### PR TITLE
Do you really need all of Xcode? 

### DIFF
--- a/etc/setup.sh
+++ b/etc/setup.sh
@@ -21,7 +21,7 @@ if [ "$(uname)" = "Darwin" ]; then
     exit 1
   fi
 	brew install libvpx x264 pkgconfig
-    export PKG_CONFIG_PATH=/System/Library/Frameworks/Python.framework/Versions/2.7/lib/pkgconfig/:$PKG_CONFIG_PATH
+        export PKG_CONFIG_PATH=/System/Library/Frameworks/Python.framework/Versions/2.7/lib/pkgconfig/:$PKG_CONFIG_PATH
 fi
 
 NLOPT_OK=1


### PR DESCRIPTION
The command line developer tools give you enough, and are less bulky. You can install them with `xcode-select --install` it's usually faster too then downloading all of the IDE stuff that comes with Xcode. Also it can be done from the command line rather than having to go to Apple's website.