### PR TITLE
removes grid pattern from alignment images by using fractional pixels

### DIFF
--- a/vision/segmentation/pointcloudsegmentation/plane_segmentation.go
+++ b/vision/segmentation/pointcloudsegmentation/plane_segmentation.go
@@ -136,7 +136,7 @@ func CreatePoints3DFromDepthMap(depthImage *rimage.DepthMap, pixel2meter float64
 				// get z distance to meter for unit uniformity
 				z := float64(d) * pixel2meter
 				// get x and y of 3D point
-				xPoint, yPoint, _ := params.PixelToPoint(x, y, z)
+				xPoint, yPoint, _ := params.PixelToPoint(float64(x), float64(y), z)
 				// Get point in PointCloud format
 				pts.Points = append(pts.Points, r3.Vector{xPoint, yPoint, z})
 			}
@@ -212,7 +212,7 @@ func DepthMapToPointCloud(depthImage *rimage.DepthMap, pixel2meter float64, para
 			// get z distance to meter for unit uniformity
 			z := float64(d) * pixel2meter
 			// get x and y of 3D point
-			xPoint, yPoint, z := params.PixelToPoint(x, y, z)
+			xPoint, yPoint, z := params.PixelToPoint(float64(x), float64(y), z)
 			// Get point in PointCloud format
 			xInt := int(math.Round(xPoint / pixel2meter))
 			yInt := int(math.Round(yPoint / pixel2meter))


### PR DESCRIPTION
Previously, aligning the depth image to the color image using the camera matrices would leave a grid pattern of empty depth pixels in the image, since the color images were higher resolution than the depth images. This small change adds a fix that projects the upper left and lower right positions of the depth pixel to a range of pixels in the color image, which fills in the grid.

I had to use "fractional pixel" in order to do this fix, so many of the arguments and outputs in the PixelToPoint and PointToPixel functions have been changed from ints to floats.
 