### PR TITLE
Add workaround to ensure GPIO resources are released on Pi

### DIFF
--- a/board/pi/board.go
+++ b/board/pi/board.go
@@ -189,6 +189,7 @@ func (pi *piPigpio) Close() error {
 	}
 
 	C.gpioTerminate()
+	pi.logger.Debug("Pi GPIO terminated properly.")
 	piInstance = nil
 	return nil
 }

--- a/utils/runtime.go
+++ b/utils/runtime.go
@@ -24,7 +24,7 @@ func ContextualMainQuit(main func(ctx context.Context, args []string, logger gol
 }
 
 func contextualMain(main func(ctx context.Context, args []string, logger golog.Logger) error, quitSignal bool, logger golog.Logger) {
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 	if quitSignal {
 		quitC := make(chan os.Signal, 1)


### PR DESCRIPTION
**tl;dr**
There's some DMA voodoo in the pigpio library that ties up resources in the VideoCore on gpioInit(). As such, gpioTerminate() must be called before a program ends to release them or they're leaked (because the kernel can't do GC in the GPU core) and the GPU runs out of DMA block handles, preventing further access.

This is a quick workaround that _mostly_ should work. It won't catch true crashes though. All uses of os.exit() and logger.Fatal() (which calls os.exit()) have to be avoided as well so the contextualMain scope properly completes, and runs the deferred stop()/sleep function.

This is also my first pull request, my first time working in golang, and my first time working in robotcore. I'm almost certain there's a better, more "go" way to do this if I knew more. Please feel free to point it out once you find it, along with anything else I need to change or do differently, code AND submission process-wise.


**Longer version**
On Pi 4, the pigpio C library is setting up DMA blocks via the /dev/vcio interface into the VideoCore (GPU.) The GPU is given messages, then reserves and locks regions of shared memory for DMA. If these are not released (via C.gpioTerminate() ) then subsequent GPIO init events set up new blocks, and after a few iterations, the GPU runs out of block handles (or something of that sort.) On the overlocked Pi images, the GPU is configured in a constrained mode, and this happens in as few as one re-init without release. Regular may take 8-10 restarts of the offending application (e.g. cmd/server.)

To work around this, I've set up go routine which waits for the context's Done channel to close, and attempts to release the resources via piInstance.Close(), which includes the gpioTerminate(). The caveat to this is that the parent main() needs to wait long enough for that to happen before terminating. To that end, I have a one second "sleep" after stop() is called. Additionally, logger.Fatal() has been replaced with logger.Error (in this context function only so far) since Fatal directly calls os.exit(1) and doesn't let the scope complete the deffered stop()/sleep function.

If we have further problems on this, I can look into the deeper code in the library and vcio system itself, and see if something can be written to free resources at/before init, to clean up after failed/crashed programs and the like. I don't know if it's possible, but suspect brute-forcing free()/unlock() on a list of likely/possible pointers in a known range might be an option.