### PR TITLE
shifts pointcloud XY origin to be at center of color camera

### DIFF
--- a/rimage/transform/image_align.go
+++ b/rimage/transform/image_align.go
@@ -37,6 +37,7 @@ type AlignConfig struct {
 
 	WarpFromCommon bool
 	OutputSize     image.Point
+	OutputOrigin   image.Point
 }
 
 // ComputeWarpFromCommon TODO

--- a/rimage/transform/warp_point_parameters.go
+++ b/rimage/transform/warp_point_parameters.go
@@ -29,7 +29,8 @@ func (dct *DepthColorWarpTransforms) ImagePointTo3DPoint(point image.Point, ii *
 	if !(point.In(ii.Bounds())) {
 		return r3.Vector{}, fmt.Errorf("point (%d,%d) not in image bounds (%d,%d)", point.X, point.Y, ii.Width(), ii.Height())
 	}
-	return r3.Vector{float64(point.X), float64(point.Y), float64(ii.Depth.Get(point))}, nil
+	i, j := float64(point.X-dct.OutputOrigin.X), float64(point.Y-dct.OutputOrigin.Y)
+	return r3.Vector{i, j, float64(ii.Depth.Get(point))}, nil
 }
 
 // ImageWithDepthToPointCloud TODO
@@ -59,7 +60,8 @@ func (dct *DepthColorWarpTransforms) ImageWithDepthToPointCloud(ii *rimage.Image
 			}
 			c := iwd.Color.GetXY(x, y)
 			r, g, b := c.RGB255()
-			err := pc.Set(pointcloud.NewColoredPoint(float64(x), float64(y), float64(z), color.NRGBA{r, g, b, 255}))
+			i, j := float64(x-dct.OutputOrigin.X), float64(y-dct.OutputOrigin.Y)
+			err := pc.Set(pointcloud.NewColoredPoint(i, j, float64(z), color.NRGBA{r, g, b, 255}))
 			if err != nil {
 				return nil, err
 			}

--- a/rimage/transform/warp_point_parameters_test.go
+++ b/rimage/transform/warp_point_parameters_test.go
@@ -24,6 +24,7 @@ func TestImageWithDepthToPointCloud(t *testing.T) {
 		DepthInputSize:  image.Point{224, 171},
 		DepthWarpPoints: []image.Point{{89, 109}, {206, 132}},
 		OutputSize:      image.Point{448, 342},
+		OutputOrigin:    image.Point{227, 160},
 	}
 	dct, err := NewDepthColorWarpTransforms(config, logger)
 	test.That(t, err, test.ShouldBeNil)
@@ -59,6 +60,7 @@ func TestWarpPointsTo3D(t *testing.T) {
 		DepthInputSize:  image.Point{224, 171},
 		DepthWarpPoints: []image.Point{{89, 109}, {206, 132}},
 		OutputSize:      image.Point{448, 342},
+		OutputOrigin:    image.Point{227, 160},
 	}
 	testPoint := image.Point{0, 0}
 	_, err = iwd.To3D(testPoint)
@@ -70,8 +72,13 @@ func TestWarpPointsTo3D(t *testing.T) {
 	iwd, err = dct.AlignImageWithDepth(iwd)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, iwd.IsAligned(), test.ShouldEqual, true)
+	// Check to see if the origin point on the pointcloud transformed correctly
+	vec, err := dct.ImagePointTo3DPoint(config.OutputOrigin, iwd)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, vec.X, test.ShouldEqual, 0.0)
+	test.That(t, vec.Y, test.ShouldEqual, 0.0)
 	// test out To3D
-	vec, err := iwd.To3D(testPoint)
+	vec, err = iwd.To3D(testPoint)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, vec.Z, test.ShouldEqual, float64(iwd.Depth.Get(testPoint)))
 	// out of bounds - panic

--- a/robots/configs/gripper-cam.json
+++ b/robots/configs/gripper-cam.json
@@ -48,7 +48,7 @@
                   "DepthWarpPoints" : [ { "X" : 89, "Y" : 109}, { "X" : 206, "Y" : 132 } ],
                   "WarpFromCommon" : true,
                   "OutputSize" : { "X" : 448, "Y" : 342 },
-                  "Smooth" : false
+                  "OutputOrigin" : { "X" : 227, "Y" : 160 }
               }
           }
         },


### PR DESCRIPTION
For the warp point alignment, shifts the XY origin to be at the center of the color camera, rather than remain at the origin of the image with depth. 