### PR TITLE
Add imu interface.

### DIFF
--- a/sensor/imu/imu.go
+++ b/sensor/imu/imu.go
@@ -10,10 +10,8 @@ import (
 	"go.viam.com/core/sensor"
 )
 
-// The known IMU types.
-const (
-	Type = "imu"
-)
+// Type is the identifier of an IMU.
+const Type = "imu"
 
 // An IMU represents a sensor that can report AngularVelocity and Orientation measurements.
 type IMU interface {

--- a/spatialmath/angularVelocity.go
+++ b/spatialmath/angularVelocity.go
@@ -1,6 +1,6 @@
 package spatialmath
 
-// AngularVelocity contains angular velocity in rads/s across x/y/z axes.
+// AngularVelocity contains angular velocity in deg/s across x/y/z axes.
 type AngularVelocity struct {
 	x float64 `json:"x"`
 	y float64 `json:"y"`


### PR DESCRIPTION
Defines an interface representing IMUs. The first implementation can currently be found [here](https://github.com/viamrobotics/core/pull/190/files) and will be copied over to the [SensorExporter repo](https://github.com/viamrobotics/SensorExporter) for review shortly.

Note that this is currently failing the linter because a struct defined for this interface (AngularVelocity) is currently unused, since no implementations have been created yet. This should be resolved once we start adding those. If there's a way to tell the linter to ignore this, I'm all ears.