### PR TITLE
update some constants for gripper v1

### DIFF
--- a/robots/vgripper/v1.go
+++ b/robots/vgripper/v1.go
@@ -42,12 +42,12 @@ func init() {
 
 // TODO
 const (
-	TargetRPM               = 100
+	TargetRPM               = 200
 	MaxCurrent              = 300
 	CurrentBadReadingCounts = 50
-	MinRotationGap          = 2.0
-	MaxRotationGap          = 3.0
-	OpenPosOffset           = 0.2 // Reduce maximum opening width, keeps out of mechanical binding region
+	MinRotationGap          = 4.0
+	MaxRotationGap          = 5.0
+	OpenPosOffset           = 0.4 // Reduce maximum opening width, keeps out of mechanical binding region
 )
 
 // GripperV1 represents a Viam gripper


### PR DESCRIPTION
The `ticksForRotation` for the motor in the gripper should be amended to 980. 1960 is 2 rotations
These constants are based on the erroneous amount so updated these
In addition to this code update, all gripper related configs should be updated to 980