### PR TITLE
Make spatialmath.AngularVelocity an alias for r3.Vector.

### DIFF
--- a/spatialmath/angular_velocity.go
+++ b/spatialmath/angular_velocity.go
@@ -1,8 +1,6 @@
 package spatialmath
 
+import "github.com/golang/geo/r3"
+
 // AngularVelocity contains angular velocity in deg/s across x/y/z axes.
-type AngularVelocity struct {
-	X float64 `json:"x"`
-	Y float64 `json:"y"`
-	Z float64 `json:"z"`
-}
+type AngularVelocity r3.Vector


### PR DESCRIPTION
Follow up from the thread in [this PR](https://github.com/viamrobotics/core/pull/210#discussion_r721729738) and our meeting last Wednesday. Change is being made because the r3.Vector contains the same information (x/y/z coords) while already having a ton of spatialmath functions already defined.