### PR TITLE
Fix libdir assignment, add MACOS_RPATH.

### DIFF
--- a/etc/camera_servers/macos.sh
+++ b/etc/camera_servers/macos.sh
@@ -25,7 +25,7 @@ index cc0146a04..a65090cd5 100644
 EOF
 mkdir build && cd build
 sudo xcode-select --reset
-cmake .. -DBUILD_EXAMPLES=true -DBUILD_WITH_OPENMP=false -DHWM_OVER_XU=false -G Xcode
+cmake .. -DBUILD_EXAMPLES=true -DBUILD_WITH_OPENMP=false -DHWM_OVER_XU=false -DCMAKE_MACOSX_RPATH=ON -G Xcode
 xcodebuild -target realsense2
 cp -R ../include/librealsense2 /usr/local/include
 cp Debug/* /usr/local/lib
@@ -35,7 +35,7 @@ prefix=/usr/local
 exec_prefix=${prefix}
 includedir=${prefix}/include
 #TODO: libdir=${exec_prefix}/lib
-libdir= ${prefix}/lib
+libdir=${prefix}/lib
 
 Name:
 Description: Intel(R) RealSense(tm) Cross Platform API


### PR DESCRIPTION
- Removes space that prevented libdir from being assigned 
- Adds cmake flag for Mac RPATH to avoid the following warning (which seemed to prevent mine from building):
```
CMake Warning (dev):
  Policy CMP0042 is not set: MACOSX_RPATH is enabled by default.  Run "cmake
  --help-policy CMP0042" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  MACOSX_RPATH is not specified for the following targets:

   realsense2-gl

This warning is for project developers.  Use -Wno-dev to suppress it.
```