### PR TITLE
Fix slip detection response message bug

### DIFF
--- a/web/runtime-shared/templates/webappindex.html
+++ b/web/runtime-shared/templates/webappindex.html
@@ -1013,6 +1013,10 @@
           console.log("error getting slip detection readings: ", err);
           return;
         }
+        if (resp === null) {
+          console.log("response is null")
+          dispEl.innerText = "response is invalid"
+        }
         let isSlipping = resp.getIsSlipping()
         let dispEl = document.getElementById("force-is-slipping-" + id);
         if (isSlipping) {


### PR DESCRIPTION
There is a bug in the code that sends the wrong request type to `forceMatrixSlipDetection`. 

This worked fine when one runs the code locally on the RPI, the response is of the correct type: `ForceMatrixSlipDetectionResponse`.

When run through `app.viam.com` on the other hand, though, the response is `null`, which breaks the UI.

In order to fix this, am going to try to send the correct response and hope that'll work.