### PR TITLE
add gps ntrip caster messaging

### DIFF
--- a/component/gps/nmea/nmeaParser.go
+++ b/component/gps/nmea/nmeaParser.go
@@ -16,12 +16,11 @@ type gpsData struct {
 	satsInView int     // quantity satellites in view
 	satsInUse  int     // quantity satellites in view
 	valid      bool
-	// gga        string
 }
 
 // parseAndUpdate will attempt to parse a line to an NMEA sentence, and if valid, will try to update the given struct
 // with the values for that line. Nothing will be updated if there is not a valid gps fix.
-func parseAndUpdate(line string, g *gpsData, n ntripInfo) error {
+func (g *gpsData) parseAndUpdate(line string, n ntripInfo) error {
 	s, err := nmea.Parse(line)
 	if err != nil {
 		return err

--- a/component/gps/nmea/nmeaParser_test.go
+++ b/component/gps/nmea/nmeaParser_test.go
@@ -12,7 +12,7 @@ func TestParsing(t *testing.T) {
 	ntripClient.sendNMEA = false
 	// Test a GGA sentence
 	nmeaSentence := "$GNGGA,191351.000,4403.4655,N,12118.7950,W,1,6,1.72,1094.5,M,-19.6,M,,*47"
-	err := parseAndUpdate(nmeaSentence, &data, ntripClient)
+	err := data.parseAndUpdate(nmeaSentence, ntripClient)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, data.valid, test.ShouldBeTrue)
 	test.That(t, data.alt, test.ShouldEqual, 1094.5)
@@ -23,20 +23,20 @@ func TestParsing(t *testing.T) {
 
 	// Test GSA, should update HDOP
 	nmeaSentence = "$GPGSA,A,3,21,10,27,08,,,,,,,,,1.98,2.99,0.98*0E"
-	err = parseAndUpdate(nmeaSentence, &data, ntripClient)
+	err = data.parseAndUpdate(nmeaSentence, ntripClient)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, data.hDOP, test.ShouldEqual, 2.99)
 	test.That(t, data.vDOP, test.ShouldEqual, 0.98)
 
 	// Test VTG, should update speed
 	nmeaSentence = "$GNVTG,176.25,T,,M,0.13,N,0.25,K,A*21"
-	err = parseAndUpdate(nmeaSentence, &data, ntripClient)
+	err = data.parseAndUpdate(nmeaSentence, ntripClient)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, data.speed, test.ShouldEqual, 0.25)
 
 	// Test RMC, should update speed and position
 	nmeaSentence = "$GNRMC,191352.000,A,4503.4656,N,13118.7951,W,0.04,90.29,011021,,,A*59"
-	err = parseAndUpdate(nmeaSentence, &data, ntripClient)
+	err = data.parseAndUpdate(nmeaSentence, ntripClient)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, data.speed, test.ShouldAlmostEqual, 0.07408)
 	test.That(t, data.location.Lat(), test.ShouldAlmostEqual, 45.05776, 0.001)
@@ -44,13 +44,13 @@ func TestParsing(t *testing.T) {
 
 	// Test GSV, should update total sats in view
 	nmeaSentence = " $GLGSV,2,2,07,85,23,327,34,70,21,234,21,77,07,028,*50"
-	err = parseAndUpdate(nmeaSentence, &data, ntripClient)
+	err = data.parseAndUpdate(nmeaSentence, ntripClient)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, data.satsInView, test.ShouldEqual, 7)
 
 	// Test GNS, should update same fields as GGA
 	nmeaSentence = "$GNGNS,014035.00,4332.69262,S,17235.48549,E,RR,13,0.9,25.63,11.24,,*70"
-	err = parseAndUpdate(nmeaSentence, &data, ntripClient)
+	err = data.parseAndUpdate(nmeaSentence, ntripClient)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, data.valid, test.ShouldBeTrue)
 	test.That(t, data.alt, test.ShouldEqual, 25.63)
@@ -61,7 +61,7 @@ func TestParsing(t *testing.T) {
 
 	// Test GLL, should update location
 	nmeaSentence = "$GPGLL,4112.26,N,11332.22,E,213276,A,*05"
-	err = parseAndUpdate(nmeaSentence, &data, ntripClient)
+	err = data.parseAndUpdate(nmeaSentence, ntripClient)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, data.location.Lat(), test.ShouldAlmostEqual, 41.20433, 0.001)
 	test.That(t, data.location.Lng(), test.ShouldAlmostEqual, 113.537, 0.001)

--- a/component/gps/nmea/pmtkI2C.go
+++ b/component/gps/nmea/pmtkI2C.go
@@ -133,7 +133,7 @@ func (g *pmtkI2CNMEAGPS) Start(ctx context.Context) {
 				if b == 0x0D {
 					if strBuf != "" {
 						g.mu.Lock()
-						err = parseAndUpdate(strBuf, &g.data, g.ntripClient)
+						err = g.data.parseAndUpdate(strBuf, g.ntripClient)
 						g.mu.Unlock()
 						if err != nil {
 							g.logger.Debugf("can't parse nmea %s : %v", strBuf, err)


### PR DESCRIPTION
added code is used to send our current NMEA messages to a Ntrip caster, which allows the caster to connect us to the best mount point for our location. Appears to be writing(or at least nothing is breaking) but would also want to test outdoors at some point to confirm accurate results. 