### PR TITLE
Embed client version in RDK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PATH_WITH_TOOLS="`pwd`/bin:`pwd`/node_modules/.bin:${PATH}"
 
 VERSION := $(shell git tag --sort=-version:refname | head -n 1)
 GIT_REVISION := $(shell git rev-parse HEAD | tr -d '\n')
-LDFLAGS = -ldflags "-X 'go.viam.com/rdk/config.version=${VERSION}' -X 'go.viam.com/rdk/config.gitRevision=${GIT_REVISION}'"
+LDFLAGS = -ldflags "-X 'go.viam.com/rdk/config.Version=${VERSION}' -X 'go.viam.com/rdk/config.GitRevision=${GIT_REVISION}'"
 
 default: build lint server
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -98,6 +98,12 @@ func TestCreateCloudRequest(t *testing.T) {
 		Secret: "b",
 		Path:   "c",
 	}
+
+	version := "test-version"
+	gitRevision := "test-git-revision"
+	config.Version = version
+	config.GitRevision = gitRevision
+
 	r, err := config.CreateCloudRequest(context.Background(), &cfg)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -108,8 +114,8 @@ func TestCreateCloudRequest(t *testing.T) {
 	userInfoJSON := r.Header.Get("User-Info")
 	json.Unmarshal([]byte(userInfoJSON), &userInfo)
 
-	test.That(t, userInfo["version"], test.ShouldNotBeNil)
-	test.That(t, userInfo["gitRevision"], test.ShouldNotBeNil)
+	test.That(t, userInfo["version"], test.ShouldEqual, version)
+	test.That(t, userInfo["gitRevision"], test.ShouldEqual, gitRevision)
 }
 
 func TestConfigEnsure(t *testing.T) {

--- a/config/reader.go
+++ b/config/reader.go
@@ -21,9 +21,10 @@ import (
 	"go.viam.com/utils"
 )
 
+// RDK versioning variables which are replaced by LD flags.
 var (
-	version     = ""
-	gitRevision = ""
+	Version     = ""
+	GitRevision = ""
 )
 
 // An AttributeConverter converts a single attribute into a possibly
@@ -191,8 +192,8 @@ func CreateCloudRequest(ctx context.Context, cloudCfg *Cloud) (*http.Request, er
 		return nil, err
 	}
 	userInfo[cloudConfigUserInfoLocalIPsField] = ips
-	userInfo[cloudConfigVersionField] = version
-	userInfo[cloudConfigGitRevisionField] = gitRevision
+	userInfo[cloudConfigVersionField] = Version
+	userInfo[cloudConfigGitRevisionField] = GitRevision
 
 	userInfoBytes, err := json.Marshal(userInfo)
 	if err != nil {


### PR DESCRIPTION
It is useful for app.viam.com to know the version of the clients/robots being used and retrieve this from the RDK.

Add:
* `version`: semantic version which will start at v0.0.1 and get bumped via git tags (locally done via `git tag -a v0.0.1 -m "Version 0.0.1"` and will push to main before submitting)
* `gitRevision`: current git revision, a unique sha-1 hash

These flags are passed to app.viam.com via `userInfo` and set with `make server` or a local `web/cmd/server/main.go` command (added to README in https://github.com/viamrobotics/app/pull/63).

Output with local `rdk/web/cmd/server/main.go` command:
<img width="1033" alt="Screen Shot 2022-01-14 at 2 48 11 PM" src="https://user-images.githubusercontent.com/3794748/149581684-3c6be521-5c29-4774-a2e8-bfe09397ed5f.png">