### PR TITLE
Allow mutiples calls to controlLoop.Stop

### DIFF
--- a/component/motor/gpio/motor_encoder.go
+++ b/component/motor/gpio/motor_encoder.go
@@ -552,6 +552,9 @@ func (m *EncodedMotor) IsOn(ctx context.Context) (bool, error) {
 
 // Close cleanly shuts down the motor.
 func (m *EncodedMotor) Close() {
+	if m.loop != nil {
+		m.loop.Stop()
+	}
 	m.cancel()
 	m.activeBackgroundWorkers.Wait()
 }

--- a/control/control.go
+++ b/control/control.go
@@ -31,7 +31,7 @@ type Control interface {
 	// Frequency returns the loop's frequency
 	Frequency(ctx context.Context) (float64, error)
 	// Start starts the loop
-	Start(ctx context.Context) error
+	Start() error
 	// Stop stops the loop
-	Stop(ctx context.Context) error
+	Stop()
 }

--- a/control/control_loop_test.go
+++ b/control/control_loop_test.go
@@ -322,5 +322,5 @@ func TestControlLoop(t *testing.T) {
 		test.That(t, b[0].GetSignalValueAt(0), test.ShouldEqual, -3.0)
 		test.That(t, err, test.ShouldBeNil)
 	}
-	cLoop.Stop(ctx)
+	cLoop.Stop()
 }


### PR DESCRIPTION
Allow the function controlLoop.Stop to be called as many times as we wants