### PR TITLE
Fetch remote git tags to set client `version`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ endif
 
 PATH_WITH_TOOLS="`pwd`/bin:`pwd`/node_modules/.bin:${PATH}"
 
-VERSION := $(shell git tag --sort=-version:refname | head -n 1)
+VERSION := $(shell git fetch --tags && git tag --sort=-version:refname | head -n 1)
 GIT_REVISION := $(shell git rev-parse HEAD | tr -d '\n')
 LDFLAGS = -ldflags "-X 'go.viam.com/rdk/config.Version=${VERSION}' -X 'go.viam.com/rdk/config.GitRevision=${GIT_REVISION}'"
 


### PR DESCRIPTION
Get `version` to show up on the `app.viam.com` robot page.

A `v0.0.1` tag was pushed to `origin/main` along with https://github.com/viamrobotics/rdk/pull/448, viewable via `git ls-remote --tags origin`. In order to work, the robot/client running RDK must fetch these from remote.

* With this code, remote tags are automatically merged with any local tags. If the local branch already has `v0.0.1` pulled, it is left as-is.
* If the local branch added `v0.0.2` more recently, then local tags will become `[v0.0.1, v0.0.2]` and `VERSION=v0.0.2`