### PR TITLE
Fix Camera bug where single_stream did not know about alignment attributes

### DIFF
--- a/component/camera/imagesource/align.go
+++ b/component/camera/imagesource/align.go
@@ -94,7 +94,6 @@ func init() {
 			}
 			return homography, err
 		})
-
 }
 
 var alignCurrentlyWriting = false

--- a/component/camera/imagesource/source.go
+++ b/component/camera/imagesource/source.go
@@ -18,10 +18,10 @@ import (
 
 	"github.com/edaniels/golog"
 	"github.com/edaniels/gostream"
-	"github.com/mitchellh/mapstructure"
 
 	// register ppm.
 	_ "github.com/lmittmann/ppm"
+	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"go.viam.com/utils"
 


### PR DESCRIPTION
Quick fix that adds the alignment attributes to the single_stream model as well.