### PR TITLE
Add fast 2D to 3D point transformation only using camera parameters

### DIFF
--- a/rimage/camera_system.go
+++ b/rimage/camera_system.go
@@ -19,7 +19,7 @@ type Aligner interface {
 type Projector interface {
 	ImageWithDepthToPointCloud(*ImageWithDepth) (pointcloud.PointCloud, error)
 	PointCloudToImageWithDepth(pointcloud.PointCloud) (*ImageWithDepth, error)
-	ImagePointTo3DPoint(image.Point, *ImageWithDepth) (r3.Vector, error)
+	ImagePointTo3DPoint(image.Point, Depth) (r3.Vector, error)
 }
 
 // A CameraSystem stores the system of camera models, the intrinsic parameters of each camera,

--- a/rimage/image_with_depth.go
+++ b/rimage/image_with_depth.go
@@ -48,7 +48,11 @@ func (i *ImageWithDepth) To3D(p image.Point) (r3.Vector, error) {
 	if i.camera == nil {
 		return r3.Vector{}, errors.New("no camera on ImageWithDepth when called To3D")
 	}
-	return i.camera.ImagePointTo3DPoint(p, i)
+	if !p.In(i.Bounds()) {
+		return r3.Vector{}, errors.Errorf("point (%d,%d) not within image bounds", p.X, p.Y)
+	}
+	d := i.Depth.Get(p)
+	return i.camera.ImagePointTo3DPoint(p, d)
 }
 
 // Width returns the horizontal width of the image.

--- a/rimage/transform/camera_matrix.go
+++ b/rimage/transform/camera_matrix.go
@@ -73,8 +73,8 @@ func (dcie *DepthColorIntrinsicsExtrinsics) TransformDepthCoordToColorCoord(img 
 }
 
 // ImagePointTo3DPoint takes in a image coordinate and returns the 3D point from the camera matrix.
-func (dcie *DepthColorIntrinsicsExtrinsics) ImagePointTo3DPoint(point image.Point, ii *rimage.ImageWithDepth) (r3.Vector, error) {
-	return intrinsics2DPtTo3DPt(point, ii, &dcie.ColorCamera)
+func (dcie *DepthColorIntrinsicsExtrinsics) ImagePointTo3DPoint(point image.Point, depth rimage.Depth) (r3.Vector, error) {
+	return intrinsics2DPtTo3DPt(point, depth, &dcie.ColorCamera)
 }
 
 // ImageWithDepthToPointCloud takes an ImageWithDepth and uses the camera parameters to project it to a pointcloud.

--- a/rimage/transform/homography.go
+++ b/rimage/transform/homography.go
@@ -124,6 +124,6 @@ func (dch *PinholeCameraHomography) PointCloudToImageWithDepth(
 }
 
 // ImagePointTo3DPoint takes in a image coordinate and returns the 3D point from the perspective of the color camera.
-func (dch *PinholeCameraHomography) ImagePointTo3DPoint(pt image.Point, iwd *rimage.ImageWithDepth) (r3.Vector, error) {
-	return intrinsics2DPtTo3DPt(pt, iwd, &dch.ColorCamera)
+func (dch *PinholeCameraHomography) ImagePointTo3DPoint(pt image.Point, d rimage.Depth) (r3.Vector, error) {
+	return intrinsics2DPtTo3DPt(pt, d, &dch.ColorCamera)
 }

--- a/rimage/transform/pinhole_camera_parameters.go
+++ b/rimage/transform/pinhole_camera_parameters.go
@@ -2,7 +2,6 @@ package transform
 
 import (
 	"encoding/json"
-	"fmt"
 	"image"
 	"image/color"
 	"io/ioutil"
@@ -181,8 +180,8 @@ func (params *PinholeCameraIntrinsics) PointToPixel(x, y, z float64) (float64, f
 }
 
 // ImagePointTo3DPoint takes in a image coordinate and returns the 3D point from the camera matrix.
-func (params *PinholeCameraIntrinsics) ImagePointTo3DPoint(point image.Point, ii *rimage.ImageWithDepth) (r3.Vector, error) {
-	return intrinsics2DPtTo3DPt(point, ii, params)
+func (params *PinholeCameraIntrinsics) ImagePointTo3DPoint(point image.Point, d rimage.Depth) (r3.Vector, error) {
+	return intrinsics2DPtTo3DPt(point, d, params)
 }
 
 // ImageWithDepthToPointCloud takes an ImageWithDepth and uses the camera parameters to project it to a pointcloud.
@@ -217,14 +216,8 @@ func (params *Extrinsics) TransformPointToPoint(x, y, z float64) (float64, float
 }
 
 // intrinsics2DPtTo3DPt takes in a image coordinate and returns the 3D point using the camera's intrinsic matrix.
-func intrinsics2DPtTo3DPt(pt image.Point, ii *rimage.ImageWithDepth, pci *PinholeCameraIntrinsics) (r3.Vector, error) {
-	if !ii.IsAligned() {
-		return r3.Vector{}, errors.New("image with depth is not aligned. will not return correct 3D point")
-	}
-	if !(pt.In(ii.Bounds())) {
-		return r3.Vector{}, fmt.Errorf("point (%d,%d) not in image bounds (%d,%d)", pt.X, pt.Y, ii.Width(), ii.Height())
-	}
-	px, py, pz := pci.PixelToPoint(float64(pt.X), float64(pt.Y), float64(ii.Depth.Get(pt)))
+func intrinsics2DPtTo3DPt(pt image.Point, d rimage.Depth, pci *PinholeCameraIntrinsics) (r3.Vector, error) {
+	px, py, pz := pci.PixelToPoint(float64(pt.X), float64(pt.Y), float64(d))
 	return r3.Vector{px, py, pz}, nil
 }
 

--- a/rimage/transform/warp_point_parameters.go
+++ b/rimage/transform/warp_point_parameters.go
@@ -1,7 +1,6 @@
 package transform
 
 import (
-	"fmt"
 	"image"
 	"image/color"
 	"math"
@@ -21,15 +20,9 @@ type DepthColorWarpTransforms struct {
 }
 
 // ImagePointTo3DPoint takes in a image coordinate and returns the 3D point from the warp points.
-func (dct *DepthColorWarpTransforms) ImagePointTo3DPoint(point image.Point, ii *rimage.ImageWithDepth) (r3.Vector, error) {
-	if !ii.IsAligned() {
-		return r3.Vector{}, errors.New("image with depth is not aligned. will not return correct 3D point")
-	}
-	if !(point.In(ii.Bounds())) {
-		return r3.Vector{}, fmt.Errorf("point (%d,%d) not in image bounds (%d,%d)", point.X, point.Y, ii.Width(), ii.Height())
-	}
+func (dct *DepthColorWarpTransforms) ImagePointTo3DPoint(point image.Point, d rimage.Depth) (r3.Vector, error) {
 	i, j := float64(point.X-dct.OutputOrigin.X), float64(point.Y-dct.OutputOrigin.Y)
-	return r3.Vector{i, j, float64(ii.Depth.Get(point))}, nil
+	return r3.Vector{i, j, float64(d)}, nil
 }
 
 // ImageWithDepthToPointCloud TODO.

--- a/rimage/transform/warp_point_parameters_test.go
+++ b/rimage/transform/warp_point_parameters_test.go
@@ -73,7 +73,7 @@ func TestWarpPointsTo3D(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, iwd.IsAligned(), test.ShouldEqual, true)
 	// Check to see if the origin point on the pointcloud transformed correctly
-	vec, err := dct.ImagePointTo3DPoint(config.OutputOrigin, iwd)
+	vec, err := dct.ImagePointTo3DPoint(config.OutputOrigin, iwd.Depth.Get(config.OutputOrigin))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, vec.X, test.ShouldEqual, 0.0)
 	test.That(t, vec.Y, test.ShouldEqual, 0.0)


### PR DESCRIPTION
Rather than using an entire ImageWithDepth, a 2D to 3D transformation can be done on a single point using only the intrinsic camera parameters. 

Any struct that fulfills the `Projector` interface will be able to do this projection