### PR TITLE
[RDK-114] fix issue with sensors service not able to get a remote sensors service

### DIFF
--- a/services/sensors/sensors.go
+++ b/services/sensors/sensors.go
@@ -88,6 +88,9 @@ func New(ctx context.Context, r robot.Robot, config config.Service, logger golog
 	// trigger an update here
 	resources := map[resource.Name]interface{}{}
 	for _, n := range r.ResourceNames() {
+		if n.ResourceType != resource.ResourceTypeComponent {
+			continue
+		}
 		res, err := r.ResourceByName(n)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
basically the issue was that the prefixed remote tells us theres a sensors service but the resource name for the remote sensors service is unprefixed, so we do not look for it on the remote.

patch simply ignores non-component resources for sensors service.
Broader issue with how to address remote services https://viam.atlassian.net/browse/RDK-115