### PR TITLE
Fix data race by having sender close the channel.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -239,16 +239,17 @@ func (config *Remote) Validate(path string) error {
 // The cloud source could be anything that supports http.
 // URL is constructed as $Path?id=ID and secret is put in a http header.
 type Cloud struct {
-	ID               string        `json:"id"`
-	Secret           string        `json:"secret"`
-	LocationSecret   string        `json:"location_secret"`
-	ManagedBy        string        `json:"managed_by"`
-	FQDN             string        `json:"fqdn"`
-	LocalFQDN        string        `json:"local_fqdn"`
-	SignalingAddress string        `json:"signaling_address"`
-	Path             string        `json:"path"`
-	LogPath          string        `json:"log_path"`
-	RefreshInterval  time.Duration `json:"refresh_interval,omitempty"`
+	ID                string        `json:"id"`
+	Secret            string        `json:"secret"`
+	LocationSecret    string        `json:"location_secret"`
+	ManagedBy         string        `json:"managed_by"`
+	FQDN              string        `json:"fqdn"`
+	LocalFQDN         string        `json:"local_fqdn"`
+	SignalingAddress  string        `json:"signaling_address"`
+	SignalingInsecure bool          `json:"signaling_insecure,omitempty"`
+	Path              string        `json:"path"`
+	LogPath           string        `json:"log_path"`
+	RefreshInterval   time.Duration `json:"refresh_interval,omitempty"`
 
 	// cached by us and fetched from a non-config endpoint.
 	TLSCertificate string `json:"tls_certificate"`

--- a/config/reader.go
+++ b/config/reader.go
@@ -400,6 +400,7 @@ func ReadFromCloud(
 	fqdn := cfg.Cloud.FQDN
 	localFQDN := cfg.Cloud.LocalFQDN
 	signalingAddress := cfg.Cloud.SignalingAddress
+	signalingInsecure := cfg.Cloud.SignalingInsecure
 	managedBy := cfg.Cloud.ManagedBy
 	locationSecret := cfg.Cloud.LocationSecret
 
@@ -408,6 +409,7 @@ func ReadFromCloud(
 		to.Cloud.FQDN = fqdn
 		to.Cloud.LocalFQDN = localFQDN
 		to.Cloud.SignalingAddress = signalingAddress
+		to.Cloud.SignalingInsecure = signalingInsecure
 		to.Cloud.ManagedBy = managedBy
 		to.Cloud.LocationSecret = locationSecret
 		to.Cloud.TLSCertificate = tlsCertificate

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -506,6 +506,9 @@ func serveWeb(ctx context.Context, cfg *config.Config, argsParsed Arguments, log
 			cfg.Cloud.ID,
 			rpc.Credentials{rutils.CredentialsTypeRobotSecret, cfg.Cloud.Secret},
 		)}
+		if cfg.Cloud.SignalingInsecure {
+			signalingDialOpts = append(signalingDialOpts, rpc.WithInsecure())
+		}
 		if argsParsed.AllowInsecureCreds {
 			signalingDialOpts = append(signalingDialOpts, rpc.WithAllowInsecureWithCredentialsDowngrade())
 		}


### PR DESCRIPTION
Sender's should close channels. This updates the code to do that. _Think_ this should prevent the error entirely; I ran the test in a loop locally and it isn't failing at all.

See [here](https://github.com/viamrobotics/rdk/runs/5648006636?check_suite_focus=true) for example of test failure.