### PR TITLE
RDK-176: add a -version flag

### DIFF
--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -277,12 +277,10 @@ func RunServer(ctx context.Context, args []string, logger golog.Logger) (err err
 	}
 
 	// Always log the version, return early if the '-version' flag was provided
-	{
-		// fmt.Println would be better but fails linting. Good enough.
-		logger.Infof("Viam RDK Version: %s, Hash: %s", config.Version, config.GitRevision)
-		if argsParsed.Version {
-			return
-		}
+	// fmt.Println would be better but fails linting. Good enough.
+	logger.Infof("Viam RDK Version: %s, Hash: %s", config.Version, config.GitRevision)
+	if argsParsed.Version {
+		return
 	}
 
 	if argsParsed.CPUProfile != "" {


### PR DESCRIPTION
Still requires a dummy positional config parameter, which will be a follow up.