### PR TITLE
Handle removing a component method from the config to stop data capture.

### DIFF
--- a/services/datamanager/data_manager.go
+++ b/services/datamanager/data_manager.go
@@ -223,7 +223,7 @@ func (svc *Service) Update(ctx context.Context, config config.Service) error {
 		newCollectorMetadata[*componentMetadata] = true
 	}
 
-	// If a component/method has been removed from the config, close the collector and remove it from the cached map.
+	// If a component/method has been removed from the config, close the collector and remove it from the map.
 	for componentMetadata, params := range svc.collectors {
 		if _, present := newCollectorMetadata[componentMetadata]; !present {
 			params.Collector.Close()


### PR DESCRIPTION
Data capture is initialized/updated/stopped when a component+method is added/updated/removed from the service config.
 
This PR handles the last part: stop capture for a component+method when the corresponding configuration is removed.

Tested locally. Example config:
```
"services":
   [
       {
           "type": "data_manager",
           "attributes": {
               "capture_dir": "/tmp/capture",
               "component_attributes": {
                   "arm1": {
                       "type": "arm",
                       "method": "GetJointPositions",
                       "capture_interval_ms": 100
                   },
                   "imu1": {
                       "type": "imu",
                       "method": "ReadAngularVelocity",
                       "capture_interval_ms": 50
                   }
               }
           }
       }
   ]

```