### PR TITLE
Remove minimum resolution constraints

### DIFF
--- a/component/camera/imagesource/webcam.go
+++ b/component/camera/imagesource/webcam.go
@@ -65,10 +65,10 @@ type WebcamAttrs struct {
 }
 
 func makeConstraints(attrs *WebcamAttrs, debug bool, logger golog.Logger) mediadevices.MediaStreamConstraints {
-	minWidth := 680
+	minWidth := 0
 	maxWidth := 4096
 	idealWidth := 800
-	minHeight := 400
+	minHeight := 0
 	maxHeight := 2160
 	idealHeight := 600
 


### PR DESCRIPTION
Prevents RDK configuration from failing when a camera does not support high resolutions