### PR TITLE
Increase default capture queue size.

### DIFF
--- a/services/datamanager/data_manager.go
+++ b/services/datamanager/data_manager.go
@@ -61,7 +61,7 @@ var Name = resource.NameFromSubtype(Subtype, "")
 // written to disk. A default value of 250 was chosen because even with the fastest reasonable capture interval (1ms),
 // this would leave 250ms for a (buffered) disk write before blocking, which seems sufficient for the size of
 // writes this would be performing.
-const defaultCaptureQueueSize = 250
+const defaultCaptureQueueSize = 1000
 
 // Default bufio.Writer buffer size in bytes.
 const defaultCaptureBufferSize = 4096


### PR DESCRIPTION
While investigating why we're unable to capture data faster than ~950hz, I found that the issue is stemming from a gap in how often we're calling our capture functions (as opposed to increased latency when calling those functions). I don't think the queue size should impact how often this is happening... but I figure might as well try low hanging fruit before a big rewrite.

If this doesn't work, I'm going to try rewriting the capture logic to _not_ use a separate goroutine for each capture/push; I think once we get into several thousand goroutines it might get slower to spin them off.