### PR TITLE
Don't do getAndPushNextReading in goroutine.

### DIFF
--- a/data/collector.go
+++ b/data/collector.go
@@ -105,25 +105,21 @@ func (c *collector) capture() {
 
 	ticker := time.NewTicker(c.interval)
 	defer ticker.Stop()
-	var wg sync.WaitGroup
 
 	for {
 		select {
 		case <-c.cancelCtx.Done():
-			wg.Wait()
 			close(c.queue)
 			return
 		case <-ticker.C:
-			wg.Add(1)
-			go c.getAndPushNextReading(&wg)
+			c.getAndPushNextReading()
 		}
 	}
 }
 
-func (c *collector) getAndPushNextReading(wg *sync.WaitGroup) {
+func (c *collector) getAndPushNextReading() {
 	_, span := trace.StartSpan(c.cancelCtx, "data::collector::getAndPushNextReading")
 	defer span.End()
-	defer wg.Done()
 
 	timeRequested := timestamppb.New(time.Now().UTC())
 	reading, err := c.capturer.Capture(c.cancelCtx, c.params)

--- a/services/datamanager/data_manager.go
+++ b/services/datamanager/data_manager.go
@@ -61,7 +61,7 @@ var Name = resource.NameFromSubtype(Subtype, "")
 // written to disk. A default value of 250 was chosen because even with the fastest reasonable capture interval (1ms),
 // this would leave 250ms for a (buffered) disk write before blocking, which seems sufficient for the size of
 // writes this would be performing.
-const defaultCaptureQueueSize = 1000
+const defaultCaptureQueueSize = 250
 
 // Default bufio.Writer buffer size in bytes.
 const defaultCaptureBufferSize = 4096


### PR DESCRIPTION
We're not able to push data capture past ~950hz. I suspect at a certain point the overhead of spinning off thousands of goroutines is starting to cause issues. I'm doing this not in a goroutine for now, and will play around with diff queue/buffer sizes to see if we can get past this performance ceiling. 