### PR TITLE
[DATA-71] Use time.Sleep for short interval collectors.

### DIFF
--- a/data/collector.go
+++ b/data/collector.go
@@ -13,6 +13,7 @@ import (
 	"github.com/matttproud/golang_protobuf_extensions/pbutil"
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
+	"go.viam.com/utils"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -20,7 +21,6 @@ import (
 	v1 "go.viam.com/rdk/proto/api/service/datamanager/v1"
 	"go.viam.com/rdk/protoutils"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/utils"
 )
 
 // Capturer provides a function for capturing a single protobuf reading from the underlying component.


### PR DESCRIPTION
### Summary

Go's time.Ticker doesn't support intervals below 1 ms well (some discussion [here](https://www.mail-archive.com/golang-nuts@googlegroups.com/msg46002.html)). To support capture rates of >950hz, this adds a switch to use a time.Sleep based approach when the configured interval is <2ms. 

I tested this on [this](https://app.viam.com/robot?id=a5719caf-8025-4e4c-bba0-0f3ee0f33fcf&tab=config&part=8a5862b6-16dd-4c6b-863f-17bc48e71659) demo robot. With the time.Ticker implementation, the capture rate would top out at ~950hz, and increasing the configured capture frequency past that would have no effect. The time.Sleep implementation was able to support seemingly arbitrarily small capture intervals.

The time.Ticker approach is kept around for longer-interval collectors, because it's far more CPU efficient in cases where the capture goroutine would be spending the vast majority of its time idling.

### Benchmarks 
Benchmarks were done by updating the config, letting it run for 2+ minutes, then calculating the number of messages written per second using a local script.

Gantry (pi):
configured -> recorded
- 1 khz -> 1 khz
- 2 khz -> 1998.4 hz
- 3 khz -> 2995 hz
- 4khz -> 3998.8 hz
- 8khz ->  7999.6 hz
- 16khz -> 15896.61 hz

Brain (laptop):
- 2khz -> 1999.3 hz
- 4 khz -> 3988.6 hz
- 8khz -> 7992.1 hz
- 16khz -> 16khz