### PR TITLE
Fix collectors concurrency.

### DIFF
--- a/component/motor/register/register.go
+++ b/component/motor/register/register.go
@@ -8,5 +8,6 @@ import (
 	_ "go.viam.com/rdk/component/motor/fake"
 	_ "go.viam.com/rdk/component/motor/gpio"
 	_ "go.viam.com/rdk/component/motor/gpiostepper"
+	_ "go.viam.com/rdk/component/motor/roboclaw"
 	_ "go.viam.com/rdk/component/motor/tmcstepper"
 )

--- a/component/motor/roboclaw/robotclaw.go
+++ b/component/motor/roboclaw/robotclaw.go
@@ -1,0 +1,200 @@
+// Package roboclaw is the driver for the roboclaw motor drivers
+package roboclaw
+
+import (
+	"context"
+	"errors"
+
+	"github.com/CPRT/roboclaw"
+	"github.com/edaniels/golog"
+
+	"go.viam.com/rdk/component/generic"
+	"go.viam.com/rdk/component/motor"
+	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/registry"
+	"go.viam.com/rdk/robot"
+	"go.viam.com/rdk/utils"
+)
+
+const modelname = "roboclaw"
+
+type roboclawConfig struct {
+	SerialPort       string `json:"serial_port"`
+	Baud             int
+	Number           int // this is 1 or 2
+	Address          int `json:"address,omitempty"`
+	TicksPerRotation int `json:"ticks_per_rotation"`
+}
+
+func init() {
+	registry.RegisterComponent(
+		motor.Subtype,
+		modelname,
+		registry.Component{
+			Constructor: func(ctx context.Context, r robot.Robot, config config.Component, logger golog.Logger) (interface{}, error) {
+				return newRoboClaw(r, config, logger)
+			},
+		},
+	)
+
+	config.RegisterComponentAttributeMapConverter(
+		motor.SubtypeName,
+		modelname,
+		func(attributes config.AttributeMap) (interface{}, error) {
+			var conf roboclawConfig
+			return config.TransformAttributeMapToStruct(&conf, attributes)
+		},
+		&roboclawConfig{},
+	)
+}
+
+func getOrCreateConnection(r robot.Robot, config *roboclawConfig) (*roboclaw.Roboclaw, error) {
+	for _, n := range r.ResourceNames() {
+		r, err := r.ResourceByName(n)
+		if err != nil {
+			continue
+		}
+		m, ok := utils.UnwrapProxy(r).(*roboclawMotor)
+		if !ok {
+			continue
+		}
+		if m.conf.SerialPort != config.SerialPort {
+			continue
+		}
+		if m.conf.Baud != config.Baud {
+			return nil, errors.New("cannot have multiple roboclaw motors with different baud")
+		}
+		return m.conn, nil
+	}
+
+	c := &roboclaw.Config{Name: config.SerialPort, Retries: 3}
+	if config.Baud > 0 {
+		c.Baud = config.Baud
+	}
+	return roboclaw.Init(c)
+}
+
+func newRoboClaw(r robot.Robot, config config.Component, logger golog.Logger) (motor.Motor, error) {
+	motorConfig, ok := config.ConvertedAttributes.(*roboclawConfig)
+	if !ok {
+		return nil, utils.NewUnexpectedTypeError(motorConfig, config.ConvertedAttributes)
+	}
+
+	if motorConfig.Number < 1 || motorConfig.Number > 2 {
+		return nil, errors.New("roboclawConfig Number has to be 1 or 2")
+	}
+
+	if motorConfig.Address == 0 {
+		motorConfig.Address = 128
+	}
+
+	if motorConfig.TicksPerRotation <= 0 {
+		motorConfig.TicksPerRotation = 1
+	}
+
+	c, err := getOrCreateConnection(r, motorConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &roboclawMotor{conn: c, conf: motorConfig, addr: uint8(motorConfig.Address), logger: logger}, nil
+}
+
+type roboclawMotor struct {
+	conn *roboclaw.Roboclaw
+	conf *roboclawConfig
+
+	addr uint8
+
+	logger golog.Logger
+
+	generic.Unimplemented
+}
+
+func (m *roboclawMotor) SetPower(ctx context.Context, powerPct float64) error {
+	switch m.conf.Number {
+	case 1:
+		return m.conn.DutyM1(m.addr, int16(powerPct*32767))
+	case 2:
+		return m.conn.DutyM2(m.addr, int16(powerPct*32767))
+	default:
+		panic("impossible")
+	}
+}
+
+func (m *roboclawMotor) GoFor(ctx context.Context, rpm float64, revolutions float64) error {
+	ticks := uint32(revolutions * float64(m.conf.TicksPerRotation))
+	ticksPerSecond := int32((rpm * float64(m.conf.TicksPerRotation)) / 60)
+
+	switch m.conf.Number {
+	case 1:
+		return m.conn.SpeedDistanceM1(m.addr, ticksPerSecond, ticks, true)
+	case 2:
+		return m.conn.SpeedDistanceM1(m.addr, ticksPerSecond, ticks, true)
+	default:
+		panic("impossible")
+	}
+}
+
+func (m *roboclawMotor) GoTo(ctx context.Context, rpm float64, positionRevolutions float64) error {
+	pos, err := m.GetPosition(ctx)
+	if err != nil {
+		return err
+	}
+	return m.GoFor(ctx, rpm, positionRevolutions-pos)
+}
+
+func (m *roboclawMotor) ResetZeroPosition(ctx context.Context, offset float64) error {
+	newTicks := int32(offset * float64(m.conf.TicksPerRotation))
+	switch m.conf.Number {
+	case 1:
+		return m.conn.SetEncM1(m.addr, newTicks)
+	case 2:
+		return m.conn.SetEncM2(m.addr, newTicks)
+	default:
+		panic("impossible")
+	}
+}
+
+func (m *roboclawMotor) GetPosition(ctx context.Context) (float64, error) {
+	var ticks uint32
+	var err error
+
+	switch m.conf.Number {
+	case 1:
+		ticks, _, err = m.conn.ReadEncM1(m.addr)
+	case 2:
+		ticks, _, err = m.conn.ReadEncM2(m.addr)
+	default:
+		panic("impossible")
+	}
+	if err != nil {
+		return 0, err
+	}
+	return float64(ticks) / float64(m.conf.TicksPerRotation), nil
+}
+
+func (m *roboclawMotor) GetFeatures(ctx context.Context) (map[motor.Feature]bool, error) {
+	return map[motor.Feature]bool{
+		motor.PositionReporting: true,
+	}, nil
+}
+
+func (m *roboclawMotor) Stop(ctx context.Context) error {
+	return m.SetPower(ctx, 0)
+}
+
+func (m *roboclawMotor) IsPowered(ctx context.Context) (bool, error) {
+	pow1, pow2, err := m.conn.ReadPWMs(m.addr)
+	if err != nil {
+		return false, err
+	}
+	switch m.conf.Number {
+	case 1:
+		return pow1 == 0, nil
+	case 2:
+		return pow2 == 0, nil
+	default:
+		panic("impossible")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -82,6 +82,7 @@ require (
 	github.com/Antonboom/errname v0.1.5 // indirect
 	github.com/Antonboom/nilnil v0.1.0 // indirect
 	github.com/BurntSushi/toml v0.4.1 // indirect
+	github.com/CPRT/roboclaw v0.0.0-20190825181223-76871438befc // indirect
 	github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24 // indirect
 	github.com/Masterminds/goutils v1.1.0 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
@@ -263,6 +264,7 @@ require (
 	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/sylvia7788/contextcheck v1.0.4 // indirect
+	github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07 // indirect
 	github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b // indirect
 	github.com/tetafro/godot v1.4.11 // indirect
 	github.com/tidwall/pretty v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw=
 github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/CPRT/roboclaw v0.0.0-20190825181223-76871438befc h1:X6Ptoxdi1w0lofv51zchUBBvULiL97ruSjtTRa/SL5Q=
+github.com/CPRT/roboclaw v0.0.0-20190825181223-76871438befc/go.mod h1:1nLByU34wsr4qNJ4yrfxuGFmIl/0/eAuB8VAiGK0GHs=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v0.0.0-20180822151419-281ae9f2d895/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
@@ -1313,6 +1315,7 @@ github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/sylvia7788/contextcheck v1.0.4 h1:MsiVqROAdr0efZc/fOCt0c235qm9XJqHtWwM+2h2B04=
 github.com/sylvia7788/contextcheck v1.0.4/go.mod h1:vuPKJMQ7MQ91ZTqfdyreNKwZjyUg6KO+IebVyQDedZQ=
+github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07 h1:UyzmZLoiDWMRywV4DUYb9Fbt8uiOSooupjTq10vpvnU=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b h1:HxLVTlqcHhFAz3nWUcuvpH7WuOMv8LQoCWmruLfFH2U=
 github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=


### PR DESCRIPTION
Based on some of the feedback around concurrency logic in [this PR](https://github.com/viamrobotics/rdk/pull/736), I realized the same issues existed in collector: collector.Close() does _not_ wait for all spun off goroutines to return before itself returning. Now it does. Tested locally by running `go test -race` several hundred times without failing.