### PR TITLE
Enable lint for more web js files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ build-go: buf-go
 	CGO_LDFLAGS=$(CGO_LDFLAGS) go build $(TAGS) ./...
 
 build-web: buf-web
-	cd web/frontend/dls && npm install && npm run build:prod
-	cd web/frontend && npm install && npx webpack
+	cd web/frontend/dls && npm ci && npm run build:prod
+	cd web/frontend && npm ci && npx webpack
 
 tool-install:
 	GOBIN=`pwd`/bin go install google.golang.org/protobuf/cmd/protoc-gen-go \

--- a/component/motor/gpio/basic.go
+++ b/component/motor/gpio/basic.go
@@ -245,11 +245,11 @@ func goForMath(maxRPM, rpm, revolutions float64) (float64, time.Duration) {
 }
 
 // GoFor moves an inputted number of revolutions at the given rpm, no encoder is present
-// for this so power is deteremiend via a linear relationship with the maxRPM and the distance
+// for this so power is determined via a linear relationship with the maxRPM and the distance
 // traveled is a time based estimation based on desired RPM.
 func (m *Motor) GoFor(ctx context.Context, rpm float64, revolutions float64) error {
 	if m.maxRPM == 0 {
-		return errors.New("not supported, define max_rpm attribute")
+		return errors.New("not supported, define max_rpm attribute != 0")
 	}
 
 	powerPct, waitDur := goForMath(m.maxRPM, rpm, revolutions)

--- a/component/motor/gpio/basic_test.go
+++ b/component/motor/gpio/basic_test.go
@@ -139,7 +139,7 @@ func TestMotorDirPWM(t *testing.T) {
 		m, err := NewMotor(b, motor.Config{Pins: motor.PinConfig{Direction: "1", EnablePinLow: "2", PWM: "3"}, PWMFreq: 4000}, logger)
 
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, m.GoFor(ctx, 50, 10), test.ShouldBeError, errors.New("not supported, define max_rpm attribute"))
+		test.That(t, m.GoFor(ctx, 50, 10), test.ShouldBeError, errors.New("not supported, define max_rpm attribute != 0"))
 
 		_, err = NewMotor(
 			b,
@@ -151,7 +151,7 @@ func TestMotorDirPWM(t *testing.T) {
 
 	m, err := NewMotor(b, motor.Config{
 		Pins:   motor.PinConfig{Direction: "1", EnablePinLow: "2", PWM: "3"},
-		MaxRPM: 100, PWMFreq: 4000,
+		MaxRPM: maxRPM, PWMFreq: 4000,
 	}, logger)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -291,6 +291,22 @@ func TestMotorAB(t *testing.T) {
 		test.That(t, mustGetGPIOPinByName(b, "2").PWMFreq(context.Background()), test.ShouldEqual, 4000)
 		mustGetGPIOPinByName(b, "2").SetPWMFreq(ctx, 8000)
 		test.That(t, mustGetGPIOPinByName(b, "2").PWMFreq(context.Background()), test.ShouldEqual, 8000)
+	})
+}
+
+func TestMotorABNoEncoder(t *testing.T) {
+	ctx := context.Background()
+	b := &fakeboard.Board{GPIOPins: map[string]*fakeboard.GPIOPin{}}
+	logger := golog.NewTestLogger(t)
+
+	m, err := NewMotor(b, motor.Config{
+		Pins:    motor.PinConfig{A: "1", B: "2", EnablePinLow: "3"},
+		PWMFreq: 4000,
+	}, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	t.Run("motor no encoder GoFor testing", func(t *testing.T) {
+		test.That(t, m.GoFor(ctx, 50, 10), test.ShouldBeError, errors.New("not supported, define max_rpm attribute != 0"))
 	})
 }
 

--- a/component/motor/motor.go
+++ b/component/motor/motor.go
@@ -296,9 +296,9 @@ type Config struct {
 	EncoderA         string  `json:"encoder,omitempty"`          // name of the digital interrupt that is the encoder a
 	EncoderB         string  `json:"encoder_b,omitempty"`        // name of the digital interrupt that is hall encoder b
 	RampRate         float64 `json:"ramp_rate,omitempty"`        // how fast to ramp power to motor when using rpm control
-	MaxRPM           float64 `json:"max_rpm"`                    // RPM
+	MaxRPM           float64 `json:"max_rpm,omitempty"`          // RPM
 	MaxAcceleration  float64 `json:"max_acceleration,omitempty"` // RPM per second
-	TicksPerRotation int     `json:"ticks_per_rotation"`
+	TicksPerRotation int     `json:"ticks_per_rotation,omitempty"`
 }
 
 // RegisterConfigAttributeConverter registers a Config converter.

--- a/services/register/all.go
+++ b/services/register/all.go
@@ -11,6 +11,7 @@ import (
 	_ "go.viam.com/rdk/services/motion"
 	_ "go.viam.com/rdk/services/navigation"
 	_ "go.viam.com/rdk/services/sensors"
+	_ "go.viam.com/rdk/services/slam"
 	_ "go.viam.com/rdk/services/vision"
 	_ "go.viam.com/rdk/services/web"
 )

--- a/services/slam/slam.go
+++ b/services/slam/slam.go
@@ -1,0 +1,296 @@
+// Package slam implements simultaneous localization and mapping
+package slam
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/edaniels/golog"
+	"github.com/pkg/errors"
+	goutils "go.viam.com/utils"
+
+	"go.viam.com/rdk/component/camera"
+	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/registry"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/rimage/transform"
+	"go.viam.com/rdk/robot"
+	"go.viam.com/rdk/utils"
+)
+
+// TBD 05/04/2022: Needs more work wonce GRPC is included (future PR).
+func init() {
+	registry.RegisterService(Subtype, registry.Service{
+		Constructor: func(ctx context.Context, r robot.Robot, c config.Service, logger golog.Logger) (interface{}, error) {
+			return New(ctx, r, c, logger)
+		},
+	})
+}
+
+// SubtypeName is the name of the type of service.
+const SubtypeName = resource.SubtypeName("slam")
+
+// Subtype is a constant that identifies the slam resource subtype.
+var Subtype = resource.NewSubtype(
+	resource.ResourceNamespaceRDK,
+	resource.ResourceTypeService,
+	SubtypeName,
+)
+
+// Name is the slam service's typed resource name.
+var Name = resource.NameFromSubtype(Subtype, "")
+
+// runtimeConfigValidation ensures all parts of the config are valid at runtime but will not close out server.
+func runtimeConfigValidation(svcConfig *AttrConfig, logger golog.Logger) error {
+	slamLib, ok := slamLibraries[svcConfig.Algorithm]
+	if !ok {
+		return errors.Errorf("%v algorithm specified not in implemented list", svcConfig.Algorithm)
+	}
+
+	// Check sensor and mode combination
+	if svcConfig.ConfigParams["mode"] != "" {
+		mode := svcConfig.ConfigParams["mode"]
+		modeCheck, ok := slamLib.SlamMode[svcConfig.ConfigParams["mode"]]
+		if !ok || !modeCheck {
+			return errors.Errorf("getting data with specified algorithm, %v, and desired mode %v", svcConfig.Algorithm, mode)
+		}
+	}
+
+	// Check Data Directory Architecture - create new one if issue accessing folder
+	for _, directoryName := range [4]string{"", "data", "map", "config"} {
+		directoryPath := filepath.Join(svcConfig.DataDirectory, directoryName)
+		if _, err := os.Stat(directoryPath); os.IsNotExist(err) {
+			logger.Warnf("%v directory does not exist", directoryPath)
+			if err := os.Mkdir(directoryPath, os.ModePerm); err != nil {
+				return errors.Errorf("issue creating directory at %v: %v", directoryPath, err)
+			}
+		}
+	}
+
+	// Check Input File Pattern
+	if svcConfig.InputFilePattern != "" {
+		pattern := `(\d+):(\d+):(\d+)`
+		re := regexp.MustCompile(pattern)
+		res := re.MatchString(svcConfig.InputFilePattern)
+		if !res {
+			return errors.Errorf("input_file_pattern (%v) does not match the regex pattern %v", svcConfig.InputFilePattern, pattern)
+		}
+
+		re = regexp.MustCompile(`(\d+)`)
+		res2 := re.FindAllString(svcConfig.InputFilePattern, 3)
+		X, err := strconv.Atoi(res2[0])
+		if err != nil {
+			return err
+		}
+		Y, err := strconv.Atoi(res2[1])
+		if err != nil {
+			return err
+		}
+
+		if X > Y {
+			return errors.Errorf("second value in input file pattern must be larger than the first [%v]", svcConfig.InputFilePattern)
+		}
+	}
+
+	// Check Slam Mode Compatibility with Slam Library
+	if svcConfig.ConfigParams["mode"] != "" {
+		result, ok := slamLib.SlamMode[svcConfig.ConfigParams["mode"]]
+		if !ok {
+			return errors.Errorf("invalid mode (%v) specified for algorithm [%v]", svcConfig.ConfigParams["mode"], svcConfig.Algorithm)
+		}
+		if !result {
+			return errors.Errorf("specified mode (%v) is not supported for algorithm [%v]", svcConfig.ConfigParams["mode"], svcConfig.Algorithm)
+		}
+	}
+
+	return nil
+}
+
+// runtimeServiceValidation ensures the service's data processing and saving is valid for the mode and cam given.
+func runtimeServiceValidation(slamSvc *slamService) error {
+	if slamSvc.camera != nil {
+		var err error
+		var path string
+
+		// TODO 05/05/2022: This will be removed once GRPC data transfer is available as the responsibility for
+		// calling the right algorithms (Next vs NextPointCloud) will be held by the slam libararies themselves
+		// Note: if GRPC data transfer is delayed to after other algorithms (or user custom algos) are being
+		// added this point will be revisited
+		switch slamSvc.slamLib.AlgoName {
+		case "orbslamv3":
+			path, err = slamSvc.getAndSaveDataSparse()
+		case "cartographer":
+			path, err = slamSvc.getAndSaveDataDense()
+		default:
+			return errors.Errorf("invalid slam algorithm %v", slamSvc.slamLib.AlgoName)
+		}
+		if err != nil {
+			return errors.Errorf("getting data with specified sensor and desired mode %v", slamSvc.slamMode)
+		}
+		err = os.RemoveAll(path)
+		if err != nil {
+			return errors.New("removing generated file during validation")
+		}
+	}
+	return nil
+}
+
+// AttrConfig describes how to configure the service.
+type AttrConfig struct {
+	Sensors          []string          `json:"sensors"`
+	Algorithm        string            `json:"algorithm"`
+	ConfigParams     map[string]string `json:"config_params"`
+	DataRateMs       int               `json:"data_rate_ms"`
+	MapRateSec       int               `json:"map_rate_sec"`
+	DataDirectory    string            `json:"data_dir"`
+	InputFilePattern string            `json:"input_file_pattern"`
+}
+
+// Service describes the functions that are available to the service.
+type Service interface {
+	getSLAMServiceData() slamService
+	startDataProcess(ctx context.Context) error
+	startSLAMProcess(ctx context.Context) error
+	Close(ctx context.Context) error
+}
+
+// SlamService is the structure of the slam service.
+type slamService struct {
+	camera           camera.Camera
+	slamLib          metadata
+	slamMode         string
+	configParams     map[string]string
+	dataDirectory    string
+	inputFilePattern string
+
+	port       int
+	dataFreqHz float64
+
+	cancelCtx  context.Context
+	cancelFunc func()
+	logger     golog.Logger
+}
+
+// configureCamera will check the config to see if a camera is desired and if so, grab the camera from
+// the robot as well as get the intrinsic assocated with it.
+func configureCamera(svcConfig *AttrConfig, r robot.Robot, logger golog.Logger) (camera.Camera, error) {
+	var cam camera.Camera
+	var err error
+	if len(svcConfig.Sensors) > 0 {
+		logger.Debug("Running in live mode")
+		cam, err = camera.FromRobot(r, svcConfig.Sensors[0])
+		if err != nil {
+			return nil, errors.Errorf("error with get camera for slam service: %q", err)
+		}
+
+		proj := camera.Projector(cam) // will be nil if no intrinsics
+		if proj != nil {
+			_, ok := proj.(*transform.PinholeCameraIntrinsics)
+			if !ok {
+				return nil, errors.New("error camera intrinsics were not defined properly")
+			}
+		}
+	} else {
+		logger.Debug("Running in non-live mode")
+		cam = nil
+	}
+
+	return cam, nil
+}
+
+// New returns a new slam service for the given robot.
+func New(ctx context.Context, r robot.Robot, config config.Service, logger golog.Logger) (Service, error) {
+	svcConfig, ok := config.ConvertedAttributes.(*AttrConfig)
+	if !ok {
+		return nil, utils.NewUnexpectedTypeError(svcConfig, config.ConvertedAttributes)
+	}
+
+	cam, err := configureCamera(svcConfig, r, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := runtimeConfigValidation(svcConfig, logger); err != nil {
+		logger.Warnf("runtime slam config error: %v", err)
+		return &slamService{}, nil
+	}
+
+	p, err := goutils.TryReserveRandomPort()
+	if err != nil {
+		return nil, errors.Errorf("error trying to return a random port %v", err)
+	}
+
+	cancelCtx, cancelFunc := context.WithCancel(ctx)
+
+	// SLAM Service Object
+	slamSvc := &slamService{
+		camera:           cam,
+		slamLib:          slamLibraries[svcConfig.Algorithm],
+		slamMode:         strings.ToLower(svcConfig.ConfigParams["mode"]),
+		configParams:     svcConfig.ConfigParams,
+		dataDirectory:    svcConfig.DataDirectory,
+		inputFilePattern: svcConfig.InputFilePattern,
+		port:             p,
+		dataFreqHz:       float64(1000.0 / svcConfig.DataRateMs),
+		cancelCtx:        cancelCtx,
+		cancelFunc:       cancelFunc,
+		logger:           logger,
+	}
+
+	if err := runtimeServiceValidation(slamSvc); err != nil {
+		logger.Warnf("runtime slam service error: %v", err)
+		return &slamService{}, nil
+	}
+
+	if err := slamSvc.startDataProcess(ctx); err != nil {
+		return nil, errors.Errorf("error with slam service data process: %q", err)
+	}
+
+	if err := slamSvc.startSLAMProcess(ctx); err != nil {
+		return nil, errors.Errorf("error with slam service slam process: %q", err)
+	}
+
+	return slamSvc, nil
+}
+
+// TBD 05/03/2022: Data processing loop in new PR (see slamlibarary.go GetandSaveData functions as well).
+// startDataProcess is the main control loops for sending data from camera to the data directory for processing.
+func (slamSvc *slamService) startDataProcess(ctx context.Context) error {
+	return nil
+}
+
+// TODO 05/03/2022: Implement SLAM starting and stopping processes (see JIRA ticket:
+// https://viam.atlassian.net/jira/software/c/projects/DATA/boards/30?modal=detail&selectedIssue=DATA-104)
+// startSLAMProcess starts up the SLAM library process by calling the executable binary.
+func (slamSvc *slamService) startSLAMProcess(ctx context.Context) error {
+	return nil
+}
+
+// GetSLAMServiceData returns the SLAM Service implementation and associated data.
+func (slamSvc *slamService) getSLAMServiceData() slamService {
+	return *slamSvc
+}
+
+// TODO 05/03/2022: Implement closeout of slam service and subprocesses.
+// Close out of all slam related processes.
+func (slamSvc *slamService) Close(ctx context.Context) error {
+	return nil
+}
+
+// TODO 05/06/2022: Data processing loop in new PR (see slam.go startDataProcessing function)
+// getAndSaveData implements the data extraction for sparse algos and saving to the specified directory.
+// nolint:unparam
+func (slamSvc *slamService) getAndSaveDataSparse() (string, error) {
+	return filepath.Join(slamSvc.dataDirectory, "temp.txt"), nil
+}
+
+// TODO 05/03/2022: Data processing loop in new PR (see slam.go startDataProcessing function)
+// getAndSaveData implements the data extraction for dense algos and saving to the specified directory.
+// nolint:unparam
+func (slamSvc *slamService) getAndSaveDataDense() (string, error) {
+	return filepath.Join(slamSvc.dataDirectory, "temp.txt"), nil
+}

--- a/services/slam/slam_test.go
+++ b/services/slam/slam_test.go
@@ -1,0 +1,289 @@
+package slam
+
+import (
+	"context"
+	"image"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/edaniels/golog"
+	"github.com/pkg/errors"
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/pointcloud"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/testutils/inject"
+	rdkutils "go.viam.com/rdk/utils"
+)
+
+func TestGeneralSLAMService(t *testing.T) {
+	cfgService := config.Service{Name: "test", Type: "slam"}
+	logger := golog.NewTestLogger(t)
+	ctx := context.Background()
+
+	r := &inject.Robot{}
+	r.ResourceByNameFunc = func(n resource.Name) (interface{}, error) {
+		return nil, rdkutils.NewResourceNotFoundError(n)
+	}
+
+	_, err := New(ctx, r, cfgService, logger)
+	test.That(t, err, test.ShouldBeError, errors.Errorf("expected *slam.AttrConfig but got %v", cfgService.ConvertedAttributes))
+
+	cfgService.ConvertedAttributes = &AttrConfig{}
+
+	_, err = New(ctx, r, cfgService, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	name1, err := createTempFolderArchiecture(true)
+	test.That(t, err, test.ShouldBeNil)
+
+	attrCfg := &AttrConfig{
+		Algorithm:        "cartographer",
+		Sensors:          []string{"rplidar"},
+		ConfigParams:     map[string]string{"mode": "2d"},
+		DataDirectory:    name1,
+		InputFilePattern: "100:300:5",
+	}
+	cfgService.ConvertedAttributes = attrCfg
+
+	_, err = New(ctx, r, cfgService, logger)
+	test.That(t, err, test.ShouldBeError,
+		errors.Errorf("error with get camera for slam service: \"resource \\\"rdk:component:camera/%v\\\" not found\"", attrCfg.Sensors[0]))
+
+	attrCfg = &AttrConfig{
+		Algorithm:        "cartographer",
+		Sensors:          []string{},
+		ConfigParams:     map[string]string{"mode": "2d"},
+		DataDirectory:    name1,
+		InputFilePattern: "100:300:5",
+		DataRateMs:       100,
+	}
+	cfgService.ConvertedAttributes = attrCfg
+
+	slamSvc, err := New(ctx, r, cfgService, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	ss := slamSvc.getSLAMServiceData()
+
+	// cam := &fake.Camera{}
+	cam := &inject.Camera{}
+	cam.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
+		return pointcloud.New(), nil
+	}
+	ss.camera = cam
+
+	// err = ss.startDataProcess(ctx)
+	// ss.cancelCtx.Done()
+	// test.That(t, err, test.ShouldBeNil)
+	err = resetFolder(name1)
+	test.That(t, err, test.ShouldBeNil)
+}
+
+// Validate Tests.
+func TestConfigValidation(t *testing.T) {
+	logger := golog.NewTestLogger(t)
+
+	cam := &inject.Camera{}
+	cam.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
+		return pointcloud.New(), nil
+	}
+
+	// Runtime Validation Tests
+	name1, err := createTempFolderArchiecture(true)
+	test.That(t, err, test.ShouldBeNil)
+
+	cfg := &AttrConfig{
+		Algorithm:        "cartographer",
+		Sensors:          []string{"rplidar"},
+		ConfigParams:     map[string]string{"mode": "2d"},
+		DataDirectory:    name1,
+		InputFilePattern: "100:300:5",
+	}
+
+	err = runtimeConfigValidation(cfg, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	// No sesnor test
+	cfg.Sensors = []string{}
+	err = runtimeConfigValidation(cfg, logger)
+	test.That(t, err, test.ShouldBeNil)
+	cfg.Sensors = []string{"rplidar"}
+
+	// Mode SLAM Library test
+	cfg.ConfigParams["mode"] = ""
+	err = runtimeConfigValidation(cfg, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	testMetadata := metadata{
+		AlgoName: "test",
+		SlamMode: map[string]bool{"test2": false},
+	}
+
+	slamLibraries["test"] = testMetadata
+	cfg.Algorithm = "test"
+	cfg.Sensors = []string{"test_sensor"}
+	cfg.ConfigParams["mode"] = "test1"
+	err = runtimeConfigValidation(cfg, logger)
+	test.That(t, err, test.ShouldBeError,
+		errors.Errorf("getting data with specified algorithm, %v, and desired mode %v", cfg.Algorithm, cfg.ConfigParams["mode"]))
+
+	cfg.Algorithm = "cartographer"
+	cfg.Sensors = []string{"rplidar"}
+	cfg.ConfigParams["mode"] = "2d"
+
+	delete(slamLibraries, "test")
+
+	// Input File Pattern test
+	cfg.InputFilePattern = "dd:300:3"
+	err = runtimeConfigValidation(cfg, logger)
+	test.That(t, err, test.ShouldBeError,
+		errors.Errorf("input_file_pattern (%v) does not match the regex pattern (\\d+):(\\d+):(\\d+)", cfg.InputFilePattern))
+
+	cfg.InputFilePattern = "500:300:3"
+	err = runtimeConfigValidation(cfg, logger)
+	test.That(t, err, test.ShouldBeError,
+		errors.Errorf("second value in input file pattern must be larger than the first [%v]", cfg.InputFilePattern))
+
+	err = resetFolder(name1)
+	test.That(t, err, test.ShouldBeNil)
+
+	// Sensor Mode test
+	cfg.ConfigParams["mode"] = "rgbd"
+	err = runtimeConfigValidation(cfg, logger)
+	test.That(t, err, test.ShouldBeError,
+		errors.Errorf("getting data with specified algorithm, %v, and desired mode %v", cfg.Algorithm, cfg.ConfigParams["mode"]))
+
+	// TODO: sensor and saving data checks once GetAndSaveData is implemented
+
+	// Valid Algo
+	cfg.Algorithm = "wrong_algo"
+	err = runtimeConfigValidation(cfg, logger)
+	test.That(t, err, test.ShouldBeError, errors.Errorf("%v algorithm specified not in implemented list", cfg.Algorithm))
+}
+
+func TestCartographerData(t *testing.T) {
+	cfgService := config.Service{Name: "test", Type: "slam"}
+
+	name, err := createTempFolderArchiecture(true)
+	test.That(t, err, test.ShouldBeNil)
+
+	attrCfg := &AttrConfig{
+		Algorithm:        "cartographer",
+		Sensors:          []string{},
+		ConfigParams:     map[string]string{"mode": "2d"},
+		DataDirectory:    name,
+		InputFilePattern: "100:300:5",
+		DataRateMs:       100,
+	}
+	cfgService.ConvertedAttributes = attrCfg
+
+	logger := golog.NewTestLogger(t)
+	ctx := context.Background()
+
+	r := &inject.Robot{}
+	r.ResourceByNameFunc = func(n resource.Name) (interface{}, error) {
+		return nil, rdkutils.NewResourceNotFoundError(n)
+	}
+
+	slamSvc, err := New(ctx, r, cfgService, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	ss := slamSvc.getSLAMServiceData()
+	cam := &inject.Camera{}
+	cam.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
+		return pointcloud.New(), nil
+	}
+	ss.camera = cam
+
+	err = runtimeServiceValidation(&ss)
+	test.That(t, err, test.ShouldBeNil)
+
+	_, _ = ss.getAndSaveDataDense()
+	test.That(t, err, test.ShouldBeNil)
+
+	ss.Close(ctx)
+	test.That(t, err, test.ShouldBeNil)
+
+	err = resetFolder(name)
+	test.That(t, err, test.ShouldBeNil)
+}
+
+func TestOrbSLAMData(t *testing.T) {
+	cfgService := config.Service{Name: "test", Type: "slam"}
+
+	name, err := createTempFolderArchiecture(true)
+	test.That(t, err, test.ShouldBeNil)
+
+	attrCfg := &AttrConfig{
+		Algorithm:        "orbslamv3",
+		Sensors:          []string{},
+		ConfigParams:     map[string]string{"mode": "mono"},
+		DataDirectory:    name,
+		InputFilePattern: "100:300:5",
+		DataRateMs:       100,
+	}
+	cfgService.ConvertedAttributes = attrCfg
+
+	logger := golog.NewTestLogger(t)
+	ctx := context.Background()
+
+	r := &inject.Robot{}
+	r.ResourceByNameFunc = func(n resource.Name) (interface{}, error) {
+		return nil, rdkutils.NewResourceNotFoundError(n)
+	}
+
+	slamSvc, err := New(ctx, r, cfgService, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	ss := slamSvc.getSLAMServiceData()
+
+	cam := &inject.Camera{}
+	cam.NextFunc = func(ctx context.Context) (image.Image, func(), error) {
+		return image.NewNRGBA(image.Rect(0, 0, 501024, 1024)), nil, nil
+	}
+	ss.camera = cam
+
+	cam = &inject.Camera{}
+	cam.NextFunc = func(ctx context.Context) (image.Image, func(), error) {
+		return image.NewNRGBA(image.Rect(0, 0, 1024, 1024)), nil, nil
+	}
+	ss.camera = cam
+
+	err = runtimeServiceValidation(&ss)
+	test.That(t, err, test.ShouldBeNil)
+
+	ss.Close(ctx)
+	test.That(t, err, test.ShouldBeNil)
+
+	err = resetFolder(name)
+	test.That(t, err, test.ShouldBeNil)
+	// TODO: image with depth test
+}
+
+// nolint:unparam
+func createTempFolderArchiecture(validArch bool) (string, error) {
+	name, err := ioutil.TempDir("/tmp", "*")
+	if err != nil {
+		return "nil", err
+	}
+
+	if validArch {
+		if err := os.Mkdir(name+"/map", os.ModePerm); err != nil {
+			return "", err
+		}
+		if err := os.Mkdir(name+"/data", os.ModePerm); err != nil {
+			return "", err
+		}
+		if err := os.Mkdir(name+"/config", os.ModePerm); err != nil {
+			return "", err
+		}
+	}
+	return name, nil
+}
+
+func resetFolder(path string) error {
+	err := os.RemoveAll(path)
+	return err
+}

--- a/services/slam/slamlibraries.go
+++ b/services/slam/slamlibraries.go
@@ -1,0 +1,27 @@
+// Package slam implements simultaneous localization and mapping
+package slam
+
+var slamLibraries = map[string]metadata{
+	"cartographer": cartographerMetadata,
+	"orbslamv3":    orbslamv3Metadata,
+}
+
+// Define currently implemented slam libraries.
+var cartographerMetadata = metadata{
+	AlgoName:       "cartographer",
+	SlamMode:       map[string]bool{"2d": true, "3d": false},
+	BinaryLocation: "",
+}
+
+var orbslamv3Metadata = metadata{
+	AlgoName:       "orbslamv3",
+	SlamMode:       map[string]bool{"mono": true, "rgbd": true},
+	BinaryLocation: "",
+}
+
+// Metadata contains all pertinant information for defining a SLAM library/algorithm including the sparse/dense definition.
+type metadata struct {
+	AlgoName       string
+	SlamMode       map[string]bool
+	BinaryLocation string
+}


### PR DESCRIPTION
This builds on the previous lint PR (https://github.com/viamrobotics/rdk/pull/791). Doing this mostly for completeness. The actual amount of code here is minimal, but may grow if we pull more js out of webappindex.

- It would be good to have a single linting strategy for dls vue and these js files. I'm punting on that to limit changes since vue lint doesn't use eslint.
- eslint rules were copied from /app and a few rules were excluded to make control.js happy.
- please eyeball the js changes (some were automated some I made) to ensure that they're safe.
- This was tested locally against a fake robot -- the page rendered fine and basic motor and base actions were correct.

CC @micheal-parks 