### PR TITLE
RSDK 70 - Delete unparseable cached config

### DIFF
--- a/config/reader.go
+++ b/config/reader.go
@@ -347,10 +347,9 @@ func readFromCloud(
 	case cached && errors.As(err, &parsingErr):
 		if deleteErr := deleteCachedConfig(cloudCfg.ID); deleteErr != nil {
 			return nil, nil, multierr.Combine(deleteErr, err)
-		} else {
-			logger.Warnw("deleted unparseable cached config", "error", err)
-			return nil, nil, err
 		}
+		logger.Warnw("deleted unparseable cached config", "error", err)
+		return nil, nil, err
 	case err != nil:
 		return nil, nil, err
 	case cfg.Cloud == nil:
@@ -370,10 +369,9 @@ func readFromCloud(
 			case errors.As(err, &parsingErr):
 				if deleteErr := deleteCachedConfig(cloudCfg.ID); deleteErr != nil {
 					return nil, nil, multierr.Combine(deleteErr, err)
-				} else {
-					logger.Warnw("deleted unparseable cached config", "error", err)
-					return nil, nil, err
 				}
+				logger.Warnw("deleted unparseable cached config", "error", err)
+				return nil, nil, err
 			case err != nil:
 				return nil, nil, err
 			case cachedConfig.Cloud == nil:


### PR DESCRIPTION
JIRA: https://viam.atlassian.net/browse/RSDK-70

#### Summary 
Delete the locally cached cloud config if it cannot be parsed.

#### Testing
I wasn't able to write a unit test for this change. In lieu of that, I ran this branch on a PI with a "tainted" local cloud config file (i.e. I added/removed some text to make the JSON invalid). The RDK server was able to start with a tainted config file, and also recover gracefully if the file was tainted again while it was running.