### PR TITLE
Fix processes execution from within AppImages

### DIFF
--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -240,12 +240,13 @@ func cleanAppImageEnv() error {
 		// Reset original values where available
 		for _, eVarStr := range os.Environ() {
 			eVar := strings.Split(eVarStr, "=")
-			origV, present := os.LookupEnv("APPRUN_ORIGINAL_" + eVar[0])
+			key := eVar[0]
+			origV, present := os.LookupEnv("APPRUN_ORIGINAL_" + key)
 			if present {
 				if origV != "" {
-					err = os.Setenv(eVar[0], origV)
+					err = os.Setenv(key, origV)
 				} else {
-					err = os.Unsetenv(eVar[0])
+					err = os.Unsetenv(key)
 				}
 				if err != nil {
 					return err
@@ -257,11 +258,12 @@ func cleanAppImageEnv() error {
 		err = multierr.Combine(os.Unsetenv("ARGV0"), os.Unsetenv("ORIGIN"))
 		for _, eVarStr := range os.Environ() {
 			eVar := strings.Split(eVarStr, "=")
-			if strings.HasPrefix(eVar[0], "APPRUN") ||
-				strings.HasPrefix(eVar[0], "APPDIR") ||
-				strings.HasPrefix(eVar[0], "APPIMAGE") ||
-				strings.HasPrefix(eVar[0], "AIX_") {
-				err = multierr.Combine(err, os.Unsetenv(eVar[0]))
+			key := eVar[0]
+			if strings.HasPrefix(key, "APPRUN") ||
+				strings.HasPrefix(key, "APPDIR") ||
+				strings.HasPrefix(key, "APPIMAGE") ||
+				strings.HasPrefix(key, "AIX_") {
+				err = multierr.Combine(err, os.Unsetenv(key))
 			}
 		}
 		if err != nil {
@@ -272,16 +274,18 @@ func cleanAppImageEnv() error {
 		for _, eVarStr := range os.Environ() {
 			eVar := strings.Split(eVarStr, "=")
 			var newPaths []string
-			if len(eVar) >= 2 && strings.Contains(eVar[1], "/tmp/.mount_") {
+			const mountPrefix = "/tmp/.mount_"
+			key := eVar[0]
+			if len(eVar) >= 2 && strings.Contains(eVar[1], mountPrefix) {
 				for _, path := range strings.Split(eVar[1], ":") {
-					if !strings.HasPrefix(path, "/tmp/.mount_") && path != "" {
+					if !strings.HasPrefix(path, mountPrefix) && path != "" {
 						newPaths = append(newPaths, path)
 					}
 				}
 				if len(newPaths) > 0 {
-					err = os.Setenv(eVar[0], strings.Join(newPaths, ":"))
+					err = os.Setenv(key, strings.Join(newPaths, ":"))
 				} else {
-					err = os.Unsetenv(eVar[0])
+					err = os.Unsetenv(key)
 				}
 				if err != nil {
 					return err


### PR DESCRIPTION
This rewrites the code in process management that was used for starting commands from within an app image. Previously calling the (appimage-included bash) was used as a workaround, since libc-based hooks were in place (and bash uses libc, unlike go.) The new appimage runtime handles things a bit differently though, and now also relies on chdir into a specific runtime folder directly in the appimage before execution, so this no longer works if we want to be able to set CWD for the new process (since go processes can't be hooked via libc overrides to change the CWD after execution begins.)

Instead, this will now scrub the environment of (hopefully) any AppImage related environment variables/paths, and thus the newly executing process will be completely unaware of the parent's AppImage environment. The downside is that this won't work for spawning processes within the AppImage, so a more complex solution may be needed in the future if we ever start building multi-process AppImages.

tl;dr This scrubs the environment variables AppImage sets. If we never try to add processes within the same appimage, this is actually a cleaner solution than the previous bash-based workaround.