### PR TITLE
[DATA-157] Add data capture configuration for remotes.

### DIFF
--- a/component/gantry/gantry.go
+++ b/component/gantry/gantry.go
@@ -147,26 +147,38 @@ func CreateStatus(ctx context.Context, resource interface{}) (*pb.Status, error)
 	return &pb.Status{PositionsMm: positions, LengthsMm: lengths, IsMoving: isMoving}, nil
 }
 
-// WrapWithReconfigurable wraps a gantry with a reconfigurable and locking interface.
+// WrapWithReconfigurable wraps a gantry or localGantry with a reconfigurable
+// and locking interface.
 func WrapWithReconfigurable(r interface{}) (resource.Reconfigurable, error) {
-	g, ok := r.(LocalGantry)
+	g, ok := r.(Gantry)
 	if !ok {
-		return nil, utils.NewUnimplementedInterfaceError("LocalGantry", r)
+		return nil, utils.NewUnimplementedInterfaceError("Gantry", r)
 	}
 	if reconfigurable, ok := g.(*reconfigurableGantry); ok {
 		return reconfigurable, nil
 	}
-	return &reconfigurableGantry{actual: g}, nil
+
+	rGantry := &reconfigurableGantry{actual: g}
+	gLocal, ok := r.(LocalGantry)
+	if !ok {
+		return rGantry, nil
+	}
+	if reconfigurable, ok := gLocal.(*reconfigurableLocalGantry); ok {
+		return reconfigurable, nil
+	}
+	return &reconfigurableLocalGantry{actual: gLocal, reconfigurableGantry: rGantry}, nil
 }
 
 var (
-	_ = LocalGantry(&reconfigurableGantry{})
+	_ = Gantry(&reconfigurableGantry{})
+	_ = LocalGantry(&reconfigurableLocalGantry{})
 	_ = resource.Reconfigurable(&reconfigurableGantry{})
+	_ = resource.Reconfigurable(&reconfigurableLocalGantry{})
 )
 
 type reconfigurableGantry struct {
 	mu     sync.RWMutex
-	actual LocalGantry
+	actual Gantry
 }
 
 func (g *reconfigurableGantry) ProxyFor() interface{} {
@@ -212,12 +224,6 @@ func (g *reconfigurableGantry) Stop(ctx context.Context) error {
 	return g.actual.Stop(ctx)
 }
 
-func (g *reconfigurableGantry) IsMoving(ctx context.Context) (bool, error) {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
-	return g.actual.IsMoving(ctx)
-}
-
 func (g *reconfigurableGantry) Close(ctx context.Context) error {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
@@ -228,6 +234,10 @@ func (g *reconfigurableGantry) Close(ctx context.Context) error {
 func (g *reconfigurableGantry) Reconfigure(ctx context.Context, newGantry resource.Reconfigurable) error {
 	g.mu.Lock()
 	defer g.mu.Unlock()
+	return g.reconfigure(ctx, newGantry)
+}
+
+func (g *reconfigurableGantry) reconfigure(ctx context.Context, newGantry resource.Reconfigurable) error {
 	actual, ok := newGantry.(*reconfigurableGantry)
 	if !ok {
 		return utils.NewUnexpectedTypeError(g, newGantry)
@@ -255,4 +265,30 @@ func (g *reconfigurableGantry) GoToInputs(ctx context.Context, goal []referencef
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	return g.actual.GoToInputs(ctx, goal)
+}
+
+type reconfigurableLocalGantry struct {
+	*reconfigurableGantry
+	actual LocalGantry
+}
+
+func (g *reconfigurableLocalGantry) IsMoving(ctx context.Context) (bool, error) {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	return g.actual.IsMoving(ctx)
+}
+
+func (g *reconfigurableLocalGantry) Reconfigure(ctx context.Context, newGantry resource.Reconfigurable) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	gantry, ok := newGantry.(*reconfigurableLocalGantry)
+	if !ok {
+		return utils.NewUnexpectedTypeError(g, newGantry)
+	}
+	if err := viamutils.TryClose(ctx, g.actual); err != nil {
+		rlog.Logger.Errorw("error closing old", "error", err)
+	}
+
+	g.actual = gantry.actual
+	return g.reconfigurableGantry.reconfigure(ctx, gantry.reconfigurableGantry)
 }

--- a/component/gantry/gantry_test.go
+++ b/component/gantry/gantry_test.go
@@ -32,13 +32,13 @@ func setupDependencies(t *testing.T) registry.Dependencies {
 	t.Helper()
 
 	deps := make(registry.Dependencies)
-	deps[gantry.Named(testGantryName)] = &mock{Name: testGantryName}
+	deps[gantry.Named(testGantryName)] = &mockLocal{Name: testGantryName}
 	deps[gantry.Named(fakeGantryName)] = "not a gantry"
 	return deps
 }
 
 func setupInjectRobot() *inject.Robot {
-	gantry1 := &mock{Name: testGantryName}
+	gantry1 := &mockLocal{Name: testGantryName}
 	r := &inject.Robot{}
 	r.ResourceByNameFunc = func(name resource.Name) (interface{}, error) {
 		switch name {
@@ -253,18 +253,30 @@ func TestWrapWithReconfigurable(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	_, err = gantry.WrapWithReconfigurable(nil)
-	test.That(t, err, test.ShouldBeError, rutils.NewUnimplementedInterfaceError("LocalGantry", nil))
+	test.That(t, err, test.ShouldBeError, rutils.NewUnimplementedInterfaceError("Gantry", nil))
+
 	reconfGantry2, err := gantry.WrapWithReconfigurable(reconfGantry1)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, reconfGantry2, test.ShouldEqual, reconfGantry1)
+
+	var actualGantry2 gantry.LocalGantry = &mockLocal{Name: testGantryName}
+	reconfGantry3, err := gantry.WrapWithReconfigurable(actualGantry2)
+	test.That(t, err, test.ShouldBeNil)
+
+	reconfGantry4, err := gantry.WrapWithReconfigurable(reconfGantry3)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, reconfGantry4, test.ShouldResemble, reconfGantry3)
+
+	_, ok := reconfGantry4.(gantry.LocalGantry)
+	test.That(t, ok, test.ShouldBeTrue)
 }
 
 func TestReconfigurableGantry(t *testing.T) {
-	actualGantry1 := &mock{Name: testGantryName}
+	actualGantry1 := &mockLocal{Name: testGantryName}
 	reconfGantry1, err := gantry.WrapWithReconfigurable(actualGantry1)
 	test.That(t, err, test.ShouldBeNil)
 
-	actualGantry2 := &mock{Name: testGantryName2}
+	actualGantry2 := &mockLocal{Name: testGantryName2}
 	reconfGantry2, err := gantry.WrapWithReconfigurable(actualGantry2)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, actualGantry1.reconfCount, test.ShouldEqual, 0)
@@ -272,7 +284,7 @@ func TestReconfigurableGantry(t *testing.T) {
 	err = reconfGantry1.Reconfigure(context.Background(), reconfGantry2)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, reconfGantry1, test.ShouldResemble, reconfGantry2)
-	test.That(t, actualGantry1.reconfCount, test.ShouldEqual, 1)
+	test.That(t, actualGantry1.reconfCount, test.ShouldEqual, 2)
 
 	test.That(t, actualGantry1.lengthsCount, test.ShouldEqual, 0)
 	test.That(t, actualGantry2.lengthsCount, test.ShouldEqual, 0)
@@ -284,11 +296,34 @@ func TestReconfigurableGantry(t *testing.T) {
 
 	err = reconfGantry1.Reconfigure(context.Background(), nil)
 	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, "expected *gantry.reconfigurableGantry")
+	test.That(t, err, test.ShouldBeError, rutils.NewUnexpectedTypeError(reconfGantry1, nil))
+
+	actualGantry3 := &mock{Name: testGantryName}
+	reconfGantry3, err := gantry.WrapWithReconfigurable(actualGantry3)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, reconfGantry3, test.ShouldNotBeNil)
+
+	err = reconfGantry1.Reconfigure(context.Background(), reconfGantry3)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldBeError, rutils.NewUnexpectedTypeError(reconfGantry1, reconfGantry3))
+	test.That(t, actualGantry3.reconfCount, test.ShouldEqual, 0)
+
+	err = reconfGantry3.Reconfigure(context.Background(), reconfGantry1)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldBeError, rutils.NewUnexpectedTypeError(reconfGantry3, reconfGantry1))
+
+	actualGantry4 := &mock{Name: testGantryName2}
+	reconfGantry4, err := gantry.WrapWithReconfigurable(actualGantry4)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, reconfGantry4, test.ShouldNotBeNil)
+
+	err = reconfGantry3.Reconfigure(context.Background(), reconfGantry4)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, reconfGantry3, test.ShouldResemble, reconfGantry4)
 }
 
 func TestStop(t *testing.T) {
-	actualGantry1 := &mock{Name: testGantryName}
+	actualGantry1 := &mockLocal{Name: testGantryName}
 	reconfGantry1, err := gantry.WrapWithReconfigurable(actualGantry1)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -298,7 +333,7 @@ func TestStop(t *testing.T) {
 }
 
 func TestClose(t *testing.T) {
-	actualGantry1 := &mock{Name: testGantryName}
+	actualGantry1 := &mockLocal{Name: testGantryName}
 	reconfGantry1, err := gantry.WrapWithReconfigurable(actualGantry1)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -310,6 +345,14 @@ func TestClose(t *testing.T) {
 var lengths = []float64{1.0, 2.0, 3.0}
 
 type mock struct {
+	gantry.Gantry
+	Name        string
+	reconfCount int
+}
+
+func (m *mock) Close() { m.reconfCount++ }
+
+type mockLocal struct {
 	gantry.LocalGantry
 	Name         string
 	lengthsCount int
@@ -317,18 +360,18 @@ type mock struct {
 	reconfCount  int
 }
 
-func (m *mock) GetLengths(context.Context) ([]float64, error) {
+func (m *mockLocal) GetLengths(context.Context) ([]float64, error) {
 	m.lengthsCount++
 	return lengths, nil
 }
 
-func (m *mock) Stop(ctx context.Context) error {
+func (m *mockLocal) Stop(ctx context.Context) error {
 	m.stopCount++
 	return nil
 }
 
-func (m *mock) Close() { m.reconfCount++ }
+func (m *mockLocal) Close() { m.reconfCount++ }
 
-func (m *mock) Do(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (m *mockLocal) Do(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
 	return cmd, nil
 }

--- a/component/gps/gps_test.go
+++ b/component/gps/gps_test.go
@@ -29,13 +29,13 @@ func setupDependencies(t *testing.T) registry.Dependencies {
 	t.Helper()
 
 	deps := make(registry.Dependencies)
-	deps[gps.Named(testGPSName)] = &mock{Name: testGPSName}
+	deps[gps.Named(testGPSName)] = &mockLocal{Name: testGPSName}
 	deps[gps.Named(fakeGPSName)] = "not an gps"
 	return deps
 }
 
 func setupInjectRobot() *inject.Robot {
-	gps1 := &mock{Name: testGPSName}
+	gps1 := &mockLocal{Name: testGPSName}
 	r := &inject.Robot{}
 	r.ResourceByNameFunc = func(name resource.Name) (interface{}, error) {
 		switch name {
@@ -155,19 +155,30 @@ func TestWrapWithReconfigurable(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	_, err = gps.WrapWithReconfigurable(nil)
-	test.That(t, err, test.ShouldBeError, rutils.NewUnimplementedInterfaceError("LocalGPS", nil))
+	test.That(t, err, test.ShouldBeError, rutils.NewUnimplementedInterfaceError("GPS", nil))
 
 	reconfGPS2, err := gps.WrapWithReconfigurable(reconfGPS1)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, reconfGPS2, test.ShouldEqual, reconfGPS1)
+
+	var actualGPS2 gps.LocalGPS = &mockLocal{Name: testGPSName}
+	reconfGPS3, err := gps.WrapWithReconfigurable(actualGPS2)
+	test.That(t, err, test.ShouldBeNil)
+
+	reconfGPS4, err := gps.WrapWithReconfigurable(reconfGPS3)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, reconfGPS4, test.ShouldResemble, reconfGPS3)
+
+	_, ok := reconfGPS4.(gps.LocalGPS)
+	test.That(t, ok, test.ShouldBeTrue)
 }
 
 func TestReconfigurableGPS(t *testing.T) {
-	actualGPS1 := &mock{Name: testGPSName}
+	actualGPS1 := &mockLocal{Name: testGPSName}
 	reconfGPS1, err := gps.WrapWithReconfigurable(actualGPS1)
 	test.That(t, err, test.ShouldBeNil)
 
-	actualGPS2 := &mock{Name: testGPSName2}
+	actualGPS2 := &mockLocal{Name: testGPSName2}
 	reconfGPS2, err := gps.WrapWithReconfigurable(actualGPS2)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, actualGPS1.reconfCount, test.ShouldEqual, 0)
@@ -175,7 +186,7 @@ func TestReconfigurableGPS(t *testing.T) {
 	err = reconfGPS1.Reconfigure(context.Background(), reconfGPS2)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, reconfGPS1, test.ShouldResemble, reconfGPS2)
-	test.That(t, actualGPS1.reconfCount, test.ShouldEqual, 1)
+	test.That(t, actualGPS1.reconfCount, test.ShouldEqual, 2)
 
 	test.That(t, actualGPS1.locCount, test.ShouldEqual, 0)
 	test.That(t, actualGPS2.locCount, test.ShouldEqual, 0)
@@ -187,11 +198,34 @@ func TestReconfigurableGPS(t *testing.T) {
 
 	err = reconfGPS1.Reconfigure(context.Background(), nil)
 	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, "expected *gps.reconfigurableGPS")
+	test.That(t, err, test.ShouldBeError, rutils.NewUnexpectedTypeError(reconfGPS1, nil))
+
+	actualGPS3 := &mock{Name: failGPSName}
+	reconfGPS3, err := gps.WrapWithReconfigurable(actualGPS3)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, reconfGPS3, test.ShouldNotBeNil)
+
+	err = reconfGPS1.Reconfigure(context.Background(), reconfGPS3)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldBeError, rutils.NewUnexpectedTypeError(reconfGPS1, reconfGPS3))
+	test.That(t, actualGPS3.reconfCount, test.ShouldEqual, 0)
+
+	err = reconfGPS3.Reconfigure(context.Background(), reconfGPS1)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldBeError, rutils.NewUnexpectedTypeError(reconfGPS3, reconfGPS1))
+
+	actualGPS4 := &mock{Name: testGPSName2}
+	reconfGPS4, err := gps.WrapWithReconfigurable(actualGPS4)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, reconfGPS4, test.ShouldNotBeNil)
+
+	err = reconfGPS3.Reconfigure(context.Background(), reconfGPS4)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, reconfGPS3, test.ShouldResemble, reconfGPS4)
 }
 
 func TestReadLocation(t *testing.T) {
-	actualGPS1 := &mock{Name: testGPSName}
+	actualGPS1 := &mockLocal{Name: testGPSName}
 	reconfGPS1, _ := gps.WrapWithReconfigurable(actualGPS1)
 
 	test.That(t, actualGPS1.locCount, test.ShouldEqual, 0)
@@ -202,7 +236,7 @@ func TestReadLocation(t *testing.T) {
 }
 
 func TestReadAltitude(t *testing.T) {
-	actualGPS1 := &mock{Name: testGPSName}
+	actualGPS1 := &mockLocal{Name: testGPSName}
 	reconfGPS1, _ := gps.WrapWithReconfigurable(actualGPS1)
 
 	test.That(t, actualGPS1.altCount, test.ShouldEqual, 0)
@@ -213,7 +247,7 @@ func TestReadAltitude(t *testing.T) {
 }
 
 func TestReadSpeed(t *testing.T) {
-	actualGPS1 := &mock{Name: testGPSName}
+	actualGPS1 := &mockLocal{Name: testGPSName}
 	reconfGPS1, _ := gps.WrapWithReconfigurable(actualGPS1)
 
 	test.That(t, actualGPS1.speedCount, test.ShouldEqual, 0)
@@ -224,7 +258,7 @@ func TestReadSpeed(t *testing.T) {
 }
 
 func TestReadSatellites(t *testing.T) {
-	actualGPS1 := &mock{Name: testGPSName}
+	actualGPS1 := &mockLocal{Name: testGPSName}
 	reconfGPS1, _ := gps.WrapWithReconfigurable(actualGPS1)
 
 	test.That(t, actualGPS1.satCount, test.ShouldEqual, 0)
@@ -236,7 +270,7 @@ func TestReadSatellites(t *testing.T) {
 }
 
 func TestReadAccuracy(t *testing.T) {
-	actualGPS1 := &mock{Name: testGPSName}
+	actualGPS1 := &mockLocal{Name: testGPSName}
 	reconfGPS1, _ := gps.WrapWithReconfigurable(actualGPS1)
 
 	test.That(t, actualGPS1.accCount, test.ShouldEqual, 0)
@@ -248,7 +282,7 @@ func TestReadAccuracy(t *testing.T) {
 }
 
 func TestReadValid(t *testing.T) {
-	actualGPS1 := &mock{Name: testGPSName}
+	actualGPS1 := &mockLocal{Name: testGPSName}
 	reconfGPS1, _ := gps.WrapWithReconfigurable(actualGPS1)
 
 	test.That(t, actualGPS1.validCount, test.ShouldEqual, 0)
@@ -259,7 +293,7 @@ func TestReadValid(t *testing.T) {
 }
 
 func TestGetReadings(t *testing.T) {
-	actualGPS1 := &mock{Name: testGPSName}
+	actualGPS1 := &mockLocal{Name: testGPSName}
 	reconfGPS1, _ := gps.WrapWithReconfigurable(actualGPS1)
 
 	readings1, err := gps.GetReadings(context.Background(), actualGPS1)
@@ -271,7 +305,7 @@ func TestGetReadings(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, result, test.ShouldResemble, readings1)
 
-	actualGPS2 := &mockWithSensor{}
+	actualGPS2 := &mockLocalWithSensor{}
 	reconfGPS2, _ := gps.WrapWithReconfigurable(actualGPS2)
 
 	test.That(t, actualGPS2.readingsCount, test.ShouldEqual, 0)
@@ -279,6 +313,15 @@ func TestGetReadings(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, result, test.ShouldResemble, readings)
 	test.That(t, actualGPS2.readingsCount, test.ShouldEqual, 1)
+
+	actualGPS3 := &mockWithSensor{}
+	reconfGPS3, _ := gps.WrapWithReconfigurable(actualGPS3)
+
+	test.That(t, actualGPS3.readingsCount, test.ShouldEqual, 0)
+	result, err = reconfGPS3.(sensor.Sensor).GetReadings(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, result, test.ShouldResemble, readings)
+	test.That(t, actualGPS3.readingsCount, test.ShouldEqual, 1)
 }
 
 func TestGetHeading(t *testing.T) {
@@ -340,7 +383,7 @@ func TestGetHeading(t *testing.T) {
 }
 
 func TestClose(t *testing.T) {
-	actualGPS1 := &mock{Name: testGPSName}
+	actualGPS1 := &mockLocal{Name: testGPSName}
 	reconfGPS1, _ := gps.WrapWithReconfigurable(actualGPS1)
 
 	test.That(t, actualGPS1.reconfCount, test.ShouldEqual, 0)
@@ -362,6 +405,14 @@ var (
 )
 
 type mock struct {
+	gps.GPS
+	Name        string
+	reconfCount int
+}
+
+func (m *mock) Close() { m.reconfCount++ }
+
+type mockLocal struct {
 	gps.LocalGPS
 	Name        string
 	locCount    int
@@ -374,44 +425,44 @@ type mock struct {
 }
 
 // ReadLocation always returns the set values.
-func (m *mock) ReadLocation(ctx context.Context) (*geo.Point, error) {
+func (m *mockLocal) ReadLocation(ctx context.Context) (*geo.Point, error) {
 	m.locCount++
 	return loc, nil
 }
 
 // ReadAltitude returns the set value.
-func (m *mock) ReadAltitude(ctx context.Context) (float64, error) {
+func (m *mockLocal) ReadAltitude(ctx context.Context) (float64, error) {
 	m.altCount++
 	return alt, nil
 }
 
 // ReadSpeed returns the set value.
-func (m *mock) ReadSpeed(ctx context.Context) (float64, error) {
+func (m *mockLocal) ReadSpeed(ctx context.Context) (float64, error) {
 	m.speedCount++
 	return speed, nil
 }
 
 // ReadSatellites returns the set values.
-func (m *mock) ReadSatellites(ctx context.Context) (int, int, error) {
+func (m *mockLocal) ReadSatellites(ctx context.Context) (int, int, error) {
 	m.satCount++
 	return activeSats, totalSats, nil
 }
 
 // ReadAccuracy returns the set values.
-func (m *mock) ReadAccuracy(ctx context.Context) (float64, float64, error) {
+func (m *mockLocal) ReadAccuracy(ctx context.Context) (float64, float64, error) {
 	m.accCount++
 	return hAcc, vAcc, nil
 }
 
 // ReadValid returns the set value.
-func (m *mock) ReadValid(ctx context.Context) (bool, error) {
+func (m *mockLocal) ReadValid(ctx context.Context) (bool, error) {
 	m.validCount++
 	return valid, nil
 }
 
-func (m *mock) Close() { m.reconfCount++ }
+func (m *mockLocal) Close() { m.reconfCount++ }
 
-func (m *mock) Do(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (m *mockLocal) Do(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
 	return cmd, nil
 }
 
@@ -421,6 +472,16 @@ type mockWithSensor struct {
 }
 
 func (m *mockWithSensor) GetReadings(ctx context.Context) ([]interface{}, error) {
+	m.readingsCount++
+	return readings, nil
+}
+
+type mockLocalWithSensor struct {
+	mockLocal
+	readingsCount int
+}
+
+func (m *mockLocalWithSensor) GetReadings(ctx context.Context) ([]interface{}, error) {
 	m.readingsCount++
 	return readings, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	github.com/BurntSushi/toml v1.1.0 // indirect
 	github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24 // indirect
 	github.com/GaijinEntertainment/go-exhaustruct/v2 v2.1.0 // indirect
-	github.com/Masterminds/goutils v1.1.0 // indirect
+	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/OpenPeeDeeP/depguard v1.1.0 // indirect
 	github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b // indirect

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,9 @@ github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24/go.mod h1:4UJr5H
 github.com/DzananGanic/numericalgo v0.0.0-20170804125527-2b389385baf0/go.mod h1:uIo7VpFvBkDQoCyKqUL/mTNjpOlv1KdWaJyCsBSpCe4=
 github.com/GaijinEntertainment/go-exhaustruct/v2 v2.1.0 h1:LAPPhJ4KR5Z8aKVZF5S48csJkxL5RMKmE/98fMs1u5M=
 github.com/GaijinEntertainment/go-exhaustruct/v2 v2.1.0/go.mod h1:LGOGuvEgCfCQsy3JF2tRmpGDpzA53iZfyGEWSPwQ6/4=
-github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
+github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=


### PR DESCRIPTION
Embed `service_config` into remote configuration, and specifically use it to support data capture configuration. See context in [the data capture config proposal](https://docs.google.com/document/d/1qK6aDKqtLDnuokuq-zqFPVabjjz5-9wf1FPkeKpYqbs/edit#heading=h.1a5y1js8wg2m) and [previous PR for component-level configuration](https://github.com/viamrobotics/rdk/pull/764).