### PR TITLE
Disable commentFormatting in gocritic so it doesn't clash with gofumpt

### DIFF
--- a/etc/.golangci.yaml
+++ b/etc/.golangci.yaml
@@ -45,6 +45,9 @@ linters:
     - wrapcheck
     - wsl
 linters-settings:
+  gocritic:
+    disabled-checks:
+      - commentFormatting
   errcheck:
     check-blank: true
   gosec:


### PR DESCRIPTION
This PR fixes malformed go comments deletion ex (`//This comment would be deleted`) 