### PR TITLE
[DATA-131] Include robot marker in SLAM image map

### DIFF
--- a/web/runtime-shared/templates/webappindex.html
+++ b/web/runtime-shared/templates/webappindex.html
@@ -653,6 +653,7 @@
               req.setName("UI");
               const mimeType = "image/jpeg";
               req.setMimeType(mimeType);
+              req.setIncludeRobotMarker(true);
               slamService.getMap(req, {}, (err, resp) => {
                 grpcCallback(err, resp, false);
                 if (err) {


### PR DESCRIPTION
This passes `include_robot_marker` in the `GetMap` request for SLAM images. The corresponding slam PR is https://github.com/viamrobotics/slam/pull/18.