### PR TITLE
[RSDK-324] Remove unneeded methods from Current Operations

### DIFF
--- a/etc/setup.sh
+++ b/etc/setup.sh
@@ -149,6 +149,7 @@ do_brew(){
 	brew "protoc-gen-grpc-web"
 	brew "pkg-config"
 	brew "tensorflowlite"
+	brew "ffmpeg"
 	# pinned
 	brew "gcc@11"
 	brew "go@1.18"

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -128,11 +128,6 @@ func newRemoteName(remote RemoteName, namespace Namespace, rType TypeName, subty
 
 // NameFromSubtype creates a new Name based on a Subtype and name string passed in.
 func NameFromSubtype(subtype Subtype, name string) Name {
-	remotes := strings.Split(name, ":")
-	if len(remotes) > 1 {
-		rName := NewName(subtype.Namespace, subtype.ResourceType, subtype.ResourceSubtype, remotes[len(remotes)-1])
-		return rName.PrependRemote(RemoteName(strings.Join(remotes[:len(remotes)-1], ":")))
-	}
 	return NewName(subtype.Namespace, subtype.ResourceType, subtype.ResourceSubtype, name)
 }
 


### PR DESCRIPTION
The /proto.rpc.webrtc.v1.SignalingService and /proto.api.robot.v1.RobotService/StreamStatus values have been scrubbed from the current operations tab since they are not started by the user and killing their processes can lead to unwanted robot behavior