### PR TITLE
Temporarily ignore control.js diff

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,14 @@ jobs:
         git add .
         chown -R testbot .
         sudo -u testbot bash -lc '${{ matrix.build_lint }}'
+
+        NOW=$(date "+%s")
+        CUTOFF_DATE=$(date -d"2022/07/25 00:00:00" "+%s")
+        if [ $NOW -gt $CUTOFF_DATE]; then
+          echo "stop ignoring web/runtime-shared/static/control.js"
+          exit 1
+        fi
+
         GEN_DIFF=$(git status -s | grep -v web/runtime-shared/static/control.js)
         if [ -n "$GEN_DIFF" ]; then
             echo '"make build lint" resulted in changes not in git' 1>&2


### PR DESCRIPTION
This unblocks CI from running tests for a few days