### PR TITLE
Update default services after additional resources added

### DIFF
--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -451,6 +451,10 @@ func newWithResources(
 		r.manager.addResource(name, res)
 	}
 
+	if len(resources) != 0 {
+		r.updateDefaultServices(ctx)
+	}
+
 	successful = true
 	return r, nil
 }


### PR DESCRIPTION
this makes sure that sensors and other services pick up on additional resources we add to the robot.

might be possible to add resources before going through reconfig flow, but will need to doublecheck on that first