### PR TITLE
[DATA-312] Add CloudMatrix function to PointClouds

### DIFF
--- a/services/datamanager/data_manager.go
+++ b/services/datamanager/data_manager.go
@@ -211,7 +211,10 @@ type componentMethodMetadata struct {
 
 // Get time.Duration from hz.
 func getDurationFromHz(captureFrequencyHz float32) time.Duration {
-	return time.Second / time.Duration(captureFrequencyHz)
+	if captureFrequencyHz == 0 {
+		return time.Duration(0)
+	}
+	return time.Duration((float32(time.Second) / captureFrequencyHz))
 }
 
 // Initialize a collector for the component/method or update it if it has previously been created.

--- a/services/datamanager/data_manager_test.go
+++ b/services/datamanager/data_manager_test.go
@@ -656,6 +656,14 @@ func TestSyncDisabled(t *testing.T) {
 	test.That(t, len(uploaded), test.ShouldEqual, 3)
 }
 
+func TestGetDurationFromHz(t *testing.T) {
+	test.That(t, datamanager.GetDurationFromHz(0.1), test.ShouldEqual, time.Second*10)
+	test.That(t, datamanager.GetDurationFromHz(0.5), test.ShouldEqual, time.Second*2)
+	test.That(t, datamanager.GetDurationFromHz(1), test.ShouldEqual, time.Second)
+	test.That(t, datamanager.GetDurationFromHz(1000), test.ShouldEqual, time.Millisecond)
+	test.That(t, datamanager.GetDurationFromHz(0), test.ShouldEqual, 0)
+}
+
 func getDataManagerConfig(config *config.Config) (*datamanager.Config, error) {
 	svcConfig, ok, err := datamanager.GetServiceConfig(config)
 	if err != nil {

--- a/services/datamanager/export_test.go
+++ b/services/datamanager/export_test.go
@@ -21,3 +21,6 @@ func (svc *dataManagerService) SetWaitAfterLastModifiedSecs(s int) {
 
 // Make getServiceConfig global for tests.
 var GetServiceConfig = getServiceConfig
+
+// Make getDurationFromHz global for tests.
+var GetDurationFromHz = getDurationFromHz


### PR DESCRIPTION
This PR adds a simple utility function called CloudMatrix which converts a pointcloud to a Matrix. There are many point cloud algorithms that are based on storage in a matrix, so this function will allow future work using this representation easily. The function returns the actual matrix as well as a header list which describes the features in each column.