### PR TITLE
[DATA-bug] Fix bug where point clouds were being saved as structs.

### DIFF
--- a/component/camera/collectors.go
+++ b/component/camera/collectors.go
@@ -42,12 +42,13 @@ func newNextPointCloudCollector(resource interface{}, params data.CollectorParam
 		}
 
 		var buf bytes.Buffer
-		buf.Grow(v.Size() * 4 * 4) // 4 numbers per point, each 4 bytes
+		headerSize := 200
+		buf.Grow(headerSize + v.Size()*4*4) // 4 numbers per point, each 4 bytes
 		err = pointcloud.ToPCD(v, &buf, pointcloud.PCDBinary)
 		if err != nil {
 			return nil, errors.Errorf("failed to convert returned point cloud to PCD: %v", err)
 		}
-		return buf, nil
+		return buf.Bytes(), nil
 	})
 	return data.NewCollector(cFunc, params)
 }


### PR DESCRIPTION
Because the capture func was returning a Bytes instead of a []byte, `collector.go` was interpreting the result as a struct (and so saving it to disk as a proto struct). This changes it to return a []byte so it's properly handled.

Also added 200 to the buffer sized when writing PCDsto account for headers (copied from an Eliot performance optimization PR).