### PR TITLE
[DATA-fix] Use correct creds type when connecting to datasync.

### DIFF
--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -61,8 +61,8 @@ func NewDefaultManager(logger golog.Logger, cfg *config.Config) (Manager, error)
 		rpc.WithEntityCredentials(
 			cloudConfig.ID,
 			rpc.Credentials{
-				Type:    rdkutils.CredentialsTypeRobotLocationSecret,
-				Payload: cloudConfig.LocationSecret,
+				Type:    rdkutils.CredentialsTypeRobotSecret,
+				Payload: cloudConfig.Secret,
 			}),
 	}
 


### PR DESCRIPTION
We need to use the Robot credential type, not the Location one.