### PR TITLE
RSDK-525 Fix version tagging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,8 @@ TOOL_BIN = bin/gotools/$(shell uname -s)-$(shell uname -m)
 
 PATH_WITH_TOOLS="`pwd`/$(TOOL_BIN):`pwd`/node_modules/.bin:${PATH}"
 
-VERSION = $(shell git fetch --tags && git tag --sort=-version:refname | head -n 1)
 GIT_REVISION = $(shell git rev-parse HEAD | tr -d '\n')
-LDFLAGS = -ldflags "-X 'go.viam.com/rdk/config.Version=${VERSION}' -X 'go.viam.com/rdk/config.GitRevision=${GIT_REVISION}'"
+LDFLAGS = -ldflags "$(shell etc/tag_version.sh) -X 'go.viam.com/rdk/config.GitRevision=${GIT_REVISION}'"
 
 default: build lint server
 

--- a/etc/packaging/appimages/package_release.sh
+++ b/etc/packaging/appimages/package_release.sh
@@ -1,17 +1,12 @@
 #!/bin/bash
+
 set -e
+SELF=$(realpath $0)
+source "$(dirname $SELF)/../../utils.sh"
 
-# This is a helper script to determine if the current git commit constitutes a new release.
-# Specifically, is it tagged in the format "v1.2.3" and a higher version than any other tags.
-# It then creates stable and v1.2.3 appimages.
-
-CUR_TAG=`git tag --points-at | sort -Vr | head -n1`
-if [[ $CUR_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+if get_version_tag > /dev/null
 then
-	NEWEST_TAG=`git tag -l "v*.*.*" | sort -Vr | head -n1`
-	if [[ $CUR_TAG == $NEWEST_TAG ]]
-	then
-		BUILD_CHANNEL=stable appimage-builder --recipe viam-server-`uname -m`.yml
-		BUILD_CHANNEL=$CUR_TAG appimage-builder --recipe viam-server-`uname -m`.yml
-	fi
+	CUR_TAG=$(get_version_tag)
+	BUILD_CHANNEL=stable appimage-builder --recipe viam-server-`uname -m`.yml
+	BUILD_CHANNEL=$CUR_TAG appimage-builder --recipe viam-server-`uname -m`.yml
 fi

--- a/etc/tag_version.sh
+++ b/etc/tag_version.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+SELF=$(realpath $0)
+source "$(dirname $SELF)/utils.sh"
+
+if get_version_tag > /dev/null
+then
+	echo -X \'go.viam.com/rdk/config.Version=$(get_version_tag)\'
+fi
+exit 0

--- a/etc/utils.sh
+++ b/etc/utils.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# This is a helper function to determine if the current git commit constitutes a new release.
+# Specifically, is it tagged in the format "v1.2.3" and a higher version than any other tags.
+# This is used for internal tagging and release building.
+get_version_tag() {
+	set -e
+	CUR_TAG=`git tag --points-at | sort -Vr | head -n1`
+	if [[ $CUR_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+	then
+		NEWEST_TAG=`git tag -l "v*.*.*" | sort -Vr | head -n1`
+		if [[ $CUR_TAG == $NEWEST_TAG ]]
+		then
+			echo $CUR_TAG
+			return 0
+		else
+			echo "latest"
+			return 128
+		fi
+	fi
+	return 1
+}


### PR DESCRIPTION
Quick fix to reuse the logic I wrote for stable/versioned build channels and use it for tagging the binary internally too.