### PR TITLE
Fix GitHub Action Running on PI

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   test:
-    uses: viamrobotics/rdk/.github/workflows/test.yml@fix-github
+    uses: viamrobotics/rdk/.github/workflows/test.yml@main
     secrets:
       REPO_READ_TOKEN: ${{ secrets.REPO_READ_TOKEN }}
       GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}


### PR DESCRIPTION
Ensure we're configuring the viam private github repo access.

This fixes issues like:
```
go: downloading go.viam.com/api v0.0.0-20220809163525-ced590c0d8de
config/proto_conversions.go:5:2: go.viam.com/api@v0.0.0-20220809163525-ced590c0d8de: invalid version: git ls-remote -q origin in /home/ghbot/go/pkg/mod/cache/vcs/fc1749c93b00389dbd1bcaeb9feace5f462d09caa1dd2f7564187eb453728907: exit status 128:
	fatal: could not read Username for 'https://github.com/': terminal prompts disabled
Confirm the import path was entered correctly.
If this is a private repository, see https://golang.org/doc/faq#git_https for additional information.
make: *** [Makefile:79: test-pi] Error 1
Error: Process completed with exit code 2.
```