### PR TITLE
Remove dependency on viam app

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -352,4 +352,4 @@ require (
 )
 
 // Disallow all usages of viamrobotics/app in rdk.
-replace  github.com/viamrobotics/app =>  github.com/viamrobotics/project-does-not-exist v0.0.0
+replace github.com/viamrobotics/app => github.com/viamrobotics/project-does-not-exist v0.0.0


### PR DESCRIPTION
https://github.com/viamrobotics/rdk/pull/1148 added a dependency on the viam/app from rdk. Remove this by manually defining the error code and run `go mod tidy`