### PR TITLE
[RSDK-526] Avoid developers failing the build when gcloud application default credentials are missing

### DIFF
--- a/motionplan/nearestNeighbor.go
+++ b/motionplan/nearestNeighbor.go
@@ -29,7 +29,7 @@ func (nm *neighborManager) nearestNeighbor(
 	seed *configuration,
 	rrtMap map[*configuration]*configuration,
 ) *configuration {
-	if len(rrtMap) > neighborsBeforeParallelization {
+	if len(rrtMap) > neighborsBeforeParallelization && nm.nCPU > 1 {
 		// If the map is large, calculate distances in parallel
 		return nm.parallelNearestNeighbor(ctx, seed, rrtMap)
 	}


### PR DESCRIPTION
RSDK-526 is a known issue when building/test the rdk when the gcloud application credential file is missing, when missing we leak goroutines causing the tests to fail. 

We fixed it in CI but we've seen a number of developers run into this already and ask for help in slack.

This ensures a dummy application credential is added on setup if it does not already exists. Real credentials will be overwritten if a developer runs `gcloud auth application-default login`