### PR TITLE
[RSDK-461] Add GetFrame to camera interface

### DIFF
--- a/component/camera/camera_test.go
+++ b/component/camera/camera_test.go
@@ -319,6 +319,12 @@ func TestCameraWithNoProjector(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	_, got := pc.At(0, 0, 0)
 	test.That(t, got, test.ShouldBeTrue)
+
+	_, mimeType, width, height, err := noProj2.GetFrame(context.Background(), "")
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, mimeType, test.ShouldEqual, rutils.MimeTypePNG)
+	test.That(t, width, test.ShouldEqual, 1280)
+	test.That(t, height, test.ShouldEqual, 720)
 }
 
 func TestCameraWithProjector(t *testing.T) {
@@ -352,4 +358,10 @@ func TestCameraWithProjector(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	_, got := pc.At(0, 0, 0)
 	test.That(t, got, test.ShouldBeTrue)
+
+	_, mimeType, width, height, err := cam2.GetFrame(context.Background(), "")
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, mimeType, test.ShouldEqual, rutils.MimeTypePNG)
+	test.That(t, width, test.ShouldEqual, 1280)
+	test.That(t, height, test.ShouldEqual, 720)
 }

--- a/component/camera/client.go
+++ b/component/camera/client.go
@@ -106,6 +106,19 @@ func (c *client) GetProperties(ctx context.Context) (rimage.Projector, error) {
 	return proj, nil
 }
 
+func (c *client) GetFrame(ctx context.Context, mimeType string) ([]byte, string, int64, int64, error) {
+	ctx, span := trace.StartSpan(ctx, "camera::client::GetFrame")
+	defer span.End()
+	resp, err := c.client.GetFrame(ctx, &pb.GetFrameRequest{
+		Name:     c.name,
+		MimeType: mimeType,
+	})
+	if err != nil {
+		return nil, "", 0, 0, err
+	}
+	return resp.GetImage(), resp.GetMimeType(), resp.GetWidthPx(), resp.GetHeightPx(), nil
+}
+
 func (c *client) Do(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
 	return generic.DoFromConnection(ctx, c.conn, c.name, cmd)
 }

--- a/grpc/client/client_test.go
+++ b/grpc/client/client_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"image"
-	"image/jpeg"
+	"image/png"
 	"math"
 	"net"
 	"testing"
@@ -130,11 +130,12 @@ func TestStatusClient(t *testing.T) {
 	injectCamera := &inject.Camera{}
 	img := image.NewNRGBA(image.Rect(0, 0, 4, 4))
 	var imgBuf bytes.Buffer
-	test.That(t, jpeg.Encode(&imgBuf, img, nil), test.ShouldBeNil)
+	test.That(t, png.Encode(&imgBuf, img), test.ShouldBeNil)
 
 	var imageReleased bool
-	injectCamera.NextFunc = func(ctx context.Context) (image.Image, func(), error) {
-		return img, func() { imageReleased = true }, nil
+	injectCamera.GetFrameFunc = func(ctx context.Context, mimeType string) ([]byte, string, int64, int64, error) {
+		imageReleased = true
+		return imgBuf.Bytes(), rutils.MimeTypePNG, int64(img.Bounds().Dx()), int64(img.Bounds().Dy()), nil
 	}
 
 	injectInputDev := &inject.InputController{}

--- a/services/vision/helpers_test.go
+++ b/services/vision/helpers_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/edaniels/golog"
 	"github.com/golang/geo/r3"
+	"github.com/pkg/errors"
 	"go.viam.com/test"
 	"go.viam.com/utils/artifact"
 
@@ -151,6 +152,10 @@ func (c *cloudSource) GetProperties(ctx context.Context) (rimage.Projector, erro
 
 	proj = intrinsics
 	return proj, nil
+}
+
+func (c *cloudSource) GetFrame(ctx context.Context, mimeType string) ([]byte, string, int64, int64, error) {
+	return nil, "", 0, 0, errors.New("not implemented")
 }
 
 func (c *cloudSource) Do(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {

--- a/testutils/inject/camera.go
+++ b/testutils/inject/camera.go
@@ -18,6 +18,7 @@ type Camera struct {
 	NextFunc           func(ctx context.Context) (image.Image, func(), error)
 	NextPointCloudFunc func(ctx context.Context) (pointcloud.PointCloud, error)
 	GetPropertiesFunc  func(ctx context.Context) (rimage.Projector, error)
+	GetFrameFunc       func(ctx context.Context, mimeType string) ([]byte, string, int64, int64, error)
 	CloseFunc          func(ctx context.Context) error
 }
 
@@ -43,6 +44,14 @@ func (c *Camera) GetProperties(ctx context.Context) (rimage.Projector, error) {
 		return c.Camera.GetProperties(ctx)
 	}
 	return c.GetPropertiesFunc(ctx)
+}
+
+// GetFrame calls the injected GetFrame or the real version.
+func (c *Camera) GetFrame(ctx context.Context, mimeType string) ([]byte, string, int64, int64, error) {
+	if c.GetFrameFunc == nil {
+		return c.Camera.GetFrame(ctx, mimeType)
+	}
+	return c.GetFrameFunc(ctx, mimeType)
 }
 
 // Close calls the injected Close or the real version.


### PR DESCRIPTION
This PR adds `GetFrame` to the camera interface. This is part of the effort to make the camera component interface consistent with the proto contract.

Additionally, when the camera is implemented using a `serverSource`/`dualServerSource`, `GetFrame` returns the raw bytes, without roundtripping them through decoding/encoding. This ensures that the slam service can use the original raw bytes, since orbslam cannot use the images that have been roundtripped through Go's encoding/decoding. It also leads to a faster `GetFrame` implementation when the camera is implemented using a `serverSource`/`dualServerSource`.