### PR TITLE
RSDK-548 remove calls to logger fatal audit calls to panic

### DIFF
--- a/rimage/transform/cmd/depth_to_color/main.go
+++ b/rimage/transform/cmd/depth_to_color/main.go
@@ -20,18 +20,22 @@ func main() {
 	flag.Parse()
 	if flag.NArg() != 3 {
 		err := errors.Errorf("need 3 numbers for a depth map point. Have %d", flag.NArg())
+		// TODO(RSDK-548): remove fatal?
 		logger.Fatal(err)
 	}
 	x, err := strconv.ParseFloat(flag.Arg(0), 64)
 	if err != nil {
+		// TODO(RSDK-548): remove fatal?
 		logger.Fatal(err)
 	}
 	y, err := strconv.ParseFloat(flag.Arg(1), 64)
 	if err != nil {
+		// TODO(RSDK-548): remove fatal?
 		logger.Fatal(err)
 	}
 	z, err := strconv.ParseFloat(flag.Arg(2), 64)
 	if err != nil {
+		// TODO(RSDK-548): remove fatal?
 		logger.Fatal(err)
 	}
 	logger.Infof("depth: x: %.3f, y: %.3f, z:%.3f\n", x, y, z)
@@ -40,6 +44,7 @@ func main() {
 	params, err := transform.NewDepthColorIntrinsicsExtrinsicsFromJSONFile(*confPtr)
 	if err != nil {
 		err = errors.Wrap(err, fmt.Sprintf("path=%q", *confPtr))
+		// TODO(RSDK-548): remove fatal?
 		logger.Fatal(err)
 	}
 	cx, cy, _ := params.DepthPixelToColorPixel(x, y, z)

--- a/rimage/transform/cmd/extrinsic_calibration/main.go
+++ b/rimage/transform/cmd/extrinsic_calibration/main.go
@@ -31,11 +31,13 @@ func main() {
 func calibrate(conf string, logger golog.Logger) {
 	cfg, err := readConfig(conf)
 	if err != nil {
+		// TODO(RSDK-548): remove fatal?
 		logger.Fatal(err)
 	}
 	// set up the optimization problem
 	problem, err := transform.BuildExtrinsicOptProblem(cfg)
 	if err != nil {
+		// TODO(RSDK-548): remove fatal?
 		logger.Fatal(err)
 	}
 	// solve the problem
@@ -43,6 +45,7 @@ func calibrate(conf string, logger golog.Logger) {
 	// print result to output stream
 	logger.Infof("\nrotation:\n%v\ntranslation:\n%.3f\n", printRot(pose.Orientation()), pose.Point())
 	if err != nil {
+		// TODO(RSDK-548): remove fatal?
 		logger.Fatal(err)
 	}
 }

--- a/samples/mycomponent/client/client.go
+++ b/samples/mycomponent/client/client.go
@@ -18,46 +18,54 @@ func main() {
 		logger,
 	)
 	if err != nil {
+		// TODO(RSDK-548): remove fatal?
 		logger.Fatal(err)
 	}
 
 	res, err := robot.ResourceByName(myc.Named("comp1"))
 	if err != nil {
+		// TODO(RSDK-548): remove fatal?
 		logger.Fatal(err)
 	}
 	comp1 := res.(myc.MyComponent)
 	ret1, err := comp1.DoOne(context.Background(), "hello")
 	if err != nil {
+		// TODO(RSDK-548): remove fatal?
 		logger.Fatal(err)
 	}
 	logger.Info(ret1)
 
 	ret2, err := comp1.DoOneClientStream(context.Background(), []string{"hello", "arg1", "foo"})
 	if err != nil {
+		// TODO(RSDK-548): remove fatal?
 		logger.Fatal(err)
 	}
 	logger.Info(ret2)
 
 	ret2, err = comp1.DoOneClientStream(context.Background(), []string{"arg1", "arg1", "arg1"})
 	if err != nil {
+		// TODO(RSDK-548): remove fatal?
 		logger.Fatal(err)
 	}
 	logger.Info(ret2)
 
 	ret3, err := comp1.DoOneServerStream(context.Background(), "hello")
 	if err != nil {
+		// TODO(RSDK-548): remove fatal?
 		logger.Fatal(err)
 	}
 	logger.Info(ret3)
 
 	ret3, err = comp1.DoOneBiDiStream(context.Background(), []string{"hello", "arg1", "foo"})
 	if err != nil {
+		// TODO(RSDK-548): remove fatal?
 		logger.Fatal(err)
 	}
 	logger.Info(ret3)
 
 	ret3, err = comp1.DoOneBiDiStream(context.Background(), []string{"arg1", "arg1", "arg1"})
 	if err != nil {
+		// TODO(RSDK-548): remove fatal?
 		logger.Fatal(err)
 	}
 	logger.Info(ret3)

--- a/vision/objectdetection/cmd/color_detection/main.go
+++ b/vision/objectdetection/cmd/color_detection/main.go
@@ -36,15 +36,18 @@ func main() {
 	flag.Parse()
 	logger := golog.NewLogger("simple_detection")
 	if *imgPtr == "" && *urlPtr == "" {
+		// TODO(RSDK-548): remove fatal?
 		logger.Fatal("must either have a -img argument or -url argument for the image source")
 	}
 	if *imgPtr != "" && *urlPtr != "" {
+		// TODO(RSDK-548): remove fatal?
 		logger.Fatal("cannot have both a path argument and a url argument for image source, must choose one")
 	}
 	if *imgPtr != "" {
 		src := &simpleSource{*imgPtr}
 		cam, err := camera.NewFromReader(context.Background(), src, nil, camera.UnspecifiedStream)
 		if err != nil {
+			// TODO(RSDK-548): remove fatal?
 			logger.Fatal(err)
 		}
 		pipeline(cam, *threshPtr, *sizePtr, *colorPtr, logger)
@@ -57,6 +60,7 @@ func main() {
 		}
 		src, err := videosource.NewServerSource(context.Background(), cfg, logger)
 		if err != nil {
+			// TODO(RSDK-548): remove fatal?
 			logger.Fatal(err)
 		}
 		pipeline(src, *threshPtr, *sizePtr, *colorPtr, logger)
@@ -74,10 +78,12 @@ func pipeline(src gostream.VideoSource, tol float64, size int, colorString strin
 	// create detector
 	det, err := objectdetection.NewColorDetector(detCfg)
 	if err != nil {
+		// TODO(RSDK-548): remove fatal?
 		logger.Fatal(err)
 	}
 	pipe, err := objectdetection.NewSource(src, det)
 	if err != nil {
+		// TODO(RSDK-548): remove fatal?
 		logger.Fatal(err)
 	}
 	defer pipe.Close()
@@ -86,6 +92,7 @@ func pipeline(src gostream.VideoSource, tol float64, size int, colorString strin
 		start := time.Now()
 		result, err := pipe.NextResult(context.Background())
 		if err != nil {
+			// TODO(RSDK-548): remove fatal?
 			logger.Fatal(err)
 		}
 		duration := time.Since(start)
@@ -96,10 +103,12 @@ func pipeline(src gostream.VideoSource, tol float64, size int, colorString strin
 		logger.Infof("FPS: %.2f", 1./duration.Seconds())
 		ovImg, err := objectdetection.Overlay(result.OriginalImage, result.Detections)
 		if err != nil {
+			// TODO(RSDK-548): remove fatal?
 			logger.Fatal(err)
 		}
 		err = rimage.WriteImageToFile("./simple_detection.jpg", ovImg)
 		if err != nil {
+			// TODO(RSDK-548): remove fatal?
 			logger.Fatal(err)
 		}
 	}

--- a/vision/odometry/cmd/estimate_motion.go
+++ b/vision/odometry/cmd/estimate_motion.go
@@ -33,6 +33,7 @@ func main() {
 	// get orb points for each image
 	imOrb1, imOrb2, err := RunOrbPointFinding(image1Path, image2Path, configPath)
 	if err != nil {
+		// TODO(RSDK-548): remove fatal?
 		logger.Fatal(err.Error())
 	}
 	// get matched lines


### PR DESCRIPTION
JIRA: https://viam.atlassian.net/browse/RSDK-548

Let's use this PR to discuss whether or not the `logger.Fatal`s are necessary. The actually changes to remove them will likely be broken out into separate PRs:
* [x] Movement sensors - https://github.com/viamrobotics/rdk/pull/1212
* [x] Trossen gripper - https://github.com/viamrobotics/rdk/pull/1225
* [x] Add linter - https://github.com/edaniels/golinters/pull/2
* [x] Use linter - https://github.com/viamrobotics/rdk/pull/1286
* [x] Robot config reader - https://github.com/viamrobotics/rdk/pull/1241