### PR TITLE
Add more orientation types to sensor protoutils

### DIFF
--- a/protoutils/sensor_test.go
+++ b/protoutils/sensor_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
-	
+
 	"go.viam.com/test"
 
 	"go.viam.com/rdk/spatialmath"
@@ -13,12 +13,15 @@ import (
 
 func TestRoundtrip(t *testing.T) {
 	m1 := map[string]interface{}{
-		"d" : 5.4,
-		"av" : spatialmath.AngularVelocity{1, 2, 3},
-		"vv" : r3.Vector{1, 2, 3},
-		"ea" : &spatialmath.EulerAngles{Roll: 3, Pitch: 5, Yaw: 4},
-		"q" : &spatialmath.Quaternion{1, 2, 3, 4},
-		"gp" : geo.NewPoint(12,13),
+		"d":   5.4,
+		"av":  spatialmath.AngularVelocity{1, 2, 3},
+		"vv":  r3.Vector{1, 2, 3},
+		"ea":  &spatialmath.EulerAngles{Roll: 3, Pitch: 5, Yaw: 4},
+		"q":   &spatialmath.Quaternion{1, 2, 3, 4},
+		"ov":  &spatialmath.OrientationVector{Theta: 1, OX: 2, OY: 3, OZ: 4},
+		"ovd": &spatialmath.OrientationVectorDegrees{Theta: 1, OX: 2, OY: 3, OZ: 4},
+		"aa":  &spatialmath.R4AA{Theta: 1, RX: 2, RY: 3, RZ: 4},
+		"gp":  geo.NewPoint(12, 13),
 	}
 
 	p, err := ReadingGoToProto(m1)


### PR DESCRIPTION
`MovementSensor` can return any concrete instance of the `Orientation` interface. We were only serializing `EulerAngles` and `Quaternions` before. This PR adds `AxisAngle`, `OrientationVector`, and `OrientationVectorDegrees`, along with a catchall of `Orientation` that uses `OrientationVectorDegrees` under the hood since that is what we send `Orientation`s as over proto