### PR TITLE
RSDK-543: Trigger fetch of TLS cert when location changed

### DIFF
--- a/services/slam/client.go
+++ b/services/slam/client.go
@@ -64,8 +64,11 @@ func (c *client) GetMap(ctx context.Context, name, mimeType string, cameraPositi
 	req := &pb.GetMapRequest{
 		Name:               name,
 		MimeType:           mimeType,
-		CameraPosition:     referenceframe.PoseInFrameToProtobuf(cameraPosition).Pose,
 		IncludeRobotMarker: includeRobotMarker,
+	}
+
+	if cameraPosition != nil {
+		req.CameraPosition = referenceframe.PoseInFrameToProtobuf(cameraPosition).Pose
 	}
 
 	var imageData image.Image

--- a/web/frontend/src/app.vue
+++ b/web/frontend/src/app.vue
@@ -793,26 +793,22 @@ export default {
 
       this.getSegmenterNames();
     },
-    updateSLAMImageRefreshFrequency(time) {
+    updateSLAMImageRefreshFrequency(name, time) {
       clearInterval(this.slamImageIntervalId);
       if (time === 'manual') {
-        this.viewSLAMImageMap();
+        this.viewSLAMImageMap(name);
       } else if (time === 'off') {
         // do nothing
       } else {
-        this.viewSLAMImageMap();
+        this.viewSLAMImageMap(name);
         this.slamImageIntervalId = window.setInterval(() => {
-          this.viewSLAMImageMap();
+          this.viewSLAMImageMap(name);
         }, Number(time) * 1000);
       }
     },
-    viewSLAMImageMap() {
-      
+    viewSLAMImageMap(name) {
       const req = new slamApi.GetMapRequest();
-      // We are deliberately just getting the first slam service to ensure this will not break.
-      // May want to allow for more services in the future
-      const slamName = filterResources(this.resources, 'rdk', 'services', 'slam')[0];
-      req.setName(slamName);
+      req.setName(name);
       req.setMimeType('image/jpeg');
       req.setIncludeRobotMarker(true);
       slamService.getMap(req, {}, (err, resp) => {
@@ -824,24 +820,23 @@ export default {
         this.imageMapTemp = URL.createObjectURL(blob);
       });
     },
-    updateSLAMPCDRefreshFrequency(time, load) {
+    updateSLAMPCDRefreshFrequency(name, time, load) {
       clearInterval(this.slamPCDIntervalId);
       if (time === 'manual') {
-        this.viewSLAMPCDMap(load);
+        this.viewSLAMPCDMap(name, load);
       } else if (time === 'off') {
         // do nothing
       } else {
-        this.viewSLAMPCDMap(load);
+        this.viewSLAMPCDMap(name, load);
         this.slamPCDIntervalId = window.setInterval(() => {
           this.viewSLAMPCDMap();
         }, Number(time) * 1000);
       }
     },
-    viewSLAMPCDMap(load) {
+    viewSLAMPCDMap(name, load) {
       this.$nextTick(() => {
         const req = new slamApi.GetMapRequest();
-        const slamName = filterResources(this.resources, 'rdk', 'services', 'slam')[0];
-        req.setName(slamName);
+        req.setName(name);
         req.setMimeType('pointcloud/pcd');
         if (load) {
           this.initPCD();
@@ -1203,7 +1198,8 @@ export default {
               }
             }
           }
-
+          
+          this.resources = resources;
           if (resourcesChanged === true) {
             this.querySensors();
 
@@ -1211,8 +1207,6 @@ export default {
               this.restartStatusStream();
             }
           }
-
-          this.resources = resources;
           resolve(this.resources);
         });
       });
@@ -2456,7 +2450,8 @@ function setBoundingBox(box, centerPoint) {
 
     <!-- ******* SLAM *******  -->
     <Slam
-      v-if="filterResources(resources, 'rdk', 'service', 'slam').length > 0"
+      v-for = "slam in filterResources(resources, 'rdk', 'service', 'slam')"
+      :name = "slam.name"
       :image-map="imageMapTemp"
       @update-slam-image-refresh-frequency="updateSLAMImageRefreshFrequency"
       @update-slam-pcd-refresh-frequency="updateSLAMPCDRefreshFrequency"

--- a/web/frontend/src/components/slam.vue
+++ b/web/frontend/src/components/slam.vue
@@ -1,6 +1,6 @@
 <template>
   <v-collapse
-    title="SLAM"
+    :title=props.name
     class="slam"
   >
     <div class="h-auto border-x border-b border-black p-2">
@@ -156,15 +156,17 @@
 import { ref } from 'vue';
 
 interface Props {
+  name: string
   imageMap?: string
 }
 
 interface Emits {
-  (event: 'update-slam-image-refresh-frequency', value: string): void
-  (event: 'update-slam-pcd-refresh-frequency', value: string, load: boolean): void
+  (event: 'update-slam-image-refresh-frequency', name: string, value: string): void
+  (event: 'update-slam-pcd-refresh-frequency', name: string, value: string, load: boolean): void
 }
 
-defineProps<Props>();
+const props = defineProps<Props>();
+
 
 const emit = defineEmits<Emits>();
 
@@ -176,35 +178,35 @@ const selectedPCDValue = ref('manual');
 const toggleImageExpand = () => {
   showImage.value = !showImage.value;
   if (showImage.value) {
-    emit('update-slam-image-refresh-frequency', selectedImageValue.value);
+    emit('update-slam-image-refresh-frequency', props.name, selectedImageValue.value);
   } else {
-    emit('update-slam-image-refresh-frequency', "off");
+    emit('update-slam-image-refresh-frequency', props.name, "off");
   }
 };
 
 const togglePCDExpand = () => {
   showPCD.value = !showPCD.value;
   if (showPCD.value) {
-    emit('update-slam-pcd-refresh-frequency', selectedPCDValue.value, true);
+    emit('update-slam-pcd-refresh-frequency', props.name, selectedPCDValue.value, true);
   } else {
-    emit('update-slam-pcd-refresh-frequency', "off", false);
+    emit('update-slam-pcd-refresh-frequency', props.name, "off", false);
   }
 };
 
 const selectSLAMImageRefreshFrequency = () => {
-  emit('update-slam-image-refresh-frequency', selectedImageValue.value);
+  emit('update-slam-image-refresh-frequency', props.name, selectedImageValue.value);
 };
 
 const selectSLAMPCDRefreshFrequency = () => {
-  emit('update-slam-pcd-refresh-frequency', selectedPCDValue.value, false);
+  emit('update-slam-pcd-refresh-frequency', props.name, selectedPCDValue.value, false);
 };
 
 const refreshImageMap = () => {
-  emit('update-slam-image-refresh-frequency', selectedImageValue.value);
+  emit('update-slam-image-refresh-frequency', props.name, selectedImageValue.value);
 };
 
 const refreshPCDMap = () => {
-  emit('update-slam-pcd-refresh-frequency', selectedPCDValue.value, false);
+  emit('update-slam-pcd-refresh-frequency', props.name, selectedPCDValue.value, false);
 };
 
 </script>


### PR DESCRIPTION
we weren't actually refetching TLS certs when location got updated.

Logic's kinda messy because the struct has > 10 fields, and something like 5 of them don't matter and get overwritten at some point - so have to either explicitly check the 6 that do or erase the 5 that don't. Opted for the explicit check, tho it is possible that we can check less fields for this.