### PR TITLE
Remove fatal log from config reader

### DIFF
--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -620,7 +620,7 @@ func (r *localRobot) TransformPose(
 func RobotFromConfigPath(ctx context.Context, cfgPath string, logger golog.Logger, opts ...Option) (robot.LocalRobot, error) {
 	cfg, err := config.Read(ctx, cfgPath, logger)
 	if err != nil {
-		logger.Fatal("cannot read config")
+		logger.Error("cannot read config")
 		return nil, err
 	}
 	return RobotFromConfig(ctx, cfg, logger, opts...)


### PR DESCRIPTION
JIRA: https://viam.atlassian.net/browse/RSDK-548

Removes a stray fatal log from the config reader. Originally part of https://github.com/viamrobotics/rdk/pull/1202