### PR TITLE
[RSDK-565] Skip flaky test

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -103,7 +103,7 @@ type Config struct {
 	Network    NetworkConfig         `json:"network"`
 	Auth       AuthConfig            `json:"auth"`
 
-	Debug bool `json:"-"`
+	Debug bool `json:"debug,omitempty"`
 
 	ConfigFilePath string `json:"-"`
 

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -103,7 +103,7 @@ func createWebOptions(cfg *config.Config, argsParsed Arguments, logger golog.Log
 	}
 	options.Pprof = argsParsed.WebProfile
 	options.SharedDir = argsParsed.SharedDir
-	options.Debug = argsParsed.Debug
+	options.Debug = argsParsed.Debug || cfg.Debug
 	options.WebRTC = argsParsed.WebRTC
 	if cfg.Cloud != nil && argsParsed.AllowInsecureCreds {
 		options.SignalingDialOpts = append(options.SignalingDialOpts, rpc.WithAllowInsecureWithCredentialsDowngrade())
@@ -136,7 +136,7 @@ func serveWeb(ctx context.Context, cfg *config.Config, argsParsed Arguments, log
 		if err != nil {
 			return nil, err
 		}
-		out.Debug = argsParsed.Debug
+		out.Debug = argsParsed.Debug || cfg.Debug
 		out.FromCommand = true
 		out.AllowInsecureCreds = argsParsed.AllowInsecureCreds
 		return out, nil


### PR DESCRIPTION
Bidi broke this. I don't know why, and don't think it's worth working on any time soon. It's something to do with trying to mock inherently non-synchronous, non-deterministically ordered things in a synchronous, deterministic way. Beyond that, 🤷 

should probably do something like [this](https://medium.com/@leeransetton/how-to-mock-grpc-stream-in-golang-db8c405fae37), but it isn't remotely high priority 