### PR TITLE
increase timeout for slam server grpc connection

### DIFF
--- a/services/slam/slam.go
+++ b/services/slam/slam.go
@@ -45,7 +45,7 @@ import (
 
 var (
 	cameraValidationMaxTimeoutSec = 30 // reconfigurable for testing
-	dialMaxTimeoutSec             = 5  // reconfigurable for testing
+	dialMaxTimeoutSec             = 30 // reconfigurable for testing
 )
 
 const (


### PR DESCRIPTION
quick change to slam service to increase the timeout time. With the appimage the orbslam binary seems to take ~22 seconds to start, so the timeout needed to be increased to account for this