### PR TITLE
[DATA-298] Support getting log lines from managed processes

### DIFF
--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -1419,6 +1419,10 @@ func (fp *fakeProcess) Stop() error {
 	return nil
 }
 
+func (fp *fakeProcess) GetLogLine(ctx context.Context) (string, error) {
+	return "log line", nil
+}
+
 func TestManagerResourceRPCSubtypes(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	injectRobot := &inject.Robot{}


### PR DESCRIPTION
There are 4 PRs necessary to reserve the port in the slam process:

https://github.com/viamrobotics/slam/pull/29: orbslam reserves and logs the port
https://github.com/viamrobotics/rdk/pull/1268 (this PR): mock managed process implements `GetLogLine`
https://github.com/viamrobotics/goutils/pull/50: add `GetLogLine` to managed process
https://github.com/viamrobotics/rdk/pull/1269: slam service reads port from orbslam logs

https://github.com/viamrobotics/goutils/pull/50 must be merged after https://github.com/viamrobotics/rdk/pull/1268. https://github.com/viamrobotics/rdk/pull/1269 must be merged after https://github.com/viamrobotics/slam/pull/29 and https://github.com/viamrobotics/goutils/pull/50.