### PR TITLE
[DATA-298] Reserve port in slam process

### DIFF
--- a/services/slam/slam.go
+++ b/services/slam/slam.go
@@ -703,8 +703,9 @@ func (slamSvc *slamService) StartSLAMProcess(ctx context.Context) error {
 			if err != nil {
 				return errors.Wrapf(err, "error getting port from slam process")
 			}
-			if strings.Contains(line, "Server listening on ") {
-				linePieces := strings.Split(line, "Server listening on ")
+			portLogLinePrefix := "Server listening on "
+			if strings.Contains(line, portLogLinePrefix) {
+				linePieces := strings.Split(line, portLogLinePrefix)
 				if len(linePieces) != 2 {
 					return errors.Errorf("failed to parse port from slam process log line: %v", line)
 				}


### PR DESCRIPTION
There are 3 PRs necessary to reserve the port in the slam process:

https://github.com/viamrobotics/slam/pull/29: orbslam reserves and logs the port
https://github.com/viamrobotics/goutils/pull/50: add support for extracting log lines from managed processes
https://github.com/viamrobotics/rdk/pull/1269 (this PR): slam service reads port from orbslam logs

https://github.com/viamrobotics/rdk/pull/1269 must be merged after https://github.com/viamrobotics/slam/pull/29 and https://github.com/viamrobotics/goutils/pull/50.

It's expected that tests for this PR fail until after https://github.com/viamrobotics/goutils/pull/50 is merged.