### PR TITLE
[DATA-452] SLAM map rate fix

### DIFF
--- a/services/slam/slam.go
+++ b/services/slam/slam.go
@@ -496,10 +496,12 @@ func New(ctx context.Context, r robot.Robot, config config.Service, logger golog
 	}
 
 	var mapRate int
-	if svcConfig.MapRateSec == -1 {
-		mapRate = 0
-	} else if svcConfig.MapRateSec <= 0 {
-		mapRate = defaultMapRateSec
+	if svcConfig.MapRateSec <= 0 {
+		if svcConfig.MapRateSec == -1 {
+			mapRate = 0
+		} else {
+			mapRate = defaultMapRateSec
+		}
 	} else {
 		mapRate = svcConfig.MapRateSec
 	}


### PR DESCRIPTION
small change for if a user specifies a map rate of -1 to disable map saving in a slam algorithm. Set it up this way to not require changes in the ORBSLAM server and to have the default still remain as `defaultMapRateSec` if no map rate is specified. 