### PR TITLE
[DATA-362] Add orbslam integration testing framework

### DIFF
--- a/.artifact/tree.json
+++ b/.artifact/tree.json
@@ -50543,6 +50543,138 @@
       }
     }
   },
+  "slam": {
+    "ORBvoc.txt": {
+      "hash": "8ecf7ccd4c22d4606783db10a26018c4",
+      "size": 145250924
+    },
+    "temp_mock_camera": {
+      "color": {
+        "0.png": {
+          "hash": "d6a4ad2b5d0a07cb42ce0a968bdd2d1e",
+          "size": 1074038
+        },
+        "1.png": {
+          "hash": "bf162ae919b499fb2a31c1c0651bc7e7",
+          "size": 1110424
+        },
+        "10.png": {
+          "hash": "7ecd6687e8af2f741b74fd6d61e5b94f",
+          "size": 1262970
+        },
+        "11.png": {
+          "hash": "e49a10305cd6444d65a2e259e092dcf3",
+          "size": 1320711
+        },
+        "12.png": {
+          "hash": "ccc96509aecebfcad460f66a8980ea9b",
+          "size": 1383680
+        },
+        "13.png": {
+          "hash": "a54e3cad45855001accb0f3e90cc4901",
+          "size": 1232388
+        },
+        "14.png": {
+          "hash": "2d0fcc43e04cfa64533f066f08286c8c",
+          "size": 1319859
+        },
+        "2.png": {
+          "hash": "561f98f2fdb955118c396071cb768711",
+          "size": 1113264
+        },
+        "3.png": {
+          "hash": "0b1245610799dfc255a39c7b28592839",
+          "size": 1126246
+        },
+        "4.png": {
+          "hash": "f87169c5c85b32e255f59aa50856ff27",
+          "size": 1126679
+        },
+        "5.png": {
+          "hash": "769088a8ebdbb1ce2979b64808ac707d",
+          "size": 1108197
+        },
+        "6.png": {
+          "hash": "fcc66c01f0f1cb5c200d0b3a67d0991e",
+          "size": 1118615
+        },
+        "7.png": {
+          "hash": "f81538daa0836653b935b97c99a60142",
+          "size": 1094447
+        },
+        "8.png": {
+          "hash": "9668c21a11b5abedb1254770dafb959d",
+          "size": 1246588
+        },
+        "9.png": {
+          "hash": "5e6afad5bf9912b1d69ed06d357f0b36",
+          "size": 1269381
+        }
+      },
+      "depth": {
+        "0.png": {
+          "hash": "e49b03a3e9fe6a9e41d67e3308a70120",
+          "size": 245153
+        },
+        "1.png": {
+          "hash": "34e0a2ae549be6f507b8f4e27f31f2e2",
+          "size": 345685
+        },
+        "10.png": {
+          "hash": "65517158a4175157ab3636e1ef9ac90d",
+          "size": 500936
+        },
+        "11.png": {
+          "hash": "593e152cea83f14e1c4b4cec78e0b33b",
+          "size": 528680
+        },
+        "12.png": {
+          "hash": "0abc4c2361127eb343572390c8d9f35c",
+          "size": 528095
+        },
+        "13.png": {
+          "hash": "3f28b21a7206a6e6cc109fd2b03d432b",
+          "size": 526535
+        },
+        "14.png": {
+          "hash": "f5142f9dbe12b339f8b4a0b92abe22f9",
+          "size": 485705
+        },
+        "2.png": {
+          "hash": "34e0a2ae549be6f507b8f4e27f31f2e2",
+          "size": 345685
+        },
+        "3.png": {
+          "hash": "2a3b9d6fa3177270c8be3fc48f12b6e9",
+          "size": 480005
+        },
+        "4.png": {
+          "hash": "59765705cd3ff8331b908f5a2f2b7d20",
+          "size": 479413
+        },
+        "5.png": {
+          "hash": "bbb525470e857878207ce030a0d78b26",
+          "size": 479728
+        },
+        "6.png": {
+          "hash": "ed4df21dd6036b0cda823de71dd81c53",
+          "size": 513825
+        },
+        "7.png": {
+          "hash": "b37632c463e4a4a78b3bcd172a215ea5",
+          "size": 511135
+        },
+        "8.png": {
+          "hash": "95683c3b3c6a93282c3d06fabcd149ed",
+          "size": 503015
+        },
+        "9.png": {
+          "hash": "fcac230bb47d1617838e48fe3ca10f56",
+          "size": 505238
+        }
+      }
+    }
+  },
   "transform": {
     "align-test-1615761793.png": {
       "hash": "64d2f7a2dd5e27e860c369ceded374c5",

--- a/services/slam/builtin/orbslam_int_test.go
+++ b/services/slam/builtin/orbslam_int_test.go
@@ -1,0 +1,91 @@
+package builtin_test
+
+import (
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/edaniels/golog"
+	"go.viam.com/rdk/services/slam/builtin"
+	"go.viam.com/rdk/services/slam/internal"
+	"go.viam.com/test"
+	"go.viam.com/utils"
+	"go.viam.com/utils/artifact"
+)
+
+func createVocabularyFile(name string) error {
+	source, err := os.Open(artifact.MustPath("slam/ORBvoc.txt"))
+	if err != nil {
+		return err
+	}
+	defer source.Close()
+	destination, err := os.Create(name + "/config/ORBvoc.txt")
+	if err != nil {
+		return err
+	}
+	defer destination.Close()
+	_, err = io.Copy(destination, source)
+	return err
+}
+
+func TestOrbslamIntegrationExample(t *testing.T) {
+	// TODO DATA-364: enable integration tests in CI
+	t.Skip()
+	name, err := createTempFolderArchitecture()
+	test.That(t, err, test.ShouldBeNil)
+	createVocabularyFile(name)
+
+	attrCfg := &builtin.AttrConfig{
+		Algorithm: "orbslamv3",
+		Sensors:   []string{"orbslam_int_color_camera", "orbslam_int_depth_camera"},
+		ConfigParams: map[string]string{
+			"mode":              "rgbd",
+			"orb_n_features":    "1000",
+			"orb_scale_factor":  "1.2",
+			"orb_n_levels":      "8",
+			"orb_n_ini_th_fast": "20",
+			"orb_n_min_th_fast": "7",
+			"debug":             "true",
+		},
+		DataDirectory: name,
+	}
+
+	// Create slam service using a real orbslam binary
+	logger := golog.NewTestLogger(t)
+	svc, err := createSLAMService(t, attrCfg, logger, true, true)
+	test.That(t, err, test.ShouldBeNil)
+
+	// Wait for orbslam to finish processing images
+	logReader := svc.(internal.Service).GetSLAMProcessBufferedLogReader()
+	for i := 0; i < numOrbslamImages; i++ {
+		t.Logf("Find log line for image %v", i)
+		for {
+			line, err := logReader.ReadString('\n')
+			test.That(t, err, test.ShouldBeNil)
+			if strings.Contains(line, "Passed image to SLAM") {
+				break
+			}
+		}
+	}
+
+	// Test position and map
+	position, err := svc.Position(context.Background(), "test")
+	test.That(t, err, test.ShouldBeNil)
+	t.Logf("Position point: (%v, %v, %v)",
+		position.Pose().Point().X, position.Pose().Point().Y, position.Pose().Point().Z)
+	t.Logf("Position orientation: RX: %v, RY: %v, RY: %v, Theta: %v",
+		position.Pose().Orientation().AxisAngles().RX,
+		position.Pose().Orientation().AxisAngles().RY,
+		position.Pose().Orientation().AxisAngles().RZ,
+		position.Pose().Orientation().AxisAngles().Theta)
+	actualMIME, _, pointcloud, err := svc.GetMap(context.Background(), "test", "pointcloud/pcd", nil, false)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, actualMIME, test.ShouldResemble, "pointcloud/pcd")
+	t.Logf("Pointcloud points: %v", pointcloud.Size())
+
+	// Close out slam service
+	test.That(t, utils.TryClose(context.Background(), svc), test.ShouldBeNil)
+	closeOutSLAMService(t, name)
+}

--- a/services/slam/builtin/orbslam_yaml_test.go
+++ b/services/slam/builtin/orbslam_yaml_test.go
@@ -53,7 +53,7 @@ func TestOrbslamYAMLNew(t *testing.T) {
 		// Create slam service
 		logger := golog.NewTestLogger(t)
 		grpcServer := setupTestGRPCServer(attrCfgGood.Port)
-		svc, err := createSLAMService(t, attrCfgGood, logger, true)
+		svc, err := createSLAMService(t, attrCfgGood, logger, false, true)
 		test.That(t, err, test.ShouldBeNil)
 
 		grpcServer.Stop()
@@ -63,7 +63,7 @@ func TestOrbslamYAMLNew(t *testing.T) {
 	t.Run("New orbslamv3 service with camera that errors from bad intrinsics", func(t *testing.T) {
 		// Create slam service
 		logger := golog.NewTestLogger(t)
-		_, err := createSLAMService(t, attrCfgBadCam, logger, false)
+		_, err := createSLAMService(t, attrCfgBadCam, logger, false, false)
 
 		test.That(t, err.Error(), test.ShouldContainSubstring,
 			transform.NewNoIntrinsicsError(fmt.Sprintf("Invalid size (%#v, %#v)", 0, 0)).Error())
@@ -88,7 +88,7 @@ func TestOrbslamYAMLNew(t *testing.T) {
 		}
 		// Create slam service
 		logger := golog.NewTestLogger(t)
-		_, err := createSLAMService(t, attrCfgBadParam1, logger, false)
+		_, err := createSLAMService(t, attrCfgBadParam1, logger, false, false)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "Parameter orb_n_features has an invalid definition")
 
 		attrCfgBadParam2 := &builtin.AttrConfig{
@@ -106,7 +106,7 @@ func TestOrbslamYAMLNew(t *testing.T) {
 			DataRateMs:    dataRateMs,
 			Port:          "localhost:4445",
 		}
-		_, err = createSLAMService(t, attrCfgBadParam2, logger, false)
+		_, err = createSLAMService(t, attrCfgBadParam2, logger, false, false)
 
 		test.That(t, err.Error(), test.ShouldContainSubstring, "Parameter orb_scale_factor has an invalid definition")
 	})

--- a/services/slam/internal/slam_test_helper.go
+++ b/services/slam/internal/slam_test_helper.go
@@ -3,6 +3,7 @@
 package internal
 
 import (
+	"bufio"
 	"context"
 
 	"github.com/edaniels/gostream"
@@ -20,4 +21,5 @@ type Service interface {
 	StopSLAMProcess() error
 	Close() error
 	GetSLAMProcessConfig() pexec.ProcessConfig
+	GetSLAMProcessBufferedLogReader() bufio.Reader
 }


### PR DESCRIPTION
Adds an integration testing framework and example integration test. Tests are disabled in CI until we do the github action work to put the orbslam binary in place (DATA-364).