### PR TITLE
Remove private-only secret deps from workflows

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -6,8 +6,6 @@ on:
     secrets:
       GCP_CREDENTIALS:
         required: true
-      REPO_READ_TOKEN:
-        required: true
 
 env:
   GOPRIVATE: "github.com/viamrobotics/*,go.viam.com/*"
@@ -38,9 +36,8 @@ jobs:
       with: 
         fetch-depth: 2
 
-    - name: Clean and configure git for private repos
+    - name: Clean
       run: |
-        echo "machine github.com login viambot password ${{ secrets.REPO_READ_TOKEN }}" > ~/.netrc
         make clean-all
 
     - name: Authorize GCP Upload

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -8,8 +8,6 @@ on:
         required: true
       REPO_READ_TOKEN:
         required: true
-      GIT_ACCESS_TOKEN:
-        required: true
 
 env:
   GOPRIVATE: "github.com/viamrobotics/*,go.viam.com/*"
@@ -99,7 +97,6 @@ jobs:
       uses: marocchino/sticky-pull-request-comment@v2.2.0
       with:
         recreate: true
-        GITHUB_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
         message: |
           AppImages ready!
           <http://packages.viam.com/apps/viam-server/viam-server-pr-${{ github.event.pull_request.number }}-x86_64.AppImage>

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,5 +50,4 @@ jobs:
     needs: canon-cache
     uses: viamrobotics/rdk/.github/workflows/test.yml@main
     secrets:
-      REPO_READ_TOKEN: ${{ secrets.REPO_READ_TOKEN }}
       ARTIFACT_READ_ONLY_GCP_CREDENTIALS: ${{ secrets.ARTIFACT_READ_ONLY_GCP_CREDENTIALS }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,5 +51,4 @@ jobs:
     uses: viamrobotics/rdk/.github/workflows/test.yml@main
     secrets:
       REPO_READ_TOKEN: ${{ secrets.REPO_READ_TOKEN }}
-      GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
       ARTIFACT_READ_ONLY_GCP_CREDENTIALS: ${{ secrets.ARTIFACT_READ_ONLY_GCP_CREDENTIALS }}

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -3,9 +3,6 @@ name: License Finder
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      REPO_READ_TOKEN:
-        required: true
   pull_request:
     branches: ['main']
   push:
@@ -24,10 +21,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
-
-      - name: Configure git for private repos
-        run: |
-          sudo -u testbot bash -lc 'echo "machine github.com login viambot password ${{ secrets.REPO_READ_TOKEN }}" > ~/.netrc'
 
       - name: Run license finder
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,6 @@ jobs:
     uses: viamrobotics/rdk/.github/workflows/test.yml@main
     secrets:
       REPO_READ_TOKEN: ${{ secrets.REPO_READ_TOKEN }}
-      GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
       ARTIFACT_READ_ONLY_GCP_CREDENTIALS: ${{ secrets.ARTIFACT_READ_ONLY_GCP_CREDENTIALS }}
 
   appimage:
@@ -30,4 +29,3 @@ jobs:
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
       REPO_READ_TOKEN: ${{ secrets.REPO_READ_TOKEN }}
-      GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,6 @@ jobs:
   test:
     uses: viamrobotics/rdk/.github/workflows/test.yml@main
     secrets:
-      REPO_READ_TOKEN: ${{ secrets.REPO_READ_TOKEN }}
       ARTIFACT_READ_ONLY_GCP_CREDENTIALS: ${{ secrets.ARTIFACT_READ_ONLY_GCP_CREDENTIALS }}
 
   appimage:
@@ -28,4 +27,3 @@ jobs:
     uses: viamrobotics/rdk/.github/workflows/appimage.yml@main
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
-      REPO_READ_TOKEN: ${{ secrets.REPO_READ_TOKEN }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   test:
-    uses: viamrobotics/rdk/.github/workflows/test.yml@main
+    uses: viamrobotics/rdk/.github/workflows/test.yml@testfix
     secrets:
       REPO_READ_TOKEN: ${{ secrets.REPO_READ_TOKEN }}
       ARTIFACT_READ_ONLY_GCP_CREDENTIALS: ${{ secrets.ARTIFACT_READ_ONLY_GCP_CREDENTIALS }}
@@ -25,7 +25,7 @@ jobs:
   appimage:
     needs: test
     if: contains(github.event.pull_request.labels.*.name, 'appimage')
-    uses: viamrobotics/rdk/.github/workflows/appimage.yml@main
+    uses: viamrobotics/rdk/.github/workflows/appimage.yml@testfix
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
       REPO_READ_TOKEN: ${{ secrets.REPO_READ_TOKEN }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -19,7 +19,6 @@ jobs:
     uses: viamrobotics/rdk/.github/workflows/test.yml@main
     secrets:
       REPO_READ_TOKEN: ${{ secrets.REPO_READ_TOKEN }}
-      GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
       ARTIFACT_READ_ONLY_GCP_CREDENTIALS: ${{ secrets.ARTIFACT_READ_ONLY_GCP_CREDENTIALS }}
 
   # This lets people add an "appimage" tag to have appimages built for the PR
@@ -30,4 +29,3 @@ jobs:
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
       REPO_READ_TOKEN: ${{ secrets.REPO_READ_TOKEN }}
-      GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   test:
-    uses: viamrobotics/rdk/.github/workflows/test.yml@testfix
+    uses: viamrobotics/rdk/.github/workflows/test.yml@main
     secrets:
       ARTIFACT_READ_ONLY_GCP_CREDENTIALS: ${{ secrets.ARTIFACT_READ_ONLY_GCP_CREDENTIALS }}
 
@@ -24,6 +24,6 @@ jobs:
   appimage:
     needs: test
     if: contains(github.event.pull_request.labels.*.name, 'appimage')
-    uses: viamrobotics/rdk/.github/workflows/appimage.yml@testfix
+    uses: viamrobotics/rdk/.github/workflows/appimage.yml@main
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -18,7 +18,6 @@ jobs:
   test:
     uses: viamrobotics/rdk/.github/workflows/test.yml@testfix
     secrets:
-      REPO_READ_TOKEN: ${{ secrets.REPO_READ_TOKEN }}
       ARTIFACT_READ_ONLY_GCP_CREDENTIALS: ${{ secrets.ARTIFACT_READ_ONLY_GCP_CREDENTIALS }}
 
   # This lets people add an "appimage" tag to have appimages built for the PR
@@ -28,4 +27,3 @@ jobs:
     uses: viamrobotics/rdk/.github/workflows/appimage.yml@testfix
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
-      REPO_READ_TOKEN: ${{ secrets.REPO_READ_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,6 @@ on:
     secrets:
       REPO_READ_TOKEN:
         required: true
-      GIT_ACCESS_TOKEN:
-        required: true
       ARTIFACT_READ_ONLY_GCP_CREDENTIALS:
         required: true
 
@@ -90,7 +88,6 @@ jobs:
       with:
         recreate: true
         path: code-coverage-results.md
-        GITHUB_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
 
   test_pi:
     name: Test Raspberry Pi Code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch:
   workflow_call:
     secrets:
-      REPO_READ_TOKEN:
-        required: true
       ARTIFACT_READ_ONLY_GCP_CREDENTIALS:
         required: true
 
@@ -44,10 +42,6 @@ jobs:
         GOOGLE_APPLICATION_CREDENTIALS=`pwd`/${GOOGLE_APPLICATION_CREDENTIALS_FILENAME}
         echo "${{ secrets.ARTIFACT_READ_ONLY_GCP_CREDENTIALS }}" >> ${GOOGLE_APPLICATION_CREDENTIALS}
         echo "GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS}" >> $GITHUB_ENV
-
-    - name: Configure git for private repos
-      run: |
-        sudo -u testbot bash -lc 'echo "machine github.com login viambot password ${{ secrets.REPO_READ_TOKEN }}" > ~/.netrc'
 
     - name: Verify no uncommitted changes from "${{ matrix.build_lint }}"
       run: |
@@ -112,10 +106,6 @@ jobs:
         echo "${{ secrets.ARTIFACT_READ_ONLY_GCP_CREDENTIALS }}" >> ${GOOGLE_APPLICATION_CREDENTIALS}
         echo "GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS}" >> $GITHUB_ENV
 
-    - name: Configure git for private repos
-      run: |
-        echo "machine github.com login viambot password ${{ secrets.REPO_READ_TOKEN }}" > ~/.netrc
-
     - name: Test
       run: make test-pi
 
@@ -149,10 +139,6 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS=`pwd`/${GOOGLE_APPLICATION_CREDENTIALS_FILENAME}
           echo "${{ secrets.ARTIFACT_READ_ONLY_GCP_CREDENTIALS }}" >> ${GOOGLE_APPLICATION_CREDENTIALS}
           echo "GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS}" >> $GITHUB_ENV
-
-      - name: Configure git for private repos
-        run: |
-          sudo -u testbot bash -lc 'echo "machine github.com login viambot password ${{ secrets.REPO_READ_TOKEN }}" > ~/.netrc'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Removing extra private-only stuff from RDK.

Note: Will fail tests in current state, due to test@main targets already reverted. Tested in previous push.