### PR TITLE
Add secure comments workflow

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -79,26 +79,6 @@ jobs:
         parent: false
         gzip: false
 
-  appimage_comment:
-    name: Add AppImage Links
-    if: contains(github.event.pull_request.labels.*.name, 'appimage')
-    needs: appimage
-    runs-on: [x64, qemu-host]
-    container:
-      image: ghcr.io/viamrobotics/canon:amd64-cache
-      options: --platform linux/amd64
-    timeout-minutes: 5
-
-    steps:
-    - name: Add links
-      uses: marocchino/sticky-pull-request-comment@v2.2.0
-      with:
-        recreate: true
-        message: |
-          AppImages ready!
-          <http://packages.viam.com/apps/viam-server/viam-server-pr-${{ github.event.pull_request.number }}-x86_64.AppImage>
-          <http://packages.viam.com/apps/viam-server/viam-server-pr-${{ github.event.pull_request.number }}-aarch64.AppImage>
-
   appimage_test:
     name: AppImage Test
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   test:
-    uses: viamrobotics/rdk/.github/workflows/test.yml@main
+    uses: viamrobotics/rdk/.github/workflows/test.yml@secure-comments
     secrets:
       ARTIFACT_READ_ONLY_GCP_CREDENTIALS: ${{ secrets.ARTIFACT_READ_ONLY_GCP_CREDENTIALS }}
 
@@ -24,6 +24,6 @@ jobs:
   appimage:
     needs: test
     if: contains(github.event.pull_request.labels.*.name, 'appimage')
-    uses: viamrobotics/rdk/.github/workflows/appimage.yml@main
+    uses: viamrobotics/rdk/.github/workflows/appimage.yml@secure-comments
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   test:
-    uses: viamrobotics/rdk/.github/workflows/test.yml@secure-comments
+    uses: viamrobotics/rdk/.github/workflows/test.yml@main
     secrets:
       ARTIFACT_READ_ONLY_GCP_CREDENTIALS: ${{ secrets.ARTIFACT_READ_ONLY_GCP_CREDENTIALS }}
 
@@ -24,6 +24,6 @@ jobs:
   appimage:
     needs: test
     if: contains(github.event.pull_request.labels.*.name, 'appimage')
-    uses: viamrobotics/rdk/.github/workflows/appimage.yml@secure-comments
+    uses: viamrobotics/rdk/.github/workflows/appimage.yml@main
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/pullrequestcomment.yml
+++ b/.github/workflows/pullrequestcomment.yml
@@ -31,3 +31,13 @@ jobs:
           number: ${{ env.PR_NUMBER }}
           recreate: true
           path: code-coverage-results.md
+
+      - name: Add AppImage Links
+        if: ${{ env.APPIMAGE }}
+        uses: marocchino/sticky-pull-request-comment@v2.2.0
+        with:
+          recreate: true
+          message: |
+            AppImages ready!
+            <http://packages.viam.com/apps/viam-server/viam-server-pr-${{ env.PR_NUMBER }}-x86_64.AppImage>
+            <http://packages.viam.com/apps/viam-server/viam-server-pr-${{ env.PR_NUMBER }}-aarch64.AppImage>

--- a/.github/workflows/pullrequestcomment.yml
+++ b/.github/workflows/pullrequestcomment.yml
@@ -1,0 +1,33 @@
+name: 'Comment on PR'
+
+on:
+  workflow_run:
+    workflows: ["Pull Request Update"]
+    types:
+      - completed
+
+jobs:
+  comment:
+    name: 'Post Comment on PR'
+    runs-on: [x64, qemu-host]
+    container:
+      image: ghcr.io/viamrobotics/canon:amd64-cache
+      options: --platform linux/amd64
+    timeout-minutes: 5
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Download Code Coverage
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          run_id: ${{ github.event.workflow_run.id }}
+          name: pr-code-coverage
+
+      - name: Restore Environment
+        run: cat pr.env >> "${GITHUB_ENV}"
+
+      - name: Add Coverage PR Comment
+        uses: marocchino/sticky-pull-request-comment@v2.2.0
+        with:
+          number: ${{ env.PR_NUMBER }}
+          recreate: true
+          path: code-coverage-results.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
 
     - name: Mark appimage label
       if: contains(github.event.pull_request.labels.*.name, 'appimage')
-      run |
+      run: |
         echo "APPIMAGE=true" >> pr.env
 
     - name: Upload code coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,12 +77,7 @@ jobs:
         thresholds: '50 70'
 
     # Now that RDK is public, can't directly comment without token having full read/write access
-    # - name: Add Coverage PR Comment
-    #   uses: marocchino/sticky-pull-request-comment@v2.2.0
-    #   if: matrix.platform == 'linux/amd64' && github.event_name == 'pull_request'
-    #   with:
-    #     recreate: true
-    #     path: code-coverage-results.md
+    # pullrequestcomment.yml will trigger seperately and post the actual comments
 
     - name: Prepare code comment
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,12 +76,26 @@ jobs:
         output: both
         thresholds: '50 70'
 
-    - name: Add Coverage PR Comment
-      uses: marocchino/sticky-pull-request-comment@v2.2.0
-      if: matrix.platform == 'linux/amd64' && github.event_name == 'pull_request'
+    # Now that RDK is public, can't directly comment without token having full read/write access
+    # - name: Add Coverage PR Comment
+    #   uses: marocchino/sticky-pull-request-comment@v2.2.0
+    #   if: matrix.platform == 'linux/amd64' && github.event_name == 'pull_request'
+    #   with:
+    #     recreate: true
+    #     path: code-coverage-results.md
+
+    - name: Prepare code comment
+      run: |
+        echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> pr.env
+
+    - name: Upload code coverage
+      uses: actions/upload-artifact@v3
       with:
-        recreate: true
-        path: code-coverage-results.md
+        name: pr-code-coverage
+        path: |
+         pr.env
+         code-coverage-results.md
+        retention-days: 1
 
   test_pi:
     name: Test Raspberry Pi Code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,6 +88,11 @@ jobs:
       run: |
         echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> pr.env
 
+    - name: Mark appimage label
+      if: contains(github.event.pull_request.labels.*.name, 'appimage')
+      run |
+        echo "APPIMAGE=true" >> pr.env
+
     - name: Upload code coverage
       uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
This is a workaround to allow code coverage (and appimages) to securely add comments to workflows now that RDK is public.