### PR TITLE
Add builtin model to datamanager test configs

### DIFF
--- a/services/datamanager/data/fake_robot_with_data_manager.json
+++ b/services/datamanager/data/fake_robot_with_data_manager.json
@@ -31,6 +31,7 @@
         {
             "name": "data_manager1",
             "type": "data_manager",
+            "model": "builtin",
             "attributes": {
                 "sync_interval_mins": 0,
                 "capture_dir": "/tmp/capture"

--- a/services/datamanager/data/fake_robot_with_remote_and_data_manager.json
+++ b/services/datamanager/data/fake_robot_with_remote_and_data_manager.json
@@ -31,6 +31,7 @@
         {
             "name": "data_manager1",
             "type": "data_manager",
+            "model": "builtin",
             "attributes": {
                 "capture_dir": "/tmp/capture"
             }

--- a/services/datamanager/data/robot_with_cam_capture.json
+++ b/services/datamanager/data/robot_with_cam_capture.json
@@ -26,6 +26,7 @@
         {
             "name": "data_manager1",
             "type": "data_manager",
+            "model": "builtin",
             "attributes": {
                 "capture_dir": "/tmp/capture"
             }


### PR DESCRIPTION
Gets rid of logging `"no model given; using default"` in tests