### PR TITLE
[DATA-363] Add integration tests for orbslam

### DIFF
--- a/.artifact/tree.json
+++ b/.artifact/tree.json
@@ -50548,6 +50548,244 @@
       "hash": "8ecf7ccd4c22d4606783db10a26018c4",
       "size": 145250924
     },
+    "mock_camera_short": {
+      "depth": {
+        "0.png": {
+          "hash": "b90597969c3b50dd417fbb05431de614",
+          "size": 360006
+        },
+        "1.png": {
+          "hash": "b90597969c3b50dd417fbb05431de614",
+          "size": 360006
+        },
+        "10.png": {
+          "hash": "92cb0b9692f2f94ec80122ba43a6ebcc",
+          "size": 439245
+        },
+        "11.png": {
+          "hash": "92cb0b9692f2f94ec80122ba43a6ebcc",
+          "size": 439245
+        },
+        "12.png": {
+          "hash": "ed29d23093d165c1cf1000c60b44e851",
+          "size": 384791
+        },
+        "13.png": {
+          "hash": "ed29d23093d165c1cf1000c60b44e851",
+          "size": 384791
+        },
+        "14.png": {
+          "hash": "ed29d23093d165c1cf1000c60b44e851",
+          "size": 384791
+        },
+        "15.png": {
+          "hash": "ed29d23093d165c1cf1000c60b44e851",
+          "size": 384791
+        },
+        "16.png": {
+          "hash": "ed29d23093d165c1cf1000c60b44e851",
+          "size": 384791
+        },
+        "17.png": {
+          "hash": "ed29d23093d165c1cf1000c60b44e851",
+          "size": 384791
+        },
+        "18.png": {
+          "hash": "ed29d23093d165c1cf1000c60b44e851",
+          "size": 384791
+        },
+        "19.png": {
+          "hash": "ed29d23093d165c1cf1000c60b44e851",
+          "size": 384791
+        },
+        "2.png": {
+          "hash": "b90597969c3b50dd417fbb05431de614",
+          "size": 360006
+        },
+        "20.png": {
+          "hash": "ed29d23093d165c1cf1000c60b44e851",
+          "size": 384791
+        },
+        "21.png": {
+          "hash": "ed29d23093d165c1cf1000c60b44e851",
+          "size": 384791
+        },
+        "22.png": {
+          "hash": "ed29d23093d165c1cf1000c60b44e851",
+          "size": 384791
+        },
+        "23.png": {
+          "hash": "ed29d23093d165c1cf1000c60b44e851",
+          "size": 384791
+        },
+        "24.png": {
+          "hash": "ed29d23093d165c1cf1000c60b44e851",
+          "size": 384791
+        },
+        "25.png": {
+          "hash": "ed29d23093d165c1cf1000c60b44e851",
+          "size": 384791
+        },
+        "26.png": {
+          "hash": "ed29d23093d165c1cf1000c60b44e851",
+          "size": 384791
+        },
+        "27.png": {
+          "hash": "ed29d23093d165c1cf1000c60b44e851",
+          "size": 384791
+        },
+        "28.png": {
+          "hash": "ed29d23093d165c1cf1000c60b44e851",
+          "size": 384791
+        },
+        "3.png": {
+          "hash": "b90597969c3b50dd417fbb05431de614",
+          "size": 360006
+        },
+        "4.png": {
+          "hash": "b90597969c3b50dd417fbb05431de614",
+          "size": 360006
+        },
+        "5.png": {
+          "hash": "b90597969c3b50dd417fbb05431de614",
+          "size": 360006
+        },
+        "6.png": {
+          "hash": "92cb0b9692f2f94ec80122ba43a6ebcc",
+          "size": 439245
+        },
+        "7.png": {
+          "hash": "92cb0b9692f2f94ec80122ba43a6ebcc",
+          "size": 439245
+        },
+        "8.png": {
+          "hash": "92cb0b9692f2f94ec80122ba43a6ebcc",
+          "size": 439245
+        },
+        "9.png": {
+          "hash": "92cb0b9692f2f94ec80122ba43a6ebcc",
+          "size": 439245
+        }
+      },
+      "rgb": {
+        "0.png": {
+          "hash": "256193b07563c08b0cca0569f264749e",
+          "size": 1797977
+        },
+        "1.png": {
+          "hash": "256193b07563c08b0cca0569f264749e",
+          "size": 1797977
+        },
+        "10.png": {
+          "hash": "256193b07563c08b0cca0569f264749e",
+          "size": 1797977
+        },
+        "11.png": {
+          "hash": "e1d292c8575d40ddb9dda1639fc17118",
+          "size": 1801849
+        },
+        "12.png": {
+          "hash": "e1d292c8575d40ddb9dda1639fc17118",
+          "size": 1801849
+        },
+        "13.png": {
+          "hash": "e1d292c8575d40ddb9dda1639fc17118",
+          "size": 1801849
+        },
+        "14.png": {
+          "hash": "e1d292c8575d40ddb9dda1639fc17118",
+          "size": 1801849
+        },
+        "15.png": {
+          "hash": "e1d292c8575d40ddb9dda1639fc17118",
+          "size": 1801849
+        },
+        "16.png": {
+          "hash": "e1d292c8575d40ddb9dda1639fc17118",
+          "size": 1801849
+        },
+        "17.png": {
+          "hash": "e1d292c8575d40ddb9dda1639fc17118",
+          "size": 1801849
+        },
+        "18.png": {
+          "hash": "e1d292c8575d40ddb9dda1639fc17118",
+          "size": 1801849
+        },
+        "19.png": {
+          "hash": "e1d292c8575d40ddb9dda1639fc17118",
+          "size": 1801849
+        },
+        "2.png": {
+          "hash": "256193b07563c08b0cca0569f264749e",
+          "size": 1797977
+        },
+        "20.png": {
+          "hash": "e1d292c8575d40ddb9dda1639fc17118",
+          "size": 1801849
+        },
+        "21.png": {
+          "hash": "e1d292c8575d40ddb9dda1639fc17118",
+          "size": 1801849
+        },
+        "22.png": {
+          "hash": "e1d292c8575d40ddb9dda1639fc17118",
+          "size": 1801849
+        },
+        "23.png": {
+          "hash": "e1d292c8575d40ddb9dda1639fc17118",
+          "size": 1801849
+        },
+        "24.png": {
+          "hash": "e1d292c8575d40ddb9dda1639fc17118",
+          "size": 1801849
+        },
+        "25.png": {
+          "hash": "e1d292c8575d40ddb9dda1639fc17118",
+          "size": 1801849
+        },
+        "26.png": {
+          "hash": "e1d292c8575d40ddb9dda1639fc17118",
+          "size": 1801849
+        },
+        "27.png": {
+          "hash": "e1d292c8575d40ddb9dda1639fc17118",
+          "size": 1801849
+        },
+        "28.png": {
+          "hash": "e1d292c8575d40ddb9dda1639fc17118",
+          "size": 1801849
+        },
+        "3.png": {
+          "hash": "256193b07563c08b0cca0569f264749e",
+          "size": 1797977
+        },
+        "4.png": {
+          "hash": "256193b07563c08b0cca0569f264749e",
+          "size": 1797977
+        },
+        "5.png": {
+          "hash": "256193b07563c08b0cca0569f264749e",
+          "size": 1797977
+        },
+        "6.png": {
+          "hash": "256193b07563c08b0cca0569f264749e",
+          "size": 1797977
+        },
+        "7.png": {
+          "hash": "256193b07563c08b0cca0569f264749e",
+          "size": 1797977
+        },
+        "8.png": {
+          "hash": "256193b07563c08b0cca0569f264749e",
+          "size": 1797977
+        },
+        "9.png": {
+          "hash": "256193b07563c08b0cca0569f264749e",
+          "size": 1797977
+        }
+      }
+    },
     "temp_mock_camera": {
       "color": {
         "0.png": {

--- a/services/slam/builtin/builtin.go
+++ b/services/slam/builtin/builtin.go
@@ -526,8 +526,12 @@ func (slamSvc *builtIn) Close() error {
 	}()
 	slamSvc.cancelFunc()
 	if slamSvc.bufferSLAMProcessLogs {
-		slamSvc.slamProcessLogReader.Close()
-		slamSvc.slamProcessLogWriter.Close()
+		if slamSvc.slamProcessLogReader != nil {
+			slamSvc.slamProcessLogReader.Close()
+		}
+		if slamSvc.slamProcessLogWriter != nil {
+			slamSvc.slamProcessLogWriter.Close()
+		}
 	}
 	if err := slamSvc.StopSLAMProcess(); err != nil {
 		return errors.Wrap(err, "error occurred during closeout of process")

--- a/services/slam/builtin/builtin_test.go
+++ b/services/slam/builtin/builtin_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -45,7 +46,13 @@ import (
 const (
 	timePadding      = 5
 	validDataRateMS  = 200
-	numOrbslamImages = 15
+	numOrbslamImages = 29
+)
+
+var (
+	orbslamIntCameraMutex             sync.Mutex
+	orbslamIntCameraReleaseImagesChan chan int = make(chan int, 2)
+	orbslamIntSynchronizeCamerasChan  chan int = make(chan int)
 )
 
 func createFakeSLAMLibraries() {
@@ -99,6 +106,23 @@ func setupInjectRobot() *inject.Robot {
 	}
 	distortionsA := &transform.BrownConrady{RadialK1: 0.001, RadialK2: 0.00004}
 	projA = intrinsicsA
+
+	var projReal transform.Projector
+	intrinsicsReal := &transform.PinholeCameraIntrinsics{
+		Width:  1280,
+		Height: 720,
+		Fx:     900.538,
+		Fy:     900.818,
+		Ppx:    648.934,
+		Ppy:    367.736,
+	}
+	distortionsReal := &transform.BrownConrady{
+		RadialK1:     0.158701,
+		RadialK2:     -0.485405,
+		RadialK3:     0.435342,
+		TangentialP1: -0.00143327,
+		TangentialP2: -0.000705919}
+	projReal = intrinsicsReal
 
 	r.ResourceByNameFunc = func(name resource.Name) (interface{}, error) {
 		cam := &inject.Camera{}
@@ -237,27 +261,38 @@ func setupInjectRobot() *inject.Robot {
 				return nil, errors.New("camera not lidar")
 			}
 			cam.ProjectorFunc = func(ctx context.Context) (transform.Projector, error) {
-				return projA, nil
+				return projReal, nil
 			}
 			cam.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
-				return camera.Properties{IntrinsicParams: intrinsicsA, DistortionParams: distortionsA}, nil
+				return camera.Properties{IntrinsicParams: intrinsicsReal, DistortionParams: distortionsReal}, nil
 			}
 			var index uint64
 			cam.StreamFunc = func(ctx context.Context, errHandlers ...gostream.ErrorHandler) (gostream.VideoStream, error) {
-				i := atomic.AddUint64(&index, 1) - 1
-				if i >= numOrbslamImages {
-					return nil, errors.New("No more orbslam color images")
+				defer func() {
+					orbslamIntSynchronizeCamerasChan <- 1
+				}()
+				// Ensure the StreamFunc functions for orbslam_int_color_camera and orbslam_int_depth_camera run under
+				// the lock so that they release images in the same call to getSimultaneousColorAndDepth().
+				orbslamIntCameraMutex.Lock()
+				select {
+				case <-orbslamIntCameraReleaseImagesChan:
+					i := atomic.AddUint64(&index, 1) - 1
+					if i >= numOrbslamImages {
+						return nil, errors.New("No more orbslam color images")
+					}
+					imgBytes, err := os.ReadFile(artifact.MustPath("slam/mock_camera_short/rgb/" + strconv.FormatUint(i, 10) + ".png"))
+					if err != nil {
+						return nil, err
+					}
+					lazy := rimage.NewLazyEncodedImage(imgBytes, rdkutils.MimeTypePNG, -1, -1)
+					return gostream.NewEmbeddedVideoStreamFromReader(
+						gostream.VideoReaderFunc(func(ctx context.Context) (image.Image, func(), error) {
+							return lazy, func() {}, nil
+						}),
+					), nil
+				default:
+					return nil, errors.Errorf("Color camera not ready to return image %v", index)
 				}
-				imgBytes, err := os.ReadFile(artifact.MustPath("slam/temp_mock_camera/color/" + strconv.FormatUint(i, 10) + ".png"))
-				if err != nil {
-					return nil, err
-				}
-				lazy := rimage.NewLazyEncodedImage(imgBytes, rdkutils.MimeTypePNG, -1, -1)
-				return gostream.NewEmbeddedVideoStreamFromReader(
-					gostream.VideoReaderFunc(func(ctx context.Context) (image.Image, func(), error) {
-						return lazy, func() {}, nil
-					}),
-				), nil
 			}
 			return cam, nil
 		case camera.Named("orbslam_int_depth_camera"):
@@ -272,20 +307,31 @@ func setupInjectRobot() *inject.Robot {
 			}
 			var index uint64
 			cam.StreamFunc = func(ctx context.Context, errHandlers ...gostream.ErrorHandler) (gostream.VideoStream, error) {
-				i := atomic.AddUint64(&index, 1) - 1
-				if i >= numOrbslamImages {
-					return nil, errors.New("No more orbslam depth images")
+				defer func() {
+					orbslamIntCameraMutex.Unlock()
+				}()
+				// Ensure StreamFunc for orbslam_int_color_camera runs first, so that we lock orbslamIntCameraMutex before
+				// unlocking it
+				<-orbslamIntSynchronizeCamerasChan
+				select {
+				case <-orbslamIntCameraReleaseImagesChan:
+					i := atomic.AddUint64(&index, 1) - 1
+					if i >= numOrbslamImages {
+						return nil, errors.New("No more orbslam depth images")
+					}
+					imgBytes, err := os.ReadFile(artifact.MustPath("slam/mock_camera_short/depth/" + strconv.FormatUint(i, 10) + ".png"))
+					if err != nil {
+						return nil, err
+					}
+					lazy := rimage.NewLazyEncodedImage(imgBytes, rdkutils.MimeTypePNG, -1, -1)
+					return gostream.NewEmbeddedVideoStreamFromReader(
+						gostream.VideoReaderFunc(func(ctx context.Context) (image.Image, func(), error) {
+							return lazy, func() {}, nil
+						}),
+					), nil
+				default:
+					return nil, errors.Errorf("Depth camera not ready to return image %v", index)
 				}
-				imgBytes, err := os.ReadFile(artifact.MustPath("slam/temp_mock_camera/depth/" + strconv.FormatUint(i, 10) + ".png"))
-				if err != nil {
-					return nil, err
-				}
-				lazy := rimage.NewLazyEncodedImage(imgBytes, rdkutils.MimeTypePNG, -1, -1)
-				return gostream.NewEmbeddedVideoStreamFromReader(
-					gostream.VideoReaderFunc(func(ctx context.Context) (image.Image, func(), error) {
-						return lazy, func() {}, nil
-					}),
-				), nil
 			}
 			return cam, nil
 		default:

--- a/services/slam/builtin/orbslam_int_test.go
+++ b/services/slam/builtin/orbslam_int_test.go
@@ -3,12 +3,15 @@ package builtin_test
 import (
 	"context"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/edaniels/golog"
+	"go.viam.com/rdk/services/slam"
 	"go.viam.com/rdk/services/slam/builtin"
 	"go.viam.com/rdk/services/slam/internal"
 	"go.viam.com/test"
@@ -16,6 +19,7 @@ import (
 	"go.viam.com/utils/artifact"
 )
 
+// Creates the vocabulary file required by the orbslam binary.
 func createVocabularyFile(name string) error {
 	source, err := os.Open(artifact.MustPath("slam/ORBvoc.txt"))
 	if err != nil {
@@ -31,7 +35,48 @@ func createVocabularyFile(name string) error {
 	return err
 }
 
-func TestOrbslamIntegrationExample(t *testing.T) {
+// Releases an image pair to be served by the mock camera. The pair is released under a mutex,
+// so that they will be consumed in the same call to getSimultaneousColorAndDepth().
+func releaseImages() {
+	for {
+		orbslamIntCameraMutex.Lock()
+		if len(orbslamIntCameraReleaseImagesChan) == cap(orbslamIntCameraReleaseImagesChan) {
+			orbslamIntCameraMutex.Unlock()
+			time.Sleep(10 * time.Millisecond)
+		} else {
+			orbslamIntCameraReleaseImagesChan <- 1
+			orbslamIntCameraReleaseImagesChan <- 1
+			orbslamIntCameraMutex.Unlock()
+			return
+		}
+	}
+}
+
+// Checks that we can get position and map, and that there are more than zero map points.
+// Doesn't check precise values due to variations in orbslam results.
+func testPositionAndMap(t *testing.T, svc slam.Service) {
+	t.Helper()
+
+	position, err := svc.Position(context.Background(), "test")
+	test.That(t, err, test.ShouldBeNil)
+	// Typical values are around (0.001, -0.001, 0.007)
+	t.Logf("Position point: (%v, %v, %v)",
+		position.Pose().Point().X, position.Pose().Point().Y, position.Pose().Point().Z)
+	// Typical values are around (-0.73, 0.34, 0.58), theta=2.6
+	t.Logf("Position orientation: RX: %v, RY: %v, RY: %v, Theta: %v",
+		position.Pose().Orientation().AxisAngles().RX,
+		position.Pose().Orientation().AxisAngles().RY,
+		position.Pose().Orientation().AxisAngles().RZ,
+		position.Pose().Orientation().AxisAngles().Theta)
+	actualMIME, _, pointcloud, err := svc.GetMap(context.Background(), "test", "pointcloud/pcd", nil, false)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, actualMIME, test.ShouldResemble, "pointcloud/pcd")
+	// Typical value is 329
+	t.Logf("Pointcloud points: %v", pointcloud.Size())
+	test.That(t, pointcloud.Size(), test.ShouldBeGreaterThan, 0)
+}
+
+func TestOrbslamIntegration(t *testing.T) {
 	// TODO DATA-364: remove this check
 	_, err := exec.LookPath("orb_grpc_server")
 	if err != nil {
@@ -42,6 +87,8 @@ func TestOrbslamIntegrationExample(t *testing.T) {
 	name, err := createTempFolderArchitecture()
 	test.That(t, err, test.ShouldBeNil)
 	createVocabularyFile(name)
+
+	t.Log("Testing online mode")
 
 	attrCfg := &builtin.AttrConfig{
 		Algorithm: "orbslamv3",
@@ -56,43 +103,162 @@ func TestOrbslamIntegrationExample(t *testing.T) {
 			"debug":             "true",
 		},
 		DataDirectory: name,
+		// Even though we don't use the maps saved in this run, indicate in the config that
+		// we want to save maps because the same yaml config gets used for the next run.
+		MapRateSec: 1,
+	}
+
+	// Release a pair of camera images for service validation
+	releaseImages()
+	// Create slam service using a real orbslam binary
+	svc, err := createSLAMService(t, attrCfg, golog.NewTestLogger(t), true, true)
+	test.That(t, err, test.ShouldBeNil)
+
+	// Release a pair of camera images, since orbslam looks for the second most recent pair
+	releaseImages()
+	// Wait for orbslam to finish processing images
+	logReader := svc.(internal.Service).GetSLAMProcessBufferedLogReader()
+	for i := 0; i < numOrbslamImages-2; i++ {
+		t.Logf("Find log line for image %v", i)
+		releaseImages()
+		for {
+			line, err := logReader.ReadString('\n')
+			test.That(t, err, test.ShouldBeNil)
+			if strings.Contains(line, "Passed image to SLAM") {
+				break
+			}
+			test.That(t, strings.Contains(line, "Fail to track local map!"), test.ShouldBeFalse)
+		}
+	}
+
+	testPositionAndMap(t, svc)
+
+	// Close out slam service
+	test.That(t, utils.TryClose(context.Background(), svc), test.ShouldBeNil)
+	// Don't clear out the directory, since we will re-use the config and data for the next run
+	closeOutSLAMService(t, "")
+
+	// Delete the last image pair, so that offline mode runs on the same set of images
+	for _, directoryName := range [2]string{"rgb/", "depth/"} {
+		files, err := ioutil.ReadDir(name + "/data/" + directoryName)
+		test.That(t, err, test.ShouldBeNil)
+		lastFileName := files[len(files)-1].Name()
+		test.That(t, os.Remove(name+"/data/"+directoryName+lastFileName), test.ShouldBeNil)
+	}
+
+	// Remove any maps
+	test.That(t, os.RemoveAll(name+"/map"), test.ShouldBeNil)
+
+	// Test offline mode using the config and data generated in the online test
+	t.Log("Testing offline mode")
+
+	attrCfg = &builtin.AttrConfig{
+		Algorithm: "orbslamv3",
+		Sensors:   []string{},
+		ConfigParams: map[string]string{
+			"mode":              "rgbd",
+			"orb_n_features":    "1000",
+			"orb_scale_factor":  "1.2",
+			"orb_n_levels":      "8",
+			"orb_n_ini_th_fast": "20",
+			"orb_n_min_th_fast": "7",
+			"debug":             "true",
+		},
+		DataDirectory: name,
+		MapRateSec:    1,
 	}
 
 	// Create slam service using a real orbslam binary
-	logger := golog.NewTestLogger(t)
-	svc, err := createSLAMService(t, attrCfg, logger, true, true)
+	svc, err = createSLAMService(t, attrCfg, golog.NewTestLogger(t), true, true)
 	test.That(t, err, test.ShouldBeNil)
 
 	// Wait for orbslam to finish processing images
-	logReader := svc.(internal.Service).GetSLAMProcessBufferedLogReader()
-	// The bug fixed in DATA-182 revealed an issue with this test framework that since
-	// orbslam is running in online mode, it will only consume the most recent image.
-	// TODO DATA-363: ensure all images are found
-	t.Logf("Find log line for image 0")
+	logReader = svc.(internal.Service).GetSLAMProcessBufferedLogReader()
 	for {
 		line, err := logReader.ReadString('\n')
 		test.That(t, err, test.ShouldBeNil)
-		if strings.Contains(line, "Passed image to SLAM") {
+		if strings.Contains(line, "Finished processing offline images") {
+			break
+		}
+		test.That(t, strings.Contains(line, "Fail to track local map!"), test.ShouldBeFalse)
+	}
+
+	testPositionAndMap(t, svc)
+
+	// Wait for the final map to be saved
+	for {
+		line, err := logReader.ReadString('\n')
+		test.That(t, err, test.ShouldBeNil)
+		if strings.Contains(line, "Finished saving final map") {
 			break
 		}
 	}
 
-	// Test position and map
-	position, err := svc.Position(context.Background(), "test")
+	// Close out slam service
+	test.That(t, utils.TryClose(context.Background(), svc), test.ShouldBeNil)
+	// Don't clear out the directory, since we will re-use the maps for the next run
+	closeOutSLAMService(t, "")
+
+	// Remove existing images, but leave maps and config (so we keep the vocabulary file).
+	// Orbslam will use the most recent config.
+	test.That(t, os.RemoveAll(name+"/data"), test.ShouldBeNil)
+
+	// Test online mode using the map generated in the offline test
+	t.Log("Testing online mode with saved map")
+
+	attrCfg = &builtin.AttrConfig{
+		Algorithm: "orbslamv3",
+		Sensors:   []string{"orbslam_int_color_camera", "orbslam_int_depth_camera"},
+		ConfigParams: map[string]string{
+			"mode":              "rgbd",
+			"orb_n_features":    "1000",
+			"orb_scale_factor":  "1.2",
+			"orb_n_levels":      "8",
+			"orb_n_ini_th_fast": "20",
+			"orb_n_min_th_fast": "7",
+			"debug":             "true",
+		},
+		DataDirectory: name,
+		MapRateSec:    -1,
+	}
+
+	// Release a pair of camera images for service validation
+	releaseImages()
+	// Create slam service using a real orbslam binary
+	svc, err = createSLAMService(t, attrCfg, golog.NewTestLogger(t), true, true)
 	test.That(t, err, test.ShouldBeNil)
-	t.Logf("Position point: (%v, %v, %v)",
-		position.Pose().Point().X, position.Pose().Point().Y, position.Pose().Point().Z)
-	t.Logf("Position orientation: RX: %v, RY: %v, RY: %v, Theta: %v",
-		position.Pose().Orientation().AxisAngles().RX,
-		position.Pose().Orientation().AxisAngles().RY,
-		position.Pose().Orientation().AxisAngles().RZ,
-		position.Pose().Orientation().AxisAngles().Theta)
-	actualMIME, _, pointcloud, err := svc.GetMap(context.Background(), "test", "pointcloud/pcd", nil, false)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, actualMIME, test.ShouldResemble, "pointcloud/pcd")
-	t.Logf("Pointcloud points: %v", pointcloud.Size())
+
+	// Make sure we initialize from a saved map
+	logReader = svc.(internal.Service).GetSLAMProcessBufferedLogReader()
+	for {
+		line, err := logReader.ReadString('\n')
+		test.That(t, err, test.ShouldBeNil)
+		if strings.Contains(line, "Initialization of Atlas from file") {
+			break
+		}
+		test.That(t, strings.Contains(line, "Initialization of Atlas from scratch"), test.ShouldBeFalse)
+	}
+
+	// Release a pair of camera images, since orbslam looks for the second most recent pair
+	releaseImages()
+	// Wait for orbslam to finish processing images
+	for i := 0; i < numOrbslamImages-2; i++ {
+		t.Logf("Find log line for image %v", i)
+		releaseImages()
+		for {
+			line, err := logReader.ReadString('\n')
+			test.That(t, err, test.ShouldBeNil)
+			if strings.Contains(line, "Passed image to SLAM") {
+				break
+			}
+			test.That(t, strings.Contains(line, "Fail to track local map!"), test.ShouldBeFalse)
+		}
+	}
+
+	testPositionAndMap(t, svc)
 
 	// Close out slam service
 	test.That(t, utils.TryClose(context.Background(), svc), test.ShouldBeNil)
+	// Clear out directory
 	closeOutSLAMService(t, name)
 }


### PR DESCRIPTION
This PR adds integration tests for orbslam running in online and offline mode, as well as using a saved map. Once this is merged, it will start running on changes to the slam repo. Also, now that app images are being built for orbslam, I'll make the github actions for rdk grab them so that this integration test can run.