### PR TITLE
Treat baud_rate as optional in imu-wit and logging

### DIFF
--- a/components/movementsensor/imuwit/imu.go
+++ b/components/movementsensor/imuwit/imu.go
@@ -4,6 +4,7 @@ package imuwit
 import (
 	"bufio"
 	"context"
+	"encoding/hex"
 	"fmt"
 	"math"
 	"sync"
@@ -142,8 +143,11 @@ func NewWit(deps registry.Dependencies, cfg config.Component, logger golog.Logge
 	}
 
 	options.PortName = conf.Port
-	options.BaudRate = uint(conf.BaudRate)
+	if conf.BaudRate > 0 {
+		options.BaudRate = uint(conf.BaudRate)
+	}
 
+	logger.Debugf("initializing wit serial connection with parameters: %+v", options)
 	port, err := slib.Open(options)
 	if err != nil {
 		return nil, err
@@ -166,7 +170,7 @@ func NewWit(deps registry.Dependencies, cfg config.Component, logger golog.Logge
 			}
 
 			line, err := portReader.ReadString('U')
-			logger.Debugf("line is %s", line)
+			logger.Debugf("read line from wit: %s", hex.EncodeToString([]byte(line)))
 
 			func() {
 				i.mu.Lock()

--- a/components/movementsensor/imuwit/imu.go
+++ b/components/movementsensor/imuwit/imu.go
@@ -170,7 +170,7 @@ func NewWit(deps registry.Dependencies, cfg config.Component, logger golog.Logge
 			}
 
 			line, err := portReader.ReadString('U')
-			logger.Debugf("read line from wit: %s", hex.EncodeToString([]byte(line)))
+			logger.Debugw("read line from wit.", "line", hex.EncodeToString([]byte(line)))
 
 			func() {
 				i.mu.Lock()

--- a/components/movementsensor/imuwit/imu.go
+++ b/components/movementsensor/imuwit/imu.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math"
+	"math/rand"
 	"sync"
 
 	"github.com/edaniels/golog"
@@ -170,7 +171,12 @@ func NewWit(deps registry.Dependencies, cfg config.Component, logger golog.Logge
 			}
 
 			line, err := portReader.ReadString('U')
-			logger.Debugw("read line from wit.", "line", hex.EncodeToString([]byte(line)))
+
+			// Randomly sampling logging until we have better log level control
+			//nolint:gosec
+			if rand.Intn(100) < 5 {
+				logger.Debugf("read line from wit: %s", hex.EncodeToString([]byte(line)))
+			}
 
 			func() {
 				i.mu.Lock()

--- a/components/movementsensor/imuwit/imu.go
+++ b/components/movementsensor/imuwit/imu.go
@@ -175,7 +175,7 @@ func NewWit(deps registry.Dependencies, cfg config.Component, logger golog.Logge
 			// Randomly sampling logging until we have better log level control
 			//nolint:gosec
 			if rand.Intn(100) < 5 {
-				logger.Debugf("read line from wit: %s", hex.EncodeToString([]byte(line)))
+				logger.Debugf("read line from wit [sampled]: %s", hex.EncodeToString([]byte(line)))
 			}
 
 			func() {


### PR DESCRIPTION
If baud_rate wasn't provided it was treated as 0
Logging read strings resulted a log flood (not surprising) and lots of failures to push to cloud due invalid characters.