### PR TITLE
Fix arm6l build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TOOL_BIN = bin/gotools/$(shell uname -s)-$(shell uname -m)
 PATH_WITH_TOOLS="`pwd`/$(TOOL_BIN):`pwd`/node_modules/.bin:${PATH}"
 
 GIT_REVISION = $(shell git rev-parse HEAD | tr -d '\n')
-LDFLAGS = -ldflags "-extldflags '-Wl,--long-plt' $(shell etc/tag_version.sh) -X 'go.viam.com/rdk/config.GitRevision=${GIT_REVISION}'"
+LDFLAGS = -ldflags "$(shell etc/set_plt.sh) $(shell etc/tag_version.sh) -X 'go.viam.com/rdk/config.GitRevision=${GIT_REVISION}'"
 BUILD_TAGS=dynamic
 GO_BUILD_TAGS = -tags $(BUILD_TAGS)
 LINT_BUILD_TAGS = --build-tags $(BUILD_TAGS)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TOOL_BIN = bin/gotools/$(shell uname -s)-$(shell uname -m)
 PATH_WITH_TOOLS="`pwd`/$(TOOL_BIN):`pwd`/node_modules/.bin:${PATH}"
 
 GIT_REVISION = $(shell git rev-parse HEAD | tr -d '\n')
-LDFLAGS = -ldflags "$(shell etc/tag_version.sh) -X 'go.viam.com/rdk/config.GitRevision=${GIT_REVISION}'"
+LDFLAGS = -ldflags "-extldflags '-Wl,--long-plt' $(shell etc/tag_version.sh) -X 'go.viam.com/rdk/config.GitRevision=${GIT_REVISION}'"
 BUILD_TAGS=dynamic
 GO_BUILD_TAGS = -tags $(BUILD_TAGS)
 LINT_BUILD_TAGS = --build-tags $(BUILD_TAGS)

--- a/etc/set_plt.sh
+++ b/etc/set_plt.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+if [ `uname -m` = "armv6l" ]
+then
+	echo "-extldflags '-Wl,--long-plt'"
+fi
+exit 0

--- a/ml/inference/tflite.go
+++ b/ml/inference/tflite.go
@@ -1,3 +1,4 @@
+//go:build !arm
 package inference
 
 import (

--- a/services/vision/builtin/builtin.go
+++ b/services/vision/builtin/builtin.go
@@ -1,3 +1,4 @@
+//go:build !arm
 // Package builtin is the service that allows you to access various computer vision algorithms
 // (like detection, segmentation, tracking, etc) that usually only require a camera or image input.
 package builtin

--- a/services/vision/builtin/builtin_notsupported.go
+++ b/services/vision/builtin/builtin_notsupported.go
@@ -1,0 +1,31 @@
+//go:build arm
+
+package builtin
+
+import (
+        "context"
+
+        "github.com/edaniels/golog"
+        "github.com/pkg/errors"
+
+        "go.viam.com/rdk/config"
+        "go.viam.com/rdk/registry"
+        "go.viam.com/rdk/resource"
+        "go.viam.com/rdk/robot"
+        "go.viam.com/rdk/services/vision"
+)
+
+
+func init() {
+        registry.RegisterService(vision.Subtype, resource.DefaultModelName, registry.Service{
+                Constructor: func(ctx context.Context, r robot.Robot, c config.Service, logger golog.Logger) (interface{}, error) {
+                        return nil, errors.New("not supported on arm6l")
+                },
+        })
+        cType := config.ServiceType(vision.SubtypeName)
+        config.RegisterServiceAttributeMapConverter(cType, func(attributeMap config.AttributeMap) (interface{}, error) {
+                return nil, errors.New("not supported on arm6l")
+        },
+                &vision.Attributes{},
+        )
+}

--- a/services/vision/builtin/registration.go
+++ b/services/vision/builtin/registration.go
@@ -1,3 +1,4 @@
+//go:build !arm
 package builtin
 
 import (

--- a/services/vision/builtin/registry.go
+++ b/services/vision/builtin/registry.go
@@ -1,3 +1,4 @@
+//go:build !arm
 package builtin
 
 import (

--- a/services/vision/builtin/tflite_classifier.go
+++ b/services/vision/builtin/tflite_classifier.go
@@ -1,3 +1,4 @@
+//go:build !arm
 package builtin
 
 import (

--- a/services/vision/builtin/tflite_detector.go
+++ b/services/vision/builtin/tflite_detector.go
@@ -1,3 +1,4 @@
+//go:build !arm
 package builtin
 
 import (


### PR DESCRIPTION
This fixes the arm6l build for RDK, which was broken for two reasons:

1) tflite does not have a version for 32-bit arm, so we selectively do not compile those files if on arm

2) Our codebase has gotten large enough that the 12bit space used by the linker can no longer address our entire binary, necessitating the `--long-plt` flag being passed to the linker, but only on 32-bit systems.