### PR TITLE
RSDK-712 - Replace global golog with logger passed to rdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The API is defined with Protocol Buffers/gRPC which can be found at https://gith
 
 ### Frontend
 
-To start the client development environment, first run the same `go run` command mentioned in Building and Using, but with the environmental variable `ENV=development` (e.g. `ENV=development go run web/cmd/server/main.go -config etc/configs/fake.json`). 
+To start the client development environment, first run the same `go run` command mentioned in Building and Using, but with the environmental variable `ENV=development` (e.g. `ENV=development go run web/cmd/server/main.go -debug -config etc/configs/fake.json`). 
 
 Then navigate to `web/frontend` and run `npm start` in a new terminal tab. Visit `localhost:8080` to view the app, not `localhost:5173`. The latter is a hot module replacement server that rebuilds frontend asset changes.
 

--- a/components/arm/arm.go
+++ b/components/arm/arm.go
@@ -20,7 +20,6 @@ import (
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/registry"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/rlog"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/robot/framesystem"
 	"go.viam.com/rdk/spatialmath"
@@ -278,7 +277,7 @@ func (r *reconfigurableArm) reconfigure(ctx context.Context, newArm resource.Rec
 		return utils.NewUnexpectedTypeError(r, newArm)
 	}
 	if err := viamutils.TryClose(ctx, r.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 	r.actual = arm.actual
 	return nil
@@ -313,7 +312,7 @@ func (r *reconfigurableLocalArm) Reconfigure(ctx context.Context, newArm resourc
 		return utils.NewUnexpectedTypeError(r, newArm)
 	}
 	if err := viamutils.TryClose(ctx, r.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 
 	r.actual = arm.actual

--- a/components/audioinput/audio_input.go
+++ b/components/audioinput/audio_input.go
@@ -18,7 +18,6 @@ import (
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/registry"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/rlog"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/subtype"
 	"go.viam.com/rdk/utils"
@@ -294,7 +293,7 @@ func (i *reconfigurableAudioInput) Reconfigure(ctx context.Context, newAudioInpu
 		return utils.NewUnexpectedTypeError(i, newAudioInput)
 	}
 	if err := viamutils.TryClose(ctx, i.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 	i.cancel()
 	// reset

--- a/components/base/agilex/limo_base_test.go
+++ b/components/base/agilex/limo_base_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/edaniels/golog"
 	"go.viam.com/test"
 
 	"go.viam.com/rdk/components/motor/fake"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/rlog"
 	"go.viam.com/rdk/testutils/inject"
 )
 
@@ -22,7 +22,7 @@ func TestLimoBaseConstructor(t *testing.T) {
 
 	c := make(chan []uint8, 100)
 
-	_, err := CreateLimoBase(context.Background(), &Config{}, rlog.Logger)
+	_, err := CreateLimoBase(context.Background(), &Config{}, golog.Global())
 	test.That(t, err, test.ShouldNotBeNil)
 
 	cfg := &Config{
@@ -30,7 +30,7 @@ func TestLimoBaseConstructor(t *testing.T) {
 		TestChan:  c,
 	}
 
-	baseBase, err := CreateLimoBase(context.Background(), cfg, rlog.Logger)
+	baseBase, err := CreateLimoBase(context.Background(), cfg, golog.Global())
 	test.That(t, err, test.ShouldBeNil)
 	base, ok := baseBase.(*limoBase)
 	test.That(t, ok, test.ShouldBeTrue)

--- a/components/base/base.go
+++ b/components/base/base.go
@@ -16,7 +16,6 @@ import (
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/registry"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/rlog"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/subtype"
 	"go.viam.com/rdk/utils"
@@ -233,7 +232,7 @@ func (r *reconfigurableBase) reconfigure(ctx context.Context, newBase resource.R
 		return utils.NewUnexpectedTypeError(r, newBase)
 	}
 	if err := viamutils.TryClose(ctx, r.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 	r.actual = actual.actual
 	return nil
@@ -264,7 +263,7 @@ func (r *reconfigurableLocalBase) Reconfigure(ctx context.Context, newBase resou
 		return utils.NewUnexpectedTypeError(r, newBase)
 	}
 	if err := viamutils.TryClose(ctx, r.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 
 	r.actual = actual.actual

--- a/components/base/wheeled/wheeled_base_test.go
+++ b/components/base/wheeled/wheeled_base_test.go
@@ -12,7 +12,6 @@ import (
 	"go.viam.com/rdk/components/motor"
 	"go.viam.com/rdk/components/motor/fake"
 	"go.viam.com/rdk/registry"
-	"go.viam.com/rdk/rlog"
 )
 
 func fakeMotorDependencies(t *testing.T, deps []string) registry.Dependencies {
@@ -41,7 +40,7 @@ func TestWheelBaseMath(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	motorDeps := fakeMotorDependencies(t, deps)
 
-	baseBase, err := CreateWheeledBase(context.Background(), motorDeps, cfg, rlog.Logger)
+	baseBase, err := CreateWheeledBase(context.Background(), motorDeps, cfg, golog.Global())
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, baseBase, test.ShouldNotBeNil)
 	base, ok := baseBase.(*wheeledBase)
@@ -302,7 +301,7 @@ func TestWheeledBaseConstructor(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	motorDeps := fakeMotorDependencies(t, deps)
 
-	baseBase, err := CreateWheeledBase(ctx, motorDeps, cfg, rlog.Logger)
+	baseBase, err := CreateWheeledBase(ctx, motorDeps, cfg, golog.Global())
 	test.That(t, err, test.ShouldBeNil)
 	base, ok := baseBase.(*wheeledBase)
 	test.That(t, ok, test.ShouldBeTrue)

--- a/components/board/beaglebone/board.go
+++ b/components/board/beaglebone/board.go
@@ -2,24 +2,24 @@
 package beaglebone
 
 import (
+	"github.com/edaniels/golog"
 	"github.com/pkg/errors"
 	"periph.io/x/host/v3"
 
 	"go.viam.com/rdk/components/board/commonsysfs"
-	"go.viam.com/rdk/rlog"
 )
 
 const modelName = "beaglebone"
 
 func init() {
 	if _, err := host.Init(); err != nil {
-		rlog.Logger.Debugw("error initializing host", "error", err)
+		golog.Global().Debugw("error initializing host", "error", err)
 	}
 
 	gpioMappings, err := commonsysfs.GetGPIOBoardMappings(modelName, boardInfoMappings)
 	var noBoardErr commonsysfs.NoBoardFoundError
 	if errors.As(err, &noBoardErr) {
-		rlog.Logger.Debugw("error getting beaglebone GPIO board mapping", "error", err)
+		golog.Global().Debugw("error getting beaglebone GPIO board mapping", "error", err)
 	}
 
 	commonsysfs.RegisterBoard(modelName, gpioMappings)

--- a/components/board/board.go
+++ b/components/board/board.go
@@ -18,7 +18,6 @@ import (
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/registry"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/rlog"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/subtype"
 	"go.viam.com/rdk/utils"
@@ -303,7 +302,7 @@ func (r *reconfigurableBoard) reconfigure(ctx context.Context, newBoard resource
 		return utils.NewUnexpectedTypeError(r, newBoard)
 	}
 	if err := viamutils.TryClose(ctx, r.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 
 	var oldAnalogReaderNames map[string]struct{}
@@ -407,7 +406,7 @@ func (r *reconfigurableLocalBoard) Reconfigure(ctx context.Context, newBoard res
 		return utils.NewUnexpectedTypeError(r, newBoard)
 	}
 	if err := viamutils.TryClose(ctx, r.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 
 	var oldSPINames map[string]struct{}
@@ -536,7 +535,7 @@ func (r *reconfigurableSPI) reconfigure(ctx context.Context, newSPI SPI) {
 		panic(utils.NewUnexpectedTypeError(r, newSPI))
 	}
 	if err := viamutils.TryClose(ctx, r.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 	r.actual = actual.actual
 }
@@ -564,7 +563,7 @@ func (r *reconfigurableI2C) reconfigure(ctx context.Context, newI2C I2C) {
 		panic(utils.NewUnexpectedTypeError(r, newI2C))
 	}
 	if err := viamutils.TryClose(ctx, r.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 	r.actual = actual.actual
 }
@@ -586,7 +585,7 @@ func (r *reconfigurableAnalogReader) reconfigure(ctx context.Context, newAnalogR
 		panic(utils.NewUnexpectedTypeError(r, newAnalogReader))
 	}
 	if err := viamutils.TryClose(ctx, r.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 	r.actual = actual.actual
 }
@@ -626,7 +625,7 @@ func (r *reconfigurableDigitalInterrupt) reconfigure(ctx context.Context, newDig
 		panic(utils.NewUnexpectedTypeError(r, newDigitalInterrupt))
 	}
 	if err := viamutils.TryClose(ctx, r.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 	r.actual = actual.actual
 }

--- a/components/board/fake/board_test.go
+++ b/components/board/fake/board_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/edaniels/golog"
 	"go.viam.com/test"
 
 	"go.viam.com/rdk/components/board"
 	"go.viam.com/rdk/config"
-	"go.viam.com/rdk/rlog"
 )
 
 func TestFakeBoard(t *testing.T) {
@@ -31,7 +31,7 @@ func TestFakeBoard(t *testing.T) {
 	}
 
 	cfg := config.Component{Name: "board1", ConvertedAttributes: &boardConfig}
-	b, err := NewBoard(context.Background(), cfg, rlog.Logger)
+	b, err := NewBoard(context.Background(), cfg, golog.Global())
 	test.That(t, err, test.ShouldBeNil)
 
 	_, ok := b.I2CByName("main")

--- a/components/board/jetson/board.go
+++ b/components/board/jetson/board.go
@@ -2,24 +2,24 @@
 package jetson
 
 import (
+	"github.com/edaniels/golog"
 	"github.com/pkg/errors"
 	"periph.io/x/host/v3"
 
 	"go.viam.com/rdk/components/board/commonsysfs"
-	"go.viam.com/rdk/rlog"
 )
 
 const modelName = "jetson"
 
 func init() {
 	if _, err := host.Init(); err != nil {
-		rlog.Logger.Debugw("error initializing host", "error", err)
+		golog.Global().Debugw("error initializing host", "error", err)
 	}
 
 	gpioMappings, err := commonsysfs.GetGPIOBoardMappings(modelName, boardInfoMappings)
 	var noBoardErr commonsysfs.NoBoardFoundError
 	if errors.As(err, &noBoardErr) {
-		rlog.Logger.Debugw("error getting jetson GPIO board mapping", "error", err)
+		golog.Global().Debugw("error getting jetson GPIO board mapping", "error", err)
 	}
 
 	commonsysfs.RegisterBoard(modelName, gpioMappings)

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -28,7 +28,6 @@ import (
 	"go.viam.com/rdk/components/generic"
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/registry"
-	"go.viam.com/rdk/rlog"
 	rdkutils "go.viam.com/rdk/utils"
 )
 
@@ -592,7 +591,7 @@ func pigpioInterruptCallback(gpio, level int, rawTick uint32) {
 	for instance := range instances {
 		i := instance.interruptsHW[uint(gpio)]
 		if i == nil {
-			rlog.Logger.Infof("no DigitalInterrupt configured for gpio %d", gpio)
+			golog.Global().Infof("no DigitalInterrupt configured for gpio %d", gpio)
 			continue
 		}
 		high := true

--- a/components/board/ti/board.go
+++ b/components/board/ti/board.go
@@ -2,24 +2,24 @@
 package ti
 
 import (
+	"github.com/edaniels/golog"
 	"github.com/pkg/errors"
 	"periph.io/x/host/v3"
 
 	"go.viam.com/rdk/components/board/commonsysfs"
-	"go.viam.com/rdk/rlog"
 )
 
 const modelName = "ti"
 
 func init() {
 	if _, err := host.Init(); err != nil {
-		rlog.Logger.Debugw("error initializing host", "error", err)
+		golog.Global().Debugw("error initializing host", "error", err)
 	}
 
 	gpioMappings, err := commonsysfs.GetGPIOBoardMappings(modelName, boardInfoMappings)
 	var noBoardErr commonsysfs.NoBoardFoundError
 	if errors.As(err, &noBoardErr) {
-		rlog.Logger.Debugw("error getting ti GPIO board mapping", "error", err)
+		golog.Global().Debugw("error getting ti GPIO board mapping", "error", err)
 	}
 
 	commonsysfs.RegisterBoard(modelName, gpioMappings)

--- a/components/camera/camera.go
+++ b/components/camera/camera.go
@@ -25,7 +25,6 @@ import (
 	"go.viam.com/rdk/rimage"
 	"go.viam.com/rdk/rimage/depthadapter"
 	"go.viam.com/rdk/rimage/transform"
-	"go.viam.com/rdk/rlog"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/subtype"
 	"go.viam.com/rdk/utils"
@@ -431,7 +430,7 @@ func (c *reconfigurableCamera) Reconfigure(ctx context.Context, newCamera resour
 		return utils.NewUnexpectedTypeError(c, newCamera)
 	}
 	if err := viamutils.TryClose(ctx, c.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 	c.cancel()
 	// reset

--- a/components/camera/transformpipeline/mods_test.go
+++ b/components/camera/transformpipeline/mods_test.go
@@ -5,6 +5,7 @@ import (
 	"image"
 	"testing"
 
+	"github.com/edaniels/golog"
 	"github.com/edaniels/gostream"
 	"github.com/pion/mediadevices/pkg/prop"
 	"go.viam.com/test"
@@ -15,7 +16,6 @@ import (
 	"go.viam.com/rdk/components/camera/videosource"
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/rimage"
-	"go.viam.com/rdk/rlog"
 )
 
 var outDir string
@@ -26,7 +26,7 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	rlog.Logger.Debugf("out dir: %q", outDir)
+	golog.Global().Debugf("out dir: %q", outDir)
 }
 
 //nolint:dupl

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -22,7 +22,6 @@ import (
 	"go.viam.com/rdk/discovery"
 	"go.viam.com/rdk/registry"
 	"go.viam.com/rdk/rimage/transform"
-	"go.viam.com/rdk/rlog"
 	"go.viam.com/rdk/utils"
 )
 
@@ -90,15 +89,15 @@ func Discover(ctx context.Context, getDrivers func() []driver.Driver) (*pb.Webca
 
 		props, err := getProperties(d)
 		if len(props) == 0 {
-			rlog.Logger.Debugw("no properties detected for driver, skipping discovery...", "driver", driverInfo.Label)
+			golog.Global().Debugw("no properties detected for driver, skipping discovery...", "driver", driverInfo.Label)
 			continue
 		} else if err != nil {
-			rlog.Logger.Debugw("cannot access driver properties, skipping discovery...", "driver", driverInfo.Label, "error", err)
+			golog.Global().Debugw("cannot access driver properties, skipping discovery...", "driver", driverInfo.Label, "error", err)
 			continue
 		}
 
 		if d.Status() == driver.StateRunning {
-			rlog.Logger.Debugw("driver is in use, skipping discovery...", "driver", driverInfo.Label)
+			golog.Global().Debugw("driver is in use, skipping discovery...", "driver", driverInfo.Label)
 			continue
 		}
 

--- a/components/encoder/encoder.go
+++ b/components/encoder/encoder.go
@@ -5,12 +5,12 @@ import (
 	"context"
 	"sync"
 
+	"github.com/edaniels/golog"
 	viamutils "go.viam.com/utils"
 
 	"go.viam.com/rdk/components/generic"
 	"go.viam.com/rdk/registry"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/rlog"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/utils"
 )
@@ -143,7 +143,7 @@ func (r *reconfigurableEncoder) reconfigure(ctx context.Context, newEncoder reso
 		return utils.NewUnexpectedTypeError(r, newEncoder)
 	}
 	if err := viamutils.TryClose(ctx, r.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 	r.actual = actual.actual
 	return nil

--- a/components/gantry/gantry.go
+++ b/components/gantry/gantry.go
@@ -15,7 +15,6 @@ import (
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/registry"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/rlog"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/subtype"
 	"go.viam.com/rdk/utils"
@@ -260,7 +259,7 @@ func (g *reconfigurableGantry) reconfigure(ctx context.Context, newGantry resour
 		return utils.NewUnexpectedTypeError(g, newGantry)
 	}
 	if err := viamutils.TryClose(ctx, g.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 	g.actual = actual.actual
 	return nil
@@ -303,7 +302,7 @@ func (g *reconfigurableLocalGantry) Reconfigure(ctx context.Context, newGantry r
 		return utils.NewUnexpectedTypeError(g, newGantry)
 	}
 	if err := viamutils.TryClose(ctx, g.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 
 	g.actual = gantry.actual

--- a/components/generic/generic.go
+++ b/components/generic/generic.go
@@ -13,7 +13,6 @@ import (
 
 	"go.viam.com/rdk/registry"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/rlog"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/subtype"
 	"go.viam.com/rdk/utils"
@@ -147,7 +146,7 @@ func (r *reconfigurableGeneric) Reconfigure(ctx context.Context, newGeneric reso
 		return utils.NewUnexpectedTypeError(r, newGeneric)
 	}
 	if err := viamutils.TryClose(ctx, r.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 	r.actual = actual.actual
 	return nil

--- a/components/gripper/gripper.go
+++ b/components/gripper/gripper.go
@@ -16,7 +16,6 @@ import (
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/registry"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/rlog"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/subtype"
 	"go.viam.com/rdk/utils"
@@ -203,7 +202,7 @@ func (g *reconfigurableGripper) reconfigure(ctx context.Context, newGripper reso
 		return utils.NewUnexpectedTypeError(g, newGripper)
 	}
 	if err := viamutils.TryClose(ctx, g.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 	g.actual = actual.actual
 	return nil
@@ -234,7 +233,7 @@ func (g *reconfigurableLocalGripper) Reconfigure(ctx context.Context, newGripper
 		return utils.NewUnexpectedTypeError(g, newGripper)
 	}
 	if err := viamutils.TryClose(ctx, g.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 
 	g.actual = gripper.actual

--- a/components/input/input.go
+++ b/components/input/input.go
@@ -16,7 +16,6 @@ import (
 	"go.viam.com/rdk/components/generic"
 	"go.viam.com/rdk/registry"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/rlog"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/subtype"
 	"go.viam.com/rdk/utils"
@@ -297,7 +296,7 @@ func (c *reconfigurableInputController) Reconfigure(ctx context.Context, newCont
 		return utils.NewUnexpectedTypeError(c, newController)
 	}
 	if err := viamutils.TryClose(ctx, c.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 	c.actual = actual.actual
 	return nil

--- a/components/motor/gpio/motor_encoder_test.go
+++ b/components/motor/gpio/motor_encoder_test.go
@@ -17,7 +17,6 @@ import (
 	"go.viam.com/rdk/components/motor"
 	fakemotor "go.viam.com/rdk/components/motor/fake"
 	"go.viam.com/rdk/config"
-	"go.viam.com/rdk/rlog"
 )
 
 func nowNanosTest() uint64 {
@@ -551,7 +550,7 @@ func TestWrapMotorWithEncoder(t *testing.T) {
 	})
 
 	t.Run("wrap motor with single encoder", func(t *testing.T) {
-		b, err := fakeboard.NewBoard(context.Background(), config.Component{ConvertedAttributes: &fakeboard.Config{}}, rlog.Logger)
+		b, err := fakeboard.NewBoard(context.Background(), config.Component{ConvertedAttributes: &fakeboard.Config{}}, golog.Global())
 		test.That(t, err, test.ShouldBeNil)
 		fakeMotor := &fakemotor.Motor{}
 		b.Digitals["a"] = &board.BasicDigitalInterrupt{}
@@ -577,7 +576,7 @@ func TestWrapMotorWithEncoder(t *testing.T) {
 	})
 
 	t.Run("wrap motor with hall encoder", func(t *testing.T) {
-		b, err := fakeboard.NewBoard(context.Background(), config.Component{ConvertedAttributes: &fakeboard.Config{}}, rlog.Logger)
+		b, err := fakeboard.NewBoard(context.Background(), config.Component{ConvertedAttributes: &fakeboard.Config{}}, golog.Global())
 		test.That(t, err, test.ShouldBeNil)
 		fakeMotor := &fakemotor.Motor{}
 		b.Digitals["a"] = &board.BasicDigitalInterrupt{}

--- a/components/motor/motor.go
+++ b/components/motor/motor.go
@@ -13,7 +13,6 @@ import (
 	"go.viam.com/rdk/data"
 	"go.viam.com/rdk/registry"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/rlog"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/subtype"
 	"go.viam.com/rdk/utils"
@@ -287,7 +286,7 @@ func (r *reconfigurableMotor) reconfigure(ctx context.Context, newMotor resource
 		return utils.NewUnexpectedTypeError(r, newMotor)
 	}
 	if err := viamutils.TryClose(ctx, r.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 	r.actual = actual.actual
 	return nil
@@ -306,7 +305,7 @@ func (r *reconfigurableLocalMotor) Reconfigure(ctx context.Context, newMotor res
 		return utils.NewUnexpectedTypeError(r, newMotor)
 	}
 	if err := viamutils.TryClose(ctx, r.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 
 	r.actual = motor.actual

--- a/components/movementsensor/movementsensor.go
+++ b/components/movementsensor/movementsensor.go
@@ -16,7 +16,6 @@ import (
 	"go.viam.com/rdk/components/sensor"
 	"go.viam.com/rdk/registry"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/rlog"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/spatialmath"
 	"go.viam.com/rdk/subtype"
@@ -247,7 +246,7 @@ func (r *reconfigurableMovementSensor) reconfigure(ctx context.Context, newMovem
 		return utils.NewUnexpectedTypeError(r, newMovementSensor)
 	}
 	if err := viamutils.TryClose(ctx, r.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 	r.actual = actual.actual
 	return nil

--- a/components/posetracker/pose_tracker.go
+++ b/components/posetracker/pose_tracker.go
@@ -16,7 +16,6 @@ import (
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/registry"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/rlog"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/subtype"
 	"go.viam.com/rdk/utils"
@@ -155,7 +154,7 @@ func (r *reconfigurablePoseTracker) Reconfigure(
 		return utils.NewUnexpectedTypeError(r, newPoseTracker)
 	}
 	if err := viamutils.TryClose(ctx, r.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 	r.actual = actual.actual
 	return nil

--- a/components/sensor/sensor.go
+++ b/components/sensor/sensor.go
@@ -13,7 +13,6 @@ import (
 	"go.viam.com/rdk/components/generic"
 	"go.viam.com/rdk/registry"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/rlog"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/subtype"
 	"go.viam.com/rdk/utils"
@@ -127,7 +126,7 @@ func (r *reconfigurableSensor) Reconfigure(ctx context.Context, newSensor resour
 		return utils.NewUnexpectedTypeError(r, newSensor)
 	}
 	if err := viamutils.TryClose(ctx, r.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 	r.actual = actual.actual
 	return nil

--- a/components/sensor/ultrasonic/ultrasonic.go
+++ b/components/sensor/ultrasonic/ultrasonic.go
@@ -14,7 +14,6 @@ import (
 	"go.viam.com/rdk/components/sensor"
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/registry"
-	"go.viam.com/rdk/rlog"
 )
 
 const (
@@ -63,7 +62,7 @@ func init() {
 }
 
 func newSensor(ctx context.Context, deps registry.Dependencies, name string, config *AttrConfig) (sensor.Sensor, error) {
-	rlog.Logger.Debug("building ultrasonic sensor")
+	golog.Global().Debug("building ultrasonic sensor")
 	s := &Sensor{Name: name, config: config}
 
 	res, ok := deps[board.Named(config.Board)]

--- a/components/servo/servo.go
+++ b/components/servo/servo.go
@@ -12,7 +12,6 @@ import (
 	"go.viam.com/rdk/components/generic"
 	"go.viam.com/rdk/registry"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/rlog"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/subtype"
 	"go.viam.com/rdk/utils"
@@ -182,7 +181,7 @@ func (r *reconfigurableServo) reconfigure(ctx context.Context, newServo resource
 		return utils.NewUnexpectedTypeError(r, newServo)
 	}
 	if err := viamutils.TryClose(ctx, r.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 	r.actual = actual.actual
 	return nil
@@ -207,7 +206,7 @@ func (r *reconfigurableLocalServo) Reconfigure(ctx context.Context, newServo res
 		return utils.NewUnexpectedTypeError(r, newServo)
 	}
 	if err := viamutils.TryClose(ctx, r.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 
 	r.actual = Servo.actual

--- a/config/config.go
+++ b/config/config.go
@@ -11,12 +11,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/edaniels/golog"
 	"github.com/pkg/errors"
 	"go.viam.com/utils"
 	"go.viam.com/utils/pexec"
 	"go.viam.com/utils/rpc"
 
-	"go.viam.com/rdk/rlog"
 	rutils "go.viam.com/rdk/utils"
 )
 
@@ -39,7 +39,7 @@ func SortComponents(components []Component) ([]Component, error) {
 	for name, dps := range dependencies {
 		for _, depName := range dps {
 			if _, ok := componentToConfig[depName]; !ok {
-				rlog.Logger.Warnw(
+				golog.Global().Warnw(
 					"missing dependency on local robot, is this a remote dependency?",
 					"component", name,
 					"dependency", depName,

--- a/config/resource.go
+++ b/config/resource.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/edaniels/golog"
 	"github.com/pkg/errors"
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/rlog"
 )
 
 // UpdateActionType help hint the reconfigure process on whether one should reconfigure a resource or rebuild it.
@@ -317,11 +317,11 @@ func (config *Service) Validate(path string) error {
 	}
 	// If services do not have a name use the name builtin
 	if config.Name == "" {
-		rlog.Logger.Warnw("no name given, defaulting name to builtin")
+		golog.Global().Warnw("no name given, defaulting name to builtin")
 		config.Name = resource.DefaultModelName
 	}
 	if config.Model == "" {
-		rlog.Logger.Warnw("no model given; using default")
+		golog.Global().Warnw("no model given; using default")
 		config.Model = resource.DefaultModelName
 	}
 	if config.Namespace == "" {

--- a/examples/mycomponent/component/mycomponent.go
+++ b/examples/mycomponent/component/mycomponent.go
@@ -17,7 +17,6 @@ import (
 	pb "go.viam.com/rdk/examples/mycomponent/proto/api/component/mycomponent/v1"
 	"go.viam.com/rdk/registry"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/rlog"
 	"go.viam.com/rdk/subtype"
 	"go.viam.com/rdk/utils"
 )
@@ -185,7 +184,7 @@ func (mc *reconfigurableMyComponent) Reconfigure(ctx context.Context, newMyCompo
 		return utils.NewUnexpectedTypeError(mc, newMyComponenet)
 	}
 	if err := goutils.TryClose(ctx, mc.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 	mc.actual = actual.actual
 	return nil

--- a/rimage/color.go
+++ b/rimage/color.go
@@ -5,11 +5,11 @@ import (
 	"image/color"
 	"math"
 
+	"github.com/edaniels/golog"
 	"github.com/lucasb-eyer/go-colorful"
 	"github.com/pkg/errors"
 	"gonum.org/v1/gonum/floats"
 
-	"go.viam.com/rdk/rlog"
 	"go.viam.com/rdk/utils"
 )
 
@@ -387,12 +387,12 @@ func (c Color) distanceDebug(b Color, debug bool) float64 {
 	res := math.Sqrt(sum)
 
 	if debug {
-		rlog.Logger.Debugf("%v -- %v", c, b)
-		rlog.Logger.Debugf("\twh: %5.1f ws: %5.1f wv: %5.1f", wh, ws, wv)
-		rlog.Logger.Debugf("\t    %5.3f     %5.3f     %5.3f", math.Abs(hd), math.Abs(s1-s2), math.Abs(v1-v2))
-		rlog.Logger.Debugf("\t    %5.3f     %5.3f     %5.3f", utils.Square(hd), utils.Square(s1-s2), utils.Square(v1-v2))
-		rlog.Logger.Debugf("\t    %5.3f     %5.3f     %5.3f", utils.Square(wh*hd), utils.Square(ws*(s1-s2)), utils.Square(wv*(v1-v2)))
-		rlog.Logger.Debugf("\t res: %f ac: %f dd: %f section: %d", res, ac, dd, section)
+		golog.Global().Debugf("%v -- %v", c, b)
+		golog.Global().Debugf("\twh: %5.1f ws: %5.1f wv: %5.1f", wh, ws, wv)
+		golog.Global().Debugf("\t    %5.3f     %5.3f     %5.3f", math.Abs(hd), math.Abs(s1-s2), math.Abs(v1-v2))
+		golog.Global().Debugf("\t    %5.3f     %5.3f     %5.3f", utils.Square(hd), utils.Square(s1-s2), utils.Square(v1-v2))
+		golog.Global().Debugf("\t    %5.3f     %5.3f     %5.3f", utils.Square(wh*hd), utils.Square(ws*(s1-s2)), utils.Square(wv*(v1-v2)))
+		golog.Global().Debugf("\t res: %f ac: %f dd: %f section: %d", res, ac, dd, section)
 	}
 	return res
 }

--- a/rimage/transform/camera_matrix_test.go
+++ b/rimage/transform/camera_matrix_test.go
@@ -5,13 +5,13 @@ import (
 	"os"
 	"testing"
 
+	"github.com/edaniels/golog"
 	"go.viam.com/test"
 	"go.viam.com/utils/artifact"
 	"go.viam.com/utils/testutils"
 
 	"go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/rimage"
-	"go.viam.com/rdk/rlog"
 )
 
 var outDir string
@@ -22,7 +22,7 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	rlog.Logger.Debugf("out dir: %q", outDir)
+	golog.Global().Debugf("out dir: %q", outDir)
 }
 
 func TestPC1(t *testing.T) {

--- a/rimage/utils_test.go
+++ b/rimage/utils_test.go
@@ -1,9 +1,8 @@
 package rimage
 
 import (
+	"github.com/edaniels/golog"
 	"go.viam.com/utils/testutils"
-
-	"go.viam.com/rdk/rlog"
 )
 
 var outDir string
@@ -14,5 +13,5 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	rlog.Logger.Debugf("out dir: %q", outDir)
+	golog.Global().Debugf("out dir: %q", outDir)
 }

--- a/rlog/logger.go
+++ b/rlog/logger.go
@@ -1,8 +1,0 @@
-// Package rlog defines common logging utilities.
-package rlog
-
-import "github.com/edaniels/golog"
-
-// Logger is the global logger that should be used when a context specific
-// one is unavailable.
-var Logger = golog.Global()

--- a/robot/web/stream/stream.go
+++ b/robot/web/stream/stream.go
@@ -7,10 +7,9 @@ import (
 	"math"
 	"time"
 
+	"github.com/edaniels/golog"
 	"github.com/edaniels/gostream"
 	"go.viam.com/utils"
-
-	"go.viam.com/rdk/rlog"
 )
 
 // StreamVideoSource starts a stream from a video source with a throttled error handler.
@@ -72,7 +71,7 @@ func (opts *BackoffTuningOptions) getErrorThrottledHandler() func(context.Contex
 		}
 
 		sleep := opts.GetSleepTimeFromErrorCount(errorCount)
-		rlog.Logger.Debugw("error getting media", "error", err, "count", errorCount, "sleep", sleep)
+		golog.Global().Debugw("error getting media", "error", err, "count", errorCount, "sleep", sleep)
 		utils.SelectContextOrWait(ctx, sleep)
 	}
 }

--- a/services/armremotecontrol/arm_remote_control.go
+++ b/services/armremotecontrol/arm_remote_control.go
@@ -5,11 +5,11 @@ import (
 	"context"
 	"sync"
 
+	"github.com/edaniels/golog"
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/registry"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/rlog"
 	rdkutils "go.viam.com/rdk/utils"
 )
 
@@ -60,7 +60,7 @@ func (svc *reconfigurableArmRemoteControl) Reconfigure(ctx context.Context, newS
 		return rdkutils.NewUnexpectedTypeError(svc, newSvc)
 	}
 	if err := utils.TryClose(ctx, svc.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 	svc.actual = rSvc.actual
 	return nil

--- a/services/armremotecontrol/builtin/builtin_test.go
+++ b/services/armremotecontrol/builtin/builtin_test.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/edaniels/golog"
 	"github.com/pkg/errors"
 	"go.viam.com/test"
 	"go.viam.com/utils"
@@ -14,7 +15,6 @@ import (
 	"go.viam.com/rdk/components/input"
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/rlog"
 	"go.viam.com/rdk/testutils/inject"
 	rdkutils "go.viam.com/rdk/utils"
 )
@@ -64,7 +64,7 @@ func TestArmRemoteControl(t *testing.T) {
 		case input.Subtype:
 			return fakeController, nil
 		case arm.Subtype:
-			return fakearm.NewArmIK(ctx, config.Component{Name: "arm"}, rlog.Logger)
+			return fakearm.NewArmIK(ctx, config.Component{Name: "arm"}, golog.Global())
 		}
 		return nil, rdkutils.NewResourceNotFoundError(name)
 	}
@@ -91,7 +91,7 @@ func TestArmRemoteControl(t *testing.T) {
 			Type:                "arm_remote_control",
 			ConvertedAttributes: cfg,
 		},
-		rlog.Logger)
+		golog.Global())
 	test.That(t, err, test.ShouldBeNil)
 
 	svc, ok := tmpSvc.(*builtIn)
@@ -111,7 +111,7 @@ func TestArmRemoteControl(t *testing.T) {
 			Type:                "arm_remote_control",
 			ConvertedAttributes: cfg,
 		},
-		rlog.Logger)
+		golog.Global())
 	test.That(t, err, test.ShouldBeError, errors.New("resource \"rdk:component:input_controller/\" not found"))
 
 	// Arm import failure
@@ -128,7 +128,7 @@ func TestArmRemoteControl(t *testing.T) {
 			Type:                "arm_remote_control",
 			ConvertedAttributes: cfg,
 		},
-		rlog.Logger)
+		golog.Global())
 	test.That(t, err, test.ShouldBeError, errors.New("resource \"rdk:component:arm/\" not found"))
 
 	// Start checks

--- a/services/baseremotecontrol/base_remote_control.go
+++ b/services/baseremotecontrol/base_remote_control.go
@@ -5,12 +5,12 @@ import (
 	"context"
 	"sync"
 
+	"github.com/edaniels/golog"
 	viamutils "go.viam.com/utils"
 
 	"go.viam.com/rdk/components/input"
 	"go.viam.com/rdk/registry"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/rlog"
 	"go.viam.com/rdk/utils"
 )
 
@@ -67,7 +67,7 @@ func (svc *reconfigurableBaseRemoteControl) Reconfigure(ctx context.Context, new
 		return utils.NewUnexpectedTypeError(svc, newSvc)
 	}
 	if err := viamutils.TryClose(ctx, svc.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 	svc.actual = rSvc.actual
 	return nil

--- a/services/baseremotecontrol/builtin/builtin_test.go
+++ b/services/baseremotecontrol/builtin/builtin_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/edaniels/golog"
 	"github.com/golang/geo/r3"
 	"github.com/pkg/errors"
 	"go.viam.com/test"
@@ -14,7 +15,6 @@ import (
 	"go.viam.com/rdk/components/input"
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/rlog"
 	"go.viam.com/rdk/testutils/inject"
 	rutils "go.viam.com/rdk/utils"
 )
@@ -58,7 +58,7 @@ func TestBaseRemoteControl(t *testing.T) {
 			Type:                "base_remote_control",
 			ConvertedAttributes: cfg,
 		},
-		rlog.Logger)
+		golog.Global())
 	test.That(t, err, test.ShouldBeNil)
 	svc, ok := tmpSvc.(*builtIn)
 	test.That(t, ok, test.ShouldBeTrue)
@@ -70,7 +70,7 @@ func TestBaseRemoteControl(t *testing.T) {
 			Type:                "base_remote_control",
 			ConvertedAttributes: cfg,
 		},
-		rlog.Logger)
+		golog.Global())
 	test.That(t, err, test.ShouldBeNil)
 	svc1, ok := tmpSvc1.(*builtIn)
 	test.That(t, ok, test.ShouldBeTrue)
@@ -82,7 +82,7 @@ func TestBaseRemoteControl(t *testing.T) {
 			Type:                "base_remote_control",
 			ConvertedAttributes: cfg,
 		},
-		rlog.Logger)
+		golog.Global())
 	test.That(t, err, test.ShouldBeNil)
 	svc2, ok := tmpSvc2.(*builtIn)
 	test.That(t, ok, test.ShouldBeTrue)
@@ -94,7 +94,7 @@ func TestBaseRemoteControl(t *testing.T) {
 			Type:                "base_remote_control",
 			ConvertedAttributes: cfg,
 		},
-		rlog.Logger)
+		golog.Global())
 	test.That(t, err, test.ShouldBeNil)
 	svc3, ok := tmpSvc3.(*builtIn)
 	test.That(t, ok, test.ShouldBeTrue)
@@ -106,7 +106,7 @@ func TestBaseRemoteControl(t *testing.T) {
 			Type:                "base_remote_control",
 			ConvertedAttributes: cfg,
 		},
-		rlog.Logger)
+		golog.Global())
 	test.That(t, err, test.ShouldBeNil)
 	svc4, ok := tmpSvc4.(*builtIn)
 	test.That(t, ok, test.ShouldBeTrue)
@@ -125,7 +125,7 @@ func TestBaseRemoteControl(t *testing.T) {
 			Type:                "base_remote_control",
 			ConvertedAttributes: cfg,
 		},
-		rlog.Logger)
+		golog.Global())
 	test.That(t, err, test.ShouldBeError, errors.New("resource \"rdk:component:input_controller/\" not found"))
 
 	// Base import failure
@@ -142,7 +142,7 @@ func TestBaseRemoteControl(t *testing.T) {
 			Type:                "base_remote_control",
 			ConvertedAttributes: cfg,
 		},
-		rlog.Logger)
+		golog.Global())
 	test.That(t, err, test.ShouldBeError, errors.New("resource \"rdk:component:base/\" not found"))
 
 	// Start checks

--- a/services/datamanager/data_manager.go
+++ b/services/datamanager/data_manager.go
@@ -14,7 +14,6 @@ import (
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/registry"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/rlog"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/subtype"
 	"go.viam.com/rdk/utils"
@@ -134,7 +133,7 @@ func (svc *reconfigurableDataManager) Reconfigure(ctx context.Context, newSvc re
 		return utils.NewUnexpectedTypeError(svc, newSvc)
 	}
 	if err := goutils.TryClose(ctx, svc.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 	svc.actual = rSvc.actual
 	return nil

--- a/services/motion/motion.go
+++ b/services/motion/motion.go
@@ -14,7 +14,6 @@ import (
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/registry"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/rlog"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/subtype"
 	"go.viam.com/rdk/utils"
@@ -158,7 +157,7 @@ func (svc *reconfigurableMotionService) Reconfigure(ctx context.Context, newSvc 
 		return utils.NewUnexpectedTypeError(svc, newSvc)
 	}
 	if err := goutils.TryClose(ctx, svc.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 	svc.actual = rSvc.actual
 	return nil

--- a/services/navigation/navigation.go
+++ b/services/navigation/navigation.go
@@ -15,7 +15,6 @@ import (
 
 	"go.viam.com/rdk/registry"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/rlog"
 	"go.viam.com/rdk/subtype"
 	rdkutils "go.viam.com/rdk/utils"
 )
@@ -161,7 +160,7 @@ func (svc *reconfigurableNavigation) Reconfigure(ctx context.Context, newSvc res
 		return rdkutils.NewUnexpectedTypeError(svc, newSvc)
 	}
 	if err := utils.TryClose(ctx, svc.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 	svc.actual = rSvc.actual
 	return nil

--- a/services/sensors/sensors.go
+++ b/services/sensors/sensors.go
@@ -12,7 +12,6 @@ import (
 
 	"go.viam.com/rdk/registry"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/rlog"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/subtype"
 	"go.viam.com/rdk/utils"
@@ -141,7 +140,7 @@ func (svc *reconfigurableSensors) Reconfigure(ctx context.Context, newSvc resour
 		return utils.NewUnexpectedTypeError(svc, newSvc)
 	}
 	if err := goutils.TryClose(ctx, svc.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 	svc.actual = rSvc.actual
 	return nil

--- a/services/shell/shell.go
+++ b/services/shell/shell.go
@@ -12,7 +12,6 @@ import (
 
 	"go.viam.com/rdk/registry"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/rlog"
 	"go.viam.com/rdk/subtype"
 	rdkutils "go.viam.com/rdk/utils"
 )
@@ -99,7 +98,7 @@ func (svc *reconfigurableShell) Reconfigure(ctx context.Context, newSvc resource
 		return rdkutils.NewUnexpectedTypeError(svc, newSvc)
 	}
 	if err := utils.TryClose(ctx, svc.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 	svc.actual = rSvc.actual
 	return nil

--- a/services/slam/slam.go
+++ b/services/slam/slam.go
@@ -14,7 +14,6 @@ import (
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/registry"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/rlog"
 	"go.viam.com/rdk/subtype"
 	"go.viam.com/rdk/utils"
 	"go.viam.com/rdk/vision"
@@ -108,7 +107,7 @@ func (svc *reconfigurableSlam) Reconfigure(ctx context.Context, newSvc resource.
 		return utils.NewUnexpectedTypeError(svc, newSvc)
 	}
 	if err := goutils.TryClose(ctx, svc.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 	svc.actual = rSvc.actual
 	return nil

--- a/services/vision/vision.go
+++ b/services/vision/vision.go
@@ -16,7 +16,6 @@ import (
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/registry"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/rlog"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/subtype"
 	"go.viam.com/rdk/utils"
@@ -255,7 +254,7 @@ func (svc *reconfigurableVision) Reconfigure(ctx context.Context, newSvc resourc
 		return utils.NewUnexpectedTypeError(svc, newSvc)
 	}
 	if err := goutils.TryClose(ctx, svc.actual); err != nil {
-		rlog.Logger.Errorw("error closing old", "error", err)
+		golog.Global().Errorw("error closing old", "error", err)
 	}
 	svc.actual = rSvc.actual
 	/*

--- a/vision/chess/chess_util_test.go
+++ b/vision/chess/chess_util_test.go
@@ -9,7 +9,6 @@ import (
 	"go.viam.com/utils/testutils"
 
 	"go.viam.com/rdk/rimage"
-	"go.viam.com/rdk/rlog"
 )
 
 var outDir string
@@ -20,7 +19,7 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	rlog.Logger.Debugf("out dir: %q", outDir)
+	golog.Global().Debugf("out dir: %q", outDir)
 }
 
 func TestGetMinChessCorner(t *testing.T) {

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -59,6 +59,7 @@ func RunServer(ctx context.Context, args []string, _ golog.Logger) (err error) {
 		logConfig = golog.NewProductionLoggerConfig()
 	}
 	logger := zap.Must(logConfig.Build()).Sugar().Named("robot_server")
+	golog.ReplaceGloabl(logger)
 
 	// Always log the version, return early if the '-version' flag was provided
 	// fmt.Println would be better but fails linting. Good enough.
@@ -110,6 +111,8 @@ func RunServer(ctx context.Context, args []string, _ golog.Logger) (err error) {
 			return err
 		}
 		defer closer()
+
+		golog.ReplaceGloabl(logger)
 	}
 
 	server := robotServer{

--- a/web/server/net_logger.go
+++ b/web/server/net_logger.go
@@ -23,7 +23,6 @@ import (
 
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/protoutils"
-	"go.viam.com/rdk/rlog"
 )
 
 const (
@@ -59,7 +58,7 @@ func (l *wrappedLogger) Sync() error {
 	return l.base.Sync()
 }
 
-func newNetLogger(config *config.Cloud) (*netLogger, error) {
+func newNetLogger(config *config.Cloud, loggerWithoutNet golog.Logger) (*netLogger, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return nil, err
@@ -72,18 +71,19 @@ func newNetLogger(config *config.Cloud) (*netLogger, error) {
 		}
 	} else {
 		logWriter = &remoteLogWriterGRPC{
-			logger: rlog.Logger,
-			cfg:    config,
+			loggerWithoutNet: loggerWithoutNet,
+			cfg:              config,
 		}
 	}
 
 	cancelCtx, cancel := context.WithCancel(context.Background())
 	nl := &netLogger{
-		hostname:     hostname,
-		cancelCtx:    cancelCtx,
-		cancel:       cancel,
-		remoteWriter: logWriter,
-		maxQueueSize: defaultMaxQueueSize,
+		hostname:         hostname,
+		cancelCtx:        cancelCtx,
+		cancel:           cancel,
+		remoteWriter:     logWriter,
+		maxQueueSize:     defaultMaxQueueSize,
+		loggerWithoutNet: loggerWithoutNet,
 	}
 	nl.activeBackgroundWorkers.Add(1)
 	utils.ManagedGo(nl.backgroundWorker, nl.activeBackgroundWorkers.Done)
@@ -101,6 +101,10 @@ type netLogger struct {
 	cancelCtx               context.Context
 	cancel                  func()
 	activeBackgroundWorkers sync.WaitGroup
+
+	// Use this logger for library errors that will not be reported through
+	// the netLogger causing a recursive loop.
+	loggerWithoutNet golog.Logger
 }
 
 func (nl *netLogger) queueSize() int {
@@ -236,8 +240,7 @@ func (nl *netLogger) backgroundWorker() {
 		err := nl.Sync()
 		if err != nil && !errors.Is(err, context.Canceled) {
 			interval = abnormalInterval
-			// fall back to regular logging
-			rlog.Logger.Infof("error logging to network: %s", err)
+			nl.loggerWithoutNet.Infof("error logging to network: %s", err)
 		} else {
 			interval = normalInterval
 		}
@@ -281,7 +284,7 @@ func (nl *netLogger) Sync() error {
 }
 
 func addCloudLogger(logger golog.Logger, cfg *config.Cloud) (golog.Logger, func(), error) {
-	nl, err := newNetLogger(cfg)
+	nl, err := newNetLogger(cfg, logger)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -367,7 +370,10 @@ type remoteLogWriterGRPC struct {
 	service     apppb.RobotServiceClient
 	rpcClient   rpc.ClientConn
 	clientMutex sync.Mutex
-	logger      golog.Logger
+
+	// Use this logger for library errors that will not be reported through
+	// the netLogger causing a recursive loop.
+	loggerWithoutNet golog.Logger
 }
 
 func (w *remoteLogWriterGRPC) write(logs []*apppb.LogEntry) error {
@@ -394,7 +400,7 @@ func (w *remoteLogWriterGRPC) getOrCreateClient(ctx context.Context) (apppb.Robo
 		w.clientMutex.Lock()
 		defer w.clientMutex.Unlock()
 
-		client, err := config.CreateNewGRPCClient(ctx, w.cfg, w.logger)
+		client, err := config.CreateNewGRPCClient(ctx, w.cfg, w.loggerWithoutNet)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
 - Remove rlog package as it was not providing any value over golog.Global()
 - Replace the global golog.Global() with our custom loggers created based on -debug and the netlogger classes. This ensures library code logs make it to the app as well.

_Note for reviewer: Nearly all changes are find and replace `rlog.Logger -> golog.Global()`. There were changes in the net_logger.go to ensure we aren't using the `golog.Global()` as it now can cause a recursive writes to the app if we have failures. Instead it uses the original logger passed to it for logging failures._