### PR TITLE
RSDK-712 - Fix log level reported to app.

### DIFF
--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -58,6 +58,7 @@ func RunServer(ctx context.Context, args []string, _ golog.Logger) (err error) {
 	} else {
 		logConfig = golog.NewProductionLoggerConfig()
 	}
+	rdkLogLevel := logConfig.Level
 	logger := zap.Must(logConfig.Build()).Sugar().Named("robot_server")
 	golog.ReplaceGloabl(logger)
 
@@ -106,7 +107,7 @@ func RunServer(ctx context.Context, args []string, _ golog.Logger) (err error) {
 	// This is to ensure we make our best effort to write logs for failures loading the remote config.
 	if cfgFromDisk.Cloud != nil && (cfgFromDisk.Cloud.LogPath != "" || cfgFromDisk.Cloud.AppAddress != "") {
 		var closer func()
-		logger, closer, err = addCloudLogger(logger, cfgFromDisk.Cloud)
+		logger, closer, err = addCloudLogger(logger, rdkLogLevel, cfgFromDisk.Cloud)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The netLogger was ignoring the level of the logger the rdk configures in the entrypoint file.

Now the netLogger uses the AtomicLevel provided by the log config to determine if a log entry should be passed to the app.

With -debug now only info+ logs will be logged to console and app.