### PR TITLE
DATA 498 add labels to geometries in RDK

### DIFF
--- a/components/camera/videosource/join_pointcloud.go
+++ b/components/camera/videosource/join_pointcloud.go
@@ -218,7 +218,7 @@ func (jpcs *joinPointCloudSource) NextPointCloudNaive(ctx context.Context) (poin
 					savedDualQuat := spatialmath.NewZeroPose()
 					pcSrc.Iterate(numLoops, loop, func(p r3.Vector, d pointcloud.Data) bool {
 						if jpcs.sourceNames[iCopy] != jpcs.targetName {
-							spatialmath.ResetPoseDQTransalation(savedDualQuat, p)
+							spatialmath.ResetPoseDQTranslation(savedDualQuat, p)
 							newPose := spatialmath.Compose(theTransform.(*referenceframe.PoseInFrame).Pose(), savedDualQuat)
 							p = newPose.Point()
 						}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -39,7 +39,7 @@ func TestConfigRobot(t *testing.T) {
 
 	// test that gripper geometry is being added correctly
 	component := cfg.FindComponent("pieceGripper")
-	bc, _ := spatialmath.NewBoxCreator(r3.Vector{1, 2, 3}, spatialmath.NewPoseFromPoint(r3.Vector{4, 5, 6}))
+	bc, _ := spatialmath.NewBoxCreator(r3.Vector{1, 2, 3}, spatialmath.NewPoseFromPoint(r3.Vector{4, 5, 6}), "")
 	test.That(t, component.Frame.Geometry, test.ShouldResemble, bc)
 }
 

--- a/config/frame_test.go
+++ b/config/frame_test.go
@@ -30,7 +30,7 @@ func TestFrame(t *testing.T) {
 	frame := Frame{}
 	err = json.Unmarshal(testMap["test"], &frame)
 	test.That(t, err, test.ShouldBeNil)
-	bc, err := spatial.NewBoxCreator(r3.Vector{1, 2, 3}, spatial.NewPoseFromPoint(r3.Vector{4, 5, 6}))
+	bc, err := spatial.NewBoxCreator(r3.Vector{1, 2, 3}, spatial.NewPoseFromPoint(r3.Vector{4, 5, 6}), "")
 	test.That(t, err, test.ShouldBeNil)
 	exp := Frame{
 		Parent:      "world",

--- a/motionplan/collision_test.go
+++ b/motionplan/collision_test.go
@@ -47,7 +47,7 @@ func TestCheckCollisions(t *testing.T) {
 	//      - a collision between two internal geometries
 	//      - a collision between an internal and external geometry
 	//      - no collision between two external geometries
-	bc1, err := spatial.NewBoxCreator(r3.Vector{2, 2, 2}, spatial.NewZeroPose())
+	bc1, err := spatial.NewBoxCreator(r3.Vector{2, 2, 2}, spatial.NewZeroPose(), "")
 	test.That(t, err, test.ShouldBeNil)
 	robot := make(map[string]spatial.Geometry)
 	robot["robotCube000"] = bc1.NewGeometry(spatial.NewZeroPose())

--- a/motionplan/constraint_test.go
+++ b/motionplan/constraint_test.go
@@ -190,7 +190,7 @@ func TestCollisionConstraint(t *testing.T) {
 	}
 
 	// define external obstacles
-	bc, err := spatial.NewBoxCreator(r3.Vector{2, 2, 2}, spatial.NewZeroPose())
+	bc, err := spatial.NewBoxCreator(r3.Vector{2, 2, 2}, spatial.NewZeroPose(), "")
 	test.That(t, err, test.ShouldBeNil)
 	obstacles := make(map[string]spatial.Geometry)
 	obstacles["obstacle1"] = bc.NewGeometry(spatial.NewZeroPose())

--- a/motionplan/dubinsRRT_test.go
+++ b/motionplan/dubinsRRT_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestDubinsRRT(t *testing.T) {
 	logger := golog.NewTestLogger(t)
-	robotGeometry, err := spatial.NewBoxCreator(r3.Vector{X: 1, Y: 1, Z: 1}, spatial.NewZeroPose())
+	robotGeometry, err := spatial.NewBoxCreator(r3.Vector{X: 1, Y: 1, Z: 1}, spatial.NewZeroPose(), "")
 	test.That(t, err, test.ShouldEqual, nil)
 	limits := []frame.Limit{{Min: -10, Max: 10}, {Min: -10, Max: 10}}
 
@@ -56,7 +56,8 @@ func TestDubinsRRT(t *testing.T) {
 	obstacleGeometries := map[string]spatial.Geometry{}
 	box, err := spatial.NewBox(spatial.NewPoseFromPoint(
 		r3.Vector{X: 5, Y: 0, Z: 0}), // Center of box
-		r3.Vector{X: 1, Y: 20, Z: 1}) // Dimensions of box
+		r3.Vector{X: 1, Y: 20, Z: 1}, // Dimensions of box
+		"")
 	test.That(t, err, test.ShouldEqual, nil)
 	obstacleGeometries["1"] = box
 	test.That(t, testDubin(obstacleGeometries), test.ShouldBeFalse)

--- a/motionplan/motionPlanner_test.go
+++ b/motionplan/motionPlanner_test.go
@@ -135,7 +135,7 @@ func TestPlanningWithGripper(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	err = fs.AddFrame(ur5e, fs.World())
 	test.That(t, err, test.ShouldBeNil)
-	bc, _ := spatial.NewBoxCreator(r3.Vector{200, 200, 200}, spatial.NewPoseFromPoint(r3.Vector{Z: 75}))
+	bc, _ := spatial.NewBoxCreator(r3.Vector{200, 200, 200}, spatial.NewPoseFromPoint(r3.Vector{Z: 75}), "")
 	gripper, err := frame.NewStaticFrameWithGeometry("gripper", spatial.NewPoseFromPoint(r3.Vector{Z: 150}), bc)
 	test.That(t, err, test.ShouldBeNil)
 	err = fs.AddFrame(gripper, ur5e)
@@ -168,7 +168,7 @@ func TestPlanningWithGripper(t *testing.T) {
 func simple2DMap() (*planConfig, error) {
 	// build model
 	limits := []frame.Limit{{Min: -100, Max: 100}, {Min: -100, Max: 100}}
-	physicalGeometry, err := spatial.NewBoxCreator(r3.Vector{X: 10, Y: 10, Z: 10}, spatial.NewZeroPose())
+	physicalGeometry, err := spatial.NewBoxCreator(r3.Vector{X: 10, Y: 10, Z: 10}, spatial.NewZeroPose(), "")
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +178,7 @@ func simple2DMap() (*planConfig, error) {
 	}
 
 	// obstacles
-	box, err := spatial.NewBox(spatial.NewPoseFromPoint(r3.Vector{0, 50, 0}), r3.Vector{80, 80, 1})
+	box, err := spatial.NewBox(spatial.NewPoseFromPoint(r3.Vector{0, 50, 0}), r3.Vector{80, 80, 1}, "")
 	if err != nil {
 		return nil, err
 	}

--- a/motionplan/solvableFrameSystem_test.go
+++ b/motionplan/solvableFrameSystem_test.go
@@ -49,7 +49,7 @@ func makeTestFS(t *testing.T) *SolvableFrameSystem {
 	fs.AddFrame(urCamera, modelUR5e)
 
 	// Add static frame for the gripper
-	bc, _ := spatial.NewBoxCreator(r3.Vector{200, 200, 200}, spatial.NewPoseFromPoint(r3.Vector{Z: 100}))
+	bc, _ := spatial.NewBoxCreator(r3.Vector{200, 200, 200}, spatial.NewPoseFromPoint(r3.Vector{Z: 100}), "")
 	xArmVgripper, err := frame.NewStaticFrameWithGeometry("xArmVgripper", spatial.NewPoseFromPoint(r3.Vector{Z: 200}), bc)
 	test.That(t, err, test.ShouldBeNil)
 	fs.AddFrame(xArmVgripper, modelXarm)
@@ -170,7 +170,7 @@ func TestMovementWithGripper(t *testing.T) {
 	test.That(t, solution, test.ShouldNotBeNil)
 
 	// plan around the obstacle with the gripper
-	obstacle, err := spatial.NewBox(spatial.NewPoseFromPoint(r3.Vector{300, 0, -400}), r3.Vector{50, 500, 500})
+	obstacle, err := spatial.NewBox(spatial.NewPoseFromPoint(r3.Vector{300, 0, -400}), r3.Vector{50, 500, 500}, "")
 	test.That(t, err, test.ShouldBeNil)
 	geometries := make(map[string]spatial.Geometry)
 	geometries["obstacle"] = obstacle

--- a/pointcloud/point.go
+++ b/pointcloud/point.go
@@ -62,7 +62,7 @@ type Data interface {
 	// Note(erd): we should try to remove this in favor of immutability.
 	SetValue(v int) Data
 
-	// Value returns the intesity value, or 0 if it doesn't exist
+	// Intensity returns the intensity value, or 0 if it doesn't exist
 	Intensity() uint16
 
 	// SetIntensity sets the intensity on the point.

--- a/pointcloud/pointcloud_utils.go
+++ b/pointcloud/pointcloud_utils.go
@@ -58,6 +58,11 @@ func MergePointCloudsWithColor(clusters []PointCloud) (PointCloud, error) {
 
 // BoundingBoxFromPointCloud returns a Geometry object that encompasses all the points in the given point cloud.
 func BoundingBoxFromPointCloud(cloud PointCloud) (spatialmath.Geometry, error) {
+	return BoundingBoxFromPointCloudWithLabel(cloud, "")
+}
+
+// BoundingBoxFromPointCloudWithLabel returns a Geometry object that encompasses all the points in the given point cloud.
+func BoundingBoxFromPointCloudWithLabel(cloud PointCloud, label string) (spatialmath.Geometry, error) {
 	if cloud.Size() == 0 {
 		return nil, nil
 	}
@@ -78,7 +83,7 @@ func BoundingBoxFromPointCloud(cloud PointCloud) (spatialmath.Geometry, error) {
 	mean := r3.Vector{x / n, y / n, z / n}
 
 	// calculate the dimensions of the bounding box formed by finding the dimensions of each axes' extrema
-	return spatialmath.NewBox(spatialmath.NewPoseFromPoint(mean), dims)
+	return spatialmath.NewBox(spatialmath.NewPoseFromPoint(mean), dims, label)
 }
 
 // PrunePointClouds removes point clouds from a slice if the point cloud has less than nMin points.

--- a/pointcloud/pointcloud_utils_test.go
+++ b/pointcloud/pointcloud_utils_test.go
@@ -49,12 +49,13 @@ func TestBoundingBoxFromPointCloud(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		expectedBox, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(c.expectedCenter), c.expectedDims)
+		expectedBox, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(c.expectedCenter), c.expectedDims, "")
 		test.That(t, err, test.ShouldBeNil)
-		box, err := BoundingBoxFromPointCloud(c.pc)
+		box, err := BoundingBoxFromPointCloudWithLabel(c.pc, "box")
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, box, test.ShouldNotBeNil)
 		test.That(t, box.AlmostEqual(expectedBox), test.ShouldBeTrue)
+		test.That(t, box.Label(), test.ShouldEqual, "box")
 	}
 }
 

--- a/referenceframe/frame_test.go
+++ b/referenceframe/frame_test.go
@@ -133,7 +133,7 @@ func TestMobile2DFrame(t *testing.T) {
 }
 
 func TestGeometries(t *testing.T) {
-	bc, err := spatial.NewBoxCreator(r3.Vector{1, 1, 1}, spatial.NewZeroPose())
+	bc, err := spatial.NewBoxCreator(r3.Vector{1, 1, 1}, spatial.NewZeroPose(), "")
 	test.That(t, err, test.ShouldBeNil)
 	pose := spatial.NewPoseFromPoint(r3.Vector{0, 10, 0})
 	expectedBox := bc.NewGeometry(pose)

--- a/referenceframe/model_test.go
+++ b/referenceframe/model_test.go
@@ -86,7 +86,7 @@ func TestIncorrectInputs(t *testing.T) {
 func TestModelGeometries(t *testing.T) {
 	// build a test model
 	offset := spatial.NewPoseFromPoint(r3.Vector{0, 0, 10})
-	bc, err := spatial.NewBoxCreator(r3.Vector{1, 1, 1}, offset)
+	bc, err := spatial.NewBoxCreator(r3.Vector{1, 1, 1}, offset, "")
 	test.That(t, err, test.ShouldBeNil)
 	// m, err := ParseModelJSONFile(utils.ResolveFile("referenceframe/model_test.json"), "")
 	frame1, err := NewStaticFrameWithGeometry("link1", offset, bc)

--- a/referenceframe/static_frame_system_test.go
+++ b/referenceframe/static_frame_system_test.go
@@ -241,7 +241,7 @@ func TestGeomtriesTransform(t *testing.T) {
 	err = fs.AddFrame(f2, fs.World())
 	test.That(t, err, test.ShouldBeNil)
 	objectFromFrame1 := spatial.NewPoseFromPoint(r3.Vector{5, 0, 0})
-	gc, err := spatial.NewBoxCreator(r3.Vector{2, 2, 2}, objectFromFrame1)
+	gc, err := spatial.NewBoxCreator(r3.Vector{2, 2, 2}, objectFromFrame1, "")
 	test.That(t, err, test.ShouldBeNil)
 	// it shouldn't matter where the transformation of the frame associated with the object is if we are just looking at its geometry
 	object, err := NewStaticFrameWithGeometry("object", spatial.NewPoseFromPoint(r3.Vector{1000, 1000, 1000}), gc)

--- a/referenceframe/transformable_test.go
+++ b/referenceframe/transformable_test.go
@@ -22,7 +22,7 @@ func TestPoseInFrame(t *testing.T) {
 
 func TestGeometriesInFrame(t *testing.T) {
 	pose := spatial.NewPoseFromOrientation(r3.Vector{1, 2, 3}, &spatial.OrientationVector{math.Pi / 2, 0, 0, -1})
-	geometry, err := spatial.NewBox(pose, r3.Vector{4, 5, 6})
+	geometry, err := spatial.NewBox(pose, r3.Vector{4, 5, 6}, "")
 	geometryMap := make(map[string]spatial.Geometry)
 	geometryMap[""] = geometry
 	test.That(t, err, test.ShouldBeNil)

--- a/services/vision/builtin/helpers_test.go
+++ b/services/vision/builtin/helpers_test.go
@@ -100,9 +100,9 @@ func buildRobotWithFakeCamera(t *testing.T) (robot.Robot, error) {
 		Name: "detect_red",
 		Type: string(builtin.ColorDetector),
 		Parameters: config.AttributeMap{
-			"detect_color":  "#C9131F", // look for red
+			"detect_color":      "#C9131F", // look for red
 			"hue_tolerance_pct": 0.05,
-			"segment_size_px":  1000,
+			"segment_size_px":   1000,
 		},
 	}
 	err = srv.AddDetector(context.Background(), detConf)
@@ -123,9 +123,9 @@ var testPointCloud = []r3.Vector{
 
 func makeExpectedBoxes(t *testing.T) []spatialmath.Geometry {
 	t.Helper()
-	box1, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{X: -5, Y: -5, Z: 5}), r3.Vector{X: 0, Y: 0, Z: 2})
+	box1, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{X: -5, Y: -5, Z: 5}), r3.Vector{X: 0, Y: 0, Z: 2}, "")
 	test.That(t, err, test.ShouldBeNil)
-	box2, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{X: 5, Y: 5, Z: 5}), r3.Vector{X: 0, Y: 0, Z: 2})
+	box2, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{X: 5, Y: 5, Z: 5}), r3.Vector{X: 0, Y: 0, Z: 2}, "")
 	test.That(t, err, test.ShouldBeNil)
 	return []spatialmath.Geometry{box1, box2}
 }

--- a/services/vision/helpers_test.go
+++ b/services/vision/helpers_test.go
@@ -124,9 +124,9 @@ var testPointCloud = []r3.Vector{
 
 func makeExpectedBoxes(t *testing.T) []spatialmath.Geometry {
 	t.Helper()
-	box1, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{X: -5, Y: -5, Z: 5}), r3.Vector{X: 0, Y: 0, Z: 2})
+	box1, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{X: -5, Y: -5, Z: 5}), r3.Vector{X: 0, Y: 0, Z: 2}, "")
 	test.That(t, err, test.ShouldBeNil)
-	box2, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{X: 5, Y: 5, Z: 5}), r3.Vector{X: 0, Y: 0, Z: 2})
+	box2, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{X: 5, Y: 5, Z: 5}), r3.Vector{X: 0, Y: 0, Z: 2}, "")
 	test.That(t, err, test.ShouldBeNil)
 	return []spatialmath.Geometry{box1, box2}
 }

--- a/spatialmath/box_test.go
+++ b/spatialmath/box_test.go
@@ -8,8 +8,8 @@ import (
 	"go.viam.com/test"
 )
 
-func makeTestBox(o Orientation, point, dims r3.Vector) Geometry {
-	box, _ := NewBox(NewPoseFromOrientation(point, o), dims)
+func makeTestBox(o Orientation, point, dims r3.Vector, label string) Geometry {
+	box, _ := NewBox(NewPoseFromOrientation(point, o), dims, label)
 	return box
 }
 
@@ -17,30 +17,30 @@ func TestNewBox(t *testing.T) {
 	offset := NewPoseFromOrientation(r3.Vector{X: 1, Y: 0, Z: 0}, &EulerAngles{0, 0, math.Pi})
 
 	// test box created from NewBox method
-	geometry, err := NewBox(offset, r3.Vector{1, 1, 1})
+	geometry, err := NewBox(offset, r3.Vector{1, 1, 1}, "")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, geometry, test.ShouldResemble, &box{pose: offset, halfSize: [3]float64{0.5, 0.5, 0.5}})
-	_, err = NewBox(offset, r3.Vector{-1, 0, 0})
+	_, err = NewBox(offset, r3.Vector{-1, 0, 0}, "")
 	test.That(t, err.Error(), test.ShouldContainSubstring, newBadGeometryDimensionsError(&box{}).Error())
 
 	// test box created from GeometryCreator with offset
-	gc, err := NewBoxCreator(r3.Vector{1, 1, 1}, offset)
+	gc, err := NewBoxCreator(r3.Vector{1, 1, 1}, offset, "")
 	test.That(t, err, test.ShouldBeNil)
 	geometry = gc.NewGeometry(PoseInverse(offset))
 	test.That(t, PoseAlmostCoincident(geometry.Pose(), NewZeroPose()), test.ShouldBeTrue)
 }
 
 func TestBoxAlmostEqual(t *testing.T) {
-	original := makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{1, 1, 1})
-	good := makeTestBox(NewZeroOrientation(), r3.Vector{1e-16, 1e-16, 1e-16}, r3.Vector{1 + 1e-16, 1 + 1e-16, 1 + 1e-16})
-	bad := makeTestBox(NewZeroOrientation(), r3.Vector{1e-2, 1e-2, 1e-2}, r3.Vector{1 + 1e-2, 1 + 1e-2, 1 + 1e-2})
+	original := makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{1, 1, 1}, "")
+	good := makeTestBox(NewZeroOrientation(), r3.Vector{1e-16, 1e-16, 1e-16}, r3.Vector{1 + 1e-16, 1 + 1e-16, 1 + 1e-16}, "")
+	bad := makeTestBox(NewZeroOrientation(), r3.Vector{1e-2, 1e-2, 1e-2}, r3.Vector{1 + 1e-2, 1 + 1e-2, 1 + 1e-2}, "")
 	test.That(t, original.AlmostEqual(good), test.ShouldBeTrue)
 	test.That(t, original.AlmostEqual(bad), test.ShouldBeFalse)
 }
 
 func TestBoxVertices(t *testing.T) {
 	offset := r3.Vector{2, 2, 2}
-	box := makeTestBox(NewZeroOrientation(), offset, r3.Vector{2, 2, 2})
+	box := makeTestBox(NewZeroOrientation(), offset, r3.Vector{2, 2, 2}, "")
 	vertices := box.Vertices()
 	test.That(t, R3VectorAlmostEqual(vertices[0], r3.Vector{1, 1, 1}.Add(offset), 1e-8), test.ShouldBeTrue)
 	test.That(t, R3VectorAlmostEqual(vertices[1], r3.Vector{1, 1, -1}.Add(offset), 1e-8), test.ShouldBeTrue)

--- a/spatialmath/geometry_test.go
+++ b/spatialmath/geometry_test.go
@@ -23,7 +23,11 @@ func TestGeometrySerialization(t *testing.T) {
 		config  GeometryConfig
 		success bool
 	}{
-		{"box", GeometryConfig{Type: "box", X: 1, Y: 1, Z: 1, TranslationOffset: translation, OrientationOffset: orientation, Label: "box"}, true},
+		{
+			"box",
+			GeometryConfig{Type: "box", X: 1, Y: 1, Z: 1, TranslationOffset: translation, OrientationOffset: orientation, Label: "box"},
+			true,
+		},
 		{"box bad dims", GeometryConfig{Type: "box", X: 1, Y: 0, Z: 1}, false},
 		{"infer box", GeometryConfig{X: 1, Y: 1, Z: 1, Label: "infer box"}, true},
 		{"sphere", GeometryConfig{Type: "sphere", R: 1, TranslationOffset: translation, OrientationOffset: orientation, Label: "sphere"}, true},

--- a/spatialmath/geometry_test.go
+++ b/spatialmath/geometry_test.go
@@ -23,13 +23,13 @@ func TestGeometrySerialization(t *testing.T) {
 		config  GeometryConfig
 		success bool
 	}{
-		{"box", GeometryConfig{Type: "box", X: 1, Y: 1, Z: 1, TranslationOffset: translation, OrientationOffset: orientation}, true},
+		{"box", GeometryConfig{Type: "box", X: 1, Y: 1, Z: 1, TranslationOffset: translation, OrientationOffset: orientation, Label: "box"}, true},
 		{"box bad dims", GeometryConfig{Type: "box", X: 1, Y: 0, Z: 1}, false},
-		{"infer box", GeometryConfig{X: 1, Y: 1, Z: 1}, true},
-		{"sphere", GeometryConfig{Type: "sphere", R: 1, TranslationOffset: translation, OrientationOffset: orientation}, true},
+		{"infer box", GeometryConfig{X: 1, Y: 1, Z: 1, Label: "infer box"}, true},
+		{"sphere", GeometryConfig{Type: "sphere", R: 1, TranslationOffset: translation, OrientationOffset: orientation, Label: "sphere"}, true},
 		{"sphere bad dims", GeometryConfig{Type: "sphere", R: -1}, false},
-		{"infer sphere", GeometryConfig{R: 1, OrientationOffset: orientation}, true},
-		{"point", GeometryConfig{Type: "point", TranslationOffset: translation, OrientationOffset: orientation}, true},
+		{"infer sphere", GeometryConfig{R: 1, OrientationOffset: orientation, Label: "infer sphere"}, true},
+		{"point", GeometryConfig{Type: "point", TranslationOffset: translation, OrientationOffset: orientation, Label: "point"}, true},
 		{"infer point", GeometryConfig{}, false},
 		{"bad type", GeometryConfig{Type: "bad"}, false},
 	}
@@ -51,6 +51,7 @@ func TestGeometrySerialization(t *testing.T) {
 			newVc, err := config.ParseConfig()
 			test.That(t, err, test.ShouldBeNil)
 			test.That(t, gc.NewGeometry(pose).AlmostEqual(newVc.NewGeometry(pose)), test.ShouldBeTrue)
+			test.That(t, config.Label, test.ShouldEqual, testCase.name)
 		})
 	}
 }
@@ -61,15 +62,16 @@ func TestGeometryToFromProtobuf(t *testing.T) {
 		name     string
 		geometry Geometry
 	}{
-		{"box", makeTestBox(&EulerAngles{0, 0, deg45}, r3.Vector{0, 0, 0}, r3.Vector{2, 2, 2})},
-		{"sphere", makeTestSphere(r3.Vector{3, 4, 5}, 10)},
-		{"point", NewPoint(r3.Vector{3, 4, 5})},
+		{"box", makeTestBox(&EulerAngles{0, 0, deg45}, r3.Vector{0, 0, 0}, r3.Vector{2, 2, 2}, "box")},
+		{"sphere", makeTestSphere(r3.Vector{3, 4, 5}, 10, "sphere")},
+		{"point", NewPoint(r3.Vector{3, 4, 5}, "point")},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			newVol, err := NewGeometryFromProto(testCase.geometry.ToProtobuf())
 			test.That(t, err, test.ShouldBeNil)
 			test.That(t, testCase.geometry.AlmostEqual(newVol), test.ShouldBeTrue)
+			test.That(t, testCase.geometry.Label(), test.ShouldEqual, testCase.name)
 		})
 	}
 
@@ -112,120 +114,120 @@ func TestBoxVsBoxCollision(t *testing.T) {
 		{
 			"inscribed",
 			[2]Geometry{
-				makeTestBox(NewZeroOrientation(), r3.Vector{0, 0, 0}, r3.Vector{2, 2, 2}),
-				makeTestBox(NewZeroOrientation(), r3.Vector{0, 0, 0}, r3.Vector{1, 1, 1}),
+				makeTestBox(NewZeroOrientation(), r3.Vector{0, 0, 0}, r3.Vector{2, 2, 2}, ""),
+				makeTestBox(NewZeroOrientation(), r3.Vector{0, 0, 0}, r3.Vector{1, 1, 1}, ""),
 			},
 			-1.5,
 		},
 		{
 			"face to face contact",
 			[2]Geometry{
-				makeTestBox(NewZeroOrientation(), r3.Vector{0, 0, 0}, r3.Vector{2, 2, 2}),
-				makeTestBox(NewZeroOrientation(), r3.Vector{2, 0, 0}, r3.Vector{2, 2, 2}),
+				makeTestBox(NewZeroOrientation(), r3.Vector{0, 0, 0}, r3.Vector{2, 2, 2}, ""),
+				makeTestBox(NewZeroOrientation(), r3.Vector{2, 0, 0}, r3.Vector{2, 2, 2}, ""),
 			},
 			0,
 		},
 		{
 			"face to face near contact",
 			[2]Geometry{
-				makeTestBox(NewZeroOrientation(), r3.Vector{0, 0, 0}, r3.Vector{2, 2, 2}),
-				makeTestBox(NewZeroOrientation(), r3.Vector{2.01, 0, 0}, r3.Vector{2, 2, 2}),
+				makeTestBox(NewZeroOrientation(), r3.Vector{0, 0, 0}, r3.Vector{2, 2, 2}, ""),
+				makeTestBox(NewZeroOrientation(), r3.Vector{2.01, 0, 0}, r3.Vector{2, 2, 2}, ""),
 			},
 			0.01,
 		},
 		{
 			"coincident edge contact",
 			[2]Geometry{
-				makeTestBox(NewZeroOrientation(), r3.Vector{0, 0, 0}, r3.Vector{2, 2, 2}),
-				makeTestBox(NewZeroOrientation(), r3.Vector{2, 4, 0}, r3.Vector{2, 6, 2}),
+				makeTestBox(NewZeroOrientation(), r3.Vector{0, 0, 0}, r3.Vector{2, 2, 2}, ""),
+				makeTestBox(NewZeroOrientation(), r3.Vector{2, 4, 0}, r3.Vector{2, 6, 2}, ""),
 			},
 			0,
 		},
 		{
 			"coincident edges near contact",
 			[2]Geometry{
-				makeTestBox((NewZeroOrientation()), r3.Vector{0, 0, 0}, r3.Vector{2, 2, 2}),
-				makeTestBox(NewZeroOrientation(), r3.Vector{2, 4.01, 0}, r3.Vector{2, 6, 2}),
+				makeTestBox((NewZeroOrientation()), r3.Vector{0, 0, 0}, r3.Vector{2, 2, 2}, ""),
+				makeTestBox(NewZeroOrientation(), r3.Vector{2, 4.01, 0}, r3.Vector{2, 6, 2}, ""),
 			},
 			0.01,
 		},
 		{
 			"vertex to vertex contact",
 			[2]Geometry{
-				makeTestBox(NewZeroOrientation(), r3.Vector{0, 0, 0}, r3.Vector{2, 2, 2}),
-				makeTestBox(NewZeroOrientation(), r3.Vector{2, 2, 2}, r3.Vector{2, 2, 2}),
+				makeTestBox(NewZeroOrientation(), r3.Vector{0, 0, 0}, r3.Vector{2, 2, 2}, ""),
+				makeTestBox(NewZeroOrientation(), r3.Vector{2, 2, 2}, r3.Vector{2, 2, 2}, ""),
 			},
 			0,
 		},
 		{
 			"vertex to vertex near contact",
 			[2]Geometry{
-				makeTestBox(NewZeroOrientation(), r3.Vector{0, 0, 0}, r3.Vector{2, 2, 2}),
-				makeTestBox(NewZeroOrientation(), r3.Vector{2.01, 2, 2}, r3.Vector{2, 2, 2}),
+				makeTestBox(NewZeroOrientation(), r3.Vector{0, 0, 0}, r3.Vector{2, 2, 2}, ""),
+				makeTestBox(NewZeroOrientation(), r3.Vector{2.01, 2, 2}, r3.Vector{2, 2, 2}, ""),
 			},
 			0.01,
 		},
 		{
 			"edge along face contact",
 			[2]Geometry{
-				makeTestBox(&EulerAngles{deg45, 0, 0}, r3.Vector{0, 0, 0}, r3.Vector{2, 2, 2}),
-				makeTestBox(NewZeroOrientation(), r3.Vector{0, 1 + math.Sqrt2, 0}, r3.Vector{2, 2, 2}),
+				makeTestBox(&EulerAngles{deg45, 0, 0}, r3.Vector{0, 0, 0}, r3.Vector{2, 2, 2}, ""),
+				makeTestBox(NewZeroOrientation(), r3.Vector{0, 1 + math.Sqrt2, 0}, r3.Vector{2, 2, 2}, ""),
 			},
 			0,
 		},
 		{
 			"edge along face near contact",
 			[2]Geometry{
-				makeTestBox(&EulerAngles{deg45, 0, 0}, r3.Vector{0, 0, 0}, r3.Vector{2, 2, 2}),
-				makeTestBox(NewZeroOrientation(), r3.Vector{0, 1.01 + math.Sqrt2, 0}, r3.Vector{2, 2, 2}),
+				makeTestBox(&EulerAngles{deg45, 0, 0}, r3.Vector{0, 0, 0}, r3.Vector{2, 2, 2}, ""),
+				makeTestBox(NewZeroOrientation(), r3.Vector{0, 1.01 + math.Sqrt2, 0}, r3.Vector{2, 2, 2}, ""),
 			},
 			0.01,
 		},
 		{
 			"edge to edge contact",
 			[2]Geometry{
-				makeTestBox(&EulerAngles{0, 0, deg45}, r3.Vector{0, 0, 0}, r3.Vector{2, 2, 2}),
-				makeTestBox(&EulerAngles{0, deg45, 0}, r3.Vector{2 * math.Sqrt2, 0, 0}, r3.Vector{2, 2, 2}),
+				makeTestBox(&EulerAngles{0, 0, deg45}, r3.Vector{0, 0, 0}, r3.Vector{2, 2, 2}, ""),
+				makeTestBox(&EulerAngles{0, deg45, 0}, r3.Vector{2 * math.Sqrt2, 0, 0}, r3.Vector{2, 2, 2}, ""),
 			},
 			0,
 		},
 		{
 			"edge to edge near contact",
 			[2]Geometry{
-				makeTestBox(&EulerAngles{0, 0, deg45}, r3.Vector{-.01, 0, 0}, r3.Vector{2, 2, 2}),
-				makeTestBox(&EulerAngles{0, deg45, 0}, r3.Vector{2 * math.Sqrt2, 0, 0}, r3.Vector{2, 2, 2}),
+				makeTestBox(&EulerAngles{0, 0, deg45}, r3.Vector{-.01, 0, 0}, r3.Vector{2, 2, 2}, ""),
+				makeTestBox(&EulerAngles{0, deg45, 0}, r3.Vector{2 * math.Sqrt2, 0, 0}, r3.Vector{2, 2, 2}, ""),
 			},
 			0.01,
 		},
 		{
 			"vertex to face contact",
 			[2]Geometry{
-				makeTestBox(&EulerAngles{deg45, deg45, 0}, r3.Vector{0.5, -.5, 0}, r3.Vector{2, 2, 2}),
-				makeTestBox(&EulerAngles{0, 0, 0}, r3.Vector{0, 0, 0.97 + math.Sqrt(3)}, r3.Vector{2, 2, 2}),
+				makeTestBox(&EulerAngles{deg45, deg45, 0}, r3.Vector{0.5, -.5, 0}, r3.Vector{2, 2, 2}, ""),
+				makeTestBox(&EulerAngles{0, 0, 0}, r3.Vector{0, 0, 0.97 + math.Sqrt(3)}, r3.Vector{2, 2, 2}, ""),
 			},
 			-.005,
 		},
 		{
 			"vertex to face near contact",
 			[2]Geometry{
-				makeTestBox(&EulerAngles{deg45, deg45, 0}, r3.Vector{0, 0, -0.01}, r3.Vector{2, 2, 2}),
-				makeTestBox(&EulerAngles{0, 0, 0}, r3.Vector{0, 0, 0.97 + math.Sqrt(3)}, r3.Vector{2, 2, 2}),
+				makeTestBox(&EulerAngles{deg45, deg45, 0}, r3.Vector{0, 0, -0.01}, r3.Vector{2, 2, 2}, ""),
+				makeTestBox(&EulerAngles{0, 0, 0}, r3.Vector{0, 0, 0.97 + math.Sqrt(3)}, r3.Vector{2, 2, 2}, ""),
 			},
 			0.005,
 		},
 		{
 			"separated axis aligned",
 			[2]Geometry{
-				makeTestBox(NewZeroOrientation(), r3.Vector{0, 0, 0}, r3.Vector{2, 2, 2}),
-				makeTestBox(NewZeroOrientation(), r3.Vector{5, 6, 0}, r3.Vector{2, 2, 2}),
+				makeTestBox(NewZeroOrientation(), r3.Vector{0, 0, 0}, r3.Vector{2, 2, 2}, ""),
+				makeTestBox(NewZeroOrientation(), r3.Vector{5, 6, 0}, r3.Vector{2, 2, 2}, ""),
 			},
 			4, // upper bound on separation distance
 		},
 		{
 			"axis aligned overlap",
 			[2]Geometry{
-				makeTestBox(NewZeroOrientation(), r3.Vector{0, 0, 0}, r3.Vector{20, 20, 20}),
-				makeTestBox(NewZeroOrientation(), r3.Vector{20, 20, 20}, r3.Vector{24, 26, 28}),
+				makeTestBox(NewZeroOrientation(), r3.Vector{0, 0, 0}, r3.Vector{20, 20, 20}, ""),
+				makeTestBox(NewZeroOrientation(), r3.Vector{20, 20, 20}, r3.Vector{24, 26, 28}, ""),
 			},
 			-2,
 		},
@@ -237,17 +239,17 @@ func TestSphereVsSphereCollision(t *testing.T) {
 	cases := []geometryComparisonTestCase{
 		{
 			"test inscribed spheres",
-			[2]Geometry{makeTestSphere(r3.Vector{}, 1), makeTestSphere(r3.Vector{}, 2)},
+			[2]Geometry{makeTestSphere(r3.Vector{}, 1, ""), makeTestSphere(r3.Vector{}, 2, "")},
 			-3,
 		},
 		{
 			"test tangent spheres",
-			[2]Geometry{makeTestSphere(r3.Vector{}, 1), makeTestSphere(r3.Vector{0, 0, 2}, 1)},
+			[2]Geometry{makeTestSphere(r3.Vector{}, 1, ""), makeTestSphere(r3.Vector{0, 0, 2}, 1, "")},
 			0,
 		},
 		{
 			"separated spheres",
-			[2]Geometry{makeTestSphere(r3.Vector{}, 1), makeTestSphere(r3.Vector{0, 0, 2 + 1e-3}, 1)},
+			[2]Geometry{makeTestSphere(r3.Vector{}, 1, ""), makeTestSphere(r3.Vector{0, 0, 2 + 1e-3}, 1, "")},
 			1e-3,
 		},
 	}
@@ -258,12 +260,12 @@ func TestPointVsPointCollision(t *testing.T) {
 	cases := []geometryComparisonTestCase{
 		{
 			"coincident",
-			[2]Geometry{NewPoint(r3.Vector{}), NewPoint(r3.Vector{})},
+			[2]Geometry{NewPoint(r3.Vector{}, ""), NewPoint(r3.Vector{}, "")},
 			0,
 		},
 		{
 			"separated",
-			[2]Geometry{NewPoint(r3.Vector{}), NewPoint(r3.Vector{1, 0, 0})},
+			[2]Geometry{NewPoint(r3.Vector{}, ""), NewPoint(r3.Vector{1, 0, 0}, "")},
 			1,
 		},
 	}
@@ -275,64 +277,64 @@ func TestSphereVsBoxCollision(t *testing.T) {
 		{
 			"separated face closest",
 			[2]Geometry{
-				makeTestSphere(r3.Vector{0, 0, 2 + 1e-3}, 1),
-				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{2, 2, 2}),
+				makeTestSphere(r3.Vector{0, 0, 2 + 1e-3}, 1, ""),
+				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{2, 2, 2}, ""),
 			},
 			1e-3,
 		},
 		{
 			"separated edge closest",
 			[2]Geometry{
-				makeTestSphere(r3.Vector{0, 2, 2}, 1),
-				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{2, 2, 2}),
+				makeTestSphere(r3.Vector{0, 2, 2}, 1, ""),
+				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{2, 2, 2}, ""),
 			},
 			math.Sqrt2 - 1,
 		},
 		{
 			"separated vertex closest",
 			[2]Geometry{
-				makeTestSphere(r3.Vector{2, 2, 2}, 1),
-				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{2, 2, 2}),
+				makeTestSphere(r3.Vector{2, 2, 2}, 1, ""),
+				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{2, 2, 2}, ""),
 			},
 			math.Sqrt(3) - 1,
 		},
 		{
 			"face tangent",
 			[2]Geometry{
-				makeTestSphere(r3.Vector{0, 0, 2}, 1),
-				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{2, 2, 2}),
+				makeTestSphere(r3.Vector{0, 0, 2}, 1, ""),
+				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{2, 2, 2}, ""),
 			},
 			0,
 		},
 		{
 			"edge tangent",
 			[2]Geometry{
-				makeTestSphere(r3.Vector{0, 2, 2}, math.Sqrt2),
-				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{2, 2, 2}),
+				makeTestSphere(r3.Vector{0, 2, 2}, math.Sqrt2, ""),
+				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{2, 2, 2}, ""),
 			},
 			0,
 		},
 		{
 			"vertex tangent",
 			[2]Geometry{
-				makeTestSphere(r3.Vector{2, 2, 2}, math.Sqrt(3)),
-				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{2, 2, 2}),
+				makeTestSphere(r3.Vector{2, 2, 2}, math.Sqrt(3), ""),
+				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{2, 2, 2}, ""),
 			},
 			0,
 		},
 		{
 			"center point inside",
 			[2]Geometry{
-				makeTestSphere(r3.Vector{-.2, 0.1, .75}, 1),
-				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{2, 2, 2}),
+				makeTestSphere(r3.Vector{-.2, 0.1, .75}, 1, ""),
+				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{2, 2, 2}, ""),
 			},
 			-1.25,
 		},
 		{
 			"inscribed",
 			[2]Geometry{
-				makeTestSphere(r3.Vector{2, 2, 2}, 1),
-				makeTestBox(NewZeroOrientation(), r3.Vector{2, 2, 2}, r3.Vector{2, 2, 2}),
+				makeTestSphere(r3.Vector{2, 2, 2}, 1, ""),
+				makeTestBox(NewZeroOrientation(), r3.Vector{2, 2, 2}, r3.Vector{2, 2, 2}, ""),
 			},
 			-2,
 		},
@@ -345,32 +347,32 @@ func TestPointVsBoxCollision(t *testing.T) {
 		{
 			"separated face closest",
 			[2]Geometry{
-				NewPoint(r3.Vector{2, 0, 0}),
-				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{2, 2, 2}),
+				NewPoint(r3.Vector{2, 0, 0}, ""),
+				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{2, 2, 2}, ""),
 			},
 			1,
 		},
 		{
 			"separated edge closest",
 			[2]Geometry{
-				NewPoint(r3.Vector{2, 2, 0}),
-				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{2, 2, 2}),
+				NewPoint(r3.Vector{2, 2, 0}, ""),
+				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{2, 2, 2}, ""),
 			},
 			math.Sqrt2,
 		},
 		{
 			"separated vertex closest",
 			[2]Geometry{
-				NewPoint(r3.Vector{2, 2, 2}),
-				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{2, 2, 2}),
+				NewPoint(r3.Vector{2, 2, 2}, ""),
+				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{2, 2, 2}, ""),
 			},
 			math.Sqrt(3),
 		},
 		{
 			"inside",
 			[2]Geometry{
-				NewPoint(r3.Vector{0, 0.3, 0.5}),
-				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{2, 2, 2}),
+				NewPoint(r3.Vector{0, 0.3, 0.5}, ""),
+				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{2, 2, 2}, ""),
 			},
 			-0.5,
 		},
@@ -383,16 +385,16 @@ func TestPointVsSphereCollision(t *testing.T) {
 		{
 			"coincident",
 			[2]Geometry{
-				NewPoint(r3.Vector{}),
-				makeTestSphere(r3.Vector{}, 1),
+				NewPoint(r3.Vector{}, ""),
+				makeTestSphere(r3.Vector{}, 1, ""),
 			},
 			-1,
 		},
 		{
 			"separated",
 			[2]Geometry{
-				NewPoint(r3.Vector{2, 0, 0}),
-				makeTestSphere(r3.Vector{}, 1),
+				NewPoint(r3.Vector{2, 0, 0}, ""),
+				makeTestSphere(r3.Vector{}, 1, ""),
 			},
 			1,
 		},
@@ -420,16 +422,16 @@ func TestBoxVsBoxEncompassed(t *testing.T) {
 		{
 			"encompassed",
 			[2]Geometry{
-				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{2, 2, 2}),
-				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{2, 2, 2}),
+				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{2, 2, 2}, ""),
+				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{2, 2, 2}, ""),
 			},
 			0,
 		},
 		{
 			"not encompassed",
 			[2]Geometry{
-				makeTestBox(NewZeroOrientation(), r3.Vector{0, 1, 0}, r3.Vector{2, 3, 2}),
-				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{2, 2, 2}),
+				makeTestBox(NewZeroOrientation(), r3.Vector{0, 1, 0}, r3.Vector{2, 3, 2}, ""),
+				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{2, 2, 2}, ""),
 			},
 			1,
 		},
@@ -442,16 +444,16 @@ func TestBoxVsSphereEncompassed(t *testing.T) {
 		{
 			"encompassed",
 			[2]Geometry{
-				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{2, 2, 2}),
-				makeTestSphere(r3.Vector{}, math.Sqrt(3)),
+				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{2, 2, 2}, ""),
+				makeTestSphere(r3.Vector{}, math.Sqrt(3), ""),
 			},
 			0,
 		},
 		{
 			"not encompassed",
 			[2]Geometry{
-				makeTestBox(NewZeroOrientation(), r3.Vector{0, 1, 0}, r3.Vector{2, 2.1, 2}),
-				makeTestSphere(r3.Vector{}, math.Sqrt(3)),
+				makeTestBox(NewZeroOrientation(), r3.Vector{0, 1, 0}, r3.Vector{2, 2.1, 2}, ""),
+				makeTestSphere(r3.Vector{}, math.Sqrt(3), ""),
 			},
 			.1,
 		},
@@ -463,7 +465,7 @@ func TestBoxVsPointEncompassed(t *testing.T) {
 	cases := []geometryComparisonTestCase{
 		{
 			"coincident",
-			[2]Geometry{makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{1, 1, 1}), NewPoint(r3.Vector{})},
+			[2]Geometry{makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{1, 1, 1}, ""), NewPoint(r3.Vector{}, "")},
 			math.Sqrt(3),
 		},
 	}
@@ -475,16 +477,16 @@ func TestSphereVsBoxEncompassed(t *testing.T) {
 		{
 			"encompassed",
 			[2]Geometry{
-				makeTestSphere(r3.Vector{3, 0, 0}, 1),
-				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{8, 8, 8}),
+				makeTestSphere(r3.Vector{3, 0, 0}, 1, ""),
+				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{8, 8, 8}, ""),
 			},
 			0,
 		},
 		{
 			"not encompassed",
 			[2]Geometry{
-				makeTestSphere(r3.Vector{3.5, 0, 0}, 1),
-				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{8, 8, 8}),
+				makeTestSphere(r3.Vector{3.5, 0, 0}, 1, ""),
+				makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{8, 8, 8}, ""),
 			},
 			0.5,
 		},
@@ -497,16 +499,16 @@ func TestSphereVsSphereEncompassed(t *testing.T) {
 		{
 			"encompassed",
 			[2]Geometry{
-				makeTestSphere(r3.Vector{3, 0, 0}, 1),
-				makeTestSphere(r3.Vector{}, 4),
+				makeTestSphere(r3.Vector{3, 0, 0}, 1, ""),
+				makeTestSphere(r3.Vector{}, 4, ""),
 			},
 			0,
 		},
 		{
 			"not encompassed",
 			[2]Geometry{
-				makeTestSphere(r3.Vector{3, 0, 0}, 1),
-				makeTestSphere(r3.Vector{}, 3.5),
+				makeTestSphere(r3.Vector{3, 0, 0}, 1, ""),
+				makeTestSphere(r3.Vector{}, 3.5, ""),
 			},
 			0.5,
 		},
@@ -518,7 +520,7 @@ func TestSphereVsPointEncompassed(t *testing.T) {
 	cases := []geometryComparisonTestCase{
 		{
 			"coincident",
-			[2]Geometry{makeTestSphere(r3.Vector{}, 1), NewPoint(r3.Vector{})},
+			[2]Geometry{makeTestSphere(r3.Vector{}, 1, ""), NewPoint(r3.Vector{}, "")},
 			1,
 		},
 	}

--- a/spatialmath/orientation.go
+++ b/spatialmath/orientation.go
@@ -15,7 +15,7 @@ type Orientation interface {
 	RotationMatrix() *RotationMatrix
 }
 
-// NewZeroOrientation returns an orientatation which signifies no rotation.
+// NewZeroOrientation returns an orientation which signifies no rotation.
 func NewZeroOrientation() Orientation {
 	return &Quaternion{1, 0, 0, 0}
 }

--- a/spatialmath/point.go
+++ b/spatialmath/point.go
@@ -11,22 +11,24 @@ import (
 // PointCreator implements the GeometryCreator interface for point structs.
 type pointCreator struct {
 	offset Pose
+	label  string
 }
 
 // point is a collision geometry that represents a single point in 3D space that occupies no geometry.
 type point struct {
-	pose Pose
+	pose  Pose
+	label string
 }
 
 // NewPointCreator instantiates a PointCreator class, which allows instantiating point geometries given only a pose which is applied
 // at the specified offset from the pose. These pointers have dimensions given by the provided halfSize vector.
-func NewPointCreator(offset Pose) GeometryCreator {
-	return &pointCreator{offset}
+func NewPointCreator(offset Pose, label string) GeometryCreator {
+	return &pointCreator{offset, label}
 }
 
 // NewGeometry instantiates a new point from a PointCreator class.
 func (pc *pointCreator) NewGeometry(pose Pose) Geometry {
-	return &point{Compose(pc.offset, pose)}
+	return &point{Compose(pc.offset, pose), pc.label}
 }
 
 func (pc *pointCreator) Offset() Pose {
@@ -42,8 +44,13 @@ func (pc *pointCreator) MarshalJSON() ([]byte, error) {
 }
 
 // NewPoint instantiates a new point Geometry.
-func NewPoint(pt r3.Vector) Geometry {
-	return &point{NewPoseFromPoint(pt)}
+func NewPoint(pt r3.Vector, label string) Geometry {
+	return &point{NewPoseFromPoint(pt), label}
+}
+
+// Label returns the labels of the point.
+func (pt *point) Label() string {
+	return pt.label
 }
 
 // Pose returns the pose of the point.
@@ -67,7 +74,7 @@ func (pt *point) AlmostEqual(g Geometry) bool {
 
 // Transform premultiplies the point pose with a transform, allowing the point to be moved in space.
 func (pt *point) Transform(toPremultiply Pose) Geometry {
-	return &point{Compose(toPremultiply, pt.pose)}
+	return &point{Compose(toPremultiply, pt.pose), pt.label}
 }
 
 // ToProto converts the point to a Geometry proto message.

--- a/spatialmath/point_test.go
+++ b/spatialmath/point_test.go
@@ -12,23 +12,23 @@ func TestNewPoint(t *testing.T) {
 	offset := NewPoseFromOrientation(r3.Vector{X: 1, Y: 0, Z: 0}, &EulerAngles{0, 0, math.Pi})
 
 	// test sphere created from NewBox method
-	geometry := NewPoint(offset.Point())
-	test.That(t, geometry, test.ShouldResemble, &point{NewPoseFromPoint(offset.Point())})
+	geometry := NewPoint(offset.Point(), "")
+	test.That(t, geometry, test.ShouldResemble, &point{NewPoseFromPoint(offset.Point()), ""})
 
 	// test sphere created from GeometryCreator with offset
-	geometry = NewPointCreator(offset).NewGeometry(PoseInverse(offset))
+	geometry = NewPointCreator(offset, "").NewGeometry(PoseInverse(offset))
 	test.That(t, PoseAlmostCoincident(geometry.Pose(), NewZeroPose()), test.ShouldBeTrue)
 }
 
 func TestPointAlmostEqual(t *testing.T) {
-	original := NewPoint(r3.Vector{})
-	good := NewPoint(r3.Vector{1e-16, 1e-16, 1e-16})
-	bad := NewPoint(r3.Vector{1e-2, 1e-2, 1e-2})
+	original := NewPoint(r3.Vector{}, "")
+	good := NewPoint(r3.Vector{1e-16, 1e-16, 1e-16}, "")
+	bad := NewPoint(r3.Vector{1e-2, 1e-2, 1e-2}, "")
 	test.That(t, original.AlmostEqual(good), test.ShouldBeTrue)
 	test.That(t, original.AlmostEqual(bad), test.ShouldBeFalse)
 }
 
 func TestPointVertices(t *testing.T) {
 	offset := r3.Vector{2, 2, 2}
-	test.That(t, R3VectorAlmostEqual(NewPoint(offset).Vertices()[0], offset, 1e-8), test.ShouldBeTrue)
+	test.That(t, R3VectorAlmostEqual(NewPoint(offset, "").Vertices()[0], offset, 1e-8), test.ShouldBeTrue)
 }

--- a/spatialmath/pose.go
+++ b/spatialmath/pose.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Epsilon represents the acceptable discrepancy between two floats
-// representing spatial coordinates wherin the coordinates should be
+// representing spatial coordinates wherein the coordinates should be
 // considered equivalent.
 const Epsilon = 1e-8
 
@@ -179,11 +179,11 @@ func (d *distancePose) Orientation() Orientation {
 	return (*Quaternion)(&d.orientation)
 }
 
-// ResetPoseDQTransalation takes a Pose that must be a dualQuaternion and reset's it's translation.
-func ResetPoseDQTransalation(p Pose, v r3.Vector) {
+// ResetPoseDQTranslation takes a Pose that must be a dualQuaternion and reset's it's translation.
+func ResetPoseDQTranslation(p Pose, v r3.Vector) {
 	q, ok := p.(*dualQuaternion)
 	if !ok {
-		panic("ResetPoseDQTransalation has to be passed a dual quaternion")
+		panic("ResetPoseDQTranslation has to be passed a dual quaternion")
 	}
 	q.SetTranslation(v)
 }

--- a/spatialmath/sphere.go
+++ b/spatialmath/sphere.go
@@ -14,26 +14,28 @@ import (
 type sphereCreator struct {
 	radius float64
 	pointCreator
+	label string
 }
 
 // sphere is a collision geometry that represents a sphere, it has a pose and a radius that fully define it.
 type sphere struct {
 	pose   Pose
 	radius float64
+	label  string
 }
 
 // NewSphereCreator instantiates a SphereCreator class, which allows instantiating spheres given only a pose which is applied
 // at the specified offset from the pose. These spheres have a radius specified by the radius argument.
-func NewSphereCreator(radius float64, offset Pose) (GeometryCreator, error) {
+func NewSphereCreator(radius float64, offset Pose, label string) (GeometryCreator, error) {
 	if radius <= 0 {
 		return nil, newBadGeometryDimensionsError(&sphere{})
 	}
-	return &sphereCreator{radius, pointCreator{offset}}, nil
+	return &sphereCreator{radius, pointCreator{offset, label}, label}, nil
 }
 
 // NewGeometry instantiates a new sphere from a SphereCreator class.
 func (sc *sphereCreator) NewGeometry(pose Pose) Geometry {
-	return &sphere{Compose(sc.offset, pose), sc.radius}
+	return &sphere{Compose(sc.offset, pose), sc.radius, sc.label}
 }
 
 func (sc *sphereCreator) MarshalJSON() ([]byte, error) {
@@ -47,11 +49,16 @@ func (sc *sphereCreator) MarshalJSON() ([]byte, error) {
 }
 
 // NewSphere instantiates a new sphere Geometry.
-func NewSphere(pt r3.Vector, radius float64) (Geometry, error) {
+func NewSphere(pt r3.Vector, radius float64, label string) (Geometry, error) {
 	if radius < 0 {
 		return nil, newBadGeometryDimensionsError(&sphere{})
 	}
-	return &sphere{NewPoseFromPoint(pt), radius}, nil
+	return &sphere{NewPoseFromPoint(pt), radius, label}, nil
+}
+
+// Label returns the label of the sphere
+func (s *sphere) Label() string {
+	return s.label
 }
 
 // Pose returns the pose of the sphere.
@@ -76,7 +83,7 @@ func (s *sphere) AlmostEqual(g Geometry) bool {
 
 // Transform premultiplies the sphere pose with a transform, allowing the sphere to be moved in space.
 func (s *sphere) Transform(toPremultiply Pose) Geometry {
-	return &sphere{Compose(toPremultiply, s.pose), s.radius}
+	return &sphere{Compose(toPremultiply, s.pose), s.radius, s.label}
 }
 
 // ToProto converts the sphere to a Geometry proto message.

--- a/spatialmath/sphere.go
+++ b/spatialmath/sphere.go
@@ -56,7 +56,7 @@ func NewSphere(pt r3.Vector, radius float64, label string) (Geometry, error) {
 	return &sphere{NewPoseFromPoint(pt), radius, label}, nil
 }
 
-// Label returns the label of the sphere
+// Label returns the label of the sphere.
 func (s *sphere) Label() string {
 	return s.label
 }

--- a/spatialmath/sphere_test.go
+++ b/spatialmath/sphere_test.go
@@ -8,8 +8,8 @@ import (
 	"go.viam.com/test"
 )
 
-func makeTestSphere(point r3.Vector, radius float64) Geometry {
-	sphere, _ := NewSphere(point, radius)
+func makeTestSphere(point r3.Vector, radius float64, label string) Geometry {
+	sphere, _ := NewSphere(point, radius, label)
 	return sphere
 }
 
@@ -17,27 +17,27 @@ func TestNewSphere(t *testing.T) {
 	offset := NewPoseFromOrientation(r3.Vector{X: 1, Y: 0, Z: 0}, &EulerAngles{0, 0, math.Pi})
 
 	// test sphere created from NewBox method
-	geometry, err := NewSphere(offset.Point(), 1)
+	geometry, err := NewSphere(offset.Point(), 1, "")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, geometry, test.ShouldResemble, &sphere{pose: NewPoseFromPoint(offset.Point()), radius: 1})
-	_, err = NewSphere(offset.Point(), -1)
+	_, err = NewSphere(offset.Point(), -1, "")
 	test.That(t, err.Error(), test.ShouldContainSubstring, newBadGeometryDimensionsError(&sphere{}).Error())
 
 	// test sphere created from GeometryCreator with offset
-	gc, err := NewSphereCreator(1, offset)
+	gc, err := NewSphereCreator(1, offset, "")
 	test.That(t, err, test.ShouldBeNil)
 	geometry = gc.NewGeometry(PoseInverse(offset))
 	test.That(t, PoseAlmostCoincident(geometry.Pose(), NewZeroPose()), test.ShouldBeTrue)
 }
 
 func TestSphereAlmostEqual(t *testing.T) {
-	original := makeTestSphere(r3.Vector{}, 1)
-	good := makeTestSphere(r3.Vector{1e-16, 1e-16, 1e-16}, 1+1e-16)
-	bad := makeTestSphere(r3.Vector{1e-2, 1e-2, 1e-2}, 1+1e-2)
+	original := makeTestSphere(r3.Vector{}, 1, "")
+	good := makeTestSphere(r3.Vector{1e-16, 1e-16, 1e-16}, 1+1e-16, "")
+	bad := makeTestSphere(r3.Vector{1e-2, 1e-2, 1e-2}, 1+1e-2, "")
 	test.That(t, original.AlmostEqual(good), test.ShouldBeTrue)
 	test.That(t, original.AlmostEqual(bad), test.ShouldBeFalse)
 }
 
 func TestSphereVertices(t *testing.T) {
-	test.That(t, R3VectorAlmostEqual(makeTestSphere(r3.Vector{}, 1).Vertices()[0], r3.Vector{}, 1e-8), test.ShouldBeTrue)
+	test.That(t, R3VectorAlmostEqual(makeTestSphere(r3.Vector{}, 1, "").Vertices()[0], r3.Vector{}, 1e-8), test.ShouldBeTrue)
 }

--- a/vision/object_test.go
+++ b/vision/object_test.go
@@ -30,7 +30,7 @@ func TestObjectCreation(t *testing.T) {
 	obj, err = NewObject(pc)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, obj.PointCloud, test.ShouldResemble, pc)
-	expectedBox, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{0.5, 0.5, 0}), r3.Vector{1, 1, 0})
+	expectedBox, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{0.5, 0.5, 0}), r3.Vector{1, 1, 0}, "")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, obj.Geometry.AlmostEqual(expectedBox), test.ShouldBeTrue)
 }

--- a/vision/segmentation/segments_test.go
+++ b/vision/segmentation/segments_test.go
@@ -150,7 +150,7 @@ func testPointCloudBoundingBox(t *testing.T, cloud pc.PointCloud, center, dims r
 	} else {
 		test.That(t, box, test.ShouldNotBeNil)
 		test.That(t, err, test.ShouldBeNil)
-		boxExpected, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(center), dims)
+		boxExpected, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(center), dims, "")
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, box.AlmostEqual(boxExpected), test.ShouldBeTrue)
 	}


### PR DESCRIPTION
This commit is the first part of [DATA-498](https://viam.atlassian.net/browse/DATA-498). The next part will focus on the client and server interface. This seemed like a good stopping point since it's pretty large and self-contained.