### PR TITLE
[Data-499] fix overlay transform

### DIFF
--- a/components/camera/transformpipeline/composed.go
+++ b/components/camera/transformpipeline/composed.go
@@ -102,6 +102,9 @@ func newOverlayTransform(
 	if attrs.IntrinsicParams == nil {
 		return nil, transform.ErrNoIntrinsics
 	}
+	if attrs.IntrinsicParams.Height <= 0. || attrs.IntrinsicParams.Width <= 0. {
+		return nil, errors.Wrapf(transform.ErrNoIntrinsics, "cannot do overlay with intrinsics (width,height) = (%v, %v)", attrs.IntrinsicParams.Width, attrs.IntrinsicParams.Height)
+	}
 	if attrs.IntrinsicParams.Fx <= 0. || attrs.IntrinsicParams.Fy <= 0. {
 		return nil, errors.Wrapf(transform.ErrNoIntrinsics, "cannot do overlay with intrinsics (Fx,Fy) = (%v, %v)", attrs.IntrinsicParams.Fx, attrs.IntrinsicParams.Fy)
 	}

--- a/components/camera/transformpipeline/composed.go
+++ b/components/camera/transformpipeline/composed.go
@@ -10,9 +10,11 @@ import (
 	"go.uber.org/multierr"
 
 	"go.viam.com/rdk/components/camera"
+	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/rimage"
 	"go.viam.com/rdk/rimage/transform"
+	rdkutils "go.viam.com/rdk/utils"
 )
 
 // depthToPretty takes a depth image and turns into a colorful image, with blue being
@@ -72,18 +74,34 @@ func (dtp *depthToPretty) PointCloud(ctx context.Context) (pointcloud.PointCloud
 	return dtp.intrinsicParameters.RGBDToPointCloud(rimage.ConvertImage(col), dm)
 }
 
-// overlaySource overlays the depth and color 2D images in order to debug the alignment of the two images.
-type overlaySource struct {
-	src                    gostream.VideoSource
-	srcIntrinsicParameters *transform.PinholeCameraIntrinsics
+// overlayAttrs are the attributes for an overlay transform
+type overlayAttrs struct {
+	IntrinsicParams *transform.PinholeCameraIntrinsics `json:"intrinsic_parameters"`
 }
 
-func newOverlayTransform(ctx context.Context, src gostream.VideoSource, attrs *camera.AttrConfig) (gostream.VideoSource, error) {
-	reader := &overlaySource{src, attrs.CameraParameters}
+// overlaySource overlays the depth and color 2D images in order to debug the alignment of the two images.
+type overlaySource struct {
+	src                 gostream.VideoSource
+	intrinsicParameters *transform.PinholeCameraIntrinsics
+}
+
+func newOverlayTransform(ctx context.Context, src gostream.VideoSource, am config.AttributeMap) (gostream.VideoSource, error) {
+	conf, err := config.TransformAttributeMapToStruct(&(overlayAttrs{}), am)
+	if err != nil {
+		return nil, err
+	}
+	attrs, ok := conf.(*overlayAttrs)
+	if !ok {
+		return nil, rdkutils.NewUnexpectedTypeError(attrs, conf)
+	}
+	if attrs.Fx <= 0. || attrs.Fy <= 0. {
+		return nil, errors.New("cannot do overlay with intrinsics (Fx,Fy) = (%v, %v)", attrs.Fx, attrs.Fy)
+	}
+	reader := &overlaySource{src, attrs.IntrinsicParams}
 	return camera.NewFromReader(
 		ctx,
 		reader,
-		&transform.PinholeCameraModel{reader.srcIntrinsicParameters, nil},
+		&transform.PinholeCameraModel{reader.intrinsicParameters, nil},
 		camera.StreamType(attrs.Stream),
 	)
 }
@@ -91,7 +109,7 @@ func newOverlayTransform(ctx context.Context, src gostream.VideoSource, attrs *c
 func (os *overlaySource) Read(ctx context.Context) (image.Image, func(), error) {
 	ctx, span := trace.StartSpan(ctx, "camera::transformpipeline::overlay::Read")
 	defer span.End()
-	if os.srcIntrinsicParameters == nil {
+	if os.intrinsicParameters == nil {
 		return nil, nil, transform.ErrNoIntrinsics
 	}
 	srcPointCloud, ok := os.src.(camera.PointCloudSource)
@@ -102,7 +120,7 @@ func (os *overlaySource) Read(ctx context.Context) (image.Image, func(), error) 
 	if err != nil {
 		return nil, nil, err
 	}
-	col, dm, err := os.srcIntrinsicParameters.PointCloudToRGBD(pc)
+	col, dm, err := os.intrinsicParameters.PointCloudToRGBD(pc)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/components/camera/transformpipeline/composed.go
+++ b/components/camera/transformpipeline/composed.go
@@ -103,10 +103,18 @@ func newOverlayTransform(
 		return nil, transform.ErrNoIntrinsics
 	}
 	if attrs.IntrinsicParams.Height <= 0. || attrs.IntrinsicParams.Width <= 0. {
-		return nil, errors.Wrapf(transform.ErrNoIntrinsics, "cannot do overlay with intrinsics (width,height) = (%v, %v)", attrs.IntrinsicParams.Width, attrs.IntrinsicParams.Height)
+		return nil, errors.Wrapf(
+			transform.ErrNoIntrinsics,
+			"cannot do overlay with intrinsics (width,height) = (%v, %v)",
+			attrs.IntrinsicParams.Width, attrs.IntrinsicParams.Height,
+		)
 	}
 	if attrs.IntrinsicParams.Fx <= 0. || attrs.IntrinsicParams.Fy <= 0. {
-		return nil, errors.Wrapf(transform.ErrNoIntrinsics, "cannot do overlay with intrinsics (Fx,Fy) = (%v, %v)", attrs.IntrinsicParams.Fx, attrs.IntrinsicParams.Fy)
+		return nil, errors.Wrapf(
+			transform.ErrNoIntrinsics,
+			"cannot do overlay with intrinsics (Fx,Fy) = (%v, %v)",
+			attrs.IntrinsicParams.Fx, attrs.IntrinsicParams.Fy,
+		)
 	}
 	reader := &overlaySource{src, attrs.IntrinsicParams}
 	return camera.NewFromReader(

--- a/components/camera/transformpipeline/composed.go
+++ b/components/camera/transformpipeline/composed.go
@@ -99,8 +99,11 @@ func newOverlayTransform(
 	if !ok {
 		return nil, rdkutils.NewUnexpectedTypeError(attrs, conf)
 	}
+	if attrs.IntrinsicParams == nil {
+		return nil, transform.ErrNoIntrinsics
+	}
 	if attrs.IntrinsicParams.Fx <= 0. || attrs.IntrinsicParams.Fy <= 0. {
-		return nil, errors.Errorf("cannot do overlay with intrinsics (Fx,Fy) = (%v, %v)", attrs.IntrinsicParams.Fx, attrs.IntrinsicParams.Fy)
+		return nil, errors.Wrapf(transform.ErrNoIntrinsics, "cannot do overlay with intrinsics (Fx,Fy) = (%v, %v)", attrs.IntrinsicParams.Fx, attrs.IntrinsicParams.Fy)
 	}
 	reader := &overlaySource{src, attrs.IntrinsicParams}
 	return camera.NewFromReader(

--- a/components/camera/transformpipeline/composed_test.go
+++ b/components/camera/transformpipeline/composed_test.go
@@ -1,11 +1,89 @@
 package transformpipeline
 
-import "testing"
+import (
+	"context"
+	"image"
+	"image/color"
+	"testing"
+
+	"go.viam.com/rdk/components/camera"
+	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/pointcloud"
+	"go.viam.com/rdk/rimage/transform"
+	"go.viam.com/rdk/testutils/inject"
+	"go.viam.com/test"
+)
 
 func TestComposed(t *testing.T) {
-	// create pointcloud source
-	// get intrinsic parameters
-	// make transform pipeline
-	// expected result with correct config
+	// create pointcloud source and fake robot
+	robot := &inject.Robot{}
+	cloudSource := &inject.Camera{}
+	cloudSource.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
+		p := pointcloud.New()
+		return p, p.Set(pointcloud.NewVector(0, 0, 0), pointcloud.NewColoredData(color.NRGBA{255, 1, 2, 255}))
+	}
+	// get intrinsic parameters, and make config
+	am := config.AttributeMap{
+		"intrinsic_parameters": &transform.PinholeCameraIntrinsics{
+			Width:  1280,
+			Height: 720,
+			Fx:     100,
+			Fy:     100,
+		},
+	}
+	// make transform pipeline, expected result with correct config
+	conf := &transformConfig{
+		AttrConfig: &camera.AttrConfig{
+			Stream: "color",
+		},
+		Pipeline: []Transformation{
+			{
+				Type:       "overlay",
+				Attributes: am,
+			},
+		},
+	}
+	pc, err := cloudSource.NextPointCloud(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, pc.Size(), test.ShouldEqual, 1)
+
+	myOverlay, err := newOverlayTransform(context.Background(), cloudSource, camera.ColorStream, am)
+	test.That(t, err, test.ShouldBeNil)
+	pic, _, err := camera.ReadImage(context.Background(), myOverlay)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, pic.Bounds(), test.ShouldResemble, image.Rect(0, 0, 1280, 720))
+
+	myPipeline, err := newTransformPipeline(context.Background(), cloudSource, conf, robot)
+	test.That(t, err, test.ShouldBeNil)
+	defer myPipeline.Close(context.Background())
+	pic, _, err = camera.ReadImage(context.Background(), myPipeline)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, pic.Bounds(), test.ShouldResemble, image.Rect(0, 0, 1280, 720))
+
 	// wrong result with bad config
+	_, err = newOverlayTransform(context.Background(), cloudSource, camera.ColorStream, config.AttributeMap{})
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldWrap, transform.ErrNoIntrinsics)
+	am = config.AttributeMap{
+		"intrinsic_parameters": &transform.PinholeCameraIntrinsics{
+			Width:  1280,
+			Height: 720,
+		},
+	}
+	_, err = newOverlayTransform(context.Background(), cloudSource, camera.ColorStream, am)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldWrap, transform.ErrNoIntrinsics)
+	conf = &transformConfig{
+		AttrConfig: &camera.AttrConfig{
+			Stream: "color",
+		},
+		Pipeline: []Transformation{
+			{
+				Type: "overlay", // no attributes
+			},
+		},
+	}
+	_, err = newTransformPipeline(context.Background(), cloudSource, conf, robot)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldWrap, transform.ErrNoIntrinsics)
 }

--- a/components/camera/transformpipeline/composed_test.go
+++ b/components/camera/transformpipeline/composed_test.go
@@ -6,12 +6,13 @@ import (
 	"image/color"
 	"testing"
 
+	"go.viam.com/test"
+
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/rimage/transform"
 	"go.viam.com/rdk/testutils/inject"
-	"go.viam.com/test"
 )
 
 func TestComposed(t *testing.T) {

--- a/components/camera/transformpipeline/composed_test.go
+++ b/components/camera/transformpipeline/composed_test.go
@@ -1,0 +1,11 @@
+package transformpipeline
+
+import "testing"
+
+func TestComposed(t *testing.T) {
+	// create pointcloud source
+	// get intrinsic parameters
+	// make transform pipeline
+	// expected result with correct config
+	// wrong result with bad config
+}

--- a/components/camera/transformpipeline/transform.go
+++ b/components/camera/transformpipeline/transform.go
@@ -49,7 +49,7 @@ func buildTransform(
 	case transformTypeDepthPretty:
 		return newDepthToPrettyTransform(ctx, source, cfg.AttrConfig)
 	case transformTypeOverlay:
-		return newOverlayTransform(ctx, source, cfg.AttrConfig)
+		return newOverlayTransform(ctx, source, tr.Attributes)
 	case transformTypeUndistort:
 		return newUndistortTransform(ctx, source, stream, tr.Attributes)
 	case transformTypeDetections:

--- a/components/camera/transformpipeline/transform.go
+++ b/components/camera/transformpipeline/transform.go
@@ -49,7 +49,7 @@ func buildTransform(
 	case transformTypeDepthPretty:
 		return newDepthToPrettyTransform(ctx, source, cfg.AttrConfig)
 	case transformTypeOverlay:
-		return newOverlayTransform(ctx, source, tr.Attributes)
+		return newOverlayTransform(ctx, source, stream, tr.Attributes)
 	case transformTypeUndistort:
 		return newUndistortTransform(ctx, source, stream, tr.Attributes)
 	case transformTypeDetections:


### PR DESCRIPTION
The problem that was causing segmentation errors was projecting to an image that was (0,0) size, because the intrinsic parameters were not set. Rather than using the camera's intrinsic parameters, the transform should require its own intrinsic parameters to do the projection.