### PR TITLE
RSDK-726 Fix get all resources by name

### DIFF
--- a/robot/robot.go
+++ b/robot/robot.go
@@ -120,7 +120,7 @@ func AllResourcesByName(r Robot, name string) []interface{} {
 	all := []interface{}{}
 
 	for _, n := range r.ResourceNames() {
-		if n.Name == name {
+		if n.ShortName() == name {
 			r, err := r.ResourceByName(n)
 			if err != nil {
 				panic("this should be impossible")

--- a/robot/robot_test.go
+++ b/robot/robot_test.go
@@ -19,7 +19,7 @@ import (
 var (
 	button1 = resource.NewName(resource.ResourceNamespaceRDK, resource.ResourceTypeComponent, resource.SubtypeName("button"), "arm1")
 
-	armNames    = []resource.Name{arm.Named("arm1"), arm.Named("arm2")}
+	armNames    = []resource.Name{arm.Named("arm1"), arm.Named("arm2"), arm.Named("remote:arm1")}
 	buttonNames = []resource.Name{button1}
 	sensorNames = []resource.Name{sensor.Named("sensor1")}
 )
@@ -48,6 +48,9 @@ func TestAllResourcesByName(t *testing.T) {
 
 	resources := robot.AllResourcesByName(r, "arm1")
 	test.That(t, resources, test.ShouldResemble, []interface{}{"here", "here"})
+
+	resources = robot.AllResourcesByName(r, "remote:arm1")
+	test.That(t, resources, test.ShouldResemble, []interface{}{"here"})
 
 	test.That(t, func() { robot.AllResourcesByName(r, "arm2") }, test.ShouldPanic)
 

--- a/testutils/resource_utils.go
+++ b/testutils/resource_utils.go
@@ -21,7 +21,7 @@ func NewResourceNameSet(resourceNames ...resource.Name) map[resource.Name]struct
 func ExtractNames(values ...resource.Name) []string {
 	var names []string
 	for _, n := range values {
-		names = append(names, n.Name)
+		names = append(names, n.ShortName())
 	}
 	return names
 }


### PR DESCRIPTION
need to do a check on ShortName() instead of Name.

running the example on the ticket still fails with
```
2022-10-07T21:17:07.768-0400    FATAL   client  sample/client.go:36     cannot move: rpc error: code = Unknown desc = arm client does not support inputs directly
```
but thats a different issue