### PR TITLE
Revert video_path

### DIFF
--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -142,8 +142,8 @@ func getProperties(d driver.Driver) (_ []prop.Media, err error) {
 type WebcamAttrs struct {
 	*camera.AttrConfig
 	Format      string `json:"format"`
-	Path        string `json:"video_path"`
-	PathPattern string `json:"video_path_pattern"`
+	Path        string `json:"path"`
+	PathPattern string `json:"path_pattern"`
 	Width       int    `json:"width_px"`
 	Height      int    `json:"height_px"`
 }


### PR DESCRIPTION
Locally compiling RDK on the Pi works with `video_path` config but not `path` while the pre-compiled binaries do not. I am reverting it for the time being but not sure what the issue is