### PR TITLE
Initialize synchronization even if capture is disabled

### DIFF
--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -463,21 +463,21 @@ func (svc *builtIn) Update(ctx context.Context, cfg *config.Config) error {
 
 	toggledCaptureOff := (svc.captureDisabled != svcConfig.CaptureDisabled) && svcConfig.CaptureDisabled
 	svc.captureDisabled = svcConfig.CaptureDisabled
+	var allComponentAttributes []dataCaptureConfig
+
 	// Service is disabled, so close all collectors and clear the map so we can instantiate new ones if we enable this service.
 	if toggledCaptureOff {
 		svc.closeCollectors()
 		svc.collectors = make(map[componentMethodMetadata]collectorAndConfig)
-		return nil
-	}
+	} else {
+		allComponentAttributes, err = buildDataCaptureConfigs(cfg)
+		if err != nil {
+			return err
+		}
 
-	allComponentAttributes, err := buildDataCaptureConfigs(cfg)
-	if err != nil {
-		return err
-	}
-
-	if len(allComponentAttributes) == 0 {
-		svc.logger.Warn("Could not find any components with data_manager service configuration")
-		return nil
+		if len(allComponentAttributes) == 0 {
+			svc.logger.Warn("no components with data_manager service configuration")
+		}
 	}
 
 	toggledSync := svc.syncDisabled != svcConfig.ScheduledSyncDisabled

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -472,6 +472,7 @@ func (svc *builtIn) Update(ctx context.Context, cfg *config.Config) error {
 	} else {
 		allComponentAttributes, err = buildDataCaptureConfigs(cfg)
 		if err != nil {
+			svc.logger.Warn(err.Error())
 			return err
 		}
 

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -477,7 +477,7 @@ func (svc *builtIn) Update(ctx context.Context, cfg *config.Config) error {
 		}
 
 		if len(allComponentAttributes) == 0 {
-			svc.logger.Warn("no components with data_manager service configuration")
+			svc.logger.Info("no components with data_manager service configuration")
 		}
 	}
 


### PR DESCRIPTION
Previously, if:
1. Capture was toggled off when synchronization was toggled on
2. No components had capture configurations

we would return early before initializing the background syncer.