### PR TITLE
Update ReadImage back to stream.Next

### DIFF
--- a/components/camera/collectors.go
+++ b/components/camera/collectors.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 
+	"github.com/edaniels/gostream"
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -77,11 +78,12 @@ func newReadImageCollector(resource interface{}, params data.CollectorParams) (d
 		}
 	}
 
+	stream := gostream.NewEmbeddedVideoStream(camera)
 	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (interface{}, error) {
 		_, span := trace.StartSpan(ctx, "camera::data::collector::CaptureFunc::ReadImage")
 		defer span.End()
 
-		img, release, err := ReadImage(ctx, camera)
+		img, release, err := stream.Next(ctx)
 		if err != nil {
 			return nil, data.FailedToReadErr(params.ComponentName, readImage.String(), err)
 		}


### PR DESCRIPTION
This was updated as part of https://github.com/viamrobotics/rdk/pull/1294/files, but ReadImage seems to do something different from stream.Next(). Reverted back to the call originally added in https://github.com/viamrobotics/rdk/pull/1223.

If this fixes capture, will rename the collector key to "Next" as a follow-up for correctness - but this will all work E2E with "ReadImage" since it's just a key string into this collector.