### PR TITLE
Don't ignore errors when setting PWMs in GPIO motors

### DIFF
--- a/components/motor/gpio/basic.go
+++ b/components/motor/gpio/basic.go
@@ -129,10 +129,10 @@ func (m *Motor) setPWM(ctx context.Context, powerPct float64, extra map[string]i
 
 	if math.Abs(powerPct) <= 0.001 {
 		if m.EnablePinLow != nil {
-			errs = multierr.Combine(m.EnablePinLow.Set(ctx, true, extra))
+			errs = multierr.Combine(errs, m.EnablePinLow.Set(ctx, true, extra))
 		}
 		if m.EnablePinHigh != nil {
-			errs = multierr.Combine(m.EnablePinHigh.Set(ctx, false, extra))
+			errs = multierr.Combine(errs, m.EnablePinHigh.Set(ctx, false, extra))
 		}
 
 		if m.A != nil && m.B != nil {

--- a/components/motor/gpio/basic.go
+++ b/components/motor/gpio/basic.go
@@ -129,10 +129,10 @@ func (m *Motor) setPWM(ctx context.Context, powerPct float64, extra map[string]i
 
 	if math.Abs(powerPct) <= 0.001 {
 		if m.EnablePinLow != nil {
-			errs = m.EnablePinLow.Set(ctx, true, extra)
+			errs = multierr.Combine(m.EnablePinLow.Set(ctx, true, extra))
 		}
 		if m.EnablePinHigh != nil {
-			errs = m.EnablePinHigh.Set(ctx, false, extra)
+			errs = multierr.Combine(m.EnablePinHigh.Set(ctx, false, extra))
 		}
 
 		if m.A != nil && m.B != nil {


### PR DESCRIPTION
I was working on something unrelated, and noticed that, when you want to turn off the power to a GPIO motor, if you encounter an error setting EnablePinLow, but no error when setting EnablePinHigh, the error gets suppressed. I've changed it so the errors are propagated no matter what order we do things in. 

I don't see an obvious way to write a test for this, but am willing to do so if someone gives me advice on how to simulate the errors in different places. 

I could have used `multierr.Append`, but went with `multierr.Combine` for consistency with the rest of the function.