### PR TITLE
[DATA] Don't acquire lock  for whole duration of syncDataCaptureFiles.

### DIFF
--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -364,8 +364,8 @@ func (svc *builtIn) Sync(_ context.Context) error {
 }
 
 func (svc *builtIn) syncDataCaptureFiles() error {
-	oldFiles := make([]string, 0, len(svc.collectors))
 	svc.lock.Lock()
+	oldFiles := make([]string, 0, len(svc.collectors))
 	currCollectors := svc.collectors
 	svc.lock.Unlock()
 	for _, collector := range currCollectors {

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -365,7 +365,9 @@ func (svc *builtIn) Sync(_ context.Context) error {
 
 func (svc *builtIn) syncDataCaptureFiles() error {
 	oldFiles := make([]string, 0, len(svc.collectors))
+	svc.lock.Lock()
 	currCollectors := svc.collectors
+	svc.lock.Unlock()
 	for _, collector := range currCollectors {
 		// Create new target and set it.
 		attributes := collector.Attributes

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -364,10 +364,9 @@ func (svc *builtIn) Sync(_ context.Context) error {
 }
 
 func (svc *builtIn) syncDataCaptureFiles() error {
-	svc.lock.Lock()
-	defer svc.lock.Unlock()
 	oldFiles := make([]string, 0, len(svc.collectors))
-	for _, collector := range svc.collectors {
+	currCollectors := svc.collectors
+	for _, collector := range currCollectors {
 		// Create new target and set it.
 		attributes := collector.Attributes
 		captureMetadata, err := datacapture.BuildCaptureMetadata(attributes.Type, attributes.Name,
@@ -378,7 +377,7 @@ func (svc *builtIn) syncDataCaptureFiles() error {
 
 		nextTarget, err := datacapture.CreateDataCaptureFile(svc.captureDir, captureMetadata)
 		if err != nil {
-			svc.logger.Errorw("failed to create new data capture file", "error", err)
+			return err
 		}
 		oldFiles = append(oldFiles, collector.Collector.GetTarget().Name())
 		collector.Collector.SetTarget(nextTarget)

--- a/services/datamanager/builtin/builtin_test.go
+++ b/services/datamanager/builtin/builtin_test.go
@@ -157,6 +157,7 @@ func TestNewDataManager(t *testing.T) {
 	// Empty config at initialization.
 	captureDir := "/tmp/capture"
 	defer resetFolder(t, captureDir)
+	resetFolder(t, captureDir)
 	err := dmsvc.Update(context.Background(), testCfg)
 	test.That(t, err, test.ShouldBeNil)
 	captureTime := time.Millisecond * 100


### PR DESCRIPTION
We don't need to acquire this lock for the duration of the function, only when accessing the shared variable svc.collectors, which we can copy. 

Also replaces the behavior when a data capture file can't be created to return an err instead of log an error. We can't capture or sync data if that doesn't work, so I think it should fail quickly/completely vs just logging.