### PR TITLE
Fix TestORBSLAMDataProcess timeout

### DIFF
--- a/services/slam/builtin/builtin.go
+++ b/services/slam/builtin/builtin.go
@@ -636,7 +636,6 @@ func (slamSvc *builtIn) StartDataProcess(
 						}
 						if c != nil {
 							c <- 1
-							c = nil
 						}
 					case slam.Sparse:
 						if _, err := slamSvc.getAndSaveDataSparse(cancelCtx, cams, camStreams); err != nil {
@@ -644,7 +643,6 @@ func (slamSvc *builtIn) StartDataProcess(
 						}
 						if c != nil {
 							c <- 1
-							c = nil
 						}
 					default:
 						slamSvc.logger.Warnw("warning invalid algorithm specified", "algorithm", slamSvc.slamLib.AlgoType)

--- a/services/slam/builtin/builtin.go
+++ b/services/slam/builtin/builtin.go
@@ -636,6 +636,7 @@ func (slamSvc *builtIn) StartDataProcess(
 						}
 						if c != nil {
 							c <- 1
+							c = nil
 						}
 					case slam.Sparse:
 						if _, err := slamSvc.getAndSaveDataSparse(cancelCtx, cams, camStreams); err != nil {
@@ -643,6 +644,7 @@ func (slamSvc *builtIn) StartDataProcess(
 						}
 						if c != nil {
 							c <- 1
+							c = nil
 						}
 					default:
 						slamSvc.logger.Warnw("warning invalid algorithm specified", "algorithm", slamSvc.slamLib.AlgoType)

--- a/services/slam/builtin/builtin_test.go
+++ b/services/slam/builtin/builtin_test.go
@@ -671,7 +671,7 @@ func TestCartographerDataProcess(t *testing.T) {
 		}()
 
 		cancelCtx, cancelFunc := context.WithCancel(context.Background())
-		c := make(chan int)
+		c := make(chan int, 100)
 		slamSvc.StartDataProcess(cancelCtx, cams, camStreams, c)
 
 		<-c
@@ -698,7 +698,7 @@ func TestCartographerDataProcess(t *testing.T) {
 		}()
 
 		cancelCtx, cancelFunc := context.WithCancel(context.Background())
-		c := make(chan int)
+		c := make(chan int, 100)
 		slamSvc.StartDataProcess(cancelCtx, cams, camStreams, c)
 
 		<-c
@@ -764,7 +764,7 @@ func TestORBSLAMDataProcess(t *testing.T) {
 
 		cancelCtx, cancelFunc := context.WithCancel(context.Background())
 
-		c := make(chan int)
+		c := make(chan int, 100)
 		slamSvc.StartDataProcess(cancelCtx, cams, camStreams, c)
 
 		<-c
@@ -788,7 +788,7 @@ func TestORBSLAMDataProcess(t *testing.T) {
 		}()
 
 		cancelCtx, cancelFunc := context.WithCancel(context.Background())
-		c := make(chan int)
+		c := make(chan int, 100)
 		slamSvc.StartDataProcess(cancelCtx, cams, camStreams, c)
 
 		<-c


### PR DESCRIPTION
I saw another failure in a PR, and realized there was still this issue in the test.