### PR TITLE
RSDK-768: Improve flaky rdk/utils test

### DIFF
--- a/utils/parallel_test.go
+++ b/utils/parallel_test.go
@@ -12,21 +12,21 @@ import (
 
 // This test may be flaky due to timing-based tests.
 func TestRunInParallel(t *testing.T) {
-	wait100ms := func(ctx context.Context) error {
-		gutils.SelectContextOrWait(ctx, 100*time.Millisecond)
+	wait200ms := func(ctx context.Context) error {
+		gutils.SelectContextOrWait(ctx, 200*time.Millisecond)
 		return ctx.Err()
 	}
 
-	elapsed, err := RunInParallel(context.Background(), []SimpleFunc{wait100ms, wait100ms})
+	elapsed, err := RunInParallel(context.Background(), []SimpleFunc{wait200ms, wait200ms})
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, elapsed, test.ShouldBeLessThan, 150*time.Millisecond)
-	test.That(t, elapsed, test.ShouldBeGreaterThan, 90*time.Millisecond)
+	test.That(t, elapsed, test.ShouldBeLessThan, 300*time.Millisecond)
+	test.That(t, elapsed, test.ShouldBeGreaterThan, 180*time.Millisecond)
 
 	errFunc := func(ctx context.Context) error {
 		return errors.New("bad")
 	}
 
-	elapsed, err = RunInParallel(context.Background(), []SimpleFunc{wait100ms, wait100ms, errFunc})
+	elapsed, err = RunInParallel(context.Background(), []SimpleFunc{wait200ms, wait200ms, errFunc})
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, elapsed, test.ShouldBeLessThan, 50*time.Millisecond)
 

--- a/utils/parallel_test.go
+++ b/utils/parallel_test.go
@@ -10,6 +10,7 @@ import (
 	gutils "go.viam.com/utils"
 )
 
+// This test may be flaky due to timing-based tests.
 func TestRunInParallel(t *testing.T) {
 	wait100ms := func(ctx context.Context) error {
 		gutils.SelectContextOrWait(ctx, 100*time.Millisecond)
@@ -18,7 +19,7 @@ func TestRunInParallel(t *testing.T) {
 
 	elapsed, err := RunInParallel(context.Background(), []SimpleFunc{wait100ms, wait100ms})
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, elapsed, test.ShouldBeLessThan, 120*time.Millisecond)
+	test.That(t, elapsed, test.ShouldBeLessThan, 150*time.Millisecond)
 	test.That(t, elapsed, test.ShouldBeGreaterThan, 90*time.Millisecond)
 
 	errFunc := func(ctx context.Context) error {
@@ -27,7 +28,7 @@ func TestRunInParallel(t *testing.T) {
 
 	elapsed, err = RunInParallel(context.Background(), []SimpleFunc{wait100ms, wait100ms, errFunc})
 	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, elapsed, test.ShouldBeLessThan, 20*time.Millisecond)
+	test.That(t, elapsed, test.ShouldBeLessThan, 50*time.Millisecond)
 
 	panicFunc := func(ctx context.Context) error {
 		panic(1)


### PR DESCRIPTION
Not sure if there's a clean way of removing the timing element from this test. Hopefully this addresses or at least lowers the incidence rate of false positives.