### PR TITLE
[DATA-558] remove SaveMapLoc from orbslam_yaml.go

### DIFF
--- a/services/slam/builtin/builtin.go
+++ b/services/slam/builtin/builtin.go
@@ -664,6 +664,7 @@ func (slamSvc *builtIn) GetSLAMProcessConfig() pexec.ProcessConfig {
 	args = append(args, "-data_dir="+slamSvc.dataDirectory)
 	args = append(args, "-input_file_pattern="+slamSvc.inputFilePattern)
 	args = append(args, "-port="+slamSvc.port)
+	args = append(args, "--aix-auto-update")
 
 	return pexec.ProcessConfig{
 		ID:      "slam_" + slamSvc.slamLib.AlgoName,

--- a/services/slam/builtin/builtin_test.go
+++ b/services/slam/builtin/builtin_test.go
@@ -881,6 +881,7 @@ func TestSLAMProcessSuccess(t *testing.T) {
 		{"-data_dir=" + name},
 		{"-input_file_pattern=10:200:1"},
 		{"-port=localhost:4445"},
+		{"--aix-auto-update"},
 	}
 
 	for i, s := range cmd {

--- a/services/slam/builtin/orbslam_yaml.go
+++ b/services/slam/builtin/orbslam_yaml.go
@@ -119,7 +119,6 @@ type ORBsettings struct {
 	StereoThDepth  float64 `yaml:"Stereo.ThDepth"`
 	DepthMapFactor float64 `yaml:"RGBD.DepthMapFactor"`
 	FPSCamera      int16   `yaml:"Camera.fps"`
-	SaveMapLoc     string  `yaml:"System.SaveAtlasToFile"`
 	LoadMapLoc     string  `yaml:"System.LoadAtlasFromFile"`
 }
 
@@ -147,9 +146,6 @@ func (slamSvc *builtIn) orbGenYAML(ctx context.Context, cam camera.Camera) error
 
 	// TODO change time format to .Format(time.RFC3339Nano) https://viam.atlassian.net/browse/DATA-277
 	timeStampNow := time.Now().UTC().Format(slamTimeFormat)
-	saveMapName := filepath.Join(slamSvc.dataDirectory, "map", slamSvc.cameraName+"_data_"+timeStampNow)
-	// timestamp to save at end of run
-	orbslam.SaveMapLoc = "\"" + saveMapName + "\""
 
 	// Check for maps in the specified directory and add map to yaml config
 	loadMapTimeStamp, loadMapName, err := slamSvc.checkMaps()

--- a/services/slam/builtin/orbslam_yaml.go
+++ b/services/slam/builtin/orbslam_yaml.go
@@ -85,7 +85,7 @@ func (slamSvc *builtIn) orbCamMaker(camProperties *transform.PinholeCameraModel)
 	if orbslam.Stereob, err = slamSvc.orbConfigToFloat("stereo_b", 0.0745); err != nil {
 		return nil, err
 	}
-	tmp, err := slamSvc.orbConfigToInt("rgb_flag", 1)
+	tmp, err := slamSvc.orbConfigToInt("rgb_flag", 0)
 	if err != nil {
 		return nil, err
 	}

--- a/services/slam/builtin/orbslam_yaml.go
+++ b/services/slam/builtin/orbslam_yaml.go
@@ -144,16 +144,14 @@ func (slamSvc *builtIn) orbGenYAML(ctx context.Context, cam camera.Camera) error
 		return err
 	}
 
-	// TODO change time format to .Format(time.RFC3339Nano) https://viam.atlassian.net/browse/DATA-277
-	timeStampNow := time.Now().UTC().Format(slamTimeFormat)
-
 	// Check for maps in the specified directory and add map to yaml config
 	loadMapTimeStamp, loadMapName, err := slamSvc.checkMaps()
 	if err != nil {
 		slamSvc.logger.Debugf("Error occurred while parsing %s for maps, building map from scratch", slamSvc.dataDirectory)
 	}
 	if loadMapTimeStamp == "" {
-		loadMapTimeStamp = timeStampNow
+		// TODO change time format to .Format(time.RFC3339Nano) https://viam.atlassian.net/browse/DATA-277
+		loadMapTimeStamp = time.Now().UTC().Format(slamTimeFormat)
 	} else {
 		orbslam.LoadMapLoc = "\"" + loadMapName + "\""
 	}

--- a/services/slam/builtin/orbslam_yaml_test.go
+++ b/services/slam/builtin/orbslam_yaml_test.go
@@ -143,7 +143,6 @@ func TestOrbslamYAMLNew(t *testing.T) {
 
 		//save a fake map for the next map using the previous timestamp
 		fakeMap = filepath.Join(name, "map", attrCfgGood.Sensors[0]+"_data_"+yamlFileTimeStampGood)
-		test.That(t, orbslam.SaveMapLoc, test.ShouldEqual, "\""+fakeMap+"\"")
 		outfile, err := os.Create(fakeMap + ".osa")
 		test.That(t, err, test.ShouldBeNil)
 		err = outfile.Close()
@@ -173,14 +172,6 @@ func TestOrbslamYAMLNew(t *testing.T) {
 		err = yaml.Unmarshal(yamlData, &orbslam)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, orbslam.LoadMapLoc, test.ShouldEqual, "\""+fakeMap+"\"")
-
-		// compare timestamps, saveTimeStamp should be more recent than oldTimeStamp
-		saveTimestampLoc := strings.Index(orbslam.SaveMapLoc, "_data_") + len("_data_")
-		saveTimeStamp, err := time.Parse(slamTimeFormat, orbslam.SaveMapLoc[saveTimestampLoc:len(orbslam.SaveMapLoc)-1])
-		test.That(t, err, test.ShouldBeNil)
-		oldTimeStamp, err := time.Parse(slamTimeFormat, fakeMapTimestamp)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, saveTimeStamp.After(oldTimeStamp), test.ShouldBeTrue)
 	})
 
 	t.Run("New orbslamv3 service with high dataRateMs", func(t *testing.T) {


### PR DESCRIPTION
Removing save map loc because it does not fit into the intended user experience of orbslam, and is not in the current tech spec. In addition adding the auto update flag for the orbslam binary call, so the most recent appimage is always used. Lastly changes the RGBflag to inform orbslam a BGR image is in use rather than a RGB, to match a change we made to the orbslam server. 

[DATA-558 remove SaveMapLoc](https://viam.atlassian.net/browse/DATA-558)

[DATA-553 add auto update flag](https://viam.atlassian.net/browse/DATA-553)