### PR TITLE
RSDK-578 Pass op id through to remotes rdk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	go.viam.com/api v0.1.2-0.20221012153305-0001bbc7a700
 	go.viam.com/dynamixel v0.0.0-20210507131419-60a9033552cb
 	go.viam.com/test v1.1.1-0.20220909204145-f61b7c01c33e
-	go.viam.com/utils v0.0.6-0.20221007203851-d4ebf5ac4bd5
+	go.viam.com/utils v0.1.1-0.20221018163750-1e19aa44e6b2
 	goji.io v2.0.2+incompatible
 	golang.org/x/image v0.0.0-20220722155232-062f8c9fd539
 	gonum.org/v1/gonum v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -1539,8 +1539,8 @@ go.viam.com/dynamixel v0.0.0-20210507131419-60a9033552cb h1:qXL9ae27upOyWn//rVGF
 go.viam.com/dynamixel v0.0.0-20210507131419-60a9033552cb/go.mod h1:bVVm3GcP8koFgCYKWJkCU0r+lkOvTQLeLaFcw8AFghE=
 go.viam.com/test v1.1.1-0.20220909204145-f61b7c01c33e h1:1tJIJv/zsobFV5feR2ZiG/+VGZkRPVHqJrSTkXbWfqQ=
 go.viam.com/test v1.1.1-0.20220909204145-f61b7c01c33e/go.mod h1:XM0tej6riszsiNLT16uoyq1YjuYPWlRBweTPRDanIts=
-go.viam.com/utils v0.0.6-0.20221007203851-d4ebf5ac4bd5 h1:BtWCS0OtdSglWd8glCUeRC6Pl0SiQZ6af1PvRUf35LA=
-go.viam.com/utils v0.0.6-0.20221007203851-d4ebf5ac4bd5/go.mod h1:j9R2UR+DC6ghHQ+I1V60KM0Es0eK4eANeigXHCpPMAg=
+go.viam.com/utils v0.1.1-0.20221018163750-1e19aa44e6b2 h1:0OOPKoLdOtpTEHtlh2mid5VCRYzOP8UghcPTM4GxSoM=
+go.viam.com/utils v0.1.1-0.20221018163750-1e19aa44e6b2/go.mod h1:j9R2UR+DC6ghHQ+I1V60KM0Es0eK4eANeigXHCpPMAg=
 go4.org v0.0.0-20180809161055-417644f6feb5/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=
 gocv.io/x/gocv v0.25.0/go.mod h1:Rar2PS6DV+T4FL+PM535EImD/h13hGVaHhnCu1xarBs=
 goji.io v2.0.2+incompatible h1:uIssv/elbKRLznFUy3Xj4+2Mz/qKhek/9aZQDUMae7c=

--- a/operation/opid.go
+++ b/operation/opid.go
@@ -115,28 +115,7 @@ func (m *Manager) FindString(id string) *Operation {
 
 // Create puts an operation on this context.
 func (m *Manager) Create(ctx context.Context, method string, args interface{}) (context.Context, func()) {
-	if ctx.Value(opidKey) != nil {
-		panic("operations cannot be nested")
-	}
-
-	for _, val := range methodPrefixesToFilter {
-		if strings.HasPrefix(method, val) {
-			return ctx, func() {}
-		}
-	}
-
-	op := &Operation{
-		ID:        uuid.New(),
-		Method:    method,
-		Arguments: args,
-		Started:   time.Now(),
-		myManager: m,
-	}
-	ctx = context.WithValue(ctx, opidKey, op)
-	ctx, op.cancel = context.WithCancel(ctx)
-	m.add(op)
-
-	return ctx, func() { op.cleanup() }
+	return m.createWithID(ctx, uuid.New(), method, args)
 }
 
 func (m *Manager) createWithID(ctx context.Context, id uuid.UUID, method string, args interface{}) (context.Context, func()) {

--- a/operation/opid.go
+++ b/operation/opid.go
@@ -36,7 +36,7 @@ func (o *Operation) Cancel() {
 	o.cancel()
 }
 
-// HasLabel returns true if this oepration has a speficic label.
+// HasLabel returns true if this operation has a specific label.
 func (o *Operation) HasLabel(label string) bool {
 	for _, l := range o.labels {
 		if l == label {
@@ -86,11 +86,6 @@ func (m *Manager) add(op *Operation) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	m.ops[op.ID.String()] = op
-}
-
-// TODO: remove this and metadata helpers to this module instead
-func (m *Manager) Add(op *Operation) {
-	m.add(op)
 }
 
 // All returns all running operations.

--- a/operation/opid.go
+++ b/operation/opid.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/edaniels/golog"
 	"github.com/google/uuid"
 )
 
@@ -66,14 +67,15 @@ func (o *Operation) cleanup() {
 }
 
 // NewManager creates a new manager for holding Operations.
-func NewManager() *Manager {
-	return &Manager{ops: map[string]*Operation{}}
+func NewManager(logger golog.Logger) *Manager {
+	return &Manager{ops: map[string]*Operation{}, logger: logger}
 }
 
 // Manager holds Operations.
 type Manager struct {
-	ops  map[string]*Operation
-	lock sync.Mutex
+	ops    map[string]*Operation
+	lock   sync.Mutex
+	logger golog.Logger
 }
 
 func (m *Manager) remove(id uuid.UUID) {

--- a/operation/opid_test.go
+++ b/operation/opid_test.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"testing"
 
+	"github.com/edaniels/golog"
 	"go.viam.com/test"
 )
 
 func TestBasic(t *testing.T) {
 	ctx := context.Background()
-	h := NewManager()
+
+	logger := golog.NewTestLogger(t)
+	h := NewManager(logger)
 	o := Get(ctx)
 	test.That(t, o, test.ShouldBeNil)
 

--- a/operation/web.go
+++ b/operation/web.go
@@ -27,7 +27,6 @@ func UnaryClientInterceptor(
 		ctx = metadata.AppendToOutgoingContext(ctx, opidMetadataKey, op.ID.String())
 	}
 	return invoker(ctx, method, req, reply, cc, opts...)
-	// TODO: should we something if the server provides a new opid?
 }
 
 // StreamClientInterceptor adds the operation id from the current context (if any) to the
@@ -45,7 +44,6 @@ func StreamClientInterceptor(
 		ctx = metadata.AppendToOutgoingContext(ctx, opidMetadataKey, op.ID.String())
 	}
 	return streamer(ctx, desc, cc, method, opts...)
-	// TODO: should we something if the server provides a new opid?
 }
 
 func (m *Manager) UnaryServerInterceptor(
@@ -93,7 +91,7 @@ func (m *Manager) StreamServerInterceptor(
 	return handler(srv, &ssStreamContextWrapper{ss, ctx})
 }
 
-// getOrCreateFromMetadata returns an operation id from metadata, or generates a random
+// GetOrCreateFromMetadata returns an operation id from metadata, or generates a random
 // UUID if the metadata does not contain any.
 func GetOrCreateFromMetadata(meta metadata.MD) (uuid.UUID, error) {
 	values := meta.Get(opidMetadataKey)

--- a/operation/web.go
+++ b/operation/web.go
@@ -43,6 +43,9 @@ func StreamClientInterceptor(
 	return streamer(ctx, desc, cc, method, opts...)
 }
 
+// UnaryServerInterceptor creates a new operation in the current context before passing
+// it to the unary response handler. If the incoming RPC metadata contains an operation
+// ID, the new operation will have the same ID.
 func (m *Manager) UnaryServerInterceptor(
 	ctx context.Context,
 	req interface{},
@@ -63,6 +66,9 @@ func (m *Manager) UnaryServerInterceptor(
 	return handler(ctx, req)
 }
 
+// StreamServerInterceptor creates a new operation in the current context before passing
+// it to the stream response handler. If the incoming RPC metadata contains an operation
+// ID, the new operation will have the same ID.
 func (m *Manager) StreamServerInterceptor(
 	srv interface{},
 	ss grpc.ServerStream,

--- a/operation/web.go
+++ b/operation/web.go
@@ -22,8 +22,7 @@ func UnaryClientInterceptor(
 	invoker googlegrpc.UnaryInvoker,
 	opts ...googlegrpc.CallOption,
 ) error {
-	if op := Get(ctx); op != nil {
-		// TODO: error if stringify fails?
+	if op := Get(ctx); op != nil && op.ID.String() != "" {
 		ctx = metadata.AppendToOutgoingContext(ctx, opidMetadataKey, op.ID.String())
 	}
 	return invoker(ctx, method, req, reply, cc, opts...)
@@ -39,8 +38,7 @@ func StreamClientInterceptor(
 	streamer googlegrpc.Streamer,
 	opts ...googlegrpc.CallOption,
 ) (googlegrpc.ClientStream, error) {
-	if op := Get(ctx); op != nil {
-		// TODO: error if stringify fails?
+	if op := Get(ctx); op != nil && op.ID.String() != "" {
 		ctx = metadata.AppendToOutgoingContext(ctx, opidMetadataKey, op.ID.String())
 	}
 	return streamer(ctx, desc, cc, method, opts...)

--- a/operation/web.go
+++ b/operation/web.go
@@ -1,0 +1,121 @@
+package operation
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+
+	googlegrpc "google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+const opidMetadataKey = "opid"
+
+// UnaryClientInterceptor adds the operation id from the current context (if any) to the
+// outgoing unary RPC metadata.
+func UnaryClientInterceptor(
+	ctx context.Context,
+	method string,
+	req, reply interface{},
+	cc *googlegrpc.ClientConn,
+	invoker googlegrpc.UnaryInvoker,
+	opts ...googlegrpc.CallOption,
+) error {
+	if op := Get(ctx); op != nil {
+		// TODO: error if stringify fails?
+		ctx = metadata.AppendToOutgoingContext(ctx, opidMetadataKey, op.ID.String())
+	}
+	return invoker(ctx, method, req, reply, cc, opts...)
+	// TODO: should we something if the server provides a new opid?
+}
+
+// StreamClientInterceptor adds the operation id from the current context (if any) to the
+// outgoing streaming RPC metadata.
+func StreamClientInterceptor(
+	ctx context.Context,
+	desc *googlegrpc.StreamDesc,
+	cc *googlegrpc.ClientConn,
+	method string,
+	streamer googlegrpc.Streamer,
+	opts ...googlegrpc.CallOption,
+) (googlegrpc.ClientStream, error) {
+	if op := Get(ctx); op != nil {
+		// TODO: error if stringify fails?
+		ctx = metadata.AppendToOutgoingContext(ctx, opidMetadataKey, op.ID.String())
+	}
+	return streamer(ctx, desc, cc, method, opts...)
+	// TODO: should we something if the server provides a new opid?
+}
+
+func (m *Manager) UnaryServerInterceptor(
+	ctx context.Context,
+	req interface{},
+	info *googlegrpc.UnaryServerInfo,
+	handler googlegrpc.UnaryHandler,
+) (interface{}, error) {
+	meta, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return nil, errors.New("failed to pull metadata from context")
+	}
+	opid, err := getOrCreateFromMetadata(meta)
+	if err != nil {
+		return nil, err
+	}
+	ctx, done := m.createWithID(ctx, opid, info.FullMethod, nil)
+	defer done()
+	meta.Set(opidMetadataKey, opid.String())
+	googlegrpc.SendHeader(ctx, meta)
+	return handler(ctx, req)
+}
+
+func (m *Manager) StreamServerInterceptor(
+	srv interface{},
+	ss googlegrpc.ServerStream,
+	info *googlegrpc.StreamServerInfo,
+	handler googlegrpc.StreamHandler,
+) error {
+	// check metadata for opids
+	ctx := ss.Context()
+	meta, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return errors.New("failed to pull metadata from context")
+	}
+	opid, err := getOrCreateFromMetadata(meta)
+	if err != nil {
+		return err
+	}
+	ctx, done := m.createWithID(ctx, opid, info.FullMethod, nil)
+	defer done()
+	meta.Set(opidMetadataKey, opid.String())
+	ss.SendHeader(meta)
+
+	return handler(srv, &ssStreamContextWrapper{ss, ctx})
+}
+
+// getOrCreateFromMetadata returns an operation id from metadata, or generates a random
+// UUID if the metadata does not contain any.
+func getOrCreateFromMetadata(meta metadata.MD) (uuid.UUID, error) {
+	values := meta.Get(opidMetadataKey)
+	switch len(values) {
+	case 0:
+		return uuid.New(), nil
+	case 1:
+		opid, err := uuid.Parse(values[0])
+		if err != nil {
+			return uuid.UUID{}, err
+		}
+		return opid, nil
+	default:
+		return uuid.UUID{}, errors.New("found more than one operation id in metadata")
+	}
+}
+
+type ssStreamContextWrapper struct {
+	googlegrpc.ServerStream
+	ctx context.Context
+}
+
+func (w ssStreamContextWrapper) Context() context.Context {
+	return w.ctx
+}

--- a/operation/web.go
+++ b/operation/web.go
@@ -58,7 +58,7 @@ func (m *Manager) UnaryServerInterceptor(
 	if !ok {
 		return nil, errors.New("failed to pull metadata from context")
 	}
-	opid, err := getOrCreateFromMetadata(meta)
+	opid, err := GetOrCreateFromMetadata(meta)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func (m *Manager) StreamServerInterceptor(
 	if !ok {
 		return errors.New("failed to pull metadata from context")
 	}
-	opid, err := getOrCreateFromMetadata(meta)
+	opid, err := GetOrCreateFromMetadata(meta)
 	if err != nil {
 		return err
 	}
@@ -95,7 +95,7 @@ func (m *Manager) StreamServerInterceptor(
 
 // getOrCreateFromMetadata returns an operation id from metadata, or generates a random
 // UUID if the metadata does not contain any.
-func getOrCreateFromMetadata(meta metadata.MD) (uuid.UUID, error) {
+func GetOrCreateFromMetadata(meta metadata.MD) (uuid.UUID, error) {
 	values := meta.Get(opidMetadataKey)
 	switch len(values) {
 	case 0:

--- a/operation/web.go
+++ b/operation/web.go
@@ -54,7 +54,8 @@ func (m *Manager) UnaryServerInterceptor(
 ) (interface{}, error) {
 	meta, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return nil, errors.New("failed to pull metadata from context")
+		m.logger.Warnw("failed to pull metadata from context", "method", info.FullMethod)
+		return handler(ctx, req)
 	}
 	opid, err := GetOrCreateFromMetadata(meta)
 	if err != nil {
@@ -78,7 +79,8 @@ func (m *Manager) StreamServerInterceptor(
 	ctx := ss.Context()
 	meta, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return errors.New("failed to pull metadata from context")
+		m.logger.Warnw("failed to pull metadata from context", "method", info.FullMethod)
+		return handler(srv, &ssStreamContextWrapper{ss, ctx})
 	}
 	opid, err := GetOrCreateFromMetadata(meta)
 	if err != nil {

--- a/operation/web.go
+++ b/operation/web.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
-	googlegrpc "google.golang.org/grpc"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -17,9 +17,9 @@ func UnaryClientInterceptor(
 	ctx context.Context,
 	method string,
 	req, reply interface{},
-	cc *googlegrpc.ClientConn,
-	invoker googlegrpc.UnaryInvoker,
-	opts ...googlegrpc.CallOption,
+	cc *grpc.ClientConn,
+	invoker grpc.UnaryInvoker,
+	opts ...grpc.CallOption,
 ) error {
 	if op := Get(ctx); op != nil && op.ID.String() != "" {
 		ctx = metadata.AppendToOutgoingContext(ctx, opidMetadataKey, op.ID.String())
@@ -31,12 +31,12 @@ func UnaryClientInterceptor(
 // outgoing streaming RPC metadata.
 func StreamClientInterceptor(
 	ctx context.Context,
-	desc *googlegrpc.StreamDesc,
-	cc *googlegrpc.ClientConn,
+	desc *grpc.StreamDesc,
+	cc *grpc.ClientConn,
 	method string,
-	streamer googlegrpc.Streamer,
-	opts ...googlegrpc.CallOption,
-) (googlegrpc.ClientStream, error) {
+	streamer grpc.Streamer,
+	opts ...grpc.CallOption,
+) (grpc.ClientStream, error) {
 	if op := Get(ctx); op != nil && op.ID.String() != "" {
 		ctx = metadata.AppendToOutgoingContext(ctx, opidMetadataKey, op.ID.String())
 	}
@@ -46,8 +46,8 @@ func StreamClientInterceptor(
 func (m *Manager) UnaryServerInterceptor(
 	ctx context.Context,
 	req interface{},
-	info *googlegrpc.UnaryServerInfo,
-	handler googlegrpc.UnaryHandler,
+	info *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler,
 ) (interface{}, error) {
 	meta, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
@@ -65,9 +65,9 @@ func (m *Manager) UnaryServerInterceptor(
 
 func (m *Manager) StreamServerInterceptor(
 	srv interface{},
-	ss googlegrpc.ServerStream,
-	info *googlegrpc.StreamServerInfo,
-	handler googlegrpc.StreamHandler,
+	ss grpc.ServerStream,
+	info *grpc.StreamServerInfo,
+	handler grpc.StreamHandler,
 ) error {
 	ctx := ss.Context()
 	meta, ok := metadata.FromIncomingContext(ctx)
@@ -103,7 +103,7 @@ func GetOrCreateFromMetadata(meta metadata.MD) (uuid.UUID, error) {
 }
 
 type ssStreamContextWrapper struct {
-	googlegrpc.ServerStream
+	grpc.ServerStream
 	ctx context.Context
 }
 

--- a/operation/web.go
+++ b/operation/web.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
-
 	googlegrpc "google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
@@ -60,8 +59,7 @@ func (m *Manager) UnaryServerInterceptor(
 	}
 	ctx, done := m.createWithID(ctx, opid, info.FullMethod, nil)
 	defer done()
-	meta.Set(opidMetadataKey, opid.String())
-	googlegrpc.SendHeader(ctx, meta)
+
 	return handler(ctx, req)
 }
 
@@ -71,7 +69,6 @@ func (m *Manager) StreamServerInterceptor(
 	info *googlegrpc.StreamServerInfo,
 	handler googlegrpc.StreamHandler,
 ) error {
-	// check metadata for opids
 	ctx := ss.Context()
 	meta, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
@@ -83,8 +80,6 @@ func (m *Manager) StreamServerInterceptor(
 	}
 	ctx, done := m.createWithID(ctx, opid, info.FullMethod, nil)
 	defer done()
-	meta.Set(opidMetadataKey, opid.String())
-	ss.SendHeader(meta)
 
 	return handler(srv, &ssStreamContextWrapper{ss, ctx})
 }

--- a/operation/web_test.go
+++ b/operation/web_test.go
@@ -1,0 +1,38 @@
+package operation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/edaniels/golog"
+	"github.com/google/uuid"
+	"go.viam.com/test"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestCreateFromIncomingContextWithoutOpid(t *testing.T) {
+	logger := golog.NewTestLogger(t)
+	m := NewManager(logger)
+
+	_, done := m.CreateFromIncomingContext(context.Background(), "fake")
+	defer done()
+
+	ops := m.All()
+	test.That(t, ops, test.ShouldHaveLength, 1)
+}
+
+func TestCreateFromIncomingContextWithOpid(t *testing.T) {
+	logger := golog.NewTestLogger(t)
+	m := NewManager(logger)
+
+	opid := uuid.New()
+	meta := metadata.New(map[string]string{opidMetadataKey: opid.String()})
+	ctx := metadata.NewIncomingContext(context.Background(), meta)
+	_, done := m.CreateFromIncomingContext(ctx, "fake")
+	defer done()
+
+	ops := m.All()
+
+	test.That(t, ops, test.ShouldHaveLength, 1)
+	test.That(t, ops[0].ID.String(), test.ShouldEqual, opid.String())
+}

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -75,6 +75,15 @@ type RobotClient struct {
 // context can be used to cancel the operation.
 func New(ctx context.Context, address string, logger golog.Logger, opts ...RobotClientOption) (*RobotClient, error) {
 	var rOpts robotClientOpts
+
+	rOpts.dialOptions = append(
+		rOpts.dialOptions,
+		// TODO: add method to go.viam.com/utils
+		rpc.WithUnaryClientInterceptor(operation.UnaryClientInterceptor),
+		// TODO: add method to go.viam.com/utils
+		rpc.WithStreamClientInterceptor(operation.StreamClientInterceptor),
+	)
+
 	for _, opt := range opts {
 		opt.apply(&rOpts)
 	}

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -78,9 +78,7 @@ func New(ctx context.Context, address string, logger golog.Logger, opts ...Robot
 
 	rOpts.dialOptions = append(
 		rOpts.dialOptions,
-		// TODO: add method to go.viam.com/utils
 		rpc.WithUnaryClientInterceptor(operation.UnaryClientInterceptor),
-		// TODO: add method to go.viam.com/utils
 		rpc.WithStreamClientInterceptor(operation.StreamClientInterceptor),
 	)
 

--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -1535,7 +1535,7 @@ func TestClientOperationIntercept(t *testing.T) {
 
 	ctx := context.Background()
 	var fakeArgs interface{}
-	fakeManager := operation.NewManager()
+	fakeManager := operation.NewManager(logger)
 	ctx, done := fakeManager.Create(ctx, "fake", fakeArgs)
 	defer done()
 	fakeOp := operation.Get(ctx)

--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -36,6 +36,7 @@ import (
 	gotestutils "go.viam.com/utils/testutils"
 	"gonum.org/v1/gonum/num/quat"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/reflection"
 
 	"go.viam.com/rdk/components/arm"
@@ -51,6 +52,7 @@ import (
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/discovery"
 	rgrpc "go.viam.com/rdk/grpc"
+	"go.viam.com/rdk/operation"
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/registry"
 	"go.viam.com/rdk/resource"
@@ -1510,6 +1512,50 @@ func TestRemoteClientDuplicate(t *testing.T) {
 	pos, err := resource1.(arm.Arm).EndPosition(context.Background(), nil)
 	test.That(t, err.Error(), test.ShouldEqual, "rpc error: code = Unknown desc = no arm with name (arm1)")
 	test.That(t, pos, test.ShouldBeNil)
+
+	err = client.Close(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+}
+
+func TestClientOperationIntercept(t *testing.T) {
+	logger := golog.NewTestLogger(t)
+	listener1, err := net.Listen("tcp", "localhost:0")
+	test.That(t, err, test.ShouldBeNil)
+
+	injectRobot := &inject.Robot{
+		ResourceNamesFunc:       func() []resource.Name { return []resource.Name{} },
+		ResourceRPCSubtypesFunc: func() []resource.RPCSubtype { return nil },
+	}
+
+	gServer := grpc.NewServer()
+	pb.RegisterRobotServiceServer(gServer, server.New(injectRobot))
+
+	go gServer.Serve(listener1)
+	defer gServer.Stop()
+
+	ctx := context.Background()
+	var fakeArgs interface{}
+	fakeManager := operation.NewManager()
+	ctx, done := fakeManager.Create(ctx, "fake", fakeArgs)
+	defer done()
+	fakeOp := operation.Get(ctx)
+	test.That(t, fakeOp, test.ShouldNotBeNil)
+
+	client, err := New(ctx, listener1.Addr().String(), logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	injectRobot.StatusFunc = func(ctx context.Context, resourceNames []resource.Name) ([]robot.Status, error) {
+		meta, ok := metadata.FromIncomingContext(ctx)
+		test.That(t, ok, test.ShouldBeTrue)
+		receivedOpID, err := operation.GetOrCreateFromMetadata(meta)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, receivedOpID.String(), test.ShouldEqual, fakeOp.ID.String())
+		return []robot.Status{}, nil
+	}
+
+	resp, err := client.Status(ctx, []resource.Name{})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, len(resp), test.ShouldEqual, 0)
 
 	err = client.Close(context.Background())
 	test.That(t, err, test.ShouldBeNil)

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -384,7 +384,7 @@ func newWithResources(
 			},
 			logger,
 		),
-		operations:                 operation.NewManager(),
+		operations:                 operation.NewManager(logger),
 		logger:                     logger,
 		remotesChanged:             make(chan string),
 		activeBackgroundWorkers:    &sync.WaitGroup{},

--- a/testutils/inject/robot.go
+++ b/testutils/inject/robot.go
@@ -119,7 +119,7 @@ func (r *Robot) OperationManager() *operation.Manager {
 	defer r.opsLock.Unlock()
 
 	if r.ops == nil {
-		r.ops = operation.NewManager()
+		r.ops = operation.NewManager(r.Logger())
 	}
 	return r.ops
 }


### PR DESCRIPTION
JIRA: https://viam.atlassian.net/browse/RSDK-578

Add client interceptors to pass opids from client to server, and update server interceptors to re-use client-sent opids.

Prerequisites:
* [x] https://github.com/viamrobotics/goutils/pull/72