### PR TITLE
[Data-565] Fix for flaky join pointcloud naive test

### DIFF
--- a/components/camera/videosource/join_pointcloud.go
+++ b/components/camera/videosource/join_pointcloud.go
@@ -209,8 +209,8 @@ func (jpcs *joinPointCloudSource) NextPointCloudNaive(ctx context.Context) (poin
 
 			var wg sync.WaitGroup
 			const numLoops = 8
-			wg.Add(numLoops)
 			for loop := 0; loop < numLoops; loop++ {
+				wg.Add(1)
 				f := func(loop int) {
 					defer wg.Done()
 					const batchSize = 500

--- a/components/camera/videosource/join_pointcloud.go
+++ b/components/camera/videosource/join_pointcloud.go
@@ -202,7 +202,7 @@ func (jpcs *joinPointCloudSource) NextPointCloudNaive(ctx context.Context) (poin
 		cloudFuncs[iCopy] = pcSrc
 	}
 
-	return pointcloud.MergePointClouds(ctx, cloudFuncs)
+	return pointcloud.MergePointClouds(ctx, cloudFuncs, jpcs.logger)
 }
 
 func (jpcs *joinPointCloudSource) NextPointCloudICP(ctx context.Context) (pointcloud.PointCloud, error) {
@@ -336,7 +336,7 @@ func (jpcs *joinPointCloudSource) Read(ctx context.Context) (image.Image, func()
 	if err != nil {
 		return nil, nil, err
 	}
-	if jpcs.debug {
+	if jpcs.debug && pc != nil {
 		jpcs.logger.Debugf("joinPointCloudSource Read: number of points in pointcloud: %d", pc.Size())
 	}
 	img, dm, err := proj.PointCloudToRGBD(pc)

--- a/components/camera/videosource/join_pointcloud.go
+++ b/components/camera/videosource/join_pointcloud.go
@@ -174,7 +174,7 @@ func (jpcs *joinPointCloudSource) NextPointCloudNaive(ctx context.Context) (poin
 	if err != nil {
 		return nil, err
 	}
-	cloudFuncs := make([]pointcloud.PointCloudWithOffsetFunc, len(jpcs.sourceCameras))
+	cloudFuncs := make([]pointcloud.CloudAndOffsetFunc, len(jpcs.sourceCameras))
 	for i, cam := range jpcs.sourceCameras {
 		iCopy := i
 		camCopy := cam
@@ -196,7 +196,7 @@ func (jpcs *joinPointCloudSource) NextPointCloudNaive(ctx context.Context) (poin
 			}
 			return pc, framePose, nil
 		}
-		cloudFuncs[i] = pcSrc
+		cloudFuncs[iCopy] = pcSrc
 	}
 
 	return pointcloud.MergePointClouds(ctx, cloudFuncs)

--- a/components/camera/videosource/join_pointcloud.go
+++ b/components/camera/videosource/join_pointcloud.go
@@ -337,7 +337,7 @@ func (jpcs *joinPointCloudSource) Read(ctx context.Context) (image.Image, func()
 		return nil, nil, err
 	}
 	if jpcs.debug {
-		jpcs.logger.Debugf("number of points in pointcloud: %d", pc.Size())
+		jpcs.logger.Debugf("joinPointCloudSource Read: number of points in pointcloud: %d", pc.Size())
 	}
 	img, dm, err := proj.PointCloudToRGBD(pc)
 	if err != nil {

--- a/components/camera/videosource/join_pointcloud.go
+++ b/components/camera/videosource/join_pointcloud.go
@@ -403,6 +403,7 @@ func (jpcs *joinPointCloudSource) Read(ctx context.Context) (image.Image, func()
 	if err != nil {
 		return nil, nil, err
 	}
+	jpcs.logger.Debugf("number of points: %d", pc.Size())
 	img, dm, err := proj.PointCloudToRGBD(pc)
 	if err != nil {
 		return nil, nil, err

--- a/components/camera/videosource/join_pointcloud.go
+++ b/components/camera/videosource/join_pointcloud.go
@@ -194,6 +194,9 @@ func (jpcs *joinPointCloudSource) NextPointCloudNaive(ctx context.Context) (poin
 			if err != nil {
 				return nil, nil, err
 			}
+			if pc == nil {
+				return nil, nil, errors.Errorf("camera %q returned a nil point cloud", jpcs.sourceNames[iCopy])
+			}
 			return pc, framePose, nil
 		}
 		cloudFuncs[iCopy] = pcSrc

--- a/components/camera/videosource/join_pointcloud.go
+++ b/components/camera/videosource/join_pointcloud.go
@@ -6,15 +6,11 @@ import (
 	"image"
 	"math"
 	"strings"
-	"sync"
-	"sync/atomic"
-	"time"
 
 	"github.com/edaniels/golog"
 	"github.com/golang/geo/r3"
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
-	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/components/generic"
@@ -178,98 +174,28 @@ func (jpcs *joinPointCloudSource) NextPointCloudNaive(ctx context.Context) (poin
 	if err != nil {
 		return nil, err
 	}
-
-	finalPoints := make(chan []pointcloud.PointAndData, 50)
-	activeReaders := int32(len(jpcs.sourceCameras))
-
+	cloudFuncs := make([]pointcloud.PointCloudWithOffsetFunc, len(jpcs.sourceCameras))
 	for i, cam := range jpcs.sourceCameras {
 		iCopy := i
 		camCopy := cam
-		utils.PanicCapturingGo(func() {
-			ctx, span := trace.StartSpan(ctx, "camera::joinPointCloudSource::NextPointCloud::"+jpcs.sourceNames[iCopy])
+		pcSrc := func(ctx context.Context) (pointcloud.PointCloud, spatialmath.Pose, error) {
+			ctx, span := trace.StartSpan(ctx, "camera::joinPointCloudSource::NextPointCloud::"+jpcs.sourceNames[iCopy]+"-NextPointCloud")
 			defer span.End()
-
-			defer func() {
-				atomic.AddInt32(&activeReaders, -1)
-			}()
-			pcSrc, err := func() (pointcloud.PointCloud, error) {
-				ctx, span := trace.StartSpan(ctx, "camera::joinPointCloudSource::NextPointCloud::"+jpcs.sourceNames[iCopy]+"-NextPointCloud")
-				defer span.End()
-				return camCopy.NextPointCloud(ctx)
-			}()
-			if err != nil {
-				panic(err) // TODO(erh) is there something better to do?
-			}
-
 			sourceFrame := referenceframe.NewPoseInFrame(jpcs.sourceNames[iCopy], spatialmath.NewZeroPose())
 			theTransform, err := fs.Transform(inputs, sourceFrame, jpcs.targetName)
 			if err != nil {
-				panic(err) // TODO(erh) is there something better to do?
+				return nil, nil, err
 			}
-
-			var wg sync.WaitGroup
-			const numLoops = 8
-			for loop := 0; loop < numLoops; loop++ {
-				wg.Add(1)
-				f := func(loop int) {
-					defer wg.Done()
-					const batchSize = 500
-					batch := make([]pointcloud.PointAndData, 0, batchSize)
-					savedDualQuat := spatialmath.NewZeroPose()
-					pcSrc.Iterate(numLoops, loop, func(p r3.Vector, d pointcloud.Data) bool {
-						if jpcs.sourceNames[iCopy] != jpcs.targetName {
-							spatialmath.ResetPoseDQTranslation(savedDualQuat, p)
-							newPose := spatialmath.Compose(theTransform.(*referenceframe.PoseInFrame).Pose(), savedDualQuat)
-							p = newPose.Point()
-						}
-						batch = append(batch, pointcloud.PointAndData{P: p, D: d})
-						if len(batch) > batchSize {
-							finalPoints <- batch
-							batch = make([]pointcloud.PointAndData, 0, batchSize)
-						}
-						return true
-					})
-					finalPoints <- batch
-				}
-				loopCopy := loop
-				utils.PanicCapturingGo(func() { f(loopCopy) })
+			pc, err := camCopy.NextPointCloud(ctx)
+			if err != nil {
+				return nil, nil, err
 			}
-			wg.Wait()
-		})
-	}
-
-	var pcTo pointcloud.PointCloud
-
-	dataLastTime := false
-	for dataLastTime || atomic.LoadInt32(&activeReaders) > 0 {
-		select {
-		case ps := <-finalPoints:
-			for _, p := range ps {
-				if pcTo == nil {
-					if p.D == nil {
-						pcTo = pointcloud.NewAppendOnlyOnlyPointsPointCloud(len(jpcs.sourceNames) * 640 * 800)
-					} else {
-						pcTo = pointcloud.NewWithPrealloc(len(jpcs.sourceNames) * 640 * 800)
-					}
-				}
-
-				myErr := pcTo.Set(p.P, p.D)
-				if myErr != nil {
-					err = myErr
-				}
-			}
-			dataLastTime = true
-		case <-time.After(5 * time.Millisecond):
-			dataLastTime = false
-			continue
+			return pc, theTransform.(*referenceframe.PoseInFrame).Pose(), nil
 		}
+		cloudFuncs[i] = pcSrc
 	}
 
-	if err != nil {
-		return nil, err
-	}
-
-	return pcTo, nil
+	return pointcloud.MergePointClouds(ctx, cloudFuncs)
 }
 
 func (jpcs *joinPointCloudSource) NextPointCloudICP(ctx context.Context) (pointcloud.PointCloud, error) {
@@ -403,7 +329,9 @@ func (jpcs *joinPointCloudSource) Read(ctx context.Context) (image.Image, func()
 	if err != nil {
 		return nil, nil, err
 	}
-	jpcs.logger.Debugf("number of points: %d", pc.Size())
+	if jpcs.debug {
+		jpcs.logger.Debugf("number of points in pointcloud: %d", pc.Size())
+	}
 	img, dm, err := proj.PointCloudToRGBD(pc)
 	if err != nil {
 		return nil, nil, err

--- a/components/camera/videosource/join_pointcloud_test.go
+++ b/components/camera/videosource/join_pointcloud_test.go
@@ -157,6 +157,7 @@ func TestJoinPointCloudNaive(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	pc, err := joinedCam.NextPointCloud(context.Background())
 	test.That(t, err, test.ShouldBeNil)
+	t.Logf("contents: %#v", pc)
 	test.That(t, pc.Size(), test.ShouldEqual, 3)
 
 	data, got := pc.At(101, 0, 0)
@@ -171,9 +172,7 @@ func TestJoinPointCloudNaive(t *testing.T) {
 	test.That(t, got, test.ShouldBeTrue)
 	test.That(t, data.Color(), test.ShouldResemble, &color.NRGBA{0, 0, 255, 255})
 
-	stream, err := joinedCam.Stream(context.Background())
-	test.That(t, err, test.ShouldBeNil)
-	img, _, err := stream.Next(context.Background())
+	img, _, err := camera.ReadImage(context.Background(), joinedCam)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, img.Bounds(), test.ShouldResemble, image.Rect(0, 0, 1, 100))
 	test.That(t, joinedCam.Close(context.Background()), test.ShouldBeNil)
@@ -189,6 +188,7 @@ func TestJoinPointCloudNaive(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	pc, err = joinedCam2.NextPointCloud(context.Background())
 	test.That(t, err, test.ShouldBeNil)
+	t.Logf("contents: %#v", pc)
 	test.That(t, pc.Size(), test.ShouldEqual, 3)
 
 	data, got = pc.At(1, 0, 0)
@@ -203,9 +203,7 @@ func TestJoinPointCloudNaive(t *testing.T) {
 	test.That(t, got, test.ShouldBeTrue)
 	test.That(t, data.Color(), test.ShouldResemble, &color.NRGBA{0, 0, 255, 255})
 
-	stream, err = joinedCam2.Stream(context.Background())
-	test.That(t, err, test.ShouldBeNil)
-	img, _, err = stream.Next(context.Background())
+	img, _, err = camera.ReadImage(context.Background(), joinedCam2)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, img.Bounds(), test.ShouldResemble, image.Rect(0, 0, 1, 100))
 	test.That(t, joinedCam2.Close(context.Background()), test.ShouldBeNil)

--- a/components/camera/videosource/join_pointcloud_test.go
+++ b/components/camera/videosource/join_pointcloud_test.go
@@ -157,6 +157,7 @@ func TestJoinPointCloudNaive(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	pc, err := joinedCam.NextPointCloud(context.Background())
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, pc, test.ShouldNotBeNil)
 	test.That(t, pc.Size(), test.ShouldEqual, 3)
 
 	data, got := pc.At(101, 0, 0)
@@ -187,6 +188,7 @@ func TestJoinPointCloudNaive(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	pc, err = joinedCam2.NextPointCloud(context.Background())
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, pc, test.ShouldNotBeNil)
 	test.That(t, pc.Size(), test.ShouldEqual, 3)
 
 	data, got = pc.At(1, 0, 0)

--- a/components/camera/videosource/join_pointcloud_test.go
+++ b/components/camera/videosource/join_pointcloud_test.go
@@ -157,11 +157,6 @@ func TestJoinPointCloudNaive(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	pc, err := joinedCam.NextPointCloud(context.Background())
 	test.That(t, err, test.ShouldBeNil)
-	t.Logf("contents: %#v", pc)
-	pc.Iterate(0, 0, func(p r3.Vector, d pointcloud.Data) bool {
-		t.Logf("point: %v, data: %v", p, d)
-		return true
-	})
 	test.That(t, pc.Size(), test.ShouldEqual, 3)
 
 	data, got := pc.At(101, 0, 0)
@@ -192,11 +187,6 @@ func TestJoinPointCloudNaive(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	pc, err = joinedCam2.NextPointCloud(context.Background())
 	test.That(t, err, test.ShouldBeNil)
-	t.Logf("contents: %#v", pc)
-	pc.Iterate(0, 0, func(p r3.Vector, d pointcloud.Data) bool {
-		t.Logf("point: %v, data: %v", p, d)
-		return true
-	})
 	test.That(t, pc.Size(), test.ShouldEqual, 3)
 
 	data, got = pc.At(1, 0, 0)
@@ -461,8 +451,6 @@ func TestTwinPointCloudICP(t *testing.T) {
 	filename := "test_twin_" + time.Now().Format(time.RFC3339) + "*.pcd"
 	file, err := os.CreateTemp("/tmp", filename)
 	pointcloud.ToPCD(pc, file, pointcloud.PCDBinary)
-
-	utils.Logger.Debugf("Number of points: %d", pc.Size())
 
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, pc, test.ShouldNotBeNil)

--- a/components/camera/videosource/join_pointcloud_test.go
+++ b/components/camera/videosource/join_pointcloud_test.go
@@ -158,6 +158,10 @@ func TestJoinPointCloudNaive(t *testing.T) {
 	pc, err := joinedCam.NextPointCloud(context.Background())
 	test.That(t, err, test.ShouldBeNil)
 	t.Logf("contents: %#v", pc)
+	pc.Iterate(0, 0, func(p r3.Vector, d pointcloud.Data) bool {
+		t.Logf("point: %v, data: %v", p, d)
+		return true
+	})
 	test.That(t, pc.Size(), test.ShouldEqual, 3)
 
 	data, got := pc.At(101, 0, 0)
@@ -189,6 +193,10 @@ func TestJoinPointCloudNaive(t *testing.T) {
 	pc, err = joinedCam2.NextPointCloud(context.Background())
 	test.That(t, err, test.ShouldBeNil)
 	t.Logf("contents: %#v", pc)
+	pc.Iterate(0, 0, func(p r3.Vector, d pointcloud.Data) bool {
+		t.Logf("point: %v, data: %v", p, d)
+		return true
+	})
 	test.That(t, pc.Size(), test.ShouldEqual, 3)
 
 	data, got = pc.At(1, 0, 0)

--- a/components/camera/videosource/join_pointcloud_test.go
+++ b/components/camera/videosource/join_pointcloud_test.go
@@ -171,7 +171,9 @@ func TestJoinPointCloudNaive(t *testing.T) {
 	test.That(t, got, test.ShouldBeTrue)
 	test.That(t, data.Color(), test.ShouldResemble, &color.NRGBA{0, 0, 255, 255})
 
-	img, _, err := camera.ReadImage(context.Background(), joinedCam)
+	stream, err := joinedCam.Stream(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+	img, _, err := stream.Next(context.Background())
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, img.Bounds(), test.ShouldResemble, image.Rect(0, 0, 1, 100))
 	test.That(t, joinedCam.Close(context.Background()), test.ShouldBeNil)
@@ -201,7 +203,9 @@ func TestJoinPointCloudNaive(t *testing.T) {
 	test.That(t, got, test.ShouldBeTrue)
 	test.That(t, data.Color(), test.ShouldResemble, &color.NRGBA{0, 0, 255, 255})
 
-	img, _, err = camera.ReadImage(context.Background(), joinedCam2)
+	stream, err = joinedCam2.Stream(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+	img, _, err = stream.Next(context.Background())
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, img.Bounds(), test.ShouldResemble, image.Rect(0, 0, 1, 100))
 	test.That(t, joinedCam2.Close(context.Background()), test.ShouldBeNil)

--- a/components/camera/videosource/join_pointcloud_test.go
+++ b/components/camera/videosource/join_pointcloud_test.go
@@ -148,7 +148,7 @@ func TestJoinPointCloudNaive(t *testing.T) {
 	test.That(t, pc3.Size(), test.ShouldEqual, 1)
 	// PoV from base1
 	attrs := &JoinAttrs{
-		AttrConfig:    &camera.AttrConfig{},
+		AttrConfig:    &camera.AttrConfig{Debug: true},
 		SourceCameras: []string{"cam1", "cam2", "cam3"},
 		TargetFrame:   "base1",
 		MergeMethod:   "naive",
@@ -183,7 +183,7 @@ func TestJoinPointCloudNaive(t *testing.T) {
 
 	// PoV from cam1
 	attrs2 := &JoinAttrs{
-		AttrConfig:    &camera.AttrConfig{},
+		AttrConfig:    &camera.AttrConfig{Debug: true},
 		SourceCameras: []string{"cam1", "cam2", "cam3"},
 		TargetFrame:   "cam1",
 		MergeMethod:   "naive",
@@ -423,6 +423,7 @@ func TestFixedPointCloudICP(t *testing.T) {
 	attrs := &JoinAttrs{
 		AttrConfig: &camera.AttrConfig{
 			Stream: "",
+			Debug:  true,
 		},
 		SourceCameras: []string{"cam1", "cam2"},
 		TargetFrame:   "base1",
@@ -446,6 +447,7 @@ func TestTwinPointCloudICP(t *testing.T) {
 	attrs := &JoinAttrs{
 		AttrConfig: &camera.AttrConfig{
 			Stream: "",
+			Debug:  true,
 		},
 		SourceCameras: []string{"cam3", "cam4"},
 		TargetFrame:   "cam3",
@@ -475,6 +477,7 @@ func TestMultiPointCloudICP(t *testing.T) {
 	attrs := &JoinAttrs{
 		AttrConfig: &camera.AttrConfig{
 			Stream: "",
+			Debug:  true,
 		},
 		SourceCameras: []string{"cam3", "cam4", "cam5"},
 		TargetFrame:   "cam3",

--- a/components/camera/videosource/join_pointcloud_test.go
+++ b/components/camera/videosource/join_pointcloud_test.go
@@ -124,28 +124,6 @@ func makeFakeRobot(t *testing.T) robot.Robot {
 func TestJoinPointCloudNaive(t *testing.T) {
 	r := makeFakeRobot(t)
 	defer utils.TryClose(context.Background(), r)
-	// check if all three pointclouds return a point
-	// cam1
-	cam1, err := camera.FromRobot(r, "cam1")
-	test.That(t, err, test.ShouldBeNil)
-	defer utils.TryClose(context.Background(), cam1)
-	pc1, err := cam1.NextPointCloud(context.Background())
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, pc1.Size(), test.ShouldEqual, 1)
-	// cam2
-	cam2, err := camera.FromRobot(r, "cam2")
-	test.That(t, err, test.ShouldBeNil)
-	defer utils.TryClose(context.Background(), cam2)
-	pc2, err := cam2.NextPointCloud(context.Background())
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, pc2.Size(), test.ShouldEqual, 1)
-	// cam3
-	cam3, err := camera.FromRobot(r, "cam3")
-	test.That(t, err, test.ShouldBeNil)
-	defer utils.TryClose(context.Background(), cam3)
-	pc3, err := cam3.NextPointCloud(context.Background())
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, pc3.Size(), test.ShouldEqual, 1)
 	// PoV from base1
 	attrs := &JoinAttrs{
 		AttrConfig:    &camera.AttrConfig{Debug: true},

--- a/components/camera/videosource/join_pointcloud_test.go
+++ b/components/camera/videosource/join_pointcloud_test.go
@@ -34,7 +34,7 @@ func makeFakeRobot(t *testing.T) robot.Robot {
 	logger := golog.NewTestLogger(t)
 	cam1 := &inject.Camera{}
 	cam1.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
-		pc1 := pointcloud.New()
+		pc1 := pointcloud.NewWithPrealloc(1)
 		err := pc1.Set(pointcloud.NewVector(1, 0, 0), pointcloud.NewColoredData(color.NRGBA{255, 0, 0, 255}))
 		test.That(t, err, test.ShouldBeNil)
 		return pc1, nil
@@ -47,7 +47,7 @@ func makeFakeRobot(t *testing.T) robot.Robot {
 	}
 	cam2 := &inject.Camera{}
 	cam2.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
-		pc2 := pointcloud.New()
+		pc2 := pointcloud.NewWithPrealloc(1)
 		err := pc2.Set(pointcloud.NewVector(0, 1, 0), pointcloud.NewColoredData(color.NRGBA{0, 255, 0, 255}))
 		test.That(t, err, test.ShouldBeNil)
 		return pc2, nil
@@ -60,7 +60,7 @@ func makeFakeRobot(t *testing.T) robot.Robot {
 	}
 	cam3 := &inject.Camera{}
 	cam3.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
-		pc3 := pointcloud.New()
+		pc3 := pointcloud.NewWithPrealloc(1)
 		err := pc3.Set(pointcloud.NewVector(0, 0, 1), pointcloud.NewColoredData(color.NRGBA{0, 0, 255, 255}))
 		test.That(t, err, test.ShouldBeNil)
 		return pc3, nil
@@ -303,6 +303,9 @@ func makeFakeRobotICP(t *testing.T) (robot.Robot, error) {
 	cam3.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
 		return pc3, nil
 	}
+	cam3.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
+		return camera.Properties{}, nil
+	}
 
 	cam4 := &inject.Camera{}
 	pc4, err := makePointCloudFromArtifact(t, "pointcloud/bun045.pcd", 0)
@@ -313,6 +316,9 @@ func makeFakeRobotICP(t *testing.T) (robot.Robot, error) {
 	cam4.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
 		return pc4, nil
 	}
+	cam4.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
+		return camera.Properties{}, nil
+	}
 
 	cam5 := &inject.Camera{}
 	pc5, err := makePointCloudFromArtifact(t, "pointcloud/bun090.pcd", 0)
@@ -322,6 +328,9 @@ func makeFakeRobotICP(t *testing.T) (robot.Robot, error) {
 
 	cam5.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
 		return pc5, nil
+	}
+	cam5.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
+		return camera.Properties{}, nil
 	}
 
 	base1 := &inject.Base{}

--- a/pointcloud/merging.go
+++ b/pointcloud/merging.go
@@ -79,10 +79,8 @@ func MergePointClouds(ctx context.Context, cloudFuncs []CloudAndOffsetFunc, logg
 	dataLastTime := false // there was data in the channel in the previous loop, so continue reading.
 	for firstRead || dataLastTime || atomic.LoadInt32(&activeReaders) > 0 {
 		firstRead = false
-		logger.Debugf("number of batches in channel: %d", len(finalPoints))
 		select {
 		case ps := <-finalPoints:
-			logger.Debugf("number of pts in batch: %d", len(ps))
 			for _, p := range ps {
 				if pcTo == nil {
 					if p.D == nil {
@@ -107,7 +105,6 @@ func MergePointClouds(ctx context.Context, cloudFuncs []CloudAndOffsetFunc, logg
 	select {
 	case lastPoints, ok := <-finalPoints:
 		if ok {
-			logger.Debugf("in last points, number of last points: %d", len(lastPoints))
 			for _, p := range lastPoints {
 				myErr := pcTo.Set(p.P, p.D)
 				if myErr != nil {

--- a/pointcloud/merging.go
+++ b/pointcloud/merging.go
@@ -80,10 +80,8 @@ func MergePointClouds(ctx context.Context, cloudFuncs []CloudAndOffsetFunc, logg
 	lastRead := false     // read one more time in case all active readers finished while loop was waiting for data.
 	for firstRead || lastRead || dataLastTime || atomic.LoadInt32(&activeReaders) > 0 {
 		firstRead = false
-		logger.Debugf("number of batches in channel: %d\n", len(finalPoints))
 		select {
 		case ps := <-finalPoints:
-			logger.Debugf("number of points in batch: %d\n", len(ps))
 			for _, p := range ps {
 				if pcTo == nil {
 					if p.D == nil {

--- a/pointcloud/merging.go
+++ b/pointcloud/merging.go
@@ -28,6 +28,7 @@ func MergePointClouds(ctx context.Context, cloudFuncs []PointCloudWithOffsetFunc
 	activeReaders := int32(len(cloudFuncs))
 	for i, pcSrc := range cloudFuncs {
 		iCopy := i
+		pcSrcCopy := pcSrc
 		utils.PanicCapturingGo(func() {
 			_, span := trace.StartSpan(ctx, "pointcloud::MergePointClouds::Cloud"+fmt.Sprint(iCopy))
 			defer span.End()
@@ -35,7 +36,7 @@ func MergePointClouds(ctx context.Context, cloudFuncs []PointCloudWithOffsetFunc
 			defer func() {
 				atomic.AddInt32(&activeReaders, -1)
 			}()
-			pc, offset, err := pcSrc(ctx)
+			pc, offset, err := pcSrcCopy(ctx)
 			if err != nil {
 				panic(err) // TODO(erh) is there something better to do?
 			}

--- a/pointcloud/merging.go
+++ b/pointcloud/merging.go
@@ -101,10 +101,10 @@ func MergePointClouds(ctx context.Context, cloudFuncs []CloudAndOffsetFunc, logg
 	}
 	// one last read to flush out any potential last data- sometimes there is still data in finalPoints.
 	lastBatches := len(finalPoints)
-	logger.Debugf("number of last batches: %d", lastBatches)
+	logger.Debugf("merge points clouds: number of last batches: %d", lastBatches)
 	for i := 0; i < lastBatches; i++ {
 		lastPoints := <-finalPoints
-		logger.Debugf("number of points in batch %d: %d", i, len(lastPoints))
+		logger.Debugf("merge point clouds: number of points in batch %d: %d", i, len(lastPoints))
 		if len(lastPoints) == 0 {
 			continue
 		}

--- a/pointcloud/merging.go
+++ b/pointcloud/merging.go
@@ -75,7 +75,7 @@ func MergePointClouds(ctx context.Context, cloudFuncs []CloudAndOffsetFunc, logg
 	var pcTo PointCloud
 	var err error
 
-	dataLastTime := false // there was data in the channel in the previous loop, so continue reading.
+	dataLastTime := false // if there was data in the channel in the previous loop, continue reading.
 	for dataLastTime || atomic.LoadInt32(&activeReaders) > 0 {
 		select {
 		case ps := <-finalPoints:

--- a/pointcloud/merging.go
+++ b/pointcloud/merging.go
@@ -13,8 +13,9 @@ import (
 	"github.com/golang/geo/r3"
 	"github.com/lucasb-eyer/go-colorful"
 	"go.opencensus.io/trace"
-	"go.viam.com/rdk/spatialmath"
 	"go.viam.com/utils"
+
+	"go.viam.com/rdk/spatialmath"
 )
 
 // CloudAndOffsetFunc is a function that returns a PointCloud with a pose that represents an offset to be applied to every point.
@@ -113,7 +114,6 @@ func MergePointClouds(ctx context.Context, cloudFuncs []CloudAndOffsetFunc, logg
 	}
 
 	return pcTo, nil
-
 }
 
 // MergePointCloudsWithColor creates a union of point clouds from the slice of point clouds, giving

--- a/pointcloud/merging.go
+++ b/pointcloud/merging.go
@@ -97,12 +97,15 @@ func MergePointClouds(ctx context.Context, cloudFuncs []CloudAndOffsetFunc, logg
 				}
 			}
 			dataLastTime = true
+			lastRead = false
 		case <-time.After(5 * time.Millisecond):
 			dataLastTime = false
 			if lastRead {
 				break // this is the 2nd time waiting for data.
 			}
-			lastRead = true
+			if atomic.LoadInt32(&activeReaders) == 0 {
+				lastRead = true
+			}
 			continue
 		}
 	}

--- a/pointcloud/merging.go
+++ b/pointcloud/merging.go
@@ -101,10 +101,8 @@ func MergePointClouds(ctx context.Context, cloudFuncs []CloudAndOffsetFunc, logg
 	}
 	// one last read to flush out any potential last data- sometimes there is still data in finalPoints.
 	lastBatches := len(finalPoints)
-	logger.Debugf("merge points clouds: number of last batches: %d", lastBatches)
 	for i := 0; i < lastBatches; i++ {
 		lastPoints := <-finalPoints
-		logger.Debugf("merge point clouds: number of points in batch %d: %d", i, len(lastPoints))
 		if len(lastPoints) == 0 {
 			continue
 		}

--- a/pointcloud/merging.go
+++ b/pointcloud/merging.go
@@ -12,15 +12,16 @@ import (
 	"github.com/golang/geo/r3"
 	"github.com/lucasb-eyer/go-colorful"
 	"go.opencensus.io/trace"
-	"go.viam.com/rdk/spatialmath"
 	"go.viam.com/utils"
+
+	"go.viam.com/rdk/spatialmath"
 )
 
-// PointCloudWithOffsetFunc is a function that returns a PointCloudWithOffset
-type PointCloudWithOffsetFunc func(context context.Context) (PointCloud, spatialmath.Pose, error)
+// CloudAndOffsetFunc is a function that returns a PointCloud with a pose that represents an offset to be applied to every point.
+type CloudAndOffsetFunc func(context context.Context) (PointCloud, spatialmath.Pose, error)
 
 // MergePointClouds takes a slice of points clouds with optional offsets and adds all their points to one point cloud.
-func MergePointClouds(ctx context.Context, cloudFuncs []PointCloudWithOffsetFunc) (PointCloud, error) {
+func MergePointClouds(ctx context.Context, cloudFuncs []CloudAndOffsetFunc) (PointCloud, error) {
 	if len(cloudFuncs) == 0 {
 		return nil, errors.New("no point clouds to merge")
 	}
@@ -103,7 +104,6 @@ func MergePointClouds(ctx context.Context, cloudFuncs []PointCloudWithOffsetFunc
 	}
 
 	return pcTo, nil
-
 }
 
 // MergePointCloudsWithColor creates a union of point clouds from the slice of point clouds, giving

--- a/pointcloud/merging.go
+++ b/pointcloud/merging.go
@@ -1,0 +1,128 @@
+package pointcloud
+
+import (
+	"errors"
+	"image/color"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/golang/geo/r3"
+	"github.com/lucasb-eyer/go-colorful"
+	"go.opencensus.io/trace"
+	"go.viam.com/rdk/spatialmath"
+	"go.viam.com/utils"
+)
+
+// PointCloudWithOffset has an optional offset that gets applied to every point within the point cloud.
+type PointCloudWithOffset struct {
+	PointCloud
+	Offset spatialmath.Pose
+}
+
+// MergePointClouds takes a slice of points clouds with optional offsets and adds all their points to one point cloud.
+func MergePointClouds(clouds []PointCloudWithOffset) (PointCloud, error) {
+	if len(clouds) == 0 {
+		return nil, errors.New("no point clouds to merge")
+	}
+	if len(clouds) == 1 && clouds[0].Offset == nil {
+		return clouds[0], nil
+	}
+	finalPoints := make(chan []PointAndData, 50)
+	activeReaders := int32(len(clouds))
+	for i, pc := range clouds {
+		iCopy := i
+		pcCopy := pc
+		utils.PanicCapturingGo(func() {
+			ctx, span := trace.StartSpan(ctx, "pointcloud::MergePointClouds::Cloud"+string(i))
+			defer span.End()
+
+			defer func() {
+				atomic.AddInt32(&activeReaders, -1)
+			}()
+			var wg sync.WaitGroup
+			const numLoops = 8
+			for loop := 0; loop < numLoops; loop++ {
+				wg.Add(1)
+				f := func(loop int) {
+					defer wg.Done()
+					const batchSize = 500
+					batch := make([]PointAndData, 0, batchSize)
+					savedDualQuat := spatialmath.NewZeroPose()
+					pcSrc.Iterate(numLoops, loop, func(p r3.Vector, d Data) bool {
+						if pcCopy.Offset != nil {
+							spatialmath.ResetPoseDQTranslation(savedDualQuat, p)
+							newPose := spatialmath.Compose(pcCopy.Offset, savedDualQuat)
+							p = newPose.Point()
+						}
+						batch = append(batch, PointAndData{P: p, D: d})
+						if len(batch) > batchSize {
+							finalPoints <- batch
+							batch = make([]PointAndData, 0, batchSize)
+						}
+						return true
+					})
+					finalPoints <- batch
+				}
+				loopCopy := loop
+				utils.PanicCapturingGo(func() { f(loopCopy) })
+			}
+			wg.Wait()
+		})
+	}
+	var pcTo PointCloud
+
+	dataLastTime := false
+	for dataLastTime || atomic.LoadInt32(&activeReaders) > 0 {
+		select {
+		case ps := <-finalPoints:
+			for _, p := range ps {
+				if pcTo == nil {
+					if p.D == nil {
+						pcTo = NewAppendOnlyOnlyPointsPointCloud(len(clouds) * 640 * 800)
+					} else {
+						pcTo = NewWithPrealloc(len(clouds) * 640 * 800)
+					}
+				}
+
+				myErr := pcTo.Set(p.P, p.D)
+				if myErr != nil {
+					err = myErr
+				}
+			}
+			dataLastTime = true
+		case <-time.After(5 * time.Millisecond):
+			dataLastTime = false
+			continue
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return pcTo, nil
+
+}
+
+// MergePointCloudsWithColor creates a union of point clouds from the slice of point clouds, giving
+// each element of the slice a unique color.
+func MergePointCloudsWithColor(clusters []PointCloud) (PointCloud, error) {
+	var err error
+	palette := colorful.FastWarmPalette(len(clusters))
+	colorSegmentation := New()
+	for i, cluster := range clusters {
+		col, ok := color.NRGBAModel.Convert(palette[i]).(color.NRGBA)
+		if !ok {
+			panic("impossible")
+		}
+		cluster.Iterate(0, 0, func(v r3.Vector, d Data) bool {
+			err = colorSegmentation.Set(v, NewColoredData(col))
+			return err == nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return colorSegmentation, nil
+}

--- a/pointcloud/merging.go
+++ b/pointcloud/merging.go
@@ -75,10 +75,8 @@ func MergePointClouds(ctx context.Context, cloudFuncs []CloudAndOffsetFunc, logg
 	var pcTo PointCloud
 	var err error
 
-	firstRead := true     // if all readers finish before loop starts, will prematurely exit, so read at least once.
 	dataLastTime := false // there was data in the channel in the previous loop, so continue reading.
-	for firstRead || dataLastTime || atomic.LoadInt32(&activeReaders) > 0 {
-		firstRead = false
+	for dataLastTime || atomic.LoadInt32(&activeReaders) > 0 {
 		select {
 		case ps := <-finalPoints:
 			for _, p := range ps {

--- a/pointcloud/merging.go
+++ b/pointcloud/merging.go
@@ -107,6 +107,9 @@ func MergePointClouds(ctx context.Context, cloudFuncs []CloudAndOffsetFunc, logg
 	for i := 0; i < lastBatches; i++ {
 		lastPoints := <-finalPoints
 		logger.Debugf("number of points in batch %d: %d", i, len(lastPoints))
+		if len(lastPoints) == 0 {
+			continue
+		}
 		for _, p := range lastPoints {
 			myErr := pcTo.Set(p.P, p.D)
 			if myErr != nil {

--- a/pointcloud/merging.go
+++ b/pointcloud/merging.go
@@ -77,10 +77,8 @@ func MergePointClouds(ctx context.Context, cloudFuncs []CloudAndOffsetFunc, logg
 
 	dataLastTime := false // if there was data in the channel in the previous loop, continue reading.
 	for dataLastTime || atomic.LoadInt32(&activeReaders) > 0 {
-		logger.Debugf("number of batches in channel: %d", len(finalPoints))
 		select {
 		case ps := <-finalPoints:
-			logger.Debugf("number of points in batch: %d", len(ps))
 			for _, p := range ps {
 				if pcTo == nil {
 					if p.D == nil {
@@ -101,7 +99,7 @@ func MergePointClouds(ctx context.Context, cloudFuncs []CloudAndOffsetFunc, logg
 			continue
 		}
 	}
-	// one last read to flush out any potential last data
+	// one last read to flush out any potential last data- sometimes there is still data in finalPoints.
 	lastBatches := len(finalPoints)
 	logger.Debugf("number of last batches: %d", lastBatches)
 	for i := 0; i < lastBatches; i++ {

--- a/pointcloud/merging_test.go
+++ b/pointcloud/merging_test.go
@@ -6,9 +6,8 @@ import (
 	"testing"
 
 	"github.com/golang/geo/r3"
-	"go.viam.com/test"
-
 	"go.viam.com/rdk/spatialmath"
+	"go.viam.com/test"
 )
 
 func makeThreeCloudsWithOffsets(t *testing.T) []CloudAndOffsetFunc {
@@ -49,6 +48,7 @@ func TestMergePoints1(t *testing.T) {
 	}
 	mergedCloud, err := MergePointClouds(context.Background(), cloudsWithOffset)
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, mergedCloud, test.ShouldNotBeNil)
 	test.That(t, mergedCloud.Size(), test.ShouldEqual, 9)
 }
 

--- a/pointcloud/merging_test.go
+++ b/pointcloud/merging_test.go
@@ -6,11 +6,13 @@ import (
 	"testing"
 
 	"github.com/golang/geo/r3"
-	"go.viam.com/rdk/spatialmath"
 	"go.viam.com/test"
+
+	"go.viam.com/rdk/spatialmath"
 )
 
-func makeThreeCloudsWithOffsets(t *testing.T) []PointCloudWithOffsetFunc {
+func makeThreeCloudsWithOffsets(t *testing.T) []CloudAndOffsetFunc {
+	t.Helper()
 	pc1 := NewWithPrealloc(1)
 	err := pc1.Set(NewVector(1, 0, 0), NewColoredData(color.NRGBA{255, 0, 0, 255}))
 	test.That(t, err, test.ShouldBeNil)
@@ -32,12 +34,12 @@ func makeThreeCloudsWithOffsets(t *testing.T) []PointCloudWithOffsetFunc {
 	func3 := func(context context.Context) (PointCloud, spatialmath.Pose, error) {
 		return pc3, pose3, nil
 	}
-	return []PointCloudWithOffsetFunc{func1, func2, func3}
+	return []CloudAndOffsetFunc{func1, func2, func3}
 }
 
 func TestMergePoints1(t *testing.T) {
 	clouds := makeClouds(t)
-	cloudsWithOffset := make([]PointCloudWithOffsetFunc, 0, len(clouds))
+	cloudsWithOffset := make([]CloudAndOffsetFunc, 0, len(clouds))
 	for _, cloud := range clouds {
 		cloudCopy := cloud
 		cloudFunc := func(ctx context.Context) (PointCloud, spatialmath.Pose, error) {

--- a/pointcloud/merging_test.go
+++ b/pointcloud/merging_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 
 	"github.com/golang/geo/r3"
-	"go.viam.com/rdk/spatialmath"
 	"go.viam.com/test"
+
+	"go.viam.com/rdk/spatialmath"
 )
 
 func makeThreeCloudsWithOffsets(t *testing.T) []CloudAndOffsetFunc {

--- a/pointcloud/merging_test.go
+++ b/pointcloud/merging_test.go
@@ -57,10 +57,6 @@ func TestMergePoints2(t *testing.T) {
 	pc, err := MergePointClouds(context.Background(), clouds)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, pc, test.ShouldNotBeNil)
-	pc.Iterate(0, 0, func(p r3.Vector, d Data) bool {
-		t.Logf("point: %v, data: %v", p, d)
-		return true
-	})
 	test.That(t, pc.Size(), test.ShouldEqual, 3)
 
 	data, got := pc.At(101, 0, 0)

--- a/pointcloud/merging_test.go
+++ b/pointcloud/merging_test.go
@@ -47,8 +47,7 @@ func TestMergePoints1(t *testing.T) {
 	}
 	mergedCloud, err := MergePointClouds(context.Background(), cloudsWithOffset)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, CloudContains(mergedCloud, 0, 0, 0), test.ShouldBeTrue)
-	test.That(t, CloudContains(mergedCloud, 30, 0, 0), test.ShouldBeTrue)
+	test.That(t, mergedCloud.Size(), test.ShouldEqual, 9)
 }
 
 func TestMergePoints2(t *testing.T) {
@@ -56,6 +55,10 @@ func TestMergePoints2(t *testing.T) {
 	pc, err := MergePointClouds(context.Background(), clouds)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, pc, test.ShouldNotBeNil)
+	pc.Iterate(0, 0, func(p r3.Vector, d Data) bool {
+		t.Logf("point: %v, data: %v", p, d)
+		return true
+	})
 	test.That(t, pc.Size(), test.ShouldEqual, 3)
 
 	data, got := pc.At(101, 0, 0)

--- a/pointcloud/merging_test.go
+++ b/pointcloud/merging_test.go
@@ -1,0 +1,58 @@
+package pointcloud
+
+import (
+	"image/color"
+	"testing"
+
+	"github.com/golang/geo/r3"
+	"go.viam.com/rdk/spatialmath"
+	"go.viam.com/test"
+)
+
+func makeThreeCloudsWithOffsets(t *testing) []PointCloudWithOffset {
+	pc1 := pointcloud.NewWithPrealloc(1)
+	err := pc1.Set(pointcloud.NewVector(1, 0, 0), pointcloud.NewColoredData(color.NRGBA{255, 0, 0, 255}))
+	test.That(t, err, test.ShouldBeNil)
+	pc2 := pointcloud.NewWithPrealloc(1)
+	err := pc2.Set(pointcloud.NewVector(0, 1, 0), pointcloud.NewColoredData(color.NRGBA{0, 255, 0, 255}))
+	test.That(t, err, test.ShouldBeNil)
+	pc3 := pointcloud.NewWithPrealloc(1)
+	err := pc3.Set(pointcloud.NewVector(0, 0, 1), pointcloud.NewColoredData(color.NRGBA{0, 0, 255, 255}))
+	test.That(t, err, test.ShouldBeNil)
+	pose1 := spatialmath.NewPoseFromPoint(r3.Vector{100, 0, 0})
+	pose2 := spatialmath.NewPoseFromPoint(r3.Vector{100, 0, 100})
+	pose3 := spatialmath.NewPoseFromPoint(r3.Vector{100, 100, 100})
+	return []PointCloudWithOffset{{pc1, pose1}, {pc2, pose2}, {pc3, pose3}}
+}
+
+func TestMergePoints1(t *testing.T) {
+	clouds := makeClouds(t)
+	cloudsWithOffset := make([]PointCloudWithOffset, 0, len(clouds))
+	for _, cloud := range clouds {
+		cloudCopy := cloud
+		cloudsWithOffset = append(cloudsWithOffset, PointCloudWithOffset{cloudCopy, nil})
+	}
+	mergedCloud, err := MergePointClouds(cloudsWithOffset)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, CloudContains(mergedCloud, 0, 0, 0), test.ShouldBeTrue)
+	test.That(t, CloudContains(mergedCloud, 30, 0, 0), test.ShouldBeTrue)
+}
+
+func TestMergePointsWithColor(t *testing.T) {
+	clouds := makeClouds(t)
+	mergedCloud, err := MergePointCloudsWithColor(clouds)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, mergedCloud.Size(), test.ShouldResemble, 9)
+
+	a, got := mergedCloud.At(0, 0, 0)
+	test.That(t, got, test.ShouldBeTrue)
+
+	b, got := mergedCloud.At(0, 0, 1)
+	test.That(t, got, test.ShouldBeTrue)
+
+	c, got := mergedCloud.At(30, 0, 0)
+	test.That(t, got, test.ShouldBeTrue)
+
+	test.That(t, a.Color(), test.ShouldResemble, b.Color())
+	test.That(t, a.Color(), test.ShouldNotResemble, c.Color())
+}

--- a/pointcloud/merging_test.go
+++ b/pointcloud/merging_test.go
@@ -5,6 +5,7 @@ import (
 	"image/color"
 	"testing"
 
+	"github.com/edaniels/golog"
 	"github.com/golang/geo/r3"
 	"go.viam.com/test"
 
@@ -38,6 +39,7 @@ func makeThreeCloudsWithOffsets(t *testing.T) []CloudAndOffsetFunc {
 }
 
 func TestMergePoints1(t *testing.T) {
+	logger := golog.NewTestLogger(t)
 	clouds := makeClouds(t)
 	cloudsWithOffset := make([]CloudAndOffsetFunc, 0, len(clouds))
 	for _, cloud := range clouds {
@@ -47,15 +49,16 @@ func TestMergePoints1(t *testing.T) {
 		}
 		cloudsWithOffset = append(cloudsWithOffset, cloudFunc)
 	}
-	mergedCloud, err := MergePointClouds(context.Background(), cloudsWithOffset)
+	mergedCloud, err := MergePointClouds(context.Background(), cloudsWithOffset, logger)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, mergedCloud, test.ShouldNotBeNil)
 	test.That(t, mergedCloud.Size(), test.ShouldEqual, 9)
 }
 
 func TestMergePoints2(t *testing.T) {
+	logger := golog.NewTestLogger(t)
 	clouds := makeThreeCloudsWithOffsets(t)
-	pc, err := MergePointClouds(context.Background(), clouds)
+	pc, err := MergePointClouds(context.Background(), clouds, logger)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, pc, test.ShouldNotBeNil)
 	test.That(t, pc.Size(), test.ShouldEqual, 3)

--- a/pointcloud/pointcloud_utils.go
+++ b/pointcloud/pointcloud_utils.go
@@ -1,60 +1,14 @@
 package pointcloud
 
 import (
-	"image/color"
 	"math"
 
 	"github.com/golang/geo/r3"
-	"github.com/lucasb-eyer/go-colorful"
 	"github.com/pkg/errors"
 	"gonum.org/v1/gonum/stat"
 
 	"go.viam.com/rdk/spatialmath"
 )
-
-// MergePointClouds takes a slice of points clouds and adds all their points to one point cloud.
-func MergePointClouds(clouds []PointCloud) (PointCloud, error) {
-	if len(clouds) == 0 {
-		return nil, errors.New("no point clouds to merge")
-	}
-	if len(clouds) == 1 {
-		return clouds[0], nil
-	}
-	merged := New()
-	var err error
-	for _, c := range clouds {
-		c.Iterate(0, 0, func(pt r3.Vector, d Data) bool {
-			err = merged.Set(pt, d)
-			return err == nil
-		})
-		if err != nil {
-			return nil, err
-		}
-	}
-	return merged, nil
-}
-
-// MergePointCloudsWithColor creates a union of point clouds from the slice of point clouds, giving
-// each element of the slice a unique color.
-func MergePointCloudsWithColor(clusters []PointCloud) (PointCloud, error) {
-	var err error
-	palette := colorful.FastWarmPalette(len(clusters))
-	colorSegmentation := New()
-	for i, cluster := range clusters {
-		col, ok := color.NRGBAModel.Convert(palette[i]).(color.NRGBA)
-		if !ok {
-			panic("impossible")
-		}
-		cluster.Iterate(0, 0, func(v r3.Vector, d Data) bool {
-			err = colorSegmentation.Set(v, NewColoredData(col))
-			return err == nil
-		})
-		if err != nil {
-			return nil, err
-		}
-	}
-	return colorSegmentation, nil
-}
 
 // BoundingBoxFromPointCloud returns a Geometry object that encompasses all the points in the given point cloud.
 func BoundingBoxFromPointCloud(cloud PointCloud) (spatialmath.Geometry, error) {

--- a/pointcloud/pointcloud_utils_test.go
+++ b/pointcloud/pointcloud_utils_test.go
@@ -59,33 +59,6 @@ func TestBoundingBoxFromPointCloud(t *testing.T) {
 	}
 }
 
-func TestMergePoints(t *testing.T) {
-	clouds := makeClouds(t)
-	mergedCloud, err := MergePointClouds(clouds)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, CloudContains(mergedCloud, 0, 0, 0), test.ShouldBeTrue)
-	test.That(t, CloudContains(mergedCloud, 30, 0, 0), test.ShouldBeTrue)
-}
-
-func TestMergePointsWithColor(t *testing.T) {
-	clouds := makeClouds(t)
-	mergedCloud, err := MergePointCloudsWithColor(clouds)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, mergedCloud.Size(), test.ShouldResemble, 9)
-
-	a, got := mergedCloud.At(0, 0, 0)
-	test.That(t, got, test.ShouldBeTrue)
-
-	b, got := mergedCloud.At(0, 0, 1)
-	test.That(t, got, test.ShouldBeTrue)
-
-	c, got := mergedCloud.At(30, 0, 0)
-	test.That(t, got, test.ShouldBeTrue)
-
-	test.That(t, a.Color(), test.ShouldResemble, b.Color())
-	test.That(t, a.Color(), test.ShouldNotResemble, c.Color())
-}
-
 func TestPrune(t *testing.T) {
 	clouds := makeClouds(t)
 	// before prune


### PR DESCRIPTION
The bug was an edge-case when reading the batches of points from a channel into the final point cloud would not read all the points in the channel. 

The loop would continue reading data into the final point cloud if `dataLastTime || atomic.LoadInt32(&activeReaders) > 0`

If there was no data in the channel, then the loop would wait 5 ms and then would set `dataLastTime = false`.

There was a situation where `dataListTime` was false, but `atomic.LoadInt32(&activeReaders)` had become 0 only within those 5 ms when `dataLastTime` was being set to false, meaning there was still some last minute data in the channel. The solution is to do one last read to make sure all of the data is out of the pipeline. 