### PR TITLE
[DATA-567] Support running cartographer through rdk

### DIFF
--- a/services/slam/builtin/builtin.go
+++ b/services/slam/builtin/builtin.go
@@ -664,7 +664,7 @@ func (slamSvc *builtIn) GetSLAMProcessConfig() pexec.ProcessConfig {
 	args = append(args, "-data_dir="+slamSvc.dataDirectory)
 	args = append(args, "-input_file_pattern="+slamSvc.inputFilePattern)
 	args = append(args, "-port="+slamSvc.port)
-	args = append(args, "--aix-auto-update")
+	args = append(args, "-aix-auto-update=1")
 
 	return pexec.ProcessConfig{
 		ID:      "slam_" + slamSvc.slamLib.AlgoName,

--- a/services/slam/builtin/builtin.go
+++ b/services/slam/builtin/builtin.go
@@ -664,7 +664,7 @@ func (slamSvc *builtIn) GetSLAMProcessConfig() pexec.ProcessConfig {
 	args = append(args, "-data_dir="+slamSvc.dataDirectory)
 	args = append(args, "-input_file_pattern="+slamSvc.inputFilePattern)
 	args = append(args, "-port="+slamSvc.port)
-	args = append(args, "-aix-auto-update=1")
+	args = append(args, "--aix-auto-update")
 
 	return pexec.ProcessConfig{
 		ID:      "slam_" + slamSvc.slamLib.AlgoName,

--- a/services/slam/slamlibraries.go
+++ b/services/slam/slamlibraries.go
@@ -33,12 +33,11 @@ var SLAMLibraries = map[string]LibraryMetadata{
 }
 
 // Define currently implemented slam libraries.
-// DISCLAIMER: Cartographer is not yet integrated with RDK.
 var cartographerMetadata = LibraryMetadata{
 	AlgoName:       "cartographer",
 	AlgoType:       Dense,
 	SlamMode:       map[string]Mode{"2d": Dim2d},
-	BinaryLocation: "",
+	BinaryLocation: "carto_grpc_server",
 }
 
 var orbslamv3Metadata = LibraryMetadata{


### PR DESCRIPTION
Together with https://github.com/viamrobotics/slam/pull/77, this lets us run cartographer through rdk.