### PR TITLE
Refactoring in encoded motors: defer mutex unlocking, better checking of sign bits

### DIFF
--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -584,7 +584,7 @@ func (m *EncodedMotor) GoTillStop(ctx context.Context, rpm float64, stopFunc fun
 		m.stateMu.RLock()
 		curRPM := m.state.currentRPM
 		m.stateMu.RUnlock()
-		if math.Abs(curRPM) >= math.Abs(rpm)/10 {
+		if math.Abs(curRPM) >= math.Abs(rpm) / 10 {
 			rpmCount++
 		} else {
 			rpmCount = 0
@@ -610,7 +610,7 @@ func (m *EncodedMotor) GoTillStop(ctx context.Context, rpm float64, stopFunc fun
 		curRPM := m.state.currentRPM
 		m.stateMu.RUnlock()
 
-		if math.Abs(curRPM) <= math.Abs(rpm)/10 {
+		if math.Abs(curRPM) <= math.Abs(rpm) / 10 {
 			rpmCount++
 		} else {
 			rpmCount = 0

--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -392,7 +392,7 @@ func (m *EncodedMotor) rpmMonitorPassSetRpmInLock(pos, lastPos, now, lastTime in
 
 	if math.Abs(currentRPM) <= 0.001 {
 		if math.Abs(lastPowerPct) < 0.01 {
-			newPowerPct = .01 * sign(desiredRPM)
+			newPowerPct = .01 * float64(sign(desiredRPM))
 		} else {
 			newPowerPct = m.computeRamp(lastPowerPct, lastPowerPct*2)
 		}

--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -583,7 +583,7 @@ func (m *EncodedMotor) GoTillStop(ctx context.Context, rpm float64, stopFunc fun
 		m.stateMu.RLock()
 		curRPM := m.state.currentRPM
 		m.stateMu.RUnlock()
-		if math.Abs(curRPM) >= math.Abs(rpm) / 10 {
+		if math.Abs(curRPM) >= math.Abs(rpm)/10 {
 			rpmCount++
 		} else {
 			rpmCount = 0
@@ -609,7 +609,7 @@ func (m *EncodedMotor) GoTillStop(ctx context.Context, rpm float64, stopFunc fun
 		curRPM := m.state.currentRPM
 		m.stateMu.RUnlock()
 
-		if math.Abs(curRPM) <= math.Abs(rpm) / 10 {
+		if math.Abs(curRPM) <= math.Abs(rpm)/10 {
 			rpmCount++
 		} else {
 			rpmCount = 0

--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -468,9 +468,10 @@ func (m *EncodedMotor) goForInternal(ctx context.Context, rpm, revolutions float
 	revolutions = math.Abs(revolutions)
 	rpm = math.Abs(rpm) * float64(d)
 
+	m.stateMu.Lock()
+	defer m.stateMu.Unlock()
+
 	if revolutions == 0 {
-		m.stateMu.Lock()
-		defer m.stateMu.Unlock()
 		oldRpm := m.state.desiredRPM
 		m.state.desiredRPM = rpm
 		if math.Abs(oldRpm) > 0.001 && d == m.directionMovingInLock() {
@@ -487,8 +488,6 @@ func (m *EncodedMotor) goForInternal(ctx context.Context, rpm, revolutions float
 		return err
 	}
 
-	m.stateMu.Lock()
-	defer m.stateMu.Unlock()
 	if d == 1 || d == -1 {
 		m.state.setPoint = pos + d*numTicks
 	} else {


### PR DESCRIPTION
Still haven't licked the main bug we're working on, but here is some refactoring that I've wanted to do since opening this file. Feel free to say "Alan, this can come after we've found the bug in GoFor, do it later."

Also feel free to say "don't create the `sign` function, do it this other way instead." 