### PR TITLE
add support for logitech G920 steering wheel and pedals

### DIFF
--- a/components/input/gamepad/gamepad_linux.go
+++ b/components/input/gamepad/gamepad_linux.go
@@ -169,11 +169,12 @@ func (g *gamepad) eventDispatcher(ctx context.Context) {
 				info := g.dev.AbsoluteTypes()[eventIn.Type.(evdev.AbsoluteType)]
 
 				var scaledPos float64
-				if thisAxis == input.AbsoluteZ || thisAxis == input.AbsoluteRZ {
+				if thisAxis == input.AbsolutePedalAccelerator || thisAxis == input.AbsolutePedalBrake || thisAxis == input.AbsolutePedalClutch {
+					// Scale pedals 1.0 to 0
+					// We invert the values because resting state is the high value and we'd like it to be zero.
+					scaledPos = 1 - scaleAxis(eventIn.Event.Value, info.Min, info.Max, 0, 1.0)
+				} else if thisAxis == input.AbsoluteZ || thisAxis == input.AbsoluteRZ {
 					// Scale triggers 0.0 to 1.0
-					scaledPos = scaleAxis(eventIn.Event.Value, info.Min, info.Max, 0, 1.0)
-				} else if g.Model == "Logitech G920 Driving Force Racing Wheel" && thisAxis == input.AbsoluteY {
-					// The Logitech G920 Driving Force Racing Wheel has AbsoluteY mapped to a pedal, which scales from 0 to 1.0
 					scaledPos = scaleAxis(eventIn.Event.Value, info.Min, info.Max, 0, 1.0)
 				} else {
 					// Scale normal axes -1.0 to 1.0

--- a/components/input/gamepad/gamepad_linux.go
+++ b/components/input/gamepad/gamepad_linux.go
@@ -169,16 +169,17 @@ func (g *gamepad) eventDispatcher(ctx context.Context) {
 				info := g.dev.AbsoluteTypes()[eventIn.Type.(evdev.AbsoluteType)]
 
 				var scaledPos float64
-				if thisAxis == input.AbsolutePedalAccelerator || thisAxis == input.AbsolutePedalBrake || thisAxis == input.AbsolutePedalClutch {
-					// Scale pedals 1.0 to 0
-					// We invert the values because resting state is the high value and we'd like it to be zero.
-					scaledPos = 1 - scaleAxis(eventIn.Event.Value, info.Min, info.Max, 0, 1.0)
-				} else if thisAxis == input.AbsoluteZ || thisAxis == input.AbsoluteRZ {
-					// Scale triggers 0.0 to 1.0
-					scaledPos = scaleAxis(eventIn.Event.Value, info.Min, info.Max, 0, 1.0)
-				} else {
-					// Scale normal axes -1.0 to 1.0
-					scaledPos = scaleAxis(eventIn.Event.Value, info.Min, info.Max, -1.0, 1.0)
+				switch thisAxis {
+					case input.AbsolutePedalAccelerator, input.AbsolutePedalBrake, input.AbsolutePedalClutch:
+						// Scale pedals 1.0 to 0
+						// We invert the values because resting state is the high value and we'd like it to be zero.
+						scaledPos = 1 - scaleAxis(eventIn.Event.Value, info.Min, info.Max, 0, 1.0)
+					case input.AbsoluteZ, input.AbsoluteRZ:
+						// Scale triggers 0.0 to 1.0
+						scaledPos = scaleAxis(eventIn.Event.Value, info.Min, info.Max, 0, 1.0)
+					default:
+						// Scale normal axes -1.0 to 1.0
+						scaledPos = scaleAxis(eventIn.Event.Value, info.Min, info.Max, -1.0, 1.0)
 				}
 
 				// Use evDev provided deadzone

--- a/components/input/gamepad/gamepad_linux.go
+++ b/components/input/gamepad/gamepad_linux.go
@@ -170,16 +170,16 @@ func (g *gamepad) eventDispatcher(ctx context.Context) {
 
 				var scaledPos float64
 				switch thisAxis {
-					case input.AbsolutePedalAccelerator, input.AbsolutePedalBrake, input.AbsolutePedalClutch:
-						// Scale pedals 1.0 to 0
-						// We invert the values because resting state is the high value and we'd like it to be zero.
-						scaledPos = 1 - scaleAxis(eventIn.Event.Value, info.Min, info.Max, 0, 1.0)
-					case input.AbsoluteZ, input.AbsoluteRZ:
-						// Scale triggers 0.0 to 1.0
-						scaledPos = scaleAxis(eventIn.Event.Value, info.Min, info.Max, 0, 1.0)
-					default:
-						// Scale normal axes -1.0 to 1.0
-						scaledPos = scaleAxis(eventIn.Event.Value, info.Min, info.Max, -1.0, 1.0)
+				case input.AbsolutePedalAccelerator, input.AbsolutePedalBrake, input.AbsolutePedalClutch:
+					// Scale pedals 1.0 to 0
+					// We invert the values because resting state is the high value and we'd like it to be zero.
+					scaledPos = 1 - scaleAxis(eventIn.Event.Value, info.Min, info.Max, 0, 1.0)
+				case input.AbsoluteZ, input.AbsoluteRZ:
+					// Scale triggers 0.0 to 1.0
+					scaledPos = scaleAxis(eventIn.Event.Value, info.Min, info.Max, 0, 1.0)
+				default:
+					// Scale normal axes -1.0 to 1.0
+					scaledPos = scaleAxis(eventIn.Event.Value, info.Min, info.Max, -1.0, 1.0)
 				}
 
 				// Use evDev provided deadzone

--- a/components/input/gamepad/gamepad_linux.go
+++ b/components/input/gamepad/gamepad_linux.go
@@ -169,7 +169,7 @@ func (g *gamepad) eventDispatcher(ctx context.Context) {
 				info := g.dev.AbsoluteTypes()[eventIn.Type.(evdev.AbsoluteType)]
 
 				var scaledPos float64
-                //nolint:exhaustive
+				//nolint:exhaustive
 				switch thisAxis {
 				case input.AbsolutePedalAccelerator, input.AbsolutePedalBrake, input.AbsolutePedalClutch:
 					// Scale pedals 1.0 to 0

--- a/components/input/gamepad/gamepad_linux.go
+++ b/components/input/gamepad/gamepad_linux.go
@@ -169,6 +169,7 @@ func (g *gamepad) eventDispatcher(ctx context.Context) {
 				info := g.dev.AbsoluteTypes()[eventIn.Type.(evdev.AbsoluteType)]
 
 				var scaledPos float64
+                //nolint:exhaustive
 				switch thisAxis {
 				case input.AbsolutePedalAccelerator, input.AbsolutePedalBrake, input.AbsolutePedalClutch:
 					// Scale pedals 1.0 to 0

--- a/components/input/gamepad/gamepad_linux.go
+++ b/components/input/gamepad/gamepad_linux.go
@@ -172,6 +172,9 @@ func (g *gamepad) eventDispatcher(ctx context.Context) {
 				if thisAxis == input.AbsoluteZ || thisAxis == input.AbsoluteRZ {
 					// Scale triggers 0.0 to 1.0
 					scaledPos = scaleAxis(eventIn.Event.Value, info.Min, info.Max, 0, 1.0)
+				} else if g.Model == "Logitech G920 Driving Force Racing Wheel" && thisAxis == input.AbsoluteY {
+					// The Logitech G920 Driving Force Racing Wheel has AbsoluteY mapped to a pedal, which scales from 0 to 1.0
+					scaledPos = scaleAxis(eventIn.Event.Value, info.Min, info.Max, 0, 1.0)
 				} else {
 					// Scale normal axes -1.0 to 1.0
 					scaledPos = scaleAxis(eventIn.Event.Value, info.Min, info.Max, -1.0, 1.0)

--- a/components/input/gamepad/gamepad_mappings_linux.go
+++ b/components/input/gamepad/gamepad_mappings_linux.go
@@ -221,9 +221,9 @@ var GamepadMappings = map[string]Mapping{
 	"Logitech G920 Driving Force Racing Wheel": {
 		Axes: map[evdev.AbsoluteType]input.Control{
 			0:  input.AbsoluteX,
-			1:  input.AbsoluteY,
-			2:  input.AbsoluteZ,
-			5:  input.AbsoluteRZ,
+			1:  input.AbsolutePedalAccelerator,
+			2:  input.AbsolutePedalBrake,
+			5:  input.AbsolutePedalClutch,
 			16: input.AbsoluteHat0X,
 			17: input.AbsoluteHat0Y,
 		},

--- a/components/input/gamepad/gamepad_mappings_linux.go
+++ b/components/input/gamepad/gamepad_mappings_linux.go
@@ -217,4 +217,28 @@ var GamepadMappings = map[string]Mapping{
 			316: input.ButtonMenu,
 		},
 	},
+	// Logitech G920/G29 Wheel
+	"Logitech G920 Driving Force Racing Wheel": {
+		Axes: map[evdev.AbsoluteType]input.Control{
+			0:  input.AbsoluteX,
+			1:  input.AbsoluteY,
+			2:  input.AbsoluteZ,
+			5:  input.AbsoluteRZ,
+			16: input.AbsoluteHat0X,
+			17: input.AbsoluteHat0Y,
+		},
+		Buttons: map[evdev.KeyType]input.Control{
+			288: input.ButtonSouth,
+			289: input.ButtonEast,
+			291: input.ButtonNorth,
+			290: input.ButtonWest,
+			293: input.ButtonLT,
+			292: input.ButtonRT,
+			295: input.ButtonSelect,
+			294: input.ButtonStart,
+			297: input.ButtonLThumb,
+			296: input.ButtonRThumb,
+			298: input.ButtonMenu,
+		},
+	},
 }

--- a/components/input/input.go
+++ b/components/input/input.go
@@ -131,6 +131,11 @@ const (
 	ButtonMenu   Control = "ButtonMenu"
 	ButtonRecord Control = "ButtonRecord"
 	ButtonEStop  Control = "ButtonEStop"
+
+	// Pedals.
+	AbsolutePedalAccelerator Control = "AbsolutePedalAccelerator"
+	AbsolutePedalBrake       Control = "AbsolutePedalBrake"
+	AbsolutePedalClutch      Control = "AbsolutePedalClutch"
 )
 
 // Event is passed to the registered ControlFunction or returned by State().


### PR DESCRIPTION
did some minor testing:
* created a bot with this controller
* logs mention detecting it correctly `found known gamepad: 'Logitech G920 Driving Force Racing Wheel' at /dev/input/event0`
* values update (have to refresh the control UI to see the new values, but i think the card is just broken more broadly)