### PR TITLE
[Data-504] reduce test image resolutions

### DIFF
--- a/.artifact/tree.json
+++ b/.artifact/tree.json
@@ -3774,6 +3774,14 @@
       "hash": "25993f4c19eec20d5acb8b10b6d3ef66",
       "size": 96058
     },
+    "board1_gray_small.png": {
+      "hash": "6ff4c7ef1b9ed8e0f3e62ae1c9a31bae",
+      "size": 10062
+    },
+    "board1_small.png": {
+      "hash": "d7cdfc43775a95eb9a37f655fc9b2932",
+      "size": 31201
+    },
     "board2.dat.gz": {
       "hash": "e5ba35b11cc8bf0c25cd997751b00b51",
       "size": 151788
@@ -3785,6 +3793,14 @@
     "board2_gray.png": {
       "hash": "3e62dc2c62bbd4f5e198fb1c4e82f9a9",
       "size": 92327
+    },
+    "board2_gray_small.png": {
+      "hash": "362b8abe03fa4ad0a5d3cfc2e2deedfd",
+      "size": 10756
+    },
+    "board2_small.png": {
+      "hash": "234d75ca63901fc11677239760fb33e9",
+      "size": 31333
     },
     "canny1.png": {
       "hash": "2484495f4ffaec93f87c4bfb52a5613a",

--- a/components/camera/camera_test.go
+++ b/components/camera/camera_test.go
@@ -301,10 +301,10 @@ func (s *simpleSourceWithPCD) NextPointCloud(ctx context.Context) (pointcloud.Po
 }
 
 func TestNewCamera(t *testing.T) {
-	intrinsics1 := &transform.PinholeCameraIntrinsics{Width: 1280, Height: 720}
+	intrinsics1 := &transform.PinholeCameraIntrinsics{Width: 128, Height: 72}
 	intrinsics2 := &transform.PinholeCameraIntrinsics{Width: 100, Height: 100}
-	videoSrc := &simpleSource{"rimage/board1"}
-	videoSrcPCD := &simpleSourceWithPCD{"rimage/board1"}
+	videoSrc := &simpleSource{"rimage/board1_small"}
+	videoSrcPCD := &simpleSourceWithPCD{"rimage/board1_small"}
 
 	// no camera
 	_, err := camera.NewFromReader(context.Background(), nil, nil, camera.UnspecifiedStream)

--- a/components/camera/transformpipeline/depth_edges_test.go
+++ b/components/camera/transformpipeline/depth_edges_test.go
@@ -32,7 +32,7 @@ func debugVideoTransformOrSkip(t *testing.T) {
 }
 
 func TestDepthSource(t *testing.T) {
-	img, err := rimage.NewDepthMapFromFile(artifact.MustPath("rimage/board1_gray.png"))
+	img, err := rimage.NewDepthMapFromFile(artifact.MustPath("rimage/board1_gray_small.png"))
 	test.That(t, err, test.ShouldBeNil)
 	source := &videosource.StaticSource{DepthImg: img}
 	am := config.AttributeMap{

--- a/components/camera/transformpipeline/mods_test.go
+++ b/components/camera/transformpipeline/mods_test.go
@@ -31,56 +31,56 @@ func init() {
 
 //nolint:dupl
 func TestResizeColor(t *testing.T) {
-	img, err := rimage.NewImageFromFile(artifact.MustPath("rimage/board1.png"))
+	img, err := rimage.NewImageFromFile(artifact.MustPath("rimage/board1_small.png"))
 	test.That(t, err, test.ShouldBeNil)
 
 	am := config.AttributeMap{
-		"height_px": 200,
-		"width_px":  300,
+		"height_px": 20,
+		"width_px":  30,
 	}
 	source := gostream.NewVideoSource(&videosource.StaticSource{ColorImg: img}, prop.Video{})
 	out, _, err := camera.ReadImage(context.Background(), source)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, out.Bounds().Dx(), test.ShouldEqual, 1280)
-	test.That(t, out.Bounds().Dy(), test.ShouldEqual, 720)
+	test.That(t, out.Bounds().Dx(), test.ShouldEqual, 128)
+	test.That(t, out.Bounds().Dy(), test.ShouldEqual, 72)
 
 	rs, err := newResizeTransform(context.Background(), source, camera.ColorStream, am)
 	test.That(t, err, test.ShouldBeNil)
 	out, _, err = camera.ReadImage(context.Background(), rs)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, out.Bounds().Dx(), test.ShouldEqual, 300)
-	test.That(t, out.Bounds().Dy(), test.ShouldEqual, 200)
+	test.That(t, out.Bounds().Dx(), test.ShouldEqual, 30)
+	test.That(t, out.Bounds().Dy(), test.ShouldEqual, 20)
 	test.That(t, rs.Close(context.Background()), test.ShouldBeNil)
 	test.That(t, source.Close(context.Background()), test.ShouldBeNil)
 }
 
 //nolint:dupl
 func TestResizeDepth(t *testing.T) {
-	img, err := rimage.NewDepthMapFromFile(artifact.MustPath("rimage/board1_gray.png"))
+	img, err := rimage.NewDepthMapFromFile(artifact.MustPath("rimage/board1_gray_small.png"))
 	test.That(t, err, test.ShouldBeNil)
 
 	am := config.AttributeMap{
-		"height_px": 400,
-		"width_px":  600,
+		"height_px": 40,
+		"width_px":  60,
 	}
 	source := gostream.NewVideoSource(&videosource.StaticSource{DepthImg: img}, prop.Video{})
 	out, _, err := camera.ReadImage(context.Background(), source)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, out.Bounds().Dx(), test.ShouldEqual, 1280)
-	test.That(t, out.Bounds().Dy(), test.ShouldEqual, 720)
+	test.That(t, out.Bounds().Dx(), test.ShouldEqual, 128)
+	test.That(t, out.Bounds().Dy(), test.ShouldEqual, 72)
 
 	rs, err := newResizeTransform(context.Background(), source, camera.DepthStream, am)
 	test.That(t, err, test.ShouldBeNil)
 	out, _, err = camera.ReadImage(context.Background(), rs)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, out.Bounds().Dx(), test.ShouldEqual, 600)
-	test.That(t, out.Bounds().Dy(), test.ShouldEqual, 400)
+	test.That(t, out.Bounds().Dx(), test.ShouldEqual, 60)
+	test.That(t, out.Bounds().Dy(), test.ShouldEqual, 40)
 	test.That(t, rs.Close(context.Background()), test.ShouldBeNil)
 	test.That(t, source.Close(context.Background()), test.ShouldBeNil)
 }
 
 func TestRotateColorSource(t *testing.T) {
-	img, err := rimage.NewImageFromFile(artifact.MustPath("rimage/board1.png"))
+	img, err := rimage.NewImageFromFile(artifact.MustPath("rimage/board1_small.png"))
 	test.That(t, err, test.ShouldBeNil)
 
 	source := gostream.NewVideoSource(&videosource.StaticSource{ColorImg: img}, prop.Video{})
@@ -112,7 +112,7 @@ func TestRotateColorSource(t *testing.T) {
 }
 
 func TestRotateDepthSource(t *testing.T) {
-	pc, err := rimage.NewDepthMapFromFile(artifact.MustPath("rimage/board1.dat.gz"))
+	pc, err := rimage.NewDepthMapFromFile(artifact.MustPath("rimage/board1_gray_small.png"))
 	test.That(t, err, test.ShouldBeNil)
 
 	source := gostream.NewVideoSource(&videosource.StaticSource{DepthImg: pc}, prop.Video{})

--- a/components/camera/transformpipeline/pipeline_test.go
+++ b/components/camera/transformpipeline/pipeline_test.go
@@ -25,27 +25,27 @@ func TestTransformPipelineColor(t *testing.T) {
 		Source: "source",
 		Pipeline: []Transformation{
 			{Type: "rotate", Attributes: config.AttributeMap{}},
-			{Type: "resize", Attributes: config.AttributeMap{"height_px": 200, "width_px": 100}},
+			{Type: "resize", Attributes: config.AttributeMap{"height_px": 20, "width_px": 10}},
 		},
 	}
 	r := &inject.Robot{}
-	img, err := rimage.NewImageFromFile(artifact.MustPath("rimage/board1.png"))
+	img, err := rimage.NewImageFromFile(artifact.MustPath("rimage/board1_small.png"))
 	test.That(t, err, test.ShouldBeNil)
 	source := gostream.NewVideoSource(&videosource.StaticSource{ColorImg: img}, prop.Video{})
 	cam, err := camera.NewFromSource(context.Background(), source, nil, camera.ColorStream)
 	test.That(t, err, test.ShouldBeNil)
 	inImg, _, err := camera.ReadImage(context.Background(), cam)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, inImg.Bounds().Dx(), test.ShouldEqual, 1280)
-	test.That(t, inImg.Bounds().Dy(), test.ShouldEqual, 720)
+	test.That(t, inImg.Bounds().Dx(), test.ShouldEqual, 128)
+	test.That(t, inImg.Bounds().Dy(), test.ShouldEqual, 72)
 
 	color, err := newTransformPipeline(context.Background(), cam, transformConf, r)
 	test.That(t, err, test.ShouldBeNil)
 
 	outImg, _, err := camera.ReadImage(context.Background(), color)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, outImg.Bounds().Dx(), test.ShouldEqual, 100)
-	test.That(t, outImg.Bounds().Dy(), test.ShouldEqual, 200)
+	test.That(t, outImg.Bounds().Dx(), test.ShouldEqual, 10)
+	test.That(t, outImg.Bounds().Dy(), test.ShouldEqual, 20)
 	_, err = color.NextPointCloud(context.Background())
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldWrap, transform.ErrNoIntrinsics)
@@ -57,12 +57,12 @@ func TestTransformPipelineColor(t *testing.T) {
 
 func TestTransformPipelineDepth(t *testing.T) {
 	intrinsics := &transform.PinholeCameraIntrinsics{
-		Width:  1280,
-		Height: 720,
+		Width:  128,
+		Height: 72,
 		Fx:     900.538000,
 		Fy:     900.818000,
-		Ppx:    648.934000,
-		Ppy:    367.736000,
+		Ppx:    64.8934000,
+		Ppy:    36.7736000,
 	}
 
 	transformConf := &transformConfig{
@@ -73,28 +73,28 @@ func TestTransformPipelineDepth(t *testing.T) {
 		Source: "source",
 		Pipeline: []Transformation{
 			{Type: "rotate", Attributes: config.AttributeMap{}},
-			{Type: "resize", Attributes: config.AttributeMap{"height_px": 300, "width_px": 400}},
+			{Type: "resize", Attributes: config.AttributeMap{"height_px": 30, "width_px": 40}},
 		},
 	}
 	r := &inject.Robot{}
 
-	dm, err := rimage.NewDepthMapFromFile(artifact.MustPath("rimage/board1_gray.png"))
+	dm, err := rimage.NewDepthMapFromFile(artifact.MustPath("rimage/board1_gray_small.png"))
 	test.That(t, err, test.ShouldBeNil)
 	source := gostream.NewVideoSource(&videosource.StaticSource{DepthImg: dm}, prop.Video{})
 	cam, err := camera.NewFromSource(context.Background(), source, nil, camera.DepthStream)
 	test.That(t, err, test.ShouldBeNil)
 	inImg, _, err := camera.ReadImage(context.Background(), cam)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, inImg.Bounds().Dx(), test.ShouldEqual, 1280)
-	test.That(t, inImg.Bounds().Dy(), test.ShouldEqual, 720)
+	test.That(t, inImg.Bounds().Dx(), test.ShouldEqual, 128)
+	test.That(t, inImg.Bounds().Dy(), test.ShouldEqual, 72)
 
 	depth, err := newTransformPipeline(context.Background(), cam, transformConf, r)
 	test.That(t, err, test.ShouldBeNil)
 
 	outImg, _, err := camera.ReadImage(context.Background(), depth)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, outImg.Bounds().Dx(), test.ShouldEqual, 400)
-	test.That(t, outImg.Bounds().Dy(), test.ShouldEqual, 300)
+	test.That(t, outImg.Bounds().Dx(), test.ShouldEqual, 40)
+	test.That(t, outImg.Bounds().Dy(), test.ShouldEqual, 30)
 	prop, err := depth.Projector(context.Background())
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, prop, test.ShouldResemble, intrinsics)
@@ -115,7 +115,7 @@ func TestTransformPipelineDepth2(t *testing.T) {
 		Pipeline: []Transformation{
 			{Type: "depth_preprocess", Attributes: config.AttributeMap{}},
 			{Type: "rotate", Attributes: config.AttributeMap{}},
-			{Type: "resize", Attributes: config.AttributeMap{"height_px": 200, "width_px": 100}},
+			{Type: "resize", Attributes: config.AttributeMap{"height_px": 20, "width_px": 10}},
 			{Type: "depth_to_pretty", Attributes: config.AttributeMap{}},
 		},
 	}
@@ -127,13 +127,13 @@ func TestTransformPipelineDepth2(t *testing.T) {
 		Pipeline: []Transformation{
 			{Type: "depth_preprocess", Attributes: config.AttributeMap{}},
 			{Type: "rotate", Attributes: config.AttributeMap{}},
-			{Type: "resize", Attributes: config.AttributeMap{"height_px": 300, "width_px": 400}},
+			{Type: "resize", Attributes: config.AttributeMap{"height_px": 30, "width_px": 40}},
 			{Type: "depth_edges", Attributes: config.AttributeMap{"high_threshold_pct": 0.85, "low_threshold_pct": 0.3, "blur_radius_px": 3.0}},
 		},
 	}
 	r := &inject.Robot{}
 
-	dm, err := rimage.NewDepthMapFromFile(artifact.MustPath("rimage/board1_gray.png"))
+	dm, err := rimage.NewDepthMapFromFile(artifact.MustPath("rimage/board1_gray_small.png"))
 	test.That(t, err, test.ShouldBeNil)
 	source := gostream.NewVideoSource(&videosource.StaticSource{DepthImg: dm}, prop.Video{})
 	// first depth transform
@@ -141,16 +141,16 @@ func TestTransformPipelineDepth2(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	outImg, _, err := camera.ReadImage(context.Background(), depth1)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, outImg.Bounds().Dx(), test.ShouldEqual, 100)
-	test.That(t, outImg.Bounds().Dy(), test.ShouldEqual, 200)
+	test.That(t, outImg.Bounds().Dx(), test.ShouldEqual, 10)
+	test.That(t, outImg.Bounds().Dy(), test.ShouldEqual, 20)
 	test.That(t, depth1.Close(context.Background()), test.ShouldBeNil)
 	// second depth image
 	depth2, err := newTransformPipeline(context.Background(), source, transform2, r)
 	test.That(t, err, test.ShouldBeNil)
 	outImg, _, err = camera.ReadImage(context.Background(), depth2)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, outImg.Bounds().Dx(), test.ShouldEqual, 400)
-	test.That(t, outImg.Bounds().Dy(), test.ShouldEqual, 300)
+	test.That(t, outImg.Bounds().Dx(), test.ShouldEqual, 40)
+	test.That(t, outImg.Bounds().Dy(), test.ShouldEqual, 30)
 	test.That(t, depth2.Close(context.Background()), test.ShouldBeNil)
 	test.That(t, source.Close(context.Background()), test.ShouldBeNil)
 }
@@ -164,7 +164,7 @@ func TestNullPipeline(t *testing.T) {
 		Pipeline: []Transformation{},
 	}
 	r := &inject.Robot{}
-	img, err := rimage.NewImageFromFile(artifact.MustPath("rimage/board1.png"))
+	img, err := rimage.NewImageFromFile(artifact.MustPath("rimage/board1_small.png"))
 	test.That(t, err, test.ShouldBeNil)
 	source := gostream.NewVideoSource(&videosource.StaticSource{ColorImg: img}, prop.Video{})
 	_, err = newTransformPipeline(context.Background(), source, transform1, r)
@@ -182,19 +182,19 @@ func TestNullPipeline(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	outImg, _, err := camera.ReadImage(context.Background(), pipe) // should not transform anything
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, outImg.Bounds().Dx(), test.ShouldEqual, 1280)
-	test.That(t, outImg.Bounds().Dy(), test.ShouldEqual, 720)
+	test.That(t, outImg.Bounds().Dx(), test.ShouldEqual, 128)
+	test.That(t, outImg.Bounds().Dy(), test.ShouldEqual, 72)
 	test.That(t, pipe.Close(context.Background()), test.ShouldBeNil)
 	test.That(t, source.Close(context.Background()), test.ShouldBeNil)
 }
 
 func TestPipeIntoPipe(t *testing.T) {
 	r := &inject.Robot{}
-	img, err := rimage.NewImageFromFile(artifact.MustPath("rimage/board1.png"))
+	img, err := rimage.NewImageFromFile(artifact.MustPath("rimage/board1_small.png"))
 	test.That(t, err, test.ShouldBeNil)
 	source := gostream.NewVideoSource(&videosource.StaticSource{ColorImg: img}, prop.Video{})
 
-	intrinsics1 := &transform.PinholeCameraIntrinsics{Width: 1280, Height: 720}
+	intrinsics1 := &transform.PinholeCameraIntrinsics{Width: 128, Height: 72}
 	transform1 := &transformConfig{
 		AttrConfig: &camera.AttrConfig{
 			Stream:           "color",
@@ -203,7 +203,7 @@ func TestPipeIntoPipe(t *testing.T) {
 		Source:   "source",
 		Pipeline: []Transformation{{Type: "rotate", Attributes: config.AttributeMap{}}},
 	}
-	intrinsics2 := &transform.PinholeCameraIntrinsics{Width: 100, Height: 200}
+	intrinsics2 := &transform.PinholeCameraIntrinsics{Width: 10, Height: 20}
 	transform2 := &transformConfig{
 		AttrConfig: &camera.AttrConfig{
 			Stream:           "color",
@@ -211,7 +211,7 @@ func TestPipeIntoPipe(t *testing.T) {
 		},
 		Source: "transform2",
 		Pipeline: []Transformation{
-			{Type: "resize", Attributes: config.AttributeMap{"height_px": 200, "width_px": 100}},
+			{Type: "resize", Attributes: config.AttributeMap{"height_px": 20, "width_px": 10}},
 		},
 	}
 	transformWrong := &transformConfig{
@@ -220,7 +220,7 @@ func TestPipeIntoPipe(t *testing.T) {
 		},
 		Source: "transform2",
 		Pipeline: []Transformation{
-			{Type: "resize", Attributes: config.AttributeMap{"height_px": 200, "width_px": 100}},
+			{Type: "resize", Attributes: config.AttributeMap{"height_px": 20, "width_px": 10}},
 		},
 	}
 
@@ -228,24 +228,24 @@ func TestPipeIntoPipe(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	outImg, _, err := camera.ReadImage(context.Background(), pipe1)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, outImg.Bounds().Dx(), test.ShouldEqual, 1280)
-	test.That(t, outImg.Bounds().Dy(), test.ShouldEqual, 720)
+	test.That(t, outImg.Bounds().Dx(), test.ShouldEqual, 128)
+	test.That(t, outImg.Bounds().Dy(), test.ShouldEqual, 72)
 	prop, err := pipe1.Projector(context.Background())
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, prop.(*transform.PinholeCameraIntrinsics).Width, test.ShouldEqual, 1280)
-	test.That(t, prop.(*transform.PinholeCameraIntrinsics).Height, test.ShouldEqual, 720)
+	test.That(t, prop.(*transform.PinholeCameraIntrinsics).Width, test.ShouldEqual, 128)
+	test.That(t, prop.(*transform.PinholeCameraIntrinsics).Height, test.ShouldEqual, 72)
 	// transform pipeline into pipeline
 	pipe2, err := newTransformPipeline(context.Background(), pipe1, transform2, r)
 	test.That(t, err, test.ShouldBeNil)
 	outImg, _, err = camera.ReadImage(context.Background(), pipe2)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, outImg.Bounds().Dx(), test.ShouldEqual, 100)
-	test.That(t, outImg.Bounds().Dy(), test.ShouldEqual, 200)
+	test.That(t, outImg.Bounds().Dx(), test.ShouldEqual, 10)
+	test.That(t, outImg.Bounds().Dy(), test.ShouldEqual, 20)
 	test.That(t, err, test.ShouldBeNil)
 	prop, err = pipe2.Projector(context.Background())
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, prop.(*transform.PinholeCameraIntrinsics).Width, test.ShouldEqual, 100)
-	test.That(t, prop.(*transform.PinholeCameraIntrinsics).Height, test.ShouldEqual, 200)
+	test.That(t, prop.(*transform.PinholeCameraIntrinsics).Width, test.ShouldEqual, 10)
+	test.That(t, prop.(*transform.PinholeCameraIntrinsics).Height, test.ShouldEqual, 20)
 	test.That(t, pipe2.Close(context.Background()), test.ShouldBeNil)
 	// should error - color image cannot be depth resized
 	pipeWrong, err := newTransformPipeline(context.Background(), pipe1, transformWrong, r)

--- a/components/camera/transformpipeline/undistort_test.go
+++ b/components/camera/transformpipeline/undistort_test.go
@@ -19,8 +19,8 @@ import (
 
 // not the real intrinsic parameters of the image, only for testing purposes.
 var undistortTestParams = &transform.PinholeCameraIntrinsics{
-	Width:  1280,
-	Height: 720,
+	Width:  128,
+	Height: 72,
 	Fx:     1.,
 	Fy:     1.,
 	Ppx:    0.,
@@ -36,7 +36,7 @@ var undistortTestBC = &transform.BrownConrady{
 }
 
 func TestUndistortSetup(t *testing.T) {
-	img, err := rimage.NewImageFromFile(artifact.MustPath("rimage/board1.png"))
+	img, err := rimage.NewImageFromFile(artifact.MustPath("rimage/board1_small.png"))
 	test.That(t, err, test.ShouldBeNil)
 	source := gostream.NewVideoSource(&videosource.StaticSource{ColorImg: img}, prop.Video{})
 
@@ -68,7 +68,7 @@ func TestUndistortSetup(t *testing.T) {
 }
 
 func TestUndistortImage(t *testing.T) {
-	img, err := rimage.NewImageFromFile(artifact.MustPath("rimage/board1.png"))
+	img, err := rimage.NewImageFromFile(artifact.MustPath("rimage/board1_small.png"))
 	test.That(t, err, test.ShouldBeNil)
 	source := gostream.NewVideoSource(&videosource.StaticSource{ColorImg: img}, prop.Video{})
 
@@ -99,7 +99,7 @@ func TestUndistortImage(t *testing.T) {
 }
 
 func TestUndistortDepthMap(t *testing.T) {
-	img, err := rimage.NewDepthMapFromFile(artifact.MustPath("rimage/board1_gray.png"))
+	img, err := rimage.NewDepthMapFromFile(artifact.MustPath("rimage/board1_gray_small.png"))
 	test.That(t, err, test.ShouldBeNil)
 	source := gostream.NewVideoSource(&videosource.StaticSource{DepthImg: img}, prop.Video{})
 

--- a/components/camera/videosource/server_test.go
+++ b/components/camera/videosource/server_test.go
@@ -24,9 +24,9 @@ import (
 func createTestRouter(t *testing.T) (*http.ServeMux, image.Image, []byte, image.Image) {
 	t.Helper()
 	// get color image
-	colorPath := artifact.MustPath("rimage/board1.png")
+	colorPath := artifact.MustPath("rimage/board1_small.png")
 	// get depth image
-	depthPath := artifact.MustPath("rimage/board1_gray.png")
+	depthPath := artifact.MustPath("rimage/board1_gray_small.png")
 	// get color bytes
 	colorBytes, err := os.ReadFile(colorPath) // get png bytes
 	test.That(t, err, test.ShouldBeNil)
@@ -44,7 +44,7 @@ func createTestRouter(t *testing.T) (*http.ServeMux, image.Image, []byte, image.
 	}
 	router := http.NewServeMux()
 	// expected depth image from raw data
-	depthDatPath := artifact.MustPath("rimage/board1.dat.gz")
+	depthDatPath := artifact.MustPath("rimage/board1_gray_small.png")
 	expectedDepth, err := rimage.NewDepthMapFromFile(depthDatPath)
 	test.That(t, err, test.ShouldBeNil)
 	router.HandleFunc("/color.png", handleColor)
@@ -60,12 +60,12 @@ func TestServerSource(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	// intrinsics for the image
 	intrinsics := &transform.PinholeCameraIntrinsics{
-		Width:  1024,
-		Height: 768,
+		Width:  128,
+		Height: 72,
 		Fx:     821.32642889,
 		Fy:     821.68607359,
-		Ppx:    494.95941428,
-		Ppy:    370.70529534,
+		Ppx:    49.495941428,
+		Ppy:    37.070529534,
 	}
 	// create mock server
 	router, expectedColor, expectedColorBytes, expectedDepth := createTestRouter(t)
@@ -149,7 +149,7 @@ func TestServerSource(t *testing.T) {
 	test.That(t, img2, test.ShouldResemble, expectedDepth)
 	pc, err := cam2.NextPointCloud(context.Background())
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, pc.Size(), test.ShouldEqual, 921600)
+	test.That(t, pc.Size(), test.ShouldEqual, 128*72)
 	test.That(t, cam2.Close(context.Background()), test.ShouldBeNil)
 }
 
@@ -159,12 +159,12 @@ func TestDualServerSource(t *testing.T) {
 	defer svr.Close()
 	// intrinsics for the image
 	intrinsics := &transform.PinholeCameraIntrinsics{
-		Width:  1024,
-		Height: 768,
+		Width:  128,
+		Height: 72,
 		Fx:     821.32642889,
 		Fy:     821.68607359,
-		Ppx:    494.95941428,
-		Ppy:    370.70529534,
+		Ppx:    49.495941428,
+		Ppy:    37.070529534,
 	}
 	// create camera with a color stream
 	attrs1 := dualServerAttrs{

--- a/pointcloud/voxel_segmentation_test.go
+++ b/pointcloud/voxel_segmentation_test.go
@@ -78,9 +78,9 @@ func TestVoxelPlaneSegmentationOnePlane(t *testing.T) {
 }
 
 func TestVoxelPlaneSegmentationCube(t *testing.T) {
-	nPoints := 800000
+	nPoints := 10000
 	pc := GenerateCubeTestData(nPoints)
-	vg := NewVoxelGridFromPointCloud(pc, 0.1, 0.01)
+	vg := NewVoxelGridFromPointCloud(pc, 0.5, 0.01)
 	vg.SegmentPlanesRegionGrowing(0.7, 25, 0.1, 1.0)
 	pcOut, err := vg.ConvertToPointCloudWithValue()
 	test.That(t, err, test.ShouldBeNil)

--- a/pointcloud/voxel_test.go
+++ b/pointcloud/voxel_test.go
@@ -44,17 +44,17 @@ func TestVoxelCreation(t *testing.T) {
 }
 
 func TestVoxelGridCreation(t *testing.T) {
-	nPoints := 1000000
+	nPoints := 10000
 	pc := GenerateCubeTestData(nPoints)
-	vg := NewVoxelGridFromPointCloud(pc, 0.1, 0.01)
+	vg := NewVoxelGridFromPointCloud(pc, 0.5, 0.01)
 	test.ShouldEqual(len(vg.Voxels), 571)
 	test.ShouldEqual(vg.maxLabel, 0)
 }
 
 func TestVoxelGridCubeSegmentation(t *testing.T) {
-	nPoints := 1000000
+	nPoints := 10000
 	pc := GenerateCubeTestData(nPoints)
-	vg := NewVoxelGridFromPointCloud(pc, 0.1, 0.01)
+	vg := NewVoxelGridFromPointCloud(pc, 0.5, 0.01)
 	vg.SegmentPlanesRegionGrowing(0.7, 25, 0.1, 1.0)
 	test.ShouldEqual(vg.maxLabel, 6)
 	_, err := vg.ConvertToPointCloudWithValue()


### PR DESCRIPTION
Only changes tests, should speed up tests times for some packages by reducing the image/pointcloud size. 