### PR TITLE
Simplify some of the RPMMonitor logic

### DIFF
--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -388,12 +388,9 @@ func (m *EncodedMotor) computeRPM(pos, lastPos, now, lastTime int64) float64 {
 	return rotations / minutes
 }
 
-func (m *EncodedMotor) rpmMonitorPassSetRpmInLock(currentRPM, desiredRPM, rotationsLeft float64, rpmDebug bool) {
+func (m *EncodedMotor) computeNewPowerPct(currentRPM, desiredRPM float64) float64 {
 	lastPowerPct := m.state.lastPowerPct
-	m.state.currentRPM = currentRPM
-
 	var newPowerPct float64
-
 	if math.Abs(currentRPM) <= 0.001 {
 		if math.Abs(lastPowerPct) < 0.01 {
 			newPowerPct = .01 * float64(sign(desiredRPM))
@@ -417,6 +414,14 @@ func (m *EncodedMotor) rpmMonitorPassSetRpmInLock(currentRPM, desiredRPM, rotati
 
 		newPowerPct = m.computeRamp(lastPowerPct, neededPowerPct)
 	}
+	return newPowerPct
+}
+
+func (m *EncodedMotor) rpmMonitorPassSetRpmInLock(currentRPM, desiredRPM, rotationsLeft float64, rpmDebug bool) {
+	lastPowerPct := m.state.lastPowerPct
+	m.state.currentRPM = currentRPM
+
+	newPowerPct := m.computeNewPowerPct(currentRPM, desiredRPM)
 
 	if newPowerPct != lastPowerPct {
 		if rpmDebug {

--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -393,28 +393,27 @@ func (m *EncodedMotor) computeNewPowerPct(currentRPM, desiredRPM float64) float6
 	var newPowerPct float64
 	if math.Abs(currentRPM) <= 0.001 {
 		if math.Abs(lastPowerPct) < 0.01 {
-			newPowerPct = .01 * float64(sign(desiredRPM))
+			return .01 * float64(sign(desiredRPM))
 		} else {
-			newPowerPct = m.computeRamp(lastPowerPct, lastPowerPct*2)
+			return m.computeRamp(lastPowerPct, lastPowerPct*2)
 		}
-	} else {
-		dOverC := desiredRPM / currentRPM
-		dOverC = math.Min(dOverC, 2)
-		dOverC = math.Max(dOverC, -2)
-
-		neededPowerPct := lastPowerPct * dOverC
-
-		if !math.Signbit(neededPowerPct) {
-			neededPowerPct = math.Max(neededPowerPct, 0.01)
-			neededPowerPct = math.Min(neededPowerPct, 1)
-		} else {
-			neededPowerPct = math.Min(neededPowerPct, -0.01)
-			neededPowerPct = math.Max(neededPowerPct, -1)
-		}
-
-		newPowerPct = m.computeRamp(lastPowerPct, neededPowerPct)
 	}
-	return newPowerPct
+
+	dOverC := desiredRPM / currentRPM
+	dOverC = math.Min(dOverC, 2)
+	dOverC = math.Max(dOverC, -2)
+
+	neededPowerPct := lastPowerPct * dOverC
+
+	if !math.Signbit(neededPowerPct) {
+		neededPowerPct = math.Max(neededPowerPct, 0.01)
+		neededPowerPct = math.Min(neededPowerPct, 1)
+	} else {
+		neededPowerPct = math.Min(neededPowerPct, -0.01)
+		neededPowerPct = math.Max(neededPowerPct, -1)
+	}
+
+	return m.computeRamp(lastPowerPct, neededPowerPct)
 }
 
 func (m *EncodedMotor) rpmMonitorPassSetRpmInLock(currentRPM, desiredRPM, rotationsLeft float64, rpmDebug bool) {

--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -488,8 +488,10 @@ func (m *EncodedMotor) goForInternal(ctx context.Context, rpm, revolutions float
 	defer m.stateMu.Unlock()
 
 	if revolutions == 0 {
+		// Moving 0 revolutions is a special value meaning "move forever."
 		oldRpm := m.state.desiredRPM
 		m.state.desiredRPM = rpm
+		m.state.regulated = true
 		if math.Abs(oldRpm) > 0.001 && d == m.directionMovingInLock() {
 			return nil
 		}

--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -504,11 +504,7 @@ func (m *EncodedMotor) goForInternal(ctx context.Context, rpm, revolutions float
 		return err
 	}
 
-	if d == 1 || d == -1 {
-		m.state.setPoint = pos + d*numTicks
-	} else {
-		panic("impossible")
-	}
+	m.state.setPoint = pos + d*numTicks
 
 	m.state.desiredRPM = rpm
 	m.state.regulated = true

--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -408,6 +408,7 @@ func (m *EncodedMotor) computeNewPowerPct(currentRPM, desiredRPM float64) float6
 	// multiply by their ratio.
 	neededPowerPct := lastPowerPct * dOverC
 
+	// Bound neededPowerPct between 0.01 and 1 in the positive or negative direction.
 	if !math.Signbit(neededPowerPct) { // neededPowerPct is positive
 		neededPowerPct = math.Max(neededPowerPct, 0.01)
 		neededPowerPct = math.Min(neededPowerPct, 1)
@@ -487,7 +488,6 @@ func (m *EncodedMotor) goForInternal(ctx context.Context, rpm, revolutions float
 		// Moving 0 revolutions is a special value meaning "move forever."
 		oldRpm := m.state.desiredRPM
 		m.state.desiredRPM = rpm
-		m.state.regulated = true
 		if math.Abs(oldRpm) > 0.001 && d == m.directionMovingInLock() {
 			return nil
 		}

--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -390,7 +390,6 @@ func (m *EncodedMotor) computeRPM(pos, lastPos, now, lastTime int64) float64 {
 
 func (m *EncodedMotor) computeNewPowerPct(currentRPM, desiredRPM float64) float64 {
 	lastPowerPct := m.state.lastPowerPct
-	var newPowerPct float64
 	if math.Abs(currentRPM) <= 0.001 {
 		if math.Abs(lastPowerPct) < 0.01 {
 			// We began stopped. Set the power to a low setting so we can get started.

--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -377,6 +377,15 @@ func (m *EncodedMotor) rpmMonitorPass(pos, lastPos, now, lastTime int64, rpmDebu
 	}
 }
 
+func (m *EncodedMotor) computeRPM(pos, lastPos, now, lastTime int64) float64 {
+	minutes := float64(now-lastTime) / (1e9 * 60)
+	if minutes == 0 {
+		return 0.0
+	}
+	rotations := float64(pos-lastPos) / float64(m.cfg.TicksPerRotation)
+	return rotations / minutes
+}
+
 func (m *EncodedMotor) rpmMonitorPassSetRpmInLock(pos, lastPos, now, lastTime int64, desiredRPM, rotationsLeft float64, rpmDebug bool) {
 	lastPowerPct := m.state.lastPowerPct
 	rotations := float64(pos-lastPos) / float64(m.cfg.TicksPerRotation)

--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -400,8 +400,6 @@ func (m *EncodedMotor) computeNewPowerPct(currentRPM, desiredRPM float64) float6
 		return m.computeRamp(lastPowerPct, lastPowerPct*2)
 	}
 
-	// TODO: if dOverC is negative, we want to travel in the opposite direction. Do we need to do
-	// something special for that?
 	dOverC := desiredRPM / currentRPM
 	dOverC = math.Min(dOverC, 2)
 	dOverC = math.Max(dOverC, -2)

--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -394,11 +394,10 @@ func (m *EncodedMotor) computeNewPowerPct(currentRPM, desiredRPM float64) float6
 		if math.Abs(lastPowerPct) < 0.01 {
 			// We began stopped. Set the power to a low setting so we can get started.
 			return .01 * float64(sign(desiredRPM))
-		} else {
-			// We've been putting power to the motor, but it's not moving yet. Try increasing the
-			// power to it, and we'll start moving soon.
-			return m.computeRamp(lastPowerPct, lastPowerPct*2)
 		}
+		// We've been putting power to the motor, but it's not moving yet. Try increasing the power
+		// to it, and we'll start moving soon.
+		return m.computeRamp(lastPowerPct, lastPowerPct*2)
 	}
 
 	// TODO: if dOverC is negative, we want to travel in the opposite direction. Do we need to do

--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -428,16 +428,17 @@ func (m *EncodedMotor) rpmMonitorPassSetRpmInLock(currentRPM, desiredRPM, rotati
 	m.state.currentRPM = currentRPM
 
 	newPowerPct := m.computeNewPowerPct(currentRPM, desiredRPM)
+	if newPowerPct == lastPowerPct {
+		return // No changes to power are needed right now
+	}
 
-	if newPowerPct != lastPowerPct {
-		if rpmDebug {
-			m.logger.Debugf("current rpm: %0.1f desiredRPM: %0.1f power: %0.1f -> %0.1f rot2go: %0.1f",
-				currentRPM, desiredRPM, lastPowerPct*100, newPowerPct*100, rotationsLeft)
-		}
-		err := m.setPower(m.cancelCtx, newPowerPct, true)
-		if err != nil {
-			m.logger.Warnf("rpm regulator cannot set power %s", err)
-		}
+	if rpmDebug {
+		m.logger.Debugf("current rpm: %0.1f desiredRPM: %0.1f power: %0.1f -> %0.1f rot2go: %0.1f",
+			currentRPM, desiredRPM, lastPowerPct*100, newPowerPct*100, rotationsLeft)
+	}
+	err := m.setPower(m.cancelCtx, newPowerPct, true)
+	if err != nil {
+		m.logger.Warnf("rpm regulator cannot set power %s", err)
 	}
 }
 


### PR DESCRIPTION
Rand and I are struggling with https://viam.atlassian.net/browse/RSDK-694, and although this is not a fix, it is some refactoring which I think makes it easier to reason about this code (splitting the code into smaller, more self-contained single-purpose functions, adding comments, simplifying the control flow). I suggest reviewing commit-by-commit, because everything together gets muddled. For commits where a large section of code has changed indentation amounts, append a `?w=1` to the end of the URL to ignore whitespace changes (e.g., https://github.com/viamrobotics/rdk/commit/b8cf4502dc8caa5af2f66de33fae2a5050017c84?w=1 instead of https://github.com/viamrobotics/rdk/commit/b8cf4502dc8caa5af2f66de33fae2a5050017c84). 

For the most part, changes to behavior are not intended, though the mention of `state.regulated` in `goForInternal()` feels like it should fix a bug when the motor receives many different commands nearly simultaneously. It assumes that the comment I added is correct; if the comment is wrong, that change to the behavior might be wrong, too.