### PR TITLE
[Data-700] extra params for audio input

### DIFF
--- a/components/audioinput/audio_input.go
+++ b/components/audioinput/audio_input.go
@@ -60,7 +60,8 @@ func Named(name string) resource.Name {
 
 // An AudioInput represents anything that can capture audio.
 type AudioInput interface {
-	gostream.AudioSource
+	Stream(ctx context.Context, extra map[string]interface{}, errHandlers ...ErrorHandler) (gostream.AudioStream, error)
+	Close(ctx context.Context) error
 	gostream.AudioPropertyProvider
 	generic.Generic
 }
@@ -171,6 +172,7 @@ type audioSource struct {
 
 func (as *audioSource) Stream(
 	ctx context.Context,
+	extra map[string]interface{},
 	errHandlers ...gostream.ErrorHandler,
 ) (gostream.AudioStream, error) {
 	return as.as.Stream(ctx, errHandlers...)

--- a/components/audioinput/audioinput_test.go
+++ b/components/audioinput/audioinput_test.go
@@ -76,7 +76,7 @@ func TestFromDependencies(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, res, test.ShouldNotBeNil)
 
-	audioData1, _, err := gostream.ReadAudio(context.Background(), res)
+	audioData1, _, err := audioinput.ReadAudio(context.Background(), res, nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, audioData, test.ShouldResemble, audioData1)
 	test.That(t, res.Close(context.Background()), test.ShouldBeNil)
@@ -97,7 +97,7 @@ func TestFromRobot(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, res, test.ShouldNotBeNil)
 
-	audioData1, _, err := gostream.ReadAudio(context.Background(), res)
+	audioData1, _, err := audioinput.ReadAudio(context.Background(), res, nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, audioData, test.ShouldResemble, audioData1)
 	test.That(t, res.Close(context.Background()), test.ShouldBeNil)
@@ -177,7 +177,7 @@ func TestReconfigurableAudioInput(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, actualaudioInput1.reconfCount, test.ShouldEqual, 0)
 
-	stream, err := reconfaudioInput1.(audioinput.AudioInput).Stream(context.Background())
+	stream, err := reconfaudioInput1.(audioinput.AudioInput).Stream(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
 
 	nextImg, _, err := stream.Next(context.Background())
@@ -195,7 +195,7 @@ func TestReconfigurableAudioInput(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, nextImg, test.ShouldResemble, audioData)
 
-	audioData1, _, err := gostream.ReadAudio(context.Background(), reconfaudioInput1.(audioinput.AudioInput))
+	audioData1, _, err := audioinput.ReadAudio(context.Background(), reconfaudioInput1.(audioinput.AudioInput), nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, audioData, test.ShouldResemble, audioData1)
 	test.That(t, actualaudioInput1.nextCount, test.ShouldEqual, 1)
@@ -254,7 +254,11 @@ func (ms *mockStream) Close(ctx context.Context) error {
 	return nil
 }
 
-func (m *mock) Stream(ctx context.Context, errHandlers ...gostream.ErrorHandler) (gostream.AudioStream, error) {
+func (m *mock) Stream(
+	ctx context.Context,
+	extra map[string]interface{},
+	errHandlers ...gostream.ErrorHandler,
+) (gostream.AudioStream, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return &mockStream{m: m}, nil
@@ -290,7 +294,7 @@ func TestNewAudioInput(t *testing.T) {
 	audioInput1, err := audioinput.NewFromReader(audioSrc, prop.Audio{})
 	test.That(t, err, test.ShouldBeNil)
 
-	audioData1, _, err := gostream.ReadAudio(context.Background(), audioInput1)
+	audioData1, _, err := audioinput.ReadAudio(context.Background(), audioInput1, nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, audioData, test.ShouldResemble, audioData1)
 

--- a/components/audioinput/fake/audio_input.go
+++ b/components/audioinput/fake/audio_input.go
@@ -61,7 +61,7 @@ func init() {
 				Latency:       time.Millisecond * latencyMillis,
 			})
 			input.AudioSource = as
-			return audioinput.NewFromSource(input)
+			return audioinput.NewFromSource(input.AudioSource)
 		}})
 }
 
@@ -83,6 +83,14 @@ const (
 	samplingRate  = 48000
 	channelCount  = 1
 )
+
+func (i *audioInput) Stream(
+	ctx context.Context,
+	extra map[string]interface{},
+	errHandlers ...gostream.ErrorHandler,
+) (gostream.AudioStream, error) {
+	return i.AudioSource.Stream(ctx, errHandlers...)
+}
 
 func (i *audioInput) Read(ctx context.Context) (wave.Audio, func(), error) {
 	select {
@@ -127,7 +135,7 @@ func (i *audioInput) Read(ctx context.Context) (wave.Audio, func(), error) {
 	return chunk, func() {}, nil
 }
 
-func (i *audioInput) MediaProperties(_ context.Context) (prop.Audio, error) {
+func (i *audioInput) MediaProperties(_ context.Context, _ map[string]interface{}) (prop.Audio, error) {
 	return prop.Audio{
 		ChannelCount:  channelCount,
 		SampleRate:    samplingRate,

--- a/components/audioinput/server.go
+++ b/components/audioinput/server.go
@@ -72,7 +72,7 @@ func (s *subtypeServer) Chunks(req *pb.ChunksRequest, server pb.AudioInputServic
 		return err
 	}
 
-	chunkStream, err := audioInput.Stream(server.Context())
+	chunkStream, err := audioInput.Stream(server.Context(), req.Extra.AsMap())
 	if err != nil {
 		return err
 	}
@@ -185,7 +185,7 @@ func (s *subtypeServer) Properties(
 		return nil, err
 	}
 
-	props, err := audioInput.MediaProperties(ctx)
+	props, err := audioInput.MediaProperties(ctx, req.Extra.AsMap())
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +215,7 @@ func (s *subtypeServer) Record(
 		return nil, err
 	}
 
-	chunkStream, err := audioInput.Stream(ctx)
+	chunkStream, err := audioInput.Stream(ctx, req.Extra.AsMap())
 	if err != nil {
 		return nil, err
 	}

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -176,7 +176,7 @@ func allAudioSourcesToDisplay(theRobot robot.Robot) map[string]gostream.AudioSou
 			continue
 		}
 
-		sources[name] = input
+		sources[name] = audioinput.NewGostreamWrapper(input)
 	}
 
 	return sources

--- a/testutils/inject/audioinput.go
+++ b/testutils/inject/audioinput.go
@@ -16,29 +16,31 @@ type AudioInput struct {
 	DoFunc     func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
 	StreamFunc func(
 		ctx context.Context,
+		extra map[string]interface{},
 		errHandlers ...gostream.ErrorHandler,
 	) (gostream.AudioStream, error)
-	MediaPropertiesFunc func(ctx context.Context) (prop.Audio, error)
+	MediaPropertiesFunc func(ctx context.Context, extra map[string]interface{}) (prop.Audio, error)
 	CloseFunc           func(ctx context.Context) error
 }
 
 // Stream calls the injected Stream or the real version.
 func (ai *AudioInput) Stream(
 	ctx context.Context,
+	extra map[string]interface{},
 	errHandlers ...gostream.ErrorHandler,
 ) (gostream.AudioStream, error) {
 	if ai.StreamFunc == nil {
-		return ai.AudioInput.Stream(ctx, errHandlers...)
+		return ai.AudioInput.Stream(ctx, extra, errHandlers...)
 	}
-	return ai.StreamFunc(ctx, errHandlers...)
+	return ai.StreamFunc(ctx, extra, errHandlers...)
 }
 
 // MediaProperties calls the injected MediaProperties or the real version.
-func (ai *AudioInput) MediaProperties(ctx context.Context) (prop.Audio, error) {
+func (ai *AudioInput) MediaProperties(ctx context.Context, extra map[string]interface{}) (prop.Audio, error) {
 	if ai.MediaPropertiesFunc == nil {
-		return ai.AudioInput.MediaProperties(ctx)
+		return ai.AudioInput.MediaProperties(ctx, extra)
 	}
-	return ai.MediaPropertiesFunc(ctx)
+	return ai.MediaPropertiesFunc(ctx, extra)
 }
 
 // Close calls the injected Close or the real version.


### PR DESCRIPTION
Don't merge until https://github.com/viamrobotics/api/pull/93 is merged

This adds "extra" params for the audio input component. 

I'm not exactly sure how useful adding extra is to the audio component - but this is the first pass at doing it.

Since camera is very similar to audio, whatever audio input ends up looking like, the same will happen to camera.