### PR TITLE
[DATA-713] Add zero padding to slamTimeFormat

### DIFF
--- a/services/slam/builtin/builtin.go
+++ b/services/slam/builtin/builtin.go
@@ -56,7 +56,7 @@ const (
 	cameraValidationIntervalSec = 1.
 	parsePortMaxTimeoutSec      = 60
 	// time format for the slam service.
-	slamTimeFormat        = time.RFC3339Nano
+	slamTimeFormat        = "2006-01-02T15:04:05.0000Z"
 	opTimeoutErrorMessage = "bad scan: OpTimeout"
 	localhost0            = "localhost:0"
 )

--- a/services/slam/builtin/orbslam_yaml_test.go
+++ b/services/slam/builtin/orbslam_yaml_test.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	yamlFilePrefixBytes = "%YAML:1.0\n"
-	slamTimeFormat      = time.RFC3339Nano
+	slamTimeFormat      = "2006-01-02T15:04:05.0000Z"
 )
 
 // function to search a SLAM data dir for a .yaml file. returns the timestamp and filepath.


### PR DESCRIPTION
Implements this ticket: https://viam.atlassian.net/browse/DATA-713

Fixes the issue that `time.RFC3339Nano` saves files with truncated zeros, e.g. `rplidar_data_2022-11-07T19:50:22.334Z.pcd` instead of `rplidar_data_2022-11-07T19:50:22.3340Z.pcd`, which messes up the sorting of files in the slam implementations. 