### PR TITLE
Remove log if collector not found

### DIFF
--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -540,6 +540,7 @@ func (svc *builtIn) Update(ctx context.Context, cfg *config.Config) error {
 	// Initialize or add a collector based on changes to the component configurations.
 	newCollectorMetadata := make(map[componentMethodMetadata]bool)
 	for _, attributes := range allComponentAttributes {
+		// if enabled and hz > 0 and capture enabled
 		if !attributes.Disabled && attributes.CaptureFrequencyHz > 0 && !svc.captureDisabled {
 			componentMetadata, err := svc.initializeOrUpdateCollector(
 				attributes, updateCaptureDir)

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -540,7 +540,6 @@ func (svc *builtIn) Update(ctx context.Context, cfg *config.Config) error {
 	// Initialize or add a collector based on changes to the component configurations.
 	newCollectorMetadata := make(map[componentMethodMetadata]bool)
 	for _, attributes := range allComponentAttributes {
-		// if enabled and hz > 0 and capture enabled
 		if !attributes.Disabled && attributes.CaptureFrequencyHz > 0 && !svc.captureDisabled {
 			componentMetadata, err := svc.initializeOrUpdateCollector(
 				attributes, updateCaptureDir)

--- a/services/datamanager/builtin/builtin_test.go
+++ b/services/datamanager/builtin/builtin_test.go
@@ -291,6 +291,47 @@ func TestRecoversAfterKilled(t *testing.T) {
 	test.That(t, len(mockService.getUploadedFiles()), test.ShouldEqual, 1+numArbitraryFilesToSync)
 }
 
+func TestCollectorDisabled(t *testing.T) {
+	// Register mock datasync service with a mock server.
+	rpcServer, mockService := buildAndStartLocalServer(t)
+	defer func() {
+		err := rpcServer.Stop()
+		test.That(t, err, test.ShouldBeNil)
+	}()
+
+	defer resetFolder(t, captureDir)
+	defer resetFolder(t, armDir)
+
+	disabledCollectorConfigPath := "services/datamanager/data/fake_robot_with_disabled_collector.json"
+	testCfg := setupConfig(t, disabledCollectorConfigPath)
+	dmCfg, err := getDataManagerConfig(testCfg)
+	test.That(t, err, test.ShouldBeNil)
+
+	// Initialize the data manager and update it with our config.
+	dmsvc := newTestDataManager(t, "arm1", "")
+	dmsvc.SetSyncerConstructor(getTestSyncerConstructor(t, rpcServer))
+
+	// Disable capture on the collector level.
+	err = dmsvc.Update(context.TODO(), testCfg)
+	test.That(t, err, test.ShouldBeNil)
+
+	// Change something else, but the previous collector capture is still disabled.
+	dmCfg.ScheduledSyncDisabled = true
+	err = dmsvc.Update(context.TODO(), testCfg)
+	test.That(t, err, test.ShouldBeNil)
+
+	// We set sync_interval_mins to be about 250ms in the config, so wait 300ms.
+	time.Sleep(time.Millisecond * 300)
+	err = dmsvc.Close(context.TODO())
+	test.That(t, err, test.ShouldBeNil)
+
+	// Test that nothing was captured or synced.
+	test.That(t, len(mockService.getUploadedFiles()), test.ShouldEqual, 0)
+	filesInArmDir, err := readDir(t, armDir)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, len(filesInArmDir), test.ShouldEqual, 0)
+}
+
 // TODO(DATA-341): Handle partial downloads in order to resume deployment.
 // TODO(DATA-344): Compare checksum of downloaded model to blob to determine whether to redeploy.
 // TODO(DATA-493): Test model deployment from config file.

--- a/services/datamanager/data/fake_robot_with_disabled_collector.json
+++ b/services/datamanager/data/fake_robot_with_disabled_collector.json
@@ -1,0 +1,44 @@
+{
+    "network": {
+        "fqdn": "something-unique",
+        "bind_address": ":8080"
+    },
+    "components": [
+        {
+            "name": "arm1",
+            "type": "arm",
+            "model": "fake",
+            "service_config": [
+                {
+                    "type": "data_manager",
+                    "attributes": {
+                        "capture_methods": [
+                            {
+                                "method": "EndPosition",
+                                "capture_frequency_hz": 100,
+                                "tags": [
+                                    "a",
+                                    "b"
+                                ],
+                                "disabled": true
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    ],
+    "services": [
+        {
+            "name": "data_manager1",
+            "type": "data_manager",
+            "model": "builtin",
+            "attributes": {
+                "sync_disabled": false,
+                "sync_interval_mins": 0,
+                "capture_dir": "/tmp/capture",
+                "capture_disabled": false
+            }
+        }
+    ]
+}


### PR DESCRIPTION
If a collector is disabled, remove it if it exists. If not, do not log.

Added a test for a disabled collector but enabled service-level capture. Also locally checked that the log would previously get triggered in this test.