### PR TITLE
APP-955 - Flag `untrusted-env` to disable all processes and shell

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -37,6 +37,11 @@ type Config struct {
 	// a user must pass via command line arguments.
 	AllowInsecureCreds bool `json:"-"`
 
+	// UntrustedEnv is used to disable Processes and shell for untrusted environments
+	// where a process cannot be trusted. This is an option a user must pass via
+	// command line arguments.
+	UntrustedEnv bool `json:"-"`
+
 	// FromCommand indicates if this config was parsed via the web server command.
 	// If false, it's for creating a robot via the RDK library. This is helpful for
 	// error messages that can indicate flags/config fields to use.

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -380,6 +380,7 @@ func newWithResources(
 				debug:              cfg.Debug,
 				fromCommand:        cfg.FromCommand,
 				allowInsecureCreds: cfg.AllowInsecureCreds,
+				untrustedEnv:       cfg.UntrustedEnv,
 				tlsConfig:          cfg.Network.TLSConfig,
 			},
 			logger,

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -35,6 +35,7 @@ type Arguments struct {
 	WebProfile                 bool   `flag:"webprofile,usage=include profiler in http server"`
 	WebRTC                     bool   `flag:"webrtc,usage=force webrtc connections instead of direct"`
 	RevealSensitiveConfigDiffs bool   `flag:"reveal-sensitive-config-diffs,usage=show config diffs"`
+	UntrustedEnv               bool   `flag:"untrusted-env,usage=disable processes and shell from running in a untrusted environment"`
 }
 
 type robotServer struct {
@@ -193,6 +194,7 @@ func (s *robotServer) serveWeb(ctx context.Context, cfg *config.Config) (err err
 		out.Debug = s.args.Debug || cfg.Debug
 		out.FromCommand = true
 		out.AllowInsecureCreds = s.args.AllowInsecureCreds
+		out.UntrustedEnv = s.args.UntrustedEnv
 		return out, nil
 	}
 


### PR DESCRIPTION
For less trusted environments where an untrusted user may update the config and we cannot trust them to run arbitrary code.

Note: This shouldn't be relied upon for completely untrusted environments.