### PR TITLE
[Data-758] update transform component

### DIFF
--- a/components/camera/transformpipeline/composed.go
+++ b/components/camera/transformpipeline/composed.go
@@ -7,7 +7,6 @@ import (
 	"github.com/edaniels/gostream"
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
-	"go.uber.org/multierr"
 
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/config"
@@ -20,37 +19,40 @@ import (
 // depthToPretty takes a depth image and turns into a colorful image, with blue being
 // farther away, and red being closest. Actual depth information is lost in the transform.
 type depthToPretty struct {
-	colorStream         gostream.VideoStream
-	depthStream         gostream.VideoStream
-	source              gostream.VideoSource
-	intrinsicParameters *transform.PinholeCameraIntrinsics
+	originalStream gostream.VideoStream
+	model          *transform.PinholeCameraModel
 }
 
 func newDepthToPrettyTransform(
 	ctx context.Context,
 	source gostream.VideoSource,
 	stream camera.StreamType,
-	cameraParams *transform.PinholeCameraIntrinsics,
-) (gostream.VideoSource, error) {
+) (gostream.VideoSource, camera.StreamType, error) {
+	if stream != camera.DepthStream {
+		return nil, camera.UnspecifiedStream,
+			errors.Errorf("source has stream type %s, depth_to_pretty only supports depth stream inputs", stream)
+	}
+	var cameraModel *transform.PinholeCameraModel
+	if cameraSrc, ok := source.(camera.Camera); ok {
+		props, err := cameraSrc.Properties(ctx)
+		if err != nil {
+			return nil, camera.UnspecifiedStream, err
+		}
+		cameraModel = &transform.PinholeCameraModel{props.IntrinsicParams, props.DistortionParams}
+	}
 	depthStream := gostream.NewEmbeddedVideoStream(source)
 	reader := &depthToPretty{
-		depthStream:         depthStream,
-		source:              source,
-		intrinsicParameters: cameraParams,
+		originalStream: depthStream,
+		model:          cameraModel,
 	}
-	reader.colorStream = gostream.NewEmbeddedVideoStreamFromReader(reader)
-	return camera.NewFromReader(
-		ctx,
-		reader,
-		&transform.PinholeCameraModel{reader.intrinsicParameters, nil},
-		stream,
-	)
+	cam, err := camera.NewFromReader(ctx, reader, cameraModel, camera.ColorStream)
+	return cam, camera.ColorStream, err
 }
 
 func (dtp *depthToPretty) Read(ctx context.Context) (image.Image, func(), error) {
 	ctx, span := trace.StartSpan(ctx, "camera::transformpipeline::depthToPretty::Read")
 	defer span.End()
-	i, release, err := dtp.depthStream.Next(ctx)
+	i, release, err := dtp.originalStream.Next(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -62,21 +64,25 @@ func (dtp *depthToPretty) Read(ctx context.Context) (image.Image, func(), error)
 }
 
 func (dtp *depthToPretty) Close(ctx context.Context) error {
-	return multierr.Combine(dtp.colorStream.Close(ctx), dtp.depthStream.Close(ctx))
+	return dtp.originalStream.Close(ctx)
 }
 
 func (dtp *depthToPretty) PointCloud(ctx context.Context) (pointcloud.PointCloud, error) {
 	ctx, span := trace.StartSpan(ctx, "camera::transformpipeline::depthToPretty::PointCloud")
 	defer span.End()
-	if dtp.intrinsicParameters == nil {
+	if dtp.cameraModel == nil || dtp.cameraModel.PinholeCameraIntrinsics == nil {
 		return nil, errors.Wrapf(transform.ErrNoIntrinsics, "depthToPretty transform cannot project to pointcloud")
 	}
-	// get the original depth map and colorful output
-	col, dm := camera.SimultaneousColorDepthNext(ctx, dtp.colorStream, dtp.depthStream)
-	if col == nil || dm == nil {
-		return nil, errors.New("requested color or depth image from camera is nil")
+	i, release, err := dtp.originalStream.Next(ctx)
+	if err != nil {
+		return nil, err
 	}
-	return dtp.intrinsicParameters.RGBDToPointCloud(rimage.ConvertImage(col), dm)
+	dm, err := rimage.ConvertImageToDepthMap(ctx, i)
+	if err != nil {
+		return nil, errors.Wrapf(err, "source camera does not make depth maps")
+	}
+	img := dm.ToPrettyPicture(0, rimage.MaxDepth)
+	return dtp.cameraModel.RGBDToPointCloud(img, dm)
 }
 
 // overlayAttrs are the attributes for an overlay transform.
@@ -86,8 +92,8 @@ type overlayAttrs struct {
 
 // overlaySource overlays the depth and color 2D images in order to debug the alignment of the two images.
 type overlaySource struct {
-	src                 gostream.VideoSource
-	intrinsicParameters *transform.PinholeCameraIntrinsics
+	src   gostream.VideoSource
+	model *transform.PinholeCameraModel
 }
 
 func newOverlayTransform(
@@ -95,45 +101,36 @@ func newOverlayTransform(
 	src gostream.VideoSource,
 	stream camera.StreamType,
 	am config.AttributeMap,
-) (gostream.VideoSource, error) {
+) (gostream.VideoSource, camera.StreamType, error) {
 	conf, err := config.TransformAttributeMapToStruct(&(overlayAttrs{}), am)
 	if err != nil {
-		return nil, err
+		return nil, camera.UnspecifiedStream, err
 	}
 	attrs, ok := conf.(*overlayAttrs)
 	if !ok {
-		return nil, rdkutils.NewUnexpectedTypeError(attrs, conf)
+		return nil, camera.UnspecifiedStream, rdkutils.NewUnexpectedTypeError(attrs, conf)
 	}
-	if attrs.IntrinsicParams == nil {
-		return nil, transform.ErrNoIntrinsics
+	cameraModel := &transform.PinholeCameraModel{}
+	if cameraSrc, ok := src.(camera.Camera); ok {
+		props, err := cameraSrc.Properties(ctx)
+		if err != nil {
+			return nil, camera.UnspecifiedStream, err
+		}
+		cameraModel = &transform.PinholeCameraModel{props.IntrinsicParams, props.DistortionParams}
 	}
-	if attrs.IntrinsicParams.Height <= 0. || attrs.IntrinsicParams.Width <= 0. {
-		return nil, errors.Wrapf(
-			transform.ErrNoIntrinsics,
-			"cannot do overlay with intrinsics (width,height) = (%v, %v)",
-			attrs.IntrinsicParams.Width, attrs.IntrinsicParams.Height,
-		)
+	if attrs.IntrinsicParams != nil && attrs.IntrinsicParams.Height > 0. &&
+		attrs.IntrinsicParams.Width > 0. && attrs.IntrinsicParams.Fx > 0. && attrs.IntrinsicParams.Fy > 0. {
+		cameraModel.PinholeCameraIntrinsics = attrs.IntrinsicParams
 	}
-	if attrs.IntrinsicParams.Fx <= 0. || attrs.IntrinsicParams.Fy <= 0. {
-		return nil, errors.Wrapf(
-			transform.ErrNoIntrinsics,
-			"cannot do overlay with intrinsics (Fx,Fy) = (%v, %v)",
-			attrs.IntrinsicParams.Fx, attrs.IntrinsicParams.Fy,
-		)
-	}
-	reader := &overlaySource{src, attrs.IntrinsicParams}
-	return camera.NewFromReader(
-		ctx,
-		reader,
-		&transform.PinholeCameraModel{reader.intrinsicParameters, nil},
-		stream,
-	)
+	reader := &overlaySource{src, cameraModel}
+	cam, err := camera.NewFromReader(ctx, reader, cameraModel, stream)
+	return cam, stream, err
 }
 
 func (os *overlaySource) Read(ctx context.Context) (image.Image, func(), error) {
 	ctx, span := trace.StartSpan(ctx, "camera::transformpipeline::overlay::Read")
 	defer span.End()
-	if os.intrinsicParameters == nil {
+	if os.cameraModel == nil || os.cameraModel.PinholeCameraIntrinsics == nil {
 		return nil, nil, transform.ErrNoIntrinsics
 	}
 	srcPointCloud, ok := os.src.(camera.PointCloudSource)
@@ -144,7 +141,7 @@ func (os *overlaySource) Read(ctx context.Context) (image.Image, func(), error) 
 	if err != nil {
 		return nil, nil, err
 	}
-	col, dm, err := os.intrinsicParameters.PointCloudToRGBD(pc)
+	col, dm, err := os.cameraModel.PointCloudToRGBD(pc)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/components/camera/transformpipeline/composed_test.go
+++ b/components/camera/transformpipeline/composed_test.go
@@ -6,9 +6,9 @@ import (
 	"image/color"
 	"testing"
 
+	"github.com/edaniels/gostream"
 	"go.viam.com/test"
 
-	"github.com/edaniels/gostream"
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/pointcloud"
@@ -19,7 +19,7 @@ import (
 
 type streamTest struct{}
 
-// Next will stream a color image
+// Next will stream a color image.
 func (*streamTest) Next(ctx context.Context) (image.Image, func(), error) {
 	return rimage.NewImage(1280, 720), func() {}, nil
 }

--- a/components/camera/transformpipeline/composed_test.go
+++ b/components/camera/transformpipeline/composed_test.go
@@ -8,12 +8,22 @@ import (
 
 	"go.viam.com/test"
 
+	"github.com/edaniels/gostream"
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/pointcloud"
+	"go.viam.com/rdk/rimage"
 	"go.viam.com/rdk/rimage/transform"
 	"go.viam.com/rdk/testutils/inject"
 )
+
+type streamTest struct{}
+
+// Next will stream a color image
+func (*streamTest) Next(ctx context.Context) (image.Image, func(), error) {
+	return rimage.NewImage(1280, 720), func() {}, nil
+}
+func (*streamTest) Close(ctx context.Context) error { return nil }
 
 func TestComposed(t *testing.T) {
 	// create pointcloud source and fake robot
@@ -22,6 +32,12 @@ func TestComposed(t *testing.T) {
 	cloudSource.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
 		p := pointcloud.New()
 		return p, p.Set(pointcloud.NewVector(0, 0, 0), pointcloud.NewColoredData(color.NRGBA{255, 1, 2, 255}))
+	}
+	cloudSource.StreamFunc = func(ctx context.Context, errHandlers ...gostream.ErrorHandler) (gostream.VideoStream, error) {
+		return &streamTest{}, nil
+	}
+	cloudSource.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
+		return nil, camera.Properties{}
 	}
 	// get intrinsic parameters, and make config
 	am := config.AttributeMap{
@@ -34,7 +50,6 @@ func TestComposed(t *testing.T) {
 	}
 	// make transform pipeline, expected result with correct config
 	conf := &transformConfig{
-		Stream: "color",
 		Pipeline: []Transformation{
 			{
 				Type:       "overlay",
@@ -46,8 +61,9 @@ func TestComposed(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, pc.Size(), test.ShouldEqual, 1)
 
-	myOverlay, err := newOverlayTransform(context.Background(), cloudSource, camera.ColorStream, am)
+	myOverlay, stream, err := newOverlayTransform(context.Background(), cloudSource, camera.ColorStream, am)
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, stream, test.ShouldEqual, camera.ColorStream)
 	pic, _, err := camera.ReadImage(context.Background(), myOverlay)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, pic.Bounds(), test.ShouldResemble, image.Rect(0, 0, 1280, 720))
@@ -60,7 +76,7 @@ func TestComposed(t *testing.T) {
 	test.That(t, pic.Bounds(), test.ShouldResemble, image.Rect(0, 0, 1280, 720))
 
 	// wrong result with bad config
-	_, err = newOverlayTransform(context.Background(), cloudSource, camera.ColorStream, config.AttributeMap{})
+	_, _, err = newOverlayTransform(context.Background(), cloudSource, camera.ColorStream, config.AttributeMap{})
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldWrap, transform.ErrNoIntrinsics)
 	am = config.AttributeMap{
@@ -69,18 +85,17 @@ func TestComposed(t *testing.T) {
 			Height: 720,
 		},
 	}
-	_, err = newOverlayTransform(context.Background(), cloudSource, camera.ColorStream, am)
+	_, _, err = newOverlayTransform(context.Background(), cloudSource, camera.ColorStream, am)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldWrap, transform.ErrNoIntrinsics)
 	conf = &transformConfig{
-		Stream: "color",
 		Pipeline: []Transformation{
 			{
 				Type: "overlay", // no attributes
 			},
 		},
 	}
-	_, err = newTransformPipeline(context.Background(), cloudSource, conf, robot)
+	_, _, err = newTransformPipeline(context.Background(), cloudSource, conf, robot)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldWrap, transform.ErrNoIntrinsics)
 }

--- a/components/camera/transformpipeline/composed_test.go
+++ b/components/camera/transformpipeline/composed_test.go
@@ -37,7 +37,7 @@ func TestComposed(t *testing.T) {
 		return &streamTest{}, nil
 	}
 	cloudSource.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
-		return nil, camera.Properties{}
+		return camera.Properties{}, nil
 	}
 	// get intrinsic parameters, and make config
 	am := config.AttributeMap{
@@ -79,6 +79,7 @@ func TestComposed(t *testing.T) {
 	_, _, err = newOverlayTransform(context.Background(), cloudSource, camera.ColorStream, config.AttributeMap{})
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldWrap, transform.ErrNoIntrinsics)
+	// wrong config, still no intrinsics
 	am = config.AttributeMap{
 		"intrinsic_parameters": &transform.PinholeCameraIntrinsics{
 			Width:  1280,
@@ -88,6 +89,7 @@ func TestComposed(t *testing.T) {
 	_, _, err = newOverlayTransform(context.Background(), cloudSource, camera.ColorStream, am)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldWrap, transform.ErrNoIntrinsics)
+	// wrong config, no attributes
 	conf = &transformConfig{
 		Pipeline: []Transformation{
 			{
@@ -95,7 +97,7 @@ func TestComposed(t *testing.T) {
 			},
 		},
 	}
-	_, _, err = newTransformPipeline(context.Background(), cloudSource, conf, robot)
+	_, err = newTransformPipeline(context.Background(), cloudSource, conf, robot)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldWrap, transform.ErrNoIntrinsics)
 }

--- a/components/camera/transformpipeline/depth_edges_test.go
+++ b/components/camera/transformpipeline/depth_edges_test.go
@@ -75,7 +75,7 @@ func (h *depthSourceTestHelper) Process(
 	}
 	ds, stream, err := newDepthEdgesTransform(context.Background(), gostream.NewVideoSource(source, prop.Video{}), am)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, stream, test.ShouldBeEqual, camera.DepthStream)
+	test.That(t, stream, test.ShouldEqual, camera.DepthStream)
 	edges, _, err := camera.ReadImage(context.Background(), ds)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, ds.Close(context.Background()), test.ShouldBeNil)

--- a/components/camera/transformpipeline/depth_edges_test.go
+++ b/components/camera/transformpipeline/depth_edges_test.go
@@ -41,8 +41,9 @@ func TestDepthSource(t *testing.T) {
 		"low_threshold":  0.40,
 		"blur_radius":    3.0,
 	}
-	ds, err := newDepthEdgesTransform(context.Background(), gostream.NewVideoSource(source, prop.Video{}), am)
+	ds, stream, err := newDepthEdgesTransform(context.Background(), gostream.NewVideoSource(source, prop.Video{}), am)
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, stream, test.ShouldEqual, camera.DepthStream)
 	_, _, err = camera.ReadImage(context.Background(), ds)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, ds.Close(context.Background()), test.ShouldBeNil)
@@ -72,8 +73,9 @@ func (h *depthSourceTestHelper) Process(
 		"low_threshold":  0.40,
 		"blur_radius":    3.0,
 	}
-	ds, err := newDepthEdgesTransform(context.Background(), gostream.NewVideoSource(source, prop.Video{}), am)
+	ds, stream, err := newDepthEdgesTransform(context.Background(), gostream.NewVideoSource(source, prop.Video{}), am)
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, stream, test.ShouldBeEqual, camera.DepthStream)
 	edges, _, err := camera.ReadImage(context.Background(), ds)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, ds.Close(context.Background()), test.ShouldBeNil)
@@ -87,8 +89,9 @@ func (h *depthSourceTestHelper) Process(
 
 	// preprocess depth map
 	source = &videosource.StaticSource{DepthImg: dm}
-	rs, err := newDepthPreprocessTransform(context.Background(), gostream.NewVideoSource(source, prop.Video{}))
+	rs, stream, err := newDepthPreprocessTransform(context.Background(), gostream.NewVideoSource(source, prop.Video{}))
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, stream, test.ShouldEqual, camera.DepthStream)
 
 	output, _, err := camera.ReadImage(context.Background(), rs)
 	test.That(t, err, test.ShouldBeNil)
@@ -102,8 +105,9 @@ func (h *depthSourceTestHelper) Process(
 	pCtx.GotDebugPointCloud(preprocessedPointCloud, "preprocessed-aligned-pointcloud")
 
 	source = &videosource.StaticSource{DepthImg: preprocessed}
-	ds, err = newDepthEdgesTransform(context.Background(), gostream.NewVideoSource(source, prop.Video{}), am)
+	ds, stream, err = newDepthEdgesTransform(context.Background(), gostream.NewVideoSource(source, prop.Video{}), am)
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, stream, test.ShouldEqual, camera.DepthStream)
 	processedEdges, _, err := camera.ReadImage(context.Background(), ds)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, ds.Close(context.Background()), test.ShouldBeNil)

--- a/components/camera/transformpipeline/mods.go
+++ b/components/camera/transformpipeline/mods.go
@@ -73,7 +73,7 @@ type resizeSource struct {
 // newResizeTransform creates a new resize transform.
 func newResizeTransform(
 	ctx context.Context, source gostream.VideoSource, stream camera.StreamType, am config.AttributeMap,
-) (gostream.VideoSource, error) {
+) (gostream.VideoSource, camera.StreamType, error) {
 	conf, err := config.TransformAttributeMapToStruct(&(resizeAttrs{}), am)
 	if err != nil {
 		return nil, camera.UnspecifiedStream, err

--- a/components/camera/transformpipeline/mods.go
+++ b/components/camera/transformpipeline/mods.go
@@ -26,7 +26,8 @@ type rotateSource struct {
 // newRotateTransform creates a new rotation transform.
 func newRotateTransform(ctx context.Context, source gostream.VideoSource, stream camera.StreamType) (gostream.VideoSource, error) {
 	reader := &rotateSource{gostream.NewEmbeddedVideoStream(source), stream}
-	return camera.NewFromReader(ctx, reader, nil, stream)
+	cam, err := camera.NewFromReader(ctx, reader, nil, stream)
+	return cam, stream, err
 }
 
 // Next rotates the 2D image depending on the stream type.
@@ -75,21 +76,22 @@ func newResizeTransform(
 ) (gostream.VideoSource, error) {
 	conf, err := config.TransformAttributeMapToStruct(&(resizeAttrs{}), am)
 	if err != nil {
-		return nil, err
+		return nil, camera.UnspecifiedStream, err
 	}
 	attrs, ok := conf.(*resizeAttrs)
 	if !ok {
-		return nil, rdkutils.NewUnexpectedTypeError(attrs, conf)
+		return nil, camera.UnspecifiedStream, rdkutils.NewUnexpectedTypeError(attrs, conf)
 	}
 	if attrs.Width == 0 {
-		return nil, errors.New("new width for resize transform cannot be 0")
+		return nil, camera.UnspecifiedStream, errors.New("new width for resize transform cannot be 0")
 	}
 	if attrs.Height == 0 {
-		return nil, errors.New("new height for resize transform cannot be 0")
+		return nil, camera.UnspecifiedStream, errors.New("new height for resize transform cannot be 0")
 	}
 
 	reader := &resizeSource{gostream.NewEmbeddedVideoStream(source), stream, attrs.Height, attrs.Width}
-	return camera.NewFromReader(ctx, reader, nil, stream)
+	cam, err := camera.NewFromReader(ctx, reader, nil, stream)
+	return cam, stream, err
 }
 
 // Next resizes the 2D image depending on the stream type.

--- a/components/camera/transformpipeline/mods_test.go
+++ b/components/camera/transformpipeline/mods_test.go
@@ -43,8 +43,9 @@ func TestResizeColor(t *testing.T) {
 	test.That(t, out.Bounds().Dx(), test.ShouldEqual, 128)
 	test.That(t, out.Bounds().Dy(), test.ShouldEqual, 72)
 
-	rs, err := newResizeTransform(context.Background(), source, camera.ColorStream, am)
+	rs, stream, err := newResizeTransform(context.Background(), source, camera.ColorStream, am)
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, stream, test.ShouldEqual, camera.ColorStream)
 	out, _, err = camera.ReadImage(context.Background(), rs)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, out.Bounds().Dx(), test.ShouldEqual, 30)
@@ -68,8 +69,9 @@ func TestResizeDepth(t *testing.T) {
 	test.That(t, out.Bounds().Dx(), test.ShouldEqual, 128)
 	test.That(t, out.Bounds().Dy(), test.ShouldEqual, 72)
 
-	rs, err := newResizeTransform(context.Background(), source, camera.DepthStream, am)
+	rs, stream, err := newResizeTransform(context.Background(), source, camera.DepthStream, am)
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, stream, test.ShouldEqual, camera.DepthStream)
 	out, _, err = camera.ReadImage(context.Background(), rs)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, out.Bounds().Dx(), test.ShouldEqual, 60)
@@ -83,8 +85,9 @@ func TestRotateColorSource(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	source := gostream.NewVideoSource(&videosource.StaticSource{ColorImg: img}, prop.Video{})
-	rs, err := newRotateTransform(context.Background(), source, camera.ColorStream)
+	rs, stream, err := newRotateTransform(context.Background(), source, camera.ColorStream)
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, stream, test.ShouldEqual, camera.ColorStream)
 
 	rawImage, _, err := camera.ReadImage(context.Background(), rs)
 	test.That(t, err, test.ShouldBeNil)
@@ -116,8 +119,9 @@ func TestRotateDepthSource(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	source := gostream.NewVideoSource(&videosource.StaticSource{DepthImg: pc}, prop.Video{})
-	rs, err := newRotateTransform(context.Background(), source, camera.DepthStream)
+	rs, stream, err := newRotateTransform(context.Background(), source, camera.DepthStream)
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, stream, test.ShouldEqual, camera.DepthStream)
 
 	rawImage, _, err := camera.ReadImage(context.Background(), rs)
 	test.That(t, err, test.ShouldBeNil)
@@ -150,8 +154,9 @@ func BenchmarkColorRotate(b *testing.B) {
 	source := gostream.NewVideoSource(&videosource.StaticSource{ColorImg: img}, prop.Video{})
 	cam, err := camera.NewFromSource(context.Background(), source, nil, camera.ColorStream)
 	test.That(b, err, test.ShouldBeNil)
-	rs, err := newRotateTransform(context.Background(), cam, camera.ColorStream)
+	rs, stream, err := newRotateTransform(context.Background(), cam, camera.ColorStream)
 	test.That(b, err, test.ShouldBeNil)
+	test.That(b, stream, test.ShouldEqual, camera.ColorStream)
 
 	b.ResetTimer()
 
@@ -170,8 +175,9 @@ func BenchmarkDepthRotate(b *testing.B) {
 	source := gostream.NewVideoSource(&videosource.StaticSource{DepthImg: img}, prop.Video{})
 	cam, err := camera.NewFromSource(context.Background(), source, nil, camera.DepthStream)
 	test.That(b, err, test.ShouldBeNil)
-	rs, err := newRotateTransform(context.Background(), cam, camera.DepthStream)
+	rs, stream, err := newRotateTransform(context.Background(), cam, camera.DepthStream)
 	test.That(b, err, test.ShouldBeNil)
+	test.That(b, stream, test.ShouldEqual, camera.DepthStream)
 
 	b.ResetTimer()
 

--- a/components/camera/transformpipeline/pipeline.go
+++ b/components/camera/transformpipeline/pipeline.go
@@ -80,11 +80,11 @@ func newTransformPipeline(
 		return nil, errors.New("pipeline has no transforms in it")
 	}
 	// check if the source produces a depth image or color image
-	streamType := camera.UnspecifiedStream
 	img, release, err := camera.ReadImage(ctx, source)
 	if err != nil {
 		return nil, err
 	}
+	var streamType camera.StreamType
 	if _, ok := img.(*rimage.DepthMap); ok {
 		streamType = camera.DepthStream
 	} else if _, ok := img.(*image.Gray16); ok {

--- a/components/camera/transformpipeline/pipeline_test.go
+++ b/components/camera/transformpipeline/pipeline_test.go
@@ -19,7 +19,6 @@ import (
 
 func TestTransformPipelineColor(t *testing.T) {
 	transformConf := &transformConfig{
-		Stream: "color",
 		Source: "source",
 		Pipeline: []Transformation{
 			{Type: "rotate", Attributes: config.AttributeMap{}},
@@ -64,7 +63,6 @@ func TestTransformPipelineDepth(t *testing.T) {
 	}
 
 	transformConf := &transformConfig{
-		Stream:           "depth",
 		CameraParameters: intrinsics,
 		Source:           "source",
 		Pipeline: []Transformation{
@@ -104,7 +102,6 @@ func TestTransformPipelineDepth(t *testing.T) {
 
 func TestTransformPipelineDepth2(t *testing.T) {
 	transform1 := &transformConfig{
-		Stream: "depth",
 		Source: "source",
 		Pipeline: []Transformation{
 			{Type: "depth_preprocess", Attributes: config.AttributeMap{}},
@@ -114,7 +111,6 @@ func TestTransformPipelineDepth2(t *testing.T) {
 		},
 	}
 	transform2 := &transformConfig{
-		Stream: "depth",
 		Source: "source",
 		Pipeline: []Transformation{
 			{Type: "depth_preprocess", Attributes: config.AttributeMap{}},
@@ -150,7 +146,6 @@ func TestTransformPipelineDepth2(t *testing.T) {
 
 func TestNullPipeline(t *testing.T) {
 	transform1 := &transformConfig{
-		Stream:   "color",
 		Source:   "source",
 		Pipeline: []Transformation{},
 	}
@@ -163,7 +158,6 @@ func TestNullPipeline(t *testing.T) {
 	test.That(t, err.Error(), test.ShouldContainSubstring, "pipeline has no transforms")
 
 	transform2 := &transformConfig{
-		Stream:   "color",
 		Source:   "source",
 		Pipeline: []Transformation{{Type: "identity", Attributes: nil}},
 	}
@@ -197,12 +191,6 @@ func TestPipeIntoPipe(t *testing.T) {
 			{Type: "resize", Attributes: config.AttributeMap{"height_px": 20, "width_px": 10}},
 		},
 	}
-	transformWrong := &transformConfig{
-		Source: "transform2",
-		Pipeline: []Transformation{
-			{Type: "resize", Attributes: config.AttributeMap{"height_px": 20, "width_px": 10}},
-		},
-	}
 
 	pipe1, err := newTransformPipeline(context.Background(), source, transform1, r)
 	test.That(t, err, test.ShouldBeNil)
@@ -226,14 +214,8 @@ func TestPipeIntoPipe(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, prop.(*transform.PinholeCameraIntrinsics).Width, test.ShouldEqual, 10)
 	test.That(t, prop.(*transform.PinholeCameraIntrinsics).Height, test.ShouldEqual, 20)
+	// Close everything
 	test.That(t, pipe2.Close(context.Background()), test.ShouldBeNil)
-	// should error - color image cannot be depth resized
-	pipeWrong, err := newTransformPipeline(context.Background(), pipe1, transformWrong, r)
-	test.That(t, err, test.ShouldBeNil)
-	_, _, err = camera.ReadImage(context.Background(), pipeWrong)
-	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, "don't know how to make image.Gray16")
-	test.That(t, pipeWrong.Close(context.Background()), test.ShouldBeNil)
 	test.That(t, pipe1.Close(context.Background()), test.ShouldBeNil)
 	test.That(t, source.Close(context.Background()), test.ShouldBeNil)
 }

--- a/components/camera/transformpipeline/pipeline_test.go
+++ b/components/camera/transformpipeline/pipeline_test.go
@@ -185,14 +185,12 @@ func TestPipeIntoPipe(t *testing.T) {
 
 	intrinsics1 := &transform.PinholeCameraIntrinsics{Width: 128, Height: 72}
 	transform1 := &transformConfig{
-		Stream:           "color",
 		CameraParameters: intrinsics1,
 		Source:           "source",
 		Pipeline:         []Transformation{{Type: "rotate", Attributes: config.AttributeMap{}}},
 	}
 	intrinsics2 := &transform.PinholeCameraIntrinsics{Width: 10, Height: 20}
 	transform2 := &transformConfig{
-		Stream:           "color",
 		CameraParameters: intrinsics2,
 		Source:           "transform2",
 		Pipeline: []Transformation{
@@ -200,7 +198,6 @@ func TestPipeIntoPipe(t *testing.T) {
 		},
 	}
 	transformWrong := &transformConfig{
-		Stream: "depth",
 		Source: "transform2",
 		Pipeline: []Transformation{
 			{Type: "resize", Attributes: config.AttributeMap{"height_px": 20, "width_px": 10}},

--- a/components/camera/transformpipeline/transform.go
+++ b/components/camera/transformpipeline/transform.go
@@ -40,7 +40,7 @@ func buildTransform(
 ) (gostream.VideoSource, camera.StreamType, error) {
 	switch transformType(tr.Type) {
 	case transformTypeUnspecified, transformTypeIdentity:
-		return source, nil
+		return source, stream, nil
 	case transformTypeRotate:
 		return newRotateTransform(ctx, source, stream)
 	case transformTypeResize:
@@ -58,6 +58,6 @@ func buildTransform(
 	case transformTypeDepthPreprocess:
 		return newDepthPreprocessTransform(ctx, source)
 	default:
-		return nil, errors.Errorf("do not know camera transform of type %q", tr.Type)
+		return nil, camera.UnspecifiedStream, errors.Errorf("do not know camera transform of type %q", tr.Type)
 	}
 }

--- a/components/camera/transformpipeline/transform.go
+++ b/components/camera/transformpipeline/transform.go
@@ -36,9 +36,8 @@ type Transformation struct {
 
 // buildTransform uses the Transformation config to build the desired transform ImageSource.
 func buildTransform(
-	ctx context.Context, r robot.Robot, source gostream.VideoSource, cfg *transformConfig, tr Transformation,
-) (gostream.VideoSource, error) {
-	stream := camera.StreamType(cfg.Stream)
+	ctx context.Context, r robot.Robot, source gostream.VideoSource, stream camera.StreamType, tr Transformation,
+) (gostream.VideoSource, camera.StreamType, error) {
 	switch transformType(tr.Type) {
 	case transformTypeUnspecified, transformTypeIdentity:
 		return source, nil
@@ -47,7 +46,7 @@ func buildTransform(
 	case transformTypeResize:
 		return newResizeTransform(ctx, source, stream, tr.Attributes)
 	case transformTypeDepthPretty:
-		return newDepthToPrettyTransform(ctx, source, stream, cfg.CameraParameters)
+		return newDepthToPrettyTransform(ctx, source, stream)
 	case transformTypeOverlay:
 		return newOverlayTransform(ctx, source, stream, tr.Attributes)
 	case transformTypeUndistort:

--- a/components/camera/transformpipeline/undistort_test.go
+++ b/components/camera/transformpipeline/undistort_test.go
@@ -58,7 +58,7 @@ func TestUndistortSetup(t *testing.T) {
 	test.That(t, us.Close(context.Background()), test.ShouldBeNil)
 
 	// success - attrs has camera parameters
-	us, stream, err = newUndistortTransform(context.Background(), source, camera.ColorStream, am)
+	us, stream, err := newUndistortTransform(context.Background(), source, camera.ColorStream, am)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, stream, test.ShouldEqual, camera.ColorStream)
 	_, _, err = camera.ReadImage(context.Background(), us)

--- a/components/camera/transformpipeline/undistort_test.go
+++ b/components/camera/transformpipeline/undistort_test.go
@@ -42,7 +42,7 @@ func TestUndistortSetup(t *testing.T) {
 
 	// no camera parameters
 	am := config.AttributeMap{}
-	_, err = newUndistortTransform(context.Background(), source, camera.ColorStream, am)
+	_, _, err = newUndistortTransform(context.Background(), source, camera.ColorStream, am)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, errors.Is(err, transform.ErrNoIntrinsics), test.ShouldBeTrue)
 	test.That(t, source.Close(context.Background()), test.ShouldBeNil)
@@ -50,7 +50,7 @@ func TestUndistortSetup(t *testing.T) {
 	// bad stream type
 	source = gostream.NewVideoSource(&videosource.StaticSource{ColorImg: img}, prop.Video{})
 	am = config.AttributeMap{"intrinsic_parameters": undistortTestParams, "distortion_parameters": undistortTestBC}
-	us, err := newUndistortTransform(context.Background(), source, camera.StreamType("fake"), am)
+	us, _, err := newUndistortTransform(context.Background(), source, camera.StreamType("fake"), am)
 	test.That(t, err, test.ShouldBeNil)
 	_, _, err = camera.ReadImage(context.Background(), us)
 	test.That(t, err, test.ShouldNotBeNil)
@@ -58,8 +58,9 @@ func TestUndistortSetup(t *testing.T) {
 	test.That(t, us.Close(context.Background()), test.ShouldBeNil)
 
 	// success - attrs has camera parameters
-	us, err = newUndistortTransform(context.Background(), source, camera.ColorStream, am)
+	us, stream, err = newUndistortTransform(context.Background(), source, camera.ColorStream, am)
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, stream, test.ShouldEqual, camera.ColorStream)
 	_, _, err = camera.ReadImage(context.Background(), us)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -74,8 +75,9 @@ func TestUndistortImage(t *testing.T) {
 
 	// success
 	am := config.AttributeMap{"intrinsic_parameters": undistortTestParams, "distortion_parameters": undistortTestBC}
-	us, err := newUndistortTransform(context.Background(), source, camera.ColorStream, am)
+	us, stream, err := newUndistortTransform(context.Background(), source, camera.ColorStream, am)
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, stream, test.ShouldEqual, camera.ColorStream)
 	corrected, _, err := camera.ReadImage(context.Background(), us)
 	test.That(t, err, test.ShouldBeNil)
 	result, ok := corrected.(*rimage.Image)
@@ -91,8 +93,9 @@ func TestUndistortImage(t *testing.T) {
 
 	// bad source
 	source = gostream.NewVideoSource(&videosource.StaticSource{ColorImg: rimage.NewImage(10, 10)}, prop.Video{})
-	us, err = newUndistortTransform(context.Background(), source, camera.ColorStream, am)
+	us, stream, err = newUndistortTransform(context.Background(), source, camera.ColorStream, am)
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, stream, test.ShouldEqual, camera.ColorStream)
 	_, _, err = camera.ReadImage(context.Background(), us)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "img dimension and intrinsics don't match")
 	test.That(t, us.Close(context.Background()), test.ShouldBeNil)
@@ -106,8 +109,9 @@ func TestUndistortDepthMap(t *testing.T) {
 
 	// success
 	am := config.AttributeMap{"intrinsic_parameters": undistortTestParams, "distortion_parameters": undistortTestBC}
-	us, err := newUndistortTransform(context.Background(), source, camera.DepthStream, am)
+	us, stream, err := newUndistortTransform(context.Background(), source, camera.DepthStream, am)
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, stream, test.ShouldEqual, camera.DepthStream)
 	corrected, _, err := camera.ReadImage(context.Background(), us)
 	test.That(t, err, test.ShouldBeNil)
 	result, ok := corrected.(*rimage.DepthMap)
@@ -123,15 +127,17 @@ func TestUndistortDepthMap(t *testing.T) {
 
 	// bad source
 	source = gostream.NewVideoSource(&videosource.StaticSource{DepthImg: rimage.NewEmptyDepthMap(10, 10)}, prop.Video{})
-	us, err = newUndistortTransform(context.Background(), source, camera.DepthStream, am)
+	us, stream, err = newUndistortTransform(context.Background(), source, camera.DepthStream, am)
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, stream, test.ShouldEqual, camera.DepthStream)
 	_, _, err = camera.ReadImage(context.Background(), us)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "img dimension and intrinsics don't match")
 	test.That(t, us.Close(context.Background()), test.ShouldBeNil)
 
 	// can't convert image to depth map
 	source = gostream.NewVideoSource(&videosource.StaticSource{ColorImg: rimage.NewImage(10, 10)}, prop.Video{})
-	us, err = newUndistortTransform(context.Background(), source, camera.DepthStream, am)
+	us, stream, err = newUndistortTransform(context.Background(), source, camera.DepthStream, am)
+	test.That(t, stream, test.ShouldEqual, camera.DepthStream)
 	test.That(t, err, test.ShouldBeNil)
 	_, _, err = camera.ReadImage(context.Background(), us)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "don't know how to make DepthMap")


### PR DESCRIPTION
Removes the stream attribute from transform model, and makes each transform pass its stream type to the next transform.

Hold off merging until coordinate with other teams, since this is a breaking change