### PR TITLE
DATA-539 Validate SLAM to auto-generate depends_on 

### DIFF
--- a/services/slam/builtin/builtin.go
+++ b/services/slam/builtin/builtin.go
@@ -261,7 +261,6 @@ type AttrConfig struct {
 
 // Validate creates the list of implicit dependencies.
 func (config *AttrConfig) Validate(path string) ([]string, error) {
-
 	if config.Algorithm == "" {
 		return nil, utils.NewConfigValidationFieldRequiredError(path, "algorithm")
 	}

--- a/services/slam/builtin/builtin.go
+++ b/services/slam/builtin/builtin.go
@@ -40,8 +40,9 @@ import (
 	"go.viam.com/rdk/rimage/transform"
 	"go.viam.com/rdk/services/slam"
 	"go.viam.com/rdk/spatialmath"
-	"go.viam.com/rdk/utils"
+	rdkutils "go.viam.com/rdk/utils"
 	"go.viam.com/rdk/vision"
+	"go.viam.com/utils"
 )
 
 var (
@@ -258,6 +259,29 @@ type AttrConfig struct {
 	Port             string            `json:"port"`
 }
 
+// Validate creates the list of implicit dependencies.
+func (config *AttrConfig) Validate(path string) ([]string, error) {
+	var deps []string
+
+	if config.Algorithm == "" {
+		return nil, utils.NewConfigValidationFieldRequiredError(path, "algorithm")
+	}
+
+	if config.ConfigParams["mode"] == "" {
+		return nil, utils.NewConfigValidationFieldRequiredError(path, "config_params[mode]")
+	}
+
+	if config.DataDirectory == "" {
+		return nil, utils.NewConfigValidationFieldRequiredError(path, "data_dir")
+	}
+
+	for _, sensor := range config.Sensors {
+		deps = append(deps, sensor)
+	}
+
+	return deps, nil
+}
+
 // builtIn is the structure of the slam service.
 type builtIn struct {
 	cameraName      string
@@ -442,12 +466,12 @@ func (slamSvc *builtIn) GetMap(
 	}
 
 	switch mimeType {
-	case utils.MimeTypeJPEG:
+	case rdkutils.MimeTypeJPEG:
 		imData, err = jpeg.Decode(bytes.NewReader(resp.GetImage()))
 		if err != nil {
 			return "", nil, nil, errors.Wrap(err, "get map decode image failed")
 		}
-	case utils.MimeTypePCD:
+	case rdkutils.MimeTypePCD:
 		pointcloudData := resp.GetPointCloud()
 		if pointcloudData == nil {
 			return "", nil, nil, errors.New("get map read pointcloud unavailable")
@@ -473,7 +497,7 @@ func NewBuiltIn(ctx context.Context, deps registry.Dependencies, config config.S
 
 	svcConfig, ok := config.ConvertedAttributes.(*AttrConfig)
 	if !ok {
-		return nil, utils.NewUnexpectedTypeError(svcConfig, config.ConvertedAttributes)
+		return nil, rdkutils.NewUnexpectedTypeError(svcConfig, config.ConvertedAttributes)
 	}
 
 	cameraName, cams, err := configureCameras(ctx, svcConfig, deps, logger)
@@ -775,20 +799,20 @@ func (slamSvc *builtIn) StopSLAMProcess() error {
 func (slamSvc *builtIn) getPNGImage(ctx context.Context, cam camera.Camera) ([]byte, func(), error) {
 	// We will hint that we want a PNG.
 	// The Camera service server implementation in RDK respects this; others may not.
-	readImgCtx := gostream.WithMIMETypeHint(ctx, utils.WithLazyMIMEType(utils.MimeTypePNG))
+	readImgCtx := gostream.WithMIMETypeHint(ctx, rdkutils.WithLazyMIMEType(rdkutils.MimeTypePNG))
 	img, release, err := camera.ReadImage(readImgCtx, cam)
 	if err != nil {
 		return nil, nil, err
 	}
 	if lazyImg, ok := img.(*rimage.LazyEncodedImage); ok {
-		if lazyImg.MIMEType() != utils.MimeTypePNG {
-			return nil, nil, errors.Errorf("expected mime type %v, got %T", utils.MimeTypePNG, img)
+		if lazyImg.MIMEType() != rdkutils.MimeTypePNG {
+			return nil, nil, errors.Errorf("expected mime type %v, got %T", rdkutils.MimeTypePNG, img)
 		}
 		return lazyImg.RawData(), release, nil
 	}
 
 	if ycbcrImg, ok := img.(*image.YCbCr); ok {
-		pngImage, err := rimage.EncodeImage(ctx, ycbcrImg, utils.MimeTypePNG)
+		pngImage, err := rimage.EncodeImage(ctx, ycbcrImg, rdkutils.MimeTypePNG)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/services/slam/builtin/builtin.go
+++ b/services/slam/builtin/builtin.go
@@ -261,7 +261,6 @@ type AttrConfig struct {
 
 // Validate creates the list of implicit dependencies.
 func (config *AttrConfig) Validate(path string) ([]string, error) {
-	// var deps []string
 
 	if config.Algorithm == "" {
 		return nil, utils.NewConfigValidationFieldRequiredError(path, "algorithm")

--- a/services/slam/builtin/builtin.go
+++ b/services/slam/builtin/builtin.go
@@ -261,7 +261,7 @@ type AttrConfig struct {
 
 // Validate creates the list of implicit dependencies.
 func (config *AttrConfig) Validate(path string) ([]string, error) {
-	var deps []string
+	// var deps []string
 
 	if config.Algorithm == "" {
 		return nil, utils.NewConfigValidationFieldRequiredError(path, "algorithm")
@@ -275,9 +275,7 @@ func (config *AttrConfig) Validate(path string) ([]string, error) {
 		return nil, utils.NewConfigValidationFieldRequiredError(path, "data_dir")
 	}
 
-	for _, sensor := range config.Sensors {
-		deps = append(deps, sensor)
-	}
+	deps := config.Sensors
 
 	return deps, nil
 }

--- a/services/slam/builtin/builtin_test.go
+++ b/services/slam/builtin/builtin_test.go
@@ -448,11 +448,11 @@ func createSLAMService(
 
 	deps := setupDeps(attrCfg)
 
-	_, err := attrCfg.Validate("path")
+	sensorDeps, err := attrCfg.Validate("path")
 	if err != nil {
 		return nil, err
 	}
-	//test.That(t, sensorDeps, test.ShouldResemble, attrCfg.Sensors)
+	test.That(t, sensorDeps, test.ShouldResemble, attrCfg.Sensors)
 
 	builtin.SetCameraValidationMaxTimeoutSecForTesting(1)
 	builtin.SetDialMaxTimeoutSecForTesting(1)

--- a/services/slam/builtin/builtin_test.go
+++ b/services/slam/builtin/builtin_test.go
@@ -443,10 +443,16 @@ func createSLAMService(
 	t.Helper()
 
 	ctx := context.Background()
-	cfgService := config.Service{Name: "test", Type: "slam", DependsOn: attrCfg.Sensors}
+	cfgService := config.Service{Name: "test", Type: "slam"}
 	cfgService.ConvertedAttributes = attrCfg
 
 	deps := setupDeps(attrCfg)
+
+	_, err := attrCfg.Validate("path")
+	if err != nil {
+		return nil, err
+	}
+	//test.That(t, sensorDeps, test.ShouldResemble, attrCfg.Sensors)
 
 	builtin.SetCameraValidationMaxTimeoutSecForTesting(1)
 	builtin.SetDialMaxTimeoutSecForTesting(1)
@@ -475,9 +481,21 @@ func TestGeneralNew(t *testing.T) {
 		logger := golog.NewTestLogger(t)
 		attrCfg := &builtin.AttrConfig{}
 		_, err := createSLAMService(t, attrCfg, logger, false, false)
-		test.That(t, err, test.ShouldBeError,
-			errors.Errorf("runtime slam config error: "+
-				"%v algorithm specified not in implemented list", attrCfg.Algorithm))
+		test.That(t, err, test.ShouldBeError, utils.NewConfigValidationFieldRequiredError("path", "algorithm"))
+	})
+
+	t.Run("New slam service with no data dir", func(t *testing.T) {
+		logger := golog.NewTestLogger(t)
+		attrCfg := &builtin.AttrConfig{Algorithm: "test", ConfigParams: map[string]string{"mode": "2d"}}
+		_, err := createSLAMService(t, attrCfg, logger, false, false)
+		test.That(t, err, test.ShouldBeError, utils.NewConfigValidationFieldRequiredError("path", "data_dir"))
+	})
+
+	t.Run("New slam service with no mode", func(t *testing.T) {
+		logger := golog.NewTestLogger(t)
+		attrCfg := &builtin.AttrConfig{Algorithm: "test", DataDirectory: "test"}
+		_, err := createSLAMService(t, attrCfg, logger, false, false)
+		test.That(t, err, test.ShouldBeError, utils.NewConfigValidationFieldRequiredError("path", "config_params[mode]"))
 	})
 
 	t.Run("New slam service with no camera", func(t *testing.T) {

--- a/web/frontend/cypress/data/test_robot_config.json
+++ b/web/frontend/cypress/data/test_robot_config.json
@@ -96,7 +96,12 @@
         },
         {
             "name": "test_slam",
-            "type": "slam"
+            "type": "slam",
+            "attributes": {
+                "algorithm" : "test",
+                "data_dir": "path",
+                "config_params": {"mode" : "mode"}
+            }
         },
         {
             "name": "test_motion",


### PR DESCRIPTION
Adding Validate function to slam to allow sensors defined by users in config to be automatically added to the depends_on field, thus avoiding requiring users to double write anything