### PR TITLE
update workflow

### DIFF
--- a/.github/workflows/update_protos.yml
+++ b/.github/workflows/update_protos.yml
@@ -21,11 +21,10 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Update go mod
-        run: go mod -u
-
-      - name: Update frontend
-        run: make buf
+      - name: Update api package
+        run: |
+          go get -u go.viam.com/api
+          go mod tidy
 
       - name: Make build lint
         run: make build lint


### PR DESCRIPTION
saw it was just failing so updated syntax.
`make buf` is not needed since `make build lint` runs that as part of it