### PR TITLE
Add JPEG hint to app video streams

### DIFF
--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -479,7 +479,7 @@ func (svc *webService) startStream(streamFunc func(opts *webstream.BackoffTuning
 }
 
 func (svc *webService) startImageStream(ctx context.Context, source gostream.VideoSource, stream gostream.Stream) {
-	ctxWithJPEGHint := gostream.WithMIMETypeHint(ctx, utils.WithLazyMIMEType(utils.MimeTypeJPEG))
+	ctxWithJPEGHint := gostream.WithMIMETypeHint(ctx, rutils.WithLazyMIMEType(rutils.MimeTypeJPEG))
 	svc.startStream(func(opts *webstream.BackoffTuningOptions) error {
 		return webstream.StreamVideoSource(ctxWithJPEGHint, source, stream, opts)
 	})

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -479,8 +479,9 @@ func (svc *webService) startStream(streamFunc func(opts *webstream.BackoffTuning
 }
 
 func (svc *webService) startImageStream(ctx context.Context, source gostream.VideoSource, stream gostream.Stream) {
+	ctxWithJPEGHint := gostream.WithMIMETypeHint(ctx, utils.WithLazyMIMEType(utils.MimeTypeJPEG))
 	svc.startStream(func(opts *webstream.BackoffTuningOptions) error {
-		return webstream.StreamVideoSource(ctx, source, stream, opts)
+		return webstream.StreamVideoSource(ctxWithJPEGHint, source, stream, opts)
 	})
 }
 


### PR DESCRIPTION
Currently, app gets back RawRGBALazy images by default from remote cameras.

 This switches all camera streams to request JPEGLazy frames from the cameras if they are using a gRPC GetImage() method.

The alternative could be to change the camera/client.go default request to be empty ( rather than the current default to request RawRGBALazy) such that the server can provide its own default MIME type in the response. 