### PR TITLE
[RSDK-1001] Add support for the ADXL345 accelerometer

### DIFF
--- a/components/movementsensor/adxl345/adxl345.go
+++ b/components/movementsensor/adxl345/adxl345.go
@@ -1,6 +1,6 @@
-// Package adxl345 implements the Sensor interface for the ADXL345 accelerometer attached to the
-// I2C bus of the robot (the chip supports communicating over SPI as well, but this package does
-// not support that interface). The manual for this chip is available at:
+// Package adxl345 implements the MovementSensor interface for the ADXL345 accelerometer attached
+// to the I2C bus of the robot (the chip supports communicating over SPI as well, but this package
+// does not support that interface). The manual for this chip is available at:
 // https://www.analog.com/media/en/technical-documentation/data-sheets/adxl345.pdf
 package adxl345
 
@@ -17,7 +17,7 @@ import (
 
 	"go.viam.com/rdk/components/board"
 	"go.viam.com/rdk/components/generic"
-	"go.viam.com/rdk/components/sensor"
+	"go.viam.com/rdk/components/movementsensor"
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/registry"
 )
@@ -46,7 +46,7 @@ func (cfg *AttrConfig) Validate(path string) ([]string, error) {
 }
 
 func init() {
-	registry.RegisterComponent(sensor.Subtype, modelName, registry.Component{
+	registry.RegisterComponent(movementsensor.Subtype, modelName, registry.Component{
 		Constructor: func(
 			ctx context.Context,
 			deps registry.Dependencies,
@@ -57,7 +57,7 @@ func init() {
 		},
 	})
 
-	config.RegisterComponentAttributeMapConverter(sensor.SubtypeName, modelName,
+	config.RegisterComponentAttributeMapConverter(movementsensor.SubtypeName, modelName,
 		func(attributes config.AttributeMap) (interface{}, error) {
 			var attr AttrConfig
 			return config.TransformAttributeMapToStruct(&attr, attributes)
@@ -89,7 +89,7 @@ func NewAdxl345(
 	deps registry.Dependencies,
 	rawConfig config.Component,
 	logger golog.Logger,
-) (sensor.Sensor, error) {
+) (movementsensor.MovementSensor, error) {
 	cfg := rawConfig.ConvertedAttributes.(*AttrConfig)
 	b, err := board.FromDependencies(deps, cfg.BoardName)
 	if err != nil {

--- a/components/movementsensor/adxl345/adxl345.go
+++ b/components/movementsensor/adxl345/adxl345.go
@@ -194,9 +194,12 @@ func toSignedValue(data []byte) int {
 	return int(int16(binary.LittleEndian.Uint16(data)))
 }
 
-// Given a value, scales it so that the range of int16s becomes the range of +/- maxValue.
+// Given a value, scales it so that the range of values read in becomes the range of +/- maxValue.
+// The trick here is that although the values are stored in 16 bits, the sensor only has 10 bits of
+// resolution. So, there are only (1 << 9) possible positive values, and a similar number of
+// negative ones.
 func setScale(value int, maxValue float64) float64 {
-	return float64(value) * maxValue / (1 << 15)
+	return float64(value) * maxValue / (1 << 9)
 }
 
 func (adxl *adxl345) pollData() {

--- a/components/movementsensor/adxl345/adxl345.go
+++ b/components/movementsensor/adxl345/adxl345.go
@@ -8,8 +8,10 @@ import (
 	"context"
 	"encoding/binary"
 	"sync"
+	"time"
 
 	"github.com/edaniels/golog"
+	"github.com/golang/geo/r3"
 	"github.com/pkg/errors"
 	"go.viam.com/utils"
 
@@ -207,7 +209,7 @@ func (adxl *adxl345) pollData() {
 			return
 		case <- timer.C:
 			// The registers holding the data are 0x32 through 0x37: two bytes each for X, Y, and Z.
-			rawData, err := adxl.readBlock(ctx, 0x32, 6)
+			rawData, err := adxl.readBlock(adxl.backgroundContext, 0x32, 6)
 			if err != nil {
 				adxl.mu.Lock()
 				adxl.lastError = err
@@ -239,7 +241,7 @@ func toLinearAcceleration(data []byte) r3.Vector {
 	}
 }
 
-func (adxl *adxl345) Readings(ctx context.Context) (map[string]interface{}, error) {
+func (adxl *adxl345) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
 	adxl.mu.Lock()
 	defer adxl.mu.Unlock()
 

--- a/components/movementsensor/adxl345/adxl345.go
+++ b/components/movementsensor/adxl345/adxl345.go
@@ -6,7 +6,6 @@ package adxl345
 
 import (
 	"context"
-	"encoding/binary"
 	"sync"
 	"time"
 
@@ -22,6 +21,7 @@ import (
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/registry"
 	"go.viam.com/rdk/spatialmath"
+	rutils "go.viam.com/rdk/utils"
 )
 
 const modelName = "accel-adxl345"
@@ -94,7 +94,7 @@ func NewAdxl345(
 ) (movementsensor.MovementSensor, error) {
 	cfg, ok := rawConfig.ConvertedAttributes.(*AttrConfig)
 	if !ok {
-		return nil, errors.Error("Cannot convert attributes to correct config type")
+		return nil, errors.New("Cannot convert attributes to correct config type")
 	}
 	b, err := board.FromDependencies(deps, cfg.BoardName)
 	if err != nil {
@@ -229,9 +229,9 @@ func setScale(value int, maxValue float64) float64 {
 
 func toLinearAcceleration(data []byte) r3.Vector {
 	// Vectors take ints, but we've got int16's, so we need to convert.
-	x := int(math.Int16FromBytesLE(data[0:2]))
-	y := int(math.Int16FromBytesLE(data[2:4]))
-	z := int(math.Int16FromBytesLE(data[4:6]))
+	x := int(rutils.Int16FromBytesLE(data[0:2]))
+	y := int(rutils.Int16FromBytesLE(data[2:4]))
+	z := int(rutils.Int16FromBytesLE(data[4:6]))
 
 	// The default scale is +/- 2G's, but our units should be mm/sec/sec.
 	maxAcceleration := 2.0 * 9.81 /* m/sec/sec */ * 1000.0 /* mm/m */

--- a/components/movementsensor/adxl345/adxl345.go
+++ b/components/movementsensor/adxl345/adxl345.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/edaniels/golog"
 	"github.com/golang/geo/r3"
+	geo "github.com/kellydunn/golang-geo"
 	"github.com/pkg/errors"
 	"go.viam.com/utils"
 
@@ -20,6 +21,7 @@ import (
 	"go.viam.com/rdk/components/movementsensor"
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/registry"
+	"go.viam.com/rdk/spatialmath"
 )
 
 const modelName = "accel-adxl345"
@@ -241,6 +243,30 @@ func toLinearAcceleration(data []byte) r3.Vector {
 	}
 }
 
+func (adxl *adxl345) AngularVelocity(ctx context.Context, extra map[string]interface{}) (spatialmath.AngularVelocity, error) {
+	return spatialmath.AngularVelocity{}, movementsensor.ErrMethodUnimplementedAngularVelocity
+}
+
+func (adxl *adxl345) LinearVelocity(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+	return r3.Vector{}, movementsensor.ErrMethodUnimplementedLinearVelocity
+}
+
+func (adxl *adxl345) Orientation(ctx context.Context, extra map[string]interface{}) (spatialmath.Orientation, error) {
+	return nil, movementsensor.ErrMethodUnimplementedOrientation
+}
+
+func (adxl *adxl345) CompassHeading(ctx context.Context, extra map[string]interface{}) (float64, error) {
+	return 0, movementsensor.ErrMethodUnimplementedCompassHeading
+}
+
+func (adxl *adxl345) Position(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+	return geo.NewPoint(0, 0), 0, movementsensor.ErrMethodUnimplementedPosition
+}
+
+func (adxl *adxl345) Accuracy(ctx context.Context, extra map[string]interface{}) (map[string]float32, error) {
+	return map[string]float32{}, movementsensor.ErrMethodUnimplementedAccuracy
+}
+
 func (adxl *adxl345) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
 	adxl.mu.Lock()
 	defer adxl.mu.Unlock()
@@ -249,6 +275,12 @@ func (adxl *adxl345) Readings(ctx context.Context, extra map[string]interface{})
 	lastError := adxl.lastError
 	adxl.lastError = nil
 	return map[string]interface{}{"linear_acceleration": adxl.linearAcceleration}, lastError
+}
+
+func (adxl *adxl345) Properties(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+	// We don't implement any of the MovementSensor interface yet, though hopefully
+	// LinearAcceleration will be added to the interface soon.
+	return &movementsensor.Properties{}, nil
 }
 
 // Puts the chip into standby mode.

--- a/components/movementsensor/adxl345/adxl345.go
+++ b/components/movementsensor/adxl345/adxl345.go
@@ -1,0 +1,199 @@
+// Package adxl345 implements the Sensor interface for the ADXL345 accelerometer attached to the
+// I2C bus of the robot (the chip supports communicating over SPI as well, but this package does
+// not support that interface). The manual for this chip is available at:
+// https://www.analog.com/media/en/technical-documentation/data-sheets/adxl345.pdf
+package adxl345
+
+import (
+	"context"
+	"encoding/binary"
+	"sync"
+
+	"github.com/edaniels/golog"
+	"github.com/pkg/errors"
+	"go.viam.com/utils"
+
+	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/generic"
+	"go.viam.com/rdk/components/sensor"
+	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/registry"
+)
+
+const modelName = "adxl345"
+
+// AttrConfig is a description of how to find an ADXL345 accelerometer on the robot.
+type AttrConfig struct {
+	BoardName              string `json:"board"`
+	BusID                  string `json:"bus_id"`
+	UseAlternateI2CAddress bool   `json:"use_alternate_i2c_address"`
+}
+
+// Validate ensures all parts of the config are valid, and then returns the list of things we
+// depend on.
+func (cfg *AttrConfig) Validate(path string) ([]string, error) {
+	if cfg.BoardName == "" {
+		return nil, utils.NewConfigValidationFieldRequiredError(path, "board")
+	}
+	if cfg.BusID == "" {
+		return nil, utils.NewConfigValidationFieldRequiredError(path, "bus_id")
+	}
+	var deps []string
+	deps = append(deps, cfg.BoardName)
+	return deps, nil
+}
+
+func init() {
+	registry.RegisterComponent(sensor.Subtype, modelName, registry.Component{
+		Constructor: func(
+			ctx context.Context,
+			deps registry.Dependencies,
+			cfg config.Component,
+			logger golog.Logger,
+		) (interface{}, error) {
+			return NewAdxl345(ctx, deps, cfg, logger)
+		},
+	})
+
+	config.RegisterComponentAttributeMapConverter(sensor.SubtypeName, modelName,
+		func(attributes config.AttributeMap) (interface{}, error) {
+			var attr AttrConfig
+			return config.TransformAttributeMapToStruct(&attr, attributes)
+		},
+		&AttrConfig{})
+}
+
+type adxl345 struct {
+	bus        board.I2C
+	i2cAddress byte
+	mu         sync.Mutex
+	logger     golog.Logger
+
+	generic.Unimplemented // Implements DoCommand with an ErrUnimplemented response
+}
+
+// NewAdxl345 is a constructor to create a new object representing an ADXL345 accelerometer.
+func NewAdxl345(
+	ctx context.Context,
+	deps registry.Dependencies,
+	rawConfig config.Component,
+	logger golog.Logger,
+) (sensor.Sensor, error) {
+	cfg := rawConfig.ConvertedAttributes.(*AttrConfig)
+	b, err := board.FromDependencies(deps, cfg.BoardName)
+	if err != nil {
+		return nil, err
+	}
+	localB, ok := b.(board.LocalBoard)
+	if !ok {
+		return nil, errors.Errorf("board %s is not local", cfg.BoardName)
+	}
+	bus, ok := localB.I2CByName(cfg.BusID)
+	if !ok {
+		return nil, errors.Errorf("can't find I2C bus '%s' for ADXL345 sensor", cfg.BusID)
+	}
+
+	var address byte
+	if cfg.UseAlternateI2CAddress {
+		address = 0x1D
+	} else {
+		address = 0x53
+	}
+
+	sensor := &adxl345{
+		bus:        bus,
+		i2cAddress: address,
+		logger:     logger,
+	}
+
+	// To check that we're able to talk to the chip, we should be able to read register 0 and get
+	// back the device ID (0xE5).
+	deviceID, err := sensor.readByte(ctx, 0)
+	if err != nil {
+		return nil, errors.Errorf("can't read from I2C address %d on bus %s of board %s: '%s'",
+			address, cfg.BusID, cfg.BoardName, err.Error())
+	}
+	if deviceID != 0xE5 {
+		return nil, errors.Errorf("unexpected I2C device instead of ADXL345 at address %d: deviceID '%d'",
+			address, deviceID)
+	}
+
+	// The chip starts out in standby mode. Set it to measurement mode so we can get data from it.
+	// To do this, we set the Power Control register (0x2D) to turn on the 8's bit.
+	err = sensor.writeByte(ctx, 0x2D, 0x08)
+	if err != nil {
+		return nil, errors.Errorf("unable to put ADXL345 into measurement mode: '%s'", err.Error())
+	}
+
+	return sensor, nil
+}
+
+func (adxl *adxl345) readByte(ctx context.Context, register byte) (byte, error) {
+	result, err := adxl.readBlock(ctx, register, 1)
+	if err != nil {
+		return 0, err
+	}
+	return result[0], err
+}
+
+func (adxl *adxl345) readBlock(ctx context.Context, register byte, length uint8) ([]byte, error) {
+	handle, err := adxl.bus.OpenHandle(adxl.i2cAddress)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		err := handle.Close()
+		if err != nil {
+			adxl.logger.Error(err)
+		}
+	}()
+
+	results, err := handle.ReadBlockData(ctx, register, length)
+	return results, err
+}
+
+func (adxl *adxl345) writeByte(ctx context.Context, register, value byte) error {
+	handle, err := adxl.bus.OpenHandle(adxl.i2cAddress)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err := handle.Close()
+		if err != nil {
+			adxl.logger.Error(err)
+		}
+	}()
+
+	return handle.WriteByteData(ctx, register, value)
+}
+
+// A helper function: takes 2 bytes and reinterprets them as a little-endian signed integer.
+func toSignedValue(data []byte) int {
+	return int(int16(binary.LittleEndian.Uint16(data)))
+}
+
+func (adxl *adxl345) Readings(ctx context.Context) (map[string]interface{}, error) {
+	adxl.mu.Lock()
+	defer adxl.mu.Unlock()
+	// The registers holding the data are 0x32 through 0x37: two bytes each for X, Y, and Z.
+	rawData, err := adxl.readBlock(ctx, 0x32, 6)
+	if err != nil {
+		return nil, err
+	}
+
+	x := toSignedValue(rawData[0:2])
+	y := toSignedValue(rawData[2:4])
+	z := toSignedValue(rawData[4:6])
+	return map[string]interface{}{"x": x, "y": y, "z": z}, nil
+}
+
+// Puts the chip into standby mode.
+func (adxl *adxl345) Close(ctx context.Context) {
+	adxl.mu.Lock()
+	defer adxl.mu.Unlock()
+	// Put the chip into standby mode by setting the Power Control register (0x2D) to 0.
+	err := adxl.writeByte(ctx, 0x2D, 0x00)
+	if err != nil {
+		adxl.logger.Error(err)
+	}
+}

--- a/components/movementsensor/adxl345/adxl345.go
+++ b/components/movementsensor/adxl345/adxl345.go
@@ -29,7 +29,7 @@ const modelName = "accel-adxl345"
 // AttrConfig is a description of how to find an ADXL345 accelerometer on the robot.
 type AttrConfig struct {
 	BoardName              string `json:"board"`
-	BusID                  string `json:"bus_id"`
+	I2cBus                 string `json:"i2c_bus"`
 	UseAlternateI2CAddress bool   `json:"use_alternate_i2c_address"`
 }
 
@@ -39,8 +39,8 @@ func (cfg *AttrConfig) Validate(path string) ([]string, error) {
 	if cfg.BoardName == "" {
 		return nil, utils.NewConfigValidationFieldRequiredError(path, "board")
 	}
-	if cfg.BusID == "" {
-		return nil, utils.NewConfigValidationFieldRequiredError(path, "bus_id")
+	if cfg.I2cBus == "" {
+		return nil, utils.NewConfigValidationFieldRequiredError(path, "i2c_bus")
 	}
 	var deps []string
 	deps = append(deps, cfg.BoardName)
@@ -101,9 +101,9 @@ func NewAdxl345(
 	if !ok {
 		return nil, errors.Errorf("board %s is not local", cfg.BoardName)
 	}
-	bus, ok := localB.I2CByName(cfg.BusID)
+	bus, ok := localB.I2CByName(cfg.I2cBus)
 	if !ok {
-		return nil, errors.Errorf("can't find I2C bus '%s' for ADXL345 sensor", cfg.BusID)
+		return nil, errors.Errorf("can't find I2C bus '%s' for ADXL345 sensor", cfg.I2cBus)
 	}
 
 	var address byte
@@ -128,7 +128,7 @@ func NewAdxl345(
 	deviceID, err := sensor.readByte(ctx, 0)
 	if err != nil {
 		return nil, errors.Errorf("can't read from I2C address %d on bus %s of board %s: '%s'",
-			address, cfg.BusID, cfg.BoardName, err.Error())
+			address, cfg.I2cBus, cfg.BoardName, err.Error())
 	}
 	if deviceID != 0xE5 {
 		return nil, errors.Errorf("unexpected I2C device instead of ADXL345 at address %d: deviceID '%d'",

--- a/components/movementsensor/adxl345/adxl345.go
+++ b/components/movementsensor/adxl345/adxl345.go
@@ -155,8 +155,6 @@ func NewAdxl345(
 
 		for {
 			select {
-			case <-sensor.backgroundContext.Done():
-				return
 			case <-timer.C:
 				// The registers with data are 0x32 through 0x37: two bytes each for X, Y, and Z.
 				rawData, err := sensor.readBlock(sensor.backgroundContext, 0x32, 6)
@@ -173,6 +171,8 @@ func NewAdxl345(
 				sensor.mu.Lock()
 				sensor.linearAcceleration = linearAcceleration
 				sensor.mu.Unlock()
+			case <-sensor.backgroundContext.Done():
+				return
 			}
 		}
 	})

--- a/components/movementsensor/adxl345/adxl345.go
+++ b/components/movementsensor/adxl345/adxl345.go
@@ -205,9 +205,9 @@ func (adxl *adxl345) pollData() {
 
 	for {
 		select {
-		case <- adxl.backgroundContext.Done():
+		case <-adxl.backgroundContext.Done():
 			return
-		case <- timer.C:
+		case <-timer.C:
 			// The registers holding the data are 0x32 through 0x37: two bytes each for X, Y, and Z.
 			rawData, err := adxl.readBlock(adxl.backgroundContext, 0x32, 6)
 			if err != nil {

--- a/components/movementsensor/mpu6050/mpu6050.go
+++ b/components/movementsensor/mpu6050/mpu6050.go
@@ -155,7 +155,7 @@ func NewMpu6050(
 	// Now, turn on the background goroutine that constantly reads from the chip and stores data in
 	// the object we created.
 	sensor.activeBackgroundWorkers.Add(1)
-	utils.PanicCapturingGo(func () {
+	utils.PanicCapturingGo(func() {
 		defer sensor.activeBackgroundWorkers.Done()
 		// Reading data a thousand times per second is probably fast enough.
 		timer := time.NewTicker(time.Millisecond)

--- a/components/movementsensor/mpu6050/mpu6050.go
+++ b/components/movementsensor/mpu6050/mpu6050.go
@@ -281,7 +281,9 @@ func (mpu *mpu6050) pollData() {
 func (mpu *mpu6050) AngularVelocity(ctx context.Context, extra map[string]interface{}) (spatialmath.AngularVelocity, error) {
 	mpu.mu.Lock()
 	defer mpu.mu.Unlock()
-	return mpu.angularVelocity, nil
+	lastError := mpu.lastError
+	mpu.lastError = nil
+	return mpu.angularVelocity, lastError
 }
 
 func (mpu *mpu6050) LinearVelocity(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
@@ -313,7 +315,10 @@ func (mpu *mpu6050) Readings(ctx context.Context, extra map[string]interface{}) 
 	readings["temperature_celsius"] = mpu.temperature
 	readings["angular_velocity"] = mpu.angularVelocity
 
-	return readings, nil
+	// Return the last error, if there was one, and clear it.
+	lastError := mpu.lastError
+	mpu.lastError = nil
+	return readings, lastError
 }
 
 func (mpu *mpu6050) Properties(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {

--- a/components/movementsensor/mpu6050/mpu6050.go
+++ b/components/movementsensor/mpu6050/mpu6050.go
@@ -3,7 +3,6 @@ package mpu6050
 
 import (
 	"context"
-	"encoding/binary"
 	"math"
 	"sync"
 	"time"
@@ -208,9 +207,9 @@ func setScale(value int, maxValue float64) float64 {
 // A helper function to abstract out shared code: takes 6 bytes and gives back AngularVelocity, in
 // radians per second.
 func toAngularVelocity(data []byte) spatialmath.AngularVelocity {
-	gx := int(math.Int16FromBytesBE(data[0:2]))
-	gy := int(math.Int16FromBytesBE(data[2:4]))
-	gz := int(math.Int16FromBytesBE(data[4:6]))
+	gx := int(rutils.Int16FromBytesBE(data[0:2]))
+	gy := int(rutils.Int16FromBytesBE(data[2:4]))
+	gz := int(rutils.Int16FromBytesBE(data[4:6]))
 
 	maxRotation := 250.0 // Maximum degrees per second measurable in the default configuration
 	radiansPerDegree := math.Pi / 180.0
@@ -223,9 +222,9 @@ func toAngularVelocity(data []byte) spatialmath.AngularVelocity {
 
 // A helper function that takes 6 bytes and gives back linear acceleration.
 func toLinearAcceleration(data []byte) r3.Vector {
-	x := int(math.Int16FromBytesBE(data[0:2]))
-	y := int(math.Int16FromBytesBE(data[2:4]))
-	z := int(math.Int16FromBytesBE(data[4:6]))
+	x := int(rutils.Int16FromBytesBE(data[0:2]))
+	y := int(rutils.Int16FromBytesBE(data[2:4]))
+	z := int(rutils.Int16FromBytesBE(data[4:6]))
 
 	// The scale is +/- 2G's, but our units should be mm/sec/sec.
 	maxAcceleration := 2.0 * 9.81 /* m/sec/sec */ * 1000.0 /* mm/m */
@@ -258,7 +257,7 @@ func (mpu *mpu6050) pollData() {
 
 			linearAcceleration := toLinearAcceleration(rawData[0:6])
 			// Taken straight from the MPU6050 register map. Yes, these are weird constants.
-			temperature := float64(math.Int16FromBytesBE(rawData[6:8]))/340.0 + 36.53
+			temperature := float64(rutils.Int16FromBytesBE(rawData[6:8]))/340.0 + 36.53
 			angularVelocity := toAngularVelocity(rawData[8:14])
 
 			// Lock the mutex before modifying the state within the object. By keeping the mutex

--- a/components/movementsensor/mpu6050/mpu6050.go
+++ b/components/movementsensor/mpu6050/mpu6050.go
@@ -163,8 +163,6 @@ func NewMpu6050(
 
 		for {
 			select {
-			case <-sensor.backgroundContext.Done():
-				return
 			case <-timer.C:
 				rawData, err := sensor.readBlock(sensor.backgroundContext, 59, 14)
 				if err != nil {
@@ -188,6 +186,8 @@ func NewMpu6050(
 				sensor.temperature = temperature
 				sensor.angularVelocity = angularVelocity
 				sensor.mu.Unlock()
+			case <-sensor.backgroundContext.Done():
+				return
 			}
 		}
 	})

--- a/components/movementsensor/register/register.go
+++ b/components/movementsensor/register/register.go
@@ -3,6 +3,7 @@ package register
 
 import (
 	// Load all movementsensors.
+	_ "go.viam.com/rdk/components/movementsensor/adxl345"
 	_ "go.viam.com/rdk/components/movementsensor/cameramono"
 	_ "go.viam.com/rdk/components/movementsensor/fake"
 	_ "go.viam.com/rdk/components/movementsensor/gpsnmea"

--- a/utils/math.go
+++ b/utils/math.go
@@ -285,12 +285,22 @@ func Float64FromBytesBE(bytes []byte) float64 {
 	return float
 }
 
-// Uint32FromBytesLE converts an array of bytes odered in little-endian to a uint32.
+// Uint32FromBytesLE converts an array of bytes ordered in little-endian to a uint32.
 func Uint32FromBytesLE(bytes []byte) uint32 {
 	return binary.LittleEndian.Uint32(bytes)
 }
 
-// Uint32FromBytesBE converts an array of bytes odered in big-endian to a uint32.
+// Uint32FromBytesBE converts an array of bytes ordered in big-endian to a uint32.
 func Uint32FromBytesBE(bytes []byte) uint32 {
 	return binary.BigEndian.Uint32(bytes)
+}
+
+// Int16FromBytesLE converts an array of bytes ordered in little-endian to a (signed) int16.
+func Int16FromBytesBE(bytes []byte) int16 {
+	return int16(binary.LittleEndian.Uint16(data))
+}
+
+// Int16FromBytesBE converts an array of bytes ordered in big-endian to a (signed) int16.
+func Int16FromBytesBE(bytes []byte) int16 {
+	return int16(binary.BigEndian.Uint16(data))
 }

--- a/utils/math.go
+++ b/utils/math.go
@@ -296,11 +296,11 @@ func Uint32FromBytesBE(bytes []byte) uint32 {
 }
 
 // Int16FromBytesLE converts an array of bytes ordered in little-endian to a (signed) int16.
-func Int16FromBytesBE(bytes []byte) int16 {
-	return int16(binary.LittleEndian.Uint16(data))
+func Int16FromBytesLE(bytes []byte) int16 {
+	return int16(binary.LittleEndian.Uint16(bytes))
 }
 
 // Int16FromBytesBE converts an array of bytes ordered in big-endian to a (signed) int16.
 func Int16FromBytesBE(bytes []byte) int16 {
-	return int16(binary.BigEndian.Uint16(data))
+	return int16(binary.BigEndian.Uint16(bytes))
 }

--- a/utils/math_test.go
+++ b/utils/math_test.go
@@ -369,6 +369,7 @@ func TestBytesToVar(t *testing.T) {
 	var f32 float32
 	var f64 float64
 	var u32 uint32
+	var i16 int16
 	f32 = -6.2598534e18
 	v := Float32FromBytesLE([]byte{0xEF, 0xBE, 0xAD, 0xDE})
 	test.That(t, v, test.ShouldEqual, f32)
@@ -385,5 +386,11 @@ func TestBytesToVar(t *testing.T) {
 	vu32 := Uint32FromBytesLE([]byte{0x78, 0x56, 0x34, 0x12})
 	test.That(t, vu32, test.ShouldEqual, u32)
 	vu32 = Uint32FromBytesBE([]byte{0x12, 0x34, 0x56, 0x78})
+	test.That(t, vu32, test.ShouldEqual, u32)
+
+	i16 = 0x1234
+	vu32 := Int16FromBytesLE([]byte{0x34, 0x12})
+	test.That(t, vu32, test.ShouldEqual, u32)
+	vu32 = Int16FromBytesBE([]byte{0x12, 0x34})
 	test.That(t, vu32, test.ShouldEqual, u32)
 }

--- a/utils/math_test.go
+++ b/utils/math_test.go
@@ -389,8 +389,8 @@ func TestBytesToVar(t *testing.T) {
 	test.That(t, vu32, test.ShouldEqual, u32)
 
 	i16 = 0x1234
-	vu32 := Int16FromBytesLE([]byte{0x34, 0x12})
-	test.That(t, vu32, test.ShouldEqual, u32)
-	vu32 = Int16FromBytesBE([]byte{0x12, 0x34})
-	test.That(t, vu32, test.ShouldEqual, u32)
+	vi16 := Int16FromBytesLE([]byte{0x34, 0x12})
+	test.That(t, vi16, test.ShouldEqual, i16)
+	vi16 = Int16FromBytesBE([]byte{0x12, 0x34})
+	test.That(t, vi16, test.ShouldEqual, i16)
 }


### PR DESCRIPTION
(and while I was looking at it, return any errors encountered when querying the MPU6050 accelerometer, too.)

This PR is adapted from https://github.com/viam-labs/adxl345-accelerometer/pull/1, and when this is merged we should probably delete that other repo.

Tried at my desk: results look plausible. I've got two accelerometers at my desk now, and although they both give okay results, the MPU6050 tends to think gravity is a pretty consistent 13.7% stronger than the ADXL345 thinks it is. Is this because I coded one of them up wrong, or because one of the chips is miscalibrated? Part of me suspects the former, but I don't actually know. :grimacing: 

but at the very least, they both give values that are the right order of magnitude, in the right direction.

Sorry the PR is so long; I would have preferred two PRs half the length, but didn't see an easy way to break it up. Maybe next time I can go for the skeleton code, and then the implementation itself?

I'm tagging Rand because she reviewed the MPU6050 code (https://github.com/viamrobotics/rdk/pull/1611), and Nicolas because he reviewed https://github.com/viam-labs/adxl345-accelerometer/pull/1. I kinda feel like only one of you needs to review this, but I don't know which that should be.