### PR TITLE
DATA-597 Automatically reconnect to a camera

### DIFF
--- a/components/camera/camera.go
+++ b/components/camera/camera.go
@@ -67,7 +67,7 @@ var Subtype = resource.NewSubtype(
 	SubtypeName,
 )
 
-// Named is a helper for getting the named cameras's typed resource name.
+// Named is a helper for getting the named camera's typed resource name.
 func Named(name string) resource.Name {
 	return resource.NameFromSubtype(Subtype, name)
 }
@@ -356,7 +356,6 @@ func (c *reconfigurableCamera) Stream(
 	stream := &reconfigurableCameraStream{
 		c:           c,
 		errHandlers: errHandlers,
-		cancelCtx:   c.cancelCtx,
 	}
 	stream.mu.Lock()
 	defer stream.mu.Unlock()
@@ -372,7 +371,6 @@ type reconfigurableCameraStream struct {
 	c           *reconfigurableCamera
 	errHandlers []gostream.ErrorHandler
 	stream      gostream.VideoStream
-	cancelCtx   context.Context
 }
 
 func (cs *reconfigurableCameraStream) init(ctx context.Context) error {
@@ -385,7 +383,7 @@ func (cs *reconfigurableCameraStream) Next(ctx context.Context) (image.Image, fu
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
 
-	if cs.stream == nil || cs.cancelCtx.Err() != nil {
+	if cs.stream == nil || cs.c.cancelCtx.Err() != nil {
 		if err := func() error {
 			cs.c.mu.Lock()
 			defer cs.c.mu.Unlock()
@@ -438,15 +436,12 @@ func (c *reconfigurableCamera) DoCommand(ctx context.Context, cmd map[string]int
 }
 
 // Reconfigure reconfigures the resource.
-func (c *reconfigurableCamera) Reconfigure(ctx context.Context, newCamera resource.Reconfigurable) error {
+func (c *reconfigurableCamera) Reconfigure(_ context.Context, newCamera resource.Reconfigurable) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	actual, ok := newCamera.(*reconfigurableCamera)
 	if !ok {
 		return utils.NewUnexpectedTypeError(c, newCamera)
-	}
-	if err := viamutils.TryClose(ctx, c.actual); err != nil {
-		golog.Global().Errorw("error closing old", "error", err)
 	}
 	c.cancel()
 	// reset

--- a/components/camera/videosource/camera_waitgroup.go
+++ b/components/camera/videosource/camera_waitgroup.go
@@ -1,0 +1,49 @@
+package videosource
+
+import (
+	"context"
+	"sync"
+
+	"github.com/edaniels/gostream"
+
+	"go.viam.com/rdk/components/camera"
+	"go.viam.com/rdk/pointcloud"
+	"go.viam.com/rdk/rimage/transform"
+)
+
+// CameraWaitGroup is a wrapper for camera.Camera with a sync.WaitGroup.
+type CameraWaitGroup struct {
+	cam                     camera.Camera
+	activeBackgroundWorkers sync.WaitGroup
+}
+
+// DoCommand wraps camera.Camera.DoCommand.
+func (c *CameraWaitGroup) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+	return c.cam.DoCommand(ctx, cmd)
+}
+
+// Projector wraps camera.Camera.Projector.
+func (c *CameraWaitGroup) Projector(ctx context.Context) (transform.Projector, error) {
+	return c.cam.Projector(ctx)
+}
+
+// Stream wraps camera.Camera.Stream.
+func (c *CameraWaitGroup) Stream(ctx context.Context, errHandlers ...gostream.ErrorHandler) (gostream.VideoStream, error) {
+	return c.cam.Stream(ctx, errHandlers...)
+}
+
+// NextPointCloud wraps camera.Camera.NextPointCloud.
+func (c *CameraWaitGroup) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, error) {
+	return c.cam.NextPointCloud(ctx)
+}
+
+// Properties wraps camera.Camera.Properties.
+func (c *CameraWaitGroup) Properties(ctx context.Context) (camera.Properties, error) {
+	return c.cam.Properties(ctx)
+}
+
+// Close calls WaitGroup.Wait before calling camera.Camera.Close.
+func (c *CameraWaitGroup) Close(ctx context.Context) error {
+	c.activeBackgroundWorkers.Wait()
+	return c.cam.Close(ctx)
+}

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"go.viam.com/rdk/resource"
+
 	"github.com/edaniels/golog"
 	"github.com/edaniels/gostream"
 	"github.com/pion/mediadevices"
@@ -194,54 +196,141 @@ func makeConstraints(attrs *WebcamAttrs, debug bool, logger golog.Logger) mediad
 	}
 }
 
-// findCamera finds a video device and returns a camera with that video device as the source.
-func findCamera(ctx context.Context, attrs *WebcamAttrs, logger golog.Logger) (camera.Camera, error) {
+// findCamera finds a video device and returns a reconfigurable camera with that video device as the source.
+func findCamera(
+	ctx context.Context,
+	attrs *WebcamAttrs,
+	label string,
+	logger golog.Logger,
+) (resource.Reconfigurable, error) {
+	var cam camera.Camera
+	var err error
+
 	debug := attrs.Debug
 	constraints := makeConstraints(attrs, debug, logger)
-	if attrs.Path != "" {
-		return tryWebcamOpen(ctx, attrs, attrs.Path, false, constraints, logger)
+	if label != "" {
+		cam, err = tryWebcamOpen(ctx, attrs, label, false, constraints, logger)
+		if err != nil {
+			return nil, errors.Wrap(err, "cannot open webcam")
+		}
+	} else {
+		source, err := gostream.GetAnyVideoSource(constraints, logger)
+		if err != nil {
+			return nil, errors.Wrap(err, "found no webcams")
+		}
+		cam, err = makeCameraFromSource(ctx, source, attrs)
+		if err != nil {
+			return nil, errors.Wrap(err, "cannot make webcam from source")
+		}
 	}
 
-	source, err := gostream.GetAnyVideoSource(constraints, logger)
+	return camera.WrapWithReconfigurable(cam, camera.Named(model))
+}
+
+// getLabelFromCameraOrPath returns the path from the camera or an empty string if a path is not found.
+func getLabelFromCamera(cam camera.Camera, logger golog.Logger) string {
+	src, err := camera.SourceFromCamera(cam)
 	if err != nil {
-		return nil, errors.Wrap(err, "found no webcams")
+		logger.Errorw("cannot get source from camera", "error", err)
+		return ""
 	}
-	return makeCameraFromSource(ctx, source, attrs)
+
+	labels, err := gostream.LabelsFromMediaSource[image.Image, prop.Video](src)
+	if err != nil || len(labels) == 0 {
+		logger.Errorw("could not get labels from media source", "error", err)
+		return ""
+	}
+
+	return labels[0]
+}
+
+// isConnected returns true if the reconfigurable camera is connected, otherwise false.
+func isConnected(reconfCam resource.Reconfigurable) (bool, error) {
+	actualCam := utils.UnwrapProxy(reconfCam).(camera.Camera)
+	src, err := camera.SourceFromCamera(actualCam)
+	if err != nil {
+		return true, errors.Wrap(err, "cannot get source from camera")
+	}
+	props, err := gostream.PropertiesFromMediaSource[image.Image, prop.Video](src)
+	if err != nil {
+		return true, errors.Wrap(err, "cannot get properties from media source")
+	}
+	// github.com/pion/mediadevices connects to the OS to get the props for a driver. On disconnect props will be empty.
+	return len(props) != 0, nil
+}
+
+// reconfigureCamera creates a new camera and reconfigures the given reconfigurable camera.
+func reconfigureCamera(
+	ctx context.Context,
+	oldCam resource.Reconfigurable,
+	attrs *WebcamAttrs,
+	label string,
+	logger golog.Logger,
+) (err error) {
+	goutils.UncheckedError(goutils.TryClose(ctx, oldCam))
+	logger.Debugw("camera disconnected", "label", label)
+
+	newCam, err := findCamera(ctx, attrs, label, logger)
+	defer func() {
+		if err != nil {
+			goutils.UncheckedError(goutils.TryClose(ctx, newCam))
+		}
+	}()
+	if err != nil {
+		return errors.Wrap(err, "cannot make camera")
+	}
+
+	if err = oldCam.Reconfigure(ctx, newCam); err != nil {
+		return errors.Wrap(err, "cannot reconfigure camera")
+	}
+	return
 }
 
 // NewWebcamSource returns a new source based on a webcam discovered from the given attributes.
 func NewWebcamSource(ctx context.Context, attrs *WebcamAttrs, logger golog.Logger) (camera.Camera, error) {
-	cam, err := findCamera(ctx, attrs, logger)
+	cam, err := findCamera(ctx, attrs, attrs.Path, logger)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not find video source for camera")
+		return nil, errors.Wrap(err, "cannot find video source for camera")
 	}
 
-	goutils.PanicCapturingGo(func() {
-		src, err := camera.SourceFromCamera(cam)
-		if err != nil {
-			logger.Debugw("cannot get source from camera", "error", err)
-			return
-		}
+	label := attrs.Path
+	if label == "" {
+		label = getLabelFromCamera(utils.UnwrapProxy(cam).(camera.Camera), logger)
+	}
 
-		defer func() {
-			logger.Debug("closing camera")
-			goutils.UncheckedError(cam.Close(ctx))
-		}()
+	const wait = 500 * time.Millisecond
+	camWg := CameraWaitGroup{cam: cam.(camera.Camera)}
+	camWg.activeBackgroundWorkers.Add(1)
+	goutils.ManagedGo(func() {
+		defer goutils.UncheckedError(goutils.TryClose(ctx, cam))
 		for {
-			if goutils.SelectContextOrWait(ctx, 500*time.Millisecond) {
-				// mediadevices connects to the OS to get the properties for a driver. If the OS no longer knows
-				// about a specific driver then properties will be empty, and we can safely assume the driver no
-				// longer exists and should be closed.
-				if len(gostream.PropertiesFromMediaSource[image.Image, prop.Video](src)) == 0 {
-					return
-				}
-			} else {
+			if !goutils.SelectContextOrWait(ctx, wait) {
 				return
 			}
-		}
-	})
 
-	return cam, nil
+			ok, err := isConnected(cam)
+			if err != nil {
+				logger.Debugw("cannot determine camera status", "error", err)
+				continue
+			}
+
+			if !ok {
+				for {
+					if !goutils.SelectContextOrWait(ctx, wait) {
+						return
+					}
+					if err := reconfigureCamera(ctx, cam, attrs, label, logger); err != nil {
+						logger.Debugw("cannot reconfigure camera", "label", label, "error", err)
+						continue
+					}
+					logger.Debugw("camera connected", "label", label)
+					break
+				}
+			}
+		}
+	}, camWg.activeBackgroundWorkers.Done)
+
+	return &camWg, nil
 }
 
 // tryWebcamOpen uses getNamedVideoSource to try and find a video device (gostream.MediaSource).

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"go.viam.com/rdk/resource"
-
 	"github.com/edaniels/golog"
 	"github.com/edaniels/gostream"
 	"github.com/pion/mediadevices"
@@ -24,6 +22,7 @@ import (
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/discovery"
 	"go.viam.com/rdk/registry"
+	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/rimage/transform"
 	"go.viam.com/rdk/utils"
 )

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -24,7 +24,6 @@ import (
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/discovery"
 	"go.viam.com/rdk/registry"
-	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/rimage/transform"
 	"go.viam.com/rdk/utils"
 )
@@ -224,7 +223,7 @@ func findCamera(
 		}
 	}
 
-	return camera.WrapWithReconfigurable(cam, camera.Named(model))
+	return camera.WrapWithReconfigurable(cam, camera.Named(model.String()))
 }
 
 // getLabelFromCameraOrPath returns the path from the camera or an empty string if a path is not found.

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/edaniels/gobag v1.0.7-0.20220607183102-4242cd9e2848
 	github.com/edaniels/golinters v0.0.5-0.20220906153528-641155550742
 	github.com/edaniels/golog v0.0.0-20221007145811-7db9cb8e37f8
-	github.com/edaniels/gostream v0.0.0-20221205212507-0f3bbdcc651b
+	github.com/edaniels/gostream v0.0.0-20230110151222-0786fc09b473
 	github.com/edaniels/lidario v0.0.0-20220607182921-5879aa7b96dd
 	github.com/erh/scheme v0.0.0-20210304170849-99d295c6ce9a
 	github.com/fogleman/gg v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -311,8 +311,8 @@ github.com/edaniels/golinters v0.0.5-0.20220906153528-641155550742/go.mod h1:i/z
 github.com/edaniels/golog v0.0.0-20220930140416-6e52e83a97fc/go.mod h1:Ms3gOPiAEPRrgN3kBOF8YIkT2JEXxPFk/HBx/FAkmgA=
 github.com/edaniels/golog v0.0.0-20221007145811-7db9cb8e37f8 h1:EhsPh2iL2t6TTUhl/yRYKXJIkywgzySfcb9hGkNLQPE=
 github.com/edaniels/golog v0.0.0-20221007145811-7db9cb8e37f8/go.mod h1:Ms3gOPiAEPRrgN3kBOF8YIkT2JEXxPFk/HBx/FAkmgA=
-github.com/edaniels/gostream v0.0.0-20221205212507-0f3bbdcc651b h1:ctvv4WxIR6/lYZ5K55jxrcZaiGefDDUfVtEyDI6p3M4=
-github.com/edaniels/gostream v0.0.0-20221205212507-0f3bbdcc651b/go.mod h1:gjWpPsRBEIMkxtETvJgsbh6tjGHWa/KWE66xrHp+wsM=
+github.com/edaniels/gostream v0.0.0-20230110151222-0786fc09b473 h1:rqhhHecKXNQiScJGgVEiHmOITM6NVK5pBd88nuyZzas=
+github.com/edaniels/gostream v0.0.0-20230110151222-0786fc09b473/go.mod h1:gjWpPsRBEIMkxtETvJgsbh6tjGHWa/KWE66xrHp+wsM=
 github.com/edaniels/lidario v0.0.0-20220607182921-5879aa7b96dd h1:W6Zlh2ja8A5vljn17Ix/gZhaUbYMFKAuBjc4t9nma7U=
 github.com/edaniels/lidario v0.0.0-20220607182921-5879aa7b96dd/go.mod h1:CibiLtefSZOd0smxazen6pzvjNK3HrvgGojYOqC3/4Q=
 github.com/edaniels/zeroconf v1.0.2 h1:LldCQMSt/5Ss2tElkdIVdak78S4xt/6827PkV79sXC0=


### PR DESCRIPTION
Draft: These gostream changes (https://github.com/edaniels/gostream/pull/16) need to be pushed first.

This PR ensures we can reconnect to a camera found at startup. ~~It keeps one of two goroutines up: one to listen for a disconnection event or another to listen for reconnection events.~~ It uses one goroutine and `goutils.ManagedGo` to ensure that routine is always up, even after panics.

There are two outstanding issues (tested in linux) that will require changes to mediadevices:
1. Cameras plugged into different usb ports from its usb port at start up will not be found. (See [DATA-879](https://viam.atlassian.net/browse/DATA-879))
2. Cameras added after starting up will not be discovered. (see [DATA-880](https://viam.atlassian.net/browse/DATA-880))

I'll create tickets for both with more details.

Note: A nice side-effect for this fix is that the [Huffman errors](https://viam.atlassian.net/browse/DATA-773) (or other camera bugs) should be fixable by unplugging the camera then plugging it back in. As of now, you have to restart the server.
