### PR TITLE
Rename bus_id -> i2c_bus in MPU6050 accelerometer

### DIFF
--- a/components/movementsensor/mpu6050/mpu6050.go
+++ b/components/movementsensor/mpu6050/mpu6050.go
@@ -28,7 +28,7 @@ const modelName = "gyro-mpu6050"
 // AttrConfig is used to configure the attributes of the chip.
 type AttrConfig struct {
 	BoardName              string `json:"board"`
-	BusID                  string `json:"bus_id"`
+	I2cBus                 string `json:"i2c_bus"`
 	UseAlternateI2CAddress bool   `json:"use_alt_i2c_address,omitempty"`
 }
 
@@ -38,8 +38,8 @@ func (cfg *AttrConfig) Validate(path string) ([]string, error) {
 	if cfg.BoardName == "" {
 		return nil, utils.NewConfigValidationFieldRequiredError(path, "board")
 	}
-	if cfg.BusID == "" {
-		return nil, utils.NewConfigValidationFieldRequiredError(path, "bus_id")
+	if cfg.I2cBus == "" {
+		return nil, utils.NewConfigValidationFieldRequiredError(path, "i2c_bus")
 	}
 
 	var deps []string
@@ -111,9 +111,9 @@ func NewMpu6050(
 	if !ok {
 		return nil, errors.Errorf("board %s is not local", cfg.BoardName)
 	}
-	bus, ok := localB.I2CByName(cfg.BusID)
+	bus, ok := localB.I2CByName(cfg.I2cBus)
 	if !ok {
-		return nil, errors.Errorf("can't find I2C bus '%s' for MPU6050 sensor", cfg.BusID)
+		return nil, errors.Errorf("can't find I2C bus '%s' for MPU6050 sensor", cfg.I2cBus)
 	}
 
 	var address byte
@@ -138,7 +138,7 @@ func NewMpu6050(
 	defaultAddress, err := sensor.readByte(ctx, 117)
 	if err != nil {
 		return nil, errors.Errorf("can't read from I2C address %d on bus %s of board %s: '%s'",
-			address, cfg.BusID, cfg.BoardName, err.Error())
+			address, cfg.I2cBus, cfg.BoardName, err.Error())
 	}
 	if defaultAddress != 0x68 {
 		return nil, errors.Errorf("unexpected non-MPU6050 device at address %d: response '%d'",


### PR DESCRIPTION
This is a breaking change because the MPU code went out earlier this week, but hopefully not many people have started using this yet. The naming standard for these is going to be "i2c_bus", so let's use that. See the scope doc "Communication bus naming convention," which I won't link here because it's an internal document and this PR is public.

Should I create a Jira ticket for this? I'm unsure: it's a breaking change, but it's also a very small change. Steve, what do you think?

Tried locally at my desk: still works great when you update the robot config to match.