### PR TITLE
[RSDK-1015] Ignore garbage bits from MCP3008 ADC chip

### DIFF
--- a/components/board/mcp3008.go
+++ b/components/board/mcp3008.go
@@ -31,7 +31,7 @@ func (mar *MCP3008AnalogReader) Read(ctx context.Context, extra map[string]inter
 	if err != nil {
 		return 0, err
 	}
-	// Reassemble the 10-bit value. Do not include bits beyond the final 10, because they contain
+	// Reassemble the 10-bit value. Do not include bits before the final 10, because they contain
 	// garbage and might be non-zero.
 	val := 0x03FF & ((int(rx[1]) << 8) | int(rx[2]))
 

--- a/components/board/mcp3008.go
+++ b/components/board/mcp3008.go
@@ -31,7 +31,9 @@ func (mar *MCP3008AnalogReader) Read(ctx context.Context, extra map[string]inter
 	if err != nil {
 		return 0, err
 	}
-	val := (int(rx[1]) << 8) | int(rx[2]) // reassemble 10 bit value
+	// Reassemble the 10-bit value. Do not include bits beyond the final 10, because they contain
+	// garbage and might be non-zero.
+	val := 0x03FF & ((int(rx[1]) << 8) | int(rx[2]))
 
 	return val, nil
 }


### PR DESCRIPTION
Tried at my desk with a Jetson Orin. Without this change, sometimes I read the correct value, and sometimes a value 64,000ish too large. With this change, it's always the correct one, somewhere between 0 and 1023 (both of which I can get by trying to read the ground pin or the hot pin). 