### PR TITLE
Make missing rpc client registration fail with more verbose message

### DIFF
--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -538,7 +538,7 @@ func (rc *RobotClient) createClient(name resource.Name) (interface{}, error) {
 		// interacting with it.
 		rc.logger.Errorw("the client registration for resource doesn't exist, you may need to import relevant client package",
 			"resource", name,
-			"import_guess", fmt.Sprintf("go.viam.com/rdk/%s/%s/register", name.ResourceType, name.Subtype)) // hi, I'm brittle
+			"import_guess", fmt.Sprintf("go.viam.com/rdk/%s/%s/register", name.ResourceType, name.Subtype))
 		return nil, ErrMissingClientRegistration
 	}
 	// pass in conn

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -3,6 +3,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"strings"
 	"sync"
@@ -532,6 +533,12 @@ func (rc *RobotClient) createClient(name resource.Name) (interface{}, error) {
 		if name.Namespace != resource.ResourceNamespaceRDK {
 			return grpc.NewForeignResource(name, rc.conn), nil
 		}
+		// At this point we checked that the 'name' is in the rc.resourceNames list
+		// and it is in the RDK namespace, so it's likely we provide a package for
+		// interacting with it.
+		rc.logger.Errorw("the client registration for resource doesn't exist, you may need to import relevant client package",
+			"resource", name,
+			"import_guess", fmt.Sprintf("go.viam.com/rdk/%s/%s/register", name.ResourceType, name.Subtype)) // hi, I'm brittle
 		return nil, ErrMissingClientRegistration
 	}
 	// pass in conn


### PR DESCRIPTION
When circumventing the `FromRobot(r)` helpers, like one may do if they are new to the RDK, the likely result of trying to address any one of `r.ResourceNames` is going to lead to the `ErrMissingClientRegistration`. If said soul is familiar with Go own flavor of DI package registration it's easy to find the x/register packages (and probably the helpers in the process). However a slight nudge never hurt anyone?