### PR TITLE
Service model fix - RegisterServiceAttributeMapConverter models

### DIFF
--- a/config/reader.go
+++ b/config/reader.go
@@ -63,6 +63,7 @@ type ComponentAttributeMapConverterRegistration struct {
 // for a model of a type of service.
 type ServiceAttributeMapConverterRegistration struct {
 	SvcType ServiceType
+	Model   string
 	Conv    AttributeMapConverter
 	RetType interface{} // the shape of what is converted to
 }
@@ -131,11 +132,13 @@ func TransformAttributeMapToStruct(to interface{}, attributes AttributeMap) (int
 }
 
 // RegisterServiceAttributeMapConverter associates a service type with a way to convert all attributes.
-func RegisterServiceAttributeMapConverter(svcType ServiceType, conv AttributeMapConverter, retType interface{}) {
+func RegisterServiceAttributeMapConverter(svcType ServiceType, model string, conv AttributeMapConverter, retType interface{}) {
 	if retType == nil {
 		panic("retType should not be nil")
 	}
-	serviceAttributeMapConverters = append(serviceAttributeMapConverters, ServiceAttributeMapConverterRegistration{svcType, conv, retType})
+	serviceAttributeMapConverters = append(
+		serviceAttributeMapConverters,
+		ServiceAttributeMapConverterRegistration{svcType, model, conv, retType})
 }
 
 // RegisteredComponentAttributeConverters returns a copy of the registered component attribute converters.

--- a/config/reader_ext_test.go
+++ b/config/reader_ext_test.go
@@ -81,9 +81,11 @@ func TestFromReaderValidate(t *testing.T) {
 	test.That(t, badComponentMapConverter, test.ShouldPanic)
 
 	badServiceMapConverter := func() {
-		config.RegisterServiceAttributeMapConverter(config.ServiceType("someservice"), func(attributes config.AttributeMap) (interface{}, error) {
-			return &conf, nil
-		}, nil)
+		config.RegisterServiceAttributeMapConverter(config.ServiceType("someservice"),
+			"somemodel",
+			func(attributes config.AttributeMap) (interface{}, error) {
+				return &conf, nil
+			}, nil)
 	}
 	test.That(t, badServiceMapConverter, test.ShouldPanic)
 }

--- a/protoutils/messages.go
+++ b/protoutils/messages.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/golang/geo/r3"
+	//nolint:staticcheck
 	protov1 "github.com/golang/protobuf/proto"
 	commonpb "go.viam.com/api/common/v1"
 	"google.golang.org/protobuf/proto"

--- a/protoutils/messages.go
+++ b/protoutils/messages.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	"github.com/golang/geo/r3"
-	//nolint:staticcheck
 	protov1 "github.com/golang/protobuf/proto"
 	commonpb "go.viam.com/api/common/v1"
 	"google.golang.org/protobuf/proto"

--- a/services/armremotecontrol/builtin/builtin.go
+++ b/services/armremotecontrol/builtin/builtin.go
@@ -46,7 +46,7 @@ func init() {
 		},
 	})
 	cType := config.ServiceType(armremotecontrol.SubtypeName)
-	config.RegisterServiceAttributeMapConverter(cType, func(attributes config.AttributeMap) (interface{}, error) {
+	config.RegisterServiceAttributeMapConverter(cType, resource.DefaultModelName, func(attributes config.AttributeMap) (interface{}, error) {
 		var conf ServiceConfig
 		decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{TagName: "json", Result: &conf})
 		if err != nil {

--- a/services/baseremotecontrol/builtin/builtin.go
+++ b/services/baseremotecontrol/builtin/builtin.go
@@ -43,7 +43,7 @@ func init() {
 		},
 	})
 	cType := config.ServiceType(SubtypeName)
-	config.RegisterServiceAttributeMapConverter(cType, func(attributes config.AttributeMap) (interface{}, error) {
+	config.RegisterServiceAttributeMapConverter(cType, resource.DefaultModelName, func(attributes config.AttributeMap) (interface{}, error) {
 		var conf Config
 		decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{TagName: "json", Result: &conf})
 		if err != nil {

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -37,7 +37,7 @@ func init() {
 		},
 	})
 	cType := config.ServiceType(datamanager.SubtypeName)
-	config.RegisterServiceAttributeMapConverter(cType, func(attributes config.AttributeMap) (interface{}, error) {
+	config.RegisterServiceAttributeMapConverter(cType, resource.DefaultModelName, func(attributes config.AttributeMap) (interface{}, error) {
 		var conf Config
 		decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{TagName: "json", Result: &conf})
 		if err != nil {

--- a/services/navigation/builtin/builtin.go
+++ b/services/navigation/builtin/builtin.go
@@ -37,7 +37,7 @@ func init() {
 	},
 	)
 	cType := config.ServiceType(navigation.SubtypeName)
-	config.RegisterServiceAttributeMapConverter(cType, func(attributes config.AttributeMap) (interface{}, error) {
+	config.RegisterServiceAttributeMapConverter(cType, resource.DefaultModelName, func(attributes config.AttributeMap) (interface{}, error) {
 		var conf Config
 		decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{TagName: "json", Result: &conf})
 		if err != nil {

--- a/services/slam/builtin/builtin.go
+++ b/services/slam/builtin/builtin.go
@@ -80,7 +80,7 @@ func init() {
 		},
 	})
 	cType := config.ServiceType(slam.SubtypeName)
-	config.RegisterServiceAttributeMapConverter(cType, func(attributes config.AttributeMap) (interface{}, error) {
+	config.RegisterServiceAttributeMapConverter(cType, resource.DefaultModelName, func(attributes config.AttributeMap) (interface{}, error) {
 		var conf AttrConfig
 		decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{TagName: "json", Result: &conf})
 		if err != nil {

--- a/services/vision/builtin/builtin.go
+++ b/services/vision/builtin/builtin.go
@@ -32,7 +32,7 @@ func init() {
 		},
 	})
 	cType := config.ServiceType(vision.SubtypeName)
-	config.RegisterServiceAttributeMapConverter(cType, func(attributeMap config.AttributeMap) (interface{}, error) {
+	config.RegisterServiceAttributeMapConverter(cType, resource.DefaultModelName, func(attributeMap config.AttributeMap) (interface{}, error) {
 		var attrs vision.Attributes
 		return config.TransformAttributeMapToStruct(&attrs, attributeMap)
 	},


### PR DESCRIPTION
A bug was found where models were not parameters for the RegisterServiceAttributeMapConverter.