### PR TITLE
RSDK-730 : RDK fails to shutdown when connected to serial components

### DIFF
--- a/components/movementsensor/imuwit/imu.go
+++ b/components/movementsensor/imuwit/imu.go
@@ -16,6 +16,7 @@ import (
 	"github.com/golang/geo/r3"
 	slib "github.com/jacobsa/go-serial/serial"
 	geo "github.com/kellydunn/golang-geo"
+	"github.com/pkg/errors"
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/generic"
@@ -37,8 +38,8 @@ type AttrConfig struct {
 }
 
 // Validate ensures all parts of the config are valid.
-func (cfg *AttrConfig) Validate(path string) error {
-	var isValid = false
+func (cfg *AttrConfig) Validate(path string, logger golog.Logger) error {
+	isValid := false
 
 	// Validating serial path
 	if cfg.Port == "" {
@@ -52,15 +53,7 @@ func (cfg *AttrConfig) Validate(path string) error {
 		}
 	}
 	if !isValid {
-
-		fmt.Print("\n")
-		fmt.Print("Please enter values from: ")
-		for i := 0; i < len(baudRateList); i++ {
-			fmt.Print(baudRateList[i], " ")
-		}
-		fmt.Print("\n")
-		return rutils.InvalidIntegerValue(cfg.BaudRate)
-
+		return errors.Errorf("Baud rate is not in %v", baudRateList)
 	}
 
 	return nil
@@ -308,7 +301,7 @@ func (imu *wit) parseWIT(line string) error {
 	return nil
 }
 
-// Close shuts down wit and closes imu.port
+// Close shuts down wit and closes imu.port.
 func (imu *wit) Close() error {
 	imu.logger.Debug("Closing wit motion imu")
 	imu.cancelFunc()
@@ -319,7 +312,6 @@ func (imu *wit) Close() error {
 			return err
 		}
 		imu.port = nil
-
 	}
 
 	imu.logger.Debug("Closed wit motion imu")

--- a/components/movementsensor/imuwit/imu.go
+++ b/components/movementsensor/imuwit/imu.go
@@ -38,7 +38,7 @@ type AttrConfig struct {
 }
 
 // Validate ensures all parts of the config are valid.
-func (cfg *AttrConfig) Validate(path string, logger golog.Logger) error {
+func (cfg *AttrConfig) Validate(path string) error {
 	isValid := false
 
 	// Validating serial path

--- a/components/movementsensor/imuwit/imu.go
+++ b/components/movementsensor/imuwit/imu.go
@@ -53,7 +53,7 @@ func (cfg *AttrConfig) Validate(path string, logger golog.Logger) error {
 		}
 	}
 	if !isValid {
-		return errors.Errorf("Baud rate is not in %v", baudRateList)
+		return utils.NewConfigValidationError(path, errors.Errorf("Baud rate is not in %v", baudRateList))
 	}
 
 	return nil
@@ -199,6 +199,7 @@ func NewWit(
 	if err != nil {
 		return nil, err
 	}
+	i.port = port
 
 	portReader := bufio.NewReader(port)
 

--- a/utils/errors.go
+++ b/utils/errors.go
@@ -59,8 +59,3 @@ func typeStr(of interface{}) string {
 func NewUnimplementedInterfaceError(expected, actual interface{}) error {
 	return errors.Errorf("expected implementation of %s but got %T", typeStr(expected), actual)
 }
-
-// InvalidIntegerValue is used when an integer value is out of bound or not valid.
-func InvalidIntegerValue(val int) error {
-	return errors.Errorf("can not validate integer value %d in config", val)
-}

--- a/utils/errors.go
+++ b/utils/errors.go
@@ -59,3 +59,8 @@ func typeStr(of interface{}) string {
 func NewUnimplementedInterfaceError(expected, actual interface{}) error {
 	return errors.Errorf("expected implementation of %s but got %T", typeStr(expected), actual)
 }
+
+// InvalidIntegerValue is used when an integer value is out of bound or not valid.
+func InvalidIntegerValue(val int) error {
+	return errors.Errorf("can not validate integer value %d in config", val)
+}


### PR DESCRIPTION
Two issues that were causing this error: 
1. Wrong/invalid baud rate
2. Not closing the port in close function. 
Baud rate validation is done by comparing the given baud rate from config file with the applicable baud rates found in Wit devices. 
Added port closing in close function. Close will error if we loose connection to the serial port. 