### PR TITLE
Update default capture directory

### DIFF
--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -113,7 +113,7 @@ type builtIn struct {
 	modelManagerConstructor model.ManagerConstructor
 }
 
-var viamCaptureDotDir = filepath.Join(os.Getenv("HOME"), "capture", ".viam")
+var viamCaptureDotDir = filepath.Join(os.Getenv("HOME"), ".viam", "capture")
 
 // NewBuiltIn returns a new data manager service for the given robot.
 func NewBuiltIn(_ context.Context, r robot.Robot, _ config.Service, logger golog.Logger) (datamanager.Service, error) {
@@ -532,6 +532,9 @@ func (svc *builtIn) Update(ctx context.Context, cfg *config.Config) error {
 	// If sync has been toggled on, sync previously captured files and update the capture directory.
 	updateCaptureDir := (svc.captureDir != svcConfig.CaptureDir) || toggledSyncOn
 	svc.captureDir = svcConfig.CaptureDir
+	if svc.captureDir == "" {
+		svc.captureDir = viamCaptureDotDir
+	}
 
 	// Stop syncing if newly disabled in the config.
 	if toggledSyncOff {

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -530,11 +530,12 @@ func (svc *builtIn) Update(ctx context.Context, cfg *config.Config) error {
 	toggledSyncOn := toggledSync && !svc.syncDisabled
 
 	// If sync has been toggled on, sync previously captured files and update the capture directory.
-	updateCaptureDir := (svc.captureDir != svcConfig.CaptureDir) || toggledSyncOn
-	svc.captureDir = svcConfig.CaptureDir
-	if svc.captureDir == "" {
-		svc.captureDir = viamCaptureDotDir
+	captureDir := svcConfig.CaptureDir
+	if captureDir == "" {
+		captureDir = viamCaptureDotDir
 	}
+	updateCaptureDir := (svc.captureDir != captureDir) || toggledSyncOn
+	svc.captureDir = captureDir
 
 	// Stop syncing if newly disabled in the config.
 	if toggledSyncOff {


### PR DESCRIPTION
Use the standard across RDK of prepending with `.viam` in order to have all Viam-generated files in one place.
Default to this if the user-configured directory is empty.

