### PR TITLE
[Rsdk-374] add stop to remaining arm implementations

### DIFF
--- a/components/arm/eva/eva.go
+++ b/components/arm/eva/eva.go
@@ -6,7 +6,6 @@ package eva
 import (
 	"bytes"
 	"context"
-
 	// for embedding model file.
 	_ "embed"
 	"encoding/json"

--- a/components/arm/eva/eva.go
+++ b/components/arm/eva/eva.go
@@ -1,9 +1,12 @@
 // Package eva implements the Eva robot from Automata.
+// api found at
+// https://github.com/automata-tech/eva_python_sdk/blob/development/evasdk/eva_http_client.py
 package eva
 
 import (
 	"bytes"
 	"context"
+
 	// for embedding model file.
 	_ "embed"
 	"encoding/json"
@@ -99,6 +102,34 @@ type eva struct {
 	frameJSON []byte
 
 	opMgr operation.SingleOperationManager
+}
+
+// NewEva TODO.
+func NewEva(ctx context.Context, r robot.Robot, cfg config.Component, logger golog.Logger) (arm.LocalArm, error) {
+	model, err := Model(cfg.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	e := &eva{
+		host:      cfg.ConvertedAttributes.(*AttrConfig).Host,
+		version:   "v1",
+		token:     cfg.ConvertedAttributes.(*AttrConfig).Token,
+		logger:    logger,
+		moveLock:  &sync.Mutex{},
+		model:     model,
+		robot:     r,
+		frameJSON: evamodeljson,
+	}
+
+	name, err := e.apiName(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	e.logger.Debugf("connected to eva: %v", name)
+
+	return e, nil
 }
 
 func (e *eva) JointPositions(ctx context.Context, extra map[string]interface{}) (*pb.JointPositions, error) {
@@ -281,8 +312,13 @@ func (e *eva) resetErrors(ctx context.Context) error {
 }
 
 func (e *eva) Stop(ctx context.Context, extra map[string]interface{}) error {
-	// RSDK-374: Implement Stop
-	return arm.ErrStopUnimplemented
+	if e.opMgr.OpRunning() {
+		return multierr.Combine(
+			e.apiRequest(ctx, "POST", "controls/pause", nil, true, nil),  // pause robot
+			e.apiRequest(ctx, "POST", "controls/cancel", nil, true, nil), // make state ready to run again
+		)
+	}
+	return nil
 }
 
 func (e *eva) IsMoving(ctx context.Context) (bool, error) {
@@ -360,32 +396,4 @@ func (e *eva) GoToInputs(ctx context.Context, goal []referenceframe.Input) error
 // Model returns the kinematics model of the eva arm, also has all Frame information.
 func Model(name string) (referenceframe.Model, error) {
 	return referenceframe.UnmarshalModelJSON(evamodeljson, name)
-}
-
-// NewEva TODO.
-func NewEva(ctx context.Context, r robot.Robot, cfg config.Component, logger golog.Logger) (arm.LocalArm, error) {
-	model, err := Model(cfg.Name)
-	if err != nil {
-		return nil, err
-	}
-
-	e := &eva{
-		host:      cfg.ConvertedAttributes.(*AttrConfig).Host,
-		version:   "v1",
-		token:     cfg.ConvertedAttributes.(*AttrConfig).Token,
-		logger:    logger,
-		moveLock:  &sync.Mutex{},
-		model:     model,
-		robot:     r,
-		frameJSON: evamodeljson,
-	}
-
-	name, err := e.apiName(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	e.logger.Debugf("connected to eva: %v", name)
-
-	return e, nil
 }

--- a/components/arm/trossen/trossen.go
+++ b/components/arm/trossen/trossen.go
@@ -13,6 +13,7 @@ import (
 	"github.com/edaniels/golog"
 	"github.com/jacobsa/go-serial/serial"
 	"github.com/pkg/errors"
+	"go.uber.org/multierr"
 	pb "go.viam.com/api/component/arm/v1"
 	"go.viam.com/dynamixel/network"
 	"go.viam.com/dynamixel/servo"
@@ -248,7 +249,10 @@ func (a *Arm) JointPositions(ctx context.Context, extra map[string]interface{}) 
 // Stop is unimplemented for trossen.
 func (a *Arm) Stop(ctx context.Context, extra map[string]interface{}) error {
 	// RSDK-374: Implement Stop
-	return arm.ErrStopUnimplemented
+	return multierr.Combine(
+		a.TorqueOff(),
+		a.TorqueOn(),
+	)
 }
 
 // IsMoving returns whether the arm is moving.

--- a/components/arm/yahboom/dofbot.go
+++ b/components/arm/yahboom/dofbot.go
@@ -1,4 +1,5 @@
 // Package yahboom implements a yahboom based robot.
+// code with commands found at http://www.yahboom.net/study/Dofbot-Pi
 package yahboom
 
 import (
@@ -18,7 +19,6 @@ import (
 	"go.viam.com/rdk/components/arm"
 	"go.viam.com/rdk/components/board"
 	"go.viam.com/rdk/components/generic"
-	"go.viam.com/rdk/components/gripper"
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/motionplan"
 	"go.viam.com/rdk/operation"
@@ -108,13 +108,14 @@ func init() {
 // Dofbot implements a yahboom dofbot arm.
 type Dofbot struct {
 	generic.Unimplemented
-	handle board.I2CHandle
-	model  referenceframe.Model
-	robot  robot.Robot
-	mu     sync.Mutex
-	muMove sync.Mutex
-	logger golog.Logger
-	opMgr  operation.SingleOperationManager
+	handle  board.I2CHandle
+	model   referenceframe.Model
+	robot   robot.Robot
+	mu      sync.Mutex
+	muMove  sync.Mutex
+	logger  golog.Logger
+	opMgr   operation.SingleOperationManager
+	stopped bool
 }
 
 // NewDofBot is a constructor to create a new dofbot arm.
@@ -190,6 +191,10 @@ func (a *Dofbot) MoveToJointPositions(ctx context.Context, pos *componentpb.Join
 
 	a.muMove.Lock()
 	defer a.muMove.Unlock()
+	if a.stopped {
+		err := a.turnOnTorque(ctx)
+		a.logger.Warnf("error turning on torque %s: ", err)
+	}
 	if len(pos.Values) > 5 {
 		return fmt.Errorf("yahboom wrong number of degrees got %d, need at most 5", len(pos.Values))
 	}
@@ -302,14 +307,34 @@ func (a *Dofbot) readJointInLock(ctx context.Context, joint int) (float64, error
 
 // Stop is unimplemented for the dofbot.
 func (a *Dofbot) Stop(ctx context.Context, extra map[string]interface{}) error {
-	// RSDK-374: Implement Stop for arm
-	return arm.ErrStopUnimplemented
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.stopped = true
+	return a.turnOffTorque(ctx)
+}
+
+func (a *Dofbot) turnOffTorque(ctx context.Context) error {
+	buf := make([]byte, 2)
+
+	buf[0] = byte(0x1A)
+	buf[1] = byte(0x00)
+	return a.handle.Write(ctx, buf)
+}
+
+func (a *Dofbot) turnOnTorque(ctx context.Context) error {
+	buf := make([]byte, 2)
+
+	buf[0] = byte(0x1A)
+	buf[1] = byte(0x01)
+
+	return a.handle.Write(ctx, buf)
 }
 
 // GripperStop is unimplemented for the dofbot.
 func (a *Dofbot) GripperStop(ctx context.Context) error {
-	// RSDK-388: Implement Stop for gripper
-	return gripper.ErrStopUnimplemented
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.Stop(ctx, nil)
 }
 
 // IsMoving returns whether the arm is moving.

--- a/components/gripper/robotiq/gripper.go
+++ b/components/gripper/robotiq/gripper.go
@@ -1,4 +1,6 @@
 // Package robotiq implements the gripper from robotiq.
+// commands found at
+// https://assets.robotiq.com/website-assets/support_documents/document/2F-85_2F-140_Instruction_Manual_CB-Series_PDF_20190329.pdf
 package robotiq
 
 import (
@@ -271,7 +273,11 @@ func (g *robotiqGripper) Calibrate(ctx context.Context) error {
 // Stop is unimplemented for robotiqGripper.
 func (g *robotiqGripper) Stop(ctx context.Context, extra map[string]interface{}) error {
 	// RSDK-388: Implement Stop
-	return gripper.ErrStopUnimplemented
+	err := g.Set("GTO", "0")
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // IsMoving returns whether the gripper is moving.

--- a/components/gripper/trossen/trossen.go
+++ b/components/gripper/trossen/trossen.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/edaniels/golog"
 	"github.com/jacobsa/go-serial/serial"
+	"go.uber.org/multierr"
 	"go.viam.com/dynamixel/network"
 	"go.viam.com/dynamixel/servo"
 	"go.viam.com/dynamixel/servo/s_model"
@@ -186,8 +187,10 @@ func (g *Gripper) Grab(ctx context.Context, extra map[string]interface{}) (bool,
 
 // Stop is unimplemented for Gripper.
 func (g *Gripper) Stop(ctx context.Context, extra map[string]interface{}) error {
-	// RSDK-388: Implement Stop
-	return gripper.ErrStopUnimplemented
+	return multierr.Combine(
+		g.jServo.SetTorqueEnable(false),
+		g.jServo.SetTorqueEnable(true),
+	)
 }
 
 // IsMoving returns whether the gripper is moving.

--- a/components/gripper/yahboom/dofbot.go
+++ b/components/gripper/yahboom/dofbot.go
@@ -1,4 +1,5 @@
 // Package yahboom implements a yahboom based gripper.
+// code with commands found at http://www.yahboom.net/study/Dofbot-Pi
 package yahboom
 
 import (
@@ -79,8 +80,7 @@ func newGripper(deps registry.Dependencies, config config.Component) (gripper.Lo
 type dofGripper struct {
 	generic.Unimplemented
 	dofArm *yahboom.Dofbot
-
-	opMgr operation.SingleOperationManager
+	opMgr  operation.SingleOperationManager
 }
 
 func (g *dofGripper) Open(ctx context.Context, extra map[string]interface{}) error {


### PR DESCRIPTION
Adds a stop to the eva arm based on api requests, turns off  dynamixel torques briefly then holds them in place, turns off yahboom servos then holds them in place, and robotiq gripper based on api request.

Also addresses RSDK-388 Add Stop() to remaining Gripper implementations