### PR TITLE
RSDK-833: add motor names to motor errors

### DIFF
--- a/components/motor/dimensionengineering/sabertooth.go
+++ b/components/motor/dimensionengineering/sabertooth.go
@@ -418,7 +418,7 @@ func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[s
 // at a specific speed. Regardless of the directionality of the RPM this function will move the motor
 // towards the specified target/position.
 func (m *Motor) GoTo(ctx context.Context, rpm, position float64, extra map[string]interface{}) error {
-	return errors.New("not supported")
+	return motor.NewGoToUnsupportedError(fmt.Sprintf("Channel %d on Sabertooth %d", m.Channel, m.c.address))
 }
 
 // GoTillStop moves a motor until stopped by the controller (due to switch or function) or stopFunc.
@@ -428,7 +428,8 @@ func (m *Motor) GoTillStop(ctx context.Context, rpm float64, stopFunc func(ctx c
 
 // ResetZeroPosition defines the current position to be zero (+/- offset).
 func (m *Motor) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]interface{}) error {
-	return errors.New("not supported")
+	return motor.NewResetZeroPositionUnsupportedError(fmt.Sprintf("Channel %d on Sabertooth %d",
+		m.Channel, m.c.address))
 }
 
 // Position reports the position in revolutions.

--- a/components/motor/dimensionengineering/sabertooth.go
+++ b/components/motor/dimensionengineering/sabertooth.go
@@ -130,7 +130,7 @@ func init() {
 			if !ok {
 				return nil, rdkutils.NewUnexpectedTypeError(conf, config.ConvertedAttributes)
 			}
-			return NewMotor(ctx, conf, config, logger)
+			return NewMotor(ctx, conf, config.Name, logger)
 		},
 	}
 	registry.RegisterComponent(motor.Subtype, modelName, _motor)
@@ -219,7 +219,7 @@ func (cfg *Config) validateValues() error {
 }
 
 // NewMotor returns a Sabertooth driven motor.
-func NewMotor(ctx context.Context, c *Config, mc config.Component, logger golog.Logger) (motor.LocalMotor, error) {
+func NewMotor(ctx context.Context, c *Config, name string, logger golog.Logger) (motor.LocalMotor, error) {
 	globalMu.Lock()
 	defer globalMu.Unlock()
 
@@ -260,7 +260,7 @@ func NewMotor(ctx context.Context, c *Config, mc config.Component, logger golog.
 		dirFlip:     c.DirectionFlip,
 		minPowerPct: c.MinPowerPct,
 		maxPowerPct: c.MaxPowerPct,
-		motorName:   mc.Name,
+		motorName:   name,
 	}
 
 	if err := m.configure(c); err != nil {

--- a/components/motor/dmc4000/dmc.go
+++ b/components/motor/dmc4000/dmc.go
@@ -4,7 +4,6 @@ package dmc4000
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -16,6 +15,7 @@ import (
 	"github.com/edaniels/golog"
 	"github.com/jacobsa/go-serial/serial"
 	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
 	"go.viam.com/utils"
 	"go.viam.com/utils/usb"
 
@@ -62,6 +62,7 @@ type Motor struct {
 	jogging          bool
 	opMgr            operation.SingleOperationManager
 	powerPct         float64
+	motorName        string
 }
 
 // Config adds DMC-specific config options.
@@ -90,7 +91,7 @@ func init() {
 
 	_motor := registry.Component{
 		Constructor: func(ctx context.Context, _ registry.Dependencies, config config.Component, logger golog.Logger) (interface{}, error) {
-			return NewMotor(ctx, config.ConvertedAttributes.(*Config), logger)
+			return NewMotor(ctx, config.ConvertedAttributes.(*Config), config, logger)
 		},
 	}
 	registry.RegisterComponent(motor.Subtype, modelName, _motor)
@@ -114,7 +115,7 @@ func init() {
 }
 
 // NewMotor returns a DMC4000 driven motor.
-func NewMotor(ctx context.Context, c *Config, logger golog.Logger) (motor.LocalMotor, error) {
+func NewMotor(ctx context.Context, c *Config, mc config.Component, logger golog.Logger) (motor.LocalMotor, error) {
 	if c.SerialDevice == "" {
 		devs := usb.Search(usbFilter, func(vendorID, productID int) bool {
 			if vendorID == 0x403 && productID == 0x6001 {
@@ -167,6 +168,7 @@ func NewMotor(ctx context.Context, c *Config, logger golog.Logger) (motor.LocalM
 		MaxAcceleration:  c.MaxAcceleration,
 		HomeRPM:          c.HomeRPM,
 		powerPct:         0.0,
+		motorName:        mc.Name,
 	}
 
 	if m.MaxRPM <= 0 {
@@ -542,7 +544,7 @@ func (m *Motor) GoTo(ctx context.Context, rpm, position float64, extra map[strin
 	defer m.c.mu.Unlock()
 
 	if err := m.doGoTo(rpm, position); err != nil {
-		return err
+		return motor.NewGoToUnsupportedError(m.motorName)
 	}
 
 	return m.opMgr.WaitForSuccess(
@@ -601,6 +603,9 @@ func (m *Motor) ResetZeroPosition(ctx context.Context, offset float64, extra map
 	m.c.mu.Lock()
 	defer m.c.mu.Unlock()
 	_, err := m.c.sendCmd(fmt.Sprintf("DP%s=%d", m.Axis, int(offset*float64(m.TicksPerRotation))))
+	if err != nil {
+		return errors.Wrapf(err, "error in ResetZeroPosition from motor (%s)", m.motorName)
+	}
 	return err
 }
 
@@ -622,7 +627,7 @@ func (m *Motor) Stop(ctx context.Context, extra map[string]interface{}) error {
 	m.jogging = false
 	_, err := m.c.sendCmd(fmt.Sprintf("ST%s", m.Axis))
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "error in Stop function from motor (%s)", m.motorName)
 	}
 
 	return m.opMgr.WaitForSuccess(
@@ -646,6 +651,9 @@ func (m *Motor) IsMoving(ctx context.Context) (bool, error) {
 // IsPowered returns whether or not the motor is currently moving.
 func (m *Motor) IsPowered(ctx context.Context, extra map[string]interface{}) (bool, float64, error) {
 	on, err := m.IsMoving(ctx)
+	if err != nil {
+		return on, m.powerPct, errors.Wrapf(err, "error in IsPowered from motor (%s)", m.motorName)
+	}
 	return on, m.powerPct, err
 }
 

--- a/components/motor/dmc4000/dmc.go
+++ b/components/motor/dmc4000/dmc.go
@@ -91,7 +91,7 @@ func init() {
 
 	_motor := registry.Component{
 		Constructor: func(ctx context.Context, _ registry.Dependencies, config config.Component, logger golog.Logger) (interface{}, error) {
-			return NewMotor(ctx, config.ConvertedAttributes.(*Config), config, logger)
+			return NewMotor(ctx, config.ConvertedAttributes.(*Config), config.Name, logger)
 		},
 	}
 	registry.RegisterComponent(motor.Subtype, modelName, _motor)
@@ -115,7 +115,7 @@ func init() {
 }
 
 // NewMotor returns a DMC4000 driven motor.
-func NewMotor(ctx context.Context, c *Config, mc config.Component, logger golog.Logger) (motor.LocalMotor, error) {
+func NewMotor(ctx context.Context, c *Config, name string, logger golog.Logger) (motor.LocalMotor, error) {
 	if c.SerialDevice == "" {
 		devs := usb.Search(usbFilter, func(vendorID, productID int) bool {
 			if vendorID == 0x403 && productID == 0x6001 {
@@ -168,7 +168,7 @@ func NewMotor(ctx context.Context, c *Config, mc config.Component, logger golog.
 		MaxAcceleration:  c.MaxAcceleration,
 		HomeRPM:          c.HomeRPM,
 		powerPct:         0.0,
-		motorName:        mc.Name,
+		motorName:        name,
 	}
 
 	if m.MaxRPM <= 0 {

--- a/components/motor/errors.go
+++ b/components/motor/errors.go
@@ -25,3 +25,8 @@ func NewFeatureUnsupportedError(feature Feature, motorName string) error {
 func NewZeroRPMError() error {
 	return errors.New("Cannot move motor at 0 RPM")
 }
+
+// NewGoToUnsupportedError returns error when a motor is required to support GoTo feature
+func NewGoToUnsupportedError(motorName string) error {
+	return errors.Errorf("motor with name %s does not support GoTo", motorName)
+}

--- a/components/motor/errors.go
+++ b/components/motor/errors.go
@@ -26,7 +26,7 @@ func NewZeroRPMError() error {
 	return errors.New("Cannot move motor at 0 RPM")
 }
 
-// NewGoToUnsupportedError returns error when a motor is required to support GoTo feature
+// NewGoToUnsupportedError returns error when a motor is required to support GoTo feature.
 func NewGoToUnsupportedError(motorName string) error {
 	return errors.Errorf("motor with name %s does not support GoTo", motorName)
 }

--- a/components/motor/fake/motor.go
+++ b/components/motor/fake/motor.go
@@ -321,7 +321,7 @@ func (m *Motor) GoTo(ctx context.Context, rpm, pos float64, extra map[string]int
 
 // GoTillStop always returns an error.
 func (m *Motor) GoTillStop(ctx context.Context, rpm float64, stopFunc func(ctx context.Context) bool) error {
-	return errors.New("not supported")
+	return motor.NewGoTillStopUnsupportedError(m.Name)
 }
 
 // ResetZeroPosition resets the zero position.
@@ -336,7 +336,7 @@ func (m *Motor) ResetZeroPosition(ctx context.Context, offset float64, extra map
 
 	err := m.Encoder.Reset(ctx, int64(offset*float64(m.TicksPerRotation)), extra)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "error in ResetZeroPosition from motor (%s)", m.Name)
 	}
 
 	return nil
@@ -352,7 +352,7 @@ func (m *Motor) Stop(ctx context.Context, extra map[string]interface{}) error {
 	if m.Encoder != nil {
 		err := m.Encoder.SetSpeed(ctx, 0.0)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "error in Stop from motor (%s)", m.Name)
 		}
 	}
 	return nil

--- a/components/motor/gpio/basic.go
+++ b/components/motor/gpio/basic.go
@@ -12,13 +12,12 @@ import (
 	"go.viam.com/rdk/components/board"
 	"go.viam.com/rdk/components/generic"
 	"go.viam.com/rdk/components/motor"
-	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/operation"
 )
 
 // NewMotor constructs a new GPIO based motor on the given board using the
 // given configuration.
-func NewMotor(b board.Board, mc Config, c config.Component, logger golog.Logger) (motor.Motor, error) {
+func NewMotor(b board.Board, mc Config, name string, logger golog.Logger) (motor.Motor, error) {
 	if mc.MaxPowerPct == 0 {
 		mc.MaxPowerPct = 1.0
 	}
@@ -41,7 +40,7 @@ func NewMotor(b board.Board, mc Config, c config.Component, logger golog.Logger)
 		maxRPM:      mc.MaxRPM,
 		dirFlip:     mc.DirectionFlip,
 		logger:      logger,
-		motorName:   c.Name,
+		motorName:   name,
 	}
 
 	if mc.Pins.A != "" {

--- a/components/motor/gpio/basic.go
+++ b/components/motor/gpio/basic.go
@@ -12,12 +12,13 @@ import (
 	"go.viam.com/rdk/components/board"
 	"go.viam.com/rdk/components/generic"
 	"go.viam.com/rdk/components/motor"
+	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/operation"
 )
 
 // NewMotor constructs a new GPIO based motor on the given board using the
 // given configuration.
-func NewMotor(b board.Board, mc Config, logger golog.Logger) (motor.Motor, error) {
+func NewMotor(b board.Board, mc Config, c config.Component, logger golog.Logger) (motor.Motor, error) {
 	if mc.MaxPowerPct == 0 {
 		mc.MaxPowerPct = 1.0
 	}
@@ -40,6 +41,7 @@ func NewMotor(b board.Board, mc Config, logger golog.Logger) (motor.Motor, error
 		maxRPM:      mc.MaxRPM,
 		dirFlip:     mc.DirectionFlip,
 		logger:      logger,
+		motorName:   c.Name,
 	}
 
 	if mc.Pins.A != "" {
@@ -103,6 +105,7 @@ type Motor struct {
 	powerPct                 float64
 	maxRPM                   float64
 	dirFlip                  bool
+	motorName                string
 
 	opMgr  operation.SingleOperationManager
 	logger golog.Logger
@@ -305,5 +308,5 @@ func (m *Motor) ResetZeroPosition(ctx context.Context, offset float64, extra map
 
 // GoTillStop is not supported.
 func (m *Motor) GoTillStop(ctx context.Context, rpm float64, stopFunc func(ctx context.Context) bool) error {
-	return motor.NewGoTillStopUnsupportedError("(name unavailable)")
+	return motor.NewGoTillStopUnsupportedError(m.motorName)
 }

--- a/components/motor/gpio/basic.go
+++ b/components/motor/gpio/basic.go
@@ -266,7 +266,7 @@ func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[s
 	powerPct, waitDur := goForMath(m.maxRPM, rpm, revolutions)
 	err := m.SetPower(ctx, powerPct, extra)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "error in GoFor from motor (%s)", m.motorName)
 	}
 
 	if revolutions == 0 {

--- a/components/motor/gpio/basic.go
+++ b/components/motor/gpio/basic.go
@@ -298,12 +298,12 @@ func (m *Motor) IsMoving(ctx context.Context) (bool, error) {
 
 // GoTo is not supported.
 func (m *Motor) GoTo(ctx context.Context, rpm, positionRevolutions float64, extra map[string]interface{}) error {
-	return errors.New("not supported")
+	return motor.NewGoToUnsupportedError(m.motorName)
 }
 
 // ResetZeroPosition is not supported.
 func (m *Motor) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]interface{}) error {
-	return errors.New("not supported")
+	return motor.NewResetZeroPositionUnsupportedError(m.motorName)
 }
 
 // GoTillStop is not supported.

--- a/components/motor/gpio/basic_test.go
+++ b/components/motor/gpio/basic_test.go
@@ -23,7 +23,9 @@ func TestMotorABPWM(t *testing.T) {
 	b := &fakeboard.Board{GPIOPins: map[string]*fakeboard.GPIOPin{}}
 	logger := golog.NewTestLogger(t)
 
-	mc := config.Component{}
+	mc := config.Component{
+		Name: "abc",
+	}
 
 	t.Run("motor (A/B/PWM) initialization errors", func(t *testing.T) {
 		m, err := NewMotor(b, Config{
@@ -136,7 +138,9 @@ func TestMotorDirPWM(t *testing.T) {
 	b := &fakeboard.Board{GPIOPins: map[string]*fakeboard.GPIOPin{}}
 	logger := golog.NewTestLogger(t)
 
-	mc := config.Component{}
+	mc := config.Component{
+		Name: "fake_motor",
+	}
 
 	t.Run("motor (DIR/PWM) initialization errors", func(t *testing.T) {
 		m, err := NewMotor(b, Config{Pins: PinConfig{Direction: "1", EnablePinLow: "2", PWM: "3"}, PWMFreq: 4000},
@@ -217,7 +221,9 @@ func TestMotorAB(t *testing.T) {
 	ctx := context.Background()
 	b := &fakeboard.Board{GPIOPins: map[string]*fakeboard.GPIOPin{}}
 	logger := golog.NewTestLogger(t)
-	mc := config.Component{}
+	mc := config.Component{
+		Name: "fake_motor",
+	}
 
 	m, err := NewMotor(b, Config{
 		Pins:   PinConfig{A: "1", B: "2", EnablePinLow: "3"},
@@ -288,7 +294,9 @@ func TestMotorABNoEncoder(t *testing.T) {
 	ctx := context.Background()
 	b := &fakeboard.Board{GPIOPins: map[string]*fakeboard.GPIOPin{}}
 	logger := golog.NewTestLogger(t)
-	mc := config.Component{}
+	mc := config.Component{
+		Name: "fake_motor",
+	}
 
 	m, err := NewMotor(b, Config{
 		Pins:    PinConfig{A: "1", B: "2", EnablePinLow: "3"},
@@ -298,6 +306,14 @@ func TestMotorABNoEncoder(t *testing.T) {
 
 	t.Run("motor no encoder GoFor testing", func(t *testing.T) {
 		test.That(t, m.GoFor(ctx, 50, 10, nil), test.ShouldBeError, errors.New("not supported, define max_rpm attribute != 0"))
+	})
+
+	t.Run("motor no encoder GoTo testing", func(t *testing.T) {
+		test.That(t, m.GoTo(ctx, 50, 10, nil), test.ShouldBeError, errors.New("motor with name fake_motor does not support GoTo"))
+	})
+
+	t.Run("motor no encoder ResetZeroPosition testing", func(t *testing.T) {
+		test.That(t, m.ResetZeroPosition(ctx, 5.0001, nil), test.ShouldBeError, errors.New("motor with name fake_motor does not support ResetZeroPosition"))
 	})
 }
 

--- a/components/motor/gpio/basic_test.go
+++ b/components/motor/gpio/basic_test.go
@@ -313,7 +313,8 @@ func TestMotorABNoEncoder(t *testing.T) {
 	})
 
 	t.Run("motor no encoder ResetZeroPosition testing", func(t *testing.T) {
-		test.That(t, m.ResetZeroPosition(ctx, 5.0001, nil), test.ShouldBeError, errors.New("motor with name fake_motor does not support ResetZeroPosition"))
+		test.That(t, m.ResetZeroPosition(ctx, 5.0001, nil), test.ShouldBeError,
+			errors.New("motor with name fake_motor does not support ResetZeroPosition"))
 	})
 }
 

--- a/components/motor/gpio/basic_test.go
+++ b/components/motor/gpio/basic_test.go
@@ -12,6 +12,7 @@ import (
 	"go.viam.com/rdk/components/board"
 	fakeboard "go.viam.com/rdk/components/board/fake"
 	"go.viam.com/rdk/components/motor"
+	"go.viam.com/rdk/config"
 )
 
 const maxRPM = 100
@@ -22,10 +23,12 @@ func TestMotorABPWM(t *testing.T) {
 	b := &fakeboard.Board{GPIOPins: map[string]*fakeboard.GPIOPin{}}
 	logger := golog.NewTestLogger(t)
 
+	mc := config.Component{}
+
 	t.Run("motor (A/B/PWM) initialization errors", func(t *testing.T) {
 		m, err := NewMotor(b, Config{
 			Pins: PinConfig{A: "1", B: "2", PWM: "3"}, MaxPowerPct: 100, PWMFreq: 4000,
-		}, logger)
+		}, mc, logger)
 		test.That(t, m, test.ShouldBeNil)
 		test.That(t, err, test.ShouldBeError, errors.New("max_power_pct must be between 0.06 and 1.0"))
 	})
@@ -33,7 +36,7 @@ func TestMotorABPWM(t *testing.T) {
 	m, err := NewMotor(b, Config{
 		Pins:   PinConfig{A: "1", B: "2", PWM: "3"},
 		MaxRPM: maxRPM, PWMFreq: 4000,
-	}, logger)
+	}, mc, logger)
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Run("motor (A/B/PWM) Off testing", func(t *testing.T) {
@@ -133,8 +136,10 @@ func TestMotorDirPWM(t *testing.T) {
 	b := &fakeboard.Board{GPIOPins: map[string]*fakeboard.GPIOPin{}}
 	logger := golog.NewTestLogger(t)
 
+	mc := config.Component{}
+
 	t.Run("motor (DIR/PWM) initialization errors", func(t *testing.T) {
-		m, err := NewMotor(b, Config{Pins: PinConfig{Direction: "1", EnablePinLow: "2", PWM: "3"}, PWMFreq: 4000}, logger)
+		m, err := NewMotor(b, Config{Pins: PinConfig{Direction: "1", EnablePinLow: "2", PWM: "3"}, PWMFreq: 4000}, mc, logger)
 
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, m.GoFor(ctx, 50, 10, nil), test.ShouldBeError, errors.New("not supported, define max_rpm attribute != 0"))
@@ -142,7 +147,7 @@ func TestMotorDirPWM(t *testing.T) {
 		_, err = NewMotor(
 			b,
 			Config{Pins: PinConfig{Direction: "1", EnablePinLow: "2", PWM: "3"}, MaxPowerPct: 100, PWMFreq: 4000},
-			logger,
+			mc, logger,
 		)
 		test.That(t, err, test.ShouldBeError, errors.New("max_power_pct must be between 0.06 and 1.0"))
 	})
@@ -150,7 +155,7 @@ func TestMotorDirPWM(t *testing.T) {
 	m, err := NewMotor(b, Config{
 		Pins:   PinConfig{Direction: "1", EnablePinLow: "2", PWM: "3"},
 		MaxRPM: maxRPM, PWMFreq: 4000,
-	}, logger)
+	}, mc, logger)
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Run("motor (DIR/PWM) Off testing", func(t *testing.T) {
@@ -211,11 +216,12 @@ func TestMotorAB(t *testing.T) {
 	ctx := context.Background()
 	b := &fakeboard.Board{GPIOPins: map[string]*fakeboard.GPIOPin{}}
 	logger := golog.NewTestLogger(t)
+	mc := config.Component{}
 
 	m, err := NewMotor(b, Config{
 		Pins:   PinConfig{A: "1", B: "2", EnablePinLow: "3"},
 		MaxRPM: maxRPM, PWMFreq: 4000,
-	}, logger)
+	}, mc, logger)
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Run("motor (A/B) On testing", func(t *testing.T) {
@@ -281,11 +287,12 @@ func TestMotorABNoEncoder(t *testing.T) {
 	ctx := context.Background()
 	b := &fakeboard.Board{GPIOPins: map[string]*fakeboard.GPIOPin{}}
 	logger := golog.NewTestLogger(t)
+	mc := config.Component{}
 
 	m, err := NewMotor(b, Config{
 		Pins:    PinConfig{A: "1", B: "2", EnablePinLow: "3"},
 		PWMFreq: 4000,
-	}, logger)
+	}, mc, logger)
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Run("motor no encoder GoFor testing", func(t *testing.T) {

--- a/components/motor/gpio/basic_test.go
+++ b/components/motor/gpio/basic_test.go
@@ -28,7 +28,7 @@ func TestMotorABPWM(t *testing.T) {
 	t.Run("motor (A/B/PWM) initialization errors", func(t *testing.T) {
 		m, err := NewMotor(b, Config{
 			Pins: PinConfig{A: "1", B: "2", PWM: "3"}, MaxPowerPct: 100, PWMFreq: 4000,
-		}, mc, logger)
+		}, mc.Name, logger)
 		test.That(t, m, test.ShouldBeNil)
 		test.That(t, err, test.ShouldBeError, errors.New("max_power_pct must be between 0.06 and 1.0"))
 	})
@@ -36,7 +36,7 @@ func TestMotorABPWM(t *testing.T) {
 	m, err := NewMotor(b, Config{
 		Pins:   PinConfig{A: "1", B: "2", PWM: "3"},
 		MaxRPM: maxRPM, PWMFreq: 4000,
-	}, mc, logger)
+	}, mc.Name, logger)
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Run("motor (A/B/PWM) Off testing", func(t *testing.T) {
@@ -139,7 +139,8 @@ func TestMotorDirPWM(t *testing.T) {
 	mc := config.Component{}
 
 	t.Run("motor (DIR/PWM) initialization errors", func(t *testing.T) {
-		m, err := NewMotor(b, Config{Pins: PinConfig{Direction: "1", EnablePinLow: "2", PWM: "3"}, PWMFreq: 4000}, mc, logger)
+		m, err := NewMotor(b, Config{Pins: PinConfig{Direction: "1", EnablePinLow: "2", PWM: "3"}, PWMFreq: 4000},
+			mc.Name, logger)
 
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, m.GoFor(ctx, 50, 10, nil), test.ShouldBeError, errors.New("not supported, define max_rpm attribute != 0"))
@@ -147,7 +148,7 @@ func TestMotorDirPWM(t *testing.T) {
 		_, err = NewMotor(
 			b,
 			Config{Pins: PinConfig{Direction: "1", EnablePinLow: "2", PWM: "3"}, MaxPowerPct: 100, PWMFreq: 4000},
-			mc, logger,
+			mc.Name, logger,
 		)
 		test.That(t, err, test.ShouldBeError, errors.New("max_power_pct must be between 0.06 and 1.0"))
 	})
@@ -155,7 +156,7 @@ func TestMotorDirPWM(t *testing.T) {
 	m, err := NewMotor(b, Config{
 		Pins:   PinConfig{Direction: "1", EnablePinLow: "2", PWM: "3"},
 		MaxRPM: maxRPM, PWMFreq: 4000,
-	}, mc, logger)
+	}, mc.Name, logger)
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Run("motor (DIR/PWM) Off testing", func(t *testing.T) {
@@ -221,7 +222,7 @@ func TestMotorAB(t *testing.T) {
 	m, err := NewMotor(b, Config{
 		Pins:   PinConfig{A: "1", B: "2", EnablePinLow: "3"},
 		MaxRPM: maxRPM, PWMFreq: 4000,
-	}, mc, logger)
+	}, mc.Name, logger)
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Run("motor (A/B) On testing", func(t *testing.T) {
@@ -292,7 +293,7 @@ func TestMotorABNoEncoder(t *testing.T) {
 	m, err := NewMotor(b, Config{
 		Pins:    PinConfig{A: "1", B: "2", EnablePinLow: "3"},
 		PWMFreq: 4000,
-	}, mc, logger)
+	}, mc.Name, logger)
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Run("motor no encoder GoFor testing", func(t *testing.T) {

--- a/components/motor/gpio/setup.go
+++ b/components/motor/gpio/setup.go
@@ -70,7 +70,7 @@ func init() {
 				return nil, err
 			}
 
-			m, err := NewMotor(actualBoard, *motorConfig, config, logger)
+			m, err := NewMotor(actualBoard, *motorConfig, config.Name, logger)
 			if err != nil {
 				return nil, err
 			}

--- a/components/motor/gpio/setup.go
+++ b/components/motor/gpio/setup.go
@@ -70,7 +70,7 @@ func init() {
 				return nil, err
 			}
 
-			m, err := NewMotor(actualBoard, *motorConfig, logger)
+			m, err := NewMotor(actualBoard, *motorConfig, config, logger)
 			if err != nil {
 				return nil, err
 			}

--- a/components/motor/gpiostepper/gpiostepper.go
+++ b/components/motor/gpiostepper/gpiostepper.go
@@ -89,7 +89,8 @@ func getBoardFromRobotConfig(deps registry.Dependencies, config config.Component
 }
 
 func newGPIOStepper(ctx context.Context, b board.Board, mc Config, name string,
-	logger golog.Logger) (motor.Motor, error) {
+	logger golog.Logger,
+) (motor.Motor, error) {
 	if mc.TicksPerRotation == 0 {
 		return nil, errors.New("expected ticks_per_rotation in config for motor")
 	}

--- a/components/motor/gpiostepper/gpiostepper.go
+++ b/components/motor/gpiostepper/gpiostepper.go
@@ -58,7 +58,7 @@ func init() {
 				return nil, err
 			}
 
-			return newGPIOStepper(ctx, actualBoard, *motorConfig, config, logger)
+			return newGPIOStepper(ctx, actualBoard, *motorConfig, config.Name, logger)
 		},
 	}
 	registry.RegisterComponent(motor.Subtype, modelName, _motor)
@@ -88,9 +88,8 @@ func getBoardFromRobotConfig(deps registry.Dependencies, config config.Component
 	return b, motorConfig, nil
 }
 
-func newGPIOStepper(ctx context.Context, b board.Board, mc Config, c config.Component,
-	logger golog.Logger,
-) (motor.Motor, error) {
+func newGPIOStepper(ctx context.Context, b board.Board, mc Config, name string,
+	logger golog.Logger) (motor.Motor, error) {
 	if mc.TicksPerRotation == 0 {
 		return nil, errors.New("expected ticks_per_rotation in config for motor")
 	}
@@ -100,7 +99,7 @@ func newGPIOStepper(ctx context.Context, b board.Board, mc Config, c config.Comp
 		stepsPerRotation: mc.TicksPerRotation,
 		stepperDelay:     mc.StepperDelay,
 		logger:           logger,
-		motorName:        c.Name,
+		motorName:        name,
 	}
 
 	if mc.Pins.EnablePinHigh != "" {

--- a/components/motor/gpiostepper/gpiostepper_test.go
+++ b/components/motor/gpiostepper/gpiostepper_test.go
@@ -21,7 +21,9 @@ func Test1(t *testing.T) {
 	b := &fakeboard.Board{GPIOPins: make(map[string]*fakeboard.GPIOPin)}
 
 	mc := Config{}
-	c := config.Component{}
+	c := config.Component{
+		Name: "fake_gpiostepper",
+	}
 
 	// Create motor with no board and default config
 	t.Run("gpiostepper initializing test with no board and default config", func(t *testing.T) {

--- a/components/motor/gpiostepper/gpiostepper_test.go
+++ b/components/motor/gpiostepper/gpiostepper_test.go
@@ -11,6 +11,7 @@ import (
 
 	fakeboard "go.viam.com/rdk/components/board/fake"
 	"go.viam.com/rdk/components/motor"
+	"go.viam.com/rdk/config"
 )
 
 func Test1(t *testing.T) {
@@ -20,32 +21,33 @@ func Test1(t *testing.T) {
 	b := &fakeboard.Board{GPIOPins: make(map[string]*fakeboard.GPIOPin)}
 
 	mc := Config{}
+	c := config.Component{}
 
 	// Create motor with no board and default config
 	t.Run("gpiostepper initializing test with no board and default config", func(t *testing.T) {
-		_, err := newGPIOStepper(ctx, nil, mc, logger)
+		_, err := newGPIOStepper(ctx, nil, mc, c, logger)
 		test.That(t, err, test.ShouldNotBeNil)
 	})
 
 	// Create motor with board and default config
 	t.Run("gpiostepper initializing test with board and default config", func(t *testing.T) {
-		_, err := newGPIOStepper(ctx, b, mc, logger)
+		_, err := newGPIOStepper(ctx, b, mc, c, logger)
 		test.That(t, err, test.ShouldNotBeNil)
 	})
 
 	mc.Pins = PinConfig{Direction: "b"}
 
-	_, err := newGPIOStepper(ctx, b, mc, logger)
+	_, err := newGPIOStepper(ctx, b, mc, c, logger)
 	test.That(t, err, test.ShouldNotBeNil)
 
 	mc.Pins.Step = "c"
 
-	_, err = newGPIOStepper(ctx, b, mc, logger)
+	_, err = newGPIOStepper(ctx, b, mc, c, logger)
 	test.That(t, err, test.ShouldNotBeNil)
 
 	mc.TicksPerRotation = 200
 
-	mm, err := newGPIOStepper(ctx, b, mc, logger)
+	mm, err := newGPIOStepper(ctx, b, mc, c, logger)
 	test.That(t, err, test.ShouldBeNil)
 
 	m := mm.(*gpioStepper)

--- a/components/motor/gpiostepper/gpiostepper_test.go
+++ b/components/motor/gpiostepper/gpiostepper_test.go
@@ -25,29 +25,29 @@ func Test1(t *testing.T) {
 
 	// Create motor with no board and default config
 	t.Run("gpiostepper initializing test with no board and default config", func(t *testing.T) {
-		_, err := newGPIOStepper(ctx, nil, mc, c, logger)
+		_, err := newGPIOStepper(ctx, nil, mc, c.Name, logger)
 		test.That(t, err, test.ShouldNotBeNil)
 	})
 
 	// Create motor with board and default config
 	t.Run("gpiostepper initializing test with board and default config", func(t *testing.T) {
-		_, err := newGPIOStepper(ctx, b, mc, c, logger)
+		_, err := newGPIOStepper(ctx, b, mc, c.Name, logger)
 		test.That(t, err, test.ShouldNotBeNil)
 	})
 
 	mc.Pins = PinConfig{Direction: "b"}
 
-	_, err := newGPIOStepper(ctx, b, mc, c, logger)
+	_, err := newGPIOStepper(ctx, b, mc, c.Name, logger)
 	test.That(t, err, test.ShouldNotBeNil)
 
 	mc.Pins.Step = "c"
 
-	_, err = newGPIOStepper(ctx, b, mc, c, logger)
+	_, err = newGPIOStepper(ctx, b, mc, c.Name, logger)
 	test.That(t, err, test.ShouldNotBeNil)
 
 	mc.TicksPerRotation = 200
 
-	mm, err := newGPIOStepper(ctx, b, mc, c, logger)
+	mm, err := newGPIOStepper(ctx, b, mc, c.Name, logger)
 	test.That(t, err, test.ShouldBeNil)
 
 	m := mm.(*gpioStepper)

--- a/components/motor/i2cmotors/ezopmp.go
+++ b/components/motor/i2cmotors/ezopmp.go
@@ -81,6 +81,7 @@ func init() {
 
 // Ezopmp represents a motor connected via the I2C protocol.
 type Ezopmp struct {
+	name        string
 	board       board.Board
 	bus         board.I2C
 	I2CAddress  byte

--- a/components/motor/i2cmotors/ezopmp.go
+++ b/components/motor/i2cmotors/ezopmp.go
@@ -59,7 +59,7 @@ const modelName = "ezopmp"
 func init() {
 	_motor := registry.Component{
 		Constructor: func(ctx context.Context, deps registry.Dependencies, config config.Component, logger golog.Logger) (interface{}, error) {
-			return NewMotor(ctx, deps, config.ConvertedAttributes.(*AttrConfig), logger)
+			return NewMotor(ctx, deps, config.ConvertedAttributes.(*AttrConfig), config, logger)
 		},
 	}
 	registry.RegisterComponent(motor.Subtype, modelName, _motor)
@@ -104,7 +104,7 @@ const (
 )
 
 // NewMotor returns a motor(Ezopmp) with I2C protocol.
-func NewMotor(ctx context.Context, deps registry.Dependencies, c *AttrConfig, logger golog.Logger) (motor.LocalMotor, error) {
+func NewMotor(ctx context.Context, deps registry.Dependencies, c *AttrConfig, cfg config.Component, logger golog.Logger) (motor.LocalMotor, error) {
 	b, err := board.FromDependencies(deps, c.BoardName)
 	if err != nil {
 		return nil, err
@@ -127,6 +127,7 @@ func NewMotor(ctx context.Context, deps registry.Dependencies, c *AttrConfig, lo
 		logger:      logger,
 		maxPowerPct: 1.0,
 		powerPct:    0.0,
+		name:        cfg.Name,
 	}
 
 	flowRate, err := m.findMaxFlowRate(ctx)
@@ -385,5 +386,5 @@ func (m *Ezopmp) IsPowered(ctx context.Context, extra map[string]interface{}) (b
 
 // GoTillStop is unimplemented.
 func (m *Ezopmp) GoTillStop(ctx context.Context, rpm float64, stopFunc func(ctx context.Context) bool) error {
-	return motor.NewGoTillStopUnsupportedError("(name unavailable)")
+	return motor.NewGoTillStopUnsupportedError(m.name)
 }

--- a/components/motor/i2cmotors/ezopmp.go
+++ b/components/motor/i2cmotors/ezopmp.go
@@ -105,7 +105,8 @@ const (
 
 // NewMotor returns a motor(Ezopmp) with I2C protocol.
 func NewMotor(ctx context.Context, deps registry.Dependencies, c *AttrConfig, name string,
-	logger golog.Logger) (motor.LocalMotor, error) {
+	logger golog.Logger,
+) (motor.LocalMotor, error) {
 	b, err := board.FromDependencies(deps, c.BoardName)
 	if err != nil {
 		return nil, err

--- a/components/motor/i2cmotors/ezopmp.go
+++ b/components/motor/i2cmotors/ezopmp.go
@@ -104,7 +104,9 @@ const (
 )
 
 // NewMotor returns a motor(Ezopmp) with I2C protocol.
-func NewMotor(ctx context.Context, deps registry.Dependencies, c *AttrConfig, cfg config.Component, logger golog.Logger) (motor.LocalMotor, error) {
+func NewMotor(ctx context.Context, deps registry.Dependencies, c *AttrConfig, cfg config.Component,
+	logger golog.Logger,
+) (motor.LocalMotor, error) {
 	b, err := board.FromDependencies(deps, c.BoardName)
 	if err != nil {
 		return nil, err

--- a/components/motor/roboclaw/roboclaw.go
+++ b/components/motor/roboclaw/roboclaw.go
@@ -118,13 +118,7 @@ func newRoboClaw(deps registry.Dependencies, config config.Component, logger gol
 		return nil, err
 	}
 
-	motorName := config.Name
-
-	if motorName == "" {
-		return nil, err
-	}
-
-	return &roboclawMotor{name: motorName, conn: c, conf: motorConfig, addr: uint8(motorConfig.Address), logger: logger}, nil
+	return &roboclawMotor{name: config.Name, conn: c, conf: motorConfig, addr: uint8(motorConfig.Address), logger: logger}, nil
 }
 
 var _ = motor.LocalMotor(&roboclawMotor{})

--- a/components/motor/roboclaw/roboclaw.go
+++ b/components/motor/roboclaw/roboclaw.go
@@ -56,7 +56,6 @@ func init() {
 		motor.Subtype,
 		modelname,
 		registry.Component{
-			//name in config.component
 			Constructor: func(ctx context.Context, deps registry.Dependencies, config config.Component, logger golog.Logger) (interface{}, error) {
 				return newRoboClaw(deps, config, logger)
 			},

--- a/components/motor/roboclaw/roboclaw.go
+++ b/components/motor/roboclaw/roboclaw.go
@@ -56,6 +56,7 @@ func init() {
 		motor.Subtype,
 		modelname,
 		registry.Component{
+			//name in config.component
 			Constructor: func(ctx context.Context, deps registry.Dependencies, config config.Component, logger golog.Logger) (interface{}, error) {
 				return newRoboClaw(deps, config, logger)
 			},
@@ -118,12 +119,19 @@ func newRoboClaw(deps registry.Dependencies, config config.Component, logger gol
 		return nil, err
 	}
 
-	return &roboclawMotor{conn: c, conf: motorConfig, addr: uint8(motorConfig.Address), logger: logger}, nil
+	motorName := config.Name
+
+	if motorName == "" {
+		return nil, err
+	}
+
+	return &roboclawMotor{name: motorName, conn: c, conf: motorConfig, addr: uint8(motorConfig.Address), logger: logger}, nil
 }
 
 var _ = motor.LocalMotor(&roboclawMotor{})
 
 type roboclawMotor struct {
+	name string
 	conn *roboclaw.Roboclaw
 	conf *AttrConfig
 
@@ -251,5 +259,5 @@ func (m *roboclawMotor) IsPowered(ctx context.Context, extra map[string]interfac
 }
 
 func (m *roboclawMotor) GoTillStop(ctx context.Context, rpm float64, stopFunc func(ctx context.Context) bool) error {
-	return motor.NewGoTillStopUnsupportedError("(name unavailable)")
+	return motor.NewGoTillStopUnsupportedError(m.name)
 }

--- a/components/motor/tmcstepper/stepper_motor_tmc.go
+++ b/components/motor/tmcstepper/stepper_motor_tmc.go
@@ -71,7 +71,7 @@ const (
 func init() {
 	_motor := registry.Component{
 		Constructor: func(ctx context.Context, deps registry.Dependencies, config config.Component, logger golog.Logger) (interface{}, error) {
-			return NewMotor(ctx, deps, *config.ConvertedAttributes.(*TMC5072Config), logger)
+			return NewMotor(ctx, deps, *config.ConvertedAttributes.(*TMC5072Config), config, logger)
 		},
 	}
 	registry.RegisterComponent(motor.Subtype, modelname, _motor)
@@ -107,6 +107,7 @@ type Motor struct {
 	logger      golog.Logger
 	opMgr       operation.SingleOperationManager
 	powerPct    float64
+	motorName   string
 }
 
 // TMC5072 Values.
@@ -151,7 +152,9 @@ const (
 )
 
 // NewMotor returns a TMC5072 driven motor.
-func NewMotor(ctx context.Context, deps registry.Dependencies, c TMC5072Config, logger golog.Logger) (motor.LocalMotor, error) {
+func NewMotor(ctx context.Context, deps registry.Dependencies, c TMC5072Config, mc config.Component,
+	logger golog.Logger,
+) (motor.LocalMotor, error) {
 	b, err := board.FromDependencies(deps, c.BoardName)
 	if err != nil {
 		return nil, errors.Errorf("%q is not a board", c.BoardName)
@@ -190,6 +193,7 @@ func NewMotor(ctx context.Context, deps registry.Dependencies, c TMC5072Config, 
 		maxAcc:      c.MaxAcceleration,
 		fClk:        baseClk / c.CalFactor,
 		logger:      logger,
+		motorName:   mc.Name,
 	}
 
 	rawMaxAcc := m.rpmsToA(m.maxAcc)
@@ -389,7 +393,7 @@ func (m *Motor) GetSG(ctx context.Context) (int32, error) {
 func (m *Motor) Position(ctx context.Context, extra map[string]interface{}) (float64, error) {
 	rawPos, err := m.readReg(ctx, xActual)
 	if err != nil {
-		return 0, err
+		return 0, errors.Wrapf(err, "error in Position from motor (%s)", m.motorName)
 	}
 	return float64(rawPos) / float64(m.stepsPerRev), nil
 }
@@ -437,7 +441,7 @@ func (m *Motor) GoFor(ctx context.Context, rpm, rotations float64, extra map[str
 
 	curPos, err := m.Position(ctx, extra)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "error in GoFor from motor (%s)", m.motorName)
 	}
 
 	var d int64 = 1
@@ -485,7 +489,7 @@ func (m *Motor) GoTo(ctx context.Context, rpm, positionRevolutions float64, extr
 		m.writeReg(ctx, xTarget, int32(positionRevolutions)),
 	)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "error in GoTo from motor (%s)", m.motorName)
 	}
 
 	return m.opMgr.WaitForSuccess(
@@ -498,6 +502,9 @@ func (m *Motor) GoTo(ctx context.Context, rpm, positionRevolutions float64, extr
 // IsPowered returns true if the motor is currently moving.
 func (m *Motor) IsPowered(ctx context.Context, extra map[string]interface{}) (bool, float64, error) {
 	on, err := m.IsMoving(ctx)
+	if err != nil {
+		return on, m.powerPct, errors.Wrapf(err, "error in IsPowered from motor (%s)", m.motorName)
+	}
 	return on, m.powerPct, err
 }
 
@@ -505,7 +512,7 @@ func (m *Motor) IsPowered(ctx context.Context, extra map[string]interface{}) (bo
 func (m *Motor) IsStopped(ctx context.Context) (bool, error) {
 	stat, err := m.readReg(ctx, rampStat)
 	if err != nil {
-		return false, err
+		return false, errors.Wrapf(err, "error in IsStopped from motor (%s)", m.motorName)
 	}
 	// Look for vzero flag
 	return stat&0x400 == 0x400, nil
@@ -642,9 +649,9 @@ func (m *Motor) GoTillStop(ctx context.Context, rpm float64, stopFunc func(ctx c
 func (m *Motor) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]interface{}) error {
 	on, _, err := m.IsPowered(ctx, extra)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "error in ResetZeroPosition from motor (%s)", m.motorName)
 	} else if on {
-		return errors.New("can't zero while moving")
+		return errors.Errorf("can't zero motor (%s) while moving", m.motorName)
 	}
 	return multierr.Combine(
 		m.writeReg(ctx, rampMode, modeHold),

--- a/components/motor/tmcstepper/stepper_motor_tmc.go
+++ b/components/motor/tmcstepper/stepper_motor_tmc.go
@@ -153,7 +153,8 @@ const (
 
 // NewMotor returns a TMC5072 driven motor.
 func NewMotor(ctx context.Context, deps registry.Dependencies, c TMC5072Config, name string,
-	logger golog.Logger) (motor.LocalMotor, error) {
+	logger golog.Logger,
+) (motor.LocalMotor, error) {
 	b, err := board.FromDependencies(deps, c.BoardName)
 	if err != nil {
 		return nil, errors.Errorf("%q is not a board", c.BoardName)

--- a/components/motor/tmcstepper/stepper_motor_tmc.go
+++ b/components/motor/tmcstepper/stepper_motor_tmc.go
@@ -71,7 +71,7 @@ const (
 func init() {
 	_motor := registry.Component{
 		Constructor: func(ctx context.Context, deps registry.Dependencies, config config.Component, logger golog.Logger) (interface{}, error) {
-			return NewMotor(ctx, deps, *config.ConvertedAttributes.(*TMC5072Config), config, logger)
+			return NewMotor(ctx, deps, *config.ConvertedAttributes.(*TMC5072Config), config.Name, logger)
 		},
 	}
 	registry.RegisterComponent(motor.Subtype, modelname, _motor)
@@ -152,9 +152,8 @@ const (
 )
 
 // NewMotor returns a TMC5072 driven motor.
-func NewMotor(ctx context.Context, deps registry.Dependencies, c TMC5072Config, mc config.Component,
-	logger golog.Logger,
-) (motor.LocalMotor, error) {
+func NewMotor(ctx context.Context, deps registry.Dependencies, c TMC5072Config, name string,
+	logger golog.Logger) (motor.LocalMotor, error) {
 	b, err := board.FromDependencies(deps, c.BoardName)
 	if err != nil {
 		return nil, errors.Errorf("%q is not a board", c.BoardName)
@@ -193,7 +192,7 @@ func NewMotor(ctx context.Context, deps registry.Dependencies, c TMC5072Config, 
 		maxAcc:      c.MaxAcceleration,
 		fClk:        baseClk / c.CalFactor,
 		logger:      logger,
-		motorName:   mc.Name,
+		motorName:   name,
 	}
 
 	rawMaxAcc := m.rpmsToA(m.maxAcc)


### PR DESCRIPTION
Part one of RSDK-833. 
This part mostly takes care of `NewGoTillStopUnsupportedError `function. 
Added motor name to all the drivers where `NewGoTillStopUnsupportedError` is called. 