### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -2,7 +2,6 @@ package modmanager
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/edaniels/golog"
@@ -38,9 +37,7 @@ func TestModManagerFunctions(t *testing.T) {
 		return logger
 	}
 
-	parentAddr, err := os.MkdirTemp("", "viam-test-*")
-	test.That(t, err, test.ShouldBeNil)
-	defer os.RemoveAll(parentAddr)
+	parentAddr := t.TempDir()
 	parentAddr += "/parent.sock"
 
 	myRobot.ModuleAddressFunc = func() (string, error) {

--- a/vision/keypoints/briefdesc_test.go
+++ b/vision/keypoints/briefdesc_test.go
@@ -1,7 +1,6 @@
 package keypoints
 
 import (
-	"os"
 	"testing"
 
 	"github.com/edaniels/golog"
@@ -14,9 +13,7 @@ func TestGenerateSamplePairs(t *testing.T) {
 	patchSize := 250
 	descSize := 128
 	offset := (patchSize / 2) - 1
-	tempDir, err := os.MkdirTemp("", "brief_sampling")
-	test.That(t, err, test.ShouldBeNil)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	logger.Infof("writing sample points to %s", tempDir)
 	// create plotter
 	plotTmpImage := func(fileName string, sp *SamplePairs) {

--- a/vision/keypoints/matching_test.go
+++ b/vision/keypoints/matching_test.go
@@ -4,7 +4,6 @@ import (
 	"image"
 	"image/draw"
 	"math"
-	"os"
 	"testing"
 
 	"github.com/edaniels/golog"
@@ -42,8 +41,7 @@ func TestRangeInt(t *testing.T) {
 
 func TestMatchDescriptors(t *testing.T) {
 	logger := golog.NewTestLogger(t)
-	tempDir, err := os.MkdirTemp("", "matching_keypoints")
-	test.That(t, err, test.ShouldBeNil)
+	tempDir := t.TempDir()
 
 	logger.Infof("writing sample points to %s", tempDir)
 	// load config

--- a/vision/keypoints/orb_test.go
+++ b/vision/keypoints/orb_test.go
@@ -3,7 +3,6 @@ package keypoints
 import (
 	"image"
 	"image/draw"
-	"os"
 	"testing"
 
 	"github.com/edaniels/golog"
@@ -66,9 +65,7 @@ func TestComputeORBKeypoints(t *testing.T) {
 	test.That(t, len(descs), test.ShouldEqual, 58)
 	test.That(t, len(kps), test.ShouldEqual, 58)
 	// save the output image in a temp file
-	tempDir, err := os.MkdirTemp("", "compute_orb_keypoints")
-	test.That(t, err, test.ShouldBeNil)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	logger.Infof("writing orb keypoint files to %s", tempDir)
 	keyImg := PlotKeypoints(imGray, kps)
 	test.That(t, keyImg, test.ShouldNotBeNil)
@@ -103,9 +100,7 @@ func TestMatchingWithRotation(t *testing.T) {
 	matchedLines := PlotMatchedLines(matchedOrbPts1, matchedOrbPts2, matchedKps1, matchedKps2, true)
 	test.That(t, matchedLines, test.ShouldNotBeNil)
 	// save the output image in a temp file
-	tempDir, err := os.MkdirTemp("", "match_rotated_points")
-	test.That(t, err, test.ShouldBeNil)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	logger.Infof("writing orb keypoint files to %s", tempDir)
 	err = rimage.WriteImageToFile(tempDir+"/rotated_chess_orb.png", matchedLines)
 	test.That(t, err, test.ShouldBeNil)


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := os.MkdirTemp("", "")
	test.That(t, err, test.ShouldBeNil)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```