### PR TITLE
[RSDK-1176] Allow request to single_server/dual_server for a lazy mim…

### DIFF
--- a/components/camera/videosource/helpers.go
+++ b/components/camera/videosource/helpers.go
@@ -18,10 +18,8 @@ import (
 
 // getMIMETypeFromData uses context to determine a MIME type requested by a parent
 // process and attempts to detect the MIME type of the data from its header.
-// If there was a MIME type requested that requires returning a LazyEncodedImage,
-// it ensures that it matches the one deduced from the data before
-// returning the requested MIME type. If no MIME type has been requested or
-// there is a mismatch, it returns the one detected by http.DetectContentType.
+// If no MIME type has been requested or there is a mismatch, it returns the one
+// detected by http.DetectContentType.
 func getMIMETypeFromData(ctx context.Context, data []byte) (string, error) {
 	detectedMimeType := http.DetectContentType(data)
 	requestedMime := gostream.MIMETypeHint(ctx, "")
@@ -40,12 +38,6 @@ func getMIMETypeFromData(ctx context.Context, data []byte) (string, error) {
 				"attempted to decode raw rgba data, but data was not encoded with the expected header format")
 		}
 	} else if (actualMime != "") && (actualMime != detectedMimeType) {
-		if isLazy {
-			return "", errors.Errorf(
-				"mime type requested (%q) for lazy decode not returned (got %q)",
-				actualMime, detectedMimeType,
-			)
-		}
 		golog.Global().Debugf(
 			"mime type requested %s for decode was not detected format %s,"+
 				" using detected format", actualMime, detectedMimeType,
@@ -59,7 +51,7 @@ func getMIMETypeFromData(ctx context.Context, data []byte) (string, error) {
 			"no MIME type specified, defaulting to detected type %s", detectedMimeType)
 	}
 	if isLazy {
-		return requestedMime, nil
+		return utils.WithLazyMIMEType(detectedMimeType), nil
 	}
 	return detectedMimeType, nil
 }

--- a/components/camera/videosource/server_test.go
+++ b/components/camera/videosource/server_test.go
@@ -108,6 +108,16 @@ func TestServerSource(t *testing.T) {
 	test.That(t, stream.Close(context.Background()), test.ShouldBeNil)
 	test.That(t, img, test.ShouldResemble, lazyPng)
 
+	// Requests for lazy JPEG can return lazy PNG
+	lazyJPEGCtx := gostream.WithMIMETypeHint(context.Background(), utils.WithLazyMIMEType(utils.MimeTypeJPEG))
+	img, release, err = camera.ReadImage(
+		lazyJPEGCtx,
+		cam,
+	)
+	test.That(t, err, test.ShouldBeNil)
+	defer release()
+	test.That(t, img, test.ShouldResemble, lazyPng)
+
 	img, release, err = camera.ReadImage(
 		gostream.WithMIMETypeHint(context.Background(), utils.MimeTypePNG),
 		cam,


### PR DESCRIPTION
…e type to return a different lazy mime type

https://viam.atlassian.net/browse/RSDK-1176

I tested that orbslam still runs correctly, and I can view the depth stream through the app.

Note that slam already checks that it gets the type it expects: https://github.com/viamrobotics/rdk/blob/1a72af4caafe27d3a328831fdf09a635b4319d73/services/slam/builtin/builtin.go#L808-L810

In testing my changes, I encountered this bug: https://viam.atlassian.net/browse/RSDK-1273