### PR TITLE
RSDK-778 - fixup rdk version in macos and brew

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ TOOL_BIN = bin/gotools/$(shell uname -s)-$(shell uname -m)
 PATH_WITH_TOOLS="`pwd`/$(TOOL_BIN):`pwd`/node_modules/.bin:${PATH}"
 
 GIT_REVISION = $(shell git rev-parse HEAD | tr -d '\n')
-LDFLAGS = -ldflags "$(shell etc/set_plt.sh) $(shell etc/tag_version.sh) -X 'go.viam.com/rdk/config.GitRevision=${GIT_REVISION}'"
+TAG_VERSION?=$(shell etc/tag_version.sh)
+LDFLAGS = -ldflags "$(shell etc/set_plt.sh) -X 'go.viam.com/rdk/config.Version=${TAG_VERSION}' -X 'go.viam.com/rdk/config.GitRevision=${GIT_REVISION}'"
 BUILD_TAGS=dynamic
 GO_BUILD_TAGS = -tags $(BUILD_TAGS)
 LINT_BUILD_TAGS = --build-tags $(BUILD_TAGS)

--- a/etc/tag_version.sh
+++ b/etc/tag_version.sh
@@ -3,9 +3,10 @@
 set -e
 SELF=$(realpath $0)
 source "$(dirname $SELF)/utils.sh"
+fn_name="get_version_tag"
 
-if get_version_tag > /dev/null
+if declare -F "$fn_name" > /dev/null
 then
-	echo -X \'go.viam.com/rdk/config.Version=$(get_version_tag)\'
+	echo $($fn_name)
 fi
 exit 0

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -67,7 +67,18 @@ func RunServer(ctx context.Context, args []string, _ golog.Logger) (err error) {
 
 	// Always log the version, return early if the '-version' flag was provided
 	// fmt.Println would be better but fails linting. Good enough.
-	logger.Infof("Viam RDK Version: %s, Hash: %s", config.Version, config.GitRevision)
+	var versionFields []interface{}
+	if config.Version != "" {
+		versionFields = append(versionFields, "version", config.Version)
+	}
+	if config.GitRevision != "" {
+		versionFields = append(versionFields, "git_rev", config.GitRevision)
+	}
+	if len(versionFields) != 0 {
+		logger.Infow("Viam RDK", versionFields...)
+	} else {
+		logger.Info("Viam RDK built from source; version unknown")
+	}
 	if argsParsed.Version {
 		return
 	}


### PR DESCRIPTION
This fixes and cleans up some version reporting info for macos and in general. Also see https://github.com/viamrobotics/homebrew-brews/pull/11