### PR TITLE
RSDK-577 - allow appimage in PR to ignore test results

### DIFF
--- a/.github/workflows/pullrequest-trusted.yml
+++ b/.github/workflows/pullrequest-trusted.yml
@@ -5,7 +5,6 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  workflow_dispatch:
   pull_request_target:
     branches: [ 'main' ]
     types: [ labeled ]
@@ -16,25 +15,30 @@ on:
 
 jobs:
   test:
-    if: |
-      github.event_name == 'workflow_dispatch' || 
-      (github.event_name == 'pull_request_target' && (github.event.label.name == 'safe to test' || github.event.label.name == 'appimage') && contains(github.event.pull_request.labels.*.name, 'safe to test'))
+    if: (github.event.label.name == 'safe to test' || github.event.label.name == 'appimage')
     uses: viamrobotics/rdk/.github/workflows/test.yml@main
     secrets:
       MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
 
   slam_integration_test:
-    if: |
-      github.event_name == 'workflow_dispatch' || 
-      (github.event_name == 'pull_request_target' && (github.event.label.name == 'safe to test' || github.event.label.name == 'appimage') && contains(github.event.pull_request.labels.*.name, 'safe to test'))
+    if: github.event.label.name == 'safe to test'
     uses: viamrobotics/rdk/.github/workflows/slam-integration-test.yml@main
 
   # This lets people add an "appimage" tag to have appimages built for the PR
   appimage:
-    needs: test
+    needs: [test]
     if: |
-      contains(github.event.pull_request.labels.*.name, 'appimage') && (github.event_name == 'workflow_dispatch' || 
-      (github.event_name == 'pull_request_target' && (github.event.label.name == 'safe to test' || github.event.label.name == 'appimage') && contains(github.event.pull_request.labels.*.name, 'safe to test')))
+      always() && !cancelled() && contains(github.event.pull_request.labels.*.name, 'safe to test') &&
+      !contains(github.event.pull_request.labels.*.name, 'appimage-ignore-tests') &&
+      contains(github.event.pull_request.labels.*.name, 'appimage') && needs.test.result == 'success'
+    uses: viamrobotics/rdk/.github/workflows/appimage.yml@main
+    secrets:
+      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+
+  appimage-ignore-tests:
+    if: |
+       always() && !cancelled() && contains(github.event.pull_request.labels.*.name, 'safe to test') &&
+       contains(github.event.pull_request.labels.*.name, 'appimage-ignore-tests')
     uses: viamrobotics/rdk/.github/workflows/appimage.yml@main
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}


### PR DESCRIPTION
This adds the `appimage-ignore-tests` label that will still build an image despite test results (basically always) and can be used in conjunction with `appimage` although it's pointless.

This additionally cleans up the logic in our PR workflow such that:
* We only run `test` when we receive the `safe to test` label (this happens per commit) or the `appimage` label (needed for when the label is added after tests run since it's difficult to have a workflow look at a past action run's results; without it, the test job is always skipped)
* We only run `slam_integration_test` when we receive the `safe to test label`
* `appimage` runs conditionally based on test success as expected
* `appimage-ignore-tests` runs conditionally on the same label and does not wait for tests