### PR TITLE
[RSDK-1616] Do not attempt to sync empty sensor reading files 

### DIFF
--- a/services/datamanager/builtin/capture_test.go
+++ b/services/datamanager/builtin/capture_test.go
@@ -2,19 +2,21 @@ package builtin
 
 import (
 	"context"
-	"go.viam.com/rdk/config"
-	"go.viam.com/test"
 	"testing"
 	"time"
+
+	"go.viam.com/rdk/config"
+	"go.viam.com/test"
 )
 
 var (
 	// Robot config which specifies data manager service.
-	enabledTabularCollectorConfigPath  = "services/datamanager/data/fake_robot_with_data_manager.json"
-	disabledTabularCollectorConfigPath = "services/datamanager/data/fake_robot_with_disabled_collector.json"
-	enabledBinaryCollectorConfigPath   = "services/datamanager/data/robot_with_cam_capture.json"
-	remoteCollectorConfigPath          = "services/datamanager/data/fake_robot_with_remote_and_data_manager.json"
-	emptyFileBytesSize                 = 30 // size of leading metadata message
+	enabledTabularCollectorConfigPath           = "services/datamanager/data/fake_robot_with_data_manager.json"
+	disabledTabularCollectorConfigPath          = "services/datamanager/data/fake_robot_with_disabled_collector.json"
+	enabledBinaryCollectorConfigPath            = "services/datamanager/data/robot_with_cam_capture.json"
+	infrequentCaptureTabularCollectorConfigPath = "services/datamanager/data/fake_robot_with_infrequent_capture.json"
+	remoteCollectorConfigPath                   = "services/datamanager/data/fake_robot_with_remote_and_data_manager.json"
+	emptyFileBytesSize                          = 30 // size of leading metadata message
 )
 
 func TestDataCaptureEnabled(t *testing.T) {

--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -303,10 +303,6 @@ func TestDataCaptureUpload(t *testing.T) {
 			}
 			failedURs := mockService.getFailedDCUploadRequests()
 
-			if tc.emptyFile {
-				test.That(t, len(successfulURs), test.ShouldEqual, 0)
-			}
-
 			// If the server was supposed to fail for some requests, verify that it did.
 			if tc.numFails != 0 || tc.serviceFailAt != 0 {
 				test.That(t, len(failedURs), test.ShouldBeGreaterThan, 0)

--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -2,14 +2,6 @@ package builtin
 
 import (
 	"context"
-	"github.com/edaniels/golog"
-	"github.com/pkg/errors"
-	v1 "go.viam.com/api/app/datasync/v1"
-	"go.viam.com/rdk/config"
-	"go.viam.com/rdk/services/datamanager/datacapture"
-	"go.viam.com/rdk/services/datamanager/datasync"
-	"go.viam.com/test"
-	"go.viam.com/utils/rpc"
 	"io"
 	"math"
 	"os"
@@ -19,6 +11,15 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/edaniels/golog"
+	"github.com/pkg/errors"
+	v1 "go.viam.com/api/app/datasync/v1"
+	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/services/datamanager/datacapture"
+	"go.viam.com/rdk/services/datamanager/datasync"
+	"go.viam.com/test"
+	"go.viam.com/utils/rpc"
 )
 
 const (
@@ -144,6 +145,7 @@ func TestDataCaptureUpload(t *testing.T) {
 		scheduledSyncDisabled bool
 		serviceFailAt         int
 		numFails              int
+		emptyFile             bool
 	}{
 		{
 			name:     "Previously captured tabular data should be synced at start up.",
@@ -190,6 +192,10 @@ func TestDataCaptureUpload(t *testing.T) {
 			dataType: v1.DataType_DATA_TYPE_BINARY_SENSOR,
 			numFails: 2,
 		},
+		{
+			name:      "If syncing more often than capturing, empty sensor reading files should be deleted locally and not uploaded.",
+			emptyFile: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -207,10 +213,14 @@ func TestDataCaptureUpload(t *testing.T) {
 			defer dmsvc.Close(context.Background())
 			dmsvc.SetSyncerConstructor(getTestSyncerConstructor(rpcServer))
 			var cfg *config.Config
-			if tc.dataType == v1.DataType_DATA_TYPE_TABULAR_SENSOR {
-				cfg = setupConfig(t, enabledTabularCollectorConfigPath)
+			if tc.emptyFile {
+				cfg = setupConfig(t, infrequentCaptureTabularCollectorConfigPath)
 			} else {
-				cfg = setupConfig(t, enabledBinaryCollectorConfigPath)
+				if tc.dataType == v1.DataType_DATA_TYPE_TABULAR_SENSOR {
+					cfg = setupConfig(t, enabledTabularCollectorConfigPath)
+				} else {
+					cfg = setupConfig(t, enabledBinaryCollectorConfigPath)
+				}
 			}
 
 			// Set up service config with only capture enabled.
@@ -233,7 +243,11 @@ func TestDataCaptureUpload(t *testing.T) {
 			// Get all captured data.
 			capturedData, err := getCapturedData(tmpDir)
 			test.That(t, err, test.ShouldBeNil)
-			test.That(t, len(capturedData), test.ShouldBeGreaterThan, 0)
+			if tc.emptyFile {
+				test.That(t, len(capturedData), test.ShouldEqual, 0)
+			} else {
+				test.That(t, len(capturedData), test.ShouldBeGreaterThan, 0)
+			}
 
 			// Turn dmsvc back on with capture disabled.
 			newDMSvc := newTestDataManager(t)
@@ -288,6 +302,10 @@ func TestDataCaptureUpload(t *testing.T) {
 				successfulURs = mockService.getSuccessfulDCUploadRequests()
 			}
 			failedURs := mockService.getFailedDCUploadRequests()
+
+			if tc.emptyFile {
+				test.That(t, len(successfulURs), test.ShouldEqual, 0)
+			}
 
 			// If the server was supposed to fail for some requests, verify that it did.
 			if tc.numFails != 0 || tc.serviceFailAt != 0 {

--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -193,7 +193,7 @@ func TestDataCaptureUpload(t *testing.T) {
 			numFails: 2,
 		},
 		{
-			name:      "If syncing more often than capturing, empty sensor reading files should be deleted locally and not uploaded.",
+			name:      "Files with no sensor data should not be synced.",
 			emptyFile: true,
 		},
 	}

--- a/services/datamanager/data/fake_robot_with_infrequent_capture.json
+++ b/services/datamanager/data/fake_robot_with_infrequent_capture.json
@@ -1,0 +1,43 @@
+{
+    "network": {
+        "fqdn": "something-unique",
+        "bind_address": ":8080"
+    },
+    "components": [
+        {
+            "name": "arm1",
+            "type": "arm",
+            "model": "fake",
+            "service_config": [
+                {
+                    "type": "data_manager",
+                    "attributes": {
+                        "capture_methods": [
+                            {
+                                "method": "EndPosition",
+                                "capture_frequency_hz": 0.001,
+                                "tags": [
+                                    "a",
+                                    "b"
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    ],
+    "services": [
+        {
+            "name": "data_manager1",
+            "type": "data_manager",
+            "model": "builtin",
+            "attributes": {
+                "sync_disabled": false,
+                "sync_interval_mins": 0,
+                "capture_dir": "/tmp/capture",
+                "capture_disabled": false
+            }
+        }
+    ]
+}

--- a/services/datamanager/datasync/upload_data_capture_file.go
+++ b/services/datamanager/datasync/upload_data_capture_file.go
@@ -18,6 +18,11 @@ func uploadDataCaptureFile(ctx context.Context, client v1.DataSyncServiceClient,
 		return err
 	}
 
+	// Do not attempt to upload a file without any sensor readings, which occurs when syncing more frequently than capturing.
+	if len(sensorData) == 0 {
+		return nil
+	}
+
 	ur := &v1.DataCaptureUploadRequest{
 		Metadata: &v1.UploadMetadata{
 			PartId:           partID,

--- a/services/datamanager/datasync/upload_data_capture_file.go
+++ b/services/datamanager/datasync/upload_data_capture_file.go
@@ -18,7 +18,7 @@ func uploadDataCaptureFile(ctx context.Context, client v1.DataSyncServiceClient,
 		return err
 	}
 
-	// Do not attempt to upload a file without any sensor readings, which occurs when syncing more frequently than capturing.
+	// Do not attempt to upload a file without any sensor readings.
 	if len(sensorData) == 0 {
 		return nil
 	}


### PR DESCRIPTION
Empty sensor readings occur when:
* Syncing more often than capturing
* Restarting/disabling/changing sync or collection before a capture file is written to

This will also delete the local empty file.