### PR TITLE
[DATA-fix] Attempt to reduce false negatives in sync/collector tests.

### DIFF
--- a/data/collector_test.go
+++ b/data/collector_test.go
@@ -253,7 +253,7 @@ func validateReadings(t *testing.T, act []*v1.SensorData, n int) {
 	}
 }
 
-// nolint
+//nolint
 func getAllFiles(dir string) []os.FileInfo {
 	var files []os.FileInfo
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/data/collector_test.go
+++ b/data/collector_test.go
@@ -251,7 +251,7 @@ func validateReadings(t *testing.T, act []*v1.SensorData, n int) {
 	}
 }
 
-// nolint
+//nolint
 func getAllFiles(dir string) []os.FileInfo {
 	var files []os.FileInfo
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/data/collector_test.go
+++ b/data/collector_test.go
@@ -183,7 +183,7 @@ func TestClose(t *testing.T) {
 
 	params := CollectorParams{
 		ComponentName: "testComponent",
-		Interval:      time.Millisecond * 15,
+		Interval:      time.Millisecond * 5,
 		MethodParams:  map[string]*anypb.Any{"name": fakeVal},
 		Target:        target,
 		QueueSize:     queueSize,
@@ -251,7 +251,7 @@ func validateReadings(t *testing.T, act []*v1.SensorData, n int) {
 	}
 }
 
-//nolint
+// nolint
 func getAllFiles(dir string) []os.FileInfo {
 	var files []os.FileInfo
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/data/collector_test.go
+++ b/data/collector_test.go
@@ -180,6 +180,7 @@ func TestClose(t *testing.T) {
 	tmpDir := t.TempDir()
 	md := v1.DataCaptureMetadata{}
 	target := datacapture.NewBuffer(tmpDir, &md)
+	sleepCaptureCutoff = time.Millisecond * 10
 
 	params := CollectorParams{
 		ComponentName: "testComponent",
@@ -216,6 +217,7 @@ func TestCtxCancelledLoggedAsDebug(t *testing.T) {
 	errorCapturer := CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (interface{}, error) {
 		return nil, fmt.Errorf("arbitrary wrapping message: %w", context.Canceled)
 	})
+	sleepCaptureCutoff = time.Millisecond * 10
 
 	params := CollectorParams{
 		ComponentName: "testComponent",

--- a/data/collector_test.go
+++ b/data/collector_test.go
@@ -219,7 +219,7 @@ func TestCtxCancelledLoggedAsDebug(t *testing.T) {
 
 	params := CollectorParams{
 		ComponentName: "testComponent",
-		Interval:      time.Millisecond * 10,
+		Interval:      time.Millisecond * 5,
 		MethodParams:  map[string]*anypb.Any{"name": fakeVal},
 		Target:        target,
 		QueueSize:     queueSize,
@@ -251,7 +251,7 @@ func validateReadings(t *testing.T, act []*v1.SensorData, n int) {
 	}
 }
 
-//nolint
+// nolint
 func getAllFiles(dir string) []os.FileInfo {
 	var files []os.FileInfo
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -136,7 +136,6 @@ func TestDataCaptureUpload(t *testing.T) {
 	datasync.RetryExponentialFactor.Store(int32(1))
 	datasync.InitialWaitTimeMillis.Store(int32(20))
 	captureTime := time.Millisecond * 300
-	syncTime := time.Millisecond * 100
 
 	tests := []struct {
 		name                  string

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -276,7 +276,7 @@ func getNextWait(lastWait time.Duration) time.Duration {
 	return nextWait
 }
 
-// nolint
+//nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -23,14 +23,6 @@ import (
 	rdkutils "go.viam.com/rdk/utils"
 )
 
-/**
-TODO: We still have the possibility of duplicated data being uploaded if the server sends an ACK (and has thus persisted
-      the data), but the client doesn't receive the ACK before shutting down/erroring/etc. In this case the client will
-      think the data hasn't been persisted, and will reupload it.
-      I think this is solvable, but it may be difficult. As an interim, we can limit the total amount of duplicate data
-      risked by lowering the ACK size (since the amount of duplicate data possible == the size of one ACK).
-*/
-
 const (
 	appAddress = "app.viam.com:443"
 )
@@ -284,7 +276,7 @@ func getNextWait(lastWait time.Duration) time.Duration {
 	return nextWait
 }
 
-//nolint
+// nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {


### PR DESCRIPTION
Saw flakiness in these tests in [these](https://github.com/viamrobotics/rdk/actions/runs/3830707034/jobs/6518919924) runs. Was not able to reproduce locally:
```
builtin$ go test -race --count=200 -run TestDataCaptureUpload/If_tabular_uploads_fail_transiently,_they_should_be_retried_until_they_succeed
PASS
ok      go.viam.com/rdk/services/datamanager/builtin    115.741s

data$ go test -race --count=2000 -run TestClose
PASS
ok      go.viam.com/rdk/data    112.579s
```

This makes 3 changes:

- Reduces test collector interval from 15ms -> 5ms. Since the test is essentially checking "after <expected interval> + <leeway>, did we capture stuff?", decreasing the expected interval from 15->5ms and increasing the leeway from 10->20ms should reduce the chances of this happening.
- In the failing TestDataCaptureUpload test we were reassigning the syncTime from 150ms -> 100ms. We don't need to do that. In the failures, sync requests were being cancelled before they were finished. Increasing the time they have to run should reduce the chance of that.
- Also removes a big comment that I forgot to remove in a previous PR.