### PR TITLE
[DATA-992] Save exported data filename as RFC3339Nano

### DIFF
--- a/cli/data.go
+++ b/cli/data.go
@@ -190,7 +190,7 @@ func downloadBinary(ctx context.Context, client datapb.DataServiceClient, dst, i
 		return err
 	}
 
-	timeRequested := datum.GetMetadata().GetTimeRequested().AsTime().Format(time.RFC3339)
+	timeRequested := datum.GetMetadata().GetTimeRequested().AsTime().Format(time.RFC3339Nano)
 	var fileName string
 	if datum.GetMetadata().GetFileName() != "" {
 		// Can use file ext directly from metadata.


### PR DESCRIPTION
Tested that works locally and matches the metadata's timeRequested field.