### PR TITLE
RSDK-1627 - Add generic DoCommand support for modules

### DIFF
--- a/components/generic/server.go
+++ b/components/generic/server.go
@@ -11,7 +11,7 @@ import (
 	"go.viam.com/rdk/subtype"
 )
 
-// subtypeServer implements the SensorService from sensor.proto.
+// subtypeServer implements the generic.Generic service.
 type subtypeServer struct {
 	pb.UnimplementedGenericServiceServer
 	s subtype.Service

--- a/examples/customresources/apis/gizmoapi/gizmoapi.go
+++ b/examples/customresources/apis/gizmoapi/gizmoapi.go
@@ -69,6 +69,7 @@ type Gizmo interface {
 	DoOneServerStream(ctx context.Context, arg1 string) ([]bool, error)
 	DoOneBiDiStream(ctx context.Context, arg1 []string) ([]bool, error)
 	DoTwo(ctx context.Context, arg1 bool) (string, error)
+	generic.Generic
 }
 
 // NewUnimplementedInterfaceError is used when there is a failed interface check.

--- a/examples/customresources/apis/gizmoapi/wrapper.go
+++ b/examples/customresources/apis/gizmoapi/wrapper.go
@@ -90,3 +90,9 @@ func (g *reconfigurableGizmo) Name() resource.Name {
 	defer g.mu.RUnlock()
 	return g.name
 }
+
+func (g *reconfigurableGizmo) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	return g.actual.DoCommand(ctx, cmd)
+}

--- a/examples/customresources/demos/complexmodule/client/client.go
+++ b/examples/customresources/demos/complexmodule/client/client.go
@@ -134,6 +134,14 @@ func main() {
 		logger.Fatal(err)
 	}
 
+	logger.Info("generic echo")
+	testCmd := map[string]interface{}{"foo": "bar"}
+	ret, err := mybase.DoCommand(context.Background(), testCmd)
+	if err != nil {
+		logger.Fatal(err)
+	}
+	logger.Infof("sent: %v recieved: %v", testCmd, ret)
+
 	logger.Info("move forward")
 	err = mybase.SetPower(context.Background(), r3.Vector{Y: 1}, r3.Vector{}, nil)
 	if err != nil {

--- a/examples/customresources/demos/complexmodule/module_test.go
+++ b/examples/customresources/demos/complexmodule/module_test.go
@@ -125,6 +125,12 @@ func TestComplexModule(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		motorR := res.(motor.Motor)
 
+		// Test generic echo
+		testCmd := map[string]interface{}{"foo": "bar"}
+		ret, err := mybase.DoCommand(context.Background(), testCmd)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, ret, test.ShouldResemble, testCmd)
+
 		// Stopped to begin with
 		moving, speed, err := motorL.IsPowered(context.Background(), nil)
 		test.That(t, err, test.ShouldBeNil)

--- a/examples/customresources/models/mybase/mybase.go
+++ b/examples/customresources/models/mybase/mybase.go
@@ -63,7 +63,7 @@ func (base *MyBase) Reconfigure(cfg config.Component, deps registry.Dependencies
 }
 
 type MyBase struct {
-	generic.Unimplemented
+	generic.Echo
 	left    motor.Motor
 	right   motor.Motor
 	logger  golog.Logger

--- a/examples/customresources/models/mygizmo/mygizmo.go
+++ b/examples/customresources/models/mygizmo/mygizmo.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/edaniels/golog"
 
+	"go.viam.com/rdk/components/generic"
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/examples/customresources/apis/gizmoapi"
 	"go.viam.com/rdk/registry"
@@ -36,6 +37,7 @@ func init() {
 type myActualGizmo struct {
 	mu sync.Mutex
 	myArg string
+	generic.Echo
 }
 
 func NewMyGizmo(

--- a/module/module.go
+++ b/module/module.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/grpc"
 	reflectpb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
 
+	"go.viam.com/rdk/components/generic"
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/operation"
 	"go.viam.com/rdk/protoutils"
@@ -272,6 +273,17 @@ func (m *Module) AddResource(ctx context.Context, req *pb.AddResourceRequest) (*
 	if !ok {
 		return nil, errors.Errorf("module cannot service api: %s", cfg.API)
 	}
+
+	if cfg.API.ResourceType == resource.ResourceTypeComponent && cfg.API != generic.Subtype {
+		genSvc, ok := m.services[generic.Subtype]
+		if !ok {
+			return nil, errors.New("module cannot service the generic API")
+		}
+		if err := genSvc.Add(cfg.ResourceName(), res); err != nil {
+			return nil, err
+		}
+	}
+
 	return &pb.AddResourceResponse{}, subSvc.Add(cfg.ResourceName(), res)
 }
 
@@ -330,6 +342,17 @@ func (m *Module) ReconfigureResource(ctx context.Context, req *pb.ReconfigureRes
 			if err != nil {
 				return nil, err
 			}
+
+			if cfg.API != generic.Subtype {
+				genSvc, ok := m.services[generic.Subtype]
+				if !ok {
+					return nil, errors.New("no generic service")
+				}
+				if err := genSvc.ReplaceOne(cfg.ResourceName(), comp); err != nil {
+					return nil, err
+				}
+			}
+
 			return &pb.ReconfigureResourceResponse{}, svc.ReplaceOne(cfg.ResourceName(), comp)
 		}
 
@@ -368,6 +391,17 @@ func (m *Module) RemoveResource(ctx context.Context, req *pb.RemoveResourceReque
 	if err := utils.TryClose(ctx, comp); err != nil {
 		m.logger.Error(err)
 	}
+
+	if name.Subtype.ResourceType == resource.ResourceTypeComponent && name.Subtype != generic.Subtype {
+		genSvc, ok := m.services[generic.Subtype]
+		if !ok {
+			return nil, errors.New("no generic service")
+		}
+		if err := genSvc.Remove(name); err != nil {
+			return nil, err
+		}
+	}
+
 	return &pb.RemoveResourceResponse{}, svc.Remove(name)
 }
 
@@ -398,9 +432,16 @@ func (m *Module) addAPIFromRegistry(ctx context.Context, api resource.Subtype) e
 func (m *Module) AddModelFromRegistry(ctx context.Context, api resource.Subtype, model resource.Model) error {
 	m.mu.Lock()
 	_, ok := m.services[api]
+	_, okGeneric := m.services[generic.Subtype]
 	m.mu.Unlock()
 	if !ok {
 		if err := m.addAPIFromRegistry(ctx, api); err != nil {
+			return err
+		}
+	}
+
+	if api.ResourceType == resource.ResourceTypeComponent && !okGeneric && api != generic.Subtype {
+		if err := m.addAPIFromRegistry(ctx, generic.Subtype); err != nil {
 			return err
 		}
 	}

--- a/module/module_test.go
+++ b/module/module_test.go
@@ -141,6 +141,12 @@ func TestModuleFunctions(t *testing.T) {
 		ret, err = gClient.DoOne(ctx, "")
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, ret, test.ShouldBeTrue)
+
+		// Test generic echo
+		testCmd := map[string]interface{}{"foo": "bar"}
+		retCmd, err := gClient.DoCommand(context.Background(), testCmd)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, retCmd, test.ShouldResemble, testCmd)
 	})
 
 	t.Run("ReconfigureResource", func(t *testing.T) {
@@ -158,6 +164,12 @@ func TestModuleFunctions(t *testing.T) {
 		ret, err = gClient.DoOne(ctx, "")
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, ret, test.ShouldBeFalse)
+
+		// Test generic echo
+		testCmd := map[string]interface{}{"foo": "bar"}
+		retCmd, err := gClient.DoCommand(context.Background(), testCmd)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, retCmd, test.ShouldResemble, testCmd)
 	})
 
 	t.Run("RemoveResource", func(t *testing.T) {
@@ -167,6 +179,12 @@ func TestModuleFunctions(t *testing.T) {
 		_, err := gClient.DoOne(ctx, "test")
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "no Gizmo with name (gizmo1)")
+
+		// Test generic echo
+		testCmd := map[string]interface{}{"foo": "bar"}
+		retCmd, err := gClient.DoCommand(context.Background(), testCmd)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "no resource with name")
+		test.That(t, retCmd, test.ShouldBeNil)
 	})
 
 	err = utils.TryClose(ctx, gClient)


### PR DESCRIPTION
Does what it says on the tin. I somehow overlooked this case (generic interface on regular components) during the main modules project. Thanks to @dannenberg for pointing it out.