### PR TITLE
[RSDK-845] Add Slack Failure Notices to Workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,3 +30,22 @@ jobs:
     uses: viamrobotics/rdk/.github/workflows/appimage.yml@main
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+
+  slack-workflow-status:
+    if: always()
+    name: Post Workflow Status To Slack
+    needs:
+      - test
+      - appimage
+    runs-on: ubuntu-latest
+    permissions:
+      actions: 'read'
+    steps:
+      - name: Slack Workflow Notification
+        uses: Gamesight/slack-workflow-status@v1
+        with:
+          repo_token: ${{secrets.GITHUB_TOKEN}}
+          slack_webhook_url: ${{secrets.SLACK_WEBHOOK_URL}}
+          channel: '#team-devops'
+          name: 'Workflow Status'
+          include_jobs: on-failure


### PR DESCRIPTION
The slack-side app is all set up to provide the integration hook, and this was just tested and works. Sending to #team-devops for now. Should be pretty simple. We can change the channel or have it spam us with successful runs too if we want. For now, failures only.