### PR TITLE
RSDK-1271 - Check for missing distortion parameters in SLAM service

### DIFF
--- a/services/slam/builtin/builtin.go
+++ b/services/slam/builtin/builtin.go
@@ -354,9 +354,13 @@ func configureCameras(ctx context.Context, svcConfig *AttrConfig, deps registry.
 				return "", nil, errors.Wrap(err, "error getting camera properties for slam service")
 			}
 
-			_, ok = props.DistortionParams.(*transform.BrownConrady)
+			brownConrady, ok := props.DistortionParams.(*transform.BrownConrady)
 			if !ok {
-				return "", nil, errors.New("error getting distortion_parameters for slam service, only BrownConrady distortion parameters are supported")
+				return "", nil, errors.New("error getting distortion_parameters for slam service, only BrownConrady distortion parameters are supported 1")
+			}
+
+			if brownConrady == nil {
+				return "", nil, errors.New("error getting distortion_parameters for slam service, only BrownConrady distortion parameters are supported 2")
 			}
 		}
 

--- a/services/slam/builtin/builtin.go
+++ b/services/slam/builtin/builtin.go
@@ -328,6 +328,7 @@ func configureCameras(ctx context.Context, svcConfig *AttrConfig, deps registry.
 		if err != nil {
 			return "", nil, errors.Wrapf(err, "error getting camera %v for slam service", cameraName)
 		}
+		logger.Debug(cam)
 		proj, err := cam.Projector(ctx)
 		if err != nil {
 			if len(svcConfig.Sensors) == 1 {

--- a/services/slam/builtin/builtin.go
+++ b/services/slam/builtin/builtin.go
@@ -355,12 +355,8 @@ func configureCameras(ctx context.Context, svcConfig *AttrConfig, deps registry.
 			}
 
 			brownConrady, ok := props.DistortionParams.(*transform.BrownConrady)
-			if !ok {
-				return "", nil, errors.New("error getting distortion_parameters for slam service, only BrownConrady distortion parameters are supported 1")
-			}
-
-			if brownConrady == nil {
-				return "", nil, errors.New("error getting distortion_parameters for slam service, only BrownConrady distortion parameters are supported 2")
+			if !ok || brownConrady == nil {
+				return "", nil, errors.New("error getting distortion_parameters for slam service, only BrownConrady distortion parameters are supported")
 			}
 		}
 

--- a/services/slam/builtin/builtin.go
+++ b/services/slam/builtin/builtin.go
@@ -351,16 +351,12 @@ func configureCameras(ctx context.Context, svcConfig *AttrConfig, deps registry.
 
 			props, err := cam.Properties(ctx)
 			if err != nil {
-				return "", nil, errors.Wrapf(err, "error getting props %v for slam service")
+				return "", nil, errors.Wrap(err, "error getting camera properties for slam service")
 			}
 
-			distortion, ok := props.DistortionParams.(*transform.BrownConrady)
+			_, ok = props.DistortionParams.(*transform.BrownConrady)
 			if !ok {
-				return "", nil, errors.New("error getting distortion_parameters for slam service")
-			}
-
-			if distortion == nil {
-				return "", nil, errors.New("camera distortion_parameters are not provided")
+				return "", nil, errors.New("error getting distortion_parameters for slam service, only BrownConrady distortion parameters are supported")
 			}
 		}
 


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-1271)

Check config's first camera component's `distortion_parameters` is not `nil` or a nil pointer. 

Return an error from `rdk.services.slam.builtin.configureCameras`, which will prevent slam initialization if check fails & will output informative log.