### PR TITLE
RSDK-894 - Remove log for already registered camera streams

### DIFF
--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -486,7 +486,6 @@ func (svc *webService) addNewStreams(ctx context.Context) error {
 		// Skip if stream is already registered, otherwise raise any other errors
 		var registeredError *gostream.StreamAlreadyRegisteredError
 		if errors.As(err, &registeredError) {
-			svc.logger.Debug(registeredError.Error())
 			return nil, true, nil
 		} else if err != nil {
 			return nil, false, err

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -486,7 +486,7 @@ func (svc *webService) addNewStreams(ctx context.Context) error {
 		// Skip if stream is already registered, otherwise raise any other errors
 		var registeredError *gostream.StreamAlreadyRegisteredError
 		if errors.As(err, &registeredError) {
-			svc.logger.Warn(registeredError.Error())
+			svc.logger.Debug(registeredError.Error())
 			return nil, true, nil
 		} else if err != nil {
 			return nil, false, err


### PR DESCRIPTION
### Summary
This PR removes Warn log for already registered camera/audio streams.

### Test
> tested on Pi and Mac

```
$ go run web/cmd/server/main.go -config etc/configs/fake.json
```

Make change to `fake.json` -> no camera/audio "already registered" log :)
