### PR TITLE
Cleanup workflows and fix security for appimage PR removal

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -129,11 +129,7 @@ jobs:
   appimage_deploy:
     name: AppImage Deploy
     needs: appimage_test
-    runs-on: [x64, qemu-host]
-    container:
-      image: ghcr.io/viamrobotics/canon:amd64-cache
-      options: --platform linux/amd64
-    timeout-minutes: 5
+    runs-on: ubuntu-latest
 
     steps:
     - name: Authorize GCP
@@ -143,10 +139,6 @@ jobs:
 
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v1
-
-    # Needed until https://github.com/google-github-actions/auth/issues/241 is fixed upstream
-    - name: Fix Auth
-      run: yes | gcloud auth login --cred-file="$GOOGLE_APPLICATION_CREDENTIALS"
 
     - name: Publish AppImage
       run: |

--- a/.github/workflows/appimagecleanup.yml
+++ b/.github/workflows/appimagecleanup.yml
@@ -12,11 +12,7 @@ on:
 jobs:
   clean_appimages:
     name: Clean Test AppImages
-    runs-on: [x64, qemu-host]
-    container:
-      image: ghcr.io/viamrobotics/canon:amd64-cache
-      options: --platform linux/amd64
-    timeout-minutes: 5
+    runs-on: ubuntu-latest
 
     steps:
     - name: Authorize GCP
@@ -27,11 +23,6 @@ jobs:
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v1
 
-    # Needed until https://github.com/google-github-actions/auth/issues/241 is fixed upstream
-    - name: Fix Auth
-      run: yes | gcloud auth login --cred-file="$GOOGLE_APPLICATION_CREDENTIALS"
-
     - name: Remove Failed Test AppImages
       run: |
-        gsutil -m rm -r "gs://packages.viam.com/apps/viam-server/testing/`date +%Y-%m -d 'last month'`*"
-        true
+        gsutil -m rm -r "gs://packages.viam.com/apps/viam-server/testing/`date +%Y-%m -d 'last month'`*" || true

--- a/.github/workflows/pullrequestclose.yml
+++ b/.github/workflows/pullrequestclose.yml
@@ -5,18 +5,14 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [ 'main' ]
     types: [ 'closed' ]
 
 jobs:
   appimage_clean:
     name: Remove PR AppImages
-    runs-on: [x64, qemu-host]
-    container:
-      image: ghcr.io/viamrobotics/canon:amd64-cache
-      options: --platform linux/amd64
-    timeout-minutes: 15
+    runs-on: ubuntu-latest
 
     steps:
     - name: Authorize GCP
@@ -26,10 +22,6 @@ jobs:
 
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v1
-
-    # Needed until https://github.com/google-github-actions/auth/issues/241 is fixed upstream
-    - name: Fix Auth
-      run: yes | gcloud auth login --cred-file="$GOOGLE_APPLICATION_CREDENTIALS"
 
     - name: Delete Files
       run: |

--- a/.github/workflows/pullrequestcomment.yml
+++ b/.github/workflows/pullrequestcomment.yml
@@ -9,11 +9,7 @@ on:
 jobs:
   comment:
     name: 'Post Comment on PR'
-    runs-on: [x64, qemu-host]
-    container:
-      image: ghcr.io/viamrobotics/canon:amd64-cache
-      options: --platform linux/amd64
-    timeout-minutes: 5
+    runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.event == 'pull_request_target' && github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Download Code Coverage


### PR DESCRIPTION
One fix to correct the always-failing appimage removal on PR close. The rest is/should just be switching to github runners for trivial (non-code) jobs and removing a now-obsolete workaround.