### PR TITLE
RSDK-1271 - follow up: add BrownConrady CheckValid

### DIFF
--- a/rimage/transform/brown_conrady.go
+++ b/rimage/transform/brown_conrady.go
@@ -14,7 +14,7 @@ type BrownConrady struct {
 // CheckValid checks if the fields for BrownConrady have valid inputs.
 func (bc *BrownConrady) CheckValid() error {
 	if bc == nil {
-		return ErrInvalidDistortionError("BrownConrady shaped distortion_parameters not provided")
+		return InvalidDistortionError("BrownConrady shaped distortion_parameters not provided")
 	}
 	return nil
 }

--- a/rimage/transform/brown_conrady.go
+++ b/rimage/transform/brown_conrady.go
@@ -11,6 +11,14 @@ type BrownConrady struct {
 	TangentialP2 float64 `json:"tp2"`
 }
 
+// CheckValid checks if the fields for BrownConrady have valid inputs.
+func (bc *BrownConrady) CheckValid() error {
+	if bc == nil {
+		return ErrInvalidDistortionError("BrownConrady shaped distortion_parameters not provided")
+	}
+	return nil
+}
+
 // NewBrownConrady takes in a slice of floats that will be passed into the struct in order.
 func NewBrownConrady(inp []float64) (*BrownConrady, error) {
 	if len(inp) > 5 {

--- a/rimage/transform/brown_conrady_test.go
+++ b/rimage/transform/brown_conrady_test.go
@@ -10,7 +10,7 @@ func TestBrownConradyCheckValid(t *testing.T) {
 	distortionsA := &BrownConrady{}
 	test.That(t, distortionsA.CheckValid(), test.ShouldBeNil)
 	var nilBrownConradyPtr *BrownConrady
-	err := nilBrownConradyPtr.CheckValid().Error()
+	err := nilBrownConradyPtr.CheckValid()
 	expected := "BrownConrady shaped distortion_parameters not provided: invalid distortion_parameters"
-	test.That(t, err, test.ShouldContainSubstring, expected)
+	test.That(t, err.Error(), test.ShouldContainSubstring, expected)
 }

--- a/rimage/transform/brown_conrady_test.go
+++ b/rimage/transform/brown_conrady_test.go
@@ -1,0 +1,16 @@
+package transform
+
+import (
+	"testing"
+
+	"go.viam.com/test"
+)
+
+func TestBrownConradyCheckValid(t *testing.T) {
+	distortionsA := &BrownConrady{}
+	test.That(t, distortionsA.CheckValid(), test.ShouldBeNil)
+	var nilBrownConradyPtr *BrownConrady
+	err := nilBrownConradyPtr.CheckValid().Error()
+	expected := "BrownConrady shaped distortion_parameters not provided: invalid distortion_parameters"
+	test.That(t, err, test.ShouldContainSubstring, expected)
+}

--- a/rimage/transform/brown_conrady_test.go
+++ b/rimage/transform/brown_conrady_test.go
@@ -7,10 +7,15 @@ import (
 )
 
 func TestBrownConradyCheckValid(t *testing.T) {
-	distortionsA := &BrownConrady{}
-	test.That(t, distortionsA.CheckValid(), test.ShouldBeNil)
-	var nilBrownConradyPtr *BrownConrady
-	err := nilBrownConradyPtr.CheckValid()
-	expected := "BrownConrady shaped distortion_parameters not provided: invalid distortion_parameters"
-	test.That(t, err.Error(), test.ShouldContainSubstring, expected)
+	t.Run("nil &BrownConrady{} are invalid", func(t *testing.T) {
+		var nilBrownConradyPtr *BrownConrady
+		err := nilBrownConradyPtr.CheckValid()
+		expected := "BrownConrady shaped distortion_parameters not provided: invalid distortion_parameters"
+		test.That(t, err.Error(), test.ShouldContainSubstring, expected)
+	})
+
+	t.Run("non nil &BrownConrady{} are valid", func(t *testing.T) {
+		distortionsA := &BrownConrady{}
+		test.That(t, distortionsA.CheckValid(), test.ShouldBeNil)
+	})
 }

--- a/rimage/transform/distorter.go
+++ b/rimage/transform/distorter.go
@@ -22,8 +22,8 @@ type Distorter interface {
 	Transform(x, y float64) (float64, float64)
 }
 
-// ErrInvalidDistortionError is used when the distortion_parameters are invalid.
-func ErrInvalidDistortionError(msg string) error {
+// InvalidDistortionError is used when the distortion_parameters are invalid.
+func InvalidDistortionError(msg string) error {
 	return errors.Wrapf(errors.New("invalid distortion_parameters"), msg)
 }
 

--- a/rimage/transform/distorter.go
+++ b/rimage/transform/distorter.go
@@ -17,8 +17,14 @@ const (
 // Distorter defines a Transform that takes an undistorted image and distorts it according to the model.
 type Distorter interface {
 	ModelType() DistortionType
+	CheckValid() error
 	Parameters() []float64
 	Transform(x, y float64) (float64, float64)
+}
+
+// ErrInvalidDistortionError is used when the distortion_parameters are invalid.
+func ErrInvalidDistortionError(msg string) error {
+	return errors.Wrapf(errors.New("invalid distortion_parameters"), msg)
 }
 
 // NewDistorter returns a Distorter given a valid DistortionType and its parameters.
@@ -35,6 +41,9 @@ func NewDistorter(distortionType DistortionType, parameters []float64) (Distorte
 
 // NoDistortion applies no Distortion to the camera.
 type NoDistortion struct{}
+
+// CheckValid returns an error if invalid.
+func (nd *NoDistortion) CheckValid() error { return nil }
 
 // ModelType returns the name of the model.
 func (nd *NoDistortion) ModelType() DistortionType { return NoneDistortionType }

--- a/services/slam/builtin/builtin.go
+++ b/services/slam/builtin/builtin.go
@@ -357,11 +357,10 @@ func configureCameras(ctx context.Context, svcConfig *AttrConfig, deps registry.
 				return "", nil, errors.Wrap(err, "error getting camera properties for slam service")
 			}
 
-			_, ok = props.DistortionParams.(*transform.BrownConrady)
+			brownConrady, ok := props.DistortionParams.(*transform.BrownConrady)
 			if !ok {
 				return "", nil, errors.New("error getting distortion_parameters for slam service, only BrownConrady distortion parameters are supported")
 			}
-
 			if err := brownConrady.CheckValid(); err != nil {
 				return "", nil, errors.Wrapf(err, "error validating distortion_parameters for slam service")
 

--- a/services/slam/builtin/builtin.go
+++ b/services/slam/builtin/builtin.go
@@ -361,6 +361,11 @@ func configureCameras(ctx context.Context, svcConfig *AttrConfig, deps registry.
 			if !ok {
 				return "", nil, errors.New("error getting distortion_parameters for slam service, only BrownConrady distortion parameters are supported")
 			}
+
+			if err := brownConrady.CheckValid(); err != nil {
+				return "", nil, errors.Wrapf(err, "error validating distortion_parameters for slam service")
+
+			}
 		}
 
 		cams = append(cams, cam)


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-1271)

Following the advice of @bhaney in response to my question in the ticket:
1.  adds a `CheckValid` method to the Distorter interface
2. adds a test for `BrownConrady{}`
3. implements `CheckValid` on `NoDistortion{}` & `BrownConrady{}`. `BrownConrady{}`'s implementation only verifies its not called on a `nil` pointer (the bug that triggered the ticket in the first place). Please let me know if you would like me to add more validations in this PR (and if so what they should be as I don't know what values are valid), or leave that up to others at a later time.