### PR TITLE
RSDK-1271 - fix nil distortion interface type propagation

### DIFF
--- a/components/camera/align/extrinsics.go
+++ b/components/camera/align/extrinsics.go
@@ -146,10 +146,15 @@ func newColorDepthExtrinsics(ctx context.Context, color, depth camera.Camera, at
 		debug:     attrs.Debug,
 		logger:    logger,
 	}
+	var cameraModel transform.PinholeCameraModel
+	cameraModel.PinholeCameraIntrinsics = attrs.CameraParameters
+	if attrs.DistortionParameters != nil {
+		cameraModel.Distortion = attrs.DistortionParameters
+	}
 	return camera.NewFromReader(
 		ctx,
 		videoSrc,
-		&transform.PinholeCameraModel{attrs.CameraParameters, attrs.DistortionParameters},
+		&cameraModel,
 		imgType,
 	)
 }

--- a/components/camera/align/extrinsics.go
+++ b/components/camera/align/extrinsics.go
@@ -146,11 +146,7 @@ func newColorDepthExtrinsics(ctx context.Context, color, depth camera.Camera, at
 		debug:     attrs.Debug,
 		logger:    logger,
 	}
-	var cameraModel transform.PinholeCameraModel
-	cameraModel.PinholeCameraIntrinsics = attrs.CameraParameters
-	if attrs.DistortionParameters != nil {
-		cameraModel.Distortion = attrs.DistortionParameters
-	}
+	cameraModel := camera.NewPinholdCameraModel(attrs.CameraParameters, attrs.DistortionParameters)
 	return camera.NewFromReader(
 		ctx,
 		videoSrc,

--- a/components/camera/align/extrinsics.go
+++ b/components/camera/align/extrinsics.go
@@ -146,7 +146,7 @@ func newColorDepthExtrinsics(ctx context.Context, color, depth camera.Camera, at
 		debug:     attrs.Debug,
 		logger:    logger,
 	}
-	cameraModel := camera.NewPinholeCameraModel(attrs.CameraParameters, attrs.DistortionParameters)
+	cameraModel := camera.NewPinholeModelWithBrownConradyDistortion(attrs.CameraParameters, attrs.DistortionParameters)
 	return camera.NewFromReader(
 		ctx,
 		videoSrc,

--- a/components/camera/align/extrinsics.go
+++ b/components/camera/align/extrinsics.go
@@ -146,7 +146,7 @@ func newColorDepthExtrinsics(ctx context.Context, color, depth camera.Camera, at
 		debug:     attrs.Debug,
 		logger:    logger,
 	}
-	cameraModel := camera.NewPinholdCameraModel(attrs.CameraParameters, attrs.DistortionParameters)
+	cameraModel := camera.NewPinholeCameraModel(attrs.CameraParameters, attrs.DistortionParameters)
 	return camera.NewFromReader(
 		ctx,
 		videoSrc,

--- a/components/camera/align/homography.go
+++ b/components/camera/align/homography.go
@@ -135,10 +135,15 @@ func newColorDepthHomography(ctx context.Context, color, depth camera.Camera, at
 		debug:     attrs.Debug,
 		logger:    logger,
 	}
+	var cameraModel transform.PinholeCameraModel
+	cameraModel.PinholeCameraIntrinsics = attrs.CameraParameters
+	if attrs.DistortionParameters != nil {
+		cameraModel.Distortion = attrs.DistortionParameters
+	}
 	return camera.NewFromReader(
 		ctx,
 		videoSrc,
-		&transform.PinholeCameraModel{attrs.CameraParameters, attrs.DistortionParameters},
+		&cameraModel,
 		imgType,
 	)
 }

--- a/components/camera/align/homography.go
+++ b/components/camera/align/homography.go
@@ -135,7 +135,7 @@ func newColorDepthHomography(ctx context.Context, color, depth camera.Camera, at
 		debug:     attrs.Debug,
 		logger:    logger,
 	}
-	cameraModel := camera.NewPinholeCameraModel(attrs.CameraParameters, attrs.DistortionParameters)
+	cameraModel := camera.NewPinholeModelWithBrownConradyDistortion(attrs.CameraParameters, attrs.DistortionParameters)
 	return camera.NewFromReader(
 		ctx,
 		videoSrc,

--- a/components/camera/align/homography.go
+++ b/components/camera/align/homography.go
@@ -135,7 +135,7 @@ func newColorDepthHomography(ctx context.Context, color, depth camera.Camera, at
 		debug:     attrs.Debug,
 		logger:    logger,
 	}
-	cameraModel := camera.NewPinholdCameraModel(attrs.CameraParameters, attrs.DistortionParameters)
+	cameraModel := camera.NewPinholeCameraModel(attrs.CameraParameters, attrs.DistortionParameters)
 	return camera.NewFromReader(
 		ctx,
 		videoSrc,

--- a/components/camera/align/homography.go
+++ b/components/camera/align/homography.go
@@ -135,11 +135,7 @@ func newColorDepthHomography(ctx context.Context, color, depth camera.Camera, at
 		debug:     attrs.Debug,
 		logger:    logger,
 	}
-	var cameraModel transform.PinholeCameraModel
-	cameraModel.PinholeCameraIntrinsics = attrs.CameraParameters
-	if attrs.DistortionParameters != nil {
-		cameraModel.Distortion = attrs.DistortionParameters
-	}
+	cameraModel := camera.NewPinholdCameraModel(attrs.CameraParameters, attrs.DistortionParameters)
 	return camera.NewFromReader(
 		ctx,
 		videoSrc,

--- a/components/camera/align/join.go
+++ b/components/camera/align/join.go
@@ -115,7 +115,7 @@ func newJoinColorDepth(ctx context.Context, color, depth camera.Camera, attrs *j
 		debug:     attrs.Debug,
 		logger:    logger,
 	}
-	cameraModel := camera.NewPinholeCameraModel(attrs.CameraParameters, attrs.DistortionParameters)
+	cameraModel := camera.NewPinholeModelWithBrownConradyDistortion(attrs.CameraParameters, attrs.DistortionParameters)
 	return camera.NewFromReader(
 		ctx,
 		videoSrc,

--- a/components/camera/align/join.go
+++ b/components/camera/align/join.go
@@ -115,10 +115,15 @@ func newJoinColorDepth(ctx context.Context, color, depth camera.Camera, attrs *j
 		debug:     attrs.Debug,
 		logger:    logger,
 	}
+	var cameraModel transform.PinholeCameraModel
+	cameraModel.PinholeCameraIntrinsics = attrs.CameraParameters
+	if attrs.DistortionParameters != nil {
+		cameraModel.Distortion = attrs.DistortionParameters
+	}
 	return camera.NewFromReader(
 		ctx,
 		videoSrc,
-		&transform.PinholeCameraModel{attrs.CameraParameters, attrs.DistortionParameters},
+		&cameraModel,
 		imgType,
 	)
 }

--- a/components/camera/align/join.go
+++ b/components/camera/align/join.go
@@ -115,7 +115,7 @@ func newJoinColorDepth(ctx context.Context, color, depth camera.Camera, attrs *j
 		debug:     attrs.Debug,
 		logger:    logger,
 	}
-	cameraModel := camera.NewPinholdCameraModel(attrs.CameraParameters, attrs.DistortionParameters)
+	cameraModel := camera.NewPinholeCameraModel(attrs.CameraParameters, attrs.DistortionParameters)
 	return camera.NewFromReader(
 		ctx,
 		videoSrc,

--- a/components/camera/align/join.go
+++ b/components/camera/align/join.go
@@ -115,11 +115,7 @@ func newJoinColorDepth(ctx context.Context, color, depth camera.Camera, attrs *j
 		debug:     attrs.Debug,
 		logger:    logger,
 	}
-	var cameraModel transform.PinholeCameraModel
-	cameraModel.PinholeCameraIntrinsics = attrs.CameraParameters
-	if attrs.DistortionParameters != nil {
-		cameraModel.Distortion = attrs.DistortionParameters
-	}
+	cameraModel := camera.NewPinholdCameraModel(attrs.CameraParameters, attrs.DistortionParameters)
 	return camera.NewFromReader(
 		ctx,
 		videoSrc,

--- a/components/camera/camera.go
+++ b/components/camera/camera.go
@@ -155,8 +155,8 @@ func NewFromReader(
 }
 
 // NewPinholeCameraModel creates a transform.PinholeCameraModel from
-// a *transform.PinholeCameraIntrinsics and a transform.Distorter.
-// If transform.Distorter is `nil`, transform.PinholeCameraModel.Distortion
+// a *transform.PinholeCameraIntrinsics and a *transform.BrownConrady.
+// If *transform.BrownConrady is `nil`, transform.PinholeCameraModel.Distortion
 // is not set & remains nil, to prevent https://go.dev/doc/faq#nil_error.
 func NewPinholeCameraModel(pinholeCameraIntrinsics *transform.PinholeCameraIntrinsics,
 	distortion *transform.BrownConrady,

--- a/components/camera/camera.go
+++ b/components/camera/camera.go
@@ -154,11 +154,11 @@ func NewFromReader(
 	}, nil
 }
 
-// NewPinholeCameraModel creates a transform.PinholeCameraModel from
+// NewPinholeModelWithBrownConradyDistortion creates a transform.PinholeCameraModel from
 // a *transform.PinholeCameraIntrinsics and a *transform.BrownConrady.
 // If *transform.BrownConrady is `nil`, transform.PinholeCameraModel.Distortion
 // is not set & remains nil, to prevent https://go.dev/doc/faq#nil_error.
-func NewPinholeCameraModel(pinholeCameraIntrinsics *transform.PinholeCameraIntrinsics,
+func NewPinholeModelWithBrownConradyDistortion(pinholeCameraIntrinsics *transform.PinholeCameraIntrinsics,
 	distortion *transform.BrownConrady,
 ) transform.PinholeCameraModel {
 	var cameraModel transform.PinholeCameraModel

--- a/components/camera/camera.go
+++ b/components/camera/camera.go
@@ -136,11 +136,7 @@ func NewFromReader(
 				return nil, NewPropertiesError("source camera")
 			}
 
-			var cameraModel transform.PinholeCameraModel
-			cameraModel.PinholeCameraIntrinsics = props.IntrinsicParams
-			if props.DistortionParams != nil {
-				cameraModel.Distortion = props.DistortionParams
-			}
+			cameraModel := NewPinholdCameraModel(props.IntrinsicParams, props.DistortionParams)
 			actualSystem = &cameraModel
 		}
 	}
@@ -151,6 +147,22 @@ func NewFromReader(
 		actualSource: reader,
 		imageType:    imageType,
 	}, nil
+}
+
+// NewPinholdCameraModel creates a transform.PinholeCameraModel from
+// a *transform.PinholeCameraIntrinsics and a transform.Distorter.
+// If transform.Distorter is `nil`, transform.PinholeCameraModel.Distortion
+// is not set & remains nil, to prevent https://go.dev/doc/faq#nil_error.
+func NewPinholdCameraModel(pinholeCameraIntrinsics *transform.PinholeCameraIntrinsics,
+	distortion transform.Distorter,
+) transform.PinholeCameraModel {
+	var cameraModel transform.PinholeCameraModel
+	cameraModel.PinholeCameraIntrinsics = pinholeCameraIntrinsics
+
+	if distortion != nil {
+		cameraModel.Distortion = distortion
+	}
+	return cameraModel
 }
 
 // NewPropertiesError returns an error specific to a failure in Properties.
@@ -178,11 +190,7 @@ func NewFromSource(
 			if err != nil {
 				return nil, NewPropertiesError("source camera")
 			}
-			var cameraModel transform.PinholeCameraModel
-			cameraModel.PinholeCameraIntrinsics = props.IntrinsicParams
-			if props.DistortionParams != nil {
-				cameraModel.Distortion = props.DistortionParams
-			}
+			cameraModel := NewPinholdCameraModel(props.IntrinsicParams, props.DistortionParams)
 			actualSystem = &cameraModel
 		}
 	}

--- a/components/camera/camera.go
+++ b/components/camera/camera.go
@@ -136,7 +136,7 @@ func NewFromReader(
 				return nil, NewPropertiesError("source camera")
 			}
 
-			cameraModel := NewPinholdCameraModel(props.IntrinsicParams, props.DistortionParams)
+			cameraModel := NewPinholeCameraModel(props.IntrinsicParams, props.DistortionParams)
 			actualSystem = &cameraModel
 		}
 	}
@@ -149,11 +149,11 @@ func NewFromReader(
 	}, nil
 }
 
-// NewPinholdCameraModel creates a transform.PinholeCameraModel from
+// NewPinholeCameraModel creates a transform.PinholeCameraModel from
 // a *transform.PinholeCameraIntrinsics and a transform.Distorter.
 // If transform.Distorter is `nil`, transform.PinholeCameraModel.Distortion
 // is not set & remains nil, to prevent https://go.dev/doc/faq#nil_error.
-func NewPinholdCameraModel(pinholeCameraIntrinsics *transform.PinholeCameraIntrinsics,
+func NewPinholeCameraModel(pinholeCameraIntrinsics *transform.PinholeCameraIntrinsics,
 	distortion transform.Distorter,
 ) transform.PinholeCameraModel {
 	var cameraModel transform.PinholeCameraModel
@@ -190,7 +190,7 @@ func NewFromSource(
 			if err != nil {
 				return nil, NewPropertiesError("source camera")
 			}
-			cameraModel := NewPinholdCameraModel(props.IntrinsicParams, props.DistortionParams)
+			cameraModel := NewPinholeCameraModel(props.IntrinsicParams, props.DistortionParams)
 			actualSystem = &cameraModel
 		}
 	}

--- a/components/camera/camera.go
+++ b/components/camera/camera.go
@@ -136,7 +136,12 @@ func NewFromReader(
 				return nil, NewPropertiesError("source camera")
 			}
 
-			cameraModel := NewPinholeCameraModel(props.IntrinsicParams, props.DistortionParams)
+			var cameraModel transform.PinholeCameraModel
+			cameraModel.PinholeCameraIntrinsics = props.IntrinsicParams
+
+			if props.DistortionParams != nil {
+				cameraModel.Distortion = props.DistortionParams
+			}
 			actualSystem = &cameraModel
 		}
 	}
@@ -154,7 +159,7 @@ func NewFromReader(
 // If transform.Distorter is `nil`, transform.PinholeCameraModel.Distortion
 // is not set & remains nil, to prevent https://go.dev/doc/faq#nil_error.
 func NewPinholeCameraModel(pinholeCameraIntrinsics *transform.PinholeCameraIntrinsics,
-	distortion transform.Distorter,
+	distortion *transform.BrownConrady,
 ) transform.PinholeCameraModel {
 	var cameraModel transform.PinholeCameraModel
 	cameraModel.PinholeCameraIntrinsics = pinholeCameraIntrinsics
@@ -190,7 +195,13 @@ func NewFromSource(
 			if err != nil {
 				return nil, NewPropertiesError("source camera")
 			}
-			cameraModel := NewPinholeCameraModel(props.IntrinsicParams, props.DistortionParams)
+			var cameraModel transform.PinholeCameraModel
+			cameraModel.PinholeCameraIntrinsics = props.IntrinsicParams
+
+			if props.DistortionParams != nil {
+				cameraModel.Distortion = props.DistortionParams
+			}
+
 			actualSystem = &cameraModel
 		}
 	}

--- a/components/camera/camera.go
+++ b/components/camera/camera.go
@@ -135,7 +135,13 @@ func NewFromReader(
 			if err != nil {
 				return nil, NewPropertiesError("source camera")
 			}
-			actualSystem = &transform.PinholeCameraModel{props.IntrinsicParams, props.DistortionParams}
+
+			var cameraModel transform.PinholeCameraModel
+			cameraModel.PinholeCameraIntrinsics = props.IntrinsicParams
+			if props.DistortionParams != nil {
+				cameraModel.Distortion = props.DistortionParams
+			}
+			actualSystem = &cameraModel
 		}
 	}
 	return &videoSource{
@@ -172,7 +178,12 @@ func NewFromSource(
 			if err != nil {
 				return nil, NewPropertiesError("source camera")
 			}
-			actualSystem = &transform.PinholeCameraModel{props.IntrinsicParams, props.DistortionParams}
+			var cameraModel transform.PinholeCameraModel
+			cameraModel.PinholeCameraIntrinsics = props.IntrinsicParams
+			if props.DistortionParams != nil {
+				cameraModel.Distortion = props.DistortionParams
+			}
+			actualSystem = &cameraModel
 		}
 	}
 	return &videoSource{
@@ -254,7 +265,11 @@ func (vs *videoSource) Properties(ctx context.Context) (Properties, error) {
 	}
 	result.ImageType = vs.imageType
 	result.IntrinsicParams = vs.system.PinholeCameraIntrinsics
-	result.DistortionParams = vs.system.Distortion
+
+	if vs.system.Distortion != nil {
+		result.DistortionParams = vs.system.Distortion
+	}
+
 	return result, nil
 }
 

--- a/components/camera/camera_test.go
+++ b/components/camera/camera_test.go
@@ -330,24 +330,24 @@ func TestNewPinholeCameraModel(t *testing.T) {
 		expected transform.PinholeCameraModel
 	}{
 		{
-      phci: intrinsics,
-      d: distortion,
-      expected: transform.PinholeCameraModel{PinholeCameraIntrinsics: intrinsics, Distortion: distortion},
+			phci:     intrinsics,
+			d:        distortion,
+			expected: transform.PinholeCameraModel{PinholeCameraIntrinsics: intrinsics, Distortion: distortion},
 		},
 		{
-      phci: intrinsics,
-      d: nil,
-      expected: transform.PinholeCameraModel{PinholeCameraIntrinsics: intrinsics},
+			phci:     intrinsics,
+			d:        nil,
+			expected: transform.PinholeCameraModel{PinholeCameraIntrinsics: intrinsics},
 		},
 		{
-			phci: nil,
-      d: distortion,
-      expected: transform.PinholeCameraModel{Distortion: distortion},
+			phci:     nil,
+			d:        distortion,
+			expected: transform.PinholeCameraModel{Distortion: distortion},
 		},
 		{
-      phci: nil,
-      d: nil,
-      expected: transform.PinholeCameraModel{},
+			phci:     nil,
+			d:        nil,
+			expected: transform.PinholeCameraModel{},
 		},
 	}
 

--- a/components/camera/camera_test.go
+++ b/components/camera/camera_test.go
@@ -322,24 +322,39 @@ func TestNewPinholeCameraModel(t *testing.T) {
 		Ppx:    3.0,
 		Ppy:    4.0,
 	}
-	distortion := &transform.NoDistortion{}
+	distortion := &transform.BrownConrady{}
 
-	expected1 := transform.PinholeCameraModel{PinholeCameraIntrinsics: intrinsics, Distortion: distortion}
-	pinholeCameraModel1 := camera.NewPinholeCameraModel(intrinsics, distortion)
-	test.That(t, pinholeCameraModel1, test.ShouldResemble, expected1)
+	testCases := []struct {
+		phci     *transform.PinholeCameraIntrinsics
+		d        *transform.BrownConrady
+		expected transform.PinholeCameraModel
+	}{
+		{
+      phci: intrinsics,
+      d: distortion,
+      expected: transform.PinholeCameraModel{PinholeCameraIntrinsics: intrinsics, Distortion: distortion},
+		},
+		{
+      phci: intrinsics,
+      d: nil,
+      expected: transform.PinholeCameraModel{PinholeCameraIntrinsics: intrinsics},
+		},
+		{
+			phci: nil,
+      d: distortion,
+      expected: transform.PinholeCameraModel{Distortion: distortion},
+		},
+		{
+      phci: nil,
+      d: nil,
+      expected: transform.PinholeCameraModel{},
+		},
+	}
 
-	expected2 := transform.PinholeCameraModel{PinholeCameraIntrinsics: intrinsics}
-	pinholeCameraModel2 := camera.NewPinholeCameraModel(intrinsics, nil)
-	test.That(t, pinholeCameraModel2, test.ShouldResemble, expected2)
-
-	expected3 := transform.PinholeCameraModel{Distortion: distortion}
-	pinholeCameraModel3 := camera.NewPinholeCameraModel(nil, distortion)
-	test.That(t, pinholeCameraModel3, test.ShouldResemble, expected3)
-
-	expected4 := transform.PinholeCameraModel{}
-	pinholeCameraModel4 := camera.NewPinholeCameraModel(nil, nil)
-	test.That(t, pinholeCameraModel4, test.ShouldResemble, expected4)
-	test.That(t, pinholeCameraModel4.Distortion, test.ShouldBeNil)
+	for _, tc := range testCases {
+		pinholeCameraModel := camera.NewPinholeCameraModel(intrinsics, distortion)
+		test.That(t, pinholeCameraModel, test.ShouldResemble, tc.expected)
+	}
 }
 
 func TestNewCamera(t *testing.T) {

--- a/components/camera/camera_test.go
+++ b/components/camera/camera_test.go
@@ -324,37 +324,23 @@ func TestNewPinholeCameraModel(t *testing.T) {
 	}
 	distortion := &transform.BrownConrady{}
 
-	testCases := []struct {
-		phci     *transform.PinholeCameraIntrinsics
-		d        *transform.BrownConrady
-		expected transform.PinholeCameraModel
-	}{
-		{
-			phci:     intrinsics,
-			d:        distortion,
-			expected: transform.PinholeCameraModel{PinholeCameraIntrinsics: intrinsics, Distortion: distortion},
-		},
-		{
-			phci:     intrinsics,
-			d:        nil,
-			expected: transform.PinholeCameraModel{PinholeCameraIntrinsics: intrinsics},
-		},
-		{
-			phci:     nil,
-			d:        distortion,
-			expected: transform.PinholeCameraModel{Distortion: distortion},
-		},
-		{
-			phci:     nil,
-			d:        nil,
-			expected: transform.PinholeCameraModel{},
-		},
-	}
+	expected1 := transform.PinholeCameraModel{PinholeCameraIntrinsics: intrinsics, Distortion: distortion}
+	pinholeCameraModel1 := camera.NewPinholeCameraModel(intrinsics, distortion)
+	test.That(t, pinholeCameraModel1, test.ShouldResemble, expected1)
 
-	for _, tc := range testCases {
-		pinholeCameraModel := camera.NewPinholeCameraModel(intrinsics, distortion)
-		test.That(t, pinholeCameraModel, test.ShouldResemble, tc.expected)
-	}
+	expected2 := transform.PinholeCameraModel{PinholeCameraIntrinsics: intrinsics}
+	pinholeCameraModel2 := camera.NewPinholeCameraModel(intrinsics, nil)
+	test.That(t, pinholeCameraModel2, test.ShouldResemble, expected2)
+	test.That(t, pinholeCameraModel2.Distortion, test.ShouldBeNil)
+
+	expected3 := transform.PinholeCameraModel{Distortion: distortion}
+	pinholeCameraModel3 := camera.NewPinholeCameraModel(nil, distortion)
+	test.That(t, pinholeCameraModel3, test.ShouldResemble, expected3)
+
+	expected4 := transform.PinholeCameraModel{}
+	pinholeCameraModel4 := camera.NewPinholeCameraModel(nil, nil)
+	test.That(t, pinholeCameraModel4, test.ShouldResemble, expected4)
+	test.That(t, pinholeCameraModel4.Distortion, test.ShouldBeNil)
 }
 
 func TestNewCamera(t *testing.T) {

--- a/components/camera/camera_test.go
+++ b/components/camera/camera_test.go
@@ -313,7 +313,7 @@ func (s *simpleSourceWithPCD) NextPointCloud(ctx context.Context) (pointcloud.Po
 	return nil, nil
 }
 
-func TestNewPinholeCameraModel(t *testing.T) {
+func TestNewPinholeModelWithBrownConradyDistortion(t *testing.T) {
 	intrinsics := &transform.PinholeCameraIntrinsics{
 		Width:  10,
 		Height: 10,
@@ -325,20 +325,20 @@ func TestNewPinholeCameraModel(t *testing.T) {
 	distortion := &transform.BrownConrady{}
 
 	expected1 := transform.PinholeCameraModel{PinholeCameraIntrinsics: intrinsics, Distortion: distortion}
-	pinholeCameraModel1 := camera.NewPinholeCameraModel(intrinsics, distortion)
+	pinholeCameraModel1 := camera.NewPinholeModelWithBrownConradyDistortion(intrinsics, distortion)
 	test.That(t, pinholeCameraModel1, test.ShouldResemble, expected1)
 
 	expected2 := transform.PinholeCameraModel{PinholeCameraIntrinsics: intrinsics}
-	pinholeCameraModel2 := camera.NewPinholeCameraModel(intrinsics, nil)
+	pinholeCameraModel2 := camera.NewPinholeModelWithBrownConradyDistortion(intrinsics, nil)
 	test.That(t, pinholeCameraModel2, test.ShouldResemble, expected2)
 	test.That(t, pinholeCameraModel2.Distortion, test.ShouldBeNil)
 
 	expected3 := transform.PinholeCameraModel{Distortion: distortion}
-	pinholeCameraModel3 := camera.NewPinholeCameraModel(nil, distortion)
+	pinholeCameraModel3 := camera.NewPinholeModelWithBrownConradyDistortion(nil, distortion)
 	test.That(t, pinholeCameraModel3, test.ShouldResemble, expected3)
 
 	expected4 := transform.PinholeCameraModel{}
-	pinholeCameraModel4 := camera.NewPinholeCameraModel(nil, nil)
+	pinholeCameraModel4 := camera.NewPinholeModelWithBrownConradyDistortion(nil, nil)
 	test.That(t, pinholeCameraModel4, test.ShouldResemble, expected4)
 	test.That(t, pinholeCameraModel4.Distortion, test.ShouldBeNil)
 }

--- a/components/camera/camera_test.go
+++ b/components/camera/camera_test.go
@@ -313,6 +313,35 @@ func (s *simpleSourceWithPCD) NextPointCloud(ctx context.Context) (pointcloud.Po
 	return nil, nil
 }
 
+func TestNewPinholdCameraModel(t *testing.T) {
+	intrinsics := &transform.PinholeCameraIntrinsics{
+		Width:  10,
+		Height: 10,
+		Fx:     1.0,
+		Fy:     2.0,
+		Ppx:    3.0,
+		Ppy:    4.0,
+	}
+	distortion := &transform.NoDistortion{}
+
+	expected1 := transform.PinholeCameraModel{PinholeCameraIntrinsics: intrinsics, Distortion: distortion}
+	pinholeCameraModel1 := camera.NewPinholdCameraModel(intrinsics, distortion)
+	test.That(t, pinholeCameraModel1, test.ShouldResemble, expected1)
+
+	expected2 := transform.PinholeCameraModel{PinholeCameraIntrinsics: intrinsics}
+	pinholeCameraModel2 := camera.NewPinholdCameraModel(intrinsics, nil)
+	test.That(t, pinholeCameraModel2, test.ShouldResemble, expected2)
+
+	expected3 := transform.PinholeCameraModel{Distortion: distortion}
+	pinholeCameraModel3 := camera.NewPinholdCameraModel(nil, distortion)
+	test.That(t, pinholeCameraModel3, test.ShouldResemble, expected3)
+
+	expected4 := transform.PinholeCameraModel{}
+	pinholeCameraModel4 := camera.NewPinholdCameraModel(nil, nil)
+	test.That(t, pinholeCameraModel4, test.ShouldResemble, expected4)
+	test.That(t, pinholeCameraModel4.Distortion, test.ShouldBeNil)
+}
+
 func TestNewCamera(t *testing.T) {
 	intrinsics1 := &transform.PinholeCameraIntrinsics{Width: 128, Height: 72}
 	intrinsics2 := &transform.PinholeCameraIntrinsics{Width: 100, Height: 100}

--- a/components/camera/camera_test.go
+++ b/components/camera/camera_test.go
@@ -313,7 +313,7 @@ func (s *simpleSourceWithPCD) NextPointCloud(ctx context.Context) (pointcloud.Po
 	return nil, nil
 }
 
-func TestNewPinholdCameraModel(t *testing.T) {
+func TestNewPinholeCameraModel(t *testing.T) {
 	intrinsics := &transform.PinholeCameraIntrinsics{
 		Width:  10,
 		Height: 10,
@@ -325,19 +325,19 @@ func TestNewPinholdCameraModel(t *testing.T) {
 	distortion := &transform.NoDistortion{}
 
 	expected1 := transform.PinholeCameraModel{PinholeCameraIntrinsics: intrinsics, Distortion: distortion}
-	pinholeCameraModel1 := camera.NewPinholdCameraModel(intrinsics, distortion)
+	pinholeCameraModel1 := camera.NewPinholeCameraModel(intrinsics, distortion)
 	test.That(t, pinholeCameraModel1, test.ShouldResemble, expected1)
 
 	expected2 := transform.PinholeCameraModel{PinholeCameraIntrinsics: intrinsics}
-	pinholeCameraModel2 := camera.NewPinholdCameraModel(intrinsics, nil)
+	pinholeCameraModel2 := camera.NewPinholeCameraModel(intrinsics, nil)
 	test.That(t, pinholeCameraModel2, test.ShouldResemble, expected2)
 
 	expected3 := transform.PinholeCameraModel{Distortion: distortion}
-	pinholeCameraModel3 := camera.NewPinholdCameraModel(nil, distortion)
+	pinholeCameraModel3 := camera.NewPinholeCameraModel(nil, distortion)
 	test.That(t, pinholeCameraModel3, test.ShouldResemble, expected3)
 
 	expected4 := transform.PinholeCameraModel{}
-	pinholeCameraModel4 := camera.NewPinholdCameraModel(nil, nil)
+	pinholeCameraModel4 := camera.NewPinholeCameraModel(nil, nil)
 	test.That(t, pinholeCameraModel4, test.ShouldResemble, expected4)
 	test.That(t, pinholeCameraModel4.Distortion, test.ShouldBeNil)
 }

--- a/components/camera/camera_test.go
+++ b/components/camera/camera_test.go
@@ -341,7 +341,7 @@ func TestNewCamera(t *testing.T) {
 	cam2, err := camera.NewFromReader(
 		context.Background(),
 		videoSrc,
-		&transform.PinholeCameraModel{intrinsics1, nil},
+		&transform.PinholeCameraModel{PinholeCameraIntrinsics: intrinsics1},
 		camera.DepthStream,
 	)
 	test.That(t, err, test.ShouldBeNil)
@@ -355,7 +355,7 @@ func TestNewCamera(t *testing.T) {
 	cam3, err := camera.NewFromReader(
 		context.Background(),
 		videoSrc,
-		&transform.PinholeCameraModel{cam2props.IntrinsicParams, nil},
+		&transform.PinholeCameraModel{PinholeCameraIntrinsics: cam2props.IntrinsicParams},
 		camera.DepthStream,
 	)
 	test.That(t, err, test.ShouldBeNil)
@@ -367,7 +367,7 @@ func TestNewCamera(t *testing.T) {
 	cam4, err := camera.NewFromReader(
 		context.Background(),
 		videoSrc,
-		&transform.PinholeCameraModel{intrinsics2, nil},
+		&transform.PinholeCameraModel{PinholeCameraIntrinsics: intrinsics2},
 		camera.DepthStream,
 	)
 	test.That(t, err, test.ShouldBeNil)
@@ -384,7 +384,7 @@ func TestNewCamera(t *testing.T) {
 	cam5, err := camera.NewFromReader(
 		context.Background(),
 		videoSrc,
-		&transform.PinholeCameraModel{props.IntrinsicParams, nil},
+		&transform.PinholeCameraModel{PinholeCameraIntrinsics: props.IntrinsicParams},
 		camera.DepthStream,
 	)
 	test.That(t, err, test.ShouldBeNil)
@@ -447,7 +447,7 @@ func TestCameraWithProjector(t *testing.T) {
 	cam, err := camera.NewFromReader(
 		context.Background(),
 		videoSrc,
-		&transform.PinholeCameraModel{params1, nil},
+		&transform.PinholeCameraModel{PinholeCameraIntrinsics: params1},
 		camera.DepthStream,
 	)
 	test.That(t, err, test.ShouldBeNil)
@@ -466,7 +466,7 @@ func TestCameraWithProjector(t *testing.T) {
 	cam2, err := camera.NewFromReader(
 		context.Background(),
 		videoSrc2,
-		&transform.PinholeCameraModel{props.IntrinsicParams, nil},
+		&transform.PinholeCameraModel{PinholeCameraIntrinsics: props.IntrinsicParams},
 		camera.DepthStream,
 	)
 	test.That(t, err, test.ShouldBeNil)

--- a/components/camera/ffmpeg/ffmpeg.go
+++ b/components/camera/ffmpeg/ffmpeg.go
@@ -170,7 +170,7 @@ func NewFFMPEGCamera(ctx context.Context, attrs *AttrConfig, logger golog.Logger
 	})
 
 	ffCam.VideoReader = reader
-	return camera.NewFromReader(ctx, ffCam, &transform.PinholeCameraModel{attrs.CameraParameters, nil}, camera.ColorStream)
+	return camera.NewFromReader(ctx, ffCam, &transform.PinholeCameraModel{PinholeCameraIntrinsics: attrs.CameraParameters}, camera.ColorStream)
 }
 
 func (fc *ffmpegCamera) Close(ctx context.Context) error {

--- a/components/camera/transformpipeline/composed.go
+++ b/components/camera/transformpipeline/composed.go
@@ -48,7 +48,7 @@ func newDepthToPrettyTransform(
 	if err != nil {
 		return nil, camera.UnspecifiedStream, err
 	}
-	cameraModel := camera.NewPinholdCameraModel(props.IntrinsicParams, props.DistortionParams)
+	cameraModel := camera.NewPinholeCameraModel(props.IntrinsicParams, props.DistortionParams)
 	depthStream := gostream.NewEmbeddedVideoStream(source)
 	reader := &depthToPretty{
 		originalStream: depthStream,
@@ -125,7 +125,7 @@ func newOverlayTransform(
 	if err != nil {
 		return nil, camera.UnspecifiedStream, err
 	}
-	cameraModel := camera.NewPinholdCameraModel(props.IntrinsicParams, props.DistortionParams)
+	cameraModel := camera.NewPinholeCameraModel(props.IntrinsicParams, props.DistortionParams)
 	if attrs.IntrinsicParams != nil && attrs.IntrinsicParams.Height > 0. &&
 		attrs.IntrinsicParams.Width > 0. && attrs.IntrinsicParams.Fx > 0. && attrs.IntrinsicParams.Fy > 0. {
 		cameraModel.PinholeCameraIntrinsics = attrs.IntrinsicParams

--- a/components/camera/transformpipeline/composed.go
+++ b/components/camera/transformpipeline/composed.go
@@ -48,7 +48,12 @@ func newDepthToPrettyTransform(
 	if err != nil {
 		return nil, camera.UnspecifiedStream, err
 	}
-	cameraModel := camera.NewPinholeCameraModel(props.IntrinsicParams, props.DistortionParams)
+	var cameraModel transform.PinholeCameraModel
+	cameraModel.PinholeCameraIntrinsics = props.IntrinsicParams
+
+	if props.DistortionParams != nil {
+		cameraModel.Distortion = props.DistortionParams
+	}
 	depthStream := gostream.NewEmbeddedVideoStream(source)
 	reader := &depthToPretty{
 		originalStream: depthStream,
@@ -125,7 +130,12 @@ func newOverlayTransform(
 	if err != nil {
 		return nil, camera.UnspecifiedStream, err
 	}
-	cameraModel := camera.NewPinholeCameraModel(props.IntrinsicParams, props.DistortionParams)
+	var cameraModel transform.PinholeCameraModel
+	cameraModel.PinholeCameraIntrinsics = props.IntrinsicParams
+
+	if props.DistortionParams != nil {
+		cameraModel.Distortion = props.DistortionParams
+	}
 	if attrs.IntrinsicParams != nil && attrs.IntrinsicParams.Height > 0. &&
 		attrs.IntrinsicParams.Width > 0. && attrs.IntrinsicParams.Fx > 0. && attrs.IntrinsicParams.Fy > 0. {
 		cameraModel.PinholeCameraIntrinsics = attrs.IntrinsicParams

--- a/components/camera/transformpipeline/depth_edges.go
+++ b/components/camera/transformpipeline/depth_edges.go
@@ -38,17 +38,20 @@ func newDepthEdgesTransform(ctx context.Context, source gostream.VideoSource, am
 	if !ok {
 		return nil, camera.UnspecifiedStream, rdkutils.NewUnexpectedTypeError(attrs, conf)
 	}
-	var cameraModel *transform.PinholeCameraModel
+	var cameraModel transform.PinholeCameraModel
 	if cameraSrc, ok := source.(camera.Camera); ok {
 		props, err := cameraSrc.Properties(ctx)
 		if err != nil {
 			return nil, camera.UnspecifiedStream, err
 		}
-		cameraModel = &transform.PinholeCameraModel{props.IntrinsicParams, props.DistortionParams}
+		cameraModel.PinholeCameraIntrinsics = props.IntrinsicParams
+		if props.DistortionParams != nil {
+			cameraModel.Distortion = props.DistortionParams
+		}
 	}
 	canny := rimage.NewCannyDericheEdgeDetectorWithParameters(attrs.HiThresh, attrs.LoThresh, true)
 	videoSrc := &depthEdgesSource{gostream.NewEmbeddedVideoStream(source), canny, 3.0}
-	cam, err := camera.NewFromReader(ctx, videoSrc, cameraModel, camera.DepthStream)
+	cam, err := camera.NewFromReader(ctx, videoSrc, &cameraModel, camera.DepthStream)
 	return cam, camera.DepthStream, err
 }
 

--- a/components/camera/transformpipeline/depth_edges.go
+++ b/components/camera/transformpipeline/depth_edges.go
@@ -41,7 +41,7 @@ func newDepthEdgesTransform(ctx context.Context, source gostream.VideoSource, am
 	if err != nil {
 		return nil, camera.UnspecifiedStream, err
 	}
-	cameraModel := camera.NewPinholdCameraModel(props.IntrinsicParams, props.DistortionParams)
+	cameraModel := camera.NewPinholeCameraModel(props.IntrinsicParams, props.DistortionParams)
 	canny := rimage.NewCannyDericheEdgeDetectorWithParameters(attrs.HiThresh, attrs.LoThresh, true)
 	videoSrc := &depthEdgesSource{gostream.NewEmbeddedVideoStream(source), canny, 3.0}
 	cam, err := camera.NewFromReader(ctx, videoSrc, &cameraModel, camera.DepthStream)

--- a/components/camera/transformpipeline/depth_edges.go
+++ b/components/camera/transformpipeline/depth_edges.go
@@ -7,11 +7,11 @@ import (
 	"github.com/edaniels/gostream"
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
-	"go.viam.com/rdk/rimage/transform"
 
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/rimage"
+	"go.viam.com/rdk/rimage/transform"
 	rdkutils "go.viam.com/rdk/utils"
 )
 

--- a/components/camera/transformpipeline/detector.go
+++ b/components/camera/transformpipeline/detector.go
@@ -10,6 +10,7 @@ import (
 
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/rimage/transform"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/services/vision"
 	rdkutils "go.viam.com/rdk/utils"
@@ -47,7 +48,12 @@ func newDetectionsTransform(
 	if err != nil {
 		return nil, camera.UnspecifiedStream, err
 	}
-	cameraModel := camera.NewPinholeCameraModel(props.IntrinsicParams, props.DistortionParams)
+	var cameraModel transform.PinholeCameraModel
+	cameraModel.PinholeCameraIntrinsics = props.IntrinsicParams
+
+	if props.DistortionParams != nil {
+		cameraModel.Distortion = props.DistortionParams
+	}
 	confFilter := objectdetection.NewScoreFilter(attrs.ConfidenceThreshold)
 	detector := &detectorSource{
 		gostream.NewEmbeddedVideoStream(source),

--- a/components/camera/transformpipeline/detector.go
+++ b/components/camera/transformpipeline/detector.go
@@ -43,13 +43,16 @@ func newDetectionsTransform(
 	if !ok {
 		return nil, camera.UnspecifiedStream, rdkutils.NewUnexpectedTypeError(attrs, conf)
 	}
-	var cameraModel *transform.PinholeCameraModel
+	var cameraModel transform.PinholeCameraModel
 	if cameraSrc, ok := source.(camera.Camera); ok {
 		props, err := cameraSrc.Properties(ctx)
 		if err != nil {
 			return nil, camera.UnspecifiedStream, err
 		}
-		cameraModel = &transform.PinholeCameraModel{props.IntrinsicParams, props.DistortionParams}
+		cameraModel.PinholeCameraIntrinsics = props.IntrinsicParams
+		if props.DistortionParams != nil {
+			cameraModel.Distortion = props.DistortionParams
+		}
 	}
 	confFilter := objectdetection.NewScoreFilter(attrs.ConfidenceThreshold)
 	detector := &detectorSource{
@@ -58,7 +61,7 @@ func newDetectionsTransform(
 		confFilter,
 		r,
 	}
-	cam, err := camera.NewFromReader(ctx, detector, cameraModel, camera.ColorStream)
+	cam, err := camera.NewFromReader(ctx, detector, &cameraModel, camera.ColorStream)
 	return cam, camera.ColorStream, err
 }
 

--- a/components/camera/transformpipeline/detector.go
+++ b/components/camera/transformpipeline/detector.go
@@ -47,7 +47,7 @@ func newDetectionsTransform(
 	if err != nil {
 		return nil, camera.UnspecifiedStream, err
 	}
-	cameraModel := camera.NewPinholdCameraModel(props.IntrinsicParams, props.DistortionParams)
+	cameraModel := camera.NewPinholeCameraModel(props.IntrinsicParams, props.DistortionParams)
 	confFilter := objectdetection.NewScoreFilter(attrs.ConfidenceThreshold)
 	detector := &detectorSource{
 		gostream.NewEmbeddedVideoStream(source),

--- a/components/camera/transformpipeline/mods.go
+++ b/components/camera/transformpipeline/mods.go
@@ -9,6 +9,7 @@ import (
 	"github.com/edaniels/gostream"
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
+	"go.viam.com/rdk/rimage/transform"
 	"golang.org/x/image/draw"
 
 	"go.viam.com/rdk/components/camera"
@@ -30,7 +31,12 @@ func newRotateTransform(ctx context.Context, source gostream.VideoSource, stream
 	if err != nil {
 		return nil, camera.UnspecifiedStream, err
 	}
-	cameraModel := camera.NewPinholeCameraModel(props.IntrinsicParams, props.DistortionParams)
+	var cameraModel transform.PinholeCameraModel
+	cameraModel.PinholeCameraIntrinsics = props.IntrinsicParams
+
+	if props.DistortionParams != nil {
+		cameraModel.Distortion = props.DistortionParams
+	}
 	reader := &rotateSource{gostream.NewEmbeddedVideoStream(source), stream}
 	cam, err := camera.NewFromReader(ctx, reader, &cameraModel, stream)
 	return cam, stream, err

--- a/components/camera/transformpipeline/mods.go
+++ b/components/camera/transformpipeline/mods.go
@@ -27,16 +27,19 @@ type rotateSource struct {
 // newRotateTransform creates a new rotation transform.
 func newRotateTransform(ctx context.Context, source gostream.VideoSource, stream camera.ImageType,
 ) (gostream.VideoSource, camera.ImageType, error) {
-	var cameraModel *transform.PinholeCameraModel
+	var cameraModel transform.PinholeCameraModel
 	if cameraSrc, ok := source.(camera.Camera); ok {
 		props, err := cameraSrc.Properties(ctx)
 		if err != nil {
 			return nil, camera.UnspecifiedStream, err
 		}
-		cameraModel = &transform.PinholeCameraModel{props.IntrinsicParams, props.DistortionParams}
+		cameraModel.PinholeCameraIntrinsics = props.IntrinsicParams
+		if props.DistortionParams != nil {
+			cameraModel.Distortion = props.DistortionParams
+		}
 	}
 	reader := &rotateSource{gostream.NewEmbeddedVideoStream(source), stream}
-	cam, err := camera.NewFromReader(ctx, reader, cameraModel, stream)
+	cam, err := camera.NewFromReader(ctx, reader, &cameraModel, stream)
 	return cam, stream, err
 }
 

--- a/components/camera/transformpipeline/mods.go
+++ b/components/camera/transformpipeline/mods.go
@@ -9,12 +9,12 @@ import (
 	"github.com/edaniels/gostream"
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
-	"go.viam.com/rdk/rimage/transform"
 	"golang.org/x/image/draw"
 
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/rimage"
+	"go.viam.com/rdk/rimage/transform"
 	rdkutils "go.viam.com/rdk/utils"
 )
 

--- a/components/camera/transformpipeline/mods.go
+++ b/components/camera/transformpipeline/mods.go
@@ -30,7 +30,7 @@ func newRotateTransform(ctx context.Context, source gostream.VideoSource, stream
 	if err != nil {
 		return nil, camera.UnspecifiedStream, err
 	}
-	cameraModel := camera.NewPinholdCameraModel(props.IntrinsicParams, props.DistortionParams)
+	cameraModel := camera.NewPinholeCameraModel(props.IntrinsicParams, props.DistortionParams)
 	reader := &rotateSource{gostream.NewEmbeddedVideoStream(source), stream}
 	cam, err := camera.NewFromReader(ctx, reader, &cameraModel, stream)
 	return cam, stream, err

--- a/components/camera/transformpipeline/pipeline.go
+++ b/components/camera/transformpipeline/pipeline.go
@@ -109,10 +109,15 @@ func newTransformPipeline(
 		streamType = newStreamType
 	}
 	lastSourceStream := gostream.NewEmbeddedVideoStream(lastSource)
+	var cameraModel transform.PinholeCameraModel
+	cameraModel.PinholeCameraIntrinsics = cfg.CameraParameters
+	if cfg.DistortionParameters != nil {
+		cameraModel.Distortion = cfg.DistortionParameters
+	}
 	return camera.NewFromReader(
 		ctx,
 		transformPipeline{pipeline, lastSourceStream, cfg.CameraParameters},
-		&transform.PinholeCameraModel{cfg.CameraParameters, cfg.DistortionParameters},
+		&cameraModel,
 		streamType,
 	)
 }

--- a/components/camera/transformpipeline/pipeline.go
+++ b/components/camera/transformpipeline/pipeline.go
@@ -109,7 +109,7 @@ func newTransformPipeline(
 		streamType = newStreamType
 	}
 	lastSourceStream := gostream.NewEmbeddedVideoStream(lastSource)
-	cameraModel := camera.NewPinholdCameraModel(cfg.CameraParameters, cfg.DistortionParameters)
+	cameraModel := camera.NewPinholeCameraModel(cfg.CameraParameters, cfg.DistortionParameters)
 	return camera.NewFromReader(
 		ctx,
 		transformPipeline{pipeline, lastSourceStream, cfg.CameraParameters},

--- a/components/camera/transformpipeline/pipeline.go
+++ b/components/camera/transformpipeline/pipeline.go
@@ -109,7 +109,7 @@ func newTransformPipeline(
 		streamType = newStreamType
 	}
 	lastSourceStream := gostream.NewEmbeddedVideoStream(lastSource)
-	cameraModel := camera.NewPinholeCameraModel(cfg.CameraParameters, cfg.DistortionParameters)
+	cameraModel := camera.NewPinholeModelWithBrownConradyDistortion(cfg.CameraParameters, cfg.DistortionParameters)
 	return camera.NewFromReader(
 		ctx,
 		transformPipeline{pipeline, lastSourceStream, cfg.CameraParameters},

--- a/components/camera/transformpipeline/pipeline.go
+++ b/components/camera/transformpipeline/pipeline.go
@@ -109,11 +109,7 @@ func newTransformPipeline(
 		streamType = newStreamType
 	}
 	lastSourceStream := gostream.NewEmbeddedVideoStream(lastSource)
-	var cameraModel transform.PinholeCameraModel
-	cameraModel.PinholeCameraIntrinsics = cfg.CameraParameters
-	if cfg.DistortionParameters != nil {
-		cameraModel.Distortion = cfg.DistortionParameters
-	}
+	cameraModel := camera.NewPinholdCameraModel(cfg.CameraParameters, cfg.DistortionParameters)
 	return camera.NewFromReader(
 		ctx,
 		transformPipeline{pipeline, lastSourceStream, cfg.CameraParameters},

--- a/components/camera/transformpipeline/preprocessing.go
+++ b/components/camera/transformpipeline/preprocessing.go
@@ -7,6 +7,7 @@ import (
 	"github.com/edaniels/gostream"
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
+	"go.viam.com/rdk/rimage/transform"
 
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/rimage"
@@ -25,7 +26,12 @@ func newDepthPreprocessTransform(ctx context.Context, source gostream.VideoSourc
 	if err != nil {
 		return nil, camera.UnspecifiedStream, err
 	}
-	cameraModel := camera.NewPinholeCameraModel(props.IntrinsicParams, props.DistortionParams)
+	var cameraModel transform.PinholeCameraModel
+	cameraModel.PinholeCameraIntrinsics = props.IntrinsicParams
+
+	if props.DistortionParams != nil {
+		cameraModel.Distortion = props.DistortionParams
+	}
 	cam, err := camera.NewFromReader(ctx, reader, &cameraModel, camera.DepthStream)
 	return cam, camera.DepthStream, err
 }

--- a/components/camera/transformpipeline/preprocessing.go
+++ b/components/camera/transformpipeline/preprocessing.go
@@ -7,10 +7,10 @@ import (
 	"github.com/edaniels/gostream"
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
-	"go.viam.com/rdk/rimage/transform"
 
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/rimage"
+	"go.viam.com/rdk/rimage/transform"
 )
 
 // preprocessDepthTransform applies pre-processing functions to depth maps in order to smooth edges and fill holes.

--- a/components/camera/transformpipeline/preprocessing.go
+++ b/components/camera/transformpipeline/preprocessing.go
@@ -25,7 +25,7 @@ func newDepthPreprocessTransform(ctx context.Context, source gostream.VideoSourc
 	if err != nil {
 		return nil, camera.UnspecifiedStream, err
 	}
-	cameraModel := camera.NewPinholdCameraModel(props.IntrinsicParams, props.DistortionParams)
+	cameraModel := camera.NewPinholeCameraModel(props.IntrinsicParams, props.DistortionParams)
 	cam, err := camera.NewFromReader(ctx, reader, &cameraModel, camera.DepthStream)
 	return cam, camera.DepthStream, err
 }

--- a/components/camera/transformpipeline/preprocessing.go
+++ b/components/camera/transformpipeline/preprocessing.go
@@ -21,15 +21,18 @@ type preprocessDepthTransform struct {
 func newDepthPreprocessTransform(ctx context.Context, source gostream.VideoSource,
 ) (gostream.VideoSource, camera.ImageType, error) {
 	reader := &preprocessDepthTransform{gostream.NewEmbeddedVideoStream(source)}
-	var cameraModel *transform.PinholeCameraModel
+	var cameraModel transform.PinholeCameraModel
 	if cameraSrc, ok := source.(camera.Camera); ok {
 		props, err := cameraSrc.Properties(ctx)
 		if err != nil {
 			return nil, camera.UnspecifiedStream, err
 		}
-		cameraModel = &transform.PinholeCameraModel{props.IntrinsicParams, props.DistortionParams}
+		cameraModel.PinholeCameraIntrinsics = props.IntrinsicParams
+		if props.DistortionParams != nil {
+			cameraModel.Distortion = props.DistortionParams
+		}
 	}
-	cam, err := camera.NewFromReader(ctx, reader, cameraModel, camera.DepthStream)
+	cam, err := camera.NewFromReader(ctx, reader, &cameraModel, camera.DepthStream)
 	return cam, camera.DepthStream, err
 }
 

--- a/components/camera/transformpipeline/undistort.go
+++ b/components/camera/transformpipeline/undistort.go
@@ -42,13 +42,17 @@ func newUndistortTransform(
 	if attrs.CameraParams == nil {
 		return nil, camera.UnspecifiedStream, errors.Wrapf(transform.ErrNoIntrinsics, "cannot create undistort transform")
 	}
-	cameraModel := &transform.PinholeCameraModel{attrs.CameraParams, attrs.DistortionParams}
+	var cameraModel transform.PinholeCameraModel
+	cameraModel.PinholeCameraIntrinsics = attrs.CameraParams
+	if attrs.DistortionParams != nil {
+		cameraModel.Distortion = attrs.DistortionParams
+	}
 	reader := &undistortSource{
 		gostream.NewEmbeddedVideoStream(source),
 		stream,
-		cameraModel,
+		&cameraModel,
 	}
-	cam, err := camera.NewFromReader(ctx, reader, cameraModel, stream)
+	cam, err := camera.NewFromReader(ctx, reader, &cameraModel, stream)
 	return cam, stream, err
 }
 

--- a/components/camera/transformpipeline/undistort.go
+++ b/components/camera/transformpipeline/undistort.go
@@ -42,11 +42,7 @@ func newUndistortTransform(
 	if attrs.CameraParams == nil {
 		return nil, camera.UnspecifiedStream, errors.Wrapf(transform.ErrNoIntrinsics, "cannot create undistort transform")
 	}
-	var cameraModel transform.PinholeCameraModel
-	cameraModel.PinholeCameraIntrinsics = attrs.CameraParams
-	if attrs.DistortionParams != nil {
-		cameraModel.Distortion = attrs.DistortionParams
-	}
+	cameraModel := camera.NewPinholeCameraModel(attrs.CameraParams, attrs.DistortionParams)
 	reader := &undistortSource{
 		gostream.NewEmbeddedVideoStream(source),
 		stream,

--- a/components/camera/transformpipeline/undistort.go
+++ b/components/camera/transformpipeline/undistort.go
@@ -42,7 +42,7 @@ func newUndistortTransform(
 	if attrs.CameraParams == nil {
 		return nil, camera.UnspecifiedStream, errors.Wrapf(transform.ErrNoIntrinsics, "cannot create undistort transform")
 	}
-	cameraModel := camera.NewPinholeCameraModel(attrs.CameraParams, attrs.DistortionParams)
+	cameraModel := camera.NewPinholeModelWithBrownConradyDistortion(attrs.CameraParams, attrs.DistortionParams)
 	reader := &undistortSource{
 		gostream.NewEmbeddedVideoStream(source),
 		stream,

--- a/components/camera/videosource/join_pointcloud.go
+++ b/components/camera/videosource/join_pointcloud.go
@@ -157,7 +157,7 @@ func newJoinPointCloudSource(ctx context.Context, r robot.Robot, l golog.Logger,
 			}
 			intrinsicParams = props.IntrinsicParams
 		}
-		return camera.NewFromReader(ctx, joinSource, &transform.PinholeCameraModel{intrinsicParams, nil}, camera.ColorStream)
+		return camera.NewFromReader(ctx, joinSource, &transform.PinholeCameraModel{PinholeCameraIntrinsics: intrinsicParams}, camera.ColorStream)
 	}
 	return camera.NewFromReader(ctx, joinSource, nil, camera.ColorStream)
 }

--- a/components/camera/videosource/server.go
+++ b/components/camera/videosource/server.go
@@ -118,7 +118,7 @@ func newDualServerSource(ctx context.Context, cfg *dualServerAttrs) (camera.Came
 		Intrinsics: cfg.CameraParameters,
 		Stream:     camera.ImageType(cfg.Stream),
 	}
-	cameraModel := camera.NewPinholeCameraModel(cfg.CameraParameters, cfg.DistortionParameters)
+	cameraModel := camera.NewPinholeModelWithBrownConradyDistortion(cfg.CameraParameters, cfg.DistortionParameters)
 	return camera.NewFromReader(
 		ctx,
 		videoSrc,
@@ -255,7 +255,7 @@ func NewServerSource(ctx context.Context, cfg *ServerAttrs, logger golog.Logger)
 		stream:     camera.ImageType(cfg.Stream),
 		Intrinsics: cfg.CameraParameters,
 	}
-	cameraModel := camera.NewPinholeCameraModel(cfg.CameraParameters, cfg.DistortionParameters)
+	cameraModel := camera.NewPinholeModelWithBrownConradyDistortion(cfg.CameraParameters, cfg.DistortionParameters)
 	return camera.NewFromReader(
 		ctx,
 		videoSrc,

--- a/components/camera/videosource/server.go
+++ b/components/camera/videosource/server.go
@@ -118,11 +118,7 @@ func newDualServerSource(ctx context.Context, cfg *dualServerAttrs) (camera.Came
 		Intrinsics: cfg.CameraParameters,
 		Stream:     camera.ImageType(cfg.Stream),
 	}
-	var cameraModel transform.PinholeCameraModel
-	cameraModel.PinholeCameraIntrinsics = cfg.CameraParameters
-	if cfg.DistortionParameters != nil {
-		cameraModel.Distortion = cfg.DistortionParameters
-	}
+	cameraModel := camera.NewPinholdCameraModel(cfg.CameraParameters, cfg.DistortionParameters)
 	return camera.NewFromReader(
 		ctx,
 		videoSrc,
@@ -259,11 +255,7 @@ func NewServerSource(ctx context.Context, cfg *ServerAttrs, logger golog.Logger)
 		stream:     camera.ImageType(cfg.Stream),
 		Intrinsics: cfg.CameraParameters,
 	}
-	var cameraModel transform.PinholeCameraModel
-	cameraModel.PinholeCameraIntrinsics = cfg.CameraParameters
-	if cfg.DistortionParameters != nil {
-		cameraModel.Distortion = cfg.DistortionParameters
-	}
+	cameraModel := camera.NewPinholdCameraModel(cfg.CameraParameters, cfg.DistortionParameters)
 	return camera.NewFromReader(
 		ctx,
 		videoSrc,

--- a/components/camera/videosource/server.go
+++ b/components/camera/videosource/server.go
@@ -118,10 +118,15 @@ func newDualServerSource(ctx context.Context, cfg *dualServerAttrs) (camera.Came
 		Intrinsics: cfg.CameraParameters,
 		Stream:     camera.ImageType(cfg.Stream),
 	}
+	var cameraModel transform.PinholeCameraModel
+	cameraModel.PinholeCameraIntrinsics = cfg.CameraParameters
+	if cfg.DistortionParameters != nil {
+		cameraModel.Distortion = cfg.DistortionParameters
+	}
 	return camera.NewFromReader(
 		ctx,
 		videoSrc,
-		&transform.PinholeCameraModel{cfg.CameraParameters, cfg.DistortionParameters},
+		&cameraModel,
 		videoSrc.Stream,
 	)
 }
@@ -254,10 +259,15 @@ func NewServerSource(ctx context.Context, cfg *ServerAttrs, logger golog.Logger)
 		stream:     camera.ImageType(cfg.Stream),
 		Intrinsics: cfg.CameraParameters,
 	}
+	var cameraModel transform.PinholeCameraModel
+	cameraModel.PinholeCameraIntrinsics = cfg.CameraParameters
+	if cfg.DistortionParameters != nil {
+		cameraModel.Distortion = cfg.DistortionParameters
+	}
 	return camera.NewFromReader(
 		ctx,
 		videoSrc,
-		&transform.PinholeCameraModel{cfg.CameraParameters, cfg.DistortionParameters},
+		&cameraModel,
 		videoSrc.stream,
 	)
 }

--- a/components/camera/videosource/server.go
+++ b/components/camera/videosource/server.go
@@ -118,7 +118,7 @@ func newDualServerSource(ctx context.Context, cfg *dualServerAttrs) (camera.Came
 		Intrinsics: cfg.CameraParameters,
 		Stream:     camera.ImageType(cfg.Stream),
 	}
-	cameraModel := camera.NewPinholdCameraModel(cfg.CameraParameters, cfg.DistortionParameters)
+	cameraModel := camera.NewPinholeCameraModel(cfg.CameraParameters, cfg.DistortionParameters)
 	return camera.NewFromReader(
 		ctx,
 		videoSrc,
@@ -255,7 +255,7 @@ func NewServerSource(ctx context.Context, cfg *ServerAttrs, logger golog.Logger)
 		stream:     camera.ImageType(cfg.Stream),
 		Intrinsics: cfg.CameraParameters,
 	}
-	cameraModel := camera.NewPinholdCameraModel(cfg.CameraParameters, cfg.DistortionParameters)
+	cameraModel := camera.NewPinholeCameraModel(cfg.CameraParameters, cfg.DistortionParameters)
 	return camera.NewFromReader(
 		ctx,
 		videoSrc,

--- a/components/camera/videosource/static.go
+++ b/components/camera/videosource/static.go
@@ -34,7 +34,7 @@ func init() {
 			if attrs.Color == "" {
 				imgType = camera.DepthStream
 			}
-			cameraModel := camera.NewPinholdCameraModel(attrs.CameraParameters, attrs.DistortionParameters)
+			cameraModel := camera.NewPinholeCameraModel(attrs.CameraParameters, attrs.DistortionParameters)
 			return camera.NewFromReader(
 				ctx,
 				videoSrc,

--- a/components/camera/videosource/static.go
+++ b/components/camera/videosource/static.go
@@ -34,10 +34,15 @@ func init() {
 			if attrs.Color == "" {
 				imgType = camera.DepthStream
 			}
+			var cameraModel transform.PinholeCameraModel
+			cameraModel.PinholeCameraIntrinsics = attrs.CameraParameters
+			if attrs.DistortionParameters != nil {
+				cameraModel.Distortion = attrs.DistortionParameters
+			}
 			return camera.NewFromReader(
 				ctx,
 				videoSrc,
-				&transform.PinholeCameraModel{attrs.CameraParameters, attrs.DistortionParameters},
+				&cameraModel,
 				imgType,
 			)
 		}})

--- a/components/camera/videosource/static.go
+++ b/components/camera/videosource/static.go
@@ -34,11 +34,7 @@ func init() {
 			if attrs.Color == "" {
 				imgType = camera.DepthStream
 			}
-			var cameraModel transform.PinholeCameraModel
-			cameraModel.PinholeCameraIntrinsics = attrs.CameraParameters
-			if attrs.DistortionParameters != nil {
-				cameraModel.Distortion = attrs.DistortionParameters
-			}
+			cameraModel := camera.NewPinholdCameraModel(attrs.CameraParameters, attrs.DistortionParameters)
 			return camera.NewFromReader(
 				ctx,
 				videoSrc,

--- a/components/camera/videosource/static.go
+++ b/components/camera/videosource/static.go
@@ -34,7 +34,7 @@ func init() {
 			if attrs.Color == "" {
 				imgType = camera.DepthStream
 			}
-			cameraModel := camera.NewPinholeCameraModel(attrs.CameraParameters, attrs.DistortionParameters)
+			cameraModel := camera.NewPinholeModelWithBrownConradyDistortion(attrs.CameraParameters, attrs.DistortionParameters)
 			return camera.NewFromReader(
 				ctx,
 				videoSrc,

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -371,7 +371,7 @@ func makeCameraFromSource(ctx context.Context,
 	if source == nil {
 		return nil, errors.New("media source not found")
 	}
-	cameraModel := camera.NewPinholeCameraModel(attrs.CameraParameters, attrs.DistortionParameters)
+	cameraModel := camera.NewPinholeModelWithBrownConradyDistortion(attrs.CameraParameters, attrs.DistortionParameters)
 	return camera.NewFromSource(
 		ctx,
 		source,

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -371,11 +371,15 @@ func makeCameraFromSource(ctx context.Context,
 	if source == nil {
 		return nil, errors.New("media source not found")
 	}
-
+	var cameraModel transform.PinholeCameraModel
+	cameraModel.PinholeCameraIntrinsics = attrs.CameraParameters
+	if attrs.DistortionParameters != nil {
+		cameraModel.Distortion = attrs.DistortionParameters
+	}
 	return camera.NewFromSource(
 		ctx,
 		source,
-		&transform.PinholeCameraModel{attrs.CameraParameters, attrs.DistortionParameters},
+		&cameraModel,
 		camera.ColorStream,
 	)
 }

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -371,11 +371,7 @@ func makeCameraFromSource(ctx context.Context,
 	if source == nil {
 		return nil, errors.New("media source not found")
 	}
-	var cameraModel transform.PinholeCameraModel
-	cameraModel.PinholeCameraIntrinsics = attrs.CameraParameters
-	if attrs.DistortionParameters != nil {
-		cameraModel.Distortion = attrs.DistortionParameters
-	}
+	cameraModel := camera.NewPinholdCameraModel(attrs.CameraParameters, attrs.DistortionParameters)
 	return camera.NewFromSource(
 		ctx,
 		source,

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -371,7 +371,7 @@ func makeCameraFromSource(ctx context.Context,
 	if source == nil {
 		return nil, errors.New("media source not found")
 	}
-	cameraModel := camera.NewPinholdCameraModel(attrs.CameraParameters, attrs.DistortionParameters)
+	cameraModel := camera.NewPinholeCameraModel(attrs.CameraParameters, attrs.DistortionParameters)
 	return camera.NewFromSource(
 		ctx,
 		source,

--- a/rimage/transform/pinhole_camera_parameters_test.go
+++ b/rimage/transform/pinhole_camera_parameters_test.go
@@ -102,7 +102,7 @@ func TestUndistortImage(t *testing.T) {
 		TangentialP2: -0.00116427,
 		RadialK3:     -0.06468911,
 	}
-	pinhole800 := &PinholeCameraModel{params800, distortion800}
+	pinhole800 := &PinholeCameraModel{PinholeCameraIntrinsics: params800, Distortion: distortion800}
 	params1280 := &PinholeCameraIntrinsics{
 		Width:  1280,
 		Height: 720,
@@ -118,7 +118,7 @@ func TestUndistortImage(t *testing.T) {
 		TangentialP2: -2.65675762e-04,
 		RadialK3:     -6.51379008e-02,
 	}
-	pinhole1280 := &PinholeCameraModel{params1280, distortion1280}
+	pinhole1280 := &PinholeCameraModel{PinholeCameraIntrinsics: params1280, Distortion: distortion1280}
 	// nil input
 	_, err := pinhole800.UndistortImage(nil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "input image is nil")
@@ -161,7 +161,10 @@ func TestUndistortDepthMap(t *testing.T) {
 		TangentialP2: 0.,
 		RadialK3:     0.,
 	}
-	pinhole := &PinholeCameraModel{params, distortion}
+	var cameraModel PinholeCameraModel
+	cameraModel.PinholeCameraIntrinsics = params
+	cameraModel.Distortion = distortion
+	pinhole := &cameraModel
 	// nil input
 	_, err := pinhole.UndistortDepthMap(nil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "input DepthMap is nil")

--- a/services/slam/builtin/builtin.go
+++ b/services/slam/builtin/builtin.go
@@ -357,8 +357,8 @@ func configureCameras(ctx context.Context, svcConfig *AttrConfig, deps registry.
 				return "", nil, errors.Wrap(err, "error getting camera properties for slam service")
 			}
 
-			brownConrady, ok := props.DistortionParams.(*transform.BrownConrady)
-			if !ok || brownConrady == nil {
+			_, ok = props.DistortionParams.(*transform.BrownConrady)
+			if !ok {
 				return "", nil, errors.New("error getting distortion_parameters for slam service, only BrownConrady distortion parameters are supported")
 			}
 		}

--- a/services/slam/builtin/orbslam_yaml.go
+++ b/services/slam/builtin/orbslam_yaml.go
@@ -139,11 +139,7 @@ func (slamSvc *builtIn) orbGenYAML(ctx context.Context, cam camera.Camera) error
 		return transform.NewNoIntrinsicsError("Distortion parameters do not exist")
 	}
 	// create orbslam struct to generate yaml file with
-	var cameraModel transform.PinholeCameraModel
-	cameraModel.PinholeCameraIntrinsics = props.IntrinsicParams
-	if props.DistortionParams != nil {
-		cameraModel.Distortion = props.DistortionParams
-	}
+	cameraModel := camera.NewPinholdCameraModel(props.IntrinsicParams, props.DistortionParams)
 	orbslam, err := slamSvc.orbCamMaker(&cameraModel)
 	if err != nil {
 		return err

--- a/services/slam/builtin/orbslam_yaml.go
+++ b/services/slam/builtin/orbslam_yaml.go
@@ -139,7 +139,7 @@ func (slamSvc *builtIn) orbGenYAML(ctx context.Context, cam camera.Camera) error
 		return transform.NewNoIntrinsicsError("Distortion parameters do not exist")
 	}
 	// create orbslam struct to generate yaml file with
-	cameraModel := camera.NewPinholdCameraModel(props.IntrinsicParams, props.DistortionParams)
+	cameraModel := camera.NewPinholeCameraModel(props.IntrinsicParams, props.DistortionParams)
 	orbslam, err := slamSvc.orbCamMaker(&cameraModel)
 	if err != nil {
 		return err

--- a/services/slam/builtin/orbslam_yaml.go
+++ b/services/slam/builtin/orbslam_yaml.go
@@ -139,7 +139,12 @@ func (slamSvc *builtIn) orbGenYAML(ctx context.Context, cam camera.Camera) error
 		return transform.NewNoIntrinsicsError("Distortion parameters do not exist")
 	}
 	// create orbslam struct to generate yaml file with
-	cameraModel := camera.NewPinholeCameraModel(props.IntrinsicParams, props.DistortionParams)
+	var cameraModel transform.PinholeCameraModel
+	cameraModel.PinholeCameraIntrinsics = props.IntrinsicParams
+
+	if props.DistortionParams != nil {
+		cameraModel.Distortion = props.DistortionParams
+	}
 	orbslam, err := slamSvc.orbCamMaker(&cameraModel)
 	if err != nil {
 		return err

--- a/services/slam/builtin/orbslam_yaml.go
+++ b/services/slam/builtin/orbslam_yaml.go
@@ -139,10 +139,12 @@ func (slamSvc *builtIn) orbGenYAML(ctx context.Context, cam camera.Camera) error
 		return transform.NewNoIntrinsicsError("Distortion parameters do not exist")
 	}
 	// create orbslam struct to generate yaml file with
-	orbslam, err := slamSvc.orbCamMaker(&transform.PinholeCameraModel{
-		PinholeCameraIntrinsics: props.IntrinsicParams,
-		Distortion:              props.DistortionParams},
-	)
+	var cameraModel transform.PinholeCameraModel
+	cameraModel.PinholeCameraIntrinsics = props.IntrinsicParams
+	if props.DistortionParams != nil {
+		cameraModel.Distortion = props.DistortionParams
+	}
+	orbslam, err := slamSvc.orbCamMaker(&cameraModel)
 	if err != nil {
 		return err
 	}

--- a/vision/segmentation/color_objects_test.go
+++ b/vision/segmentation/color_objects_test.go
@@ -23,11 +23,11 @@ func TestColorObjects(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	params, err := transform.NewDepthColorIntrinsicsExtrinsicsFromJSONFile(intel515ParamsPath)
 	test.That(t, err, test.ShouldBeNil)
-	c := &videosource.StaticSource{img, dm, &params.ColorCamera}
+	c := &videosource.StaticSource{ColorImg: img, DepthImg: dm, Proj: &params.ColorCamera}
 	cam, err := camera.NewFromReader(
 		context.Background(),
 		c,
-		&transform.PinholeCameraModel{&params.ColorCamera, nil},
+		&transform.PinholeCameraModel{PinholeCameraIntrinsics: &params.ColorCamera},
 		camera.DepthStream,
 	)
 	test.That(t, err, test.ShouldBeNil)


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-1271

Fixes issue with original [fix](https://github.com/viamrobotics/rdk/commit/24aaa2572adf385b1739e0a48511b4aa7622757e) which  @edaniels raised to me was only band-aiding over a deeper issue which turned out to occur multiple places in RDK.

The problem is that `transform.PinholeCameraModel`'s `Distortion` field is an interface type, which means that if it is set to a `nil` value it results in the type being `*transform.BrownConrady)(nil)` but the value being `*transform.BrownConrady`, of which `nil` is a valid value. This means that for any users of `transform.PinholeCameraModel.Distortion`, if this was left unaddressed, users would need to write:

```golang
distortion, ok := camaraModel.Distortion.(*transform.BrownConrady)
if !ok {
// 
}

if distortion == nil {
// this happens if camaraModel.Distortion was set to nil b/c it is treated as a nil interface
}
```

which is not reasonable to expect from users.

The solution is NOT for users of `transform.PinholeCameraModel` values to need to constantly check whether or not this confusing condition has occurred, but rather for creators of instances of that type to guarantee that they are not setting the interface type struct member to a nil value (as it causes this confusing behavior). Simply allowing `transform.PinholeCameraModel.Distortion` to be the zero value whenever the proposed `Distortion` value is `nil` solves the problem. 

This PR:
1. Fixes all instantiations of `transform.PinholeCameraModel` to check the proposed `Distortion` value is not nil before setting it. 
2. Fixes the common compiler warning for `transform.PinholeCameraModel` instantiation where the struct was created from untagged struct members.
3. Removes the unnecessary check that the value of the `BrownConrady` type assertion  is not nil

Durring review:
 - First commit rolls back the bandaid fix & fixes the bug for the 
 - Second commit changes all other cases where a 