### PR TITLE
[RSDK-1192] Multi camera robustness to order of plug/unplug

### DIFF
--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -29,6 +29,7 @@ import (
 
 var model = resource.NewDefaultModel("webcam")
 
+// camRegistry maps each camera's video path to it's label.
 var camRegistry = make(map[string]string, 10)
 
 func init() {
@@ -292,22 +293,14 @@ func NewWebcamSource(ctx context.Context, attrs *WebcamAttrs, logger golog.Logge
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot find video source for camera")
 	}
-
-	logger.Infof("THE ATTRIBUTE PATH IS: %v", attrs.Path)
-
 	label := getLabelFromCamera(utils.UnwrapProxy(cam).(camera.Camera), logger)
-	logger.Infof("THE LABEL IS: %v", label)
 
+	// grab this camera's label from the registry if it's there
 	foundCamLabel, ok := camRegistry[attrs.Path]
-	if !ok { // not in the map
+	if !ok {
 		camRegistry[attrs.Path] = label
-	} else { // is in the map
+	} else {
 		label = foundCamLabel
-	}
-
-	//label := attrs.Path
-	if label == "" {
-		label = getLabelFromCamera(utils.UnwrapProxy(cam).(camera.Camera), logger)
 	}
 
 	const wait = 500 * time.Millisecond

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -29,6 +29,8 @@ import (
 
 var model = resource.NewDefaultModel("webcam")
 
+var camRegistry = make(map[string]string, 10)
+
 func init() {
 	registry.RegisterComponent(
 		camera.Subtype,
@@ -291,7 +293,19 @@ func NewWebcamSource(ctx context.Context, attrs *WebcamAttrs, logger golog.Logge
 		return nil, errors.Wrap(err, "cannot find video source for camera")
 	}
 
-	label := attrs.Path
+	logger.Infof("THE ATTRIBUTE PATH IS: %v", attrs.Path)
+
+	label := getLabelFromCamera(utils.UnwrapProxy(cam).(camera.Camera), logger)
+	logger.Infof("THE LABEL IS: %v", label)
+
+	foundCamLabel, ok := camRegistry[attrs.Path]
+	if !ok { // not in the map
+		camRegistry[attrs.Path] = label
+	} else { // is in the map
+		label = foundCamLabel
+	}
+
+	//label := attrs.Path
 	if label == "" {
 		label = getLabelFromCamera(utils.UnwrapProxy(cam).(camera.Camera), logger)
 	}


### PR DESCRIPTION
The solution here was to add a camRegistry (map) that will remember the label (by-path USB string) and the corresponding video path. This way, regardless of disconnections and the order of reconnection, AS LONG AS YOU USE THE SAME USB PORT, we will be able to reconnect to your same camera. This is a draft right now because I need to do cleaning and linting but I'm going home for now.