### PR TITLE
Migrate FindRobots -> ListRobots

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -388,7 +388,7 @@ func (c *AppClient) ListRobots(orgStr, locStr string) ([]*apppb.Robot, error) {
 	if err := c.selectLocation(locStr); err != nil {
 		return nil, err
 	}
-	resp, err := c.client.FindRobots(c.c.Context, &apppb.FindRobotsRequest{
+	resp, err := c.client.ListRobots(c.c.Context, &apppb.ListRobotsRequest{
 		LocationId: c.selectedLoc.Id,
 	})
 	if err != nil {


### PR DESCRIPTION
We've renamed FindRobots to ListRobots in API to match the naming conventions we want. This PR updates RDK to point to the new ListRobots API with no other changes.

This isn't breaking RDK now. Both APIs exist. I'd like to delete FindRobots as soon as this is released in the RDK and robots are using this RDK version. Its also just a CLI change and not a part of Viam Server.