### PR TITLE
Rsdk-1632 : add attributes to fake camera to change resolution

### DIFF
--- a/.artifact/tree.json
+++ b/.artifact/tree.json
@@ -2905,6 +2905,16 @@
           "size": 13914
         }
       },
+      "rtsp": {
+        "earth_480_video.mp4": {
+          "hash": "e67d8c48b673bd5c3b80ab91aec4a42f",
+          "size": 1570024
+        },
+        "rtsp-simple-server.yml": {
+          "hash": "c4c85f758f48bb6f54fd5735f4003bc7",
+          "size": 14348
+        }
+      },
       "transformpipeline": {
         "vision.json": {
           "hash": "6d5137a207e8fa9a5638314db62b30ff",
@@ -3801,6 +3811,22 @@
     "board2_gray_small.png": {
       "hash": "362b8abe03fa4ad0a5d3cfc2e2deedfd",
       "size": 10756
+    },
+    "board2_low.png": {
+      "hash": "b78113154014a7862046fd872e36fae4",
+      "size": 106124
+    },
+    "board2_low_gray.png": {
+      "hash": "c293ee9fd19505e490d86e31e7033d52",
+      "size": 28457
+    },
+    "board2_med.png": {
+      "hash": "ea2e2567aa8792896b838a2202c21b0b",
+      "size": 356347
+    },
+    "board2_med_gray.png": {
+      "hash": "e60df17823598a37e4f2bdce55277cdb",
+      "size": 68198
     },
     "board2_small.png": {
       "hash": "234d75ca63901fc11677239760fb33e9",

--- a/.artifact/tree.json
+++ b/.artifact/tree.json
@@ -3825,8 +3825,8 @@
       "size": 356347
     },
     "board2_med_gray.png": {
-      "hash": "e60df17823598a37e4f2bdce55277cdb",
-      "size": 68198
+      "hash": "9b89043ea5edd98835cb0ac6e48c5928",
+      "size": 68227
     },
     "board2_small.png": {
       "hash": "234d75ca63901fc11677239760fb33e9",

--- a/.artifact/tree.json
+++ b/.artifact/tree.json
@@ -2905,16 +2905,6 @@
           "size": 13914
         }
       },
-      "rtsp": {
-        "earth_480_video.mp4": {
-          "hash": "e67d8c48b673bd5c3b80ab91aec4a42f",
-          "size": 1570024
-        },
-        "rtsp-simple-server.yml": {
-          "hash": "c4c85f758f48bb6f54fd5735f4003bc7",
-          "size": 14348
-        }
-      },
       "transformpipeline": {
         "vision.json": {
           "hash": "6d5137a207e8fa9a5638314db62b30ff",
@@ -3811,22 +3801,6 @@
     "board2_gray_small.png": {
       "hash": "362b8abe03fa4ad0a5d3cfc2e2deedfd",
       "size": 10756
-    },
-    "board2_low.png": {
-      "hash": "b78113154014a7862046fd872e36fae4",
-      "size": 106124
-    },
-    "board2_low_gray.png": {
-      "hash": "c293ee9fd19505e490d86e31e7033d52",
-      "size": 28457
-    },
-    "board2_med.png": {
-      "hash": "ea2e2567aa8792896b838a2202c21b0b",
-      "size": 356347
-    },
-    "board2_med_gray.png": {
-      "hash": "9b89043ea5edd98835cb0ac6e48c5928",
-      "size": 68227
     },
     "board2_small.png": {
       "hash": "234d75ca63901fc11677239760fb33e9",

--- a/components/camera/fake/camera.go
+++ b/components/camera/fake/camera.go
@@ -78,8 +78,8 @@ func init() {
 
 // Attrs are the attributes of the fake camera config.
 type Attrs struct {
-	Width  int `json:"width"`
-	Height int `json:"height"`
+	Width  int `json:"width,omitempty"`
+	Height int `json:"height,omtiempty"`
 }
 
 var fakeIntrinsics = &transform.PinholeCameraIntrinsics{

--- a/components/camera/fake/camera.go
+++ b/components/camera/fake/camera.go
@@ -79,7 +79,7 @@ func init() {
 // Attrs are the attributes of the fake camera config.
 type Attrs struct {
 	Width  int `json:"width,omitempty"`
-	Height int `json:"height,omtiempty"`
+	Height int `json:"height,omitempty"`
 }
 
 var fakeIntrinsics = &transform.PinholeCameraIntrinsics{

--- a/components/camera/fake/camera.go
+++ b/components/camera/fake/camera.go
@@ -24,9 +24,8 @@ import (
 var model = resource.NewDefaultModel("fake")
 
 const (
-	high   = "high"
-	medium = "medium"
-	low    = "low"
+	initialWidth  = 1280
+	initialHeight = 720
 )
 
 func init() {
@@ -43,11 +42,19 @@ func init() {
 			if !ok {
 				return nil, utils.NewUnexpectedTypeError(attrs, cfg.ConvertedAttributes)
 			}
-			resModel, err := fakeModel(attrs.Resolution)
-			if err != nil {
-				return nil, err
+			if attrs.Height%2 != 0 {
+				return nil, errors.Errorf("odd-number resolutions cannot be rendered, cannot use a height of %d", attrs.Height)
 			}
-			cam := &Camera{Name: cfg.Name, Model: resModel, Resolution: attrs.Resolution}
+			if attrs.Width%2 != 0 {
+				return nil, errors.Errorf("odd-number resolutions cannot be rendered, cannot use a width of %d", attrs.Width)
+			}
+			resModel, width, height := fakeModel(attrs.Width, attrs.Height)
+			cam := &Camera{
+				Name:   cfg.Name,
+				Model:  resModel,
+				Width:  width,
+				Height: height,
+			}
 			return camera.NewFromReader(ctx, cam, resModel, camera.ColorStream)
 		}})
 	config.RegisterComponentAttributeMapConverter(
@@ -69,7 +76,13 @@ func init() {
 	)
 }
 
-var fakeIntrinsicsHigh = &transform.PinholeCameraIntrinsics{
+// Attrs are the attributes of the fake camera config.
+type Attrs struct {
+	Width  int `json:"width"`
+	Height int `json:"height"`
+}
+
+var fakeIntrinsics = &transform.PinholeCameraIntrinsics{
 	Width:  1024,
 	Height: 768,
 	Fx:     821.32642889,
@@ -78,7 +91,7 @@ var fakeIntrinsicsHigh = &transform.PinholeCameraIntrinsics{
 	Ppy:    370.70529534,
 }
 
-var fakeDistortionHigh = &transform.BrownConrady{
+var fakeDistortion = &transform.BrownConrady{
 	RadialK1:     0.11297234,
 	RadialK2:     -0.21375332,
 	RadialK3:     -0.01584774,
@@ -86,61 +99,69 @@ var fakeDistortionHigh = &transform.BrownConrady{
 	TangentialP2: 0.19969297,
 }
 
-var fakeIntrinsicsMed = &transform.PinholeCameraIntrinsics{
-	Width:  512,
-	Height: 384,
-	Fx:     410.663214445,
-	Fy:     410.843036795,
-	Ppx:    247.47970714,
-	Ppy:    185.35264767,
-}
-
-var fakeIntrinsicsLow = &transform.PinholeCameraIntrinsics{
-	Width:  256,
-	Height: 192,
-	Fx:     205.3316072,
-	Fy:     205.4215184,
-	Ppx:    123.73985357,
-	Ppy:    92.676323835,
-}
-
-var fakeModelHigh = &transform.PinholeCameraModel{
-	PinholeCameraIntrinsics: fakeIntrinsicsHigh,
-	Distortion:              fakeDistortionHigh,
-}
-
-var fakeModelMed = &transform.PinholeCameraModel{
-	PinholeCameraIntrinsics: fakeIntrinsicsMed,
-}
-
-var fakeModelLow = &transform.PinholeCameraModel{
-	PinholeCameraIntrinsics: fakeIntrinsicsLow,
-}
-
-func fakeModel(res string) (*transform.PinholeCameraModel, error) {
-	switch res {
-	case high, "":
-		return fakeModelHigh, nil
-	case medium:
-		return fakeModelMed, nil
-	case low:
-		return fakeModelLow, nil
-	default:
-		return nil, errors.Errorf(`do not know resolution %q, only "high", "medium", or "low" are available`, res)
+func fakeModel(width, height int) (*transform.PinholeCameraModel, int, int) {
+	fakeModelReshaped := &transform.PinholeCameraModel{
+		PinholeCameraIntrinsics: fakeIntrinsics,
+		Distortion:              fakeDistortion,
 	}
-}
-
-// Attrs are the attributes of the fake camera config.
-type Attrs struct {
-	Resolution string `json:"resolution"`
+	switch {
+	case width > 0 && height > 0:
+		widthRatio := float64(width) / float64(initialWidth)
+		heightRatio := float64(height) / float64(initialHeight)
+		intrinsics := &transform.PinholeCameraIntrinsics{
+			Width:  int(float64(fakeIntrinsics.Width) * widthRatio),
+			Height: int(float64(fakeIntrinsics.Height) * heightRatio),
+			Fx:     fakeIntrinsics.Fx * widthRatio,
+			Fy:     fakeIntrinsics.Fy * heightRatio,
+			Ppx:    fakeIntrinsics.Ppx * widthRatio,
+			Ppy:    fakeIntrinsics.Ppy * heightRatio,
+		}
+		fakeModelReshaped.PinholeCameraIntrinsics = intrinsics
+		return fakeModelReshaped, width, height
+	case width > 0 && height <= 0:
+		ratio := float64(width) / float64(initialWidth)
+		intrinsics := &transform.PinholeCameraIntrinsics{
+			Width:  int(float64(fakeIntrinsics.Width) * ratio),
+			Height: int(float64(fakeIntrinsics.Height) * ratio),
+			Fx:     fakeIntrinsics.Fx * ratio,
+			Fy:     fakeIntrinsics.Fy * ratio,
+			Ppx:    fakeIntrinsics.Ppx * ratio,
+			Ppy:    fakeIntrinsics.Ppy * ratio,
+		}
+		fakeModelReshaped.PinholeCameraIntrinsics = intrinsics
+		newHeight := int(float64(initialHeight) * ratio)
+		if newHeight%2 != 0 {
+			newHeight++
+		}
+		return fakeModelReshaped, width, newHeight
+	case width <= 0 && height > 0:
+		ratio := float64(height) / float64(initialHeight)
+		intrinsics := &transform.PinholeCameraIntrinsics{
+			Width:  int(float64(fakeIntrinsics.Width) * ratio),
+			Height: int(float64(fakeIntrinsics.Height) * ratio),
+			Fx:     fakeIntrinsics.Fx * ratio,
+			Fy:     fakeIntrinsics.Fy * ratio,
+			Ppx:    fakeIntrinsics.Ppx * ratio,
+			Ppy:    fakeIntrinsics.Ppy * ratio,
+		}
+		fakeModelReshaped.PinholeCameraIntrinsics = intrinsics
+		newWidth := int(float64(initialWidth) * ratio)
+		if newWidth%2 != 0 {
+			newWidth++
+		}
+		return fakeModelReshaped, newWidth, height
+	default:
+		return fakeModelReshaped, initialWidth, initialHeight
+	}
 }
 
 // Camera is a fake camera that always returns the same image.
 type Camera struct {
 	generic.Echo
-	Name       string
-	Model      *transform.PinholeCameraModel
-	Resolution string
+	Name   string
+	Model  *transform.PinholeCameraModel
+	Width  int
+	Height int
 }
 
 // Read always returns the same image of a chess board.
@@ -164,52 +185,32 @@ func (c *Camera) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, err
 
 // getColorImage always returns the same color image of a chess board.
 func (c *Camera) getColorImage() (*rimage.Image, error) {
-	switch c.Resolution {
-	case high, "":
-		img, err := rimage.NewImageFromFile(artifact.MustPath("rimage/board2.png"))
-		return img, err
-	case medium:
-		img, err := rimage.NewImageFromFile(artifact.MustPath("rimage/board2_med.png"))
-		return img, err
-	case low:
-		img, err := rimage.NewImageFromFile(artifact.MustPath("rimage/board2_low.png"))
-		return img, err
-	default:
-		return nil, errors.Errorf(`do not know resolution %q, only "high", "medium", or "low" are available`, c.Resolution)
+	img, err := rimage.NewImageFromFile(artifact.MustPath("rimage/board2.png"))
+	if err != nil {
+		return nil, err
 	}
+	if c.Height == initialHeight && c.Width == initialWidth {
+		return img, nil
+	}
+	dst := image.NewRGBA(image.Rect(0, 0, c.Width, c.Height))
+	draw.NearestNeighbor.Scale(dst, dst.Bounds(), img, img.Bounds(), draw.Over, nil)
+	return rimage.ConvertImage(dst), nil
 }
 
 // getDepthImage always returns the same depth image of a chess board.
 func (c *Camera) getDepthImage(ctx context.Context) (*rimage.DepthMap, error) {
-	img, err := rimage.NewDepthMapFromFile(ctx, artifact.MustPath("rimage/board2_gray.png"))
+	dm, err := rimage.NewDepthMapFromFile(ctx, artifact.MustPath("rimage/board2_gray.png"))
 	if err != nil {
 		return nil, err
 	}
-	switch c.Resolution {
-	case high, "":
-		return img, nil
-	case medium:
-		dm, err := c.resizeDepthImage(ctx, img, 640, 360)
-		return dm, err
-	case low:
-		dm, err := c.resizeDepthImage(ctx, img, 320, 180)
-		return dm, err
-	default:
-		return nil, errors.Errorf(`do not know resolution %q, only "high", "medium", or "low" are available`, c.Resolution)
+	if c.Height == initialHeight && c.Width == initialWidth {
+		return dm, nil
 	}
-}
-
-func (c *Camera) resizeDepthImage(ctx context.Context, dm *rimage.DepthMap, width, height int,
-) (*rimage.DepthMap, error) {
 	dm2, err := rimage.ConvertImageToGray16(dm)
 	if err != nil {
 		return nil, err
 	}
-	dst := image.NewGray16(image.Rect(0, 0, width, height))
-	draw.NearestNeighbor.Scale(dst, dst.Bounds(), dm2, dm.Bounds(), draw.Over, nil)
-	dmFinal, err := rimage.ConvertImageToDepthMap(ctx, dst)
-	if err != nil {
-		return nil, err
-	}
-	return dmFinal, nil
+	dst := image.NewGray16(image.Rect(0, 0, c.Width, c.Height))
+	draw.NearestNeighbor.Scale(dst, dst.Bounds(), dm2, dm2.Bounds(), draw.Over, nil)
+	return rimage.ConvertImageToDepthMap(ctx, dst)
 }

--- a/components/camera/fake/camera.go
+++ b/components/camera/fake/camera.go
@@ -1,4 +1,4 @@
-// Package fake implements a fake camera.
+// Package fake implements a fake camera which always returns the same image with a user specified resolution.
 package fake
 
 import (

--- a/components/camera/fake/camera.go
+++ b/components/camera/fake/camera.go
@@ -6,6 +6,7 @@ import (
 	"image"
 
 	"github.com/edaniels/golog"
+	"github.com/pkg/errors"
 	"go.viam.com/utils/artifact"
 
 	"go.viam.com/rdk/components/camera"
@@ -28,12 +29,14 @@ func init() {
 			config config.Component,
 			logger golog.Logger,
 		) (interface{}, error) {
+			res := config.Attributes.String("resolution")
+			resModel, err := fakeModel(res)
 			cam := &Camera{Name: config.Name, Model: fakeModel}
 			return camera.NewFromReader(ctx, cam, fakeModel, camera.ColorStream)
 		}})
 }
 
-var fakeIntrinsics = &transform.PinholeCameraIntrinsics{
+var fakeIntrinsicsHigh = &transform.PinholeCameraIntrinsics{
 	Width:  1024,
 	Height: 768,
 	Fx:     821.32642889,
@@ -41,8 +44,7 @@ var fakeIntrinsics = &transform.PinholeCameraIntrinsics{
 	Ppx:    494.95941428,
 	Ppy:    370.70529534,
 }
-
-var fakeDistortion = &transform.BrownConrady{
+var fakeDistortionHigh = &transform.BrownConrady{
 	RadialK1:     0.11297234,
 	RadialK2:     -0.21375332,
 	RadialK3:     -0.01584774,
@@ -50,16 +52,56 @@ var fakeDistortion = &transform.BrownConrady{
 	TangentialP2: 0.19969297,
 }
 
-var fakeModel = &transform.PinholeCameraModel{
-	PinholeCameraIntrinsics: fakeIntrinsics,
-	Distortion:              fakeDistortion,
+var fakeIntrinsicsMed = &transform.PinholeCameraIntrinsics{
+	Width:  512,
+	Height: 384,
+	Fx:     410.66321445,
+	Fy:     410.84303680,
+	Ppx:    247.47970714,
+	Ppy:    185.35264767,
+}
+
+var fakeIntrinsicsLow = &transform.PinholeCameraIntrinsics{
+	Width:  256,
+	Height: 192,
+	Fx:     205.3316072,
+	Fy:     205.4215184,
+	Ppx:    123.73985357,
+	Ppy:    92.676323835,
+}
+
+var fakeModelHigh = &transform.PinholeCameraModel{
+	PinholeCameraIntrinsics: fakeIntrinsicsHigh,
+	Distortion:              fakeDistortionHigh,
+}
+
+var fakeModelMed = &transform.PinholeCameraModel{
+	PinholeCameraIntrinsics: fakeIntrinsicsMed,
+}
+
+var fakeModelLow = &transform.PinholeCameraModel{
+	PinholeCameraIntrinsics: fakeIntrinsicsLow,
+}
+
+func fakeModel(res string) (*transform.PinholeCameraModel, error) {
+	switch res {
+	case "high", "hi", "":
+		return fakeModelHigh, nil
+	case "medium", "med":
+		return fakeModelMed, nil
+	case "low", "lo":
+		return fakeModelLow, nil
+	default:
+		return nil, errors.Errorf(`do not know resolution %q, only "high", "medium", or "low" are available`, res)
+	}
 }
 
 // Camera is a fake camera that always returns the same image.
 type Camera struct {
 	generic.Echo
-	Name  string
-	Model *transform.PinholeCameraModel
+	Name       string
+	Model      *transform.PinholeCameraModel
+	Resolution string
 }
 
 // Read always returns the same image of a chess board.

--- a/components/camera/fake/camera_test.go
+++ b/components/camera/fake/camera_test.go
@@ -11,28 +11,31 @@ import (
 )
 
 func TestFakeCameraHighResolution(t *testing.T) {
-	camOri := &Camera{Name: "test_high", Model: fakeModelHigh}
-	cam, err := camera.NewFromReader(context.Background(), camOri, fakeModelHigh, camera.ColorStream)
+	model, width, height := fakeModel(1280, 720)
+	camOri := &Camera{Name: "test_high", Model: model, Width: width, Height: height}
+	cam, err := camera.NewFromReader(context.Background(), camOri, model, camera.ColorStream)
 	test.That(t, err, test.ShouldBeNil)
-	cameraTest(t, cam, 1280, 720, 812050, fakeIntrinsicsHigh, fakeDistortionHigh)
+	cameraTest(t, cam, 1280, 720, 812050, model.PinholeCameraIntrinsics, model.Distortion)
 	err = cam.Close(context.Background())
 	test.That(t, err, test.ShouldBeNil)
 }
 
 func TestFakeCameraMedResolution(t *testing.T) {
-	camOri := &Camera{Name: "test_med", Model: fakeModelMed, Resolution: "medium"}
-	cam, err := camera.NewFromReader(context.Background(), camOri, fakeModelMed, camera.ColorStream)
+	model, width, height := fakeModel(640, 360)
+	camOri := &Camera{Name: "test_high", Model: model, Width: width, Height: height}
+	cam, err := camera.NewFromReader(context.Background(), camOri, model, camera.ColorStream)
 	test.That(t, err, test.ShouldBeNil)
-	cameraTest(t, cam, 640, 360, 203139, fakeIntrinsicsMed, nil)
+	cameraTest(t, cam, 640, 360, 203139, model.PinholeCameraIntrinsics, model.Distortion)
 	err = cam.Close(context.Background())
 	test.That(t, err, test.ShouldBeNil)
 }
 
 func TestFakeCameraLowResolution(t *testing.T) {
-	camOri := &Camera{Name: "test_low", Model: fakeModelLow, Resolution: "low"}
-	cam, err := camera.NewFromReader(context.Background(), camOri, fakeModelLow, camera.ColorStream)
+	model, width, height := fakeModel(320, 0)
+	camOri := &Camera{Name: "test_low", Model: model, Width: width, Height: height}
+	cam, err := camera.NewFromReader(context.Background(), camOri, model, camera.ColorStream)
 	test.That(t, err, test.ShouldBeNil)
-	cameraTest(t, cam, 320, 180, 50717, fakeIntrinsicsLow, nil)
+	cameraTest(t, cam, 320, 180, 50717, model.PinholeCameraIntrinsics, model.Distortion)
 	err = cam.Close(context.Background())
 	test.That(t, err, test.ShouldBeNil)
 }
@@ -42,7 +45,7 @@ func cameraTest(
 	cam camera.Camera,
 	width, height, points int,
 	intrinsics *transform.PinholeCameraIntrinsics,
-	distortion *transform.BrownConrady,
+	distortion transform.Distorter,
 ) {
 	t.Helper()
 	stream, err := cam.Stream(context.Background())

--- a/components/camera/fake/camera_test.go
+++ b/components/camera/fake/camera_test.go
@@ -9,9 +9,9 @@ import (
 	"go.viam.com/rdk/components/camera"
 )
 
-func TestFakeCamera(t *testing.T) {
-	camOri := &Camera{Name: "test", Model: fakeModel}
-	cam, err := camera.NewFromReader(context.Background(), camOri, fakeModel, camera.ColorStream)
+func TestFakeCameraHighResolution(t *testing.T) {
+	camOri := &Camera{Name: "test_high", Model: fakeModelHigh}
+	cam, err := camera.NewFromReader(context.Background(), camOri, fakeModelHigh, camera.ColorStream)
 	test.That(t, err, test.ShouldBeNil)
 	stream, err := cam.Stream(context.Background())
 	test.That(t, err, test.ShouldBeNil)
@@ -24,8 +24,50 @@ func TestFakeCamera(t *testing.T) {
 	test.That(t, pc.Size(), test.ShouldEqual, 812050)
 	prop, err := cam.Properties(context.Background())
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, prop.IntrinsicParams, test.ShouldResemble, fakeIntrinsics)
-	test.That(t, prop.DistortionParams, test.ShouldResemble, fakeDistortion)
+	test.That(t, prop.IntrinsicParams, test.ShouldResemble, fakeIntrinsicsHigh)
+	test.That(t, prop.DistortionParams, test.ShouldResemble, fakeDistortionHigh)
+	err = cam.Close(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+}
+
+func TestFakeCameraMedResolution(t *testing.T) {
+	camOri := &Camera{Name: "test_med", Model: fakeModelMed, Resolution: "medium"}
+	cam, err := camera.NewFromReader(context.Background(), camOri, fakeModelMed, camera.ColorStream)
+	test.That(t, err, test.ShouldBeNil)
+	stream, err := cam.Stream(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+	img, _, err := stream.Next(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, img.Bounds().Dx(), test.ShouldEqual, 640)
+	test.That(t, img.Bounds().Dy(), test.ShouldEqual, 360)
+	pc, err := cam.NextPointCloud(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, pc.Size(), test.ShouldEqual, 206957)
+	prop, err := cam.Properties(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, prop.IntrinsicParams, test.ShouldResemble, fakeIntrinsicsMed)
+	test.That(t, prop.DistortionParams, test.ShouldBeNil)
+	err = cam.Close(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+}
+
+func TestFakeCameraLowResolution(t *testing.T) {
+	camOri := &Camera{Name: "test_low", Model: fakeModelLow, Resolution: "low"}
+	cam, err := camera.NewFromReader(context.Background(), camOri, fakeModelLow, camera.ColorStream)
+	test.That(t, err, test.ShouldBeNil)
+	stream, err := cam.Stream(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+	img, _, err := stream.Next(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, img.Bounds().Dx(), test.ShouldEqual, 320)
+	test.That(t, img.Bounds().Dy(), test.ShouldEqual, 180)
+	pc, err := cam.NextPointCloud(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, pc.Size(), test.ShouldEqual, 52918)
+	prop, err := cam.Properties(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, prop.IntrinsicParams, test.ShouldResemble, fakeIntrinsicsLow)
+	test.That(t, prop.DistortionParams, test.ShouldBeNil)
 	err = cam.Close(context.Background())
 	test.That(t, err, test.ShouldBeNil)
 }

--- a/components/camera/fake/camera_test.go
+++ b/components/camera/fake/camera_test.go
@@ -7,25 +7,14 @@ import (
 	"go.viam.com/test"
 
 	"go.viam.com/rdk/components/camera"
+	"go.viam.com/rdk/rimage/transform"
 )
 
 func TestFakeCameraHighResolution(t *testing.T) {
 	camOri := &Camera{Name: "test_high", Model: fakeModelHigh}
 	cam, err := camera.NewFromReader(context.Background(), camOri, fakeModelHigh, camera.ColorStream)
 	test.That(t, err, test.ShouldBeNil)
-	stream, err := cam.Stream(context.Background())
-	test.That(t, err, test.ShouldBeNil)
-	img, _, err := stream.Next(context.Background())
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, img.Bounds().Dx(), test.ShouldEqual, 1280)
-	test.That(t, img.Bounds().Dy(), test.ShouldEqual, 720)
-	pc, err := cam.NextPointCloud(context.Background())
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, pc.Size(), test.ShouldEqual, 812050)
-	prop, err := cam.Properties(context.Background())
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, prop.IntrinsicParams, test.ShouldResemble, fakeIntrinsicsHigh)
-	test.That(t, prop.DistortionParams, test.ShouldResemble, fakeDistortionHigh)
+	cameraTest(t, cam, 1280, 720, 812050, fakeIntrinsicsHigh, fakeDistortionHigh)
 	err = cam.Close(context.Background())
 	test.That(t, err, test.ShouldBeNil)
 }
@@ -34,19 +23,7 @@ func TestFakeCameraMedResolution(t *testing.T) {
 	camOri := &Camera{Name: "test_med", Model: fakeModelMed, Resolution: "medium"}
 	cam, err := camera.NewFromReader(context.Background(), camOri, fakeModelMed, camera.ColorStream)
 	test.That(t, err, test.ShouldBeNil)
-	stream, err := cam.Stream(context.Background())
-	test.That(t, err, test.ShouldBeNil)
-	img, _, err := stream.Next(context.Background())
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, img.Bounds().Dx(), test.ShouldEqual, 640)
-	test.That(t, img.Bounds().Dy(), test.ShouldEqual, 360)
-	pc, err := cam.NextPointCloud(context.Background())
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, pc.Size(), test.ShouldEqual, 206957)
-	prop, err := cam.Properties(context.Background())
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, prop.IntrinsicParams, test.ShouldResemble, fakeIntrinsicsMed)
-	test.That(t, prop.DistortionParams, test.ShouldBeNil)
+	cameraTest(t, cam, 640, 360, 203139, fakeIntrinsicsMed, nil)
 	err = cam.Close(context.Background())
 	test.That(t, err, test.ShouldBeNil)
 }
@@ -55,19 +32,34 @@ func TestFakeCameraLowResolution(t *testing.T) {
 	camOri := &Camera{Name: "test_low", Model: fakeModelLow, Resolution: "low"}
 	cam, err := camera.NewFromReader(context.Background(), camOri, fakeModelLow, camera.ColorStream)
 	test.That(t, err, test.ShouldBeNil)
+	cameraTest(t, cam, 320, 180, 50717, fakeIntrinsicsLow, nil)
+	err = cam.Close(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+}
+
+func cameraTest(
+	t *testing.T,
+	cam camera.Camera,
+	width, height, points int,
+	intrinsics *transform.PinholeCameraIntrinsics,
+	distortion *transform.BrownConrady,
+) {
+	t.Helper()
 	stream, err := cam.Stream(context.Background())
 	test.That(t, err, test.ShouldBeNil)
 	img, _, err := stream.Next(context.Background())
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, img.Bounds().Dx(), test.ShouldEqual, 320)
-	test.That(t, img.Bounds().Dy(), test.ShouldEqual, 180)
+	test.That(t, img.Bounds().Dx(), test.ShouldEqual, width)
+	test.That(t, img.Bounds().Dy(), test.ShouldEqual, height)
 	pc, err := cam.NextPointCloud(context.Background())
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, pc.Size(), test.ShouldEqual, 52918)
+	test.That(t, pc.Size(), test.ShouldEqual, points)
 	prop, err := cam.Properties(context.Background())
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, prop.IntrinsicParams, test.ShouldResemble, fakeIntrinsicsLow)
-	test.That(t, prop.DistortionParams, test.ShouldBeNil)
-	err = cam.Close(context.Background())
-	test.That(t, err, test.ShouldBeNil)
+	test.That(t, prop.IntrinsicParams, test.ShouldResemble, intrinsics)
+	if distortion == nil {
+		test.That(t, prop.DistortionParams, test.ShouldBeNil)
+	} else {
+		test.That(t, prop.DistortionParams, test.ShouldResemble, distortion)
+	}
 }

--- a/components/camera/fake/camera_test.go
+++ b/components/camera/fake/camera_test.go
@@ -16,8 +16,12 @@ func TestFakeCameraHighResolution(t *testing.T) {
 	cam, err := camera.NewFromReader(context.Background(), camOri, model, camera.ColorStream)
 	test.That(t, err, test.ShouldBeNil)
 	cameraTest(t, cam, 1280, 720, 812050, model.PinholeCameraIntrinsics, model.Distortion)
-	err = cam.Close(context.Background())
+	// (0,0) entry defaults to (1280, 720)
+	model, width, height = fakeModel(0, 0)
+	camOri = &Camera{Name: "test_high_zero", Model: model, Width: width, Height: height}
+	cam, err = camera.NewFromReader(context.Background(), camOri, model, camera.ColorStream)
 	test.That(t, err, test.ShouldBeNil)
+	cameraTest(t, cam, 1280, 720, 812050, model.PinholeCameraIntrinsics, model.Distortion)
 }
 
 func TestFakeCameraMedResolution(t *testing.T) {
@@ -30,14 +34,20 @@ func TestFakeCameraMedResolution(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 }
 
-func TestFakeCameraLowResolution(t *testing.T) {
+func TestFakeCameraUnspecified(t *testing.T) {
+	// one unspecified side should keep 16:9 aspect ratio
+	// (320, 0) -> (320, 180)
 	model, width, height := fakeModel(320, 0)
-	camOri := &Camera{Name: "test_low", Model: model, Width: width, Height: height}
+	camOri := &Camera{Name: "test_320", Model: model, Width: width, Height: height}
 	cam, err := camera.NewFromReader(context.Background(), camOri, model, camera.ColorStream)
 	test.That(t, err, test.ShouldBeNil)
 	cameraTest(t, cam, 320, 180, 50717, model.PinholeCameraIntrinsics, model.Distortion)
-	err = cam.Close(context.Background())
+	// (0, 180) -> (320, 180)
+	model, width, height = fakeModel(0, 180)
+	camOri = &Camera{Name: "test_180", Model: model, Width: width, Height: height}
+	cam, err = camera.NewFromReader(context.Background(), camOri, model, camera.ColorStream)
 	test.That(t, err, test.ShouldBeNil)
+	cameraTest(t, cam, 320, 180, 50717, model.PinholeCameraIntrinsics, model.Distortion)
 }
 
 func cameraTest(
@@ -65,4 +75,6 @@ func cameraTest(
 	} else {
 		test.That(t, prop.DistortionParams, test.ShouldResemble, distortion)
 	}
+	err = cam.Close(context.Background())
+	test.That(t, err, test.ShouldBeNil)
 }

--- a/robot/impl/data/cfgtest1.json
+++ b/robot/impl/data/cfgtest1.json
@@ -4,10 +4,7 @@
             "name": "c1",
             "type": "camera",
             "model": "fake",
-            "attributes": {
-                "bar": "a${HOME}b${HOME}c",
-                "aligned": false
-            }
+            "attributes": {}
         }
     ]
 }

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"math"
 	"net"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -86,8 +85,6 @@ func TestConfig1(t *testing.T) {
 	bounds := pic.Bounds()
 
 	test.That(t, bounds.Max.X, test.ShouldBeGreaterThanOrEqualTo, 32)
-
-	test.That(t, cfg.Components[0].Attributes["bar"], test.ShouldEqual, fmt.Sprintf("a%sb%sc", os.Getenv("HOME"), os.Getenv("HOME")))
 }
 
 func TestConfigFake(t *testing.T) {


### PR DESCRIPTION
The camera model “fake” is changing, such that a user will have an option of choosing the resolution of the fake image being served. 

- They can leave the attributes blank, which means that the default resolution of 1280 x 720 is used.
- They can specify either “width” or “height”, and the other one will be scaled appropriately with the same ratio of 16:9.
- They can specify both “width” and “height” which will skew the image to whatever they want. 
- Useful for bench marking certain point cloud tests