### PR TITLE
RSDK-142 change gantry oneaxis structure

### DIFF
--- a/components/encoder/fake/encoder.go
+++ b/components/encoder/fake/encoder.go
@@ -46,7 +46,7 @@ func init() {
 
 // AttrConfig describes the configuration of a fake encoder.
 type AttrConfig struct {
-	UpdateRate int64 `json:"update_rate_msec,omitempty"`
+	UpdateRate int64 `json:"update_rate_msec"`
 }
 
 // Validate ensures all parts of a config is valid.

--- a/components/gantry/oneaxis/oneaxis.go
+++ b/components/gantry/oneaxis/oneaxis.go
@@ -3,7 +3,6 @@ package oneaxis
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 
@@ -136,7 +135,7 @@ func (g *oneAxis) homeEncoder(ctx context.Context) error {
 	g.positionLimits = []float64{positionA, positionB}
 
 	if g.gantryRange = positionB - positionA; g.gantryRange == 0 {
-		return errors.New("zero range gantry found between position limits")
+		return errZeroLengthGantry
 	}
 
 	return nil

--- a/components/gantry/oneaxis/oneaxis.go
+++ b/components/gantry/oneaxis/oneaxis.go
@@ -38,10 +38,9 @@ type oneAxis struct {
 
 	model referenceframe.Model
 
-	logger                  golog.Logger
-	opMgr                   operation.SingleOperationManager
-	activeBackGroundWorkers sync.WaitGroup
-	mu                      sync.Mutex
+	logger golog.Logger
+	opMgr  operation.SingleOperationManager
+	mu     sync.Mutex
 }
 
 // newOneAxis creates a new one axis gantry.
@@ -93,6 +92,8 @@ func newOneAxis(
 }
 
 func (g *oneAxis) createModel(axis r3.Vector) (referenceframe.Model, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	var errs error
 	m := referenceframe.NewSimpleModel("")
 
@@ -113,6 +114,8 @@ func (g *oneAxis) createModel(axis r3.Vector) (referenceframe.Model, error) {
 }
 
 func (g *oneAxis) linearToRotational(positions float64) float64 {
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	theRange := g.positionLimits[1] - g.positionLimits[0]
 	x := positions / g.lengthMm
 	x = g.positionLimits[0] + (x * theRange)
@@ -120,6 +123,9 @@ func (g *oneAxis) linearToRotational(positions float64) float64 {
 }
 
 func (g *oneAxis) homeEncoder(ctx context.Context) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
 	ctx, done := g.opMgr.New(ctx)
 	defer done()
 	// should be non-zero from creator function

--- a/components/gantry/oneaxis/oneaxis.go
+++ b/components/gantry/oneaxis/oneaxis.go
@@ -211,8 +211,6 @@ func (g *oneAxis) IsMoving(ctx context.Context) (bool, error) {
 
 // ModelFrame returns the frame model of the Gantry.
 func (g *oneAxis) ModelFrame() referenceframe.Model {
-	g.mu.Lock()
-	defer g.mu.Unlock()
 	return g.model
 }
 

--- a/components/gantry/oneaxis/oneaxis_test.go
+++ b/components/gantry/oneaxis/oneaxis_test.go
@@ -21,9 +21,8 @@ import (
 const (
 	motorName = "x"
 	testGName = "test"
+	counter   = 1
 )
-
-var counter = 0
 
 func createfakemotor() motor.Motor {
 	return &inject.Motor{
@@ -31,7 +30,6 @@ func createfakemotor() motor.Motor {
 			return map[motor.Feature]bool{motor.PositionReporting: true}, nil
 		},
 		PositionFunc: func(ctx context.Context, extra map[string]interface{}) (float64, error) {
-			counter++
 			return float64(counter), nil
 		}, ResetZeroPositionFunc: func(ctx context.Context, offset float64, extra map[string]interface{}) error { return nil },
 		GoToFunc:     func(ctx context.Context, rpm, position float64, extra map[string]interface{}) error { return nil },
@@ -39,6 +37,7 @@ func createfakemotor() motor.Motor {
 		StopFunc:     func(ctx context.Context, extra map[string]interface{}) error { return nil },
 		SetPowerFunc: func(ctx context.Context, powerPct float64, extra map[string]interface{}) error { return nil },
 	}
+
 }
 
 func createfakeboard() board.Board {

--- a/components/gantry/oneaxis/oneaxis_test.go
+++ b/components/gantry/oneaxis/oneaxis_test.go
@@ -25,8 +25,10 @@ const (
 
 var (
 	counter = 0
+)
 
-	fakeMotor = &inject.Motor{
+func createfakemotor() motor.Motor {
+	return &inject.Motor{
 		PropertiesFunc: func(ctx context.Context, extra map[string]interface{}) (map[motor.Feature]bool, error) {
 			return map[motor.Feature]bool{motor.PositionReporting: true}, nil
 		},
@@ -40,18 +42,21 @@ var (
 		SetPowerFunc: func(ctx context.Context, powerPct float64, extra map[string]interface{}) error { return nil },
 	}
 
-	injectGPIOPin = &inject.GPIOPin{
+}
+
+func createfakeboard() board.Board {
+	injectGPIOPin := &inject.GPIOPin{
 		GetFunc: func(ctx context.Context, extra map[string]interface{}) (bool, error) { return true, nil },
 		SetFunc: func(ctx context.Context, high bool, extra map[string]interface{}) error { return nil },
 	}
-	fakeBoard = &inject.Board{GPIOPinByNameFunc: func(pin string) (board.GPIOPin, error) { return injectGPIOPin, nil }}
-)
+	return &inject.Board{GPIOPinByNameFunc: func(pin string) (board.GPIOPin, error) { return injectGPIOPin, nil }}
+}
 
 func createFakeDepsForTestNewOneAxis(t *testing.T) registry.Dependencies {
 	t.Helper()
 	deps := make(registry.Dependencies)
-	deps[board.Named("board")] = fakeBoard
-	deps[motor.Named(motorName)] = fakeMotor
+	deps[board.Named("board")] = createfakeboard()
+	deps[motor.Named(motorName)] = createfakemotor()
 	return deps
 }
 
@@ -131,14 +136,6 @@ func TestValidate(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, fakecfg.GantryRPM, test.ShouldEqual, float64(100))
 }
-
-// func TestSetup(t testing.T) {
-// ctx := context.Background()
-// logger := golog.NewTestLogger(t)
-// deps := createFakeDepsForTestNewOneAxis(t)
-// fakcfg := config.Component{}
-
-// }
 
 func TestNewGantryTypes(t *testing.T) {
 	ctx := context.Background()
@@ -228,8 +225,8 @@ func TestHome(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	fakeOneAx := &oneAxis{
 		name:            testGName,
-		motor:           fakeMotor,
-		board:           fakeBoard,
+		motor:           createfakemotor(),
+		board:           createfakeboard(),
 		logger:          logger,
 		rpm:             float64(300),
 		lengthMm:        100,
@@ -283,8 +280,8 @@ func TestHome(t *testing.T) {
 func TestTestLimit(t *testing.T) {
 	ctx := context.Background()
 	baseG := &oneAxis{
-		motor: fakeMotor,
-		board: fakeBoard,
+		motor: createfakemotor(),
+		board: createfakeboard(),
 		rpm:   float64(300),
 	}
 
@@ -306,7 +303,7 @@ func TestTestLimit(t *testing.T) {
 func TestLimitHit(t *testing.T) {
 	ctx := context.Background()
 	baseG := &oneAxis{
-		board: fakeBoard,
+		board: createfakeboard(),
 	}
 
 	fakegantry := &limitSwitchGantry{
@@ -437,8 +434,8 @@ func TestStop(t *testing.T) {
 	ctx := context.Background()
 
 	fakeOAx := &oneAxis{
-		motor:          fakeMotor,
-		board:          fakeBoard,
+		motor:          createfakemotor(),
+		board:          createfakeboard(),
 		logger:         logger,
 		rpm:            float64(300),
 		lengthMm:       float64(200),
@@ -505,7 +502,7 @@ func TestGoToInputs(t *testing.T) {
 	inputs := []referenceframe.Input{}
 
 	fakeOAx := &oneAxis{
-		motor:          fakeMotor,
+		motor:          createfakemotor(),
 		lengthMm:       1.0,
 		positionLimits: []float64{1, 2},
 	}
@@ -543,7 +540,7 @@ func TestGoToInputs(t *testing.T) {
 func TestIsMoving(t *testing.T) {
 	ctx := context.Background()
 	fakeOAx := &oneAxis{
-		motor:          fakeMotor,
+		motor:          createfakemotor(),
 		lengthMm:       1.0,
 		positionLimits: []float64{1, 2},
 	}

--- a/components/gantry/oneaxis/oneaxis_test.go
+++ b/components/gantry/oneaxis/oneaxis_test.go
@@ -62,12 +62,12 @@ func TestValidate(t *testing.T) {
 	fakecfg := &AttrConfig{}
 	deps, err := fakecfg.Validate("path")
 	test.That(t, deps, test.ShouldBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, "cannot find motor for gantry")
+	test.That(t, err.Error(), test.ShouldContainSubstring, "motor")
 
 	fakecfg.Motor = motorName
 	deps, err = fakecfg.Validate("path")
 	test.That(t, deps, test.ShouldBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, "non-zero and positive")
+	test.That(t, err.Error(), test.ShouldContainSubstring, "length_mm")
 
 	fakecfg.LengthMm = 1.0
 	fakecfg.LimitSwitchPins = []string{}
@@ -84,7 +84,7 @@ func TestValidate(t *testing.T) {
 	fakecfg.LimitSwitchPins = []string{"1"}
 	deps, err = fakecfg.Validate("path")
 	test.That(t, deps, test.ShouldBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, "cannot find board for gantry")
+	test.That(t, err.Error(), test.ShouldContainSubstring, "board")
 
 	fakecfg.Board = "board"
 	deps, err = fakecfg.Validate("path")

--- a/components/gantry/oneaxis/oneaxis_test.go
+++ b/components/gantry/oneaxis/oneaxis_test.go
@@ -215,7 +215,7 @@ func TestNewGantryTypes(t *testing.T) {
 func TestHome(t *testing.T) {
 	ctx := context.Background()
 	logger := golog.NewTestLogger(t)
-	fakeOneAx := &oneAxis{
+	fake1ax := &oneAxis{
 		name:            testGName,
 		motor:           createfakemotor(),
 		board:           createfakeboard(),
@@ -225,32 +225,32 @@ func TestHome(t *testing.T) {
 		mmPerRevolution: 1,
 	}
 
-	fakePins := &limitPins{
+	fakepins := &limitPins{
 		limitHigh:       true,
 		limitSwitchPins: []string{"1", "2"},
 	}
 
-	err := homeEncoder(ctx, fakeOneAx)
+	err := homeEncoder(ctx, fake1ax)
 	test.That(t, err, test.ShouldBeNil)
-	lastPos := count + int(fakeOneAx.lengthMm)/int(fakeOneAx.mmPerRevolution) + 1
-	test.That(t, fakeOneAx.positionLimits, test.ShouldResemble, []float64{float64(count) + 1, float64(lastPos)})
+	lastPos := count + int(fake1ax.lengthMm)/int(fake1ax.mmPerRevolution) + 1
+	test.That(t, fake1ax.positionLimits, test.ShouldResemble, []float64{float64(count) + 1, float64(lastPos)})
 
-	fakePins.limitSwitchPins = []string{"1"}
-	err = homeWithLimSwitch(ctx, fakePins, fakeOneAx)
+	fakepins.limitSwitchPins = []string{"1"}
+	err = homeWithLimSwitch(ctx, fakepins, fake1ax)
 	test.That(t, err, test.ShouldBeNil)
-	lastPos = count + int(fakeOneAx.lengthMm) + 1
-	test.That(t, fakeOneAx.positionLimits, test.ShouldResemble, []float64{float64(count + 1), float64(lastPos)})
+	lastPos = count + int(fake1ax.lengthMm) + 1
+	test.That(t, fake1ax.positionLimits, test.ShouldResemble, []float64{float64(count + 1), float64(lastPos)})
 
-	fakeOneAx.lengthMm = 0
-	err = homeWithLimSwitch(ctx, fakePins, fakeOneAx)
+	fake1ax.lengthMm = 0
+	err = homeWithLimSwitch(ctx, fakepins, fake1ax)
 	test.That(t, err, test.ShouldResemble, errDimensionsNotFound(testGName,
-		fakeOneAx.lengthMm,
-		fakeOneAx.mmPerRevolution))
+		fake1ax.lengthMm,
+		fake1ax.mmPerRevolution))
 
 	goForErr := errors.New("GoFor failed")
 	posErr := errors.New("Position failed")
-	fakeOneAx.lengthMm = 100
-	fakeOneAx.motor = &inject.Motor{
+	fake1ax.lengthMm = 100
+	fake1ax.motor = &inject.Motor{
 		PropertiesFunc: func(ctx context.Context, extra map[string]interface{}) (map[motor.Feature]bool, error) {
 			return map[motor.Feature]bool{
 				motor.PositionReporting: false,
@@ -260,11 +260,12 @@ func TestHome(t *testing.T) {
 		StopFunc:     func(ctx context.Context, extra map[string]interface{}) error { return nil },
 		PositionFunc: func(ctx context.Context, extra map[string]interface{}) (float64, error) { return 1.0, posErr },
 	}
-	err = homeWithLimSwitch(ctx, fakePins, fakeOneAx)
+	err = homeWithLimSwitch(ctx, fakepins, fake1ax)
 	test.That(t, err, test.ShouldBeError, goForErr)
 
-	err = homeEncoder(ctx, fakeOneAx)
+	err = homeEncoder(ctx, fake1ax)
 	test.That(t, err, test.ShouldBeError, posErr)
+
 }
 
 func TestTestLimit(t *testing.T) {
@@ -275,16 +276,16 @@ func TestTestLimit(t *testing.T) {
 		rpm:   float64(300),
 	}
 
-	fakePins := &limitPins{
+	fakepins := &limitPins{
 		limitSwitchPins: []string{"1", "2"},
 		limitHigh:       true,
 	}
 
-	pos, err := fakePins.testLimit(ctx, 0, fake1ax)
+	pos, err := fakepins.testLimit(ctx, 0, fake1ax)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, pos, test.ShouldEqual, count+1) // we called inject motors move position once
 
-	pos, err = fakePins.testLimit(ctx, 1, fake1ax)
+	pos, err = fakepins.testLimit(ctx, 1, fake1ax)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, pos, test.ShouldEqual, count+1) // same as l295
 }
@@ -295,12 +296,12 @@ func TestLimitHit(t *testing.T) {
 		board: createfakeboard(),
 	}
 
-	fakePins := &limitPins{
+	fakepins := &limitPins{
 		limitSwitchPins: []string{"1", "2", "3"},
 		limitHigh:       true,
 	}
 
-	hit, err := fakePins.limitHit(ctx, 0, fake1ax)
+	hit, err := fakepins.limitHit(ctx, 0, fake1ax)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, hit, test.ShouldEqual, true)
 }

--- a/components/gantry/oneaxis/oneaxis_test.go
+++ b/components/gantry/oneaxis/oneaxis_test.go
@@ -23,9 +23,7 @@ const (
 	testGName = "test"
 )
 
-var (
-	counter = 0
-)
+var counter = 0
 
 func createfakemotor() motor.Motor {
 	return &inject.Motor{
@@ -41,7 +39,6 @@ func createfakemotor() motor.Motor {
 		StopFunc:     func(ctx context.Context, extra map[string]interface{}) error { return nil },
 		SetPowerFunc: func(ctx context.Context, powerPct float64, extra map[string]interface{}) error { return nil },
 	}
-
 }
 
 func createfakeboard() board.Board {

--- a/components/gantry/oneaxis/oneaxis_test.go
+++ b/components/gantry/oneaxis/oneaxis_test.go
@@ -23,9 +23,7 @@ const (
 	testGName = "test"
 )
 
-var (
-	count = 0
-)
+var count = 0
 
 func createfakemotor() motor.Motor {
 	return &inject.Motor{
@@ -40,7 +38,6 @@ func createfakemotor() motor.Motor {
 		StopFunc:     func(ctx context.Context, extra map[string]interface{}) error { return nil },
 		SetPowerFunc: func(ctx context.Context, powerPct float64, extra map[string]interface{}) error { return nil },
 	}
-
 }
 
 func createfakeboard() board.Board {

--- a/components/gantry/oneaxis/setup.go
+++ b/components/gantry/oneaxis/setup.go
@@ -1,0 +1,374 @@
+// Package oneaxis implements a one-axis gantry.
+package oneaxis
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/edaniels/golog"
+	"github.com/golang/geo/r3"
+	"go.uber.org/multierr"
+	"go.viam.com/utils"
+
+	"go.viam.com/rdk/components/gantry"
+	"go.viam.com/rdk/components/generic"
+	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/referenceframe"
+	"go.viam.com/rdk/registry"
+	"go.viam.com/rdk/resource"
+	rdkutils "go.viam.com/rdk/utils"
+)
+
+var modelname = resource.NewDefaultModel("oneaxis")
+
+func errBadNumLimitSwitches(name string, numLimPins int) error {
+	return fmt.Errorf("bad number of limit switch pins for gantry %s: can only be 0, 1 or 2, have %d",
+		name, numLimPins)
+}
+
+func errDimensionsNotFound(name string, length, mmPerRev float64) error {
+	return fmt.Errorf("zero dimension found for gantry %s, length: %.2f, mmPerRev %.2f",
+		name, length, mmPerRev)
+}
+
+// AttrConfig is used for converting oneAxis config attributes.
+type AttrConfig struct {
+	Board           string    `json:"board,omitempty"` // used to read limit switch pins and control motor with gpio pins
+	Motor           string    `json:"motor"`
+	LimitSwitchPins []string  `json:"limit_pins,omitempty"`
+	LimitPinEnabled *bool     `json:"limit_pin_enabled_high,omitempty"`
+	LengthMm        float64   `json:"length_mm"`
+	MmPerRevolution float64   `json:"mm_per_rev,omitempty"`
+	GantryRPM       float64   `json:"gantry_rpm,omitempty"`
+	Axis            r3.Vector `json:"axis"`
+}
+
+// Validate ensures all parts of the config are valid.
+func (cfg *AttrConfig) Validate(path string) ([]string, error) {
+	var deps []string
+
+	if len(cfg.Motor) == 0 {
+		return nil, errors.New("cannot find motor for gantry")
+	}
+	deps = append(deps, cfg.Motor)
+
+	if cfg.LengthMm <= 0 {
+		return nil, errors.New("each axis needs a non-zero and positive length")
+	}
+
+	if len(cfg.LimitSwitchPins) == 0 && len(cfg.Board) > 0 {
+		return nil, errors.New("gantry with encoders have to assign boards or controllers to motors")
+	}
+
+	if len(cfg.Board) == 0 && len(cfg.LimitSwitchPins) > 0 {
+		return nil, errors.New("cannot find board for gantry")
+	}
+	deps = append(deps, cfg.Board)
+
+	if len(cfg.LimitSwitchPins) == 1 && cfg.MmPerRevolution == 0 {
+		return nil, errors.New("gantry has one limit switch per axis, needs pulley radius to set position limits")
+	}
+
+	if len(cfg.LimitSwitchPins) > 0 && cfg.LimitPinEnabled == nil {
+		return nil, errors.New("limit pin enabled muist be set to true or false")
+	}
+
+	if cfg.Axis.X == 0 && cfg.Axis.Y == 0 && cfg.Axis.Z == 0 {
+		return nil, errors.New("gantry axis undefined, need one translational axis")
+	}
+
+	if cfg.Axis.X == 1 && cfg.Axis.Y == 1 ||
+		cfg.Axis.X == 1 && cfg.Axis.Z == 1 || cfg.Axis.Y == 1 && cfg.Axis.Z == 1 {
+		return nil, errors.New("only one translational axis of movement allowed for single axis gantry")
+	}
+
+	if cfg.GantryRPM == 0 {
+		cfg.GantryRPM = float64(100)
+	}
+
+	return deps, nil
+}
+
+func init() {
+	registry.RegisterComponent(gantry.Subtype, modelname, registry.Component{Constructor: setUpGantry})
+
+	config.RegisterComponentAttributeMapConverter(gantry.Subtype, modelname,
+		func(attributes config.AttributeMap) (interface{}, error) {
+			var conf AttrConfig
+			return config.TransformAttributeMapToStruct(&conf, attributes)
+		},
+		&AttrConfig{})
+}
+
+func setUpGantry(
+	ctx context.Context,
+	deps registry.Dependencies,
+	cfg config.Component,
+	logger golog.Logger,
+) (interface{}, error) {
+	// sets up a single axis that assumes motor can be used alone to
+	// set up limits, range and knows absolute position along the axis
+	g, err := newOneAxis(ctx, deps, cfg, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	conf, ok := cfg.ConvertedAttributes.(*AttrConfig)
+	if !ok {
+		return nil, rdkutils.NewUnexpectedTypeError(conf, cfg.ConvertedAttributes)
+	}
+
+	oAx, ok := g.(*oneAxis)
+	if !ok {
+		return nil, rdkutils.NewUnexpectedTypeError(&oneAxis{}, oAx)
+	}
+
+	switch len(conf.LimitSwitchPins) {
+	case 0:
+		// homes the motor and finds limits using the motor's position reporting
+		if err = oAx.homeEncoder(ctx); err != nil {
+			return nil, err
+		}
+		return oAx, nil
+	default:
+		// sets up a gantry that requires polling of external sensors, in this case limit switches
+		// to find position limits and gantry range
+		g, err := newLimitSwitchGantry(ctx, cfg, logger, oAx)
+		if err != nil {
+			return nil, err
+		}
+
+		lAx, ok := g.(*limitSwitchGantry)
+		if !ok {
+			return nil, rdkutils.NewUnexpectedTypeError(&limitSwitchGantry{}, lAx)
+		}
+		if err = lAx.homeWithLimSwitch(ctx, conf.LimitSwitchPins); err != nil {
+			return nil, err
+		}
+		return g, nil
+	}
+}
+
+type limitSwitchGantry struct {
+	oAx *oneAxis
+
+	limitSwitchPins []string
+	limitHigh       bool
+
+	mu     sync.Mutex
+	logger golog.Logger
+	generic.Unimplemented
+}
+
+// newOneAxis creates a new one axis gantry.
+func newLimitSwitchGantry(
+	ctx context.Context,
+	cfg config.Component,
+	logger golog.Logger,
+	oneAxis *oneAxis,
+) (gantry.LocalGantry, error) {
+	conf, ok := cfg.ConvertedAttributes.(*AttrConfig)
+	if !ok {
+		return nil, rdkutils.NewUnexpectedTypeError(conf, cfg.ConvertedAttributes)
+	}
+
+	if len(conf.LimitSwitchPins) > 2 {
+		return nil, errBadNumLimitSwitches(cfg.Name, len(conf.LimitSwitchPins))
+	}
+
+	g := &limitSwitchGantry{
+		limitSwitchPins: conf.LimitSwitchPins,
+		limitHigh:       *conf.LimitPinEnabled,
+		oAx:             oneAxis,
+		logger:          logger,
+	}
+
+	if len(g.limitSwitchPins) == 1 && (g.oAx.mmPerRevolution == 0 || g.oAx.lengthMm == 0) {
+		return nil, errDimensionsNotFound(g.oAx.name, g.oAx.mmPerRevolution, g.oAx.mmPerRevolution)
+	}
+
+	for idx := range g.limitSwitchPins {
+		if err := g.limitHitChecker(ctx, idx); err != nil {
+			return nil, err
+		}
+	}
+	return g, nil
+}
+
+func (g *limitSwitchGantry) limitHit(ctx context.Context, offset int) (bool, error) {
+	if offset < 0 || offset > 1 {
+		return true, errBadNumLimitSwitches(g.oAx.name, offset)
+	}
+	pin, err := g.oAx.board.GPIOPinByName(g.limitSwitchPins[offset])
+	if err != nil {
+		return false, err
+	}
+	high, err := pin.Get(ctx, nil)
+
+	return high == g.limitHigh, err
+}
+
+func (g *limitSwitchGantry) limitHitChecker(
+	ctx context.Context,
+	limInt int,
+) error {
+	var errs error
+	g.oAx.activeBackGroundWorkers.Add(1)
+	utils.ManagedGo(func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			hit, err := g.limitHit(ctx, limInt)
+			if hit || err != nil {
+				errs = multierr.Combine(errs, err)
+				// motor operation manager cancels running
+				err = g.oAx.motor.Stop(ctx, nil)
+				errs = multierr.Combine(errs, err)
+				return
+			}
+		}
+	}, g.oAx.activeBackGroundWorkers.Done)
+	return errs
+}
+
+func (g *limitSwitchGantry) testLimit(ctx context.Context, limInt int) (float64, error) {
+	defer utils.UncheckedErrorFunc(func() error {
+		return g.oAx.motor.Stop(ctx, nil)
+	})
+
+	d := -1.0 // go backwards to hit first limit switch pin
+	if limInt > 0 {
+		d *= -1 // go forwards to hit second limit switch pin
+	}
+
+	err := g.oAx.motor.GoFor(ctx, d*g.oAx.rpm, 0, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	start := time.Now()
+	for {
+		hit, err := g.limitHit(ctx, limInt)
+		if err != nil {
+			return 0, err
+		}
+		if hit {
+			err = g.oAx.motor.Stop(ctx, nil)
+			if err != nil {
+				return 0, err
+			}
+			break
+		}
+
+		elapsed := start.Sub(start)
+		if elapsed > (time.Second * 15) {
+			return 0, errors.New("gantry timed out testing limit")
+		}
+
+		if !utils.SelectContextOrWait(ctx, time.Millisecond*10) {
+			return 0, ctx.Err()
+		}
+	}
+
+	return g.oAx.motor.Position(ctx, nil)
+}
+
+func (g *limitSwitchGantry) homeWithLimSwitch(ctx context.Context, limSwitchPins []string) error {
+	ctx, done := g.oAx.opMgr.New(ctx)
+	defer done()
+	positionA, err := g.testLimit(ctx, 0)
+	if err != nil {
+		return err
+	}
+
+	np := len(g.limitSwitchPins)
+	var positionB float64
+	switch len(limSwitchPins) {
+	case 1:
+		if g.oAx.lengthMm == 0.0 || g.oAx.mmPerRevolution == 0.0 {
+			return errDimensionsNotFound(g.oAx.name, g.oAx.lengthMm, g.oAx.mmPerRevolution)
+		}
+		revPerLength := g.oAx.lengthMm / g.oAx.mmPerRevolution
+		positionB = positionA + revPerLength
+	case 2:
+		positionB, err = g.testLimit(ctx, 1)
+		if err != nil {
+			return err
+		}
+	default:
+		return errBadNumLimitSwitches(g.oAx.name, np)
+	}
+
+	g.oAx.logger.Debugf("positionA: %0.2f positionB: %0.2f", positionA, positionB)
+
+	g.oAx.positionLimits = []float64{positionA, positionB}
+
+	if g.oAx.gantryRange = positionB - positionA; g.oAx.gantryRange == 0 {
+		return errors.New("zero range gantry found between position limits")
+	}
+
+	// Go backwards so limit stops are not hit.
+	x := g.oAx.linearToRotational(0.9 * (g.oAx.gantryRange + positionA))
+	err = g.oAx.motor.GoTo(ctx, g.oAx.rpm, x, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (g *limitSwitchGantry) Position(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.oAx.Position(ctx, extra)
+}
+
+func (g *limitSwitchGantry) MoveToPosition(
+	ctx context.Context,
+	positionsMm []float64,
+	worldstate *referenceframe.WorldState,
+	extra map[string]interface{},
+) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.oAx.MoveToPosition(ctx, positionsMm, worldstate, extra)
+}
+
+func (g *limitSwitchGantry) Lengths(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.oAx.Lengths(ctx, extra)
+}
+
+func (g *limitSwitchGantry) Stop(ctx context.Context, extra map[string]interface{}) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.oAx.Stop(ctx, extra)
+}
+
+func (g *limitSwitchGantry) ModelFrame() referenceframe.Model {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.oAx.ModelFrame()
+}
+
+func (g *limitSwitchGantry) CurrentInputs(ctx context.Context) ([]referenceframe.Input, error) {
+	return g.oAx.CurrentInputs(ctx)
+}
+
+func (g *limitSwitchGantry) GoToInputs(ctx context.Context, goal []referenceframe.Input) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.oAx.GoToInputs(ctx, goal)
+}
+
+func (g *limitSwitchGantry) IsMoving(ctx context.Context) (bool, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.oAx.IsMoving(ctx)
+}


### PR DESCRIPTION
Changes the one-axis structure to assume that we have knowledge of the position of gantry limits, and wraps that in limit switch logic if that is available. Both still need to "home", but axes with encoded motors can do so using math based on motor position and length input by the user.

Added tests for more coverage, and code cleanup. Hardware re-testing is needed when I am back, but not blocking.
- [ ]  Test on hardware when back in the office.