### PR TITLE
replicate-hang-on-panic

### DIFF
--- a/services/slam/builtin/orbslam_yaml.go
+++ b/services/slam/builtin/orbslam_yaml.go
@@ -26,6 +26,7 @@ const (
 
 // orbCamMaker takes in the camera properties and config params for orbslam and constructs a ORBsettings struct to use with yaml.Marshal.
 func (slamSvc *builtIn) orbCamMaker(camProperties *transform.PinholeCameraModel) (*ORBsettings, error) {
+	panic("this is a panic!")
 	var err error
 
 	if camProperties.PinholeCameraIntrinsics == nil {


### PR DESCRIPTION
When the panic is hit, the RDK OS process does not terminate. 
Logs stop being emitted. 
Ctrl-c does terminate the process.

Config:
```
{
  "components": [
    {
      "depends_on": [],
      "type": "camera",
      "model": "webcam",
      "name": "color",
      "attributes": {
        "video_path": "video0",
        "intrinsic_parameters": {
          "ppy": 252.38006394497992,
          "width_px": 640,
          "fx": 738.2067449333528,
          "fy": 740.2024480417015,
          "height_px": 480,
          "ppx": 319.152919932532
        }
      }
    }
  ],
  "services": [
    {
      "name": "run-slam",
      "type": "slam",
      "model": "orbslamv3",
      "attributes": {
        "use_live_data": true,
        "map_rate_sec": 60,
        "data_rate_ms": 200,
        "sensors": [
          "color"
        ],
        "config_params": {
          "orb_n_levels": "8",
          "orb_n_min_th_fast": "7",
          "debug": "false",
          "orb_scale_factor": "1.2",
          "mode": "mono",
          "orb_n_features": "1250",
          "orb_n_ini_th_fast": "20"
        },
        "data_dir": "/home/nickpi/orbslamv3_data"
      }
    }
  ]
}
```

Log output: 
```
2023-01-19T10:07:23.246-0500    DEBUG   robot_server    builtin/builtin.go:326  Running in live mode
2023-01-19T10:07:23.247-0500    DEBUG   robot_server    builtin/builtin.go:604  no data_rate_msec given, setting to default value of 200
2023/01/19 10:07:23 slam::slamService::New 495 ms
2023/01/19 10:07:23    slam::builtIn::getAndSaveDataSparse 493 ms
2023/01/19 10:07:23      rimage::EncodeImage::image/png 480 ms
2023-01-19T10:07:23.742-0500    INFO    robot_server.process.0_intelrealgrpcserver      pexec/managed_process.go:323    stopping process 25348 with signal terminated
2023-01-19T10:07:23.747-0500    DEBUG   robot_server.process.0_intelrealgrpcserver      pexec/managed_process.go:380    unable to check exit status
```