### PR TITLE
RSDK-1237 Added interaction space constraint management

### DIFF
--- a/motionplan/planManager.go
+++ b/motionplan/planManager.go
@@ -370,6 +370,15 @@ func (pm *planManager) plannerSetupFromMoveRequest(
 	}
 	opt.AddConstraint(defaultCollisionConstraintName, collisionConstraint)
 
+	// Only add the occupancy constraint if a given world space has an Interaction Space
+	if len(worldState.InteractionSpaces) > 0 {
+		occupancyConstraint, err := NewOccupancyConstraintFromWorldState(pm.frame, pm.fs, worldState, seedMap)
+		if err != nil {
+			return nil, err
+		}
+		opt.AddConstraint(defaultOccupancyConstraintName, occupancyConstraint)
+	}
+
 	// error handling around extracting motion_profile information from map[string]interface{}
 	var motionProfile string
 	profile, ok := planningOpts["motion_profile"]

--- a/motionplan/plannerOptions.go
+++ b/motionplan/plannerOptions.go
@@ -43,6 +43,7 @@ const (
 	defaultOrientationConstraintName  = "defaultOrientationConstraint"
 	defaultCollisionConstraintName    = "defaultCollisionConstraint"
 	defaultJointConstraint            = "defaultJointSwingConstraint"
+	defaultOccupancyConstraintName    = "defaultOccupancyConstraint"
 
 	// When breaking down a path into smaller waypoints, add a waypoint every this many mm of movement.
 	defaultPathStepSize = 10


### PR DESCRIPTION
Small addition to create a new interaction-space-encapsulation constraint. Automatically gets added to the `PlanManager` when there's an interaction space supplied in a `struct`.

**Without latest I-Space constraint additions:**
- We can move when fully outside the I-Space
- We can move when fully inside the I-Space
- We cannot move from the outside to the inside of the I-Space
- We cannot move from the inside to the outside (even partially) of the I-Space

**With the new Occupancy constraint addition:**
- We cannot move when fully outside the I-Space
- We can move when fully inside the I-Space
- We cannot move from the outside to the inside of the I-Space
- We cannot move from the inside to the outside (even partially) of the I-Space