### PR TITLE
format error properly

### DIFF
--- a/components/board/status.go
+++ b/components/board/status.go
@@ -23,7 +23,7 @@ func CreateStatus(ctx context.Context, b Board, extra map[string]interface{}) (*
 			}
 			val, err := x.Read(ctx, extra)
 			if err != nil {
-				return nil, errors.Wrap(err, "couldn't read analog (%s)")
+				return nil, errors.Wrapf(err, "couldn't read analog (%s)", name)
 			}
 			status.Analogs[name] = &commonpb.AnalogStatus{Value: int32(val)}
 		}


### PR DESCRIPTION
This was going to be in https://github.com/viamrobotics/rdk/pull/1759, which is no longer going to be merged. but this line shouldn't be forgotten! Without it, the error contains a `"%s"` in its description and doesn't mention the name of the pin that couldn't be read.

Github suggests I tag Eric, but he's a very busy man and this change isn't worth his time. Instead, I'll get a review from the low guy on the totem pole! (Sorry, Drew :wink:)