### PR TITLE
RSDK 889 - Restart web service on media change

### DIFF
--- a/config/diff.go
+++ b/config/diff.go
@@ -22,6 +22,7 @@ type Diff struct {
 	Removed        *Config
 	ResourcesEqual bool
 	NetworkEqual   bool
+	MediaEqual     bool
 	PrettyDiff     string
 }
 
@@ -71,6 +72,8 @@ func DiffConfigs(left, right Config, revealSensitiveConfigDiffs bool) (_ *Diff, 
 
 	networkDifferent := diffNetworkingCfg(&left, &right)
 	diff.NetworkEqual = !networkDifferent
+
+	diff.MediaEqual = diffMedia(diff.Added, diff.Removed)
 
 	return &diff, nil
 }
@@ -400,4 +403,18 @@ func diffTLS(leftTLS, rightTLS *tls.Config) bool {
 		return true
 	}
 	return false
+}
+
+func diffMedia(added, removed *Config) bool {
+	for idx := 0; idx < len(added.Components); idx++ {
+		if added.Components[idx].Type == "camera" {
+			return false
+		}
+	}
+	for idx := 0; idx < len(removed.Components); idx++ {
+		if removed.Components[idx].Type == "camera" {
+			return false
+		}
+	}
+	return true
 }

--- a/config/diff.go
+++ b/config/diff.go
@@ -73,7 +73,8 @@ func DiffConfigs(left, right Config, revealSensitiveConfigDiffs bool) (_ *Diff, 
 	networkDifferent := diffNetworkingCfg(&left, &right)
 	diff.NetworkEqual = !networkDifferent
 
-	diff.MediaEqual = diffMedia(diff.Added, diff.Removed)
+	different = diffMedia(diff.Added, diff.Removed)
+	diff.MediaEqual = !different
 
 	return &diff, nil
 }
@@ -407,14 +408,14 @@ func diffTLS(leftTLS, rightTLS *tls.Config) bool {
 
 func diffMedia(added, removed *Config) bool {
 	for idx := 0; idx < len(added.Components); idx++ {
-		if added.Components[idx].Type == "camera" {
-			return false
+		if added.Components[idx].Type == "camera" || added.Components[idx].Type == "audio_input" {
+			return true
 		}
 	}
 	for idx := 0; idx < len(removed.Components); idx++ {
-		if removed.Components[idx].Type == "camera" {
-			return false
+		if removed.Components[idx].Type == "camera" || removed.Components[idx].Type == "audio_input" {
+			return true
 		}
 	}
-	return true
+	return false
 }

--- a/config/diff_test.go
+++ b/config/diff_test.go
@@ -178,6 +178,7 @@ func TestDiffConfigs(t *testing.T) {
 				Removed:        &config.Config{},
 				ResourcesEqual: true,
 				NetworkEqual:   true,
+				MediaEqual:     true,
 			},
 		},
 		{
@@ -190,6 +191,7 @@ func TestDiffConfigs(t *testing.T) {
 				Removed:        &config.Config{},
 				ResourcesEqual: true,
 				NetworkEqual:   true,
+				MediaEqual:     true,
 			},
 		},
 		{
@@ -202,6 +204,7 @@ func TestDiffConfigs(t *testing.T) {
 				Removed:        &config.Config{},
 				ResourcesEqual: false,
 				NetworkEqual:   true,
+				MediaEqual:     true,
 			},
 		},
 		{
@@ -214,6 +217,7 @@ func TestDiffConfigs(t *testing.T) {
 				Modified:       &config.ModifiedConfigDiff{},
 				ResourcesEqual: false,
 				NetworkEqual:   true,
+				MediaEqual:     true,
 			},
 		},
 		{
@@ -226,6 +230,7 @@ func TestDiffConfigs(t *testing.T) {
 				Modified:       &config2,
 				ResourcesEqual: false,
 				NetworkEqual:   true,
+				MediaEqual:     true,
 			},
 		},
 		{
@@ -328,6 +333,7 @@ func TestDiffConfigs(t *testing.T) {
 				},
 				ResourcesEqual: false,
 				NetworkEqual:   true,
+				MediaEqual:     true,
 			},
 		},
 	} {

--- a/config/diff_test.go
+++ b/config/diff_test.go
@@ -14,6 +14,7 @@ import (
 	"go.viam.com/rdk/components/base"
 	"go.viam.com/rdk/components/board"
 	fakeboard "go.viam.com/rdk/components/board/fake"
+	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/resource"
 )
@@ -633,5 +634,45 @@ func TestDiffSanitize(t *testing.T) {
 		test.That(t, diffStr, test.ShouldNotContainSubstring, rem.Secret)
 		test.That(t, diffStr, test.ShouldNotContainSubstring, rem.Auth.Credentials.Payload)
 		test.That(t, diffStr, test.ShouldNotContainSubstring, rem.Auth.SignalingCreds.Payload)
+	}
+}
+
+func TestDiffMedia(t *testing.T) {
+	config1 := config.Config{}
+	config2 := config.Config{
+		Components: []config.Component{
+			{
+				Namespace: resource.ResourceNamespaceRDK,
+				Name:      "cam1",
+				Type:      camera.SubtypeName,
+				API:       camera.Subtype,
+				Model:     fakeModel,
+			},
+		},
+	}
+	for _, tc := range []struct {
+		Name       string
+		Leftcfg    config.Config
+		RightCfg   config.Config
+		MediaEqual bool
+	}{
+		{
+			"different media config",
+			config1,
+			config2,
+			false,
+		},
+		{
+			"same media config",
+			config2,
+			config2,
+			true,
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			diff, err := config.DiffConfigs(tc.Leftcfg, tc.RightCfg, true)
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, diff.MediaEqual, test.ShouldEqual, tc.MediaEqual)
+		})
 	}
 }

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -307,20 +307,22 @@ func (s *robotServer) serveWeb(ctx context.Context, cfg *config.Config) (err err
 					continue
 				}
 				var options weboptions.Options
-				if !diff.NetworkEqual {
+
+				if !diff.NetworkEqual || !diff.MediaEqual {
+					if err := myRobot.StopWeb(); err != nil {
+						s.logger.Errorw("reconfiguration failed: error stopping web service while reconfiguring", "error", err)
+						continue
+					}
 					options, err = s.createWebOptions(processedConfig)
 					if err != nil {
 						s.logger.Errorw("reconfiguration aborted: error creating weboptions", "error", err)
 						continue
 					}
 				}
+
 				myRobot.Reconfigure(ctx, processedConfig)
 
-				if !diff.NetworkEqual {
-					if err := myRobot.StopWeb(); err != nil {
-						s.logger.Errorw("reconfiguration failed: error stopping web service while reconfiguring", "error", err)
-						continue
-					}
+				if !diff.NetworkEqual || !diff.MediaEqual {
 					if err := myRobot.StartWeb(ctx, options); err != nil {
 						s.logger.Errorw("reconfiguration failed: error starting web service while reconfiguring", "error", err)
 					}


### PR DESCRIPTION
### Description

This PR fixes a problem with the local `rc page` not being able to switch from `grpc` to `webrtc` when a media component is added.

Added a method to `diff.go` called `diffMedia` and an attribute to the `Diff` struct called `MediaEqual`.

WARNING
I had to slightly rearrange the reconfiguring process to first `StopWeb` before `createWebOptions`  and `myRobot.Reconfigure` to avoid race conditions with the `webService` close out.

### Test
> tested on RPI

To recreate, start with an empty config and run the server.
```
$ go run ./web/cmd/server/main.go --config ./to/local/config.json
```
```
{}
```

Notice how the rc page on `localhost:8080` is using GRPC.

Then, edit the config by adding a camera component:

```
{
    "components": [
        {
            "type": "camera",
            "model": "webcam",
            "name": "cam1"
        }
    ]
}
```

Refresh the webpage - now loading with WebRTC!



