### PR TITLE
Don't spam log messages on sysfs boards

### DIFF
--- a/components/board/commonsysfs/board.go
+++ b/components/board/commonsysfs/board.go
@@ -226,7 +226,6 @@ func (b *sysfsBoard) SPINames() []string {
 }
 
 func (b *sysfsBoard) I2CNames() []string {
-	b.logger.Warn("I2C is not currently supported on sysfs boards.")
 	return nil
 }
 
@@ -239,7 +238,6 @@ func (b *sysfsBoard) AnalogReaderNames() []string {
 }
 
 func (b *sysfsBoard) DigitalInterruptNames() []string {
-	b.logger.Warn("Digital interrupts are not currently supported on sysfs boards.")
 	return nil
 }
 


### PR DESCRIPTION
Sorry about this! We want to log when you try using the unimplemented parts, but not when you're just checking their statuses. So, remove half of https://github.com/viamrobotics/rdk/pull/1786. 

This time, we're going to actually try it out on a robot before merging. Thanks to @thegreatco and @dannenberg for pointing out the problem.