### PR TITLE
enable other repos to trigger motion benchmarks

### DIFF
--- a/.github/workflows/motion-benchmarks.yml
+++ b/.github/workflows/motion-benchmarks.yml
@@ -16,11 +16,6 @@ jobs:
       BASELINE: ${{ github.event.pull_request.base.label }}
       MODIFIED: ${{ github.event.pull_request.head.label }}
     steps:
-    - name: Dump github context
-      run:   echo "$GITHUB_CONTEXT"
-      shell: bash
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
     - name: Check out main branch code
       if: github.event_name != 'pull_request_target'
       uses: actions/checkout@v3

--- a/.github/workflows/motion-benchmarks.yml
+++ b/.github/workflows/motion-benchmarks.yml
@@ -43,13 +43,15 @@ jobs:
     - name: Run motion quality tests on main branch
       run: |
         cd motion-testing
-        go get -v -u go.viam.com/rdk@${{ github.event.pull_request.base.sha }}
+        go mod edit -replace go.viam.com/rdk=${{ github.event.pull_request.base.repo.html_url#"https://" }}@${{ github.event.pull_request.base.sha }}
+        go mod tidy
         sudo -u testbot bash -lc "sudo go test ./... -v -run TestDefault --name=$BASELINE"
         
     - name: Run motion quality tests on PR branch
       run: |
         cd motion-testing
-        go get -v -u go.viam.com/rdk@${{ github.event.pull_request.head.sha }}
+        go mod edit -replace go.viam.com/rdk=${{ github.event.pull_request.head.repo.html_url#"https://" }}@${{ github.event.pull_request.head.sha }}
+        go mod tidy
         sudo -u testbot bash -lc "sudo go test ./... -v -run TestDefault --name=$MODIFIED"
         
     - name: Print results

--- a/.github/workflows/motion-benchmarks.yml
+++ b/.github/workflows/motion-benchmarks.yml
@@ -42,17 +42,23 @@ jobs:
 
     - name: Run motion quality tests on main branch
       shell: bash
+      env: 
+        URL: ${{ github.event.pull_request.base.repo.html_url }}
+        SHA: ${{ github.event.pull_request.base.sha }}
       run: |
         cd motion-testing
-        go mod edit -replace go.viam.com/rdk=${{ github.event.pull_request.base.repo.html_url#"https://" }}@${{ github.event.pull_request.base.sha }}
+        go mod edit -replace go.viam.com/rdk=${URL#"https://"}@$SHA
         go mod tidy
         sudo -u testbot bash -lc "sudo go test ./... -v -run TestDefault --name=$BASELINE"
         
     - name: Run motion quality tests on PR branch
       shell: bash
+      env: 
+        URL: ${{ github.event.pull_request.head.repo.html_url }}
+        SHA: ${{ github.event.pull_request.head.sha }}
       run: |
         cd motion-testing
-        go mod edit -replace go.viam.com/rdk=${{ github.event.pull_request.head.repo.html_url#"https://" }}@${{ github.event.pull_request.head.sha }}
+        go mod edit -replace go.viam.com/rdk=${URL#"https://"}@$SHA
         go mod tidy
         sudo -u testbot bash -lc "sudo go test ./... -v -run TestDefault --name=$MODIFIED"
         

--- a/.github/workflows/motion-benchmarks.yml
+++ b/.github/workflows/motion-benchmarks.yml
@@ -16,6 +16,11 @@ jobs:
       BASELINE: ${{ github.event.pull_request.base.label }}
       MODIFIED: ${{ github.event.pull_request.head.label }}
     steps:
+    - name: Dump github context
+      run:   echo "$GITHUB_CONTEXT"
+      shell: bash
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
     - name: Check out main branch code
       if: github.event_name != 'pull_request_target'
       uses: actions/checkout@v3

--- a/.github/workflows/motion-benchmarks.yml
+++ b/.github/workflows/motion-benchmarks.yml
@@ -41,6 +41,7 @@ jobs:
         path: motion-testing
 
     - name: Run motion quality tests on main branch
+      shell: bash
       run: |
         cd motion-testing
         go mod edit -replace go.viam.com/rdk=${{ github.event.pull_request.base.repo.html_url#"https://" }}@${{ github.event.pull_request.base.sha }}
@@ -48,6 +49,7 @@ jobs:
         sudo -u testbot bash -lc "sudo go test ./... -v -run TestDefault --name=$BASELINE"
         
     - name: Run motion quality tests on PR branch
+      shell: bash
       run: |
         cd motion-testing
         go mod edit -replace go.viam.com/rdk=${{ github.event.pull_request.head.repo.html_url#"https://" }}@${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/motion-pull-request-trusted.yml
+++ b/.github/workflows/motion-pull-request-trusted.yml
@@ -6,7 +6,7 @@ concurrency:
 
 on:
   pull_request_target:
-    branches: [ main]
+    branches: [ motion-benchmarks-fix ]
     types: [ labeled ]
     paths:
       - 'motionplan/**'
@@ -22,4 +22,4 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' || 
       (github.event_name == 'pull_request_target' && (github.event.label.name == 'safe to test' || github.event.label.name == 'appimage') && contains(github.event.pull_request.labels.*.name, 'safe to test'))
-    uses: viamrobotics/rdk/.github/workflows/motion-benchmarks.yml@main
+    uses: viamrobotics/rdk/.github/workflows/motion-benchmarks.yml@motion-benchmarks-fix

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -2,7 +2,7 @@ name: PR Test Label Manager
 
 on:
   pull_request_target:
-    branches: [ main ]
+    branches: [ motion-benchmarks-fix ]
     types: [ opened, synchronize, reopened ]
 
 jobs:


### PR DESCRIPTION
This PR fixes a bug I created earlier today when I pushed the first version of the motion benchmarking Github action. I had overlooked that I will have to be more general in my logic to `go get` the head branch, and this will fix that to make it more robust.

See [this reference PR](https://github.com/viamrobotics/rdk/pull/1797) for a demonstration that this new iteration is functional from PRs within RDK. And [another reference PR](https://github.com/viamrobotics/rdk/pull/1799) to show that it works from other forks, etc.