### PR TITLE
Fix video source for image streams

### DIFF
--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -299,6 +299,7 @@ func NewWebcamSource(ctx context.Context, attrs *WebcamAttrs, logger golog.Logge
 	const wait = 500 * time.Millisecond
 	camWg := CameraWaitGroup{cam: cam.(camera.Camera)}
 	camWg.activeBackgroundWorkers.Add(1)
+
 	goutils.ManagedGo(func() {
 		defer goutils.UncheckedError(goutils.TryClose(ctx, cam))
 		for {
@@ -328,7 +329,7 @@ func NewWebcamSource(ctx context.Context, attrs *WebcamAttrs, logger golog.Logge
 		}
 	}, camWg.activeBackgroundWorkers.Done)
 
-	return &camWg, nil
+	return cam.(camera.Camera), nil
 }
 
 // tryWebcamOpen uses getNamedVideoSource to try and find a video device (gostream.MediaSource).

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -606,8 +606,13 @@ func (svc *webService) startStream(streamFunc func(opts *webstream.BackoffTuning
 
 func (svc *webService) startImageStream(ctx context.Context, source gostream.VideoSource, stream gostream.Stream) {
 	ctxWithJPEGHint := gostream.WithMIMETypeHint(ctx, rutils.WithLazyMIMEType(rutils.MimeTypeJPEG))
+	actualCam := rutils.UnwrapProxy(source).(camera.Camera)
+	cameraSource, err := camera.SourceFromCamera(actualCam)
+	if err != nil {
+		golog.Global().Errorf("error getting camera source: %v", err)
+	}
 	svc.startStream(func(opts *webstream.BackoffTuningOptions) error {
-		return webstream.StreamVideoSource(ctxWithJPEGHint, source, stream, opts)
+		return webstream.StreamVideoSource(ctxWithJPEGHint, cameraSource, stream, opts)
 	})
 }
 


### PR DESCRIPTION
### Description

This PR fixes an issue in how we pass the video source to gostream.  Instead of passing a wrapped Camera, RDK now sends the video source on `startImageStream`.

### Test
1. Set up RDK with camera component
2. Start video feed in app.viam.com

Check logs. No more annoying `no properties found for media; will assume empty` logs.