### PR TITLE
Extra documentation for accelerometers

### DIFF
--- a/components/movementsensor/adxl345/adxl345.go
+++ b/components/movementsensor/adxl345/adxl345.go
@@ -1,7 +1,18 @@
 // Package adxl345 implements the MovementSensor interface for the ADXL345 accelerometer attached
-// to the I2C bus of the robot (the chip supports communicating over SPI as well, but this package
-// does not support that interface). The manual for this chip is available at:
+// to an I2C bus on the robot (the chip supports communicating over SPI as well, but this package
+// does not support that interface). The datasheet for this chip is available at:
 // https://www.analog.com/media/en/technical-documentation/data-sheets/adxl345.pdf
+
+// We support reading the accelerometer data off of the chip. We do not yet support using the
+// digital interrupt pins to notify when interesting things happen (freefall, collisions, etc.). 
+
+// Because we only support I2C interaction, the CS pin must be wired to a high signal (which tells
+// the chip which communication interface to use). The chip has two possible I2C addresses, which
+// can be selected by wiring the SDO pin to either hot or ground:
+//   - if SDO is wired to ground, it uses the default I2C address of 0x53
+//   - if SDO is wired to hot, it uses the alternate I2C address of 0x1D
+// If you use the alternate address, your config file for this component must set its
+// "use_alternate_i2c_address" boolean to true.
 package adxl345
 
 import (
@@ -31,7 +42,7 @@ var modelName = resource.NewDefaultModel("accel-adxl345")
 type AttrConfig struct {
 	BoardName              string `json:"board"`
 	I2cBus                 string `json:"i2c_bus"`
-	UseAlternateI2CAddress bool   `json:"use_alternate_i2c_address"`
+	UseAlternateI2CAddress bool   `json:"use_alternate_i2c_address,omitempty"`
 }
 
 // Validate ensures all parts of the config are valid, and then returns the list of things we

--- a/components/movementsensor/adxl345/adxl345.go
+++ b/components/movementsensor/adxl345/adxl345.go
@@ -4,11 +4,11 @@
 // https://www.analog.com/media/en/technical-documentation/data-sheets/adxl345.pdf
 //
 // We support reading the accelerometer data off of the chip. We do not yet support using the
-// digital interrupt pins to notify when interesting things happen (freefall, collisions, etc.).
+// digital interrupt pins to notify on events (freefall, collision, etc.).
 //
-// Because we only support I2C interaction, the CS pin must be wired to a high signal (which tells
-// the chip which communication interface to use). The chip has two possible I2C addresses, which
-// can be selected by wiring the SDO pin to either hot or ground:
+// Because we only support I2C interaction, the CS pin must be wired to hot (which tells the chip
+// which communication interface to use). The chip has two possible I2C addresses, which can be
+// selected by wiring the SDO pin to either hot or ground:
 //   - if SDO is wired to ground, it uses the default I2C address of 0x53
 //   - if SDO is wired to hot, it uses the alternate I2C address of 0x1D
 //

--- a/components/movementsensor/adxl345/adxl345.go
+++ b/components/movementsensor/adxl345/adxl345.go
@@ -2,10 +2,10 @@
 // to an I2C bus on the robot (the chip supports communicating over SPI as well, but this package
 // does not support that interface). The datasheet for this chip is available at:
 // https://www.analog.com/media/en/technical-documentation/data-sheets/adxl345.pdf
-
+//
 // We support reading the accelerometer data off of the chip. We do not yet support using the
 // digital interrupt pins to notify when interesting things happen (freefall, collisions, etc.). 
-
+//
 // Because we only support I2C interaction, the CS pin must be wired to a high signal (which tells
 // the chip which communication interface to use). The chip has two possible I2C addresses, which
 // can be selected by wiring the SDO pin to either hot or ground:

--- a/components/movementsensor/adxl345/adxl345.go
+++ b/components/movementsensor/adxl345/adxl345.go
@@ -4,13 +4,14 @@
 // https://www.analog.com/media/en/technical-documentation/data-sheets/adxl345.pdf
 //
 // We support reading the accelerometer data off of the chip. We do not yet support using the
-// digital interrupt pins to notify when interesting things happen (freefall, collisions, etc.). 
+// digital interrupt pins to notify when interesting things happen (freefall, collisions, etc.).
 //
 // Because we only support I2C interaction, the CS pin must be wired to a high signal (which tells
 // the chip which communication interface to use). The chip has two possible I2C addresses, which
 // can be selected by wiring the SDO pin to either hot or ground:
 //   - if SDO is wired to ground, it uses the default I2C address of 0x53
 //   - if SDO is wired to hot, it uses the alternate I2C address of 0x1D
+//
 // If you use the alternate address, your config file for this component must set its
 // "use_alternate_i2c_address" boolean to true.
 package adxl345

--- a/components/movementsensor/mpu6050/mpu6050.go
+++ b/components/movementsensor/mpu6050/mpu6050.go
@@ -5,9 +5,9 @@
 // https://download.datasheets.com/pdfs/2015/3/19/8/3/59/59/invse_/manual/5rm-mpu-6000a-00v4.2.pdf
 //
 // We support reading the accelerometer, gyroscope, and thermometer data off of the chip. We do not
-// yet support using the digital interrupt pin to notify when interesting things happen (freefall,
-// collisions, etc.), nor do we yet support using the secondary I2C connection to add an external
-// clock or magnetometer.
+// yet support using the digital interrupt pin to notify on events (freefall, collision, etc.),
+// nor do we yet support using the secondary I2C connection to add an external clock or
+// magnetometer.
 //
 // The chip has two possible I2C addresses, which can be selected by wiring the AD0 pin to either
 // hot or ground:

--- a/components/movementsensor/mpu6050/mpu6050.go
+++ b/components/movementsensor/mpu6050/mpu6050.go
@@ -7,12 +7,13 @@
 // We support reading the accelerometer, gyroscope, and thermometer data off of the chip. We do not
 // yet support using the digital interrupt pin to notify when interesting things happen (freefall,
 // collisions, etc.), nor do we yet support using the I2C slave connection to add an external clock
-// or magnetometer. 
+// or magnetometer.
 //
 // The chip has two possible I2C addresses, which can be selected by wiring the AD0 pin to either
 // hot or ground:
 //   - if AD0 is wired to ground, it uses the default I2C address of 0x68
 //   - if AD0 is wired to hot, it uses the alternate I2C address of 0x69
+//
 // If you use the alternate address, your config file for this component must set its
 // "use_alternate_i2c_address" boolean to true.
 package mpu6050

--- a/components/movementsensor/mpu6050/mpu6050.go
+++ b/components/movementsensor/mpu6050/mpu6050.go
@@ -1,4 +1,20 @@
-// Package mpu6050 implements the movementsensor interface for an MPU-6050 6-axis accelerometer.
+// Package mpu6050 implements the movementsensor interface for an MPU-6050 6-axis accelerometer. A
+// datasheet for this chip is at
+// https://components101.com/sites/default/files/component_datasheet/MPU6050-DataSheet.pdf and a
+// description of the I2C registers is at
+// https://download.datasheets.com/pdfs/2015/3/19/8/3/59/59/invse_/manual/5rm-mpu-6000a-00v4.2.pdf
+
+// We support reading the accelerometer, gyroscope, and thermometer data off of the chip. We do not
+// yet support using the digital interrupt pin to notify when interesting things happen (freefall,
+// collisions, etc.), nor do we yet support using the I2C slave connection to add an external clock
+// or magnetometer. 
+
+// The chip has two possible I2C addresses, which can be selected by wiring the AD0 pin to either
+// hot or ground:
+//   - if AD0 is wired to ground, it uses the default I2C address of 0x68
+//   - if AD0 is wired to hot, it uses the alternate I2C address of 0x69
+// If you use the alternate address, your config file for this component must set its
+// "use_alternate_i2c_address" boolean to true.
 package mpu6050
 
 import (

--- a/components/movementsensor/mpu6050/mpu6050.go
+++ b/components/movementsensor/mpu6050/mpu6050.go
@@ -6,8 +6,8 @@
 //
 // We support reading the accelerometer, gyroscope, and thermometer data off of the chip. We do not
 // yet support using the digital interrupt pin to notify when interesting things happen (freefall,
-// collisions, etc.), nor do we yet support using the I2C slave connection to add an external clock
-// or magnetometer.
+// collisions, etc.), nor do we yet support using the secondary I2C connection to add an external
+// clock or magnetometer.
 //
 // The chip has two possible I2C addresses, which can be selected by wiring the AD0 pin to either
 // hot or ground:

--- a/components/movementsensor/mpu6050/mpu6050.go
+++ b/components/movementsensor/mpu6050/mpu6050.go
@@ -3,12 +3,12 @@
 // https://components101.com/sites/default/files/component_datasheet/MPU6050-DataSheet.pdf and a
 // description of the I2C registers is at
 // https://download.datasheets.com/pdfs/2015/3/19/8/3/59/59/invse_/manual/5rm-mpu-6000a-00v4.2.pdf
-
+//
 // We support reading the accelerometer, gyroscope, and thermometer data off of the chip. We do not
 // yet support using the digital interrupt pin to notify when interesting things happen (freefall,
 // collisions, etc.), nor do we yet support using the I2C slave connection to add an external clock
 // or magnetometer. 
-
+//
 // The chip has two possible I2C addresses, which can be selected by wiring the AD0 pin to either
 // hot or ground:
 //   - if AD0 is wired to ground, it uses the default I2C address of 0x68


### PR DESCRIPTION
...and also marking the optional config value as optional.

Should the documentation mention that backup copies of the 3 datasheets mentioned are available at https://drive.google.com/drive/folders/1-4yLhMyciG8mu0XWf5lq9o-1BAPpBXdJ ? Maybe not: perhaps Google Drive is private to just Viam employees.

I'm unable to test out that the `omitempty` annotation is working correctly. Things run fine on my robot (i.e., the sensor still functions as you'd expect), but I'd like to have the asterisk removed from this image:
![Screenshot_2023-01-30_13-49-50](https://user-images.githubusercontent.com/2861124/215568618-0633d155-fe22-4366-b8ca-ed18bb49d19a.png)
Any ideas on that front?