### PR TITLE
RSDK-1732 Fix for Flaky Cartographer SLAM Test

### DIFF
--- a/services/slam/builtin/cartographer_int_test.go
+++ b/services/slam/builtin/cartographer_int_test.go
@@ -84,7 +84,7 @@ func integrationtestHelperCartographer(t *testing.T, mode slam.Mode) {
 
 	t.Log("\n=== Testing online mode ===\n")
 
-	mapRate := 1
+	mapRate := 9999
 	deleteProcessedData := false
 	useLiveData := true
 
@@ -109,8 +109,21 @@ func integrationtestHelperCartographer(t *testing.T, mode slam.Mode) {
 
 	// Release point cloud, since cartographer looks for the second most recent point cloud
 	cartographerIntLidarReleasePointCloudChan <- 1
-	// Wait for cartographer to finish processing data
+
+	// Make sure we initialize in mapping mode
 	logReader := svc.(testhelper.Service).GetSLAMProcessBufferedLogReader()
+	for {
+		line, err := logReader.ReadString('\n')
+		test.That(t, err, test.ShouldBeNil)
+		if strings.Contains(line, "Running in mapping mode") {
+			break
+		}
+
+		test.That(t, strings.Contains(line, "Running in updating mode"), test.ShouldBeFalse)
+		test.That(t, strings.Contains(line, "Running in localization only mode"), test.ShouldBeFalse)
+	}
+
+	// Wait for cartographer to finish processing data
 	for i := 0; i < numCartographerPointClouds-2; i++ {
 		t.Logf("Find log line for point cloud %v", i)
 		cartographerIntLidarReleasePointCloudChan <- 1
@@ -145,14 +158,11 @@ func integrationtestHelperCartographer(t *testing.T, mode slam.Mode) {
 	test.That(t, os.Remove(name+"/data/"+lastFileName), test.ShouldBeNil)
 	prevNumFiles -= 1
 
-	// Remove maps so that testing in offline mode will run in mapping mode,
-	// as opposed to updating mode.
-	test.That(t, resetFolder(name+"/map"), test.ShouldBeNil)
-
 	// Test offline mode using the data generated in the online test
 	t.Log("\n=== Testing offline mode ===\n")
 
 	useLiveData = false
+	mapRate = 1
 
 	attrCfg = &builtin.AttrConfig{
 		Sensors: []string{},
@@ -170,8 +180,19 @@ func integrationtestHelperCartographer(t *testing.T, mode slam.Mode) {
 	svc, err = createSLAMService(t, attrCfg, "cartographer", golog.NewTestLogger(t), true, true)
 	test.That(t, err, test.ShouldBeNil)
 
-	// Wait for cartographer to finish processing data
+	// Make sure we initialize in mapping mode
 	logReader = svc.(testhelper.Service).GetSLAMProcessBufferedLogReader()
+	for {
+		line, err := logReader.ReadString('\n')
+		test.That(t, err, test.ShouldBeNil)
+		if strings.Contains(line, "Running in mapping mode") {
+			break
+		}
+		test.That(t, strings.Contains(line, "Running in updating mode"), test.ShouldBeFalse)
+		test.That(t, strings.Contains(line, "Running in localization only mode"), test.ShouldBeFalse)
+	}
+
+	// Wait for cartographer to finish processing data
 	for {
 		line, err := logReader.ReadString('\n')
 		test.That(t, err, test.ShouldBeNil)
@@ -230,7 +251,7 @@ func integrationtestHelperCartographer(t *testing.T, mode slam.Mode) {
 	svc, err = createSLAMService(t, attrCfg, "cartographer", golog.NewTestLogger(t), true, true)
 	test.That(t, err, test.ShouldBeNil)
 
-	// Make sure we initialize from a saved map
+	// Make sure we initialize in localization mode
 	logReader = svc.(testhelper.Service).GetSLAMProcessBufferedLogReader()
 	for {
 		line, err := logReader.ReadString('\n')
@@ -303,7 +324,7 @@ func integrationtestHelperCartographer(t *testing.T, mode slam.Mode) {
 	svc, err = createSLAMService(t, attrCfg, "cartographer", golog.NewTestLogger(t), true, true)
 	test.That(t, err, test.ShouldBeNil)
 
-	// Make sure we initialize from a saved map
+	// Make sure we initialize in updating mode
 	logReader = svc.(testhelper.Service).GetSLAMProcessBufferedLogReader()
 	for {
 		line, err := logReader.ReadString('\n')

--- a/services/slam/builtin/cartographer_int_test.go
+++ b/services/slam/builtin/cartographer_int_test.go
@@ -158,6 +158,9 @@ func integrationtestHelperCartographer(t *testing.T, mode slam.Mode) {
 	test.That(t, os.Remove(name+"/data/"+lastFileName), test.ShouldBeNil)
 	prevNumFiles -= 1
 
+	// Check that no maps were generated during previous test
+	testCartographerDir(t, name, 0)
+
 	// Test offline mode using the data generated in the online test
 	t.Log("\n=== Testing offline mode ===\n")
 


### PR DESCRIPTION
This PR fixes a flaky test in the cartographer integration tests where an unexpected map would be generated due to slow close out leading to failures in the offline mode test which was expecting no maps. This has been resolved by changing the map rate on the initial online test and removing the creation of a map at closeout on the SLAM side of things

JIRa Ticket: [RSDK-1732](https://viam.atlassian.net/browse/RSDK-1732)

Associated PR: [#143](https://github.com/viamrobotics/slam/pull/143)

[RSDK-1732]: https://viam.atlassian.net/browse/RSDK-1732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ