### PR TITLE
RSDK-1130 unwrap camera for gostream ingestion

### DIFF
--- a/components/camera/camera.go
+++ b/components/camera/camera.go
@@ -228,6 +228,17 @@ func SourceFromCamera(cam Camera) (gostream.VideoSource, error) {
 	if asSrc, ok := cam.(*videoSource); ok {
 		return asSrc.videoSource, nil
 	}
+
+	if asWaitGroup, ok := cam.(*CameraWaitGroup); ok {
+		asAct := utils.UnwrapProxy(asWaitGroup.Cam).(Camera)
+		return SourceFromCamera(asAct)
+	}
+
+	if asReconfigurable, ok := cam.(*reconfigurableCamera); ok {
+		asAct := utils.UnwrapProxy(asReconfigurable).(Camera)
+		return SourceFromCamera(asAct)
+	}
+
 	return nil, errors.Errorf("invalid conversion from %T to %v", cam, "*camera.videoSource")
 }
 

--- a/components/camera/camera.go
+++ b/components/camera/camera.go
@@ -229,7 +229,7 @@ func SourceFromCamera(cam Camera) (gostream.VideoSource, error) {
 		return asSrc.videoSource, nil
 	}
 
-	if asWaitGroup, ok := cam.(*CameraWaitGroup); ok {
+	if asWaitGroup, ok := cam.(*WaitGroupCamera); ok {
 		return SourceFromCamera(asWaitGroup.Cam)
 	}
 

--- a/components/camera/camera.go
+++ b/components/camera/camera.go
@@ -230,8 +230,7 @@ func SourceFromCamera(cam Camera) (gostream.VideoSource, error) {
 	}
 
 	if asWaitGroup, ok := cam.(*CameraWaitGroup); ok {
-		asAct := utils.UnwrapProxy(asWaitGroup.Cam).(Camera)
-		return SourceFromCamera(asAct)
+		return SourceFromCamera(asWaitGroup.Cam)
 	}
 
 	if asReconfigurable, ok := cam.(*reconfigurableCamera); ok {

--- a/components/camera/camera_test.go
+++ b/components/camera/camera_test.go
@@ -237,11 +237,15 @@ func TestSourceFromCamera(t *testing.T) {
 
 	wgCam := &camera.WaitGroupCamera{Cam: reconfCam.(camera.Camera)}
 	test.That(t, wgCam.Cam, test.ShouldNotBeNil)
-	wgReconfCam, err := camera.WrapWithReconfigurable(wgCam, resource.Name{})
-	test.That(t, err, test.ShouldBeNil)
-	source2, err := camera.SourceFromCamera(wgReconfCam.(camera.Camera))
+	source2, err := camera.SourceFromCamera(wgCam)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, source2, test.ShouldNotBeNil)
+
+	wgReconfCam, err := camera.WrapWithReconfigurable(wgCam, resource.Name{})
+	test.That(t, err, test.ShouldBeNil)
+	source3, err := camera.SourceFromCamera(wgReconfCam.(camera.Camera))
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, source3, test.ShouldNotBeNil)
 }
 
 func TestClose(t *testing.T) {

--- a/components/camera/camera_test.go
+++ b/components/camera/camera_test.go
@@ -231,15 +231,15 @@ func TestSourceFromCamera(t *testing.T) {
 	reconfCam, err := camera.WrapWithReconfigurable(actualCam, resource.Name{})
 	test.That(t, reconfCam, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldBeNil)
-
 	source, err := camera.SourceFromCamera(reconfCam.(camera.Camera))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, source, test.ShouldNotBeNil)
 
-	wgCam := camera.WaitGroupCamera{Cam: reconfCam.(camera.Camera)}
+	wgCam := &camera.WaitGroupCamera{Cam: reconfCam.(camera.Camera)}
 	test.That(t, wgCam.Cam, test.ShouldNotBeNil)
-
-	source2, err := camera.SourceFromCamera(wgCam.Cam)
+	wgReconfCam, err := camera.WrapWithReconfigurable(wgCam, resource.Name{})
+	test.That(t, err, test.ShouldBeNil)
+	source2, err := camera.SourceFromCamera(wgReconfCam.(camera.Camera))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, source2, test.ShouldNotBeNil)
 }

--- a/components/camera/camera_test.go
+++ b/components/camera/camera_test.go
@@ -236,7 +236,7 @@ func TestSourceFromCamera(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, source, test.ShouldNotBeNil)
 
-	wgCam := camera.CameraWaitGroup{Cam: reconfCam.(camera.Camera)}
+	wgCam := camera.WaitGroupCamera{Cam: reconfCam.(camera.Camera)}
 	test.That(t, wgCam.Cam, test.ShouldNotBeNil)
 
 	source2, err := camera.SourceFromCamera(wgCam.Cam)

--- a/components/camera/camera_test.go
+++ b/components/camera/camera_test.go
@@ -223,6 +223,22 @@ func TestReconfigurableCamera(t *testing.T) {
 	test.That(t, stream.Close(context.Background()), test.ShouldBeNil)
 }
 
+func TestSourceFromCamera(t *testing.T) {
+	videoSrc := &simpleSource{"rimage/board1_small"}
+	actualCam, err := camera.NewFromReader(context.Background(), videoSrc, nil, camera.UnspecifiedStream)
+	reconfCam, err := camera.WrapWithReconfigurable(actualCam, resource.Name{})
+	test.That(t, reconfCam, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldBeNil)
+	source, err := camera.SourceFromCamera(reconfCam.(camera.Camera))
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, source, test.ShouldNotBeNil)
+	wgCam := camera.CameraWaitGroup{Cam: reconfCam.(camera.Camera)}
+	test.That(t, wgCam.Cam, test.ShouldNotBeNil)
+	source2, err := camera.SourceFromCamera(wgCam.Cam)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, source2, test.ShouldNotBeNil)
+}
+
 func TestClose(t *testing.T) {
 	actualCamera1 := &mock{Name: testCameraName}
 	reconfCamera1, err := camera.WrapWithReconfigurable(actualCamera1, resource.Name{})

--- a/components/camera/camera_test.go
+++ b/components/camera/camera_test.go
@@ -226,14 +226,19 @@ func TestReconfigurableCamera(t *testing.T) {
 func TestSourceFromCamera(t *testing.T) {
 	videoSrc := &simpleSource{"rimage/board1_small"}
 	actualCam, err := camera.NewFromReader(context.Background(), videoSrc, nil, camera.UnspecifiedStream)
+	test.That(t, err, test.ShouldBeNil)
+
 	reconfCam, err := camera.WrapWithReconfigurable(actualCam, resource.Name{})
 	test.That(t, reconfCam, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldBeNil)
+
 	source, err := camera.SourceFromCamera(reconfCam.(camera.Camera))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, source, test.ShouldNotBeNil)
+
 	wgCam := camera.CameraWaitGroup{Cam: reconfCam.(camera.Camera)}
 	test.That(t, wgCam.Cam, test.ShouldNotBeNil)
+
 	source2, err := camera.SourceFromCamera(wgCam.Cam)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, source2, test.ShouldNotBeNil)

--- a/components/camera/camera_waitgroup.go
+++ b/components/camera/camera_waitgroup.go
@@ -11,6 +11,10 @@ import (
 )
 
 // WaitGroupCamera is a wrapper for camera.Camera with a sync.WaitGroup.
+// WARNING: ActiveBackgroundWorkes is publicly available. WaitGroup must
+// be used with care to avoid deadlocks. The WaitGroup must be fully populated
+// before any goroutines are launched, and all routines must Signal
+// Done before Wait can return.
 type WaitGroupCamera struct {
 	Cam                     Camera
 	ActiveBackgroundWorkers sync.WaitGroup

--- a/components/camera/camera_waitgroup.go
+++ b/components/camera/camera_waitgroup.go
@@ -10,39 +10,39 @@ import (
 	"go.viam.com/rdk/rimage/transform"
 )
 
-// CameraWaitGroup is a wrapper for camera.Camera with a sync.WaitGroup.
-type CameraWaitGroup struct {
+// WaitGroupCamera is a wrapper for camera.Camera with a sync.WaitGroup.
+type WaitGroupCamera struct {
 	Cam                     Camera
 	ActiveBackgroundWorkers sync.WaitGroup
 }
 
 // DoCommand wraps camera.Camera.DoCommand.
-func (c *CameraWaitGroup) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (c *WaitGroupCamera) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
 	return c.Cam.DoCommand(ctx, cmd)
 }
 
 // Projector wraps camera.Camera.Projector.
-func (c *CameraWaitGroup) Projector(ctx context.Context) (transform.Projector, error) {
+func (c *WaitGroupCamera) Projector(ctx context.Context) (transform.Projector, error) {
 	return c.Cam.Projector(ctx)
 }
 
 // Stream wraps camera.Camera.Stream.
-func (c *CameraWaitGroup) Stream(ctx context.Context, errHandlers ...gostream.ErrorHandler) (gostream.VideoStream, error) {
+func (c *WaitGroupCamera) Stream(ctx context.Context, errHandlers ...gostream.ErrorHandler) (gostream.VideoStream, error) {
 	return c.Cam.Stream(ctx, errHandlers...)
 }
 
 // NextPointCloud wraps camera.Camera.NextPointCloud.
-func (c *CameraWaitGroup) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, error) {
+func (c *WaitGroupCamera) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, error) {
 	return c.Cam.NextPointCloud(ctx)
 }
 
 // Properties wraps camera.Camera.Properties.
-func (c *CameraWaitGroup) Properties(ctx context.Context) (Properties, error) {
+func (c *WaitGroupCamera) Properties(ctx context.Context) (Properties, error) {
 	return c.Cam.Properties(ctx)
 }
 
 // Close calls WaitGroup.Wait before calling camera.Camera.Close.
-func (c *CameraWaitGroup) Close(ctx context.Context) error {
+func (c *WaitGroupCamera) Close(ctx context.Context) error {
 	c.ActiveBackgroundWorkers.Wait()
 	return c.Cam.Close(ctx)
 }

--- a/components/camera/camera_waitgroup.go
+++ b/components/camera/camera_waitgroup.go
@@ -1,4 +1,4 @@
-package videosource
+package camera
 
 import (
 	"context"
@@ -6,44 +6,43 @@ import (
 
 	"github.com/edaniels/gostream"
 
-	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/rimage/transform"
 )
 
 // CameraWaitGroup is a wrapper for camera.Camera with a sync.WaitGroup.
 type CameraWaitGroup struct {
-	cam                     camera.Camera
-	activeBackgroundWorkers sync.WaitGroup
+	Cam                     Camera
+	ActiveBackgroundWorkers sync.WaitGroup
 }
 
 // DoCommand wraps camera.Camera.DoCommand.
 func (c *CameraWaitGroup) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
-	return c.cam.DoCommand(ctx, cmd)
+	return c.Cam.DoCommand(ctx, cmd)
 }
 
 // Projector wraps camera.Camera.Projector.
 func (c *CameraWaitGroup) Projector(ctx context.Context) (transform.Projector, error) {
-	return c.cam.Projector(ctx)
+	return c.Cam.Projector(ctx)
 }
 
 // Stream wraps camera.Camera.Stream.
 func (c *CameraWaitGroup) Stream(ctx context.Context, errHandlers ...gostream.ErrorHandler) (gostream.VideoStream, error) {
-	return c.cam.Stream(ctx, errHandlers...)
+	return c.Cam.Stream(ctx, errHandlers...)
 }
 
 // NextPointCloud wraps camera.Camera.NextPointCloud.
 func (c *CameraWaitGroup) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, error) {
-	return c.cam.NextPointCloud(ctx)
+	return c.Cam.NextPointCloud(ctx)
 }
 
 // Properties wraps camera.Camera.Properties.
-func (c *CameraWaitGroup) Properties(ctx context.Context) (camera.Properties, error) {
-	return c.cam.Properties(ctx)
+func (c *CameraWaitGroup) Properties(ctx context.Context) (Properties, error) {
+	return c.Cam.Properties(ctx)
 }
 
 // Close calls WaitGroup.Wait before calling camera.Camera.Close.
 func (c *CameraWaitGroup) Close(ctx context.Context) error {
-	c.activeBackgroundWorkers.Wait()
-	return c.cam.Close(ctx)
+	c.ActiveBackgroundWorkers.Wait()
+	return c.Cam.Close(ctx)
 }

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -287,8 +287,8 @@ func NewWebcamSource(ctx context.Context, attrs *WebcamAttrs, logger golog.Logge
 	}
 
 	const wait = 500 * time.Millisecond
-	camWg := CameraWaitGroup{cam: cam.(camera.Camera)}
-	camWg.activeBackgroundWorkers.Add(1)
+	camWg := camera.CameraWaitGroup{Cam: cam.(camera.Camera)}
+	camWg.ActiveBackgroundWorkers.Add(1)
 	goutils.ManagedGo(func() {
 		defer goutils.UncheckedError(goutils.TryClose(ctx, cam))
 		for {
@@ -316,7 +316,7 @@ func NewWebcamSource(ctx context.Context, attrs *WebcamAttrs, logger golog.Logge
 				}
 			}
 		}
-	}, camWg.activeBackgroundWorkers.Done)
+	}, camWg.ActiveBackgroundWorkers.Done)
 
 	return &camWg, nil
 }

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -287,7 +287,7 @@ func NewWebcamSource(ctx context.Context, attrs *WebcamAttrs, logger golog.Logge
 	}
 
 	const wait = 500 * time.Millisecond
-	camWg := camera.CameraWaitGroup{Cam: cam.(camera.Camera)}
+	camWg := camera.WaitGroupCamera{Cam: cam.(camera.Camera)}
 	camWg.ActiveBackgroundWorkers.Add(1)
 	goutils.ManagedGo(func() {
 		defer goutils.UncheckedError(goutils.TryClose(ctx, cam))

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -627,6 +627,12 @@ func (svc *webService) startStream(streamFunc func(opts *webstream.BackoffTuning
 func (svc *webService) startImageStream(ctx context.Context, source gostream.VideoSource, stream gostream.Stream) {
 	ctxWithJPEGHint := gostream.WithMIMETypeHint(ctx, rutils.WithLazyMIMEType(rutils.MimeTypeJPEG))
 	svc.startStream(func(opts *webstream.BackoffTuningOptions) error {
+		if cam, ok := source.(camera.Camera); ok {
+			src, err := camera.SourceFromCamera(cam)
+			if err == nil {
+				source = src
+			}
+		}
 		return webstream.StreamVideoSource(ctxWithJPEGHint, source, stream, opts)
 	})
 }

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -629,7 +629,9 @@ func (svc *webService) startImageStream(ctx context.Context, source gostream.Vid
 	svc.startStream(func(opts *webstream.BackoffTuningOptions) error {
 		if cam, ok := source.(camera.Camera); ok {
 			src, err := camera.SourceFromCamera(cam)
-			if err == nil {
+			if err != nil {
+				svc.logger.Warnw("error getting camera source", "error", err)
+			} else {
 				source = src
 			}
 		}


### PR DESCRIPTION
### Description
This PR fixes how we pass the `mediaSource` into gostream `streamMediaSource`. Instead of handing off a wrapped camera, we now extract the videoSource directly.

This is accomplished. by extending `SourceFromCamera` to handle all camera types (`reconfigurableCamera`, `CameraWaitGroup`)

### Testing

Run Server in debug mode:
```
./web/cmd/server/main.go -debug --config /etc/viam.json
```

In app.viam.com -> control -> start camera stream

Notice how the log `no properties found for media; will assume empty` no longer appears.


___


_Warning:_ CameraWaitGroup has been moved from `videosource` to `camera` package
