### PR TITLE
Remove stream server not initialized log

### DIFF
--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -480,7 +480,6 @@ func (svc *webService) streamInitialized() bool {
 
 func (svc *webService) addNewStreams(ctx context.Context) error {
 	if !svc.streamInitialized() {
-		svc.logger.Warn("attempting to add stream before stream server is initialized. skipping this operation...")
 		return nil
 	}
 	videoSources := allVideoSourcesToDisplay(svc.r)


### PR DESCRIPTION
### Description
This PR removes the warning log that appears while adding a stream if the stream server is not initialized.

During `runServer` startup, the `robotimpl` is initialized which triggers a `Reconfigure` call that attempts to add the internal web service before the stream server is created which happens later on in `runWeb`. 

This one-time warning is unavoidable without major refactors to the entrypoint and the web service. Removing to avoid user confusion.