### PR TITLE
DATA-751-fix : respect cancellations, never fully block the RTSP model

### DIFF
--- a/components/camera/rtsp/rtsp.go
+++ b/components/camera/rtsp/rtsp.go
@@ -222,13 +222,19 @@ func NewRTSPCamera(ctx context.Context, attrs *Attrs, logger golog.Logger) (came
 	}
 	cancelCtx, cancel := context.WithCancel(context.Background())
 	reader := gostream.VideoReaderFunc(func(ctx context.Context) (image.Image, func(), error) {
-		select {
+		select { // one select block to always ensure the cancellations are listened to.
 		case <-cancelCtx.Done():
 			return nil, nil, cancelCtx.Err()
 		case <-ctx.Done():
 			return nil, nil, ctx.Err()
 		default:
-			<-rtspCam.gotFirstFrame // block until you get the first frame
+		}
+		select { // if gotFirstFrame is closed, this case will almost always fire and not respect the cancelation.
+		case <-cancelCtx.Done():
+			return nil, nil, cancelCtx.Err()
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
+		case <-rtspCam.gotFirstFrame:
 		}
 		return rtspCam.latestFrame.Load().(image.Image), func() {}, nil
 	})

--- a/components/camera/rtsp/rtsp.go
+++ b/components/camera/rtsp/rtsp.go
@@ -222,7 +222,7 @@ func NewRTSPCamera(ctx context.Context, attrs *Attrs, logger golog.Logger) (came
 	}
 	cancelCtx, cancel := context.WithCancel(context.Background())
 	reader := gostream.VideoReaderFunc(func(ctx context.Context) (image.Image, func(), error) {
-		select { // one select block to always ensure the cancellations are listened to.
+		select { // First select block always ensures the cancellations are listened to.
 		case <-cancelCtx.Done():
 			return nil, nil, cancelCtx.Err()
 		case <-ctx.Done():


### PR DESCRIPTION
Addresses these two comments:

https://github.com/viamrobotics/rdk/pull/1653#discussion_r1082883572

https://github.com/viamrobotics/rdk/pull/1653#discussion_r1094803685

By doing two select statements, cancellations are respected and the reader never is in a state that could get fully blocked.