### PR TITLE
RSDK-1678 Add Fake SLAM Model

### DIFF
--- a/.artifact/tree.json
+++ b/.artifact/tree.json
@@ -50622,6 +50622,14 @@
       "hash": "8ecf7ccd4c22d4606783db10a26018c4",
       "size": 145250924
     },
+    "fakeImageMap.jpg": {
+      "hash": "0a9ce6cac42cd580ec5d9e06e8db80f7",
+      "size": 242152
+    },
+    "fakePCDMap.pcd": {
+      "hash": "3a1a4c791dcdd7d468f0e194479497ea",
+      "size": 7384940
+    },
     "locating_in_map.lua": {
       "hash": "94180b8051257132b0e6eaab763c303a",
       "size": 1017

--- a/.artifact/tree.json
+++ b/.artifact/tree.json
@@ -50622,13 +50622,287 @@
       "hash": "8ecf7ccd4c22d4606783db10a26018c4",
       "size": 145250924
     },
-    "fakeImageMap.jpg": {
-      "hash": "0a9ce6cac42cd580ec5d9e06e8db80f7",
-      "size": 242152
-    },
-    "fakePCDMap.pcd": {
-      "hash": "3a1a4c791dcdd7d468f0e194479497ea",
-      "size": 7384940
+    "example_cartographer_outputs": {
+      "image_map": {
+        "image_map_0.png": {
+          "hash": "ef3ae35202ee101f2a7e00d466bc52cd",
+          "size": 4953132
+        },
+        "image_map_1.png": {
+          "hash": "ef3ae35202ee101f2a7e00d466bc52cd",
+          "size": 4953132
+        },
+        "image_map_10.png": {
+          "hash": "f9bbc93a72cd88a549b69cc53a1a9aab",
+          "size": 9023789
+        },
+        "image_map_11.png": {
+          "hash": "419028283957cb3d7503f547908a64c7",
+          "size": 10085111
+        },
+        "image_map_12.png": {
+          "hash": "760c479ea579f8e22268a8bfec12c74b",
+          "size": 11626006
+        },
+        "image_map_13.png": {
+          "hash": "485694cf59fc83deec6e023acaed7974",
+          "size": 12274622
+        },
+        "image_map_14.png": {
+          "hash": "7823cbf75ba509e141061090bec6b25c",
+          "size": 12082723
+        },
+        "image_map_15.png": {
+          "hash": "88dbcc629c794f4181a745d7b01a7f34",
+          "size": 12247746
+        },
+        "image_map_16.png": {
+          "hash": "0ecf22d83d1912dbeecc64d0fe41cfbe",
+          "size": 12250315
+        },
+        "image_map_2.png": {
+          "hash": "4db6ac9cdc8253e07b23c61fb7d0d293",
+          "size": 5279244
+        },
+        "image_map_3.png": {
+          "hash": "70f1ee618052d70496100397108cd7ad",
+          "size": 5523194
+        },
+        "image_map_4.png": {
+          "hash": "e24c02ca77f33d9cdcd86e48cfdab5b0",
+          "size": 6677008
+        },
+        "image_map_5.png": {
+          "hash": "5012e89ed9be0936e832ffa1ba96ebaf",
+          "size": 6965702
+        },
+        "image_map_6.png": {
+          "hash": "6c5365fa289f006d6aeaf6f2328a934e",
+          "size": 7414026
+        },
+        "image_map_7.png": {
+          "hash": "78aed6da3a9adf36e2239a7755b11725",
+          "size": 7454978
+        },
+        "image_map_8.png": {
+          "hash": "66d5d24957f702a2f24290e585439617",
+          "size": 7564849
+        },
+        "image_map_9.png": {
+          "hash": "d74cf66ef3db317991ef30be0a0214af",
+          "size": 8246206
+        }
+      },
+      "internal_state": {
+        "internal_state_0.pbstream": {
+          "hash": "52c4fff6f4b25332b498f59ade1abd76",
+          "size": 1475162
+        },
+        "internal_state_1.pbstream": {
+          "hash": "52c4fff6f4b25332b498f59ade1abd76",
+          "size": 1475162
+        },
+        "internal_state_10.pbstream": {
+          "hash": "718c4030067479b8c2610a3134f4e549",
+          "size": 3566542
+        },
+        "internal_state_11.pbstream": {
+          "hash": "3a646e167fcf80925ca04c4f39a15f78",
+          "size": 3962250
+        },
+        "internal_state_12.pbstream": {
+          "hash": "11b27c737316181c5a22c22340114789",
+          "size": 4327711
+        },
+        "internal_state_13.pbstream": {
+          "hash": "dcf97ef1beb9deef6d6e09b236afb7af",
+          "size": 4433485
+        },
+        "internal_state_14.pbstream": {
+          "hash": "b62b5cf557103699b55279db4f20f669",
+          "size": 4675661
+        },
+        "internal_state_15.pbstream": {
+          "hash": "ab9fd90e25f22a612f019fa664eb2e96",
+          "size": 4767845
+        },
+        "internal_state_16.pbstream": {
+          "hash": "3fd95e5d6f5a5177e5f89919d43d6cde",
+          "size": 4768535
+        },
+        "internal_state_2.pbstream": {
+          "hash": "0467a7bfdcdf25e41322c444e2f6791f",
+          "size": 1596608
+        },
+        "internal_state_3.pbstream": {
+          "hash": "b969c48527a5e3085b4c78399a4adc1f",
+          "size": 1621622
+        },
+        "internal_state_4.pbstream": {
+          "hash": "bae7991c65ee34b31121705ed4438186",
+          "size": 1900855
+        },
+        "internal_state_5.pbstream": {
+          "hash": "8f43ca6e867ae0f21d33396dba56a993",
+          "size": 2186340
+        },
+        "internal_state_6.pbstream": {
+          "hash": "a936272eac2fc5876c90534eeaaed128",
+          "size": 2564959
+        },
+        "internal_state_7.pbstream": {
+          "hash": "8283ed48a1ec60bf4bc27833334bde91",
+          "size": 2794685
+        },
+        "internal_state_8.pbstream": {
+          "hash": "b5eca3678c2e2bdc4782312193ad8519",
+          "size": 2965058
+        },
+        "internal_state_9.pbstream": {
+          "hash": "4258e2bf3b5962920d200209d9865277",
+          "size": 3259586
+        }
+      },
+      "pointcloud": {
+        "pointcloud_0.pcd": {
+          "hash": "a5d2a84f53a50f908167a60b83d33285",
+          "size": 2539100
+        },
+        "pointcloud_1.pcd": {
+          "hash": "a5d2a84f53a50f908167a60b83d33285",
+          "size": 2539100
+        },
+        "pointcloud_10.pcd": {
+          "hash": "ab567341d4f6d99b487a6a2b6ec6054c",
+          "size": 6860812
+        },
+        "pointcloud_11.pcd": {
+          "hash": "2861efd29bb9e7112add4762e61c9e60",
+          "size": 7594636
+        },
+        "pointcloud_12.pcd": {
+          "hash": "5c050729ab01c5c7ca3cd5440ce1a12b",
+          "size": 8244684
+        },
+        "pointcloud_13.pcd": {
+          "hash": "6d857e67cab20d33d44f438bb07782ee",
+          "size": 8479180
+        },
+        "pointcloud_14.pcd": {
+          "hash": "2caf4fc09585288e077abb49fb445ec0",
+          "size": 8962508
+        },
+        "pointcloud_15.pcd": {
+          "hash": "8c4892ada370101791523a7c7fd8bf5d",
+          "size": 9118652
+        },
+        "pointcloud_16.pcd": {
+          "hash": "79afc74d387def419767946f78801e23",
+          "size": 9118652
+        },
+        "pointcloud_2.pcd": {
+          "hash": "60526b2d8c3cf4fde1b4969f87339415",
+          "size": 2730508
+        },
+        "pointcloud_3.pcd": {
+          "hash": "6e5bc4e263eea89fd72d4a9c2c8512d3",
+          "size": 2773708
+        },
+        "pointcloud_4.pcd": {
+          "hash": "32fefc2c56ff640760c9c1fae2850346",
+          "size": 3287852
+        },
+        "pointcloud_5.pcd": {
+          "hash": "27dbd382f7e2366c68da3a39189c1bfa",
+          "size": 3966012
+        },
+        "pointcloud_6.pcd": {
+          "hash": "1da4924ca53aa2338c60d2cbac1940d0",
+          "size": 4870332
+        },
+        "pointcloud_7.pcd": {
+          "hash": "4532b313984c6b79151740805c7c7dfc",
+          "size": 5349036
+        },
+        "pointcloud_8.pcd": {
+          "hash": "5f89a12a19dd9d4030d0d026af5a1629",
+          "size": 5752988
+        },
+        "pointcloud_9.pcd": {
+          "hash": "f29af015a74f3606de0c9f032b25a407",
+          "size": 6307292
+        }
+      },
+      "position": {
+        "position_0.txt": {
+          "hash": "a7470eead12e41287c4c3bc350e459cc",
+          "size": 65
+        },
+        "position_1.txt": {
+          "hash": "a7470eead12e41287c4c3bc350e459cc",
+          "size": 65
+        },
+        "position_10.txt": {
+          "hash": "c8bc4a56454a410b48ced67553c3798e",
+          "size": 69
+        },
+        "position_11.txt": {
+          "hash": "c14b8a9a3fd5a85f91330f303c90f303",
+          "size": 67
+        },
+        "position_12.txt": {
+          "hash": "883f9b338e2f50b7fde2b5d95072c3b5",
+          "size": 65
+        },
+        "position_13.txt": {
+          "hash": "88923c1dd62b2e3578cc434cd43fbaf7",
+          "size": 68
+        },
+        "position_14.txt": {
+          "hash": "e63e49027c7256f1db63b7e0a644bb54",
+          "size": 67
+        },
+        "position_15.txt": {
+          "hash": "826ad85b36a13c0679ae2f48c6632d46",
+          "size": 67
+        },
+        "position_16.txt": {
+          "hash": "826ad85b36a13c0679ae2f48c6632d46",
+          "size": 67
+        },
+        "position_2.txt": {
+          "hash": "3f25fe48642eae23a8a62568b1d9170e",
+          "size": 65
+        },
+        "position_3.txt": {
+          "hash": "38a29704ffdec2553e86acad8279b48d",
+          "size": 66
+        },
+        "position_4.txt": {
+          "hash": "eb0c40612c413a4d81ff48ba3d178637",
+          "size": 67
+        },
+        "position_5.txt": {
+          "hash": "78f87699aaeb081af8e5c450d170648c",
+          "size": 68
+        },
+        "position_6.txt": {
+          "hash": "29925919201f92e3af02a42882289f70",
+          "size": 68
+        },
+        "position_7.txt": {
+          "hash": "ea119365eb8fb626649191f49b30ec17",
+          "size": 66
+        },
+        "position_8.txt": {
+          "hash": "b9b9c7f53aa5de1509c19e0c754eec99",
+          "size": 69
+        },
+        "position_9.txt": {
+          "hash": "0d51f528a74e1f656e6b7b31cb12b389",
+          "size": 69
+        }
+      }
     },
     "locating_in_map.lua": {
       "hash": "94180b8051257132b0e6eaab763c303a",

--- a/etc/configs/fake.json
+++ b/etc/configs/fake.json
@@ -128,6 +128,21 @@
                 "movement_sensor": "movement_sensor1",
                 "base": "base1"
             }
-        }
+        },
+        {
+            "name": "slam1",
+            "type": "slam",
+            "model": "fake",
+            "attributes": {
+                "config_params": {
+                    "mode": "2d"
+                  },
+                  "data_dir": "",
+                  "use_live_data": true,
+                  "sensors": [
+                    "rplidar"
+                  ]
+            }
+        }       
     ]
 }

--- a/services/slam/fake/slam.go
+++ b/services/slam/fake/slam.go
@@ -4,8 +4,11 @@ package fake
 import (
 	"context"
 	"errors"
+	"fmt"
 	"image"
 	"os"
+	"strconv"
+	"strings"
 
 	"github.com/edaniels/golog"
 	"github.com/golang/geo/r3"
@@ -24,7 +27,10 @@ import (
 	"go.viam.com/rdk/vision"
 )
 
-var model = resource.NewDefaultModel("fake")
+var (
+	model        = resource.NewDefaultModel("fake")
+	maxDataCount = 16
+)
 
 func init() {
 	registry.RegisterService(
@@ -37,7 +43,7 @@ func init() {
 				config config.Service,
 				logger golog.Logger,
 			) (interface{}, error) {
-				return &FakeSLAM{Name: config.Name}, nil
+				return &FakeSLAM{Name: config.Name, dataCount: 1}, nil
 			},
 		},
 	)
@@ -48,7 +54,8 @@ var _ = slam.Service(&FakeSLAM{})
 // FakeSLAM is a fake slam that returns generic data.
 type FakeSLAM struct {
 	generic.Echo
-	Name string
+	Name      string
+	dataCount int
 }
 
 // GetMap does nothing.
@@ -59,9 +66,12 @@ func (slamSvc *FakeSLAM) GetMap(ctx context.Context, name, mimeType string, cp *
 	var img image.Image
 	var vObj *vision.Object
 
+	// Increment data after getMap call
+	slamSvc.incrementDataCount()
+
 	switch mimeType {
 	case rdkutils.MimeTypePCD:
-		pcdFile, err := os.Open(artifact.MustPath("slam/fakePCDMap.pcd"))
+		pcdFile, err := os.Open(artifact.MustPath(fmt.Sprintf("slam/example_cartographer_outputs/pointcloud/pointcloud_%d.pcd", slamSvc.dataCount)))
 		if err != nil {
 			return "", nil, nil, err
 		}
@@ -74,23 +84,69 @@ func (slamSvc *FakeSLAM) GetMap(ctx context.Context, name, mimeType string, cp *
 			return "", nil, nil, err
 		}
 	case rdkutils.MimeTypeJPEG:
-		img, err = rimage.NewImageFromFile(artifact.MustPath("slam/fakeImageMap.jpg"))
+		img, err = rimage.NewImageFromFile(artifact.MustPath(fmt.Sprintf("slam/example_cartographer_outputs/image_map/image_map_%d.png", slamSvc.dataCount)))
 	default:
 		return "", nil, nil, errors.New("received invalid mimeType for GetMap call")
 	}
 	if err != nil {
 		return "", nil, nil, err
 	}
+
+	slamSvc.Position(ctx, name, map[string]interface{}{})
 	return mimeType, img, vObj, nil
 }
 
 // Position does nothing.
 func (slamSvc *FakeSLAM) Position(ctx context.Context, name string, extra map[string]interface{}) (*referenceframe.PoseInFrame, error) {
-	pInFrame := referenceframe.NewPoseInFrame(name, spatialmath.NewPose(r3.Vector{X: 0, Y: 0, Z: 0}, spatialmath.NewOrientationVector()))
+	data, err := os.ReadFile(artifact.MustPath(fmt.Sprintf("slam/example_cartographer_outputs/position/position_%d.txt", slamSvc.dataCount)))
+	if err != nil {
+		return nil, err
+	}
+
+	substrings := strings.Split(string(data), " | ")
+
+	// Extract point
+	pointStrings := strings.Split(substrings[0], " ")
+
+	point := make([]float64, len(pointStrings))
+	for i, v := range pointStrings {
+		x, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return nil, err
+		}
+		point[i] = x
+	}
+
+	// Extract orientation
+	orientationStrings := strings.Split(substrings[1], " ")
+	orientations := make([]float64, len(orientationStrings))
+	for i, v := range orientationStrings {
+		x, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return nil, err
+		}
+		orientations[i] = x
+	}
+
+	ori := spatialmath.NewR4AA()
+	ori.RX = orientations[0]
+	ori.RY = orientations[1]
+	ori.RZ = orientations[2]
+	ori.Theta = orientations[3]
+
+	pInFrame := referenceframe.NewPoseInFrame(name, spatialmath.NewPose(r3.Vector{X: point[0], Y: point[1], Z: point[2]}, ori))
 	return pInFrame, nil
 }
 
 // GetInternalState does nothing.
 func (slamSvc *FakeSLAM) GetInternalState(ctx context.Context, name string) ([]byte, error) {
-	return []byte{0, 0, 0}, nil
+	data, err := os.ReadFile(artifact.MustPath(fmt.Sprintf("slam/example_cartographer_outputs/internal_state/internal_state_%d.pbstream", slamSvc.dataCount)))
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func (slamSvc *FakeSLAM) incrementDataCount() {
+	slamSvc.dataCount = ((slamSvc.dataCount + 1) % maxDataCount)
 }

--- a/services/slam/fake/slam.go
+++ b/services/slam/fake/slam.go
@@ -1,0 +1,96 @@
+// Package fake implements a fake base.
+package fake
+
+import (
+	"context"
+	"errors"
+	"image"
+	"os"
+
+	"github.com/edaniels/golog"
+	"github.com/golang/geo/r3"
+	"go.viam.com/utils/artifact"
+
+	"go.viam.com/rdk/components/generic"
+	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/pointcloud"
+	"go.viam.com/rdk/referenceframe"
+	"go.viam.com/rdk/registry"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/rimage"
+	"go.viam.com/rdk/services/slam"
+	"go.viam.com/rdk/spatialmath"
+	rdkutils "go.viam.com/rdk/utils"
+	"go.viam.com/rdk/vision"
+)
+
+var model = resource.NewDefaultModel("fake")
+
+func init() {
+	registry.RegisterService(
+		slam.Subtype,
+		model,
+		registry.Service{
+			Constructor: func(
+				ctx context.Context,
+				_ registry.Dependencies,
+				config config.Service,
+				logger golog.Logger,
+			) (interface{}, error) {
+				return &FakeSLAM{Name: config.Name}, nil
+			},
+		},
+	)
+}
+
+var _ = slam.Service(&FakeSLAM{})
+
+// FakeSLAM is a fake slam that returns generic data.
+type FakeSLAM struct {
+	generic.Echo
+	Name string
+}
+
+// GetMap does nothing.
+func (slamSvc *FakeSLAM) GetMap(ctx context.Context, name, mimeType string, cp *referenceframe.PoseInFrame,
+	include bool, extra map[string]interface{},
+) (string, image.Image, *vision.Object, error) {
+	var err error
+	var img image.Image
+	var vObj *vision.Object
+
+	switch mimeType {
+	case rdkutils.MimeTypePCD:
+		pcdFile, err := os.Open(artifact.MustPath("slam/fakePCDMap.pcd"))
+		if err != nil {
+			return "", nil, nil, err
+		}
+		pc, err := pointcloud.ReadPCDToBasicOctree(pcdFile)
+		if err != nil {
+			return "", nil, nil, err
+		}
+		vObj, err = vision.NewObject(pc)
+		if err != nil {
+			return "", nil, nil, err
+		}
+	case rdkutils.MimeTypeJPEG:
+		img, err = rimage.NewImageFromFile(artifact.MustPath("slam/fakeImageMap.jpg"))
+	default:
+		return "", nil, nil, errors.New("received invalid mimeType for GetMap call")
+	}
+	if err != nil {
+		return "", nil, nil, err
+	}
+	return mimeType, img, vObj, nil
+}
+
+// Position does nothing.
+func (slamSvc *FakeSLAM) Position(ctx context.Context, name string, extra map[string]interface{}) (*referenceframe.PoseInFrame, error) {
+	pInFrame := referenceframe.NewPoseInFrame(name, spatialmath.NewPose(r3.Vector{X: 0, Y: 0, Z: 0}, spatialmath.NewOrientationVector()))
+	return pInFrame, nil
+}
+
+// GetInternalState does nothing.
+func (slamSvc *FakeSLAM) GetInternalState(ctx context.Context, name string) ([]byte, error) {
+	return []byte{0, 0, 0}, nil
+}

--- a/services/slam/fake/slam_test.go
+++ b/services/slam/fake/slam_test.go
@@ -17,15 +17,21 @@ func TestFakeSLAMPosition(t *testing.T) {
 	pInFrame, err := slamSvc.Position(context.Background(), slamSvc.Name, map[string]interface{}{})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, pInFrame.Parent(), test.ShouldEqual, slamSvc.Name)
-	test.That(t, pInFrame.Pose().Point(), test.ShouldResemble, r3.Vector{X: 0, Y: 0, Z: 0})
-	test.That(t, pInFrame.Pose().Orientation().AxisAngles(), test.ShouldResemble, spatialmath.NewOrientationVector().AxisAngles())
+
+	expectedPoint := r3.Vector{X: 1.8607751801785188, Y: 34.26593374183797, Z: 0}
+	test.That(t, pInFrame.Pose().Point(), test.ShouldResemble, expectedPoint)
+
+	expectedOri := spatialmath.NewR4AA()
+	expectedOri.RZ = -1
+	expectedOri.Theta = 3.0542483867902197
+	test.That(t, pInFrame.Pose().Orientation().AxisAngles(), test.ShouldResemble, expectedOri)
 }
 
 func TestFakeSLAMGetInternalState(t *testing.T) {
 	slamSvc := &FakeSLAM{Name: "test"}
 	data, err := slamSvc.GetInternalState(context.Background(), slamSvc.Name)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, data, test.ShouldResemble, []byte{0, 0, 0})
+	test.That(t, len(data), test.ShouldBeGreaterThan, 0)
 }
 
 func TestFakeSLAMGetMap(t *testing.T) {

--- a/services/slam/fake/slam_test.go
+++ b/services/slam/fake/slam_test.go
@@ -1,0 +1,59 @@
+package fake
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/geo/r3"
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/referenceframe"
+	"go.viam.com/rdk/spatialmath"
+	rdkutils "go.viam.com/rdk/utils"
+)
+
+func TestFakeSLAMPosition(t *testing.T) {
+	slamSvc := &FakeSLAM{Name: "test"}
+	pInFrame, err := slamSvc.Position(context.Background(), slamSvc.Name, map[string]interface{}{})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, pInFrame.Parent(), test.ShouldEqual, slamSvc.Name)
+	test.That(t, pInFrame.Pose().Point(), test.ShouldResemble, r3.Vector{X: 0, Y: 0, Z: 0})
+	test.That(t, pInFrame.Pose().Orientation().AxisAngles(), test.ShouldResemble, spatialmath.NewOrientationVector().AxisAngles())
+}
+
+func TestFakeSLAMGetInternalState(t *testing.T) {
+	slamSvc := &FakeSLAM{Name: "test"}
+	data, err := slamSvc.GetInternalState(context.Background(), slamSvc.Name)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, data, test.ShouldResemble, []byte{0, 0, 0})
+}
+
+func TestFakeSLAMGetMap(t *testing.T) {
+	slamSvc := &FakeSLAM{Name: "test"}
+	pInFrame := referenceframe.NewPoseInFrame(slamSvc.Name, spatialmath.NewPose(r3.Vector{X: 0, Y: 0, Z: 0}, spatialmath.NewOrientationVector()))
+	extra := map[string]interface{}{}
+
+	t.Run("Test getting valid PCD map", func(t *testing.T) {
+		mimeType, im, vObj, err := slamSvc.GetMap(context.Background(), slamSvc.Name, rdkutils.MimeTypePCD, pInFrame, true, extra)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, mimeType, test.ShouldEqual, rdkutils.MimeTypePCD)
+		test.That(t, im, test.ShouldBeNil)
+		test.That(t, vObj, test.ShouldNotBeNil)
+	})
+
+	t.Run("Test getting valid JPEG map", func(t *testing.T) {
+		mimeType, im, vObj, err := slamSvc.GetMap(context.Background(), slamSvc.Name, rdkutils.MimeTypeJPEG, pInFrame, true, extra)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, mimeType, test.ShouldEqual, rdkutils.MimeTypeJPEG)
+		test.That(t, vObj, test.ShouldBeNil)
+		test.That(t, im, test.ShouldNotBeNil)
+	})
+
+	t.Run("Test getting invalid PNG map", func(t *testing.T) {
+		mimeType, im, vObj, err := slamSvc.GetMap(context.Background(), slamSvc.Name, rdkutils.MimeTypePNG, pInFrame, true, extra)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, mimeType, test.ShouldEqual, "")
+		test.That(t, vObj, test.ShouldBeNil)
+		test.That(t, im, test.ShouldBeNil)
+	})
+}

--- a/services/slam/register/register.go
+++ b/services/slam/register/register.go
@@ -4,4 +4,5 @@ package register
 import (
 	// for slam models.
 	_ "go.viam.com/rdk/services/slam/builtin"
+	_ "go.viam.com/rdk/services/slam/fake"
 )


### PR DESCRIPTION
This PR adds a fake slam model that can return positions, images, point clouds, or internal state from an aligned set of data taken from Cartographer. This should provide a useful basis for the frontend and design teams to begin working on the UI design.

JIRA Ticket: [RSDK-1678](https://viam.atlassian.net/browse/RSDK-1678)

[RSDK-1678]: https://viam.atlassian.net/browse/RSDK-1678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ