### PR TITLE
fix-build-failure-due-to-useless-Errorf

### DIFF
--- a/components/board/genericlinux/gpio_unsupported.go
+++ b/components/board/genericlinux/gpio_unsupported.go
@@ -4,6 +4,7 @@ package genericlinux
 
 import (
 	"github.com/pkg/errors"
+
 	"go.viam.com/rdk/components/board"
 )
 
@@ -14,5 +15,5 @@ func gpioInitialize(gpioMappings map[int]GPIOBoardMapping) {
 }
 
 func gpioGetPin(pinName string) (board.GPIOPin, error) {
-	return nil, errors.Errorf("ioctl GPIO pins are not supported in a non-Linux environment")
+	return nil, errors.New("ioctl GPIO pins are not supported in a non-Linux environment")
 }


### PR DESCRIPTION
This fixes a lint error introduced in https://github.com/viamrobotics/rdk/pull/1822 which results in `make` failing currently.
```
➜  rdk git:(main) ✗ make
... not posting unrelated frontend logs
go build -tags dynamic ./...
GOBIN=`pwd`/bin/gotools/Darwin-arm64 go install google.golang.org/protobuf/cmd/protoc-gen-go \
                github.com/bufbuild/buf/cmd/protoc-gen-buf-breaking \
                github.com/bufbuild/buf/cmd/protoc-gen-buf-lint \
                github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc \
                google.golang.org/grpc/cmd/protoc-gen-go-grpc \
                github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway \
                github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2 \
                github.com/edaniels/golinters/cmd/combined \
                github.com/golangci/golangci-lint/cmd/golangci-lint \
                github.com/AlekSi/gocov-xml \
                github.com/axw/gocov/gocov \
                github.com/bufbuild/buf/cmd/buf \
                gotest.tools/gotestsum \
                github.com/rhysd/actionlint/cmd/actionlint
export pkgs="`go list -tags dynamic -f '{{.Dir}}' ./... | grep -v /proto/`" && echo "$pkgs" | xargs go vet -tags dynamic -vettool=bin/gotools/Darwin-arm64/combined
# go.viam.com/rdk/components/board/genericlinux
components/board/genericlinux/gpio_unsupported.go:17:21: uesless fmt.Errorf usage found; use errors.New instead
make: *** [lint-go] Error 1
```