### PR TITLE
[DATA-1035] Add option to disable directory configuration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -46,9 +46,9 @@ type Config struct {
 	// command line arguments.
 	UntrustedEnv bool `json:"-"`
 
-	// DisableDirectoryConfiguration is used to disable the configurability of directories where we
-	// capture data. This is set via command line arguments.
-	DisableDirectoryConfiguration bool `json:"-"`
+	// LimitConfigurableDirectories is used to limit which directories users can configure for
+	// storing data on-robot. This is set via command line arguments.
+	LimitConfigurableDirectories bool `json:"-"`
 
 	// FromCommand indicates if this config was parsed via the web server command.
 	// If false, it's for creating a robot via the RDK library. This is helpful for

--- a/config/config.go
+++ b/config/config.go
@@ -46,9 +46,9 @@ type Config struct {
 	// command line arguments.
 	UntrustedEnv bool `json:"-"`
 
-	// DisableDirConfig is used to disable the configurability of directories where we
+	// DisableDirectoryConfiguration is used to disable the configurability of directories where we
 	// capture data. This is set via command line arguments.
-	DisableDirConfig bool `json:"-"`
+	DisableDirectoryConfiguration bool `json:"-"`
 
 	// FromCommand indicates if this config was parsed via the web server command.
 	// If false, it's for creating a robot via the RDK library. This is helpful for

--- a/config/config.go
+++ b/config/config.go
@@ -46,6 +46,10 @@ type Config struct {
 	// command line arguments.
 	UntrustedEnv bool `json:"-"`
 
+	// DisableDirConfig is used to disable the configurability of directories where we
+	// capture data. This is set via command line arguments.
+	DisableDirConfig bool `json:"-"`
+
 	// FromCommand indicates if this config was parsed via the web server command.
 	// If false, it's for creating a robot via the RDK library. This is helpful for
 	// error messages that can indicate flags/config fields to use.

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -742,7 +742,7 @@ func (manager *resourceManager) wrapResource(name resource.Name, config interfac
 	return nil
 }
 
-// updateResourceGraph using the difference between current config
+// updateResources using the difference between current config
 // and next we create resource wrappers to be consumed by completeConfig later on
 // Ideally at the end of this function we should have a complete graph representation of the configuration.
 func (manager *resourceManager) updateResources(

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -406,7 +406,7 @@ func (svc *builtIn) Update(ctx context.Context, cfg *config.Config) error {
 		return err
 	}
 
-	if cfg.DisableDirectoryConfiguration && svcConfig.CaptureDir != "" && svcConfig.CaptureDir != viamCaptureDotDir {
+	if cfg.LimitConfigurableDirectories && svcConfig.CaptureDir != "" && svcConfig.CaptureDir != viamCaptureDotDir {
 		return errCaptureDirectoryConfigurationDisabled
 	}
 	svc.captureDir = svcConfig.CaptureDir

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -406,7 +406,7 @@ func (svc *builtIn) Update(ctx context.Context, cfg *config.Config) error {
 		return err
 	}
 
-	if cfg.DisableDirConfig && svcConfig.CaptureDir != "" && svcConfig.CaptureDir != viamCaptureDotDir {
+	if cfg.DisableDirectoryConfiguration && svcConfig.CaptureDir != "" && svcConfig.CaptureDir != viamCaptureDotDir {
 		return errCaptureDirectoryConfigurationDisabled
 	}
 	svc.captureDir = svcConfig.CaptureDir

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -404,7 +404,7 @@ func (svc *builtIn) Update(ctx context.Context, cfg *config.Config) error {
 		return err
 	}
 
-	if cfg.UntrustedEnv && svcConfig.CaptureDir != "" && svcConfig.CaptureDir != viamCaptureDotDir {
+	if cfg.DisableDirConfig && svcConfig.CaptureDir != "" && svcConfig.CaptureDir != viamCaptureDotDir {
 		return errors.New("cannot change capture directory in untrusted environment")
 	}
 	svc.captureDir = svcConfig.CaptureDir

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -409,7 +409,9 @@ func (svc *builtIn) Update(ctx context.Context, cfg *config.Config) error {
 	if cfg.LimitConfigurableDirectories && svcConfig.CaptureDir != "" && svcConfig.CaptureDir != viamCaptureDotDir {
 		return errCaptureDirectoryConfigurationDisabled
 	}
-	svc.captureDir = svcConfig.CaptureDir
+	if svcConfig.CaptureDir != "" {
+		svc.captureDir = svcConfig.CaptureDir
+	}
 	svc.captureDisabled = svcConfig.CaptureDisabled
 	// Service is disabled, so close all collectors and clear the map so we can instantiate new ones if we enable this service.
 	if svc.captureDisabled {

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -404,6 +404,9 @@ func (svc *builtIn) Update(ctx context.Context, cfg *config.Config) error {
 		return err
 	}
 
+	if cfg.UntrustedEnv && svcConfig.CaptureDir != "" && svcConfig.CaptureDir != viamCaptureDotDir {
+		return errors.New("cannot change capture directory in untrusted environment")
+	}
 	svc.captureDir = svcConfig.CaptureDir
 	svc.captureDisabled = svcConfig.CaptureDisabled
 	// Service is disabled, so close all collectors and clear the map so we can instantiate new ones if we enable this service.

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -61,6 +61,8 @@ const defaultCaptureQueueSize = 250
 // Default bufio.Writer buffer size in bytes.
 const defaultCaptureBufferSize = 4096
 
+var errCaptureDirectoryConfigurationDisabled = errors.New("changing the capture directory is prohibited in this environment")
+
 // Attributes to initialize the collector for a component or remote.
 type dataCaptureConfig struct {
 	Name               string            `json:"name"`
@@ -405,7 +407,7 @@ func (svc *builtIn) Update(ctx context.Context, cfg *config.Config) error {
 	}
 
 	if cfg.DisableDirConfig && svcConfig.CaptureDir != "" && svcConfig.CaptureDir != viamCaptureDotDir {
-		return errors.New("cannot change capture directory in untrusted environment")
+		return errCaptureDirectoryConfigurationDisabled
 	}
 	svc.captureDir = svcConfig.CaptureDir
 	svc.captureDisabled = svcConfig.CaptureDisabled

--- a/services/datamanager/builtin/builtin_test.go
+++ b/services/datamanager/builtin/builtin_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"go.viam.com/rdk/spatialmath"
-
 	"github.com/edaniels/golog"
 	"github.com/edaniels/gostream"
 	"github.com/golang/geo/r3"
@@ -25,6 +23,7 @@ import (
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/services/datamanager/internal"
+	"go.viam.com/rdk/spatialmath"
 	"go.viam.com/rdk/testutils/inject"
 	rdkutils "go.viam.com/rdk/utils"
 )

--- a/services/datamanager/builtin/builtin_test.go
+++ b/services/datamanager/builtin/builtin_test.go
@@ -3,13 +3,14 @@ package builtin
 import (
 	"bytes"
 	"context"
-	"go.viam.com/rdk/spatialmath"
 	"image"
 	"image/png"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"go.viam.com/rdk/spatialmath"
 
 	"github.com/edaniels/golog"
 	"github.com/edaniels/gostream"
@@ -104,6 +105,17 @@ func TestGetDurationFromHz(t *testing.T) {
 	test.That(t, GetDurationFromHz(1), test.ShouldEqual, time.Second)
 	test.That(t, GetDurationFromHz(1000), test.ShouldEqual, time.Millisecond)
 	test.That(t, GetDurationFromHz(0), test.ShouldEqual, 0)
+}
+
+func TestDirectoryConfigurationDisabled(t *testing.T) {
+	dmsvc := newTestDataManager(t)
+	defer dmsvc.Close(context.Background())
+
+	config := setupConfig(t, enabledTabularCollectorConfigPath)
+	config.DisableDirConfig = true
+
+	err := dmsvc.Update(context.Background(), config)
+	test.That(t, err, test.ShouldEqual, errCaptureDirectoryConfigurationDisabled)
 }
 
 func getDataManagerConfig(config *config.Config) (*Config, error) {

--- a/services/datamanager/builtin/builtin_test.go
+++ b/services/datamanager/builtin/builtin_test.go
@@ -112,7 +112,7 @@ func TestDirectoryConfigurationDisabled(t *testing.T) {
 	defer dmsvc.Close(context.Background())
 
 	config := setupConfig(t, enabledTabularCollectorConfigPath)
-	config.DisableDirConfig = true
+	config.DisableDirectoryConfiguration = true
 
 	err := dmsvc.Update(context.Background(), config)
 	test.That(t, err, test.ShouldEqual, errCaptureDirectoryConfigurationDisabled)

--- a/services/datamanager/builtin/builtin_test.go
+++ b/services/datamanager/builtin/builtin_test.go
@@ -106,12 +106,12 @@ func TestGetDurationFromHz(t *testing.T) {
 	test.That(t, GetDurationFromHz(0), test.ShouldEqual, 0)
 }
 
-func TestDirectoryConfigurationDisabled(t *testing.T) {
+func TestLimitConfigurableDirectories(t *testing.T) {
 	dmsvc := newTestDataManager(t)
 	defer dmsvc.Close(context.Background())
 
 	config := setupConfig(t, enabledTabularCollectorConfigPath)
-	config.DisableDirectoryConfiguration = true
+	config.LimitConfigurableDirectories = true
 
 	err := dmsvc.Update(context.Background(), config)
 	test.That(t, err, test.ShouldEqual, errCaptureDirectoryConfigurationDisabled)

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -28,17 +28,17 @@ import (
 
 // Arguments for the command.
 type Arguments struct {
-	AllowInsecureCreds            bool   `flag:"allow-insecure-creds,usage=allow connections to send credentials over plaintext"`
-	ConfigFile                    string `flag:"config,usage=robot config file"`
-	CPUProfile                    string `flag:"cpuprofile,usage=write cpu profile to file"`
-	Debug                         bool   `flag:"debug"`
-	DisableDirectoryConfiguration bool   `flag:"disable-directory-configuration,usage=prohibit connections from changing the directories where data is stored on-robot"` //nolint:lll
-	SharedDir                     string `flag:"shareddir,usage=web resource directory"`
-	Version                       bool   `flag:"version,usage=print version"`
-	WebProfile                    bool   `flag:"webprofile,usage=include profiler in http server"`
-	WebRTC                        bool   `flag:"webrtc,usage=force webrtc connections instead of direct"`
-	RevealSensitiveConfigDiffs    bool   `flag:"reveal-sensitive-config-diffs,usage=show config diffs"`
-	UntrustedEnv                  bool   `flag:"untrusted-env,usage=disable processes and shell from running in a untrusted environment"`
+	AllowInsecureCreds           bool   `flag:"allow-insecure-creds,usage=allow connections to send credentials over plaintext"`
+	ConfigFile                   string `flag:"config,usage=robot config file"`
+	CPUProfile                   string `flag:"cpuprofile,usage=write cpu profile to file"`
+	Debug                        bool   `flag:"debug"`
+	LimitConfigurableDirectories bool   `flag:"limit-configurable-directories,usage=limit which directories users can configure for storing data on-robot"` //nolint:lll
+	SharedDir                    string `flag:"shareddir,usage=web resource directory"`
+	Version                      bool   `flag:"version,usage=print version"`
+	WebProfile                   bool   `flag:"webprofile,usage=include profiler in http server"`
+	WebRTC                       bool   `flag:"webrtc,usage=force webrtc connections instead of direct"`
+	RevealSensitiveConfigDiffs   bool   `flag:"reveal-sensitive-config-diffs,usage=show config diffs"`
+	UntrustedEnv                 bool   `flag:"untrusted-env,usage=disable processes and shell from running in a untrusted environment"`
 }
 
 type robotServer struct {
@@ -214,7 +214,7 @@ func (s *robotServer) serveWeb(ctx context.Context, cfg *config.Config) (err err
 		out.Debug = s.args.Debug || cfg.Debug
 		out.FromCommand = true
 		out.AllowInsecureCreds = s.args.AllowInsecureCreds
-		out.DisableDirectoryConfiguration = s.args.DisableDirectoryConfiguration
+		out.LimitConfigurableDirectories = s.args.LimitConfigurableDirectories
 		out.UntrustedEnv = s.args.UntrustedEnv
 		return out, nil
 	}

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -32,6 +32,7 @@ type Arguments struct {
 	ConfigFile                 string `flag:"config,usage=robot config file"`
 	CPUProfile                 string `flag:"cpuprofile,usage=write cpu profile to file"`
 	Debug                      bool   `flag:"debug"`
+	DisableDirConfig           bool   `flag:"disable-dir-config,usage=prohibit connections from changing the directories where data is stored on-robot"`
 	SharedDir                  string `flag:"shareddir,usage=web resource directory"`
 	Version                    bool   `flag:"version,usage=print version"`
 	WebProfile                 bool   `flag:"webprofile,usage=include profiler in http server"`
@@ -213,6 +214,7 @@ func (s *robotServer) serveWeb(ctx context.Context, cfg *config.Config) (err err
 		out.Debug = s.args.Debug || cfg.Debug
 		out.FromCommand = true
 		out.AllowInsecureCreds = s.args.AllowInsecureCreds
+		out.DisableDirConfig = s.args.DisableDirConfig
 		out.UntrustedEnv = s.args.UntrustedEnv
 		return out, nil
 	}

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -32,7 +32,7 @@ type Arguments struct {
 	ConfigFile                    string `flag:"config,usage=robot config file"`
 	CPUProfile                    string `flag:"cpuprofile,usage=write cpu profile to file"`
 	Debug                         bool   `flag:"debug"`
-	DisableDirectoryConfiguration bool   `flag:"disable-directory-configuration,usage=prohibit connections from changing the directories where data is stored on-robot"`
+	DisableDirectoryConfiguration bool   `flag:"disable-directory-configuration,usage=prohibit connections from changing the directories where data is stored on-robot"` //nolint:lll
 	SharedDir                     string `flag:"shareddir,usage=web resource directory"`
 	Version                       bool   `flag:"version,usage=print version"`
 	WebProfile                    bool   `flag:"webprofile,usage=include profiler in http server"`

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -28,17 +28,17 @@ import (
 
 // Arguments for the command.
 type Arguments struct {
-	AllowInsecureCreds         bool   `flag:"allow-insecure-creds,usage=allow connections to send credentials over plaintext"`
-	ConfigFile                 string `flag:"config,usage=robot config file"`
-	CPUProfile                 string `flag:"cpuprofile,usage=write cpu profile to file"`
-	Debug                      bool   `flag:"debug"`
-	DisableDirConfig           bool   `flag:"disable-dir-config,usage=prohibit connections from changing the directories where data is stored on-robot"`
-	SharedDir                  string `flag:"shareddir,usage=web resource directory"`
-	Version                    bool   `flag:"version,usage=print version"`
-	WebProfile                 bool   `flag:"webprofile,usage=include profiler in http server"`
-	WebRTC                     bool   `flag:"webrtc,usage=force webrtc connections instead of direct"`
-	RevealSensitiveConfigDiffs bool   `flag:"reveal-sensitive-config-diffs,usage=show config diffs"`
-	UntrustedEnv               bool   `flag:"untrusted-env,usage=disable processes and shell from running in a untrusted environment"`
+	AllowInsecureCreds            bool   `flag:"allow-insecure-creds,usage=allow connections to send credentials over plaintext"`
+	ConfigFile                    string `flag:"config,usage=robot config file"`
+	CPUProfile                    string `flag:"cpuprofile,usage=write cpu profile to file"`
+	Debug                         bool   `flag:"debug"`
+	DisableDirectoryConfiguration bool   `flag:"disable-directory-configuration,usage=prohibit connections from changing the directories where data is stored on-robot"`
+	SharedDir                     string `flag:"shareddir,usage=web resource directory"`
+	Version                       bool   `flag:"version,usage=print version"`
+	WebProfile                    bool   `flag:"webprofile,usage=include profiler in http server"`
+	WebRTC                        bool   `flag:"webrtc,usage=force webrtc connections instead of direct"`
+	RevealSensitiveConfigDiffs    bool   `flag:"reveal-sensitive-config-diffs,usage=show config diffs"`
+	UntrustedEnv                  bool   `flag:"untrusted-env,usage=disable processes and shell from running in a untrusted environment"`
 }
 
 type robotServer struct {
@@ -214,7 +214,7 @@ func (s *robotServer) serveWeb(ctx context.Context, cfg *config.Config) (err err
 		out.Debug = s.args.Debug || cfg.Debug
 		out.FromCommand = true
 		out.AllowInsecureCreds = s.args.AllowInsecureCreds
-		out.DisableDirConfig = s.args.DisableDirConfig
+		out.DisableDirectoryConfiguration = s.args.DisableDirectoryConfiguration
 		out.UntrustedEnv = s.args.UntrustedEnv
 		return out, nil
 	}


### PR DESCRIPTION
This PR adds the `disable-directory-configuration` flag to `viam-server`. When this flag is used, connections to the robot will not be able to change the directory where we store data captured by the data service, and all data will be captured to the default directory, `$HOME/.viam/capture`. This flag can also be able to disable directory configuration for other services such as SLAM, but that work is not included in this PR.

**Manual Testing**
In addition to the automated tests, I tested this manually by running `go run web/cmd/server/main.go -config services/datamanager/data/fake_robot_with_data_manager.json -disable-directory-configuration`, which logged an error. I also tested that when the configuration does not have the capture directory configured at all (empty string), we _do not_ return an error.

**Open Questions**
I noticed that we suppress this error by logging it and just moving on without updating any parts of the data service. Is this okay? If this error is not surfaced to the user in any way (and maybe it is, I haven't tested manually with the UI/don't know how to do this), this could be confusing for users. This only matters if we want to allow Try Viam users to change some parts of the data service configuration but not others - if not, we should disable that as well.