### PR TITLE
RSDK-856 Add a default timeout to all inbound gRPC methods

### DIFF
--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -373,6 +373,7 @@ func (svc *webService) StartModule(ctx context.Context) error {
 		unaryInterceptors  []googlegrpc.UnaryServerInterceptor
 		streamInterceptors []googlegrpc.StreamServerInterceptor
 	)
+
 	unaryInterceptors = append(unaryInterceptors, ensureTimeoutUnaryInterceptor)
 
 	opManager := svc.r.OperationManager()
@@ -844,9 +845,8 @@ func (svc *webService) initRPCOptions(listenerTCPAddr *net.TCPAddr, options webo
 	}
 	var unaryInterceptors []googlegrpc.UnaryServerInterceptor
 
-	// Use the first interceptor to set a default timeout on the context
-	// if one is not already set.
 	unaryInterceptors = append(unaryInterceptors, ensureTimeoutUnaryInterceptor)
+
 	if options.Debug {
 		rpcOpts = append(rpcOpts, rpc.WithDebug())
 		unaryInterceptors = append(unaryInterceptors, func(

--- a/robot/web/web_test.go
+++ b/robot/web/web_test.go
@@ -1025,7 +1025,7 @@ func TestMethodTimeout(t *testing.T) {
 		iRobot.(*inject.Robot).StatusFunc = func(ctx context.Context, resourceNames []resource.Name) ([]robot.Status, error) {
 			deadline, deadlineSet := ctx.Deadline()
 			test.That(t, deadlineSet, test.ShouldBeTrue)
-			// Assert that deadline is between 9 and 10 minutes from now (some time will
+			// Assert that deadline is between 4 and 5 minutes from now (some time will
 			// have elapsed).
 			test.That(t, deadline, test.ShouldHappenBetween,
 				time.Now().Add(time.Minute*4), time.Now().Add(time.Minute*5))


### PR DESCRIPTION
RSDK-856

Adds a default context timeout for all inbound gRPC methods of 10 minutes using a new unary interceptor. Tests that the context is modified when no deadline is declared and that the context remains untouched when a deadline is already declared.