### PR TITLE
Clean up board.I2CHandle interface

### DIFF
--- a/components/arm/yahboom/dofbot.go
+++ b/components/arm/yahboom/dofbot.go
@@ -295,14 +295,14 @@ func (a *Dofbot) readJointInLock(ctx context.Context, joint int) (float64, error
 
 	time.Sleep(3 * time.Millisecond)
 
-	bytes, err := a.handle.ReadBlockData(ctx, reg, 2)
+	rd, err := a.handle.ReadBlockData(ctx, reg, 2)
 	if err != nil {
 		return 0, fmt.Errorf("error reading joint %v from register %v: %w", joint, reg, err)
 	}
 
 	time.Sleep(3 * time.Millisecond)
 
-	res := binary.BigEndian.Uint16(bytes)
+	res := binary.BigEndian.Uint16(rd)
 	return joints[joint-1].toValues(int(res)), nil
 }
 

--- a/components/arm/yahboom/dofbot.go
+++ b/components/arm/yahboom/dofbot.go
@@ -294,15 +294,15 @@ func (a *Dofbot) readJointInLock(ctx context.Context, joint int) (float64, error
 
 	time.Sleep(3 * time.Millisecond)
 
-	res, err := a.handle.ReadWordData(ctx, reg)
+	bytes, err := a.handle.ReadBlockData(ctx, reg, 2)
 	if err != nil {
 		return 0, fmt.Errorf("error reading joint %v from register %v: %w", joint, reg, err)
 	}
 
 	time.Sleep(3 * time.Millisecond)
 
-	res = (res >> 8 & 0xff) | (res << 8 & 0xff00)
-	return joints[joint-1].toValues(int(res)), nil
+	res := (int(bytes[0]) << 8) + int(bytes[1])
+	return joints[joint-1].toValues(res), nil
 }
 
 // Stop is unimplemented for the dofbot.

--- a/components/arm/yahboom/dofbot.go
+++ b/components/arm/yahboom/dofbot.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	// for embedding model file.
 	_ "embed"
+	"encoding/binary"
 	"fmt"
 	"math"
 	"sync"
@@ -301,8 +302,8 @@ func (a *Dofbot) readJointInLock(ctx context.Context, joint int) (float64, error
 
 	time.Sleep(3 * time.Millisecond)
 
-	res := (int(bytes[0]) << 8) + int(bytes[1])
-	return joints[joint-1].toValues(res), nil
+	res := binary.BigEndian.Uint16(bytes)
+	return joints[joint-1].toValues(int(res)), nil
 }
 
 // Stop is unimplemented for the dofbot.

--- a/components/board/board_test.go
+++ b/components/board/board_test.go
@@ -676,7 +676,7 @@ func (m *mockI2CHandle) ReadBlockData(ctx context.Context, register byte, numByt
 	return []byte{}, nil
 }
 
-func (m *mockI2CHandle) WriteBlockData(ctx context.Context, register byte, numBytes uint8, data []byte) error {
+func (m *mockI2CHandle) WriteBlockData(ctx context.Context, register byte, data []byte) error {
 	return nil
 }
 

--- a/components/board/board_test.go
+++ b/components/board/board_test.go
@@ -676,10 +676,6 @@ func (m *mockI2CHandle) ReadWordData(ctx context.Context, register byte) (uint16
 	return 0, nil
 }
 
-func (m *mockI2CHandle) WriteWordData(ctx context.Context, register byte, data uint16) error {
-	return nil
-}
-
 func (m *mockI2CHandle) ReadBlockData(ctx context.Context, register byte, numBytes uint8) ([]byte, error) {
 	return []byte{}, nil
 }

--- a/components/board/board_test.go
+++ b/components/board/board_test.go
@@ -672,10 +672,6 @@ func (m *mockI2CHandle) WriteByteData(ctx context.Context, register, data byte) 
 	return nil
 }
 
-func (m *mockI2CHandle) ReadWordData(ctx context.Context, register byte) (uint16, error) {
-	return 0, nil
-}
-
 func (m *mockI2CHandle) ReadBlockData(ctx context.Context, register byte, numBytes uint8) ([]byte, error) {
 	return []byte{}, nil
 }

--- a/components/board/fake/board.go
+++ b/components/board/fake/board.go
@@ -327,7 +327,7 @@ func (h *I2CHandle) ReadBlockData(ctx context.Context, register byte, numBytes u
 }
 
 // WriteBlockData writes the given bytes to the i2c channel.
-func (h *I2CHandle) WriteBlockData(ctx context.Context, register byte, numBytes uint8, data []byte) error {
+func (h *I2CHandle) WriteBlockData(ctx context.Context, register byte, data []byte) error {
 	return errors.New("finish me")
 }
 

--- a/components/board/fake/board.go
+++ b/components/board/fake/board.go
@@ -326,11 +326,6 @@ func (h *I2CHandle) ReadWordData(ctx context.Context, register byte) (uint16, er
 	return 0, errors.New("finish me")
 }
 
-// WriteWordData writes a word to the i2c channel.
-func (h *I2CHandle) WriteWordData(ctx context.Context, register byte, data uint16) error {
-	return errors.New("finish me")
-}
-
 // ReadBlockData reads the given number of bytes from the i2c channel.
 func (h *I2CHandle) ReadBlockData(ctx context.Context, register byte, numBytes uint8) ([]byte, error) {
 	return nil, errors.New("finish me")

--- a/components/board/fake/board.go
+++ b/components/board/fake/board.go
@@ -321,11 +321,6 @@ func (h *I2CHandle) WriteByteData(ctx context.Context, register, data byte) erro
 	return errors.New("finish me")
 }
 
-// ReadWordData reads a word from the i2c channel.
-func (h *I2CHandle) ReadWordData(ctx context.Context, register byte) (uint16, error) {
-	return 0, errors.New("finish me")
-}
-
 // ReadBlockData reads the given number of bytes from the i2c channel.
 func (h *I2CHandle) ReadBlockData(ctx context.Context, register byte, numBytes uint8) ([]byte, error) {
 	return nil, errors.New("finish me")

--- a/components/board/genericlinux/i2c.go
+++ b/components/board/genericlinux/i2c.go
@@ -2,7 +2,6 @@ package genericlinux
 
 import (
 	"context"
-	"encoding/binary"
 	"sync"
 
 	"github.com/edaniels/golog"
@@ -85,21 +84,6 @@ func (h *i2cHandle) WriteByteData(ctx context.Context, register, data byte) erro
 	return h.transactAtRegister(register, []byte{data}, nil)
 }
 
-func (h *i2cHandle) ReadWordData(ctx context.Context, register byte) (uint16, error) {
-	result := make([]byte, 2)
-	err := h.transactAtRegister(register, nil, result)
-	if err != nil {
-		return 0, err
-	}
-	return binary.BigEndian.Uint16(result), nil
-}
-
-func (h *i2cHandle) WriteWordData(ctx context.Context, register byte, data uint16) error {
-	w := make([]byte, 2)
-	binary.BigEndian.PutUint16(w, data)
-	return h.transactAtRegister(register, w, nil)
-}
-
 func (h *i2cHandle) ReadBlockData(ctx context.Context, register byte, numBytes uint8) ([]byte, error) {
 	result := make([]byte, numBytes)
 	err := h.transactAtRegister(register, nil, result)
@@ -109,7 +93,7 @@ func (h *i2cHandle) ReadBlockData(ctx context.Context, register byte, numBytes u
 	return result, nil
 }
 
-func (h *i2cHandle) WriteBlockData(ctx context.Context, register byte, numBytes uint8, data []byte) error {
+func (h *i2cHandle) WriteBlockData(ctx context.Context, register byte, data []byte) error {
 	return h.transactAtRegister(register, data, nil)
 }
 

--- a/components/board/i2c.go
+++ b/components/board/i2c.go
@@ -20,7 +20,7 @@ type I2CHandle interface {
 	WriteByteData(ctx context.Context, register, data byte) error
 
 	ReadBlockData(ctx context.Context, register byte, numBytes uint8) ([]byte, error)
-	WriteBlockData(ctx context.Context, register byte, numBytes uint8, data []byte) error
+	WriteBlockData(ctx context.Context, register byte, data []byte) error
 
 	// Close closes the handle and releases the lock on the bus.
 	Close() error

--- a/components/board/i2c.go
+++ b/components/board/i2c.go
@@ -20,7 +20,6 @@ type I2CHandle interface {
 	WriteByteData(ctx context.Context, register, data byte) error
 
 	ReadWordData(ctx context.Context, register byte) (uint16, error)
-	WriteWordData(ctx context.Context, register byte, data uint16) error
 
 	ReadBlockData(ctx context.Context, register byte, numBytes uint8) ([]byte, error)
 	WriteBlockData(ctx context.Context, register byte, numBytes uint8, data []byte) error
@@ -48,9 +47,4 @@ func (reg *I2CRegister) WriteByteData(ctx context.Context, data byte) error {
 // ReadWordData reads a word from the I2C channel register.
 func (reg *I2CRegister) ReadWordData(ctx context.Context) (uint16, error) {
 	return reg.Handle.ReadWordData(ctx, reg.Register)
-}
-
-// WriteWordData writes a word to the I2C channel register.
-func (reg *I2CRegister) WriteWordData(ctx context.Context, data uint16) error {
-	return reg.Handle.WriteWordData(ctx, reg.Register, data)
 }

--- a/components/board/i2c.go
+++ b/components/board/i2c.go
@@ -19,8 +19,6 @@ type I2CHandle interface {
 	ReadByteData(ctx context.Context, register byte) (byte, error)
 	WriteByteData(ctx context.Context, register, data byte) error
 
-	ReadWordData(ctx context.Context, register byte) (uint16, error)
-
 	ReadBlockData(ctx context.Context, register byte, numBytes uint8) ([]byte, error)
 	WriteBlockData(ctx context.Context, register byte, numBytes uint8, data []byte) error
 
@@ -42,9 +40,4 @@ func (reg *I2CRegister) ReadByteData(ctx context.Context) (byte, error) {
 // WriteByteData writes a byte to the I2C channel register.
 func (reg *I2CRegister) WriteByteData(ctx context.Context, data byte) error {
 	return reg.Handle.WriteByteData(ctx, reg.Register, data)
-}
-
-// ReadWordData reads a word from the I2C channel register.
-func (reg *I2CRegister) ReadWordData(ctx context.Context) (uint16, error) {
-	return reg.Handle.ReadWordData(ctx, reg.Register)
 }

--- a/components/board/pi/impl/i2c.go
+++ b/components/board/pi/impl/i2c.go
@@ -80,14 +80,6 @@ func (s *piPigpioI2CHandle) ReadWordData(ctx context.Context, register byte) (ui
 	return uint16(res & 0xFFFF), nil
 }
 
-func (s *piPigpioI2CHandle) WriteWordData(ctx context.Context, register byte, data uint16) error {
-	res := C.i2cWriteWordData(s.handle, C.uint(register), C.uint(data))
-	if res != 0 {
-		return errors.Errorf("error in WriteWordData (%d)", res)
-	}
-	return nil
-}
-
 func (s *piPigpioI2CHandle) ReadBlockData(ctx context.Context, register byte, numBytes uint8) ([]byte, error) {
 	if numBytes > 32 { // A limitation from the underlying pigpio.h library
 		return nil, errors.New("Cannot read more than 32 bytes from I2C")

--- a/components/board/pi/impl/i2c.go
+++ b/components/board/pi/impl/i2c.go
@@ -72,14 +72,6 @@ func (s *piPigpioI2CHandle) WriteByteData(ctx context.Context, register, data by
 	return nil
 }
 
-func (s *piPigpioI2CHandle) ReadWordData(ctx context.Context, register byte) (uint16, error) {
-	res := C.i2cReadWordData(s.handle, C.uint(register))
-	if res < 0 {
-		return 0, errors.Errorf("error in ReadWordData (%d)", res)
-	}
-	return uint16(res & 0xFFFF), nil
-}
-
 func (s *piPigpioI2CHandle) ReadBlockData(ctx context.Context, register byte, numBytes uint8) ([]byte, error) {
 	if numBytes > 32 { // A limitation from the underlying pigpio.h library
 		return nil, errors.New("Cannot read more than 32 bytes from I2C")

--- a/components/board/pi/impl/i2c.go
+++ b/components/board/pi/impl/i2c.go
@@ -86,7 +86,8 @@ func (s *piPigpioI2CHandle) ReadBlockData(ctx context.Context, register byte, nu
 	return data, nil
 }
 
-func (s *piPigpioI2CHandle) WriteBlockData(ctx context.Context, register byte, numBytes uint8, data []byte) error {
+func (s *piPigpioI2CHandle) WriteBlockData(ctx context.Context, register byte, data []byte) error {
+	numBytes := len(data)
 	if numBytes > 32 { // A limitation from the underlying pigpio.h library
 		return errors.New("Cannot write more than 32 bytes from I2C")
 	}

--- a/components/movementsensor/mpu6050/mpu6050.go
+++ b/components/movementsensor/mpu6050/mpu6050.go
@@ -231,7 +231,7 @@ func (mpu *mpu6050) writeByte(ctx context.Context, register, value byte) error {
 		}
 	}()
 
-	return handle.WriteByteData(ctx, register, value)
+	return handle.WriteBlockData(ctx, register, []byte{value})
 }
 
 // Given a value, scales it so that the range of int16s becomes the range of +/- maxValue.

--- a/components/movementsensor/mpu6050/mpu6050.go
+++ b/components/movementsensor/mpu6050/mpu6050.go
@@ -231,7 +231,7 @@ func (mpu *mpu6050) writeByte(ctx context.Context, register, value byte) error {
 		}
 	}()
 
-	return handle.WriteBlockData(ctx, register, []byte{value})
+	return handle.WriteByteData(ctx, register, value)
 }
 
 // Given a value, scales it so that the range of int16s becomes the range of +/- maxValue.

--- a/components/sensor/bme280/bme280.go
+++ b/components/sensor/bme280/bme280.go
@@ -478,63 +478,72 @@ func (s *bme280) setupCalibration(ctx context.Context) error {
 		return err
 	}
 
+	// Make a helper function to read 2 bytes from the handle and interpret it as a word.
+	readWord := func(register byte) uint16, error {
+		bytes, err := handle.ReadBlockData(ctx, register, 2)
+		if err != nil {
+			return 0, err
+		}
+		return (uint16(bytes[0]) << 8 + uint16(bytes[1])), nil
+	}
+
 	// Note, some are signed, others are unsigned
-	if calib, err := handle.ReadWordData(ctx, bme280T1LSBReg); err == nil {
+	if calib, err := readWord(bme280T1LSBReg); err == nil {
 		s.calibration["digT1"] = int(calib)
 	} else {
 		return err
 	}
-	if calib, err := handle.ReadWordData(ctx, bme280T2LSBReg); err == nil {
+	if calib, err := readWord(bme280T2LSBReg); err == nil {
 		s.calibration["digT2"] = int(int16(calib))
 	} else {
 		return err
 	}
-	if calib, err := handle.ReadWordData(ctx, bme280T3LSBReg); err == nil {
+	if calib, err := readWord(bme280T3LSBReg); err == nil {
 		s.calibration["digT3"] = int(int16(calib))
 	} else {
 		return err
 	}
-	if calib, err := handle.ReadWordData(ctx, bme280P1LSBReg); err == nil {
+	if calib, err := readWord(bme280P1LSBReg); err == nil {
 		s.calibration["digP1"] = int(calib)
 	} else {
 		return err
 	}
-	if calib, err := handle.ReadWordData(ctx, bme280P2LSBReg); err == nil {
+	if calib, err := readWord(bme280P2LSBReg); err == nil {
 		s.calibration["digP2"] = int(int16(calib))
 	} else {
 		return err
 	}
-	if calib, err := handle.ReadWordData(ctx, bme280P3LSBReg); err == nil {
+	if calib, err := readWord(bme280P3LSBReg); err == nil {
 		s.calibration["digP3"] = int(int16(calib))
 	} else {
 		return err
 	}
-	if calib, err := handle.ReadWordData(ctx, bme280P4LSBReg); err == nil {
+	if calib, err := readWord(bme280P4LSBReg); err == nil {
 		s.calibration["digP4"] = int(int16(calib))
 	} else {
 		return err
 	}
-	if calib, err := handle.ReadWordData(ctx, bme280P5LSBReg); err == nil {
+	if calib, err := readWord(bme280P5LSBReg); err == nil {
 		s.calibration["digP5"] = int(int16(calib))
 	} else {
 		return err
 	}
-	if calib, err := handle.ReadWordData(ctx, bme280P6LSBReg); err == nil {
+	if calib, err := readword(bme280P6LSBReg); err == nil {
 		s.calibration["digP6"] = int(int16(calib))
 	} else {
 		return err
 	}
-	if calib, err := handle.ReadWordData(ctx, bme280P7LSBReg); err == nil {
+	if calib, err := readWord(bme280P7LSBReg); err == nil {
 		s.calibration["digP7"] = int(int16(calib))
 	} else {
 		return err
 	}
-	if calib, err := handle.ReadWordData(ctx, bme280P8LSBReg); err == nil {
+	if calib, err := readWord(bme280P8LSBReg); err == nil {
 		s.calibration["digP8"] = int(int16(calib))
 	} else {
 		return err
 	}
-	if calib, err := handle.ReadWordData(ctx, bme280P9LSBReg); err == nil {
+	if calib, err := readWord(bme280P9LSBReg); err == nil {
 		s.calibration["digP9"] = int(int16(calib))
 	} else {
 		return err
@@ -546,7 +555,7 @@ func (s *bme280) setupCalibration(ctx context.Context) error {
 	}
 	s.calibration["digH1"] = int(calib)
 
-	if calib, err := handle.ReadWordData(ctx, bme280H2LSBReg); err == nil {
+	if calib, err := readWord(bme280H2LSBReg); err == nil {
 		s.calibration["digH2"] = int(int16(calib))
 	} else {
 		return err

--- a/components/sensor/bme280/bme280.go
+++ b/components/sensor/bme280/bme280.go
@@ -479,7 +479,7 @@ func (s *bme280) setupCalibration(ctx context.Context) error {
 		return err
 	}
 
-	// Make a helper function to read 2 bytes from the handle and interpret it as a word.
+	// A helper function to read 2 bytes from the handle and interpret it as a word
 	readWord := func(register byte) (uint16, error) {
 		bytes, err := handle.ReadBlockData(ctx, register, 2)
 		if err != nil {

--- a/components/sensor/bme280/bme280.go
+++ b/components/sensor/bme280/bme280.go
@@ -485,7 +485,7 @@ func (s *bme280) setupCalibration(ctx context.Context) error {
 		if err != nil {
 			return 0, err
 		}
-		return binary.BigEndian.Uint16(rd), nil
+		return binary.LittleEndian.Uint16(rd), nil
 	}
 
 	// Note, some are signed, others are unsigned

--- a/components/sensor/bme280/bme280.go
+++ b/components/sensor/bme280/bme280.go
@@ -5,6 +5,7 @@ package bme280
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
@@ -484,7 +485,7 @@ func (s *bme280) setupCalibration(ctx context.Context) error {
 		if err != nil {
 			return 0, err
 		}
-		return (uint16(bytes[0])<<8 + uint16(bytes[1])), nil
+		return binary.BigEndian.Uint16(bytes), nil
 	}
 
 	// Note, some are signed, others are unsigned

--- a/components/sensor/bme280/bme280.go
+++ b/components/sensor/bme280/bme280.go
@@ -481,11 +481,11 @@ func (s *bme280) setupCalibration(ctx context.Context) error {
 
 	// A helper function to read 2 bytes from the handle and interpret it as a word
 	readWord := func(register byte) (uint16, error) {
-		bytes, err := handle.ReadBlockData(ctx, register, 2)
+		rd, err := handle.ReadBlockData(ctx, register, 2)
 		if err != nil {
 			return 0, err
 		}
-		return binary.BigEndian.Uint16(bytes), nil
+		return binary.BigEndian.Uint16(rd), nil
 	}
 
 	// Note, some are signed, others are unsigned

--- a/components/sensor/bme280/bme280.go
+++ b/components/sensor/bme280/bme280.go
@@ -479,12 +479,12 @@ func (s *bme280) setupCalibration(ctx context.Context) error {
 	}
 
 	// Make a helper function to read 2 bytes from the handle and interpret it as a word.
-	readWord := func(register byte) uint16, error {
+	readWord := func(register byte) (uint16, error) {
 		bytes, err := handle.ReadBlockData(ctx, register, 2)
 		if err != nil {
 			return 0, err
 		}
-		return (uint16(bytes[0]) << 8 + uint16(bytes[1])), nil
+		return (uint16(bytes[0])<<8 + uint16(bytes[1])), nil
 	}
 
 	// Note, some are signed, others are unsigned
@@ -528,7 +528,7 @@ func (s *bme280) setupCalibration(ctx context.Context) error {
 	} else {
 		return err
 	}
-	if calib, err := readword(bme280P6LSBReg); err == nil {
+	if calib, err := readWord(bme280P6LSBReg); err == nil {
 		s.calibration["digP6"] = int(int16(calib))
 	} else {
 		return err


### PR DESCRIPTION
These changes were discussed in https://github.com/viamrobotics/rdk/pull/1844, but I split them to a separate PR because they're self-contained and unrelated to the main thrust of that branch. There are 3 changes in here:
- Remove `ReadWordData` from the `board.I2CHandle` interface. The I2C protocol lets you read a sequence of bytes from the device, but interpreting two bytes as a word is not well defined: some devices are big endian (e.g., the MPU6050 accelerometer), and others are little endian (e.g., the ADXL345 accelerometer). We could either have twice as many of these functions (`ReadWordBE` and `ReadWordLE`), or get rid of them and make the caller interpret the bytes themselves (which is the implementation I went with).
- Remove `WriteWordData` from the same interface, for the same justification.
- Remove the `numBytes` argument from the `WriteBlockData` function. You're already passing in a (slice of a) byte array: we'll just write however many bytes you provided, and it's up to the caller to slice the array to the right size.

Testing:
- I can read the joint positions from the dofbot. I cannot _move_ the dofbot joints (I get errors about a nil pointer dereference), but I have the same errors on the main branch. and since the thing I changed was reading values, and it's still able to read values that look plausible, I think I didn't break anything further (and it looks like I got the endianness correct: the joint positions change smoothly as I push the joints around). It sounds like no one has used this arm in a very long time, and perhaps the code has rotted while we weren't looking. but I don't think this PR has changed any functionality.
- I don't have a BME280 sensor to test, but have asked @biotinker to check that the sensor works the same as it used to.