### PR TITLE
[RSDK-1881] Initialize the robot member variable when constructing a dofbot arm

### DIFF
--- a/components/arm/yahboom/dofbot.go
+++ b/components/arm/yahboom/dofbot.go
@@ -128,6 +128,7 @@ func NewDofBot(ctx context.Context, r robot.Robot, config config.Component, logg
 
 	a := Dofbot{}
 	a.logger = logger
+	a.robot = r
 
 	b, err := board.FromRobot(r, attr.Board)
 	if err != nil {


### PR DESCRIPTION
Thanks to @biotinker for suggesting this fix!

Without this, I get "nil pointer dereference" errors any time I try to modify the end position of the dofbot arm, and with it I get "zero IK solutions produced, goal positions appears to be physically unreachable" errors instead. Peter suspects this might be because the arm doesn't have enough degrees of freedom to get to any location? but it's at least progress enough to close the original ticket.

I don't like that Go is perfectly happy to leave things uninitialized like this, but that's a complaint with the language, not with our use thereof.