### PR TITLE
Publish RC components to NPM

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,7 @@ jobs:
 
   npm_publish:
     uses: viamrobotics/rdk/.github/workflows/npm-publish.yml@main
+    needs: test
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,11 @@ jobs:
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
+  npm_publish:
+    uses: viamrobotics/rdk/.github/workflows/npm-publish.yml@main
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   slack-workflow-status:
     if: ${{ failure() }}
     name: Post Workflow Status To Slack

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,7 +1,7 @@
 name: NPM Publish
 
 on:
-  workflow_call:
+  [workflow_call, workflow_dispatch]:
     secrets:
         NPM_TOKEN:
           required: true

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,27 @@
+name: NPM Publish
+
+on:
+  workflow_call:
+    secrets:
+        NPM_TOKEN:
+          required: true
+
+jobs:
+  publish:
+    if: github.repository_owner == 'viamrobotics'
+    runs-on: [self-hosted, x64]
+    container:
+      image: ghcr.io/viamrobotics/canon:amd64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Publish
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          package: ./web/frontend/package.json
+          access: public

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,10 +1,11 @@
 name: NPM Publish
 
 on:
-  [workflow_call, workflow_dispatch]:
+  workflow_call:
     secrets:
         NPM_TOKEN:
           required: true
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,7 +1,11 @@
 {
-  "name": "rdk-web",
-  "version": "0.1.0",
+  "name": "@viamrobotics/remote-control",
+  "version": "0.1.28",
   "license": "Apache-2.0",
+  "files": [
+    "src/components/**/*.vue",
+    "src/lib/**/*.ts"
+  ],
   "dependencies": {
     "@fontsource/space-mono": "^4.5.10",
     "@improbable-eng/grpc-web": "^0.13.0",


### PR DESCRIPTION
This PR add a build step to RDK to publish Remote Control components to the NPM Repository `@viamrobotics/remote-control`.

The workflow was tested on another branch and PR: https://github.com/viamrobotics/rdk/pull/1826. The logic in the workflow was based on the TS SDK: https://github.com/viamrobotics/viam-typescript-sdk/blob/main/.github/workflows/publish.yml

Right now I am using incremental version numbers during development. At the end of the project I will update to use the same version number as git tags, and I think we keep updating the version numbers when we tag the RDK.