### PR TITLE
Fix PR Labeler Workflow

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -13,9 +13,9 @@ jobs:
       github.event_name == 'pull_request_target' &&
       contains(fromJson('["opened", "synchronize", "reopened"]'), github.event.action)
     steps:
-      - name: "Label PR"
+      - name: "Check Membership and Label PR"
         uses: actions/github-script@v6
-        id: labeler
+        id: check-membership
         with:
           github-token: ${{ secrets.PR_TOKEN }}
           script: |
@@ -53,12 +53,10 @@ jobs:
                 name: "safe to test"
               });
             }
-            let result = {is_member: isMember};
-            console.log(result);
-            return result;
+            return isMember;
 
       - name: Add Unsafe PR Comment
-        if: steps.labeler.outputs.is_member != true
+        if: steps.check-membership.outputs.result != true
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           recreate: true

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -2,7 +2,7 @@ name: PR Test Label Manager
 
 on:
   pull_request_target:
-    branches: [ 'workflow-labels' ] # revert before merge
+    branches: [ 'main' ]
     types: [ opened, synchronize, reopened ]
 
 jobs:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -20,20 +20,13 @@ jobs:
           organization: viamrobotics
           username: ${{ github.event.sender.login }}
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Remove label
-        if: |
-          steps.is_organization_member.outputs.result == 'false'
-        uses: andymckay/labeler@1.0.4
-        with:
-          repo-token: ${{ secrets.PR_TOKEN }} 
-          remove-labels: "safe to test"
       - name: Auto label org members
         if: |
           steps.is_organization_member.outputs.result == 'true'
         uses: andymckay/labeler@1.0.4
         with:
           repo-token: ${{ secrets.PR_TOKEN }} 
-          add-labels: "safe to test, viam-org"
+          add-labels: "viam-org"
       - name: Add Unsafe PR Comment
         if: |
           steps.is_organization_member.outputs.result == 'false'
@@ -41,3 +34,17 @@ jobs:
         with:
           recreate: true
           message: For security reasons, this PR must be labeled with `safe to test` in order for tests to run.
+      - name: Remove Safe to Test
+        if: |
+          steps.is_organization_member.outputs.result == 'false'
+        uses: andymckay/labeler@1.0.4
+        with:
+          repo-token: ${{ secrets.PR_TOKEN }} 
+          remove-labels: "safe to test"
+      - name: Mark Safe to Test # each label fires an event, so this must be done last for tests to work
+        if: |
+          steps.is_organization_member.outputs.result == 'true'
+        uses: andymckay/labeler@1.0.4
+        with:
+          repo-token: ${{ secrets.PR_TOKEN }} 
+          add-labels: "safe to test"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -60,9 +60,3 @@ jobs:
 
       - name: "Echo output"
         run: echo ${{ steps.labeler.outputs }}
-      - name: Add Unsafe PR Comment
-        if: steps.labeler.outputs.is_member != true
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          recreate: true
-          message: For security reasons, this PR must be labeled with `safe to test` in order for tests to run.

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -18,15 +18,33 @@ jobs:
         id: labeler
         with:
           script: |
-            let isMember = await github.rest.orgs.checkMembershipForUser({"viamrobotics", context.payload.event.sender.login});
-            let prNumber = context.payload.pull_request && context.payload.pull_request.number            
+            let isMember = await github.rest.orgs.checkMembershipForUser({
+              org: "viamrobotics",
+              username: context.payload.event.sender.login
+            });
+            let prNumber = context.payload.pull_request && context.payload.pull_request.number;
 
             if (isMember) {
-              await github.rest.issues.addLabels({viamrobotics, rdk, prNumber, ['viam-org']});
-              await new Promise(r => setTimeout(r, 2000));
-              await github.rest.issues.addLabels({viamrobotics, rdk, prNumber, ['safe to test']});
+              await github.rest.issues.addLabels({
+                org: "viamrobotics",
+                repo: "rdk",
+                issue_number: prNumber,
+                labels: ["viam-org"]
+              });
+              await new Promise((r) => setTimeout(r, 2000));
+              await github.rest.issues.addLabels({
+                org: "viamrobotics",
+                repo: "rdk",
+                issue_number: prNumber,
+                labels: ["safe to test"]
+              });
             } else {
-              await github.rest.issues.removeLabel({viamrobotics, rdk, prNumber, 'safe to test'});
+              await github.rest.issues.removeLabel({
+                org: "viamrobotics",
+                repo: "rdk",
+                issue_number: prNumber,
+                name: "safe to test"
+              });
             }
             return {is_member: isMember};
 

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -20,17 +20,17 @@ jobs:
           github-token: ${{ secrets.PR_TOKEN }}
           script: |
             let prNumber = context.payload.pull_request && context.payload.pull_request.number;
-            let isMember = false;
-            let orgResp = await github.rest.orgs.checkMembershipForUser({"viamrobotics", context.payload.sender.login});
-            if (orgResp.status === 204) {isMember = true;}
-            if (isMember) {
-              await github.rest.issues.addLabels({"viamrobotics", "rdk", prNumber, ["viam-org"]});
+            let orgResp = await github.rest.orgs.checkMembershipForUser({org: "viamrobotics", username: context.payload.sender.login});
+            if (orgResp.status === 204) {
+              // pr owner is an org member
+              await github.rest.issues.addLabels({owner: "viamrobotics", repo: "rdk", issue_number: prNumber, labels: ["viam-org"]});
               await new Promise((r) => setTimeout(r, 2000));
-              await github.rest.issues.addLabels({"viamrobotics", "rdk", prNumber, ["safe to test"]});
-            } else {
-              await github.rest.issues.removeLabel({"viamrobotics", "rdk", prNumber, "safe to test"});
+              // order of labeling events must be preserved, so two seperate calls
+              await github.rest.issues.addLabels({owner: "viamrobotics", repo: "rdk", issue_number: prNumber, labels: ["safe to test"]});
+              return true;
             }
-            return isMember;
+            await github.rest.issues.removeLabel({owner: "viamrobotics", repo: "rdk", issue_number: prNumber, name: "safe to test"});
+            return false;
 
       - name: Add Unsafe PR Comment
         if: steps.check-membership.outputs.result != 'true'

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -47,7 +47,16 @@ jobs:
                 name: "safe to test"
               });
             }
-            return {is_member: isMember};
+            let result = {is_member: isMember};
+            console.log(result);
+            return result;
+
+      - name: Add Unsafe PR Comment
+        if: steps.labeler.outputs.is_member != true
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          recreate: true
+          message: For security reasons, this PR must be labeled with `safe to test` in order for tests to run.
 
       - name: Add Unsafe PR Comment
         if: steps.labeler.outputs.is_member != true

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -20,14 +20,14 @@ jobs:
           github-token: ${{ secrets.PR_TOKEN }}
           script: |
             let prNumber = context.payload.pull_request && context.payload.pull_request.number;
-            let isMember = false
+            let isMember = false;
 
             let orgResp = await github.rest.orgs.checkMembershipForUser({
               org: "viamrobotics",
               username: context.payload.sender.login
             });
 
-            if orgResp.status == 204 {
+            if (orgResp.status === 204) {
               isMember = true;
             }
 

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -49,7 +49,7 @@ jobs:
             return {is_member: isMember};
 
       - name: Add Unsafe PR Comment
-        if: steps.labeler.outputs.is_member == 'false'
+        if: steps.labeler.outputs.is_member != 'true'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           recreate: true

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -56,7 +56,7 @@ jobs:
             return isMember;
 
       - name: Add Unsafe PR Comment
-        if: steps.check-membership.outputs.result != true
+        if: steps.check-membership.outputs.result != 'true'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           recreate: true

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/github-script@v6
         id: labeler
         with:
+          token: {{ $secrets.PR_TOKEN }}
           script: |
             let isMember = await github.rest.orgs.checkMembershipForUser({
               org: "viamrobotics",
@@ -49,7 +50,7 @@ jobs:
             return {is_member: isMember};
 
       - name: Add Unsafe PR Comment
-        if: steps.labeler.outputs.is_member != 'true'
+        if: !steps.labeler.outputs.is_member
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           recreate: true

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -13,38 +13,26 @@ jobs:
       github.event_name == 'pull_request_target' &&
       contains(fromJson('["opened", "synchronize", "reopened"]'), github.event.action)
     steps:
-      - name: Check if organization member
-        id: is_organization_member
-        uses: jamessingleton/is-organization-member@1.0.1
+      - name: "Label PR"
+        uses: actions/github-script@v6
+        id: labeler
         with:
-          organization: viamrobotics
-          username: ${{ github.event.sender.login }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Auto label org members
-        if: |
-          steps.is_organization_member.outputs.result == 'true'
-        uses: andymckay/labeler@1.0.4
-        with:
-          repo-token: ${{ secrets.PR_TOKEN }} 
-          add-labels: "viam-org"
+          script: |
+            let isMember = await github.rest.orgs.checkMembershipForUser({"viamrobotics", context.payload.event.sender.login});
+            let prNumber = context.payload.pull_request && context.payload.pull_request.number            
+
+            if (isMember) {
+              await github.rest.issues.addLabels({viamrobotics, rdk, prNumber, ['viam-org']});
+              await new Promise(r => setTimeout(r, 2000));
+              await github.rest.issues.addLabels({viamrobotics, rdk, prNumber, ['safe to test']});
+            } else {
+              await github.rest.issues.removeLabel({viamrobotics, rdk, prNumber, 'safe to test'});
+            }
+            return {is_member: isMember};
+
       - name: Add Unsafe PR Comment
-        if: |
-          steps.is_organization_member.outputs.result == 'false'
+        if: steps.labeler.outputs.is_member == 'false'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           recreate: true
           message: For security reasons, this PR must be labeled with `safe to test` in order for tests to run.
-      - name: Remove Safe to Test
-        if: |
-          steps.is_organization_member.outputs.result == 'false'
-        uses: andymckay/labeler@1.0.4
-        with:
-          repo-token: ${{ secrets.PR_TOKEN }} 
-          remove-labels: "safe to test"
-      - name: Mark Safe to Test # each label fires an event, so this must be done last for tests to work
-        if: |
-          steps.is_organization_member.outputs.result == 'true'
-        uses: andymckay/labeler@1.0.4
-        with:
-          repo-token: ${{ secrets.PR_TOKEN }} 
-          add-labels: "safe to test"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -58,6 +58,8 @@ jobs:
           recreate: true
           message: For security reasons, this PR must be labeled with `safe to test` in order for tests to run.
 
+      - name: "Echo output"
+        run: echo ${{ steps.labeler.outputs }}
       - name: Add Unsafe PR Comment
         if: steps.labeler.outputs.is_member != true
         uses: marocchino/sticky-pull-request-comment@v2

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -21,6 +21,7 @@ jobs:
           script: |
             let prNumber = context.payload.pull_request && context.payload.pull_request.number;
             let orgResp = await github.rest.orgs.checkMembershipForUser({org: "viamrobotics", username: context.payload.sender.login});
+            await github.rest.issues.removeLabel({owner: "viamrobotics", repo: "rdk", issue_number: prNumber, name: "safe to test"});
             if (orgResp.status === 204) {
               // pr owner is an org member
               await github.rest.issues.addLabels({owner: "viamrobotics", repo: "rdk", issue_number: prNumber, labels: ["viam-org"]});
@@ -29,7 +30,6 @@ jobs:
               await github.rest.issues.addLabels({owner: "viamrobotics", repo: "rdk", issue_number: prNumber, labels: ["safe to test"]});
               return true;
             }
-            await github.rest.issues.removeLabel({owner: "viamrobotics", repo: "rdk", issue_number: prNumber, name: "safe to test"});
             return false;
 
       - name: Add Unsafe PR Comment

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -2,7 +2,7 @@ name: PR Test Label Manager
 
 on:
   pull_request_target:
-    branches: [ main ]
+    branches: [ 'workflow-labels' ]
     types: [ opened, synchronize, reopened ]
 
 jobs:
@@ -20,7 +20,9 @@ jobs:
           organization: viamrobotics
           username: ${{ github.event.sender.login }}
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Always remove label
+      - name: Remove label
+        if: |
+          steps.is_organization_member.outputs.result == 'false'
         uses: andymckay/labeler@1.0.4
         with:
           repo-token: ${{ secrets.PR_TOKEN }} 

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -23,7 +23,7 @@ jobs:
             try {
               await github.rest.issues.removeLabel({owner: "viamrobotics", repo: "rdk", issue_number: prNumber, name: "safe to test"});
             } catch (err) {
-              core.error(`Error ${err}, while trying to remove 'safe to test' label.`);
+              core.info(`Non-fatal error ${err}, while trying to remove 'safe to test' label.`);
             }
             let orgResp = await github.rest.orgs.checkMembershipForUser({org: "viamrobotics", username: context.payload.sender.login});
             if (orgResp.status === 204) {

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/github-script@v6
         id: labeler
         with:
-          github-token: {{ $secrets.PR_TOKEN }}
+          github-token: ${{ secrets.PR_TOKEN }}
           script: |
             let isMember = await github.rest.orgs.checkMembershipForUser({
               org: "viamrobotics",

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -19,11 +19,17 @@ jobs:
         with:
           github-token: ${{ secrets.PR_TOKEN }}
           script: |
-            let isMember = await github.rest.orgs.checkMembershipForUser({
+            let prNumber = context.payload.pull_request && context.payload.pull_request.number;
+            let isMember = false
+
+            let orgResp = await github.rest.orgs.checkMembershipForUser({
               org: "viamrobotics",
               username: context.payload.sender.login
             });
-            let prNumber = context.payload.pull_request && context.payload.pull_request.number;
+
+            if orgResp.status == 204 {
+              isMember = true;
+            }
 
             if (isMember) {
               await github.rest.issues.addLabels({
@@ -59,4 +65,4 @@ jobs:
           message: For security reasons, this PR must be labeled with `safe to test` in order for tests to run.
 
       - name: "Echo output"
-        run: echo ${{ steps.labeler.outputs }}
+        run: echo ${{ steps.labeler.outputs.is_member }}

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -2,7 +2,7 @@ name: PR Test Label Manager
 
 on:
   pull_request_target:
-    branches: [ 'workflow-labels' ]
+    branches: [ 'workflow-labels' ] # revert before merge
     types: [ opened, synchronize, reopened ]
 
 jobs:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -26,21 +26,21 @@ jobs:
 
             if (isMember) {
               await github.rest.issues.addLabels({
-                org: "viamrobotics",
+                owner: "viamrobotics",
                 repo: "rdk",
                 issue_number: prNumber,
                 labels: ["viam-org"]
               });
               await new Promise((r) => setTimeout(r, 2000));
               await github.rest.issues.addLabels({
-                org: "viamrobotics",
+                owner: "viamrobotics",
                 repo: "rdk",
                 issue_number: prNumber,
                 labels: ["safe to test"]
               });
             } else {
               await github.rest.issues.removeLabel({
-                org: "viamrobotics",
+                owner: "viamrobotics",
                 repo: "rdk",
                 issue_number: prNumber,
                 name: "safe to test"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -20,7 +20,7 @@ jobs:
           script: |
             let isMember = await github.rest.orgs.checkMembershipForUser({
               org: "viamrobotics",
-              username: context.payload.event.sender.login
+              username: context.payload.sender.login
             });
             let prNumber = context.payload.pull_request && context.payload.pull_request.number;
 

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -50,7 +50,7 @@ jobs:
             return {is_member: isMember};
 
       - name: Add Unsafe PR Comment
-        if: !steps.labeler.outputs.is_member
+        if: steps.labeler.outputs.is_member != true
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           recreate: true

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -21,37 +21,14 @@ jobs:
           script: |
             let prNumber = context.payload.pull_request && context.payload.pull_request.number;
             let isMember = false;
-
-            let orgResp = await github.rest.orgs.checkMembershipForUser({
-              org: "viamrobotics",
-              username: context.payload.sender.login
-            });
-
-            if (orgResp.status === 204) {
-              isMember = true;
-            }
-
+            let orgResp = await github.rest.orgs.checkMembershipForUser({"viamrobotics", context.payload.sender.login});
+            if (orgResp.status === 204) {isMember = true;}
             if (isMember) {
-              await github.rest.issues.addLabels({
-                owner: "viamrobotics",
-                repo: "rdk",
-                issue_number: prNumber,
-                labels: ["viam-org"]
-              });
+              await github.rest.issues.addLabels({"viamrobotics", "rdk", prNumber, ["viam-org"]});
               await new Promise((r) => setTimeout(r, 2000));
-              await github.rest.issues.addLabels({
-                owner: "viamrobotics",
-                repo: "rdk",
-                issue_number: prNumber,
-                labels: ["safe to test"]
-              });
+              await github.rest.issues.addLabels({"viamrobotics", "rdk", prNumber, ["safe to test"]});
             } else {
-              await github.rest.issues.removeLabel({
-                owner: "viamrobotics",
-                repo: "rdk",
-                issue_number: prNumber,
-                name: "safe to test"
-              });
+              await github.rest.issues.removeLabel({"viamrobotics", "rdk", prNumber, "safe to test"});
             }
             return isMember;
 
@@ -61,6 +38,3 @@ jobs:
         with:
           recreate: true
           message: For security reasons, this PR must be labeled with `safe to test` in order for tests to run.
-
-      - name: "Echo output"
-        run: echo ${{ steps.labeler.outputs.is_member }}

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -20,8 +20,12 @@ jobs:
           github-token: ${{ secrets.PR_TOKEN }}
           script: |
             let prNumber = context.payload.pull_request && context.payload.pull_request.number;
+            try {
+              await github.rest.issues.removeLabel({owner: "viamrobotics", repo: "rdk", issue_number: prNumber, name: "safe to test"});
+            } catch (err) {
+              core.error(`Error ${err}, while trying to remove 'safe to test' label.`);
+            }
             let orgResp = await github.rest.orgs.checkMembershipForUser({org: "viamrobotics", username: context.payload.sender.login});
-            await github.rest.issues.removeLabel({owner: "viamrobotics", repo: "rdk", issue_number: prNumber, name: "safe to test"});
             if (orgResp.status === 204) {
               // pr owner is an org member
               await github.rest.issues.addLabels({owner: "viamrobotics", repo: "rdk", issue_number: prNumber, labels: ["viam-org"]});

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/github-script@v6
         id: labeler
         with:
-          token: {{ $secrets.PR_TOKEN }}
+          github-token: {{ $secrets.PR_TOKEN }}
           script: |
             let isMember = await github.rest.orgs.checkMembershipForUser({
               org: "viamrobotics",

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -22,15 +22,15 @@ jobs:
             let prNumber = context.payload.pull_request && context.payload.pull_request.number;
             let isMember = false;
             let orgResp = await github.rest.orgs.checkMembershipForUser({"viamrobotics", context.payload.sender.login});
-            if (orgResp.status === 204) {
-              // pr is from a member of the org
+            if (orgResp.status === 204) {isMember = true;}
+            if (isMember) {
               await github.rest.issues.addLabels({"viamrobotics", "rdk", prNumber, ["viam-org"]});
-              // order of labeling events must be preserved, so two seperate calls
+              await new Promise((r) => setTimeout(r, 2000));
               await github.rest.issues.addLabels({"viamrobotics", "rdk", prNumber, ["safe to test"]});
-              return true;
+            } else {
+              await github.rest.issues.removeLabel({"viamrobotics", "rdk", prNumber, "safe to test"});
             }
-            await github.rest.issues.removeLabel({"viamrobotics", "rdk", prNumber, "safe to test"});
-            return false;
+            return isMember;
 
       - name: Add Unsafe PR Comment
         if: steps.check-membership.outputs.result != 'true'

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -22,15 +22,15 @@ jobs:
             let prNumber = context.payload.pull_request && context.payload.pull_request.number;
             let isMember = false;
             let orgResp = await github.rest.orgs.checkMembershipForUser({"viamrobotics", context.payload.sender.login});
-            if (orgResp.status === 204) {isMember = true;}
-            if (isMember) {
+            if (orgResp.status === 204) {
+              // pr is from a member of the org
               await github.rest.issues.addLabels({"viamrobotics", "rdk", prNumber, ["viam-org"]});
-              await new Promise((r) => setTimeout(r, 2000));
+              // order of labeling events must be preserved, so two seperate calls
               await github.rest.issues.addLabels({"viamrobotics", "rdk", prNumber, ["safe to test"]});
-            } else {
-              await github.rest.issues.removeLabel({"viamrobotics", "rdk", prNumber, "safe to test"});
+              return true;
             }
-            return isMember;
+            await github.rest.issues.removeLabel({"viamrobotics", "rdk", prNumber, "safe to test"});
+            return false;
 
       - name: Add Unsafe PR Comment
         if: steps.check-membership.outputs.result != 'true'

--- a/.github/workflows/pullrequest-trusted.yml
+++ b/.github/workflows/pullrequest-trusted.yml
@@ -6,7 +6,7 @@ concurrency:
 
 on:
   pull_request_target:
-    branches: [ 'workflow-labels' ] # revert before merge
+    branches: [ 'main' ]
     types: [ 'labeled' ]
 
 # To test workflow updates you need to work in a branch directly on viamrobotics/rdk

--- a/.github/workflows/pullrequest-trusted.yml
+++ b/.github/workflows/pullrequest-trusted.yml
@@ -5,7 +5,7 @@ concurrency:
 
 on:
   pull_request_target:
-    branches: [ 'workflow-labels' ]
+    branches: [ 'workflow-labels' ] # revert before merge
     types: [ 'labeled' ]
 
 # To test workflow updates you need to work in a branch directly on viamrobotics/rdk

--- a/.github/workflows/pullrequest-trusted.yml
+++ b/.github/workflows/pullrequest-trusted.yml
@@ -6,8 +6,8 @@ concurrency:
 
 on:
   pull_request_target:
-    branches: [ 'main' ]
-    types: [ labeled ]
+    branches: [ 'workflow-labels' ]
+    types: [ 'labeled' ]
 
 # To test workflow updates you need to work in a branch directly on viamrobotics/rdk
 # and tag your working branch instead of @main in any viamrobotics/rdk "uses" below.

--- a/.github/workflows/pullrequest-trusted.yml
+++ b/.github/workflows/pullrequest-trusted.yml
@@ -2,7 +2,6 @@ name: Pull Request Update
 
 concurrency: 
   group: pullrequest-untrusted-${{ github.head_ref }}
-  cancel-in-progress: true
 
 on:
   pull_request_target:

--- a/.github/workflows/pullrequest-trusted.yml
+++ b/.github/workflows/pullrequest-trusted.yml
@@ -2,6 +2,7 @@ name: Pull Request Update
 
 concurrency: 
   group: pullrequest-untrusted-${{ github.head_ref }}
+  cancel-in-progress: true
 
 on:
   pull_request_target:


### PR DESCRIPTION
Ugh, this turned out to be more annoying to debug and correct than I ever expected. Long story short, github fires an event trigger for every label added, even though the .update() action is a single call. When we added the "viam-org" label at the same time as "safe-to-test" it appears to have been doing them in alphabetical order, so the second Test workflow that fired was on a label that wouldn't actually do anything, yet it still cancelled the workflow from the first label (started seconds prior.) And thus, new PRs would just hang and not run their tests. So the labels are now being added one at a time, in the correct order.

Additionally, both the "is-organization-member" and "labeler" actions we were using were out of date and causing warnings. I couldn't find ready/easy replacements, but the code in each was pretty simple, so figured it was easier to just replicate as action script here instead (which runs much faster in a single step.)