### PR TITLE
RSDK-888 Stop bases and arms on controller connect events

### DIFF
--- a/services/baseremotecontrol/builtin/builtin.go
+++ b/services/baseremotecontrol/builtin/builtin.go
@@ -34,6 +34,7 @@ const (
 	arrowControl
 	droneControl
 )
+
 var Subtype = baseremotecontrol.Subtype
 
 func init() {
@@ -194,6 +195,9 @@ func (svc *builtIn) start(ctx context.Context) error {
 	connect := func(ctx context.Context, event input.Event) {
 		onlyOneAtATime.Lock()
 		defer onlyOneAtATime.Unlock()
+
+		// Connect and Disconnect events should both stop the base completely.
+		svc.base.Stop(ctx, map[string]interface{}{})
 
 		if !updateLastEvent(event) {
 			return


### PR DESCRIPTION
RSDK-888

Modifies base and arm remote control services to call `Stop` on the underlying resource when a `Connect` or `Disconnect` event is triggered. Adds tests to ensure this new behavior.

I thought it would make sense to stop all movement on both types of connect events. Let me know if I should only add this functionality for `Disconnect`.