### PR TITLE
RSDK-1666 remove flaky MergePoints tests for now 

### DIFF
--- a/pointcloud/merging_test.go
+++ b/pointcloud/merging_test.go
@@ -113,6 +113,7 @@ func TestApplyOffset(t *testing.T) {
 }
 
 func TestMergePoints1(t *testing.T) {
+	t.Skip("remove skip once RSDK-1200 improvement is complete")
 	logger := golog.NewTestLogger(t)
 	clouds := makeClouds(t)
 	cloudsWithOffset := make([]CloudAndOffsetFunc, 0, len(clouds))
@@ -130,6 +131,7 @@ func TestMergePoints1(t *testing.T) {
 }
 
 func TestMergePoints2(t *testing.T) {
+	t.Skip("remove skip once RSDK-1200 improvement is complete")
 	logger := golog.NewTestLogger(t)
 	clouds := makeThreeCloudsWithOffsets(t)
 	pc, err := MergePointClouds(context.Background(), clouds, logger)

--- a/pointcloud/merging_test.go
+++ b/pointcloud/merging_test.go
@@ -13,6 +13,7 @@ import (
 	"go.viam.com/rdk/spatialmath"
 )
 
+//nolint:unused
 func makeThreeCloudsWithOffsets(t *testing.T) []CloudAndOffsetFunc {
 	t.Helper()
 	pc1 := NewWithPrealloc(1)


### PR DESCRIPTION
These flaky tests could potentially be fixed by improvements as explained in RSDK-1200, but until we do the improvements, we should skip these tests. 