### PR TITLE
add header field to auto-generated pr comments

### DIFF
--- a/.github/workflows/code-coverage-comment.yml
+++ b/.github/workflows/code-coverage-comment.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Add Coverage PR Comment
         uses: marocchino/sticky-pull-request-comment@v2
         with:
+          header: code-coverage
           number: ${{ env.PR_NUMBER }}
           recreate: true
           path: code-coverage-results.md
@@ -32,6 +33,7 @@ jobs:
         if: ${{ env.APPIMAGE }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
+          header: AppImage
           number: ${{ env.PR_NUMBER }}
           recreate: true
           message: |

--- a/.github/workflows/motion-benchmarks-comment.yml
+++ b/.github/workflows/motion-benchmarks-comment.yml
@@ -25,9 +25,10 @@ jobs:
       - name: Restore Environment
         run: cat pr.env >> "${GITHUB_ENV}"
 
-      - name: Add Coverage PR Comment
+      - name: Add Motion Benchmarks Comment
         uses: marocchino/sticky-pull-request-comment@v2
         with:
+          header: motion-benchmark
           number: ${{ env.PR_NUMBER }}
           recreate: true
           path: motion-testing/results/motion-benchmarks.md


### PR DESCRIPTION
This PR fixes a latent issue in CI where the auto-generated comments from the commenting bot would overwrite each other by adding a `header` field to the action.