### PR TITLE
RSDK-1875 Ensure parent resources are updated when fetched from module

### DIFF
--- a/module/module.go
+++ b/module/module.go
@@ -197,6 +197,12 @@ func (m *Module) GetParentResource(ctx context.Context, name resource.Name) (int
 	if err := m.connectParent(ctx); err != nil {
 		return nil, err
 	}
+
+	// Refresh parent to ensure it has the most up-to-date resources before calling
+	// ResourceByName.
+	if err := m.parent.Refresh(ctx); err != nil {
+		return nil, err
+	}
 	return m.parent.ResourceByName(name)
 }
 

--- a/module/module_test.go
+++ b/module/module_test.go
@@ -116,6 +116,16 @@ func TestModuleFunctions(t *testing.T) {
 
 		err = utils.TryClose(ctx, rMotor)
 		test.That(t, err, test.ShouldBeNil)
+
+		// Test that GetParentResouce will refresh resources on the parent
+		cfg.Components = append(cfg.Components, config.Component{
+			Name:  "motor2",
+			API:   resource.NewSubtype("rdk", "component", "motor"),
+			Model: resource.NewDefaultModel("fake"),
+		})
+		myRobot.Reconfigure(ctx, cfg)
+		_, err = m.GetParentResource(ctx, motor.Named("motor2"))
+		test.That(t, err, test.ShouldBeNil)
 	})
 
 	var gClient gizmoapi.Gizmo

--- a/module/module_test.go
+++ b/module/module_test.go
@@ -117,7 +117,7 @@ func TestModuleFunctions(t *testing.T) {
 		err = utils.TryClose(ctx, rMotor)
 		test.That(t, err, test.ShouldBeNil)
 
-		// Test that GetParentResouce will refresh resources on the parent
+		// Test that GetParentResource will refresh resources on the parent
 		cfg.Components = append(cfg.Components, config.Component{
 			Name:  "motor2",
 			API:   resource.NewSubtype("rdk", "component", "motor"),


### PR DESCRIPTION
RSDK-1875

Adds a `Refresh` call in module before trying to access parent's resources to ensure the parent `RobotClient` has the most updated resources. Tests that `GetParentResource` will discover resources that were registered after module connected to parent.