### PR TITLE
RSDK-1935 emptying the config

### DIFF
--- a/config/reader.go
+++ b/config/reader.go
@@ -550,7 +550,7 @@ func readFromCloud(
 	}
 
 	mergeCloudConfig(cfg)
-
+	// TODO(RSDK-1960): add more tests around config caching
 	unprocessedConfig.Cloud.TLSCertificate = tlsCertificate
 	unprocessedConfig.Cloud.TLSPrivateKey = tlsPrivateKey
 

--- a/config/reader.go
+++ b/config/reader.go
@@ -551,9 +551,10 @@ func readFromCloud(
 
 	mergeCloudConfig(cfg)
 
-	logger.Infow("configs before caching", "unprocessed", unprocessedConfig, "merged", cfg)
+	unprocessedConfig.Cloud.TLSCertificate = tlsCertificate
+	unprocessedConfig.Cloud.TLSPrivateKey = tlsPrivateKey
 
-	if err := storeToCache(cloudCfg.ID, cfg); err != nil {
+	if err := storeToCache(cloudCfg.ID, unprocessedConfig); err != nil {
 		logger.Errorw("failed to cache config", "error", err)
 	}
 

--- a/config/reader.go
+++ b/config/reader.go
@@ -551,6 +551,8 @@ func readFromCloud(
 
 	mergeCloudConfig(cfg)
 
+	logger.Infow("configs before caching", "unprocessed", unprocessedConfig, "merged", cfg)
+
 	if err := storeToCache(cloudCfg.ID, cfg); err != nil {
 		logger.Errorw("failed to cache config", "error", err)
 	}

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -463,20 +463,13 @@ func newWithResources(
 
 	if cfg.Cloud != nil && cfg.Cloud.AppAddress != "" {
 		var err error
-		timeOutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		r.cloudConn, err = config.CreateNewGRPCClient(timeOutCtx, cfg.Cloud, logger)
-		cancel()
-		if err == nil {
-			r.packageManager, err = packages.NewCloudManager(pb.NewPackageServiceClient(r.cloudConn), cfg.PackagePath, logger)
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			if !errors.Is(err, context.DeadlineExceeded) {
-				return nil, err
-			}
-			r.logger.Debug("Using no-op PackageManager when internet not available")
-			r.packageManager = packages.NewNoopManager()
+		r.cloudConn, err = config.CreateNewGRPCClient(ctx, cfg.Cloud, logger)
+		if err != nil {
+			return nil, err
+		}
+		r.packageManager, err = packages.NewCloudManager(pb.NewPackageServiceClient(r.cloudConn), cfg.PackagePath, logger)
+		if err != nil {
+			return nil, err
 		}
 	} else {
 		r.logger.Debug("Using no-op PackageManager when Cloud config is not available")


### PR DESCRIPTION
JIRA: https://viam.atlassian.net/browse/RSDK-1935

Amends https://github.com/viamrobotics/rdk/pull/1855 to just add TLS information to our cached config, caching a merged config. The latter does not include attribute information.