### PR TITLE
DATA-1119 - Fix package download on the RDK side

### DIFF
--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -338,6 +338,9 @@ func (m *cloudManager) downloadFileFromGCSURL(ctx context.Context, url string, p
 	checksum := getGoogleHash(resp.Header, "crc32c")
 
 	//nolint:gosec // safe
+	if err := os.Mkdir(filepath.Dir(downloadPath), 0o700); err != nil {
+		return checksum, contentType, err
+	}
 	out, err := os.Create(downloadPath)
 	if err != nil {
 		return checksum, contentType, err

--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -337,10 +337,10 @@ func (m *cloudManager) downloadFileFromGCSURL(ctx context.Context, url string, p
 	contentType := resp.Header.Get("Content-Type")
 	checksum := getGoogleHash(resp.Header, "crc32c")
 
-	//nolint:gosec // safe
 	if err := os.Mkdir(filepath.Dir(downloadPath), 0o700); err != nil {
 		return checksum, contentType, err
 	}
+	//nolint:gosec // safe
 	out, err := os.Create(downloadPath)
 	if err != nil {
 		return checksum, contentType, err


### PR DESCRIPTION
We already call MkdirAll on `~/.viam/packages/data`, but need to do for each package subdirectory in order to successfully create a .tar.gz file within it.

Tested: Package deployment now works with this local RDK version connected to prod app.