### PR TITLE
RSDK-840 remove redundant client connection checks

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -78,7 +78,7 @@ func (c *Config) Ensure(fromCloud bool) error {
 			if c.DisablePartialStart {
 				return err
 			}
-			golog.Global().Debug(errors.Wrap(err, "Module config error, starting robot without module: "+c.Modules[idx].Name))
+			golog.Global().Error(errors.Wrap(err, "Module config error, starting robot without module: "+c.Modules[idx].Name))
 		}
 	}
 
@@ -87,7 +87,7 @@ func (c *Config) Ensure(fromCloud bool) error {
 			if c.DisablePartialStart {
 				return err
 			}
-			golog.Global().Debug(errors.Wrap(err, "Remote config error, starting robot without remote: "+c.Remotes[idx].Name))
+			golog.Global().Error(errors.Wrap(err, "Remote config error, starting robot without remote: "+c.Remotes[idx].Name))
 		}
 	}
 
@@ -98,7 +98,7 @@ func (c *Config) Ensure(fromCloud bool) error {
 			if c.DisablePartialStart {
 				return fullErr
 			}
-			golog.Global().Debug(errors.Wrap(err, "Component config error, starting robot without component: "+c.Components[idx].Name))
+			golog.Global().Error(errors.Wrap(err, "Component config error, starting robot without component: "+c.Components[idx].Name))
 		} else {
 			c.Components[idx].ImplicitDependsOn = dependsOn
 		}
@@ -109,7 +109,7 @@ func (c *Config) Ensure(fromCloud bool) error {
 			if c.DisablePartialStart {
 				return err
 			}
-			golog.Global().Debug(errors.Wrap(err, "Process config error, starting robot without process: "+c.Processes[idx].Name))
+			golog.Global().Error(errors.Wrap(err, "Process config error, starting robot without process: "+c.Processes[idx].Name))
 		}
 	}
 
@@ -119,7 +119,7 @@ func (c *Config) Ensure(fromCloud bool) error {
 			if c.DisablePartialStart {
 				return err
 			}
-			golog.Global().Debug(errors.Wrap(err, "Service config error, starting robot without service: "+c.Services[idx].Name))
+			golog.Global().Error(errors.Wrap(err, "Service config error, starting robot without service: "+c.Services[idx].Name))
 		} else {
 			c.Services[idx].ImplicitDependsOn = dependsOn
 		}
@@ -139,7 +139,7 @@ func (c *Config) Ensure(fromCloud bool) error {
 			if c.DisablePartialStart {
 				return fullErr
 			}
-			golog.Global().Debug(errors.Wrap(err, "Package config error, starting robot without package: "+c.Packages[idx].Name))
+			golog.Global().Error(errors.Wrap(err, "Package config error, starting robot without package: "+c.Packages[idx].Name))
 		}
 	}
 

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -125,7 +125,7 @@ func (rc *RobotClient) handleUnaryDisconnect(
 		return invoker(ctx, method, req, reply, cc, opts...)
 	}
 
-	if err := rc.checkConnected(); err != nil {
+	if err := rc.CheckConnected(); err != nil {
 		rc.Logger().Debugw("connection is down, skipping method call", "method", method)
 		return status.Error(codes.Unavailable, err.Error())
 	}
@@ -145,7 +145,7 @@ type handleDisconnectClientStream struct {
 }
 
 func (cs *handleDisconnectClientStream) RecvMsg(m interface{}) error {
-	if err := cs.RobotClient.checkConnected(); err != nil {
+	if err := cs.RobotClient.CheckConnected(); err != nil {
 		return status.Error(codes.Unavailable, err.Error())
 	}
 
@@ -171,7 +171,7 @@ func (rc *RobotClient) handleStreamDisconnect(
 		return streamer(ctx, desc, cc, method, opts...)
 	}
 
-	if err := rc.checkConnected(); err != nil {
+	if err := rc.CheckConnected(); err != nil {
 		rc.Logger().Debugw("connection is down, skipping method call", "method", method)
 		return nil, status.Error(codes.Unavailable, err.Error())
 	}
@@ -276,13 +276,6 @@ func (rc *RobotClient) SetParentNotifier(f func()) {
 	rc.mu.Lock()
 	defer rc.mu.Unlock()
 	rc.notifyParent = f
-}
-
-// Connected exposes whether a robot client is connected to the remote.
-func (rc *RobotClient) Connected() bool {
-	rc.mu.RLock()
-	defer rc.mu.RUnlock()
-	return rc.connected
 }
 
 // Changed watches for whether the remote has changed.
@@ -461,7 +454,8 @@ func (rc *RobotClient) Close(ctx context.Context) error {
 	return rc.conn.Close()
 }
 
-func (rc *RobotClient) checkConnected() error {
+// Checks if robot client is connected.
+func (rc *RobotClient) CheckConnected() error {
 	if !rc.connected {
 		return rc.notConnectedToRemoteError()
 	}
@@ -494,7 +488,7 @@ func (rc *RobotClient) RemoteByName(name string) (robot.Robot, bool) {
 // ResourceByName returns resource by name.
 func (rc *RobotClient) ResourceByName(name resource.Name) (interface{}, error) {
 	rc.mu.RLock()
-	if err := rc.checkConnected(); err != nil {
+	if err := rc.CheckConnected(); err != nil {
 		rc.mu.RUnlock()
 		return nil, err
 	}
@@ -608,7 +602,7 @@ func (rc *RobotClient) resources(ctx context.Context) ([]resource.Name, []resour
 func (rc *RobotClient) Refresh(ctx context.Context) (err error) {
 	rc.mu.Lock()
 	defer rc.mu.Unlock()
-	if err := rc.checkConnected(); err != nil {
+	if err := rc.CheckConnected(); err != nil {
 		return err
 	}
 	return rc.updateResources(ctx, updateReasonRefresh)
@@ -685,7 +679,7 @@ func (rc *RobotClient) PackageManager() packages.Manager {
 func (rc *RobotClient) ResourceNames() []resource.Name {
 	rc.mu.RLock()
 	defer rc.mu.RUnlock()
-	if err := rc.checkConnected(); err != nil {
+	if err := rc.CheckConnected(); err != nil {
 		rc.Logger().Errorw("failed to get remote resource names", "error", err)
 		return nil
 	}
@@ -704,7 +698,7 @@ func (rc *RobotClient) ResourceNames() []resource.Name {
 func (rc *RobotClient) ResourceRPCSubtypes() []resource.RPCSubtype {
 	rc.mu.RLock()
 	defer rc.mu.RUnlock()
-	if err := rc.checkConnected(); err != nil {
+	if err := rc.CheckConnected(); err != nil {
 		rc.Logger().Errorw("failed to get remote resource types", "error", err)
 		return nil
 	}

--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -739,19 +739,19 @@ func TestClientDisconnect(t *testing.T) {
 		test.That(t, utils.TryClose(context.Background(), client), test.ShouldBeNil)
 	}()
 
-	test.That(t, client.CheckConnected(), test.ShouldBeNil)
+	test.That(t, client.Connected(), test.ShouldBeTrue)
 	test.That(t, len(client.ResourceNames()), test.ShouldEqual, 1)
 	_, err = client.ResourceByName(arm.Named("arm1"))
 	test.That(t, err, test.ShouldBeNil)
 
 	gServer.Stop()
 	test.That(t, <-client.Changed(), test.ShouldBeTrue)
-	test.That(t, client.CheckConnected(), test.ShouldBeError)
+	test.That(t, client.Connected(), test.ShouldBeFalse)
 	timeSinceStart := time.Since(start)
 	test.That(t, timeSinceStart, test.ShouldBeBetweenOrEqual, dur, 4*dur)
 	test.That(t, len(client.ResourceNames()), test.ShouldEqual, 0)
 	_, err = client.ResourceByName(arm.Named("arm1"))
-	test.That(t, err, test.ShouldBeError, client.CheckConnected())
+	test.That(t, err, test.ShouldBeError, client.checkConnected())
 }
 
 func TestClientUnaryDisconnectHandler(t *testing.T) {
@@ -1000,7 +1000,7 @@ func TestClientReconnect(t *testing.T) {
 	test.That(t, <-client.Changed(), test.ShouldBeTrue)
 	test.That(t, len(client.ResourceNames()), test.ShouldEqual, 0)
 	_, err = client.ResourceByName(arm.Named("arm1"))
-	test.That(t, err, test.ShouldBeError, client.CheckConnected())
+	test.That(t, err, test.ShouldBeError, client.checkConnected())
 
 	gServer2 := grpc.NewServer()
 	pb.RegisterRobotServiceServer(gServer2, server.New(injectRobot))
@@ -1014,7 +1014,7 @@ func TestClientReconnect(t *testing.T) {
 	defer gServer2.Stop()
 
 	test.That(t, <-client.Changed(), test.ShouldBeTrue)
-	test.That(t, client.CheckConnected(), test.ShouldBeNil)
+	test.That(t, client.Connected(), test.ShouldBeTrue)
 	test.That(t, len(client.ResourceNames()), test.ShouldEqual, 2)
 	_, err = client.ResourceByName(arm.Named("arm1"))
 	test.That(t, err, test.ShouldBeNil)

--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -739,19 +739,19 @@ func TestClientDisconnect(t *testing.T) {
 		test.That(t, utils.TryClose(context.Background(), client), test.ShouldBeNil)
 	}()
 
-	test.That(t, client.Connected(), test.ShouldBeTrue)
+	test.That(t, client.CheckConnected(), test.ShouldBeNil)
 	test.That(t, len(client.ResourceNames()), test.ShouldEqual, 1)
 	_, err = client.ResourceByName(arm.Named("arm1"))
 	test.That(t, err, test.ShouldBeNil)
 
 	gServer.Stop()
 	test.That(t, <-client.Changed(), test.ShouldBeTrue)
-	test.That(t, client.Connected(), test.ShouldBeFalse)
+	test.That(t, client.CheckConnected(), test.ShouldBeError)
 	timeSinceStart := time.Since(start)
 	test.That(t, timeSinceStart, test.ShouldBeBetweenOrEqual, dur, 4*dur)
 	test.That(t, len(client.ResourceNames()), test.ShouldEqual, 0)
 	_, err = client.ResourceByName(arm.Named("arm1"))
-	test.That(t, err, test.ShouldBeError, client.checkConnected())
+	test.That(t, err, test.ShouldBeError, client.CheckConnected())
 }
 
 func TestClientUnaryDisconnectHandler(t *testing.T) {
@@ -1000,7 +1000,7 @@ func TestClientReconnect(t *testing.T) {
 	test.That(t, <-client.Changed(), test.ShouldBeTrue)
 	test.That(t, len(client.ResourceNames()), test.ShouldEqual, 0)
 	_, err = client.ResourceByName(arm.Named("arm1"))
-	test.That(t, err, test.ShouldBeError, client.checkConnected())
+	test.That(t, err, test.ShouldBeError, client.CheckConnected())
 
 	gServer2 := grpc.NewServer()
 	pb.RegisterRobotServiceServer(gServer2, server.New(injectRobot))
@@ -1014,7 +1014,7 @@ func TestClientReconnect(t *testing.T) {
 	defer gServer2.Stop()
 
 	test.That(t, <-client.Changed(), test.ShouldBeTrue)
-	test.That(t, client.Connected(), test.ShouldBeTrue)
+	test.That(t, client.CheckConnected(), test.ShouldBeNil)
 	test.That(t, len(client.ResourceNames()), test.ShouldEqual, 2)
 	_, err = client.ResourceByName(arm.Named("arm1"))
 	test.That(t, err, test.ShouldBeNil)

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -1946,7 +1946,7 @@ func TestReconnectRemote(t *testing.T) {
 
 	// check if the original arm can still be called
 	test.That(t, <-remoteRobotClient.Changed(), test.ShouldBeTrue)
-	test.That(t, remoteRobotClient.Connected(), test.ShouldBeTrue)
+	test.That(t, remoteRobotClient.CheckConnected(), test.ShouldBeNil)
 	test.That(t, len(remoteRobotClient.ResourceNames()), test.ShouldEqual, 5)
 	testutils.WaitForAssertion(t, func(tb testing.TB) {
 		tb.Helper()
@@ -2071,7 +2071,7 @@ func TestReconnectRemoteChangeConfig(t *testing.T) {
 
 	// check if the original arm can't be called anymore
 	test.That(t, <-remoteRobotClient.Changed(), test.ShouldBeTrue)
-	test.That(t, remoteRobotClient.Connected(), test.ShouldBeTrue)
+	test.That(t, remoteRobotClient.CheckConnected(), test.ShouldBeNil)
 	test.That(t, len(remoteRobotClient.ResourceNames()), test.ShouldEqual, 5)
 	testutils.WaitForAssertion(t, func(tb testing.TB) {
 		tb.Helper()

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -1946,7 +1946,7 @@ func TestReconnectRemote(t *testing.T) {
 
 	// check if the original arm can still be called
 	test.That(t, <-remoteRobotClient.Changed(), test.ShouldBeTrue)
-	test.That(t, remoteRobotClient.CheckConnected(), test.ShouldBeNil)
+	test.That(t, remoteRobotClient.Connected(), test.ShouldBeTrue)
 	test.That(t, len(remoteRobotClient.ResourceNames()), test.ShouldEqual, 5)
 	testutils.WaitForAssertion(t, func(tb testing.TB) {
 		tb.Helper()
@@ -2071,7 +2071,7 @@ func TestReconnectRemoteChangeConfig(t *testing.T) {
 
 	// check if the original arm can't be called anymore
 	test.That(t, <-remoteRobotClient.Changed(), test.ShouldBeTrue)
-	test.That(t, remoteRobotClient.CheckConnected(), test.ShouldBeNil)
+	test.That(t, remoteRobotClient.Connected(), test.ShouldBeTrue)
 	test.That(t, len(remoteRobotClient.ResourceNames()), test.ShouldEqual, 5)
 	testutils.WaitForAssertion(t, func(tb testing.TB) {
 		tb.Helper()


### PR DESCRIPTION
Removed the redundant method Connected(), changed tests to use CheckConnection() instead