### PR TITLE
RSDK-1764 - add maxRotation angle to the servo config

### DIFF
--- a/components/board/pi/common/common.go
+++ b/components/board/pi/common/common.go
@@ -19,11 +19,11 @@ var ModelName = resource.NewDefaultModel("pi")
 type ServoConfig struct {
 	Pin         string   `json:"pin"`
 	Min         int      `json:"min,omitempty"`
-	Max         int      `json:"max,omitempty"`
+	Max         int      `json:"max,omitempty"` // describes a position the user does not want the servo to move past. 
 	StartPos    *float64 `json:"starting_position_degs,omitempty"`
 	HoldPos     *bool    `json:"hold_position,omitempty"` // defaults True. False holds for 500 ms then disables servo
 	BoardName   string   `json:"board"`
-	MaxRotation int      `json:"max_rotation_deg,omitempty"`
+	MaxRotation int      `json:"max_rotation_deg,omitempty"` //describes max position the servo could reach in degrees as specified by the data sheet. Defaults to 180
 }
 
 // Validate ensures all parts of the config are valid.

--- a/components/board/pi/common/common.go
+++ b/components/board/pi/common/common.go
@@ -23,7 +23,7 @@ type ServoConfig struct {
 	StartPos    *float64 `json:"starting_position_degs,omitempty"`
 	HoldPos     *bool    `json:"hold_position,omitempty"` // defaults True. False holds for 500 ms then disables servo
 	BoardName   string   `json:"board"`
-	MaxRotation int      `json:"max_rotation_deg,omitempty"` //describes max position the servo could reach in degrees as specified by the data sheet. Defaults to 180
+	MaxRotation int      `json:"max_rotation_deg,omitempty"` // describes max position the servo could reach in degrees as specified by the data sheet. Defaults to 180
 }
 
 // Validate ensures all parts of the config are valid.

--- a/components/board/pi/common/common.go
+++ b/components/board/pi/common/common.go
@@ -23,7 +23,7 @@ type ServoConfig struct {
 	StartPos    *float64 `json:"starting_position_degs,omitempty"`
 	HoldPos     *bool    `json:"hold_position,omitempty"` // defaults True. False holds for 500 ms then disables servo
 	BoardName   string   `json:"board"`
-	MaxRotation int      `json:"max_rotation,omitempty"`
+	MaxRotation int      `json:"max_rotation_deg,omitempty"`
 }
 
 // Validate ensures all parts of the config are valid.

--- a/components/board/pi/common/common.go
+++ b/components/board/pi/common/common.go
@@ -19,11 +19,11 @@ var ModelName = resource.NewDefaultModel("pi")
 type ServoConfig struct {
 	Pin         string   `json:"pin"`
 	Min         int      `json:"min,omitempty"`
-	Max         int      `json:"max,omitempty"` // describes a position the user does not want the servo to move past. 
+	Max         int      `json:"max,omitempty"` // specifies a user inputted position limitation
 	StartPos    *float64 `json:"starting_position_degs,omitempty"`
 	HoldPos     *bool    `json:"hold_position,omitempty"` // defaults True. False holds for 500 ms then disables servo
 	BoardName   string   `json:"board"`
-	MaxRotation int      `json:"max_rotation_deg,omitempty"` // describes max position the servo could reach in degrees as specified by the data sheet. Defaults to 180
+	MaxRotation int      `json:"max_rotation_deg,omitempty"` // specifies a hardware position limitation. Defaults to 180
 }
 
 // Validate ensures all parts of the config are valid.

--- a/components/board/pi/common/common.go
+++ b/components/board/pi/common/common.go
@@ -17,12 +17,13 @@ var ModelName = resource.NewDefaultModel("pi")
 
 // ServoConfig is the config for a pi servo.
 type ServoConfig struct {
-	Pin       string   `json:"pin"`
-	Min       int      `json:"min,omitempty"`
-	Max       int      `json:"max,omitempty"`
-	StartPos  *float64 `json:"starting_position_degs,omitempty"`
-	HoldPos   *bool    `json:"hold_position,omitempty"` // defaults True. False holds for 500 ms then disables servo
-	BoardName string   `json:"board"`
+	Pin         string   `json:"pin"`
+	Min         int      `json:"min,omitempty"`
+	Max         int      `json:"max,omitempty"`
+	StartPos    *float64 `json:"starting_position_degs,omitempty"`
+	HoldPos     *bool    `json:"hold_position,omitempty"` // defaults True. False holds for 500 ms then disables servo
+	BoardName   string   `json:"board"`
+	MaxRotation int      `json:"max_rotation,omitempty"`
 }
 
 // Validate ensures all parts of the config are valid.

--- a/components/board/pi/impl/board_test.go
+++ b/components/board/pi/impl/board_test.go
@@ -240,27 +240,35 @@ func TestPiPigpio(t *testing.T) {
 
 func TestServoFunctions(t *testing.T) {
 	t.Run("check servo math", func(t *testing.T) {
-		pw := angleToPulseWidth(1)
+		pw := angleToPulseWidth(1, servoDefaultMaxRotation)
 		test.That(t, pw, test.ShouldEqual, 511)
-		pw = angleToPulseWidth(0)
+		pw = angleToPulseWidth(0, servoDefaultMaxRotation)
 		test.That(t, pw, test.ShouldEqual, 500)
-		pw = angleToPulseWidth(179)
+		pw = angleToPulseWidth(179, servoDefaultMaxRotation)
 		test.That(t, pw, test.ShouldEqual, 2488)
-		pw = angleToPulseWidth(180)
+		pw = angleToPulseWidth(180, servoDefaultMaxRotation)
 		test.That(t, pw, test.ShouldEqual, 2500)
-		a := pulseWidthToAngle(511)
+		pw = angleToPulseWidth(179, 270)
+		test.That(t, pw, test.ShouldEqual, 1825)
+		pw = angleToPulseWidth(180, 270)
+		test.That(t, pw, test.ShouldEqual, 1833)
+		a := pulseWidthToAngle(511, servoDefaultMaxRotation)
 		test.That(t, a, test.ShouldEqual, 1)
-		a = pulseWidthToAngle(500)
+		a = pulseWidthToAngle(500, servoDefaultMaxRotation)
 		test.That(t, a, test.ShouldEqual, 0)
-		a = pulseWidthToAngle(2500)
+		a = pulseWidthToAngle(2500, servoDefaultMaxRotation)
 		test.That(t, a, test.ShouldEqual, 180)
-		a = pulseWidthToAngle(2488)
+		a = pulseWidthToAngle(2488, servoDefaultMaxRotation)
 		test.That(t, a, test.ShouldEqual, 179)
+		a = pulseWidthToAngle(1825, 270)
+		test.That(t, a, test.ShouldEqual, 179)
+		a = pulseWidthToAngle(1833, 270)
+		test.That(t, a, test.ShouldEqual, 180)
 	})
 
 	t.Run(("check Move IsMoving ande pigpio errors"), func(t *testing.T) {
 		ctx := context.Background()
-		s := &piPigpioServo{pinname: "1"}
+		s := &piPigpioServo{pinname: "1", maxRotation: 180}
 
 		s.res = -93
 		err := s.pigpioErrors(int(s.res))

--- a/components/board/pi/impl/servo.go
+++ b/components/board/pi/impl/servo.go
@@ -25,6 +25,7 @@ import (
 )
 
 var holdTime = 250000000 // 250ms in nanoseconds
+var servoDefaultMaxRotation = 180
 
 // init registers a pi servo based on pigpio.
 func init() {
@@ -54,6 +55,10 @@ func init() {
 				if attr.Max > 0 {
 					theServo.max = uint32(attr.Max)
 				}
+				theServo.maxRotation = uint32(attr.MaxRotation)
+				if theServo.maxRotation == 0 {
+					theServo.maxRotation = uint32(servoDefaultMaxRotation)
+				}
 
 				theServo.pinname = attr.Pin
 
@@ -63,7 +68,7 @@ func init() {
 						return nil, errors.Errorf("gpioServo failed with %d", setPos)
 					}
 				} else {
-					setPos := C.gpioServo(theServo.pin, C.uint(angleToPulseWidth(int(*attr.StartPos))))
+					setPos := C.gpioServo(theServo.pin, C.uint(angleToPulseWidth(int(*attr.StartPos), int(theServo.maxRotation))))
 					if setPos != 0 {
 						return nil, errors.Errorf("gpioServo failed with %d", setPos)
 					}
@@ -87,13 +92,14 @@ var _ = servo.LocalServo(&piPigpioServo{})
 // piPigpioServo implements a servo.Servo using pigpio.
 type piPigpioServo struct {
 	generic.Unimplemented
-	pin        C.uint
-	pinname    string
-	res        C.int
-	min, max   uint32
-	opMgr      operation.SingleOperationManager
-	pulseWidth int // pulsewidth value, 500-2500us is 0-180 degrees, 0 is off
-	holdPos    bool
+	pin         C.uint
+	pinname     string
+	res         C.int
+	min, max    uint32
+	opMgr       operation.SingleOperationManager
+	pulseWidth  int // pulsewidth value, 500-2500us is 0-180 degrees, 0 is off
+	holdPos     bool
+	maxRotation uint32
 }
 
 // Move moves the servo to the given angle (0-180 degrees)
@@ -108,8 +114,7 @@ func (s *piPigpioServo) Move(ctx context.Context, angle uint32, extra map[string
 	if s.max > 0 && angle > s.max {
 		angle = s.max
 	}
-
-	pulseWidth := angleToPulseWidth(int(angle))
+	pulseWidth := angleToPulseWidth(int(angle), int(s.maxRotation))
 	res := C.gpioServo(s.pin, C.uint(pulseWidth))
 
 	s.pulseWidth = pulseWidth
@@ -157,20 +162,20 @@ func (s *piPigpioServo) Position(ctx context.Context, extra map[string]interface
 	if err != nil {
 		return 0, err
 	}
-	return uint32(pulseWidthToAngle(int(s.res))), nil
+	return uint32(pulseWidthToAngle(int(s.res), int(s.maxRotation))), nil
 }
 
 // angleToPulseWidth changes the input angle in degrees
 // into the corresponding pulsewidth value in microsecond
-func angleToPulseWidth(angle int) int {
-	pulseWidth := 500 + (2000 * angle / 180)
+func angleToPulseWidth(angle int, maxRotation int) int {
+	pulseWidth := 500 + (2000 * angle / maxRotation)
 	return pulseWidth
 }
 
 // pulseWidthToAngle changes the pulsewidth value in microsecond
 // to the corresponding angle in degrees
-func pulseWidthToAngle(pulseWidth int) int {
-	angle := 180 * (pulseWidth + 1 - 500) / 2000
+func pulseWidthToAngle(pulseWidth int, maxRotation int) int {
+	angle := maxRotation * (pulseWidth + 1 - 500) / 2000
 	return angle
 }
 

--- a/components/board/pi/impl/servo.go
+++ b/components/board/pi/impl/servo.go
@@ -61,6 +61,12 @@ func init() {
 				if theServo.maxRotation == 0 {
 					theServo.maxRotation = uint32(servoDefaultMaxRotation)
 				}
+				if theServo.maxRotation < theServo.min {
+					return nil, errors.New("maxRotation is less than minimum")
+				}
+				if theServo.maxRotation < theServo.max {
+					return nil, errors.New("maxRotation is less than maximum")
+				}
 
 				theServo.pinname = attr.Pin
 

--- a/components/board/pi/impl/servo.go
+++ b/components/board/pi/impl/servo.go
@@ -24,8 +24,10 @@ import (
 	"go.viam.com/rdk/registry"
 )
 
-var holdTime = 250000000 // 250ms in nanoseconds
-var servoDefaultMaxRotation = 180
+var (
+	holdTime                = 250000000 // 250ms in nanoseconds
+	servoDefaultMaxRotation = 180
+)
 
 // init registers a pi servo based on pigpio.
 func init() {
@@ -167,14 +169,14 @@ func (s *piPigpioServo) Position(ctx context.Context, extra map[string]interface
 
 // angleToPulseWidth changes the input angle in degrees
 // into the corresponding pulsewidth value in microsecond
-func angleToPulseWidth(angle int, maxRotation int) int {
+func angleToPulseWidth(angle, maxRotation int) int {
 	pulseWidth := 500 + (2000 * angle / maxRotation)
 	return pulseWidth
 }
 
 // pulseWidthToAngle changes the pulsewidth value in microsecond
 // to the corresponding angle in degrees
-func pulseWidthToAngle(pulseWidth int, maxRotation int) int {
+func pulseWidthToAngle(pulseWidth, maxRotation int) int {
 	angle := maxRotation * (pulseWidth + 1 - 500) / 2000
 	return angle
 }


### PR DESCRIPTION
180 degrees was hardcoded as the maxAngle for servos in `pulseWidthToAngle` and `angleToPulseWidth`. Updated to be the maxAngle from the servo config instead