### PR TITLE
[RSDK-2019] Hold onto the file descriptors for GPIO pins

### DIFF
--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -164,7 +164,7 @@ type sysfsBoard struct {
 	logger        golog.Logger
 
 	usePeriphGpio bool
-	gpios         map[string]gpioPin // Only used for non-periph.io pins
+	gpios         map[string]*gpioPin // Only used for non-periph.io pins
 
 	cancelCtx               context.Context
 	cancelFunc              func()
@@ -324,7 +324,7 @@ func (b *sysfsBoard) GPIOPinByName(pinName string) (board.GPIOPin, error) {
     if !ok {
         return nil, errors.Errorf("Cannot find GPIO for unknown pin: %s", pinName)
     }
-    return &pin, nil
+    return pin, nil
 }
 
 func (b *sysfsBoard) periphGPIOPinByName(pinName string) (board.GPIOPin, error) {

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -480,7 +480,6 @@ func (b *sysfsBoard) ModelAttributes() board.ModelAttributes {
 }
 
 func (b *sysfsBoard) Close() {
-	fmt.Println("closing the board...")
 	b.mu.Lock()
 	b.cancelFunc()
 	b.mu.Unlock()

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -477,4 +477,9 @@ func (b *sysfsBoard) Close() {
 	b.cancelFunc()
 	b.mu.Unlock()
 	b.activeBackgroundWorkers.Wait()
+	if !b.usePeriphGpio {
+		if err := gpioCloseAll(); err != nil {
+			b.logger.Error(err)
+		}
+	}
 }

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -111,7 +111,7 @@ func RegisterBoard(modelName string, gpioMappings map[int]GPIOBoardMapping, useP
 				// We currently have two implementations of GPIO pins on these boards: one using
 				// libraries from periph.io and one using an ioctl approach. If we're using the
 				// latter, we need to initialize it here.
-				b.gpios := gpioInitialize(gpioMappings) // Defined in gpio.go
+				b.gpios = gpioInitialize(gpioMappings) // Defined in gpio.go
 			}
 			return &b, nil
 		}})
@@ -324,7 +324,7 @@ func (b *sysfsBoard) GPIOPinByName(pinName string) (board.GPIOPin, error) {
     if !ok {
         return nil, errors.Errorf("Cannot find GPIO for unknown pin: %s", pinName)
     }
-    return pin, nil
+    return &pin, nil
 }
 
 func (b *sysfsBoard) periphGPIOPinByName(pinName string) (board.GPIOPin, error) {

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -155,13 +155,13 @@ func init() {
 
 type sysfsBoard struct {
 	generic.Unimplemented
-	mu            sync.RWMutex
-	gpioMappings  map[int]GPIOBoardMapping
-	spis          map[string]*spiBus
-	analogs       map[string]board.AnalogReader
-	pwms          map[string]pwmSetting
-	i2cs          map[string]board.I2C
-	logger        golog.Logger
+	mu           sync.RWMutex
+	gpioMappings map[int]GPIOBoardMapping
+	spis         map[string]*spiBus
+	analogs      map[string]board.AnalogReader
+	pwms         map[string]pwmSetting
+	i2cs         map[string]board.I2C
+	logger       golog.Logger
 
 	usePeriphGpio bool
 	gpios         map[string]*gpioPin // Only used for non-periph.io pins
@@ -321,10 +321,10 @@ func (b *sysfsBoard) GPIOPinByName(pinName string) (board.GPIOPin, error) {
 	}
 	// Otherwise, the pins are stored in b.gpios.
 	pin, ok := b.gpios[pinName]
-    if !ok {
-        return nil, errors.Errorf("Cannot find GPIO for unknown pin: %s", pinName)
-    }
-    return pin, nil
+	if !ok {
+		return nil, errors.Errorf("Cannot find GPIO for unknown pin: %s", pinName)
+	}
+	return pin, nil
 }
 
 func (b *sysfsBoard) periphGPIOPinByName(pinName string) (board.GPIOPin, error) {

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -64,7 +64,7 @@ func (pin *gpioPin) Set(ctx context.Context, isHigh bool, extra map[string]inter
 		value = 0
 	}
 
-	return pin.line.SetValues([]byte{value})
+	return pin.line.SetValue(value)
 }
 
 // This helps implement the board.GPIOPin interface for gpioPin.

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/mkch/gpio"
 	"github.com/pkg/errors"
+	"go.viam.com/utils"
 )
 
 type gpioPin struct {
@@ -34,7 +35,7 @@ func (pin *gpioPin) openGpioFd() error {
 	if err != nil {
 		return err
 	}
-	defer func() { err = chip.Close()
+	defer utils.UncheckedErrorFunc(chip.Close)
 
 	// The 0 just means the default value for this pin is off. We'll set it to the intended value
 	// in Set(), below.

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -26,29 +26,22 @@ type gpioPin struct {
 // This is a private helper function that should only be called when the mutex is locked. It sets
 // pin.line to a valid struct or returns an error.
 func (pin *gpioPin) openGpioFd() error {
-	fmt.Printf("starting openGpioFd, pin.line is ->%v<-\n", pin.line)
 	if pin.line != nil {
-		fmt.Println("line is already opened! Skip the rest")
 		return nil // If the pin is already opened, don't re-open it.
 	}
 
-	fmt.Println("opening chip...")
 	chip, err := gpio.OpenChip(pin.devicePath)
 	if err != nil {
 		return err
 	}
-	fmt.Println("chip opened!")
 	defer func() { err = chip.Close()
-fmt.Println("deferred chip closing")}()
 
 	// The 0 just means the default value for this pin is off. We'll set it to the intended value
 	// in Set(), below.
-	fmt.Println("opening line...")
 	line, err := chip.OpenLine(pin.offset, 0, gpio.Output, "viam-gpio")
 	if err != nil {
 		return err
 	}
-	fmt.Printf("line opened, it is now ->%v<-!\n", line)
 	pin.line = line
 	return nil
 }
@@ -58,11 +51,9 @@ func (pin *gpioPin) Set(ctx context.Context, isHigh bool, extra map[string]inter
 	pin.mu.Lock()
 	defer pin.mu.Unlock()
 
-	fmt.Println("About to try to open FD...")
 	if err := pin.openGpioFd(); err != nil {
 		return err
 	}
-	fmt.Println("successfully opened FD!")
 
 	var value byte
 	if isHigh {
@@ -71,7 +62,6 @@ func (pin *gpioPin) Set(ctx context.Context, isHigh bool, extra map[string]inter
 		value = 0
 	}
 
-	fmt.Println("About to call line.SetValue...")
 	return pin.line.SetValue(value)
 }
 
@@ -132,7 +122,6 @@ func (pin *gpioPin) Close() error {
 func gpioInitialize(gpioMappings map[int]GPIOBoardMapping) map[string]*gpioPin {
 	pins := make(map[string]*gpioPin)
 	for pin, mapping := range gpioMappings {
-		fmt.Printf("creating pin %d...\n", pin)
 		pins[fmt.Sprintf("%d", pin)] = &gpioPin{
 			devicePath: mapping.GPIOChipDev,
 			offset:     uint32(mapping.GPIO),


### PR DESCRIPTION
This is a follow-up to https://github.com/viamrobotics/rdk/pull/1810. Thanks to @thegreatco for noticing the issue! 

We've been acquiring file descriptors for each GPIO pin, setting their direction to input/output, and if output, setting their value, and then closing the files again. It turns out that when you close the file, the value of the output is undetermined: the pin I tried last time (pin 40) keeps its most recent value, but pins like 37 and 32 float instead.

So, this PR holds the file descriptors open for the remainder of the program (once they're opened for the first time). That way, the GPIO pins keep the same output all the way until the next time you change one of them.

The diff here is a little messed up: I took a sort of pre-amble from both `Set()` and `Get()` and refactored it into `openGpioFd()`, which just creates the `gpio.Line` object. The rest of `Set()` and `Get()` just interact with that object to do what they're supposed to. I suggest ignoring the diff and just reading through the final versions of `openGpioFd`, `Set` and `Get`.