### PR TITLE
RSDK-2034 - Do not Fatal log module serve error

### DIFF
--- a/module/module.go
+++ b/module/module.go
@@ -167,7 +167,7 @@ func (m *Module) Start(ctx context.Context) error {
 		defer utils.UncheckedErrorFunc(func() error { return os.Remove(m.addr) })
 		m.logger.Infof("server listening at %v", lis.Addr())
 		if err := m.server.Serve(lis); err != nil {
-			m.logger.Fatalf("failed to serve: %v", err)
+			m.logger.Errorf("failed to serve: %v", err)
 		}
 	})
 	return nil


### PR DESCRIPTION
This will allow the mod server to close down and clean up a bit more gracefully. This will end the process naturally, so we will not restart it, unlike with Fatal.