### PR TITLE
Update package.json to use latest version

### DIFF
--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "0.1.28",
+  "version": "0.1.31",
   "license": "Apache-2.0",
   "files": [
     "src/components/**/*.vue",


### PR DESCRIPTION
In my last PR I merged I accidentally had a lower version that what I published in my testing. This should fix the build failure seen: `npm ERR! 403 403 Forbidden - PUT https://registry.npmjs.org/@viamrobotics%2fremote-control - You cannot publish over the previously published versions: 0.1.28.`

Btw: This doesn't mean that every merge requires a version bump. That would be crazy. Its just that the version is accidentally lower than latest version so it errors. If the version is the same as latest, no error exists.