### PR TITLE
[RSDK-1609] Fix module test timeouts

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -241,7 +241,7 @@ func (m *module) dial() error {
 }
 
 func (m *module) checkReady(ctx context.Context, parentAddr string) error {
-	ctxTimeout, cancelFunc := context.WithTimeout(ctx, time.Second*10)
+	ctxTimeout, cancelFunc := context.WithTimeout(ctx, time.Second*30)
 	defer cancelFunc()
 
 	for {
@@ -275,7 +275,7 @@ func (m *module) startProcess(ctx context.Context, parentAddr string, logger gol
 		return errors.WithMessage(err, "module startup failed")
 	}
 
-	ctxTimeout, cancel := context.WithTimeout(ctx, time.Second*10)
+	ctxTimeout, cancel := context.WithTimeout(ctx, time.Second*30)
 	defer cancel()
 	for {
 		select {

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -2,6 +2,7 @@ package modmanager
 
 import (
 	"context"
+	"os/exec"
 	"testing"
 
 	"github.com/edaniels/golog"
@@ -22,6 +23,13 @@ func TestModManagerFunctions(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	modExe := utils.ResolveFile("examples/customresources/demos/simplemodule/run.sh")
 
+	// Precompile module to avoid timeout issues when building takes too long.
+	builder := exec.Command("go", "build", ".")
+	builder.Dir = utils.ResolveFile("examples/customresources/demos/simplemodule")
+	out, err := builder.CombinedOutput()
+	test.That(t, string(out), test.ShouldEqual, "")
+	test.That(t, err, test.ShouldBeNil)
+
 	myCounterModel := resource.NewModel("acme", "demo", "mycounter")
 	rNameCounter1 := resource.NameFromSubtype(generic.Subtype, "counter1")
 	cfgCounter1 := config.Component{
@@ -29,7 +37,7 @@ func TestModManagerFunctions(t *testing.T) {
 		API:   generic.Subtype,
 		Model: myCounterModel,
 	}
-	_, err := cfgCounter1.Validate("test")
+	_, err = cfgCounter1.Validate("test")
 	test.That(t, err, test.ShouldBeNil)
 
 	myRobot := &inject.Robot{}


### PR DESCRIPTION
This addresses two tests that are in the top 5 by failure count. Same issue with each is that they rely on building the module at module startup time so it's always "fresh" but... under load, that build process can make the effective startup time exceed the timeouts. So added a few lines to pre-build the module (and server) binaries within the tests, and also increased a couple of timeouts.