### PR TITLE
update gpio_unsupported.go to match gpio.go

### DIFF
--- a/components/board/genericlinux/gpio_unsupported.go
+++ b/components/board/genericlinux/gpio_unsupported.go
@@ -2,9 +2,36 @@
 
 package genericlinux
 
+import (
+	"context"
+	"math"
+
+	"github.com/pkg/errors"
+)
+
 type gpioPin struct {
 	// This struct is implemented in the Linux version. We have a dummy struct here just to get
 	// things to compile on non-Linux environments.
+}
+
+// We need gpioPin to implement the board.GPIOPin interface.
+func (p *gpioPin) Set(ctx context.Context, high bool, extra map[string]interface{}) error {
+	return errors.New("GPIO pins using ioctl are not supported on non-Linux boards")
+}
+func (p *gpioPin) Get(ctx context.Context, extra map[string]interface{}) (bool, error) {
+	return false, errors.New("GPIO pins using ioctl are not supported on non-Linux boards")
+}
+func (p *gpioPin) PWM(ctx context.Context, extra map[string]interface{}) (float64, error) {
+	return math.NaN, errors.New("GPIO pins using ioctl are not supported on non-Linux boards")
+}
+func (p *gpioPin) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[string]interface{}) error {
+	return errors.New("GPIO pins using ioctl are not supported on non-Linux boards")
+}
+func (p *gpioPin) PWMFreq(ctx context.Context, extra map[string]interface{}) (uint, error) {
+	return 0, errors.New("GPIO pins using ioctl are not supported on non-Linux boards")
+}
+func (p *gpioPin) SetPWMFreq(ctx context.Context, freqHz uint, extra map[string]interface{}) error {
+	return errors.New("GPIO pins using ioctl are not supported on non-Linux boards")
 }
 
 func gpioInitialize(gpioMappings map[int]GPIOBoardMapping) map[string]*gpioPin {

--- a/components/board/genericlinux/gpio_unsupported.go
+++ b/components/board/genericlinux/gpio_unsupported.go
@@ -2,12 +2,6 @@
 
 package genericlinux
 
-import (
-	"github.com/pkg/errors"
-
-	"go.viam.com/rdk/components/board"
-)
-
 type gpioPin struct {
 	// This struct is implemented in the Linux version. We have a dummy struct here just to get
 	// things to compile on non-Linux environments.

--- a/components/board/genericlinux/gpio_unsupported.go
+++ b/components/board/genericlinux/gpio_unsupported.go
@@ -8,12 +8,14 @@ import (
 	"go.viam.com/rdk/components/board"
 )
 
-func gpioInitialize(gpioMappings map[int]GPIOBoardMapping) {
-	// Don't even log anything here: if someone is running in a non-Linux environment, things
-	// should work fine as long as they don't try using ioctl, and the log would be an unnecessary
-	// warning.
+type gpioPin struct {
+	// This struct is implemented in the Linux version. We have a dummy struct here just to get
+	// things to compile on non-Linux environments.
 }
 
-func gpioGetPin(pinName string) (board.GPIOPin, error) {
-	return nil, errors.New("ioctl GPIO pins are not supported in a non-Linux environment")
+func gpioInitialize(gpioMappings map[int]GPIOBoardMapping) map[string]*gpioPin {
+	// Don't even log anything here: if someone is running in a non-Linux environment, things
+	// should work fine as long as they don't try using these pins, and the log would be an
+	// unnecessary warning.
+	return map[string]*gpioPin{}
 }

--- a/components/board/genericlinux/gpio_unsupported.go
+++ b/components/board/genericlinux/gpio_unsupported.go
@@ -22,7 +22,7 @@ func (p *gpioPin) Get(ctx context.Context, extra map[string]interface{}) (bool, 
 	return false, errors.New("GPIO pins using ioctl are not supported on non-Linux boards")
 }
 func (p *gpioPin) PWM(ctx context.Context, extra map[string]interface{}) (float64, error) {
-	return math.NaN, errors.New("GPIO pins using ioctl are not supported on non-Linux boards")
+	return math.NaN(), errors.New("GPIO pins using ioctl are not supported on non-Linux boards")
 }
 func (p *gpioPin) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[string]interface{}) error {
 	return errors.New("GPIO pins using ioctl are not supported on non-Linux boards")
@@ -31,6 +31,9 @@ func (p *gpioPin) PWMFreq(ctx context.Context, extra map[string]interface{}) (ui
 	return 0, errors.New("GPIO pins using ioctl are not supported on non-Linux boards")
 }
 func (p *gpioPin) SetPWMFreq(ctx context.Context, freqHz uint, extra map[string]interface{}) error {
+	return errors.New("GPIO pins using ioctl are not supported on non-Linux boards")
+}
+func (p *gpioPin) Close() error {
 	return errors.New("GPIO pins using ioctl are not supported on non-Linux boards")
 }
 


### PR DESCRIPTION
Thanks to @randhid for noticing this problem! In https://github.com/viamrobotics/rdk/pull/1896, I updated the function signature of `gpioInitialize` in the Linux-specific file, but forgot to update the non-Linux version to match.

This PR:
- creates a dummy `gpioPin` struct that contains nothing
- updates `gpioInitialize` to return a map of `gpioPin`s to match the function signature of the Linux version
- removes `gpioGetPin`, which was removed from the Linux version, too

I'm unable to test this myself, because I don't have a non-Linux environment. Do I need to implement the GPIOPin interface on the new struct for it to typecheck correctly? Hopefully Rand can tell me.