### PR TITLE
RSDK-1909 - return 0,0 if position is called before getting any reading of position

### DIFF
--- a/components/movementsensor/gpsnmea/nmeaParser.go
+++ b/components/movementsensor/gpsnmea/nmeaParser.go
@@ -37,7 +37,7 @@ func (g *gpsData) parseAndUpdate(line string) error {
 	// add parsing to filter out corrupted data
 	ind := strings.Index(line, "$G")
 	if ind == -1 {
-		line = ""
+		return nil
 	} else {
 		line = line[ind:]
 	}

--- a/components/movementsensor/gpsnmea/nmeaParser.go
+++ b/components/movementsensor/gpsnmea/nmeaParser.go
@@ -37,7 +37,7 @@ func (g *gpsData) parseAndUpdate(line string) error {
 	// add parsing to filter out corrupted data
 	ind := strings.Index(line, "$G")
 	if ind == -1 {
-		return nil
+		line = ""
 	} else {
 		line = line[ind:]
 	}

--- a/components/movementsensor/gpsnmea/pmtkI2C.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C.go
@@ -185,7 +185,7 @@ func (g *PmtkI2CNMEAMovementSensor) Position(ctx context.Context, extra map[stri
 	g.mu.RLock()
 	defer g.mu.RUnlock()
 	if g.data.location == nil {
-		return geo.NewPoint(0, 0), 0, errors.New("No valid reading of location has occured yet, using default value of lat:0, long: 0")
+		return geo.NewPoint(0, 0), 0, errNilLocation
 	}
 	return g.data.location, g.data.alt, g.err.Get()
 }

--- a/components/movementsensor/gpsnmea/pmtkI2C.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C.go
@@ -184,6 +184,9 @@ func (g *PmtkI2CNMEAMovementSensor) GetBusAddr() (board.I2C, byte) {
 func (g *PmtkI2CNMEAMovementSensor) Position(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
+	if g.data.location == nil {
+		return geo.NewPoint(0, 0), 0, errors.New("No valid reading of location has occured yet, using default value of lat:0, long: 0")
+	}
 	return g.data.location, g.data.alt, g.err.Get()
 }
 

--- a/components/movementsensor/gpsrtk/gpsrtk.go
+++ b/components/movementsensor/gpsrtk/gpsrtk.go
@@ -586,7 +586,7 @@ func (g *RTKMovementSensor) Position(ctx context.Context, extra map[string]inter
 	lastError := g.err.Get()
 	if lastError != nil {
 		defer g.mu.Unlock()
-		return &geo.Point{}, 0, lastError
+		return geo.NewPoint(0, 0), 0, lastError
 	}
 	g.mu.Unlock()
 


### PR DESCRIPTION
How to reproduce the bug:
- add a `time.sleep(20 * time.Second)` before starting readings in `Start()` IN `pmtkI2C.go`
- Call `getPosition()` from a script before the readings start

Bug Fix:
- If no position has been read during `Position()`, return (0,0) for position, 0 for altitude and an error

Separate from the bug described in the ticket we found that the ublox chip has pullup resistors, which cause the readings on an I2C to be corrupted. This was not causing the panic described in the ticket but was discovered while investigating the bug - what should be done with this information? Docs ticket?