### PR TITLE
RSDK-2074 - Add guards around unix socket address length

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -261,6 +261,9 @@ func (m *module) checkReady(ctx context.Context, parentAddr string) error {
 
 func (m *module) startProcess(ctx context.Context, parentAddr string, logger golog.Logger) error {
 	m.addr = filepath.ToSlash(filepath.Join(filepath.Dir(parentAddr), m.name+".sock"))
+	if len(m.addr) > modlib.MaxSocketAddressLength {
+		return errors.Errorf("module socket path exceeds OS limit of %d characters: %s", modlib.MaxSocketAddressLength, m.addr)
+	}
 
 	pcfg := pexec.ProcessConfig{
 		ID:   m.name,

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -261,10 +261,9 @@ func (m *module) checkReady(ctx context.Context, parentAddr string) error {
 
 func (m *module) startProcess(ctx context.Context, parentAddr string, logger golog.Logger) error {
 	m.addr = filepath.ToSlash(filepath.Join(filepath.Dir(parentAddr), m.name+".sock"))
-	if len(m.addr) > modlib.MaxSocketAddressLength {
-		return errors.Errorf("module socket path exceeds OS limit of %d characters: %s", modlib.MaxSocketAddressLength, m.addr)
+	if err := modlib.CheckSocketAddressLength(m.addr); err != nil {
+		return err
 	}
-
 	pcfg := pexec.ProcessConfig{
 		ID:   m.name,
 		Name: m.exe,

--- a/module/module.go
+++ b/module/module.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"runtime"
 	"sync"
 	"time"
 
@@ -30,6 +31,15 @@ import (
 	"go.viam.com/rdk/robot/client"
 	"go.viam.com/rdk/subtype"
 )
+
+// MaxSocketAddressLength is the length (-1 for null terminator) of the .sun_path field as used in kernel bind()/connect() syscalls.
+var MaxSocketAddressLength = 103
+
+func init() {
+	if runtime.GOOS == "linux" {
+		MaxSocketAddressLength = 107
+	}
+}
 
 // HandlerMap is the format for api->model pairs that the module will service.
 // Ex: mymap["rdk:component:motor"] = ["acme:marine:thruster", "acme:marine:outboard"].

--- a/module/module.go
+++ b/module/module.go
@@ -32,13 +32,17 @@ import (
 	"go.viam.com/rdk/subtype"
 )
 
-// MaxSocketAddressLength is the length (-1 for null terminator) of the .sun_path field as used in kernel bind()/connect() syscalls.
-var MaxSocketAddressLength = 103
-
-func init() {
+// CheckSocketAddressLength returns an error if the socket path is too long for the OS.
+func CheckSocketAddressLength(addr string) error {
+	// maxSocketAddressLength is the length (-1 for null terminator) of the .sun_path field as used in kernel bind()/connect() syscalls.
+	maxSocketAddressLength := 103
 	if runtime.GOOS == "linux" {
-		MaxSocketAddressLength = 107
+		maxSocketAddressLength = 107
 	}
+	if len(addr) > maxSocketAddressLength {
+		return errors.Errorf("module socket path exceeds OS limit of %d characters: %s", maxSocketAddressLength, addr)
+	}
+	return nil
 }
 
 // HandlerMap is the format for api->model pairs that the module will service.

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -360,8 +360,8 @@ func (svc *webService) StartModule(ctx context.Context) error {
 			// agree on using the same drive.
 			addr = addr[2:]
 		}
-		if len(addr) > module.MaxSocketAddressLength {
-			return errors.Errorf("module socket path exceeds OS limit of %d characters: %s", module.MaxSocketAddressLength, addr)
+		if err := module.CheckSocketAddressLength(addr); err != nil {
+			return err
 		}
 		svc.modAddr = addr
 		lis, err = net.Listen("unix", addr)

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -360,6 +360,9 @@ func (svc *webService) StartModule(ctx context.Context) error {
 			// agree on using the same drive.
 			addr = addr[2:]
 		}
+		if len(addr) > module.MaxSocketAddressLength {
+			return errors.Errorf("module socket path exceeds OS limit of %d characters: %s", module.MaxSocketAddressLength, addr)
+		}
 		svc.modAddr = addr
 		lis, err = net.Listen("unix", addr)
 		if err != nil {


### PR DESCRIPTION
Down at the syscall level, there's a field in the socket address structure called .sun_path which has a max length of 104 characters on MacOS and 108 on Linux (-1 for null terminator.) testing.TempDir() on Mac gets relatively long paths that can exceed this limit. It's also possible a really long, user-configured module name (used in the socket path), combined with Mac's long tempdirs could hit this too.

This PR adds guards around the socket calls, to catch this early and return more readable errors. Previously, the error that bubbled up with just "bind: invalid arugment."

I looked into working around this using chdir(), as the use of relative paths would allow it to work regardless of the true path length, and it looked like it was gonna work great but... I hit a bug in GRPC that prevents the use of relative paths with unix sockets. I filed this: https://github.com/grpc/grpc-go/issues/6057

Until then, this is likely the best workaround/guard for the issue.

FYI, unused work with chdir workaround is in: https://github.com/Otterverse/rdk/tree/socket-tmpdir-chdir