### PR TITLE
Fix out-of-range error in connecting to microphone

### DIFF
--- a/components/audioinput/microphone/microphone.go
+++ b/components/audioinput/microphone/microphone.go
@@ -79,33 +79,35 @@ func newMicrophoneSource(attrs *Attrs, logger golog.Logger) (audioinput.AudioInp
 	}
 	all := gostream.QueryAudioDevices()
 
-	for i, info := range all {
+	for _, info := range all {
 		logger.Debugf("%s", info.ID)
 		logger.Debugf("\t labels: %v", info.Labels)
-		if pattern != nil && !pattern.MatchString(info.Labels[i]) {
-			if debug {
-				logger.Debug("\t skipping because of pattern")
-			}
-			continue
-		}
-		for _, p := range info.Properties {
-			logger.Debugf("\t %+v", p.Audio)
-			if p.Audio.ChannelCount == 0 {
+		for _, label := range info.Labels {
+			if pattern != nil && !pattern.MatchString(label) {
 				if debug {
-					logger.Debug("\t skipping because audio channels are empty")
+					logger.Debug("\t skipping because of pattern")
 				}
 				continue
 			}
-			s, err := tryMicrophoneOpen(info.Labels[i], gostream.DefaultConstraints, logger)
-			if err == nil {
-				if debug {
-					logger.Debug("\t USING")
+			for _, p := range info.Properties {
+				logger.Debugf("\t %+v", p.Audio)
+				if p.Audio.ChannelCount == 0 {
+					if debug {
+						logger.Debug("\t skipping because audio channels are empty")
+					}
+					continue
 				}
-				return s, nil
-			}
-			if debug {
-				logger.Debugw("cannot open driver with properties", "properties", p,
-					"error", err)
+				s, err := tryMicrophoneOpen(label, gostream.DefaultConstraints, logger)
+				if err == nil {
+					if debug {
+						logger.Debug("\t USING")
+					}
+					return s, nil
+				}
+				if debug {
+					logger.Debugw("cannot open driver with properties", "properties", p,
+						"error", err)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Accessing microphone labels was not using the correct index, fixed to loop over all labels. 