### PR TITLE
RSDK-1896 - add timeouts and re-tries for flaky rtsp server tests

### DIFF
--- a/.artifact/tree.json
+++ b/.artifact/tree.json
@@ -2915,8 +2915,8 @@
           "size": 1570024
         },
         "rtsp-simple-server.yml": {
-          "hash": "c4c85f758f48bb6f54fd5735f4003bc7",
-          "size": 14348
+          "hash": "fdc3f04b6e7577019d4085c85b9cf534",
+          "size": 14349
         }
       },
       "transformpipeline": {

--- a/components/camera/rtsp/rtsp.go
+++ b/components/camera/rtsp/rtsp.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aler9/gortsplib/v2"
 	"github.com/aler9/gortsplib/v2/pkg/base"
 	"github.com/aler9/gortsplib/v2/pkg/liberrors"
-	"github.com/aler9/gortsplib/v2/pkg/media"
 	"github.com/aler9/gortsplib/v2/pkg/url"
 	"github.com/edaniels/golog"
 	"github.com/edaniels/gostream"
@@ -143,7 +142,6 @@ func (rc *rtspCamera) clientReconnectBackgroundWorker() {
 
 // reconnectClient reconnects the RTSP client to the streaming server by closing the old one and starting a new one.
 func (rc *rtspCamera) reconnectClient() (err error) {
-	timeout := 10 * time.Second
 	if rc == nil {
 		return errors.New("rtspCamera is nil")
 	}
@@ -164,36 +162,12 @@ func (rc *rtspCamera) reconnectClient() (err error) {
 			}
 		}
 	}()
-	// send Start to server URL and timeout if you can't
-	doneStart := make(chan struct{})
-	go func() {
-		err = rc.client.Start(rc.u.Scheme, rc.u.Host)
-		close(doneStart)
-	}()
-	select {
-	case <-doneStart:
-		// Start returned before timeout
-	case <-time.After(timeout):
-		return errors.New("rtsp client Start request timed out")
-	}
+	err = rc.client.Start(rc.u.Scheme, rc.u.Host)
 	if err != nil {
 		return err
 	}
-	// send Describe to server URL and timeout if you can't
 	mjpegFormat, mjpegDecoder := mjpegDecoding()
-	var tracks media.Medias
-	var baseURL *url.URL
-	doneDescribe := make(chan struct{})
-	go func() {
-		tracks, baseURL, _, err = rc.client.Describe(rc.u)
-		close(doneDescribe)
-	}()
-	select {
-	case <-doneDescribe:
-		// Describe returned before timeout
-	case <-time.After(timeout):
-		return errors.New("rtsp client Describe request timed out")
-	}
+	tracks, baseURL, _, err := rc.client.Describe(rc.u)
 	if err != nil {
 		return err
 	}
@@ -201,18 +175,7 @@ func (rc *rtspCamera) reconnectClient() (err error) {
 	if track == nil {
 		return errors.New("MJPEG track not found")
 	}
-	// send Setup to server URL and timeout if you can't
-	doneSetup := make(chan struct{})
-	go func() {
-		_, err = rc.client.Setup(track, baseURL, 0, 0)
-		close(doneSetup)
-	}()
-	select {
-	case <-doneSetup:
-		// Setup returned before timeout
-	case <-time.After(timeout):
-		return errors.New("rtsp client Setup request timed out")
-	}
+	_, err = rc.client.Setup(track, baseURL, 0, 0)
 	if err != nil {
 		return err
 	}

--- a/components/camera/rtsp/rtsp.go
+++ b/components/camera/rtsp/rtsp.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aler9/gortsplib/v2"
 	"github.com/aler9/gortsplib/v2/pkg/base"
 	"github.com/aler9/gortsplib/v2/pkg/liberrors"
+	"github.com/aler9/gortsplib/v2/pkg/media"
 	"github.com/aler9/gortsplib/v2/pkg/url"
 	"github.com/edaniels/golog"
 	"github.com/edaniels/gostream"
@@ -168,7 +169,10 @@ func (rc *rtspCamera) reconnectClient() (err error) {
 	}
 	mjpegFormat, mjpegDecoder := mjpegDecoding()
 
-	tracks, baseURL, _, err := rc.client.Describe(rc.u)
+	var tracks media.Medias
+	var baseURL *url.URL
+	timer := time.NewTimer(time.Duration(10 * time.Second))
+	tracks, baseURL, _, err = rc.client.Describe(rc.u)
 	if err != nil {
 		return err
 	}

--- a/components/camera/rtsp/rtsp_test.go
+++ b/components/camera/rtsp/rtsp_test.go
@@ -57,7 +57,7 @@ func TestRTSPCamera(t *testing.T) {
 		for err != nil && (strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "400")) {
 			rtspCam, err = NewRTSPCamera(context.Background(), rtspConf, logger)
 		}
-		if err != nil && (strings.Contains(err.Error(), "timed out")) { // server is messed up, build it again
+		if err != nil && (strings.Contains(err.Error(), "timeout")) { // server is messed up, build it again
 			cancel()
 			serverClose()
 			continue

--- a/components/camera/rtsp/rtsp_test.go
+++ b/components/camera/rtsp/rtsp_test.go
@@ -65,7 +65,7 @@ func TestRTSPCamera(t *testing.T) {
 			cancel()
 			serverClose()
 			if tries >= 5 {
-				t.Error("RTSP server failed to build 5 times in a row")
+				t.Errorf("RTSP server failed to build 5 times in a row: %v", err)
 			}
 			tries++
 			continue

--- a/components/camera/rtsp/rtsp_test.go
+++ b/components/camera/rtsp/rtsp_test.go
@@ -49,8 +49,8 @@ func TestRTSPCamera(t *testing.T) {
 	rtspConf := &Attrs{Address: outputURL}
 	var rtspCam camera.Camera
 	var err error
-	timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-	defer cancel()
+	timeoutCtx, timeoutCancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer timeoutCancel()
 	// Just keep trying until you connect, but fail after 5 tries
 	tries := 1
 	for {


### PR DESCRIPTION
Flaky tests were caused by RTSP requests to the server never getting returned.

- Added a timeout context to the RTSP client.
- Changed the test to rebuild the RTSP server in case it was in a bad state that was causing the requests to hang.