### PR TITLE
RSDK-2107: Handle op cancellation in fake and basic gpio motors (don't merge)

### DIFF
--- a/components/motor/dimensionengineering/sabertooth.go
+++ b/components/motor/dimensionengineering/sabertooth.go
@@ -411,10 +411,8 @@ func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[s
 		return nil
 	}
 
-	if m.opMgr.NewTimedWaitOp(ctx, waitDur) {
-		return m.Stop(ctx, extra)
-	}
-	return nil
+	m.opMgr.NewTimedWaitOp(ctx, waitDur)
+	return m.Stop(ctx, extra)
 }
 
 // GoTo instructs the motor to go to a specific position (provided in revolutions from home/zero),

--- a/components/motor/fake/motor.go
+++ b/components/motor/fake/motor.go
@@ -267,16 +267,16 @@ func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[s
 		return nil
 	}
 
-	if m.opMgr.NewTimedWaitOp(ctx, waitDur) {
-		err = m.Stop(ctx, nil)
-		if err != nil {
-			return err
-		}
-
-		if m.Encoder != nil {
-			return m.Encoder.SetPosition(ctx, int64(finalPos*float64(m.TicksPerRotation)))
-		}
+	m.opMgr.NewTimedWaitOp(ctx, waitDur)
+	err = m.Stop(ctx, nil)
+	if err != nil {
+		return err
 	}
+
+	if m.Encoder != nil {
+		return m.Encoder.SetPosition(ctx, int64(finalPos*float64(m.TicksPerRotation)))
+	}
+
 	return nil
 }
 
@@ -307,12 +307,13 @@ func (m *Motor) GoTo(ctx context.Context, rpm, pos float64, extra map[string]int
 		return nil
 	}
 
-	if m.opMgr.NewTimedWaitOp(ctx, waitDur) {
-		err = m.Stop(ctx, nil)
-		if err != nil {
-			return err
-		}
+	m.opMgr.NewTimedWaitOp(ctx, waitDur)
+	err = m.Stop(ctx, nil)
+	if err != nil {
+		return err
+	}
 
+	if m.Encoder != nil {
 		return m.Encoder.SetPosition(ctx, int64(pos*float64(m.TicksPerRotation)))
 	}
 

--- a/components/motor/gpio/basic.go
+++ b/components/motor/gpio/basic.go
@@ -272,10 +272,8 @@ func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[s
 		return nil
 	}
 
-	if m.opMgr.NewTimedWaitOp(ctx, waitDur) {
-		return m.Stop(ctx, extra)
-	}
-	return nil
+	m.opMgr.NewTimedWaitOp(ctx, waitDur)
+	return m.Stop(ctx, extra)
 }
 
 // IsPowered returns if the motor is currently on or off.

--- a/components/motor/gpio/basic.go
+++ b/components/motor/gpio/basic.go
@@ -262,9 +262,10 @@ func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[s
 		return motor.NewZeroRPMError()
 	}
 
+	m.opMgr.CancelRunning(ctx)
+
 	powerPct, waitDur := goForMath(m.maxRPM, rpm, revolutions)
 
-	m.opMgr.CancelRunning(ctx)
 	err := m.SetPower(ctx, powerPct, extra)
 	if err != nil {
 		return errors.Wrapf(err, "error in GoFor from motor (%s)", m.motorName)

--- a/components/motor/gpio/basic.go
+++ b/components/motor/gpio/basic.go
@@ -263,6 +263,8 @@ func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[s
 	}
 
 	powerPct, waitDur := goForMath(m.maxRPM, rpm, revolutions)
+
+	m.opMgr.CancelRunning(ctx)
 	err := m.SetPower(ctx, powerPct, extra)
 	if err != nil {
 		return errors.Wrapf(err, "error in GoFor from motor (%s)", m.motorName)


### PR DESCRIPTION
Currently: 
1. Cancelling the op doesn't `Stop` the basic motor. 
2. A new `GoFor` also doesn't stop the already-running `GoFor` command until **AFTER** it issues the `SetPower` call.

A few changes:
1. `NewTimedWaitOp` - call `Stop` after this returns, regardless of the return value. This ensures that op (context) cancelation results in a Stop call.
2. `GoFor` and `SetPower` now have a `CancelRunning` call at the start. This cancels prior ops BEFORE actuating the motor.

I think the change is correct, but it exposes a pretty critical issue -- It exposes a race condition between `CancelRunning` completing and `NewTimedWaitOp` completing, which leads to a race between `Stop` and `SetPower` I don't want to merge this until we tweak the opmanager api.