### PR TITLE
Add Z16 to webcam constraints.

### DIFF
--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -172,6 +172,7 @@ func makeConstraints(attrs *WebcamAttrs, debug bool, logger golog.Logger) mediad
 					frame.FormatMJPEG,
 					frame.FormatNV12,
 					frame.FormatNV21,
+					frame.FormatZ16,
 				}
 			} else {
 				constraint.FrameFormat = prop.FrameFormatExact(attrs.Format)


### PR DESCRIPTION
### Description

Z16 discovery for camera components.

### Test

- plugin RealSense to linux device
- add camera component `video0`
- view video feed in `Control` tab