### PR TITLE
Rsdk 2077 write gray16 images to viam depth format

### DIFF
--- a/.artifact/tree.json
+++ b/.artifact/tree.json
@@ -3881,8 +3881,8 @@
       "size": 567
     },
     "fakeDM.vnd.viam.dep": {
-      "hash": "81d039d0786ecda6a9d8f1fb40ff9cba",
-      "size": 1624
+      "hash": "4a7dca803d353064c65886fae49c823a",
+      "size": 424
     },
     "go_encoded_image.png": {
       "hash": "ae17174de7ec900b670aa2230ce83db9",

--- a/rimage/depth_map_raw.go
+++ b/rimage/depth_map_raw.go
@@ -301,6 +301,13 @@ func WriteRawDepthMapTo(img image.Image, out io.Writer) (int64, error) {
 // WriteViamDepthMapTo writes depth map or gray16 image to the given writer.
 // Does not write the ViamMagic.
 func WriteViamDepthMapTo(img image.Image, out io.Writer) (int64, error) {
+	if lazy, ok := img.(*LazyEncodedImage); ok {
+		lazy.decode()
+		if lazy.decodeErr != nil {
+			return 0, errors.Errorf("could not decode LazyEncodedImage: %v", lazy.decodeErr)
+		}
+		img = lazy.decodedImage
+	}
 	buf := make([]byte, 8)
 	var totalN int64
 	width := img.Bounds().Dx()

--- a/rimage/depth_map_raw.go
+++ b/rimage/depth_map_raw.go
@@ -298,8 +298,7 @@ func WriteRawDepthMapTo(img image.Image, out io.Writer) (int64, error) {
 	return totalN, nil
 }
 
-// WriteViamDepthMapTo writes depth map or gray16 image to the given writer.
-// Does not write the ViamMagic.
+// WriteViamDepthMapTo writes depth map or gray16 image to the given writer as vnd.viam.dep bytes.
 func WriteViamDepthMapTo(img image.Image, out io.Writer) (int64, error) {
 	if lazy, ok := img.(*LazyEncodedImage); ok {
 		lazy.decode()

--- a/rimage/depth_map_raw.go
+++ b/rimage/depth_map_raw.go
@@ -19,7 +19,7 @@ import (
 const MagicNumIntVersionX = 6363110499870197078
 
 // MagicNumIntViamType is the magic number (as an int) for the custom Viam depth type.
-// magic number for ViamCustomType is uint64([]byte("DEPTHMAP")), Little Endian
+// magic number for ViamCustomType is uint64([]byte("DEPTHMAP")), Little Endian.
 const MagicNumIntViamType = 5782988369567958340
 
 func _readNext(r io.Reader) (int64, error) {
@@ -299,7 +299,7 @@ func WriteRawDepthMapTo(img image.Image, out io.Writer) (int64, error) {
 }
 
 // WriteViamDepthMapTo writes depth map or gray16 image to the given writer.
-// Does not write the ViamMagic
+// Does not write the ViamMagic.
 func WriteViamDepthMapTo(img image.Image, out io.Writer) (int64, error) {
 	buf := make([]byte, 8)
 	var totalN int64

--- a/rimage/depth_map_raw.go
+++ b/rimage/depth_map_raw.go
@@ -91,19 +91,19 @@ func readDepthMapViam(ff io.Reader) (*DepthMap, error) {
 
 	rawWidth, err := _readNext(f)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not read vnd.vima.dep width")
+		return nil, errors.Wrapf(err, "could not read vnd.viam.dep width")
 	}
 	dm.width = int(rawWidth)
 	rawHeight, err := _readNext(f)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not read vnd.vima.dep height")
+		return nil, errors.Wrapf(err, "could not read vnd.viam.dep height")
 	}
 	dm.height = int(rawHeight)
 	// dump the rest of the bytes in a depth slice
 	datSlice := make([]Depth, dm.height*dm.width)
 	err = binary.Read(f, binary.LittleEndian, &datSlice)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not read vnd.vima.dep data slice")
+		return nil, errors.Wrapf(err, "could not read vnd.viam.dep data slice")
 	}
 	dm.data = datSlice
 	return dm, nil
@@ -303,7 +303,7 @@ func WriteViamDepthMapTo(img image.Image, out io.Writer) (int64, error) {
 	if lazy, ok := img.(*LazyEncodedImage); ok {
 		lazy.decode()
 		if lazy.decodeErr != nil {
-			return 0, errors.Errorf("could not decode LazyEncodedImage: %v", lazy.decodeErr)
+			return 0, errors.Errorf("could not decode LazyEncodedImage to a depth image: %v", lazy.decodeErr)
 		}
 		img = lazy.decodedImage
 	}
@@ -353,7 +353,7 @@ func WriteViamDepthMapTo(img image.Image, out io.Writer) (int64, error) {
 			}
 		}
 	default:
-		return totalN, errors.Errorf("cannot convert image type %T to a raw depth format", dm)
+		return totalN, errors.Errorf("cannot convert image type %T to image/vnd.viam.dep depth format", dm)
 	}
 	return totalN, nil
 }

--- a/rimage/depth_map_raw.go
+++ b/rimage/depth_map_raw.go
@@ -193,6 +193,7 @@ func readDepthMapVersionX(rr io.Reader) (*DepthMap, error) {
 	return &dm, nil
 }
 
+// setRawDepthMapValues read out values 8 bytes at a time, converting the 8 bytes into a 2 byte depth value.
 func setRawDepthMapValues(f *bufio.Reader, dm *DepthMap) (*DepthMap, error) {
 	if dm.width <= 0 || dm.width >= 100000 || dm.height <= 0 || dm.height >= 100000 {
 		return nil, errors.Errorf("bad width or height for depth map %v %v", dm.width, dm.height)
@@ -257,6 +258,7 @@ func WriteRawDepthMapToFile(dm image.Image, fn string) (err error) {
 }
 
 // WriteRawDepthMapTo writes this depth map to the given writer.
+// the raw depth map type writes 8 bytes of width, 8 bytes of height, and 8 bytes per pixel.
 func WriteRawDepthMapTo(img image.Image, out io.Writer) (int64, error) {
 	buf := make([]byte, 8)
 	var totalN int64
@@ -299,6 +301,7 @@ func WriteRawDepthMapTo(img image.Image, out io.Writer) (int64, error) {
 }
 
 // WriteViamDepthMapTo writes depth map or gray16 image to the given writer as vnd.viam.dep bytes.
+// the Viam custom depth type writes 8 bytes of "magic number", 8 bytes of width, 8 bytes of height, and 2 bytes per pixel.
 func WriteViamDepthMapTo(img image.Image, out io.Writer) (int64, error) {
 	if lazy, ok := img.(*LazyEncodedImage); ok {
 		lazy.decode()

--- a/rimage/depth_map_test.go
+++ b/rimage/depth_map_test.go
@@ -335,8 +335,8 @@ func TestDepthColorModel(t *testing.T) {
 
 func TestViamDepthMap(t *testing.T) {
 	// create various types of depth representations
-	width := 3
-	height := 5
+	width := 10
+	height := 20
 	dm := NewEmptyDepthMap(width, height)
 	g16 := image.NewGray16(image.Rect(0, 0, width, height))
 	g8 := image.NewGray(image.Rect(0, 0, width, height))
@@ -372,11 +372,14 @@ func TestViamDepthMap(t *testing.T) {
 }
 
 func TestDepthMapEncoding(t *testing.T) {
-	m, err := NewDepthMapFromFile(context.Background(), artifact.MustPath("rimage/fakeDM.vnd.viam.dep"))
-	test.That(t, err, test.ShouldBeNil)
-
-	// Test values at points of DepthMap
-	// This example DepthMap (fakeDM) was made such that Depth(x,y) = x*y
+	width := 20
+	height := 10
+	m := NewEmptyDepthMap(width, height)
+	for x := 0; x < width; x++ {
+		for y := 0; y < height; y++ {
+			m.Set(x, y, Depth(x*y))
+		}
+	}
 	test.That(t, m.Width(), test.ShouldEqual, 20)
 	test.That(t, m.Height(), test.ShouldEqual, 10)
 	testPt1 := m.GetDepth(13, 3)
@@ -386,7 +389,7 @@ func TestDepthMapEncoding(t *testing.T) {
 
 	// Save DepthMap BYTES to a file
 	buf := bytes.Buffer{}
-	err = m.WriteToBuf(&buf)
+	err := m.WriteToBuf(&buf)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, buf.Bytes(), test.ShouldNotBeNil)
 	outDir := testutils.TempDirT(t, "", "rimage")

--- a/rimage/depth_map_test.go
+++ b/rimage/depth_map_test.go
@@ -373,6 +373,7 @@ func TestViamDepthMap(t *testing.T) {
 
 func TestDepthMapEncoding(t *testing.T) {
 	m, err := NewDepthMapFromFile(context.Background(), artifact.MustPath("rimage/fakeDM.vnd.viam.dep"))
+	test.That(t, err, test.ShouldBeNil)
 	test.That(t, m.Width(), test.ShouldEqual, 20)
 	test.That(t, m.Height(), test.ShouldEqual, 10)
 	testPt1 := m.GetDepth(13, 3)

--- a/rimage/depth_map_test.go
+++ b/rimage/depth_map_test.go
@@ -372,14 +372,7 @@ func TestViamDepthMap(t *testing.T) {
 }
 
 func TestDepthMapEncoding(t *testing.T) {
-	width := 20
-	height := 10
-	m := NewEmptyDepthMap(width, height)
-	for x := 0; x < width; x++ {
-		for y := 0; y < height; y++ {
-			m.Set(x, y, Depth(x*y))
-		}
-	}
+	m, err := NewDepthMapFromFile(context.Background(), artifact.MustPath("rimage/fakeDM.vnd.viam.dep"))
 	test.That(t, m.Width(), test.ShouldEqual, 20)
 	test.That(t, m.Height(), test.ShouldEqual, 10)
 	testPt1 := m.GetDepth(13, 3)
@@ -389,7 +382,7 @@ func TestDepthMapEncoding(t *testing.T) {
 
 	// Save DepthMap BYTES to a file
 	buf := bytes.Buffer{}
-	err := m.WriteToBuf(&buf)
+	err = m.WriteToBuf(&buf)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, buf.Bytes(), test.ShouldNotBeNil)
 	outDir := testutils.TempDirT(t, "", "rimage")

--- a/rimage/depth_map_test.go
+++ b/rimage/depth_map_test.go
@@ -333,6 +333,44 @@ func TestDepthColorModel(t *testing.T) {
 	test.That(t, convGray.(color.Gray16).Y, test.ShouldEqual, 6168)
 }
 
+func TestViamDepthMap(t *testing.T) {
+	// create various types of depth representations
+	width := 3
+	height := 5
+	dm := NewEmptyDepthMap(width, height)
+	g16 := image.NewGray16(image.Rect(0, 0, width, height))
+	g8 := image.NewGray(image.Rect(0, 0, width, height))
+	for x := 0; x < width; x++ {
+		for y := 0; y < height; y++ {
+			dm.Set(x, y, Depth(x*y))
+			g16.SetGray16(x, y, color.Gray16{uint16(x * y)})
+			g8.SetGray(x, y, color.Gray{uint8(x * y)})
+		}
+	}
+	// write dm to a viam type buffer
+	buf := &bytes.Buffer{}
+	byt, err := WriteViamDepthMapTo(dm, buf)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, byt, test.ShouldEqual, (3*8 + 2*width*height)) // 3 bytes for header, 2 bytes per pixel
+	// write gray16 to a viam type buffer
+	buf16 := &bytes.Buffer{}
+	byt16, err := WriteViamDepthMapTo(g16, buf16)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, byt16, test.ShouldEqual, (3*8 + 2*width*height)) // 3 bytes for header, 2 bytes per pixel
+	// gray should fail
+	buf8 := &bytes.Buffer{}
+	_, err = WriteViamDepthMapTo(g8, buf8)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "cannot convert image type")
+	// read from a viam type buffers and compare to original
+	dm2, err := ReadDepthMap(buf)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, dm2, test.ShouldResemble, dm)
+	dm3, err := ReadDepthMap(buf16)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, dm3, test.ShouldResemble, dm)
+}
+
 func TestDepthMapEncoding(t *testing.T) {
 	m, err := NewDepthMapFromFile(context.Background(), artifact.MustPath("rimage/fakeDM.vnd.viam.dep"))
 	test.That(t, err, test.ShouldBeNil)

--- a/rimage/depth_map_test.go
+++ b/rimage/depth_map_test.go
@@ -374,6 +374,9 @@ func TestViamDepthMap(t *testing.T) {
 func TestDepthMapEncoding(t *testing.T) {
 	m, err := NewDepthMapFromFile(context.Background(), artifact.MustPath("rimage/fakeDM.vnd.viam.dep"))
 	test.That(t, err, test.ShouldBeNil)
+
+	// Test values at points of DepthMap
+	// This example DepthMap (fakeDM) was made such that Depth(x,y) = x*y
 	test.That(t, m.Width(), test.ShouldEqual, 20)
 	test.That(t, m.Height(), test.ShouldEqual, 10)
 	testPt1 := m.GetDepth(13, 3)

--- a/rimage/image_file.go
+++ b/rimage/image_file.go
@@ -295,7 +295,7 @@ func EncodeImage(ctx context.Context, img image.Image, mimeType string) ([]byte,
 	case ut.MimeTypeRawDepth:
 		buf.Write(DepthMapMagicNumber)
 		// WriteRawDepthMapTo encodes the height and width
-		if _, err := WriteRawDepthMapTo(img.(*DepthMap), &buf); err != nil {
+		if _, err := WriteRawDepthMapTo(img, &buf); err != nil {
 			return nil, err
 		}
 	case ut.MimeTypeRawRGBA:

--- a/rimage/image_file.go
+++ b/rimage/image_file.go
@@ -293,9 +293,7 @@ func EncodeImage(ctx context.Context, img image.Image, mimeType string) ([]byte,
 	bounds := img.Bounds()
 	switch actualOutMIME {
 	case ut.MimeTypeRawDepth:
-		buf.Write(DepthMapMagicNumber)
-		// WriteRawDepthMapTo encodes the height and width
-		if _, err := WriteRawDepthMapTo(img, &buf); err != nil {
+		if _, err := WriteViamDepthMapTo(img, &buf); err != nil {
 			return nil, err
 		}
 	case ut.MimeTypeRawRGBA:

--- a/rimage/image_file.go
+++ b/rimage/image_file.go
@@ -86,8 +86,7 @@ func init() {
 	// image.Decode as long as we have the appropriate header
 	image.RegisterFormat("vnd.viam.dep", string(DepthMapMagicNumber),
 		func(r io.Reader) (image.Image, error) {
-			f := r.(*bufio.Reader)
-			dm, err := ReadDepthMap(f)
+			dm, err := ReadDepthMap(r)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
This will allow an *image.Gray16 to be written to an `image/vnd.viam.dep` as well.
It also speeds up some of the writing to file if you are writing a Viam *DepthMap.

This also changes the form a `vnd.viam.dep` file. Before, each depth value was given 8 bytes of space to put in 2 bytes of depth info. The new way of encoding just gives each pixel the necessary 2 bytes. This also allows dumps of data from the DepthMap slices to be written and read faster. 

Testing with an intel realsense, and it makes correct point clouds.