### PR TITLE
bugfix: have same function signatures in gpio.go and gpio_unsupported.go for Macs

### DIFF
--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -220,8 +220,7 @@ func (pin *gpioPin) Close() error {
 }
 
 func gpioInitialize(cancelCtx context.Context, gpioMappings map[int]GPIOBoardMapping,
-	waitGroup *sync.WaitGroup, logger golog.Logger,
-) map[string]*gpioPin {
+	waitGroup *sync.WaitGroup, logger golog.Logger) map[string]*gpioPin {
 	pins := make(map[string]*gpioPin)
 	for pin, mapping := range gpioMappings {
 		pins[fmt.Sprintf("%d", pin)] = &gpioPin{

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -220,7 +220,8 @@ func (pin *gpioPin) Close() error {
 }
 
 func gpioInitialize(cancelCtx context.Context, gpioMappings map[int]GPIOBoardMapping,
-	waitGroup *sync.WaitGroup, logger golog.Logger) map[string]*gpioPin {
+	waitGroup *sync.WaitGroup, logger golog.Logger,
+) map[string]*gpioPin {
 	pins := make(map[string]*gpioPin)
 	for pin, mapping := range gpioMappings {
 		pins[fmt.Sprintf("%d", pin)] = &gpioPin{

--- a/components/board/genericlinux/gpio_unsupported.go
+++ b/components/board/genericlinux/gpio_unsupported.go
@@ -5,7 +5,9 @@ package genericlinux
 import (
 	"context"
 	"math"
+	"sync"
 
+	"github.com/edaniels/golog"
 	"github.com/pkg/errors"
 )
 

--- a/components/board/genericlinux/gpio_unsupported.go
+++ b/components/board/genericlinux/gpio_unsupported.go
@@ -44,7 +44,8 @@ func (p *gpioPin) Close() error {
 }
 
 func gpioInitialize(cancelCtx context.Context, gpioMappings map[int]GPIOBoardMapping,
-    waitGroup *sync.WaitGroup, logger golog.Logger) map[string]*gpioPin {
+    waitGroup *sync.WaitGroup, logger golog.Logger,
+) map[string]*gpioPin {
 	// Don't even log anything here: if someone is running in a non-Linux environment, things
 	// should work fine as long as they don't try using these pins, and the log would be an
 	// unnecessary warning.

--- a/components/board/genericlinux/gpio_unsupported.go
+++ b/components/board/genericlinux/gpio_unsupported.go
@@ -43,7 +43,8 @@ func (p *gpioPin) Close() error {
 	return errors.New("GPIO pins using ioctl are not supported on non-Linux boards")
 }
 
-func gpioInitialize(gpioMappings map[int]GPIOBoardMapping) map[string]*gpioPin {
+func gpioInitialize(cancelCtx context.Context, gpioMappings map[int]GPIOBoardMapping,
+    waitGroup *sync.WaitGroup, logger golog.Logger) map[string]*gpioPin {
 	// Don't even log anything here: if someone is running in a non-Linux environment, things
 	// should work fine as long as they don't try using these pins, and the log would be an
 	// unnecessary warning.


### PR DESCRIPTION
Sorry about this! The non-Periph genericlinux GPIO pins use Linux-specific functions, so we use build tags to have a separate file that gets substituted in for non-Linux OSes. I changed the function signature on the "real" one, forgot to change the non-Linux one to match, and didn't notice the problem because neither I nor Github's CI has a non-Linux environment to test on. 

Jason, please try this out and let me know if it works!