### PR TITLE
RSDK-2145: Increase the default needs restart poll interval to 5s

### DIFF
--- a/web/server/restart_checker.go
+++ b/web/server/restart_checker.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	defaultNeedsRestartCheckInterval = time.Second * 1
+	defaultNeedsRestartCheckInterval = time.Second * 5
 	minNeedsRestartCheckInterval     = time.Second * 1
 )
 


### PR DESCRIPTION
Not setting it to 10s to match config interval as I think that's too long for restart request.
Also, it's all adjustable from the app side so didn't think too much 