### PR TITLE
RSDK-2077 Make sure custom depth type is big endian encoded

### DIFF
--- a/.artifact/tree.json
+++ b/.artifact/tree.json
@@ -3881,7 +3881,7 @@
       "size": 567
     },
     "fakeDM.vnd.viam.dep": {
-      "hash": "4a7dca803d353064c65886fae49c823a",
+      "hash": "80f3125fe6b7244ea0ca8ab7a27fa866",
       "size": 424
     },
     "go_encoded_image.png": {

--- a/rimage/depth_map_test.go
+++ b/rimage/depth_map_test.go
@@ -374,7 +374,6 @@ func TestViamDepthMap(t *testing.T) {
 func TestDepthMapEncoding(t *testing.T) {
 	m, err := NewDepthMapFromFile(context.Background(), artifact.MustPath("rimage/fakeDM.vnd.viam.dep"))
 	test.That(t, err, test.ShouldBeNil)
-
 	// Test values at points of DepthMap
 	// This example DepthMap (fakeDM) was made such that Depth(x,y) = x*y
 	test.That(t, m.Width(), test.ShouldEqual, 20)
@@ -385,10 +384,6 @@ func TestDepthMapEncoding(t *testing.T) {
 	test.That(t, testPt2, test.ShouldEqual, 60)
 
 	// Save DepthMap BYTES to a file
-	buf := bytes.Buffer{}
-	err = m.WriteToBuf(&buf)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, buf.Bytes(), test.ShouldNotBeNil)
 	outDir := testutils.TempDirT(t, "", "rimage")
 	saveTo := outDir + "/grayboard_bytes.vnd.viam.dep"
 	err = WriteRawDepthMapToFile(m, saveTo)

--- a/rimage/image_file.go
+++ b/rimage/image_file.go
@@ -1,7 +1,6 @@
 package rimage
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/binary"
@@ -94,23 +93,18 @@ func init() {
 		},
 		func(r io.Reader) (image.Config, error) {
 			// Using Gray 16 as underlying color model for depth
-			f := r.(*bufio.Reader)
-			firstBytes, err := _readNext(r)
-			if err != nil || firstBytes != MagicNumIntViamType {
-				return image.Config{}, errors.Wrap(err, "first image bytes do not match expected magic number")
-			}
-			rawWidth, err := _readNext(f)
+			imgBytes := make([]byte, RawDepthHeaderLength)
+			_, err := io.ReadFull(r, imgBytes)
 			if err != nil {
 				return image.Config{}, err
 			}
-			rawHeight, err := _readNext(f)
-			if err != nil {
-				return image.Config{}, err
-			}
+			header := imgBytes[:RawDepthHeaderLength]
+			width := binary.BigEndian.Uint64(header[8:16])
+			height := binary.BigEndian.Uint64(header[16:24])
 			return image.Config{
 				ColorModel: color.Gray16Model,
-				Width:      int(rawWidth),
-				Height:     int(rawHeight),
+				Width:      int(width),
+				Height:     int(height),
 			}, nil
 		},
 	)

--- a/rimage/image_file_test.go
+++ b/rimage/image_file_test.go
@@ -85,6 +85,12 @@ func TestRawRGBAEncodingDecoding(t *testing.T) {
 
 	encodedImgBytes, err := EncodeImage(context.Background(), img, utils.MimeTypeRawRGBA)
 	test.That(t, err, test.ShouldBeNil)
+	reader := bytes.NewReader(encodedImgBytes)
+	conf, header, err := image.DecodeConfig(reader)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, header, test.ShouldEqual, "vnd.viam.rgba")
+	test.That(t, conf.Width, test.ShouldEqual, img.Bounds().Dx())
+	test.That(t, conf.Height, test.ShouldEqual, img.Bounds().Dy())
 
 	decodedImg, err := DecodeImage(context.Background(), encodedImgBytes, utils.MimeTypeRawRGBA)
 	test.That(t, err, test.ShouldBeNil)
@@ -95,4 +101,29 @@ func TestRawRGBAEncodingDecoding(t *testing.T) {
 	test.That(t, imgG, test.ShouldResemble, decodedImgG)
 	test.That(t, imgB, test.ShouldResemble, decodedImgB)
 	test.That(t, imgA, test.ShouldResemble, decodedImgA)
+}
+
+func TestRawDepthEncodingDecoding(t *testing.T) {
+	img := NewEmptyDepthMap(4, 8)
+	for x := 0; x < 4; x++ {
+		for y := 0; y < 8; y++ {
+			img.Set(x, y, Depth(x*y))
+		}
+	}
+	encodedImgBytes, err := EncodeImage(context.Background(), img, utils.MimeTypeRawDepth)
+	test.That(t, err, test.ShouldBeNil)
+	reader := bytes.NewReader(encodedImgBytes)
+	conf, header, err := image.DecodeConfig(reader)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, header, test.ShouldEqual, "vnd.viam.dep")
+	test.That(t, conf.Width, test.ShouldEqual, img.Bounds().Dx())
+	test.That(t, conf.Height, test.ShouldEqual, img.Bounds().Dy())
+
+	decodedImg, err := DecodeImage(context.Background(), encodedImgBytes, utils.MimeTypeRawDepth)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, decodedImg.Bounds(), test.ShouldResemble, img.Bounds())
+	decodedDm, ok := decodedImg.(*DepthMap)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, decodedDm.GetDepth(2, 3), test.ShouldEqual, img.GetDepth(2, 3))
+	test.That(t, decodedDm.GetDepth(1, 0), test.ShouldEqual, img.GetDepth(1, 0))
 }

--- a/rimage/image_file_test.go
+++ b/rimage/image_file_test.go
@@ -86,11 +86,21 @@ func TestRawRGBAEncodingDecoding(t *testing.T) {
 	encodedImgBytes, err := EncodeImage(context.Background(), img, utils.MimeTypeRawRGBA)
 	test.That(t, err, test.ShouldBeNil)
 	reader := bytes.NewReader(encodedImgBytes)
+
 	conf, header, err := image.DecodeConfig(reader)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, header, test.ShouldEqual, "vnd.viam.rgba")
 	test.That(t, conf.Width, test.ShouldEqual, img.Bounds().Dx())
 	test.That(t, conf.Height, test.ShouldEqual, img.Bounds().Dy())
+
+	// decode with image package
+	reader = bytes.NewReader(encodedImgBytes)
+	imgDecoded, header, err := image.Decode(reader)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, header, test.ShouldEqual, "vnd.viam.rgba")
+	test.That(t, imgDecoded.Bounds(), test.ShouldResemble, img.Bounds())
+	test.That(t, imgDecoded.At(3, 6), test.ShouldResemble, img.At(3, 6))
+	test.That(t, imgDecoded.At(1, 3), test.ShouldResemble, img.At(1, 3))
 
 	decodedImg, err := DecodeImage(context.Background(), encodedImgBytes, utils.MimeTypeRawRGBA)
 	test.That(t, err, test.ShouldBeNil)
@@ -113,12 +123,24 @@ func TestRawDepthEncodingDecoding(t *testing.T) {
 	encodedImgBytes, err := EncodeImage(context.Background(), img, utils.MimeTypeRawDepth)
 	test.That(t, err, test.ShouldBeNil)
 	reader := bytes.NewReader(encodedImgBytes)
+
+	// decode Header
 	conf, header, err := image.DecodeConfig(reader)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, header, test.ShouldEqual, "vnd.viam.dep")
 	test.That(t, conf.Width, test.ShouldEqual, img.Bounds().Dx())
 	test.That(t, conf.Height, test.ShouldEqual, img.Bounds().Dy())
 
+	// decode with image package
+	reader = bytes.NewReader(encodedImgBytes)
+	imgDecoded, header, err := image.Decode(reader)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, header, test.ShouldEqual, "vnd.viam.dep")
+	test.That(t, imgDecoded.Bounds(), test.ShouldResemble, img.Bounds())
+	test.That(t, imgDecoded.At(2, 3), test.ShouldResemble, img.At(2, 3))
+	test.That(t, imgDecoded.At(1, 0), test.ShouldResemble, img.At(1, 0))
+
+	// decode with rimage package
 	decodedImg, err := DecodeImage(context.Background(), encodedImgBytes, utils.MimeTypeRawDepth)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, decodedImg.Bounds(), test.ShouldResemble, img.Bounds())


### PR DESCRIPTION
Changes `vnd.viam.dep` to be encoded in a Big Endian way, as that is the network byte order, as used by the C++ server and on the Internet.