### PR TITLE
RSDK-2152 - Fake arms do not use default arm motion planning constraints

### DIFF
--- a/components/arm/fake/fake.go
+++ b/components/arm/fake/fake.go
@@ -150,7 +150,11 @@ func (a *Arm) MoveToPosition(
 	if err != nil {
 		return err
 	}
-	solution, err := motionplan.PlanFrameMotion(ctx, a.logger, pos, a.model, a.model.InputFromProtobuf(joints), nil)
+
+	constraintMap := make(map[string]interface{})
+	constraintMap["motion_profile"] = "linear"
+
+	solution, err := motionplan.PlanFrameMotion(ctx, a.logger, pos, a.model, a.model.InputFromProtobuf(joints), constraintMap)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
TICKET DESCRIPTION:
All arms use a linear constraint when executing `MoveToPosition` calls. The easiest way to do this is to use the `Plan()` function in `arm.go`, which will handle all of this.
The fake arm does not use that function and instead calls `PlanFrameMotion` directly in `fake.go`.

We **do not** substitute with `Plan()`. This is because `Plan()` has the following arguments:
```
Plan(ctx context.Context, r robot.Robot, a Arm, dst spatialmath.Pose, worldState *referenceframe.WorldState)
```
and a `fake` arm does not have access to a `robot`.
Instead, we use the extra parameter to pass in a linear profile constraint.

Putting this first as a draft because:
1. use of `extra` to specify a motion profile constraint will soon be depreciated. Is this is the correct solution?
2. should a unit test be written for this? (easy to do but not sure if needed)


edit: perhaps a different solution is the use of `inject.robot` which would enable us to use `Plan()`.
looking for opinions. LMK