### PR TITLE
[RSDK-1055] update SLAM integration tests

### DIFF
--- a/services/slam/builtin/cartographer_int_test.go
+++ b/services/slam/builtin/cartographer_int_test.go
@@ -222,7 +222,7 @@ func integrationtestHelperCartographer(t *testing.T, mode slam.Mode) {
 		}
 	}
 
-	testCartographerPosition(t, svc, "")
+	testCartographerPosition(t, svc, "") // leaving this empty because cartographer does not interpret the component reference in offline mode
 	testCartographerMap(t, svc)
 
 	// Sleep to ensure cartographer saves at least one map

--- a/services/slam/builtin/cartographer_int_test.go
+++ b/services/slam/builtin/cartographer_int_test.go
@@ -16,9 +16,9 @@ import (
 	"github.com/golang/geo/r3"
 	"go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/services/slam"
-	"go.viam.com/rdk/services/slam/builtin"
 	"go.viam.com/rdk/services/slam/internal/testhelper"
 	"go.viam.com/rdk/spatialmath"
+	slamConfig "go.viam.com/slam/config"
 	"go.viam.com/test"
 	"go.viam.com/utils"
 )
@@ -124,7 +124,7 @@ func integrationtestHelperCartographer(t *testing.T, mode slam.Mode) {
 	deleteProcessedData := false
 	useLiveData := true
 
-	attrCfg := &builtin.AttrConfig{
+	attrCfg := &slamConfig.AttrConfig{
 		Sensors: []string{"cartographer_int_lidar"},
 		ConfigParams: map[string]string{
 			"mode":  reflect.ValueOf(mode).String(),
@@ -203,7 +203,7 @@ func integrationtestHelperCartographer(t *testing.T, mode slam.Mode) {
 	useLiveData = false
 	mapRate = 1
 
-	attrCfg = &builtin.AttrConfig{
+	attrCfg = &slamConfig.AttrConfig{
 		Sensors: []string{},
 		ConfigParams: map[string]string{
 			"mode": reflect.ValueOf(mode).String(),
@@ -243,7 +243,6 @@ func integrationtestHelperCartographer(t *testing.T, mode slam.Mode) {
 		}
 	}
 
-	// if a sensor is added to the attribute config, the sensor should be passed into this test
 	testCartographerPosition(t, svc, "")
 	testCartographerMap(t, svc)
 
@@ -273,7 +272,7 @@ func integrationtestHelperCartographer(t *testing.T, mode slam.Mode) {
 	deleteProcessedData = true
 	useLiveData = true
 
-	attrCfg = &builtin.AttrConfig{
+	attrCfg = &slamConfig.AttrConfig{
 		Sensors: []string{"cartographer_int_lidar"},
 		ConfigParams: map[string]string{
 			"mode": reflect.ValueOf(mode).String(),
@@ -347,7 +346,7 @@ func integrationtestHelperCartographer(t *testing.T, mode slam.Mode) {
 
 	mapRate = 1
 
-	attrCfg = &builtin.AttrConfig{
+	attrCfg = &slamConfig.AttrConfig{
 		Sensors: []string{"cartographer_int_lidar"},
 		ConfigParams: map[string]string{
 			"mode": reflect.ValueOf(mode).String(),

--- a/services/slam/builtin/cartographer_int_test.go
+++ b/services/slam/builtin/cartographer_int_test.go
@@ -46,27 +46,6 @@ func testCartographerMap(t *testing.T, svc slam.Service) {
 
 // Checks the cartographer position within a defined tolerance.
 func testCartographerPosition(t *testing.T, svc slam.Service, sensor string) {
-	expectedPosOld := r3.Vector{X: -0.004, Y: 0.004, Z: 0}
-	tolerancePosOld := 0.04
-	expectedOriOld := &spatialmath.R4AA{Theta: 0, RX: 0, RY: 0, RZ: -1}
-	toleranceOriOld := 0.5
-
-	position2, err := svc.Position(context.Background(), "test", map[string]interface{}{})
-	test.That(t, err, test.ShouldBeNil)
-
-	actualPosOld := position2.Pose().Point()
-	t.Logf("Position point: (%v, %v, %v)", actualPosOld.X, actualPosOld.Y, actualPosOld.Z)
-	test.That(t, actualPosOld.X, test.ShouldBeBetween, expectedPosOld.X-tolerancePosOld, expectedPosOld.X+tolerancePosOld)
-	test.That(t, actualPosOld.Y, test.ShouldBeBetween, expectedPosOld.Y-tolerancePosOld, expectedPosOld.Y+tolerancePosOld)
-	test.That(t, actualPosOld.Z, test.ShouldBeBetween, expectedPosOld.Z-tolerancePosOld, expectedPosOld.Z+tolerancePosOld)
-
-	actualOriOld := position2.Pose().Orientation().AxisAngles()
-	t.Logf("Position orientation: RX: %v, RY: %v, RZ: %v, Theta: %v", actualOriOld.RX, actualOriOld.RY, actualOriOld.RZ, actualOriOld.Theta)
-	test.That(t, actualOriOld.RX, test.ShouldBeBetween, expectedOriOld.RX-toleranceOriOld, expectedOriOld.RX+toleranceOriOld)
-	test.That(t, actualOriOld.RY, test.ShouldBeBetween, expectedOriOld.RY-toleranceOriOld, expectedOriOld.RY+toleranceOriOld)
-	test.That(t, actualOriOld.RZ, test.ShouldBeBetween, expectedOriOld.RZ-toleranceOriOld, expectedOriOld.RZ+toleranceOriOld)
-	test.That(t, actualOriOld.Theta, test.ShouldBeBetween, expectedOriOld.Theta-toleranceOriOld, expectedOriOld.Theta+toleranceOriOld)
-
 	expectedPos := r3.Vector{X: -0.004, Y: 0, Z: -0.004}
 	tolerancePos := 0.04
 	expectedOri := &spatialmath.R4AA{Theta: 0, RX: 0, RY: 1, RZ: 0}

--- a/services/slam/builtin/cartographer_int_test.go
+++ b/services/slam/builtin/cartographer_int_test.go
@@ -45,7 +45,7 @@ func testCartographerMap(t *testing.T, svc slam.Service) {
 }
 
 // Checks the cartographer position within a defined tolerance.
-func testCartographerPosition(t *testing.T, svc slam.Service, sensor string) {
+func testCartographerPosition(t *testing.T, svc slam.Service, expectedComponentRef string) {
 	expectedPos := r3.Vector{X: -0.004, Y: 0, Z: -0.004}
 	tolerancePos := 0.04
 	expectedOri := &spatialmath.R4AA{Theta: 0, RX: 0, RY: 1, RZ: 0}
@@ -53,7 +53,7 @@ func testCartographerPosition(t *testing.T, svc slam.Service, sensor string) {
 
 	position, componentRef, err := svc.GetPosition(context.Background(), "test")
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, componentRef, test.ShouldEqual, sensor)
+	test.That(t, componentRef, test.ShouldEqual, expectedComponentRef)
 
 	actualPos := position.Point()
 	t.Logf("Position point: (%v, %v, %v)", actualPos.X, actualPos.Y, actualPos.Z)

--- a/services/slam/builtin/orbslam_int_test.go
+++ b/services/slam/builtin/orbslam_int_test.go
@@ -17,9 +17,9 @@ import (
 	"github.com/golang/geo/r3"
 	"go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/services/slam"
-	"go.viam.com/rdk/services/slam/builtin"
 	"go.viam.com/rdk/services/slam/internal/testhelper"
 	"go.viam.com/rdk/spatialmath"
+	slamConfig "go.viam.com/slam/config"
 	"go.viam.com/test"
 	"go.viam.com/utils"
 	"go.viam.com/utils/artifact"
@@ -187,7 +187,7 @@ func integrationTestHelperOrbslam(t *testing.T, mode slam.Mode) {
 	deleteProcessedData := false
 	useLiveData := true
 
-	attrCfg := &builtin.AttrConfig{
+	attrCfg := &slamConfig.AttrConfig{
 		Sensors: sensors,
 		ConfigParams: map[string]string{
 			"mode":              reflect.ValueOf(mode).String(),
@@ -293,7 +293,7 @@ func integrationTestHelperOrbslam(t *testing.T, mode slam.Mode) {
 	deleteProcessedData = false
 	useLiveData = false
 
-	attrCfg = &builtin.AttrConfig{
+	attrCfg = &slamConfig.AttrConfig{
 		Sensors: []string{},
 		ConfigParams: map[string]string{
 			"mode":              reflect.ValueOf(mode).String(),
@@ -338,7 +338,6 @@ func integrationTestHelperOrbslam(t *testing.T, mode slam.Mode) {
 		}
 	}
 
-	// offline mode parses the config file to determine component reference in offline mode
 	testOrbslamPosition(t, svc, reflect.ValueOf(mode).String(), "mapping", sensors[0])
 	testOrbslamMap(t, svc)
 
@@ -387,7 +386,7 @@ func integrationTestHelperOrbslam(t *testing.T, mode slam.Mode) {
 	deleteProcessedData = true
 	useLiveData = true
 
-	attrCfg = &builtin.AttrConfig{
+	attrCfg = &slamConfig.AttrConfig{
 		Sensors: sensors,
 		ConfigParams: map[string]string{
 			"mode":              reflect.ValueOf(mode).String(),

--- a/services/slam/builtin/orbslam_int_test.go
+++ b/services/slam/builtin/orbslam_int_test.go
@@ -89,7 +89,7 @@ func testOrbslamMap(t *testing.T, svc slam.Service) {
 }
 
 // Checks the orbslam position within a defined tolerance
-func testOrbslamPosition(t *testing.T, svc slam.Service, mode, actionMode string, sensor string) {
+func testOrbslamPosition(t *testing.T, svc slam.Service, mode, actionMode string, expectedComponentRef string) {
 	var expectedPos r3.Vector
 	expectedOri := &spatialmath.R4AA{}
 	tolerancePos := 0.5
@@ -109,7 +109,7 @@ func testOrbslamPosition(t *testing.T, svc slam.Service, mode, actionMode string
 
 	position, componentRef, err := svc.GetPosition(context.Background(), "test")
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, componentRef, test.ShouldEqual, sensor)
+	test.That(t, componentRef, test.ShouldEqual, expectedComponentRef)
 
 	actualPos := position.Point()
 	t.Logf("Position point: (%v, %v, %v)", actualPos.X, actualPos.Y, actualPos.Z)

--- a/services/slam/builtin/orbslam_int_test.go
+++ b/services/slam/builtin/orbslam_int_test.go
@@ -107,22 +107,6 @@ func testOrbslamPosition(t *testing.T, svc slam.Service, mode, actionMode string
 		expectedOri = &spatialmath.R4AA{Theta: 0.002, RX: 0.602, RY: -0.772, RZ: -0.202}
 	}
 
-	positionOld, err := svc.Position(context.Background(), "test", map[string]interface{}{})
-	test.That(t, err, test.ShouldBeNil)
-
-	actualPosOld := positionOld.Pose().Point()
-	t.Logf("Position point: (%v, %v, %v)", actualPosOld.X, actualPosOld.Y, actualPosOld.Z)
-	test.That(t, actualPosOld.X, test.ShouldBeBetween, expectedPos.X-tolerancePos, expectedPos.X+tolerancePos)
-	test.That(t, actualPosOld.Y, test.ShouldBeBetween, expectedPos.Y-tolerancePos, expectedPos.Y+tolerancePos)
-	test.That(t, actualPosOld.Z, test.ShouldBeBetween, expectedPos.Z-tolerancePos, expectedPos.Z+tolerancePos)
-
-	actualOriOld := positionOld.Pose().Orientation().AxisAngles()
-	t.Logf("Position orientation: RX: %v, RY: %v, RZ: %v, Theta: %v", actualOriOld.RX, actualOriOld.RY, actualOriOld.RZ, actualOriOld.Theta)
-	test.That(t, actualOriOld.RX, test.ShouldBeBetween, expectedOri.RX-toleranceOri, expectedOri.RX+toleranceOri)
-	test.That(t, actualOriOld.RY, test.ShouldBeBetween, expectedOri.RY-toleranceOri, expectedOri.RY+toleranceOri)
-	test.That(t, actualOriOld.RZ, test.ShouldBeBetween, expectedOri.RZ-toleranceOri, expectedOri.RZ+toleranceOri)
-	test.That(t, actualOriOld.Theta, test.ShouldBeBetween, expectedOri.Theta-toleranceOri, expectedOri.Theta+toleranceOri)
-
 	position, componentRef, err := svc.GetPosition(context.Background(), "test")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, componentRef, test.ShouldEqual, sensor)
@@ -265,7 +249,7 @@ func integrationTestHelperOrbslam(t *testing.T, mode slam.Mode) {
 	// Delete the last image (or image pair) in the data directory, so that offline mode runs on
 	// the same data as online mode. (Online mode will not read the last image (or image pair),
 	// since it always processes the second-most-recent image (or image pair), in case the
-	// most-recent image (or image pair) is currently being written.)
+	// most-recent image (or image pair) is currently being written.
 	var directories []string
 	switch mode {
 	case slam.Mono:

--- a/services/slam/builtin/orbslam_int_test.go
+++ b/services/slam/builtin/orbslam_int_test.go
@@ -226,7 +226,7 @@ func integrationTestHelperOrbslam(t *testing.T, mode slam.Mode) {
 		}
 	}
 
-	testOrbslamPosition(t, svc, reflect.ValueOf(mode).String(), "mapping", sensors[0])
+	testOrbslamPosition(t, svc, reflect.ValueOf(mode).String(), "mapping", attrCfg.Sensors[0])
 	testOrbslamMap(t, svc)
 
 	// Close out slam service
@@ -322,7 +322,7 @@ func integrationTestHelperOrbslam(t *testing.T, mode slam.Mode) {
 		}
 	}
 
-	testOrbslamPosition(t, svc, reflect.ValueOf(mode).String(), "mapping", sensors[0])
+	testOrbslamPosition(t, svc, reflect.ValueOf(mode).String(), "mapping", sensors[0]) // setting to sensors[0] because orbslam interprets the component reference in offline mode
 	testOrbslamMap(t, svc)
 
 	if !orbslam_hangs {
@@ -433,7 +433,7 @@ func integrationTestHelperOrbslam(t *testing.T, mode slam.Mode) {
 		}
 	}
 
-	testOrbslamPosition(t, svc, reflect.ValueOf(mode).String(), "updating", sensors[0])
+	testOrbslamPosition(t, svc, reflect.ValueOf(mode).String(), "updating", attrCfg.Sensors[0])
 	testOrbslamMap(t, svc)
 
 	// Close out slam service

--- a/web/frontend/src/components/input-controller.vue
+++ b/web/frontend/src/components/input-controller.vue
@@ -52,17 +52,21 @@ const getValue = (controlMatch: string) => {
   return '';
 };
 
-const controls: string[][] = [];
+const controls = $computed(() => {
+  const pendingControls = [];
 
-for (const ctrl of controlOrder) {
-  const value = getValue(ctrl);
-  if (value !== '') {
-    controls.push([
-      ctrl.replace('Absolute', '').replace('Button', ''),
-      value,
-    ]);
+  for (const ctrl of controlOrder) {
+    const value = getValue(ctrl);
+    if (value !== '') {
+      pendingControls.push([
+        ctrl.replace('Absolute', '').replace('Button', ''),
+        value,
+      ]);
+    }
   }
-}
+
+  return pendingControls;
+});
 
 </script>
 


### PR DESCRIPTION
Note: remade previous PR to clean up commit history https://github.com/viamrobotics/rdk/pull/1999

updates integration tests with new endpoints to prep for map representation wrap up. Does not remove old endpoints, as those should be removed in [RSDK-1066](https://viam.atlassian.net/browse/RSDK-1066?atlOrigin=eyJpIjoiMjgwNjQ4MWM0NmUzNGM1OThkZWMzN2JlYTJhMjZhZjUiLCJwIjoiaiJ9). In addition, the internal state and pointcloud endpoints were [added previously](https://viam.atlassian.net/browse/RSDK-1955?atlOrigin=eyJpIjoiOWYyZDY1NTFiOTBjNDkwOGJkOGI0ODJkMjIxOTRjZmYiLCJwIjoiaiJ9), so this PR only adds the GetPosition method

tickets:
[cartographer integration test](https://viam.atlassian.net/browse/RSDK-1055)
[orbslam integration test](https://viam.atlassian.net/browse/RSDK-1067?atlOrigin=eyJpIjoiMjg2OGZlNWRiOGZkNGQ4MzllY2Q4YjdmNzA2MTJlYWUiLCJwIjoiaiJ9)

[RSDK-1066]: https://viam.atlassian.net/browse/RSDK-1066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ