### PR TITLE
Add webrtc option to network config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -468,6 +468,9 @@ type NetworkConfigData struct {
 
 	// Sessions configures session management.
 	Sessions SessionsConfig `json:"sessions"`
+
+	// Webrtc indicates whether or not to enable WebRTC support.
+	WebRTC bool `json:"webrtc"`
 }
 
 // MarshalJSON marshals out this config.

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -179,7 +179,7 @@ func (s *robotServer) createWebOptions(cfg *config.Config) (weboptions.Options, 
 	options.Pprof = s.args.WebProfile
 	options.SharedDir = s.args.SharedDir
 	options.Debug = s.args.Debug || cfg.Debug
-	options.WebRTC = s.args.WebRTC
+	options.WebRTC = s.args.WebRTC || cfg.Network.WebRTC
 	if cfg.Cloud != nil && s.args.AllowInsecureCreds {
 		options.SignalingDialOpts = append(options.SignalingDialOpts, rpc.WithAllowInsecureWithCredentialsDowngrade())
 	}


### PR DESCRIPTION
### Description

This PR addresses a problem with the local RC page not picking up the webrtc option with remote media streams. If the initial connection to the Remote fails then no streams will be present and the local RC page will not enable WebRTC.

By adding a webrtc network config option, you can can change the webrtc flag at runtime which will reboot the webservice.

### Testing

RDK with intel realsense remote. 

```
{
    "remotes": [
      {
        "address": "127.0.0.1:8085",
        "insecure": true,
        "name": "intel121"
      }
    ],
    "processes": [
      {
        "log": true,
        "name": "/usr/local/bin/intelrealgrpcserver",
        "cwd": "",
        "args": [
          "8085",
          "640",
          "480",
          "640",
          "480"
        ],
        "id": "intel"
      }
    ],
    "network": {
        "bind_address": "127.0.0.1:8080",
        "insecure": true
    }
  }
```

Add the webrtc option to the network config.

```
{
    "remotes": [
      {
        "address": "127.0.0.1:8085",
        "insecure": true,
        "name": "intel121"
      }
    ],
    "processes": [
      {
        "log": true,
        "name": "/usr/local/bin/intelrealgrpcserver",
        "cwd": "",
        "args": [
          "8085",
          "640",
          "480",
          "640",
          "480"
        ],
        "id": "intel"
      }
    ],
    "network": {
        "bind_address": "127.0.0.1:8080",
        "insecure": true,
        "webrtc": true
    }
  }
```

Now you can view Realsense streams in the local RC page.
