### PR TITLE
RSDK-2182 - stop multiplying by a 100 confidence

### DIFF
--- a/vision/classification/classification_utils.go
+++ b/vision/classification/classification_utils.go
@@ -18,7 +18,7 @@ func Overlay(img image.Image, classifications Classifications) (image.Image, err
 	y := 30
 	for _, classification := range classifications {
 		rimage.DrawString(gimg,
-			fmt.Sprintf("%v: %.2f %%", classification.Label(), classification.Score()*100.),
+			fmt.Sprintf("%v: %.2f %%", classification.Label(), classification.Score()),
 			image.Point{x, y},
 			color.NRGBA{255, 0, 0, 255},
 			30)

--- a/vision/classification/classification_utils.go
+++ b/vision/classification/classification_utils.go
@@ -18,7 +18,7 @@ func Overlay(img image.Image, classifications Classifications) (image.Image, err
 	y := 30
 	for _, classification := range classifications {
 		rimage.DrawString(gimg,
-			fmt.Sprintf("%v: %.2f %%", classification.Label(), classification.Score()),
+			fmt.Sprintf("%v: %.2f", classification.Label(), classification.Score()),
 			image.Point{x, y},
 			color.NRGBA{255, 0, 0, 255},
 			30)


### PR DESCRIPTION
Remove "*100" but want to make sure that `classification.Score()` is already a percentage.
If so, there might be an inconstancy with [those tests ](https://github.com/viamrobotics/rdk/blob/main/services/vision/builtin/tflite_test.go#L233) (that are probably expecting a value between 0 and 1).
Also. should "_pct" be added to the attribute of the transform camera "confidence_threshold" ? It is the case for the attribute of detection.