### PR TITLE
RSDK-1863: Fix flaky analog smoother test

### DIFF
--- a/components/board/analog_smoother_test.go
+++ b/components/board/analog_smoother_test.go
@@ -54,7 +54,7 @@ func TestAnalogSmoother1(t *testing.T) {
 	_, ok = as.(*AnalogSmoother)
 	test.That(t, ok, test.ShouldBeTrue)
 
-	testutils.WaitForAssertionWithSleep(t, 10*time.Millisecond, 100, func(tb testing.TB) {
+	testutils.WaitForAssertionWithSleep(t, 10*time.Millisecond, 200, func(tb testing.TB) {
 		tb.Helper()
 		v, err := as.Read(context.Background(), nil)
 		test.That(tb, testReader.n, test.ShouldEqual, testReader.lim)

--- a/components/board/analog_smoother_test.go
+++ b/components/board/analog_smoother_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/edaniels/golog"
 	"go.viam.com/test"
 	"go.viam.com/utils"
+	"go.viam.com/utils/testutils"
 )
 
 type testReader struct {
@@ -53,14 +54,14 @@ func TestAnalogSmoother1(t *testing.T) {
 	_, ok = as.(*AnalogSmoother)
 	test.That(t, ok, test.ShouldBeTrue)
 
-	// Sleep far longer than needed. Want to hit the reader limit for deterministic behavior.
-	time.Sleep(500 * time.Millisecond)
+	testutils.WaitForAssertionWithSleep(t, 10*time.Millisecond, 100, func(tb testing.TB) {
+		tb.Helper()
+		v, err := as.Read(context.Background(), nil)
+		test.That(tb, testReader.n, test.ShouldEqual, testReader.lim)
+		test.That(tb, err, test.ShouldEqual, errStopReading)
+		test.That(tb, v, test.ShouldEqual, 52)
+	})
 
-	v, err := as.Read(context.Background(), nil)
-	test.That(t, testReader.n, test.ShouldEqual, testReader.lim)
-	test.That(t, err, test.ShouldEqual, errStopReading)
-	test.That(t, v, test.ShouldEqual, 52)
-
-	err = utils.TryClose(context.Background(), as)
+	err := utils.TryClose(context.Background(), as)
 	test.That(t, err, test.ShouldBeNil)
 }

--- a/components/board/analog_smoother_test.go
+++ b/components/board/analog_smoother_test.go
@@ -57,9 +57,13 @@ func TestAnalogSmoother1(t *testing.T) {
 	testutils.WaitForAssertionWithSleep(t, 10*time.Millisecond, 200, func(tb testing.TB) {
 		tb.Helper()
 		v, err := as.Read(context.Background(), nil)
-		test.That(tb, testReader.n, test.ShouldEqual, testReader.lim)
 		test.That(tb, err, test.ShouldEqual, errStopReading)
 		test.That(tb, v, test.ShouldEqual, 52)
+
+		// need lock to access testReader.n
+		testReader.mu.Lock()
+		defer testReader.mu.Unlock()
+		test.That(tb, testReader.n, test.ShouldEqual, testReader.lim)
 	})
 
 	err := utils.TryClose(context.Background(), as)


### PR DESCRIPTION
Another time-based test. Doesn't fail too often. The fix effectively extends the time from 500ms to 2s while speeding the test up with more frequent checks.