### PR TITLE
rollback-slam-vue-to-pre-map-representation

### DIFF
--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/remote-control",
-      "version": "0.2.2",
+      "version": "0.2.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource/space-mono": "^4.5.10",

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "license": "Apache-2.0",
   "type": "module",
   "files": [

--- a/web/frontend/src/components/slam.vue
+++ b/web/frontend/src/components/slam.vue
@@ -1,13 +1,16 @@
 
 <script setup lang="ts">
 
-import { nextTick } from 'vue';
+// import { nextTick } from 'vue';
 import { grpc } from '@improbable-eng/grpc-web';
 import { Client, commonApi, slamApi } from '@viamrobotics/sdk';
 import { displayError } from '../lib/error';
 import { rcLogConditionally } from '../lib/log';
-import PCD from './pcd/pcd-view.vue';
-import Slam2dRender from './slam-2d-render.vue';
+
+/*
+ * import PCD from './pcd/pcd-view.vue';
+ * import Slam2dRender from './slam-2d-render.vue';
+ */
 
 const props = defineProps<{
   name: string
@@ -17,28 +20,31 @@ const props = defineProps<{
 
 let imageMap = $ref('');
 const selected2dValue = $ref('manual');
-const selected3dValue = $ref('manual');
-let pointCloudUpdateCount = $ref(0);
-let pointcloud = $ref<Uint8Array | undefined>();
-let pose = $ref<commonApi.Pose | undefined>();
 let show2d = $ref(false);
-let show3d = $ref(false);
-
-const loaded2d = $computed(() => (pointcloud !== undefined && pose !== undefined));
-
 let slam2dIntervalId = -1;
-let slam3dIntervalId = -1;
 
-const concatArrayU8 = (arrays: Uint8Array[]) => {
-  const totalLength = arrays.reduce((acc, value) => acc + value.length, 0);
-  const result = new Uint8Array(totalLength);
-  let length = 0;
-  for (const array of arrays) {
-    result.set(array, length);
-    length += array.length;
-  }
-  return result;
-};
+/*
+ * const selected3dValue = $ref('manual');
+ * let pointCloudUpdateCount = $ref(0);
+ * let pointcloud = $ref<Uint8Array | undefined>();
+ * let pose = $ref<commonApi.Pose | undefined>();
+ * let show3d = $ref(false);
+ * const loaded2d = $computed(() => (pointcloud !== undefined && pose !== undefined));
+ * let slam3dIntervalId = -1;
+ */
+
+/*
+ * const concatArrayU8 = (arrays: Uint8Array[]) => {
+ *   const totalLength = arrays.reduce((acc, value) => acc + value.length, 0);
+ *   const result = new Uint8Array(totalLength);
+ *   let length = 0;
+ *   for (const array of arrays) {
+ *     result.set(array, length);
+ *     length += array.length;
+ *   }
+ *   return result;
+ * };
+ */
 
 const fetchSLAMImageMap = (name: string) => {
   const req = new slamApi.GetMapRequest();
@@ -55,52 +61,55 @@ const fetchSLAMImageMap = (name: string) => {
   });
 };
 
-const fetchSLAMMap = (name: string) => {
-  return nextTick(() => {
-    const req = new slamApi.GetPointCloudMapStreamRequest();
-    req.setName(name);
-    rcLogConditionally(req);
-    const chunks: Uint8Array[] = [];
+/*
+ * const fetchSLAMMap = (name: string) => {
+ *   return nextTick(() => {
+ *     const req = new slamApi.GetPointCloudMapStreamRequest();
+ *     req.setName(name);
+ *     rcLogConditionally(req);
+ *     const chunks: Uint8Array[] = [];
+ *     const getPointCloudMapStream = props.client.slamService.getPointCloudMapStream(req);
+ *     getPointCloudMapStream.on('data', (res) => {
+ *       const chunk = res.getPointCloudPcdChunk_asU8();
+ *       chunks.push(chunk);
+ *     });
+ *     getPointCloudMapStream.on('status', (status) => {
+ *       if (status.code !== 0) {
+ *         const error = {
+ *           message: status.details,
+ *           code: status.code,
+ *           metadata: status.metadata,
+ *         };
+ *         displayError(error);
+ *       }
+ *     });
+ *     getPointCloudMapStream.on('end', (end) => {
+ *       if (end === undefined || end.code !== 0) {
+ *         // the error will be logged in the 'status' callback
+ *         return;
+ *       }
+ *       pointcloud = concatArrayU8(chunks);
+ *       pointCloudUpdateCount += 1;
+ *     });
+ *   });
+ * };
+ */
 
-    const getPointCloudMapStream = props.client.slamService.getPointCloudMapStream(req);
-    getPointCloudMapStream.on('data', (res) => {
-      const chunk = res.getPointCloudPcdChunk_asU8();
-      chunks.push(chunk);
-    });
-    getPointCloudMapStream.on('status', (status) => {
-      if (status.code !== 0) {
-        const error = {
-          message: status.details,
-          code: status.code,
-          metadata: status.metadata,
-        };
-        displayError(error);
-      }
-    });
-    getPointCloudMapStream.on('end', (end) => {
-      if (end === undefined || end.code !== 0) {
-        // the error will be logged in the 'status' callback
-        return;
-      }
-      pointcloud = concatArrayU8(chunks);
-      pointCloudUpdateCount += 1;
-    });
-  });
-};
-
-const fetchSLAMPose = (name: string) => {
-  return nextTick(() => {
-    const req = new slamApi.GetPositionNewRequest();
-    req.setName(name);
-    props.client.slamService.getPositionNew(req, new grpc.Metadata(), (error, res): void => {
-      if (error) {
-        displayError(error);
-        return;
-      }
-      pose = res!.getPose()!;
-    });
-  });
-};
+/*
+ * const fetchSLAMPose = (name: string) => {
+ *   return nextTick(() => {
+ *     const req = new slamApi.GetPositionNewRequest();
+ *     req.setName(name);
+ *     props.client.slamService.getPositionNew(req, new grpc.Metadata(), (error, res): void => {
+ *       if (error) {
+ *         displayError(error);
+ *         return;
+ *       }
+ *       pose = res!.getPose()!;
+ *     });
+ *   });
+ * };
+ */
 
 const refresh2d = async (name: string) => {
 
@@ -131,47 +140,54 @@ const updateSLAM2dRefreshFrequency = async (name: string, time: 'manual' | 'off'
   }
 };
 
-const updateSLAM3dRefreshFrequency = (name: string, time: 'manual' | 'off' | string) => {
-  clearInterval(slam3dIntervalId);
-
-  if (time === 'manual') {
-    fetchSLAMMap(name);
-  } else if (time === 'off') {
-    // do nothing
-  } else {
-    fetchSLAMMap(name);
-    slam3dIntervalId = window.setInterval(() => {
-      fetchSLAMMap(name);
-    }, Number.parseFloat(time) * 1000);
-  }
-};
+/*
+ * const updateSLAM3dRefreshFrequency = (name: string, time: 'manual' | 'off' | string) => {
+ *   clearInterval(slam3dIntervalId);
+ *   if (time === 'manual') {
+ *     fetchSLAMMap(name);
+ *   } else if (time === 'off') {
+ *     // do nothing
+ *   } else {
+ *     fetchSLAMMap(name);
+ *     slam3dIntervalId = window.setInterval(() => {
+ *       fetchSLAMMap(name);
+ *     }, Number.parseFloat(time) * 1000);
+ *   }
+ * };
+ */
 
 const toggle2dExpand = () => {
   show2d = !show2d;
   updateSLAM2dRefreshFrequency(props.name, show2d ? selected2dValue : 'off');
 };
 
-const toggle3dExpand = () => {
-  show3d = !show3d;
-  updateSLAM3dRefreshFrequency(props.name, show3d ? selected3dValue : 'off');
-};
+/*
+ * const toggle3dExpand = () => {
+ *   show3d = !show3d;
+ *   updateSLAM3dRefreshFrequency(props.name, show3d ? selected3dValue : 'off');
+ * };
+ */
 
 const selectSLAM2dRefreshFrequency = () => {
   updateSLAM2dRefreshFrequency(props.name, selected2dValue);
 };
 
-const selectSLAMPCDRefreshFrequency = () => {
-  updateSLAM3dRefreshFrequency(props.name, selected3dValue);
-};
+/*
+ * const selectSLAMPCDRefreshFrequency = () => {
+ *   updateSLAM3dRefreshFrequency(props.name, selected3dValue);
+ * };
+ */
 
 // eslint-disable-next-line require-await
 const refresh2dMap = async () => {
   updateSLAM2dRefreshFrequency(props.name, selected2dValue);
 };
 
-const refresh3dMap = () => {
-  updateSLAM3dRefreshFrequency(props.name, selected3dValue);
-};
+/*
+ * const refresh3dMap = () => {
+ *   updateSLAM3dRefreshFrequency(props.name, selected3dValue);
+ * };
+ */
 
 </script>
 
@@ -269,14 +285,14 @@ const refresh3dMap = () => {
             :client="client"
           /> -->
         </div>
-        <div class="pt-4">
-          <!-- <div class="flex items-center gap-2">
+        <!-- <div class="pt-4">
+          <div class="flex items-center gap-2">
             <v-switch
               :value="show3d ? 'on' : 'off'"
               @input="toggle3dExpand()"
             />
             <span class="pr-2">View SLAM Map (3D))</span>
-          </div> -->
+          </div>
           <div class="float-right pb-4">
             <div class="flex">
               <div
@@ -325,14 +341,14 @@ const refresh3dMap = () => {
                   </div>
                 </div>
               </div>
-              <!-- <div class="px-2 pt-7">
+              <div class="px-2 pt-7">
                 <v-button
                   v-if="show3d"
                   icon="refresh"
                   label="Refresh"
                   @click="refresh3dMap()"
                 />
-              </div> -->
+              </div>
             </div>
           </div>
           <PCD
@@ -341,7 +357,7 @@ const refresh3dMap = () => {
             :pointcloud="pointcloud"
             :client="client"
           />
-        </div>
+        </div> -->
       </div>
     </div>
   </v-collapse>

--- a/web/frontend/src/components/slam.vue
+++ b/web/frontend/src/components/slam.vue
@@ -270,13 +270,13 @@ const refresh3dMap = () => {
           /> -->
         </div>
         <div class="pt-4">
-          <div class="flex items-center gap-2">
+          <!-- <div class="flex items-center gap-2">
             <v-switch
               :value="show3d ? 'on' : 'off'"
               @input="toggle3dExpand()"
             />
             <span class="pr-2">View SLAM Map (3D))</span>
-          </div>
+          </div> -->
           <div class="float-right pb-4">
             <div class="flex">
               <div
@@ -325,14 +325,14 @@ const refresh3dMap = () => {
                   </div>
                 </div>
               </div>
-              <div class="px-2 pt-7">
+              <!-- <div class="px-2 pt-7">
                 <v-button
                   v-if="show3d"
                   icon="refresh"
                   label="Refresh"
                   @click="refresh3dMap()"
                 />
-              </div>
+              </div> -->
             </div>
           </div>
           <PCD


### PR DESCRIPTION
1. Rolls back slam.vue to call GetMap (image/jpeg) for the 2d view rather than GetPointCloudMapStream
2. Removes 3d view
3. Changes 2d view to only allow polling at 5, 10, and 30 second intervals or manual refresh
4. Bump remote-control to version `0.2.4`

This leaves all the code for using the temp post map representation APIs unchanged so that we can roll forward when the new APIs have the required performance characteristics. 

![Screenshot 2023-03-10 at 12 23 19 PM](https://user-images.githubusercontent.com/5927876/224382438-50e9c312-1f16-4d2f-b89a-b1f97d6a50c6.png)
![Screenshot 2023-03-10 at 12 22 53 PM](https://user-images.githubusercontent.com/5927876/224382440-2d2fac33-1937-4811-8579-26c4f37fa713.png)
