### PR TITLE
[DATA-fix] Switch from using app address to signaling address

### DIFF
--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -278,7 +278,7 @@ func getNextWait(lastWait time.Duration) time.Duration {
 	return nextWait
 }
 
-// nolint
+//nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {


### PR DESCRIPTION
**Context**
It seems like in the cloud config, the app address is empty whereas the signaling address is not. Instead, we should use the signaling address.

