### PR TITLE
Make client argument to createRcApp() optional

### DIFF
--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "license": "Apache-2.0",
   "type": "module",
   "files": [

--- a/web/frontend/src/main-lib.ts
+++ b/web/frontend/src/main-lib.ts
@@ -2,7 +2,7 @@ import './index.css';
 import { createApp } from 'vue';
 import RemoteControlCards from './components/remote-control-cards.vue';
 import type { Credentials } from '@viamrobotics/rpc';
-import type { Client } from '@viamrobotics/sdk';
+import { Client } from '@viamrobotics/sdk';
 
 export const createRcApp = (props: {
   host: string;
@@ -12,7 +12,33 @@ export const createRcApp = (props: {
   },
   supportedAuthTypes: string[],
   webrtcEnabled: boolean,
-  client: Client;
+  client?: Client;
 }) => {
+  if (!props.client) {
+    const rtcConfig = {
+      iceServers: [
+        {
+          urls: 'stun:global.stun.twilio.com:3478',
+        },
+      ],
+    };
+
+    if (window.webrtcAdditionalICEServers) {
+      rtcConfig.iceServers = [
+        ...rtcConfig.iceServers,
+        ...window.webrtcAdditionalICEServers,
+      ];
+    }
+
+    const impliedURL = `${location.protocol}//${location.hostname}${location.port ? `:${location.port}` : ''}`;
+
+    props.client = new Client(impliedURL, {
+      enabled: true,
+      host: window.host,
+      signalingAddress: window.webrtcSignalingAddress,
+      rtcConfig,
+    });
+  }
+
   return createApp(RemoteControlCards, props);
 };


### PR DESCRIPTION
This is done to investigate moving the `new Client` constructor over to the RDK side always to avoid `@viamrobotics/sdk` version mismatches between library and application.