### PR TITLE
[DATA-1224] Only include the host portion of the URL when making a direct GRPC connection

### DIFF
--- a/services/datamanager/datasync/client.go
+++ b/services/datamanager/datasync/client.go
@@ -2,11 +2,14 @@ package datasync
 
 import (
 	"context"
+	"time"
 
 	"go.uber.org/zap"
 	v1 "go.viam.com/api/app/datasync/v1"
 	"go.viam.com/utils/rpc"
 )
+
+var grpcConnectionTimeout = 10 * time.Second
 
 // NewClient constructs a new v1.DataSyncServiceClient using the passed in connection.
 func NewClient(conn rpc.ClientConn) v1.DataSyncServiceClient {
@@ -15,7 +18,9 @@ func NewClient(conn rpc.ClientConn) v1.DataSyncServiceClient {
 
 // NewConnection builds a connection to the passed address with the passed rpcOpts.
 func NewConnection(logger *zap.SugaredLogger, address string, rpcOpts []rpc.DialOption) (rpc.ClientConn, error) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), grpcConnectionTimeout)
+	defer cancel()
+
 	conn, err := rpc.DialDirectGRPC(
 		ctx,
 		address,

--- a/services/datamanager/datasync/client.go
+++ b/services/datamanager/datasync/client.go
@@ -14,7 +14,8 @@ func NewClient(conn rpc.ClientConn) v1.DataSyncServiceClient {
 }
 
 // NewConnection builds a connection to the passed address with the passed rpcOpts.
-func NewConnection(ctx context.Context, logger *zap.SugaredLogger, address string, rpcOpts []rpc.DialOption) (rpc.ClientConn, error) {
+func NewConnection(logger *zap.SugaredLogger, address string, rpcOpts []rpc.DialOption) (rpc.ClientConn, error) {
+	ctx := context.Background()
 	conn, err := rpc.DialDirectGRPC(
 		ctx,
 		address,

--- a/services/datamanager/datasync/client.go
+++ b/services/datamanager/datasync/client.go
@@ -14,8 +14,7 @@ func NewClient(conn rpc.ClientConn) v1.DataSyncServiceClient {
 }
 
 // NewConnection builds a connection to the passed address with the passed rpcOpts.
-func NewConnection(logger *zap.SugaredLogger, address string, rpcOpts []rpc.DialOption) (rpc.ClientConn, error) {
-	ctx := context.Background()
+func NewConnection(ctx context.Context, logger *zap.SugaredLogger, address string, rpcOpts []rpc.DialOption) (rpc.ClientConn, error) {
 	conn, err := rpc.DialDirectGRPC(
 		ctx,
 		address,

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -29,7 +29,6 @@ var (
 	// RetryExponentialFactor defines the factor by which the retry wait time increases.
 	RetryExponentialFactor = atomic.NewInt32(2)
 	maxRetryInterval       = time.Hour
-	managerInitTimeout     = 10 * time.Second
 )
 
 // Manager is responsible for enqueuing files in captureDir and uploading them to the cloud.

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -4,6 +4,7 @@ package datasync
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sync"
@@ -72,7 +73,11 @@ func NewDefaultManager(logger golog.Logger, cfg *config.Config, lastModMillis in
 			}),
 	}
 
-	conn, err := NewConnection(logger, cfg.Cloud.AppAddress, rpcOpts)
+	appURLParsed, err := url.Parse(cfg.Cloud.AppAddress)
+	if err != nil {
+		return nil, err
+	}
+	conn, err := NewConnection(logger, appURLParsed.Host, rpcOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -58,9 +58,6 @@ type ManagerConstructor func(logger golog.Logger, cfg *config.Config, lastModMil
 
 // NewDefaultManager returns the default Manager that syncs data to app.viam.com.
 func NewDefaultManager(logger golog.Logger, cfg *config.Config, lastModMillis int) (Manager, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), managerInitTimeout)
-	defer cancel()
-
 	if cfg.Cloud == nil || cfg.Cloud.AppAddress == "" {
 		logger.Debug("Using no-op sync manager when Cloud config is not available")
 		return NewNoopManager(), nil
@@ -81,7 +78,7 @@ func NewDefaultManager(logger golog.Logger, cfg *config.Config, lastModMillis in
 	if err != nil {
 		return nil, err
 	}
-	conn, err := NewConnection(ctx, logger, appURLParsed.Host, rpcOpts)
+	conn, err := NewConnection(logger, appURLParsed.Host, rpcOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -190,7 +190,9 @@ func (s *syncer) syncArbitraryFile(f *os.File) {
 		s.cancelCtx,
 		func(ctx context.Context) error {
 			err := uploadArbitraryFile(ctx, s.client, f, s.partID)
-			s.logger.Errorw(fmt.Sprintf("error uploading file %s", f.Name()), "error", err)
+			if err != nil {
+				s.logger.Errorw(fmt.Sprintf("error uploading file %s", f.Name()), "error", err)
+			}
 			return err
 		},
 	)


### PR DESCRIPTION
When connecting with the cloud in the RDK syncer, remove the https protocol that is included in app address (e.g. https://app.viam.com:443 -> app.viam.com:443)
Otherwise, the full URL causes DialDirectGRPC to hang.

[note for red herring]: confirmed that AppAddress is properly populated when reaching RDK, just not in the app UI full config

**Testing**
The crashing was previously not viewable locally in logs or when shutting down viam-server locally via ctrl-C, but now see that after a few minutes the robot would silently fail. Tested that this no longer happens and that we successfully sync to app, both prod and staging.
This was immediately visible in prod since stopping viam-service would show logs of `initSyncer` hanging.