### PR TITLE
[RSDK-2327] Add build-web as requirement for server make target

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -53,12 +53,6 @@ jobs:
       with:
         credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
 
-    - name: Build Web Artifacts (PR)
-      if: contains(github.event.pull_request.labels.*.name, 'appimage') || contains(github.event.pull_request.labels.*.name, 'appimage-ignore-tests')
-      run: |
-        echo "running 'make build-web'"
-        make build-web
-
     - name: Build and Package (PR)
       if: contains(github.event.pull_request.labels.*.name, 'appimage') || contains(github.event.pull_request.labels.*.name, 'appimage-ignore-tests')
       run: |
@@ -74,12 +68,6 @@ jobs:
         glob: '*'
         parent: false
         gzip: false
-
-    - name: Build Web Artifacts (Latest)
-      if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
-      run: |
-        echo "running 'make build-web'"
-        make build-web
 
     - name: Build and Package (Latest)
       id: build_test_app

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,10 @@ build: build-web build-go
 build-go:
 	go build $(GO_BUILD_TAGS) ./...
 
-build-web:
+build-web: web/runtime-shared/static/control.js
+
+# this assumes that control.js is always updated when this target runs
+web/runtime-shared/static/control.js: web/frontend/src/*/* web/frontend/src/*/*/* web/frontend/src/*.* web/frontend/scripts/* web/frontend/*.*
 	npm ci --audit=false --prefix web/frontend
 	export NODE_OPTIONS=--openssl-legacy-provider && node --version 2>/dev/null || unset NODE_OPTIONS;\
 	npm run build --prefix web/frontend
@@ -84,7 +87,7 @@ test-integration:
 	cd services/slam/builtin && sudo --preserve-env=APPIMAGE_EXTRACT_AND_RUN go test -v -run TestOrbslamIntegration
 	cd services/slam/builtin && sudo --preserve-env=APPIMAGE_EXTRACT_AND_RUN go test -v -run TestCartographerIntegration
 
-server:
+server: build-web
 	go build $(GO_BUILD_TAGS) $(LDFLAGS) -o $(BIN_OUTPUT_PATH)/server web/cmd/server/main.go
 
 clean-all:

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ build-go:
 
 build-web: web/runtime-shared/static/control.js
 
-# this assumes that control.js is always updated when this target runs
+# only generate static files when source has changed.
 web/runtime-shared/static/control.js: web/frontend/src/*/* web/frontend/src/*/*/* web/frontend/src/*.* web/frontend/scripts/* web/frontend/*.*
 	npm ci --audit=false --prefix web/frontend
 	export NODE_OPTIONS=--openssl-legacy-provider && node --version 2>/dev/null || unset NODE_OPTIONS;\


### PR DESCRIPTION
Currently `make server` fails to build and include the web UI when run locally. This means it also fails the `make appimage` target, which depends on the `server` target, and fails when built by homebrew packaging.

This removes the CI automation that worked around this for releases, and instead creates the proper dependencies within the Makefile itself. Source deps are setup so that repeated runs of `make server` won't rebuild the frontend every time, unless the frontend sources change.

Another PR will be incoming for the brew formula itself, since building the server now requires node.