### PR TITLE
RSDK-2326 Do not build modular resources that fail validation

### DIFF
--- a/examples/customresources/demos/complexmodule/moduletest/bad_modular_validation.json
+++ b/examples/customresources/demos/complexmodule/moduletest/bad_modular_validation.json
@@ -1,0 +1,34 @@
+{
+	"modules": [
+		{
+			"name": "AcmeModule",
+			"executable_path": "./complexmodule"
+		}
+	],
+	"components": [
+		{
+			"namespace": "rdk",
+			"type": "motor",
+			"name": "motor1",
+			"model": "rdk:builtin:fake"
+		},
+		{
+			"namespace": "rdk",
+			"type": "motor",
+			"name": "motor2",
+			"model": "rdk:builtin:fake"
+		},
+		{
+			"namespace": "rdk",
+			"type": "base",
+			"name": "base1",
+			"model": "acme:demo:mybase",
+			"attributes": {
+				"motorR": "motor2"
+			}
+		}
+	],
+	"network": {
+		"bind_address": ":8080"
+	}
+}

--- a/examples/customresources/demos/complexmodule/moduletest/module_test.go
+++ b/examples/customresources/demos/complexmodule/moduletest/module_test.go
@@ -37,8 +37,8 @@ func TestComplexModule(t *testing.T) {
 	// Modify the example config to run directly, without compiling the module first.
 	cfgFilename, port, err := modifyCfg(utils.ResolveFile("examples/customresources/demos/complexmodule/module.json"), logger)
 	test.That(t, err, test.ShouldBeNil)
-	defer func(){
-			test.That(t, os.Remove(cfgFilename), test.ShouldBeNil)
+	defer func() {
+		test.That(t, os.Remove(cfgFilename), test.ShouldBeNil)
 	}()
 
 	// Build a binary server and module. This seperate process avoids having custom APIs (imported above) in the parent server.
@@ -53,12 +53,12 @@ func TestComplexModule(t *testing.T) {
 	server := pexec.NewManagedProcess(pexec.ProcessConfig{
 		Name: "bash",
 		Args: []string{"-c", "exec bin/`uname`-`uname -m`/server -config " + cfgFilename},
-		CWD: utils.ResolveFile("./"),
-		Log: true,
+		CWD:  utils.ResolveFile("./"),
+		Log:  true,
 	}, logger)
 
 	err = server.Start(context.Background())
-	test.That(t, err, test.ShouldBeNil)	
+	test.That(t, err, test.ShouldBeNil)
 	defer func() {
 		test.That(t, server.Stop(), test.ShouldBeNil)
 	}()
@@ -71,7 +71,7 @@ func TestComplexModule(t *testing.T) {
 
 	// Gizmo is a custom component model and API.
 	t.Run("Test Gizmo", func(t *testing.T) {
-	 	res, err := rc.ResourceByName(gizmoapi.Named("gizmo1"))
+		res, err := rc.ResourceByName(gizmoapi.Named("gizmo1"))
 		test.That(t, err, test.ShouldBeNil)
 
 		giz := res.(gizmoapi.Gizmo)
@@ -97,7 +97,7 @@ func TestComplexModule(t *testing.T) {
 
 		ret3, err = giz.DoOneBiDiStream(context.Background(), []string{"arg1", "arg1", "arg1"})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, ret3,  test.ShouldResemble, []bool{true, true})
+		test.That(t, ret3, test.ShouldResemble, []bool{true, true})
 	})
 
 	// Summation is a custom service model and API.
@@ -297,11 +297,11 @@ func TestComplexModule(t *testing.T) {
 }
 
 func connect(port string, logger golog.Logger) (robot.Robot, error) {
-	connectCtx, cancelConn := context.WithTimeout(context.Background(), time.Second * 30)
+	connectCtx, cancelConn := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancelConn()
 	for {
-		dialCtx, dialCancel := context.WithTimeout(context.Background(), time.Millisecond * 500)
-		rc, err := client.New(dialCtx, "localhost:" + port, logger,
+		dialCtx, dialCancel := context.WithTimeout(context.Background(), time.Millisecond*500)
+		rc, err := client.New(dialCtx, "localhost:"+port, logger,
 			client.WithDialOptions(rpc.WithForceDirectGRPC()),
 			client.WithDisableSessions(), // TODO(PRODUCT-343): add session support to modules
 		)
@@ -322,13 +322,13 @@ func modifyCfg(cfgIn string, logger golog.Logger) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
- 	port := strconv.Itoa(p)
- 	if err != nil {
- 		return "", "", err
- 	}
+	port := strconv.Itoa(p)
+	if err != nil {
+		return "", "", err
+	}
 
- 	// workaround because config.Read can't validate a module config with a "missing" ExePath
- 	touchFile("./complexmodule")
+	// workaround because config.Read can't validate a module config with a "missing" ExePath
+	touchFile("./complexmodule")
 	defer os.Remove("./complexmodule")
 	cfg, err := config.Read(context.Background(), cfgIn, logger)
 	if err != nil {
@@ -358,4 +358,51 @@ func touchFile(path string) error {
 		return err
 	}
 	return f.Close()
+}
+
+func TestValidationFailure(t *testing.T) {
+	logger := golog.NewTestLogger(t)
+
+	// bad_modular_validation.json contains a "mybase" modular component that will
+	// fail modular Validation due to a missing "motorL" attribute.
+	cfgFilename, port, err := modifyCfg(
+		utils.ResolveFile("examples/customresources/demos/complexmodule/moduletest/bad_modular_validation.json"), logger)
+	test.That(t, err, test.ShouldBeNil)
+	defer func() {
+		test.That(t, os.Remove(cfgFilename), test.ShouldBeNil)
+	}()
+
+	builder := exec.Command("bash", "-c", "make -s server && cd examples/customresources/demos/complexmodule && go build .")
+	builder.Dir = utils.ResolveFile("")
+	out, err := builder.CombinedOutput()
+	test.That(t, string(out), test.ShouldEqual, "")
+	test.That(t, err, test.ShouldBeNil)
+
+	server := pexec.NewManagedProcess(pexec.ProcessConfig{
+		Name: "bash",
+		Args: []string{"-c", "exec bin/`uname`-`uname -m`/server -config " + cfgFilename},
+		CWD:  utils.ResolveFile("./"),
+		Log:  true,
+	}, logger)
+
+	err = server.Start(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+	defer func() {
+		test.That(t, server.Stop(), test.ShouldBeNil)
+	}()
+
+	rc, err := connect(port, logger)
+	test.That(t, err, test.ShouldBeNil)
+	defer func() {
+		test.That(t, rc.Close(context.Background()), test.ShouldBeNil)
+	}()
+
+	// Assert that motors were added but base was not due to failed Validation.
+	_, err = rc.ResourceByName(motor.Named("motor1"))
+	test.That(t, err, test.ShouldBeNil)
+	_, err = rc.ResourceByName(motor.Named("motor2"))
+	test.That(t, err, test.ShouldBeNil)
+	_, err = rc.ResourceByName(base.Named("base1"))
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldResemble, `resource "rdk:component:base/base1" not found`)
 }

--- a/examples/customresources/models/mybase/mybase.go
+++ b/examples/customresources/models/mybase/mybase.go
@@ -27,19 +27,19 @@ var (
 func init() {
 	registry.RegisterComponent(base.Subtype, Model, registry.Component{Constructor: newBase})
 
-  // Use RegisterComponentAttributeMapConverter to register a custom configuration
+	// Use RegisterComponentAttributeMapConverter to register a custom configuration
 	// struct that has a Validate(string) ([]string, error) method.
 	//
 	// The Validate method will automatically be called in RDK's module manager to
 	// Validate the MyBase's configuration and register implicit dependencies.
 	config.RegisterComponentAttributeMapConverter(
-    base.Subtype,
-    Model,
-    func(attributes config.AttributeMap) (interface{}, error) {
-      var conf MyBaseConfig
-      return config.TransformAttributeMapToStruct(&conf, attributes)
-    },
-    &MyBaseConfig{})
+		base.Subtype,
+		Model,
+		func(attributes config.AttributeMap) (interface{}, error) {
+			var conf MyBaseConfig
+			return config.TransformAttributeMapToStruct(&conf, attributes)
+		},
+		&MyBaseConfig{})
 }
 
 func newBase(ctx context.Context, deps registry.Dependencies, config config.Component, logger golog.Logger) (interface{}, error) {
@@ -70,6 +70,12 @@ func (base *MyBase) Reconfigure(cfg config.Component, deps registry.Dependencies
 		}
 	}
 
+	if base.left == nil {
+		return errors.Errorf("mybase %q is missing left motor", cfg.Name)
+	}
+	if base.right == nil {
+		return errors.Errorf("mybase %q is missing right motor", cfg.Name)
+	}
 	return nil
 }
 

--- a/examples/customresources/models/mybase/mybase.go
+++ b/examples/customresources/models/mybase/mybase.go
@@ -70,11 +70,8 @@ func (base *MyBase) Reconfigure(cfg config.Component, deps registry.Dependencies
 		}
 	}
 
-	if base.left == nil {
-		return errors.Errorf("mybase %q is missing left motor", cfg.Name)
-	}
-	if base.right == nil {
-		return errors.Errorf("mybase %q is missing right motor", cfg.Name)
+	if base.left == nil || base.right == nil {
+		return errors.Errorf(`mybase %q needs both "motorL" and "motorR"`, cfg.Name)
 	}
 	return nil
 }


### PR DESCRIPTION
RSDK-2326

Follow up to RSDK-1820. Adds `ValidateConfig` calls before `processComponent` and `processService` to check whether we should build the resources at all. Adds better safeguards against missing motors for `mybase`. Tests that modular components that fail validation will not cause RDK failure and are not built.

Just like with regular validation, we should not actually build resources that fail modular validation.