### PR TITLE
fake-slam-ParallelProjectionOntoXZWithRobotMarker

### DIFF
--- a/services/slam/fake/slam.go
+++ b/services/slam/fake/slam.go
@@ -109,3 +109,9 @@ func (slamSvc *SLAM) GetInternalStateStream(ctx context.Context, name string) (f
 func (slamSvc *SLAM) incrementDataCount() {
 	slamSvc.dataCount = ((slamSvc.dataCount + 1) % maxDataCount)
 }
+
+func (slamSvc *SLAM) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+	ctx, span := trace.StartSpan(ctx, "slam::fake::DoCommand")
+	defer span.End()
+	return fakeParallelProjectionOntoXZWithRobotMarker(ctx, datasetDirectory, slamSvc, cmd)
+}

--- a/services/slam/fake/slam.go
+++ b/services/slam/fake/slam.go
@@ -113,5 +113,6 @@ func (slamSvc *SLAM) incrementDataCount() {
 func (slamSvc *SLAM) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
 	ctx, span := trace.StartSpan(ctx, "slam::fake::DoCommand")
 	defer span.End()
+	slamSvc.incrementDataCount()
 	return fakeParallelProjectionOntoXZWithRobotMarker(ctx, datasetDirectory, slamSvc, cmd)
 }


### PR DESCRIPTION
Demos using the DoCommand to call ParallelProjectionOntoXZWithRobotMarker on the fake SLAM service.

Manual Testing Steps:
```
ENV=development go run web/cmd/server/main.go -debug -config /etc/viam.json 
```

Ensure your config looks like so:
```json
{
    "network": {
    "fqdn": "something-unique",
    "bind_address": "localhost:8080"
  },
  "services": [
    {
      "model": "fake",
      "name": "fake",
      "type": "slam"
    }
  ],
  "components": []
}
```

```
viam robot part run --robot nick-slam-mac --location "First Location" --organization "Nick's Org" -part nick-slam-mac-main  -d '{"name": "fake", "command": {"command": "render_pointcloud_map"}}' viam.service.slam.v1.SLAMService.DoCommand > image

cat image | jq -r '.result.return' | base64 -d > projection.jpeg
```

Outputs the following image:
![projection](https://user-images.githubusercontent.com/5927876/225190874-719dbfc1-4f69-4600-8962-6c57bebe5812.jpeg)
