### PR TITLE
RSDK-2117 Skip flaky test TestApplyOffset

### DIFF
--- a/pointcloud/merging_test.go
+++ b/pointcloud/merging_test.go
@@ -40,6 +40,7 @@ func makeThreeCloudsWithOffsets(t *testing.T) []CloudAndOffsetFunc {
 }
 
 func TestApplyOffset(t *testing.T) {
+	t.Skip("remove skip once RSDK-1200 improvement is complete")
 	logger := golog.NewTestLogger(t)
 	pc1 := NewWithPrealloc(3)
 	err := pc1.Set(NewVector(1, 0, 0), NewColoredData(color.NRGBA{255, 0, 0, 255}))


### PR DESCRIPTION
Skipping this test since MergePointCloud function is known to create flaky tests.

Will be un-skipped once improvements specified in RSDK-1200 are complete.