### PR TITLE
fixes for deadlocks in webService

### DIFF
--- a/robot/client/client_session_test.go
+++ b/robot/client/client_session_test.go
@@ -119,7 +119,7 @@ func TestClientSessionOptions(t *testing.T) {
 							SessMgr:                 sessMgr,
 						}
 
-						svc := web.New(ctx, injectRobot, logger)
+						svc := web.New(injectRobot, logger)
 
 						options, _, addr := robottestutils.CreateBaseOptionsAndListener(t)
 						err := svc.Start(ctx, options)
@@ -305,7 +305,7 @@ func TestClientSessionExpiration(t *testing.T) {
 					SessMgr:                 sessMgr,
 				}
 
-				svc := web.New(ctx, injectRobot, logger)
+				svc := web.New(injectRobot, logger)
 
 				options, _, addr := robottestutils.CreateBaseOptionsAndListener(t)
 				err := svc.Start(ctx, options)
@@ -495,7 +495,7 @@ func TestClientSessionResume(t *testing.T) {
 					SessMgr:                 sessMgr,
 				}
 
-				svc := web.New(ctx, injectRobot, logger)
+				svc := web.New(injectRobot, logger)
 
 				options, _, addr := robottestutils.CreateBaseOptionsAndListener(t)
 				err := svc.Start(ctx, options)

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -489,7 +489,7 @@ func newWithResources(
 	}
 
 	r.internalServices = make(map[internalServiceName]interface{})
-	r.internalServices[webName] = web.New(ctx, r, logger, rOpts.webOptions...)
+	r.internalServices[webName] = web.New(r, logger, rOpts.webOptions...)
 	r.internalServices[framesystemName] = framesystem.New(ctx, r, logger)
 	r.internalServices[packageManagerName] = r.packageManager
 

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -289,6 +289,7 @@ func (svc *webService) Start(ctx context.Context, o weboptions.Options) error {
 	if err := svc.runWeb(cancelCtx, o); err != nil {
 		cancelFunc()
 		svc.cancelFuncs = nil
+		svc.isRunning = false
 		return err
 	}
 	return nil
@@ -635,7 +636,9 @@ func (svc *webService) startImageStream(ctx context.Context, source gostream.Vid
 
 func (svc *webService) startAudioStream(ctx context.Context, source gostream.AudioSource, stream gostream.Stream) {
 	svc.startStream(func(opts *webstream.BackoffTuningOptions) error {
-		return webstream.StreamAudioSource(ctx, source, stream, opts)
+		cancelCtx, cancelFunc := context.WithCancel(ctx)
+		svc.cancelFuncs = append(svc.cancelFuncs, cancelFunc)
+		return webstream.StreamAudioSource(cancelCtx, source, stream, opts)
 	})
 }
 

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -458,6 +458,7 @@ func (svc *webService) Stop() {
 		cancel()
 	}
 	svc.cancelFuncs = nil
+	svc.isRunning = false
 }
 
 // Close closes a webService via calls to its Cancel func.
@@ -469,6 +470,7 @@ func (svc *webService) Close() error {
 		cancel()
 	}
 	svc.cancelFuncs = nil
+	svc.isRunning = false
 	if svc.modServer != nil {
 		err = svc.modServer.Stop()
 	}

--- a/robot/web/web_test.go
+++ b/robot/web/web_test.go
@@ -696,7 +696,7 @@ func TestWebWithStreams(t *testing.T) {
 	robot.MockResourcesFromMap(rs)
 	updateable, ok := svc.(resource.Updateable)
 	test.That(t, ok, test.ShouldBeTrue)
-	err = updateable.Update(ctx, rs)
+	err = updateable.Update(context.Background(), rs)
 	test.That(t, err, test.ShouldBeNil)
 
 	// Test that new streams are available

--- a/robot/web/web_test.go
+++ b/robot/web/web_test.go
@@ -6,10 +6,11 @@ import (
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
-	"go.viam.com/rdk/components/audioinput"
 	"net"
 	"testing"
 	"time"
+
+	"go.viam.com/rdk/components/audioinput"
 
 	"github.com/edaniels/golog"
 	"github.com/edaniels/gostream/codec/x264"
@@ -33,6 +34,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"go.viam.com/rdk/components/arm"
+	"go.viam.com/rdk/components/audioinput"
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/config"
 	gizmopb "go.viam.com/rdk/examples/customresources/apis/proto/api/component/gizmo/v1"

--- a/robot/web/web_test.go
+++ b/robot/web/web_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"go.viam.com/rdk/components/audioinput"
-
 	"github.com/edaniels/golog"
 	"github.com/edaniels/gostream/codec/x264"
 	streampb "github.com/edaniels/gostream/proto/stream/v1"

--- a/robot/web/web_test.go
+++ b/robot/web/web_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
+	"go.viam.com/rdk/components/audioinput"
 	"net"
 	"testing"
 	"time"
@@ -661,6 +662,7 @@ func TestWebWithStreams(t *testing.T) {
 	const (
 		camera1Key = "camera1"
 		camera2Key = "camera2"
+		audioKey   = "audio"
 	)
 
 	// Start a robot with a camera
@@ -699,12 +701,21 @@ func TestWebWithStreams(t *testing.T) {
 	err = updateable.Update(context.Background(), rs)
 	test.That(t, err, test.ShouldBeNil)
 
+	// Add an audio stream
+	audio := &inject.AudioInput{}
+	rs[audioinput.Named(audioKey)] = audio
+	robot.MockResourcesFromMap(rs)
+	updateable, ok = svc.(resource.Updateable)
+	test.That(t, ok, test.ShouldBeTrue)
+	err = updateable.Update(context.Background(), rs)
+	test.That(t, err, test.ShouldBeNil)
+
 	// Test that new streams are available
 	resp, err = streamClient.ListStreams(ctx, &streampb.ListStreamsRequest{})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, resp.Names, test.ShouldContain, camera1Key)
 	test.That(t, resp.Names, test.ShouldContain, camera2Key)
-	test.That(t, resp.Names, test.ShouldHaveLength, 2)
+	test.That(t, resp.Names, test.ShouldHaveLength, 3)
 
 	// We need to cancel otherwise we are stuck waiting for WebRTC to start streaming.
 	cancel()

--- a/robot/web/web_test.go
+++ b/robot/web/web_test.go
@@ -61,7 +61,7 @@ func TestWebStart(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	ctx, injectRobot := setupRobotCtx(t)
 
-	svc := web.New(ctx, injectRobot, logger)
+	svc := web.New(injectRobot, logger)
 
 	options, _, addr := robottestutils.CreateBaseOptionsAndListener(t)
 
@@ -89,7 +89,7 @@ func TestModule(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	ctx, injectRobot := setupRobotCtx(t)
 
-	svc := web.New(ctx, injectRobot, logger)
+	svc := web.New(injectRobot, logger)
 
 	err := svc.StartModule(ctx)
 	test.That(t, err, test.ShouldBeNil)
@@ -142,7 +142,7 @@ func TestWebStartOptions(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	ctx, injectRobot := setupRobotCtx(t)
 
-	svc := web.New(ctx, injectRobot, logger)
+	svc := web.New(injectRobot, logger)
 
 	options, _, addr := robottestutils.CreateBaseOptionsAndListener(t)
 
@@ -183,7 +183,7 @@ func TestWebWithAuth(t *testing.T) {
 		{Case: "managed and specific host", Managed: true, EntityName: "something-different"},
 	} {
 		t.Run(tc.Case, func(t *testing.T) {
-			svc := web.New(ctx, injectRobot, logger)
+			svc := web.New(injectRobot, logger)
 
 			keyset := jwk.NewSet()
 			privKeyForWebAuth, err := rsa.GenerateKey(rand.Reader, 4096)
@@ -368,7 +368,7 @@ func TestWebWithTLSAuth(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	ctx, injectRobot := setupRobotCtx(t)
 
-	svc := web.New(ctx, injectRobot, logger)
+	svc := web.New(injectRobot, logger)
 
 	altName := primitive.NewObjectID().Hex()
 	cert, _, _, certPool, err := testutils.GenerateSelfSignedCertificate("somename", altName)
@@ -523,7 +523,7 @@ func TestWebWithBadAuthHandlers(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	ctx, injectRobot := setupRobotCtx(t)
 
-	svc := web.New(ctx, injectRobot, logger)
+	svc := web.New(injectRobot, logger)
 
 	options, _, _ := robottestutils.CreateBaseOptionsAndListener(t)
 	options.Auth.Handlers = []config.AuthHandlerConfig{
@@ -538,7 +538,7 @@ func TestWebWithBadAuthHandlers(t *testing.T) {
 	test.That(t, err.Error(), test.ShouldContainSubstring, "unknown")
 	test.That(t, utils.TryClose(context.Background(), svc), test.ShouldBeNil)
 
-	svc = web.New(ctx, injectRobot, logger)
+	svc = web.New(injectRobot, logger)
 
 	options, _, _ = robottestutils.CreateBaseOptionsAndListener(t)
 	options.Auth.Handlers = []config.AuthHandlerConfig{
@@ -558,7 +558,7 @@ func TestWebUpdate(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	ctx, robot := setupRobotCtx(t)
 
-	svc := web.New(ctx, robot, logger)
+	svc := web.New(robot, logger)
 
 	options, _, addr := robottestutils.CreateBaseOptionsAndListener(t)
 	err := svc.Start(ctx, options)
@@ -604,7 +604,7 @@ func TestWebUpdate(t *testing.T) {
 		return injectArm, nil
 	}
 
-	svc2 := web.New(ctx, robot2, logger)
+	svc2 := web.New(robot2, logger)
 
 	listener := testutils.ReserveRandomListener(t)
 	addr = listener.Addr().String()
@@ -677,7 +677,7 @@ func TestWebWithStreams(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	robot.LoggerFunc = func() golog.Logger { return logger }
 	options, _, addr := robottestutils.CreateBaseOptionsAndListener(t)
-	svc := web.New(ctx, robot, logger, web.WithStreamConfig(x264.DefaultStreamConfig))
+	svc := web.New(robot, logger, web.WithStreamConfig(x264.DefaultStreamConfig))
 	err := svc.Start(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -740,7 +740,7 @@ func TestWebAddFirstStream(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	robot.LoggerFunc = func() golog.Logger { return logger }
 	options, _, addr := robottestutils.CreateBaseOptionsAndListener(t)
-	svc := web.New(ctx, robot, logger, web.WithStreamConfig(x264.DefaultStreamConfig))
+	svc := web.New(robot, logger, web.WithStreamConfig(x264.DefaultStreamConfig))
 	err := svc.Start(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -802,7 +802,7 @@ func TestForeignResource(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	ctx, robot := setupRobotCtx(t)
 
-	svc := web.New(ctx, robot, logger)
+	svc := web.New(robot, logger)
 
 	options, _, addr := robottestutils.CreateBaseOptionsAndListener(t)
 	err := svc.Start(ctx, options)
@@ -859,7 +859,7 @@ func TestForeignResource(t *testing.T) {
 	listener := testutils.ReserveRandomListener(t)
 	addr = listener.Addr().String()
 	options.Network.Listener = listener
-	svc = web.New(ctx, injectRobot, logger)
+	svc = web.New(injectRobot, logger)
 	err = svc.Start(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -930,7 +930,7 @@ func TestRawClientOperation(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	ctx, iRobot := setupRobotCtx(t)
 
-	svc := web.New(ctx, iRobot, logger)
+	svc := web.New(iRobot, logger)
 
 	options, _, addr := robottestutils.CreateBaseOptionsAndListener(t)
 	err := svc.Start(ctx, options)
@@ -995,7 +995,7 @@ func TestInboundMethodTimeout(t *testing.T) {
 
 	t.Run("web start", func(t *testing.T) {
 		t.Run("default timeout", func(t *testing.T) {
-			svc := web.New(ctx, iRobot, logger)
+			svc := web.New(iRobot, logger)
 			options, _, addr := robottestutils.CreateBaseOptionsAndListener(t)
 
 			err := svc.Start(ctx, options)
@@ -1029,7 +1029,7 @@ func TestInboundMethodTimeout(t *testing.T) {
 			test.That(t, utils.TryClose(ctx, svc), test.ShouldBeNil)
 		})
 		t.Run("overridden timeout", func(t *testing.T) {
-			svc := web.New(ctx, iRobot, logger)
+			svc := web.New(iRobot, logger)
 			options, _, addr := robottestutils.CreateBaseOptionsAndListener(t)
 
 			err := svc.Start(ctx, options)
@@ -1066,7 +1066,7 @@ func TestInboundMethodTimeout(t *testing.T) {
 	})
 	t.Run("module start", func(t *testing.T) {
 		t.Run("default timeout", func(t *testing.T) {
-			svc := web.New(ctx, iRobot, logger)
+			svc := web.New(iRobot, logger)
 
 			err := svc.StartModule(ctx)
 			test.That(t, err, test.ShouldBeNil)
@@ -1099,7 +1099,7 @@ func TestInboundMethodTimeout(t *testing.T) {
 			test.That(t, utils.TryClose(ctx, svc), test.ShouldBeNil)
 		})
 		t.Run("overridden timeout", func(t *testing.T) {
-			svc := web.New(ctx, iRobot, logger)
+			svc := web.New(iRobot, logger)
 
 			err := svc.StartModule(ctx)
 			test.That(t, err, test.ShouldBeNil)

--- a/testutils/inject/audioinput.go
+++ b/testutils/inject/audioinput.go
@@ -3,7 +3,6 @@ package inject
 import (
 	"context"
 
-
 	"github.com/edaniels/gostream"
 	"github.com/pion/mediadevices/pkg/prop"
 	"github.com/pkg/errors"

--- a/testutils/inject/audioinput.go
+++ b/testutils/inject/audioinput.go
@@ -3,8 +3,10 @@ package inject
 import (
 	"context"
 
+
 	"github.com/edaniels/gostream"
 	"github.com/pion/mediadevices/pkg/prop"
+	"github.com/pkg/errors"
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/audioinput"
@@ -41,7 +43,7 @@ func (ai *AudioInput) MediaProperties(ctx context.Context) (prop.Audio, error) {
 	if ai.AudioInput != nil {
 		return ai.AudioInput.MediaProperties(ctx)
 	}
-	return prop.Audio{}, ctx.Err()
+	return prop.Audio{}, errors.Wrap(ctx.Err(), "media properties unavailable")
 }
 
 // Close calls the injected Close or the real version.

--- a/testutils/inject/audioinput.go
+++ b/testutils/inject/audioinput.go
@@ -35,10 +35,13 @@ func (ai *AudioInput) Stream(
 
 // MediaProperties calls the injected MediaProperties or the real version.
 func (ai *AudioInput) MediaProperties(ctx context.Context) (prop.Audio, error) {
-	if ai.MediaPropertiesFunc == nil {
+	if ai.MediaPropertiesFunc != nil {
+		return ai.MediaPropertiesFunc(ctx)
+	}
+	if ai.AudioInput != nil {
 		return ai.AudioInput.MediaProperties(ctx)
 	}
-	return ai.MediaPropertiesFunc(ctx)
+	return prop.Audio{}, ctx.Err()
 }
 
 // Close calls the injected Close or the real version.

--- a/testutils/inject/camera.go
+++ b/testutils/inject/camera.go
@@ -2,7 +2,9 @@ package inject
 
 import (
 	"context"
+
 	"github.com/edaniels/gostream"
+	"github.com/pkg/errors"
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/camera"
@@ -43,7 +45,7 @@ func (c *Camera) Stream(
 	if c.Camera != nil {
 		return c.Camera.Stream(ctx, errHandlers...)
 	}
-	return nil, ctx.Err()
+	return nil, errors.Wrap(ctx.Err(), "no stream function available")
 }
 
 // Projector calls the injected Projector or the real version.

--- a/testutils/inject/camera.go
+++ b/testutils/inject/camera.go
@@ -2,7 +2,6 @@ package inject
 
 import (
 	"context"
-
 	"github.com/edaniels/gostream"
 	"go.viam.com/utils"
 
@@ -38,10 +37,13 @@ func (c *Camera) Stream(
 	ctx context.Context,
 	errHandlers ...gostream.ErrorHandler,
 ) (gostream.VideoStream, error) {
-	if c.StreamFunc == nil {
+	if c.StreamFunc != nil {
+		return c.StreamFunc(ctx, errHandlers...)
+	}
+	if c.Camera != nil {
 		return c.Camera.Stream(ctx, errHandlers...)
 	}
-	return c.StreamFunc(ctx, errHandlers...)
+	return nil, ctx.Err()
 }
 
 // Projector calls the injected Projector or the real version.


### PR DESCRIPTION
This PR fixes two deadlocks in with `webService`. To reproduce, 

1. start the viam-server with an empty config
2. add a webcam component
3. remove the webcam component and observe the indefinite hang.

This happens because ` webService.startStream` adds to `webstream.activeBackgroundWorkers` but its argument `streamFunc` cannot be canceled with `webService.cancelFunc`. Because of this, a call to `webService.Close` or `webService.Stop` will hang indefinitely.