### PR TITLE
[DATA-1200] Don't log context cancellation errors in collectors or sync.Manager if they occur after Close().

### DIFF
--- a/data/collector.go
+++ b/data/collector.go
@@ -82,7 +82,7 @@ func (c *collector) Flush() {
 	}
 }
 
-// Collect starts the Collector, causing it to run c.capturer.Capture every c.interval, and writeCaptureResults the results to
+// Collect starts the Collector, causing it to run c.capturer.Capture every c.interval, and write the results to
 // c.target. It blocks until the underlying capture goroutine starts.
 func (c *collector) Collect() {
 	_, span := trace.StartSpan(c.cancelCtx, "data::collector::Collect")
@@ -98,7 +98,7 @@ func (c *collector) Collect() {
 	utils.PanicCapturingGo(func() {
 		defer c.captureWorkers.Done()
 		if err := c.writeCaptureResults(); err != nil {
-			c.captureErrors <- errors.Wrap(err, fmt.Sprintf("failed to writeCaptureResults to collector %s", c.target.Path()))
+			c.captureErrors <- errors.Wrap(err, fmt.Sprintf("failed to write to collector %s", c.target.Path()))
 		}
 	})
 	c.logRoutine.Add(1)
@@ -274,7 +274,7 @@ func (c *collector) writeCaptureResults() error {
 func (c *collector) logCaptureErrs() {
 	for err := range c.captureErrors {
 		if c.closed.Load() {
-			// Don't logCaptureErrs context cancellation errors if the collector has already been closed. This means the collector
+			// Don't log context cancellation errors if the collector has already been closed. This means the collector
 			// cancelled the context, and the context cancellation error is expected.
 			if errors.Is(err, context.Canceled) {
 				continue

--- a/data/collector.go
+++ b/data/collector.go
@@ -66,7 +66,7 @@ func (c *collector) Close() {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	if err := c.target.Flush(); err != nil {
-		c.logger.Errorw("failed to flush capture captureResults", "error", err)
+		c.logger.Errorw("failed to flush capture data", "error", err)
 	}
 	close(c.captureErrors)
 	c.logRoutine.Wait()

--- a/data/collector.go
+++ b/data/collector.go
@@ -78,7 +78,7 @@ func (c *collector) Flush() {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	if err := c.target.Flush(); err != nil {
-		c.captureErrors <- errors.Wrap(err, "failed to flush collector")
+		c.logger.Errorw("failed to flush collector", "error", err)
 	}
 }
 
@@ -262,7 +262,6 @@ func NewCollector(captureFunc CaptureFunc, params CollectorParams) (Collector, e
 	}, nil
 }
 
-// TODO: We should ave this for errors coming from getAndpush, too.
 func (c *collector) write() error {
 	for msg := range c.captureResults {
 		if err := c.target.Write(msg); err != nil {

--- a/data/collector.go
+++ b/data/collector.go
@@ -262,7 +262,7 @@ func NewCollector(captureFunc CaptureFunc, params CollectorParams) (Collector, e
 	}, nil
 }
 
-// TODO: We should ave this for errors coming from getAndpush, too
+// TODO: We should ave this for errors coming from getAndpush, too.
 func (c *collector) write() error {
 	for msg := range c.queue {
 		if err := c.target.Write(msg); err != nil {
@@ -283,7 +283,6 @@ func (c *collector) log() {
 		}
 		c.logger.Error(err)
 	}
-	return
 }
 
 // InvalidInterfaceErr is the error describing when an interface not conforming to the expected resource.Subtype was

--- a/data/collector_test.go
+++ b/data/collector_test.go
@@ -291,7 +291,7 @@ func validateReadings(t *testing.T, act []*v1.SensorData, n int) {
 	}
 }
 
-// nolint
+//nolint
 func getAllFiles(dir string) []os.FileInfo {
 	var files []os.FileInfo
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/data/collector_test.go
+++ b/data/collector_test.go
@@ -240,7 +240,7 @@ func TestClose(t *testing.T) {
 	select {
 	case <-ctx.Done():
 	case <-wrote:
-		t.Fatalf("unexpected write after close")
+		t.Fatalf("unexpected writeCaptureResults after close")
 	}
 }
 
@@ -291,7 +291,7 @@ func validateReadings(t *testing.T, act []*v1.SensorData, n int) {
 	}
 }
 
-//nolint
+// nolint
 func getAllFiles(dir string) []os.FileInfo {
 	var files []os.FileInfo
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/data/collector_test.go
+++ b/data/collector_test.go
@@ -244,7 +244,7 @@ func TestClose(t *testing.T) {
 	}
 }
 
-// TestCtxCancelledNotLoggedafterClose verifies that context cancelled errors are not logged if they occur after Close
+// TestCtxCancelledNotLoggedAfterClose verifies that context cancelled errors are not logged if they occur after Close
 // has been called. The collector context is cancelled as part of Close, so we expect to see context cancelled errors
 // for any running capture routines.
 func TestCtxCancelledNotLoggedAfterClose(t *testing.T) {

--- a/data/collector_test.go
+++ b/data/collector_test.go
@@ -289,7 +289,7 @@ func validateReadings(t *testing.T, act []*v1.SensorData, n int) {
 	}
 }
 
-// nolint
+//nolint
 func getAllFiles(dir string) []os.FileInfo {
 	var files []os.FileInfo
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/data/collector_test.go
+++ b/data/collector_test.go
@@ -247,7 +247,7 @@ func TestClose(t *testing.T) {
 // TestCtxCancelledNotLoggedafterClose verifies that context cancelled errors are not logged if they occur after Close
 // has been called. The collector context is cancelled as part of Close, so we expect to see context cancelled errors
 // for any running capture routines.
-func TestCtxCancelledNotLoggedafterClose(t *testing.T) {
+func TestCtxCancelledNotLoggedAfterClose(t *testing.T) {
 	logger, logs := golog.NewObservedTestLogger(t)
 	tmpDir := t.TempDir()
 	target := datacapture.NewBuffer(tmpDir, &v1.DataCaptureMetadata{})

--- a/data/collector_test.go
+++ b/data/collector_test.go
@@ -244,8 +244,10 @@ func TestClose(t *testing.T) {
 	}
 }
 
-// TestCtxCancelledLoggedAsDebug verifies that context cancelled errors are logged as debug level instead of as errors.
-func TestCtxCancelledLoggedAsDebug(t *testing.T) {
+// TestCtxCancelledNotLoggedafterClose verifies that context cancelled errors are not logged if they occur after Close
+// has been called. The collector context is cancelled as part of Close, so we expect to see context cancelled errors
+// for any running capture routines.
+func TestCtxCancelledNotLoggedafterClose(t *testing.T) {
 	logger, logs := golog.NewObservedTestLogger(t)
 	tmpDir := t.TempDir()
 	target := datacapture.NewBuffer(tmpDir, &v1.DataCaptureMetadata{})
@@ -289,7 +291,7 @@ func validateReadings(t *testing.T, act []*v1.SensorData, n int) {
 	}
 }
 
-//nolint
+// nolint
 func getAllFiles(dir string) []os.FileInfo {
 	var files []os.FileInfo
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/data/collector_test.go
+++ b/data/collector_test.go
@@ -240,7 +240,7 @@ func TestClose(t *testing.T) {
 	select {
 	case <-ctx.Done():
 	case <-wrote:
-		t.Fatalf("unexpected writeCaptureResults after close")
+		t.Fatalf("unexpected write after close")
 	}
 }
 
@@ -291,7 +291,7 @@ func validateReadings(t *testing.T, act []*v1.SensorData, n int) {
 	}
 }
 
-// nolint
+//nolint
 func getAllFiles(dir string) []os.FileInfo {
 	var files []os.FileInfo
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -130,7 +130,7 @@ func TestSyncEnabled(t *testing.T) {
 func TestDataCaptureUpload(t *testing.T) {
 	datacapture.MaxFileSize = 500
 	// Set exponential factor to 1 and retry wait time to 20ms so retries happen very quickly.
-	datasync.RetryExponentialFactor.Store(int32(1))
+	datasync.RetryExponentialFactor.Store(int32(2))
 	datasync.InitialWaitTimeMillis.Store(int32(20))
 	captureTime := time.Millisecond * 300
 
@@ -168,6 +168,8 @@ func TestDataCaptureUpload(t *testing.T) {
 			dataType:   v1.DataType_DATA_TYPE_TABULAR_SENSOR,
 			manualSync: true,
 		},
+		// TODO: this is deadlocking. I think because we get >100 failures really quickly. We shouldn't deadlock when
+		// the error queue is full.
 		{
 			name:          "If tabular sync fails part way through, it should be resumed without duplicate uploads",
 			dataType:      v1.DataType_DATA_TYPE_TABULAR_SENSOR,

--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -168,8 +168,6 @@ func TestDataCaptureUpload(t *testing.T) {
 			dataType:   v1.DataType_DATA_TYPE_TABULAR_SENSOR,
 			manualSync: true,
 		},
-		// TODO: this is deadlocking. I think because we get >100 failures really quickly. We shouldn't deadlock when
-		// the error queue is full.
 		{
 			name:          "If tabular sync fails part way through, it should be resumed without duplicate uploads",
 			dataType:      v1.DataType_DATA_TYPE_TABULAR_SENSOR,

--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -130,7 +130,7 @@ func TestSyncEnabled(t *testing.T) {
 func TestDataCaptureUpload(t *testing.T) {
 	datacapture.MaxFileSize = 500
 	// Set exponential factor to 1 and retry wait time to 20ms so retries happen very quickly.
-	datasync.RetryExponentialFactor.Store(int32(2))
+	datasync.RetryExponentialFactor.Store(int32(1))
 	datasync.InitialWaitTimeMillis.Store(int32(20))
 	captureTime := time.Millisecond * 300
 

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -33,8 +33,6 @@ var (
 	maxRetryInterval       = time.Hour
 )
 
-// TODO: Goal: don't log cancel if cancelled because Manager was closed
-
 // Manager is responsible for enqueuing files in captureDir and uploading them to the cloud.
 type Manager interface {
 	SyncDirectory(dir string)
@@ -133,7 +131,6 @@ func (s *syncer) Close() {
 			s.logger.Errorw("error closing datasync server connection", "error", err)
 		}
 	}
-	// TODO: this is waiting for the syncErrs channel to be drained, but it's not being drained
 	s.backgroundWorkers.Wait()
 	close(s.syncErrs)
 	s.logRoutine.Wait()
@@ -190,7 +187,6 @@ func (s *syncer) syncDataCaptureFile(f *datacapture.File) {
 		func(ctx context.Context) error {
 			err := uploadDataCaptureFile(ctx, s.client, f, s.partID)
 			if err != nil {
-				// TODO: All the routines are blocking here
 				s.syncErrs <- errors.Wrap(err, fmt.Sprintf("error uploading file %s", f.GetPath()))
 			}
 			return err

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -256,7 +256,6 @@ func (s *syncer) log() {
 		}
 		s.logger.Error(err)
 	}
-	return
 }
 
 // exponentialRetry calls fn and retries with exponentially increasing waits from initialWait to a

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -249,7 +249,7 @@ func (s *syncer) log() {
 		if s.closed.Load() {
 			// Don't log context cancellation errors if the Manager has already been closed. This means the Manager
 			// cancelled the context, and the context cancellation error is expected.
-			if errors.Is(err, context.Canceled) || strings.Contains(err.Error(), context.Canceled.Error()) {
+			if strings.Contains(err.Error(), context.Canceled.Error()) {
 				continue
 			}
 		}
@@ -310,7 +310,7 @@ func getNextWait(lastWait time.Duration) time.Duration {
 	return nextWait
 }
 
-//nolint
+// nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -311,7 +311,7 @@ func getNextWait(lastWait time.Duration) time.Duration {
 	return nextWait
 }
 
-// nolint
+//nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -132,6 +132,7 @@ func (s *syncer) Close() {
 	s.backgroundWorkers.Wait()
 	close(s.syncErrs)
 	s.logRoutine.Wait()
+	goutils.UncheckedError(s.logger.Sync())
 }
 
 func (s *syncer) SyncDirectory(dir string) {
@@ -310,7 +311,7 @@ func getNextWait(lastWait time.Duration) time.Duration {
 	return nextWait
 }
 
-//nolint
+// nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -108,8 +108,7 @@ func NewManager(logger golog.Logger, partID string, client v1.DataSyncServiceCli
 		progressLock:       &sync.Mutex{},
 		inProgress:         make(map[string]bool),
 
-		// TODO: channel size?
-		syncErrs:   make(chan error, 100),
+		syncErrs:   make(chan error, 10),
 		closed:     &atomic.Bool{},
 		logRoutine: sync.WaitGroup{},
 	}

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -33,6 +33,8 @@ var (
 	maxRetryInterval       = time.Hour
 )
 
+// TODO: Goal: don't log cancel if cancelled because Manager was closed
+
 // Manager is responsible for enqueuing files in captureDir and uploading them to the cloud.
 type Manager interface {
 	SyncDirectory(dir string)
@@ -293,7 +295,7 @@ func getNextWait(lastWait time.Duration) time.Duration {
 	return nextWait
 }
 
-//nolint
+// nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -115,7 +115,7 @@ func NewManager(logger golog.Logger, partID string, client v1.DataSyncServiceCli
 	ret.logRoutine.Add(1)
 	goutils.PanicCapturingGo(func() {
 		defer ret.logRoutine.Done()
-		ret.log()
+		ret.logSyncErrs()
 	})
 	return &ret, nil
 }
@@ -151,7 +151,7 @@ func (s *syncer) SyncDirectory(dir string) {
 				//nolint:gosec
 				f, err := os.Open(newP)
 				if err != nil {
-					// Don't log if the file does not exist, because that means it was successfully synced and deleted
+					// Don't logSyncErrs if the file does not exist, because that means it was successfully synced and deleted
 					// in between paths being built and this executing.
 					if !errors.Is(err, os.ErrNotExist) {
 						s.syncErrs <- errors.Wrap(err, "error opening file")
@@ -244,10 +244,10 @@ func (s *syncer) unmarkInProgress(path string) {
 	delete(s.inProgress, path)
 }
 
-func (s *syncer) log() {
+func (s *syncer) logSyncErrs() {
 	for err := range s.syncErrs {
 		if s.closed.Load() {
-			// Don't log context cancellation errors if the Manager has already been closed. This means the Manager
+			// Don't logSyncErrs context cancellation errors if the Manager has already been closed. This means the Manager
 			// cancelled the context, and the context cancellation error is expected.
 			if strings.Contains(err.Error(), context.Canceled.Error()) {
 				continue
@@ -310,7 +310,7 @@ func getNextWait(lastWait time.Duration) time.Duration {
 	return nextWait
 }
 
-//nolint
+// nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -310,7 +310,7 @@ func getNextWait(lastWait time.Duration) time.Duration {
 	return nextWait
 }
 
-// nolint
+//nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -248,7 +248,7 @@ func (s *syncer) unmarkInProgress(path string) {
 func (s *syncer) log() {
 	for err := range s.syncErrs {
 		if s.closed.Load() {
-			// Don't log context cancellation errors if the collector has already been closed. This means the collector
+			// Don't log context cancellation errors if the Manager has already been closed. This means the Manager
 			// cancelled the context, and the context cancellation error is expected.
 			if errors.Is(err, context.Canceled) || strings.Contains(err.Error(), context.Canceled.Error()) {
 				continue
@@ -311,7 +311,7 @@ func getNextWait(lastWait time.Duration) time.Duration {
 	return nextWait
 }
 
-//nolint
+// nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -151,7 +151,7 @@ func (s *syncer) SyncDirectory(dir string) {
 				//nolint:gosec
 				f, err := os.Open(newP)
 				if err != nil {
-					// Don't logSyncErrs if the file does not exist, because that means it was successfully synced and deleted
+					// Don't log if the file does not exist, because that means it was successfully synced and deleted
 					// in between paths being built and this executing.
 					if !errors.Is(err, os.ErrNotExist) {
 						s.syncErrs <- errors.Wrap(err, "error opening file")
@@ -247,7 +247,7 @@ func (s *syncer) unmarkInProgress(path string) {
 func (s *syncer) logSyncErrs() {
 	for err := range s.syncErrs {
 		if s.closed.Load() {
-			// Don't logSyncErrs context cancellation errors if the Manager has already been closed. This means the Manager
+			// Don't log context cancellation errors if the Manager has already been closed. This means the Manager
 			// cancelled the context, and the context cancellation error is expected.
 			if strings.Contains(err.Error(), context.Canceled.Error()) {
 				continue
@@ -310,7 +310,7 @@ func getNextWait(lastWait time.Duration) time.Duration {
 	return nextWait
 }
 
-// nolint
+//nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -123,7 +123,6 @@ func NewManager(logger golog.Logger, partID string, client v1.DataSyncServiceCli
 // Close closes all resources (goroutines) associated with s.
 func (s *syncer) Close() {
 	s.closed.Store(true)
-
 	s.cancelFunc()
 	if s.conn != nil {
 		if err := s.conn.Close(); err != nil {
@@ -311,7 +310,7 @@ func getNextWait(lastWait time.Duration) time.Duration {
 	return nextWait
 }
 
-// nolint
+//nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -116,10 +116,10 @@ func NewManager(logger golog.Logger, partID string, client v1.DataSyncServiceCli
 		logRoutine: sync.WaitGroup{},
 	}
 	ret.logRoutine.Add(1)
-	go func() {
+	goutils.PanicCapturingGo(func() {
 		defer ret.logRoutine.Done()
 		ret.log()
-	}()
+	})
 	return &ret, nil
 }
 


### PR DESCRIPTION
# Summary
Previously, both `Collectors` and `sync.Managers` would log context.Cancelled errors, even if the contexts were intentionally cancelled by the `Collector`/`sync.Manager` (i.e. their `Close()` functions were called, cancelling the parent context of all of their sub-capture/sync routines). This led to spammy logging of behavior that isn't a true error.

This fixes that: in both `Collectors` and `sync.Managers`, we ignore/don't log context.Cancellation errors that occur after `Close()` has been called.

[Ticket](https://viam.atlassian.net/browse/DATA-1200).

# Testing

TestCtxCancelledNotLoggedafterClose validates that collector's don't log Error level logs when the context is cancelled. It is passing. Note that the Collector logger doesn't log non-Error level logs anywhere.

For sync, I ran updated `mockDataSyncServiceServer.DataCaptureUpload` to sleep for one minute, then ran `TestDataCaptureUpload/Previously_captured_tabular_data_should_be_synced_at_start_up`, and added a print statement to the `sync.go` line where context.Cancelled error logs are skipped. This test closes the datamanager service (and so the sync.Manager) after <1s, ensuring that the context is cancelledby the `sync.Manager` during ongoing `DataCaptureUpload` calls. This confirmed nothing was logged, and that the skip line was reached.