### PR TITLE
[RSDK-1868] Skip sync tests for now.

### DIFF
--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -33,6 +33,7 @@ var (
 // TODO DATA-849: Add a test that validates that sync interval is accurately respected.
 
 func TestSyncEnabled(t *testing.T) {
+	t.Skip()
 	tests := []struct {
 		name                        string
 		initialServiceDisableStatus bool
@@ -128,6 +129,7 @@ func TestSyncEnabled(t *testing.T) {
 
 // TODO DATA-849: Test concurrent capture and sync more thoroughly.
 func TestDataCaptureUpload(t *testing.T) {
+	t.Skip()
 	datacapture.MaxFileSize = 500
 	// Set exponential factor to 1 and retry wait time to 20ms so retries happen very quickly.
 	datasync.RetryExponentialFactor.Store(int32(1))


### PR DESCRIPTION
Skipping these two sync tests for now because they're non-deterministic and being flaky in CI. Will put out a PR with a fix by EOD.