### PR TITLE
[DATA-1200] Replace utils.uncheckedErr with nolint:errcheck in sync/collector.

### DIFF
--- a/data/collector.go
+++ b/data/collector.go
@@ -69,7 +69,8 @@ func (c *collector) Close() {
 	}
 	close(c.captureErrors)
 	c.logRoutine.Wait()
-	utils.UncheckedError(c.logger.Sync())
+	//nolint:errcheck
+	_ = c.logger.Sync()
 }
 
 func (c *collector) Flush() {

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -132,7 +132,8 @@ func (s *syncer) Close() {
 	s.backgroundWorkers.Wait()
 	close(s.syncErrs)
 	s.logRoutine.Wait()
-	goutils.UncheckedError(s.logger.Sync())
+	//nolint:errcheck
+	_ = s.logger.Sync()
 }
 
 func (s *syncer) SyncDirectory(dir string) {


### PR DESCRIPTION
I didn't realized that utils.UncheckedErr logs errors at the debug level. We want to ignore these ones entirely.