### PR TITLE
APP-1428: Use digital interrupt name instead of board name

### DIFF
--- a/web/frontend/src/components/board.vue
+++ b/web/frontend/src/components/board.vue
@@ -112,7 +112,7 @@ const setPWMFrequency = async () => {
           :key="interruptName"
         >
           <th class="border border-black p-2">
-            {{ name }}
+            {{ interruptName }}
           </th>
           <td class="border border-black p-2">
             {{ di.value || 0 }}


### PR DESCRIPTION
**20230322_APP-1428: Use digital interrupt name instead of board name**

- Uses digital interrupt name instead of board name in the digital interrupts section of the board component.