### PR TITLE
[DATA-1255] Use base64.StdEncoding on the crc32 hash on deployed files

### DIFF
--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -353,10 +353,10 @@ func (m *cloudManager) downloadFileFromGCSURL(ctx context.Context, url string, p
 		return checksum, contentType, err
 	}
 
-	outHash := base64.URLEncoding.EncodeToString(hash.Sum(nil))
+	outHash := base64.StdEncoding.EncodeToString(hash.Sum(nil))
 	if outHash != checksum {
 		utils.UncheckedError(os.Remove(downloadPath))
-		return checksum, contentType, errors.Errorf("download did not match expected hash %s != %s", outHash, checksum)
+		return checksum, contentType, errors.Errorf("download did not match expected hash %s != %s", checksum, outHash)
 	}
 
 	return checksum, contentType, nil

--- a/robot/packages/testutils/fake_package_server.go
+++ b/robot/packages/testutils/fake_package_server.go
@@ -336,10 +336,10 @@ func ValidateContentsOfPPackage(t *testing.T, dir string) {
 
 	expected := []content{
 		{path: "some-link.txt", isLink: true, linkTarget: "sub-dir/sub-file.txt"},
-		{path: "some-text.txt", checksum: "p_E54w=="},
-		{path: "some-text2.txt", checksum: "p_E54w=="},
+		{path: "some-text.txt", checksum: "p/E54w=="},
+		{path: "some-text2.txt", checksum: "p/E54w=="},
 		{path: "sub-dir", isDir: true},
-		{path: "sub-dir/sub-file.txt", checksum: "p_E54w=="},
+		{path: "sub-dir/sub-file.txt", checksum: "p/E54w=="},
 		{path: "sub-dir-link", isLink: true, linkTarget: "sub-dir"},
 	}
 
@@ -394,7 +394,7 @@ func checksumFile(path string) (string, error) {
 		return "", err
 	}
 
-	return base64.URLEncoding.EncodeToString(hasher.Sum(nil)), nil
+	return base64.StdEncoding.EncodeToString(hasher.Sum(nil)), nil
 }
 
 func crc32Hash() hash.Hash32 {


### PR DESCRIPTION
We were getting issues with some files having off-by-one calculated checksum values from the ones provided from the URL response header. The sums were the same, but the base64's were different. We should be using base64.StdEncoding rather than base64.URLEncoding, which is reserved for URLs and filenames.

**Testing**
Tested that existing packages uploaded to app still deploy correctly using this local RDK.