### PR TITLE
bugfix for ina219: defer closing the I2C handle

### DIFF
--- a/components/sensor/power_ina219/power_ina219.go
+++ b/components/sensor/power_ina219/power_ina219.go
@@ -166,7 +166,7 @@ func (d *ina219) Readings(ctx context.Context, extra map[string]interface{}) (ma
 		d.logger.Errorf("can't open ina219 i2c: %s", err)
 		return nil, err
 	}
-	defer utils.UncheckedError(handle.Close())
+	defer utils.UncheckedErrorFunc(handle.Close)
 
 	// use the calibration result to set the scaling factor
 	// of the current and power registers for the maximum resolution


### PR DESCRIPTION
This should fix the troubles Matt encountered with being unable to read the sensor from Viam's code while being able to read it from non-Viam code and being able to read other I2C devices from Viam.

Defer statements are unintuitive for me: the function being deferred runs at the end, but the arguments to the function are evaluated immediately. Consequently, we were closing the I2C handle immediately, and then just deferring the check of whether it closed successfully. 