### PR TITLE
Only compile hw_pwm.go on Linux; it's unused on Mac

### DIFF
--- a/components/board/genericlinux/hw_pwm.go
+++ b/components/board/genericlinux/hw_pwm.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 // Package genericlinux is for Linux boards. This particular file is for using sysfs to
 // interact with PWM devices. All of these functions are idempotent: you can double-export a pin or
 // double-close it with no problems.


### PR DESCRIPTION
Hopefully this will get @randhid unstuck. I wish we had a CI check that made sure things worked on Mac!