### PR TITLE
[RSDK-2394] Sort captured data by time, not just the nanosecond field of the timestamp.

### DIFF
--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -519,10 +519,10 @@ func compareSensorData(t *testing.T, dataType v1.DataType, act []*v1.SensorData,
 
 	// Sort both by time requested.
 	sort.Slice(act, func(i, j int) bool {
-		return act[i].GetMetadata().GetTimeRequested().Nanos < act[j].GetMetadata().GetTimeRequested().Nanos
+		return act[i].GetMetadata().GetTimeReceived().Nanos < act[j].GetMetadata().GetTimeReceived().Nanos
 	})
 	sort.Slice(exp, func(i, j int) bool {
-		return exp[i].GetMetadata().GetTimeRequested().Nanos < exp[j].GetMetadata().GetTimeRequested().Nanos
+		return exp[i].GetMetadata().GetTimeReceived().Nanos < exp[j].GetMetadata().GetTimeReceived().Nanos
 	})
 
 	test.That(t, len(act), test.ShouldEqual, len(exp))

--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -518,11 +518,11 @@ func compareSensorData(t *testing.T, dataType v1.DataType, act []*v1.SensorData,
 	}
 
 	// Sort both by time requested.
-	sort.Slice(act, func(i, j int) bool {
-		return act[i].GetMetadata().GetTimeRequested().AsTime().Sub(act[j].GetMetadata().GetTimeRequested().AsTime()) > 0
+	sort.SliceStable(act, func(i, j int) bool {
+		return act[j].GetMetadata().GetTimeRequested().AsTime().Sub(act[i].GetMetadata().GetTimeRequested().AsTime()) > 0
 	})
-	sort.Slice(exp, func(i, j int) bool {
-		return exp[i].GetMetadata().GetTimeRequested().AsTime().Sub(exp[j].GetMetadata().GetTimeRequested().AsTime()) > 0
+	sort.SliceStable(exp, func(i, j int) bool {
+		return exp[j].GetMetadata().GetTimeRequested().AsTime().Sub(exp[i].GetMetadata().GetTimeRequested().AsTime()) > 0
 	})
 
 	test.That(t, len(act), test.ShouldEqual, len(exp))

--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -519,10 +519,10 @@ func compareSensorData(t *testing.T, dataType v1.DataType, act []*v1.SensorData,
 
 	// Sort both by time requested.
 	sort.Slice(act, func(i, j int) bool {
-		return act[i].GetMetadata().GetTimeReceived().Nanos < act[j].GetMetadata().GetTimeReceived().Nanos
+		return act[i].GetMetadata().GetTimeRequested().AsTime().Sub(act[j].GetMetadata().GetTimeRequested().AsTime()) > 0
 	})
 	sort.Slice(exp, func(i, j int) bool {
-		return exp[i].GetMetadata().GetTimeReceived().Nanos < exp[j].GetMetadata().GetTimeReceived().Nanos
+		return exp[i].GetMetadata().GetTimeRequested().AsTime().Sub(exp[j].GetMetadata().GetTimeRequested().AsTime()) > 0
 	})
 
 	test.That(t, len(act), test.ShouldEqual, len(exp))

--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -526,14 +526,14 @@ func compareSensorData(t *testing.T, dataType v1.DataType, act []*v1.SensorData,
 	})
 
 	test.That(t, len(act), test.ShouldEqual, len(exp))
-	if dataType == v1.DataType_DATA_TYPE_TABULAR_SENSOR {
-		for i := range act {
-			test.That(t, act[i].GetMetadata(), test.ShouldResemble, exp[i].GetMetadata())
+
+	for i := range act {
+		act[i].Metadata.TimeReceived = nil
+		exp[i].Metadata.TimeReceived = nil
+		test.That(t, act[i].GetMetadata(), test.ShouldResemble, exp[i].GetMetadata())
+		if dataType == v1.DataType_DATA_TYPE_TABULAR_SENSOR {
 			test.That(t, act[i].GetStruct(), test.ShouldResemble, exp[i].GetStruct())
-		}
-	} else {
-		for i := range act {
-			test.That(t, act[i].GetMetadata(), test.ShouldResemble, exp[i].GetMetadata())
+		} else {
 			test.That(t, act[i].GetBinary(), test.ShouldResemble, exp[i].GetBinary())
 		}
 	}

--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -519,17 +519,29 @@ func compareSensorData(t *testing.T, dataType v1.DataType, act []*v1.SensorData,
 
 	// Sort both by time requested.
 	sort.SliceStable(act, func(i, j int) bool {
-		return act[j].GetMetadata().GetTimeRequested().AsTime().Sub(act[i].GetMetadata().GetTimeRequested().AsTime()) > 0
+		diffRequested := act[j].GetMetadata().GetTimeRequested().AsTime().Sub(act[i].GetMetadata().GetTimeRequested().AsTime())
+		if diffRequested > 0 {
+			return true
+		} else if diffRequested == 0 {
+			return act[j].GetMetadata().GetTimeReceived().AsTime().Sub(act[i].GetMetadata().GetTimeReceived().AsTime()) > 0
+		} else {
+			return false
+		}
 	})
 	sort.SliceStable(exp, func(i, j int) bool {
-		return exp[j].GetMetadata().GetTimeRequested().AsTime().Sub(exp[i].GetMetadata().GetTimeRequested().AsTime()) > 0
+		diffRequested := exp[j].GetMetadata().GetTimeRequested().AsTime().Sub(exp[i].GetMetadata().GetTimeRequested().AsTime())
+		if diffRequested > 0 {
+			return true
+		} else if diffRequested == 0 {
+			return exp[j].GetMetadata().GetTimeReceived().AsTime().Sub(exp[i].GetMetadata().GetTimeReceived().AsTime()) > 0
+		} else {
+			return false
+		}
 	})
 
 	test.That(t, len(act), test.ShouldEqual, len(exp))
 
 	for i := range act {
-		act[i].Metadata.TimeReceived = nil
-		exp[i].Metadata.TimeReceived = nil
 		test.That(t, act[i].GetMetadata(), test.ShouldResemble, exp[i].GetMetadata())
 		if dataType == v1.DataType_DATA_TYPE_TABULAR_SENSOR {
 			test.That(t, act[i].GetStruct(), test.ShouldResemble, exp[i].GetStruct())


### PR DESCRIPTION
We were sorting only by the nano second field. This does not sort things correctly when we roll over to the next second. This fixes that by using time.Sub to compare times. Also changes to use a stable sort. Also changes to use TimeReceived as tiebreaker if time requested are the same.

# Testing
```
builtin$ go test -race -run=TestDataCaptureUploadIntegration --count=1000 --timeout=20m
PASS
ok      go.viam.com/rdk/services/datamanager/builtin    714.245s
```