### PR TITLE
RSDK-2389 Support reconfiguration of modules

### DIFF
--- a/config/data/diff_config_1.json
+++ b/config/data/diff_config_1.json
@@ -1,4 +1,10 @@
 {
+    "modules": [
+        {
+            "name": "my-module",
+            "executable_path": "path/to/my-module"
+        }
+    ],
     "remotes": [
         {
             "name": "remote1",

--- a/config/data/diff_config_2.json
+++ b/config/data/diff_config_2.json
@@ -1,4 +1,10 @@
 {
+    "modules": [
+        {
+            "name": "my-module",
+            "executable_path": "new/path/to/my-module"
+        }
+    ],
     "remotes": [
         {
             "name": "remote1",

--- a/config/diff_test.go
+++ b/config/diff_test.go
@@ -25,6 +25,12 @@ var (
 
 func TestDiffConfigs(t *testing.T) {
 	config1 := config.Config{
+		Modules: []config.Module{
+			{
+				Name:    "my-module",
+				ExePath: "path/to/my-module",
+			},
+		},
 		Remotes: []config.Remote{
 			{
 				Name:    "remote1",
@@ -94,6 +100,12 @@ func TestDiffConfigs(t *testing.T) {
 	}
 
 	config2 := config.ModifiedConfigDiff{
+		Modules: []config.Module{
+			{
+				Name:    "my-module",
+				ExePath: "new/path/to/my-module",
+			},
+		},
 		Remotes: []config.Remote{
 			{
 				Name:    "remote1",
@@ -305,6 +317,12 @@ func TestDiffConfigs(t *testing.T) {
 					},
 				},
 				Removed: &config.Config{
+					Modules: []config.Module{
+						{
+							Name:    "my-module",
+							ExePath: "path/to/my-module",
+						},
+					},
 					Components: []config.Component{
 						{
 							Namespace: resource.ResourceNamespaceRDK,

--- a/module/modmanager/data/simplemoduleruncopy.sh
+++ b/module/modmanager/data/simplemoduleruncopy.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+#
+# simplemoduleruncopy is a copy of examples/customresources/demos/simplemodule/run.sh
+# used to test reconfiguring modules to have new executable paths.
+cd `dirname $0`
+cd ../../../examples/customresources/demos/simplemodule
+
+go build ./
+exec ./simplemodule $@

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -458,8 +458,6 @@ func (m *module) stopProcess() error {
 		return nil
 	})
 
-	// Stop managed process and swallow 143 errors. Some stopped modules may return
-	// "exit status 143" indicating a graceful exit after SIGTERM.
 	if err := m.process.Stop(); err != nil {
 		return err
 	}

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 	pb "go.viam.com/api/module/v1"
+	"go.viam.com/utils"
 	"go.viam.com/utils/pexec"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -28,7 +29,6 @@ import (
 	"go.viam.com/rdk/registry"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot"
-	"go.viam.com/utils"
 )
 
 var validateConfigTimeout = 5 * time.Second

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -161,7 +161,7 @@ func (mgr *Manager) Reconfigure(ctx context.Context, cfg config.Module) error {
 
 // Remove removes and stops an existing resource module.
 func (mgr *Manager) Remove(modName string) error {
-	return mgr.remove(modName, true)
+	return mgr.remove(modName, false)
 }
 
 func (mgr *Manager) remove(modName string, reconfigure bool) error {

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -70,14 +70,9 @@ type Manager struct {
 
 // Close terminates module connections and processes.
 func (mgr *Manager) Close(ctx context.Context) error {
-	mgr.mu.Lock()
-	defer mgr.mu.Unlock()
 	var err error
 	for _, mod := range mgr.modules {
-		if mod.conn != nil {
-			err = multierr.Combine(err, mod.conn.Close())
-		}
-		err = multierr.Combine(err, mod.stopProcess())
+		err = multierr.Combine(err, mgr.remove(mod, false))
 	}
 	return err
 }

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -74,7 +74,7 @@ func TestModManagerFunctions(t *testing.T) {
 	oldConn := mod.conn
 	err = mod.dial(mod.conn)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, mod.conn, test.ShouldResemble, oldConn)
+	test.That(t, mod.conn, test.ShouldEqual, oldConn)
 
 	err = mod.checkReady(ctx, parentAddr)
 	test.That(t, err, test.ShouldBeNil)

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -2,7 +2,6 @@ package modmanager
 
 import (
 	"context"
-	"io"
 	"os"
 	"os/exec"
 	"testing"
@@ -170,26 +169,7 @@ func TestModManagerFunctions(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	// Change underlying binary path of module to be a copy of simplemodule/run.sh.
-	simpleModule, err := os.Open(utils.ResolveFile("examples/customresources/demos/simplemodule/run.sh"))
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		err := simpleModule.Close()
-		test.That(t, err, test.ShouldBeNil)
-	}()
-	simpleModuleCopy, err := os.CreateTemp(
-		utils.ResolveFile("examples/customresources/demos/simplemodule"), "viam-simplemodule-copy-*")
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		err := simpleModuleCopy.Close()
-		test.That(t, err, test.ShouldBeNil)
-		err = os.Remove(simpleModuleCopy.Name())
-		test.That(t, err, test.ShouldBeNil)
-	}()
-	_, err = io.Copy(simpleModuleCopy, simpleModule)
-	test.That(t, err, test.ShouldBeNil)
-	err = os.Chmod(simpleModuleCopy.Name(), 0o777)
-	test.That(t, err, test.ShouldBeNil)
-	modCfg.ExePath = simpleModuleCopy.Name()
+	modCfg.ExePath = utils.ResolveFile("module/modmanager/data/simplemoduleruncopy.sh")
 
 	// Reconfigure module with new ExePath.
 	err = mgr.Reconfigure(ctx, modCfg)

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -172,19 +172,18 @@ func TestModManagerFunctions(t *testing.T) {
 	modCfg.ExePath = utils.ResolveFile("module/modmanager/data/simplemoduleruncopy.sh")
 
 	// Reconfigure module with new ExePath.
-	err = mgr.Reconfigure(ctx, modCfg)
+	orphanedResourceNames, err := mgr.Reconfigure(ctx, modCfg)
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, orphanedResourceNames, test.ShouldBeNil)
 
 	// counter1 should still be provided by reconfigured module.
 	ok = mgr.IsModularResource(rNameCounter1)
 	test.That(t, ok, test.ShouldBeTrue)
-	ret, err = counter.DoCommand(ctx, map[string]interface{}{"command": "get"})
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, ret["total"], test.ShouldEqual, 0)
 
 	t.Log("test RemoveModule")
-	err = mgr.Remove("simple-module")
+	orphanedResourceNames, err = mgr.Remove("simple-module")
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, orphanedResourceNames, test.ShouldResemble, []resource.Name{rNameCounter1})
 
 	ok = mgr.IsModularResource(rNameCounter1)
 	test.That(t, ok, test.ShouldBeFalse)

--- a/module/modmaninterface/interface.go
+++ b/module/modmaninterface/interface.go
@@ -11,8 +11,8 @@ import (
 // ModuleManager abstracts the module manager interface.
 type ModuleManager interface {
 	Add(ctx context.Context, cfg config.Module) error
-	Reconfigure(ctx context.Context, cfg config.Module) error
-	Remove(modName string) error
+	Reconfigure(ctx context.Context, cfg config.Module) ([]resource.Name, error)
+	Remove(modName string) ([]resource.Name, error)
 
 	AddResource(ctx context.Context, cfg config.Component, deps []string) (interface{}, error)
 	ReconfigureResource(ctx context.Context, cfg config.Component, deps []string) error

--- a/module/modmaninterface/interface.go
+++ b/module/modmaninterface/interface.go
@@ -11,6 +11,8 @@ import (
 // ModuleManager abstracts the module manager interface.
 type ModuleManager interface {
 	Add(ctx context.Context, cfg config.Module) error
+	Reconfigure(ctx context.Context, cfg config.Module) error
+	Remove(modName string) error
 
 	AddResource(ctx context.Context, cfg config.Component, deps []string) (interface{}, error)
 	ReconfigureResource(ctx context.Context, cfg config.Component, deps []string) error

--- a/module/module.go
+++ b/module/module.go
@@ -177,7 +177,6 @@ func (m *Module) Start(ctx context.Context) error {
 	m.activeBackgroundWorkers.Add(1)
 	utils.PanicCapturingGo(func() {
 		defer m.activeBackgroundWorkers.Done()
-		defer utils.UncheckedErrorFunc(func() error { return os.Remove(m.addr) })
 		m.logger.Infof("server listening at %v", lis.Addr())
 		if err := m.server.Serve(lis); err != nil {
 			m.logger.Errorf("failed to serve: %v", err)

--- a/module/module.go
+++ b/module/module.go
@@ -178,8 +178,7 @@ func (m *Module) Start(ctx context.Context) error {
 	utils.PanicCapturingGo(func() {
 		defer m.activeBackgroundWorkers.Done()
 		defer utils.UncheckedErrorFunc(func() error {
-			// Attempt to remove module's .sock file if parent did not remove it
-			// already.
+			// Attempt to remove module's .sock file.
 			if _, err := os.Stat(m.addr); err == nil {
 				return os.Remove(m.addr)
 			}

--- a/module/module.go
+++ b/module/module.go
@@ -177,6 +177,14 @@ func (m *Module) Start(ctx context.Context) error {
 	m.activeBackgroundWorkers.Add(1)
 	utils.PanicCapturingGo(func() {
 		defer m.activeBackgroundWorkers.Done()
+		defer utils.UncheckedErrorFunc(func() error {
+			// Attempt to remove module's .sock file if parent did not remove it
+			// already.
+			if _, err := os.Stat(m.addr); err == nil {
+				return os.Remove(m.addr)
+			}
+			return nil
+		})
 		m.logger.Infof("server listening at %v", lis.Addr())
 		if err := m.server.Serve(lis); err != nil {
 			m.logger.Errorf("failed to serve: %v", err)

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -952,9 +952,11 @@ func (r *localRobot) Reconfigure(ctx context.Context, newConfig *config.Config) 
 		allErrs = multierr.Combine(allErrs, err)
 	}
 
+	// Now that we have the new config and all references are resolved, diff it with the old
+	// config to see what has changed.
 	diff, err := config.DiffConfigs(*r.config, *newConfig, r.revealSensitiveConfigDiffs)
 	if err != nil {
-		r.logger.Error("error diffing the configs", "error", err)
+		r.logger.Errorw("error diffing the configs", "error", err)
 		return
 	}
 	if diff.ResourcesEqual {

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -967,9 +967,25 @@ func (r *localRobot) Reconfigure(ctx context.Context, newConfig *config.Config) 
 		r.logger.Debugf("(re)configuring with %+v", diff)
 	}
 
-	if err := r.reconfigureModules(ctx, diff); err != nil {
+	modularOrphanedResourceNames, err := r.reconfigureModules(ctx, diff)
+	if err != nil {
 		r.logger.Error(err)
 		return
+	}
+
+	// Before filtering config, manually add modular orphaned resources (resources
+	// handled by removed modules) to diff.Removed.
+	for _, name := range modularOrphanedResourceNames {
+		for _, c := range newConfig.Components {
+			if c.ResourceName() == name {
+				diff.Removed.Components = append(diff.Removed.Components, c)
+			}
+		}
+		for _, s := range newConfig.Services {
+			if s.ResourceName() == name {
+				diff.Removed.Services = append(diff.Removed.Services, s)
+			}
+		}
 	}
 
 	// First we remove resources and their children that are not in the graph.
@@ -1085,22 +1101,33 @@ func (r *localRobot) checkMaxInstance(subtype resource.Subtype, max int) error {
 }
 
 // reconfigureModules will add, remove and reconfigure modules from the module
-// manager as needed depending on the passed-in config diff.
-func (r *localRobot) reconfigureModules(ctx context.Context, diff *config.Diff) error {
+// manager as needed depending on the passed-in config diff. It will return the
+// names of now orphaned resources.
+func (r *localRobot) reconfigureModules(ctx context.Context,
+	diff *config.Diff,
+) ([]resource.Name, error) {
 	for _, mod := range diff.Added.Modules {
 		if err := r.modules.Add(ctx, mod); err != nil {
-			return errors.Wrapf(err, "error adding module %s ", mod.Name)
+			return nil, errors.Wrapf(err, "error adding module %s ", mod.Name)
 		}
 	}
+
+	var allOrphanedResourceNames []resource.Name
 	for _, mod := range diff.Modified.Modules {
-		if err := r.modules.Reconfigure(ctx, mod); err != nil {
-			return errors.Wrapf(err, "error reconfiguring module %s ", mod.Name)
+		orphanedResourceNames, err := r.modules.Reconfigure(ctx, mod)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error reconfiguring module %s ", mod.Name)
 		}
+		allOrphanedResourceNames = append(allOrphanedResourceNames, orphanedResourceNames...)
 	}
+
 	for _, mod := range diff.Removed.Modules {
-		if err := r.modules.Remove(mod.Name); err != nil {
-			return errors.Wrapf(err, "error removing module %s ", mod.Name)
+		orphanedResourceNames, err := r.modules.Remove(mod.Name)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error removing module %s ", mod.Name)
 		}
+		allOrphanedResourceNames = append(allOrphanedResourceNames, orphanedResourceNames...)
 	}
-	return nil
+
+	return allOrphanedResourceNames, nil
 }


### PR DESCRIPTION
RSDK-2389

Main changes:
- Adds `Reconfigure` to module manager
- Adds `Remove` to module manager
- Refactors module manager to handle reconfiguration
- Adds `diffModules` to make `DiffConfigs` sensitive to changes in `modules` array
- Calls modular `Add`, `Reconfigure` and `Remove` from local robot `Reconfigure` to allow dynamic updates to the config's `modules` array
- Handles resources orphaned by removed/reconfigured modules in `Reconfigure`

Secondary changes:
- Adds test for module manager `Reconfigure`
- Adds test for module manager `Remove`
- Adds test for modular orphaned resources
- Adds test for mixed orphaned resources
- Modifies `TestDiffConfigs` to test module changes
- Adds `nolint:dupl` to some duplicated code