### PR TITLE
RSDK-2350-increase-slam-streaming-chunk-to-1mb

### DIFF
--- a/services/slam/fake/data_loader.go
+++ b/services/slam/fake/data_loader.go
@@ -14,7 +14,7 @@ import (
 	"go.viam.com/rdk/spatialmath"
 )
 
-const chunkSizeBytes = 64 * 1024
+const chunkSizeBytes = 1 * 1024 * 1024
 
 type pose struct {
 	X float64 `json:"x"`


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-2350)