### PR TITLE
RSDK-2253 ignore StreamStatus Unimplemented errors

### DIFF
--- a/robot/server/server.go
+++ b/robot/server/server.go
@@ -6,11 +6,12 @@ package server
 import (
 	"bytes"
 	"context"
-	"google.golang.org/grpc/codes"
-	grpcstatus "google.golang.org/grpc/status"
 	"strings"
 	"sync"
 	"time"
+
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"

--- a/robot/server/server.go
+++ b/robot/server/server.go
@@ -333,7 +333,7 @@ func (s *Server) StreamStatus(req *pb.StreamStatusRequest, streamServer pb.Robot
 		switch {
 		case err == nil:
 		case grpcstatus.Code(err) == codes.Unimplemented:
-			continue
+			return nil
 		default:
 			return err
 		}

--- a/robot/server/server.go
+++ b/robot/server/server.go
@@ -10,9 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"google.golang.org/grpc/codes"
-	grpcstatus "google.golang.org/grpc/status"
-
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	commonpb "go.viam.com/api/common/v1"
@@ -20,6 +17,8 @@ import (
 	"go.viam.com/utils"
 	vprotoutils "go.viam.com/utils/protoutils"
 	"go.viam.com/utils/rpc"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"


### PR DESCRIPTION
Tested locally with the [Intel® RealSense™](https://www.intelrealsense.com/) camera. This removes the `Unimplemented` errors but there are still `WARN`ings (see below). Let me know if I should remove those too.

```bash
pi@raspberrypi:~/rdk $ go run web/cmd/server/main.go -config /etc/viam.json 
...
2023-03-27T17:26:18.969-0400    INFO    robot_server    zap/options.go:212      finished unary call with code OK        {"grpc.start_time": "2023-03-27T17:26:18-04:00", "system": "grpc", "span.kind": "server", "grpc.service": "viam.robot.v1.RobotService", "grpc.method": "SendSessionHeartbeat", "grpc.code": "OK", "grpc.time_ms": 0.279}

2023-03-27T17:26:19.215-0400    WARN    robot_server    zap/options.go:212      finished client unary call      {"system": "grpc", "span.kind": "client", "grpc.service": "viam.robot.v1.RobotService", "grpc.method": "GetStatus", "error": "rpc error: code = Unimplemented desc = ", "grpc.code": "Unimplemented", "grpc.time_ms": 0.914}

2023-03-27T17:26:19.368-0400    INFO    robot_server    zap/options.go:212      finished unary call with code OK        {"grpc.start_time": "2023-03-27T17:26:19-04:00", "system": "grpc", "span.kind": "server", "grpc.service": "viam.robot.v1.RobotService", "grpc.method": "ResourceNames", "grpc.code": "OK", "grpc.time_ms": 0.185}
2023-03-27T17:26:19.377-0400    INFO    robot_server    zap/options.go:212      finished unary call with code OK        {"grpc.start_time": "2023-03-27T17:26:19-04:00", "system": "grpc", "span.kind": "server", "grpc.service": "viam.robot.v1.RobotService", "grpc.method": "GetOperations", "grpc.code": "OK", "grpc.time_ms": 0.219}
2023-03-27T17:26:19.379-0400    INFO    robot_server    zap/options.go:212      finished unary call with code OK        {"grpc.start_time": "2023-03-27T17:26:19-04:00", "system": "grpc", "span.kind": "server", "grpc.service": "viam.robot.v1.RobotService", "grpc.method": "SendSessionHeartbeat", "grpc.code": "OK", "grpc.time_ms": 0.153}
2023-03-27T17:26:19.392-0400    INFO    robot_server    zap/options.go:212      finished unary call with code OK        {"grpc.start_time": "2023-03-27T17:26:19-04:00", "system": "grpc", "span.kind": "server", "grpc.service": "viam.robot.v1.RobotService", "grpc.method": "GetSessions", "grpc.code": "OK", "grpc.time_ms": 0.212}
2023-03-27T17:26:19.714-0400    WARN    robot_server    zap/options.go:212      finished client unary call      {"system": "grpc", "span.kind": "client", "grpc.service": "viam.robot.v1.RobotService", "grpc.method": "GetStatus", "error": "rpc error: code = Unimplemented desc = ", "grpc.code": "Unimplemented", "grpc.time_ms": 0.838}
2023-03-27T17:26:19.809-0400  INFO    robot_server    zap/options.go:212      finished streaming call with code Canceled      {"grpc.start_time": "2023-03-27T17:26:04-04:00", "system": "grpc", "span.kind": "server", "grpc.service": "proto.rpc.webrtc.v1.SignalingService", "grpc.method": "Answer", "error": "rpc error: code = Canceled desc = context canceled", "grpc.code": "Canceled", "grpc.time_ms": 14919.015}
...
```