### PR TITLE
Check pointers exist before closing in local robot

### DIFF
--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -181,12 +181,18 @@ func (r *localRobot) Close(ctx context.Context) error {
 	if r.cloudConn != nil {
 		err = multierr.Combine(err, r.cloudConn.Close())
 	}
+	if r.manager != nil {
+		err = multierr.Combine(err, r.manager.Close(ctx, r))
+	}
+	if r.modules != nil {
+		err = multierr.Combine(err, r.modules.Close(ctx))
+	}
+	if r.packageManager != nil {
+		err = multierr.Combine(err, r.packageManager.Close())
+	}
 
 	err = multierr.Combine(
 		err,
-		r.manager.Close(ctx, r),
-		r.modules.Close(ctx),
-		r.packageManager.Close(),
 		goutils.TryClose(ctx, web),
 	)
 	r.sessionManager.Close()


### PR DESCRIPTION
Makes sure we do not try to close anything that does not exist by checking to see if it exists, instead of throwing a nil pointer error and crashing the server.

sample error output

```
johnnicholson@Johns-MacBook-Air rdk % go run web/cmd/server/main.go -debug -config ../viam-slam/configs/john-mac.json
2023-03-28T11:28:06.266-0400	INFO	robot_server	server/entrypoint.go:82	Viam RDK built from source; version unknown
2023-03-28T11:28:06.267-0400	DEBUG	robot_server	config/reader.go:352	reading configuration from the cloud
2023-03-28T11:28:06.343-0400	DEBUG	robot_server	rpc/dial.go:189	connected via gRPC	{"address": "app.viam.com:443"}
2023-03-28T11:28:06.438-0400	DEBUG	robot_server	rpc/dial.go:189	connected via gRPC	{"address": "app.viam.com:443"}
2023-03-28T11:28:06.522-0400	DEBUG	robot_server	config/reader.go:408	reading tlsCertificate from the cloud
2023-03-28T11:28:06.582-0400	DEBUG	robot_server	rpc/dial.go:189	connected via gRPC	{"address": "app.viam.com:443"}
2023-03-28T11:28:06.788-0400	DEBUG	robot_server	rpc/dial.go:189	connected via gRPC	{"address": "app.viam.com:443"}
2023-03-28T11:28:06.788-0400	ERROR	robot_server	impl/local_robot.go:465	failed to close robot down after startup failure	{"error": "web service not initialized", "errorVerbose": "web service not initialized\ngo.viam.com/rdk/robot/impl.(*localRobot).webService\n\t/Users/johnnicholson/rdk/robot/impl/local_robot.go:82\ngo.viam.com/rdk/robot/impl.(*localRobot).Close\n\t/Users/johnnicholson/rdk/robot/impl/local_robot.go:160\ngo.viam.com/rdk/robot/impl.newWithResources.func1\n\t/Users/johnnicholson/rdk/robot/impl/local_robot.go:464\ngo.viam.com/rdk/robot/impl.newWithResources\n\t/Users/johnnicholson/rdk/robot/impl/local_robot.go:478\ngo.viam.com/rdk/robot/impl.New\n\t/Users/johnnicholson/rdk/robot/impl/local_robot.go:625\ngo.viam.com/rdk/web/server.(*robotServer).serveWeb\n\t/Users/johnnicholson/rdk/web/server/entrypoint.go:277\ngo.viam.com/rdk/web/server.(*robotServer).runServer\n\t/Users/johnnicholson/rdk/web/server/entrypoint.go:164\ngo.viam.com/rdk/web/server.RunServer\n\t/Users/johnnicholson/rdk/web/server/entrypoint.go:142\ngo.viam.com/utils.contextualMain\n\t/Users/johnnicholson/go/pkg/mod/go.viam.com/utils@v0.1.18-0.20230327140716-bfeb34d89117/runtime.go:72\ngo.viam.com/utils.ContextualMain\n\t/Users/johnnicholson/go/pkg/mod/go.viam.com/utils@v0.1.18-0.20230327140716-bfeb34d89117/runtime.go:29\nmain.main\n\t/Users/johnnicholson/rdk/web/cmd/server/main.go:19\nruntime.main\n\t/opt/homebrew/Cellar/go@1.19/1.19.7/libexec/src/runtime/proc.go:250\nruntime.goexit\n\t/opt/homebrew/Cellar/go@1.19/1.19.7/libexec/src/runtime/asm_arm64.s:1172"}
2023-03-28T11:28:06.788-0400	ERROR	robot_server	server/entrypoint.go:166	error serving web	{"error": "mkdir /Users/johnnicholson/.viam/packages/.data: permission denied"}
2023-03-28 11:28:06.788728 -0400 EDT m=+1.782926126 write error: unable to construct structpb.Struct from map map[Integer:0 Interface:map[Err:permission denied Op:mkdir Path:/Users/johnnicholson/.viam/packages/.data] Key:error String:mkdir /Users/johnnicholson/.viam/packages/.data: permission denied Type:26]: proto: invalid type: syscall.Errno
2023-03-28T11:28:06.788-0400	ERROR	robot_server	server/entrypoint.go:144	Fatal error running server, exiting now: mkdir /Users/johnnicholson/.viam/packages/.data: permission denied
2023-03-28T11:28:06.907-0400	FATAL	robot_server	utils@v0.1.18-0.20230327140716-bfeb34d89117/runtime.go:78	mkdir /Users/johnnicholson/.viam/packages/.data: permission denied
exit status 1
```

