### PR TITLE
Tell users to auth if they're not logged in.

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -159,7 +159,7 @@ func (c *AppClient) ensureLoggedIn() error {
 	}
 
 	if c.conf.Auth == nil {
-		return errors.New("not logged in: try $viam auth to re-authenticate")
+		return errors.New("not logged in: run the following command to authenticate:\nviam auth")
 	}
 
 	if c.conf.Auth.IsExpired() {

--- a/cli/client.go
+++ b/cli/client.go
@@ -159,7 +159,7 @@ func (c *AppClient) ensureLoggedIn() error {
 	}
 
 	if c.conf.Auth == nil {
-		return errors.New("not logged in")
+		return errors.New("not logged in: try $viam auth to re-authenticate")
 	}
 
 	if c.conf.Auth.IsExpired() {

--- a/cli/client.go
+++ b/cli/client.go
@@ -159,7 +159,7 @@ func (c *AppClient) ensureLoggedIn() error {
 	}
 
 	if c.conf.Auth == nil {
-		return errors.New("not logged in: run the following command to authenticate:\nviam auth")
+		return errors.New("not logged in: run the following command to authenticate:\n\tviam auth")
 	}
 
 	if c.conf.Auth.IsExpired() {


### PR DESCRIPTION
# Context

If a user is new to the CLI, they may not know how to authenticate. This adds a message telling them what to do if they're not logged in.