### PR TITLE
RSDK-2490 Gantry axis does not move with not limit switch pins

### DIFF
--- a/components/gantry/multiaxis/multiaxis.go
+++ b/components/gantry/multiaxis/multiaxis.go
@@ -37,12 +37,15 @@ type multiAxis struct {
 }
 
 // Validate ensures all parts of the config are valid.
-func (config *AttrConfig) Validate(path string) error {
+func (config *AttrConfig) Validate(path string) ([]string, error) {
+	var deps []string
+
 	if len(config.SubAxes) == 0 {
-		return utils.NewConfigValidationError(path, errors.New("need at least one axis"))
+		return nil, utils.NewConfigValidationError(path, errors.New("need at least one axis"))
 	}
 
-	return nil
+	deps = append(deps, config.SubAxes...)
+	return deps, nil
 }
 
 func init() {

--- a/components/gantry/multiaxis/multiaxis_test.go
+++ b/components/gantry/multiaxis/multiaxis_test.go
@@ -70,11 +70,11 @@ var twoAxes = []gantry.Gantry{
 
 func TestValidate(t *testing.T) {
 	fakecfg := &AttrConfig{SubAxes: []string{}}
-	err := fakecfg.Validate("path")
+	_, err := fakecfg.Validate("path")
 	test.That(t, err.Error(), test.ShouldContainSubstring, "need at least one axis")
 
 	fakecfg = &AttrConfig{SubAxes: []string{"singleaxis"}}
-	err = fakecfg.Validate("path")
+	_, err = fakecfg.Validate("path")
 	test.That(t, err, test.ShouldBeNil)
 }
 

--- a/components/gantry/oneaxis/oneaxis.go
+++ b/components/gantry/oneaxis/oneaxis.go
@@ -395,11 +395,11 @@ func (g *oneAxis) MoveToPosition(
 	defer done()
 
 	if len(positions) != 1 {
-		return fmt.Errorf("oneAxis gantry MoveToPosition needs 1 position, got: %v", len(positions))
+		return fmt.Errorf("oneAxis (%s) MoveToPosition needs 1 position to move, got: %v", g.name, len(positions))
 	}
 
 	if positions[0] < 0 || positions[0] > g.lengthMm {
-		return fmt.Errorf("oneAxis gantry position out of range, got %.2f min is 0 max is %.2f", positions[0], g.lengthMm)
+		return fmt.Errorf("oneAxis %s out of range (%.2f) min: 0 max: %.2f", g.name, positions[0], g.lengthMm)
 	}
 
 	x := g.rotationalToLinear(positions[0])

--- a/components/gantry/oneaxis/oneaxis.go
+++ b/components/gantry/oneaxis/oneaxis.go
@@ -172,6 +172,10 @@ func newOneAxis(ctx context.Context, deps registry.Dependencies, config config.C
 		axis:            conf.Axis,
 	}
 
+	if oAx.rpm == 0 {
+		oAx.rpm = 100
+	}
+
 	switch len(oAx.limitSwitchPins) {
 	case 1:
 		oAx.limitType = limitOnePin
@@ -302,7 +306,6 @@ func (g *oneAxis) rotationalToLinear(positions float64) float64 {
 	theRange := g.positionLimits[1] - g.positionLimits[0]
 	x := positions / g.lengthMm
 	x = g.positionLimits[0] + (x * theRange)
-	g.logger.Debugf("oneAxis SetPosition %.2f -> %.2f", positions, x)
 
 	return x
 }
@@ -396,40 +399,47 @@ func (g *oneAxis) MoveToPosition(
 	}
 
 	if positions[0] < 0 || positions[0] > g.lengthMm {
-		return fmt.Errorf("oneAxis gantry position out of range, got %.02f max is %.02f", positions[0], g.lengthMm)
+		return fmt.Errorf("oneAxis gantry position out of range, got %.2f min is 0 max is %.2f", positions[0], g.lengthMm)
 	}
 
 	x := g.rotationalToLinear(positions[0])
 	// Limit switch errors that stop the motors.
 	// Currently needs to be moved by underlying gantry motor.
-	hit, err := g.limitHit(ctx, true)
-	if err != nil {
-		return err
-	}
-
-	// Hits backwards limit switch, goes in forwards direction for two revolutions
-	if hit {
-		if x < g.positionLimits[0] {
-			dir := float64(1)
-			return g.motor.GoFor(ctx, dir*g.rpm, 2, extra)
+	if len(g.limitSwitchPins) > 0 {
+		hit, err := g.limitHit(ctx, true)
+		if err != nil {
+			return err
 		}
-		return g.motor.Stop(ctx, extra)
-	}
 
-	// Hits forward limit switch, goes in backwards direction for two revolutions
-	hit, err = g.limitHit(ctx, false)
-	if err != nil {
-		return err
-	}
-	if hit {
-		if x > g.positionLimits[1] {
-			dir := float64(-1)
-			return g.motor.GoFor(ctx, dir*g.rpm, 2, extra)
+		// Hits backwards limit switch, goes in forwards direction for two revolutions
+		if hit {
+			if x < g.positionLimits[0] {
+				dir := float64(1)
+				return g.motor.GoFor(ctx, dir*g.rpm, 2, extra)
+			}
+			return g.motor.Stop(ctx, extra)
 		}
-		return g.motor.Stop(ctx, extra)
+
+		// Hits forward limit switch, goes in backwards direction for two revolutions
+		hit, err = g.limitHit(ctx, false)
+		if err != nil {
+			return err
+		}
+		if hit {
+			if x > g.positionLimits[1] {
+				dir := float64(-1)
+				return g.motor.GoFor(ctx, dir*g.rpm, 2, extra)
+			}
+			return g.motor.Stop(ctx, extra)
+		}
+
+		err = g.motor.GoTo(ctx, g.rpm, x, extra)
+		if err != nil {
+			return err
+		}
 	}
 
-	err = g.motor.GoTo(ctx, g.rpm, x, extra)
+	err := g.motor.GoTo(ctx, g.rpm, x, extra)
 	if err != nil {
 		return err
 	}

--- a/components/gantry/oneaxis/oneaxis_test.go
+++ b/components/gantry/oneaxis/oneaxis_test.go
@@ -626,11 +626,11 @@ func TestMoveToPosition(t *testing.T) {
 	}
 	pos := []float64{1, 2}
 	err := fakegantry.MoveToPosition(ctx, pos, &referenceframe.WorldState{}, nil)
-	test.That(t, err.Error(), test.ShouldEqual, "oneAxis gantry MoveToPosition needs 1 position, got: 2")
+	test.That(t, err.Error(), test.ShouldContainSubstring, "needs 1 position to move")
 
 	pos = []float64{1}
 	err = fakegantry.MoveToPosition(ctx, pos, &referenceframe.WorldState{}, nil)
-	test.That(t, err.Error(), test.ShouldEqual, "oneAxis gantry position out of range, got 1.00 max is 0.00")
+	test.That(t, err.Error(), test.ShouldContainSubstring, "out of range")
 
 	fakegantry.lengthMm = float64(4)
 	fakegantry.positionLimits = []float64{0, 4}
@@ -786,19 +786,19 @@ func TestGoToInputs(t *testing.T) {
 		logger:          logger,
 	}
 	err := fakegantry.GoToInputs(ctx, inputs)
-	test.That(t, err.Error(), test.ShouldEqual, "oneAxis gantry MoveToPosition needs 1 position, got: 0")
+	test.That(t, err.Error(), test.ShouldContainSubstring, "needs 1 position to move")
 
 	inputs = []referenceframe.Input{{Value: 1.0}, {Value: 2.0}}
 	err = fakegantry.GoToInputs(ctx, inputs)
-	test.That(t, err.Error(), test.ShouldEqual, "oneAxis gantry MoveToPosition needs 1 position, got: 2")
+	test.That(t, err.Error(), test.ShouldContainSubstring, "needs 1 position to move")
 
 	inputs = []referenceframe.Input{{Value: -1.0}}
 	err = fakegantry.GoToInputs(ctx, inputs)
-	test.That(t, err.Error(), test.ShouldEqual, "oneAxis gantry position out of range, got -1.00 min is 0 max is 1.00")
+	test.That(t, err.Error(), test.ShouldContainSubstring, "out of range")
 
 	inputs = []referenceframe.Input{{Value: 4.0}}
 	err = fakegantry.GoToInputs(ctx, inputs)
-	test.That(t, err.Error(), test.ShouldEqual, "oneAxis gantry position out of range, got 4.00 min is 0 max is 1.00")
+	test.That(t, err.Error(), test.ShouldContainSubstring, "out of range")
 
 	inputs = []referenceframe.Input{{Value: 1.0}}
 	err = fakegantry.GoToInputs(ctx, inputs)

--- a/components/gantry/oneaxis/oneaxis_test.go
+++ b/components/gantry/oneaxis/oneaxis_test.go
@@ -298,6 +298,7 @@ func TestHome(t *testing.T) {
 	}
 	fakegantry = &oneAxis{
 		motor:     fakeMotor,
+		logger:    logger,
 		limitType: "onePinOneLength",
 	}
 	err = fakegantry.Home(ctx)
@@ -793,11 +794,11 @@ func TestGoToInputs(t *testing.T) {
 
 	inputs = []referenceframe.Input{{Value: -1.0}}
 	err = fakegantry.GoToInputs(ctx, inputs)
-	test.That(t, err.Error(), test.ShouldEqual, "oneAxis gantry position out of range, got -1.00 max is 1.00")
+	test.That(t, err.Error(), test.ShouldEqual, "oneAxis gantry position out of range, got -1.00 min is 0 max is 1.00")
 
 	inputs = []referenceframe.Input{{Value: 4.0}}
 	err = fakegantry.GoToInputs(ctx, inputs)
-	test.That(t, err.Error(), test.ShouldEqual, "oneAxis gantry position out of range, got 4.00 max is 1.00")
+	test.That(t, err.Error(), test.ShouldEqual, "oneAxis gantry position out of range, got 4.00 min is 0 max is 1.00")
 
 	inputs = []referenceframe.Input{{Value: 1.0}}
 	err = fakegantry.GoToInputs(ctx, inputs)


### PR DESCRIPTION
This fixes:
- multiaxis and single-axis dependencies are not being created on the fly.
- an error after limit switch pins are not found causing an empty input rather than an array of floats into MoveToPosition.
- a zero default gantry rpm being set and fed to `motor.GoTo` - since remote control does not allow you to set gantry rpms anymore.

