### PR TITLE
[RSDK-2496] Directly refresh webservice subtype services before modular resource loading

### DIFF
--- a/examples/customresources/models/mybase/mybase.go
+++ b/examples/customresources/models/mybase/mybase.go
@@ -73,7 +73,9 @@ func (base *MyBase) Reconfigure(cfg config.Component, deps registry.Dependencies
 	if base.left == nil || base.right == nil {
 		return errors.Errorf(`mybase %q needs both "motorL" and "motorR"`, cfg.Name)
 	}
-	return nil
+
+	// Good practice to stop motors, but also this effectively tests https://viam.atlassian.net/browse/RSDK-2496
+	return multierr.Combine(base.left.Stop(context.Background(), nil), base.right.Stop(context.Background(), nil))
 }
 
 type MyBaseConfig struct {

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -134,6 +134,15 @@ func (mgr *Manager) AddResource(ctx context.Context, cfg config.Component, deps 
 	if err != nil {
 		return nil, err
 	}
+
+	svc, ok := mgr.r.(robot.Refresher)
+	if !ok {
+		return nil, errors.New("robot can't refresh resources")
+	}
+	if err = svc.Refresh(ctx); err != nil {
+		return nil, err
+	}
+
 	_, err = module.client.AddResource(ctx, &pb.AddResourceRequest{Config: cfgProto, Dependencies: deps})
 	if err != nil {
 		return nil, err

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -767,9 +767,13 @@ func (r *localRobot) updateDefaultServices(ctx context.Context) {
 	}
 }
 
-// Refresh does nothing for now.
+// Refresh causes the web service to reload it's subtype service maps from the actual robot resources.
 func (r *localRobot) Refresh(ctx context.Context) error {
-	return nil
+	svc, err := r.webService()
+	if err != nil {
+		return err
+	}
+	return svc.RefreshResources()
 }
 
 // FrameSystemConfig returns the info of each individual part that makes up a robot's frame system.

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -217,6 +217,9 @@ type Service interface {
 	// StartModule starts the module server socket.
 	StartModule(context.Context) error
 
+	// RefreshResources reloads the grpc-service subtypes with current robot Resources
+	RefreshResources() error
+
 	// Returns the address and port the web service listens on.
 	Address() string
 
@@ -391,7 +394,7 @@ func (svc *webService) StartModule(ctx context.Context) error {
 	if err := svc.modServer.RegisterServiceServer(ctx, &pb.RobotService_ServiceDesc, grpcserver.New(svc.r)); err != nil {
 		return err
 	}
-	if err := svc.initResources(); err != nil {
+	if err := svc.RefreshResources(); err != nil {
 		return err
 	}
 	if err := svc.initSubtypeServices(ctx, true); err != nil {
@@ -732,7 +735,7 @@ func (svc *webService) runWeb(ctx context.Context, options weboptions.Options) (
 		return err
 	}
 
-	if err := svc.initResources(); err != nil {
+	if err := svc.RefreshResources(); err != nil {
 		return err
 	}
 
@@ -1000,21 +1003,16 @@ func (svc *webService) initAuthHandlers(listenerTCPAddr *net.TCPAddr, options we
 }
 
 // Populate subtype services with robot resources.
-func (svc *webService) initResources() error {
+func (svc *webService) RefreshResources() error {
 	resources := make(map[resource.Name]interface{})
 	for _, name := range svc.r.ResourceNames() {
 		resource, err := svc.r.ResourceByName(name)
 		if err != nil {
 			continue
 		}
-
 		resources[name] = resource
 	}
-	if err := svc.updateResources(resources); err != nil {
-		return err
-	}
-
-	return nil
+	return svc.updateResources(resources)
 }
 
 // Register every subtype resource grpc service here.


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-2496 describes the problem, but the short example is that it was impossible to use `motor.Stop()` during something like `NewBase()`

This should fix that issue, but may not be the best approach. (See inline notes.)