### PR TITLE
RSDK-2497: Filter out ISP cameras from discovery drop down

### DIFF
--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -102,21 +102,22 @@ func Discover(ctx context.Context, getDrivers func() []driver.Driver) (*pb.Webca
 
 		labelParts := strings.Split(driverInfo.Label, mediadevicescamera.LabelSeparator)
 		label := labelParts[0]
-		wc := &pb.Webcam{
-			Label:      label,
-			Status:     string(d.Status()),
-			Properties: make([]*pb.Property, 0, len(d.Properties())),
-		}
-
-		for _, prop := range props {
-			pbProp := &pb.Property{
-				WidthPx:     int32(prop.Video.Width),
-				HeightPx:    int32(prop.Video.Height),
-				FrameFormat: string(prop.Video.FrameFormat),
+		if !strings.Contains(label, "-isp-") {
+			wc := &pb.Webcam{
+				Label:      label,
+				Status:     string(d.Status()),
+				Properties: make([]*pb.Property, 0, len(d.Properties())),
 			}
-			wc.Properties = append(wc.Properties, pbProp)
+
+			for _, prop := range props {
+				pbProp := &pb.Property{
+					WidthPx:     int32(prop.Video.Width),
+					HeightPx:    int32(prop.Video.Height),
+					FrameFormat: string(prop.Video.FrameFormat),
+				}
+				wc.Properties = append(wc.Properties, pbProp)
+			}
 		}
-		webcams = append(webcams, wc)
 	}
 	return &pb.Webcams{Webcams: webcams}, nil
 }

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -117,6 +117,7 @@ func Discover(ctx context.Context, getDrivers func() []driver.Driver) (*pb.Webca
 				}
 				wc.Properties = append(wc.Properties, pbProp)
 			}
+			webcams = append(webcams, wc)
 		}
 	}
 	return &pb.Webcams{Webcams: webcams}, nil

--- a/components/camera/videosource/webcam_test.go
+++ b/components/camera/videosource/webcam_test.go
@@ -34,7 +34,8 @@ func testGetDrivers() []driver.Driver {
 	}
 	withProps := newFakeDriver("some label", []prop.Media{props})
 	withoutProps := newFakeDriver("another label", []prop.Media{})
-	return []driver.Driver{withProps, withoutProps}
+	isISP := newFakeDriver("some-isp-label", []prop.Media{props})
+	return []driver.Driver{withProps, withoutProps, isISP}
 }
 
 func TestDiscoveryWebcam(t *testing.T) {


### PR DESCRIPTION
This change filters out any labels with the substring `"-isp-"` that are returned from the discovery service in order to eliminate confusion for users about which discovered device is their connected camera.