### PR TITLE
RSDK-2325 Remove orphaned resources from newConfig in Reconfigure

### DIFF
--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -972,12 +972,14 @@ func (r *localRobot) Reconfigure(ctx context.Context, newConfig *config.Config) 
 	for _, name := range filtered.resources.Names() {
 		for i, c := range newConfig.Components {
 			if c.ResourceName() == name {
-				newConfig.Components = append(newConfig.Components[:i], newConfig.Components[i+1:]...)
+				newConfig.Components[i] = newConfig.Components[len(newConfig.Components)-1]
+				newConfig.Components = newConfig.Components[:len(newConfig.Components)-1]
 			}
 		}
 		for i, s := range newConfig.Services {
 			if s.ResourceName() == name {
-				newConfig.Services = append(newConfig.Services[:i], newConfig.Services[i+1:]...)
+				newConfig.Services[i] = newConfig.Services[len(newConfig.Services)-1]
+				newConfig.Services = newConfig.Services[:len(newConfig.Services)-1]
 			}
 		}
 	}

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -2309,6 +2309,12 @@ func TestOrphanedResources(t *testing.T) {
 				Type:      motor.SubtypeName,
 				DependsOn: []string{"b"},
 			},
+			{
+				Name:      "m1",
+				Model:     fakeModel,
+				Type:      motor.SubtypeName,
+				DependsOn: []string{"m"},
+			},
 		},
 		Services: []config.Service{
 			{
@@ -2335,6 +2341,12 @@ func TestOrphanedResources(t *testing.T) {
 				Type:      motor.SubtypeName,
 				DependsOn: []string{"b"},
 			},
+			{
+				Name:      "m1",
+				Model:     fakeModel,
+				Type:      motor.SubtypeName,
+				DependsOn: []string{"m"},
+			},
 		},
 		Services: []config.Service{
 			{
@@ -2355,6 +2367,9 @@ func TestOrphanedResources(t *testing.T) {
 	res, err = r.ResourceByName(motor.Named("m"))
 	test.That(t, err, test.ShouldBeError,
 		rutils.NewResourceNotFoundError(motor.Named("m")))
+	res, err = r.ResourceByName(motor.Named("m1"))
+	test.That(t, err, test.ShouldBeError,
+		rutils.NewResourceNotFoundError(motor.Named("m1")))
 	test.That(t, res, test.ShouldBeNil)
 	res, err = r.ResourceByName(slam.Named("s"))
 	test.That(t, err, test.ShouldBeError,
@@ -2367,6 +2382,8 @@ func TestOrphanedResources(t *testing.T) {
 	_, err = r.ResourceByName(base.Named("b"))
 	test.That(t, err, test.ShouldBeNil)
 	_, err = r.ResourceByName(motor.Named("m"))
+	test.That(t, err, test.ShouldBeNil)
+	_, err = r.ResourceByName(motor.Named("m1"))
 	test.That(t, err, test.ShouldBeNil)
 	_, err = r.ResourceByName(slam.Named("s"))
 	test.That(t, err, test.ShouldBeNil)

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -2364,10 +2364,10 @@ func TestOrphanedResources(t *testing.T) {
 	// Assert that adding base 'b' back re-adds 'm' and slam service 's'.
 	r.Reconfigure(ctx, cfg)
 
-	res, err = r.ResourceByName(base.Named("b"))
+	_, err = r.ResourceByName(base.Named("b"))
 	test.That(t, err, test.ShouldBeNil)
-	res, err = r.ResourceByName(motor.Named("m"))
+	_, err = r.ResourceByName(motor.Named("m"))
 	test.That(t, err, test.ShouldBeNil)
-	res, err = r.ResourceByName(slam.Named("s"))
+	_, err = r.ResourceByName(slam.Named("s"))
 	test.That(t, err, test.ShouldBeNil)
 }

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -2332,7 +2332,7 @@ func TestOrphanedResources(t *testing.T) {
 		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
 	}()
 
-	// Assert that removing base 'b' removes motor 'm' and slam service 's'.
+	// Assert that removing base 'b' removes motors 'm' and 'm1' and slam service 's'.
 	cfg2 := &config.Config{
 		Components: []config.Component{
 			{
@@ -2367,6 +2367,7 @@ func TestOrphanedResources(t *testing.T) {
 	res, err = r.ResourceByName(motor.Named("m"))
 	test.That(t, err, test.ShouldBeError,
 		rutils.NewResourceNotFoundError(motor.Named("m")))
+	test.That(t, res, test.ShouldBeNil)
 	res, err = r.ResourceByName(motor.Named("m1"))
 	test.That(t, err, test.ShouldBeError,
 		rutils.NewResourceNotFoundError(motor.Named("m1")))
@@ -2376,7 +2377,7 @@ func TestOrphanedResources(t *testing.T) {
 		rutils.NewResourceNotFoundError(slam.Named("s")))
 	test.That(t, res, test.ShouldBeNil)
 
-	// Assert that adding base 'b' back re-adds 'm' and slam service 's'.
+	// Assert that adding base 'b' back re-adds 'm' and 'm1' and slam service 's'.
 	r.Reconfigure(ctx, cfg)
 
 	_, err = r.ResourceByName(base.Named("b"))


### PR DESCRIPTION
RSDK-2325

Removes resources whose dependencies have also been removed from `newConfig`. Adds test for this behavior.

Previously, if motor 'm' was dependent on base 'b' and base 'b' was removed and re-added, motor 'm' would not be accessible through SDKs or the web app. Now, motor 'm' correctly reappears when base 'b' is re-added.