### PR TITLE
RSDK-2521 Add ConvertedAttributes to module configs

### DIFF
--- a/examples/customresources/models/mybase/mybase.go
+++ b/examples/customresources/models/mybase/mybase.go
@@ -17,6 +17,7 @@ import (
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/registry"
 	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/utils"
 )
 
 var (
@@ -51,27 +52,20 @@ func newBase(ctx context.Context, deps registry.Dependencies, config config.Comp
 func (base *MyBase) Reconfigure(cfg config.Component, deps registry.Dependencies) error {
 	base.left = nil
 	base.right = nil
-	for n, d := range deps {
-		switch n.Name {
-		case cfg.Attributes.String("motorL"):
-			m, ok := d.(motor.Motor)
-			if !ok {
-				return errors.Errorf("resource %s is not a motor", n.Name)
-			}
-			base.left = m
-		case cfg.Attributes.String("motorR"):
-			m, ok := d.(motor.Motor)
-			if !ok {
-				return errors.Errorf("resource %s is not a motor", n.Name)
-			}
-			base.right = m
-		default:
-			continue
-		}
+	baseConfig, ok := cfg.ConvertedAttributes.(*MyBaseConfig)
+	if !ok {
+		return utils.NewUnexpectedTypeError(baseConfig, cfg.ConvertedAttributes)
+	}
+	err := errors.New("")
+
+	base.left, err = motor.FromDependencies(deps, baseConfig.LeftMotor)
+	if err != nil {
+		return errors.Wrapf(err, "unable to get motor %v for mybase", baseConfig.LeftMotor)
 	}
 
-	if base.left == nil || base.right == nil {
-		return errors.Errorf(`mybase %q needs both "motorL" and "motorR"`, cfg.Name)
+	base.right, err = motor.FromDependencies(deps, baseConfig.LeftMotor)
+	if err != nil {
+		return errors.Wrapf(err, "unable to get motor %v for mybase", baseConfig.RightMotor)
 	}
 
 	// Good practice to stop motors, but also this effectively tests https://viam.atlassian.net/browse/RSDK-2496

--- a/examples/customresources/models/mybase/mybase.go
+++ b/examples/customresources/models/mybase/mybase.go
@@ -63,7 +63,7 @@ func (base *MyBase) Reconfigure(cfg config.Component, deps registry.Dependencies
 		return errors.Wrapf(err, "unable to get motor %v for mybase", baseConfig.LeftMotor)
 	}
 
-	base.right, err = motor.FromDependencies(deps, baseConfig.LeftMotor)
+	base.right, err = motor.FromDependencies(deps, baseConfig.RightMotor)
 	if err != nil {
 		return errors.Wrapf(err, "unable to get motor %v for mybase", baseConfig.RightMotor)
 	}

--- a/examples/customresources/models/mybase/mybase.go
+++ b/examples/customresources/models/mybase/mybase.go
@@ -56,7 +56,7 @@ func (base *MyBase) Reconfigure(cfg config.Component, deps registry.Dependencies
 	if !ok {
 		return utils.NewUnexpectedTypeError(baseConfig, cfg.ConvertedAttributes)
 	}
-	err := errors.New("")
+	var err error
 
 	base.left, err = motor.FromDependencies(deps, baseConfig.LeftMotor)
 	if err != nil {

--- a/module/module.go
+++ b/module/module.go
@@ -275,7 +275,7 @@ func (m *Module) AddResource(ctx context.Context, req *pb.AddResourceRequest) (*
 		return nil, err
 	}
 
-	if err := addConvertAttributes(cfg); err != nil {
+	if err := addConvertedAttributes(cfg); err != nil {
 		return nil, errors.Wrapf(err, "unable to convert attributes when adding resource")
 	}
 
@@ -401,7 +401,7 @@ func (m *Module) ValidateConfig(ctx context.Context,
 		return nil, err
 	}
 
-	if err := addConvertAttributes(c); err != nil {
+	if err := addConvertedAttributes(c); err != nil {
 		return nil, errors.Wrapf(err, "unable to convert attributes for validation")
 	}
 
@@ -504,9 +504,9 @@ func (m *Module) OperationManager() *operation.Manager {
 	return m.operations
 }
 
-// addConvertAttributesToConfig uses the MapAttributeConverter to fill in the
+// addConvertedAttributesToConfig uses the MapAttributeConverter to fill in the
 // ConvertedAttributes field from the Attributes.
-func addConvertAttributes(cfg *config.Component) error {
+func addConvertedAttributes(cfg *config.Component) error {
 	// Try to find map converter for a component.
 	conv := config.FindMapConverter(cfg.API, cfg.Model)
 	// If no map converter for a component exists, try to find map converter for a

--- a/module/module.go
+++ b/module/module.go
@@ -504,7 +504,7 @@ func (m *Module) OperationManager() *operation.Manager {
 	return m.operations
 }
 
-// addConvertAttributesToConfig uses the SeriviceMapAttributeConverter to fill in the
+// addConvertAttributesToConfig uses the MapAttributeConverter to fill in the
 // ConvertedAttributes field from the Attributes
 func addConvertAttributesToConfig(cfg *config.Component) error {
 	// Try to find map converter for a component.

--- a/module/module.go
+++ b/module/module.go
@@ -275,7 +275,7 @@ func (m *Module) AddResource(ctx context.Context, req *pb.AddResourceRequest) (*
 		return nil, err
 	}
 
-	if err := addConvertAttributesToConfig(cfg); err != nil {
+	if err := addConvertAttributes(cfg); err != nil {
 		return nil, errors.Wrapf(err, "unable to convert attributes when adding resource")
 	}
 
@@ -401,7 +401,7 @@ func (m *Module) ValidateConfig(ctx context.Context,
 		return nil, err
 	}
 
-	if err := addConvertAttributesToConfig(c); err != nil {
+	if err := addConvertAttributes(c); err != nil {
 		return nil, errors.Wrapf(err, "unable to convert attributes for validation")
 	}
 
@@ -506,14 +506,13 @@ func (m *Module) OperationManager() *operation.Manager {
 
 // addConvertAttributesToConfig uses the MapAttributeConverter to fill in the
 // ConvertedAttributes field from the Attributes.
-func addConvertAttributesToConfig(cfg *config.Component) error {
+func addConvertAttributes(cfg *config.Component) error {
 	// Try to find map converter for a component.
-	cType := resource.NewSubtype(cfg.Namespace, cfg.API.ResourceType, cfg.API.ResourceSubtype)
-	conv := config.FindMapConverter(cType, cfg.Model)
+	conv := config.FindMapConverter(cfg.API, cfg.Model)
 	// If no map converter for a component exists, try to find map converter for a
 	// service.
 	if conv == nil {
-		conv = config.FindServiceMapConverter(cType, cfg.Model)
+		conv = config.FindServiceMapConverter(cfg.API, cfg.Model)
 	}
 	if conv != nil {
 		converted, err := conv(cfg.Attributes)

--- a/module/module.go
+++ b/module/module.go
@@ -505,7 +505,7 @@ func (m *Module) OperationManager() *operation.Manager {
 }
 
 // addConvertAttributesToConfig uses the MapAttributeConverter to fill in the
-// ConvertedAttributes field from the Attributes
+// ConvertedAttributes field from the Attributes.
 func addConvertAttributesToConfig(cfg *config.Component) error {
 	// Try to find map converter for a component.
 	cType := resource.NewSubtype(cfg.Namespace, cfg.API.ResourceType, cfg.API.ResourceSubtype)

--- a/module/module.go
+++ b/module/module.go
@@ -276,7 +276,7 @@ func (m *Module) AddResource(ctx context.Context, req *pb.AddResourceRequest) (*
 	}
 
 	if err := addConvertAttributesToConfig(cfg); err != nil {
-		return nil, errors.Wrapf(err, "unable to convert attributes for validation")
+		return nil, errors.Wrapf(err, "unable to convert attributes when adding resource")
 	}
 
 	var res interface{}

--- a/module/module.go
+++ b/module/module.go
@@ -275,6 +275,10 @@ func (m *Module) AddResource(ctx context.Context, req *pb.AddResourceRequest) (*
 		return nil, err
 	}
 
+	if err := addConvertAttributesToConfig(cfg); err != nil {
+		return nil, errors.Wrapf(err, "unable to convert attributes for validation")
+	}
+
 	var res interface{}
 	switch cfg.API.ResourceType {
 	case resource.ResourceTypeComponent:
@@ -397,20 +401,12 @@ func (m *Module) ValidateConfig(ctx context.Context,
 		return nil, err
 	}
 
-	// Try to find map converter for a component.
-	cType := resource.NewSubtype(c.Namespace, c.API.ResourceType, c.API.ResourceSubtype)
-	conv := config.FindMapConverter(cType, c.Model)
-	// If no map converter for a component exists, try to find map converter for a
-	// service.
-	if conv == nil {
-		conv = config.FindServiceMapConverter(cType, c.Model)
+	if err := addConvertAttributesToConfig(c); err != nil {
+		return nil, errors.Wrapf(err, "unable to convert attributes for validation")
 	}
-	if conv != nil {
-		converted, err := conv(c.Attributes)
-		if err != nil {
-			return nil, errors.Wrapf(err, "error converting attributes for resource")
-		}
-		validator, ok := converted.(Validator)
+
+	if c.ConvertedAttributes != nil {
+		validator, ok := c.ConvertedAttributes.(Validator)
 		if ok {
 			implicitDeps, err := validator.Validate(c.Name)
 			if err != nil {
@@ -506,4 +502,25 @@ func (m *Module) AddModelFromRegistry(ctx context.Context, api resource.Subtype,
 // OperationManager returns the operation manager for the module.
 func (m *Module) OperationManager() *operation.Manager {
 	return m.operations
+}
+
+// addConvertAttributesToConfig uses the SeriviceMapAttributeConverter to fill in the
+// ConvertedAttributes field from the Attributes
+func addConvertAttributesToConfig(cfg *config.Component) error {
+	// Try to find map converter for a component.
+	cType := resource.NewSubtype(cfg.Namespace, cfg.API.ResourceType, cfg.API.ResourceSubtype)
+	conv := config.FindMapConverter(cType, cfg.Model)
+	// If no map converter for a component exists, try to find map converter for a
+	// service.
+	if conv == nil {
+		conv = config.FindServiceMapConverter(cType, cfg.Model)
+	}
+	if conv != nil {
+		converted, err := conv(cfg.Attributes)
+		if err != nil {
+			return errors.Wrapf(err, "error converting attributes for resource")
+		}
+		cfg.ConvertedAttributes = converted
+	}
+	return nil
 }


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-2521

Important design decisions:
- Dont set Attributes to nil if we set ConvertedAttributes. This diverges from rdk behavior which sets Attributes to nil if it is converted. This was done because I think it is worth it to give customers more flexibility in case there is a bug with ConvertedAttributes in the future or in some sdk. 
- Use FromDependencies in mybase.go rather than the switch statement