### PR TITLE
Refactor the way GPIO chips in sysfs get discovered

### DIFF
--- a/components/board/genericlinux/data.go
+++ b/components/board/genericlinux/data.go
@@ -58,6 +58,14 @@ func noBoardError(modelName string) error {
 	return fmt.Errorf("could not determine %q model", modelName)
 }
 
+// gpioChipData is a struct used solely within GetGPIOBoardMappings and its sub-pieces. It
+// describes a GPIO chip within sysfs.
+type gpioChipData struct {
+	Dir   string // Pseudofile within sysfs to interact with this chip
+	Base  int // Taken from the /base pseudofile in sysfs: offset to the start of the lines
+	Ngpio int // Taken from the /ngpio pseudofile in sysfs: number of lines on the chip
+}
+
 // GetGPIOBoardMappings attempts to find a compatible board-pin mapping for the given mappings.
 func GetGPIOBoardMappings(modelName string, boardInfoMappings map[string]BoardInformation) (map[int]GPIOBoardMapping, error) {
 	pinDefs, err := getCompatiblePinDefs(modelName, boardInfoMappings)
@@ -101,12 +109,6 @@ func getCompatiblePinDefs(modelName string, boardInfoMappings map[string]BoardIn
 		return nil, noBoardError(modelName)
 	}
 	return pinDefs, nil
-}
-
-type gpioChipData struct {
-	Dir   string // Pseudofile within sysfs to interact with this chip
-	Base  int // Taken from the /base pseudofile in sysfs: offset to the start of the lines
-	Ngpio int // Taken from the /ngpio pseudofile in sysfs: number of lines on the chip
 }
 
 func getGpioChipDefs(pinDefs []PinDefinition) (map[string]gpioChipData, error) {

--- a/components/board/genericlinux/data.go
+++ b/components/board/genericlinux/data.go
@@ -62,8 +62,8 @@ func noBoardError(modelName string) error {
 // describes a GPIO chip within sysfs.
 type gpioChipData struct {
 	Dir   string // Pseudofile within sysfs to interact with this chip
-	Base  int // Taken from the /base pseudofile in sysfs: offset to the start of the lines
-	Ngpio int // Taken from the /ngpio pseudofile in sysfs: number of lines on the chip
+	Base  int    // Taken from the /base pseudofile in sysfs: offset to the start of the lines
+	Ngpio int    // Taken from the /ngpio pseudofile in sysfs: number of lines on the chip
 }
 
 // GetGPIOBoardMappings attempts to find a compatible board-pin mapping for the given mappings.
@@ -187,8 +187,8 @@ func getGpioChipDefs(pinDefs []PinDefinition) (map[string]gpioChipData, error) {
 			}
 
 			gpioChipInfo[gpioChipName] = gpioChipData{
-				Dir: chipFileName,
-				Base: int(baseParsed),
+				Dir:   chipFileName,
+				Base:  int(baseParsed),
 				Ngpio: int(ngpioParsed),
 			}
 			break
@@ -206,8 +206,8 @@ func getBoardMapping(pinDefs []PinDefinition, gpioChipInfo map[string]gpioChipDa
 
 		chipInfo, ok := gpioChipInfo[pinDef.GPIOChipSysFSDir]
 		if !ok {
-			return nil, fmt.Errorf("Unknown GPIO device %s for pin %d",
-			                       pinDef.GPIOChipSysFSDir, key)
+			return nil, fmt.Errorf("unknown GPIO device %s for pin %d",
+				pinDef.GPIOChipSysFSDir, key)
 		}
 
 		chipRelativeID, ok := pinDef.GPIOChipRelativeIDs[chipInfo.Ngpio]

--- a/components/board/genericlinux/data.go
+++ b/components/board/genericlinux/data.go
@@ -120,7 +120,6 @@ func getBoardMapping(pinDefs []PinDefinition) (map[int]GPIOBoardMapping, error) 
 
 	// For each chip, add entries to the 3 maps previously defined.
 	for gpioChipName := range gpioChipNames {
-		gpioChipInfo[gpioChipName] = gpioChipData{} // We'll fill this in later
 		var gpioChipDir string
 		for _, prefix := range sysfsPrefixes {
 			d := prefix + gpioChipName
@@ -140,11 +139,12 @@ func getBoardMapping(pinDefs []PinDefinition) (map[int]GPIOBoardMapping, error) 
 		if err != nil {
 			return nil, err
 		}
+		var chipFileName string
 		for _, file := range files {
 			if !strings.HasPrefix(file.Name(), "gpiochip") {
 				continue
 			}
-			gpioChipInfo[gpioChipName].Dir = file.Name()
+			chipFileName = file.Name()
 			break
 		}
 
@@ -168,7 +168,6 @@ func getBoardMapping(pinDefs []PinDefinition) (map[int]GPIOBoardMapping, error) 
 			if err != nil {
 				return nil, err
 			}
-			gpioChipInfo[gpioChipName].Base = int(baseParsed)
 
 			ngpioFn := filepath.Join(gpioChipGPIODir, file.Name(), "ngpio")
 			//nolint:gosec
@@ -180,7 +179,12 @@ func getBoardMapping(pinDefs []PinDefinition) (map[int]GPIOBoardMapping, error) 
 			if err != nil {
 				return nil, err
 			}
-			gpioChipInfo[gpioChipName].Ngpio = int(ngpioParsed)
+
+			gpioChipInfo[gpioChipName] = gpioChipData{
+				Dir: chipFileName,
+				Base: int(baseParsed),
+				Ngpio: int(ngpioParsed),
+			}
 			break
 		}
 	}

--- a/components/board/genericlinux/data.go
+++ b/components/board/genericlinux/data.go
@@ -60,6 +60,15 @@ func noBoardError(modelName string) error {
 
 // GetGPIOBoardMappings attempts to find a compatible board-pin mapping for the given mappings.
 func GetGPIOBoardMappings(modelName string, boardInfoMappings map[string]BoardInformation) (map[int]GPIOBoardMapping, error) {
+	pinDefs, err := getCompatiblePinDefs(modelName, boardInfoMappings)
+	if err != nil {
+		return nil, err
+	}
+
+	return getBoardMapping(pinDefs)
+}
+
+func getCompatiblePinDefs(modelName string, boardInfoMappings map[string]BoardInformation) ([]PinDefinition, error) {
 	const compatiblePath = "/proc/device-tree/compatible"
 
 	compatiblesRd, err := os.ReadFile(compatiblePath)
@@ -84,7 +93,10 @@ func GetGPIOBoardMappings(modelName string, boardInfoMappings map[string]BoardIn
 	if pinDefs == nil {
 		return nil, noBoardError(modelName)
 	}
+	return pinDefs, nil
+}
 
+func getBoardMapping(pinDefs []PinDefinition,) (map[int]GPIOBoardMapping, error) {
 	gpioChipDirs := map[string]string{}
 	gpioChipBase := map[string]int{}
 	gpioChipNgpio := map[string]int{}

--- a/components/board/genericlinux/data.go
+++ b/components/board/genericlinux/data.go
@@ -60,10 +60,7 @@ func noBoardError(modelName string) error {
 
 // GetGPIOBoardMappings attempts to find a compatible board-pin mapping for the given mappings.
 func GetGPIOBoardMappings(modelName string, boardInfoMappings map[string]BoardInformation) (map[int]GPIOBoardMapping, error) {
-	const (
-		compatiblePath = "/proc/device-tree/compatible"
-		idsPath        = "/proc/device-tree/chosen/plugin-manager/ids"
-	)
+	const compatiblePath = "/proc/device-tree/compatible"
 
 	compatiblesRd, err := os.ReadFile(compatiblePath)
 	if err != nil {


### PR DESCRIPTION
This is in anticipation of adding something similar for PWM chips to fix RSDK-2332. I recommend reviewing this commit-by-commit, though perhaps it's easy enough all together, too.

No changes to functionality are intended, this is just reorganizing things so they're easier to think about and easier to extend in the future.

Tried on an Orin: GPIO functionality appears unchanged.