### PR TITLE
RSDK-2435 Remove Dev Flag RDK

### DIFF
--- a/services/slam/builtin/builtin.go
+++ b/services/slam/builtin/builtin.go
@@ -32,11 +32,11 @@ import (
 	"go.viam.com/rdk/rimage/transform"
 	"go.viam.com/rdk/services/slam"
 	"go.viam.com/rdk/services/slam/grpchelper"
-	"go.viam.com/rdk/spatialmath"
-	rdkutils "go.viam.com/rdk/utils"
 	slamConfig "go.viam.com/rdk/services/slam/slam_copy/config"
 	"go.viam.com/rdk/services/slam/slam_copy/dataprocess"
 	slamUtils "go.viam.com/rdk/services/slam/slam_copy/utils"
+	"go.viam.com/rdk/spatialmath"
+	rdkutils "go.viam.com/rdk/utils"
 )
 
 var (
@@ -170,8 +170,6 @@ type builtIn struct {
 	port       string
 	dataRateMs int
 	mapRateSec int
-
-	dev bool
 
 	cancelFunc              func()
 	logger                  golog.Logger
@@ -353,7 +351,6 @@ func NewBuiltIn(ctx context.Context, deps registry.Dependencies, config config.S
 		useLiveData:           useLiveData,
 		deleteProcessedData:   deleteProcessedData,
 		port:                  port,
-		dev:                   svcConfig.Dev,
 		dataRateMs:            dataRateMsec,
 		mapRateSec:            mapRateSec,
 		cancelFunc:            cancelFunc,

--- a/services/slam/slam_copy/config/config.go
+++ b/services/slam/slam_copy/config/config.go
@@ -53,7 +53,6 @@ type AttrConfig struct {
 	MapRateSec          *int              `json:"map_rate_sec"`
 	Port                string            `json:"port"`
 	DeleteProcessedData *bool             `json:"delete_processed_data"`
-	Dev                 bool              `json:"dev"`
 }
 
 // NewAttrConfig creates a SLAM config from a service config.

--- a/services/slam/slam_copy/config/config_test.go
+++ b/services/slam/slam_copy/config/config_test.go
@@ -151,7 +151,6 @@ func TestNewAttrConf(t *testing.T) {
 		cfgService.Attributes["map_rate_sec"] = 1002
 		cfgService.Attributes["port"] = "47"
 		cfgService.Attributes["delete_processed_data"] = true
-		cfgService.Attributes["dev"] = false
 
 		cfgService.Attributes["config_params"] = map[string]string{
 			"mode":    "test mode",
@@ -166,7 +165,6 @@ func TestNewAttrConf(t *testing.T) {
 		test.That(t, cfg.DataRateMsec, test.ShouldEqual, cfgService.Attributes["data_rate_msec"])
 		test.That(t, *cfg.MapRateSec, test.ShouldEqual, cfgService.Attributes["map_rate_sec"])
 		test.That(t, cfg.Port, test.ShouldEqual, cfgService.Attributes["port"])
-		test.That(t, cfg.Dev, test.ShouldEqual, cfgService.Attributes["dev"])
 		test.That(t, cfg.ConfigParams, test.ShouldResemble, cfgService.Attributes["config_params"])
 	})
 }


### PR DESCRIPTION
Remove the unused dev flag in SLAM Map Representation project. Similar edits were also made in slam, viam-cartographer, viam-orb-slam3 repos, see associated PRs.

JIRA Ticket: https://viam.atlassian.net/browse/RSDK-2435

Associated PRs: 
- https://github.com/viamrobotics/slam/pull/184
- https://github.com/viamrobotics/viam-orb-slam3/pull/34
- https://github.com/viamrobotics/viam-cartographer/pull/37