### PR TITLE
RSDK-2524: Create new "fake" camera model that does not depend on a real image

### DIFF
--- a/components/camera/fake/camera.go
+++ b/components/camera/fake/camera.go
@@ -4,11 +4,12 @@ package fake
 import (
 	"context"
 	"image"
+	"image/color"
+	"math"
 
 	"github.com/edaniels/golog"
+	"github.com/golang/geo/r3"
 	"github.com/pkg/errors"
-	"go.viam.com/utils/artifact"
-	"golang.org/x/image/draw"
 
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/components/generic"
@@ -176,53 +177,46 @@ type Camera struct {
 	Height int
 }
 
-// Read always returns the same image of a chess board.
+// Read always returns the same image of a yellow to blue gradient.
 func (c *Camera) Read(ctx context.Context) (image.Image, func(), error) {
-	img, err := c.getColorImage()
-	return img, func() {}, err
+	width := float64(c.Width)
+	height := float64(c.Height)
+	img := image.NewRGBA(image.Rect(0, 0, c.Width, c.Height))
+
+	totalDist := math.Sqrt(math.Pow(0-width, 2) + math.Pow(0-height, 2))
+
+	var x, y float64
+	for x = 0; x < width; x++ {
+		for y = 0; y < height; y++ {
+			dist := math.Sqrt(math.Pow(0-x, 2) + math.Pow(0-y, 2))
+			dist /= totalDist
+			thisColor := color.RGBA{uint8(255 - (255 * dist)), uint8(255 - (255 * dist)), uint8(0 + (255 * dist)), 255}
+			img.Set(int(x), int(y), thisColor)
+		}
+	}
+
+	return rimage.ConvertImage(img), func() {}, nil
 }
 
-// NextPointCloud always returns a pointcloud of the chess board.
+// NextPointCloud always returns a pointcloud of a yellow to blue gradient, with the depth determined by the intensity of blue.
 func (c *Camera) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, error) {
-	img, err := c.getColorImage()
-	if err != nil {
-		return nil, err
-	}
-	dm, err := c.getDepthImage(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return c.Model.RGBDToPointCloud(img, dm)
-}
+	dm := pointcloud.New()
+	width := float64(c.Width)
+	height := float64(c.Height)
 
-// getColorImage always returns the same color image of a chess board.
-func (c *Camera) getColorImage() (*rimage.Image, error) {
-	img, err := rimage.NewImageFromFile(artifact.MustPath("rimage/board2.png"))
-	if err != nil {
-		return nil, err
-	}
-	if c.Height == initialHeight && c.Width == initialWidth {
-		return img, nil
-	}
-	dst := image.NewRGBA(image.Rect(0, 0, c.Width, c.Height))
-	draw.NearestNeighbor.Scale(dst, dst.Bounds(), img, img.Bounds(), draw.Over, nil)
-	return rimage.ConvertImage(dst), nil
-}
+	totalDist := math.Sqrt(math.Pow(0-width, 2) + math.Pow(0-height, 2))
 
-// getDepthImage always returns the same depth image of a chess board.
-func (c *Camera) getDepthImage(ctx context.Context) (*rimage.DepthMap, error) {
-	dm, err := rimage.NewDepthMapFromFile(ctx, artifact.MustPath("rimage/board2_gray.png"))
-	if err != nil {
-		return nil, err
+	var x, y float64
+	for x = 0; x < width; x++ {
+		for y = 0; y < height; y++ {
+			dist := math.Sqrt(math.Pow(0-x, 2) + math.Pow(0-y, 2))
+			dist /= totalDist
+			thisColor := color.NRGBA{uint8(255 - (255 * dist)), uint8(255 - (255 * dist)), uint8(0 + (255 * dist)), 255}
+			err := dm.Set(r3.Vector{X: x, Y: y, Z: 255 * dist}, pointcloud.NewColoredData(thisColor))
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
-	if c.Height == initialHeight && c.Width == initialWidth {
-		return dm, nil
-	}
-	dm2, err := rimage.ConvertImageToGray16(dm)
-	if err != nil {
-		return nil, err
-	}
-	dst := image.NewGray16(image.Rect(0, 0, c.Width, c.Height))
-	draw.NearestNeighbor.Scale(dst, dst.Bounds(), dm2, dm2.Bounds(), draw.Over, nil)
-	return rimage.ConvertImageToDepthMap(ctx, dst)
+	return dm, nil
 }

--- a/components/camera/fake/camera.go
+++ b/components/camera/fake/camera.go
@@ -173,7 +173,7 @@ type Camera struct {
 	Width           int
 	Height          int
 	cacheImage      *image.RGBA
-	cachePointCloud *pointcloud.PointCloud
+	cachePointCloud pointcloud.PointCloud
 }
 
 // Read always returns the same image of a yellow to blue gradient.
@@ -196,14 +196,14 @@ func (c *Camera) Read(ctx context.Context) (image.Image, func(), error) {
 			img.Set(int(x), int(y), thisColor)
 		}
 	}
-
+	c.cacheImage = img
 	return rimage.ConvertImage(img), func() {}, nil
 }
 
 // NextPointCloud always returns a pointcloud of a yellow to blue gradient, with the depth determined by the intensity of blue.
 func (c *Camera) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, error) {
 	if c.cachePointCloud != nil {
-		return *c.cachePointCloud, nil
+		return c.cachePointCloud, nil
 	}
 	dm := pointcloud.New()
 	width := float64(c.Width)
@@ -223,5 +223,6 @@ func (c *Camera) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, err
 			}
 		}
 	}
+	c.cachePointCloud = dm
 	return dm, nil
 }

--- a/components/camera/fake/camera.go
+++ b/components/camera/fake/camera.go
@@ -89,9 +89,6 @@ func (at *Attrs) Validate() error {
 	if at.Width%2 != 0 {
 		return errors.Errorf("odd-number resolutions cannot be rendered, cannot use a width of %d", at.Width)
 	}
-	if at.Height > 0 && at.Width > 0 {
-		return errors.New("only height or width can be specified, not both")
-	}
 	return nil
 }
 

--- a/components/camera/fake/camera.go
+++ b/components/camera/fake/camera.go
@@ -168,14 +168,19 @@ func fakeModel(width, height int) (*transform.PinholeCameraModel, int, int) {
 // Camera is a fake camera that always returns the same image.
 type Camera struct {
 	generic.Echo
-	Name   string
-	Model  *transform.PinholeCameraModel
-	Width  int
-	Height int
+	Name            string
+	Model           *transform.PinholeCameraModel
+	Width           int
+	Height          int
+	cacheImage      *image.RGBA
+	cachePointCloud *pointcloud.PointCloud
 }
 
 // Read always returns the same image of a yellow to blue gradient.
 func (c *Camera) Read(ctx context.Context) (image.Image, func(), error) {
+	if c.cacheImage != nil {
+		return c.cacheImage, func() {}, nil
+	}
 	width := float64(c.Width)
 	height := float64(c.Height)
 	img := image.NewRGBA(image.Rect(0, 0, c.Width, c.Height))
@@ -197,6 +202,9 @@ func (c *Camera) Read(ctx context.Context) (image.Image, func(), error) {
 
 // NextPointCloud always returns a pointcloud of a yellow to blue gradient, with the depth determined by the intensity of blue.
 func (c *Camera) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, error) {
+	if c.cachePointCloud != nil {
+		return *c.cachePointCloud, nil
+	}
 	dm := pointcloud.New()
 	width := float64(c.Width)
 	height := float64(c.Height)

--- a/components/camera/fake/camera_test.go
+++ b/components/camera/fake/camera_test.go
@@ -15,13 +15,13 @@ func TestFakeCameraHighResolution(t *testing.T) {
 	camOri := &Camera{Name: "test_high", Model: model, Width: width, Height: height}
 	cam, err := camera.NewFromReader(context.Background(), camOri, model, camera.ColorStream)
 	test.That(t, err, test.ShouldBeNil)
-	cameraTest(t, cam, 1280, 720, 812050, model.PinholeCameraIntrinsics, model.Distortion)
+	cameraTest(t, cam, 1280, 720, 921600, model.PinholeCameraIntrinsics, model.Distortion)
 	// (0,0) entry defaults to (1280, 720)
 	model, width, height = fakeModel(0, 0)
 	camOri = &Camera{Name: "test_high_zero", Model: model, Width: width, Height: height}
 	cam, err = camera.NewFromReader(context.Background(), camOri, model, camera.ColorStream)
 	test.That(t, err, test.ShouldBeNil)
-	cameraTest(t, cam, 1280, 720, 812050, model.PinholeCameraIntrinsics, model.Distortion)
+	cameraTest(t, cam, 1280, 720, 921600, model.PinholeCameraIntrinsics, model.Distortion)
 }
 
 func TestFakeCameraMedResolution(t *testing.T) {
@@ -29,7 +29,7 @@ func TestFakeCameraMedResolution(t *testing.T) {
 	camOri := &Camera{Name: "test_high", Model: model, Width: width, Height: height}
 	cam, err := camera.NewFromReader(context.Background(), camOri, model, camera.ColorStream)
 	test.That(t, err, test.ShouldBeNil)
-	cameraTest(t, cam, 640, 360, 203139, model.PinholeCameraIntrinsics, model.Distortion)
+	cameraTest(t, cam, 640, 360, 230400, model.PinholeCameraIntrinsics, model.Distortion)
 	err = cam.Close(context.Background())
 	test.That(t, err, test.ShouldBeNil)
 }
@@ -41,13 +41,13 @@ func TestFakeCameraUnspecified(t *testing.T) {
 	camOri := &Camera{Name: "test_320", Model: model, Width: width, Height: height}
 	cam, err := camera.NewFromReader(context.Background(), camOri, model, camera.ColorStream)
 	test.That(t, err, test.ShouldBeNil)
-	cameraTest(t, cam, 320, 180, 50717, model.PinholeCameraIntrinsics, model.Distortion)
+	cameraTest(t, cam, 320, 180, 57600, model.PinholeCameraIntrinsics, model.Distortion)
 	// (0, 180) -> (320, 180)
 	model, width, height = fakeModel(0, 180)
 	camOri = &Camera{Name: "test_180", Model: model, Width: width, Height: height}
 	cam, err = camera.NewFromReader(context.Background(), camOri, model, camera.ColorStream)
 	test.That(t, err, test.ShouldBeNil)
-	cameraTest(t, cam, 320, 180, 50717, model.PinholeCameraIntrinsics, model.Distortion)
+	cameraTest(t, cam, 320, 180, 57600, model.PinholeCameraIntrinsics, model.Distortion)
 }
 
 func TestFakeCameraParams(t *testing.T) {

--- a/components/camera/fake/camera_test.go
+++ b/components/camera/fake/camera_test.go
@@ -51,19 +51,12 @@ func TestFakeCameraUnspecified(t *testing.T) {
 }
 
 func TestFakeCameraParams(t *testing.T) {
-	// test only height or width
-	cfg := &Attrs{
-		Width:  320,
-		Height: 320,
-	}
-	err := cfg.Validate()
-	test.That(t, err, test.ShouldNotBeNil)
 	// test odd width and height
-	cfg = &Attrs{
+	cfg := &Attrs{
 		Width:  321,
 		Height: 0,
 	}
-	err = cfg.Validate()
+	err := cfg.Validate()
 	test.That(t, err, test.ShouldNotBeNil)
 	cfg = &Attrs{
 		Width:  0,


### PR DESCRIPTION
This change removes the chess board fake camera image and point cloud, and instead generates a fake image and point cloud to display. They are generated as follows:

-  The image is a gradient from blue to yellow, where the intensity is fully yellow in the upper left, and fully blue in the lower right.
![image](https://user-images.githubusercontent.com/106617924/229219904-76659640-7598-460d-9a33-ec505fceea0e.png)
- The point cloud is a sloping plane of this gradient, starting at height 0 at the fully yellow pixel (0,0), and sloping upwards as the intensity of blue increases. Its (x,y) position is its x,y pixel value, and its z position is the intensity of “blue” at that point.
![Untitled](https://user-images.githubusercontent.com/106617924/229220242-28bbfc1c-afd7-4393-9bf6-297cdda09ce5.jpg) 

This gets rid of the chess board images all together because they couldn't be found if not running RDK locally, but they also cannot be embedded into RDK.