### PR TITLE
RSDK-2401 move to position calls with particular start goal specifications will erroneously fail

### DIFF
--- a/motionplan/cBiRRT.go
+++ b/motionplan/cBiRRT.go
@@ -269,12 +269,17 @@ func (mp *cBiRRTMotionPlanner) constrainedExtend(
 	near, target node,
 	mchan chan node,
 ) {
+	// Once per extend, allow qstep to be doubled as a means to escape from configurations which gradient descend to their seed
+	qstep := mp.algOpts.qstep
+	doubled := false
+
 	oldNear := near
 	// This should iterate until one of the following conditions:
 	// 1) we have reached the target
 	// 2) the request is cancelled/times out
 	// 3) we are no longer approaching the target and our "best" node is further away than the previous best
 	// 4) further iterations change our best node by close-to-zero amounts
+	// 5) we have iterated more than maxExtendIter times
 	for i := 0; i < maxExtendIter; i++ {
 		select {
 		case <-ctx.Done():
@@ -304,7 +309,7 @@ func (mp *cBiRRTMotionPlanner) constrainedExtend(
 				newNear = append(newNear, nearInput)
 			} else {
 				v1, v2 := nearInput.Value, target.Q()[j].Value
-				newVal := math.Min(mp.algOpts.qstep[j], math.Abs(v2-v1))
+				newVal := math.Min(qstep[j], math.Abs(v2-v1))
 				// get correct sign
 				newVal *= (v2 - v1) / math.Abs(v2-v1)
 				newNear = append(newNear, referenceframe.Input{nearInput.Value + newVal})
@@ -316,11 +321,23 @@ func (mp *cBiRRTMotionPlanner) constrainedExtend(
 		if newNear != nil {
 			nearDist := mp.planOpts.DistanceFunc(&Segment{StartConfiguration: oldNear.Q(), EndConfiguration: newNear})
 			if nearDist < math.Pow(mp.algOpts.JointSolveDist, 3) {
-				// We've arrived back at very nearly the same configuration again; stop solving and send back oldNear.
-				// Do not add the near-identical configuration to the RRT map
-				mchan <- oldNear
-				return
+				if !doubled {
+					doubled = true
+					// Check if doubling qstep will allow escape from the identical configuration
+					// If not, we terminate and return.
+					// If so, qstep will be reset to its original value after the rescue.
+					for i, q := range qstep {
+						qstep[i] = q * 2.0
+					}
+					continue
+				} else {
+					// We've arrived back at very nearly the same configuration again; stop solving and send back oldNear.
+					// Do not add the near-identical configuration to the RRT map
+					mchan <- oldNear
+					return
+				}
 			}
+			qstep = mp.algOpts.qstep
 			// constrainNear will ensure path between oldNear and newNear satisfies constraints along the way
 			near = &basicNode{q: newNear}
 			rrtMap[near] = oldNear

--- a/motionplan/cBiRRT.go
+++ b/motionplan/cBiRRT.go
@@ -269,8 +269,9 @@ func (mp *cBiRRTMotionPlanner) constrainedExtend(
 	near, target node,
 	mchan chan node,
 ) {
-	// Once per extend, allow qstep to be doubled as a means to escape from configurations which gradient descend to their seed
-	qstep := mp.algOpts.qstep
+	// Allow qstep to be doubled as a means to escape from configurations which gradient descend to their seed
+	qstep := make([]float64, len(mp.algOpts.qstep))
+	copy(qstep, mp.algOpts.qstep)
 	doubled := false
 
 	oldNear := near
@@ -337,7 +338,10 @@ func (mp *cBiRRTMotionPlanner) constrainedExtend(
 					return
 				}
 			}
-			qstep = mp.algOpts.qstep
+			if doubled {
+				copy(qstep, mp.algOpts.qstep)
+				doubled = false
+			}
 			// constrainNear will ensure path between oldNear and newNear satisfies constraints along the way
 			near = &basicNode{q: newNear}
 			rrtMap[near] = oldNear


### PR DESCRIPTION
While the merge of 1899 had enough of a subtle adjustment of underlying float values that 2401 is coincidentally no longer hit on `main`, the bug still existed.

This PR was tested against the old failing `main` branch pre-1899 and a solution valid both pre- and post-1899 was developed.