### PR TITLE
Add support for nanopi boards supported by periph.io

### DIFF
--- a/components/board/nanopi/board.go
+++ b/components/board/nanopi/board.go
@@ -1,0 +1,19 @@
+// Package nanopi implements a nanopi based board.
+package nanopi
+
+import (
+	"github.com/edaniels/golog"
+	"periph.io/x/host/v3"
+
+	"go.viam.com/rdk/components/board/genericlinux"
+)
+
+const modelName = "nanopi"
+
+func init() {
+	if _, err := host.Init(); err != nil {
+		golog.Global().Debugw("error initializing host", "error", err)
+	}
+
+	genericlinux.RegisterBoard(modelName, nil, true)
+}

--- a/components/board/nanopi/board.go
+++ b/components/board/nanopi/board.go
@@ -1,4 +1,7 @@
 // Package nanopi implements a nanopi based board.
+// This is an experimental package.
+// Supported functionality: GPIO pins, I2C, SPI, Software PWM
+// Unsupported functionality: Digital Interrupts, Hardware PWM
 package nanopi
 
 import (

--- a/components/board/nanopi/board.go
+++ b/components/board/nanopi/board.go
@@ -17,6 +17,5 @@ func init() {
 	if _, err := host.Init(); err != nil {
 		golog.Global().Debugw("error initializing host", "error", err)
 	}
-
 	genericlinux.RegisterBoard(modelName, nil, true)
 }

--- a/components/board/register/register.go
+++ b/components/board/register/register.go
@@ -8,6 +8,7 @@ import (
 	_ "go.viam.com/rdk/components/board/fake"
 	_ "go.viam.com/rdk/components/board/hat/pca9685"
 	_ "go.viam.com/rdk/components/board/jetson"
+	_ "go.viam.com/rdk/components/board/nanopi"
 	_ "go.viam.com/rdk/components/board/numato"
 	_ "go.viam.com/rdk/components/board/pi"
 	_ "go.viam.com/rdk/components/board/ti"


### PR DESCRIPTION
Bee ring is using the nanopi neo air, which is now supported OOTB by periph.io https://github.com/periph/host/pull/30

This means very little is required to use the nanopi neo air with RDK's genericlinux.

Tested this on the real hardware and confirmed that GPIO, i2c, and SPI are all working.