### PR TITLE
[RSDK-2332] Look for hardware PWM devices during board initialization

### DIFF
--- a/components/board/genericlinux/data.go
+++ b/components/board/genericlinux/data.go
@@ -224,10 +224,10 @@ func getPwmChipDefs(pinDefs []PinDefinition) (map[string]pwmChipData, error) {
 	// Now, look for all chips whose names we found.
 	pwmChipsInfo := map[string]pwmChipData{}
 	for chipName := range pwmChipNames {
-		chipDir := fmt.Sprintf("/sys/devices/platform/%s/pwm", chipName)
 		// There should be a single directory within /sys/devices/platform/<chipName>/pwm/, whose
 		// name is mirrored in /sys/class/pwm. That's the one we want to use.
 		// TODO[RSDK-2332]: make this universally usable by all genericlinux boards.
+		chipDir := fmt.Sprintf("/sys/devices/platform/%s/pwm", chipName)
 		files, err := os.ReadDir(chipDir)
 		if err != nil {
 			return nil, err

--- a/components/board/genericlinux/data.go
+++ b/components/board/genericlinux/data.go
@@ -66,6 +66,15 @@ type gpioChipData struct {
 	Ngpio int    // Taken from the /ngpio pseudofile in sysfs: number of lines on the chip
 }
 
+// pwmChipData is a struct used solely within GetGPIOBoardMappings and its sub-pieces. It
+// describes a PWM chip within sysfs. It has the exact same form as gpioChipData, but we make it a
+// separate type so you can't accidentally use one when you should have used the other.
+type pwmChipData struct {
+	Dir   string // Pseudofile within sysfs to interact with this chip
+	Base  int    // Taken from the /base pseudofile in sysfs: offset to the start of the lines
+	Ngpio int    // Taken from the /ngpio pseudofile in sysfs: number of lines on the chip
+}
+
 // GetGPIOBoardMappings attempts to find a compatible board-pin mapping for the given mappings.
 func GetGPIOBoardMappings(modelName string, boardInfoMappings map[string]BoardInformation) (map[int]GPIOBoardMapping, error) {
 	pinDefs, err := getCompatiblePinDefs(modelName, boardInfoMappings)
@@ -78,7 +87,12 @@ func GetGPIOBoardMappings(modelName string, boardInfoMappings map[string]BoardIn
 		return nil, err
 	}
 
-	return getBoardMapping(pinDefs, gpioChipInfo)
+	pwmChipInfo, err := getPwmChipDefs(pinDefs)
+	if err != nil {
+		return nil, err
+	}
+
+	return getBoardMapping(pinDefs, gpioChipInfo, pwmChipInfo)
 }
 
 // getCompatiblePinDefs returns a list of pin definitions, from the first BoardInformation struct
@@ -198,7 +212,11 @@ func getGpioChipDefs(pinDefs []PinDefinition) (map[string]gpioChipData, error) {
 	return gpioChipInfo, nil
 }
 
-func getBoardMapping(pinDefs []PinDefinition, gpioChipInfo map[string]gpioChipData) (map[int]GPIOBoardMapping, error) {
+func getPwmChipDefs(pinDefs []PinDefinition) (map[string]pwmChipData, error) {
+	return nil, errors.New("unimplemented")
+}
+
+func getBoardMapping(pinDefs []PinDefinition, gpioChipInfo map[string]gpioChipData, pwmChipInfo map[string]pwmChipData) (map[int]GPIOBoardMapping, error) {
 	data := make(map[int]GPIOBoardMapping, len(pinDefs))
 
 	for _, pinDef := range pinDefs {

--- a/components/board/genericlinux/data.go
+++ b/components/board/genericlinux/data.go
@@ -240,9 +240,18 @@ func getPwmChipDefs(pinDefs []PinDefinition) (map[string]pwmChipData, error) {
 			}
 			found = true
 			chipPath := fmt.Sprintf("/sys/class/pwm/%s", file.Name())
-			baseInt := -1 // TODO: implement these.
-			npwmInt := -1
-			pwmChipsInfo[chipName] = pwmChipData{Dir: chipPath, Base: baseInt, Npwm: npwmInt}
+
+			base, err := readIntFile(filepath.Join(chipPath, "base"))
+			if err != nil {
+				return nil, err
+			}
+
+			npwm, err := readIntFile(filepath.Join(chipPath, "npwm"))
+			if err != nil {
+				return nil, err
+			}
+
+			pwmChipsInfo[chipName] = pwmChipData{Dir: chipPath, Base: base, Npwm: npwm}
 			break
 		}
 		if !found {

--- a/components/board/genericlinux/data.go
+++ b/components/board/genericlinux/data.go
@@ -70,7 +70,7 @@ type gpioChipData struct {
 // describes a PWM chip within sysfs. It has the exact same form as gpioChipData, but we make it a
 // separate type so you can't accidentally use one when you should have used the other.
 type pwmChipData struct {
-	Dir  string // Pseudofile within sysfs to interact with this chip
+	Dir  string // Absolute path to pseudofile within sysfs to interact with this chip
 	Base int    // Taken from the /base pseudofile in sysfs: offset to the start of the lines
 	Npwm int    // Taken from the /ngpio pseudofile in sysfs: number of lines on the chip
 }

--- a/components/board/genericlinux/data.go
+++ b/components/board/genericlinux/data.go
@@ -239,6 +239,7 @@ func getBoardMapping(pinDefs []PinDefinition, gpioChipsInfo map[string]gpioChipD
 			}
 		} else {
 			if pinDef.PWMChipSysFSDir == "" {
+				// This pin isn't supposed to have hardware PWM support; all is well.
 				pwmChipInfo = dummyPwmInfo
 			} else {
 				return nil, fmt.Errorf("unknown PWM device %s for pin %d",

--- a/components/board/genericlinux/data.go
+++ b/components/board/genericlinux/data.go
@@ -82,17 +82,17 @@ func GetGPIOBoardMappings(modelName string, boardInfoMappings map[string]BoardIn
 		return nil, err
 	}
 
-	gpioChipInfo, err := getGpioChipDefs(pinDefs)
+	gpioChipsInfo, err := getGpioChipDefs(pinDefs)
 	if err != nil {
 		return nil, err
 	}
 
-	pwmChipInfo, err := getPwmChipDefs(pinDefs)
+	pwmChipsInfo, err := getPwmChipDefs(pinDefs)
 	if err != nil {
 		return nil, err
 	}
 
-	return getBoardMapping(pinDefs, gpioChipInfo, pwmChipInfo)
+	return getBoardMapping(pinDefs, gpioChipsInfo, pwmChipsInfo)
 }
 
 // getCompatiblePinDefs returns a list of pin definitions, from the first BoardInformation struct
@@ -126,7 +126,7 @@ func getCompatiblePinDefs(modelName string, boardInfoMappings map[string]BoardIn
 }
 
 func getGpioChipDefs(pinDefs []PinDefinition) (map[string]gpioChipData, error) {
-	gpioChipInfo := map[string]gpioChipData{}
+	gpioChipsInfo := map[string]gpioChipData{}
 	sysfsPrefixes := []string{"/sys/devices/", "/sys/devices/platform/", "/sys/devices/platform/bus@100000/"}
 
 	// Get a set of all the chip names with duplicates removed. Go doesn't have native set objects,
@@ -200,7 +200,7 @@ func getGpioChipDefs(pinDefs []PinDefinition) (map[string]gpioChipData, error) {
 				return nil, err
 			}
 
-			gpioChipInfo[gpioChipName] = gpioChipData{
+			gpioChipsInfo[gpioChipName] = gpioChipData{
 				Dir:   chipFileName,
 				Base:  int(baseParsed),
 				Ngpio: int(ngpioParsed),
@@ -209,20 +209,20 @@ func getGpioChipDefs(pinDefs []PinDefinition) (map[string]gpioChipData, error) {
 		}
 	}
 
-	return gpioChipInfo, nil
+	return gpioChipsInfo, nil
 }
 
 func getPwmChipDefs(pinDefs []PinDefinition) (map[string]pwmChipData, error) {
 	return nil, errors.New("unimplemented")
 }
 
-func getBoardMapping(pinDefs []PinDefinition, gpioChipInfo map[string]gpioChipData, pwmChipInfo map[string]pwmChipData) (map[int]GPIOBoardMapping, error) {
+func getBoardMapping(pinDefs []PinDefinition, gpioChipsInfo map[string]gpioChipData, pwmChipsInfo map[string]pwmChipData) (map[int]GPIOBoardMapping, error) {
 	data := make(map[int]GPIOBoardMapping, len(pinDefs))
 
 	for _, pinDef := range pinDefs {
 		key := pinDef.PinNumberBoard
 
-		chipInfo, ok := gpioChipInfo[pinDef.GPIOChipSysFSDir]
+		chipInfo, ok := gpioChipsInfo[pinDef.GPIOChipSysFSDir]
 		if !ok {
 			return nil, fmt.Errorf("unknown GPIO device %s for pin %d",
 				pinDef.GPIOChipSysFSDir, key)

--- a/components/board/genericlinux/data.go
+++ b/components/board/genericlinux/data.go
@@ -279,8 +279,8 @@ func getBoardMapping(pinDefs []PinDefinition, gpioChipsInfo map[string]gpioChipD
 		pwmChipInfo, ok := pwmChipsInfo[pinDef.PWMChipSysFSDir]
 		if ok {
 			if pinDef.PWMID >= pwmChipInfo.Npwm {
-				return nil, fmt.Errorf("too high PWM ID %s for pin %d",
-					pinDef.PWMID, key)
+				return nil, fmt.Errorf("too high PWM ID %d for pin %d (npwm is %d for chip %s)",
+					pinDef.PWMID, key, pwmChipInfo.Npwm, pinDef.PWMChipSysFSDir)
 			}
 		} else {
 			if pinDef.PWMChipSysFSDir == "" {

--- a/components/board/genericlinux/data.go
+++ b/components/board/genericlinux/data.go
@@ -124,6 +124,17 @@ func getCompatiblePinDefs(modelName string, boardInfoMappings map[string]BoardIn
 	return pinDefs, nil
 }
 
+// A helper function: we read the contents of filePath and return its integer value.
+func readIntFile(filePath string) (int, error) {
+	//nolint:gosec
+	contents, err := os.ReadFile(filePath)
+	if err != nil {
+		return -1, err
+	}
+	resultInt64, err := strconv.ParseInt(strings.TrimSpace(string(contents)), 10, 64)
+	return int(resultInt64), err
+}
+
 func getGpioChipDefs(pinDefs []PinDefinition) (map[string]gpioChipData, error) {
 	gpioChipsInfo := map[string]gpioChipData{}
 	sysfsPrefixes := []string{"/sys/devices/", "/sys/devices/platform/", "/sys/devices/platform/bus@100000/"}
@@ -177,32 +188,20 @@ func getGpioChipDefs(pinDefs []PinDefinition) (map[string]gpioChipData, error) {
 				continue
 			}
 
-			baseFn := filepath.Join(gpioChipGPIODir, file.Name(), "base")
-			//nolint:gosec
-			baseRd, err := os.ReadFile(baseFn)
-			if err != nil {
-				return nil, err
-			}
-			baseParsed, err := strconv.ParseInt(strings.TrimSpace(string(baseRd)), 10, 64)
+			base, err := readIntFile(filepath.Join(gpioChipGPIODir, file.Name(), "base"))
 			if err != nil {
 				return nil, err
 			}
 
-			ngpioFn := filepath.Join(gpioChipGPIODir, file.Name(), "ngpio")
-			//nolint:gosec
-			ngpioRd, err := os.ReadFile(ngpioFn)
-			if err != nil {
-				return nil, err
-			}
-			ngpioParsed, err := strconv.ParseInt(strings.TrimSpace(string(ngpioRd)), 10, 64)
+			ngpio, err := readIntFile(filepath.Join(gpioChipGPIODir, file.Name(), "ngpio"))
 			if err != nil {
 				return nil, err
 			}
 
 			gpioChipsInfo[gpioChipName] = gpioChipData{
 				Dir:   chipFileName,
-				Base:  int(baseParsed),
-				Ngpio: int(ngpioParsed),
+				Base:  base,
+				Ngpio: ngpio,
 			}
 			break
 		}

--- a/components/board/genericlinux/hw_pwm.go
+++ b/components/board/genericlinux/hw_pwm.go
@@ -8,7 +8,6 @@ package genericlinux
 import (
 	"fmt"
 	"os"
-	"strings"
 	"sync"
 
 	"github.com/edaniels/golog"
@@ -24,23 +23,8 @@ type pwmDevice struct {
 	logger golog.Logger
 }
 
-func newPwmDevice(chipName string, line int, logger golog.Logger) (*pwmDevice, error) {
-	// There should be a single directory within /sys/devices/platform/<chipName>/pwm/, whose name
-	// is mirrored in /sys/class/pwm. That's the one we want to use.
-	// TODO[RSDK-2332]: make this universally usable by all genericlinux boards.
-	chipDir := fmt.Sprintf("/sys/devices/platform/%s/pwm", chipName)
-	files, err := os.ReadDir(chipDir)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, file := range files {
-		if strings.Contains(file.Name(), "pwmchip") && file.IsDir() {
-			chipPath := fmt.Sprintf("/sys/class/pwm/%s", file.Name())
-			return &pwmDevice{chipPath: chipPath, line: line, logger: logger}, nil
-		}
-	}
-	return nil, errors.Errorf("Could not find any PWM device with name %s", chipName)
+func newPwmDevice(chipPath string, line int, logger golog.Logger) (*pwmDevice, error) {
+	return &pwmDevice{chipPath: chipPath, line: line, logger: logger}, nil
 }
 
 func writeValue(filepath string, value uint64) error {


### PR DESCRIPTION
No changes to behavior should yet exist, as only a single board uses non-Periph pins so far. The changes to behavior will come when other boards start using non-Periph pins, which should allow them to use hardware PWM.

Changes include:
- Create the helper function `readIntFile` when initializing a board, and using that in several places instead of copying and pasting paragraphs of code.
- Rename `gpioChipInfo` to `gpioChipsInfo` because it contains data about multiple chips. This helps with other variable names later, when we need to specify whether we're talking about the `gpio` or `pwm` chip.
- Move the place where we look for hardware PWM chips, from where we initialize PWM structs to where we initialize the board's pin descriptions (the same place where we look for GPIO chips).
- Search for PWM devices in several different directories. The new directories added in are their locations on the BeagleBone and Up4000 boards, though neither of those are used yet because the BB still uses Periph for its pins and the Up4000 isn't ready to go yet. This is just preparation!
- Change the semantic meaning of the `PWMSysFsDir` field within the `GPIOBoardMapping` struct. It used to be a relative path within the one place we look for things, and it's now an absolute path because there are multiple places in sysfs that this directory might be, depending on which board you're on.

Future changes that are planned but will be in a separate PR:
- If you're unable to find a PWM device that you expect to find, _log the error but continue on._ Perhaps you're on a BeagleBone, which requires [modifying the device tree overlays from their factory defaults and then rebooting](https://forum.beagleboard.org/t/overlays-beaglebone-ai-64-pwm/32508), before you can see the PWM devices, and the rest of the board should still be usable as long as you don't try using hardware PWMs.
- Change the BeagleBone board to stop using Periph and start using our own implementation of GPIO pins, including support for hardware PWM.
- When the Up4000 board is further along, change it from Periph to this implementation, too.
- Same thing with the [nanopi board](https://github.com/viamrobotics/rdk/pull/2157), though that's lower priority for now.

Tried on the Orin: everything still works normally. Tried on the BeagleBone: still needs work (hence why the future changes are not in this PR. They'll come later).