### PR TITLE
RSDK-2100 add v4l2loopback_setup.sh

### DIFF
--- a/etc/v4l2loopback_setup.sh
+++ b/etc/v4l2loopback_setup.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+if [ "$(whoami)" == "root" ]; then
+	echo "Please do not run this script directly as root. Use your normal development user account."
+	exit 1
+fi
+
+if ! apt-get --version >/dev/null 2>&1; then
+  echo "Unable to find APT package handling utility (apt-get)"
+  echo "Are you sure you're on a Debian-based Linux variant (e.g. Ubuntu)?"
+  exit 1
+fi
+
+install_dependencies() {
+  sudo bash -c "apt-get install --assume-yes kmod git make gcc libelf-dev"
+}
+
+install_kernel_headers() {
+  echo "updating kernel module..."
+  sudo bash <<-EOS
+	sudo apt-get --assume-yes update
+	sudo apt-get --assume-yes dist-upgrade
+	sudo apt-get --assume-yes upgrade
+	EOS
+	echo "done"
+
+	if [ -f /var/run/reboot-required ]; then
+      echo "Reboot required!"
+      echo "Run script after reboot"
+      exit 1
+  fi
+
+  echo "installing kernel headers..."
+  sudo apt-get --assume-yes install "linux-headers-$(uname -r)" || sudo apt-get --assume-yes install linux-headers
+  echo "done"
+}
+
+install_v4l2loopback(){
+  if command -v v4l2loopback-ctl > /dev/null 2>&1; then
+    echo "v4l2loopback already installed"
+    return
+  fi
+
+  sudo bash <<-EOS
+	apt-get install --assume-yes v4l2loopback-dkms v4l2loopback-utils
+	EOS
+}
+
+install_gstreamer(){
+  if command -v gst-launch-1.0 --version > /dev/null 2>&1; then
+    echo "gstreamer already installed"
+    return
+  fi
+
+  sudo bash <<-EOS
+	apt-get install --assume-yes libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev
+	apt-get install --assume-yes gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad
+	apt-get install --assume-yes gstreamer1.0-plugins-ugly gstreamer1.0-libav gstreamer1.0-tools gstreamer1.0-x
+	apt-get install --assume-yes gstreamer1.0-alsa gstreamer1.0-gl gstreamer1.0-gtk3 gstreamer1.0-qt5 gstreamer1.0-pulseaudio
+	EOS
+}
+
+allow_modprobe_as_superuser() {
+  SUDOER_FILE=/etc/sudoers.d/v4l2loopback
+  if [ -f $SUDOER_FILE ]; then
+    echo "$SUDOER_FILE already exists"
+    exit
+  fi
+
+  echo "$SUDOER_FILE not found"
+  echo "'modprobe', which requires sudo permissions, is needed to load kernel modules."
+  echo "To run 'sudo modprobe' without requesting a password from stdin (essential for automated tasks like go test) it's recommended you give the current user permission to do so"
+  echo "Attempting to do so now..."
+  printf "Do you want to continue? [Y/n] "
+  read -r response
+  case $response in
+    [yY][eE][sS]|[yY]|'')
+      echo
+      echo "Allowing the current user to run 'sudo modprobe' without a password...";
+      echo "$USER ALL = NOPASSWD: $(which modprobe)" | sudo EDITOR='tee -a' visudo -f $SUDOER_FILE
+      echo "Done."
+      echo
+      ;;
+    *)
+      echo "Abort. No changes were made"
+      return
+      ;;
+  esac
+}
+
+# In order to build kernel modules (i.e. v4l2loopback) you must have the kernel headers installed
+install_kernel_headers
+install_dependencies
+install_v4l2loopback
+install_gstreamer
+allow_modprobe_as_superuser


### PR DESCRIPTION
**DESCRIPTION**
The is the first or (probably) three commits for automated testing with virtual cameras. The next couple of commits will create a golang package that uses these tools to create a vritual camera so you don't have do this via the command line. For now, I'd like to make sure the install script is working correctly. Also, no one likes massive commits so I'm breaking this up!

This commit adds a setup script for installing v4l2loopback which is used to created virtual capture and output devices. This script is only for Debian based Linux distros for now.

**DO NOT ATTEMPT TO DEBUG THIS SCRIPT** ... unless you really want to. Just log any issues in the comments or ping me and I'll get on it. It should be painless to use. 

**TESTING**

- Run this script on a Raspberry Pi (or another Linux distro with no cameras connected)
```
./etc/v4l2loopback_setup.sh
```
- load the v4l2loopback kernel module (it should _not_ ask for a password if you answered yes to the prompt in the script)
```
sudo modprobe v4l2loopback
```
- verify the device was created
```
ls -1 /sys/devices/virtual/video4linux
```
- stream a test image to the device
```
gst-launch-1.0 videotestsrc ! tee ! v4l2sink device=/dev/video0
```
- create a camera component in app and view the test image! 
- remove _all_ virtual devices
```
sudo modprobe v4l2loopback -r
```

**GETTING FUNKY**
[v4l2loopback](https://github.com/umlaeute/v4l2loopback) can map to any device path you'd like. To create multiple devices at `/dev/video3`, `/dev/video5`, `/dev/video7`
```
v4l2loopback video_nr=3,4,7
```

[gstreamer](https://gstreamer.freedesktop.org/documentation/videotestsrc/index.html?gi-language=c) allows for all kinds of test images and video formats. Here's an example of using of more complicated options
```
 gst-launch-1.0 -v videotestsrc pattern=ball \                  
    ! video/x-raw,width=1280,height=720 \
    ! videoconvert \
    ! tee \
    ! v4l2sink device=/dev/video0
``` 
