### PR TITLE
[RSDK-2631] Allow GPIO pins on genericlinux boards to act as inputs again! :scream: 

### DIFF
--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -24,14 +24,14 @@ type gpioPin struct {
 	// These values should both be considered immutable.
 	devicePath string
 	offset     uint32
-	line       *gpio.Line
 
 	// These values are mutable. Lock the mutex when interacting with them.
+	line            *gpio.Line
+	isInput         bool
 	swPwmRunning    bool
 	hwPwm           *pwmDevice // Defined in hw_pwm.go, will be nil for pins that don't support it.
 	pwmFreqHz       uint
 	pwmDutyCyclePct float64
-	isInput         bool
 
 	mu        sync.Mutex
 	cancelCtx context.Context

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -45,7 +45,9 @@ func (pin *gpioPin) openGpioFd(isInput bool) error {
 	if isInput != pin.isInput {
 		// We're switching from an input pin to an output one or vice versa. Close the line and
 		// repoen in the other mode.
-		pin.closeGpioFd()
+		if err := pin.closeGpioFd(); err != nil {
+			return err
+		}
 	}
 	pin.isInput = isInput
 	if pin.line != nil {

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -48,8 +48,9 @@ func (pin *gpioPin) openGpioFd(isInput bool) error {
 		if err := pin.closeGpioFd(); err != nil {
 			return err
 		}
+		pin.isInput = isInput
 	}
-	pin.isInput = isInput
+
 	if pin.line != nil {
 		return nil // The pin is already opened, don't re-open it.
 	}

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -31,6 +31,7 @@ type gpioPin struct {
 	hwPwm           *pwmDevice // Defined in hw_pwm.go, will be nil for pins that don't support it.
 	pwmFreqHz       uint
 	pwmDutyCyclePct float64
+	isInput         bool
 
 	mu        sync.Mutex
 	cancelCtx context.Context
@@ -40,7 +41,13 @@ type gpioPin struct {
 
 // This is a private helper function that should only be called when the mutex is locked. It sets
 // pin.line to a valid struct or returns an error.
-func (pin *gpioPin) openGpioFd() error {
+func (pin *gpioPin) openGpioFd(isInput bool) error {
+	if isInput != pin.isInput {
+		// We're switching from an input pin to an output one or vice versa. Close the line and
+		// repoen in the other mode.
+		pin.closeGpioFd()
+	}
+	pin.isInput = isInput
 	if pin.line != nil {
 		return nil // The pin is already opened, don't re-open it.
 	}
@@ -59,11 +66,16 @@ func (pin *gpioPin) openGpioFd() error {
 	}
 	defer utils.UncheckedErrorFunc(chip.Close)
 
-	// The 0 just means the default value for this pin is off. We'll set it to the intended value
-	// in Set(), below.
+	direction := gpio.Output
+	if pin.isInput {
+		direction = gpio.Input
+	}
+
+	// The 0 just means the default output value for this pin is off. We'll set it to the intended
+	// value in Set(), below, if this is an output pin.
 	// NOTE: we could pass in extra flags to configure the pin to be open-source or open-drain, but
-	// we haven't done that yet, and instead go with whatever the default on the board is.
-	line, err := chip.OpenLine(pin.offset, 0, gpio.Output, "viam-gpio")
+	// we haven't done that yet, and we instead go with whatever the default on the board is.
+	line, err := chip.OpenLine(pin.offset, 0, direction, "viam-gpio")
 	if err != nil {
 		return err
 	}
@@ -103,7 +115,7 @@ func (pin *gpioPin) setInternal(isHigh bool) (err error) {
 		value = 0
 	}
 
-	if err := pin.openGpioFd(); err != nil {
+	if err := pin.openGpioFd(/* isInput= */ false); err != nil {
 		return err
 	}
 
@@ -117,7 +129,7 @@ func (pin *gpioPin) Get(
 	pin.mu.Lock()
 	defer pin.mu.Unlock()
 
-	if err := pin.openGpioFd(); err != nil {
+	if err := pin.openGpioFd(/* isInput= */ true); err != nil {
 		return false, err
 	}
 

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -117,7 +117,7 @@ func (pin *gpioPin) setInternal(isHigh bool) (err error) {
 		value = 0
 	}
 
-	if err := pin.openGpioFd(/* isInput= */ false); err != nil {
+	if err := pin.openGpioFd( /* isInput= */ false); err != nil {
 		return err
 	}
 
@@ -131,7 +131,7 @@ func (pin *gpioPin) Get(
 	pin.mu.Lock()
 	defer pin.mu.Unlock()
 
-	if err := pin.openGpioFd(/* isInput= */ true); err != nil {
+	if err := pin.openGpioFd( /* isInput= */ true); err != nil {
 		return false, err
 	}
 


### PR DESCRIPTION
This broke way back in https://github.com/viamrobotics/rdk/pull/1896 and I didn't notice until yesterday!

Tried at my desk: at the very least pins 7 and 40 work properly again. You can set a pin high or low and its output value will be what you'd expect, but then you can connect it to either the 3.3V rail or ground and read it, and it will read the thing it's connected to, not the value it was most recently set to. I'll test the rest of the pins exhaustively when working on RSDK-1027 (making sure the pin definitions are all correct).

The new field is named `isInput` so that the default value (0/false) is the most commonly used one. and then the comments reminding you what the argument means are because it's super easy to forget and not recognize it.

and while I was looking at this, the `line` of the pin has been mutable for months, and should be documented as such.