### PR TITLE
[RSDK-1027] complete the Orin AGX pinout

### DIFF
--- a/components/board/jetson/data.go
+++ b/components/board/jetson/data.go
@@ -369,6 +369,7 @@ var boardInfoMappings = map[string]genericlinux.BoardInformation{
 		// 2023) Viam doesn't use those values for anything anyway.
 		[]genericlinux.PinDefinition{
 			{map[int]int{164: 106}, map[int]string{164: "PQ.06"}, "2200000.gpio", 7, 4, "MCLK05", "GP66", "", -1},
+			// Output-only (due to base board)
 			{map[int]int{164: 110}, map[int]string{164: "PR.02"}, "2200000.gpio", 8, -1, "UART1_TX", "GP70_UART1_TXD_BOOT2_STRAP", "", -1},
 			// Input-only (due to base board)
 			{map[int]int{164: 111}, map[int]string{164: "PR.03"}, "2200000.gpio", 10, -1, "UART1_RX", "GP71_UART1_RXD", "", -1},

--- a/components/board/jetson/data.go
+++ b/components/board/jetson/data.go
@@ -362,10 +362,10 @@ var boardInfoMappings = map[string]genericlinux.BoardInformation{
 		},
 	},
 	jetsonOrin: {
-		// For pins whose Broadcom SOC channel is -1 (pins 8, 10, 27, and 28), we added these
-		// pin definitions ourselves because they're not present in
+		// There are 4 pins whose Broadcom SOC channel is -1 (pins 8, 10, 27, and 28). We added
+		// these pin definitions ourselves because they're not present in
 		// https://github.com/NVIDIA/jetson-gpio/blob/master/lib/python/Jetson/GPIO/gpio_pin_data.py
-		// We were unable to find the broadcom channel numbers for these pins, but (as of March
+		// We were unable to find the broadcom channel numbers for these pins, but (as of April
 		// 2023) Viam doesn't use those values for anything anyway.
 		[]genericlinux.PinDefinition{
 			{map[int]int{164: 106}, map[int]string{164: "PQ.06"}, "2200000.gpio", 7, 4, "MCLK05", "GP66", "", -1},

--- a/components/board/jetson/data.go
+++ b/components/board/jetson/data.go
@@ -368,10 +368,13 @@ var boardInfoMappings = map[string]genericlinux.BoardInformation{
 		// We were unable to find the broadcom channel numbers for these pins, but (as of April
 		// 2023) Viam doesn't use those values for anything anyway.
 		[]genericlinux.PinDefinition{
+			// Pins 3 and 5 are I2C-only, not GPIO, and thus are not included here.
 			{map[int]int{164: 106}, map[int]string{164: "PQ.06"}, "2200000.gpio", 7, 4, "MCLK05", "GP66", "", -1},
+			// Output-only (due to hardware limitation)
 			{map[int]int{164: 110}, map[int]string{164: "PR.02"}, "2200000.gpio", 8, -1, "UART1_TX", "GP70_UART1_TXD_BOOT2_STRAP", "", -1},
+			// Input-only (due to hardware limitation)
 			{map[int]int{164: 111}, map[int]string{164: "PR.03"}, "2200000.gpio", 10, -1, "UART1_RX", "GP71_UART1_RXD", "", -1},
-			// Output-only (due to base board)
+			// Output-only (due to hardware limitation)
 			{map[int]int{164: 112}, map[int]string{164: "PR.04"}, "2200000.gpio", 11, 17, "UART1_RTS", "GP72_UART1_RTS_N", "", -1},
 			{map[int]int{164: 50}, map[int]string{164: "PH.07"}, "2200000.gpio", 12, 18, "I2S2_CLK", "GP122", "", -1},
 			{map[int]int{164: 108}, map[int]string{164: "PR.00"}, "2200000.gpio", 13, 27, "PWM01", "GP68", "", -1},
@@ -391,6 +394,7 @@ var boardInfoMappings = map[string]genericlinux.BoardInformation{
 			{map[int]int{32: 8}, map[int]string{32: "PBB.00"}, "c2f0000.gpio", 32, 12, "GPIO09", "GP25", "", -1},
 			{map[int]int{32: 2}, map[int]string{32: "PAA.02"}, "c2f0000.gpio", 33, 13, "CAN1_DOUT", "GP19_CAN1_DOUT", "", -1},
 			{map[int]int{164: 53}, map[int]string{164: "PI.02"}, "2200000.gpio", 35, 19, "I2S2_FS", "GP125", "", -1},
+			// Input-only (due to hardware limitation)
 			{map[int]int{164: 113}, map[int]string{164: "PR.05"}, "2200000.gpio", 36, 16, "UART1_CTS", "GP73_UART1_CTS_N", "", -1},
 			{map[int]int{32: 3}, map[int]string{32: "PAA.03"}, "c2f0000.gpio", 37, 26, "CAN1_DIN", "GP20_CAN1_DIN", "", -1},
 			{map[int]int{164: 52}, map[int]string{164: "PI.01"}, "2200000.gpio", 38, 20, "I2S2_DIN", "GP124", "", -1},

--- a/components/board/jetson/data.go
+++ b/components/board/jetson/data.go
@@ -362,8 +362,16 @@ var boardInfoMappings = map[string]genericlinux.BoardInformation{
 		},
 	},
 	jetsonOrin: {
+		// For pins whose Broadcom SOC channel is -1 (pins 8, 10, 27, and 28), we added these
+		// pin definitions ourselves because they're not present in
+		// https://github.com/NVIDIA/jetson-gpio/blob/master/lib/python/Jetson/GPIO/gpio_pin_data.py
+		// We were unable to find the broadcom channel numbers for these pins, but (as of March
+		// 2023) Viam doesn't use those values for anything anyway.
 		[]genericlinux.PinDefinition{
 			{map[int]int{164: 106}, map[int]string{164: "PQ.06"}, "2200000.gpio", 7, 4, "MCLK05", "GP66", "", -1},
+			{map[int]int{164: 110}, map[int]string{164: "PR.02"}, "2200000.gpio", 8, -1, "UART1_TX", "GP70_UART1_TXD_BOOT2_STRAP", "", -1},
+			// Input-only (due to base board)
+			{map[int]int{164: 111}, map[int]string{164: "PR.03"}, "2200000.gpio", 10, -1, "UART1_RX", "GP71_UART1_RXD", "", -1},
 			// Output-only (due to base board)
 			{map[int]int{164: 112}, map[int]string{164: "PR.04"}, "2200000.gpio", 11, 17, "UART1_RTS", "GP72_UART1_RTS_N", "", -1},
 			{map[int]int{164: 50}, map[int]string{164: "PH.07"}, "2200000.gpio", 12, 18, "I2S2_CLK", "GP122", "", -1},
@@ -377,6 +385,10 @@ var boardInfoMappings = map[string]genericlinux.BoardInformation{
 			{map[int]int{164: 133}, map[int]string{164: "PZ.03"}, "2200000.gpio", 23, 11, "SPI1_CLK", "GP47_SPI1_CLK", "", -1},
 			{map[int]int{164: 136}, map[int]string{164: "PZ.06"}, "2200000.gpio", 24, 8, "SPI1_CS0_N", "GP50_SPI1_CS0_N", "", -1},
 			{map[int]int{164: 137}, map[int]string{164: "PZ.07"}, "2200000.gpio", 26, 7, "SPI1_CS1_N", "GP51_SPI1_CS1_N", "", -1},
+			// Has pull-up resistors that cannot be disabled (due to use in I2C bus on board)
+			{map[int]int{32: 20}, map[int]string{32: "PDD.00"}, "c2f0000.gpio", 27, -1, "I2C2_DAT", "GP14_I2C2_DAT", "", -1},
+			// Has pull-up resistors that cannot be disabled (due to use in I2C bus on board)
+			{map[int]int{32: 19}, map[int]string{32: "PCC.07"}, "c2f0000.gpio", 28, -1, "I2C2_CLK", "GP13_I2C2_CLK", "", -1},
 			{map[int]int{32: 1}, map[int]string{32: "PAA.01"}, "c2f0000.gpio", 29, 5, "CAN0_DIN", "GP18_CAN0_DIN", "", -1},
 			{map[int]int{32: 0}, map[int]string{32: "PAA.00"}, "c2f0000.gpio", 31, 6, "CAN0_DOUT", "GP17_CAN0_DOUT", "", -1},
 			{map[int]int{32: 8}, map[int]string{32: "PBB.00"}, "c2f0000.gpio", 32, 12, "GPIO09", "GP25", "", -1},

--- a/components/board/jetson/data.go
+++ b/components/board/jetson/data.go
@@ -369,9 +369,7 @@ var boardInfoMappings = map[string]genericlinux.BoardInformation{
 		// 2023) Viam doesn't use those values for anything anyway.
 		[]genericlinux.PinDefinition{
 			{map[int]int{164: 106}, map[int]string{164: "PQ.06"}, "2200000.gpio", 7, 4, "MCLK05", "GP66", "", -1},
-			// Output-only (due to base board)
 			{map[int]int{164: 110}, map[int]string{164: "PR.02"}, "2200000.gpio", 8, -1, "UART1_TX", "GP70_UART1_TXD_BOOT2_STRAP", "", -1},
-			// Input-only (due to base board)
 			{map[int]int{164: 111}, map[int]string{164: "PR.03"}, "2200000.gpio", 10, -1, "UART1_RX", "GP71_UART1_RXD", "", -1},
 			// Output-only (due to base board)
 			{map[int]int{164: 112}, map[int]string{164: "PR.04"}, "2200000.gpio", 11, 17, "UART1_RTS", "GP72_UART1_RTS_N", "", -1},
@@ -386,9 +384,7 @@ var boardInfoMappings = map[string]genericlinux.BoardInformation{
 			{map[int]int{164: 133}, map[int]string{164: "PZ.03"}, "2200000.gpio", 23, 11, "SPI1_CLK", "GP47_SPI1_CLK", "", -1},
 			{map[int]int{164: 136}, map[int]string{164: "PZ.06"}, "2200000.gpio", 24, 8, "SPI1_CS0_N", "GP50_SPI1_CS0_N", "", -1},
 			{map[int]int{164: 137}, map[int]string{164: "PZ.07"}, "2200000.gpio", 26, 7, "SPI1_CS1_N", "GP51_SPI1_CS1_N", "", -1},
-			// Has pull-up resistors that cannot be disabled (due to use in I2C bus on board)
 			{map[int]int{32: 20}, map[int]string{32: "PDD.00"}, "c2f0000.gpio", 27, -1, "I2C2_DAT", "GP14_I2C2_DAT", "", -1},
-			// Has pull-up resistors that cannot be disabled (due to use in I2C bus on board)
 			{map[int]int{32: 19}, map[int]string{32: "PCC.07"}, "c2f0000.gpio", 28, -1, "I2C2_CLK", "GP13_I2C2_CLK", "", -1},
 			{map[int]int{32: 1}, map[int]string{32: "PAA.01"}, "c2f0000.gpio", 29, 5, "CAN0_DIN", "GP18_CAN0_DIN", "", -1},
 			{map[int]int{32: 0}, map[int]string{32: "PAA.00"}, "c2f0000.gpio", 31, 6, "CAN0_DOUT", "GP17_CAN0_DOUT", "", -1},


### PR DESCRIPTION
Of the 40 pins in the Orin's header, all but 2 are either hot, ground, or defined in this file now. The remaining 2 are I2C-only and not GPIO at all.

Tried with the Orin on my desk: unless mentioned in a comment above the pin, both input and output work great on them all (output checked by wiring it to an LED, input checked by wiring it to either the 3.3V rail or ground). There are 2 input-only pins, and 2 output-only pins. I think it has something to do with those 4 pins also being hooked up to the UART chip? I didn't try out digital interrupts on each pin; I assume that those work as long as the pin supports inputs (and that's not as easily checked through Viam, though I suppose I could plug an encoder into each one if anyone thinks that's an important test to do). 

I didn't document which pins are high by default at bootup and which are low by default, though that could be useful information (when I wired up the base-in-the-world, I accidentally used some pins that were high by default for the motors, and when the Orin rebooted that motor would start spinning out of control). OTOH, that's information you can probably get from NVidia without us copying it over, and if we did copy it over, I don't even know where I'd put it.

Working on this was how I discovered the problems behind https://github.com/viamrobotics/rdk/pull/2180. (The tests I describe above were performed after that PR was merged and this branch was rebased onto the latest main branch. Before then, none of the inputs worked.)