### PR TITLE
RSDK-2632 Call addConvertedAttributes from Module.ReconfigureResource

### DIFF
--- a/module/module.go
+++ b/module/module.go
@@ -484,6 +484,11 @@ func (m *Module) addAPIFromRegistry(ctx context.Context, api resource.Subtype) e
 
 // AddModelFromRegistry adds a preregistered component or service model to the module's services.
 func (m *Module) AddModelFromRegistry(ctx context.Context, api resource.Subtype, model resource.Model) error {
+	err := validateRegistered(api, model)
+	if err != nil {
+		return err
+	}
+
 	m.mu.Lock()
 	_, ok := m.services[api]
 	m.mu.Unlock()
@@ -491,11 +496,6 @@ func (m *Module) AddModelFromRegistry(ctx context.Context, api resource.Subtype,
 		if err := m.addAPIFromRegistry(ctx, api); err != nil {
 			return err
 		}
-	}
-
-	err := validateRegistered(api, model)
-	if err != nil {
-		return err
 	}
 
 	creator := registry.ResourceSubtypeLookup(api)

--- a/module/module.go
+++ b/module/module.go
@@ -337,6 +337,10 @@ func (m *Module) ReconfigureResource(ctx context.Context, req *pb.ReconfigureRes
 		return nil, err
 	}
 
+	if err := addConvertedAttributes(cfg); err != nil {
+		return nil, errors.Wrapf(err, "unable to convert attributes when adding resource")
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/module/module.go
+++ b/module/module.go
@@ -492,6 +492,7 @@ func (m *Module) AddModelFromRegistry(ctx context.Context, api resource.Subtype,
 			return err
 		}
 	}
+
 	err := validateRegistered(api, model)
 	if err != nil {
 		return err
@@ -540,18 +541,21 @@ func addConvertedAttributes(cfg *config.Component) error {
 	return nil
 }
 
+// validateRegistered returns an error if the passed-in api and model have not
+// yet been registered.
 func validateRegistered(api resource.Subtype, model resource.Model) error {
 	switch api.ResourceType {
 	case resource.ResourceTypeComponent:
 		creator := registry.ComponentLookup(api, model)
 		if creator == nil || creator.Constructor == nil {
-			return errors.New("Unregistered component")
+			return fmt.Errorf("component with API %s and model %s not yet registered",
+				api, model)
 		}
-
 	case resource.ResourceTypeService:
 		creator := registry.ServiceLookup(api, model)
 		if creator == nil || creator.Constructor == nil {
-			return errors.New("Unregistered service")
+			return fmt.Errorf("service with API %s and model %s not yet registered",
+				api, model)
 		}
 	default:
 		return errors.Errorf("unknown resource type %s", api.ResourceType)

--- a/module/module.go
+++ b/module/module.go
@@ -338,7 +338,7 @@ func (m *Module) ReconfigureResource(ctx context.Context, req *pb.ReconfigureRes
 	}
 
 	if err := addConvertedAttributes(cfg); err != nil {
-		return nil, errors.Wrapf(err, "unable to convert attributes when adding resource")
+		return nil, errors.Wrapf(err, "unable to convert attributes when reconfiguring resource")
 	}
 
 	m.mu.Lock()

--- a/module/module_test.go
+++ b/module/module_test.go
@@ -496,9 +496,13 @@ func TestAttributeConversion(t *testing.T) {
 		})
 		test.That(t, err, test.ShouldBeNil)
 
-		test.That(t, createDeps1, test.ShouldResemble, deps)
-		test.That(t, createConf1.Attributes, test.ShouldResemble, mockConf.Attributes)
-		test.That(t, createConf1.ConvertedAttributes, test.ShouldImplement, &MockConfig{})
+		_, ok := createDeps1[motor.Named("motor1")]
+		test.That(t, ok, test.ShouldBeTrue)
+		test.That(t, createConf1.Attributes.StringSlice("motors"), test.ShouldResemble, []string{motor.Named("motor1").String()})
+
+		mc, ok := createConf1.ConvertedAttributes.(*MockConfig)
+		test.That(t, ok, test.ShouldBeTrue)
+		test.That(t, mc.Motors, test.ShouldResemble, []string{motor.Named("motor1").String()})
 	})
 
 	//nolint:dupl
@@ -523,9 +527,13 @@ func TestAttributeConversion(t *testing.T) {
 		})
 		test.That(t, err, test.ShouldBeNil)
 
-		test.That(t, createDeps1, test.ShouldResemble, deps)
-		test.That(t, createConf1.Attributes, test.ShouldResemble, mockConf.Attributes)
-		test.That(t, createConf1.ConvertedAttributes, test.ShouldImplement, &MockConfig{})
+		_, ok := createDeps1[motor.Named("motor2")]
+		test.That(t, ok, test.ShouldBeTrue)
+		test.That(t, createConf1.Attributes.StringSlice("motors"), test.ShouldResemble, []string{motor.Named("motor2").String()})
+
+		mc, ok := createConf1.ConvertedAttributes.(*MockConfig)
+		test.That(t, ok, test.ShouldBeTrue)
+		test.That(t, mc.Motors, test.ShouldResemble, []string{motor.Named("motor2").String()})
 	})
 
 	t.Run("reconfigurable creation", func(t *testing.T) {
@@ -550,12 +558,15 @@ func TestAttributeConversion(t *testing.T) {
 		})
 		test.That(t, err, test.ShouldBeNil)
 
-		test.That(t, reconfigDeps1, test.ShouldResemble, deps)
-		test.That(t, reconfigConf1.Attributes, test.ShouldResemble, mockReconfigConf.Attributes)
-		test.That(t, reconfigConf1.ConvertedAttributes, test.ShouldImplement, &MockConfig{})
+		_, ok := reconfigDeps1[motor.Named("motor1")]
+		test.That(t, ok, test.ShouldBeTrue)
+		test.That(t, reconfigConf1.Attributes.StringSlice("motors"), test.ShouldResemble, []string{motor.Named("motor1").String()})
+
+		mc, ok := reconfigConf1.ConvertedAttributes.(*MockConfig)
+		test.That(t, ok, test.ShouldBeTrue)
+		test.That(t, mc.Motors, test.ShouldResemble, []string{motor.Named("motor1").String()})
 	})
 
-	//nolint:dupl
 	t.Run("reconfigurable reconfiguration", func(t *testing.T) {
 		mockAttrs, err := protoutils.StructToStructPb(MockConfig{
 			Motors: []string{motor.Named("motor2").String()},
@@ -577,9 +588,22 @@ func TestAttributeConversion(t *testing.T) {
 		})
 		test.That(t, err, test.ShouldBeNil)
 
-		test.That(t, reconfigDeps2, test.ShouldResemble, deps)
-		test.That(t, reconfigConf2.Attributes, test.ShouldResemble, mockReconfigConf.Attributes)
-		test.That(t, reconfigConf2.ConvertedAttributes, test.ShouldImplement, &MockConfig{})
+		_, ok := reconfigDeps2[motor.Named("motor2")]
+		test.That(t, ok, test.ShouldBeTrue)
+		test.That(t, reconfigConf2.Attributes.StringSlice("motors"), test.ShouldResemble, []string{motor.Named("motor2").String()})
+
+		mc, ok := reconfigConf2.ConvertedAttributes.(*MockConfig)
+		test.That(t, ok, test.ShouldBeTrue)
+		test.That(t, mc.Motors, test.ShouldResemble, []string{motor.Named("motor2").String()})
+
+		// and as a final confirmation, check that original values weren't modified
+		_, ok = reconfigDeps1[motor.Named("motor1")]
+		test.That(t, ok, test.ShouldBeTrue)
+		test.That(t, reconfigConf1.Attributes.StringSlice("motors"), test.ShouldResemble, []string{motor.Named("motor1").String()})
+
+		mc, ok = reconfigConf1.ConvertedAttributes.(*MockConfig)
+		test.That(t, ok, test.ShouldBeTrue)
+		test.That(t, mc.Motors, test.ShouldResemble, []string{motor.Named("motor1").String()})
 	})
 
 	err = conn.Close()

--- a/module/module_test.go
+++ b/module/module_test.go
@@ -237,6 +237,23 @@ func TestModuleFunctions(t *testing.T) {
 			`error validating resource: expected "motorL" attribute for mybase "mybase2"`)
 	})
 
+	t.Run("ConvertedAttributes set correctly", func(t *testing.T) {
+		// mybase.Reconfigure attempts to access ConvertedAttributes. Ensure that
+		// Adding and Reconfiguring mybase does not result in error (both
+		// module.AddResource and module.ReconfigureResource should fill in
+		// ConvertedAttributes).
+		deps := []string{motor.Named("motor1").String(), motor.Named("motor2").String()}
+		_, err = m.AddResource(ctx, &pb.AddResourceRequest{
+			Config: myBaseConf, Dependencies: deps,
+		})
+		test.That(t, err, test.ShouldBeNil)
+
+		_, err = m.ReconfigureResource(ctx, &pb.ReconfigureResourceRequest{
+			Config: myBaseConf, Dependencies: deps,
+		})
+		test.That(t, err, test.ShouldBeNil)
+	})
+
 	err = utils.TryClose(ctx, gClient)
 	test.That(t, err, test.ShouldBeNil)
 

--- a/module/module_test.go
+++ b/module/module_test.go
@@ -2,11 +2,14 @@ package module_test
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"path/filepath"
 	"testing"
 
 	"github.com/edaniels/golog"
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
+	"go.uber.org/zap"
 	v1 "go.viam.com/api/app/v1"
 	pb "go.viam.com/api/module/v1"
 	"go.viam.com/test"
@@ -21,12 +24,153 @@ import (
 	_ "go.viam.com/rdk/components/motor/fake"
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/examples/customresources/apis/gizmoapi"
+	"go.viam.com/rdk/examples/customresources/apis/summationapi"
 	"go.viam.com/rdk/examples/customresources/models/mybase"
 	"go.viam.com/rdk/examples/customresources/models/mygizmo"
+	"go.viam.com/rdk/examples/customresources/models/mysum"
 	"go.viam.com/rdk/module"
+	"go.viam.com/rdk/registry"
+	// "go.viam.com/rdk/registry".
 	"go.viam.com/rdk/resource"
 	robotimpl "go.viam.com/rdk/robot/impl"
+	rdkutils "go.viam.com/rdk/utils"
 )
+
+type MockSumation struct {
+	deps   registry.Dependencies
+	config *MockSumationConfig
+}
+
+type MockSumationConfig struct {
+	Motors []string `json:"motors"`
+}
+
+var (
+	validateCallCount    int
+	reconfigureCallCount int
+)
+
+func (c *MockSumationConfig) Validate(path string) ([]string, error) {
+	validateCallCount++
+	if len(c.Motors) < 1 {
+		return c.Motors, errors.New(fmt.Sprintf("Validation error, no motors specified, got config attrs %#v\n", c))
+	}
+	return c.Motors, nil
+}
+
+func (mock *MockSumation) Sum(ctx context.Context, nums []float64) (float64, error) {
+	return 0, errors.New("Sum unimplemented")
+}
+
+type MockSumationWithReconfigure struct {
+	deps   registry.Dependencies
+	config *MockSumationConfig
+}
+
+func (mock *MockSumationWithReconfigure) Sum(ctx context.Context, nums []float64) (float64, error) {
+	return 0, errors.New("Sum unimplemented")
+}
+
+func (mock *MockSumationWithReconfigure) Reconfigure(ctx context.Context, cfg config.Service, deps registry.Dependencies) error {
+	reconfigureCallCount++
+	conf, ok := cfg.ConvertedAttributes.(*MockSumationConfig)
+	if !ok {
+		return rdkutils.NewUnexpectedTypeError(conf, cfg.ConvertedAttributes)
+	}
+	mock.config = conf
+	mock.deps = deps
+	return nil
+}
+
+func TestModuleAddModelFromRegistry(t *testing.T) {
+	ctx := context.Background()
+	logger := golog.NewTestLogger(t)
+
+	cfg := &config.Config{Components: []config.Component{
+		{
+			Name:  "motor1",
+			API:   resource.NewSubtype("rdk", "component", "motor"),
+			Model: resource.NewDefaultModel("fake"),
+		},
+		{
+			Name:  "motor2",
+			API:   resource.NewSubtype("rdk", "component", "motor"),
+			Model: resource.NewDefaultModel("fake"),
+		},
+		{
+			Name:  "motor3",
+			API:   resource.NewSubtype("rdk", "component", "motor"),
+			Model: resource.NewDefaultModel("fake"),
+		},
+	}}
+
+	myRobot, err := robotimpl.RobotFromConfig(ctx, cfg, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	parentAddr, err := myRobot.ModuleAddress()
+	test.That(t, err, test.ShouldBeNil)
+
+	addr := filepath.ToSlash(filepath.Join(filepath.Dir(parentAddr), "mod.sock"))
+	m, err := module.NewModule(ctx, addr, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	t.Run("AddModelFromRegistry", func(t *testing.T) {
+		invalidModel := resource.NewModel("non", "existent", "model")
+
+		invalidServiceSubtype := resource.NewSubtype(
+			resource.Namespace("fake"),
+			resource.ResourceTypeService,
+			resource.SubtypeName("nonexistantservice"))
+
+		invalidComponentSubtype := resource.NewSubtype(
+			resource.Namespace("fake"),
+			resource.ResourceTypeComponent,
+			resource.SubtypeName("nonexistantcomponent"))
+
+		validServiceSubtype := summationapi.Subtype
+		validComponentSubtype := gizmoapi.Subtype
+
+		validServiceModel := mysum.Model
+		validComponentModel := mygizmo.Model
+
+		serviceError := "Unregistered service"
+		componentError := "Unregistered component"
+
+		tests := []struct {
+			subtype  resource.Subtype
+			model    resource.Model
+			hasErr   bool
+			expected string
+		}{
+			// invalid resource subtype & model
+			{invalidServiceSubtype, invalidModel, true, serviceError},
+			{invalidComponentSubtype, invalidModel, true, componentError},
+
+			// valid resource subtype, invalid model
+			{validServiceSubtype, invalidModel, true, serviceError},
+			{validComponentSubtype, invalidModel, true, componentError},
+
+			// mismatched valid models & subtypes
+			{validServiceSubtype, validComponentModel, true, serviceError},
+			{validComponentSubtype, validServiceModel, true, componentError},
+
+
+			{validServiceSubtype, validServiceModel, false, ""},
+			{validComponentSubtype, validComponentModel, false, ""},
+		}
+
+		for _, tes := range tests {
+			t.Logf("test subtype: %#v, model: %#v", tes.subtype.String(), tes.model.String())
+			err := m.AddModelFromRegistry(ctx, tes.subtype, tes.model)
+			if tes.hasErr {
+				test.That(t, err, test.ShouldNotBeNil)
+				test.That(t, err.Error(), test.ShouldContainSubstring, tes.expected)
+			} else {
+				test.That(t, err, test.ShouldBeNil)
+			}
+		}
+	})
+}
 
 func TestModuleFunctions(t *testing.T) {
 	ctx := context.Background()
@@ -237,24 +381,363 @@ func TestModuleFunctions(t *testing.T) {
 			`error validating resource: expected "motorL" attribute for mybase "mybase2"`)
 	})
 
-	t.Run("ConvertedAttributes set correctly", func(t *testing.T) {
-		// mybase.Reconfigure attempts to access ConvertedAttributes. Ensure that
-		// Adding and Reconfiguring mybase does not result in error (both
-		// module.AddResource and module.ReconfigureResource should fill in
-		// ConvertedAttributes).
-		deps := []string{motor.Named("motor1").String(), motor.Named("motor2").String()}
-		_, err = m.AddResource(ctx, &pb.AddResourceRequest{
-			Config: myBaseConf, Dependencies: deps,
-		})
-		test.That(t, err, test.ShouldBeNil)
+	err = utils.TryClose(ctx, gClient)
+	test.That(t, err, test.ShouldBeNil)
 
-		_, err = m.ReconfigureResource(ctx, &pb.ReconfigureResourceRequest{
-			Config: myBaseConf, Dependencies: deps,
-		})
-		test.That(t, err, test.ShouldBeNil)
+	err = conn.Close()
+	test.That(t, err, test.ShouldBeNil)
+
+	m.Close(ctx)
+
+	err = myRobot.Close(ctx)
+	test.That(t, err, test.ShouldBeNil)
+}
+
+func TestModuleDefaultReconfig(t *testing.T) {
+	ctx := context.Background()
+	logger := golog.NewTestLogger(t)
+
+	cfg := &config.Config{Components: []config.Component{
+		{
+			Name:  "motor1",
+			API:   resource.NewSubtype("rdk", "component", "motor"),
+			Model: resource.NewDefaultModel("fake"),
+		},
+		{
+			Name:  "motor2",
+			API:   resource.NewSubtype("rdk", "component", "motor"),
+			Model: resource.NewDefaultModel("fake"),
+		},
+	}}
+
+	myRobot, err := robotimpl.RobotFromConfig(ctx, cfg, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	parentAddr, err := myRobot.ModuleAddress()
+	test.That(t, err, test.ShouldBeNil)
+
+	addr := filepath.ToSlash(filepath.Join(filepath.Dir(parentAddr), "mod.sock"))
+	m, err := module.NewModule(ctx, addr, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	model := resource.NewModel("mock", "demo", "mocksumation")
+	var mock *MockSumation
+
+	// Register the mock summation api
+	registry.RegisterService(summationapi.Subtype, model, registry.Service{
+		Constructor: func(ctx context.Context, deps registry.Dependencies, cfg config.Service, logger *zap.SugaredLogger) (interface{}, error) {
+			conf, ok := cfg.ConvertedAttributes.(*MockSumationConfig)
+			res := &MockSumation{deps: deps, config: conf}
+			if !ok {
+				return nil, rdkutils.NewUnexpectedTypeError(conf, cfg.ConvertedAttributes)
+			}
+
+			mock = res
+			return res, nil
+		},
 	})
 
-	err = utils.TryClose(ctx, gClient)
+	// Register the mock summation api attribute map converter
+	config.RegisterServiceAttributeMapConverter(
+		summationapi.Subtype,
+		model,
+		func(attributes config.AttributeMap) (interface{}, error) {
+			var conf MockSumationConfig
+			return config.TransformAttributeMapToStruct(&conf, attributes)
+		},
+		&MockSumationConfig{})
+
+	myAttrs, err := protoutils.StructToStructPb(MockSumationConfig{Motors: []string{motor.Named("motor1").String()}})
+	test.That(t, err, test.ShouldBeNil)
+
+	myConf := &v1.ComponentConfig{
+		Name:       "mymocksumation1",
+		Api:        summationapi.Subtype.String(),
+		Model:      model.String(),
+		Attributes: myAttrs,
+	}
+
+	myInvalidAttrs, err := protoutils.StructToStructPb(MockSumationConfig{Motors: []string{}})
+	test.That(t, err, test.ShouldBeNil)
+
+	myInvalidConf := &v1.ComponentConfig{
+		Name:       "mymocksumation1",
+		Api:        summationapi.Subtype.String(),
+		Model:      model.String(),
+		Attributes: myInvalidAttrs,
+	}
+
+	myReAttrs, err := protoutils.StructToStructPb(MockSumationConfig{Motors: []string{motor.Named("motor2").String()}})
+	test.That(t, err, test.ShouldBeNil)
+
+	myReConf := &v1.ComponentConfig{
+		Name:       "mymocksumation1",
+		Api:        summationapi.Subtype.String(),
+		Model:      model.String(),
+		Attributes: myReAttrs,
+	}
+
+	// register the sumatioapi with the mock model
+	test.That(t, m.AddModelFromRegistry(ctx, summationapi.Subtype, model), test.ShouldBeNil)
+
+	test.That(t, m.Start(ctx), test.ShouldBeNil)
+
+	conn, err := grpc.Dial(
+		"unix://"+addr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithStreamInterceptor(grpc_retry.StreamClientInterceptor()),
+		grpc.WithUnaryInterceptor(grpc_retry.UnaryClientInterceptor()),
+	)
+	test.That(t, err, test.ShouldBeNil)
+
+	client := pb.NewModuleServiceClient(conn)
+
+	m.SetReady(false)
+
+	resp, err := client.Ready(ctx, &pb.ReadyRequest{})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, resp.Ready, test.ShouldBeFalse)
+
+	m.SetReady(true)
+
+	resp, err = client.Ready(ctx, &pb.ReadyRequest{ParentAddress: parentAddr})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, resp.Ready, test.ShouldBeTrue)
+
+	t.Run("ConvertedAttributes set correctly when Reconfigure method is not defined", func(t *testing.T) {
+		test.That(t, mock, test.ShouldBeNil)
+
+		_, err := m.ValidateConfig(ctx, &pb.ValidateConfigRequest{Config: myInvalidConf})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "Validation error, no motors specified")
+		test.That(t, validateCallCount, test.ShouldEqual, 1)
+
+		resp, err := m.ValidateConfig(ctx, &pb.ValidateConfigRequest{Config: myConf})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, validateCallCount, test.ShouldEqual, 2)
+
+		test.That(t, mock, test.ShouldBeNil)
+		deps := resp.Dependencies
+		test.That(t, deps, test.ShouldResemble, []string{"rdk:component:motor/motor1"})
+		test.That(t, validateCallCount, test.ShouldEqual, 2)
+
+		_, err = m.AddResource(ctx, &pb.AddResourceRequest{
+			Config: myConf, Dependencies: deps,
+		})
+		test.That(t, err, test.ShouldBeNil)
+		// validate & reconfigure are not called
+		test.That(t, validateCallCount, test.ShouldEqual, 2)
+		test.That(t, reconfigureCallCount, test.ShouldEqual, 0)
+
+		depNames := make([]string, 0, len(mock.deps))
+		for k := range mock.deps {
+			depNames = append(depNames, motor.Named(k.Name).String())
+		}
+		test.That(t, depNames, test.ShouldResemble, deps)
+
+		test.That(t, mock.config.Motors, test.ShouldResemble, []string{"rdk:component:motor/motor1"})
+
+		reconfigureDeps := []string{motor.Named("motor2").String()}
+		_, err = m.ReconfigureResource(ctx, &pb.ReconfigureResourceRequest{
+			Config: myReConf, Dependencies: reconfigureDeps,
+		})
+		test.That(t, err, test.ShouldBeNil)
+		// validate & reconfigure are not called
+		test.That(t, validateCallCount, test.ShouldEqual, 2)
+		test.That(t, reconfigureCallCount, test.ShouldEqual, 0)
+
+		reDepNames := make([]string, 0, len(mock.deps))
+		for k := range mock.deps {
+			reDepNames = append(reDepNames, motor.Named(k.Name).String())
+		}
+
+		test.That(t, reDepNames, test.ShouldResemble, reconfigureDeps)
+
+		test.That(t, mock.config.Motors, test.ShouldResemble, []string{"rdk:component:motor/motor2"})
+		defer func() {
+			validateCallCount = 0
+			reconfigureCallCount = 0
+		}()
+	})
+
+	test.That(t, err, test.ShouldBeNil)
+
+	err = conn.Close()
+	test.That(t, err, test.ShouldBeNil)
+
+	m.Close(ctx)
+
+	err = myRobot.Close(ctx)
+	test.That(t, err, test.ShouldBeNil)
+}
+
+func TestModuleReconfig(t *testing.T) {
+	ctx := context.Background()
+	logger := golog.NewTestLogger(t)
+
+	cfg := &config.Config{Components: []config.Component{
+		{
+			Name:  "motor1",
+			API:   resource.NewSubtype("rdk", "component", "motor"),
+			Model: resource.NewDefaultModel("fake"),
+		},
+		{
+			Name:  "motor2",
+			API:   resource.NewSubtype("rdk", "component", "motor"),
+			Model: resource.NewDefaultModel("fake"),
+		},
+	}}
+
+	myRobot, err := robotimpl.RobotFromConfig(ctx, cfg, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	parentAddr, err := myRobot.ModuleAddress()
+	test.That(t, err, test.ShouldBeNil)
+
+	addr := filepath.ToSlash(filepath.Join(filepath.Dir(parentAddr), "mod.sock"))
+	m, err := module.NewModule(ctx, addr, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	model := resource.NewModel("mock", "demo", "mocksumationreconfigure")
+	var mock *MockSumationWithReconfigure
+
+	// Register the mock summation api
+	registry.RegisterService(summationapi.Subtype, model, registry.Service{
+		Constructor: func(ctx context.Context, deps registry.Dependencies, cfg config.Service, logger *zap.SugaredLogger) (interface{}, error) {
+			conf, ok := cfg.ConvertedAttributes.(*MockSumationConfig)
+			res := &MockSumationWithReconfigure{deps: deps, config: conf}
+			if !ok {
+				return nil, rdkutils.NewUnexpectedTypeError(conf, cfg.ConvertedAttributes)
+			}
+
+			mock = res
+			return res, nil
+		},
+	})
+
+	// Register the mock summation api attribute map converter
+	config.RegisterServiceAttributeMapConverter(
+		summationapi.Subtype,
+		model,
+		func(attributes config.AttributeMap) (interface{}, error) {
+			var conf MockSumationConfig
+			return config.TransformAttributeMapToStruct(&conf, attributes)
+		},
+		&MockSumationConfig{})
+
+	myAttrs, err := protoutils.StructToStructPb(MockSumationConfig{Motors: []string{motor.Named("motor1").String()}})
+	test.That(t, err, test.ShouldBeNil)
+
+	myConf := &v1.ComponentConfig{
+		Name:       "mymocksumation1",
+		Api:        summationapi.Subtype.String(),
+		Model:      model.String(),
+		Attributes: myAttrs,
+	}
+
+	myInvalidAttrs, err := protoutils.StructToStructPb(MockSumationConfig{Motors: []string{}})
+	test.That(t, err, test.ShouldBeNil)
+
+	myInvalidConf := &v1.ComponentConfig{
+		Name:       "mymocksumation1",
+		Api:        summationapi.Subtype.String(),
+		Model:      model.String(),
+		Attributes: myInvalidAttrs,
+	}
+
+	myReAttrs, err := protoutils.StructToStructPb(MockSumationConfig{Motors: []string{motor.Named("motor2").String()}})
+	test.That(t, err, test.ShouldBeNil)
+
+	myReConf := &v1.ComponentConfig{
+		Name:       "mymocksumation1",
+		Api:        summationapi.Subtype.String(),
+		Model:      model.String(),
+		Attributes: myReAttrs,
+	}
+
+	// register the sumatioapi with the mock model
+	test.That(t, m.AddModelFromRegistry(ctx, summationapi.Subtype, model), test.ShouldBeNil)
+
+	test.That(t, m.Start(ctx), test.ShouldBeNil)
+
+	conn, err := grpc.Dial(
+		"unix://"+addr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithStreamInterceptor(grpc_retry.StreamClientInterceptor()),
+		grpc.WithUnaryInterceptor(grpc_retry.UnaryClientInterceptor()),
+	)
+	test.That(t, err, test.ShouldBeNil)
+
+	client := pb.NewModuleServiceClient(conn)
+
+	m.SetReady(false)
+
+	resp, err := client.Ready(ctx, &pb.ReadyRequest{})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, resp.Ready, test.ShouldBeFalse)
+
+	m.SetReady(true)
+
+	resp, err = client.Ready(ctx, &pb.ReadyRequest{ParentAddress: parentAddr})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, resp.Ready, test.ShouldBeTrue)
+
+	t.Run("ConvertedAttributes set correctly when Reconfigure method is defined", func(t *testing.T) {
+		test.That(t, mock, test.ShouldBeNil)
+
+		_, err := m.ValidateConfig(ctx, &pb.ValidateConfigRequest{Config: myInvalidConf})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "Validation error, no motors specified")
+		test.That(t, validateCallCount, test.ShouldEqual, 1)
+
+		resp, err := m.ValidateConfig(ctx, &pb.ValidateConfigRequest{Config: myConf})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, validateCallCount, test.ShouldEqual, 2)
+
+		test.That(t, mock, test.ShouldBeNil)
+		deps := resp.Dependencies
+		test.That(t, deps, test.ShouldResemble, []string{"rdk:component:motor/motor1"})
+		test.That(t, validateCallCount, test.ShouldEqual, 2)
+
+		_, err = m.AddResource(ctx, &pb.AddResourceRequest{
+			Config: myConf, Dependencies: deps,
+		})
+		test.That(t, err, test.ShouldBeNil)
+		// validate & reconfigure are not called
+		test.That(t, validateCallCount, test.ShouldEqual, 2)
+		test.That(t, reconfigureCallCount, test.ShouldEqual, 0)
+
+		depNames := make([]string, 0, len(mock.deps))
+		for k := range mock.deps {
+			depNames = append(depNames, motor.Named(k.Name).String())
+		}
+		test.That(t, depNames, test.ShouldResemble, deps)
+
+		test.That(t, mock.config.Motors, test.ShouldResemble, []string{"rdk:component:motor/motor1"})
+
+		reconfigureDeps := []string{motor.Named("motor2").String()}
+		_, err = m.ReconfigureResource(ctx, &pb.ReconfigureResourceRequest{
+			Config: myReConf, Dependencies: reconfigureDeps,
+		})
+		test.That(t, err, test.ShouldBeNil)
+		// reconfigure is called
+		test.That(t, validateCallCount, test.ShouldEqual, 2)
+		test.That(t, reconfigureCallCount, test.ShouldEqual, 1)
+
+		reDepNames := make([]string, 0, len(mock.deps))
+		for k := range mock.deps {
+			reDepNames = append(reDepNames, motor.Named(k.Name).String())
+		}
+
+		test.That(t, reDepNames, test.ShouldResemble, reconfigureDeps)
+
+		test.That(t, mock.config.Motors, test.ShouldResemble, []string{"rdk:component:motor/motor2"})
+		defer func() {
+			validateCallCount = 0
+			reconfigureCallCount = 0
+		}()
+	})
+
 	test.That(t, err, test.ShouldBeNil)
 
 	err = conn.Close()

--- a/testutils/inject/shell_service.go
+++ b/testutils/inject/shell_service.go
@@ -3,6 +3,10 @@ package inject
 import (
 	"context"
 
+	"github.com/pkg/errors"
+
+	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/registry"
 	"go.viam.com/rdk/services/shell"
 )
 
@@ -21,4 +25,33 @@ func (s *ShellService) DoCommand(ctx context.Context,
 		return s.Service.DoCommand(ctx, cmd)
 	}
 	return s.DoCommandFunc(ctx, cmd)
+}
+
+// ShellServiceWithReconfigure represents a fake instance of a shell service.
+type ShellServiceWithReconfigure struct {
+	shell.Service
+	DoCommandFunc   func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
+	ReconfigureFunc func(ctx context.Context, cfg config.Service, deps registry.Dependencies) error
+}
+
+// DoCommand calls the injected DoCommand or the real variant.
+func (s *ShellServiceWithReconfigure) DoCommand(ctx context.Context,
+	cmd map[string]interface{},
+) (map[string]interface{}, error) {
+	if s.DoCommandFunc == nil {
+		return s.Service.DoCommand(ctx, cmd)
+	}
+	return s.DoCommandFunc(ctx, cmd)
+}
+
+// Reconfigure calls the injected Reconfigure or the real variant.
+func (s *ShellServiceWithReconfigure) Reconfigure(ctx context.Context, cfg config.Service, deps registry.Dependencies) error {
+	if s.ReconfigureFunc == nil {
+		reconf, ok := s.Service.(registry.ReconfigurableService)
+		if ok {
+			return reconf.Reconfigure(ctx, cfg, deps)
+		}
+		return errors.New("no reconfigure function set")
+	}
+	return s.ReconfigureFunc(ctx, cfg, deps)
 }


### PR DESCRIPTION
RSDK-2632

Calls `addConvertedAttributes` from `Module.ReconfigureResource`. Adds check `validateRegistered` for previous registration in `AddModelFromRegistry`. Adds test for possible `AddModelFromRegistry` errors. Adds tests for proper handling of modular resources with and without a `Reconfigure` function when `ConvertedAttributes` is accessed.

#2142 added converted attributes to `Module.AddResource` but not to `Module.ReconfigureResource` (my apologies for not catching that in review). Reconfiguration of modular resources that attempted to access `ConvertedAttributes` was failing (see associated ticket).

cc @nicksanford + @edaniels 