### PR TITLE
RSDK-1902 Random panic occurring somewhere in CBiRRT method

### DIFF
--- a/motionplan/cBiRRT.go
+++ b/motionplan/cBiRRT.go
@@ -198,10 +198,23 @@ func (mp *cBiRRTMotionPlanner) rrtBackgroundRunner(
 		default:
 		}
 
-		tryExtend := func(target []referenceframe.Input) (node, node, float64) {
+		tryExtend := func(target []referenceframe.Input) (node, node, float64, error) {
 			// attempt to extend maps 1 and 2 towards the target
-			nearest1 := nm.nearestNeighbor(nmContext, mp.planOpts, target, map1)
-			nearest2 := nm.nearestNeighbor(nmContext, mp.planOpts, target, map2)
+			utils.PanicCapturingGo(func() {
+				nm.nearestNeighbor(nmContext, mp.planOpts, target, map1, m1chan)
+			})
+			utils.PanicCapturingGo(func() {
+				nm.nearestNeighbor(nmContext, mp.planOpts, target, map2, m2chan)
+			})
+			nearest1 := <-m1chan
+			nearest2 := <-m2chan
+			// If ctx is done, nearest neighbors will be invalid and we want to return immediately
+			select {
+			case <-ctx.Done():
+				return nil, nil, 0, ctx.Err()
+			default:
+			}
+
 			//nolint: gosec
 			rseed1 := rand.New(rand.NewSource(int64(mp.randseed.Int())))
 			//nolint: gosec
@@ -220,14 +233,23 @@ func (mp *cBiRRTMotionPlanner) rrtBackgroundRunner(
 			corners[map2reached] = true
 
 			reachedDelta := mp.planOpts.DistanceFunc(&Segment{StartConfiguration: map1reached.Q(), EndConfiguration: map2reached.Q()})
-			return map1reached, map2reached, reachedDelta
+			return map1reached, map2reached, reachedDelta, nil
 		}
 
-		map1reached, map2reached, reachedDelta := tryExtend(target)
+		map1reached, map2reached, reachedDelta, err := tryExtend(target)
+		if err != nil {
+			rrt.solutionChan <- &rrtPlanReturn{planerr: err, maps: rrt.maps}
+			return
+		}
+
 		// Second iteration; extend maps 1 and 2 towards the halfway point between where they reached
 		if reachedDelta > mp.algOpts.JointSolveDist {
 			target = referenceframe.InterpolateInputs(map1reached.Q(), map2reached.Q(), 0.5)
-			map1reached, map2reached, reachedDelta = tryExtend(target)
+			map1reached, map2reached, reachedDelta, err = tryExtend(target)
+			if err != nil {
+				rrt.solutionChan <- &rrtPlanReturn{planerr: err, maps: rrt.maps}
+				return
+			}
 		}
 
 		// Solved!

--- a/motionplan/cBiRRT_test.go
+++ b/motionplan/cBiRRT_test.go
@@ -76,7 +76,10 @@ func TestSimpleLinearMotion(t *testing.T) {
 	})
 	seedReached := <-m1chan
 	// Find the nearest point in goalMap to the furthest point reached in seedMap
-	near2 := nn.nearestNeighbor(ctx, opt, seedReached.Q(), goalMap)
+	utils.PanicCapturingGo(func() {
+		nn.nearestNeighbor(ctx, opt, seedReached.Q(), goalMap, m1chan)
+	})
+	near2 := <-m1chan
 	// extend goalMap towards the point in seedMap
 	utils.PanicCapturingGo(func() {
 		cbirrt.constrainedExtend(ctx, cbirrt.randseed, goalMap, near2, seedReached, m1chan)

--- a/motionplan/nearestNeighbor.go
+++ b/motionplan/nearestNeighbor.go
@@ -58,10 +58,12 @@ func (nm *neighborManager) nearestNeighbor(
 	planOpts *plannerOptions,
 	seed []referenceframe.Input,
 	rrtMap map[node]node,
-) node {
+	returnChan chan node,
+) {
 	if len(rrtMap) > neighborsBeforeParallelization && nm.nCPU > 1 {
 		// If the map is large, calculate distances in parallel
-		return nm.parallelNearestNeighbor(ctx, planOpts, seed, rrtMap)
+		returnChan <- nm.parallelNearestNeighbor(ctx, planOpts, seed, rrtMap)
+		return
 	}
 	bestDist := math.Inf(1)
 	var best node
@@ -75,7 +77,7 @@ func (nm *neighborManager) nearestNeighbor(
 			best = k
 		}
 	}
-	return best
+	returnChan <- best
 }
 
 func (nm *neighborManager) parallelNearestNeighbor(


### PR DESCRIPTION
Update NearestNeighbor to run on multiple maps in parallel, and properly handle the return of a `nil` from NN which can only be due to the ctx being cancelled