### PR TITLE
Add a valid arm-model to fake configuration

### DIFF
--- a/etc/configs/fake.json
+++ b/etc/configs/fake.json
@@ -7,7 +7,10 @@
         {
             "name": "arm1",
             "type": "arm",
-            "model": "fake"
+            "model": "fake",
+            "attributes": {
+                "arm-model": "xArm6"
+            }
         },
         {
             "name": "audio_input1",

--- a/etc/configs/fake.json
+++ b/etc/configs/fake.json
@@ -9,7 +9,7 @@
             "type": "arm",
             "model": "fake",
             "attributes": {
-                "arm-model": "xArm6"
+                "arm-model": "ur5e"
             }
         },
         {

--- a/etc/configs/fake.json
+++ b/etc/configs/fake.json
@@ -9,7 +9,7 @@
             "type": "arm",
             "model": "fake",
             "attributes": {
-                "arm-model": "ur5e"
+                "arm-model": "xArm6"
             }
         },
         {


### PR DESCRIPTION
When we modified the fake arm behavior, we updated this in several places but not the `/etc` config for checking out all fake components. This just adds an `xArm6` as the faked arm model. Coincidentally, the errors emitted do indicate the underlying issue, but Eric didn't seem to follow what was happening. We might need to reevaluate that error message.

We could use model-path (I tested with this) but you have relative path resolution issues if you start the server from a different place, so I opted to keep this as simple as possible.