### PR TITLE
Add Stadia gamepad mapping

### DIFF
--- a/components/input/gamepad/gamepad_linux.go
+++ b/components/input/gamepad/gamepad_linux.go
@@ -306,7 +306,7 @@ func (g *gamepad) connectDev(ctx context.Context) error {
 		}
 		name := dev.Name()
 		name = strings.TrimSpace(name)
-		mapping, ok := GetGamepadMapping(name)
+		mapping, ok := MappingForModel(name)
 		if ok {
 			g.logger.Infof("found known gamepad: '%s' at %s", name, n)
 			g.dev = dev
@@ -333,7 +333,7 @@ func (g *gamepad) connectDev(ctx context.Context) error {
 				g.logger.Infof("no button mapping for '%s', using default: '%s'", name, defaultMapping)
 				g.dev = dev
 				g.Model = g.dev.Name()
-				g.Mapping, _ = GetGamepadMapping(defaultMapping)
+				g.Mapping, _ = MappingForModel(defaultMapping)
 				break
 			} else {
 				if err := dev.Close(); err != nil {

--- a/components/input/gamepad/gamepad_linux.go
+++ b/components/input/gamepad/gamepad_linux.go
@@ -306,7 +306,7 @@ func (g *gamepad) connectDev(ctx context.Context) error {
 		}
 		name := dev.Name()
 		name = strings.TrimSpace(name)
-		mapping, ok := GamepadMappings[name]
+		mapping, ok := GetGamepadMapping(name)
 		if ok {
 			g.logger.Infof("found known gamepad: '%s' at %s", name, n)
 			g.dev = dev
@@ -333,7 +333,7 @@ func (g *gamepad) connectDev(ctx context.Context) error {
 				g.logger.Infof("no button mapping for '%s', using default: '%s'", name, defaultMapping)
 				g.dev = dev
 				g.Model = g.dev.Name()
-				g.Mapping = GamepadMappings[defaultMapping]
+				g.Mapping, _ = GetGamepadMapping(defaultMapping)
 				break
 			} else {
 				if err := dev.Close(); err != nil {

--- a/components/input/gamepad/gamepad_mappings_linux.go
+++ b/components/input/gamepad/gamepad_mappings_linux.go
@@ -4,14 +4,18 @@
 package gamepad
 
 import (
+	"strings"
+
 	"github.com/viamrobotics/evdev"
 
 	"go.viam.com/rdk/components/input"
 )
 
-// GamepadMappings contains all the axes/button translations for each model.
+const stadiaPrefix = "Stadia"
+
+// gamepadMappings contains all the axes/button translations for each model.
 // use evtest on linux figure out what maps to what.
-var GamepadMappings = map[string]Mapping{
+var gamepadMappings = map[string]Mapping{
 	// 8BitDo Pro 2 Wireless, S-input mode
 	// Also the Nintendo Switch Pro Controller
 	"Pro Controller": {
@@ -241,4 +245,40 @@ var GamepadMappings = map[string]Mapping{
 			298: input.ButtonMenu,
 		},
 	},
+	// Stadia Controller
+	stadiaPrefix: {
+		Axes: map[evdev.AbsoluteType]input.Control{
+			0:  input.AbsoluteX,
+			1:  input.AbsoluteY,
+			10: input.AbsoluteZ,
+			2:  input.AbsoluteRX,
+			5:  input.AbsoluteRY,
+			9:  input.AbsoluteRZ,
+			16: input.AbsoluteHat0X,
+			17: input.AbsoluteHat0Y,
+		},
+		Buttons: map[evdev.KeyType]input.Control{
+			304: input.ButtonSouth,
+			305: input.ButtonEast,
+			307: input.ButtonWest,
+			308: input.ButtonNorth,
+			310: input.ButtonLT,
+			311: input.ButtonRT,
+			314: input.ButtonSelect,
+			315: input.ButtonStart,
+			316: input.ButtonMenu,
+			317: input.ButtonLThumb,
+			318: input.ButtonRThumb,
+		},
+	},
+}
+
+// GetGamepadMapping returns the mapping for a given model.
+func GetGamepadMapping(model string) (Mapping, bool) {
+	// Stadia controller device names are unique of the form "StadiaXXXX-XXXX"
+	if strings.HasPrefix(model, stadiaPrefix) {
+		model = stadiaPrefix
+	}
+	mapping, ok := gamepadMappings[model]
+	return mapping, ok
 }

--- a/components/input/gamepad/gamepad_mappings_linux.go
+++ b/components/input/gamepad/gamepad_mappings_linux.go
@@ -273,8 +273,8 @@ var gamepadMappings = map[string]Mapping{
 	},
 }
 
-// GetGamepadMapping returns the mapping for a given model.
-func GetGamepadMapping(model string) (Mapping, bool) {
+// MappingForModel returns the mapping for a given model.
+func MappingForModel(model string) (Mapping, bool) {
 	// Stadia controller device names are unique of the form "StadiaXXXX-XXXX"
 	if strings.HasPrefix(model, stadiaPrefix) {
 		model = stadiaPrefix


### PR DESCRIPTION
Stadia controllers have a mapping that is different than the default. Controller device names are unique of the form `StadiaXXXX-XXXX` so using the model name to lookup the mapping will fail. Instead, expose a simple helper to get the mapping which checks for the prefix.

**Question:** The mapping for Stadia controllers is the same as the "Xbox Wireless Controller" excluding the "record" button. Should this change reuse the mapping or duplicate it?

**Tested:** Ran from source on a Raspberry Pi 4 with the Stadia gamepad connected by bluetooth. Verified in the Viam app in the `input_controller` control panel.