### PR TITLE
[RSDK-2345] Create digital interrupts if not mentioned in the config

### DIFF
--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -283,7 +283,7 @@ func (b *sysfsBoard) DigitalInterruptByName(name string) (board.DigitalInterrupt
 		Type: "basic",
 	}
 	interrupt, err := createDigitalInterrupt(b.cancelCtx, defaultInterruptConfig, b.gpioMappings,
-	                                         b.activeBackgroundWorkers)
+	                                         &b.activeBackgroundWorkers)
 	if err != nil {
 		b.logger.Errorf("Unable to create digital interrupt pin on the fly: %s", err)
 		return nil, false
@@ -291,7 +291,7 @@ func (b *sysfsBoard) DigitalInterruptByName(name string) (board.DigitalInterrupt
 
 	delete(b.gpios, name)
 	b.interrupts[name] = interrupt
-	return interrupt, true
+	return interrupt.interrupt, true
 }
 
 func (b *sysfsBoard) SPINames() []string {

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -277,10 +277,11 @@ func (b *sysfsBoard) DigitalInterruptByName(name string) (board.DigitalInterrupt
 		return nil, false
 	}
 
+	const defaultInterruptType = "basic"
 	defaultInterruptConfig := board.DigitalInterruptConfig{
 		Name: name,
 		Pin:  name,
-		Type: "basic",
+		Type: defaultInterruptType,
 	}
 	interrupt, err := createDigitalInterrupt(b.cancelCtx, defaultInterruptConfig, b.gpioMappings,
 		&b.activeBackgroundWorkers)
@@ -325,6 +326,10 @@ func (b *sysfsBoard) AnalogReaderNames() []string {
 }
 
 func (b *sysfsBoard) DigitalInterruptNames() []string {
+	if b.interrupts == nil {
+		return nil
+	}
+
 	names := []string{}
 	for name := range b.interrupts {
 		names = append(names, name)

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -277,8 +277,13 @@ func (b *sysfsBoard) DigitalInterruptByName(name string) (board.DigitalInterrupt
 		return nil, false // It's not a GPIO pin either. Give up.
 	}
 
-	// TODO: fix this line
-	interrupt, err := createDigitalInterrupt(context, digint_config, gpioMappings, activeBackgroundWorkers)
+	defaultInterruptConfig = board.DigitalInterruptConfig{
+		Name: name,
+		Pin:  name,
+		Type: "basic",
+	}
+	interrupt, err := createDigitalInterrupt(b.cancelCtx, defaultInterruptConfig, b.gpioMappings,
+	                                         b.activeBackgroundWorkers)
 	if err != nil {
 		b.logger.Errorf("Unable to create digital interrupt pin on the fly: %s", err)
 		return nil, false

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -256,10 +256,10 @@ func (b *sysfsBoard) AnalogReaderByName(name string) (board.AnalogReader, bool) 
 func (b *sysfsBoard) DigitalInterruptByName(name string) (board.DigitalInterrupt, bool) {
 	// TODO(RSDK-2345): If the name is numerical and doesn't already exist, create it here anyway.
 	interrupt, ok := b.interrupts[name]
-	if !ok {
-		return nil, false
+	if ok {
+		return interrupt.interrupt, true
 	}
-	return interrupt.interrupt, true
+	return nil, false
 }
 
 func (b *sysfsBoard) SPINames() []string {

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -283,7 +283,7 @@ func (b *sysfsBoard) DigitalInterruptByName(name string) (board.DigitalInterrupt
 		Type: "basic",
 	}
 	interrupt, err := createDigitalInterrupt(b.cancelCtx, defaultInterruptConfig, b.gpioMappings,
-	                                         &b.activeBackgroundWorkers)
+		&b.activeBackgroundWorkers)
 	if err != nil {
 		b.logger.Errorf("Unable to create digital interrupt pin on the fly: %s", err)
 		return nil, false

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -277,8 +277,16 @@ func (b *sysfsBoard) DigitalInterruptByName(name string) (board.DigitalInterrupt
 		return nil, false // It's not a GPIO pin either. Give up.
 	}
 
-	// TODO(RSDK-2345): If the name is numerical and doesn't already exist, create it here anyway.
-	return nil, false
+	// TODO: fix this line
+	interrupt, err := createDigitalInterrupt(context, digint_config, gpioMappings, activeBackgroundWorkers)
+	if err != nil {
+		b.logger.Errorf("Unable to create digital interrupt pin on the fly: %s", err)
+		return nil, false
+	}
+
+	b.interrupts[name] = interrupt
+	delete(b.gpios, name)
+	return interrupt, true
 }
 
 func (b *sysfsBoard) SPINames() []string {

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -293,7 +293,11 @@ func (b *sysfsBoard) AnalogReaderNames() []string {
 }
 
 func (b *sysfsBoard) DigitalInterruptNames() []string {
-	return nil
+	names := []string{}
+	for name := range b.interrupts {
+		names = append(names, name)
+	}
+	return names
 }
 
 func (b *sysfsBoard) GPIOPinNames() []string {

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -272,12 +272,11 @@ func (b *sysfsBoard) DigitalInterruptByName(name string) (board.DigitalInterrupt
 		return nil, false // Non-numeric name, just give up.
 	}
 
-	gpio, ok := b.gpios[name]
-	if !ok {
+	if _, ok := b.gpios[name]; !ok {
 		return nil, false // It's not a GPIO pin either. Give up.
 	}
 
-	defaultInterruptConfig = board.DigitalInterruptConfig{
+	defaultInterruptConfig := board.DigitalInterruptConfig{
 		Name: name,
 		Pin:  name,
 		Type: "basic",
@@ -289,8 +288,8 @@ func (b *sysfsBoard) DigitalInterruptByName(name string) (board.DigitalInterrupt
 		return nil, false
 	}
 
-	b.interrupts[name] = interrupt
 	delete(b.gpios, name)
+	b.interrupts[name] = interrupt
 	return interrupt, true
 }
 


### PR DESCRIPTION
This is to say, you can mention interrupts by pin number without pre-defining them in the board config, and we'll automatically convert those GPIO pins to digital interrupts. You can't convert a digital interrupt pin back to a GPIO pin afterward, but in practice no one should ever want to do that.

Tried on a Jetson Orin with an ultrasonic sensor plugged in. This config was enough to get the sensor to work:
```
{
  "modules": [],
  "services": [],
  "components": [
    {
      "depends_on": [],
      "model": "jetson",
      "name": "main_board",
      "type": "board",
      "attributes": {}
    },
    {
      "name": "ult",
      "type": "sensor",
      "model": "ultrasonic",
      "attributes": {
        "trigger_pin": "40",
        "echo_interrupt_pin": "38",
        "board": "main_board"
      },
      "depends_on": []
    }
  ]
}
```
Note how the `main_board` component doesn't say nuthin' about nuthin', but the ultrasonic sensor can access digital interrupt pins anyway.

and while I was at it, I implemented `DigitalInterruptNames()`, which we forgot to implement when we added support for digital interrupts earlier this year. This function is untested, but it sure looks right to me! Compare to `AnalogReaderNames()`, `GPIOPinNames()`, and similar functions nearby.