### PR TITLE
[DATA-fix] Use path flag for destination dir.

### DIFF
--- a/cli/viam/main.go
+++ b/cli/viam/main.go
@@ -240,7 +240,7 @@ func main() {
 							dataFlagPartID, dataFlagPartName, dataFlagComponentType, dataFlagComponentModel, dataFlagComponentName,
 							dataFlagStart, dataFlagEnd, dataFlagMethod, dataFlagMimeTypes, dataFlagParallelDownloads, dataFlagTags),
 						Flags: []cli.Flag{
-							&cli.StringFlag{
+							&cli.PathFlag{
 								Name:     dataFlagDestination,
 								Required: true,
 								Usage:    "output directory for downloaded data",
@@ -829,11 +829,11 @@ func DataCommand(c *cli.Context) error {
 
 	switch c.String(dataFlagDataType) {
 	case dataTypeBinary:
-		if err := client.BinaryData(c.String(dataFlagDestination), filter, c.Uint(dataFlagParallelDownloads)); err != nil {
+		if err := client.BinaryData(c.Path(dataFlagDestination), filter, c.Uint(dataFlagParallelDownloads)); err != nil {
 			return err
 		}
 	case dataTypeTabular:
-		if err := client.TabularData(c.String(dataFlagDestination), filter); err != nil {
+		if err := client.TabularData(c.Path(dataFlagDestination), filter); err != nil {
 			return err
 		}
 	default:


### PR DESCRIPTION
# Summary

Changes destination from a string flag to a path flag in the CLI. This allows it to properly resolve home directories when passed `~`. 

# Testing
Tested locally with:

```
viam data export <filter flags> --destination ~/test_tilde
```
And confirmed it downloaded data into `$HOME_DIR/test_tilde`, rather than `./~/test_tilde` like before