### PR TITLE
RSDK-2704 - Remove duplicate package descriptions

### DIFF
--- a/services/slam/builtin/builtin.go
+++ b/services/slam/builtin/builtin.go
@@ -1,5 +1,5 @@
-// Package builtin implements simultaneous localization and mapping
-// This is an Experimental package
+// Package builtin implements simultaneous localization and mapping.
+// This is an Experimental package.
 package builtin
 
 import (

--- a/services/slam/builtin/orbslam_yaml.go
+++ b/services/slam/builtin/orbslam_yaml.go
@@ -1,4 +1,3 @@
-// This is an Experimental package
 package builtin
 
 import (

--- a/services/slam/client.go
+++ b/services/slam/client.go
@@ -1,5 +1,3 @@
-// Package slam implements simultaneous localization and mapping
-// This is an Experimental package
 package slam
 
 import (

--- a/services/slam/fake/slam.go
+++ b/services/slam/fake/slam.go
@@ -1,4 +1,4 @@
-// Package fake implements a fake slam service.
+// Package fake implements a fake slam service
 package fake
 
 import (

--- a/services/slam/server.go
+++ b/services/slam/server.go
@@ -1,5 +1,3 @@
-// Package slam implements simultaneous localization and mapping
-// This is an Experimental package
 package slam
 
 import (

--- a/services/slam/slam.go
+++ b/services/slam/slam.go
@@ -1,5 +1,5 @@
-// Package slam implements simultaneous localization and mapping
-// This is an Experimental package
+// Package slam implements simultaneous localization and mapping.
+// This is an Experimental package.
 package slam
 
 import (

--- a/services/slam/slam_libraries.go
+++ b/services/slam/slam_libraries.go
@@ -1,5 +1,3 @@
-// Package slam implements simultaneous localization and mapping
-// This is an Experimental package
 package slam
 
 // TODO 05/12/2022: Both type and constants will be deprecated when data ingestion via GRPC is available


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-2704

Problem:
* Adding the package description to every file that belongs to the same package ends up with a repeated package description in [go.viam.com](http://go.viam.com/)

Done:
* Removed duplicate package descriptions. Only one file for each package has the package description.