### PR TITLE
[RSDK-2734] turn off PWM signals when closing a board

### DIFF
--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -280,7 +280,8 @@ func (pin *gpioPin) Close() error {
 	pin.mu.Lock()
 	defer pin.mu.Unlock()
 
-	// Set the pin to low. That way, we turn it off if the entire server is shutting down.
+	// If the entire server is shutting down, it's important to turn off all pins so they don't
+	// continue outputting signals we will no longer control.
 	if err := pin.setInternal(false); err != nil {
 		return err
 	}

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -280,6 +280,11 @@ func (pin *gpioPin) Close() error {
 	pin.mu.Lock()
 	defer pin.mu.Unlock()
 
+	// Set the pin to low. That way, we turn it off if the entire server is shutting down.
+	if err := pin.setInternal(false); err != nil {
+		return err
+	}
+
 	if pin.hwPwm != nil {
 		// Make sure to unexport the sysfs device for hardware PWM on this pin, if it's in use.
 		if err := pin.hwPwm.Close(); err != nil {

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -281,16 +281,9 @@ func (pin *gpioPin) Close() error {
 	defer pin.mu.Unlock()
 
 	// If the entire server is shutting down, it's important to turn off all pins so they don't
-	// continue outputting signals we will no longer control.
+	// continue outputting signals we can no longer control.
 	if err := pin.setInternal(false); err != nil {
 		return err
-	}
-
-	if pin.hwPwm != nil {
-		// Make sure to unexport the sysfs device for hardware PWM on this pin, if it's in use.
-		if err := pin.hwPwm.Close(); err != nil {
-			return err
-		}
 	}
 	return pin.closeGpioFd()
 }

--- a/components/board/genericlinux/hw_pwm.go
+++ b/components/board/genericlinux/hw_pwm.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/edaniels/golog"
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 )
 
 // There are times when we need to set the period to some value, any value. It must be a positive
@@ -192,7 +191,5 @@ func (pwm *pwmDevice) SetPwm(freqHz uint, dutyCycle float64) (err error) {
 func (pwm *pwmDevice) Close() error {
 	pwm.mu.Lock()
 	defer pwm.mu.Unlock()
-	err1 := pwm.wrapError(pwm.disable())
-	err2 := pwm.wrapError(pwm.unexport())
-	return multierr.Combine(err1, err2)
+	return pwm.wrapError(pwm.unexport())
 }

--- a/components/board/genericlinux/hw_pwm.go
+++ b/components/board/genericlinux/hw_pwm.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/edaniels/golog"
 	"github.com/pkg/errors"
+	"go.uber.org/multierr"
 )
 
 // There are times when we need to set the period to some value, any value. It must be a positive
@@ -191,5 +192,7 @@ func (pwm *pwmDevice) SetPwm(freqHz uint, dutyCycle float64) (err error) {
 func (pwm *pwmDevice) Close() error {
 	pwm.mu.Lock()
 	defer pwm.mu.Unlock()
-	return pwm.wrapError(pwm.unexport())
+	err1 := pwm.wrapError(pwm.disable())
+	err2 := pwm.wrapError(pwm.unexport())
+	return multierr.Combine(err1, err2)
 }


### PR DESCRIPTION
Tried on an Orin: if you set a pin to high _or_ turn on a PWM signal, and then hit control-C to kill the RDK server, the pin goes low again and stays there. 

If you set a pin high or turn on a PWM signal, and then change the board config, the pin goes low again and stays there (until you set it to something else afterwards on the new board component). Is that the right choice? I think it might be, but would like a second opinion.