### PR TITLE
Refactoring: split interrupts out from GPIO on genericlinux boards (redux)

### DIFF
--- a/components/board/genericlinux/digital_interrupts.go
+++ b/components/board/genericlinux/digital_interrupts.go
@@ -1,7 +1,7 @@
 //go:build linux
 
-// Package genericlinux is for Linux boards, and this particular file is for GPIO pins using the
-// ioctl interface, indirectly by way of mkch's gpio package.
+// Package genericlinux is for Linux boards, and this particular file is for digital interrupt pins
+// using the ioctl interface, indirectly by way of mkch's gpio package.
 package genericlinux
 
 import (

--- a/components/board/genericlinux/digital_interrupts.go
+++ b/components/board/genericlinux/digital_interrupts.go
@@ -1,0 +1,89 @@
+//go:build linux
+
+// Package genericlinux is for Linux boards, and this particular file is for GPIO pins using the
+// ioctl interface, indirectly by way of mkch's gpio package.
+package genericlinux
+
+import (
+	"context"
+	"strconv"
+	"sync"
+
+	"github.com/mkch/gpio"
+	"github.com/pkg/errors"
+	"go.uber.org/multierr"
+	"go.viam.com/utils"
+
+	"go.viam.com/rdk/components/board"
+)
+
+type digitalInterrupt struct {
+	interrupt  board.DigitalInterrupt
+	line       *gpio.LineWithEvent
+	cancelCtx  context.Context
+	cancelFunc func()
+}
+
+func createDigitalInterrupt(ctx context.Context, config board.DigitalInterruptConfig,
+	gpioMappings map[int]GPIOBoardMapping, activeBackgroundWorkers *sync.WaitGroup,
+) (*digitalInterrupt, error) {
+	pinInt, err := strconv.Atoi(config.Pin)
+	if err != nil {
+		return nil, errors.Errorf("pin numbers must be numerical, not '%s'", config.Pin)
+	}
+	mapping, ok := gpioMappings[pinInt]
+	if !ok {
+		return nil, errors.Errorf("Unknown interrupt pin %s", config.Pin)
+	}
+
+	chip, err := gpio.OpenChip(mapping.GPIOChipDev)
+	if err != nil {
+		return nil, err
+	}
+	defer utils.UncheckedErrorFunc(chip.Close)
+
+	line, err := chip.OpenLineWithEvents(
+		uint32(mapping.GPIO), gpio.Input, gpio.BothEdges, "viam-interrupt")
+	if err != nil {
+		return nil, err
+	}
+
+	interrupt, err := board.CreateDigitalInterrupt(config)
+	if err != nil {
+		return nil, multierr.Combine(err, line.Close())
+	}
+
+	cancelCtx, cancelFunc := context.WithCancel(ctx)
+	result := digitalInterrupt{
+		interrupt:  interrupt,
+		line:       line,
+		cancelCtx:  cancelCtx,
+		cancelFunc: cancelFunc,
+	}
+	result.startMonitor(activeBackgroundWorkers)
+	return &result, nil
+}
+
+func (di *digitalInterrupt) startMonitor(activeBackgroundWorkers *sync.WaitGroup) {
+	activeBackgroundWorkers.Add(1)
+	utils.ManagedGo(func() {
+		for {
+			select {
+			case <-di.cancelCtx.Done():
+				return
+			case event := <-di.line.Events():
+				utils.UncheckedError(di.interrupt.Tick(
+					di.cancelCtx, event.RisingEdge, uint64(event.Time.UnixNano())))
+			}
+		}
+	}, activeBackgroundWorkers.Done)
+}
+
+func (di *digitalInterrupt) Close() error {
+	// We shut down the background goroutine that monitors this interrupt, but don't need to wait
+	// for it to finish shutting down because it doesn't use anything in the line itself (just a
+	// channel of events that the line generates). It will shut down sometime soon, and if that's
+	// after the line is closed, that's fine.
+	di.cancelFunc()
+	return di.line.Close()
+}

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -291,6 +291,7 @@ func gpioInitialize(cancelCtx context.Context, gpioMappings map[int]GPIOBoardMap
 ) (map[string]*gpioPin, map[string]*digitalInterrupt, error) {
 	interrupts := make(map[string]*digitalInterrupt, len(interruptConfigs))
 	for _, config := range interruptConfigs {
+		// The createDigitalInterrupt function is in digital_interrupts.go
 		interrupt, err := createDigitalInterrupt(cancelCtx, config, gpioMappings, waitGroup)
 		if err != nil {
 			// Close all pins we've started

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -7,13 +7,11 @@ package genericlinux
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"sync"
 	"time"
 
 	"github.com/edaniels/golog"
 	"github.com/mkch/gpio"
-	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 	"go.viam.com/utils"
 
@@ -325,75 +323,4 @@ func gpioInitialize(cancelCtx context.Context, gpioMappings map[int]GPIOBoardMap
 		pins[fmt.Sprintf("%d", pinNumber)] = pin
 	}
 	return pins, interrupts, nil
-}
-
-type digitalInterrupt struct {
-	interrupt  board.DigitalInterrupt
-	line       *gpio.LineWithEvent
-	cancelCtx  context.Context
-	cancelFunc func()
-}
-
-func createDigitalInterrupt(ctx context.Context, config board.DigitalInterruptConfig,
-	gpioMappings map[int]GPIOBoardMapping, activeBackgroundWorkers *sync.WaitGroup,
-) (*digitalInterrupt, error) {
-	pinInt, err := strconv.Atoi(config.Pin)
-	if err != nil {
-		return nil, errors.Errorf("pin numbers must be numerical, not '%s'", config.Pin)
-	}
-	mapping, ok := gpioMappings[pinInt]
-	if !ok {
-		return nil, errors.Errorf("Unknown interrupt pin %s", config.Pin)
-	}
-
-	chip, err := gpio.OpenChip(mapping.GPIOChipDev)
-	if err != nil {
-		return nil, err
-	}
-	defer utils.UncheckedErrorFunc(chip.Close)
-
-	line, err := chip.OpenLineWithEvents(
-		uint32(mapping.GPIO), gpio.Input, gpio.BothEdges, "viam-interrupt")
-	if err != nil {
-		return nil, err
-	}
-
-	interrupt, err := board.CreateDigitalInterrupt(config)
-	if err != nil {
-		return nil, multierr.Combine(err, line.Close())
-	}
-
-	cancelCtx, cancelFunc := context.WithCancel(ctx)
-	result := digitalInterrupt{
-		interrupt:  interrupt,
-		line:       line,
-		cancelCtx:  cancelCtx,
-		cancelFunc: cancelFunc,
-	}
-	result.startMonitor(activeBackgroundWorkers)
-	return &result, nil
-}
-
-func (di *digitalInterrupt) startMonitor(activeBackgroundWorkers *sync.WaitGroup) {
-	activeBackgroundWorkers.Add(1)
-	utils.ManagedGo(func() {
-		for {
-			select {
-			case <-di.cancelCtx.Done():
-				return
-			case event := <-di.line.Events():
-				utils.UncheckedError(di.interrupt.Tick(
-					di.cancelCtx, event.RisingEdge, uint64(event.Time.UnixNano())))
-			}
-		}
-	}, activeBackgroundWorkers.Done)
-}
-
-func (di *digitalInterrupt) Close() error {
-	// We shut down the background goroutine that monitors this interrupt, but don't need to wait
-	// for it to finish shutting down because it doesn't use anything in the line itself (just a
-	// channel of events that the line generates). It will shut down sometime soon, and if that's
-	// after the line is closed, that's fine.
-	di.cancelFunc()
-	return di.line.Close()
 }


### PR DESCRIPTION
This is https://github.com/viamrobotics/rdk/pull/2222, but adjusted for the history-rewrite yesterday (which I'd link to, except it doesn't appear to be either https://github.com/viamrobotics/rdk/pull/2144 or https://github.com/viamrobotics/rdk/pull/2225, so not sure what happened). 

Gautham reviewed the previous attempt, so he gets to review this one, too. It should be super easy.

Original PR description, edited from follow-up comments:
> That file was getting uncomfortably long, and was doing 2 unrelated things. So, I split it into 2 files.

> Everything still compiles, and the ultrasonic sensor still works on the Orin.
