### PR TITLE
RSDK-2613: Absolute functionality in AMS

### DIFF
--- a/components/encoder/AMS/ams_as5048.go
+++ b/components/encoder/AMS/ams_as5048.go
@@ -277,7 +277,8 @@ func (enc *Encoder) ResetPosition(
 	// NOTE (GV): potential improvement could be writing the offset position
 	// to the zero register of the encoder rather than keeping track
 	// on the struct
-
+	enc.position = 0
+	enc.rotations = 0
 	// clear current zero position
 	err := enc.writeByteDataToBus(ctx, enc.i2cBus, enc.i2cAddr, byte(0x16), byte(0))
 	if err != nil {

--- a/components/encoder/AMS/ams_as5048.go
+++ b/components/encoder/AMS/ams_as5048.go
@@ -277,21 +277,22 @@ func (enc *Encoder) ResetPosition(
 	// NOTE (GV): potential improvement could be writing the offset position
 	// to the zero register of the encoder rather than keeping track
 	// on the struct
-	enc.position = 0.0
+
+	// clear current zero position
+	err := enc.writeByteDataToBus(ctx, enc.i2cBus, enc.i2cAddr, byte(0x16), byte(0))
+	if err != nil {
+		return err
+	}
+	err = enc.writeByteDataToBus(ctx, enc.i2cBus, enc.i2cAddr, byte(0x17), byte(0))
+	if err != nil {
+		return err
+	}
+	// read current position
 	currentMSB, err := enc.readByteDataFromBus(ctx, enc.i2cBus, enc.i2cAddr, byte(0xFE))
 	if err != nil {
 		return err
 	}
 	currentLSB, err := enc.readByteDataFromBus(ctx, enc.i2cBus, enc.i2cAddr, byte(0xFF))
-	if err != nil {
-		return err
-	}
-	// clear current zero position
-	err = enc.writeByteDataToBus(ctx, enc.i2cBus, enc.i2cAddr, byte(0x16), byte(0))
-	if err != nil {
-		return err
-	}
-	err = enc.writeByteDataToBus(ctx, enc.i2cBus, enc.i2cAddr, byte(0x17), byte(0))
 	if err != nil {
 		return err
 	}

--- a/components/encoder/AMS/ams_as5048_test.go
+++ b/components/encoder/AMS/ams_as5048_test.go
@@ -1,10 +1,26 @@
 package ams
 
 import (
+	"context"
 	"math"
 	"testing"
 
+	"github.com/edaniels/golog"
+	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/encoder"
+	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/registry"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/testutils/inject"
 	"go.viam.com/test"
+)
+
+var model = resource.NewDefaultModel("AMS-AS5048")
+
+const (
+	defaultAddressRegister = 117
+	expectedDefaultAddress = 0x68
+	alternateAddress       = 0x69
 )
 
 func TestConvertBytesToAngle(t *testing.T) {
@@ -26,4 +42,76 @@ func TestConvertBytesToAngle(t *testing.T) {
 	lsB = byte(28)
 	deg = convertBytesToAngle(msB, lsB)
 	test.That(t, deg, test.ShouldAlmostEqual, 219.990234, 1e-6)
+}
+
+func setupDependencies(mockData []byte) (config.Component, registry.Dependencies) {
+	testBoardName := "board"
+	i2cName := "i2c"
+
+	i2cConf := &I2CAttrConfig{
+		I2CBus:  i2cName,
+		I2CAddr: 64,
+	}
+
+	cfg := config.Component{
+		Name:  "encoder",
+		Model: model,
+		Type:  encoder.SubtypeName,
+		ConvertedAttributes: &AttrConfig{
+			BoardName:      testBoardName,
+			ConnectionType: "i2c",
+			I2CAttrConfig:  i2cConf,
+		},
+	}
+
+	i2cHandle := &inject.I2CHandle{}
+	i2cHandle.ReadByteDataFunc = func(ctx context.Context, register byte) (byte, error) {
+		return mockData[register], nil
+	}
+	i2cHandle.WriteByteDataFunc = func(ctx context.Context, b1, b2 byte) error {
+		mockData[b1] = b2
+		return nil
+	}
+	i2cHandle.CloseFunc = func() error { return nil }
+	mockBoard := &inject.Board{}
+	mockBoard.I2CByNameFunc = func(name string) (board.I2C, bool) {
+		i2c := &inject.I2C{}
+		i2c.OpenHandleFunc = func(addr byte) (board.I2CHandle, error) {
+			return i2cHandle, nil
+		}
+		return i2c, true
+	}
+	return cfg, registry.Dependencies{
+		resource.NameFromSubtype(board.Subtype, testBoardName): mockBoard,
+	}
+}
+
+func TestAMSEncoder(t *testing.T) {
+	ctx := context.Background()
+
+	positionMockData := make([]byte, 256)
+	positionMockData[0xFE] = 100
+	positionMockData[0xFF] = 60
+
+	logger := golog.NewTestLogger(t)
+	cfg, deps := setupDependencies(positionMockData)
+	enc, err := newAS5048Encoder(ctx, deps, cfg, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	t.Run("test automatically set to type ticks", func(t *testing.T) {
+		enc.(*Encoder).position = 142
+		pos, posType, _ := enc.GetPosition(ctx, nil, nil)
+		test.That(t, pos, test.ShouldAlmostEqual, 0.4, 0.1)
+		test.That(t, posType, test.ShouldEqual, 1)
+	})
+	t.Run("test ticks type from input", func(t *testing.T) {
+		pos, posType, _ := enc.GetPosition(ctx, encoder.PositionTypeTICKS.Enum(), nil)
+		test.That(t, pos, test.ShouldAlmostEqual, 0.4, 0.1)
+		test.That(t, posType, test.ShouldEqual, 1)
+	})
+	t.Run("test degrees type from input", func(t *testing.T) {
+		pos, posType, _ := enc.GetPosition(ctx, encoder.PositionTypeDEGREES.Enum(), nil)
+		test.That(t, pos, test.ShouldAlmostEqual, 142, 0.1)
+		test.That(t, posType, test.ShouldEqual, 2)
+	})
 }

--- a/testutils/inject/i2c.go
+++ b/testutils/inject/i2c.go
@@ -32,6 +32,14 @@ type I2CHandle struct {
 	CloseFunc          func() error
 }
 
+// WriteByteData calls the injected ReadByteDataFunc or the real version.
+func (handle *I2CHandle) ReadByteData(ctx context.Context, register byte) (byte, error) {
+	if handle.ReadByteDataFunc == nil {
+		return handle.I2CHandle.ReadByteData(ctx, register)
+	}
+	return handle.ReadByteDataFunc(ctx, register)
+}
+
 // WriteByteData calls the injected WriteByteDataFunc or the real version.
 func (handle *I2CHandle) WriteByteData(ctx context.Context, register, data byte) error {
 	if handle.WriteByteDataFunc == nil {


### PR DESCRIPTION
Fixes `ResetPosition` for AMS encoders and adds software tests for all relevant encoder api functions.