### PR TITLE
Remove dynamic tag to use default opus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,11 @@ PATH_WITH_TOOLS="`pwd`/$(TOOL_BIN):`pwd`/node_modules/.bin:${PATH}"
 GIT_REVISION = $(shell git rev-parse HEAD | tr -d '\n')
 TAG_VERSION?=$(shell etc/tag_version.sh)
 LDFLAGS = -ldflags "$(shell etc/set_plt.sh) -X 'go.viam.com/rdk/config.Version=${TAG_VERSION}' -X 'go.viam.com/rdk/config.GitRevision=${GIT_REVISION}'"
-BUILD_TAGS=dynamic
-GO_BUILD_TAGS = -tags $(BUILD_TAGS)
-LINT_BUILD_TAGS = --build-tags $(BUILD_TAGS)
+
+# build tags are not currently needed, but leaving placeholders in case future requirements need a tag again
+# BUILD_TAGS=dynamic
+# GO_BUILD_TAGS = -tags $(BUILD_TAGS)
+# LINT_BUILD_TAGS = --build-tags $(BUILD_TAGS)
 
 default: build lint server
 


### PR DESCRIPTION
Updated canon images stopped including opus, as the go package itself includes prebuilt libraries.