### PR TITLE
RSDK-2356: base.Spin changes speed for different distances

### DIFF
--- a/components/base/wheeled/wheeled_base.go
+++ b/components/base/wheeled/wheeled_base.go
@@ -244,12 +244,13 @@ func (wb *wheeledBase) SetPower(ctx context.Context, linear, angular r3.Vector, 
 
 // returns rpm, revolutions for a spin motion.
 func (wb *wheeledBase) spinMath(angleDeg, degsPerSec float64) (float64, float64) {
-	wheelTravel := wb.spinSlipFactor * float64(wb.widthMm) * math.Pi * angleDeg / 360.0
+	wheelTravel := wb.spinSlipFactor * float64(wb.widthMm) * math.Pi * (angleDeg / 360.0)
 	revolutions := wheelTravel / float64(wb.wheelCircumferenceMm)
+	revolutions = math.Abs(revolutions)
 
 	// RPM = revolutions (unit) * deg/sec * (1 rot / 2pi deg) * (60 sec / 1 min) = rot/min
-	rpm := revolutions * degsPerSec * 30 / math.Pi
-	revolutions = math.Abs(revolutions)
+	// RPM = (revolutions (unit) / angleDeg) * degPerSec * 60
+	rpm := (revolutions / angleDeg) * degsPerSec * 60
 
 	return rpm, revolutions
 }

--- a/components/base/wheeled/wheeled_base_test.go
+++ b/components/base/wheeled/wheeled_base_test.go
@@ -165,20 +165,28 @@ func TestWheelBaseMath(t *testing.T) {
 	// Spin tests
 	t.Run("spin math", func(t *testing.T) {
 		rpms, rotations := base.spinMath(90, 10)
-		test.That(t, rpms, test.ShouldAlmostEqual, 7.5, 0.001)
+		test.That(t, rpms, test.ShouldAlmostEqual, 0.523, 0.001)
 		test.That(t, rotations, test.ShouldAlmostEqual, 0.0785, 0.001)
 
 		rpms, rotations = base.spinMath(-90, 10)
-		test.That(t, rpms, test.ShouldAlmostEqual, -7.5, 0.001)
+		test.That(t, rpms, test.ShouldAlmostEqual, -0.523, 0.001)
 		test.That(t, rotations, test.ShouldAlmostEqual, 0.0785, 0.001)
 
 		rpms, rotations = base.spinMath(90, -10)
-		test.That(t, rpms, test.ShouldAlmostEqual, -7.5, 0.001)
+		test.That(t, rpms, test.ShouldAlmostEqual, -0.523, 0.001)
 		test.That(t, rotations, test.ShouldAlmostEqual, 0.0785, 0.001)
 
 		rpms, rotations = base.spinMath(-90, -10)
-		test.That(t, rpms, test.ShouldAlmostEqual, 7.5, 0.001)
+		test.That(t, rpms, test.ShouldAlmostEqual, 0.523, 0.001)
 		test.That(t, rotations, test.ShouldAlmostEqual, 0.0785, 0.001)
+
+		rpms, rotations = base.spinMath(60, 10)
+		test.That(t, rpms, test.ShouldAlmostEqual, 0.523, 0.001)
+		test.That(t, rotations, test.ShouldAlmostEqual, 0.0523, 0.001)
+
+		rpms, rotations = base.spinMath(30, 10)
+		test.That(t, rpms, test.ShouldAlmostEqual, 0.523, 0.001)
+		test.That(t, rotations, test.ShouldAlmostEqual, 0.0261, 0.001)
 	})
 	t.Run("spin block", func(t *testing.T) {
 		go func() {


### PR DESCRIPTION
This change fixes base.spinMath and adds some initial tests. The calculation for RPM was incorrect but seems to be working now based on hand timing on actual hardware and the few test cases I added. I can add more if necessary but these cover the error I have seen.