### PR TITLE
RSDK-1020 Part IA change back encoder test pointer change for now, keep skips

### DIFF
--- a/components/motor/gpio/motor_encoder_test.go
+++ b/components/motor/gpio/motor_encoder_test.go
@@ -277,7 +277,7 @@ func TestMotorEncoder1(t *testing.T) {
 }
 
 func TestMotorEncoderIncremental(t *testing.T) {
-	t.Skip()
+	// t.Skip()
 	logger := golog.NewTestLogger(t)
 	undo := SetRPMSleepDebug(1, false)
 	defer undo()

--- a/components/motor/gpio/motor_encoder_test.go
+++ b/components/motor/gpio/motor_encoder_test.go
@@ -283,7 +283,7 @@ func TestMotorEncoderIncremental(t *testing.T) {
 	defer undo()
 
 	type testHarness struct {
-		Encoder   incremental.Encoder
+		Encoder   *incremental.Encoder
 		EncoderA  board.DigitalInterrupt
 		EncoderB  board.DigitalInterrupt
 		RealMotor *fakemotor.Motor
@@ -317,7 +317,7 @@ func TestMotorEncoderIncremental(t *testing.T) {
 		})
 
 		return testHarness{
-			*encoder,
+			encoder,
 			encoderA,
 			encoderB,
 			fakeMotor,


### PR DESCRIPTION
I made a mistake in where the pointer to the `incremental.Encoder` is created.