### PR TITLE
RSDK-2482: add rc card for encoder

### DIFF
--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/remote-control",
-      "version": "0.2.16",
+      "version": "0.2.17",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource/space-mono": "^4.5.12",
         "@improbable-eng/grpc-web": "^0.13.0",
         "@viamrobotics/prime": "^0.1.10",
         "@viamrobotics/rpc": "^0.1.34",
-        "@viamrobotics/sdk": "^0.0.42",
+        "@viamrobotics/sdk": "^0.0.44",
         "@vueuse/core": "^9.13.0",
         "google-protobuf": "^3.21.2",
         "three": "^0.150.1",
@@ -1283,9 +1283,9 @@
       }
     },
     "node_modules/@viamrobotics/sdk": {
-      "version": "0.0.42",
-      "resolved": "https://registry.npmjs.org/@viamrobotics/sdk/-/sdk-0.0.42.tgz",
-      "integrity": "sha512-+p0TgGxff6KZuPAB1HruHrfzOAYRnPBuCHZLUg1DAROfnCQ6PhEs3uNqHt23v4hi6KrixpcyuWcwAQAYnbibOw==",
+      "version": "0.0.44",
+      "resolved": "https://registry.npmjs.org/@viamrobotics/sdk/-/sdk-0.0.44.tgz",
+      "integrity": "sha512-PWD0i5oLXKXsPhlDwwwGjkrRF7+/zv8gIUj0jJbNrRHPVKv7liRNc+bYxiCPyfn9Tm3JhlDj91zJ4bYAKx4DEg==",
       "dependencies": {
         "@viamrobotics/rpc": "^0.1.34"
       }
@@ -7916,9 +7916,9 @@
       }
     },
     "@viamrobotics/sdk": {
-      "version": "0.0.42",
-      "resolved": "https://registry.npmjs.org/@viamrobotics/sdk/-/sdk-0.0.42.tgz",
-      "integrity": "sha512-+p0TgGxff6KZuPAB1HruHrfzOAYRnPBuCHZLUg1DAROfnCQ6PhEs3uNqHt23v4hi6KrixpcyuWcwAQAYnbibOw==",
+      "version": "0.0.44",
+      "resolved": "https://registry.npmjs.org/@viamrobotics/sdk/-/sdk-0.0.44.tgz",
+      "integrity": "sha512-PWD0i5oLXKXsPhlDwwwGjkrRF7+/zv8gIUj0jJbNrRHPVKv7liRNc+bYxiCPyfn9Tm3JhlDj91zJ4bYAKx4DEg==",
       "requires": {
         "@viamrobotics/rpc": "^0.1.34"
       }

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "license": "Apache-2.0",
   "type": "module",
   "files": [
@@ -18,7 +18,7 @@
     "@improbable-eng/grpc-web": "^0.13.0",
     "@viamrobotics/prime": "^0.1.10",
     "@viamrobotics/rpc": "^0.1.34",
-    "@viamrobotics/sdk": "^0.0.42",
+    "@viamrobotics/sdk": "^0.0.44",
     "@vueuse/core": "^9.13.0",
     "google-protobuf": "^3.21.2",
     "three": "^0.150.1",

--- a/web/frontend/src/components/encoder.vue
+++ b/web/frontend/src/components/encoder.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, toRaw } from 'vue';
+import { onMounted, onUnmounted } from 'vue';
 import { grpc } from '@improbable-eng/grpc-web';
 import { Client, encoderApi, type ServiceError } from '@viamrobotics/sdk';
 import { displayError } from '../lib/error';

--- a/web/frontend/src/components/encoder.vue
+++ b/web/frontend/src/components/encoder.vue
@@ -10,9 +10,12 @@ const props = defineProps<{
   client: Client
 }>();
 
-let properties = $ref<encoderApi.GetPropertiesResponse.AsObject | undefined>();
-let positionTicks = $ref<encoderApi.GetPositionResponse.AsObject | undefined>();
-let positionDegrees = $ref<encoderApi.GetPositionResponse.AsObject | undefined>();
+let properties = $ref<encoderApi.GetPropertiesResponse.AsObject | undefined>({
+  ticksCountSupported: false,
+  angleDegreesSupported: false,
+});
+let positionTicks = $ref<encoderApi.GetPositionResponse.AsObject | undefined>({ value: 0 });
+let positionDegrees = $ref<encoderApi.GetPositionResponse.AsObject | undefined>({ value: 0 });
 
 let refreshId = -1;
 

--- a/web/frontend/src/components/encoder.vue
+++ b/web/frontend/src/components/encoder.vue
@@ -119,7 +119,7 @@ onUnmounted(() => {
             Count
           </th>
           <td class="border-border-1 border p-2">
-            {{ (toRaw(positionTicks).value).toFixed(2) || 0 }}
+            {{ positionTicks.toFixed(2) || 0 }}
           </td>
         </tr>
         <tr
@@ -130,7 +130,7 @@ onUnmounted(() => {
             Angle (degrees)
           </th>
           <td class="border-border-1 border p-2">
-            {{ (toRaw(positionDegrees).value).toFixed(2) || 0 }}
+            {{ positionDegrees.toFixed(2) || 0 }}
           </td>
         </tr>
       </table>

--- a/web/frontend/src/components/encoder.vue
+++ b/web/frontend/src/components/encoder.vue
@@ -24,9 +24,9 @@ const refresh = () => {
   props.client.encoderService.getPosition(
     req,
     new grpc.Metadata(),
-    (err: ServiceError, resp: encoderApi.GetPositionResponse) => {
-      if (err) {
-        return displayError(err);
+    (error: ServiceError, resp: encoderApi.GetPositionResponse) => {
+      if (error) {
+        return displayError(error);
       }
 
       positionTicks = resp!.toObject();
@@ -39,9 +39,9 @@ const refresh = () => {
     props.client.encoderService.getPosition(
       req,
       new grpc.Metadata(),
-      (err: ServiceError, resp: encoderApi.GetPositionResponse) => {
-        if (err) {
-          return displayError(err);
+      (error: ServiceError, resp: encoderApi.GetPositionResponse) => {
+        if (error) {
+          return displayError(error);
         }
 
         positionDegrees = resp!.toObject();
@@ -60,9 +60,9 @@ const reset = async () => {
   await props.client.encoderService.resetPosition(
     req,
     new grpc.Metadata(),
-    (err: ServiceError, resp: encoderApi.ResetPositionResponse) => {
-      if (err) {
-        return displayError(err);
+    (error: ServiceError) => {
+      if (error) {
+        return displayError(error);
       }
     }
   );
@@ -77,13 +77,13 @@ onMounted(async () => {
     await props.client.encoderService.getProperties(
       req,
       new grpc.Metadata(),
-      (err: ServiceError, resp: encoderApi.GetPropertiesResponse) => {
-        if (err) {
-          if (err.message === 'Response closed without headers') {
+      (error: ServiceError, resp: encoderApi.GetPropertiesResponse) => {
+        if (error) {
+          if (error.message === 'Response closed without headers') {
             refreshId = window.setTimeout(refresh, 500);
             return;
           }
-          return displayError(err);
+          return displayError(error);
         }
         properties = resp!.toObject();
       }

--- a/web/frontend/src/components/encoder.vue
+++ b/web/frontend/src/components/encoder.vue
@@ -10,12 +10,12 @@ const props = defineProps<{
   client: Client
 }>();
 
-let properties = $ref<encoderApi.GetPropertiesResponse.AsObject | undefined>({
+let properties = $ref<encoderApi.GetPropertiesResponse.AsObject>({
   ticksCountSupported: false,
   angleDegreesSupported: false,
 });
-let positionTicks = $ref<encoderApi.GetPositionResponse.AsObject | undefined>({ value: 0 });
-let positionDegrees = $ref<encoderApi.GetPositionResponse.AsObject | undefined>({ value: 0 });
+let positionTicks = $ref<encoderApi.GetPositionResponse.AsObject>({ value: 0 });
+let positionDegrees = $ref<encoderApi.GetPositionResponse.AsObject>({ value: 0 });
 
 let refreshId = -1;
 
@@ -80,7 +80,7 @@ onMounted(async () => {
     await props.client.encoderService.getProperties(
       req,
       new grpc.Metadata(),
-      (error: ServiceError, resp: encoderApi.GetPropertiesResponse | null) => {
+      (error: ServiceError | null, resp: encoderApi.GetPropertiesResponse | null) => {
         if (error) {
           if (error.message === 'Response closed without headers') {
             refreshId = window.setTimeout(refresh, 500);

--- a/web/frontend/src/components/encoder.vue
+++ b/web/frontend/src/components/encoder.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, toRaw } from 'vue';
 import { grpc } from '@improbable-eng/grpc-web';
-import { Client, encoderApi, ServiceError } from '@viamrobotics/sdk';
+import { Client, encoderApi, type ServiceError } from '@viamrobotics/sdk';
 import { displayError } from '../lib/error';
 import { rcLogConditionally } from '../lib/log';
 
@@ -27,7 +27,7 @@ const refresh = () => {
   props.client.encoderService.getPosition(
     req,
     new grpc.Metadata(),
-    (error: ServiceError, resp: encoderApi.GetPositionResponse) => {
+    (error: ServiceError | null, resp: encoderApi.GetPositionResponse) => {
       if (error) {
         return displayError(error as ServiceError);
       }
@@ -63,7 +63,7 @@ const reset = async () => {
   await props.client.encoderService.resetPosition(
     req,
     new grpc.Metadata(),
-    (error: ServiceError) => {
+    (error: ServiceError | null) => {
       if (error) {
         return displayError(error as ServiceError);
       }

--- a/web/frontend/src/components/encoder.vue
+++ b/web/frontend/src/components/encoder.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, toRaw } from 'vue';
 import { grpc } from '@improbable-eng/grpc-web';
-import { Client, type encoderApi, type ServiceError } from '@viamrobotics/sdk';
+import { Client, encoderApi, type ServiceError } from '@viamrobotics/sdk';
 import { displayError } from '../lib/error';
 import { rcLogConditionally } from '../lib/log';
 
@@ -10,12 +10,9 @@ const props = defineProps<{
   client: Client
 }>();
 
-let properties = $ref<encoderApi.GetPropertiesResponse.AsObject>({
-  ticksCountSupported: false,
-  angleDegreesSupported: false,
-});
-let positionTicks = $ref<encoderApi.GetPositionResponse.AsObject>({ value: 0 });
-let positionDegrees = $ref<encoderApi.GetPositionResponse.AsObject>({ value: 0 });
+let properties = $ref<encoderApi.GetPropertiesResponse.AsObject | undefined>();
+let positionTicks = $ref<encoderApi.GetPositionResponse.AsObject | undefined>();
+let positionDegrees = $ref<encoderApi.GetPositionResponse.AsObject | undefined>();
 
 let refreshId = -1;
 
@@ -115,8 +112,8 @@ onUnmounted(() => {
     <div class="border-border-1 overflow-auto border border-t-0 p-4 text-left">
       <table class="bborder-border-1 table-auto border">
         <tr
-          v-if="properties.ticksCountSupported ||
-            (!properties.ticksCountSupported && !properties.angleDegreesSupported)"
+          v-if="properties && (properties.ticksCountSupported ||
+            (!properties.ticksCountSupported && !properties.angleDegreesSupported))"
         >
           <th class="border-border-1 border p-2">
             Count
@@ -126,8 +123,8 @@ onUnmounted(() => {
           </td>
         </tr>
         <tr
-          v-if="properties.angleDegreesSupported ||
-            (!properties.ticksCountSupported && !properties.angleDegreesSupported)"
+          v-if="properties && (properties.angleDegreesSupported ||
+            (!properties.ticksCountSupported && !properties.angleDegreesSupported))"
         >
           <th class="border-border-1 border p-2">
             Angle (degrees)

--- a/web/frontend/src/components/encoder.vue
+++ b/web/frontend/src/components/encoder.vue
@@ -11,8 +11,8 @@ const props = defineProps<{
 }>();
 
 let properties = $ref<encoderApi.GetPropertiesResponse.AsObject | undefined>();
-let positionTicks = $ref<encoderApi.GetPositionResponse.AsObject | undefined>();
-let positionDegrees = $ref<encoderApi.GetPositionResponse.AsObject | undefined>();
+let positionTicks = 0;
+let positionDegrees = 0;
 
 let refreshId = -1;
 
@@ -29,7 +29,7 @@ const refresh = () => {
         return displayError(error as ServiceError);
       }
 
-      positionTicks = resp!.toObject();
+      positionTicks = resp!.toObject().value;
     }
   );
 
@@ -44,7 +44,7 @@ const refresh = () => {
           return displayError(error as ServiceError);
         }
 
-        positionDegrees = resp!.toObject();
+        positionDegrees = resp!.toObject().value;
       }
     );
   }

--- a/web/frontend/src/components/encoder.vue
+++ b/web/frontend/src/components/encoder.vue
@@ -29,7 +29,7 @@ const refresh = () => {
     new grpc.Metadata(),
     (error: ServiceError, resp: encoderApi.GetPositionResponse) => {
       if (error) {
-        return displayError(error);
+        return displayError(error as ServiceError);
       }
 
       positionTicks = resp!.toObject();
@@ -42,9 +42,9 @@ const refresh = () => {
     props.client.encoderService.getPosition(
       req,
       new grpc.Metadata(),
-      (error: ServiceError, resp: encoderApi.GetPositionResponse) => {
+      (error: ServiceError | null, resp: encoderApi.GetPositionResponse) => {
         if (error) {
-          return displayError(error);
+          return displayError(error as ServiceError);
         }
 
         positionDegrees = resp!.toObject();
@@ -65,7 +65,7 @@ const reset = async () => {
     new grpc.Metadata(),
     (error: ServiceError) => {
       if (error) {
-        return displayError(error);
+        return displayError(error as ServiceError);
       }
     }
   );
@@ -86,7 +86,7 @@ onMounted(async () => {
             refreshId = window.setTimeout(refresh, 500);
             return;
           }
-          return displayError(error);
+          return displayError(error as ServiceError);
         }
         properties = resp!.toObject();
       }

--- a/web/frontend/src/components/encoder.vue
+++ b/web/frontend/src/components/encoder.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, toRaw } from 'vue';
 import { grpc } from '@improbable-eng/grpc-web';
-import { Client, encoderApi, type ServiceError } from '@viamrobotics/sdk';
+import { Client, type encoderApi, type ServiceError } from '@viamrobotics/sdk';
 import { displayError } from '../lib/error';
 import { rcLogConditionally } from '../lib/log';
 
@@ -27,7 +27,7 @@ const refresh = () => {
   props.client.encoderService.getPosition(
     req,
     new grpc.Metadata(),
-    (error: ServiceError | null, resp: encoderApi.GetPositionResponse) => {
+    (error: ServiceError | null, resp: encoderApi.GetPositionResponse | null) => {
       if (error) {
         return displayError(error as ServiceError);
       }
@@ -42,7 +42,7 @@ const refresh = () => {
     props.client.encoderService.getPosition(
       req,
       new grpc.Metadata(),
-      (error: ServiceError | null, resp: encoderApi.GetPositionResponse) => {
+      (error: ServiceError | null, resp: encoderApi.GetPositionResponse | null) => {
         if (error) {
           return displayError(error as ServiceError);
         }
@@ -80,7 +80,7 @@ onMounted(async () => {
     await props.client.encoderService.getProperties(
       req,
       new grpc.Metadata(),
-      (error: ServiceError, resp: encoderApi.GetPropertiesResponse) => {
+      (error: ServiceError, resp: encoderApi.GetPropertiesResponse | null) => {
         if (error) {
           if (error.message === 'Response closed without headers') {
             refreshId = window.setTimeout(refresh, 500);

--- a/web/frontend/src/components/encoder.vue
+++ b/web/frontend/src/components/encoder.vue
@@ -1,0 +1,146 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, toRaw } from 'vue';
+import { grpc } from '@improbable-eng/grpc-web';
+import { Client, encoderApi, ServiceError } from '@viamrobotics/sdk';
+import { displayError } from '../lib/error';
+import { rcLogConditionally } from '../lib/log';
+
+const props = defineProps<{
+  name: string
+  client: Client
+}>();
+
+let properties = $ref<encoderApi.GetPropertiesResponse.AsObject | undefined>();
+let positionTicks = $ref<encoderApi.GetPositionResponse.AsObject | undefined>();
+let positionDegrees = $ref<encoderApi.GetPositionResponse.AsObject | undefined>();
+
+let refreshId = -1;
+
+const refresh = () => {
+  const req = new encoderApi.GetPositionRequest();
+  req.setName(props.name);
+
+  rcLogConditionally(req);
+  props.client.encoderService.getPosition(
+    req,
+    new grpc.Metadata(),
+    (err: ServiceError, resp: encoderApi.GetPositionResponse) => {
+      if (err) {
+        return displayError(err);
+      }
+
+      positionTicks = resp!.toObject();
+    }
+  );
+
+  if (properties!.angleDegreesSupported) {
+    req.setPositionType(2);
+    rcLogConditionally(req);
+    props.client.encoderService.getPosition(
+      req,
+      new grpc.Metadata(),
+      (err: ServiceError, resp: encoderApi.GetPositionResponse) => {
+        if (err) {
+          return displayError(err);
+        }
+
+        positionDegrees = resp!.toObject();
+      }
+    );
+  }
+
+  refreshId = window.setTimeout(refresh, 500);
+};
+
+const reset = async () => {
+  const req = new encoderApi.ResetPositionRequest();
+  req.setName(props.name);
+
+  rcLogConditionally(req);
+  await props.client.encoderService.resetPosition(
+    req,
+    new grpc.Metadata(),
+    (err: ServiceError, resp: encoderApi.ResetPositionResponse) => {
+      if (err) {
+        return displayError(err);
+      }
+    }
+  );
+};
+
+onMounted(async () => {
+  try {
+    const req = new encoderApi.GetPropertiesRequest();
+    req.setName(props.name);
+
+    rcLogConditionally(req);
+    await props.client.encoderService.getProperties(
+      req,
+      new grpc.Metadata(),
+      (err: ServiceError, resp: encoderApi.GetPropertiesResponse) => {
+        if (err) {
+          if (err.message === 'Response closed without headers') {
+            refreshId = window.setTimeout(refresh, 500);
+            return;
+          }
+          return displayError(err);
+        }
+        properties = resp!.toObject();
+      }
+    );
+    refreshId = window.setTimeout(refresh, 500);
+  } catch (error) {
+    displayError(error as ServiceError);
+  }
+});
+
+onUnmounted(() => {
+  clearTimeout(refreshId);
+});
+
+</script>
+
+<template>
+  <v-collapse
+    :title="name"
+    class="encoder"
+  >
+    <v-breadcrumbs
+      slot="title"
+      crumbs="encoder"
+    />
+    <div class="border-border-1 overflow-auto border border-t-0 p-4 text-left">
+      <table class="bborder-border-1 table-auto border">
+        <tr
+          v-if="properties.ticksCountSupported ||
+            (!properties.ticksCountSupported && !properties.angleDegreesSupported)"
+        >
+          <th class="border-border-1 border p-2">
+            Count
+          </th>
+          <td class="border-border-1 border p-2">
+            {{ (toRaw(positionTicks).value).toFixed(2) || 0 }}
+          </td>
+        </tr>
+        <tr
+          v-if="properties.angleDegreesSupported ||
+            (!properties.ticksCountSupported && !properties.angleDegreesSupported)"
+        >
+          <th class="border-border-1 border p-2">
+            Angle (degrees)
+          </th>
+          <td class="border-border-1 border p-2">
+            {{ (toRaw(positionDegrees).value).toFixed(2) || 0 }}
+          </td>
+        </tr>
+      </table>
+      <div class="mt-2 flex gap-2">
+        <v-button
+          label="Reset"
+          class="flex-auto"
+          @click="reset"
+        />
+      </div>
+    </div>
+  </v-collapse>
+</template>

--- a/web/frontend/src/components/remote-control-cards.vue
+++ b/web/frontend/src/components/remote-control-cards.vue
@@ -34,6 +34,7 @@ import Board from './board.vue';
 import CamerasList from './camera/cameras-list.vue';
 import OperationsSessions from './operations-sessions.vue';
 import DoCommand from './do-command.vue';
+import Encoder from './encoder.vue';
 import Gantry from './gantry.vue';
 import Gripper from './gripper.vue';
 import Gamepad from './gamepad.vue';
@@ -734,6 +735,14 @@ onUnmounted(() => {
       :client="client"
       :resources="resources"
       :stream-manager="streamManager"
+    />
+
+    <!-- ******* ENCODER *******  -->
+    <Encoder
+      v-for="encoder in filterRdkComponentsWithStatus(resources, status, 'encoder')"
+      :key="encoder.name"
+      :name="encoder.name"
+      :client="client"
     />
 
     <!-- ******* GANTRY *******  -->

--- a/web/frontend/src/components/remote-control-cards.vue
+++ b/web/frontend/src/components/remote-control-cards.vue
@@ -739,7 +739,7 @@ onUnmounted(() => {
 
     <!-- ******* ENCODER *******  -->
     <Encoder
-      v-for="encoder in filterRdkComponentsWithStatus(resources, status, 'encoder')"
+      v-for="encoder in filterResources(resources, 'rdk', 'component', 'encoder')"
       :key="encoder.name"
       :name="encoder.name"
       :client="client"


### PR DESCRIPTION
This change adds an RC card for the new encoder API. If the encoder only supports ticks, only the `Count` column will be shown, and if it only supports degrees, only the `Angle (degrees)` column will be shown. If the encoder supports both, then both columns will be there, as shown in the image below.
<img width="907" alt="Screenshot 2023-04-13 at 5 59 49 PM" src="https://user-images.githubusercontent.com/106617924/231892676-8d717d45-8e07-4018-a43f-32c427da487f.png">
