### PR TITLE
RSDK-2692 - Add collectors for MovementSensor LinearAcceleration and Orientation

### DIFF
--- a/components/movementsensor/movementsensor.go
+++ b/components/movementsensor/movementsensor.go
@@ -49,6 +49,14 @@ func init() {
 		h, err := ms.CompassHeading(ctx, make(map[string]interface{}))
 		return Heading{Heading: h}, err
 	})
+	registerCollector("LinearAcceleration", func(ctx context.Context, ms MovementSensor) (interface{}, error) {
+		v, err := ms.LinearAcceleration(ctx, make(map[string]interface{}))
+		return v, err
+	})
+	registerCollector("Orientation", func(ctx context.Context, ms MovementSensor) (interface{}, error) {
+		v, err := ms.Orientation(ctx, make(map[string]interface{}))
+		return v, err
+	})
 }
 
 // SubtypeName is a constant that identifies the component resource subtype string "movement_sensor".


### PR DESCRIPTION
I tested this manually by creating a robot with a fake movement sensor and capturing Position, LinearAcceleration, and Orientation. I didn't see a place to add unit test coverage.

Here is the exported sensor data.
[sensor_data.zip](https://github.com/viamrobotics/rdk/files/11298362/sensor_data.zip)

Here are the corresponding app changes: https://github.com/viamrobotics/app/pull/1503
