### PR TITLE
RSDK-2489

### DIFF
--- a/services/slam/fake/data_loader.go
+++ b/services/slam/fake/data_loader.go
@@ -3,6 +3,7 @@ package fake
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -54,12 +55,19 @@ func fakeGetPointCloudMap(_ context.Context, datasetDir string, slamSvc *SLAM) (
 		return nil, err
 	}
 	chunk := make([]byte, chunkSizeBytes)
+	var chunkCount int
 	f := func() ([]byte, error) {
 		bytesRead, err := file.Read(chunk)
 		if err != nil {
 			defer utils.UncheckedErrorFunc(file.Close)
 			return nil, err
 		}
+		chunkCount++
+    slamSvc.logger.Warnf("slamSvc.getCount() > %d, chunkCount %d", slamSvc.getCount(), chunkCount)
+    if slamSvc.getCount() > 5 && chunkCount >= 3 {
+      return nil, errors.New("ah ah ah")
+
+    }
 		return chunk[:bytesRead], err
 	}
 	return f, nil

--- a/services/slam/fake/data_loader.go
+++ b/services/slam/fake/data_loader.go
@@ -47,10 +47,6 @@ const (
 )
 
 func fakeGetPointCloudMap(_ context.Context, datasetDir string, slamSvc *SLAM) (func() ([]byte, error), error) {
-	c := slamSvc.getCount()
-	if c == 17 {
-		return nil, fmt.Errorf("simulated bad fakeGetPointCloudMap response %d", c)
-	}
 	path := filepath.Clean(artifact.MustPath(fmt.Sprintf(pcdTemplate, datasetDir, slamSvc.getCount())))
 	slamSvc.logger.Debug("Reading " + path)
 	file, err := os.Open(path)
@@ -58,17 +54,11 @@ func fakeGetPointCloudMap(_ context.Context, datasetDir string, slamSvc *SLAM) (
 		return nil, err
 	}
 	chunk := make([]byte, chunkSizeBytes)
-	var chunkCount int
 	f := func() ([]byte, error) {
 		bytesRead, err := file.Read(chunk)
 		if err != nil {
 			defer utils.UncheckedErrorFunc(file.Close)
 			return nil, err
-		}
-		chunkCount++
-		slamSvc.logger.Warnf("slamSvc.getCount() > %d, chunkCount %d", slamSvc.getCount(), chunkCount)
-		if c%3 == 0 && chunkCount >= 2 {
-			return nil, fmt.Errorf("simulated bad PCD chunk %d", c)
 		}
 		return chunk[:bytesRead], err
 	}
@@ -97,10 +87,6 @@ func fakeGetInternalState(_ context.Context, datasetDir string, slamSvc *SLAM) (
 func fakeGetPosition(_ context.Context, datasetDir string, slamSvc *SLAM) (spatialmath.Pose, string, error) {
 	path := filepath.Clean(artifact.MustPath(fmt.Sprintf(positionTemplate, datasetDir, slamSvc.getCount())))
 	slamSvc.logger.Debug("Reading " + path)
-	c := slamSvc.getCount()
-	if c%2 == 0 {
-		return nil, "", fmt.Errorf("simulated bad position %d", c)
-	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, "", err

--- a/web/frontend/src/components/slam.vue
+++ b/web/frontend/src/components/slam.vue
@@ -1,7 +1,6 @@
 
 <script setup lang="ts">
 
-import { onMounted, onUnmounted } from 'vue';
 import { $ref, $computed } from 'vue/macros';
 import { grpc } from '@improbable-eng/grpc-web';
 import { Client, commonApi, ResponseStream, robotApi, ServiceError, slamApi } from '@viamrobotics/sdk';

--- a/web/frontend/src/components/slam.vue
+++ b/web/frontend/src/components/slam.vue
@@ -56,16 +56,12 @@ const fetchSLAMMap = (name: string): Promise<Uint8Array> => {
 
     const getPointCloudMap: ResponseStream<slamApi.GetPointCloudMapResponse> =
       props.client.slamService.getPointCloudMap(req);
-    let dataCounter = 0;
     getPointCloudMap.on('data', (res: { getPointCloudPcdChunk_asU8(): Uint8Array }) => {
-      dataCounter += 1;
-      console.log('received data', dataCounter);
       const chunk = res.getPointCloudPcdChunk_asU8();
       chunks.push(chunk);
     });
     getPointCloudMap.on('status', (status: { code: number, details: string, metadata: grpc.Metadata }) => {
       if (status.code !== 0) {
-        console.warn('status called with status', status);
         const error = {
           message: status.details,
           code: status.code,
@@ -79,7 +75,6 @@ const fetchSLAMMap = (name: string): Promise<Uint8Array> => {
         const error = { message: 'Stream ended without status code' };
         reject(error);
       } else if (end.code !== 0) {
-        console.warn('called with end', end);
         const error = {
           message: end.details,
           code: end.code,

--- a/web/frontend/src/components/slam.vue
+++ b/web/frontend/src/components/slam.vue
@@ -148,7 +148,9 @@ const scheduleRefresh2d = (name: string, time: string) => {
     } catch (error) {
       handleError('refresh2d', error);
       selected2dValue = 'manual';
-      refreshErrorMessage2d = `${refreshErrorMessage} ${error.message}`;
+      refreshErrorMessage2d = error !== null && typeof error === 'object' && 'message' in error
+        ? `${refreshErrorMessage} ${error.message}`
+        : `${refreshErrorMessage} ${error}`;
       return;
     }
     if (refresh2DCancelled) {
@@ -167,7 +169,9 @@ const scheduleRefresh3d = (name: string, time: string) => {
     } catch (error) {
       handleError('fetchSLAMMap', error);
       selected3dValue = 'manual';
-      refreshErrorMessage3d = `${refreshErrorMessage} ${error.message}`;
+      refreshErrorMessage3d = error !== null && typeof error === 'object' && 'message' in error
+        ? `${refreshErrorMessage} ${error.message}`
+        : `${refreshErrorMessage} ${error}`;
       return;
     }
     if (refresh3DCancelled) {
@@ -191,7 +195,9 @@ const updateSLAM2dRefreshFrequency = async (name: string, time: 'manual' | strin
     } catch (error) {
       handleError('refresh2d', error);
       selected2dValue = 'manual';
-      refreshErrorMessage2d = `${refreshErrorMessage} ${error.message}`;
+      refreshErrorMessage2d = error !== null && typeof error === 'object' && 'message' in error
+        ? `${refreshErrorMessage} ${error.message}`
+        : `${refreshErrorMessage} ${error}`;
     }
   } else {
     refresh2DCancelled = false;
@@ -212,7 +218,9 @@ const updateSLAM3dRefreshFrequency = async (name: string, time: 'manual' | strin
     } catch (error) {
       handleError('fetchSLAMMap', error);
       selected3dValue = 'manual';
-      refreshErrorMessage3d = `${refreshErrorMessage} ${error.message}`;
+      refreshErrorMessage3d = error !== null && typeof error === 'object' && 'message' in error
+        ? `${refreshErrorMessage} ${error.message}`
+        : `${refreshErrorMessage} ${error}`;
     }
   } else {
     refresh3DCancelled = false;
@@ -266,7 +274,6 @@ onUnmounted(() => {
   window.clearTimeout(slam3dTimeoutId);
 });
 
-
 </script>
 
 <template>
@@ -280,7 +287,7 @@ onUnmounted(() => {
     />
     <div class="border-border-1 h-auto border-x border-b p-2">
       <div class="container mx-auto">
-        <div class="flex-col pt-4"> <!--here is the end of the thing-->
+        <div class="flex-col pt-4">
           <div class="flex items-center gap-2">
             <v-switch
               id="showImage"

--- a/web/frontend/src/components/slam.vue
+++ b/web/frontend/src/components/slam.vue
@@ -18,7 +18,7 @@ const props = defineProps<{
   client: Client
   statusStream: ResponseStream<robotApi.StreamStatusResponse> | null
 }>();
-const refreshErrorMessage = 'Map stale... error refreshing map:';
+const refreshErrorMessage = 'Error refreshing map. The map shown may be stale.';
 let refreshErrorMessage2d = $ref<string | null>();
 let refreshErrorMessage3d = $ref<string | null>();
 let selected2dValue = $ref('manual');


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-2489)


Fixed issues:
1. If GetPosition or GetPointCloudMap returns an error, both the 2d & 3d slam views stop polling, reset the polling interval dropdown & pins the error that stopped polling to the top of the 2d or 3d slam view (respectively)
2. Makes it so that every time the 2d or 3d views are expanded 

TODO:
- [x] Test on fake slam (by triggering errors on an interval for GetPosition or GetPointCloud requests)
- [x] Test on rover
- [x] Confirm errors on get position also stop map polling


![Screenshot 2023-04-21 at 4 19 22 PM](https://user-images.githubusercontent.com/5927876/233727635-633f9a14-abae-450f-884d-3daa33dbe562.png)
![Screenshot 2023-04-21 at 4 20 40 PM](https://user-images.githubusercontent.com/5927876/233727640-540931f1-f852-4250-968b-c00022d1c6a1.png)


https://user-images.githubusercontent.com/5927876/233727611-165a812f-81dc-4693-801d-362a9314de82.mp4

