### PR TITLE
Add h-[400px] to safe list

### DIFF
--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/remote-control",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource/space-mono": "^4.5.12",

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "license": "Apache-2.0",
   "type": "module",
   "files": [

--- a/web/frontend/tailwind.config.cjs
+++ b/web/frontend/tailwind.config.cjs
@@ -75,5 +75,5 @@ module.exports = {
     },
   },
   plugins: [],
-  safelist: ['list-disc'],
+  safelist: ['list-disc', 'h-[400px]'],
 };


### PR DESCRIPTION
We are seeing an issue where the `h-[400px]` arbitrary class is not being respected in production builds. This will attempt to ensure it is included by adding it to the `tailwind` config safe list. 