### PR TITLE
remove comment about digital interrupt callbacks

### DIFF
--- a/components/board/digital_interrupts.go
+++ b/components/board/digital_interrupts.go
@@ -42,8 +42,6 @@ type DigitalInterrupt interface {
 
 	// AddCallback adds a callback to be sent a low/high value to when a tick
 	// happens.
-	// Note(erd): not all interrupts can have callbacks so this should probably be a
-	// separate interface.
 	AddCallback(c chan Tick)
 
 	// AddPostProcessor adds a post processor that should be used to modify


### PR DESCRIPTION
I don't know if we'll ever remove the "servo" type of digital interrupt (see https://viam.atlassian.net/browse/RSDK-1963), but in the meantime this comment is showing up in the [public, auto-generated documentation](https://pkg.go.dev/go.viam.com/rdk/components/board#DigitalInterrupt), and is causing some confusion (per @sguequierre). Basic digital interrupts have supported callbacks for a long time, and non-basic (servo) digital interrupts probably shouldn't be used.

Eric wrote this in 2021, which I suspect was before the current interface had been fleshed out very well.