### PR TITLE
RSDK-2721 add guardrails around worldstate names by making constructor

### DIFF
--- a/referenceframe/errors.go
+++ b/referenceframe/errors.go
@@ -41,3 +41,7 @@ func NewIncorrectInputLengthError(actual, expected int) error {
 func NewUnsupportedJointTypeError(jointType string) error {
 	return errors.Errorf("unsupported joint type detected: %q", jointType)
 }
+
+func NewWorldStateNameError(name string) error {
+	return errors.Errorf("cannot specify multiple geometries with the same name: %s", name)
+}

--- a/referenceframe/worldstate_test.go
+++ b/referenceframe/worldstate_test.go
@@ -1,0 +1,41 @@
+package referenceframe
+
+import (
+	"testing"
+
+	"go.viam.com/rdk/spatialmath"
+	"go.viam.com/test"
+)
+
+func TestWorldStateConstruction(t *testing.T) {
+	ws := NewEmptyWorldState()
+	foo, err := spatialmath.NewSphere(spatialmath.NewZeroPose(), 10, "foo")
+	test.That(t, err, test.ShouldBeNil)
+	bar, err := spatialmath.NewSphere(spatialmath.NewZeroPose(), 10, "bar")
+	test.That(t, err, test.ShouldBeNil)
+	noname, err := spatialmath.NewSphere(spatialmath.NewZeroPose(), 10, "")
+	test.That(t, err, test.ShouldBeNil)
+	unnamed, err := spatialmath.NewSphere(spatialmath.NewZeroPose(), 10, "")
+	test.That(t, err, test.ShouldBeNil)
+	expectedErr := NewWorldStateNameError(foo.Label()).Error()
+
+	// test that you can add two geometries of different names
+	err = ws.AddObstacles("", foo, bar)
+	test.That(t, err, test.ShouldBeNil)
+
+	// test that you can't add two "foos" to the same frame
+	err = ws.AddObstacles("", foo, foo)
+	test.That(t, err.Error(), test.ShouldResemble, expectedErr)
+
+	// test that you can't add two "foos" to different frames
+	err = ws.AddObstacles("", foo)
+	test.That(t, err.Error(), test.ShouldResemble, expectedErr)
+
+	// test that you can add multiple geometries with no name
+	err = ws.AddObstacles("", noname, unnamed)
+	test.That(t, err, test.ShouldBeNil)
+}
+
+func TestWorldStateProtoConversions(t *testing.T) {
+
+}


### PR DESCRIPTION
This PR will serve as the groundwork for RSDK-2624 RSDK-2206 by outlining the way we expect users to work with worldstate objects.  This changes the go SDK object to have private obstacles such that a user cannot modify them outside of using the functions we promote which ensure that two geometries cannot be named the same way.  