### PR TITLE
Check for self-managed connections

### DIFF
--- a/web/frontend/README.md
+++ b/web/frontend/README.md
@@ -36,4 +36,4 @@ The file paths listed in the `files` field of `package.json` determines what is 
 
 If you intend to use the Remote Control in you own application, consider whether or not your application will be creating its own connection to the robot using the [Viam TypeScript SDK](https://github.com/viamrobotics/viam-typescript-sdk). If so, be aware the Remote Control has a peer dependency for the SDK at a locked version, and will expect your application to include a dependency to _that version_.
 
-The SDK `Client` you create for your connection should be passed to the `createRcApp` function when creating your Remote Control.
+The SDK `Client` you create for your connection should be passed to the `createRcApp` function when creating your Remote Control. _The Remote Control will assume you are managing the client connection, and will not attempt to connect or disconnect on its own._

--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/remote-control",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource/space-mono": "^4.5.12",

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "Apache-2.0",
   "type": "module",
   "files": [

--- a/web/frontend/src/app.vue
+++ b/web/frontend/src/app.vue
@@ -41,6 +41,7 @@ const client = new Client(impliedURL, {
     :supported-auth-types="supportedAuthTypes"
     :webrtc-enabled="webrtcEnabled"
     :client="client"
+    manage-client-connection
   />
 </template>
 

--- a/web/frontend/src/components/remote-control-cards.vue
+++ b/web/frontend/src/components/remote-control-cards.vue
@@ -65,6 +65,7 @@ const props = defineProps<{
   supportedAuthTypes: string[],
   webrtcEnabled: boolean,
   client: Client;
+  manageClientConnection: boolean
 }>();
 
 const relevantSubtypesForStatus = [
@@ -544,7 +545,10 @@ const createAppConnectionManager = () => {
         }
         resourcesOnce = false;
 
-        await props.client.connect();
+        if (props.manageClientConnection) {
+          await props.client.connect();
+        }
+
         await fetchCurrentOps();
         lastStatusTS = Date.now();
         console.log('reconnected');
@@ -563,6 +567,8 @@ const createAppConnectionManager = () => {
 
   const stop = () => {
     window.clearTimeout(timeout);
+    statusStream?.cancel();
+    statusStream = null;
   };
 
   const start = () => {
@@ -664,9 +670,13 @@ const initConnect = () => {
   }
 };
 
-const handleUnload = () => {
+const handleUnload = async () => {
   console.debug('disconnecting');
   appConnectionManager.stop();
+
+  if (props.manageClientConnection) {
+    await props.client.disconnect();
+  }
 };
 
 onMounted(async () => {

--- a/web/frontend/src/main-lib.ts
+++ b/web/frontend/src/main-lib.ts
@@ -14,7 +14,8 @@ export const createRcApp = (props: {
   webrtcEnabled: boolean,
   client?: Client;
 }) => {
-  if (!props.client) {
+  const manageClientConnection = props.client === undefined;
+  if (manageClientConnection) {
     const rtcConfig = {
       iceServers: [
         {
@@ -40,5 +41,5 @@ export const createRcApp = (props: {
     });
   }
 
-  return createApp(RemoteControlCards, props);
+  return createApp(RemoteControlCards, { ...props, manageClientConnection });
 };


### PR DESCRIPTION
Now that we can pass a robot client to the RC, the RC should be aware if it needs to self-manage the connection. If a client is passed, the RC will not attempt to connect/disconnect and will leave that up to whatever parent component is passing to it. If a client is not passed, the RC will create its own client and connect/disconnect as expected.