### PR TITLE
Make RC SDK client self managed

### DIFF
--- a/web/frontend/README.md
+++ b/web/frontend/README.md
@@ -34,6 +34,4 @@ The file paths listed in the `files` field of `package.json` determines what is 
 
 ### Using the NPM Package
 
-If you intend to use the Remote Control in you own application, consider whether or not your application will be creating its own connection to the robot using the [Viam TypeScript SDK](https://github.com/viamrobotics/viam-typescript-sdk). If so, be aware the Remote Control has a peer dependency for the SDK at a locked version, and will expect your application to include a dependency to _that version_.
-
-The SDK `Client` you create for your connection should be passed to the `createRcApp` function when creating your Remote Control. _The Remote Control will assume you are managing the client connection, and will not attempt to connect or disconnect on its own._
+If you intend to use the Remote Control in you own application, consider whether or not your application will be creating its own connection to the robot using the [Viam TypeScript SDK](https://github.com/viamrobotics/viam-typescript-sdk). If so, be aware the Remote Control also creates and manages its own SDK `Client`. If you intend to use the Remote Control _and_ make your own SDK `Client` to make API calls, you will want to make sure you disconnect from your `Client` after each API call so you do not maintain multiple long-running connections to the robot. 

--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/remote-control",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource/space-mono": "^4.5.12",
         "@improbable-eng/grpc-web": "^0.13.0",
         "@viamrobotics/prime": "^0.1.10",
         "@viamrobotics/rpc": "^0.1.34",
+        "@viamrobotics/sdk": "^0.0.47",
         "@vueuse/core": "^9.13.0",
         "google-protobuf": "^3.21.2",
         "three": "^0.150.1",
@@ -25,7 +26,6 @@
         "@types/google.maps": "^3.52.4",
         "@types/three": "^0.150.1",
         "@typescript-eslint/eslint-plugin": "^5.57.1",
-        "@viamrobotics/sdk": "^0.0.47",
         "@vitejs/plugin-vue": "^4.1.0",
         "cypress": "^10.10.0",
         "eslint": "^8.37.0",
@@ -46,9 +46,6 @@
         "vue-toast-notification": "^3.1.1",
         "vue-tsc": "^1.2.0",
         "vue3-popper": "^1.5.0"
-      },
-      "peerDependencies": {
-        "@viamrobotics/sdk": "^0.0.47"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1289,7 +1286,6 @@
       "version": "0.0.47",
       "resolved": "https://registry.npmjs.org/@viamrobotics/sdk/-/sdk-0.0.47.tgz",
       "integrity": "sha512-j2+RaOjPrvTVcY+nFDby1fbrkjXmuNvYDBezDsEXzDZvnkO3vLAUPfULcrEWxiB6B7aEnzAfd3537IG4zkZ0cQ==",
-      "dev": true,
       "dependencies": {
         "@viamrobotics/rpc": "^0.1.35"
       }
@@ -7923,7 +7919,6 @@
       "version": "0.0.47",
       "resolved": "https://registry.npmjs.org/@viamrobotics/sdk/-/sdk-0.0.47.tgz",
       "integrity": "sha512-j2+RaOjPrvTVcY+nFDby1fbrkjXmuNvYDBezDsEXzDZvnkO3vLAUPfULcrEWxiB6B7aEnzAfd3537IG4zkZ0cQ==",
-      "dev": true,
       "requires": {
         "@viamrobotics/rpc": "^0.1.35"
       }

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "license": "Apache-2.0",
   "type": "module",
   "files": [
@@ -13,14 +13,12 @@
       "import": "./dist/rc.js"
     }
   },
-  "peerDependencies": {
-    "@viamrobotics/sdk": "^0.0.47"
-  },
   "dependencies": {
     "@fontsource/space-mono": "^4.5.12",
     "@improbable-eng/grpc-web": "^0.13.0",
     "@viamrobotics/prime": "^0.1.10",
     "@viamrobotics/rpc": "^0.1.34",
+    "@viamrobotics/sdk": "^0.0.47",
     "@vueuse/core": "^9.13.0",
     "google-protobuf": "^3.21.2",
     "three": "^0.150.1",
@@ -33,7 +31,6 @@
     "@types/google.maps": "^3.52.4",
     "@types/three": "^0.150.1",
     "@typescript-eslint/eslint-plugin": "^5.57.1",
-    "@viamrobotics/sdk": "^0.0.47",
     "@vitejs/plugin-vue": "^4.1.0",
     "cypress": "^10.10.0",
     "eslint": "^8.37.0",

--- a/web/frontend/src/app.vue
+++ b/web/frontend/src/app.vue
@@ -1,6 +1,5 @@
 <!-- eslint-disable require-atomic-updates -->
 <script setup lang="ts">
-import { Client } from '@viamrobotics/sdk';
 import RemoteControlCards from './components/remote-control-cards.vue';
 
 const {
@@ -11,22 +10,6 @@ const {
   webrtcSignalingAddress,
 } = window;
 
-const rtcConfig = {
-  iceServers: [
-    {
-      urls: 'stun:global.stun.twilio.com:3478',
-    },
-  ],
-};
-
-const impliedURL = `${location.protocol}//${location.hostname}${location.port ? `:${location.port}` : ''}`;
-const client = new Client(impliedURL, {
-  enabled: webrtcEnabled,
-  host,
-  signalingAddress: webrtcSignalingAddress,
-  rtcConfig,
-});
-
 </script>
 
 <template>
@@ -35,8 +18,7 @@ const client = new Client(impliedURL, {
     :baked-auth="bakedAuth"
     :supported-auth-types="supportedAuthTypes"
     :webrtc-enabled="webrtcEnabled"
-    :client="client"
-    manage-client-connection
+    :signaling-address="webrtcSignalingAddress"
   />
 </template>
 

--- a/web/frontend/src/components/base.vue
+++ b/web/frontend/src/components/base.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 
 import { onMounted, onUnmounted } from 'vue';
+import { $ref, $computed, $$ } from 'vue/macros';
 import { onClickOutside } from '@vueuse/core';
-import { BaseClient, Client, type ServiceError, commonApi } from '@viamrobotics/sdk';
+import { BaseClient, Client, type ServiceError, commonApi, ResponseStream, robotApi } from '@viamrobotics/sdk';
 import { filterResources } from '../lib/resource';
 import { displayError } from '../lib/error';
 import KeyboardInput, { type Keys } from './keyboard-input.vue';
@@ -23,6 +24,7 @@ const props = defineProps<{
   resources: commonApi.ResourceName.AsObject[];
   client: Client;
   streamManager:StreamManager
+  statusStream: ResponseStream<robotApi.StreamStatusResponse> | null
 }>();
 
 type Tabs = 'Keyboard' | 'Discrete'
@@ -473,6 +475,7 @@ onUnmounted(() => {
               :refresh-rate="refreshFrequency"
               :trigger-refresh="triggerRefresh"
               :stream-manager="props.streamManager"
+              :status-stream="props.statusStream"
             />
           </template>
         </div>

--- a/web/frontend/src/components/camera/camera.vue
+++ b/web/frontend/src/components/camera/camera.vue
@@ -5,11 +5,14 @@ import {
   CameraClient,
   Client,
   commonApi,
+  ResponseStream,
+  robotApi,
   ServiceError,
 } from '@viamrobotics/sdk';
 import { selectedMap } from '../../lib/camera-state';
 import type { CameraManager } from './camera-manager';
 import type { StreamManager } from './stream-manager';
+import { $ref, $computed } from 'vue/macros';
 
 const props = defineProps< {
   cameraName: string;
@@ -20,6 +23,7 @@ const props = defineProps< {
   refreshRate: string | undefined;
   triggerRefresh: boolean;
   streamManager:StreamManager;
+  statusStream: ResponseStream<robotApi.StreamStatusResponse> | null
 }>();
 
 const imgEl = $ref<HTMLImageElement>();
@@ -74,6 +78,7 @@ onMounted(() => {
     cameraManager.addStream();
   }
   updateCameraRefreshRate();
+  props.statusStream?.on('end', () => clearFrameInterval());
 });
 
 onUnmounted(() => {

--- a/web/frontend/src/components/camera/cameras-list.vue
+++ b/web/frontend/src/components/camera/cameras-list.vue
@@ -2,18 +2,22 @@
 import type {
   commonApi,
   Client,
+  ResponseStream,
+  robotApi,
 } from '@viamrobotics/sdk';
 
 import Camera from './camera.vue';
 import PCD from '../pcd/pcd.vue';
 import { selectedMap } from '../../lib/camera-state';
 import type { StreamManager } from './stream-manager';
+import { $ref } from 'vue/macros';
 
 const props = defineProps<{
   resources: commonApi.ResourceName.AsObject[],
   streamManager: StreamManager,
   client: Client,
   parentName: string
+  statusStream: ResponseStream<robotApi.StreamStatusResponse> | null
 }>();
 
 const openCameras = $ref<Record<string, boolean | undefined>>({});
@@ -83,6 +87,7 @@ const setupCamera = (cameraName: string) => {
         :refresh-rate="refreshFrequency[camera.name]"
         :trigger-refresh="triggerRefresh"
         :stream-manager="props.streamManager"
+        :status-stream="props.statusStream"
       />
 
       <PCD

--- a/web/frontend/src/components/camera/stream-manager.ts
+++ b/web/frontend/src/components/camera/stream-manager.ts
@@ -33,4 +33,14 @@ export class StreamManager {
       }
     }
   }
+
+  close () {
+    for (const camera of this.cameraManagers.values()) {
+      // Close all open streams
+      if (camera.streamCount > 0) {
+        camera.close();
+      }
+    }
+
+  }
 }

--- a/web/frontend/src/components/gamepad.vue
+++ b/web/frontend/src/components/gamepad.vue
@@ -5,13 +5,21 @@ import { grpc } from '@improbable-eng/grpc-web';
 import { onMounted, onUnmounted, watch } from 'vue';
 import { Timestamp } from 'google-protobuf/google/protobuf/timestamp_pb';
 import { ConnectionClosedError } from '@viamrobotics/rpc';
-import { Client, inputControllerApi as InputController, type ServiceError } from '@viamrobotics/sdk';
+import {
+  Client,
+  inputControllerApi as InputController,
+  ResponseStream,
+  robotApi,
+  type ServiceError,
+} from '@viamrobotics/sdk';
 import { toast } from '../lib/toast';
 import { rcLogConditionally } from '../lib/log';
+import { $ref } from 'vue/macros';
 
 const props = defineProps<{
   name: string;
   client: Client;
+  statusStream: ResponseStream<robotApi.StreamStatusResponse> | null
 }>();
 
 let gamepadIdx = $ref<number | null>(null);
@@ -252,6 +260,7 @@ onMounted(() => {
     return;
   }
   prevStates = { ...prevStates, ...curStates };
+  props.statusStream?.on('end', () => clearTimeout(handle));
   tick();
 });
 

--- a/web/frontend/src/components/navigation.vue
+++ b/web/frontend/src/components/navigation.vue
@@ -4,7 +4,7 @@ import { ref, onMounted, onUnmounted } from 'vue';
 import { grpc } from '@improbable-eng/grpc-web';
 import { toast } from '../lib/toast';
 import { filterResources } from '../lib/resource';
-import { Client, commonApi, robotApi, navigationApi, type ServiceError } from '@viamrobotics/sdk';
+import { Client, commonApi, robotApi, navigationApi, type ServiceError, ResponseStream } from '@viamrobotics/sdk';
 import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
 import { rcLogConditionally } from '../lib/log';
 
@@ -12,6 +12,7 @@ const props = defineProps<{
   resources: commonApi.ResourceName.AsObject[]
   name:string
   client: Client
+  statusStream: ResponseStream<robotApi.StreamStatusResponse> | null
 }>();
 
 let googleMapsInitResolve: () => void;
@@ -20,7 +21,8 @@ const mapReady = new Promise<void>((resolve) => {
 });
 
 let map: google.maps.Map;
-let updateTimerId: number;
+let updateWaypointsId: number;
+let updateLocationsId: number;
 
 const mapInit = ref(false);
 const googleApiKey = ref('');
@@ -145,7 +147,7 @@ const initNavigation = async () => {
         grpcCallback(err, resp, false);
 
         if (err) {
-          updateTimerId = window.setTimeout(updateWaypoints, 1000);
+          updateWaypointsId = window.setTimeout(updateWaypoints, 1000);
           return;
         }
 
@@ -182,7 +184,7 @@ const initNavigation = async () => {
           knownWaypoints[posStr] = marker;
 
           marker.addListener('click', () => {
-            console.log('clicked on marker', pos);
+            console.debug('clicked on marker', pos);
           });
 
           marker.addListener('dblclick', () => {
@@ -209,7 +211,7 @@ const initNavigation = async () => {
           delete knownWaypoints[key];
         }
 
-        updateTimerId = window.setTimeout(updateWaypoints, 1000);
+        updateWaypointsId = window.setTimeout(updateWaypoints, 1000);
       }
     );
   };
@@ -230,7 +232,7 @@ const initNavigation = async () => {
         grpcCallback(err, resp, false);
 
         if (err) {
-          setTimeout(updateLocation, 1000);
+          updateLocationsId = window.setTimeout(updateLocation, 1000);
           return;
         }
 
@@ -247,10 +249,11 @@ const initNavigation = async () => {
         locationMarker.setPosition(pos);
         locationMarker.setMap(map);
 
-        setTimeout(updateLocation, 1000);
+        updateLocationsId = window.setTimeout(updateLocation, 1000);
       }
     );
   };
+
   updateLocation();
 };
 
@@ -269,7 +272,7 @@ const loadMaps = () => {
 };
 
 window.googleMapsInit = () => {
-  console.log('google maps is ready');
+  console.debug('google maps is ready');
   googleMapsInitResolve();
 };
 
@@ -286,10 +289,16 @@ onMounted(() => {
     googleApiKey.value = apiKey;
     initNavigationView();
   }
+
+  props.statusStream?.on('end', () => {
+    clearTimeout(updateWaypointsId);
+    clearTimeout(updateLocationsId);
+  });
 });
 
 onUnmounted(() => {
-  clearTimeout(updateTimerId);
+  clearTimeout(updateWaypointsId);
+  clearTimeout(updateLocationsId);
 });
 
 </script>

--- a/web/frontend/src/components/slam-2d-render.vue
+++ b/web/frontend/src/components/slam-2d-render.vue
@@ -66,7 +66,7 @@ const raycaster = new MouseRaycaster({ camera, renderer, recursive: false });
 raycaster.on('click', (event) => {
   const [intersection] = event.intersections as THREE.Intersection[];
   if (intersection && intersection.point) {
-    console.log(intersection.point);
+    console.debug(intersection.point);
   }
 });
 

--- a/web/frontend/src/components/slam.vue
+++ b/web/frontend/src/components/slam.vue
@@ -3,11 +3,12 @@
 
 import { $ref, $computed } from 'vue/macros';
 import { grpc } from '@improbable-eng/grpc-web';
-import { Client, commonApi, ResponseStream, ServiceError, slamApi } from '@viamrobotics/sdk';
+import { Client, commonApi, ResponseStream, robotApi, ServiceError, slamApi } from '@viamrobotics/sdk';
 import { displayError, isServiceError } from '../lib/error';
 import { rcLogConditionally } from '../lib/log';
 import PCD from './pcd/pcd-view.vue';
 import Slam2dRender from './slam-2d-render.vue';
+import { onMounted, onUnmounted } from 'vue';
 
 type MapAndPose = { map: Uint8Array, pose: commonApi.Pose}
 
@@ -15,6 +16,7 @@ const props = defineProps<{
   name: string
   resources: commonApi.ResourceName.AsObject[]
   client: Client
+  statusStream: ResponseStream<robotApi.StreamStatusResponse> | null
 }>();
 
 const selected2dValue = $ref('manual');
@@ -221,6 +223,18 @@ const refresh2dMap = () => {
 const refresh3dMap = () => {
   updateSLAM3dRefreshFrequency(props.name, selected3dValue);
 };
+
+onMounted(() => {
+  props.statusStream?.on('end', () => {
+    window.clearTimeout(slam2dTimeoutId);
+    window.clearTimeout(slam3dTimeoutId);
+  });
+});
+
+onUnmounted(() => {
+  window.clearTimeout(slam2dTimeoutId);
+  window.clearTimeout(slam3dTimeoutId);
+});
 
 </script>
 

--- a/web/frontend/src/main-lib.ts
+++ b/web/frontend/src/main-lib.ts
@@ -1,38 +1,6 @@
 import './index.css';
 import { createApp } from 'vue';
-import RemoteControlCards from './components/remote-control-cards.vue';
-import type { Credentials } from '@viamrobotics/rpc';
-import { Client } from '@viamrobotics/sdk';
+import RemoteControlCards, { RemoteControlCardsProps } from './components/remote-control-cards.vue';
 
-export const createRcApp = (props: {
-  host: string;
-  bakedAuth?: {
-    authEntity: string;
-    creds: Credentials;
-  },
-  supportedAuthTypes: string[],
-  webrtcEnabled: boolean,
-  client?: Client;
-}) => {
-  const manageClientConnection = props.client === undefined;
-  if (manageClientConnection) {
-    const rtcConfig = {
-      iceServers: [
-        {
-          urls: 'stun:global.stun.twilio.com:3478',
-        },
-      ],
-    };
-
-    const impliedURL = `${location.protocol}//${location.hostname}${location.port ? `:${location.port}` : ''}`;
-
-    props.client = new Client(impliedURL, {
-      enabled: true,
-      host: props.host,
-      signalingAddress: window.webrtcSignalingAddress,
-      rtcConfig,
-    });
-  }
-
-  return createApp(RemoteControlCards, { ...props, manageClientConnection });
-};
+export const createRcApp = (props: RemoteControlCardsProps) =>
+  createApp(RemoteControlCards, { ...props });


### PR DESCRIPTION
Instead of allowing the RC to accept a client, instead we are going to simplify it have the RC create and manage its own client entirely. This should avoid version mismatching with app and no longer require a peer dependency. 

This also includes a bunch of fixes to stop `setTimeout` loops that are being opened and not closed.