### PR TITLE
RSDK-2279 Remove Extra Parentheses in SLAM 3D View

### DIFF
--- a/web/frontend/src/components/slam.vue
+++ b/web/frontend/src/components/slam.vue
@@ -320,7 +320,7 @@ const refresh3dMap = () => {
               :value="show3d ? 'on' : 'off'"
               @input="toggle3dExpand()"
             />
-            <span class="pr-2">View SLAM Map (3D))</span>
+            <span class="pr-2">View SLAM Map (3D)</span>
           </div>
           <div class="float-right pb-4">
             <div class="flex">


### PR DESCRIPTION
This PR removes the extra parentheses from the SLAM UI's 3D View header.

<img width="466" alt="image" src="https://user-images.githubusercontent.com/34897732/234621841-436b01ac-d0f1-4f1c-b1b0-7eb232c7151d.png">

JIRA Ticket: https://viam.atlassian.net/browse/RSDK-2779