### PR TITLE
RSDK-1229 RSDK-2693 Remove robot from motion service constructor, and prepare for removal from framesystem service constructor

### DIFF
--- a/components/arm/xarm/xarm.go
+++ b/components/arm/xarm/xarm.go
@@ -148,6 +148,9 @@ func (x *xArm) Reconfigure(ctx context.Context, deps resource.Dependencies, conf
 	if speed == 0 {
 		speed = defaultSpeed
 	}
+	if speed < 0 {
+		return fmt.Errorf("given speed %f cannot be negative", speed)
+	}
 
 	x.mu.Lock()
 	defer x.mu.Unlock()

--- a/components/arm/xarm/xarm.go
+++ b/components/arm/xarm/xarm.go
@@ -41,9 +41,10 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 }
 
 const (
-	defaultSpeed        = 20
-	defaultAcceleration = 50
+	defaultSpeed        = 20. // degrees per second
+	defaultAcceleration = 50. // degrees per second per second.
 	defaultPort         = "502"
+	defaultMoveHz       = 100. // Don't change this
 )
 
 type xArm struct {
@@ -119,7 +120,7 @@ func NewxArm(ctx context.Context, conf resource.Config, logger golog.Logger, mod
 		Named:   conf.ResourceName().AsNamed(),
 		dof:     len(model.DoF()),
 		tid:     0,
-		moveHZ:  100.,
+		moveHZ:  defaultMoveHz,
 		model:   model,
 		started: false,
 		logger:  logger,
@@ -153,13 +154,16 @@ func (x *xArm) Reconfigure(ctx context.Context, deps resource.Dependencies, conf
 
 	newAddr := net.JoinHostPort(newConf.Host, newConf.parsedPort)
 	if x.conn == nil || x.conn.RemoteAddr().String() != newAddr {
+		// Need a new or replacement connection
 		var d net.Dialer
 		newConn, err := d.DialContext(ctx, "tcp", newAddr)
 		if err != nil {
 			return err
 		}
-		if err := x.conn.Close(); err != nil {
-			x.logger.Warnw("error closing old connection but will continue with reconfiguration", "error", err)
+		if x.conn != nil {
+			if err := x.conn.Close(); err != nil {
+				x.logger.Warnw("error closing old connection but will continue with reconfiguration", "error", err)
+			}
 		}
 		x.conn = newConn
 
@@ -168,9 +172,7 @@ func (x *xArm) Reconfigure(ctx context.Context, deps resource.Dependencies, conf
 		}
 	}
 
-	if newConf.Speed > 0 {
-		x.speed = float32(utils.DegToRad(float64(speed)))
-	}
+	x.speed = float32(utils.DegToRad(float64(speed)))
 	return nil
 }
 

--- a/components/arm/xarm/xarm_comm.go
+++ b/components/arm/xarm/xarm_comm.go
@@ -369,7 +369,7 @@ func (x *xArm) MoveToJointPositions(ctx context.Context, newPositions *pb.JointP
 	diff := getMaxDiff(from, to)
 	x.mu.RLock()
 	nSteps := int((diff / float64(x.speed)) * x.moveHZ)
-	x.mu.Unlock()
+	x.mu.RUnlock()
 
 	// convenience for structuring and sending individual joint steps
 	sendMoveJointsCmd := func(ctx context.Context, step []float64) error {

--- a/components/camera/videosource/join_pointcloud.go
+++ b/components/camera/videosource/join_pointcloud.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"image"
 	"math"
-	"strings"
 
 	"github.com/edaniels/golog"
 	"github.com/golang/geo/r3"
@@ -107,7 +106,7 @@ type joinPointCloudSource struct {
 	sourceCameras []camera.Camera
 	sourceNames   []string
 	targetName    string
-	robot         robot.Robot
+	fsService     framesystem.Service
 	mergeMethod   MergeMethodType
 	logger        golog.Logger
 	debug         bool
@@ -139,7 +138,11 @@ func newJoinPointCloudSource(
 	}
 	// frame to merge to
 	joinSource.targetName = conf.TargetFrame
-	joinSource.robot = r
+	fsService, err := framesystem.FromRobot(r)
+	if err != nil {
+		return nil, err
+	}
+	joinSource.fsService = fsService
 	joinSource.closeness = conf.Closeness
 
 	joinSource.logger = l
@@ -185,12 +188,12 @@ func (jpcs *joinPointCloudSource) NextPointCloudNaive(ctx context.Context) (poin
 	ctx, span := trace.StartSpan(ctx, "joinPointCloudSource::NextPointCloudNaive")
 	defer span.End()
 
-	fs, err := framesystem.RobotFrameSystem(ctx, jpcs.robot, nil)
+	fs, err := jpcs.fsService.FrameSystem(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	inputs, err := jpcs.initializeInputs(ctx, fs)
+	inputs, _, err := jpcs.fsService.AllCurrentInputs(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -229,12 +232,12 @@ func (jpcs *joinPointCloudSource) NextPointCloudICP(ctx context.Context) (pointc
 	ctx, span := trace.StartSpan(ctx, "joinPointCloudSource::NextPointCloudICP")
 	defer span.End()
 
-	fs, err := framesystem.RobotFrameSystem(ctx, jpcs.robot, nil)
+	fs, err := jpcs.fsService.FrameSystem(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	inputs, err := jpcs.initializeInputs(ctx, fs)
+	inputs, _, err := jpcs.fsService.AllCurrentInputs(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -302,40 +305,6 @@ func (jpcs *joinPointCloudSource) NextPointCloudICP(ctx context.Context) (pointc
 	}
 
 	return finalPointCloud, nil
-}
-
-// initalizeInputs gets all the input positions for the robot components in order to calculate the frame system offsets.
-func (jpcs *joinPointCloudSource) initializeInputs(
-	ctx context.Context,
-	fs referenceframe.FrameSystem,
-) (map[string][]referenceframe.Input, error) {
-	inputs := referenceframe.StartPositions(fs)
-
-	for k, original := range inputs {
-		if strings.HasSuffix(k, "_origin") {
-			continue
-		}
-		if len(original) == 0 {
-			continue
-		}
-
-		all := robot.AllResourcesByName(jpcs.robot, k)
-		if len(all) != 1 {
-			return nil, fmt.Errorf("got %d resources instead of 1 for (%s)", len(all), k)
-		}
-
-		ii, ok := all[0].(referenceframe.InputEnabled)
-		if !ok {
-			return nil, fmt.Errorf("%v(%T) is not InputEnabled", k, all[0])
-		}
-
-		pos, err := ii.CurrentInputs(ctx)
-		if err != nil {
-			return nil, err
-		}
-		inputs[k] = pos
-	}
-	return inputs, nil
 }
 
 // Read gets the merged point cloud from all sources, and then uses a projection to turn it into a 2D image.

--- a/components/camera/videosource/join_pointcloud_test.go
+++ b/components/camera/videosource/join_pointcloud_test.go
@@ -21,6 +21,7 @@ import (
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/rimage/transform"
 	"go.viam.com/rdk/robot"
+	"go.viam.com/rdk/robot/framesystem"
 	framesystemparts "go.viam.com/rdk/robot/framesystem/parts"
 	"go.viam.com/rdk/spatialmath"
 	"go.viam.com/rdk/testutils/inject"
@@ -316,6 +317,9 @@ func makeFakeRobotICP(t *testing.T) (robot.Robot, error) {
 	base1 := &inject.Base{}
 
 	r := &inject.Robot{}
+
+	fsSvc := framesystem.New(context.Background(), r, logger)
+
 	o1 := &spatialmath.EulerAngles{Roll: 0, Pitch: 0.6, Yaw: 0}
 	o2 := &spatialmath.EulerAngles{Roll: 0, Pitch: 0.6, Yaw: -0.3}
 
@@ -379,6 +383,8 @@ func makeFakeRobotICP(t *testing.T) (robot.Robot, error) {
 			return cam5, nil
 		case "base1":
 			return base1, nil
+		case framesystem.InternalServiceName.Name:
+			return fsSvc, nil
 		default:
 			return nil, resource.NewNotFoundError(n)
 		}

--- a/motionplan/motionPlanner.go
+++ b/motionplan/motionPlanner.go
@@ -72,7 +72,13 @@ func PlanRobotMotion(ctx context.Context,
 	constraintSpec *pb.Constraints,
 	planningOpts map[string]interface{},
 ) ([]map[string][]frame.Input, error) {
-	seedMap, _, err := framesystem.RobotFsCurrentInputs(ctx, r, fs)
+	// Get the framesystem service if it exists
+	fsSvc, err := framesystem.FromRobot(r)
+	if err != nil {
+		return nil, err
+	}
+
+	seedMap, _, err := fsSvc.AllCurrentInputs(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/motionplan/motionPlanner.go
+++ b/motionplan/motionPlanner.go
@@ -67,13 +67,17 @@ func PlanRobotMotion(ctx context.Context,
 	dst *frame.PoseInFrame,
 	f frame.Frame,
 	r robot.Robot,
-	fs frame.FrameSystem,
 	worldState *frame.WorldState,
 	constraintSpec *pb.Constraints,
 	planningOpts map[string]interface{},
 ) ([]map[string][]frame.Input, error) {
 	// Get the framesystem service if it exists
 	fsSvc, err := framesystem.FromRobot(r)
+	if err != nil {
+		return nil, err
+	}
+
+	fs, err := fsSvc.FrameSystem(ctx, worldState.Transforms)
 	if err != nil {
 		return nil, err
 	}

--- a/robot/framesystem/errors.go
+++ b/robot/framesystem/errors.go
@@ -1,0 +1,7 @@
+package framesystem
+
+import "fmt"
+
+func wrongNumberOfResourcesError(count int, name string) error {
+	return fmt.Errorf("got %d resources instead of 1 for (%s)", count, name)
+}

--- a/robot/framesystem/framesystem.go
+++ b/robot/framesystem/framesystem.go
@@ -214,7 +214,6 @@ func (svc *frameSystemService) AllCurrentInputs(
 	input := referenceframe.StartPositions(fs)
 
 	// build maps of relevant components and inputs from initial inputs
-	allOriginals := map[string][]referenceframe.Input{}
 	resources := map[string]referenceframe.InputEnabled{}
 	for name, original := range input {
 		// skip frames with no input
@@ -223,7 +222,6 @@ func (svc *frameSystemService) AllCurrentInputs(
 		}
 
 		// add component to map
-		allOriginals[name] = original
 		components := robot.AllResourcesByName(svc.r, name)
 		if len(components) != 1 {
 			return nil, nil, fmt.Errorf("got %d resources instead of 1 for (%s)", len(components), name)

--- a/robot/framesystem/framesystem.go
+++ b/robot/framesystem/framesystem.go
@@ -179,7 +179,7 @@ func (svc *frameSystemService) TransformPose(
 		// add component to map
 		components := robot.AllResourcesByName(svc.r, name)
 		if len(components) != 1 {
-			return nil, fmt.Errorf("got %d resources instead of 1 for (%s)", len(components), name)
+			return nil, wrongNumberOfResourcesError(len(components), name)
 		}
 		component, ok := components[0].(referenceframe.InputEnabled)
 		if !ok {
@@ -224,7 +224,7 @@ func (svc *frameSystemService) AllCurrentInputs(
 		// add component to map
 		components := robot.AllResourcesByName(svc.r, name)
 		if len(components) != 1 {
-			return nil, nil, fmt.Errorf("got %d resources instead of 1 for (%s)", len(components), name)
+			return nil, nil, wrongNumberOfResourcesError(len(components), name)
 		}
 		component, ok := components[0].(referenceframe.InputEnabled)
 		if !ok {
@@ -322,7 +322,10 @@ func (svc *frameSystemService) updateLocalParts(ctx context.Context) error {
 		seen[c.Name] = true
 		model, err := extractModelFrameJSON(svc.r, c.ResourceName())
 		if err != nil && !errors.Is(err, referenceframe.ErrNoModelInformation) {
-			return err
+			// When we have non-nil erros here, it is because the resource is not yet available.
+			// In this case, we will exclude it from the FS.
+			// When it becomes available, it will be included.
+			continue
 		}
 		lif, err := cfgCopy.ParseConfig()
 		if err != nil {

--- a/robot/framesystem/framesystem.go
+++ b/robot/framesystem/framesystem.go
@@ -39,47 +39,8 @@ type Service interface {
 		additionalTransforms []*referenceframe.LinkInFrame,
 	) (*referenceframe.PoseInFrame, error)
 	TransformPointCloud(ctx context.Context, srcpc pointcloud.PointCloud, srcName, dstName string) (pointcloud.PointCloud, error)
-}
-
-// RobotFsCurrentInputs will get present inputs for a framesystem from a robot and return a map of those inputs, as well as a map of the
-// InputEnabled resources that those inputs came from.
-func RobotFsCurrentInputs(
-	ctx context.Context,
-	r robot.Robot,
-	fs referenceframe.FrameSystem,
-) (map[string][]referenceframe.Input, map[string]referenceframe.InputEnabled, error) {
-	input := referenceframe.StartPositions(fs)
-
-	// build maps of relevant components and inputs from initial inputs
-	allOriginals := map[string][]referenceframe.Input{}
-	resources := map[string]referenceframe.InputEnabled{}
-	for name, original := range input {
-		// skip frames with no input
-		if len(original) == 0 {
-			continue
-		}
-
-		// add component to map
-		allOriginals[name] = original
-		components := robot.AllResourcesByName(r, name)
-		if len(components) != 1 {
-			return nil, nil, fmt.Errorf("got %d resources instead of 1 for (%s)", len(components), name)
-		}
-		component, ok := components[0].(referenceframe.InputEnabled)
-		if !ok {
-			return nil, nil, fmt.Errorf("%v(%T) is not InputEnabled", name, components[0])
-		}
-		resources[name] = component
-
-		// add input to map
-		pos, err := component.CurrentInputs(ctx)
-		if err != nil {
-			return nil, nil, err
-		}
-		input[name] = pos
-	}
-
-	return input, resources, nil
+	AllCurrentInputs(ctx context.Context) (map[string][]referenceframe.Input, map[string]referenceframe.InputEnabled, error)
+	FrameSystem(ctx context.Context, additionalTransforms []*referenceframe.LinkInFrame) (referenceframe.FrameSystem, error)
 }
 
 // New returns a new frame system service for the given robot.
@@ -89,6 +50,11 @@ func New(ctx context.Context, r robot.Robot, logger golog.Logger) Service {
 		r:      r,
 		logger: logger,
 	}
+}
+
+// FromRobot is a helper for getting the framesystem service from the given Robot.
+func FromRobot(r robot.Robot) (Service, error) {
+	return robot.ResourceFromRobot[Service](r, InternalServiceName)
 }
 
 var internalFrameSystemServiceName = resource.NewName(
@@ -234,6 +200,68 @@ func (svc *frameSystemService) TransformPose(
 	}
 	pose, _ = tf.(*referenceframe.PoseInFrame)
 	return pose, nil
+}
+
+// AllCurrentInputs will get present inputs for a framesystem from a robot and return a map of those inputs, as well as a map of the
+// InputEnabled resources that those inputs came from.
+func (svc *frameSystemService) AllCurrentInputs(
+	ctx context.Context,
+) (map[string][]referenceframe.Input, map[string]referenceframe.InputEnabled, error) {
+	fs, err := svc.FrameSystem(ctx, []*referenceframe.LinkInFrame{})
+	if err != nil {
+		return nil, nil, err
+	}
+	input := referenceframe.StartPositions(fs)
+
+	// build maps of relevant components and inputs from initial inputs
+	allOriginals := map[string][]referenceframe.Input{}
+	resources := map[string]referenceframe.InputEnabled{}
+	for name, original := range input {
+		// skip frames with no input
+		if len(original) == 0 {
+			continue
+		}
+
+		// add component to map
+		allOriginals[name] = original
+		components := robot.AllResourcesByName(svc.r, name)
+		if len(components) != 1 {
+			return nil, nil, fmt.Errorf("got %d resources instead of 1 for (%s)", len(components), name)
+		}
+		component, ok := components[0].(referenceframe.InputEnabled)
+		if !ok {
+			return nil, nil, fmt.Errorf("%v(%T) is not InputEnabled", name, components[0])
+		}
+		resources[name] = component
+
+		// add input to map
+		pos, err := component.CurrentInputs(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+		input[name] = pos
+	}
+
+	return input, resources, nil
+}
+
+// FrameSystem returns the frame system of the robot.
+func (svc *frameSystemService) FrameSystem(
+	ctx context.Context,
+	additionalTransforms []*referenceframe.LinkInFrame,
+) (referenceframe.FrameSystem, error) {
+	ctx, span := trace.StartSpan(ctx, "services::framesystem::FrameSystem")
+	defer span.End()
+	// create the frame system
+	allParts, err := svc.r.FrameSystemConfig(ctx, additionalTransforms)
+	if err != nil {
+		return nil, err
+	}
+	fs, err := NewFrameSystemFromParts(LocalFrameSystemName, "", allParts, svc.r.Logger())
+	if err != nil {
+		return nil, err
+	}
+	return fs, nil
 }
 
 // TransformPointCloud applies the same pose offset to each point in a single pointcloud and returns the transformed point cloud.

--- a/robot/framesystem/framesystem_utils.go
+++ b/robot/framesystem/framesystem_utils.go
@@ -16,26 +16,6 @@ import (
 	framesystemparts "go.viam.com/rdk/robot/framesystem/parts"
 )
 
-// RobotFrameSystem returns the frame system of the robot.
-func RobotFrameSystem(
-	ctx context.Context,
-	r robot.Robot,
-	additionalTransforms []*referenceframe.LinkInFrame,
-) (referenceframe.FrameSystem, error) {
-	ctx, span := trace.StartSpan(ctx, "services::framesystem::RobotFrameSystem")
-	defer span.End()
-	// create the frame system
-	allParts, err := r.FrameSystemConfig(ctx, additionalTransforms)
-	if err != nil {
-		return nil, err
-	}
-	fs, err := NewFrameSystemFromParts(LocalFrameSystemName, "", allParts, r.Logger())
-	if err != nil {
-		return nil, err
-	}
-	return fs, nil
-}
-
 // NewFrameSystemFromParts assembles a frame system from a collection of parts,
 // usually acquired by calling Config on a frame system service.
 func NewFrameSystemFromParts(

--- a/robot/framesystem/service_test.go
+++ b/robot/framesystem/service_test.go
@@ -40,6 +40,8 @@ func TestFrameSystemFromConfig(t *testing.T) {
 	r, err := robotimpl.New(context.Background(), cfg, logger)
 	test.That(t, err, test.ShouldBeNil)
 	defer r.Close(context.Background())
+	svc, err := framesystem.FromRobot(r)
+	test.That(t, err, test.ShouldBeNil)
 
 	// use fake registrations to have a FrameSystem return
 	testPose := spatialmath.NewPose(
@@ -55,7 +57,7 @@ func TestFrameSystemFromConfig(t *testing.T) {
 		referenceframe.NewLinkInFrame(referenceframe.World, testPose, "frame3", nil),
 	}
 
-	fs, err := framesystem.RobotFrameSystem(context.Background(), r, transforms)
+	fs, err := svc.FrameSystem(context.Background(), transforms)
 	test.That(t, err, test.ShouldBeNil)
 	// 4 frames defined + 5 from transforms, 18 frames when including the offset,
 	test.That(t, len(fs.FrameNames()), test.ShouldEqual, 18)
@@ -215,14 +217,19 @@ func TestWrongFrameSystems(t *testing.T) {
 		referenceframe.NewLinkInFrame("pieceArm", testPose, "frame1", nil),
 		referenceframe.NewLinkInFrame("noParent", testPose, "frame2", nil),
 	}
-	fs, err := framesystem.RobotFrameSystem(context.Background(), r, transforms)
+	svc, err := framesystem.FromRobot(r)
+	test.That(t, err, test.ShouldBeNil)
+	fs, err := svc.FrameSystem(context.Background(), transforms)
+
 	test.That(t, err, test.ShouldBeError, framesystemparts.NewMissingParentError("frame2", "noParent"))
 	test.That(t, fs, test.ShouldBeNil)
 
 	transforms = []*referenceframe.LinkInFrame{
 		referenceframe.NewLinkInFrame("pieceArm", testPose, "", nil),
 	}
-	fs, err = framesystem.RobotFrameSystem(context.Background(), r, transforms)
+	svc, err = framesystem.FromRobot(r)
+	test.That(t, err, test.ShouldBeNil)
+	fs, err = svc.FrameSystem(context.Background(), transforms)
 	test.That(t, err, test.ShouldBeError, referenceframe.ErrEmptyStringFrameName)
 	test.That(t, fs, test.ShouldBeNil)
 }
@@ -313,7 +320,10 @@ func TestServiceWithRemote(t *testing.T) {
 
 	r2, err := robotimpl.New(context.Background(), localConfig, logger)
 	test.That(t, err, test.ShouldBeNil)
-	fs, err := framesystem.RobotFrameSystem(context.Background(), r2, transforms)
+	svc, err := framesystem.FromRobot(r2)
+	test.That(t, err, test.ShouldBeNil)
+	fs, err := svc.FrameSystem(context.Background(), transforms)
+
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, fs.FrameNames(), test.ShouldHaveLength, 34)
 	// run the frame system service

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -52,6 +52,7 @@ import (
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/robot/client"
+	"go.viam.com/rdk/robot/framesystem"
 	framesystemparts "go.viam.com/rdk/robot/framesystem/parts"
 	robotimpl "go.viam.com/rdk/robot/impl"
 	"go.viam.com/rdk/robot/packages"
@@ -2174,14 +2175,16 @@ func TestCheckMaxInstanceValid(t *testing.T) {
 	cfg := &config.Config{
 		Services: []resource.Config{
 			{
-				Name:  "fake1",
-				Model: resource.DefaultServiceModel,
-				API:   motion.API,
+				Name:      "fake1",
+				Model:     resource.DefaultServiceModel,
+				API:       motion.API,
+				DependsOn: []string{framesystem.InternalServiceName.String()},
 			},
 			{
-				Name:  "fake2",
-				Model: resource.DefaultServiceModel,
-				API:   motion.API,
+				Name:      "fake2",
+				Model:     resource.DefaultServiceModel,
+				API:       motion.API,
+				DependsOn: []string{framesystem.InternalServiceName.String()},
 			},
 		},
 		Components: []resource.Config{

--- a/robot/impl/resource_manager_modular_test.go
+++ b/robot/impl/resource_manager_modular_test.go
@@ -15,6 +15,7 @@ import (
 	"go.viam.com/rdk/module/modmanager"
 	"go.viam.com/rdk/module/modmaninterface"
 	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/robot/framesystem"
 	"go.viam.com/rdk/services/motion"
 	"go.viam.com/rdk/utils"
 )
@@ -198,6 +199,7 @@ func TestModularResources(t *testing.T) {
 			API:                 motion.API,
 			Model:               resource.DefaultServiceModel,
 			ConvertedAttributes: &fake.Config{},
+			DependsOn:           []string{framesystem.InternalServiceName.String()},
 		}
 		_, err = cfg3.Validate("test", resource.APITypeServiceName)
 		test.That(t, err, test.ShouldBeNil)

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -12,7 +12,6 @@ import (
 
 	servicepb "go.viam.com/api/service/motion/v1"
 	"go.viam.com/rdk/components/arm"
-	//~ "go.viam.com/rdk/internal"
 	"go.viam.com/rdk/motionplan"
 	"go.viam.com/rdk/operation"
 	"go.viam.com/rdk/referenceframe"

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -69,7 +69,6 @@ func (ms *builtIn) Reconfigure(
 	ms.lock.Lock()
 	defer ms.lock.Unlock()
 
-
 	fsService, err := resource.FromDependencies[framesystem.Service](deps, framesystem.InternalServiceName)
 	if err != nil {
 		return err

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -26,7 +26,6 @@ func init() {
 	resource.RegisterDefaultService(
 		motion.API,
 		resource.DefaultServiceModel,
-		//~ resource.Registration[motion.Service, resource.NoNativeConfig]{
 		resource.Registration[motion.Service, *Config]{
 			Constructor: func(
 				ctx context.Context,
@@ -36,7 +35,6 @@ func init() {
 			) (motion.Service, error) {
 				return NewBuiltIn(ctx, deps, conf, logger)
 			},
-			//~ WeakDependencies: []internal.ResourceMatcher{internal.ComponentDependencyWildcardMatcher},
 		})
 }
 
@@ -78,14 +76,6 @@ func (ms *builtIn) Reconfigure(
 		return err
 	}
 	ms.fsService = fsService
-	//~ singleComponentMoves := map[resource.Name]arm.Arm{}
-	//~ for n, r := range deps {
-		//~ fmt.Println("n, r", n, r)
-		//~ if thisArm, ok := r.(arm.Arm); ok {
-			//~ singleComponentMoves[n] = thisArm
-		//~ }
-	//~ }
-	//~ ms.singleComponentMoves = singleComponentMoves
 	return nil
 
 	return nil

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -189,18 +189,15 @@ func (ms *builtIn) MoveSingleComponent(
 		return false, err
 	}
 	ms.logger.Debugf("frame system inputs: %v", fsInputs)
-	
-	singleComponentMoves := map[string]arm.Arm{}
-	for n, r := range allResources {
-		if thisArm, ok := r.(arm.Arm); ok {
-			singleComponentMoves[n] = thisArm
-		}
-	}
 
-	movableArm, ok := singleComponentMoves[componentName.ShortName()]
+	armResource, ok := allResources[componentName.ShortName()]
+	if !ok {
+		return false, fmt.Errorf("could not find a resource named %v", componentName.ShortName())
+	}
+	movableArm, ok := armResource.(arm.Arm)
 	if !ok {
 		return false, fmt.Errorf(
-			"could not find an arm named %v. MoveSingleComponent only supports moving arms for now",
+			"could not cast resource named %v to an arm. MoveSingleComponent only supports moving arms for now",
 			componentName.ShortName(),
 		)
 	}

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -12,7 +12,6 @@ import (
 	"go.viam.com/rdk/components/arm"
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/components/gripper"
-	"go.viam.com/rdk/resource"
 
 	// register.
 	commonpb "go.viam.com/api/common/v1"
@@ -22,7 +21,6 @@ import (
 	framesystemparts "go.viam.com/rdk/robot/framesystem/parts"
 	robotimpl "go.viam.com/rdk/robot/impl"
 	"go.viam.com/rdk/services/motion"
-	"go.viam.com/rdk/services/motion/builtin"
 	"go.viam.com/rdk/spatialmath"
 )
 
@@ -34,7 +32,7 @@ func setupMotionServiceFromConfig(t *testing.T, configFilename string) (motion.S
 	test.That(t, err, test.ShouldBeNil)
 	myRobot, err := robotimpl.New(ctx, cfg, logger)
 	test.That(t, err, test.ShouldBeNil)
-	svc, err := builtin.NewBuiltIn(ctx, myRobot, resource.Config{}, logger)
+	svc, err := motion.FromRobot(myRobot, "builtin")
 	test.That(t, err, test.ShouldBeNil)
 	return svc, func() {
 		myRobot.Close(context.Background())

--- a/services/motion/data/fake_tomato.json
+++ b/services/motion/data/fake_tomato.json
@@ -1,10 +1,4 @@
 {
-    "services": [
-        {
-            "name": "motion1",
-            "type": "motion"
-        }
-    ],
     "components": [
         {
             "name": "c",


### PR DESCRIPTION
Note that this also alters pointcloud as that uses the FS service and was affected by these changes; added @bhaney to look at that, feel free to swap to someone else if needed.

The design of this update removes any need for Motion to talk to the robot or individual resources in real-time, and moves all responsibility of keeping track of discrete resources to the frame system service.