### PR TITLE
[DATA-1351]: Update CLI tool BE

### DIFF
--- a/cli/viam/main.go
+++ b/cli/viam/main.go
@@ -36,6 +36,7 @@ const (
 	dataFlagEnd               = "end"
 	dataFlagParallelDownloads = "parallel"
 	dataFlagTags              = "tags"
+	dataFlagBboxLabels        = "bbox_labels"
 
 	dataTypeBinary  = "binary"
 	dataTypeTabular = "tabular"
@@ -325,6 +326,12 @@ func main() {
 								Required: false,
 								Usage: "tags filter. " +
 									"accepts tagged for all tagged data, untagged for all untagged data, or a list of tags for all data matching any of the tags",
+							},
+							&cli.StringSliceFlag{
+								Name:     dataFlagBboxLabels,
+								Required: false,
+								Usage: "bbox labels filter. " +
+									"accepts string labels corresponding to bounding boxes within images",
 							},
 						},
 						Action: DataCommand,
@@ -923,7 +930,9 @@ func createDataFilter(c *cli.Context) (*datapb.Filter, error) {
 			}
 		}
 	}
-
+	if len(c.StringSlice(dataFlagBboxLabels)) != 0 {
+		filter.BboxLabels = c.StringSlice(dataFlagBboxLabels)
+	}
 	var start *timestamppb.Timestamp
 	var end *timestamppb.Timestamp
 	timeLayout := time.RFC3339


### PR DESCRIPTION
**Context**
CLI string in the FE was updated to include --bboxLabel, but not the BE, so the export command will fail if you copy and paste in with --bboxLabel. This updates the cli tool to include the flag `bbox_labels` since this is following the convention for all other cli flags. FE will need to be updated accordingly. 

**Testing**
Testing locally by building `go build -o ~/go/bin/viam cli/viam/main.go` and then exporting:
`viam --base-url=https://app.viam.dev:443 data export --bbox_labels=blue_square,blue_star,brown_circle,green_square,orange_triangle,pink_star,pink_triangle,yellow_circle --org_ids=0fbe951e-d4c6-427f-985f-784b7b85842c --data_type=binary --mime_types=image/jpeg,image/png --destination=exported_data`