### PR TITLE
RSDK-2886 Reduce config ticker and simplify completeConfig goroutine

### DIFF
--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -480,14 +480,12 @@ func (manager *resourceManager) completeConfig(
 			}
 			manager.addRemote(ctx, rr, gNode, *remConf)
 			rr.SetParentNotifier(func() {
-				rName := remConf.Name
-				if robot.closeContext.Err() != nil {
-					return
-				}
+				// Trigger completeConfig goroutine execution when a change in remote
+				// is detected.
 				select {
 				case <-robot.closeContext.Done():
 					return
-				case robot.remotesChanged <- rName:
+				case robot.triggerConfig <- struct{}{}:
 				}
 			})
 		default:

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -317,7 +317,7 @@ func TestRobotReconfigure(t *testing.T) {
 		rr, ok := robot.(*localRobot)
 		test.That(t, ok, test.ShouldBeTrue)
 
-		rr.triggerConfig <- true
+		rr.triggerConfig <- struct{}{}
 
 		utils.SelectContextOrWait(context.Background(), 200*time.Millisecond)
 
@@ -1978,7 +1978,7 @@ func TestRobotReconfigure(t *testing.T) {
 		rr, ok := robot.(*localRobot)
 		test.That(t, ok, test.ShouldBeTrue)
 
-		rr.triggerConfig <- true
+		rr.triggerConfig <- struct{}{}
 
 		utils.SelectContextOrWait(context.Background(), 200*time.Millisecond)
 		mock6, err = robot.ResourceByName(mockNamed("mock6"))
@@ -2672,7 +2672,7 @@ func TestRemoteRobotsGold(t *testing.T) {
 	rr, ok := r.(*localRobot)
 	test.That(t, ok, test.ShouldBeTrue)
 
-	rr.triggerConfig <- true
+	rr.triggerConfig <- struct{}{}
 
 	utils.SelectContextOrWait(ctx, 2*time.Second)
 
@@ -2750,7 +2750,7 @@ func TestRemoteRobotsGold(t *testing.T) {
 	rr, ok = r.(*localRobot)
 	test.That(t, ok, test.ShouldBeTrue)
 
-	rr.triggerConfig <- true
+	rr.triggerConfig <- struct{}{}
 
 	utils.SelectContextOrWait(ctx, 2*time.Second)
 
@@ -2825,7 +2825,7 @@ func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
 	rr, ok := r.(*localRobot)
 	test.That(t, ok, test.ShouldBeTrue)
 
-	rr.triggerConfig <- true
+	rr.triggerConfig <- struct{}{}
 	utils.SelectContextOrWait(ctx, 2*time.Second)
 
 	expectedSet := rdktestutils.NewResourceNameSet(
@@ -2844,7 +2844,7 @@ func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
 	test.That(t, foo.Close(context.Background()), test.ShouldBeNil)
 	// wait for local_robot to detect that the remote is now offline
 	utils.SelectContextOrWait(ctx, 15*time.Second)
-	rr.triggerConfig <- true
+	rr.triggerConfig <- struct{}{}
 	utils.SelectContextOrWait(ctx, 2*time.Second)
 
 	test.That(
@@ -2878,7 +2878,7 @@ func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
 	rr, ok = r.(*localRobot)
 	test.That(t, ok, test.ShouldBeTrue)
 
-	rr.triggerConfig <- true
+	rr.triggerConfig <- struct{}{}
 
 	utils.SelectContextOrWait(ctx, 2*time.Second)
 
@@ -2949,7 +2949,7 @@ func TestInferRemoteRobotDependencyConnectAfterStartup(t *testing.T) {
 	test.That(t, ok, test.ShouldBeTrue)
 
 	utils.SelectContextOrWait(ctx, 15*time.Second)
-	rr.triggerConfig <- true
+	rr.triggerConfig <- struct{}{}
 	utils.SelectContextOrWait(ctx, 2*time.Second)
 
 	expectedSet := rdktestutils.NewResourceNameSet(
@@ -2968,7 +2968,7 @@ func TestInferRemoteRobotDependencyConnectAfterStartup(t *testing.T) {
 	test.That(t, foo.Close(context.Background()), test.ShouldBeNil)
 	// wait for local_robot to detect that the remote is now offline
 	utils.SelectContextOrWait(ctx, 15*time.Second)
-	rr.triggerConfig <- true
+	rr.triggerConfig <- struct{}{}
 	utils.SelectContextOrWait(ctx, 2*time.Second)
 
 	test.That(
@@ -3069,7 +3069,7 @@ func TestInferRemoteRobotDependencyAmbiguous(t *testing.T) {
 	rr, ok := r.(*localRobot)
 	test.That(t, ok, test.ShouldBeTrue)
 
-	rr.triggerConfig <- true
+	rr.triggerConfig <- struct{}{}
 	utils.SelectContextOrWait(ctx, 2*time.Second)
 
 	// we expect the robot to correctly detect the ambiguous dependency and not build the resource
@@ -3101,7 +3101,7 @@ func TestInferRemoteRobotDependencyAmbiguous(t *testing.T) {
 	}
 	r.Reconfigure(ctx, reConfig)
 	utils.SelectContextOrWait(ctx, 15*time.Second)
-	rr.triggerConfig <- true
+	rr.triggerConfig <- struct{}{}
 	utils.SelectContextOrWait(ctx, 2*time.Second)
 
 	finalSet := rdktestutils.NewResourceNameSet(

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -2745,7 +2745,7 @@ func TestRemoteRobotsGold(t *testing.T) {
 	err = remote3.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
-	utils.SelectContextOrWait(ctx, 26*time.Second)
+	utils.SelectContextOrWait(ctx, 5*time.Second)
 
 	rr, ok = r.(*localRobot)
 	test.That(t, ok, test.ShouldBeTrue)
@@ -2873,7 +2873,7 @@ func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
 	err = foo2.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
-	utils.SelectContextOrWait(ctx, 26*time.Second)
+	utils.SelectContextOrWait(ctx, 5*time.Second)
 
 	rr, ok = r.(*localRobot)
 	test.That(t, ok, test.ShouldBeTrue)
@@ -2948,7 +2948,7 @@ func TestInferRemoteRobotDependencyConnectAfterStartup(t *testing.T) {
 	rr, ok := r.(*localRobot)
 	test.That(t, ok, test.ShouldBeTrue)
 
-	utils.SelectContextOrWait(ctx, 15*time.Second)
+	utils.SelectContextOrWait(ctx, 5*time.Second)
 	rr.triggerConfig <- struct{}{}
 	utils.SelectContextOrWait(ctx, 2*time.Second)
 
@@ -2967,7 +2967,7 @@ func TestInferRemoteRobotDependencyConnectAfterStartup(t *testing.T) {
 
 	test.That(t, foo.Close(context.Background()), test.ShouldBeNil)
 	// wait for local_robot to detect that the remote is now offline
-	utils.SelectContextOrWait(ctx, 15*time.Second)
+	utils.SelectContextOrWait(ctx, 5*time.Second)
 	rr.triggerConfig <- struct{}{}
 	utils.SelectContextOrWait(ctx, 2*time.Second)
 
@@ -3100,7 +3100,7 @@ func TestInferRemoteRobotDependencyAmbiguous(t *testing.T) {
 		},
 	}
 	r.Reconfigure(ctx, reConfig)
-	utils.SelectContextOrWait(ctx, 15*time.Second)
+	utils.SelectContextOrWait(ctx, 5*time.Second)
 	rr.triggerConfig <- struct{}{}
 	utils.SelectContextOrWait(ctx, 2*time.Second)
 


### PR DESCRIPTION
RSDK-2886

[idea] We should be able to reduce the config timer (renamed `configTicker`) to tick every 5 seconds. This should decrease test running time and increase the frequency with which we're able to detect changes in cloud configs/remotes. I think we can also use a single `triggerConfig` channel (`bool` seemed overly expressive given we only ever send `true`).