### PR TITLE
RSDK-1053-reenable-staticcheck-linter

### DIFF
--- a/etc/.golangci.yaml
+++ b/etc/.golangci.yaml
@@ -97,11 +97,6 @@ issues:
     - path: /doc.go$
       linters:
         - lll
-    # TODO(RSDK-1053): reenable the staticcheck linter for this directory
-    # once deprecated API is no longer used.
-    - path: services/slam/
-      linters:
-        - staticcheck
   exclude-use-default: false
   max-per-linter: 0
   max-same-issues: 0


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-1053)

This reenables the staticcheck linter now that slam deprecated APIs no longer exist
