### PR TITLE
RSDK-2482 FIX: encoder RC card

### DIFF
--- a/web/frontend/src/components/encoder.vue
+++ b/web/frontend/src/components/encoder.vue
@@ -11,8 +11,8 @@ const props = defineProps<{
 }>();
 
 let properties = $ref<encoderApi.GetPropertiesResponse.AsObject | undefined>();
-let positionTicks = 0;
-let positionDegrees = 0;
+let positionTicks = $ref(0);
+let positionDegrees = $ref(0);
 
 let refreshId = -1;
 


### PR DESCRIPTION
The displayed values weren't `$ref()` so they weren't updating. The RC card was always displaying 0 even when the encoder count was changing.