### PR TITLE
Refactor genericlinux reconfiguration, in preparation for RSDK-2683

### DIFF
--- a/components/board/digital_interrupts.go
+++ b/components/board/digital_interrupts.go
@@ -73,11 +73,9 @@ func CreateDigitalInterrupt(cfg DigitalInterruptConfig) (DigitalInterrupt, error
 	var i ReconfigurableDigitalInterrupt
 	switch cfg.Type {
 	case "basic":
-		iActual := &BasicDigitalInterrupt{}
-		i = iActual
+		i = &BasicDigitalInterrupt{}
 	case "servo":
-		iActual := &ServoDigitalInterrupt{ra: utils.NewRollingAverage(ServoRollingAverageWindow)}
-		i = iActual
+		i = &ServoDigitalInterrupt{ra: utils.NewRollingAverage(ServoRollingAverageWindow)}
 	default:
 		panic(errors.Errorf("unknown interrupt type (%s)", cfg.Type))
 	}

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -126,12 +126,6 @@ func (b *sysfsBoard) Reconfigure(
 		return err
 	}
 
-	if b.usePeriphGpio {
-		if len(newConf.DigitalInterrupts) != 0 {
-			return errors.New("digital interrupts on Periph GPIO pins are not yet supported")
-		}
-	}
-
 	if err := b.reconfigureSpis(newConf); err != nil {
 		return err
 	}
@@ -144,6 +138,11 @@ func (b *sysfsBoard) Reconfigure(
 		return err
 	}
 
+	if b.usePeriphGpio {
+		if len(newConf.DigitalInterrupts) != 0 {
+			return errors.New("digital interrupts on Periph GPIO pins are not yet supported")
+		}
+	}
 	if !b.usePeriphGpio {
 		// TODO(RSDK-2684): we dont configure pins so we just unset them here. not really great behavior.
 		// We currently have two implementations of GPIO pins on these boards: one using

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -132,7 +132,9 @@ func (b *sysfsBoard) Reconfigure(
 		}
 	}
 
-	b.reconfigureSpis(newConf)
+	if err := b.reconfigureSpis(newConf); err != nil {
+		return err
+	}
 
 	stillExists := map[string]struct{}{}
 	for _, c := range newConf.I2Cs {
@@ -215,7 +217,9 @@ func (b *sysfsBoard) Reconfigure(
 	return nil
 }
 
-func (b *sysfsBoard) reconfigureSpis(newConf *Config) {
+// This never returns errors, but we give it the same function signature as the other
+// reconfiguration helpers for consistency.
+func (b *sysfsBoard) reconfigureSpis(newConf *Config) error {
 	stillExists := map[string]struct{}{}
 	for _, c := range newConf.SPIs {
 		stillExists[c.Name] = struct{}{}
@@ -234,6 +238,7 @@ func (b *sysfsBoard) reconfigureSpis(newConf *Config) {
 		}
 		delete(b.spis, name)
 	}
+	return nil
 }
 
 type wrappedAnalog struct {

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -160,6 +160,7 @@ func (b *sysfsBoard) reconfigureSpis(newConf *Config) error {
 		b.spis[c.Name] = &spiBus{}
 		b.spis[c.Name].reset(c.BusSelect)
 	}
+
 	for name := range b.spis {
 		if _, ok := stillExists[name]; ok {
 			continue
@@ -191,6 +192,7 @@ func (b *sysfsBoard) reconfigureI2cs(newConf *Config) error {
 		}
 		b.i2cs[c.Name] = bus
 	}
+
 	for name := range b.i2cs {
 		if _, ok := stillExists[name]; ok {
 			continue
@@ -227,6 +229,7 @@ func (b *sysfsBoard) reconfigureAnalogs(ctx context.Context, newConf *Config) er
 		ar := &board.MCP3008AnalogReader{channel, bus, c.ChipSelect}
 		b.analogs[c.Name] = newWrappedAnalog(ctx, c.ChipSelect, board.SmoothAnalogReader(ar, c, b.logger))
 	}
+
 	for name := range b.analogs {
 		if _, ok := stillExists[name]; ok {
 			continue

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -242,22 +242,23 @@ func (b *sysfsBoard) reconfigureGpios(newConf *Config) error {
 		if len(newConf.DigitalInterrupts) != 0 {
 			return errors.New("digital interrupts on Periph GPIO pins are not yet supported")
 		}
-	} else {
-		// TODO(RSDK-2684): we dont configure pins so we just unset them here. not really great behavior.
-		// We currently have two implementations of GPIO pins on these boards: one using
-		// libraries from periph.io and one using an ioctl approach. If we're using the
-		// latter, we need to initialize it here.
-		gpios, interrupts, err := b.gpioInitialize( // Defined in gpio.go
-			b.cancelCtx,
-			b.gpioMappings,
-			newConf.DigitalInterrupts,
-			b.logger)
-		if err != nil {
-			return err
-		}
-		b.gpios = gpios
-		b.interrupts = interrupts
+		return nil // No digital interrupts to reconfigure.
 	}
+
+	// TODO(RSDK-2684): we dont configure pins so we just unset them here. not really great behavior.
+	// We currently have two implementations of GPIO pins on these boards: one using
+	// libraries from periph.io and one using an ioctl approach. If we're using the
+	// latter, we need to initialize it here.
+	gpios, interrupts, err := b.gpioInitialize( // Defined in gpio.go
+		b.cancelCtx,
+		b.gpioMappings,
+		newConf.DigitalInterrupts,
+		b.logger)
+	if err != nil {
+		return err
+	}
+	b.gpios = gpios
+	b.interrupts = interrupts
 	return nil
 }
 

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -142,8 +142,7 @@ func (b *sysfsBoard) Reconfigure(
 		if len(newConf.DigitalInterrupts) != 0 {
 			return errors.New("digital interrupts on Periph GPIO pins are not yet supported")
 		}
-	}
-	if !b.usePeriphGpio {
+	} else {
 		// TODO(RSDK-2684): we dont configure pins so we just unset them here. not really great behavior.
 		// We currently have two implementations of GPIO pins on these boards: one using
 		// libraries from periph.io and one using an ioctl approach. If we're using the


### PR DESCRIPTION
This splits up a 150-line function that did 4 different things into four 40-line functions that each do 1 thing. The next step after that will be to change one of those 40-line helpers to have different behavior, so we can reconfigure digital interrupt pins as relevant.

No changes to behavior are intended. An unintended change to behavior that I don't think is a big deal: if you try to reconfigure a board that uses Periph and specifies digital interrupt pins (which Periph does not support), you will get slightly farther through the reconfiguration procedure before getting the same error as usual.

I recommend reviewing commit-by-commit: I think each commit should be pretty straightforward by itself. but maybe the entire PR is straightforward, too? I dunno; I'm happy to explain myself if you want.