### PR TITLE
RSDK-2645 - Fix for wrapper arm status breaking Arm RC cards when out-of-bounds

### DIFF
--- a/components/arm/arm.go
+++ b/components/arm/arm.go
@@ -101,7 +101,7 @@ func NamesFromRobot(r robot.Robot) []string {
 	return robot.NamesByAPI(r, API)
 }
 
-// CreateStatus creates a status from the arm. This will report calculated end effector positions even if the underlying
+// CreateStatus creates a status from the arm. This will report calculated end effector positions even if the given
 // arm is perceived to be out of bounds.
 func CreateStatus(ctx context.Context, a Arm) (*pb.Status, error) {
 	jointPositions, err := a.JointPositions(ctx, nil)

--- a/components/arm/arm.go
+++ b/components/arm/arm.go
@@ -101,14 +101,15 @@ func NamesFromRobot(r robot.Robot) []string {
 	return robot.NamesByAPI(r, API)
 }
 
-// CreateStatus creates a status from the arm.
+// CreateStatus creates a status from the arm. This will report calculated end effector positions even if the underlying
+// arm is perceived to be out of bounds.
 func CreateStatus(ctx context.Context, a Arm) (*pb.Status, error) {
 	jointPositions, err := a.JointPositions(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
 	model := a.ModelFrame()
-	endPosition, err := motionplan.ComputePosition(model, jointPositions)
+	endPosition, err := motionplan.ComputeOOBPosition(model, jointPositions)
 	if err != nil {
 		return nil, err
 	}

--- a/components/arm/arm_test.go
+++ b/components/arm/arm_test.go
@@ -182,13 +182,6 @@ func TestOOBArm(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, positions, test.ShouldResemble, &jPositions)
 
-	t.Run("CreateStatus errors when OOB", func(t *testing.T) {
-		status, err := arm.CreateStatus(context.Background(), injectedArm)
-		test.That(t, status, test.ShouldBeNil)
-		stringCheck := "joint 0 input out of bounds, input 12.56637 needs to be within range [6.28319 -6.28319]"
-		test.That(t, err.Error(), test.ShouldEqual, stringCheck)
-	})
-
 	t.Run("EndPosition works when OOB", func(t *testing.T) {
 		jPositions := pb.JointPositions{Values: []float64{0, 0, 0, 0, 0, 720}}
 		pose, err := motionplan.ComputeOOBPosition(injectedArm.ModelFrame(), &jPositions)


### PR DESCRIPTION
This looks simple but needed to be tested in a lot of different scenarios to make sure things were OK. Here's what we looked at:

Testing was done with a **wrapper** xArmLite around a **wrapped** xArm6 component. These have different rotation axes for some joints (specifically 2 and 4) that were originally causing a problem with getting status information in `local_robot` when moving the **wrapped** xArm6arm to good configurations. Switching to using the `ComputeOOBPosition` method works for preserving end effector pose computation when the **wrapper** arm is outside its limits. Similarly for the **wrapped** arm.

* Move a **wrapped** xArm6 to < -20.0 degrees on Joint 2, observe that `viam_server` emits errors when getting status information for the **wrapper** xArmLite arm, and now both the **wrapped** and **wrapper** arm status readouts are broken.
* Apply this fix.
* Move the **wrapped** xArm6 to < -20.0 degrees on Joint 2, observe that status continues to work for both cards, end effector positions are being calculated, but per restrictions on `Move` when a model is out-of-bounds, the **wrapper** arm is limited in its control freedom.

No changes have been made to how `Move` works.