### PR TITLE
Add resource equality check to DataCaptureConfig.Equals

### DIFF
--- a/components/camera/collectors.go
+++ b/components/camera/collectors.go
@@ -3,7 +3,6 @@ package camera
 import (
 	"bytes"
 	"context"
-	"runtime/debug"
 
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
@@ -84,7 +83,6 @@ func newReadImageCollector(resource interface{}, params data.CollectorParams) (d
 
 		img, release, err := ReadImage(ctx, camera)
 		if err != nil {
-			debug.PrintStack()
 			return nil, data.FailedToReadErr(params.ComponentName, readImage.String(), err)
 		}
 		defer func() {

--- a/services/datamanager/data_manager.go
+++ b/services/datamanager/data_manager.go
@@ -84,7 +84,8 @@ type DataCaptureConfig struct {
 
 // Equals checks if one capture config is equal to another.
 func (c *DataCaptureConfig) Equals(other *DataCaptureConfig) bool {
-	return c.Name.String() == other.Name.String() &&
+	return c.Resource == other.Resource &&
+		c.Name.String() == other.Name.String() &&
 		c.Method == other.Method &&
 		c.CaptureFrequencyHz == other.CaptureFrequencyHz &&
 		c.CaptureQueueSize == other.CaptureQueueSize &&


### PR DESCRIPTION
Filed https://viam.atlassian.net/browse/RSDK-2929 as this fix is needed (and small) and adding a test for this condition is non trivial given the current structure of TestDataCaptureEnabled.