### PR TITLE
[RSDK-2940] The default I2C address of the PCA9685 board is 0x40

### DIFF
--- a/components/board/hat/pca9685/pca9685.go
+++ b/components/board/hat/pca9685/pca9685.go
@@ -92,7 +92,7 @@ const (
 	prescaleReg = 0xFE
 )
 
-var defaultAddr = 0x60
+var defaultAddr = 0x40
 
 // New returns a new PCA9685 residing on the given bus and address.
 func New(ctx context.Context, deps resource.Dependencies, conf resource.Config) (*PCA9685, error) {

--- a/components/board/hat/pca9685/pca9685.go
+++ b/components/board/hat/pca9685/pca9685.go
@@ -92,6 +92,7 @@ const (
 	prescaleReg = 0xFE
 )
 
+// This should be considered const, except you cannot take the address of a const value.
 var defaultAddr = 0x40
 
 // New returns a new PCA9685 residing on the given bus and address.


### PR DESCRIPTION
The address is only 0x60 if you solder the most significant address pin; out of the box it's 0x40. 

I noticed this while helping someone on Discord, who was unable to wire up this board without specifying a non-default I2C address.

This feels like a breaking change. Is anyone relying on 0x60 being the default address? Is this even a change we're able to make at this point? I'm willing to close the PR and leave the defaults as-is, though I think this will continue to be a source of user confusion in the future if we don't change it.

I'm tagging Steve; he knows what's what with breaking changes. I didn't bother creating a Jira ticket for this, but I'm willing to do so if you want.