### PR TITLE
DATA-1419 | DATA-861 - Check sync config in reconfigure

### DIFF
--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -450,11 +450,11 @@ func (svc *builtIn) Reconfigure(
 		}
 		svc.startSyncScheduler(svc.syncIntervalMins)
 	} else {
-		svc.closeSyncer()
 		if svc.ticker != nil {
 			svc.ticker.Stop()
 			svc.ticker = nil
 		}
+		svc.closeSyncer()
 	}
 
 	return nil

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
 	"sync"
 	"time"
 
@@ -428,15 +427,14 @@ func (svc *builtIn) Reconfigure(
 	}
 	svc.collectors = newCollectors
 
-	if svc.syncDisabled == svcConfig.ScheduledSyncDisabled &&
-		svc.syncIntervalMins == svcConfig.SyncIntervalMins &&
-		reflect.DeepEqual(svc.additionalSyncPaths, svcConfig.AdditionalSyncPaths) {
+	svc.additionalSyncPaths = svcConfig.AdditionalSyncPaths
+
+	if svc.syncDisabled == svcConfig.ScheduledSyncDisabled && svc.syncIntervalMins == svcConfig.SyncIntervalMins {
 		return nil
 	}
 
 	svc.syncDisabled = svcConfig.ScheduledSyncDisabled
 	svc.syncIntervalMins = svcConfig.SyncIntervalMins
-	svc.additionalSyncPaths = svcConfig.AdditionalSyncPaths
 
 	svc.cancelSyncScheduler()
 	if !svc.syncDisabled && svc.syncIntervalMins != 0.0 {

--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -519,7 +519,7 @@ func TestSyncConfigUpdateBehavior(t *testing.T) {
 			test.That(t, err, test.ShouldBeNil)
 
 			builtInSvc := dmsvc.(*builtIn)
-			initTicker := builtInSvc.ticker
+			initTicker := builtInSvc.syncTicker
 
 			// Reconfigure the dmsvc with new sync configs
 			cfg.ScheduledSyncDisabled = tc.newSyncDisabled
@@ -531,7 +531,7 @@ func TestSyncConfigUpdateBehavior(t *testing.T) {
 			test.That(t, err, test.ShouldBeNil)
 
 			newBuildInSvc := dmsvc.(*builtIn)
-			newTicker := newBuildInSvc.ticker
+			newTicker := newBuildInSvc.syncTicker
 			newSyncer := newBuildInSvc.syncer
 
 			if tc.newSyncDisabled {

--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -479,12 +479,6 @@ func TestSyncConfigUpdateBehavior(t *testing.T) {
 			newSyncIntervalMins:  newSyncIntervalMins,
 		},
 		{
-			name:                 "additional paths changes, new ticker should be created for sync",
-			initSyncDisabled:     false,
-			initSyncIntervalMins: syncIntervalMins,
-			newSyncDisabled:      false,
-			newSyncIntervalMins:  syncIntervalMins,
-		}, {
 			name:                 "sync gets disabled, syncer should be nil",
 			initSyncDisabled:     false,
 			initSyncIntervalMins: syncIntervalMins,


### PR DESCRIPTION
Fix:
- sync ticker was being reset on every reconfigure which causes data manager to not sync when the sync interval is long
- updated now to ensure that the syncer is only reset when the sync config is changed

Test:
- tested locally on robot and everything is working as expected
- current tests act as unit tests for the service, further tests will be added in larger data reconfiguration integration testing