### PR TITLE
RSDK-2954 Move module manager to be owned by resource manager

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -38,10 +38,11 @@ var (
 )
 
 // NewManager returns a Manager.
-func NewManager(logger golog.Logger, options modmanageroptions.Options) modmaninterface.ModuleManager {
+func NewManager(parentAddr string, logger golog.Logger, options modmanageroptions.Options) modmaninterface.ModuleManager {
 	return &Manager{
 		logger:       logger,
 		modules:      map[string]*module{},
+		parentAddr:   parentAddr,
 		rMap:         map[resource.Name]*module{},
 		untrustedEnv: options.UntrustedEnv,
 	}
@@ -71,12 +72,6 @@ type Manager struct {
 	parentAddr   string
 	rMap         map[resource.Name]*module
 	untrustedEnv bool
-}
-
-// SetParentAddress sets the unix socket parent address to pass to started
-// modules. To be used after the robot's web service has been started.
-func (mgr *Manager) SetParentAddress(parentAddr string) {
-	mgr.parentAddr = parentAddr
 }
 
 // Close terminates module connections and processes.

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -48,8 +48,7 @@ func TestModManagerFunctions(t *testing.T) {
 	parentAddr += "/parent.sock"
 
 	t.Log("test Helpers")
-	mgr := NewManager(logger, modmanageroptions.Options{UntrustedEnv: false})
-	mgr.SetParentAddress(parentAddr)
+	mgr := NewManager(parentAddr, logger, modmanageroptions.Options{UntrustedEnv: false})
 
 	mod := &module{name: "test", exe: modExe}
 
@@ -82,8 +81,7 @@ func TestModManagerFunctions(t *testing.T) {
 	test.That(t, mod.process.Stop(), test.ShouldBeNil)
 
 	t.Log("test AddModule")
-	mgr = NewManager(logger, modmanageroptions.Options{UntrustedEnv: false})
-	mgr.SetParentAddress(parentAddr)
+	mgr = NewManager(parentAddr, logger, modmanageroptions.Options{UntrustedEnv: false})
 	test.That(t, err, test.ShouldBeNil)
 
 	modCfg := config.Module{
@@ -201,8 +199,7 @@ func TestModManagerFunctions(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Log("test UntrustedEnv")
-	mgr = NewManager(logger, modmanageroptions.Options{UntrustedEnv: true})
-	mgr.SetParentAddress(parentAddr)
+	mgr = NewManager(parentAddr, logger, modmanageroptions.Options{UntrustedEnv: true})
 
 	modCfg = config.Module{
 		Name:    "simple-module",
@@ -253,8 +250,7 @@ func TestModManagerValidation(t *testing.T) {
 	parentAddr += "/parent.sock"
 
 	t.Log("adding complex module")
-	mgr := NewManager(logger, modmanageroptions.Options{UntrustedEnv: false})
-	mgr.SetParentAddress(parentAddr)
+	mgr := NewManager(parentAddr, logger, modmanageroptions.Options{UntrustedEnv: false})
 
 	modCfg := config.Module{
 		Name:    "complex-module",

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -16,7 +16,6 @@ import (
 	"go.viam.com/rdk/config"
 	modmanageroptions "go.viam.com/rdk/module/modmanager/options"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/testutils/inject"
 	"go.viam.com/rdk/utils"
 )
 
@@ -42,24 +41,15 @@ func TestModManagerFunctions(t *testing.T) {
 	_, err = cfgCounter1.Validate("test", resource.APITypeComponentName)
 	test.That(t, err, test.ShouldBeNil)
 
-	myRobot := &inject.Robot{}
-	myRobot.LoggerFunc = func() golog.Logger {
-		return logger
-	}
-
 	// This cannot use t.TempDir() as the path it gives on MacOS exceeds module.MaxSocketAddressLength.
 	parentAddr, err := os.MkdirTemp("", "viam-test-*")
 	test.That(t, err, test.ShouldBeNil)
 	defer os.RemoveAll(parentAddr)
 	parentAddr += "/parent.sock"
 
-	myRobot.ModuleAddressFunc = func() (string, error) {
-		return parentAddr, nil
-	}
-
 	t.Log("test Helpers")
-	mgr, err := NewManager(myRobot, modmanageroptions.Options{UntrustedEnv: false})
-	test.That(t, err, test.ShouldBeNil)
+	mgr := NewManager(logger, modmanageroptions.Options{UntrustedEnv: false})
+	mgr.SetParentAddress(parentAddr)
 
 	mod := &module{name: "test", exe: modExe}
 
@@ -92,7 +82,8 @@ func TestModManagerFunctions(t *testing.T) {
 	test.That(t, mod.process.Stop(), test.ShouldBeNil)
 
 	t.Log("test AddModule")
-	mgr, err = NewManager(myRobot, modmanageroptions.Options{UntrustedEnv: false})
+	mgr = NewManager(logger, modmanageroptions.Options{UntrustedEnv: false})
+	mgr.SetParentAddress(parentAddr)
 	test.That(t, err, test.ShouldBeNil)
 
 	modCfg := config.Module{
@@ -210,8 +201,8 @@ func TestModManagerFunctions(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Log("test UntrustedEnv")
-	mgr, err = NewManager(myRobot, modmanageroptions.Options{UntrustedEnv: true})
-	test.That(t, err, test.ShouldBeNil)
+	mgr = NewManager(logger, modmanageroptions.Options{UntrustedEnv: true})
+	mgr.SetParentAddress(parentAddr)
 
 	modCfg = config.Module{
 		Name:    "simple-module",
@@ -255,24 +246,15 @@ func TestModManagerValidation(t *testing.T) {
 	_, err = cfgMyBase2.Validate("test", resource.APITypeComponentName)
 	test.That(t, err, test.ShouldBeNil)
 
-	myRobot := &inject.Robot{}
-	myRobot.LoggerFunc = func() golog.Logger {
-		return logger
-	}
-
 	// This cannot use t.TempDir() as the path it gives on MacOS exceeds module.MaxSocketAddressLength.
 	parentAddr, err := os.MkdirTemp("", "viam-test-*")
 	test.That(t, err, test.ShouldBeNil)
 	defer os.RemoveAll(parentAddr)
 	parentAddr += "/parent.sock"
 
-	myRobot.ModuleAddressFunc = func() (string, error) {
-		return parentAddr, nil
-	}
-
 	t.Log("adding complex module")
-	mgr, err := NewManager(myRobot, modmanageroptions.Options{UntrustedEnv: false})
-	test.That(t, err, test.ShouldBeNil)
+	mgr := NewManager(logger, modmanageroptions.Options{UntrustedEnv: false})
+	mgr.SetParentAddress(parentAddr)
 
 	modCfg := config.Module{
 		Name:    "complex-module",

--- a/module/modmaninterface/interface.go
+++ b/module/modmaninterface/interface.go
@@ -22,5 +22,6 @@ type ModuleManager interface {
 
 	Provides(cfg resource.Config) bool
 
+	SetParentAddress(string)
 	Close(ctx context.Context) error
 }

--- a/module/modmaninterface/interface.go
+++ b/module/modmaninterface/interface.go
@@ -22,6 +22,5 @@ type ModuleManager interface {
 
 	Provides(cfg resource.Config) bool
 
-	SetParentAddress(string)
 	Close(ctx context.Context) error
 }

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -426,8 +426,15 @@ func newWithResources(
 		return nil, err
 	}
 
-	// Once web service is started, set parent address in module manager.
+	// Once web service is started, set parent address in module manager and add
+	// initially specified modules.
 	r.manager.moduleManager.SetParentAddress(r.webSvc.ModuleAddress())
+	for _, mod := range cfg.Modules {
+		err := r.manager.moduleManager.Add(ctx, mod)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	r.activeBackgroundWorkers.Add(1)
 	r.configTicker = time.NewTicker(5 * time.Second)

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -426,9 +426,9 @@ func newWithResources(
 		return nil, err
 	}
 
-	// Once web service is started, set parent address in module manager and add
-	// initially specified modules.
-	r.manager.moduleManager.SetParentAddress(r.webSvc.ModuleAddress())
+	// Once web service is started, start module manager and add initially
+	// specified modules.
+	r.manager.startModuleManager(r.webSvc.ModuleAddress(), cfg.UntrustedEnv, logger)
 	for _, mod := range cfg.Modules {
 		err := r.manager.moduleManager.Add(ctx, mod)
 		if err != nil {

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -21,9 +21,6 @@ import (
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/internal"
 	"go.viam.com/rdk/internal/cloud"
-	"go.viam.com/rdk/module/modmanager"
-	modmanageroptions "go.viam.com/rdk/module/modmanager/options"
-	modif "go.viam.com/rdk/module/modmaninterface"
 	"go.viam.com/rdk/operation"
 	"go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/referenceframe"
@@ -50,7 +47,6 @@ type localRobot struct {
 	config  *config.Config
 
 	operations                 *operation.Manager
-	modules                    modif.ModuleManager
 	sessionManager             session.Manager
 	packageManager             packages.ManagerSyncer
 	cloudConnSvc               cloud.ConnectionService
@@ -106,11 +102,6 @@ func (r *localRobot) OperationManager() *operation.Manager {
 	return r.operations
 }
 
-// ModuleManager returns the module manager for the robot.
-func (r *localRobot) ModuleManager() modif.ModuleManager {
-	return r.modules
-}
-
 // SessionManager returns the session manager for the robot.
 func (r *localRobot) SessionManager() session.Manager {
 	return r.sessionManager
@@ -148,10 +139,7 @@ func (r *localRobot) Close(ctx context.Context) error {
 		err = multierr.Combine(err, r.cloudConnSvc.Close(ctx))
 	}
 	if r.manager != nil {
-		err = multierr.Combine(err, r.manager.Close(ctx, r))
-	}
-	if r.modules != nil {
-		err = multierr.Combine(err, r.modules.Close(ctx))
+		err = multierr.Combine(err, r.manager.Close(ctx))
 	}
 	if r.packageManager != nil {
 		err = multierr.Combine(err, r.packageManager.Close(ctx))
@@ -438,17 +426,8 @@ func newWithResources(
 		return nil, err
 	}
 
-	modMgr, err := modmanager.NewManager(r, modmanageroptions.Options{UntrustedEnv: r.manager.opts.untrustedEnv})
-	if err != nil {
-		return nil, err
-	}
-	r.modules = modMgr
-	for _, mod := range cfg.Modules {
-		err := r.modules.Add(ctx, mod)
-		if err != nil {
-			return nil, err
-		}
-	}
+	// Once web service is started, set parent address in module manager.
+	r.manager.moduleManager.SetParentAddress(r.webSvc.ModuleAddress())
 
 	r.activeBackgroundWorkers.Add(1)
 	r.configTicker = time.NewTicker(5 * time.Second)
@@ -922,8 +901,8 @@ func (r *localRobot) Reconfigure(ctx context.Context, newConfig *config.Config) 
 	// and store implicit dependencies.
 	validateModularResources := func(confs []resource.Config) {
 		for i, c := range confs {
-			if r.modules.Provides(c) {
-				implicitDeps, err := r.modules.ValidateConfig(ctx, c)
+			if r.manager.moduleManager.Provides(c) {
+				implicitDeps, err := r.manager.moduleManager.ValidateConfig(ctx, c)
 				if err != nil {
 					r.logger.Errorw("modular config validation error found in resource: "+c.Name, "error", err)
 					continue
@@ -947,26 +926,6 @@ func (r *localRobot) Reconfigure(ctx context.Context, newConfig *config.Config) 
 		r.logger.Debugf("(re)configuring with %+v", diff)
 	}
 
-	orphanedResourceNames, err := r.reconfigureModules(ctx, diff)
-	if err != nil {
-		r.logger.Error(err)
-	}
-
-	// Before filtering config, manually add modular orphaned resources (resources
-	// handled by removed modules) to diff.Removed.
-	for _, name := range orphanedResourceNames {
-		for _, c := range newConfig.Components {
-			if c.ResourceName() == name {
-				diff.Removed.Components = append(diff.Removed.Components, c)
-			}
-		}
-		for _, s := range newConfig.Services {
-			if s.ResourceName() == name {
-				diff.Removed.Services = append(diff.Removed.Services, s)
-			}
-		}
-	}
-
 	// First we remove resources and their children that are not in the graph.
 	processesToClose, resourcesToCloseBeforeComplete, _ := r.manager.markRemoved(ctx, diff.Removed, r.logger)
 
@@ -979,14 +938,14 @@ func (r *localRobot) Reconfigure(ctx context.Context, newConfig *config.Config) 
 	// Third we attempt to complete the config (see function for details)
 	alreadyClosed := make(map[resource.Name]struct{}, len(resourcesToCloseBeforeComplete))
 	for _, res := range resourcesToCloseBeforeComplete {
-		allErrs = multierr.Combine(allErrs, r.manager.closeResource(ctx, r, res))
+		allErrs = multierr.Combine(allErrs, r.manager.closeResource(ctx, res))
 		// avoid a double close later
 		alreadyClosed[res.Name()] = struct{}{}
 	}
 	r.manager.completeConfig(ctx, r)
 	r.updateWeakDependents(ctx)
 
-	removedNames, removedErr := r.manager.removeMarkedAndClose(ctx, r, alreadyClosed)
+	removedNames, removedErr := r.manager.removeMarkedAndClose(ctx, alreadyClosed)
 	if removedErr != nil {
 		allErrs = multierr.Combine(allErrs, removedErr)
 	}
@@ -1067,36 +1026,4 @@ func (r *localRobot) checkMaxInstance(api resource.API, max int) error {
 		}
 	}
 	return nil
-}
-
-// reconfigureModules will add, remove and reconfigure modules from the module
-// manager as needed depending on the passed-in config diff. It will return the
-// names of now orphaned resources.
-func (r *localRobot) reconfigureModules(ctx context.Context,
-	diff *config.Diff,
-) ([]resource.Name, error) {
-	for _, mod := range diff.Added.Modules {
-		if err := r.modules.Add(ctx, mod); err != nil {
-			return nil, errors.Wrapf(err, "error adding module %s ", mod.Name)
-		}
-	}
-
-	var allOrphanedResourceNames []resource.Name
-	for _, mod := range diff.Modified.Modules {
-		orphanedResourceNames, err := r.modules.Reconfigure(ctx, mod)
-		if err != nil {
-			return nil, errors.Wrapf(err, "error reconfiguring module %s ", mod.Name)
-		}
-		allOrphanedResourceNames = append(allOrphanedResourceNames, orphanedResourceNames...)
-	}
-
-	for _, mod := range diff.Removed.Modules {
-		orphanedResourceNames, err := r.modules.Remove(mod.Name)
-		if err != nil {
-			return nil, errors.Wrapf(err, "error removing module %s ", mod.Name)
-		}
-		allOrphanedResourceNames = append(allOrphanedResourceNames, orphanedResourceNames...)
-	}
-
-	return allOrphanedResourceNames, nil
 }

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -18,6 +18,8 @@ import (
 
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/module/modmanager"
+	modmanageroptions "go.viam.com/rdk/module/modmanager/options"
+	modif "go.viam.com/rdk/module/modmaninterface"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/robot/client"
@@ -41,6 +43,7 @@ var (
 type resourceManager struct {
 	resources      *resource.Graph
 	processManager pexec.ProcessManager
+	moduleManager  modif.ModuleManager
 	opts           resourceManagerOptions
 	logger         golog.Logger
 	configLock     sync.Mutex
@@ -62,6 +65,7 @@ func newResourceManager(
 	return &resourceManager{
 		resources:      resource.NewGraph(),
 		processManager: newProcessManager(opts, logger),
+		moduleManager:  newModuleManager(opts, logger),
 		opts:           opts,
 		logger:         logger,
 	}
@@ -75,6 +79,14 @@ func newProcessManager(
 		return pexec.NoopProcessManager
 	}
 	return pexec.NewProcessManager(logger)
+}
+
+func newModuleManager(
+	opts resourceManagerOptions,
+	logger golog.Logger,
+) modif.ModuleManager {
+	mmOpts := modmanageroptions.Options{UntrustedEnv: opts.untrustedEnv}
+	return modmanager.NewManager(logger, mmOpts)
 }
 
 func fromRemoteNameToRemoteNodeName(name string) resource.Name {
@@ -377,12 +389,12 @@ func (manager *resourceManager) mergeResourceRPCAPIsWithRemote(r robot.Robot, ty
 	}
 }
 
-func (manager *resourceManager) closeResource(ctx context.Context, r robot.LocalRobot, res resource.Resource) error {
+func (manager *resourceManager) closeResource(ctx context.Context, res resource.Resource) error {
 	allErrs := res.Close(ctx)
 
 	resName := res.Name()
-	if modMan := r.ModuleManager(); modMan != nil && modMan.IsModularResource(resName) {
-		if err := r.ModuleManager().RemoveResource(ctx, resName); err != nil {
+	if manager.moduleManager != nil && manager.moduleManager.IsModularResource(resName) {
+		if err := manager.moduleManager.RemoveResource(ctx, resName); err != nil {
 			allErrs = multierr.Combine(err, errors.Wrap(err, "error removing modular resource for closure"))
 		}
 	}
@@ -396,7 +408,6 @@ func (manager *resourceManager) closeResource(ctx context.Context, r robot.Local
 // before add) or need to be removed in a different way (e.g. web internal service last).
 func (manager *resourceManager) removeMarkedAndClose(
 	ctx context.Context,
-	r robot.LocalRobot,
 	excludeFromClose map[resource.Name]struct{},
 ) ([]resource.Name, error) {
 	var allErrs error
@@ -408,25 +419,28 @@ func (manager *resourceManager) removeMarkedAndClose(
 		if _, ok := excludeFromClose[resName]; ok {
 			continue
 		}
-		allErrs = multierr.Combine(allErrs, manager.closeResource(ctx, r, res))
+		allErrs = multierr.Combine(allErrs, manager.closeResource(ctx, res))
 	}
 	return removedNames, allErrs
 }
 
 // Close attempts to close/stop all parts.
-func (manager *resourceManager) Close(ctx context.Context, r robot.LocalRobot) error {
+func (manager *resourceManager) Close(ctx context.Context) error {
 	manager.resources.MarkForRemoval(manager.resources.Clone())
 
 	var allErrs error
 	if err := manager.processManager.Stop(); err != nil {
 		allErrs = multierr.Combine(allErrs, errors.Wrap(err, "error stopping process manager"))
 	}
+	if err := manager.moduleManager.Close(ctx); err != nil {
+		allErrs = multierr.Combine(allErrs, errors.Wrap(err, "error closing module manager"))
+	}
 
 	// our caller will close web
 	excludeWebFromClose := map[resource.Name]struct{}{
 		web.InternalServiceName: {},
 	}
-	if _, err := manager.removeMarkedAndClose(ctx, r, excludeWebFromClose); err != nil {
+	if _, err := manager.removeMarkedAndClose(ctx, excludeWebFromClose); err != nil {
 		allErrs = multierr.Combine(allErrs, err)
 	}
 
@@ -524,8 +538,8 @@ func (manager *resourceManager) completeConfig(
 			gNode.SetLastError(errors.Wrap(err, "config validation error found in resource: "+conf.ResourceName().String()))
 			continue
 		}
-		if robot.ModuleManager().Provides(conf) {
-			if _, err := robot.ModuleManager().ValidateConfig(ctx, conf); err != nil {
+		if manager.moduleManager.Provides(conf) {
+			if _, err := manager.moduleManager.ValidateConfig(ctx, conf); err != nil {
 				manager.logger.Errorw("modular resource config validation error", "resource", conf.ResourceName(), "model", conf.Model, "error", err)
 				gNode.SetLastError(errors.Wrap(err, "config validation error found in modular resource: "+conf.ResourceName().String()))
 				continue
@@ -709,13 +723,13 @@ func (manager *resourceManager) processResource(
 	resName := conf.ResourceName()
 	deps, err := r.getDependencies(ctx, resName, gNode)
 	if err != nil {
-		return nil, false, multierr.Combine(err, manager.closeResource(ctx, r, currentRes))
+		return nil, false, multierr.Combine(err, manager.closeResource(ctx, currentRes))
 	}
 
-	isModular := r.ModuleManager().Provides(conf)
+	isModular := manager.moduleManager.Provides(conf)
 	if gNode.ResourceModel() == conf.Model {
 		if isModular {
-			if err := r.ModuleManager().ReconfigureResource(ctx, conf, modmanager.DepsToNames(deps)); err != nil {
+			if err := manager.moduleManager.ReconfigureResource(ctx, conf, modmanager.DepsToNames(deps)); err != nil {
 				return nil, false, err
 			}
 			return currentRes, false, nil
@@ -735,7 +749,7 @@ func (manager *resourceManager) processResource(
 	}
 
 	manager.logger.Debugw("rebuilding", "name", resName)
-	if err := r.manager.closeResource(ctx, r, currentRes); err != nil {
+	if err := r.manager.closeResource(ctx, currentRes); err != nil {
 		manager.logger.Error(err)
 	}
 	newRes, err := r.newResource(ctx, gNode, conf)
@@ -848,6 +862,26 @@ func (manager *resourceManager) updateResources(
 			continue
 		}
 	}
+
+	// modules are not added into the resource tree as they belong to the module manager
+	for _, mod := range conf.Added.Modules {
+		if err := manager.moduleManager.Add(ctx, mod); err != nil {
+			manager.logger.Errorw("error adding module", "module", mod.Name, "error", err)
+			continue
+		}
+	}
+	for _, mod := range conf.Modified.Modules {
+		orphanedResourceNames, err := manager.moduleManager.Reconfigure(ctx, mod)
+		if err != nil {
+			manager.logger.Errorw("error reconfiguring module", "module", mod.Name, "error", err)
+		}
+		for _, resToClose := range manager.markResourcesRemoved(orphanedResourceNames, nil) {
+			if err := resToClose.Close(ctx); err != nil {
+				manager.logger.Errorw("error closing now orphaned resource", "resource",
+					resToClose.Name().String(), "module", mod.Name, "error", err)
+			}
+		}
+	}
 	return allErrs
 }
 
@@ -897,14 +931,6 @@ func (manager *resourceManager) markRemoved(
 	logger golog.Logger,
 ) (pexec.ProcessManager, []resource.Resource, map[resource.Name]struct{}) {
 	processesToClose := newProcessManager(manager.opts, logger)
-	var resourcesToCloseBeforeComplete []resource.Resource
-	markedResourceNames := map[resource.Name]struct{}{}
-	addNames := func(names ...resource.Name) {
-		for _, name := range names {
-			markedResourceNames[name] = struct{}{}
-		}
-	}
-
 	for _, conf := range conf.Processes {
 		if manager.opts.untrustedEnv {
 			continue
@@ -920,42 +946,42 @@ func (manager *resourceManager) markRemoved(
 		}
 	}
 
+	var resourcesToMark []resource.Name
+	for _, conf := range conf.Modules {
+		orphanedResourceNames, err := manager.moduleManager.Remove(conf.Name)
+		if err != nil {
+			manager.logger.Errorw("error removing module", "module", conf.Name, "error", err)
+		}
+		resourcesToMark = append(resourcesToMark, orphanedResourceNames...)
+	}
+
 	for _, conf := range conf.Remotes {
-		remoteName := fromRemoteNameToRemoteNodeName(conf.Name)
-		resNode, ok := manager.resources.Node(remoteName)
-		if !ok {
-			continue
-		}
-		resourcesToCloseBeforeComplete = append(
-			resourcesToCloseBeforeComplete,
-			resource.NewCloseOnlyResource(remoteName, resNode.Close))
-		subG, err := manager.resources.SubGraphFrom(remoteName)
-		if err != nil {
-			manager.logger.Errorw("error while getting a subgraph", "error", err)
-			continue
-		}
-		addNames(subG.Names()...)
-		manager.resources.MarkForRemoval(subG)
+		resourcesToMark = append(
+			resourcesToMark,
+			fromRemoteNameToRemoteNodeName(conf.Name),
+		)
 	}
-	for _, compConf := range conf.Components {
-		rName := compConf.ResourceName()
-		resNode, ok := manager.resources.Node(rName)
-		if !ok {
-			continue
-		}
-		resourcesToCloseBeforeComplete = append(
-			resourcesToCloseBeforeComplete,
-			resource.NewCloseOnlyResource(rName, resNode.Close))
-		subG, err := manager.resources.SubGraphFrom(rName)
-		if err != nil {
-			manager.logger.Errorw("error while getting a subgraph", "error", err)
-			continue
-		}
-		addNames(subG.Names()...)
-		manager.resources.MarkForRemoval(subG)
+	for _, conf := range append(conf.Components, conf.Services...) {
+		resourcesToMark = append(resourcesToMark, conf.ResourceName())
 	}
-	for _, conf := range conf.Services {
-		rName := conf.ResourceName()
+	markedResourceNames := map[resource.Name]struct{}{}
+	addNames := func(names ...resource.Name) {
+		for _, name := range names {
+			markedResourceNames[name] = struct{}{}
+		}
+	}
+	resourcesToCloseBeforeComplete := manager.markResourcesRemoved(resourcesToMark, addNames)
+	return processesToClose, resourcesToCloseBeforeComplete, markedResourceNames
+}
+
+// markResourcesRemoved marks all passed in resources (assumed to be resource
+// names of components, services or remotes) for removal.
+func (manager *resourceManager) markResourcesRemoved(
+	rNames []resource.Name,
+	addNames func(names ...resource.Name),
+) []resource.Resource {
+	var resourcesToCloseBeforeComplete []resource.Resource
+	for _, rName := range rNames {
 		// Disable changes to shell in untrusted
 		if manager.opts.untrustedEnv && rName.API == shell.API {
 			continue
@@ -972,10 +998,12 @@ func (manager *resourceManager) markRemoved(
 			manager.logger.Errorw("error while getting a subgraph", "error", err)
 			continue
 		}
-		addNames(subG.Names()...)
+		if addNames != nil {
+			addNames(subG.Names()...)
+		}
 		manager.resources.MarkForRemoval(subG)
 	}
-	return processesToClose, resourcesToCloseBeforeComplete, markedResourceNames
+	return resourcesToCloseBeforeComplete
 }
 
 func remoteDialOptions(config config.Remote, opts resourceManagerOptions) []rpc.DialOption {

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -433,8 +433,12 @@ func (manager *resourceManager) Close(ctx context.Context) error {
 	if err := manager.processManager.Stop(); err != nil {
 		allErrs = multierr.Combine(allErrs, errors.Wrap(err, "error stopping process manager"))
 	}
-	if err := manager.moduleManager.Close(ctx); err != nil {
-		allErrs = multierr.Combine(allErrs, errors.Wrap(err, "error closing module manager"))
+	// moduleManager may be nil if startModuleManager was never called (may be
+	// the case in tests).
+	if manager.moduleManager != nil {
+		if err := manager.moduleManager.Close(ctx); err != nil {
+			allErrs = multierr.Combine(allErrs, errors.Wrap(err, "error closing module manager"))
+		}
 	}
 
 	// our caller will close web

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -58,6 +58,7 @@ type resourceManagerOptions struct {
 }
 
 // newResourceManager returns a properly initialized set of parts.
+// moduleManager will not be initialized until startModuleManager is called.
 func newResourceManager(
 	opts resourceManagerOptions,
 	logger golog.Logger,
@@ -65,7 +66,6 @@ func newResourceManager(
 	return &resourceManager{
 		resources:      resource.NewGraph(),
 		processManager: newProcessManager(opts, logger),
-		moduleManager:  newModuleManager(opts, logger),
 		opts:           opts,
 		logger:         logger,
 	}
@@ -81,16 +81,17 @@ func newProcessManager(
 	return pexec.NewProcessManager(logger)
 }
 
-func newModuleManager(
-	opts resourceManagerOptions,
-	logger golog.Logger,
-) modif.ModuleManager {
-	mmOpts := modmanageroptions.Options{UntrustedEnv: opts.untrustedEnv}
-	return modmanager.NewManager(logger, mmOpts)
-}
-
 func fromRemoteNameToRemoteNodeName(name string) resource.Name {
 	return resource.NewName(client.RemoteAPI, name)
+}
+
+func (manager *resourceManager) startModuleManager(
+	parentAddr string,
+	untrustedEnv bool,
+	logger golog.Logger,
+) {
+	mmOpts := modmanageroptions.Options{UntrustedEnv: untrustedEnv}
+	manager.moduleManager = modmanager.NewManager(parentAddr, logger, mmOpts)
 }
 
 // addRemote adds a remote to the manager.

--- a/robot/impl/resource_manager_modular_test.go
+++ b/robot/impl/resource_manager_modular_test.go
@@ -46,7 +46,7 @@ func TestModularResources(t *testing.T) {
 		r, err := New(context.Background(), &config.Config{}, logger)
 		test.That(t, err, test.ShouldBeNil)
 		actualR := r.(*localRobot)
-		actualR.modules = mod
+		actualR.manager.moduleManager = mod
 
 		resource.RegisterAPI(compAPI,
 			resource.APIRegistration[resource.Resource]{ReflectRPCServiceDesc: &desc.ServiceDescriptor{}})
@@ -264,7 +264,7 @@ func TestModularResources(t *testing.T) {
 
 		test.That(t, len(mod.add), test.ShouldEqual, 2)
 
-		test.That(t, r.manager.Close(ctx, r), test.ShouldBeNil)
+		test.That(t, r.manager.Close(ctx), test.ShouldBeNil)
 
 		test.That(t, len(mod.add), test.ShouldEqual, 2)
 		test.That(t, len(mod.reconf), test.ShouldEqual, 0)

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -185,7 +185,7 @@ func TestManagerForRemoteRobot(t *testing.T) {
 
 	manager := managerForDummyRobot(injectRobot)
 	defer func() {
-		test.That(t, manager.Close(context.Background(), injectRobot), test.ShouldBeNil)
+		test.That(t, manager.Close(context.Background()), test.ShouldBeNil)
 	}()
 
 	armNames := []resource.Name{arm.Named("arm1"), arm.Named("arm2")}
@@ -250,7 +250,7 @@ func TestManagerMergeNamesWithRemotes(t *testing.T) {
 
 	manager := managerForDummyRobot(injectRobot)
 	defer func() {
-		test.That(t, manager.Close(context.Background(), injectRobot), test.ShouldBeNil)
+		test.That(t, manager.Close(context.Background()), test.ShouldBeNil)
 	}()
 	manager.addRemote(
 		context.Background(),
@@ -380,7 +380,7 @@ func TestManagerResourceRemoteName(t *testing.T) {
 
 	manager := managerForDummyRobot(injectRobot)
 	defer func() {
-		test.That(t, manager.Close(context.Background(), injectRobot), test.ShouldBeNil)
+		test.That(t, manager.Close(context.Background()), test.ShouldBeNil)
 	}()
 
 	injectRemote := &inject.Robot{}
@@ -415,7 +415,7 @@ func TestManagerWithSameNameInRemoteNoPrefix(t *testing.T) {
 
 	manager := managerForDummyRobot(injectRobot)
 	defer func() {
-		test.That(t, manager.Close(context.Background(), injectRobot), test.ShouldBeNil)
+		test.That(t, manager.Close(context.Background()), test.ShouldBeNil)
 	}()
 	manager.addRemote(
 		context.Background(),
@@ -442,7 +442,7 @@ func TestManagerWithSameNameInBaseAndRemote(t *testing.T) {
 
 	manager := managerForDummyRobot(injectRobot)
 	defer func() {
-		test.That(t, manager.Close(context.Background(), injectRobot), test.ShouldBeNil)
+		test.That(t, manager.Close(context.Background()), test.ShouldBeNil)
 	}()
 	manager.addRemote(
 		context.Background(),
@@ -854,7 +854,7 @@ func TestManagerMarkRemoved(t *testing.T) {
 	}, logger)
 	checkEmpty(processesToRemove, resourcesToCloseBeforeComplete, markedResourceNames)
 
-	test.That(t, manager.Close(ctx, &localRobot{}), test.ShouldBeNil)
+	test.That(t, manager.Close(ctx), test.ShouldBeNil)
 	cancel()
 
 	ctx, cancel = context.WithCancel(context.Background())
@@ -940,7 +940,7 @@ func TestManagerMarkRemoved(t *testing.T) {
 		utils.NewStringSet("2"),
 	)
 
-	test.That(t, manager.Close(ctx, &localRobot{}), test.ShouldBeNil)
+	test.That(t, manager.Close(ctx), test.ShouldBeNil)
 	cancel()
 
 	ctx, cancel = context.WithCancel(context.Background())
@@ -1059,7 +1059,7 @@ func TestManagerMarkRemoved(t *testing.T) {
 		utils.NewStringSet("2"),
 	)
 
-	test.That(t, manager.Close(ctx, &localRobot{}), test.ShouldBeNil)
+	test.That(t, manager.Close(ctx), test.ShouldBeNil)
 	cancel()
 
 	ctx, cancel = context.WithCancel(context.Background())
@@ -1246,7 +1246,7 @@ func TestManagerMarkRemoved(t *testing.T) {
 		test.ShouldResemble,
 		utils.NewStringSet("1", "2"),
 	)
-	test.That(t, manager.Close(ctx, &localRobot{}), test.ShouldBeNil)
+	test.That(t, manager.Close(ctx), test.ShouldBeNil)
 	cancel()
 }
 
@@ -1431,7 +1431,7 @@ func TestManagerResourceRPCAPIs(t *testing.T) {
 
 	manager := managerForDummyRobot(injectRobot)
 	defer func() {
-		test.That(t, manager.Close(context.Background(), injectRobot), test.ShouldBeNil)
+		test.That(t, manager.Close(context.Background()), test.ShouldBeNil)
 	}()
 
 	api1 := resource.APINamespace("acme").WithComponentType("huwat")
@@ -1580,7 +1580,7 @@ func TestManagerEmptyResourceDesc(t *testing.T) {
 
 	manager := managerForDummyRobot(injectRobot)
 	defer func() {
-		test.That(t, manager.Close(context.Background(), injectRobot), test.ShouldBeNil)
+		test.That(t, manager.Close(context.Background()), test.ShouldBeNil)
 	}()
 
 	apis := manager.ResourceRPCAPIs()
@@ -1619,7 +1619,7 @@ func TestReconfigure(t *testing.T) {
 
 	manager := managerForDummyRobot(r)
 	defer func() {
-		test.That(t, manager.Close(ctx, r), test.ShouldBeNil)
+		test.That(t, manager.Close(ctx), test.ShouldBeNil)
 	}()
 
 	svc1 := resource.Config{
@@ -1658,7 +1658,7 @@ func TestResourceCreationPanic(t *testing.T) {
 
 	manager := managerForDummyRobot(r)
 	defer func() {
-		test.That(t, manager.Close(ctx, r), test.ShouldBeNil)
+		test.That(t, manager.Close(ctx), test.ShouldBeNil)
 		test.That(t, r.Close(ctx), test.ShouldBeNil)
 	}()
 

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -1847,6 +1847,10 @@ func (rr *dummyRobot) StopAll(ctx context.Context, extra map[resource.Name]map[s
 func managerForDummyRobot(robot robot.Robot) *resourceManager {
 	manager := newResourceManager(resourceManagerOptions{}, robot.Logger().Named("manager"))
 
+	// start a dummy module manager so calls to moduleManager.Provides() do not
+	// panic.
+	manager.startModuleManager("", false, robot.Logger())
+
 	for _, name := range robot.ResourceNames() {
 		res, err := robot.ResourceByName(name)
 		if err != nil {

--- a/robot/robot.go
+++ b/robot/robot.go
@@ -14,7 +14,6 @@ import (
 
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/grpc"
-	modif "go.viam.com/rdk/module/modmaninterface"
 	"go.viam.com/rdk/operation"
 	"go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/referenceframe"
@@ -110,9 +109,6 @@ type LocalRobot interface {
 
 	// ModuleAddress returns the address (path) of the unix socket modules use to contact the parent.
 	ModuleAddress() (string, error)
-
-	// ModuleManager returns the module manager the robot is using.
-	ModuleManager() modif.ModuleManager
 }
 
 // A RemoteRobot is a Robot that was created through a connection.

--- a/testutils/inject/robot.go
+++ b/testutils/inject/robot.go
@@ -13,7 +13,6 @@ import (
 	"go.viam.com/utils/pexec"
 
 	"go.viam.com/rdk/config"
-	"go.viam.com/rdk/module/modmaninterface"
 	"go.viam.com/rdk/operation"
 	"go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/referenceframe"
@@ -49,7 +48,6 @@ type Robot struct {
 	TransformPointCloudFunc func(ctx context.Context, srcpc pointcloud.PointCloud, srcName, dstName string) (pointcloud.PointCloud, error)
 	StatusFunc              func(ctx context.Context, resourceNames []resource.Name) ([]robot.Status, error)
 	ModuleAddressFunc       func() (string, error)
-	ModuleManagerFunc       func() modmaninterface.ModuleManager
 
 	ops        *operation.Manager
 	SessMgr    session.Manager
@@ -275,19 +273,6 @@ func (r *Robot) ModuleAddress() (string, error) {
 		return r.LocalRobot.ModuleAddress()
 	}
 	return r.ModuleAddressFunc()
-}
-
-// ModuleManager calls the injected ModuleManager or the real one.
-func (r *Robot) ModuleManager() modmaninterface.ModuleManager {
-	r.Mu.RLock()
-	defer r.Mu.RUnlock()
-	if r.ModuleManagerFunc == nil {
-		if r.LocalRobot == nil {
-			return nil
-		}
-		return r.LocalRobot.ModuleManager()
-	}
-	return r.ModuleManagerFunc()
 }
 
 type noopSessionManager struct{}


### PR DESCRIPTION
RSDK-2954

Moves the module manager to be owned by the resource manager instead of by local robot.

Currently, local robot has both a module manager object and a resource manager object. Increasingly, the module manager must interface with the resource manager and vice versa. It may be wise to have the module manager be owned by the resource manager (like the process manager). This turns the weird `MM <-> LR <-> RM` interaction into something more like `LR -> RM -> MM`.