### PR TITLE
RSDK-2948 Do not call ValidateConfig with no diff in config

### DIFF
--- a/examples/customresources/demos/complexmodule/moduletest/module_test.go
+++ b/examples/customresources/demos/complexmodule/moduletest/module_test.go
@@ -413,6 +413,6 @@ func TestValidationFailure(t *testing.T) {
 	// Assert that Validation failure is present in server output, but build failure
 	// is not.
 	test.That(t, logs.FilterMessageSnippet(
-		"modular config validation error found in component: base1").Len(), test.ShouldEqual, 1)
+		"modular config validation error found in resource: base1").Len(), test.ShouldEqual, 1)
 	test.That(t, logs.FilterMessageSnippet("error building component").Len(), test.ShouldEqual, 0)
 }


### PR DESCRIPTION
RSDK-2948

Moves calls to `ValidateConfig` that gather implicit dependencies to after the call to `DiffConfigs`.

This change stops running `ValidateConfig` when `Reconfigure` is called with a config identical to the current config (`Reconfigure` returns early [here](https://github.com/viamrobotics/rdk/pull/2316/files#diff-0b975da6011656cd3f2caf0435023573bdb5ac7c6a425e7917dd5cc9d6be63e4R916-R918)). Modules run in the cloud were receiving calls to `ValidateConfig` every 10 seconds to gather implicit deps even when the config hadn't changed. The use case of dynamic implicit dependencies (inconsistent return values of `ValidateConfig` from modules) is not something we wish to support at this point in time.

