### PR TITLE
Add a missing getter to the WorldState

### DIFF
--- a/referenceframe/worldstate.go
+++ b/referenceframe/worldstate.go
@@ -115,6 +115,14 @@ func (ws *WorldState) ObstacleNames() map[string]bool {
 	return copiedMap
 }
 
+// Obstacles returns the obstacles that have been added to the WorldState.
+func (ws *WorldState) Obstacles() []*GeometriesInFrame {
+	if ws == nil {
+		return []*GeometriesInFrame{}
+	}
+	return ws.obstacles
+}
+
 // Transforms returns the transforms that have been added to the WorldState.
 func (ws *WorldState) Transforms() []*LinkInFrame {
 	if ws == nil {


### PR DESCRIPTION
Looks like we just forgot to add a getter for Obstacles (we have one for Transforms and ObstacleNames already).