### PR TITLE
Add async cancellable scheduling function

### DIFF
--- a/web/frontend/src/components/encoder.vue
+++ b/web/frontend/src/components/encoder.vue
@@ -107,14 +107,8 @@ const reset = () => {
 onMounted(async () => {
   try {
     properties = await getProperties();
-
-    cancelPoll = scheduleAsyncPoll(refresh, 500);
+    refresh();
   } catch (error) {
-    if ((error as ServiceError).message === 'Response closed without headers') {
-      cancelPoll = scheduleAsyncPoll(refresh, 500);
-      return;
-    }
-
     displayError(error as ServiceError);
   }
 

--- a/web/frontend/src/components/encoder.vue
+++ b/web/frontend/src/components/encoder.vue
@@ -81,7 +81,7 @@ const refresh = async () => {
       positionDegrees = await getPositionDegrees();
     }
   } catch (error) {
-    displayError(error);
+    displayError(error as ServiceError);
   }
 
   cancelPoll = scheduleAsyncPoll(refresh, 500);
@@ -110,12 +110,12 @@ onMounted(async () => {
 
     cancelPoll = scheduleAsyncPoll(refresh, 500);
   } catch (error) {
-    if (error.message === 'Response closed without headers') {
+    if ((error as ServiceError).message === 'Response closed without headers') {
       cancelPoll = scheduleAsyncPoll(refresh, 500);
       return;
     }
 
-    displayError(error);
+    displayError(error as ServiceError);
   }
 
   props.statusStream?.on('end', () => cancelPoll?.());

--- a/web/frontend/src/components/encoder.vue
+++ b/web/frontend/src/components/encoder.vue
@@ -30,7 +30,6 @@ const getProperties = () => new Promise<encoderApi.GetPropertiesResponse.AsObjec
     }
 
     resolve(response!.toObject());
-    properties = response!.toObject();
   });
 });
 

--- a/web/frontend/src/components/encoder.vue
+++ b/web/frontend/src/components/encoder.vue
@@ -24,35 +24,27 @@ const getProperties = () => new Promise<encoderApi.GetPropertiesResponse.AsObjec
   request.setName(props.name);
 
   rcLogConditionally(request);
-  props.client.encoderService.getProperties(
-    request,
-    new grpc.Metadata(),
-    (error: ServiceError | null, response: encoderApi.GetPropertiesResponse | null) => {
-      if (error) {
-        return reject((error as ServiceError).message);
-      }
-
-      resolve(response!.toObject());
-      properties = response!.toObject();
+  props.client.encoderService.getProperties(request, new grpc.Metadata(), (error, response) => {
+    if (error) {
+      return reject((error as ServiceError).message);
     }
-  );
+
+    resolve(response!.toObject());
+    properties = response!.toObject();
+  });
 });
 
 const getPosition = () => new Promise<number>((resolve, reject) => {
   const request = new encoderApi.GetPositionRequest();
   request.setName(props.name);
   rcLogConditionally(request);
-  props.client.encoderService.getPosition(
-    request,
-    new grpc.Metadata(),
-    (error: ServiceError | null, resp: encoderApi.GetPositionResponse | null) => {
-      if (error) {
-        return reject(new Error((error as ServiceError).message));
-      }
-
-      resolve(resp!.toObject().value);
+  props.client.encoderService.getPosition(request, new grpc.Metadata(), (error, resp) => {
+    if (error) {
+      return reject(new Error((error as ServiceError).message));
     }
-  );
+
+    resolve(resp!.toObject().value);
+  });
 });
 
 const getPositionDegrees = () => new Promise<number>((resolve, reject) => {
@@ -60,17 +52,13 @@ const getPositionDegrees = () => new Promise<number>((resolve, reject) => {
   request.setPositionType(2);
   rcLogConditionally(request);
 
-  props.client.encoderService.getPosition(
-    request,
-    new grpc.Metadata(),
-    (error: ServiceError | null, resp: encoderApi.GetPositionResponse | null) => {
-      if (error) {
-        return reject(new Error((error as ServiceError).message));
-      }
-
-      resolve(resp!.toObject().value);
+  props.client.encoderService.getPosition(request, new grpc.Metadata(), (error, resp) => {
+    if (error) {
+      return reject(new Error((error as ServiceError).message));
     }
-  );
+
+    resolve(resp!.toObject().value);
+  });
 });
 
 const refresh = async () => {
@@ -88,20 +76,16 @@ const refresh = async () => {
 };
 
 const reset = () => {
-  const req = new encoderApi.ResetPositionRequest();
-  req.setName(props.name);
+  const request = new encoderApi.ResetPositionRequest();
+  request.setName(props.name);
 
-  rcLogConditionally(req);
+  rcLogConditionally(request);
 
-  props.client.encoderService.resetPosition(
-    req,
-    new grpc.Metadata(),
-    (error: ServiceError | null) => {
-      if (error) {
-        return displayError(error as ServiceError);
-      }
+  props.client.encoderService.resetPosition(request, new grpc.Metadata(), (error) => {
+    if (error) {
+      return displayError(error as ServiceError);
     }
-  );
+  });
 };
 
 onMounted(async () => {

--- a/web/frontend/src/components/encoder.vue
+++ b/web/frontend/src/components/encoder.vue
@@ -36,7 +36,7 @@ const getProperties = () => new Promise<encoderApi.GetPropertiesResponse.AsObjec
       properties = response!.toObject();
     }
   );
-})
+});
 
 const getPosition = () => new Promise<number>((resolve, reject) => {
   const request = new encoderApi.GetPositionRequest();

--- a/web/frontend/src/lib/schedule.ts
+++ b/web/frontend/src/lib/schedule.ts
@@ -1,0 +1,28 @@
+export const scheduleAsyncPoll = (callback: () => Promise<void>, interval: number) => {
+  let cancelled = false;
+  let timeoutId = -1;
+
+  const refreshAndScheduleNext = async () => {
+    await callback();
+
+    // eslint-disable-next-line no-use-before-define
+    scheduleNext();
+  };
+
+  const scheduleNext = () => {
+    if (cancelled) {
+      return;
+    }
+
+    timeoutId = window.setTimeout(refreshAndScheduleNext, interval);
+  };
+
+  const cancel = () => {
+    cancelled = true;
+    window.clearTimeout(timeoutId);
+  };
+
+  scheduleNext();
+
+  return cancel;
+};


### PR DESCRIPTION
This PR introduces a new util, `scheduleAsyncPoll`, which schedules a clearable timeout for an async polling function. It also introduces better practices for polling in the Encoder card:

* If a polling function is async, wait for it to entirely execute before scheduling the next poll
* Polling functions should listen for disconnection events and clear timeouts for future polls if a disconnect occurs, and resume once reconnection occurs

I'll update other components in a follow-up PR. 