### PR TITLE
RSDK-2959 - SLAM UI does not resize well

### DIFF
--- a/web/frontend/src/components/slam-2d-render.vue
+++ b/web/frontend/src/components/slam-2d-render.vue
@@ -115,7 +115,6 @@ raycaster.on('click', (event: THREE.Event) => {
  * svgLoader example for webgl:
  * https://github.com/mrdoob/three.js/blob/master/examples/webgl_loader_svg.html
  */
-//
 const svgLoader = new SVGLoader();
 const makeMarker = async (url : string, name: string, scalar: number) => {
   const data = await svgLoader.loadAsync(url);
@@ -411,7 +410,7 @@ watch(() => props.pointCloudUpdateCount, () => {
 <template>
   <div
     ref="container"
-    class="pcd-container relative w-full"
+    class="relative w-full"
   >
     <p class="absolute left-3 top-3 bg-white text-xs">
       Grid set to 1 meter

--- a/web/frontend/src/components/slam.vue
+++ b/web/frontend/src/components/slam.vue
@@ -508,7 +508,7 @@ onUnmounted(() => {
           />
         </div>
       </div>
-      <div class="gap-4x border-border-1 justify-start sm:border-l">
+      <div class="gap-4x border-border-1 w-full justify-start sm:border-l">
         <div
           v-if="refreshErrorMessage2d && show2d"
           class="border-l-4 border-red-500 bg-gray-100 px-4 py-3"


### PR DESCRIPTION
This PR makes it such that the 2D view of the slam map occupies the entirety of the screen on a larger monitor.

screen recording 5.4.23
![slamui](https://user-images.githubusercontent.com/46872531/236254780-e1973ffe-1ed3-44ec-9ba5-78735cac0e0d.gif)

