### PR TITLE
[RSDK-2684] Reconfigure interrupts properly on genericlinux boards

### DIFF
--- a/components/board/digital_interrupts.go
+++ b/components/board/digital_interrupts.go
@@ -63,7 +63,7 @@ type ReconfigurableDigitalInterrupt interface {
 
 // CreateDigitalInterrupt is a factory method for creating a specific DigitalInterrupt based
 // on the given config. If no type is specified, a BasicDigitalInterrupt is returned.
-func CreateDigitalInterrupt(cfg DigitalInterruptConfig) (DigitalInterrupt, error) {
+func CreateDigitalInterrupt(cfg DigitalInterruptConfig) (ReconfigurableDigitalInterrupt, error) {
 	if cfg.Type == "" {
 		cfg.Type = "basic"
 	}

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -253,6 +253,7 @@ func (b *sysfsBoard) reconfigureInterrupts(newConf *Config) error {
 				                oldInterrupt.config.Pin)
 			}
 		} else {
+			// TODO: reconfigure the interrupt
 			newInterrupts[newConfig.Name] = oldInterrupt
 			if err := oldInterrupt.interrupt.Reconfigure(*newConfig); err != nil {
 				return err
@@ -264,7 +265,10 @@ func (b *sysfsBoard) reconfigureInterrupts(newConf *Config) error {
 	// Add any new interrupts that should be freshly made.
 	for _, config := range newConf.DigitalInterrupts {
 		if _, ok := b.interrupts[config.Name]; !ok {
-			// TODO: remove GPIO pins
+			if oldPin, ok := b.gpios[config.Pin]; ok {
+				oldPin.Close()
+				delete(b.gpios, config.Pin)
+			}
 			if interrupt, err := b.createDigitalInterrupt(b.cancelCtx, config, b.gpioMappings); err != nil {
 				return err
 			} else {

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -211,7 +211,9 @@ func (b *sysfsBoard) reconfigureAnalogs(ctx context.Context, newConf *Config) er
 
 // This helper function is used while reconfiguring digital interrupts. It finds the new config (if
 // any) for a pre-existing digital interrupt.
-func findNewDigIntConfig(interrupt *digitalInterrupt, newConf *Config, logger golog.Logger) *board.DigitalInterruptConfig {
+func findNewDigIntConfig(
+	interrupt *digitalInterrupt, newConf *Config, logger golog.Logger,
+) *board.DigitalInterruptConfig {
 	for _, newConfig := range newConf.DigitalInterrupts {
 		if newConfig.Pin == interrupt.config.Pin {
 			return &newConfig
@@ -229,8 +231,8 @@ func findNewDigIntConfig(interrupt *digitalInterrupt, newConf *Config, logger go
 			}
 		}
 		logger.Debugf(
-			"Keeping digital interrupt on pin %s even though it's not explicitly mentioned " +
-			"in the new board config",
+			"Keeping digital interrupt on pin %s even though it's not explicitly mentioned "+
+				"in the new board config",
 			interrupt.config.Pin)
 		return interrupt.config
 	}
@@ -264,7 +266,7 @@ func (b *sysfsBoard) reconfigureInterrupts(newConf *Config) error {
 				}
 			} else {
 				b.logger.Warnf("Unable to reinterpret old interrupt pin '%s' as GPIO, ignoring.",
-				               oldInterrupt.config.Pin)
+					oldInterrupt.config.Pin)
 			}
 		} else { // The old interrupt should stick around.
 			if err := oldInterrupt.interrupt.Reconfigure(*newConfig); err != nil {

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -268,16 +268,18 @@ func (b *sysfsBoard) reconfigureInterrupts(newConf *Config) error {
 
 	// Add any new interrupts that should be freshly made.
 	for _, config := range newConf.DigitalInterrupts {
-		if _, ok := b.interrupts[config.Name]; !ok {
-			if oldPin, ok := b.gpios[config.Pin]; ok {
-				oldPin.Close()
-				delete(b.gpios, config.Pin)
-			}
-			if interrupt, err := b.createDigitalInterrupt(b.cancelCtx, config, b.gpioMappings); err != nil {
-				return err
-			} else {
-				b.interrupts[config.Name] = interrupt
-			}
+		if _, ok := b.interrupts[config.Name]; ok {
+			continue // Already initialized; keep going
+		}
+
+		if oldPin, ok := b.gpios[config.Pin]; ok {
+			oldPin.Close()
+			delete(b.gpios, config.Pin)
+		}
+		if interrupt, err := b.createDigitalInterrupt(b.cancelCtx, config, b.gpioMappings); err != nil {
+			return err
+		} else {
+			b.interrupts[config.Name] = interrupt
 		}
 	}
 

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -103,7 +103,7 @@ func (b *sysfsBoard) Reconfigure(
 		return err
 	}
 
-	if err := b.reconfigureGpios(newConf); err != nil {
+	if err := b.reconfigureInterrupts(newConf); err != nil {
 		return err
 	}
 
@@ -205,7 +205,7 @@ func (b *sysfsBoard) reconfigureAnalogs(ctx context.Context, newConf *Config) er
 	return nil
 }
 
-func (b *sysfsBoard) reconfigureGpios(newConf *Config) error {
+func (b *sysfsBoard) reconfigureInterrupts(newConf *Config) error {
 	if b.usePeriphGpio {
 		if len(newConf.DigitalInterrupts) != 0 {
 			return errors.New("digital interrupts on Periph GPIO pins are not yet supported")
@@ -255,7 +255,7 @@ func (b *sysfsBoard) reconfigureGpios(newConf *Config) error {
 
 	// Reuse any old GPIO pins that should stick around, too.
 	for pin, oldGpio := range b.gpios {
-		// TODO
+		if newConfig, ok := newConf.
 	}
 
 	// Add any new interrupts that should be freshly made.

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -298,11 +298,12 @@ func (b *sysfsBoard) reconfigureInterrupts(newConf *Config) error {
 			}
 			delete(b.gpios, config.Pin)
 		}
-		if interrupt, err := b.createDigitalInterrupt(b.cancelCtx, config, b.gpioMappings); err != nil {
+
+		interrupt, err := b.createDigitalInterrupt(b.cancelCtx, config, b.gpioMappings)
+		if err != nil {
 			return err
-		} else {
-			b.interrupts[config.Name] = interrupt
 		}
+		b.interrupts[config.Name] = interrupt
 	}
 
 	return nil

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -231,8 +231,15 @@ func (b *sysfsBoard) reconfigureInterrupts(newConf *Config) error {
 		}
 		if interrupt.config.Name == interrupt.config.Pin {
 			// This interrupt is named identically to its pin. It was probably created on the fly
-			// by some other component (an encoder?). Keep it initialized as-is, even though it's
-			// not explicitly mentioned in the config, because it's probably still in-use.
+			// by some other component (an encoder?). Unless there's now some other config with the
+			// same name but on a different pin, keep it initialized as-is.
+			for _, intConfig := range newConf.DigitalInterrupts {
+				if intConfig.Name == interrupt.config.Name {
+					// The name of this interrupt is defined in the new config, but on a different
+					// pin. This interrupt should be closed.
+					return nil
+				}
+			}
 			b.logger.Debugf(
 				"Keeping digital interrupt on pin %s even though it's not explicitly mentioned " +
 				"in the new board config",

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -72,6 +72,10 @@ func newBoard(
 		interrupts: map[string]*digitalInterrupt{},
 	}
 
+	for pinNumber, mapping := range gpioMappings {
+		b.gpios[fmt.Sprintf("%d", pinNumber)] = b.createGpioPin(mapping)
+	}
+
 	if err := b.Reconfigure(ctx, nil, conf); err != nil {
 		return nil, err
 	}

--- a/components/board/genericlinux/digital_interrupts.go
+++ b/components/board/genericlinux/digital_interrupts.go
@@ -22,6 +22,7 @@ type digitalInterrupt struct {
 	line        *gpio.LineWithEvent
 	cancelCtx   context.Context
 	cancelFunc  func()
+	config      *board.DigitalInterruptConfig
 }
 
 func (b *sysfsBoard) createDigitalInterrupt(
@@ -62,6 +63,7 @@ func (b *sysfsBoard) createDigitalInterrupt(
 		line:        line,
 		cancelCtx:   cancelCtx,
 		cancelFunc:  cancelFunc,
+		config:      &config,
 	}
 	result.startMonitor()
 	return &result, nil

--- a/components/board/genericlinux/digital_interrupts.go
+++ b/components/board/genericlinux/digital_interrupts.go
@@ -63,7 +63,9 @@ func (b *sysfsBoard) createDigitalInterrupt(
 		}
 	} else {
 		interrupt = oldCallbackHolder
-		interrupt.Reconfigure(config)
+		if err := interrupt.Reconfigure(config); err != nil {
+			return nil, err // Should never have errors, but this makes the linter happy
+		}
 	}
 
 	cancelCtx, cancelFunc := context.WithCancel(ctx)

--- a/components/board/genericlinux/digital_interrupts.go
+++ b/components/board/genericlinux/digital_interrupts.go
@@ -18,7 +18,7 @@ import (
 
 type digitalInterrupt struct {
 	parentBoard *sysfsBoard
-	interrupt   board.DigitalInterrupt
+	interrupt   board.ReconfigurableDigitalInterrupt
 	line        *gpio.LineWithEvent
 	cancelCtx   context.Context
 	cancelFunc  func()

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -311,17 +311,21 @@ func (b *sysfsBoard) gpioInitialize(cancelCtx context.Context, gpioMappings map[
 				pinNumber)
 			continue
 		}
-		pin := &gpioPin{
-			parentBoard: b,
-			devicePath:  mapping.GPIOChipDev,
-			offset:      uint32(mapping.GPIO),
-			cancelCtx:   cancelCtx,
-			logger:      logger,
-		}
-		if mapping.HWPWMSupported {
-			pin.hwPwm = newPwmDevice(mapping.PWMSysFsDir, mapping.PWMID, logger)
-		}
-		pins[fmt.Sprintf("%d", pinNumber)] = pin
+		pins[fmt.Sprintf("%d", pinNumber)] = b.createGpioPin(mapping)
 	}
 	return pins, interrupts, nil
+}
+
+func (b *sysfsBoard) createGpioPin(mapping GPIOBoardMapping) *gpioPin {
+	pin := gpioPin{
+		parentBoard: b,
+		devicePath:  mapping.GPIOChipDev,
+		offset:      uint32(mapping.GPIO),
+		cancelCtx:   b.cancelCtx,
+		logger:      b.logger,
+	}
+	if mapping.HWPWMSupported {
+		pin.hwPwm = newPwmDevice(mapping.PWMSysFsDir, mapping.PWMID, b.logger)
+	}
+	return &pin
 }

--- a/components/sensor/ultrasonic/ultrasonic.go
+++ b/components/sensor/ultrasonic/ultrasonic.go
@@ -92,12 +92,12 @@ func newSensor(ctx context.Context, deps resource.Dependencies, name resource.Na
 	s.ticksChan = make(chan board.Tick, 2)
 
 	// Set the trigger pin to low, so it's ready for later.
-	if triggerPin, err := b.GPIOPinByName(config.TriggerPin); err != nil {
+	triggerPin, err := b.GPIOPinByName(config.TriggerPin)
+	if err != nil {
 		return nil, errors.Wrapf(err, "ultrasonic: cannot grab gpio %q", config.TriggerPin)
-	} else {
-		if err := triggerPin.Set(ctx, false, nil); err != nil {
-			return nil, errors.Wrap(err, "ultrasonic: cannot set trigger pin to low")
-		}
+	}
+	if err := triggerPin.Set(ctx, false, nil); err != nil {
+		return nil, errors.Wrap(err, "ultrasonic: cannot set trigger pin to low")
 	}
 
 	return s, nil

--- a/components/sensor/ultrasonic/ultrasonic.go
+++ b/components/sensor/ultrasonic/ultrasonic.go
@@ -107,13 +107,13 @@ func newSensor(ctx context.Context, deps resource.Dependencies, name resource.Na
 type Sensor struct {
 	resource.Named
 	resource.AlwaysRebuild
-	mu            sync.Mutex
-	config        *Config
-	board         board.Board
-	ticksChan     chan board.Tick
-	timeoutMs     uint
-	cancelCtx     context.Context
-	cancelFunc    func()
+	mu         sync.Mutex
+	config     *Config
+	board      board.Board
+	ticksChan  chan board.Tick
+	timeoutMs  uint
+	cancelCtx  context.Context
+	cancelFunc func()
 }
 
 func (s *Sensor) namedError(err error) error {


### PR DESCRIPTION
Tried on the Orin on my desk with an ultrasonic sensor plugged in. Works great! (see below for what I used to test it)

Major changes include:
- `CreateDigitalInterrupt` returns a `ReconfigurableDigitalInterrupt` instead of a `DigitalInterrupt`. It's always returned that underlying data structure, but now it's more explicit about it.
- Renamed `sysfsBoard.reconfigureGpios` to `sysfsBoard.reconfigureInterrupts`. The interrupts have the interesting reconfiguration, and the GPIOs are just along for the ride (they're never even mentioned in the user-defined config, so they never reconfigure unless they turn into/back from interrupt pins).
- The ultrasonic sensor grabs its pins from the board every time it wants to use them, rather than grabbing them once on initialization and assuming the board will never reconfigure itself and change pins. :smiling_imp: This was a fun bug to discover.
- The `sysfsBoard.gpioInitialize` function, which had done a zillion things, has been simplified into a mere `sysfsBoard.createGpioPin`, and the extra functionality has been moved to `sysfsBoard.reconfigureInterrupts`.
- When a board is reconfigured, any pins that used to be and still are interrupts get reconfigured and reused. Any pins that used to be but no longer are interrupts get turned back into GPIO (unless they look like they were implicitly created, in which case they stay as interrupts!). Any pins that did not used to be interrupts but now are get transformed from GPIO pins to interrupts.

Things I have tried that work:
- Make a board with an interrupt pin. Change some other part of the board's config, and make sure the interrupt pin is unchanged.
- Make a board with an interrupt pin. Then rename the pin, and make sure the hardware is unchanged (never closed, still works with the new name)
- Implicitly create an interrupt pin in the ultrasonic sensor's config. Then change the board to explicitly define that same pin with a different name. The new pin name should work.
- Implicitly create an interrupt pin in the ultrasonic sensor's config. Then change the board to explicitly define a _different_ pin with that same name. The new pin should work.
- Implicitly create an interrupt pin in the ultrasonic sensor's config. Change the board in some unrelated way. The ultrasonic sensor should still work.
- Make a board with an interrupt pin. Change the board to no longer define the interrupt. That pin should now be GPIO.
- Define 2 named interrupts in a board config, and make an encoded motor whose encoder uses those names. Turn the motor to some non-zero position, then change the board's config to have different pin numbers (without changing the names or the encoder's config). Plug the encoder into the new pins, and make sure the position is still nonzero and the encoder still works.

This fixes a bunch of different Jira tickets, in addition to the one in the title:
- RSDK-2684 (reconfiguring a board should not delete implicitly defined interrupt pins)
- RSDK-2683 (reconfiguring a board should close interrupts that are no longer defined)
- I was sure there were more, but can't find them right now. Will add more later...