### PR TITLE
RSDK-2933 - add warning if API not registered

### DIFF
--- a/examples/customresources/demos/complexmodule/module.go
+++ b/examples/customresources/demos/complexmodule/module.go
@@ -32,10 +32,22 @@ func mainWithArgs(ctx context.Context, args []string, logger golog.Logger) (err 
 
 	// Models and APIs add helpers to the registry during their init().
 	// They can then be added to the module here.
-	myMod.AddModelFromRegistry(ctx, gizmoapi.API, mygizmo.Model)
-	myMod.AddModelFromRegistry(ctx, summationapi.API, mysum.Model)
-	myMod.AddModelFromRegistry(ctx, base.API, mybase.Model)
-	myMod.AddModelFromRegistry(ctx, navigation.API, mynavigation.Model)
+	err = myMod.AddModelFromRegistry(ctx, gizmoapi.API, mygizmo.Model)
+	if err != nil {
+		return err
+	}
+	err = myMod.AddModelFromRegistry(ctx, summationapi.API, mysum.Model)
+	if err != nil {
+		return err
+	}
+	err = myMod.AddModelFromRegistry(ctx, base.API, mybase.Model)
+	if err != nil {
+		return err
+	}
+	err = myMod.AddModelFromRegistry(ctx, navigation.API, mynavigation.Model)
+	if err != nil {
+		return err
+	}
 
 	err = myMod.Start(ctx)
 	defer myMod.Close(ctx)

--- a/examples/customresources/demos/simplemodule/module.go
+++ b/examples/customresources/demos/simplemodule/module.go
@@ -36,7 +36,10 @@ func mainWithArgs(ctx context.Context, args []string, logger golog.Logger) error
 	resource.RegisterComponent(generic.API, myModel, resource.Registration[resource.Resource, resource.NoNativeConfig]{
 		Constructor: newCounter,
 	})
-	myMod.AddModelFromRegistry(ctx, generic.API, myModel)
+	err = myMod.AddModelFromRegistry(ctx, generic.API, myModel)
+	if err != nil {
+		return err
+	}
 
 	// The module is started.
 	err = myMod.Start(ctx)

--- a/module/module.go
+++ b/module/module.go
@@ -439,7 +439,7 @@ func (m *Module) addAPIFromRegistry(ctx context.Context, api resource.API) error
 
 	apiInfo, ok := resource.LookupGenericAPIRegistration(api)
 	if !ok {
-		return errors.Errorf("invariant: resource subtype does not exist for %q", api)
+		return errors.Errorf("invariant: registration does not exist for %q", api)
 	}
 
 	newColl := apiInfo.MakeEmptyCollection()
@@ -469,7 +469,7 @@ func (m *Module) AddModelFromRegistry(ctx context.Context, api resource.API, mod
 
 	apiInfo, ok := resource.LookupGenericAPIRegistration(api)
 	if !ok {
-		return errors.Errorf("invariant: resource subtype does not exist for %q", api)
+		return errors.Errorf("invariant: registration does not exist for %q", api)
 	}
 	if apiInfo.ReflectRPCServiceDesc == nil {
 		m.logger.Errorf("rpc subtype %s doesn't contain a valid ReflectRPCServiceDesc", api)

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -430,9 +430,9 @@ func newWithResources(
 	// specified modules.
 	r.manager.startModuleManager(r.webSvc.ModuleAddress(), cfg.UntrustedEnv, logger)
 	for _, mod := range cfg.Modules {
-		err := r.manager.moduleManager.Add(ctx, mod)
-		if err != nil {
-			return nil, err
+		if err := r.manager.moduleManager.Add(ctx, mod); err != nil {
+			r.logger.Errorw("error adding module", "module", mod.Name, "error", err)
+			continue
 		}
 	}
 


### PR DESCRIPTION
had a similar bug in Python SDK, this just gives users a better idea of what might be wrong if they try to add a new API with their modular resource and forgot to register something.

also updated the examples to actually return the error - it's a bit more verbose but would help users debug if they run into issues

also allows modules to fail to start up

empty resource collection is not needed - was able to run the modular resources examples just fine with it gone.