### PR TITLE
RSDK-2696 Add Skeleton Code for Replay Camera

### DIFF
--- a/components/camera/register/register.go
+++ b/components/camera/register/register.go
@@ -6,6 +6,7 @@ import (
 	_ "go.viam.com/rdk/components/camera/align"
 	_ "go.viam.com/rdk/components/camera/fake"
 	_ "go.viam.com/rdk/components/camera/ffmpeg"
+	_ "go.viam.com/rdk/components/camera/replaypcd"
 	_ "go.viam.com/rdk/components/camera/rtsp"
 	_ "go.viam.com/rdk/components/camera/transformpipeline"
 	_ "go.viam.com/rdk/components/camera/velodyne"

--- a/components/camera/replaypcd/replaypcd.go
+++ b/components/camera/replaypcd/replaypcd.go
@@ -8,6 +8,7 @@ import (
 	"github.com/edaniels/golog"
 	"github.com/edaniels/gostream"
 	"github.com/pkg/errors"
+
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/resource"

--- a/components/camera/replaypcd/replaypcd.go
+++ b/components/camera/replaypcd/replaypcd.go
@@ -1,0 +1,100 @@
+// Package replaypcd implements a replay camera that can return point cloud data.
+package replaypcd
+
+import (
+	"context"
+	"time"
+
+	"github.com/edaniels/golog"
+	"github.com/edaniels/gostream"
+	"github.com/pkg/errors"
+	"go.viam.com/rdk/components/camera"
+	"go.viam.com/rdk/pointcloud"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/rimage/transform"
+)
+
+// Model is the model of a replay camera.
+var model = resource.DefaultModelFamily.WithModel("replaypcd")
+
+func init() {
+	resource.RegisterComponent(camera.API, model, resource.Registration[camera.Camera, *Config]{
+		Constructor: newReplayPCDCamera,
+	})
+}
+
+// Config describes how to configure the replay camera component.
+type Config struct {
+	Source   resource.Name `json:"source,omitempty"`
+	RobotID  string        `json:"robot_id,omitempty"`
+	Interval TimeInterval  `json:"time_interval,omitempty"`
+}
+
+// TimeInterval holds the start and end time used to filter data.
+type TimeInterval struct {
+	Start time.Time `json:"start,omitempty"`
+	End   time.Time `json:"end,omitempty"`
+}
+
+// Validate checks that the config attributes are valid for a replay camera.
+func (c *Config) Validate(path string) ([]string, error) {
+	return nil, nil
+}
+
+// newReplayCamera creates a new replay camera based on the inputted config and dependencies.
+func newReplayPCDCamera(ctx context.Context, deps resource.Dependencies, cfg resource.Config, logger golog.Logger) (camera.Camera, error) {
+	cam := &pcdCamera{
+		logger: logger,
+	}
+	// TODO: Add start protocol for replay camera https://viam.atlassian.net/browse/RSDK-2893
+	return cam, nil
+}
+
+// pcdCamera is a camera model that plays back pre-captured point cloud data.
+type pcdCamera struct {
+	logger golog.Logger
+}
+
+// NextPointCloud is part of the camera interface but is not implemented for replay.
+func (replay *pcdCamera) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, error) {
+	var pc pointcloud.PointCloud
+	return pc, errors.New("NextPointCloud is unimplemented")
+}
+
+// Properties is a part of the camera interface but is not implemented for replay.
+func (replay *pcdCamera) Properties(ctx context.Context) (camera.Properties, error) {
+	var props camera.Properties
+	return props, errors.New("Properties is unimplemented")
+}
+
+// Projector is a part of the camera interface but is not implemented for replay.
+func (replay *pcdCamera) Projector(ctx context.Context) (transform.Projector, error) {
+	var proj transform.Projector
+	return proj, errors.New("Projector is unimplemented")
+}
+
+// Stream is a part of the camera interface but is not implemented for replay.
+func (replay *pcdCamera) Stream(ctx context.Context, errHandlers ...gostream.ErrorHandler) (gostream.VideoStream, error) {
+	var stream gostream.VideoStream
+	return stream, errors.New("Stream is unimplemented")
+}
+
+// Close stops replay camera but is not implemented for replay.
+func (replay *pcdCamera) Close(ctx context.Context) error {
+	return errors.New("Close is unimplemented")
+}
+
+// DoCommand is a generic function but is not implemented for replay.
+func (replay *pcdCamera) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+	return nil, resource.ErrDoUnimplemented
+}
+
+// Name returns the name of a replay camera but is not implemented for replay.
+func (replay *pcdCamera) Name() resource.Name {
+	return resource.Name{}
+}
+
+// Reconfigure will bring up a replay camera using the new config but is not implemented for replay.
+func (replay *pcdCamera) Reconfigure(ctx context.Context, _ resource.Dependencies, cfg resource.Config) error {
+	return errors.New("Reconfigure is unimplemented")
+}

--- a/components/camera/replaypcd/replaypcd.go
+++ b/components/camera/replaypcd/replaypcd.go
@@ -20,7 +20,7 @@ var model = resource.DefaultModelFamily.WithModel("replaypcd")
 
 func init() {
 	resource.RegisterComponent(camera.API, model, resource.Registration[camera.Camera, *Config]{
-		Constructor: newReplayPCDCamera,
+		Constructor: newPCDCamera,
 	})
 }
 
@@ -48,8 +48,8 @@ type pcdCamera struct {
 	logger golog.Logger
 }
 
-// newReplayCamera creates a new replay camera based on the inputted config and dependencies.
-func newReplayPCDCamera(ctx context.Context, deps resource.Dependencies, cfg resource.Config, logger golog.Logger) (camera.Camera, error) {
+// newPCDCamera creates a new replay camera based on the inputted config and dependencies.
+func newPCDCamera(ctx context.Context, deps resource.Dependencies, cfg resource.Config, logger golog.Logger) (camera.Camera, error) {
 	cam := &pcdCamera{
 		logger: logger,
 	}

--- a/components/camera/replaypcd/replaypcd.go
+++ b/components/camera/replaypcd/replaypcd.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Model is the model of a replay camera.
-var model = resource.DefaultModelFamily.WithModel("replaypcd")
+var model = resource.DefaultModelFamily.WithModel("replay_pcd")
 
 func init() {
 	resource.RegisterComponent(camera.API, model, resource.Registration[camera.Camera, *Config]{

--- a/components/camera/replaypcd/replaypcd.go
+++ b/components/camera/replaypcd/replaypcd.go
@@ -41,6 +41,12 @@ func (c *Config) Validate(path string) ([]string, error) {
 	return nil, nil
 }
 
+// pcdCamera is a camera model that plays back pre-captured point cloud data.
+type pcdCamera struct {
+	resource.Named
+	logger golog.Logger
+}
+
 // newReplayCamera creates a new replay camera based on the inputted config and dependencies.
 func newReplayPCDCamera(ctx context.Context, deps resource.Dependencies, cfg resource.Config, logger golog.Logger) (camera.Camera, error) {
 	cam := &pcdCamera{
@@ -48,11 +54,6 @@ func newReplayPCDCamera(ctx context.Context, deps resource.Dependencies, cfg res
 	}
 	// TODO: Add start protocol for replay camera https://viam.atlassian.net/browse/RSDK-2893
 	return cam, nil
-}
-
-// pcdCamera is a camera model that plays back pre-captured point cloud data.
-type pcdCamera struct {
-	logger golog.Logger
 }
 
 // NextPointCloud is part of the camera interface but is not implemented for replay.
@@ -82,16 +83,6 @@ func (replay *pcdCamera) Stream(ctx context.Context, errHandlers ...gostream.Err
 // Close stops replay camera but is not implemented for replay.
 func (replay *pcdCamera) Close(ctx context.Context) error {
 	return errors.New("Close is unimplemented")
-}
-
-// DoCommand is a generic function but is not implemented for replay.
-func (replay *pcdCamera) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
-	return nil, resource.ErrDoUnimplemented
-}
-
-// Name returns the name of a replay camera but is not implemented for replay.
-func (replay *pcdCamera) Name() resource.Name {
-	return resource.Name{}
 }
 
 // Reconfigure will bring up a replay camera using the new config but is not implemented for replay.

--- a/components/camera/replaypcd/replaypcd_test.go
+++ b/components/camera/replaypcd/replaypcd_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 
 	"github.com/edaniels/golog"
-	"go.viam.com/rdk/resource"
 	"go.viam.com/test"
+
+	"go.viam.com/rdk/resource"
 )
 
 func TestNewReplayCamera(t *testing.T) {

--- a/components/camera/replaypcd/replaypcd_test.go
+++ b/components/camera/replaypcd/replaypcd_test.go
@@ -1,4 +1,3 @@
-// Package replay_test will test the  functions of a replay camera.
 package replaypcd
 
 import (
@@ -11,31 +10,31 @@ import (
 	"go.viam.com/rdk/resource"
 )
 
-func TestNewReplayCamera(t *testing.T) {
+func TestPCDCameraUnimplemented(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	ctx := context.Background()
 
 	cfg := resource.Config{}
 
-	replayCamera, err := newReplayPCDCamera(ctx, nil, cfg, logger)
+	replayCamera, err := newPCDCamera(ctx, nil, cfg, logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	t.Run("Test NextPointCloud", func(t *testing.T) {
+	t.Run("NextPointCloud", func(t *testing.T) {
 		_, err := replayCamera.NextPointCloud(ctx)
 		test.That(t, err.Error(), test.ShouldEqual, "NextPointCloud is unimplemented")
 	})
 
-	t.Run("Test Stream", func(t *testing.T) {
+	t.Run("Stream", func(t *testing.T) {
 		_, err := replayCamera.Stream(ctx, nil)
 		test.That(t, err.Error(), test.ShouldEqual, "Stream is unimplemented")
 	})
 
-	t.Run("Test Properties", func(t *testing.T) {
+	t.Run("Properties", func(t *testing.T) {
 		_, err := replayCamera.Properties(ctx)
 		test.That(t, err.Error(), test.ShouldEqual, "Properties is unimplemented")
 	})
 
-	t.Run("Test Projector", func(t *testing.T) {
+	t.Run("Projector", func(t *testing.T) {
 		_, err := replayCamera.Projector(ctx)
 		test.That(t, err.Error(), test.ShouldEqual, "Projector is unimplemented")
 	})

--- a/components/camera/replaypcd/replaypcd_test.go
+++ b/components/camera/replaypcd/replaypcd_test.go
@@ -1,0 +1,44 @@
+// Package replay_test will test the  functions of a replay camera.
+package replaypcd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/edaniels/golog"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/test"
+)
+
+func TestNewReplayCamera(t *testing.T) {
+	logger := golog.NewTestLogger(t)
+	ctx := context.Background()
+
+	cfg := resource.Config{}
+
+	replayCamera, err := newReplayPCDCamera(ctx, nil, cfg, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	t.Run("Test NextPointCloud", func(t *testing.T) {
+		_, err := replayCamera.NextPointCloud(ctx)
+		test.That(t, err.Error(), test.ShouldEqual, "NextPointCloud is unimplemented")
+	})
+
+	t.Run("Test Stream", func(t *testing.T) {
+		_, err := replayCamera.Stream(ctx, nil)
+		test.That(t, err.Error(), test.ShouldEqual, "Stream is unimplemented")
+	})
+
+	t.Run("Test Properties", func(t *testing.T) {
+		_, err := replayCamera.Properties(ctx)
+		test.That(t, err.Error(), test.ShouldEqual, "Properties is unimplemented")
+	})
+
+	t.Run("Test Projector", func(t *testing.T) {
+		_, err := replayCamera.Projector(ctx)
+		test.That(t, err.Error(), test.ShouldEqual, "Projector is unimplemented")
+	})
+
+	err = replayCamera.Close(ctx)
+	test.That(t, err.Error(), test.ShouldEqual, "Close is unimplemented")
+}


### PR DESCRIPTION
This PR adds the skeleton code for an unimplemented replay camera with model: replaypcd.

Note: This code was previously in the replay module. Previous discussion can be found here (https://github.com/viamrobotics/replay/pull/3)

**Testing:** 
Module correctly loaded into rdk and outputted the correct error when NextPointCloud/Stream was called from the app:

**Config:**
```
  "components": [
    {
      "name": "replay",
      "namespace": "rdk",
      "attributes": {},
      "type": "camera",
      "depends_on": [],
      "model": "replay_pcd"
    }
  ]
}
```

**Test Results:**
<img width="1354" alt="Screen Shot 2023-05-04 at 12 42 26 PM" src="https://user-images.githubusercontent.com/34897732/236542774-a51cffaf-6e57-4c0e-8abe-7e786fd67473.png">
<img width="1384" alt="Screen Shot 2023-05-04 at 12 40 23 PM" src="https://user-images.githubusercontent.com/34897732/236542788-ecc797fc-f627-4d5b-aaaa-e959b3caa021.png">

**JIRA Ticket:** https://viam.atlassian.net/browse/RSDK-2696