### PR TITLE
RSDK-2958 Fix tests and races in robot/impl

### DIFF
--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -139,7 +139,6 @@ func (r *localRobot) Close(ctx context.Context) error {
 		if r.configTicker != nil {
 			r.configTicker.Stop()
 		}
-		close(r.triggerConfig)
 	}
 	r.activeBackgroundWorkers.Wait()
 

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -801,6 +801,10 @@ func TestStopAll(t *testing.T) {
 		]
 	}
 	`, model.String())
+	defer func() {
+		resource.Deregister(arm.API, model)
+	}()
+
 	cfg, err := config.FromReader(context.Background(), "", strings.NewReader(armConfig), logger)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -918,6 +922,11 @@ func TestNewTeardown(t *testing.T) {
 		) (gripper.Gripper, error) {
 			return nil, errors.New("whoops")
 		}})
+
+	defer func() {
+		resource.Deregister(board.API, model)
+		resource.Deregister(gripper.API, model)
+	}()
 
 	failingConfig := fmt.Sprintf(`{
     "components": [
@@ -1076,6 +1085,10 @@ func TestStatus(t *testing.T) {
 			Status: func(ctx context.Context, res resource.Resource) (interface{}, error) { return nil, errFailed },
 		},
 	)
+	defer func() {
+		resource.DeregisterAPI(workingAPI)
+		resource.DeregisterAPI(failAPI)
+	}()
 
 	statuses := []robot.Status{{Name: button1, Status: map[string]interface{}{}}}
 	logger := golog.NewTestLogger(t)

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -1570,6 +1570,9 @@ func TestManagerEmptyResourceDesc(t *testing.T) {
 		api,
 		resource.APIRegistration[resource.Resource]{},
 	)
+	defer func() {
+		resource.DeregisterAPI(api)
+	}()
 
 	injectRobot.ResourceNamesFunc = func() []resource.Name {
 		return []resource.Name{resource.NewName(api, "mock1")}
@@ -1603,6 +1606,9 @@ func TestReconfigure(t *testing.T) {
 	test.That(t, r, test.ShouldNotBeNil)
 
 	resource.RegisterAPI(api, resource.APIRegistration[resource.Resource]{})
+	defer func() {
+		resource.DeregisterAPI(api)
+	}()
 
 	resource.Register(api, resource.DefaultServiceModel, resource.Registration[resource.Resource, resource.NoNativeConfig]{
 		Constructor: func(
@@ -1616,6 +1622,9 @@ func TestReconfigure(t *testing.T) {
 			}, nil
 		},
 	})
+	defer func() {
+		resource.Deregister(api, resource.DefaultServiceModel)
+	}()
 
 	manager := managerForDummyRobot(r)
 	defer func() {
@@ -1672,6 +1681,9 @@ func TestResourceCreationPanic(t *testing.T) {
 				panic("hello")
 			},
 		})
+		defer func() {
+			resource.Deregister(api, model)
+		}()
 
 		svc1 := resource.Config{
 			Name:  "test",
@@ -1699,8 +1711,14 @@ func TestResourceCreationPanic(t *testing.T) {
 				panic("hello")
 			},
 		})
+		defer func() {
+			resource.Deregister(api, resource.DefaultServiceModel)
+		}()
 
 		resource.RegisterAPI(api, resource.APIRegistration[resource.Resource]{})
+		defer func() {
+			resource.DeregisterAPI(api)
+		}()
 
 		svc1 := resource.Config{
 			Name:  "",


### PR DESCRIPTION
Two parts to this. The first was simply avoiding a racey channel close. The rest is fixing up the tests themselves to avoid sleep-timing induced issues, and to allow -count > 1 (in order to catch rare races in the first place.)