### PR TITLE
RSDK-2960 - Fix order of execution for 2D slam ui when first loaded or refreshed

### DIFF
--- a/web/frontend/src/components/slam-2d-render.vue
+++ b/web/frontend/src/components/slam-2d-render.vue
@@ -195,8 +195,6 @@ const disposeScene = () => {
       }
     }
   });
-
-  scene.clear();
 };
 
 const updatePose = async (newPose: commonApi.Pose) => {
@@ -348,10 +346,16 @@ const updatePointCloud = (pointcloud: Uint8Array) => {
     axesNeg
   );
 
-  if (props.pose !== undefined) {
-    updatePose(props.pose!);
+  // re-add base and destination marker so they render on top of all other objects
+  const destinationMarker = scene.getObjectByName('DestinationMarker');
+  if (destinationMarker !== undefined) {
+    scene.add(destinationMarker);
   }
-  updateOrRemoveDestinationMarker();
+
+  const baseMarker = scene.getObjectByName('BaseMarker');
+  if (baseMarker !== undefined) {
+    scene.add(baseMarker);
+  }
 };
 
 onMounted(() => {


### PR DESCRIPTION
When we refresh it is always the case that we the watch method the pose is triggered before the watch method for pointclouds. Hence, we need to re-add the base/destination marker to ensure that it renders on top of the updated pointcloud.