### PR TITLE
[DATA-1268] Re-add arbitrary file upload test.

### DIFF
--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -530,7 +530,6 @@ func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 		}
 		// If a file was modified within the past lastModifiedMillis seconds, do not sync it (data
 		// may still be being written).
-		// TODO: ModTime doesn't use mock clock! How to get around...
 		timeSinceMod := clock.Since(info.ModTime())
 		if timeSinceMod < 0 {
 			timeSinceMod = 0

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -530,8 +530,12 @@ func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 		}
 		// If a file was modified within the past lastModifiedMillis seconds, do not sync it (data
 		// may still be being written).
-		timeSinceMod := time.Since(info.ModTime())
-		if timeSinceMod > (time.Duration(lastModifiedMillis)*time.Millisecond) || filepath.Ext(path) == datacapture.FileExt {
+		// TODO: ModTime doesn't use mock clock! How to get around...
+		timeSinceMod := clock.Since(info.ModTime())
+		if timeSinceMod < 0 {
+			timeSinceMod = 0
+		}
+		if timeSinceMod >= (time.Duration(lastModifiedMillis)*time.Millisecond) || filepath.Ext(path) == datacapture.FileExt {
 			filePaths = append(filePaths, path)
 		}
 		return nil


### PR DESCRIPTION
# Context
Re-adds this test that was removed when [this](https://github.com/viamrobotics/rdk/pull/2092) refactor to make tests deterministic/use signaling rather than timing happened.

# Testing
```
$ go test -race ./... -run TestArbitraryFileUpload --count=500
ok      go.viam.com/rdk/services/datamanager/builtin    14.224s
```