### PR TITLE
RSDK-2357 FIX: only log maxrpm warning when maxrpm > 0

### DIFF
--- a/components/motor/dimensionengineering/sabertooth.go
+++ b/components/motor/dimensionengineering/sabertooth.go
@@ -349,6 +349,7 @@ func (m *Motor) SetPower(ctx context.Context, powerPct float64, extra map[string
 		m.c.logger.Warn("motor speed is nearly 0 rev_per_min")
 	case m.maxRPM > 0 && speed > m.maxRPM-0.1:
 		m.c.logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.maxRPM)
+	default:
 	}
 	if math.Signbit(rawSpeed) {
 		rawSpeed *= -1

--- a/components/motor/dimensionengineering/sabertooth.go
+++ b/components/motor/dimensionengineering/sabertooth.go
@@ -238,6 +238,7 @@ func NewMotor(ctx context.Context, c *Config, name resource.Name, logger golog.L
 		dirFlip:     c.DirectionFlip,
 		minPowerPct: c.MinPowerPct,
 		maxPowerPct: c.MaxPowerPct,
+		maxRPM:      c.MaxRPM,
 	}
 
 	if err := m.configure(c); err != nil {

--- a/components/motor/dimensionengineering/sabertooth.go
+++ b/components/motor/dimensionengineering/sabertooth.go
@@ -345,9 +345,9 @@ func (m *Motor) SetPower(ctx context.Context, powerPct float64, extra map[string
 	rawSpeed := powerPct * maxSpeed
 	switch speed := math.Abs(rawSpeed); {
 	case speed < 0.1:
-		m.c.logger.Warnf("motor (%s) speed is nearly 0 rev_per_min", m.Name())
-	case speed > m.maxRPM-0.1:
-		m.c.logger.Warnf("motor (%s) speed is nearly the max rev_per_min (%f)", m.Name(), m.maxRPM)
+		m.c.logger.Warn("motor speed is nearly 0 rev_per_min")
+	case m.maxRPM > 0 && speed > m.maxRPM-0.1:
+		m.c.logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.maxRPM)
 	}
 	if math.Signbit(rawSpeed) {
 		rawSpeed *= -1

--- a/components/motor/dimensionengineering/sabertooth_test.go
+++ b/components/motor/dimensionengineering/sabertooth_test.go
@@ -40,6 +40,7 @@ func TestSabertoothMotor(t *testing.T) {
 		TestChan:      c,
 		SerialAddress: 128,
 		DirectionFlip: false,
+		MaxRPM:        1,
 	}
 
 	motorReg, ok := resource.LookupRegistration(motor.API, sabertoothModel)
@@ -102,6 +103,7 @@ func TestSabertoothMotor(t *testing.T) {
 		TestChan:      c,
 		SerialAddress: 128,
 		DirectionFlip: false,
+		MaxRPM:        1,
 	}
 
 	m2, err := motorReg.Constructor(context.Background(), deps, resource.Config{Name: "motor2", ConvertedAttributes: &mc2}, logger)
@@ -167,6 +169,7 @@ func TestSabertoothMotorDirectionFlip(t *testing.T) {
 		TestChan:      c,
 		SerialAddress: 128,
 		DirectionFlip: true,
+		MaxRPM:        1,
 	}
 
 	motorReg, ok := resource.LookupRegistration(motor.API, sabertoothModel)
@@ -222,6 +225,7 @@ func TestSabertoothMotorDirectionFlip(t *testing.T) {
 		TestChan:      c,
 		SerialAddress: 128,
 		DirectionFlip: true,
+		MaxRPM:        1,
 	}
 
 	m2, err := motorReg.Constructor(context.Background(), deps, resource.Config{Name: "motor2", ConvertedAttributes: &mc2}, logger)
@@ -286,6 +290,7 @@ func TestSabertoothRampConfig(t *testing.T) {
 		TestChan:      c,
 		SerialAddress: 128,
 		RampValue:     100,
+		MaxRPM:        1,
 	}
 
 	motorReg, ok := resource.LookupRegistration(motor.API, sabertoothModel)
@@ -318,6 +323,7 @@ func TestSabertoothAddressMapping(t *testing.T) {
 		MotorChannel:  1,
 		TestChan:      c,
 		SerialAddress: 129,
+		MaxRPM:        1,
 	}
 
 	motorReg, ok := resource.LookupRegistration(motor.API, sabertoothModel)
@@ -342,6 +348,7 @@ func TestInvalidMotorChannel(t *testing.T) {
 		MotorChannel:  3,
 		TestChan:      c,
 		SerialAddress: 129,
+		MaxRPM:        1,
 	}
 
 	motorReg, ok := resource.LookupRegistration(motor.API, sabertoothModel)
@@ -364,6 +371,7 @@ func TestInvalidBaudRate(t *testing.T) {
 		TestChan:      c,
 		SerialAddress: 129,
 		BaudRate:      1,
+		MaxRPM:        1,
 	}
 
 	motorReg, ok := resource.LookupRegistration(motor.API, sabertoothModel)
@@ -385,6 +393,7 @@ func TestInvalidSerialAddress(t *testing.T) {
 		MotorChannel:  1,
 		TestChan:      c,
 		SerialAddress: 140,
+		MaxRPM:        1,
 	}
 
 	motorReg, ok := resource.LookupRegistration(motor.API, sabertoothModel)
@@ -408,6 +417,7 @@ func TestInvalidMinPowerPct(t *testing.T) {
 		SerialAddress: 129,
 		MinPowerPct:   0.7,
 		MaxPowerPct:   0.5,
+		MaxRPM:        1,
 	}
 
 	motorReg, ok := resource.LookupRegistration(motor.API, sabertoothModel)
@@ -431,6 +441,7 @@ func TestInvalidMaxPowerPct(t *testing.T) {
 		SerialAddress: 129,
 		MinPowerPct:   0.7,
 		MaxPowerPct:   1.5,
+		MaxRPM:        1,
 	}
 
 	motorReg, ok := resource.LookupRegistration(motor.API, sabertoothModel)
@@ -455,6 +466,7 @@ func TestMultipleInvalidParameters(t *testing.T) {
 		SerialAddress: 140,
 		MinPowerPct:   1.7,
 		MaxPowerPct:   1.5,
+		MaxRPM:        1,
 	}
 
 	motorReg, ok := resource.LookupRegistration(motor.API, sabertoothModel)

--- a/components/motor/dmc4000/dmc.go
+++ b/components/motor/dmc4000/dmc.go
@@ -54,7 +54,7 @@ type Motor struct {
 	c                *controller
 	Axis             string
 	TicksPerRotation int
-	MaxRPM           float64
+	maxRPM           float64
 	MaxAcceleration  float64
 	HomeRPM          float64
 	jogging          bool
@@ -149,14 +149,14 @@ func NewMotor(ctx context.Context, c *Config, name resource.Name, logger golog.L
 		c:                ctrl,
 		Axis:             c.Axis,
 		TicksPerRotation: c.TicksPerRotation,
-		MaxRPM:           c.MaxRPM,
+		maxRPM:           c.MaxRPM,
 		MaxAcceleration:  c.MaxAcceleration,
 		HomeRPM:          c.HomeRPM,
 		powerPct:         0.0,
 	}
 
-	if m.MaxRPM <= 0 {
-		m.MaxRPM = 1000 // arbitrary high value
+	if m.maxRPM <= 0 {
+		m.maxRPM = 1000 // arbitrary high value
 	}
 
 	if m.MaxAcceleration <= 0 {
@@ -164,7 +164,7 @@ func NewMotor(ctx context.Context, c *Config, name resource.Name, logger golog.L
 	}
 
 	if m.HomeRPM <= 0 {
-		m.HomeRPM = m.MaxRPM / 4
+		m.HomeRPM = m.maxRPM / 4
 	}
 
 	if err := m.configure(c); err != nil {
@@ -395,8 +395,8 @@ func (c *controller) sendCmd(cmd string) (string, error) {
 // Convert rpm to DMC4000 counts/sec.
 func (m *Motor) rpmToV(rpm float64) int {
 	rpm = math.Abs(rpm)
-	if rpm > m.MaxRPM {
-		rpm = m.MaxRPM
+	if rpm > m.maxRPM {
+		rpm = m.maxRPM
 	}
 	speed := rpm * float64(m.TicksPerRotation) / 60
 
@@ -447,12 +447,13 @@ func (m *Motor) SetPower(ctx context.Context, powerPct float64, extra map[string
 	case pow < 0.1:
 		m.c.logger.Warn("motor speed is nearly 0 rev_per_min")
 		return m.Stop(ctx, extra)
-	case m.MaxRPM > 0 && pow*m.MaxRPM > m.MaxRPM-0.1:
-		m.c.logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.MaxRPM)
+	case m.maxRPM > 0 && pow*m.maxRPM > m.maxRPM-0.1:
+		m.c.logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.maxRPM)
+	default:
 	}
 
 	m.powerPct = powerPct
-	return m.Jog(ctx, powerPct*m.MaxRPM)
+	return m.Jog(ctx, powerPct*m.maxRPM)
 }
 
 // Jog moves indefinitely at the specified RPM.
@@ -499,8 +500,9 @@ func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[s
 	case speed < 0.1:
 		m.c.logger.Warn("motor speed is nearly 0 rev_per_min")
 		return motor.NewZeroRPMError()
-	case m.MaxRPM > 0 && speed > m.MaxRPM-0.1:
-		m.c.logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.MaxRPM)
+	case m.maxRPM > 0 && speed > m.maxRPM-0.1:
+		m.c.logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.maxRPM)
+	default:
 	}
 	ctx, done := m.opMgr.New(ctx)
 	defer done()
@@ -787,8 +789,9 @@ func (m *Motor) doGoTo(rpm, position float64) error {
 	switch speed := math.Abs(rpm); {
 	case speed < 0.1:
 		m.c.logger.Warn("motor speed is nearly 0 rev_per_min")
-	case m.MaxRPM > 0 && speed > m.MaxRPM-0.1:
-		m.c.logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.MaxRPM)
+	case m.maxRPM > 0 && speed > m.maxRPM-0.1:
+		m.c.logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.maxRPM)
+	default:
 	}
 
 	// Speed

--- a/components/motor/dmc4000/dmc.go
+++ b/components/motor/dmc4000/dmc.go
@@ -445,10 +445,10 @@ func (m *Motor) SetPower(ctx context.Context, powerPct float64, extra map[string
 
 	switch pow := math.Abs(powerPct); {
 	case pow < 0.1:
-		m.c.logger.Warnf("motor (%s) speed is nearly 0 rev_per_min", m.Name())
+		m.c.logger.Warn("motor speed is nearly 0 rev_per_min")
 		return m.Stop(ctx, extra)
-	case pow*m.MaxRPM > m.MaxRPM-0.1:
-		m.c.logger.Warnf("motor (%s) speed is nearly the max rev_per_min (%f)", m.Name(), m.MaxRPM)
+	case m.MaxRPM > 0 && pow*m.MaxRPM > m.MaxRPM-0.1:
+		m.c.logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.MaxRPM)
 	}
 
 	m.powerPct = powerPct
@@ -497,10 +497,10 @@ func (m *Motor) stopJog() error {
 func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]interface{}) error {
 	switch speed := math.Abs(rpm); {
 	case speed < 0.1:
-		m.c.logger.Warnf("motor (%s) speed is nearly 0 rev_per_min", m.Name())
+		m.c.logger.Warn("motor speed is nearly 0 rev_per_min")
 		return motor.NewZeroRPMError()
-	case speed > m.MaxRPM-0.1:
-		m.c.logger.Warnf("motor (%s) speed is nearly the max rev_per_min (%f)", m.Name(), m.MaxRPM)
+	case m.MaxRPM > 0 && speed > m.MaxRPM-0.1:
+		m.c.logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.MaxRPM)
 	}
 	ctx, done := m.opMgr.New(ctx)
 	defer done()
@@ -786,9 +786,9 @@ func (m *Motor) doGoTo(rpm, position float64) error {
 
 	switch speed := math.Abs(rpm); {
 	case speed < 0.1:
-		m.c.logger.Warnf("motor (%s) speed is nearly 0 rev_per_min", m.Name())
-	case speed > m.MaxRPM-0.1:
-		m.c.logger.Warnf("motor (%s) speed is nearly the max rev_per_min (%f)", m.Name(), m.MaxRPM)
+		m.c.logger.Warn("motor speed is nearly 0 rev_per_min")
+	case m.MaxRPM > 0 && speed > m.MaxRPM-0.1:
+		m.c.logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.MaxRPM)
 	}
 
 	// Speed

--- a/components/motor/fake/motor.go
+++ b/components/motor/fake/motor.go
@@ -262,7 +262,7 @@ func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[s
 	case speed < 0.1:
 		m.Logger.Warn("motor speed is nearly 0 rev_per_min")
 		return motor.NewZeroRPMError()
-	case speed > m.MaxRPM-0.1:
+	case m.MaxRPM > 0 && speed > m.MaxRPM-0.1:
 		m.Logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.MaxRPM)
 	}
 
@@ -308,7 +308,7 @@ func (m *Motor) GoTo(ctx context.Context, rpm, pos float64, extra map[string]int
 	switch speed := math.Abs(rpm); {
 	case speed < 0.1:
 		m.Logger.Warn("motor speed is nearly 0 rev_per_min")
-	case speed > m.MaxRPM-0.1:
+	case m.MaxRPM > 0 && speed > m.MaxRPM-0.1:
 		m.Logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.MaxRPM)
 	}
 

--- a/components/motor/fake/motor.go
+++ b/components/motor/fake/motor.go
@@ -91,7 +91,7 @@ type Motor struct {
 	PWM               board.GPIOPin
 	PositionReporting bool
 	Encoder           fake.Encoder
-	MaxRPM            float64
+	maxRPM            float64
 	DirFlip           bool
 	TicksPerRotation  int
 
@@ -123,11 +123,11 @@ func (m *Motor) Reconfigure(ctx context.Context, deps resource.Dependencies, con
 			}
 		}
 	}
-	m.MaxRPM = newConf.MaxRPM
+	m.maxRPM = newConf.MaxRPM
 
-	if m.MaxRPM == 0 {
+	if m.maxRPM == 0 {
 		m.Logger.Infof("Max RPM not provided to a fake motor, defaulting to %v", defaultMaxRpm)
-		m.MaxRPM = defaultMaxRpm
+		m.maxRPM = defaultMaxRpm
 	}
 
 	if newConf.Encoder != "" {
@@ -195,7 +195,7 @@ func (m *Motor) SetPower(ctx context.Context, powerPct float64, extra map[string
 			return errors.New("need positive nonzero TicksPerRotation")
 		}
 
-		newSpeed := (m.MaxRPM * m.powerPct) * float64(m.TicksPerRotation)
+		newSpeed := (m.maxRPM * m.powerPct) * float64(m.TicksPerRotation)
 		err := m.Encoder.SetSpeed(ctx, newSpeed)
 		if err != nil {
 			return err
@@ -262,11 +262,12 @@ func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[s
 	case speed < 0.1:
 		m.Logger.Warn("motor speed is nearly 0 rev_per_min")
 		return motor.NewZeroRPMError()
-	case m.MaxRPM > 0 && speed > m.MaxRPM-0.1:
-		m.Logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.MaxRPM)
+	case m.maxRPM > 0 && speed > m.maxRPM-0.1:
+		m.Logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.maxRPM)
+	default:
 	}
 
-	powerPct, waitDur, dir := goForMath(m.MaxRPM, rpm, revolutions)
+	powerPct, waitDur, dir := goForMath(m.maxRPM, rpm, revolutions)
 
 	var finalPos float64
 	if m.Encoder != nil {
@@ -308,8 +309,9 @@ func (m *Motor) GoTo(ctx context.Context, rpm, pos float64, extra map[string]int
 	switch speed := math.Abs(rpm); {
 	case speed < 0.1:
 		m.Logger.Warn("motor speed is nearly 0 rev_per_min")
-	case m.MaxRPM > 0 && speed > m.MaxRPM-0.1:
-		m.Logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.MaxRPM)
+	case m.maxRPM > 0 && speed > m.maxRPM-0.1:
+		m.Logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.maxRPM)
+	default:
 	}
 
 	curPos, err := m.Position(ctx, nil)
@@ -322,7 +324,7 @@ func (m *Motor) GoTo(ctx context.Context, rpm, pos float64, extra map[string]int
 
 	revolutions := pos - curPos
 
-	powerPct, waitDur, _ := goForMath(m.MaxRPM, math.Abs(rpm), revolutions)
+	powerPct, waitDur, _ := goForMath(m.maxRPM, math.Abs(rpm), revolutions)
 
 	err = m.SetPower(ctx, powerPct, nil)
 	if err != nil {

--- a/components/motor/fake/motor.go
+++ b/components/motor/fake/motor.go
@@ -91,7 +91,7 @@ type Motor struct {
 	PWM               board.GPIOPin
 	PositionReporting bool
 	Encoder           fake.Encoder
-	maxRPM            float64
+	MaxRPM            float64
 	DirFlip           bool
 	TicksPerRotation  int
 
@@ -123,11 +123,11 @@ func (m *Motor) Reconfigure(ctx context.Context, deps resource.Dependencies, con
 			}
 		}
 	}
-	m.maxRPM = newConf.MaxRPM
+	m.MaxRPM = newConf.MaxRPM
 
-	if m.maxRPM == 0 {
+	if m.MaxRPM == 0 {
 		m.Logger.Infof("Max RPM not provided to a fake motor, defaulting to %v", defaultMaxRpm)
-		m.maxRPM = defaultMaxRpm
+		m.MaxRPM = defaultMaxRpm
 	}
 
 	if newConf.Encoder != "" {
@@ -195,7 +195,7 @@ func (m *Motor) SetPower(ctx context.Context, powerPct float64, extra map[string
 			return errors.New("need positive nonzero TicksPerRotation")
 		}
 
-		newSpeed := (m.maxRPM * m.powerPct) * float64(m.TicksPerRotation)
+		newSpeed := (m.MaxRPM * m.powerPct) * float64(m.TicksPerRotation)
 		err := m.Encoder.SetSpeed(ctx, newSpeed)
 		if err != nil {
 			return err
@@ -262,12 +262,12 @@ func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[s
 	case speed < 0.1:
 		m.Logger.Warn("motor speed is nearly 0 rev_per_min")
 		return motor.NewZeroRPMError()
-	case m.maxRPM > 0 && speed > m.maxRPM-0.1:
-		m.Logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.maxRPM)
+	case m.MaxRPM > 0 && speed > m.MaxRPM-0.1:
+		m.Logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.MaxRPM)
 	default:
 	}
 
-	powerPct, waitDur, dir := goForMath(m.maxRPM, rpm, revolutions)
+	powerPct, waitDur, dir := goForMath(m.MaxRPM, rpm, revolutions)
 
 	var finalPos float64
 	if m.Encoder != nil {
@@ -309,8 +309,8 @@ func (m *Motor) GoTo(ctx context.Context, rpm, pos float64, extra map[string]int
 	switch speed := math.Abs(rpm); {
 	case speed < 0.1:
 		m.Logger.Warn("motor speed is nearly 0 rev_per_min")
-	case m.maxRPM > 0 && speed > m.maxRPM-0.1:
-		m.Logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.maxRPM)
+	case m.MaxRPM > 0 && speed > m.MaxRPM-0.1:
+		m.Logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.MaxRPM)
 	default:
 	}
 
@@ -324,7 +324,7 @@ func (m *Motor) GoTo(ctx context.Context, rpm, pos float64, extra map[string]int
 
 	revolutions := pos - curPos
 
-	powerPct, waitDur, _ := goForMath(m.maxRPM, math.Abs(rpm), revolutions)
+	powerPct, waitDur, _ := goForMath(m.MaxRPM, math.Abs(rpm), revolutions)
 
 	err = m.SetPower(ctx, powerPct, nil)
 	if err != nil {

--- a/components/motor/gpio/basic.go
+++ b/components/motor/gpio/basic.go
@@ -276,6 +276,7 @@ func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[s
 		return motor.NewZeroRPMError()
 	case m.maxRPM > 0 && speed > m.maxRPM-0.1:
 		m.logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.maxRPM)
+	default:
 	}
 
 	powerPct, waitDur := goForMath(m.maxRPM, rpm, revolutions)

--- a/components/motor/gpio/basic.go
+++ b/components/motor/gpio/basic.go
@@ -272,10 +272,10 @@ func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[s
 
 	switch speed := math.Abs(rpm); {
 	case speed < 0.1:
-		m.logger.Warnf("motor (%s) speed is nearly 0 rev_per_min", m.Name())
+		m.logger.Warn("motor speed is nearly 0 rev_per_min")
 		return motor.NewZeroRPMError()
-	case speed > m.maxRPM-0.1:
-		m.logger.Warnf("motor (%s) speed is nearly the max rev_per_min (%f)", m.Name(), m.maxRPM)
+	case m.maxRPM > 0 && speed > m.maxRPM-0.1:
+		m.logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.maxRPM)
 	}
 
 	powerPct, waitDur := goForMath(m.maxRPM, rpm, revolutions)

--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -562,6 +562,7 @@ func (m *EncodedMotor) goForInternal(ctx context.Context, rpm, revolutions float
 		return motor.NewZeroRPMError()
 	case m.cfg.MaxRPM > 0 && speed > m.cfg.MaxRPM-0.1:
 		m.logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.cfg.MaxRPM)
+	default:
 	}
 
 	m.stateMu.Lock()

--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -558,10 +558,10 @@ func (m *EncodedMotor) goForInternal(ctx context.Context, rpm, revolutions float
 
 	switch speed := math.Abs(rpm); {
 	case speed < 0.1:
-		m.logger.Warnf("motor (%s) speed is nearly 0 rev_per_min", m.Name())
+		m.logger.Warn("motor speed is nearly 0 rev_per_min")
 		return motor.NewZeroRPMError()
-	case speed > m.cfg.MaxRPM-0.1:
-		m.logger.Warnf("motor (%s) speed is nearly the max rev_per_min (%f)", m.Name(), m.cfg.MaxRPM)
+	case m.cfg.MaxRPM > 0 && speed > m.cfg.MaxRPM-0.1:
+		m.logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.cfg.MaxRPM)
 	}
 
 	m.stateMu.Lock()

--- a/components/motor/gpiostepper/gpiostepper.go
+++ b/components/motor/gpiostepper/gpiostepper.go
@@ -308,7 +308,7 @@ func (m *gpioStepper) goForInternal(ctx context.Context, rpm, revolutions float6
 
 	speed := math.Abs(rpm)
 	if speed < 0.1 {
-		m.logger.Warnf("motor (%s) speed is nearly 0 rev_per_min", m.Name())
+		m.logger.Warn("motor speed is nearly 0 rev_per_min")
 		return m.Stop(ctx, nil)
 	}
 

--- a/components/motor/i2cmotors/ezopmp.go
+++ b/components/motor/i2cmotors/ezopmp.go
@@ -273,10 +273,10 @@ func (m *Ezopmp) SetPower(ctx context.Context, powerPct float64, extra map[strin
 func (m *Ezopmp) GoFor(ctx context.Context, mLPerMin, mins float64, extra map[string]interface{}) error {
 	switch speed := math.Abs(mLPerMin); {
 	case speed < 0.1:
-		m.logger.Warnf("motor (%s) speed is nearly 0 rev_per_min", m.Name())
+		m.logger.Warn("motor speed is nearly 0 rev_per_min")
 		return motor.NewZeroRPMError()
-	case speed > m.maxFlowRate-0.1:
-		m.logger.Warnf("motor (%s) speed is nearly the max rev_per_min (%f)", m.Name(), m.maxFlowRate)
+	case m.maxFlowRate > 0 && speed > m.maxFlowRate-0.1:
+		m.logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.maxFlowRate)
 	}
 
 	ctx, done := m.opMgr.New(ctx)

--- a/components/motor/i2cmotors/ezopmp.go
+++ b/components/motor/i2cmotors/ezopmp.go
@@ -277,6 +277,7 @@ func (m *Ezopmp) GoFor(ctx context.Context, mLPerMin, mins float64, extra map[st
 		return motor.NewZeroRPMError()
 	case m.maxFlowRate > 0 && speed > m.maxFlowRate-0.1:
 		m.logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.maxFlowRate)
+	default:
 	}
 
 	ctx, done := m.opMgr.New(ctx)

--- a/components/motor/roboclaw/roboclaw.go
+++ b/components/motor/roboclaw/roboclaw.go
@@ -161,7 +161,7 @@ func (m *roboclawMotor) SetPower(ctx context.Context, powerPct float64, extra ma
 func (m *roboclawMotor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]interface{}) error {
 	speed := math.Abs(rpm)
 	if speed < 0.1 {
-		m.logger.Warnf("motor (%s) speed is nearly 0 rev_per_min", m.Name())
+		m.logger.Warn("motor speed is nearly 0 rev_per_min")
 		return motor.NewZeroRPMError()
 	}
 

--- a/components/motor/tmcstepper/stepper_motor_tmc.go
+++ b/components/motor/tmcstepper/stepper_motor_tmc.go
@@ -423,6 +423,7 @@ func (m *Motor) doJog(ctx context.Context, rpm float64) error {
 		m.logger.Warn("motor speed is nearly 0 rev_per_min")
 	case m.maxRPM > 0 && speed0 > m.maxRPM:
 		m.logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.maxRPM)
+	default:
 	}
 
 	speed := m.rpmToV(math.Abs(rpm))
@@ -491,6 +492,7 @@ func (m *Motor) GoTo(ctx context.Context, rpm, positionRevolutions float64, extr
 		m.logger.Warn("motor speed is nearly 0 rev_per_min")
 	case m.maxRPM > 0 && speed > m.maxRPM-0.1:
 		m.logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.maxRPM)
+	default:
 	}
 
 	err := multierr.Combine(

--- a/components/motor/tmcstepper/stepper_motor_tmc.go
+++ b/components/motor/tmcstepper/stepper_motor_tmc.go
@@ -420,9 +420,9 @@ func (m *Motor) doJog(ctx context.Context, rpm float64) error {
 
 	switch speed0 := math.Abs(rpm); {
 	case speed0 < 0.1:
-		m.logger.Warnf("motor (%s) speed is nearly 0 rev_per_min", m.Name())
-	case speed0 > m.maxRPM:
-		m.logger.Warnf("motor (%s) speed is nearly the max rev_per_min (%f)", m.Name(), m.maxRPM)
+		m.logger.Warn("motor speed is nearly 0 rev_per_min")
+	case m.maxRPM > 0 && speed0 > m.maxRPM:
+		m.logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.maxRPM)
 	}
 
 	speed := m.rpmToV(math.Abs(rpm))
@@ -437,7 +437,7 @@ func (m *Motor) doJog(ctx context.Context, rpm float64) error {
 // Note: if both are negative the motor will spin in the forward direction.
 func (m *Motor) GoFor(ctx context.Context, rpm, rotations float64, extra map[string]interface{}) error {
 	if math.Abs(rpm) < 0.1 {
-		m.logger.Warnf("motor (%s) speed is nearly 0 rev_per_min", m.Name())
+		m.logger.Warn("motor speed is nearly 0 rev_per_min")
 		return motor.NewZeroRPMError()
 	}
 
@@ -488,9 +488,9 @@ func (m *Motor) GoTo(ctx context.Context, rpm, positionRevolutions float64, extr
 
 	switch speed := math.Abs(rpm); {
 	case speed < 0.1:
-		m.logger.Warnf("motor (%s) speed is nearly 0 rev_per_min", m.Name())
-	case speed > m.maxRPM-0.1:
-		m.logger.Warnf("motor (%s) speed is nearly the max rev_per_min (%f)", m.Name(), m.maxRPM)
+		m.logger.Warn("motor speed is nearly 0 rev_per_min")
+	case m.maxRPM > 0 && speed > m.maxRPM-0.1:
+		m.logger.Warnf("motor speed is nearly the max rev_per_min (%f)", m.maxRPM)
 	}
 
 	err := multierr.Combine(

--- a/components/motor/ulnstepper/28byj-48.go
+++ b/components/motor/ulnstepper/28byj-48.go
@@ -255,6 +255,7 @@ func (m *uln28byj) GoFor(ctx context.Context, rpm, revolutions float64, extra ma
 	case speed > 146-0.1:
 		m.logger.Warnf("motor speed is nearly the max rev_per_min (%f)", 146)
 		return m.Stop(ctx, nil)
+	default:
 	}
 
 	m.lock.Lock()

--- a/components/motor/ulnstepper/28byj-48.go
+++ b/components/motor/ulnstepper/28byj-48.go
@@ -250,10 +250,10 @@ func (m *uln28byj) GoFor(ctx context.Context, rpm, revolutions float64, extra ma
 
 	switch speed := math.Abs(rpm); {
 	case speed < 0.1:
-		m.logger.Warnf("motor (%s) speed is nearly 0 rev_per_min", m.Name())
+		m.logger.Warn("motor speed is nearly 0 rev_per_min")
 		return motor.NewZeroRPMError()
 	case speed > 146-0.1:
-		m.logger.Warnf("motor (%s) speed is nearly the max rev_per_min (%f)", m.Name(), 146)
+		m.logger.Warnf("motor speed is nearly the max rev_per_min (%f)", 146)
 		return m.Stop(ctx, nil)
 	}
 


### PR DESCRIPTION
Now the maxRPM warning is only logged when the maxRPM of the motor is greater than 0. Additionally, the names were removed from all the motor RPM warnings