### PR TITLE
Fix async scheduler

### DIFF
--- a/web/frontend/src/components/encoder.vue
+++ b/web/frontend/src/components/encoder.vue
@@ -5,7 +5,7 @@ import { grpc } from '@improbable-eng/grpc-web';
 import { Client, encoderApi, ResponseStream, robotApi, type ServiceError } from '@viamrobotics/sdk';
 import { displayError } from '../lib/error';
 import { rcLogConditionally } from '../lib/log';
-import { scheduleAsyncPoll } from '../lib/schedule';
+import { setAsyncInterval } from '../lib/schedule';
 
 const props = defineProps<{
   name: string
@@ -17,7 +17,7 @@ let properties = $ref<encoderApi.GetPropertiesResponse.AsObject>();
 let positionTicks = $ref(0);
 let positionDegrees = $ref(0);
 
-let cancelPoll: (() => void) | undefined;
+let cancelInterval: (() => void) | undefined;
 
 const getProperties = () => new Promise<encoderApi.GetPropertiesResponse.AsObject>((resolve, reject) => {
   const request = new encoderApi.GetPropertiesRequest();
@@ -70,8 +70,6 @@ const refresh = async () => {
   } catch (error) {
     displayError(error as ServiceError);
   }
-
-  cancelPoll = scheduleAsyncPoll(refresh, 500);
 };
 
 const reset = () => {
@@ -91,15 +89,16 @@ onMounted(async () => {
   try {
     properties = await getProperties();
     refresh();
+    cancelInterval = setAsyncInterval(refresh, 500);
   } catch (error) {
     displayError(error as ServiceError);
   }
 
-  props.statusStream?.on('end', () => cancelPoll?.());
+  props.statusStream?.on('end', () => cancelInterval?.());
 });
 
 onUnmounted(() => {
-  cancelPoll?.();
+  cancelInterval?.();
 });
 
 </script>

--- a/web/frontend/src/lib/schedule.ts
+++ b/web/frontend/src/lib/schedule.ts
@@ -1,15 +1,10 @@
-export const scheduleAsyncPoll = (callback: () => Promise<void>, interval: number) => {
+export const setAsyncInterval = (callback: () => Promise<void>, interval: number) => {
   let cancelled = false;
   let timeoutId = -1;
 
   const refreshAndScheduleNext = async () => {
     await callback();
 
-    // eslint-disable-next-line no-use-before-define
-    scheduleNext();
-  };
-
-  const scheduleNext = () => {
     if (cancelled) {
       return;
     }
@@ -22,7 +17,7 @@ export const scheduleAsyncPoll = (callback: () => Promise<void>, interval: numbe
     window.clearTimeout(timeoutId);
   };
 
-  scheduleNext();
+  timeoutId = window.setTimeout(refreshAndScheduleNext, interval);
 
   return cancel;
 };


### PR DESCRIPTION
This PR fixes an issue introduced when `scheduleAsyncPoll` was introduced: when using it in encoder I thought of it as a timeout function rather than an interval function, and called the scheduler each time a poll occurred. This had the effect of adding new interval polls on every poll, which created an exponentially increasing number of pollers, which eventually ate up all CPU / RAM, causing WebRTC disconnects and out-of-memory warnings.

In this PR I've fixed the issue, and renamed the function to be more similar to `setInterval`, so that no one else falls victim to this tragic fate.