### PR TITLE
RSDK-3009 - Unpack mlClassifier easier

### DIFF
--- a/.artifact/tree.json
+++ b/.artifact/tree.json
@@ -52138,6 +52138,10 @@
         "hash": "93b03dc453206b6ce0cd083f96066544",
         "size": 23685
       },
+      "lampshade.jpg": {
+        "hash": "d3bd30dd375e610925ab8edafa907767",
+        "size": 86278
+      },
       "lion.jpeg": {
         "hash": "7a24ee403e1606a0956d63dc744f24de",
         "size": 31645
@@ -52149,6 +52153,14 @@
       "mobilenet.tflite": {
         "hash": "66ee95e3edbaa9b3de5138cf1cbb127d",
         "size": 1866640
+      },
+      "mobilenetlogitlabels.txt": {
+        "hash": "9a59ebc6b30aa6edffa8f17abbeb5b74",
+        "size": 10483
+      },
+      "mobilenetlogits.tflite": {
+        "hash": "6219259140b1d3a05314083d7024d4a7",
+        "size": 16019482
       },
       "mobilenetv2_class.tflite": {
         "hash": "4fc85180f4b6c4bf2fb9417b94d84bcd",
@@ -52169,6 +52181,14 @@
       "ssdmobilenet.tflite": {
         "hash": "4c421353bf0a105c5ffba593ffee4099",
         "size": 27523960
+      },
+      "useslogitlabels.txt": {
+        "hash": "9a59ebc6b30aa6edffa8f17abbeb5b74",
+        "size": 10483
+      },
+      "useslogits.tflite": {
+        "hash": "6219259140b1d3a05314083d7024d4a7",
+        "size": 16019482
       }
     },
     "white1.png": {

--- a/services/vision/mlvision/classifier.go
+++ b/services/vision/mlvision/classifier.go
@@ -5,6 +5,8 @@ import (
 	"image"
 	"strconv"
 
+	"go.uber.org/multierr"
+
 	"github.com/nfnt/resize"
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
@@ -47,12 +49,15 @@ func attemptToBuildClassifier(mlm mlmodel.Service) (classification.Classifier, e
 		}
 
 		var err2 error
-
+		var err3 error
 		probs, err := unpack(outMap, "probability")
 		if err != nil || len(probs) == 0 {
 			probs, err2 = unpack(outMap, DefaultOutTensorName+"0")
-			if err2 != nil {
-				return nil, multierr.Combine(err, err2)
+			if err2 != nil || len(probs) == 0 {
+				probs, err3 = unpack(outMap, "")
+				if err3 != nil {
+					return nil, multierr.Combine(err, err2, err3)
+				}
 			}
 		}
 

--- a/services/vision/mlvision/classifier.go
+++ b/services/vision/mlvision/classifier.go
@@ -5,8 +5,6 @@ import (
 	"image"
 	"strconv"
 
-	"go.uber.org/multierr"
-
 	"github.com/nfnt/resize"
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
@@ -26,6 +24,10 @@ func attemptToBuildClassifier(mlm mlmodel.Service) (classification.Classifier, e
 	var inHeight, inWidth uint
 	inType := md.Inputs[0].DataType
 	labels := getLabelsFromMetadata(md)
+
+	if len(md.Inputs[0].Shape) < 4 {
+		return nil, errors.New("could not get input dimensions")
+	}
 	if shape := md.Inputs[0].Shape; getIndex(shape, 3) == 1 {
 		inHeight, inWidth = uint(shape[2]), uint(shape[3])
 	} else {

--- a/services/vision/mlvision/ml_model.go
+++ b/services/vision/mlvision/ml_model.go
@@ -108,12 +108,25 @@ func registerMLModelVisionService(
 }
 
 // Unpack output based on expected type and force it into a []float64.
+// If "" is selected as the name argument, we will attempt to unpack the first entity in the map.
 func unpack(inMap map[string]interface{}, name string) ([]float64, error) {
 	var out []float64
-	me := inMap[name]
+	var me interface{}
+	if name != "" {
+		me = inMap[name]
+	} else {
+		if len(inMap) < 1 {
+			return nil, errors.New("could not unpack nonexistent first tensor")
+		}
+		for _, v := range inMap {
+			me = v
+			break
+		}
+	}
 	if me == nil {
 		return nil, errors.Errorf("no such tensor named %q to unpack", name)
 	}
+
 	switch v := me.(type) {
 	case []uint8:
 		out = make([]float64, 0, len(v))

--- a/services/vision/mlvision/ml_model.go
+++ b/services/vision/mlvision/ml_model.go
@@ -114,15 +114,13 @@ func unpack(inMap map[string]interface{}, name string) ([]float64, error) {
 	var me interface{}
 	if name != "" {
 		me = inMap[name]
-	} else {
-		if len(inMap) < 1 {
-			return nil, errors.New("could not unpack nonexistent first tensor")
-		}
+	} else if len(inMap) == 1 {
 		for _, v := range inMap {
 			me = v
 			break
 		}
 	}
+
 	if me == nil {
 		return nil, errors.Errorf("no such tensor named %q to unpack", name)
 	}

--- a/services/vision/mlvision/ml_model_test.go
+++ b/services/vision/mlvision/ml_model_test.go
@@ -92,7 +92,7 @@ func TestAddingIncorrectModelTypeToModel(t *testing.T) {
 	test.That(t, classifier, test.ShouldNotBeNil)
 
 	err = checkIfClassifierWorks(ctx, classifier)
-	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldBeNil)
 
 	detector, err := attemptToBuildDetector(mlm)
 	test.That(t, err, test.ShouldBeNil)


### PR DESCRIPTION
Resolved this issue. checkIfClassifierWorks was failing because we only ever attempt to unpack tensors listed under the term "probability" (empirically found) or "output0" (given default if MD does not exist).  In this particular case, the metadata did exist and was labeled output under the term "logits."

Rather than unpack based on the word "logits" as well, I've added a third and final check (for classifiers only). If you can't find "probability" or the default "output0", unpack the first output the map contains. This makes me nervous for future cases where we have a metadata-included detector, but the names are not what we expect.

Also slipped in here is a quick solution to RSDK-3034. Needed to do some length checking. 