### PR TITLE
RSDK-3027 - implement resource.Named for vision service models

### DIFF
--- a/services/vision/colordetector/color_detector.go
+++ b/services/vision/colordetector/color_detector.go
@@ -29,7 +29,7 @@ func init() {
 			if err != nil {
 				return nil, err
 			}
-			return registerColorDetector(ctx, c.ResourceName().Name, attrs, actualR)
+			return registerColorDetector(ctx, c.ResourceName(), attrs, actualR)
 		},
 	})
 }
@@ -37,7 +37,7 @@ func init() {
 // registerColorDetector creates a new Color Detector from the config.
 func registerColorDetector(
 	ctx context.Context,
-	name string,
+	name resource.Name,
 	conf *objdet.ColorDetectorConfig,
 	r robot.Robot,
 ) (vision.Service, error) {

--- a/services/vision/colordetector/color_detector_test.go
+++ b/services/vision/colordetector/color_detector_test.go
@@ -24,6 +24,7 @@ func TestColorDetector(t *testing.T) {
 	name := vision.Named("test_cd")
 	srv, err := registerColorDetector(ctx, name, &inp, r)
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, srv.Name(), test.ShouldResemble, name)
 	img, err := rimage.NewImageFromFile(artifact.MustPath("vision/objectdetection/detection_test.jpg"))
 	test.That(t, err, test.ShouldBeNil)
 

--- a/services/vision/colordetector/color_detector_test.go
+++ b/services/vision/colordetector/color_detector_test.go
@@ -8,6 +8,7 @@ import (
 	"go.viam.com/utils/artifact"
 
 	"go.viam.com/rdk/rimage"
+	"go.viam.com/rdk/services/vision"
 	"go.viam.com/rdk/testutils/inject"
 	"go.viam.com/rdk/vision/objectdetection"
 )
@@ -20,7 +21,8 @@ func TestColorDetector(t *testing.T) {
 	}
 	ctx := context.Background()
 	r := &inject.Robot{}
-	srv, err := registerColorDetector(ctx, "test_cd", &inp, r)
+	name := vision.Named("test_cd")
+	srv, err := registerColorDetector(ctx, name, &inp, r)
 	test.That(t, err, test.ShouldBeNil)
 	img, err := rimage.NewImageFromFile(artifact.MustPath("vision/objectdetection/detection_test.jpg"))
 	test.That(t, err, test.ShouldBeNil)
@@ -37,10 +39,10 @@ func TestColorDetector(t *testing.T) {
 
 	// with error - bad parameters
 	inp.HueTolerance = 4.0 // value out of range
-	_, err = registerColorDetector(ctx, "test_cd", &inp, r)
+	_, err = registerColorDetector(ctx, name, &inp, r)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "hue_tolerance_pct must be between")
 
 	// with error - nil parameters
-	_, err = registerColorDetector(ctx, "test_cd", nil, r)
+	_, err = registerColorDetector(ctx, name, nil, r)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "cannot be nil")
 }

--- a/services/vision/detectionstosegments/detections_to_3dsegments.go
+++ b/services/vision/detectionstosegments/detections_to_3dsegments.go
@@ -31,7 +31,7 @@ func init() {
 			if err != nil {
 				return nil, err
 			}
-			return register3DSegmenterFromDetector(ctx, c.ResourceName().Name, attrs, actualR)
+			return register3DSegmenterFromDetector(ctx, c.ResourceName(), attrs, actualR)
 		},
 	})
 }
@@ -39,7 +39,7 @@ func init() {
 // register3DSegmenterFromDetector creates a 3D segmenter from a previously registered detector.
 func register3DSegmenterFromDetector(
 	ctx context.Context,
-	name string,
+	name resource.Name,
 	conf *segmentation.DetectionSegmenterConfig,
 	r robot.Robot,
 ) (vision.Service, error) {

--- a/services/vision/detectionstosegments/detections_to_3dsegments_test.go
+++ b/services/vision/detectionstosegments/detections_to_3dsegments_test.go
@@ -71,6 +71,7 @@ func Test3DSegmentsFromDetector(t *testing.T) {
 	name3 := vision.Named("test_rcs")
 	seg, err := register3DSegmenterFromDetector(context.Background(), name3, params, r)
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, seg.Name(), test.ShouldResemble, name3)
 
 	// fails on not finding camera
 	_, err = seg.GetObjectPointClouds(context.Background(), "no_camera", map[string]interface{}{})

--- a/services/vision/mlvision/ml_model.go
+++ b/services/vision/mlvision/ml_model.go
@@ -45,7 +45,7 @@ func init() {
 			if err != nil {
 				return nil, err
 			}
-			return registerMLModelVisionService(ctx, c.ResourceName().Name, attrs, actualR, logger)
+			return registerMLModelVisionService(ctx, c.ResourceName(), attrs, actualR, logger)
 		},
 	})
 }
@@ -58,7 +58,7 @@ type MLModelConfig struct {
 
 func registerMLModelVisionService(
 	ctx context.Context,
-	name string,
+	name resource.Name,
 	params *MLModelConfig,
 	r robot.Robot,
 	logger golog.Logger,

--- a/services/vision/mlvision/ml_model_test.go
+++ b/services/vision/mlvision/ml_model_test.go
@@ -32,7 +32,7 @@ func BenchmarkAddMLVisionModel(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		service, err := registerMLModelVisionService(ctx, name.Name, &modelCfg, &inject.Robot{}, golog.NewLogger("benchmark"))
+		service, err := registerMLModelVisionService(ctx, name, &modelCfg, &inject.Robot{}, golog.NewLogger("benchmark"))
 		test.That(b, err, test.ShouldBeNil)
 		test.That(b, service, test.ShouldNotBeNil)
 	}
@@ -54,7 +54,7 @@ func BenchmarkUseMLVisionModel(b *testing.B) {
 	test.That(b, out, test.ShouldNotBeNil)
 	modelCfg := MLModelConfig{ModelName: name.Name}
 
-	service, err := registerMLModelVisionService(ctx, name.Name, &modelCfg, &inject.Robot{}, golog.NewLogger("benchmark"))
+	service, err := registerMLModelVisionService(ctx, name, &modelCfg, &inject.Robot{}, golog.NewLogger("benchmark"))
 	test.That(b, err, test.ShouldBeNil)
 	test.That(b, service, test.ShouldNotBeNil)
 

--- a/services/vision/mlvision/ml_model_test.go
+++ b/services/vision/mlvision/ml_model_test.go
@@ -35,6 +35,7 @@ func BenchmarkAddMLVisionModel(b *testing.B) {
 		service, err := registerMLModelVisionService(ctx, name, &modelCfg, &inject.Robot{}, golog.NewLogger("benchmark"))
 		test.That(b, err, test.ShouldBeNil)
 		test.That(b, service, test.ShouldNotBeNil)
+		test.That(b, service.Name(), test.ShouldResemble, name)
 	}
 }
 
@@ -57,6 +58,7 @@ func BenchmarkUseMLVisionModel(b *testing.B) {
 	service, err := registerMLModelVisionService(ctx, name, &modelCfg, &inject.Robot{}, golog.NewLogger("benchmark"))
 	test.That(b, err, test.ShouldBeNil)
 	test.That(b, service, test.ShouldNotBeNil)
+	test.That(b, service.Name(), test.ShouldResemble, name)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/services/vision/radiusclustering/radius_clustering.go
+++ b/services/vision/radiusclustering/radius_clustering.go
@@ -29,7 +29,7 @@ func init() {
 			if err != nil {
 				return nil, err
 			}
-			return registerRCSegmenter(ctx, c.ResourceName().Name, attrs, actualR)
+			return registerRCSegmenter(ctx, c.ResourceName(), attrs, actualR)
 		},
 	})
 }
@@ -37,7 +37,7 @@ func init() {
 // registerRCSegmenter creates a new 3D radius clustering segmenter from the config.
 func registerRCSegmenter(
 	ctx context.Context,
-	name string,
+	name resource.Name,
 	conf *segmentation.RadiusClusteringConfig,
 	r robot.Robot,
 ) (vision.Service, error) {

--- a/services/vision/radiusclustering/radius_clustering_test.go
+++ b/services/vision/radiusclustering/radius_clustering_test.go
@@ -11,6 +11,7 @@ import (
 	"go.viam.com/rdk/components/camera"
 	pc "go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/services/vision"
 	"go.viam.com/rdk/testutils/inject"
 	"go.viam.com/rdk/vision/segmentation"
 )
@@ -39,17 +40,18 @@ func TestRadiusClusteringSegmentation(t *testing.T) {
 		MeanKFiltering:     10.,
 	}
 	// bad registration, no parameters
-	_, err := registerRCSegmenter(context.Background(), "test_rcs", nil, r)
+	name := vision.Named("test_rcs")
+	_, err := registerRCSegmenter(context.Background(), name, nil, r)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "cannot be nil")
 	// bad registration, parameters out of bounds
 	params.ClusteringRadiusMm = -3.0
-	_, err = registerRCSegmenter(context.Background(), "test_rcs", params, r)
+	_, err = registerRCSegmenter(context.Background(), name, params, r)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "segmenter config error")
 	// successful registration
 	params.ClusteringRadiusMm = 5.0
-	seg, err := registerRCSegmenter(context.Background(), "test_rcs", params, r)
+	seg, err := registerRCSegmenter(context.Background(), name, params, r)
 	test.That(t, err, test.ShouldBeNil)
 
 	// fails on not finding camera

--- a/services/vision/radiusclustering/radius_clustering_test.go
+++ b/services/vision/radiusclustering/radius_clustering_test.go
@@ -53,6 +53,7 @@ func TestRadiusClusteringSegmentation(t *testing.T) {
 	params.ClusteringRadiusMm = 5.0
 	seg, err := registerRCSegmenter(context.Background(), name, params, r)
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, seg.Name(), test.ShouldResemble, name)
 
 	// fails on not finding camera
 	_, err = seg.GetObjectPointClouds(context.Background(), "no_camera", map[string]interface{}{})

--- a/services/vision/vision_test.go
+++ b/services/vision/vision_test.go
@@ -47,7 +47,7 @@ func (s *simpleDetector) Detect(context.Context, image.Image) ([]objectdetection
 func TestNewService(t *testing.T) {
 	var r inject.Robot
 	var m simpleDetector
-	svc, err := vision.NewService("testService", &r, nil, nil, m.Detect, nil)
+	svc, err := vision.NewService(vision.Named("testService"), &r, nil, nil, m.Detect, nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, svc, test.ShouldNotBeNil)
 	result, err := svc.Detections(context.Background(), nil, nil)


### PR DESCRIPTION
All vision service models did not actually implement the `resource.Named` interface, and had left it nil. This caused a nil pointer de-reference whenever "Name()" was called on any vision service resource. 

Manually tested out the fixes with the QA plan for the color detector that originally found the error, and it now works. 