### PR TITLE
RSDK-2876 Generate local robot config instead of storing

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -276,6 +276,20 @@ func (mgr *Manager) ReconfigureResource(ctx context.Context, conf resource.Confi
 	return nil
 }
 
+// ModuleConfigs returns a slice of config.Module representing the currently
+// managed modules.
+func (mgr *Manager) ModuleConfigs() []config.Module {
+	mgr.mu.RLock()
+	defer mgr.mu.RUnlock()
+	var moduleConfigs []config.Module
+	for _, mod := range mgr.modules {
+		moduleConfigs = append(moduleConfigs, config.Module{
+			Name: mod.name, ExePath: mod.exe,
+		})
+	}
+	return moduleConfigs
+}
+
 // Provides returns true if a component/service config WOULD be handled by a module.
 func (mgr *Manager) Provides(conf resource.Config) bool {
 	mgr.mu.RLock()

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -276,18 +276,18 @@ func (mgr *Manager) ReconfigureResource(ctx context.Context, conf resource.Confi
 	return nil
 }
 
-// ModuleConfigs returns a slice of config.Module representing the currently
-// managed modules.
-func (mgr *Manager) ModuleConfigs() []config.Module {
+// Configs returns a slice of config.Module representing the currently managed
+// modules.
+func (mgr *Manager) Configs() []config.Module {
 	mgr.mu.RLock()
 	defer mgr.mu.RUnlock()
-	var moduleConfigs []config.Module
+	var configs []config.Module
 	for _, mod := range mgr.modules {
-		moduleConfigs = append(moduleConfigs, config.Module{
+		configs = append(configs, config.Module{
 			Name: mod.name, ExePath: mod.exe,
 		})
 	}
-	return moduleConfigs
+	return configs
 }
 
 // Provides returns true if a component/service config WOULD be handled by a module.

--- a/module/modmaninterface/interface.go
+++ b/module/modmaninterface/interface.go
@@ -20,6 +20,7 @@ type ModuleManager interface {
 	IsModularResource(name resource.Name) bool
 	ValidateConfig(ctx context.Context, cfg resource.Config) ([]string, error)
 
+	ModuleConfigs() []config.Module
 	Provides(cfg resource.Config) bool
 
 	Close(ctx context.Context) error

--- a/module/modmaninterface/interface.go
+++ b/module/modmaninterface/interface.go
@@ -20,7 +20,7 @@ type ModuleManager interface {
 	IsModularResource(name resource.Name) bool
 	ValidateConfig(ctx context.Context, cfg resource.Config) ([]string, error)
 
-	ModuleConfigs() []config.Module
+	Configs() []config.Module
 	Provides(cfg resource.Config) bool
 
 	Close(ctx context.Context) error

--- a/resource/resource_graph.go
+++ b/resource/resource_graph.go
@@ -213,6 +213,46 @@ func (g *Graph) FindNodesByAPI(api API) []Name {
 	return ret
 }
 
+// RemoteConfigs returns the configs of all remote API nodes.
+func (g *Graph) RemoteConfigs() []Config {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	var remotes []Config
+	for k, v := range g.nodes {
+		// using client.RemoteAPI can cause an import cycle.
+		if k.API == APINamespaceRDK.WithType("remote").WithSubtype("") {
+			remotes = append(remotes, v.Config())
+		}
+	}
+	return remotes
+}
+
+// ComponentConfigs returns the configs of all component API nodes.
+func (g *Graph) ComponentConfigs() []Config {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	var components []Config
+	for k, v := range g.nodes {
+		if k.API.IsComponent() {
+			components = append(components, v.Config())
+		}
+	}
+	return components
+}
+
+// ServiceConfigs returns the configs of all service API nodes.
+func (g *Graph) ServiceConfigs() []Config {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	var services []Config
+	for k, v := range g.nodes {
+		if k.API.IsService() {
+			services = append(services, v.Config())
+		}
+	}
+	return services
+}
+
 // findNodesByShortName returns all resources matching the given short name.
 func (g *Graph) findNodesByShortName(name string) []Name {
 	hasRemote := strings.Contains(name, ":")

--- a/resource/resource_graph.go
+++ b/resource/resource_graph.go
@@ -213,46 +213,6 @@ func (g *Graph) FindNodesByAPI(api API) []Name {
 	return ret
 }
 
-// RemoteConfigs returns the configs of all remote API nodes.
-func (g *Graph) RemoteConfigs() []Config {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	var remotes []Config
-	for k, v := range g.nodes {
-		// using client.RemoteAPI can cause an import cycle.
-		if k.API == APINamespaceRDK.WithType("remote").WithSubtype("") {
-			remotes = append(remotes, v.Config())
-		}
-	}
-	return remotes
-}
-
-// ComponentConfigs returns the configs of all component API nodes.
-func (g *Graph) ComponentConfigs() []Config {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	var components []Config
-	for k, v := range g.nodes {
-		if k.API.IsComponent() {
-			components = append(components, v.Config())
-		}
-	}
-	return components
-}
-
-// ServiceConfigs returns the configs of all service API nodes.
-func (g *Graph) ServiceConfigs() []Config {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	var services []Config
-	for k, v := range g.nodes {
-		if k.API.IsService() {
-			services = append(services, v.Config())
-		}
-	}
-	return services
-}
-
 // findNodesByShortName returns all resources matching the given short name.
 func (g *Graph) findNodesByShortName(name string) []Name {
 	hasRemote := strings.Contains(name, ":")

--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -295,8 +295,8 @@ func TestStatusClient(t *testing.T) {
 			},
 		},
 	}
-	injectRobot1.ConfigFunc = func(ctx context.Context) (*config.Config, error) {
-		return &cfg, nil
+	injectRobot1.ConfigFunc = func() *config.Config {
+		return &cfg
 	}
 
 	client, err := New(context.Background(), listener1.Addr().String(), logger)

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -177,8 +177,7 @@ func (r *localRobot) StopAll(ctx context.Context, extra map[resource.Name]map[st
 	return nil
 }
 
-// Config returns a config representing the current state of the resource
-// manager.
+// Config returns a config representing the current state of the robot.
 func (r *localRobot) Config() *config.Config {
 	return r.manager.createConfig()
 }

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -43,7 +43,6 @@ var _ = robot.LocalRobot(&localRobot{})
 type localRobot struct {
 	mu      sync.Mutex
 	manager *resourceManager
-	config  *config.Config
 
 	operations                 *operation.Manager
 	sessionManager             session.Manager
@@ -178,13 +177,10 @@ func (r *localRobot) StopAll(ctx context.Context, extra map[resource.Name]map[st
 	return nil
 }
 
-// Config returns the config used to construct the robot. Only local resources are returned.
-// This is allowed to be partial or empty.
-func (r *localRobot) Config(ctx context.Context) (*config.Config, error) {
-	cfgCpy := *r.config
-	cfgCpy.Components = append([]resource.Config{}, cfgCpy.Components...)
-
-	return &cfgCpy, nil
+// Config returns a config representing the current state of the resource
+// manager.
+func (r *localRobot) Config() *config.Config {
+	return r.manager.createConfig()
 }
 
 // Logger returns the logger the robot is using.
@@ -463,7 +459,6 @@ func newWithResources(
 		}
 	}, r.activeBackgroundWorkers.Done)
 
-	r.config = &config.Config{}
 	r.Reconfigure(ctx, cfg)
 
 	for name, res := range resources {
@@ -712,10 +707,11 @@ func (r *localRobot) updateWeakDependents(ctx context.Context) {
 			r.Logger().Errorw("failed to reconfigure resource with weak dependencies", "resource", resName, "error", err)
 		}
 	}
-	for _, conf := range r.config.Components {
+	conf := r.Config()
+	for _, conf := range conf.Components {
 		updateResourceWeakDependents(conf)
 	}
-	for _, conf := range r.config.Services {
+	for _, conf := range conf.Services {
 		updateResourceWeakDependents(conf)
 	}
 }
@@ -724,7 +720,7 @@ func (r *localRobot) updateWeakDependents(ctx context.Context) {
 // The output of this function is to be sent over GRPC to the client, so the client
 // can build its frame system. requests the remote components from the remote's frame system service.
 func (r *localRobot) FrameSystemConfig(ctx context.Context) (*framesystem.Config, error) {
-	localParts, err := r.getLocalFrameSystemParts(ctx)
+	localParts, err := r.getLocalFrameSystemParts()
 	if err != nil {
 		return nil, err
 	}
@@ -738,11 +734,8 @@ func (r *localRobot) FrameSystemConfig(ctx context.Context) (*framesystem.Config
 
 // getLocalFrameSystemParts collects and returns the physical parts of the robot that may have frame info,
 // excluding remote robots and services, etc from the robot's config.Config.
-func (r *localRobot) getLocalFrameSystemParts(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
-	cfg, err := r.Config(ctx)
-	if err != nil {
-		return nil, err
-	}
+func (r *localRobot) getLocalFrameSystemParts() ([]*referenceframe.FrameSystemPart, error) {
+	cfg := r.Config()
 
 	parts := make([]*referenceframe.FrameSystemPart, 0)
 	for _, component := range cfg.Components {
@@ -784,10 +777,7 @@ func (r *localRobot) getLocalFrameSystemParts(ctx context.Context) ([]*reference
 }
 
 func (r *localRobot) getRemoteFrameSystemParts(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
-	cfg, err := r.Config(ctx)
-	if err != nil {
-		return nil, err
-	}
+	cfg := r.Config()
 
 	remoteParts := make([]*referenceframe.FrameSystemPart, 0)
 	for _, remoteCfg := range cfg.Remotes {
@@ -941,8 +931,7 @@ func dialRobotClient(
 
 // Reconfigure will safely reconfigure a robot based on the given config. It will make
 // a best effort to remove no longer in use parts, but if it fails to do so, they could
-// possibly leak resources.
-// The given config is assumed to be owned by the robot now.
+// possibly leak resources. The given config may be modified by Reconfigure.
 func (r *localRobot) Reconfigure(ctx context.Context, newConfig *config.Config) {
 	var allErrs error
 
@@ -1007,9 +996,9 @@ func (r *localRobot) Reconfigure(ctx context.Context, newConfig *config.Config) 
 		allErrs = multierr.Combine(allErrs, err)
 	}
 
-	// Now that we have the new config and all references are resolved, diff it with the old
-	// config to see what has changed.
-	diff, err := config.DiffConfigs(*r.config, *newConfig, r.revealSensitiveConfigDiffs)
+	// Now that we have the new config and all references are resolved, diff it
+	// with the current generated config to see what has changed.
+	diff, err := config.DiffConfigs(*r.Config(), *newConfig, r.revealSensitiveConfigDiffs)
 	if err != nil {
 		r.logger.Errorw("error diffing the configs", "error", err)
 		return
@@ -1048,48 +1037,30 @@ func (r *localRobot) Reconfigure(ctx context.Context, newConfig *config.Config) 
 		r.logger.Debugf("(re)configuring with %+v", diff)
 	}
 
-	// First we remove resources and their children that are not in the graph.
+	// First we mark diff.Removed resources and their children for removal.
 	processesToClose, resourcesToCloseBeforeComplete, _ := r.manager.markRemoved(ctx, diff.Removed, r.logger)
 
-	// Second we update the resource graph.
+	// Second we update the resource graph and stop any removed processes.
 	allErrs = multierr.Combine(allErrs, r.manager.updateResources(ctx, diff))
-	r.config = newConfig
-
 	allErrs = multierr.Combine(allErrs, processesToClose.Stop())
 
-	// Third we attempt to complete the config (see function for details)
+	// Third we attempt to Close resources.
 	alreadyClosed := make(map[resource.Name]struct{}, len(resourcesToCloseBeforeComplete))
 	for _, res := range resourcesToCloseBeforeComplete {
 		allErrs = multierr.Combine(allErrs, r.manager.closeResource(ctx, res))
 		// avoid a double close later
 		alreadyClosed[res.Name()] = struct{}{}
 	}
+
+	// Fourth we attempt to complete the config (see function for details) and
+	// update weak dependents.
 	r.manager.completeConfig(ctx, r)
 	r.updateWeakDependents(ctx)
 
-	removedNames, removedErr := r.manager.removeMarkedAndClose(ctx, alreadyClosed)
-	if removedErr != nil {
-		allErrs = multierr.Combine(allErrs, removedErr)
-	}
-	for _, removedName := range removedNames {
-		// Remove dependents of removed resources from r.config; leaving these
-		// resources in the stored config means they cannot be correctly re-added
-		// when their dependency reappears.
-		//
-		// TODO(RSDK-2876): remove this code when we start referring to a config
-		// generated from resource graph instead of r.config.
-		for i, c := range r.config.Components {
-			if c.ResourceName() == removedName {
-				r.config.Components[i] = r.config.Components[len(r.config.Components)-1]
-				r.config.Components = r.config.Components[:len(r.config.Components)-1]
-			}
-		}
-		for i, s := range r.config.Services {
-			if s.ResourceName() == removedName {
-				r.config.Services[i] = r.config.Services[len(r.config.Services)-1]
-				r.config.Services = r.config.Services[:len(r.config.Services)-1]
-			}
-		}
+	// Finally we actually remove marked resources and Close any that are
+	// still unclosed.
+	if err := r.manager.removeMarkedAndClose(ctx, alreadyClosed); err != nil {
+		allErrs = multierr.Combine(allErrs, err)
 	}
 
 	// cleanup unused packages after all old resources have been closed above. This ensures

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -296,7 +296,9 @@ func TestConfigRemote(t *testing.T) {
 	test.That(t, convMap, test.ShouldResemble, armStatus)
 
 	cfg2 := r2.Config()
-	test.That(t, len(cfg2.Components), test.ShouldEqual, 2)
+	// Number of components should be equal to sum of number of local components
+	// (2) and remote components (18).
+	test.That(t, len(cfg2.Components), test.ShouldEqual, 20)
 
 	fsConfig, err := r2.FrameSystemConfig(context.Background())
 	test.That(t, err, test.ShouldBeNil)

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -295,8 +295,7 @@ func TestConfigRemote(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, convMap, test.ShouldResemble, armStatus)
 
-	cfg2, err := r2.Config(context.Background())
-	test.That(t, err, test.ShouldBeNil)
+	cfg2 := r2.Config()
 	test.That(t, len(cfg2.Components), test.ShouldEqual, 2)
 
 	fsConfig, err := r2.FrameSystemConfig(context.Background())
@@ -2591,14 +2590,20 @@ func TestOrphanedResources(t *testing.T) {
 		test.That(t, err, test.ShouldBeError,
 			resource.NewNotFoundError(generic.Named("h")))
 
-		// Assert that recompiling testmodule, removing testmodule and 'h' from
-		// config and adding both back re-adds 'h'.
-		//
-		// TODO(RSDK-2876): assert that we can keep 'h' in the config and it gets
-		// re-added to testmodule.
+		// Assert that recompiling testmodule, removing testmodule from config and
+		// adding it back re-adds 'h'.
 		err = rtestutils.BuildInDir("module/testmodule")
 		test.That(t, err, test.ShouldBeNil)
-		r.Reconfigure(ctx, &config.Config{})
+		cfg2 := &config.Config{
+			Components: []resource.Config{
+				{
+					Name:  "h",
+					Model: helperModel,
+					API:   generic.API,
+				},
+			},
+		}
+		r.Reconfigure(ctx, cfg2)
 		r.Reconfigure(ctx, cfg)
 
 		h, err = r.ResourceByName(generic.Named("h"))

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -1038,7 +1038,7 @@ func (manager *resourceManager) removeOrphanedResources(ctx context.Context,
 func (manager *resourceManager) createConfig() *config.Config {
 	conf := &config.Config{}
 
-	for _, resName := range manager.ResourceNames() {
+	for _, resName := range manager.resources.Names() {
 		gNode, ok := manager.resources.Node(resName)
 		if !ok {
 			continue

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -1053,7 +1053,7 @@ func (manager *resourceManager) createConfig() *config.Config {
 			remoteConf, err := rutils.AssertType[*config.Remote](resConf.ConvertedAttributes)
 			if err != nil {
 				manager.logger.Errorw("remote has unexpected type for ConvertedAttributes",
-					"resource", resName.String(),
+					"remote", resName.String(),
 					"error", err)
 				continue
 			}

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -1050,9 +1050,11 @@ func (manager *resourceManager) createConfig() *config.Config {
 		//
 		//nolint: gocritic
 		if resName.API == client.RemoteAPI {
-			remoteConf, ok := resConf.ConvertedAttributes.(*config.Remote)
-			if !ok {
-				manager.logger.Errorw("ConvertedAttributes is not a config.Remote")
+			remoteConf, err := rutils.AssertType[*config.Remote](resConf.ConvertedAttributes)
+			if err != nil {
+				manager.logger.Errorw("remote has unexpected type for ConvertedAttributes",
+					"resource", resName.String(),
+					"error", err)
 				continue
 			}
 

--- a/robot/impl/resource_manager_modular_test.go
+++ b/robot/impl/resource_manager_modular_test.go
@@ -208,7 +208,7 @@ func TestModularResources(t *testing.T) {
 
 		// Add a modular service
 		r.Reconfigure(context.Background(), &config.Config{
-			Components: []resource.Config{cfg},
+			Services: []resource.Config{cfg},
 		})
 		_, err = r.ResourceByName(cfg.ResourceName())
 		test.That(t, err, test.ShouldBeNil)
@@ -217,7 +217,7 @@ func TestModularResources(t *testing.T) {
 
 		// Reconfigure a modular service
 		r.Reconfigure(context.Background(), &config.Config{
-			Components: []resource.Config{cfg2},
+			Services: []resource.Config{cfg2},
 		})
 		_, err = r.ResourceByName(cfg2.ResourceName())
 		test.That(t, err, test.ShouldBeNil)
@@ -227,7 +227,7 @@ func TestModularResources(t *testing.T) {
 
 		// Add a non-modular service
 		r.Reconfigure(context.Background(), &config.Config{
-			Components: []resource.Config{cfg2, cfg3},
+			Services: []resource.Config{cfg2, cfg3},
 		})
 		_, err = r.ResourceByName(cfg2.ResourceName())
 		test.That(t, err, test.ShouldBeNil)
@@ -426,6 +426,12 @@ func (m *dummyModMan) IsModularResource(name resource.Name) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return name.Name != "builtin"
+}
+
+func (m *dummyModMan) ModuleConfigs() []config.Module {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return nil
 }
 
 func (m *dummyModMan) Provides(cfg resource.Config) bool {

--- a/robot/impl/resource_manager_modular_test.go
+++ b/robot/impl/resource_manager_modular_test.go
@@ -428,7 +428,7 @@ func (m *dummyModMan) IsModularResource(name resource.Name) bool {
 	return name.Name != "builtin"
 }
 
-func (m *dummyModMan) ModuleConfigs() []config.Module {
+func (m *dummyModMan) Configs() []config.Module {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return nil

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -721,13 +721,11 @@ func TestManagerNewComponent(t *testing.T) {
 	robotForRemote := &localRobot{
 		manager: newResourceManager(resourceManagerOptions{}, logger),
 		logger:  logger,
-		config:  cfg,
 	}
 	diff, err := config.DiffConfigs(config.Config{}, *cfg, true)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, robotForRemote.manager.updateResources(context.Background(), diff), test.ShouldBeNil)
 	test.That(t, robotForRemote.manager.resources.ResolveDependencies(logger), test.ShouldBeNil)
-	robotForRemote.config.Components[8].DependsOn = append(robotForRemote.config.Components[8].DependsOn, "arm3")
 
 	diff = &config.Diff{
 		Added: &config.Config{},

--- a/robot/robot.go
+++ b/robot/robot.go
@@ -90,8 +90,7 @@ type Robot interface {
 type LocalRobot interface {
 	Robot
 
-	// Config returns a config representing the current state of the resource
-	// manager.
+	// Config returns a config representing the current state of the robot.
 	Config() *config.Config
 
 	// Reconfigure instructs the robot to safely reconfigure itself based

--- a/robot/robot.go
+++ b/robot/robot.go
@@ -90,9 +90,9 @@ type Robot interface {
 type LocalRobot interface {
 	Robot
 
-	// Config returns the local config used to construct the robot.
-	// This is allowed to be partial or empty.
-	Config(ctx context.Context) (*config.Config, error)
+	// Config returns a config representing the current state of the resource
+	// manager.
+	Config() *config.Config
 
 	// Reconfigure instructs the robot to safely reconfigure itself based
 	// on the given new config.

--- a/robot/web/web_test.go
+++ b/robot/web/web_test.go
@@ -794,7 +794,7 @@ func setupRobotCtx(t *testing.T) (context.Context, robot.Robot) {
 		return pos, nil
 	}
 	injectRobot := &inject.Robot{}
-	injectRobot.ConfigFunc = func(ctx context.Context) (*config.Config, error) { return &config.Config{}, nil }
+	injectRobot.ConfigFunc = func() *config.Config { return &config.Config{} }
 	injectRobot.ResourceNamesFunc = func() []resource.Name { return resources }
 	injectRobot.ResourceRPCAPIsFunc = func() []resource.RPCAPI { return nil }
 	injectRobot.ResourceByNameFunc = func(name resource.Name) (resource.Resource, error) {
@@ -856,7 +856,7 @@ func TestForeignResource(t *testing.T) {
 
 	injectRobot := &inject.Robot{}
 	injectRobot.LoggerFunc = func() golog.Logger { return logger }
-	injectRobot.ConfigFunc = func(ctx context.Context) (*config.Config, error) { return &config.Config{}, nil }
+	injectRobot.ConfigFunc = func() *config.Config { return &config.Config{} }
 	injectRobot.ResourceNamesFunc = func() []resource.Name {
 		return []resource.Name{
 			resource.NewName(resourceAPI, "thing1"),

--- a/testutils/inject/robot.go
+++ b/testutils/inject/robot.go
@@ -33,7 +33,7 @@ type Robot struct {
 	ResourceNamesFunc      func() []resource.Name
 	ResourceRPCAPIsFunc    func() []resource.RPCAPI
 	ProcessManagerFunc     func() pexec.ProcessManager
-	ConfigFunc             func(ctx context.Context) (*config.Config, error)
+	ConfigFunc             func() *config.Config
 	LoggerFunc             func() golog.Logger
 	CloseFunc              func(ctx context.Context) error
 	StopAllFunc            func(ctx context.Context, extra map[resource.Name]map[string]interface{}) error
@@ -165,13 +165,13 @@ func (r *Robot) PackageManager() packages.Manager {
 }
 
 // Config calls the injected Config or the real version.
-func (r *Robot) Config(ctx context.Context) (*config.Config, error) {
+func (r *Robot) Config() *config.Config {
 	r.Mu.RLock()
 	defer r.Mu.RUnlock()
 	if r.ConfigFunc == nil {
-		return r.LocalRobot.Config(ctx)
+		return r.LocalRobot.Config()
 	}
-	return r.ConfigFunc(ctx)
+	return r.ConfigFunc()
 }
 
 // Logger calls the injected Logger or the real version.


### PR DESCRIPTION
RSDK-2876

Stops storing any `config.Config` on `localRobot`. Adds `createConfig` to the resource manager to dynamically generate a config based on the state of the manager. Stores added module and process configs in the resource manager. Updates tests.