### PR TITLE
RSDK-2886 Add better context checks before selects

### DIFF
--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -446,6 +446,10 @@ func newWithResources(
 	// detected and in testing.
 	goutils.ManagedGo(func() {
 		for {
+			if closeCtx.Err() != nil {
+				return
+			}
+
 			select {
 			case <-closeCtx.Done():
 				return

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -502,6 +502,10 @@ func (manager *resourceManager) completeConfig(
 			}
 			manager.addRemote(ctx, rr, gNode, *remConf)
 			rr.SetParentNotifier(func() {
+				if robot.closeContext.Err() != nil {
+					return
+				}
+
 				// Trigger completeConfig goroutine execution when a change in remote
 				// is detected.
 				select {


### PR DESCRIPTION
RSDK-2886 (followup)

I removed these context checks, as I thought they were unnecessary. They are not unnecessary and add extra safety (`select` selects non-deterministically and may pick a different `case` even if the context has expired).