### PR TITLE
RSDK-2100 Automated test for camera discovery service

### DIFF
--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -28,12 +28,13 @@ import (
 	"go.viam.com/rdk/rimage/transform"
 )
 
-var model = resource.DefaultModelFamily.WithModel("webcam")
+// ModelWebcam is the name of the webcam component.
+var ModelWebcam = resource.DefaultModelFamily.WithModel("webcam")
 
 func init() {
 	resource.RegisterComponent(
 		camera.API,
-		model,
+		ModelWebcam,
 		resource.Registration[camera.Camera, *WebcamConfig]{
 			Constructor: NewWebcam,
 			Discover: func(ctx context.Context, logger golog.Logger) (interface{}, error) {

--- a/components/camera/videosource/webcam_e2e_test.go
+++ b/components/camera/videosource/webcam_e2e_test.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux && vcamera
 
 package videosource_test
 
@@ -28,7 +28,6 @@ func findWebcam(t *testing.T, webcams []*pb.Webcam, name string) *pb.Webcam {
 }
 
 func TestWebcamDiscovery(t *testing.T) {
-	t.Skip() // TODO: install dependencies to Github-hosted runners
 	logger := golog.NewTestLogger(t)
 
 	reg, ok := resource.LookupRegistration(camera.API, videosource.ModelWebcam)
@@ -79,7 +78,6 @@ func newWebcamConfig(name, path string) resource.Config {
 }
 
 func TestWebcamGetImage(t *testing.T) {
-	t.Skip() // TODO: install dependencies to Github-hosted runners
 	logger := golog.NewTestLogger(t)
 	config, err := vcamera.Builder(logger).
 		NewCamera(62, "Lo Res Webcam", vcamera.Resolution{Width: 640, Height: 480}).

--- a/components/camera/videosource/webcam_e2e_test.go
+++ b/components/camera/videosource/webcam_e2e_test.go
@@ -28,6 +28,7 @@ func findWebcam(t *testing.T, webcams []*pb.Webcam, name string) *pb.Webcam {
 }
 
 func TestWebcamDiscovery(t *testing.T) {
+	t.Skip() // TODO: install dependencies to Github-hosted runners
 	logger := golog.NewTestLogger(t)
 
 	reg, ok := resource.LookupRegistration(camera.API, videosource.ModelWebcam)
@@ -78,6 +79,7 @@ func newWebcamConfig(name, path string) resource.Config {
 }
 
 func TestWebcamGetImage(t *testing.T) {
+	t.Skip() // TODO: install dependencies to Github-hosted runners
 	logger := golog.NewTestLogger(t)
 	config, err := vcamera.Builder(logger).
 		NewCamera(62, "Lo Res Webcam", vcamera.Resolution{Width: 640, Height: 480}).

--- a/components/camera/videosource/webcam_e2e_test.go
+++ b/components/camera/videosource/webcam_e2e_test.go
@@ -1,0 +1,122 @@
+//go:build linux
+
+package videosource_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/edaniels/golog"
+	pb "go.viam.com/api/component/camera/v1"
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/components/camera"
+	"go.viam.com/rdk/components/camera/videosource"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/testutils/vcamera"
+)
+
+func findWebcam(t *testing.T, webcams []*pb.Webcam, name string) *pb.Webcam {
+	t.Helper()
+	for _, w := range webcams {
+		if w.Name == name {
+			return w
+		}
+	}
+	t.Fatalf("could not find webcam %s", name)
+	return nil
+}
+
+func TestWebcamDiscovery(t *testing.T) {
+	logger := golog.NewTestLogger(t)
+
+	reg, ok := resource.LookupRegistration(camera.API, videosource.ModelWebcam)
+	test.That(t, ok, test.ShouldBeTrue)
+
+	ctx := context.Background()
+	discoveries, err := reg.Discover(ctx, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	webcams, ok := discoveries.(*pb.Webcams)
+	test.That(t, ok, test.ShouldBeTrue)
+	webcamsLen := len(webcams.Webcams)
+
+	// Video capture and overlay minor numbers range == [0, 63]
+	// Start from the end of the range to avoid conflicts with other devices
+	// Source: https://www.kernel.org/doc/html/v4.9/media/uapi/v4l/diff-v4l.html
+	config, err := vcamera.Builder(logger).
+		NewCamera(62, "Lo Res Webcam", vcamera.Resolution{Width: 640, Height: 480}).
+		NewCamera(63, "Hi Res Webcam", vcamera.Resolution{Width: 1280, Height: 720}).
+		Stream()
+
+	test.That(t, err, test.ShouldBeNil)
+	defer config.Shutdown()
+
+	discoveries, err = reg.Discover(ctx, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	webcams, ok = discoveries.(*pb.Webcams)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, len(webcams.Webcams), test.ShouldEqual, webcamsLen+2)
+
+	webcam := findWebcam(t, webcams.Webcams, "Hi Res Webcam")
+	test.That(t, webcam.Properties[0].WidthPx, test.ShouldEqual, 1280)
+	test.That(t, webcam.Properties[0].HeightPx, test.ShouldEqual, 720)
+
+	webcam = findWebcam(t, webcams.Webcams, "Lo Res Webcam")
+	test.That(t, webcam.Properties[0].WidthPx, test.ShouldEqual, 640)
+	test.That(t, webcam.Properties[0].HeightPx, test.ShouldEqual, 480)
+}
+
+func newWebcamConfig(name, path string) resource.Config {
+	conf := resource.NewEmptyConfig(
+		resource.NewName(camera.API, name),
+		resource.DefaultModelFamily.WithModel("webcam"),
+	)
+	conf.ConvertedAttributes = &videosource.WebcamConfig{Path: path}
+	return conf
+}
+
+func TestWebcamGetImage(t *testing.T) {
+	logger := golog.NewTestLogger(t)
+	config, err := vcamera.Builder(logger).
+		NewCamera(62, "Lo Res Webcam", vcamera.Resolution{Width: 640, Height: 480}).
+		NewCamera(63, "Hi Res Webcam", vcamera.Resolution{Width: 1280, Height: 720}).
+		Stream()
+
+	test.That(t, err, test.ShouldBeNil)
+	defer config.Shutdown()
+
+	cancelCtx, cancelFn := context.WithCancel(context.Background())
+	defer cancelFn()
+
+	conf := newWebcamConfig("cam1", "video62")
+	cam1, err := videosource.NewWebcam(cancelCtx, nil, conf, logger)
+	test.That(t, err, test.ShouldBeNil)
+	defer cam1.Close(cancelCtx)
+
+	stream, err := cam1.Stream(cancelCtx)
+	test.That(t, err, test.ShouldBeNil)
+
+	img, rel, err := stream.Next(cancelCtx)
+	test.That(t, err, test.ShouldBeNil)
+	defer rel()
+
+	test.That(t, img.Bounds().Dx(), test.ShouldEqual, 640)
+	test.That(t, img.Bounds().Dy(), test.ShouldEqual, 480)
+
+	conf = newWebcamConfig("cam2", "video63")
+	cam2, err := videosource.NewWebcam(cancelCtx, nil, conf, logger)
+	test.That(t, err, test.ShouldBeNil)
+	defer cam2.Close(cancelCtx)
+
+	stream, err = cam2.Stream(cancelCtx)
+	test.That(t, err, test.ShouldBeNil)
+
+	img, rel, err = stream.Next(cancelCtx)
+	test.That(t, err, test.ShouldBeNil)
+	defer rel()
+
+	test.That(t, img.Bounds().Dx(), test.ShouldEqual, 1280)
+	test.That(t, img.Bounds().Dy(), test.ShouldEqual, 720)
+}

--- a/testutils/vcamera/cmd/main.go
+++ b/testutils/vcamera/cmd/main.go
@@ -1,0 +1,40 @@
+//go:build linux
+
+// This package creates two virtual cameras and streams test video to them until the program
+// halts (with ctrl-c for example). These cameras are discoverable by app.
+//
+// Prerequisites: run etc/v4l2loopback_setup.sh which will install GStreamer and V4L2Loopback.
+package main
+
+import (
+	"github.com/edaniels/golog"
+	"go.viam.com/rdk/testutils/vcamera"
+	"os"
+	"os/signal"
+)
+
+func main() {
+	logger := golog.NewDebugLogger("vcamera")
+	config, err := vcamera.Builder(logger).
+		NewCamera(1, "Low-res Camera", vcamera.Resolution{Width: 640, Height: 480}).
+		NewCamera(2, "Hi-res Camera", vcamera.Resolution{Width: 1280, Height: 720}).
+		Stream()
+
+	defer func() {
+		if err := config.Shutdown(); err != nil {
+			logger.Fatal(err)
+		}
+	}()
+
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+
+	logger.Info("Streaming on /dev/video1 and /dev/video2...")
+	// wait for ctrl-c or other interrupt
+	<-c
+	logger.Info("Finished streaming.")
+}

--- a/testutils/vcamera/cmd/main.go
+++ b/testutils/vcamera/cmd/main.go
@@ -7,10 +7,12 @@
 package main
 
 import (
-	"github.com/edaniels/golog"
-	"go.viam.com/rdk/testutils/vcamera"
 	"os"
 	"os/signal"
+
+	"github.com/edaniels/golog"
+
+	"go.viam.com/rdk/testutils/vcamera"
 )
 
 func main() {

--- a/testutils/vcamera/vcamera.go
+++ b/testutils/vcamera/vcamera.go
@@ -1,0 +1,237 @@
+//go:build linux
+
+/*
+Package vcamera creates and streams video to virtual V4L2 capture devices on Linux.
+
+It uses [V4L2Loopback] to create virtual camera drivers and [GStreamer] to display test video streams. You can install
+both using our V4L2Loopback setup [script]. This script also needs to run `sudo modprobe v4l2loopback`. Since
+feeding the root password to that command at runtime would be impractical, it's recommended that you allow the current user
+to run that command without requiring a password. The script above will display a prompt asking if you want this behavior.
+Select "yes".
+
+Usage:
+
+	// create a builder object
+	config := vcamera.Builder()
+
+	// create 1-to-N cameras
+	config = config.NewCamera(1, "Low-res Camera", vcamera.Resolution{Width: 640, Height: 480})
+	config = config.NewCamera(2, "Hi-res Camera", vcamera.Resolution{Width: 1280, Height: 720})
+	...
+
+	// start streaming
+	config, err := Stream()
+	if err != nil {
+		// handle error
+	}
+
+	// shutdown streams
+	config.Shutdown()
+
+Because this class allows for method chaining the above could be accomplished like so
+
+	config, err := vcamera.Builder().
+		NewCamera(1, "Low-res Camera", vcamera.Resolution{Width: 640, Height: 480}).
+		NewCamera(2, "Hi-res Camera", vcamera.Resolution{Width: 1280, Height: 720}).
+		Stream()
+
+	// DO NOT forget to stop streaming to avoid leaking resources.
+	defer config.Shutdown()
+
+[V4L2Loopback]: https://github.com/umlaeute/v4l2loopback/tree/8cb5270d20484bde26eabb085011a8ea27285446
+[GStreamer]: https://gstreamer.freedesktop.org/
+[script]: https://github.com/viamrobotics/rdk/blob/0f49904ec550e5a33fc649e3153b4d465256a02a/etc/v4l2loopback_setup.sh
+*/
+package vcamera
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/edaniels/golog"
+	"github.com/pkg/errors"
+	"go.viam.com/utils"
+)
+
+// Resolution stores the Width and Height in pixels for a camera resolution.
+type Resolution struct {
+	Width  int
+	Height int
+}
+
+type device struct {
+	key        string
+	label      string
+	resolution Resolution
+}
+
+// Config is a builder object used to create virtual cameras.
+type Config struct {
+	deviceMap               map[int]bool
+	devices                 []device
+	err                     error
+	cancelCtx               context.Context
+	cancelFn                func()
+	activeBackgroundWorkers sync.WaitGroup
+	logger                  golog.Logger
+}
+
+// Builder creates a new vcamera.Config builder object.
+func Builder(logger golog.Logger) *Config {
+	cancelCtx, cancelFn := context.WithCancel(context.Background())
+	return &Config{
+		deviceMap: make(map[int]bool),
+		cancelFn:  cancelFn,
+		cancelCtx: cancelCtx,
+		logger:    logger,
+	}
+}
+
+// NewCamera lazily creates a new camera. No cameras are actually created until Stream is called.
+func (c *Config) NewCamera(id int, label string, res Resolution) *Config {
+	if c.err != nil {
+		return c
+	}
+
+	if _, ok := c.deviceMap[id]; ok {
+		c.err = fmt.Errorf("duplicate camera id %d", id)
+		return c
+	}
+
+	c.deviceMap[id] = true
+	device := device{
+		key:        strconv.Itoa(id),
+		label:      fmt.Sprintf("\"%s\"", label), // add quotes
+		resolution: res,
+	}
+	c.devices = append(c.devices, device)
+	return c
+}
+
+func createCameras(c *Config) error {
+	var devKeys []string
+	var devLabels []string
+	for _, d := range c.devices {
+		devKeys = append(devKeys, d.key)
+		devLabels = append(devLabels, d.label)
+	}
+
+	devices := fmt.Sprintf("%s=%s", "video_nr", strings.Join(devKeys, ","))
+	labels := fmt.Sprintf("%s=%s", "card_label", strings.Join(devLabels, ","))
+
+	cmd := fmt.Sprintf("sudo modprobe v4l2loopback %s %s", devices, labels)
+	out, err := exec.Command("bash", "-c", cmd).CombinedOutput() //nolint:gosec
+	if err != nil {
+		return errors.New(string(out))
+	}
+	return nil
+}
+
+func startStream(config *Config, dev device) (<-chan struct{}, error) {
+	//nolint:gosec
+	cmd := exec.CommandContext(config.cancelCtx, "bash", "-c", fmt.Sprintf(
+		"gst-launch-1.0 -v videotestsrc "+
+			"! video/x-raw,format=YUY2,width=320,height=240 "+
+			"! videoscale "+
+			"! video/x-raw,format=YUY2,width=%d,height=%d "+
+			"! v4l2sink device=/dev/video%s",
+		dev.resolution.Width, dev.resolution.Height, dev.key))
+
+	// capture output from stdout
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	// wait for cmd to finish to avoid leak
+	config.activeBackgroundWorkers.Add(1)
+	go func() {
+		defer config.activeBackgroundWorkers.Done()
+		if err := cmd.Wait(); err != nil {
+			config.logger.Warn(err)
+		}
+	}()
+
+	// broadcast channel, closed when stream is in state "PLAYING"
+	readyCh := make(chan struct{})
+	scanner := bufio.NewScanner(stdout)
+
+	config.activeBackgroundWorkers.Add(1)
+	utils.PanicCapturingGo(func() {
+		defer config.activeBackgroundWorkers.Done()
+		for {
+			select {
+			case <-config.cancelCtx.Done():
+				return
+			default:
+				scanner.Scan()
+				// looks for state "PLAYING" in stdout
+				if line := scanner.Text(); strings.Contains(line, "PLAYING") {
+					close(readyCh)
+					return
+				}
+			}
+		}
+	})
+	return readyCh, nil
+}
+
+// Stream starts streaming videos to all virtual cameras.
+//
+// This function blocks until all virtual cameras successfully start streaming, or an error occurs.
+// Shutdown will stop all streams started by this method.
+func (c *Config) Stream() (*Config, error) {
+	if c.err != nil {
+		return c, c.err
+	}
+
+	if c.err = createCameras(c); c.err != nil {
+		return c, c.err
+	}
+
+	var streamChs []<-chan struct{}
+	for _, d := range c.devices {
+		var ch <-chan struct{}
+		ch, c.err = startStream(c, d)
+		streamChs = append(streamChs, ch)
+		if c.err != nil {
+			return c, c.err
+		}
+	}
+
+	// wait for streams to become ready or timeout
+	timeout := time.After(time.Second)
+	for _, s := range streamChs {
+		select {
+		case <-s:
+		case <-timeout:
+			c.err = errors.New("timeout waiting for stream")
+			return c, c.err
+		}
+	}
+
+	return c, c.err
+}
+
+// Shutdown stops streaming to and removes all virtual cameras.
+func (c *Config) Shutdown() error {
+	c.cancelFn()
+	c.activeBackgroundWorkers.Wait()
+	c.err = errors.New("stopped streaming")
+
+	// removes all virtual cameras
+	if out, err := exec.Command("bash", "-c", "sudo modprobe v4l2loopback -r").CombinedOutput(); err != nil {
+		return errors.New(string(out))
+	}
+	return nil
+}


### PR DESCRIPTION
This PR adds end-to-end test for webcams. There are three files
1. **main.go** - a script to create virtual cameras that can be displayed on in app
2. **webcam_e2e_test.go** - the end-to-end tests.
3. **vcamera.go** - the builder for creating virtual cameras

I recommend reviewing them in that order which is the order of least complexity. Below is a screen recording for the test video in app. `main.go` created both cameras. 
![output](https://github.com/viamrobotics/rdk/assets/34226620/2075cadd-8ded-4589-832c-f6b3db05adfb)
#### TODO
If these test prove useful it may be worth wrapping the actual libraries rather than running bash commands for GStreamer and V4L2loopback assuming we can include them only for test dependencies. 

If I can figure out a way to install V4L2Loopback on some VM runnable by Github I'll run these tests as a Github check in PRs.
#### Testing
These test can only run on Linux and assumes GStreamer and V4L2Loopback are installed. You can use `etc/v4l2loopback_setup.sh` to install both.

The only hiccup is that something in app (or upstream) continues to use `/dev/video*` even after closing the cameras. This prevents `sudo modprobe v4l2loopback -r` from properly removing all devices after running a test. Simply running that command before testing solves the problem. 

The outputs of the tests in `webcam_e2e_test.go` are below

```
➜  videosource git:(RSDK-2100) ✗ go test -race webcam_e2e_test.go -v
=== RUN   TestWebcamDiscoveryNil
--- PASS: TestWebcamDiscoveryNil (0.00s)
=== RUN   TestWebcamDiscovery
--- PASS: TestWebcamDiscovery (0.05s)
=== RUN   TestWebcamGetImage
    logger.go:130: 2023-05-12T14:53:26.293-0400 DEBUG   videosource/webcam.go:290       reinitializing driver   {"camera_name": "cam1"}
    logger.go:130: 2023-05-12T14:53:26.294-0400 DEBUG   gostream@v0.0.0-20230509190834-366e3941adaa/query.go:492        before specific filter, we found the following drivers  {"camera_name": "cam1", "count": 4}
    logger.go:130: 2023-05-12T14:53:26.294-0400 DEBUG   gostream@v0.0.0-20230509190834-366e3941adaa/query.go:494        video0;video0   {"camera_name": "cam1", "priority": 0.1, "type": "camera"}
    logger.go:130: 2023-05-12T14:53:26.294-0400 DEBUG   gostream@v0.0.0-20230509190834-366e3941adaa/query.go:494        video1;video1   {"camera_name": "cam1", "priority": 0, "type": "camera"}
    logger.go:130: 2023-05-12T14:53:26.294-0400 DEBUG   gostream@v0.0.0-20230509190834-366e3941adaa/query.go:494        video0;video0   {"camera_name": "cam1", "priority": 0.1, "type": "camera"}
    logger.go:130: 2023-05-12T14:53:26.294-0400 DEBUG   gostream@v0.0.0-20230509190834-366e3941adaa/query.go:494        video1;video1   {"camera_name": "cam1", "priority": 0, "type": "camera"}
    logger.go:130: 2023-05-12T14:53:26.294-0400 DEBUG   gostream@v0.0.0-20230509190834-366e3941adaa/query.go:501        found drivers matching specific filter  {"camera_name": "cam1", "count": 2}
    logger.go:130: 2023-05-12T14:53:26.294-0400 DEBUG   gostream@v0.0.0-20230509190834-366e3941adaa/query.go:505        considering driver      {"camera_name": "cam1", "label": "video0;video0", "priority": 0.10000000149011612}
    logger.go:130: 2023-05-12T14:53:26.294-0400 DEBUG   gostream@v0.0.0-20230509190834-366e3941adaa/query.go:516        driver properties satisfy some constraints      {"camera_name": "cam1", "label": "video0;video0", "props": {"DeviceID":"29e37073-600c-4b24-8545-0e8438b5c303","Width":640,"Height":480,"FrameRate":0,"FrameFormat":"YUY2","DiscardFramesOlderThan":0,"ChannelCount":0,"Latency":0,"SampleRate":0,"SampleSize":0,"IsBigEndian":false,"IsFloat":false,"IsInterleaved":false}, "distance": 0, "distance_with_priority": -0.10000000149011612}
    logger.go:130: 2023-05-12T14:53:26.295-0400 DEBUG   gostream@v0.0.0-20230509190834-366e3941adaa/query.go:505        considering driver      {"camera_name": "cam1", "label": "video0;video0", "priority": 0.10000000149011612}
    logger.go:130: 2023-05-12T14:53:26.295-0400 DEBUG   gostream@v0.0.0-20230509190834-366e3941adaa/query.go:516        driver properties satisfy some constraints      {"camera_name": "cam1", "label": "video0;video0", "props": {"DeviceID":"de209623-3e45-4b84-923e-7456bac12e95","Width":640,"Height":480,"FrameRate":0,"FrameFormat":"YUY2","DiscardFramesOlderThan":0,"ChannelCount":0,"Latency":0,"SampleRate":0,"SampleSize":0,"IsBigEndian":false,"IsFloat":false,"IsInterleaved":false}, "distance": 0, "distance_with_priority": -0.10000000149011612}
    logger.go:130: 2023-05-12T14:53:26.295-0400 DEBUG   gostream@v0.0.0-20230509190834-366e3941adaa/query.go:534        winning driver  {"camera_name": "cam1", "label": "video0;video0", "props": {"DeviceID":"29e37073-600c-4b24-8545-0e8438b5c303","Width":640,"Height":480,"FrameRate":0,"FrameFormat":"YUY2","DiscardFramesOlderThan":0,"ChannelCount":0,"Latency":0,"SampleRate":0,"SampleSize":0,"IsBigEndian":false,"IsFloat":false,"IsInterleaved":false}}
    logger.go:130: 2023-05-12T14:53:26.297-0400 DEBUG   videosource/webcam.go:290       reinitializing driver   {"camera_name": "cam2"}
    logger.go:130: 2023-05-12T14:53:26.298-0400 DEBUG   gostream@v0.0.0-20230509190834-366e3941adaa/query.go:492        before specific filter, we found the following drivers  {"camera_name": "cam2", "count": 6}
    logger.go:130: 2023-05-12T14:53:26.298-0400 DEBUG   gostream@v0.0.0-20230509190834-366e3941adaa/query.go:494        video1;video1   {"camera_name": "cam2", "priority": 0, "type": "camera"}
    logger.go:130: 2023-05-12T14:53:26.298-0400 DEBUG   gostream@v0.0.0-20230509190834-366e3941adaa/query.go:494        video0;video0   {"camera_name": "cam2", "priority": 0.1, "type": "camera"}
    logger.go:130: 2023-05-12T14:53:26.298-0400 DEBUG   gostream@v0.0.0-20230509190834-366e3941adaa/query.go:494        video1;video1   {"camera_name": "cam2", "priority": 0, "type": "camera"}
    logger.go:130: 2023-05-12T14:53:26.298-0400 DEBUG   gostream@v0.0.0-20230509190834-366e3941adaa/query.go:494        video0;video0   {"camera_name": "cam2", "priority": 0.1, "type": "camera"}
    logger.go:130: 2023-05-12T14:53:26.298-0400 DEBUG   gostream@v0.0.0-20230509190834-366e3941adaa/query.go:494        video1;video1   {"camera_name": "cam2", "priority": 0, "type": "camera"}
    logger.go:130: 2023-05-12T14:53:26.298-0400 DEBUG   gostream@v0.0.0-20230509190834-366e3941adaa/query.go:494        video0;video0   {"camera_name": "cam2", "priority": 0.1, "type": "camera"}
    logger.go:130: 2023-05-12T14:53:26.298-0400 DEBUG   gostream@v0.0.0-20230509190834-366e3941adaa/query.go:501        found drivers matching specific filter  {"camera_name": "cam2", "count": 3}
    logger.go:130: 2023-05-12T14:53:26.298-0400 DEBUG   gostream@v0.0.0-20230509190834-366e3941adaa/query.go:505        considering driver      {"camera_name": "cam2", "label": "video1;video1", "priority": 0}
    logger.go:130: 2023-05-12T14:53:26.298-0400 DEBUG   gostream@v0.0.0-20230509190834-366e3941adaa/query.go:516        driver properties satisfy some constraints      {"camera_name": "cam2", "label": "video1;video1", "props": {"DeviceID":"446c50a5-8f45-47d2-be72-725eb2931c7e","Width":1280,"Height":720,"FrameRate":0,"FrameFormat":"YUY2","DiscardFramesOlderThan":0,"ChannelCount":0,"Latency":0,"SampleRate":0,"SampleSize":0,"IsBigEndian":false,"IsFloat":false,"IsInterleaved":false}, "distance": 0.328042328042328, "distance_with_priority": 0.328042328042328}
    logger.go:130: 2023-05-12T14:53:26.299-0400 DEBUG   gostream@v0.0.0-20230509190834-366e3941adaa/query.go:505        considering driver      {"camera_name": "cam2", "label": "video1;video1", "priority": 0}
    logger.go:130: 2023-05-12T14:53:26.299-0400 DEBUG   gostream@v0.0.0-20230509190834-366e3941adaa/query.go:516        driver properties satisfy some constraints      {"camera_name": "cam2", "label": "video1;video1", "props": {"DeviceID":"b0c4b31e-b0cc-4558-8f64-952870f40647","Width":1280,"Height":720,"FrameRate":0,"FrameFormat":"YUY2","DiscardFramesOlderThan":0,"ChannelCount":0,"Latency":0,"SampleRate":0,"SampleSize":0,"IsBigEndian":false,"IsFloat":false,"IsInterleaved":false}, "distance": 0.328042328042328, "distance_with_priority": 0.328042328042328}
    logger.go:130: 2023-05-12T14:53:26.299-0400 DEBUG   gostream@v0.0.0-20230509190834-366e3941adaa/query.go:505        considering driver      {"camera_name": "cam2", "label": "video1;video1", "priority": 0}
    logger.go:130: 2023-05-12T14:53:26.299-0400 DEBUG   gostream@v0.0.0-20230509190834-366e3941adaa/query.go:516        driver properties satisfy some constraints      {"camera_name": "cam2", "label": "video1;video1", "props": {"DeviceID":"9e2299ca-6126-4dac-841a-44fe597e5aef","Width":1280,"Height":720,"FrameRate":0,"FrameFormat":"YUY2","DiscardFramesOlderThan":0,"ChannelCount":0,"Latency":0,"SampleRate":0,"SampleSize":0,"IsBigEndian":false,"IsFloat":false,"IsInterleaved":false}, "distance": 0.328042328042328, "distance_with_priority": 0.328042328042328}
    logger.go:130: 2023-05-12T14:53:26.299-0400 DEBUG   gostream@v0.0.0-20230509190834-366e3941adaa/query.go:534        winning driver  {"camera_name": "cam2", "label": "video1;video1", "props": {"DeviceID":"446c50a5-8f45-47d2-be72-725eb2931c7e","Width":1280,"Height":720,"FrameRate":0,"FrameFormat":"YUY2","DiscardFramesOlderThan":0,"ChannelCount":0,"Latency":0,"SampleRate":0,"SampleSize":0,"IsBigEndian":false,"IsFloat":false,"IsInterleaved":false}}
--- PASS: TestWebcamGetImage (0.04s)
PASS
ok      command-line-arguments  0.145s

```