### PR TITLE
[RSDK-2691] Refactor the raspberry pi boards in anticipation of reconfiguration

### DIFF
--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -94,20 +94,23 @@ func initializePigpio() error {
 	instanceMu.Lock()
 	defer instanceMu.Unlock()
 
-	if !pigpioInitialized {
-		resCode = C.gpioInitialise()
-		if resCode < 0 {
-			// failed to init, check for common causes
-			_, err := os.Stat("/sys/bus/platform/drivers/raspberrypi-firmware")
-			if err != nil {
-				return errors.New("not running on a pi")
-			}
-			if os.Getuid() != 0 {
-				return errors.New("not running as root, try sudo")
-			}
-			return picommon.ConvertErrorCodeToMessage(int(resCode), "error")
-		}
+	if pigpioInitialized {
+		return nil
 	}
+
+	resCode = C.gpioInitialise()
+	if resCode < 0 {
+		// failed to init, check for common causes
+		_, err := os.Stat("/sys/bus/platform/drivers/raspberrypi-firmware")
+		if err != nil {
+			return errors.New("not running on a pi")
+		}
+		if os.Getuid() != 0 {
+			return errors.New("not running as root, try sudo")
+		}
+		return picommon.ConvertErrorCodeToMessage(int(resCode), "error")
+	}
+
 	pigpioInitialized = true
 	return nil
 }

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -78,8 +78,8 @@ type piPigpio struct {
 	analogs         map[string]board.AnalogReader
 	i2cs            map[string]board.I2C
 	spis            map[string]board.SPI
-	interrupts      map[string]board.DigitalInterrupt
-	interruptsHW    map[uint]board.DigitalInterrupt
+	interrupts      map[string]board.DigitalInterrupt // Maps interrupt names to interrupts
+	interruptsHW    map[uint]board.DigitalInterrupt // Maps broadcom addresses to the same
 	logger          golog.Logger
 	isClosed        bool
 }

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -55,7 +55,7 @@ func init() {
 				conf resource.Config,
 				logger golog.Logger,
 			) (board.Board, error) {
-				return NewPigpio(ctx, conf.ResourceName(), conf, logger)
+				return newPigpio(ctx, conf.ResourceName(), conf, logger)
 			},
 		})
 }
@@ -110,8 +110,8 @@ func initializePigpio() error {
 	return nil
 }
 
-// NewPigpio makes a new pigpio based Board using the given config.
-func NewPigpio(ctx context.Context, name resource.Name, cfg resource.Config, logger golog.Logger) (board.LocalBoard, error) {
+// newPigpio makes a new pigpio based Board using the given config.
+func newPigpio(ctx context.Context, name resource.Name, cfg resource.Config, logger golog.Logger) (board.LocalBoard, error) {
 	// this is so we can run it inside a daemon
 	internals := C.gpioCfgGetInternals()
 	internals |= C.PI_CFG_NOSIGHANDLER

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -147,6 +147,9 @@ func (piInstance *piPigpio) Reconfigure(
     _ resource.Dependencies,
     conf resource.Config,
 ) error {
+	piInstance.mu.Lock()
+	defer piInstance.mu.Unlock()
+
 	// setup I2C buses
 	if len(cfg.I2Cs) != 0 {
 		piInstance.i2cs = make(map[string]board.I2C, len(cfg.I2Cs))

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -610,9 +610,6 @@ func (pi *piPigpio) Close(ctx context.Context) error {
 		err = multierr.Combine(err, interrupt.Close(ctx))
 	}
 
-	for _, interruptHW := range pi.interruptsHW {
-		err = multierr.Combine(err, interruptHW.Close(ctx))
-	}
 	pi.mu.Lock()
 	pi.isClosed = true
 	pi.mu.Unlock()

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -601,14 +601,18 @@ func (pi *piPigpio) Close(ctx context.Context) error {
 	for _, spi := range pi.spis {
 		err = multierr.Combine(err, spi.Close(ctx))
 	}
+	pi.spis = map[string]board.SPI{}
 
 	for _, analog := range pi.analogs {
 		err = multierr.Combine(err, analog.Close(ctx))
 	}
+	pi.analogs = map[string]board.AnalogReader{}
 
 	for _, interrupt := range pi.interrupts {
 		err = multierr.Combine(err, interrupt.Close(ctx))
 	}
+	pi.interrupts = map[string]board.DigitalInterrupt{}
+	pi.interruptsHW = map[uint]board.DigitalInterrupt{}
 
 	pi.mu.Lock()
 	pi.isClosed = true

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -74,7 +74,7 @@ type piPigpio struct {
 	i2cs            map[string]board.I2C
 	spis            map[string]board.SPI
 	interrupts      map[string]board.DigitalInterrupt // Maps interrupt names to interrupts
-	interruptsHW    map[uint]board.DigitalInterrupt // Maps broadcom addresses to the same
+	interruptsHW    map[uint]board.DigitalInterrupt   // Maps broadcom addresses to the same
 	logger          golog.Logger
 	isClosed        bool
 }
@@ -143,9 +143,9 @@ func NewPigpio(ctx context.Context, name resource.Name, cfg resource.Config, log
 
 // TODO(RSDK-RSDK-2691): implement reconfigure.
 func (pi *piPigpio) performConfiguration(
-    _ context.Context,
-    _ resource.Dependencies,
-    conf resource.Config,
+	_ context.Context,
+	_ resource.Dependencies,
+	conf resource.Config,
 ) error {
 	cfg, err := resource.NativeConfig[*genericlinux.Config](conf)
 	if err != nil {

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -135,7 +135,7 @@ func newPigpio(ctx context.Context, name resource.Name, cfg resource.Config, log
 
 	if err := piInstance.performConfiguration(ctx, nil, cfg); err != nil {
 		C.gpioTerminate()
-		logger.Debug("Pi GPIO terminated due to failed init.")
+		logger.Error("Pi GPIO terminated due to failed init.")
 		return nil, err
 	}
 	return piInstance, nil

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -55,11 +55,7 @@ func init() {
 				conf resource.Config,
 				logger golog.Logger,
 			) (board.Board, error) {
-				boardConfig, err := resource.NativeConfig[*genericlinux.Config](conf)
-				if err != nil {
-					return nil, err
-				}
-				return NewPigpio(ctx, conf.ResourceName(), boardConfig, logger)
+				return NewPigpio(ctx, conf.ResourceName(), conf, logger)
 			},
 		})
 }
@@ -116,7 +112,7 @@ func initializePigpio() error {
 
 // NewPigpio makes a new pigpio based Board using the given config.
 // TODO(RSDK-RSDK-2691): implement reconfigure.
-func NewPigpio(ctx context.Context, name resource.Name, cfg *genericlinux.Config, logger golog.Logger) (board.LocalBoard, error) {
+func NewPigpio(ctx context.Context, name resource.Name, cfg resource.Config, logger golog.Logger) (board.LocalBoard, error) {
 	// this is so we can run it inside a daemon
 	internals := C.gpioCfgGetInternals()
 	internals |= C.PI_CFG_NOSIGHANDLER

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -72,7 +72,6 @@ type piPigpio struct {
 	mu              sync.Mutex
 	interruptCtx    context.Context
 	interruptCancel context.CancelFunc
-	cfg             *genericlinux.Config
 	duty            int // added for mutex
 	gpioConfigSet   map[int]bool
 	analogs         map[string]board.AnalogReader
@@ -133,7 +132,6 @@ func NewPigpio(ctx context.Context, name resource.Name, cfg *genericlinux.Config
 	cancelCtx, cancelFunc := context.WithCancel(context.Background())
 	piInstance := &piPigpio{
 		Named:           name.AsNamed(),
-		cfg:             cfg,
 		logger:          logger,
 		isClosed:        false,
 		interruptCtx:    cancelCtx,

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -92,26 +92,23 @@ var (
 
 func initializePigpio() error {
 	instanceMu.Lock()
+	defer instanceMu.Unlock()
+
 	if !pigpioInitialized {
 		resCode = C.gpioInitialise()
 		if resCode < 0 {
-			instanceMu.Unlock()
 			// failed to init, check for common causes
 			_, err := os.Stat("/sys/bus/platform/drivers/raspberrypi-firmware")
 			if err != nil {
-				instanceMu.Unlock()
 				return nil, errors.New("not running on a pi")
 			}
 			if os.Getuid() != 0 {
-				instanceMu.Unlock()
 				return nil, errors.New("not running as root, try sudo")
 			}
-			instanceMu.Unlock()
 			return nil, picommon.ConvertErrorCodeToMessage(int(resCode), "error")
 		}
 	}
 	pigpioInitialized = true
-	instanceMu.Unlock()
 }
 
 // NewPigpio makes a new pigpio based Board using the given config.

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -151,26 +151,22 @@ func (pi *piPigpio) Reconfigure(
 	defer pi.mu.Unlock()
 
 	// setup I2C buses
-	if len(cfg.I2Cs) != 0 {
-		pi.i2cs = make(map[string]board.I2C, len(cfg.I2Cs))
-		for _, sc := range cfg.I2Cs {
-			id, err := strconv.Atoi(sc.Bus)
-			if err != nil {
-				return nil, err
-			}
-			pi.i2cs[sc.Name] = &piPigpioI2C{pi: pi, id: id}
+	pi.i2cs = make(map[string]board.I2C, len(cfg.I2Cs))
+	for _, sc := range cfg.I2Cs {
+		id, err := strconv.Atoi(sc.Bus)
+		if err != nil {
+			return nil, err
 		}
+		pi.i2cs[sc.Name] = &piPigpioI2C{pi: pi, id: id}
 	}
 
 	// setup SPI buses
-	if len(cfg.SPIs) != 0 {
-		pi.spis = make(map[string]board.SPI, len(cfg.SPIs))
-		for _, sc := range cfg.SPIs {
-			if sc.BusSelect != "0" && sc.BusSelect != "1" {
-				return nil, errors.New("only SPI buses 0 and 1 are available on Pi boards")
-			}
-			pi.spis[sc.Name] = &piPigpioSPI{pi: pi, busSelect: sc.BusSelect}
+	pi.spis = make(map[string]board.SPI, len(cfg.SPIs))
+	for _, sc := range cfg.SPIs {
+		if sc.BusSelect != "0" && sc.BusSelect != "1" {
+			return nil, errors.New("only SPI buses 0 and 1 are available on Pi boards")
 		}
+		pi.spis[sc.Name] = &piPigpioSPI{pi: pi, busSelect: sc.BusSelect}
 	}
 
 	// setup analogs

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -122,14 +122,6 @@ func NewPigpio(ctx context.Context, name resource.Name, cfg *genericlinux.Config
 		}
 	}
 	pigpioInitialized = true
-
-	initGood := false
-	defer func() {
-		if !initGood {
-			C.gpioTerminate()
-			logger.Debug("Pi GPIO terminated due to failed init.")
-		}
-	}()
 	instanceMu.Unlock()
 
 	cancelCtx, cancelFunc := context.WithCancel(context.Background())
@@ -143,6 +135,8 @@ func NewPigpio(ctx context.Context, name resource.Name, cfg *genericlinux.Config
 	}
 
 	if err := piInstance.Reconfigure(ctx, nil, cfg); err != nil {
+		C.gpioTerminate()
+		logger.Debug("Pi GPIO terminated due to failed init.")
 		return nil, err
 	}
 	return piInstance, nil
@@ -214,7 +208,6 @@ func (piInstance *piPigpio) Reconfigure(
 	instanceMu.Lock()
 	instances[piInstance] = struct{}{}
 	instanceMu.Unlock()
-	initGood = true
 	return piInstance, nil
 }
 

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -142,6 +142,17 @@ func NewPigpio(ctx context.Context, name resource.Name, cfg *genericlinux.Config
 		interruptCancel: cancelFunc,
 	}
 
+	if err := piInstance.Reconfigure(ctx, nil, cfg); err != nil {
+		return nil, err
+	}
+	return piInstance, nil
+}
+
+func (piInstance *piPigpio) Reconfigure(
+    ctx context.Context,
+    _ resource.Dependencies,
+    conf resource.Config,
+) error {
 	// setup I2C buses
 	if len(cfg.I2Cs) != 0 {
 		piInstance.i2cs = make(map[string]board.I2C, len(cfg.I2Cs))

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -503,9 +503,6 @@ func (pi *piPigpio) AnalogReaderNames() []string {
 }
 
 // DigitalInterruptNames returns the names of all known digital interrupts.
-// NOTE: During board setup, if a digital interrupt has not been created
-// for a pin, then this function will attempt to create one with the pin
-// number as the name.
 func (pi *piPigpio) DigitalInterruptNames() []string {
 	names := []string{}
 	for k := range pi.interrupts {
@@ -533,6 +530,9 @@ func (pi *piPigpio) I2CByName(name string) (board.I2C, bool) {
 }
 
 // DigitalInterruptByName returns a digital interrupt by name.
+// NOTE: During board setup, if a digital interrupt has not been created
+// for a pin, then this function will attempt to create one with the pin
+// number as the name.
 func (pi *piPigpio) DigitalInterruptByName(name string) (board.DigitalInterrupt, bool) {
 	pi.mu.Lock()
 	defer pi.mu.Unlock()

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -143,7 +143,7 @@ func NewPigpio(ctx context.Context, name resource.Name, cfg *genericlinux.Config
 }
 
 func (pi *piPigpio) Reconfigure(
-    ctx context.Context,
+    _ context.Context,
     _ resource.Dependencies,
     conf resource.Config,
 ) error {

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -111,7 +111,6 @@ func initializePigpio() error {
 }
 
 // NewPigpio makes a new pigpio based Board using the given config.
-// TODO(RSDK-RSDK-2691): implement reconfigure.
 func NewPigpio(ctx context.Context, name resource.Name, cfg resource.Config, logger golog.Logger) (board.LocalBoard, error) {
 	// this is so we can run it inside a daemon
 	internals := C.gpioCfgGetInternals()
@@ -134,7 +133,7 @@ func NewPigpio(ctx context.Context, name resource.Name, cfg resource.Config, log
 		interruptCancel: cancelFunc,
 	}
 
-	if err := piInstance.Reconfigure(ctx, nil, cfg); err != nil {
+	if err := piInstance.performConfiguration(ctx, nil, cfg); err != nil {
 		C.gpioTerminate()
 		logger.Debug("Pi GPIO terminated due to failed init.")
 		return nil, err
@@ -142,7 +141,8 @@ func NewPigpio(ctx context.Context, name resource.Name, cfg resource.Config, log
 	return piInstance, nil
 }
 
-func (pi *piPigpio) Reconfigure(
+// TODO(RSDK-RSDK-2691): implement reconfigure.
+func (pi *piPigpio) performConfiguration(
     _ context.Context,
     _ resource.Dependencies,
     conf resource.Config,

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -100,15 +100,16 @@ func initializePigpio() error {
 			// failed to init, check for common causes
 			_, err := os.Stat("/sys/bus/platform/drivers/raspberrypi-firmware")
 			if err != nil {
-				return nil, errors.New("not running on a pi")
+				return errors.New("not running on a pi")
 			}
 			if os.Getuid() != 0 {
-				return nil, errors.New("not running as root, try sudo")
+				return errors.New("not running as root, try sudo")
 			}
-			return nil, picommon.ConvertErrorCodeToMessage(int(resCode), "error")
+			return picommon.ConvertErrorCodeToMessage(int(resCode), "error")
 		}
 	}
 	pigpioInitialized = true
+	return nil
 }
 
 // NewPigpio makes a new pigpio based Board using the given config.

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -132,7 +132,7 @@ func NewPigpio(ctx context.Context, name resource.Name, cfg *genericlinux.Config
 	}()
 	instanceMu.Unlock()
 
-	cancelCtx, cancelFunc := context.WithCancel(ctx)
+	cancelCtx, cancelFunc := context.WithCancel(context.Background())
 	piInstance := &piPigpio{
 		Named:           name.AsNamed(),
 		cfg:             cfg,

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -110,11 +110,14 @@ func NewPigpio(ctx context.Context, name resource.Name, cfg *genericlinux.Config
 			// failed to init, check for common causes
 			_, err := os.Stat("/sys/bus/platform/drivers/raspberrypi-firmware")
 			if err != nil {
+				instanceMu.Unlock()
 				return nil, errors.New("not running on a pi")
 			}
 			if os.Getuid() != 0 {
+				instanceMu.Unlock()
 				return nil, errors.New("not running as root, try sudo")
 			}
+			instanceMu.Unlock()
 			return nil, picommon.ConvertErrorCodeToMessage(int(resCode), "error")
 		}
 	}

--- a/components/board/pi/impl/board_test.go
+++ b/components/board/pi/impl/board_test.go
@@ -28,8 +28,9 @@ func TestPiPigpio(t *testing.T) {
 			{Name: "servo-i", Pin: "22", Type: "servo"},
 		},
 	}
+	resourceConfig := resource.Config{ConvertedAttributes: &cfg}
 
-	pp, err := NewPigpio(ctx, board.Named("foo"), &cfg, logger)
+	pp, err := NewPigpio(ctx, board.Named("foo"), resourceConfig, logger)
 	if errors.Is(err, errors.New("not running on a pi")) {
 		t.Skip("not running on a pi")
 		return

--- a/components/board/pi/impl/board_test.go
+++ b/components/board/pi/impl/board_test.go
@@ -30,7 +30,7 @@ func TestPiPigpio(t *testing.T) {
 	resourceConfig := resource.Config{ConvertedAttributes: &cfg}
 
 	pp, err := newPigpio(ctx, board.Named("foo"), resourceConfig, logger)
-	if err.Error() == "not running on a pi" {
+	if err != nil && err.Error() == "not running on a pi" {
 		t.Skip("not running on a pi")
 		return
 	}

--- a/components/board/pi/impl/board_test.go
+++ b/components/board/pi/impl/board_test.go
@@ -30,10 +30,6 @@ func TestPiPigpio(t *testing.T) {
 	resourceConfig := resource.Config{ConvertedAttributes: &cfg}
 
 	pp, err := newPigpio(ctx, board.Named("foo"), resourceConfig, logger)
-	// Go's error comparison is shallow, meaning it only checks if two variables point to the same
-	// location in memory. We want to check if the error is due to not running on a raspberry pi,
-	// regardless of whether it's a new copy of the error. Consequently, we can't use `errors.Is`
-	// to compare the error directly to one that we think it should resemble.
 	if err.Error() == "not running on a pi" {
 		t.Skip("not running on a pi")
 		return

--- a/components/board/pi/impl/board_test.go
+++ b/components/board/pi/impl/board_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/edaniels/golog"
-	"github.com/pkg/errors"
 	"go.viam.com/test"
 
 	"go.viam.com/rdk/components/board"
@@ -31,7 +30,11 @@ func TestPiPigpio(t *testing.T) {
 	resourceConfig := resource.Config{ConvertedAttributes: &cfg}
 
 	pp, err := NewPigpio(ctx, board.Named("foo"), resourceConfig, logger)
-	if errors.Is(err, errors.New("not running on a pi")) {
+	// Go's error comparison is shallow, meaning it only checks if two variables point to the same
+	// location in memory. We want to check if the error is due to not running on a raspberry pi,
+	// regardless of whether it's a new copy of the error. Consequently, we can't use `errors.Is`
+	// to compare the error directly to one that we think it should resemble.
+	if err.Error() == "not running on a pi" {
 		t.Skip("not running on a pi")
 		return
 	}

--- a/components/board/pi/impl/board_test.go
+++ b/components/board/pi/impl/board_test.go
@@ -29,7 +29,7 @@ func TestPiPigpio(t *testing.T) {
 	}
 	resourceConfig := resource.Config{ConvertedAttributes: &cfg}
 
-	pp, err := NewPigpio(ctx, board.Named("foo"), resourceConfig, logger)
+	pp, err := newPigpio(ctx, board.Named("foo"), resourceConfig, logger)
 	// Go's error comparison is shallow, meaning it only checks if two variables point to the same
 	// location in memory. We want to check if the error is due to not running on a raspberry pi,
 	// regardless of whether it's a new copy of the error. Consequently, we can't use `errors.Is`

--- a/components/board/pi/impl/external_hardware_test.go
+++ b/components/board/pi/impl/external_hardware_test.go
@@ -38,8 +38,9 @@ func TestPiHardware(t *testing.T) {
 			{Name: "b", Pin: "37"},                      // bcom 26
 		},
 	}
+	resourceConfig := resource.Config{ConvertedAttributes: &cfg}
 
-	pp, err := NewPigpio(ctx, board.Named("foo"), &cfg, logger)
+	pp, err := NewPigpio(ctx, board.Named("foo"), resourceConfig, logger)
 	if errors.Is(err, errors.New("not running on a pi")) {
 		t.Skip("not running on a pi")
 		return

--- a/components/board/pi/impl/external_hardware_test.go
+++ b/components/board/pi/impl/external_hardware_test.go
@@ -39,7 +39,7 @@ func TestPiHardware(t *testing.T) {
 	}
 	resourceConfig := resource.Config{ConvertedAttributes: &cfg}
 
-	pp, err := NewPigpio(ctx, board.Named("foo"), resourceConfig, logger)
+	pp, err := newPigpio(ctx, board.Named("foo"), resourceConfig, logger)
 	if err.Error() == "not running on a pi" {
 		t.Skip("not running on a pi")
 		return

--- a/components/board/pi/impl/external_hardware_test.go
+++ b/components/board/pi/impl/external_hardware_test.go
@@ -40,7 +40,7 @@ func TestPiHardware(t *testing.T) {
 	resourceConfig := resource.Config{ConvertedAttributes: &cfg}
 
 	pp, err := newPigpio(ctx, board.Named("foo"), resourceConfig, logger)
-	if err.Error() == "not running on a pi" {
+	if err != nil && err.Error() == "not running on a pi" {
 		t.Skip("not running on a pi")
 		return
 	}

--- a/components/board/pi/impl/external_hardware_test.go
+++ b/components/board/pi/impl/external_hardware_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/edaniels/golog"
-	"github.com/pkg/errors"
 	"go.viam.com/test"
 
 	"go.viam.com/rdk/components/board"
@@ -41,7 +40,7 @@ func TestPiHardware(t *testing.T) {
 	resourceConfig := resource.Config{ConvertedAttributes: &cfg}
 
 	pp, err := NewPigpio(ctx, board.Named("foo"), resourceConfig, logger)
-	if errors.Is(err, errors.New("not running on a pi")) {
+	if err.Error() == "not running on a pi" {
 		t.Skip("not running on a pi")
 		return
 	}


### PR DESCRIPTION
I've been going down a garden path of fixes and improvements, trying to get the pi boards to reconfigure themselves. Eventually, I had so many extraneous refactorings that I spun them out into this PR, and the actual pi reconfiguration will come separately. I recommend reviewing this commit-by-commit: most of them are small, self-contained changes unrelated to the commits before and after them.

Changes include:
- Remember to unlock the mutex if you return early
- Don't fail tests on non-pi non-x86 machines
- Move most configuration stuff out of the constructor and into a new function that the constructor calls
- Make the new function have the same function signature as `Reconfigure`, even though it currently just finishes constructing a new board and doesn't reconfigure an old one.
- If you can flip if statements around to get less-indented code, do it because that's simpler to read
- If you have a very long function and some piece within it is unrelated to the rest, pull it out into a separate function
- When you close the digital interrupts, don't close them again
- After you close a board, remove all the things within the board that have been closed.
- Remove unused fields/arguments/variables

The first few commits talk about preparing to do reconfiguration, and the last commit renames `Reconfigure` to `performConfiguration`. Next PR will change the name back and do reconfiguration properly. 

No changes to the happy path are intended. I haven't thoroughly tested the changes that I did make: they're for error cases that seemingly no one has hit in the past year or two. Tried on a raspberry pi: the ultrasonic sensor still works, as does GPIO. 

@randhid had expressed interest in reviewing the changes I'm working on, though if she's busy I'm happy with anyone else reviewing the code instead.