### PR TITLE
RSDK-2796 Do not log uuid.UUID directly

### DIFF
--- a/robot/session_manager.go
+++ b/robot/session_manager.go
@@ -118,7 +118,14 @@ func (m *SessionManager) expireLoop(ctx context.Context) {
 		}()
 
 		if len(toDelete) != 0 {
-			m.logger.Debugw("sessions expired", "session_ids", toDelete)
+			// Logging to the app struggles to pass along uuid.UUID due to an
+			// inability to convert the type to proto. Pass deleted IDs as a slice of
+			// strings instead.
+			var deletedIDs []string
+			for id := range toDelete {
+				deletedIDs = append(deletedIDs, id.String())
+			}
+			m.logger.Debugw("sessions expired", "session_ids", deletedIDs)
 		}
 		if len(toStop) != 0 {
 			m.logger.Debugw("tried to stop some resources", "resources", toStop)

--- a/robot/session_manager_test.go
+++ b/robot/session_manager_test.go
@@ -6,12 +6,13 @@ import (
 	"time"
 
 	"github.com/edaniels/golog"
+	"go.viam.com/test"
+	"go.viam.com/utils/testutils"
+
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/session"
 	"go.viam.com/rdk/testutils/inject"
-	"go.viam.com/test"
-	"go.viam.com/utils/testutils"
 )
 
 func TestSessionManager(t *testing.T) {

--- a/robot/session_manager_test.go
+++ b/robot/session_manager_test.go
@@ -1,0 +1,86 @@
+package robot_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/edaniels/golog"
+	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/robot"
+	"go.viam.com/rdk/session"
+	"go.viam.com/rdk/testutils/inject"
+	"go.viam.com/test"
+	"go.viam.com/utils/testutils"
+)
+
+func TestSessionManager(t *testing.T) {
+	ctx := context.Background()
+	logger := golog.NewTestLogger(t)
+	r := &inject.Robot{}
+
+	r.LoggerFunc = func() golog.Logger {
+		return logger
+	}
+
+	sm := robot.NewSessionManager(r, config.DefaultSessionHeartbeatWindow)
+	defer sm.Close()
+
+	// Start two arbitrary sessions.
+	fooSess, err := sm.Start(ctx, "foo")
+	test.That(t, err, test.ShouldBeNil)
+
+	barSess, err := sm.Start(ctx, "bar")
+	test.That(t, err, test.ShouldBeNil)
+
+	// Assert that FindByID requires correct owner ID.
+	foundSess, err := sm.FindByID(ctx, fooSess.ID(), "bar")
+	test.That(t, foundSess, test.ShouldBeNil)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldBeError, session.ErrNoSession)
+
+	// Assert that fooSess and barSess can be found with FindByID.
+	foundFooSess, err := sm.FindByID(ctx, fooSess.ID(), "foo")
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, foundFooSess, test.ShouldEqual, fooSess)
+
+	foundBarSess, err := sm.FindByID(ctx, barSess.ID(), "bar")
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, foundBarSess, test.ShouldEqual, barSess)
+
+	// Assert that fooSess and barSess can be found with All.
+	allSessions := sm.All()
+	test.That(t, len(allSessions), test.ShouldEqual, 2)
+	test.That(t, allSessions[0], test.ShouldBeIn, fooSess, barSess)
+	test.That(t, allSessions[1], test.ShouldBeIn, fooSess, barSess)
+}
+
+// mostly a regression test for RSDK-2796
+func TestSessionManagerExpiredSessions(t *testing.T) {
+	ctx := context.Background()
+	logger, logs := golog.NewObservedTestLogger(t)
+	r := &inject.Robot{}
+
+	r.LoggerFunc = func() golog.Logger {
+		return logger
+	}
+
+	// Use a negative duration to cause immediate heartbeat timeout and
+	// session expiration.
+	sm := robot.NewSessionManager(r, time.Duration(-1))
+	defer sm.Close()
+
+	_, err := sm.Start(ctx, "foo")
+	test.That(t, err, test.ShouldBeNil)
+
+	// associate an actuating resource somehow
+	// sm.AssociateResource(sess.ID(),
+
+	testutils.WaitForAssertion(t, func(tb testing.TB) {
+		tb.Helper()
+		test.That(tb, logs.FilterMessageSnippet("sessions expired").Len(),
+			test.ShouldEqual, 1)
+	})
+
+	time.Sleep(2 * time.Second)
+}

--- a/robot/session_manager_test.go
+++ b/robot/session_manager_test.go
@@ -55,7 +55,6 @@ func TestSessionManager(t *testing.T) {
 	test.That(t, allSessions[1], test.ShouldBeIn, fooSess, barSess)
 }
 
-// mostly a regression test for RSDK-2796
 func TestSessionManagerExpiredSessions(t *testing.T) {
 	ctx := context.Background()
 	logger, logs := golog.NewObservedTestLogger(t)
@@ -73,14 +72,9 @@ func TestSessionManagerExpiredSessions(t *testing.T) {
 	_, err := sm.Start(ctx, "foo")
 	test.That(t, err, test.ShouldBeNil)
 
-	// associate an actuating resource somehow
-	// sm.AssociateResource(sess.ID(),
-
 	testutils.WaitForAssertion(t, func(tb testing.TB) {
 		tb.Helper()
 		test.That(tb, logs.FilterMessageSnippet("sessions expired").Len(),
 			test.ShouldEqual, 1)
 	})
-
-	time.Sleep(2 * time.Second)
 }


### PR DESCRIPTION
RSDK-2796

Logs deleted session IDs as a slice of strings rather than a `map[uuid.UUID]struct{}`. Adds unrelated tests for the session manager that were missing.

Logging to app requires that all logs are convertible to proto. `uuid.UUID` cannot be converted to proto. There's only [one other place](https://github.com/viamrobotics/rdk/blob/main/operation/opid.go#L140) in RDK where we log a `uuid.UUID`, and we convert it to a string.

I added more tests for the session manager (was trying to figure out how it worked), but they do not act as a regression test for this bug fix. I'm not sure how we can easily test that all our logs are convertible to proto.