### PR TITLE
remove gomock from net logger tests in favor of a mocked robot service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,6 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
 	github.com/golang/geo v0.0.0-20210211234256-740aa86cb551
-	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.3
 	github.com/golangci/golangci-lint v1.51.2
 	github.com/google/flatbuffers v2.0.6+incompatible

--- a/go.sum
+++ b/go.sum
@@ -537,8 +537,6 @@ github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
-github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
-github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/web/server/net_logger_test.go
+++ b/web/server/net_logger_test.go
@@ -4,85 +4,19 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
+	"sync"
 	"testing"
 
 	"github.com/edaniels/golog"
-	"github.com/golang/mock/gomock"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-	mockapppb "go.viam.com/api/app/mock_v1"
 	apppb "go.viam.com/api/app/v1"
 	"go.viam.com/test"
+	"go.viam.com/utils/rpc"
 
 	"go.viam.com/rdk/config"
 )
-
-func TestNewNetLogger(t *testing.T) {
-	logger := golog.NewTestLogger(t)
-	level := zap.NewAtomicLevelAt(zap.InfoLevel)
-
-	nl, err := newNetLogger(&config.Cloud{
-		AppAddress: "http://localhost:8080",
-		ID:         "abc-123",
-	}, logger, level)
-	test.That(t, err, test.ShouldBeNil)
-
-	_, ok := nl.remoteWriter.(*remoteLogWriterGRPC)
-	test.That(t, ok, test.ShouldBeTrue)
-	nl.cancel()
-}
-
-func TestNewNetBatchWrites(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	client := mockapppb.NewMockRobotServiceClient(ctrl)
-
-	logger := golog.NewTestLogger(t)
-	cancelCtx, cancel := context.WithCancel(context.Background())
-
-	config := &config.Cloud{
-		AppAddress: "http://localhost:8080",
-		ID:         "abc-123",
-	}
-
-	logWriter := &remoteLogWriterGRPC{
-		loggerWithoutNet: logger,
-		cfg:              config,
-		service:          client,
-	}
-
-	nl := &netLogger{
-		hostname:     "hostname",
-		cancelCtx:    cancelCtx,
-		cancel:       cancel,
-		remoteWriter: logWriter,
-		maxQueueSize: 1000,
-		logLevel:     zap.NewAtomicLevelAt(zap.InfoLevel),
-	}
-
-	l := logger.Desugar()
-	l = l.WithOptions(zap.WrapCore(func(c zapcore.Core) zapcore.Core {
-		return zapcore.NewTee(c, nl)
-	}))
-
-	client.EXPECT().
-		Log(gomock.Any(), &expectedLogMatch{nLogs: 100, id: "abc-123"}).
-		Times(1).
-		Return(&apppb.LogResponse{}, nil)
-
-	client.EXPECT().
-		Log(gomock.Any(), &expectedLogMatch{nLogs: 1, id: "abc-123"}).
-		Times(1).
-		Return(&apppb.LogResponse{}, nil)
-
-	for i := 0; i < writeBatchSize+1; i++ {
-		l.Info("Some-info")
-	}
-
-	nl.Sync()
-	nl.Close()
-}
 
 func TestNetLoggerQueueOperations(t *testing.T) {
 	t.Run("test addBatchToQueue", func(t *testing.T) {
@@ -118,190 +52,177 @@ func TestNetLoggerQueueOperations(t *testing.T) {
 	})
 }
 
-func TestBatchFailureAndRetry(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+type mockRobotService struct {
+	apppb.UnimplementedRobotServiceServer
+	expectedID string
 
-	client := mockapppb.NewMockRobotServiceClient(ctrl)
-
-	logger := golog.NewTestLogger(t)
-	cancelCtx, cancel := context.WithCancel(context.Background())
-
-	config := &config.Cloud{
-		AppAddress: "http://localhost:8080",
-		ID:         "abc-123",
-	}
-
-	logWriter := &remoteLogWriterGRPC{
-		loggerWithoutNet: logger,
-		cfg:              config,
-		service:          client,
-	}
-
-	nl := &netLogger{
-		hostname:     "hostname",
-		cancelCtx:    cancelCtx,
-		cancel:       cancel,
-		remoteWriter: logWriter,
-		maxQueueSize: 100,
-		logLevel:     zap.NewAtomicLevelAt(zap.InfoLevel),
-	}
-
-	l := logger.Desugar()
-	l = l.WithOptions(zap.WrapCore(func(c zapcore.Core) zapcore.Core {
-		return zapcore.NewTee(c, nl)
-	}))
-
-	client.EXPECT().
-		Log(gomock.Any(), &expectedLogMatch{nLogs: 10, id: "abc-123"}).
-		Times(1).
-		Return(nil, errors.New("failure"))
-
-	for i := 0; i < 10; i++ {
-		l.Info("Some-info")
-	}
-	nl.Sync()
-
-	l.Info("New info")
-	client.EXPECT().
-		Log(gomock.Any(), &expectedLogMatch{nLogs: 11, id: "abc-123"}).
-		Times(1).
-		Return(&apppb.LogResponse{}, nil)
-
-	nl.Sync()
-
-	nl.Close()
+	logsMu              sync.Mutex
+	logFailForSizeCount int
+	logs                []*apppb.LogEntry
+	logBatches          [][]*apppb.LogEntry
 }
 
-func TestUnderlyingLoggerDoesntRecurse(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+func (ms *mockRobotService) Log(ctx context.Context, req *apppb.LogRequest) (*apppb.LogResponse, error) {
+	if ms.expectedID != req.Id {
+		return nil, fmt.Errorf("expected id %q but got %q", ms.expectedID, req.Id)
+	}
+	ms.logsMu.Lock()
+	defer ms.logsMu.Unlock()
+	if ms.logFailForSizeCount > 0 {
+		ms.logFailForSizeCount -= len(req.Logs)
+		return &apppb.LogResponse{}, errors.New("not right now")
+	}
+	ms.logs = append(ms.logs, req.Logs...)
+	ms.logBatches = append(ms.logBatches, req.Logs)
+	return &apppb.LogResponse{}, nil
+}
 
-	client := mockapppb.NewMockRobotServiceClient(ctrl)
+type serverForRobotLogger struct {
+	service     *mockRobotService
+	cloudConfig *config.Cloud
+	stop        func() error
+}
+
+func makeServerForRobotLogger(t *testing.T) serverForRobotLogger {
+	logger := golog.NewTestLogger(t)
+	listener, err := net.Listen("tcp", "localhost:0")
+	test.That(t, err, test.ShouldBeNil)
+	rpcServer, err := rpc.NewServer(logger, rpc.WithUnauthenticated())
+	test.That(t, err, test.ShouldBeNil)
+
+	robotService := &mockRobotService{expectedID: "abc-123"}
+	test.That(t, rpcServer.RegisterServiceServer(
+		context.Background(),
+		&apppb.RobotService_ServiceDesc,
+		robotService,
+		apppb.RegisterRobotServiceHandlerFromEndpoint,
+	), test.ShouldBeNil)
+
+	go rpcServer.Serve(listener)
+	config := &config.Cloud{
+		AppAddress: fmt.Sprintf("http://%s", listener.Addr().String()),
+		ID:         robotService.expectedID,
+	}
+	return serverForRobotLogger{robotService, config, rpcServer.Stop}
+}
+
+func TestNetLoggerBatchWrites(t *testing.T) {
+	server := makeServerForRobotLogger(t)
 
 	logger := golog.NewTestLogger(t)
-	cancelCtx, cancel := context.WithCancel(context.Background())
+	nl, err := newNetLogger(server.cloudConfig, logger, zap.NewAtomicLevelAt(zap.InfoLevel))
+	test.That(t, err, test.ShouldBeNil)
 
-	config := &config.Cloud{
-		AppAddress: "http://localhost:8080",
-		ID:         "abc-123",
-	}
-
-	logWriter := &remoteLogWriterGRPC{
-		loggerWithoutNet: logger,
-		cfg:              config,
-		service:          client,
-	}
-
-	nl := &netLogger{
-		hostname:         "hostname",
-		cancelCtx:        cancelCtx,
-		cancel:           cancel,
-		remoteWriter:     logWriter,
-		maxQueueSize:     100,
-		loggerWithoutNet: logger,
-		logLevel:         zap.NewAtomicLevelAt(zap.InfoLevel),
-	}
-
-	newLogger := logger.Desugar()
-	newLogger = newLogger.WithOptions(zap.WrapCore(func(c zapcore.Core) zapcore.Core {
+	loggerWithNet := logger.Desugar()
+	loggerWithNet = loggerWithNet.WithOptions(zap.WrapCore(func(c zapcore.Core) zapcore.Core {
 		return zapcore.NewTee(c, nl)
 	}))
 
-	client.EXPECT().
-		Log(gomock.Any(), &expectedLogMatch{nLogs: 1, id: "abc-123"}).
-		Times(1).
-		Return(nil, errors.New("failure"))
+	for i := 0; i < writeBatchSize+1; i++ {
+		loggerWithNet.Info("Some-info")
+	}
 
-	newLogger.Info("should write to network")
+	nl.Sync()
+	nl.Close()
+	server.stop()
+
+	test.That(t, server.service.logBatches, test.ShouldHaveLength, 2)
+	test.That(t, server.service.logBatches[0], test.ShouldHaveLength, 100)
+	test.That(t, server.service.logBatches[1], test.ShouldHaveLength, 1)
+	for i := 0; i < writeBatchSize+1; i++ {
+		test.That(t, server.service.logs[i].Message, test.ShouldEqual, "Some-info")
+	}
+}
+
+func TestNetLoggerBatchFailureAndRetry(t *testing.T) {
+	server := makeServerForRobotLogger(t)
+
+	logger := golog.NewTestLogger(t)
+	nl, err := newNetLogger(server.cloudConfig, logger, zap.NewAtomicLevelAt(zap.InfoLevel))
+	test.That(t, err, test.ShouldBeNil)
+
+	loggerWithNet := logger.Desugar()
+	loggerWithNet = loggerWithNet.WithOptions(zap.WrapCore(func(c zapcore.Core) zapcore.Core {
+		return zapcore.NewTee(c, nl)
+	}))
+
+	numLogs := 11
+	server.service.logsMu.Lock()
+	server.service.logFailForSizeCount = 11
+	server.service.logsMu.Unlock()
+
+	for i := 0; i < numLogs-1; i++ {
+		loggerWithNet.Info("Some-info")
+	}
+	nl.Sync()
+
+	loggerWithNet.Info("New info")
+
+	nl.Sync()
+	nl.Close()
+	server.stop()
+
+	test.That(t, server.service.logs, test.ShouldHaveLength, numLogs)
+	for i := 0; i < numLogs-1; i++ {
+		test.That(t, server.service.logs[i].Message, test.ShouldEqual, "Some-info")
+	}
+	test.That(t, server.service.logs[numLogs-1].Message, test.ShouldEqual, "New info")
+}
+
+func TestNetLoggerUnderlyingLoggerDoesntRecurse(t *testing.T) {
+	server := makeServerForRobotLogger(t)
+
+	logger := golog.NewTestLogger(t)
+	nl, err := newNetLogger(server.cloudConfig, logger, zap.NewAtomicLevelAt(zap.InfoLevel))
+	test.That(t, err, test.ShouldBeNil)
+
+	loggerWithNet := logger.Desugar()
+	loggerWithNet = loggerWithNet.WithOptions(zap.WrapCore(func(c zapcore.Core) zapcore.Core {
+		return zapcore.NewTee(c, nl)
+	}))
+
+	loggerWithNet.Info("should write to network")
 	logger.Info("should not write to network")
-	nl.Sync()
 
+	nl.Sync()
 	nl.Close()
+	server.stop()
+
+	test.That(t, server.service.logs, test.ShouldHaveLength, 1)
+	test.That(t, server.service.logs[0].Message, test.ShouldEqual, "should write to network")
 }
 
-func TestLogLevel(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	client := mockapppb.NewMockRobotServiceClient(ctrl)
+func TestNetLoggerLogLevel(t *testing.T) {
+	server := makeServerForRobotLogger(t)
 
 	logger := golog.NewTestLogger(t)
-	cancelCtx, cancel := context.WithCancel(context.Background())
-
-	config := &config.Cloud{
-		AppAddress: "http://localhost:8080",
-		ID:         "abc-123",
-	}
-
-	logWriter := &remoteLogWriterGRPC{
-		loggerWithoutNet: logger,
-		cfg:              config,
-		service:          client,
-	}
-
 	level := zap.NewAtomicLevelAt(zap.InfoLevel)
+	nl, err := newNetLogger(server.cloudConfig, logger, level)
+	test.That(t, err, test.ShouldBeNil)
 
-	nl := &netLogger{
-		hostname:         "hostname",
-		cancelCtx:        cancelCtx,
-		cancel:           cancel,
-		remoteWriter:     logWriter,
-		maxQueueSize:     100,
-		loggerWithoutNet: logger,
-		logLevel:         level,
-	}
-
-	newLogger := logger.Desugar()
-	newLogger = newLogger.WithOptions(zap.WrapCore(func(c zapcore.Core) zapcore.Core {
+	loggerWithNet := logger.Desugar()
+	loggerWithNet = loggerWithNet.WithOptions(zap.WrapCore(func(c zapcore.Core) zapcore.Core {
 		return zapcore.NewTee(c, nl)
 	}))
 
-	client.EXPECT().
-		Log(gomock.Any(), &expectedLogMatch{nLogs: 1, id: "abc-123"}).
-		Times(1).
-		Return(&apppb.LogResponse{}, nil)
-
-	newLogger.Info("info level")
-	newLogger.Debug("debug level")
+	loggerWithNet.Info("info level")
+	loggerWithNet.Debug("debug level")
 	nl.Sync()
 
 	level.SetLevel(zap.DebugLevel)
 
-	client.EXPECT().
-		Log(gomock.Any(), &expectedLogMatch{nLogs: 2, id: "abc-123"}).
-		Times(1).
-		Return(&apppb.LogResponse{}, nil)
-
-	newLogger.Info("info level")
-	newLogger.Debug("debug level")
+	loggerWithNet.Info("info level")
+	loggerWithNet.Debug("debug level")
 	nl.Sync()
 
 	nl.Close()
-}
+	server.stop()
 
-type expectedLogMatch struct {
-	nLogs int
-	id    string
-}
-
-func (lr *expectedLogMatch) Matches(x interface{}) bool {
-	m, ok := x.(*apppb.LogRequest)
-	if !ok {
-		return false
-	}
-
-	if m.Id != lr.id {
-		return false
-	}
-
-	if len(m.Logs) != lr.nLogs {
-		return false
-	}
-
-	return true
-}
-
-func (lr *expectedLogMatch) String() string {
-	return fmt.Sprintf("Expected LogRequest with %d logs", &lr.nLogs)
+	test.That(t, server.service.logs, test.ShouldHaveLength, 3)
+	test.That(t, server.service.logs[0].Message, test.ShouldEqual, "info level")
+	test.That(t, server.service.logs[0].Level, test.ShouldEqual, "info")
+	test.That(t, server.service.logs[1].Message, test.ShouldEqual, "info level")
+	test.That(t, server.service.logs[1].Level, test.ShouldEqual, "info")
+	test.That(t, server.service.logs[2].Message, test.ShouldEqual, "debug level")
+	test.That(t, server.service.logs[2].Level, test.ShouldEqual, "debug")
 }


### PR DESCRIPTION
This is the only place in rdk where we are using gomock and although there is value in being able to mock out specific requests to log with precision, it feels better to be consistent with how the rest of our tests work. Plus, this allows us to rely less on our knowledge about how the client/logger works.