### PR TITLE
RSDK-2796 Remove no longer relevant comment about net logger limitations

### DIFF
--- a/robot/session_manager.go
+++ b/robot/session_manager.go
@@ -118,9 +118,6 @@ func (m *SessionManager) expireLoop(ctx context.Context) {
 		}()
 
 		if len(toDelete) != 0 {
-			// Logging to the app struggles to pass along uuid.UUID due to an
-			// inability to convert the type to proto. Pass deleted IDs as a slice of
-			// strings instead.
 			var deletedIDs []string
 			for id := range toDelete {
 				deletedIDs = append(deletedIDs, id.String())


### PR DESCRIPTION
RSDK-2796

After [this PR](https://github.com/viamrobotics/goutils/pull/169) in goutils, we can use non-string types that implement `fmt.Stringer` as keys for maps. The removed comment is therefore no longer relevant, but logging deleted sessions IDs as a `[]string` instead of the odd `map[uuid.UUID]struct{}` makes more sense IMO.