### PR TITLE
remove todo comment from doc.go

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,2 +1,3 @@
-// Package rdk is the Robot Development Kit, the open-source, on-robot portion of the Viam platform that provides viam-server and the Go SDK.
+// Package rdk defines the Robot Development Kit.
+// This is the open-source, on-robot portion of the Viam platform that provides viam-server and the Go SDK.
 package rdk

--- a/doc.go
+++ b/doc.go
@@ -1,2 +1,2 @@
-// The Robot Development Kit (RDK) is the open-source, on-robot portion of the Viam platform that provides viam-server and the Go SDK.
+// Package rdk is the Robot Development Kit, the open-source, on-robot portion of the Viam platform that provides viam-server and the Go SDK.
 package rdk

--- a/doc.go
+++ b/doc.go
@@ -1,2 +1,1 @@
-// Package rdk TODO
 package rdk

--- a/doc.go
+++ b/doc.go
@@ -1,4 +1,4 @@
 // Package rdk defines the Robot Development Kit.
 // This is the open-source, on-robot portion of the Viam platform,
-//  providing viam-server and the Go SDK.
+// providing viam-server and the Go SDK.
 package rdk

--- a/doc.go
+++ b/doc.go
@@ -1,1 +1,2 @@
+// The Robot Development Kit (RDK) is the open-source, on-robot portion of the Viam platform that provides viam-server and the Go SDK.
 package rdk

--- a/doc.go
+++ b/doc.go
@@ -1,3 +1,4 @@
 // Package rdk defines the Robot Development Kit.
-// This is the open-source, on-robot portion of the Viam platform that provides viam-server and the Go SDK.
+// This is the open-source, on-robot portion of the Viam platform,
+//  providing viam-server and the Go SDK.
 package rdk


### PR DESCRIPTION
* Shows up on https://pkg.go.dev/go.viam.com/rdk#pkg-overview go docs landing page
* Some RDK overview is given at beginning of https://pkg.go.dev/go.viam.com/rdk -> could remove doc.go overview entirely? 