### PR TITLE
Never deinitialize pigpio

### DIFF
--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -593,11 +593,7 @@ func (pi *piPigpio) Close(ctx context.Context) error {
 	delete(instances, pi)
 
 	if terminate {
-		pigpioInitialized = false
 		instanceMu.Unlock()
-		// This has to happen outside of the lock to avoid a deadlock with interrupts.
-		C.gpioTerminate()
-		pi.logger.Debug("Pi GPIO terminated properly.")
 	} else {
 		instanceMu.Unlock()
 	}

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -575,7 +575,6 @@ func (pi *piPigpio) SetPowerMode(ctx context.Context, mode pb.PowerMode, duratio
 
 // Close attempts to close all parts of the board cleanly.
 func (pi *piPigpio) Close(ctx context.Context) error {
-	var terminate bool
 	// Prevent duplicate calls to Close a board as this may overlap with
 	// the reinitialization of the board
 	pi.mu.Lock()
@@ -587,9 +586,6 @@ func (pi *piPigpio) Close(ctx context.Context) error {
 	pi.mu.Unlock()
 	pi.interruptCancel()
 	instanceMu.Lock()
-	if len(instances) == 1 {
-		terminate = true
-	}
 	delete(instances, pi)
 
 	instanceMu.Unlock()

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -592,11 +592,7 @@ func (pi *piPigpio) Close(ctx context.Context) error {
 	}
 	delete(instances, pi)
 
-	if terminate {
-		instanceMu.Unlock()
-	} else {
-		instanceMu.Unlock()
-	}
+	instanceMu.Unlock()
 
 	var err error
 	for _, spi := range pi.spis {

--- a/components/board/pi/impl/board_test.go
+++ b/components/board/pi/impl/board_test.go
@@ -269,7 +269,7 @@ func TestServoFunctions(t *testing.T) {
 		test.That(t, a, test.ShouldEqual, 180)
 	})
 
-	t.Run(("check Move IsMoving ande pigpio errors"), func(t *testing.T) {
+	t.Run(("check Move IsMoving and pigpio errors"), func(t *testing.T) {
 		ctx := context.Background()
 		s := &piPigpioServo{pinname: "1", maxRotation: 180}
 

--- a/components/board/pi/impl/board_test.go
+++ b/components/board/pi/impl/board_test.go
@@ -306,15 +306,5 @@ func TestServoFunctions(t *testing.T) {
 		moving, err = s.IsMoving(ctx)
 		test.That(t, moving, test.ShouldBeFalse)
 		test.That(t, err, test.ShouldBeNil)
-
-		err = s.Move(ctx, 8, nil)
-		test.That(t, err, test.ShouldNotBeNil)
-
-		err = s.Stop(ctx, nil)
-		test.That(t, err, test.ShouldNotBeNil)
-
-		pos, err := s.Position(ctx, nil)
-		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, pos, test.ShouldEqual, 0)
 	})
 }


### PR DESCRIPTION
Hopefully this unblocks @chris-viam! He encountered errors about pigpio being uninitialized when changing a config on a raspberry pi. Without this change, if you start up the server and reconfigure the pi, you get errors about pigpio not being initialized. With this change, things work!

What's going on: when you change the config, you go through the reconfiguration process. The raspberry pi component is part of `resource.AlwaysRebuild`, meaning that when it gets reconfigured it just returns a special error indicating that it's safe to construct a brand new struct. The reconfiguration then constructs the new one, and closes the old one. This order is unintuitive: constructing the new one initializes pigpio, and closing the old one de-initializes it again, hence the errors Chris was seeing.

There is no obvious reason we'd ever want to de-initialize the library: let's just keep it initialized the whole time.

I suggest reading this commit-by-commit: each one is self-contained.