### PR TITLE
RSDK-1880: wheeled base audit

### DIFF
--- a/components/base/wheeled/wheeled_base.go
+++ b/components/base/wheeled/wheeled_base.go
@@ -203,7 +203,8 @@ func (wb *wheeledBase) SetVelocity(ctx context.Context, linear, angular r3.Vecto
 	wb.opMgr.CancelRunning(ctx)
 
 	wb.logger.Debugf(
-		"received a SetVelocity with linear.X: %.2f, linear.Y: %.2f linear.Z: %.2f (mmPerSec), angular.X: %.2f, angular.Y: %.2f, angular.Z: %.2f",
+		"received a SetVelocity with linear.X: %.2f, linear.Y: %.2f linear.Z: %.2f"+
+			" (mmPerSec), angular.X: %.2f, angular.Y: %.2f, angular.Z: %.2f",
 		linear.X, linear.Y, linear.Z, angular.X, angular.Y, angular.Z)
 
 	l, r := wb.velocityMath(linear.Y, angular.Z)
@@ -216,7 +217,8 @@ func (wb *wheeledBase) SetPower(ctx context.Context, linear, angular r3.Vector, 
 	wb.opMgr.CancelRunning(ctx)
 
 	wb.logger.Debugf(
-		"received a SetPower with linear.X: %.2f, linear.Y: %.2f linear.Z: %.2f, angular.X: %.2f, angular.Y: %.2f, angular.Z: %.2f",
+		"received a SetPower with linear.X: %.2f, linear.Y: %.2f linear.Z: %.2f,"+
+			" angular.X: %.2f, angular.Y: %.2f, angular.Z: %.2f",
 		linear.X, linear.Y, linear.Z, angular.X, angular.Y, angular.Z)
 
 	lPower, rPower := wb.differentialDrive(linear.Y, angular.Z)

--- a/components/base/wheeled/wheeled_base.go
+++ b/components/base/wheeled/wheeled_base.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"time"
 
 	"github.com/edaniels/golog"
 	"github.com/golang/geo/r3"
@@ -273,40 +272,6 @@ func (wb *wheeledBase) straightDistanceToMotorInputs(distanceMm int, mmPerSec fl
 	rpm := 60 * rotationsPerSec
 
 	return rpm, rotations
-}
-
-// WaitForMotorsToStop is unused except for tests, polls all motors to see if they're on
-// TODO: Audit in  RSDK-1880.
-func (wb *wheeledBase) WaitForMotorsToStop(ctx context.Context) error {
-	for {
-		if !utils.SelectContextOrWait(ctx, 10*time.Millisecond) {
-			return ctx.Err()
-		}
-
-		anyOn := false
-		anyOff := false
-
-		for _, m := range wb.allMotors {
-			isOn, _, err := m.IsPowered(ctx, nil)
-			if err != nil {
-				return err
-			}
-			if isOn {
-				anyOn = true
-			} else {
-				anyOff = true
-			}
-		}
-
-		if !anyOn {
-			return nil
-		}
-
-		if anyOff {
-			// once one motor turns off, we turn them all off
-			return wb.Stop(ctx, nil)
-		}
-	}
 }
 
 // Stop commands the base to stop moving.

--- a/components/base/wheeled/wheeled_base.go
+++ b/components/base/wheeled/wheeled_base.go
@@ -1,6 +1,12 @@
 // Package wheeled implements some bases, like a wheeled base.
 package wheeled
 
+/*	This driver package enables control of a wheeled base, supporting
+	spinning, straight movement, velocity and power control, and stopping.
+	It provides configuration validation and implements the base interface
+	for movement control.
+*/
+
 import (
 	"context"
 	"fmt"

--- a/components/base/wheeled/wheeled_base_test.go
+++ b/components/base/wheeled/wheeled_base_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/edaniels/golog"
 	"go.viam.com/test"
+	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/base"
 	"go.viam.com/rdk/components/motor"
@@ -86,7 +87,7 @@ func TestWheelBaseMath(t *testing.T) {
 		err := base.MoveStraight(ctx, 1000, 0, nil)
 		test.That(t, err, test.ShouldBeNil)
 
-		err = base.WaitForMotorsToStop(ctx)
+		err = base.waitForMotorsToStop(ctx)
 		test.That(t, err, test.ShouldBeNil)
 
 		for _, m := range base.allMotors {
@@ -101,7 +102,7 @@ func TestWheelBaseMath(t *testing.T) {
 		err := base.MoveStraight(ctx, 0, 1000, nil)
 		test.That(t, err, test.ShouldBeNil)
 
-		err = base.WaitForMotorsToStop(ctx)
+		err = base.waitForMotorsToStop(ctx)
 		test.That(t, err, test.ShouldBeNil)
 
 		for _, m := range base.allMotors {
@@ -112,7 +113,7 @@ func TestWheelBaseMath(t *testing.T) {
 		}
 	})
 
-	t.Run("WaitForMotorsToStop", func(t *testing.T) {
+	t.Run("waitForMotorsToStop", func(t *testing.T) {
 		err := base.Stop(ctx, nil)
 		test.That(t, err, test.ShouldBeNil)
 
@@ -123,7 +124,7 @@ func TestWheelBaseMath(t *testing.T) {
 		test.That(t, isOn, test.ShouldBeTrue)
 		test.That(t, powerPct, test.ShouldEqual, 1.0)
 
-		err = base.WaitForMotorsToStop(ctx)
+		err = base.waitForMotorsToStop(ctx)
 		test.That(t, err, test.ShouldBeNil)
 
 		for _, m := range base.allMotors {
@@ -133,7 +134,7 @@ func TestWheelBaseMath(t *testing.T) {
 			test.That(t, powerPct, test.ShouldEqual, 0.0)
 		}
 
-		err = base.WaitForMotorsToStop(ctx)
+		err = base.waitForMotorsToStop(ctx)
 		test.That(t, err, test.ShouldBeNil)
 
 		for _, m := range base.allMotors {
@@ -363,4 +364,38 @@ func TestValidate(t *testing.T) {
 	deps, err = cfg.Validate("path")
 	test.That(t, deps, test.ShouldResemble, []string{"fl-m", "bl-m", "fr-m", "br-m"})
 	test.That(t, err, test.ShouldBeNil)
+}
+
+// waitForMotorsToStop is unused except for tests, polls all motors to see if they're on
+// TODO: Audit in  RSDK-1880.
+func (wb *wheeledBase) waitForMotorsToStop(ctx context.Context) error {
+	for {
+		if !utils.SelectContextOrWait(ctx, 10*time.Millisecond) {
+			return ctx.Err()
+		}
+
+		anyOn := false
+		anyOff := false
+
+		for _, m := range wb.allMotors {
+			isOn, _, err := m.IsPowered(ctx, nil)
+			if err != nil {
+				return err
+			}
+			if isOn {
+				anyOn = true
+			} else {
+				anyOff = true
+			}
+		}
+
+		if !anyOn {
+			return nil
+		}
+
+		if anyOff {
+			// once one motor turns off, we turn them all off
+			return wb.Stop(ctx, nil)
+		}
+	}
 }

--- a/components/base/wheeled/wheeled_base_test.go
+++ b/components/base/wheeled/wheeled_base_test.go
@@ -367,7 +367,6 @@ func TestValidate(t *testing.T) {
 }
 
 // waitForMotorsToStop is unused except for tests, polls all motors to see if they're on
-// TODO: Audit in  RSDK-1880.
 func (wb *wheeledBase) waitForMotorsToStop(ctx context.Context) error {
 	for {
 		if !utils.SelectContextOrWait(ctx, 10*time.Millisecond) {

--- a/components/base/wheeled/wheeled_base_test.go
+++ b/components/base/wheeled/wheeled_base_test.go
@@ -366,7 +366,7 @@ func TestValidate(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 }
 
-// waitForMotorsToStop is unused except for tests, polls all motors to see if they're on
+// waitForMotorsToStop polls all motors to see if they're on
 func (wb *wheeledBase) waitForMotorsToStop(ctx context.Context) error {
 	for {
 		if !utils.SelectContextOrWait(ctx, 10*time.Millisecond) {

--- a/components/base/wheeled/wheeled_base_test.go
+++ b/components/base/wheeled/wheeled_base_test.go
@@ -366,7 +366,7 @@ func TestValidate(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 }
 
-// waitForMotorsToStop polls all motors to see if they're on
+// waitForMotorsToStop polls all motors to see if they're on.
 func (wb *wheeledBase) waitForMotorsToStop(ctx context.Context) error {
 	for {
 		if !utils.SelectContextOrWait(ctx, 10*time.Millisecond) {


### PR DESCRIPTION
In this audit: 
- made wheeled base reconfigurable 
- moved waitForMotorsToStop to test, since that's the only place it is used. 
- added package description. 
- rearranged functions for consistent pattern. 