### PR TITLE
[RSDK-2691] Reconfigure digital interrupts on raspberry pi boards!

### DIFF
--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -77,7 +77,7 @@ type piPigpio struct {
 	i2cs          map[string]board.I2C
 	spis          map[string]board.SPI
 	// `interrupts` maps interrupt names to the interrupts. `interruptsHW` maps broadcom addresses
-	// to these same values.
+	// to these same values. The two should always have the same set of values.
 	interrupts   map[string]board.ReconfigurableDigitalInterrupt
 	interruptsHW map[uint]board.ReconfigurableDigitalInterrupt
 	logger       golog.Logger
@@ -266,6 +266,8 @@ func (pi *piPigpio) reconfigureInterrupts(ctx context.Context, cfg *genericlinux
 	// We reuse the old interrupts when possible.
 	oldInterrupts := pi.interrupts
 	oldInterruptsHW := pi.interruptsHW
+	// Like with pi.interrupts and pi.interruptsHW, these two will have identical values, mapped to
+	// using different keys.
 	newInterrupts := map[string]board.ReconfigurableDigitalInterrupt{}
 	newInterruptsHW := map[uint]board.ReconfigurableDigitalInterrupt{}
 

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -231,8 +231,21 @@ func (pi *piPigpio) reconfigureInterrupts(conf resource.Config) error {
 	// for each new interrupt:
 	//     if it exists but is wrong, close it
 	//     if it doesn't exist, create it
+
+	// We reuse the old interrupts when possible.
+	oldInterrupts = pi.interrupts
+	oldInterruptsHW = pi.interruptsHW
 	pi.interrupts = map[string]board.DigitalInterrupt{}
 	pi.interruptsHW = map[uint]board.DigitalInterrupt{}
+
+	for name, interrupt := range oldInterrupts {
+		if newConfig := getInterruptConfig(name, cfg); newConfig != nil {
+		} else {
+			// No longer used.
+			interrupt.Close()
+		}
+	}
+
 	for _, c := range cfg.DigitalInterrupts {
 		bcom, have := broadcomPinFromHardwareLabel(c.Pin)
 		if !have {

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -184,6 +184,7 @@ func (pi *piPigpio) Reconfigure(
 }
 
 func (pi *piPigpio) reconfigureI2cs(ctx context.Context, cfg *genericlinux.Config) error {
+	// No need to reconfigure the old I2C buses; just throw them out and make new ones.
 	pi.i2cs = make(map[string]board.I2C, len(cfg.I2Cs))
 	for _, sc := range cfg.I2Cs {
 		id, err := strconv.Atoi(sc.Bus)
@@ -196,6 +197,7 @@ func (pi *piPigpio) reconfigureI2cs(ctx context.Context, cfg *genericlinux.Confi
 }
 
 func (pi *piPigpio) reconfigureSpis(ctx context.Context, cfg *genericlinux.Config) error {
+	// No need to reconfigure the old SPI buses; just throw them out and make new ones.
 	pi.spis = make(map[string]board.SPI, len(cfg.SPIs))
 	for _, sc := range cfg.SPIs {
 		if sc.BusSelect != "0" && sc.BusSelect != "1" {
@@ -207,6 +209,7 @@ func (pi *piPigpio) reconfigureSpis(ctx context.Context, cfg *genericlinux.Confi
 }
 
 func (pi *piPigpio) reconfigureAnalogs(ctx context.Context, cfg *genericlinux.Config) error {
+	// No need to reconfigure the old analog readers; just throw them out and make new ones.
 	pi.analogs = map[string]board.AnalogReader{}
 	for _, ac := range cfg.Analogs {
 		channel, err := strconv.Atoi(ac.Pin)
@@ -225,6 +228,8 @@ func (pi *piPigpio) reconfigureAnalogs(ctx context.Context, cfg *genericlinux.Co
 	return nil
 }
 
+// This is a helper function for digital interrupt reconfiguration. It finds the key in the map
+// whose value is the given interrupt, and returns that key and whether we successfully found it.
 func findInterruptName(
 	interrupt board.ReconfigurableDigitalInterrupt,
 	interrupts map[string]board.ReconfigurableDigitalInterrupt,
@@ -234,10 +239,10 @@ func findInterruptName(
 			return key, true
 		}
 	}
-
 	return "", false
 }
 
+// This is a very similar helper function, which does the same thing but for broadcom addresses.
 func findInterruptBcom(
 	interrupt board.ReconfigurableDigitalInterrupt,
 	interruptsHW map[uint]board.ReconfigurableDigitalInterrupt,
@@ -247,7 +252,6 @@ func findInterruptBcom(
 			return key, true
 		}
 	}
-
 	return 0, false
 }
 

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -281,6 +281,9 @@ func (pi *piPigpio) reconfigureInterrupts(ctx context.Context, cfg *genericlinux
 		newInterruptsHW[bcom] = interrupt
 		delete(interruptsToClose, interrupt)
 
+		// We also need to remove the reused interrupt from oldInterrupts and oldInterruptsHW, to
+		// avoid double-reuse (e.g., the old interrupt had name "foo" on pin 7, and the new config
+		// has name "foo" on pin 8 and name "bar" on pin 7).
 		if oldName, ok := findInterruptName(interrupt, oldInterrupts); ok {
 			delete(oldInterrupts, oldName)
 		} else {

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -64,7 +64,6 @@ func init() {
 // accessed via pigpio.
 type piPigpio struct {
 	resource.Named
-	resource.AlwaysRebuild
 	mu              sync.Mutex
 	interruptCtx    context.Context
 	interruptCancel context.CancelFunc
@@ -135,7 +134,7 @@ func newPigpio(ctx context.Context, name resource.Name, cfg resource.Config, log
 		interruptCancel: cancelFunc,
 	}
 
-	if err := piInstance.performConfiguration(ctx, nil, cfg); err != nil {
+	if err := piInstance.Reconfigure(ctx, nil, cfg); err != nil {
 		// This has to happen outside of the lock to avoid a deadlock with interrupts.
 		C.gpioTerminate()
 		instanceMu.Lock()
@@ -147,8 +146,7 @@ func newPigpio(ctx context.Context, name resource.Name, cfg resource.Config, log
 	return piInstance, nil
 }
 
-// TODO(RSDK-RSDK-2691): implement reconfigure.
-func (pi *piPigpio) performConfiguration(
+func (pi *piPigpio) Reconfigure(
 	ctx context.Context,
 	_ resource.Dependencies,
 	conf resource.Config,

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -735,12 +735,11 @@ func (pi *piPigpio) Close(ctx context.Context) error {
 	// Prevent duplicate calls to Close a board as this may overlap with
 	// the reinitialization of the board
 	pi.mu.Lock()
+	defer pi.mu.Unlock()
 	if pi.isClosed {
 		pi.logger.Info("Duplicate call to close pi board detected, skipping")
-		pi.mu.Unlock()
 		return nil
 	}
-	pi.mu.Unlock()
 	pi.interruptCancel()
 
 	instanceMu.Lock()
@@ -779,8 +778,6 @@ func (pi *piPigpio) Close(ctx context.Context) error {
 	pi.interrupts = map[string]board.ReconfigurableDigitalInterrupt{}
 	pi.interruptsHW = map[uint]board.ReconfigurableDigitalInterrupt{}
 
-	pi.mu.Lock()
-	defer pi.mu.Unlock()
 	pi.isClosed = true
 	return err
 }

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -73,7 +73,7 @@ type piPigpio struct {
 	analogs         map[string]board.AnalogReader
 	i2cs            map[string]board.I2C
 	spis            map[string]board.SPI
-	// `interrupts` maps interrupt names to the interrupts. `interruptsHW` makes broadcom addresses
+	// `interrupts` maps interrupt names to the interrupts. `interruptsHW` maps broadcom addresses
 	// to these same values.
 	interrupts      map[string]board.ReconfigurableDigitalInterrupt
 	interruptsHW    map[uint]board.ReconfigurableDigitalInterrupt

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -134,10 +134,10 @@ func newPigpio(ctx context.Context, name resource.Name, cfg resource.Config, log
 
 	cancelCtx, cancelFunc := context.WithCancel(context.Background())
 	piInstance := &piPigpio{
-		Named:           name.AsNamed(),
-		logger:          logger,
-		isClosed:        false,
-		cancelCtx:    cancelCtx,
+		Named:      name.AsNamed(),
+		logger:     logger,
+		isClosed:   false,
+		cancelCtx:  cancelCtx,
 		cancelFunc: cancelFunc,
 	}
 

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -181,7 +181,7 @@ func (pi *piPigpio) performConfiguration(
 	return nil
 }
 
-func (pi *piPigpio) reconfigureI2cs(conf resource.Config) error {
+func (pi *piPigpio) reconfigureI2cs(cfg *genericlinux.Config) error {
 	pi.i2cs = make(map[string]board.I2C, len(cfg.I2Cs))
 	for _, sc := range cfg.I2Cs {
 		id, err := strconv.Atoi(sc.Bus)
@@ -193,7 +193,7 @@ func (pi *piPigpio) reconfigureI2cs(conf resource.Config) error {
 	return nil
 }
 
-func (pi *piPigpio) reconfigureSpis(conf resource.Config) error {
+func (pi *piPigpio) reconfigureSpis(cfg *genericlinux.Config) error {
 	pi.spis = make(map[string]board.SPI, len(cfg.SPIs))
 	for _, sc := range cfg.SPIs {
 		if sc.BusSelect != "0" && sc.BusSelect != "1" {
@@ -204,7 +204,7 @@ func (pi *piPigpio) reconfigureSpis(conf resource.Config) error {
 	return nil
 }
 
-func (pi *piPigpio) reconfigureAnalogs(conf resource.Config) error {
+func (pi *piPigpio) reconfigureAnalogs(cfg *genericlinux.Config) error {
 	pi.analogs = map[string]board.AnalogReader{}
 	for _, ac := range cfg.Analogs {
 		channel, err := strconv.Atoi(ac.Pin)
@@ -223,7 +223,7 @@ func (pi *piPigpio) reconfigureAnalogs(conf resource.Config) error {
 	return nil
 }
 
-func (pi *piPigpio) reconfigureInterrupts(conf resource.Config) error {
+func (pi *piPigpio) reconfigureInterrupts(cfg *genericlinux.Config) error {
 	// For each old interrupt:
 	//     if you're supposed to copy it over, do so
 	//     else close it

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -696,8 +696,8 @@ func (pi *piPigpio) Close(ctx context.Context) error {
 	for _, interrupt := range pi.interrupts {
 		err = multierr.Combine(err, interrupt.Close(ctx))
 	}
-	pi.interrupts = map[string]board.DigitalInterrupt{}
-	pi.interruptsHW = map[uint]board.DigitalInterrupt{}
+	pi.interrupts = map[string]board.ReconfigurableDigitalInterrupt{}
+	pi.interruptsHW = map[uint]board.ReconfigurableDigitalInterrupt{}
 
 	pi.mu.Lock()
 	pi.isClosed = true

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -270,7 +270,9 @@ func (pi *piPigpio) reconfigureInterrupts(conf resource.Config) error {
 		}
 		pi.interrupts[c.Name] = di
 		pi.interruptsHW[bcom] = di
-		C.setupInterrupt(C.int(bcom))
+		if result := C.setupInterrupt(C.int(bcom)); result != 0 {
+			return picommon.ConvertErrorCodeToMessage(int(result), "error")
+		}
 	}
 }
 
@@ -618,6 +620,11 @@ func (pi *piPigpio) DigitalInterruptByName(name string) (board.DigitalInterrupt,
 			pi.interrupts[name] = d
 			pi.interruptsHW[bcom] = d
 			C.setupInterrupt(C.int(bcom))
+			if result := C.setupInterrupt(C.int(bcom)); result != 0 {
+				err := picommon.ConvertErrorCodeToMessage(int(result), "error")
+				pi.logger.Errorf("Unable to set up interrupt on pin %s: %s", name, err)
+				return nil, false
+			}
 			return d, true
 		}
 	}

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -675,13 +675,14 @@ func (pi *piPigpio) DigitalInterruptByName(name string) (board.DigitalInterrupt,
 			if err != nil {
 				return nil, false
 			}
-			pi.interrupts[name] = d
-			pi.interruptsHW[bcom] = d
 			if result := C.setupInterrupt(C.int(bcom)); result != 0 {
 				err := picommon.ConvertErrorCodeToMessage(int(result), "error")
 				pi.logger.Errorf("Unable to set up interrupt on pin %s: %s", name, err)
 				return nil, false
 			}
+
+			pi.interrupts[name] = d
+			pi.interruptsHW[bcom] = d
 			return d, true
 		}
 	}

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -680,7 +680,6 @@ func (pi *piPigpio) DigitalInterruptByName(name string) (board.DigitalInterrupt,
 			}
 			pi.interrupts[name] = d
 			pi.interruptsHW[bcom] = d
-			C.setupInterrupt(C.int(bcom))
 			if result := C.setupInterrupt(C.int(bcom)); result != 0 {
 				err := picommon.ConvertErrorCodeToMessage(int(result), "error")
 				pi.logger.Errorf("Unable to set up interrupt on pin %s: %s", name, err)

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -196,6 +196,12 @@ func (pi *piPigpio) performConfiguration(
 	}
 
 	// setup interrupts
+	// For each old interrupt:
+	//     if you're supposed to copy it over, do so
+	//     else close it
+	// for each new interrupt:
+	//     if it exists but is wrong, close it
+	//     if it doesn't exist, create it
 	pi.interrupts = map[string]board.DigitalInterrupt{}
 	pi.interruptsHW = map[uint]board.DigitalInterrupt{}
 	for _, c := range cfg.DigitalInterrupts {

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -180,8 +180,8 @@ func (pi *piPigpio) performConfiguration(
 	}
 
 	instanceMu.Lock()
+	defer instanceMu.Unlock()
 	instances[pi] = struct{}{}
-	instanceMu.Unlock()
 	return nil
 }
 
@@ -747,8 +747,8 @@ func (pi *piPigpio) Close(ctx context.Context) error {
 	pi.interruptsHW = map[uint]board.ReconfigurableDigitalInterrupt{}
 
 	pi.mu.Lock()
+	defer pi.mu.Unlock()
 	pi.isClosed = true
-	pi.mu.Unlock()
 	return err
 }
 

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -372,6 +372,8 @@ func (pi *piPigpio) reconfigureInterrupts(ctx context.Context, cfg *genericlinux
 
 // GPIOPinNames returns the names of all known GPIO pins.
 func (pi *piPigpio) GPIOPinNames() []string {
+	pi.mu.Lock()
+	defer pi.mu.Unlock()
 	names := make([]string, 0, len(piHWPinToBroadcom))
 	for k := range piHWPinToBroadcom {
 		names = append(names, k)
@@ -381,6 +383,8 @@ func (pi *piPigpio) GPIOPinNames() []string {
 
 // GPIOPinByName returns a GPIOPin by name.
 func (pi *piPigpio) GPIOPinByName(pin string) (board.GPIOPin, error) {
+	pi.mu.Lock()
+	defer pi.mu.Unlock()
 	bcom, have := broadcomPinFromHardwareLabel(pin)
 	if !have {
 		return nil, errors.Errorf("no hw pin for (%s)", pin)
@@ -466,9 +470,9 @@ func (pi *piPigpio) pwmBcom(bcom int) (float64, error) {
 
 // SetPWMBcom sets the given broadcom pin to the given PWM duty cycle.
 func (pi *piPigpio) SetPWMBcom(bcom int, dutyCyclePct float64) error {
-	dutyCycle := rdkutils.ScaleByPct(255, dutyCyclePct)
 	pi.mu.Lock()
 	defer pi.mu.Unlock()
+	dutyCycle := rdkutils.ScaleByPct(255, dutyCyclePct)
 	pi.duty = int(C.gpioPWM(C.uint(bcom), C.uint(dutyCycle)))
 	if pi.duty != 0 {
 		return errors.Errorf("pwm set fail %d", pi.duty)
@@ -483,6 +487,8 @@ func (pi *piPigpio) pwmFreqBcom(bcom int) (uint, error) {
 
 // SetPWMFreqBcom sets the given broadcom pin to the given PWM frequency.
 func (pi *piPigpio) SetPWMFreqBcom(bcom int, freqHz uint) error {
+	pi.mu.Lock()
+	defer pi.mu.Unlock()
 	if freqHz == 0 {
 		freqHz = 800 // Original default from libpigpio
 	}
@@ -631,6 +637,8 @@ func (s *piPigpioSPIHandle) Close() error {
 
 // SPINames returns the names of all known SPI buses.
 func (pi *piPigpio) SPINames() []string {
+	pi.mu.Lock()
+	defer pi.mu.Unlock()
 	if len(pi.spis) == 0 {
 		return nil
 	}
@@ -643,6 +651,8 @@ func (pi *piPigpio) SPINames() []string {
 
 // I2CNames returns the names of all known SPI buses.
 func (pi *piPigpio) I2CNames() []string {
+	pi.mu.Lock()
+	defer pi.mu.Unlock()
 	if len(pi.i2cs) == 0 {
 		return nil
 	}
@@ -655,6 +665,8 @@ func (pi *piPigpio) I2CNames() []string {
 
 // AnalogReaderNames returns the names of all known analog readers.
 func (pi *piPigpio) AnalogReaderNames() []string {
+	pi.mu.Lock()
+	defer pi.mu.Unlock()
 	names := []string{}
 	for k := range pi.analogs {
 		names = append(names, k)
@@ -664,6 +676,8 @@ func (pi *piPigpio) AnalogReaderNames() []string {
 
 // DigitalInterruptNames returns the names of all known digital interrupts.
 func (pi *piPigpio) DigitalInterruptNames() []string {
+	pi.mu.Lock()
+	defer pi.mu.Unlock()
 	names := []string{}
 	for k := range pi.interrupts {
 		names = append(names, k)
@@ -673,18 +687,24 @@ func (pi *piPigpio) DigitalInterruptNames() []string {
 
 // AnalogReaderByName returns an analog reader by name.
 func (pi *piPigpio) AnalogReaderByName(name string) (board.AnalogReader, bool) {
+	pi.mu.Lock()
+	defer pi.mu.Unlock()
 	a, ok := pi.analogs[name]
 	return a, ok
 }
 
 // SPIByName returns an SPI bus by name.
 func (pi *piPigpio) SPIByName(name string) (board.SPI, bool) {
+	pi.mu.Lock()
+	defer pi.mu.Unlock()
 	s, ok := pi.spis[name]
 	return s, ok
 }
 
 // I2CByName returns an I2C by name.
 func (pi *piPigpio) I2CByName(name string) (board.I2C, bool) {
+	pi.mu.Lock()
+	defer pi.mu.Unlock()
 	s, ok := pi.i2cs[name]
 	return s, ok
 }

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -256,13 +256,6 @@ func findInterruptBcom(
 }
 
 func (pi *piPigpio) reconfigureInterrupts(ctx context.Context, cfg *genericlinux.Config) error {
-	// For each old interrupt:
-	//     if you're supposed to copy it over, do so
-	//     else close it
-	// for each new interrupt:
-	//     if it exists but is wrong, close it
-	//     if it doesn't exist, create it
-
 	// We reuse the old interrupts when possible.
 	oldInterrupts := pi.interrupts
 	oldInterruptsHW := pi.interruptsHW

--- a/components/board/pi/impl/pi.c
+++ b/components/board/pi/impl/pi.c
@@ -16,3 +16,8 @@ void setupInterrupt(int gpio) {
     gpioSetPullUpDown(gpio, PI_PUD_UP); // should this be configurable?
     gpioSetAlertFunc(gpio, interruptCallback);
 }
+
+void teardownInterrupt(int gpio) {
+    gpioSetAlertFunc(gpio, NULL);
+    // Do we need to unset the pullup resistors?
+}

--- a/components/board/pi/impl/pi.c
+++ b/components/board/pi/impl/pi.c
@@ -11,13 +11,21 @@ void interruptCallback(int gpio, int level, uint32_t tick) {
     pigpioInterruptCallback(gpio, level, tick);
 }
 
-void setupInterrupt(int gpio) {
-    gpioSetMode(gpio, PI_INPUT);
-    gpioSetPullUpDown(gpio, PI_PUD_UP); // should this be configurable?
-    gpioSetAlertFunc(gpio, interruptCallback);
+int setupInterrupt(int gpio) {
+    int result = gpioSetMode(gpio, PI_INPUT);
+	if (result != 0) {
+		return result;
+	}
+    result = gpioSetPullUpDown(gpio, PI_PUD_UP); // should this be configurable?
+	if (result != 0) {
+		return result;
+	}
+    result = gpioSetAlertFunc(gpio, interruptCallback);
+	return result;
 }
 
-void teardownInterrupt(int gpio) {
-    gpioSetAlertFunc(gpio, NULL);
+int teardownInterrupt(int gpio) {
+    int result = gpioSetAlertFunc(gpio, NULL);
     // Do we need to unset the pullup resistors?
+	return result;
 }

--- a/components/board/pi/impl/pi.c
+++ b/components/board/pi/impl/pi.c
@@ -13,19 +13,19 @@ void interruptCallback(int gpio, int level, uint32_t tick) {
 
 int setupInterrupt(int gpio) {
     int result = gpioSetMode(gpio, PI_INPUT);
-	if (result != 0) {
-		return result;
-	}
+    if (result != 0) {
+        return result;
+    }
     result = gpioSetPullUpDown(gpio, PI_PUD_UP); // should this be configurable?
-	if (result != 0) {
-		return result;
-	}
+    if (result != 0) {
+        return result;
+    }
     result = gpioSetAlertFunc(gpio, interruptCallback);
-	return result;
+    return result;
 }
 
 int teardownInterrupt(int gpio) {
     int result = gpioSetAlertFunc(gpio, NULL);
     // Do we need to unset the pullup resistors?
-	return result;
+    return result;
 }

--- a/components/board/pi/impl/pi.h
+++ b/components/board/pi/impl/pi.h
@@ -1,5 +1,5 @@
 #pragma once
 
 // interruptCallback calls through to the go linked interrupt callback.
-void setupInterrupt(int gpio);
-void teardownInterrupt(int gpio);
+int setupInterrupt(int gpio);
+int teardownInterrupt(int gpio);

--- a/components/board/pi/impl/pi.h
+++ b/components/board/pi/impl/pi.h
@@ -2,3 +2,4 @@
 
 // interruptCallback calls through to the go linked interrupt callback.
 void setupInterrupt(int gpio);
+void teardownInterrupt(int gpio);


### PR DESCRIPTION
Not fully tried out yet, will finish that tomorrow. but this is very close to ready! Changes include:
- When using the pigpio library to set up a digital interrupt, it's possible to have errors returned. We should check for those.
- Make a way to tear down digital interrupts that are no longer used (and check for errors here, too)
- When you close a digital interrupt, tear it down within pigpio, too
- Split the reconfiguration function, which was getting pretty large already, into smaller helpers that focus on I2C, SPI, analog readers, and digital interrupts. For everything except digital interrupts, reconfiguration involves throwing out everything old and building the new one from scratch.
- Reconfigure digital interrupts:
  - For each new interrupt, if you can find an old one whose pin or name matches, reuse it. If you can't find an old one that matches, make a new one.
  - For each remaining old interrupt, if it looks like it was implicitly created from its pin name (e.g., it's named "3" and it's on pin 3), reuse it.
  - Close all other old interrupts.
  - Note that if an old interrupt matches two different new ones (e.g., you used to have an interrupt named "foo" on pin 3, and now you've got one named "foo" on pin 4 and one named "bar" on pin 3), the old one will be reused by whichever comes first in your new config.
- Document an invariant about the mutexes that must be enforced to avoid deadlocks. I did not create or modify this invariant; I'm just pointing it out so future people see it.

I do _not_ suggest you review commit-by-commit: many of them were made while I was in the middle of things, because I was stopping for lunch or whatever.