### PR TITLE
Revert "Never deinitialize pigpio"

### DIFF
--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -575,6 +575,7 @@ func (pi *piPigpio) SetPowerMode(ctx context.Context, mode pb.PowerMode, duratio
 
 // Close attempts to close all parts of the board cleanly.
 func (pi *piPigpio) Close(ctx context.Context) error {
+	var terminate bool
 	// Prevent duplicate calls to Close a board as this may overlap with
 	// the reinitialization of the board
 	pi.mu.Lock()
@@ -586,9 +587,20 @@ func (pi *piPigpio) Close(ctx context.Context) error {
 	pi.mu.Unlock()
 	pi.interruptCancel()
 	instanceMu.Lock()
+	if len(instances) == 1 {
+		terminate = true
+	}
 	delete(instances, pi)
 
-	instanceMu.Unlock()
+	if terminate {
+		pigpioInitialized = false
+		instanceMu.Unlock()
+		// This has to happen outside of the lock to avoid a deadlock with interrupts.
+		C.gpioTerminate()
+		pi.logger.Debug("Pi GPIO terminated properly.")
+	} else {
+		instanceMu.Unlock()
+	}
 
 	var err error
 	for _, spi := range pi.spis {

--- a/components/board/pi/impl/board_test.go
+++ b/components/board/pi/impl/board_test.go
@@ -269,7 +269,7 @@ func TestServoFunctions(t *testing.T) {
 		test.That(t, a, test.ShouldEqual, 180)
 	})
 
-	t.Run(("check Move IsMoving and pigpio errors"), func(t *testing.T) {
+	t.Run(("check Move IsMoving ande pigpio errors"), func(t *testing.T) {
 		ctx := context.Background()
 		s := &piPigpioServo{pinname: "1", maxRotation: 180}
 
@@ -306,5 +306,15 @@ func TestServoFunctions(t *testing.T) {
 		moving, err = s.IsMoving(ctx)
 		test.That(t, moving, test.ShouldBeFalse)
 		test.That(t, err, test.ShouldBeNil)
+
+		err = s.Move(ctx, 8, nil)
+		test.That(t, err, test.ShouldNotBeNil)
+
+		err = s.Stop(ctx, nil)
+		test.That(t, err, test.ShouldNotBeNil)
+
+		pos, err := s.Position(ctx, nil)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, pos, test.ShouldEqual, 0)
 	})
 }


### PR DESCRIPTION
Reverts viamrobotics/rdk#2367

Thanks to @Otterverse for catching this! Although normal memory and file descriptors get cleaned up when a process terminates, DMA'ed memory within the GPU does not! Consequently, this PR meant that the (actual, physical) raspberry pi we use for CI testing had more and more of its GPU taken up by DMA'ed stuff for processes that no longer existed, until it was full and the tests on https://github.com/viamrobotics/rdk/pull/2372 began failing.

We need to bring back the call to `gpioTerminate` to fix this, and then find a different way to avoid the race condition that caused the trouble PR #2367 was meant to fix.