### PR TITLE
[RSDK-3148] Don't allow sampling analog readers at a non-positive rate

### DIFF
--- a/components/board/analog_smoother.go
+++ b/components/board/analog_smoother.go
@@ -91,7 +91,7 @@ func (as *AnalogSmoother) Start(ctx context.Context) {
 	//    numSamples        4
 
 	numSamples := (as.SamplesPerSecond * as.AverageOverMillis) / 1000
-	if numSamples == 0 {
+	if numSamples <= 0 {
 		as.logger.Debug("Can't smooth over 0 samples at a time; defaulting to 1")
 		numSamples = 1
 	}

--- a/components/board/analog_smoother.go
+++ b/components/board/analog_smoother.go
@@ -91,6 +91,10 @@ func (as *AnalogSmoother) Start(ctx context.Context) {
 	//    numSamples        4
 
 	numSamples := (as.SamplesPerSecond * as.AverageOverMillis) / 1000
+	if numSamples == 0 {
+		as.logger.Debug("Can't smooth over 0 samples at a time; defaulting to 1")
+		numSamples = 1
+	}
 	as.data = utils.NewRollingAverage(numSamples)
 	nanosBetween := 1e9 / as.SamplesPerSecond
 

--- a/components/board/analog_smoother.go
+++ b/components/board/analog_smoother.go
@@ -37,6 +37,10 @@ func SmoothAnalogReader(r AnalogReader, c AnalogConfig, logger golog.Logger) *An
 		logger:            logger,
 		cancel:            cancel,
 	}
+	if smoother.SamplesPerSecond <= 0 {
+		logger.Debug("Can't read nonpositive samples per second; defaulting to 1 instead")
+		smoother.SamplesPerSecond = 1
+	}
 	smoother.Start(cancelCtx)
 	return smoother
 }

--- a/components/board/config.go
+++ b/components/board/config.go
@@ -50,6 +50,9 @@ func (config *AnalogConfig) Validate(path string) error {
 	if config.Name == "" {
 		return utils.NewConfigValidationFieldRequiredError(path, "name")
 	}
+	if config.SamplesPerSecond <= 0 {
+		return utils.NewConfigValidationError(path, "SamplesPerSecond must be non-negative")
+	}
 	return nil
 }
 

--- a/components/board/config.go
+++ b/components/board/config.go
@@ -1,6 +1,7 @@
 package board
 
 import (
+	"github.com/pkg/errors"
 	"go.viam.com/utils"
 )
 
@@ -51,7 +52,8 @@ func (config *AnalogConfig) Validate(path string) error {
 		return utils.NewConfigValidationFieldRequiredError(path, "name")
 	}
 	if config.SamplesPerSecond <= 0 {
-		return utils.NewConfigValidationError(path, "SamplesPerSecond must be non-negative")
+		return utils.NewConfigValidationError(
+			path, errors.New("SamplesPerSecond must be non-negative"))
 	}
 	return nil
 }

--- a/components/board/config.go
+++ b/components/board/config.go
@@ -1,7 +1,6 @@
 package board
 
 import (
-	"github.com/pkg/errors"
 	"go.viam.com/utils"
 )
 
@@ -52,8 +51,7 @@ func (config *AnalogConfig) Validate(path string) error {
 		return utils.NewConfigValidationFieldRequiredError(path, "name")
 	}
 	if config.SamplesPerSecond <= 0 {
-		return utils.NewConfigValidationError(
-			path, errors.New("SamplesPerSecond must be non-negative"))
+		return utils.NewConfigValidationError(path, "SamplesPerSecond must be non-negative")
 	}
 	return nil
 }

--- a/components/board/config.go
+++ b/components/board/config.go
@@ -50,9 +50,6 @@ func (config *AnalogConfig) Validate(path string) error {
 	if config.Name == "" {
 		return utils.NewConfigValidationFieldRequiredError(path, "name")
 	}
-	if config.SamplesPerSecond <= 0 {
-		return utils.NewConfigValidationError(path, "SamplesPerSecond must be non-negative")
-	}
 	return nil
 }
 


### PR DESCRIPTION
Ideally, we'll catch this in `Validate` and reject the config. but just in case something slips past that, we'll also have it default to 1 sample per second if someone tries to sample at 0 or below.

I haven't tried running this yet, but everything compiles, and it sure looks right to me...

edit: this fixes RSDK-3149 in addition to RSDK-3148.