### PR TITLE
RSDK-2876 Ignore non-internal non-remote services and implicit deps in Config

### DIFF
--- a/resource/config.go
+++ b/resource/config.go
@@ -174,7 +174,7 @@ func (conf Config) Equals(other Config) bool {
 }
 
 // Dependencies returns the deduplicated union of user-defined and implicit dependencies.
-// Implicit dependenices will be set to nil.
+// Implicit dependencies will be set to nil.
 func (conf *Config) Dependencies() []string {
 	result := make([]string, 0, len(conf.DependsOn)+len(conf.ImplicitDependsOn))
 	seen := make(map[string]struct{})

--- a/resource/config.go
+++ b/resource/config.go
@@ -174,6 +174,7 @@ func (conf Config) Equals(other Config) bool {
 }
 
 // Dependencies returns the deduplicated union of user-defined and implicit dependencies.
+// Implicit dependenices will be set to nil.
 func (conf *Config) Dependencies() []string {
 	result := make([]string, 0, len(conf.DependsOn)+len(conf.ImplicitDependsOn))
 	seen := make(map[string]struct{})
@@ -189,6 +190,7 @@ func (conf *Config) Dependencies() []string {
 	for _, dep := range conf.ImplicitDependsOn {
 		appendUniq(dep)
 	}
+	conf.ImplicitDependsOn = nil
 	return result
 }
 

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -136,8 +136,9 @@ func (manager *resourceManager) remoteResourceNames(remoteName resource.Name) []
 }
 
 var (
-	unknownModel = resource.DefaultModelFamily.WithModel("unknown")
-	builtinModel = resource.DefaultModelFamily.WithModel("builtin")
+	unknownModel     = resource.DefaultModelFamily.WithModel("unknown")
+	builtinModelName = "builtin"
+	builtinModel     = resource.DefaultModelFamily.WithModel(builtinModelName)
 )
 
 // maybe in the future this can become an actual resource with its own type
@@ -1065,9 +1066,12 @@ func (manager *resourceManager) createConfig() *config.Config {
 			conf.Remotes = append(conf.Remotes, *remoteConf)
 		} else if resName.API.IsComponent() {
 			conf.Components = append(conf.Components, resConf)
-		} else if resName.API.IsService() &&
-			resName.API.Type.Namespace != resource.APINamespaceRDKInternal {
-			conf.Services = append(conf.Services, resConf)
+		} else if resName.API.IsService() {
+			// Only append non-internal, non-builtin services.
+			if resName.API.Type.Namespace != resource.APINamespaceRDKInternal &&
+				resName.Name != builtinModelName {
+				conf.Services = append(conf.Services, resConf)
+			}
 		}
 	}
 

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -1065,7 +1065,8 @@ func (manager *resourceManager) createConfig() *config.Config {
 			conf.Remotes = append(conf.Remotes, *remoteConf)
 		} else if resName.API.IsComponent() {
 			conf.Components = append(conf.Components, resConf)
-		} else if resName.API.IsService() {
+		} else if resName.API.IsService() &&
+			resName.API.Type.Namespace != resource.APINamespaceRDKInternal {
 			conf.Services = append(conf.Services, resConf)
 		}
 	}

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -1065,9 +1065,10 @@ func (manager *resourceManager) createConfig() *config.Config {
 			conf.Remotes = append(conf.Remotes, *remoteConf)
 		} else if resName.API.IsComponent() {
 			conf.Components = append(conf.Components, resConf)
-		} else if resName.API.IsService() && !resConf.Equals(resource.Config{}) {
-			// Only append non-empty service configs. Internal services and remotes'
-			// builtin services will have empty configs.
+		} else if resName.API.IsService() &&
+			resName.API.Type.Namespace != resource.APINamespaceRDKInternal &&
+			!resName.ContainsRemoteNames() {
+			// Only append non-internal, non-remote service configs.
 			conf.Services = append(conf.Services, resConf)
 		}
 	}

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -136,9 +136,8 @@ func (manager *resourceManager) remoteResourceNames(remoteName resource.Name) []
 }
 
 var (
-	unknownModel     = resource.DefaultModelFamily.WithModel("unknown")
-	builtinModelName = "builtin"
-	builtinModel     = resource.DefaultModelFamily.WithModel(builtinModelName)
+	unknownModel = resource.DefaultModelFamily.WithModel("unknown")
+	builtinModel = resource.DefaultModelFamily.WithModel("builtin")
 )
 
 // maybe in the future this can become an actual resource with its own type
@@ -1066,12 +1065,10 @@ func (manager *resourceManager) createConfig() *config.Config {
 			conf.Remotes = append(conf.Remotes, *remoteConf)
 		} else if resName.API.IsComponent() {
 			conf.Components = append(conf.Components, resConf)
-		} else if resName.API.IsService() {
-			// Only append non-internal, non-builtin services.
-			if resName.API.Type.Namespace != resource.APINamespaceRDKInternal &&
-				resName.Name != builtinModelName {
-				conf.Services = append(conf.Services, resConf)
-			}
+		} else if resName.API.IsService() && !resConf.Equals(resource.Config{}) {
+			// Only append non-empty service configs. Internal services and remotes'
+			// builtin services will have empty configs.
+			conf.Services = append(conf.Services, resConf)
 		}
 	}
 


### PR DESCRIPTION
RSDK-2876 (bug fix for original PR #2353)

Ignores non-internal, non-remote configs when generating service configs from the resource graph. Sets `ImplicitDependsOn` to `nil` after calculating dependencies for a resource with `Dependencies()`.

`localRobot.Config()` was always returning a few empty service configs and causing needless reconfiguration, as `DiffConfigs` always reported the internal services (and builtin remote services) had been "removed" in the `newConfig`. `localRobot.Config()` was also returning RDK-calculated `ImplicitDependsOn` fields (for modular and regular resources), and `DiffConfigs` always reported the `ImplicitDependsOn` field as "removed" in the `newConfig`.  This caused needless reconfiguration/potential restart of any modular resource with implicit dependencies every 10 seconds (when run with a cloud config).