### PR TITLE
RSDK-2596 - Encoded Motors Dirflip Fixes 

### DIFF
--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -527,7 +527,6 @@ func (m *EncodedMotor) computeRamp(oldPower, newPower float64) float64 {
 // Both the RPM and the revolutions can be assigned negative values to move in a backwards direction.
 // Note: if both are negative the motor will spin in the forward direction.
 func (m *EncodedMotor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]interface{}) error {
-
 	ctx, done := m.opMgr.New(ctx)
 	defer done()
 
@@ -602,7 +601,8 @@ func (m *EncodedMotor) goForInternal(ctx context.Context, rpm, revolutions float
 	if err != nil {
 		return err
 	}
-	if !isOn { // if we're off we start slow, otherwise we just set the desired rpm
+	if !isOn {
+		// if we're off we start slow, otherwise we just set the desired rpm
 		err := m.setPower(ctx, 0.03*float64(d)*float64(m.flip), true)
 		if err != nil {
 			return err
@@ -649,7 +649,6 @@ func (m *EncodedMotor) Close(ctx context.Context) error {
 // at a specific speed. Regardless of the directionality of the RPM this function will move the motor
 // towards the specified target.
 func (m *EncodedMotor) GoTo(ctx context.Context, rpm, targetPosition float64, extra map[string]interface{}) error {
-
 	rpm *= float64(m.flip)
 	curPos, err := m.Position(ctx, extra)
 	if err != nil {

--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -1,4 +1,3 @@
-// Package gpio implements a GPIO based motor.
 package gpio
 
 import (
@@ -403,9 +402,8 @@ func (m *EncodedMotor) rpmMonitorPass(pos, lastPos, now, lastTime int64, rpmDebu
 
 	// slow down so we don't overshoot
 	// halve and quarter rpm values based on seconds remaining in move
-
 	desiredRPM := m.state.desiredRPM
-	timeLeftSeconds := 60.0 * rotationsLeft / desiredRPM
+	timeLeftSeconds := math.Abs(60.0 * rotationsLeft / desiredRPM)
 
 	desiredRPM = slowDownMath(timeLeftSeconds, desiredRPM, m.rampRate)
 
@@ -468,7 +466,7 @@ func (m *EncodedMotor) computeNewPowerPct(currentRPM, desiredRPM float64) float6
 		// to it, and we'll start moving soon.
 		return m.computeRamp(lastPowerPct, lastPowerPct*2)
 	}
-	dOverC := desiredRPM / currentRPM * float64(m.flip)
+	dOverC := desiredRPM / currentRPM
 	dOverC = math.Min(dOverC, 2)
 	dOverC = math.Max(dOverC, -2)
 
@@ -527,11 +525,9 @@ func (m *EncodedMotor) computeRamp(oldPower, newPower float64) float64 {
 // Both the RPM and the revolutions can be assigned negative values to move in a backwards direction.
 // Note: if both are negative the motor will spin in the forward direction.
 func (m *EncodedMotor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]interface{}) error {
-	rpm *= float64(m.flip)
 
 	ctx, done := m.opMgr.New(ctx)
 	defer done()
-
 	if err := m.goForInternal(ctx, rpm, revolutions); err != nil {
 		return err
 	}
@@ -545,6 +541,8 @@ func (m *EncodedMotor) GoFor(ctx context.Context, rpm, revolutions float64, extr
 
 func (m *EncodedMotor) goForInternal(ctx context.Context, rpm, revolutions float64) error {
 	m.RPMMonitorStart()
+
+	rpm *= float64(m.flip)
 
 	var d int64 = 1
 
@@ -587,7 +585,7 @@ func (m *EncodedMotor) goForInternal(ctx context.Context, rpm, revolutions float
 	if err != nil {
 		return err
 	}
-	m.state.setPoint = int64(pos) + d*numTicks*m.flip
+	m.state.setPoint = int64(pos) + d*numTicks
 
 	_, rpmDebug := getRPMSleepDebug()
 	if rpmDebug {
@@ -601,9 +599,8 @@ func (m *EncodedMotor) goForInternal(ctx context.Context, rpm, revolutions float
 	if err != nil {
 		return err
 	}
-	if !isOn {
-		// if we're off we start slow, otherwise we just set the desired rpm
-		err := m.setPower(ctx, float64(d)*0.03, true)
+	if !isOn { // if we're off we start slow, otherwise we just set the desired rpm
+		err := m.setPower(ctx, 0.03*float64(d)*float64(m.flip), true)
 		if err != nil {
 			return err
 		}
@@ -649,6 +646,8 @@ func (m *EncodedMotor) Close(ctx context.Context) error {
 // at a specific speed. Regardless of the directionality of the RPM this function will move the motor
 // towards the specified target.
 func (m *EncodedMotor) GoTo(ctx context.Context, rpm, targetPosition float64, extra map[string]interface{}) error {
+
+	rpm *= float64(m.flip)
 	curPos, err := m.Position(ctx, extra)
 	if err != nil {
 		return err
@@ -660,7 +659,7 @@ func (m *EncodedMotor) GoTo(ctx context.Context, rpm, targetPosition float64, ex
 		m.logger.Debug("GoTo distance nearly zero, not moving")
 		return nil
 	}
-	return m.GoFor(ctx, math.Abs(rpm), moveDistance, extra)
+	return m.GoFor(ctx, rpm, moveDistance, extra)
 }
 
 // GoTillStop moves until physically stopped (though with a ten second timeout) or stopFunc() returns true.

--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -1,3 +1,4 @@
+// Package gpio implements a GPIO based motor.
 package gpio
 
 import (
@@ -402,6 +403,7 @@ func (m *EncodedMotor) rpmMonitorPass(pos, lastPos, now, lastTime int64, rpmDebu
 
 	// slow down so we don't overshoot
 	// halve and quarter rpm values based on seconds remaining in move
+
 	desiredRPM := m.state.desiredRPM
 	timeLeftSeconds := math.Abs(60.0 * rotationsLeft / desiredRPM)
 
@@ -528,6 +530,7 @@ func (m *EncodedMotor) GoFor(ctx context.Context, rpm, revolutions float64, extr
 
 	ctx, done := m.opMgr.New(ctx)
 	defer done()
+
 	if err := m.goForInternal(ctx, rpm, revolutions); err != nil {
 		return err
 	}

--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -649,7 +649,7 @@ func (m *EncodedMotor) Close(ctx context.Context) error {
 // at a specific speed. Regardless of the directionality of the RPM this function will move the motor
 // towards the specified target.
 func (m *EncodedMotor) GoTo(ctx context.Context, rpm, targetPosition float64, extra map[string]interface{}) error {
-	rpm *= float64(m.flip)
+	rpm = math.Abs(rpm) * float64(m.flip)
 	curPos, err := m.Position(ctx, extra)
 	if err != nil {
 		return err

--- a/components/motor/gpio/motor_encoder_test.go
+++ b/components/motor/gpio/motor_encoder_test.go
@@ -140,7 +140,7 @@ func TestMotorEncoder1(t *testing.T) {
 		})
 	})
 
-	t.Run("encoded motor testing GoFor (REV + | REV +)", func(t *testing.T) {
+	t.Run("encoded motor testing GoFor (RPM + | REV +)", func(t *testing.T) {
 		test.That(t, motorDep.goForInternal(context.Background(), 1000, 1), test.ShouldBeNil)
 		test.That(t, fakeMotor.Direction(), test.ShouldEqual, 1)
 		test.That(t, fakeMotor.PowerPct(), test.ShouldBeGreaterThan, 0)
@@ -229,7 +229,7 @@ func TestMotorEncoder1(t *testing.T) {
 		test.That(t, motorDep.Stop(context.Background(), nil), test.ShouldBeNil)
 	})
 
-	t.Run("encoded motor testing GoFor (REV - | REV -)", func(t *testing.T) {
+	t.Run("encoded motor testing GoFor (RPM - | REV -)", func(t *testing.T) {
 		test.That(t, motorDep.goForInternal(context.Background(), -1000, -1), test.ShouldBeNil)
 		test.That(t, fakeMotor.Direction(), test.ShouldEqual, 1)
 		test.That(t, fakeMotor.PowerPct(), test.ShouldBeGreaterThan, 0)

--- a/components/motor/gpio/motor_encoder_test.go
+++ b/components/motor/gpio/motor_encoder_test.go
@@ -170,7 +170,7 @@ func TestMotorEncoder1(t *testing.T) {
 		test.That(t, motorDep.Stop(context.Background(), nil), test.ShouldBeNil)
 	})
 
-	t.Run("encoded motor testing GoFor (REV - | REV +)", func(t *testing.T) {
+	t.Run("encoded motor testing GoFor (RPM - | REV +)", func(t *testing.T) {
 		test.That(t, motorDep.goForInternal(context.Background(), -1000, 1), test.ShouldBeNil)
 		test.That(t, fakeMotor.Direction(), test.ShouldEqual, -1)
 		test.That(t, fakeMotor.PowerPct(), test.ShouldBeLessThan, 0)
@@ -199,7 +199,7 @@ func TestMotorEncoder1(t *testing.T) {
 		test.That(t, motorDep.Stop(context.Background(), nil), test.ShouldBeNil)
 	})
 
-	t.Run("encoded motor testing GoFor (REV + | REV -)", func(t *testing.T) {
+	t.Run("encoded motor testing GoFor (RPM + | REV -)", func(t *testing.T) {
 		test.That(t, motorDep.goForInternal(context.Background(), 1000, -1), test.ShouldBeNil)
 		test.That(t, fakeMotor.Direction(), test.ShouldEqual, -1)
 		test.That(t, fakeMotor.PowerPct(), test.ShouldBeLessThan, 0)


### PR DESCRIPTION
**Summary**
This fixes various bugs with encoded motors:

- GoFor moves in wrong direction when dirflip is true
- GoTo moves in wrong direction when dirflip is true
- SlowDownMath doesn't work correctly when RPM is negative 

Also fixed the incorrect test names in encoded motor tests since they were confusing me

**Testing**
Tested manually using encoded motor with control page. 