### PR TITLE
record the state when you de-initialize pigpio

### DIFF
--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -134,7 +134,11 @@ func newPigpio(ctx context.Context, name resource.Name, cfg resource.Config, log
 	}
 
 	if err := piInstance.performConfiguration(ctx, nil, cfg); err != nil {
+		// This has to happen outside of the lock to avoid a deadlock with interrupts.
 		C.gpioTerminate()
+		instanceMu.Lock()
+		pigpioInitialized = false
+		instanceMu.Unlock()
 		logger.Error("Pi GPIO terminated due to failed init.")
 		return nil, err
 	}


### PR DESCRIPTION
Thanks to @edaniels for noticing this! It is hopefully the correct way to fix the errors that https://github.com/viamrobotics/rdk/pull/2367 had been attempting to fix. With this change, every time we call `C.gpioTerminate()`, we also set `pigpioInitialized` to false. Without this change, we could get into a state where pigpio is not initialized but we mistakenly think it is, leading to trouble (we try using it and can't because it's not initialized, but we don't initialize it because we think that's already been done).

To try this out, I took my pi, made sure the RDK started up on it, and then changed the config to mention an I2C bus whose bus number was "asdf" (which is not a valid name: they must be numerical, and on a pi it's almost certainly "1"). This led to errors about invalid I2C buses. Then, I changed the config to be about I2C bus "1" again. On the main branch, this results in errors about pigpio not being initialized, and on this branch things recover properly.