### PR TITLE
RSDK-3177 Ignore remote components in localRobot.Config

### DIFF
--- a/robot/impl/data/remote_fake.json
+++ b/robot/impl/data/remote_fake.json
@@ -26,5 +26,17 @@
                 "model-path": "../../components/arm/fake/fake_model.json"
             }
         }
+    ],
+    "services": [
+        {
+            "name": "slam1",
+            "type": "slam",
+            "model": "fake"
+        },
+        {
+            "name": "data_manager1",
+            "type": "data_manager",
+            "model": "fake"
+        }
     ]
 }

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -1043,6 +1043,10 @@ func (manager *resourceManager) createConfig() *config.Config {
 	conf := &config.Config{}
 
 	for _, resName := range manager.resources.Names() {
+		// Ignore non-local resources.
+		if resName.ContainsRemoteNames() {
+			continue
+		}
 		gNode, ok := manager.resources.Node(resName)
 		if !ok {
 			continue
@@ -1066,9 +1070,7 @@ func (manager *resourceManager) createConfig() *config.Config {
 		} else if resName.API.IsComponent() {
 			conf.Components = append(conf.Components, resConf)
 		} else if resName.API.IsService() &&
-			resName.API.Type.Namespace != resource.APINamespaceRDKInternal &&
-			!resName.ContainsRemoteNames() {
-			// Only append non-internal, non-remote service configs.
+			resName.API.Type.Namespace != resource.APINamespaceRDKInternal {
 			conf.Services = append(conf.Services, resConf)
 		}
 	}


### PR DESCRIPTION
RSDK-3177

Follow up to #2379. Also ignores remote components when creating a config for `localRobot.Config()`.