### PR TITLE
bugfix - remote control, camera card borders

### DIFF
--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/remote-control",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "Apache-2.0",
       "devDependencies": {
         "@improbable-eng/grpc-web": "0.15.0",
@@ -15,7 +15,7 @@
         "@types/google.maps": "3.53.0",
         "@types/three": "0.152.0",
         "@typescript-eslint/eslint-plugin": "5.59.5",
-        "@viamrobotics/prime": "0.2.0",
+        "@viamrobotics/prime": "0.2.4",
         "@viamrobotics/rpc": "0.1.36",
         "@viamrobotics/sdk": "0.0.56",
         "@vitejs/plugin-vue": "4.2.1",
@@ -1292,9 +1292,9 @@
       }
     },
     "node_modules/@viamrobotics/prime": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@viamrobotics/prime/-/prime-0.2.0.tgz",
-      "integrity": "sha512-Bf2gvkYg9nB8EMzLmcF9nKGxv/mKzFwmIKgbGFgRTYCoKz7VgDTJYktKQE4PNGSs3YFYz8zFo7kTiyRshHwJyQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@viamrobotics/prime/-/prime-0.2.4.tgz",
+      "integrity": "sha512-p4Cb+jfC/1auSrjtbKrjOWeoM0pVTbGAbxe240zyNXlJ411yehy23vbSyBktHPg1AqiNYccRD2v63y7abX7bPw==",
       "dev": true
     },
     "node_modules/@viamrobotics/rpc": {
@@ -8075,9 +8075,9 @@
       }
     },
     "@viamrobotics/prime": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@viamrobotics/prime/-/prime-0.2.0.tgz",
-      "integrity": "sha512-Bf2gvkYg9nB8EMzLmcF9nKGxv/mKzFwmIKgbGFgRTYCoKz7VgDTJYktKQE4PNGSs3YFYz8zFo7kTiyRshHwJyQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@viamrobotics/prime/-/prime-0.2.4.tgz",
+      "integrity": "sha512-p4Cb+jfC/1auSrjtbKrjOWeoM0pVTbGAbxe240zyNXlJ411yehy23vbSyBktHPg1AqiNYccRD2v63y7abX7bPw==",
       "dev": true
     },
     "@viamrobotics/rpc": {

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "license": "Apache-2.0",
   "type": "module",
   "files": [
@@ -24,7 +24,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@viamrobotics/prime": "0.2.0",
+    "@viamrobotics/prime": "0.2.4",
     "@improbable-eng/grpc-web": "0.15.0",
     "@viamrobotics/rpc": "0.1.36",
     "@viamrobotics/sdk": "0.0.56",

--- a/web/frontend/src/components/audio-input.vue
+++ b/web/frontend/src/components/audio-input.vue
@@ -42,7 +42,7 @@ const toggleExpand = async () => {
       slot="title"
       crumbs="audio_input"
     />
-    <div class="border-medium h-auto border-x border-b p-2">
+    <div class="border-medium h-auto border border-t-0 p-2">
       <div class="container mx-auto">
         <div class="pt-4">
           <div class="flex items-center gap-2">

--- a/web/frontend/src/components/camera/cameras-list.vue
+++ b/web/frontend/src/components/camera/cameras-list.vue
@@ -48,7 +48,7 @@ const setupCamera = (cameraName: string) => {
       crumbs="camera"
     />
 
-    <div class="border-medium flex flex-col gap-4 border-x border-b p-4">
+    <div class="border-medium flex flex-col gap-4 border border-t-0 p-4">
       <v-switch
         :label="camera.name"
         :aria-label="openCameras[camera.name] ? `Hide Camera: ${camera.name}` : `View Camera: ${camera.name}`"


### PR DESCRIPTION
RC camera cards are missing right and left borders in the Viam app. This does not happen when running RDK locally, and seems to be a weird Tailwind build issue.

Fix: use `border border-t-0` instead of `border-x border-b`