### PR TITLE
RSDK-3016 cache the frame system config

### DIFF
--- a/components/arm/client_test.go
+++ b/components/arm/client_test.go
@@ -16,7 +16,6 @@ import (
 	viamgrpc "go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/robot/framesystem"
 	"go.viam.com/rdk/robot/server"
 	"go.viam.com/rdk/spatialmath"
 	"go.viam.com/rdk/testutils"
@@ -110,8 +109,8 @@ func TestClient(t *testing.T) {
 	test.That(t, resourceAPI.RegisterRPCService(context.Background(), rpcServer, armSvc), test.ShouldBeNil)
 
 	injectRobot := &inject.Robot{}
-	injectRobot.FrameSystemConfigFunc = func(ctx context.Context) (*framesystem.Config, error) {
-		return &framesystem.Config{}, nil
+	injectRobot.FrameSystemConfigFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
+		return []*referenceframe.FrameSystemPart{}, nil
 	}
 	test.That(t, rpcServer.RegisterServiceServer(
 		context.Background(),

--- a/components/arm/client_test.go
+++ b/components/arm/client_test.go
@@ -109,7 +109,7 @@ func TestClient(t *testing.T) {
 	test.That(t, resourceAPI.RegisterRPCService(context.Background(), rpcServer, armSvc), test.ShouldBeNil)
 
 	injectRobot := &inject.Robot{}
-	injectRobot.FrameSystemConfigFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
+	injectRobot.FrameSystemPartsFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
 		return []*referenceframe.FrameSystemPart{}, nil
 	}
 	test.That(t, rpcServer.RegisterServiceServer(

--- a/components/camera/videosource/join_pointcloud_test.go
+++ b/components/camera/videosource/join_pointcloud_test.go
@@ -69,7 +69,7 @@ func makeFakeRobot(t *testing.T) resource.Dependencies {
 	}
 	base1 := &inject.Base{}
 
-	fsParts := []*framesystem.FrameSystemPartConfig{
+	fsParts := []*framesystem.PartConfig{
 		{
 			PreprocessedPart: &referenceframe.FrameSystemPart{
 				FrameConfig: referenceframe.NewLinkInFrame(referenceframe.World, spatialmath.NewZeroPose(), "base1", nil),
@@ -306,7 +306,7 @@ func makeFakeRobotICP(t *testing.T) resource.Dependencies {
 	o1 := &spatialmath.EulerAngles{Roll: 0, Pitch: 0.6, Yaw: 0}
 	o2 := &spatialmath.EulerAngles{Roll: 0, Pitch: 0.6, Yaw: -0.3}
 
-	fsParts := []*framesystem.FrameSystemPartConfig{
+	fsParts := []*framesystem.PartConfig{
 		{
 			PreprocessedPart: &referenceframe.FrameSystemPart{
 				FrameConfig: referenceframe.NewLinkInFrame(referenceframe.World, spatialmath.NewZeroPose(), "base1", nil),

--- a/components/camera/videosource/join_pointcloud_test.go
+++ b/components/camera/videosource/join_pointcloud_test.go
@@ -72,12 +72,12 @@ func makeFakeRobot(t *testing.T) resource.Dependencies {
 	fsParts := []*framesystem.PartConfig{
 		{
 			PreprocessedPart: &referenceframe.FrameSystemPart{
-				FrameConfig: referenceframe.NewLinkInFrame(referenceframe.World, spatialmath.NewZeroPose(), "base1", nil),
+				Origin: referenceframe.NewLinkInFrame(referenceframe.World, spatialmath.NewZeroPose(), "base1", nil),
 			},
 		},
 		{
 			PreprocessedPart: &referenceframe.FrameSystemPart{
-				FrameConfig: referenceframe.NewLinkInFrame(
+				Origin: referenceframe.NewLinkInFrame(
 					referenceframe.World,
 					spatialmath.NewPoseFromPoint(r3.Vector{X: 100}),
 					"cam1",
@@ -87,12 +87,12 @@ func makeFakeRobot(t *testing.T) resource.Dependencies {
 		},
 		{
 			PreprocessedPart: &referenceframe.FrameSystemPart{
-				FrameConfig: referenceframe.NewLinkInFrame("cam1", spatialmath.NewPoseFromPoint(r3.Vector{Z: 100}), "cam2", nil),
+				Origin: referenceframe.NewLinkInFrame("cam1", spatialmath.NewPoseFromPoint(r3.Vector{Z: 100}), "cam2", nil),
 			},
 		},
 		{
 			PreprocessedPart: &referenceframe.FrameSystemPart{
-				FrameConfig: referenceframe.NewLinkInFrame("cam2", spatialmath.NewPoseFromPoint(r3.Vector{Y: 100}), "cam3", nil),
+				Origin: referenceframe.NewLinkInFrame("cam2", spatialmath.NewPoseFromPoint(r3.Vector{Y: 100}), "cam3", nil),
 			},
 		},
 	}
@@ -309,32 +309,32 @@ func makeFakeRobotICP(t *testing.T) resource.Dependencies {
 	fsParts := []*framesystem.PartConfig{
 		{
 			PreprocessedPart: &referenceframe.FrameSystemPart{
-				FrameConfig: referenceframe.NewLinkInFrame(referenceframe.World, spatialmath.NewZeroPose(), "base1", nil),
+				Origin: referenceframe.NewLinkInFrame(referenceframe.World, spatialmath.NewZeroPose(), "base1", nil),
 			},
 		},
 		{
 			PreprocessedPart: &referenceframe.FrameSystemPart{
-				FrameConfig: referenceframe.NewLinkInFrame(referenceframe.World, spatialmath.NewZeroPose(), "cam1", nil),
+				Origin: referenceframe.NewLinkInFrame(referenceframe.World, spatialmath.NewZeroPose(), "cam1", nil),
 			},
 		},
 		{
 			PreprocessedPart: &referenceframe.FrameSystemPart{
-				FrameConfig: referenceframe.NewLinkInFrame("cam1", spatialmath.NewPoseFromPoint(r3.Vector{0, 0, -100}), "cam2", nil),
+				Origin: referenceframe.NewLinkInFrame("cam1", spatialmath.NewPoseFromPoint(r3.Vector{0, 0, -100}), "cam2", nil),
 			},
 		},
 		{
 			PreprocessedPart: &referenceframe.FrameSystemPart{
-				FrameConfig: referenceframe.NewLinkInFrame(referenceframe.World, spatialmath.NewZeroPose(), "cam3", nil),
+				Origin: referenceframe.NewLinkInFrame(referenceframe.World, spatialmath.NewZeroPose(), "cam3", nil),
 			},
 		},
 		{
 			PreprocessedPart: &referenceframe.FrameSystemPart{
-				FrameConfig: referenceframe.NewLinkInFrame("cam3", spatialmath.NewPose(r3.Vector{-60, 0, -10}, o1), "cam4", nil),
+				Origin: referenceframe.NewLinkInFrame("cam3", spatialmath.NewPose(r3.Vector{-60, 0, -10}, o1), "cam4", nil),
 			},
 		},
 		{
 			PreprocessedPart: &referenceframe.FrameSystemPart{
-				FrameConfig: referenceframe.NewLinkInFrame("cam4", spatialmath.NewPose(r3.Vector{-60, 0, -10}, o2), "cam5", nil),
+				Origin: referenceframe.NewLinkInFrame("cam4", spatialmath.NewPose(r3.Vector{-60, 0, -10}, o2), "cam5", nil),
 			},
 		},
 	}

--- a/components/camera/videosource/join_pointcloud_test.go
+++ b/components/camera/videosource/join_pointcloud_test.go
@@ -69,22 +69,31 @@ func makeFakeRobot(t *testing.T) resource.Dependencies {
 	}
 	base1 := &inject.Base{}
 
-	fsParts := []*referenceframe.FrameSystemPart{
+	fsParts := []*framesystem.FrameSystemPartConfig{
 		{
-			FrameConfig: referenceframe.NewLinkInFrame(referenceframe.World, spatialmath.NewZeroPose(), "base1", nil),
+			PreprocessedPart: &referenceframe.FrameSystemPart{
+				FrameConfig: referenceframe.NewLinkInFrame(referenceframe.World, spatialmath.NewZeroPose(), "base1", nil),
+			},
 		},
 		{
-			FrameConfig: referenceframe.NewLinkInFrame(
-				referenceframe.World,
-				spatialmath.NewPoseFromPoint(r3.Vector{100, 0, 0}),
-				"cam1",
-				nil),
+			PreprocessedPart: &referenceframe.FrameSystemPart{
+				FrameConfig: referenceframe.NewLinkInFrame(
+					referenceframe.World,
+					spatialmath.NewPoseFromPoint(r3.Vector{X: 100}),
+					"cam1",
+					nil,
+				),
+			},
 		},
 		{
-			FrameConfig: referenceframe.NewLinkInFrame("cam1", spatialmath.NewPoseFromPoint(r3.Vector{0, 0, 100}), "cam2", nil),
+			PreprocessedPart: &referenceframe.FrameSystemPart{
+				FrameConfig: referenceframe.NewLinkInFrame("cam1", spatialmath.NewPoseFromPoint(r3.Vector{Z: 100}), "cam2", nil),
+			},
 		},
 		{
-			FrameConfig: referenceframe.NewLinkInFrame("cam2", spatialmath.NewPoseFromPoint(r3.Vector{0, 100, 0}), "cam3", nil),
+			PreprocessedPart: &referenceframe.FrameSystemPart{
+				FrameConfig: referenceframe.NewLinkInFrame("cam2", spatialmath.NewPoseFromPoint(r3.Vector{Y: 100}), "cam3", nil),
+			},
 		},
 	}
 	deps := make(resource.Dependencies)
@@ -94,7 +103,7 @@ func makeFakeRobot(t *testing.T) resource.Dependencies {
 	deps[base.Named("base1")] = base1
 	fsSvc, err := framesystem.New(context.Background(), resource.Dependencies{}, logger)
 	test.That(t, err, test.ShouldBeNil)
-	err = fsSvc.Reconfigure(context.Background(), deps, resource.Config{ConvertedAttributes: &framesystem.Config{Parts: fsParts}})
+	err = fsSvc.Reconfigure(context.Background(), deps, resource.Config{ConvertedAttributes: &framesystem.Config{PartConfigs: fsParts}})
 	test.That(t, err, test.ShouldBeNil)
 	deps[framesystem.InternalServiceName] = fsSvc
 	return deps
@@ -297,34 +306,36 @@ func makeFakeRobotICP(t *testing.T) resource.Dependencies {
 	o1 := &spatialmath.EulerAngles{Roll: 0, Pitch: 0.6, Yaw: 0}
 	o2 := &spatialmath.EulerAngles{Roll: 0, Pitch: 0.6, Yaw: -0.3}
 
-	fsParts := []*referenceframe.FrameSystemPart{
+	fsParts := []*framesystem.FrameSystemPartConfig{
 		{
-			FrameConfig: referenceframe.NewLinkInFrame(referenceframe.World, spatialmath.NewZeroPose(), "base1", nil),
+			PreprocessedPart: &referenceframe.FrameSystemPart{
+				FrameConfig: referenceframe.NewLinkInFrame(referenceframe.World, spatialmath.NewZeroPose(), "base1", nil),
+			},
 		},
 		{
-			FrameConfig: referenceframe.NewLinkInFrame(referenceframe.World, spatialmath.NewZeroPose(), "cam1", nil),
+			PreprocessedPart: &referenceframe.FrameSystemPart{
+				FrameConfig: referenceframe.NewLinkInFrame(referenceframe.World, spatialmath.NewZeroPose(), "cam1", nil),
+			},
 		},
 		{
-			FrameConfig: referenceframe.NewLinkInFrame("cam1", spatialmath.NewPoseFromPoint(r3.Vector{0, 0, -100}), "cam2", nil),
+			PreprocessedPart: &referenceframe.FrameSystemPart{
+				FrameConfig: referenceframe.NewLinkInFrame("cam1", spatialmath.NewPoseFromPoint(r3.Vector{0, 0, -100}), "cam2", nil),
+			},
 		},
 		{
-			FrameConfig: referenceframe.NewLinkInFrame(referenceframe.World, spatialmath.NewZeroPose(), "cam3", nil),
+			PreprocessedPart: &referenceframe.FrameSystemPart{
+				FrameConfig: referenceframe.NewLinkInFrame(referenceframe.World, spatialmath.NewZeroPose(), "cam3", nil),
+			},
 		},
 		{
-			FrameConfig: referenceframe.NewLinkInFrame(
-				"cam3",
-				spatialmath.NewPose(r3.Vector{-60, 0, -10}, o1),
-				"cam4",
-				nil,
-			),
+			PreprocessedPart: &referenceframe.FrameSystemPart{
+				FrameConfig: referenceframe.NewLinkInFrame("cam3", spatialmath.NewPose(r3.Vector{-60, 0, -10}, o1), "cam4", nil),
+			},
 		},
 		{
-			FrameConfig: referenceframe.NewLinkInFrame(
-				"cam4",
-				spatialmath.NewPose(r3.Vector{-60, 0, -10}, o2),
-				"cam5",
-				nil,
-			),
+			PreprocessedPart: &referenceframe.FrameSystemPart{
+				FrameConfig: referenceframe.NewLinkInFrame("cam4", spatialmath.NewPose(r3.Vector{-60, 0, -10}, o2), "cam5", nil),
+			},
 		},
 	}
 
@@ -337,7 +348,7 @@ func makeFakeRobotICP(t *testing.T) resource.Dependencies {
 	deps[base.Named("base1")] = base1
 	fsSvc, err := framesystem.New(context.Background(), resource.Dependencies{}, logger)
 	test.That(t, err, test.ShouldBeNil)
-	err = fsSvc.Reconfigure(context.Background(), deps, resource.Config{ConvertedAttributes: &framesystem.Config{Parts: fsParts}})
+	err = fsSvc.Reconfigure(context.Background(), deps, resource.Config{ConvertedAttributes: &framesystem.Config{PartConfigs: fsParts}})
 	test.That(t, err, test.ShouldBeNil)
 	deps[framesystem.InternalServiceName] = fsSvc
 	return deps

--- a/referenceframe/frame_json.go
+++ b/referenceframe/frame_json.go
@@ -2,6 +2,7 @@ package referenceframe
 
 import (
 	"github.com/golang/geo/r3"
+	"github.com/pkg/errors"
 
 	spatial "go.viam.com/rdk/spatialmath"
 	"go.viam.com/rdk/utils"
@@ -70,6 +71,12 @@ func NewLinkConfig(frame staticFrame) (*LinkConfig, error) {
 
 // ParseConfig converts a LinkConfig into a staticFrame.
 func (cfg *LinkConfig) ParseConfig() (*LinkInFrame, error) {
+	if cfg.ID == World {
+		return nil, errors.Errorf("cannot give frame system part the name %s", World)
+	}
+	if cfg.Parent == "" {
+		return nil, errors.Errorf("parent field in frame config for part %q is empty", cfg.ID)
+	}
 	pose, err := cfg.Pose()
 	if err != nil {
 		return nil, err
@@ -85,6 +92,18 @@ func (cfg *LinkConfig) ParseConfig() (*LinkInFrame, error) {
 		}
 	}
 	return NewLinkInFrame(cfg.Parent, pose, cfg.ID, geom), nil
+}
+
+// Rename makes a deep copy of the config with an ID corresponding to the given name
+func (cfg *LinkConfig) Rename(name string) *LinkConfig {
+	cfgCopy := &LinkConfig{
+		ID:          name,
+		Translation: cfg.Translation,
+		Orientation: cfg.Orientation,
+		Geometry:    cfg.Geometry,
+		Parent:      cfg.Parent,
+	}
+	return cfgCopy
 }
 
 // Pose will parse out the Pose of a LinkConfig and return it if it is valid.

--- a/referenceframe/frame_json.go
+++ b/referenceframe/frame_json.go
@@ -94,7 +94,7 @@ func (cfg *LinkConfig) ParseConfig() (*LinkInFrame, error) {
 	return NewLinkInFrame(cfg.Parent, pose, cfg.ID, geom), nil
 }
 
-// Rename makes a deep copy of the config with an ID corresponding to the given name
+// Rename makes a deep copy of the config with an ID corresponding to the given name.
 func (cfg *LinkConfig) Rename(name string) *LinkConfig {
 	cfgCopy := &LinkConfig{
 		ID:          name,

--- a/referenceframe/frame_json.go
+++ b/referenceframe/frame_json.go
@@ -94,8 +94,8 @@ func (cfg *LinkConfig) ParseConfig() (*LinkInFrame, error) {
 	return NewLinkInFrame(cfg.Parent, pose, cfg.ID, geom), nil
 }
 
-// Rename makes a deep copy of the config with an ID corresponding to the given name.
-func (cfg *LinkConfig) Rename(name string) *LinkConfig {
+// CopyWithNewName makes a deep copy of the config with an ID corresponding to the given name.
+func (cfg *LinkConfig) CopyWithNewName(name string) *LinkConfig {
 	cfgCopy := &LinkConfig{
 		ID:          name,
 		Translation: cfg.Translation,

--- a/referenceframe/frame_system.go
+++ b/referenceframe/frame_system.go
@@ -104,7 +104,7 @@ func NewFrameSystem(name string, parts []*FrameSystemPart, additionalTransforms 
 		return nil, err
 	}
 
-	// Build the frame sytem from the parts
+	// Build the frame system from the parts
 	fs := NewEmptyFrameSystem(name)
 	for _, part := range sortedParts {
 		// make the frames from the configs

--- a/referenceframe/frame_system_test.go
+++ b/referenceframe/frame_system_test.go
@@ -31,16 +31,16 @@ func TestFrameModelPart(t *testing.T) {
 
 	// minimally specified part
 	part := &FrameSystemPart{
-		FrameConfig: &LinkInFrame{PoseInFrame: &PoseInFrame{name: "test"}},
-		ModelFrame:  nil,
+		Origin:     &LinkInFrame{PoseInFrame: &PoseInFrame{name: "test"}},
+		ModelFrame: nil,
 	}
 	_, err = part.ToProtobuf()
 	test.That(t, err, test.ShouldBeNil)
 
 	// slightly specified part
 	part = &FrameSystemPart{
-		FrameConfig: &LinkInFrame{PoseInFrame: &PoseInFrame{name: "test", parent: "world"}},
-		ModelFrame:  nil,
+		Origin:     &LinkInFrame{PoseInFrame: &PoseInFrame{name: "test", parent: "world"}},
+		ModelFrame: nil,
 	}
 	result, err := part.ToProtobuf()
 	test.That(t, err, test.ShouldBeNil)
@@ -63,11 +63,11 @@ func TestFrameModelPart(t *testing.T) {
 	// return to FrameSystemPart
 	partAgain, err := ProtobufToFrameSystemPart(result)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, partAgain.FrameConfig.name, test.ShouldEqual, part.FrameConfig.name)
-	test.That(t, partAgain.FrameConfig.parent, test.ShouldEqual, part.FrameConfig.parent)
-	test.That(t, partAgain.FrameConfig.pose, test.ShouldResemble, spatial.NewZeroPose())
+	test.That(t, partAgain.Origin.name, test.ShouldEqual, part.Origin.name)
+	test.That(t, partAgain.Origin.parent, test.ShouldEqual, part.Origin.parent)
+	test.That(t, partAgain.Origin.pose, test.ShouldResemble, spatial.NewZeroPose())
 	// nil orientations become specified as zero orientations
-	test.That(t, partAgain.FrameConfig.pose.Orientation(), test.ShouldResemble, spatial.NewZeroOrientation())
+	test.That(t, partAgain.Origin.pose.Orientation(), test.ShouldResemble, spatial.NewZeroOrientation())
 	test.That(t, partAgain.ModelFrame, test.ShouldResemble, part.ModelFrame)
 
 	orientConf, err := spatial.NewOrientationConfig(spatial.NewZeroOrientation())
@@ -83,8 +83,8 @@ func TestFrameModelPart(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	// fully specified part
 	part = &FrameSystemPart{
-		FrameConfig: lif,
-		ModelFrame:  model,
+		Origin:     lif,
+		ModelFrame: model,
 	}
 	result, err = part.ToProtobuf()
 	test.That(t, err, test.ShouldBeNil)
@@ -104,9 +104,9 @@ func TestFrameModelPart(t *testing.T) {
 	// return to FrameSystemPart
 	partAgain, err = ProtobufToFrameSystemPart(result)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, partAgain.FrameConfig.name, test.ShouldEqual, part.FrameConfig.name)
-	test.That(t, partAgain.FrameConfig.parent, test.ShouldEqual, part.FrameConfig.parent)
-	test.That(t, partAgain.FrameConfig.pose, test.ShouldResemble, part.FrameConfig.pose)
+	test.That(t, partAgain.Origin.name, test.ShouldEqual, part.Origin.name)
+	test.That(t, partAgain.Origin.parent, test.ShouldEqual, part.Origin.parent)
+	test.That(t, partAgain.Origin.pose, test.ShouldResemble, part.Origin.pose)
 	test.That(t, partAgain.ModelFrame.Name, test.ShouldEqual, part.ModelFrame.Name)
 	test.That(t,
 		len(partAgain.ModelFrame.(*SimpleModel).OrdTransforms),
@@ -122,21 +122,21 @@ func TestFramesFromPart(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	// minimally specified part
 	part := &FrameSystemPart{
-		FrameConfig: &LinkInFrame{PoseInFrame: &PoseInFrame{name: "test"}},
-		ModelFrame:  nil,
+		Origin:     &LinkInFrame{PoseInFrame: &PoseInFrame{name: "test"}},
+		ModelFrame: nil,
 	}
 	_, _, err = createFramesFromPart(part)
 	test.That(t, err, test.ShouldBeNil)
 
 	// slightly specified part
 	part = &FrameSystemPart{
-		FrameConfig: &LinkInFrame{PoseInFrame: &PoseInFrame{name: "test", parent: "world"}},
-		ModelFrame:  nil,
+		Origin:     &LinkInFrame{PoseInFrame: &PoseInFrame{name: "test", parent: "world"}},
+		ModelFrame: nil,
 	}
 	modelFrame, originFrame, err := createFramesFromPart(part)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, modelFrame, test.ShouldResemble, NewZeroStaticFrame(part.FrameConfig.name))
-	originTailFrame, ok := NewZeroStaticFrame(part.FrameConfig.name + "_origin").(*staticFrame)
+	test.That(t, modelFrame, test.ShouldResemble, NewZeroStaticFrame(part.Origin.name))
+	originTailFrame, ok := NewZeroStaticFrame(part.Origin.name + "_origin").(*staticFrame)
 	test.That(t, ok, test.ShouldBeTrue)
 	test.That(t, originFrame, test.ShouldResemble, &tailGeometryStaticFrame{originTailFrame})
 	orientConf, err := spatial.NewOrientationConfig(spatial.NewZeroOrientation())
@@ -153,14 +153,14 @@ func TestFramesFromPart(t *testing.T) {
 
 	// fully specified part
 	part = &FrameSystemPart{
-		FrameConfig: lif,
-		ModelFrame:  model,
+		Origin:     lif,
+		ModelFrame: model,
 	}
 	modelFrame, originFrame, err = createFramesFromPart(part)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, modelFrame.Name(), test.ShouldEqual, part.FrameConfig.name)
+	test.That(t, modelFrame.Name(), test.ShouldEqual, part.Origin.name)
 	test.That(t, modelFrame.DoF(), test.ShouldResemble, part.ModelFrame.DoF())
-	test.That(t, originFrame.Name(), test.ShouldEqual, part.FrameConfig.name+"_origin")
+	test.That(t, originFrame.Name(), test.ShouldEqual, part.Origin.name+"_origin")
 	test.That(t, originFrame.DoF(), test.ShouldHaveLength, 0)
 
 	// Test geometries are not overwritten for non-zero DOF frames
@@ -174,8 +174,8 @@ func TestFramesFromPart(t *testing.T) {
 	lif, err = lc.ParseConfig()
 	test.That(t, err, test.ShouldBeNil)
 	part = &FrameSystemPart{
-		FrameConfig: lif,
-		ModelFrame:  model,
+		Origin:     lif,
+		ModelFrame: model,
 	}
 	modelFrame, originFrame, err = createFramesFromPart(part)
 	test.That(t, err, test.ShouldBeNil)
@@ -201,8 +201,8 @@ func TestFramesFromPart(t *testing.T) {
 	lif, err = lc.ParseConfig()
 	test.That(t, err, test.ShouldBeNil)
 	part = &FrameSystemPart{
-		FrameConfig: lif,
-		ModelFrame:  model,
+		Origin:     lif,
+		ModelFrame: model,
 	}
 	modelFrame, originFrame, err = createFramesFromPart(part)
 	test.That(t, err, test.ShouldBeNil)
@@ -231,10 +231,10 @@ func TestConvertTransformProtobufToFrameSystemPart(t *testing.T) {
 		transform := NewLinkInFrame("parent", testPose, "child", nil)
 		part, err := LinkInFrameToFrameSystemPart(transform)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, part.FrameConfig.name, test.ShouldEqual, transform.Name())
-		test.That(t, part.FrameConfig.parent, test.ShouldEqual, transform.Parent())
-		test.That(t, spatial.R3VectorAlmostEqual(part.FrameConfig.pose.Point(), testPose.Point(), 1e-8), test.ShouldBeTrue)
-		test.That(t, spatial.OrientationAlmostEqual(part.FrameConfig.pose.Orientation(), testPose.Orientation()), test.ShouldBeTrue)
+		test.That(t, part.Origin.name, test.ShouldEqual, transform.Name())
+		test.That(t, part.Origin.parent, test.ShouldEqual, transform.Parent())
+		test.That(t, spatial.R3VectorAlmostEqual(part.Origin.pose.Point(), testPose.Point(), 1e-8), test.ShouldBeTrue)
+		test.That(t, spatial.OrientationAlmostEqual(part.Origin.pose.Orientation(), testPose.Orientation()), test.ShouldBeTrue)
 	})
 }
 
@@ -422,8 +422,8 @@ func TestFrameSystemToPCD(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		// fully specified part
 		part := &FrameSystemPart{
-			FrameConfig: lif,
-			ModelFrame:  model,
+			Origin:     lif,
+			ModelFrame: model,
 		}
 		armFrame, _, err := createFramesFromPart(part)
 		test.That(t, err, test.ShouldBeNil)
@@ -452,8 +452,8 @@ func TestFrameSystemToPCD(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		// fully specified part
 		part := &FrameSystemPart{
-			FrameConfig: lif,
-			ModelFrame:  model,
+			Origin:     lif,
+			ModelFrame: model,
 		}
 		armFrame, _, err := createFramesFromPart(part)
 		test.That(t, err, test.ShouldBeNil)
@@ -503,8 +503,8 @@ func TestFrameSystemToPCD(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		// fully specified part
 		part := &FrameSystemPart{
-			FrameConfig: lif,
-			ModelFrame:  model,
+			Origin:     lif,
+			ModelFrame: model,
 		}
 		armFrame, _, err := createFramesFromPart(part)
 		test.That(t, err, test.ShouldBeNil)

--- a/referenceframe/frame_test.go
+++ b/referenceframe/frame_test.go
@@ -154,7 +154,7 @@ func TestSerializationStatic(t *testing.T) {
 	data, err := f.MarshalJSON()
 	test.That(t, err, test.ShouldBeNil)
 
-	f2Cfg := &LinkConfig{}
+	f2Cfg := &LinkConfig{Parent: "bar"}
 	err = json.Unmarshal(data, f2Cfg)
 	test.That(t, err, test.ShouldBeNil)
 

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -34,7 +34,6 @@ import (
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot"
-	"go.viam.com/rdk/robot/framesystem"
 	"go.viam.com/rdk/robot/packages"
 	"go.viam.com/rdk/session"
 	"go.viam.com/rdk/spatialmath"
@@ -804,15 +803,19 @@ func (rc *RobotClient) DiscoverComponents(ctx context.Context, qs []resource.Dis
 }
 
 // FrameSystemConfig returns the info of each individual part that makes up the frame system.
-func (rc *RobotClient) FrameSystemParts(ctx context.Context) ([]*framesystem.FrameSystemPartConfig, error) {
+func (rc *RobotClient) FrameSystemParts(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
 	resp, err := rc.client.FrameSystemConfig(ctx, &pb.FrameSystemConfigRequest{})
 	if err != nil {
 		return nil, err
 	}
 	cfgs := resp.GetFrameSystemConfigs()
-	result := make([]*framesystem.FrameSystemPartConfig, 0, len(cfgs))
+	result := make([]*referenceframe.FrameSystemPart, 0, len(cfgs))
 	for _, cfg := range cfgs {
-		result = append(result, &framesystem.FrameSystemPartConfig{Protobuf: cfg})
+		part, err := referenceframe.ProtobufToFrameSystemPart(cfg)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, part)
 	}
 	return result, nil
 }

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -804,21 +804,17 @@ func (rc *RobotClient) DiscoverComponents(ctx context.Context, qs []resource.Dis
 }
 
 // FrameSystemConfig returns the info of each individual part that makes up the frame system.
-func (rc *RobotClient) FrameSystemConfig(ctx context.Context) (*framesystem.Config, error) {
+func (rc *RobotClient) FrameSystemParts(ctx context.Context) ([]*framesystem.FrameSystemPartConfig, error) {
 	resp, err := rc.client.FrameSystemConfig(ctx, &pb.FrameSystemConfigRequest{})
 	if err != nil {
 		return nil, err
 	}
 	cfgs := resp.GetFrameSystemConfigs()
-	result := make([]*referenceframe.FrameSystemPart, 0, len(cfgs))
+	result := make([]*framesystem.FrameSystemPartConfig, 0, len(cfgs))
 	for _, cfg := range cfgs {
-		part, err := referenceframe.ProtobufToFrameSystemPart(cfg)
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, part)
+		result = append(result, &framesystem.FrameSystemPartConfig{Protobuf: cfg})
 	}
-	return &framesystem.Config{Parts: result}, nil
+	return result, nil
 }
 
 // TransformPose will transform the pose of the requested poseInFrame to the desired frame in the robot's frame system.

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -803,7 +803,7 @@ func (rc *RobotClient) DiscoverComponents(ctx context.Context, qs []resource.Dis
 }
 
 // FrameSystemConfig returns the info of each individual part that makes up the frame system.
-func (rc *RobotClient) FrameSystemParts(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
+func (rc *RobotClient) FrameSystemConfig(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
 	resp, err := rc.client.FrameSystemConfig(ctx, &pb.FrameSystemConfigRequest{})
 	if err != nil {
 		return nil, err

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -802,8 +802,8 @@ func (rc *RobotClient) DiscoverComponents(ctx context.Context, qs []resource.Dis
 	return discoveries, nil
 }
 
-// FrameSystemConfig returns the info of each individual part that makes up the frame system.
-func (rc *RobotClient) FrameSystemConfig(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
+// FrameSystemParts returns the info of each individual part that makes up the frame system.
+func (rc *RobotClient) FrameSystemParts(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
 	resp, err := rc.client.FrameSystemConfig(ctx, &pb.FrameSystemConfigRequest{})
 	if err != nil {
 		return nil, err

--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -1169,11 +1169,11 @@ func TestClientDiscovery(t *testing.T) {
 }
 
 func ensurePartsAreEqual(part, otherPart *referenceframe.FrameSystemPart) error {
-	if part.FrameConfig.Name() != otherPart.FrameConfig.Name() {
-		return errors.Errorf("part had name %s while other part had name %s", part.FrameConfig.Name(), otherPart.FrameConfig.Name())
+	if part.Origin.Name() != otherPart.Origin.Name() {
+		return errors.Errorf("part had name %s while other part had name %s", part.Origin.Name(), otherPart.Origin.Name())
 	}
-	frameConfig := part.FrameConfig
-	otherFrameConfig := otherPart.FrameConfig
+	frameConfig := part.Origin
+	otherFrameConfig := otherPart.Origin
 	if frameConfig.Parent() != otherFrameConfig.Parent() {
 		return errors.Errorf("part had parent %s while other part had parent %s", frameConfig.Parent(), otherFrameConfig.Parent())
 	}
@@ -1240,10 +1240,10 @@ func TestClientConfig(t *testing.T) {
 
 	fsParts := []*referenceframe.FrameSystemPart{
 		{
-			FrameConfig: lif1,
+			Origin: lif1,
 		},
 		{
-			FrameConfig: lif2,
+			Origin: lif2,
 		},
 	}
 

--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -119,20 +119,13 @@ func TestStatusClient(t *testing.T) {
 		}
 	}
 
-	// TODO(RSDK-882): will update this so that this is not necessary
-	FrameSystemPartsFunc := func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
-		return make([]*referenceframe.FrameSystemPart, 0), nil
-	}
-
 	injectRobot1 := &inject.Robot{
-		FrameSystemPartsFunc: FrameSystemPartsFunc,
-		ResourceNamesFunc:    resourcesFunc,
-		ResourceRPCAPIsFunc:  func() []resource.RPCAPI { return nil },
+		ResourceNamesFunc:   resourcesFunc,
+		ResourceRPCAPIsFunc: func() []resource.RPCAPI { return nil },
 	}
 	injectRobot2 := &inject.Robot{
-		FrameSystemPartsFunc: FrameSystemPartsFunc,
-		ResourceNamesFunc:    resourcesFunc,
-		ResourceRPCAPIsFunc:  func() []resource.RPCAPI { return nil },
+		ResourceNamesFunc:   resourcesFunc,
+		ResourceRPCAPIsFunc: func() []resource.RPCAPI { return nil },
 	}
 	pb.RegisterRobotServiceServer(gServer1, server.New(injectRobot1))
 	pb.RegisterRobotServiceServer(gServer2, server.New(injectRobot2))
@@ -665,11 +658,6 @@ func TestClientDisconnect(t *testing.T) {
 		return []resource.Name{arm.Named("arm1")}
 	}
 
-	// TODO(RSDK-882): will update this so that this is not necessary
-	injectRobot.FrameSystemPartsFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
-		return make([]*referenceframe.FrameSystemPart, 0), nil
-	}
-
 	go gServer.Serve(listener)
 
 	start := time.Now()
@@ -895,11 +883,6 @@ func TestClientReconnect(t *testing.T) {
 	thing1Name := resource.NewName(someAPI, "thing1")
 	injectRobot.ResourceNamesFunc = func() []resource.Name {
 		return []resource.Name{arm.Named("arm1"), thing1Name}
-	}
-
-	// TODO(RSDK-882): will update this so that this is not necessary
-	injectRobot.FrameSystemPartsFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
-		return make([]*referenceframe.FrameSystemPart, 0), nil
 	}
 
 	injectArm := &inject.Arm{}
@@ -1453,10 +1436,6 @@ func TestForeignResource(t *testing.T) {
 
 	injectRobot.ResourceRPCAPIsFunc = func() []resource.RPCAPI { return respWith }
 	injectRobot.ResourceNamesFunc = func() []resource.Name { return respWithResources }
-	// TODO(RSDK-882): will update this so that this is not necessary
-	injectRobot.FrameSystemPartsFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
-		return make([]*referenceframe.FrameSystemPart, 0), nil
-	}
 
 	gServer := grpc.NewServer()
 	pb.RegisterRobotServiceServer(gServer, server.New(injectRobot))
@@ -1587,10 +1566,6 @@ func TestRemoteClientMatch(t *testing.T) {
 		ResourceRPCAPIsFunc: func() []resource.RPCAPI { return nil },
 	}
 
-	// TODO(RSDK-882): will update this so that this is not necessary
-	injectRobot1.FrameSystemPartsFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
-		return make([]*referenceframe.FrameSystemPart, 0), nil
-	}
 	pb.RegisterRobotServiceServer(gServer1, server.New(injectRobot1))
 
 	injectArm := &inject.Arm{}
@@ -1722,11 +1697,6 @@ func TestGetUnknownResource(t *testing.T) {
 	injectRobot := &inject.Robot{
 		ResourceNamesFunc:   func() []resource.Name { return []resource.Name{arm.Named("myArm")} },
 		ResourceRPCAPIsFunc: func() []resource.RPCAPI { return nil },
-	}
-
-	// TODO(RSDK-882): will update this so that this is not necessary
-	injectRobot.FrameSystemPartsFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
-		return make([]*referenceframe.FrameSystemPart, 0), nil
 	}
 
 	gServer := grpc.NewServer()

--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -120,19 +120,19 @@ func TestStatusClient(t *testing.T) {
 	}
 
 	// TODO(RSDK-882): will update this so that this is not necessary
-	FrameSystemConfigFunc := func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
+	FrameSystemPartsFunc := func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
 		return make([]*referenceframe.FrameSystemPart, 0), nil
 	}
 
 	injectRobot1 := &inject.Robot{
-		FrameSystemConfigFunc: FrameSystemConfigFunc,
-		ResourceNamesFunc:     resourcesFunc,
-		ResourceRPCAPIsFunc:   func() []resource.RPCAPI { return nil },
+		FrameSystemPartsFunc: FrameSystemPartsFunc,
+		ResourceNamesFunc:    resourcesFunc,
+		ResourceRPCAPIsFunc:  func() []resource.RPCAPI { return nil },
 	}
 	injectRobot2 := &inject.Robot{
-		FrameSystemConfigFunc: FrameSystemConfigFunc,
-		ResourceNamesFunc:     resourcesFunc,
-		ResourceRPCAPIsFunc:   func() []resource.RPCAPI { return nil },
+		FrameSystemPartsFunc: FrameSystemPartsFunc,
+		ResourceNamesFunc:    resourcesFunc,
+		ResourceRPCAPIsFunc:  func() []resource.RPCAPI { return nil },
 	}
 	pb.RegisterRobotServiceServer(gServer1, server.New(injectRobot1))
 	pb.RegisterRobotServiceServer(gServer2, server.New(injectRobot2))
@@ -666,7 +666,7 @@ func TestClientDisconnect(t *testing.T) {
 	}
 
 	// TODO(RSDK-882): will update this so that this is not necessary
-	injectRobot.FrameSystemConfigFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
+	injectRobot.FrameSystemPartsFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
 		return make([]*referenceframe.FrameSystemPart, 0), nil
 	}
 
@@ -898,7 +898,7 @@ func TestClientReconnect(t *testing.T) {
 	}
 
 	// TODO(RSDK-882): will update this so that this is not necessary
-	injectRobot.FrameSystemConfigFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
+	injectRobot.FrameSystemPartsFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
 		return make([]*referenceframe.FrameSystemPart, 0), nil
 	}
 
@@ -1247,12 +1247,12 @@ func TestClientConfig(t *testing.T) {
 		},
 	}
 
-	workingRobot.FrameSystemConfigFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
+	workingRobot.FrameSystemPartsFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
 		return fsParts, nil
 	}
 
 	configErr := errors.New("failed to retrieve config")
-	failingRobot.FrameSystemConfigFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
+	failingRobot.FrameSystemPartsFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
 		return nil, configErr
 	}
 
@@ -1276,7 +1276,7 @@ func TestClientConfig(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Run("client test config for working frame service", func(t *testing.T) {
-		parts, err := workingFSClient.FrameSystemConfig(ctx)
+		parts, err := workingFSClient.FrameSystemParts(ctx)
 		test.That(t, err, test.ShouldBeNil)
 		err = ensurePartsAreEqual(fsParts[0], parts[0])
 		test.That(t, err, test.ShouldBeNil)
@@ -1290,7 +1290,7 @@ func TestClientConfig(t *testing.T) {
 	t.Run("dialed client test config for working frame service", func(t *testing.T) {
 		workingDialedClient, err := New(ctx, listener1.Addr().String(), logger)
 		test.That(t, err, test.ShouldBeNil)
-		parts, err := workingDialedClient.FrameSystemConfig(ctx)
+		parts, err := workingDialedClient.FrameSystemParts(ctx)
 		test.That(t, err, test.ShouldBeNil)
 		err = ensurePartsAreEqual(fsParts[0], parts[0])
 		test.That(t, err, test.ShouldBeNil)
@@ -1307,8 +1307,8 @@ func TestClientConfig(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Run("client test config for failing frame service", func(t *testing.T) {
-		FrameSystemConfig, err := failingFSClient.FrameSystemConfig(ctx)
-		test.That(t, FrameSystemConfig, test.ShouldBeNil)
+		FrameSystemParts, err := failingFSClient.FrameSystemParts(ctx)
+		test.That(t, FrameSystemParts, test.ShouldBeNil)
 		test.That(t, err, test.ShouldNotBeNil)
 	})
 
@@ -1318,7 +1318,7 @@ func TestClientConfig(t *testing.T) {
 	t.Run("dialed client test config for failing frame service with failing config", func(t *testing.T) {
 		failingDialedClient, err := New(ctx, listener2.Addr().String(), logger)
 		test.That(t, err, test.ShouldBeNil)
-		parts, err := failingDialedClient.FrameSystemConfig(ctx)
+		parts, err := failingDialedClient.FrameSystemParts(ctx)
 		test.That(t, parts, test.ShouldBeNil)
 		test.That(t, err, test.ShouldNotBeNil)
 
@@ -1454,7 +1454,7 @@ func TestForeignResource(t *testing.T) {
 	injectRobot.ResourceRPCAPIsFunc = func() []resource.RPCAPI { return respWith }
 	injectRobot.ResourceNamesFunc = func() []resource.Name { return respWithResources }
 	// TODO(RSDK-882): will update this so that this is not necessary
-	injectRobot.FrameSystemConfigFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
+	injectRobot.FrameSystemPartsFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
 		return make([]*referenceframe.FrameSystemPart, 0), nil
 	}
 
@@ -1588,7 +1588,7 @@ func TestRemoteClientMatch(t *testing.T) {
 	}
 
 	// TODO(RSDK-882): will update this so that this is not necessary
-	injectRobot1.FrameSystemConfigFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
+	injectRobot1.FrameSystemPartsFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
 		return make([]*referenceframe.FrameSystemPart, 0), nil
 	}
 	pb.RegisterRobotServiceServer(gServer1, server.New(injectRobot1))
@@ -1725,7 +1725,7 @@ func TestGetUnknownResource(t *testing.T) {
 	}
 
 	// TODO(RSDK-882): will update this so that this is not necessary
-	injectRobot.FrameSystemConfigFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
+	injectRobot.FrameSystemPartsFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
 		return make([]*referenceframe.FrameSystemPart, 0), nil
 	}
 

--- a/robot/framesystem/framesystem.go
+++ b/robot/framesystem/framesystem.go
@@ -79,7 +79,7 @@ type Config struct {
 }
 
 // PartConfig is the structure that encodes all the information needed for a frame system part.
-// Only one of the two fields between FrameConfig and PreprossedPart should be non-nil as they each provide the same
+// Only one of the two fields between FrameConfig and PreprocessedPart should be non-nil as they each provide the same
 // information in different formats.
 type PartConfig struct {
 	Name        string

--- a/robot/framesystem/framesystem.go
+++ b/robot/framesystem/framesystem.go
@@ -131,7 +131,6 @@ func (svc *frameSystemService) Reconfigure(ctx context.Context, deps resource.De
 	components := make(map[string]resource.Resource)
 	for name, r := range deps {
 		short := name.ShortName()
-		// is this only for InputEnabled components or everything?
 		if _, present := components[short]; present {
 			return DuplicateResourceShortNameError(short)
 		}

--- a/robot/framesystem/framesystem.go
+++ b/robot/framesystem/framesystem.go
@@ -84,7 +84,7 @@ type FrameSystemPartConfig struct {
 
 	// Preprocessed is a field that if filled means that no further processing of the config is necessary
 	// This is efficient because parts that are returned from remotes should not have to be turned into configs only
-	// to be converted back into FrameSystemParts once in the framesystem service
+	// to be converted back into FrameSystemConfig once in the framesystem service
 	PreprocessedPart *referenceframe.FrameSystemPart
 }
 
@@ -316,7 +316,7 @@ func (svc *frameSystemService) TransformPointCloud(ctx context.Context, srcpc po
 	return pointcloud.ApplyOffset(ctx, srcpc, theTransform.Pose(), svc.logger)
 }
 
-// PrefixRemoteParts applies prefixes to a list of FrameSystemParts appropriate to the remote they originate from.
+// PrefixRemoteParts applies prefixes to a list of FrameSystemConfig appropriate to the remote they originate from.
 func ProcessRemoteFrameSystem(parts []*referenceframe.FrameSystemPart, remoteName, remoteParent string) []*FrameSystemPartConfig {
 	partConfigs := make([]*FrameSystemPartConfig, 0, len(parts))
 	for _, part := range parts {

--- a/robot/framesystem/framesystem.go
+++ b/robot/framesystem/framesystem.go
@@ -87,7 +87,7 @@ type PartConfig struct {
 
 	// PreprocessedPart is a field that if filled means that no further processing of the config is necessary
 	// This is efficient because parts that are returned from remotes should not have to be turned into configs only
-	// to be converted back into FrameSystemConfig once in the framesystem service
+	// to be converted back into FrameSystemParts once in the framesystem service
 	PreprocessedPart *referenceframe.FrameSystemPart
 }
 
@@ -317,7 +317,7 @@ func (svc *frameSystemService) TransformPointCloud(ctx context.Context, srcpc po
 	return pointcloud.ApplyOffset(ctx, srcpc, theTransform.Pose(), svc.logger)
 }
 
-// PrefixRemoteParts applies prefixes to a list of FrameSystemConfig appropriate to the remote they originate from.
+// PrefixRemoteParts applies prefixes to a list of FrameSystemParts appropriate to the remote they originate from.
 func PrefixRemoteParts(parts []*referenceframe.FrameSystemPart, remoteName, remoteParent string) []*PartConfig {
 	partConfigs := make([]*PartConfig, 0, len(parts))
 	for _, part := range parts {

--- a/robot/framesystem/framesystem.go
+++ b/robot/framesystem/framesystem.go
@@ -113,7 +113,7 @@ func (svc *frameSystemService) ConfigToParts(cfg *Config) (parts []*referencefra
 		} else { // part is local to the robot and needs to be parsed
 			frame := component.Origin
 			if frame.ID == "" {
-				frame = frame.Rename(component.Name)
+				frame = frame.CopyWithNewName(component.Name)
 			}
 			link, err := frame.ParseConfig()
 			if err != nil {

--- a/robot/framesystem/framesystem_test.go
+++ b/robot/framesystem/framesystem_test.go
@@ -222,9 +222,9 @@ func TestNewFrameSystemFromBadConfig(t *testing.T) {
 		num  string
 		err  error
 	}{
-		{"no world node", "2", referenceframe.ErrNoWorldConnection},
+		// {"no world node", "2", referenceframe.ErrNoWorldConnection},
 		{"frame named world", "3", errors.Errorf("cannot give frame system part the name %s", referenceframe.World)},
-		{"parent field empty", "4", errors.New("parent field in frame config for part \"cameraOver\" is empty")},
+		// {"parent field empty", "4", errors.New("parent field in frame config for part \"cameraOver\" is empty")},
 	}
 
 	for _, tc := range testCases {

--- a/robot/framesystem/framesystem_test.go
+++ b/robot/framesystem/framesystem_test.go
@@ -28,7 +28,7 @@ func TestEmptyConfigFrameService(t *testing.T) {
 	ctx := context.Background()
 	r, err := robotimpl.New(ctx, &config.Config{}, logger)
 	test.That(t, err, test.ShouldBeNil)
-	parts, err := r.FrameSystemConfig(ctx)
+	parts, err := r.FrameSystemParts(ctx)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, parts, test.ShouldHaveLength, 0)
 	fs, err := referenceframe.NewFrameSystem("test", parts, nil)
@@ -103,7 +103,7 @@ func TestNewFrameSystemFromConfigWithTransforms(t *testing.T) {
 	r, err := robotimpl.New(context.Background(), cfg, logger)
 	test.That(t, err, test.ShouldBeNil)
 	defer r.Close(context.Background())
-	parts, err := r.FrameSystemConfig(ctx)
+	parts, err := r.FrameSystemParts(ctx)
 	test.That(t, err, test.ShouldBeNil)
 
 	// use fake registrations to have a FrameSystem return
@@ -234,7 +234,7 @@ func TestNewFrameSystemFromBadConfig(t *testing.T) {
 			r, err := robotimpl.New(ctx, cfg, logger)
 			test.That(t, err, test.ShouldBeNil)
 			defer r.Close(ctx)
-			parts, err := r.FrameSystemConfig(ctx)
+			parts, err := r.FrameSystemParts(ctx)
 			if err != nil {
 				test.That(t, err, test.ShouldBeError, tc.err)
 				return
@@ -257,7 +257,7 @@ func TestNewFrameSystemFromBadConfig(t *testing.T) {
 			referenceframe.NewLinkInFrame("pieceArm", testPose, "frame1", nil),
 			referenceframe.NewLinkInFrame("noParent", testPose, "frame2", nil),
 		}
-		parts, err := r.FrameSystemConfig(ctx)
+		parts, err := r.FrameSystemParts(ctx)
 		test.That(t, err, test.ShouldBeNil)
 		fs, err := referenceframe.NewFrameSystem("", parts, transforms)
 		test.That(t, err, test.ShouldBeError, referenceframe.NewParentFrameMissingError("frame2", "noParent"))
@@ -268,7 +268,7 @@ func TestNewFrameSystemFromBadConfig(t *testing.T) {
 		transforms := []*referenceframe.LinkInFrame{
 			referenceframe.NewLinkInFrame("pieceArm", testPose, "", nil),
 		}
-		parts, err := r.FrameSystemConfig(ctx)
+		parts, err := r.FrameSystemParts(ctx)
 		test.That(t, err, test.ShouldBeNil)
 		fs, err := referenceframe.NewFrameSystem("", parts, transforms)
 		test.That(t, err, test.ShouldBeError, referenceframe.ErrEmptyStringFrameName)
@@ -362,14 +362,14 @@ func TestServiceWithRemote(t *testing.T) {
 
 	r2, err := robotimpl.New(context.Background(), localConfig, logger)
 	test.That(t, err, test.ShouldBeNil)
-	parts, err := r2.FrameSystemConfig(context.Background())
+	parts, err := r2.FrameSystemParts(context.Background())
 	test.That(t, err, test.ShouldBeNil)
 	fs, err := referenceframe.NewFrameSystem("test", parts, transforms)
 
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, fs.FrameNames(), test.ShouldHaveLength, 34)
 	// run the frame system service
-	allParts, err := r2.FrameSystemConfig(context.Background())
+	allParts, err := r2.FrameSystemParts(context.Background())
 	test.That(t, err, test.ShouldBeNil)
 	t.Logf("frame system:\n%v", allParts)
 	test.That(t, r2.Close(context.Background()), test.ShouldBeNil)

--- a/robot/framesystem/framesystem_test.go
+++ b/robot/framesystem/framesystem_test.go
@@ -10,12 +10,16 @@ import (
 	"github.com/pkg/errors"
 	"go.viam.com/test"
 
+	"go.viam.com/rdk/components/base"
+	"go.viam.com/rdk/components/gripper"
 	_ "go.viam.com/rdk/components/register"
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/referenceframe"
+	"go.viam.com/rdk/resource"
 	robotimpl "go.viam.com/rdk/robot/impl"
 	_ "go.viam.com/rdk/services/register"
 	"go.viam.com/rdk/spatialmath"
+	"go.viam.com/rdk/testutils/robottestutils"
 	rdkutils "go.viam.com/rdk/utils"
 )
 
@@ -270,4 +274,96 @@ func TestNewFrameSystemFromBadConfig(t *testing.T) {
 		test.That(t, err, test.ShouldBeError, referenceframe.ErrEmptyStringFrameName)
 		test.That(t, fs, test.ShouldBeNil)
 	})
+}
+
+func TestFrameSystemRemoteReconfiguration(t *testing.T) {
+	logger := golog.NewTestLogger(t)
+	// make the remote robots
+	remoteConfig1, err := config.Read(context.Background(), rdkutils.ResolveFile("robot/impl/data/fake.json"), logger)
+	test.That(t, err, test.ShouldBeNil)
+	ctx := context.Background()
+	remoteRobot, err := robotimpl.New(ctx, remoteConfig1, logger)
+	test.That(t, err, test.ShouldBeNil)
+	defer func() {
+		test.That(t, remoteRobot.Close(context.Background()), test.ShouldBeNil)
+	}()
+
+	options, _, addr := robottestutils.CreateBaseOptionsAndListener(t)
+	err = remoteRobot.StartWeb(ctx, options)
+	test.That(t, err, test.ShouldBeNil)
+
+	oCfg, err := spatialmath.NewOrientationConfig(&spatialmath.R4AA{math.Pi / 2., 0, 0, 1})
+	test.That(t, err, test.ShouldBeNil)
+
+	// make the local robot
+	localConfig := &config.Config{
+		Components: []resource.Config{
+			{
+				Name:  "foo",
+				API:   base.API,
+				Model: resource.DefaultModelFamily.WithModel("fake"),
+				Frame: &referenceframe.LinkConfig{
+					Parent: referenceframe.World,
+				},
+			},
+			{
+				Name:  "myParentIsRemote",
+				API:   gripper.API,
+				Model: resource.DefaultModelFamily.WithModel("fake"),
+				Frame: &referenceframe.LinkConfig{
+					Parent: "bar:pieceArm",
+				},
+			},
+		},
+		Remotes: []config.Remote{
+			{
+				Name:    "bar",
+				Address: addr,
+				Frame: &referenceframe.LinkConfig{
+					Parent:      "foo",
+					Translation: r3.Vector{100, 200, 300},
+					Orientation: oCfg,
+				},
+			},
+			{
+				Name:    "squee",
+				Address: addr,
+				Frame: &referenceframe.LinkConfig{
+					Parent:      referenceframe.World,
+					Translation: r3.Vector{500, 600, 700},
+					Orientation: oCfg,
+				},
+			},
+			{
+				Name:    "dontAddMe", // no frame info, should be skipped
+				Address: addr,
+			},
+		},
+	}
+
+	// make local robot
+	testPose := spatialmath.NewPose(
+		r3.Vector{X: 1., Y: 2., Z: 3.},
+		&spatialmath.R4AA{Theta: math.Pi / 2, RX: 0., RY: 1., RZ: 0.},
+	)
+
+	transforms := []*referenceframe.LinkInFrame{
+		referenceframe.NewLinkInFrame("bar:pieceArm", testPose, "frame1", nil),
+		referenceframe.NewLinkInFrame("bar:pieceGripper", testPose, "frame2", nil),
+		referenceframe.NewLinkInFrame("frame2", testPose, "frame2a", nil),
+		referenceframe.NewLinkInFrame("frame2", testPose, "frame2c", nil),
+		referenceframe.NewLinkInFrame(referenceframe.World, testPose, "frame3", nil),
+	}
+
+	r2, err := robotimpl.New(context.Background(), localConfig, logger)
+	test.That(t, err, test.ShouldBeNil)
+	defer func() {
+		test.That(t, r2.Close(context.Background()), test.ShouldBeNil)
+	}()
+
+	parts, err := r2.FrameSystemParts(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+	fs, err := referenceframe.NewFrameSystem("test", parts, transforms)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, fs.FrameNames(), test.ShouldHaveLength, 34)
 }

--- a/robot/framesystem/framesystem_test.go
+++ b/robot/framesystem/framesystem_test.go
@@ -61,10 +61,10 @@ func TestNewFrameSystemFromConfig(t *testing.T) {
 
 	parts := []*referenceframe.FrameSystemPart{
 		{
-			FrameConfig: lif1,
+			Origin: lif1,
 		},
 		{
-			FrameConfig: lif2,
+			Origin: lif2,
 		},
 	}
 	frameSys, err := referenceframe.NewFrameSystem("test", parts, []*referenceframe.LinkInFrame{})

--- a/robot/framesystem/framesystem_test.go
+++ b/robot/framesystem/framesystem_test.go
@@ -10,16 +10,12 @@ import (
 	"github.com/pkg/errors"
 	"go.viam.com/test"
 
-	"go.viam.com/rdk/components/base"
-	"go.viam.com/rdk/components/gripper"
 	_ "go.viam.com/rdk/components/register"
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/referenceframe"
-	"go.viam.com/rdk/resource"
 	robotimpl "go.viam.com/rdk/robot/impl"
 	_ "go.viam.com/rdk/services/register"
 	"go.viam.com/rdk/spatialmath"
-	"go.viam.com/rdk/testutils/robottestutils"
 	rdkutils "go.viam.com/rdk/utils"
 )
 
@@ -274,103 +270,4 @@ func TestNewFrameSystemFromBadConfig(t *testing.T) {
 		test.That(t, err, test.ShouldBeError, referenceframe.ErrEmptyStringFrameName)
 		test.That(t, fs, test.ShouldBeNil)
 	})
-}
-
-func TestServiceWithRemote(t *testing.T) {
-	logger := golog.NewTestLogger(t)
-	// make the remote robots
-	remoteConfig, err := config.Read(context.Background(), rdkutils.ResolveFile("robot/impl/data/fake.json"), logger)
-	test.That(t, err, test.ShouldBeNil)
-	ctx := context.Background()
-	remoteRobot, err := robotimpl.New(ctx, remoteConfig, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, remoteRobot.Close(context.Background()), test.ShouldBeNil)
-	}()
-
-	options, _, addr := robottestutils.CreateBaseOptionsAndListener(t)
-	err = remoteRobot.StartWeb(ctx, options)
-	test.That(t, err, test.ShouldBeNil)
-
-	o1 := &spatialmath.R4AA{math.Pi / 2., 0, 0, 1}
-	o1Cfg, err := spatialmath.NewOrientationConfig(o1)
-	test.That(t, err, test.ShouldBeNil)
-
-	o2 := &spatialmath.R4AA{math.Pi / 2., 1, 0, 0}
-	o2Cfg, err := spatialmath.NewOrientationConfig(o2)
-	test.That(t, err, test.ShouldBeNil)
-
-	// make the local robot
-	localConfig := &config.Config{
-		Components: []resource.Config{
-			{
-				Name:  "foo",
-				API:   base.API,
-				Model: resource.DefaultModelFamily.WithModel("fake"),
-				Frame: &referenceframe.LinkConfig{
-					Parent: referenceframe.World,
-				},
-			},
-			{
-				Name:  "myParentIsRemote",
-				API:   gripper.API,
-				Model: resource.DefaultModelFamily.WithModel("fake"),
-				Frame: &referenceframe.LinkConfig{
-					Parent: "bar:pieceArm",
-				},
-			},
-		},
-		Remotes: []config.Remote{
-			{
-				Name:    "bar",
-				Address: addr,
-				Frame: &referenceframe.LinkConfig{
-					Parent:      "foo",
-					Translation: r3.Vector{100, 200, 300},
-					Orientation: o1Cfg,
-				},
-			},
-			{
-				Name:    "squee",
-				Address: addr,
-				Frame: &referenceframe.LinkConfig{
-					Parent:      referenceframe.World,
-					Translation: r3.Vector{500, 600, 700},
-					Orientation: o2Cfg,
-				},
-			},
-			{
-				Name:    "dontAddMe", // no frame info, should be skipped
-				Address: addr,
-			},
-		},
-	}
-
-	// make local robot
-	testPose := spatialmath.NewPose(
-		r3.Vector{X: 1., Y: 2., Z: 3.},
-		&spatialmath.R4AA{Theta: math.Pi / 2, RX: 0., RY: 1., RZ: 0.},
-	)
-
-	transforms := []*referenceframe.LinkInFrame{
-		referenceframe.NewLinkInFrame("bar:pieceArm", testPose, "frame1", nil),
-		referenceframe.NewLinkInFrame("bar:pieceGripper", testPose, "frame2", nil),
-		referenceframe.NewLinkInFrame("frame2", testPose, "frame2a", nil),
-		referenceframe.NewLinkInFrame("frame2", testPose, "frame2c", nil),
-		referenceframe.NewLinkInFrame(referenceframe.World, testPose, "frame3", nil),
-	}
-
-	r2, err := robotimpl.New(context.Background(), localConfig, logger)
-	test.That(t, err, test.ShouldBeNil)
-	parts, err := r2.FrameSystemParts(context.Background())
-	test.That(t, err, test.ShouldBeNil)
-	fs, err := referenceframe.NewFrameSystem("test", parts, transforms)
-
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, fs.FrameNames(), test.ShouldHaveLength, 34)
-	// run the frame system service
-	allParts, err := r2.FrameSystemParts(context.Background())
-	test.That(t, err, test.ShouldBeNil)
-	t.Logf("frame system:\n%v", allParts)
-	test.That(t, r2.Close(context.Background()), test.ShouldBeNil)
 }

--- a/robot/impl/data/fake_wrongconfig4.json
+++ b/robot/impl/data/fake_wrongconfig4.json
@@ -11,7 +11,7 @@
         {
             "name": "cameraOver",
             "type": "camera",
-            "model": "fake",
+            "model": "image_file",
             "attributes": {
                 "color": "artifact_data/vision/chess/board3.png",
                 "depth": "artifact_data/vision/chess/board3.dat.gz",

--- a/robot/impl/data/fake_wrongconfig4.json
+++ b/robot/impl/data/fake_wrongconfig4.json
@@ -11,7 +11,7 @@
         {
             "name": "cameraOver",
             "type": "camera",
-            "model": "file",
+            "model": "fake",
             "attributes": {
                 "color": "artifact_data/vision/chess/board3.png",
                 "depth": "artifact_data/vision/chess/board3.dat.gz",

--- a/robot/impl/data/remote_fake.json
+++ b/robot/impl/data/remote_fake.json
@@ -5,13 +5,13 @@
             "type": "gripper",
             "model": "fake",
             "frame": {
-                "parent": ""
+                "parent": "pieceArm"
             }
         },
         {
             "name": "cameraOver",
             "type": "camera",
-            "model": "file",
+            "model": "image_file",
             "attributes": {
                 "color": "artifact_data/vision/chess/board3.png",
                 "depth": "artifact_data/vision/chess/board3.dat.gz",
@@ -22,8 +22,8 @@
             "model": "fake",
             "name": "pieceArm",
             "type": "arm",
-            "attributes": {
-                "model-path": "../../components/arm/fake/fake_model.json"
+            "frame": {
+                "parent": "world"
             }
         }
     ],
@@ -36,7 +36,7 @@
         {
             "name": "data_manager1",
             "type": "data_manager",
-            "model": "fake"
+            "model": "builtin"
         }
     ]
 }

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -774,7 +774,7 @@ func (r *localRobot) updateWeakDependents(ctx context.Context) {
 	}
 }
 
-// config returns the info of each individual part that makes up the frame system
+// FrameSystemParts returns the info of each individual part that makes up the frame system
 // The output of this function is to be sent over GRPC to the client, so the client
 // can build its frame system. requests the remote components from the remote's frame system service.
 func (r *localRobot) FrameSystemParts(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -828,12 +828,11 @@ func (r *localRobot) getRemoteFrameSystemParts(ctx context.Context) ([]*framesys
 		if !ok {
 			return nil, errors.Errorf("cannot find remote robot %q", remoteCfg.Name)
 		}
-		remoteFsCfg, err := remote.FrameSystemParts(ctx)
+		remoteFSParts, err := remote.FrameSystemParts(ctx)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error from remote %q", remoteCfg.Name)
 		}
-		framesystem.PrefixRemoteParts(remoteFsCfg.Parts, remoteCfg.Name, parentName)
-		remoteParts = append(remoteParts, remoteFsCfg.Parts...)
+		remoteParts = append(remoteParts, framesystem.ProcessRemoteFrameSystem(remoteFSParts, remoteCfg.Name, parentName)...)
 	}
 	return remoteParts, nil
 }

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -813,7 +813,7 @@ func (r *localRobot) getRemoteFrameSystemConfig(ctx context.Context) ([]*framesy
 			continue
 		}
 		parentName := remoteCfg.Name + "_" + referenceframe.World
-		preprocessed, err := remoteCfg.Frame.Rename(parentName).ParseConfig()
+		preprocessed, err := remoteCfg.Frame.CopyWithNewName(parentName).ParseConfig()
 		if err != nil {
 			return nil, err
 		}

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -798,7 +798,7 @@ func (r *localRobot) getLocalFrameSystemConfig() []*framesystem.PartConfig {
 		if component.Frame == nil { // no Frame means dont include in frame system.
 			continue
 		}
-		parts = append(parts, &framesystem.PartConfig{Name: component.Name, FrameConfig: component.Frame})
+		parts = append(parts, &framesystem.PartConfig{Name: component.Name, Origin: component.Frame})
 	}
 	return parts
 }
@@ -818,7 +818,7 @@ func (r *localRobot) getRemoteFrameSystemConfig(ctx context.Context) ([]*framesy
 			return nil, err
 		}
 		remoteParts = append(remoteParts, &framesystem.PartConfig{
-			PreprocessedPart: &referenceframe.FrameSystemPart{FrameConfig: preprocessed},
+			PreprocessedPart: &referenceframe.FrameSystemPart{Origin: preprocessed},
 		})
 
 		// get the parts from the remote itself

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
-
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	armpb "go.viam.com/api/component/arm/v1"

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -300,7 +300,7 @@ func TestConfigRemote(t *testing.T) {
 	// Components should only include local components.
 	test.That(t, len(cfg2.Components), test.ShouldEqual, 2)
 
-	fsParts, err := r2.FrameSystemConfig(context.Background())
+	fsParts, err := r2.FrameSystemParts(context.Background())
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, fsParts, test.ShouldHaveLength, 12)
 
@@ -1237,9 +1237,9 @@ func TestStatusRemote(t *testing.T) {
 	}
 
 	injectRobot1 := &inject.Robot{
-		FrameSystemConfigFunc: frameSystemConfigFunc,
-		ResourceNamesFunc:     resourcesFunc,
-		ResourceRPCAPIsFunc:   func() []resource.RPCAPI { return nil },
+		FrameSystemPartsFunc: frameSystemConfigFunc,
+		ResourceNamesFunc:    resourcesFunc,
+		ResourceRPCAPIsFunc:  func() []resource.RPCAPI { return nil },
 	}
 	armStatus := &armpb.Status{
 		EndPosition:    &commonpb.Pose{},
@@ -1254,9 +1254,9 @@ func TestStatusRemote(t *testing.T) {
 		return statuses, nil
 	}
 	injectRobot2 := &inject.Robot{
-		FrameSystemConfigFunc: frameSystemConfigFunc,
-		ResourceNamesFunc:     resourcesFunc,
-		ResourceRPCAPIsFunc:   func() []resource.RPCAPI { return nil },
+		FrameSystemPartsFunc: frameSystemConfigFunc,
+		ResourceNamesFunc:    resourcesFunc,
+		ResourceRPCAPIsFunc:  func() []resource.RPCAPI { return nil },
 	}
 	injectRobot2.StatusFunc = func(ctx context.Context, resourceNames []resource.Name) ([]robot.Status, error) {
 		statusCallCount++

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -1222,24 +1222,9 @@ func TestStatusRemote(t *testing.T) {
 	resourcesFunc := func() []resource.Name { return []resource.Name{arm.Named("arm1"), arm.Named("arm2")} }
 	statusCallCount := 0
 
-	// TODO: RSDK-882 will update this so that this is not necessary
-	frameSystemConfigFunc := func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
-		return []*referenceframe.FrameSystemPart{
-			{
-				Origin:     referenceframe.NewLinkInFrame(referenceframe.World, nil, "arm1", nil),
-				ModelFrame: referenceframe.NewSimpleModel("arm1"),
-			},
-			{
-				Origin:     referenceframe.NewLinkInFrame(referenceframe.World, nil, "arm2", nil),
-				ModelFrame: referenceframe.NewSimpleModel("arm2"),
-			},
-		}, nil
-	}
-
 	injectRobot1 := &inject.Robot{
-		FrameSystemPartsFunc: frameSystemConfigFunc,
-		ResourceNamesFunc:    resourcesFunc,
-		ResourceRPCAPIsFunc:  func() []resource.RPCAPI { return nil },
+		ResourceNamesFunc:   resourcesFunc,
+		ResourceRPCAPIsFunc: func() []resource.RPCAPI { return nil },
 	}
 	armStatus := &armpb.Status{
 		EndPosition:    &commonpb.Pose{},
@@ -1254,9 +1239,8 @@ func TestStatusRemote(t *testing.T) {
 		return statuses, nil
 	}
 	injectRobot2 := &inject.Robot{
-		FrameSystemPartsFunc: frameSystemConfigFunc,
-		ResourceNamesFunc:    resourcesFunc,
-		ResourceRPCAPIsFunc:  func() []resource.RPCAPI { return nil },
+		ResourceNamesFunc:   resourcesFunc,
+		ResourceRPCAPIsFunc: func() []resource.RPCAPI { return nil },
 	}
 	injectRobot2.StatusFunc = func(ctx context.Context, resourceNames []resource.Name) ([]robot.Status, error) {
 		statusCallCount++

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
+
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	armpb "go.viam.com/api/component/arm/v1"
@@ -299,9 +300,9 @@ func TestConfigRemote(t *testing.T) {
 	// Components should only include local components.
 	test.That(t, len(cfg2.Components), test.ShouldEqual, 2)
 
-	fsConfig, err := r2.FrameSystemConfig(context.Background())
+	fsParts, err := r2.FrameSystemConfig(context.Background())
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, fsConfig.Parts, test.ShouldHaveLength, 12)
+	test.That(t, fsParts, test.ShouldHaveLength, 12)
 
 	test.That(t, r2.Close(context.Background()), test.ShouldBeNil)
 }
@@ -1222,8 +1223,8 @@ func TestStatusRemote(t *testing.T) {
 	statusCallCount := 0
 
 	// TODO: RSDK-882 will update this so that this is not necessary
-	frameSystemConfigFunc := func(ctx context.Context) (*framesystem.Config, error) {
-		return &framesystem.Config{Parts: []*referenceframe.FrameSystemPart{
+	frameSystemConfigFunc := func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
+		return []*referenceframe.FrameSystemPart{
 			{
 				FrameConfig: referenceframe.NewLinkInFrame(referenceframe.World, nil, "arm1", nil),
 				ModelFrame:  referenceframe.NewSimpleModel("arm1"),
@@ -1232,7 +1233,7 @@ func TestStatusRemote(t *testing.T) {
 				FrameConfig: referenceframe.NewLinkInFrame(referenceframe.World, nil, "arm2", nil),
 				ModelFrame:  referenceframe.NewSimpleModel("arm2"),
 			},
-		}}, nil
+		}, nil
 	}
 
 	injectRobot1 := &inject.Robot{

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
+
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	armpb "go.viam.com/api/component/arm/v1"
@@ -1225,12 +1226,12 @@ func TestStatusRemote(t *testing.T) {
 	frameSystemConfigFunc := func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
 		return []*referenceframe.FrameSystemPart{
 			{
-				FrameConfig: referenceframe.NewLinkInFrame(referenceframe.World, nil, "arm1", nil),
-				ModelFrame:  referenceframe.NewSimpleModel("arm1"),
+				Origin:     referenceframe.NewLinkInFrame(referenceframe.World, nil, "arm1", nil),
+				ModelFrame: referenceframe.NewSimpleModel("arm1"),
 			},
 			{
-				FrameConfig: referenceframe.NewLinkInFrame(referenceframe.World, nil, "arm2", nil),
-				ModelFrame:  referenceframe.NewSimpleModel("arm2"),
+				Origin:     referenceframe.NewLinkInFrame(referenceframe.World, nil, "arm2", nil),
+				ModelFrame: referenceframe.NewSimpleModel("arm2"),
 			},
 		}, nil
 	}

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -53,7 +53,6 @@ import (
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/robot/client"
-	"go.viam.com/rdk/robot/framesystem"
 	"go.viam.com/rdk/robot/packages"
 	"go.viam.com/rdk/services/motion"
 	"go.viam.com/rdk/services/shell"
@@ -1800,7 +1799,7 @@ func (rr *dummyRobot) ResourceByName(name resource.Name) (resource.Resource, err
 }
 
 // FrameSystemConfig returns a remote robot's FrameSystem Config.
-func (rr *dummyRobot) FrameSystemConfig(ctx context.Context) (*framesystem.Config, error) {
+func (rr *dummyRobot) FrameSystemConfig(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
 	panic("change to return nil")
 }
 

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -1798,8 +1798,8 @@ func (rr *dummyRobot) ResourceByName(name resource.Name) (resource.Resource, err
 	return rr.manager.ResourceByName(name)
 }
 
-// FrameSystemConfig returns a remote robot's FrameSystem Config.
-func (rr *dummyRobot) FrameSystemConfig(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
+// FrameSystemParts returns a remote robot's FrameSystem Config.
+func (rr *dummyRobot) FrameSystemParts(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
 	panic("change to return nil")
 }
 

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"math"
 	"net"
 	"os"
 	"path/filepath"
@@ -16,7 +15,6 @@ import (
 
 	"github.com/a8m/envsubst"
 	"github.com/edaniels/golog"
-	"github.com/golang/geo/r3"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"go.uber.org/zap/zaptest/observer"
@@ -42,7 +40,6 @@ import (
 	"go.viam.com/rdk/components/servo"
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/internal"
-	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/services/datamanager"
 	_ "go.viam.com/rdk/services/datamanager/builtin"
@@ -50,7 +47,6 @@ import (
 	_ "go.viam.com/rdk/services/motion/builtin"
 	"go.viam.com/rdk/services/sensors"
 	_ "go.viam.com/rdk/services/sensors/builtin"
-	"go.viam.com/rdk/spatialmath"
 	rdktestutils "go.viam.com/rdk/testutils"
 	"go.viam.com/rdk/testutils/robottestutils"
 	rutils "go.viam.com/rdk/utils"
@@ -2602,6 +2598,84 @@ func TestUpdateWeakDependents(t *testing.T) {
 	test.That(t, weak1.resources, test.ShouldContainKey, base2Name)
 }
 
+func TestRemoteRobotFrameReconfigure(t *testing.T) {
+	logger := golog.NewTestLogger(t)
+	ctx := context.Background()
+	remoteCfg := &config.Config{
+		Components: []resource.Config{
+			{
+				Name:  "arm",
+				API:   arm.API,
+				Model: fake.Model,
+				ConvertedAttributes: &fake.Config{
+					ArmModel: "ur5e",
+				},
+				// Frame: &referenceframe.LinkConfig{
+				// 	Parent: referenceframe.World,
+				// },
+			},
+		},
+	}
+	remote, err := New(ctx, remoteCfg, logger)
+	test.That(t, err, test.ShouldBeNil)
+	defer func() {
+		test.That(t, remote.Close(context.Background()), test.ShouldBeNil)
+	}()
+
+	options, _, addr := robottestutils.CreateBaseOptionsAndListener(t)
+	err = remote.StartWeb(ctx, options)
+	test.That(t, err, test.ShouldBeNil)
+
+	localConfig := &config.Config{
+		Remotes: []config.Remote{
+			{
+				Name:    "foo",
+				Address: addr,
+			},
+		},
+	}
+	r, err := New(ctx, localConfig, logger)
+	defer func() {
+		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
+	}()
+	test.That(t, err, test.ShouldBeNil)
+
+	defaultServices := []resource.Name{
+		motion.Named(resource.DefaultServiceName),
+		sensors.Named(resource.DefaultServiceName),
+		datamanager.Named(resource.DefaultServiceName),
+		motion.Named("foo:builtin"),
+		sensors.Named("foo:builtin"),
+		datamanager.Named("foo:builtin"),
+	}
+
+	name := r.ResourceNames()
+	_ = name
+	test.That(
+		t,
+		rdktestutils.NewResourceNameSet(r.ResourceNames()...),
+		test.ShouldResemble,
+		rdktestutils.NewResourceNameSet(append(defaultServices, arm.Named("foo:arm"))...),
+	)
+
+	// Reconfigure remote to remove slam service.
+	remote.Reconfigure(ctx, &config.Config{})
+
+	rr, ok := r.(*localRobot)
+	test.That(t, ok, test.ShouldBeTrue)
+
+	rr.triggerConfig <- struct{}{}
+
+	for _, name := range r.ResourceNames() {
+		fmt.Println(name)
+	}
+
+	// Assert that some time after remote Reconfigure, r.ResourceNames no longer returns the "foo:arm" resource
+	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
+		test.That(tb, rdktestutils.NewResourceNameSet(r.ResourceNames()...), test.ShouldResemble, defaultServices)
+	})
+}
+
 func TestDefaultServiceReconfigure(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 
@@ -2652,116 +2726,6 @@ func TestDefaultServiceReconfigure(t *testing.T) {
 			sensors.Named(sName),
 		),
 	)
-}
-
-func TestFrameSystemRemoteReconfiguration(t *testing.T) {
-	logger := golog.NewTestLogger(t)
-	// make the remote robots
-	remoteConfig1, err := config.Read(context.Background(), rutils.ResolveFile("robot/impl/data/fake.json"), logger)
-	test.That(t, err, test.ShouldBeNil)
-	ctx := context.Background()
-	remoteRobot, err := New(ctx, remoteConfig1, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, remoteRobot.Close(context.Background()), test.ShouldBeNil)
-	}()
-
-	options, _, addr := robottestutils.CreateBaseOptionsAndListener(t)
-	err = remoteRobot.StartWeb(ctx, options)
-	test.That(t, err, test.ShouldBeNil)
-
-	oCfg, err := spatialmath.NewOrientationConfig(&spatialmath.R4AA{math.Pi / 2., 0, 0, 1})
-	test.That(t, err, test.ShouldBeNil)
-
-	// make the local robot
-	localConfig := &config.Config{
-		Components: []resource.Config{
-			{
-				Name:  "foo",
-				API:   base.API,
-				Model: resource.DefaultModelFamily.WithModel("fake"),
-				Frame: &referenceframe.LinkConfig{
-					Parent: referenceframe.World,
-				},
-			},
-			{
-				Name:  "myParentIsRemote",
-				API:   gripper.API,
-				Model: resource.DefaultModelFamily.WithModel("fake"),
-				Frame: &referenceframe.LinkConfig{
-					Parent: "bar:pieceArm",
-				},
-			},
-		},
-		Remotes: []config.Remote{
-			{
-				Name:    "bar",
-				Address: addr,
-				Frame: &referenceframe.LinkConfig{
-					Parent:      "foo",
-					Translation: r3.Vector{100, 200, 300},
-					Orientation: oCfg,
-				},
-			},
-			{
-				Name:    "squee",
-				Address: addr,
-				Frame: &referenceframe.LinkConfig{
-					Parent:      referenceframe.World,
-					Translation: r3.Vector{500, 600, 700},
-					Orientation: oCfg,
-				},
-			},
-			{
-				Name:    "dontAddMe", // no frame info, should be skipped
-				Address: addr,
-			},
-		},
-	}
-
-	// make local robot
-	testPose := spatialmath.NewPose(
-		r3.Vector{X: 1., Y: 2., Z: 3.},
-		&spatialmath.R4AA{Theta: math.Pi / 2, RX: 0., RY: 1., RZ: 0.},
-	)
-
-	transforms := []*referenceframe.LinkInFrame{
-		referenceframe.NewLinkInFrame("bar:pieceArm", testPose, "frame1", nil),
-		referenceframe.NewLinkInFrame("bar:pieceGripper", testPose, "frame2", nil),
-		referenceframe.NewLinkInFrame("frame2", testPose, "frame2a", nil),
-		referenceframe.NewLinkInFrame("frame2", testPose, "frame2c", nil),
-		referenceframe.NewLinkInFrame(referenceframe.World, testPose, "frame3", nil),
-	}
-
-	r2, err := New(context.Background(), localConfig, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, r2.Close(context.Background()), test.ShouldBeNil)
-	}()
-
-	parts, err := r2.FrameSystemParts(context.Background())
-	test.That(t, err, test.ShouldBeNil)
-	fs, err := referenceframe.NewFrameSystem("test", parts, transforms)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, fs.FrameNames(), test.ShouldHaveLength, 34)
-
-	// reconfigure a remote to have a different config
-	remoteConfig2, err := config.Read(context.Background(), rutils.ResolveFile("robot/impl/data/remote_fake.json"), logger)
-	test.That(t, err, test.ShouldBeNil)
-	remoteRobot.Reconfigure(ctx, remoteConfig2)
-
-	// ensure that it configured correctly
-	parts, err = remoteRobot.FrameSystemParts(context.Background())
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, len(parts), test.ShouldEqual, 2)
-
-	local, ok := r2.(*localRobot)
-	test.That(t, ok, test.ShouldBeTrue)
-	local.triggerConfig <- struct{}{}
-	time.Sleep(time.Second * 6)
-	parts, err = r2.FrameSystemParts(context.Background())
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, len(parts), test.ShouldEqual, 0)
 }
 
 func TestStatusServiceUpdate(t *testing.T) {

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -40,6 +40,7 @@ import (
 	"go.viam.com/rdk/components/servo"
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/internal"
+	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/services/datamanager"
 	_ "go.viam.com/rdk/services/datamanager/builtin"
@@ -2598,6 +2599,8 @@ func TestUpdateWeakDependents(t *testing.T) {
 	test.That(t, weak1.resources, test.ShouldContainKey, base2Name)
 }
 
+// TODO(benji): refactor this test to test sensing reconfigurations of remote framesystems
+// not just resources.
 func TestRemoteRobotFrameReconfigure(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	ctx := context.Background()
@@ -2610,9 +2613,9 @@ func TestRemoteRobotFrameReconfigure(t *testing.T) {
 				ConvertedAttributes: &fake.Config{
 					ArmModel: "ur5e",
 				},
-				// Frame: &referenceframe.LinkConfig{
-				// 	Parent: referenceframe.World,
-				// },
+				Frame: &referenceframe.LinkConfig{
+					Parent: referenceframe.World,
+				},
 			},
 		},
 	}
@@ -2672,7 +2675,8 @@ func TestRemoteRobotFrameReconfigure(t *testing.T) {
 
 	// Assert that some time after remote Reconfigure, r.ResourceNames no longer returns the "foo:arm" resource
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		test.That(tb, rdktestutils.NewResourceNameSet(r.ResourceNames()...), test.ShouldResemble, defaultServices)
+		test.That(tb, rdktestutils.NewResourceNameSet(r.ResourceNames()...), test.ShouldResemble,
+			rdktestutils.NewResourceNameSet(defaultServices...))
 	})
 }
 

--- a/robot/robot.go
+++ b/robot/robot.go
@@ -59,7 +59,7 @@ type Robot interface {
 	// Logger returns the logger the robot is using.
 	Logger() golog.Logger
 
-	// FrameSystemConfig returns the individual parts that make up a robot's frame system
+	// FrameSystemParts returns the individual parts that make up a robot's frame system
 	FrameSystemParts(ctx context.Context) ([]*referenceframe.FrameSystemPart, error)
 
 	// TransformPose will transform the pose of the requested poseInFrame to the desired frame in the robot's frame system.

--- a/robot/robot.go
+++ b/robot/robot.go
@@ -59,8 +59,8 @@ type Robot interface {
 	// Logger returns the logger the robot is using.
 	Logger() golog.Logger
 
-	// FrameSystemConfig returns the individual parts that make up a robot's frame system
-	FrameSystemConfig(ctx context.Context) ([]*referenceframe.FrameSystemPart, error)
+	// FrameSystemParts returns the individual parts that make up a robot's frame system
+	FrameSystemParts(ctx context.Context) ([]*referenceframe.FrameSystemPart, error)
 
 	// TransformPose will transform the pose of the requested poseInFrame to the desired frame in the robot's frame system.
 	TransformPose(

--- a/robot/robot.go
+++ b/robot/robot.go
@@ -59,8 +59,8 @@ type Robot interface {
 	// Logger returns the logger the robot is using.
 	Logger() golog.Logger
 
-	// FrameSystemParts returns the individual parts that make up a robot's frame system
-	FrameSystemParts(ctx context.Context) ([]*referenceframe.FrameSystemPart, error)
+	// FrameSystemConfig returns the individual parts that make up a robot's frame system
+	FrameSystemConfig(ctx context.Context) ([]*referenceframe.FrameSystemPart, error)
 
 	// TransformPose will transform the pose of the requested poseInFrame to the desired frame in the robot's frame system.
 	TransformPose(

--- a/robot/robot.go
+++ b/robot/robot.go
@@ -18,7 +18,6 @@ import (
 	"go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/robot/framesystem"
 	"go.viam.com/rdk/robot/packages"
 	weboptions "go.viam.com/rdk/robot/web/options"
 	"go.viam.com/rdk/session"
@@ -61,7 +60,7 @@ type Robot interface {
 	Logger() golog.Logger
 
 	// FrameSystemConfig returns the individual parts that make up a robot's frame system
-	FrameSystemConfig(ctx context.Context) (*framesystem.Config, error)
+	FrameSystemParts(ctx context.Context) ([]*referenceframe.FrameSystemPart, error)
 
 	// TransformPose will transform the pose of the requested poseInFrame to the desired frame in the robot's frame system.
 	TransformPose(

--- a/robot/server/server.go
+++ b/robot/server/server.go
@@ -217,9 +217,9 @@ func (s *Server) DiscoverComponents(ctx context.Context, req *pb.DiscoverCompone
 	return &pb.DiscoverComponentsResponse{Discovery: pbDiscoveries}, nil
 }
 
-// FrameSystemConfig returns the info of each individual part that makes up the frame system.
-func (s *Server) FrameSystemConfig(ctx context.Context, req *pb.FrameSystemConfigRequest) (*pb.FrameSystemConfigResponse, error) {
-	parts, err := s.r.FrameSystemConfig(ctx)
+// FrameSystemParts returns the info of each individual part that makes up the frame system.
+func (s *Server) FrameSystemParts(ctx context.Context, req *pb.FrameSystemConfigRequest) (*pb.FrameSystemConfigResponse, error) {
+	parts, err := s.r.FrameSystemParts(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/robot/server/server.go
+++ b/robot/server/server.go
@@ -219,12 +219,12 @@ func (s *Server) DiscoverComponents(ctx context.Context, req *pb.DiscoverCompone
 
 // FrameSystemConfig returns the info of each individual part that makes up the frame system.
 func (s *Server) FrameSystemConfig(ctx context.Context, req *pb.FrameSystemConfigRequest) (*pb.FrameSystemConfigResponse, error) {
-	fsCfg, err := s.r.FrameSystemConfig(ctx)
+	parts, err := s.r.FrameSystemParts(ctx)
 	if err != nil {
 		return nil, err
 	}
-	configs := make([]*pb.FrameSystemConfig, len(fsCfg.Parts))
-	for i, part := range fsCfg.Parts {
+	configs := make([]*pb.FrameSystemConfig, len(parts))
+	for i, part := range parts {
 		c, err := part.ToProtobuf()
 		if err != nil {
 			if errors.Is(err, referenceframe.ErrNoModelInformation) {

--- a/robot/server/server.go
+++ b/robot/server/server.go
@@ -217,8 +217,8 @@ func (s *Server) DiscoverComponents(ctx context.Context, req *pb.DiscoverCompone
 	return &pb.DiscoverComponentsResponse{Discovery: pbDiscoveries}, nil
 }
 
-// FrameSystemConfig returns the info of each individual part that makes up the frame system.
-func (s *Server) FrameSystemConfig(ctx context.Context, req *pb.FrameSystemConfigRequest) (*pb.FrameSystemConfigResponse, error) {
+// FrameSystemParts returns the info of each individual part that makes up the frame system.
+func (s *Server) FrameSystemParts(ctx context.Context, req *pb.FrameSystemConfigRequest) (*pb.FrameSystemConfigResponse, error) {
 	parts, err := s.r.FrameSystemParts(ctx)
 	if err != nil {
 		return nil, err

--- a/robot/server/server.go
+++ b/robot/server/server.go
@@ -217,9 +217,9 @@ func (s *Server) DiscoverComponents(ctx context.Context, req *pb.DiscoverCompone
 	return &pb.DiscoverComponentsResponse{Discovery: pbDiscoveries}, nil
 }
 
-// FrameSystemParts returns the info of each individual part that makes up the frame system.
-func (s *Server) FrameSystemParts(ctx context.Context, req *pb.FrameSystemConfigRequest) (*pb.FrameSystemConfigResponse, error) {
-	parts, err := s.r.FrameSystemParts(ctx)
+// FrameSystemConfig returns the info of each individual part that makes up the frame system.
+func (s *Server) FrameSystemConfig(ctx context.Context, req *pb.FrameSystemConfigRequest) (*pb.FrameSystemConfigResponse, error) {
+	parts, err := s.r.FrameSystemConfig(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/robot/server/server.go
+++ b/robot/server/server.go
@@ -217,8 +217,8 @@ func (s *Server) DiscoverComponents(ctx context.Context, req *pb.DiscoverCompone
 	return &pb.DiscoverComponentsResponse{Discovery: pbDiscoveries}, nil
 }
 
-// FrameSystemParts returns the info of each individual part that makes up the frame system.
-func (s *Server) FrameSystemParts(ctx context.Context, req *pb.FrameSystemConfigRequest) (*pb.FrameSystemConfigResponse, error) {
+// FrameSystemConfig returns the info of each individual part that makes up the frame system.
+func (s *Server) FrameSystemConfig(ctx context.Context, req *pb.FrameSystemConfigRequest) (*pb.FrameSystemConfigResponse, error) {
 	parts, err := s.r.FrameSystemParts(ctx)
 	if err != nil {
 		return nil, err

--- a/robot/server/server_test.go
+++ b/robot/server/server_test.go
@@ -30,7 +30,6 @@ import (
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot"
-	"go.viam.com/rdk/robot/framesystem"
 	"go.viam.com/rdk/robot/server"
 	"go.viam.com/rdk/session"
 	"go.viam.com/rdk/spatialmath"
@@ -319,8 +318,8 @@ func TestServerFrameSystemConfig(t *testing.T) {
 			},
 		}
 
-		injectRobot.FrameSystemConfigFunc = func(ctx context.Context) (*framesystem.Config, error) {
-			return &framesystem.Config{Parts: fsConfigs}, nil
+		injectRobot.FrameSystemConfigFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
+			return fsConfigs, nil
 		}
 		server := server.New(injectRobot)
 		req := &pb.FrameSystemConfigRequest{}
@@ -374,7 +373,7 @@ func TestServerFrameSystemConfig(t *testing.T) {
 
 	t.Run("test failing config function", func(t *testing.T) {
 		expectedErr := errors.New("failed to retrieve config")
-		injectRobot.FrameSystemConfigFunc = func(ctx context.Context) (*framesystem.Config, error) {
+		injectRobot.FrameSystemConfigFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
 			return nil, expectedErr
 		}
 		req := &pb.FrameSystemConfigRequest{}

--- a/robot/server/server_test.go
+++ b/robot/server/server_test.go
@@ -318,7 +318,7 @@ func TestServerFrameSystemConfig(t *testing.T) {
 			},
 		}
 
-		injectRobot.FrameSystemConfigFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
+		injectRobot.FrameSystemPartsFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
 			return fsConfigs, nil
 		}
 		server := server.New(injectRobot)
@@ -373,7 +373,7 @@ func TestServerFrameSystemConfig(t *testing.T) {
 
 	t.Run("test failing config function", func(t *testing.T) {
 		expectedErr := errors.New("failed to retrieve config")
-		injectRobot.FrameSystemConfigFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
+		injectRobot.FrameSystemPartsFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
 			return nil, expectedErr
 		}
 		req := &pb.FrameSystemConfigRequest{}

--- a/robot/server/server_test.go
+++ b/robot/server/server_test.go
@@ -311,10 +311,10 @@ func TestServerFrameSystemConfig(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		fsConfigs := []*referenceframe.FrameSystemPart{
 			{
-				FrameConfig: lif1,
+				Origin: lif1,
 			},
 			{
-				FrameConfig: lif2,
+				Origin: lif2,
 			},
 		}
 
@@ -326,29 +326,29 @@ func TestServerFrameSystemConfig(t *testing.T) {
 		resp, err := server.FrameSystemConfig(context.Background(), req)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, len(resp.FrameSystemConfigs), test.ShouldEqual, len(fsConfigs))
-		test.That(t, resp.FrameSystemConfigs[0].Frame.ReferenceFrame, test.ShouldEqual, fsConfigs[0].FrameConfig.Name())
+		test.That(t, resp.FrameSystemConfigs[0].Frame.ReferenceFrame, test.ShouldEqual, fsConfigs[0].Origin.Name())
 		test.That(
 			t,
 			resp.FrameSystemConfigs[0].Frame.PoseInObserverFrame.ReferenceFrame,
 			test.ShouldEqual,
-			fsConfigs[0].FrameConfig.Parent(),
+			fsConfigs[0].Origin.Parent(),
 		)
 		test.That(t,
 			resp.FrameSystemConfigs[0].Frame.PoseInObserverFrame.Pose.X,
 			test.ShouldAlmostEqual,
-			fsConfigs[0].FrameConfig.Pose().Point().X,
+			fsConfigs[0].Origin.Pose().Point().X,
 		)
 		test.That(t,
 			resp.FrameSystemConfigs[0].Frame.PoseInObserverFrame.Pose.Y,
 			test.ShouldAlmostEqual,
-			fsConfigs[0].FrameConfig.Pose().Point().Y,
+			fsConfigs[0].Origin.Pose().Point().Y,
 		)
 		test.That(t,
 			resp.FrameSystemConfigs[0].Frame.PoseInObserverFrame.Pose.Z,
 			test.ShouldAlmostEqual,
-			fsConfigs[0].FrameConfig.Pose().Point().Z,
+			fsConfigs[0].Origin.Pose().Point().Z,
 		)
-		pose := fsConfigs[0].FrameConfig.Pose()
+		pose := fsConfigs[0].Origin.Pose()
 		test.That(t,
 			resp.FrameSystemConfigs[0].Frame.PoseInObserverFrame.Pose.OX,
 			test.ShouldAlmostEqual,

--- a/robot/web/web_test.go
+++ b/robot/web/web_test.go
@@ -825,7 +825,7 @@ func setupRobotCtx(t *testing.T) (context.Context, robot.Robot) {
 		return injectArm, nil
 	}
 	injectRobot.LoggerFunc = func() golog.Logger { return golog.NewTestLogger(t) }
-	injectRobot.FrameSystemPartsFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
+	injectRobot.FrameSystemConfigFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
 		return make([]*referenceframe.FrameSystemPart, 0), nil
 	}
 

--- a/robot/web/web_test.go
+++ b/robot/web/web_test.go
@@ -825,7 +825,7 @@ func setupRobotCtx(t *testing.T) (context.Context, robot.Robot) {
 		return injectArm, nil
 	}
 	injectRobot.LoggerFunc = func() golog.Logger { return golog.NewTestLogger(t) }
-	injectRobot.FrameSystemConfigFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
+	injectRobot.FrameSystemPartsFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
 		return make([]*referenceframe.FrameSystemPart, 0), nil
 	}
 

--- a/robot/web/web_test.go
+++ b/robot/web/web_test.go
@@ -37,9 +37,9 @@ import (
 	"go.viam.com/rdk/config"
 	gizmopb "go.viam.com/rdk/examples/customresources/apis/proto/api/component/gizmo/v1"
 	rgrpc "go.viam.com/rdk/grpc"
+	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot"
-	"go.viam.com/rdk/robot/framesystem"
 	"go.viam.com/rdk/robot/web"
 	weboptions "go.viam.com/rdk/robot/web/options"
 	"go.viam.com/rdk/spatialmath"
@@ -825,8 +825,8 @@ func setupRobotCtx(t *testing.T) (context.Context, robot.Robot) {
 		return injectArm, nil
 	}
 	injectRobot.LoggerFunc = func() golog.Logger { return golog.NewTestLogger(t) }
-	injectRobot.FrameSystemConfigFunc = func(ctx context.Context) (*framesystem.Config, error) {
-		return &framesystem.Config{}, nil
+	injectRobot.FrameSystemPartsFunc = func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
+		return make([]*referenceframe.FrameSystemPart, 0), nil
 	}
 
 	return context.Background(), injectRobot

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -82,15 +82,12 @@ func createEnvironment(ctx context.Context, t *testing.T, gpsPoint *geo.Point) (
 	test.That(t, err, test.ShouldBeNil)
 
 	// create base link
-	basePose := spatialmath.NewPoseFromPoint(r3.Vector{0, 0, 0})
-	baseSphere, err := spatialmath.NewSphere(basePose, 10, "base-sphere")
-	test.That(t, err, test.ShouldBeNil)
-	baseLink := referenceframe.NewLinkInFrame(
-		referenceframe.World,
-		spatialmath.NewZeroPose(),
-		"test-base",
-		baseSphere,
-	)
+	baseLink := referenceframe.LinkConfig{
+		ID:          "test-base",
+		Parent:      referenceframe.World,
+		Geometry:    &spatialmath.GeometryConfig{R: 10, X: 0, Y: 0, Z: 0},
+		Translation: r3.Vector{0, 0, 0},
+	}
 
 	// create injected MovementSensor
 	injectedMovementSensor := inject.NewMovementSensor("test-gps")
@@ -105,17 +102,17 @@ func createEnvironment(ctx context.Context, t *testing.T, gpsPoint *geo.Point) (
 	}
 
 	// create MovementSensor link
-	movementSensorLink := referenceframe.NewLinkInFrame(
-		baseLink.Name(),
-		spatialmath.NewPoseFromPoint(r3.Vector{-10, 0, 0}),
-		"test-gps",
-		nil,
-	)
+	movementSensorLink := referenceframe.LinkConfig{
+		ID:          "test-gps",
+		Parent:      "test-base",
+		Translation: r3.Vector{-10, 0, 0},
+	}
+	test.That(t, err, test.ShouldBeNil)
 
 	// create the frame system
 	fsParts := []*framesystem.PartConfig{
-		{Origin: movementSensorLink},
-		{Origin: baseLink},
+		{Origin: &movementSensorLink},
+		{Origin: &baseLink},
 	}
 	deps := resource.Dependencies{
 		fakeBase.Name():               fakeBase,

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -113,9 +113,9 @@ func createEnvironment(ctx context.Context, t *testing.T, gpsPoint *geo.Point) (
 	)
 
 	// create the frame system
-	fsParts := []*referenceframe.FrameSystemPart{
-		{FrameConfig: movementSensorLink},
-		{FrameConfig: baseLink},
+	fsParts := []*framesystem.PartConfig{
+		{Origin: movementSensorLink},
+		{Origin: baseLink},
 	}
 	deps := resource.Dependencies{
 		fakeBase.Name():               fakeBase,
@@ -123,7 +123,7 @@ func createEnvironment(ctx context.Context, t *testing.T, gpsPoint *geo.Point) (
 	}
 	fsSvc, err := framesystem.New(context.Background(), deps, logger)
 	test.That(t, err, test.ShouldBeNil)
-	err = fsSvc.Reconfigure(context.Background(), deps, resource.Config{ConvertedAttributes: &framesystem.Config{Parts: fsParts}})
+	err = fsSvc.Reconfigure(context.Background(), deps, resource.Config{ConvertedAttributes: &framesystem.Config{PartConfigs: fsParts}})
 	test.That(t, err, test.ShouldBeNil)
 
 	// create the motion service

--- a/testutils/inject/robot.go
+++ b/testutils/inject/robot.go
@@ -36,7 +36,7 @@ type Robot struct {
 	LoggerFunc             func() golog.Logger
 	CloseFunc              func(ctx context.Context) error
 	StopAllFunc            func(ctx context.Context, extra map[resource.Name]map[string]interface{}) error
-	FrameSystemConfigFunc  func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error)
+	FrameSystemPartsFunc   func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error)
 	TransformPoseFunc      func(
 		ctx context.Context,
 		pose *referenceframe.PoseInFrame,
@@ -216,15 +216,15 @@ func (r *Robot) DiscoverComponents(ctx context.Context, keys []resource.Discover
 	return r.DiscoverComponentsFunc(ctx, keys)
 }
 
-// FrameSystemConfig calls the injected FrameSystemConfig or the real version.
-func (r *Robot) FrameSystemConfig(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
+// FrameSystemParts calls the injected FrameSystemParts or the real version.
+func (r *Robot) FrameSystemParts(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
 	r.Mu.RLock()
 	defer r.Mu.RUnlock()
-	if r.FrameSystemConfigFunc == nil {
-		return r.LocalRobot.FrameSystemConfig(ctx)
+	if r.FrameSystemPartsFunc == nil {
+		return r.LocalRobot.FrameSystemParts(ctx)
 	}
 
-	return r.FrameSystemConfigFunc(ctx)
+	return r.FrameSystemPartsFunc(ctx)
 }
 
 // TransformPose calls the injected TransformPose or the real version.

--- a/testutils/inject/robot.go
+++ b/testutils/inject/robot.go
@@ -36,7 +36,7 @@ type Robot struct {
 	LoggerFunc             func() golog.Logger
 	CloseFunc              func(ctx context.Context) error
 	StopAllFunc            func(ctx context.Context, extra map[resource.Name]map[string]interface{}) error
-	FrameSystemPartsFunc   func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error)
+	FrameSystemConfigFunc  func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error)
 	TransformPoseFunc      func(
 		ctx context.Context,
 		pose *referenceframe.PoseInFrame,
@@ -217,14 +217,14 @@ func (r *Robot) DiscoverComponents(ctx context.Context, keys []resource.Discover
 }
 
 // FrameSystemConfig calls the injected FrameSystemConfig or the real version.
-func (r *Robot) FrameSystemParts(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
+func (r *Robot) FrameSystemConfig(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
 	r.Mu.RLock()
 	defer r.Mu.RUnlock()
-	if r.FrameSystemPartsFunc == nil {
-		return r.LocalRobot.FrameSystemParts(ctx)
+	if r.FrameSystemConfigFunc == nil {
+		return r.LocalRobot.FrameSystemConfig(ctx)
 	}
 
-	return r.FrameSystemPartsFunc(ctx)
+	return r.FrameSystemConfigFunc(ctx)
 }
 
 // TransformPose calls the injected TransformPose or the real version.

--- a/testutils/inject/robot.go
+++ b/testutils/inject/robot.go
@@ -17,7 +17,6 @@ import (
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot"
-	"go.viam.com/rdk/robot/framesystem"
 	"go.viam.com/rdk/robot/packages"
 	"go.viam.com/rdk/session"
 )
@@ -37,7 +36,7 @@ type Robot struct {
 	LoggerFunc             func() golog.Logger
 	CloseFunc              func(ctx context.Context) error
 	StopAllFunc            func(ctx context.Context, extra map[resource.Name]map[string]interface{}) error
-	FrameSystemConfigFunc  func(ctx context.Context) (*framesystem.Config, error)
+	FrameSystemPartsFunc   func(ctx context.Context) ([]*referenceframe.FrameSystemPart, error)
 	TransformPoseFunc      func(
 		ctx context.Context,
 		pose *referenceframe.PoseInFrame,
@@ -218,14 +217,14 @@ func (r *Robot) DiscoverComponents(ctx context.Context, keys []resource.Discover
 }
 
 // FrameSystemConfig calls the injected FrameSystemConfig or the real version.
-func (r *Robot) FrameSystemConfig(ctx context.Context) (*framesystem.Config, error) {
+func (r *Robot) FrameSystemParts(ctx context.Context) ([]*referenceframe.FrameSystemPart, error) {
 	r.Mu.RLock()
 	defer r.Mu.RUnlock()
-	if r.FrameSystemConfigFunc == nil {
-		return r.LocalRobot.FrameSystemConfig(ctx)
+	if r.FrameSystemPartsFunc == nil {
+		return r.LocalRobot.FrameSystemParts(ctx)
 	}
 
-	return r.FrameSystemConfigFunc(ctx)
+	return r.FrameSystemPartsFunc(ctx)
 }
 
 // TransformPose calls the injected TransformPose or the real version.


### PR DESCRIPTION
This work makes it so that we don't have to rebuild the frame system config every time it is requested which will result in fewer queries to remotes