### PR TITLE
APP-1953 Opt out of typescript SDK reconnect logic

### DIFF
--- a/web/frontend/src/components/remote-control-cards.vue
+++ b/web/frontend/src/components/remote-control-cards.vue
@@ -99,6 +99,17 @@ const client = new Client(impliedURL, {
       },
     ],
   },
+
+  /*
+   * TODO(RSDK-3183): Opt out of reconnection management in the Typescript
+   * SDK because the Remote Control implements it's own reconnection management.
+   *
+   * The Typescript SDK only manages reconnections for WebRTC connections - once
+   * it can manage reconnections for direct gRPC connections, then we remove
+   * reconnection management from the Remote Control panel entirely and just rely
+   * on the Typescript SDK for that.
+   */
+  noReconnect: true,
 });
 
 const streamManager = new StreamManager(client);


### PR DESCRIPTION
Since RC has it's own reconnect management logic, we need to opt out of the same logic offered by the typescript SDK to avoid clobbering behavior.