### PR TITLE
Fix fake json

### DIFF
--- a/etc/configs/fake.json
+++ b/etc/configs/fake.json
@@ -137,8 +137,8 @@
                 "store": {
                     "type": "memory"
                 },
-                "movement_sensor": "movement_sensor1",
-                "base": "base1"
+                "movement_sensor_name": "movement_sensor1",
+                "base_name": "base1"
             }
         },
         {


### PR DESCRIPTION
we really should be running the fake.json before merging, especially if you're gonna be changing config values.

Why `base_name` when a lot of our other drivers seems to leave `name` out? @randhid do we have guidelines around this?