### PR TITLE
RSDK-3094: Fix transform camera failing because of dependencies

### DIFF
--- a/components/camera/transformpipeline/pipeline.go
+++ b/components/camera/transformpipeline/pipeline.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 	"go.uber.org/multierr"
-	rutils "go.viam.com/utils"
+	goutils "go.viam.com/utils"
 
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/resource"
@@ -72,7 +72,7 @@ type transformConfig struct {
 func (cfg *transformConfig) Validate(path string) ([]string, error) {
 	var deps []string
 	if len(cfg.Source) == 0 {
-		return nil, rutils.NewConfigValidationFieldRequiredError("%q is required", "source")
+		return nil, goutils.NewConfigValidationFieldRequiredError(path, "source")
 	}
 	deps = append(deps, cfg.Source)
 	return deps, nil

--- a/components/camera/transformpipeline/pipeline.go
+++ b/components/camera/transformpipeline/pipeline.go
@@ -86,7 +86,6 @@ func newTransformPipeline(
 	r robot.Robot,
 ) (camera.VideoSource, error) {
 	if source == nil {
-		fmt.Println("Erroring here, newTransformPipeline")
 		return nil, errors.New("no source camera for transform pipeline")
 	}
 	if len(cfg.Pipeline) == 0 {

--- a/components/camera/transformpipeline/pipeline.go
+++ b/components/camera/transformpipeline/pipeline.go
@@ -47,7 +47,6 @@ func init() {
 				sourceName := newConf.Source
 				source, err := camera.FromRobot(actualR, sourceName)
 				if err != nil {
-					fmt.Println("Erroring here, init")
 					return nil, fmt.Errorf("no source camera for transform pipeline (%s): %w", sourceName, err)
 				}
 				src, err := newTransformPipeline(ctx, source, newConf, actualR)

--- a/components/camera/transformpipeline/pipeline.go
+++ b/components/camera/transformpipeline/pipeline.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 	"go.uber.org/multierr"
+	rutils "go.viam.com/utils"
 
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/resource"
@@ -46,6 +47,7 @@ func init() {
 				sourceName := newConf.Source
 				source, err := camera.FromRobot(actualR, sourceName)
 				if err != nil {
+					fmt.Println("Erroring here, init")
 					return nil, fmt.Errorf("no source camera for transform pipeline (%s): %w", sourceName, err)
 				}
 				src, err := newTransformPipeline(ctx, source, newConf, actualR)
@@ -67,6 +69,16 @@ type transformConfig struct {
 	Pipeline             []Transformation                   `json:"pipeline"`
 }
 
+// Validate ensures all parts of the config are valid.
+func (cfg *transformConfig) Validate(path string) ([]string, error) {
+	var deps []string
+	if len(cfg.Source) == 0 {
+		return nil, rutils.NewConfigValidationFieldRequiredError("%q is required", "source")
+	}
+	deps = append(deps, cfg.Source)
+	return deps, nil
+}
+
 func newTransformPipeline(
 	ctx context.Context,
 	source gostream.VideoSource,
@@ -74,6 +86,7 @@ func newTransformPipeline(
 	r robot.Robot,
 ) (camera.VideoSource, error) {
 	if source == nil {
+		fmt.Println("Erroring here, newTransformPipeline")
 		return nil, errors.New("no source camera for transform pipeline")
 	}
 	if len(cfg.Pipeline) == 0 {

--- a/components/camera/transformpipeline/pipeline_test.go
+++ b/components/camera/transformpipeline/pipeline_test.go
@@ -2,6 +2,7 @@ package transformpipeline
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/edaniels/gostream"
@@ -220,7 +221,7 @@ func TestPipeIntoPipe(t *testing.T) {
 	test.That(t, source.Close(context.Background()), test.ShouldBeNil)
 }
 
-func TestTransformPipelineValidate(t *testing.T) {
+func TestTransformPipelineValidatePass(t *testing.T) {
 	transformConf := &transformConfig{
 		Source: "source",
 		Pipeline: []Transformation{
@@ -231,4 +232,18 @@ func TestTransformPipelineValidate(t *testing.T) {
 	deps, err := transformConf.Validate("path")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, deps, test.ShouldResemble, []string{"source"})
+}
+
+func TestTransformPipelineValidateFail(t *testing.T) {
+	transformConf := &transformConfig{
+		Pipeline: []Transformation{
+			{Type: "rotate", Attributes: utils.AttributeMap{}},
+			{Type: "resize", Attributes: utils.AttributeMap{"height_px": 20, "width_px": 10}},
+		},
+	}
+	path := "path"
+	deps, err := transformConf.Validate(path)
+	fmt.Println(err.Error())
+	test.That(t, err.Error(), test.ShouldResemble, "error validating \"path\": \"source\" is required")
+	test.That(t, deps, test.ShouldBeNil)
 }

--- a/components/camera/transformpipeline/pipeline_test.go
+++ b/components/camera/transformpipeline/pipeline_test.go
@@ -219,3 +219,16 @@ func TestPipeIntoPipe(t *testing.T) {
 	test.That(t, pipe1.Close(context.Background()), test.ShouldBeNil)
 	test.That(t, source.Close(context.Background()), test.ShouldBeNil)
 }
+
+func TestTransformPipelineValidate(t *testing.T) {
+	transformConf := &transformConfig{
+		Source: "source",
+		Pipeline: []Transformation{
+			{Type: "rotate", Attributes: utils.AttributeMap{}},
+			{Type: "resize", Attributes: utils.AttributeMap{"height_px": 20, "width_px": 10}},
+		},
+	}
+	deps, err := transformConf.Validate("path")
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, deps, test.ShouldResemble, []string{"source"})
+}

--- a/components/camera/transformpipeline/pipeline_test.go
+++ b/components/camera/transformpipeline/pipeline_test.go
@@ -2,7 +2,6 @@ package transformpipeline
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/edaniels/gostream"
@@ -243,7 +242,6 @@ func TestTransformPipelineValidateFail(t *testing.T) {
 	}
 	path := "path"
 	deps, err := transformConf.Validate(path)
-	fmt.Println(err.Error())
 	test.That(t, err.Error(), test.ShouldResemble, "error validating \"path\": \"source\" is required")
 	test.That(t, deps, test.ShouldBeNil)
 }


### PR DESCRIPTION
Added validation function to transform pipeline to ensure that source camera is registered prior to transformation itself