### PR TITLE
Switch buildjet test runners from 16->8 cores

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,11 +17,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - arch: [buildjet-16vcpu-ubuntu-2204]
+          - arch: [buildjet-8vcpu-ubuntu-2204]
             image: ghcr.io/viamrobotics/canon:amd64-cache
             platform: linux/amd64
             test_cmd: "make cover test-web"
-          - arch: [buildjet-16vcpu-ubuntu-2204-arm]
+          - arch: [buildjet-8vcpu-ubuntu-2204-arm]
             image: ghcr.io/viamrobotics/canon:arm64-cache
             platform: linux/arm64
             test_cmd: "make cover test-web"


### PR DESCRIPTION
Buildjet has an overall concurrency limit of 32 arm64 cores. Many of our tests were waiting 15+ minutes for a 16 core runner (since only two were effectively available) negating any speed boost in normal use. This reduces things to 8 cores. Slightly slower in standalone, but should be faster in aggregate during the middle of the day.

And yes, reduces amd64 as well. It's already faster, no need for it to out-race the arm64 by an even wider margin.