### PR TITLE
Revert "Fix fake json"

### DIFF
--- a/etc/configs/fake.json
+++ b/etc/configs/fake.json
@@ -137,8 +137,8 @@
                 "store": {
                     "type": "memory"
                 },
-                "movement_sensor_name": "movement_sensor1",
-                "base_name": "base1"
+                "movement_sensor": "movement_sensor1",
+                "base": "base1"
             }
         },
         {


### PR DESCRIPTION
We are changing these back.
There is a PR out now here (https://github.com/viamrobotics/rdk/pull/2442) which removes the _name suffix from the config fields
Reverts viamrobotics/rdk#2432