### PR TITLE
[RSDK-3392] Fix module tests to use unique binary paths

### DIFF
--- a/module/modmanager/data/simplemoduleruncopy.sh
+++ b/module/modmanager/data/simplemoduleruncopy.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-#
-# simplemoduleruncopy is a copy of examples/customresources/demos/simplemodule/run.sh
-# used to test reconfiguring modules to have new executable paths.
-cd `dirname $0`
-cd ../../../examples/customresources/demos/simplemodule
-
-go build ./
-exec ./simplemodule $@

--- a/module/module_interceptors_test.go
+++ b/module/module_interceptors_test.go
@@ -150,7 +150,8 @@ func connect(port string) (robotpb.RobotServiceClient, genericpb.GenericServiceC
 
 func makeConfig(t *testing.T, logger golog.Logger) (string, string, error) {
 	// Precompile module to avoid timeout issues when building takes too long.
-	if err := rtestutils.BuildInDir("module/testmodule"); err != nil {
+	modPath, err := rtestutils.BuildTempModule(t, "module/testmodule")
+	if err != nil {
 		return "", "", err
 	}
 
@@ -163,7 +164,7 @@ func makeConfig(t *testing.T, logger golog.Logger) (string, string, error) {
 	cfg := config.Config{
 		Modules: []config.Module{{
 			Name:    "TestModule",
-			ExePath: utils.ResolveFile("module/testmodule/run.sh"),
+			ExePath: modPath,
 		}},
 		Network: config.NetworkConfig{NetworkConfigData: config.NetworkConfigData{BindAddress: "localhost:" + port}},
 		Components: []resource.Config{{

--- a/testutils/file_utils.go
+++ b/testutils/file_utils.go
@@ -3,20 +3,25 @@ package testutils
 import (
 	"fmt"
 	"os/exec"
+	"path/filepath"
+	"testing"
 
 	"go.uber.org/multierr"
 
 	"go.viam.com/rdk/utils"
 )
 
-// BuildInDir will run "go build ." in the provided RDK directory and return
+// BuildTempModule will run "go build ." in the provided RDK directory and return
 // any build related errors.
-func BuildInDir(dir string) error {
-	builder := exec.Command("go", "build", ".")
+func BuildTempModule(tb testing.TB, dir string) (string, error) {
+	tb.Helper()
+	modPath := filepath.Join(tb.TempDir(), filepath.Base(dir))
+	//nolint:gosec
+	builder := exec.Command("go", "build", "-o", modPath, ".")
 	builder.Dir = utils.ResolveFile(dir)
 	out, err := builder.CombinedOutput()
-	if len(out) != 0 {
-		return multierr.Combine(err, fmt.Errorf(`output from "go build .": %s`, out))
+	if len(out) != 0 || err != nil {
+		return modPath, multierr.Combine(err, fmt.Errorf(`output from "go build .": %s`, out))
 	}
-	return nil
+	return modPath, nil
 }

--- a/testutils/file_utils.go
+++ b/testutils/file_utils.go
@@ -12,7 +12,7 @@ import (
 )
 
 // BuildTempModule will run "go build ." in the provided RDK directory and return
-// any build related errors.
+// the path to the built temporary file and any build related errors.
 func BuildTempModule(tb testing.TB, dir string) (string, error) {
 	tb.Helper()
 	modPath := filepath.Join(tb.TempDir(), filepath.Base(dir))


### PR DESCRIPTION
Recently, newer module tests have been introduced to handle reconfiguration, and they delete and/or recreate the module binaries. Unfortunately, as multiple tests are trying to use a binary from the same location, this can cause a race condition, where a test can fail to execute a module because another test just removed it, or is in the process of recompiling it, resulting in a 'test file busy' error.

This modifies the module build helper to return a unique, temporary path on each build, so tests no longer step on each others toes.