### PR TITLE
RSDK-3095 Making mlmodel info logs less confusing

### DIFF
--- a/services/vision/mlvision/ml_model.go
+++ b/services/vision/mlvision/ml_model.go
@@ -73,12 +73,12 @@ func registerMLModelVisionService(
 
 	classifierFunc, err := attemptToBuildClassifier(mlm)
 	if err != nil {
-		logger.Infow("error turning ml model into a classifier", "model", params.ModelName, "error", err)
+		logger.Infow("unable to use ml model as a classifier, will attempt to evaluate as detector and segmenter", "model", params.ModelName, "error", err)
 	} else {
 		err := checkIfClassifierWorks(ctx, classifierFunc)
 		if err != nil {
 			classifierFunc = nil
-			logger.Infow("error turning ml model into a classifier", "model", params.ModelName, "error", err)
+			logger.Infow("unable to use ml model as a classifier, will attempt to evaluate as detector and segmenter", "model", params.ModelName, "error", err)
 		} else {
 			logger.Infow("model fulfills a vision service classifier", "model", params.ModelName)
 		}
@@ -86,12 +86,12 @@ func registerMLModelVisionService(
 
 	detectorFunc, err := attemptToBuildDetector(mlm)
 	if err != nil {
-		logger.Infow("error turning ml model into a detector", "model", params.ModelName, "error", err)
+		logger.Infow("unable to use ml model as a detector, will attempt to evaluate as segmenter", "model", params.ModelName, "error", err)
 	} else {
 		err = checkIfDetectorWorks(ctx, detectorFunc)
 		if err != nil {
 			detectorFunc = nil
-			logger.Infow("error turning ml model into a detector", "model", params.ModelName, "error", err)
+			logger.Infow("unable to use ml model as a detector, will attempt to evaluate as segmenter", "model", params.ModelName, "error", err)
 		} else {
 			logger.Infow("model fulfills a vision service detector", "model", params.ModelName)
 		}
@@ -99,7 +99,7 @@ func registerMLModelVisionService(
 
 	segmenter3DFunc, err := attemptToBuild3DSegmenter(mlm)
 	if err != nil {
-		logger.Infow("error turning turn ml model into a 3D segmenter", "model", params.ModelName, "error", err)
+		logger.Infow("unable to use ml model as segmenter", "model", params.ModelName, "error", err)
 	} else {
 		logger.Infow("model fulfills a vision service 3D segmenter", "model", params.ModelName)
 	}

--- a/services/vision/mlvision/ml_model.go
+++ b/services/vision/mlvision/ml_model.go
@@ -78,7 +78,7 @@ func registerMLModelVisionService(
 		err := checkIfClassifierWorks(ctx, classifierFunc)
 		if err != nil {
 			classifierFunc = nil
-			logger.Infow("unable to use ml model as a classifier, will attempt to evaluate as detector and segmenter", "model", params.ModelName, "error", err)
+			logger.Debugw("unable to use ml model as a classifier, will attempt to evaluate as detector and segmenter", "model", params.ModelName, "error", err)
 		} else {
 			logger.Infow("model fulfills a vision service classifier", "model", params.ModelName)
 		}
@@ -91,7 +91,7 @@ func registerMLModelVisionService(
 		err = checkIfDetectorWorks(ctx, detectorFunc)
 		if err != nil {
 			detectorFunc = nil
-			logger.Infow("unable to use ml model as a detector, will attempt to evaluate as segmenter", "model", params.ModelName, "error", err)
+			logger.Debugw("unable to use ml model as a detector, will attempt to evaluate as segmenter", "model", params.ModelName, "error", err)
 		} else {
 			logger.Infow("model fulfills a vision service detector", "model", params.ModelName)
 		}
@@ -99,7 +99,7 @@ func registerMLModelVisionService(
 
 	segmenter3DFunc, err := attemptToBuild3DSegmenter(mlm)
 	if err != nil {
-		logger.Infow("unable to use ml model as segmenter", "model", params.ModelName, "error", err)
+		logger.Debugw("unable to use ml model as segmenter", "model", params.ModelName, "error", err)
 	} else {
 		logger.Infow("model fulfills a vision service 3D segmenter", "model", params.ModelName)
 	}

--- a/services/vision/mlvision/ml_model.go
+++ b/services/vision/mlvision/ml_model.go
@@ -80,7 +80,7 @@ func registerMLModelVisionService(
 		if err != nil {
 			classifierFunc = nil
 			logger.Debugw("unable to use ml model as a classifier, will attempt to evaluate as detector"+
-				" and segmenter", "model", params.ModelName, "error", err)
+				" and 3D segmenter", "model", params.ModelName, "error", err)
 		} else {
 			logger.Infow("model fulfills a vision service classifier", "model", params.ModelName)
 		}
@@ -88,13 +88,13 @@ func registerMLModelVisionService(
 
 	detectorFunc, err := attemptToBuildDetector(mlm)
 	if err != nil {
-		logger.Debugw("unable to use ml model as a detector, will attempt to evaluate as segmenter",
+		logger.Debugw("unable to use ml model as a detector, will attempt to evaluate as 3D segmenter",
 			"model", params.ModelName, "error", err)
 	} else {
 		err = checkIfDetectorWorks(ctx, detectorFunc)
 		if err != nil {
 			detectorFunc = nil
-			logger.Debugw("unable to use ml model as a detector, will attempt to evaluate as segmenter",
+			logger.Debugw("unable to use ml model as a detector, will attempt to evaluate as 3D segmenter",
 				"model", params.ModelName, "error", err)
 		} else {
 			logger.Infow("model fulfills a vision service detector", "model", params.ModelName)
@@ -103,7 +103,7 @@ func registerMLModelVisionService(
 
 	segmenter3DFunc, err := attemptToBuild3DSegmenter(mlm)
 	if err != nil {
-		logger.Debugw("unable to use ml model as segmenter", "model", params.ModelName, "error", err)
+		logger.Debugw("unable to use ml model as 3D segmenter", "model", params.ModelName, "error", err)
 	} else {
 		logger.Infow("model fulfills a vision service 3D segmenter", "model", params.ModelName)
 	}

--- a/services/vision/mlvision/ml_model.go
+++ b/services/vision/mlvision/ml_model.go
@@ -73,12 +73,14 @@ func registerMLModelVisionService(
 
 	classifierFunc, err := attemptToBuildClassifier(mlm)
 	if err != nil {
-		logger.Infow("unable to use ml model as a classifier, will attempt to evaluate as detector and segmenter", "model", params.ModelName, "error", err)
+		logger.Debugw("unable to use ml model as a classifier, will attempt to evaluate as"+
+			"detector and segmenter", "model", params.ModelName, "error", err)
 	} else {
 		err := checkIfClassifierWorks(ctx, classifierFunc)
 		if err != nil {
 			classifierFunc = nil
-			logger.Debugw("unable to use ml model as a classifier, will attempt to evaluate as detector and segmenter", "model", params.ModelName, "error", err)
+			logger.Debugw("unable to use ml model as a classifier, will attempt to evaluate as detector"+
+				" and segmenter", "model", params.ModelName, "error", err)
 		} else {
 			logger.Infow("model fulfills a vision service classifier", "model", params.ModelName)
 		}
@@ -86,12 +88,14 @@ func registerMLModelVisionService(
 
 	detectorFunc, err := attemptToBuildDetector(mlm)
 	if err != nil {
-		logger.Infow("unable to use ml model as a detector, will attempt to evaluate as segmenter", "model", params.ModelName, "error", err)
+		logger.Debugw("unable to use ml model as a detector, will attempt to evaluate as segmenter",
+			"model", params.ModelName, "error", err)
 	} else {
 		err = checkIfDetectorWorks(ctx, detectorFunc)
 		if err != nil {
 			detectorFunc = nil
-			logger.Debugw("unable to use ml model as a detector, will attempt to evaluate as segmenter", "model", params.ModelName, "error", err)
+			logger.Debugw("unable to use ml model as a detector, will attempt to evaluate as segmenter",
+				"model", params.ModelName, "error", err)
 		} else {
 			logger.Infow("model fulfills a vision service detector", "model", params.ModelName)
 		}


### PR DESCRIPTION
Change wording of info logs in mlmodel to lessen confusion and make it easier for users to find errors