### PR TITLE
RSDK-2914 Remove tailwind styles from main-lib, stop emit declarations for non lib files 

### DIFF
--- a/web/frontend/README.md
+++ b/web/frontend/README.md
@@ -35,3 +35,17 @@ The file paths listed in the `files` field of `package.json` determines what is 
 ### Using the NPM Package
 
 If you intend to use the Remote Control in you own application, consider whether or not your application will be creating its own connection to the robot using the [Viam TypeScript SDK](https://github.com/viamrobotics/viam-typescript-sdk). If so, be aware the Remote Control also creates and manages its own SDK `Client`. If you intend to use the Remote Control _and_ make your own SDK `Client` to make API calls, you will want to make sure you disconnect from your `Client` after each API call so you do not maintain multiple long-running connections to the robot. 
+
+The NPM package _does not_ include styles. Instead, we require `tailwindcss` as a peer dependency, and you must include the NPM package artifacts in your tailwind config:
+
+```js
+// tailwind.config.js
+module.exports = {
+  content: [
+    './components/**/*.{html,js}',
+    './pages/**/*.{html,js}',
+    './node_modules/@viamrobotics/remote-control/**/*.js',
+  ],
+  // ...
+}
+```

--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "1.1.13",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/remote-control",
-      "version": "1.1.13",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@improbable-eng/grpc-web": "0.15.0",
@@ -55,6 +55,7 @@
         "@viamrobotics/rpc": "~0.1.*",
         "@viamrobotics/sdk": "0.2.0-pre.1",
         "google-protobuf": "~3.*.*",
+        "tailwindcss": "~3.3.*",
         "three": "~0.152.*",
         "trzy": "0.0.49"
       }

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "1.1.13",
+  "version": "2.0.0",
   "license": "Apache-2.0",
   "type": "module",
   "files": [
@@ -20,6 +20,7 @@
     "@viamrobotics/sdk": "0.2.0-pre.1",
     "google-protobuf": "~3.*.*",
     "three": "~0.152.*",
+    "tailwindcss": "~3.3.*",
     "trzy": "0.0.49"
   },
   "devDependencies": {
@@ -69,7 +70,7 @@
     "start": "node ./node_modules/vite/bin/vite.js --host",
     "build": "node ./node_modules/vite/bin/vite.js build && npm run copy-prime-assets",
     "build-prod": "node ./node_modules/vite/bin/vite.js build --no-sourcemap && npm run copy-prime-assets",
-    "build-npm": "node ./node_modules/vite/bin/vite.js build --config vite.lib.config.ts && vue-tsc --emitDeclarationOnly",
+    "build-npm": "node ./node_modules/vite/bin/vite.js build --config vite.lib.config.ts && vue-tsc --project ./tsconfig.lib.json --emitDeclarationOnly",
     "typecheck": "vue-tsc --noEmit",
     "preview": "vite preview",
     "lint": "eslint 'src/**/*.{ts,js,vue}' --fix --ignore-pattern 'gen/'",

--- a/web/frontend/src/components/remote-control-cards.vue
+++ b/web/frontend/src/components/remote-control-cards.vue
@@ -730,7 +730,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div>
+  <div class="remote-control">
     <div v-if="showAuth">
       <div
         v-if="isConnecting"

--- a/web/frontend/src/index.css
+++ b/web/frontend/src/index.css
@@ -1,62 +1,60 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 @keyframes fadeOut {
   from {
-      opacity: 1
+    opacity: 1;
   }
 
   to {
-      opacity: 0
+    opacity: 0;
   }
 }
 
-.v-toast--fade-out {
-  animation-name: fadeOut
+.remote-control .v-toast--fade-out {
+  animation-name: fadeOut;
 }
 
 @keyframes fadeInDown {
   from {
-      opacity: 0;
-      transform: translate3d(0, -100%, 0)
+    opacity: 0;
+    transform: translate3d(0, -100%, 0);
   }
 
   to {
-      opacity: 1;
-      transform: none
+    opacity: 1;
+    transform: none;
   }
 }
 
-.v-toast--fade-in-down {
-  animation-name: fadeInDown
+.remote-control .v-toast--fade-in-down {
+  animation-name: fadeInDown;
 }
 
 @keyframes fadeInUp {
   from {
-      opacity: 0;
-      transform: translate3d(0, 100%, 0)
+    opacity: 0;
+    transform: translate3d(0, 100%, 0);
   }
 
   to {
-      opacity: 1;
-      transform: none
+    opacity: 1;
+    transform: none;
   }
 }
 
-.v-toast--fade-in-up {
-  animation-name: fadeInUp
+.remote-control .v-toast--fade-in-up {
+  animation-name: fadeInUp;
 }
 
-.fade-enter-active, .fade-leave-active {
-  transition: opacity 150ms ease-out
+.remote-control .fade-enter-active,
+.remote-control .fade-leave-active {
+  transition: opacity 150ms ease-out;
 }
 
-.fade-enter, .fade-leave-to {
-  opacity: 0
+.remote-control .fade-enter,
+.remote-control .fade-leave-to {
+  opacity: 0;
 }
 
-.v-toast {
+.remote-control .v-toast {
   position: fixed;
   display: flex;
   top: 0;
@@ -69,103 +67,110 @@
   pointer-events: none;
 }
 
-.v-toast__item {
+.remote-control .v-toast__item {
   display: inline-flex;
   align-items: center;
   animation-duration: 150ms;
-  margin: .5em 0;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, .12), 0 0 6px rgba(0, 0, 0, .04);
+  margin: 0.5em 0;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12), 0 0 6px rgba(0, 0, 0, 0.04);
   pointer-events: auto;
-  opacity: .92;
+  opacity: 0.92;
   color: #fff;
   min-height: 3em;
   cursor: pointer;
   text-transform: uppercase;
 }
 
-.v-toast__item--success {
-  background-color: #25933C;
+.remote-control .v-toast__item--success {
+  background-color: #25933c;
 }
 
-.v-toast__item--info {
+.remote-control .v-toast__item--info {
   background-color: #000;
 }
 
-.v-toast__item--warning {
+.remote-control .v-toast__item--warning {
   background-color: #000;
 }
 
-.v-toast__item--error {
-  background-color: #D82323;
+.remote-control .v-toast__item--error {
+  background-color: #d82323;
 }
 
-.v-toast__item--default {
+.remote-control .v-toast__item--default {
   background-color: #000;
 }
 
-.v-toast__item.v-toast__item--top, .v-toast__item.v-toast__item--bottom {
-  align-self: center
+.remote-control .v-toast__item.v-toast__item--top,
+.remote-control .v-toast__item.v-toast__item--bottom {
+  align-self: center;
 }
 
-.v-toast__item.v-toast__item--top-right, .v-toast__item.v-toast__item--bottom-right {
-  align-self: flex-end
+.remote-control .v-toast__item.v-toast__item--top-right,
+.remote-control .v-toast__item.v-toast__item--bottom-right {
+  align-self: flex-end;
 }
 
-.v-toast__item.v-toast__item--top-left, .v-toast__item.v-toast__item--bottom-left {
-  align-self: flex-start
+.remote-control .v-toast__item.v-toast__item--top-left,
+.remote-control .v-toast__item.v-toast__item--bottom-left {
+  align-self: flex-start;
 }
 
-.v-toast__text {
+.remote-control .v-toast__text {
   margin: 0;
-  padding: .5em 1em;
-  word-break: break-word
+  padding: 0.5em 1em;
+  word-break: break-word;
 }
 
-.v-toast.v-toast--top {
-  flex-direction: column
+.remote-control .v-toast.v-toast--top {
+  flex-direction: column;
 }
 
-.v-toast.v-toast--bottom {
-  flex-direction: column-reverse
+.remote-control .v-toast.v-toast--bottom {
+  flex-direction: column-reverse;
 }
 
-.v-toast.v-toast--custom-parent {
-  position: absolute
+.remote-control .v-toast.v-toast--custom-parent {
+  position: absolute;
 }
 
 @media screen and (max-width: 768px) {
-  .v-toast {
-      padding: 0;
-      position: fixed !important
+  .remote-control .v-toast {
+    padding: 0;
+    position: fixed !important;
   }
 }
 
-.v-toast__item {
+.remote-control .v-toast__item {
   opacity: 1;
-  min-height: 4em
+  min-height: 4em;
 }
 
-.v-toast__item .v-toast__text {
-  padding: 1.5em 1em
+.remote-control .v-toast__item .v-toast__text {
+  padding: 1.5em 1em;
 }
 
-.v-toast__item .v-toast__icon {
+.remote-control .v-toast__item .v-toast__icon {
   display: block;
   width: 27px;
   min-width: 27px;
   height: 27px;
   margin-left: 1em;
-  background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 45.999 45.999'%3e %3cpath fill='%23fff' d='M39.264 6.736c-8.982-8.981-23.545-8.982-32.528 0-8.982 8.982-8.981 23.545 0 32.528 8.982 8.98 23.545 8.981 32.528 0 8.981-8.983 8.98-23.545 0-32.528zM25.999 33a3 3 0 11-6 0V21a3 3 0 116 0v12zm-3.053-17.128c-1.728 0-2.88-1.224-2.844-2.735-.036-1.584 1.116-2.771 2.879-2.771 1.764 0 2.88 1.188 2.917 2.771-.001 1.511-1.152 2.735-2.952 2.735z'/%3e %3c/svg%3e") no-repeat
+  background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 45.999 45.999'%3e %3cpath fill='%23fff' d='M39.264 6.736c-8.982-8.981-23.545-8.982-32.528 0-8.982 8.982-8.981 23.545 0 32.528 8.982 8.98 23.545 8.981 32.528 0 8.981-8.983 8.98-23.545 0-32.528zM25.999 33a3 3 0 11-6 0V21a3 3 0 116 0v12zm-3.053-17.128c-1.728 0-2.88-1.224-2.844-2.735-.036-1.584 1.116-2.771 2.879-2.771 1.764 0 2.88 1.188 2.917 2.771-.001 1.511-1.152 2.735-2.952 2.735z'/%3e %3c/svg%3e")
+    no-repeat;
 }
 
-.v-toast__item.v-toast__item--success .v-toast__icon {
-  background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'%3e %3cpath fill='%23fff' d='M26 0C11.664 0 0 11.663 0 26s11.664 26 26 26 26-11.663 26-26S40.336 0 26 0zm14.495 17.329l-16 18a1.997 1.997 0 01-2.745.233l-10-8a2 2 0 012.499-3.124l8.517 6.813L37.505 14.67a2.001 2.001 0 012.99 2.659z'/%3e %3c/svg%3e") no-repeat
+.remote-control .v-toast__item.v-toast__item--success .v-toast__icon {
+  background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52'%3e %3cpath fill='%23fff' d='M26 0C11.664 0 0 11.663 0 26s11.664 26 26 26 26-11.663 26-26S40.336 0 26 0zm14.495 17.329l-16 18a1.997 1.997 0 01-2.745.233l-10-8a2 2 0 012.499-3.124l8.517 6.813L37.505 14.67a2.001 2.001 0 012.99 2.659z'/%3e %3c/svg%3e")
+    no-repeat;
 }
 
-.v-toast__item.v-toast__item--error .v-toast__icon {
-  background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 51.976 51.976'%3e %3cpath fill='%23fff' d='M44.373 7.603c-10.137-10.137-26.632-10.138-36.77 0-10.138 10.138-10.137 26.632 0 36.77s26.632 10.138 36.77 0c10.137-10.138 10.137-26.633 0-36.77zm-8.132 28.638a2 2 0 01-2.828 0l-7.425-7.425-7.778 7.778a2 2 0 11-2.828-2.828l7.778-7.778-7.425-7.425a2 2 0 112.828-2.828l7.425 7.425 7.071-7.071a2 2 0 112.828 2.828l-7.071 7.071 7.425 7.425a2 2 0 010 2.828z'/%3e %3c/svg%3e") no-repeat
+.remote-control .v-toast__item.v-toast__item--error .v-toast__icon {
+  background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 51.976 51.976'%3e %3cpath fill='%23fff' d='M44.373 7.603c-10.137-10.137-26.632-10.138-36.77 0-10.138 10.138-10.137 26.632 0 36.77s26.632 10.138 36.77 0c10.137-10.138 10.137-26.633 0-36.77zm-8.132 28.638a2 2 0 01-2.828 0l-7.425-7.425-7.778 7.778a2 2 0 11-2.828-2.828l7.778-7.778-7.425-7.425a2 2 0 112.828-2.828l7.425 7.425 7.071-7.071a2 2 0 112.828 2.828l-7.071 7.071 7.425 7.425a2 2 0 010 2.828z'/%3e %3c/svg%3e")
+    no-repeat;
 }
 
-.v-toast__item.v-toast__item--warning .v-toast__icon {
-  background: url("data:image/svg+xml,%3csvg viewBox='0 0 52 52' xmlns='http://www.w3.org/2000/svg'%3e %3cpath fill='%23fff' d='M49.466 41.26L29.216 6.85c-.69-1.16-1.89-1.85-3.22-1.85-1.32 0-2.53.69-3.21 1.85L2.536 41.26c-.71 1.2-.72 2.64-.03 3.85.68 1.18 1.89 1.89 3.24 1.89h40.51c1.35 0 2.56-.71 3.23-1.89.7-1.21.69-2.65-.02-3.85zm-25.53-21.405h3.381v3.187l-.724 8.92H24.66l-.725-8.92v-3.187zm2.97 17.344a1.712 1.712 0 01-1.267.543c-.491 0-.914-.181-1.268-.543a1.788 1.788 0 01-.531-1.297c0-.502.176-.935.53-1.297a1.712 1.712 0 011.269-.544c.49 0 .914.181 1.268.544s.53.795.53 1.297c0 .503-.176.934-.53 1.297z'/%3e %3c/svg%3e") no-repeat
+.remote-control .v-toast__item.v-toast__item--warning .v-toast__icon {
+  background: url("data:image/svg+xml,%3csvg viewBox='0 0 52 52' xmlns='http://www.w3.org/2000/svg'%3e %3cpath fill='%23fff' d='M49.466 41.26L29.216 6.85c-.69-1.16-1.89-1.85-3.22-1.85-1.32 0-2.53.69-3.21 1.85L2.536 41.26c-.71 1.2-.72 2.64-.03 3.85.68 1.18 1.89 1.89 3.24 1.89h40.51c1.35 0 2.56-.71 3.23-1.89.7-1.21.69-2.65-.02-3.85zm-25.53-21.405h3.381v3.187l-.724 8.92H24.66l-.725-8.92v-3.187zm2.97 17.344a1.712 1.712 0 01-1.267.543c-.491 0-.914-.181-1.268-.543a1.788 1.788 0 01-.531-1.297c0-.502.176-.935.53-1.297a1.712 1.712 0 011.269-.544c.49 0 .914.181 1.268.544s.53.795.53 1.297c0 .503-.176.934-.53 1.297z'/%3e %3c/svg%3e")
+    no-repeat;
 }

--- a/web/frontend/src/main.ts
+++ b/web/frontend/src/main.ts
@@ -1,5 +1,6 @@
 import { createApp } from 'vue';
 import '@viamrobotics/prime';
+import './tailwind.css';
 import './index.css';
 import App from './app.vue';
 

--- a/web/frontend/src/tailwind.css
+++ b/web/frontend/src/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/web/frontend/tsconfig.lib.json
+++ b/web/frontend/tsconfig.lib.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "src/main.ts",
+    "src/app.vue",
+    "src/tailwind.css"
+  ]
+}

--- a/web/frontend/vite.lib.config.ts
+++ b/web/frontend/vite.lib.config.ts
@@ -4,14 +4,11 @@ import pkg from './package.json';
 import path from 'node:path';
 import url from 'node:url';
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js';
-import { plugins } from './vite.config'
+import { plugins } from './vite.config';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [
-    ...plugins,
-    cssInjectedByJsPlugin(),
-  ],
+  plugins: [...plugins, cssInjectedByJsPlugin()],
   build: {
     minify: true,
     target: 'esnext',
@@ -24,7 +21,7 @@ export default defineConfig({
       fileName: 'rc',
     },
     rollupOptions: {
-      // make sure to externalize deps that shouldn't be bundled into your library
+      // make sure to externalize deps that shouldn't be bundled
       external: Object.keys(pkg.peerDependencies),
       output: {
         inlineDynamicImports: true,
@@ -34,7 +31,10 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@': path.resolve(path.dirname(url.fileURLToPath(import.meta.url)), './src'),
+      '@': path.resolve(
+        path.dirname(url.fileURLToPath(import.meta.url)),
+        './src'
+      ),
     },
   },
 });


### PR DESCRIPTION
We are seeing conflicts in styles from what is declared in RC vs the App by tailwind. For example, we may use a class of `mt-2 sm:mt-0` in app, but once the RC is loaded by clicking on the control tab, its `mt-2` class takes priority and ignores the breakpoint styles of `sm:mt-0`. 

Instead, the RC npm package should not include the styles, and expect `tailwindcss` to be installed as a peer dependency. Furthermore, any project using the package should include its artifacts in their tailwind config `contents`. I added documentation to reflect that.

I also added a `remote-control` class to the root element in the `remote-control-cards` component. This way we can scope all of the `v-toast` override styles to the RC, and they should not affect other projects toast tyles.