### PR TITLE
RSDK-3260: combine home one and two limit switch logic

### DIFF
--- a/components/gantry/oneaxis/oneaxis.go
+++ b/components/gantry/oneaxis/oneaxis.go
@@ -253,6 +253,7 @@ func (g *oneAxis) goToStart(ctx context.Context, percent float64) error {
 	if err := g.motor.GoTo(ctx, g.rpm, x, nil); err != nil {
 		return err
 	}
+	return nil
 }
 
 func (g *oneAxis) gantryToMotorPosition(positions float64) float64 {

--- a/components/gantry/oneaxis/oneaxis.go
+++ b/components/gantry/oneaxis/oneaxis.go
@@ -4,7 +4,6 @@ package oneaxis
 import (
 	"context"
 	"fmt"
-	"math"
 	"time"
 
 	"github.com/edaniels/golog"
@@ -194,9 +193,7 @@ func (g *oneAxis) home(ctx context.Context, np int) error {
 }
 
 func (g *oneAxis) homeLimSwitch(ctx context.Context) error {
-	positionA := math.NaN()
-	positionB := math.NaN()
-	var start float64
+	var positionA, positionB, start float64
 	positionA, err := g.testLimit(ctx, true)
 	if err != nil {
 		return err
@@ -218,7 +215,7 @@ func (g *oneAxis) homeLimSwitch(ctx context.Context) error {
 
 	g.positionLimits = []float64{positionA, positionB}
 	g.positionRange = positionB - positionA
-	if g.positionRange == 0 || g.positionRange == math.NaN() {
+	if g.positionRange == 0 {
 		return errors.New("positionRange is 0 or not a valid number")
 	}
 	g.logger.Debugf("positionA: %0.2f positionB: %0.2f range: %0.2f", g.positionLimits[0], g.positionLimits[1], g.positionRange)

--- a/components/gantry/oneaxis/oneaxis.go
+++ b/components/gantry/oneaxis/oneaxis.go
@@ -216,7 +216,7 @@ func (g *oneAxis) homeLimSwitch(ctx context.Context) error {
 	g.positionLimits = []float64{positionA, positionB}
 	g.positionRange = positionB - positionA
 	if g.positionRange == 0 {
-		return errors.New("positionRange is 0 or not a valid number")
+		g.logger.Error("positionRange is 0 or not a valid number")
 	}
 	g.logger.Debugf("positionA: %0.2f positionB: %0.2f range: %0.2f", g.positionLimits[0], g.positionLimits[1], g.positionRange)
 

--- a/components/gantry/oneaxis/oneaxis.go
+++ b/components/gantry/oneaxis/oneaxis.go
@@ -172,22 +172,18 @@ func (g *oneAxis) home(ctx context.Context, np int) error {
 	defer done()
 	// Mapping one limit switch motor0->limsw0, motor1 ->limsw1, motor 2 -> limsw2
 	// Mapping two limit switch motor0->limSw0,limSw1; motor1->limSw2,limSw3; motor2->limSw4,limSw5
-	switch np {
-	// An axis with one limit switch will go till it hits the limit switch, encode that position as the
-	// zero position of the oneaxis, and adds a second position limit based on the steps per length.
-	case 1:
-		if err := g.homeOneLimSwitch(ctx); err != nil {
+
+	if np > 0 {
+		// An axis with one limit switch will go till it hits the limit switch, encode that position as the
+		// zero position of the oneaxis, and adds a second position limit based on the steps per length.
+		// An axis with two limit switches will go till it hits the first limit switch, encode that position as the
+		// zero position of the oneaxis, then go till it hits the second limit switch, then encode that position as the
+		// at-length position of the oneaxis.
+		if err := g.homeLimSwitch(ctx); err != nil {
 			return err
 		}
-	// An axis with two limit switches will go till it hits the first limit switch, encode that position as the
-	// zero position of the oneaxis, then go till it hits the second limit switch, then encode that position as the
-	// at-length position of the oneaxis.
-	case 2:
-		if err := g.homeTwoLimSwitch(ctx); err != nil {
-			return err
-		}
-	// An axis with an encoder will encode the
-	case 0:
+	} else {
+		// An axis with an encoder will encode the
 		if err := g.homeEncoder(ctx); err != nil {
 			return err
 		}
@@ -195,44 +191,31 @@ func (g *oneAxis) home(ctx context.Context, np int) error {
 	return nil
 }
 
-func (g *oneAxis) homeTwoLimSwitch(ctx context.Context) error {
+func (g *oneAxis) homeLimSwitch(ctx context.Context) error {
 	positionA, err := g.testLimit(ctx, true)
 	if err != nil {
 		return err
 	}
 
-	positionB, err := g.testLimit(ctx, false)
-	if err != nil {
-		return err
+	positionB := 0.0
+	if len(g.limitSwitchPins) > 1 {
+		// Multiple limit switches, get positionB from testLimit
+		positionB, err = g.testLimit(ctx, false)
+		if err != nil {
+			return err
+		}
+	} else {
+		// Only one limit switch, calculate positionB
+		revPerLength := g.lengthMm / g.mmPerRevolution
+		positionB = positionA + revPerLength
 	}
 
 	g.positionLimits = []float64{positionA, positionB}
 	g.positionRange = positionB - positionA
+	g.logger.Debugf("positionA: %0.2f positionB: %0.2f range: %0.2f", g.positionLimits[0], g.positionLimits[1], g.positionRange)
 
-	g.logger.Infof("positionA: %0.2f positionB: %0.2f range: %0.2f", g.positionLimits[0], g.positionLimits[1], g.positionRange)
-
-	// Go backwards so limit stops are not hit.
-	x := g.gantryToMotorPosition(0.8 * g.lengthMm)
-	if err = g.motor.GoTo(ctx, g.rpm, x, nil); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (g *oneAxis) homeOneLimSwitch(ctx context.Context) error {
-	// One pin always and only should go backwards.
-	positionA, err := g.testLimit(ctx, true)
-	if err != nil {
-		return err
-	}
-
-	revPerLength := g.lengthMm / g.mmPerRevolution
-	positionB := positionA + revPerLength
-
-	g.positionLimits = []float64{positionA, positionB}
-
-	// Go backwards so limit stops are not hit.
-	x := g.gantryToMotorPosition(0.2 * g.lengthMm)
+	// Go to middle so limit stops are not hit.
+	x := g.gantryToMotorPosition(0.5 * g.lengthMm)
 	if err = g.motor.GoTo(ctx, g.rpm, x, nil); err != nil {
 		return err
 	}

--- a/components/gantry/oneaxis/oneaxis_test.go
+++ b/components/gantry/oneaxis/oneaxis_test.go
@@ -152,6 +152,7 @@ func TestNewOneAxis(t *testing.T) {
 			Board:           boardName,
 		},
 	}
+
 	_, err = newOneAxis(ctx, deps, fakecfg, logger)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "invalid gantry type: need 1, 2 or 0 pins per axis, have 3 pins")
 

--- a/components/gantry/oneaxis/oneaxis_test.go
+++ b/components/gantry/oneaxis/oneaxis_test.go
@@ -255,7 +255,7 @@ func TestHome(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 }
 
-func TestHomeTwoLimitSwitch(t *testing.T) {
+func TestHomeLimitSwitch(t *testing.T) {
 	ctx := context.Background()
 	logger := golog.NewTestLogger(t)
 	fakegantry := &oneAxis{
@@ -267,7 +267,7 @@ func TestHomeTwoLimitSwitch(t *testing.T) {
 		limitSwitchPins: []string{"1", "2"},
 	}
 
-	err := fakegantry.homeTwoLimSwitch(ctx)
+	err := fakegantry.homeLimSwitch(ctx)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, fakegantry.positionLimits, test.ShouldResemble, []float64{1, 1})
 
@@ -277,7 +277,7 @@ func TestHomeTwoLimitSwitch(t *testing.T) {
 		StopFunc:     func(ctx context.Context, extra map[string]interface{}) error { return nil },
 		PositionFunc: func(ctx context.Context, extra map[string]interface{}) (float64, error) { return 0, getPosErr },
 	}
-	err = fakegantry.homeTwoLimSwitch(ctx)
+	err = fakegantry.homeLimSwitch(ctx)
 	test.That(t, err, test.ShouldBeError, getPosErr)
 
 	fakegantry.motor = &inject.Motor{
@@ -291,7 +291,7 @@ func TestHomeTwoLimitSwitch(t *testing.T) {
 		},
 		StopFunc: func(ctx context.Context, extra map[string]interface{}) error { return nil },
 	}
-	err = fakegantry.homeTwoLimSwitch(ctx)
+	err = fakegantry.homeLimSwitch(ctx)
 	test.That(t, err, test.ShouldNotBeNil)
 
 	fakegantry.motor = &inject.Motor{
@@ -305,7 +305,7 @@ func TestHomeTwoLimitSwitch(t *testing.T) {
 		},
 		StopFunc: func(ctx context.Context, extra map[string]interface{}) error { return errors.New("err") },
 	}
-	err = fakegantry.homeTwoLimSwitch(ctx)
+	err = fakegantry.homeLimSwitch(ctx)
 	test.That(t, err, test.ShouldNotBeNil)
 
 	fakegantry.motor = &inject.Motor{
@@ -319,7 +319,7 @@ func TestHomeTwoLimitSwitch(t *testing.T) {
 		},
 		StopFunc: func(ctx context.Context, extra map[string]interface{}) error { return nil },
 	}
-	err = fakegantry.homeTwoLimSwitch(ctx)
+	err = fakegantry.homeLimSwitch(ctx)
 	test.That(t, err, test.ShouldNotBeNil)
 
 	injectGPIOPin := &inject.GPIOPin{}
@@ -336,7 +336,7 @@ func TestHomeTwoLimitSwitch(t *testing.T) {
 			return injectGPIOPin, nil
 		},
 	}
-	err = fakegantry.homeTwoLimSwitch(ctx)
+	err = fakegantry.homeLimSwitch(ctx)
 	test.That(t, err, test.ShouldNotBeNil)
 
 	fakegantry.board = &inject.Board{
@@ -347,11 +347,11 @@ func TestHomeTwoLimitSwitch(t *testing.T) {
 			return injectGPIOPin, nil
 		},
 	}
-	err = fakegantry.homeTwoLimSwitch(ctx)
+	err = fakegantry.homeLimSwitch(ctx)
 	test.That(t, err, test.ShouldNotBeNil)
 }
 
-func TestHomeOneLimitSwitch(t *testing.T) {
+func TestHomeLimitSwitch2(t *testing.T) {
 	ctx := context.Background()
 	logger := golog.NewTestLogger(t)
 	fakegantry := &oneAxis{
@@ -365,7 +365,7 @@ func TestHomeOneLimitSwitch(t *testing.T) {
 		mmPerRevolution: float64(.1),
 	}
 
-	err := fakegantry.homeOneLimSwitch(ctx)
+	err := fakegantry.homeLimSwitch(ctx)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, fakegantry.positionLimits, test.ShouldResemble, []float64{1, 11})
 
@@ -381,7 +381,7 @@ func TestHomeOneLimitSwitch(t *testing.T) {
 			return 0, getPosErr
 		},
 	}
-	err = fakegantry.homeOneLimSwitch(ctx)
+	err = fakegantry.homeLimSwitch(ctx)
 	test.That(t, err, test.ShouldBeError, getPosErr)
 
 	fakegantry.motor = &inject.Motor{
@@ -395,7 +395,7 @@ func TestHomeOneLimitSwitch(t *testing.T) {
 		},
 		StopFunc: func(ctx context.Context, extra map[string]interface{}) error { return nil },
 	}
-	err = fakegantry.homeOneLimSwitch(ctx)
+	err = fakegantry.homeLimSwitch(ctx)
 	test.That(t, err, test.ShouldNotBeNil)
 
 	injectGPIOPin := &inject.GPIOPin{}
@@ -408,7 +408,7 @@ func TestHomeOneLimitSwitch(t *testing.T) {
 			return injectGPIOPin, nil
 		},
 	}
-	err = fakegantry.homeOneLimSwitch(ctx)
+	err = fakegantry.homeLimSwitch(ctx)
 	test.That(t, err, test.ShouldNotBeNil)
 }
 


### PR DESCRIPTION
Currently there are two functions for homing with limit switches, one for one limit switch and one for two limit switches. This PR combines them into one function called `homeLimSwitch` that internally makes the necessary distinctions between one or two limit switches.