### PR TITLE
[RSDK-3308] Added support for reading digital interrupt pins as input

### DIFF
--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -586,18 +586,16 @@ func (b *sysfsBoard) GPIOPinByName(pinName string) (board.GPIOPin, error) {
 		return b.periphGPIOPinByName(pinName)
 	}
 	// Otherwise, the pins are stored in b.gpios.
-	pin, ok := b.gpios[pinName]
-	if !ok {
-		// check if pin is a digital interrupt
-		interrupt, interruptOk := b.interrupts[pinName]
+	if pin, ok := b.gpios[pinName]; ok {
+		return pin, nil
+	}
 
-		if !interruptOk {
-			return nil, errors.Errorf("cannot find GPIO for unknown pin: %s", pinName)
-		}
-
+	// check if pin is a digital interrupt
+	if interrupt, interruptOk := b.interrupts[pinName]; interruptOk {
 		return &gpioInterruptWrapperPin{*interrupt}, nil
 	}
-	return pin, nil
+
+	return nil, errors.Errorf("cannot find GPIO for unknown pin: %s", pinName)
 }
 
 func (b *sysfsBoard) periphGPIOPinByName(pinName string) (board.GPIOPin, error) {

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -589,9 +589,9 @@ func (b *sysfsBoard) GPIOPinByName(pinName string) (board.GPIOPin, error) {
 	pin, ok := b.gpios[pinName]
 	if !ok {
 		// check if pin is a digital interrupt
-		interrupt, interrupt_ok := b.interrupts[pinName]
+		interrupt, interruptOk := b.interrupts[pinName]
 
-		if !interrupt_ok {
+		if !interruptOk {
 			return nil, errors.Errorf("cannot find GPIO for unknown pin: %s", pinName)
 		}
 

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -588,7 +588,14 @@ func (b *sysfsBoard) GPIOPinByName(pinName string) (board.GPIOPin, error) {
 	// Otherwise, the pins are stored in b.gpios.
 	pin, ok := b.gpios[pinName]
 	if !ok {
-		return nil, errors.Errorf("cannot find GPIO for unknown pin: %s", pinName)
+		// check if pin is a digital interrupt
+		interrupt, interrupt_ok := b.interrupts[pinName]
+
+		if !interrupt_ok {
+			return nil, errors.Errorf("cannot find GPIO for unknown pin: %s", pinName)
+		}
+
+		return &gpioInterruptWrapperPin{*interrupt}, nil
 	}
 	return pin, nil
 }

--- a/components/board/genericlinux/digital_interrupts.go
+++ b/components/board/genericlinux/digital_interrupts.go
@@ -25,6 +25,43 @@ type digitalInterrupt struct {
 	config      *board.DigitalInterruptConfig
 }
 
+// struct to support reading from digital interrupt pins
+type gpioInterruptWrapperPin struct {
+	interrupt digitalInterrupt
+}
+
+func (gp gpioInterruptWrapperPin) Set(
+	ctx context.Context, isHigh bool, extra map[string]interface{},
+) error {
+	return errors.Errorf("cannot set value of a digital interrupt pin")
+}
+
+func (gp gpioInterruptWrapperPin) Get(ctx context.Context, extra map[string]interface{}) (result bool, err error) {
+	value, err := gp.interrupt.line.Value()
+	if err != nil {
+		return false, err
+	}
+
+	// We'd expect value to be either 0 or 1, but any non-zero value should be considered high.
+	return (value != 0), nil
+}
+
+func (gp gpioInterruptWrapperPin) PWM(ctx context.Context, extra map[string]interface{}) (float64, error) {
+	return 0, errors.Errorf("cannot get PWM of a digital interrupt pin")
+}
+
+func (gp gpioInterruptWrapperPin) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[string]interface{}) error {
+	return errors.Errorf("cannot set PWM of a digital interrupt pin")
+}
+
+func (gp gpioInterruptWrapperPin) PWMFreq(ctx context.Context, extra map[string]interface{}) (uint, error) {
+	return 0, errors.Errorf("cannot get PWM freq of a digital interrupt pin")
+}
+
+func (gp gpioInterruptWrapperPin) SetPWMFreq(ctx context.Context, freqHz uint, extra map[string]interface{}) error {
+	return errors.Errorf("cannot set PWM freq of a digital interrupt pin")
+}
+
 func (b *sysfsBoard) createDigitalInterrupt(
 	ctx context.Context,
 	config board.DigitalInterruptConfig,

--- a/components/board/genericlinux/digital_interrupts.go
+++ b/components/board/genericlinux/digital_interrupts.go
@@ -105,7 +105,7 @@ func (di *digitalInterrupt) Close() error {
 	return di.line.Close()
 }
 
-// struct implements GPIOPin to support reading current state of digital interrupt pins as GPIO inputs.
+// struct implements board.GPIOPin to support reading current state of digital interrupt pins as GPIO inputs.
 type gpioInterruptWrapperPin struct {
 	interrupt digitalInterrupt
 }
@@ -130,14 +130,20 @@ func (gp gpioInterruptWrapperPin) PWM(ctx context.Context, extra map[string]inte
 	return 0, errors.New("cannot get PWM of a digital interrupt pin")
 }
 
-func (gp gpioInterruptWrapperPin) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[string]interface{}) error {
+func (gp gpioInterruptWrapperPin) SetPWM(
+	ctx context.Context, dutyCyclePct float64, extra map[string]interface{},
+) error {
 	return errors.New("cannot set PWM of a digital interrupt pin")
 }
 
-func (gp gpioInterruptWrapperPin) PWMFreq(ctx context.Context, extra map[string]interface{}) (uint, error) {
+func (gp gpioInterruptWrapperPin) PWMFreq(
+	ctx context.Context, extra map[string]interface{},
+) (uint, error) {
 	return 0, errors.New("cannot get PWM freq of a digital interrupt pin")
 }
 
-func (gp gpioInterruptWrapperPin) SetPWMFreq(ctx context.Context, freqHz uint, extra map[string]interface{}) error {
+func (gp gpioInterruptWrapperPin) SetPWMFreq(
+	ctx context.Context, freqHz uint, extra map[string]interface{},
+) error {
 	return errors.New("cannot set PWM freq of a digital interrupt pin")
 }

--- a/components/board/genericlinux/digital_interrupts.go
+++ b/components/board/genericlinux/digital_interrupts.go
@@ -25,43 +25,6 @@ type digitalInterrupt struct {
 	config      *board.DigitalInterruptConfig
 }
 
-// struct to support reading from digital interrupt pins.
-type gpioInterruptWrapperPin struct {
-	interrupt digitalInterrupt
-}
-
-func (gp gpioInterruptWrapperPin) Set(
-	ctx context.Context, isHigh bool, extra map[string]interface{},
-) error {
-	return errors.New("cannot set value of a digital interrupt pin")
-}
-
-func (gp gpioInterruptWrapperPin) Get(ctx context.Context, extra map[string]interface{}) (result bool, err error) {
-	value, err := gp.interrupt.line.Value()
-	if err != nil {
-		return false, err
-	}
-
-	// We'd expect value to be either 0 or 1, but any non-zero value should be considered high.
-	return (value != 0), nil
-}
-
-func (gp gpioInterruptWrapperPin) PWM(ctx context.Context, extra map[string]interface{}) (float64, error) {
-	return 0, errors.New("cannot get PWM of a digital interrupt pin")
-}
-
-func (gp gpioInterruptWrapperPin) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[string]interface{}) error {
-	return errors.New("cannot set PWM of a digital interrupt pin")
-}
-
-func (gp gpioInterruptWrapperPin) PWMFreq(ctx context.Context, extra map[string]interface{}) (uint, error) {
-	return 0, errors.New("cannot get PWM freq of a digital interrupt pin")
-}
-
-func (gp gpioInterruptWrapperPin) SetPWMFreq(ctx context.Context, freqHz uint, extra map[string]interface{}) error {
-	return errors.New("cannot set PWM freq of a digital interrupt pin")
-}
-
 func (b *sysfsBoard) createDigitalInterrupt(
 	ctx context.Context,
 	config board.DigitalInterruptConfig,
@@ -140,4 +103,41 @@ func (di *digitalInterrupt) Close() error {
 	// after the line is closed, that's fine.
 	di.cancelFunc()
 	return di.line.Close()
+}
+
+// struct implements GPIOPin to support reading current state of digital interrupt pins as GPIO inputs.
+type gpioInterruptWrapperPin struct {
+	interrupt digitalInterrupt
+}
+
+func (gp gpioInterruptWrapperPin) Set(
+	ctx context.Context, isHigh bool, extra map[string]interface{},
+) error {
+	return errors.New("cannot set value of a digital interrupt pin")
+}
+
+func (gp gpioInterruptWrapperPin) Get(ctx context.Context, extra map[string]interface{}) (result bool, err error) {
+	value, err := gp.interrupt.line.Value()
+	if err != nil {
+		return false, err
+	}
+
+	// We'd expect value to be either 0 or 1, but any non-zero value should be considered high.
+	return (value != 0), nil
+}
+
+func (gp gpioInterruptWrapperPin) PWM(ctx context.Context, extra map[string]interface{}) (float64, error) {
+	return 0, errors.New("cannot get PWM of a digital interrupt pin")
+}
+
+func (gp gpioInterruptWrapperPin) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[string]interface{}) error {
+	return errors.New("cannot set PWM of a digital interrupt pin")
+}
+
+func (gp gpioInterruptWrapperPin) PWMFreq(ctx context.Context, extra map[string]interface{}) (uint, error) {
+	return 0, errors.New("cannot get PWM freq of a digital interrupt pin")
+}
+
+func (gp gpioInterruptWrapperPin) SetPWMFreq(ctx context.Context, freqHz uint, extra map[string]interface{}) error {
+	return errors.New("cannot set PWM freq of a digital interrupt pin")
 }

--- a/components/board/genericlinux/digital_interrupts.go
+++ b/components/board/genericlinux/digital_interrupts.go
@@ -33,7 +33,7 @@ type gpioInterruptWrapperPin struct {
 func (gp gpioInterruptWrapperPin) Set(
 	ctx context.Context, isHigh bool, extra map[string]interface{},
 ) error {
-	return errors.Errorf("cannot set value of a digital interrupt pin")
+	return errors.New("cannot set value of a digital interrupt pin")
 }
 
 func (gp gpioInterruptWrapperPin) Get(ctx context.Context, extra map[string]interface{}) (result bool, err error) {
@@ -47,19 +47,19 @@ func (gp gpioInterruptWrapperPin) Get(ctx context.Context, extra map[string]inte
 }
 
 func (gp gpioInterruptWrapperPin) PWM(ctx context.Context, extra map[string]interface{}) (float64, error) {
-	return 0, errors.Errorf("cannot get PWM of a digital interrupt pin")
+	return 0, errors.New("cannot get PWM of a digital interrupt pin")
 }
 
 func (gp gpioInterruptWrapperPin) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[string]interface{}) error {
-	return errors.Errorf("cannot set PWM of a digital interrupt pin")
+	return errors.New("cannot set PWM of a digital interrupt pin")
 }
 
 func (gp gpioInterruptWrapperPin) PWMFreq(ctx context.Context, extra map[string]interface{}) (uint, error) {
-	return 0, errors.Errorf("cannot get PWM freq of a digital interrupt pin")
+	return 0, errors.New("cannot get PWM freq of a digital interrupt pin")
 }
 
 func (gp gpioInterruptWrapperPin) SetPWMFreq(ctx context.Context, freqHz uint, extra map[string]interface{}) error {
-	return errors.Errorf("cannot set PWM freq of a digital interrupt pin")
+	return errors.New("cannot set PWM freq of a digital interrupt pin")
 }
 
 func (b *sysfsBoard) createDigitalInterrupt(

--- a/components/board/genericlinux/digital_interrupts.go
+++ b/components/board/genericlinux/digital_interrupts.go
@@ -25,7 +25,7 @@ type digitalInterrupt struct {
 	config      *board.DigitalInterruptConfig
 }
 
-// struct to support reading from digital interrupt pins
+// struct to support reading from digital interrupt pins.
 type gpioInterruptWrapperPin struct {
 	interrupt digitalInterrupt
 }


### PR DESCRIPTION
- added struct gpioInterruptWrapperPin to wrap digital interrupts as a GPIOPin
- tested with an encoder component by reading the value of the interrupt pins while turning the encoder and ensuring they go low and high