### PR TITLE
rsdk-fix remove AlwaysRebuild From Roboclaw

### DIFF
--- a/components/motor/roboclaw/roboclaw.go
+++ b/components/motor/roboclaw/roboclaw.go
@@ -204,7 +204,6 @@ func newRoboClaw(conf resource.Config, logger golog.Logger) (motor.Motor, error)
 
 type roboclawMotor struct {
 	resource.Named
-	resource.AlwaysRebuild
 	resource.TriviallyCloseable
 	conn *roboclaw.Roboclaw
 	conf *Config


### PR DESCRIPTION
### Summary
Removing AlwaysRebuild from roboclawMotor since it now has a reconfigure method. 