### PR TITLE
[RSDK-3496] Use a background context for the background goroutine

### DIFF
--- a/components/encoder/ams/ams_as5048.go
+++ b/components/encoder/ams/ams_as5048.go
@@ -125,7 +125,7 @@ func newAS5048Encoder(
 	conf resource.Config,
 	logger *zap.SugaredLogger,
 ) (encoder.Encoder, error) {
-	cancelCtx, cancel := context.WithCancel(ctx)
+	cancelCtx, cancel := context.WithCancel(context.Background())
 	res := &Encoder{
 		Named:        conf.ResourceName().AsNamed(),
 		cancelCtx:    cancelCtx,
@@ -187,7 +187,7 @@ func (enc *Encoder) startPositionLoop(ctx context.Context) error {
 			if enc.cancelCtx.Err() != nil {
 				return
 			}
-			if err := enc.updatePosition(ctx); err != nil {
+			if err := enc.updatePosition(enc.cancelCtx); err != nil {
 				enc.logger.Errorf(
 					"error in position loop (skipping update): %s", err.Error(),
 				)
@@ -276,33 +276,39 @@ func (enc *Encoder) ResetPosition(
 	// on the struct
 	enc.position = 0
 	enc.rotations = 0
+
+	i2cHandle, err := enc.i2cBus.OpenHandle(enc.i2cAddr)
+	if err != nil {
+		return err
+	}
+	defer utils.UncheckedErrorFunc(i2cHandle.Close)
+
 	// clear current zero position
-	err := enc.writeByteDataToBus(ctx, enc.i2cBus, enc.i2cAddr, byte(0x16), byte(0))
-	if err != nil {
+	if err := i2cHandle.WriteByteData(ctx, byte(0x16), byte(0)); err != nil {
 		return err
 	}
-	err = enc.writeByteDataToBus(ctx, enc.i2cBus, enc.i2cAddr, byte(0x17), byte(0))
-	if err != nil {
+	if err := i2cHandle.WriteByteData(ctx, byte(0x17), byte(0)); err != nil {
 		return err
 	}
+
 	// read current position
-	currentMSB, err := enc.readByteDataFromBus(ctx, enc.i2cBus, enc.i2cAddr, byte(0xFE))
+	currentMSB, err := i2cHandle.ReadByteData(ctx, byte(0xFE))
 	if err != nil {
 		return err
 	}
-	currentLSB, err := enc.readByteDataFromBus(ctx, enc.i2cBus, enc.i2cAddr, byte(0xFF))
+	currentLSB, err := i2cHandle.ReadByteData(ctx, byte(0xFF))
 	if err != nil {
 		return err
 	}
+
 	// write current position to zero register
-	err = enc.writeByteDataToBus(ctx, enc.i2cBus, enc.i2cAddr, byte(0x16), currentMSB)
-	if err != nil {
+	if err := i2cHandle.WriteByteData(ctx, byte(0x16), currentMSB); err != nil {
 		return err
 	}
-	err = enc.writeByteDataToBus(ctx, enc.i2cBus, enc.i2cAddr, byte(0x17), currentLSB)
-	if err != nil {
+	if err := i2cHandle.WriteByteData(ctx, byte(0x17), currentLSB); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -335,19 +341,4 @@ func (enc *Encoder) readByteDataFromBus(ctx context.Context, bus board.I2C, addr
 		}
 	}()
 	return i2cHandle.ReadByteData(ctx, register)
-}
-
-// writeByteDataToBus opens a handle for the bus adhoc to perform a single write.
-// The handle is closed at the end.
-func (enc *Encoder) writeByteDataToBus(ctx context.Context, bus board.I2C, addr, register, data byte) error {
-	i2cHandle, err := bus.OpenHandle(addr)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := i2cHandle.Close(); err != nil {
-			enc.logger.Error(err)
-		}
-	}()
-	return i2cHandle.WriteByteData(ctx, register, data)
 }

--- a/components/encoder/incremental/incremental_encoder.go
+++ b/components/encoder/incremental/incremental_encoder.go
@@ -94,12 +94,9 @@ func NewIncrementalEncoder(
 	conf resource.Config,
 	logger golog.Logger,
 ) (encoder.Encoder, error) {
-	cancelCtx, cancelFunc := context.WithCancel(ctx)
 	e := &Encoder{
 		Named:        conf.ResourceName().AsNamed(),
 		logger:       logger,
-		CancelCtx:    cancelCtx,
-		cancelFunc:   cancelFunc,
 		position:     0,
 		positionType: encoder.PositionTypeTicks,
 		pRaw:         0,
@@ -153,7 +150,7 @@ func (e *Encoder) Reconfigure(
 		return nil
 	}
 	utils.UncheckedError(e.Close(ctx))
-	cancelCtx, cancelFunc := context.WithCancel(ctx)
+	cancelCtx, cancelFunc := context.WithCancel(context.Background())
 	e.CancelCtx = cancelCtx
 	e.cancelFunc = cancelFunc
 

--- a/components/encoder/incremental/incremental_encoder.go
+++ b/components/encoder/incremental/incremental_encoder.go
@@ -94,9 +94,12 @@ func NewIncrementalEncoder(
 	conf resource.Config,
 	logger golog.Logger,
 ) (encoder.Encoder, error) {
+	cancelCtx, cancelFunc := context.WithCancel(context.Background())
 	e := &Encoder{
 		Named:        conf.ResourceName().AsNamed(),
 		logger:       logger,
+		CancelCtx:    cancelCtx,
+		cancelFunc:   cancelFunc,
 		position:     0,
 		positionType: encoder.PositionTypeTicks,
 		pRaw:         0,

--- a/components/encoder/single/single_encoder.go
+++ b/components/encoder/single/single_encoder.go
@@ -115,7 +115,7 @@ func NewSingleEncoder(
 	conf resource.Config,
 	logger golog.Logger,
 ) (encoder.Encoder, error) {
-	cancelCtx, cancelFunc := context.WithCancel(ctx)
+	cancelCtx, cancelFunc := context.WithCancel(context.Background())
 	e := &Encoder{
 		Named:        conf.ResourceName().AsNamed(),
 		logger:       logger,
@@ -163,7 +163,7 @@ func (e *Encoder) Reconfigure(
 		return nil
 	}
 	utils.UncheckedError(e.Close(ctx))
-	cancelCtx, cancelFunc := context.WithCancel(ctx)
+	cancelCtx, cancelFunc := context.WithCancel(context.Background())
 	e.CancelCtx = cancelCtx
 	e.cancelFunc = cancelFunc
 


### PR DESCRIPTION
Tried on a Jetson Orin Nano (not the Orin AGX! The new, smaller one). Everything seems to work, though I was unable to reproduce the original problem behavior. I was able to set up an incremental encoder, then swap the two pins so it needs to go through Reconfiguration, and things continued to work afterwards (and the encoder even kept its position, rather than resetting to 0 during reconfiguration! On the main branch, the position resets to 0 during reconfiguration). 

I'm a little surprised that you need to create the context twice, but it does make other things easier. During reconfiguration, we shut down the background goroutine if any is running by cancelling the context, then start up a new one with a new context after we're done reconfiguring. We call `Reconfigure` from within `NewIncrementalEncoder` so that we only set up the struct in one place (in `Reconfigure; this is a common pattern in our code). So, if we call Reconfigure when creating the encoder for the very first time, and that cancels the old context, we need an old context created within `NewIncrementalEncoder` before we call `Reconfigure`. and _that's_ why there are two of them.