### PR TITLE
add injected framesystem service to testutils

### DIFF
--- a/components/camera/videosource/join_pointcloud_test.go
+++ b/components/camera/videosource/join_pointcloud_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestInjectedCameras(t *testing.T) {
+	base1 := &inject.Base{}
 	cam1 := &inject.Camera{}
 	cam2 := &inject.Camera{}
 	cam3 := &inject.Camera{}
@@ -47,7 +48,7 @@ func TestInjectedCameras(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		return pc3, nil
 	}
-	base1 := &inject.Base{}
+	// create a very simple frame system
 	fs := inject.NewFrameSystemService()
 	fs.CurrentInputsFunc = func(ctx context.Context) (map[string][]referenceframe.Input, map[string]referenceframe.InputEnabled, error) {
 		return nil, nil, nil // doesn't matter for test

--- a/components/camera/videosource/join_pointcloud_test.go
+++ b/components/camera/videosource/join_pointcloud_test.go
@@ -26,10 +26,11 @@ import (
 )
 
 func TestInjectedCameras(t *testing.T) {
-	base1 := &inject.Base{}
-	cam1 := &inject.Camera{}
-	cam2 := &inject.Camera{}
-	cam3 := &inject.Camera{}
+	base1 := inject.NewBase("base1")
+	cam1 := inject.NewCamera("cam1")
+	cam2 := inject.NewCamera("cam2")
+	cam3 := inject.NewCamera("cam3")
+	fs := inject.NewFrameSystemService()
 	cam1.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
 		pc1 := pointcloud.NewWithPrealloc(1)
 		err := pc1.Set(pointcloud.NewVector(1, 0, 0), pointcloud.NewColoredData(color.NRGBA{255, 0, 0, 255}))
@@ -49,7 +50,6 @@ func TestInjectedCameras(t *testing.T) {
 		return pc3, nil
 	}
 	// create a very simple frame system
-	fs := inject.NewFrameSystemService()
 	fs.CurrentInputsFunc = func(ctx context.Context) (map[string][]referenceframe.Input, map[string]referenceframe.InputEnabled, error) {
 		return nil, nil, nil // doesn't matter for test
 	}
@@ -74,10 +74,10 @@ func TestInjectedCameras(t *testing.T) {
 		return sfs, nil
 	}
 	deps := make(resource.Dependencies)
-	deps[camera.Named("cam1")] = cam1
-	deps[camera.Named("cam2")] = cam2
-	deps[camera.Named("cam3")] = cam3
-	deps[base.Named("base1")] = base1
+	deps[cam1.Name()] = cam1
+	deps[cam2.Name()] = cam2
+	deps[cam3.Name()] = cam3
+	deps[base1.Name()] = base1
 	deps[fs.Name()] = fs
 	// PoV from base1
 	conf := &Config{

--- a/testutils/inject/framesystem.go
+++ b/testutils/inject/framesystem.go
@@ -1,0 +1,109 @@
+package inject
+
+import (
+	"context"
+
+	"go.viam.com/rdk/pointcloud"
+	"go.viam.com/rdk/referenceframe"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/robot/framesystem"
+)
+
+// FrameSystemService represents a fake instance of an framesystem service.
+type FrameSystemService struct {
+	framesystem.Service
+	name              resource.Name
+	TransformPoseFunc func(
+		ctx context.Context,
+		pose *referenceframe.PoseInFrame,
+		dst string,
+		additionalTransforms []*referenceframe.LinkInFrame,
+	) (*referenceframe.PoseInFrame, error)
+	TransformPointCloudFunc func(
+		ctx context.Context,
+		srcpc pointcloud.PointCloud,
+		srcName, dstName string,
+	) (pointcloud.PointCloud, error)
+	CurrentInputsFunc func(ctx context.Context) (map[string][]referenceframe.Input, map[string]referenceframe.InputEnabled, error)
+	FrameSystemFunc   func(
+		ctx context.Context,
+		additionalTransforms []*referenceframe.LinkInFrame,
+	) (referenceframe.FrameSystem, error)
+	DoCommandFunc func(ctx context.Context,
+		cmd map[string]interface{}) (map[string]interface{}, error)
+	CloseFunc func(ctx context.Context) error
+}
+
+// NewFrameSystemService returns a new injected framesystem service.
+func NewFrameSystemService() *FrameSystemService {
+	return &FrameSystemService{name: resource.NewName(framesystem.API, "builtin")}
+}
+
+// Name returns the name of the resource.
+func (fs *FrameSystemService) Name() resource.Name {
+	return fs.name
+}
+
+// TransformPose calls the injected method or the real variant.
+func (fs *FrameSystemService) TransformPose(
+	ctx context.Context,
+	pose *referenceframe.PoseInFrame,
+	dst string,
+	additionalTransforms []*referenceframe.LinkInFrame,
+) (*referenceframe.PoseInFrame, error) {
+	if fs.TransformPoseFunc == nil {
+		return fs.Service.TransformPose(ctx, pose, dst, additionalTransforms)
+	}
+	return fs.TransformPoseFunc(ctx, pose, dst, additionalTransforms)
+}
+
+// TransformPointCloud calls the injected method or the real variant.
+func (fs *FrameSystemService) TransformPointCloud(
+	ctx context.Context,
+	srcpc pointcloud.PointCloud,
+	srcName, dstName string,
+) (pointcloud.PointCloud, error) {
+	if fs.TransformPointCloudFunc == nil {
+		return fs.Service.TransformPointCloud(ctx, srcpc, srcName, dstName)
+	}
+	return fs.TransformPointCloudFunc(ctx, srcpc, srcName, dstName)
+}
+
+// CurrentInputs calls the injected method or the real variant.
+func (fs *FrameSystemService) CurrentInputs(ctx context.Context) (map[string][]referenceframe.Input, map[string]referenceframe.InputEnabled, error) {
+	if fs.CurrentInputsFunc == nil {
+		return fs.Service.CurrentInputs(ctx)
+	}
+	return fs.CurrentInputsFunc(ctx)
+}
+
+func (fs *FrameSystemService) FrameSystem(
+	ctx context.Context,
+	additionalTransforms []*referenceframe.LinkInFrame,
+) (referenceframe.FrameSystem, error) {
+	if fs.FrameSystemFunc == nil {
+		return fs.Service.FrameSystem(ctx, additionalTransforms)
+	}
+	return fs.FrameSystemFunc(ctx, additionalTransforms)
+}
+
+// DoCommand calls the injected DoCommand or the real variant.
+func (fs *FrameSystemService) DoCommand(ctx context.Context,
+	cmd map[string]interface{},
+) (map[string]interface{}, error) {
+	if fs.DoCommandFunc == nil {
+		return fs.Service.DoCommand(ctx, cmd)
+	}
+	return fs.DoCommandFunc(ctx, cmd)
+}
+
+// Close calls the injected Close or the real version.
+func (fs *FrameSystemService) Close(ctx context.Context) error {
+	if fs.CloseFunc == nil {
+		if fs.Service == nil {
+			return nil
+		}
+		return fs.Service.Close(ctx)
+	}
+	return fs.CloseFunc(ctx)
+}

--- a/testutils/inject/framesystem.go
+++ b/testutils/inject/framesystem.go
@@ -72,13 +72,16 @@ func (fs *FrameSystemService) TransformPointCloud(
 }
 
 // CurrentInputs calls the injected method or the real variant.
-func (fs *FrameSystemService) CurrentInputs(ctx context.Context) (map[string][]referenceframe.Input, map[string]referenceframe.InputEnabled, error) {
+func (fs *FrameSystemService) CurrentInputs(ctx context.Context) (
+	map[string][]referenceframe.Input, map[string]referenceframe.InputEnabled, error,
+) {
 	if fs.CurrentInputsFunc == nil {
 		return fs.Service.CurrentInputs(ctx)
 	}
 	return fs.CurrentInputsFunc(ctx)
 }
 
+// FrameSystem calls the injected method of the real variant.
 func (fs *FrameSystemService) FrameSystem(
 	ctx context.Context,
 	additionalTransforms []*referenceframe.LinkInFrame,

--- a/testutils/inject/framesystem.go
+++ b/testutils/inject/framesystem.go
@@ -10,6 +10,8 @@ import (
 )
 
 // FrameSystemService represents a fake instance of an framesystem service.
+// Due to the nature of the FrameSystem service, there should never be more than one on a robot.
+// If you use an injected frame system, do not also create the system's default frame system as well.
 type FrameSystemService struct {
 	framesystem.Service
 	name              resource.Name

--- a/testutils/inject/framesystem.go
+++ b/testutils/inject/framesystem.go
@@ -9,8 +9,8 @@ import (
 	"go.viam.com/rdk/robot/framesystem"
 )
 
-// FrameSystemService represents a fake instance of an framesystem service.
-// Due to the nature of the FrameSystem service, there should never be more than one on a robot.
+// FrameSystemService represents a fake instance of a framesystem service.
+// Due to the nature of the framesystem service, there should never be more than one on a robot.
 // If you use an injected frame system, do not also create the system's default frame system as well.
 type FrameSystemService struct {
 	framesystem.Service


### PR DESCRIPTION
I was writing a talk about testutils and the inject library, and realized we didn't have one for frame system. I made one quickly for the sake of examples, and if people think it's useful, we can merge it.

Some caveats - by the nature of the frame system, it has to have a specific name, and there can only be one on a robot. So someone using an injected frame system in a test shouldn't try to create more than one.