### PR TITLE
RSDK-3207: change the way to check when gantry limit switches are hit

### DIFF
--- a/components/gantry/singleaxis/singleaxis.go
+++ b/components/gantry/singleaxis/singleaxis.go
@@ -22,10 +22,7 @@ import (
 	spatial "go.viam.com/rdk/spatialmath"
 )
 
-var (
-	model = resource.DefaultModelFamily.WithModel("single-axis")
-	wg    sync.WaitGroup
-)
+var model = resource.DefaultModelFamily.WithModel("single-axis")
 
 // limitErrorMargin is added or subtracted from the location of the limit switch to ensure the switch is not passed.
 const limitErrorMargin = 0.25

--- a/components/gantry/singleaxis/singleaxis.go
+++ b/components/gantry/singleaxis/singleaxis.go
@@ -69,7 +69,6 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 	if len(cfg.LimitSwitchPins) > 0 && cfg.LimitPinEnabled == nil {
 		return nil, errors.New("limit pin enabled must be set to true or false")
 	}
-
 	return deps, nil
 }
 
@@ -144,7 +143,8 @@ func (g *singleAxis) Reconfigure(ctx context.Context, deps resource.Dependencies
 	if g.mmPerRevolution <= 0 && len(newConf.LimitSwitchPins) == 1 {
 		return errors.New("gantry with one limit switch per axis needs a mm_per_length ratio defined")
 	}
-	g.frame = conf.Frame.Translation
+	g.frame = r3.Vector{X: 1.0, Y: 0, Z: 0}
+	// TODO: check if frame exists from the config
 	g.rpm = newConf.GantryRPM
 	if g.rpm == 0 {
 		g.rpm = 100

--- a/components/gantry/singleaxis/singleaxis.go
+++ b/components/gantry/singleaxis/singleaxis.go
@@ -101,8 +101,10 @@ type singleAxis struct {
 	model referenceframe.Model
 	frame r3.Vector
 
-	logger golog.Logger
-	opMgr  operation.SingleOperationManager
+	cancelFunc              func()
+	logger                  golog.Logger
+	opMgr                   operation.SingleOperationManager
+	activeBackgroundWorkers sync.WaitGroup
 }
 
 // newSingleAxis creates a new single axis gantry.
@@ -121,6 +123,18 @@ func newSingleAxis(ctx context.Context, deps resource.Dependencies, conf resourc
 func (g *singleAxis) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
 	g.mu.Lock()
 	defer g.mu.Unlock()
+
+	if g.motor != nil {
+		if err := g.motor.Stop(ctx, nil); err != nil {
+			return err
+		}
+	}
+
+	if g.cancelFunc != nil {
+		g.cancelFunc()
+		g.activeBackgroundWorkers.Wait()
+	}
+
 	needsToReHome := false
 	newConf, err := resource.NativeConfig[*Config](conf)
 	if err != nil {
@@ -196,7 +210,78 @@ func (g *singleAxis) Reconfigure(ctx context.Context, deps resource.Dependencies
 		wg.Wait()
 	}
 
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	g.cancelFunc = cancelFunc
+	g.checkHit(ctx)
+
 	return nil
+}
+
+func (g *singleAxis) checkHit(ctx context.Context) {
+	g.activeBackgroundWorkers.Add(1)
+	utils.PanicCapturingGo(func() {
+		defer utils.UncheckedErrorFunc(func() error {
+			g.mu.Lock()
+			defer g.mu.Unlock()
+			return g.motor.Stop(ctx, nil)
+		})
+		defer g.activeBackgroundWorkers.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			for i := 0; i < len(g.limitSwitchPins); i++ {
+				hit, err := g.limitHit(ctx, i)
+				if err != nil {
+					g.logger.Error(err)
+				}
+
+				if hit {
+					child, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+					g.mu.Lock()
+					if err := g.motor.Stop(ctx, nil); err != nil {
+						g.logger.Error(err)
+					}
+					g.mu.Unlock()
+					<-child.Done()
+					cancel()
+					g.mu.Lock()
+					if err := g.moveAway(ctx, i); err != nil {
+						g.logger.Error(err)
+					}
+					g.mu.Unlock()
+				}
+			}
+		}
+	})
+}
+
+// Once a limit switch is hit in any move call (from the motor or the gantry component),
+// this function stops the motor, and reverses the direction of movement until the limit
+// switch is no longer activated.
+func (g *singleAxis) moveAway(ctx context.Context, pin int) error {
+	dir := 1.0
+	if pin != 0 {
+		dir = -1.0
+	}
+	if err := g.motor.GoFor(ctx, dir*g.rpm, 0, nil); err != nil {
+		return err
+	}
+	for {
+		hit, err := g.limitHit(ctx, pin)
+		if err != nil {
+			return err
+		}
+		if !hit {
+			if err := g.motor.Stop(ctx, nil); err != nil {
+				return err
+			}
+			return nil
+		}
+	}
 }
 
 func (g *singleAxis) home(ctx context.Context, np int) error {
@@ -226,14 +311,14 @@ func (g *singleAxis) home(ctx context.Context, np int) error {
 
 func (g *singleAxis) homeLimSwitch(ctx context.Context) error {
 	var positionA, positionB, start float64
-	positionA, err := g.testLimit(ctx, true)
+	positionA, err := g.testLimit(ctx, 0)
 	if err != nil {
 		return err
 	}
 
 	if len(g.limitSwitchPins) > 1 {
 		// Multiple limit switches, get positionB from testLimit
-		positionB, err = g.testLimit(ctx, false)
+		positionB, err = g.testLimit(ctx, 1)
 		if err != nil {
 			return err
 		}
@@ -249,8 +334,9 @@ func (g *singleAxis) homeLimSwitch(ctx context.Context) error {
 	g.positionRange = positionB - positionA
 	if g.positionRange == 0 {
 		g.logger.Error("positionRange is 0 or not a valid number")
+	} else {
+		g.logger.Debugf("positionA: %0.2f positionB: %0.2f range: %0.2f", positionA, positionB, g.positionRange)
 	}
-	g.logger.Debugf("positionA: %0.2f positionB: %0.2f range: %0.2f", g.positionRange)
 
 	// Go to start position so limit stops are not hit.
 	if err = g.goToStart(ctx, start); err != nil {
@@ -291,14 +377,14 @@ func (g *singleAxis) gantryToMotorPosition(positions float64) float64 {
 	return x
 }
 
-func (g *singleAxis) testLimit(ctx context.Context, zero bool) (float64, error) {
+func (g *singleAxis) testLimit(ctx context.Context, pin int) (float64, error) {
 	defer utils.UncheckedErrorFunc(func() error {
 		return g.motor.Stop(ctx, nil)
 	})
 
 	d := -1.0
-	if !zero {
-		d *= -1
+	if pin != 0 {
+		d = 1
 	}
 
 	err := g.motor.GoFor(ctx, d*g.rpm, 0, nil)
@@ -308,7 +394,7 @@ func (g *singleAxis) testLimit(ctx context.Context, zero bool) (float64, error) 
 
 	start := time.Now()
 	for {
-		hit, err := g.limitHit(ctx, zero)
+		hit, err := g.limitHit(ctx, pin)
 		if err != nil {
 			return 0, err
 		}
@@ -337,12 +423,8 @@ func (g *singleAxis) testLimit(ctx context.Context, zero bool) (float64, error) 
 
 // this function may need to be run in the background upon initialisation of the ganty,
 // also may need to use a digital intterupt pin instead of a gpio pin.
-func (g *singleAxis) limitHit(ctx context.Context, zero bool) (bool, error) {
-	offset := 0
-	if !zero {
-		offset = 1
-	}
-	pin, err := g.board.GPIOPinByName(g.limitSwitchPins[offset])
+func (g *singleAxis) limitHit(ctx context.Context, limitPin int) (bool, error) {
+	pin, err := g.board.GPIOPinByName(g.limitSwitchPins[limitPin])
 	if err != nil {
 		return false, err
 	}
@@ -422,7 +504,12 @@ func (g *singleAxis) Stop(ctx context.Context, extra map[string]interface{}) err
 func (g *singleAxis) Close(ctx context.Context) error {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	return g.Stop(ctx, nil)
+	if err := g.Stop(ctx, nil); err != nil {
+		return err
+	}
+	g.cancelFunc()
+	g.activeBackgroundWorkers.Wait()
+	return nil
 }
 
 // IsMoving returns whether the gantry is moving.

--- a/components/gantry/singleaxis/singleaxis.go
+++ b/components/gantry/singleaxis/singleaxis.go
@@ -199,15 +199,9 @@ func (g *singleAxis) Reconfigure(ctx context.Context, deps resource.Dependencies
 	}
 
 	if needsToReHome {
-		wg.Add(1)
-		go func() {
-			// Decrement the counter when the go routine completes
-			defer wg.Done()
-			if err = g.home(ctx, len(newConf.LimitSwitchPins)); err != nil {
-				g.logger.Error(err)
-			}
-		}()
-		wg.Wait()
+		if err = g.home(ctx, len(newConf.LimitSwitchPins)); err != nil {
+			g.logger.Error(err)
+		}
 	}
 
 	ctx, cancelFunc := context.WithCancel(context.Background())

--- a/components/gantry/singleaxis/singleaxis_test.go
+++ b/components/gantry/singleaxis/singleaxis_test.go
@@ -57,7 +57,7 @@ func createFakeBoard() board.Board {
 	pinCount := 0
 	injectGPIOPin := &inject.GPIOPin{
 		GetFunc: func(ctx context.Context, extra map[string]interface{}) (bool, error) {
-			pinCount += 1
+			pinCount++
 			if pinCount%2 == 0 {
 				return false, nil
 			}

--- a/components/gantry/singleaxis/singleaxis_test.go
+++ b/components/gantry/singleaxis/singleaxis_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math"
 	"testing"
+	"time"
 
 	"github.com/edaniels/golog"
 	"github.com/golang/geo/r3"
@@ -45,9 +46,23 @@ func createFakeMotor() motor.Motor {
 	}
 }
 
-func createFakeBoard() board.Board {
+func createLimitBoard() board.Board {
 	injectGPIOPin := &inject.GPIOPin{
 		GetFunc: func(ctx context.Context, extra map[string]interface{}) (bool, error) { return true, nil },
+		SetFunc: func(ctx context.Context, high bool, extra map[string]interface{}) error { return nil },
+	}
+	return &inject.Board{GPIOPinByNameFunc: func(pin string) (board.GPIOPin, error) { return injectGPIOPin, nil }}
+}
+
+func createFakeBoard() board.Board {
+	injectGPIOPin := &inject.GPIOPin{
+		GetFunc: func(ctx context.Context, extra map[string]interface{}) (bool, error) {
+			pinCount := time.Now().Unix()
+			if pinCount%2 == 0 {
+				return false, nil
+			}
+			return true, nil
+		},
 		SetFunc: func(ctx context.Context, high bool, extra map[string]interface{}) error { return nil },
 	}
 	return &inject.Board{GPIOPinByNameFunc: func(pin string) (board.GPIOPin, error) { return injectGPIOPin, nil }}
@@ -98,6 +113,7 @@ func TestNewSingleAxis(t *testing.T) {
 	_, err := newSingleAxis(ctx, deps, fakecfg, logger)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "expected *singleaxis.Config but got <nil>")
 
+	deps = createFakeDepsForTestNewSingleAxis(t)
 	fakecfg = resource.Config{
 		Name:  testGName,
 		Frame: fakeFrame,
@@ -115,6 +131,7 @@ func TestNewSingleAxis(t *testing.T) {
 	_, ok := fakegantry.(*singleAxis)
 	test.That(t, ok, test.ShouldBeTrue)
 
+	deps = createFakeDepsForTestNewSingleAxis(t)
 	fakecfg = resource.Config{
 		Name:  testGName,
 		Frame: fakeFrame,
@@ -133,6 +150,7 @@ func TestNewSingleAxis(t *testing.T) {
 	test.That(t, ok, test.ShouldBeTrue)
 	test.That(t, err, test.ShouldBeNil)
 
+	deps = createFakeDepsForTestNewSingleAxis(t)
 	fakecfg = resource.Config{
 		Name:  testGName,
 		Frame: fakeFrame,
@@ -150,6 +168,7 @@ func TestNewSingleAxis(t *testing.T) {
 	test.That(t, ok, test.ShouldBeFalse)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "gantry with one limit switch per axis needs a mm_per_length ratio defined")
 
+	deps = createFakeDepsForTestNewSingleAxis(t)
 	fakecfg = resource.Config{
 		Name:  testGName,
 		Frame: fakeFrame,
@@ -219,6 +238,7 @@ func TestReconfigure(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	g := fakegantry.(*singleAxis)
 
+	deps = createFakeDepsForTestNewSingleAxis(t)
 	newconf := resource.Config{
 		Name:  testGName,
 		Frame: fakeFrame,
@@ -494,11 +514,11 @@ func TestTestLimit(t *testing.T) {
 	fakegantry := &singleAxis{
 		limitSwitchPins: []string{"1", "2"},
 		motor:           createFakeMotor(),
-		board:           createFakeBoard(),
+		board:           createLimitBoard(),
 		rpm:             float64(300),
 		limitHigh:       true,
 	}
-	pos, err := fakegantry.testLimit(ctx, true)
+	pos, err := fakegantry.testLimit(ctx, 0)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, pos, test.ShouldEqual, float64(1))
 }
@@ -507,11 +527,11 @@ func TestLimitHit(t *testing.T) {
 	ctx := context.Background()
 	fakegantry := &singleAxis{
 		limitSwitchPins: []string{"1", "2", "3"},
-		board:           createFakeBoard(),
+		board:           createLimitBoard(),
 		limitHigh:       true,
 	}
 
-	hit, err := fakegantry.limitHit(ctx, true)
+	hit, err := fakegantry.limitHit(ctx, 0)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, hit, test.ShouldEqual, true)
 }

--- a/components/gantry/singleaxis/singleaxis_test.go
+++ b/components/gantry/singleaxis/singleaxis_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"math"
 	"testing"
-	"time"
 
 	"github.com/edaniels/golog"
 	"github.com/golang/geo/r3"
@@ -55,9 +54,10 @@ func createLimitBoard() board.Board {
 }
 
 func createFakeBoard() board.Board {
+	pinCount := 0
 	injectGPIOPin := &inject.GPIOPin{
 		GetFunc: func(ctx context.Context, extra map[string]interface{}) (bool, error) {
-			pinCount := time.Now().Unix()
+			pinCount += 1
 			if pinCount%2 == 0 {
 				return false, nil
 			}

--- a/components/gantry/singleaxis/singleaxis_test.go
+++ b/components/gantry/singleaxis/singleaxis_test.go
@@ -27,6 +27,8 @@ var fakeFrame = &referenceframe.LinkConfig{
 	Translation: r3.Vector{X: 0, Y: 1.0, Z: 0},
 }
 
+var badFrame = &referenceframe.LinkConfig{}
+
 var count = 0
 
 func createFakeMotor() motor.Motor {
@@ -116,7 +118,7 @@ func TestNewSingleAxis(t *testing.T) {
 	deps = createFakeDepsForTestNewSingleAxis(t)
 	fakecfg = resource.Config{
 		Name:  testGName,
-		Frame: fakeFrame,
+		Frame: badFrame,
 		ConvertedAttributes: &Config{
 			Motor:           motorName,
 			LimitSwitchPins: []string{"1", "2"},


### PR DESCRIPTION
This PR implements a background loop that is constantly checking if a limit switch is hit. If so, the motor will move in the opposite direction until the limit switch is no longer hit. This works for all types of movement so the motor move commands will now stopped if a limit switch is hit (in addition to the gantry move commands). I am not 100% confident on the all of the `context` stuff so would appreciate a close look at the structure of that specifically.

RSDK-3533 is also addressed in this PR