### PR TITLE
Migrate arm to Svelte and avoid unnecessary DOM element creation / network requests

### DIFF
--- a/web/frontend/src/api/movement-sensor.ts
+++ b/web/frontend/src/api/movement-sensor.ts
@@ -5,11 +5,12 @@ import type { commonApi } from '@viamrobotics/sdk';
 import { rcLogConditionally } from '@/lib/log';
 
 export const getProperties = (client: Client, name: string) => {
-  return new Promise<movementSensorApi.GetPropertiesResponse.AsObject | undefined>((resolve, reject) => {
-    const req = new movementSensorApi.GetPropertiesRequest();
-    req.setName(name);
+  const req = new movementSensorApi.GetPropertiesRequest();
+  req.setName(name);
 
-    rcLogConditionally(req);
+  rcLogConditionally(req);
+
+  return new Promise<movementSensorApi.GetPropertiesResponse.AsObject | undefined>((resolve, reject) => {
     client.movementSensorService.getProperties(req, new grpc.Metadata(), (error, response) => (
       error ? reject(error) : resolve(response?.toObject())
     ));

--- a/web/frontend/src/api/movement-sensor.ts
+++ b/web/frontend/src/api/movement-sensor.ts
@@ -1,0 +1,95 @@
+
+import { grpc } from '@improbable-eng/grpc-web';
+import { type Client, movementSensorApi } from '@viamrobotics/sdk';
+import type { commonApi } from '@viamrobotics/sdk';
+import { rcLogConditionally } from '@/lib/log';
+
+export const getProperties = (client: Client, name: string) => {
+  return new Promise<movementSensorApi.GetPropertiesResponse.AsObject | undefined>((resolve, reject) => {
+    const req = new movementSensorApi.GetPropertiesRequest();
+    req.setName(name);
+
+    rcLogConditionally(req);
+    client.movementSensorService.getProperties(req, new grpc.Metadata(), (error, response) => (
+      error ? reject(error) : resolve(response?.toObject())
+    ));
+  });
+};
+
+export const getOrientation = (client: Client, name: string) => {
+  const req = new movementSensorApi.GetOrientationRequest();
+  req.setName(name);
+
+  rcLogConditionally(req);
+
+  return new Promise<commonApi.Orientation.AsObject | undefined>((resolve, reject) => {
+    client.movementSensorService.getOrientation(req, new grpc.Metadata(), (error, response) => (
+      error ? reject(error) : resolve(response?.toObject().orientation)
+    ));
+  });
+};
+
+export const getAngularVelocity = (client: Client, name: string) => {
+  const req = new movementSensorApi.GetAngularVelocityRequest();
+  req.setName(name);
+
+  rcLogConditionally(req);
+
+  return new Promise<commonApi.Vector3.AsObject | undefined>((resolve, reject) => {
+    client.movementSensorService.getAngularVelocity(req,new grpc.Metadata(), (error, response) => (
+      error ? reject(error) : resolve(response?.toObject().angularVelocity)
+    ));
+  });
+};
+
+export const getLinearAcceleration = (client: Client, name: string) => {
+  const req = new movementSensorApi.GetLinearAccelerationRequest();
+  req.setName(name);
+
+  rcLogConditionally(req);
+
+  return new Promise<commonApi.Vector3.AsObject | undefined>((resolve, reject) => {
+    client.movementSensorService.getLinearAcceleration(req, new grpc.Metadata(), (error, response) => (
+      error ? reject(error) : resolve(response?.toObject().linearAcceleration)
+    ));
+  });
+};
+
+export const getLinearVelocity = (client: Client, name: string) => {
+  const req = new movementSensorApi.GetLinearVelocityRequest();
+  req.setName(name);
+
+  rcLogConditionally(req);
+
+  return new Promise<commonApi.Vector3.AsObject | undefined>((resolve, reject) => {
+    client.movementSensorService.getLinearVelocity(req, new grpc.Metadata(), (error, response) => (
+      error ? reject(error) : resolve(response?.toObject().linearVelocity)
+    ));
+  });
+};
+
+export const getCompassHeading = (client: Client, name: string) => {
+  const req = new movementSensorApi.GetCompassHeadingRequest();
+  req.setName(name);
+
+  rcLogConditionally(req);
+
+  return new Promise<number | undefined>((resolve, reject) => {
+    client.movementSensorService.getCompassHeading(req, new grpc.Metadata(), (error, response) => (
+      error ? reject(error) : resolve(response?.toObject().value)
+    ));
+  });
+};
+
+export const getPosition = (client: Client, name: string) => {
+  const req = new movementSensorApi.GetPositionRequest();
+  req.setName(name);
+
+  rcLogConditionally(req);
+
+  return new Promise<movementSensorApi.GetPositionResponse.AsObject | undefined>((resolve, reject) => {
+    client.movementSensorService.getPosition(req, new grpc.Metadata(), (error, response) => (
+      error ? reject(error) : resolve(response?.toObject())
+    ));
+  });
+};

--- a/web/frontend/src/api/movement-sensor.ts
+++ b/web/frontend/src/api/movement-sensor.ts
@@ -37,7 +37,7 @@ export const getAngularVelocity = (client: Client, name: string) => {
   rcLogConditionally(req);
 
   return new Promise<commonApi.Vector3.AsObject | undefined>((resolve, reject) => {
-    client.movementSensorService.getAngularVelocity(req,new grpc.Metadata(), (error, response) => (
+    client.movementSensorService.getAngularVelocity(req, new grpc.Metadata(), (error, response) => (
       error ? reject(error) : resolve(response?.toObject().angularVelocity)
     ));
   });

--- a/web/frontend/src/components/audio-input/index.svelte
+++ b/web/frontend/src/components/audio-input/index.svelte
@@ -3,6 +3,7 @@
 import { StreamClient } from '@viamrobotics/sdk';
 import type { Client, ServiceError } from '@viamrobotics/sdk';
 import { displayError } from '@/lib/error';
+import Collapse from '@/components/collapse.svelte';
 
 export let name: string;
 export let client: Client;
@@ -48,7 +49,7 @@ const toggleExpand = async () => {
 
 </script>
 
-<v-collapse title={name}>
+<Collapse title={name}>
   <v-breadcrumbs slot="title" crumbs="audio_input" />
   <div class="h-auto border border-t-0 border-medium p-2">
     <div class="container mx-auto">
@@ -73,4 +74,4 @@ const toggleExpand = async () => {
       </div>
     </div>
   </div>
-</v-collapse>
+</Collapse>

--- a/web/frontend/src/components/base.vue
+++ b/web/frontend/src/components/base.vue
@@ -458,7 +458,6 @@ onUnmounted(() => {
           </div>
         </div>
         <div
-          data-parent="base"
           class="justify-start gap-4 border-medium p-4 sm:border-l"
           :class="selectedView === 'Stacked' ? 'flex flex-col' : 'grid grid-cols-2 gap-4'"
         >

--- a/web/frontend/src/components/camera/index.svelte
+++ b/web/frontend/src/components/camera/index.svelte
@@ -8,6 +8,7 @@ import type {
 
 import Camera from './camera.svelte';
 import PCD from '../pcd/index.svelte';
+import Collapse from '../collapse.svelte';
 import { selectedMap } from '@/lib/camera-state';
 import type { StreamManager } from './stream-manager';
 
@@ -40,11 +41,7 @@ const handleRefreshInput = (name: string) => {
 </script>
 
 {#each resources as camera (camera.name)}
-  <v-collapse
-    title={camera.name}
-    class="camera"
-    data-parent="app"
-  >
+  <Collapse title={camera.name}>
     <v-breadcrumbs
       slot="title"
       crumbs="camera"
@@ -96,5 +93,5 @@ const handleRefreshInput = (name: string) => {
         cameraName={camera.name}
       />
     </div>
-  </v-collapse>
+  </Collapse>
 {/each}

--- a/web/frontend/src/components/motor/index.svelte
+++ b/web/frontend/src/components/motor/index.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 
-import { onMount } from 'svelte';
 import { Client, motorApi, MotorClient, type ServiceError } from '@viamrobotics/sdk';
 import { displayError } from '@/lib/error';
 import { rcLogConditionally } from '@/lib/log';
+import Collapse from '../collapse.svelte';
 
 const motorPosFormat = new Intl.NumberFormat(undefined, {
   maximumFractionDigits: 3,
@@ -126,17 +126,21 @@ const motorStop = async () => {
   }
 };
 
-onMount(async () => {
+const handleToggle = async (event: CustomEvent<{ open: boolean }>) => {
+  if (event.detail.open === false) {
+    return
+  }
+
   try {
     properties = await motorClient.getProperties();
   } catch (error) {
     displayError(error as ServiceError);
   }
-});
+}
 
 </script>
 
-<v-collapse title={name}>
+<Collapse title={name} on:toggle={handleToggle}>
   <v-breadcrumbs crumbs="motor" slot="title" />
   <div class="flex items-center justify-between gap-2" slot="header">
     {#if properties?.positionReporting}
@@ -251,4 +255,4 @@ onMount(async () => {
       </div>
     </div>
   </div>
-</v-collapse>
+</Collapse>

--- a/web/frontend/src/components/movement-sensor/index.svelte
+++ b/web/frontend/src/components/movement-sensor/index.svelte
@@ -40,8 +40,6 @@ const refresh = async () => {
       properties.positionSupported ? getPosition(client, name): undefined,
     ] as const)
 
-    console.log(results)
-
     orientation = results[0]
     angularVelocity = results[1]
     linearAcceleration = results[2]

--- a/web/frontend/src/components/operations-sessions/index.svelte
+++ b/web/frontend/src/components/operations-sessions/index.svelte
@@ -4,6 +4,7 @@ import { grpc } from '@improbable-eng/grpc-web';
 import { Client, robotApi } from '@viamrobotics/sdk';
 import { displayError } from '@/lib/error';
 import { rcLogConditionally } from '@/lib/log';
+import Collapse from '../collapse.svelte';
 
 export let operations: { op: robotApi.Operation.AsObject; elapsed: number }[];
 export let sessions: robotApi.Session.AsObject[];
@@ -40,7 +41,7 @@ const peerConnectionType = (info?: robotApi.PeerConnectionInfo.AsObject) => {
 
 </script>
 
-<v-collapse title={sessionsSupported ? 'Operations & Sessions' : 'Operations'}>
+<Collapse title={sessionsSupported ? 'Operations & Sessions' : 'Operations'}>
   <div class="border border-t-0 border-medium p-4 text-xs">
     <div class="mb-4 flex gap-2 justify-end items-center">
       <label>RTT:</label>
@@ -124,4 +125,4 @@ const peerConnectionType = (info?: robotApi.PeerConnectionInfo.AsObject) => {
       </div>
     {/if}
   </div>
-</v-collapse>
+</Collapse>

--- a/web/frontend/src/components/remote-control-cards.vue
+++ b/web/frontend/src/components/remote-control-cards.vue
@@ -27,7 +27,7 @@ import {
   filterComponentsWithNames,
 } from '../lib/resource';
 
-import Arm from './arm.vue';
+import ArmSvelte from './arm/index.svelte';
 import AudioInputSvelte from './audio-input/index.svelte';
 import Base from './base.vue';
 import Board from './board.vue';
@@ -47,6 +47,7 @@ import Sensors from './sensors.vue';
 import Slam from './slam/index.vue';
 import { svelteAdapter } from '../lib/svelte-adapter';
 
+const Arm = svelteAdapter(ArmSvelte);
 const AudioInput = svelteAdapter(AudioInputSvelte);
 const CamerasList = svelteAdapter(CamerasListSvelte, { display: 'flex', 'flex-direction': 'column', gap: '1rem' });
 const Motor = svelteAdapter(MotorSvelte);
@@ -826,7 +827,7 @@ onUnmounted(() => {
         :name="arm.name"
         :client="client"
         :status="(resourceStatusByName(arm) as any)"
-        :raw-status="(rawResourceStatusByName(arm) as any)"
+        :rawStatus="(rawResourceStatusByName(arm) as any)"
       />
 
       <!-- ******* GRIPPER *******  -->

--- a/web/frontend/src/components/servo/index.svelte
+++ b/web/frontend/src/components/servo/index.svelte
@@ -4,6 +4,7 @@ import { grpc } from '@improbable-eng/grpc-web';
 import { Client, type ServiceError, servoApi } from '@viamrobotics/sdk';
 import { displayError } from '@/lib/error';
 import { rcLogConditionally } from '@/lib/log';
+    import Collapse from '../collapse.svelte';
 
 export let name: string;
 export let status: servoApi.Status.AsObject;
@@ -40,7 +41,7 @@ const move = (amount: number) => {
 
 </script>
 
-<v-collapse title={name} class="servo">
+<Collapse title={name}>
   <v-breadcrumbs slot="title" crumbs="servo" />
   <v-button
     slot="header"
@@ -59,4 +60,4 @@ const move = (amount: number) => {
       <v-button label="10" on:click={() => move(10)} />
     </div>
   </div>
-</v-collapse>
+</Collapse>

--- a/web/frontend/src/components/servo/index.svelte
+++ b/web/frontend/src/components/servo/index.svelte
@@ -4,7 +4,7 @@ import { grpc } from '@improbable-eng/grpc-web';
 import { Client, type ServiceError, servoApi } from '@viamrobotics/sdk';
 import { displayError } from '@/lib/error';
 import { rcLogConditionally } from '@/lib/log';
-    import Collapse from '../collapse.svelte';
+import Collapse from '../collapse.svelte';
 
 export let name: string;
 export let status: servoApi.Status.AsObject;

--- a/web/frontend/src/lib/error.ts
+++ b/web/frontend/src/lib/error.ts
@@ -1,17 +1,23 @@
 import type { ServiceError } from '@viamrobotics/sdk';
 import { toast } from './toast';
 
+const nonUserErrors = new Set(['Response closed without headers']);
+
 export const isServiceError = (error: unknown): boolean => {
   return error instanceof Object && error && 'message' in error && 'code' in error && 'metadata' in error;
 };
 
 export const displayError = (error: ServiceError | string | null) => {
-  if (error instanceof String) {
-    toast.error(error as string);
+  if (typeof error === 'string') {
+    if (!nonUserErrors.has(error)) {
+      toast.error(error);
+    }
     console.error(error);
   } else if (isServiceError(error)) {
     const serviceError = error as ServiceError;
-    toast.error(serviceError.message);
+    if (!nonUserErrors.has(serviceError.message)) {
+      toast.error(serviceError.message);
+    }
     console.error(serviceError);
   }
 };


### PR DESCRIPTION
This PR migrates `arm.vue` to Svelte and adds a few optimizations to all migrated svelte components:

* Wraps them in an improved `<Collapse>` which does not render any DOM elements until opened. Doing this has so far reduced the amount of elements rendered at app startup from ~1,600 to ~800 for the default fake config. We'll be able to further reduce this when all components are migrated and these optimizations will be backported to PRIME when the migration is complete. This optimization so far raised us about 5 points in lighthouse's performance tab (45/100).
* If a svelte component polls for updates, polling only starts once a `<Collapse>` has been opened for that specific component.