### PR TITLE
[RSDK-3341] shorten-TestFakeSLAMStateful-remove-skip

### DIFF
--- a/services/slam/fake/data_loader.go
+++ b/services/slam/fake/data_loader.go
@@ -39,8 +39,9 @@ type position struct {
 	Extra              extra  `json:"extra"`
 }
 
+var maxDataCount = 24
+
 const (
-	maxDataCount          = 24
 	internalStateTemplate = "%s/internal_state/internal_state_%d.pbstream"
 	pcdTemplate           = "%s/pointcloud/pointcloud_%d.pcd"
 	positionTemplate      = "%s/position/position_%d.json"

--- a/services/slam/fake/slam_test.go
+++ b/services/slam/fake/slam_test.go
@@ -45,11 +45,13 @@ func TestFakeSLAMGetPosition(t *testing.T) {
 func TestFakeSLAMStateful(t *testing.T) {
 	t.Run("Test getting a PCD map via streaming APIs advances the test data", func(t *testing.T) {
 		orgMaxDataCount := maxDataCount
+		defer func() {
+			maxDataCount = orgMaxDataCount
+		}()
 		// maxDataCount lowered under test to reduce test runtime
 		maxDataCount = 5
 		slamSvc := &SLAM{Named: slam.Named("test").AsNamed(), logger: golog.NewTestLogger(t)}
 		verifyGetPointCloudMapStateful(t, slamSvc)
-		maxDataCount = orgMaxDataCount
 	})
 }
 

--- a/services/slam/fake/slam_test.go
+++ b/services/slam/fake/slam_test.go
@@ -43,10 +43,13 @@ func TestFakeSLAMGetPosition(t *testing.T) {
 }
 
 func TestFakeSLAMStateful(t *testing.T) {
-	t.Skip("Skipping this test because it takes too long. Re-enable in RSDK-3341")
 	t.Run("Test getting a PCD map via streaming APIs advances the test data", func(t *testing.T) {
+		orgMaxDataCount := maxDataCount
+		// maxDataCount lowered under test to reduce test runtime
+		maxDataCount = 5
 		slamSvc := &SLAM{Named: slam.Named("test").AsNamed(), logger: golog.NewTestLogger(t)}
 		verifyGetPointCloudMapStateful(t, slamSvc)
+		maxDataCount = orgMaxDataCount
 	})
 }
 


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-3341

- Reduce fake.maxDataCount during fake slam integration test
- Delete skip