### PR TITLE
[RSDK-2782] Move the TI boards off of Periph

### DIFF
--- a/components/board/genericlinux/data.go
+++ b/components/board/genericlinux/data.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/edaniels/golog"
 	"github.com/pkg/errors"
 
 	rdkutils "go.viam.com/rdk/utils"
@@ -87,8 +88,9 @@ func GetGPIOBoardMappings(modelName string, boardInfoMappings map[string]BoardIn
 	}
 	pwmChipsInfo, err := getPwmChipDefs(pinDefs)
 	if err != nil {
-		fmt.Printf("couldn't getPwmChipDefs: %v\n", err)
-		fmt.Println("ERROR: this needs to be logged properly. We were unable to get the PWM chip info. Will continue without it...")
+		// Try continuing on without hardware PWM support. Many boards do not have it enabled by
+		// default, and perhaps this robot doesn't even use it.
+		golog.Global().Debugw("unable to find PWM chips, continuing without them", "error", err)
 		pwmChipsInfo = map[string]pwmChipData{}
 	}
 
@@ -301,7 +303,8 @@ func getBoardMapping(pinDefs []PinDefinition, gpioChipsInfo map[string]gpioChipD
 				// This pin isn't supposed to have hardware PWM support; all is well.
 				pwmChipInfo = dummyPwmInfo
 			} else {
-				fmt.Println("ERROR: log this properly. We're unable to find the PWM chip for this pin, but will continue without it.")
+				golog.Global().Errorw(
+					"cannot find expected hardware PWM chip, continuing without it", "pin", key)
 				pwmChipInfo = dummyPwmInfo
 			}
 		}

--- a/components/board/genericlinux/data.go
+++ b/components/board/genericlinux/data.go
@@ -87,7 +87,9 @@ func GetGPIOBoardMappings(modelName string, boardInfoMappings map[string]BoardIn
 	}
 	pwmChipsInfo, err := getPwmChipDefs(pinDefs)
 	if err != nil {
-		return nil, err
+		fmt.Printf("couldn't getPwmChipDefs: %v\n", err)
+		fmt.Println("ERROR: this needs to be logged properly. We were unable to get the PWM chip info. Will continue without it...")
+		pwmChipsInfo = map[string]pwmChipData{}
 	}
 
 	mapping, err := getBoardMapping(pinDefs, gpioChipsInfo, pwmChipsInfo)
@@ -299,8 +301,8 @@ func getBoardMapping(pinDefs []PinDefinition, gpioChipsInfo map[string]gpioChipD
 				// This pin isn't supposed to have hardware PWM support; all is well.
 				pwmChipInfo = dummyPwmInfo
 			} else {
-				return nil, fmt.Errorf("unknown PWM device %s for pin %d",
-					pinDef.GPIOChipSysFSDir, key)
+				fmt.Println("ERROR: log this properly. We're unable to find the PWM chip for this pin, but will continue without it.")
+				pwmChipInfo = dummyPwmInfo
 			}
 		}
 

--- a/components/board/ti/board.go
+++ b/components/board/ti/board.go
@@ -22,5 +22,5 @@ func init() {
 		golog.Global().Debugw("error getting ti GPIO board mapping", "error", err)
 	}
 
-	genericlinux.RegisterBoard(modelName, gpioMappings, true)
+	genericlinux.RegisterBoard(modelName, gpioMappings, false)
 }

--- a/components/board/ti/data.go
+++ b/components/board/ti/data.go
@@ -7,8 +7,11 @@ const tiTDA4VM = "ti_tda4vm"
 var boardInfoMappings = map[string]genericlinux.BoardInformation{
 	tiTDA4VM: {
 		[]genericlinux.PinDefinition{
+			// Pins 3 and 5 don't work as GPIO by default; you might need to disable the I2C bus to
+			// use them.
 			{map[int]int{128: 84}, map[int]string{}, "600000.gpio", 3, 2, "GPIO0_84", "", "", -1},
 			{map[int]int{128: 83}, map[int]string{}, "600000.gpio", 5, 3, "GPIO0_83", "", "", -1},
+			// Pin 7 appears to be input-only, due to some sort of hardware limitation.
 			{map[int]int{128: 7}, map[int]string{}, "600000.gpio", 7, 4, "GPIO0_7", "", "", -1},
 			{map[int]int{128: 70}, map[int]string{}, "600000.gpio", 8, 14, "GPIO0_70", "", "", -1},
 			{map[int]int{128: 81}, map[int]string{}, "600000.gpio", 10, 15, "GPIO0_81", "", "", -1},

--- a/utils/hardware_info.go
+++ b/utils/hardware_info.go
@@ -36,7 +36,10 @@ func stringSetFromARM(modelName string) (utils.StringSet, error) {
 		return nil, err
 	}
 
-	return utils.NewStringSet(strings.Split(string(compatiblesRd), "\x00")...), nil
+	compatiblesStr := string(compatiblesRd)
+	// Remove any initial or final null bytes, then split on the rest of them.
+	compatiblesStr = strings.Trim(compatiblesStr, "\x00")
+	return utils.NewStringSet(strings.Split(compatiblesStr, "\x00")...), nil
 }
 
 // A helper function for AMD architecture to process contents of the


### PR DESCRIPTION
One sneaky thing with this is that the PWM chips are not enabled by default, and I haven't figured out how to turn them on yet. This also happens on the raspberry pi's (did you know it's got proper hardware PWMs on a couple pins in addition to the DMA-based stuff on all the other pins!? I didn't until earlier this week), which makes me suspect there are lots of boards that don't enable their PWM chips by default. So, I made that optional: if we can't find the PWM chips we're expecting, we log that fact and then continue on.

Also, when getting the compatible devices from the device tree, we read a list of items separated by null bytes, but need to remember to remove the null byte at the very end (so we don't decide we match on the empty string). 

Tried on a TI board: without this change, none of the pins work at all (@randhid wonders if the last time someone used a TI board was before the genericlinux/sysfsboard component existed? That would explain why Periph doesn't seem to recognize this board at all). With this change, we log some errors about being unable to find the hardware PWM chips (twice as many as you'd expect, because the TI boards also appear compatible with the BeagleBone components), and then all the pins work except for pins 3 and 5 (my guess is that they're part of the I2C bus, and I'd need to disable them to get the GPIO functionality to work properly), and pin 7 is input-only (not sure what's going on with that). All other pins work for all GPIO functions. I couldn't figure out at a glance how to turn on the PWM chips, so I couldn't check if the hardware PWM functionality is there. but our data.go file matches the documentation I can find online, so I'd expect it to work if you can find the correct device tree overlay.