### PR TITLE
RSDK-2929 Add data manager test to verify collector restarts when a resource changes

### DIFF
--- a/services/datamanager/builtin/capture_test.go
+++ b/services/datamanager/builtin/capture_test.go
@@ -282,7 +282,7 @@ func passTime(ctx context.Context, mc *clk.Mock, interval time.Duration) chan st
 	return done
 }
 
-// testFilesContainSensorData verifies that the files in `dir` contain sensor data, and that there are `expectedUniqueDataValues` num of unique datapoints.
+// testFilesContainSensorData verifies that the files in `dir` contain sensor data, and calls `validateSensorData` on the data.
 func testFilesContainSensorData(t *testing.T, dir string, validateSensorData func(*testing.T, []*v1.SensorData)) {
 	t.Helper()
 	var sd []*v1.SensorData

--- a/services/datamanager/builtin/capture_test.go
+++ b/services/datamanager/builtin/capture_test.go
@@ -31,8 +31,6 @@ var (
 	remoteCollectorConfigPath                   = "services/datamanager/data/fake_robot_with_remote_and_data_manager.json"
 	emptyFileBytesSize                          = 100 // size of leading metadata message
 	captureInterval                             = time.Millisecond * 10
-	initialJmagValue                            = float64(1)
-	updatedJmagValue                            = float64(444)
 )
 
 func TestDataCaptureEnabled(t *testing.T) {
@@ -258,17 +256,17 @@ func TestSwitchResource(t *testing.T) {
 	// Test that sensor data is captured from the new collector.
 	waitForCaptureFilesToExceedNFiles(captureDir, len(getAllFileInfos(captureDir)))
 	testFilesContainSensorData(t, captureDir, func(t *testing.T, sd []*v1.SensorData) {
-		valueSet := map[float64]int{}
+		valueMap := map[float64]int{}
 		for _, d := range sd {
 			jmag := d.GetStruct().GetFields()["Number"].GetStructValue().GetFields()["Dual"].GetStructValue().GetFields()["Jmag"].GetNumberValue()
-			valueSet[jmag]++
+			valueMap[jmag]++
 		}
 		// Each resource's mocked capture method outputs a different value. Assert that we see data captured by the initial arm1 resource as well as the changed resource.
-		test.That(t, len(valueSet), test.ShouldEqual, 2)
-		test.That(t, valueSet[updatedJmagValue], test.ShouldBeGreaterThan, 0)
+		test.That(t, len(valueMap), test.ShouldEqual, 2)
+		test.That(t, valueMap[float64(444)], test.ShouldBeGreaterThan, 0)
 
 		// Assert that the initial arm1 resource isn't capturing any more data.
-		test.That(t, valueSet[initialJmagValue], test.ShouldEqual, len(initialData))
+		test.That(t, valueMap[float64(1)], test.ShouldEqual, len(initialData))
 	})
 
 	cancelPassTime2()

--- a/services/datamanager/builtin/capture_test.go
+++ b/services/datamanager/builtin/capture_test.go
@@ -262,21 +262,21 @@ func TestSwitchResource(t *testing.T) {
 
 	initialData, err := datacapture.SensorDataFromFilePath(filePaths[0])
 	test.That(t, err, test.ShouldBeNil)
-	// Assert that the initial arm1 resource isn't capturing any more data.
-	test.That(t, len(initialData), test.ShouldEqual, len(dataBeforeSwitch))
 	for _, d := range initialData {
 		// Each resource's mocked capture method outputs a different value. Assert that we see the expected data captured by the initial arm1 resource.
 		test.That(t, d.GetStruct().GetFields()["Number"].GetStructValue().GetFields()["Dual"].GetStructValue().GetFields()["Jmag"].GetNumberValue(), test.ShouldEqual, float64(1))
 	}
+	// Assert that the initial arm1 resource isn't capturing any more data.
+	test.That(t, len(initialData), test.ShouldEqual, len(dataBeforeSwitch))
 
 	newData, err := datacapture.SensorDataFromFilePath(filePaths[1])
 	test.That(t, err, test.ShouldBeNil)
-	// Assert that the updated arm1 resource is capturing data.
-	test.That(t, len(newData), test.ShouldBeGreaterThan, 0)
 	for _, d := range newData {
 		// Assert that we see the expected data captured by the updated arm1 resource.
 		test.That(t, d.GetStruct().GetFields()["Number"].GetStructValue().GetFields()["Dual"].GetStructValue().GetFields()["Jmag"].GetNumberValue(), test.ShouldEqual, float64(444))
 	}
+	// Assert that the updated arm1 resource is capturing data.
+	test.That(t, len(newData), test.ShouldBeGreaterThan, 0)
 
 	cancelPassTime2()
 	<-donePassingTime2

--- a/services/datamanager/builtin/capture_test.go
+++ b/services/datamanager/builtin/capture_test.go
@@ -275,6 +275,7 @@ func passTime(ctx context.Context, mc *clk.Mock, interval time.Duration) chan st
 	return done
 }
 
+// testFilesContainSensorData verifies that the files in `dir` contain sensor data, and that there are `expectedUniqueDataValues` num of unique datapoints.
 func testFilesContainSensorData(t *testing.T, dir string, expectedUniqueDataValues int) {
 	t.Helper()
 	var sd []*v1.SensorData
@@ -305,6 +306,7 @@ func testFilesContainSensorData(t *testing.T, dir string, expectedUniqueDataValu
 	test.That(t, len(valueSet), test.ShouldEqual, expectedUniqueDataValues)
 }
 
+// waitForCaptureFilesToExceedN returns once `captureDir` contains more than `n` files.
 func waitForCaptureFilesToExceedN(captureDir string, n int) {
 	totalWait := time.Second * 2
 	waitPerCheck := time.Millisecond * 10

--- a/services/datamanager/builtin/capture_test.go
+++ b/services/datamanager/builtin/capture_test.go
@@ -256,7 +256,7 @@ func TestSwitchResource(t *testing.T) {
 	donePassingTime2 := passTime(passTimeCtx2, mockClock, captureInterval)
 
 	// Test that sensor data is captured from the new collector.
-	waitForCaptureFilesToExceedNFiles(captureDir, len(getAllFileInfos(captureDir))+10)
+	waitForCaptureFilesToExceedNFiles(captureDir, len(getAllFileInfos(captureDir)))
 	testFilesContainSensorData(t, captureDir, func(t *testing.T, sd []*v1.SensorData) {
 		valueSet := map[float64]int{}
 		for _, d := range sd {

--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -87,7 +87,7 @@ func TestSyncEnabled(t *testing.T) {
 			})
 			test.That(t, err, test.ShouldBeNil)
 			mockClock.Add(captureInterval)
-			waitForCaptureFilesToExceedN(tmpDir, 0)
+			waitForCaptureFilesToExceedNFiles(tmpDir, 0)
 			mockClock.Add(syncInterval)
 			var sentReq bool
 			wait := time.After(time.Second)
@@ -121,7 +121,7 @@ func TestSyncEnabled(t *testing.T) {
 			}
 			var sentReqAfterUpdate bool
 			mockClock.Add(captureInterval)
-			waitForCaptureFilesToExceedN(tmpDir, 0)
+			waitForCaptureFilesToExceedNFiles(tmpDir, 0)
 			mockClock.Add(syncInterval)
 			wait = time.After(time.Second)
 			select {

--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -87,7 +87,7 @@ func TestSyncEnabled(t *testing.T) {
 			})
 			test.That(t, err, test.ShouldBeNil)
 			mockClock.Add(captureInterval)
-			waitForCaptureFiles(tmpDir)
+			waitForCaptureFilesToExceedN(tmpDir, 0)
 			mockClock.Add(syncInterval)
 			var sentReq bool
 			wait := time.After(time.Second)
@@ -121,7 +121,7 @@ func TestSyncEnabled(t *testing.T) {
 			}
 			var sentReqAfterUpdate bool
 			mockClock.Add(captureInterval)
-			waitForCaptureFiles(tmpDir)
+			waitForCaptureFilesToExceedN(tmpDir, 0)
 			mockClock.Add(syncInterval)
 			wait = time.After(time.Second)
 			select {


### PR DESCRIPTION
This PR adds a test to verify that when a robot resource changes but all other fields in the DataCaptureConfig stays the same, the data manager captures data using the new collector instead of the old one.

Ticket: https://viam.atlassian.net/browse/RSDK-2929