### PR TITLE
[RSDK-3532] Move some types into type file to allow mac and linux builds

### DIFF
--- a/components/board/genericlinux/data.go
+++ b/components/board/genericlinux/data.go
@@ -14,38 +14,6 @@ import (
 
 // adapted from https://github.com/NVIDIA/jetson-gpio (MIT License)
 
-// GPIOBoardMapping represents a GPIO pin's location locally within a GPIO chip
-// and globally within sysfs.
-type GPIOBoardMapping struct {
-	GPIOChipDev    string
-	GPIO           int
-	GPIOGlobal     int
-	GPIOName       string
-	PWMSysFsDir    string // Absolute path to the directory, empty string for none
-	PWMID          int
-	HWPWMSupported bool
-}
-
-// PinDefinition describes board specific information on how a particular pin can be accessed
-// via sysfs along with information about its PWM capabilities.
-type PinDefinition struct {
-	GPIOChipRelativeIDs map[int]int    // ngpio -> relative id
-	GPIONames           map[int]string // e.g. ngpio=169=PQ.06 for claraAGXXavier
-	GPIOChipSysFSDir    string
-	PinNumberBoard      int
-	PinNumberBCM        int
-	PinNameCVM          string
-	PinNameTegraSOC     string
-	PWMChipSysFSDir     string // empty for none
-	PWMID               int    // -1 for none
-}
-
-// BoardInformation details pin definitions and device compatibility for a particular board.
-type BoardInformation struct {
-	PinDefinitions []PinDefinition
-	Compats        []string
-}
-
 // A NoBoardFoundError is returned when no compatible mapping is found for a board during GPIO board mapping.
 type NoBoardFoundError struct {
 	modelName string
@@ -57,21 +25,6 @@ func (err NoBoardFoundError) Error() string {
 
 func noBoardError(modelName string) error {
 	return fmt.Errorf("could not determine %q model", modelName)
-}
-
-// gpioChipData is a struct used solely within GetGPIOBoardMappings and its sub-pieces. It
-// describes a GPIO chip within sysfs.
-type gpioChipData struct {
-	Dir   string // Pseudofile within sysfs to interact with this chip
-	Base  int    // Taken from the /base pseudofile in sysfs: offset to the start of the lines
-	Ngpio int    // Taken from the /ngpio pseudofile in sysfs: number of lines on the chip
-}
-
-// pwmChipData is a struct used solely within GetGPIOBoardMappings and its sub-pieces. It
-// describes a PWM chip within sysfs.
-type pwmChipData struct {
-	Dir  string // Absolute path to pseudofile within sysfs to interact with this chip
-	Npwm int    // Taken from the /npwm pseudofile in sysfs: number of lines on the chip
 }
 
 // GetGPIOBoardMappings attempts to find a compatible board-pin mapping for the given mappings.

--- a/components/board/genericlinux/pin_types.go
+++ b/components/board/genericlinux/pin_types.go
@@ -1,0 +1,48 @@
+package genericlinux
+
+// GPIOBoardMapping represents a GPIO pin's location locally within a GPIO chip
+// and globally within sysfs.
+type GPIOBoardMapping struct {
+	GPIOChipDev    string
+	GPIO           int
+	GPIOGlobal     int
+	GPIOName       string
+	PWMSysFsDir    string // Absolute path to the directory, empty string for none
+	PWMID          int
+	HWPWMSupported bool
+}
+
+// PinDefinition describes board specific information on how a particular pin can be accessed
+// via sysfs along with information about its PWM capabilities.
+type PinDefinition struct {
+	GPIOChipRelativeIDs map[int]int    // ngpio -> relative id
+	GPIONames           map[int]string // e.g. ngpio=169=PQ.06 for claraAGXXavier
+	GPIOChipSysFSDir    string
+	PinNumberBoard      int
+	PinNumberBCM        int
+	PinNameCVM          string
+	PinNameTegraSOC     string
+	PWMChipSysFSDir     string // empty for none
+	PWMID               int    // -1 for none
+}
+
+// BoardInformation details pin definitions and device compatibility for a particular board.
+type BoardInformation struct {
+	PinDefinitions []PinDefinition
+	Compats        []string
+}
+
+// gpioChipData is a struct used solely within GetGPIOBoardMappings and its sub-pieces. It
+// describes a GPIO chip within sysfs.
+type gpioChipData struct {
+	Dir   string // Pseudofile within sysfs to interact with this chip
+	Base  int    // Taken from the /base pseudofile in sysfs: offset to the start of the lines
+	Ngpio int    // Taken from the /ngpio pseudofile in sysfs: number of lines on the chip
+}
+
+// pwmChipData is a struct used solely within GetGPIOBoardMappings and its sub-pieces. It
+// describes a PWM chip within sysfs.
+type pwmChipData struct {
+	Dir  string // Absolute path to pseudofile within sysfs to interact with this chip
+	Npwm int    // Taken from the /npwm pseudofile in sysfs: number of lines on the chip
+}


### PR DESCRIPTION
- having types in linux-specific files is breaking the mac build, move structs not associated with specific methods into a different file
- checked that it builds on linux and mac