### PR TITLE
Cleanup unused const variables in const blocks

### DIFF
--- a/components/arm/arm_test.go
+++ b/components/arm/arm_test.go
@@ -27,8 +27,7 @@ const (
 	testArmName    = "arm1"
 	testArmName2   = "arm2"
 	failArmName    = "arm3"
-	fakeArmName    = "arm4"
-	missingArmName = "arm5"
+	missingArmName = "arm4"
 )
 
 var pose = spatialmath.NewPoseFromPoint(r3.Vector{X: 1, Y: 2, Z: 3})

--- a/components/arm/xarm/xarm.go
+++ b/components/arm/xarm/xarm.go
@@ -42,10 +42,9 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 }
 
 const (
-	defaultSpeed        = 20. // degrees per second
-	defaultAcceleration = 50. // degrees per second per second.
-	defaultPort         = "502"
-	defaultMoveHz       = 100. // Don't change this
+	defaultSpeed  = 20. // degrees per second
+	defaultPort   = "502"
+	defaultMoveHz = 100. // Don't change this
 )
 
 type xArm struct {

--- a/components/base/base_test.go
+++ b/components/base/base_test.go
@@ -15,11 +15,8 @@ import (
 )
 
 const (
-	testBaseName    = "base1"
-	testBaseName2   = "base2"
-	failBaseName    = "base3"
-	fakeBaseName    = "base4"
-	missingBaseName = "base5"
+	testBaseName = "base1"
+	failBaseName = "base2"
 )
 
 func TestStatusValid(t *testing.T) {

--- a/components/camera/camera_test.go
+++ b/components/camera/camera_test.go
@@ -21,10 +21,8 @@ import (
 const (
 	testCameraName    = "camera1"
 	depthCameraName   = "camera_depth"
-	testCameraName2   = "camera2"
-	failCameraName    = "camera3"
-	fakeCameraName    = "camera4"
-	missingCameraName = "camera5"
+	failCameraName    = "camera2"
+	missingCameraName = "camera3"
 )
 
 type simpleSource struct {

--- a/components/encoder/client_test.go
+++ b/components/encoder/client_test.go
@@ -19,11 +19,9 @@ import (
 )
 
 const (
-	testEncoderName    = "encoder1"
-	testEncoderName2   = "encoder2"
-	failEncoderName    = "encoder3"
-	fakeEncoderName    = "encoder4"
-	missingEncoderName = "encoder5"
+	testEncoderName = "encoder1"
+	failEncoderName = "encoder2"
+	fakeEncoderName = "encoder3"
 )
 
 func TestClient(t *testing.T) {

--- a/components/gantry/gantry_test.go
+++ b/components/gantry/gantry_test.go
@@ -19,8 +19,7 @@ const (
 	testGantryName    = "gantry1"
 	testGantryName2   = "gantry2"
 	failGantryName    = "gantry3"
-	fakeGantryName    = "gantry4"
-	missingGantryName = "gantry5"
+	missingGantryName = "gantry4"
 )
 
 func TestStatusValid(t *testing.T) {

--- a/components/gripper/gripper_test.go
+++ b/components/gripper/gripper_test.go
@@ -16,8 +16,7 @@ const (
 	testGripperName    = "gripper1"
 	testGripperName2   = "gripper2"
 	failGripperName    = "gripper3"
-	fakeGripperName    = "gripper4"
-	missingGripperName = "gripper5"
+	missingGripperName = "gripper4"
 )
 
 func TestCreateStatus(t *testing.T) {

--- a/components/input/input_test.go
+++ b/components/input/input_test.go
@@ -16,10 +16,8 @@ import (
 
 const (
 	testInputControllerName    = "inputController1"
-	testInputControllerName2   = "inputController2"
-	failInputControllerName    = "inputController3"
-	fakeInputControllerName    = "inputController4"
-	missingInputControllerName = "inputController5"
+	failInputControllerName    = "inputController2"
+	missingInputControllerName = "inputController3"
 )
 
 func TestCreateStatus(t *testing.T) {

--- a/components/motor/motor_test.go
+++ b/components/motor/motor_test.go
@@ -16,11 +16,9 @@ import (
 )
 
 const (
-	testMotorName    = "motor1"
-	testMotorName2   = "motor2"
-	failMotorName    = "motor3"
-	fakeMotorName    = "motor4"
-	missingMotorName = "motor5"
+	testMotorName = "motor1"
+	failMotorName = "motor2"
+	fakeMotorName = "motor3"
 )
 
 func TestStatusValid(t *testing.T) {

--- a/components/posetracker/server_test.go
+++ b/components/posetracker/server_test.go
@@ -19,7 +19,6 @@ import (
 const (
 	workingPTName = "workingPT"
 	failingPTName = "failingPT"
-	notPTName     = "notAPT"
 	bodyName      = "body1"
 	bodyFrame     = "bodyFrame"
 )

--- a/pointcloud/basic_octree.go
+++ b/pointcloud/basic_octree.go
@@ -11,7 +11,6 @@ const (
 	internalNode = NodeType(iota)
 	leafNodeEmpty
 	leafNodeFilled
-	octreeVersion = 1.0
 	// This value allows for high level of granularity in the octree while still allowing for fast access times
 	// even on a pi.
 	maxRecursionDepth = 1000

--- a/robot/session_manager.go
+++ b/robot/session_manager.go
@@ -151,9 +151,7 @@ func (m *SessionManager) expireLoop(ctx context.Context) {
 }
 
 const (
-	defaultHeartbeatWindow = 500 * time.Millisecond
-	maxHeartbeatWindow     = time.Minute
-	maxSessions            = 1024
+	maxSessions = 1024
 )
 
 // Start creates a new session that expects at least one heartbeat within the configured window.


### PR DESCRIPTION
While reading through session management code, I noticed that the const `defaultHeartbeatWindow` was set, but was not referenced anywhere else. 

Upon further inspection, this seems to have passed the linter because the `unused` lint does not warn on unused `const` variables if any other variables within the `const` block are used ([some context](https://github.com/dominikh/go-tools/issues/1055)). 

However, the (deprecated) `deadcode` lint does warn on these. I am not suggesting that we re-enable `deadcode` as there is value in declaring (but not using) `consts` (especially in files such as `components/motor/dimensionengineering/common.go` or `components/sensor/bme280/bme280.go` where these values may be useful in the future). 

I have gone through the lints to determine what is reasonable to remove vs what should be kept. Here are the remaining deadcode lints after this PR:
```
components/sensor/bme280/bme280.go:34:2: `bme280T1MSBReg` is unused (deadcode)
	bme280T1MSBReg           = 0x89
	^
components/sensor/bme280/bme280.go:36:2: `bme280T2MSBReg` is unused (deadcode)
	bme280T2MSBReg           = 0x8B
	^
components/sensor/bme280/bme280.go:38:2: `bme280T3MSBReg` is unused (deadcode)
	bme280T3MSBReg           = 0x8D
	^
components/sensor/bme280/bme280.go:40:2: `bme280P1MSBReg` is unused (deadcode)
	bme280P1MSBReg           = 0x8F
	^
components/sensor/bme280/bme280.go:42:2: `bme280P2MSBReg` is unused (deadcode)
	bme280P2MSBReg           = 0x91
	^
components/sensor/bme280/bme280.go:44:2: `bme280P3MSBReg` is unused (deadcode)
	bme280P3MSBReg           = 0x93
	^
components/sensor/bme280/bme280.go:46:2: `bme280P4MSBReg` is unused (deadcode)
	bme280P4MSBReg           = 0x95
	^
components/sensor/bme280/bme280.go:48:2: `bme280P5MSBReg` is unused (deadcode)
	bme280P5MSBReg           = 0x97
	^
components/sensor/bme280/bme280.go:50:2: `bme280P6MSBReg` is unused (deadcode)
	bme280P6MSBReg           = 0x99
	^
components/sensor/bme280/bme280.go:52:2: `bme280P7MSBReg` is unused (deadcode)
	bme280P7MSBReg           = 0x9B
	^
components/sensor/bme280/bme280.go:54:2: `bme280P8MSBReg` is unused (deadcode)
	bme280P8MSBReg           = 0x9D
	^
components/sensor/bme280/bme280.go:56:2: `bme280P9MSBReg` is unused (deadcode)
	bme280P9MSBReg           = 0x9F
	^
components/sensor/bme280/bme280.go:58:2: `bme280CHIPIDReg` is unused (deadcode)
	bme280CHIPIDReg          = 0xD0 // Chip ID
	^
components/sensor/bme280/bme280.go:61:2: `bme280H2MSBReg` is unused (deadcode)
	bme280H2MSBReg           = 0xE2
	^
components/sensor/bme280/bme280.go:72:2: `bme280PressureMSBReg` is unused (deadcode)
	bme280PressureMSBReg     = 0xF7 // Pressure MSB
	^
components/sensor/bme280/bme280.go:73:2: `bme280PressureLSBReg` is unused (deadcode)
	bme280PressureLSBReg     = 0xF8 // Pressure LSB
	^
components/sensor/bme280/bme280.go:74:2: `bme280PressureXLSBReg` is unused (deadcode)
	bme280PressureXLSBReg    = 0xF9 // Pressure XLSB
	^
components/sensor/bme280/bme280.go:75:2: `bme280TemperatureMSBReg` is unused (deadcode)
	bme280TemperatureMSBReg  = 0xFA // Temperature MSB
	^
components/sensor/bme280/bme280.go:76:2: `bme280TemperatureLSBReg` is unused (deadcode)
	bme280TemperatureLSBReg  = 0xFB // Temperature LSB
	^
components/sensor/bme280/bme280.go:77:2: `bme280TemperatureXLSBReg` is unused (deadcode)
	bme280TemperatureXLSBReg = 0xFC // Temperature XLSB
	^
components/sensor/bme280/bme280.go:78:2: `bme280HumidityMSBReg` is unused (deadcode)
	bme280HumidityMSBReg     = 0xFD // Humidity MSB
	^
components/sensor/bme280/bme280.go:79:2: `bme280HumidityLSBReg` is unused (deadcode)
	bme280HumidityLSBReg     = 0xFE // Humidity LSB
	^
components/motor/dimensionengineering/common.go:9:2: `minSpeed` is unused (deadcode)
	minSpeed = 0x0
	^
components/motor/dimensionengineering/common.go:28:2: `opMinVoltage` is unused (deadcode)
	opMinVoltage          opCode = 0x02
	^
components/motor/dimensionengineering/common.go:29:2: `opMaxVoltage` is unused (deadcode)
	opMaxVoltage          opCode = 0x03
	^
components/motor/dimensionengineering/common.go:35:2: `opMultiDriveBackwards` is unused (deadcode)
	opMultiDriveBackwards opCode = 0x09
	^
components/motor/dimensionengineering/common.go:36:2: `opMultiDriveRight` is unused (deadcode)
	opMultiDriveRight     opCode = 0x0a
	^
components/motor/dimensionengineering/common.go:37:2: `opMultiDriveLeft` is unused (deadcode)
	opMultiDriveLeft      opCode = 0x0b
	^
components/motor/dimensionengineering/common.go:39:2: `opMultiTurn` is unused (deadcode)
	opMultiTurn           opCode = 0x0d
	^
components/motor/dimensionengineering/common.go:40:2: `opSerialTimeout` is unused (deadcode)
	opSerialTimeout       opCode = 0x0e
	^
components/motor/dimensionengineering/common.go:41:2: `opSerialBaudRate` is unused (deadcode)
	opSerialBaudRate      opCode = 0x0f
	^
components/motor/dimensionengineering/common.go:43:2: `opDeadband` is unused (deadcode)
	opDeadband            opCode = 0x11
	^
components/movementsensor/gpsnmea/gpsnmea.go:113:2: `connectionType` is unused (deadcode)
	connectionType = "connection_type"
	^
components/movementsensor/gpsnmea/gpsnmea.go:116:2: `rtkStr` is unused (deadcode)
	rtkStr         = "rtk"
	^
components/movementsensor/gpsrtk/serial.go:58:2: `baudRateName` is unused (deadcode)
	baudRateName       = "correction_baud"
```