### PR TITLE
APP-2035 disable svelte/valid-compile.

### DIFF
--- a/web/frontend/.eslintrc.cjs
+++ b/web/frontend/.eslintrc.cjs
@@ -70,7 +70,8 @@ module.exports = {
     },
   },
   rules: {
-    'svelte/valid-compile': 'warn',
+    // TODO(APP-2035): Promote back to error.
+    'svelte/valid-compile': 'off',
   
     // https://github.com/eslint/eslint/issues/13956
     indent: 'off',


### PR DESCRIPTION
`make build lint` was spewing warnings about `a11y-click-events-have-key-events`. Until we clean those up, this disables the rule to reduce the noise. Cleanup tracked in APP-2035.