### PR TITLE
RSDK-2735 change BERT model

### DIFF
--- a/.artifact/tree.json
+++ b/.artifact/tree.json
@@ -52146,6 +52146,10 @@
         "hash": "c042101edfe4f0fad9ff47447bc3f685",
         "size": 51808808
       },
+      "mobilebert_1_default_1.tflite": {
+        "hash": "1446418b1dfd804ce92ee68fafd95470",
+        "size": 100456296
+      },
       "mobilenet.tflite": {
         "hash": "66ee95e3edbaa9b3de5138cf1cbb127d",
         "size": 1866640

--- a/services/mlmodel/tflitecpu/tflite_cpu_test.go
+++ b/services/mlmodel/tflitecpu/tflite_cpu_test.go
@@ -127,18 +127,16 @@ func TestTFLiteCPUClassifier(t *testing.T) {
 }
 
 func TestTFLiteCPUTextModel(t *testing.T) {
-	// TODO(RSDK-2735): remove skip when complete
-	t.Skip("remove skip once RSDK-2735 is complete")
 	// Setup
 	ctx := context.Background()
-	modelLoc := artifact.MustPath("vision/tflite/mobileBERT.tflite")
+	modelLoc := artifact.MustPath("vision/tflite/mobilebert_1_default_1.tflite")
 
 	cfg := TFLiteConfig{ // text classifier config
 		ModelPath:  modelLoc,
 		NumThreads: 1,
 	}
 
-	// Test that even a text classifier gives an output with good input
+	// Test that a text classifier gives an output with good input
 	out, err := NewTFLiteCPUModel(ctx, &cfg, mlmodel.Named("myTextModel"))
 	got := out.(*Model)
 	test.That(t, err, test.ShouldBeNil)
@@ -162,7 +160,6 @@ func TestTFLiteCPUTextModel(t *testing.T) {
 	test.That(t, len(gotOutput), test.ShouldEqual, 2)
 	test.That(t, gotOutput["output0"], test.ShouldNotBeNil)
 	test.That(t, gotOutput["output1"], test.ShouldNotBeNil)
-	test.That(t, gotOutput["output2"], test.ShouldBeNil)
 	test.That(t, len(gotOutput["output0"].([]float32)), test.ShouldEqual, 384)
 	test.That(t, len(gotOutput["output1"].([]float32)), test.ShouldEqual, 384)
 }


### PR DESCRIPTION
**Change to a better BERT model**
This new model still include a Gather() function, but doesn't fail

**Manual tests**
Tested on MacOS with:
- built from source libtensorflowlite_c
- with brew with the default formula for tensorflowltite 2.12
- with [our formula](https://github.com/viamrobotics/homebrew-brews/blob/main/Formula/tensorflowlite.rb)

**Follow-up PR** is removing the older BERT model from artifacts (@kharijarrett :) )