### PR TITLE
APP-2044 Explicitly kill child process on test-e2e exit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Run e2e Tests
         run: |
           chown -R testbot:testbot .
-          sudo -Hu testbot bash -lc 'make build-web test-e2e'
+          sudo -Hu testbot bash -lc 'make build-web test-e2e ARGS="-k false"'
 
   test_passing:
     name: All Tests Passing

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ test-pi:
 
 test-e2e:
 	go build $(LDFLAGS) -o bin/test-e2e/server web/cmd/server/main.go
-	./etc/e2e.sh -o 'run'
+	./etc/e2e.sh -o 'run' $(ARGS)
 
 open-cypress-ui:
 	go build $(LDFLAGS) -o bin/test-e2e/server web/cmd/server/main.go


### PR DESCRIPTION
The child subprocess running the server was not cleaned up when test-e2e exited. This explicitly kills the process as the last step of the script.

Also added flag validation to be sure not to start the server if the required flag was not provided.