### PR TITLE
RSDK-3645: gantry scope config changes

### DIFF
--- a/components/gantry/multiaxis/multiaxis.go
+++ b/components/gantry/multiaxis/multiaxis.go
@@ -20,7 +20,7 @@ var model = resource.DefaultModelFamily.WithModel("multi-axis")
 // Config is used for converting multiAxis config attributes.
 type Config struct {
 	SubAxes            []string `json:"subaxes_list"`
-	MoveSimultaneously *bool    `json:"move_simultaneously"`
+	MoveSimultaneously *bool    `json:"move_simultaneously,omitempty"`
 }
 
 type multiAxis struct {
@@ -41,10 +41,6 @@ func (conf *Config) Validate(path string) ([]string, error) {
 
 	if len(conf.SubAxes) == 0 {
 		return nil, utils.NewConfigValidationError(path, errors.New("need at least one axis"))
-	}
-
-	if conf.MoveSimultaneously == nil {
-		return nil, utils.NewConfigValidationError(path, errors.New("move_simultaneously is a required config attribute"))
 	}
 
 	deps = append(deps, conf.SubAxes...)
@@ -82,7 +78,10 @@ func newMultiAxis(
 		mAx.subAxes = append(mAx.subAxes, subAx)
 	}
 
-	mAx.moveSimultaneously = *newConf.MoveSimultaneously
+	mAx.moveSimultaneously = false
+	if newConf.MoveSimultaneously != nil {
+		mAx.moveSimultaneously = *newConf.MoveSimultaneously
+	}
 
 	mAx.lengthsMm, err = mAx.Lengths(ctx, nil)
 	if err != nil {

--- a/components/gantry/multiaxis/multiaxis_test.go
+++ b/components/gantry/multiaxis/multiaxis_test.go
@@ -17,26 +17,26 @@ import (
 )
 
 func createFakeOneaAxis(length float64, positions []float64) *inject.Gantry {
-	fakeoneaxis := inject.NewGantry("fake")
-	fakeoneaxis.PositionFunc = func(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+	fakesingleaxis := inject.NewGantry("fake")
+	fakesingleaxis.PositionFunc = func(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
 		return positions, nil
 	}
-	fakeoneaxis.MoveToPositionFunc = func(ctx context.Context, pos []float64, extra map[string]interface{}) error {
+	fakesingleaxis.MoveToPositionFunc = func(ctx context.Context, pos []float64, extra map[string]interface{}) error {
 		return nil
 	}
-	fakeoneaxis.LengthsFunc = func(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+	fakesingleaxis.LengthsFunc = func(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
 		return []float64{length}, nil
 	}
-	fakeoneaxis.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	fakesingleaxis.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
 		return nil
 	}
-	fakeoneaxis.CloseFunc = func(ctx context.Context) error {
+	fakesingleaxis.CloseFunc = func(ctx context.Context) error {
 		return nil
 	}
-	fakeoneaxis.ModelFrameFunc = func() referenceframe.Model {
+	fakesingleaxis.ModelFrameFunc = func() referenceframe.Model {
 		return nil
 	}
-	return fakeoneaxis
+	return fakesingleaxis
 }
 
 func createFakeDeps() resource.Dependencies {

--- a/components/gantry/register/register.go
+++ b/components/gantry/register/register.go
@@ -5,5 +5,5 @@ import (
 	// for gantries.
 	_ "go.viam.com/rdk/components/gantry/fake"
 	_ "go.viam.com/rdk/components/gantry/multiaxis"
-	_ "go.viam.com/rdk/components/gantry/oneaxis"
+	_ "go.viam.com/rdk/components/gantry/singleaxis"
 )

--- a/components/gantry/singleaxis/singleaxis.go
+++ b/components/gantry/singleaxis/singleaxis.go
@@ -120,7 +120,6 @@ func newSingleAxis(ctx context.Context, deps resource.Dependencies, conf resourc
 }
 
 func (g *singleAxis) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
-	g.logger.Error(time.Now())
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	needsToReHome := false
@@ -198,7 +197,6 @@ func (g *singleAxis) Reconfigure(ctx context.Context, deps resource.Dependencies
 		wg.Wait()
 	}
 
-	g.logger.Error(time.Now())
 	return nil
 }
 

--- a/components/gantry/singleaxis/singleaxis.go
+++ b/components/gantry/singleaxis/singleaxis.go
@@ -94,7 +94,7 @@ type singleAxis struct {
 	rpm             float64
 
 	model referenceframe.Model
-	Frame r3.Vector
+	frame r3.Vector
 
 	logger golog.Logger
 	opMgr  operation.SingleOperationManager
@@ -129,7 +129,7 @@ func (g *singleAxis) Reconfigure(ctx context.Context, deps resource.Dependencies
 	if g.mmPerRevolution <= 0 && len(newConf.LimitSwitchPins) == 1 {
 		return errors.New("gantry with one limit switch per axis needs a mm_per_length ratio defined")
 	}
-	g.Frame = conf.Frame.Translation
+	g.frame = conf.Frame.Translation
 	g.rpm = newConf.GantryRPM
 	if g.rpm == 0 {
 		g.rpm = 100
@@ -441,7 +441,7 @@ func (g *singleAxis) ModelFrame() referenceframe.Model {
 		errs = multierr.Combine(errs, err)
 		m.OrdTransforms = append(m.OrdTransforms, f)
 
-		f, err = referenceframe.NewTranslationalFrame(g.Name().ShortName(), g.Frame, referenceframe.Limit{Min: 0, Max: g.lengthMm})
+		f, err = referenceframe.NewTranslationalFrame(g.Name().ShortName(), g.frame, referenceframe.Limit{Min: 0, Max: g.lengthMm})
 		errs = multierr.Combine(errs, err)
 
 		if errs != nil {

--- a/components/gantry/singleaxis/singleaxis.go
+++ b/components/gantry/singleaxis/singleaxis.go
@@ -37,7 +37,8 @@ type Config struct {
 	LimitSwitchPins []string `json:"limit_pins,omitempty"`
 	LimitPinEnabled *bool    `json:"limit_pin_enabled_high,omitempty"`
 	LengthMm        float64  `json:"length_mm"`
-	MmPerRevolution float64  `json:"mm_per_rev,omitempty"`
+	MmPerRevolution float64  `json:"mm_per_rev"`
+	GantryMmPerSec  float64  `json:"gantry_mm_per_sec,omitempty"`
 	GantryRPM       float64  `json:"gantry_rpm,omitempty"`
 }
 
@@ -53,6 +54,11 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 	if cfg.LengthMm <= 0 {
 		err := utils.NewConfigValidationFieldRequiredError(path, "length_mm")
 		return nil, errors.Wrap(err, "length must be non-zero and positive")
+	}
+
+	if cfg.MmPerRevolution <= 0 {
+		err := utils.NewConfigValidationFieldRequiredError(path, "mm_per_rev")
+		return nil, errors.Wrap(err, "mm_per_rev must be non-zero and positive")
 	}
 
 	if len(cfg.Board) == 0 && len(cfg.LimitSwitchPins) > 0 {

--- a/components/gantry/singleaxis/singleaxis.go
+++ b/components/gantry/singleaxis/singleaxis.go
@@ -1,5 +1,5 @@
-// Package oneaxis implements a oneaxis gantry.
-package oneaxis
+// Package singleaxis implements a single-axis gantry.
+package singleaxis
 
 import (
 	"context"
@@ -22,21 +22,23 @@ import (
 	spatial "go.viam.com/rdk/spatialmath"
 )
 
-var model = resource.DefaultModelFamily.WithModel("oneaxis")
+var (
+	model = resource.DefaultModelFamily.WithModel("single-axis")
+	wg    sync.WaitGroup
+)
 
 // limitErrorMargin is added or subtracted from the location of the limit switch to ensure the switch is not passed.
 const limitErrorMargin = 0.25
 
-// Config is used for converting oneAxis config attributes.
+// Config is used for converting singleAxis config attributes.
 type Config struct {
-	Board           string    `json:"board,omitempty"` // used to read limit switch pins and control motor with gpio pins
-	Motor           string    `json:"motor"`
-	LimitSwitchPins []string  `json:"limit_pins,omitempty"`
-	LimitPinEnabled *bool     `json:"limit_pin_enabled_high,omitempty"`
-	LengthMm        float64   `json:"length_mm"`
-	MmPerRevolution float64   `json:"mm_per_rev,omitempty"`
-	GantryRPM       float64   `json:"gantry_rpm,omitempty"`
-	Axis            r3.Vector `json:"axis"`
+	Board           string   `json:"board,omitempty"` // used to read limit switch pins and control motor with gpio pins
+	Motor           string   `json:"motor"`
+	LimitSwitchPins []string `json:"limit_pins,omitempty"`
+	LimitPinEnabled *bool    `json:"limit_pin_enabled_high,omitempty"`
+	LengthMm        float64  `json:"length_mm"`
+	MmPerRevolution float64  `json:"mm_per_rev,omitempty"`
+	GantryRPM       float64  `json:"gantry_rpm,omitempty"`
 }
 
 // Validate ensures all parts of the config are valid.
@@ -59,16 +61,11 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 	deps = append(deps, cfg.Board)
 
 	if len(cfg.LimitSwitchPins) == 1 && cfg.MmPerRevolution == 0 {
-		return nil, errors.New("the oneaxis gantry has one limit switch axis, needs pulley radius to set position limits")
+		return nil, errors.New("the single-axis gantry has one limit switch axis, needs pulley radius to set position limits")
 	}
 
 	if len(cfg.LimitSwitchPins) > 0 && cfg.LimitPinEnabled == nil {
 		return nil, errors.New("limit pin enabled must be set to true or false")
-	}
-
-	if cfg.Axis.X == 1 && cfg.Axis.Y == 1 ||
-		cfg.Axis.X == 1 && cfg.Axis.Z == 1 || cfg.Axis.Y == 1 && cfg.Axis.Z == 1 {
-		return nil, errors.New("only one translational axis of movement allowed for single axis gantry")
 	}
 
 	return deps, nil
@@ -76,11 +73,11 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 
 func init() {
 	resource.RegisterComponent(gantry.API, model, resource.Registration[gantry.Gantry, *Config]{
-		Constructor: newOneAxis,
+		Constructor: newSingleAxis,
 	})
 }
 
-type oneAxis struct {
+type singleAxis struct {
 	resource.Named
 
 	board board.Board
@@ -97,26 +94,27 @@ type oneAxis struct {
 	rpm             float64
 
 	model referenceframe.Model
-	axis  r3.Vector
+	Frame r3.Vector
 
 	logger golog.Logger
 	opMgr  operation.SingleOperationManager
 }
 
-// newOneAxis creates a new one axis gantry.
-func newOneAxis(ctx context.Context, deps resource.Dependencies, conf resource.Config, logger golog.Logger) (gantry.Gantry, error) {
-	oAx := &oneAxis{
+// newSingleAxis creates a new single axis gantry.
+func newSingleAxis(ctx context.Context, deps resource.Dependencies, conf resource.Config, logger golog.Logger) (gantry.Gantry, error) {
+	sAx := &singleAxis{
 		Named:  conf.ResourceName().AsNamed(),
 		logger: logger,
 	}
 
-	if err := oAx.Reconfigure(ctx, deps, conf); err != nil {
+	if err := sAx.Reconfigure(ctx, deps, conf); err != nil {
 		return nil, err
 	}
-	return oAx, nil
+	return sAx, nil
 }
 
-func (g *oneAxis) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+func (g *singleAxis) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+	g.logger.Error(time.Now())
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	needsToReHome := false
@@ -131,7 +129,7 @@ func (g *oneAxis) Reconfigure(ctx context.Context, deps resource.Dependencies, c
 	if g.mmPerRevolution <= 0 && len(newConf.LimitSwitchPins) == 1 {
 		return errors.New("gantry with one limit switch per axis needs a mm_per_length ratio defined")
 	}
-	g.axis = newConf.Axis
+	g.Frame = conf.Frame.Translation
 	g.rpm = newConf.GantryRPM
 	if g.rpm == 0 {
 		g.rpm = 100
@@ -183,15 +181,22 @@ func (g *oneAxis) Reconfigure(ctx context.Context, deps resource.Dependencies, c
 	}
 
 	if needsToReHome {
-		if err = g.home(ctx, len(newConf.LimitSwitchPins)); err != nil {
-			return err
-		}
+		wg.Add(1)
+		go func() {
+			// Decrement the counter when the go routine completes
+			defer wg.Done()
+			if err = g.home(ctx, len(newConf.LimitSwitchPins)); err != nil {
+				g.logger.Error(err)
+			}
+		}()
+		wg.Wait()
 	}
 
+	g.logger.Error(time.Now())
 	return nil
 }
 
-func (g *oneAxis) home(ctx context.Context, np int) error {
+func (g *singleAxis) home(ctx context.Context, np int) error {
 	ctx, done := g.opMgr.New(ctx)
 	defer done()
 
@@ -203,10 +208,10 @@ func (g *oneAxis) home(ctx context.Context, np int) error {
 			return err
 		}
 	// An axis with one limit switch will go till it hits the limit switch, encode that position as the
-	// zero position of the oneaxis, and adds a second position limit based on the steps per length.
+	// zero position of the singleAxis, and adds a second position limit based on the steps per length.
 	// An axis with two limit switches will go till it hits the first limit switch, encode that position as the
-	// zero position of the oneaxis, then go till it hits the second limit switch, then encode that position as the
-	// at-length position of the oneaxis.
+	// zero position of the singleAxis, then go till it hits the second limit switch, then encode that position as the
+	// at-length position of the singleAxis.
 	case 1, 2:
 		if err := g.homeLimSwitch(ctx); err != nil {
 			return err
@@ -216,7 +221,7 @@ func (g *oneAxis) home(ctx context.Context, np int) error {
 	return nil
 }
 
-func (g *oneAxis) homeLimSwitch(ctx context.Context) error {
+func (g *singleAxis) homeLimSwitch(ctx context.Context) error {
 	var positionA, positionB, start float64
 	positionA, err := g.testLimit(ctx, true)
 	if err != nil {
@@ -255,7 +260,7 @@ func (g *oneAxis) homeLimSwitch(ctx context.Context) error {
 // home encoder assumes that you have places one of the stepper motors where you
 // want your zero position to be, you need to know which way is "forward"
 // on your motor.
-func (g *oneAxis) homeEncoder(ctx context.Context) error {
+func (g *singleAxis) homeEncoder(ctx context.Context) error {
 	revPerLength := g.lengthMm / g.mmPerRevolution
 
 	positionA, err := g.motor.Position(ctx, nil)
@@ -269,7 +274,7 @@ func (g *oneAxis) homeEncoder(ctx context.Context) error {
 	return nil
 }
 
-func (g *oneAxis) goToStart(ctx context.Context, percent float64) error {
+func (g *singleAxis) goToStart(ctx context.Context, percent float64) error {
 	x := g.gantryToMotorPosition(percent * g.lengthMm)
 	if err := g.motor.GoTo(ctx, g.rpm, x, nil); err != nil {
 		return err
@@ -277,13 +282,13 @@ func (g *oneAxis) goToStart(ctx context.Context, percent float64) error {
 	return nil
 }
 
-func (g *oneAxis) gantryToMotorPosition(positions float64) float64 {
+func (g *singleAxis) gantryToMotorPosition(positions float64) float64 {
 	x := positions / g.lengthMm
 	x = g.positionLimits[0] + (x * g.positionRange)
 	return x
 }
 
-func (g *oneAxis) testLimit(ctx context.Context, zero bool) (float64, error) {
+func (g *singleAxis) testLimit(ctx context.Context, zero bool) (float64, error) {
 	defer utils.UncheckedErrorFunc(func() error {
 		return g.motor.Stop(ctx, nil)
 	})
@@ -329,7 +334,7 @@ func (g *oneAxis) testLimit(ctx context.Context, zero bool) (float64, error) {
 
 // this function may need to be run in the background upon initialisation of the ganty,
 // also may need to use a digital intterupt pin instead of a gpio pin.
-func (g *oneAxis) limitHit(ctx context.Context, zero bool) (bool, error) {
+func (g *singleAxis) limitHit(ctx context.Context, zero bool) (bool, error) {
 	offset := 0
 	if !zero {
 		offset = 1
@@ -344,7 +349,7 @@ func (g *oneAxis) limitHit(ctx context.Context, zero bool) (bool, error) {
 }
 
 // Position returns the position in millimeters.
-func (g *oneAxis) Position(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+func (g *singleAxis) Position(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
 	pos, err := g.motor.Position(ctx, extra)
 	if err != nil {
 		return []float64{}, err
@@ -356,14 +361,14 @@ func (g *oneAxis) Position(ctx context.Context, extra map[string]interface{}) ([
 }
 
 // Lengths returns the physical lengths of an axis of a Gantry.
-func (g *oneAxis) Lengths(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+func (g *singleAxis) Lengths(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	return []float64{g.lengthMm}, nil
 }
 
 // MoveToPosition moves along an axis using inputs in millimeters.
-func (g *oneAxis) MoveToPosition(ctx context.Context, positions []float64, extra map[string]interface{}) error {
+func (g *singleAxis) MoveToPosition(ctx context.Context, positions []float64, extra map[string]interface{}) error {
 	ctx, done := g.opMgr.New(ctx)
 	defer done()
 
@@ -404,28 +409,28 @@ func (g *oneAxis) MoveToPosition(ctx context.Context, positions []float64, extra
 }
 
 // Stop stops the motor of the gantry.
-func (g *oneAxis) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (g *singleAxis) Stop(ctx context.Context, extra map[string]interface{}) error {
 	ctx, done := g.opMgr.New(ctx)
 	defer done()
 	return g.motor.Stop(ctx, extra)
 }
 
 // Close calls stop.
-func (g *oneAxis) Close(ctx context.Context) error {
+func (g *singleAxis) Close(ctx context.Context) error {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	return g.Stop(ctx, nil)
 }
 
 // IsMoving returns whether the gantry is moving.
-func (g *oneAxis) IsMoving(ctx context.Context) (bool, error) {
+func (g *singleAxis) IsMoving(ctx context.Context) (bool, error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	return g.opMgr.OpRunning(), nil
 }
 
 // ModelFrame returns the frame model of the Gantry.
-func (g *oneAxis) ModelFrame() referenceframe.Model {
+func (g *singleAxis) ModelFrame() referenceframe.Model {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	if g.model == nil {
@@ -436,7 +441,7 @@ func (g *oneAxis) ModelFrame() referenceframe.Model {
 		errs = multierr.Combine(errs, err)
 		m.OrdTransforms = append(m.OrdTransforms, f)
 
-		f, err = referenceframe.NewTranslationalFrame(g.Name().ShortName(), g.axis, referenceframe.Limit{Min: 0, Max: g.lengthMm})
+		f, err = referenceframe.NewTranslationalFrame(g.Name().ShortName(), g.Frame, referenceframe.Limit{Min: 0, Max: g.lengthMm})
 		errs = multierr.Combine(errs, err)
 
 		if errs != nil {
@@ -451,7 +456,7 @@ func (g *oneAxis) ModelFrame() referenceframe.Model {
 }
 
 // CurrentInputs returns the current inputs of the Gantry frame.
-func (g *oneAxis) CurrentInputs(ctx context.Context) ([]referenceframe.Input, error) {
+func (g *singleAxis) CurrentInputs(ctx context.Context) ([]referenceframe.Input, error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	res, err := g.Position(ctx, nil)
@@ -462,7 +467,7 @@ func (g *oneAxis) CurrentInputs(ctx context.Context) ([]referenceframe.Input, er
 }
 
 // GoToInputs moves the gantry to a goal position in the Gantry frame.
-func (g *oneAxis) GoToInputs(ctx context.Context, goal []referenceframe.Input) error {
+func (g *singleAxis) GoToInputs(ctx context.Context, goal []referenceframe.Input) error {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	return g.MoveToPosition(ctx, referenceframe.InputsToFloats(goal), nil)

--- a/components/gantry/singleaxis/singleaxis.go
+++ b/components/gantry/singleaxis/singleaxis.go
@@ -38,7 +38,6 @@ type Config struct {
 	LimitPinEnabled *bool    `json:"limit_pin_enabled_high,omitempty"`
 	LengthMm        float64  `json:"length_mm"`
 	MmPerRevolution float64  `json:"mm_per_rev"`
-	GantryMmPerSec  float64  `json:"gantry_mm_per_sec,omitempty"`
 	GantryRPM       float64  `json:"gantry_rpm,omitempty"`
 }
 

--- a/components/gantry/singleaxis/singleaxis_test.go
+++ b/components/gantry/singleaxis/singleaxis_test.go
@@ -1,4 +1,4 @@
-package oneaxis
+package singleaxis
 
 import (
 	"context"
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/edaniels/golog"
-	"github.com/golang/geo/r3"
 	"github.com/pkg/errors"
 	"go.viam.com/test"
 
@@ -50,7 +49,7 @@ func createFakeBoard() board.Board {
 	return &inject.Board{GPIOPinByNameFunc: func(pin string) (board.GPIOPin, error) { return injectGPIOPin, nil }}
 }
 
-func createFakeDepsForTestNewOneAxis(t *testing.T) resource.Dependencies {
+func createFakeDepsForTestNewSingleAxis(t *testing.T) resource.Dependencies {
 	t.Helper()
 	deps := make(resource.Dependencies)
 	deps[board.Named(boardName)] = createFakeBoard()
@@ -86,13 +85,13 @@ func TestValidate(t *testing.T) {
 	test.That(t, fakecfg.GantryRPM, test.ShouldEqual, float64(0))
 }
 
-func TestNewOneAxis(t *testing.T) {
+func TestNewSingleAxis(t *testing.T) {
 	ctx := context.Background()
 	logger := golog.NewTestLogger(t)
-	deps := createFakeDepsForTestNewOneAxis(t)
+	deps := createFakeDepsForTestNewSingleAxis(t)
 	fakecfg := resource.Config{Name: testGName}
-	_, err := newOneAxis(ctx, deps, fakecfg, logger)
-	test.That(t, err.Error(), test.ShouldContainSubstring, "expected *oneaxis.Config but got <nil>")
+	_, err := newSingleAxis(ctx, deps, fakecfg, logger)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "expected *singleaxis.Config but got <nil>")
 
 	fakecfg = resource.Config{
 		Name: testGName,
@@ -105,9 +104,9 @@ func TestNewOneAxis(t *testing.T) {
 			GantryRPM:       float64(300),
 		},
 	}
-	fakegantry, err := newOneAxis(ctx, deps, fakecfg, logger)
+	fakegantry, err := newSingleAxis(ctx, deps, fakecfg, logger)
 	test.That(t, err, test.ShouldBeNil)
-	_, ok := fakegantry.(*oneAxis)
+	_, ok := fakegantry.(*singleAxis)
 	test.That(t, ok, test.ShouldBeTrue)
 
 	fakecfg = resource.Config{
@@ -122,8 +121,8 @@ func TestNewOneAxis(t *testing.T) {
 			GantryRPM:       float64(300),
 		},
 	}
-	fakegantry, err = newOneAxis(ctx, deps, fakecfg, logger)
-	_, ok = fakegantry.(*oneAxis)
+	fakegantry, err = newSingleAxis(ctx, deps, fakecfg, logger)
+	_, ok = fakegantry.(*singleAxis)
 	test.That(t, ok, test.ShouldBeTrue)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -138,8 +137,8 @@ func TestNewOneAxis(t *testing.T) {
 			GantryRPM:       float64(300),
 		},
 	}
-	fakegantry, err = newOneAxis(ctx, deps, fakecfg, logger)
-	_, ok = fakegantry.(*oneAxis)
+	fakegantry, err = newSingleAxis(ctx, deps, fakecfg, logger)
+	_, ok = fakegantry.(*singleAxis)
 	test.That(t, ok, test.ShouldBeFalse)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "gantry with one limit switch per axis needs a mm_per_length ratio defined")
 
@@ -154,11 +153,11 @@ func TestNewOneAxis(t *testing.T) {
 		},
 	}
 
-	_, err = newOneAxis(ctx, deps, fakecfg, logger)
+	_, err = newSingleAxis(ctx, deps, fakecfg, logger)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "invalid gantry type: need 1, 2 or 0 pins per axis, have 3 pins")
 
 	deps = make(resource.Dependencies)
-	_, err = newOneAxis(ctx, deps, fakecfg, logger)
+	_, err = newSingleAxis(ctx, deps, fakecfg, logger)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "missing from dependencies")
 
 	injectMotor := &inject.Motor{
@@ -172,7 +171,7 @@ func TestNewOneAxis(t *testing.T) {
 	deps[motor.Named(motorName)] = injectMotor
 	deps[board.Named(boardName)] = createFakeBoard()
 
-	_, err = newOneAxis(ctx, deps, fakecfg, logger)
+	_, err = newSingleAxis(ctx, deps, fakecfg, logger)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "invalid gantry type")
 
 	injectMotor = &inject.Motor{
@@ -186,7 +185,7 @@ func TestNewOneAxis(t *testing.T) {
 	deps = make(resource.Dependencies)
 	deps[motor.Named(motorName)] = injectMotor
 	deps[board.Named(boardName)] = createFakeBoard()
-	_, err = newOneAxis(ctx, deps, fakecfg, logger)
+	_, err = newSingleAxis(ctx, deps, fakecfg, logger)
 	expectedErr := motor.NewFeatureUnsupportedError(motor.PositionReporting, motorName)
 	test.That(t, err, test.ShouldBeError, expectedErr)
 }
@@ -194,7 +193,7 @@ func TestNewOneAxis(t *testing.T) {
 func TestReconfigure(t *testing.T) {
 	ctx := context.Background()
 	logger := golog.NewTestLogger(t)
-	deps := createFakeDepsForTestNewOneAxis(t)
+	deps := createFakeDepsForTestNewSingleAxis(t)
 	fakecfg := resource.Config{
 		Name: testGName,
 		ConvertedAttributes: &Config{
@@ -206,9 +205,9 @@ func TestReconfigure(t *testing.T) {
 			GantryRPM:       float64(300),
 		},
 	}
-	fakegantry, err := newOneAxis(ctx, deps, fakecfg, logger)
+	fakegantry, err := newSingleAxis(ctx, deps, fakecfg, logger)
 	test.That(t, err, test.ShouldBeNil)
-	g := fakegantry.(*oneAxis)
+	g := fakegantry.(*singleAxis)
 
 	newconf := resource.Config{
 		Name: testGName,
@@ -234,7 +233,7 @@ func TestReconfigure(t *testing.T) {
 func TestHome(t *testing.T) {
 	ctx := context.Background()
 	logger := golog.NewTestLogger(t)
-	fakegantry := &oneAxis{
+	fakegantry := &singleAxis{
 		motor:           createFakeMotor(),
 		board:           createFakeBoard(),
 		limitHigh:       true,
@@ -263,14 +262,14 @@ func TestHome(t *testing.T) {
 			return math.NaN(), posErr
 		},
 	}
-	fakegantry = &oneAxis{
+	fakegantry = &singleAxis{
 		motor:  fakeMotor,
 		logger: logger,
 	}
 	err = fakegantry.home(ctx, len(fakegantry.limitSwitchPins))
 	test.That(t, err, test.ShouldBeError, posErr)
 
-	fakegantry = &oneAxis{
+	fakegantry = &singleAxis{
 		motor:           createFakeMotor(),
 		board:           createFakeBoard(),
 		limitHigh:       true,
@@ -281,13 +280,13 @@ func TestHome(t *testing.T) {
 	err = fakegantry.home(ctx, len(fakegantry.limitSwitchPins))
 	test.That(t, err, test.ShouldBeNil)
 
-	fakegantry = &oneAxis{
+	fakegantry = &singleAxis{
 		motor: fakeMotor,
 	}
 	err = fakegantry.home(ctx, len(fakegantry.limitSwitchPins))
 	test.That(t, err, test.ShouldBeError, posErr)
 
-	fakegantry = &oneAxis{
+	fakegantry = &singleAxis{
 		motor:           createFakeMotor(),
 		board:           createFakeBoard(),
 		limitHigh:       true,
@@ -302,7 +301,7 @@ func TestHome(t *testing.T) {
 func TestHomeLimitSwitch(t *testing.T) {
 	ctx := context.Background()
 	logger := golog.NewTestLogger(t)
-	fakegantry := &oneAxis{
+	fakegantry := &singleAxis{
 		motor:           createFakeMotor(),
 		board:           createFakeBoard(),
 		limitHigh:       true,
@@ -398,7 +397,7 @@ func TestHomeLimitSwitch(t *testing.T) {
 func TestHomeLimitSwitch2(t *testing.T) {
 	ctx := context.Background()
 	logger := golog.NewTestLogger(t)
-	fakegantry := &oneAxis{
+	fakegantry := &singleAxis{
 		motor:           createFakeMotor(),
 		board:           createFakeBoard(),
 		limitHigh:       true,
@@ -457,7 +456,7 @@ func TestHomeLimitSwitch2(t *testing.T) {
 }
 
 func TestHomeEncoder(t *testing.T) {
-	fakegantry := &oneAxis{}
+	fakegantry := &singleAxis{}
 
 	resetZeroErr := errors.New("failed to set zero")
 	injMotor := &inject.Motor{
@@ -481,7 +480,7 @@ func TestHomeEncoder(t *testing.T) {
 
 func TestTestLimit(t *testing.T) {
 	ctx := context.Background()
-	fakegantry := &oneAxis{
+	fakegantry := &singleAxis{
 		limitSwitchPins: []string{"1", "2"},
 		motor:           createFakeMotor(),
 		board:           createFakeBoard(),
@@ -495,7 +494,7 @@ func TestTestLimit(t *testing.T) {
 
 func TestLimitHit(t *testing.T) {
 	ctx := context.Background()
-	fakegantry := &oneAxis{
+	fakegantry := &singleAxis{
 		limitSwitchPins: []string{"1", "2", "3"},
 		board:           createFakeBoard(),
 		limitHigh:       true,
@@ -509,7 +508,7 @@ func TestLimitHit(t *testing.T) {
 func TestPosition(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	ctx := context.Background()
-	fakegantry := &oneAxis{
+	fakegantry := &singleAxis{
 		motor: &inject.Motor{
 			PropertiesFunc: func(ctx context.Context, extra map[string]interface{}) (map[motor.Feature]bool, error) {
 				return map[motor.Feature]bool{
@@ -529,7 +528,7 @@ func TestPosition(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, positions, test.ShouldResemble, []float64{0})
 
-	fakegantry = &oneAxis{
+	fakegantry = &singleAxis{
 		motor: &inject.Motor{
 			PropertiesFunc: func(ctx context.Context, extra map[string]interface{}) (map[motor.Feature]bool, error) {
 				return nil, errors.New("not supported")
@@ -550,7 +549,7 @@ func TestPosition(t *testing.T) {
 }
 
 func TestLengths(t *testing.T) {
-	fakegantry := &oneAxis{
+	fakegantry := &singleAxis{
 		lengthMm: float64(1.0),
 	}
 	ctx := context.Background()
@@ -564,7 +563,7 @@ func TestMoveToPosition(t *testing.T) {
 	t.Skip()
 	ctx := context.Background()
 	logger := golog.NewTestLogger(t)
-	fakegantry := &oneAxis{
+	fakegantry := &singleAxis{
 		logger:    logger,
 		board:     createFakeBoard(),
 		motor:     createFakeMotor(),
@@ -628,10 +627,9 @@ func TestMoveToPosition(t *testing.T) {
 }
 
 func TestModelFrame(t *testing.T) {
-	fakegantry := &oneAxis{
+	fakegantry := &singleAxis{
 		Named:    gantry.Named("foo").AsNamed(),
 		lengthMm: 1.0,
-		axis:     r3.Vector{X: 0, Y: 0, Z: 1},
 		model:    nil,
 	}
 
@@ -643,7 +641,7 @@ func TestStop(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	ctx := context.Background()
 
-	fakegantry := &oneAxis{
+	fakegantry := &singleAxis{
 		motor:           createFakeMotor(),
 		board:           createFakeBoard(),
 		limitHigh:       true,
@@ -661,7 +659,7 @@ func TestCurrentInputs(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	ctx := context.Background()
 
-	fakegantry := &oneAxis{
+	fakegantry := &singleAxis{
 		motor:           createFakeMotor(),
 		board:           createFakeBoard(),
 		limitHigh:       true,
@@ -677,7 +675,7 @@ func TestCurrentInputs(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, input[0].Value, test.ShouldEqual, 100)
 
-	fakegantry = &oneAxis{
+	fakegantry = &singleAxis{
 		motor:           createFakeMotor(),
 		board:           createFakeBoard(),
 		limitHigh:       true,
@@ -694,7 +692,7 @@ func TestCurrentInputs(t *testing.T) {
 	test.That(t, input[0].Value, test.ShouldEqual, 100)
 
 	// out of bounds position
-	fakegantry = &oneAxis{
+	fakegantry = &singleAxis{
 		motor: &inject.Motor{
 			PositionFunc: func(ctx context.Context, extra map[string]interface{}) (float64, error) {
 				return 5, errors.New("nope")
@@ -718,7 +716,7 @@ func TestGoToInputs(t *testing.T) {
 	inputs := []referenceframe.Input{}
 	logger := golog.NewTestLogger(t)
 
-	fakegantry := &oneAxis{
+	fakegantry := &singleAxis{
 		board:           createFakeBoard(),
 		limitSwitchPins: []string{"1", "2"},
 		limitHigh:       true,
@@ -726,7 +724,6 @@ func TestGoToInputs(t *testing.T) {
 		lengthMm:        1.0,
 		mmPerRevolution: 0.1,
 		rpm:             10,
-		axis:            r3.Vector{},
 		positionLimits:  []float64{1, 2},
 		model:           nil,
 		logger:          logger,


### PR DESCRIPTION
1. add move_simultaneously parameter in multi axis config
2. remove Axis from one-axis config
3. rename one-axis → single-axis
4. only allow gantry to use position reporting motors as dependencies
5. rename multiaxis → multi-axis