### PR TITLE
RSDK-3537 Immediately remove modules with no handled resources

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -208,6 +208,13 @@ func (mgr *Manager) Remove(modName string) ([]resource.Name, error) {
 	}
 	handledResources := mod.resources
 
+	// If module handles no resources, remove it now. Otherwise mark it
+	// pendingRemoval for eventual removal after last handled resource has been
+	// closed.
+	if len(handledResources) == 0 {
+		return nil, mgr.remove(mod, false)
+	}
+
 	var orphanedResourceNames []resource.Name
 	for name := range handledResources {
 		orphanedResourceNames = append(orphanedResourceNames, name)


### PR DESCRIPTION
RSDK-3537

Followup to #2486 . We were missing the case where a module is removed that handles no resources.