### PR TITLE
RSDK-3609 TestAMSEncoderReset flaky test fix

### DIFF
--- a/components/encoder/ams/ams_as5048_test.go
+++ b/components/encoder/ams/ams_as5048_test.go
@@ -179,9 +179,6 @@ func TestAMSEncoderReset(t *testing.T) {
 	t.Run("test reset", func(t *testing.T) {
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			enc.ResetPosition(ctx, nil)
-		})
-
-		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			pos, posType, _ := enc.Position(ctx, encoder.PositionTypeUnspecified, nil)
 			test.That(tb, pos, test.ShouldAlmostEqual, 0, 0.1)
 			test.That(tb, posType, test.ShouldEqual, 1)


### PR DESCRIPTION
### Summary
fixes test flakiness. Seems like having two WaitForAssertion calls in the same test was causing issues. 