### PR TITLE
APP-2044 Kill test-e2e child process on exit except in Github Workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Run e2e Tests
         run: |
           chown -R testbot:testbot .
-          sudo -Hu testbot bash -lc 'make build-web test-e2e'
+          sudo -Hu testbot bash -lc 'make build-web test-e2e E2E_ARGS="-k"'
 
   test_passing:
     name: All Tests Passing

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ test-pi:
 
 test-e2e:
 	go build $(LDFLAGS) -o bin/test-e2e/server web/cmd/server/main.go
-	./etc/e2e.sh -o 'run'
+	./etc/e2e.sh -o 'run' $(E2E_ARGS)
 
 open-cypress-ui:
 	go build $(LDFLAGS) -o bin/test-e2e/server web/cmd/server/main.go

--- a/etc/e2e.sh
+++ b/etc/e2e.sh
@@ -5,21 +5,35 @@ ROOT_DIR="$DIR/../"
 
 cd $ROOT_DIR
 
+FLAG_OPEN="open"
+FLAG_RUN="run"
+
 helpFunction()
 {
    echo ""
-   echo "Usage: $0 -o <open|run>"
+   echo "Usage: $0 -o <$FLAG_OPEN|$FLAG_RUN> [-k]"
    echo -e "\t-o Whether or not to open the cypress UI or just run the tests"
+   echo -e "\t-k Does *not* try to pkill the child test-e2e process. Helpful to avoid pkill in CI."
    exit 1 # Exit script after printing help
 }
 
-while getopts "o:" opt
+# TODO(APP-2044): Flip default to true
+KILL_CHILD=false
+
+while getopts "o:k" opt
 do
    case "$opt" in
       o ) OPEN="$OPTARG" ;;
+      k ) KILL_CHILD=false ;;
       ? ) helpFunction ;; 
    esac
 done
+
+if [ -z "$OPEN" ] ; then
+    helpFunction
+elif [ $OPEN != $FLAG_OPEN ] && [ $OPEN != $FLAG_RUN ] ; then
+    helpFunction
+fi
 
 # Run server with test config
 nohup ./bin/test-e2e/server --config web/frontend/cypress/data/test_robot_config.json &
@@ -34,8 +48,8 @@ if [ $OPEN == "open" ] ; then
     npm run cypress -- -c defaultCommandTimeout=30000
 elif [ $OPEN == "run" ] ; then
     npm run cypress:ci -- -c defaultCommandTimeout=30000
-else
-    helpFunction
 fi
 
-
+if [ $KILL_CHILD == true ] ; then
+    pkill -f test-e2e
+fi


### PR DESCRIPTION
This updates `e2e.sh` to kill zombie child processes at the end of the script.

Killing processes using `pkill` is not allowed in CI without `sudo`. The target does not use `sudo` so someone running it locally does not require the user's password. Instead, the flag `-k` is used in the Github Workflow (and passed down in the makefile target definition) to avoid calling `pkill`.

The default to kill the child process must first be merged as false so the workflow still passes. I'll follow up this PR with another PR to flip the default to true.

This change was [validated](https://github.com/viamrobotics/rdk/pull/2553/checks) by using an [empty commit/PR](https://github.com/viamrobotics/rdk/pull/2553) against the branch. I'm currently [documenting the process](https://viam.atlassian.net/wiki/spaces/ENG/pages/207257613/Engineering+Processes+and+Common+Workflows#Updating-GitHub-Workflows).