### PR TITLE
APP-2044 Flip test-e2e kill process default to true

### DIFF
--- a/etc/e2e.sh
+++ b/etc/e2e.sh
@@ -17,8 +17,7 @@ helpFunction()
    exit 1 # Exit script after printing help
 }
 
-# TODO(APP-2044): Flip default to true
-KILL_CHILD=false
+KILL_CHILD=true
 
 while getopts "o:k" opt
 do


### PR DESCRIPTION
Now that the flag is included in the workflow, the default can be flipped to true.