### PR TITLE
RSDK-3684 - Make LabelPath Optional Again

### DIFF
--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -1917,7 +1917,7 @@ func TestConfigPackageReferenceReplacement(t *testing.T) {
 				Model: resource.DefaultModelFamily.WithModel("tflite_cpu"),
 				ConvertedAttributes: &tflitecpu.TFLiteConfig{
 					ModelPath:  "${packages.package-1}/model.tflite",
-					LabelPath:  &labelPath,
+					LabelPath:  labelPath,
 					NumThreads: 1,
 				},
 			},

--- a/services/mlmodel/tflitecpu/tflite_cpu.go
+++ b/services/mlmodel/tflitecpu/tflite_cpu.go
@@ -43,9 +43,9 @@ func init() {
 type TFLiteConfig struct {
 	resource.TriviallyValidateConfig
 	// this should come from the attributes of the tflite_cpu instance of the MLMS
-	ModelPath  string  `json:"model_path"`
-	NumThreads int     `json:"num_threads"`
-	LabelPath  *string `json:"label_path"`
+	ModelPath  string `json:"model_path"`
+	NumThreads int    `json:"num_threads"`
+	LabelPath  string `json:"label_path"`
 }
 
 // Walk implements the Walker interface and correctly replaces model and label paths.
@@ -60,7 +60,7 @@ func (cfg *TFLiteConfig) Walk(visitor utils.Visitor) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	cfg.LabelPath = labelPath.(*string)
+	cfg.LabelPath = labelPath.(string)
 
 	return cfg, nil
 }
@@ -225,8 +225,8 @@ func (m *Model) Metadata(ctx context.Context) (mlmodel.MLMetadata, error) {
 		outputT := md.SubgraphMetadata[0].OutputTensorMetadata[i]
 		td := getTensorInfo(outputT)
 		td.DataType = strings.ToLower(m.model.Info.OutputTensorTypes[i]) // grab from model info, not metadata
-		if i == 0 && m.conf.LabelPath != nil {
-			td.Extra = map[string]interface{}{"labels": *m.conf.LabelPath}
+		if i == 0 && m.conf.LabelPath != "" {
+			td.Extra = map[string]interface{}{"labels": m.conf.LabelPath}
 		}
 		outputList = append(outputList, td)
 	}
@@ -298,8 +298,8 @@ func (m *Model) blindFillMetadata() mlmodel.MLMetadata {
 	for i := 0; i < numOut; i++ {
 		var td mlmodel.TensorInfo
 		td.DataType = strings.ToLower(m.model.Info.OutputTensorTypes[i])
-		if i == 0 && m.conf.LabelPath != nil {
-			td.Extra = map[string]interface{}{"labels": *m.conf.LabelPath}
+		if i == 0 && m.conf.LabelPath != "" {
+			td.Extra = map[string]interface{}{"labels": m.conf.LabelPath}
 		}
 		outputList = append(outputList, td)
 	}

--- a/services/mlmodel/tflitecpu/tflite_cpu_test.go
+++ b/services/mlmodel/tflitecpu/tflite_cpu_test.go
@@ -247,7 +247,7 @@ func makeExampleSlice(length int) []int32 {
 }
 
 func TestTFLiteConfigWalker(t *testing.T) {
-	makeVisionAttributes := func(modelPath string, labelPath string) *TFLiteConfig {
+	makeVisionAttributes := func(modelPath, labelPath string) *TFLiteConfig {
 		return &TFLiteConfig{
 			ModelPath:  modelPath,
 			LabelPath:  labelPath,

--- a/services/mlmodel/tflitecpu/tflite_cpu_test.go
+++ b/services/mlmodel/tflitecpu/tflite_cpu_test.go
@@ -247,7 +247,7 @@ func makeExampleSlice(length int) []int32 {
 }
 
 func TestTFLiteConfigWalker(t *testing.T) {
-	makeVisionAttributes := func(modelPath string, labelPath *string) *TFLiteConfig {
+	makeVisionAttributes := func(modelPath string, labelPath string) *TFLiteConfig {
 		return &TFLiteConfig{
 			ModelPath:  modelPath,
 			LabelPath:  labelPath,
@@ -256,13 +256,13 @@ func TestTFLiteConfigWalker(t *testing.T) {
 	}
 
 	labelPath := "/other/path/on/robot/textFile.txt"
-	visionAttrs := makeVisionAttributes("/some/path/on/robot/model.tflite", &labelPath)
+	visionAttrs := makeVisionAttributes("/some/path/on/robot/model.tflite", labelPath)
 
 	labelPathWithRefs := "${packages.test_model}/textFile.txt"
-	visionAttrsWithRefs := makeVisionAttributes("${packages.test_model}/model.tflite", &labelPathWithRefs)
+	visionAttrsWithRefs := makeVisionAttributes("${packages.test_model}/model.tflite", labelPathWithRefs)
 
 	labelPathOneRef := "${packages.test_model}/textFile.txt"
-	visionAttrsOneRef := makeVisionAttributes("/some/path/on/robot/model.tflite", &labelPathOneRef)
+	visionAttrsOneRef := makeVisionAttributes("/some/path/on/robot/model.tflite", labelPathOneRef)
 
 	packageManager := packages.NewNoopManager()
 	testAttributesWalker := func(t *testing.T, attrs *TFLiteConfig, expectedModelPath, expectedLabelPath string) {
@@ -270,7 +270,7 @@ func TestTFLiteConfigWalker(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		test.That(t, newAttrs.(*TFLiteConfig).ModelPath, test.ShouldEqual, expectedModelPath)
-		test.That(t, *newAttrs.(*TFLiteConfig).LabelPath, test.ShouldEqual, expectedLabelPath)
+		test.That(t, newAttrs.(*TFLiteConfig).LabelPath, test.ShouldEqual, expectedLabelPath)
 		test.That(t, newAttrs.(*TFLiteConfig).NumThreads, test.ShouldEqual, 1)
 	}
 

--- a/services/mlmodel/tflitecpu/tflite_cpu_test.go
+++ b/services/mlmodel/tflitecpu/tflite_cpu_test.go
@@ -278,3 +278,26 @@ func TestTFLiteConfigWalker(t *testing.T) {
 	testAttributesWalker(t, visionAttrsWithRefs, "test_model/model.tflite", "test_model/textFile.txt")
 	testAttributesWalker(t, visionAttrsOneRef, "/some/path/on/robot/model.tflite", "test_model/textFile.txt")
 }
+
+func TestLabelPathWalkFail(t *testing.T) {
+	labelPath := "/blah/blah/mylabels.txt"
+	var oldLabelPath *string
+
+	packageManager := packages.NewNoopManager()
+	visitor := packages.NewPackagePathVisitor(packageManager)
+
+	outNew, err := visitor.Visit(labelPath)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, outNew, test.ShouldResemble, labelPath)
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				// If we're here, the old approach "Visit(nil)" did not panic
+				test.That(t, 3, test.ShouldResemble, 5)
+			}
+		}()
+
+		// This should cause a panic
+		visitor.Visit(oldLabelPath)
+	}()
+}

--- a/services/vision/mlvision/ml_model_test.go
+++ b/services/vision/mlvision/ml_model_test.go
@@ -136,7 +136,7 @@ func TestNewMLDetector(t *testing.T) {
 	cfg := tflitecpu.TFLiteConfig{ // detector config
 		ModelPath:  modelLoc,
 		NumThreads: 2,
-		LabelPath:  &labelLoc,
+		LabelPath:  labelLoc,
 	}
 	noLabelCfg := tflitecpu.TFLiteConfig{ // detector config
 		ModelPath:  modelLoc,
@@ -211,7 +211,7 @@ func TestNewMLClassifier(t *testing.T) {
 	cfg := tflitecpu.TFLiteConfig{ // detector config
 		ModelPath:  modelLoc,
 		NumThreads: 2,
-		LabelPath:  &labelLoc,
+		LabelPath:  labelLoc,
 	}
 	noLabelCfg := tflitecpu.TFLiteConfig{ // detector config
 		ModelPath:  modelLoc,
@@ -277,7 +277,7 @@ func TestMoreMLDetectors(t *testing.T) {
 	cfg := tflitecpu.TFLiteConfig{
 		ModelPath:  modelLoc,
 		NumThreads: 2,
-		LabelPath:  &labelLoc,
+		LabelPath:  labelLoc,
 	}
 
 	// Test that a detector would give the expected output on the dog image
@@ -367,7 +367,7 @@ func TestLabelReader(t *testing.T) {
 	cfg := tflitecpu.TFLiteConfig{ // detector config
 		ModelPath:  modelLoc,
 		NumThreads: 2,
-		LabelPath:  &labelLoc,
+		LabelPath:  labelLoc,
 	}
 	out, err := tflitecpu.NewTFLiteCPUModel(ctx, &cfg, mlmodel.Named("fakeLabels"))
 	test.That(t, err, test.ShouldBeNil)
@@ -390,7 +390,7 @@ func TestSpaceDelineatedLabels(t *testing.T) {
 	cfg := tflitecpu.TFLiteConfig{ // detector config
 		ModelPath:  modelLoc,
 		NumThreads: 2,
-		LabelPath:  &labelLoc,
+		LabelPath:  labelLoc,
 	}
 	out, err := tflitecpu.NewTFLiteCPUModel(ctx, &cfg, mlmodel.Named("spacedLabels"))
 	test.That(t, err, test.ShouldBeNil)


### PR DESCRIPTION
There's a bug now because labelpath was originally written as a pointer to a string and not just a string. It's also supposed to be optional so when we walk the config and it gets visited and it's nil, it ends up panicking with a nil pointer dereference.  I could have hacked around it but I think the better fix is to make the attribute a direct string like every other one.

Tested on a Mac and I'm able to get my bounding boxes with numbers instead of classes. :)