### PR TITLE
DATA-1524 - Remove unused session ID from upload metadata

### DIFF
--- a/services/datamanager/datasync/upload_data_capture_file.go
+++ b/services/datamanager/datasync/upload_data_capture_file.go
@@ -30,7 +30,6 @@ func uploadDataCaptureFile(ctx context.Context, client v1.DataSyncServiceClient,
 			MethodParameters: md.GetMethodParameters(),
 			FileExtension:    md.GetFileExtension(),
 			Tags:             md.GetTags(),
-			SessionId:        md.GetSessionId(),
 		},
 		SensorContents: sensorData,
 	}


### PR DESCRIPTION
Session ID is neither populated in RDK nor used in app, so remove. This is the only place it's used in RDK.