### PR TITLE
[RSDK-3649] Create the obstacles_distance vision model

### DIFF
--- a/services/vision/obstacledistance/obstacle_distance.go
+++ b/services/vision/obstacledistance/obstacle_distance.go
@@ -27,8 +27,7 @@ var model = resource.DefaultModelFamily.WithModel("obstacle_distance_detector")
 // for the obstacle distance detection service.
 type DistanceDetectorConfig struct {
 	resource.TriviallyValidateConfig
-	DetectorName string `json:"detector_name"`
-	NumQueries   int    `json:"num_queries"`
+	NumQueries int `json:"num_queries"`
 }
 
 func init() {
@@ -58,10 +57,6 @@ func registerObstacleDistanceDetector(
 	if conf == nil {
 		return nil, errors.New("object detection config for distance detector cannot be nil")
 	}
-	usSensor, err := camera.FromRobot(r, conf.DetectorName)
-	if err != nil {
-		return nil, errors.Wrapf(err, "could not find necessary dependency, detector %q", conf.DetectorName)
-	}
 	if conf.NumQueries < 1 || conf.NumQueries > 20 {
 		return nil, errors.New("invalid number of queries, pick a number between 1 and 20")
 	}
@@ -70,7 +65,7 @@ func registerObstacleDistanceDetector(
 		clouds := make([]pointcloud.PointCloud, conf.NumQueries)
 
 		for i := 0; i < conf.NumQueries; i++ {
-			nxtPC, err := usSensor.NextPointCloud(ctx)
+			nxtPC, err := src.NextPointCloud(ctx)
 			if err != nil {
 				return nil, err
 			}

--- a/services/vision/obstacledistance/obstacle_distance.go
+++ b/services/vision/obstacledistance/obstacle_distance.go
@@ -1,0 +1,136 @@
+package obstacledistance
+
+import (
+	"context"
+
+	"github.com/edaniels/golog"
+	"github.com/golang/geo/r3"
+	"github.com/montanaflynn/stats"
+	"github.com/pkg/errors"
+	"go.opencensus.io/trace"
+
+	"go.viam.com/rdk/components/camera"
+	"go.viam.com/rdk/pointcloud"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/robot"
+	svision "go.viam.com/rdk/services/vision"
+	"go.viam.com/rdk/spatialmath"
+	"go.viam.com/rdk/utils"
+
+	vision "go.viam.com/rdk/vision"
+)
+
+var model = resource.DefaultModelFamily.WithModel("obstacle_distance_detector")
+
+type ObstacleDistanceDetectorConfig struct {
+	resource.TriviallyValidateConfig
+	DetectorName string `json:"detector_name"`
+	// ConfidenceThresh float64 `json:"confidence_threshold_pct"`
+	NumQueries int `json:"num_queries"`
+	// add field for number of queries
+}
+
+func init() {
+	resource.RegisterService(svision.API, model, resource.Registration[svision.Service, *ObstacleDistanceDetectorConfig]{
+		DeprecatedRobotConstructor: func(ctx context.Context, r any, c resource.Config, logger golog.Logger) (svision.Service, error) {
+			attrs, err := resource.NativeConfig[*ObstacleDistanceDetectorConfig](c)
+			if err != nil {
+				return nil, err
+			}
+			actualR, err := utils.AssertType[robot.Robot](r)
+			if err != nil {
+				return nil, err
+			}
+			return registerObstacleDistanceDetector(ctx, c.ResourceName(), attrs, actualR)
+		},
+	})
+}
+
+func registerObstacleDistanceDetector(
+	ctx context.Context,
+	name resource.Name,
+	conf *ObstacleDistanceDetectorConfig,
+	r robot.Robot,
+) (svision.Service, error) {
+	_, span := trace.StartSpan(ctx, "service::vision::registerObstacleDistanceDetector")
+	defer span.End()
+	if conf == nil {
+		return nil, errors.New("object detection config for distance detector cannot be nil")
+	}
+	usSensor, err := camera.FromRobot(r, conf.DetectorName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not find necessary dependency, detector %q", conf.DetectorName)
+	}
+	if conf.NumQueries < 1 || conf.NumQueries > 20 {
+		return nil, errors.New("invalid number of queries, pick a number between 1 and 20")
+	}
+
+	segmenter := func(ctx context.Context, src camera.VideoSource) ([]*vision.Object, error) {
+		clouds := []pointcloud.PointCloud{}
+
+		for i := 0; i < conf.NumQueries; i++ {
+			nxtPC, err := usSensor.NextPointCloud(ctx)
+			if err != nil {
+				return nil, err
+			}
+			clouds[i] = nxtPC
+		}
+
+		cloudsWithOffset := make([]pointcloud.CloudAndOffsetFunc, 0, len(clouds))
+		for _, cloud := range clouds {
+			cloudCopy := cloud
+			cloudFunc := func(ctx context.Context) (pointcloud.PointCloud, spatialmath.Pose, error) {
+				return cloudCopy, nil, nil
+			}
+			cloudsWithOffset = append(cloudsWithOffset, cloudFunc)
+		}
+		mergedCloud, err := pointcloud.MergePointClouds(context.Background(), cloudsWithOffset, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		values := []float64{}
+		count := 0
+
+		mergedCloud.Iterate(0, 0, func(p r3.Vector, d pointcloud.Data) bool {
+			values = append(values, p.Z)
+			count++
+			return true
+		})
+		if count > conf.NumQueries {
+			return nil, errors.New("more than one point from one of the readings, expected one")
+		}
+
+		median, err := stats.Median(values)
+		if err != nil {
+			return nil, err
+		}
+
+		vector := pointcloud.NewVector(0, 0, median)
+
+		pt := spatialmath.NewPoint(vector, "obstacle").Pose()
+
+		sphere, err := spatialmath.NewSphere(pt, 0, "obstacle")
+		if err != nil {
+			return nil, err
+		}
+
+		pcToReturn := pointcloud.New()
+		basicData := pointcloud.NewBasicData()
+		err = pcToReturn.Set(vector, basicData)
+		if err != nil {
+			return nil, err
+		}
+
+		// when iterating if more than one point, return error
+		// query nextpointcloud multiple times, take median?
+		// implementation of kalman filter (smart smoothing average function) over readings from nextpointcloud
+		// return pointcloud and geometry
+
+		toReturn := make([]*vision.Object, 0)
+		toReturn[0] = &vision.Object{PointCloud: pcToReturn, Geometry: sphere}
+
+		return toReturn, nil
+	}
+	return svision.NewService(name, r, nil, nil, nil, segmenter)
+}

--- a/services/vision/obstacledistance/obstacle_distance.go
+++ b/services/vision/obstacledistance/obstacle_distance.go
@@ -89,9 +89,6 @@ func registerObstacleDistanceDetector(
 		count := 0
 
 		mergedCloud.Iterate(0, 0, func(p r3.Vector, d pointcloud.Data) bool {
-			// if p.X != 0 || p.Y != 0 {
-			// Should this be an error case?
-			// }
 			values = append(values, p.Z)
 			count++
 			return true

--- a/services/vision/obstacledistance/obstacle_distance_test.go
+++ b/services/vision/obstacledistance/obstacle_distance_test.go
@@ -111,5 +111,4 @@ func TestObstacleDistDetector(t *testing.T) {
 	// with error - nil parameters
 	_, err = registerObstacleDistanceDetector(ctx, name, nil, r)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "cannot be nil")
-
 }

--- a/services/vision/obstacledistance/obstacle_distance_test.go
+++ b/services/vision/obstacledistance/obstacle_distance_test.go
@@ -19,8 +19,7 @@ import (
 
 func TestObstacleDistDetector(t *testing.T) {
 	inp := DistanceDetectorConfig{
-		DetectorName: "fakeCamera",
-		NumQueries:   10,
+		NumQueries: 10,
 	}
 	ctx := context.Background()
 	r := &inject.Robot{}

--- a/services/vision/obstacledistance/obstacle_distance_test.go
+++ b/services/vision/obstacledistance/obstacle_distance_test.go
@@ -107,4 +107,10 @@ func TestObstacleDistDetector(t *testing.T) {
 	err = cloud2.Set(pc.NewVector(0, 0, 5.0), pc.NewColoredData(color.NRGBA{255, 0, 0, 255}))
 	_, err = medianFromPointClouds([]pc.PointCloud{cloud1, cloud2})
 	test.That(t, err.Error(), test.ShouldContainSubstring, "obstacles_distance expects only one point in the point cloud")
+
+	cloud2 = pc.New()
+	err = cloud2.Set(pc.NewVector(0, 0, 6.0), pc.NewColoredData(color.NRGBA{255, 0, 0, 255}))
+	err = cloud2.Set(pc.NewVector(0, 0, 5.0), pc.NewColoredData(color.NRGBA{255, 0, 0, 255}))
+	_, err = medianFromPointClouds([]pc.PointCloud{cloud1, cloud2})
+	test.That(t, err.Error(), test.ShouldContainSubstring, "obstacles_distance expects only one point in the point cloud")
 }

--- a/services/vision/obstacledistance/obstacle_distance_test.go
+++ b/services/vision/obstacledistance/obstacle_distance_test.go
@@ -40,7 +40,7 @@ func TestObstacleDistDetector(t *testing.T) {
 			return nil, resource.NewNotFoundError(n)
 		}
 	}
-	name := vision.Named("test_odd") // what should this line be
+	name := vision.Named("test_odd")
 	srv, err := registerObstacleDistanceDetector(ctx, name, &inp, r)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, srv.Name(), test.ShouldResemble, name)

--- a/services/vision/obstacledistance/obstacle_distance_test.go
+++ b/services/vision/obstacledistance/obstacle_distance_test.go
@@ -1,0 +1,50 @@
+package obstacledistance
+
+import (
+	"context"
+	"testing"
+
+	"go.viam.com/test"
+	"go.viam.com/utils/artifact"
+
+	"go.viam.com/rdk/rimage"
+	"go.viam.com/rdk/services/vision"
+	"go.viam.com/rdk/testutils/inject"
+)
+
+func TestObstacleDistDetector(t *testing.T) {
+	inp := ObstacleDistanceDetectorConfig{
+		NumQueries: 10,
+	}
+	ctx := context.Background()
+	r := &inject.Robot{}
+	name := vision.Named("test_odd") // what should this line be
+	srv, err := registerObstacleDistanceDetector(ctx, name, &inp, r)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, srv.Name(), test.ShouldResemble, name)
+	img, err := rimage.NewImageFromFile(artifact.MustPath("vision/objectdetection/detection_test.jpg"))
+	test.That(t, err, test.ShouldBeNil)
+
+	// Does not implement Detections
+	_, err = srv.Detections(ctx, img, nil)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "does not implement")
+
+	// Does not implement Classifications
+	_, err = srv.Classifications(ctx, img, 1, nil)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "does not implement")
+
+	// fakeCam := inject.NewCamera("myCam") // needs some work
+
+	// visObj, err := srv.GetObjectPointClouds(ctx, "usSensor", nil)
+
+	// with error - bad parameters
+	inp.NumQueries = 0 // value out of range
+	_, err = registerObstacleDistanceDetector(ctx, name, &inp, r)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "invalid number of queries")
+
+	// with error - nil parameters
+	_, err = registerObstacleDistanceDetector(ctx, name, nil, r)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "cannot be nil")
+}

--- a/services/vision/obstacledistance/obstacle_distance_test.go
+++ b/services/vision/obstacledistance/obstacle_distance_test.go
@@ -92,10 +92,19 @@ func TestObstacleDistDetector(t *testing.T) {
 	test.That(t, isPoint, test.ShouldBeTrue)
 
 	inp.NumQueries = 0 // value out of range
-	_, err = registerObstacleDistanceDetector(ctx, name, &inp, r)
+	_, err = inp.Validate("path")
 	test.That(t, err.Error(), test.ShouldContainSubstring, "invalid number of queries")
 
 	// with error - nil parameters
 	_, err = registerObstacleDistanceDetector(ctx, name, nil, r)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "cannot be nil")
+
+	// error more than one point in cloud
+	cloud1 := pc.New()
+	err = cloud1.Set(pc.NewVector(0, 0, 6.0), pc.NewColoredData(color.NRGBA{255, 0, 0, 255}))
+	cloud2 := pc.New()
+	err = cloud2.Set(pc.NewVector(0, 0, 2.0), pc.NewColoredData(color.NRGBA{255, 0, 0, 255}))
+	err = cloud2.Set(pc.NewVector(0, 0, 5.0), pc.NewColoredData(color.NRGBA{255, 0, 0, 255}))
+	_, err = medianFromPointClouds([]pc.PointCloud{cloud1, cloud2})
+	test.That(t, err.Error(), test.ShouldContainSubstring, "obstacles_distance expects only one point in the point cloud")
 }

--- a/services/vision/obstacledistance/obstacle_distance_test.go
+++ b/services/vision/obstacledistance/obstacle_distance_test.go
@@ -17,7 +17,7 @@ import (
 	"go.viam.com/rdk/testutils/inject"
 )
 
-func TestObstacleDistDetector(t *testing.T) {
+func TestObstacleDist(t *testing.T) {
 	inp := DistanceDetectorConfig{
 		NumQueries: 10,
 	}
@@ -92,17 +92,17 @@ func TestObstacleDistDetector(t *testing.T) {
 	test.That(t, isPoint, test.ShouldBeTrue)
 
 	// error more than one point in cloud
+	count = 0
 	cam.NextPointCloudFunc = func(ctx context.Context) (pc.PointCloud, error) {
 		cloud := pc.New()
 		err = cloud.Set(pc.NewVector(0, 0, nums[count]), pc.NewColoredData(color.NRGBA{255, 0, 0, 255}))
 		test.That(t, err, test.ShouldBeNil)
 		err = cloud.Set(pc.NewVector(0, 0, 6.0), pc.NewColoredData(color.NRGBA{255, 0, 0, 255}))
 		test.That(t, err, test.ShouldBeNil)
-		count++
 		return cloud, err
 	}
 	_, err = srv.GetObjectPointClouds(ctx, "fakeCamera", nil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, "obstacles_distance expects only one point in the point cloud")
+	test.That(t, err.Error(), test.ShouldContainSubstring, "obstacles_distance expects one point in the point cloud")
 
 	inp.NumQueries = 0 // value out of range
 	_, err = inp.Validate("path")

--- a/services/vision/register/register.go
+++ b/services/vision/register/register.go
@@ -6,5 +6,6 @@ import (
 	_ "go.viam.com/rdk/services/vision/colordetector"
 	_ "go.viam.com/rdk/services/vision/detectionstosegments"
 	_ "go.viam.com/rdk/services/vision/mlvision"
+	_ "go.viam.com/rdk/services/vision/obstacledistance"
 	_ "go.viam.com/rdk/services/vision/radiusclustering"
 )


### PR DESCRIPTION
Add new vision model, for taking readings from a camera (probably an underlying sensor) and returning it as well formatted vision object.

For documentation purposes please pay special attention to the following error:
`obstacles_distance expects only one point in the point cloud from the camera. Underlying camera generates more than 1 point in its point cloud`
This just means that clouds from NextPointCloud should only be returning a singular point in their cloud, because it's supposed to be just one reading from an ultrasonic sensor or something of the sort, should just be one value.