### PR TITLE
RDSK-3752 - Configured gripper pose gets doubled

### DIFF
--- a/referenceframe/frame_system.go
+++ b/referenceframe/frame_system.go
@@ -589,7 +589,7 @@ func createFramesFromPart(part *FrameSystemPart) (Frame, Frame, error) {
 		if err != nil {
 			return nil, nil, err
 		}
-		pose, err := staticOriginFrame.Transform([]Input{})
+		pose, err := modelFrame.Transform([]Input{})
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
a hardware test was done to validate this solution.
cfg for the robot:
```
"components": [
    {
      "model": "fake",
      "attributes": {
        "arm-model": "ur5e"
      },
      "depends_on": [],
      "name": "a",
      "type": "arm",
      "frame": {
        "orientation": {
          "value": {
            "th": 0,
            "x": 0,
            "y": 0,
            "z": 1
          },
          "type": "ov_degrees"
        },
        "parent": "world",
        "translation": {
          "x": 0,
          "y": 0,
          "z": 0
        }
      }
    },
    {
      "name": "g",
      "type": "gripper",
      "model": "fake",
      "attributes": {},
      "depends_on": [],
      "frame": {
        "parent": "world",
        "translation": {
          "x": 0,
          "y": 0,
          "z": 40
        },
        "orientation": {
          "type": "ov_degrees",
          "value": {
            "x": 0,
            "y": 0,
            "z": 1,
            "th": 0
          }
        },
        "geometry": {
          "x": 1,
          "y": 1,
          "z": 1,
          "translation": {
            "x": 0,
            "y": 0,
            "z": 0
          }
        }
      }
    }
  ]
```

script used (golang):
```
	// Access myArm
	myArmComponent, _ := arm.FromRobot(robot, "a")

	// move to the arm to its home position
	myArmComponent.MoveToJointPositions(context.Background(), &v1.JointPositions{Values: []float64{0, 0, 0, 0, 0, 0}}, nil)

	// get motion service
	motionService, err := motion.FromRobot(robot, "builtin")
	if err != nil {
		logger.Fatal(err)
	}

	gripperName := "g"
	gripperResource := gripper.Named(gripperName)

	// Get the pose of gripper from the Motion Service
	mygripperPose, err := motionService.GetPose(context.Background(), gripperResource, referenceframe.World, nil, nil)
	if err != nil {
		fmt.Println(err)
	}
	fmt.Println("Position 1:", mygripperPose.Pose().Point())
```
in the script we validate that mygripperPose.Pose.Point.Z == 40 and not 80.