### PR TITLE
RSDK-3539: Make the gantry homing sequence asynchronous to the constructor

### DIFF
--- a/components/gantry/singleaxis/singleaxis.go
+++ b/components/gantry/singleaxis/singleaxis.go
@@ -223,6 +223,7 @@ func (g *singleAxis) Reconfigure(ctx context.Context, deps resource.Dependencies
 	return nil
 }
 
+// Home runs the homing sequence of the gantry, starts checkHit in the background, and returns true once completed.
 func (g *singleAxis) Home(ctx context.Context, extra map[string]interface{}) (bool, error) {
 	if g.cancelFunc != nil {
 		g.cancelFunc()
@@ -307,7 +308,7 @@ func (g *singleAxis) moveAway(ctx context.Context, pin int) error {
 	}
 }
 
-// Home runs the homing sequence of the gantry and returns true once completed.
+// doHome is a helper function that runs the actual homing sequence
 func (g *singleAxis) doHome(ctx context.Context) (bool, error) {
 	np := len(g.limitSwitchPins)
 	ctx, done := g.opMgr.New(ctx)

--- a/components/gantry/singleaxis/singleaxis.go
+++ b/components/gantry/singleaxis/singleaxis.go
@@ -308,7 +308,7 @@ func (g *singleAxis) moveAway(ctx context.Context, pin int) error {
 	}
 }
 
-// doHome is a helper function that runs the actual homing sequence
+// doHome is a helper function that runs the actual homing sequence.
 func (g *singleAxis) doHome(ctx context.Context) (bool, error) {
 	np := len(g.limitSwitchPins)
 	ctx, done := g.opMgr.New(ctx)

--- a/components/gantry/singleaxis/singleaxis_test.go
+++ b/components/gantry/singleaxis/singleaxis_test.go
@@ -767,35 +767,35 @@ func TestGoToInputs(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 
 	fakecfg := resource.Config{
-		Name:  "fake",
+		Name:  "fakeGantry",
 		Frame: fakeFrame,
 		ConvertedAttributes: &Config{
-			Motor:          motorName,
-			LengthMm:       1.0,
-			GantryMmPerSec: float64(300),
+			Motor:           motorName,
+			LengthMm:        1.0,
+			MmPerRevolution: 10,
 		},
 	}
 	deps := createFakeDepsForTestNewSingleAxis(t)
-	fakegantry, err := newSingleAxis(ctx, deps, fakecfg, logger)
+	g, err := newSingleAxis(ctx, deps, fakecfg, logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	g := fakegantry.(*singleAxis)
-
-	g.board = createFakeBoard()
-	g.limitSwitchPins = []string{"1", "2"}
-	g.limitHigh = true
-	g.motor = createFakeMotor()
-	g.lengthMm = 1.0
-	g.mmPerRevolution = 0.1
-	g.rpm = 10
-	g.positionLimits = []float64{1, 2}
-	g.model = nil
-	g.logger = logger
-
-	err = fakegantry.GoToInputs(ctx, inputs)
+	err = g.GoToInputs(ctx, inputs)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "is homed")
 
-	g.positionRange = 10
+	fakegantry := &singleAxis{
+		board:           createFakeBoard(),
+		limitSwitchPins: []string{"1", "2"},
+		limitHigh:       true,
+		motor:           createFakeMotor(),
+		lengthMm:        1.0,
+		mmPerRevolution: 0.1,
+		rpm:             10,
+		positionLimits:  []float64{1, 2},
+		model:           nil,
+		logger:          logger,
+	}
+
+	fakegantry.positionRange = 10
 	err = fakegantry.GoToInputs(ctx, inputs)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "needs 1 position to move")
 

--- a/components/gantry/singleaxis/singleaxis_test.go
+++ b/components/gantry/singleaxis/singleaxis_test.go
@@ -777,6 +777,7 @@ func TestGoToInputs(t *testing.T) {
 	}
 	deps := createFakeDepsForTestNewSingleAxis(t)
 	fakegantry, err := newSingleAxis(ctx, deps, fakecfg, logger)
+	test.That(t, err, test.ShouldBeNil)
 
 	g := fakegantry.(*singleAxis)
 

--- a/components/gantry/singleaxis/singleaxis_test.go
+++ b/components/gantry/singleaxis/singleaxis_test.go
@@ -766,19 +766,36 @@ func TestGoToInputs(t *testing.T) {
 	inputs := []referenceframe.Input{}
 	logger := golog.NewTestLogger(t)
 
-	fakegantry := &singleAxis{
-		board:           createFakeBoard(),
-		limitSwitchPins: []string{"1", "2"},
-		limitHigh:       true,
-		motor:           createFakeMotor(),
-		lengthMm:        1.0,
-		mmPerRevolution: 0.1,
-		rpm:             10,
-		positionLimits:  []float64{1, 2},
-		model:           nil,
-		logger:          logger,
+	fakecfg := resource.Config{
+		Name:  "fake",
+		Frame: fakeFrame,
+		ConvertedAttributes: &Config{
+			Motor:          motorName,
+			LengthMm:       1.0,
+			GantryMmPerSec: float64(300),
+		},
 	}
-	err := fakegantry.GoToInputs(ctx, inputs)
+	deps := createFakeDepsForTestNewSingleAxis(t)
+	fakegantry, err := newSingleAxis(ctx, deps, fakecfg, logger)
+
+	g := fakegantry.(*singleAxis)
+
+	g.board = createFakeBoard()
+	g.limitSwitchPins = []string{"1", "2"}
+	g.limitHigh = true
+	g.motor = createFakeMotor()
+	g.lengthMm = 1.0
+	g.mmPerRevolution = 0.1
+	g.rpm = 10
+	g.positionLimits = []float64{1, 2}
+	g.model = nil
+	g.logger = logger
+
+	err = fakegantry.GoToInputs(ctx, inputs)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "is homed")
+
+	g.positionRange = 10
+	err = fakegantry.GoToInputs(ctx, inputs)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "needs 1 position to move")
 
 	inputs = []referenceframe.Input{{Value: 1.0}, {Value: 2.0}}


### PR DESCRIPTION
The initial changes in this PR successfully implement homing as a background coroutine, however this meant all axes would home at once, which is not what we want. The solution is to remove homing from construction/reconfiguration, and add logs and errors that inform users they must run Home before they can use MoveToPosition