### PR TITLE
RSDK-3299 - Clarify navigation behavior in log statement when MoveOnGlobe errors out

### DIFF
--- a/services/navigation/builtin/builtin.go
+++ b/services/navigation/builtin/builtin.go
@@ -430,7 +430,7 @@ func (svc *builtIn) startWaypointExperimental(extra map[string]interface{}) erro
 		for wp, err := svc.nextWaypoint(svc.cancelCtx); err == nil; wp, err = svc.nextWaypoint(svc.cancelCtx) {
 			svc.logger.Infof("navigating to waypoint: %+v", wp)
 			if err := navOnce(svc.cancelCtx, wp); err != nil {
-				svc.logger.Infof("skipping waypoint %+v due to error navigating: %s", wp, err)
+				svc.logger.Infof("skipping waypoint %+v due to error while navigating towards it: %s", wp, err)
 			}
 		}
 

--- a/services/navigation/builtin/builtin.go
+++ b/services/navigation/builtin/builtin.go
@@ -430,7 +430,7 @@ func (svc *builtIn) startWaypointExperimental(extra map[string]interface{}) erro
 		for wp, err := svc.nextWaypoint(svc.cancelCtx); err == nil; wp, err = svc.nextWaypoint(svc.cancelCtx) {
 			svc.logger.Infof("navigating to waypoint: %+v", wp)
 			if err := navOnce(svc.cancelCtx, wp); err != nil {
-				svc.logger.Infof("error navigating: %s", err)
+				svc.logger.Infof("skipping waypoint %+v due to error navigating: %s", wp, err)
 			}
 		}
 


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-3299

The ticket above asks for verification that the navigation service continues to the next waypoint when `MoveOnGlobe` errors out. This seems to be the case since the returned error from `MoveOnGlobe` is passed through `navOnce` to [this log statement](https://github.com/viamrobotics/rdk/blob/87f32df5ab71fee742c0237b8b9fdcaf7ac68bab/services/navigation/builtin/builtin.go#L433), after which we continue processing the next waypoint.

This PR adds more information to the log statement to clarify that we're skipping the waypoint.