### PR TITLE
RSDK-3795 - Switch from deprecated file IDs to binary IDs

### DIFF
--- a/components/camera/replaypcd/replaypcd.go
+++ b/components/camera/replaypcd/replaypcd.go
@@ -203,7 +203,7 @@ func (replay *pcdCamera) NextPointCloud(ctx context.Context) (pointcloud.PointCl
 		md := dataResponse.GetMetadata()
 		replay.cache[i] = &cacheEntry{id: &datapb.BinaryID{
 			FileId:         md.GetId(),
-			OrganizationId: md.GetCaptureMetadata().GetOrganizationId(),
+			OrganizationId: md.GetCaptureMetadata().GetOrgId(),
 			LocationId:     md.GetCaptureMetadata().GetLocationId(),
 		}}
 	}

--- a/components/camera/replaypcd/replaypcd.go
+++ b/components/camera/replaypcd/replaypcd.go
@@ -62,7 +62,7 @@ type TimeInterval struct {
 // cacheEntry stores data that was downloaded from a previous operation but has not yet been passed
 // to the caller.
 type cacheEntry struct {
-	id            string
+	id            *datapb.BinaryID
 	pc            pointcloud.PointCloud
 	timeRequested *timestamppb.Timestamp
 	timeReceived  *timestamppb.Timestamp
@@ -200,7 +200,12 @@ func (replay *pcdCamera) NextPointCloud(ctx context.Context) (pointcloud.PointCl
 	// data in parallel and cache the results
 	replay.cache = make([]*cacheEntry, len(resp.Data))
 	for i, dataResponse := range resp.Data {
-		replay.cache[i] = &cacheEntry{id: dataResponse.GetMetadata().Id}
+		md := dataResponse.GetMetadata()
+		replay.cache[i] = &cacheEntry{id: &datapb.BinaryID{
+			FileId:         md.GetId(),
+			OrganizationId: md.GetCaptureMetadata().GetOrganizationId(),
+			LocationId:     md.GetCaptureMetadata().GetLocationId(),
+		}}
 	}
 
 	ctxTimeout, cancelTimeout := context.WithTimeout(ctx, downloadTimeout)
@@ -227,7 +232,7 @@ func (replay *pcdCamera) downloadBatch(ctx context.Context) {
 
 			var resp *datapb.BinaryDataByIDsResponse
 			resp, data.err = replay.dataClient.BinaryDataByIDs(ctx, &datapb.BinaryDataByIDsRequest{
-				FileIds:       []string{data.id},
+				BinaryIds:     []*datapb.BinaryID{data.id},
 				IncludeBinary: true,
 			})
 			if data.err != nil {

--- a/components/camera/replaypcd/replaypcd_utils_test.go
+++ b/components/camera/replaypcd/replaypcd_utils_test.go
@@ -33,7 +33,11 @@ import (
 	"go.viam.com/rdk/testutils/inject"
 )
 
-const testTime = "2000-01-01T12:00:%02dZ"
+const (
+	testTime   = "2000-01-01T12:00:%02dZ"
+	orgID      = "slam_org_id"
+	locationID = "slam_location_id"
+)
 
 // mockDataServiceServer is a struct that includes unimplemented versions of all the Data Service endpoints. These
 // can be overwritten to allow developers to trigger desired behaviors during testing.
@@ -46,9 +50,7 @@ type mockDataServiceServer struct {
 func (mDServer *mockDataServiceServer) BinaryDataByIDs(ctx context.Context, req *datapb.BinaryDataByIDsRequest,
 ) (*datapb.BinaryDataByIDsResponse, error) {
 	// Parse request
-	// TODO(RSDK-3795): Update BinaryDataByIDs test to match newest API
-	//nolint: staticcheck
-	fileID := req.FileIds[0]
+	fileID := req.BinaryIds[0].GetFileId()
 
 	data, err := getCompressedBytesFromArtifact(fileID)
 	if err != nil {
@@ -71,6 +73,10 @@ func (mDServer *mockDataServiceServer) BinaryDataByIDs(ctx context.Context, req 
 			Id:            fileID,
 			TimeRequested: timeReq,
 			TimeReceived:  timeRec,
+			CaptureMetadata: &datapb.CaptureMetadata{
+				OrgId:      orgID,
+				LocationId: locationID,
+			},
 		},
 	}
 	resp := &datapb.BinaryDataByIDsResponse{
@@ -113,6 +119,10 @@ func (mDServer *mockDataServiceServer) BinaryDataByFilter(ctx context.Context, r
 				Id:            fmt.Sprintf(datasetDirectory, newFileNum),
 				TimeRequested: timeReq,
 				TimeReceived:  timeRec,
+				CaptureMetadata: &datapb.CaptureMetadata{
+					OrgId:      orgID,
+					LocationId: locationID,
+				},
 			},
 		}
 
@@ -133,6 +143,10 @@ func (mDServer *mockDataServiceServer) BinaryDataByFilter(ctx context.Context, r
 					Id:            fmt.Sprintf(datasetDirectory, newFileNum+i),
 					TimeRequested: timeReq,
 					TimeReceived:  timeRec,
+					CaptureMetadata: &datapb.CaptureMetadata{
+						OrgId:      orgID,
+						LocationId: locationID,
+					},
 				},
 			}
 			resp.Data = append(resp.Data, &binaryData)


### PR DESCRIPTION
Pulled these changes out of https://github.com/viamrobotics/rdk/pull/2591. Switch use of deprecated FileIDs in BinaryDataByIDs to BinaryIDs.

Tested CLI locally and ran replaypcd tests.