### PR TITLE
Remove LocalMotor and GoTillStop

### DIFF
--- a/components/motor/dimensionengineering/sabertooth.go
+++ b/components/motor/dimensionengineering/sabertooth.go
@@ -201,7 +201,7 @@ func (cfg *Config) validateValues() error {
 }
 
 // NewMotor returns a Sabertooth driven motor.
-func NewMotor(ctx context.Context, c *Config, name resource.Name, logger golog.Logger) (motor.LocalMotor, error) {
+func NewMotor(ctx context.Context, c *Config, name resource.Name, logger golog.Logger) (motor.Motor, error) {
 	globalMu.Lock()
 	defer globalMu.Unlock()
 
@@ -414,11 +414,6 @@ func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[s
 // towards the specified target/position.
 func (m *Motor) GoTo(ctx context.Context, rpm, position float64, extra map[string]interface{}) error {
 	return motor.NewGoToUnsupportedError(fmt.Sprintf("Channel %d on Sabertooth %d", m.Channel, m.c.address))
-}
-
-// GoTillStop moves a motor until stopped by the controller (due to switch or function) or stopFunc.
-func (m *Motor) GoTillStop(ctx context.Context, rpm float64, stopFunc func(ctx context.Context) bool) error {
-	return motor.NewGoTillStopUnsupportedError(fmt.Sprintf("Channel %d on Sabertooth %d", m.Channel, m.c.address))
 }
 
 // ResetZeroPosition defines the current position to be zero (+/- offset).

--- a/components/motor/dimensionengineering/sabertooth_test.go
+++ b/components/motor/dimensionengineering/sabertooth_test.go
@@ -57,8 +57,6 @@ func TestSabertoothMotor(t *testing.T) {
 
 	motor1, ok := m1.(motor.Motor)
 	test.That(t, ok, test.ShouldBeTrue)
-	_, ok = motor1.(motor.LocalMotor)
-	test.That(t, ok, test.ShouldBeTrue)
 
 	t.Run("motor supports position reporting", func(t *testing.T) {
 		features, err := motor1.Properties(ctx, nil)
@@ -113,8 +111,6 @@ func TestSabertoothMotor(t *testing.T) {
 	checkTx(t, resChan, c, []byte{0x80, 0x04, 0x00, 0x04})
 
 	motor2, ok := m2.(motor.Motor)
-	test.That(t, ok, test.ShouldBeTrue)
-	_, ok = motor2.(motor.LocalMotor)
 	test.That(t, ok, test.ShouldBeTrue)
 
 	t.Run("motor supports position reporting", func(t *testing.T) {
@@ -185,8 +181,6 @@ func TestSabertoothMotorDirectionFlip(t *testing.T) {
 
 	motor1, ok := m1.(motor.Motor)
 	test.That(t, ok, test.ShouldBeTrue)
-	_, ok = motor1.(motor.LocalMotor)
-	test.That(t, ok, test.ShouldBeTrue)
 
 	t.Run("motor SetPower testing", func(t *testing.T) {
 		// Test 0 (aka "stop")
@@ -235,8 +229,6 @@ func TestSabertoothMotorDirectionFlip(t *testing.T) {
 	checkTx(t, resChan, c, []byte{0x80, 0x04, 0x00, 0x04})
 
 	motor2, ok := m2.(motor.Motor)
-	test.That(t, ok, test.ShouldBeTrue)
-	_, ok = motor2.(motor.LocalMotor)
 	test.That(t, ok, test.ShouldBeTrue)
 
 	t.Run("motor supports position reporting", func(t *testing.T) {
@@ -305,9 +297,7 @@ func TestSabertoothRampConfig(t *testing.T) {
 	checkTx(t, resChan, c, []byte{0x80, 0x00, 0x00, 0x00})
 	checkTx(t, resChan, c, []byte{0x80, 0x10, 0x64, 0x74})
 
-	motor1, ok := m1.(motor.Motor)
-	test.That(t, ok, test.ShouldBeTrue)
-	_, ok = motor1.(motor.LocalMotor)
+	_, ok = m1.(motor.Motor)
 	test.That(t, ok, test.ShouldBeTrue)
 }
 

--- a/components/motor/dmc4000/dmc4000_test.go
+++ b/components/motor/dmc4000/dmc4000_test.go
@@ -123,8 +123,6 @@ func TestDMC4000Motor(t *testing.T) {
 	}()
 	motorDep, ok := m.(motor.Motor)
 	test.That(t, ok, test.ShouldBeTrue)
-	stoppableMotor, ok := motorDep.(motor.LocalMotor)
-	test.That(t, ok, test.ShouldBeTrue)
 	waitTx(t, resChan)
 
 	t.Run("motor supports position reporting", func(t *testing.T) {
@@ -656,101 +654,6 @@ func TestDMC4000Motor(t *testing.T) {
 		txMu.Lock()
 		go checkTx(resChan, c, []string{"DPA=39680"})
 		test.That(t, motorDep.ResetZeroPosition(ctx, 3.1, nil), test.ShouldBeNil)
-		waitTx(t, resChan)
-	})
-
-	t.Run("motor gotillstop testing", func(t *testing.T) {
-		// No stop func
-		txMu.Lock()
-		go checkRx(resChan, c,
-			[]string{
-				"JGA=32000",
-				"BGA",
-				"SCA",
-				"SCA",
-				"SCA",
-				"SCA",
-				"SCA",
-				"SCA",
-				"SCA",
-				"TEA",
-				"STA",
-				"SCA",
-				"TEA",
-			},
-			[]string{
-				":",
-				":",
-				" 0\r\n:",
-				" 0\r\n:",
-				" 0\r\n:",
-				" 0\r\n:",
-				" 0\r\n:",
-				" 0\r\n:",
-				" 4\r\n:",
-				" 0\r\n:",
-				":",
-				" 4\r\n:",
-				" 0\r\n:",
-			},
-		)
-		test.That(t, stoppableMotor.GoTillStop(ctx, -25.0, nil), test.ShouldBeNil)
-
-		// Always-false stopFunc
-		txMu.Lock()
-		go checkRx(resChan, c,
-			[]string{
-				"JGA=5333",
-				"BGA",
-				"SCA",
-				"SCA",
-				"SCA",
-				"SCA",
-				"SCA",
-				"SCA",
-				"SCA",
-				"TEA",
-				"STA",
-				"SCA",
-				"TEA",
-			},
-			[]string{
-				":",
-				":",
-				" 0\r\n:",
-				" 0\r\n:",
-				" 0\r\n:",
-				" 0\r\n:",
-				" 0\r\n:",
-				" 0\r\n:",
-				" 4\r\n:",
-				" 0\r\n:",
-				":",
-				" 4\r\n:",
-				" 0\r\n:",
-			},
-		)
-		test.That(t, stoppableMotor.GoTillStop(ctx, -25.0, func(ctx context.Context) bool { return false }), test.ShouldBeNil)
-
-		// Always true stopFunc
-		txMu.Lock()
-		go checkRx(resChan, c,
-			[]string{
-				"JGA=32000",
-				"BGA",
-				"STA",
-				"SCA",
-				"TEA",
-			},
-			[]string{
-				":",
-				":",
-				":",
-				" 4\r\n:",
-				" 0\r\n:",
-			},
-		)
-		test.That(t, stoppableMotor.GoTillStop(ctx, -25.0, func(ctx context.Context) bool { return true }), test.ShouldBeNil)
 		waitTx(t, resChan)
 	})
 

--- a/components/motor/errors.go
+++ b/components/motor/errors.go
@@ -2,12 +2,6 @@ package motor
 
 import "github.com/pkg/errors"
 
-// NewGoTillStopUnsupportedError returns a standard error for when a motor
-// is required to support the GoTillStop feature.
-func NewGoTillStopUnsupportedError(motorName string) error {
-	return errors.Errorf("motor with name %s does not support GoTillStop", motorName)
-}
-
 // NewResetZeroPositionUnsupportedError returns a standard error for when a motor
 // is required to support reseting the zero position.
 func NewResetZeroPositionUnsupportedError(motorName string) error {

--- a/components/motor/fake/motor.go
+++ b/components/motor/fake/motor.go
@@ -361,9 +361,22 @@ func (m *Motor) Stop(ctx context.Context, extra map[string]interface{}) error {
 	return nil
 }
 
-// ResetZeroPosition resets the zero position of the motor.
+// ResetZeroPosition resets the zero position.
 func (m *Motor) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]interface{}) error {
-	return m.Encoder.ResetPosition(ctx, extra)
+	if m.Encoder == nil {
+		return errors.New("encoder is not defined")
+	}
+
+	if m.TicksPerRotation == 0 {
+		return errors.New("need nonzero TicksPerRotation for motor")
+	}
+
+	err := m.Encoder.ResetPosition(ctx, extra)
+	if err != nil {
+		return errors.Wrapf(err, "error in ResetZeroPosition from motor (%s)", m.Name())
+	}
+
+	return nil
 }
 
 // IsPowered returns if the motor is pretending to be on or not, and its power level.

--- a/components/motor/fake/motor.go
+++ b/components/motor/fake/motor.go
@@ -77,8 +77,6 @@ func init() {
 	})
 }
 
-var _ motor.LocalMotor = &Motor{}
-
 // A Motor allows setting and reading a set power percentage and
 // direction.
 type Motor struct {
@@ -347,29 +345,6 @@ func (m *Motor) GoTo(ctx context.Context, rpm, pos float64, extra map[string]int
 	return nil
 }
 
-// GoTillStop always returns an error.
-func (m *Motor) GoTillStop(ctx context.Context, rpm float64, stopFunc func(ctx context.Context) bool) error {
-	return motor.NewGoTillStopUnsupportedError(m.Name().ShortName())
-}
-
-// ResetZeroPosition resets the zero position.
-func (m *Motor) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]interface{}) error {
-	if m.Encoder == nil {
-		return errors.New("encoder is not defined")
-	}
-
-	if m.TicksPerRotation == 0 {
-		return errors.New("need nonzero TicksPerRotation for motor")
-	}
-
-	err := m.Encoder.ResetPosition(ctx, extra)
-	if err != nil {
-		return errors.Wrapf(err, "error in ResetZeroPosition from motor (%s)", m.Name())
-	}
-
-	return nil
-}
-
 // Stop has the motor pretend to be off.
 func (m *Motor) Stop(ctx context.Context, extra map[string]interface{}) error {
 	m.mu.Lock()
@@ -384,6 +359,11 @@ func (m *Motor) Stop(ctx context.Context, extra map[string]interface{}) error {
 		}
 	}
 	return nil
+}
+
+// ResetZeroPosition resets the zero position of the motor.
+func (m *Motor) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]interface{}) error {
+	return m.Encoder.ResetPosition(ctx, extra)
 }
 
 // IsPowered returns if the motor is pretending to be on or not, and its power level.

--- a/components/motor/fake/motor_test.go
+++ b/components/motor/fake/motor_test.go
@@ -111,27 +111,6 @@ func TestGoTo(t *testing.T) {
 	})
 }
 
-func TestGoTillStop(t *testing.T) {
-	logger := golog.NewTestLogger(t)
-	ctx := context.Background()
-
-	enc, err := fake.NewEncoder(context.Background(), resource.Config{
-		ConvertedAttributes: &fake.Config{},
-	})
-	test.That(t, err, test.ShouldBeNil)
-	m := &Motor{
-		Named:             motor.Named("foo").AsNamed(),
-		Encoder:           enc.(fake.Encoder),
-		Logger:            logger,
-		PositionReporting: true,
-		MaxRPM:            60,
-		TicksPerRotation:  1,
-	}
-
-	err = m.GoTillStop(ctx, 0, func(ctx context.Context) bool { return false })
-	test.That(t, err, test.ShouldNotBeNil)
-}
-
 func TestResetZeroPosition(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	ctx := context.Background()

--- a/components/motor/gpio/basic.go
+++ b/components/motor/gpio/basic.go
@@ -326,8 +326,3 @@ func (m *Motor) GoTo(ctx context.Context, rpm, positionRevolutions float64, extr
 func (m *Motor) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]interface{}) error {
 	return motor.NewResetZeroPositionUnsupportedError(m.Name().ShortName())
 }
-
-// GoTillStop is not supported.
-func (m *Motor) GoTillStop(ctx context.Context, rpm float64, stopFunc func(ctx context.Context) bool) error {
-	return motor.NewGoTillStopUnsupportedError(m.Name().ShortName())
-}

--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -60,7 +60,6 @@ func WrapMotorWithEncoder(
 		return m, nil
 	}
 
-	logger.Info("meow")
 	if mc.TicksPerRotation < 0 {
 		return nil, utils.NewConfigValidationError("", errors.New("ticks_per_rotation should be positive or zero"))
 	}

--- a/components/motor/i2cmotors/ezopmp.go
+++ b/components/motor/i2cmotors/ezopmp.go
@@ -98,7 +98,7 @@ const (
 // NewMotor returns a motor(Ezopmp) with I2C protocol.
 func NewMotor(ctx context.Context, deps resource.Dependencies, c *Config, name resource.Name,
 	logger golog.Logger,
-) (motor.LocalMotor, error) {
+) (motor.Motor, error) {
 	b, err := board.FromDependencies(deps, c.BoardName)
 	if err != nil {
 		return nil, err
@@ -375,9 +375,4 @@ func (m *Ezopmp) IsPowered(ctx context.Context, extra map[string]interface{}) (b
 		return true, m.powerPct, nil
 	}
 	return false, 0.0, nil
-}
-
-// GoTillStop is unimplemented.
-func (m *Ezopmp) GoTillStop(ctx context.Context, rpm float64, stopFunc func(ctx context.Context) bool) error {
-	return motor.NewGoTillStopUnsupportedError(m.Name().ShortName())
 }

--- a/components/motor/motor.go
+++ b/components/motor/motor.go
@@ -73,17 +73,6 @@ type Motor interface {
 	IsPowered(ctx context.Context, extra map[string]interface{}) (bool, float64, error)
 }
 
-// A LocalMotor is a motor that supports additional features provided by RDK
-// (e.g. GoTillStop).
-type LocalMotor interface {
-	Motor
-	// GoTillStop moves a motor until stopped. The "stop" mechanism is up to the underlying motor implementation.
-	// Ex: EncodedMotor goes until physically stopped/stalled (detected by change in position being very small over a fixed time.)
-	// Ex: TMCStepperMotor has "StallGuard" which detects the current increase when obstructed and stops when that reaches a threshold.
-	// Ex: Other motors may use an endstop switch (such as via a DigitalInterrupt) or be configured with other sensors.
-	GoTillStop(ctx context.Context, rpm float64, stopFunc func(ctx context.Context) bool) error
-}
-
 // Named is a helper for getting the named Motor's typed resource name.
 func Named(name string) resource.Name {
 	return resource.NewName(API, name)

--- a/components/motor/motor_test.go
+++ b/components/motor/motor_test.go
@@ -55,7 +55,7 @@ func TestStatusValid(t *testing.T) {
 func TestCreateStatus(t *testing.T) {
 	status := &pb.Status{IsPowered: true, Position: 7.7, IsMoving: true}
 
-	injectMotor := &inject.LocalMotor{}
+	injectMotor := &inject.Motor{}
 	injectMotor.IsPoweredFunc = func(ctx context.Context, extra map[string]interface{}) (bool, float64, error) {
 		return status.IsPowered, 1.0, nil
 	}

--- a/components/motor/roboclaw/roboclaw.go
+++ b/components/motor/roboclaw/roboclaw.go
@@ -372,7 +372,3 @@ func (m *roboclawMotor) IsPowered(ctx context.Context, extra map[string]interfac
 		return false, 0.0, m.conf.wrongChannelError()
 	}
 }
-
-func (m *roboclawMotor) GoTillStop(ctx context.Context, rpm float64, stopFunc func(ctx context.Context) bool) error {
-	return motor.NewGoTillStopUnsupportedError(m.Name().ShortName())
-}

--- a/components/motor/tmcstepper/stepper_motor_tmc.go
+++ b/components/motor/tmcstepper/stepper_motor_tmc.go
@@ -601,7 +601,7 @@ func (m *Motor) goTillStop(ctx context.Context, rpm float64, stopFunc func(ctx c
 	var fails int
 	for {
 		if !utils.SelectContextOrWait(ctx, 10*time.Millisecond) {
-			return errors.New("context cancelled during GoTillStop")
+			return errors.New("context cancelled: duration timeout trying to get up to speed while homing")
 		}
 
 		if stopFunc != nil && stopFunc(ctx) {
@@ -618,7 +618,7 @@ func (m *Motor) goTillStop(ctx context.Context, rpm float64, stopFunc func(ctx c
 		}
 
 		if fails >= 500 {
-			return errors.New("timed out during GoTillStop acceleration")
+			return errors.New("over 500 failures trying to get up to speed while homing")
 		}
 		fails++
 	}
@@ -632,7 +632,7 @@ func (m *Motor) goTillStop(ctx context.Context, rpm float64, stopFunc func(ctx c
 	fails = 0
 	for {
 		if !utils.SelectContextOrWait(ctx, 10*time.Millisecond) {
-			return errors.New("context cancelled during GoTillStop")
+			return errors.New("context cancelled: duration timeout trying to stop at the endstop while homing")
 		}
 
 		if stopFunc != nil && stopFunc(ctx) {
@@ -648,7 +648,7 @@ func (m *Motor) goTillStop(ctx context.Context, rpm float64, stopFunc func(ctx c
 		}
 
 		if fails >= 10000 {
-			return errors.New("timed out during GoTillStop")
+			return errors.New("over 1000 failures trying to stop at endstop while homing")
 		}
 		fails++
 	}

--- a/components/motor/tmcstepper/stepper_motor_tmc.go
+++ b/components/motor/tmcstepper/stepper_motor_tmc.go
@@ -146,7 +146,7 @@ const (
 // NewMotor returns a TMC5072 driven motor.
 func NewMotor(ctx context.Context, deps resource.Dependencies, c TMC5072Config, name resource.Name,
 	logger golog.Logger,
-) (motor.LocalMotor, error) {
+) (motor.Motor, error) {
 	b, err := board.FromDependencies(deps, c.BoardName)
 	if err != nil {
 		return nil, errors.Errorf("%q is not a board", c.BoardName)
@@ -560,9 +560,9 @@ func (m *Motor) IsMoving(ctx context.Context) (bool, error) {
 	return !stop, err
 }
 
-// Home homes the motor using stallguard.
-func (m *Motor) Home(ctx context.Context) error {
-	err := m.GoTillStop(ctx, m.homeRPM, nil)
+// home homes the motor using stallguard.
+func (m *Motor) home(ctx context.Context) error {
+	err := m.goTillStop(ctx, m.homeRPM, nil)
 	if err != nil {
 		return err
 	}
@@ -579,8 +579,8 @@ func (m *Motor) Home(ctx context.Context) error {
 	return m.ResetZeroPosition(ctx, 0, nil)
 }
 
-// GoTillStop enables StallGuard detection, then moves in the direction/speed given until resistance (endstop) is detected.
-func (m *Motor) GoTillStop(ctx context.Context, rpm float64, stopFunc func(ctx context.Context) bool) error {
+// goTillStop enables StallGuard detection, then moves in the direction/speed given until resistance (endstop) is detected.
+func (m *Motor) goTillStop(ctx context.Context, rpm float64, stopFunc func(ctx context.Context) bool) error {
 	if err := m.Jog(ctx, rpm); err != nil {
 		return err
 	}
@@ -688,7 +688,7 @@ func (m *Motor) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[
 	}
 	switch name {
 	case Home:
-		return nil, m.Home(ctx)
+		return nil, m.home(ctx)
 	case Jog:
 		rpmRaw, ok := cmd[RPMVal]
 		if !ok {

--- a/components/motor/tmcstepper/stepper_motor_tmc_test.go
+++ b/components/motor/tmcstepper/stepper_motor_tmc_test.go
@@ -192,7 +192,6 @@ func TestTMCStepperMotor(t *testing.T) {
 	}()
 	motorDep, ok := m.(motor.Motor)
 	test.That(t, ok, test.ShouldBeTrue)
-	stoppableMotor, ok := motorDep.(motor.LocalMotor)
 	test.That(t, ok, test.ShouldBeTrue)
 
 	t.Run("motor supports position reporting", func(t *testing.T) {
@@ -615,123 +614,6 @@ func TestTMCStepperMotor(t *testing.T) {
 			},
 		)
 		test.That(t, motorDep.ResetZeroPosition(ctx, 3.1, nil), test.ShouldBeNil)
-	})
-
-	t.Run("motor gotillstop testing", func(t *testing.T) {
-		go func() {
-			// Jog
-			checkTx(t, c,
-				[][]byte{
-					{160, 0, 0, 0, 2},
-					{167, 0, 0, 105, 234},
-				},
-			)
-
-			// RampStat (for velocity reached)
-			checkRx(t, c,
-				[][]byte{
-					{53, 0, 0, 0, 0},
-					{53, 0, 0, 0, 0},
-				},
-				[][]byte{
-					{0, 0, 0, 1, 0},
-					{0, 0, 0, 1, 0},
-				},
-			)
-
-			// Enable SG
-			checkTx(t, c, [][]byte{
-				{180, 0, 0, 4, 0},
-			})
-
-			// RampStat (for velocity zero reached)
-			checkRx(t, c,
-				[][]byte{
-					{53, 0, 0, 0, 0},
-					{53, 0, 0, 0, 0},
-				},
-				[][]byte{
-					{0, 0, 0, 4, 0},
-					{0, 0, 0, 4, 0},
-				},
-			)
-
-			// Deferred SG disable
-			checkTx(t, c, [][]byte{
-				{180, 0, 0, 0, 0},
-				{160, 0, 0, 0, 1},
-				{167, 0, 0, 0, 0},
-			})
-		}()
-		// No stop func
-		test.That(t, stoppableMotor.GoTillStop(ctx, -25.0, nil), test.ShouldBeNil)
-
-		go func() {
-			// Jog
-			checkTx(t, c,
-				[][]byte{
-					{160, 0, 0, 0, 2},
-					{167, 0, 0, 105, 234},
-				},
-			)
-
-			// RampStat (for velocity reached)
-			checkRx(t, c,
-				[][]byte{
-					{53, 0, 0, 0, 0},
-					{53, 0, 0, 0, 0},
-				},
-				[][]byte{
-					{0, 0, 0, 1, 0},
-					{0, 0, 0, 1, 0},
-				},
-			)
-
-			// Enable SG
-			checkTx(t, c, [][]byte{
-				{180, 0, 0, 4, 0},
-			})
-
-			// RampStat (for velocity zero reached)
-			checkRx(t, c,
-				[][]byte{
-					{53, 0, 0, 0, 0},
-					{53, 0, 0, 0, 0},
-				},
-				[][]byte{
-					{0, 0, 0, 4, 0},
-					{0, 0, 0, 4, 0},
-				},
-			)
-
-			// Deferred off and SG disable
-			checkTx(t, c, [][]byte{
-				{180, 0, 0, 0, 0},
-				{160, 0, 0, 0, 1},
-				{167, 0, 0, 0, 0},
-			})
-		}()
-		// Always-false stopFunc
-		test.That(t, stoppableMotor.GoTillStop(ctx, -25.0, func(ctx context.Context) bool { return false }), test.ShouldBeNil)
-
-		go func() {
-			// Jog
-			checkTx(t, c,
-				[][]byte{
-					{160, 0, 0, 0, 2},
-					{167, 0, 0, 105, 234},
-				},
-			)
-
-			// Deferred off and SG disable
-			checkTx(t, c, [][]byte{
-				{180, 0, 0, 0, 0},
-				{160, 0, 0, 0, 1},
-				{167, 0, 0, 0, 0},
-			})
-		}()
-		// Always true stopFunc
-		test.That(t, stoppableMotor.GoTillStop(ctx, -25.0, func(ctx context.Context) bool { return true }), test.ShouldBeNil)
 	})
 
 	//nolint:dupl


### PR DESCRIPTION
This makes the motor interface more uniform with our Motor API, and removes an intermediate interface and unimplemented methods from many motor drivers. 

Tested on a motor with a single encoder to verify `motor_encoder.go` does not show any regressions, server started and stopped cleanly and APIs functioned as expected from RC card.