### PR TITLE
pull function name out of dict correctly

### DIFF
--- a/etc/code-samples-action.py
+++ b/etc/code-samples-action.py
@@ -3,11 +3,11 @@ import json
 data = None
 with open("./examples/apis.json") as f:
     data = json.load(f)
-    data = data["functions"]
 with open("code-samples-warning.md", "w") as f:
     f.write("Warning your change may break code samples. ")
     f.write("If your change modifies any of the following functions please contact @viamrobotics/fleet-management. Thanks!\n")
     f.write("|component|function|\n")
     f.write("|-|-|\n")
     for k, v in data.items():
-        f.write(f"|{k}|{v}|\n")
+        func = v["func"]
+        f.write(f"|{k}|{func}|\n")


### PR DESCRIPTION
The code samples refactor changed our file format for adding code samples. This broke a script that warns users about breaking code samples. This fix adjusts that script to correctly get the component and function names