### PR TITLE
[RSDK-3608] Make the genericlinux I2C classes public

### DIFF
--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -64,7 +64,7 @@ func newBoard(
 		analogs: map[string]*wrappedAnalog{},
 		// this is not yet modified during reconfiguration but maybe should be
 		pwms:       map[string]pwmSetting{},
-		i2cs:       map[string]*i2cBus{},
+		i2cs:       map[string]*I2cBus{},
 		gpios:      map[string]*gpioPin{},
 		interrupts: map[string]*digitalInterrupt{},
 	}
@@ -152,7 +152,7 @@ func (b *sysfsBoard) reconfigureI2cs(newConf *Config) error {
 			}
 			continue
 		}
-		bus, err := newI2cBus(c.Bus)
+		bus, err := NewI2cBus(c.Bus)
 		if err != nil {
 			return err
 		}
@@ -363,7 +363,7 @@ type sysfsBoard struct {
 	spis         map[string]*spiBus
 	analogs      map[string]*wrappedAnalog
 	pwms         map[string]pwmSetting
-	i2cs         map[string]*i2cBus
+	i2cs         map[string]*I2cBus
 	logger       golog.Logger
 
 	usePeriphGpio bool

--- a/components/board/genericlinux/i2c.go
+++ b/components/board/genericlinux/i2c.go
@@ -21,6 +21,9 @@ func init() {
 	}
 }
 
+// This struct represents an I2C bus. You can use it to create handles for devices at specific
+// addresses on the bus. Creating a handle locks the bus, and closing the handle unlocks the bus
+// again, so that you can only communicate with 1 device on the bus at a time.
 type I2cBus struct {
 	// Despite the type name BusCloser, this is the I2C bus itself (plus a way to close itself when
 	// it's done, though we never use that because we want to keep it open until the entire process
@@ -30,6 +33,7 @@ type I2cBus struct {
 	deviceName   string
 }
 
+// This function creates a new I2cBus object.
 func NewI2cBus(deviceName string) (*I2cBus, error) {
 	// We return a pointer to an I2cBus instead of an I2cBus itself so that we can return nil if
 	// something goes wrong.
@@ -49,21 +53,29 @@ func (bus *I2cBus) reset(deviceName string) error {
 	return nil
 }
 
-// This lets the I2cBus type implement the board.I2C interface.
+// This lets the I2cBus type implement the board.I2C interface. It returns a handle for
+// communicating with a device at a specific I2C handle. Opening a handle locks the I2C bus so
+// nothing else can use it, and closing the handle unlocks the bus again.
 func (bus *I2cBus) OpenHandle(addr byte) (board.I2CHandle, error) {
 	bus.mu.Lock() // Lock the bus so no other handle can use it until this one is closed.
 	return &I2cHandle{device: &i2c.Dev{Bus: bus.closeableBus, Addr: uint16(addr)}, parentBus: bus}, nil
 }
 
+// The I2cHadle struct represents a way to talk to a specific device on the I2C bus. Creating a
+// handle locks the bus so nothing else can use it, and closing the handle unlocks it again.
 type I2cHandle struct { // Implements the board.I2CHandle interface
 	device    *i2c.Dev // Will become nil if we Close() the handle
 	parentBus *I2cBus
 }
 
+// This writes the given bytes to the handle. For I2C devices that organize their data into
+// registers, prefer using WriteBlockData instead.
 func (h *I2cHandle) Write(ctx context.Context, tx []byte) error {
 	return h.device.Tx(tx, nil)
 }
 
+// This reads the given number of bytes from the handle. For I2C devices that organize their data
+// into registers, prefer using ReadBlockData instead.
 func (h *I2cHandle) Read(ctx context.Context, count int) ([]byte, error) {
 	buffer := make([]byte, count)
 	err := h.device.Tx(nil, buffer)
@@ -84,6 +96,7 @@ func (h *I2cHandle) transactAtRegister(register byte, w, r []byte) error {
 	return h.device.Tx(fullW, r)
 }
 
+// This reads a single byte from the given register on this I2C device.
 func (h *I2cHandle) ReadByteData(ctx context.Context, register byte) (byte, error) {
 	result := make([]byte, 1)
 	err := h.transactAtRegister(register, nil, result)
@@ -93,10 +106,12 @@ func (h *I2cHandle) ReadByteData(ctx context.Context, register byte) (byte, erro
 	return result[0], nil
 }
 
+// This writes a single byte to the given register on this I2C device.
 func (h *I2cHandle) WriteByteData(ctx context.Context, register, data byte) error {
 	return h.transactAtRegister(register, []byte{data}, nil)
 }
 
+// This reads the given number of bytes from the I2C device, starting at the given register.
 func (h *I2cHandle) ReadBlockData(ctx context.Context, register byte, numBytes uint8) ([]byte, error) {
 	result := make([]byte, numBytes)
 	err := h.transactAtRegister(register, nil, result)
@@ -106,10 +121,12 @@ func (h *I2cHandle) ReadBlockData(ctx context.Context, register byte, numBytes u
 	return result, nil
 }
 
+// This writes the given bytes into the given register on the I2C device.
 func (h *I2cHandle) WriteBlockData(ctx context.Context, register byte, data []byte) error {
 	return h.transactAtRegister(register, data, nil)
 }
 
+// This closes the handle to the device, and unlocks the I2C device.
 func (h *I2cHandle) Close() error {
 	defer h.parentBus.mu.Unlock() // Unlock the entire bus so someone else can use it
 	h.device = nil

--- a/components/board/genericlinux/i2c.go
+++ b/components/board/genericlinux/i2c.go
@@ -21,7 +21,7 @@ func init() {
 	}
 }
 
-type i2cBus struct {
+type I2cBus struct {
 	// Despite the type name BusCloser, this is the I2C bus itself (plus a way to close itself when
 	// it's done, though we never use that because we want to keep it open until the entire process
 	// exits)!
@@ -30,19 +30,17 @@ type i2cBus struct {
 	deviceName   string
 }
 
-func newI2cBus(deviceName string) (*i2cBus, error) {
-	// We return a pointer to an i2cBus instead of an i2cBus itself so that we can return nil if
+func NewI2cBus(deviceName string) (*I2cBus, error) {
+	// We return a pointer to an I2cBus instead of an I2cBus itself so that we can return nil if
 	// something goes wrong.
-	b := &i2cBus{}
+	b := &I2cBus{}
 	if err := b.reset(deviceName); err != nil {
 		return nil, err
 	}
 	return b, nil
 }
 
-func (bus *i2cBus) reset(deviceName string) error {
-	// We return a pointer to an i2cBus instead of an i2cBus itself so that we can return nil if
-	// something goes wrong.
+func (bus *I2cBus) reset(deviceName string) error {
 	newBus, err := i2creg.Open(deviceName)
 	if err != nil {
 		return err
@@ -51,22 +49,22 @@ func (bus *i2cBus) reset(deviceName string) error {
 	return nil
 }
 
-// This lets the i2cBus type implement the board.I2C interface.
-func (bus *i2cBus) OpenHandle(addr byte) (board.I2CHandle, error) {
+// This lets the I2cBus type implement the board.I2C interface.
+func (bus *I2cBus) OpenHandle(addr byte) (board.I2CHandle, error) {
 	bus.mu.Lock() // Lock the bus so no other handle can use it until this one is closed.
-	return &i2cHandle{device: &i2c.Dev{Bus: bus.closeableBus, Addr: uint16(addr)}, parentBus: bus}, nil
+	return &I2cHandle{device: &i2c.Dev{Bus: bus.closeableBus, Addr: uint16(addr)}, parentBus: bus}, nil
 }
 
-type i2cHandle struct { // Implements the board.I2CHandle interface
+type I2cHandle struct { // Implements the board.I2CHandle interface
 	device    *i2c.Dev // Will become nil if we Close() the handle
-	parentBus *i2cBus
+	parentBus *I2cBus
 }
 
-func (h *i2cHandle) Write(ctx context.Context, tx []byte) error {
+func (h *I2cHandle) Write(ctx context.Context, tx []byte) error {
 	return h.device.Tx(tx, nil)
 }
 
-func (h *i2cHandle) Read(ctx context.Context, count int) ([]byte, error) {
+func (h *I2cHandle) Read(ctx context.Context, count int) ([]byte, error) {
 	buffer := make([]byte, count)
 	err := h.device.Tx(nil, buffer)
 	if err != nil {
@@ -76,7 +74,7 @@ func (h *i2cHandle) Read(ctx context.Context, count int) ([]byte, error) {
 }
 
 // This is a private helper function, used to implement the rest of the board.I2CHandle interface.
-func (h *i2cHandle) transactAtRegister(register byte, w, r []byte) error {
+func (h *I2cHandle) transactAtRegister(register byte, w, r []byte) error {
 	if w == nil {
 		w = []byte{}
 	}
@@ -86,7 +84,7 @@ func (h *i2cHandle) transactAtRegister(register byte, w, r []byte) error {
 	return h.device.Tx(fullW, r)
 }
 
-func (h *i2cHandle) ReadByteData(ctx context.Context, register byte) (byte, error) {
+func (h *I2cHandle) ReadByteData(ctx context.Context, register byte) (byte, error) {
 	result := make([]byte, 1)
 	err := h.transactAtRegister(register, nil, result)
 	if err != nil {
@@ -95,11 +93,11 @@ func (h *i2cHandle) ReadByteData(ctx context.Context, register byte) (byte, erro
 	return result[0], nil
 }
 
-func (h *i2cHandle) WriteByteData(ctx context.Context, register, data byte) error {
+func (h *I2cHandle) WriteByteData(ctx context.Context, register, data byte) error {
 	return h.transactAtRegister(register, []byte{data}, nil)
 }
 
-func (h *i2cHandle) ReadBlockData(ctx context.Context, register byte, numBytes uint8) ([]byte, error) {
+func (h *I2cHandle) ReadBlockData(ctx context.Context, register byte, numBytes uint8) ([]byte, error) {
 	result := make([]byte, numBytes)
 	err := h.transactAtRegister(register, nil, result)
 	if err != nil {
@@ -108,11 +106,11 @@ func (h *i2cHandle) ReadBlockData(ctx context.Context, register byte, numBytes u
 	return result, nil
 }
 
-func (h *i2cHandle) WriteBlockData(ctx context.Context, register byte, data []byte) error {
+func (h *I2cHandle) WriteBlockData(ctx context.Context, register byte, data []byte) error {
 	return h.transactAtRegister(register, data, nil)
 }
 
-func (h *i2cHandle) Close() error {
+func (h *I2cHandle) Close() error {
 	defer h.parentBus.mu.Unlock() // Unlock the entire bus so someone else can use it
 	h.device = nil
 	// Don't close the bus itself: it should remain open for other handles to use

--- a/components/board/genericlinux/i2c.go
+++ b/components/board/genericlinux/i2c.go
@@ -21,7 +21,7 @@ func init() {
 	}
 }
 
-// This struct represents an I2C bus. You can use it to create handles for devices at specific
+// I2cBus represents an I2C bus. You can use it to create handles for devices at specific
 // addresses on the bus. Creating a handle locks the bus, and closing the handle unlocks the bus
 // again, so that you can only communicate with 1 device on the bus at a time.
 type I2cBus struct {
@@ -33,7 +33,7 @@ type I2cBus struct {
 	deviceName   string
 }
 
-// This function creates a new I2cBus object.
+// NewI2cBus creates a new I2cBus object.
 func NewI2cBus(deviceName string) (*I2cBus, error) {
 	// We return a pointer to an I2cBus instead of an I2cBus itself so that we can return nil if
 	// something goes wrong.
@@ -53,7 +53,7 @@ func (bus *I2cBus) reset(deviceName string) error {
 	return nil
 }
 
-// This lets the I2cBus type implement the board.I2C interface. It returns a handle for
+// OpenHandle lets the I2cBus type implement the board.I2C interface. It returns a handle for
 // communicating with a device at a specific I2C handle. Opening a handle locks the I2C bus so
 // nothing else can use it, and closing the handle unlocks the bus again.
 func (bus *I2cBus) OpenHandle(addr byte) (board.I2CHandle, error) {
@@ -61,20 +61,20 @@ func (bus *I2cBus) OpenHandle(addr byte) (board.I2CHandle, error) {
 	return &I2cHandle{device: &i2c.Dev{Bus: bus.closeableBus, Addr: uint16(addr)}, parentBus: bus}, nil
 }
 
-// The I2cHadle struct represents a way to talk to a specific device on the I2C bus. Creating a
-// handle locks the bus so nothing else can use it, and closing the handle unlocks it again.
+// I2cHandle represents a way to talk to a specific device on the I2C bus. Creating a handle locks
+// the bus so nothing else can use it, and closing the handle unlocks it again.
 type I2cHandle struct { // Implements the board.I2CHandle interface
 	device    *i2c.Dev // Will become nil if we Close() the handle
 	parentBus *I2cBus
 }
 
-// This writes the given bytes to the handle. For I2C devices that organize their data into
+// Write writes the given bytes to the handle. For I2C devices that organize their data into
 // registers, prefer using WriteBlockData instead.
 func (h *I2cHandle) Write(ctx context.Context, tx []byte) error {
 	return h.device.Tx(tx, nil)
 }
 
-// This reads the given number of bytes from the handle. For I2C devices that organize their data
+// Read reads the given number of bytes from the handle. For I2C devices that organize their data
 // into registers, prefer using ReadBlockData instead.
 func (h *I2cHandle) Read(ctx context.Context, count int) ([]byte, error) {
 	buffer := make([]byte, count)
@@ -96,7 +96,7 @@ func (h *I2cHandle) transactAtRegister(register byte, w, r []byte) error {
 	return h.device.Tx(fullW, r)
 }
 
-// This reads a single byte from the given register on this I2C device.
+// ReadByteData reads a single byte from the given register on this I2C device.
 func (h *I2cHandle) ReadByteData(ctx context.Context, register byte) (byte, error) {
 	result := make([]byte, 1)
 	err := h.transactAtRegister(register, nil, result)
@@ -106,12 +106,13 @@ func (h *I2cHandle) ReadByteData(ctx context.Context, register byte) (byte, erro
 	return result[0], nil
 }
 
-// This writes a single byte to the given register on this I2C device.
+// WriteByteData writes a single byte to the given register on this I2C device.
 func (h *I2cHandle) WriteByteData(ctx context.Context, register, data byte) error {
 	return h.transactAtRegister(register, []byte{data}, nil)
 }
 
-// This reads the given number of bytes from the I2C device, starting at the given register.
+// ReadBlockData reads the given number of bytes from the I2C device, starting at the given
+// register.
 func (h *I2cHandle) ReadBlockData(ctx context.Context, register byte, numBytes uint8) ([]byte, error) {
 	result := make([]byte, numBytes)
 	err := h.transactAtRegister(register, nil, result)
@@ -121,12 +122,12 @@ func (h *I2cHandle) ReadBlockData(ctx context.Context, register byte, numBytes u
 	return result, nil
 }
 
-// This writes the given bytes into the given register on the I2C device.
+// WriteBlockData writes the given bytes into the given register on the I2C device.
 func (h *I2cHandle) WriteBlockData(ctx context.Context, register byte, data []byte) error {
 	return h.transactAtRegister(register, data, nil)
 }
 
-// This closes the handle to the device, and unlocks the I2C device.
+// Close closes the handle to the device, and unlocks the I2C bus.
 func (h *I2cHandle) Close() error {
 	defer h.parentBus.mu.Unlock() // Unlock the entire bus so someone else can use it
 	h.device = nil


### PR DESCRIPTION
@biotinker wanted to use this code from a modular component outside the genericlinux package. So, now it's available!

Everything compiles fine, and the ADXL345 accelerometer can still be used from a Jetson Orin Nano.