### PR TITLE
RSDK-2911: GPIO Stepper motor driver tweaks and test improvements

### DIFF
--- a/components/board/fake/board.go
+++ b/components/board/fake/board.go
@@ -497,10 +497,15 @@ type GPIOPin struct {
 	high    bool
 	pwm     float64
 	pwmFreq uint
+
+	mu sync.Mutex
 }
 
 // Set sets the pin to either low or high.
 func (gp *GPIOPin) Set(ctx context.Context, high bool, extra map[string]interface{}) error {
+	gp.mu.Lock()
+	defer gp.mu.Unlock()
+
 	gp.high = high
 	gp.pwm = 0
 	gp.pwmFreq = 0
@@ -509,27 +514,42 @@ func (gp *GPIOPin) Set(ctx context.Context, high bool, extra map[string]interfac
 
 // Get gets the high/low state of the pin.
 func (gp *GPIOPin) Get(ctx context.Context, extra map[string]interface{}) (bool, error) {
+	gp.mu.Lock()
+	defer gp.mu.Unlock()
+
 	return gp.high, nil
 }
 
 // PWM gets the pin's given duty cycle.
 func (gp *GPIOPin) PWM(ctx context.Context, extra map[string]interface{}) (float64, error) {
+	gp.mu.Lock()
+	defer gp.mu.Unlock()
+
 	return gp.pwm, nil
 }
 
 // SetPWM sets the pin to the given duty cycle.
 func (gp *GPIOPin) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[string]interface{}) error {
+	gp.mu.Lock()
+	defer gp.mu.Unlock()
+
 	gp.pwm = dutyCyclePct
 	return nil
 }
 
 // PWMFreq gets the PWM frequency of the pin.
 func (gp *GPIOPin) PWMFreq(ctx context.Context, extra map[string]interface{}) (uint, error) {
+	gp.mu.Lock()
+	defer gp.mu.Unlock()
+
 	return gp.pwmFreq, nil
 }
 
 // SetPWMFreq sets the given pin to the given PWM frequency.
 func (gp *GPIOPin) SetPWMFreq(ctx context.Context, freqHz uint, extra map[string]interface{}) error {
+	gp.mu.Lock()
+	defer gp.mu.Unlock()
+
 	gp.pwmFreq = freqHz
 	return nil
 }

--- a/components/motor/gpiostepper/gpiostepper.go
+++ b/components/motor/gpiostepper/gpiostepper.go
@@ -313,7 +313,9 @@ func (m *gpioStepper) GoFor(ctx context.Context, rpm, revolutions float64, extra
 		return nil
 	}
 
-	return m.opMgr.WaitTillNotPowered(ctx, time.Millisecond, m, m.Stop)
+	return multierr.Combine(
+		m.enable(ctx, false),
+		m.opMgr.WaitTillNotPowered(ctx, time.Millisecond, m, m.Stop))
 }
 
 func (m *gpioStepper) goForInternal(ctx context.Context, rpm, revolutions float64) error {

--- a/components/motor/gpiostepper/gpiostepper.go
+++ b/components/motor/gpiostepper/gpiostepper.go
@@ -264,7 +264,6 @@ func (m *gpioStepper) doCycle(ctx context.Context) (time.Duration, error) {
 // have to be locked to call.
 func (m *gpioStepper) doStep(ctx context.Context, forward bool) error {
 	err := multierr.Combine(
-
 		m.dirPin.Set(ctx, forward, nil),
 		m.stepPin.Set(ctx, true, nil))
 	if err != nil {

--- a/components/motor/gpiostepper/gpiostepper.go
+++ b/components/motor/gpiostepper/gpiostepper.go
@@ -169,7 +169,11 @@ func newGPIOStepper(
 		m.minDelay = time.Duration(mc.StepperDelay * int(time.Microsecond))
 	}
 
-	m.enable(ctx, false)
+	err = m.enable(ctx, false)
+	if err != nil {
+		return nil, err
+	}
+
 	m.startThread(ctx)
 	return m, nil
 }

--- a/components/motor/gpiostepper/gpiostepper.go
+++ b/components/motor/gpiostepper/gpiostepper.go
@@ -308,8 +308,9 @@ func (m *gpioStepper) GoFor(ctx context.Context, rpm, revolutions float64, extra
 			errors.Wrapf(err, "error in GoFor from motor (%s)", m.motorName))
 	}
 
+	// this is a long-running operation, do not wait for Stop, do not disable enable pins
 	if revolutions == 0 {
-		return m.enable(ctx, false)
+		return nil
 	}
 
 	return m.opMgr.WaitTillNotPowered(ctx, time.Millisecond, m, m.Stop)

--- a/components/motor/gpiostepper/gpiostepper.go
+++ b/components/motor/gpiostepper/gpiostepper.go
@@ -314,8 +314,8 @@ func (m *gpioStepper) GoFor(ctx context.Context, rpm, revolutions float64, extra
 	}
 
 	return multierr.Combine(
-		m.enable(ctx, false),
-		m.opMgr.WaitTillNotPowered(ctx, time.Millisecond, m, m.Stop))
+		m.opMgr.WaitTillNotPowered(ctx, time.Millisecond, m, m.Stop),
+		m.enable(ctx, false))
 }
 
 func (m *gpioStepper) goForInternal(ctx context.Context, rpm, revolutions float64) error {

--- a/components/motor/gpiostepper/gpiostepper_test.go
+++ b/components/motor/gpiostepper/gpiostepper_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/edaniels/golog"
 	"go.viam.com/test"
+	"go.viam.com/utils"
 	"go.viam.com/utils/testutils"
 
 	fakeboard "go.viam.com/rdk/components/board/fake"
@@ -70,13 +71,13 @@ func TestConfigs(t *testing.T) {
 
 		_, err := mc.Validate("")
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "\"dir\" is required")
+		test.That(t, err, test.ShouldBeError, utils.NewConfigValidationFieldRequiredError("", "dir"))
 
 		mc = goodConfig
 		mc.Pins.Step = ""
 		_, err = mc.Validate("")
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "\"step\" is required")
+		test.That(t, err, test.ShouldBeError, utils.NewConfigValidationFieldRequiredError("", "step"))
 	})
 
 	t.Run("config missing ticks", func(t *testing.T) {
@@ -85,7 +86,7 @@ func TestConfigs(t *testing.T) {
 
 		_, err := mc.Validate("")
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "\"ticks_per_rotation\" is required")
+		test.That(t, err, test.ShouldBeError, utils.NewConfigValidationFieldRequiredError("", "ticks_per_rotation"))
 	})
 
 	t.Run("config missing board", func(t *testing.T) {
@@ -94,7 +95,7 @@ func TestConfigs(t *testing.T) {
 
 		_, err := mc.Validate("")
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "\"board\" is required")
+		test.That(t, err, test.ShouldBeError, utils.NewConfigValidationFieldRequiredError("", "board"))
 	})
 
 	t.Run("initializing good with enable pins", func(t *testing.T) {

--- a/components/motor/gpiostepper/gpiostepper_test.go
+++ b/components/motor/gpiostepper/gpiostepper_test.go
@@ -16,154 +16,344 @@ import (
 	"go.viam.com/rdk/resource"
 )
 
-// Warning: Tests that run goForInternal are racy. Conditions evaluated after the call
-// rely on the timing of the worker thread in the fake gpiostepper. Larger runtimes (>1s)
-// and more test retries compensate for this at the cost of test runtime.
-func Test1(t *testing.T) {
+func TestConfigs(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	logger, obs := golog.NewObservedTestLogger(t)
+	defer cancel()
 
-	b := &fakeboard.Board{GPIOPins: make(map[string]*fakeboard.GPIOPin)}
-
-	mc := Config{}
+	logger := golog.NewTestLogger(t)
 	c := resource.Config{
 		Name: "fake_gpiostepper",
 	}
 
-	// Create motor with no board and default config
-	t.Run("gpiostepper initializing test with no board and default config", func(t *testing.T) {
-		_, err := newGPIOStepper(ctx, nil, mc, c.ResourceName(), logger)
-		test.That(t, err, test.ShouldNotBeNil)
+	goodConfig := Config{
+		Pins:             PinConfig{Direction: "b", Step: "c", EnablePinHigh: "d", EnablePinLow: "e"},
+		TicksPerRotation: 200,
+		BoardName:        "brd",
+		StepperDelay:     30,
+	}
+
+	pinB := &fakeboard.GPIOPin{}
+	pinC := &fakeboard.GPIOPin{}
+	pinD := &fakeboard.GPIOPin{}
+	pinE := &fakeboard.GPIOPin{}
+	pinMap := map[string]*fakeboard.GPIOPin{
+		"b": pinB,
+		"c": pinC,
+		"d": pinD,
+		"e": pinE,
+	}
+	b := fakeboard.Board{GPIOPins: pinMap}
+
+	t.Run("config validation good", func(t *testing.T) {
+		mc := goodConfig
+
+		deps, err := mc.Validate("")
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, deps, test.ShouldResemble, []string{"brd"})
+
+		// remove optional fields
+		mc.StepperDelay = 0
+		deps, err = mc.Validate("")
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, deps, test.ShouldResemble, []string{"brd"})
+
+		mc.Pins.EnablePinHigh = ""
+		mc.Pins.EnablePinLow = ""
+		deps, err = mc.Validate("")
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, deps, test.ShouldResemble, []string{"brd"})
 	})
 
-	// Create motor with board and default config
-	t.Run("gpiostepper initializing test with board and default config", func(t *testing.T) {
-		_, err := newGPIOStepper(ctx, b, mc, c.ResourceName(), logger)
+	t.Run("config missing required pins", func(t *testing.T) {
+		mc := goodConfig
+		mc.Pins.Direction = ""
+
+		_, err := mc.Validate("")
 		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "\"dir\" is required")
+
+		mc = goodConfig
+		mc.Pins.Step = ""
+		_, err = mc.Validate("")
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "\"step\" is required")
 	})
 
-	mc.Pins = PinConfig{Direction: "b"}
+	t.Run("config missing ticks", func(t *testing.T) {
+		mc := goodConfig
+		mc.TicksPerRotation = 0
 
-	_, err := newGPIOStepper(ctx, b, mc, c.ResourceName(), logger)
-	test.That(t, err, test.ShouldNotBeNil)
+		_, err := mc.Validate("")
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "\"ticks_per_rotation\" is required")
+	})
 
-	mc.Pins.Step = "c"
+	t.Run("config missing board", func(t *testing.T) {
+		mc := goodConfig
+		mc.BoardName = ""
 
-	_, err = newGPIOStepper(ctx, b, mc, c.ResourceName(), logger)
-	test.That(t, err, test.ShouldNotBeNil)
+		_, err := mc.Validate("")
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "\"board\" is required")
+	})
 
-	mc.TicksPerRotation = 200
+	t.Run("initializing good with enable pins", func(t *testing.T) {
+		m, err := newGPIOStepper(ctx, &b, goodConfig, c.ResourceName(), logger)
+		s := m.(*gpioStepper)
 
-	mm, err := newGPIOStepper(ctx, b, mc, c.ResourceName(), logger)
-	test.That(t, err, test.ShouldBeNil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, s.minDelay, test.ShouldEqual, 30*time.Microsecond)
+		test.That(t, s.stepsPerRotation, test.ShouldEqual, 200)
+		test.That(t, s.dirPin, test.ShouldEqual, pinB)
+		test.That(t, s.stepPin, test.ShouldEqual, pinC)
+		test.That(t, s.enablePinHigh, test.ShouldEqual, pinD)
+		test.That(t, s.enablePinLow, test.ShouldEqual, pinE)
+	})
 
-	m := mm.(*gpioStepper)
+	t.Run("initializing good without enable pins", func(t *testing.T) {
+		mc := goodConfig
+		mc.Pins.EnablePinHigh = ""
+		mc.Pins.EnablePinLow = ""
 
-	t.Run("motor test supports position reporting", func(t *testing.T) {
+		m, err := newGPIOStepper(ctx, &b, mc, c.ResourceName(), logger)
+		s := m.(*gpioStepper)
+
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, s.dirPin, test.ShouldEqual, pinB)
+		test.That(t, s.stepPin, test.ShouldEqual, pinC)
+
+		// fake board auto-creates new pins by default. just make sure they're not what they would normally be.
+		test.That(t, s.enablePinHigh, test.ShouldNotEqual, pinD)
+		test.That(t, s.enablePinLow, test.ShouldNotEqual, pinE)
+	})
+
+	t.Run("initializing with no board", func(t *testing.T) {
+		_, err := newGPIOStepper(ctx, nil, goodConfig, c.ResourceName(), logger)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "board is required")
+	})
+
+	t.Run("initializing without ticks per rotation", func(t *testing.T) {
+		mc := goodConfig
+		mc.TicksPerRotation = 0
+
+		_, err := newGPIOStepper(ctx, &b, mc, c.ResourceName(), logger)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "expected ticks_per_rotation")
+	})
+
+	t.Run("initializing with negative stepper delay", func(t *testing.T) {
+		mc := goodConfig
+		mc.StepperDelay = -100
+
+		m, err := newGPIOStepper(ctx, &b, mc, c.ResourceName(), logger)
+		s := m.(*gpioStepper)
+
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, s.minDelay, test.ShouldEqual, 0*time.Microsecond)
+	})
+
+	t.Run("motor supports position reporting", func(t *testing.T) {
+		m, err := newGPIOStepper(ctx, &b, goodConfig, c.ResourceName(), logger)
+		test.That(t, err, test.ShouldBeNil)
+
 		features, err := m.Properties(ctx, nil)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, features[motor.PositionReporting], test.ShouldBeTrue)
 	})
+}
 
-	t.Run("motor test isOn functionality", func(t *testing.T) {
+// Warning: Tests that run goForInternal may be racy.
+func TestRunning(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger, obs := golog.NewObservedTestLogger(t)
+	c := resource.Config{
+		Name: "fake_gpiostepper",
+	}
+
+	goodConfig := Config{
+		Pins:             PinConfig{Direction: "b", Step: "c", EnablePinHigh: "d", EnablePinLow: "e"},
+		TicksPerRotation: 200,
+		BoardName:        "brd",
+		StepperDelay:     30,
+	}
+
+	pinB := &fakeboard.GPIOPin{}
+	pinC := &fakeboard.GPIOPin{}
+	pinD := &fakeboard.GPIOPin{}
+	pinE := &fakeboard.GPIOPin{}
+	pinMap := map[string]*fakeboard.GPIOPin{
+		"b": pinB,
+		"c": pinC,
+		"d": pinD,
+		"e": pinE,
+	}
+	b := fakeboard.Board{GPIOPins: pinMap}
+
+	t.Run("isPowered false after init", func(t *testing.T) {
+		m, err := newGPIOStepper(ctx, &b, goodConfig, c.ResourceName(), logger)
+		test.That(t, err, test.ShouldBeNil)
+
 		on, powerPct, err := m.IsPowered(ctx, nil)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, on, test.ShouldEqual, false)
 		test.That(t, powerPct, test.ShouldEqual, 0.0)
+
+		h, err := pinD.Get(ctx, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, h, test.ShouldBeFalse)
+
+		l, err := pinE.Get(ctx, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, l, test.ShouldBeTrue)
+	})
+
+	t.Run("IsPowered true", func(t *testing.T) {
+		m, err := newGPIOStepper(ctx, &b, goodConfig, c.ResourceName(), logger)
+		s := m.(*gpioStepper)
+		test.That(t, err, test.ShouldBeNil)
+
+		// long running goFor
+		err = s.goForInternal(ctx, 100, 3)
+		defer m.Stop(ctx, nil)
+
+		test.That(t, err, test.ShouldBeNil)
+
+		// the motor is running
+		testutils.WaitForAssertion(t, func(tb testing.TB) {
+			tb.Helper()
+			on, powerPct, err := m.IsPowered(ctx, nil)
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, on, test.ShouldEqual, true)
+			test.That(t, powerPct, test.ShouldEqual, 1.0)
+		})
+
+		// the motor finished running
+		testutils.WaitForAssertionWithSleep(t, 100*time.Millisecond, 100, func(tb testing.TB) {
+			tb.Helper()
+			on, powerPct, err := m.IsPowered(ctx, nil)
+			test.That(tb, err, test.ShouldBeNil)
+			test.That(tb, on, test.ShouldEqual, false)
+			test.That(tb, powerPct, test.ShouldEqual, 0.0)
+		})
+
+		pos, err := m.Position(ctx, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, pos, test.ShouldEqual, 3)
+		test.That(t, s.targetStepPosition, test.ShouldEqual, 600)
+	})
+
+	t.Run("motor enable", func(t *testing.T) {
+		m, err := newGPIOStepper(ctx, &b, goodConfig, c.ResourceName(), logger)
+		s := m.(*gpioStepper)
+		test.That(t, err, test.ShouldBeNil)
+
+		err = s.enable(ctx, true)
+		test.That(t, err, test.ShouldBeNil)
+
+		h, err := pinD.Get(ctx, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, h, test.ShouldBeTrue)
+
+		l, err := pinE.Get(ctx, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, l, test.ShouldBeFalse)
+
+		err = s.enable(ctx, false)
+		test.That(t, err, test.ShouldBeNil)
+
+		h, err = pinD.Get(ctx, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, h, test.ShouldBeFalse)
+
+		l, err = pinE.Get(ctx, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, l, test.ShouldBeTrue)
 	})
 
 	t.Run("motor testing with positive rpm and positive revolutions", func(t *testing.T) {
-		err = m.goForInternal(ctx, 100, 2)
+		m, err := newGPIOStepper(ctx, &b, goodConfig, c.ResourceName(), logger)
+		s := m.(*gpioStepper)
+		test.That(t, err, test.ShouldBeNil)
+
+		err = s.GoFor(ctx, 10000, 1, nil)
 		test.That(t, err, test.ShouldBeNil)
 
 		on, powerPct, err := m.IsPowered(ctx, nil)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, on, test.ShouldEqual, true)
-		test.That(t, powerPct, test.ShouldEqual, 1.0)
-
-		testutils.WaitForAssertionWithSleep(t, 100*time.Millisecond, 100, func(tb testing.TB) {
-			tb.Helper()
-			on, powerPct, err = m.IsPowered(ctx, nil)
-			test.That(tb, err, test.ShouldBeNil)
-			test.That(tb, on, test.ShouldEqual, false)
-			test.That(tb, powerPct, test.ShouldEqual, 0.0)
-		})
+		test.That(t, on, test.ShouldEqual, false)
+		test.That(t, powerPct, test.ShouldEqual, 0.0)
 
 		pos, err := m.Position(ctx, nil)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, pos, test.ShouldEqual, 2)
-		test.That(t, m.targetStepPosition, test.ShouldEqual, 400)
+		test.That(t, pos, test.ShouldEqual, 1)
+		test.That(t, s.targetStepPosition, test.ShouldEqual, 200)
 	})
 
 	t.Run("motor testing with negative rpm and positive revolutions", func(t *testing.T) {
-		err = m.goForInternal(ctx, -100, 2)
+		m, err := newGPIOStepper(ctx, &b, goodConfig, c.ResourceName(), logger)
+		s := m.(*gpioStepper)
+		test.That(t, err, test.ShouldBeNil)
+
+		err = m.GoFor(ctx, -10000, 1, nil)
 		test.That(t, err, test.ShouldBeNil)
 
 		on, powerPct, err := m.IsPowered(ctx, nil)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, on, test.ShouldEqual, true)
-		test.That(t, powerPct, test.ShouldEqual, 1.0)
-
-		testutils.WaitForAssertionWithSleep(t, 100*time.Millisecond, 100, func(tb testing.TB) {
-			tb.Helper()
-			on, powerPct, err = m.IsPowered(ctx, nil)
-			test.That(tb, err, test.ShouldBeNil)
-			test.That(tb, on, test.ShouldEqual, false)
-			test.That(tb, powerPct, test.ShouldEqual, 0.0)
-		})
+		test.That(t, on, test.ShouldEqual, false)
+		test.That(t, powerPct, test.ShouldEqual, 0.0)
 
 		pos, err := m.Position(ctx, nil)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, pos, test.ShouldEqual, 0)
-		test.That(t, m.targetStepPosition, test.ShouldEqual, 0)
+		test.That(t, pos, test.ShouldEqual, -1)
+		test.That(t, s.targetStepPosition, test.ShouldEqual, -200)
 	})
 
 	t.Run("motor testing with positive rpm and negative revolutions", func(t *testing.T) {
-		err = m.goForInternal(ctx, 100, -2)
+		m, err := newGPIOStepper(ctx, &b, goodConfig, c.ResourceName(), logger)
+		s := m.(*gpioStepper)
+		test.That(t, err, test.ShouldBeNil)
+
+		err = m.GoFor(ctx, 10000, -1, nil)
 		test.That(t, err, test.ShouldBeNil)
 
 		on, powerPct, err := m.IsPowered(ctx, nil)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, on, test.ShouldEqual, true)
-		test.That(t, powerPct, test.ShouldEqual, 1.0)
-
-		testutils.WaitForAssertionWithSleep(t, 100*time.Millisecond, 100, func(tb testing.TB) {
-			tb.Helper()
-			on, powerPct, err = m.IsPowered(ctx, nil)
-			test.That(tb, err, test.ShouldBeNil)
-			test.That(tb, on, test.ShouldEqual, false)
-			test.That(tb, powerPct, test.ShouldEqual, 0.0)
-		})
+		test.That(t, on, test.ShouldEqual, false)
+		test.That(t, powerPct, test.ShouldEqual, 0.0)
 
 		pos, err := m.Position(ctx, nil)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, pos, test.ShouldEqual, -2)
-		test.That(t, m.targetStepPosition, test.ShouldEqual, -400)
+		test.That(t, pos, test.ShouldEqual, -1)
+		test.That(t, s.targetStepPosition, test.ShouldEqual, -200)
 	})
 
 	t.Run("motor testing with negative rpm and negative revolutions", func(t *testing.T) {
-		err = m.goForInternal(ctx, -100, -2)
+		m, err := newGPIOStepper(ctx, &b, goodConfig, c.ResourceName(), logger)
+		s := m.(*gpioStepper)
+		test.That(t, err, test.ShouldBeNil)
+
+		err = m.GoFor(ctx, -10000, -1, nil)
 		test.That(t, err, test.ShouldBeNil)
 
 		on, powerPct, err := m.IsPowered(ctx, nil)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, on, test.ShouldEqual, true)
-		test.That(t, powerPct, test.ShouldEqual, 1.0)
-
-		testutils.WaitForAssertionWithSleep(t, 100*time.Millisecond, 100, func(tb testing.TB) {
-			tb.Helper()
-			on, powerPct, err = m.IsPowered(ctx, nil)
-			test.That(tb, err, test.ShouldBeNil)
-			test.That(tb, on, test.ShouldEqual, false)
-			test.That(tb, powerPct, test.ShouldEqual, 0.0)
-		})
+		test.That(t, on, test.ShouldEqual, false)
+		test.That(t, powerPct, test.ShouldEqual, 0.0)
 
 		pos, err := m.Position(ctx, nil)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, pos, test.ShouldEqual, 0)
-		test.That(t, m.targetStepPosition, test.ShouldEqual, 0)
+		test.That(t, pos, test.ShouldEqual, 1)
+		test.That(t, s.targetStepPosition, test.ShouldEqual, 200)
 	})
+
 	t.Run("Ensure stop called when gofor is interrupted", func(t *testing.T) {
+		m, err := newGPIOStepper(ctx, &b, goodConfig, c.ResourceName(), logger)
+		s := m.(*gpioStepper)
+		test.That(t, err, test.ShouldBeNil)
+
 		ctx := context.Background()
 		var wg sync.WaitGroup
 		ctx, cancel := context.WithCancel(ctx)
@@ -172,23 +362,51 @@ func Test1(t *testing.T) {
 			m.GoFor(ctx, 100, 100, map[string]interface{}{})
 			wg.Done()
 		}()
+
+		// Make sure it starts moving
+		testutils.WaitForAssertion(t, func(tb testing.TB) {
+			tb.Helper()
+			on, _, err := m.IsPowered(ctx, nil)
+			test.That(tb, err, test.ShouldBeNil)
+			test.That(tb, on, test.ShouldEqual, true)
+		})
+
 		cancel()
 		wg.Wait()
 
+		// Make sure it stops moving
+		testutils.WaitForAssertion(t, func(tb testing.TB) {
+			tb.Helper()
+			on, _, err := m.IsPowered(ctx, nil)
+			test.That(tb, err, test.ShouldBeNil)
+			test.That(tb, on, test.ShouldEqual, false)
+		})
 		test.That(t, ctx.Err(), test.ShouldNotBeNil)
+
+		p, err := m.Position(context.Background(), nil)
+		test.That(t, err, test.ShouldBeNil)
+
+		// stop() sets targetStepPosition to the stepPostion value
+		test.That(t, s.targetStepPosition, test.ShouldEqual, s.stepPosition)
+		test.That(t, s.targetStepPosition, test.ShouldBeBetweenOrEqual, 1, 100*200)
+		test.That(t, p, test.ShouldBeBetween, 0, 100)
 	})
 
 	t.Run("motor testing with large # of revolutions", func(t *testing.T) {
-		err = m.goForInternal(ctx, 100, 200)
+		m, err := newGPIOStepper(ctx, &b, goodConfig, c.ResourceName(), logger)
+		s := m.(*gpioStepper)
 		test.That(t, err, test.ShouldBeNil)
 
-		on, powerPct, err := m.IsPowered(ctx, nil)
+		err = s.goForInternal(ctx, 1000, 200)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, on, test.ShouldEqual, true)
-		test.That(t, powerPct, test.ShouldEqual, 1.0)
 
-		testutils.WaitForAssertionWithSleep(t, 100*time.Millisecond, 100, func(tb testing.TB) {
+		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
+
+			on, _, err := m.IsPowered(ctx, nil)
+			test.That(tb, err, test.ShouldBeNil)
+			test.That(tb, on, test.ShouldEqual, true)
+
 			pos, err := m.Position(ctx, nil)
 			test.That(tb, err, test.ShouldBeNil)
 			test.That(tb, pos, test.ShouldBeGreaterThan, 2)
@@ -197,6 +415,10 @@ func Test1(t *testing.T) {
 		err = m.Stop(ctx, nil)
 		test.That(t, err, test.ShouldBeNil)
 
+		on, _, err := m.IsPowered(ctx, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, on, test.ShouldEqual, false)
+
 		pos, err := m.Position(ctx, nil)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, pos, test.ShouldBeGreaterThan, 2)
@@ -204,11 +426,18 @@ func Test1(t *testing.T) {
 	})
 
 	t.Run("motor testing with 0 rpm", func(t *testing.T) {
+		m, err := newGPIOStepper(ctx, &b, goodConfig, c.ResourceName(), logger)
+		test.That(t, err, test.ShouldBeNil)
+
 		err = m.GoFor(ctx, 0, 1, nil)
 		test.That(t, err, test.ShouldBeNil)
 		allObs := obs.All()
 		latestLoggedEntry := allObs[len(allObs)-1]
 		test.That(t, fmt.Sprint(latestLoggedEntry), test.ShouldContainSubstring, "nearly 0")
+
+		on, _, err := m.IsPowered(ctx, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, on, test.ShouldEqual, false)
 	})
 
 	cancel()

--- a/components/motor/gpiostepper/gpiostepper_test.go
+++ b/components/motor/gpiostepper/gpiostepper_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/edaniels/golog"
 	"go.viam.com/test"
@@ -15,6 +16,9 @@ import (
 	"go.viam.com/rdk/resource"
 )
 
+// Warning: Tests that run goForInternal are racy. Conditions evaluated after the call
+// rely on the timing of the worker thread in the fake gpiostepper. Larger runtimes (>1s)
+// and more test retries compensate for this at the cost of test runtime.
 func Test1(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	logger, obs := golog.NewObservedTestLogger(t)
@@ -77,7 +81,7 @@ func Test1(t *testing.T) {
 		test.That(t, on, test.ShouldEqual, true)
 		test.That(t, powerPct, test.ShouldEqual, 1.0)
 
-		testutils.WaitForAssertion(t, func(tb testing.TB) {
+		testutils.WaitForAssertionWithSleep(t, 100*time.Millisecond, 100, func(tb testing.TB) {
 			tb.Helper()
 			on, powerPct, err = m.IsPowered(ctx, nil)
 			test.That(tb, err, test.ShouldBeNil)
@@ -88,6 +92,7 @@ func Test1(t *testing.T) {
 		pos, err := m.Position(ctx, nil)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, pos, test.ShouldEqual, 2)
+		test.That(t, m.targetStepPosition, test.ShouldEqual, 400)
 	})
 
 	t.Run("motor testing with negative rpm and positive revolutions", func(t *testing.T) {
@@ -99,7 +104,7 @@ func Test1(t *testing.T) {
 		test.That(t, on, test.ShouldEqual, true)
 		test.That(t, powerPct, test.ShouldEqual, 1.0)
 
-		testutils.WaitForAssertion(t, func(tb testing.TB) {
+		testutils.WaitForAssertionWithSleep(t, 100*time.Millisecond, 100, func(tb testing.TB) {
 			tb.Helper()
 			on, powerPct, err = m.IsPowered(ctx, nil)
 			test.That(tb, err, test.ShouldBeNil)
@@ -110,6 +115,7 @@ func Test1(t *testing.T) {
 		pos, err := m.Position(ctx, nil)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, pos, test.ShouldEqual, 0)
+		test.That(t, m.targetStepPosition, test.ShouldEqual, 0)
 	})
 
 	t.Run("motor testing with positive rpm and negative revolutions", func(t *testing.T) {
@@ -121,7 +127,7 @@ func Test1(t *testing.T) {
 		test.That(t, on, test.ShouldEqual, true)
 		test.That(t, powerPct, test.ShouldEqual, 1.0)
 
-		testutils.WaitForAssertion(t, func(tb testing.TB) {
+		testutils.WaitForAssertionWithSleep(t, 100*time.Millisecond, 100, func(tb testing.TB) {
 			tb.Helper()
 			on, powerPct, err = m.IsPowered(ctx, nil)
 			test.That(tb, err, test.ShouldBeNil)
@@ -132,6 +138,7 @@ func Test1(t *testing.T) {
 		pos, err := m.Position(ctx, nil)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, pos, test.ShouldEqual, -2)
+		test.That(t, m.targetStepPosition, test.ShouldEqual, -400)
 	})
 
 	t.Run("motor testing with negative rpm and negative revolutions", func(t *testing.T) {
@@ -143,7 +150,7 @@ func Test1(t *testing.T) {
 		test.That(t, on, test.ShouldEqual, true)
 		test.That(t, powerPct, test.ShouldEqual, 1.0)
 
-		testutils.WaitForAssertion(t, func(tb testing.TB) {
+		testutils.WaitForAssertionWithSleep(t, 100*time.Millisecond, 100, func(tb testing.TB) {
 			tb.Helper()
 			on, powerPct, err = m.IsPowered(ctx, nil)
 			test.That(tb, err, test.ShouldBeNil)
@@ -154,6 +161,7 @@ func Test1(t *testing.T) {
 		pos, err := m.Position(ctx, nil)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, pos, test.ShouldEqual, 0)
+		test.That(t, m.targetStepPosition, test.ShouldEqual, 0)
 	})
 	t.Run("Ensure stop called when gofor is interrupted", func(t *testing.T) {
 		ctx := context.Background()
@@ -179,7 +187,7 @@ func Test1(t *testing.T) {
 		test.That(t, on, test.ShouldEqual, true)
 		test.That(t, powerPct, test.ShouldEqual, 1.0)
 
-		testutils.WaitForAssertion(t, func(tb testing.TB) {
+		testutils.WaitForAssertionWithSleep(t, 100*time.Millisecond, 100, func(tb testing.TB) {
 			tb.Helper()
 			pos, err := m.Position(ctx, nil)
 			test.That(tb, err, test.ShouldBeNil)

--- a/components/motor/gpiostepper/gpiostepper_test.go
+++ b/components/motor/gpiostepper/gpiostepper_test.go
@@ -392,6 +392,56 @@ func TestRunning(t *testing.T) {
 		test.That(t, p, test.ShouldBeBetween, 0, 100)
 	})
 
+	t.Run("enable pins handled properly during GoFor", func(t *testing.T) {
+		m, err := newGPIOStepper(ctx, &b, goodConfig, c.ResourceName(), logger)
+		test.That(t, err, test.ShouldBeNil)
+
+		ctx := context.Background()
+		var wg sync.WaitGroup
+		ctx, cancel := context.WithCancel(ctx)
+		wg.Add(1)
+		go func() {
+			m.GoFor(ctx, 100, 100, map[string]interface{}{})
+			wg.Done()
+		}()
+
+		// Make sure it starts moving
+		testutils.WaitForAssertion(t, func(tb testing.TB) {
+			tb.Helper()
+			on, _, err := m.IsPowered(ctx, nil)
+			test.That(tb, err, test.ShouldBeNil)
+			test.That(tb, on, test.ShouldEqual, true)
+
+			h, err := pinD.Get(ctx, nil)
+			test.That(tb, err, test.ShouldBeNil)
+			test.That(tb, h, test.ShouldBeTrue)
+
+			l, err := pinE.Get(ctx, nil)
+			test.That(tb, err, test.ShouldBeNil)
+			test.That(tb, l, test.ShouldBeFalse)
+		})
+
+		cancel()
+		wg.Wait()
+
+		// Make sure it stops moving
+		testutils.WaitForAssertion(t, func(tb testing.TB) {
+			tb.Helper()
+			on, _, err := m.IsPowered(ctx, nil)
+			test.That(tb, err, test.ShouldBeNil)
+			test.That(tb, on, test.ShouldEqual, false)
+
+			h, err := pinD.Get(ctx, nil)
+			test.That(tb, err, test.ShouldBeNil)
+			test.That(tb, h, test.ShouldBeFalse)
+
+			l, err := pinE.Get(ctx, nil)
+			test.That(tb, err, test.ShouldBeNil)
+			test.That(tb, l, test.ShouldBeTrue)
+		})
+		test.That(t, ctx.Err(), test.ShouldNotBeNil)
+	})
+
 	t.Run("motor testing with large # of revolutions", func(t *testing.T) {
 		m, err := newGPIOStepper(ctx, &b, goodConfig, c.ResourceName(), logger)
 		s := m.(*gpioStepper)


### PR DESCRIPTION
Functional changes to enable pins (done as a fly by):
1. pins are set to proper disable values at on initialization
2. enable is only done once on GoFor instead of on every step. Functionally the same, but removes an unnecessary pin on/off cycle.
3. Both high and low pins are supported in `enable()`. Previously, config validation allowed both but `enable()` respected one.

Test changes:
1. Lots more config validation tests
2. All tests are hermetic now
3. More explicit testing for high/low pins
4. Explicit testing for board pins
5. Eliminated many time-based tests and shortened their runtimes

Fake board's pin getter/setters now have a mutex

Tested with a NEMA17 motor on a A4988 driver