### PR TITLE
RSDK-3738: [Gantry] Order of limit pins is significant

### DIFF
--- a/components/gantry/singleaxis/singleaxis.go
+++ b/components/gantry/singleaxis/singleaxis.go
@@ -336,7 +336,7 @@ func (g *singleAxis) doHome(ctx context.Context) (bool, error) {
 }
 
 func (g *singleAxis) homeLimSwitch(ctx context.Context) error {
-	var positionA, positionB, start float64
+	var positionA, positionB float64
 	positionA, err := g.testLimit(ctx, 0)
 	if err != nil {
 		return err
@@ -348,12 +348,10 @@ func (g *singleAxis) homeLimSwitch(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		start = 0.8
 	} else {
 		// Only one limit switch, calculate positionB
 		revPerLength := g.lengthMm / g.mmPerRevolution
 		positionB = positionA + revPerLength
-		start = 0.2
 	}
 
 	g.positionLimits = []float64{positionA, positionB}
@@ -364,8 +362,9 @@ func (g *singleAxis) homeLimSwitch(ctx context.Context) error {
 		g.logger.Debugf("positionA: %0.2f positionB: %0.2f range: %0.2f", positionA, positionB, g.positionRange)
 	}
 
-	// Go to start position so limit stops are not hit.
-	if err = g.goToStart(ctx, start); err != nil {
+	// Go to start position at the middle of the axis.
+	x := g.gantryToMotorPosition(0.5 * g.lengthMm)
+	if err := g.motor.GoTo(ctx, g.rpm, x, nil); err != nil {
 		return err
 	}
 
@@ -389,14 +388,6 @@ func (g *singleAxis) homeEncoder(ctx context.Context) error {
 	return nil
 }
 
-func (g *singleAxis) goToStart(ctx context.Context, percent float64) error {
-	x := g.gantryToMotorPosition(percent * g.lengthMm)
-	if err := g.motor.GoTo(ctx, g.rpm, x, nil); err != nil {
-		return err
-	}
-	return nil
-}
-
 func (g *singleAxis) gantryToMotorPosition(positions float64) float64 {
 	x := positions / g.lengthMm
 	x = g.positionLimits[0] + (x * g.positionRange)
@@ -412,10 +403,11 @@ func (g *singleAxis) testLimit(ctx context.Context, pin int) (float64, error) {
 	defer utils.UncheckedErrorFunc(func() error {
 		return g.motor.Stop(ctx, nil)
 	})
-
+	wrongPin := 1
 	d := -1.0
 	if pin != 0 {
 		d = 1
+		wrongPin = 0
 	}
 
 	err := g.motor.GoFor(ctx, d*g.rpm, 0, nil)
@@ -435,6 +427,22 @@ func (g *singleAxis) testLimit(ctx context.Context, pin int) (float64, error) {
 				return 0, err
 			}
 			break
+		}
+
+		// check if the wrong limit switch was hit
+		wrongHit, err := g.limitHit(ctx, wrongPin)
+		if err != nil {
+			return 0, err
+		}
+		if wrongHit {
+			err = g.motor.Stop(ctx, nil)
+			if err != nil {
+				return 0, err
+			}
+			return 0, errors.Errorf(
+				"expected limit switch %v but hit limit switch %v, try switching the order in the config",
+				pin,
+				wrongPin)
 		}
 
 		elapsed := start.Sub(start)

--- a/components/gantry/singleaxis/singleaxis_test.go
+++ b/components/gantry/singleaxis/singleaxis_test.go
@@ -29,8 +29,10 @@ var fakeFrame = &referenceframe.LinkConfig{
 
 var badFrame = &referenceframe.LinkConfig{}
 
-var count = 0
-var pinValues = []int{1, 1, 0}
+var (
+	count     = 0
+	pinValues = []int{1, 1, 0}
+)
 
 func createFakeMotor() motor.Motor {
 	return &inject.Motor{

--- a/components/gantry/singleaxis/singleaxis_test.go
+++ b/components/gantry/singleaxis/singleaxis_test.go
@@ -30,6 +30,7 @@ var fakeFrame = &referenceframe.LinkConfig{
 var badFrame = &referenceframe.LinkConfig{}
 
 var count = 0
+var pinValues = []int{1, 1, 0}
 
 func createFakeMotor() motor.Motor {
 	return &inject.Motor{
@@ -59,11 +60,14 @@ func createFakeBoard() board.Board {
 	pinCount := 0
 	injectGPIOPin := &inject.GPIOPin{
 		GetFunc: func(ctx context.Context, extra map[string]interface{}) (bool, error) {
-			pinCount++
-			if pinCount%2 == 0 {
-				return false, nil
+			if pinValues[pinCount] == 1 {
+				return true, nil
 			}
-			return true, nil
+			pinCount++
+			if pinCount == len(pinValues) {
+				pinCount = 0
+			}
+			return false, nil
 		},
 		SetFunc: func(ctx context.Context, high bool, extra map[string]interface{}) error { return nil },
 	}


### PR DESCRIPTION
This PR adds a check during homing to see if the wrong limit switch is hit. If so, the gantry stops and errors so that it's no longer possible to go past a limit switch during homing. Additionally, the start position after homing is now 50% of the length of the axis with both one and two limit switches.