### PR TITLE
[RSDK-3779] update module timeout to 1 minute

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -655,7 +655,7 @@ func (m *module) startProcess(
 		return errors.WithMessage(err, "module startup failed")
 	}
 
-	ctxTimeout, cancel := context.WithTimeout(ctx, time.Second*30)
+	ctxTimeout, cancel := context.WithTimeout(ctx, time.Second*60)
 	defer cancel()
 	for {
 		select {


### PR DESCRIPTION
increasing the timeout to 1 minute because the cartographer module takes 31 seconds to load in cloud run