### PR TITLE
Remove errant comment about movement sensor Readings not going over the network

### DIFF
--- a/components/movementsensor/client.go
+++ b/components/movementsensor/client.go
@@ -135,7 +135,6 @@ func (c *client) CompassHeading(ctx context.Context, extra map[string]interface{
 }
 
 func (c *client) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
-	// Does not currently go over the network, you cannot call a remote movement sensor's Readings method
 	return Readings(ctx, c, extra)
 }
 


### PR DESCRIPTION
This is not true. Calling readings from the movement sensor client calls the interface method, which in turn calls each API. 
Test with remotes just to find any bug(s)