### PR TITLE
Fix viam-server build/race issues in tests

### DIFF
--- a/examples/customresources/demos/complexmodule/moduletest/module_test.go
+++ b/examples/customresources/demos/complexmodule/moduletest/module_test.go
@@ -42,9 +42,12 @@ func TestComplexModule(t *testing.T) {
 	cfgFilename, port, err := modifyCfg(t, utils.ResolveFile("examples/customresources/demos/complexmodule/module.json"), logger)
 	test.That(t, err, test.ShouldBeNil)
 
+	serverPath, err := testutils.BuildTempModule(t, "web/cmd/server/")
+	test.That(t, err, test.ShouldBeNil)
+
 	server := pexec.NewManagedProcess(pexec.ProcessConfig{
-		Name: "bash",
-		Args: []string{"-c", "exec bin/`uname`-`uname -m`/viam-server -config " + cfgFilename},
+		Name: serverPath,
+		Args: []string{"-config", cfgFilename},
 		CWD:  utils.ResolveFile("./"),
 		Log:  true,
 	}, logger)
@@ -366,9 +369,12 @@ func TestValidationFailure(t *testing.T) {
 		utils.ResolveFile("examples/customresources/demos/complexmodule/moduletest/bad_modular_validation.json"), logger)
 	test.That(t, err, test.ShouldBeNil)
 
+	serverPath, err := testutils.BuildTempModule(t, "web/cmd/server/")
+	test.That(t, err, test.ShouldBeNil)
+
 	server := pexec.NewManagedProcess(pexec.ProcessConfig{
-		Name: "bash",
-		Args: []string{"-c", "exec bin/`uname`-`uname -m`/viam-server -config " + cfgFilename},
+		Name: serverPath,
+		Args: []string{"-config", cfgFilename},
 		CWD:  utils.ResolveFile("./"),
 		Log:  true,
 	}, logger)

--- a/module/module_interceptors_test.go
+++ b/module/module_interceptors_test.go
@@ -34,9 +34,21 @@ func TestOpID(t *testing.T) {
 	defer func() {
 		test.That(t, os.Remove(cfgFilename), test.ShouldBeNil)
 	}()
+
+	buildCmd := pexec.NewManagedProcess(pexec.ProcessConfig{
+		Name:    "bash",
+		Args:    []string{"-c", "make server"},
+		CWD:     utils.ResolveFile("./"),
+		Log:     true,
+		OneShot: true,
+	}, logger)
+
+	err = buildCmd.Start(ctx)
+	test.That(t, err, test.ShouldBeNil)
+
 	server := pexec.NewManagedProcess(pexec.ProcessConfig{
 		Name: "bash",
-		Args: []string{"-c", "make server && exec bin/`uname`-`uname -m`/viam-server -config " + cfgFilename},
+		Args: []string{"-c", "exec bin/`uname`-`uname -m`/viam-server -config " + cfgFilename},
 		CWD:  utils.ResolveFile("./"),
 		Log:  true,
 	}, logger)

--- a/module/module_interceptors_test.go
+++ b/module/module_interceptors_test.go
@@ -35,20 +35,12 @@ func TestOpID(t *testing.T) {
 		test.That(t, os.Remove(cfgFilename), test.ShouldBeNil)
 	}()
 
-	buildCmd := pexec.NewManagedProcess(pexec.ProcessConfig{
-		Name:    "bash",
-		Args:    []string{"-c", "make server"},
-		CWD:     utils.ResolveFile("./"),
-		Log:     true,
-		OneShot: true,
-	}, logger)
-
-	err = buildCmd.Start(ctx)
+	serverPath, err := rtestutils.BuildTempModule(t, "web/cmd/server/")
 	test.That(t, err, test.ShouldBeNil)
 
 	server := pexec.NewManagedProcess(pexec.ProcessConfig{
-		Name: "bash",
-		Args: []string{"-c", "exec bin/`uname`-`uname -m`/viam-server -config " + cfgFilename},
+		Name: serverPath,
+		Args: []string{"-config", cfgFilename},
 		CWD:  utils.ResolveFile("./"),
 		Log:  true,
 	}, logger)

--- a/web/server/entrypoint_test.go
+++ b/web/server/entrypoint_test.go
@@ -35,9 +35,20 @@ func TestNumResources(t *testing.T) {
 	cfgFilename, err = robottestutils.MakeTempConfig(t, cfg, logger)
 	test.That(t, err, test.ShouldBeNil)
 
+	buildCmd := pexec.NewManagedProcess(pexec.ProcessConfig{
+		Name:    "bash",
+		Args:    []string{"-c", "make server"},
+		CWD:     utils.ResolveFile("./"),
+		Log:     true,
+		OneShot: true,
+	}, logger)
+
+	err = buildCmd.Start(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+
 	server := pexec.NewManagedProcess(pexec.ProcessConfig{
 		Name: "bash",
-		Args: []string{"-c", "make server && exec bin/`uname`-`uname -m`/viam-server -config " + cfgFilename},
+		Args: []string{"-c", "exec bin/`uname`-`uname -m`/viam-server -config " + cfgFilename},
 		CWD:  utils.ResolveFile("./"),
 		Log:  true,
 	}, logger)

--- a/web/server/entrypoint_test.go
+++ b/web/server/entrypoint_test.go
@@ -13,6 +13,7 @@ import (
 	"go.viam.com/utils/pexec"
 
 	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/testutils"
 	"go.viam.com/rdk/testutils/robottestutils"
 	"go.viam.com/rdk/utils"
 )
@@ -35,20 +36,12 @@ func TestNumResources(t *testing.T) {
 	cfgFilename, err = robottestutils.MakeTempConfig(t, cfg, logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	buildCmd := pexec.NewManagedProcess(pexec.ProcessConfig{
-		Name:    "bash",
-		Args:    []string{"-c", "make server"},
-		CWD:     utils.ResolveFile("./"),
-		Log:     true,
-		OneShot: true,
-	}, logger)
-
-	err = buildCmd.Start(context.Background())
+	serverPath, err := testutils.BuildTempModule(t, "web/cmd/server/")
 	test.That(t, err, test.ShouldBeNil)
 
 	server := pexec.NewManagedProcess(pexec.ProcessConfig{
-		Name: "bash",
-		Args: []string{"-c", "exec bin/`uname`-`uname -m`/viam-server -config " + cfgFilename},
+		Name: serverPath,
+		Args: []string{"-config", cfgFilename},
 		CWD:  utils.ResolveFile("./"),
 		Log:  true,
 	}, logger)


### PR DESCRIPTION
@dgottlieb found that tests are flaky on slow machines at times, as they attempt to build viam-server from scratch in the same process as running it, which leaves the connection timeout ticking. In correcting that, I also found a race condition where two tests (in separate packages) could both attempt to build at the same time, and this can cause problems.

This uses the module build helper to build viam-server itself, and skips the frontend entirely (as it's not needed for these tests.) It builds to temporary locations, so won't interfere with later tests or leave cruft behind.