### PR TITLE
print out error message

### DIFF
--- a/components/arm/client.go
+++ b/components/arm/client.go
@@ -48,7 +48,7 @@ func NewClientFromConn(
 	}
 	clientFrame, err := c.updateKinematics(ctx)
 	if err != nil {
-		logger.Errorw("error getting model for arm; will not allow certain methods")
+		logger.Errorw("error getting model for arm; will not allow certain methods", "err", err)
 	} else {
 		c.model = clientFrame
 	}


### PR DESCRIPTION
While trying to debug modular resources and creating a new client from the connection, it was super helpful to have the error message as part of the logs. The error message should be available for easy debugging.