### PR TITLE
DATA-1646 - Define and register collector for GetPosition

### DIFF
--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -505,7 +505,7 @@ func (svc *builtIn) sync() {
 	}
 }
 
-// nolint
+//nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -48,7 +48,7 @@ func init() {
 			},
 			// NOTE(erd): this would be better as a weak dependencies returned through a more
 			// typed validate or different system.
-			WeakDependencies: []internal.ResourceMatcher{internal.ComponentDependencyWildcardMatcher},
+			WeakDependencies: []internal.ResourceMatcher{internal.ComponentDependencyWildcardMatcher, internal.SLAMDependencyWildcardMatcher},
 		})
 }
 
@@ -505,7 +505,7 @@ func (svc *builtIn) sync() {
 	}
 }
 
-//nolint
+// nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/services/slam/collector.go
+++ b/services/slam/collector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"go.opencensus.io/trace"
+	pb "go.viam.com/api/service/slam/v1"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"go.viam.com/rdk/data"
@@ -27,12 +28,6 @@ func (m method) String() string {
 	return "Unknown"
 }
 
-// Position defines the struct returned by the capturer for GetPosition.
-type Position struct {
-	Pose               spatialmath.Pose
-	ComponentReference string
-}
-
 func newGetPositionCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
 	slam, err := assertSLAM(resource)
 	if err != nil {
@@ -47,7 +42,7 @@ func newGetPositionCollector(resource interface{}, params data.CollectorParams) 
 		if err != nil {
 			return nil, data.FailedToReadErr(params.ComponentName, getPosition.String(), err)
 		}
-		return Position{Pose: pose, ComponentReference: componentRef}, nil
+		return &pb.GetPositionResponse{Pose: spatialmath.PoseToProtobuf(pose), ComponentReference: componentRef}, nil
 	})
 	return data.NewCollector(cFunc, params)
 }

--- a/services/slam/collector.go
+++ b/services/slam/collector.go
@@ -13,16 +13,12 @@ import (
 type method int64
 
 const (
-	getPosition      method = iota
-	getPointCloudMap method = iota
+	getPosition method = iota
 )
 
 func (m method) String() string {
-	switch m {
-	case getPosition:
+	if m == getPosition {
 		return "GetPosition"
-	case getPointCloudMap:
-		return "GetPointCloudMap"
 	}
 	return "Unknown"
 }

--- a/services/slam/collector.go
+++ b/services/slam/collector.go
@@ -3,7 +3,6 @@ package slam
 import (
 	"context"
 
-	"go.opencensus.io/trace"
 	pb "go.viam.com/api/service/slam/v1"
 	"google.golang.org/protobuf/types/known/anypb"
 
@@ -35,9 +34,6 @@ func newGetPositionCollector(resource interface{}, params data.CollectorParams) 
 	}
 
 	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (interface{}, error) {
-		_, span := trace.StartSpan(ctx, "slam::data::collector::CaptureFunc::GetPosition")
-		defer span.End()
-
 		pose, componentRef, err := slam.GetPosition(ctx)
 		if err != nil {
 			return nil, data.FailedToReadErr(params.ComponentName, getPosition.String(), err)

--- a/services/slam/collector.go
+++ b/services/slam/collector.go
@@ -4,9 +4,10 @@ import (
 	"context"
 
 	"go.opencensus.io/trace"
+	"google.golang.org/protobuf/types/known/anypb"
+
 	"go.viam.com/rdk/data"
 	"go.viam.com/rdk/spatialmath"
-	"google.golang.org/protobuf/types/known/anypb"
 )
 
 type method int64
@@ -26,6 +27,7 @@ func (m method) String() string {
 	return "Unknown"
 }
 
+// Position defines the struct returned by the capturer for GetPosition.
 type Position struct {
 	Pose               spatialmath.Pose
 	ComponentReference string

--- a/services/slam/collector.go
+++ b/services/slam/collector.go
@@ -1,0 +1,59 @@
+package slam
+
+import (
+	"context"
+
+	"go.opencensus.io/trace"
+	"go.viam.com/rdk/data"
+	"go.viam.com/rdk/spatialmath"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+type method int64
+
+const (
+	getPosition      method = iota
+	getPointCloudMap method = iota
+)
+
+func (m method) String() string {
+	switch m {
+	case getPosition:
+		return "GetPosition"
+	case getPointCloudMap:
+		return "GetPointCloudMap"
+	}
+	return "Unknown"
+}
+
+type Position struct {
+	Pose               spatialmath.Pose
+	ComponentReference string
+}
+
+func newGetPositionCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+	slam, err := assertSLAM(resource)
+	if err != nil {
+		return nil, err
+	}
+
+	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (interface{}, error) {
+		_, span := trace.StartSpan(ctx, "slam::data::collector::CaptureFunc::GetPosition")
+		defer span.End()
+
+		pose, componentRef, err := slam.GetPosition(ctx)
+		if err != nil {
+			return nil, data.FailedToReadErr(params.ComponentName, getPosition.String(), err)
+		}
+		return Position{Pose: pose, ComponentReference: componentRef}, nil
+	})
+	return data.NewCollector(cFunc, params)
+}
+
+func assertSLAM(resource interface{}) (Service, error) {
+	slamService, ok := resource.(Service)
+	if !ok {
+		return nil, data.InvalidInterfaceErr(API)
+	}
+	return slamService, nil
+}

--- a/services/slam/slam.go
+++ b/services/slam/slam.go
@@ -12,6 +12,7 @@ import (
 	"go.opencensus.io/trace"
 	pb "go.viam.com/api/service/slam/v1"
 
+	"go.viam.com/rdk/data"
 	"go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/resource"
@@ -27,6 +28,10 @@ func init() {
 		RPCServiceDesc:              &pb.SLAMService_ServiceDesc,
 		RPCClient:                   NewClientFromConn,
 	})
+	data.RegisterCollector(data.MethodMetadata{
+		API:        API,
+		MethodName: getPosition.String(),
+	}, newGetPositionCollector)
 }
 
 // SubtypeName is the name of the type of service.


### PR DESCRIPTION
### Context
This implements `GetPosition` collector to allow for us to use DataCapture with SLAM endpoints

### Testing
You can use this config with the command `ENV=development go run web/cmd/server/main.go -debug -config ~/scripts/rdk-slam-local.json` to test it out. You'll see the data from a fake-slam component being loaded into the directory `~/.viam/capture/rdk:sensor:slam/fake-slam/GetPosition`. We will add subsequent tests in [DATA-1668](https://viam.atlassian.net/browse/DATA-1668?atlOrigin=eyJpIjoiMTIzZTcxOWY3ZjJmNDU5YjgzNzNhNmIyZTQ3YzU5MDUiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

```
{
  "services": [
    {
      "type": "data_manager",
      "attributes": {
        "capture_dir": "",
        "sync_disabled": true,
        "tags": [],
        "sync_interval_mins": 0.1
      },
      "name": "Data-Management-Service"
    },
    {
      "name": "fake-slam",
      "type": "slam",
      "model": "fake",
      "attributes": {},
      "service_configs": [
        {
          "type": "data_manager",
          "attributes": {
            "capture_methods": [
              {
                "method": "GetPosition",
                "additional_params": {},
                "capture_frequency_hz": 0.1
              }
            ]
          }
        }
      ]
    }
  ],
  "components": [
    {
      "name": "camera",
      "type": "camera",
      "model": "fake",
      "attributes": {},
      "depends_on": [],
      "service_configs": [
        {
          "type": "data_manager",
          "attributes": {
            "capture_methods": [
              {
                "method": "ReadImage",
                "additional_params": {
                  "mime_type": "image/jpeg"
                }
              }
            ]
          }
        }
      ]
    }
  ]
}
```

[DATA-1668]: https://viam.atlassian.net/browse/DATA-1668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ