### PR TITLE
Add drag-n-drop path visualization to SLAM 2d map.

### DIFF
--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "license": "Apache-2.0",
   "type": "module",
   "files": [

--- a/web/frontend/src/components/slam/2d-renderer.svelte
+++ b/web/frontend/src/components/slam/2d-renderer.svelte
@@ -9,6 +9,8 @@ import type { commonApi } from '@viamrobotics/sdk';
 import DestMarker from '@/lib/images/destination-marker.txt?raw';
 import BaseMarker from '@/lib/images/base-marker.txt?raw';
 import Legend from './2d-legend.svelte';
+import Dropzone from '@/lib/components/dropzone.svelte';
+import MotionPath from './motion-path.svelte';
 
 export let pointcloud: Uint8Array | undefined;
 export let pose: commonApi.Pose | undefined;
@@ -20,6 +22,7 @@ const dispatch = createEventDispatcher();
 let points: THREE.Points | undefined;
 let pointsMaterial: THREE.PointsMaterial | undefined;
 let intersectionPlane: THREE.Mesh | undefined;
+let motionPath: string | undefined
 
 const markerColor = '#FF0047';
 const backgroundGridColor = '#cacaca';
@@ -263,6 +266,10 @@ const scaleObjects = () => {
   destMarker.scale.set(spriteSize, spriteSize, 1);
 };
 
+const handleDrop = (event: CustomEvent<string>) => {
+  motionPath = event.detail;
+}
+
 onMount(() => {
   removeUpdate = update(scaleObjects);
   container?.append(canvas);
@@ -335,17 +342,21 @@ $: {
 
 </script>
 
-<div
-  bind:this={container}
-  class="relative w-full"
->
-  {#if axesVisible}
-    <p class="absolute left-3 top-3 bg-white text-xs">
-      Grid set to 1 meter
-    </p>
-  {/if}
+<Dropzone on:drop={handleDrop}>
+  <div
+    bind:this={container}
+    class="relative w-full"
+  >
+    {#if axesVisible}
+      <p class="absolute left-3 top-3 bg-white text-xs">
+        Grid set to 1 meter
+      </p>
+    {/if}
 
-  <div class="absolute right-3 top-3">
-    <Legend />
+    <MotionPath {scene} path={motionPath} />
+
+    <div class="absolute right-3 top-3">
+      <Legend />
+    </div>
   </div>
-</div>
+</Dropzone>

--- a/web/frontend/src/components/slam/2d-renderer.svelte
+++ b/web/frontend/src/components/slam/2d-renderer.svelte
@@ -22,7 +22,7 @@ const dispatch = createEventDispatcher();
 let points: THREE.Points | undefined;
 let pointsMaterial: THREE.PointsMaterial | undefined;
 let intersectionPlane: THREE.Mesh | undefined;
-let motionPath: string | undefined
+let motionPath: string | undefined;
 
 const markerColor = '#FF0047';
 const backgroundGridColor = '#cacaca';
@@ -268,7 +268,7 @@ const scaleObjects = () => {
 
 const handleDrop = (event: CustomEvent<string>) => {
   motionPath = event.detail;
-}
+};
 
 onMount(() => {
   removeUpdate = update(scaleObjects);

--- a/web/frontend/src/components/slam/motion-path.svelte
+++ b/web/frontend/src/components/slam/motion-path.svelte
@@ -1,45 +1,44 @@
 <script lang='ts'>
 
-import * as THREE from 'three'
-import { Line2 } from 'three/examples/jsm/lines/Line2.js'
-import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js'
-import { LineGeometry } from 'three/examples/jsm/lines/LineGeometry.js'
+import * as THREE from 'three';
+import { Line2 } from 'three/examples/jsm/lines/Line2.js';
+import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
+import { LineGeometry } from 'three/examples/jsm/lines/LineGeometry.js';
 
 export let scene: THREE.Scene;
 export let path: string | undefined;
 
 const geometry = new LineGeometry();
 const material = new LineMaterial({
-  color: 0xFF0047,
+  color: 0xFF_00_47,
   linewidth: 0.005,
   dashed: false,
   alphaToCoverage: true,
 });
 
 const line = new Line2(geometry, material);
-line.visible = false,
+line.visible = false;
 scene.add(line);
 
 $: {
   if (path === undefined) {
-    line.visible = false
+    line.visible = false;
   } else {
-    line.visible = true
+    line.visible = true;
 
-    let points: number[] = []
+    const points: number[] = [];
 
-    for (const line of path.split('\n')) {
-      const [a, b] = line.split(',')
-      if (a !== undefined && b !== undefined) {
-        const x = Number.parseFloat(a!) / 1000
-        const y = Number.parseFloat(b!) / 1000
-        points.push(x, y, 0)
+    for (const xy of path.split('\n')) {
+      const [xString, yString] = xy.split(',');
+      if (xString !== undefined && yString !== undefined) {
+        const x = Number.parseFloat(xString) / 1000;
+        const y = Number.parseFloat(yString) / 1000;
+        points.push(x, y, 0);
       }
     }
 
-    const vertices = new Float32Array(points)
+    const vertices = new Float32Array(points);
     geometry.setPositions(vertices);
-  
   }
 }
 

--- a/web/frontend/src/components/slam/motion-path.svelte
+++ b/web/frontend/src/components/slam/motion-path.svelte
@@ -1,0 +1,46 @@
+<script lang='ts'>
+
+import * as THREE from 'three'
+import { Line2 } from 'three/examples/jsm/lines/Line2.js'
+import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js'
+import { LineGeometry } from 'three/examples/jsm/lines/LineGeometry.js'
+
+export let scene: THREE.Scene;
+export let path: string | undefined;
+
+const geometry = new LineGeometry();
+const material = new LineMaterial({
+  color: 0xFF0047,
+  linewidth: 0.005,
+  dashed: false,
+  alphaToCoverage: true,
+});
+
+const line = new Line2(geometry, material);
+line.visible = false,
+scene.add(line);
+
+$: {
+  if (path === undefined) {
+    line.visible = false
+  } else {
+    line.visible = true
+
+    let points: number[] = []
+
+    for (const line of path.split('\n')) {
+      const [a, b] = line.split(',')
+      if (a !== undefined && b !== undefined) {
+        const x = Number.parseFloat(a!) / 1000
+        const y = Number.parseFloat(b!) / 1000
+        points.push(x, y, 0)
+      }
+    }
+
+    const vertices = new Float32Array(points)
+    geometry.setPositions(vertices);
+  
+  }
+}
+
+</script>

--- a/web/frontend/src/lib/components/dropzone.svelte
+++ b/web/frontend/src/lib/components/dropzone.svelte
@@ -1,38 +1,37 @@
 <script lang='ts'>
 
-import { createEventDispatcher } from 'svelte'
+/* eslint-disable unicorn/prefer-blob-reading-methods */
+import { createEventDispatcher } from 'svelte';
 
-export let format: 'string' | 'arrayBuffer' = 'string'
+export let format: 'string' | 'arrayBuffer' = 'string';
 
-type $$Events = { drop: 'string' | 'arrayBuffer' }
-
-const dispatch = createEventDispatcher<$$Events>()
+const dispatch = createEventDispatcher();
 
 const handleDrop = (event: DragEvent) => {
-  const reader = new FileReader()
+  const reader = new FileReader();
 
   reader.addEventListener('load', () => {
-    dispatch('drop', reader.result as typeof format)
-  })
+    dispatch('drop', reader.result);
+  });
 
   if (event.dataTransfer === null) {
-    return
+    return;
   }
 
-  const [file] = event.dataTransfer.files
+  const [file] = event.dataTransfer.files;
 
   if (file === undefined) {
-    return
+    return;
   }
 
   if (format === 'string') {
-    reader.readAsBinaryString(file)
+    reader.readAsBinaryString(file);
   } else if (format === 'arrayBuffer') {
-    reader.readAsArrayBuffer(file)
+    reader.readAsArrayBuffer(file);
   } else {
-    throw new Error ('Unsupported dropzone format.')
+    throw new Error('Unsupported dropzone format.');
   }
-}
+};
 
 </script>
 

--- a/web/frontend/src/lib/components/dropzone.svelte
+++ b/web/frontend/src/lib/components/dropzone.svelte
@@ -1,0 +1,46 @@
+<script lang='ts'>
+
+import { createEventDispatcher } from 'svelte'
+
+export let format: 'string' | 'arrayBuffer' = 'string'
+
+type $$Events = { drop: 'string' | 'arrayBuffer' }
+
+const dispatch = createEventDispatcher<$$Events>()
+
+const handleDrop = (event: DragEvent) => {
+  const reader = new FileReader()
+
+  reader.addEventListener('load', () => {
+    dispatch('drop', reader.result as typeof format)
+  })
+
+  if (event.dataTransfer === null) {
+    return
+  }
+
+  const [file] = event.dataTransfer.files
+
+  if (file === undefined) {
+    return
+  }
+
+  if (format === 'string') {
+    reader.readAsBinaryString(file)
+  } else if (format === 'arrayBuffer') {
+    reader.readAsArrayBuffer(file)
+  } else {
+    throw new Error ('Unsupported dropzone format.')
+  }
+}
+
+</script>
+
+<div
+  on:dragenter|preventDefault
+  on:dragover|preventDefault
+  on:drop|preventDefault={handleDrop}
+  {...$$restProps}
+>
+  <slot />
+</div>


### PR DESCRIPTION
This is a bit of a power-user feature requested by motion team for debugging. Currently there's no API for returning motion planning paths to overlay on SLAM maps, and this provides a good debugging solution in the interim. Users can now drop text files on the slam map, and if they're populated with x,y positions then a motion path will show up. Most users won't ever discover this. Maybe in the near future we'll hook this up to an API.

https://github.com/viamrobotics/rdk/assets/103450731/85166f1d-cb01-4261-81ce-445fe2572594

cc @jeremyrhyde @nicksanford Just so the SLAM team knows about this feature as well.

