### PR TITLE
RSDK-3829 - Cancellation of in-progress movements between waypoints

### DIFF
--- a/services/navigation/builtin/builtin.go
+++ b/services/navigation/builtin/builtin.go
@@ -429,6 +429,7 @@ func (svc *builtIn) startWaypointExperimental(extra map[string]interface{}) erro
 		for wp, err := svc.nextWaypoint(svc.cancelCtx); err == nil; wp, err = svc.nextWaypoint(svc.cancelCtx) {
 			svc.logger.Infof("navigating to waypoint: %+v", wp)
 			if err := navOnce(svc.cancelCtx, wp); err != nil {
+				svc.waypointReached(svc.cancelCtx)
 				svc.logger.Infof("skipping waypoint %+v due to error while navigating towards it: %s", wp, err)
 			}
 		}

--- a/services/navigation/builtin/builtin.go
+++ b/services/navigation/builtin/builtin.go
@@ -344,6 +344,8 @@ func (svc *builtIn) RemoveWaypoint(ctx context.Context, id primitive.ObjectID, e
 	}
 	if goalWaypoint.ID == id {
 		svc.cancelFunc()
+		svc.activeBackgroundWorkers.Wait()
+		svc.cancelCtx, svc.cancelFunc = context.WithCancel(context.Background())
 	}
 	return svc.store.RemoveWaypoint(ctx, id)
 }


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-3829

Done:
* Calling `RemoveWaypoint` on a waypoint in progress cancels `MoveOnGlobe`
* Write tests to prove the above, as well as that calling `SetMode` to change to manual mode cancels `MoveOnGlobe`