### PR TITLE
RSDK-3329 Cache validation errors for modules, processes and packages

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -266,10 +266,16 @@ func TestConfigEnsure(t *testing.T) {
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, `processes.0`)
 	test.That(t, err.Error(), test.ShouldContainSubstring, `"id" is required`)
-	invalidProcesses.Processes[0].ID = "bar"
+	invalidProcesses = config.Config{
+		DisablePartialStart: true,
+		Processes:           []pexec.ProcessConfig{{ID: "bar"}},
+	}
 	err = invalidProcesses.Ensure(false, logger)
 	test.That(t, err.Error(), test.ShouldContainSubstring, `"name" is required`)
-	invalidProcesses.Processes[0].Name = "foo"
+	invalidProcesses = config.Config{
+		DisablePartialStart: true,
+		Processes:           []pexec.ProcessConfig{{ID: "bar", Name: "foo"}},
+	}
 	test.That(t, invalidProcesses.Ensure(false, logger), test.ShouldBeNil)
 
 	invalidNetwork := config.Config{

--- a/config/data/diff_config_1.json
+++ b/config/data/diff_config_1.json
@@ -2,7 +2,7 @@
     "modules": [
         {
             "name": "my-module",
-            "executable_path": "path/to/my-module",
+            "executable_path": ".",
             "log_level": "info"
         }
     ],

--- a/config/data/diff_config_2.json
+++ b/config/data/diff_config_2.json
@@ -2,7 +2,7 @@
     "modules": [
         {
             "name": "my-module",
-            "executable_path": "new/path/to/my-module",
+            "executable_path": "..",
             "log_level": "debug"
         }
     ],

--- a/config/diff.go
+++ b/config/diff.go
@@ -294,7 +294,7 @@ func diffProcesses(left, right []pexec.ProcessConfig, diff *Diff) bool {
 }
 
 func diffProcess(left, right pexec.ProcessConfig, diff *Diff) bool {
-	if reflect.DeepEqual(left, right) {
+	if left.Equals(right) {
 		return false
 	}
 	diff.Modified.Processes = append(diff.Modified.Processes, right)
@@ -336,7 +336,7 @@ func diffPackages(left, right []PackageConfig, diff *Diff) bool {
 }
 
 func diffPackage(left, right PackageConfig, diff *Diff) bool {
-	if reflect.DeepEqual(left, right) {
+	if left.Equals(right) {
 		return false
 	}
 	diff.Modified.Packages = append(diff.Modified.Packages, right)
@@ -489,7 +489,7 @@ func diffModules(leftModules, rightModules []Module, diff *Diff) bool {
 }
 
 func diffModule(left, right Module, diff *Diff) bool {
-	if reflect.DeepEqual(left, right) {
+	if left.Equals(right) {
 		return false
 	}
 	diff.Modified.Modules = append(diff.Modified.Modules, right)

--- a/config/diff_test.go
+++ b/config/diff_test.go
@@ -30,7 +30,7 @@ func TestDiffConfigs(t *testing.T) {
 		Modules: []config.Module{
 			{
 				Name:     "my-module",
-				ExePath:  "path/to/my-module",
+				ExePath:  ".",
 				LogLevel: "info",
 			},
 		},
@@ -103,7 +103,7 @@ func TestDiffConfigs(t *testing.T) {
 		Modules: []config.Module{
 			{
 				Name:     "my-module",
-				ExePath:  "new/path/to/my-module",
+				ExePath:  "..",
 				LogLevel: "debug",
 			},
 		},
@@ -314,7 +314,7 @@ func TestDiffConfigs(t *testing.T) {
 					Modules: []config.Module{
 						{
 							Name:     "my-module",
-							ExePath:  "path/to/my-module",
+							ExePath:  ".",
 							LogLevel: "info",
 						},
 					},
@@ -660,6 +660,12 @@ func modifiedConfigDiffValidate(c *config.ModifiedConfigDiff) error {
 
 	for idx := 0; idx < len(c.Packages); idx++ {
 		if err := c.Packages[idx].Validate(fmt.Sprintf("%s.%d", "packages", idx)); err != nil {
+			return err
+		}
+	}
+
+	for idx := 0; idx < len(c.Modules); idx++ {
+		if err := c.Modules[idx].Validate(fmt.Sprintf("%s.%d", "modules", idx)); err != nil {
 			return err
 		}
 	}

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -442,6 +442,11 @@ func newWithResources(
 	// specified modules.
 	r.manager.startModuleManager(r.webSvc.ModuleAddress(), cfg.UntrustedEnv, logger)
 	for _, mod := range cfg.Modules {
+		// this is done in config validation but partial start rules require us to check again
+		if err := mod.Validate(""); err != nil {
+			r.logger.Errorw("module config validation error; skipping", "module", mod.Name, "error", err)
+			continue
+		}
 		if err := r.manager.moduleManager.Add(ctx, mod); err != nil {
 			r.logger.Errorw("error adding module", "module", mod.Name, "error", err)
 			continue

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -849,6 +849,11 @@ func (manager *resourceManager) updateResources(
 			break
 		}
 
+		// this is done in config validation but partial start rules require us to check again
+		if err := p.Validate(""); err != nil {
+			manager.logger.Errorw("process config validation error; skipping", "process", p.Name, "error", err)
+			continue
+		}
 		_, err := manager.processManager.AddProcessFromConfig(ctx, p)
 		if err != nil {
 			manager.logger.Errorw("error while adding process; skipping", "process", p.ID, "error", err)
@@ -873,6 +878,11 @@ func (manager *resourceManager) updateResources(
 		// Remove processConfig from map in case re-addition fails.
 		delete(manager.processConfigs, p.ID)
 
+		// this is done in config validation but partial start rules require us to check again
+		if err := p.Validate(""); err != nil {
+			manager.logger.Errorw("process config validation error; skipping", "process", p.Name, "error", err)
+			continue
+		}
 		_, err := manager.processManager.AddProcessFromConfig(ctx, p)
 		if err != nil {
 			manager.logger.Errorw("error while changing process; skipping", "process", p.ID, "error", err)
@@ -883,12 +893,22 @@ func (manager *resourceManager) updateResources(
 
 	// modules are not added into the resource tree as they belong to the module manager
 	for _, mod := range conf.Added.Modules {
+		// this is done in config validation but partial start rules require us to check again
+		if err := mod.Validate(""); err != nil {
+			manager.logger.Errorw("module config validation error; skipping", "module", mod.Name, "error", err)
+			continue
+		}
 		if err := manager.moduleManager.Add(ctx, mod); err != nil {
 			manager.logger.Errorw("error adding module", "module", mod.Name, "error", err)
 			continue
 		}
 	}
 	for _, mod := range conf.Modified.Modules {
+		// this is done in config validation but partial start rules require us to check again
+		if err := mod.Validate(""); err != nil {
+			manager.logger.Errorw("module config validation error; skipping", "module", mod.Name, "error", err)
+			continue
+		}
 		orphanedResourceNames, err := manager.moduleManager.Reconfigure(ctx, mod)
 		if err != nil {
 			manager.logger.Errorw("error reconfiguring module", "module", mod.Name, "error", err)

--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -145,6 +145,11 @@ func (m *cloudManager) Sync(ctx context.Context, packages []config.PackageConfig
 		default:
 		}
 
+		if err := p.Validate(""); err != nil {
+			m.logger.Debugf("package config validation error; skipping", "package", p.Name, "error", err)
+			continue
+		}
+
 		start := time.Now()
 		m.logger.Debugf("Starting package sync [%d/%d] %s:%s", idx+1, len(packages), p.Package, p.Version)
 


### PR DESCRIPTION
RSDK-3329

Caches validation errors for modules, process and packages. Previously, `config.Ensure` would validate these three and say "starting robot without module/process/package", but the robot would start with it anyway. As we do with regular resources, we should probably cache the result of validation for these three and not actually add them to their managers if there was a validation error.

Requires an update to goutils to cache validation errors for `ProcessConfig`.