### PR TITLE
Change error check in movementsensor readings

### DIFF
--- a/components/movementsensor/movementsensor.go
+++ b/components/movementsensor/movementsensor.go
@@ -148,7 +148,7 @@ func Readings(ctx context.Context, g MovementSensor, extra map[string]interface{
 
 	ori, err := g.Orientation(ctx, extra)
 	if err != nil {
-		if !strings.Contains(err.Error(), ErrMethodUnimplementedLinearVelocity.Error()) {
+		if !strings.Contains(err.Error(), ErrMethodUnimplementedOrientation.Error()) {
 			return nil, err
 		}
 	} else {

--- a/components/movementsensor/movementsensor.go
+++ b/components/movementsensor/movementsensor.go
@@ -3,7 +3,7 @@ package movementsensor
 
 import (
 	"context"
-	"errors"
+	"strings"
 
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
@@ -102,7 +102,7 @@ func Readings(ctx context.Context, g MovementSensor, extra map[string]interface{
 
 	pos, altitude, err := g.Position(ctx, extra)
 	if err != nil {
-		if !errors.Is(err, ErrMethodUnimplementedPosition) {
+		if !strings.Contains(err.Error(), ErrMethodUnimplementedPosition.Error()) {
 			return nil, err
 		}
 	} else {
@@ -112,7 +112,7 @@ func Readings(ctx context.Context, g MovementSensor, extra map[string]interface{
 
 	vel, err := g.LinearVelocity(ctx, extra)
 	if err != nil {
-		if !errors.Is(err, ErrMethodUnimplementedLinearVelocity) {
+		if !strings.Contains(err.Error(), ErrMethodUnimplementedLinearVelocity.Error()) {
 			return nil, err
 		}
 	} else {
@@ -121,7 +121,7 @@ func Readings(ctx context.Context, g MovementSensor, extra map[string]interface{
 
 	la, err := g.LinearAcceleration(ctx, extra)
 	if err != nil {
-		if !errors.Is(err, ErrMethodUnimplementedLinearAcceleration) {
+		if !strings.Contains(err.Error(), ErrMethodUnimplementedLinearAcceleration.Error()) {
 			return nil, err
 		}
 	} else {
@@ -130,7 +130,7 @@ func Readings(ctx context.Context, g MovementSensor, extra map[string]interface{
 
 	avel, err := g.AngularVelocity(ctx, extra)
 	if err != nil {
-		if !errors.Is(err, ErrMethodUnimplementedAngularVelocity) {
+		if !strings.Contains(err.Error(), ErrMethodUnimplementedAngularVelocity.Error()) {
 			return nil, err
 		}
 	} else {
@@ -139,7 +139,7 @@ func Readings(ctx context.Context, g MovementSensor, extra map[string]interface{
 
 	compass, err := g.CompassHeading(ctx, extra)
 	if err != nil {
-		if !errors.Is(err, ErrMethodUnimplementedCompassHeading) {
+		if !strings.Contains(err.Error(), ErrMethodUnimplementedCompassHeading.Error()) {
 			return nil, err
 		}
 	} else {
@@ -148,7 +148,7 @@ func Readings(ctx context.Context, g MovementSensor, extra map[string]interface{
 
 	ori, err := g.Orientation(ctx, extra)
 	if err != nil {
-		if !errors.Is(err, ErrMethodUnimplementedOrientation) {
+		if !strings.Contains(err.Error(), ErrMethodUnimplementedLinearVelocity.Error()) {
 			return nil, err
 		}
 	} else {


### PR DESCRIPTION
### Summary
This change allows modular movementsensors to call readings without erroring when not all of the interface is implemented. 