### PR TITLE
RSDK-4015: flaky test in components/gantry/singleaxis, times out after 10 minutes

### DIFF
--- a/components/gantry/singleaxis/singleaxis.go
+++ b/components/gantry/singleaxis/singleaxis.go
@@ -295,6 +295,14 @@ func (g *singleAxis) moveAway(ctx context.Context, pin int) error {
 		return err
 	}
 	for {
+		if ctx.Err() != nil {
+			if g.motor != nil {
+				if err := g.motor.Stop(ctx, nil); err != nil {
+					return err
+				}
+			}
+			return ctx.Err()
+		}
 		hit, err := g.limitHit(ctx, pin)
 		if err != nil {
 			return err

--- a/components/gantry/singleaxis/singleaxis.go
+++ b/components/gantry/singleaxis/singleaxis.go
@@ -295,9 +295,11 @@ func (g *singleAxis) moveAway(ctx context.Context, pin int) error {
 		return err
 	}
 	for {
+		defer utils.UncheckedErrorFunc(func() error {
+			return g.motor.Stop(ctx, nil)
+		})
 		if ctx.Err() != nil {
-			defer g.motor.Stop(ctx, nil)
-			return errors.Wrapf(multierr.Combine(ctx.Err(), g.motor.Stop(ctx, nil)), "stop error and context error")
+			return ctx.Err()
 		}
 		hit, err := g.limitHit(ctx, pin)
 		if err != nil {

--- a/components/gantry/singleaxis/singleaxis.go
+++ b/components/gantry/singleaxis/singleaxis.go
@@ -296,12 +296,8 @@ func (g *singleAxis) moveAway(ctx context.Context, pin int) error {
 	}
 	for {
 		if ctx.Err() != nil {
-			if g.motor != nil {
-				if err := g.motor.Stop(ctx, nil); err != nil {
-					return err
-				}
-			}
-			return ctx.Err()
+			defer g.motor.Stop(ctx, nil)
+			return errors.Wrapf(multierr.Combine(ctx.Err(), g.motor.Stop(ctx, nil)), "stop error and context error")
 		}
 		hit, err := g.limitHit(ctx, pin)
 		if err != nil {

--- a/components/gantry/singleaxis/singleaxis.go
+++ b/components/gantry/singleaxis/singleaxis.go
@@ -294,10 +294,10 @@ func (g *singleAxis) moveAway(ctx context.Context, pin int) error {
 	if err := g.motor.GoFor(ctx, dir*g.rpm, 0, nil); err != nil {
 		return err
 	}
+	defer utils.UncheckedErrorFunc(func() error {
+		return g.motor.Stop(ctx, nil)
+	})
 	for {
-		defer utils.UncheckedErrorFunc(func() error {
-			return g.motor.Stop(ctx, nil)
-		})
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}


### PR DESCRIPTION
This PR fixes the data race in the single axis `moveAway` function