### PR TITLE
RSDK-4048: Verify that RunInParallel can run multiple functions at once

### DIFF
--- a/components/base/wheeled/wheeled_base.go
+++ b/components/base/wheeled/wheeled_base.go
@@ -291,11 +291,13 @@ func (wb *wheeledBase) runAll(ctx context.Context, leftRPM, leftRotations, right
 	fs := []rdkutils.SimpleFunc{}
 
 	for _, m := range wb.left {
-		fs = append(fs, func(ctx context.Context) error { return m.GoFor(ctx, leftRPM, leftRotations, nil) })
+		motor := m
+		fs = append(fs, func(ctx context.Context) error { return motor.GoFor(ctx, leftRPM, leftRotations, nil) })
 	}
 
 	for _, m := range wb.right {
-		fs = append(fs, func(ctx context.Context) error { return m.GoFor(ctx, rightRPM, rightRotations, nil) })
+		motor := m
+		fs = append(fs, func(ctx context.Context) error { return motor.GoFor(ctx, rightRPM, rightRotations, nil) })
 	}
 
 	if _, err := rdkutils.RunInParallel(ctx, fs); err != nil {


### PR DESCRIPTION
 This PR fixes runAll for case with 4 motors. Before, only one motor on the left and one motor on the right would receive the commands, but now all motors will move in parallel.