### PR TITLE
RSDK-3329, RSDK-4070 - Do not restart modules that crash before ready and respect resource configuration timeout

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -449,14 +449,17 @@ func (mgr *Manager) newOnUnexpectedExitHandler(mod *module) func(exitCode int) b
 		// If mod.handles was never set, the module was never actually ready in the
 		// first place before crashing. Log an error and do not attempt a restart;
 		// something is likely wrong with the module implemenation.
+		mgr.mu.Lock()
 		if mod.handles == nil {
 			mgr.logger.Errorw(
 				"module has unexpectedly exited without responding to a ready request ",
 				"module", mod.name,
 				"exit_code", exitCode,
 			)
+			mgr.mu.Unlock()
 			return false
 		}
+		mgr.mu.Unlock()
 
 		mod.inRecovery.Store(true)
 		defer mod.inRecovery.Store(false)

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -145,7 +145,7 @@ func (mgr *Manager) add(ctx context.Context, conf config.Module, conn *grpc.Clie
 		}
 	}()
 
-	// dial will re-use m.conn if it's non-nil (module being added in a Reconfigure).
+	// dial will re-use mod.conn if it's non-nil (module being added in a Reconfigure).
 	if err := mod.dial(); err != nil {
 		return errors.WithMessage(err, "error while dialing module "+mod.name)
 	}
@@ -589,7 +589,7 @@ func (mgr *Manager) attemptRestart(ctx context.Context, mod *module) []resource.
 		}
 	}()
 
-	// dial will re-use m.conn; old connection can still be used when module
+	// dial will re-use mod.conn; old connection can still be used when module
 	// crashes.
 	if err := mod.dial(); err != nil {
 		mgr.logger.Errorw("error while dialing restarted module",

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -491,7 +491,7 @@ func TestModuleReloading(t *testing.T) {
 
 		// Assert that manager removes module after immediate crash.
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
-			test.That(t, len(mgr.Configs()), test.ShouldEqual, 0)
+			test.That(tb, len(mgr.Configs()), test.ShouldEqual, 0)
 		})
 
 		err = mgr.Close(ctx)

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -56,12 +56,12 @@ func TestModManagerFunctions(t *testing.T) {
 	err = mod.startProcess(ctx, parentAddr, nil, logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	err = mod.dial(nil)
+	err = mod.dial()
 	test.That(t, err, test.ShouldBeNil)
 
 	// check that dial can re-use connections.
 	oldConn := mod.conn
-	err = mod.dial(mod.conn)
+	err = mod.dial()
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, mod.conn, test.ShouldEqual, oldConn)
 
@@ -471,7 +471,7 @@ func TestModuleReloading(t *testing.T) {
 		}(oueRestartInterval)
 		oueRestartInterval = 10 * time.Millisecond
 
-		// Lower resource configuration timeout to avoid waiting for 30 seconds
+		// Lower resource configuration timeout to avoid waiting for 60 seconds
 		// for manager.Add to time out waiting for module to start listening.
 		defer func() {
 			test.That(t, os.Unsetenv(rutils.ResourceConfigurationTimeoutEnvVar),

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -489,6 +489,11 @@ func TestModuleReloading(t *testing.T) {
 		test.That(t, err.Error(), test.ShouldContainSubstring,
 			"timed out waiting for module test-module to start listening")
 
+		// Assert that manager removes module after immediate crash.
+		testutils.WaitForAssertion(t, func(tb testing.TB) {
+			test.That(t, len(mgr.Configs()), test.ShouldEqual, 0)
+		})
+
 		err = mgr.Close(ctx)
 		test.That(t, err, test.ShouldBeNil)
 

--- a/module/testmodule/fakemodule.sh
+++ b/module/testmodule/fakemodule.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# fakemodule is a completely fake module that echos a message and exits. Used
+# to test that modules that never respond to ready requests will not be
+# restarted.
+
+echo "this is a fake module; exiting now"

--- a/resource/errors.go
+++ b/resource/errors.go
@@ -71,8 +71,8 @@ func (e *mustRebuildError) Error() string {
 // NewBuildTimeoutError is used when a resource times out during construction or reconfiguration.
 func NewBuildTimeoutError(name Name) error {
 	return fmt.Errorf(
-		"resource %s timed out during reconfigure. The default timeout is 1min; update %s env variable to override",
-		name, utils.ResourceConfigurationTimeoutEnvVar)
+		"resource %s timed out during reconfigure. The default timeout is %v; update %s env variable to override",
+		name, utils.DefaultResourceConfigurationTimeout, utils.ResourceConfigurationTimeoutEnvVar)
 }
 
 // DependencyNotFoundError is used when a resource is not found in a dependencies.

--- a/resource/errors.go
+++ b/resource/errors.go
@@ -70,9 +70,9 @@ func (e *mustRebuildError) Error() string {
 
 // NewBuildTimeoutError is used when a resource times out during construction or reconfiguration.
 func NewBuildTimeoutError(name Name) error {
-	envVar := "VIAM_RESOURCE_CONFIGURATION_TIMEOUT"
 	return fmt.Errorf(
-		"resource %s timed out during reconfigure. The default timeout is 1min; update %s env variable to override", name, envVar)
+		"resource %s timed out during reconfigure. The default timeout is 1min; update %s env variable to override",
+		name, utils.ResourceConfigurationTimeoutEnvVar)
 }
 
 // DependencyNotFoundError is used when a resource is not found in a dependencies.

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -6,7 +6,6 @@ package robotimpl
 
 import (
 	"context"
-	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -39,8 +38,6 @@ import (
 )
 
 var _ = robot.LocalRobot(&localRobot{})
-
-var resourceConfigurationTimeout = time.Minute
 
 // localRobot satisfies robot.LocalRobot and defers most
 // logic to its manager.
@@ -653,18 +650,6 @@ func (r *localRobot) newResource(
 	return resInfo.DeprecatedRobotConstructor(ctx, r, conf, resLogger)
 }
 
-func (r *localRobot) getTimeout() time.Duration {
-	if newTimeout := os.Getenv("VIAM_RESOURCE_CONFIGURATION_TIMEOUT"); newTimeout != "" {
-		timeOut, err := time.ParseDuration(newTimeout)
-		if err != nil {
-			r.logger.Warn("Failed to parse VIAM_RESOURCE_CONFIGURATION_TIMEOUT env var, falling back to default 1 minute timeout")
-			return resourceConfigurationTimeout
-		}
-		return timeOut
-	}
-	return resourceConfigurationTimeout
-}
-
 func (r *localRobot) updateWeakDependents(ctx context.Context) {
 	// track that we are current in resources up to the latest update time. This will
 	// be used to determine if this method should be called while completing a config.
@@ -693,7 +678,7 @@ func (r *localRobot) updateWeakDependents(ctx context.Context) {
 		}
 	}
 
-	timeout := r.getTimeout()
+	timeout := utils.GetResourceConfigurationTimeout(r.logger)
 	// NOTE(erd): this is intentionally hard coded since these services are treated specially with
 	// how they request dependencies or consume the robot's config. We should make an effort to
 	// formalize these as servcices that while internal, obey the reconfigure lifecycle.

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -528,7 +528,7 @@ func (manager *resourceManager) completeConfig(
 	}
 
 	resourceNames := manager.resources.ReverseTopologicalSort()
-	timeout := robot.getTimeout()
+	timeout := rutils.GetResourceConfigurationTimeout(manager.logger)
 	for _, resName := range resourceNames {
 		resChan := make(chan struct{}, 1)
 		resName := resName

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -49,6 +49,7 @@ import (
 	_ "go.viam.com/rdk/services/sensors/builtin"
 	rdktestutils "go.viam.com/rdk/testutils"
 	"go.viam.com/rdk/testutils/robottestutils"
+	rutils "go.viam.com/rdk/utils"
 )
 
 var (
@@ -3565,9 +3566,13 @@ func TestResourceConstructTimeout(t *testing.T) {
 
 	// create new cfg with wheeled base modified to trigger Reconfigure, set timeout
 	// to the shortest possible window to ensure timeout
+	defer func() {
+		test.That(t, os.Unsetenv(rutils.ResourceConfigurationTimeoutEnvVar),
+			test.ShouldBeNil)
+	}()
+	test.That(t, os.Setenv(rutils.ResourceConfigurationTimeoutEnvVar, "1ns"),
+		test.ShouldBeNil)
 
-	resourceConfigurationTimeout = time.Nanosecond
-	defer func() { resourceConfigurationTimeout = time.Minute }()
 	newestCfg := &config.Config{
 		Components: []resource.Config{
 			{

--- a/utils/env.go
+++ b/utils/env.go
@@ -1,0 +1,34 @@
+package utils
+
+import (
+	"os"
+	"time"
+
+	"github.com/edaniels/golog"
+)
+
+const (
+	defaultResourceConfigurationTimeout = time.Minute
+
+	// ResourceConfigurationTimeoutEnvVar is the environment variable that can
+	// be set to override defaultResourceConfigurationTimeout as the duration
+	// that resources and modules are allowed to (re)configure and startup
+	// respectively.
+	ResourceConfigurationTimeoutEnvVar = "VIAM_RESOURCE_CONFIGURATION_TIMEOUT"
+)
+
+// GetResourceConfigurationTimeout calculates the resource configuration
+// timeout (env variable value if set, defaultResourceConfigurationTimeout
+// otherwise).
+func GetResourceConfigurationTimeout(logger golog.Logger) time.Duration {
+	if timeoutVal := os.Getenv(ResourceConfigurationTimeoutEnvVar); timeoutVal != "" {
+		timeout, err := time.ParseDuration(timeoutVal)
+		if err != nil {
+			logger.Warn("Failed to parse %s env var, falling back to default 1 minute timeout",
+				ResourceConfigurationTimeoutEnvVar)
+			return defaultResourceConfigurationTimeout
+		}
+		return timeout
+	}
+	return defaultResourceConfigurationTimeout
+}

--- a/utils/env.go
+++ b/utils/env.go
@@ -8,7 +8,9 @@ import (
 )
 
 const (
-	defaultResourceConfigurationTimeout = time.Minute
+	// DefaultResourceConfigurationTimeout is the default resource configuration
+	// timeout.
+	DefaultResourceConfigurationTimeout = time.Minute
 
 	// ResourceConfigurationTimeoutEnvVar is the environment variable that can
 	// be set to override defaultResourceConfigurationTimeout as the duration
@@ -24,11 +26,11 @@ func GetResourceConfigurationTimeout(logger golog.Logger) time.Duration {
 	if timeoutVal := os.Getenv(ResourceConfigurationTimeoutEnvVar); timeoutVal != "" {
 		timeout, err := time.ParseDuration(timeoutVal)
 		if err != nil {
-			logger.Warn("Failed to parse %s env var, falling back to default 1 minute timeout",
-				ResourceConfigurationTimeoutEnvVar)
-			return defaultResourceConfigurationTimeout
+			logger.Warn("Failed to parse %s env var, falling back to default %v timeout",
+				ResourceConfigurationTimeoutEnvVar, DefaultResourceConfigurationTimeout)
+			return DefaultResourceConfigurationTimeout
 		}
 		return timeout
 	}
-	return defaultResourceConfigurationTimeout
+	return DefaultResourceConfigurationTimeout
 }


### PR DESCRIPTION
RSDK-3329
RSDK-4070

Only restarts modules in the OUE handler when the `handles` field has been set on the module (the module responded to a ready request and returned its handler map). Changes hard-coded 30 second listen/ready timeouts to be 60 second defaults that can overridden with `VIAM_RESOURCE_CONFIGURATION_TIMEOUT` variable). Adds a test that immediate crash of a module does not result in an attempted restart. 