### PR TITLE
RSDK-2672: tests using Incremental/Single encoder should use constructor, not initialization

### DIFF
--- a/components/encoder/incremental/incremental_encoder.go
+++ b/components/encoder/incremental/incremental_encoder.go
@@ -49,8 +49,7 @@ type Encoder struct {
 	encBName  string
 
 	logger golog.Logger
-	// TODO(RSDK-2672): This is exposed for tests and should be unexported with
-	// the constructor being used instead.
+
 	cancelCtx               context.Context
 	cancelFunc              func()
 	activeBackgroundWorkers sync.WaitGroup

--- a/components/encoder/single/single_encoder.go
+++ b/components/encoder/single/single_encoder.go
@@ -67,8 +67,7 @@ type Encoder struct {
 
 	positionType encoder.PositionType
 	logger       golog.Logger
-	// TODO(RSDK-2672): This is exposed for tests and should be unexported with
-	// the constructor being used instead.
+
 	cancelCtx               context.Context
 	cancelFunc              func()
 	activeBackgroundWorkers sync.WaitGroup

--- a/components/motor/gpio/motor_encoder_test.go
+++ b/components/motor/gpio/motor_encoder_test.go
@@ -80,7 +80,6 @@ func MakeIncrementalBoard(t *testing.T) *fakeboard.Board {
 }
 
 func TestMotorEncoder1(t *testing.T) {
-	t.Skip()
 	logger := golog.NewTestLogger(t)
 	undo := SetRPMSleepDebug(1, false)
 	defer undo()
@@ -152,7 +151,6 @@ func TestMotorEncoder1(t *testing.T) {
 	})
 
 	t.Run("encoded motor testing SetPower interrupt GoFor", func(t *testing.T) {
-		t.Skip()
 		test.That(t, motorDep.goForInternal(context.Background(), 1000, 1000), test.ShouldBeNil)
 		test.That(t, fakeMotor.Direction(), test.ShouldEqual, 1)
 		test.That(t, fakeMotor.PowerPct(), test.ShouldBeGreaterThan, float32(0))
@@ -190,30 +188,16 @@ func TestMotorEncoder1(t *testing.T) {
 		})
 
 		test.That(t, motorDep.Stop(context.Background(), nil), test.ShouldBeNil)
-
-		testutils.WaitForAssertion(t, func(tb testing.TB) {
-			tb.Helper()
-			pos, err := motorDep.Position(context.Background(), nil)
-			test.That(tb, err, test.ShouldBeNil)
-			test.That(tb, pos, test.ShouldAlmostEqual, 10, 0.01)
-		})
 	})
 
 	t.Run("encoded motor testing GoFor (RPM + | REV +)", func(t *testing.T) {
 		test.That(t, motorDep.goForInternal(context.Background(), 1000, 1), test.ShouldBeNil)
-		test.That(t, fakeMotor.Direction(), test.ShouldEqual, 1)
-		test.That(t, fakeMotor.PowerPct(), test.ShouldBeGreaterThan, 0)
+		test.That(t, motorDep.DirectionMoving(), test.ShouldEqual, 1)
 
-		test.That(t, interrupt.Ticks(context.Background(), 99, nowNanosTest()), test.ShouldBeNil)
+		test.That(t, enc.I.Tick(context.Background(), true, nowNanosTest()), test.ShouldBeNil)
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
 			test.That(tb, fakeMotor.Direction(), test.ShouldEqual, 1)
-		})
-
-		test.That(t, interrupt.Tick(context.Background(), true, nowNanosTest()), test.ShouldBeNil)
-		testutils.WaitForAssertion(t, func(tb testing.TB) {
-			tb.Helper()
-			test.That(tb, fakeMotor.Direction(), test.ShouldEqual, 0)
 		})
 
 		test.That(t, motorDep.Stop(context.Background(), nil), test.ShouldBeNil)
@@ -234,16 +218,10 @@ func TestMotorEncoder1(t *testing.T) {
 		test.That(t, fakeMotor.Direction(), test.ShouldEqual, -1)
 		test.That(t, fakeMotor.PowerPct(), test.ShouldBeLessThan, 0)
 
-		test.That(t, interrupt.Ticks(context.Background(), 99, nowNanosTest()), test.ShouldBeNil)
+		test.That(t, enc.I.Tick(context.Background(), true, nowNanosTest()), test.ShouldBeNil)
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
 			test.That(tb, fakeMotor.Direction(), test.ShouldEqual, -1)
-		})
-
-		test.That(t, interrupt.Tick(context.Background(), true, nowNanosTest()), test.ShouldBeNil)
-		testutils.WaitForAssertion(t, func(tb testing.TB) {
-			tb.Helper()
-			test.That(tb, fakeMotor.Direction(), test.ShouldEqual, 0)
 		})
 
 		test.That(t, motorDep.Stop(context.Background(), nil), test.ShouldBeNil)
@@ -269,12 +247,6 @@ func TestMotorEncoder1(t *testing.T) {
 			test.That(tb, fakeMotor.Direction(), test.ShouldEqual, -1)
 		})
 
-		test.That(t, interrupt.Tick(context.Background(), true, nowNanosTest()), test.ShouldBeNil)
-		testutils.WaitForAssertion(t, func(tb testing.TB) {
-			tb.Helper()
-			test.That(tb, fakeMotor.Direction(), test.ShouldEqual, 0)
-		})
-
 		test.That(t, motorDep.Stop(context.Background(), nil), test.ShouldBeNil)
 
 		test.That(t, motorDep.goForInternal(context.Background(), 1000, -1), test.ShouldBeNil)
@@ -297,12 +269,6 @@ func TestMotorEncoder1(t *testing.T) {
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
 			test.That(tb, fakeMotor.Direction(), test.ShouldEqual, 1)
-		})
-
-		test.That(t, interrupt.Tick(context.Background(), true, nowNanosTest()), test.ShouldBeNil)
-		testutils.WaitForAssertion(t, func(tb testing.TB) {
-			tb.Helper()
-			test.That(tb, fakeMotor.Direction(), test.ShouldEqual, 0)
 		})
 
 		test.That(t, motorDep.Stop(context.Background(), nil), test.ShouldBeNil)
@@ -336,7 +302,6 @@ func TestMotorEncoder1(t *testing.T) {
 }
 
 func TestMotorEncoderIncremental(t *testing.T) {
-	// t.Skip()
 	logger := golog.NewTestLogger(t)
 	undo := SetRPMSleepDebug(1, false)
 	defer undo()

--- a/components/motor/gpio/motor_encoder_test.go
+++ b/components/motor/gpio/motor_encoder_test.go
@@ -110,8 +110,10 @@ func TestMotorEncoder1(t *testing.T) {
 
 	enc.AttachDirectionalAwareness(&fakeDirectionAware{m: fakeMotor})
 	dirFMotor, err := NewEncodedMotor(resource.Config{}, cfg, fakeMotor, e, logger)
+	defer dirFMotor.Close(context.Background())
 	test.That(t, err, test.ShouldBeNil)
 	motorDep, ok := dirFMotor.(*EncodedMotor)
+	defer motorDep.Close(context.Background())
 	test.That(t, ok, test.ShouldBeTrue)
 	defer func() {
 		test.That(t, motorDep.Close(context.Background()), test.ShouldBeNil)
@@ -666,6 +668,7 @@ func TestWrapMotorWithEncoder(t *testing.T) {
 			fakeMotor,
 			logger,
 		)
+		defer m.Close(context.Background())
 		test.That(t, err, test.ShouldBeNil)
 		_, ok := m.(*EncodedMotor)
 		test.That(t, ok, test.ShouldBeTrue)
@@ -707,6 +710,7 @@ func TestWrapMotorWithEncoder(t *testing.T) {
 			fakeMotor,
 			logger,
 		)
+		defer m.Close(context.Background())
 		test.That(t, err, test.ShouldBeNil)
 		_, ok := m.(*EncodedMotor)
 		test.That(t, ok, test.ShouldBeTrue)
@@ -723,6 +727,7 @@ func TestDirFlipMotor(t *testing.T) {
 		TicksPerRotation: 100,
 		DirFlip:          true,
 	}
+	defer dirflipFakeMotor.Close(context.Background())
 
 	ctx := context.Background()
 	b := MakeSingleBoard(t)
@@ -742,8 +747,10 @@ func TestDirFlipMotor(t *testing.T) {
 
 	enc.AttachDirectionalAwareness(&fakeDirectionAware{m: dirflipFakeMotor})
 	dirFMotor, err := NewEncodedMotor(resource.Config{}, cfg, dirflipFakeMotor, e, logger)
+	defer dirFMotor.Close(context.Background())
 	test.That(t, err, test.ShouldBeNil)
 	_dirFMotor, ok := dirFMotor.(*EncodedMotor)
+	defer _dirFMotor.Close(context.Background())
 	test.That(t, ok, test.ShouldBeTrue)
 
 	t.Run("Direction flip RPM + | REV + ", func(t *testing.T) {

--- a/components/motor/gpio/motor_encoder_test.go
+++ b/components/motor/gpio/motor_encoder_test.go
@@ -367,12 +367,11 @@ func TestMotorEncoderIncremental(t *testing.T) {
 			BoardName: "main",
 			Pins:      incremental.Pins{A: "11", B: "13"},
 		}
-		rawcfg := resource.Config{Name: "enc1", ConvertedAttributes: &ic}
 
+		rawcfg := resource.Config{Name: "enc1", ConvertedAttributes: &ic}
 		e, err := incremental.NewIncrementalEncoder(ctx, deps, rawcfg, golog.NewTestLogger(t))
-		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err, test.ShouldBeNil)
 		enc := e.(*incremental.Encoder)
-		defer enc.Close(context.Background())
 
 		motorIfc, err := NewEncodedMotor(resource.Config{}, cfg, fakeMotor, enc, logger)
 		test.That(t, err, test.ShouldBeNil)
@@ -399,7 +398,6 @@ func TestMotorEncoderIncremental(t *testing.T) {
 
 	t.Run("motor encoder no motion", func(t *testing.T) {
 		th := setup(t)
-		defer th.Encoder.Close(context.Background())
 		defer th.Teardown()
 
 		enc := th.Encoder
@@ -415,7 +413,6 @@ func TestMotorEncoderIncremental(t *testing.T) {
 
 	t.Run("motor encoder move forward", func(t *testing.T) {
 		th := setup(t)
-		defer th.Encoder.Close(context.Background())
 		defer th.Teardown()
 
 		enc := th.Encoder
@@ -476,7 +473,6 @@ func TestMotorEncoderIncremental(t *testing.T) {
 
 	t.Run("motor encoder move backward", func(t *testing.T) {
 		th := setup(t)
-		defer th.Encoder.Close(context.Background())
 		defer th.Teardown()
 
 		enc := th.Encoder
@@ -581,7 +577,6 @@ func TestMotorEncoderIncremental(t *testing.T) {
 
 	t.Run("motor encoder test GoFor (forward)", func(t *testing.T) {
 		th := setup(t)
-		defer th.Encoder.Close(context.Background())
 		defer th.Teardown()
 		undo := SetRPMSleepDebug(1, false)
 		defer undo()
@@ -619,7 +614,6 @@ func TestMotorEncoderIncremental(t *testing.T) {
 
 	t.Run("motor encoder test GoFor (backwards)", func(t *testing.T) {
 		th := setup(t)
-		defer th.Encoder.Close(context.Background())
 		defer th.Teardown()
 		undo := SetRPMSleepDebug(1, false)
 		defer undo()

--- a/components/motor/gpio/motor_encoder_test.go
+++ b/components/motor/gpio/motor_encoder_test.go
@@ -110,8 +110,8 @@ func TestMotorEncoder1(t *testing.T) {
 
 	enc.AttachDirectionalAwareness(&fakeDirectionAware{m: fakeMotor})
 	dirFMotor, err := NewEncodedMotor(resource.Config{}, cfg, fakeMotor, e, logger)
-	defer dirFMotor.Close(context.Background())
 	test.That(t, err, test.ShouldBeNil)
+	defer dirFMotor.Close(context.Background())
 	motorDep, ok := dirFMotor.(*EncodedMotor)
 	defer motorDep.Close(context.Background())
 	test.That(t, ok, test.ShouldBeTrue)
@@ -668,8 +668,8 @@ func TestWrapMotorWithEncoder(t *testing.T) {
 			fakeMotor,
 			logger,
 		)
-		defer m.Close(context.Background())
 		test.That(t, err, test.ShouldBeNil)
+		defer m.Close(context.Background())
 		_, ok := m.(*EncodedMotor)
 		test.That(t, ok, test.ShouldBeTrue)
 		test.That(t, m.Close(context.Background()), test.ShouldBeNil)
@@ -710,8 +710,8 @@ func TestWrapMotorWithEncoder(t *testing.T) {
 			fakeMotor,
 			logger,
 		)
-		defer m.Close(context.Background())
 		test.That(t, err, test.ShouldBeNil)
+		defer m.Close(context.Background())
 		_, ok := m.(*EncodedMotor)
 		test.That(t, ok, test.ShouldBeTrue)
 		test.That(t, m.Close(context.Background()), test.ShouldBeNil)
@@ -747,11 +747,11 @@ func TestDirFlipMotor(t *testing.T) {
 
 	enc.AttachDirectionalAwareness(&fakeDirectionAware{m: dirflipFakeMotor})
 	dirFMotor, err := NewEncodedMotor(resource.Config{}, cfg, dirflipFakeMotor, e, logger)
-	defer dirFMotor.Close(context.Background())
 	test.That(t, err, test.ShouldBeNil)
+	defer dirFMotor.Close(context.Background())
 	_dirFMotor, ok := dirFMotor.(*EncodedMotor)
-	defer _dirFMotor.Close(context.Background())
 	test.That(t, ok, test.ShouldBeTrue)
+	defer _dirFMotor.Close(context.Background())
 
 	t.Run("Direction flip RPM + | REV + ", func(t *testing.T) {
 		test.That(t, _dirFMotor.goForInternal(context.Background(), 1000, 1), test.ShouldBeNil)


### PR DESCRIPTION
Make `CancelCtx` private (now `cancelCtx`) for encoders and update tests accordingly.