### PR TITLE
Fix createRcApp function in library mode

### DIFF
--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/remote-control",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@improbable-eng/grpc-web": "0.15.0",

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "Apache-2.0",
   "type": "module",
   "files": [

--- a/web/frontend/src/components/remote-control-cards.svelte
+++ b/web/frontend/src/components/remote-control-cards.svelte
@@ -27,8 +27,8 @@ import Client from '@/lib/components/robot-client.svelte';
 const { resources, components, services, statuses, sensorNames } = useRobotClient();
 
 export let host: string;
-export let bakedAuth: { authEntity: string; creds: Credentials; } | undefined;
-export let supportedAuthTypes: string[];
+export let bakedAuth: { authEntity: string; creds: Credentials; } | undefined = undefined;
+export let supportedAuthTypes: string[] | undefined = [];
 export let webrtcEnabled: boolean;
 export let signalingAddress: string;
 

--- a/web/frontend/src/components/remote-control-cards.svelte
+++ b/web/frontend/src/components/remote-control-cards.svelte
@@ -27,7 +27,7 @@ import Client from '@/lib/components/robot-client.svelte';
 const { resources, components, services, statuses, sensorNames } = useRobotClient();
 
 export let host: string;
-export let bakedAuth: { authEntity: string; creds: Credentials; } | undefined = undefined;
+export let bakedAuth: { authEntity?: string; creds?: Credentials; } | undefined = {};
 export let supportedAuthTypes: string[] | undefined = [];
 export let webrtcEnabled: boolean;
 export let signalingAddress: string;

--- a/web/frontend/src/lib/components/robot-client.svelte
+++ b/web/frontend/src/lib/components/robot-client.svelte
@@ -17,8 +17,8 @@ import { resourceNameToString, filterSubtype } from '@/lib/resource';
 export let webrtcEnabled: boolean;
 export let host: string;
 export let signalingAddress: string;
-export let bakedAuth: { authEntity?: string; creds?: Credentials; } | undefined = {};
-export let supportedAuthTypes: string[] | undefined = [];
+export let bakedAuth: { authEntity?: string; creds?: Credentials; } = {};
+export let supportedAuthTypes: string[] = [];
 
 const {
   robotClient,

--- a/web/frontend/src/lib/components/robot-client.svelte
+++ b/web/frontend/src/lib/components/robot-client.svelte
@@ -17,8 +17,8 @@ import { resourceNameToString, filterSubtype } from '@/lib/resource';
 export let webrtcEnabled: boolean;
 export let host: string;
 export let signalingAddress: string;
-export let bakedAuth: { authEntity?: string; creds?: Credentials; } = {};
-export let supportedAuthTypes: string[];
+export let bakedAuth: { authEntity?: string; creds?: Credentials; } | undefined = {};
+export let supportedAuthTypes: string[] | undefined = [];
 
 const {
   robotClient,

--- a/web/frontend/src/main-lib.ts
+++ b/web/frontend/src/main-lib.ts
@@ -2,13 +2,10 @@ import './index.css';
 import type { Credentials } from '@viamrobotics/rpc';
 import RemoteControlCards from './components/remote-control-cards.svelte';
 
-export const createRcApp = (props: {
+export const createRcApp = (target: HTMLElement, props: {
   host: string;
-  bakedAuth?: { authEntity: string; creds: Credentials; };
-  supportedAuthTypes: string[];
+  bakedAuth?: { authEntity: string; creds: Credentials; } | undefined;
+  supportedAuthTypes?: string[];
   webrtcEnabled: boolean;
   signalingAddress: string
-}) => new RemoteControlCards({
-  target: document.querySelector('#app')!,
-  ...props,
-});
+}) => new RemoteControlCards({ target, props });

--- a/web/frontend/src/main-lib.ts
+++ b/web/frontend/src/main-lib.ts
@@ -4,7 +4,7 @@ import RemoteControlCards from './components/remote-control-cards.svelte';
 
 export const createRcApp = (target: HTMLElement, props: {
   host: string;
-  bakedAuth?: { authEntity: string; creds: Credentials; } | undefined;
+  bakedAuth?: { authEntity: string; creds: Credentials; };
   supportedAuthTypes?: string[];
   webrtcEnabled: boolean;
   signalingAddress: string


### PR DESCRIPTION
createRcApp was given an incorrect body when we converted it to Svelte: props was merged into its config rather than being a top level property. This PR fixes that.