### PR TITLE
RSDK-4074 - make errEndOfDataset public

### DIFF
--- a/components/camera/replaypcd/replaypcd.go
+++ b/components/camera/replaypcd/replaypcd.go
@@ -36,8 +36,10 @@ const (
 
 var (
 	// model is the model of a replay camera.
-	model           = resource.DefaultModelFamily.WithModel("replay_pcd")
-	errEndOfDataset = errors.New("reached end of dataset")
+	model = resource.DefaultModelFamily.WithModel("replay_pcd")
+
+	// Error that the replay sensor reports when it has reached the end of the dataset
+	ErrEndOfDataset = errors.New("reached end of dataset")
 )
 
 func init() {
@@ -178,7 +180,7 @@ func (replay *pcdCamera) NextPointCloud(ctx context.Context) (pointcloud.PointCl
 	}
 
 	if len(resp.GetData()) == 0 {
-		return nil, errEndOfDataset
+		return nil, ErrEndOfDataset
 	}
 	replay.lastData = resp.GetLast()
 

--- a/components/camera/replaypcd/replaypcd.go
+++ b/components/camera/replaypcd/replaypcd.go
@@ -38,7 +38,7 @@ var (
 	// model is the model of a replay camera.
 	model = resource.DefaultModelFamily.WithModel("replay_pcd")
 
-	// ErrEndOfDataset represents that the replay sensor has reached the end of the dataset
+	// ErrEndOfDataset represents that the replay sensor has reached the end of the dataset.
 	ErrEndOfDataset = errors.New("reached end of dataset")
 )
 

--- a/components/camera/replaypcd/replaypcd.go
+++ b/components/camera/replaypcd/replaypcd.go
@@ -38,7 +38,7 @@ var (
 	// model is the model of a replay camera.
 	model = resource.DefaultModelFamily.WithModel("replay_pcd")
 
-	// Error that the replay sensor reports when it has reached the end of the dataset
+	// ErrEndOfDataset represents that the replay sensor has reached the end of the dataset
 	ErrEndOfDataset = errors.New("reached end of dataset")
 )
 

--- a/components/camera/replaypcd/replaypcd_test.go
+++ b/components/camera/replaypcd/replaypcd_test.go
@@ -268,7 +268,7 @@ func TestNextPointCloud(t *testing.T) {
 			// Confirm the end of the dataset was reached when expected
 			pc, err := replayCamera.NextPointCloud(ctx)
 			test.That(t, err, test.ShouldNotBeNil)
-			test.That(t, err.Error(), test.ShouldContainSubstring, errEndOfDataset.Error())
+			test.That(t, err.Error(), test.ShouldContainSubstring, ErrEndOfDataset.Error())
 			test.That(t, pc, test.ShouldBeNil)
 
 			err = replayCamera.Close(ctx)
@@ -303,7 +303,7 @@ func TestLiveNextPointCloud(t *testing.T) {
 		pc, err := replayCamera.NextPointCloud(ctx)
 		if i == numPCDFiles {
 			test.That(t, err, test.ShouldNotBeNil)
-			test.That(t, err.Error(), test.ShouldContainSubstring, errEndOfDataset.Error())
+			test.That(t, err.Error(), test.ShouldContainSubstring, ErrEndOfDataset.Error())
 			test.That(t, pc, test.ShouldBeNil)
 
 			// Add new files for future processing
@@ -544,7 +544,7 @@ func TestNextPointCloudTimestamps(t *testing.T) {
 		// Confirm the end of the dataset was reached when expected
 		pc, err := replayCamera.NextPointCloud(ctx)
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, errEndOfDataset.Error())
+		test.That(t, err.Error(), test.ShouldContainSubstring, ErrEndOfDataset.Error())
 		test.That(t, pc, test.ShouldBeNil)
 
 		err = replayCamera.Close(ctx)
@@ -610,7 +610,7 @@ func TestReconfigure(t *testing.T) {
 	// Confirm the end of the dataset was reached when expected
 	pc, err := replayCamera.NextPointCloud(ctx)
 	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, errEndOfDataset.Error())
+	test.That(t, err.Error(), test.ShouldContainSubstring, ErrEndOfDataset.Error())
 	test.That(t, pc, test.ShouldBeNil)
 
 	err = replayCamera.Close(ctx)

--- a/components/camera/replaypcd/replaypcd_utils_test.go
+++ b/components/camera/replaypcd/replaypcd_utils_test.go
@@ -237,12 +237,12 @@ func resourcesFromDeps(t *testing.T, r robot.Robot, deps []string) resource.Depe
 func getNextDataAfterFilter(filter *datapb.Filter, last string) (int, error) {
 	// Basic component part (source) filter
 	if filter.ComponentName != "" && filter.ComponentName != "source" {
-		return 0, errEndOfDataset
+		return 0, ErrEndOfDataset
 	}
 
 	// Basic robot_id filter
 	if filter.RobotId != "" && filter.RobotId != "robot_id" {
-		return 0, errEndOfDataset
+		return 0, ErrEndOfDataset
 	}
 
 	// Apply the time-based filter based on the seconds value in the start and end fields. Because artifacts
@@ -274,7 +274,7 @@ func getFile(i, end int) (int, error) {
 	if i < end {
 		return i, nil
 	}
-	return 0, errEndOfDataset
+	return 0, ErrEndOfDataset
 }
 
 // getCompressedBytesFromArtifact will return an array of bytes from the
@@ -282,12 +282,12 @@ func getFile(i, end int) (int, error) {
 func getCompressedBytesFromArtifact(inputPath string) ([]byte, error) {
 	artifactPath, err := artifact.Path(inputPath)
 	if err != nil {
-		return nil, errEndOfDataset
+		return nil, ErrEndOfDataset
 	}
 	path := filepath.Clean(artifactPath)
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, errEndOfDataset
+		return nil, ErrEndOfDataset
 	}
 
 	var dataBuf bytes.Buffer


### PR DESCRIPTION
We are matching on a string in carto code and want to match on a var so that the strings do not need to be kept in sync. This error needs to be public so we can access it there