### PR TITLE
APP-2075: placeholder replacement using a walker

### DIFF
--- a/config/reader.go
+++ b/config/reader.go
@@ -49,7 +49,10 @@ func getAgentInfo() (*apppb.AgentInfo, error) {
 	}, nil
 }
 
-var viamDotDir = filepath.Join(os.Getenv("HOME"), ".viam")
+var (
+	viamDotDir = filepath.Join(os.Getenv("HOME"), ".viam")
+	dataDotDir = ".data"
+)
 
 func getCloudCacheFilePath(id string) string {
 	return filepath.Join(viamDotDir, fmt.Sprintf("cached_cloud_config_%s.json", id))

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -1147,12 +1147,14 @@ func (r *localRobot) Reconfigure(ctx context.Context, newConfig *config.Config) 
 	}
 }
 
-func walkConvertedAttributes[T any](pacMan packages.ManagerSyncer, convertedAttributes T, allErrs error) (T, error) {
+func walkConvertedAttributes[T any](
+	pacMan packages.ManagerSyncer, packageMap map[string]string, convertedAttributes T, allErrs error,
+) (T, error) {
 	// Replace all package references with the actual path containing the package
 	// on the robot.
 	var asIfc interface{} = convertedAttributes
 	if walker, ok := asIfc.(utils.Walker); ok {
-		newAttrs, err := walker.Walk(packages.NewPackagePathVisitor(pacMan))
+		newAttrs, err := walker.Walk(packages.NewPackagePathVisitor(pacMan, packageMap))
 		if err != nil {
 			allErrs = multierr.Combine(allErrs, err)
 			return convertedAttributes, allErrs
@@ -1169,14 +1171,22 @@ func walkConvertedAttributes[T any](pacMan packages.ManagerSyncer, convertedAttr
 
 func (r *localRobot) replacePackageReferencesWithPaths(cfg *config.Config) error {
 	var allErrs error
+	packageMap := cfg.GetExpectedPackagePlaceholders()
+
 	for i, s := range cfg.Services {
-		s.ConvertedAttributes, allErrs = walkConvertedAttributes(r.packageManager, s.ConvertedAttributes, allErrs)
+		s.ConvertedAttributes, allErrs = walkConvertedAttributes(r.packageManager, packageMap, s.ConvertedAttributes, allErrs)
 		cfg.Services[i] = s
 	}
 
 	for i, c := range cfg.Components {
-		c.ConvertedAttributes, allErrs = walkConvertedAttributes(r.packageManager, c.ConvertedAttributes, allErrs)
+		c.ConvertedAttributes, allErrs = walkConvertedAttributes(r.packageManager, packageMap, c.ConvertedAttributes, allErrs)
 		cfg.Components[i] = c
+	}
+
+	for _, c := range cfg.Modules {
+		newExecPath, err := packages.NewPackagePathVisitor(r.packageManager, packageMap).VisitAndReplaceString(c.ExePath)
+		allErrs = multierr.Combine(allErrs, err)
+		c.ExePath = newExecPath
 	}
 
 	return allErrs

--- a/robot/packages/cloud_package_manager_test.go
+++ b/robot/packages/cloud_package_manager_test.go
@@ -243,14 +243,14 @@ func validatePackageDir(t *testing.T, dir string, input []config.PackageConfig) 
 	byLogicalName := make(map[string]*config.PackageConfig)
 	for _, pI := range input {
 		p := pI
-		byPackageHash[hashName(p)] = &p
+		byPackageHash[p.SanitizeName()] = &p
 		byLogicalName[p.Name] = &p
 	}
 
 	// check all known packages exist and are linked to the correct package dir.
 	for _, p := range input {
 		logicalPath := path.Join(dir, p.Name)
-		dataPath := path.Join(dir, fmt.Sprintf(".data/%s", hashName(p)))
+		dataPath := path.Join(dir, fmt.Sprintf(".data/%s", p.SanitizeName()))
 
 		info, err := os.Stat(logicalPath)
 		test.That(t, err, test.ShouldBeNil)
@@ -338,50 +338,6 @@ func TestPackageRefs(t *testing.T) {
 		t.Run("missing package for empty", func(t *testing.T) {
 			_, err = pm.PackagePath("")
 			test.That(t, err, test.ShouldEqual, ErrPackageMissing)
-		})
-	})
-
-	t.Run("RefPath", func(t *testing.T) {
-		t.Run("empty path", func(t *testing.T) {
-			pPath, err := pm.RefPath("")
-			test.That(t, err, test.ShouldBeNil)
-			test.That(t, pPath, test.ShouldEqual, "")
-		})
-
-		t.Run("non-ref absolute path", func(t *testing.T) {
-			pPath, err := pm.RefPath("/some/absolute/path")
-			test.That(t, err, test.ShouldBeNil)
-			test.That(t, pPath, test.ShouldEqual, "/some/absolute/path")
-		})
-
-		t.Run("non-ref relative path", func(t *testing.T) {
-			pPath, err := pm.RefPath("some/absolute/path")
-			test.That(t, err, test.ShouldBeNil)
-			test.That(t, pPath, test.ShouldEqual, "some/absolute/path")
-		})
-
-		t.Run("non-ref relative path with backtrack", func(t *testing.T) {
-			pPath, err := pm.RefPath("some/../absolute/path")
-			test.That(t, err, test.ShouldBeNil)
-			test.That(t, pPath, test.ShouldEqual, "some/../absolute/path")
-		})
-
-		t.Run("valid ref, empty package path", func(t *testing.T) {
-			pPath, err := pm.RefPath("${packages.some-name}")
-			test.That(t, err, test.ShouldBeNil)
-			test.That(t, pPath, test.ShouldEqual, path.Join(packageDir, "some-name"))
-		})
-
-		t.Run("valid ref, with package path", func(t *testing.T) {
-			pPath, err := pm.RefPath("${packages.some-name}/some/path")
-			test.That(t, err, test.ShouldBeNil)
-			test.That(t, pPath, test.ShouldEqual, path.Join(packageDir, "some-name", "some/path"))
-		})
-
-		t.Run("valid ref, ensure no escape from package path", func(t *testing.T) {
-			pPath, err := pm.RefPath("${packages.some-name}/../../../some-other-package/some/path")
-			test.That(t, err, test.ShouldBeNil)
-			test.That(t, pPath, test.ShouldEqual, path.Join(packageDir, "some-name", "some-other-package/some/path"))
 		})
 	})
 }

--- a/robot/packages/noop_package_manager.go
+++ b/robot/packages/noop_package_manager.go
@@ -2,6 +2,7 @@ package packages
 
 import (
 	"context"
+	"fmt"
 	"path"
 
 	"go.viam.com/rdk/config"
@@ -28,6 +29,15 @@ func NewNoopManager() ManagerSyncer {
 // PackagePath returns the package if it exists and already download. If it does not exist it returns a ErrPackageMissing error.
 func (m *noopManager) PackagePath(name PackageName) (string, error) {
 	return string(name), nil
+}
+
+func (m *noopManager) PlaceholderPath(path string) (*PlaceholderRef, error) {
+	matches := placeholderRegexp.FindStringSubmatch(path)
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("invalid package placeholder path: %s", path)
+	}
+
+	return &PlaceholderRef{matchedPlaceholder: matches[0], nestedPath: matches[1]}, nil
 }
 
 func (m *noopManager) RefPath(refPath string) (string, error) {

--- a/robot/packages/package_manager.go
+++ b/robot/packages/package_manager.go
@@ -28,6 +28,14 @@ var ErrPackageMissing = errors.New("package missing")
 // ErrInvalidPackageRef is an error when a invalid package reference syntax.
 var ErrInvalidPackageRef = errors.New("invalid package reference")
 
+// PlaceholderRef stores the destructured info about the matched placeholder
+// if the Placeholder is ${packges.ml_model.hello} ->
+// { matchedPlaceholder: ${packges.ml_model.hello}, nestedPath: packges.ml_model.hello }.
+type PlaceholderRef struct {
+	matchedPlaceholder string
+	nestedPath         string
+}
+
 // Manager provides a managed interface for looking up package paths. This is separated from ManagerSyncer to avoid passing
 // the full sync interface to all components.
 type Manager interface {
@@ -36,11 +44,8 @@ type Manager interface {
 	// PackagePath returns the package if it exists and is already downloaded. If it does not exist it returns a ErrPackageMissing error.
 	PackagePath(name PackageName) (string, error)
 
-	// RefPath returns the absolute path of the package reference for a given path with a package reference.
-	// - If not the original path is not a package reference the original path is returned without an error.
-	// - If the path contains a package reference and the package does not exist a ErrPackageMissing will be returned.
-	// - Any syntax errors in the package reference will produce an ErrInvalidPackageRef.
-	RefPath(name string) (string, error)
+	// Placeholder path returns a valid package placeholder from the entire string or errors if there is none
+	PlaceholderPath(path string) (*PlaceholderRef, error)
 }
 
 // ManagerSyncer provides a managed interface for both reading package paths and syncing packages from the RDK config.

--- a/robot/packages/package_path_visitor.go
+++ b/robot/packages/package_path_visitor.go
@@ -1,20 +1,54 @@
 package packages
 
 import (
+	"fmt"
 	"reflect"
+	"strings"
 )
 
 // PackagePathVisitor is a visitor that replaces strings containing references to package names
 // with the path containing the package files on the robot.
 type PackagePathVisitor struct {
 	packageManager Manager
+	packagePaths   map[string]string
 }
 
 // NewPackagePathVisitor creates a new PackagePathVisitor.
-func NewPackagePathVisitor(packageManager Manager) *PackagePathVisitor {
+func NewPackagePathVisitor(packageManager Manager, packagePaths map[string]string) *PackagePathVisitor {
 	return &PackagePathVisitor{
 		packageManager: packageManager,
+		packagePaths:   packagePaths,
 	}
+}
+
+func (v *PackagePathVisitor) getExpectedFilepathForPackagePlaceholder(placeholder string) (string, error) {
+	filepath, ok := v.packagePaths[placeholder]
+	if !ok {
+		return placeholder, fmt.Errorf("there is no corresponding real path for this valid placeholder %s", placeholder)
+	}
+	return filepath, nil
+}
+
+// VisitAndReplaceString replaces a string with a package path if its a valid package placeholder.
+func (v *PackagePathVisitor) VisitAndReplaceString(s string) (string, error) {
+	if len(s) > 0 && s[0] != '$' {
+		// don't error here as its not a placeholder
+		return s, nil
+	}
+
+	placeholderRef, err := v.packageManager.PlaceholderPath(s)
+	if err != nil {
+		return "", err
+	}
+
+	// get the expected filepath based on the list of packages in the config
+	filepath, err := v.getExpectedFilepathForPackagePlaceholder(placeholderRef.nestedPath)
+	if err != nil {
+		return "", err
+	}
+
+	withReplacedRefs := strings.Replace(s, placeholderRef.matchedPlaceholder, filepath, 1)
+	return withReplacedRefs, nil
 }
 
 // Visit implements config.Visitor.
@@ -31,9 +65,11 @@ func (v *PackagePathVisitor) Visit(data interface{}) (interface{}, error) {
 		return data, nil
 	}
 
-	withReplacedRefs, err := v.packageManager.RefPath(s)
+	// if there is an error do not replace the string
+	// the reasoning is because this could be any string so we don't want to nullify any string
+	withReplacedRefs, err := v.VisitAndReplaceString(s)
 	if err != nil {
-		return nil, err
+		return data, err
 	}
 
 	// If the input was a pointer, return a pointer.

--- a/robot/packages/package_path_visitor_test.go
+++ b/robot/packages/package_path_visitor_test.go
@@ -1,6 +1,8 @@
 package packages
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -8,53 +10,104 @@ import (
 )
 
 func TestPackagePathVisitor(t *testing.T) {
+	viamDotDir := filepath.Join(os.Getenv("HOME"), ".viam")
+	dataDir := ".data"
+
 	testStringNoRef := "some/path/file_name.txt"
 	testStringRef := "${packages.custom_package}/file_name.txt"
-	testStringRefReplaced := "custom_package/file_name.txt"
+	testStringMlModel := "${packages.ml_models.custom_package}/file_name.txt"
+	testStringModule := "${packages.modules.custom_package}/file_name.txt"
+	testBadPlaceholder := "${packages.my_model.ml.big}/file.txt"
 	testInt := 17
 
+	packageMap := make(map[string]string)
+	packageMap["packages.custom_package"] = filepath.Join(viamDotDir, "packages", "custom_package")
+	packageMap["packages.ml_models.custom_package"] = filepath.Join(
+		viamDotDir, "packages", dataDir, "ml_models", "orgID-custom_package-latest")
+	packageMap["packages.modules.custom_package"] = filepath.Join(
+		viamDotDir, "packages", dataDir, "modules", "orgID-custom_package-latest")
+
+	testStringRefOutput := filepath.Join(packageMap["packages.custom_package"], "file_name.txt")
+	invalidPackageErr := "invalid package placeholder path"
 	testCases := []struct {
-		desc     string
-		input    interface{}
-		expected interface{}
+		desc        string
+		input       interface{}
+		expected    interface{}
+		errorString *string
 	}{
 		{
 			"visit string with package reference",
 			testStringRef,
-			testStringRefReplaced,
+			testStringRefOutput,
+			nil,
 		},
 		{
 			"visit string without package reference",
 			testStringNoRef,
 			testStringNoRef,
+			nil,
+		},
+		{
+			"visit string with package ml model reference",
+			testStringMlModel,
+			filepath.Join(packageMap["packages.ml_models.custom_package"], "file_name.txt"),
+			nil,
+		},
+		{
+			"visit string with package module reference",
+			testStringModule,
+			filepath.Join(packageMap["packages.modules.custom_package"], "file_name.txt"),
+			nil,
+		},
+		{
+			"visit string without package reference",
+			testStringNoRef,
+			testStringNoRef,
+			nil,
 		},
 		{
 			"visit pointer to string with package reference",
 			&testStringRef,
-			&testStringRefReplaced,
+			&testStringRefOutput,
+			nil,
 		},
 		{
 			"visit pointer to string without package reference",
 			&testStringNoRef,
 			&testStringNoRef,
+			nil,
 		},
 		{
 			"visit non-string type",
 			testInt,
 			testInt,
+			nil,
 		},
 		{
 			"visit pointer to non-string type",
 			&testInt,
 			&testInt,
+			nil,
+		},
+		{
+			"visit placeholder with bad reference",
+			testBadPlaceholder,
+			testBadPlaceholder,
+			&invalidPackageErr,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			v := NewPackagePathVisitor(NewNoopManager())
+			v := NewPackagePathVisitor(NewNoopManager(), packageMap)
 			actual, err := v.Visit(tc.input)
-			test.That(t, err, test.ShouldBeNil)
+			hasErr := tc.errorString
+			if hasErr == nil {
+				test.That(t, err, test.ShouldBeNil)
+			} else {
+				test.That(t, err, test.ShouldNotBeNil)
+				test.That(t, err.Error(), test.ShouldContainSubstring, *hasErr)
+			}
 
 			if reflect.TypeOf(tc.input).Kind() == reflect.Ptr {
 				if reflect.TypeOf(actual).Kind() != reflect.Ptr {

--- a/services/mlmodel/tflitecpu/tflite_cpu_test.go
+++ b/services/mlmodel/tflitecpu/tflite_cpu_test.go
@@ -265,8 +265,11 @@ func TestTFLiteConfigWalker(t *testing.T) {
 	visionAttrsOneRef := makeVisionAttributes("/some/path/on/robot/model.tflite", labelPathOneRef)
 
 	packageManager := packages.NewNoopManager()
+	packgeMap := make(map[string]string)
+	packgeMap["packages.test_model"] = "packages/test_model"
+
 	testAttributesWalker := func(t *testing.T, attrs *TFLiteConfig, expectedModelPath, expectedLabelPath string) {
-		newAttrs, err := attrs.Walk(packages.NewPackagePathVisitor(packageManager))
+		newAttrs, err := attrs.Walk(packages.NewPackagePathVisitor(packageManager, packgeMap))
 		test.That(t, err, test.ShouldBeNil)
 
 		test.That(t, newAttrs.(*TFLiteConfig).ModelPath, test.ShouldEqual, expectedModelPath)
@@ -275,8 +278,8 @@ func TestTFLiteConfigWalker(t *testing.T) {
 	}
 
 	testAttributesWalker(t, visionAttrs, "/some/path/on/robot/model.tflite", "/other/path/on/robot/textFile.txt")
-	testAttributesWalker(t, visionAttrsWithRefs, "test_model/model.tflite", "test_model/textFile.txt")
-	testAttributesWalker(t, visionAttrsOneRef, "/some/path/on/robot/model.tflite", "test_model/textFile.txt")
+	testAttributesWalker(t, visionAttrsWithRefs, "packages/test_model/model.tflite", "packages/test_model/textFile.txt")
+	testAttributesWalker(t, visionAttrsOneRef, "/some/path/on/robot/model.tflite", "packages/test_model/textFile.txt")
 }
 
 func TestLabelPathWalkFail(t *testing.T) {
@@ -284,7 +287,7 @@ func TestLabelPathWalkFail(t *testing.T) {
 	var oldLabelPath *string
 
 	packageManager := packages.NewNoopManager()
-	visitor := packages.NewPackagePathVisitor(packageManager)
+	visitor := packages.NewPackagePathVisitor(packageManager, make(map[string]string))
 
 	outNew, err := visitor.Visit(labelPath)
 	test.That(t, err, test.ShouldBeNil)


### PR DESCRIPTION
This is based on PR: https://github.com/viamrobotics/rdk/pull/2628

This will replace placeholders in packages to what their real filepath is for packages with types (ml_model or module). As we already use placeholders without types for ml_models, if there is package without a type, we will generate the same path as what is currently generated and follow the same symlink pattern. 

