### PR TITLE
Fix state updates for motion path visualization when multiple files are dropped

### DIFF
--- a/web/frontend/src/components/slam/motion-path.svelte
+++ b/web/frontend/src/components/slam/motion-path.svelte
@@ -8,7 +8,7 @@ import { LineGeometry } from 'three/examples/jsm/lines/LineGeometry.js';
 export let scene: THREE.Scene;
 export let path: string | undefined;
 
-const geometry = new LineGeometry();
+
 const material = new LineMaterial({
   color: 0xFF_00_47,
   linewidth: 0.005,
@@ -16,17 +16,19 @@ const material = new LineMaterial({
   alphaToCoverage: true,
 });
 
-const line = new Line2(geometry, material);
-line.visible = false;
-scene.add(line);
+let line: Line2
 
 const updatePath = (pathstr?: string) => {
+  if (line !== undefined) {
+    scene.remove(line)
+    line.geometry.dispose()
+  }
+
   if (pathstr === undefined) {
-    line.visible = false;
     return;
   }
 
-  line.visible = true;
+  const geometry = new LineGeometry();
 
   const points: number[] = [];
 
@@ -41,6 +43,14 @@ const updatePath = (pathstr?: string) => {
 
   const vertices = new Float32Array(points);
   geometry.setPositions(vertices);
+
+  line = new Line2(geometry, material);
+
+  // Render above pointcloud.
+  line.renderOrder = 3;
+
+  line.computeLineDistances()
+  scene.add(line)
 };
 
 $: updatePath(path);

--- a/web/frontend/src/components/slam/motion-path.svelte
+++ b/web/frontend/src/components/slam/motion-path.svelte
@@ -8,7 +8,6 @@ import { LineGeometry } from 'three/examples/jsm/lines/LineGeometry.js';
 export let scene: THREE.Scene;
 export let path: string | undefined;
 
-
 const material = new LineMaterial({
   color: 0xFF_00_47,
   linewidth: 0.005,
@@ -16,12 +15,12 @@ const material = new LineMaterial({
   alphaToCoverage: true,
 });
 
-let line: Line2
+let line: Line2;
 
 const updatePath = (pathstr?: string) => {
   if (line !== undefined) {
-    scene.remove(line)
-    line.geometry.dispose()
+    scene.remove(line);
+    line.geometry.dispose();
   }
 
   if (pathstr === undefined) {
@@ -49,8 +48,8 @@ const updatePath = (pathstr?: string) => {
   // Render above pointcloud.
   line.renderOrder = 3;
 
-  line.computeLineDistances()
-  scene.add(line)
+  line.computeLineDistances();
+  scene.add(line);
 };
 
 $: updatePath(path);

--- a/web/frontend/src/components/slam/motion-path.svelte
+++ b/web/frontend/src/components/slam/motion-path.svelte
@@ -20,26 +20,29 @@ const line = new Line2(geometry, material);
 line.visible = false;
 scene.add(line);
 
-$: {
-  if (path === undefined) {
-    line.visible = false;
-  } else {
-    line.visible = true;
-
-    const points: number[] = [];
-
-    for (const xy of path.split('\n')) {
-      const [xString, yString] = xy.split(',');
-      if (xString !== undefined && yString !== undefined) {
-        const x = Number.parseFloat(xString) / 1000;
-        const y = Number.parseFloat(yString) / 1000;
-        points.push(x, y, 0);
-      }
-    }
-
-    const vertices = new Float32Array(points);
-    geometry.setPositions(vertices);
+const updatePath = (pathstr?: string) => {
+  if (pathstr === undefined) {
+    line.visible = false
+    return
   }
+
+  line.visible = true
+
+  const points: number[] = [];
+
+  for (const xy of pathstr.split('\n')) {
+    const [xString, yString] = xy.split(',');
+    if (xString !== undefined && yString !== undefined) {
+      const x = Number.parseFloat(xString) / 1000;
+      const y = Number.parseFloat(yString) / 1000;
+      points.push(x, y, 0);
+    }
+  }
+
+  const vertices = new Float32Array(points);
+  geometry.setPositions(vertices);
 }
+
+$: updatePath(path)
 
 </script>

--- a/web/frontend/src/components/slam/motion-path.svelte
+++ b/web/frontend/src/components/slam/motion-path.svelte
@@ -22,11 +22,11 @@ scene.add(line);
 
 const updatePath = (pathstr?: string) => {
   if (pathstr === undefined) {
-    line.visible = false
-    return
+    line.visible = false;
+    return;
   }
 
-  line.visible = true
+  line.visible = true;
 
   const points: number[] = [];
 
@@ -41,8 +41,8 @@ const updatePath = (pathstr?: string) => {
 
   const vertices = new Float32Array(points);
   geometry.setPositions(vertices);
-}
+};
 
-$: updatePath(path)
+$: updatePath(path);
 
 </script>


### PR DESCRIPTION
This PR includes a small state update fix for when users drag n' drop multiple files to visualize paths. Dropping files after a previous drop would fail to trigger a state change. Now it works!