### PR TITLE
APP-2115 - cloud_package_manager improvements

### DIFF
--- a/config/reader.go
+++ b/config/reader.go
@@ -39,6 +39,7 @@ func getAgentInfo() (*apppb.AgentInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+	platform := fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
 
 	return &apppb.AgentInfo{
 		Host:        hostname,
@@ -46,6 +47,7 @@ func getAgentInfo() (*apppb.AgentInfo, error) {
 		Os:          runtime.GOOS,
 		Version:     Version,
 		GitRevision: GitRevision,
+		Platform:    &platform,
 	}, nil
 }
 

--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -452,7 +452,7 @@ func (m *cloudManager) unpackFile(ctx context.Context, fromFile, toDir string) e
 
 		case tar.TypeReg:
 			// This is required because it is possible create tarballs without a directory entry
-			// but whose files names start a new directory prefix
+			// but whose files names start with a new directory prefix
 			// Ex: tar -czf package.tar.gz ./bin/module.exe
 			parent := filepath.Dir(path)
 			if err := os.MkdirAll(parent, info.Mode()); err != nil {

--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -451,8 +451,15 @@ func (m *cloudManager) unpackFile(ctx context.Context, fromFile, toDir string) e
 			}
 
 		case tar.TypeReg:
+			// This is required because it is possible create tarballs without a directory entry
+			// but whose files names start a new directory prefix
+			// Ex: tar -czf package.tar.gz ./bin/module.exe
+			parent := filepath.Dir(path)
+			if err := os.MkdirAll(parent, info.Mode()); err != nil {
+				return errors.Wrapf(err, "failed to create directory %q", parent)
+			}
 			//nolint:gosec // path sanitized with safeJoin
-			outFile, err := os.Create(path)
+			outFile, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
 			if err != nil {
 				return errors.Wrapf(err, "failed to create file %s", path)
 			}

--- a/robot/packages/testutils/fake_package_server.go
+++ b/robot/packages/testutils/fake_package_server.go
@@ -331,15 +331,16 @@ func ValidateContentsOfPPackage(t *testing.T, dir string) {
 		isLink     bool
 		linkTarget string
 		isDir      bool
+		perms      os.FileMode
 	}
 
 	expected := []content{
-		{path: "some-link.txt", isLink: true, linkTarget: "sub-dir/sub-file.txt"},
-		{path: "some-text.txt", checksum: "p/E54w=="},
-		{path: "some-text2.txt", checksum: "p/E54w=="},
-		{path: "sub-dir", isDir: true},
-		{path: "sub-dir/sub-file.txt", checksum: "p/E54w=="},
-		{path: "sub-dir-link", isLink: true, linkTarget: "sub-dir"},
+		{path: "some-link.txt", isLink: true, linkTarget: "sub-dir/sub-file.txt", perms: 0o777},
+		{path: "some-text.txt", checksum: "p/E54w==", perms: 0o644},
+		{path: "some-text2.txt", checksum: "p/E54w==", perms: 0o644},
+		{path: "sub-dir", isDir: true, perms: 0o755},
+		{path: "sub-dir/sub-file.txt", checksum: "p/E54w==", perms: 0o644},
+		{path: "sub-dir-link", isLink: true, linkTarget: "sub-dir", perms: 0o777},
 	}
 
 	out := make([]content, 0, len(expected))
@@ -371,6 +372,7 @@ func ValidateContentsOfPPackage(t *testing.T, dir string) {
 			isDir:      info.IsDir(),
 			isLink:     isSymLink,
 			linkTarget: symTarget,
+			perms:      info.Mode().Perm(),
 		})
 
 		return nil


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/APP-2115

This PR:
- Expands on package logic to support preserving the permissions of the original tarball (useful for modules).
- Fixes a bug with single-file tarballs in a subdirectory
- Adds the platform field to the agent info