### PR TITLE
RSDK-3395 Add missing package comment

### DIFF
--- a/components/board/customlinux/board_nonlinux.go
+++ b/components/board/customlinux/board_nonlinux.go
@@ -1,3 +1,5 @@
 //go:build !linux
 
+// Package customlinux implements a board running Linux. This file, however, is
+// a placeholder for when you build the server in a non-Linux environment.
 package customlinux


### PR DESCRIPTION
RSDK-3395

Adds a missing package comment from https://github.com/viamrobotics/rdk/pull/2613.

Without this comment, lint fails on MacOS (or any other non-linux OS).