### PR TITLE
Add better logs for module resource registration

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -748,7 +748,7 @@ func (m *module) registerResources(mgr modmaninterface.ModuleManager, logger gol
 			}
 		case api.API.IsService():
 			for _, model := range models {
-				logger.Debugf("registering service from module", "module", m.name, "API", api.API, "model", model)
+				logger.Debugw("registering service from module", "module", m.name, "API", api.API, "model", model)
 				resource.RegisterService(api.API, model, resource.Registration[resource.Resource, resource.NoNativeConfig]{
 					Constructor: func(
 						ctx context.Context,

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -734,6 +734,7 @@ func (m *module) registerResources(mgr modmaninterface.ModuleManager, logger gol
 		switch {
 		case api.API.IsComponent():
 			for _, model := range models {
+				logger.Debugw("registering component from module", "module", m.name, "API", api.API, "model", model)
 				resource.RegisterComponent(api.API, model, resource.Registration[resource.Resource, resource.NoNativeConfig]{
 					Constructor: func(
 						ctx context.Context,
@@ -747,6 +748,7 @@ func (m *module) registerResources(mgr modmaninterface.ModuleManager, logger gol
 			}
 		case api.API.IsService():
 			for _, model := range models {
+				logger.Debugf("registering service from module", "module", m.name, "API", api.API, "model", model)
 				resource.RegisterService(api.API, model, resource.Registration[resource.Resource, resource.NoNativeConfig]{
 					Constructor: func(
 						ctx context.Context,

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -626,7 +626,7 @@ func (r *localRobot) newResource(
 	resName := conf.ResourceName()
 	resInfo, ok := resource.LookupRegistration(resName.API, conf.Model)
 	if !ok {
-		return nil, errors.Errorf("unknown resource type: %s and/or model: %s", resName.API, conf.Model)
+		return nil, errors.Errorf("unknown resource type: API %q with model %q not registered", resName.API, conf.Model)
 	}
 
 	deps, err := r.getDependencies(ctx, resName, gNode)

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -1782,7 +1782,7 @@ func TestResourceStartsOnReconfigure(t *testing.T) {
 		test.ShouldBeError,
 		resource.NewNotAvailableError(
 			base.Named("fake0"),
-			errors.New("resource build error: unknown resource type: rdk:component:base and/or model: rdk:builtin:random"),
+			errors.New(`resource build error: unknown resource type: API "rdk:component:base" with model "rdk:builtin:random" not registered`),
 		),
 	)
 	test.That(t, noBase, test.ShouldBeNil)


### PR DESCRIPTION
Adds some debug logs in the module manager for which resources are actually getting registered from modules (helpful when your WIP module is not returning the correct handler map). Updates confusing "unknown resource type" error message in `local_robot` (the "and/or", in particular, made it seem like APIs and models were registered as separate things).

(credit to @zaporter-work for the idea on better messaging here).