### PR TITLE
RSDK-3504: Review sensor server and client tests

### DIFF
--- a/components/posetracker/client_test.go
+++ b/components/posetracker/client_test.go
@@ -69,7 +69,7 @@ func TestClient(t *testing.T) {
 	failingPT.PosesFunc = func(ctx context.Context, bodyNames []string, extra map[string]interface{}) (
 		posetracker.BodyToPoseInFrame, error,
 	) {
-		return nil, poseFailureErr
+		return nil, errPoseFailed
 	}
 
 	resourceMap := map[resource.Name]posetracker.PoseTracker{
@@ -141,7 +141,7 @@ func TestClient(t *testing.T) {
 
 		bodyToPoseInFrame, err := failingPTDialedClient.Poses(context.Background(), []string{}, nil)
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, poseFailureErr.Error())
+		test.That(t, err.Error(), test.ShouldContainSubstring, errPoseFailed.Error())
 		test.That(t, bodyToPoseInFrame, test.ShouldBeNil)
 		test.That(t, conn.Close(), test.ShouldBeNil)
 	})

--- a/components/posetracker/server_test.go
+++ b/components/posetracker/server_test.go
@@ -16,7 +16,7 @@ import (
 	"go.viam.com/rdk/testutils/inject"
 )
 
-var poseFailureErr = errors.New("failure to get poses")
+var errPoseFailed = errors.New("failure to get poses")
 
 const (
 	workingPTName = "workingPT"
@@ -59,7 +59,7 @@ func TestGetPoses(t *testing.T) {
 	failingPT.PosesFunc = func(ctx context.Context, bodyNames []string, extra map[string]interface{}) (
 		posetracker.BodyToPoseInFrame, error,
 	) {
-		return nil, poseFailureErr
+		return nil, errPoseFailed
 	}
 
 	t.Run("get poses fails on failing pose tracker", func(t *testing.T) {
@@ -67,7 +67,7 @@ func TestGetPoses(t *testing.T) {
 			Name: failingPTName, BodyNames: []string{bodyName},
 		}
 		resp, err := ptServer.GetPoses(context.Background(), &req)
-		test.That(t, err, test.ShouldBeError, poseFailureErr)
+		test.That(t, err, test.ShouldBeError, errPoseFailed)
 		test.That(t, resp, test.ShouldBeNil)
 	})
 

--- a/components/posetracker/server_test.go
+++ b/components/posetracker/server_test.go
@@ -16,6 +16,8 @@ import (
 	"go.viam.com/rdk/testutils/inject"
 )
 
+var poseFailureErr = errors.New("failure to get poses")
+
 const (
 	workingPTName = "workingPT"
 	failingPTName = "failingPT"
@@ -53,7 +55,7 @@ func TestGetPoses(t *testing.T) {
 			bodyName: referenceframe.NewPoseInFrame(bodyFrame, zeroPose),
 		}, nil
 	}
-	poseFailureErr := errors.New("failure to get poses")
+
 	failingPT.PosesFunc = func(ctx context.Context, bodyNames []string, extra map[string]interface{}) (
 		posetracker.BodyToPoseInFrame, error,
 	) {

--- a/components/sensor/client_test.go
+++ b/components/sensor/client_test.go
@@ -2,7 +2,6 @@ package sensor_test
 
 import (
 	"context"
-	"errors"
 	"net"
 	"testing"
 
@@ -42,7 +41,7 @@ func TestClient(t *testing.T) {
 
 	injectSensor2 := &inject.Sensor{}
 	injectSensor2.ReadingsFunc = func(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
-		return nil, errors.New("can't get readings")
+		return nil, errReadingsFailed
 	}
 
 	sensorSvc, err := resource.NewAPIResourceCollection(
@@ -66,7 +65,7 @@ func TestClient(t *testing.T) {
 		cancel()
 		_, err := viamgrpc.Dial(cancelCtx, listener1.Addr().String(), logger)
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "canceled")
+		test.That(t, err, test.ShouldBeError, context.Canceled)
 	})
 
 	t.Run("Sensor client 1", func(t *testing.T) {
@@ -105,7 +104,7 @@ func TestClient(t *testing.T) {
 
 		_, err = client2.Readings(context.Background(), make(map[string]interface{}))
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "can't get readings")
+		test.That(t, err.Error(), test.ShouldContainSubstring, errReadingsFailed.Error())
 
 		test.That(t, client2.Close(context.Background()), test.ShouldBeNil)
 		test.That(t, conn.Close(), test.ShouldBeNil)

--- a/components/sensor/server_test.go
+++ b/components/sensor/server_test.go
@@ -15,6 +15,8 @@ import (
 	"go.viam.com/rdk/testutils/inject"
 )
 
+var errReadingsFailed = errors.New("can't get readings")
+
 func newServer() (pb.SensorServiceServer, *inject.Sensor, *inject.Sensor, error) {
 	injectSensor := &inject.Sensor{}
 	injectSensor2 := &inject.Sensor{}
@@ -42,7 +44,7 @@ func TestServer(t *testing.T) {
 	}
 
 	injectSensor2.ReadingsFunc = func(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
-		return nil, errors.New("can't get readings")
+		return nil, errReadingsFailed
 	}
 
 	t.Run("GetReadings", func(t *testing.T) {
@@ -62,7 +64,7 @@ func TestServer(t *testing.T) {
 
 		_, err = sensorServer.GetReadings(context.Background(), &pb.GetReadingsRequest{Name: failSensorName})
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "can't get readings")
+		test.That(t, err.Error(), test.ShouldContainSubstring, errReadingsFailed.Error())
 
 		_, err = sensorServer.GetReadings(context.Background(), &pb.GetReadingsRequest{Name: missingSensorName})
 		test.That(t, err, test.ShouldNotBeNil)


### PR DESCRIPTION
This PR checks against error variables in the `sensor` client and server tests in addition to checking if the error is nil or not. Since the changes were small, this PR also covers RSDK-3505 (same thing but for `posetracker` component) and RSDK-3506 (same thing but for `input` component)