### PR TITLE
RSDK-3507: Review gripper server and client tests

### DIFF
--- a/components/gantry/server_test.go
+++ b/components/gantry/server_test.go
@@ -14,6 +14,15 @@ import (
 	"go.viam.com/rdk/testutils/inject"
 )
 
+var (
+	errPositionFailed       = errors.New("can't get position")
+	errHomingFailed         = errors.New("homing unsuccessful")
+	errMoveToPositionFailed = errors.New("can't move to position")
+	errLengthsFailed        = errors.New("can't get lengths")
+	errStopFailed           = errors.New("no stop")
+	errGantryUnimplemented  = errors.New("not found")
+)
+
 func newServer() (pb.GantryServiceServer, *inject.Gantry, *inject.Gantry, error) {
 	injectGantry := &inject.Gantry{}
 	injectGantry2 := &inject.Gantry{}
@@ -65,29 +74,29 @@ func TestServer(t *testing.T) {
 	pos2 := []float64{4.0, 5.0, 6.0}
 	speed2 := []float64{100.0, 80.0, 120.0}
 	injectGantry2.PositionFunc = func(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
-		return nil, errors.New("can't get position")
+		return nil, errPositionFailed
 	}
 	injectGantry2.HomeFunc = func(ctx context.Context, extra map[string]interface{}) (bool, error) {
 		extra1 = extra
-		return false, errors.New("homing unsuccessful")
+		return false, errHomingFailed
 	}
 	injectGantry2.MoveToPositionFunc = func(ctx context.Context, pos, speed []float64, extra map[string]interface{}) error {
 		gantryPos = pos
 		gantrySpeed = speed
-		return errors.New("can't move to position")
+		return errMoveToPositionFailed
 	}
 	injectGantry2.LengthsFunc = func(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
-		return nil, errors.New("can't get lengths")
+		return nil, errLengthsFailed
 	}
 	injectGantry2.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
-		return errors.New("no stop")
+		return errStopFailed
 	}
 
 	//nolint:dupl
 	t.Run("gantry position", func(t *testing.T) {
 		_, err := gantryServer.GetPosition(context.Background(), &pb.GetPositionRequest{Name: missingGantryName})
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "not found")
+		test.That(t, err.Error(), test.ShouldContainSubstring, errGantryUnimplemented.Error())
 
 		ext, err := protoutils.StructToStructPb(map[string]interface{}{"foo": "123", "bar": 234})
 		test.That(t, err, test.ShouldBeNil)
@@ -98,7 +107,7 @@ func TestServer(t *testing.T) {
 
 		_, err = gantryServer.GetPosition(context.Background(), &pb.GetPositionRequest{Name: failGantryName})
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "can't get position")
+		test.That(t, err.Error(), test.ShouldContainSubstring, errPositionFailed.Error())
 	})
 
 	t.Run("move to position", func(t *testing.T) {
@@ -107,7 +116,7 @@ func TestServer(t *testing.T) {
 			&pb.MoveToPositionRequest{Name: missingGantryName, PositionsMm: pos2, SpeedsMmPerSec: speed2},
 		)
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "not found")
+		test.That(t, err.Error(), test.ShouldContainSubstring, errGantryUnimplemented.Error())
 
 		ext, err := protoutils.StructToStructPb(map[string]interface{}{"foo": "234", "bar": 345})
 		test.That(t, err, test.ShouldBeNil)
@@ -125,7 +134,7 @@ func TestServer(t *testing.T) {
 			&pb.MoveToPositionRequest{Name: failGantryName, PositionsMm: pos1, SpeedsMmPerSec: speed1},
 		)
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "can't move to position")
+		test.That(t, err.Error(), test.ShouldContainSubstring, errMoveToPositionFailed.Error())
 		test.That(t, gantryPos, test.ShouldResemble, pos1)
 		test.That(t, gantrySpeed, test.ShouldResemble, speed1)
 	})
@@ -134,7 +143,7 @@ func TestServer(t *testing.T) {
 	t.Run("lengths", func(t *testing.T) {
 		_, err := gantryServer.GetLengths(context.Background(), &pb.GetLengthsRequest{Name: missingGantryName})
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "not found")
+		test.That(t, err.Error(), test.ShouldContainSubstring, errGantryUnimplemented.Error())
 
 		ext, err := protoutils.StructToStructPb(map[string]interface{}{"foo": 123, "bar": "234"})
 		test.That(t, err, test.ShouldBeNil)
@@ -145,13 +154,13 @@ func TestServer(t *testing.T) {
 
 		_, err = gantryServer.GetLengths(context.Background(), &pb.GetLengthsRequest{Name: failGantryName})
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "can't get lengths")
+		test.That(t, err.Error(), test.ShouldContainSubstring, errLengthsFailed.Error())
 	})
 
 	t.Run("home", func(t *testing.T) {
 		_, err := gantryServer.Home(context.Background(), &pb.HomeRequest{Name: missingGantryName})
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "not found")
+		test.That(t, err.Error(), test.ShouldContainSubstring, errGantryUnimplemented.Error())
 
 		ext, err := protoutils.StructToStructPb(map[string]interface{}{"foo": 123, "bar": "234"})
 		test.That(t, err, test.ShouldBeNil)
@@ -163,12 +172,13 @@ func TestServer(t *testing.T) {
 		resp, err = gantryServer.Home(context.Background(), &pb.HomeRequest{Name: failGantryName})
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, resp.Homed, test.ShouldBeFalse)
+		test.That(t, err.Error(), test.ShouldContainSubstring, errHomingFailed.Error())
 	})
 
 	t.Run("stop", func(t *testing.T) {
 		_, err = gantryServer.Stop(context.Background(), &pb.StopRequest{Name: missingGantryName})
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "not found")
+		test.That(t, err.Error(), test.ShouldContainSubstring, errGantryUnimplemented.Error())
 
 		ext, err := protoutils.StructToStructPb(map[string]interface{}{"foo": 234, "bar": "123"})
 		test.That(t, err, test.ShouldBeNil)
@@ -178,7 +188,6 @@ func TestServer(t *testing.T) {
 
 		_, err = gantryServer.Stop(context.Background(), &pb.StopRequest{Name: failGantryName})
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "no stop")
+		test.That(t, err.Error(), test.ShouldContainSubstring, errStopFailed.Error())
 	})
 }

--- a/components/gantry/server_test.go
+++ b/components/gantry/server_test.go
@@ -15,12 +15,12 @@ import (
 )
 
 var (
-	errPositionFailed       = errors.New("can't get position")
+	errPositionFailed       = errors.New("couldn't get position")
 	errHomingFailed         = errors.New("homing unsuccessful")
-	errMoveToPositionFailed = errors.New("can't move to position")
-	errLengthsFailed        = errors.New("can't get lengths")
-	errStopFailed           = errors.New("no stop")
-	errGantryUnimplemented  = errors.New("not found")
+	errMoveToPositionFailed = errors.New("couldn't move to position")
+	errLengthsFailed        = errors.New("couldn't get lengths")
+	errStopFailed           = errors.New("couldn't stop")
+	errGantryNotFound       = errors.New("not found")
 )
 
 func newServer() (pb.GantryServiceServer, *inject.Gantry, *inject.Gantry, error) {
@@ -96,7 +96,7 @@ func TestServer(t *testing.T) {
 	t.Run("gantry position", func(t *testing.T) {
 		_, err := gantryServer.GetPosition(context.Background(), &pb.GetPositionRequest{Name: missingGantryName})
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, errGantryUnimplemented.Error())
+		test.That(t, err.Error(), test.ShouldContainSubstring, errGantryNotFound.Error())
 
 		ext, err := protoutils.StructToStructPb(map[string]interface{}{"foo": "123", "bar": 234})
 		test.That(t, err, test.ShouldBeNil)
@@ -116,7 +116,7 @@ func TestServer(t *testing.T) {
 			&pb.MoveToPositionRequest{Name: missingGantryName, PositionsMm: pos2, SpeedsMmPerSec: speed2},
 		)
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, errGantryUnimplemented.Error())
+		test.That(t, err.Error(), test.ShouldContainSubstring, errGantryNotFound.Error())
 
 		ext, err := protoutils.StructToStructPb(map[string]interface{}{"foo": "234", "bar": 345})
 		test.That(t, err, test.ShouldBeNil)
@@ -143,7 +143,7 @@ func TestServer(t *testing.T) {
 	t.Run("lengths", func(t *testing.T) {
 		_, err := gantryServer.GetLengths(context.Background(), &pb.GetLengthsRequest{Name: missingGantryName})
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, errGantryUnimplemented.Error())
+		test.That(t, err.Error(), test.ShouldContainSubstring, errGantryNotFound.Error())
 
 		ext, err := protoutils.StructToStructPb(map[string]interface{}{"foo": 123, "bar": "234"})
 		test.That(t, err, test.ShouldBeNil)
@@ -160,7 +160,7 @@ func TestServer(t *testing.T) {
 	t.Run("home", func(t *testing.T) {
 		_, err := gantryServer.Home(context.Background(), &pb.HomeRequest{Name: missingGantryName})
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, errGantryUnimplemented.Error())
+		test.That(t, err.Error(), test.ShouldContainSubstring, errGantryNotFound.Error())
 
 		ext, err := protoutils.StructToStructPb(map[string]interface{}{"foo": 123, "bar": "234"})
 		test.That(t, err, test.ShouldBeNil)
@@ -178,7 +178,7 @@ func TestServer(t *testing.T) {
 	t.Run("stop", func(t *testing.T) {
 		_, err = gantryServer.Stop(context.Background(), &pb.StopRequest{Name: missingGantryName})
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, errGantryUnimplemented.Error())
+		test.That(t, err.Error(), test.ShouldContainSubstring, errGantryNotFound.Error())
 
 		ext, err := protoutils.StructToStructPb(map[string]interface{}{"foo": 234, "bar": "123"})
 		test.That(t, err, test.ShouldBeNil)

--- a/components/generic/client_test.go
+++ b/components/generic/client_test.go
@@ -2,7 +2,6 @@ package generic_test
 
 import (
 	"context"
-	"errors"
 	"net"
 	"testing"
 
@@ -40,7 +39,7 @@ func TestClient(t *testing.T) {
 		map[string]interface{},
 		error,
 	) {
-		return nil, errors.New("do failed")
+		return nil, errDoFailed
 	}
 
 	resourceMap := map[resource.Name]resource.Resource{
@@ -62,7 +61,7 @@ func TestClient(t *testing.T) {
 		cancel()
 		_, err = viamgrpc.Dial(cancelCtx, listener1.Addr().String(), logger)
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "canceled")
+		test.That(t, err, test.ShouldBeError, context.Canceled)
 	})
 
 	t.Run("client tests for working generic", func(t *testing.T) {
@@ -88,6 +87,7 @@ func TestClient(t *testing.T) {
 
 		_, err = failingGenericClient.DoCommand(context.Background(), testutils.TestCommand)
 		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, errDoFailed.Error())
 
 		test.That(t, failingGenericClient.Close(context.Background()), test.ShouldBeNil)
 		test.That(t, conn.Close(), test.ShouldBeNil)

--- a/components/generic/server_test.go
+++ b/components/generic/server_test.go
@@ -16,6 +16,8 @@ import (
 	"go.viam.com/rdk/testutils/inject"
 )
 
+var errDoFailed = errors.New("do failed")
+
 func newServer() (genericpb.GenericServiceServer, *inject.Generic, *inject.Generic, error) {
 	injectGeneric := &inject.Generic{}
 	injectGeneric2 := &inject.Generic{}
@@ -50,7 +52,7 @@ func TestGenericDo(t *testing.T) {
 		map[string]interface{},
 		error,
 	) {
-		return nil, errors.New("do failed")
+		return nil, errDoFailed
 	}
 
 	commandStruct, err := protoutils.StructToStructPb(testutils.TestCommand)
@@ -66,5 +68,6 @@ func TestGenericDo(t *testing.T) {
 	req = commonpb.DoCommandRequest{Name: failGenericName, Command: commandStruct}
 	resp, err = genericServer.DoCommand(context.Background(), &req)
 	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, errDoFailed.Error())
 	test.That(t, resp, test.ShouldBeNil)
 }

--- a/components/gripper/gripper.go
+++ b/components/gripper/gripper.go
@@ -4,7 +4,6 @@ package gripper
 import (
 	"context"
 
-	"github.com/pkg/errors"
 	commonpb "go.viam.com/api/common/v1"
 	pb "go.viam.com/api/component/gripper/v1"
 
@@ -50,9 +49,6 @@ type Gripper interface {
 	// This will block until done or a new operation cancels this one
 	Grab(ctx context.Context, extra map[string]interface{}) (bool, error)
 }
-
-// ErrStopUnimplemented is used for when Stop is unimplemented.
-var ErrStopUnimplemented = errors.New("Stop unimplemented")
 
 // FromRobot is a helper for getting the named Gripper from the given Robot.
 func FromRobot(r robot.Robot, name string) (Gripper, error) {

--- a/components/gripper/server_test.go
+++ b/components/gripper/server_test.go
@@ -15,10 +15,10 @@ import (
 )
 
 var (
-	errCantOpen             = errors.New("can't open")
-	errCantGrab             = errors.New("can't grab")
-	errStopUnimplemented    = errors.New("stop unimplemented")
-	errGripperUnimplemented = errors.New("not found")
+	errCantOpen          = errors.New("can't open")
+	errCantGrab          = errors.New("can't grab")
+	errStopUnimplemented = errors.New("stop unimplemented")
+	errGripperNotFound   = errors.New("not found")
 )
 
 func newServer() (pb.GripperServiceServer, *inject.Gripper, *inject.Gripper, error) {

--- a/components/gripper/server_test.go
+++ b/components/gripper/server_test.go
@@ -71,7 +71,7 @@ func TestServer(t *testing.T) {
 	t.Run("open", func(t *testing.T) {
 		_, err := gripperServer.Open(context.Background(), &pb.OpenRequest{Name: missingGripperName})
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, errGripperUnimplemented.Error())
+		test.That(t, err.Error(), test.ShouldContainSubstring, errGripperNotFound.Error())
 
 		extra := map[string]interface{}{"foo": "Open"}
 		ext, err := protoutils.StructToStructPb(extra)
@@ -90,7 +90,7 @@ func TestServer(t *testing.T) {
 	t.Run("grab", func(t *testing.T) {
 		_, err := gripperServer.Grab(context.Background(), &pb.GrabRequest{Name: missingGripperName})
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, errGripperUnimplemented.Error())
+		test.That(t, err.Error(), test.ShouldContainSubstring, errGripperNotFound.Error())
 
 		extra := map[string]interface{}{"foo": "Grab"}
 		ext, err := protoutils.StructToStructPb(extra)
@@ -109,7 +109,7 @@ func TestServer(t *testing.T) {
 	t.Run("stop", func(t *testing.T) {
 		_, err = gripperServer.Stop(context.Background(), &pb.StopRequest{Name: missingGripperName})
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, errGripperUnimplemented.Error())
+		test.That(t, err.Error(), test.ShouldContainSubstring, errGripperNotFound.Error())
 
 		extra := map[string]interface{}{"foo": "Stop"}
 		ext, err := protoutils.StructToStructPb(extra)

--- a/components/gripper/server_test.go
+++ b/components/gripper/server_test.go
@@ -17,7 +17,7 @@ import (
 var (
 	errCantOpen             = errors.New("can't open")
 	errCantGrab             = errors.New("can't grab")
-	errStopUnimplemented    = errors.New("Stop unimplemented")
+	errStopUnimplemented    = errors.New("stop unimplemented")
 	errGripperUnimplemented = errors.New("not found")
 )
 


### PR DESCRIPTION
This PR checks against error variables in the `gripper` client and server tests in addition to checking if the error is nil or not. Since the changes were small, this PR also covers RSDK-3508 (same thing but for `gantry` component) and RSDK-3512 (same thing but for `generic` component)