### PR TITLE
RSDK-4158: Create separate environments for parallel motion planning tests.

### DIFF
--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -67,7 +67,9 @@ func getPointCloudMap(path string) (func() ([]byte, error), error) {
 	return f, nil
 }
 
-func createEnvironment(ctx context.Context, t *testing.T, gpsPoint *geo.Point) (*inject.MovementSensor, framesystem.Service, base.Base, motion.Service) {
+func createEnvironment(ctx context.Context, t *testing.T, gpsPoint *geo.Point) (
+	*inject.MovementSensor, framesystem.Service, base.Base, motion.Service,
+) {
 	logger := golog.NewTestLogger(t)
 
 	// create fake base

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/edaniels/golog"
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
-
 	// register.
 	commonpb "go.viam.com/api/common/v1"
 	"go.viam.com/test"

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/edaniels/golog"
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
+
 	// register.
 	commonpb "go.viam.com/api/common/v1"
 	"go.viam.com/test"
@@ -65,6 +66,71 @@ func getPointCloudMap(path string) (func() ([]byte, error), error) {
 		return chunk[:bytesRead], err
 	}
 	return f, nil
+}
+
+func createEnvironment(ctx context.Context, t *testing.T, gpsPoint *geo.Point) (*inject.MovementSensor, framesystem.Service, base.Base, motion.Service) {
+	logger := golog.NewTestLogger(t)
+
+	// create fake base
+	baseCfg := resource.Config{
+		Name:  "test-base",
+		API:   base.API,
+		Frame: &referenceframe.LinkConfig{Geometry: &spatialmath.GeometryConfig{R: 20}},
+	}
+	fakeBase, err := fake.NewBase(ctx, nil, baseCfg, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	// create base link
+	basePose := spatialmath.NewPoseFromPoint(r3.Vector{0, 0, 0})
+	baseSphere, err := spatialmath.NewSphere(basePose, 10, "base-sphere")
+	test.That(t, err, test.ShouldBeNil)
+	baseLink := referenceframe.NewLinkInFrame(
+		referenceframe.World,
+		spatialmath.NewZeroPose(),
+		"test-base",
+		baseSphere,
+	)
+
+	// create injected MovementSensor
+	injectedMovementSensor := inject.NewMovementSensor("test-gps")
+	injectedMovementSensor.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+		return gpsPoint, 0, nil
+	}
+	injectedMovementSensor.CompassHeadingFunc = func(ctx context.Context, extra map[string]interface{}) (float64, error) {
+		return 0, nil
+	}
+	injectedMovementSensor.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+		return &movementsensor.Properties{CompassHeadingSupported: true}, nil
+	}
+
+	// create MovementSensor link
+	movementSensorLink := referenceframe.NewLinkInFrame(
+		baseLink.Name(),
+		spatialmath.NewPoseFromPoint(r3.Vector{-10, 0, 0}),
+		"test-gps",
+		nil,
+	)
+
+	// create the frame system
+	fsParts := []*referenceframe.FrameSystemPart{
+		{FrameConfig: movementSensorLink},
+		{FrameConfig: baseLink},
+	}
+	deps := resource.Dependencies{
+		fakeBase.Name():               fakeBase,
+		injectedMovementSensor.Name(): injectedMovementSensor,
+	}
+	fsSvc, err := framesystem.New(context.Background(), deps, logger)
+	test.That(t, err, test.ShouldBeNil)
+	err = fsSvc.Reconfigure(context.Background(), deps, resource.Config{ConvertedAttributes: &framesystem.Config{Parts: fsParts}})
+	test.That(t, err, test.ShouldBeNil)
+
+	// create the motion service
+	deps[fsSvc.Name()] = fsSvc
+	ms, err := NewBuiltIn(ctx, deps, resource.Config{ConvertedAttributes: &Config{}}, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	return injectedMovementSensor, fsSvc, fakeBase, ms
 }
 
 func TestMoveFailures(t *testing.T) {
@@ -409,7 +475,6 @@ func TestMoveOnMapTimeout(t *testing.T) {
 func TestMoveOnGlobe(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := golog.NewTestLogger(t)
 
 	gpsPoint := geo.NewPoint(-70, 40)
 
@@ -418,71 +483,12 @@ func TestMoveOnGlobe(t *testing.T) {
 	motionCfg["motion_profile"] = "position_only"
 	motionCfg["timeout"] = 5.
 
-	// create fake base
-	baseCfg := resource.Config{
-		Name:  "test-base",
-		API:   base.API,
-		Frame: &referenceframe.LinkConfig{Geometry: &spatialmath.GeometryConfig{R: 20}},
-	}
-	fakeBase, err := fake.NewBase(ctx, nil, baseCfg, logger)
-	test.That(t, err, test.ShouldBeNil)
-
-	// create base link
-	basePose := spatialmath.NewPoseFromPoint(r3.Vector{0, 0, 0})
-	baseSphere, err := spatialmath.NewSphere(basePose, 10, "base-sphere")
-	test.That(t, err, test.ShouldBeNil)
-	baseLink := referenceframe.NewLinkInFrame(
-		referenceframe.World,
-		spatialmath.NewZeroPose(),
-		"test-base",
-		baseSphere,
-	)
-
-	// create injected MovementSensor
-	injectedMovementSensor := inject.NewMovementSensor("test-gps")
-	injectedMovementSensor.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
-		return gpsPoint, 0, nil
-	}
-	injectedMovementSensor.CompassHeadingFunc = func(ctx context.Context, extra map[string]interface{}) (float64, error) {
-		return 0, nil
-	}
-	injectedMovementSensor.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
-		return &movementsensor.Properties{CompassHeadingSupported: true}, nil
-	}
-
-	// create MovementSensor link
-	movementSensorLink := referenceframe.NewLinkInFrame(
-		baseLink.Name(),
-		spatialmath.NewPoseFromPoint(r3.Vector{-10, 0, 0}),
-		"test-gps",
-		nil,
-	)
-
-	// create the frame system
-	fsParts := []*referenceframe.FrameSystemPart{
-		{FrameConfig: movementSensorLink},
-		{FrameConfig: baseLink},
-	}
-	deps := resource.Dependencies{
-		fakeBase.Name():               fakeBase,
-		injectedMovementSensor.Name(): injectedMovementSensor,
-	}
-	fsSvc, err := framesystem.New(context.Background(), deps, logger)
-	test.That(t, err, test.ShouldBeNil)
-	err = fsSvc.Reconfigure(context.Background(), deps, resource.Config{ConvertedAttributes: &framesystem.Config{Parts: fsParts}})
-	test.That(t, err, test.ShouldBeNil)
-
-	// create the motion service
-	deps[fsSvc.Name()] = fsSvc
-	ms, err := NewBuiltIn(ctx, deps, resource.Config{ConvertedAttributes: &Config{}}, logger)
-	test.That(t, err, test.ShouldBeNil)
-
-	gp, _, err := injectedMovementSensor.Position(ctx, nil)
-	test.That(t, err, test.ShouldBeNil)
-	dst := geo.NewPoint(gp.Lat(), gp.Lng()+1e-5)
+	dst := geo.NewPoint(gpsPoint.Lat(), gpsPoint.Lng()+1e-5)
 	expectedDst := r3.Vector{380, 0, 0}
 
 	t.Run("ensure success to a nearby geo point", func(t *testing.T) {
+		t.Parallel()
+		injectedMovementSensor, _, fakeBase, ms := createEnvironment(ctx, t, gpsPoint)
 		plan, _, err := ms.(*builtIn).planMoveOnGlobe(
 			context.Background(),
 			fakeBase.Name(),
@@ -501,6 +507,7 @@ func TestMoveOnGlobe(t *testing.T) {
 
 	t.Run("go around an obstacle", func(t *testing.T) {
 		t.Parallel()
+		injectedMovementSensor, _, fakeBase, ms := createEnvironment(ctx, t, gpsPoint)
 		boxPose := spatialmath.NewPoseFromPoint(r3.Vector{50, 0, 0})
 		boxDims := r3.Vector{5, 50, 10}
 		geometries, err := spatialmath.NewBox(boxPose, boxDims, "wall")
@@ -525,6 +532,7 @@ func TestMoveOnGlobe(t *testing.T) {
 
 	t.Run("fail because of obstacle", func(t *testing.T) {
 		t.Parallel()
+		injectedMovementSensor, _, fakeBase, ms := createEnvironment(ctx, t, gpsPoint)
 
 		boxPose := spatialmath.NewPoseFromPoint(r3.Vector{50, 0, 0})
 		boxDims := r3.Vector{2, 6660, 10}
@@ -547,6 +555,8 @@ func TestMoveOnGlobe(t *testing.T) {
 	})
 
 	t.Run("check offset constructed correctly", func(t *testing.T) {
+		t.Parallel()
+		_, fsSvc, _, _ := createEnvironment(ctx, t, gpsPoint)
 		baseOrigin := referenceframe.NewPoseInFrame("test-base", spatialmath.NewZeroPose())
 		movementSensorToBase, err := fsSvc.TransformPose(ctx, baseOrigin, "test-gps", nil)
 		if err != nil {


### PR DESCRIPTION
I just did a mechanical "refactor" so we can give each parallel test its own copy of variables to write to, avoiding the (testing only) data race. I felt that coming up with a more thoughtful way to manage the environment (compared to the new function that has 4 return values) was going to be more time consuming.