### PR TITLE
RSDK-3510: review board server and client tests

### DIFF
--- a/components/arm/arm.go
+++ b/components/arm/arm.go
@@ -83,9 +83,6 @@ type Arm interface {
 	JointPositions(ctx context.Context, extra map[string]interface{}) (*pb.JointPositions, error)
 }
 
-// ErrStopUnimplemented is used for when Stop is unimplemented.
-var ErrStopUnimplemented = errors.New("Stop unimplemented")
-
 // FromDependencies is a helper for getting the named arm from a collection of
 // dependencies.
 func FromDependencies(deps resource.Dependencies, name string) (Arm, error) {

--- a/components/arm/client_test.go
+++ b/components/arm/client_test.go
@@ -60,7 +60,7 @@ func TestClient(t *testing.T) {
 	}
 	injectArm.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
 		extraOptions = extra
-		return arm.ErrStopUnimplemented
+		return errStopUnimplemented
 	}
 	injectArm.ModelFrameFunc = func() referenceframe.Model {
 		data := []byte("{\"links\": [{\"parent\": \"world\"}]}")
@@ -130,7 +130,7 @@ func TestClient(t *testing.T) {
 		cancel()
 		_, err = viamgrpc.Dial(cancelCtx, listener1.Addr().String(), logger)
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "canceled")
+		test.That(t, err, test.ShouldBeError, context.Canceled)
 	})
 
 	// working
@@ -169,7 +169,7 @@ func TestClient(t *testing.T) {
 
 		err = arm1Client.Stop(context.Background(), map[string]interface{}{"foo": "Stop"})
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, arm.ErrStopUnimplemented.Error())
+		test.That(t, err.Error(), test.ShouldContainSubstring, errStopUnimplemented.Error())
 		test.That(t, extraOptions, test.ShouldResemble, map[string]interface{}{"foo": "Stop"})
 
 		test.That(t, arm1Client.Close(context.Background()), test.ShouldBeNil)

--- a/components/base/client_test.go
+++ b/components/base/client_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/edaniels/golog"
 	"github.com/golang/geo/r3"
-	"github.com/pkg/errors"
 	"go.viam.com/test"
 	"go.viam.com/utils/rpc"
 
@@ -54,34 +53,27 @@ func setupWorkingBase(
 	}
 }
 
-const (
-	errMsgMoveStraight = "critical failure in MoveStraight"
-	errMsgSpin         = "critical failure in Spin"
-	errMsgStop         = "critical failure in Stop"
-	errMsgProperties   = "critical failure in Properties"
-)
-
 func setupBrokenBase(brokenBase *inject.Base) {
 	brokenBase.MoveStraightFunc = func(
 		ctx context.Context,
 		distanceMm int, mmPerSec float64,
 		extra map[string]interface{},
 	) error {
-		return errors.New(errMsgMoveStraight)
+		return errMoveStraight
 	}
 	brokenBase.SpinFunc = func(
 		ctx context.Context,
 		angleDeg, degsPerSec float64,
 		extra map[string]interface{},
 	) error {
-		return errors.New(errMsgSpin)
+		return errSpinFailed
 	}
 	brokenBase.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
-		return errors.New(errMsgStop)
+		return errStopFailed
 	}
 
 	brokenBase.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (base.Properties, error) {
-		return base.Properties{}, errors.New(errMsgProperties)
+		return base.Properties{}, errPropertiesFailed
 	}
 }
 
@@ -128,7 +120,7 @@ func TestClient(t *testing.T) {
 		cancel()
 		_, err = viamgrpc.Dial(cancelCtx, listener1.Addr().String(), logger)
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "canceled")
+		test.That(t, err, test.ShouldBeError, context.Canceled)
 	})
 	conn, err := viamgrpc.Dial(context.Background(), listener1.Addr().String(), logger)
 	test.That(t, err, test.ShouldBeNil)
@@ -221,16 +213,16 @@ func TestClient(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		err = failingBaseClient.MoveStraight(context.Background(), 42, 42.0, nil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, errMsgMoveStraight)
+		test.That(t, err.Error(), test.ShouldContainSubstring, errMoveStraight.Error())
 
 		err = failingBaseClient.Spin(context.Background(), 42.0, 42.0, nil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, errMsgSpin)
+		test.That(t, err.Error(), test.ShouldContainSubstring, errSpinFailed.Error())
 
 		_, err = failingBaseClient.Properties(context.Background(), nil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, errMsgProperties)
+		test.That(t, err.Error(), test.ShouldContainSubstring, errPropertiesFailed.Error())
 
 		err = failingBaseClient.Stop(context.Background(), nil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, errMsgStop)
+		test.That(t, err.Error(), test.ShouldContainSubstring, errStopFailed.Error())
 
 		test.That(t, failingBaseClient.Close(context.Background()), test.ShouldBeNil)
 		test.That(t, conn.Close(), test.ShouldBeNil)

--- a/components/board/client_test.go
+++ b/components/board/client_test.go
@@ -255,9 +255,6 @@ func TestClientWithoutStatus(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 
 	injectBoard := &inject.Board{}
-	injectBoard.StatusFunc = func(ctx context.Context, extra map[string]interface{}) (*commonpb.BoardStatus, error) {
-		return nil, errStatusFailed
-	}
 
 	listener1, err := net.Listen("tcp", "localhost:0")
 	test.That(t, err, test.ShouldBeNil)

--- a/components/board/client_test.go
+++ b/components/board/client_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/edaniels/golog"
-	"github.com/pkg/errors"
 	commonpb "go.viam.com/api/common/v1"
 	boardpb "go.viam.com/api/component/board/v1"
 	"go.viam.com/test"
@@ -57,7 +56,7 @@ func TestFailingClient(t *testing.T) {
 
 	_, err := viamgrpc.Dial(cancelCtx, listener.Addr().String(), logger)
 	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, "canceled")
+	test.That(t, err, test.ShouldBeError, context.Canceled)
 }
 
 func TestWorkingClient(t *testing.T) {
@@ -257,7 +256,7 @@ func TestClientWithoutStatus(t *testing.T) {
 
 	injectBoard := &inject.Board{}
 	injectBoard.StatusFunc = func(ctx context.Context, extra map[string]interface{}) (*commonpb.BoardStatus, error) {
-		return nil, errors.New("no status")
+		return nil, errStatusFailed
 	}
 
 	listener1, err := net.Listen("tcp", "localhost:0")

--- a/components/board/server_test.go
+++ b/components/board/server_test.go
@@ -18,7 +18,6 @@ import (
 var (
 	errFoo           = errors.New("whoops")
 	errUnimplemented = errors.New("not found")
-	errStatusFailed  = errors.New("no status")
 )
 
 func newServer() (pb.BoardServiceServer, *inject.Board, error) {

--- a/components/board/server_test.go
+++ b/components/board/server_test.go
@@ -15,7 +15,11 @@ import (
 	"go.viam.com/rdk/testutils/inject"
 )
 
-var errFoo = errors.New("whoops")
+var (
+	errFoo           = errors.New("whoops")
+	errUnimplemented = errors.New("not found")
+	errStatusFailed  = errors.New("no status")
+)
 
 func newServer() (pb.BoardServiceServer, *inject.Board, error) {
 	injectBoard := &inject.Board{}
@@ -61,7 +65,7 @@ func TestServerStatus(t *testing.T) {
 			req:          &request{Name: missingBoardName},
 			expCapArgs:   []interface{}(nil),
 			expResp:      nil,
-			expRespErr:   "not found",
+			expRespErr:   errUnimplemented.Error(),
 		},
 		{
 			injectResult: status,
@@ -125,7 +129,7 @@ func TestServerSetGPIO(t *testing.T) {
 			injectErr:  nil,
 			req:        &request{Name: missingBoardName},
 			expCapArgs: []interface{}(nil),
-			expRespErr: "not found",
+			expRespErr: errUnimplemented.Error(),
 		},
 		{
 			injectErr:  errFoo,
@@ -194,7 +198,7 @@ func TestServerGetGPIO(t *testing.T) {
 			req:          &request{Name: missingBoardName},
 			expCapArgs:   []interface{}(nil),
 			expResp:      nil,
-			expRespErr:   "not found",
+			expRespErr:   errUnimplemented.Error(),
 		},
 		{
 			injectResult: false,
@@ -269,7 +273,7 @@ func TestServerPWM(t *testing.T) {
 			req:          &request{Name: missingBoardName},
 			expCapArgs:   []interface{}(nil),
 			expResp:      nil,
-			expRespErr:   "not found",
+			expRespErr:   errUnimplemented.Error(),
 		},
 		{
 			injectResult: 0,
@@ -337,7 +341,7 @@ func TestServerSetPWM(t *testing.T) {
 			injectErr:  nil,
 			req:        &request{Name: missingBoardName},
 			expCapArgs: []interface{}(nil),
-			expRespErr: "not found",
+			expRespErr: errUnimplemented.Error(),
 		},
 		{
 			injectErr:  errFoo,
@@ -407,7 +411,7 @@ func TestServerPWMFrequency(t *testing.T) {
 			req:          &request{Name: missingBoardName},
 			expCapArgs:   []interface{}(nil),
 			expResp:      nil,
-			expRespErr:   "not found",
+			expRespErr:   errUnimplemented.Error(),
 		},
 		{
 			injectResult: 0,
@@ -475,7 +479,7 @@ func TestServerSetPWMFrequency(t *testing.T) {
 			injectErr:  nil,
 			req:        &request{Name: missingBoardName},
 			expCapArgs: []interface{}(nil),
-			expRespErr: "not found",
+			expRespErr: errUnimplemented.Error(),
 		},
 		{
 			injectErr:  errFoo,
@@ -551,7 +555,7 @@ func TestServerReadAnalogReader(t *testing.T) {
 			expCapAnalogReaderArgs: []interface{}(nil),
 			expCapArgs:             []interface{}(nil),
 			expResp:                nil,
-			expRespErr:             "not found",
+			expRespErr:             errUnimplemented.Error(),
 		},
 		{
 			injectAnalogReader:     nil,
@@ -650,7 +654,7 @@ func TestServerGetDigitalInterruptValue(t *testing.T) {
 			expCapDigitalInterruptArgs: []interface{}(nil),
 			expCapArgs:                 []interface{}(nil),
 			expResp:                    nil,
-			expRespErr:                 "not found",
+			expRespErr:                 errUnimplemented.Error(),
 		},
 		{
 			injectDigitalInterrupt:     nil,

--- a/components/camera/server_test.go
+++ b/components/camera/server_test.go
@@ -23,6 +23,15 @@ import (
 	"go.viam.com/rdk/utils"
 )
 
+var (
+	errInvalidMimeType          = errors.New("invalid mime type")
+	errGeneratePointCloudFailed = errors.New("can't generate next point cloud")
+	errPropertiesFailed         = errors.New("can't get camera properties")
+	errCameraProjectorFailed    = errors.New("can't get camera properties")
+	errStreamFailed             = errors.New("can't generate stream")
+	errCameraUnimplemented      = errors.New("not found")
+)
+
 func newServer() (pb.CameraServiceServer, *inject.Camera, *inject.Camera, *inject.Camera, error) {
 	injectCamera := &inject.Camera{}
 	injectCameraDepth := &inject.Camera{}
@@ -113,7 +122,7 @@ func TestServer(t *testing.T) {
 			case "image/woohoo":
 				return rimage.NewLazyEncodedImage([]byte{1, 2, 3}, mimeType), func() {}, nil
 			default:
-				return nil, nil, errors.New("invalid mime type")
+				return nil, nil, errInvalidMimeType
 			}
 		})), nil
 	}
@@ -149,22 +158,22 @@ func TestServer(t *testing.T) {
 	}
 	// bad camera
 	injectCamera2.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
-		return nil, errors.New("can't generate next point cloud")
+		return nil, errGeneratePointCloudFailed
 	}
 	injectCamera2.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
-		return camera.Properties{}, errors.New("can't get camera properties")
+		return camera.Properties{}, errPropertiesFailed
 	}
 	injectCamera2.ProjectorFunc = func(ctx context.Context) (transform.Projector, error) {
-		return nil, errors.New("can't get camera properties")
+		return nil, errCameraProjectorFailed
 	}
 	injectCamera2.StreamFunc = func(ctx context.Context, errHandlers ...gostream.ErrorHandler) (gostream.VideoStream, error) {
-		return nil, errors.New("can't generate stream")
+		return nil, errStreamFailed
 	}
 	// does a depth camera transfer its depth image properly
 	t.Run("GetImage", func(t *testing.T) {
 		_, err := cameraServer.GetImage(context.Background(), &pb.GetImageRequest{Name: missingCameraName})
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "not found")
+		test.That(t, err.Error(), test.ShouldContainSubstring, errCameraUnimplemented.Error())
 
 		// color camera
 		// ensure that explicit RawRGBA mimetype request will return RawRGBA mimetype response
@@ -225,7 +234,7 @@ func TestServer(t *testing.T) {
 			MimeType: "image/who",
 		})
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "invalid mime type")
+		test.That(t, err.Error(), test.ShouldContainSubstring, errInvalidMimeType.Error())
 
 		// depth camera
 		imageReleasedMu.Lock()
@@ -267,7 +276,7 @@ func TestServer(t *testing.T) {
 		// bad camera
 		_, err = cameraServer.GetImage(context.Background(), &pb.GetImageRequest{Name: failCameraName, MimeType: utils.MimeTypeRawRGBA})
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "can't generate stream")
+		test.That(t, err.Error(), test.ShouldContainSubstring, errStreamFailed.Error())
 	})
 
 	t.Run("GetImage with lazy", func(t *testing.T) {
@@ -285,7 +294,7 @@ func TestServer(t *testing.T) {
 			MimeType: "image/notwoo",
 		})
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "invalid mime type")
+		test.That(t, err.Error(), test.ShouldContainSubstring, errInvalidMimeType.Error())
 	})
 
 	t.Run("GetImage with +lazy default", func(t *testing.T) {
@@ -308,7 +317,7 @@ func TestServer(t *testing.T) {
 	t.Run("RenderFrame", func(t *testing.T) {
 		_, err := cameraServer.RenderFrame(context.Background(), &pb.RenderFrameRequest{Name: missingCameraName})
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "not found")
+		test.That(t, err.Error(), test.ShouldContainSubstring, errCameraUnimplemented.Error())
 
 		resp, err := cameraServer.RenderFrame(context.Background(), &pb.RenderFrameRequest{
 			Name: testCameraName,
@@ -343,20 +352,20 @@ func TestServer(t *testing.T) {
 			MimeType: "image/who",
 		})
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "invalid mime type")
+		test.That(t, err.Error(), test.ShouldContainSubstring, errInvalidMimeType.Error())
 		imageReleasedMu.Lock()
 		test.That(t, imageReleased, test.ShouldBeTrue)
 		imageReleasedMu.Unlock()
 
 		_, err = cameraServer.RenderFrame(context.Background(), &pb.RenderFrameRequest{Name: failCameraName})
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "can't generate stream")
+		test.That(t, err.Error(), test.ShouldContainSubstring, errStreamFailed.Error())
 	})
 
 	t.Run("GetPointCloud", func(t *testing.T) {
 		_, err := cameraServer.GetPointCloud(context.Background(), &pb.GetPointCloudRequest{Name: missingCameraName})
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "not found")
+		test.That(t, err.Error(), test.ShouldContainSubstring, errCameraUnimplemented.Error())
 
 		pcA := pointcloud.New()
 		err = pcA.Set(pointcloud.NewVector(5, 5, 5), nil)
@@ -374,12 +383,12 @@ func TestServer(t *testing.T) {
 			Name: failCameraName,
 		})
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "can't generate next point cloud")
+		test.That(t, err.Error(), test.ShouldContainSubstring, errGeneratePointCloudFailed.Error())
 	})
 	t.Run("GetImages", func(t *testing.T) {
 		_, err := cameraServer.GetImages(context.Background(), &pb.GetImagesRequest{Name: missingCameraName})
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "not found")
+		test.That(t, err.Error(), test.ShouldContainSubstring, errCameraUnimplemented.Error())
 
 		resp, err := cameraServer.GetImages(context.Background(), &pb.GetImagesRequest{Name: testCameraName})
 		test.That(t, err, test.ShouldBeNil)
@@ -392,7 +401,7 @@ func TestServer(t *testing.T) {
 	t.Run("GetProperties", func(t *testing.T) {
 		_, err := cameraServer.GetProperties(context.Background(), &pb.GetPropertiesRequest{Name: missingCameraName})
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "not found")
+		test.That(t, err.Error(), test.ShouldContainSubstring, errCameraUnimplemented.Error())
 
 		resp, err := cameraServer.GetProperties(context.Background(), &pb.GetPropertiesRequest{Name: testCameraName})
 		test.That(t, err, test.ShouldBeNil)


### PR DESCRIPTION
This PR checks against error variables in the `board` client and server tests in addition to checking if the error is nil or not. Since the changes were small, this PR also covers RSDK-3511 (same thing but for `base` component), RSDK-3513 (same thing but for `arm` component), and RSDK-3517 (same thing but for `camera` component)