### PR TITLE
REVERT RSDK-3975

### DIFF
--- a/components/encoder/single/single_encoder.go
+++ b/components/encoder/single/single_encoder.go
@@ -181,7 +181,6 @@ func (e *Encoder) Reconfigure(
 
 // Start starts the Encoder background thread.
 func (e *Encoder) Start(ctx context.Context) {
-	var lastTick int64
 	encoderChannel := make(chan board.Tick)
 	e.I.AddCallback(encoderChannel)
 	e.activeBackgroundWorkers.Add(1)
@@ -206,15 +205,7 @@ func (e *Encoder) Start(ctx context.Context) {
 				// the motor. This may result in ticks being lost or applied in the wrong direction.
 				dir := e.m.DirectionMoving()
 				if dir == 1 || dir == -1 {
-					tick, err := e.I.Value(ctx, nil)
-					if err != nil {
-						e.logger.Error(err)
-						return
-					}
-					if tick != lastTick {
-						atomic.AddInt64(&e.position, dir)
-					}
-					lastTick = tick
+					atomic.AddInt64(&e.position, dir)
 				}
 			} else {
 				e.logger.Warn("received tick for encoder that isn't connected to a motor; ignoring")


### PR DESCRIPTION
revert single encoder change to continue to double counting ticks until we can determine if this is the correct solution