### PR TITLE
DATA-fix - Check that collector error is non-nil if not returning directly

### DIFF
--- a/components/movementsensor/movementsensor.go
+++ b/components/movementsensor/movementsensor.go
@@ -29,6 +29,9 @@ func init() {
 			Lng float64
 		}
 		p, _, err := ms.Position(ctx, make(map[string]interface{}))
+		if err != nil {
+			return nil, err
+		}
 		return Position{Lat: p.Lat(), Lng: p.Lng()}, err
 	})
 	registerCollector("LinearVelocity", func(ctx context.Context, ms MovementSensor) (interface{}, error) {
@@ -44,6 +47,9 @@ func init() {
 			Heading float64
 		}
 		h, err := ms.CompassHeading(ctx, make(map[string]interface{}))
+		if err != nil {
+			return nil, err
+		}
 		return Heading{Heading: h}, err
 	})
 	registerCollector("LinearAcceleration", func(ctx context.Context, ms MovementSensor) (interface{}, error) {

--- a/components/movementsensor/movementsensor.go
+++ b/components/movementsensor/movementsensor.go
@@ -32,7 +32,7 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return Position{Lat: p.Lat(), Lng: p.Lng()}, err
+		return Position{Lat: p.Lat(), Lng: p.Lng()}, nil
 	})
 	registerCollector("LinearVelocity", func(ctx context.Context, ms MovementSensor) (interface{}, error) {
 		v, err := ms.LinearVelocity(ctx, make(map[string]interface{}))
@@ -50,7 +50,7 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return Heading{Heading: h}, err
+		return Heading{Heading: h}, nil
 	})
 	registerCollector("LinearAcceleration", func(ctx context.Context, ms MovementSensor) (interface{}, error) {
 		v, err := ms.LinearAcceleration(ctx, make(map[string]interface{}))


### PR DESCRIPTION
Fixes panic if position is invalid. All other collector methods check the error first before wrapping or accessing the returned value.