### PR TITLE
APP-2099 Test implicit deps across modules and deregister crash resources

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -773,6 +773,7 @@ func (m *module) deregisterResources() {
 			resource.Deregister(api.API, model)
 		}
 	}
+	m.handles = nil
 }
 
 // DepsToNames converts a dependency list to a simple string slice.

--- a/module/testmodule/main.go
+++ b/module/testmodule/main.go
@@ -149,9 +149,8 @@ func (tm *testMotor) Position(_ context.Context, _ map[string]interface{}) (floa
 }
 
 // Properties trivially implements motor.Motor.
-func (tm *testMotor) Properties(_ context.Context, _ map[string]interface{}) (map[motor.Feature]bool, error) {
-	//nolint:nilnil
-	return nil, nil
+func (tm *testMotor) Properties(_ context.Context, _ map[string]interface{}) (motor.Properties, error) {
+	return motor.Properties{}, nil
 }
 
 // Stop trivially implements motor.Motor.

--- a/module/testmodule/main.go
+++ b/module/testmodule/main.go
@@ -12,13 +12,15 @@ import (
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/generic"
+	"go.viam.com/rdk/components/motor"
 	"go.viam.com/rdk/module"
 	"go.viam.com/rdk/resource"
 )
 
 var (
-	myModel = resource.NewModel("rdk", "test", "helper")
-	myMod   *module.Module
+	helperModel    = resource.NewModel("rdk", "test", "helper")
+	testMotorModel = resource.NewModel("rdk", "test", "motor")
+	myMod          *module.Module
 )
 
 func main() {
@@ -33,14 +35,25 @@ func mainWithArgs(ctx context.Context, args []string, logger golog.Logger) error
 	if err != nil {
 		return err
 	}
+
 	resource.RegisterComponent(
 		generic.API,
-		myModel,
+		helperModel,
 		resource.Registration[resource.Resource, resource.NoNativeConfig]{Constructor: newHelper})
-	err = myMod.AddModelFromRegistry(ctx, generic.API, myModel)
+	err = myMod.AddModelFromRegistry(ctx, generic.API, helperModel)
 	if err != nil {
 		return err
 	}
+
+	resource.RegisterComponent(
+		motor.API,
+		testMotorModel,
+		resource.Registration[resource.Resource, resource.NoNativeConfig]{Constructor: newTestMotor})
+	err = myMod.AddModelFromRegistry(ctx, motor.API, testMotorModel)
+	if err != nil {
+		return err
+	}
+
 	err = myMod.Start(ctx)
 	defer myMod.Close(ctx)
 	if err != nil {
@@ -94,4 +107,70 @@ func (h *helper) DoCommand(ctx context.Context, req map[string]interface{}) (map
 	default:
 		return nil, fmt.Errorf("unknown command string %s", cmd)
 	}
+}
+
+func newTestMotor(ctx context.Context, deps resource.Dependencies, conf resource.Config, logger golog.Logger) (resource.Resource, error) {
+	return &testMotor{
+		Named: conf.ResourceName().AsNamed(),
+	}, nil
+}
+
+type testMotor struct {
+	resource.Named
+	resource.TriviallyReconfigurable
+	resource.TriviallyCloseable
+}
+
+var _ motor.Motor = &testMotor{}
+
+// SetPower trivially implements motor.Motor.
+func (tm *testMotor) SetPower(_ context.Context, _ float64, _ map[string]interface{}) error {
+	return nil
+}
+
+// GoFor trivially implements motor.Motor.
+func (tm *testMotor) GoFor(_ context.Context, _, _ float64, _ map[string]interface{}) error {
+	return nil
+}
+
+// GoTo trivially implements motor.Motor.
+func (tm *testMotor) GoTo(_ context.Context, _, _ float64, _ map[string]interface{}) error {
+	return nil
+}
+
+// ResetZeroPosition trivially implements motor.Motor.
+func (tm *testMotor) ResetZeroPosition(_ context.Context, _ float64, _ map[string]interface{}) error {
+	return nil
+}
+
+// Position trivially implements motor.Motor.
+func (tm *testMotor) Position(_ context.Context, _ map[string]interface{}) (float64, error) {
+	return 0.0, nil
+}
+
+// Properties trivially implements motor.Motor.
+func (tm *testMotor) Properties(_ context.Context, _ map[string]interface{}) (map[motor.Feature]bool, error) {
+	//nolint:nilnil
+	return nil, nil
+}
+
+// Stop trivially implements motor.Motor.
+func (tm *testMotor) Stop(_ context.Context, _ map[string]interface{}) error {
+	return nil
+}
+
+// IsPowered trivally implements motor.Motor.
+func (tm *testMotor) IsPowered(_ context.Context, _ map[string]interface{}) (bool, float64, error) {
+	return false, 0.0, nil
+}
+
+// DoCommand trivially implements motor.Motor.
+func (tm *testMotor) DoCommand(_ context.Context, _ map[string]interface{}) (map[string]interface{}, error) {
+	//nolint:nilnil
+	return nil, nil
+}
+
+// IsMoving trivially implements motor.Motor.
+func (tm *testMotor) IsMoving(context.Context) (bool, error) {
+	return false, nil
 }

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -3202,3 +3202,64 @@ func TestCrashedModuleReconfigure(t *testing.T) {
 		test.That(tb, err, test.ShouldBeNil)
 	})
 }
+
+func TestImplicitDepsAcrossModules(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := golog.NewObservedTestLogger(t)
+
+	// Precompile modules to avoid timeout issues when building takes too long.
+	complexPath, err := rtestutils.BuildTempModule(t, "examples/customresources/demos/complexmodule")
+	test.That(t, err, test.ShouldBeNil)
+	testPath, err := rtestutils.BuildTempModule(t, "module/testmodule")
+	test.That(t, err, test.ShouldBeNil)
+
+	// Manually define models, as importing them can cause double registration.
+	myBaseModel := resource.NewModel("acme", "demo", "mybase")
+	testMotorModel := resource.NewModel("rdk", "test", "motor")
+
+	cfg := &config.Config{
+		Modules: []config.Module{
+			{
+				Name:    "complex-module",
+				ExePath: complexPath,
+			},
+			{
+				Name:    "test-module",
+				ExePath: testPath,
+			},
+		},
+		Components: []resource.Config{
+			{
+				Name:  "b",
+				Model: myBaseModel,
+				API:   base.API,
+				Attributes: rutils.AttributeMap{
+					"motorL": "m1",
+					"motorR": "m2",
+				},
+			},
+			{
+				Name:  "m1",
+				Model: testMotorModel,
+				API:   motor.API,
+			},
+			{
+				Name:  "m2",
+				Model: testMotorModel,
+				API:   motor.API,
+			},
+		},
+	}
+	r, err := robotimpl.New(ctx, cfg, logger)
+	test.That(t, err, test.ShouldBeNil)
+	defer func() {
+		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
+	}()
+
+	_, err = r.ResourceByName(base.Named("b"))
+	test.That(t, err, test.ShouldBeNil)
+	_, err = r.ResourceByName(motor.Named("m1"))
+	test.That(t, err, test.ShouldBeNil)
+	_, err = r.ResourceByName(motor.Named("m2"))
+	test.That(t, err, test.ShouldBeNil)
+}

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -2858,8 +2858,11 @@ func TestOrphanedResources(t *testing.T) {
 		test.That(t, err, test.ShouldBeError,
 			resource.NewNotFoundError(generic.Named("h")))
 
-		// Also assert that generic helper resource was deregistered.
+		// Also assert that testmodule's resources were deregistered.
 		_, ok := resource.LookupRegistration(generic.API, helperModel)
+		test.That(t, ok, test.ShouldBeFalse)
+		testMotorModel := resource.NewModel("rdk", "test", "motor")
+		_, ok = resource.LookupRegistration(motor.API, testMotorModel)
 		test.That(t, ok, test.ShouldBeFalse)
 	})
 }


### PR DESCRIPTION
APP-2099

Deregisters resources more consistently for crashed modules when attempting a restart. Modifies existing test to ensure crash and restart will deregister all of crashed module's resources. Also adds a test to ensure that implicit dependencies can be used across modules (complexmodule's `mybase` can depend upon new `rdk:test:motor` models served by testmodule).