### PR TITLE
RSDK-4156: Make the dependency error string less painful.

### DIFF
--- a/resource/resource_registry.go
+++ b/resource/resource_registry.go
@@ -78,7 +78,7 @@ func (e *DependencyNotReadyError) Error() string {
 	return fmt.Sprintf("dependency %q is not ready yet; reason=%s", e.Name, e.Reason)
 }
 
-func (e *DependencyNotReadyError) DebugString() string {
+func (e *DependencyNotReadyError) PrettyPrint() string {
 	var leafError error
 	var indent string = ""
 	ret := strings.Builder{}

--- a/resource/resource_registry.go
+++ b/resource/resource_registry.go
@@ -78,9 +78,11 @@ func (e *DependencyNotReadyError) Error() string {
 	return fmt.Sprintf("dependency %q is not ready yet; reason=%s", e.Name, e.Reason)
 }
 
+// PrettyPrint returns a formatted string representing a `DependencyNotReadyError` error. This can be useful as a
+// `DependencyNotReadyError` often wraps a series of lower level `DependencyNotReadyError` errors.
 func (e *DependencyNotReadyError) PrettyPrint() string {
 	var leafError error
-	var indent string = ""
+	indent := ""
 	ret := strings.Builder{}
 	// Iterate through each `Reason`, incrementing the indent at each level.
 	for curError := e; curError != nil; indent = fmt.Sprintf("%v%v", indent, "  ") {
@@ -94,8 +96,9 @@ func (e *DependencyNotReadyError) PrettyPrint() string {
 
 		// If the `Reason` is also of type `DependencyNotReadyError`, we keep going with the
 		// "because X is not ready" language. The leaf error will be framed separately.
-		if IsDependencyNotReadyError(curError.Reason) {
-			curError = curError.Reason.(*DependencyNotReadyError)
+		var errArt *DependencyNotReadyError
+		if errors.As(curError.Reason, &errArt) {
+			curError = errArt
 		} else {
 			leafError = curError.Reason
 			curError = nil

--- a/resource/resource_registry.go
+++ b/resource/resource_registry.go
@@ -89,7 +89,7 @@ func (e *DependencyNotReadyError) DebugString() string {
 			ret.WriteString(fmt.Sprintf("Dependency %q is not ready yet\n", curError.Name))
 		} else {
 			ret.WriteString(indent)
-			ret.WriteString(fmt.Sprintf("- Because %v is not ready yet\n", curError.Name))
+			ret.WriteString(fmt.Sprintf("- Because %q is not ready yet\n", curError.Name))
 		}
 
 		// If the `Reason` is also of type `DependencyNotReadyError`, we keep going with the
@@ -103,7 +103,7 @@ func (e *DependencyNotReadyError) DebugString() string {
 	}
 
 	ret.WriteString(indent)
-	ret.WriteString(fmt.Sprintf("- Because %v", leafError))
+	ret.WriteString(fmt.Sprintf("- Because %q", leafError))
 
 	return ret.String()
 }

--- a/resource/resource_registry_test.go
+++ b/resource/resource_registry_test.go
@@ -320,8 +320,8 @@ func TestDependencyNotReadyError(t *testing.T) {
 
 	test.That(t, strings.Count(human.Error(), "\\"), test.ShouldEqual, 0)
 	test.That(t, human.DebugString(), test.ShouldEqual, `Dependency "human" is not ready yet
-  - Because leg is not ready yet
-    - Because foot is not ready yet
-      - Because toe is not ready yet
-        - Because turf toe`)
+  - Because "leg" is not ready yet
+    - Because "foot" is not ready yet
+      - Because "toe" is not ready yet
+        - Because "turf toe"`)
 }

--- a/resource/resource_registry_test.go
+++ b/resource/resource_registry_test.go
@@ -319,7 +319,7 @@ func TestDependencyNotReadyError(t *testing.T) {
 	human := &resource.DependencyNotReadyError{"human", leg}
 
 	test.That(t, strings.Count(human.Error(), "\\"), test.ShouldEqual, 0)
-	test.That(t, human.DebugString(), test.ShouldEqual, `Dependency "human" is not ready yet
+	test.That(t, human.PrettyPrint(), test.ShouldEqual, `Dependency "human" is not ready yet
   - Because "leg" is not ready yet
     - Because "foot" is not ready yet
       - Because "toe" is not ready yet

--- a/resource/resource_registry_test.go
+++ b/resource/resource_registry_test.go
@@ -3,6 +3,7 @@ package resource_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/edaniels/golog"
@@ -309,4 +310,18 @@ func TestTransformAttributeMap(t *testing.T) {
 			"e": 5,
 		},
 	})
+}
+
+func TestDependencyNotReadyError(t *testing.T) {
+	toe := &resource.DependencyNotReadyError{"toe", errors.New("turf toe")}
+	foot := &resource.DependencyNotReadyError{"foot", toe}
+	leg := &resource.DependencyNotReadyError{"leg", foot}
+	human := &resource.DependencyNotReadyError{"human", leg}
+
+	test.That(t, strings.Count(human.Error(), "\\"), test.ShouldEqual, 0)
+	test.That(t, human.DebugString(), test.ShouldEqual, `Dependency "human" is not ready yet
+  - Because leg is not ready yet
+    - Because foot is not ready yet
+      - Because toe is not ready yet
+        - Because turf toe`)
 }


### PR DESCRIPTION
Provide a starting point for more structured dependency reporting.