### PR TITLE
RSDK-4193: New logic for GetLatestMapInfo

### DIFF
--- a/services/slam/fake/slam.go
+++ b/services/slam/fake/slam.go
@@ -77,7 +77,6 @@ func (slamSvc *SLAM) GetPointCloudMap(ctx context.Context) (func() ([]byte, erro
 	ctx, span := trace.StartSpan(ctx, "slam::fake::GetPointCloudMap")
 	defer span.End()
 	slamSvc.incrementDataCount()
-	slamSvc.mapTimestamp = time.Now().UTC()
 	return fakeGetPointCloudMap(ctx, datasetDirectory, slamSvc)
 }
 
@@ -89,10 +88,12 @@ func (slamSvc *SLAM) GetInternalState(ctx context.Context) (func() ([]byte, erro
 	return fakeGetInternalState(ctx, datasetDirectory, slamSvc)
 }
 
-// GetLatestMapInfo returns a message indicating details regarding the latest map returned to the system.
+// GetLatestMapInfo returns information used to determine whether the slam mode is localizing.
+// Fake Slam is always in mapping mode, so it always returns a new timestamp.
 func (slamSvc *SLAM) GetLatestMapInfo(ctx context.Context) (time.Time, error) {
 	_, span := trace.StartSpan(ctx, "slam::fake::GetLatestMapInfo")
 	defer span.End()
+	slamSvc.mapTimestamp = time.Now().UTC()
 	return slamSvc.mapTimestamp, nil
 }
 

--- a/services/slam/fake/slam_test.go
+++ b/services/slam/fake/slam_test.go
@@ -47,15 +47,10 @@ func TestFakeSLAMGetLatestMapInfo(t *testing.T) {
 
 	timestamp1, err := slamSvc.GetLatestMapInfo(context.Background())
 	test.That(t, err, test.ShouldBeNil)
+
 	timestamp2, err := slamSvc.GetLatestMapInfo(context.Background())
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, timestamp1, test.ShouldResemble, timestamp2)
-
-	_, err = slamSvc.GetPointCloudMap(context.Background())
-	test.That(t, err, test.ShouldBeNil)
-	timestamp3, err := slamSvc.GetLatestMapInfo(context.Background())
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, timestamp3.After(timestamp2), test.ShouldBeTrue)
+	test.That(t, timestamp2.After(timestamp1), test.ShouldBeTrue)
 }
 
 func TestFakeSLAMStateful(t *testing.T) {

--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -73,7 +73,6 @@ const refresh2d = async () => {
      * to see if a change has been made to the pointcloud map.
      * A new call to getPointCloudMap is made if an update has occured.
      */
-
     if (localizationMode(mapTimestamp)) {
       nextPose = await getPosition($robotClient, name);
     } else {

--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -53,7 +53,7 @@ const deleteDestinationMarker = () => {
   destination = undefined;
 };
 
-const localizationMode = (mapTimestamp) => {
+const localizationMode = (mapTimestamp: Timestamp | undefined) => {
   if (mapTimestamp === undefined) {
     return false
   }

--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -65,9 +65,14 @@ const refresh2d = async () => {
      * A new call to getPointCloudMap is made if an update has occured.
      */
 
-    if (mapTimestamp?.getSeconds() > lastTimestamp.getSeconds() ||
-    (mapTimestamp?.getSeconds() === lastTimestamp.getSeconds() && mapTimestamp?.getNanos() > lastTimestamp.getNanos())) {
-      nextPose = await getPosition($robotClient, name);
+    const seconds = mapTimestamp?.getSeconds()
+    const nanos = mapTimestamp?.getNanos()
+
+    if (seconds !== undefined && nanos !== undefined) {
+      if (seconds > lastTimestamp.getSeconds() ||
+      (seconds === lastTimestamp.getSeconds() && nanos > lastTimestamp.getNanos())) {
+        pointcloud = await getPointCloudMap($robotClient, name);
+      }
     } else {
       [pointcloud, nextPose] = await Promise.all([
         getPointCloudMap($robotClient, name),
@@ -102,9 +107,16 @@ const refresh3d = async () => {
      * to see if a change has been made to the pointcloud map.
      * A new call to getPointCloudMap is made if an update has occured.
      */
-    if (mapTimestamp?.getSeconds() !== lastTimestamp.getSeconds()) {
-      pointcloud = await getPointCloudMap($robotClient, name);
+    const seconds = mapTimestamp?.getSeconds()
+    const nanos = mapTimestamp?.getNanos()
+
+    if (seconds !== undefined && nanos !== undefined) {
+      if (seconds > lastTimestamp.getSeconds() ||
+      (seconds === lastTimestamp.getSeconds() && nanos > lastTimestamp.getNanos())) {
+        pointcloud = await getPointCloudMap($robotClient, name);
+      }
     }
+
     if (mapTimestamp) {
       lastTimestamp = mapTimestamp;
     }

--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -55,12 +55,12 @@ const deleteDestinationMarker = () => {
 
 const localizationMode = (mapTimestamp: Timestamp | undefined) => {
   if (mapTimestamp === undefined) {
-    return false
+    return false;
   }
-  const seconds = mapTimestamp.getSeconds()
-  const nanos = mapTimestamp.getNanos()
-  return seconds === lastTimestamp.getSeconds() && nanos === lastTimestamp.getNanos()
-}
+  const seconds = mapTimestamp.getSeconds();
+  const nanos = mapTimestamp.getNanos();
+  return seconds === lastTimestamp.getSeconds() && nanos === lastTimestamp.getNanos();
+};
 
 const refresh2d = async () => {
 
@@ -110,10 +110,10 @@ const refresh3d = async () => {
      * to see if a change has been made to the pointcloud map.
      * A new call to getPointCloudMap is made if an update has occured.
      */
-     
-     if (!localizationMode(mapTimestamp)) {
+
+    if (!localizationMode(mapTimestamp)) {
       pointcloud = await getPointCloudMap($robotClient, name);
-    } 
+    }
     if (mapTimestamp) {
       lastTimestamp = mapTimestamp;
     }

--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -53,8 +53,8 @@ const deleteDestinationMarker = () => {
   destination = undefined;
 };
 
-const localizationMode = (mapTimestamp: { getSeconds: () => any; getNanos: () => any; } | undefined) => {
-  if (mapTimestamp == undefined) {
+const localizationMode = (mapTimestamp) => {
+  if (mapTimestamp === undefined) {
     return false
   }
   const seconds = mapTimestamp.getSeconds()

--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -65,6 +65,8 @@ const refresh2d = async () => {
      * A new call to getPointCloudMap is made if an update has occured.
      */
     if (mapTimestamp?.getSeconds() === lastTimestamp.getSeconds()) {
+    if (mapTimestamp?.getSeconds() > lastTimestamp.getSeconds() ||
+    (mapTimestamp?.getSeconds() === lastTimestamp.getSeconds() && mapTimestamp?.getNanos() > lastTimestamp.getNanos())) {
       nextPose = await getPosition($robotClient, name);
     } else {
       [pointcloud, nextPose] = await Promise.all([

--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -64,7 +64,7 @@ const refresh2d = async () => {
      * to see if a change has been made to the pointcloud map.
      * A new call to getPointCloudMap is made if an update has occured.
      */
-    if (mapTimestamp?.getSeconds() === lastTimestamp.getSeconds()) {
+
     if (mapTimestamp?.getSeconds() > lastTimestamp.getSeconds() ||
     (mapTimestamp?.getSeconds() === lastTimestamp.getSeconds() && mapTimestamp?.getNanos() > lastTimestamp.getNanos())) {
       nextPose = await getPosition($robotClient, name);

--- a/web/frontend/tsconfig.json
+++ b/web/frontend/tsconfig.json
@@ -11,7 +11,6 @@
 
     "noPropertyAccessFromIndexSignature": false,
     "exactOptionalPropertyTypes": false,
-    "noImplicitAny": false,
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 }

--- a/web/frontend/tsconfig.json
+++ b/web/frontend/tsconfig.json
@@ -11,6 +11,7 @@
 
     "noPropertyAccessFromIndexSignature": false,
     "exactOptionalPropertyTypes": false,
+    "noImplicitAny": false,
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 }


### PR DESCRIPTION
The current granularity of the comparison between the most recent and previous map timestamps is on the order of seconds, which means that any users who presses the map refresh more than once in the same second will inadvertently induce localizing mode. 
This PR reduces the granularity to nanosecond level. 

It also changes the logic used in fake slam to determine whether the session is in localizing or mapping mode. Instead of updating the timestamp in the GetPointCloud function when not in localizing, the timestamp will be updated within getLatestMapInfo. A similar change will be made to viam-cartographer.