### PR TITLE
[RSDK-4296] sleep to avoid race condition in odroid's sysfs implementation

### DIFF
--- a/components/board/genericlinux/hw_pwm.go
+++ b/components/board/genericlinux/hw_pwm.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/edaniels/golog"
 	"github.com/pkg/errors"
@@ -87,6 +88,11 @@ func (pwm *pwmDevice) unexport() error {
 	// device results in an error. We don't care if there's an error: it should be disabled no
 	// matter what.
 	goutils.UncheckedError(pwm.disable())
+
+	// On boards like the Odroid C4, there is a race condition in the kernel where, if you unexport
+	// the pin too quickly after changing something else about it (e.g., disabling it), the whole
+	// PWM system gets corrupted. Sleep for a small amount of time to avoid this.
+	time.Sleep(time.Microsecond)
 	if err := pwm.writeChip("unexport", uint64(pwm.line)); err != nil {
 		return err
 	}


### PR DESCRIPTION
Tried on an Odroid C4: without this, the kernel spews a bunch of errors and the whole process locks up (in a way that cannot be quit with control-C or backgrounded with control-Z, since it's stuck in kernelspace). With this, hardware PWM works normally.

I strongly dislike sleeping to avoid race conditions, but this one isn't easily fixable without a sleep, since it has to do with how quickly things are happening in kernel space and we don't have control over which kernel our users are running.

Should we make this configurable, so that non-Odroid users don't need to sleep? Part of me says "yes, that's the code that will run most efficiently," and part of me says "no, adding extra tunable features just makes stuff more complicated, and nobody will notice a spare microsecond when turning PWM off." What do others think?