### PR TITLE
RSDK-4274 context.Background for fake controller goroutine

### DIFF
--- a/components/input/fake/input.go
+++ b/components/input/fake/input.go
@@ -50,7 +50,7 @@ type callback struct {
 
 // NewInputController returns a fake input.Controller.
 func NewInputController(ctx context.Context, conf resource.Config) (input.Controller, error) {
-	closeCtx, cancelFunc := context.WithCancel(ctx)
+	closeCtx, cancelFunc := context.WithCancel(context.Background())
 
 	c := &InputController{
 		Named:      conf.ResourceName().AsNamed(),


### PR DESCRIPTION
RSDK-4274

Uses `context.Background` for the fake controller goroutine. Storing the constructor's context as the context controlling goroutines for any resource is an antipattern, as the background goroutine will stop as soon as construction is finished now that we cancel the context for (re)configuration due to RSDK-3667.