### PR TITLE
RSDK-4342 Fix Camera Client GetProperties error on empty Distortion model

### DIFF
--- a/components/camera/client.go
+++ b/components/camera/client.go
@@ -237,6 +237,9 @@ func (c *client) Properties(ctx context.Context) (Properties, error) {
 	if resp.DistortionParameters == nil {
 		return result, nil
 	}
+	if resp.DistortionParameters.Model == "" { // same as if nil
+		return result, nil
+	}
 	// switch distortion model based on model name
 	model := transform.DistortionType(resp.DistortionParameters.Model)
 	distorter, err := transform.NewDistorter(model, resp.DistortionParameters.Parameters)

--- a/rimage/transform/distorter.go
+++ b/rimage/transform/distorter.go
@@ -31,6 +31,6 @@ func NewDistorter(distortionType DistortionType, parameters []float64) (Distorte
 	case BrownConradyDistortionType:
 		return NewBrownConrady(parameters)
 	default:
-		return nil, errors.Errorf("do no know how to parse %q distortion model", distortionType)
+		return nil, errors.Errorf("do not know how to parse %q distortion model", distortionType)
 	}
 }


### PR DESCRIPTION
Distortion Models with name "" no longer cause a GRPC error that says, "no such distortion model"