### PR TITLE
RSDK-2010 Euler fix

### DIFF
--- a/spatialmath/quat_test.go
+++ b/spatialmath/quat_test.go
@@ -38,9 +38,9 @@ func TestEulerAnglesConversion(t *testing.T) {
 	// 	t.Skip()
 	// }
 
-	// gimbal lock edge case: pitch is π / 2
-	expectedEA := EulerAngles{math.Pi / 4.0, math.Pi / 2.0, math.Pi}
-	q := quat.Number{Real: 0.2705980500730985, Imag: -0.6532814824381882, Jmag: 0.27059805007309856, Kmag: 0.6532814824381883}
+	// roll pitch and yaw are not near edge cases
+	expectedEA := EulerAngles{math.Pi / 4.0, math.Pi / 4.0, 3.0 * math.Pi / 4.0}
+	q := quat.Number{Real: 0.4619397662556435, Imag: -0.19134171618254486, Jmag: 0.4619397662556434, Kmag: 0.7325378163287418}
 	endEa := QuatToEulerAngles(q)
 	test.That(t, expectedEA.Roll, test.ShouldAlmostEqual, endEa.Roll)
 	test.That(t, expectedEA.Pitch, test.ShouldAlmostEqual, endEa.Pitch)
@@ -48,8 +48,29 @@ func TestEulerAnglesConversion(t *testing.T) {
 	q2 := endEa.Quaternion()
 	quatCompare(t, q, q2)
 
-	expectedEA = EulerAngles{math.Pi / 4.0, math.Pi / 4.0, 3.0 * math.Pi / 4.0}
-	q = quat.Number{Real: 0.4619397662556435, Imag: -0.19134171618254486, Jmag: 0.4619397662556434, Kmag: 0.7325378163287418}
+	// another vanilla angles test
+	expectedEA = EulerAngles{-math.Pi / 4.0, -math.Pi / 4.0, math.Pi/4}
+	q = quat.Number{Real: 1, Imag: 0, Jmag: 0, Kmag: 0}
+	endEa = QuatToEulerAngles(q)
+	test.That(t, expectedEA.Roll, test.ShouldAlmostEqual, endEa.Roll)
+	test.That(t, expectedEA.Pitch, test.ShouldAlmostEqual, endEa.Pitch)
+	test.That(t, expectedEA.Yaw, test.ShouldAlmostEqual, endEa.Yaw)
+	q2 = endEa.Quaternion()
+	quatCompare(t, q, q2)
+
+	// gimbal lock edge case1: pitch is π / 2
+	expectedEA = EulerAngles{-3 * math.Pi / 4.0, math.Pi / 2.0, 0}
+	q = quat.Number{Real: 0.2705980500730985, Imag: -0.6532814824381882, Jmag: 0.27059805007309856, Kmag: 0.6532814824381883}
+	endEa = QuatToEulerAngles(q)
+	test.That(t, expectedEA.Roll, test.ShouldAlmostEqual, endEa.Roll)
+	test.That(t, expectedEA.Pitch, test.ShouldAlmostEqual, endEa.Pitch)
+	test.That(t, expectedEA.Yaw, test.ShouldAlmostEqual, endEa.Yaw)
+	q2 = endEa.Quaternion()
+	quatCompare(t, q, q2)
+
+	// gimbal lock edge case: pitch is π / 2
+	expectedEA = EulerAngles{math.Pi / 4.0, math.Pi / 2.0, math.Pi}
+	q = quat.Number{Real: 0.2705980500730985, Imag: -0.6532814824381882, Jmag: 0.27059805007309856, Kmag: 0.6532814824381883}
 	endEa = QuatToEulerAngles(q)
 	test.That(t, expectedEA.Roll, test.ShouldAlmostEqual, endEa.Roll)
 	test.That(t, expectedEA.Pitch, test.ShouldAlmostEqual, endEa.Pitch)

--- a/spatialmath/quat_test.go
+++ b/spatialmath/quat_test.go
@@ -38,11 +38,6 @@ func TestEulerAnglesConversion(t *testing.T) {
 		q          quat.Number
 	}{
 		{
-			"gimbal lock 1: pitch is π/2",
-			EulerAngles{math.Pi / 4.0, math.Pi / 2.0, math.Pi},
-			quat.Number{Real: 0.27059808647933425, Imag: 0.6532814673582304, Jmag: 0.2705980864793342, Kmag: 0.6532814673582303},
-		},
-		{
 			"vanilla 1: roll pitch and yaw are not near edge cases",
 			EulerAngles{math.Pi / 4.0, math.Pi / 4.0, 3.0 * math.Pi / 4.0},
 			quat.Number{Real: 0.46193978734586505, Imag: -0.19134171618254486, Jmag: 0.4619397662556434, Kmag: 0.7325378046916491},

--- a/spatialmath/quat_test.go
+++ b/spatialmath/quat_test.go
@@ -2,7 +2,6 @@ package spatialmath
 
 import (
 	"math"
-	"runtime"
 	"testing"
 
 	"github.com/golang/geo/r3"
@@ -35,9 +34,9 @@ func TestAngleAxisConversion2(t *testing.T) {
 func TestEulerAnglesConversion(t *testing.T) {
 	// TODO RSDK-2010 (rh) handle edge cases properly while
 	// maintaining quadrant in euler conversions
-	if runtime.GOARCH == "arm64" {
-		t.Skip()
-	}
+	// if runtime.GOARCH == "arm64" {
+	// 	t.Skip()
+	// }
 
 	// gimbal lock edge case: pitch is π / 2
 	expectedEA := EulerAngles{math.Pi / 4.0, math.Pi / 2.0, math.Pi}

--- a/spatialmath/quaternion.go
+++ b/spatialmath/quaternion.go
@@ -51,14 +51,14 @@ func QuatToEulerAngles(q quat.Number) *EulerAngles {
 
 	// yaw (z-axis rotation)
 	sinyCosp := 2.0 * (q.Real*q.Kmag + q.Imag*q.Jmag)
-	// if math.Abs(sinyCosp) < 1e-8 {
-	// sinyCosp = 0
-	// }
+	if math.Abs(sinyCosp) < 1e-8 {
+		sinyCosp = 0
+	}
 
 	cosyCosp := 1.0 - 2.0*(q.Jmag*q.Jmag+q.Kmag*q.Kmag)
-	// if math.Abs(cosyCosp) < 1e-8 {
-	// cosyCosp = 0
-	// }
+	if math.Abs(cosyCosp) < 1e-8 {
+		cosyCosp = 0
+	}
 
 	angles.Yaw = math.Atan2(sinyCosp, cosyCosp)
 

--- a/spatialmath/quaternion.go
+++ b/spatialmath/quaternion.go
@@ -51,12 +51,12 @@ func QuatToEulerAngles(q quat.Number) *EulerAngles {
 
 	// yaw (z-axis rotation)
 	sinyCosp := 2.0 * (q.Real*q.Kmag + q.Imag*q.Jmag)
-	if math.Abs(sinyCosp) < 1e-8 {
+	if math.Abs(sinyCosp) < 1e-16 { // && runtime.GOARCH == "arm64"
 		sinyCosp = 0
 	}
 
 	cosyCosp := 1.0 - 2.0*(q.Jmag*q.Jmag+q.Kmag*q.Kmag)
-	if math.Abs(cosyCosp) < 1e-8 {
+	if math.Abs(cosyCosp) < 1e-16 { 
 		cosyCosp = 0
 	}
 

--- a/spatialmath/quaternion.go
+++ b/spatialmath/quaternion.go
@@ -51,7 +51,15 @@ func QuatToEulerAngles(q quat.Number) *EulerAngles {
 
 	// yaw (z-axis rotation)
 	sinyCosp := 2.0 * (q.Real*q.Kmag + q.Imag*q.Jmag)
+	// if math.Abs(sinyCosp) < 1e-8 {
+	// sinyCosp = 0
+	// }
+
 	cosyCosp := 1.0 - 2.0*(q.Jmag*q.Jmag+q.Kmag*q.Kmag)
+	// if math.Abs(cosyCosp) < 1e-8 {
+	// cosyCosp = 0
+	// }
+
 	angles.Yaw = math.Atan2(sinyCosp, cosyCosp)
 
 	// for a pitch that is π / 2, we experience gimbal lock

--- a/spatialmath/quaternion.go
+++ b/spatialmath/quaternion.go
@@ -51,12 +51,12 @@ func QuatToEulerAngles(q quat.Number) *EulerAngles {
 
 	// yaw (z-axis rotation)
 	sinyCosp := 2.0 * (q.Real*q.Kmag + q.Imag*q.Jmag)
-	if math.Abs(sinyCosp) < 1e-16 { // && runtime.GOARCH == "arm64"
+	if math.Abs(sinyCosp) < 1e-12 { // && runtime.GOARCH == "arm64"
 		sinyCosp = 0
 	}
 
 	cosyCosp := 1.0 - 2.0*(q.Jmag*q.Jmag+q.Kmag*q.Kmag)
-	if math.Abs(cosyCosp) < 1e-16 { 
+	if math.Abs(cosyCosp) < 1e-12 {
 		cosyCosp = 0
 	}
 


### PR DESCRIPTION
Got around to writing more tests with the proposed fix. There were discrepancies in amd64 and arm64 and some failing cases on both - the "vanilla" case isn't well-named since it produces near zero trigonometric product.

Things discovered:
- There is always a discrepancy between the two conversion functions, very often numerical, and is handled by the 1e-6 epsilon comparison in the test.
- The happy clamping factor seems to be 1e-12 rather than 1e-16 in `quaternion.go`.  Right now, two tests are failing because it is finding equivalent angles and trying to compare them in one or more axes.
- Should we edit the tests and the conversion function further to prefer 0 to Pi results? I'm indifferent here - I feel like functionally, we'll be going one way (quaternion -> euler, or quaternion -> orientationvector -> euler) rather than comparing two avenues of conversion, and as long as that's stable for heading in the near future, we may be okay.

- [x] Need to test with an imu live when I get back to new york, log behaviour with and without the clamping to zero. Compare with raw readings from the imu in the log as well.