### PR TITLE
RSDK-4246 Add collectors to power sensor

### DIFF
--- a/components/powersensor/collectors.go
+++ b/components/powersensor/collectors.go
@@ -23,13 +23,13 @@ func registerCollector(name string, f lowLevelCollector) {
 		API:        API,
 		MethodName: name,
 	}, func(resource interface{}, params data.CollectorParams) (data.Collector, error) {
-		ms, err := assertPowerSensor(resource)
+		ps, err := assertPowerSensor(resource)
 		if err != nil {
 			return nil, err
 		}
 
 		cFunc := data.CaptureFunc(func(ctx context.Context, extra map[string]*anypb.Any) (interface{}, error) {
-			v, err := f(ctx, ms)
+			v, err := f(ctx, ps)
 			if err != nil {
 				return nil, data.FailedToReadErr(params.ComponentName, name, err)
 			}

--- a/components/powersensor/collectors.go
+++ b/components/powersensor/collectors.go
@@ -1,0 +1,41 @@
+package powersensor
+
+import (
+	"context"
+
+	"google.golang.org/protobuf/types/known/anypb"
+
+	"go.viam.com/rdk/data"
+)
+
+func assertPowerSensor(resource interface{}) (PowerSensor, error) {
+	ps, ok := resource.(PowerSensor)
+	if !ok {
+		return nil, data.InvalidInterfaceErr(API)
+	}
+	return ps, nil
+}
+
+type lowLevelCollector func(ctx context.Context, ps PowerSensor) (interface{}, error)
+
+func registerCollector(name string, f lowLevelCollector) {
+	data.RegisterCollector(data.MethodMetadata{
+		API:        API,
+		MethodName: name,
+	}, func(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+		ms, err := assertPowerSensor(resource)
+		if err != nil {
+			return nil, err
+		}
+
+		cFunc := data.CaptureFunc(func(ctx context.Context, extra map[string]*anypb.Any) (interface{}, error) {
+			v, err := f(ctx, ms)
+			if err != nil {
+				return nil, data.FailedToReadErr(params.ComponentName, name, err)
+			}
+			return v, nil
+		})
+		return data.NewCollector(cFunc, params)
+	},
+	)
+}

--- a/components/powersensor/fake/powersensor.go
+++ b/components/powersensor/fake/powersensor.go
@@ -28,12 +28,12 @@ func init() {
 				conf resource.Config,
 				logger golog.Logger,
 			) (powersensor.PowerSensor, error) {
-				return newFakePowerSensorModel(ctx, conf, logger)
+				return newFakePowerSensorModel(conf, logger)
 			},
 		})
 }
 
-func newFakePowerSensorModel(ctx context.Context, conf resource.Config, logger golog.Logger) (powersensor.PowerSensor, error) {
+func newFakePowerSensorModel(conf resource.Config, logger golog.Logger) (powersensor.PowerSensor, error) {
 	return powersensor.PowerSensor(&PowerSensor{
 		Named:  conf.ResourceName().AsNamed(),
 		logger: logger,

--- a/components/powersensor/fake/powersensor.go
+++ b/components/powersensor/fake/powersensor.go
@@ -22,18 +22,12 @@ func init() {
 		powersensor.API,
 		model,
 		resource.Registration[powersensor.PowerSensor, *Config]{
-			Constructor: func(
-				ctx context.Context,
-				deps resource.Dependencies,
-				conf resource.Config,
-				logger golog.Logger,
-			) (powersensor.PowerSensor, error) {
-				return newFakePowerSensorModel(conf, logger)
-			},
+			Constructor: newFakePowerSensorModel,
 		})
 }
 
-func newFakePowerSensorModel(conf resource.Config, logger golog.Logger) (powersensor.PowerSensor, error) {
+func newFakePowerSensorModel(_ context.Context, _ resource.Dependencies, conf resource.Config, logger golog.Logger,
+) (powersensor.PowerSensor, error) {
 	return powersensor.PowerSensor(&PowerSensor{
 		Named:  conf.ResourceName().AsNamed(),
 		logger: logger,

--- a/components/powersensor/fake/powersensor.go
+++ b/components/powersensor/fake/powersensor.go
@@ -1,0 +1,76 @@
+// Package fake is a fake PowerSensor for testing
+package fake
+
+import (
+	"context"
+
+	"github.com/edaniels/golog"
+
+	"go.viam.com/rdk/components/powersensor"
+	"go.viam.com/rdk/resource"
+)
+
+var model = resource.DefaultModelFamily.WithModel("fake")
+
+// Config is used for converting fake movementsensor attributes.
+type Config struct {
+	resource.TriviallyValidateConfig
+	ConnectionType string `json:"connection_type,omitempty"`
+}
+
+func init() {
+	resource.RegisterComponent(
+		powersensor.API,
+		model,
+		resource.Registration[powersensor.PowerSensor, *Config]{
+			Constructor: func(
+				ctx context.Context,
+				deps resource.Dependencies,
+				conf resource.Config,
+				logger golog.Logger,
+			) (powersensor.PowerSensor, error) {
+				return powersensor.PowerSensor(&PowerSensor{
+					Named: conf.ResourceName().AsNamed(),
+				}), nil
+			},
+		})
+}
+
+// PowerSensor implements a fake PowerSensor interface.
+type PowerSensor struct {
+	resource.Named
+	resource.AlwaysRebuild
+}
+
+// DoCommand uses a map string to run custom functionality of a fake powersensor.
+func (f *PowerSensor) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+	return map[string]interface{}{}, nil
+}
+
+// Voltage gets the voltage and isAC of a fake powersensor.
+func (f *PowerSensor) Voltage(ctx context.Context, cmd map[string]interface{}) (float64, bool, error) {
+	return 1, true, nil
+}
+
+// Current gets the current and isAC of a fake powersensor.
+func (f *PowerSensor) Current(ctx context.Context, cmd map[string]interface{}) (float64, bool, error) {
+	return 2.2, true, nil
+}
+
+// Power gets the power of a fake powersensor.
+func (f *PowerSensor) Power(ctx context.Context, cmd map[string]interface{}) (float64, error) {
+	return 9.8, nil
+}
+
+// Readings gets the readings of a fake powersensor.
+func (f *PowerSensor) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+	return powersensor.Readings(ctx, f, extra)
+}
+
+// Start starts the fake powersensor.
+func (f *PowerSensor) Start(ctx context.Context) error { return nil }
+
+// Close closes the fake powersensor.
+func (f *PowerSensor) Close(ctx context.Context) error {
+	return nil
+}

--- a/components/powersensor/fake/powersensor.go
+++ b/components/powersensor/fake/powersensor.go
@@ -15,7 +15,6 @@ var model = resource.DefaultModelFamily.WithModel("fake")
 // Config is used for converting fake movementsensor attributes.
 type Config struct {
 	resource.TriviallyValidateConfig
-	ConnectionType string `json:"connection_type,omitempty"`
 }
 
 func init() {
@@ -29,17 +28,23 @@ func init() {
 				conf resource.Config,
 				logger golog.Logger,
 			) (powersensor.PowerSensor, error) {
-				return powersensor.PowerSensor(&PowerSensor{
-					Named: conf.ResourceName().AsNamed(),
-				}), nil
+				return newFakePowerSensorModel(ctx, conf, logger)
 			},
 		})
+}
+
+func newFakePowerSensorModel(ctx context.Context, conf resource.Config, logger golog.Logger) (powersensor.PowerSensor, error) {
+	return powersensor.PowerSensor(&PowerSensor{
+		Named:  conf.ResourceName().AsNamed(),
+		logger: logger,
+	}), nil
 }
 
 // PowerSensor implements a fake PowerSensor interface.
 type PowerSensor struct {
 	resource.Named
 	resource.AlwaysRebuild
+	logger golog.Logger
 }
 
 // DoCommand uses a map string to run custom functionality of a fake powersensor.
@@ -49,7 +54,7 @@ func (f *PowerSensor) DoCommand(ctx context.Context, cmd map[string]interface{})
 
 // Voltage gets the voltage and isAC of a fake powersensor.
 func (f *PowerSensor) Voltage(ctx context.Context, cmd map[string]interface{}) (float64, bool, error) {
-	return 1, true, nil
+	return 1.5, true, nil
 }
 
 // Current gets the current and isAC of a fake powersensor.
@@ -66,9 +71,6 @@ func (f *PowerSensor) Power(ctx context.Context, cmd map[string]interface{}) (fl
 func (f *PowerSensor) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
 	return powersensor.Readings(ctx, f, extra)
 }
-
-// Start starts the fake powersensor.
-func (f *PowerSensor) Start(ctx context.Context) error { return nil }
 
 // Close closes the fake powersensor.
 func (f *PowerSensor) Close(ctx context.Context) error {

--- a/components/powersensor/powersensor.go
+++ b/components/powersensor/powersensor.go
@@ -19,6 +19,42 @@ func init() {
 		RPCServiceDesc:              &pb.PowerSensorService_ServiceDesc,
 		RPCClient:                   NewClientFromConn,
 	})
+
+	registerCollector("Voltage", func(ctx context.Context, ps PowerSensor) (interface{}, error) {
+		type Voltage struct {
+			Volts float64
+			IsAc  bool
+		}
+		v, ac, err := ps.Voltage(ctx, make(map[string]interface{}))
+		if err != nil {
+			return nil, err
+		}
+
+		return Voltage{Volts: v, IsAc: ac}, nil
+	})
+
+	registerCollector("Current", func(ctx context.Context, ps PowerSensor) (interface{}, error) {
+		type Current struct {
+			Amperes float64
+			IsAc    bool
+		}
+		c, ac, err := ps.Current(ctx, make(map[string]interface{}))
+		if err != nil {
+			return nil, err
+		}
+		return Current{Amperes: c, IsAc: ac}, nil
+	})
+
+	registerCollector("Power", func(ctx context.Context, ps PowerSensor) (interface{}, error) {
+		type Power struct {
+			Watts float64
+		}
+		p, err := ps.Power(ctx, make(map[string]interface{}))
+		if err != nil {
+			return nil, err
+		}
+		return Power{Watts: p}, nil
+	})
 }
 
 // SubtypeName is a constant that identifies the component resource API string "power_sensor".

--- a/components/powersensor/register/register.go
+++ b/components/powersensor/register/register.go
@@ -1,0 +1,7 @@
+// Package register registers all relevant motors
+package register
+
+import (
+	// register all powersensors.
+	_ "go.viam.com/rdk/components/powersensor/fake"
+)

--- a/components/register/all.go
+++ b/components/register/all.go
@@ -15,8 +15,10 @@ import (
 	_ "go.viam.com/rdk/components/input/register"
 	_ "go.viam.com/rdk/components/motor/register"
 	_ "go.viam.com/rdk/components/movementsensor/register"
+
 	// register APIs without implementations directly.
 	_ "go.viam.com/rdk/components/posetracker"
+	_ "go.viam.com/rdk/components/powersensor/register"
 	_ "go.viam.com/rdk/components/sensor/register"
 	_ "go.viam.com/rdk/components/servo/register"
 )

--- a/components/register/all.go
+++ b/components/register/all.go
@@ -15,7 +15,6 @@ import (
 	_ "go.viam.com/rdk/components/input/register"
 	_ "go.viam.com/rdk/components/motor/register"
 	_ "go.viam.com/rdk/components/movementsensor/register"
-
 	// register APIs without implementations directly.
 	_ "go.viam.com/rdk/components/posetracker"
 	_ "go.viam.com/rdk/components/powersensor/register"

--- a/etc/configs/fake.json
+++ b/etc/configs/fake.json
@@ -97,7 +97,11 @@
             "type": "movement_sensor",
             "model": "fake"
         },
-        
+        {
+            "name": "power_sensor1",
+            "type": "power_sensor",
+            "model": "fake"
+        },
         {
             "name": "sensor1",
             "type": "sensor",

--- a/web/server/entrypoint_test.go
+++ b/web/server/entrypoint_test.go
@@ -20,7 +20,7 @@ import (
 
 // numResources is the # of resources in /etc/configs/fake.json + the 2
 // expected builtin resources.
-const numResources = 19
+const numResources = 20
 
 func TestNumResources(t *testing.T) {
 	logger := golog.NewTestLogger(t)


### PR DESCRIPTION
### Summary
Adds collectors to capture voltage, current and power on the powersensor component. 

### Testing
Tested with fake power sensor and confirmed it was capturing data for all 3 functions. 