### PR TITLE
Preliminary work on RSDK-4092: get a single config for genericlinux and customlinux

### DIFF
--- a/components/board/customlinux/board.go
+++ b/components/board/customlinux/board.go
@@ -45,7 +45,7 @@ func createNewBoard(
 
 // This is a ConfigConverter which loads pin definitions from a file, assuming that the config
 // passed in is a customlinux.Config underneath.
-func pinDefsFromFile(conf resource.Config) (*genericlinux.UnderlyingConfig, error) {
+func pinDefsFromFile(conf resource.Config) (*genericlinux.LinuxBoardConfig, error) {
 	newConf, err := resource.NativeConfig[*Config](conf)
 	if err != nil {
 		return nil, err
@@ -61,7 +61,7 @@ func pinDefsFromFile(conf resource.Config) (*genericlinux.UnderlyingConfig, erro
 		return nil, err
 	}
 
-	return &genericlinux.UnderlyingConfig{
+	return &genericlinux.LinuxBoardConfig{
 		I2Cs:              newConf.I2Cs,
 		SPIs:              newConf.SPIs,
 		Analogs:           newConf.Analogs,

--- a/components/board/customlinux/board.go
+++ b/components/board/customlinux/board.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 
 	"github.com/edaniels/golog"
-	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 	"periph.io/x/host/v3"
 
@@ -41,7 +40,7 @@ func createNewBoard(
 	conf resource.Config,
 	logger golog.Logger,
 ) (board.Board, error) {
-	return genericlinux.newBoard(ctx, conf, pinDefsFromFile, logger)
+	return genericlinux.NewBoard(ctx, conf, pinDefsFromFile, logger)
 }
 
 // This is a ConfigConverter which loads pin definitions from a file, assuming that the config

--- a/components/board/customlinux/board.go
+++ b/components/board/customlinux/board.go
@@ -35,12 +35,6 @@ func init() {
 		})
 }
 
-// customLinuxBoard wraps the genericlinux board type so that both can implement their own Reconfigure function.
-type customLinuxBoard struct {
-	*genericlinux.SysfsBoard
-	logger golog.Logger
-}
-
 func createNewBoard(
 	ctx context.Context,
 	_ resource.Dependencies,
@@ -110,22 +104,4 @@ func createGenericLinuxConfig(conf *Config) genericlinux.Config {
 		Analogs:           conf.Analogs,
 		DigitalInterrupts: conf.DigitalInterrupts,
 	}
-}
-
-// Reconfigure reconfigures the board with interrupt pins, spi and i2c, and analogs.
-// WARNING: does not update pin definitions when the config file changes.
-// TODO[RSDK-4092]: implement reconfiguration when pin definitions change.
-func (b *customLinuxBoard) Reconfigure(
-	ctx context.Context,
-	_ resource.Dependencies,
-	conf resource.Config,
-) error {
-	newConf, err := resource.NativeConfig[*Config](conf)
-	if err != nil {
-		return err
-	}
-
-	boardConfig := createGenericLinuxConfig(newConf)
-
-	return b.ReconfigureParsedConfig(ctx, &boardConfig)
 }

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -40,6 +40,7 @@ func RegisterBoard(modelName string, gpioMappings map[string]GPIOBoardMapping) {
 		})
 }
 
+// NewBoard is the constructor for a SysfsBoard.
 func NewBoard(
 	ctx context.Context,
 	conf resource.Config,

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -35,12 +35,12 @@ func RegisterBoard(modelName string, gpioMappings map[string]GPIOBoardMapping) {
 				conf resource.Config,
 				logger golog.Logger,
 			) (board.Board, error) {
-				return newBoard(ctx, conf, ConstPinDefs(gpioMappings), logger)
+				return NewBoard(ctx, conf, ConstPinDefs(gpioMappings), logger)
 			},
 		})
 }
 
-func newBoard(
+func NewBoard(
 	ctx context.Context,
 	conf resource.Config,
 	convertConfig ConfigConverter,

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -118,8 +118,10 @@ func (b *SysfsBoard) ReconfigureParsedConfig(ctx context.Context, conf Underlyin
 }
 
 func (b *SysfsBoard) reconfigureGpios(newConf UnderlyingConfig) error {
-	// TODO(RSDK-4092): do this correctly.
-	b.gpioMappings = newConf.GpioMappings
+	// TODO(RSDK-4092): implement this correctly.
+	if len(b.gpioMappings) == 0 {
+		b.gpioMappings = newConf.GpioMappings
+	}
 	return nil
 }
 

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -51,7 +51,7 @@ func newBoard(
 		return nil, err
 	}
 
-	b, err := NewSysfsBoard(ctx, conf.ResourceName().AsNamed(), newConf, convertConfig, logger)
+	b, err := NewSysfsBoard(ctx, conf.ResourceName().AsNamed(), *newConf, convertConfig, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func (b *SysfsBoard) Reconfigure(
 		return err
 	}
 
-	return b.ReconfigureParsedConfig(ctx, newConf)
+	return b.ReconfigureParsedConfig(ctx, *newConf)
 }
 
 // ReconfigureParsedConfig is a public helper that should only be used

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -96,7 +96,7 @@ func (b *SysfsBoard) Reconfigure(
 
 // ReconfigureParsedConfig is a public helper that should only be used
 // by the customlinux package.
-func (b *SysfsBoard) ReconfigureParsedConfig(ctx context.Context, conf UnderlyingConfig) error {
+func (b *SysfsBoard) ReconfigureParsedConfig(ctx context.Context, conf LinuxBoardConfig) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -118,7 +118,7 @@ func (b *SysfsBoard) ReconfigureParsedConfig(ctx context.Context, conf Underlyin
 	return nil
 }
 
-func (b *SysfsBoard) reconfigureGpios(newConf UnderlyingConfig) error {
+func (b *SysfsBoard) reconfigureGpios(newConf LinuxBoardConfig) error {
 	// TODO(RSDK-4092): implement this correctly.
 	if len(b.gpioMappings) == 0 {
 		b.gpioMappings = newConf.GpioMappings
@@ -128,7 +128,7 @@ func (b *SysfsBoard) reconfigureGpios(newConf UnderlyingConfig) error {
 
 // This never returns errors, but we give it the same function signature as the other
 // reconfiguration helpers for consistency.
-func (b *SysfsBoard) reconfigureSpis(newConf UnderlyingConfig) error {
+func (b *SysfsBoard) reconfigureSpis(newConf LinuxBoardConfig) error {
 	stillExists := map[string]struct{}{}
 	for _, c := range newConf.SPIs {
 		stillExists[c.Name] = struct{}{}
@@ -151,7 +151,7 @@ func (b *SysfsBoard) reconfigureSpis(newConf UnderlyingConfig) error {
 	return nil
 }
 
-func (b *SysfsBoard) reconfigureI2cs(newConf UnderlyingConfig) error {
+func (b *SysfsBoard) reconfigureI2cs(newConf LinuxBoardConfig) error {
 	stillExists := map[string]struct{}{}
 	for _, c := range newConf.I2Cs {
 		stillExists[c.Name] = struct{}{}
@@ -186,7 +186,7 @@ func (b *SysfsBoard) reconfigureI2cs(newConf UnderlyingConfig) error {
 	return nil
 }
 
-func (b *SysfsBoard) reconfigureAnalogs(ctx context.Context, newConf UnderlyingConfig) error {
+func (b *SysfsBoard) reconfigureAnalogs(ctx context.Context, newConf LinuxBoardConfig) error {
 	stillExists := map[string]struct{}{}
 	for _, c := range newConf.Analogs {
 		channel, err := strconv.Atoi(c.Pin)
@@ -251,7 +251,7 @@ func findNewDigIntConfig(
 	return nil
 }
 
-func (b *SysfsBoard) reconfigureInterrupts(newConf UnderlyingConfig) error {
+func (b *SysfsBoard) reconfigureInterrupts(newConf LinuxBoardConfig) error {
 	// Any pin that already exists in the right configuration should just be copied over; closing
 	// and re-opening it risks losing its state.
 	newInterrupts := make(map[string]*digitalInterrupt, len(newConf.DigitalInterrupts))

--- a/components/board/genericlinux/config.go
+++ b/components/board/genericlinux/config.go
@@ -60,10 +60,10 @@ type UnderlyingConfig struct {
 // We'll use one of these to turn whatever config we get during reconfiguration into an
 // UnderlyingConfig, and then reconfigure based on that. We return a pointer to an UnderlyingConfig
 // instead of the struct itself so that we can return nil if we encounter an error.
-type ConfigConverter = func (resource.Config) (*UnderlyingConfig, error)
+type ConfigConverter = func(resource.Config) (*UnderlyingConfig, error)
 
 func ConstPinDefs(gpioMappings map[string]GPIOBoardMapping) ConfigConverter {
-	return func (conf resource.Config) (*UnderlyingConfig, error) {
+	return func(conf resource.Config) (*UnderlyingConfig, error) {
 		newConf, err := resource.NativeConfig[*Config](conf)
 		if err != nil {
 			return nil, err

--- a/components/board/genericlinux/config.go
+++ b/components/board/genericlinux/config.go
@@ -58,17 +58,18 @@ type UnderlyingConfig struct {
 }
 
 // We'll use one of these to turn whatever config we get during reconfiguration into an
-// UnderlyingConfig, and then reconfigure based on that.
-type ConfigConverter = func (resource.Config) (UnderlyingConfig, error)
+// UnderlyingConfig, and then reconfigure based on that. We return a pointer to an UnderlyingConfig
+// instead of the struct itself so that we can return nil if we encounter an error.
+type ConfigConverter = func (resource.Config) (*UnderlyingConfig, error)
 
 func ConstPinDefs(gpioMappings map[string]GPIOBoardMapping) ConfigConverter {
-	return func (conf resource.Config) (UnderlyingConfig, error) {
+	return func (conf resource.Config) (*UnderlyingConfig, error) {
 		newConf, err := resource.NativeConfig[*Config](conf)
 		if err != nil {
-			return UnderlyingConfig{}, err
+			return nil, err
 		}
 
-		return UnderlyingConfig{
+		return &UnderlyingConfig{
 			I2Cs:              newConf.I2Cs,
 			SPIs:              newConf.SPIs,
 			Analogs:           newConf.Analogs,

--- a/components/board/genericlinux/config.go
+++ b/components/board/genericlinux/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/utils"
 )
 
@@ -39,4 +40,40 @@ func (conf *Config) Validate(path string) ([]string, error) {
 		}
 	}
 	return nil, nil
+}
+
+// UnderlyingConfig is a struct containing absolutely everything a genericlinux board might need
+// configured. It is a union of the configs for the customlinux boards and the genericlinux boards
+// with static pin definitions, because those components all use the same underlying code but have
+// different config types (e.g., only genericlinux has named I2C and SPI buses, while only
+// customlinux can change its pin definitions during reconfiguration). The UnderlyingConfig struct
+// is a unification of the two of them. Whenever we go through reconfiguration, we convert the
+// provided config into this type, and then reconfigure based on this.
+type UnderlyingConfig struct {
+	I2Cs              []board.I2CConfig
+	SPIs              []board.SPIConfig
+	Analogs           []board.AnalogConfig
+	DigitalInterrupts []board.DigitalInterruptConfig
+	GpioMappings      map[string]GPIOBoardMapping
+}
+
+// We'll use one of these to turn whatever config we get during reconfiguration into an
+// UnderlyingConfig, and then reconfigure based on that.
+type ConfigConverter = func (resource.Config) (UnderlyingConfig, error)
+
+func ConstPinDefs(gpioMappings map[string]GPIOBoardMapping) ConfigConverter {
+	return func (conf resource.Config) (UnderlyingConfig, error) {
+		newConf, err := resource.NativeConfig[*Config](conf)
+		if err != nil {
+			return UnderlyingConfig{}, err
+		}
+
+		return UnderlyingConfig{
+			I2Cs:              newConf.I2Cs,
+			SPIs:              newConf.SPIs,
+			Analogs:           newConf.Analogs,
+			DigitalInterrupts: newConf.DigitalInterrupts,
+			GpioMappings:      gpioMappings,
+		}, nil
+	}
 }

--- a/components/board/genericlinux/config.go
+++ b/components/board/genericlinux/config.go
@@ -57,11 +57,16 @@ type UnderlyingConfig struct {
 	GpioMappings      map[string]GPIOBoardMapping
 }
 
-// We'll use one of these to turn whatever config we get during reconfiguration into an
-// UnderlyingConfig, and then reconfigure based on that. We return a pointer to an UnderlyingConfig
-// instead of the struct itself so that we can return nil if we encounter an error.
+// ConfigConverter is a type synonym for a function to turn whatever config we get during
+// reconfiguration into an UnderlyingConfig, so that we can reconfigure based on that. We return a
+// pointer to an UnderlyingConfig instead of the struct itself so that we can return nil if we
+// encounter an error.
 type ConfigConverter = func(resource.Config) (*UnderlyingConfig, error)
 
+// ConstPinDefs takes in a map from pin names to GPIOBoardMapping structs, and returns a
+// ConfigConverter that will use these pin definitions in the underlying config. It is intended to
+// be used for board components whose pin definitions are built into the RDK, such as the
+// BeagleBone or Jetson boards.
 func ConstPinDefs(gpioMappings map[string]GPIOBoardMapping) ConfigConverter {
 	return func(conf resource.Config) (*UnderlyingConfig, error) {
 		newConf, err := resource.NativeConfig[*Config](conf)

--- a/components/board/genericlinux/config.go
+++ b/components/board/genericlinux/config.go
@@ -42,14 +42,14 @@ func (conf *Config) Validate(path string) ([]string, error) {
 	return nil, nil
 }
 
-// UnderlyingConfig is a struct containing absolutely everything a genericlinux board might need
+// LinuxBoardConfig is a struct containing absolutely everything a genericlinux board might need
 // configured. It is a union of the configs for the customlinux boards and the genericlinux boards
 // with static pin definitions, because those components all use the same underlying code but have
 // different config types (e.g., only genericlinux has named I2C and SPI buses, while only
-// customlinux can change its pin definitions during reconfiguration). The UnderlyingConfig struct
+// customlinux can change its pin definitions during reconfiguration). The LinuxBoardConfig struct
 // is a unification of the two of them. Whenever we go through reconfiguration, we convert the
 // provided config into this type, and then reconfigure based on this.
-type UnderlyingConfig struct {
+type LinuxBoardConfig struct {
 	I2Cs              []board.I2CConfig
 	SPIs              []board.SPIConfig
 	Analogs           []board.AnalogConfig
@@ -58,23 +58,23 @@ type UnderlyingConfig struct {
 }
 
 // ConfigConverter is a type synonym for a function to turn whatever config we get during
-// reconfiguration into an UnderlyingConfig, so that we can reconfigure based on that. We return a
-// pointer to an UnderlyingConfig instead of the struct itself so that we can return nil if we
+// reconfiguration into a LinuxBoardConfig, so that we can reconfigure based on that. We return a
+// pointer to a LinuxBoardConfig instead of the struct itself so that we can return nil if we
 // encounter an error.
-type ConfigConverter = func(resource.Config) (*UnderlyingConfig, error)
+type ConfigConverter = func(resource.Config) (*LinuxBoardConfig, error)
 
 // ConstPinDefs takes in a map from pin names to GPIOBoardMapping structs, and returns a
 // ConfigConverter that will use these pin definitions in the underlying config. It is intended to
 // be used for board components whose pin definitions are built into the RDK, such as the
 // BeagleBone or Jetson boards.
 func ConstPinDefs(gpioMappings map[string]GPIOBoardMapping) ConfigConverter {
-	return func(conf resource.Config) (*UnderlyingConfig, error) {
+	return func(conf resource.Config) (*LinuxBoardConfig, error) {
 		newConf, err := resource.NativeConfig[*Config](conf)
 		if err != nil {
 			return nil, err
 		}
 
-		return &UnderlyingConfig{
+		return &LinuxBoardConfig{
 			I2Cs:              newConf.I2Cs,
 			SPIs:              newConf.SPIs,
 			Analogs:           newConf.Analogs,


### PR DESCRIPTION
With this in place, we only have a single underlying config struct for everything, and we only go through a single reconfiguration process for all of these boards. The next step after this will be to make that reconfiguration actually update the pin definitions on boards whose pin definitions have changed.

Major steps include:
- Create a new type, `UnderlyingConfig`, which is what "really" gets used in all the boards that use genericlinux stuff. It contains every field that any of these boards could have (i2cs, spis, analogs, digital interrupts, and pin definitions)
- Create a new function type, `ConfigConverter`, which turns whatever config the user thinks this component uses into an `UnderlyingConfig`.
- Make two `ConfigConverter`s: `ConstPinDefs` generates a `ConfigConverter` with a fixed set of pin definitions, for use by all the boards that have historically used genericlinux, while `pinDefsFromFile` loads the pin definitions from the file instead.
- Change `SysfsBoard` to store a `ConfigConverter` when it's created, and use it at the top of reconfiguration to turn the new config into an `UnderlyingConfig`. 
- Add a new reconfiguration step which will look at the pin definitions in the `UnderlyingConfig`. This will be implemented more fully in a follow-up PR, which is where RSDK-4092 (updating pin definitions during reconfiguration) will actually get implemented.
- Remove the `customLinuxBoard` struct entirely in favor of just a `SysfsBoard` struct that uses the `pinDefsFromFile` config converter. Now that the `SysfsBoard`'s version of reconfiguration can update its pin definitions, we don't need a separate struct.

Tried on a Jetson Nano: GPIO still works, hardware PWM still works. Tried on an Odroid C4: same results.

I recommend reviewing everything together: the individual commits are messy. I can clean them up if you want, but if you don't want, that's wasted effort because they'll get squashed anyway.