### PR TITLE
RSDK-4145 cli version flag

### DIFF
--- a/cli/viam/main.go
+++ b/cli/viam/main.go
@@ -911,37 +911,37 @@ viam module upload --version "0.1.0" --platform "linux/amd64" packaged-module.ta
 				Name:  "version",
 				Usage: "print version info for this program",
 				Action: func(c *cli.Context) error {
-					if info, ok := debug.ReadBuildInfo(); !ok {
-						return errors.Errorf("Error reading build info")
-					} else {
-						if c.Bool("debug") {
-							fmt.Fprintf(c.App.Writer, "%s\n", info.String())
-						}
-						settings := make(map[string]string, len(info.Settings))
-						for _, setting := range info.Settings {
-							settings[setting.Key] = setting.Value
-						}
-						version := "?"
-						if rev, ok := settings["vcs.revision"]; ok {
-							version = rev[:8]
-							if settings["vcs.modified"] == "true" {
-								version += "+"
-							}
-						}
-						deps := make(map[string]*debug.Module, len(info.Deps))
-						for _, dep := range info.Deps {
-							deps[dep.Path] = dep
-						}
-						apiVersion := "?"
-						if dep, ok := deps["go.viam.com/api"]; ok {
-							apiVersion = dep.Version
-						}
-						appVersion := config.Version
-						if appVersion == "" {
-							appVersion = "(dev)"
-						}
-						fmt.Fprintf(c.App.Writer, "version %s git=%s api=%s\n", appVersion, version, apiVersion)
+					info, ok := debug.ReadBuildInfo()
+					if !ok {
+						return errors.New("Error reading build info")
 					}
+					if c.Bool("debug") {
+						fmt.Fprintf(c.App.Writer, "%s\n", info.String())
+					}
+					settings := make(map[string]string, len(info.Settings))
+					for _, setting := range info.Settings {
+						settings[setting.Key] = setting.Value
+					}
+					version := "?"
+					if rev, ok := settings["vcs.revision"]; ok {
+						version = rev[:8]
+						if settings["vcs.modified"] == "true" {
+							version += "+"
+						}
+					}
+					deps := make(map[string]*debug.Module, len(info.Deps))
+					for _, dep := range info.Deps {
+						deps[dep.Path] = dep
+					}
+					apiVersion := "?"
+					if dep, ok := deps["go.viam.com/api"]; ok {
+						apiVersion = dep.Version
+					}
+					appVersion := config.Version
+					if appVersion == "" {
+						appVersion = "(dev)"
+					}
+					fmt.Fprintf(c.App.Writer, "version %s git=%s api=%s\n", appVersion, version, apiVersion)
 					return nil
 				},
 			},

--- a/cli/viam/main.go
+++ b/cli/viam/main.go
@@ -946,7 +946,7 @@ viam module upload --version "0.1.0" --platform "linux/amd64" packaged-module.ta
 						if appVersion == "" {
 							appVersion = "(dev)"
 						}
-						fmt.Fprintf(c.App.Writer, "version %s git=%s api=%s %s\n", appVersion, version, apiVersion, info.GoVersion)
+						fmt.Fprintf(c.App.Writer, "version %s git=%s api=%s\n", appVersion, version, apiVersion)
 					}
 					return nil
 				},

--- a/cli/viam/main.go
+++ b/cli/viam/main.go
@@ -18,7 +18,7 @@ import (
 	rdkcli "go.viam.com/rdk/cli"
 )
 
-// set with ldflags
+// CliVersion set with ldflags.
 var CliVersion = "(dev)"
 
 const (
@@ -923,7 +923,7 @@ viam module upload --version "0.1.0" --platform "linux/amd64" packaged-module.ta
 						log.Fatal("Error reading build info")
 					} else {
 						if c.Bool("debug") {
-							fmt.Printf("%s\n", info.String())
+							fmt.Fprintf(c.App.Writer, "%s\n", info.String())
 						}
 						settings := make(map[string]string, len(info.Settings))
 						for _, setting := range info.Settings {
@@ -940,11 +940,11 @@ viam module upload --version "0.1.0" --platform "linux/amd64" packaged-module.ta
 						for _, dep := range info.Deps {
 							deps[dep.Path] = dep
 						}
-						api_version := "?"
+						apiVersion := "?"
 						if dep, ok := deps["go.viam.com/api"]; ok {
-							api_version = dep.Version
+							apiVersion = dep.Version
 						}
-						fmt.Fprintf(c.App.Writer, "version %s git=%s api=%s %s\n", CliVersion, version, api_version, info.GoVersion)
+						fmt.Fprintf(c.App.Writer, "version %s git=%s api=%s %s\n", CliVersion, version, apiVersion, info.GoVersion)
 					}
 					return nil
 				},

--- a/cli/viam/main.go
+++ b/cli/viam/main.go
@@ -910,12 +910,6 @@ viam module upload --version "0.1.0" --platform "linux/amd64" packaged-module.ta
 			{
 				Name:  "version",
 				Usage: "print version info for this program",
-				Flags: []cli.Flag{
-					&cli.BoolFlag{
-						Name:  "debug",
-						Usage: "dump full BuildInfo",
-					},
-				},
 				Action: func(c *cli.Context) error {
 					if info, ok := debug.ReadBuildInfo(); !ok {
 						return errors.Errorf("Error reading build info")

--- a/cli/viam/main.go
+++ b/cli/viam/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime/debug"
 	"time"
 
 	"github.com/edaniels/golog"
@@ -903,6 +904,29 @@ viam module upload --version "0.1.0" --platform "linux/amd64" packaged-module.ta
 						},
 						Action: rdkcli.UploadModuleCommand,
 					},
+				},
+			},
+			{
+				Name:  "version",
+				Usage: "print version info for this program",
+				Action: func(c *cli.Context) error {
+					if info, ok := debug.ReadBuildInfo(); !ok {
+						log.Fatal("Error reading build info")
+					} else {
+						settings := make(map[string]string, len(info.Settings))
+						for _, setting := range info.Settings {
+							settings[setting.Key] = setting.Value
+						}
+						version := "?"
+						if rev, ok := settings["vcs.revision"]; ok {
+							version = rev[:8]
+							if settings["vcs.modified"] == "true" {
+								version += "+"
+							}
+						}
+						fmt.Fprintf(c.App.Writer, "version %s %s %s\n", info.Main.Version, version, info.GoVersion)
+					}
+					return nil
 				},
 			},
 		},

--- a/cli/viam/main.go
+++ b/cli/viam/main.go
@@ -918,7 +918,7 @@ viam module upload --version "0.1.0" --platform "linux/amd64" packaged-module.ta
 				},
 				Action: func(c *cli.Context) error {
 					if info, ok := debug.ReadBuildInfo(); !ok {
-						log.Fatal("Error reading build info")
+						return errors.Errorf("Error reading build info")
 					} else {
 						if c.Bool("debug") {
 							fmt.Fprintf(c.App.Writer, "%s\n", info.String())

--- a/cli/viam/main.go
+++ b/cli/viam/main.go
@@ -16,10 +16,8 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	rdkcli "go.viam.com/rdk/cli"
+	"go.viam.com/rdk/config"
 )
-
-// CliVersion set with ldflags.
-var CliVersion = "(dev)"
 
 const (
 	// Flags.
@@ -944,7 +942,11 @@ viam module upload --version "0.1.0" --platform "linux/amd64" packaged-module.ta
 						if dep, ok := deps["go.viam.com/api"]; ok {
 							apiVersion = dep.Version
 						}
-						fmt.Fprintf(c.App.Writer, "version %s git=%s api=%s %s\n", CliVersion, version, apiVersion, info.GoVersion)
+						appVersion := config.Version
+						if appVersion == "" {
+							appVersion = "(dev)"
+						}
+						fmt.Fprintf(c.App.Writer, "version %s git=%s api=%s %s\n", appVersion, version, apiVersion, info.GoVersion)
 					}
 					return nil
 				},


### PR DESCRIPTION
## what
add `viam version` and `viam -debug version` to viam cli
## example output
```sh
# with ldflags
~/repo/rdk$ go install -ldflags="-X go.viam.com/rdk/config.Version=v1.2.3" ./cli/viam && viam version
version v1.2.3 git=46a090d5+ api=v0.1.164

# without ldflags
~/repo/rdk$ go install ./cli/viam && viam version
version (dev) git=46a090d5+ api=v0.1.164
```
## note: ldflags alternatives
- built-in BuildInfo has a `.Main.Version` -- I think this works when you do a remote build (i.e. reference a package path), but not local. depending on how CI ends up working for this, we may be able to replace ldflags with info.Main.Version
- there is also `go:embed` but it requires a file on disk
