### PR TITLE
RSDK-4373 poc for CLI build

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -1,0 +1,27 @@
+jobs:
+  viam-cli:
+    name: Viam CLI
+    strategy:
+      matrix:
+        include:
+        - goos: linux
+          goarch: amd64
+        - goos: darwin
+          goarch: amd64
+        - goos: darwin
+          goarch: arm64
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v4
+      with:
+        # todo: pin this for prod
+        go-version: '1.20.x'
+    - name: build
+      env:
+        GOOS: ${{ matrix.goos }}
+        GOARCH: ${{ matrix.goarch }}
+      run: go build -ldflags="-X main.CliVersion=whatever" ./cli/viam
+    - uses: actions/upload-artifact@v3
+      with:
+        path: viam

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -26,4 +26,5 @@ jobs:
       run: go build -ldflags="-X main.CliVersion=whatever" ./cli/viam
     - uses: actions/upload-artifact@v3
       with:
+        name: viam-${{ matrix.goos }}-${{ matrix.goarch }}
         path: viam

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -1,3 +1,5 @@
+on:
+  push
 jobs:
   viam-cli:
     name: Viam CLI


### PR DESCRIPTION
## what
proof-of-concept for pre-built `viam` CLI downloadable from github
## background
currently we tell people to run `go build` to get the CLI. But not every user has go on their system