### PR TITLE
RSDK-4076 Better colors and messages for CLI

### DIFF
--- a/cli/auth.go
+++ b/cli/auth.go
@@ -142,7 +142,7 @@ func (a *authFlow) Login(ctx context.Context) (*Token, error) {
 
 	deviceCode, err := a.makeDeviceCodeRequest(ctx, discovery)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed return device code")
+		return nil, errors.Wrapf(err, "failed to return device code")
 	}
 
 	err = a.directUser(deviceCode)
@@ -214,10 +214,9 @@ func (a *authFlow) makeDeviceCodeRequest(ctx context.Context, discovery *openIDD
 }
 
 func (a *authFlow) directUser(code *deviceCodeResponse) error {
-	fmt.Fprintf(a.console, `You can log into Viam through the opened browser window or follow the URL below.
-Ensure the code in the URL matches the one shown in your browser.
-  %s
-`, code.VerificationURIComplete)
+	Infof(a.console, `you can log into Viam through the opened browser window or follow the URL below.
+ensure the code in the URL matches the one shown in your browser.
+  %s`, code.VerificationURIComplete)
 
 	if a.disableBrowserOpen {
 		return nil
@@ -233,7 +232,7 @@ func (a *authFlow) waitForUser(ctx context.Context, code *deviceCodeResponse, di
 	waitInterval := defaultWaitInterval
 	for {
 		if !utils.SelectContextOrWait(ctxWithTimeout, waitInterval) {
-			return nil, errors.New("timed out getting token	")
+			return nil, fmt.Errorf("timed out getting token after %f seconds", waitInterval.Seconds())
 		}
 
 		data := url.Values{}

--- a/cli/data.go
+++ b/cli/data.go
@@ -37,7 +37,7 @@ func (c *AppClient) BinaryData(dst string, filter *datapb.Filter, parallelDownlo
 	}
 
 	if err := makeDestinationDirs(dst); err != nil {
-		return errors.Wrapf(err, "error creating destination directories")
+		return errors.Wrapf(err, "could not create destination directories")
 	}
 
 	if parallelDownloads == 0 {
@@ -222,7 +222,7 @@ func downloadBinary(ctx context.Context, client datapb.DataServiceClient, dst st
 	//nolint:gosec
 	dataFile, err := os.Create(filepath.Join(dst, dataDir, fileName+datum.GetMetadata().GetFileExt()))
 	if err != nil {
-		return errors.Wrapf(err, fmt.Sprintf("error creating file for datum %s", datum.GetMetadata().GetId()))
+		return errors.Wrapf(err, fmt.Sprintf("could not create file for datum %s", datum.GetMetadata().GetId()))
 	}
 	//nolint:gosec
 	if _, err := io.Copy(dataFile, r); err != nil {
@@ -241,7 +241,7 @@ func (c *AppClient) TabularData(dst string, filter *datapb.Filter) error {
 	}
 
 	if err := makeDestinationDirs(dst); err != nil {
-		return errors.Wrapf(err, "error creating destination directories")
+		return errors.Wrapf(err, "could not create destination directories")
 	}
 
 	var err error
@@ -250,11 +250,11 @@ func (c *AppClient) TabularData(dst string, filter *datapb.Filter) error {
 	//nolint:gosec
 	dataFile, err := os.Create(filepath.Join(dst, dataDir, "data.ndjson"))
 	if err != nil {
-		return errors.Wrapf(err, "error creating data file")
+		return errors.Wrapf(err, "could not create data file")
 	}
 	w := bufio.NewWriter(dataFile)
 
-	fmt.Fprintf(c.c.App.Writer, "Downloading..")
+	fmt.Fprintf(c.c.App.Writer, "downloading..")
 	var last string
 	mdIndexes := make(map[string]int)
 	mdIndex := 0
@@ -295,18 +295,18 @@ func (c *AppClient) TabularData(dst string, filter *datapb.Filter) error {
 
 			mdJSONBytes, err := protojson.Marshal(md)
 			if err != nil {
-				return errors.Wrap(err, "error marshaling metadata")
+				return errors.Wrap(err, "could not marshal metadata")
 			}
 			//nolint:gosec
 			mdFile, err := os.Create(filepath.Join(dst, metadataDir, strconv.Itoa(mdIndex)+".json"))
 			if err != nil {
-				return errors.Wrapf(err, fmt.Sprintf("error creating metadata file for metadata index %d", mdIndex))
+				return errors.Wrapf(err, fmt.Sprintf("could not create metadata file for metadata index %d", mdIndex))
 			}
 			if _, err := mdFile.Write(mdJSONBytes); err != nil {
-				return errors.Wrapf(err, "error writing metadata file %s", mdFile.Name())
+				return errors.Wrapf(err, "could not write to metadata file %s", mdFile.Name())
 			}
 			if err := mdFile.Close(); err != nil {
-				return errors.Wrapf(err, "error closing metadata file %s", mdFile.Name())
+				return errors.Wrapf(err, "could not close metadata file %s", mdFile.Name())
 			}
 			mdIndex++
 		}
@@ -324,18 +324,18 @@ func (c *AppClient) TabularData(dst string, filter *datapb.Filter) error {
 			m["MetadataIndex"] = localToGlobalMDIndex[int(datum.GetMetadataIndex())]
 			j, err := json.Marshal(m)
 			if err != nil {
-				return errors.Wrap(err, "error marshaling json response")
+				return errors.Wrap(err, "could not marshal JSON response")
 			}
 			_, err = w.Write(append(j, []byte("\n")...))
 			if err != nil {
-				return errors.Wrapf(err, "error writing reading to file %s", dataFile.Name())
+				return errors.Wrapf(err, "could not write to file %s", dataFile.Name())
 			}
 		}
 	}
 
 	fmt.Fprintf(c.c.App.Writer, "\n")
 	if err := w.Flush(); err != nil {
-		return errors.Wrapf(err, "error flushing writer for %s", dataFile.Name())
+		return errors.Wrapf(err, "could not flush writer for %s", dataFile.Name())
 	}
 
 	return nil

--- a/cli/data.go
+++ b/cli/data.go
@@ -246,7 +246,7 @@ func (c *AppClient) TabularData(dst string, filter *datapb.Filter) error {
 
 	var err error
 	var resp *datapb.TabularDataByFilterResponse
-	// TODO: [DATA-640] Support export in additional formats.
+	// TODO(DATA-640): Support export in additional formats.
 	//nolint:gosec
 	dataFile, err := os.Create(filepath.Join(dst, dataDir, "data.ndjson"))
 	if err != nil {

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -64,11 +64,11 @@ func CreateModuleCommand(c *cli.Context) error {
 		return err
 	}
 	if org == nil {
-		return errors.Errorf("Unable to determine org from orgID(%q) and namespace(%q)", orgIDArg, publicNamespaceArg)
+		return errors.Errorf("unable to determine org from orgID(%q) and namespace(%q)", orgIDArg, publicNamespaceArg)
 	}
 	// Check to make sure the user doesn't accidentally overwrite a module manifest
 	if _, err := os.Stat(defaultManifestFilename); err == nil {
-		return errors.New("Another module's meta.json already exists in the current directory. Delete it and try again")
+		return errors.New("another module's meta.json already exists in the current directory. delete it and try again")
 	}
 
 	response, err := client.CreateModule(moduleNameArg, org.GetId())
@@ -87,9 +87,9 @@ func CreateModuleCommand(c *cli.Context) error {
 	if isValidOrgID(returnedModuleID.Prefix) {
 		returnedModuleID.Prefix = ""
 	}
-	fmt.Fprintf(c.App.Writer, "Successfully created '%s'.\n", returnedModuleID.toString())
+	fmt.Fprintf(c.App.Writer, "successfully created '%s'.\n", returnedModuleID.toString())
 	if response.GetUrl() != "" {
-		fmt.Fprintf(c.App.Writer, "You can view it here: %s \n", response.GetUrl())
+		fmt.Fprintf(c.App.Writer, "you can view it here: %s \n", response.GetUrl())
 	}
 	emptyManifest := ModuleManifest{
 		Name:       returnedModuleID.toString(),
@@ -137,7 +137,7 @@ func UpdateModuleCommand(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(c.App.Writer, "Module successfully updated! You can view your changes online here: %s\n", response.GetUrl())
+	fmt.Fprintf(c.App.Writer, "module successfully updated! you can view your changes online here: %s\n", response.GetUrl())
 
 	// If the namespace isn't set, modify the meta.json to set it (if available)
 	manifestModuleID, err := parseModuleID(manifest.Name)
@@ -149,17 +149,17 @@ func UpdateModuleCommand(c *cli.Context) error {
 		if err != nil {
 			// hopefully a user never sees this. An alternative would be to fail silently here
 			// to prevent the user from being surprised/scared that their update failed
-			return errors.Wrap(err, "Failed to update meta.json with new information from Viam")
+			return errors.Wrap(err, "failed to update meta.json with new information from Viam")
 		}
 		if org.PublicNamespace != "" {
 			moduleID.Prefix = org.PublicNamespace
 			manifest.Name = moduleID.toString()
 			if err := writeManifest(manifestPath, manifest); err != nil {
-				return errors.Wrap(err, "Failed to update meta.json with new information from Viam")
+				return errors.Wrap(err, "failed to update meta.json with new information from Viam")
 			}
-			fmt.Fprintf(c.App.Writer, "\nUpdated meta.json to use the public namespace of %q which is %q\n",
+			fmt.Fprintf(c.App.Writer, "\nupdated meta.json to use the public namespace of %q which is %q\n",
 				org.Name, org.PublicNamespace)
-			fmt.Fprintf(c.App.Writer, "You no longer need to specify org-id or public-namespace\n")
+			Infof(c.App.Writer, "you no longer need to specify org-id or public-namespace")
 		}
 	}
 	return nil
@@ -175,11 +175,11 @@ func UploadModuleCommand(c *cli.Context) error {
 	platformArg := c.String("platform")
 	tarballPath := c.Args().First()
 	if c.Args().Len() > 1 {
-		return errors.New("Too many arguments passed to upload command. " +
-			"Make sure to specify flag and optional arguments before the required positional package argument")
+		return errors.New("too many arguments passed to upload command. " +
+			"make sure to specify flag and optional arguments before the required positional package argument")
 	}
 	if tarballPath == "" {
-		return errors.New("No package to upload -- please provide an archive containing your module. See the help for more information")
+		return errors.New("no package to upload -- please provide an archive containing your module. use --help for more information")
 	}
 
 	client, err := NewAppClient(c)
@@ -196,8 +196,8 @@ func UploadModuleCommand(c *cli.Context) error {
 	if _, err := os.Stat(manifestPath); err != nil {
 		// no manifest found.
 		if nameArg == "" || (publicNamespaceArg == "" && orgIDArg == "") {
-			return errors.New("Unable to find the meta.json. " +
-				"If you want to upload a version without a meta.json, you must supply a module name and namespace (or module name and orgid)",
+			return errors.New("unable to find the meta.json. " +
+				"if you want to upload a version without a meta.json, you must supply a module name and namespace (or module name and orgid)",
 			)
 		}
 		moduleID, err = updateManifestModuleIDWithArgs(c, client, nameArg, publicNamespaceArg, orgIDArg)
@@ -217,7 +217,7 @@ func UploadModuleCommand(c *cli.Context) error {
 		}
 		if nameArg != "" && nameArg != moduleID.Name {
 			// This is almost certainly a mistake we want to catch
-			return errors.Errorf("Module name %q was supplied via command line args but the meta.json has a module name of %q",
+			return errors.Errorf("module name %q was supplied via command line args but the meta.json has a module name of %q",
 				nameArg, moduleID.Name)
 		}
 	}
@@ -229,14 +229,14 @@ func UploadModuleCommand(c *cli.Context) error {
 	}
 	// TODO(APP-2226) support .tar.xz
 	if !strings.HasSuffix(file.Name(), ".tar.gz") {
-		return errors.New("You must upload your module in the form of a .tar.gz")
+		return errors.New("you must upload your module in the form of a .tar.gz")
 	}
 	response, err := client.UploadModuleFile(moduleID, versionArg, platformArg, file)
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintf(c.App.Writer, "Version successfully uploaded! You can view your changes online here: %s\n", response.GetUrl())
+	fmt.Fprintf(c.App.Writer, "version successfully uploaded! you can view your changes online here: %s\n", response.GetUrl())
 
 	return nil
 }
@@ -251,8 +251,8 @@ func parseModuleID(moduleName string) (ModuleID, error) {
 	case 2:
 		return ModuleID{Prefix: splitModuleName[0], Name: splitModuleName[1]}, nil
 	default:
-		return ModuleID{}, errors.Errorf("Invalid module name '%s'."+
-			" It must be in the form 'prefix:module-name' for public modules"+
+		return ModuleID{}, errors.Errorf("invalid module name '%s'."+
+			" module name must be in the form 'prefix:module-name' for public modules"+
 			" or just 'module-name' for private modules in organizations without a public namespace", moduleName)
 	}
 }
@@ -291,10 +291,10 @@ func updateManifestModuleIDWithArgs(
 				// This is almost certainly a user mistake
 				// Preferring org name rather than orgid here because the manifest probably has it specified in terms of
 				// public_namespace so returning the ids would be frustrating
-				return ModuleID{}, errors.Errorf("The meta.json specifies a different org %q than the one provided via args %q",
+				return ModuleID{}, errors.Errorf("the meta.json specifies a different org %q than the one provided via args %q",
 					org.GetName(), expectedOrg.GetName())
 			}
-			fmt.Fprintln(c.App.Writer, "The module's meta.json already specifies a full module id. Ignoring public-namespace and org-id arg")
+			fmt.Fprintln(c.App.Writer, "the module's meta.json already specifies a full module id. ignoring public-namespace and org-id arg")
 		}
 		return moduleID, nil
 	}
@@ -356,7 +356,7 @@ func loadManifest(manifestPath string) (ModuleManifest, error) {
 	manifestBytes, err := os.ReadFile(manifestPath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return ModuleManifest{}, errors.Wrapf(err, "Cannot find %s", manifestPath)
+			return ModuleManifest{}, errors.Wrapf(err, "cannot find %s", manifestPath)
 		}
 		return ModuleManifest{}, err
 	}

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -227,7 +227,7 @@ func UploadModuleCommand(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	// TODO(APP-2226) support .tar.xz
+	// TODO(APP-2226): support .tar.xz
 	if !strings.HasSuffix(file.Name(), ".tar.gz") {
 		return errors.New("you must upload your module in the form of a .tar.gz")
 	}

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -64,7 +64,7 @@ func CreateModuleCommand(c *cli.Context) error {
 		return err
 	}
 	if org == nil {
-		return errors.Errorf("unable to determine org from orgID(%q) and namespace(%q)", orgIDArg, publicNamespaceArg)
+		return errors.Errorf("unable to determine org from org-id (%q) and namespace (%q)", orgIDArg, publicNamespaceArg)
 	}
 	// Check to make sure the user doesn't accidentally overwrite a module manifest
 	if _, err := os.Stat(defaultManifestFilename); err == nil {

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -102,7 +102,7 @@ func CreateModuleCommand(c *cli.Context) error {
 	if err := writeManifest(defaultManifestFilename, emptyManifest); err != nil {
 		return err
 	}
-	fmt.Fprintf(c.App.Writer, "Configuration for the module has been written to meta.json\n")
+	fmt.Fprintf(c.App.Writer, "configuration for the module has been written to meta.json\n")
 	return nil
 }
 

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -197,7 +197,7 @@ func UploadModuleCommand(c *cli.Context) error {
 		// no manifest found.
 		if nameArg == "" || (publicNamespaceArg == "" && orgIDArg == "") {
 			return errors.New("unable to find the meta.json. " +
-				"if you want to upload a version without a meta.json, you must supply a module name and namespace (or module name and orgid)",
+				"if you want to upload a version without a meta.json, you must supply a module name and namespace (or module name and org-id)",
 			)
 		}
 		moduleID, err = updateManifestModuleIDWithArgs(c, client, nameArg, publicNamespaceArg, orgIDArg)

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -217,7 +217,7 @@ func UploadModuleCommand(c *cli.Context) error {
 		}
 		if nameArg != "" && nameArg != moduleID.Name {
 			// This is almost certainly a mistake we want to catch
-			return errors.Errorf("module name %q was supplied via command line args but the meta.json has a module name of %q",
+			return errors.Errorf("module name %q was supplied on the command line but the meta.json has a module name of %q",
 				nameArg, moduleID.Name)
 		}
 	}

--- a/cli/print.go
+++ b/cli/print.go
@@ -9,6 +9,16 @@ import (
 	"github.com/fatih/color"
 )
 
+const asciiViam = `
+@@BO..    "%@@B^%@@<      .}j.      !B@B$v'.    'nB$$$!
+.*@$%l   f$$@X  %$$+      &@$$      l$$$$@@^   "B$$$$@!
+  (@$$0'M@$@:   B$$~    ~B$$@$@1    !$$BQ@@@q.0@$$0@$$!
+   'WB$$B@p     B$$~   qB$%-!@@@o.  l$@B..B@$@$@%; @$@!
+    .u$$$!      B$$~ ;@@@& ... oB$@~!!$$@. z$$$z'. $$$!
+      :h'       B$$~L%@$||     -@@$bi$@B    'M'    $$$!
+
+`
+
 // Infof prints a message prefixed with a bold cyan "Info: ".
 func Infof(w io.Writer, format string, a ...interface{}) {
 	// NOTE(benjirewis): for some reason, both errcheck and gosec complain about
@@ -35,4 +45,11 @@ func Errorf(w io.Writer, format string, a ...interface{}) {
 	}
 	fmt.Fprintf(w, format+"\n", a...)
 	os.Exit(1)
+}
+
+// ViamLogo prints an ASCII Viam logo.
+func ViamLogo(w io.Writer) {
+	if _, err := color.New(color.Bold, color.FgWhite).Fprint(w, asciiViam); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/cli/print.go
+++ b/cli/print.go
@@ -1,0 +1,38 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+
+	"github.com/fatih/color"
+)
+
+// Infof prints a message prefixed with a bold cyan "Info: ".
+func Infof(w io.Writer, format string, a ...interface{}) {
+	// NOTE(benjirewis): for some reason, both errcheck and gosec complain about
+	// Fprint's "unchecked error" here. Fatally log any errors write errors here
+	// and below.
+	if _, err := color.New(color.Bold, color.FgCyan).Fprint(w, "Info: "); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Fprintf(w, format+"\n", a...)
+}
+
+// Warningf prints a message prefixed with a bold yellow "Warning: ".
+func Warningf(w io.Writer, format string, a ...interface{}) {
+	if _, err := color.New(color.Bold, color.FgYellow).Fprint(w, "Warning: "); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Fprintf(w, format+"\n", a...)
+}
+
+// Errorf prints a message prefixed with a bold red "Error: " prefix and exits with 1.
+func Errorf(w io.Writer, format string, a ...interface{}) {
+	if _, err := color.New(color.Bold, color.FgRed).Fprint(w, "Error: "); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Fprintf(w, format+"\n", a...)
+	os.Exit(1)
+}

--- a/cli/viam/main.go
+++ b/cli/viam/main.go
@@ -917,7 +917,7 @@ viam module upload --version "0.1.0" --platform "linux/amd64" packaged-module.ta
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		rdkcli.Errorf(app.Writer, err.Error())
+		rdkcli.Errorf(app.ErrWriter, err.Error())
 	}
 }
 

--- a/cli/viam/main.go
+++ b/cli/viam/main.go
@@ -88,9 +88,10 @@ func main() {
 					}
 
 					loggedInMessage := func(token *rdkcli.Token, alreadyLoggedIn bool) {
-						var already string
-						if alreadyLoggedIn {
-							already = "already "
+						already := "already "
+						if !alreadyLoggedIn {
+							already = ""
+							rdkcli.ViamLogo(c.App.Writer)
 						}
 
 						fmt.Fprintf(c.App.Writer, "%slogged in as %q, expires %s\n", already, token.User.Email,

--- a/cli/viam/main.go
+++ b/cli/viam/main.go
@@ -762,7 +762,7 @@ func main() {
 							{
 								Name:  "shell",
 								Usage: "start a shell on a robot part",
-								// TODO: remove this warning
+								// TODO(RSDK-4377): remove this warning
 								Description: `WARNING: Functionality of the shell command is highly experimental. In particular, there may be text-input issues
 in the opened shell.
 
@@ -787,7 +787,7 @@ In order to use the shell command, the robot must have a valid shell type servic
 									},
 								},
 								Action: func(c *cli.Context) error {
-									// TODO: remove this warning message
+									// TODO(RSDK-4377): remove this warning message
 									rdkcli.Warningf(c.App.Writer, "shell command is highly experimental")
 
 									client, err := rdkcli.NewAppClient(c)

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/edaniels/golog v0.0.0-20230215213219-28954395e8d0
 	github.com/edaniels/lidario v0.0.0-20220607182921-5879aa7b96dd
 	github.com/erh/scheme v0.0.0-20210304170849-99d295c6ce9a
+	github.com/fatih/color v1.15.0
 	github.com/fogleman/gg v1.3.0
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/fullstorydev/grpcurl v1.8.6
@@ -161,7 +162,6 @@ require (
 	github.com/esimonov/ifshort v1.0.4 // indirect
 	github.com/ettle/strcase v0.1.1 // indirect
 	github.com/fatih/camelcase v1.0.0 // indirect
-	github.com/fatih/color v1.15.0 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/firefart/nonamedreturns v1.0.4 // indirect
 	github.com/fzipp/gocyclo v0.6.0 // indirect


### PR DESCRIPTION
RSDK-4076

Adds colored `Infof`, `Warningf` and `Errorf` print functions. Prints errors to stderr and exits instead of fatally logging them. Elaborates on/fixes typos for existing errors messages. Lowercases all error messages and removes the term "error", as the fact that it's an error will be clear in eventual output. 

The following code in an `Action`:
```go
fmt.Fprintf(c.App.Writer, "a regular message\n")
rdkcli.Infof(c.App.Writer, "an info messsage")
rdkcli.Warningf(c.App.Writer, "a warning messsage")
rdkcli.Errorf(c.App.ErrWriter, "an error messsage")
```
Results in:

<img width="194" alt="image" src="https://github.com/viamrobotics/rdk/assets/32186188/3c548191-0c3d-4089-b3dd-2b799d42c9ff">

and an exit status of 1.
