### PR TITLE
RSDK-2261: TestArmReconnection flaky

### DIFF
--- a/components/arm/universalrobots/ur.go
+++ b/components/arm/universalrobots/ur.go
@@ -4,6 +4,7 @@ package universalrobots
 import (
 	"bufio"
 	"context"
+
 	// for embedding model file.
 	_ "embed"
 	"encoding/binary"
@@ -235,6 +236,9 @@ func URArmConnect(ctx context.Context, conf resource.Config, logger golog.Logger
 				}
 			} else if err != nil {
 				logger.Errorw("dashboard reader failed", "error", err)
+				newArm.mu.Lock()
+				newArm.isConnected = false
+				newArm.mu.Unlock()
 				return
 			}
 		}

--- a/components/arm/universalrobots/ur.go
+++ b/components/arm/universalrobots/ur.go
@@ -216,7 +216,7 @@ func URArmConnect(ctx context.Context, conf resource.Config, logger golog.Logger
 						return
 					}
 					logger.Debug("attempting to reconnect to ur arm dashboard")
-					// time.Sleep(1 * time.Second)
+					time.Sleep(1 * time.Second)
 					connDashboard, err = d.DialContext(cancelCtx, "tcp", newArm.host+":29999")
 					if err == nil {
 						newArm.mu.Lock()

--- a/components/arm/universalrobots/ur.go
+++ b/components/arm/universalrobots/ur.go
@@ -4,7 +4,6 @@ package universalrobots
 import (
 	"bufio"
 	"context"
-
 	// for embedding model file.
 	_ "embed"
 	"encoding/binary"

--- a/components/arm/universalrobots/ur5e_test.go
+++ b/components/arm/universalrobots/ur5e_test.go
@@ -366,6 +366,13 @@ func TestArmReconnection(t *testing.T) {
 
 	test.That(t, goutils.SelectContextOrWait(parentCtx, time.Millisecond*500), test.ShouldBeTrue)
 
+	testutils.WaitForAssertion(t, func(tb testing.TB) {
+		tb.Helper()
+		ua.mu.Lock()
+		test.That(tb, ua.isConnected, test.ShouldBeFalse)
+		ua.mu.Unlock()
+	})
+
 	ctx, childCancel = context.WithCancel(parentCtx)
 
 	closer, err = setupListeners(ctx, statusBlob, &remote)

--- a/components/arm/universalrobots/ur5e_test.go
+++ b/components/arm/universalrobots/ur5e_test.go
@@ -3,7 +3,6 @@ package universalrobots
 import (
 	"bufio"
 	"context"
-	"errors"
 	"fmt"
 	"math"
 	"net"
@@ -203,16 +202,6 @@ func computeUR5ePosition(t *testing.T, jointRadians []float64) spatialmath.Pose 
 		r3.Vector{X: res.At(0, 3), Y: res.At(1, 3), Z: res.At(2, 3)}.Mul(1000),
 		&spatialmath.OrientationVectorDegrees{OX: poseOV.OX, OY: poseOV.OY, OZ: poseOV.OZ, Theta: utils.RadToDeg(poseOV.Theta)},
 	)
-}
-
-func selectChanOrTimeout(c <-chan struct{}, timeout time.Duration) error {
-	timer := time.NewTimer(timeout)
-	select {
-	case <-timer.C:
-		return errors.New("timeout")
-	case <-c:
-		return nil
-	}
 }
 
 func setupListeners(ctx context.Context, statusBlob []byte,


### PR DESCRIPTION
This is a potential solution for the `TestArmReconnection` flaky test. Not sure if this changes the test too much to the point where it's not accomplishing what was originally intended.