### PR TITLE
RSDK-4373 poc for CLI build

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -45,7 +45,7 @@ jobs:
     - name: tagged alias
       env:
          CI_RELEASE: ${{ github.ref_name }}
-      if: inputs.release_type == 'stable'
+      # if: inputs.release_type == 'stable' # DONOTMERGE comment
       run: |
         GOOS=linux GOARCH=amd64 make cli-ci
         GOOS=linux GOARCH=arm64 make cli-ci

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -37,18 +37,18 @@ jobs:
       env:
         BINPREFIX: -${{ inputs.release_type }}
       run: |
-        GOOS=linux GOARCH=amd64 make bin/viam-${{ inputs.release_type }}-$GOOS-$GOARCH
-        # GOOS=linux GOARCH=arm64 make bin/viam-${{ inputs.release_type }}-$GOOS-$GOARCH
-        # GOOS=darwin GOARCH=amd64 make bin/viam-${{ inputs.release_type }}-$GOOS-$GOARCH
-        # GOOS=darwin GOARCH=arm64 make bin/viam-${{ inputs.release_type }}-$GOOS-$GOARCH
+        GOOS=linux GOARCH=amd64 make bin/viam-${{ inputs.release_type }}-linux-amd64
+        # GOOS=linux GOARCH=arm64 make bin/viam-${{ inputs.release_type }}-linux-arm64
+        # GOOS=darwin GOARCH=amd64 make bin/viam-${{ inputs.release_type }}-darwin-amd64
+        # GOOS=darwin GOARCH=arm64 make bin/viam-${{ inputs.release_type }}-darwin-arm64
 
     - name: tagged alias
       # if: inputs.release_type == 'stable' # DONOTMERGE comment
       run: |
-        GOOS=linux GOARCH=amd64 cp bin/viam-${{ inputs.release_type }}-$GOOS-$GOARCH bin/viam-${{ github.ref_name }}-$GOOS-$GOARCH
-        # GOOS=linux GOARCH=arm64 cp bin/viam-${{ inputs.release_type }}-$GOOS-$GOARCH bin/viam-${{ github.ref_name }}-$GOOS-$GOARCH
-        # GOOS=darwin GOARCH=amd64 cp bin/viam-${{ inputs.release_type }}-$GOOS-$GOARCH bin/viam-${{ github.ref_name }}-$GOOS-$GOARCH
-        # GOOS=darwin GOARCH=arm64 cp bin/viam-${{ inputs.release_type }}-$GOOS-$GOARCH bin/viam-${{ github.ref_name }}-$GOOS-$GOARCH
+        GOOS=linux GOARCH=amd64 cp bin/viam-${{ inputs.release_type }}-linux-amd64 bin/viam-${{ github.ref_name }}-linux-amd64
+        # GOOS=linux GOARCH=arm64 cp bin/viam-${{ inputs.release_type }}-linux-arm64 bin/viam-${{ github.ref_name }}-linux-arm64
+        # GOOS=darwin GOARCH=amd64 cp bin/viam-${{ inputs.release_type }}-darwin-amd64 bin/viam-${{ github.ref_name }}-darwin-amd64
+        # GOOS=darwin GOARCH=arm64 cp bin/viam-${{ inputs.release_type }}-darwin-arm64 bin/viam-${{ github.ref_name }}-darwin-arm64
 
     - name: Authorize GCP Upload
       uses: google-github-actions/auth@v1

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -43,7 +43,7 @@ jobs:
         GOOS=darwin GOARCH=arm64 make bin/viam-${{ inputs.release_type }}-darwin-arm64
 
     - name: tagged alias
-      # if: inputs.release_type == 'stable' # DONOTMERGE comment
+      if: inputs.release_type == 'stable'
       run: |
         GOOS=linux GOARCH=amd64 cp bin/viam-${{ inputs.release_type }}-linux-amd64 bin/viam-${{ github.ref_name }}-linux-amd64
         GOOS=linux GOARCH=arm64 cp bin/viam-${{ inputs.release_type }}-linux-arm64 bin/viam-${{ github.ref_name }}-linux-arm64

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -38,17 +38,17 @@ jobs:
         BINPREFIX: -${{ inputs.release_type }}
       run: |
         GOOS=linux GOARCH=amd64 make bin/viam-${{ inputs.release_type }}-linux-amd64
-        # GOOS=linux GOARCH=arm64 make bin/viam-${{ inputs.release_type }}-linux-arm64
-        # GOOS=darwin GOARCH=amd64 make bin/viam-${{ inputs.release_type }}-darwin-amd64
-        # GOOS=darwin GOARCH=arm64 make bin/viam-${{ inputs.release_type }}-darwin-arm64
+        GOOS=linux GOARCH=arm64 make bin/viam-${{ inputs.release_type }}-linux-arm64
+        GOOS=darwin GOARCH=amd64 make bin/viam-${{ inputs.release_type }}-darwin-amd64
+        GOOS=darwin GOARCH=arm64 make bin/viam-${{ inputs.release_type }}-darwin-arm64
 
     - name: tagged alias
       # if: inputs.release_type == 'stable' # DONOTMERGE comment
       run: |
         GOOS=linux GOARCH=amd64 cp bin/viam-${{ inputs.release_type }}-linux-amd64 bin/viam-${{ github.ref_name }}-linux-amd64
-        # GOOS=linux GOARCH=arm64 cp bin/viam-${{ inputs.release_type }}-linux-arm64 bin/viam-${{ github.ref_name }}-linux-arm64
-        # GOOS=darwin GOARCH=amd64 cp bin/viam-${{ inputs.release_type }}-darwin-amd64 bin/viam-${{ github.ref_name }}-darwin-amd64
-        # GOOS=darwin GOARCH=arm64 cp bin/viam-${{ inputs.release_type }}-darwin-arm64 bin/viam-${{ github.ref_name }}-darwin-arm64
+        GOOS=linux GOARCH=arm64 cp bin/viam-${{ inputs.release_type }}-linux-arm64 bin/viam-${{ github.ref_name }}-linux-arm64
+        GOOS=darwin GOARCH=amd64 cp bin/viam-${{ inputs.release_type }}-darwin-amd64 bin/viam-${{ github.ref_name }}-darwin-amd64
+        GOOS=darwin GOARCH=arm64 cp bin/viam-${{ inputs.release_type }}-darwin-arm64 bin/viam-${{ github.ref_name }}-darwin-arm64
 
     - name: Authorize GCP Upload
       uses: google-github-actions/auth@v1

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -47,7 +47,7 @@ jobs:
       env:
         GOOS: ${{ matrix.goos }}
         GOARCH: ${{ matrix.goarch }}
-      run: go build -ldflags="-X main.CliVersion=${{ github.ref_name }}" ./cli/viam
+      run: go build -ldflags="-X 'go.viam.com/rdk/config.Version=${{ github.ref_name }}'" ./cli/viam
 
     - name: Authorize GCP Upload
       uses: google-github-actions/auth@v1

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -45,15 +45,11 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
-    - name: vars
-      id: vars
-      run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-
     - name: build
       env:
         GOOS: ${{ matrix.goos }}
         GOARCH: ${{ matrix.goarch }}
-      run: go build -ldflags="-X main.CliVersion=${{ steps.vars.outputs.sha_short }}" ./cli/viam
+      run: go build -ldflags="-X main.CliVersion=${{ github.ref_name }}" ./cli/viam
 
     - name: Authorize GCP Upload
       uses: google-github-actions/auth@v1
@@ -64,7 +60,15 @@ jobs:
       with:
         headers: "cache-control: no-cache"
         path: 'viam'
-        destination: 'packages.viam.com/apps/viam-cli/viam-${{ inputs.release_type }}-${{ matrix.goos }}-${{ matrix.goarch }}'
+        destination: 'packages.viam.com/apps/viam-cli/${{ inputs.release_type }}-${{ matrix.goos }}-${{ matrix.goarch }}'
         parent: false # what
         gzip: false # why
-    # todo: also `gs mv` for tagged release
+
+    # publish tagged version for stable
+    - name: Set up Cloud SDK
+      if: inputs.release_type == 'stable'
+      uses: google-github-actions/setup-gcloud@v1
+    - name: Publish AppImage
+      if: inputs.release_type == 'stable'
+      run: |
+        gsutil mv 'gs://packages.viam.com/apps/viam-cli/${{ inputs.release_type }}-${{ matrix.goos }}-${{ matrix.goarch }}/viam' 'gs://packages.viam.com/apps/viam-cli/${{ github.ref_name }}-${{ matrix.goos }}-${{ matrix.goarch }}/viam'

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -32,10 +32,8 @@ jobs:
     steps:
     - uses: actions/setup-go@v4
       with:
-        # todo: pin this for prod
         go-version: '1.20.x'
 
-    # todo(ask): factor out this conditional checkout behavior? why not always use current?
     - name: Check out code
       if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
       uses: actions/checkout@v3
@@ -61,8 +59,6 @@ jobs:
         headers: "cache-control: no-cache"
         path: 'viam'
         destination: 'packages.viam.com/apps/viam-cli/${{ inputs.release_type }}-${{ matrix.goos }}-${{ matrix.goarch }}'
-        parent: false # what
-        gzip: false # why
 
     # publish tagged version for stable
     - name: Set up Cloud SDK

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -37,17 +37,18 @@ jobs:
       env:
         BINPREFIX: -${{ inputs.release_type }}
       run: |
-        GOOS=linux GOARCH=amd64 make bin/viam-${{ inputs.release_type }}-linux-amd64
-        GOOS=linux GOARCH=arm64 make bin/viam-${{ inputs.release_type }}-linux-arm64
-        GOOS=darwin GOARCH=amd64 make bin/viam-${{ inputs.release_type }}-darwin-amd64
-        GOOS=darwin GOARCH=arm64 make bin/viam-${{ inputs.release_type }}-darwin-arm64
+        GOOS=linux GOARCH=amd64 make bin/viam-${{ inputs.release_type }}-$GOOS-$GOARCH
+        # GOOS=linux GOARCH=arm64 make bin/viam-${{ inputs.release_type }}-$GOOS-$GOARCH
+        # GOOS=darwin GOARCH=amd64 make bin/viam-${{ inputs.release_type }}-$GOOS-$GOARCH
+        # GOOS=darwin GOARCH=arm64 make bin/viam-${{ inputs.release_type }}-$GOOS-$GOARCH
 
     - name: tagged alias
       # if: inputs.release_type == 'stable' # DONOTMERGE comment
       run: |
-        cp -R bin tagged-bin
-        rename viam-${{ inputs.release_type }}- viam-${{ github.ref_name }}- tagged-bin/viam-*
-        mv tagged-bin/viam-* bin
+        GOOS=linux GOARCH=amd64 cp bin/viam-${{ inputs.release_type }}-$GOOS-$GOARCH bin/viam-${{ github.ref_name }}-$GOOS-$GOARCH
+        # GOOS=linux GOARCH=arm64 cp bin/viam-${{ inputs.release_type }}-$GOOS-$GOARCH bin/viam-${{ github.ref_name }}-$GOOS-$GOARCH
+        # GOOS=darwin GOARCH=amd64 cp bin/viam-${{ inputs.release_type }}-$GOOS-$GOARCH bin/viam-${{ github.ref_name }}-$GOOS-$GOARCH
+        # GOOS=darwin GOARCH=arm64 cp bin/viam-${{ inputs.release_type }}-$GOOS-$GOARCH bin/viam-${{ github.ref_name }}-$GOOS-$GOARCH
 
     - name: Authorize GCP Upload
       uses: google-github-actions/auth@v1

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -1,0 +1,70 @@
+name: Viam CLI
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      release_type:
+        required: true
+        type: string
+    secrets:
+      GCP_CREDENTIALS:
+        required: true
+
+jobs:
+  viam-cli:
+    strategy:
+      matrix:
+        include:
+        - goos: linux
+          goarch: amd64
+        - goos: linux
+          goarch: arm64
+        - goos: darwin
+          goarch: amd64
+        - goos: darwin
+          goarch: arm64
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-go@v4
+      with:
+        # todo: pin this for prod
+        go-version: '1.20.x'
+
+    # todo(ask): factor out this conditional checkout behavior? why not always use current?
+    - name: Check out code
+      if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
+      uses: actions/checkout@v3
+    - name: Check out PR branch code
+      if: github.event_name == 'pull_request_target'
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: vars
+      id: vars
+      run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+    - name: build
+      env:
+        GOOS: ${{ matrix.goos }}
+        GOARCH: ${{ matrix.goarch }}
+      run: go build -ldflags="-X main.CliVersion=${{ steps.vars.outputs.sha_short }}" ./cli/viam
+
+    - name: Authorize GCP Upload
+      uses: google-github-actions/auth@v1
+      with:
+        credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+    - name: upload
+      uses: google-github-actions/upload-cloud-storage@v0.10.4
+      with:
+        headers: "cache-control: no-cache"
+        path: 'viam'
+        destination: 'packages.viam.com/apps/viam-cli/viam-${{ inputs.release_type }}-${{ matrix.goos }}-${{ matrix.goarch }}'
+        parent: false # what
+        gzip: false # why
+    # todo: also `gs mv` for tagged release

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -45,7 +45,7 @@ jobs:
     - name: tagged alias
       env:
          CI_RELEASE: ${{ github.ref_name }}
-      # if: inputs.release_type == 'stable' # DONOTMERGE comment
+      if: inputs.release_type == 'stable'
       run: |
         GOOS=linux GOARCH=amd64 make cli-ci
         GOOS=linux GOARCH=arm64 make cli-ci

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -18,17 +18,6 @@ on:
 
 jobs:
   viam-cli:
-    strategy:
-      matrix:
-        include:
-        - goos: linux
-          goarch: amd64
-        - goos: linux
-          goarch: arm64
-        - goos: darwin
-          goarch: amd64
-        - goos: darwin
-          goarch: arm64
     runs-on: ubuntu-latest
     steps:
     - uses: actions/setup-go@v4
@@ -46,9 +35,19 @@ jobs:
 
     - name: build
       env:
-        GOOS: ${{ matrix.goos }}
-        GOARCH: ${{ matrix.goarch }}
-      run: go build -ldflags="-X 'go.viam.com/rdk/config.Version=${{ github.ref_name }}'" ./cli/viam
+        BINPREFIX: -${{ inputs.release_type }}
+      run: |
+        GOOS=linux GOARCH=amd64 make bin/viam-${{ inputs.release_type }}-linux-amd64
+        GOOS=linux GOARCH=arm64 make bin/viam-${{ inputs.release_type }}-linux-arm64
+        GOOS=darwin GOARCH=amd64 make bin/viam-${{ inputs.release_type }}-darwin-amd64
+        GOOS=darwin GOARCH=arm64 make bin/viam-${{ inputs.release_type }}-darwin-arm64
+
+    - name: tagged alias
+      if: inputs.release_type == 'stable'
+      run: |
+        cp -R bin tagged-bin
+        rename viam-${{ inputs.release_type }}- viam-${{ github.ref_name }}- tagged-bin/viam-*
+        mv tagged-bin/viam-* bin
 
     - name: Authorize GCP Upload
       uses: google-github-actions/auth@v1
@@ -58,14 +57,6 @@ jobs:
       uses: google-github-actions/upload-cloud-storage@v0.10.4
       with:
         headers: "cache-control: no-cache"
-        path: 'viam'
-        destination: 'packages.viam.com/apps/viam-cli/${{ inputs.release_type }}-${{ matrix.goos }}-${{ matrix.goarch }}'
-
-    # publish tagged version for stable
-    - name: Set up Cloud SDK
-      if: inputs.release_type == 'stable'
-      uses: google-github-actions/setup-gcloud@v1
-    - name: Publish AppImage
-      if: inputs.release_type == 'stable'
-      run: |
-        gsutil mv 'gs://packages.viam.com/apps/viam-cli/${{ inputs.release_type }}-${{ matrix.goos }}-${{ matrix.goarch }}/viam' 'gs://packages.viam.com/apps/viam-cli/${{ github.ref_name }}-${{ matrix.goos }}-${{ matrix.goarch }}/viam'
+        path: 'bin'
+        glob: 'viam-*'
+        destination: 'packages.viam.com/apps/viam-cli/'

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -6,6 +6,7 @@ on:
       release_type:
         required: true
         type: string
+        default: latest
   workflow_call:
     inputs:
       release_type:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -43,7 +43,7 @@ jobs:
         GOOS=darwin GOARCH=arm64 make bin/viam-${{ inputs.release_type }}-darwin-arm64
 
     - name: tagged alias
-      if: inputs.release_type == 'stable'
+      # if: inputs.release_type == 'stable' # DONOTMERGE comment
       run: |
         cp -R bin tagged-bin
         rename viam-${{ inputs.release_type }}- viam-${{ github.ref_name }}- tagged-bin/viam-*
@@ -60,3 +60,4 @@ jobs:
         path: 'bin'
         glob: 'viam-*'
         destination: 'packages.viam.com/apps/viam-cli/'
+        parent: false

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -35,20 +35,22 @@ jobs:
 
     - name: build
       env:
-        BINPREFIX: -${{ inputs.release_type }}
+        CI_RELEASE: ${{ inputs.release_type }}
       run: |
-        GOOS=linux GOARCH=amd64 make bin/viam-${{ inputs.release_type }}-linux-amd64
-        GOOS=linux GOARCH=arm64 make bin/viam-${{ inputs.release_type }}-linux-arm64
-        GOOS=darwin GOARCH=amd64 make bin/viam-${{ inputs.release_type }}-darwin-amd64
-        GOOS=darwin GOARCH=arm64 make bin/viam-${{ inputs.release_type }}-darwin-arm64
+        GOOS=linux GOARCH=amd64 make cli-ci
+        GOOS=linux GOARCH=arm64 make cli-ci
+        GOOS=darwin GOARCH=amd64 make cli-ci
+        GOOS=darwin GOARCH=arm64 make cli-ci
 
     - name: tagged alias
+      env:
+         CI_RELEASE: ${{ github.ref_name }}
       if: inputs.release_type == 'stable'
       run: |
-        GOOS=linux GOARCH=amd64 cp bin/viam-${{ inputs.release_type }}-linux-amd64 bin/viam-${{ github.ref_name }}-linux-amd64
-        GOOS=linux GOARCH=arm64 cp bin/viam-${{ inputs.release_type }}-linux-arm64 bin/viam-${{ github.ref_name }}-linux-arm64
-        GOOS=darwin GOARCH=amd64 cp bin/viam-${{ inputs.release_type }}-darwin-amd64 bin/viam-${{ github.ref_name }}-darwin-amd64
-        GOOS=darwin GOARCH=arm64 cp bin/viam-${{ inputs.release_type }}-darwin-arm64 bin/viam-${{ github.ref_name }}-darwin-arm64
+        GOOS=linux GOARCH=amd64 make cli-ci
+        GOOS=linux GOARCH=arm64 make cli-ci
+        GOOS=darwin GOARCH=amd64 make cli-ci
+        GOOS=darwin GOARCH=arm64 make cli-ci
 
     - name: Authorize GCP Upload
       uses: google-github-actions/auth@v1
@@ -58,7 +60,7 @@ jobs:
       uses: google-github-actions/upload-cloud-storage@v0.10.4
       with:
         headers: "cache-control: no-cache"
-        path: 'bin'
-        glob: 'viam-*'
+        path: 'bin/deploy-ci'
+        glob: 'viam-cli-*'
         destination: 'packages.viam.com/apps/viam-cli/'
         parent: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: Build and Publish Latest
 
-concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.ref }}
 
 # DONOTMERGE comment
 # on:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ concurrency:
 on:
   workflow_dispatch:
   push:
-    branches: [cli-build-poc-2] # DONOTMERGE [ main ]
+    branches: [ main ]
     paths-ignore:
       - 'README.md'
 
@@ -15,58 +15,58 @@ on:
 # Don't forget to tag back to @main before merge.
 
 jobs:
-  # test:
-  #   uses: viamrobotics/rdk/.github/workflows/test.yml@main
-  #   secrets:
-  #     MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
+  test:
+    uses: viamrobotics/rdk/.github/workflows/test.yml@main
+    secrets:
+      MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
 
-  # appimage:
-  #   needs: test
-  #   uses: viamrobotics/rdk/.github/workflows/appimage.yml@main
-  #   with:
-  #     release_type: 'latest'
-  #   secrets:
-  #     GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
-
-  # staticbuild:
-  #   needs: test
-  #   uses: viamrobotics/rdk/.github/workflows/staticbuild.yml@main
-  #   with:
-  #     release_type: 'latest'
-  #   secrets:
-  #     GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
-
-  cli:
-    uses: ./.github/workflows/cli.yml # DONOTMERGE viamrobotics/rdk/.github/workflows/cli.yml@main
+  appimage:
+    needs: test
+    uses: viamrobotics/rdk/.github/workflows/appimage.yml@main
     with:
       release_type: 'latest'
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
-  # npm_publish:
-  #   uses: viamrobotics/rdk/.github/workflows/npm-publish.yml@main
-  #   needs: test
-  #   secrets:
-  #     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  staticbuild:
+    needs: test
+    uses: viamrobotics/rdk/.github/workflows/staticbuild.yml@main
+    with:
+      release_type: 'latest'
+    secrets:
+      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
-  # license_finder:
-  #   uses: viamrobotics/rdk/.github/workflows/license_finder.yml@main
+  cli:
+    uses: viamrobotics/rdk/.github/workflows/cli.yml@main
+    with:
+      release_type: 'latest'
+    secrets:
+      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
-  # slack-workflow-status:
-  #   if: ${{ failure() }}
-  #   name: Post Workflow Status To Slack
-  #   needs:
-  #     - test
-  #     - appimage
-  #     - staticbuild
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     actions: 'read'
-  #   steps:
-  #     - name: Slack Workflow Notification
-  #       uses: Gamesight/slack-workflow-status@master
-  #       with:
-  #         repo_token: ${{secrets.GITHUB_TOKEN}}
-  #         slack_webhook_url: ${{secrets.SLACK_WEBHOOK_URL}}
-  #         channel: '#team-devops'
-  #         name: 'Workflow Status'
+  npm_publish:
+    uses: viamrobotics/rdk/.github/workflows/npm-publish.yml@main
+    needs: test
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  license_finder:
+    uses: viamrobotics/rdk/.github/workflows/license_finder.yml@main
+
+  slack-workflow-status:
+    if: ${{ failure() }}
+    name: Post Workflow Status To Slack
+    needs:
+      - test
+      - appimage
+      - staticbuild
+    runs-on: ubuntu-latest
+    permissions:
+      actions: 'read'
+    steps:
+      - name: Slack Workflow Notification
+        uses: Gamesight/slack-workflow-status@master
+        with:
+          repo_token: ${{secrets.GITHUB_TOKEN}}
+          slack_webhook_url: ${{secrets.SLACK_WEBHOOK_URL}}
+          channel: '#team-devops'
+          name: 'Workflow Status'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,13 +3,17 @@ name: Build and Publish Latest
 concurrency: 
   group: ${{ github.workflow }}-${{ github.ref }}
 
-on:
-  workflow_dispatch:
-  push:
-    # branches: [ main ] # DONOTMERGE
-    branches: [ cli-build-poc-2 ]
-    paths-ignore:
-      - 'README.md'
+# DONOTMERGE comment
+# on:
+#   workflow_dispatch:
+#   push:
+#     branches: [ main ]
+#     paths-ignore:
+#       - 'README.md'
+on: # DONOTMERGE block
+  pull_request_target:
+    branches: [ main ]
+    types: [ labeled ]
 
 # To test workflow updates you need to work in a branch directly on viamrobotics/rdk
 # and tag your working branch instead of @main in any viamrobotics/rdk "uses" below.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
 
   cli:
     # uses: viamrobotics/rdk/.github/workflows/cli.yml@main
-    uses: ./cli.yml # DONOTMERGE
+    uses: ./.github/workflows/cli.yml # DONOTMERGE
     with:
       release_type: 'latest'
     secrets:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ concurrency:
 on:
   workflow_dispatch:
   push:
-    branches: [ main ]
+    branches: [cli-build-poc-2] # DONOTMERGE [ main ]
     paths-ignore:
       - 'README.md'
 
@@ -15,58 +15,58 @@ on:
 # Don't forget to tag back to @main before merge.
 
 jobs:
-  test:
-    uses: viamrobotics/rdk/.github/workflows/test.yml@main
-    secrets:
-      MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
+  # test:
+  #   uses: viamrobotics/rdk/.github/workflows/test.yml@main
+  #   secrets:
+  #     MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
 
-  appimage:
-    needs: test
-    uses: viamrobotics/rdk/.github/workflows/appimage.yml@main
-    with:
-      release_type: 'latest'
-    secrets:
-      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+  # appimage:
+  #   needs: test
+  #   uses: viamrobotics/rdk/.github/workflows/appimage.yml@main
+  #   with:
+  #     release_type: 'latest'
+  #   secrets:
+  #     GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
-  staticbuild:
-    needs: test
-    uses: viamrobotics/rdk/.github/workflows/staticbuild.yml@main
-    with:
-      release_type: 'latest'
-    secrets:
-      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+  # staticbuild:
+  #   needs: test
+  #   uses: viamrobotics/rdk/.github/workflows/staticbuild.yml@main
+  #   with:
+  #     release_type: 'latest'
+  #   secrets:
+  #     GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
   cli:
-    uses: viamrobotics/rdk/.github/workflows/cli.yml@main
+    uses: ./.github/workflows/cli.yml # DONOTMERGE viamrobotics/rdk/.github/workflows/cli.yml@main
     with:
       release_type: 'latest'
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
-  npm_publish:
-    uses: viamrobotics/rdk/.github/workflows/npm-publish.yml@main
-    needs: test
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  # npm_publish:
+  #   uses: viamrobotics/rdk/.github/workflows/npm-publish.yml@main
+  #   needs: test
+  #   secrets:
+  #     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  license_finder:
-    uses: viamrobotics/rdk/.github/workflows/license_finder.yml@main
+  # license_finder:
+  #   uses: viamrobotics/rdk/.github/workflows/license_finder.yml@main
 
-  slack-workflow-status:
-    if: ${{ failure() }}
-    name: Post Workflow Status To Slack
-    needs:
-      - test
-      - appimage
-      - staticbuild
-    runs-on: ubuntu-latest
-    permissions:
-      actions: 'read'
-    steps:
-      - name: Slack Workflow Notification
-        uses: Gamesight/slack-workflow-status@master
-        with:
-          repo_token: ${{secrets.GITHUB_TOKEN}}
-          slack_webhook_url: ${{secrets.SLACK_WEBHOOK_URL}}
-          channel: '#team-devops'
-          name: 'Workflow Status'
+  # slack-workflow-status:
+  #   if: ${{ failure() }}
+  #   name: Post Workflow Status To Slack
+  #   needs:
+  #     - test
+  #     - appimage
+  #     - staticbuild
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     actions: 'read'
+  #   steps:
+  #     - name: Slack Workflow Notification
+  #       uses: Gamesight/slack-workflow-status@master
+  #       with:
+  #         repo_token: ${{secrets.GITHUB_TOKEN}}
+  #         slack_webhook_url: ${{secrets.SLACK_WEBHOOK_URL}}
+  #         channel: '#team-devops'
+  #         name: 'Workflow Status'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,76 +1,72 @@
 name: Build and Publish Latest
 
-# concurrency:
-#   group: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
 
-# DONOTMERGE comment
-# on:
-#   workflow_dispatch:
-#   push:
-#     branches: [ main ]
-#     paths-ignore:
-#       - 'README.md'
-on: # DONOTMERGE block
+on:
+  workflow_dispatch:
   push:
+    branches: [ main ]
+    paths-ignore:
+      - 'README.md'
 
 # To test workflow updates you need to work in a branch directly on viamrobotics/rdk
 # and tag your working branch instead of @main in any viamrobotics/rdk "uses" below.
 # Don't forget to tag back to @main before merge.
 
 jobs:
-  # test:
-  #   uses: viamrobotics/rdk/.github/workflows/test.yml@main
-  #   secrets:
-  #     MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
+  test:
+    uses: viamrobotics/rdk/.github/workflows/test.yml@main
+    secrets:
+      MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
 
-  # appimage:
-  #   needs: test
-  #   uses: viamrobotics/rdk/.github/workflows/appimage.yml@main
-  #   with:
-  #     release_type: 'latest'
-  #   secrets:
-  #     GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
-
-  # staticbuild:
-  #   needs: test
-  #   uses: viamrobotics/rdk/.github/workflows/staticbuild.yml@main
-  #   with:
-  #     release_type: 'latest'
-  #   secrets:
-  #     GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
-
-  cli:
-    # uses: viamrobotics/rdk/.github/workflows/cli.yml@main
-    uses: ./.github/workflows/cli.yml # DONOTMERGE
+  appimage:
+    needs: test
+    uses: viamrobotics/rdk/.github/workflows/appimage.yml@main
     with:
       release_type: 'latest'
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
-  # npm_publish:
-  #   uses: viamrobotics/rdk/.github/workflows/npm-publish.yml@main
-  #   needs: test
-  #   secrets:
-  #     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  staticbuild:
+    needs: test
+    uses: viamrobotics/rdk/.github/workflows/staticbuild.yml@main
+    with:
+      release_type: 'latest'
+    secrets:
+      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
-  # license_finder:
-  #   uses: viamrobotics/rdk/.github/workflows/license_finder.yml@main
+  cli:
+    uses: viamrobotics/rdk/.github/workflows/cli.yml@main
+    with:
+      release_type: 'latest'
+    secrets:
+      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
-  # slack-workflow-status:
-  #   if: ${{ failure() }}
-  #   name: Post Workflow Status To Slack
-  #   needs:
-  #     - test
-  #     - appimage
-  #     - staticbuild
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     actions: 'read'
-  #   steps:
-  #     - name: Slack Workflow Notification
-  #       uses: Gamesight/slack-workflow-status@master
-  #       with:
-  #         repo_token: ${{secrets.GITHUB_TOKEN}}
-  #         slack_webhook_url: ${{secrets.SLACK_WEBHOOK_URL}}
-  #         channel: '#team-devops'
-  #         name: 'Workflow Status'
+  npm_publish:
+    uses: viamrobotics/rdk/.github/workflows/npm-publish.yml@main
+    needs: test
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  license_finder:
+    uses: viamrobotics/rdk/.github/workflows/license_finder.yml@main
+
+  slack-workflow-status:
+    if: ${{ failure() }}
+    name: Post Workflow Status To Slack
+    needs:
+      - test
+      - appimage
+      - staticbuild
+    runs-on: ubuntu-latest
+    permissions:
+      actions: 'read'
+    steps:
+      - name: Slack Workflow Notification
+        uses: Gamesight/slack-workflow-status@master
+        with:
+          repo_token: ${{secrets.GITHUB_TOKEN}}
+          slack_webhook_url: ${{secrets.SLACK_WEBHOOK_URL}}
+          channel: '#team-devops'
+          name: 'Workflow Status'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,7 @@ concurrency:
 #     paths-ignore:
 #       - 'README.md'
 on: # DONOTMERGE block
-  pull_request_target:
-    branches: [ main ]
-    # types: [ labeled ]
+  push:
 
 # To test workflow updates you need to work in a branch directly on viamrobotics/rdk
 # and tag your working branch instead of @main in any viamrobotics/rdk "uses" below.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,12 +1,12 @@
 name: Build and Publish Latest
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.ref }}
 
 on:
   workflow_dispatch:
   push:
-    branches: [ main ]
+    branches: [ cli-build-poc-2 ] # branches: [ main ] # DONOTMERGE
     paths-ignore:
       - 'README.md'
 
@@ -15,58 +15,58 @@ on:
 # Don't forget to tag back to @main before merge.
 
 jobs:
-  test:
-    uses: viamrobotics/rdk/.github/workflows/test.yml@main
-    secrets:
-      MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
+  # test:
+  #   uses: viamrobotics/rdk/.github/workflows/test.yml@main
+  #   secrets:
+  #     MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
 
-  appimage:
-    needs: test
-    uses: viamrobotics/rdk/.github/workflows/appimage.yml@main
-    with:
-      release_type: 'latest'
-    secrets:
-      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+  # appimage:
+  #   needs: test
+  #   uses: viamrobotics/rdk/.github/workflows/appimage.yml@main
+  #   with:
+  #     release_type: 'latest'
+  #   secrets:
+  #     GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
-  staticbuild:
-    needs: test
-    uses: viamrobotics/rdk/.github/workflows/staticbuild.yml@main
-    with:
-      release_type: 'latest'
-    secrets:
-      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+  # staticbuild:
+  #   needs: test
+  #   uses: viamrobotics/rdk/.github/workflows/staticbuild.yml@main
+  #   with:
+  #     release_type: 'latest'
+  #   secrets:
+  #     GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
   cli:
-    uses: viamrobotics/rdk/.github/workflows/cli.yml@main
+    uses: ./.github/workflows/cli.yml # uses: viamrobotics/rdk/.github/workflows/cli.yml@main # DONOTMERGE
     with:
       release_type: 'latest'
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
-  npm_publish:
-    uses: viamrobotics/rdk/.github/workflows/npm-publish.yml@main
-    needs: test
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  # npm_publish:
+  #   uses: viamrobotics/rdk/.github/workflows/npm-publish.yml@main
+  #   needs: test
+  #   secrets:
+  #     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  license_finder:
-    uses: viamrobotics/rdk/.github/workflows/license_finder.yml@main
+  # license_finder:
+  #   uses: viamrobotics/rdk/.github/workflows/license_finder.yml@main
 
-  slack-workflow-status:
-    if: ${{ failure() }}
-    name: Post Workflow Status To Slack
-    needs:
-      - test
-      - appimage
-      - staticbuild
-    runs-on: ubuntu-latest
-    permissions:
-      actions: 'read'
-    steps:
-      - name: Slack Workflow Notification
-        uses: Gamesight/slack-workflow-status@master
-        with:
-          repo_token: ${{secrets.GITHUB_TOKEN}}
-          slack_webhook_url: ${{secrets.SLACK_WEBHOOK_URL}}
-          channel: '#team-devops'
-          name: 'Workflow Status'
+  # slack-workflow-status:
+  #   if: ${{ failure() }}
+  #   name: Post Workflow Status To Slack
+  #   needs:
+  #     - test
+  #     - appimage
+  #     - staticbuild
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     actions: 'read'
+  #   steps:
+  #     - name: Slack Workflow Notification
+  #       uses: Gamesight/slack-workflow-status@master
+  #       with:
+  #         repo_token: ${{secrets.GITHUB_TOKEN}}
+  #         slack_webhook_url: ${{secrets.SLACK_WEBHOOK_URL}}
+  #         channel: '#team-devops'
+  #         name: 'Workflow Status'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,14 @@ jobs:
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
+  cli:
+    # uses: viamrobotics/rdk/.github/workflows/cli.yml@main
+    uses: ./cli.yml # DONOTMERGE
+    with:
+      release_type: 'latest'
+    secrets:
+      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+
   npm_publish:
     uses: viamrobotics/rdk/.github/workflows/npm-publish.yml@main
     needs: test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ concurrency:
 on: # DONOTMERGE block
   pull_request_target:
     branches: [ main ]
-    types: [ labeled ]
+    # types: [ labeled ]
 
 # To test workflow updates you need to work in a branch directly on viamrobotics/rdk
 # and tag your working branch instead of @main in any viamrobotics/rdk "uses" below.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,12 +1,12 @@
 name: Build and Publish Latest
 
-# concurrency:
-#   group: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
 
 on:
   workflow_dispatch:
   push:
-    branches: [ cli-build-poc-2 ] # branches: [ main ] # DONOTMERGE
+    branches: [ main ]
     paths-ignore:
       - 'README.md'
 
@@ -15,58 +15,58 @@ on:
 # Don't forget to tag back to @main before merge.
 
 jobs:
-  # test:
-  #   uses: viamrobotics/rdk/.github/workflows/test.yml@main
-  #   secrets:
-  #     MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
+  test:
+    uses: viamrobotics/rdk/.github/workflows/test.yml@main
+    secrets:
+      MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
 
-  # appimage:
-  #   needs: test
-  #   uses: viamrobotics/rdk/.github/workflows/appimage.yml@main
-  #   with:
-  #     release_type: 'latest'
-  #   secrets:
-  #     GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
-
-  # staticbuild:
-  #   needs: test
-  #   uses: viamrobotics/rdk/.github/workflows/staticbuild.yml@main
-  #   with:
-  #     release_type: 'latest'
-  #   secrets:
-  #     GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
-
-  cli:
-    uses: ./.github/workflows/cli.yml # uses: viamrobotics/rdk/.github/workflows/cli.yml@main # DONOTMERGE
+  appimage:
+    needs: test
+    uses: viamrobotics/rdk/.github/workflows/appimage.yml@main
     with:
       release_type: 'latest'
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
-  # npm_publish:
-  #   uses: viamrobotics/rdk/.github/workflows/npm-publish.yml@main
-  #   needs: test
-  #   secrets:
-  #     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  staticbuild:
+    needs: test
+    uses: viamrobotics/rdk/.github/workflows/staticbuild.yml@main
+    with:
+      release_type: 'latest'
+    secrets:
+      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
-  # license_finder:
-  #   uses: viamrobotics/rdk/.github/workflows/license_finder.yml@main
+  cli:
+    uses: viamrobotics/rdk/.github/workflows/cli.yml@main
+    with:
+      release_type: 'latest'
+    secrets:
+      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
-  # slack-workflow-status:
-  #   if: ${{ failure() }}
-  #   name: Post Workflow Status To Slack
-  #   needs:
-  #     - test
-  #     - appimage
-  #     - staticbuild
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     actions: 'read'
-  #   steps:
-  #     - name: Slack Workflow Notification
-  #       uses: Gamesight/slack-workflow-status@master
-  #       with:
-  #         repo_token: ${{secrets.GITHUB_TOKEN}}
-  #         slack_webhook_url: ${{secrets.SLACK_WEBHOOK_URL}}
-  #         channel: '#team-devops'
-  #         name: 'Workflow Status'
+  npm_publish:
+    uses: viamrobotics/rdk/.github/workflows/npm-publish.yml@main
+    needs: test
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  license_finder:
+    uses: viamrobotics/rdk/.github/workflows/license_finder.yml@main
+
+  slack-workflow-status:
+    if: ${{ failure() }}
+    name: Post Workflow Status To Slack
+    needs:
+      - test
+      - appimage
+      - staticbuild
+    runs-on: ubuntu-latest
+    permissions:
+      actions: 'read'
+    steps:
+      - name: Slack Workflow Notification
+        uses: Gamesight/slack-workflow-status@master
+        with:
+          repo_token: ${{secrets.GITHUB_TOKEN}}
+          slack_webhook_url: ${{secrets.SLACK_WEBHOOK_URL}}
+          channel: '#team-devops'
+          name: 'Workflow Status'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,8 @@ concurrency:
 on:
   workflow_dispatch:
   push:
-    branches: [ main ]
+    # branches: [ main ] # DONOTMERGE
+    branches: [ cli-build-poc-2 ]
     paths-ignore:
       - 'README.md'
 
@@ -15,26 +16,26 @@ on:
 # Don't forget to tag back to @main before merge.
 
 jobs:
-  test:
-    uses: viamrobotics/rdk/.github/workflows/test.yml@main
-    secrets:
-      MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
+  # test:
+  #   uses: viamrobotics/rdk/.github/workflows/test.yml@main
+  #   secrets:
+  #     MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
 
-  appimage:
-    needs: test
-    uses: viamrobotics/rdk/.github/workflows/appimage.yml@main
-    with:
-      release_type: 'latest'
-    secrets:
-      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+  # appimage:
+  #   needs: test
+  #   uses: viamrobotics/rdk/.github/workflows/appimage.yml@main
+  #   with:
+  #     release_type: 'latest'
+  #   secrets:
+  #     GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
-  staticbuild:
-    needs: test
-    uses: viamrobotics/rdk/.github/workflows/staticbuild.yml@main
-    with:
-      release_type: 'latest'
-    secrets:
-      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+  # staticbuild:
+  #   needs: test
+  #   uses: viamrobotics/rdk/.github/workflows/staticbuild.yml@main
+  #   with:
+  #     release_type: 'latest'
+  #   secrets:
+  #     GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
   cli:
     # uses: viamrobotics/rdk/.github/workflows/cli.yml@main
@@ -44,30 +45,30 @@ jobs:
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
-  npm_publish:
-    uses: viamrobotics/rdk/.github/workflows/npm-publish.yml@main
-    needs: test
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  # npm_publish:
+  #   uses: viamrobotics/rdk/.github/workflows/npm-publish.yml@main
+  #   needs: test
+  #   secrets:
+  #     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  license_finder:
-    uses: viamrobotics/rdk/.github/workflows/license_finder.yml@main
+  # license_finder:
+  #   uses: viamrobotics/rdk/.github/workflows/license_finder.yml@main
 
-  slack-workflow-status:
-    if: ${{ failure() }}
-    name: Post Workflow Status To Slack
-    needs:
-      - test
-      - appimage
-      - staticbuild
-    runs-on: ubuntu-latest
-    permissions:
-      actions: 'read'
-    steps:
-      - name: Slack Workflow Notification
-        uses: Gamesight/slack-workflow-status@master
-        with:
-          repo_token: ${{secrets.GITHUB_TOKEN}}
-          slack_webhook_url: ${{secrets.SLACK_WEBHOOK_URL}}
-          channel: '#team-devops'
-          name: 'Workflow Status'
+  # slack-workflow-status:
+  #   if: ${{ failure() }}
+  #   name: Post Workflow Status To Slack
+  #   needs:
+  #     - test
+  #     - appimage
+  #     - staticbuild
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     actions: 'read'
+  #   steps:
+  #     - name: Slack Workflow Notification
+  #       uses: Gamesight/slack-workflow-status@master
+  #       with:
+  #         repo_token: ${{secrets.GITHUB_TOKEN}}
+  #         slack_webhook_url: ${{secrets.SLACK_WEBHOOK_URL}}
+  #         channel: '#team-devops'
+  #         name: 'Workflow Status'

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -34,6 +34,14 @@ jobs:
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
+  cli:
+    needs: test
+    uses: viamrobotics/rdk/.github/workflows/cli.yml@main
+    with:
+      release_type: 'stable'
+    secrets:
+      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+
   slack-workflow-status:
     if: ${{ failure() }}
     name: Post Workflow Status To Slack

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ build: build-web build-go
 build-go:
 	go build ./...
 
+bin/viam$(BINPREFIX)-$(GOOS)-$(GOARCH): ./cli/viam
+	go build -ldflags="-X 'go.viam.com/rdk/config.Version=$(TAG_VERSION)' -s -w" -o $@ ./$<
+
 build-web: web/runtime-shared/static/control.js
 
 # only generate static files when source has changed.

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ cli: bin/$(GOOS)-$(GOARCH)/viam-cli
 
 .PHONY: cli-ci
 cli-ci: bin/$(GOOS)-$(GOARCH)/viam-cli
-	if [[ -n "$(CI_RELEASE)" ]]; then \
+	if [ -n "$(CI_RELEASE)" ]; then \
 		mkdir -p bin/deploy-ci/; \
 		cp $< bin/deploy-ci/viam-cli-$(CI_RELEASE)-$(GOOS)-$(GOARCH); \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ build-go:
 	go build ./...
 
 bin/viam$(BINPREFIX)-$(GOOS)-$(GOARCH): ./cli/viam
-	go build -ldflags="-X 'go.viam.com/rdk/config.Version=$(TAG_VERSION)' -s -w" -o $@ ./$<
+	go build -ldflags="-X 'go.viam.com/rdk/config.Version=$(TAG_VERSION)' -s -w" -tags osusergo,netgo -o $@ ./$<
 
 build-web: web/runtime-shared/static/control.js
 

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,20 @@ build: build-web build-go
 build-go:
 	go build ./...
 
-bin/viam$(BINPREFIX)-$(GOOS)-$(GOARCH): ./cli/viam
-	go build -ldflags="-X 'go.viam.com/rdk/config.Version=$(TAG_VERSION)' -s -w" -tags osusergo,netgo -o $@ ./$<
+GOOS ?= $(shell go env GOOS)
+GOARCH ?= $(shell go env GOARCH)
+bin/$(GOOS)-$(GOARCH)/viam-cli:
+	go build $(LDFLAGS) -tags osusergo,netgo -o $@ ./cli/viam
+
+.PHONY: cli
+cli: bin/$(GOOS)-$(GOARCH)/viam-cli
+
+.PHONY: cli-ci
+cli-ci: bin/$(GOOS)-$(GOARCH)/viam-cli
+	if [[ -n "$(CI_RELEASE)" ]]; then \
+		mkdir -p bin/deploy-ci/; \
+		cp $< bin/deploy-ci/viam-cli-$(CI_RELEASE)-$(GOOS)-$(GOARCH); \
+	fi
 
 build-web: web/runtime-shared/static/control.js
 


### PR DESCRIPTION
## what
- Add workflows/cli.yml, which saves a pre-built CLI in GCP
- this copies most of the behavior in staticbuild / appimage
## deploy paths
bucket contents after first run (the ones that have the branch name, cli-build-poc-2, would normally only be created in a tag / release context i.e. from stable.yml):

![Screenshot 2023-08-08 at 19-48-46 viam-cli -… viam com – Bucket details – Cloud Storage – Google Cloud console](https://github.com/viamrobotics/rdk/assets/7256523/73806cf6-3e4c-4155-b438-0373991a156d)

## try the build
```sh
wget https://storage.googleapis.com/packages.viam.com/apps/viam-cli/viam-cli-latest-linux-amd64 \
  && chmod +x viam-cli-latest-linux-amd64 \
  && ./viam-cli-latest-linux-amd64 version
```
(change linux-amd64 to darwin-amd64 on intel mac, or darwin-arm64 on apple silicon)
## notes
- 'latest' build doesn't depend on tests (because the CLI doesn't have tests), the 'stable' build does (because we don't want to do a release until everything is working)