### PR TITLE
RSDK-4383 - Resource configs are not re-validated after a changed executable path of the underlying module

### DIFF
--- a/examples/customresources/demos/complexmodule/moduletest/module_test.go
+++ b/examples/customresources/demos/complexmodule/moduletest/module_test.go
@@ -115,17 +115,17 @@ func TestComplexModule(t *testing.T) {
 
 	// Base is a custom component, but built-in API. It also depends on built-in motors, so tests dependencies.
 	t.Run("Test Base", func(t *testing.T) {
-		res, err := rc.ResourceByName(base.Named("base1"))
-		test.That(t, err, test.ShouldBeNil)
-		mybase := res.(base.Base)
-
-		res, err = rc.ResourceByName(motor.Named("motor1"))
+		res, err := rc.ResourceByName(motor.Named("motor1"))
 		test.That(t, err, test.ShouldBeNil)
 		motorL := res.(motor.Motor)
 
 		res, err = rc.ResourceByName(motor.Named("motor2"))
 		test.That(t, err, test.ShouldBeNil)
 		motorR := res.(motor.Motor)
+
+		res, err = rc.ResourceByName(base.Named("base1"))
+		test.That(t, err, test.ShouldBeNil)
+		mybase := res.(base.Base)
 
 		// Test generic echo
 		testCmd := map[string]interface{}{"foo": "bar"}

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -19,6 +19,7 @@ import (
 	pb "go.viam.com/api/module/v1"
 	"go.viam.com/utils"
 	"go.viam.com/utils/pexec"
+	"golang.org/x/exp/slices"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
@@ -415,6 +416,67 @@ func (mgr *Manager) ValidateConfig(ctx context.Context, conf resource.Config) ([
 		return nil, err
 	}
 	return resp.Dependencies, nil
+}
+
+// ResolveImplicitDependenciesInConfig modifies the config diff to add implicit dependencies to changed components
+// and updates modular components & services whose module has been changed with new implicit deps and adds them to conf.Modified.
+func (mgr *Manager) ResolveImplicitDependenciesInConfig(ctx context.Context, conf *config.Diff) error {
+	mgr.mu.RLock()
+	defer mgr.mu.RUnlock()
+	// Find all components/services that are unmodified the same but whose module has been updated and add them to the modified arrays
+	for _, c := range conf.Right.Components {
+		// See if this component is being provided by a module
+		mod, ok := mgr.getModule(c)
+		if !ok {
+			continue
+		}
+		// If it is, check against the modified modules to determine if the config should also be updated but won't already be
+		if slices.ContainsFunc(conf.Modified.Modules, func(elem config.Module) bool { return elem.Name == mod.name }) &&
+			!slices.ContainsFunc(conf.Added.Components, func(elem resource.Config) bool { return elem.Name == c.Name }) &&
+			!slices.ContainsFunc(conf.Modified.Components, func(elem resource.Config) bool { return elem.Name == c.Name }) {
+			conf.Modified.Components = append(conf.Modified.Components, c)
+		}
+	}
+	for _, s := range conf.Right.Services {
+		// See if this component is being provided by a module
+		mod, ok := mgr.getModule(s)
+		if !ok {
+			continue
+		}
+		// If it is, check against the modified modules to determine if the config should also be updated but won't already be
+		if slices.ContainsFunc(conf.Modified.Modules, func(elem config.Module) bool { return elem.Name == mod.name }) &&
+			!slices.ContainsFunc(conf.Added.Services, func(elem resource.Config) bool { return elem.Name == s.Name }) &&
+			!slices.ContainsFunc(conf.Modified.Services, func(elem resource.Config) bool { return elem.Name == s.Name }) {
+			conf.Modified.Services = append(conf.Modified.Services, s)
+		}
+	}
+
+	// If something was added or modified, go through components and services in
+	// diff.Added and diff.Modified, call Validate on all those that are modularized,
+	// and store implicit dependencies.
+	validateModularResources := func(confs []resource.Config) {
+		for i, c := range confs {
+			if mgr.Provides(c) {
+				implicitDeps, err := mgr.ValidateConfig(ctx, c)
+				if err != nil {
+					mgr.logger.Errorw("modular config validation error found in resource: "+c.Name, "error", err)
+					continue
+				}
+
+				// Modify resource to add its implicit dependencies.
+				confs[i].ImplicitDependsOn = implicitDeps
+			}
+		}
+	}
+	if conf.Added != nil {
+		validateModularResources(conf.Added.Components)
+		validateModularResources(conf.Added.Services)
+	}
+	if conf.Modified != nil {
+		validateModularResources(conf.Modified.Components)
+		validateModularResources(conf.Modified.Services)
+	}
+	return nil
 }
 
 func (mgr *Manager) getModule(conf resource.Config) (*module, bool) {

--- a/module/modmaninterface/interface.go
+++ b/module/modmaninterface/interface.go
@@ -19,6 +19,7 @@ type ModuleManager interface {
 	RemoveResource(ctx context.Context, name resource.Name) error
 	IsModularResource(name resource.Name) bool
 	ValidateConfig(ctx context.Context, cfg resource.Config) ([]string, error)
+	ResolveImplicitDependenciesInConfig(ctx context.Context, conf *config.Diff) error
 
 	Configs() []config.Module
 	Provides(cfg resource.Config) bool

--- a/module/multiversionmodule/.gitignore
+++ b/module/multiversionmodule/.gitignore
@@ -1,0 +1,1 @@
+version*

--- a/module/multiversionmodule/module.go
+++ b/module/multiversionmodule/module.go
@@ -1,0 +1,117 @@
+// Package main is a module designed to help build tests for reconfiguration logic between module versions
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/edaniels/golog"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+	"go.viam.com/utils"
+
+	"go.viam.com/rdk/components/generic"
+	"go.viam.com/rdk/components/motor"
+	"go.viam.com/rdk/module"
+	"go.viam.com/rdk/resource"
+)
+
+var myModel = resource.NewModel("acme", "demo", "multiversionmodule")
+
+// VERSION is set with `-ldflags "-X main.VERSION=..."`.
+var VERSION string
+
+// config is a simple config for a generic component.
+type config struct {
+	// Required to be non-empty for VERSION="v2", not required otherwise
+	Parameter string `json:"parameter"`
+	// Required to be non-empty for VERSION="v3", not required otherwise
+	Motor string `json:"motor"`
+}
+
+type component struct {
+	resource.Named
+	resource.TriviallyCloseable
+	logger golog.Logger
+	cfg    *config
+}
+
+// Validate validates the config depending on VERSION.
+func (cfg *config) Validate(_ string) ([]string, error) {
+	switch VERSION {
+	case "v2":
+		if cfg.Parameter == "" {
+			return nil, errors.New("version 2 requires a parameter")
+		}
+	case "v3":
+		if cfg.Motor == "" {
+			return nil, errors.New("version 3 requires a motor")
+		}
+		return []string{cfg.Motor}, nil
+	default:
+	}
+	return make([]string, 0), nil
+}
+
+func main() {
+	utils.ContextualMain(mainWithArgs, golog.NewDevelopmentLogger(fmt.Sprintf("MultiVersionModule-%s", VERSION)))
+}
+
+func mainWithArgs(ctx context.Context, args []string, logger golog.Logger) error {
+	myMod, err := module.NewModuleFromArgs(ctx, logger)
+	if err != nil {
+		return err
+	}
+	resource.RegisterComponent(generic.API, myModel, resource.Registration[resource.Resource, *config]{
+		Constructor: newComponent,
+	})
+	err = myMod.AddModelFromRegistry(ctx, generic.API, myModel)
+	if err != nil {
+		return err
+	}
+
+	err = myMod.Start(ctx)
+	defer myMod.Close(ctx)
+	if err != nil {
+		return err
+	}
+	<-ctx.Done()
+	return nil
+}
+
+func newComponent(_ context.Context,
+	deps resource.Dependencies,
+	conf resource.Config,
+	logger *zap.SugaredLogger,
+) (resource.Resource, error) {
+	newConf, err := resource.NativeConfig[*config](conf)
+	if err != nil {
+		return nil, errors.Wrap(err, "create component failed due to config parsing")
+	}
+	if VERSION == "v3" {
+		// Version 3 should have a motor in the deps
+		if _, err := motor.FromDependencies(deps, "motor1"); err != nil {
+			return nil, errors.Wrapf(err, "failed to resolve motor %q for version 3", "motor1")
+		}
+	}
+	return &component{
+		Named:  conf.ResourceName().AsNamed(),
+		cfg:    newConf,
+		logger: logger,
+	}, nil
+}
+
+// Reconfigure swaps the config to the new conf.
+func (c *component) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+	cfg, err := resource.NativeConfig[*config](conf)
+	if err != nil {
+		return err
+	}
+	c.cfg = cfg
+	return nil
+}
+
+// DoCommand does nothing for now.
+func (c *component) DoCommand(ctx context.Context, req map[string]interface{}) (map[string]interface{}, error) {
+	return map[string]interface{}{}, nil
+}

--- a/module/multiversionmodule/module.json
+++ b/module/multiversionmodule/module.json
@@ -1,0 +1,38 @@
+{
+  "modules": [
+    {
+      "name": "AcmeModule",
+      "executable_path": "module/multiversionmodule/run_version1.sh",
+      "log_level": "debug"
+    }
+  ],
+  "components": [
+    {
+      "name": "generic1",
+      "api": "rdk:component:generic",
+      "model": "acme:demo:multiversionmodule",
+      "attributes": {}
+    },
+    {
+      "namespace": "rdk",
+      "type": "motor",
+      "name": "motor1",
+      "model": "rdk:builtin:fake",
+      "attributes": {
+        "max_rpm": 500,
+        "encoder": "encoder1",
+        "max_power_pct": 0.5,
+        "ticks_per_rotation": 10000
+      },
+      "depends_on": ["encoder1"]
+    },
+    {
+      "name": "encoder1",
+      "type": "encoder",
+      "model": "fake"
+    }
+  ],
+  "network": {
+    "bind_address": ":8080"
+  }
+}

--- a/module/multiversionmodule/run_version1.sh
+++ b/module/multiversionmodule/run_version1.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+cd `dirname $0`
+
+go build -o ./version1 -ldflags "-X main.VERSION=v1" ./
+exec ./version1 $@

--- a/module/multiversionmodule/run_version2.sh
+++ b/module/multiversionmodule/run_version2.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+cd `dirname $0`
+
+go build -o ./version2 -ldflags "-X main.VERSION=v2" ./
+exec ./version2 $@

--- a/module/multiversionmodule/run_version3.sh
+++ b/module/multiversionmodule/run_version3.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+cd `dirname $0`
+
+go build -o ./version3 -ldflags "-X main.VERSION=v3" ./
+exec ./version3 $@

--- a/module/version_reconfigure_test.go
+++ b/module/version_reconfigure_test.go
@@ -1,0 +1,235 @@
+package module_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/edaniels/golog"
+	"github.com/pkg/errors"
+	"go.viam.com/test"
+	goutils "go.viam.com/utils"
+	"go.viam.com/utils/pexec"
+	"go.viam.com/utils/rpc"
+
+	"go.viam.com/rdk/components/generic"
+	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/robot"
+	"go.viam.com/rdk/robot/client"
+	"go.viam.com/rdk/testutils"
+	"go.viam.com/rdk/utils"
+)
+
+// TODO(pre-merge) refactor this somewhat-shared function into a test_helpers esque file.
+func connect(port string, logger golog.Logger) (robot.Robot, error) {
+	connectCtx, cancelConn := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancelConn()
+	for {
+		dialCtx, dialCancel := context.WithTimeout(context.Background(), time.Millisecond*500)
+		rc, err := client.New(dialCtx, "localhost:"+port, logger,
+			client.WithDialOptions(rpc.WithForceDirectGRPC()),
+			client.WithDisableSessions(), // TODO(PRODUCT-343): add session support to modules
+		)
+		dialCancel()
+		if !errors.Is(err, context.DeadlineExceeded) {
+			return rc, err
+		}
+		select {
+		case <-connectCtx.Done():
+			return nil, connectCtx.Err()
+		default:
+		}
+	}
+}
+
+// TODO(pre-merge) refactor this somewhat-shared function into a test_helpers esque file.
+func modifyCfg(t *testing.T, cfgIn string, logger golog.Logger) (string, string, error) {
+	p, err := goutils.TryReserveRandomPort()
+	if err != nil {
+		return "", "", err
+	}
+	port := strconv.Itoa(p)
+
+	cfg, err := config.Read(context.Background(), cfgIn, logger)
+	if err != nil {
+		return "", "", err
+	}
+	cfg.Network.BindAddress = "localhost:" + port
+	output, err := json.Marshal(cfg)
+	if err != nil {
+		return "", "", err
+	}
+	file, err := os.CreateTemp(t.TempDir(), "viam-multiversionmodule-config-*")
+	if err != nil {
+		return "", "", err
+	}
+	cfgFilename := file.Name()
+	_, err = file.Write(output)
+	if err != nil {
+		return "", "", err
+	}
+	return cfgFilename, port, file.Close()
+}
+
+func TestValidationFailureDuringReconfiguration(t *testing.T) {
+	logger, logs := golog.NewObservedTestLogger(t)
+
+	// Use a valid config
+	cfgFilename, port, err := modifyCfg(t, utils.ResolveFile("module/multiversionmodule/module.json"), logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	serverPath, err := testutils.BuildTempModule(t, "web/cmd/server/")
+	test.That(t, err, test.ShouldBeNil)
+
+	server := pexec.NewManagedProcess(pexec.ProcessConfig{
+		Name: serverPath,
+		Args: []string{"-config", cfgFilename},
+		CWD:  utils.ResolveFile("./"),
+		Log:  true,
+	}, logger)
+
+	err = server.Start(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+	defer func() {
+		test.That(t, server.Stop(), test.ShouldBeNil)
+	}()
+
+	rc, err := connect(port, logger)
+	test.That(t, err, test.ShouldBeNil)
+	defer func() {
+		test.That(t, rc.Close(context.Background()), test.ShouldBeNil)
+	}()
+
+	// Assert that motors and base were added.
+	_, err = rc.ResourceByName(generic.Named("generic1"))
+	test.That(t, err, test.ShouldBeNil)
+
+	// Assert that there were no validation or component building errors
+	test.That(t, logs.FilterMessageSnippet(
+		"modular config validation error found in resource: generic1").Len(), test.ShouldEqual, 0)
+	test.That(t, logs.FilterMessageSnippet("error building component").Len(), test.ShouldEqual, 0)
+
+	// Read the config, swap to `run_version2.sh`, and overwrite the config, triggering a reconfigure where `generic1` will fail validation
+	cfg, err := config.Read(context.Background(), cfgFilename, logger)
+	test.That(t, err, test.ShouldBeNil)
+	cfg.Modules[0].ExePath = utils.ResolveFile("module/multiversionmodule/run_version2.sh")
+	newCfgBytes, err := json.Marshal(cfg)
+	test.That(t, err, test.ShouldBeNil)
+	os.WriteFile(cfgFilename, newCfgBytes, 0o644)
+
+	// Wait for reconfiguration to finish with a 30 second timeout.
+	reconfigureCheckTicker := time.NewTicker(time.Second)
+	reconfigureFinished := false
+	reconfigureCtx, reconfigureCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer reconfigureCancel()
+	for !reconfigureFinished {
+		select {
+		case <-reconfigureCheckTicker.C:
+			_, err = rc.ResourceByName(generic.Named("generic1"))
+			if err != nil {
+				reconfigureFinished = true
+			}
+		case <-reconfigureCtx.Done():
+			test.That(t, reconfigureCtx.Err(), test.ShouldBeNil)
+		}
+	}
+
+	// Check that the motors are still present but that "base1" is not started
+	_, err = rc.ResourceByName(generic.Named("generic1"))
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldResemble, `resource "rdk:component:generic/generic1" not found`)
+
+	// Assert that Validation failure message is present
+	//
+	// Race condition safety: Resource removal should occur after modular resource validation (during completeConfig), so if
+	// ResourceByName is failing, these errors should already be present
+	test.That(t, logs.FilterMessageSnippet(
+		"modular config validation error found in resource: generic1").Len(), test.ShouldEqual, 1)
+	test.That(t, logs.FilterMessageSnippet("error building component").Len(), test.ShouldEqual, 0)
+}
+
+func TestVersionBumpWithNewImplicitDeps(t *testing.T) {
+	t.Skip()
+	logger, logs := golog.NewObservedTestLogger(t)
+
+	// Use a valid config
+	cfgFilename, port, err := modifyCfg(t, utils.ResolveFile("module/multiversionmodule/module.json"), logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	serverPath, err := testutils.BuildTempModule(t, "web/cmd/server/")
+	test.That(t, err, test.ShouldBeNil)
+
+	server := pexec.NewManagedProcess(pexec.ProcessConfig{
+		Name: serverPath,
+		Args: []string{"-config", cfgFilename},
+		CWD:  utils.ResolveFile("./"),
+		Log:  true,
+	}, logger)
+
+	err = server.Start(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+	defer func() {
+		test.That(t, server.Stop(), test.ShouldBeNil)
+	}()
+
+	rc, err := connect(port, logger)
+	test.That(t, err, test.ShouldBeNil)
+	defer func() {
+		test.That(t, rc.Close(context.Background()), test.ShouldBeNil)
+	}()
+
+	// Assert that motors and base were added.
+	_, err = rc.ResourceByName(generic.Named("generic1"))
+	test.That(t, err, test.ShouldBeNil)
+
+	// Assert that there were no validation or component building errors
+	test.That(t, logs.FilterMessageSnippet(
+		"modular config validation error found in resource: generic1").Len(), test.ShouldEqual, 0)
+	test.That(t, logs.FilterMessageSnippet("error building component").Len(), test.ShouldEqual, 0)
+
+	// Read the config, swap to `run_version2.sh`, and overwrite the config, triggering a reconfigure where `generic1` will fail validation
+	cfg, err := config.Read(context.Background(), cfgFilename, logger)
+	test.That(t, err, test.ShouldBeNil)
+	cfg.Modules[0].ExePath = utils.ResolveFile("module/multiversionmodule/run_version3.sh")
+	for i, c := range cfg.Components {
+		if c.Name == "generic1" {
+			cfg.Components[i].Attributes = map[string]interface{}{"motor": "motor1"}
+		}
+	}
+	newCfgBytes, err := json.Marshal(cfg)
+	test.That(t, err, test.ShouldBeNil)
+	os.WriteFile(cfgFilename, newCfgBytes, 0o644)
+
+	// Wait for reconfiguration to finish with a 30 second timeout.
+	reconfigureCheckTicker := time.NewTicker(time.Second)
+	reconfigureFinished := false
+	reconfigureCtx, reconfigureCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer reconfigureCancel()
+	for !reconfigureFinished {
+		select {
+		case <-reconfigureCheckTicker.C:
+			_, err = rc.ResourceByName(generic.Named("generic1"))
+			if err != nil {
+				reconfigureFinished = true
+			}
+		case <-reconfigureCtx.Done():
+			test.That(t, reconfigureCtx.Err(), test.ShouldBeNil)
+		}
+	}
+
+	// Check that the motors are still present but that "base1" is not started
+	_, err = rc.ResourceByName(generic.Named("generic1"))
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldResemble, `resource "rdk:component:generic/generic1" not found`)
+
+	// Assert that Validation failure message is present
+	//
+	// Race condition safety: Resource removal should occur after modular resource validation (during completeConfig), so if
+	// ResourceByName is failing, these errors should already be present
+	test.That(t, logs.FilterMessageSnippet(
+		"modular config validation error found in resource: generic1").Len(), test.ShouldEqual, 1)
+	test.That(t, logs.FilterMessageSnippet("error building component").Len(), test.ShouldEqual, 0)
+}

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -1081,51 +1081,13 @@ func (r *localRobot) Reconfigure(ctx context.Context, newConfig *config.Config) 
 	if diff.ResourcesEqual {
 		return
 	}
-	// Set mostRecentConfig if resources were not equal.
-	r.mostRecentCfg = *newConfig
-
-	// We need to pre-add the new modules so that resource validation can check against the new models
-	// TODO(RSDK-4383) These lines are taken from uppdateResources() and should be refactored as part of this bugfix
-	for _, mod := range diff.Added.Modules {
-		if err := mod.Validate(""); err != nil {
-			r.manager.logger.Errorw("module config validation error; skipping", "module", mod.Name, "error", err)
-			continue
-		}
-		if err := r.manager.moduleManager.Add(ctx, mod); err != nil {
-			r.manager.logger.Errorw("error adding module", "module", mod.Name, "error", err)
-			continue
-		}
-	}
-
-	// If something was added or modified, go through components and services in
-	// diff.Added and diff.Modified, call Validate on all those that are modularized,
-	// and store implicit dependencies.
-	validateModularResources := func(confs []resource.Config) {
-		for i, c := range confs {
-			if r.manager.moduleManager.Provides(c) {
-				implicitDeps, err := r.manager.moduleManager.ValidateConfig(ctx, c)
-				if err != nil {
-					r.logger.Errorw("modular config validation error found in resource: "+c.Name, "error", err)
-					continue
-				}
-
-				// Modify resource to add its implicit dependencies.
-				confs[i].ImplicitDependsOn = implicitDeps
-			}
-		}
-	}
-	if diff.Added != nil {
-		validateModularResources(diff.Added.Components)
-		validateModularResources(diff.Added.Services)
-	}
-	if diff.Modified != nil {
-		validateModularResources(diff.Modified.Components)
-		validateModularResources(diff.Modified.Services)
-	}
 
 	if r.revealSensitiveConfigDiffs {
 		r.logger.Debugf("(re)configuring with %+v", diff)
 	}
+
+	// Set mostRecentConfig if resources were not equal.
+	r.mostRecentCfg = *newConfig
 
 	// First we mark diff.Removed resources and their children for removal.
 	processesToClose, resourcesToCloseBeforeComplete, _ := r.manager.markRemoved(ctx, diff.Removed, r.logger)

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -873,6 +873,43 @@ func (manager *resourceManager) updateResources(
 	defer manager.configLock.Unlock()
 	var allErrs error
 
+	for _, mod := range conf.Added.Modules {
+		// this is done in config validation but partial start rules require us to check again
+		if err := mod.Validate(""); err != nil {
+			manager.logger.Errorw("module config validation error; skipping", "module", mod.Name, "error", err)
+			continue
+		}
+		if err := manager.moduleManager.Add(ctx, mod); err != nil {
+			manager.logger.Errorw("error adding module", "module", mod.Name, "error", err)
+			continue
+		}
+	}
+
+	for _, mod := range conf.Modified.Modules {
+		// this is done in config validation but partial start rules require us to check again
+		if err := mod.Validate(""); err != nil {
+			manager.logger.Errorw("module config validation error; skipping", "module", mod.Name, "error", err)
+			continue
+		}
+		orphanedResourceNames, err := manager.moduleManager.Reconfigure(ctx, mod)
+		if err != nil {
+			manager.logger.Errorw("error reconfiguring module", "module", mod.Name, "error", err)
+		}
+		for _, resToClose := range manager.markResourcesRemoved(orphanedResourceNames, nil) {
+			if err := resToClose.Close(ctx); err != nil {
+				manager.logger.Errorw("error closing now orphaned resource", "resource",
+					resToClose.Name().String(), "module", mod.Name, "error", err)
+			}
+		}
+	}
+
+	// modules are not added into the resource tree as they belong to the module manager
+	if manager.moduleManager != nil {
+		if err := manager.moduleManager.ResolveImplicitDependenciesInConfig(ctx, conf); err != nil {
+			manager.logger.Errorw("error adding implicit dependencies", "error", err)
+		}
+	}
+
 	for _, s := range conf.Added.Services {
 		rName := s.ResourceName()
 		if manager.opts.untrustedEnv && rName.API == shell.API {
@@ -960,24 +997,6 @@ func (manager *resourceManager) updateResources(
 		manager.processConfigs[p.ID] = p
 	}
 
-	// modules are not added into the resource tree as they belong to the module manager
-	for _, mod := range conf.Modified.Modules {
-		// this is done in config validation but partial start rules require us to check again
-		if err := mod.Validate(""); err != nil {
-			manager.logger.Errorw("module config validation error; skipping", "module", mod.Name, "error", err)
-			continue
-		}
-		orphanedResourceNames, err := manager.moduleManager.Reconfigure(ctx, mod)
-		if err != nil {
-			manager.logger.Errorw("error reconfiguring module", "module", mod.Name, "error", err)
-		}
-		for _, resToClose := range manager.markResourcesRemoved(orphanedResourceNames, nil) {
-			if err := resToClose.Close(ctx); err != nil {
-				manager.logger.Errorw("error closing now orphaned resource", "resource",
-					resToClose.Name().String(), "module", mod.Name, "error", err)
-			}
-		}
-	}
 	return allErrs
 }
 

--- a/robot/impl/resource_manager_modular_test.go
+++ b/robot/impl/resource_manager_modular_test.go
@@ -453,6 +453,12 @@ func (m *dummyModMan) ValidateConfig(ctx context.Context, cfg resource.Config) (
 	return nil, nil
 }
 
+func (m *dummyModMan) ResolveImplicitDependenciesInConfig(ctx context.Context, conf *config.Diff) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return nil
+}
+
 func (m *dummyModMan) Close(ctx context.Context) error {
 	if len(m.state) != 0 {
 		return errors.New("attempt to close with active resources in place")


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-4383

In order to properly support implicit dep hotswapping, I think I need modules to be in the resource graph.