### PR TITLE
RSDK-4377 Set raw and -echo for CLI shell service

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -772,12 +772,15 @@ func (c *AppClient) StartRobotPartShell(
 	}
 
 	setRaw := func(isRaw bool) error {
-		r := "raw"
+		// NOTE(benjirewis): Linux systems seem to need both "raw" (no processing) and "-echo"
+		// (no echoing back inputted characters) in order to allow the input and output loops
+		// below to completely control the terminal.
+		args := []string{"raw", "-echo"}
 		if !isRaw {
-			r = "-raw"
+			args = []string{"-raw", "echo"}
 		}
 
-		rawMode := exec.Command("stty", r)
+		rawMode := exec.Command("stty", args...)
 		rawMode.Stdin = os.Stdin
 		return rawMode.Run()
 	}


### PR DESCRIPTION
RSDK-4377

This seems to fix the double input CLI shell issue on my Ubuntu x86 linux laptop.