### PR TITLE
[RSDK-3951] Rename SysfsBoard

### DIFF
--- a/components/board/genericlinux/board_test.go
+++ b/components/board/genericlinux/board_test.go
@@ -20,7 +20,7 @@ import (
 func TestGenericLinux(t *testing.T) {
 	ctx := context.Background()
 
-	b := &SysfsBoard{
+	b := &Board{
 		logger: golog.NewTestLogger(t),
 	}
 
@@ -46,7 +46,7 @@ func TestGenericLinux(t *testing.T) {
 	boardSPIs["open"].bus.Store(&twoStr)
 	boardSPIs["open"].openHandle.bus.bus.Store(&twoStr)
 
-	b = &SysfsBoard{
+	b = &Board{
 		Named:        board.Named("foo").AsNamed(),
 		gpioMappings: nil,
 		spis:         boardSPIs,

--- a/components/board/genericlinux/digital_interrupts.go
+++ b/components/board/genericlinux/digital_interrupts.go
@@ -16,7 +16,7 @@ import (
 )
 
 type digitalInterrupt struct {
-	parentBoard *SysfsBoard
+	parentBoard *Board
 	interrupt   board.ReconfigurableDigitalInterrupt
 	line        *gpio.LineWithEvent
 	cancelCtx   context.Context
@@ -24,7 +24,7 @@ type digitalInterrupt struct {
 	config      *board.DigitalInterruptConfig
 }
 
-func (b *SysfsBoard) createDigitalInterrupt(
+func (b *Board) createDigitalInterrupt(
 	ctx context.Context,
 	config board.DigitalInterruptConfig,
 	gpioMappings map[string]GPIOBoardMapping,

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -15,7 +15,7 @@ import (
 )
 
 type gpioPin struct {
-	parentBoard *SysfsBoard
+	parentBoard *Board
 
 	// These values should both be considered immutable.
 	devicePath string
@@ -283,7 +283,7 @@ func (pin *gpioPin) Close() error {
 	return pin.closeGpioFd()
 }
 
-func (b *SysfsBoard) createGpioPin(mapping GPIOBoardMapping) *gpioPin {
+func (b *Board) createGpioPin(mapping GPIOBoardMapping) *gpioPin {
 	pin := gpioPin{
 		parentBoard: b,
 		devicePath:  mapping.GPIOChipDev,

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -15,7 +15,7 @@ import (
 )
 
 type gpioPin struct {
-	activeBackgroundWorkers *sync.WaitGroup
+	boardWorkers *sync.WaitGroup
 
 	// These values should both be considered immutable.
 	devicePath string
@@ -180,8 +180,8 @@ func (pin *gpioPin) startSoftwarePWM() error {
 	}
 
 	pin.swPwmRunning = true
-	pin.activeBackgroundWorkers.Add(1)
-	utils.ManagedGo(pin.softwarePwmLoop, pin.activeBackgroundWorkers.Done)
+	pin.boardWorkers.Add(1)
+	utils.ManagedGo(pin.softwarePwmLoop, pin.boardWorkers.Done)
 	return nil
 }
 
@@ -285,11 +285,11 @@ func (pin *gpioPin) Close() error {
 
 func (b *Board) createGpioPin(mapping GPIOBoardMapping) *gpioPin {
 	pin := gpioPin{
-		activeBackgroundWorkers: &b.activeBackgroundWorkers,
-		devicePath:              mapping.GPIOChipDev,
-		offset:                  uint32(mapping.GPIO),
-		cancelCtx:               b.cancelCtx,
-		logger:                  b.logger,
+		boardWorkers: &b.activeBackgroundWorkers,
+		devicePath:   mapping.GPIOChipDev,
+		offset:       uint32(mapping.GPIO),
+		cancelCtx:    b.cancelCtx,
+		logger:       b.logger,
 	}
 	if mapping.HWPWMSupported {
 		pin.hwPwm = newPwmDevice(mapping.PWMSysFsDir, mapping.PWMID, b.logger)


### PR DESCRIPTION
and while I was at it, I noticed that every GPIO pin and digital interrupt was storing a pointer to the entire board, when all it really needed was a pointer to the `sync.WaitGroup` within the board. So, I cleaned that up, too. 

Each commit should be self-contained, though all 3 combined are hopefully straightforward, too. 

Thanks to @gvaradarajan for suggesting the name! Now, within this package it's just `Board`, which should be straightforward, and in other packages it's `genericlinux.Board`, which is what we've already been calling it. 

I haven't yet tried this out on a board, but I don't anticipate any problems and will make sure things work correctly before I merge. but in the meantime, I think this is ready for review.