### PR TITLE
Fix race conditions in nav service tests

### DIFF
--- a/services/navigation/store.go
+++ b/services/navigation/store.go
@@ -80,6 +80,9 @@ type MemoryNavigationStore struct {
 
 // Waypoints returns a copy of all of the waypoints in the MemoryNavigationStore.
 func (store *MemoryNavigationStore) Waypoints(ctx context.Context) ([]Waypoint, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
 	store.mu.RLock()
 	defer store.mu.RUnlock()
 	wps := make([]Waypoint, 0, len(store.waypoints))
@@ -95,6 +98,9 @@ func (store *MemoryNavigationStore) Waypoints(ctx context.Context) ([]Waypoint, 
 
 // AddWaypoint adds a waypoint to the MemoryNavigationStore.
 func (store *MemoryNavigationStore) AddWaypoint(ctx context.Context, point *geo.Point) (Waypoint, error) {
+	if ctx.Err() != nil {
+		return Waypoint{}, ctx.Err()
+	}
 	store.mu.Lock()
 	defer store.mu.Unlock()
 	newPoint := Waypoint{
@@ -108,6 +114,9 @@ func (store *MemoryNavigationStore) AddWaypoint(ctx context.Context, point *geo.
 
 // RemoveWaypoint removes a waypoint from the MemoryNavigationStore.
 func (store *MemoryNavigationStore) RemoveWaypoint(ctx context.Context, id primitive.ObjectID) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
 	store.mu.Lock()
 	defer store.mu.Unlock()
 	newWps := make([]*Waypoint, 0, len(store.waypoints)-1)
@@ -123,6 +132,9 @@ func (store *MemoryNavigationStore) RemoveWaypoint(ctx context.Context, id primi
 
 // NextWaypoint gets the next waypoint that has not been visited.
 func (store *MemoryNavigationStore) NextWaypoint(ctx context.Context) (Waypoint, error) {
+	if ctx.Err() != nil {
+		return Waypoint{}, ctx.Err()
+	}
 	store.mu.RLock()
 	defer store.mu.RUnlock()
 	for _, wp := range store.waypoints {
@@ -135,6 +147,9 @@ func (store *MemoryNavigationStore) NextWaypoint(ctx context.Context) (Waypoint,
 
 // WaypointVisited sets that a waypoint has been visited.
 func (store *MemoryNavigationStore) WaypointVisited(ctx context.Context, id primitive.ObjectID) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
 	store.mu.Lock()
 	defer store.mu.Unlock()
 	for _, wp := range store.waypoints {


### PR DESCRIPTION
This fixes at least three different lurking race conditions.

First, the "MoveOnGlobe error results in skipping the current waypoint" was failing to cancel the context with which it manually started `startWaypoint`, such that it would pick up the subsequent test's waypoints, and leave that test's `SetMode` with no way to stop it.

Second, the "Calling RemoveWaypoint on the waypoint in progress cancels current MoveOnGlobe call" was racing to see if its own `startWaypoints` loop would actually manage to start the intended waypoint before it removed it.

Finally, memory stores were not properly handling cancelled contexts, resulting in a variety of really strange behavior.

The interplay of contexts and functions here, especially in the test suite, is complex and fragile and fairly difficult to properly walk through. It may be worth looking at simplifying this. In the interim this PR should fix the flaky tests.
