### PR TITLE
RSDK-4430: Idiomize map-reduce used in motionplan nearest neighbor algorithm.

### DIFF
--- a/motionplan/nearestNeighbor.go
+++ b/motionplan/nearestNeighbor.go
@@ -109,6 +109,7 @@ func (nm *neighborManager) parallelNearestNeighbor(
 	}
 	close(nm.nnKeys)
 
+	wasInterrupted := false
 	var best node
 	bestDist := math.Inf(1)
 	for workerIdx := 0; workerIdx < nm.nCPU; workerIdx++ {
@@ -116,7 +117,8 @@ func (nm *neighborManager) parallelNearestNeighbor(
 		if candidate == nil {
 			// Seeing a `nil` here implies the workers did not get to all of the candidate
 			// neighbors. And thus we don't have the right answer to return.
-			return nil
+			wasInterrupted = true
+			continue
 		}
 
 		if candidate.dist < bestDist {
@@ -124,6 +126,10 @@ func (nm *neighborManager) parallelNearestNeighbor(
 			best = candidate.node
 		}
 	}
+	if wasInterrupted {
+		return nil
+	}
+
 	return best
 }
 

--- a/motionplan/nearestNeighbor.go
+++ b/motionplan/nearestNeighbor.go
@@ -143,7 +143,8 @@ func (nm *neighborManager) nnWorker(ctx context.Context, planOpts *plannerOption
 
 		select {
 		case <-ctx.Done():
-			break
+			nm.neighbors <- &neighbor{bestDist, best}
+			return
 		default:
 		}
 	}

--- a/motionplan/nearestNeighbor_test.go
+++ b/motionplan/nearestNeighbor_test.go
@@ -14,7 +14,7 @@ func TestNearestNeighbor(t *testing.T) {
 	rrtMap := map[node]node{}
 
 	j := &basicNode{q: []referenceframe.Input{{0.0}}}
-	// We add 110 nodes to the set of candidates. This is smaller than the configured
+	// We add ~110 nodes to the set of candidates. This is smaller than the configured
 	// `parallelNeighbors` or 1000 meaning the `nearestNeighbor` call will be evaluated in series.
 	for i := 1.0; i < 110.0; i++ {
 		iSol := &basicNode{q: []referenceframe.Input{{i}}}

--- a/motionplan/nearestNeighbor_test.go
+++ b/motionplan/nearestNeighbor_test.go
@@ -10,32 +10,32 @@ import (
 )
 
 func TestNearestNeighbor(t *testing.T) {
-	nm := &neighborManager{nCPU: 2}
+	nm := &neighborManager{nCPU: 2, parallelNeighbors: 1000}
 	rrtMap := map[node]node{}
 
 	j := &basicNode{q: []referenceframe.Input{{0.0}}}
+	// We add 110 nodes to the set of candidates. This is smaller than the configured
+	// `parallelNeighbors` or 1000 meaning the `nearestNeighbor` call will be evaluated in series.
 	for i := 1.0; i < 110.0; i++ {
 		iSol := &basicNode{q: []referenceframe.Input{{i}}}
 		rrtMap[iSol] = j
 		j = iSol
 	}
 	ctx := context.Background()
-	m1chan := make(chan node, 1)
-	defer close(m1chan)
 
 	seed := []referenceframe.Input{{23.1}}
-	// test serial NN
 	opt := newBasicPlannerOptions()
 	nn := nm.nearestNeighbor(ctx, opt, &basicNode{q: seed}, rrtMap)
 	test.That(t, nn.Q()[0].Value, test.ShouldAlmostEqual, 23.0)
 
+	// We add more nodes to trip the 1000 threshold. The `nearestNeighbor` call will use `nCPU` (2)
+	// goroutines for evaluation.
 	for i := 120.0; i < 1100.0; i++ {
 		iSol := &basicNode{q: []referenceframe.Input{{i}}}
 		rrtMap[iSol] = j
 		j = iSol
 	}
 	seed = []referenceframe.Input{{723.6}}
-	// test parallel NN
 	nn = nm.nearestNeighbor(ctx, opt, &basicNode{q: seed}, rrtMap)
 	test.That(t, nn.Q()[0].Value, test.ShouldAlmostEqual, 724.0)
 }


### PR DESCRIPTION
To start: I didn't see anything wrong with the concurrency control of how the parallel nearest neighbor code worked. But it did rely on an extra moving piece (the `ready` flag which came with its own mutex).

So I don't think I'm actually fixing anything, but figured I'd publish my thoughts/suggestions in PR format, and if we want to accept them (and cross our fingers), that's great.