### PR TITLE
RSDK-4306 Update Propertiesfor ReplayPCD

### DIFF
--- a/components/camera/replaypcd/replaypcd.go
+++ b/components/camera/replaypcd/replaypcd.go
@@ -80,6 +80,18 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 		return nil, goutils.NewConfigValidationFieldRequiredError(path, "source")
 	}
 
+	if cfg.RobotID == "" {
+		return nil, goutils.NewConfigValidationFieldRequiredError(path, "robot_id")
+	}
+
+	if cfg.LocationID == "" {
+		return nil, goutils.NewConfigValidationFieldRequiredError(path, "location_id")
+	}
+
+	if cfg.OrganizationID == "" {
+		return nil, goutils.NewConfigValidationFieldRequiredError(path, "organization_id")
+	}
+
 	var err error
 	var startTime time.Time
 	if cfg.Interval.Start != "" {

--- a/components/camera/replaypcd/replaypcd.go
+++ b/components/camera/replaypcd/replaypcd.go
@@ -309,12 +309,12 @@ func (replay *pcdCamera) Images(ctx context.Context) ([]image.Image, time.Time, 
 	return nil, time.Time{}, errors.New("Images is unimplemented")
 }
 
-// Properties is a part of the camera interface but is not implemented for replay.
+// Properties is a part of the camera interface and returns the camera.Properties struct with SupportsPCD set to true.
 func (replay *pcdCamera) Properties(ctx context.Context) (camera.Properties, error) {
 	props := camera.Properties{
 		SupportsPCD: true,
 	}
-	return props, errors.New("Properties is unimplemented")
+	return props, nil
 }
 
 // Projector is a part of the camera interface but is not implemented for replay.

--- a/components/camera/replaypcd/replaypcd.go
+++ b/components/camera/replaypcd/replaypcd.go
@@ -50,10 +50,12 @@ func init() {
 
 // Config describes how to configure the replay camera component.
 type Config struct {
-	Source    string       `json:"source,omitempty"`
-	RobotID   string       `json:"robot_id,omitempty"`
-	Interval  TimeInterval `json:"time_interval,omitempty"`
-	BatchSize *uint64      `json:"batch_size,omitempty"`
+	Source         string       `json:"source,omitempty"`
+	RobotID        string       `json:"robot_id,omitempty"`
+	LocationID     string       `json:"location_id,omitempty"`
+	OrganizationID string       `json:"organization_id,omitempty"`
+	Interval       TimeInterval `json:"time_interval,omitempty"`
+	BatchSize      *uint64      `json:"batch_size,omitempty"`
 }
 
 // TimeInterval holds the start and end time used to filter data.
@@ -297,7 +299,9 @@ func (replay *pcdCamera) Images(ctx context.Context) ([]image.Image, time.Time, 
 
 // Properties is a part of the camera interface but is not implemented for replay.
 func (replay *pcdCamera) Properties(ctx context.Context) (camera.Properties, error) {
-	var props camera.Properties
+	props := camera.Properties{
+		SupportsPCD: true,
+	}
 	return props, errors.New("Properties is unimplemented")
 }
 
@@ -362,10 +366,12 @@ func (replay *pcdCamera) Reconfigure(ctx context.Context, deps resource.Dependen
 	replay.cache = nil
 
 	replay.filter = &datapb.Filter{
-		ComponentName: replayCamConfig.Source,
-		RobotId:       replayCamConfig.RobotID,
-		MimeType:      []string{"pointcloud/pcd"},
-		Interval:      &datapb.CaptureInterval{},
+		ComponentName:   replayCamConfig.Source,
+		RobotId:         replayCamConfig.RobotID,
+		LocationIds:     []string{replayCamConfig.LocationID},
+		OrganizationIds: []string{replayCamConfig.OrganizationID},
+		MimeType:        []string{"pointcloud/pcd"},
+		Interval:        &datapb.CaptureInterval{},
 	}
 	replay.lastData = ""
 

--- a/components/camera/replaypcd/replaypcd_test.go
+++ b/components/camera/replaypcd/replaypcd_test.go
@@ -19,6 +19,7 @@ import (
 
 const (
 	datasetDirectory    = "slam/mock_lidar/%d.pcd"
+	validSource         = "source"
 	validRobotID        = "robot_id"
 	validOrganizationID = "organization_id"
 	validLocationID     = "location_id"
@@ -47,14 +48,20 @@ func TestNewReplayPCD(t *testing.T) {
 		{
 			description: "valid config with internal cloud service",
 			cfg: &Config{
-				Source: "source",
+				Source:         validSource,
+				RobotID:        validRobotID,
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
 			},
 			validCloudConnection: true,
 		},
 		{
 			description: "bad internal cloud service",
 			cfg: &Config{
-				Source: "source",
+				Source:         validSource,
+				RobotID:        validRobotID,
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
 			},
 			validCloudConnection: false,
 			expectedErr:          errors.New("failure to connect to the cloud: cloud connection error"),
@@ -62,7 +69,10 @@ func TestNewReplayPCD(t *testing.T) {
 		{
 			description: "bad start timestamp",
 			cfg: &Config{
-				Source: "source",
+				Source:         validSource,
+				RobotID:        validRobotID,
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
 				Interval: TimeInterval{
 					Start: "bad timestamp",
 				},
@@ -73,7 +83,10 @@ func TestNewReplayPCD(t *testing.T) {
 		{
 			description: "bad end timestamp",
 			cfg: &Config{
-				Source: "source",
+				Source:         validSource,
+				RobotID:        validRobotID,
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
 				Interval: TimeInterval{
 					End: "bad timestamp",
 				},
@@ -116,53 +129,21 @@ func TestNextPointCloud(t *testing.T) {
 		{
 			description: "Calling NextPointCloud no filter",
 			cfg: &Config{
-				Source: "source",
-			},
-			startFileNum: 0,
-			endFileNum:   numPCDFiles,
-		},
-		{
-			description: "Calling NextPointCloud with bad source",
-			cfg: &Config{
-				Source: "bad_source",
-			},
-			startFileNum: -1,
-			endFileNum:   -1,
-		},
-		{
-			description: "Calling NextPointCloud with robot_id",
-			cfg: &Config{
-				Source:         "source",
+				Source:         validSource,
 				RobotID:        validRobotID,
-				OrganizationID: validOrganizationID,
 				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
 			},
 			startFileNum: 0,
 			endFileNum:   numPCDFiles,
 		},
 		{
-			description: "Calling NextPointCloud with bad robot_id",
+			description: "Calling NextPointCloud with bad filter",
 			cfg: &Config{
-				Source:  "source",
-				RobotID: "bad_robot_id",
-			},
-			startFileNum: -1,
-			endFileNum:   -1,
-		},
-		{
-			description: "Calling NextPointCloud with bad robot_id",
-			cfg: &Config{
-				Source:     "source",
-				LocationID: "bad_location_id",
-			},
-			startFileNum: -1,
-			endFileNum:   -1,
-		},
-		{
-			description: "Calling NextPointCloud with bad robot_id",
-			cfg: &Config{
-				Source:         "source",
-				OrganizationID: "bad_organization_id",
+				Source:         "bad_source",
+				RobotID:        validRobotID,
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
 			},
 			startFileNum: -1,
 			endFileNum:   -1,
@@ -170,8 +151,11 @@ func TestNextPointCloud(t *testing.T) {
 		{
 			description: "Calling NextPointCloud with filter no data",
 			cfg: &Config{
-				Source:    "source",
-				BatchSize: &batchSize1,
+				Source:         validSource,
+				RobotID:        validRobotID,
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
+				BatchSize:      &batchSize1,
 				Interval: TimeInterval{
 					Start: "2000-01-01T12:00:30Z",
 					End:   "2000-01-01T12:00:40Z",
@@ -183,8 +167,11 @@ func TestNextPointCloud(t *testing.T) {
 		{
 			description: "Calling NextPointCloud with end filter",
 			cfg: &Config{
-				Source:    "source",
-				BatchSize: &batchSize1,
+				Source:         validSource,
+				RobotID:        validRobotID,
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
+				BatchSize:      &batchSize1,
 				Interval: TimeInterval{
 					End: "2000-01-01T12:00:10Z",
 				},
@@ -195,8 +182,11 @@ func TestNextPointCloud(t *testing.T) {
 		{
 			description: "Calling NextPointCloud with start filter",
 			cfg: &Config{
-				Source:    "source",
-				BatchSize: &batchSize1,
+				Source:         validSource,
+				RobotID:        validRobotID,
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
+				BatchSize:      &batchSize1,
 				Interval: TimeInterval{
 					Start: "2000-01-01T12:00:05Z",
 				},
@@ -207,8 +197,11 @@ func TestNextPointCloud(t *testing.T) {
 		{
 			description: "Calling NextPointCloud with start and end filter",
 			cfg: &Config{
-				Source:    "source",
-				BatchSize: &batchSize1,
+				Source:         validSource,
+				RobotID:        validRobotID,
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
+				BatchSize:      &batchSize1,
 				Interval: TimeInterval{
 					Start: "2000-01-01T12:00:05Z",
 					End:   "2000-01-01T12:00:10Z",
@@ -220,8 +213,11 @@ func TestNextPointCloud(t *testing.T) {
 		{
 			description: "Calling NextPointCloud with non-divisible batch size, last batch size 1",
 			cfg: &Config{
-				Source:    "source",
-				BatchSize: &batchSize2,
+				Source:         validSource,
+				RobotID:        validRobotID,
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
+				BatchSize:      &batchSize2,
 			},
 			startFileNum: 0,
 			endFileNum:   numPCDFiles,
@@ -229,8 +225,11 @@ func TestNextPointCloud(t *testing.T) {
 		{
 			description: "Calling NextPointCloud with non-divisible batch size, last batch > 1",
 			cfg: &Config{
-				Source:    "source",
-				BatchSize: &batchSize4,
+				Source:         validSource,
+				RobotID:        validRobotID,
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
+				BatchSize:      &batchSize4,
 			},
 			startFileNum: 0,
 			endFileNum:   numPCDFiles,
@@ -238,8 +237,11 @@ func TestNextPointCloud(t *testing.T) {
 		{
 			description: "Calling NextPointCloud with divisible batch size",
 			cfg: &Config{
-				Source:    "source",
-				BatchSize: &batchSize3,
+				Source:         validSource,
+				RobotID:        validRobotID,
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
+				BatchSize:      &batchSize3,
 			},
 			startFileNum: 0,
 			endFileNum:   numPCDFiles,
@@ -247,7 +249,7 @@ func TestNextPointCloud(t *testing.T) {
 		{
 			description: "Calling NextPointCloud with batching and a start and end filter",
 			cfg: &Config{
-				Source:    "source",
+				Source:    validSource,
 				BatchSize: &batchSize2,
 				Interval: TimeInterval{
 					Start: "2000-01-01T12:00:05Z",
@@ -260,8 +262,11 @@ func TestNextPointCloud(t *testing.T) {
 		{
 			description: "Calling NextPointCloud with a large batch size",
 			cfg: &Config{
-				Source:    "source",
-				BatchSize: &batchSizeLarge,
+				Source:         validSource,
+				RobotID:        validRobotID,
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
+				BatchSize:      &batchSizeLarge,
 			},
 			startFileNum: 0,
 			endFileNum:   numPCDFiles,
@@ -315,7 +320,7 @@ func TestLiveNextPointCloud(t *testing.T) {
 	defer func() { numPCDFiles = numPCDFilesOriginal }()
 
 	cfg := &Config{
-		Source: "source",
+		Source: validSource,
 	}
 
 	replayCamera, _, serverClose, err := createNewReplayPCDCamera(ctx, t, cfg, true)
@@ -366,23 +371,61 @@ func TestConfigValidation(t *testing.T) {
 		{
 			description: "Valid config with source and no timestamp",
 			cfg: &Config{
-				Source:   "source",
-				Interval: TimeInterval{},
+				Source:         validSource,
+				RobotID:        validRobotID,
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
+				Interval:       TimeInterval{},
 			},
 			expectedDeps: []string{cloud.InternalServiceName.String()},
 		},
 		{
-			description: "Valid config with source and any robot id",
+			description: "Valid config with bad source",
 			cfg: &Config{
-				Source:  "source",
-				RobotID: "source",
+				RobotID:        validRobotID,
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
+				Interval:       TimeInterval{},
 			},
-			expectedDeps: []string{cloud.InternalServiceName.String()},
+			expectedErr: utils.NewConfigValidationFieldRequiredError("", validSource),
+		},
+		{
+			description: "Valid config with bad robot_id",
+			cfg: &Config{
+				Source:         validSource,
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
+				Interval:       TimeInterval{},
+			},
+			expectedErr: utils.NewConfigValidationFieldRequiredError("", validRobotID),
+		},
+		{
+			description: "Valid config with bad location_id",
+			cfg: &Config{
+				Source:         validSource,
+				RobotID:        validRobotID,
+				OrganizationID: validOrganizationID,
+				Interval:       TimeInterval{},
+			},
+			expectedErr: utils.NewConfigValidationFieldRequiredError("", validLocationID),
+		},
+		{
+			description: "Valid config with bad organization_id",
+			cfg: &Config{
+				Source:     validSource,
+				RobotID:    validRobotID,
+				LocationID: validLocationID,
+				Interval:   TimeInterval{},
+			},
+			expectedErr: utils.NewConfigValidationFieldRequiredError("", validOrganizationID),
 		},
 		{
 			description: "Valid config with start timestamp",
 			cfg: &Config{
-				Source: "source",
+				Source:         validSource,
+				RobotID:        validRobotID,
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
 				Interval: TimeInterval{
 					Start: "2000-01-01T12:00:00Z",
 				},
@@ -392,7 +435,10 @@ func TestConfigValidation(t *testing.T) {
 		{
 			description: "Valid config with end timestamp",
 			cfg: &Config{
-				Source: "source",
+				Source:         validSource,
+				RobotID:        validRobotID,
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
 				Interval: TimeInterval{
 					End: "2000-01-01T12:00:00Z",
 				},
@@ -402,7 +448,10 @@ func TestConfigValidation(t *testing.T) {
 		{
 			description: "Valid config with start and end timestamps",
 			cfg: &Config{
-				Source: "source",
+				Source:         validSource,
+				RobotID:        validRobotID,
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
 				Interval: TimeInterval{
 					Start: "2000-01-01T12:00:00Z",
 					End:   "2000-01-01T12:00:01Z",
@@ -411,17 +460,12 @@ func TestConfigValidation(t *testing.T) {
 			expectedDeps: []string{cloud.InternalServiceName.String()},
 		},
 		{
-			description: "Invalid config no source and no timestamp",
-			cfg: &Config{
-				Source:   "",
-				Interval: TimeInterval{},
-			},
-			expectedErr: utils.NewConfigValidationFieldRequiredError("", "source"),
-		},
-		{
 			description: "Invalid config with bad start timestamp format",
 			cfg: &Config{
-				Source: "source",
+				Source:         validSource,
+				RobotID:        validRobotID,
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
 				Interval: TimeInterval{
 					Start: "gibberish",
 				},
@@ -431,7 +475,10 @@ func TestConfigValidation(t *testing.T) {
 		{
 			description: "Invalid config with bad end timestamp format",
 			cfg: &Config{
-				Source: "source",
+				Source:         validSource,
+				RobotID:        validRobotID,
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
 				Interval: TimeInterval{
 					End: "gibberish",
 				},
@@ -441,7 +488,10 @@ func TestConfigValidation(t *testing.T) {
 		{
 			description: "Invalid config with bad start timestamp",
 			cfg: &Config{
-				Source: "source",
+				Source:         validSource,
+				RobotID:        validRobotID,
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
 				Interval: TimeInterval{
 					Start: "3000-01-01T12:00:00Z",
 				},
@@ -451,7 +501,10 @@ func TestConfigValidation(t *testing.T) {
 		{
 			description: "Invalid config with bad end timestamp",
 			cfg: &Config{
-				Source: "source",
+				Source:         validSource,
+				RobotID:        validRobotID,
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
 				Interval: TimeInterval{
 					End: "3000-01-01T12:00:00Z",
 				},
@@ -461,7 +514,10 @@ func TestConfigValidation(t *testing.T) {
 		{
 			description: "Invalid config with start after end timestamps",
 			cfg: &Config{
-				Source: "source",
+				Source:         validSource,
+				RobotID:        validRobotID,
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
 				Interval: TimeInterval{
 					Start: "2000-01-01T12:00:01Z",
 					End:   "2000-01-01T12:00:00Z",
@@ -472,7 +528,10 @@ func TestConfigValidation(t *testing.T) {
 		{
 			description: "Invalid config with batch size above max",
 			cfg: &Config{
-				Source: "source",
+				Source:         validSource,
+				RobotID:        validRobotID,
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
 				Interval: TimeInterval{
 					Start: "2000-01-01T12:00:00Z",
 					End:   "2000-01-01T12:00:01Z",
@@ -484,7 +543,10 @@ func TestConfigValidation(t *testing.T) {
 		{
 			description: "Invalid config with batch size 0",
 			cfg: &Config{
-				Source: "source",
+				Source:         validSource,
+				RobotID:        validRobotID,
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
 				Interval: TimeInterval{
 					Start: "2000-01-01T12:00:00Z",
 					End:   "2000-01-01T12:00:01Z",
@@ -511,7 +573,12 @@ func TestConfigValidation(t *testing.T) {
 func TestUnimplementedFunctions(t *testing.T) {
 	ctx := context.Background()
 
-	replayCamCfg := &Config{Source: "source"}
+	replayCamCfg := &Config{
+		Source:         validSource,
+		RobotID:        validRobotID,
+		LocationID:     validLocationID,
+		OrganizationID: validOrganizationID,
+	}
 	replayCamera, _, serverClose, err := createNewReplayPCDCamera(ctx, t, replayCamCfg, true)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -579,18 +646,34 @@ func TestNextPointCloudTimestamps(t *testing.T) {
 	}
 
 	t.Run("no batching", func(t *testing.T) {
-		cfg := &Config{Source: "source"}
+		cfg := &Config{
+			Source:         validSource,
+			RobotID:        validRobotID,
+			LocationID:     validLocationID,
+			OrganizationID: validOrganizationID,
+		}
 		testCameraWithCfg(cfg)
 	})
 	t.Run("with batching", func(t *testing.T) {
-		cfg := &Config{Source: "source", BatchSize: &batchSize2}
+		cfg := &Config{
+			Source:         validSource,
+			RobotID:        validRobotID,
+			LocationID:     validLocationID,
+			OrganizationID: validOrganizationID,
+			BatchSize:      &batchSize2,
+		}
 		testCameraWithCfg(cfg)
 	})
 }
 
 func TestReconfigure(t *testing.T) {
 	// Construct replay camera
-	cfg := &Config{Source: "source"}
+	cfg := &Config{
+		Source:         validSource,
+		RobotID:        validRobotID,
+		LocationID:     validLocationID,
+		OrganizationID: validOrganizationID,
+	}
 	ctx := context.Background()
 	replayCamera, deps, serverClose, err := createNewReplayPCDCamera(ctx, t, cfg, true)
 	test.That(t, err, test.ShouldBeNil)
@@ -606,7 +689,7 @@ func TestReconfigure(t *testing.T) {
 	}
 
 	// Reconfigure with a new batch size
-	cfg = &Config{Source: "source", BatchSize: &batchSize4}
+	cfg = &Config{Source: validSource, BatchSize: &batchSize4}
 	replayCamera.Reconfigure(ctx, deps, resource.Config{ConvertedAttributes: cfg})
 
 	// Call NextPointCloud a couple more times, ensuring that we start over from the beginning
@@ -620,7 +703,7 @@ func TestReconfigure(t *testing.T) {
 	}
 
 	// Reconfigure again, batch size 1
-	cfg = &Config{Source: "source", BatchSize: &batchSize1}
+	cfg = &Config{Source: validSource, BatchSize: &batchSize1}
 	replayCamera.Reconfigure(ctx, deps, resource.Config{ConvertedAttributes: cfg})
 
 	// Again verify dataset starts from beginning

--- a/components/camera/replaypcd/replaypcd_test.go
+++ b/components/camera/replaypcd/replaypcd_test.go
@@ -138,12 +138,45 @@ func TestNextPointCloud(t *testing.T) {
 			endFileNum:   numPCDFiles,
 		},
 		{
-			description: "Calling NextPointCloud with bad filter",
+			description: "Calling NextPointCloud with bad source",
 			cfg: &Config{
 				Source:         "bad_source",
 				RobotID:        validRobotID,
 				LocationID:     validLocationID,
 				OrganizationID: validOrganizationID,
+			},
+			startFileNum: -1,
+			endFileNum:   -1,
+		},
+		{
+			description: "Calling NextPointCloud with bad robot_id",
+			cfg: &Config{
+				Source:         validSource,
+				RobotID:        "bad_robot_id",
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
+			},
+			startFileNum: -1,
+			endFileNum:   -1,
+		},
+		{
+			description: "Calling NextPointCloud with bad location_id",
+			cfg: &Config{
+				Source:         validSource,
+				RobotID:        validRobotID,
+				LocationID:     "bad_location_id",
+				OrganizationID: validOrganizationID,
+			},
+			startFileNum: -1,
+			endFileNum:   -1,
+		},
+		{
+			description: "Calling NextPointCloud with bad organization_id",
+			cfg: &Config{
+				Source:         validSource,
+				RobotID:        validRobotID,
+				LocationID:     validLocationID,
+				OrganizationID: "bad_organization_id",
 			},
 			startFileNum: -1,
 			endFileNum:   -1,

--- a/components/camera/replaypcd/replaypcd_test.go
+++ b/components/camera/replaypcd/replaypcd_test.go
@@ -17,7 +17,12 @@ import (
 	"go.viam.com/rdk/utils/contextutils"
 )
 
-const datasetDirectory = "slam/mock_lidar/%d.pcd"
+const (
+	datasetDirectory    = "slam/mock_lidar/%d.pcd"
+	validRobotID        = "robot_id"
+	validOrganizationID = "organization_id"
+	validLocationID     = "location_id"
+)
 
 var (
 	numPCDFiles       = 15
@@ -127,8 +132,10 @@ func TestNextPointCloud(t *testing.T) {
 		{
 			description: "Calling NextPointCloud with robot_id",
 			cfg: &Config{
-				Source:  "source",
-				RobotID: "robot_id",
+				Source:         "source",
+				RobotID:        validRobotID,
+				OrganizationID: validOrganizationID,
+				LocationID:     validLocationID,
 			},
 			startFileNum: 0,
 			endFileNum:   numPCDFiles,
@@ -138,6 +145,24 @@ func TestNextPointCloud(t *testing.T) {
 			cfg: &Config{
 				Source:  "source",
 				RobotID: "bad_robot_id",
+			},
+			startFileNum: -1,
+			endFileNum:   -1,
+		},
+		{
+			description: "Calling NextPointCloud with bad robot_id",
+			cfg: &Config{
+				Source:     "source",
+				LocationID: "bad_location_id",
+			},
+			startFileNum: -1,
+			endFileNum:   -1,
+		},
+		{
+			description: "Calling NextPointCloud with bad robot_id",
+			cfg: &Config{
+				Source:         "source",
+				OrganizationID: "bad_organization_id",
 			},
 			startFileNum: -1,
 			endFileNum:   -1,

--- a/components/camera/replaypcd/replaypcd_utils_test.go
+++ b/components/camera/replaypcd/replaypcd_utils_test.go
@@ -236,7 +236,7 @@ func resourcesFromDeps(t *testing.T, r robot.Robot, deps []string) resource.Depe
 // the provided filter and last returned artifact.
 func getNextDataAfterFilter(filter *datapb.Filter, last string) (int, error) {
 	// Basic component part (source) filter
-	if filter.ComponentName != "" && filter.ComponentName != "source" {
+	if filter.ComponentName != "" && filter.ComponentName != validSource {
 		return 0, ErrEndOfDataset
 	}
 

--- a/components/camera/replaypcd/replaypcd_utils_test.go
+++ b/components/camera/replaypcd/replaypcd_utils_test.go
@@ -247,7 +247,7 @@ func getNextDataAfterFilter(filter *datapb.Filter, last string) (int, error) {
 
 	// Basic location_id filter
 	if len(filter.LocationIds) == 0 {
-		return 0, errors.New("issue occurred with transmitting LocationIds to the cloud")
+		return 0, errors.New("LocationIds in filter is empty")
 	}
 	if filter.LocationIds[0] != "" && filter.LocationIds[0] != validLocationID {
 		return 0, ErrEndOfDataset
@@ -255,7 +255,7 @@ func getNextDataAfterFilter(filter *datapb.Filter, last string) (int, error) {
 
 	// Basic organization_id filter
 	if len(filter.OrganizationIds) == 0 {
-		return 0, errors.New("issue occurred with transmitting OrganizationIds to the cloud")
+		return 0, errors.New("OrganizationIds in filter is empty")
 	}
 	if filter.OrganizationIds[0] != "" && filter.OrganizationIds[0] != validOrganizationID {
 		return 0, ErrEndOfDataset

--- a/components/camera/replaypcd/replaypcd_utils_test.go
+++ b/components/camera/replaypcd/replaypcd_utils_test.go
@@ -241,7 +241,23 @@ func getNextDataAfterFilter(filter *datapb.Filter, last string) (int, error) {
 	}
 
 	// Basic robot_id filter
-	if filter.RobotId != "" && filter.RobotId != "robot_id" {
+	if filter.RobotId != "" && filter.RobotId != validRobotID {
+		return 0, ErrEndOfDataset
+	}
+
+	// Basic location_id filter
+	if len(filter.LocationIds) == 0 {
+		return 0, errors.New("issue occurred with transmitting LocationIds to the cloud")
+	}
+	if filter.LocationIds[0] != "" && filter.LocationIds[0] != validLocationID {
+		return 0, ErrEndOfDataset
+	}
+
+	// Basic organization_id filter
+	if len(filter.OrganizationIds) == 0 {
+		return 0, errors.New("issue occurred with transmitting OrganizationIds to the cloud")
+	}
+	if filter.OrganizationIds[0] != "" && filter.OrganizationIds[0] != validOrganizationID {
 		return 0, ErrEndOfDataset
 	}
 


### PR DESCRIPTION
This PR implements the Properties function for the `replaypcd` component as well as updates the config to include `organization_id` and `location_id` as described in the scope doc for IMU integration for replay movement sensors.

**JIRA Ticket:** https://viam.atlassian.net/browse/RSDK-4306