### PR TITLE
Bump RC for app hotfix

### DIFF
--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "2.0.13",
+  "version": "2.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/remote-control",
-      "version": "2.0.13",
+      "version": "2.0.15",
       "license": "Apache-2.0",
       "devDependencies": {
         "@improbable-eng/grpc-web": "0.15.0",

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "license": "Apache-2.0",
   "type": "module",
   "files": [


### PR DESCRIPTION
We want to publish the RC to unblock users hitting https://viam.atlassian.net/browse/RSDK-4451 in the app. This PR bumps the version of RC for publication with the included fix from: https://github.com/viamrobotics/rdk/pull/2772

This code was tested on a bot using the app image from the above PR.