### PR TITLE
RSDK-4429 - add slam map package type to RDK

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -870,6 +870,8 @@ const (
 	PackageTypeMlModel PackageType = "ml_model"
 	// PackageTypeModule represents a module type.
 	PackageTypeModule PackageType = "module"
+	// PackageTypeSlamMap represents a slam internal state.
+	PackageTypeSlamMap PackageType = "slam_map"
 )
 
 // SupportedPackageTypes is a list of all of the valid package types.

--- a/config/config.go
+++ b/config/config.go
@@ -875,7 +875,7 @@ const (
 )
 
 // SupportedPackageTypes is a list of all of the valid package types.
-var SupportedPackageTypes = []PackageType{PackageTypeMlModel, PackageTypeModule}
+var SupportedPackageTypes = []PackageType{PackageTypeMlModel, PackageTypeModule, PackageTypeSlamMap}
 
 // A PackageConfig describes the configuration of a Package.
 type PackageConfig struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1004,6 +1004,15 @@ func TestPackageConfig(t *testing.T) {
 		},
 		{
 			config: config.PackageConfig{
+				Name:    "my_slam_map",
+				Type:    config.PackageTypeSlamMap,
+				Package: "my_org/my_slam_map",
+				Version: "latest",
+			},
+			expectedRealFilePath: filepath.Join(viamDotDir, "packages", ".data", "slam_map", "my_org-my_slam_map-latest"),
+		},
+		{
+			config: config.PackageConfig{
 				Name:    "::::",
 				Type:    config.PackageTypeMlModel,
 				Package: "my_org/my_ml_model",

--- a/config/proto_conversions.go
+++ b/config/proto_conversions.go
@@ -841,6 +841,8 @@ func PackageTypeToProto(t PackageType) (*packagespb.PackageType, error) {
 		return packagespb.PackageType_PACKAGE_TYPE_ML_MODEL.Enum(), nil
 	case PackageTypeModule:
 		return packagespb.PackageType_PACKAGE_TYPE_MODULE.Enum(), nil
+	case PackageTypeSlamMap:
+		return packagespb.PackageType_PACKAGE_TYPE_SLAM_MAP.Enum(), nil
 	default:
 		return packagespb.PackageType_PACKAGE_TYPE_UNSPECIFIED.Enum(), errors.Errorf("unknown package type %q", t)
 	}


### PR DESCRIPTION
### Changes

1. slam_map as a type that rdk looks for in config.go
2. add test for slam map case
3. add packagespb.PackageType_PACKAGE_TYPE_SLAM_MAP 

### Testing
ran viam server with this config:
```
{
  "packages": [
    {
      "name": "rsdk-2191",
      "type": "slam_map",
      "version": "1691788595",
      "package": "a848d8aa-c258-4492-9ca6-90c6d7b78308/rsdk-2191"
    }
  ],
  "components": []
}
```
and saw the pbstream appear in the .viam directory of my machine