### PR TITLE
RSDK-3646 - Obstacles Depth (fixes)

### DIFF
--- a/services/vision/client.go
+++ b/services/vision/client.go
@@ -222,7 +222,7 @@ func protoToObjects(pco []*commonpb.PointCloudObject) ([]*vision.Object, error) 
 			}
 			return ""
 		}()
-		objects[i], err = vision.NewObjectWithLabel(pc, label)
+		objects[i], err = vision.NewObjectWithLabel(pc, label, o.Geometries.GetGeometries()[i])
 		if err != nil {
 			return nil, err
 		}

--- a/services/vision/client.go
+++ b/services/vision/client.go
@@ -222,7 +222,12 @@ func protoToObjects(pco []*commonpb.PointCloudObject) ([]*vision.Object, error) 
 			}
 			return ""
 		}()
-		objects[i], err = vision.NewObjectWithLabel(pc, label, o.Geometries.GetGeometries()[i])
+		n := len(o.Geometries.GetGeometries())
+		if i < n {
+			objects[i], err = vision.NewObjectWithLabel(pc, label, o.Geometries.GetGeometries()[i])
+		} else {
+			objects[i], err = vision.NewObjectWithLabel(pc, label, nil)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/services/vision/obstaclesdepth/obstacles_depth.go
+++ b/services/vision/obstaclesdepth/obstacles_depth.go
@@ -38,7 +38,7 @@ type ObsDepthConfig struct {
 	Hmax           float64 `json:"h_max_m"`
 	ThetaMax       float64 `json:"theta_max_deg"`
 	ReturnPCDs     bool    `json:"return_pcds"`
-	WithGeometries bool    `json:"with_geometries"`
+	WithGeometries *bool   `json:"with_geometries"`
 }
 
 // obsDepth is the underlying struct actually used by the service.
@@ -120,11 +120,15 @@ func registerObstaclesDepth(
 	if conf.ThetaMax == 0 {
 		conf.ThetaMax = defaultThetamax
 	}
+	if conf.WithGeometries == nil {
+		wg := true
+		conf.WithGeometries = &wg
+	}
 
 	sinTheta := math.Sin(conf.ThetaMax * math.Pi / 180) // sin(radians(theta))
 	myObsDep := obsDepth{
 		hMin: 1000 * conf.Hmin, hMax: 1000 * conf.Hmax, sinTheta: sinTheta,
-		returnPCDs: conf.ReturnPCDs, k: defaultK, withGeoms: conf.WithGeometries,
+		returnPCDs: conf.ReturnPCDs, k: defaultK, withGeoms: *conf.WithGeometries,
 	}
 
 	segmenter := myObsDep.buildObsDepth(logger) // does the thing

--- a/services/vision/obstaclesdepth/obstacles_depth.go
+++ b/services/vision/obstaclesdepth/obstacles_depth.go
@@ -170,7 +170,6 @@ func (o *obsDepth) obsDepthNoIntrinsics(ctx context.Context, src camera.VideoSou
 	pt := spatialmath.NewPoint(r3.Vector{X: 0, Y: 0, Z: float64(depData[med])}, "")
 	toReturn := make([]*vision.Object, 1)
 	toReturn[0] = &vision.Object{Geometry: pt}
-
 	return toReturn, nil
 }
 

--- a/services/vision/obstaclesdepth/obstacles_depth.go
+++ b/services/vision/obstaclesdepth/obstacles_depth.go
@@ -82,7 +82,7 @@ func init() {
 // Validate ensures all parts of the config are valid.
 func (config *ObsDepthConfig) Validate(path string) ([]string, error) {
 	deps := []string{}
-	if config.Hmin >= config.Hmax {
+	if config.Hmin >= config.Hmax && !(config.Hmin == 0 && config.Hmax == 0) {
 		return nil, errors.New("Hmin should be less than Hmax")
 	}
 	if config.Hmin < 0 {
@@ -105,7 +105,7 @@ func registerObstaclesDepth(
 	r robot.Robot,
 	logger golog.Logger,
 ) (svision.Service, error) {
-	_, span := trace.StartSpan(ctx, "service::vision::registerObstacleDistanceDetector")
+	_, span := trace.StartSpan(ctx, "service::vision::registerObstacleDepth")
 	defer span.End()
 	if conf == nil {
 		return nil, errors.New("config for obstacles_depth cannot be nil")

--- a/services/vision/obstaclesdepth/obstacles_depth_test.go
+++ b/services/vision/obstaclesdepth/obstacles_depth_test.go
@@ -38,17 +38,19 @@ func (r testReader) Close(ctx context.Context) error {
 
 func TestObstacleDepth(t *testing.T) {
 	noIntrinsicsCfg := ObsDepthConfig{
-		Hmin:       defaultHmin,
-		Hmax:       defaultHmax,
-		ThetaMax:   defaultThetamax,
-		ReturnPCDs: false,
+		Hmin:           defaultHmin,
+		Hmax:           defaultHmax,
+		ThetaMax:       defaultThetamax,
+		ReturnPCDs:     false,
+		WithGeometries: false,
 	}
 	someIntrinsics := transform.PinholeCameraIntrinsics{Fx: 604.5, Fy: 609.6, Ppx: 324.6, Ppy: 238.9, Width: 640, Height: 480}
 	withIntrinsicsCfg := ObsDepthConfig{
-		Hmin:       defaultHmin,
-		Hmax:       defaultHmax,
-		ThetaMax:   defaultThetamax,
-		ReturnPCDs: true,
+		Hmin:           defaultHmin,
+		Hmax:           defaultHmax,
+		ThetaMax:       defaultThetamax,
+		ReturnPCDs:     true,
+		WithGeometries: true,
 	}
 
 	ctx := context.Background()

--- a/services/vision/obstaclesdepth/obstacles_depth_test.go
+++ b/services/vision/obstaclesdepth/obstacles_depth_test.go
@@ -37,20 +37,20 @@ func (r testReader) Close(ctx context.Context) error {
 }
 
 func TestObstacleDepth(t *testing.T) {
+	no := false
 	noIntrinsicsCfg := ObsDepthConfig{
 		Hmin:           defaultHmin,
 		Hmax:           defaultHmax,
 		ThetaMax:       defaultThetamax,
 		ReturnPCDs:     false,
-		WithGeometries: false,
+		WithGeometries: &no,
 	}
 	someIntrinsics := transform.PinholeCameraIntrinsics{Fx: 604.5, Fy: 609.6, Ppx: 324.6, Ppy: 238.9, Width: 640, Height: 480}
 	withIntrinsicsCfg := ObsDepthConfig{
-		Hmin:           defaultHmin,
-		Hmax:           defaultHmax,
-		ThetaMax:       defaultThetamax,
-		ReturnPCDs:     true,
-		WithGeometries: true,
+		Hmin:       defaultHmin,
+		Hmax:       defaultHmax,
+		ThetaMax:   defaultThetamax,
+		ReturnPCDs: true,
 	}
 
 	ctx := context.Background()

--- a/services/vision/server.go
+++ b/services/vision/server.go
@@ -3,6 +3,7 @@ package vision
 import (
 	"bytes"
 	"context"
+
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 	commonpb "go.viam.com/api/common/v1"

--- a/services/vision/server.go
+++ b/services/vision/server.go
@@ -198,6 +198,9 @@ func segmentsToProto(frame string, segs []*vision.Object) ([]*commonpb.PointClou
 	protoSegs := make([]*commonpb.PointCloudObject, 0, len(segs))
 	for _, seg := range segs {
 		var buf bytes.Buffer
+		if seg.PointCloud == nil {
+			seg.PointCloud = pointcloud.New()
+		}
 		err := pointcloud.ToPCD(seg, &buf, pointcloud.PCDBinary)
 		if err != nil {
 			return nil, err

--- a/services/vision/server.go
+++ b/services/vision/server.go
@@ -3,7 +3,6 @@ package vision
 import (
 	"bytes"
 	"context"
-
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 	commonpb "go.viam.com/api/common/v1"

--- a/vision/object.go
+++ b/vision/object.go
@@ -2,8 +2,10 @@ package vision
 
 import (
 	"errors"
-	commonpb "go.viam.com/api/common/v1"
 	"math"
+
+
+	commonpb "go.viam.com/api/common/v1"
 
 	pc "go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/spatialmath"
@@ -38,7 +40,6 @@ func NewObjectWithLabel(cloud pc.PointCloud, label string, geometry *commonpb.Ge
 		return nil, err
 	}
 	return &Object{PointCloud: cloud, Geometry: geom}, nil
-
 }
 
 // NewEmptyObject creates a new empty point cloud with metadata.

--- a/vision/object.go
+++ b/vision/object.go
@@ -34,6 +34,9 @@ func NewObjectWithLabel(cloud pc.PointCloud, label string, geometry *commonpb.Ge
 		}
 		return &Object{cloud, box}, nil
 	}
+	if label != "" { // will override geometry proto label with given label (unless empty)
+		geometry.Label = label
+	}
 	geom, err := spatialmath.NewGeometryFromProto(geometry)
 	if err != nil {
 		return nil, err

--- a/vision/object.go
+++ b/vision/object.go
@@ -3,6 +3,7 @@ package vision
 import (
 	"errors"
 	"math"
+
 	commonpb "go.viam.com/api/common/v1"
 
 	pc "go.viam.com/rdk/pointcloud"

--- a/vision/object.go
+++ b/vision/object.go
@@ -3,8 +3,6 @@ package vision
 import (
 	"errors"
 	"math"
-
-
 	commonpb "go.viam.com/api/common/v1"
 
 	pc "go.viam.com/rdk/pointcloud"

--- a/vision/object_test.go
+++ b/vision/object_test.go
@@ -36,6 +36,43 @@ func TestObjectCreation(t *testing.T) {
 	test.That(t, obj.Geometry.AlmostEqual(expectedBox), test.ShouldBeTrue)
 }
 
+func TestObjectCreationWithLabel(t *testing.T) {
+	// test that object created "withlabel" maintains label
+
+	geomLabel := "blah"
+	requestedLabel := "notBlah"
+
+	// create point cloud
+	pc := pointcloud.New()
+	err := pc.Set(pointcloud.NewVector(0, 0, 200), nil)
+	test.That(t, err, test.ShouldBeNil)
+
+	// create labelled and unlabelled Geometries
+	geom := spatialmath.NewPoint(r3.Vector{0, 0, 200}, geomLabel)
+	geom2 := spatialmath.NewPoint(r3.Vector{0, 0, 200}, "")
+	pbGeomWithLabel := geom.ToProtobuf()
+	pbGeomNoLabel := geom2.ToProtobuf()
+
+	// Test that a requestedLabel will overwrite the geometry label
+	obj, err := NewObjectWithLabel(pc, "", pbGeomWithLabel)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, obj.Geometry.Label(), test.ShouldResemble, geomLabel)
+
+	obj, err = NewObjectWithLabel(pc, requestedLabel, pbGeomWithLabel)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, obj.Geometry.Label(), test.ShouldResemble, requestedLabel)
+
+	// Test that with no geometry label, the requestedLabel persists
+	obj2, err := NewObjectWithLabel(pc, "", pbGeomNoLabel)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, obj2.Geometry.Label(), test.ShouldResemble, "")
+
+	obj2, err = NewObjectWithLabel(pc, requestedLabel, pbGeomNoLabel)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, obj2.Geometry.Label(), test.ShouldResemble, requestedLabel)
+
+}
+
 func TestObjectDistance(t *testing.T) {
 	pc := pointcloud.New()
 	err := pc.Set(pointcloud.NewVector(0, 0, 0), nil)

--- a/vision/object_test.go
+++ b/vision/object_test.go
@@ -40,7 +40,7 @@ func TestObjectCreationWithLabel(t *testing.T) {
 	// test that object created "withlabel" maintains label
 
 	geomLabel := "blah"
-	requestedLabel := "notBlah"
+	providedLabel := "notBlah"
 
 	// create point cloud
 	pc := pointcloud.New()
@@ -53,24 +53,23 @@ func TestObjectCreationWithLabel(t *testing.T) {
 	pbGeomWithLabel := geom.ToProtobuf()
 	pbGeomNoLabel := geom2.ToProtobuf()
 
-	// Test that a requestedLabel will overwrite the geometry label
+	// Test that a providedLabel will overwrite the geometry label
 	obj, err := NewObjectWithLabel(pc, "", pbGeomWithLabel)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, obj.Geometry.Label(), test.ShouldResemble, geomLabel)
 
-	obj, err = NewObjectWithLabel(pc, requestedLabel, pbGeomWithLabel)
+	obj, err = NewObjectWithLabel(pc, providedLabel, pbGeomWithLabel)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, obj.Geometry.Label(), test.ShouldResemble, requestedLabel)
+	test.That(t, obj.Geometry.Label(), test.ShouldResemble, providedLabel)
 
-	// Test that with no geometry label, the requestedLabel persists
+	// Test that with no geometry label, the providedLabel persists
 	obj2, err := NewObjectWithLabel(pc, "", pbGeomNoLabel)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, obj2.Geometry.Label(), test.ShouldResemble, "")
 
-	obj2, err = NewObjectWithLabel(pc, requestedLabel, pbGeomNoLabel)
+	obj2, err = NewObjectWithLabel(pc, providedLabel, pbGeomNoLabel)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, obj2.Geometry.Label(), test.ShouldResemble, requestedLabel)
-
+	test.That(t, obj2.Geometry.Label(), test.ShouldResemble, providedLabel)
 }
 
 func TestObjectDistance(t *testing.T) {

--- a/vision/segmentation/detections_to_objects.go
+++ b/vision/segmentation/detections_to_objects.go
@@ -89,7 +89,7 @@ func DetectionSegmenter(detector objectdetection.Detector, meanK int, sigma, con
 			if pc.Size() == 0 {
 				continue
 			}
-			obj, err := vision.NewObjectWithLabel(pc, d.Label())
+			obj, err := vision.NewObjectWithLabel(pc, d.Label(), nil)
 			if err != nil {
 				return nil, err
 			}

--- a/vision/segmentation/segments.go
+++ b/vision/segmentation/segments.go
@@ -28,7 +28,7 @@ func NewSegments() *Segments {
 func NewSegmentsFromSlice(clouds []pc.PointCloud, label string) (*Segments, error) {
 	segments := NewSegments()
 	for i, cloud := range clouds {
-		seg, err := vision.NewObjectWithLabel(cloud, label)
+		seg, err := vision.NewObjectWithLabel(cloud, label, nil)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
A handful of fixes necessary for obstacles_depth to work well. Successfully tested on hardware (RPi). Quick list:

1. Currently, when you don't put in parameters (to get default), you get an error because Hmin isn't less than Hmax.
2. There was a typo in the trace/span
3. Update vision server (segmentsToProto) to handle a nil pointcloud instead of freaking out.
4. Update vision client (protoToObjects) to not delete geometries from the object

