### PR TITLE
RSDK-4551: Remove the localRobot lock acquisition from `Close`.

### DIFF
--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -114,9 +114,6 @@ func (r *localRobot) PackageManager() packages.Manager {
 
 // Close attempts to cleanly close down all constituent parts of the robot.
 func (r *localRobot) Close(ctx context.Context) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
 	// we will stop and close web ourselves since modules need it to be
 	// removed properly and in the right order, so grab it before its removed
 	// from the graph/closed automatically.


### PR DESCRIPTION
The lock can create a deadlock when `Close` happens concurrently to processing a `localRobot.Status` call. Specifically when the `Close` method is waiting on its sub-components to shutdown. An alternate fix would be to release the lock while waiting for the sub-components to shutdown.

I argue the lock acquisition in `Close` can be removed because:
- All `localRobot` members accessed in `Close` are assigned to in construction.
- All `WaitGroup.Wait` calls have had the corresponding `Add` calls done during construction.
- If the lock acquisition is providing necessary synchronization for calls into `localRobot` member fields, I argue those sub-components should own their synchronization requirements. We should file separate tickets as those problems are observed.