### PR TITLE
RSDK-4469 - add reconfigure waitgroup

### DIFF
--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -534,9 +534,11 @@ func (manager *resourceManager) completeConfig(
 		resName := resName
 		ctxWithTimeout, timeoutCancel := context.WithTimeout(ctx, timeout)
 		defer timeoutCancel()
+		robot.reconfigureWorkers.Add(1)
 		goutils.PanicCapturingGo(func() {
 			defer func() {
 				resChan <- struct{}{}
+				robot.reconfigureWorkers.Done()
 			}()
 			gNode, ok := manager.resources.Node(resName)
 			if !ok || !gNode.NeedsReconfigure() {

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -3607,6 +3607,11 @@ func TestResourceConstructTimeout(t *testing.T) {
 	testutils.WaitForAssertion(t, func(tb testing.TB) {
 		test.That(tb, timeOutErrorCount(), test.ShouldEqual, 1)
 	})
+
+	rr, ok := r.(*localRobot)
+	test.That(t, ok, test.ShouldBeTrue)
+
+	rr.reconfigureWorkers.Wait()
 }
 
 type mockFake struct {


### PR DESCRIPTION
#### Major changes
Adds waitgroup to local robot for tracking reconfigure threads. This allows us to delay completing a test until all background threads are complete, thus eliminating a class of race condition risks.