### PR TITLE
RSDK-4576: Change default values for kinematic base

### DIFF
--- a/components/base/kinematicbase/differentialDrive.go
+++ b/components/base/kinematicbase/differentialDrive.go
@@ -215,7 +215,7 @@ func (ddk *differentialDriveKinematics) issueCommand(ctx context.Context, curren
 		return true, ddk.Spin(ctx, math.Min(headingErr, ddk.options.MaxSpinAngleDeg), ddk.options.AngularVelocityDegsPerSec, nil)
 	} else if distErr > ddk.options.GoalRadiusMM {
 		// base is pointed the correct direction but not there yet; forge onward
-		return true, ddk.MoveStraight(ctx, int(distErr), ddk.options.LinearVelocityMMPerSec, nil)
+		return true, ddk.MoveStraight(ctx, int(math.Min(distErr, ddk.options.MaxMoveStraightMM)), ddk.options.LinearVelocityMMPerSec, nil)
 	}
 	return false, nil
 }

--- a/components/base/kinematicbase/kinematics.go
+++ b/components/base/kinematicbase/kinematics.go
@@ -23,17 +23,17 @@ type KinematicBase interface {
 
 const (
 	// LinearVelocityMMPerSec is the linear velocity the base will drive at in mm/s.
-	defaultLinearVelocityMMPerSec = 100
+	defaultLinearVelocityMMPerSec = 200
 
 	// AngularVelocityMMPerSec is the angular velocity the base will turn with in deg/s.
 	defaultAngularVelocityDegsPerSec = 60
 
 	// distThresholdMM is used when the base is moving to a goal. It is considered successful if it is within this radius.
-	defaultGoalRadiusMM = 100
+	defaultGoalRadiusMM = 300
 
 	// headingThresholdDegrees is used when the base is moving to a goal.
 	// If its heading is within this angle it is considered on the correct path.
-	defaultHeadingThresholdDegrees = 15
+	defaultHeadingThresholdDegrees = 8
 
 	// planDeviationThresholdMM is the amount that the base is allowed to deviate from the straight line path it is intended to travel.
 	// If it ever exceeds this amount the movement will fail and an error will be returned.
@@ -44,6 +44,10 @@ const (
 
 	// minimumMovementThresholdMM is the amount that a base needs to move for it not to be considered stationary.
 	defaultMinimumMovementThresholdMM = 20 // mm
+
+	// maxMoveStraightMM is the maximum distance the base should move with a single MoveStraight command.
+	// used to break up large driving segments to prevent error from building up due to slightly incorrect angle.
+	defaultMaxMoveStraightMM = 1000
 
 	// maxSpinAngleDeg is the maximum amount of degrees the base should turn with a single Spin command.
 	// used to break up large turns into smaller chunks to prevent error from building up.
@@ -78,6 +82,10 @@ type Options struct {
 	// MinimumMovementThresholdMM is the amount that a base needs to move for it not to be considered stationary.
 	MinimumMovementThresholdMM float64
 
+	// MaxMoveStraightMM is the maximum distance the base should move with a single MoveStraight command.
+	// used to break up large driving segments to prevent error from building up due to slightly incorrect angle.
+	MaxMoveStraightMM float64
+
 	// MaxSpinAngleDeg is the maximum amount of degrees the base should turn with a single Spin command.
 	// used to break up large turns into smaller chunks to prevent error from building up.
 	MaxSpinAngleDeg float64
@@ -98,6 +106,7 @@ func NewKinematicBaseOptions() Options {
 		PlanDeviationThresholdMM:   defaultPlanDeviationThresholdMM,
 		Timeout:                    defaultTimeout,
 		MinimumMovementThresholdMM: defaultMinimumMovementThresholdMM,
+		MaxMoveStraightMM:          defaultMaxMoveStraightMM,
 		MaxSpinAngleDeg:            defaultMaxSpinAngleDeg,
 		PositionOnlyMode:           defaultPositionOnlyMode,
 	}

--- a/pointcloud/basic_octree.go
+++ b/pointcloud/basic_octree.go
@@ -20,8 +20,8 @@ const (
 	maxRecursionDepth = 1000
 	nodeRegionOverlap = 1e-6
 	// TODO (RSDK-3767): pass these in a different way.
-	confidenceThreshold = 50   // value between 0-100, threshold sets the confidence level required for a point to be considered a collision
-	buffer              = 60.0 // max distance from base to point for it to be considered a collision in mm
+	confidenceThreshold = 50    // value between 0-100, threshold sets the confidence level required for a point to be considered a collision
+	buffer              = 150.0 // max distance from base to point for it to be considered a collision in mm
 )
 
 // NodeType represents the possible types of nodes in an octree.


### PR DESCRIPTION
Update default values in `kinematics.go` and `basic_octree.go` to reflect values that work better for executing plans.
Implement max move straight distance of 1m to fix error building up when moving long distances.