### PR TITLE
RSDK-4459 Create sensor base model 

### DIFF
--- a/components/base/register/register.go
+++ b/components/base/register/register.go
@@ -5,5 +5,6 @@ import (
 	// register bases.
 	_ "go.viam.com/rdk/components/base/agilex"
 	_ "go.viam.com/rdk/components/base/fake"
+	_ "go.viam.com/rdk/components/base/sensorbase"
 	_ "go.viam.com/rdk/components/base/wheeled"
 )

--- a/components/base/register/register.go
+++ b/components/base/register/register.go
@@ -5,6 +5,5 @@ import (
 	// register bases.
 	_ "go.viam.com/rdk/components/base/agilex"
 	_ "go.viam.com/rdk/components/base/fake"
-	_ "go.viam.com/rdk/components/base/sensorbase"
 	_ "go.viam.com/rdk/components/base/wheeled"
 )

--- a/components/base/sensorbase/sensorbase.go
+++ b/components/base/sensorbase/sensorbase.go
@@ -1,4 +1,4 @@
-// Package sensorcontrolled base implement a base with feedback control from a movement sensor
+// Package sensorcontrolled base implements a base with feedback control from a movement sensor
 package sensorcontrolled
 
 import (
@@ -202,7 +202,7 @@ func (sb *sensorBase) Spin(ctx context.Context, angleDeg, degsPerSec float64, ex
 		return err
 	}
 
-	// is moving returns true when moving, which is not a success condition for our
+	// IsMoving returns true when moving, which is not a success condition for our controll loop
 	baseStopped := func(ctx context.Context) (bool, error) {
 		moving, err := sb.IsMoving(ctx)
 		return !moving, err

--- a/components/base/sensorbase/sensorbase.go
+++ b/components/base/sensorbase/sensorbase.go
@@ -202,7 +202,7 @@ func (sb *sensorBase) Spin(ctx context.Context, angleDeg, degsPerSec float64, ex
 		return err
 	}
 
-	// IsMoving returns true when moving, which is not a success condition for our controll loop
+	// IsMoving returns true when moving, which is not a success condition for our control loop
 	baseStopped := func(ctx context.Context) (bool, error) {
 		moving, err := sb.IsMoving(ctx)
 		return !moving, err

--- a/components/base/sensorbase/sensorbase.go
+++ b/components/base/sensorbase/sensorbase.go
@@ -1,4 +1,5 @@
-package wheeled
+// Package sensorcontrolled base implement a base with feedback control from a movement sensor
+package sensorcontrolled
 
 import (
 	"context"
@@ -29,7 +30,33 @@ const (
 	sensorDebug        = false
 )
 
-var errNoGoodSensor = errors.New("no appropriate sensor for orientaiton or velocity feedback")
+var (
+	// Model is the name of the sensor_controlled model of a base component.
+	Model           = resource.DefaultModelFamily.WithModel("sensor-controlled")
+	errNoGoodSensor = errors.New("no appropriate sensor for orientaiton or velocity feedback")
+)
+
+// Config configures a sencor controlled base.
+type Config struct {
+	MovementSensor []string `json:"movement_sensor"`
+	Base           string   `json:"base"`
+}
+
+// Validate validates all parts of the sensor controlled base config.
+func (cfg *Config) Validate(path string) ([]string, error) {
+	deps := []string{}
+	if len(cfg.MovementSensor) == 0 {
+		return nil, utils.NewConfigValidationError(path, errors.New("need at least one movement sensor for base"))
+	}
+
+	deps = append(deps, cfg.MovementSensor...)
+	if cfg.Base == "" {
+		return nil, utils.NewConfigValidationFieldRequiredError(path, "base")
+	}
+
+	deps = append(deps, cfg.Base)
+	return deps, nil
+}
 
 type sensorBase struct {
 	resource.Named
@@ -37,7 +64,7 @@ type sensorBase struct {
 	mu     sync.Mutex
 
 	activeBackgroundWorkers sync.WaitGroup
-	wBase                   base.Base // the inherited wheeled base
+	controlledBase          base.Base // the inherited wheeled base
 
 	sensorLoopMu      sync.Mutex
 	sensorLoopDone    func()
@@ -48,6 +75,32 @@ type sensorBase struct {
 	allSensors  []movementsensor.MovementSensor
 	orientation movementsensor.MovementSensor
 	velocities  movementsensor.MovementSensor
+}
+
+func init() {
+	resource.RegisterComponent(
+		base.API,
+		Model,
+		resource.Registration[base.Base, *Config]{Constructor: createSensorBase})
+}
+
+func createSensorBase(
+	ctx context.Context,
+	deps resource.Dependencies,
+	conf resource.Config,
+	logger golog.Logger,
+) (base.Base, error) {
+	sb := &sensorBase{
+		logger: logger,
+		Named:  conf.ResourceName().AsNamed(),
+		opMgr:  operation.NewSingleOperationManager(),
+	}
+
+	if err := sb.Reconfigure(ctx, deps, conf); err != nil {
+		return nil, err
+	}
+
+	return sb, nil
 }
 
 func (sb *sensorBase) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
@@ -63,9 +116,7 @@ func (sb *sensorBase) Reconfigure(ctx context.Context, deps resource.Dependencie
 	sb.allSensors = nil
 	sb.velocities = nil
 	sb.orientation = nil
-	if sb.opMgr == nil {
-		sb.opMgr = operation.NewSingleOperationManager()
-	}
+	sb.controlledBase = nil
 
 	for _, name := range newConf.MovementSensor {
 		ms, err := movementsensor.FromDependencies(deps, name)
@@ -99,6 +150,11 @@ func (sb *sensorBase) Reconfigure(ctx context.Context, deps resource.Dependencie
 		return errNoGoodSensor
 	}
 
+	sb.controlledBase, err = base.FromDependencies(deps, newConf.Base)
+	if err != nil {
+		return errors.Wrapf(err, "no base named (%s)", newConf.Base)
+	}
+
 	return nil
 }
 
@@ -123,7 +179,7 @@ func (sb *sensorBase) Spin(ctx context.Context, angleDeg, degsPerSec float64, ex
 	if int(angleDeg) >= 360 {
 		sb.setPolling(false)
 		sb.logger.Warn("feedback for spin calls over 360 not supported yet, spinning without sensor")
-		return sb.wBase.Spin(ctx, angleDeg, degsPerSec, nil)
+		return sb.controlledBase.Spin(ctx, angleDeg, degsPerSec, nil)
 	}
 	ctx, done := sb.opMgr.New(ctx)
 	defer done()
@@ -146,23 +202,23 @@ func (sb *sensorBase) Spin(ctx context.Context, angleDeg, degsPerSec float64, ex
 		return err
 	}
 
-	wb := sb.wBase.(*wheeledBase)
-	motor := wb.allMotors[0]
-	if err := sb.opMgr.WaitTillNotPowered(ctx, 500*time.Millisecond, motor,
-		func(context.Context, map[string]interface{}) error {
-			return nil
-		},
-	); err != nil {
-		return err
+	// is moving returns true when moving, which is not a success condition for our
+	baseStopped := func(ctx context.Context) (bool, error) {
+		moving, err := sb.IsMoving(ctx)
+		return !moving, err
 	}
-	return nil
+	return sb.opMgr.WaitForSuccess(
+		ctx,
+		yawPollTime,
+		baseStopped,
+	)
 }
 
 func (sb *sensorBase) startRunningMotors(ctx context.Context, angleDeg, degsPerSec float64) error {
 	if math.Signbit(angleDeg) != math.Signbit(degsPerSec) {
 		degsPerSec *= -1
 	}
-	return sb.wBase.SetVelocity(ctx,
+	return sb.controlledBase.SetVelocity(ctx,
 		r3.Vector{X: 0, Y: 0, Z: 0},
 		r3.Vector{X: 0, Y: 0, Z: degsPerSec}, nil)
 }
@@ -357,7 +413,7 @@ func (sb *sensorBase) MoveStraight(
 	ctx, done := sb.opMgr.New(ctx)
 	defer done()
 	sb.setPolling(false)
-	return sb.wBase.MoveStraight(ctx, distanceMm, mmPerSec, extra)
+	return sb.controlledBase.MoveStraight(ctx, distanceMm, mmPerSec, extra)
 }
 
 func (sb *sensorBase) SetVelocity(
@@ -383,7 +439,7 @@ func (sb *sensorBase) SetVelocity(
 		return errors.New(
 			"setvelocity with sensor feedback not currently implemented, remove movement sensor reporting linear and angular velocity ")
 	}
-	return sb.wBase.SetVelocity(ctx, linear, angular, extra)
+	return sb.controlledBase.SetVelocity(ctx, linear, angular, extra)
 }
 
 func (sb *sensorBase) pollsensors(ctx context.Context, extra map[string]interface{}) {
@@ -432,25 +488,25 @@ func (sb *sensorBase) SetPower(
 ) error {
 	sb.opMgr.CancelRunning(ctx)
 	sb.setPolling(false)
-	return sb.wBase.SetPower(ctx, linear, angular, extra)
+	return sb.controlledBase.SetPower(ctx, linear, angular, extra)
 }
 
 func (sb *sensorBase) Stop(ctx context.Context, extra map[string]interface{}) error {
 	sb.opMgr.CancelRunning(ctx)
 	sb.setPolling(false)
-	return sb.wBase.Stop(ctx, extra)
+	return sb.controlledBase.Stop(ctx, extra)
 }
 
 func (sb *sensorBase) IsMoving(ctx context.Context) (bool, error) {
-	return sb.wBase.IsMoving(ctx)
+	return sb.controlledBase.IsMoving(ctx)
 }
 
 func (sb *sensorBase) Properties(ctx context.Context, extra map[string]interface{}) (base.Properties, error) {
-	return sb.wBase.Properties(ctx, extra)
+	return sb.controlledBase.Properties(ctx, extra)
 }
 
 func (sb *sensorBase) Geometries(ctx context.Context, extra map[string]interface{}) ([]spatialmath.Geometry, error) {
-	return sb.wBase.Geometries(ctx, extra)
+	return sb.controlledBase.Geometries(ctx, extra)
 }
 
 func (sb *sensorBase) Close(ctx context.Context) error {

--- a/components/base/sensorbase/sensorbase_test.go
+++ b/components/base/sensorbase/sensorbase_test.go
@@ -386,7 +386,6 @@ func TestSensorBase(t *testing.T) {
 	test.That(t, sb.SetPower(ctx, r3.Vector{X: 0, Y: 10, Z: 0}, r3.Vector{X: 0, Y: 0, Z: 0}, nil), test.ShouldBeNil)
 	test.That(t, sb.SetVelocity(ctx, r3.Vector{X: 0, Y: 100, Z: 0}, r3.Vector{X: 0, Y: 100, Z: 0}, nil), test.ShouldBeNil)
 	test.That(t, sb.MoveStraight(ctx, 10, 10, nil), test.ShouldBeNil)
-	// our fake motor code should immediately cancel the base context in this test
 	test.That(t, sb.Spin(ctx, 2, 10, nil), test.ShouldBeNil)
 	test.That(t, sb.Stop(ctx, nil), test.ShouldBeNil)
 

--- a/components/base/sensorbase/sensorbase_test.go
+++ b/components/base/sensorbase/sensorbase_test.go
@@ -1,4 +1,4 @@
-package wheeled
+package sensorcontrolled
 
 import (
 	"context"
@@ -14,10 +14,10 @@ import (
 	"go.viam.com/test"
 
 	"go.viam.com/rdk/components/base"
-	"go.viam.com/rdk/components/motor"
 	"go.viam.com/rdk/components/movementsensor"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/spatialmath"
+	"go.viam.com/rdk/testutils"
 	"go.viam.com/rdk/testutils/inject"
 	"go.viam.com/rdk/utils"
 )
@@ -270,7 +270,7 @@ func TestSpinWithMovementSensor(t *testing.T) {
 	sensorCtx, sensorCancel := context.WithCancel(ctx)
 	sensorBase := &sensorBase{
 		logger:         logger,
-		wBase:          wb,
+		controlledBase: wb,
 		sensorLoopMu:   sync.Mutex{},
 		sensorLoopDone: sensorCancel,
 		allSensors:     []movementsensor.MovementSensor{ms},
@@ -291,28 +291,19 @@ func sConfig() resource.Config {
 		API:   base.API,
 		Model: resource.Model{Name: "wheeled_base"},
 		ConvertedAttributes: &Config{
-			WidthMM:              100,
-			WheelCircumferenceMM: 1000,
-			Left:                 []string{"fl-m", "bl-m"},
-			Right:                []string{"fr-m", "br-m"},
-			MovementSensor:       []string{"ms"},
+			MovementSensor: []string{"ms"},
+			Base:           "test_base",
 		},
 	}
 }
 
-func TestSensorBase(t *testing.T) {
-	ctx := context.Background()
-	logger := golog.NewTestLogger(t)
-	testCfg := sConfig()
-	conf, ok := testCfg.ConvertedAttributes.(*Config)
-	test.That(t, ok, test.ShouldBeTrue)
-	deps, err := conf.Validate("path")
-	test.That(t, err, test.ShouldBeNil)
-	msDeps := fakeMotorDependencies(t, deps)
+func createDependencies(t *testing.T) resource.Dependencies {
+	t.Helper()
+	deps := make(resource.Dependencies)
 
 	counter := 0
 
-	msDeps[movementsensor.Named("ms")] = &inject.MovementSensor{
+	deps[movementsensor.Named("ms")] = &inject.MovementSensor{
 		PropertiesFuncExtraCap: map[string]interface{}{},
 		PropertiesFunc: func(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
 			return &movementsensor.Properties{OrientationSupported: true}, nil
@@ -323,12 +314,62 @@ func TestSensorBase(t *testing.T) {
 		},
 	}
 
-	wheeled, err := createWheeledBase(ctx, msDeps, testCfg, logger)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, wheeled, test.ShouldNotBeNil)
+	deps = addBaseDependency(deps)
 
-	sb, ok := wheeled.(*sensorBase)
+	return deps
+}
+
+func addBaseDependency(deps resource.Dependencies) resource.Dependencies {
+	deps[base.Named(("test_base"))] = &inject.Base{
+		DoFunc: testutils.EchoFunc,
+		MoveStraightFunc: func(ctx context.Context, distanceMm int, mmPerSec float64, extra map[string]interface{}) error {
+			return nil
+		},
+		SpinFunc: func(ctx context.Context, angleDeg, degsPerSec float64, extra map[string]interface{}) error {
+			return nil
+		},
+		StopFunc: func(ctx context.Context, extra map[string]interface{}) error {
+			return nil
+		},
+		IsMovingFunc: func(context.Context) (bool, error) {
+			return false, nil
+		},
+		CloseFunc: func(ctx context.Context) error {
+			return nil
+		},
+		SetPowerFunc: func(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error {
+			return nil
+		},
+		SetVelocityFunc: func(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error {
+			return nil
+		},
+		PropertiesFunc: func(ctx context.Context, extra map[string]interface{}) (base.Properties, error) {
+			return base.Properties{
+				TurningRadiusMeters: 0.1,
+				WidthMeters:         0.1,
+			}, nil
+		},
+		GeometriesFunc: func(ctx context.Context) ([]spatialmath.Geometry, error) {
+			return nil, nil
+		},
+	}
+	return deps
+}
+
+func TestSensorBase(t *testing.T) {
+	ctx := context.Background()
+	logger := golog.NewTestLogger(t)
+	testCfg := sConfig()
+	conf, ok := testCfg.ConvertedAttributes.(*Config)
 	test.That(t, ok, test.ShouldBeTrue)
+	deps, err := conf.Validate("path")
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, deps, test.ShouldResemble, []string{"ms", "test_base"})
+	sbDeps := createDependencies(t)
+
+	sb, err := createSensorBase(ctx, sbDeps, testCfg, logger)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, sb, test.ShouldNotBeNil)
 
 	moving, err := sb.IsMoving(ctx)
 	test.That(t, err, test.ShouldBeNil)
@@ -346,42 +387,31 @@ func TestSensorBase(t *testing.T) {
 	test.That(t, sb.SetVelocity(ctx, r3.Vector{X: 0, Y: 100, Z: 0}, r3.Vector{X: 0, Y: 100, Z: 0}, nil), test.ShouldBeNil)
 	test.That(t, sb.MoveStraight(ctx, 10, 10, nil), test.ShouldBeNil)
 	// our fake motor code should immediately cancel the base context in this test
-	test.That(t, sb.Spin(ctx, 2, 10, nil), test.ShouldBeError, context.Canceled)
+	test.That(t, sb.Spin(ctx, 2, 10, nil), test.ShouldBeNil)
 	test.That(t, sb.Stop(ctx, nil), test.ShouldBeNil)
 
 	test.That(t, sb.Close(ctx), test.ShouldBeNil)
 }
 
-func sBaseTestConfig(msNames, lmotors, rmotors []string) resource.Config {
+func sBaseTestConfig(msNames []string) resource.Config {
 	return resource.Config{
 		Name:  "test",
 		API:   base.API,
-		Model: resource.Model{Name: "wheeled_base"},
+		Model: resource.Model{Name: "controlled_base"},
 		ConvertedAttributes: &Config{
-			WidthMM:              100,
-			WheelCircumferenceMM: 1000,
-			Left:                 lmotors,
-			Right:                rmotors,
-			MovementSensor:       msNames,
+			MovementSensor: msNames,
+			Base:           "test_base",
 		},
 	}
 }
 
-func msDependencies(t *testing.T, lmotors, rmotors, msNames []string,
+func msDependencies(t *testing.T, msNames []string,
 ) (resource.Dependencies, resource.Config) {
 	t.Helper()
 
-	cfg := sBaseTestConfig(msNames, lmotors, rmotors)
+	cfg := sBaseTestConfig(msNames)
 
 	deps := make(resource.Dependencies)
-
-	for _, lm := range lmotors {
-		deps[motor.Named(lm)] = inject.NewMotor(lm)
-	}
-
-	for _, rm := range rmotors {
-		deps[motor.Named(rm)] = inject.NewMotor(rm)
-	}
 
 	for _, msName := range msNames {
 		ms := inject.NewMovementSensor(msName)
@@ -416,56 +446,57 @@ func msDependencies(t *testing.T, lmotors, rmotors, msNames []string,
 		default:
 		}
 	}
+
+	deps = addBaseDependency(deps)
+
 	return deps, cfg
 }
 
 func TestReconfig(t *testing.T) {
 	ctx := context.Background()
 	logger := golog.NewTestLogger(t)
-	lmNames := []string{"l-m"}
-	rmNames := []string{"r-m"}
 
-	deps, cfg := msDependencies(t, lmNames, rmNames, []string{"orientation"})
+	deps, cfg := msDependencies(t, []string{"orientation"})
 
-	b, err := createWheeledBase(ctx, deps, cfg, logger)
+	b, err := createSensorBase(ctx, deps, cfg, logger)
 	test.That(t, err, test.ShouldBeNil)
 	sb, ok := b.(*sensorBase)
 	test.That(t, ok, test.ShouldBeTrue)
 	test.That(t, sb.orientation.Name().ShortName(), test.ShouldResemble, "orientation")
 
-	deps, cfg = msDependencies(t, lmNames, rmNames, []string{"orientation1"})
+	deps, cfg = msDependencies(t, []string{"orientation1"})
 	err = b.Reconfigure(ctx, deps, cfg)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, sb.orientation.Name().ShortName(), test.ShouldResemble, "orientation1")
 
-	deps, cfg = msDependencies(t, lmNames, rmNames, []string{"orientation2"})
+	deps, cfg = msDependencies(t, []string{"orientation2"})
 	err = b.Reconfigure(ctx, deps, cfg)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, sb.orientation.Name().ShortName(), test.ShouldResemble, "orientation2")
 
-	deps, cfg = msDependencies(t, lmNames, rmNames, []string{"setvel1"})
+	deps, cfg = msDependencies(t, []string{"setvel1"})
 	err = b.Reconfigure(ctx, deps, cfg)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, sb.velocities.Name().ShortName(), test.ShouldResemble, "setvel1")
 
-	deps, cfg = msDependencies(t, lmNames, rmNames, []string{"setvel2"})
+	deps, cfg = msDependencies(t, []string{"setvel2"})
 	err = b.Reconfigure(ctx, deps, cfg)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, sb.velocities.Name().ShortName(), test.ShouldResemble, "setvel2")
 
-	deps, cfg = msDependencies(t, lmNames, rmNames, []string{"orientation3", "setvel3", "Bad"})
+	deps, cfg = msDependencies(t, []string{"orientation3", "setvel3", "Bad"})
 	err = b.Reconfigure(ctx, deps, cfg)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, sb.orientation.Name().ShortName(), test.ShouldResemble, "orientation3")
 	test.That(t, sb.velocities.Name().ShortName(), test.ShouldResemble, "setvel3")
 
-	deps, cfg = msDependencies(t, lmNames, rmNames, []string{"Bad", "orientation4", "setvel4", "orientation5", "setvel5"})
+	deps, cfg = msDependencies(t, []string{"Bad", "orientation4", "setvel4", "orientation5", "setvel5"})
 	err = b.Reconfigure(ctx, deps, cfg)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, sb.orientation.Name().ShortName(), test.ShouldResemble, "orientation4")
 	test.That(t, sb.velocities.Name().ShortName(), test.ShouldResemble, "setvel4")
 
-	deps, cfg = msDependencies(t, lmNames, rmNames, []string{"Bad"})
+	deps, cfg = msDependencies(t, []string{"Bad"})
 	err = b.Reconfigure(ctx, deps, cfg)
 	test.That(t, sb.orientation, test.ShouldBeNil)
 	test.That(t, sb.velocities, test.ShouldBeNil)

--- a/components/base/wheeled/wheeled_base.go
+++ b/components/base/wheeled/wheeled_base.go
@@ -62,7 +62,6 @@ type Config struct {
 	SpinSlipFactor       float64  `json:"spin_slip_factor,omitempty"`
 	Left                 []string `json:"left"`
 	Right                []string `json:"right"`
-	MovementSensor       []string `json:"movement_sensor,omitempty"`
 }
 
 // Validate ensures all parts of the config are valid.
@@ -92,10 +91,6 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 
 	deps = append(deps, cfg.Left...)
 	deps = append(deps, cfg.Right...)
-
-	if len(cfg.MovementSensor) != 0 {
-		deps = append(deps, cfg.MovementSensor...)
-	}
 
 	return deps, nil
 }
@@ -231,19 +226,6 @@ func createWheeledBase(
 
 	if err := wb.Reconfigure(ctx, deps, conf); err != nil {
 		return nil, err
-	}
-
-	if len(newConf.MovementSensor) != 0 {
-		sb := sensorBase{
-			wBase:  &wb,
-			logger: logger,
-			Named:  conf.ResourceName().AsNamed(),
-			opMgr:  operation.NewSingleOperationManager(),
-		}
-		if err := sb.Reconfigure(ctx, deps, conf); err != nil {
-			return nil, err
-		}
-		return &sb, nil
 	}
 
 	return &wb, nil


### PR DESCRIPTION
This moves the movement sensor attribute field from the wheeled base and creates the sensor base model that takes in a base and a movement sensor for feedback to API calls.

- Spin behaviour is retained, it stops within 3degs of requested call using the sdk and rc card. Both are still blocking with the new wait for success function.
- The SetVelocity control loop will be addressed in a separate pr
- registration of this resource will be done in a separate pr.