### PR TITLE
RSDK-4446 Unify CLI arguments into single style

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -7,6 +7,27 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+// CLI flags.
+const (
+	dataFlagDestination       = "destination"
+	dataFlagDataType          = "data-type"
+	dataFlagOrgIDs            = "org-ids"
+	dataFlagLocationIDs       = "location-ids"
+	dataFlagRobotID           = "robot-id"
+	dataFlagPartID            = "part-id"
+	dataFlagRobotName         = "robot-name"
+	dataFlagPartName          = "part-name"
+	dataFlagComponentType     = "component-type"
+	dataFlagComponentName     = "component-name"
+	dataFlagMethod            = "method"
+	dataFlagMimeTypes         = "mime-types"
+	dataFlagStart             = "start"
+	dataFlagEnd               = "end"
+	dataFlagParallelDownloads = "parallel"
+	dataFlagTags              = "tags"
+	dataFlagBboxLabels        = "bbox-labels"
+)
+
 var app = &cli.App{
 	Name:            "viam",
 	Usage:           "interact with your Viam robots",
@@ -89,78 +110,78 @@ var app = &cli.App{
 					Name:  "export",
 					Usage: "download data from Viam cloud",
 					UsageText: fmt.Sprintf("viam data export <%s> <%s> [other options]",
-						DataFlagDestination, DataFlagDataType),
+						dataFlagDestination, dataFlagDataType),
 					Flags: []cli.Flag{
 						&cli.PathFlag{
-							Name:     DataFlagDestination,
+							Name:     dataFlagDestination,
 							Required: true,
 							Usage:    "output directory for downloaded data",
 						},
 						&cli.StringFlag{
-							Name:     DataFlagDataType,
+							Name:     dataFlagDataType,
 							Required: true,
 							Usage:    "data type to be downloaded: either binary or tabular",
 						},
 						&cli.StringSliceFlag{
-							Name:  DataFlagOrgIDs,
+							Name:  dataFlagOrgIDs,
 							Usage: "orgs filter",
 						},
 						&cli.StringSliceFlag{
-							Name:  DataFlagLocationIDs,
+							Name:  dataFlagLocationIDs,
 							Usage: "locations filter",
 						},
 						&cli.StringFlag{
-							Name:  DataFlagRobotID,
+							Name:  dataFlagRobotID,
 							Usage: "robot-id filter",
 						},
 						&cli.StringFlag{
-							Name:  DataFlagPartID,
+							Name:  dataFlagPartID,
 							Usage: "part id filter",
 						},
 						&cli.StringFlag{
-							Name:  DataFlagRobotName,
+							Name:  dataFlagRobotName,
 							Usage: "robot name filter",
 						},
 						&cli.StringFlag{
-							Name:  DataFlagPartName,
+							Name:  dataFlagPartName,
 							Usage: "part name filter",
 						},
 						&cli.StringFlag{
-							Name:  DataFlagComponentType,
+							Name:  dataFlagComponentType,
 							Usage: "component type filter",
 						},
 						&cli.StringFlag{
-							Name:  DataFlagComponentName,
+							Name:  dataFlagComponentName,
 							Usage: "component name filter",
 						},
 						&cli.StringFlag{
-							Name:  DataFlagMethod,
+							Name:  dataFlagMethod,
 							Usage: "method filter",
 						},
 						&cli.StringSliceFlag{
-							Name:  DataFlagMimeTypes,
+							Name:  dataFlagMimeTypes,
 							Usage: "mime types filter",
 						},
 						&cli.UintFlag{
-							Name:        DataFlagParallelDownloads,
+							Name:        dataFlagParallelDownloads,
 							Usage:       "number of download requests to make in parallel",
 							DefaultText: "10",
 						},
 						&cli.StringFlag{
-							Name:  DataFlagStart,
+							Name:  dataFlagStart,
 							Usage: "ISO-8601 timestamp indicating the start of the interval filter",
 						},
 						&cli.StringFlag{
-							Name:  DataFlagEnd,
+							Name:  dataFlagEnd,
 							Usage: "ISO-8601 timestamp indicating the end of the interval filter",
 						},
 						&cli.StringSliceFlag{
-							Name: DataFlagTags,
+							Name: dataFlagTags,
 							Usage: "tags filter. " +
 								"accepts tagged for all tagged data, untagged for all untagged data, or a list of tags for all data matching any of the tags",
 						},
 						&cli.StringSliceFlag{
-							Name: DataFlagBboxLabels,
+							Name: dataFlagBboxLabels,
 							Usage: "bbox labels filter. " +
 								"accepts string labels corresponding to bounding boxes within images",
 						},
@@ -170,59 +191,59 @@ var app = &cli.App{
 				{
 					Name:      "delete",
 					Usage:     "delete data from Viam cloud",
-					UsageText: fmt.Sprintf("viam data delete <%s> [other options]", DataFlagDataType),
+					UsageText: fmt.Sprintf("viam data delete <%s> [other options]", dataFlagDataType),
 					Flags: []cli.Flag{
 						&cli.StringFlag{
-							Name:     DataFlagDataType,
+							Name:     dataFlagDataType,
 							Required: true,
 							Usage:    "data type to be deleted: either binary or tabular",
 						},
 						&cli.StringSliceFlag{
-							Name:  DataFlagOrgIDs,
+							Name:  dataFlagOrgIDs,
 							Usage: "orgs filter",
 						},
 						&cli.StringSliceFlag{
-							Name:  DataFlagLocationIDs,
+							Name:  dataFlagLocationIDs,
 							Usage: "locations filter",
 						},
 						&cli.StringFlag{
-							Name:  DataFlagRobotID,
+							Name:  dataFlagRobotID,
 							Usage: "robot id filter",
 						},
 						&cli.StringFlag{
-							Name:  DataFlagPartID,
+							Name:  dataFlagPartID,
 							Usage: "part id filter",
 						},
 						&cli.StringFlag{
-							Name:  DataFlagRobotName,
+							Name:  dataFlagRobotName,
 							Usage: "robot name filter",
 						},
 						&cli.StringFlag{
-							Name:  DataFlagPartName,
+							Name:  dataFlagPartName,
 							Usage: "part name filter",
 						},
 						&cli.StringFlag{
-							Name:  DataFlagComponentType,
+							Name:  dataFlagComponentType,
 							Usage: "component type filter",
 						},
 						&cli.StringFlag{
-							Name:  DataFlagComponentName,
+							Name:  dataFlagComponentName,
 							Usage: "component name filter",
 						},
 						&cli.StringFlag{
-							Name:  DataFlagMethod,
+							Name:  dataFlagMethod,
 							Usage: "method filter",
 						},
 						&cli.StringSliceFlag{
-							Name:  DataFlagMimeTypes,
+							Name:  dataFlagMimeTypes,
 							Usage: "mime types filter",
 						},
 						&cli.StringFlag{
-							Name:  DataFlagStart,
+							Name:  dataFlagStart,
 							Usage: "ISO-8601 timestamp indicating the start of the interval filter",
 						},
 						&cli.StringFlag{
-							Name:  DataFlagEnd,
+							Name:  dataFlagEnd,
 							Usage: "ISO-8601 timestamp indicating the end of the interval filter",
 						},
 					},

--- a/cli/app.go
+++ b/cli/app.go
@@ -9,6 +9,27 @@ import (
 
 // CLI flags.
 const (
+	baseURLFlag      = "base-url"
+	configFlag       = "config"
+	debugFlag        = "debug"
+	organizationFlag = "organization"
+	locationFlag     = "location"
+	robotFlag        = "robot"
+	partFlag         = "part"
+
+	logsFlagErrors = "errors"
+	logsFlagTail   = "tail"
+
+	runFlagData   = "data"
+	runFlagStream = "stream"
+
+	moduleFlagName            = "name"
+	moduleFlagPublicNamespace = "public-namespace"
+	moduleFlagOrgID           = "org-id"
+	moduleFlagPath            = "module"
+	moduleFlagVersion         = "version"
+	moduleFlagPlatform        = "platform"
+
 	dataFlagDestination       = "destination"
 	dataFlagDataType          = "data-type"
 	dataFlagOrgIDs            = "org-ids"
@@ -34,18 +55,18 @@ var app = &cli.App{
 	HideHelpCommand: true,
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:   "base-url",
+			Name:   baseURLFlag,
 			Hidden: true,
 			Value:  "https://app.viam.com:443",
 			Usage:  "base URL of app",
 		},
 		&cli.StringFlag{
-			Name:    "config",
+			Name:    configFlag,
 			Aliases: []string{"c"},
 			Usage:   "load configuration from `FILE`",
 		},
 		&cli.BoolFlag{
-			Name:    "debug",
+			Name:    debugFlag,
 			Aliases: []string{"vvv"},
 			Usage:   "enable debug logging",
 		},
@@ -261,11 +282,11 @@ var app = &cli.App{
 					Usage: "list robots in an organization and location",
 					Flags: []cli.Flag{
 						&cli.StringFlag{
-							Name:        "organization",
+							Name:        organizationFlag,
 							DefaultText: "first organization alphabetically",
 						},
 						&cli.StringFlag{
-							Name:        "location",
+							Name:        locationFlag,
 							DefaultText: "first location alphabetically",
 						},
 					},
@@ -284,15 +305,15 @@ var app = &cli.App{
 					UsageText: "viam robot status <robot> [other options]",
 					Flags: []cli.Flag{
 						&cli.StringFlag{
-							Name:        "organization",
+							Name:        organizationFlag,
 							DefaultText: "first organization alphabetically",
 						},
 						&cli.StringFlag{
-							Name:        "location",
+							Name:        locationFlag,
 							DefaultText: "first location alphabetically",
 						},
 						&cli.StringFlag{
-							Name:     "robot",
+							Name:     robotFlag,
 							Required: true,
 						},
 					},
@@ -304,19 +325,19 @@ var app = &cli.App{
 					UsageText: "viam robot logs <robot> [other options]",
 					Flags: []cli.Flag{
 						&cli.StringFlag{
-							Name:        "organization",
+							Name:        organizationFlag,
 							DefaultText: "first organization alphabetically",
 						},
 						&cli.StringFlag{
-							Name:        "location",
+							Name:        locationFlag,
 							DefaultText: "first location alphabetically",
 						},
 						&cli.StringFlag{
-							Name:     "robot",
+							Name:     robotFlag,
 							Required: true,
 						},
 						&cli.BoolFlag{
-							Name:  "errors",
+							Name:  logsFlagErrors,
 							Usage: "show only errors",
 						},
 					},
@@ -333,19 +354,19 @@ var app = &cli.App{
 							UsageText: "viam robot part status <robot> <part> [other options]",
 							Flags: []cli.Flag{
 								&cli.StringFlag{
-									Name:        "organization",
+									Name:        organizationFlag,
 									DefaultText: "first organization alphabetically",
 								},
 								&cli.StringFlag{
-									Name:        "location",
+									Name:        locationFlag,
 									DefaultText: "first location alphabetically",
 								},
 								&cli.StringFlag{
-									Name:     "robot",
+									Name:     robotFlag,
 									Required: true,
 								},
 								&cli.StringFlag{
-									Name:     "part",
+									Name:     partFlag,
 									Required: true,
 								},
 							},
@@ -357,27 +378,27 @@ var app = &cli.App{
 							UsageText: "viam robot part logs <robot> <part> [other options]",
 							Flags: []cli.Flag{
 								&cli.StringFlag{
-									Name:        "organization",
+									Name:        organizationFlag,
 									DefaultText: "first organization alphabetically",
 								},
 								&cli.StringFlag{
-									Name:        "location",
+									Name:        locationFlag,
 									DefaultText: "first location alphabetically",
 								},
 								&cli.StringFlag{
-									Name:     "robot",
+									Name:     robotFlag,
 									Required: true,
 								},
 								&cli.StringFlag{
-									Name:     "part",
+									Name:     partFlag,
 									Required: true,
 								},
 								&cli.BoolFlag{
-									Name:  "errors",
+									Name:  logsFlagErrors,
 									Usage: "show only errors",
 								},
 								&cli.BoolFlag{
-									Name:    "tail",
+									Name:    logsFlagTail,
 									Aliases: []string{"f"},
 									Usage:   "follow logs",
 								},
@@ -390,27 +411,27 @@ var app = &cli.App{
 							UsageText: "viam robot part run <organization> <location> <robot> <part> [other options] <service.method>",
 							Flags: []cli.Flag{
 								&cli.StringFlag{
-									Name:     "organization",
+									Name:     organizationFlag,
 									Required: true,
 								},
 								&cli.StringFlag{
-									Name:     "location",
+									Name:     locationFlag,
 									Required: true,
 								},
 								&cli.StringFlag{
-									Name:     "robot",
+									Name:     robotFlag,
 									Required: true,
 								},
 								&cli.StringFlag{
-									Name:     "part",
+									Name:     partFlag,
 									Required: true,
 								},
 								&cli.StringFlag{
-									Name:    "data",
+									Name:    runFlagData,
 									Aliases: []string{"d"},
 								},
 								&cli.DurationFlag{
-									Name:    "stream",
+									Name:    runFlagStream,
 									Aliases: []string{"s"},
 								},
 							},
@@ -423,19 +444,19 @@ var app = &cli.App{
 							UsageText:   "viam robot part shell <organization> <location> <robot> <part>",
 							Flags: []cli.Flag{
 								&cli.StringFlag{
-									Name:     "organization",
+									Name:     organizationFlag,
 									Required: true,
 								},
 								&cli.StringFlag{
-									Name:     "location",
+									Name:     locationFlag,
 									Required: true,
 								},
 								&cli.StringFlag{
-									Name:     "robot",
+									Name:     robotFlag,
 									Required: true,
 								},
 								&cli.StringFlag{
-									Name:     "part",
+									Name:     partFlag,
 									Required: true,
 								},
 							},
@@ -465,16 +486,16 @@ After creation, use 'viam module update' to push your new module to app.viam.com
 					UsageText: "viam module create <name> [other options]",
 					Flags: []cli.Flag{
 						&cli.StringFlag{
-							Name:     "name",
+							Name:     moduleFlagName,
 							Usage:    "name of your module (cannot be changed once set)",
 							Required: true,
 						},
 						&cli.StringFlag{
-							Name:  "public-namespace",
+							Name:  moduleFlagPublicNamespace,
 							Usage: "the public namespace where the module will reside (alternative way of specifying the org id)",
 						},
 						&cli.StringFlag{
-							Name:  "org-id",
+							Name:  moduleFlagOrgID,
 							Usage: "id of the organization that will host the module",
 						},
 					},
@@ -485,17 +506,17 @@ After creation, use 'viam module update' to push your new module to app.viam.com
 					Usage: "update a module's metadata on app.viam.com",
 					Flags: []cli.Flag{
 						&cli.StringFlag{
-							Name:        "module",
+							Name:        moduleFlagPath,
 							Usage:       "path to meta.json",
 							DefaultText: "./meta.json",
 							TakesFile:   true,
 						},
 						&cli.StringFlag{
-							Name:  "public-namespace",
+							Name:  moduleFlagPublicNamespace,
 							Usage: "the public namespace where the module resides (alternative way of specifying the org id)",
 						},
 						&cli.StringFlag{
-							Name:  "org-id",
+							Name:  moduleFlagOrgID,
 							Usage: "id of the organization that hosts the module",
 						},
 					},
@@ -513,30 +534,30 @@ viam module upload --version "0.1.0" --platform "linux/amd64" packaged-module.ta
 					UsageText: "viam module upload <version> <platform> [other options] <packaged-module.tar.gz>",
 					Flags: []cli.Flag{
 						&cli.StringFlag{
-							Name:        "module",
+							Name:        moduleFlagPath,
 							Usage:       "path to meta.json",
 							DefaultText: "./meta.json",
 							TakesFile:   true,
 						},
 						&cli.StringFlag{
-							Name:  "public-namespace",
+							Name:  moduleFlagPublicNamespace,
 							Usage: "the public namespace where the module resides (alternative way of specifying the org id)",
 						},
 						&cli.StringFlag{
-							Name:  "org-id",
+							Name:  moduleFlagOrgID,
 							Usage: "id of the organization that hosts the module",
 						},
 						&cli.StringFlag{
-							Name:  "name",
+							Name:  moduleFlagName,
 							Usage: "name of the module (used if you don't have a meta.json)",
 						},
 						&cli.StringFlag{
-							Name:     "version",
+							Name:     moduleFlagVersion,
 							Usage:    "version of the module to upload (semver2.0) ex: \"0.1.0\"",
 							Required: true,
 						},
 						&cli.StringFlag{
-							Name: "platform",
+							Name: moduleFlagPlatform,
 							Usage: `platform of the binary you are uploading. Must be one of:
                       linux/amd64
                       linux/arm64

--- a/cli/client.go
+++ b/cli/client.go
@@ -118,8 +118,8 @@ func ListRobotsAction(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	orgStr := c.String("organization")
-	locStr := c.String("location")
+	orgStr := c.String(organizationFlag)
+	locStr := c.String(locationFlag)
 	robots, err := client.listRobots(orgStr, locStr)
 	if err != nil {
 		return errors.Wrap(err, "could not list robots")
@@ -142,9 +142,9 @@ func RobotStatusAction(c *cli.Context) error {
 		return err
 	}
 
-	orgStr := c.String("organization")
-	locStr := c.String("location")
-	robot, err := client.robot(orgStr, locStr, c.String("robot"))
+	orgStr := c.String(organizationFlag)
+	locStr := c.String(locationFlag)
+	robot, err := client.robot(orgStr, locStr, c.String(robotFlag))
 	if err != nil {
 		return err
 	}
@@ -197,9 +197,9 @@ func RobotLogsAction(c *cli.Context) error {
 		return err
 	}
 
-	orgStr := c.String("organization")
-	locStr := c.String("location")
-	robotStr := c.String("robot")
+	orgStr := c.String(organizationFlag)
+	locStr := c.String(locationFlag)
+	robotStr := c.String(robotFlag)
 	robot, err := client.robot(orgStr, locStr, robotStr)
 	if err != nil {
 		return errors.Wrap(err, "could not get robot")
@@ -223,7 +223,7 @@ func RobotLogsAction(c *cli.Context) error {
 		}
 		if err := client.printRobotPartLogs(
 			orgStr, locStr, robotStr, part.Id,
-			c.Bool("errors"),
+			c.Bool(logsFlagErrors),
 			"\t",
 			header,
 		); err != nil {
@@ -241,15 +241,15 @@ func RobotPartStatusAction(c *cli.Context) error {
 		return err
 	}
 
-	orgStr := c.String("organization")
-	locStr := c.String("location")
-	robotStr := c.String("robot")
+	orgStr := c.String(organizationFlag)
+	locStr := c.String(locationFlag)
+	robotStr := c.String(robotFlag)
 	robot, err := client.robot(orgStr, locStr, robotStr)
 	if err != nil {
 		return errors.Wrap(err, "could not get robot")
 	}
 
-	part, err := client.robotPart(orgStr, locStr, robotStr, c.String("part"))
+	part, err := client.robotPart(orgStr, locStr, robotStr, c.String(partFlag))
 	if err != nil {
 		return errors.Wrap(err, "could not get robot part")
 	}
@@ -281,9 +281,9 @@ func RobotPartLogsAction(c *cli.Context) error {
 		return err
 	}
 
-	orgStr := c.String("organization")
-	locStr := c.String("location")
-	robotStr := c.String("robot")
+	orgStr := c.String(organizationFlag)
+	locStr := c.String(locationFlag)
+	robotStr := c.String(robotFlag)
 	robot, err := client.robot(orgStr, locStr, robotStr)
 	if err != nil {
 		return errors.Wrap(err, "could not get robot")
@@ -293,17 +293,17 @@ func RobotPartLogsAction(c *cli.Context) error {
 	if orgStr == "" || locStr == "" || robotStr == "" {
 		header = fmt.Sprintf("%s -> %s -> %s", client.selectedOrg.Name, client.selectedLoc.Name, robot.Name)
 	}
-	if c.Bool("tail") {
+	if c.Bool(logsFlagTail) {
 		return client.tailRobotPartLogs(
-			orgStr, locStr, robotStr, c.String("part"),
-			c.Bool("errors"),
+			orgStr, locStr, robotStr, c.String(partFlag),
+			c.Bool(logsFlagErrors),
 			"",
 			header,
 		)
 	}
 	return client.printRobotPartLogs(
-		orgStr, locStr, robotStr, c.String("part"),
-		c.Bool("errors"),
+		orgStr, locStr, robotStr, c.String(partFlag),
+		c.Bool(logsFlagErrors),
 		"",
 		header,
 	)
@@ -321,21 +321,21 @@ func RobotPartRunAction(c *cli.Context) error {
 		return err
 	}
 
-	// Create logger based on presence of "debug" flag.
+	// Create logger based on presence of debugFlag.
 	logger := zap.NewNop().Sugar()
-	if c.Bool("debug") {
+	if c.Bool(debugFlag) {
 		logger = golog.NewDebugLogger("cli")
 	}
 
 	return client.runRobotPartCommand(
-		c.String("organization"),
-		c.String("location"),
-		c.String("robot"),
-		c.String("part"),
+		c.String(organizationFlag),
+		c.String(locationFlag),
+		c.String(robotFlag),
+		c.String(partFlag),
 		svcMethod,
-		c.String("data"),
-		c.Duration("stream"),
-		c.Bool("debug"),
+		c.String(runFlagData),
+		c.Duration(runFlagStream),
+		c.Bool(debugFlag),
 		logger,
 	)
 }
@@ -349,18 +349,18 @@ func RobotPartShellAction(c *cli.Context) error {
 		return err
 	}
 
-	// Create logger based on presence of "debug" flag.
+	// Create logger based on presence of debugFlag.
 	logger := zap.NewNop().Sugar()
-	if c.Bool("debug") {
+	if c.Bool(debugFlag) {
 		logger = golog.NewDebugLogger("cli")
 	}
 
 	return client.startRobotPartShell(
-		c.String("organization"),
-		c.String("location"),
-		c.String("robot"),
-		c.String("part"),
-		c.Bool("debug"),
+		c.String(organizationFlag),
+		c.String(locationFlag),
+		c.String(robotFlag),
+		c.String(partFlag),
+		c.Bool(debugFlag),
 		logger,
 	)
 }
@@ -371,7 +371,7 @@ func VersionAction(c *cli.Context) error {
 	if !ok {
 		return errors.New("error reading build info")
 	}
-	if c.Bool("debug") {
+	if c.Bool(debugFlag) {
 		fmt.Fprintf(c.App.Writer, "%s\n", info.String())
 	}
 	settings := make(map[string]string, len(info.Settings))
@@ -402,7 +402,7 @@ func VersionAction(c *cli.Context) error {
 }
 
 func checkBaseURL(c *cli.Context) (*url.URL, []rpc.DialOption, error) {
-	baseURL := c.String("base-url")
+	baseURL := c.String(baseURLFlag)
 	baseURLParsed, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, nil, err

--- a/cli/data.go
+++ b/cli/data.go
@@ -31,41 +31,6 @@ const (
 	logEveryN                = 100
 	maxLimit                 = 100
 
-	// DataFlagDestination is the output directory for downloaded data.
-	DataFlagDestination = "destination"
-	// DataFlagDataType is the data type to be downloaded: either binary or tabular.
-	DataFlagDataType = "data-type"
-	// DataFlagOrgIDs is the orgs filter.
-	DataFlagOrgIDs = "org-ids"
-	// DataFlagLocationIDs is the location filter.
-	DataFlagLocationIDs = "location-ids"
-	// DataFlagRobotID is the robot-id filter.
-	DataFlagRobotID = "robot-id"
-	// DataFlagPartID is the robot-id filter.
-	DataFlagPartID = "part-id"
-	// DataFlagRobotName is the robot name filter.
-	DataFlagRobotName = "robot-name"
-	// DataFlagPartName is the part name filter.
-	DataFlagPartName = "part-name"
-	// DataFlagComponentType is the component type filter.
-	DataFlagComponentType = "component-type"
-	// DataFlagComponentName is the component name filter.
-	DataFlagComponentName = "component-name"
-	// DataFlagMethod is the method filter.
-	DataFlagMethod = "method"
-	// DataFlagMimeTypes is the mime types filter.
-	DataFlagMimeTypes = "mime-types"
-	// DataFlagStart is an ISO-8601 timestamp indicating the start of the interval filter.
-	DataFlagStart = "start"
-	// DataFlagEnd is an ISO-8601 timestamp indicating the end of the interval filter.
-	DataFlagEnd = "end"
-	// DataFlagParallelDownloads is the number of download requests to make in parallel.
-	DataFlagParallelDownloads = "parallel"
-	// DataFlagTags is the tags filter.
-	DataFlagTags = "tags"
-	// DataFlagBboxLabels is the bbox labels filter.
-	DataFlagBboxLabels = "bbox-labels"
-
 	dataTypeBinary  = "binary"
 	dataTypeTabular = "tabular"
 )
@@ -82,17 +47,17 @@ func DataExportAction(c *cli.Context) error {
 		return err
 	}
 
-	switch c.String(DataFlagDataType) {
+	switch c.String(dataFlagDataType) {
 	case dataTypeBinary:
-		if err := client.binaryData(c.Path(DataFlagDestination), filter, c.Uint(DataFlagParallelDownloads)); err != nil {
+		if err := client.binaryData(c.Path(dataFlagDestination), filter, c.Uint(dataFlagParallelDownloads)); err != nil {
 			return err
 		}
 	case dataTypeTabular:
-		if err := client.tabularData(c.Path(DataFlagDestination), filter); err != nil {
+		if err := client.tabularData(c.Path(dataFlagDestination), filter); err != nil {
 			return err
 		}
 	default:
-		return errors.Errorf("%s must be binary or tabular, got %q", DataFlagDataType, c.String(DataFlagDataType))
+		return errors.Errorf("%s must be binary or tabular, got %q", dataFlagDataType, c.String(dataFlagDataType))
 	}
 	return nil
 }
@@ -109,7 +74,7 @@ func DataDeleteAction(c *cli.Context) error {
 		return err
 	}
 
-	switch c.String(DataFlagDataType) {
+	switch c.String(dataFlagDataType) {
 	case dataTypeBinary:
 		if err := client.deleteBinaryData(filter); err != nil {
 			return err
@@ -119,7 +84,7 @@ func DataDeleteAction(c *cli.Context) error {
 			return err
 		}
 	default:
-		return errors.Errorf("%s must be binary or tabular, got %q", DataFlagDataType, c.String(DataFlagDataType))
+		return errors.Errorf("%s must be binary or tabular, got %q", dataFlagDataType, c.String(dataFlagDataType))
 	}
 
 	return nil
@@ -128,68 +93,68 @@ func DataDeleteAction(c *cli.Context) error {
 func createDataFilter(c *cli.Context) (*datapb.Filter, error) {
 	filter := &datapb.Filter{}
 
-	if c.StringSlice(DataFlagOrgIDs) != nil {
-		filter.OrganizationIds = c.StringSlice(DataFlagOrgIDs)
+	if c.StringSlice(dataFlagOrgIDs) != nil {
+		filter.OrganizationIds = c.StringSlice(dataFlagOrgIDs)
 	}
-	if c.StringSlice(DataFlagLocationIDs) != nil {
-		filter.LocationIds = c.StringSlice(DataFlagLocationIDs)
+	if c.StringSlice(dataFlagLocationIDs) != nil {
+		filter.LocationIds = c.StringSlice(dataFlagLocationIDs)
 	}
-	if c.String(DataFlagRobotID) != "" {
-		filter.RobotId = c.String(DataFlagRobotID)
+	if c.String(dataFlagRobotID) != "" {
+		filter.RobotId = c.String(dataFlagRobotID)
 	}
-	if c.String(DataFlagPartID) != "" {
-		filter.PartId = c.String(DataFlagPartID)
+	if c.String(dataFlagPartID) != "" {
+		filter.PartId = c.String(dataFlagPartID)
 	}
-	if c.String(DataFlagRobotName) != "" {
-		filter.RobotName = c.String(DataFlagRobotName)
+	if c.String(dataFlagRobotName) != "" {
+		filter.RobotName = c.String(dataFlagRobotName)
 	}
-	if c.String(DataFlagPartName) != "" {
-		filter.PartName = c.String(DataFlagPartName)
+	if c.String(dataFlagPartName) != "" {
+		filter.PartName = c.String(dataFlagPartName)
 	}
-	if c.String(DataFlagComponentType) != "" {
-		filter.ComponentType = c.String(DataFlagComponentType)
+	if c.String(dataFlagComponentType) != "" {
+		filter.ComponentType = c.String(dataFlagComponentType)
 	}
-	if c.String(DataFlagComponentName) != "" {
-		filter.ComponentName = c.String(DataFlagComponentName)
+	if c.String(dataFlagComponentName) != "" {
+		filter.ComponentName = c.String(dataFlagComponentName)
 	}
-	if c.String(DataFlagMethod) != "" {
-		filter.Method = c.String(DataFlagMethod)
+	if c.String(dataFlagMethod) != "" {
+		filter.Method = c.String(dataFlagMethod)
 	}
-	if len(c.StringSlice(DataFlagMimeTypes)) != 0 {
-		filter.MimeType = c.StringSlice(DataFlagMimeTypes)
+	if len(c.StringSlice(dataFlagMimeTypes)) != 0 {
+		filter.MimeType = c.StringSlice(dataFlagMimeTypes)
 	}
-	if c.StringSlice(DataFlagTags) != nil {
+	if c.StringSlice(dataFlagTags) != nil {
 		switch {
-		case len(c.StringSlice(DataFlagTags)) == 1 && c.StringSlice(DataFlagTags)[0] == "tagged":
+		case len(c.StringSlice(dataFlagTags)) == 1 && c.StringSlice(dataFlagTags)[0] == "tagged":
 			filter.TagsFilter = &datapb.TagsFilter{
 				Type: datapb.TagsFilterType_TAGS_FILTER_TYPE_TAGGED,
 			}
-		case len(c.StringSlice(DataFlagTags)) == 1 && c.StringSlice(DataFlagTags)[0] == "untagged":
+		case len(c.StringSlice(dataFlagTags)) == 1 && c.StringSlice(dataFlagTags)[0] == "untagged":
 			filter.TagsFilter = &datapb.TagsFilter{
 				Type: datapb.TagsFilterType_TAGS_FILTER_TYPE_UNTAGGED,
 			}
 		default:
 			filter.TagsFilter = &datapb.TagsFilter{
 				Type: datapb.TagsFilterType_TAGS_FILTER_TYPE_MATCH_BY_OR,
-				Tags: c.StringSlice(DataFlagTags),
+				Tags: c.StringSlice(dataFlagTags),
 			}
 		}
 	}
-	if len(c.StringSlice(DataFlagBboxLabels)) != 0 {
-		filter.BboxLabels = c.StringSlice(DataFlagBboxLabels)
+	if len(c.StringSlice(dataFlagBboxLabels)) != 0 {
+		filter.BboxLabels = c.StringSlice(dataFlagBboxLabels)
 	}
 	var start *timestamppb.Timestamp
 	var end *timestamppb.Timestamp
 	timeLayout := time.RFC3339
-	if c.String(DataFlagStart) != "" {
-		t, err := time.Parse(timeLayout, c.String(DataFlagStart))
+	if c.String(dataFlagStart) != "" {
+		t, err := time.Parse(timeLayout, c.String(dataFlagStart))
 		if err != nil {
 			return nil, errors.Wrap(err, "could not parse start flag")
 		}
 		start = timestamppb.New(t)
 	}
-	if c.String(DataFlagEnd) != "" {
-		t, err := time.Parse(timeLayout, c.String(DataFlagEnd))
+	if c.String(dataFlagEnd) != "" {
+		t, err := time.Parse(timeLayout, c.String(dataFlagEnd))
 		if err != nil {
 			return nil, errors.Wrap(err, "could not parse end flag")
 		}

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -181,7 +181,7 @@ func UploadModuleAction(c *cli.Context) error {
 	orgIDArg := c.String(moduleFlagOrgID)
 	nameArg := c.String(moduleFlagName)
 	versionArg := c.String(moduleFlagVersion)
-	platformArg := c.String(moduleFlagVersion)
+	platformArg := c.String(moduleFlagPlatform)
 	tarballPath := c.Args().First()
 	if c.Args().Len() > 1 {
 		return errors.New("too many arguments passed to upload command. " +

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -59,9 +59,9 @@ const (
 // the command to create a module. This includes both a gRPC call to register
 // the module on app.viam.com and creating the manifest file.
 func CreateModuleAction(c *cli.Context) error {
-	moduleNameArg := c.String("name")
-	publicNamespaceArg := c.String("public-namespace")
-	orgIDArg := c.String("org-id")
+	moduleNameArg := c.String(moduleFlagName)
+	publicNamespaceArg := c.String(moduleFlagPublicNamespace)
+	orgIDArg := c.String(moduleFlagOrgID)
 
 	client, err := newAppClient(c)
 	if err != nil {
@@ -118,9 +118,9 @@ func CreateModuleAction(c *cli.Context) error {
 // the command to update a module. This includes updating the meta.json to
 // include the public namespace (if set on the org).
 func UpdateModuleAction(c *cli.Context) error {
-	publicNamespaceArg := c.String("public-namespace")
-	orgIDArg := c.String("org-id")
-	manifestPathArg := c.String("module")
+	publicNamespaceArg := c.String(moduleFlagPublicNamespace)
+	orgIDArg := c.String(moduleFlagOrgID)
+	manifestPathArg := c.String(moduleFlagPath)
 
 	manifestPath := defaultManifestFilename
 	if manifestPathArg != "" {
@@ -176,12 +176,12 @@ func UpdateModuleAction(c *cli.Context) error {
 
 // UploadModuleAction is the corresponding action for 'module upload'.
 func UploadModuleAction(c *cli.Context) error {
-	manifestPathArg := c.String("module")
-	publicNamespaceArg := c.String("public-namespace")
-	orgIDArg := c.String("org-id")
-	nameArg := c.String("name")
-	versionArg := c.String("version")
-	platformArg := c.String("platform")
+	manifestPathArg := c.String(moduleFlagPath)
+	publicNamespaceArg := c.String(moduleFlagPublicNamespace)
+	orgIDArg := c.String(moduleFlagOrgID)
+	nameArg := c.String(moduleFlagName)
+	versionArg := c.String(moduleFlagVersion)
+	platformArg := c.String(moduleFlagVersion)
 	tarballPath := c.Args().First()
 	if c.Args().Len() > 1 {
 		return errors.New("too many arguments passed to upload command. " +


### PR DESCRIPTION
RSDK-4446

Moves all CLI string flags to a `const` block at the top of `cli/app.go`. Modifies all usages of `c.String` and `c.Bool` to use these constants.