### PR TITLE
Add Status to genericlinux board

### DIFF
--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -588,7 +588,7 @@ func (b *Board) GPIOPinByName(pinName string) (board.GPIOPin, error) {
 
 // Status returns the current status of the board.
 func (b *Board) Status(ctx context.Context, extra map[string]interface{}) (*commonpb.BoardStatus, error) {
-	return board.CreateStatus(ctx, b, extra), nil
+	return board.CreateStatus(ctx, b, extra)
 }
 
 // ModelAttributes returns attributes related to the model of this board.

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -588,7 +588,7 @@ func (b *Board) GPIOPinByName(pinName string) (board.GPIOPin, error) {
 
 // Status returns the current status of the board.
 func (b *Board) Status(ctx context.Context, extra map[string]interface{}) (*commonpb.BoardStatus, error) {
-	return &commonpb.BoardStatus{}, nil
+	return board.CreateStatus(ctx, b, extra), nil
 }
 
 // ModelAttributes returns attributes related to the model of this board.

--- a/components/board/genericlinux/board_test.go
+++ b/components/board/genericlinux/board_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/edaniels/golog"
-	commonpb "go.viam.com/api/common/v1"
 	"go.viam.com/test"
 
 	"go.viam.com/rdk/components/board"
@@ -100,15 +99,6 @@ func TestGenericLinux(t *testing.T) {
 		gn1, err := b.GPIOPinByName("10")
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, gn1, test.ShouldBeNil)
-	})
-
-	t.Run("test genericlinux gpio pin functionality", func(t *testing.T) {
-		bs, err := b.Status(ctx, nil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "closed")
-		test.That(t, bs, test.ShouldHaveSameTypeAs, &commonpb.BoardStatus{})
-
-		bma := b.ModelAttributes()
-		test.That(t, bma, test.ShouldResemble, board.ModelAttributes{})
 	})
 
 	t.Run("test spi functionality", func(t *testing.T) {

--- a/components/board/genericlinux/board_test.go
+++ b/components/board/genericlinux/board_test.go
@@ -104,8 +104,8 @@ func TestGenericLinux(t *testing.T) {
 
 	t.Run("test genericlinux gpio pin functionality", func(t *testing.T) {
 		bs, err := b.Status(ctx, nil)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, bs, test.ShouldResemble, &commonpb.BoardStatus{})
+		test.That(t, err.Error(), test.ShouldContainSubstring, "closed")
+		test.That(t, bs, test.ShouldHaveSameTypeAs, &commonpb.BoardStatus{})
 
 		bma := b.ModelAttributes()
 		test.That(t, bma, test.ShouldResemble, board.ModelAttributes{})


### PR DESCRIPTION
This pr implements status for the genericlinux boards similar to numato and pi. Note not all boards have implemented status. The create status function is implemented in the board interface and relies on the names of digital interrupts and analogs in configuration to be present to report them. It is unknown how this interact with out new reconfigure flow.

*** this status method may be moved with different functionality eventually. 