### PR TITLE
RSDK-4195, RSDK-3352, RSDK-3009, RSDK-3096: add support for flat tensors to RDK, in mlmodel/tflite_cpu and vision/mlmodel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -357,7 +357,7 @@ require (
 	github.com/zitadel/oidc v1.13.4 // indirect
 	gitlab.com/bosi/decorder v0.2.3 // indirect
 	go.uber.org/goleak v1.2.1 // indirect
-	go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760 // indirect
+	go4.org/unsafe/assume-no-moving-gc v0.0.0-20230525183740-e7c30c78aeb2 // indirect
 	golang.org/x/crypto v0.10.0 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20230203172020-98cc5a0785f9 // indirect
 	golang.org/x/mod v0.10.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -127,6 +127,7 @@ require (
 	github.com/alecthomas/participle/v2 v2.0.0-alpha3 // indirect
 	github.com/alexkohler/prealloc v1.0.0 // indirect
 	github.com/alingse/asasalint v0.0.11 // indirect
+	github.com/apache/arrow/go/arrow v0.0.0-20201229220542-30ce2eb5d4dc // indirect
 	github.com/ashanbrown/forbidigo v1.4.0 // indirect
 	github.com/ashanbrown/makezero v1.1.1 // indirect
 	github.com/aws/aws-sdk-go v1.38.20 // indirect
@@ -148,6 +149,8 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/charithe/durationcheck v0.0.9 // indirect
 	github.com/chavacava/garif v0.0.0-20221024190013-b3ef35877348 // indirect
+	github.com/chewxy/hm v1.0.0 // indirect
+	github.com/chewxy/math32 v1.0.8 // indirect
 	github.com/cncf/udpa/go v0.0.0-20220112060539-c52dc94e7fbe // indirect
 	github.com/cncf/xds/go v0.0.0-20230105202645-06c439db220b // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
@@ -189,6 +192,7 @@ require (
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/gofrs/flock v0.8.1 // indirect
 	github.com/gofrs/uuid v4.2.0+incompatible // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/glog v1.0.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/snappy v0.0.4 // indirect
@@ -346,12 +350,14 @@ require (
 	github.com/xdg-go/scram v1.1.2 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
+	github.com/xtgo/set v1.0.0 // indirect
 	github.com/yagipy/maintidx v1.0.0 // indirect
 	github.com/yeya24/promlinter v0.2.0 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a // indirect
 	github.com/zitadel/oidc v1.13.4 // indirect
 	gitlab.com/bosi/decorder v0.2.3 // indirect
 	go.uber.org/goleak v1.2.1 // indirect
+	go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760 // indirect
 	golang.org/x/crypto v0.10.0 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20230203172020-98cc5a0785f9 // indirect
 	golang.org/x/mod v0.10.0 // indirect
@@ -368,6 +374,9 @@ require (
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gorgonia.org/tensor v0.9.24 // indirect
+	gorgonia.org/vecf32 v0.9.0 // indirect
+	gorgonia.org/vecf64 v0.9.0 // indirect
 	honnef.co/go/tools v0.4.2 // indirect
 	howett.net/plist v1.0.0 // indirect
 	mvdan.cc/gofumpt v0.4.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -96,6 +96,7 @@ require (
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.2.0
 	google.golang.org/protobuf v1.30.0
 	gopkg.in/src-d/go-billy.v4 v4.3.2
+	gorgonia.org/tensor v0.9.24
 	gotest.tools/gotestsum v1.10.0
 	periph.io/x/conn/v3 v3.7.0
 	periph.io/x/host/v3 v3.8.1-0.20230331112814-9f0d9f7d76db
@@ -374,7 +375,6 @@ require (
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	gorgonia.org/tensor v0.9.24 // indirect
 	gorgonia.org/vecf32 v0.9.0 // indirect
 	gorgonia.org/vecf64 v0.9.0 // indirect
 	honnef.co/go/tools v0.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -152,7 +152,6 @@ github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
-github.com/armon/go-metrics v0.3.10/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
 github.com/ashanbrown/forbidigo v1.1.0/go.mod h1:vVW7PEdqEFqapJe95xHkTfB1+XvZXBFg8t0sG2FIxmI=
@@ -277,7 +276,6 @@ github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7
 github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190620071333-e64a0ec8b42a/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
-github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
@@ -289,7 +287,6 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.19-0.20220421211855-0d412c9fbeb1 h1:Tw0uuY+3UWYiSbR0+wsrJ30vY3zMFZ4JNPkSp9XdFyA=
 github.com/creack/pty v1.1.19-0.20220421211855-0d412c9fbeb1/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
-github.com/cristalhq/acmd v0.8.1/go.mod h1:LG5oa43pE/BbxtfMoImHCQN++0Su7dzipdgBjMCBVDQ=
 github.com/curioswitch/go-reassign v0.2.0 h1:G9UZyOcpk/d7Gd6mqYgd8XYWFMw/znxwGDUstnC9DIo=
 github.com/curioswitch/go-reassign v0.2.0/go.mod h1:x6OpXuWvgfQaMGks2BZybTngWjT84hqJfKoO8Tt/Roc=
 github.com/d2r2/go-i2c v0.0.0-20191123181816-73a8a799d6bc h1:HLRSIWzUGMLCq4ldt0W1GLs3nnAxa5EGoP+9qHgh6j0=
@@ -424,11 +421,9 @@ github.com/go-critic/go-critic v0.5.5/go.mod h1:eMs1Oc/oIP+CYNVN09M+XZYffIPuRHaw
 github.com/go-critic/go-critic v0.6.7 h1:1evPrElnLQ2LZtJfmNDzlieDhjnq36SLgNzisx06oPM=
 github.com/go-critic/go-critic v0.6.7/go.mod h1:fYZUijFdcnxgx6wPjQA2QEjIRaNCT0gO8bhexy6/QmE=
 github.com/go-fonts/dejavu v0.1.0 h1:JSajPXURYqpr+Cu8U9bt8K+XcACIHWqWrvWCKyeFmVQ=
-github.com/go-fonts/dejavu v0.1.0/go.mod h1:4Wt4I4OU2Nq9asgDCteaAaWZOV24E+0/Pwo0gppep4g=
 github.com/go-fonts/latin-modern v0.3.0 h1:CIDlMm0djMO3XIKHVz2na9lFKt3kdC/YCy7k7lLpyjE=
 github.com/go-fonts/liberation v0.3.0 h1:3BI2iaE7R/s6uUUtzNCjo3QijJu3aS4wmrMgfSpYQ+8=
 github.com/go-fonts/liberation v0.3.0/go.mod h1:jdJ+cqF+F4SUL2V+qxBth8fvBpBDS7yloUL5Fi8GTGY=
-github.com/go-fonts/stix v0.1.0/go.mod h1:w/c1f0ldAUlJmLBvlbkvVXLAD+tAMqobIIQpmnUIzUY=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -489,7 +484,6 @@ github.com/go-toolsmith/astp v1.1.0 h1:dXPuCl6u2llURjdPLLDxJeZInAeZ0/eZwFJmqZMnp
 github.com/go-toolsmith/astp v1.1.0/go.mod h1:0T1xFGz9hicKs8Z5MfAqSUitoUYS30pDMsRVIDHs8CA=
 github.com/go-toolsmith/pkgload v1.0.0/go.mod h1:5eFArkbO80v7Z0kdngIxsRXRMTaX4Ilcwuh3clNrQJc=
 github.com/go-toolsmith/pkgload v1.0.2-0.20220101231613-e814995d17c5 h1:eD9POs68PHkwrx7hAB78z1cb6PfGq/jyWn3wJywsH1o=
-github.com/go-toolsmith/pkgload v1.0.2-0.20220101231613-e814995d17c5/go.mod h1:3NAwwmD4uY/yggRxoEjk/S00MIV3A+H7rrE3i87eYxM=
 github.com/go-toolsmith/strparse v1.0.0/go.mod h1:YI2nUKP9YGZnL/L1/DLFBfixrcjslWct4wyljWhSRy8=
 github.com/go-toolsmith/strparse v1.1.0 h1:GAioeZUK9TGxnLS+qfdqNbA4z0SSm5zVNtCQiyP2Bvw=
 github.com/go-toolsmith/strparse v1.1.0/go.mod h1:7ksGy58fsaQkGQlY8WVoBFNyEPMGuJin1rfoPS4lBSQ=
@@ -552,7 +546,6 @@ github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
-github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -634,7 +627,6 @@ github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
-github.com/google/go-github/v31 v31.0.0/go.mod h1:NQPZol8/1sMoWYGN2yaALIBytu17gAWfhbweiEed3pM=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
@@ -683,7 +675,6 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
-github.com/gorilla/schema v1.2.0/go.mod h1:kgLaKoK1FELgZqMAVxx/5cbj0kT+57qxUrAlIO2eleU=
 github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.0/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
@@ -734,15 +725,12 @@ github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
-github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
-github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
-github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v0.0.0-20180228145832-27454136f036/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
@@ -796,14 +784,11 @@ github.com/jdxcode/netrc v0.0.0-20210204082910-926c7f70242a/go.mod h1:Zi/ZFkEqFH
 github.com/jedib0t/go-pretty/v6 v6.4.6 h1:v6aG9h6Uby3IusSSEjHaZNXpHFhzqMmjXcPq1Rjl9Jw=
 github.com/jedib0t/go-pretty/v6 v6.4.6/go.mod h1:Ndk3ase2CkQbXLLNf5QDHoYb6J9WtVfmHZu9n8rk2xs=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
-github.com/jeremija/gosubmit v0.2.7/go.mod h1:Ui+HS073lCFREXBbdfrJzMB57OI/bdxTiLtrDHHhFPI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jezek/xgb v0.0.0-20210312150743-0e0f116e1240/go.mod h1:3P4UH/k22rXyHIJD2w4h2XMqPX4Of/eySEZq9L6wqc4=
 github.com/jgautheron/goconst v1.4.0/go.mod h1:aAosetZ5zaeC/2EfMeRswtxUFBpe2Hr7HzkgX4fanO4=
 github.com/jgautheron/goconst v1.5.1 h1:HxVbL1MhydKs8R8n/HE5NPvzfaYmQJA3o879lE4+WcM=
 github.com/jgautheron/goconst v1.5.1/go.mod h1:aAosetZ5zaeC/2EfMeRswtxUFBpe2Hr7HzkgX4fanO4=
-github.com/jhump/gopoet v0.1.0/go.mod h1:me9yfT6IJSlOL3FCfrg+L6yzUEZ+5jW6WHt4Sk+UPUI=
-github.com/jhump/goprotoc v0.5.0/go.mod h1:VrbvcYrQOrTi3i0Vf+m+oqQWk9l72mjkJCYo7UvLHRQ=
 github.com/jhump/protocompile v0.0.0-20220216033700-d705409f108f h1:BNuUg9k2EiJmlMwjoef3e8vZLHplbVw6DrjGFjLL+Yo=
 github.com/jhump/protocompile v0.0.0-20220216033700-d705409f108f/go.mod h1:qr2b5kx4HbFS7/g4uYO5qv9ei8303JMsC7ESbYiqr2Q=
 github.com/jhump/protoreflect v1.6.1/go.mod h1:RZQ/lnuN+zqeRVpQigTwO6o0AJUkxbnSnpuG7toUTG4=
@@ -1088,7 +1073,6 @@ github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
-github.com/oklog/ulid/v2 v2.0.2/go.mod h1:mtBL0Qe/0HAx6/a4Z30qxVIAL1eQDweXq5lxOEiwQ68=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.2/go.mod h1:rSAaSIOAGT9odnlyGlUfAJaoc5w2fSBUmeGDbRWPxyQ=
@@ -1198,7 +1182,6 @@ github.com/pion/transport/v2 v2.2.1/go.mod h1:cXXWavvCnFF6McHTft3DWS9iic2Mftcz1A
 github.com/pion/turn/v2 v2.1.0/go.mod h1:yrT5XbXSGX1VFSF31A3c1kCNB5bBZgk/uu5LET162qs=
 github.com/pion/turn/v2 v2.1.2 h1:wj0cAoGKltaZ790XEGW9HwoUewqjliwmhtxCuB2ApyM=
 github.com/pion/turn/v2 v2.1.2/go.mod h1:1kjnPkBcex3dhCU2Am+AAmxDcGhLX3WnMfmkNpvSTQU=
-github.com/pion/udp v0.1.4/go.mod h1:G8LDo56HsFwC24LIcnT4YIDU5qcB6NepqqjP0keL2us=
 github.com/pion/webrtc/v3 v3.2.11 h1:lfGKYZcG7ghCTQWn+zsD+icIIWL3qIfclEjBGk537+s=
 github.com/pion/webrtc/v3 v3.2.11/go.mod h1:fejQio1v8tKG4ntq4u8H4uDHsCNX6eX7bT093t4H+0E=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
@@ -1220,7 +1203,6 @@ github.com/polyfloyd/go-errorlint v0.0.0-20201127212506-19bd8db6546f/go.mod h1:w
 github.com/polyfloyd/go-errorlint v1.1.0 h1:VKoEFg5yxSgJ2yFPVhxW7oGz+f8/OVcuMeNvcPIi6Eg=
 github.com/polyfloyd/go-errorlint v1.1.0/go.mod h1:Uss7Bc/izYG0leCMRx3WVlrpqWedSZk7V/FUQW6VJ6U=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
-github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
@@ -1275,7 +1257,6 @@ github.com/quasilyte/go-ruleguard/dsl v0.3.1/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQP
 github.com/quasilyte/go-ruleguard/rules v0.0.0-20201231183845-9e62ed36efe1/go.mod h1:7JTjp89EGyU1d6XfBiXihJNG37wB2VRkd125Q1u7Plc=
 github.com/quasilyte/go-ruleguard/rules v0.0.0-20210203162857-b223e0831f88/go.mod h1:4cgAphtvu7Ftv7vOT2ZOYhC6CvBxZixcasr8qIOTA50=
 github.com/quasilyte/go-ruleguard/rules v0.0.0-20210221215616-dfcc94e3dffd/go.mod h1:4cgAphtvu7Ftv7vOT2ZOYhC6CvBxZixcasr8qIOTA50=
-github.com/quasilyte/go-ruleguard/rules v0.0.0-20211022131956-028d6511ab71/go.mod h1:4cgAphtvu7Ftv7vOT2ZOYhC6CvBxZixcasr8qIOTA50=
 github.com/quasilyte/gogrep v0.5.0 h1:eTKODPXbI8ffJMN+W2aE0+oL0z/nh8/5eNdiO34SOAo=
 github.com/quasilyte/gogrep v0.5.0/go.mod h1:Cm9lpz9NZjEoL1tgZ2OgeUKPIxL1meE7eo60Z6Sk+Ng=
 github.com/quasilyte/regex/syntax v0.0.0-20200407221936-30656e2c4a95 h1:L8QM9bvf68pVdQ3bCFZMDmnt9yqcMBro1pC7F+IPYMY=
@@ -1518,7 +1499,6 @@ github.com/xdg-go/stringprep v1.0.4 h1:XLI/Ng3O1Atzq0oBs3TWm+5ZVgkq2aqdlvP9JtoZ6
 github.com/xdg-go/stringprep v1.0.4/go.mod h1:mPGuuIYwz7CmR2bT9j4GbQqutWS1zV24gijq1dTyGkM=
 github.com/xfmoulet/qoi v0.2.0 h1:+Smrwzy5ptRnPzGm/YHkZfyK9qGUSoOpiEPngGmFv+c=
 github.com/xfmoulet/qoi v0.2.0/go.mod h1:uuPUygmV7o8qy7PhiaGAQX0iLiqoUvFEUKjwUFtlaTQ=
-github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xitongsys/parquet-go v1.5.1/go.mod h1:xUxwM8ELydxh4edHGegYq1pA8NnMKDx0K/GyB0o2bww=
 github.com/xitongsys/parquet-go v1.5.2/go.mod h1:90swTgY6VkNM4MkMDsNxq8h30m6Yj1Arv9UMEl5V5DM=
@@ -1547,7 +1527,6 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-github.com/zitadel/logging v0.3.4/go.mod h1:aPpLQhE+v6ocNK0TWrBrd363hZ95KcI17Q1ixAQwZF0=
 github.com/zitadel/oidc v1.13.4 h1:+k2GKqP9Ld9S2MSFlj+KaNsoZ3J9oy+Ezw51EzSFuC8=
 github.com/zitadel/oidc v1.13.4/go.mod h1:3h2DhUcP02YV6q/CA/BG4yla0o6rXjK+DkJGK/dwJfw=
 github.com/ziutek/mymysql v1.5.4 h1:GB0qdRGsTwQSBVYuVShFBKaXSnSnYYC2d9knnE1LHFs=
@@ -1609,10 +1588,7 @@ go.viam.com/test v1.1.1-0.20220913152726-5da9916c08a2 h1:oBiK580EnEIzgFLU4lHOXmG
 go.viam.com/test v1.1.1-0.20220913152726-5da9916c08a2/go.mod h1:XM0tej6riszsiNLT16uoyq1YjuYPWlRBweTPRDanIts=
 go.viam.com/utils v0.1.40 h1:sf6x7U1/D34YmyWQL/LE8OB6RRXcc0zTgEFWXTa6miA=
 go.viam.com/utils v0.1.40/go.mod h1:tjPInze4C0UYFRqL/FU96yqhJpHR1zjiNZ7qChTN/b8=
-go4.org v0.0.0-20180809161055-417644f6feb5 h1:+hE86LblG4AyDgwMCLTE6FOlM9+qjHSYS+rKqxUVdsM=
 go4.org v0.0.0-20180809161055-417644f6feb5/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=
-go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760 h1:FyBZqvoA/jbNzuAWLQE2kG820zMAkcilx6BMjGbL/E4=
-go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
 go4.org/unsafe/assume-no-moving-gc v0.0.0-20230525183740-e7c30c78aeb2 h1:WJhcL4p+YeDxmZWg141nRm7XC8IDmhz7lk5GpadO1Sg=
 go4.org/unsafe/assume-no-moving-gc v0.0.0-20230525183740-e7c30c78aeb2/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
 gocv.io/x/gocv v0.25.0/go.mod h1:Rar2PS6DV+T4FL+PM535EImD/h13hGVaHhnCu1xarBs=

--- a/go.sum
+++ b/go.sum
@@ -1613,6 +1613,8 @@ go4.org v0.0.0-20180809161055-417644f6feb5 h1:+hE86LblG4AyDgwMCLTE6FOlM9+qjHSYS+
 go4.org v0.0.0-20180809161055-417644f6feb5/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=
 go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760 h1:FyBZqvoA/jbNzuAWLQE2kG820zMAkcilx6BMjGbL/E4=
 go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
+go4.org/unsafe/assume-no-moving-gc v0.0.0-20230525183740-e7c30c78aeb2 h1:WJhcL4p+YeDxmZWg141nRm7XC8IDmhz7lk5GpadO1Sg=
+go4.org/unsafe/assume-no-moving-gc v0.0.0-20230525183740-e7c30c78aeb2/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
 gocv.io/x/gocv v0.25.0/go.mod h1:Rar2PS6DV+T4FL+PM535EImD/h13hGVaHhnCu1xarBs=
 goji.io v2.0.2+incompatible h1:uIssv/elbKRLznFUy3Xj4+2Mz/qKhek/9aZQDUMae7c=
 goji.io v2.0.2+incompatible/go.mod h1:sbqFwrtqZACxLBTQcdgVjFh54yGVCvwq8+w49MVMMIk=

--- a/go.sum
+++ b/go.sum
@@ -144,12 +144,15 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYU
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/aokoli/goutils v1.0.1/go.mod h1:SijmP0QR8LtwsmDs8Yii5Z/S4trXFGFC2oO5g9DP+DQ=
+github.com/apache/arrow/go/arrow v0.0.0-20201229220542-30ce2eb5d4dc h1:zvQ6w7KwtQWgMQiewOF9tFtundRMVZFSAksNV6ogzuY=
+github.com/apache/arrow/go/arrow v0.0.0-20201229220542-30ce2eb5d4dc/go.mod h1:c9sxoIT3YgLxH4UhLOCKaBlEojuMhVYpk4Ntv3opUTQ=
 github.com/apache/thrift v0.0.0-20181112125854-24918abba929/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
+github.com/armon/go-metrics v0.3.10/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
 github.com/ashanbrown/forbidigo v1.1.0/go.mod h1:vVW7PEdqEFqapJe95xHkTfB1+XvZXBFg8t0sG2FIxmI=
@@ -235,6 +238,11 @@ github.com/charithe/durationcheck v0.0.9 h1:mPP4ucLrf/rKZiIG/a9IPXHGlh8p4CzgpyTy
 github.com/charithe/durationcheck v0.0.9/go.mod h1:SSbRIBVfMjCi/kEB6K65XEA83D6prSM8ap1UCpNKtgg=
 github.com/chavacava/garif v0.0.0-20221024190013-b3ef35877348 h1:cy5GCEZLUCshCGCRRUjxHrDUqkB4l5cuUt3ShEckQEo=
 github.com/chavacava/garif v0.0.0-20221024190013-b3ef35877348/go.mod h1:f/miWtG3SSuTxKsNK3o58H1xl+XV6ZIfbC6p7lPPB8U=
+github.com/chewxy/hm v1.0.0 h1:zy/TSv3LV2nD3dwUEQL2VhXeoXbb9QkpmdRAVUFiA6k=
+github.com/chewxy/hm v1.0.0/go.mod h1:qg9YI4q6Fkj/whwHR1D+bOGeF7SniIP40VweVepLjg0=
+github.com/chewxy/math32 v1.0.0/go.mod h1:Miac6hA1ohdDUTagnvJy/q+aNnEk16qWUdb8ZVhvCN0=
+github.com/chewxy/math32 v1.0.8 h1:fU5E4Ec4Z+5RtRAi3TovSxUjQPkgRh+HbP7tKB2OFbM=
+github.com/chewxy/math32 v1.0.8/go.mod h1:dOB2rcuFrCn6UHrze36WSLVPKtzPMRAQvBvUwkSsLqs=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -269,6 +277,7 @@ github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7
 github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190620071333-e64a0ec8b42a/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
@@ -280,6 +289,7 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.19-0.20220421211855-0d412c9fbeb1 h1:Tw0uuY+3UWYiSbR0+wsrJ30vY3zMFZ4JNPkSp9XdFyA=
 github.com/creack/pty v1.1.19-0.20220421211855-0d412c9fbeb1/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
+github.com/cristalhq/acmd v0.8.1/go.mod h1:LG5oa43pE/BbxtfMoImHCQN++0Su7dzipdgBjMCBVDQ=
 github.com/curioswitch/go-reassign v0.2.0 h1:G9UZyOcpk/d7Gd6mqYgd8XYWFMw/znxwGDUstnC9DIo=
 github.com/curioswitch/go-reassign v0.2.0/go.mod h1:x6OpXuWvgfQaMGks2BZybTngWjT84hqJfKoO8Tt/Roc=
 github.com/d2r2/go-i2c v0.0.0-20191123181816-73a8a799d6bc h1:HLRSIWzUGMLCq4ldt0W1GLs3nnAxa5EGoP+9qHgh6j0=
@@ -414,9 +424,11 @@ github.com/go-critic/go-critic v0.5.5/go.mod h1:eMs1Oc/oIP+CYNVN09M+XZYffIPuRHaw
 github.com/go-critic/go-critic v0.6.7 h1:1evPrElnLQ2LZtJfmNDzlieDhjnq36SLgNzisx06oPM=
 github.com/go-critic/go-critic v0.6.7/go.mod h1:fYZUijFdcnxgx6wPjQA2QEjIRaNCT0gO8bhexy6/QmE=
 github.com/go-fonts/dejavu v0.1.0 h1:JSajPXURYqpr+Cu8U9bt8K+XcACIHWqWrvWCKyeFmVQ=
+github.com/go-fonts/dejavu v0.1.0/go.mod h1:4Wt4I4OU2Nq9asgDCteaAaWZOV24E+0/Pwo0gppep4g=
 github.com/go-fonts/latin-modern v0.3.0 h1:CIDlMm0djMO3XIKHVz2na9lFKt3kdC/YCy7k7lLpyjE=
 github.com/go-fonts/liberation v0.3.0 h1:3BI2iaE7R/s6uUUtzNCjo3QijJu3aS4wmrMgfSpYQ+8=
 github.com/go-fonts/liberation v0.3.0/go.mod h1:jdJ+cqF+F4SUL2V+qxBth8fvBpBDS7yloUL5Fi8GTGY=
+github.com/go-fonts/stix v0.1.0/go.mod h1:w/c1f0ldAUlJmLBvlbkvVXLAD+tAMqobIIQpmnUIzUY=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -477,6 +489,7 @@ github.com/go-toolsmith/astp v1.1.0 h1:dXPuCl6u2llURjdPLLDxJeZInAeZ0/eZwFJmqZMnp
 github.com/go-toolsmith/astp v1.1.0/go.mod h1:0T1xFGz9hicKs8Z5MfAqSUitoUYS30pDMsRVIDHs8CA=
 github.com/go-toolsmith/pkgload v1.0.0/go.mod h1:5eFArkbO80v7Z0kdngIxsRXRMTaX4Ilcwuh3clNrQJc=
 github.com/go-toolsmith/pkgload v1.0.2-0.20220101231613-e814995d17c5 h1:eD9POs68PHkwrx7hAB78z1cb6PfGq/jyWn3wJywsH1o=
+github.com/go-toolsmith/pkgload v1.0.2-0.20220101231613-e814995d17c5/go.mod h1:3NAwwmD4uY/yggRxoEjk/S00MIV3A+H7rrE3i87eYxM=
 github.com/go-toolsmith/strparse v1.0.0/go.mod h1:YI2nUKP9YGZnL/L1/DLFBfixrcjslWct4wyljWhSRy8=
 github.com/go-toolsmith/strparse v1.1.0 h1:GAioeZUK9TGxnLS+qfdqNbA4z0SSm5zVNtCQiyP2Bvw=
 github.com/go-toolsmith/strparse v1.1.0/go.mod h1:7ksGy58fsaQkGQlY8WVoBFNyEPMGuJin1rfoPS4lBSQ=
@@ -539,6 +552,7 @@ github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
+github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -600,6 +614,7 @@ github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Z
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/certificate-transparency-go v1.0.21/go.mod h1:QeJfpSbVSfYc7RgB3gJFj9cbuQMMchQxrWXz8Ruopmg=
 github.com/google/certificate-transparency-go v1.1.1/go.mod h1:FDKqPvSXawb2ecErVRrD+nfy23RCzyl7eqVCEmlT1Zs=
+github.com/google/flatbuffers v1.11.0/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/flatbuffers v2.0.6+incompatible h1:XHFReMv7nFFusa+CEokzWbzaYocKXI6C7hdU5Kgh9Lw=
 github.com/google/flatbuffers v2.0.6+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -619,6 +634,7 @@ github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
+github.com/google/go-github/v31 v31.0.0/go.mod h1:NQPZol8/1sMoWYGN2yaALIBytu17gAWfhbweiEed3pM=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
@@ -667,6 +683,7 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/schema v1.2.0/go.mod h1:kgLaKoK1FELgZqMAVxx/5cbj0kT+57qxUrAlIO2eleU=
 github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.0/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
@@ -717,12 +734,15 @@ github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
+github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
+github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v0.0.0-20180228145832-27454136f036/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
@@ -776,11 +796,14 @@ github.com/jdxcode/netrc v0.0.0-20210204082910-926c7f70242a/go.mod h1:Zi/ZFkEqFH
 github.com/jedib0t/go-pretty/v6 v6.4.6 h1:v6aG9h6Uby3IusSSEjHaZNXpHFhzqMmjXcPq1Rjl9Jw=
 github.com/jedib0t/go-pretty/v6 v6.4.6/go.mod h1:Ndk3ase2CkQbXLLNf5QDHoYb6J9WtVfmHZu9n8rk2xs=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
+github.com/jeremija/gosubmit v0.2.7/go.mod h1:Ui+HS073lCFREXBbdfrJzMB57OI/bdxTiLtrDHHhFPI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jezek/xgb v0.0.0-20210312150743-0e0f116e1240/go.mod h1:3P4UH/k22rXyHIJD2w4h2XMqPX4Of/eySEZq9L6wqc4=
 github.com/jgautheron/goconst v1.4.0/go.mod h1:aAosetZ5zaeC/2EfMeRswtxUFBpe2Hr7HzkgX4fanO4=
 github.com/jgautheron/goconst v1.5.1 h1:HxVbL1MhydKs8R8n/HE5NPvzfaYmQJA3o879lE4+WcM=
 github.com/jgautheron/goconst v1.5.1/go.mod h1:aAosetZ5zaeC/2EfMeRswtxUFBpe2Hr7HzkgX4fanO4=
+github.com/jhump/gopoet v0.1.0/go.mod h1:me9yfT6IJSlOL3FCfrg+L6yzUEZ+5jW6WHt4Sk+UPUI=
+github.com/jhump/goprotoc v0.5.0/go.mod h1:VrbvcYrQOrTi3i0Vf+m+oqQWk9l72mjkJCYo7UvLHRQ=
 github.com/jhump/protocompile v0.0.0-20220216033700-d705409f108f h1:BNuUg9k2EiJmlMwjoef3e8vZLHplbVw6DrjGFjLL+Yo=
 github.com/jhump/protocompile v0.0.0-20220216033700-d705409f108f/go.mod h1:qr2b5kx4HbFS7/g4uYO5qv9ei8303JMsC7ESbYiqr2Q=
 github.com/jhump/protoreflect v1.6.1/go.mod h1:RZQ/lnuN+zqeRVpQigTwO6o0AJUkxbnSnpuG7toUTG4=
@@ -1065,6 +1088,7 @@ github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
+github.com/oklog/ulid/v2 v2.0.2/go.mod h1:mtBL0Qe/0HAx6/a4Z30qxVIAL1eQDweXq5lxOEiwQ68=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.2/go.mod h1:rSAaSIOAGT9odnlyGlUfAJaoc5w2fSBUmeGDbRWPxyQ=
@@ -1174,6 +1198,7 @@ github.com/pion/transport/v2 v2.2.1/go.mod h1:cXXWavvCnFF6McHTft3DWS9iic2Mftcz1A
 github.com/pion/turn/v2 v2.1.0/go.mod h1:yrT5XbXSGX1VFSF31A3c1kCNB5bBZgk/uu5LET162qs=
 github.com/pion/turn/v2 v2.1.2 h1:wj0cAoGKltaZ790XEGW9HwoUewqjliwmhtxCuB2ApyM=
 github.com/pion/turn/v2 v2.1.2/go.mod h1:1kjnPkBcex3dhCU2Am+AAmxDcGhLX3WnMfmkNpvSTQU=
+github.com/pion/udp v0.1.4/go.mod h1:G8LDo56HsFwC24LIcnT4YIDU5qcB6NepqqjP0keL2us=
 github.com/pion/webrtc/v3 v3.2.11 h1:lfGKYZcG7ghCTQWn+zsD+icIIWL3qIfclEjBGk537+s=
 github.com/pion/webrtc/v3 v3.2.11/go.mod h1:fejQio1v8tKG4ntq4u8H4uDHsCNX6eX7bT093t4H+0E=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
@@ -1195,6 +1220,7 @@ github.com/polyfloyd/go-errorlint v0.0.0-20201127212506-19bd8db6546f/go.mod h1:w
 github.com/polyfloyd/go-errorlint v1.1.0 h1:VKoEFg5yxSgJ2yFPVhxW7oGz+f8/OVcuMeNvcPIi6Eg=
 github.com/polyfloyd/go-errorlint v1.1.0/go.mod h1:Uss7Bc/izYG0leCMRx3WVlrpqWedSZk7V/FUQW6VJ6U=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
+github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
@@ -1249,6 +1275,7 @@ github.com/quasilyte/go-ruleguard/dsl v0.3.1/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQP
 github.com/quasilyte/go-ruleguard/rules v0.0.0-20201231183845-9e62ed36efe1/go.mod h1:7JTjp89EGyU1d6XfBiXihJNG37wB2VRkd125Q1u7Plc=
 github.com/quasilyte/go-ruleguard/rules v0.0.0-20210203162857-b223e0831f88/go.mod h1:4cgAphtvu7Ftv7vOT2ZOYhC6CvBxZixcasr8qIOTA50=
 github.com/quasilyte/go-ruleguard/rules v0.0.0-20210221215616-dfcc94e3dffd/go.mod h1:4cgAphtvu7Ftv7vOT2ZOYhC6CvBxZixcasr8qIOTA50=
+github.com/quasilyte/go-ruleguard/rules v0.0.0-20211022131956-028d6511ab71/go.mod h1:4cgAphtvu7Ftv7vOT2ZOYhC6CvBxZixcasr8qIOTA50=
 github.com/quasilyte/gogrep v0.5.0 h1:eTKODPXbI8ffJMN+W2aE0+oL0z/nh8/5eNdiO34SOAo=
 github.com/quasilyte/gogrep v0.5.0/go.mod h1:Cm9lpz9NZjEoL1tgZ2OgeUKPIxL1meE7eo60Z6Sk+Ng=
 github.com/quasilyte/regex/syntax v0.0.0-20200407221936-30656e2c4a95 h1:L8QM9bvf68pVdQ3bCFZMDmnt9yqcMBro1pC7F+IPYMY=
@@ -1393,6 +1420,7 @@ github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v0.0.0-20170130113145-4d4bfba8f1d1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.1.4/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.2.0/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -1490,6 +1518,7 @@ github.com/xdg-go/stringprep v1.0.4 h1:XLI/Ng3O1Atzq0oBs3TWm+5ZVgkq2aqdlvP9JtoZ6
 github.com/xdg-go/stringprep v1.0.4/go.mod h1:mPGuuIYwz7CmR2bT9j4GbQqutWS1zV24gijq1dTyGkM=
 github.com/xfmoulet/qoi v0.2.0 h1:+Smrwzy5ptRnPzGm/YHkZfyK9qGUSoOpiEPngGmFv+c=
 github.com/xfmoulet/qoi v0.2.0/go.mod h1:uuPUygmV7o8qy7PhiaGAQX0iLiqoUvFEUKjwUFtlaTQ=
+github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xitongsys/parquet-go v1.5.1/go.mod h1:xUxwM8ELydxh4edHGegYq1pA8NnMKDx0K/GyB0o2bww=
 github.com/xitongsys/parquet-go v1.5.2/go.mod h1:90swTgY6VkNM4MkMDsNxq8h30m6Yj1Arv9UMEl5V5DM=
@@ -1499,6 +1528,8 @@ github.com/xitongsys/parquet-go-source v0.0.0-20200509081216-8db33acb0acf/go.mod
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
+github.com/xtgo/set v1.0.0 h1:6BCNBRv3ORNDQ7fyoJXRv+tstJz3m1JVFQErfeZz2pY=
+github.com/xtgo/set v1.0.0/go.mod h1:d3NHzGzSa0NmB2NhFyECA+QdRp29oEn2xbT+TpeFoM8=
 github.com/yagipy/maintidx v1.0.0 h1:h5NvIsCz+nRDapQ0exNv4aJ0yXSI0420omVANTv3GJM=
 github.com/yagipy/maintidx v1.0.0/go.mod h1:0qNf/I/CCZXSMhsRsrEPDZ+DkekpKLXAJfsTACwgXLk=
 github.com/yeya24/promlinter v0.2.0 h1:xFKDQ82orCU5jQujdaD8stOHiv8UN68BSdn2a8u8Y3o=
@@ -1516,6 +1547,7 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/zitadel/logging v0.3.4/go.mod h1:aPpLQhE+v6ocNK0TWrBrd363hZ95KcI17Q1ixAQwZF0=
 github.com/zitadel/oidc v1.13.4 h1:+k2GKqP9Ld9S2MSFlj+KaNsoZ3J9oy+Ezw51EzSFuC8=
 github.com/zitadel/oidc v1.13.4/go.mod h1:3h2DhUcP02YV6q/CA/BG4yla0o6rXjK+DkJGK/dwJfw=
 github.com/ziutek/mymysql v1.5.4 h1:GB0qdRGsTwQSBVYuVShFBKaXSnSnYYC2d9knnE1LHFs=
@@ -1577,7 +1609,10 @@ go.viam.com/test v1.1.1-0.20220913152726-5da9916c08a2 h1:oBiK580EnEIzgFLU4lHOXmG
 go.viam.com/test v1.1.1-0.20220913152726-5da9916c08a2/go.mod h1:XM0tej6riszsiNLT16uoyq1YjuYPWlRBweTPRDanIts=
 go.viam.com/utils v0.1.40 h1:sf6x7U1/D34YmyWQL/LE8OB6RRXcc0zTgEFWXTa6miA=
 go.viam.com/utils v0.1.40/go.mod h1:tjPInze4C0UYFRqL/FU96yqhJpHR1zjiNZ7qChTN/b8=
+go4.org v0.0.0-20180809161055-417644f6feb5 h1:+hE86LblG4AyDgwMCLTE6FOlM9+qjHSYS+rKqxUVdsM=
 go4.org v0.0.0-20180809161055-417644f6feb5/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=
+go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760 h1:FyBZqvoA/jbNzuAWLQE2kG820zMAkcilx6BMjGbL/E4=
+go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
 gocv.io/x/gocv v0.25.0/go.mod h1:Rar2PS6DV+T4FL+PM535EImD/h13hGVaHhnCu1xarBs=
 goji.io v2.0.2+incompatible h1:uIssv/elbKRLznFUy3Xj4+2Mz/qKhek/9aZQDUMae7c=
 goji.io v2.0.2+incompatible/go.mod h1:sbqFwrtqZACxLBTQcdgVjFh54yGVCvwq8+w49MVMMIk=
@@ -1710,6 +1745,7 @@ golang.org/x/net v0.0.0-20200602114024-627f9648deb9/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20200904194848-62affa334b73/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
@@ -1822,6 +1858,7 @@ golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201024232916-9f70ab9862d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -2111,6 +2148,7 @@ google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20200911024640-645f7a48b24f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201201144952-b05cb90ed32e/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201210142538-e3217bee35cc/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
@@ -2155,6 +2193,7 @@ google.golang.org/grpc v1.44.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ5
 google.golang.org/grpc v1.45.0/go.mod h1:lN7owxKUQEqMfSyQikvvk5tf/6zMPsrK+ONuO11+0rQ=
 google.golang.org/grpc v1.54.0 h1:EhTqbhiYeixwWQtAEZAxmV9MGqcjEU2mFx52xCzNyag=
 google.golang.org/grpc v1.54.0/go.mod h1:PUSEXI6iWghWaB6lXM4knEgpJNu2qUcKfDtNci3EC2g=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v0.0.0-20200910201057-6591123024b3/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.2.0 h1:TLkBREm4nIsEcexnCjgQd5GQWaHcqMzwQV0TX9pq8S0=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.2.0/go.mod h1:DNq5QpG7LJqD2AamLZ7zvKE0DEpVl2BSEVjFycAAjRY=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
@@ -2223,6 +2262,12 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gorgonia.org/tensor v0.9.24 h1:8ahrfwO4iby+1ILObIqfjJa+wyA2RoCfJSS3LVERSRE=
+gorgonia.org/tensor v0.9.24/go.mod h1:1dsOegMm2n1obs69YnVJdp2oPSKx9Q9Tco5i7GEaXRg=
+gorgonia.org/vecf32 v0.9.0 h1:PClazic1r+JVJ1dEzRXgeiVl4g1/Hf/w+wUSqnco1Xg=
+gorgonia.org/vecf32 v0.9.0/go.mod h1:NCc+5D2oxddRL11hd+pCB1PEyXWOyiQxfZ/1wwhOXCA=
+gorgonia.org/vecf64 v0.9.0 h1:bgZDP5x0OzBF64PjMGC3EvTdOoMEcmfAh1VCUnZFm1A=
+gorgonia.org/vecf64 v0.9.0/go.mod h1:hp7IOWCnRiVQKON73kkC/AUMtEXyf9kGlVrtPQ9ccVA=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/gotestsum v1.10.0 h1:lVO4uQJoxdsJb7jgmr1fg8QW7zGQ/tuqvsq5fHKyoHQ=

--- a/ml/api.go
+++ b/ml/api.go
@@ -3,8 +3,8 @@ package ml
 
 import "gorgonia.org/tensor"
 
-// Tensors are a data structure to hold the input and output map of tensors to be fed into a
-// model or the result coming from the model.
+// Tensors are a data structure to hold the input and output map of tensors that will fed into a
+// model, or come from the result of a model.
 type Tensors map[string]*tensor.Dense
 
 // TODO(erh): this is all wrong, I just need a pivot point in the sand

--- a/ml/api.go
+++ b/ml/api.go
@@ -1,6 +1,12 @@
 // Package ml provides some fundamental machine learning primitives.
 package ml
 
+import "gorgonia.org/tensor"
+
+// Tensors are a data structure to hold the input and output map of tensors to be fed into a
+// model or the result coming from the model.
+type Tensors map[string]*tensor.Dense
+
 // TODO(erh): this is all wrong, I just need a pivot point in the sand
 
 // Classifier TODO.

--- a/ml/inference/inference.go
+++ b/ml/inference/inference.go
@@ -3,6 +3,7 @@ package inference
 
 import (
 	"github.com/pkg/errors"
+
 	"go.viam.com/rdk/ml"
 )
 

--- a/ml/inference/inference.go
+++ b/ml/inference/inference.go
@@ -10,7 +10,7 @@ import (
 type MLModel interface {
 	// Infer takes an already ordered input tensor as an array,
 	// and makes an inference on the model, returning an output tensor map
-	Infer(inputTensor ml.Tensors) (ml.Tensors, error)
+	Infer(inputTensors ml.Tensors) (ml.Tensors, error)
 
 	// Metadata gets the entire model metadata structure from file
 	Metadata() (interface{}, error)

--- a/ml/inference/inference.go
+++ b/ml/inference/inference.go
@@ -3,15 +3,14 @@ package inference
 
 import (
 	"github.com/pkg/errors"
-
-	"go.viam.com/rdk/utils"
+	"go.viam.com/rdk/ml"
 )
 
 // MLModel represents a trained machine learning model.
 type MLModel interface {
 	// Infer takes an already ordered input tensor as an array,
 	// and makes an inference on the model, returning an output tensor map
-	Infer(inputTensor interface{}) (utils.AttributeMap, error)
+	Infer(inputTensor ml.Tensors) (ml.Tensors, error)
 
 	// Metadata gets the entire model metadata structure from file
 	Metadata() (interface{}, error)

--- a/ml/inference/tflite.go
+++ b/ml/inference/tflite.go
@@ -10,7 +10,9 @@ import (
 
 	tflite "github.com/mattn/go-tflite"
 	"github.com/pkg/errors"
+	"gorgonia.org/tensor"
 
+	"go.viam.com/rdk/ml"
 	tfliteSchema "go.viam.com/rdk/ml/inference/tflite"
 	metadata "go.viam.com/rdk/ml/inference/tflite_metadata"
 )
@@ -174,61 +176,75 @@ func getInfo(inter Interpreter) *TFLiteInfo {
 	return info
 }
 
-// Infer takes an input array in desired type and returns an array of the output tensors.
-func (model *TFLiteStruct) Infer(inputTensor interface{}) ([]interface{}, error) {
+// Infer takes an input map of tensors and returns an output map of tensors.
+func (model *TFLiteStruct) Infer(inputTensors ml.Tensors) (ml.Tensors, error) {
 	model.mu.Lock()
 	defer model.mu.Unlock()
 
 	interpreter := model.interpreter
-	input := interpreter.GetInputTensor(0)
-	status := input.CopyFromBuffer(inputTensor)
-	if status != tflite.OK {
-		return nil, errors.New("copying to buffer failed")
-	}
-
-	status = interpreter.Invoke()
-	if status != tflite.OK {
-		return nil, errors.New("invoke failed")
-	}
-
-	var output []interface{}
-	numOutputTensors := interpreter.GetOutputTensorCount()
-	for i := 0; i < numOutputTensors; i++ {
-		var buf interface{}
-		currTensor := interpreter.GetOutputTensor(i)
-		if currTensor == nil {
+	for i := 0; i < interpreter.GetInputTensorCount(); i++ {
+		input := interpreter.GetInputTensor(i)
+		inpTensor, ok := inputTensors[input.Name()]
+		if !ok {
+			return nil, errors.Errorf("tflite model expected a tensor named %q, but no such input tensor found", input.Name())
+		}
+		if inpTensor == nil {
 			continue
 		}
-		switch currTensor.Type() {
-		case tflite.Float32:
-			buf = currTensor.Float32s()
-		case tflite.UInt8:
-			buf = currTensor.UInt8s()
-		case tflite.Bool:
-			buf = make([]bool, currTensor.ByteSize())
-			currTensor.CopyToBuffer(buf)
-		case tflite.Int8:
-			buf = currTensor.Int8s()
-		case tflite.Int16:
-			buf = currTensor.Int16s()
-		case tflite.Int32:
-			buf = currTensor.Int32s()
-		case tflite.Int64:
-			buf = currTensor.Int64s()
-		case tflite.Complex64:
-			buf = make([]complex64, currTensor.ByteSize()/8)
-			currTensor.CopyToBuffer(buf)
-		case tflite.String, tflite.NoType:
-			// TODO: find a model that outputs tflite.String to test
-			// if there is a better solution than this
-			buf = make([]byte, currTensor.ByteSize())
-			currTensor.CopyToBuffer(buf)
-		default:
-			return nil, FailedToGetError("output tensor type")
+		status := input.CopyFromBuffer(inpTensor.Data())
+		if status != tflite.OK {
+			return nil, errors.Errorf("copying from tensor buffer named %q failed", input.Name())
 		}
-		output = append(output, buf)
+	}
+
+	status := interpreter.Invoke()
+	if status != tflite.OK {
+		return nil, errors.Errorf("tflite invoke failed")
+	}
+
+	output := ml.Tensors{}
+	for i := 0; i < interpreter.GetOutputTensorCount(); i++ {
+		t := interpreter.GetOutputTensor(i)
+		if t == nil {
+			continue
+		}
+		tType := TFliteTensorToGorgoniaTensor(t.Type())
+		outputTensor := tensor.New(
+			tensor.WithShape(t.Shape()...),
+			tensor.Of(tType),
+			tensor.FromMemory(uintptr(t.Data()), uintptr(t.ByteSize())),
+		)
+		output[t.Name()] = outputTensor
 	}
 	return output, nil
+}
+
+// TFliteTensorToGorgoniaTensor converts the constants from one tensor library to another
+func TFliteTensorToGorgoniaTensor(t tflite.TensorType) tensor.Dtype {
+	switch t {
+	case tflite.NoType:
+		return tensor.Uintptr // just return is as a general pointer type...
+	case tflite.Float32:
+		return tensor.Float32
+	case tflite.Int32:
+		return tensor.Int32
+	case tflite.UInt8:
+		return tensor.Uint8
+	case tflite.Int64:
+		return tensor.Int64
+	case tflite.String:
+		return tensor.String
+	case tflite.Bool:
+		return tensor.Bool
+	case tflite.Int16:
+		return tensor.Int16
+	case tflite.Complex64:
+		return tensor.Complex64
+	case tflite.Int8:
+		return tensor.Int8
+	default: // shouldn't reach here unless tflite adds more tyes
+		return tensor.Uintptr
+	}
 }
 
 // Metadata provides the metadata information based on the model flatbuffer file.

--- a/ml/inference/tflite.go
+++ b/ml/inference/tflite.go
@@ -211,7 +211,7 @@ func (model *TFLiteStruct) Infer(inputTensors ml.Tensors) (ml.Tensors, error) {
 
 	status := interpreter.Invoke()
 	if status != tflite.OK {
-		return nil, errors.Errorf("tflite invoke failed")
+		return nil, errors.New("tflite invoke failed")
 	}
 
 	output := ml.Tensors{}
@@ -232,7 +232,7 @@ func (model *TFLiteStruct) Infer(inputTensors ml.Tensors) (ml.Tensors, error) {
 	return output, nil
 }
 
-// TFliteTensorToGorgoniaTensor converts the constants from one tensor library to another
+// TFliteTensorToGorgoniaTensor converts the constants from one tensor library to another.
 func TFliteTensorToGorgoniaTensor(t tflite.TensorType) tensor.Dtype {
 	switch t {
 	case tflite.NoType:

--- a/ml/inference/tflite.go
+++ b/ml/inference/tflite.go
@@ -255,7 +255,7 @@ func TFliteTensorToGorgoniaTensor(t tflite.TensorType) tensor.Dtype {
 		return tensor.Complex64
 	case tflite.Int8:
 		return tensor.Int8
-	default: // shouldn't reach here unless tflite adds more tyes
+	default: // shouldn't reach here unless tflite adds more types
 		return tensor.Uintptr
 	}
 }

--- a/ml/inference/tflite_test.go
+++ b/ml/inference/tflite_test.go
@@ -4,8 +4,10 @@ import (
 	"testing"
 
 	tflite "github.com/mattn/go-tflite"
+	"go.viam.com/rdk/ml"
 	"go.viam.com/test"
 	"go.viam.com/utils/artifact"
+	"gorgonia.org/tensor"
 )
 
 type fakeInterpreter struct{}
@@ -66,7 +68,8 @@ func TestLoadModel(t *testing.T) {
 	test.That(t, structInfo.OutputTensorTypes, test.ShouldResemble, []string{"Float32", "Float32", "Float32", "Float32"})
 
 	buf := make([]float32, c*h*w)
-	outTensors, err := tfliteStruct.Infer(buf)
+	tensors := ml.Tensors{"serving_default_input:0": tensor.New(tensor.WithShape(h, w, c), tensor.WithBacking(buf))}
+	outTensors, err := tfliteStruct.Infer(tensors)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, outTensors, test.ShouldNotBeNil)
 	test.That(t, len(outTensors), test.ShouldEqual, 4)

--- a/ml/inference/tflite_test.go
+++ b/ml/inference/tflite_test.go
@@ -4,10 +4,11 @@ import (
 	"testing"
 
 	tflite "github.com/mattn/go-tflite"
-	"go.viam.com/rdk/ml"
 	"go.viam.com/test"
 	"go.viam.com/utils/artifact"
 	"gorgonia.org/tensor"
+
+	"go.viam.com/rdk/ml"
 )
 
 type fakeInterpreter struct{}

--- a/services/mlmodel/client.go
+++ b/services/mlmodel/client.go
@@ -72,7 +72,7 @@ func (c *client) Infer(ctx context.Context, tensors ml.Tensors, input map[string
 	if err != nil {
 		return nil, nil, err
 	}
-	tensorResp, err := protoToTensors(resp.OutputTensors)
+	tensorResp, err := ProtoToTensors(resp.OutputTensors)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -83,8 +83,8 @@ func (c *client) Infer(ctx context.Context, tensors ml.Tensors, input map[string
 	return tensorResp, mapResp, nil
 }
 
-// protoToTensors takes pb.FlatTensors and turns it into a Tensors map.
-func protoToTensors(pbft *pb.FlatTensors) (ml.Tensors, error) {
+// ProtoToTensors takes pb.FlatTensors and turns it into a Tensors map.
+func ProtoToTensors(pbft *pb.FlatTensors) (ml.Tensors, error) {
 	if pbft == nil {
 		return nil, errors.New("protobuf FlatTensors is nil")
 	}

--- a/services/mlmodel/client.go
+++ b/services/mlmodel/client.go
@@ -2,11 +2,14 @@ package mlmodel
 
 import (
 	"context"
+	"unsafe"
 
 	"github.com/edaniels/golog"
+	"github.com/pkg/errors"
 	pb "go.viam.com/api/service/mlmodel/v1"
 	"go.viam.com/utils/rpc"
 	"google.golang.org/protobuf/types/known/structpb"
+	"gorgonia.org/tensor"
 
 	"go.viam.com/rdk/resource"
 )
@@ -41,20 +44,138 @@ func NewClientFromConn(
 	return c, nil
 }
 
-func (c *client) Infer(ctx context.Context, input map[string]interface{}) (map[string]interface{}, error) {
+func (c *client) Infer(ctx context.Context, tensors Tensors, input map[string]interface{}) (Tensors, map[string]interface{}, error) {
 	inProto, err := structpb.NewStruct(input)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
+	}
+	tensorProto, err := tensors.toProto()
+	if err != nil {
+		return nil, nil, err
 	}
 	resp, err := c.client.Infer(ctx, &pb.InferRequest{
-		Name:      c.name,
-		InputData: inProto,
+		Name:         c.name,
+		InputTensors: tensorProto,
+		InputData:    inProto,
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
+	tensorResp, err := protoToTensors(resp.OutputTensors)
+	if err != nil {
+		return nil, nil, err
+	}
+	return tensorResp, resp.OutputData.AsMap(), nil
+}
 
-	return resp.OutputData.AsMap(), nil
+// protoToTensors takes pb.FlatTensors and turns it into a Tensors map.
+func protoToTensors(pbft *pb.FlatTensors) (Tensors, error) {
+	tensors := Tensors{}
+	for name, ftproto := range pbft.Tensors {
+		t, err := createNewTensor(ftproto)
+		if err != nil {
+			return nil, err
+		}
+		tensors[name] = t
+	}
+	return tensors, nil
+}
+
+// createNewTensor turns a proto FlatTensor into a *tensor.Dense
+func createNewTensor(pft *pb.FlatTensor) (*tensor.Dense, error) {
+	shape := make([]int, 0, len(pft.Shape))
+	for _, s := range pft.Shape {
+		shape = append(shape, int(s))
+	}
+	pt := pft.Tensor
+	switch t := pt.(type) {
+	case *pb.FlatTensor_Int8Tensor:
+		data := t.Int8Tensor
+		if data == nil {
+			return nil, errors.New("tensor of type Int8Tensor is nil")
+		}
+		dataSlice := data.GetData()
+		unsafeInt8Slice := *(*[]int8)(unsafe.Pointer(&dataSlice))
+		int8Slice := make([]int8, 0, len(dataSlice))
+		int8Slice = append(int8Slice, unsafeInt8Slice...)
+		return tensor.New(tensor.WithShape(shape...), tensor.WithBacking(int8Slice)), nil
+	case *pb.FlatTensor_Uint8Tensor:
+		data := t.Uint8Tensor
+		if data == nil {
+			return nil, errors.New("tensor of type Uint8Tensor is nil")
+		}
+		return tensor.New(tensor.WithShape(shape...), tensor.WithBacking(data.GetData())), nil
+	case *pb.FlatTensor_Int16Tensor:
+		data := t.Int16Tensor
+		if data == nil {
+			return nil, errors.New("tensor of type Int16Tensor is nil")
+		}
+		int16Data := uint32ToInt16(data.GetData())
+		return tensor.New(tensor.WithShape(shape...), tensor.WithBacking(int16Data)), nil
+	case *pb.FlatTensor_Uint16Tensor:
+		data := t.Uint16Tensor
+		if data == nil {
+			return nil, errors.New("tensor of type Uint16Tensor is nil")
+		}
+		uint16Data := uint32ToUint16(data.GetData())
+		return tensor.New(tensor.WithShape(shape...), tensor.WithBacking(uint16Data)), nil
+	case *pb.FlatTensor_Int32Tensor:
+		data := t.Int32Tensor
+		if data == nil {
+			return nil, errors.New("tensor of type Int32Tensor is nil")
+		}
+		return tensor.New(tensor.WithShape(shape...), tensor.WithBacking(data.GetData())), nil
+	case *pb.FlatTensor_Uint32Tensor:
+		data := t.Uint32Tensor
+		if data == nil {
+			return nil, errors.New("tensor of type Uint32Tensor is nil")
+		}
+		return tensor.New(tensor.WithShape(shape...), tensor.WithBacking(data.GetData())), nil
+	case *pb.FlatTensor_Int64Tensor:
+		data := t.Int64Tensor
+		if data == nil {
+			return nil, errors.New("tensor of type Int64Tensor is nil")
+		}
+		return tensor.New(tensor.WithShape(shape...), tensor.WithBacking(data.GetData())), nil
+	case *pb.FlatTensor_Uint64Tensor:
+		data := t.Uint64Tensor
+		if data == nil {
+			return nil, errors.New("tensor of type Uint64Tensor is nil")
+		}
+		return tensor.New(tensor.WithShape(shape...), tensor.WithBacking(data.GetData())), nil
+	case *pb.FlatTensor_FloatTensor:
+		data := t.FloatTensor
+		if data == nil {
+			return nil, errors.New("tensor of type FloatTensor is nil")
+		}
+		return tensor.New(tensor.WithShape(shape...), tensor.WithBacking(data.GetData())), nil
+	case *pb.FlatTensor_DoubleTensor:
+		data := t.DoubleTensor
+		if data == nil {
+			return nil, errors.New("tensor of type DoubleTensor is nil")
+		}
+		return tensor.New(tensor.WithShape(shape...), tensor.WithBacking(data.GetData())), nil
+	default:
+		return nil, errors.Errorf("don't know how to create tensor.Dense from proto type %T", pt)
+	}
+}
+
+func uint32ToInt16(uint32Slice []uint32) []int16 {
+	int16Slice := make([]int16, len(uint32Slice))
+
+	for i, value := range uint32Slice {
+		int16Slice[i] = int16(value)
+	}
+	return int16Slice
+}
+
+func uint32ToUint16(uint32Slice []uint32) []uint16 {
+	uint16Slice := make([]uint16, len(uint32Slice))
+
+	for i, value := range uint32Slice {
+		uint16Slice[i] = uint16(value)
+	}
+	return uint16Slice
 }
 
 func (c *client) Metadata(ctx context.Context) (MLMetadata, error) {

--- a/services/mlmodel/client.go
+++ b/services/mlmodel/client.go
@@ -85,7 +85,7 @@ func protoToTensors(pbft *pb.FlatTensors) (ml.Tensors, error) {
 	return tensors, nil
 }
 
-// createNewTensor turns a proto FlatTensor into a *tensor.Dense
+// createNewTensor turns a proto FlatTensor into a *tensor.Dense.
 func createNewTensor(pft *pb.FlatTensor) (*tensor.Dense, error) {
 	shape := make([]int, 0, len(pft.Shape))
 	for _, s := range pft.Shape {
@@ -99,7 +99,7 @@ func createNewTensor(pft *pb.FlatTensor) (*tensor.Dense, error) {
 			return nil, errors.New("tensor of type Int8Tensor is nil")
 		}
 		dataSlice := data.GetData()
-		unsafeInt8Slice := *(*[]int8)(unsafe.Pointer(&dataSlice))
+		unsafeInt8Slice := *(*[]int8)(unsafe.Pointer(&dataSlice)) //nolint:gosec
 		int8Slice := make([]int8, 0, len(dataSlice))
 		int8Slice = append(int8Slice, unsafeInt8Slice...)
 		return tensor.New(tensor.WithShape(shape...), tensor.WithBacking(int8Slice)), nil

--- a/services/mlmodel/client.go
+++ b/services/mlmodel/client.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	"gorgonia.org/tensor"
 
+	"go.viam.com/rdk/ml"
 	"go.viam.com/rdk/resource"
 )
 
@@ -44,12 +45,12 @@ func NewClientFromConn(
 	return c, nil
 }
 
-func (c *client) Infer(ctx context.Context, tensors Tensors, input map[string]interface{}) (Tensors, map[string]interface{}, error) {
+func (c *client) Infer(ctx context.Context, tensors ml.Tensors, input map[string]interface{}) (ml.Tensors, map[string]interface{}, error) {
 	inProto, err := structpb.NewStruct(input)
 	if err != nil {
 		return nil, nil, err
 	}
-	tensorProto, err := tensors.ToProto()
+	tensorProto, err := TensorsToProto(tensors)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -69,11 +70,11 @@ func (c *client) Infer(ctx context.Context, tensors Tensors, input map[string]in
 }
 
 // protoToTensors takes pb.FlatTensors and turns it into a Tensors map.
-func protoToTensors(pbft *pb.FlatTensors) (Tensors, error) {
+func protoToTensors(pbft *pb.FlatTensors) (ml.Tensors, error) {
 	if pbft == nil {
 		return nil, errors.New("protobuf FlatTensors is nil")
 	}
-	tensors := Tensors{}
+	tensors := ml.Tensors{}
 	for name, ftproto := range pbft.Tensors {
 		t, err := createNewTensor(ftproto)
 		if err != nil {

--- a/services/mlmodel/client.go
+++ b/services/mlmodel/client.go
@@ -49,7 +49,7 @@ func (c *client) Infer(ctx context.Context, tensors Tensors, input map[string]in
 	if err != nil {
 		return nil, nil, err
 	}
-	tensorProto, err := tensors.toProto()
+	tensorProto, err := tensors.ToProto()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -70,6 +70,9 @@ func (c *client) Infer(ctx context.Context, tensors Tensors, input map[string]in
 
 // protoToTensors takes pb.FlatTensors and turns it into a Tensors map.
 func protoToTensors(pbft *pb.FlatTensors) (Tensors, error) {
+	if pbft == nil {
+		return nil, errors.New("protobuf FlatTensors is nil")
+	}
 	tensors := Tensors{}
 	for name, ftproto := range pbft.Tensors {
 		t, err := createNewTensor(ftproto)

--- a/services/mlmodel/client.go
+++ b/services/mlmodel/client.go
@@ -46,7 +46,6 @@ func NewClientFromConn(
 }
 
 func (c *client) Infer(ctx context.Context, tensors ml.Tensors, input map[string]interface{}) (ml.Tensors, map[string]interface{}, error) {
-
 	if input != nil && tensors != nil {
 		return nil, nil, errors.New("cannot have both input tensors and input map fed to Infer")
 	}

--- a/services/mlmodel/client.go
+++ b/services/mlmodel/client.go
@@ -46,7 +46,7 @@ func NewClientFromConn(
 }
 
 func (c *client) Infer(ctx context.Context, tensors ml.Tensors, input map[string]interface{}) (ml.Tensors, map[string]interface{}, error) {
-	//TODO(RSDK-4199) just for now until we remove backwards compatibility
+
 	if input != nil && tensors != nil {
 		return nil, nil, errors.New("cannot have both input tensors and input map fed to Infer")
 	}
@@ -58,7 +58,7 @@ func (c *client) Infer(ctx context.Context, tensors ml.Tensors, input map[string
 	if err != nil {
 		return nil, nil, err
 	}
-	//TODO(RSDK-4199) just for now until we remove backwards compatibility
+
 	if input == nil {
 		inProto = nil
 	}

--- a/services/mlmodel/client_test.go
+++ b/services/mlmodel/client_test.go
@@ -56,7 +56,7 @@ func TestClient(t *testing.T) {
 	})
 
 	// working
-	t.Run("ml model client", func(t *testing.T) {
+	t.Run("ml model client infer", func(t *testing.T) {
 		conn, err := viamgrpc.Dial(context.Background(), listener1.Addr().String(), logger)
 		test.That(t, err, test.ShouldBeNil)
 		client, err := mlmodel.NewClientFromConn(context.Background(), conn, "", mlmodel.Named(testMLModelServiceName), logger)
@@ -86,6 +86,15 @@ func TestClient(t *testing.T) {
 		result, _, err = client.Infer(context.Background(), nil, nil)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, len(result), test.ShouldEqual, 4)
+		// close the client
+		test.That(t, client.Close(context.Background()), test.ShouldBeNil)
+		test.That(t, conn.Close(), test.ShouldBeNil)
+	})
+	t.Run("ml model client metadata", func(t *testing.T) {
+		conn, err := viamgrpc.Dial(context.Background(), listener1.Addr().String(), logger)
+		test.That(t, err, test.ShouldBeNil)
+		client, err := mlmodel.NewClientFromConn(context.Background(), conn, "", mlmodel.Named(testMLModelServiceName), logger)
+		test.That(t, err, test.ShouldBeNil)
 		// Metadata Command
 		meta, err := client.Metadata(context.Background())
 		test.That(t, err, test.ShouldBeNil)

--- a/services/mlmodel/client_test.go
+++ b/services/mlmodel/client_test.go
@@ -11,6 +11,7 @@ import (
 	"gorgonia.org/tensor"
 
 	viamgrpc "go.viam.com/rdk/grpc"
+	"go.viam.com/rdk/ml"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/services/mlmodel"
 	"go.viam.com/rdk/testutils/inject"
@@ -40,7 +41,7 @@ func TestClient(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, ok, test.ShouldBeTrue)
 	test.That(t, resourceAPI.RegisterRPCService(context.Background(), rpcServer, svc), test.ShouldBeNil)
-	inputTensors := mlmodel.Tensors{}
+	inputTensors := ml.Tensors{}
 	inputTensors["image"] = tensor.New(tensor.WithShape(3, 3), tensor.WithBacking([]uint8{10, 10, 255, 0, 0, 255, 255, 0, 100}))
 	go rpcServer.Serve(listener1)
 	defer rpcServer.Stop()

--- a/services/mlmodel/client_test.go
+++ b/services/mlmodel/client_test.go
@@ -62,7 +62,7 @@ func TestClient(t *testing.T) {
 		client, err := mlmodel.NewClientFromConn(context.Background(), conn, "", mlmodel.Named(testMLModelServiceName), logger)
 		test.That(t, err, test.ShouldBeNil)
 		// Infer Command
-		result, err := client.Infer(context.Background(), inputData)
+		_, result, err := client.Infer(context.Background(), nil, inputData)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, len(result), test.ShouldEqual, 4)
 		// decode the map[string]interface{} into a struct
@@ -79,7 +79,7 @@ func TestClient(t *testing.T) {
 		test.That(t, len(temp.Labels[0]), test.ShouldEqual, 3)
 		test.That(t, temp.Locations[0][0], test.ShouldResemble, []float32{0.1, 0.4, 0.22, 0.4})
 		// nil data should work too
-		result, err = client.Infer(context.Background(), nil)
+		_, result, err = client.Infer(context.Background(), nil, nil)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, len(result), test.ShouldEqual, 4)
 		// Metadata Command

--- a/services/mlmodel/client_test.go
+++ b/services/mlmodel/client_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"go.viam.com/test"
 	"go.viam.com/utils/rpc"
+	"gorgonia.org/tensor"
 
 	viamgrpc "go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/resource"
@@ -40,9 +41,8 @@ func TestClient(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, ok, test.ShouldBeTrue)
 	test.That(t, resourceAPI.RegisterRPCService(context.Background(), rpcServer, svc), test.ShouldBeNil)
-	inputData := map[string]interface{}{
-		"image": []uint8{10, 10, 255, 0, 0, 255, 255, 0, 100},
-	}
+	inputTensors := mlmodel.Tensors{}
+	inputTensors["image"] = tensor.New(tensor.WithShape(3, 3), tensor.WithBacking([]uint8{10, 10, 255, 0, 0, 255, 255, 0, 100}))
 	go rpcServer.Serve(listener1)
 	defer rpcServer.Stop()
 
@@ -62,7 +62,7 @@ func TestClient(t *testing.T) {
 		client, err := mlmodel.NewClientFromConn(context.Background(), conn, "", mlmodel.Named(testMLModelServiceName), logger)
 		test.That(t, err, test.ShouldBeNil)
 		// Infer Command
-		_, result, err := client.Infer(context.Background(), nil, inputData)
+		_, result, err := client.Infer(context.Background(), inputTensors, nil)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, len(result), test.ShouldEqual, 4)
 		// decode the map[string]interface{} into a struct

--- a/services/mlmodel/mlmodel.go
+++ b/services/mlmodel/mlmodel.go
@@ -11,6 +11,7 @@ import (
 	vprotoutils "go.viam.com/utils/protoutils"
 	"gorgonia.org/tensor"
 
+	"go.viam.com/rdk/ml"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot"
 )
@@ -29,16 +30,12 @@ func init() {
 // the struct that will decode that map[string]interface{} correctly.
 type Service interface {
 	resource.Resource
-	Infer(ctx context.Context, tensors Tensors, input map[string]interface{}) (Tensors, map[string]interface{}, error)
+	Infer(ctx context.Context, tensors ml.Tensors, input map[string]interface{}) (ml.Tensors, map[string]interface{}, error)
 	Metadata(ctx context.Context) (MLMetadata, error)
 }
 
-// Tensors are a data structure to hold the input and output map of tensors to be fed into a
-// model or the result coming from the model.
-type Tensors map[string]*tensor.Dense
-
-// ToProto turns the Tensors map into a protobuf message of FlatTensors
-func (ts Tensors) ToProto() (*servicepb.FlatTensors, error) {
+// TensorsToProto turns the ml.Tensors map into a protobuf message of FlatTensors
+func TensorsToProto(ts ml.Tensors) (*servicepb.FlatTensors, error) {
 	pbts := &servicepb.FlatTensors{
 		Tensors: make(map[string]*servicepb.FlatTensor),
 	}

--- a/services/mlmodel/mlmodel.go
+++ b/services/mlmodel/mlmodel.go
@@ -37,8 +37,11 @@ type Service interface {
 // model or the result coming from the model.
 type Tensors map[string]*tensor.Dense
 
-func (ts Tensors) toProto() (*servicepb.FlatTensors, error) {
-	pbts := &servicepb.FlatTensors{}
+// ToProto turns the Tensors map into a protobuf message of FlatTensors
+func (ts Tensors) ToProto() (*servicepb.FlatTensors, error) {
+	pbts := &servicepb.FlatTensors{
+		Tensors: make(map[string]*servicepb.FlatTensor),
+	}
 	for name, t := range ts {
 		tp, err := tensorToProto(t)
 		if err != nil {

--- a/services/mlmodel/mlmodel.go
+++ b/services/mlmodel/mlmodel.go
@@ -34,7 +34,7 @@ type Service interface {
 	Metadata(ctx context.Context) (MLMetadata, error)
 }
 
-// TensorsToProto turns the ml.Tensors map into a protobuf message of FlatTensors
+// TensorsToProto turns the ml.Tensors map into a protobuf message of FlatTensors.
 func TensorsToProto(ts ml.Tensors) (*servicepb.FlatTensors, error) {
 	pbts := &servicepb.FlatTensors{
 		Tensors: make(map[string]*servicepb.FlatTensor),
@@ -59,7 +59,7 @@ func tensorToProto(t *tensor.Dense) (*servicepb.FlatTensor, error) {
 	data := t.Data()
 	switch dataSlice := data.(type) {
 	case []int8:
-		unsafeByteSlice := *(*[]byte)(unsafe.Pointer(&dataSlice))
+		unsafeByteSlice := *(*[]byte)(unsafe.Pointer(&dataSlice)) //nolint:gosec
 		data := &servicepb.FlatTensorDataInt8{}
 		data.Data = append(data.Data, unsafeByteSlice...)
 		ftpb.Tensor = &servicepb.FlatTensor_Int8Tensor{Int8Tensor: data}
@@ -106,12 +106,12 @@ func tensorToProto(t *tensor.Dense) (*servicepb.FlatTensor, error) {
 			},
 		}
 	case []int:
-		unsafeInt64Slice := *(*[]int64)(unsafe.Pointer(&dataSlice))
+		unsafeInt64Slice := *(*[]int64)(unsafe.Pointer(&dataSlice)) //nolint:gosec
 		data := &servicepb.FlatTensorDataInt64{}
 		data.Data = append(data.Data, unsafeInt64Slice...)
 		ftpb.Tensor = &servicepb.FlatTensor_Int64Tensor{Int64Tensor: data}
 	case []uint:
-		unsafeUint64Slice := *(*[]uint64)(unsafe.Pointer(&dataSlice))
+		unsafeUint64Slice := *(*[]uint64)(unsafe.Pointer(&dataSlice)) //nolint:gosec
 		data := &servicepb.FlatTensorDataUInt64{}
 		data.Data = append(data.Data, unsafeUint64Slice...)
 		ftpb.Tensor = &servicepb.FlatTensor_Uint64Tensor{Uint64Tensor: data}

--- a/services/mlmodel/mlmodel_test.go
+++ b/services/mlmodel/mlmodel_test.go
@@ -1,0 +1,40 @@
+package mlmodel
+
+import (
+	"testing"
+
+	"go.viam.com/test"
+	"gorgonia.org/tensor"
+)
+
+func TestTensorRoundTrip(t *testing.T) {
+	testCases := []struct {
+		name   string
+		tensor *tensor.Dense
+	}{
+		{"int8", tensor.New(tensor.WithShape(2, 3), tensor.WithBacking([]int8{-1, 2, 3, 4, -5, 6}))},
+		{"uint8", tensor.New(tensor.WithShape(2, 3), tensor.WithBacking([]uint8{1, 2, 3, 4, 5, 6}))},
+		{"int16", tensor.New(tensor.WithShape(2, 3), tensor.WithBacking([]int16{-1, 2, 3, 4, -5, 6}))},
+		{"uint16", tensor.New(tensor.WithShape(2, 3), tensor.WithBacking([]uint16{1, 2, 3, 4, 5, 6}))},
+		{"int32", tensor.New(tensor.WithShape(2, 3), tensor.WithBacking([]int32{-1, 2, 3, 4, -5, 6}))},
+		{"uint32", tensor.New(tensor.WithShape(2, 3), tensor.WithBacking([]uint32{1, 2, 3, 4, 5, 6}))},
+		{"int64", tensor.New(tensor.WithShape(2, 3), tensor.WithBacking([]int64{-1, 2, 3, 4, -5, 6}))},
+		{"uint64", tensor.New(tensor.WithShape(2, 3), tensor.WithBacking([]uint64{1, 2, 3, 4, 5, 6}))},
+		{"float32", tensor.New(tensor.WithShape(2, 3), tensor.WithBacking([]float32{1.1, 2.0, 3.0, 4.0, 5.0, -6.0}))},
+		{"float64", tensor.New(tensor.WithShape(2, 3), tensor.WithBacking([]float64{-1.1, 2.0, -3.0, 4.5, 5.0, 6.0}))},
+	}
+
+	for _, tensor := range testCases {
+		t.Run(tensor.name, func(t *testing.T) {
+			resp, err := tensorToProto(tensor.tensor)
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, resp.Shape, test.ShouldHaveLength, 2)
+			test.That(t, resp.Shape[0], test.ShouldEqual, 2)
+			test.That(t, resp.Shape[1], test.ShouldEqual, 3)
+			back, err := createNewTensor(resp)
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, back.Shape(), test.ShouldResemble, tensor.tensor.Shape())
+			test.That(t, back.Data(), test.ShouldResemble, tensor.tensor.Data())
+		})
+	}
+}

--- a/services/mlmodel/server.go
+++ b/services/mlmodel/server.go
@@ -39,7 +39,7 @@ func (server *serviceServer) Infer(ctx context.Context, req *pb.InferRequest) (*
 	}
 	var it ml.Tensors
 	if req.InputTensors != nil {
-		it, err = protoToTensors(req.InputTensors)
+		it, err = ProtoToTensors(req.InputTensors)
 		if err != nil {
 			return nil, err
 		}

--- a/services/mlmodel/server.go
+++ b/services/mlmodel/server.go
@@ -44,7 +44,7 @@ func (server *serviceServer) Infer(ctx context.Context, req *pb.InferRequest) (*
 	if err != nil {
 		return nil, err
 	}
-	outputTensors, err := ot.toProto()
+	outputTensors, err := ot.ToProto()
 	if err != nil {
 		return nil, err
 	}

--- a/services/mlmodel/server.go
+++ b/services/mlmodel/server.go
@@ -44,7 +44,7 @@ func (server *serviceServer) Infer(ctx context.Context, req *pb.InferRequest) (*
 	if err != nil {
 		return nil, err
 	}
-	outputTensors, err := ot.ToProto()
+	outputTensors, err := TensorsToProto(ot)
 	if err != nil {
 		return nil, err
 	}

--- a/services/mlmodel/server.go
+++ b/services/mlmodel/server.go
@@ -32,7 +32,11 @@ func (server *serviceServer) Infer(ctx context.Context, req *pb.InferRequest) (*
 	if err != nil {
 		return nil, err
 	}
-	od, err := svc.Infer(ctx, id)
+	it, err := protoToTensors(req.InputTensors)
+	if err != nil {
+		return nil, err
+	}
+	ot, od, err := svc.Infer(ctx, it, id)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +44,11 @@ func (server *serviceServer) Infer(ctx context.Context, req *pb.InferRequest) (*
 	if err != nil {
 		return nil, err
 	}
-	return &pb.InferResponse{OutputData: outputData}, nil
+	outputTensors, err := ot.toProto()
+	if err != nil {
+		return nil, err
+	}
+	return &pb.InferResponse{OutputData: outputData, OutputTensors: outputTensors}, nil
 }
 
 // AsMap converts x to a general-purpose Go map.

--- a/services/mlmodel/server.go
+++ b/services/mlmodel/server.go
@@ -30,6 +30,10 @@ func (server *serviceServer) Infer(ctx context.Context, req *pb.InferRequest) (*
 	if err != nil {
 		return nil, err
 	}
+	if req.InputData != nil && req.InputTensors != nil {
+		return nil, errors.New("both input_data and input_tensors fields in the Infer request are not nil." +
+			"Server can only process one or the other")
+	}
 	var id map[string]interface{}
 	if req.InputData != nil {
 		id, err = asMap(req.InputData)

--- a/services/mlmodel/server_test.go
+++ b/services/mlmodel/server_test.go
@@ -118,7 +118,11 @@ var injectedMetadataFunc = func(ctx context.Context) (mlmodel.MLMetadata, error)
 	return md, nil
 }
 
-var injectedInferFunc = func(ctx context.Context, tensors ml.Tensors, input map[string]interface{}) (ml.Tensors, map[string]interface{}, error) {
+var injectedInferFunc = func(
+	ctx context.Context,
+	tensors ml.Tensors,
+	input map[string]interface{},
+) (ml.Tensors, map[string]interface{}, error) {
 	// this is a possible form of what a detection tensor with 3 detection in 1 image would look like
 	outputMap := ml.Tensors{}
 	outputMap["n_detections"] = tensor.New(

--- a/services/mlmodel/server_test.go
+++ b/services/mlmodel/server_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pkg/errors"
 	pb "go.viam.com/api/service/mlmodel/v1"
 	"go.viam.com/test"
-	vprotoutils "go.viam.com/utils/protoutils"
 	"gorgonia.org/tensor"
 
 	"go.viam.com/rdk/ml"
@@ -145,12 +144,6 @@ var injectedInferFunc = func(
 }
 
 func TestServerInfer(t *testing.T) {
-	// input data to proto
-	inputData := map[string]interface{}{
-		"image": [][]uint8{{10, 10, 255, 0, 0, 255, 255, 0, 100}},
-	}
-	inputProto, err := vprotoutils.StructToStructPb(inputData)
-	test.That(t, err, test.ShouldBeNil)
 	// input tensors to proto
 	inputTensors := ml.Tensors{}
 	inputTensors["image"] = tensor.New(tensor.WithShape(3, 3), tensor.WithBacking([]uint8{10, 10, 255, 0, 0, 255, 255, 0, 100}))
@@ -158,7 +151,6 @@ func TestServerInfer(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	inferRequest := &pb.InferRequest{
 		Name:         testMLModelServiceName,
-		InputData:    inputProto,
 		InputTensors: tensorsProto,
 	}
 

--- a/services/mlmodel/server_test.go
+++ b/services/mlmodel/server_test.go
@@ -9,6 +9,7 @@ import (
 	pb "go.viam.com/api/service/mlmodel/v1"
 	"go.viam.com/test"
 	vprotoutils "go.viam.com/utils/protoutils"
+	"gorgonia.org/tensor"
 
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/services/mlmodel"
@@ -119,16 +120,24 @@ var injectedMetadataFunc = func(ctx context.Context) (mlmodel.MLMetadata, error)
 
 var injectedInferFunc = func(ctx context.Context, tensors mlmodel.Tensors, input map[string]interface{}) (mlmodel.Tensors, map[string]interface{}, error) {
 	// this is a possible form of what a detection tensor with 3 detection in 1 image would look like
-	outputMap := make(map[string]interface{})
-	outputMap["n_detections"] = []int32{3}
-	outputMap["confidence_scores"] = [][]float32{{0.9084375, 0.7359375, 0.33984375}}
-	outputMap["labels"] = [][]int32{{0, 0, 4}}
-	outputMap["locations"] = [][][]float32{{
-		{0.1, 0.4, 0.22, 0.4},
-		{0.02, 0.22, 0.77, 0.90},
-		{0.40, 0.50, 0.40, 0.50},
-	}}
-	return nil, outputMap, nil
+	outputMap := mlmodel.Tensors{}
+	outputMap["n_detections"] = tensor.New(
+		tensor.WithShape(1),
+		tensor.WithBacking([]int32{3}),
+	)
+	outputMap["confidence_scores"] = tensor.New(
+		tensor.WithShape(1, 3),
+		tensor.WithBacking([]float32{0.9084375, 0.7359375, 0.33984375}),
+	)
+	outputMap["labels"] = tensor.New(
+		tensor.WithShape(1, 3),
+		tensor.WithBacking([]int32{0, 0, 4}),
+	)
+	outputMap["locations"] = tensor.New(
+		tensor.WithShape(1, 3, 4),
+		tensor.WithBacking([]float32{0.1, 0.4, 0.22, 0.4, 0.02, 0.22, 0.77, 0.90, 0.40, 0.50, 0.40, 0.50}),
+	)
+	return outputMap, nil, nil
 }
 
 func TestServerInfer(t *testing.T) {

--- a/services/mlmodel/server_test.go
+++ b/services/mlmodel/server_test.go
@@ -10,6 +10,7 @@ import (
 	vprotoutils "go.viam.com/utils/protoutils"
 	"gorgonia.org/tensor"
 
+	"go.viam.com/rdk/ml"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/services/mlmodel"
 	"go.viam.com/rdk/testutils/inject"
@@ -117,9 +118,9 @@ var injectedMetadataFunc = func(ctx context.Context) (mlmodel.MLMetadata, error)
 	return md, nil
 }
 
-var injectedInferFunc = func(ctx context.Context, tensors mlmodel.Tensors, input map[string]interface{}) (mlmodel.Tensors, map[string]interface{}, error) {
+var injectedInferFunc = func(ctx context.Context, tensors ml.Tensors, input map[string]interface{}) (ml.Tensors, map[string]interface{}, error) {
 	// this is a possible form of what a detection tensor with 3 detection in 1 image would look like
-	outputMap := mlmodel.Tensors{}
+	outputMap := ml.Tensors{}
 	outputMap["n_detections"] = tensor.New(
 		tensor.WithShape(1),
 		tensor.WithBacking([]int32{3}),
@@ -147,9 +148,9 @@ func TestServerInfer(t *testing.T) {
 	inputProto, err := vprotoutils.StructToStructPb(inputData)
 	test.That(t, err, test.ShouldBeNil)
 	// input tensors to proto
-	inputTensors := mlmodel.Tensors{}
+	inputTensors := ml.Tensors{}
 	inputTensors["image"] = tensor.New(tensor.WithShape(3, 3), tensor.WithBacking([]uint8{10, 10, 255, 0, 0, 255, 255, 0, 100}))
-	tensorsProto, err := inputTensors.ToProto()
+	tensorsProto, err := mlmodel.TensorsToProto(inputTensors)
 	test.That(t, err, test.ShouldBeNil)
 	inferRequest := &pb.InferRequest{
 		Name:         testMLModelServiceName,

--- a/services/mlmodel/server_test.go
+++ b/services/mlmodel/server_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	pb "go.viam.com/api/service/mlmodel/v1"
 	"go.viam.com/test"
@@ -141,14 +140,21 @@ var injectedInferFunc = func(ctx context.Context, tensors mlmodel.Tensors, input
 }
 
 func TestServerInfer(t *testing.T) {
+	// input data to proto
 	inputData := map[string]interface{}{
 		"image": [][]uint8{{10, 10, 255, 0, 0, 255, 255, 0, 100}},
 	}
 	inputProto, err := vprotoutils.StructToStructPb(inputData)
 	test.That(t, err, test.ShouldBeNil)
+	// input tensors to proto
+	inputTensors := mlmodel.Tensors{}
+	inputTensors["image"] = tensor.New(tensor.WithShape(3, 3), tensor.WithBacking([]uint8{10, 10, 255, 0, 0, 255, 255, 0, 100}))
+	tensorsProto, err := inputTensors.ToProto()
+	test.That(t, err, test.ShouldBeNil)
 	inferRequest := &pb.InferRequest{
-		Name:      testMLModelServiceName,
-		InputData: inputProto,
+		Name:         testMLModelServiceName,
+		InputData:    inputProto,
+		InputTensors: tensorsProto,
 	}
 
 	mockSrv := inject.NewMLModelService(testMLModelServiceName)
@@ -161,19 +167,26 @@ func TestServerInfer(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	resp, err := server.Infer(context.Background(), inferRequest)
 	test.That(t, err, test.ShouldBeNil)
-	outMap := resp.OutputData.AsMap()
-	test.That(t, len(outMap), test.ShouldEqual, 4)
-	// decode the map[string]interface{} into a struct
-	temp := struct {
-		NDetections      []int32       `mapstructure:"n_detections"`
-		ConfidenceScores [][]float32   `mapstructure:"confidence_scores"`
-		Labels           [][]int32     `mapstructure:"labels"`
-		Locations        [][][]float32 `mapstructure:"locations"`
-	}{}
-	err = mapstructure.Decode(outMap, &temp)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, temp.NDetections[0], test.ShouldEqual, 3)
-	test.That(t, len(temp.ConfidenceScores[0]), test.ShouldEqual, 3)
-	test.That(t, len(temp.Labels[0]), test.ShouldEqual, 3)
-	test.That(t, temp.Locations[0][0], test.ShouldResemble, []float32{0.1, 0.4, 0.22, 0.4})
+	test.That(t, len(resp.OutputTensors.Tensors), test.ShouldEqual, 4)
+	protoTensors := resp.OutputTensors.Tensors
+	// n detections
+	test.That(t, protoTensors["n_detections"].GetShape(), test.ShouldResemble, []uint64{1})
+	nDetections := protoTensors["n_detections"].GetInt32Tensor()
+	test.That(t, nDetections, test.ShouldNotBeNil)
+	test.That(t, nDetections.Data[0], test.ShouldEqual, 3)
+	// confidence scores
+	test.That(t, protoTensors["confidence_scores"].GetShape(), test.ShouldResemble, []uint64{1, 3})
+	confScores := protoTensors["confidence_scores"].GetFloatTensor()
+	test.That(t, confScores, test.ShouldNotBeNil)
+	test.That(t, confScores.Data, test.ShouldHaveLength, 3)
+	// labels
+	test.That(t, protoTensors["labels"].GetShape(), test.ShouldResemble, []uint64{1, 3})
+	labels := protoTensors["labels"].GetInt32Tensor()
+	test.That(t, labels, test.ShouldNotBeNil)
+	test.That(t, labels.Data, test.ShouldHaveLength, 3)
+	// locations
+	test.That(t, protoTensors["locations"].GetShape(), test.ShouldResemble, []uint64{1, 3, 4})
+	locations := protoTensors["locations"].GetFloatTensor()
+	test.That(t, locations, test.ShouldNotBeNil)
+	test.That(t, locations.Data[0:4], test.ShouldResemble, []float32{0.1, 0.4, 0.22, 0.4})
 }

--- a/services/mlmodel/server_test.go
+++ b/services/mlmodel/server_test.go
@@ -117,7 +117,7 @@ var injectedMetadataFunc = func(ctx context.Context) (mlmodel.MLMetadata, error)
 	return md, nil
 }
 
-var injectedInferFunc = func(ctx context.Context, input map[string]interface{}) (map[string]interface{}, error) {
+var injectedInferFunc = func(ctx context.Context, tensors mlmodel.Tensors, input map[string]interface{}) (mlmodel.Tensors, map[string]interface{}, error) {
 	// this is a possible form of what a detection tensor with 3 detection in 1 image would look like
 	outputMap := make(map[string]interface{})
 	outputMap["n_detections"] = []int32{3}
@@ -128,7 +128,7 @@ var injectedInferFunc = func(ctx context.Context, input map[string]interface{}) 
 		{0.02, 0.22, 0.77, 0.90},
 		{0.40, 0.50, 0.40, 0.50},
 	}}
-	return outputMap, nil
+	return nil, outputMap, nil
 }
 
 func TestServerInfer(t *testing.T) {

--- a/services/mlmodel/tflitecpu/tflite_cpu.go
+++ b/services/mlmodel/tflitecpu/tflite_cpu.go
@@ -121,6 +121,7 @@ func (m *Model) Infer(ctx context.Context, tensors ml.Tensors, input map[string]
 	}
 	// Fill in the output map with the names from metadata if u have them
 	// if at any point this fails, just use the default name
+	// also, make sure tensor names are not reused
 	results := ml.Tensors{}
 	for defaultName, tensor := range outTensors {
 		outName := defaultName
@@ -128,11 +129,11 @@ func (m *Model) Infer(ctx context.Context, tensors ml.Tensors, input map[string]
 		if len(parts) > 1 {
 			nameInt, err := strconv.Atoi(parts[len(parts)-1])
 			if err != nil {
-				outName = parts[0] // just use default name
+				outName = strings.Join(parts[0:len(parts)-1], ":") // just use default name, add colons back
 			} else if len(m.metadata.Outputs) > nameInt && m.metadata.Outputs[nameInt].Name != "" {
 				outName = m.metadata.Outputs[nameInt].Name
 			} else {
-				outName = parts[0]
+				outName = strings.Join(parts[0:len(parts)-1], ":") // just use default name, add colons back
 			}
 		} else if len(parts) == 1 {
 			outName = parts[0] // default name

--- a/services/mlmodel/tflitecpu/tflite_cpu.go
+++ b/services/mlmodel/tflitecpu/tflite_cpu.go
@@ -121,16 +121,13 @@ func (m *Model) Infer(ctx context.Context, tensors ml.Tensors, input map[string]
 	}
 	// Fill in the output map with the names from metadata if u have them
 	// if at any point this fails, just use the default name
-	// also, make sure tensor names are not reused
 	results := ml.Tensors{}
 	for defaultName, tensor := range outTensors {
 		outName := defaultName
 		parts := strings.Split(defaultName, ":") // number after colon associates it with metadata
 		if len(parts) > 1 {
 			nameInt, err := strconv.Atoi(parts[len(parts)-1])
-			if err != nil { //nolint:gocritic
-				outName = strings.Join(parts[0:len(parts)-1], ":") // just use default name, add colons back
-			} else if len(m.metadata.Outputs) > nameInt && m.metadata.Outputs[nameInt].Name != "" {
+			if err == nil && len(m.metadata.Outputs) > nameInt && m.metadata.Outputs[nameInt].Name != "" {
 				outName = m.metadata.Outputs[nameInt].Name
 			} else {
 				outName = strings.Join(parts[0:len(parts)-1], ":") // just use default name, add colons back

--- a/services/mlmodel/tflitecpu/tflite_cpu.go
+++ b/services/mlmodel/tflitecpu/tflite_cpu.go
@@ -128,7 +128,7 @@ func (m *Model) Infer(ctx context.Context, tensors ml.Tensors, input map[string]
 		parts := strings.Split(defaultName, ":") // number after colon associates it with metadata
 		if len(parts) > 1 {
 			nameInt, err := strconv.Atoi(parts[len(parts)-1])
-			if err != nil {
+			if err != nil { //nolint:gocritic
 				outName = strings.Join(parts[0:len(parts)-1], ":") // just use default name, add colons back
 			} else if len(m.metadata.Outputs) > nameInt && m.metadata.Outputs[nameInt].Name != "" {
 				outName = m.metadata.Outputs[nameInt].Name

--- a/services/mlmodel/tflitecpu/tflite_cpu_test.go
+++ b/services/mlmodel/tflitecpu/tflite_cpu_test.go
@@ -136,6 +136,7 @@ func TestTFLiteCPUClassifier(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotOutput, test.ShouldNotBeNil)
 
+	test.That(t, len(gotOutput), test.ShouldEqual, 1)
 	test.That(t, gotOutput["probability"], test.ShouldNotBeNil)
 	result, err := gotOutput["probability"].At(0, 290)
 	test.That(t, err, test.ShouldBeNil)

--- a/services/mlmodel/tflitecpu/tflite_cpu_test.go
+++ b/services/mlmodel/tflitecpu/tflite_cpu_test.go
@@ -66,7 +66,7 @@ func TestTFLiteCPUDetector(t *testing.T) {
 	imgBytes := rimage.ImageToUInt8Buffer(resized)
 	test.That(t, imgBytes, test.ShouldNotBeNil)
 	inputMap := ml.Tensors{}
-	inputMap["serving_default_images:0"] = tensor.New(
+	inputMap["image"] = tensor.New(
 		tensor.WithShape(got.metadata.Inputs[0].Shape[1], got.metadata.Inputs[0].Shape[2], 3),
 		tensor.WithBacking(imgBytes),
 	)
@@ -76,20 +76,20 @@ func TestTFLiteCPUDetector(t *testing.T) {
 
 	test.That(t, len(gotOutput), test.ShouldEqual, 4)
 	// n detections
-	test.That(t, gotOutput["StatefulPartitionedCall:0"], test.ShouldNotBeNil)
-	test.That(t, gotOutput["StatefulPartitionedCall:0"].Data(), test.ShouldResemble, []float32{25})
+	test.That(t, gotOutput["number of detections"], test.ShouldNotBeNil)
+	test.That(t, gotOutput["number of detections"].Data(), test.ShouldResemble, []float32{25})
 	// score
-	test.That(t, gotOutput["StatefulPartitionedCall:1"], test.ShouldNotBeNil)
-	test.That(t, gotOutput["StatefulPartitionedCall:1"].Shape(), test.ShouldResemble, tensor.Shape{1, 25})
+	test.That(t, gotOutput["score"], test.ShouldNotBeNil)
+	test.That(t, gotOutput["score"].Shape(), test.ShouldResemble, tensor.Shape{1, 25})
 	// category
-	test.That(t, gotOutput["StatefulPartitionedCall:2"], test.ShouldNotBeNil)
-	test.That(t, gotOutput["StatefulPartitionedCall:2"].Shape(), test.ShouldResemble, tensor.Shape{1, 25})
-	result, err := gotOutput["StatefulPartitionedCall:2"].At(0, 0)
+	test.That(t, gotOutput["category"], test.ShouldNotBeNil)
+	test.That(t, gotOutput["category"].Shape(), test.ShouldResemble, tensor.Shape{1, 25})
+	result, err := gotOutput["category"].At(0, 0)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, result, test.ShouldEqual, 17) // 17 is dog
 	// location
-	test.That(t, gotOutput["StatefulPartitionedCall:3"], test.ShouldNotBeNil)
-	test.That(t, gotOutput["StatefulPartitionedCall:3"].Shape(), test.ShouldResemble, tensor.Shape{1, 25, 4})
+	test.That(t, gotOutput["location"], test.ShouldNotBeNil)
+	test.That(t, gotOutput["location"].Shape(), test.ShouldResemble, tensor.Shape{1, 25, 4})
 }
 
 func TestTFLiteCPUClassifier(t *testing.T) {
@@ -136,14 +136,14 @@ func TestTFLiteCPUClassifier(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotOutput, test.ShouldNotBeNil)
 
-	test.That(t, gotOutput["Softmax"], test.ShouldNotBeNil)
-	result, err := gotOutput["Softmax"].At(0, 290)
+	test.That(t, gotOutput["probability"], test.ShouldNotBeNil)
+	result, err := gotOutput["probability"].At(0, 290)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, result, test.ShouldEqual, 0)
-	result, err = gotOutput["Softmax"].At(0, 291)
+	result, err = gotOutput["probability"].At(0, 291)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, result, test.ShouldBeGreaterThan, 200) // 291 is lion
-	result, err = gotOutput["Softmax"].At(0, 292)
+	result, err = gotOutput["probability"].At(0, 292)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, result, test.ShouldEqual, 0)
 }
@@ -224,7 +224,7 @@ func TestTFLiteCPUClient(t *testing.T) {
 	imgBytes := rimage.ImageToUInt8Buffer(resized)
 	test.That(t, imgBytes, test.ShouldNotBeNil)
 	inputMap := ml.Tensors{}
-	inputMap["serving_default_images:0"] = tensor.New(
+	inputMap["image"] = tensor.New(
 		tensor.WithShape(320, 320, 3),
 		tensor.WithBacking(imgBytes),
 	)
@@ -254,20 +254,20 @@ func TestTFLiteCPUClient(t *testing.T) {
 	test.That(t, gotOutput, test.ShouldNotBeNil)
 	test.That(t, len(gotOutput), test.ShouldEqual, 4)
 	// n detections
-	test.That(t, gotOutput["StatefulPartitionedCall:0"], test.ShouldNotBeNil)
-	test.That(t, gotOutput["StatefulPartitionedCall:0"].Data(), test.ShouldResemble, []float32{25})
+	test.That(t, gotOutput["number of detections"], test.ShouldNotBeNil)
+	test.That(t, gotOutput["number of detections"].Data(), test.ShouldResemble, []float32{25})
 	// score
-	test.That(t, gotOutput["StatefulPartitionedCall:1"], test.ShouldNotBeNil)
-	test.That(t, gotOutput["StatefulPartitionedCall:1"].Shape(), test.ShouldResemble, tensor.Shape{1, 25})
+	test.That(t, gotOutput["score"], test.ShouldNotBeNil)
+	test.That(t, gotOutput["score"].Shape(), test.ShouldResemble, tensor.Shape{1, 25})
 	// category
-	test.That(t, gotOutput["StatefulPartitionedCall:2"], test.ShouldNotBeNil)
-	test.That(t, gotOutput["StatefulPartitionedCall:2"].Shape(), test.ShouldResemble, tensor.Shape{1, 25})
-	result, err := gotOutput["StatefulPartitionedCall:2"].At(0, 0)
+	test.That(t, gotOutput["category"], test.ShouldNotBeNil)
+	test.That(t, gotOutput["category"].Shape(), test.ShouldResemble, tensor.Shape{1, 25})
+	result, err := gotOutput["category"].At(0, 0)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, result, test.ShouldEqual, 17) // 17 is dog
 	// location
-	test.That(t, gotOutput["StatefulPartitionedCall:3"], test.ShouldNotBeNil)
-	test.That(t, gotOutput["StatefulPartitionedCall:3"].Shape(), test.ShouldResemble, tensor.Shape{1, 25, 4})
+	test.That(t, gotOutput["location"], test.ShouldNotBeNil)
+	test.That(t, gotOutput["location"].Shape(), test.ShouldResemble, tensor.Shape{1, 25, 4})
 }
 
 func makeExampleTensor(length int) *tensor.Dense {

--- a/services/mlmodel/tflitecpu/tflite_cpu_test.go
+++ b/services/mlmodel/tflitecpu/tflite_cpu_test.go
@@ -3,7 +3,6 @@ package tflitecpu
 import (
 	"context"
 	"net"
-	"reflect"
 	"testing"
 
 	"github.com/edaniels/golog"
@@ -11,8 +10,10 @@ import (
 	"go.viam.com/test"
 	"go.viam.com/utils/artifact"
 	"go.viam.com/utils/rpc"
+	"gorgonia.org/tensor"
 
 	viamgrpc "go.viam.com/rdk/grpc"
+	"go.viam.com/rdk/ml"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/rimage"
 	"go.viam.com/rdk/services/mlmodel"
@@ -64,18 +65,31 @@ func TestTFLiteCPUDetector(t *testing.T) {
 	resized := resize.Resize(uint(got.metadata.Inputs[0].Shape[1]), uint(got.metadata.Inputs[0].Shape[2]), pic, resize.Bilinear)
 	imgBytes := rimage.ImageToUInt8Buffer(resized)
 	test.That(t, imgBytes, test.ShouldNotBeNil)
-	inputMap := make(map[string]interface{})
-	inputMap["image"] = imgBytes
-
-	gotOutput, err := got.Infer(ctx, inputMap)
+	inputMap := ml.Tensors{}
+	inputMap["serving_default_images:0"] = tensor.New(
+		tensor.WithShape(got.metadata.Inputs[0].Shape[1], got.metadata.Inputs[0].Shape[2], 3),
+		tensor.WithBacking(imgBytes),
+	)
+	gotOutput, _, err := got.Infer(ctx, inputMap, nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotOutput, test.ShouldNotBeNil)
 
-	test.That(t, gotOutput["number of detections"], test.ShouldResemble, []float32{25})
-	test.That(t, len(gotOutput["score"].([]float32)), test.ShouldResemble, 25)
-	test.That(t, len(gotOutput["location"].([]float32)), test.ShouldResemble, 100)
-	test.That(t, len(gotOutput["category"].([]float32)), test.ShouldResemble, 25)
-	test.That(t, gotOutput["category"].([]float32)[0], test.ShouldEqual, 17) // 17 is dog
+	test.That(t, len(gotOutput), test.ShouldEqual, 4)
+	// n detections
+	test.That(t, gotOutput["StatefulPartitionedCall:0"], test.ShouldNotBeNil)
+	test.That(t, gotOutput["StatefulPartitionedCall:0"].Data(), test.ShouldResemble, []float32{25})
+	// score
+	test.That(t, gotOutput["StatefulPartitionedCall:1"], test.ShouldNotBeNil)
+	test.That(t, gotOutput["StatefulPartitionedCall:1"].Shape(), test.ShouldResemble, tensor.Shape{1, 25})
+	// category
+	test.That(t, gotOutput["StatefulPartitionedCall:2"], test.ShouldNotBeNil)
+	test.That(t, gotOutput["StatefulPartitionedCall:2"].Shape(), test.ShouldResemble, tensor.Shape{1, 25})
+	result, err := gotOutput["StatefulPartitionedCall:2"].At(0, 0)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, result, test.ShouldEqual, 17) // 17 is dog
+	// location
+	test.That(t, gotOutput["StatefulPartitionedCall:3"], test.ShouldNotBeNil)
+	test.That(t, gotOutput["StatefulPartitionedCall:3"].Shape(), test.ShouldResemble, tensor.Shape{1, 25, 4})
 }
 
 func TestTFLiteCPUClassifier(t *testing.T) {
@@ -112,17 +126,26 @@ func TestTFLiteCPUClassifier(t *testing.T) {
 	resized := resize.Resize(uint(got.metadata.Inputs[0].Shape[1]), uint(got.metadata.Inputs[0].Shape[2]), pic, resize.Bilinear)
 	imgBytes := rimage.ImageToUInt8Buffer(resized)
 	test.That(t, imgBytes, test.ShouldNotBeNil)
-	inputMap := make(map[string]interface{})
-	inputMap["image"] = imgBytes
+	inputMap := ml.Tensors{}
+	inputMap["images"] = tensor.New(
+		tensor.WithShape(got.metadata.Inputs[0].Shape[1], got.metadata.Inputs[0].Shape[2], 3),
+		tensor.WithBacking(imgBytes),
+	)
 
-	gotOutput, err := got.Infer(ctx, inputMap)
+	gotOutput, _, err := got.Infer(ctx, inputMap, nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotOutput, test.ShouldNotBeNil)
 
-	test.That(t, gotOutput["probability"].([]uint8), test.ShouldNotBeNil)
-	test.That(t, gotOutput["probability"].([]uint8)[290], test.ShouldEqual, 0)
-	test.That(t, gotOutput["probability"].([]uint8)[291], test.ShouldBeGreaterThan, 200) // 291 is lion
-	test.That(t, gotOutput["probability"].([]uint8)[292], test.ShouldEqual, 0)
+	test.That(t, gotOutput["Softmax"], test.ShouldNotBeNil)
+	result, err := gotOutput["Softmax"].At(0, 290)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, result, test.ShouldEqual, 0)
+	result, err = gotOutput["Softmax"].At(0, 291)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, result, test.ShouldBeGreaterThan, 200) // 291 is lion
+	result, err = gotOutput["Softmax"].At(0, 292)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, result, test.ShouldEqual, 0)
 }
 
 func TestTFLiteCPUTextModel(t *testing.T) {
@@ -150,17 +173,20 @@ func TestTFLiteCPUTextModel(t *testing.T) {
 	test.That(t, got.metadata, test.ShouldNotBeNil)
 
 	// Test that the Infer() works even on a text classifier
-	inputMap := make(map[string]interface{})
-	inputMap["text"] = makeExampleSlice(got.model.Info.InputHeight)
-	test.That(t, len(inputMap["text"].([]int32)), test.ShouldEqual, 384)
-	gotOutput, err := got.Infer(ctx, inputMap)
+	zeros := make([]int32, got.model.Info.InputHeight)
+	inputMap := ml.Tensors{}
+	inputMap["input_ids"] = makeExampleTensor(got.model.Info.InputHeight)
+	test.That(t, inputMap["input_ids"].Shape(), test.ShouldResemble, tensor.Shape{384})
+	inputMap["input_mask"] = tensor.New(tensor.WithShape(384), tensor.WithBacking(zeros))
+	inputMap["segment_ids"] = tensor.New(tensor.WithShape(384), tensor.WithBacking(zeros))
+	gotOutput, _, err := got.Infer(ctx, inputMap, nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotOutput, test.ShouldNotBeNil)
 	test.That(t, len(gotOutput), test.ShouldEqual, 2)
-	test.That(t, gotOutput["output0"], test.ShouldNotBeNil)
-	test.That(t, gotOutput["output1"], test.ShouldNotBeNil)
-	test.That(t, len(gotOutput["output0"].([]float32)), test.ShouldEqual, 384)
-	test.That(t, len(gotOutput["output1"].([]float32)), test.ShouldEqual, 384)
+	test.That(t, gotOutput["end_logits"], test.ShouldNotBeNil)
+	test.That(t, gotOutput["start_logits"], test.ShouldNotBeNil)
+	test.That(t, gotOutput["end_logits"].Shape(), test.ShouldResemble, tensor.Shape{1, 384})
+	test.That(t, gotOutput["start_logits"].Shape(), test.ShouldResemble, tensor.Shape{1, 384})
 }
 
 func TestTFLiteCPUClient(t *testing.T) {
@@ -197,8 +223,11 @@ func TestTFLiteCPUClient(t *testing.T) {
 	resized := resize.Resize(320, 320, pic, resize.Bilinear)
 	imgBytes := rimage.ImageToUInt8Buffer(resized)
 	test.That(t, imgBytes, test.ShouldNotBeNil)
-	inputMap := make(map[string]interface{})
-	inputMap["image"] = imgBytes
+	inputMap := ml.Tensors{}
+	inputMap["serving_default_images:0"] = tensor.New(
+		tensor.WithShape(320, 320, 3),
+		tensor.WithBacking(imgBytes),
+	)
 
 	conn, err := viamgrpc.Dial(context.Background(), listener1.Addr().String(), logger)
 	test.That(t, err, test.ShouldBeNil)
@@ -220,27 +249,31 @@ func TestTFLiteCPUClient(t *testing.T) {
 	test.That(t, gotMD.Outputs[1].AssociatedFiles[0].Name, test.ShouldResemble, "labelmap.txt")
 
 	// Test call to Infer
-	gotOutput, err := client.Infer(context.Background(), inputMap)
+	gotOutput, _, err := client.Infer(context.Background(), inputMap, nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotOutput, test.ShouldNotBeNil)
 	test.That(t, len(gotOutput), test.ShouldEqual, 4)
-	locs := reflect.ValueOf(gotOutput["location"])
-	test.That(t, locs.Len(), test.ShouldEqual, 100)
-	scores := reflect.ValueOf(gotOutput["score"])
-	test.That(t, scores.Len(), test.ShouldEqual, 25)
-	nDets := reflect.ValueOf(gotOutput["number of detections"])
-	test.That(t, nDets.Len(), test.ShouldEqual, 1)
-	test.That(t, nDets.Index(0).Interface().(float64), test.ShouldResemble, float64(25))
-	test.That(t, reflect.TypeOf(gotOutput["category"]).Kind(), test.ShouldResemble, reflect.Slice)
-	cats := reflect.ValueOf(gotOutput["category"])
-	test.That(t, cats.Len(), test.ShouldEqual, 25)
-	test.That(t, cats.Index(0).Interface().(float64), test.ShouldResemble, float64(17)) // 17 is dog
+	// n detections
+	test.That(t, gotOutput["StatefulPartitionedCall:0"], test.ShouldNotBeNil)
+	test.That(t, gotOutput["StatefulPartitionedCall:0"].Data(), test.ShouldResemble, []float32{25})
+	// score
+	test.That(t, gotOutput["StatefulPartitionedCall:1"], test.ShouldNotBeNil)
+	test.That(t, gotOutput["StatefulPartitionedCall:1"].Shape(), test.ShouldResemble, tensor.Shape{1, 25})
+	// category
+	test.That(t, gotOutput["StatefulPartitionedCall:2"], test.ShouldNotBeNil)
+	test.That(t, gotOutput["StatefulPartitionedCall:2"].Shape(), test.ShouldResemble, tensor.Shape{1, 25})
+	result, err := gotOutput["StatefulPartitionedCall:2"].At(0, 0)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, result, test.ShouldEqual, 17) // 17 is dog
+	// location
+	test.That(t, gotOutput["StatefulPartitionedCall:3"], test.ShouldNotBeNil)
+	test.That(t, gotOutput["StatefulPartitionedCall:3"].Shape(), test.ShouldResemble, tensor.Shape{1, 25, 4})
 }
 
-func makeExampleSlice(length int) []int32 {
+func makeExampleTensor(length int) *tensor.Dense {
 	out := make([]int32, 0, length)
 	for i := 0; i < length; i++ {
 		out = append(out, int32(i))
 	}
-	return out
+	return tensor.New(tensor.WithShape(length), tensor.WithBacking(out))
 }

--- a/services/vision/mlvision/classifier.go
+++ b/services/vision/mlvision/classifier.go
@@ -56,12 +56,12 @@ func attemptToBuildClassifier(mlm mlmodel.Service, nameMap map[string]string) (c
 		switch inType {
 		case UInt8:
 			inMap["image"] = tensor.New(
-				tensor.WithShape(1, int(inHeight), int(inWidth), 3),
+				tensor.WithShape(1, resized.Bounds().Dy(), resized.Bounds().Dx(), 3),
 				tensor.WithBacking(rimage.ImageToUInt8Buffer(resized)),
 			)
 		case Float32:
 			inMap["image"] = tensor.New(
-				tensor.WithShape(1, int(inHeight), int(inWidth), 3),
+				tensor.WithShape(1, resized.Bounds().Dy(), resized.Bounds().Dx(), 3),
 				tensor.WithBacking(rimage.ImageToFloatBuffer(resized)),
 			)
 		default:

--- a/services/vision/mlvision/classifier.go
+++ b/services/vision/mlvision/classifier.go
@@ -55,9 +55,15 @@ func attemptToBuildClassifier(mlm mlmodel.Service) (classification.Classifier, e
 		inMap := ml.Tensors{}
 		switch inType {
 		case UInt8:
-			inMap["image"] = tensor.New(tensor.WithBacking(rimage.ImageToUInt8Buffer(resized)))
+			inMap["image"] = tensor.New(
+				tensor.WithShape(1, int(inHeight), int(inWidth), 3),
+				tensor.WithBacking(rimage.ImageToUInt8Buffer(resized)),
+			)
 		case Float32:
-			inMap["image"] = tensor.New(tensor.WithBacking(rimage.ImageToFloatBuffer(resized)))
+			inMap["image"] = tensor.New(
+				tensor.WithShape(1, int(inHeight), int(inWidth), 3),
+				tensor.WithBacking(rimage.ImageToFloatBuffer(resized)),
+			)
 		default:
 			return nil, errors.New("invalid input type. try uint8 or float32")
 		}

--- a/services/vision/mlvision/detector.go
+++ b/services/vision/mlvision/detector.go
@@ -63,9 +63,15 @@ func attemptToBuildDetector(mlm mlmodel.Service) (objectdetection.Detector, erro
 		inMap := ml.Tensors{}
 		switch inType {
 		case UInt8:
-			inMap["image"] = tensor.New(tensor.WithBacking(rimage.ImageToUInt8Buffer(resized)))
+			inMap["image"] = tensor.New(
+				tensor.WithShape(1, int(inHeight), int(inWidth), 3),
+				tensor.WithBacking(rimage.ImageToUInt8Buffer(resized)),
+			)
 		case Float32:
-			inMap["image"] = tensor.New(tensor.WithBacking(rimage.ImageToFloatBuffer(resized)))
+			inMap["image"] = tensor.New(
+				tensor.WithShape(1, int(inHeight), int(inWidth), 3),
+				tensor.WithBacking(rimage.ImageToFloatBuffer(resized)),
+			)
 		default:
 			return nil, errors.New("invalid input type. try uint8 or float32")
 		}

--- a/services/vision/mlvision/detector.go
+++ b/services/vision/mlvision/detector.go
@@ -64,12 +64,12 @@ func attemptToBuildDetector(mlm mlmodel.Service, nameMap map[string]string) (obj
 		switch inType {
 		case UInt8:
 			inMap["image"] = tensor.New(
-				tensor.WithShape(1, int(inHeight), int(inWidth), 3),
+				tensor.WithShape(1, resized.Bounds().Dy(), resized.Bounds().Dx(), 3),
 				tensor.WithBacking(rimage.ImageToUInt8Buffer(resized)),
 			)
 		case Float32:
 			inMap["image"] = tensor.New(
-				tensor.WithShape(1, int(inHeight), int(inWidth), 3),
+				tensor.WithShape(1, resized.Bounds().Dy(), resized.Bounds().Dx(), 3),
 				tensor.WithBacking(rimage.ImageToFloatBuffer(resized)),
 			)
 		default:

--- a/services/vision/mlvision/detector.go
+++ b/services/vision/mlvision/detector.go
@@ -184,7 +184,8 @@ func guessDetectionTensors(outMap ml.Tensors) (*tensor.Dense, *tensor.Dense, *te
 		}
 	}
 	if !okCat { // guess the name of the category tensor
-		// a category usually has a whole number in its elements
+		// a category usually has a whole number in its elements, so either look for
+		// int data types in the tensor, or sum the elements and make sure they dont have any decimals
 		for name, t := range outMap {
 			if _, alreadyFound := foundTensor[name]; alreadyFound {
 				continue

--- a/services/vision/mlvision/detector.go
+++ b/services/vision/mlvision/detector.go
@@ -114,7 +114,7 @@ func attemptToBuildDetector(mlm mlmodel.Service) (objectdetection.Detector, erro
 }
 
 // findDetectionTensors finds the tensors that are necessary for object detection
-// the returned tensor order is location, category, score
+// the returned tensor order is location, category, score.
 func findDetectionTensors(outMap ml.Tensors) (*tensor.Dense, *tensor.Dense, *tensor.Dense, error) {
 	locations, okLoc := outMap["location"]
 	categories, okCat := outMap["category"]

--- a/services/vision/mlvision/ml_model.go
+++ b/services/vision/mlvision/ml_model.go
@@ -80,7 +80,11 @@ func registerMLModelVisionService(
 		return nil, err
 	}
 
-	classifierFunc, err := attemptToBuildClassifier(mlm)
+	// the nameMap that associates the tensor names as they are found in the model, to
+	// what the vision service expects. This might not be necessary any more once we
+	// get the vision service to have rename maps in its configs.
+	nameMap := make(map[string]string)
+	classifierFunc, err := attemptToBuildClassifier(mlm, nameMap)
 	if err != nil {
 		logger.Debugw("unable to use ml model as a classifier, will attempt to evaluate as"+
 			"detector and segmenter", "model", params.ModelName, "error", err)
@@ -95,7 +99,7 @@ func registerMLModelVisionService(
 		}
 	}
 
-	detectorFunc, err := attemptToBuildDetector(mlm)
+	detectorFunc, err := attemptToBuildDetector(mlm, nameMap)
 	if err != nil {
 		logger.Debugw("unable to use ml model as a detector, will attempt to evaluate as 3D segmenter",
 			"model", params.ModelName, "error", err)
@@ -110,7 +114,7 @@ func registerMLModelVisionService(
 		}
 	}
 
-	segmenter3DFunc, err := attemptToBuild3DSegmenter(mlm)
+	segmenter3DFunc, err := attemptToBuild3DSegmenter(mlm, nameMap)
 	if err != nil {
 		logger.Debugw("unable to use ml model as 3D segmenter", "model", params.ModelName, "error", err)
 	} else {

--- a/services/vision/mlvision/ml_model.go
+++ b/services/vision/mlvision/ml_model.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/edaniels/golog"
 	"github.com/montanaflynn/stats"
@@ -83,7 +84,7 @@ func registerMLModelVisionService(
 	// the nameMap that associates the tensor names as they are found in the model, to
 	// what the vision service expects. This might not be necessary any more once we
 	// get the vision service to have rename maps in its configs.
-	nameMap := make(map[string]string)
+	nameMap := &sync.Map{}
 	classifierFunc, err := attemptToBuildClassifier(mlm, nameMap)
 	if err != nil {
 		logger.Debugw("unable to use ml model as a classifier, will attempt to evaluate as"+

--- a/services/vision/mlvision/ml_model.go
+++ b/services/vision/mlvision/ml_model.go
@@ -54,8 +54,15 @@ func init() {
 
 // MLModelConfig specifies the parameters needed to turn an ML model into a vision Model.
 type MLModelConfig struct {
-	resource.TriviallyValidateConfig
 	ModelName string `json:"mlmodel_name"`
+}
+
+// Validate will add the ModelName as an implicit dependency to the robot
+func (conf *MLModelConfig) Validate(path string) ([]string, error) {
+	if conf.ModelName == "" {
+		return nil, errors.New("mlmodel_name cannot be empty")
+	}
+	return []string{conf.ModelName}, nil
 }
 
 func registerMLModelVisionService(

--- a/services/vision/mlvision/ml_model.go
+++ b/services/vision/mlvision/ml_model.go
@@ -14,7 +14,9 @@ import (
 	"github.com/montanaflynn/stats"
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
+	"golang.org/x/exp/constraints"
 
+	"go.viam.com/rdk/ml"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/services/mlmodel"
@@ -109,28 +111,6 @@ func registerMLModelVisionService(
 	}
 	// Don't return a close function, because you don't want to close the underlying ML service
 	return vision.NewService(name, r, nil, classifierFunc, detectorFunc, segmenter3DFunc)
-}
-
-// Unpack output based on expected type and force it into a []float64.
-func unpack(inMap map[string]interface{}, name string) ([]float64, error) {
-	var out []float64
-	me := inMap[name]
-	if me == nil {
-		return nil, errors.Errorf("no such tensor named %q to unpack", name)
-	}
-	switch v := me.(type) {
-	case []uint8:
-		out = make([]float64, 0, len(v))
-		for _, t := range v {
-			out = append(out, float64(t))
-		}
-	case []float32:
-		out = make([]float64, 0, len(v))
-		for _, t := range v {
-			out = append(out, float64(t))
-		}
-	}
-	return out, nil
 }
 
 // getLabelsFromMetadata returns a slice of strings--the intended labels.
@@ -231,4 +211,82 @@ func checkClassificationScores(in []float64) []float64 {
 		return out
 	}
 	return in // no need to sigmoid
+}
+
+// Number interface for converting between numbers
+type number interface {
+	constraints.Integer | constraints.Float
+}
+
+// convertNumberSlice converts any number slice into another number slice
+func convertNumberSlice[T1 number, T2 number](t1 []T1) []T2 {
+	t2 := make([]T2, len(t1))
+	for i := range t1 {
+		t2[i] = T2(t1[i])
+	}
+	return t2
+}
+
+func convertToFloat64Slice(slice interface{}) ([]float64, error) {
+	switch v := slice.(type) {
+	case []float64:
+		return v, nil
+	case float64:
+		return []float64{v}, nil
+	case []float32:
+		return convertNumberSlice[float32, float64](v), nil
+	case float32:
+		return convertNumberSlice[float32, float64]([]float32{v}), nil
+	case []int:
+		return convertNumberSlice[int, float64](v), nil
+	case int:
+		return convertNumberSlice[int, float64]([]int{v}), nil
+	case []uint:
+		return convertNumberSlice[uint, float64](v), nil
+	case uint:
+		return convertNumberSlice[uint, float64]([]uint{v}), nil
+	case []int8:
+		return convertNumberSlice[int8, float64](v), nil
+	case int8:
+		return convertNumberSlice[int8, float64]([]int8{v}), nil
+	case []int16:
+		return convertNumberSlice[int16, float64](v), nil
+	case int16:
+		return convertNumberSlice[int16, float64]([]int16{v}), nil
+	case []int32:
+		return convertNumberSlice[int32, float64](v), nil
+	case int32:
+		return convertNumberSlice[int32, float64]([]int32{v}), nil
+	case []int64:
+		return convertNumberSlice[int64, float64](v), nil
+	case int64:
+		return convertNumberSlice[int64, float64]([]int64{v}), nil
+	case []uint8:
+		return convertNumberSlice[uint8, float64](v), nil
+	case uint8:
+		return convertNumberSlice[uint8, float64]([]uint8{v}), nil
+	case []uint16:
+		return convertNumberSlice[uint16, float64](v), nil
+	case uint16:
+		return convertNumberSlice[uint16, float64]([]uint16{v}), nil
+	case []uint32:
+		return convertNumberSlice[uint32, float64](v), nil
+	case uint32:
+		return convertNumberSlice[uint32, float64]([]uint32{v}), nil
+	case []uint64:
+		return convertNumberSlice[uint64, float64](v), nil
+	case uint64:
+		return convertNumberSlice[uint64, float64]([]uint64{v}), nil
+	default:
+		return nil, errors.Errorf("dont know how to convert slice of %T into a []float64", slice)
+	}
+}
+
+// tensorNames returns all the names of the tensors
+func tensorNames(t ml.Tensors) []string {
+	names := []string{}
+	for name := range t {
+		names = append(names, name)
+	}
+	return names
 }

--- a/services/vision/mlvision/ml_model.go
+++ b/services/vision/mlvision/ml_model.go
@@ -213,13 +213,13 @@ func checkClassificationScores(in []float64) []float64 {
 	return in // no need to sigmoid
 }
 
-// Number interface for converting between numbers
+// Number interface for converting between numbers.
 type number interface {
 	constraints.Integer | constraints.Float
 }
 
-// convertNumberSlice converts any number slice into another number slice
-func convertNumberSlice[T1 number, T2 number](t1 []T1) []T2 {
+// convertNumberSlice converts any number slice into another number slice.
+func convertNumberSlice[T1, T2 number](t1 []T1) []T2 {
 	t2 := make([]T2, len(t1))
 	for i := range t1 {
 		t2[i] = T2(t1[i])
@@ -282,7 +282,7 @@ func convertToFloat64Slice(slice interface{}) ([]float64, error) {
 	}
 }
 
-// tensorNames returns all the names of the tensors
+// tensorNames returns all the names of the tensors.
 func tensorNames(t ml.Tensors) []string {
 	names := []string{}
 	for name := range t {

--- a/services/vision/mlvision/ml_model.go
+++ b/services/vision/mlvision/ml_model.go
@@ -57,7 +57,7 @@ type MLModelConfig struct {
 	ModelName string `json:"mlmodel_name"`
 }
 
-// Validate will add the ModelName as an implicit dependency to the robot
+// Validate will add the ModelName as an implicit dependency to the robot.
 func (conf *MLModelConfig) Validate(path string) ([]string, error) {
 	if conf.ModelName == "" {
 		return nil, errors.New("mlmodel_name cannot be empty")

--- a/services/vision/mlvision/ml_model_test.go
+++ b/services/vision/mlvision/ml_model_test.go
@@ -89,7 +89,7 @@ func TestAddingIncorrectModelTypeToModel(t *testing.T) {
 	mlm, err := getTestMlModel(modelLocDetector)
 	test.That(t, err, test.ShouldBeNil)
 
-	nameMap := map[string]string{}
+	nameMap := &sync.Map{}
 	classifier, err := attemptToBuildClassifier(mlm, nameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, classifier, test.ShouldNotBeNil)
@@ -109,7 +109,7 @@ func TestAddingIncorrectModelTypeToModel(t *testing.T) {
 	mlm, err = getTestMlModel(modelLocClassifier)
 	test.That(t, err, test.ShouldBeNil)
 
-	nameMap = map[string]string{}
+	nameMap = &sync.Map{}
 	classifier, err = attemptToBuildClassifier(mlm, nameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, classifier, test.ShouldNotBeNil)
@@ -161,7 +161,7 @@ func TestNewMLDetector(t *testing.T) {
 	test.That(t, check.Outputs[1].Name, test.ShouldResemble, "category")
 	test.That(t, check.Outputs[0].Extra["labels"], test.ShouldNotBeNil)
 
-	nameMap := map[string]string{}
+	nameMap := &sync.Map{}
 	gotDetector, err := attemptToBuildDetector(out, nameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotDetector, test.ShouldNotBeNil)
@@ -186,7 +186,7 @@ func TestNewMLDetector(t *testing.T) {
 	outNL, err := tflitecpu.NewTFLiteCPUModel(ctx, &noLabelCfg, mlmodel.Named("myOtherMLDet"))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, outNL, test.ShouldNotBeNil)
-	nameMap = map[string]string{}
+	nameMap = &sync.Map{}
 	gotDetectorNL, err := attemptToBuildDetector(outNL, nameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotDetectorNL, test.ShouldNotBeNil)
@@ -236,7 +236,7 @@ func TestNewMLClassifier(t *testing.T) {
 	test.That(t, check.Outputs[0].Name, test.ShouldResemble, "probability")
 	test.That(t, check.Outputs[0].Extra["labels"], test.ShouldNotBeNil)
 
-	nameMap := map[string]string{}
+	nameMap := &sync.Map{}
 	gotClassifier, err := attemptToBuildClassifier(out, nameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotClassifier, test.ShouldNotBeNil)
@@ -255,7 +255,7 @@ func TestNewMLClassifier(t *testing.T) {
 	outNL, err := tflitecpu.NewTFLiteCPUModel(ctx, &noLabelCfg, mlmodel.Named("myOtherMLClassif"))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, outNL, test.ShouldNotBeNil)
-	nameMap = map[string]string{}
+	nameMap = &sync.Map{}
 	gotClassifierNL, err := attemptToBuildClassifier(outNL, nameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotClassifierNL, test.ShouldNotBeNil)
@@ -298,7 +298,7 @@ func TestMoreMLDetectors(t *testing.T) {
 	test.That(t, check.Inputs[0].DataType, test.ShouldResemble, "float32")
 	test.That(t, len(check.Outputs), test.ShouldEqual, 4)
 
-	nameMap := map[string]string{}
+	nameMap := &sync.Map{}
 	gotDetector, err := attemptToBuildDetector(outModel, nameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotDetector, test.ShouldNotBeNil)
@@ -329,7 +329,7 @@ func TestMoreMLClassifiers(t *testing.T) {
 	test.That(t, check, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldBeNil)
 
-	nameMap := map[string]string{}
+	nameMap := &sync.Map{}
 	gotClassifier, err := attemptToBuildClassifier(outModel, nameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotClassifier, test.ShouldNotBeNil)
@@ -357,7 +357,7 @@ func TestMoreMLClassifiers(t *testing.T) {
 	test.That(t, check, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldBeNil)
 
-	nameMap = map[string]string{}
+	nameMap = &sync.Map{}
 	gotClassifier, err = attemptToBuildClassifier(outModel, nameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotClassifier, test.ShouldNotBeNil)
@@ -431,7 +431,7 @@ func TestOneClassifierOnManyCameras(t *testing.T) {
 	out, err := tflitecpu.NewTFLiteCPUModel(ctx, &cfg, mlmodel.Named("testClassifier"))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, out, test.ShouldNotBeNil)
-	nameMap := map[string]string{}
+	nameMap := &sync.Map{}
 	outClassifier, err := attemptToBuildClassifier(out, nameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, outClassifier, test.ShouldNotBeNil)
@@ -450,11 +450,11 @@ func TestMultipleClassifiersOneModel(t *testing.T) {
 	out, err := tflitecpu.NewTFLiteCPUModel(ctx, &cfg, mlmodel.Named("testClassifier"))
 	test.That(t, err, test.ShouldBeNil)
 
-	nameMap := map[string]string{}
+	nameMap := &sync.Map{}
 	Classifier1, err := attemptToBuildClassifier(out, nameMap)
 	test.That(t, err, test.ShouldBeNil)
 
-	nameMap = map[string]string{}
+	nameMap = &sync.Map{}
 	Classifier2, err := attemptToBuildClassifier(out, nameMap)
 	test.That(t, err, test.ShouldBeNil)
 

--- a/services/vision/mlvision/ml_model_test.go
+++ b/services/vision/mlvision/ml_model_test.go
@@ -290,6 +290,7 @@ func TestMoreMLDetectors(t *testing.T) {
 	// Even without metadata we should find
 	test.That(t, check.Inputs[0].Shape, test.ShouldResemble, []int{1, 320, 320, 3})
 	test.That(t, check.Inputs[0].DataType, test.ShouldResemble, "float32")
+	test.That(t, len(check.Outputs), test.ShouldEqual, 4)
 
 	gotDetector, err := attemptToBuildDetector(outModel)
 	test.That(t, err, test.ShouldBeNil)

--- a/services/vision/mlvision/ml_model_test.go
+++ b/services/vision/mlvision/ml_model_test.go
@@ -89,14 +89,15 @@ func TestAddingIncorrectModelTypeToModel(t *testing.T) {
 	mlm, err := getTestMlModel(modelLocDetector)
 	test.That(t, err, test.ShouldBeNil)
 
-	classifier, err := attemptToBuildClassifier(mlm)
+	nameMap := map[string]string{}
+	classifier, err := attemptToBuildClassifier(mlm, nameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, classifier, test.ShouldNotBeNil)
 
 	err = checkIfClassifierWorks(ctx, classifier)
 	test.That(t, err, test.ShouldNotBeNil)
 
-	detector, err := attemptToBuildDetector(mlm)
+	detector, err := attemptToBuildDetector(mlm, nameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, detector, test.ShouldNotBeNil)
 
@@ -108,7 +109,8 @@ func TestAddingIncorrectModelTypeToModel(t *testing.T) {
 	mlm, err = getTestMlModel(modelLocClassifier)
 	test.That(t, err, test.ShouldBeNil)
 
-	classifier, err = attemptToBuildClassifier(mlm)
+	nameMap = map[string]string{}
+	classifier, err = attemptToBuildClassifier(mlm, nameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, classifier, test.ShouldNotBeNil)
 
@@ -118,7 +120,7 @@ func TestAddingIncorrectModelTypeToModel(t *testing.T) {
 	mlm, err = getTestMlModel(modelLocClassifier)
 	test.That(t, err, test.ShouldBeNil)
 
-	detector, err = attemptToBuildDetector(mlm)
+	detector, err = attemptToBuildDetector(mlm, nameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, detector, test.ShouldNotBeNil)
 
@@ -159,7 +161,8 @@ func TestNewMLDetector(t *testing.T) {
 	test.That(t, check.Outputs[1].Name, test.ShouldResemble, "category")
 	test.That(t, check.Outputs[0].Extra["labels"], test.ShouldNotBeNil)
 
-	gotDetector, err := attemptToBuildDetector(out)
+	nameMap := map[string]string{}
+	gotDetector, err := attemptToBuildDetector(out, nameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotDetector, test.ShouldNotBeNil)
 
@@ -183,7 +186,8 @@ func TestNewMLDetector(t *testing.T) {
 	outNL, err := tflitecpu.NewTFLiteCPUModel(ctx, &noLabelCfg, mlmodel.Named("myOtherMLDet"))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, outNL, test.ShouldNotBeNil)
-	gotDetectorNL, err := attemptToBuildDetector(outNL)
+	nameMap = map[string]string{}
+	gotDetectorNL, err := attemptToBuildDetector(outNL, nameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotDetectorNL, test.ShouldNotBeNil)
 	gotDetectionsNL, err := gotDetectorNL(ctx, pic)
@@ -232,7 +236,8 @@ func TestNewMLClassifier(t *testing.T) {
 	test.That(t, check.Outputs[0].Name, test.ShouldResemble, "probability")
 	test.That(t, check.Outputs[0].Extra["labels"], test.ShouldNotBeNil)
 
-	gotClassifier, err := attemptToBuildClassifier(out)
+	nameMap := map[string]string{}
+	gotClassifier, err := attemptToBuildClassifier(out, nameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotClassifier, test.ShouldNotBeNil)
 
@@ -250,7 +255,8 @@ func TestNewMLClassifier(t *testing.T) {
 	outNL, err := tflitecpu.NewTFLiteCPUModel(ctx, &noLabelCfg, mlmodel.Named("myOtherMLClassif"))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, outNL, test.ShouldNotBeNil)
-	gotClassifierNL, err := attemptToBuildClassifier(outNL)
+	nameMap = map[string]string{}
+	gotClassifierNL, err := attemptToBuildClassifier(outNL, nameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotClassifierNL, test.ShouldNotBeNil)
 	gotClassificationsNL, err := gotClassifierNL(ctx, pic)
@@ -292,7 +298,8 @@ func TestMoreMLDetectors(t *testing.T) {
 	test.That(t, check.Inputs[0].DataType, test.ShouldResemble, "float32")
 	test.That(t, len(check.Outputs), test.ShouldEqual, 4)
 
-	gotDetector, err := attemptToBuildDetector(outModel)
+	nameMap := map[string]string{}
+	gotDetector, err := attemptToBuildDetector(outModel, nameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotDetector, test.ShouldNotBeNil)
 
@@ -322,7 +329,8 @@ func TestMoreMLClassifiers(t *testing.T) {
 	test.That(t, check, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldBeNil)
 
-	gotClassifier, err := attemptToBuildClassifier(outModel)
+	nameMap := map[string]string{}
+	gotClassifier, err := attemptToBuildClassifier(outModel, nameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotClassifier, test.ShouldNotBeNil)
 
@@ -349,7 +357,8 @@ func TestMoreMLClassifiers(t *testing.T) {
 	test.That(t, check, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldBeNil)
 
-	gotClassifier, err = attemptToBuildClassifier(outModel)
+	nameMap = map[string]string{}
+	gotClassifier, err = attemptToBuildClassifier(outModel, nameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotClassifier, test.ShouldNotBeNil)
 	gotClassifications, err = gotClassifier(ctx, pic)
@@ -422,7 +431,8 @@ func TestOneClassifierOnManyCameras(t *testing.T) {
 	out, err := tflitecpu.NewTFLiteCPUModel(ctx, &cfg, mlmodel.Named("testClassifier"))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, out, test.ShouldNotBeNil)
-	outClassifier, err := attemptToBuildClassifier(out)
+	nameMap := map[string]string{}
+	outClassifier, err := attemptToBuildClassifier(out, nameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, outClassifier, test.ShouldNotBeNil)
 	valuePanda, valueLion := classifyTwoImages(picPanda, picLion, outClassifier)
@@ -440,10 +450,12 @@ func TestMultipleClassifiersOneModel(t *testing.T) {
 	out, err := tflitecpu.NewTFLiteCPUModel(ctx, &cfg, mlmodel.Named("testClassifier"))
 	test.That(t, err, test.ShouldBeNil)
 
-	Classifier1, err := attemptToBuildClassifier(out)
+	nameMap := map[string]string{}
+	Classifier1, err := attemptToBuildClassifier(out, nameMap)
 	test.That(t, err, test.ShouldBeNil)
 
-	Classifier2, err := attemptToBuildClassifier(out)
+	nameMap = map[string]string{}
+	Classifier2, err := attemptToBuildClassifier(out, nameMap)
 	test.That(t, err, test.ShouldBeNil)
 
 	picPanda, err := rimage.NewImageFromFile(artifact.MustPath("vision/tflite/redpanda.jpeg"))

--- a/services/vision/mlvision/segmenter3d.go
+++ b/services/vision/mlvision/segmenter3d.go
@@ -2,12 +2,13 @@ package mlvision
 
 import (
 	"errors"
+	"sync"
 
 	"go.viam.com/rdk/services/mlmodel"
 	"go.viam.com/rdk/vision/segmentation"
 )
 
 // TODO: RSDK-2665, build 3D segmenter from ML models.
-func attemptToBuild3DSegmenter(mlm mlmodel.Service, nameMap map[string]string) (segmentation.Segmenter, error) {
+func attemptToBuild3DSegmenter(mlm mlmodel.Service, nameMap *sync.Map) (segmentation.Segmenter, error) {
 	return nil, errors.New("vision 3D segmenters from ML models are currently not supported")
 }

--- a/services/vision/mlvision/segmenter3d.go
+++ b/services/vision/mlvision/segmenter3d.go
@@ -8,6 +8,6 @@ import (
 )
 
 // TODO: RSDK-2665, build 3D segmenter from ML models.
-func attemptToBuild3DSegmenter(mlm mlmodel.Service) (segmentation.Segmenter, error) {
+func attemptToBuild3DSegmenter(mlm mlmodel.Service, nameMap map[string]string) (segmentation.Segmenter, error) {
 	return nil, errors.New("vision 3D segmenters from ML models are currently not supported")
 }

--- a/testutils/inject/mlmodel_service.go
+++ b/testutils/inject/mlmodel_service.go
@@ -3,6 +3,7 @@ package inject
 import (
 	"context"
 
+	"go.viam.com/rdk/ml"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/services/mlmodel"
 )
@@ -11,7 +12,7 @@ import (
 type MLModelService struct {
 	mlmodel.Service
 	name         resource.Name
-	InferFunc    func(ctx context.Context, tensors mlmodel.Tensors, input map[string]interface{}) (mlmodel.Tensors, map[string]interface{}, error)
+	InferFunc    func(ctx context.Context, tensors ml.Tensors, input map[string]interface{}) (ml.Tensors, map[string]interface{}, error)
 	MetadataFunc func(ctx context.Context) (mlmodel.MLMetadata, error)
 	CloseFunc    func(ctx context.Context) error
 }
@@ -27,7 +28,7 @@ func (s *MLModelService) Name() resource.Name {
 }
 
 // Infer calls the injected Infer or the real variant.
-func (s *MLModelService) Infer(ctx context.Context, tensors mlmodel.Tensors, input map[string]interface{}) (mlmodel.Tensors, map[string]interface{}, error) {
+func (s *MLModelService) Infer(ctx context.Context, tensors ml.Tensors, input map[string]interface{}) (ml.Tensors, map[string]interface{}, error) {
 	if s.InferFunc == nil {
 		return s.Service.Infer(ctx, tensors, input)
 	}

--- a/testutils/inject/mlmodel_service.go
+++ b/testutils/inject/mlmodel_service.go
@@ -11,7 +11,7 @@ import (
 type MLModelService struct {
 	mlmodel.Service
 	name         resource.Name
-	InferFunc    func(ctx context.Context, input map[string]interface{}) (map[string]interface{}, error)
+	InferFunc    func(ctx context.Context, tensors mlmodel.Tensors, input map[string]interface{}) (mlmodel.Tensors, map[string]interface{}, error)
 	MetadataFunc func(ctx context.Context) (mlmodel.MLMetadata, error)
 	CloseFunc    func(ctx context.Context) error
 }
@@ -27,11 +27,11 @@ func (s *MLModelService) Name() resource.Name {
 }
 
 // Infer calls the injected Infer or the real variant.
-func (s *MLModelService) Infer(ctx context.Context, input map[string]interface{}) (map[string]interface{}, error) {
+func (s *MLModelService) Infer(ctx context.Context, tensors mlmodel.Tensors, input map[string]interface{}) (mlmodel.Tensors, map[string]interface{}, error) {
 	if s.InferFunc == nil {
-		return s.Service.Infer(ctx, input)
+		return s.Service.Infer(ctx, tensors, input)
 	}
-	return s.InferFunc(ctx, input)
+	return s.InferFunc(ctx, tensors, input)
 }
 
 // Metadata calls the injected Metadata or the real variant.

--- a/testutils/inject/mlmodel_service.go
+++ b/testutils/inject/mlmodel_service.go
@@ -28,7 +28,11 @@ func (s *MLModelService) Name() resource.Name {
 }
 
 // Infer calls the injected Infer or the real variant.
-func (s *MLModelService) Infer(ctx context.Context, tensors ml.Tensors, input map[string]interface{}) (ml.Tensors, map[string]interface{}, error) {
+func (s *MLModelService) Infer(
+	ctx context.Context,
+	tensors ml.Tensors,
+	input map[string]interface{},
+) (ml.Tensors, map[string]interface{}, error) {
 	if s.InferFunc == nil {
 		return s.Service.Infer(ctx, tensors, input)
 	}


### PR DESCRIPTION
## What this changes

- Imported gorgonia/tensor library to implement flat tensors
- Edited the RDK server.go and client.go to use flat tensors.
  -  For backwards compatibility (until python is updated) the pb.Struct methods still works
- BREAKING CHANGE: The RDK tflite API was changed to use FlatTensors rather than interface maps
- BREAKING CHANGE: tflite_cpu model in RDK was edited to use flat tensors, and get rid of use for pb.Struct
- BREAKING CHANGE: vision service/mlmodel detector and classifier code was updated to use flat tensors.

## Testing

- Manually tested this on effDet0 using the tflite file.
- Manually tested on a classifier model that previously didn't work, RSDK-3009
- Manually tested on both a detector and classifier model with no metadata made by Viam


@tahiyasalam cc - no need to review unless something sticks out to you for Data/ML