### PR TITLE
RDSK-4634 and RSDK-4750: Small vision service improvements

### DIFF
--- a/services/vision/mlvision/classifier.go
+++ b/services/vision/mlvision/classifier.go
@@ -104,7 +104,7 @@ func checkIfClassifierWorks(ctx context.Context, cf classification.Classifier) e
 
 	_, err := cf(ctx, img)
 	if err != nil {
-		return errors.New("Cannot use model as a classifier")
+		return errors.Wrap(err, "Cannot use model as a classifier")
 	}
 	return nil
 }

--- a/services/vision/mlvision/detector.go
+++ b/services/vision/mlvision/detector.go
@@ -132,7 +132,7 @@ func checkIfDetectorWorks(ctx context.Context, df objectdetection.Detector) erro
 
 	_, err := df(ctx, img)
 	if err != nil {
-		return errors.New("Cannot use model as a detector")
+		return errors.Wrap(err, "Cannot use model as a detector")
 	}
 	return nil
 }

--- a/services/vision/mlvision/detector.go
+++ b/services/vision/mlvision/detector.go
@@ -23,7 +23,7 @@ func attemptToBuildDetector(mlm mlmodel.Service) (objectdetection.Detector, erro
 	}
 
 	// Set up input type, height, width, and labels
-	var inHeight, inWidth uint
+	var inHeight, inWidth int
 	if len(md.Inputs) < 1 {
 		return nil, errors.New("no input tensors received")
 	}
@@ -39,14 +39,25 @@ func attemptToBuildDetector(mlm mlmodel.Service) (objectdetection.Detector, erro
 	}
 
 	if shape := md.Inputs[0].Shape; getIndex(shape, 3) == 1 {
-		inHeight, inWidth = uint(shape[2]), uint(shape[3])
+		inHeight, inWidth = shape[2], shape[3]
 	} else {
-		inHeight, inWidth = uint(shape[1]), uint(shape[2])
+		inHeight, inWidth = shape[1], shape[2]
 	}
 
 	return func(ctx context.Context, img image.Image) ([]objectdetection.Detection, error) {
 		origW, origH := img.Bounds().Dx(), img.Bounds().Dy()
-		resized := resize.Resize(inWidth, inHeight, img, resize.Bilinear)
+		resizeW := inWidth
+		if resizeW == -1 {
+			resizeW = origW
+		}
+		resizeH := inHeight
+		if resizeH == -1 {
+			resizeH = origH
+		}
+		resized := img
+		if (origW != resizeW) || (origH != resizeH) {
+			resized = resize.Resize(uint(resizeW), uint(resizeH), img, resize.Bilinear)
+		}
 		inMap := make(map[string]interface{})
 		switch inType {
 		case UInt8:


### PR DESCRIPTION
@bhaney and @kharijarrett

Two changes in this PR:
- RSDK-4634 is just a quality of life improvement. Previously, the errors that you can see with `-debug` didn't provide the nested error that actually caused the detector or classifier to decide that the model wasn't useable, but now it does.
- RSDK-4750 is a little more important. The full TFLite effdet model can take any size input, so the `image` metadata reports the height/width as `-1, -1`. For such models, skip the resizing step and send the image as is.