### PR TITLE
[RSDK-4635] Fix issue with Power Sensor code sample

### DIFF
--- a/examples/apis.json
+++ b/examples/apis.json
@@ -53,7 +53,7 @@
     "args": ["context.Background()", "map[string]interface{}{}"]
   },
   "power_sensor": {
-    "func": "Voltage",
+    "func": "Power",
     "args": ["context.Background()", "map[string]interface{}{}"]
   },
   "pose_tracker": {


### PR DESCRIPTION
powersensor code sample was problematic because the old function (`Voltage`) returned 3 values (bool, float, err), but the docs assumes there are always only ever 2 values returned (cc @Kschappacher we might want to add `return_types` to the `api.json`).

This PR changes the code sample function to be `Power`, which only returns a float and an error, so docs should work

[Ticket](https://viam.atlassian.net/browse/RSDK-4635)