### PR TITLE
Rotate Transform Should Support 90 & 270 turns

### DIFF
--- a/components/camera/transformpipeline/mods.go
+++ b/components/camera/transformpipeline/mods.go
@@ -37,7 +37,6 @@ func newRotateTransform(ctx context.Context, source gostream.VideoSource, stream
 	if err != nil {
 		return nil, camera.UnspecifiedStream, errors.Wrap(err, "cannot parse rotate attribute map")
 	}
-	// TODO: error check angle?
 
 	props, err := propsFromVideoSource(ctx, source)
 	if err != nil {

--- a/components/camera/transformpipeline/mods.go
+++ b/components/camera/transformpipeline/mods.go
@@ -18,15 +18,27 @@ import (
 	"go.viam.com/rdk/utils"
 )
 
+// rotateConfig are the attributes for a rotate transform.
+type rotateConfig struct {
+	Angle float64 `json:"angle_degs"`
+}
+
 // rotateSource is the source to be rotated and the kind of image type.
 type rotateSource struct {
 	originalStream gostream.VideoStream
 	stream         camera.ImageType
+	angle          float64
 }
 
 // newRotateTransform creates a new rotation transform.
-func newRotateTransform(ctx context.Context, source gostream.VideoSource, stream camera.ImageType,
+func newRotateTransform(ctx context.Context, source gostream.VideoSource, stream camera.ImageType, am utils.AttributeMap,
 ) (gostream.VideoSource, camera.ImageType, error) {
+	conf, err := resource.TransformAttributeMap[*rotateConfig](am)
+	if err != nil {
+		return nil, camera.UnspecifiedStream, errors.Wrap(err, "cannot parse rotate attribute map")
+	}
+	// TODO: error check angle?
+
 	props, err := propsFromVideoSource(ctx, source)
 	if err != nil {
 		return nil, camera.UnspecifiedStream, err
@@ -37,7 +49,7 @@ func newRotateTransform(ctx context.Context, source gostream.VideoSource, stream
 	if props.DistortionParams != nil {
 		cameraModel.Distortion = props.DistortionParams
 	}
-	reader := &rotateSource{gostream.NewEmbeddedVideoStream(source), stream}
+	reader := &rotateSource{gostream.NewEmbeddedVideoStream(source), stream, conf.Angle}
 	src, err := camera.NewVideoSourceFromReader(ctx, reader, &cameraModel, stream)
 	if err != nil {
 		return nil, camera.UnspecifiedStream, err
@@ -55,13 +67,15 @@ func (rs *rotateSource) Read(ctx context.Context) (image.Image, func(), error) {
 	}
 	switch rs.stream {
 	case camera.ColorStream, camera.UnspecifiedStream:
-		return imaging.Rotate(orig, 180, color.Black), release, nil
+		// imaging.Rotate rotates an image counter-clockwise but our rotate function rotates in the
+		// clockwise direction. The angle is negated here for consistency.
+		return imaging.Rotate(orig, -(rs.angle), color.Black), release, nil
 	case camera.DepthStream:
 		dm, err := rimage.ConvertImageToDepthMap(ctx, orig)
 		if err != nil {
 			return nil, nil, err
 		}
-		return dm.Rotate(180), release, nil
+		return dm.Rotate(int(rs.angle)), release, nil
 	default:
 		return nil, nil, camera.NewUnsupportedImageTypeError(rs.stream)
 	}

--- a/components/camera/transformpipeline/mods_test.go
+++ b/components/camera/transformpipeline/mods_test.go
@@ -218,7 +218,38 @@ func TestRotateColorSource(t *testing.T) {
 
 	source = gostream.NewVideoSource(&videosource.StaticSource{ColorImg: img}, prop.Video{})
 	am = utils.AttributeMap{
-		"angle_degs": -90, // == 270, but additionally tests for negative numbers
+		"angle_degs": -90,
+	}
+	rs, stream, err = newRotateTransform(context.Background(), source, camera.ColorStream, am)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, stream, test.ShouldEqual, camera.ColorStream)
+
+	rawImage, _, err = camera.ReadImage(context.Background(), rs)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, rs.Close(context.Background()), test.ShouldBeNil)
+
+	err = rimage.WriteImageToFile(t.TempDir()+"/test_rotate_color_source.png", rawImage)
+	test.That(t, err, test.ShouldBeNil)
+
+	img2 = rimage.ConvertImage(rawImage)
+
+	for x := 0; x < img.Width(); x++ {
+		p1 := image.Point{X: x}
+		p2 := image.Point{Y: img2.Height() - 1 - x}
+
+		a := img.Get(p1)
+		b := img2.Get(p2)
+
+		d := a.Distance(b)
+		test.That(t, d, test.ShouldEqual, 0)
+	}
+
+	test.That(t, rs.Close(context.Background()), test.ShouldBeNil)
+	test.That(t, source.Close(context.Background()), test.ShouldBeNil)
+
+	source = gostream.NewVideoSource(&videosource.StaticSource{ColorImg: img}, prop.Video{})
+	am = utils.AttributeMap{
+		"angle_degs": 270,
 	}
 	rs, stream, err = newRotateTransform(context.Background(), source, camera.ColorStream, am)
 	test.That(t, err, test.ShouldBeNil)
@@ -317,7 +348,38 @@ func TestRotateDepthSource(t *testing.T) {
 
 	source = gostream.NewVideoSource(&videosource.StaticSource{DepthImg: pc}, prop.Video{})
 	am = utils.AttributeMap{
-		"angle_degs": -90, // == 270, but additionally tests for negative numbers
+		"angle_degs": -90,
+	}
+	rs, stream, err = newRotateTransform(context.Background(), source, camera.DepthStream, am)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, stream, test.ShouldEqual, camera.DepthStream)
+
+	rawImage, _, err = camera.ReadImage(context.Background(), rs)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, rs.Close(context.Background()), test.ShouldBeNil)
+
+	err = rimage.WriteImageToFile(t.TempDir()+"/test_rotate_depth_source.png", rawImage)
+	test.That(t, err, test.ShouldBeNil)
+
+	dm, err = rimage.ConvertImageToDepthMap(context.Background(), rawImage)
+	test.That(t, err, test.ShouldBeNil)
+
+	for x := 0; x < pc.Width(); x++ {
+		p1 := image.Point{X: x}
+		p2 := image.Point{Y: dm.Height() - 1 - x}
+
+		d1 := pc.Get(p1)
+		d2 := dm.Get(p2)
+
+		test.That(t, d1, test.ShouldEqual, d2)
+	}
+
+	test.That(t, rs.Close(context.Background()), test.ShouldBeNil)
+	test.That(t, source.Close(context.Background()), test.ShouldBeNil)
+
+	source = gostream.NewVideoSource(&videosource.StaticSource{DepthImg: pc}, prop.Video{})
+	am = utils.AttributeMap{
+		"angle_degs": 270,
 	}
 	rs, stream, err = newRotateTransform(context.Background(), source, camera.DepthStream, am)
 	test.That(t, err, test.ShouldBeNil)

--- a/components/camera/transformpipeline/mods_test.go
+++ b/components/camera/transformpipeline/mods_test.go
@@ -155,7 +155,10 @@ func TestRotateColorSource(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	source := gostream.NewVideoSource(&videosource.StaticSource{ColorImg: img}, prop.Video{})
-	rs, stream, err := newRotateTransform(context.Background(), source, camera.ColorStream)
+	am := utils.AttributeMap{
+		"angle_degs": 180,
+	}
+	rs, stream, err := newRotateTransform(context.Background(), source, camera.ColorStream, am)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, stream, test.ShouldEqual, camera.ColorStream)
 
@@ -181,6 +184,68 @@ func TestRotateColorSource(t *testing.T) {
 
 	test.That(t, rs.Close(context.Background()), test.ShouldBeNil)
 	test.That(t, source.Close(context.Background()), test.ShouldBeNil)
+
+	source = gostream.NewVideoSource(&videosource.StaticSource{ColorImg: img}, prop.Video{})
+	am = utils.AttributeMap{
+		"angle_degs": 90,
+	}
+	rs, stream, err = newRotateTransform(context.Background(), source, camera.ColorStream, am)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, stream, test.ShouldEqual, camera.ColorStream)
+
+	rawImage, _, err = camera.ReadImage(context.Background(), rs)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, rs.Close(context.Background()), test.ShouldBeNil)
+
+	err = rimage.WriteImageToFile(t.TempDir()+"/test_rotate_color_source.png", rawImage)
+	test.That(t, err, test.ShouldBeNil)
+
+	img2 = rimage.ConvertImage(rawImage)
+
+	for x := 0; x < img.Width(); x++ {
+		p1 := image.Point{X: x}
+		p2 := image.Point{X: img2.Width() - 1, Y: x}
+
+		a := img.Get(p1)
+		b := img2.Get(p2)
+
+		d := a.Distance(b)
+		test.That(t, d, test.ShouldEqual, 0)
+	}
+
+	test.That(t, rs.Close(context.Background()), test.ShouldBeNil)
+	test.That(t, source.Close(context.Background()), test.ShouldBeNil)
+
+	source = gostream.NewVideoSource(&videosource.StaticSource{ColorImg: img}, prop.Video{})
+	am = utils.AttributeMap{
+		"angle_degs": -90, // == 270, but additionally tests for negative numbers
+	}
+	rs, stream, err = newRotateTransform(context.Background(), source, camera.ColorStream, am)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, stream, test.ShouldEqual, camera.ColorStream)
+
+	rawImage, _, err = camera.ReadImage(context.Background(), rs)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, rs.Close(context.Background()), test.ShouldBeNil)
+
+	err = rimage.WriteImageToFile(t.TempDir()+"/test_rotate_color_source.png", rawImage)
+	test.That(t, err, test.ShouldBeNil)
+
+	img2 = rimage.ConvertImage(rawImage)
+
+	for x := 0; x < img.Width(); x++ {
+		p1 := image.Point{X: x}
+		p2 := image.Point{Y: img2.Height() - 1 - x}
+
+		a := img.Get(p1)
+		b := img2.Get(p2)
+
+		d := a.Distance(b)
+		test.That(t, d, test.ShouldEqual, 0)
+	}
+
+	test.That(t, rs.Close(context.Background()), test.ShouldBeNil)
+	test.That(t, source.Close(context.Background()), test.ShouldBeNil)
 }
 
 func TestRotateDepthSource(t *testing.T) {
@@ -189,7 +254,10 @@ func TestRotateDepthSource(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	source := gostream.NewVideoSource(&videosource.StaticSource{DepthImg: pc}, prop.Video{})
-	rs, stream, err := newRotateTransform(context.Background(), source, camera.DepthStream)
+	am := utils.AttributeMap{
+		"angle_degs": 180,
+	}
+	rs, stream, err := newRotateTransform(context.Background(), source, camera.DepthStream, am)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, stream, test.ShouldEqual, camera.DepthStream)
 
@@ -215,6 +283,68 @@ func TestRotateDepthSource(t *testing.T) {
 
 	test.That(t, rs.Close(context.Background()), test.ShouldBeNil)
 	test.That(t, source.Close(context.Background()), test.ShouldBeNil)
+
+	source = gostream.NewVideoSource(&videosource.StaticSource{DepthImg: pc}, prop.Video{})
+	am = utils.AttributeMap{
+		"angle_degs": 90,
+	}
+	rs, stream, err = newRotateTransform(context.Background(), source, camera.DepthStream, am)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, stream, test.ShouldEqual, camera.DepthStream)
+
+	rawImage, _, err = camera.ReadImage(context.Background(), rs)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, rs.Close(context.Background()), test.ShouldBeNil)
+
+	err = rimage.WriteImageToFile(t.TempDir()+"/test_rotate_depth_source.png", rawImage)
+	test.That(t, err, test.ShouldBeNil)
+
+	dm, err = rimage.ConvertImageToDepthMap(context.Background(), rawImage)
+	test.That(t, err, test.ShouldBeNil)
+
+	for x := 0; x < pc.Width(); x++ {
+		p1 := image.Point{X: x}
+		p2 := image.Point{X: dm.Width() - 1, Y: x}
+
+		d1 := pc.Get(p1)
+		d2 := dm.Get(p2)
+
+		test.That(t, d1, test.ShouldEqual, d2)
+	}
+
+	test.That(t, rs.Close(context.Background()), test.ShouldBeNil)
+	test.That(t, source.Close(context.Background()), test.ShouldBeNil)
+
+	source = gostream.NewVideoSource(&videosource.StaticSource{DepthImg: pc}, prop.Video{})
+	am = utils.AttributeMap{
+		"angle_degs": -90, // == 270, but additionally tests for negative numbers
+	}
+	rs, stream, err = newRotateTransform(context.Background(), source, camera.DepthStream, am)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, stream, test.ShouldEqual, camera.DepthStream)
+
+	rawImage, _, err = camera.ReadImage(context.Background(), rs)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, rs.Close(context.Background()), test.ShouldBeNil)
+
+	err = rimage.WriteImageToFile(t.TempDir()+"/test_rotate_depth_source.png", rawImage)
+	test.That(t, err, test.ShouldBeNil)
+
+	dm, err = rimage.ConvertImageToDepthMap(context.Background(), rawImage)
+	test.That(t, err, test.ShouldBeNil)
+
+	for x := 0; x < pc.Width(); x++ {
+		p1 := image.Point{X: x}
+		p2 := image.Point{Y: dm.Height() - 1 - x}
+
+		d1 := pc.Get(p1)
+		d2 := dm.Get(p2)
+
+		test.That(t, d1, test.ShouldEqual, d2)
+	}
+
+	test.That(t, rs.Close(context.Background()), test.ShouldBeNil)
+	test.That(t, source.Close(context.Background()), test.ShouldBeNil)
 }
 
 func BenchmarkColorRotate(b *testing.B) {
@@ -224,7 +354,10 @@ func BenchmarkColorRotate(b *testing.B) {
 	source := gostream.NewVideoSource(&videosource.StaticSource{ColorImg: img}, prop.Video{})
 	src, err := camera.WrapVideoSourceWithProjector(context.Background(), source, nil, camera.ColorStream)
 	test.That(b, err, test.ShouldBeNil)
-	rs, stream, err := newRotateTransform(context.Background(), src, camera.ColorStream)
+	am := utils.AttributeMap{
+		"angle_degs": 180,
+	}
+	rs, stream, err := newRotateTransform(context.Background(), src, camera.ColorStream, am)
 	test.That(b, err, test.ShouldBeNil)
 	test.That(b, stream, test.ShouldEqual, camera.ColorStream)
 
@@ -245,7 +378,10 @@ func BenchmarkDepthRotate(b *testing.B) {
 	source := gostream.NewVideoSource(&videosource.StaticSource{DepthImg: img}, prop.Video{})
 	src, err := camera.WrapVideoSourceWithProjector(context.Background(), source, nil, camera.DepthStream)
 	test.That(b, err, test.ShouldBeNil)
-	rs, stream, err := newRotateTransform(context.Background(), src, camera.DepthStream)
+	am := utils.AttributeMap{
+		"angle_degs": 180,
+	}
+	rs, stream, err := newRotateTransform(context.Background(), src, camera.DepthStream, am)
 	test.That(b, err, test.ShouldBeNil)
 	test.That(b, stream, test.ShouldEqual, camera.DepthStream)
 

--- a/components/camera/transformpipeline/transform.go
+++ b/components/camera/transformpipeline/transform.go
@@ -140,7 +140,7 @@ func buildTransform(
 	case transformTypeUnspecified, transformTypeIdentity:
 		return source, stream, nil
 	case transformTypeRotate:
-		return newRotateTransform(ctx, source, stream)
+		return newRotateTransform(ctx, source, stream, tr.Attributes)
 	case transformTypeResize:
 		return newResizeTransform(ctx, source, stream, tr.Attributes)
 	case transformTypeCrop:

--- a/rimage/depth_map.go
+++ b/rimage/depth_map.go
@@ -7,6 +7,7 @@ import (
 	"image/png"
 	"io"
 	"math"
+	"strconv"
 
 	"github.com/pkg/errors"
 	"gonum.org/v1/gonum/mat"
@@ -251,6 +252,10 @@ func (dm *DepthMap) ToPrettyPicture(hardMin, hardMax Depth) *Image {
 
 // Rotate rotates a copy of this depth map clockwise by the given amount.
 func (dm *DepthMap) Rotate(amount int) *DepthMap {
+	if amount == 0 {
+		return dm
+	}
+
 	if amount == 180 {
 		return dm.Rotate180()
 	}
@@ -259,12 +264,12 @@ func (dm *DepthMap) Rotate(amount int) *DepthMap {
 		return dm.Rotate90(true)
 	}
 
-	if amount == -90 {
+	if amount == -90 || amount == 270 {
 		return dm.Rotate90(false)
 	}
 
 	// made this a panic
-	panic("vision.DepthMap can only rotate 90, -90, or 180 degrees right now")
+	panic("vision.DepthMap can only rotate 90, -90, or 180 degrees, not " + strconv.Itoa(amount))
 }
 
 // Rotate90 rotates a copy of this depth map either by 90 degrees clockwise or counterclockwise.


### PR DESCRIPTION
This PR supports rotating images/videos 90,-90, and 270 in addition to 180, which we currently support. For color streams, as implemented, users can rotate an arbitrary number of degrees in either direction (e.g., 45 or -45), but the height and width are subject to constraints imposed by libx264. For example, the height and width must be divisible by two. Therefore, we'll only document the safe rotations, the ones tested below, since they either do not change the width and height or swap them.

### Testing (90, -90, 270)
[Screencast from 08-21-2023 07:24:01 PM.webm](https://github.com/viamrobotics/rdk/assets/34226620/a5f93574-55e0-4080-94a6-0aacc22e4dff)
