### PR TITLE
Dont mutate config data during initialization/reconfiguration

### DIFF
--- a/components/base/wheeled/wheeled_base.go
+++ b/components/base/wheeled/wheeled_base.go
@@ -134,10 +134,10 @@ func (wb *wheeledBase) Reconfigure(ctx context.Context, deps resource.Dependenci
 	}
 
 	if newConf.SpinSlipFactor == 0 {
-		newConf.SpinSlipFactor = 1
+		wb.spinSlipFactor = 1
+	} else {
+		wb.spinSlipFactor = newConf.SpinSlipFactor
 	}
-
-	wb.spinSlipFactor = newConf.SpinSlipFactor
 
 	updateMotors := func(curr []motor.Motor, fromConfig []string, whichMotor string) ([]motor.Motor, error) {
 		newMotors := make([]motor.Motor, 0)

--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
@@ -126,10 +126,11 @@ func (g *rtkI2C) Reconfigure(ctx context.Context, deps resource.Dependencies, co
 	}
 
 	if newConf.I2CBaudRate == 0 {
-		newConf.I2CBaudRate = 115200
+		g.wbaud = 115200
+	} else {
+		g.wbaud = newConf.I2CBaudRate
 	}
 
-	g.wbaud = newConf.I2CBaudRate
 	g.addr = byte(newConf.I2CAddr)
 
 	b, err := board.FromDependencies(deps, newConf.Board)
@@ -209,15 +210,15 @@ func newRTKI2C(
 	}
 
 	// Init NMEAMovementSensor
-	if newConf.I2CBaudRate == 0 {
-		newConf.I2CBaudRate = 115200
-	}
-
 	nmeaConf.I2CConfig = &gpsnmea.I2CConfig{
 		Board:       newConf.Board,
 		I2CBus:      newConf.I2CBus,
 		I2CBaudRate: newConf.I2CBaudRate,
 		I2CAddr:     newConf.I2CAddr,
+	}
+
+	if nmeaConf.I2CConfig.I2CBaudRate == 0 {
+		nmeaConf.I2CConfig.I2CBaudRate = 115200
 	}
 
 	g.nmeamovementsensor, err = gpsnmea.NewPmtkI2CGPSNMEA(ctx, deps, conf.ResourceName(), nmeaConf, logger)


### PR DESCRIPTION
@dgottlieb found an interesting bug yesterday: if you mutate the data in a config struct during reconfiguration, it looks different from the raw config afterwards, which triggers reconfiguration, which mutates the data, and you get stuck in a loop. Dan is working on a fix within the config-monitoring code, but in the meantime I think we should fix this in the components, too, so that nobody copies and pastes this, thinking it's the standard approach to take. 

I wish Go let you declare certain data as immutable, but the compiler isn't going to help with this. As a general rule, if you can avoid side effects (e.g., mutating your arguments when the caller of the function isn't expecting them to mutate), code becomes easier to reason about and more likely to be bug-free.

Everything compiles, but I haven't tested it further than that. but it's a pretty straightforward change, and I'm fairly confident I did it right.