### PR TITLE
RSDK-4657: Safeguard components from modifying component configuration.

### DIFF
--- a/components/camera/align/extrinsics.go
+++ b/components/camera/align/extrinsics.go
@@ -66,6 +66,10 @@ func init() {
 				if err := matrices.CheckValid(); err != nil {
 					return nil, err
 				}
+				oldCameraSystem := attributes["camera_system"]
+				defer func() {
+					attributes["camera_system"] = oldCameraSystem
+				}()
 				attributes["camera_system"] = matrices
 
 				return resource.TransformAttributeMap[*extrinsicsConfig](attributes)

--- a/config/diff_test.go
+++ b/config/diff_test.go
@@ -385,7 +385,7 @@ func TestDiffConfigs(t *testing.T) {
 			tc.Expected.Added.Network = config.NetworkConfig{}
 			tc.Expected.Removed.Network = config.NetworkConfig{}
 
-			for _, revealSensitiveConfigDiffs := range []bool{true} { // , false} {
+			for _, revealSensitiveConfigDiffs := range []bool{true, false} {
 				t.Run(fmt.Sprintf("revealSensitiveConfigDiffs=%t", revealSensitiveConfigDiffs), func(t *testing.T) {
 					logger := golog.NewTestLogger(t)
 					left, err := config.Read(context.Background(), tc.LeftFile, logger)

--- a/config/diff_test.go
+++ b/config/diff_test.go
@@ -68,6 +68,19 @@ func TestDiffConfigs(t *testing.T) {
 				Model: fakeModel,
 
 				API: board.API,
+				DiffingAttributes: &fakeboard.Config{
+					Analogs: []board.AnalogConfig{
+						{
+							Name: "analog1",
+							Pin:  "0",
+						},
+					}, DigitalInterrupts: []board.DigitalInterruptConfig{
+						{
+							Name: "encoder",
+							Pin:  "14",
+						},
+					},
+				},
 				ConvertedAttributes: &fakeboard.Config{
 					Analogs: []board.AnalogConfig{
 						{
@@ -141,6 +154,19 @@ func TestDiffConfigs(t *testing.T) {
 				Model: fakeModel,
 
 				API: board.API,
+				DiffingAttributes: &fakeboard.Config{
+					Analogs: []board.AnalogConfig{
+						{
+							Name: "analog1",
+							Pin:  "1",
+						},
+					}, DigitalInterrupts: []board.DigitalInterruptConfig{
+						{
+							Name: "encoder",
+							Pin:  "15",
+						},
+					},
+				},
 				ConvertedAttributes: &fakeboard.Config{
 					Analogs: []board.AnalogConfig{
 						{
@@ -256,6 +282,9 @@ func TestDiffConfigs(t *testing.T) {
 
 							API:   board.API,
 							Model: fakeModel,
+							DiffingAttributes: &fakeboard.Config{
+								DigitalInterrupts: []board.DigitalInterruptConfig{{Name: "encoder2", Pin: "16"}},
+							},
 							ConvertedAttributes: &fakeboard.Config{
 								DigitalInterrupts: []board.DigitalInterruptConfig{{Name: "encoder2", Pin: "16"}},
 							},
@@ -296,6 +325,9 @@ func TestDiffConfigs(t *testing.T) {
 
 							API:   board.API,
 							Model: fakeModel,
+							DiffingAttributes: &fakeboard.Config{
+								Analogs: []board.AnalogConfig{{Name: "analog1", Pin: "1"}},
+							},
 							ConvertedAttributes: &fakeboard.Config{
 								Analogs: []board.AnalogConfig{{Name: "analog1", Pin: "1"}},
 							},
@@ -353,7 +385,7 @@ func TestDiffConfigs(t *testing.T) {
 			tc.Expected.Added.Network = config.NetworkConfig{}
 			tc.Expected.Removed.Network = config.NetworkConfig{}
 
-			for _, revealSensitiveConfigDiffs := range []bool{true, false} {
+			for _, revealSensitiveConfigDiffs := range []bool{true} { // , false} {
 				t.Run(fmt.Sprintf("revealSensitiveConfigDiffs=%t", revealSensitiveConfigDiffs), func(t *testing.T) {
 					logger := golog.NewTestLogger(t)
 					left, err := config.Read(context.Background(), tc.LeftFile, logger)

--- a/resource/config.go
+++ b/resource/config.go
@@ -180,7 +180,7 @@ func (conf Config) Equals(other Config) bool {
 	case !reflect.DeepEqual(conf.AssociatedResourceConfigs, other.AssociatedResourceConfigs):
 		return false
 	case !reflect.DeepEqual(conf.Attributes, other.Attributes):
-		// Only one of `Attributes` or `DiffingAttributes` should be in populated.
+		// Only one of `Attributes` or `DiffingAttributes` should be populated.
 		return false
 	case !reflect.DeepEqual(conf.DiffingAttributes, other.DiffingAttributes):
 		return false

--- a/resource/config.go
+++ b/resource/config.go
@@ -165,7 +165,6 @@ func (assoc AssociatedResourceConfig) MarshalJSON() ([]byte, error) {
 // Equals checks if the two configs are logically equivalent. From the perspective of the
 // component's JSON configuration string.
 func (conf Config) Equals(other Config) bool {
-	//nolint:govet
 	switch {
 	case conf.Name != other.Name:
 		return false

--- a/resource/config.go
+++ b/resource/config.go
@@ -173,6 +173,8 @@ func (conf Config) Equals(other Config) bool {
 		return false
 	case conf.Model != other.Model:
 		return false
+	case !reflect.DeepEqual(conf.Frame, other.Frame):
+		return false
 	case !reflect.DeepEqual(conf.DependsOn, other.DependsOn):
 		return false
 	case !reflect.DeepEqual(conf.AssociatedResourceConfigs, other.AssociatedResourceConfigs):

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
-
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	armpb "go.viam.com/api/component/arm/v1"

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
+
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	armpb "go.viam.com/api/component/arm/v1"
@@ -1531,6 +1532,7 @@ func TestConfigStartsInvalidReconfiguresValid(t *testing.T) {
 				Name:                "test",
 				API:                 base.API,
 				Model:               fakeModel,
+				DiffingAttributes:   someConfig{},
 				ConvertedAttributes: someConfig{},
 			},
 		},
@@ -1538,6 +1540,7 @@ func TestConfigStartsInvalidReconfiguresValid(t *testing.T) {
 			{
 				Name:                "fake1",
 				API:                 datamanager.API,
+				DiffingAttributes:   someConfig{},
 				ConvertedAttributes: someConfig{},
 			},
 		},
@@ -1571,6 +1574,7 @@ func TestConfigStartsInvalidReconfiguresValid(t *testing.T) {
 				Name:                "fake1",
 				API:                 datamanager.API,
 				Model:               resource.DefaultServiceModel,
+				DiffingAttributes:   &builtin.Config{},
 				ConvertedAttributes: &builtin.Config{},
 			},
 		},
@@ -1624,6 +1628,9 @@ func TestConfigStartsValidReconfiguresInvalid(t *testing.T) {
 		Name:  "arm1",
 		API:   arm.API,
 		Model: fakeModel,
+		DiffingAttributes: &fake.Config{
+			ModelFilePath: "../../components/arm/fake/fake_model.json",
+		},
 		ConvertedAttributes: &fake.Config{
 			ModelFilePath: "../../components/arm/fake/fake_model.json",
 		},
@@ -1655,6 +1662,7 @@ func TestConfigStartsValidReconfiguresInvalid(t *testing.T) {
 				Name:                "fake1",
 				API:                 datamanager.API,
 				Model:               resource.DefaultServiceModel,
+				DiffingAttributes:   &builtin.Config{},
 				ConvertedAttributes: &builtin.Config{},
 			},
 		},
@@ -1678,6 +1686,7 @@ func TestConfigStartsValidReconfiguresInvalid(t *testing.T) {
 				Name:                "test",
 				API:                 base.API,
 				Model:               fakeModel,
+				DiffingAttributes:   someConfig{},
 				ConvertedAttributes: someConfig{},
 			},
 		},
@@ -1685,6 +1694,7 @@ func TestConfigStartsValidReconfiguresInvalid(t *testing.T) {
 			{
 				Name:                "fake1",
 				API:                 datamanager.API,
+				DiffingAttributes:   someConfig{},
 				ConvertedAttributes: someConfig{},
 			},
 		},

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -2462,6 +2462,7 @@ func TestUpdateWeakDependents(t *testing.T) {
 				Name:                arm1Name.Name,
 				API:                 arm.API,
 				Model:               fake.Model,
+				DiffingAttributes:   &fake.Config{},
 				ConvertedAttributes: &fake.Config{},
 			},
 		},
@@ -2508,6 +2509,9 @@ func TestUpdateWeakDependents(t *testing.T) {
 				Name:  weak1Name.Name,
 				API:   weakAPI,
 				Model: weakModel,
+				DiffingAttributes: &someTypeWithWeakAndStrongDepsConfig{
+					deps: []resource.Name{generic.Named("foo")},
+				},
 				ConvertedAttributes: &someTypeWithWeakAndStrongDepsConfig{
 					deps: []resource.Name{generic.Named("foo")},
 				},
@@ -2537,6 +2541,9 @@ func TestUpdateWeakDependents(t *testing.T) {
 				Name:  weak1Name.Name,
 				API:   weakAPI,
 				Model: weakModel,
+				DiffingAttributes: &someTypeWithWeakAndStrongDepsConfig{
+					weakDeps: []resource.Name{base1Name},
+				},
 				ConvertedAttributes: &someTypeWithWeakAndStrongDepsConfig{
 					weakDeps: []resource.Name{base1Name},
 				},
@@ -2569,6 +2576,10 @@ func TestUpdateWeakDependents(t *testing.T) {
 				Name:  weak1Name.Name,
 				API:   weakAPI,
 				Model: weakModel,
+				DiffingAttributes: &someTypeWithWeakAndStrongDepsConfig{
+					deps:     []resource.Name{base2Name},
+					weakDeps: []resource.Name{base1Name},
+				},
 				ConvertedAttributes: &someTypeWithWeakAndStrongDepsConfig{
 					deps:     []resource.Name{base2Name},
 					weakDeps: []resource.Name{base1Name},
@@ -3316,6 +3327,7 @@ func TestReconfigureModelRebuild(t *testing.T) {
 				Name:                "one",
 				Model:               model1,
 				API:                 mockAPI,
+				DiffingAttributes:   resource.NoNativeConfig{},
 				ConvertedAttributes: resource.NoNativeConfig{},
 			},
 		},
@@ -3535,6 +3547,12 @@ func TestResourceConstructTimeout(t *testing.T) {
 				Name:  "fakewheel",
 				API:   base.API,
 				Model: wheeled.Model,
+				DiffingAttributes: &wheeled.Config{
+					Right:                []string{"left", "right"},
+					Left:                 []string{"left", "right"},
+					WheelCircumferenceMM: 1,
+					WidthMM:              2,
+				},
 				ConvertedAttributes: &wheeled.Config{
 					Right:                []string{"left", "right"},
 					Left:                 []string{"left", "right"},
@@ -3547,12 +3565,14 @@ func TestResourceConstructTimeout(t *testing.T) {
 				Name:                "left",
 				API:                 motor.API,
 				Model:               fakeModel,
+				DiffingAttributes:   &fakemotor.Config{},
 				ConvertedAttributes: &fakemotor.Config{},
 			},
 			{
 				Name:                "right",
 				API:                 motor.API,
 				Model:               fakeModel,
+				DiffingAttributes:   &fakemotor.Config{},
 				ConvertedAttributes: &fakemotor.Config{},
 			},
 		},
@@ -3579,6 +3599,12 @@ func TestResourceConstructTimeout(t *testing.T) {
 				Name:  "fakewheel",
 				API:   base.API,
 				Model: wheeled.Model,
+				DiffingAttributes: &wheeled.Config{
+					Right:                []string{"right"},
+					Left:                 []string{"left"},
+					WheelCircumferenceMM: 1,
+					WidthMM:              2,
+				},
 				ConvertedAttributes: &wheeled.Config{
 					Right:                []string{"right"},
 					Left:                 []string{"left"},
@@ -3591,12 +3617,14 @@ func TestResourceConstructTimeout(t *testing.T) {
 				Name:                "left",
 				API:                 motor.API,
 				Model:               fakeModel,
+				DiffingAttributes:   &fakemotor.Config{},
 				ConvertedAttributes: &fakemotor.Config{},
 			},
 			{
 				Name:                "right",
 				API:                 motor.API,
 				Model:               fakeModel,
+				DiffingAttributes:   &fakemotor.Config{},
 				ConvertedAttributes: &fakemotor.Config{},
 			},
 		},


### PR DESCRIPTION
We diff new configurations from the cloud against the current configuration to determine whether a `Reconfigure` is needed. Prior to this patch, component code could alter the configuration object for the purpose of assigning defaults. This modification would cause spurious reconfigures.