### PR TITLE
[DATA-1872] Don't gunzip non-gzipped files.

### DIFF
--- a/cli/data.go
+++ b/cli/data.go
@@ -352,10 +352,14 @@ func downloadBinary(ctx context.Context, client datapb.DataServiceClient, dst st
 		return err
 	}
 
-	gzippedBytes := datum.GetBinary()
-	r, err := gzip.NewReader(bytes.NewBuffer(gzippedBytes))
-	if err != nil {
-		return err
+	bin := datum.GetBinary()
+
+	r := io.NopCloser(bytes.NewReader(bin))
+	if datum.GetMetadata().GetFileExt() == ".gz" {
+		r, err = gzip.NewReader(r)
+		if err != nil {
+			return err
+		}
 	}
 
 	//nolint:gosec


### PR DESCRIPTION
# Context
We no longer gzip files that are already compressed. This includes jpg files. The CLI wasn't updated to not try to gunzip all files.

This updates the cli to only try to gunzip `.gz` files.

# Ticket

https://viam.atlassian.net/browse/DATA-1872

# Testing
Validated that not seeing those `gzip: invalid header` errors anymore, and that downloaded files are valid jpegs.