### PR TITLE
RSDK-4414: flaky gpiostepper test fix

### DIFF
--- a/components/motor/gpiostepper/gpiostepper_test.go
+++ b/components/motor/gpiostepper/gpiostepper_test.go
@@ -369,6 +369,7 @@ func TestRunning(t *testing.T) {
 			on, _, err := m.IsPowered(ctx, nil)
 			test.That(tb, err, test.ShouldBeNil)
 			test.That(tb, on, test.ShouldEqual, true)
+			test.That(tb, s.stepPosition, test.ShouldBeGreaterThan, 0)
 		})
 
 		cancel()

--- a/components/motor/gpiostepper/gpiostepper_test.go
+++ b/components/motor/gpiostepper/gpiostepper_test.go
@@ -369,7 +369,10 @@ func TestRunning(t *testing.T) {
 			on, _, err := m.IsPowered(ctx, nil)
 			test.That(tb, err, test.ShouldBeNil)
 			test.That(tb, on, test.ShouldEqual, true)
-			test.That(tb, s.stepPosition, test.ShouldBeGreaterThan, 0)
+
+			p, err := m.Position(ctx, nil)
+			test.That(tb, err, test.ShouldBeNil)
+			test.That(tb, p, test.ShouldBeGreaterThan, 0)
 		})
 
 		cancel()


### PR DESCRIPTION
Very hard to actually repro this, only failed once in CI and I couldn't repro locally. Theory is that IsPowered() returns true before doCycle() is ever called, so it's possible for IsPowered == true while position is still 0.
