### PR TITLE
add end session to slam overrides

### DIFF
--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -312,6 +312,7 @@ const handleEndMapping = () => {
   mappingSessionEnded = true;
   clearRefresh();
   clearInterval(durationInterval);
+  overrides?.endMappingSession(sessionId);
 };
 
 const formatDisplayTime = (time: number) =>

--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -303,6 +303,7 @@ const handleStartMapping = async () => {
     } catch {
       hasActiveSession = false;
       sessionDuration = 0;
+      clearInterval(durationInterval);
     }
   }
 };

--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -296,9 +296,14 @@ const handleStartMapping = async () => {
       return;
     }
 
-    hasActiveSession = true;
-    sessionId = await overrides.startMappingSession(mapName);
-    startMappingIntervals(Date.now());
+    try {
+      hasActiveSession = true;
+      sessionId = await overrides.startMappingSession(mapName);
+      startMappingIntervals(Date.now());
+    } catch {
+      hasActiveSession = false;
+      sessionDuration = 0;
+    }
   }
 };
 


### PR DESCRIPTION
Forgot to actually call `endSession` override on SLAM card

-- EDIT -- 
Discovered when testing app overrides that when start session fails, the timer + end session displays, though it doesn't tick. Just added some error handling to make sure we reset to initial state and clear any intervals