### PR TITLE
RSDK-4334 add option to disable server discovery via mdns

### DIFF
--- a/robot/web/options/options.go
+++ b/robot/web/options/options.go
@@ -68,7 +68,7 @@ type Options struct {
 	WebRTCOnPeerAdded   func(pc *webrtc.PeerConnection)
 	WebRTCOnPeerRemoved func(pc *webrtc.PeerConnection)
 
-	MulticastDNS bool
+	DisableMulticastDNS bool
 }
 
 // New returns a default set of options which will have the

--- a/robot/web/options/options.go
+++ b/robot/web/options/options.go
@@ -67,6 +67,8 @@ type Options struct {
 
 	WebRTCOnPeerAdded   func(pc *webrtc.PeerConnection)
 	WebRTCOnPeerRemoved func(pc *webrtc.PeerConnection)
+
+	DisableMulticastDNS bool
 }
 
 // New returns a default set of options which will have the

--- a/robot/web/options/options.go
+++ b/robot/web/options/options.go
@@ -68,7 +68,7 @@ type Options struct {
 	WebRTCOnPeerAdded   func(pc *webrtc.PeerConnection)
 	WebRTCOnPeerRemoved func(pc *webrtc.PeerConnection)
 
-	DisableMulticastDNS bool
+	MulticastDNS bool
 }
 
 // New returns a default set of options which will have the

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -927,7 +927,7 @@ func (svc *webService) initRPCOptions(listenerTCPAddr *net.TCPAddr, options webo
 			OnPeerRemoved:             options.WebRTCOnPeerRemoved,
 		}),
 	}
-	if options.DisableMulticastDNS {
+	if !options.MulticastDNS {
 		rpcOpts = append(rpcOpts, rpc.WithDisableMulticastDNS())
 	}
 

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -927,7 +927,7 @@ func (svc *webService) initRPCOptions(listenerTCPAddr *net.TCPAddr, options webo
 			OnPeerRemoved:             options.WebRTCOnPeerRemoved,
 		}),
 	}
-	if !options.MulticastDNS {
+	if options.DisableMulticastDNS {
 		rpcOpts = append(rpcOpts, rpc.WithDisableMulticastDNS())
 	}
 

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -927,6 +927,10 @@ func (svc *webService) initRPCOptions(listenerTCPAddr *net.TCPAddr, options webo
 			OnPeerRemoved:             options.WebRTCOnPeerRemoved,
 		}),
 	}
+	if options.DisableMulticastDNS {
+		rpcOpts = append(rpcOpts, rpc.WithDisableMulticastDNS())
+	}
+
 	var unaryInterceptors []googlegrpc.UnaryServerInterceptor
 
 	unaryInterceptors = append(unaryInterceptors, ensureTimeoutUnaryInterceptor)

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -54,7 +54,7 @@ type Arguments struct {
 	RevealSensitiveConfigDiffs bool   `flag:"reveal-sensitive-config-diffs,usage=show config diffs"`
 	UntrustedEnv               bool   `flag:"untrusted-env,usage=disable processes and shell from running in a untrusted environment"`
 	OutputTelemetry            bool   `flag:"output-telemetry,usage=print out telemetry data (metrics and spans)"`
-	DisableMulticastDNS        bool   `flag:"disable-mdns,usage=disable server discovery through multicast DNS"`
+	MulticastDNS               bool   `flag:"mdns,default=true,usage=enable server discovery through multicast DNS"`
 }
 
 type robotServer struct {
@@ -199,7 +199,7 @@ func (s *robotServer) createWebOptions(cfg *config.Config) (weboptions.Options, 
 	options.SharedDir = s.args.SharedDir
 	options.Debug = s.args.Debug || cfg.Debug
 	options.WebRTC = s.args.WebRTC
-	options.DisableMulticastDNS = s.args.DisableMulticastDNS
+	options.MulticastDNS = s.args.MulticastDNS
 	if cfg.Cloud != nil && s.args.AllowInsecureCreds {
 		options.SignalingDialOpts = append(options.SignalingDialOpts, rpc.WithAllowInsecureWithCredentialsDowngrade())
 	}

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -54,7 +54,7 @@ type Arguments struct {
 	RevealSensitiveConfigDiffs bool   `flag:"reveal-sensitive-config-diffs,usage=show config diffs"`
 	UntrustedEnv               bool   `flag:"untrusted-env,usage=disable processes and shell from running in a untrusted environment"`
 	OutputTelemetry            bool   `flag:"output-telemetry,usage=print out telemetry data (metrics and spans)"`
-	MulticastDNS               bool   `flag:"mdns,default=true,usage=enable server discovery through multicast DNS"`
+	DisableMulticastDNS        bool   `flag:"disable-mdns,usage=disable server discovery through multicast DNS"`
 }
 
 type robotServer struct {
@@ -199,7 +199,7 @@ func (s *robotServer) createWebOptions(cfg *config.Config) (weboptions.Options, 
 	options.SharedDir = s.args.SharedDir
 	options.Debug = s.args.Debug || cfg.Debug
 	options.WebRTC = s.args.WebRTC
-	options.DisableMulticastDNS = !s.args.MulticastDNS
+	options.DisableMulticastDNS = s.args.DisableMulticastDNS
 	if cfg.Cloud != nil && s.args.AllowInsecureCreds {
 		options.SignalingDialOpts = append(options.SignalingDialOpts, rpc.WithAllowInsecureWithCredentialsDowngrade())
 	}

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -199,7 +199,7 @@ func (s *robotServer) createWebOptions(cfg *config.Config) (weboptions.Options, 
 	options.SharedDir = s.args.SharedDir
 	options.Debug = s.args.Debug || cfg.Debug
 	options.WebRTC = s.args.WebRTC
-	options.MulticastDNS = s.args.MulticastDNS
+	options.DisableMulticastDNS = !s.args.MulticastDNS
 	if cfg.Cloud != nil && s.args.AllowInsecureCreds {
 		options.SignalingDialOpts = append(options.SignalingDialOpts, rpc.WithAllowInsecureWithCredentialsDowngrade())
 	}

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -54,6 +54,7 @@ type Arguments struct {
 	RevealSensitiveConfigDiffs bool   `flag:"reveal-sensitive-config-diffs,usage=show config diffs"`
 	UntrustedEnv               bool   `flag:"untrusted-env,usage=disable processes and shell from running in a untrusted environment"`
 	OutputTelemetry            bool   `flag:"output-telemetry,usage=print out telemetry data (metrics and spans)"`
+	DisableMulticastDNS        bool   `flag:"disable-mdns,usage=disable server discovery through multicast DNS"`
 }
 
 type robotServer struct {
@@ -198,6 +199,7 @@ func (s *robotServer) createWebOptions(cfg *config.Config) (weboptions.Options, 
 	options.SharedDir = s.args.SharedDir
 	options.Debug = s.args.Debug || cfg.Debug
 	options.WebRTC = s.args.WebRTC
+	options.DisableMulticastDNS = s.args.DisableMulticastDNS
 	if cfg.Cloud != nil && s.args.AllowInsecureCreds {
 		options.SignalingDialOpts = append(options.SignalingDialOpts, rpc.WithAllowInsecureWithCredentialsDowngrade())
 	}


### PR DESCRIPTION
Mainly to support [a more rigorous dial scenario testing](https://github.com/viamrobotics/sdk-integration-tests/pull/14), but probably a useful configuration to expose in general.