### PR TITLE
Don't balk at nonexistent SPI buses if they're unused

### DIFF
--- a/components/board/genericlinux/i2c.go
+++ b/components/board/genericlinux/i2c.go
@@ -69,7 +69,7 @@ func (bus *I2cBus) OpenHandle(addr byte) (board.I2CHandle, error) {
 	if bus.closeableBus == nil {
 		newBus, err := i2creg.Open(bus.deviceName)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		bus.closeableBus = newBus
 	}

--- a/components/board/genericlinux/i2c.go
+++ b/components/board/genericlinux/i2c.go
@@ -63,12 +63,13 @@ func (bus *I2cBus) reset(deviceName string) error {
 // communicating with a device at a specific I2C handle. Opening a handle locks the I2C bus so
 // nothing else can use it, and closing the handle unlocks the bus again.
 func (bus *I2cBus) OpenHandle(addr byte) (board.I2CHandle, error) {
-	bus.mu.Lock() // Lock the bus so no other handle can use it until this one is closed.
+	bus.mu.Lock() // Lock the bus so no other handle can use it until this handle is closed.
 
 	// If we haven't yet connected to the bus itself, do so now.
 	if bus.closeableBus == nil {
 		newBus, err := i2creg.Open(bus.deviceName)
 		if err != nil {
+			bus.mu.Unlock() // We never created a handle, so unlock the bus for next time.
 			return nil, err
 		}
 		bus.closeableBus = newBus


### PR DESCRIPTION
This is a follow-up to a discussion on Slack. Hazal had reported that, when she names but does not use a nonexistent bus, she encounters all kinds of trouble, and I said I'd take a look. Here's what I found:
- On an Orin Nano, you would have trouble naming a nonexistent I2C bus, hence this PR.
- On an Orin Nano, you can name nonexistent SPI buses, and it's okay as long as you don't use them.
- On an rpi, you can name nonexistent I2C buses, and it's okay as long as you don't use them.
- On an rpi, you cannot name nonexistent SPI buses: we return an error during reconfiguration because the code knows the board only has 2 SPI buses. I'd prefer to check for this during `Validate()` instead, but the rpi board uses the genericlinux config, and its `Validate` cannot assume that only buses 0 and 1 are allowed, hence why this is in `reconfigureSpis()` instead. It's not great, but I can't see an obviously better version (Go doesn't obviously let you override a function implementation in a subclass, because subclasses don't really exist and struct embeddings don't play well with the JSON parsing).

In this PR:
- We used to open the I2C bus immediately (in `reset()`, which is called from within `NewI2cBus()`). Now, `reset()` merely closes any open old bus, and stores the name for later.
- `OpenHandle()` used to assume the I2C bus was already opened, and give you a handle to it. Now, we first check if the bus is nil and connect to it if so (using the device name stored earlier).

It turns out the `I2cBus` struct has always had a place to store the device name, but it has been unused until now! :flushed: I'm surprised the linter didn't warn us about this.

Tried on an Orin Nano: seems to work fine!