### PR TITLE
[hot-fix] IMUWIT Angular Velocity Unit Correction (deg/sec -> rad/sec)

### DIFF
--- a/components/movementsensor/imuwit/imu.go
+++ b/components/movementsensor/imuwit/imu.go
@@ -308,9 +308,9 @@ func (imu *wit) parseWIT(line string) error {
 		if len(line) < 7 {
 			return fmt.Errorf("line is wrong for imu angularVelocity %d %v", len(line), line)
 		}
-		imu.angularVelocity.X = scale(line[1], line[2], 2000)
-		imu.angularVelocity.Y = scale(line[3], line[4], 2000)
-		imu.angularVelocity.Z = scale(line[5], line[6], 2000)
+		imu.angularVelocity.X = rutils.DegToRad(scale(line[1], line[2], 2000))
+		imu.angularVelocity.Y = rutils.DegToRad(scale(line[3], line[4], 2000))
+		imu.angularVelocity.Z = rutils.DegToRad(scale(line[5], line[6], 2000))
 	}
 
 	if line[0] == 0x53 {


### PR DESCRIPTION
During IMU integration we discovered that the imuwit is returning data in degree/sec instead of the RDK standard of rad/sec.

From IMUWIT datasheet:
<img width="661" alt="image" src="https://github.com/viamrobotics/rdk/assets/34897732/766e1bc7-737b-44f3-b411-761b3b39aa42">
