### PR TITLE
[RSDK-4639] Make sure Orin Nanos have hardware PWM support

### DIFF
--- a/components/board/jetson/data.go
+++ b/components/board/jetson/data.go
@@ -274,6 +274,7 @@ var jetsonOrinNXPins = []genericlinux.PinDefinition{
 	{Name: "26", DeviceName: "gpiochip0", LineNumber: 137, PwmChipSysfsDir: "", PwmID: -1},
 	{Name: "29", DeviceName: "gpiochip0", LineNumber: 105, PwmChipSysfsDir: "", PwmID: -1},
 	{Name: "31", DeviceName: "gpiochip0", LineNumber: 106, PwmChipSysfsDir: "", PwmID: -1},
+	// Pin 32 supposedly has hardware PWM support, but we've been unable to turn it on.
 	{Name: "32", DeviceName: "gpiochip0", LineNumber: 41, PwmChipSysfsDir: "", PwmID: -1},
 	{Name: "33", DeviceName: "gpiochip0", LineNumber: 43, PwmChipSysfsDir: "32c0000.pwm", PwmID: 0},
 	{Name: "35", DeviceName: "gpiochip0", LineNumber: 53, PwmChipSysfsDir: "", PwmID: -1},


### PR DESCRIPTION
Tried on a board: pins 15 and 33 work great! Pin 32 claims to have PWM support, but I couldn't figure it out. I ran `jetson-io.py`, and it said it was already enabled. but there are 4 PWM chips with 1 line each:
- Device `3280000.pwm` sends output to pin 15. It works great.
- Device `32c0000.pwm` sends output to pin 33. It works great.
- Device `32a0000.pwm` claims the device is already in use and cannot be exported, even immediately after rebooting when nothing unusual should already be in use.
- Device `39c0000.tachometer` doesn't seem to do anything obvious.

but the 2 existing PWM lines are probably good enough for most purposes. 