### PR TITLE
RSDK-3979 - Remove "Get" from slam service method names

### DIFF
--- a/components/base/kinematicbase/differentialDrive_test.go
+++ b/components/base/kinematicbase/differentialDrive_test.go
@@ -114,7 +114,7 @@ func TestErrorState(t *testing.T) {
 
 	// make injected slam service
 	slam := inject.NewSLAMService("the slammer")
-	slam.GetPositionFunc = func(ctx context.Context) (spatialmath.Pose, string, error) {
+	slam.PositionFunc = func(ctx context.Context) (spatialmath.Pose, string, error) {
 		return spatialmath.NewZeroPose(), "", nil
 	}
 
@@ -151,7 +151,7 @@ func buildTestDDK(
 
 	// make a SLAM service and get its limits
 	fakeSLAM := fake.NewSLAM(slam.Named("test"), logger)
-	limits, err := fakeSLAM.GetLimits(ctx)
+	limits, err := fakeSLAM.Limits(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/components/base/kinematicbase/fake_kinematics_test.go
+++ b/components/base/kinematicbase/fake_kinematics_test.go
@@ -33,7 +33,7 @@ func TestNewFakeKinematics(t *testing.T) {
 	b, err := fakebase.NewBase(ctx, resource.Dependencies{}, conf, logger)
 	test.That(t, err, test.ShouldBeNil)
 	fakeSLAM := fake.NewSLAM(slam.Named("test"), logger)
-	limits, err := fakeSLAM.GetLimits(ctx)
+	limits, err := fakeSLAM.Limits(ctx)
 	test.That(t, err, test.ShouldBeNil)
 	limits = append(limits, referenceframe.Limit{-2 * math.Pi, 2 * math.Pi})
 

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -448,7 +448,7 @@ func (ms *builtIn) planMoveOnMap(
 	}
 
 	// gets the extents of the SLAM map
-	limits, err := slam.GetLimits(ctx, slamSvc)
+	limits, err := slam.Limits(ctx, slamSvc)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -492,7 +492,7 @@ func (ms *builtIn) planMoveOnMap(
 	}
 
 	// get point cloud data in the form of bytes from pcd
-	pointCloudData, err := slam.GetPointCloudMapFull(ctx, slamSvc)
+	pointCloudData, err := slam.PointCloudMapFull(ctx, slamSvc)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
 	"github.com/pkg/errors"
+
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	"go.viam.com/test"
@@ -88,10 +89,10 @@ func createInjectedMovementSensor(name string, gpsPoint *geo.Point) *inject.Move
 
 func createInjectedSlam(name, pcdPath string) *inject.SLAMService {
 	injectSlam := inject.NewSLAMService(name)
-	injectSlam.GetPointCloudMapFunc = func(ctx context.Context) (func() ([]byte, error), error) {
+	injectSlam.PointCloudMapFunc = func(ctx context.Context) (func() ([]byte, error), error) {
 		return getPointCloudMap(filepath.Clean(artifact.MustPath(pcdPath)))
 	}
-	injectSlam.GetPositionFunc = func(ctx context.Context) (spatialmath.Pose, string, error) {
+	injectSlam.PositionFunc = func(ctx context.Context) (spatialmath.Pose, string, error) {
 		return spatialmath.NewZeroPose(), "", nil
 	}
 	return injectSlam

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
 	"github.com/pkg/errors"
-
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	"go.viam.com/test"

--- a/services/motion/localizer.go
+++ b/services/motion/localizer.go
@@ -30,7 +30,7 @@ func NewSLAMLocalizer(slam slam.Service) Localizer {
 
 // CurrentPosition returns slam's current position.
 func (s *slamLocalizer) CurrentPosition(ctx context.Context) (*referenceframe.PoseInFrame, error) {
-	pose, _, err := s.GetPosition(ctx)
+	pose, _, err := s.Position(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/services/navigation/builtin/builtin_test.go
+++ b/services/navigation/builtin/builtin_test.go
@@ -130,7 +130,7 @@ func TestStartWaypoint(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	fakeSlam := fakeslam.NewSLAM(slam.Named("foo"), logger)
-	limits, err := fakeSlam.GetLimits(ctx)
+	limits, err := fakeSlam.Limits(ctx)
 	test.That(t, err, test.ShouldBeNil)
 
 	localizer := motion.NewSLAMLocalizer(fakeSlam)

--- a/services/slam/client.go
+++ b/services/slam/client.go
@@ -44,9 +44,9 @@ func NewClientFromConn(
 	return c, nil
 }
 
-// GetPosition creates a request, calls the slam service GetPosition, and parses the response into a Pose with a component reference string.
-func (c *client) GetPosition(ctx context.Context) (spatialmath.Pose, string, error) {
-	ctx, span := trace.StartSpan(ctx, "slam::client::GetPosition")
+// Position creates a request, calls the slam service Position, and parses the response into a Pose with a component reference string.
+func (c *client) Position(ctx context.Context) (spatialmath.Pose, string, error) {
+	ctx, span := trace.StartSpan(ctx, "slam::client::Position")
 	defer span.End()
 
 	req := &pb.GetPositionRequest{
@@ -64,28 +64,28 @@ func (c *client) GetPosition(ctx context.Context) (spatialmath.Pose, string, err
 	return spatialmath.NewPoseFromProtobuf(p), componentReference, nil
 }
 
-// GetPointCloudMap creates a request, calls the slam service GetPointCloudMap and returns a callback
+// PointCloudMap creates a request, calls the slam service PointCloudMap and returns a callback
 // function which will return the next chunk of the current pointcloud map when called.
-func (c *client) GetPointCloudMap(ctx context.Context) (func() ([]byte, error), error) {
-	ctx, span := trace.StartSpan(ctx, "slam::client::GetPointCloudMap")
+func (c *client) PointCloudMap(ctx context.Context) (func() ([]byte, error), error) {
+	ctx, span := trace.StartSpan(ctx, "slam::client::PointCloudMap")
 	defer span.End()
 
-	return grpchelper.GetPointCloudMapCallback(ctx, c.name, c.client)
+	return grpchelper.PointCloudMapCallback(ctx, c.name, c.client)
 }
 
-// GetInternalState creates a request, calls the slam service GetInternalState and returns a callback
+// InternalState creates a request, calls the slam service InternalState and returns a callback
 // function which will return the next chunk of the current internal state of the slam algo when called.
-func (c *client) GetInternalState(ctx context.Context) (func() ([]byte, error), error) {
-	ctx, span := trace.StartSpan(ctx, "slam::client::GetInternalState")
+func (c *client) InternalState(ctx context.Context) (func() ([]byte, error), error) {
+	ctx, span := trace.StartSpan(ctx, "slam::client::InternalState")
 	defer span.End()
 
-	return grpchelper.GetInternalStateCallback(ctx, c.name, c.client)
+	return grpchelper.InternalStateCallback(ctx, c.name, c.client)
 }
 
-// GetLatestMapInfo creates a request, calls the slam service GetLatestMapInfo, and
+// LatestMapInfo creates a request, calls the slam service LatestMapInfo, and
 // returns the timestamp of the last update to the map.
-func (c *client) GetLatestMapInfo(ctx context.Context) (time.Time, error) {
-	ctx, span := trace.StartSpan(ctx, "slam::client::GetLatestMapInfo")
+func (c *client) LatestMapInfo(ctx context.Context) (time.Time, error) {
+	ctx, span := trace.StartSpan(ctx, "slam::client::LatestMapInfo")
 	defer span.End()
 
 	req := &pb.GetLatestMapInfoRequest{

--- a/services/slam/client_test.go
+++ b/services/slam/client_test.go
@@ -118,13 +118,13 @@ func TestClientWorkingService(t *testing.T) {
 
 		workingSLAMClient, err := slam.NewClientFromConn(context.Background(), conn, "", slam.Named(nameSucc), logger)
 		test.That(t, err, test.ShouldBeNil)
-		// test get position
+		// test position
 		pose, componentRef, err := workingSLAMClient.Position(context.Background())
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, spatial.PoseAlmostEqual(poseSucc, pose), test.ShouldBeTrue)
 		test.That(t, componentRef, test.ShouldEqual, componentRefSucc)
 
-		// test get point cloud map
+		// test point cloud map
 		fullBytesPCD, err := slam.PointCloudMapFull(context.Background(), workingSLAMClient)
 		test.That(t, err, test.ShouldBeNil)
 		// comparing raw bytes to ensure order is correct
@@ -132,12 +132,12 @@ func TestClientWorkingService(t *testing.T) {
 		// comparing pointclouds to ensure PCDs are correct
 		testhelper.TestComparePointCloudsFromPCDs(t, fullBytesPCD, pcd)
 
-		// test get internal state
+		// test internal state
 		fullBytesInternalState, err := slam.InternalStateFull(context.Background(), workingSLAMClient)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, fullBytesInternalState, test.ShouldResemble, internalStateSucc)
 
-		// test get latest map info
+		// test latest map info
 		timestamp, err := workingSLAMClient.LatestMapInfo(context.Background())
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, timestamp, test.ShouldResemble, timestampSucc)
@@ -151,13 +151,13 @@ func TestClientWorkingService(t *testing.T) {
 		workingDialedClient, err := slam.NewClientFromConn(context.Background(), conn, "", slam.Named(nameSucc), logger)
 		test.That(t, err, test.ShouldBeNil)
 
-		// test get position
+		// test position
 		pose, componentRef, err := workingDialedClient.Position(context.Background())
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, spatial.PoseAlmostEqual(poseSucc, pose), test.ShouldBeTrue)
 		test.That(t, componentRef, test.ShouldEqual, componentRefSucc)
 
-		// test get point cloud map
+		// test point cloud map
 		fullBytesPCD, err := slam.PointCloudMapFull(context.Background(), workingDialedClient)
 		test.That(t, err, test.ShouldBeNil)
 		// comparing raw bytes to ensure order is correct
@@ -165,12 +165,12 @@ func TestClientWorkingService(t *testing.T) {
 		// comparing pointclouds to ensure PCDs are correct
 		testhelper.TestComparePointCloudsFromPCDs(t, fullBytesPCD, pcd)
 
-		// test get internal state
+		// test internal state
 		fullBytesInternalState, err := slam.InternalStateFull(context.Background(), workingDialedClient)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, fullBytesInternalState, test.ShouldResemble, internalStateSucc)
 
-		// test get latest map info
+		// test latest map info
 		timestamp, err := workingDialedClient.LatestMapInfo(context.Background())
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, timestamp, test.ShouldResemble, timestampSucc)
@@ -192,13 +192,13 @@ func TestClientWorkingService(t *testing.T) {
 		dialedClient, err := resourceAPI.RPCClient(context.Background(), conn, "", slam.Named(nameSucc), logger)
 		test.That(t, err, test.ShouldBeNil)
 
-		// test get position
+		// test position
 		pose, componentRef, err := dialedClient.Position(context.Background())
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, spatial.PoseAlmostEqual(poseSucc, pose), test.ShouldBeTrue)
 		test.That(t, componentRef, test.ShouldEqual, componentRefSucc)
 
-		// test get point cloud map
+		// test point cloud map
 		fullBytesPCD, err := slam.PointCloudMapFull(context.Background(), dialedClient)
 		test.That(t, err, test.ShouldBeNil)
 		// comparing raw bytes to ensure order is correct
@@ -206,12 +206,12 @@ func TestClientWorkingService(t *testing.T) {
 		// comparing pointclouds to ensure PCDs are correct
 		testhelper.TestComparePointCloudsFromPCDs(t, fullBytesPCD, pcd)
 
-		// test get internal state
+		// test internal state
 		fullBytesInternalState, err := slam.InternalStateFull(context.Background(), dialedClient)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, fullBytesInternalState, test.ShouldResemble, internalStateSucc)
 
-		// test get latest map info
+		// test latest map info
 		timestamp, err := dialedClient.LatestMapInfo(context.Background())
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, timestamp, test.ShouldResemble, timestampSucc)
@@ -278,23 +278,23 @@ func TestFailingClient(t *testing.T) {
 		_, err = failingSLAMClient.InternalState(cancelCtx)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "context cancel")
 
-		// test get position
+		// test position
 		pose, componentRef, err := failingSLAMClient.Position(context.Background())
 		test.That(t, err.Error(), test.ShouldContainSubstring, "failure to get position")
 		test.That(t, pose, test.ShouldBeNil)
 		test.That(t, componentRef, test.ShouldBeEmpty)
 
-		// test get pointcloud map
+		// test pointcloud map
 		fullBytesPCD, err := slam.PointCloudMapFull(context.Background(), failingSLAMClient)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "failure during get pointcloud map")
 		test.That(t, fullBytesPCD, test.ShouldBeNil)
 
-		// test get internal state
+		// test internal state
 		fullBytesInternalState, err := slam.InternalStateFull(context.Background(), failingSLAMClient)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "failure during get internal state")
 		test.That(t, fullBytesInternalState, test.ShouldBeNil)
 
-		// test get latest map info
+		// test latest map info
 		timestamp, err := failingSLAMClient.LatestMapInfo(context.Background())
 		test.That(t, err.Error(), test.ShouldContainSubstring, "failure to get latest map info")
 		test.That(t, timestamp, test.ShouldResemble, time.Time{})
@@ -323,12 +323,12 @@ func TestFailingClient(t *testing.T) {
 		failingSLAMClient, err := slam.NewClientFromConn(context.Background(), conn, "", slam.Named(nameFail), logger)
 		test.That(t, err, test.ShouldBeNil)
 
-		// test get pointcloud map
+		// test pointcloud map
 		fullBytesPCD, err := slam.PointCloudMapFull(context.Background(), failingSLAMClient)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "failure during callback")
 		test.That(t, fullBytesPCD, test.ShouldBeNil)
 
-		// test get internal state
+		// test internal state
 		fullBytesInternalState, err := slam.InternalStateFull(context.Background(), failingSLAMClient)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "failure during callback")
 		test.That(t, fullBytesInternalState, test.ShouldBeNil)

--- a/services/slam/client_test.go
+++ b/services/slam/client_test.go
@@ -57,11 +57,11 @@ func TestClientWorkingService(t *testing.T) {
 
 	workingSLAMService := &inject.SLAMService{}
 
-	workingSLAMService.GetPositionFunc = func(ctx context.Context) (spatial.Pose, string, error) {
+	workingSLAMService.PositionFunc = func(ctx context.Context) (spatial.Pose, string, error) {
 		return poseSucc, componentRefSucc, nil
 	}
 
-	workingSLAMService.GetPointCloudMapFunc = func(ctx context.Context) (func() ([]byte, error), error) {
+	workingSLAMService.PointCloudMapFunc = func(ctx context.Context) (func() ([]byte, error), error) {
 		reader := bytes.NewReader(pcd)
 		clientBuffer := make([]byte, chunkSizePointCloud)
 		f := func() ([]byte, error) {
@@ -74,7 +74,7 @@ func TestClientWorkingService(t *testing.T) {
 		return f, nil
 	}
 
-	workingSLAMService.GetInternalStateFunc = func(ctx context.Context) (func() ([]byte, error), error) {
+	workingSLAMService.InternalStateFunc = func(ctx context.Context) (func() ([]byte, error), error) {
 		reader := bytes.NewReader(internalStateSucc)
 		clientBuffer := make([]byte, chunkSizeInternalState)
 		f := func() ([]byte, error) {
@@ -88,7 +88,7 @@ func TestClientWorkingService(t *testing.T) {
 		return f, nil
 	}
 
-	workingSLAMService.GetLatestMapInfoFunc = func(ctx context.Context) (time.Time, error) {
+	workingSLAMService.LatestMapInfoFunc = func(ctx context.Context) (time.Time, error) {
 		return timestampSucc, nil
 	}
 
@@ -119,13 +119,13 @@ func TestClientWorkingService(t *testing.T) {
 		workingSLAMClient, err := slam.NewClientFromConn(context.Background(), conn, "", slam.Named(nameSucc), logger)
 		test.That(t, err, test.ShouldBeNil)
 		// test get position
-		pose, componentRef, err := workingSLAMClient.GetPosition(context.Background())
+		pose, componentRef, err := workingSLAMClient.Position(context.Background())
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, spatial.PoseAlmostEqual(poseSucc, pose), test.ShouldBeTrue)
 		test.That(t, componentRef, test.ShouldEqual, componentRefSucc)
 
 		// test get point cloud map
-		fullBytesPCD, err := slam.GetPointCloudMapFull(context.Background(), workingSLAMClient)
+		fullBytesPCD, err := slam.PointCloudMapFull(context.Background(), workingSLAMClient)
 		test.That(t, err, test.ShouldBeNil)
 		// comparing raw bytes to ensure order is correct
 		test.That(t, fullBytesPCD, test.ShouldResemble, pcd)
@@ -133,12 +133,12 @@ func TestClientWorkingService(t *testing.T) {
 		testhelper.TestComparePointCloudsFromPCDs(t, fullBytesPCD, pcd)
 
 		// test get internal state
-		fullBytesInternalState, err := slam.GetInternalStateFull(context.Background(), workingSLAMClient)
+		fullBytesInternalState, err := slam.InternalStateFull(context.Background(), workingSLAMClient)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, fullBytesInternalState, test.ShouldResemble, internalStateSucc)
 
 		// test get latest map info
-		timestamp, err := workingSLAMClient.GetLatestMapInfo(context.Background())
+		timestamp, err := workingSLAMClient.LatestMapInfo(context.Background())
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, timestamp, test.ShouldResemble, timestampSucc)
 
@@ -152,13 +152,13 @@ func TestClientWorkingService(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		// test get position
-		pose, componentRef, err := workingDialedClient.GetPosition(context.Background())
+		pose, componentRef, err := workingDialedClient.Position(context.Background())
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, spatial.PoseAlmostEqual(poseSucc, pose), test.ShouldBeTrue)
 		test.That(t, componentRef, test.ShouldEqual, componentRefSucc)
 
 		// test get point cloud map
-		fullBytesPCD, err := slam.GetPointCloudMapFull(context.Background(), workingDialedClient)
+		fullBytesPCD, err := slam.PointCloudMapFull(context.Background(), workingDialedClient)
 		test.That(t, err, test.ShouldBeNil)
 		// comparing raw bytes to ensure order is correct
 		test.That(t, fullBytesPCD, test.ShouldResemble, pcd)
@@ -166,12 +166,12 @@ func TestClientWorkingService(t *testing.T) {
 		testhelper.TestComparePointCloudsFromPCDs(t, fullBytesPCD, pcd)
 
 		// test get internal state
-		fullBytesInternalState, err := slam.GetInternalStateFull(context.Background(), workingDialedClient)
+		fullBytesInternalState, err := slam.InternalStateFull(context.Background(), workingDialedClient)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, fullBytesInternalState, test.ShouldResemble, internalStateSucc)
 
 		// test get latest map info
-		timestamp, err := workingDialedClient.GetLatestMapInfo(context.Background())
+		timestamp, err := workingDialedClient.LatestMapInfo(context.Background())
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, timestamp, test.ShouldResemble, timestampSucc)
 
@@ -193,13 +193,13 @@ func TestClientWorkingService(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		// test get position
-		pose, componentRef, err := dialedClient.GetPosition(context.Background())
+		pose, componentRef, err := dialedClient.Position(context.Background())
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, spatial.PoseAlmostEqual(poseSucc, pose), test.ShouldBeTrue)
 		test.That(t, componentRef, test.ShouldEqual, componentRefSucc)
 
 		// test get point cloud map
-		fullBytesPCD, err := slam.GetPointCloudMapFull(context.Background(), dialedClient)
+		fullBytesPCD, err := slam.PointCloudMapFull(context.Background(), dialedClient)
 		test.That(t, err, test.ShouldBeNil)
 		// comparing raw bytes to ensure order is correct
 		test.That(t, fullBytesPCD, test.ShouldResemble, pcd)
@@ -207,12 +207,12 @@ func TestClientWorkingService(t *testing.T) {
 		testhelper.TestComparePointCloudsFromPCDs(t, fullBytesPCD, pcd)
 
 		// test get internal state
-		fullBytesInternalState, err := slam.GetInternalStateFull(context.Background(), dialedClient)
+		fullBytesInternalState, err := slam.InternalStateFull(context.Background(), dialedClient)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, fullBytesInternalState, test.ShouldResemble, internalStateSucc)
 
 		// test get latest map info
-		timestamp, err := dialedClient.GetLatestMapInfo(context.Background())
+		timestamp, err := dialedClient.LatestMapInfo(context.Background())
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, timestamp, test.ShouldResemble, timestampSucc)
 
@@ -235,19 +235,19 @@ func TestFailingClient(t *testing.T) {
 
 	failingSLAMService := &inject.SLAMService{}
 
-	failingSLAMService.GetPositionFunc = func(ctx context.Context) (spatial.Pose, string, error) {
+	failingSLAMService.PositionFunc = func(ctx context.Context) (spatial.Pose, string, error) {
 		return nil, "", errors.New("failure to get position")
 	}
 
-	failingSLAMService.GetPointCloudMapFunc = func(ctx context.Context) (func() ([]byte, error), error) {
+	failingSLAMService.PointCloudMapFunc = func(ctx context.Context) (func() ([]byte, error), error) {
 		return nil, errors.New("failure during get pointcloud map")
 	}
 
-	failingSLAMService.GetInternalStateFunc = func(ctx context.Context) (func() ([]byte, error), error) {
+	failingSLAMService.InternalStateFunc = func(ctx context.Context) (func() ([]byte, error), error) {
 		return nil, errors.New("failure during get internal state")
 	}
 
-	failingSLAMService.GetLatestMapInfoFunc = func(ctx context.Context) (time.Time, error) {
+	failingSLAMService.LatestMapInfoFunc = func(ctx context.Context) (time.Time, error) {
 		return time.Time{}, errors.New("failure to get latest map info")
 	}
 
@@ -273,43 +273,43 @@ func TestFailingClient(t *testing.T) {
 		ctx := context.Background()
 		cancelCtx, cancelFunc := context.WithCancel(ctx)
 		cancelFunc()
-		_, err = failingSLAMClient.GetPointCloudMap(cancelCtx)
+		_, err = failingSLAMClient.PointCloudMap(cancelCtx)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "context cancel")
-		_, err = failingSLAMClient.GetInternalState(cancelCtx)
+		_, err = failingSLAMClient.InternalState(cancelCtx)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "context cancel")
 
 		// test get position
-		pose, componentRef, err := failingSLAMClient.GetPosition(context.Background())
+		pose, componentRef, err := failingSLAMClient.Position(context.Background())
 		test.That(t, err.Error(), test.ShouldContainSubstring, "failure to get position")
 		test.That(t, pose, test.ShouldBeNil)
 		test.That(t, componentRef, test.ShouldBeEmpty)
 
 		// test get pointcloud map
-		fullBytesPCD, err := slam.GetPointCloudMapFull(context.Background(), failingSLAMClient)
+		fullBytesPCD, err := slam.PointCloudMapFull(context.Background(), failingSLAMClient)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "failure during get pointcloud map")
 		test.That(t, fullBytesPCD, test.ShouldBeNil)
 
 		// test get internal state
-		fullBytesInternalState, err := slam.GetInternalStateFull(context.Background(), failingSLAMClient)
+		fullBytesInternalState, err := slam.InternalStateFull(context.Background(), failingSLAMClient)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "failure during get internal state")
 		test.That(t, fullBytesInternalState, test.ShouldBeNil)
 
 		// test get latest map info
-		timestamp, err := failingSLAMClient.GetLatestMapInfo(context.Background())
+		timestamp, err := failingSLAMClient.LatestMapInfo(context.Background())
 		test.That(t, err.Error(), test.ShouldContainSubstring, "failure to get latest map info")
 		test.That(t, timestamp, test.ShouldResemble, time.Time{})
 
 		test.That(t, conn.Close(), test.ShouldBeNil)
 	})
 
-	failingSLAMService.GetPointCloudMapFunc = func(ctx context.Context) (func() ([]byte, error), error) {
+	failingSLAMService.PointCloudMapFunc = func(ctx context.Context) (func() ([]byte, error), error) {
 		f := func() ([]byte, error) {
 			return nil, errors.New("failure during callback")
 		}
 		return f, nil
 	}
 
-	failingSLAMService.GetInternalStateFunc = func(ctx context.Context) (func() ([]byte, error), error) {
+	failingSLAMService.InternalStateFunc = func(ctx context.Context) (func() ([]byte, error), error) {
 		f := func() ([]byte, error) {
 			return nil, errors.New("failure during callback")
 		}
@@ -324,12 +324,12 @@ func TestFailingClient(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		// test get pointcloud map
-		fullBytesPCD, err := slam.GetPointCloudMapFull(context.Background(), failingSLAMClient)
+		fullBytesPCD, err := slam.PointCloudMapFull(context.Background(), failingSLAMClient)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "failure during callback")
 		test.That(t, fullBytesPCD, test.ShouldBeNil)
 
 		// test get internal state
-		fullBytesInternalState, err := slam.GetInternalStateFull(context.Background(), failingSLAMClient)
+		fullBytesInternalState, err := slam.InternalStateFull(context.Background(), failingSLAMClient)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "failure during callback")
 		test.That(t, fullBytesInternalState, test.ShouldBeNil)
 

--- a/services/slam/collector.go
+++ b/services/slam/collector.go
@@ -13,21 +13,21 @@ import (
 type method int64
 
 const (
-	getPosition method = iota
-	getPointCloudMap
+	position method = iota
+	pointCloudMap
 )
 
 func (m method) String() string {
-	if m == getPosition {
-		return "GetPosition"
+	if m == position {
+		return "Position"
 	}
-	if m == getPointCloudMap {
-		return "GetPointCloudMap"
+	if m == pointCloudMap {
+		return "PointCloudMap"
 	}
 	return "Unknown"
 }
 
-func newGetPositionCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+func newPositionCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
 	slam, err := assertSLAM(resource)
 	if err != nil {
 		return nil, err
@@ -36,14 +36,14 @@ func newGetPositionCollector(resource interface{}, params data.CollectorParams) 
 	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (interface{}, error) {
 		pose, componentRef, err := slam.Position(ctx)
 		if err != nil {
-			return nil, data.FailedToReadErr(params.ComponentName, getPosition.String(), err)
+			return nil, data.FailedToReadErr(params.ComponentName, position.String(), err)
 		}
 		return &pb.GetPositionResponse{Pose: spatialmath.PoseToProtobuf(pose), ComponentReference: componentRef}, nil
 	})
 	return data.NewCollector(cFunc, params)
 }
 
-func newGetPointCloudMapCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+func newPointCloudMapCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
 	slam, err := assertSLAM(resource)
 	if err != nil {
 		return nil, err
@@ -52,12 +52,12 @@ func newGetPointCloudMapCollector(resource interface{}, params data.CollectorPar
 	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (interface{}, error) {
 		f, err := slam.PointCloudMap(ctx)
 		if err != nil {
-			return nil, data.FailedToReadErr(params.ComponentName, getPointCloudMap.String(), err)
+			return nil, data.FailedToReadErr(params.ComponentName, pointCloudMap.String(), err)
 		}
 
 		pcd, err := HelperConcatenateChunksToFull(f)
 		if err != nil {
-			return nil, data.FailedToReadErr(params.ComponentName, getPointCloudMap.String(), err)
+			return nil, data.FailedToReadErr(params.ComponentName, pointCloudMap.String(), err)
 		}
 
 		return pcd, nil

--- a/services/slam/collector.go
+++ b/services/slam/collector.go
@@ -34,7 +34,7 @@ func newGetPositionCollector(resource interface{}, params data.CollectorParams) 
 	}
 
 	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (interface{}, error) {
-		pose, componentRef, err := slam.GetPosition(ctx)
+		pose, componentRef, err := slam.Position(ctx)
 		if err != nil {
 			return nil, data.FailedToReadErr(params.ComponentName, getPosition.String(), err)
 		}
@@ -50,7 +50,7 @@ func newGetPointCloudMapCollector(resource interface{}, params data.CollectorPar
 	}
 
 	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (interface{}, error) {
-		f, err := slam.GetPointCloudMap(ctx)
+		f, err := slam.PointCloudMap(ctx)
 		if err != nil {
 			return nil, data.FailedToReadErr(params.ComponentName, getPointCloudMap.String(), err)
 		}

--- a/services/slam/fake/data_loader.go
+++ b/services/slam/fake/data_loader.go
@@ -47,7 +47,7 @@ const (
 	positionTemplate      = "%s/position/position_%d.json"
 )
 
-func fakeGetPointCloudMap(_ context.Context, datasetDir string, slamSvc *SLAM) (func() ([]byte, error), error) {
+func fakePointCloudMap(_ context.Context, datasetDir string, slamSvc *SLAM) (func() ([]byte, error), error) {
 	path := filepath.Clean(artifact.MustPath(fmt.Sprintf(pcdTemplate, datasetDir, slamSvc.getCount())))
 	slamSvc.logger.Debug("Reading " + path)
 	file, err := os.Open(path)
@@ -66,7 +66,7 @@ func fakeGetPointCloudMap(_ context.Context, datasetDir string, slamSvc *SLAM) (
 	return f, nil
 }
 
-func fakeGetInternalState(_ context.Context, datasetDir string, slamSvc *SLAM) (func() ([]byte, error), error) {
+func fakeInternalState(_ context.Context, datasetDir string, slamSvc *SLAM) (func() ([]byte, error), error) {
 	path := filepath.Clean(artifact.MustPath(fmt.Sprintf(internalStateTemplate, datasetDir, slamSvc.getCount())))
 	slamSvc.logger.Debug("Reading " + path)
 	file, err := os.Open(path)
@@ -85,7 +85,7 @@ func fakeGetInternalState(_ context.Context, datasetDir string, slamSvc *SLAM) (
 	return f, nil
 }
 
-func fakeGetPosition(_ context.Context, datasetDir string, slamSvc *SLAM) (spatialmath.Pose, string, error) {
+func fakePosition(_ context.Context, datasetDir string, slamSvc *SLAM) (spatialmath.Pose, string, error) {
 	path := filepath.Clean(artifact.MustPath(fmt.Sprintf(positionTemplate, datasetDir, slamSvc.getCount())))
 	slamSvc.logger.Debug("Reading " + path)
 	data, err := os.ReadFile(path)

--- a/services/slam/fake/slam.go
+++ b/services/slam/fake/slam.go
@@ -64,34 +64,34 @@ func (slamSvc *SLAM) getCount() int {
 	return slamSvc.dataCount
 }
 
-// GetPosition returns a Pose and a component reference string of the robot's current location according to SLAM.
-func (slamSvc *SLAM) GetPosition(ctx context.Context) (spatialmath.Pose, string, error) {
-	ctx, span := trace.StartSpan(ctx, "slam::fake::GetPosition")
+// Position returns a Pose and a component reference string of the robot's current location according to SLAM.
+func (slamSvc *SLAM) Position(ctx context.Context) (spatialmath.Pose, string, error) {
+	ctx, span := trace.StartSpan(ctx, "slam::fake::Position")
 	defer span.End()
-	return fakeGetPosition(ctx, datasetDirectory, slamSvc)
+	return fakePosition(ctx, datasetDirectory, slamSvc)
 }
 
-// GetPointCloudMap returns a callback function which will return the next chunk of the current pointcloud
+// PointCloudMap returns a callback function which will return the next chunk of the current pointcloud
 // map.
-func (slamSvc *SLAM) GetPointCloudMap(ctx context.Context) (func() ([]byte, error), error) {
-	ctx, span := trace.StartSpan(ctx, "slam::fake::GetPointCloudMap")
+func (slamSvc *SLAM) PointCloudMap(ctx context.Context) (func() ([]byte, error), error) {
+	ctx, span := trace.StartSpan(ctx, "slam::fake::PointCloudMap")
 	defer span.End()
 	slamSvc.incrementDataCount()
-	return fakeGetPointCloudMap(ctx, datasetDirectory, slamSvc)
+	return fakePointCloudMap(ctx, datasetDirectory, slamSvc)
 }
 
-// GetInternalState returns a callback function which will return the next chunk of the current internal
+// InternalState returns a callback function which will return the next chunk of the current internal
 // state of the slam algo.
-func (slamSvc *SLAM) GetInternalState(ctx context.Context) (func() ([]byte, error), error) {
-	ctx, span := trace.StartSpan(ctx, "slam::fake::GetInternalState")
+func (slamSvc *SLAM) InternalState(ctx context.Context) (func() ([]byte, error), error) {
+	ctx, span := trace.StartSpan(ctx, "slam::fake::InternalState")
 	defer span.End()
-	return fakeGetInternalState(ctx, datasetDirectory, slamSvc)
+	return fakeInternalState(ctx, datasetDirectory, slamSvc)
 }
 
-// GetLatestMapInfo returns information used to determine whether the slam mode is localizing.
+// LatestMapInfo returns information used to determine whether the slam mode is localizing.
 // Fake Slam is always in mapping mode, so it always returns a new timestamp.
-func (slamSvc *SLAM) GetLatestMapInfo(ctx context.Context) (time.Time, error) {
-	_, span := trace.StartSpan(ctx, "slam::fake::GetLatestMapInfo")
+func (slamSvc *SLAM) LatestMapInfo(ctx context.Context) (time.Time, error) {
+	_, span := trace.StartSpan(ctx, "slam::fake::LatestMapInfo")
 	defer span.End()
 	slamSvc.mapTimestamp = time.Now().UTC()
 	return slamSvc.mapTimestamp, nil
@@ -103,9 +103,9 @@ func (slamSvc *SLAM) incrementDataCount() {
 	slamSvc.dataCount = ((slamSvc.dataCount + 1) % maxDataCount)
 }
 
-// GetLimits returns the bounds of the slam map as a list of referenceframe.Limits.
-func (slamSvc *SLAM) GetLimits(ctx context.Context) ([]referenceframe.Limit, error) {
-	data, err := slam.GetPointCloudMapFull(ctx, slamSvc)
+// Limits returns the bounds of the slam map as a list of referenceframe.Limits.
+func (slamSvc *SLAM) Limits(ctx context.Context) ([]referenceframe.Limit, error) {
+	data, err := slam.PointCloudMapFull(ctx, slamSvc)
 	if err != nil {
 		return nil, err
 	}

--- a/services/slam/grpchelper/grpchelper.go
+++ b/services/slam/grpchelper/grpchelper.go
@@ -8,9 +8,9 @@ import (
 	pb "go.viam.com/api/service/slam/v1"
 )
 
-// GetPointCloudMapCallback helps a client request the point cloud stream from a SLAM server,
+// PointCloudMapCallback helps a client request the point cloud stream from a SLAM server,
 // returning a callback function for accessing the stream data.
-func GetPointCloudMapCallback(ctx context.Context, name string, slamClient pb.SLAMServiceClient) (func() ([]byte, error), error) {
+func PointCloudMapCallback(ctx context.Context, name string, slamClient pb.SLAMServiceClient) (func() ([]byte, error), error) {
 	req := &pb.GetPointCloudMapRequest{Name: name}
 
 	// If the target gRPC server returns an error status, this call doesn't return an error.
@@ -33,9 +33,9 @@ func GetPointCloudMapCallback(ctx context.Context, name string, slamClient pb.SL
 	return f, nil
 }
 
-// GetInternalStateCallback helps a client request the internal state stream from a SLAM server,
+// InternalStateCallback helps a client request the internal state stream from a SLAM server,
 // returning a callback function for accessing the stream data.
-func GetInternalStateCallback(ctx context.Context, name string, slamClient pb.SLAMServiceClient) (func() ([]byte, error), error) {
+func InternalStateCallback(ctx context.Context, name string, slamClient pb.SLAMServiceClient) (func() ([]byte, error), error) {
 	req := &pb.GetInternalStateRequest{Name: name}
 
 	// If the target gRPC server returns an error status, this call doesn't return an error.

--- a/services/slam/server.go
+++ b/services/slam/server.go
@@ -57,7 +57,7 @@ func (server *serviceServer) GetPointCloudMap(req *pb.GetPointCloudMapRequest,
 ) error {
 	ctx := context.Background()
 
-	ctx, span := trace.StartSpan(ctx, "slam::server::PointCloudMap")
+	ctx, span := trace.StartSpan(ctx, "slam::server::GetPointCloudMap")
 	defer span.End()
 
 	svc, err := server.coll.Resource(req.Name)
@@ -95,7 +95,7 @@ func (server *serviceServer) GetInternalState(req *pb.GetInternalStateRequest,
 	stream pb.SLAMService_GetInternalStateServer,
 ) error {
 	ctx := context.Background()
-	ctx, span := trace.StartSpan(ctx, "slam::server::InternalState")
+	ctx, span := trace.StartSpan(ctx, "slam::server::GetInternalState")
 	defer span.End()
 
 	svc, err := server.coll.Resource(req.Name)
@@ -131,7 +131,7 @@ func (server *serviceServer) GetInternalState(req *pb.GetInternalStateRequest,
 func (server *serviceServer) GetLatestMapInfo(ctx context.Context, req *pb.GetLatestMapInfoRequest) (
 	*pb.GetLatestMapInfoResponse, error,
 ) {
-	ctx, span := trace.StartSpan(ctx, "slam::server::LatestMapInfo")
+	ctx, span := trace.StartSpan(ctx, "slam::server::GetLatestMapInfo")
 	defer span.End()
 
 	svc, err := server.coll.Resource(req.Name)

--- a/services/slam/server.go
+++ b/services/slam/server.go
@@ -31,7 +31,7 @@ func NewRPCServiceServer(coll resource.APIResourceCollection[Service]) interface
 func (server *serviceServer) GetPosition(ctx context.Context, req *pb.GetPositionRequest) (
 	*pb.GetPositionResponse, error,
 ) {
-	ctx, span := trace.StartSpan(ctx, "slam::server::Position")
+	ctx, span := trace.StartSpan(ctx, "slam::server::GetPosition")
 	defer span.End()
 
 	svc, err := server.coll.Resource(req.Name)

--- a/services/slam/server.go
+++ b/services/slam/server.go
@@ -27,11 +27,11 @@ func NewRPCServiceServer(coll resource.APIResourceCollection[Service]) interface
 	return &serviceServer{coll: coll}
 }
 
-// GetPosition returns a Pose and a component reference string of the robot's current location according to SLAM.
-func (server *serviceServer) GetPosition(ctx context.Context, req *pb.GetPositionRequest) (
+// Position returns a Pose and a component reference string of the robot's current location according to SLAM.
+func (server *serviceServer) Position(ctx context.Context, req *pb.GetPositionRequest) (
 	*pb.GetPositionResponse, error,
 ) {
-	ctx, span := trace.StartSpan(ctx, "slam::server::GetPosition")
+	ctx, span := trace.StartSpan(ctx, "slam::server::Position")
 	defer span.End()
 
 	svc, err := server.coll.Resource(req.Name)
@@ -39,7 +39,7 @@ func (server *serviceServer) GetPosition(ctx context.Context, req *pb.GetPositio
 		return nil, err
 	}
 
-	p, componentReference, err := svc.GetPosition(ctx)
+	p, componentReference, err := svc.Position(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -50,14 +50,14 @@ func (server *serviceServer) GetPosition(ctx context.Context, req *pb.GetPositio
 	}, nil
 }
 
-// GetPointCloudMap returns the slam service's slam algo's current map state in PCD format as
+// PointCloudMap returns the slam service's slam algo's current map state in PCD format as
 // a stream of byte chunks.
-func (server *serviceServer) GetPointCloudMap(req *pb.GetPointCloudMapRequest,
+func (server *serviceServer) PointCloudMap(req *pb.GetPointCloudMapRequest,
 	stream pb.SLAMService_GetPointCloudMapServer,
 ) error {
 	ctx := context.Background()
 
-	ctx, span := trace.StartSpan(ctx, "slam::server::GetPointCloudMap")
+	ctx, span := trace.StartSpan(ctx, "slam::server::PointCloudMap")
 	defer span.End()
 
 	svc, err := server.coll.Resource(req.Name)
@@ -65,9 +65,9 @@ func (server *serviceServer) GetPointCloudMap(req *pb.GetPointCloudMapRequest,
 		return err
 	}
 
-	f, err := svc.GetPointCloudMap(ctx)
+	f, err := svc.PointCloudMap(ctx)
 	if err != nil {
-		return errors.Wrap(err, "getting callback function from GetPointCloudMap encountered an issue")
+		return errors.Wrap(err, "getting callback function from PointCloudMap encountered an issue")
 	}
 
 	// In the future, channel buffer could be used here to optimize for latency
@@ -89,13 +89,13 @@ func (server *serviceServer) GetPointCloudMap(req *pb.GetPointCloudMapRequest,
 	}
 }
 
-// GetInternalState returns the internal state of the slam service's slam algo in a stream of
+// InternalState returns the internal state of the slam service's slam algo in a stream of
 // byte chunks.
-func (server *serviceServer) GetInternalState(req *pb.GetInternalStateRequest,
+func (server *serviceServer) InternalState(req *pb.GetInternalStateRequest,
 	stream pb.SLAMService_GetInternalStateServer,
 ) error {
 	ctx := context.Background()
-	ctx, span := trace.StartSpan(ctx, "slam::server::GetInternalState")
+	ctx, span := trace.StartSpan(ctx, "slam::server::InternalState")
 	defer span.End()
 
 	svc, err := server.coll.Resource(req.Name)
@@ -103,7 +103,7 @@ func (server *serviceServer) GetInternalState(req *pb.GetInternalStateRequest,
 		return err
 	}
 
-	f, err := svc.GetInternalState(ctx)
+	f, err := svc.InternalState(ctx)
 	if err != nil {
 		return err
 	}
@@ -127,11 +127,11 @@ func (server *serviceServer) GetInternalState(req *pb.GetInternalStateRequest,
 	}
 }
 
-// GetLatestMapInfo returns the timestamp of when the map was last updated.
-func (server *serviceServer) GetLatestMapInfo(ctx context.Context, req *pb.GetLatestMapInfoRequest) (
+// LatestMapInfo returns the timestamp of when the map was last updated.
+func (server *serviceServer) LatestMapInfo(ctx context.Context, req *pb.GetLatestMapInfoRequest) (
 	*pb.GetLatestMapInfoResponse, error,
 ) {
-	ctx, span := trace.StartSpan(ctx, "slam::server::GetLatestMapInfo")
+	ctx, span := trace.StartSpan(ctx, "slam::server::LatestMapInfo")
 	defer span.End()
 
 	svc, err := server.coll.Resource(req.Name)
@@ -139,7 +139,7 @@ func (server *serviceServer) GetLatestMapInfo(ctx context.Context, req *pb.GetLa
 		return nil, err
 	}
 
-	mapTimestamp, err := svc.GetLatestMapInfo(ctx)
+	mapTimestamp, err := svc.LatestMapInfo(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/services/slam/server.go
+++ b/services/slam/server.go
@@ -27,8 +27,8 @@ func NewRPCServiceServer(coll resource.APIResourceCollection[Service]) interface
 	return &serviceServer{coll: coll}
 }
 
-// Position returns a Pose and a component reference string of the robot's current location according to SLAM.
-func (server *serviceServer) Position(ctx context.Context, req *pb.GetPositionRequest) (
+// GetPosition returns a Pose and a component reference string of the robot's current location according to SLAM.
+func (server *serviceServer) GetPosition(ctx context.Context, req *pb.GetPositionRequest) (
 	*pb.GetPositionResponse, error,
 ) {
 	ctx, span := trace.StartSpan(ctx, "slam::server::Position")
@@ -50,9 +50,9 @@ func (server *serviceServer) Position(ctx context.Context, req *pb.GetPositionRe
 	}, nil
 }
 
-// PointCloudMap returns the slam service's slam algo's current map state in PCD format as
+// GetPointCloudMap returns the slam service's slam algo's current map state in PCD format as
 // a stream of byte chunks.
-func (server *serviceServer) PointCloudMap(req *pb.GetPointCloudMapRequest,
+func (server *serviceServer) GetPointCloudMap(req *pb.GetPointCloudMapRequest,
 	stream pb.SLAMService_GetPointCloudMapServer,
 ) error {
 	ctx := context.Background()
@@ -89,9 +89,9 @@ func (server *serviceServer) PointCloudMap(req *pb.GetPointCloudMapRequest,
 	}
 }
 
-// InternalState returns the internal state of the slam service's slam algo in a stream of
+// GetInternalState returns the internal state of the slam service's slam algo in a stream of
 // byte chunks.
-func (server *serviceServer) InternalState(req *pb.GetInternalStateRequest,
+func (server *serviceServer) GetInternalState(req *pb.GetInternalStateRequest,
 	stream pb.SLAMService_GetInternalStateServer,
 ) error {
 	ctx := context.Background()
@@ -127,8 +127,8 @@ func (server *serviceServer) InternalState(req *pb.GetInternalStateRequest,
 	}
 }
 
-// LatestMapInfo returns the timestamp of when the map was last updated.
-func (server *serviceServer) LatestMapInfo(ctx context.Context, req *pb.GetLatestMapInfoRequest) (
+// GetLatestMapInfo returns the timestamp of when the map was last updated.
+func (server *serviceServer) GetLatestMapInfo(ctx context.Context, req *pb.GetLatestMapInfoRequest) (
 	*pb.GetLatestMapInfoResponse, error,
 ) {
 	ctx, span := trace.StartSpan(ctx, "slam::server::LatestMapInfo")

--- a/services/slam/server_test.go
+++ b/services/slam/server_test.go
@@ -78,7 +78,7 @@ func TestWorkingServer(t *testing.T) {
 		poseSucc := spatial.NewPose(r3.Vector{X: 1, Y: 2, Z: 3}, &spatial.OrientationVector{Theta: math.Pi / 2, OX: 0, OY: 0, OZ: -1})
 		componentRefSucc := "cam"
 
-		injectSvc.GetPositionFunc = func(ctx context.Context) (spatial.Pose, string, error) {
+		injectSvc.PositionFunc = func(ctx context.Context) (spatial.Pose, string, error) {
 			return poseSucc, componentRefSucc, nil
 		}
 
@@ -92,7 +92,7 @@ func TestWorkingServer(t *testing.T) {
 	})
 
 	t.Run("working GetPointCloudMap", func(t *testing.T) {
-		injectSvc.GetPointCloudMapFunc = func(ctx context.Context) (func() ([]byte, error), error) {
+		injectSvc.PointCloudMapFunc = func(ctx context.Context) (func() ([]byte, error), error) {
 			reader := bytes.NewReader(pcd)
 			serverBuffer := make([]byte, chunkSizeServer)
 			f := func() ([]byte, error) {
@@ -121,7 +121,7 @@ func TestWorkingServer(t *testing.T) {
 	t.Run("working GetInternalState", func(t *testing.T) {
 		internalStateSucc := []byte{0, 1, 2, 3, 4}
 		chunkSizeInternalState := 2
-		injectSvc.GetInternalStateFunc = func(ctx context.Context) (func() ([]byte, error), error) {
+		injectSvc.InternalStateFunc = func(ctx context.Context) (func() ([]byte, error), error) {
 			reader := bytes.NewReader(internalStateSucc)
 			f := func() ([]byte, error) {
 				serverBuffer := make([]byte, chunkSizeInternalState)
@@ -146,7 +146,7 @@ func TestWorkingServer(t *testing.T) {
 
 	t.Run("working GetLatestMapInfo", func(t *testing.T) {
 		timestamp := time.Now().UTC()
-		injectSvc.GetLatestMapInfoFunc = func(ctx context.Context) (time.Time, error) {
+		injectSvc.LatestMapInfoFunc = func(ctx context.Context) (time.Time, error) {
 			return timestamp, nil
 		}
 
@@ -170,11 +170,11 @@ func TestWorkingServer(t *testing.T) {
 		poseSucc := spatial.NewPose(r3.Vector{X: 1, Y: 2, Z: 3}, &spatial.OrientationVector{Theta: math.Pi / 2, OX: 0, OY: 0, OZ: -1})
 		componentRefSucc := "cam"
 
-		injectSvc.GetPositionFunc = func(ctx context.Context) (spatial.Pose, string, error) {
+		injectSvc.PositionFunc = func(ctx context.Context) (spatial.Pose, string, error) {
 			return poseSucc, componentRefSucc, nil
 		}
 
-		injectSvc.GetPointCloudMapFunc = func(ctx context.Context) (func() ([]byte, error), error) {
+		injectSvc.PointCloudMapFunc = func(ctx context.Context) (func() ([]byte, error), error) {
 			reader := bytes.NewReader(pcd)
 			serverBuffer := make([]byte, chunkSizeServer)
 			f := func() ([]byte, error) {
@@ -231,7 +231,7 @@ func TestFailingServer(t *testing.T) {
 	slamServer := slam.NewRPCServiceServer(injectAPISvc).(pb.SLAMServiceServer)
 
 	t.Run("failing GetPosition", func(t *testing.T) {
-		injectSvc.GetPositionFunc = func(ctx context.Context) (spatial.Pose, string, error) {
+		injectSvc.PositionFunc = func(ctx context.Context) (spatial.Pose, string, error) {
 			return nil, "", errors.New("failure to get position")
 		}
 
@@ -244,8 +244,8 @@ func TestFailingServer(t *testing.T) {
 	})
 
 	t.Run("failing GetPointCloudMap", func(t *testing.T) {
-		// GetPointCloudMapFunc failure
-		injectSvc.GetPointCloudMapFunc = func(ctx context.Context) (func() ([]byte, error), error) {
+		// PointCloudMapFunc failure
+		injectSvc.PointCloudMapFunc = func(ctx context.Context) (func() ([]byte, error), error) {
 			return nil, errors.New("failure to get pointcloud map")
 		}
 
@@ -256,7 +256,7 @@ func TestFailingServer(t *testing.T) {
 		test.That(t, err.Error(), test.ShouldContainSubstring, "failure to get pointcloud map")
 
 		// Callback failure
-		injectSvc.GetPointCloudMapFunc = func(ctx context.Context) (func() ([]byte, error), error) {
+		injectSvc.PointCloudMapFunc = func(ctx context.Context) (func() ([]byte, error), error) {
 			f := func() ([]byte, error) {
 				return []byte{}, errors.New("callback error")
 			}
@@ -270,7 +270,7 @@ func TestFailingServer(t *testing.T) {
 
 	t.Run("failing GetInternalState", func(t *testing.T) {
 		// GetInternalStateFunc error
-		injectSvc.GetInternalStateFunc = func(ctx context.Context) (func() ([]byte, error), error) {
+		injectSvc.InternalStateFunc = func(ctx context.Context) (func() ([]byte, error), error) {
 			return nil, errors.New("failure to get internal state")
 		}
 
@@ -280,7 +280,7 @@ func TestFailingServer(t *testing.T) {
 		test.That(t, err.Error(), test.ShouldContainSubstring, "failure to get internal state")
 
 		// Callback failure
-		injectSvc.GetInternalStateFunc = func(ctx context.Context) (func() ([]byte, error), error) {
+		injectSvc.InternalStateFunc = func(ctx context.Context) (func() ([]byte, error), error) {
 			f := func() ([]byte, error) {
 				return []byte{}, errors.New("callback error")
 			}
@@ -292,7 +292,7 @@ func TestFailingServer(t *testing.T) {
 	})
 
 	t.Run("failing GetLatestMapInfo", func(t *testing.T) {
-		injectSvc.GetLatestMapInfoFunc = func(ctx context.Context) (time.Time, error) {
+		injectSvc.LatestMapInfoFunc = func(ctx context.Context) (time.Time, error) {
 			return time.Time{}, errors.New("failure to get latest map info")
 		}
 		reqInfo := &pb.GetLatestMapInfoRequest{Name: testSlamServiceName}

--- a/services/slam/server_test.go
+++ b/services/slam/server_test.go
@@ -269,7 +269,7 @@ func TestFailingServer(t *testing.T) {
 	})
 
 	t.Run("failing GetInternalState", func(t *testing.T) {
-		// GetInternalStateFunc error
+		// InternalStateFunc error
 		injectSvc.InternalStateFunc = func(ctx context.Context) (func() ([]byte, error), error) {
 			return nil, errors.New("failure to get internal state")
 		}

--- a/services/slam/slam.go
+++ b/services/slam/slam.go
@@ -57,10 +57,10 @@ func FromRobot(r robot.Robot, name string) (Service, error) {
 // Service describes the functions that are available to the service.
 type Service interface {
 	resource.Resource
-	GetPosition(ctx context.Context) (spatialmath.Pose, string, error)
-	GetPointCloudMap(ctx context.Context) (func() ([]byte, error), error)
-	GetInternalState(ctx context.Context) (func() ([]byte, error), error)
-	GetLatestMapInfo(ctx context.Context) (time.Time, error)
+	Position(ctx context.Context) (spatialmath.Pose, string, error)
+	PointCloudMap(ctx context.Context) (func() ([]byte, error), error)
+	InternalState(ctx context.Context) (func() ([]byte, error), error)
+	LatestMapInfo(ctx context.Context) (time.Time, error)
 }
 
 // HelperConcatenateChunksToFull concatenates the chunks from a streamed grpc endpoint.
@@ -79,32 +79,32 @@ func HelperConcatenateChunksToFull(f func() ([]byte, error)) ([]byte, error) {
 	}
 }
 
-// GetPointCloudMapFull concatenates the streaming responses from GetPointCloudMap into a full point cloud.
-func GetPointCloudMapFull(ctx context.Context, slamSvc Service) ([]byte, error) {
-	ctx, span := trace.StartSpan(ctx, "slam::GetPointCloudMapFull")
+// PointCloudMapFull concatenates the streaming responses from PointCloudMap into a full point cloud.
+func PointCloudMapFull(ctx context.Context, slamSvc Service) ([]byte, error) {
+	ctx, span := trace.StartSpan(ctx, "slam::PointCloudMapFull")
 	defer span.End()
-	callback, err := slamSvc.GetPointCloudMap(ctx)
+	callback, err := slamSvc.PointCloudMap(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return HelperConcatenateChunksToFull(callback)
 }
 
-// GetInternalStateFull concatenates the streaming responses from GetInternalState into
+// InternalStateFull concatenates the streaming responses from InternalState into
 // the internal serialized state of the slam algorithm.
-func GetInternalStateFull(ctx context.Context, slamSvc Service) ([]byte, error) {
-	ctx, span := trace.StartSpan(ctx, "slam::GetInternalStateFull")
+func InternalStateFull(ctx context.Context, slamSvc Service) ([]byte, error) {
+	ctx, span := trace.StartSpan(ctx, "slam::InternalStateFull")
 	defer span.End()
-	callback, err := slamSvc.GetInternalState(ctx)
+	callback, err := slamSvc.InternalState(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return HelperConcatenateChunksToFull(callback)
 }
 
-// GetLimits returns the bounds of the slam map as a list of referenceframe.Limits.
-func GetLimits(ctx context.Context, svc Service) ([]referenceframe.Limit, error) {
-	data, err := GetPointCloudMapFull(ctx, svc)
+// Limits returns the bounds of the slam map as a list of referenceframe.Limits.
+func Limits(ctx context.Context, svc Service) ([]referenceframe.Limit, error) {
+	data, err := PointCloudMapFull(ctx, svc)
 	if err != nil {
 		return nil, err
 	}

--- a/services/slam/slam.go
+++ b/services/slam/slam.go
@@ -30,12 +30,12 @@ func init() {
 	})
 	data.RegisterCollector(data.MethodMetadata{
 		API:        API,
-		MethodName: getPosition.String(),
-	}, newGetPositionCollector)
+		MethodName: position.String(),
+	}, newPositionCollector)
 	data.RegisterCollector(data.MethodMetadata{
 		API:        API,
-		MethodName: getPointCloudMap.String(),
-	}, newGetPointCloudMapCollector)
+		MethodName: pointCloudMap.String(),
+	}, newPointCloudMapCollector)
 }
 
 // SubtypeName is the name of the type of service.

--- a/testutils/inject/slam_service.go
+++ b/testutils/inject/slam_service.go
@@ -12,13 +12,13 @@ import (
 // SLAMService represents a fake instance of a slam service.
 type SLAMService struct {
 	slam.Service
-	name                 resource.Name
-	GetPositionFunc      func(ctx context.Context) (spatialmath.Pose, string, error)
-	GetPointCloudMapFunc func(ctx context.Context) (func() ([]byte, error), error)
-	GetInternalStateFunc func(ctx context.Context) (func() ([]byte, error), error)
-	GetLatestMapInfoFunc func(ctx context.Context) (time.Time, error)
-	DoCommandFunc        func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
-	CloseFunc            func(ctx context.Context) error
+	name              resource.Name
+	PositionFunc      func(ctx context.Context) (spatialmath.Pose, string, error)
+	PointCloudMapFunc func(ctx context.Context) (func() ([]byte, error), error)
+	InternalStateFunc func(ctx context.Context) (func() ([]byte, error), error)
+	LatestMapInfoFunc func(ctx context.Context) (time.Time, error)
+	DoCommandFunc     func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
+	CloseFunc         func(ctx context.Context) error
 }
 
 // NewSLAMService returns a new injected SLAM service.
@@ -31,36 +31,36 @@ func (slamSvc *SLAMService) Name() resource.Name {
 	return slamSvc.name
 }
 
-// GetPosition calls the injected GetPositionFunc or the real version.
-func (slamSvc *SLAMService) GetPosition(ctx context.Context) (spatialmath.Pose, string, error) {
-	if slamSvc.GetPositionFunc == nil {
-		return slamSvc.Service.GetPosition(ctx)
+// Position calls the injected PositionFunc or the real version.
+func (slamSvc *SLAMService) Position(ctx context.Context) (spatialmath.Pose, string, error) {
+	if slamSvc.PositionFunc == nil {
+		return slamSvc.Service.Position(ctx)
 	}
-	return slamSvc.GetPositionFunc(ctx)
+	return slamSvc.PositionFunc(ctx)
 }
 
-// GetPointCloudMap calls the injected GetPointCloudMap or the real version.
-func (slamSvc *SLAMService) GetPointCloudMap(ctx context.Context) (func() ([]byte, error), error) {
-	if slamSvc.GetPointCloudMapFunc == nil {
-		return slamSvc.Service.GetPointCloudMap(ctx)
+// PointCloudMap calls the injected PointCloudMap or the real version.
+func (slamSvc *SLAMService) PointCloudMap(ctx context.Context) (func() ([]byte, error), error) {
+	if slamSvc.PointCloudMapFunc == nil {
+		return slamSvc.Service.PointCloudMap(ctx)
 	}
-	return slamSvc.GetPointCloudMapFunc(ctx)
+	return slamSvc.PointCloudMapFunc(ctx)
 }
 
-// GetInternalState calls the injected GetInternalState or the real version.
-func (slamSvc *SLAMService) GetInternalState(ctx context.Context) (func() ([]byte, error), error) {
-	if slamSvc.GetInternalStateFunc == nil {
-		return slamSvc.Service.GetInternalState(ctx)
+// InternalState calls the injected InternalState or the real version.
+func (slamSvc *SLAMService) InternalState(ctx context.Context) (func() ([]byte, error), error) {
+	if slamSvc.InternalStateFunc == nil {
+		return slamSvc.Service.InternalState(ctx)
 	}
-	return slamSvc.GetInternalStateFunc(ctx)
+	return slamSvc.InternalStateFunc(ctx)
 }
 
-// GetLatestMapInfo calls the injected GetLatestMapInfoFunc or the real version.
-func (slamSvc *SLAMService) GetLatestMapInfo(ctx context.Context) (time.Time, error) {
-	if slamSvc.GetLatestMapInfoFunc == nil {
-		return slamSvc.Service.GetLatestMapInfo(ctx)
+// LatestMapInfo calls the injected LatestMapInfoFunc or the real version.
+func (slamSvc *SLAMService) LatestMapInfo(ctx context.Context) (time.Time, error) {
+	if slamSvc.LatestMapInfoFunc == nil {
+		return slamSvc.Service.LatestMapInfo(ctx)
 	}
-	return slamSvc.GetLatestMapInfoFunc(ctx)
+	return slamSvc.LatestMapInfoFunc(ctx)
 }
 
 // DoCommand calls the injected DoCommand or the real variant.


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-3979

Tested using fake slam.

This PR has to be merged before the corresponding PR in viam-cartographer can be merged: https://github.com/viamrobotics/viam-cartographer/pull/257