### PR TITLE
APP-2541: make visibility required for cli create command

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -26,7 +26,6 @@ const (
 	moduleFlagName            = "name"
 	moduleFlagPublicNamespace = "public-namespace"
 	moduleFlagOrgID           = "org-id"
-	moduleFlagVisibility      = "visibility"
 	moduleFlagPath            = "module"
 	moduleFlagVersion         = "version"
 	moduleFlagPlatform        = "platform"
@@ -502,11 +501,6 @@ After creation, use 'viam module update' to push your new module to app.viam.com
 						&cli.StringFlag{
 							Name:  moduleFlagOrgID,
 							Usage: "id of the organization that will host the module",
-						},
-						&cli.StringFlag{
-							Name:     moduleFlagVisibility,
-							Required: true,
-							Usage:    "the visibility of your module on app.viam.com. It can be either 'public' (readable outside of your org) or 'private'.",
 						},
 					},
 					Action: CreateModuleAction,

--- a/cli/app.go
+++ b/cli/app.go
@@ -26,6 +26,7 @@ const (
 	moduleFlagName            = "name"
 	moduleFlagPublicNamespace = "public-namespace"
 	moduleFlagOrgID           = "org-id"
+	moduleFlagVisibility      = "visibility"
 	moduleFlagPath            = "module"
 	moduleFlagVersion         = "version"
 	moduleFlagPlatform        = "platform"
@@ -501,6 +502,11 @@ After creation, use 'viam module update' to push your new module to app.viam.com
 						&cli.StringFlag{
 							Name:  moduleFlagOrgID,
 							Usage: "id of the organization that will host the module",
+						},
+						&cli.StringFlag{
+							Name:     moduleFlagVisibility,
+							Required: true,
+							Usage:    "the visibility of your module on app.viam.com. It can be either 'public' (readable outside of your org) or 'private'.",
 						},
 					},
 					Action: CreateModuleAction,

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -64,6 +64,7 @@ func CreateModuleAction(c *cli.Context) error {
 	moduleNameArg := c.String(moduleFlagName)
 	publicNamespaceArg := c.String(moduleFlagPublicNamespace)
 	orgIDArg := c.String(moduleFlagOrgID)
+	visibility := c.String(moduleFlagVisibility)
 
 	client, err := newViamClient(c)
 	if err != nil {
@@ -76,6 +77,10 @@ func CreateModuleAction(c *cli.Context) error {
 	// Check to make sure the user doesn't accidentally overwrite a module manifest
 	if _, err := os.Stat(defaultManifestFilename); err == nil {
 		return errors.New("another module's meta.json already exists in the current directory. delete it and try again")
+	}
+
+	if visibility == "" || (visibility != string(moduleVisibilityPrivate) && visibility != string(moduleVisibilityPublic)) {
+		return errors.New("must specificy visibility as either private or public")
 	}
 
 	response, err := client.createModule(moduleNameArg, org.GetId())
@@ -94,7 +99,7 @@ func CreateModuleAction(c *cli.Context) error {
 	}
 	emptyManifest := moduleManifest{
 		ModuleID:   returnedModuleID.String(),
-		Visibility: moduleVisibilityPrivate,
+		Visibility: moduleVisibility(visibility),
 		// This is done so that the json has an empty example
 		Models: []moduleComponent{
 			{},

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -64,7 +64,6 @@ func CreateModuleAction(c *cli.Context) error {
 	moduleNameArg := c.String(moduleFlagName)
 	publicNamespaceArg := c.String(moduleFlagPublicNamespace)
 	orgIDArg := c.String(moduleFlagOrgID)
-	visibility := c.String(moduleFlagVisibility)
 
 	client, err := newViamClient(c)
 	if err != nil {
@@ -77,10 +76,6 @@ func CreateModuleAction(c *cli.Context) error {
 	// Check to make sure the user doesn't accidentally overwrite a module manifest
 	if _, err := os.Stat(defaultManifestFilename); err == nil {
 		return errors.New("another module's meta.json already exists in the current directory. delete it and try again")
-	}
-
-	if visibility == "" || (visibility != string(moduleVisibilityPrivate) && visibility != string(moduleVisibilityPublic)) {
-		return errors.New("must specificy visibility as either private or public")
 	}
 
 	response, err := client.createModule(moduleNameArg, org.GetId())
@@ -99,7 +94,7 @@ func CreateModuleAction(c *cli.Context) error {
 	}
 	emptyManifest := moduleManifest{
 		ModuleID:   returnedModuleID.String(),
-		Visibility: moduleVisibility(visibility),
+		Visibility: "",
 		// This is done so that the json has an empty example
 		Models: []moduleComponent{
 			{},


### PR DESCRIPTION
This change should make it so that when you upload your meta.json file there must be visibility set in the file. 

**OLD - no longer relevant**

Creating a private module in staging:
<img width="1266" alt="Screenshot 2023-08-29 at 11 25 46 AM" src="https://github.com/viamrobotics/rdk/assets/40992044/258bf4e1-1fd1-4cb9-bcda-21ceab316333">

Creating a public module in staging:
<img width="1244" alt="Screenshot 2023-08-29 at 11 26 39 AM" src="https://github.com/viamrobotics/rdk/assets/40992044/14225b4c-11e8-4e82-bc75-88876c0c1e12">

Bad Value:
<img width="1227" alt="Screenshot 2023-08-29 at 11 27 49 AM" src="https://github.com/viamrobotics/rdk/assets/40992044/5284a097-6768-45e2-8e05-749ee9621a09">

No Value:
<img width="1232" alt="Screenshot 2023-08-29 at 11 28 21 AM" src="https://github.com/viamrobotics/rdk/assets/40992044/8df2a0d7-6ba7-4aaa-ac6c-8658bad464d9">
