### PR TITLE
DATA-1874 Add example modular sensor for filtering data capture

### DIFF
--- a/examples/filters/sensorfilter/module/main.go
+++ b/examples/filters/sensorfilter/module/main.go
@@ -1,0 +1,37 @@
+// Package main is a module which serves the sensorfilter custom module.
+package main
+
+import (
+	"context"
+
+	"github.com/edaniels/golog"
+	"go.viam.com/utils"
+
+	"go.viam.com/rdk/components/sensor"
+	"go.viam.com/rdk/examples/filters/sensorfilter"
+	"go.viam.com/rdk/module"
+)
+
+func main() {
+	utils.ContextualMain(mainWithArgs, module.NewLoggerFromArgs("sensorfilter_module"))
+}
+
+func mainWithArgs(ctx context.Context, args []string, logger golog.Logger) (err error) {
+	myMod, err := module.NewModuleFromArgs(ctx, logger)
+	if err != nil {
+		return err
+	}
+
+	err = myMod.AddModelFromRegistry(ctx, sensor.API, sensorfilter.Model)
+	if err != nil {
+		return err
+	}
+
+	err = myMod.Start(ctx)
+	defer myMod.Close(ctx)
+	if err != nil {
+		return err
+	}
+	<-ctx.Done()
+	return nil
+}

--- a/examples/filters/sensorfilter/sensor_filter.go
+++ b/examples/filters/sensorfilter/sensor_filter.go
@@ -90,10 +90,11 @@ func relativeChange(curr, prev map[string]interface{}, logger golog.Logger) floa
 		logger.Errorw("sensor's previous distance reading is not of type float", "prevReading", prev)
 		return 0
 	}
-	diff := currDist - prevDist
+	logger.Warnln("calculating rel change - curr: ", currDist, "; prev: ", prevDist)
 	if prevDist == 0 {
-		return math.Abs(diff)
+		return math.Abs(currDist)
 	}
+	diff := currDist - prevDist
 	return math.Abs(diff / prevDist)
 }
 
@@ -110,10 +111,10 @@ func (s *filterSensor) Readings(ctx context.Context, extra map[string]interface{
 
 	// Only return captured readings if they are significantly different from the previously stored readings.
 	if s.prevReadings == nil || relativeChange(readings, s.prevReadings, s.logger) > threshold {
+		s.logger.Warnln("returning reading: ", readings)
 		s.prevReadings = readings
 		return readings, nil
 	}
-
 	return nil, data.ErrNoCaptureToStore
 }
 

--- a/examples/filters/sensorfilter/sensor_filter.go
+++ b/examples/filters/sensorfilter/sensor_filter.go
@@ -1,0 +1,118 @@
+// Package sensorfilter implements a modular component that filters the output of an underlying ultrasonic sensor
+// and only keeps captured data if there is a significant change in readings.
+package sensorfilter
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"github.com/edaniels/golog"
+	"github.com/pkg/errors"
+
+	"go.viam.com/rdk/components/sensor"
+	"go.viam.com/rdk/data"
+	"go.viam.com/rdk/resource"
+)
+
+// Model is the full model definition.
+var Model = resource.NewModel("example", "sensor", "sensorfilter")
+
+func init() {
+	resource.RegisterComponent(sensor.API, Model, resource.Registration[sensor.Sensor, *Config]{
+		Constructor: newSensor,
+	})
+}
+
+func newSensor(ctx context.Context, deps resource.Dependencies, conf resource.Config, logger golog.Logger) (sensor.Sensor, error) {
+	s := &filterSensor{
+		Named:  conf.ResourceName().AsNamed(),
+		logger: logger,
+	}
+	if err := s.Reconfigure(ctx, deps, conf); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// Config contains the name to the underlying sensor.
+type Config struct {
+	ActualSensor string `json:"actual_sensor"`
+}
+
+// Validate validates the config and returns implicit dependencies.
+func (cfg *Config) Validate(path string) ([]string, error) {
+	if cfg.ActualSensor == "" {
+		return nil, fmt.Errorf(`expected "actual_sensor" attribute in %q`, path)
+	}
+
+	return []string{cfg.ActualSensor}, nil
+}
+
+// A filterSensor wraps the underlying sensor `actualSensor` and only keeps the data captured on the actual sensor if the current reading
+// is significantly different from the previously captured reading.
+type filterSensor struct {
+	resource.Named
+	actualSensor sensor.Sensor
+	prevReadings map[string]interface{}
+	logger       golog.Logger
+}
+
+// Reconfigure reconfigures the modular component with new settings.
+func (s *filterSensor) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+	sensorConfig, err := resource.NativeConfig[*Config](conf)
+	if err != nil {
+		return err
+	}
+
+	s.actualSensor, err = sensor.FromDependencies(deps, sensorConfig.ActualSensor)
+	if err != nil {
+		return errors.Wrapf(err, "unable to get sensor %v for sensorfilter", sensorConfig.ActualSensor)
+	}
+	return nil
+}
+
+// DoCommand simply echoes whatever was sent.
+func (s *filterSensor) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+	return cmd, nil
+}
+
+func delta(curr, prev map[string]interface{}, logger golog.Logger) float64 {
+	currDist, ok := curr["distance"].(float64)
+	if !ok {
+		logger.Errorw("sensor's current distance reading is not of type float", "currReading", curr)
+		return 0
+	}
+	prevDist, ok := prev["distance"].(float64)
+	if !ok {
+		logger.Errorw("sensor's previous distance reading is not of type float", "prevReading", prev)
+		return 0
+	}
+	diff := currDist - prevDist
+	return math.Abs(diff / prevDist)
+}
+
+// Readings returns data from the sensor.
+func (s *filterSensor) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+	if extra[data.FromDMString] != true {
+		// If not data management collector, return underlying sensor contents without filtering.
+		return s.actualSensor.Readings(ctx, extra)
+	}
+	readings, err := s.actualSensor.Readings(ctx, extra)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get next reading from sensor")
+	}
+
+	// Only return captured readings if they are significantly different from the previously stored readings.
+	if s.prevReadings == nil || delta(readings, s.prevReadings, s.logger) > 0.1 {
+		s.prevReadings = readings
+		return readings, nil
+	}
+
+	return nil, data.ErrNoCaptureToStore
+}
+
+// Close closes the underlying sensor.
+func (s *filterSensor) Close(ctx context.Context) error {
+	return s.actualSensor.Close(ctx)
+}

--- a/examples/filters/sensorfilter/sensor_filter.go
+++ b/examples/filters/sensorfilter/sensor_filter.go
@@ -90,7 +90,7 @@ func relativeChange(curr, prev map[string]interface{}, logger golog.Logger) floa
 		logger.Errorw("sensor's previous distance reading is not of type float", "prevReading", prev)
 		return 0
 	}
-	logger.Warnln("calculating rel change - curr: ", currDist, "; prev: ", prevDist)
+	fmt.Println("calculating rel change - curr: ", currDist, "; prev: ", prevDist)
 	if prevDist == 0 {
 		return math.Abs(currDist)
 	}
@@ -111,7 +111,7 @@ func (s *filterSensor) Readings(ctx context.Context, extra map[string]interface{
 
 	// Only return captured readings if they are significantly different from the previously stored readings.
 	if s.prevReadings == nil || relativeChange(readings, s.prevReadings, s.logger) > threshold {
-		s.logger.Warnln("returning reading: ", readings)
+		fmt.Println("returning reading: ", readings)
 		s.prevReadings = readings
 		return readings, nil
 	}


### PR DESCRIPTION
Tested on a viam rover with an ultrasonic sensor attached. Built from source (to include recent changes in [DATA-1803](https://github.com/viamrobotics/rdk/pull/2830) that are not yet in the most recent RDK version) and ran that on robot - verified that fromDM flag and filter error propagation works as expected!

[DATA-1803]: https://viam.atlassian.net/browse/DATA-1803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ