### PR TITLE
RSDK-4724 - Update CLI to support api-key create

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -138,10 +138,10 @@ var app = &cli.App{
 								},
 								&cli.StringFlag{
 									Name:  apiKeyCreateFlagName,
-									Usage: "the name of the key (defaults to the current time)",
+									Usage: "the name of the key (defaults to your login info with the current time)",
 								},
 							},
-							Action: OrganizationApiKeyCreateAction,
+							Action: OrganizationAPIKeyCreateAction,
 						},
 					},
 				},

--- a/cli/app.go
+++ b/cli/app.go
@@ -23,6 +23,9 @@ const (
 	runFlagData   = "data"
 	runFlagStream = "stream"
 
+	apiKeyCreateFlagOrgID = "org-id"
+	apiKeyCreateFlagName  = "name"
+
 	moduleFlagName            = "name"
 	moduleFlagPublicNamespace = "public-namespace"
 	moduleFlagOrgID           = "org-id"
@@ -112,6 +115,35 @@ var app = &cli.App{
 					Name:   "list",
 					Usage:  "list organizations for the current user",
 					Action: ListOrganizationsAction,
+				},
+			},
+		},
+		{
+			Name:            "organization",
+			Usage:           "work with a organization",
+			HideHelpCommand: true,
+			Subcommands: []*cli.Command{
+				{
+					Name:  "api-key",
+					Usage: "work with an organization's api keys",
+					Subcommands: []*cli.Command{
+						{
+							Name:  "create",
+							Usage: "create an api key for your organization",
+							Flags: []cli.Flag{
+								&cli.StringFlag{
+									Name:     apiKeyCreateFlagOrgID,
+									Required: true,
+									Usage:    "the org to create an api key for",
+								},
+								&cli.StringFlag{
+									Name:  apiKeyCreateFlagName,
+									Usage: "the name of the key (defaults to the current time)",
+								},
+							},
+							Action: OrganizationApiKeyCreateAction,
+						},
+					},
 				},
 			},
 		},

--- a/cli/auth.go
+++ b/cli/auth.go
@@ -207,6 +207,55 @@ func (c *viamClient) whoAmIAction(cCtx *cli.Context) error {
 	return nil
 }
 
+// OrganizationApiKeyCreateAction corresponds to `organization api-key create`
+func OrganizationApiKeyCreateAction(cCtx *cli.Context) error {
+	c, err := newViamClient(cCtx)
+	if err != nil {
+		return err
+	}
+	if c.conf.Auth == nil {
+		return errors.New("not logged in. run \"login\" command")
+	}
+	orgID := c.c.String(apiKeyCreateFlagOrgID)
+	keyName := c.c.String(apiKeyCreateFlagName)
+	if keyName == "" {
+		// Formats name as myusername@gmail.com-2009-11-10T23:00:00Z
+		keyName = fmt.Sprintf("%s-%s", c.conf.Auth.User.Email, time.Now().Format(time.RFC3339))
+		infof(cCtx.App.Writer, "using default key name of %q", keyName)
+	}
+	resp, err := c.createOrganizationApiKey(cCtx, orgID, keyName)
+	if err != nil {
+		return err
+	}
+	infof(cCtx.App.Writer, "successfully created key:", resp.GetKey())
+	fmt.Fprintf(cCtx.App.Writer, "key id: %s\n", resp.GetId())
+	fmt.Fprintf(cCtx.App.Writer, "key value: %s\n\n", resp.GetKey())
+	infof(cCtx.App.Writer, "keep this key somewhere safe; it has full access to your organization")
+	return nil
+}
+
+func (c *viamClient) createOrganizationApiKey(cCtx *cli.Context, orgID, keyName string) (*apppb.CreateKeyResponse, error) {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+
+	req := &apppb.CreateKeyRequest{
+		Authorizations: []*apppb.Authorization{
+			{
+				AuthorizationType: "role",
+				AuthorizationId:   "organization_owner",
+				ResourceType:      "organization",
+				ResourceId:        orgID,
+				IdentityId:        "",
+				OrganizationId:    orgID,
+				IdentityType:      "api-key",
+			},
+		},
+		Name: keyName,
+	}
+	return c.client.CreateKey(c.c.Context, req)
+}
+
 func (c *viamClient) ensureLoggedIn() error {
 	if c.client != nil {
 		return nil

--- a/cli/auth.go
+++ b/cli/auth.go
@@ -213,11 +213,11 @@ func OrganizationAPIKeyCreateAction(cCtx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	if c.conf.Auth == nil {
-		return errors.New("not logged in: run the following command to login:\n\tviam login")
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
 	}
-	orgID := c.c.String(apiKeyCreateFlagOrgID)
-	keyName := c.c.String(apiKeyCreateFlagName)
+	orgID := cCtx.String(apiKeyCreateFlagOrgID)
+	keyName := cCtx.String(apiKeyCreateFlagName)
 	if keyName == "" {
 		// Formats name as myusername@gmail.com-2009-11-10T23:00:00Z
 		keyName = fmt.Sprintf("%s-%s", c.conf.Auth.User.Email, time.Now().Format(time.RFC3339))
@@ -230,7 +230,7 @@ func OrganizationAPIKeyCreateAction(cCtx *cli.Context) error {
 	infof(cCtx.App.Writer, "successfully created key:")
 	fmt.Fprintf(cCtx.App.Writer, "key id: %s\n", resp.GetId())
 	fmt.Fprintf(cCtx.App.Writer, "key value: %s\n\n", resp.GetKey())
-	infof(cCtx.App.Writer, "keep this key somewhere safe; it has full write access to your organization")
+	warningf(cCtx.App.Writer, "keep this key somewhere safe; it has full write access to your organization")
 	return nil
 }
 

--- a/cli/auth.go
+++ b/cli/auth.go
@@ -207,14 +207,14 @@ func (c *viamClient) whoAmIAction(cCtx *cli.Context) error {
 	return nil
 }
 
-// OrganizationApiKeyCreateAction corresponds to `organization api-key create`
-func OrganizationApiKeyCreateAction(cCtx *cli.Context) error {
+// OrganizationAPIKeyCreateAction corresponds to `organization api-key create`.
+func OrganizationAPIKeyCreateAction(cCtx *cli.Context) error {
 	c, err := newViamClient(cCtx)
 	if err != nil {
 		return err
 	}
 	if c.conf.Auth == nil {
-		return errors.New("not logged in. run \"login\" command")
+		return errors.New("not logged in: run the following command to login:\n\tviam login")
 	}
 	orgID := c.c.String(apiKeyCreateFlagOrgID)
 	keyName := c.c.String(apiKeyCreateFlagName)
@@ -223,20 +223,20 @@ func OrganizationApiKeyCreateAction(cCtx *cli.Context) error {
 		keyName = fmt.Sprintf("%s-%s", c.conf.Auth.User.Email, time.Now().Format(time.RFC3339))
 		infof(cCtx.App.Writer, "using default key name of %q", keyName)
 	}
-	resp, err := c.createOrganizationApiKey(cCtx, orgID, keyName)
+	resp, err := c.createOrganizationAPIKey(orgID, keyName)
 	if err != nil {
 		return err
 	}
-	infof(cCtx.App.Writer, "successfully created key:", resp.GetKey())
+	infof(cCtx.App.Writer, "successfully created key:")
 	fmt.Fprintf(cCtx.App.Writer, "key id: %s\n", resp.GetId())
 	fmt.Fprintf(cCtx.App.Writer, "key value: %s\n\n", resp.GetKey())
 	infof(cCtx.App.Writer, "keep this key somewhere safe; it has full access to your organization")
 	return nil
 }
 
-func (c *viamClient) createOrganizationApiKey(cCtx *cli.Context, orgID, keyName string) (*apppb.CreateKeyResponse, error) {
+func (c *viamClient) createOrganizationAPIKey(orgID, keyName string) (*apppb.CreateKeyResponse, error) {
 	if err := c.ensureLoggedIn(); err != nil {
-		return err
+		return nil, err
 	}
 
 	req := &apppb.CreateKeyRequest{

--- a/cli/auth.go
+++ b/cli/auth.go
@@ -213,6 +213,10 @@ func OrganizationAPIKeyCreateAction(cCtx *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	return c.organizationAPIKeyCreateAction(cCtx)
+}
+
+func (c *viamClient) organizationAPIKeyCreateAction(cCtx *cli.Context) error {
 	if err := c.ensureLoggedIn(); err != nil {
 		return err
 	}

--- a/cli/auth.go
+++ b/cli/auth.go
@@ -230,7 +230,7 @@ func OrganizationAPIKeyCreateAction(cCtx *cli.Context) error {
 	infof(cCtx.App.Writer, "successfully created key:")
 	fmt.Fprintf(cCtx.App.Writer, "key id: %s\n", resp.GetId())
 	fmt.Fprintf(cCtx.App.Writer, "key value: %s\n\n", resp.GetKey())
-	infof(cCtx.App.Writer, "keep this key somewhere safe; it has full access to your organization")
+	infof(cCtx.App.Writer, "keep this key somewhere safe; it has full write access to your organization")
 	return nil
 }
 

--- a/cli/auth_test.go
+++ b/cli/auth_test.go
@@ -34,7 +34,6 @@ func TestPrintAccessTokenAction(t *testing.T) {
 }
 
 func TestAPIKeyCreateAction(t *testing.T) {
-	// AppServiceClient needed for any Action that calls ensureLoggedIn.
 	createKeyFunc := func(ctx context.Context, in *apppb.CreateKeyRequest,
 		opts ...grpc.CallOption,
 	) (*apppb.CreateKeyResponse, error) {

--- a/testutils/inject/app_service_client.go
+++ b/testutils/inject/app_service_client.go
@@ -12,6 +12,8 @@ type AppServiceClient struct {
 	apppb.AppServiceClient
 	ListOrganizationsFunc func(ctx context.Context, in *apppb.ListOrganizationsRequest,
 		opts ...grpc.CallOption) (*apppb.ListOrganizationsResponse, error)
+	CreateKeyFunc func(ctx context.Context, in *apppb.CreateKeyRequest,
+		opts ...grpc.CallOption) (*apppb.CreateKeyResponse, error)
 }
 
 // ListOrganizations calls the injected ListOrganizationsFunc or the real version.
@@ -22,4 +24,14 @@ func (asc *AppServiceClient) ListOrganizations(ctx context.Context, in *apppb.Li
 		return asc.AppServiceClient.ListOrganizations(ctx, in, opts...)
 	}
 	return asc.ListOrganizationsFunc(ctx, in, opts...)
+}
+
+// CreateKey calls the injected CreateKeyFunc or the real version.
+func (asc *AppServiceClient) CreateKey(ctx context.Context, in *apppb.CreateKeyRequest,
+	opts ...grpc.CallOption,
+) (*apppb.CreateKeyResponse, error) {
+	if asc.CreateKeyFunc == nil {
+		return asc.AppServiceClient.CreateKey(ctx, in, opts...)
+	}
+	return asc.CreateKeyFunc(ctx, in, opts...)
 }


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-4724
help msg for `viam organization api-key create`:
```
NAME:
   viam organization api-key create - create an api key for your organization

USAGE:
   viam organization api-key create [command options] [arguments...]

OPTIONS:
   --name value    the name of the key (defaults to your login info with the current time)
   --org-id value  the org to create an api key for
```
creating a key:
```

➜  cli git:(zp/2496) ✗ ./main --base-url="https://pr-2344-appmain-bplesliplq-uc.a.run.app:443" organization api-key create --org-id "43e11169-62e6-4dda-96b1-be2cad5d1878"
Info: using default key name of "zack.porter@viam.com-2023-08-30T16:45:13-04:00"
Info: successfully created key:
key id: 2a3380da-f047-0000-b6bf-5f4d0000f5c
key value: r00009undtvh0000iicl000000009ou2

Info: keep this key somewhere safe; it has full access to your organization
```
(changed the keys from real -- they don't actually have that many 0s)


(side note: we will now have both `organizations` and `organization` just like we have `robots` and `robot`. It would make sense to bring `organizations list` into `organization` and `robots list` into `robot`)