### PR TITLE
RSDK-4127 - Obstacles depth 3D clustering 

### DIFF
--- a/services/vision/client.go
+++ b/services/vision/client.go
@@ -222,9 +222,8 @@ func protoToObjects(pco []*commonpb.PointCloudObject) ([]*vision.Object, error) 
 			}
 			return ""
 		}()
-		n := len(o.Geometries.GetGeometries())
-		if i < n {
-			objects[i], err = vision.NewObjectWithLabel(pc, label, o.Geometries.GetGeometries()[i])
+		if len(o.Geometries.Geometries) >= 1 {
+			objects[i], err = vision.NewObjectWithLabel(pc, label, o.Geometries.GetGeometries()[0])
 		} else {
 			objects[i], err = vision.NewObjectWithLabel(pc, label, nil)
 		}


### PR DESCRIPTION
Hi, previously we were clustering these points in 2D, only to later project them out in order to make boxes. Now, we will cluster on the 3D points instead. With a k-means clustering implementation, this'll probably result in much improved accuracy with only a teeny tiny performance cost. 

Also, the vision client wasn't letting any of the other geometries (besides the first) slide through. I've included a quick fix for that. 

@biotinker I've added you as a reviewer (Bijan's OOO) but I've been told to let you know that you can focus more on the "Golang and style" and less on the "what is CV doing," if that makes sense. 