### PR TITLE
RSDK-4734 More polishing of CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ coverage2.txt
 coverage.xml
 profile*.pdf
 code-coverage-results.md
+cli/metadata
 
 *~
 *#

--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ coverage2.txt
 coverage.xml
 profile*.pdf
 code-coverage-results.md
-cli/metadata
+metadata
 
 *~
 *#

--- a/cli/auth.go
+++ b/cli/auth.go
@@ -123,12 +123,13 @@ func LoginAction(cCtx *cli.Context) error {
 
 func (c *viamClient) loginAction(cCtx *cli.Context) error {
 	loggedInMessage := func(t *token, alreadyLoggedIn bool) {
-		already := "already "
+		already := "Already l"
 		if !alreadyLoggedIn {
-			already = ""
+			already = "L"
 			viamLogo(cCtx.App.Writer)
 		}
-		printf(cCtx.App.Writer, "%slogged in as %q, expires %s", already, t.User.Email,
+
+		printf(cCtx.App.Writer, "%sogged in as %q, expires %s", already, t.User.Email,
 			t.ExpiresAt.Format("Mon Jan 2 15:04:05 MST 2006"))
 	}
 
@@ -208,9 +209,9 @@ func (c *viamClient) printAccessTokenAction(cCtx *cli.Context) error {
 	}
 
 	if token, ok := c.conf.Auth.(*token); ok {
-		fmt.Fprintln(cCtx.App.Writer, token.AccessToken)
+		printf(cCtx.App.Writer, token.AccessToken)
 	} else {
-		return errors.New("not logged in as a user. cannot print access token. run \"viam login\" to sign in with your account")
+		return errors.New("not logged in as a user. Cannot print access token. Run \"viam login\" to sign in with your account")
 	}
 	return nil
 }
@@ -236,13 +237,13 @@ func LogoutAction(cCtx *cli.Context) error {
 func (c *viamClient) logoutAction(cCtx *cli.Context) error {
 	auth := c.conf.Auth
 	if auth == nil {
-		printf(cCtx.App.Writer, "already logged out")
+		printf(cCtx.App.Writer, "Already logged out")
 		return nil
 	}
 	if err := c.logout(); err != nil {
 		return errors.Wrap(err, "could not logout")
 	}
-	printf(cCtx.App.Writer, "logged out from %q", auth)
+	printf(cCtx.App.Writer, "Logged out from %q", auth)
 	return nil
 }
 
@@ -256,8 +257,9 @@ func WhoAmIAction(cCtx *cli.Context) error {
 }
 
 func (c *viamClient) whoAmIAction(cCtx *cli.Context) error {
-	if c.conf.Auth == nil {
-		warningf(cCtx.App.Writer, "not logged in. run \"login\" command")
+	auth := c.conf.Auth
+	if auth == nil {
+		warningf(cCtx.App.Writer, "Not logged in. Run \"login\" command")
 		return nil
 	}
 	printf(cCtx.App.Writer, "%s", c.conf.Auth)
@@ -555,8 +557,8 @@ func (a *authFlow) makeDeviceCodeRequest(ctx context.Context, discovery *openIDD
 }
 
 func (a *authFlow) directUser(code *deviceCodeResponse) error {
-	infof(a.console, `you can log into Viam through the opened browser window or follow the URL below.
-ensure the code in the URL matches the one shown in your browser.
+	infof(a.console, `You can log into Viam through the opened browser window or follow the URL below.
+Ensure the code in the URL matches the one shown in your browser.
   %s`, code.VerificationURIComplete)
 
 	if a.disableBrowserOpen {

--- a/cli/auth.go
+++ b/cli/auth.go
@@ -128,7 +128,7 @@ func (c *viamClient) loginAction(cCtx *cli.Context) error {
 			already = ""
 			viamLogo(cCtx.App.Writer)
 		}
-		fmt.Fprintf(cCtx.App.Writer, "%slogged in as %q, expires %s\n", already, t.User.Email,
+		printf(cCtx.App.Writer, "%slogged in as %q, expires %s", already, t.User.Email,
 			t.ExpiresAt.Format("Mon Jan 2 15:04:05 MST 2006"))
 	}
 
@@ -236,13 +236,13 @@ func LogoutAction(cCtx *cli.Context) error {
 func (c *viamClient) logoutAction(cCtx *cli.Context) error {
 	auth := c.conf.Auth
 	if auth == nil {
-		fmt.Fprintf(cCtx.App.Writer, "already logged out\n")
+		printf(cCtx.App.Writer, "already logged out")
 		return nil
 	}
 	if err := c.logout(); err != nil {
 		return errors.Wrap(err, "could not logout")
 	}
-	fmt.Fprintf(cCtx.App.Writer, "logged out from %q\n", auth)
+	printf(cCtx.App.Writer, "logged out from %q", auth)
 	return nil
 }
 
@@ -260,7 +260,7 @@ func (c *viamClient) whoAmIAction(cCtx *cli.Context) error {
 		warningf(cCtx.App.Writer, "not logged in. run \"login\" command")
 		return nil
 	}
-	fmt.Fprintf(cCtx.App.Writer, "%s\n", c.conf.Auth)
+	printf(cCtx.App.Writer, "%s", c.conf.Auth)
 	return nil
 }
 

--- a/cli/auth.go
+++ b/cli/auth.go
@@ -291,10 +291,10 @@ func (c *viamClient) organizationAPIKeyCreateAction(cCtx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	infof(cCtx.App.Writer, "successfully created key:")
-	fmt.Fprintf(cCtx.App.Writer, "key id: %s\n", resp.GetId())
-	fmt.Fprintf(cCtx.App.Writer, "key value: %s\n\n", resp.GetKey())
-	warningf(cCtx.App.Writer, "keep this key somewhere safe; it has full write access to your organization")
+	infof(cCtx.App.Writer, "Successfully created key:")
+	printf(cCtx.App.Writer, "Key ID: %s\n", resp.GetId())
+	printf(cCtx.App.Writer, "Key Value: %s\n\n", resp.GetKey())
+	warningf(cCtx.App.Writer, "Keep this key somewhere safe; it has full write access to your organization")
 	return nil
 }
 

--- a/cli/auth.go
+++ b/cli/auth.go
@@ -190,7 +190,7 @@ func (c viamClient) loginWithAPIKeyAction(cCtx *cli.Context) error {
 	if _, err := c.listOrganizations(); err != nil {
 		return errors.Wrapf(err, "unable to connect to %q using the provided api key", c.conf.BaseURL)
 	}
-	fmt.Fprintf(cCtx.App.Writer, "successfully logged in with api key %q\n", key.KeyID)
+	printf(cCtx.App.Writer, "Successfully logged in with api key %q", key.KeyID)
 	return nil
 }
 
@@ -262,7 +262,7 @@ func (c *viamClient) whoAmIAction(cCtx *cli.Context) error {
 		warningf(cCtx.App.Writer, "Not logged in. Run \"login\" command")
 		return nil
 	}
-	printf(cCtx.App.Writer, "%s", c.conf.Auth)
+	printf(cCtx.App.Writer, "%s", auth)
 	return nil
 }
 
@@ -285,7 +285,7 @@ func (c *viamClient) organizationAPIKeyCreateAction(cCtx *cli.Context) error {
 		// Default name is in the form myusername@gmail.com-2009-11-10T23:00:00Z
 		// or key-uuid-2009-11-10T23:00:00Z if it was created by a key
 		keyName = fmt.Sprintf("%s-%s", c.conf.Auth, time.Now().Format(time.RFC3339))
-		infof(cCtx.App.Writer, "using default key name of %q", keyName)
+		infof(cCtx.App.Writer, "Using default key name of %q", keyName)
 	}
 	resp, err := c.createOrganizationAPIKey(orgID, keyName)
 	if err != nil {

--- a/cli/auth.go
+++ b/cli/auth.go
@@ -217,11 +217,20 @@ func (c *viamClient) printAccessTokenAction(cCtx *cli.Context) error {
 
 // LogoutAction is the corresponding Action for 'logout'.
 func LogoutAction(cCtx *cli.Context) error {
-	c, err := newViamClient(cCtx)
+	// Create basic viam client; no need to check base URL.
+	conf, err := configFromCache()
 	if err != nil {
-		return err
+		if !os.IsNotExist(err) {
+			return err
+		}
+		conf = &config{}
 	}
-	return c.logoutAction(cCtx)
+
+	vc := &viamClient{
+		c:    cCtx,
+		conf: conf,
+	}
+	return vc.logoutAction(cCtx)
 }
 
 func (c *viamClient) logoutAction(cCtx *cli.Context) error {

--- a/cli/auth_test.go
+++ b/cli/auth_test.go
@@ -21,7 +21,7 @@ func TestLoginAction(t *testing.T) {
 	test.That(t, len(errOut.messages), test.ShouldEqual, 0)
 	test.That(t, len(out.messages), test.ShouldEqual, 1)
 	test.That(t, out.messages[0], test.ShouldContainSubstring,
-		fmt.Sprintf("already logged in as %q", testEmail))
+		fmt.Sprintf("Already logged in as %q", testEmail))
 }
 
 func TestPrintAccessTokenAction(t *testing.T) {
@@ -59,7 +59,7 @@ func TestLogoutAction(t *testing.T) {
 	test.That(t, len(errOut.messages), test.ShouldEqual, 0)
 	test.That(t, len(out.messages), test.ShouldEqual, 1)
 	test.That(t, out.messages[0], test.ShouldContainSubstring,
-		fmt.Sprintf("logged out from %q", testEmail))
+		fmt.Sprintf("Logged out from %q", testEmail))
 }
 
 func TestWhoAmIAction(t *testing.T) {

--- a/cli/boards.go
+++ b/cli/boards.go
@@ -76,7 +76,7 @@ func UploadBoardDefsAction(ctx *cli.Context) error {
 		return err
 	}
 
-	fmt.Fprintf(ctx.App.Writer, "Board definitions file was successfully uploaded!\n")
+	printf(ctx.App.Writer, "Board definitions file was successfully uploaded!")
 	return nil
 }
 
@@ -106,7 +106,7 @@ func DownloadBoardDefsAction(c *cli.Context) error {
 		return err
 	}
 
-	fmt.Fprintf(c.App.Writer, "%s board definitions successfully downloaded!\n", nameArg)
+	printf(c.App.Writer, "%s board definitions successfully downloaded!", nameArg)
 
 	return nil
 }

--- a/cli/client.go
+++ b/cli/client.go
@@ -72,9 +72,9 @@ func (c *viamClient) listOrganizationsAction(cCtx *cli.Context) error {
 	}
 	for i, org := range orgs {
 		if i == 0 {
-			fmt.Fprintf(cCtx.App.Writer, "organizations for %q:\n", c.conf.Auth)
+			printf(cCtx.App.Writer, "organizations for %q:", c.conf.Auth)
 		}
-		fmt.Fprintf(cCtx.App.Writer, "\t%s (id: %s)\n", org.Name, org.Id)
+		printf(cCtx.App.Writer, "\t%s (id: %s)", org.Name, org.Id)
 	}
 	return nil
 }
@@ -92,7 +92,7 @@ func ListLocationsAction(c *cli.Context) error {
 			return errors.Wrap(err, "could not list locations")
 		}
 		for _, loc := range locs {
-			fmt.Fprintf(c.App.Writer, "\t%s (id: %s)\n", loc.Name, loc.Id)
+			printf(c.App.Writer, "\t%s (id: %s)", loc.Name, loc.Id)
 		}
 		return nil
 	}
@@ -103,9 +103,9 @@ func ListLocationsAction(c *cli.Context) error {
 		}
 		for i, org := range orgs {
 			if i == 0 {
-				fmt.Fprintf(c.App.Writer, "locations for %q:\n", client.conf.Auth)
+				printf(c.App.Writer, "locations for %q:", client.conf.Auth)
 			}
-			fmt.Fprintf(c.App.Writer, "%s:\n", org.Name)
+			printf(c.App.Writer, "%s:", org.Name)
 			if err := listLocations(org.Id); err != nil {
 				return err
 			}
@@ -129,11 +129,11 @@ func ListRobotsAction(c *cli.Context) error {
 	}
 
 	if orgStr == "" || locStr == "" {
-		fmt.Fprintf(c.App.Writer, "%s -> %s\n", client.selectedOrg.Name, client.selectedLoc.Name)
+		printf(c.App.Writer, "%s -> %s", client.selectedOrg.Name, client.selectedLoc.Name)
 	}
 
 	for _, robot := range robots {
-		fmt.Fprintf(c.App.Writer, "%s (id: %s)\n", robot.Name, robot.Id)
+		printf(c.App.Writer, "%s (id: %s)", robot.Name, robot.Id)
 	}
 	return nil
 }
@@ -157,12 +157,12 @@ func RobotStatusAction(c *cli.Context) error {
 	}
 
 	if orgStr == "" || locStr == "" {
-		fmt.Fprintf(c.App.Writer, "%s -> %s\n", client.selectedOrg.Name, client.selectedLoc.Name)
+		printf(c.App.Writer, "%s -> %s", client.selectedOrg.Name, client.selectedLoc.Name)
 	}
 
-	fmt.Fprintf(
+	printf(
 		c.App.Writer,
-		"ID: %s\nname: %s\nlast access: %s (%s ago)\n",
+		"ID: %s\nname: %s\nlast access: %s (%s ago)",
 		robot.Id,
 		robot.Name,
 		robot.LastAccess.AsTime().Format(time.UnixDate),
@@ -177,9 +177,9 @@ func RobotStatusAction(c *cli.Context) error {
 		if part.MainPart {
 			name += " (main)"
 		}
-		fmt.Fprintf(
+		printf(
 			c.App.Writer,
-			"\tID: %s\n\tname: %s\n\tlast access: %s (%s ago)\n",
+			"\tID: %s\n\tname: %s\n\tlast access: %s (%s ago)",
 			part.Id,
 			name,
 			part.LastAccess.AsTime().Format(time.UnixDate),
@@ -258,16 +258,16 @@ func RobotPartStatusAction(c *cli.Context) error {
 	}
 
 	if orgStr == "" || locStr == "" || robotStr == "" {
-		fmt.Fprintf(c.App.Writer, "%s -> %s -> %s\n", client.selectedOrg.Name, client.selectedLoc.Name, robot.Name)
+		printf(c.App.Writer, "%s -> %s -> %s", client.selectedOrg.Name, client.selectedLoc.Name, robot.Name)
 	}
 
 	name := part.Name
 	if part.MainPart {
 		name += " (main)"
 	}
-	fmt.Fprintf(
+	printf(
 		c.App.Writer,
-		"ID: %s\nname: %s\nlast access: %s (%s ago)\n",
+		"ID: %s\nname: %s\nlast access: %s (%s ago)",
 		part.Id,
 		name,
 		part.LastAccess.AsTime().Format(time.UnixDate),
@@ -375,7 +375,7 @@ func VersionAction(c *cli.Context) error {
 		return errors.New("error reading build info")
 	}
 	if c.Bool(debugFlag) {
-		fmt.Fprintf(c.App.Writer, "%s\n", info.String())
+		printf(c.App.Writer, "%s", info.String())
 	}
 	settings := make(map[string]string, len(info.Settings))
 	for _, setting := range info.Settings {
@@ -400,7 +400,7 @@ func VersionAction(c *cli.Context) error {
 	if appVersion == "" {
 		appVersion = "(dev)"
 	}
-	fmt.Fprintf(c.App.Writer, "version %s git=%s api=%s\n", appVersion, version, apiVersion)
+	printf(c.App.Writer, "version %s git=%s api=%s", appVersion, version, apiVersion)
 	return nil
 }
 
@@ -768,9 +768,9 @@ func (c *viamClient) robotParts(orgStr, locStr, robotStr string) ([]*apppb.Robot
 
 func (c *viamClient) printRobotPartLogsInner(logs []*apppb.LogEntry, indent string) {
 	for _, log := range logs {
-		fmt.Fprintf(
+		printf(
 			c.c.App.Writer,
-			"%s%s\t%s\t%s\t%s\n",
+			"%s%s\t%s\t%s\t%s",
 			indent,
 			log.Time.AsTime().Format("2006-01-02T15:04:05.000Z0700"),
 			log.Level,
@@ -790,7 +790,7 @@ func (c *viamClient) printRobotPartLogs(orgStr, locStr, robotStr, partStr string
 		fmt.Fprintln(c.c.App.Writer, header)
 	}
 	if len(logs) == 0 {
-		fmt.Fprintf(c.c.App.Writer, "%sno recent logs\n", indent)
+		printf(c.c.App.Writer, "%sno recent logs", indent)
 		return nil
 	}
 	c.printRobotPartLogsInner(logs, indent)

--- a/cli/client.go
+++ b/cli/client.go
@@ -439,7 +439,8 @@ func parseBaseURL(baseURL string, verifyConnection bool) (*url.URL, []rpc.DialOp
 		// Check if URL is even valid with a TCP dial.
 		conn, err := net.DialTimeout("tcp", baseURLParsed.Host, 3*time.Second)
 		if err != nil {
-			return nil, nil, fmt.Errorf("value of %q argument %q is an unreachable URL", baseURLFlag, baseURL)
+			return nil, nil, fmt.Errorf("base URL %q (needed for auth) is currently unreachable. "+
+				"Ensure URL is valid and you are connected to internet", baseURLParsed.Host)
 		}
 		utils.UncheckedError(conn.Close())
 	}

--- a/cli/client.go
+++ b/cli/client.go
@@ -72,7 +72,7 @@ func (c *viamClient) listOrganizationsAction(cCtx *cli.Context) error {
 	}
 	for i, org := range orgs {
 		if i == 0 {
-			printf(cCtx.App.Writer, "organizations for %q:", c.conf.Auth)
+			printf(cCtx.App.Writer, "Organizations for %q:", c.conf.Auth)
 		}
 		printf(cCtx.App.Writer, "\t%s (id: %s)", org.Name, org.Id)
 	}
@@ -103,7 +103,7 @@ func ListLocationsAction(c *cli.Context) error {
 		}
 		for i, org := range orgs {
 			if i == 0 {
-				printf(c.App.Writer, "locations for %q:", client.conf.Auth)
+				printf(c.App.Writer, "Locations for %q:", client.conf.Auth)
 			}
 			printf(c.App.Writer, "%s:", org.Name)
 			if err := listLocations(org.Id); err != nil {
@@ -162,7 +162,7 @@ func RobotStatusAction(c *cli.Context) error {
 
 	printf(
 		c.App.Writer,
-		"ID: %s\nname: %s\nlast access: %s (%s ago)",
+		"ID: %s\nName: %s\nLast Access: %s (%s ago)",
 		robot.Id,
 		robot.Name,
 		robot.LastAccess.AsTime().Format(time.UnixDate),
@@ -170,7 +170,7 @@ func RobotStatusAction(c *cli.Context) error {
 	)
 
 	if len(parts) != 0 {
-		fmt.Fprintln(c.App.Writer, "parts:")
+		printf(c.App.Writer, "Parts:")
 	}
 	for i, part := range parts {
 		name := part.Name
@@ -179,14 +179,14 @@ func RobotStatusAction(c *cli.Context) error {
 		}
 		printf(
 			c.App.Writer,
-			"\tID: %s\n\tname: %s\n\tlast access: %s (%s ago)",
+			"\tID: %s\n\tName: %s\n\tLast Access: %s (%s ago)",
 			part.Id,
 			name,
 			part.LastAccess.AsTime().Format(time.UnixDate),
 			time.Since(part.LastAccess.AsTime()),
 		)
 		if i != len(parts)-1 {
-			fmt.Fprintln(c.App.Writer, "")
+			printf(c.App.Writer, "")
 		}
 	}
 
@@ -215,7 +215,7 @@ func RobotLogsAction(c *cli.Context) error {
 
 	for i, part := range parts {
 		if i != 0 {
-			fmt.Fprintln(c.App.Writer, "")
+			printf(c.App.Writer, "")
 		}
 
 		var header string
@@ -267,7 +267,7 @@ func RobotPartStatusAction(c *cli.Context) error {
 	}
 	printf(
 		c.App.Writer,
-		"ID: %s\nname: %s\nlast access: %s (%s ago)",
+		"ID: %s\nName: %s\nLast Access: %s (%s ago)",
 		part.Id,
 		name,
 		part.LastAccess.AsTime().Format(time.UnixDate),
@@ -345,7 +345,7 @@ func RobotPartRunAction(c *cli.Context) error {
 
 // RobotPartShellAction is the corresponding Action for 'robot part shell'.
 func RobotPartShellAction(c *cli.Context) error {
-	infof(c.App.Writer, "ensure robot part has a valid shell type service")
+	infof(c.App.Writer, "Ensure robot part has a valid shell type service")
 
 	client, err := newViamClient(c)
 	if err != nil {
@@ -400,7 +400,7 @@ func VersionAction(c *cli.Context) error {
 	if appVersion == "" {
 		appVersion = "(dev)"
 	}
-	printf(c.App.Writer, "version %s git=%s api=%s", appVersion, version, apiVersion)
+	printf(c.App.Writer, "Version %s Git=%s API=%s", appVersion, version, apiVersion)
 	return nil
 }
 
@@ -435,8 +435,8 @@ func parseBaseURL(baseURL string, verifyConnection bool) (*url.URL, []rpc.DialOp
 		}
 	}
 
-	// Check if URL is even valid with a TCP dial.
 	if verifyConnection {
+		// Check if URL is even valid with a TCP dial.
 		conn, err := net.DialTimeout("tcp", baseURLParsed.Host, 3*time.Second)
 		if err != nil {
 			return nil, nil, fmt.Errorf("value of %q argument %q is an unreachable URL", baseURLFlag, baseURL)
@@ -475,12 +475,12 @@ func newViamClient(c *cli.Context) (*viamClient, error) {
 	case conf.BaseURL == "" && baseURLArg != "":
 		conf.BaseURL = baseURLArg
 	case baseURLArg != "" && conf.BaseURL != "" && conf.BaseURL != baseURLArg:
-		return nil, fmt.Errorf("cached base URL for this session is %q, "+
-			"please logout and login again to use provided base URL %q", conf.BaseURL, baseURLArg)
+		return nil, fmt.Errorf("cached base URL for this session is %q. "+
+			"Please logout and login again to use provided base URL %q", conf.BaseURL, baseURLArg)
 	}
 
 	if conf.BaseURL != defaultBaseURL {
-		infof(c.App.Writer, "using %q as base URL value", conf.BaseURL)
+		infof(c.App.Writer, "Using %q as base URL value", conf.BaseURL)
 	}
 	baseURL, rpcOpts, err := parseBaseURL(conf.BaseURL, true)
 	if err != nil {
@@ -787,10 +787,10 @@ func (c *viamClient) printRobotPartLogs(orgStr, locStr, robotStr, partStr string
 	}
 
 	if header != "" {
-		fmt.Fprintln(c.c.App.Writer, header)
+		printf(c.c.App.Writer, header)
 	}
 	if len(logs) == 0 {
-		printf(c.c.App.Writer, "%sno recent logs", indent)
+		printf(c.c.App.Writer, "%sNo recent logs", indent)
 		return nil
 	}
 	c.printRobotPartLogsInner(logs, indent)
@@ -812,7 +812,7 @@ func (c *viamClient) tailRobotPartLogs(orgStr, locStr, robotStr, partStr string,
 	}
 
 	if header != "" {
-		fmt.Fprintln(c.c.App.Writer, header)
+		printf(c.c.App.Writer, header)
 	}
 
 	for {
@@ -935,7 +935,7 @@ func (c *viamClient) startRobotPartShell(
 	}
 
 	if debug {
-		fmt.Fprintln(c.c.App.Writer, "establishing connection...")
+		printf(c.c.App.Writer, "Establishing connection...")
 	}
 	robotClient, err := client.New(dialCtx, fqdn, logger, client.WithDialOptions(rpcOpts...))
 	if err != nil {

--- a/cli/client.go
+++ b/cli/client.go
@@ -1026,10 +1026,10 @@ func (c *viamClient) startRobotPartShell(
 			case outputData, ok := <-output:
 				if ok {
 					if outputData.Output != "" {
-						fmt.Fprint(c.c.App.Writer, outputData.Output)
+						fmt.Fprint(c.c.App.Writer, outputData.Output) // no newline
 					}
 					if outputData.Error != "" {
-						fmt.Fprint(c.c.App.ErrWriter, outputData.Error)
+						fmt.Fprint(c.c.App.ErrWriter, outputData.Error) // no newline
 					}
 					if outputData.EOF {
 						return

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -80,7 +80,7 @@ func TestListOrganizationsAction(t *testing.T) {
 	test.That(t, ac.listOrganizationsAction(cCtx), test.ShouldBeNil)
 	test.That(t, len(errOut.messages), test.ShouldEqual, 0)
 	test.That(t, len(out.messages), test.ShouldEqual, 3)
-	test.That(t, out.messages[0], test.ShouldEqual, fmt.Sprintf("organizations for %q:\n", testEmail))
+	test.That(t, out.messages[0], test.ShouldEqual, fmt.Sprintf("Organizations for %q:\n", testEmail))
 	test.That(t, out.messages[1], test.ShouldContainSubstring, "jedi")
 	test.That(t, out.messages[2], test.ShouldContainSubstring, "mandalorians")
 }
@@ -114,7 +114,7 @@ func TestTabularDataByFilterAction(t *testing.T) {
 	test.That(t, ac.dataExportAction(cCtx), test.ShouldBeNil)
 	test.That(t, len(errOut.messages), test.ShouldEqual, 0)
 	test.That(t, len(out.messages), test.ShouldEqual, 4)
-	test.That(t, out.messages[0], test.ShouldEqual, "downloading..")
+	test.That(t, out.messages[0], test.ShouldEqual, "Downloading..")
 	test.That(t, out.messages[1], test.ShouldEqual, ".")
 	test.That(t, out.messages[2], test.ShouldEqual, ".")
 	test.That(t, out.messages[3], test.ShouldEqual, "\n")

--- a/cli/data.go
+++ b/cli/data.go
@@ -258,7 +258,7 @@ func (c *viamClient) binaryData(dst string, filter *datapb.Filter, parallelDownl
 					}
 					numFilesDownloaded.Add(1)
 					if numFilesDownloaded.Load()%logEveryN == 0 {
-						printf(c.c.App.Writer, "downloaded %d files", numFilesDownloaded.Load())
+						printf(c.c.App.Writer, "Downloaded %d files", numFilesDownloaded.Load())
 					}
 				}(nextID)
 			}
@@ -268,7 +268,7 @@ func (c *viamClient) binaryData(dst string, filter *datapb.Filter, parallelDownl
 			}
 		}
 		if numFilesDownloaded.Load()%logEveryN != 0 {
-			printf(c.c.App.Writer, "downloaded %d files to %s", numFilesDownloaded.Load(), dst)
+			printf(c.c.App.Writer, "Downloaded %d files to %s", numFilesDownloaded.Load(), dst)
 		}
 	}()
 	wg.Wait()
@@ -411,7 +411,7 @@ func (c *viamClient) tabularData(dst string, filter *datapb.Filter) error {
 	}
 	w := bufio.NewWriter(dataFile)
 
-	fmt.Fprintf(c.c.App.Writer, "downloading..") // no newline
+	fmt.Fprintf(c.c.App.Writer, "Downloading..") // no newline
 	var last string
 	mdIndexes := make(map[string]int)
 	mdIndex := 0
@@ -517,7 +517,7 @@ func (c *viamClient) deleteBinaryData(filter *datapb.Filter) error {
 	if err != nil {
 		return errors.Wrapf(err, "received error from server")
 	}
-	printf(c.c.App.Writer, "deleted %d files", resp.GetDeletedCount())
+	printf(c.c.App.Writer, "Deleted %d files", resp.GetDeletedCount())
 	return nil
 }
 
@@ -531,6 +531,6 @@ func (c *viamClient) deleteTabularData(orgID string, deleteOlderThanDays int) er
 	if err != nil {
 		return errors.Wrapf(err, "received error from server")
 	}
-	printf(c.c.App.Writer, "deleted %d datapoints", resp.GetDeletedCount())
+	printf(c.c.App.Writer, "Deleted %d datapoints", resp.GetDeletedCount())
 	return nil
 }

--- a/cli/data.go
+++ b/cli/data.go
@@ -258,7 +258,7 @@ func (c *viamClient) binaryData(dst string, filter *datapb.Filter, parallelDownl
 					}
 					numFilesDownloaded.Add(1)
 					if numFilesDownloaded.Load()%logEveryN == 0 {
-						fmt.Fprintf(c.c.App.Writer, "downloaded %d files\n", numFilesDownloaded.Load())
+						printf(c.c.App.Writer, "downloaded %d files", numFilesDownloaded.Load())
 					}
 				}(nextID)
 			}
@@ -268,7 +268,7 @@ func (c *viamClient) binaryData(dst string, filter *datapb.Filter, parallelDownl
 			}
 		}
 		if numFilesDownloaded.Load()%logEveryN != 0 {
-			fmt.Fprintf(c.c.App.Writer, "downloaded %d files to %s\n", numFilesDownloaded.Load(), dst)
+			printf(c.c.App.Writer, "downloaded %d files to %s", numFilesDownloaded.Load(), dst)
 		}
 	}()
 	wg.Wait()
@@ -411,7 +411,7 @@ func (c *viamClient) tabularData(dst string, filter *datapb.Filter) error {
 	}
 	w := bufio.NewWriter(dataFile)
 
-	fmt.Fprintf(c.c.App.Writer, "downloading..")
+	fmt.Fprintf(c.c.App.Writer, "downloading..") // no newline
 	var last string
 	mdIndexes := make(map[string]int)
 	mdIndex := 0
@@ -425,7 +425,7 @@ func (c *viamClient) tabularData(dst string, filter *datapb.Filter) error {
 				},
 				CountOnly: false,
 			})
-			fmt.Fprintf(c.c.App.Writer, ".")
+			fmt.Fprintf(c.c.App.Writer, ".") // no newline
 			if err == nil {
 				break
 			}
@@ -490,7 +490,7 @@ func (c *viamClient) tabularData(dst string, filter *datapb.Filter) error {
 		}
 	}
 
-	fmt.Fprintf(c.c.App.Writer, "\n")
+	printf(c.c.App.Writer, "") // newline
 	if err := w.Flush(); err != nil {
 		return errors.Wrapf(err, "could not flush writer for %s", dataFile.Name())
 	}
@@ -517,7 +517,7 @@ func (c *viamClient) deleteBinaryData(filter *datapb.Filter) error {
 	if err != nil {
 		return errors.Wrapf(err, "received error from server")
 	}
-	fmt.Fprintf(c.c.App.Writer, "deleted %d files\n", resp.GetDeletedCount())
+	printf(c.c.App.Writer, "deleted %d files", resp.GetDeletedCount())
 	return nil
 }
 
@@ -531,6 +531,6 @@ func (c *viamClient) deleteTabularData(orgID string, deleteOlderThanDays int) er
 	if err != nil {
 		return errors.Wrapf(err, "received error from server")
 	}
-	fmt.Fprintf(c.c.App.Writer, "deleted %d datapoints\n", resp.GetDeletedCount())
+	printf(c.c.App.Writer, "deleted %d datapoints", resp.GetDeletedCount())
 	return nil
 }

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -78,7 +78,7 @@ func CreateModuleAction(c *cli.Context) error {
 	}
 	// Check to make sure the user doesn't accidentally overwrite a module manifest
 	if _, err := os.Stat(defaultManifestFilename); err == nil {
-		return errors.New("another module's meta.json already exists in the current directory. delete it and try again")
+		return errors.New("another module's meta.json already exists in the current directory. Delete it and try again")
 	}
 
 	response, err := client.createModule(moduleNameArg, org.GetId())
@@ -91,9 +91,9 @@ func CreateModuleAction(c *cli.Context) error {
 		return err
 	}
 
-	fmt.Fprintf(c.App.Writer, "successfully created '%s'.\n", returnedModuleID.String())
+	printf(c.App.Writer, "Successfully created '%s'", returnedModuleID.String())
 	if response.GetUrl() != "" {
-		fmt.Fprintf(c.App.Writer, "you can view it here: %s \n", response.GetUrl())
+		printf(c.App.Writer, "You can view it here: %s", response.GetUrl())
 	}
 	emptyManifest := moduleManifest{
 		ModuleID:   returnedModuleID.String(),
@@ -106,7 +106,7 @@ func CreateModuleAction(c *cli.Context) error {
 	if err := writeManifest(defaultManifestFilename, emptyManifest); err != nil {
 		return err
 	}
-	fmt.Fprintf(c.App.Writer, "configuration for the module has been written to meta.json\n")
+	printf(c.App.Writer, "Configuration for the module has been written to meta.json\n")
 	return nil
 }
 
@@ -151,7 +151,7 @@ func UpdateModuleAction(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(c.App.Writer, "module successfully updated! you can view your changes online here: %s\n", response.GetUrl())
+	printf(c.App.Writer, "Module successfully updated! You can view your changes online here: %s\n", response.GetUrl())
 
 	// if we have gotten this far it means that moduleID will have a prefix in it
 	// because the validate command resolves the orgId or namespace to the moduleID with the namespace as the priority
@@ -180,10 +180,10 @@ func UploadModuleAction(c *cli.Context) error {
 	tarballPath := c.Args().First()
 	if c.Args().Len() > 1 {
 		return errors.New("too many arguments passed to upload command. " +
-			"make sure to specify flag and optional arguments before the required positional package argument")
+			"Make sure to specify flag and optional arguments before the required positional package argument")
 	}
 	if tarballPath == "" {
-		return errors.New("no package to upload -- please provide an archive containing your module. use --help for more information")
+		return errors.New("no package to upload -- please provide an archive containing your module. Use --help for more information")
 	}
 
 	client, err := newViamClient(c)
@@ -201,7 +201,7 @@ func UploadModuleAction(c *cli.Context) error {
 		// no manifest found.
 		if nameArg == "" || (publicNamespaceArg == "" && orgIDArg == "") {
 			return errors.New("unable to find the meta.json. " +
-				"if you want to upload a version without a meta.json, you must supply a module name and namespace (or module name and org-id)",
+				"If you want to upload a version without a meta.json, you must supply a module name and namespace (or module name and org-id)",
 			)
 		}
 	} else {
@@ -249,7 +249,7 @@ func UploadModuleAction(c *cli.Context) error {
 		return err
 	}
 
-	fmt.Fprintf(c.App.Writer, "version successfully uploaded! you can view your changes online here: %s\n", response.GetUrl())
+	printf(c.App.Writer, "Version successfully uploaded! you can view your changes online here: %s", response.GetUrl())
 
 	return nil
 }
@@ -351,7 +351,7 @@ func sendModuleUploadRequests(ctx context.Context, stream apppb.AppService_Uploa
 	fileSize := stat.Size()
 	uploadedBytes := 0
 	// Close the line with the progress reading
-	defer fmt.Fprint(stdout, "\n")
+	defer printf(stdout, "")
 
 	//nolint:errcheck
 	defer stream.CloseSend()
@@ -378,7 +378,7 @@ func sendModuleUploadRequests(ctx context.Context, stream apppb.AppService_Uploa
 		uploadedBytes += len(uploadReq.GetFile())
 		// Simple progress reading until we have a proper tui library
 		uploadPercent := int(math.Ceil(100 * float64(uploadedBytes) / float64(fileSize)))
-		fmt.Fprintf(stdout, "\ruploading... %d%% (%d/%d bytes)", uploadPercent, uploadedBytes, fileSize)
+		fmt.Fprintf(stdout, "\rUploading... %d%% (%d/%d bytes)", uploadPercent, uploadedBytes, fileSize) // no newline
 	}
 }
 
@@ -454,7 +454,7 @@ func validateModuleFile(client *viamClient, moduleID moduleID, tarballPath, vers
 	}
 	extraErrInfo := ""
 	if len(filesWithSameNameAsEntrypoint) > 0 {
-		extraErrInfo = fmt.Sprintf(". did you mean to set your entrypoint to %v?", filesWithSameNameAsEntrypoint)
+		extraErrInfo = fmt.Sprintf(". Did you mean to set your entrypoint to %v?", filesWithSameNameAsEntrypoint)
 	}
 	return errors.Errorf("the provided tarball %q does not contain a file at the desired entrypoint %q%s",
 		tarballPath, entrypoint, extraErrInfo)
@@ -490,7 +490,7 @@ func parseModuleID(id string) (moduleID, error) {
 		return moduleID{prefix: splitModuleName[0], name: splitModuleName[1]}, nil
 	default:
 		return moduleID{}, errors.Errorf("invalid module name '%s'."+
-			" module name must be in the form 'prefix:module-name' for public modules"+
+			" Module name must be in the form 'prefix:module-name' for public modules"+
 			" or just 'module-name' for private modules in organizations without a public namespace", id)
 	}
 }
@@ -533,7 +533,7 @@ func validateModuleID(
 				return moduleID{}, errors.Errorf("the meta.json specifies a different org %q than the one provided via args %q",
 					org.GetName(), expectedOrg.GetName())
 			}
-			fmt.Fprintln(c.App.Writer, "the module's meta.json already specifies a full module id. ignoring public-namespace and org-id arg")
+			printf(c.App.Writer, "the module's meta.json already specifies a full module id. Ignoring public-namespace and org-id arg")
 		}
 		return mid, nil
 	}

--- a/cli/print.go
+++ b/cli/print.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"log"
 	"os"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/fatih/color"
 )
@@ -44,11 +46,20 @@ func warningf(w io.Writer, format string, a ...interface{}) {
 }
 
 // Errorf prints a message prefixed with a bold red "Error: " prefix and exits with 1.
+// It also capitalizes the first letter of the message.
 func Errorf(w io.Writer, format string, a ...interface{}) {
 	if _, err := color.New(color.Bold, color.FgRed).Fprint(w, "Error: "); err != nil {
 		log.Fatal(err)
 	}
-	fmt.Fprintf(w, format+"\n", a...)
+
+	toPrint := fmt.Sprintf(format+"\n", a...)
+	r, i := utf8.DecodeRuneInString(toPrint)
+	if r == utf8.RuneError {
+		log.Fatal("Malformed error message:", toPrint)
+	}
+	upperR := unicode.ToUpper(r)
+	fmt.Fprintf(w, string(upperR)+toPrint[i:])
+
 	os.Exit(1)
 }
 

--- a/cli/print.go
+++ b/cli/print.go
@@ -19,6 +19,11 @@ const asciiViam = `
 
 `
 
+// printf prints a message with no prefix.
+func printf(w io.Writer, format string, a ...interface{}) {
+	fmt.Fprintf(w, format+"\n", a...)
+}
+
 // infof prints a message prefixed with a bold cyan "Info: ".
 func infof(w io.Writer, format string, a ...interface{}) {
 	// NOTE(benjirewis): for some reason, both errcheck and gosec complain about


### PR DESCRIPTION
RSDK-4734

Avoids base URL logic for logging out (just clears the cache). Adds a new `printf` method to replace the numerous `fmt.Fprintf` calls. Capitalizes all printed messages and errors returned to the user (Go standard is lowercase but _CLI standard_ is uppercase; maintains all errors as lowercase-starting internally). Modifies tests accordingly.