### PR TITLE
remove libx264 dep

### DIFF
--- a/components/camera/videosource/logging/logger.go
+++ b/components/camera/videosource/logging/logger.go
@@ -25,11 +25,20 @@ import (
 	"go.viam.com/rdk/config"
 )
 
-var filePath string
+var (
+	// GLoggerCamComp is the global logger-to-file for camera components.
+	GLoggerCamComp *Logger
+	filePath       string
+)
 
 func init() {
 	t := time.Now().UTC().Format(time.RFC3339)
 	filePath = filepath.Join(config.ViamDotDir, "debug", "components", "camera", fmt.Sprintf("%s.txt", t))
+
+	var err error
+	if GLoggerCamComp, err = NewLogger(); err != nil && !errors.Is(err, UnsupportedError{}) {
+		log.Println("cannot create new logger: ", err)
+	}
 }
 
 // InfoMap is a map of information to be written to the log.

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -28,7 +28,6 @@ import (
 	"go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/rimage/transform"
-	"go.viam.com/rdk/web/server"
 )
 
 // ModelWebcam is the name of the webcam component.
@@ -111,7 +110,7 @@ func Discover(_ context.Context, getDrivers func() []driver.Driver, logger golog
 		webcams = append(webcams, wc)
 	}
 
-	goutils.UncheckedError(server.GLoggerCamComp.Log("discovery service", webcamsToMap(webcams)))
+	goutils.UncheckedError(debugLogger.GLoggerCamComp.Log("discovery service", webcamsToMap(webcams)))
 	return &pb.Webcams{Webcams: webcams}, nil
 }
 
@@ -279,7 +278,7 @@ func NewWebcam(
 
 	s, err := cam.Stream(ctx)
 	if err != nil {
-		goutils.UncheckedError(server.GLoggerCamComp.Log("camera test results",
+		goutils.UncheckedError(debugLogger.GLoggerCamComp.Log("camera test results",
 			debugLogger.InfoMap{
 				"name":  cam.Name().Name,
 				"error": fmt.Sprint(err),
@@ -289,7 +288,7 @@ func NewWebcam(
 	}
 
 	img, _, err := s.Next(ctx)
-	goutils.UncheckedError(server.GLoggerCamComp.Log("camera test results",
+	goutils.UncheckedError(debugLogger.GLoggerCamComp.Log("camera test results",
 		debugLogger.InfoMap{
 			"camera name":        cam.Name().Name,
 			"has non-nil image?": fmt.Sprintf("%t", img != nil),

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -3,7 +3,6 @@ package server
 
 import (
 	"context"
-	"log"
 	"net"
 	"os"
 	"path"
@@ -27,18 +26,7 @@ import (
 	rutils "go.viam.com/rdk/utils"
 )
 
-var (
-	// GLoggerCamComp is the global logger-to-file for camera components.
-	GLoggerCamComp *logging.Logger
-	viamDotDir     = filepath.Join(os.Getenv("HOME"), ".viam")
-)
-
-func init() {
-	var err error
-	if GLoggerCamComp, err = logging.NewLogger(); err != nil && !errors.Is(err, logging.UnsupportedError{}) {
-		log.Println("cannot create new logger: ", err)
-	}
-}
+var viamDotDir = filepath.Join(os.Getenv("HOME"), ".viam")
 
 // Arguments for the command.
 type Arguments struct {
@@ -123,7 +111,7 @@ func RunServer(ctx context.Context, args []string, _ golog.Logger) (err error) {
 	}
 
 	if argsParsed.Logging {
-		utils.UncheckedError(GLoggerCamComp.Start(ctx))
+		utils.UncheckedError(logging.GLoggerCamComp.Start(ctx))
 	}
 
 	// Read the config from disk and use it to initialize the remote logger.


### PR DESCRIPTION
This PR removes the libx264 dependency for `make webserver`. I manually verified this by 
```
➜  app git:(main) ✗ make webserver
... do stuff
│   ✔ done
│ ✓ built in 6.45s
└─ Done in 7.5s
GOOS=linux GOARCH=amd64 go build  -o bin/linux/amd64/webserver cmd/webserver/cmd.go
➜  app git:(main) ✗ ldd bin/linux/amd64/webserver  | grep x264
➜  app git:(main) ✗ cat go.mod | grep rdk     
        go.viam.com/rdk v0.8.0-rc0
replace go.viam.com/rdk => /usr/local/libs/rdk
➜  app git:(main) ✗ 

```