### PR TITLE
RSDK-4744 INA219 current readings incorrect fix

### DIFF
--- a/components/powersensor/ina/ina.go
+++ b/components/powersensor/ina/ina.go
@@ -150,11 +150,6 @@ func newINA(
 		return nil, err
 	}
 
-	err = s.calibrate()
-	if err != nil {
-		return nil, err
-	}
-
 	return s, nil
 }
 
@@ -260,6 +255,8 @@ func (d *ina) Current(ctx context.Context, extra map[string]interface{}) (float6
 	}
 	defer utils.UncheckedErrorFunc(handle.Close)
 
+	// Calibrate each time the current value is read, so if anything else is also writing to these registers
+	// we have the correct value.
 	err = d.calibrate()
 	if err != nil {
 		return 0, false, err
@@ -283,6 +280,8 @@ func (d *ina) Power(ctx context.Context, extra map[string]interface{}) (float64,
 	}
 	defer utils.UncheckedErrorFunc(handle.Close)
 
+	// Calibrate each time the power value is read, so if anything else is also writing to these registers
+	// we have the correct value.
 	err = d.calibrate()
 	if err != nil {
 		return 0, err

--- a/components/powersensor/ina/ina.go
+++ b/components/powersensor/ina/ina.go
@@ -247,7 +247,6 @@ func (d *ina) Voltage(ctx context.Context, extra map[string]interface{}) (float6
 }
 
 func (d *ina) Current(ctx context.Context, extra map[string]interface{}) (float64, bool, error) {
-
 	handle, err := i2c.NewI2C(d.addr, d.bus)
 	if err != nil {
 		d.logger.Errorf("can't open ina i2c: %s", err)

--- a/components/powersensor/ina/ina.go
+++ b/components/powersensor/ina/ina.go
@@ -210,7 +210,7 @@ func (d *ina) calibrate() error {
 		return err
 	}
 
-	// setting config to 111 sets to normal operating mode
+	// set the config register to all default values.
 	err = handle.WriteRegU16BE(configRegister, uint16(0x399F))
 	if err != nil {
 		return err


### PR DESCRIPTION
### Summary
- changing the configuration register to the default values
- calling calibrate() each time we read power and current instead of just once at build time. This is so that if another process is also writing to the ina registers we will still have the expected values in them 
- changing the readregisters calls to signed integer so that negative values can be properly read 

### Testing
tested manually with ina219 connected to a DC motor, @mcvella also confirmed this solved the issues he was seeing. 