### PR TITLE
[RSDK-4483] BME280 Sensor Error building resource on different boards 

### DIFF
--- a/components/sensor/bme280/bme280.go
+++ b/components/sensor/bme280/bme280.go
@@ -436,8 +436,8 @@ func (s *bme280) setOverSample(ctx context.Context, addr, offset, val byte) erro
 	if err != nil {
 		return err
 	}
-	err = s.setMode(ctx, 0b00)
-	if err != nil {
+
+	if err = s.setMode(ctx, 0b00); err != nil {
 		return err
 	}
 
@@ -453,16 +453,19 @@ func (s *bme280) setOverSample(ctx context.Context, addr, offset, val byte) erro
 	controlData &= ^((byte(1) << (offset + 2)) | (byte(1) << (offset + 1)) | (byte(1) << offset))
 	controlData |= (val << offset)
 
-	err = handle.WriteByteData(ctx, addr, controlData)
-	if err != nil {
-		return err
-	}
-	err = s.setMode(ctx, mode)
-	if err != nil {
+	if err = handle.WriteByteData(ctx, addr, controlData); err != nil {
 		return err
 	}
 
-	return handle.Close()
+	if err := handle.Close(); err != nil {
+		return err
+	}
+
+	if err = s.setMode(ctx, mode); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // setupCalibration sets up all calibration data for the chip.


### PR DESCRIPTION
This adds a close of the open handle right before we call open handle again from the nested `setMode` function, which was deadlocking genericlinux's mutex.

Tested on a jetson orin and seems like pigpio handles already open handlesthis through the pi driver already.