### PR TITLE
RSDK-4505

### DIFF
--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
-
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	armpb "go.viam.com/api/component/arm/v1"

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
+
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	armpb "go.viam.com/api/component/arm/v1"
@@ -63,6 +64,7 @@ import (
 	"go.viam.com/rdk/services/mlmodel"
 	"go.viam.com/rdk/services/mlmodel/tflitecpu"
 	"go.viam.com/rdk/services/motion"
+	motionBuiltin "go.viam.com/rdk/services/motion/builtin"
 	"go.viam.com/rdk/services/navigation"
 	_ "go.viam.com/rdk/services/register"
 	"go.viam.com/rdk/services/sensors"
@@ -2409,16 +2411,18 @@ func TestCheckMaxInstanceValid(t *testing.T) {
 	cfg := &config.Config{
 		Services: []resource.Config{
 			{
-				Name:      "fake1",
-				Model:     resource.DefaultServiceModel,
-				API:       motion.API,
-				DependsOn: []string{framesystem.InternalServiceName.String()},
+				Name:                "fake1",
+				Model:               resource.DefaultServiceModel,
+				API:                 motion.API,
+				DependsOn:           []string{framesystem.InternalServiceName.String()},
+				ConvertedAttributes: &motionBuiltin.Config{},
 			},
 			{
-				Name:      "fake2",
-				Model:     resource.DefaultServiceModel,
-				API:       motion.API,
-				DependsOn: []string{framesystem.InternalServiceName.String()},
+				Name:                "fake2",
+				Model:               resource.DefaultServiceModel,
+				API:                 motion.API,
+				DependsOn:           []string{framesystem.InternalServiceName.String()},
+				ConvertedAttributes: &motionBuiltin.Config{},
 			},
 		},
 		Components: []resource.Config{

--- a/robot/impl/resource_manager_modular_test.go
+++ b/robot/impl/resource_manager_modular_test.go
@@ -18,6 +18,7 @@ import (
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot/framesystem"
 	"go.viam.com/rdk/services/motion"
+	motionBuiltin "go.viam.com/rdk/services/motion/builtin"
 	"go.viam.com/rdk/utils"
 )
 
@@ -201,7 +202,7 @@ func TestModularResources(t *testing.T) {
 			Name:                "builtin",
 			API:                 motion.API,
 			Model:               resource.DefaultServiceModel,
-			ConvertedAttributes: &fake.Config{},
+			ConvertedAttributes: &motionBuiltin.Config{},
 			DependsOn:           []string{framesystem.InternalServiceName.String()},
 		}
 		_, err = cfg3.Validate("test", resource.APITypeServiceName)

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -388,7 +388,6 @@ func (ms *builtIn) MoveOnGlobe(
 
 			plan, err := motionplan.PlanMotion(ctx, planRequest)
 			if err != nil {
-				cancelFn()
 				return false, err
 			}
 

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -373,13 +373,13 @@ func (ms *builtIn) MoveOnGlobe(
 			}
 			backgroundWorkers.Wait()
 			// context is not lost because it is cancelled above and then cancelled again with defer
-			
+
 			cancelCtx, cancelFn = context.WithCancel(ctx)
 
 			inputs, err := kb.CurrentInputs(ctx)
 			if err != nil {
 				cancelFn()
-				
+
 				return false, err
 			}
 			// TODO: this is really hacky and we should figure out a better place to store this information

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -373,13 +373,13 @@ func (ms *builtIn) MoveOnGlobe(
 			}
 			backgroundWorkers.Wait()
 			// context is not lost because it is cancelled above and then cancelled again with defer
-			//nolint:govet
+			
 			cancelCtx, cancelFn = context.WithCancel(ctx)
 
 			inputs, err := kb.CurrentInputs(ctx)
 			if err != nil {
 				cancelFn()
-				//nolint:govet
+				
 				return false, err
 			}
 			// TODO: this is really hacky and we should figure out a better place to store this information

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -13,6 +13,8 @@ import (
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	servicepb "go.viam.com/api/service/motion/v1"
 	goutils "go.viam.com/utils"
 
@@ -61,7 +63,9 @@ type inputEnabledActuator interface {
 var ErrNotImplemented = errors.New("function coming soon but not yet implemented")
 
 // Config describes how to configure the service; currently only used for specifying dependency on framesystem service.
-type Config struct{}
+type Config struct {
+	LogFilePath string `json:"log_file_path"`
+}
 
 // Validate here adds a dependency on the internal framesystem service.
 func (c *Config) Validate(path string) ([]string, error) {
@@ -81,6 +85,30 @@ func NewBuiltIn(ctx context.Context, deps resource.Dependencies, conf resource.C
 	return ms, nil
 }
 
+func newFilePathLoggerConfig(filepath string) zap.Config {
+	return zap.Config{
+		Level:    zap.NewAtomicLevelAt(zap.DebugLevel),
+		Encoding: "console",
+		EncoderConfig: zapcore.EncoderConfig{
+			TimeKey:        "ts",
+			LevelKey:       "level",
+			NameKey:        "logger",
+			CallerKey:      "caller",
+			FunctionKey:    zapcore.OmitKey,
+			MessageKey:     "msg",
+			StacktraceKey:  "stacktrace",
+			LineEnding:     zapcore.DefaultLineEnding,
+			EncodeLevel:    zapcore.CapitalColorLevelEncoder,
+			EncodeTime:     zapcore.ISO8601TimeEncoder,
+			EncodeDuration: zapcore.StringDurationEncoder,
+			EncodeCaller:   zapcore.ShortCallerEncoder,
+		},
+		DisableStacktrace: true,
+		OutputPaths:       []string{filepath, "stdout"},
+		ErrorOutputPaths:  []string{filepath, "stderr"},
+	}
+}
+
 // Reconfigure updates the motion service when the config has changed.
 func (ms *builtIn) Reconfigure(
 	ctx context.Context,
@@ -90,6 +118,17 @@ func (ms *builtIn) Reconfigure(
 	ms.lock.Lock()
 	defer ms.lock.Unlock()
 
+	config, ok := conf.ConvertedAttributes.(*Config)
+	if !ok {
+		return errors.New("converted attributes invalid")
+	}
+	if config.LogFilePath != "" {
+		logger, err := newFilePathLoggerConfig(config.LogFilePath).Build()
+		if err != nil {
+			return err
+		}
+		ms.logger = logger.Sugar().Named("motion")
+	}
 	movementSensors := make(map[resource.Name]movementsensor.MovementSensor)
 	slamServices := make(map[resource.Name]slam.Service)
 	components := make(map[resource.Name]resource.Resource)
@@ -314,14 +353,18 @@ func (ms *builtIn) MoveOnGlobe(
 	// and exits when something is read from the success channel
 	for {
 		if err := ctx.Err(); err != nil {
+			cancelFn()
 			return false, err
 		}
 		select {
 		case <-ctx.Done():
+			cancelFn()
 			return false, ctx.Err()
 		case <-successChan:
+			cancelFn()
 			return true, nil
 		case err := <-errChan:
+			cancelFn()
 			return false, err
 		case <-replanChan:
 			// cancel the goroutines spawned by this function, create a new cancellable context to use in the future
@@ -335,6 +378,7 @@ func (ms *builtIn) MoveOnGlobe(
 
 			inputs, err := kb.CurrentInputs(ctx)
 			if err != nil {
+				cancelFn()
 				//nolint:govet
 				return false, err
 			}
@@ -346,6 +390,7 @@ func (ms *builtIn) MoveOnGlobe(
 
 			plan, err := motionplan.PlanMotion(ctx, planRequest)
 			if err != nil {
+				cancelFn()
 				return false, err
 			}
 
@@ -559,7 +604,7 @@ func (ms *builtIn) GetPose(
 		ctx,
 		referenceframe.NewPoseInFrame(
 			componentName.ShortName(),
-			spatialmath.NewPoseFromPoint(r3.Vector{0, 0, 0}),
+			spatialmath.NewPoseFromPoint(r3.Vector{X: 0, Y: 0, Z: 0}),
 		),
 		destinationFrame,
 		supplementalTransforms,

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -353,7 +353,6 @@ func (ms *builtIn) MoveOnGlobe(
 	// and exits when something is read from the success channel
 	for {
 		if err := ctx.Err(); err != nil {
-			//nolint:govet
 			return false, err
 		}
 		select {
@@ -370,14 +369,12 @@ func (ms *builtIn) MoveOnGlobe(
 			}
 			backgroundWorkers.Wait()
 			// context is not lost because it is cancelled above and then cancelled again with defer
-
 			//nolint:govet
 			cancelCtx, cancelFn = context.WithCancel(ctx)
 
 			inputs, err := kb.CurrentInputs(ctx)
 			if err != nil {
-				cancelFn()
-
+				//nolint:govet
 				return false, err
 			}
 			// TODO: this is really hacky and we should figure out a better place to store this information


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-4505)

1. Add `log_file_path` to motion config 
2. When `log_file_path` is not empty, replace logger with a zap logger which logs at debug level, both to the file at `log_file_path & stdout / stderr

Sample config:
```json
{
  "services": [
    {
      "name": "motionthingy",
      "attributes": {
        "log_file_path": "/Users/nicksanford/motion.log"
      },
      "type": "motion"
    }
  ],
  "components": [
    {
      "depends_on": [],
      "type": "camera",
      "model": "fake",
      "frame": {
        "parent": "pieceGripper"
      },
      "name": "c",
      "attributes": {}
    },
    {
      "model": "fake",
      "frame": {
        "parent": "pieceArm"
      },
      "attributes": {},
      "depends_on": [],
      "name": "pieceGripper",
      "type": "gripper"
    },
    {
      "model": "fake",
      "depends_on": [],
      "attributes": {
        "arm-model": "ur5e"
      },
      "frame": {
        "parent": "world"
      },
      "name": "pieceArm",
      "type": "arm"
    }
  ]
}
```

Sample log output:
[motion.log](https://github.com/viamrobotics/rdk/files/12541193/motion.log)
