### PR TITLE
DATA-1913 Change PointCloudMap data type to tabular

### DIFF
--- a/services/datamanager/datacapture/data_capture_file.go
+++ b/services/datamanager/datacapture/data_capture_file.go
@@ -28,7 +28,7 @@ const (
 	FileExt           = ".capture"
 	readImage         = "ReadImage"
 	nextPointCloud    = "NextPointCloud"
-	getPointCloudMap  = "GetPointCloudMap"
+	pointCloudMap     = "PointCloudMap"
 )
 
 // File is the data structure containing data captured by collectors. It is backed by a file on disk containing
@@ -239,7 +239,7 @@ func getFileTimestampName() string {
 // TODO DATA-246: Implement this in some more robust, programmatic way.
 func getDataType(methodName string) v1.DataType {
 	switch methodName {
-	case nextPointCloud, readImage, getPointCloudMap:
+	case nextPointCloud, readImage, pointCloudMap:
 		return v1.DataType_DATA_TYPE_BINARY_SENSOR
 	default:
 		return v1.DataType_DATA_TYPE_TABULAR_SENSOR


### PR DESCRIPTION
Tested with a fake SLAM service capturing data with PointCloudMap, no longer get the error:
`error uploading file /Users/katherinewu/.viam/capture/rdk:service:slam/fake-slam/PointCloudMap/2023-09-06T15:36:39.376396-04:00.capture: rpc error: code = InvalidArgument desc = request contains SensorData with non-struct contents`