### PR TITLE
32-bit struct order and fixes

### DIFF
--- a/components/encoder/incremental/incremental_encoder.go
+++ b/components/encoder/incremental/incremental_encoder.go
@@ -30,9 +30,6 @@ func init() {
 // Encoder keeps track of a motor position using a rotary incremental encoder.
 type Encoder struct {
 	resource.Named
-
-	positionType encoder.PositionType
-
 	mu   sync.Mutex
 	A, B board.DigitalInterrupt
 	// The position is pRaw with the least significant bit chopped off.
@@ -53,6 +50,7 @@ type Encoder struct {
 	cancelCtx               context.Context
 	cancelFunc              func()
 	activeBackgroundWorkers sync.WaitGroup
+	positionType            encoder.PositionType
 }
 
 // Pins describes the configuration of Pins for a quadrature encoder.

--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -173,6 +173,7 @@ func newEncodedMotor(
 
 // EncodedMotor is a motor that utilizes an encoder to track its position.
 type EncodedMotor struct {
+	rpmMonitorCalls int64
 	resource.Named
 	resource.AlwaysRebuild
 
@@ -195,12 +196,11 @@ type EncodedMotor struct {
 	flip             int64 // defaults to 1, becomes -1 if the motor config has a true DirectionFLip bool
 	ticksPerRotation int64
 
-	rpmMonitorCalls int64
-	logger          golog.Logger
-	cancelCtx       context.Context
-	cancel          func()
-	loop            *control.Loop
-	opMgr           *operation.SingleOperationManager
+	logger    golog.Logger
+	cancelCtx context.Context
+	cancel    func()
+	loop      *control.Loop
+	opMgr     *operation.SingleOperationManager
 }
 
 // EncodedMotorState is the core, non-statistical state for the motor.

--- a/control/derivative_test.go
+++ b/control/derivative_test.go
@@ -77,7 +77,8 @@ func TestDerivativeConfig(t *testing.T) {
 }
 
 func TestDerivativeNext(t *testing.T) {
-	const iter int = 3000
+	const iter int64 = 3000
+	const tenMs = 10 * int64(time.Millisecond)
 	logger := golog.NewTestLogger(t)
 	ctx := context.Background()
 	cfg := BlockConfig{
@@ -92,8 +93,8 @@ func TestDerivativeNext(t *testing.T) {
 	d := b.(*derivative)
 	test.That(t, err, test.ShouldBeNil)
 	var sin []float64
-	for i := 0; i < iter; i++ {
-		sin = append(sin, math.Sin((time.Duration(10 * i * int(time.Millisecond)).Seconds())))
+	for i := int64(0); i < iter; i++ {
+		sin = append(sin, math.Sin(time.Duration(i*tenMs).Seconds()))
 	}
 	sig := &Signal{
 		name:      "A",
@@ -101,13 +102,13 @@ func TestDerivativeNext(t *testing.T) {
 		time:      make([]int, 1),
 		dimension: 1,
 	}
-	for i := 0; i < iter; i++ {
+	for i := int64(0); i < iter; i++ {
 		sig.SetSignalValueAt(0, sin[i])
 		out, ok := d.Next(ctx, []*Signal{sig}, (10 * time.Millisecond))
 		test.That(t, ok, test.ShouldBeTrue)
 		if i > 5 {
 			test.That(t, out[0].GetSignalValueAt(0), test.ShouldAlmostEqual,
-				-math.Sin((time.Duration(10 * i * int(time.Millisecond)).Seconds())), 0.01)
+				-math.Sin((time.Duration(i * tenMs).Seconds())), 0.01)
 		}
 	}
 	cfg = BlockConfig{
@@ -120,13 +121,13 @@ func TestDerivativeNext(t *testing.T) {
 	}
 	err = d.UpdateConfig(ctx, cfg)
 	test.That(t, err, test.ShouldBeNil)
-	for i := 0; i < iter; i++ {
+	for i := int64(0); i < iter; i++ {
 		sig.SetSignalValueAt(0, sin[i])
 		out, ok := d.Next(ctx, []*Signal{sig}, (10 * time.Millisecond))
 		test.That(t, ok, test.ShouldBeTrue)
 		if i > 5 {
 			test.That(t, out[0].GetSignalValueAt(0), test.ShouldAlmostEqual,
-				math.Cos((time.Duration(10 * i * int(time.Millisecond)).Seconds())), 0.01)
+				math.Cos((time.Duration(i * tenMs).Seconds())), 0.01)
 		}
 	}
 	cfg = BlockConfig{
@@ -140,16 +141,16 @@ func TestDerivativeNext(t *testing.T) {
 	err = d.UpdateConfig(ctx, cfg)
 	test.That(t, err, test.ShouldBeNil)
 	sin = nil
-	for i := 0; i < iter; i++ {
-		sin = append(sin, math.Sin(2*math.Pi*(time.Duration(10*i*int(time.Millisecond)).Seconds())))
+	for i := int64(0); i < iter; i++ {
+		sin = append(sin, math.Sin(2*math.Pi*(time.Duration(i*tenMs).Seconds())))
 	}
-	for i := 0; i < iter; i++ {
+	for i := int64(0); i < iter; i++ {
 		sig.SetSignalValueAt(0, sin[i])
 		out, ok := d.Next(ctx, []*Signal{sig}, 10*time.Millisecond)
 		test.That(t, ok, test.ShouldBeTrue)
 		if i > 5 {
 			test.That(t, out[0].GetSignalValueAt(0), test.ShouldAlmostEqual,
-				2*math.Pi*math.Cos(2*math.Pi*(time.Duration(10*i*int(time.Millisecond)).Seconds())), 0.01)
+				2*math.Pi*math.Cos(2*math.Pi*(time.Duration(i*tenMs).Seconds())), 0.01)
 		}
 	}
 }

--- a/protoutils/messages_test.go
+++ b/protoutils/messages_test.go
@@ -15,7 +15,7 @@ func TestStringToAnyPB(t *testing.T) {
 	wrappedVal := wrapperspb.Int64(int64(12))
 	test.That(t, anyVal.MessageIs(wrappedVal), test.ShouldBeTrue)
 
-	anyVal, err = ConvertStringToAnyPB(strconv.Itoa(math.MaxInt64))
+	anyVal, err = ConvertStringToAnyPB(strconv.Itoa(math.MaxInt))
 	test.That(t, err, test.ShouldBeNil)
 	wrappedVal = wrapperspb.Int64(math.MaxInt64)
 	test.That(t, anyVal.MessageIs(wrappedVal), test.ShouldBeTrue)

--- a/rimage/gray_image_helpers.go
+++ b/rimage/gray_image_helpers.go
@@ -45,14 +45,14 @@ func MultiplyGrays(g1, g2 *image.Gray) (*image.Gray16, error) {
 
 // GetGrayAvg takes in a grayscale image and returns the average value as an int.
 func GetGrayAvg(pic *image.Gray16) int {
-	var sum int
+	var sum int64
 	for y := pic.Bounds().Min.Y; y < pic.Bounds().Max.Y; y++ {
 		for x := pic.Bounds().Min.X; x < pic.Bounds().Max.X; x++ {
 			val := pic.At(x, y).(color.Gray16).Y
-			sum += int(val)
+			sum += int64(val)
 		}
 	}
-	return sum / (pic.Bounds().Max.X * pic.Bounds().Max.Y)
+	return int(sum / int64(pic.Bounds().Max.X*pic.Bounds().Max.Y))
 }
 
 // GetGraySum takes in a grayscale image and returns the total sum as an int.

--- a/utils/average.go
+++ b/utils/average.go
@@ -7,8 +7,8 @@ import "sync/atomic"
 // used for statistical purposes only due to the use of
 // atomics and not mutexes.
 type RollingAverage struct {
-	data []int64
 	pos  int64
+	data []int64
 }
 
 // NewRollingAverage returns a rolling average computed on the given


### PR DESCRIPTION
## Changes
- this includes just the fixes from #2790, specifically:
- reordered structs to fix sync/atomic unaligned panic
- test failures and crashes from bit width
## Follow-on work
- add back build tags which remove unavailable libraries
- atomicalign linting in CI, test in 32 bits