### PR TITLE
RSDK-2261: TestArmReconnection flaky

### DIFF
--- a/components/arm/universalrobots/ur.go
+++ b/components/arm/universalrobots/ur.go
@@ -4,6 +4,7 @@ package universalrobots
 import (
 	"bufio"
 	"context"
+
 	// for embedding model file.
 	_ "embed"
 	"encoding/binary"
@@ -209,7 +210,7 @@ func URArmConnect(ctx context.Context, conf resource.Config, logger golog.Logger
 			readerWriter := bufio.NewReadWriter(bufio.NewReader(newArm.dashboardConnection), bufio.NewWriter(newArm.dashboardConnection))
 			err := dashboardReader(cancelCtx, *readerWriter, newArm)
 			if err != nil &&
-				(errors.Is(err, syscall.ECONNRESET) || errors.Is(err, io.ErrClosedPipe) || os.IsTimeout(err) || errors.Is(err, io.ErrUnexpectedEOF)) {
+				(errors.Is(err, syscall.ECONNRESET) || errors.Is(err, io.ErrClosedPipe) || os.IsTimeout(err) || errors.Is(err, io.EOF)) {
 				newArm.mu.Lock()
 				newArm.inRemoteMode = false
 				newArm.mu.Unlock()
@@ -256,7 +257,7 @@ func URArmConnect(ctx context.Context, conf resource.Config, logger golog.Logger
 				})
 			})
 			if err != nil &&
-				(errors.Is(err, syscall.ECONNRESET) || errors.Is(err, io.ErrClosedPipe) || os.IsTimeout(err) || errors.Is(err, io.ErrUnexpectedEOF)) {
+				(errors.Is(err, syscall.ECONNRESET) || errors.Is(err, io.ErrClosedPipe) || os.IsTimeout(err) || errors.Is(err, io.EOF)) {
 				for {
 					if err := cancelCtx.Err(); err != nil {
 						return

--- a/components/arm/universalrobots/ur.go
+++ b/components/arm/universalrobots/ur.go
@@ -208,7 +208,8 @@ func URArmConnect(ctx context.Context, conf resource.Config, logger golog.Logger
 		for {
 			readerWriter := bufio.NewReadWriter(bufio.NewReader(newArm.dashboardConnection), bufio.NewWriter(newArm.dashboardConnection))
 			err := dashboardReader(cancelCtx, *readerWriter, newArm)
-			if err != nil && (errors.Is(err, syscall.ECONNRESET) || errors.Is(err, io.ErrClosedPipe) || os.IsTimeout(err)) {
+			if err != nil &&
+				(errors.Is(err, syscall.ECONNRESET) || errors.Is(err, io.ErrClosedPipe) || os.IsTimeout(err) || errors.Is(err, io.ErrUnexpectedEOF)) {
 				newArm.mu.Lock()
 				newArm.inRemoteMode = false
 				newArm.mu.Unlock()
@@ -254,7 +255,8 @@ func URArmConnect(ctx context.Context, conf resource.Config, logger golog.Logger
 					close(onData)
 				})
 			})
-			if err != nil && (errors.Is(err, syscall.ECONNRESET) || errors.Is(err, io.ErrClosedPipe) || os.IsTimeout(err)) {
+			if err != nil &&
+				(errors.Is(err, syscall.ECONNRESET) || errors.Is(err, io.ErrClosedPipe) || os.IsTimeout(err) || errors.Is(err, io.ErrUnexpectedEOF)) {
 				for {
 					if err := cancelCtx.Err(); err != nil {
 						return

--- a/components/arm/universalrobots/ur.go
+++ b/components/arm/universalrobots/ur.go
@@ -4,7 +4,6 @@ package universalrobots
 import (
 	"bufio"
 	"context"
-
 	// for embedding model file.
 	_ "embed"
 	"encoding/binary"

--- a/components/arm/universalrobots/ur5e_test.go
+++ b/components/arm/universalrobots/ur5e_test.go
@@ -303,7 +303,6 @@ func setupListeners(ctx context.Context, statusBlob []byte,
 }
 
 func TestArmReconnection(t *testing.T) {
-	t.Skip()
 	var remote atomic.Bool
 
 	remote.Store(false)

--- a/components/arm/universalrobots/ur5e_test.go
+++ b/components/arm/universalrobots/ur5e_test.go
@@ -303,6 +303,7 @@ func setupListeners(ctx context.Context, statusBlob []byte,
 }
 
 func TestArmReconnection(t *testing.T) {
+	t.Skip()
 	var remote atomic.Bool
 
 	remote.Store(false)


### PR DESCRIPTION
ignore end of frame error that's causing flaky test