### PR TITLE
RSDK-4877 - Long module names can result in socket path errors on macos

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/fs"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -608,8 +609,8 @@ func (m *module) startProcess(
 	oue func(int) bool,
 	logger golog.Logger,
 ) error {
-	m.addr = filepath.ToSlash(filepath.Join(filepath.Dir(parentAddr), m.name+".sock"))
-	if err := modlib.CheckSocketAddressLength(m.addr); err != nil {
+	var err error
+	if m.addr, err = modlib.TruncatedSocketAddress(filepath.Dir(parentAddr), m.name, runtime.GOOS); err != nil {
 		return err
 	}
 
@@ -630,8 +631,7 @@ func (m *module) startProcess(
 
 	m.process = pexec.NewManagedProcess(pconf, logger)
 
-	err := m.process.Start(context.Background())
-	if err != nil {
+	if err := m.process.Start(context.Background()); err != nil {
 		return errors.WithMessage(err, "module startup failed")
 	}
 

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -609,7 +609,7 @@ func (m *module) startProcess(
 	logger golog.Logger,
 ) error {
 	var err error
-	if m.addr, err = modlib.TruncatedSocketAddress(filepath.Dir(parentAddr), m.name); err != nil {
+	if m.addr, err = modlib.CreateSocketAddress(filepath.Dir(parentAddr), m.name); err != nil {
 		return err
 	}
 

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/fs"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -610,7 +609,7 @@ func (m *module) startProcess(
 	logger golog.Logger,
 ) error {
 	var err error
-	if m.addr, err = modlib.TruncatedSocketAddress(filepath.Dir(parentAddr), m.name, runtime.GOOS); err != nil {
+	if m.addr, err = modlib.TruncatedSocketAddress(filepath.Dir(parentAddr), m.name); err != nil {
 		return err
 	}
 

--- a/module/module.go
+++ b/module/module.go
@@ -41,10 +41,10 @@ const (
 	socketMaxAddressLength int = 103
 )
 
-// TruncatedSocketAddress returns a socket address of the form parentDir/desiredName.sock
+// CreateSocketAddress returns a socket address of the form parentDir/desiredName.sock
 // if it is shorter than the max socket length on the given os. If this path would be too long, this function
 // truncates desiredName and returns parentDir/truncatedName-randomStr.sock.
-func TruncatedSocketAddress(parentDir, desiredName string) (string, error) {
+func CreateSocketAddress(parentDir, desiredName string) (string, error) {
 	baseAddr := filepath.ToSlash(parentDir)
 	numRemainingChars := socketMaxAddressLength -
 		len(baseAddr) -

--- a/module/module_test.go
+++ b/module/module_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	"github.com/edaniels/golog"
@@ -669,66 +669,37 @@ func TestAttributeConversion(t *testing.T) {
 }
 
 func TestModuleSocketAddrTruncation(t *testing.T) {
-	rand.Seed(0)
 	// test with a short base path
-	path, err := module.TruncatedSocketAddress("/tmp", "my-cool-module", "linux")
+	path, err := module.TruncatedSocketAddress("/tmp", "my-cool-module")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, path, test.ShouldEqual, "/tmp/my-cool-module.sock")
 
-	// test exactly 107 chars on linux
+	// test exactly 104
 	path, err = module.TruncatedSocketAddress(
 		"/tmp",
-		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-		"linux",
-	)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, path, test.ShouldHaveLength, 107)
-	test.That(t, path, test.ShouldEqual,
-		"/tmp/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.sock",
-	)
-
-	// test 108 chars on linux
-	path, err = module.TruncatedSocketAddress(
-		"/tmp",
-		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-		"linux",
-	)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, path, test.ShouldHaveLength, 107)
-	test.That(t, path, test.ShouldEqual,
-		"/tmp/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-mPGBa.sock",
-	)
-
-	// test with a truncated path on linux
-	path, err = module.TruncatedSocketAddress(
-		"/run/user/1000/viam-module",
-		"my_extra_extremely_extraordinarily_superfluously_tremendously_surprisingly_long_module_name",
-		"linux",
-	)
-
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, path, test.ShouldHaveLength, 107)
-	test.That(t, path, test.ShouldEqual,
-		"/run/user/1000/viam-module/my_extra_extremely_extraordinarily_superfluously_tremendously_surpris-yA47K.sock",
-	)
-
-	// test with a truncated path on macos
-	path, err = module.TruncatedSocketAddress(
-		"/var/folders/pc/yyrlrx8n0yq_xr550xh62pq80000gn/T/viam-module-2923273079",
-		"my_extra_long_module_name_service",
-		"darwin",
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 	)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, path, test.ShouldHaveLength, 103)
 	test.That(t, path, test.ShouldEqual,
-		"/var/folders/pc/yyrlrx8n0yq_xr550xh62pq80000gn/T/viam-module-2923273079/my_extra_long_module-B4vMT.sock",
+		"/tmp/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.sock",
 	)
+
+	// test 105 chars
+	path, err = module.TruncatedSocketAddress(
+		"/tmp",
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, path, test.ShouldHaveLength, 103)
+	matches, err := regexp.MatchString(`\/tmp\/a+-.{5}\.sock`, path)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, matches, test.ShouldBeTrue)
 
 	// test with an extra-long base path
 	_, err = module.TruncatedSocketAddress(
-		"/var/folders/pc/yyrlrx8n0yq_xr550xh62pq80000gn/T/viam-module-2923273079--------------------------",
+		"/var/folders/pc/yyrlrx8n0yq_xr550xh62pq80000gn/T/viam-module-29232730790000000000000000000000000000000000",
 		"a",
-		"darwin",
 	)
 	test.That(t, err, test.ShouldBeError)
 }

--- a/module/module_test.go
+++ b/module/module_test.go
@@ -670,12 +670,12 @@ func TestAttributeConversion(t *testing.T) {
 
 func TestModuleSocketAddrTruncation(t *testing.T) {
 	// test with a short base path
-	path, err := module.TruncatedSocketAddress("/tmp", "my-cool-module")
+	path, err := module.CreateSocketAddress("/tmp", "my-cool-module")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, path, test.ShouldEqual, "/tmp/my-cool-module.sock")
 
 	// test exactly 104
-	path, err = module.TruncatedSocketAddress(
+	path, err = module.CreateSocketAddress(
 		"/tmp",
 		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 	)
@@ -686,7 +686,7 @@ func TestModuleSocketAddrTruncation(t *testing.T) {
 	)
 
 	// test 105 chars
-	path, err = module.TruncatedSocketAddress(
+	path, err = module.CreateSocketAddress(
 		"/tmp",
 		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 	)
@@ -697,7 +697,7 @@ func TestModuleSocketAddrTruncation(t *testing.T) {
 	test.That(t, matches, test.ShouldBeTrue)
 
 	// test with an extra-long base path
-	_, err = module.TruncatedSocketAddress(
+	_, err = module.CreateSocketAddress(
 		"/var/folders/pc/yyrlrx8n0yq_xr550xh62pq80000gn/T/viam-module-29232730790000000000000000000000000000000000",
 		"a",
 	)

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -378,7 +378,7 @@ func (svc *webService) StartModule(ctx context.Context) error {
 		if err != nil {
 			return errors.WithMessage(err, "module startup failed")
 		}
-		addr, err = module.TruncatedSocketAddress(dir, "parent", runtime.GOOS)
+		addr, err = module.TruncatedSocketAddress(dir, "parent")
 		if err != nil {
 			return errors.WithMessage(err, "module startup failed")
 		}

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -378,7 +378,7 @@ func (svc *webService) StartModule(ctx context.Context) error {
 		if err != nil {
 			return errors.WithMessage(err, "module startup failed")
 		}
-		addr, err = module.TruncatedSocketAddress(dir, "parent")
+		addr, err = module.CreateSocketAddress(dir, "parent")
 		if err != nil {
 			return errors.WithMessage(err, "module startup failed")
 		}

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -378,7 +378,11 @@ func (svc *webService) StartModule(ctx context.Context) error {
 		if err != nil {
 			return errors.WithMessage(err, "module startup failed")
 		}
-		addr = filepath.ToSlash(filepath.Join(dir, "parent.sock"))
+		addr, err = module.TruncatedSocketAddress(dir, "parent", runtime.GOOS)
+		if err != nil {
+			return errors.WithMessage(err, "module startup failed")
+		}
+
 		if runtime.GOOS == "windows" {
 			// on windows, we need to craft a good enough looking URL for gRPC which
 			// means we need to take out the volume which will have the current drive
@@ -387,9 +391,6 @@ func (svc *webService) StartModule(ctx context.Context) error {
 			// of dialing without any resolver modifications to gRPC, they must initially
 			// agree on using the same drive.
 			addr = addr[2:]
-		}
-		if err := module.CheckSocketAddressLength(addr); err != nil {
-			return err
 		}
 		svc.modAddr = addr
 		lis, err = net.Listen("unix", addr)


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-4877

Discovered by @ethanlook . 


Fix suggested by James:
``
Yeah, there's no way around the path char limit and Mac's temp directory already eats up a lot of those characters. Truncating it is probably best. Or... we could stop using the name in the path. It was more elegant for debugging and I hate "mystery filenames" in general, but 16 random characters work just as well.
Or some combo of the two, truncate namespace +random extension combine with truncated name plus random. So humans would at least see some of the namespace and name, but It'd always be a fixed length.
``

This keeps the current behavior of using the module name if possible, but if that would be too long, it truncates the name and adds some random chars.