### PR TITLE
RSDK-4829 32-bit build tags

### DIFF
--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -1,4 +1,4 @@
-//go:build linux && (arm64 || arm)
+//go:build linux && (arm64 || arm) && !no_pigpio
 
 // Package piimpl contains the implementation of a supported Raspberry Pi board.
 package piimpl

--- a/components/board/pi/impl/i2c.go
+++ b/components/board/pi/impl/i2c.go
@@ -1,4 +1,4 @@
-//go:build linux && (arm64 || arm)
+//go:build linux && (arm64 || arm) && !no_pigpio
 
 package piimpl
 

--- a/components/board/pi/impl/pi.c
+++ b/components/board/pi/impl/pi.c
@@ -1,3 +1,4 @@
+//go:build !no_pigpio
 #include <pigpio.h>
 
 extern void pigpioInterruptCallback(int gpio, int level, uint32_t tick);

--- a/components/board/pi/impl/pi.h
+++ b/components/board/pi/impl/pi.h
@@ -1,3 +1,4 @@
+//go:build !no_pigpio
 #pragma once
 
 // interruptCallback calls through to the go linked interrupt callback.

--- a/components/board/pi/impl/servo.go
+++ b/components/board/pi/impl/servo.go
@@ -1,4 +1,4 @@
-//go:build linux && (arm64 || arm)
+//go:build linux && (arm64 || arm) && !no_pigpio
 
 package piimpl
 

--- a/components/board/pi/impl/utils.go
+++ b/components/board/pi/impl/utils.go
@@ -1,4 +1,4 @@
-//go:build linux && (arm64 || arm)
+//go:build linux && (arm64 || arm) && !no_pigpio
 
 package piimpl
 

--- a/components/board/pi/pi_notsupported.go
+++ b/components/board/pi/pi_notsupported.go
@@ -1,4 +1,4 @@
-//go:build !(linux && (arm64 || arm))
+//go:build !(linux && (arm64 || arm) && !no_pigpio)
 
 package pi
 

--- a/components/board/pi/pi_supported.go
+++ b/components/board/pi/pi_supported.go
@@ -1,4 +1,4 @@
-//go:build linux && (arm64 || arm)
+//go:build linux && (arm64 || arm) && !no_pigpio
 
 package pi
 

--- a/ml/inference/tflite.go
+++ b/ml/inference/tflite.go
@@ -1,4 +1,4 @@
-//go:build !arm && !windows
+//go:build !arm && !windows && !no_tflite
 
 package inference
 

--- a/services/mlmodel/register/register.go
+++ b/services/mlmodel/register/register.go
@@ -1,3 +1,5 @@
+//go:build !no_tflite
+
 // Package register registers all relevant ML model services
 package register
 

--- a/services/mlmodel/tflitecpu/tflite_cpu.go
+++ b/services/mlmodel/tflitecpu/tflite_cpu.go
@@ -1,3 +1,5 @@
+//go:build !no_tflite
+
 // Package tflitecpu runs tflite model files on the host's CPU, as an implementation the ML model service.
 package tflitecpu
 

--- a/services/register/all.go
+++ b/services/register/all.go
@@ -5,7 +5,6 @@ import (
 	// register services.
 	_ "go.viam.com/rdk/services/baseremotecontrol/register"
 	_ "go.viam.com/rdk/services/datamanager/register"
-	_ "go.viam.com/rdk/services/mlmodel/register"
 	_ "go.viam.com/rdk/services/motion/register"
 	_ "go.viam.com/rdk/services/navigation/register"
 	_ "go.viam.com/rdk/services/sensors/register"

--- a/services/register/all_tflite.go
+++ b/services/register/all_tflite.go
@@ -1,0 +1,9 @@
+//go:build !no_tflite
+
+// Package register registers all services
+package register
+
+import (
+	// register services.
+	_ "go.viam.com/rdk/services/mlmodel/register"
+)


### PR DESCRIPTION
## What
- this adds `no_tflite` and `no_pigpio` build flags, which can be used to toggle off tensorflow lite and pi GPIO libraries so that people can make 32-bit builds
- this is part of closed giant PR #2790 
- note: I excluded changes to test files; will add those back when we do 32-bit tests in CI
## Using this
- `go build -tags no_tflite,no_pigpio ./web/cmd/server`