### PR TITLE
[RSDK-4883][RSDK-4891]Stop when SetVelocity is all zeros and Change units in WheeledOdometry

### DIFF
--- a/components/base/wheeled/wheeled_base.go
+++ b/components/base/wheeled/wheeled_base.go
@@ -361,8 +361,6 @@ func (wb *wheeledBase) SetVelocity(ctx context.Context, linear, angular r3.Vecto
 	const numRevolutions = 0
 	errs := make([]error, 0)
 
-	wb.logger.Debugf("leftrpm %v, rightrpm %v", leftRPM, rightRPM)
-
 	wb.mu.Lock()
 	// Because `SetVelocity` does not create a new operation, canceling must be done atomically with
 	// engaging the underlying motors. Otherwise, for example:

--- a/components/base/wheeled/wheeled_base_test.go
+++ b/components/base/wheeled/wheeled_base_test.go
@@ -81,10 +81,27 @@ func TestWheelBaseMath(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, moving, test.ShouldBeTrue)
 
+		err = wb.SetVelocity(ctx, r3.Vector{X: 0, Y: 0, Z: 0}, r3.Vector{X: 0, Y: 0, Z: 0}, nil)
+		test.That(t, err, test.ShouldBeNil)
+
+		moving, err = wb.IsMoving(ctx)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, moving, test.ShouldBeFalse)
+
 		err = wb.SetPower(ctx, r3.Vector{X: 0, Y: 10, Z: 0}, r3.Vector{X: 0, Y: 0, Z: 10}, nil)
 		test.That(t, err, test.ShouldBeNil)
 
 		test.That(t, wb.Stop(ctx, nil), test.ShouldBeNil)
+
+		moving, err = wb.IsMoving(ctx)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, moving, test.ShouldBeFalse)
+
+		err = wb.SetPower(ctx, r3.Vector{X: 0, Y: 10, Z: 0}, r3.Vector{X: 0, Y: 0, Z: 10}, nil)
+		test.That(t, err, test.ShouldBeNil)
+
+		err = wb.SetPower(ctx, r3.Vector{X: 0, Y: 0, Z: 0}, r3.Vector{X: 0, Y: 0, Z: 0}, nil)
+		test.That(t, err, test.ShouldBeNil)
 
 		moving, err = wb.IsMoving(ctx)
 		test.That(t, err, test.ShouldBeNil)

--- a/components/movementsensor/wheeledodometry/wheeledodometry.go
+++ b/components/movementsensor/wheeledodometry/wheeledodometry.go
@@ -26,6 +26,8 @@ var model = resource.DefaultModelFamily.WithModel("wheeled-odometry")
 const (
 	defaultTimeIntervalMSecs = 500
 	oneTurn                  = 2 * math.Pi
+	mToKm                    = 1e-3
+	returnRelative           = "return_relative_pos_m"
 )
 
 // Config is the config for a wheeledodometry MovementSensor.
@@ -57,6 +59,7 @@ type odometry struct {
 	linearVelocity  r3.Vector
 	position        r3.Vector
 	orientation     spatialmath.EulerAngles
+	coord           *geo.Point
 
 	cancelFunc              func()
 	activeBackgroundWorkers sync.WaitGroup
@@ -256,11 +259,30 @@ func (o *odometry) LinearVelocity(ctx context.Context, extra map[string]interfac
 func (o *odometry) Position(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	return geo.NewPoint(o.position.X, o.position.Y), o.position.Z, nil
+
+	if relative, ok := extra[returnRelative]; ok {
+		if relative.(bool) {
+			return geo.NewPoint(o.position.X, o.position.Y), o.position.Z, nil
+		}
+	}
+
+	return o.coord, o.position.Z, nil
 }
 
 func (o *odometry) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
-	return movementsensor.Readings(ctx, o, extra)
+	readings, err := movementsensor.Readings(ctx, o, extra)
+	if err != nil {
+		return nil, err
+	}
+
+	// movementsensor.Readings calls all the APIs with their owm mutex lock in this driver
+	// the lock has been released, so for the last two readings we lock again to append them to the readings map
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	readings["position_meters_X"] = o.position.X
+	readings["position_meters_Y"] = o.position.Y
+
+	return readings, nil
 }
 
 func (o *odometry) Accuracy(ctx context.Context, extra map[string]interface{}) (map[string]float32, error) {
@@ -287,6 +309,8 @@ func (o *odometry) Close(ctx context.Context) error {
 // The estimations in this function are based on the math outlined in this article:
 // https://stuff.mit.edu/afs/athena/course/6/6.186/OldFiles/2005/doc/odomtutorial/odomtutorial.pdf
 func (o *odometry) trackPosition(ctx context.Context) {
+	geoOrigin := geo.NewPoint(0, 0)
+
 	o.activeBackgroundWorkers.Add(1)
 	utils.PanicCapturingGo(func() {
 		defer o.activeBackgroundWorkers.Done()
@@ -356,6 +380,10 @@ func (o *odometry) trackPosition(ctx context.Context) {
 			// Calculate X and Y by using centerDist and the current orientation yaw (theta).
 			o.position.X += (centerDist * math.Cos(o.orientation.Yaw))
 			o.position.Y += (centerDist * math.Sin(o.orientation.Yaw))
+
+			distance := math.Hypot(o.position.X, o.position.Y)
+			heading := math.Atan2(o.position.Y, o.position.X)
+			o.coord = geoOrigin.PointAtDistanceAndBearing(distance*mToKm, heading)
 
 			// Update the linear and angular velocity values using the provided time interval.
 			o.linearVelocity.Y = centerDist / (o.timeIntervalMSecs / 1000)

--- a/components/movementsensor/wheeledodometry/wheeledodometry_test.go
+++ b/components/movementsensor/wheeledodometry/wheeledodometry_test.go
@@ -40,6 +40,8 @@ var position = positions{
 	rightPos: 0.0,
 }
 
+var relativePos = map[string]interface{}{returnRelative: true}
+
 func createFakeMotor(dir bool) motor.Motor {
 	return &inject.Motor{
 		PropertiesFunc: func(ctx context.Context, extra map[string]interface{}) (motor.Properties, error) {
@@ -317,7 +319,7 @@ func TestMoveStraight(t *testing.T) {
 	setPositions(5, 5)
 	time.Sleep(time.Duration(od.timeIntervalMSecs*1.15) * time.Millisecond)
 
-	pos, _, err := od.Position(ctx, nil)
+	pos, _, err := od.Position(ctx, relativePos)
 	or, _ := od.Orientation(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, or.OrientationVectorDegrees().Theta, test.ShouldAlmostEqual, 0, 0.1)
@@ -328,7 +330,7 @@ func TestMoveStraight(t *testing.T) {
 	setPositions(-10, -10)
 	time.Sleep(time.Duration(od.timeIntervalMSecs*1.15) * time.Millisecond)
 
-	pos, _, err = od.Position(ctx, nil)
+	pos, _, err = od.Position(ctx, relativePos)
 	or, _ = od.Orientation(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, or.OrientationVectorDegrees().Theta, test.ShouldAlmostEqual, 0, 0.1)
@@ -357,7 +359,7 @@ func TestComplicatedPath(t *testing.T) {
 	setPositions(5, 5)
 	time.Sleep(time.Duration(od.timeIntervalMSecs*1.15) * time.Millisecond)
 
-	pos, _, err := od.Position(ctx, nil)
+	pos, _, err := od.Position(ctx, relativePos)
 	test.That(t, err, test.ShouldBeNil)
 	or, _ := od.Orientation(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
@@ -369,7 +371,7 @@ func TestComplicatedPath(t *testing.T) {
 	setPositions(1*(math.Pi/4), -1*(math.Pi/4))
 	time.Sleep(time.Duration(od.timeIntervalMSecs*1.15) * time.Millisecond)
 
-	pos, _, err = od.Position(ctx, nil)
+	pos, _, err = od.Position(ctx, relativePos)
 	test.That(t, err, test.ShouldBeNil)
 	or, err = od.Orientation(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
@@ -381,7 +383,7 @@ func TestComplicatedPath(t *testing.T) {
 	setPositions(5, 5)
 	time.Sleep(time.Duration(od.timeIntervalMSecs*1.15) * time.Millisecond)
 
-	pos, _, err = od.Position(ctx, nil)
+	pos, _, err = od.Position(ctx, relativePos)
 	test.That(t, err, test.ShouldBeNil)
 	or, err = od.Orientation(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
@@ -393,7 +395,7 @@ func TestComplicatedPath(t *testing.T) {
 	setPositions(-1*(math.Pi/8), 1*(math.Pi/8))
 	time.Sleep(time.Duration(od.timeIntervalMSecs*1.15) * time.Millisecond)
 
-	pos, _, err = od.Position(ctx, nil)
+	pos, _, err = od.Position(ctx, relativePos)
 	test.That(t, err, test.ShouldBeNil)
 	or, err = od.Orientation(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
@@ -405,7 +407,7 @@ func TestComplicatedPath(t *testing.T) {
 	setPositions(2, 2)
 	time.Sleep(time.Duration(od.timeIntervalMSecs*1.15) * time.Millisecond)
 
-	pos, _, err = od.Position(ctx, nil)
+	pos, _, err = od.Position(ctx, relativePos)
 	test.That(t, err, test.ShouldBeNil)
 	or, err = od.Orientation(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
@@ -417,7 +419,7 @@ func TestComplicatedPath(t *testing.T) {
 	setPositions(1*(math.Pi/4), 2*(math.Pi/4))
 	time.Sleep(time.Duration(od.timeIntervalMSecs*1.15) * time.Millisecond)
 
-	pos, _, err = od.Position(ctx, nil)
+	pos, _, err = od.Position(ctx, relativePos)
 	test.That(t, err, test.ShouldBeNil)
 	or, err = od.Orientation(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)


### PR DESCRIPTION
Previously #2911

Want to 
- [x] Add software tests for SetVelocity in wheeled base
- [x] Test out wheeled odometer changes in nav service rc card, and make sure we're moving at the correct lat/long units.
- [x] Test out SetVel command 0s once again from and sdk.