### PR TITLE
RSDK-4871 - add backtrace printing on restart

### DIFF
--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -329,7 +329,7 @@ func (s *robotServer) serveWeb(ctx context.Context, cfg *config.Config) (err err
 				restartInterval = newRestartInterval
 
 				if mustRestart {
-					s.logger.Debug(string(debug.Stack()))
+					s.logger.Debugf("backtrace at robot restart, %s", string(debug.Stack()))
 					cancel()
 					return
 				}

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime/debug"
 	"runtime/pprof"
 	"time"
 
@@ -328,6 +329,7 @@ func (s *robotServer) serveWeb(ctx context.Context, cfg *config.Config) (err err
 				restartInterval = newRestartInterval
 
 				if mustRestart {
+					s.logger.Debug(string(debug.Stack()))
 					cancel()
 					return
 				}

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -3,11 +3,12 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"os"
 	"path"
 	"path/filepath"
-	"runtime/debug"
+	"runtime"
 	"runtime/pprof"
 	"time"
 
@@ -329,7 +330,14 @@ func (s *robotServer) serveWeb(ctx context.Context, cfg *config.Config) (err err
 				restartInterval = newRestartInterval
 
 				if mustRestart {
-					s.logger.Debugf("backtrace at robot restart, %s", string(debug.Stack()))
+					bufSize := 1 << 20
+					traces := make([]byte, bufSize)
+					traceSize := runtime.Stack(traces, true)
+					message := "backtrace at robot restart"
+					if traceSize == bufSize {
+						message = fmt.Sprintf("%s (warning: backtrace truncated to %v bytes)", message, bufSize)
+					}
+					s.logger.Infof("%s, %s", message, traces)
 					cancel()
 					return
 				}


### PR DESCRIPTION
#### Major Changes
Adds printing of backtrace on restart

Screenshot of backtrace on local output.
![Screen Shot 2023-09-14 at 16 44 27](https://github.com/viamrobotics/rdk/assets/29895141/56955a42-85ba-4a30-83c3-389de21a0c65)

Screenshot of backtrace as it appears in app.
<img width="1397" alt="Screen Shot 2023-09-14 at 16 44 12" src="https://github.com/viamrobotics/rdk/assets/29895141/b4661ec3-2518-4114-b2db-9c5e11d15e99">

