### PR TITLE
RSDK-4773 - Camera discovery service causes the config page to hang

### DIFF
--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -58,7 +58,6 @@ type CameraConfig struct {
 
 // Discover webcam attributes.
 func Discover(_ context.Context, getDrivers func() []driver.Driver, logger golog.Logger) (*pb.Webcams, error) {
-	mediadevicescamera.Initialize()
 	var webcams []*pb.Webcam
 	drivers := getDrivers()
 	for _, d := range drivers {


### PR DESCRIPTION
### Description

Specifically on linux, every discovery API call appends the full set of drivers to the manager in mediadevices.

### Solution

We simply remove the extra `Initialize` call on discovery. Driver fetching already happens on `init()` of the mediadevices library.

_This issue does not occur with macos avfoundation driver. In the future, we may want to consider fixing this in the mediadevices layer as well for linux cameras._

### Testing
- [x]  linux
- [x] macos (no regression)
