### PR TITLE
[DATA-1868] Upload arbitrary files with their full original file paths and maintain their directory structure upon export

### DIFF
--- a/cli/data.go
+++ b/cli/data.go
@@ -354,11 +354,11 @@ func downloadBinary(ctx context.Context, client datapb.DataServiceClient, dst st
 		fileName = timeRequested + "_" + strings.TrimSuffix(datum.GetMetadata().GetFileName(), datum.GetMetadata().GetFileExt())
 	}
 
-	//nolint:gosec
 	jsonPath := filepath.Join(dst, metadataDir, fileName+".json")
 	if err := os.MkdirAll(filepath.Dir(jsonPath), 0o700); err != nil {
 		return errors.Wrapf(err, "could not create metadata directory %s", filepath.Dir(jsonPath))
 	}
+	//nolint:gosec
 	jsonFile, err := os.Create(jsonPath)
 	if err != nil {
 		return err
@@ -380,17 +380,16 @@ func downloadBinary(ctx context.Context, client datapb.DataServiceClient, dst st
 		if err != nil {
 			return err
 		}
-	} else {
+	} else if filepath.Ext(dataPath) != ext {
 		// If the file name did not already include the extension (e.g. for data capture files), add it.
 		// Don't do this for files that we're unzipping.
-		if filepath.Ext(dataPath) != ext {
-			dataPath += ext
-		}
+		dataPath += ext
 	}
 
 	if err := os.MkdirAll(filepath.Dir(dataPath), 0o700); err != nil {
 		return errors.Wrapf(err, "could not create data directory %s", filepath.Dir(dataPath))
 	}
+	//nolint:gosec
 	dataFile, err := os.Create(dataPath)
 	if err != nil {
 		return errors.Wrapf(err, fmt.Sprintf("could not create file for datum %s", datum.GetMetadata().GetId()))

--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -439,7 +439,7 @@ func TestArbitraryFileUpload(t *testing.T) {
 				actMD := urs[0].GetMetadata()
 				test.That(t, actMD, test.ShouldNotBeNil)
 				test.That(t, actMD.Type, test.ShouldEqual, v1.DataType_DATA_TYPE_FILE)
-				test.That(t, actMD.FileName, test.ShouldEqual, fileName)
+				test.That(t, filepath.Base(actMD.FileName), test.ShouldEqual, fileName)
 				test.That(t, actMD.FileExtension, test.ShouldEqual, fileExt)
 				test.That(t, actMD.PartId, test.ShouldNotBeBlank)
 

--- a/services/datamanager/datasync/upload_arbitrary_file.go
+++ b/services/datamanager/datasync/upload_arbitrary_file.go
@@ -22,7 +22,7 @@ func uploadArbitraryFile(ctx context.Context, client v1.DataSyncServiceClient, f
 	md := &v1.UploadMetadata{
 		PartId:        partID,
 		Type:          v1.DataType_DATA_TYPE_FILE,
-		FileName:      filepath.Base(f.Name()),
+		FileName:      f.Name(),
 		FileExtension: filepath.Ext(f.Name()),
 		Tags:          tags,
 	}

--- a/services/datamanager/datasync/upload_arbitrary_file.go
+++ b/services/datamanager/datasync/upload_arbitrary_file.go
@@ -19,10 +19,14 @@ func uploadArbitraryFile(ctx context.Context, client v1.DataSyncServiceClient, f
 		return err
 	}
 
+	path, err := filepath.Abs(f.Name())
+	if err != nil {
+		return err
+	}
 	md := &v1.UploadMetadata{
 		PartId:        partID,
 		Type:          v1.DataType_DATA_TYPE_FILE,
-		FileName:      f.Name(),
+		FileName:      path,
 		FileExtension: filepath.Ext(f.Name()),
 		Tags:          tags,
 	}


### PR DESCRIPTION
Name an arbitrary file with its original file path. This PR:

* Uploads arbitrary files with the absolute directory path as their file name.
* In CLI export, saves files according to their original directory structure. 
   * Data capture files are still saved at the top-level directory with timestamps prepended in order to sort. Timestamps are not prepended to arbitrary files that have a predetermined directory structure.
* In CLI export, unzips gzipped files, whether they were gzipped server-side or the user uploaded a gzipped file.

**Testing**

Tested with:
```
"additional_sync_paths": [
  "/tmp/my/path/example.txt",
  "/tmp/other"
],
```

And the names were correctly saved into app:
![image](https://github.com/viamrobotics/rdk/assets/3794748/3fd6a628-9657-4afc-a93f-09184150c14b)

Tested again with absolute and relative paths, both of which are saved as their absolute paths:
```
"additional_sync_paths": [
  "/tmp/i_am_a_test",
  "relative_test"
],
```
![image](https://github.com/viamrobotics/rdk/assets/3794748/f1d34115-027e-47c5-a959-d0e9f7214202)

The above also saved point clouds which don't have file names associated with them. Exporting the above correctly saved PCDs and images at the top-level data and metadata directories with timestamps prepended to the files, as well as the arbitrary files saved in their original nested directory structures. If the user uploaded a gzipped file, this is correctly unzipped and renamed at CLI time.