### PR TITLE
bugfix: onKeyUp handler on base

### DIFF
--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "2.0.19",
+  "version": "2.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/remote-control",
-      "version": "2.0.19",
+      "version": "2.0.20",
       "license": "Apache-2.0",
       "devDependencies": {
         "@improbable-eng/grpc-web": "0.15.0",

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "2.0.19",
+  "version": "2.0.20",
   "license": "Apache-2.0",
   "type": "module",
   "files": [

--- a/web/frontend/src/components/base/index.svelte
+++ b/web/frontend/src/components/base/index.svelte
@@ -288,13 +288,13 @@
   };
 
   const handleOnKeyUpRun = (event: KeyboardInput) => {
-    if (event.key === 13) {
+    if (event.key === 'Enter') {
       baseRun();
     }
   };
 
   const handleOnKeyUpStop = (event: KeyboardInput) => {
-    if (event.key === 13) {
+    if (event.key === 'Enter') {
       stop();
     }
   };

--- a/web/frontend/src/components/base/index.svelte
+++ b/web/frontend/src/components/base/index.svelte
@@ -324,7 +324,7 @@
       icon="stop-circle-outline"
       label="Stop"
       on:click={stop}
-      on:keyup={(event) => handleOnKeyUp(event, stop)}
+      on:keyup={(event: KeyboardInput) => handleOnKeyUp(event, stop)}
       role="button"
       tabindex="0"
     />
@@ -437,7 +437,7 @@
               variant="success"
               label="Run"
               on:click={baseRun}
-              on:keyup={(event) => handleOnKeyUp(event, baseRun)}
+              on:keyup={(event: KeyboardInput) => handleOnKeyUp(event, baseRun)}
               role="button"
               tabindex="0"
             />

--- a/web/frontend/src/components/base/index.svelte
+++ b/web/frontend/src/components/base/index.svelte
@@ -287,6 +287,12 @@
     angle = event.detail.value;
   };
 
+  const handleOnKeyUp = (event: KeyboardInput, callback: () => void) => {
+    if (event.KeyCode === 13) {
+      callback();
+    }
+  };
+
   onMount(() => {
     window.addEventListener('visibilitychange', handleVisibilityChange);
 
@@ -318,7 +324,7 @@
       icon="stop-circle-outline"
       label="Stop"
       on:click={stop}
-      on:keyup={stop}
+      on:keyup={(event) => handleOnKeyUp(event, stop)}
       role="button"
       tabindex="0"
     />
@@ -431,7 +437,7 @@
               variant="success"
               label="Run"
               on:click={baseRun}
-              on:keyup={baseRun}
+              on:keyup={(event) => handleOnKeyUp(event, baseRun)}
               role="button"
               tabindex="0"
             />

--- a/web/frontend/src/components/base/index.svelte
+++ b/web/frontend/src/components/base/index.svelte
@@ -287,9 +287,15 @@
     angle = event.detail.value;
   };
 
-  const handleOnKeyUp = (event: KeyboardInput, callback: () => void) => {
-    if (event.KeyCode === 13) {
-      callback();
+  const handleOnKeyUpRun = (event: KeyboardInput) => {
+    if (event.key === 13) {
+      baseRun();
+    }
+  };
+
+  const handleOnKeyUpStop = (event: KeyboardInput) => {
+    if (event.key === 13) {
+      stop();
     }
   };
 
@@ -324,7 +330,7 @@
       icon="stop-circle-outline"
       label="Stop"
       on:click={stop}
-      on:keyup={(event: KeyboardInput) => handleOnKeyUp(event, stop)}
+      on:keyup={handleOnKeyUpStop}
       role="button"
       tabindex="0"
     />
@@ -437,7 +443,7 @@
               variant="success"
               label="Run"
               on:click={baseRun}
-              on:keyup={(event: KeyboardInput) => handleOnKeyUp(event, baseRun)}
+              on:keyup={handleOnKeyUpRun}
               role="button"
               tabindex="0"
             />


### PR DESCRIPTION
Refocusing browser window with base RC open causes base to execute currently queued command.

The current bug is caused by our on key event for the `Run` button, under discrete tab. Being that the button is active, when one clicks `alt tab` for instance, this triggers the function call.

The fix adds a helper function that validates that the user is actually hitting the `return` key and not just any key, and from there executes the callback.