### PR TITLE
[RSDK-1939] Don't kill the I2C bus when closing GPIO pins

### DIFF
--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -607,33 +607,19 @@ func (b *Board) SetPowerMode(
 	return grpc.UnimplementedError
 }
 
-func (b *Board) slowLog(message string) {
-		b.logger.Info(message)
-		time.Sleep(10 * time.Second)
-}
-
 // Close attempts to cleanly close each part of the board.
 func (b *Board) Close(ctx context.Context) error {
-	b.slowLog("Starting to close board...")
 	b.mu.Lock()
-	b.slowLog("Acquired lock...")
 	b.cancelFunc()
-	b.slowLog("Canceled background context...")
 	b.mu.Unlock()
-	b.slowLog("Unlocked lock...")
 	b.activeBackgroundWorkers.Wait()
 
 	var err error
-	b.slowLog("Closing GPIO pins...")
-	for i, pin := range b.gpios {
-		b.slowLog(fmt.Sprintf("closing GPIO pin %d", i))
+	for _, pin := range b.gpios {
 		err = multierr.Combine(err, pin.Close())
 	}
-	b.slowLog("Closing interrupt pins...")
-	for i, interrupt := range b.interrupts {
-		b.slowLog(fmt.Sprintf("closing interrupt pin %d", i))
+	for _, interrupt := range b.interrupts {
 		err = multierr.Combine(err, interrupt.Close())
 	}
-	b.slowLog("Done closing the board!")
 	return err
 }

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -607,19 +607,33 @@ func (b *Board) SetPowerMode(
 	return grpc.UnimplementedError
 }
 
+func (b *Board) slowLog(message string) {
+		b.logger.Info(message)
+		time.Sleep(10 * time.Second)
+}
+
 // Close attempts to cleanly close each part of the board.
 func (b *Board) Close(ctx context.Context) error {
+	b.slowLog("Starting to close board...")
 	b.mu.Lock()
+	b.slowLog("Acquired lock...")
 	b.cancelFunc()
+	b.slowLog("Canceled background context...")
 	b.mu.Unlock()
+	b.slowLog("Unlocked lock...")
 	b.activeBackgroundWorkers.Wait()
 
 	var err error
-	for _, pin := range b.gpios {
+	b.slowLog("Closing GPIO pins...")
+	for i, pin := range b.gpios {
+		b.slowLog(fmt.Sprintf("closing GPIO pin %d", i))
 		err = multierr.Combine(err, pin.Close())
 	}
-	for _, interrupt := range b.interrupts {
+	b.slowLog("Closing interrupt pins...")
+	for i, interrupt := range b.interrupts {
+		b.slowLog(fmt.Sprintf("closing interrupt pin %d", i))
 		err = multierr.Combine(err, interrupt.Close())
 	}
+	b.slowLog("Done closing the board!")
 	return err
 }

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -275,12 +275,29 @@ func (pin *gpioPin) Close() error {
 	pin.mu.Lock()
 	defer pin.mu.Unlock()
 
-	// If the entire server is shutting down, it's important to turn off all pins so they don't
-	// continue outputting signals we can no longer control.
-	if err := pin.setInternal(false); err != nil {
-		return err
+	if pin.hwPwm != nil {
+		if err := pin.hwPwm.Close(); err != nil {
+			return err
+		}
 	}
-	return pin.closeGpioFd()
+
+	// If a pin has never been used, leave it alone. This is more important than you might expect:
+	// on some boards (e.g., the Beaglebone AI-64), turning off a GPIO pin tells the kernel that
+	// the pin is in use by the GPIO system and therefore it cannot be used for I2C or other
+	// functions. Make sure that closing a pin here doesn't disable I2C!
+	if pin.line != nil {
+		// If the entire server is shutting down, it's important to turn off all pins so they don't
+		// continue outputting signals we can no longer control.
+		if err := pin.setInternal(false); err != nil {
+			return err
+		}
+
+		if err := pin.closeGpioFd(); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (b *Board) createGpioPin(mapping GPIOBoardMapping) *gpioPin {

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -288,7 +288,7 @@ func (pin *gpioPin) Close() error {
 	if pin.line != nil {
 		// If the entire server is shutting down, it's important to turn off all pins so they don't
 		// continue outputting signals we can no longer control.
-		if err := pin.setInternal(false); err != nil {
+		if err := pin.setInternal(false); err != nil { // setInternal won't double-lock the mutex
 			return err
 		}
 


### PR DESCRIPTION
With this change, you can hammer multiple I2C devices all you want simultaneously through multiple different approaches both in the RDK server and out of it, and all is well.

...and while I was looking at this part, I noticed that we're not turning off hardware PWM when we shut down the RDK server, so I added that in, too.

Tried on an Orin Nano and a Beaglebone: the Orin Nano worked both with and without this change, while the BB only worked with it.