### PR TITLE
Remove mistakenly passing package replacement test

### DIFF
--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -60,8 +60,6 @@ import (
 	weboptions "go.viam.com/rdk/robot/web/options"
 	"go.viam.com/rdk/services/datamanager"
 	"go.viam.com/rdk/services/datamanager/builtin"
-	"go.viam.com/rdk/services/mlmodel"
-	"go.viam.com/rdk/services/mlmodel/tflitecpu"
 	"go.viam.com/rdk/services/motion"
 	motionBuiltin "go.viam.com/rdk/services/motion/builtin"
 	"go.viam.com/rdk/services/navigation"
@@ -1894,80 +1892,6 @@ func TestConfigPackages(t *testing.T) {
 	path2, err := r.PackageManager().PackagePath("some-name-2")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, path2, test.ShouldEqual, path.Join(packageDir, ".data", "ml_model", "package-2-v2"))
-}
-
-func TestConfigPackageReferenceReplacement(t *testing.T) {
-	ctx := context.Background()
-	logger := golog.NewTestLogger(t)
-
-	fakePackageServer, err := putils.NewFakePackageServer(ctx, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer utils.UncheckedErrorFunc(fakePackageServer.Shutdown)
-
-	packageDir := t.TempDir()
-	labelPath := "${packages.orgID/some-name-2}/labels.txt"
-
-	robotConfig := &config.Config{
-		Packages: []config.PackageConfig{
-			{
-				Name:    "some-name-1",
-				Package: "package-1",
-				Version: "v1",
-			},
-			{
-				Name:    "orgID/some-name-2",
-				Package: "package-2",
-				Version: "latest",
-			},
-			{
-				Name:    "my-module",
-				Package: "orgID/my-module",
-				Type:    config.PackageTypeModule,
-				Version: "1.2",
-			},
-			{
-				Name:    "my-ml-model",
-				Package: "orgID/my-ml-model",
-				Type:    config.PackageTypeMlModel,
-				Version: "latest",
-			},
-		},
-		PackagePath: packageDir,
-		Services: []resource.Config{
-			{
-				Name:  "ml-model-service",
-				API:   mlmodel.API,
-				Model: resource.DefaultModelFamily.WithModel("tflite_cpu"),
-				ConvertedAttributes: &tflitecpu.TFLiteConfig{
-					ModelPath:  "${packages.some-name-1}/model.tflite",
-					LabelPath:  labelPath,
-					NumThreads: 1,
-				},
-			},
-			{
-				Name:  "my-ml-model",
-				API:   mlmodel.API,
-				Model: resource.DefaultModelFamily.WithModel("tflite_cpu"),
-				ConvertedAttributes: &tflitecpu.TFLiteConfig{
-					ModelPath:  "${packages.ml_models.my-ml-model}/model.tflite",
-					LabelPath:  labelPath,
-					NumThreads: 2,
-				},
-			},
-		},
-		Modules: []config.Module{
-			{
-				Name:    "my-module",
-				ExePath: "${packages.modules.my-module}/exec.sh",
-			},
-		},
-	}
-
-	fakePackageServer.StorePackage(robotConfig.Packages...)
-
-	r, err := robotimpl.New(ctx, robotConfig, logger)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, r.Close(context.Background()), test.ShouldBeNil)
 }
 
 // removeDefaultServices removes default services and returns the removed


### PR DESCRIPTION
Was reading through some robot tests when I stumbled upon this test (I must've missed it). 

Everything that this test is supposed to test is already tested elsewhere. Unfortunately, this test also passes when it should clearly fail (the placeholders are invalid and are never evaluated).

I don't see the value in fixing this test given that the things it tests are tested elsewhere and because it was already broken.

If you feel strongly that it should be replaced, happy to look into putting something in its place.