### PR TITLE
[RSDK-4900][RSDK-4981]: add functionality to access rpmMonitor state and redo test file

### DIFF
--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -54,8 +54,6 @@ func WrapMotorWithEncoder(
 		logger.Info("direction attached to single encoder from encoded motor")
 	}
 
-	mm.RPMMonitorStart()
-
 	return mm, nil
 }
 
@@ -183,7 +181,7 @@ type EncodedMotorState struct {
 }
 
 // RPMMonitorStart starts the RPM monitor.
-func (m *EncodedMotor) RPMMonitorStart() {
+func (m *EncodedMotor) rpmMonitorStart() {
 	m.startedRPMMonitorMu.Lock()
 	startedRPMMonitor := m.startedRPMMonitor
 	m.startedRPMMonitorMu.Unlock()
@@ -383,7 +381,7 @@ func (m *EncodedMotor) GoFor(ctx context.Context, rpm, revolutions float64, extr
 }
 
 func (m *EncodedMotor) goForInternal(ctx context.Context, rpm, revolutions float64) error {
-	m.RPMMonitorStart()
+	m.rpmMonitorStart()
 	m.state.direction = sign(rpm * revolutions)
 
 	switch speed := math.Abs(rpm); {

--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -349,8 +349,8 @@ func (m *EncodedMotor) SetPower(ctx context.Context, powerPct float64, extra map
 // setPower assumes the state lock is held.
 func (m *EncodedMotor) setPower(ctx context.Context, powerPct float64, internal bool) error {
 	dir := sign(powerPct)
-	if math.Abs(powerPct) < 0.2 {
-		m.state.lastPowerPct = 0.2 * dir
+	if math.Abs(powerPct) < 0.1 {
+		m.state.lastPowerPct = 0.1 * dir
 	} else {
 		m.state.lastPowerPct = powerPct
 	}
@@ -383,6 +383,7 @@ func (m *EncodedMotor) GoFor(ctx context.Context, rpm, revolutions float64, extr
 }
 
 func (m *EncodedMotor) goForInternal(ctx context.Context, rpm, revolutions float64) error {
+	m.RPMMonitorStart()
 	m.state.direction = sign(rpm * revolutions)
 
 	switch speed := math.Abs(rpm); {

--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -496,6 +496,20 @@ func (m *EncodedMotor) IsMoving(ctx context.Context) (bool, error) {
 	return m.real.IsMoving(ctx)
 }
 
+// SetMotorState allows users to set the motor state values.
+func (m *EncodedMotor) SetMotorState(ctx context.Context, newState EncodedMotorState) {
+	m.stateMu.Lock()
+	defer m.stateMu.Unlock()
+	m.state = newState
+}
+
+// GetMotorState allows users to get the motor state values.
+func (m *EncodedMotor) GetMotorState(ctx context.Context) EncodedMotorState {
+	m.stateMu.Lock()
+	defer m.stateMu.Unlock()
+	return m.state
+}
+
 // Stop stops rpmMonitor and stops the real motor.
 func (m *EncodedMotor) Stop(ctx context.Context, extra map[string]interface{}) error {
 	m.stateMu.Lock()

--- a/components/motor/gpio/motor_encoder_test.go
+++ b/components/motor/gpio/motor_encoder_test.go
@@ -81,7 +81,6 @@ func MakeIncrementalBoard(t *testing.T) *fakeboard.Board {
 }
 
 func TestMotorEncoder1(t *testing.T) {
-	t.Skip()
 	logger := golog.NewTestLogger(t)
 
 	cfg := Config{TicksPerRotation: 100, MaxRPM: 100}
@@ -120,6 +119,38 @@ func TestMotorEncoder1(t *testing.T) {
 		test.That(t, motorDep.Close(context.Background()), test.ShouldBeNil)
 	}()
 
+	t.Run("test get and set motor", func(t *testing.T) {
+		ctx := context.Background()
+
+		expectedState := EncodedMotorState{
+			regulated:    false,
+			goalRPM:      0,
+			currentRPM:   0,
+			lastPowerPct: 0,
+			goalPos:      0,
+			direction:    0,
+		}
+		state := motorDep.GetMotorState(ctx)
+		testutils.WaitForAssertion(t, func(tb testing.TB) {
+			tb.Helper()
+			test.That(tb, state, test.ShouldResemble, expectedState)
+		})
+
+		newState := EncodedMotorState{
+			regulated:    true,
+			goalRPM:      100,
+			currentRPM:   10,
+			lastPowerPct: 0.2,
+			goalPos:      200,
+			direction:    -1,
+		}
+		motorDep.SetMotorState(ctx, newState)
+		testutils.WaitForAssertion(t, func(tb testing.TB) {
+			tb.Helper()
+			test.That(tb, motorDep.state, test.ShouldResemble, newState)
+		})
+	})
+
 	t.Run("encoded motor testing the basics", func(t *testing.T) {
 		isOn, powerPct, err := motorDep.IsPowered(context.Background(), nil)
 		test.That(t, err, test.ShouldBeNil)
@@ -133,7 +164,7 @@ func TestMotorEncoder1(t *testing.T) {
 	t.Run("encoded motor testing SetPower", func(t *testing.T) {
 		test.That(t, motorDep.SetPower(context.Background(), .01, nil), test.ShouldBeNil)
 		test.That(t, fakeMotor.Direction(), test.ShouldEqual, 1)
-		test.That(t, fakeMotor.PowerPct(), test.ShouldEqual, .01)
+		test.That(t, fakeMotor.PowerPct(), test.ShouldEqual, .1)
 	})
 
 	t.Run("encoded motor testing Stop", func(t *testing.T) {
@@ -157,7 +188,7 @@ func TestMotorEncoder1(t *testing.T) {
 		}()
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			test.That(tb, fakeMotor.PowerPct(), test.ShouldEqual, float32(1))
+			test.That(tb, fakeMotor.PowerPct(), test.ShouldEqual, float32(0.1))
 		})
 		motorDep.SetPower(context.Background(), -0.25, nil)
 		receivedErr := <-errChan
@@ -297,7 +328,6 @@ func TestMotorEncoder1(t *testing.T) {
 }
 
 func TestMotorEncoderIncremental(t *testing.T) {
-	t.Skip()
 	logger := golog.NewTestLogger(t)
 
 	type testHarness struct {
@@ -607,7 +637,6 @@ func TestMotorEncoderIncremental(t *testing.T) {
 }
 
 func TestWrapMotorWithEncoder(t *testing.T) {
-	t.Skip()
 	logger := golog.NewTestLogger(t)
 
 	t.Run("wrap motor no encoder", func(t *testing.T) {
@@ -715,7 +744,6 @@ func TestWrapMotorWithEncoder(t *testing.T) {
 }
 
 func TestDirFlipMotor(t *testing.T) {
-	t.Skip()
 	logger := golog.NewTestLogger(t)
 	cfg := Config{TicksPerRotation: 100, MaxRPM: 100, DirectionFlip: true}
 	dirflipFakeMotor := &fakemotor.Motor{

--- a/components/motor/gpio/motor_encoder_test.go
+++ b/components/motor/gpio/motor_encoder_test.go
@@ -369,7 +369,6 @@ func TestMotorEncoderIncremental(t *testing.T) {
 		motor, ok := motorIfc.(*EncodedMotor)
 		test.That(t, ok, test.ShouldBeTrue)
 
-		motor.RPMMonitorStart()
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
 			pos := enc.RawPosition()


### PR DESCRIPTION
This PR implements `GetMotorState` and `SetMotorState` which allows users to access the internal state that rpmMonitor uses. Kind of wondering if this is how we want to do it or just export motor.state? or should a user only be able to access certain parts of the motor state instead of everything?

Also went back through the test file to get everything working again