### PR TITLE
RSDK-5015: simplify/combine constructors to one function

### DIFF
--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -59,17 +59,7 @@ func WrapMotorWithEncoder(
 	return mm, nil
 }
 
-// NewEncodedMotor creates a new motor that supports an arbitrary source of encoder information.
-func NewEncodedMotor(
-	conf resource.Config,
-	motorConfig Config,
-	realMotor motor.Motor,
-	encoder encoder.Encoder,
-	logger golog.Logger,
-) (motor.Motor, error) {
-	return newEncodedMotor(conf.ResourceName(), motorConfig, realMotor, encoder, logger)
-}
-
+// newEncodedMotor creates a new motor that supports an arbitrary source of encoder information.
 func newEncodedMotor(
 	name resource.Name,
 	motorConfig Config,

--- a/components/motor/gpio/motor_encoder_test.go
+++ b/components/motor/gpio/motor_encoder_test.go
@@ -21,8 +21,6 @@ import (
 	"go.viam.com/rdk/resource"
 )
 
-// setupMotorWithEncoder(encType string) {}
-
 func nowNanosTest() uint64 {
 	return uint64(time.Now().UnixNano())
 }
@@ -110,7 +108,7 @@ func TestMotorEncoder1(t *testing.T) {
 	defer enc.Close(context.Background())
 
 	enc.AttachDirectionalAwareness(&fakeDirectionAware{m: fakeMotor})
-	dirFMotor, err := NewEncodedMotor(resource.Config{}, cfg, fakeMotor, e, logger)
+	dirFMotor, err := WrapMotorWithEncoder(context.Background(), e, resource.Config{}, cfg, fakeMotor, logger)
 	test.That(t, err, test.ShouldBeNil)
 	defer dirFMotor.Close(context.Background())
 	motorDep, ok := dirFMotor.(*EncodedMotor)
@@ -333,7 +331,7 @@ func TestMotorEncoderIncremental(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		enc := e.(*incremental.Encoder)
 
-		motorIfc, err := NewEncodedMotor(resource.Config{}, cfg, fakeMotor, enc, logger)
+		motorIfc, err := WrapMotorWithEncoder(context.Background(), enc, resource.Config{}, cfg, fakeMotor, logger)
 		test.That(t, err, test.ShouldBeNil)
 
 		motor, ok := motorIfc.(*EncodedMotor)
@@ -744,7 +742,7 @@ func TestDirFlipMotor(t *testing.T) {
 	defer enc.Close(context.Background())
 
 	enc.AttachDirectionalAwareness(&fakeDirectionAware{m: dirflipFakeMotor})
-	dirFMotor, err := NewEncodedMotor(resource.Config{}, cfg, dirflipFakeMotor, e, logger)
+	dirFMotor, err := WrapMotorWithEncoder(context.Background(), e, resource.Config{}, cfg, dirflipFakeMotor, logger)
 	test.That(t, err, test.ShouldBeNil)
 	defer dirFMotor.Close(context.Background())
 	_dirFMotor, ok := dirFMotor.(*EncodedMotor)


### PR DESCRIPTION
this PR replaces the use of `NewEncodedMotor` with `WrapMotorWithEncoder` so there aren't so many related creator functions