### PR TITLE
RSDK-4171, RSDK-4546 - Fix weird module behavior on process kill and model switch

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -493,6 +493,7 @@ func (mgr *Manager) newOnUnexpectedExitHandler(mod *module) func(exitCode int) b
 			if _, err := mgr.addResource(ctx, res.conf, res.deps); err != nil {
 				mgr.logger.Warnw("error while re-adding resource to module",
 					"resource", name, "module", mod.name, "error", err)
+				delete(mgr.rMap, name)
 				delete(mod.resources, name)
 				orphanedResourceNames = append(orphanedResourceNames, name)
 			}

--- a/resource/graph_node.go
+++ b/resource/graph_node.go
@@ -119,6 +119,14 @@ func (w *GraphNode) IsUninitialized() bool {
 	return w.current == nil
 }
 
+// UnsetResource unsets the current resource. This function does not clean up
+// or close the resource and should be used carefully.
+func (w *GraphNode) UnsetResource() {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	w.current = nil
+}
+
 // SwapResource emplaces the new resource. It may be the same as before
 // and expects the caller to close the old one. This is considered
 // to be a working resource and as such we unmark it for removal

--- a/resource/graph_node.go
+++ b/resource/graph_node.go
@@ -122,8 +122,8 @@ func (w *GraphNode) IsUninitialized() bool {
 // UnsetResource unsets the current resource. This function does not clean up
 // or close the resource and should be used carefully.
 func (w *GraphNode) UnsetResource() {
-	w.mu.RLock()
-	defer w.mu.RUnlock()
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	w.current = nil
 }
 

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -795,11 +795,10 @@ func (manager *resourceManager) processResource(
 	if err != nil {
 		gNode.UnsetResource()
 		manager.logger.Debugw(
-			"failed to rebuild resource of different model, removing closed resource from graph node",
-			"name",
-			resName,
-			"new_model",
-			conf.Model,
+			"failed to build resource of new model, removing closed resource of old model from graph node",
+			"name", resName,
+			"old_model", gNode.ResourceModel(),
+			"new_model", conf.Model,
 		)
 		return nil, false, err
 	}

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -793,6 +793,14 @@ func (manager *resourceManager) processResource(
 	}
 	newRes, err := r.newResource(ctx, gNode, conf)
 	if err != nil {
+		gNode.UnsetResource()
+		manager.logger.Debugw(
+			"failed to rebuild resource of different model, removing closed resource from graph node",
+			"name",
+			resName,
+			"new_model",
+			conf.Model,
+		)
 		return nil, false, err
 	}
 	return newRes, true, nil

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -90,12 +90,13 @@ func fromRemoteNameToRemoteNodeName(name string) resource.Name {
 
 func (manager *resourceManager) startModuleManager(
 	parentAddr string,
+	removeOrphanedResources func(context.Context, []resource.Name),
 	untrustedEnv bool,
 	logger golog.Logger,
 ) {
 	mmOpts := modmanageroptions.Options{
 		UntrustedEnv:            untrustedEnv,
-		RemoveOrphanedResources: manager.removeOrphanedResources,
+		RemoveOrphanedResources: removeOrphanedResources,
 	}
 	manager.moduleManager = modmanager.NewManager(parentAddr, logger, mmOpts)
 }
@@ -1058,18 +1059,6 @@ func (manager *resourceManager) markResourcesRemoved(
 		manager.resources.MarkForRemoval(subG)
 	}
 	return resourcesToCloseBeforeComplete
-}
-
-// removeOrphanedResources is called by the module manager to remove resources
-// orphaned due to module crashes.
-func (manager *resourceManager) removeOrphanedResources(ctx context.Context,
-	rNames []resource.Name,
-) {
-	manager.markResourcesRemoved(rNames, nil)
-	if err := manager.removeMarkedAndClose(ctx, nil); err != nil {
-		manager.logger.Errorw("error removing and closing marked resources",
-			"error", err)
-	}
 }
 
 // createConfig will create a config.Config based on the current state of the

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -1861,7 +1861,7 @@ func managerForDummyRobot(robot robot.Robot) *resourceManager {
 
 	// start a dummy module manager so calls to moduleManager.Provides() do not
 	// panic.
-	manager.startModuleManager("", false, robot.Logger())
+	manager.startModuleManager("", nil, false, robot.Logger())
 
 	for _, name := range robot.ResourceNames() {
 		res, err := robot.ResourceByName(name)

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -3419,6 +3419,90 @@ func TestReconfigureModelSwitch(t *testing.T) {
 	test.That(t, res3.(*mockFake2).closeCount, test.ShouldEqual, 0)
 }
 
+func TestReconfigureModelSwitchErr(t *testing.T) {
+	logger := golog.NewTestLogger(t)
+
+	mockAPI := resource.APINamespaceRDK.WithComponentType("mock")
+	mockNamed := func(name string) resource.Name {
+		return resource.NewName(mockAPI, name)
+	}
+	modelName1 := utils.RandomAlphaString(5)
+	model1 := resource.DefaultModelFamily.WithModel(modelName1)
+
+	newCount := 0
+	resource.RegisterComponent(mockAPI, model1, resource.Registration[resource.Resource, resource.NoNativeConfig]{
+		Constructor: func(
+			ctx context.Context,
+			deps resource.Dependencies,
+			conf resource.Config,
+			logger golog.Logger,
+		) (resource.Resource, error) {
+			newCount++
+			return &mockFake{Named: conf.ResourceName().AsNamed()}, nil
+		},
+	})
+
+	defer func() {
+		resource.Deregister(mockAPI, model1)
+	}()
+
+	cfg := &config.Config{
+		Components: []resource.Config{
+			{
+				Name:  "one",
+				Model: model1,
+				API:   mockAPI,
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	r, err := New(ctx, cfg, logger)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, newCount, test.ShouldEqual, 1)
+	defer func() {
+		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
+	}()
+
+	name1 := mockNamed("one")
+	res1, err := r.ResourceByName(name1)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, res1.(*mockFake).reconfCount, test.ShouldEqual, 0)
+	test.That(t, res1.(*mockFake).closeCount, test.ShouldEqual, 0)
+
+	modelName2 := utils.RandomAlphaString(5)
+	model2 := resource.DefaultModelFamily.WithModel(modelName2)
+
+	newCfg := &config.Config{
+		Components: []resource.Config{
+			{
+				Name:  "one",
+				Model: model2,
+				API:   mockAPI,
+			},
+		},
+	}
+	r.Reconfigure(ctx, newCfg)
+	test.That(t, newCount, test.ShouldEqual, 1)
+
+	_, err = r.ResourceByName(name1)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, res1.(*mockFake).reconfCount, test.ShouldEqual, 0)
+	test.That(t, res1.(*mockFake).closeCount, test.ShouldEqual, 1)
+
+	r.Reconfigure(ctx, cfg)
+	test.That(t, newCount, test.ShouldEqual, 2)
+
+	res2, err := r.ResourceByName(name1)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, res2, test.ShouldNotEqual, res1)
+	test.That(t, res1.(*mockFake).reconfCount, test.ShouldEqual, 0)
+	test.That(t, res1.(*mockFake).closeCount, test.ShouldEqual, 1)
+	test.That(t, res2.(*mockFake).reconfCount, test.ShouldEqual, 0)
+	test.That(t, res2.(*mockFake).closeCount, test.ShouldEqual, 0)
+}
+
 func TestReconfigureRename(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 


### PR DESCRIPTION
If we kill a module process, the viam-server starts the module back up but the WeakDependents are not updated - so in cases where the module now serves a different model, certain things will not get updated (sensors, motion, etc). Causes issues when you have a sensor that no longer exists showing up on the sensors service card. (not sure of a good test for this, open to suggestions!)

if we switch the model of a modular resource to an invalid model and then back, we were also unable to reinstantiate the resource - we closed the old one but because the invalid model never succeeded, on reconfiguring it back to the valid model the rdk recognizes it as a regular reconfigure. Since the old resource is already gone, the module will respond with various kinds of ResourceNotFound errors - this change correctly unsets the resource from the graph node.

