### PR TITLE
Control Loop Base Part I: Refactors for more general endpoints

### DIFF
--- a/components/motor/gpio/loop.go
+++ b/components/motor/gpio/loop.go
@@ -1,0 +1,11 @@
+package gpio
+
+import "context"
+
+func (m *EncodedMotor) SetState(ctx context.Context, state float64) error {
+	return m.SetPower(ctx, state, nil)
+}
+
+func (m *EncodedMotor) State(ctx context.Context) (float64, error) {
+	return m.position(ctx, nil)
+}

--- a/components/motor/gpio/loop.go
+++ b/components/motor/gpio/loop.go
@@ -2,10 +2,12 @@ package gpio
 
 import "context"
 
+// SetState sets the state of the motor for the built-in control loop.
 func (m *EncodedMotor) SetState(ctx context.Context, state float64) error {
 	return m.SetPower(ctx, state, nil)
 }
 
+// State gets the state of the motor for the built-in control loop.
 func (m *EncodedMotor) State(ctx context.Context) (float64, error) {
 	return m.position(ctx, nil)
 }

--- a/control/constant.go
+++ b/control/constant.go
@@ -36,7 +36,7 @@ func (b *constant) reset() error {
 	if len(b.cfg.DependsOn) > 0 {
 		return errors.Errorf("invalid number of inputs for constant block %s expected 0 got %d", b.cfg.Name, len(b.cfg.DependsOn))
 	}
-	b.constant = b.cfg.Attribute.Float64("constant_val", 0.0)
+	b.constant = b.cfg.Attribute["constant_val"].(float64) // default 0
 	b.y = make([]*Signal, 1)
 	b.y[0] = makeSignal(b.cfg.Name)
 	b.y[0].SetSignalValueAt(0, b.constant)

--- a/control/control.go
+++ b/control/control.go
@@ -8,10 +8,10 @@ import (
 
 // Controllable controllable type for a DC motor.
 type Controllable interface {
-	// SetPower set the power and direction of the motor
-	SetPower(ctx context.Context, power float64, extra map[string]interface{}) error
+	// SetState set the power and direction of the motor
+	SetState(ctx context.Context, state float64) error
 	// Position returns the current encoder count value
-	Position(ctx context.Context, extra map[string]interface{}) (float64, error)
+	State(ctx context.Context) (float64, error)
 }
 
 // Config configuration of the control loop.

--- a/control/control_block.go
+++ b/control/control_block.go
@@ -32,11 +32,6 @@ type BlockConfig struct {
 	DependsOn []string           `json:"depends_on"` // List of blocks needed for calling Next
 }
 
-/* Full List of Attributes
-
-*/
-
-
 // Block interface for a control block.
 type Block interface {
 	// Reset will reset the control block to initial state. Returns an error on failure

--- a/control/control_block.go
+++ b/control/control_block.go
@@ -32,6 +32,8 @@ type BlockConfig struct {
 	DependsOn []string           `json:"depends_on"` // List of blocks needed for calling Next
 }
 
+
+
 // Block interface for a control block.
 type Block interface {
 	// Reset will reset the control block to initial state. Returns an error on failure

--- a/control/control_block.go
+++ b/control/control_block.go
@@ -32,8 +32,6 @@ type BlockConfig struct {
 	DependsOn []string           `json:"depends_on"` // List of blocks needed for calling Next
 }
 
-
-
 // Block interface for a control block.
 type Block interface {
 	// Reset will reset the control block to initial state. Returns an error on failure

--- a/control/control_block.go
+++ b/control/control_block.go
@@ -32,6 +32,11 @@ type BlockConfig struct {
 	DependsOn []string           `json:"depends_on"` // List of blocks needed for calling Next
 }
 
+/* Full List of Attributes
+
+*/
+
+
 // Block interface for a control block.
 type Block interface {
 	// Reset will reset the control block to initial state. Returns an error on failure

--- a/control/derivative.go
+++ b/control/derivative.go
@@ -107,7 +107,7 @@ func (d *derivative) reset() error {
 	if len(d.cfg.DependsOn) != 1 {
 		return errors.Errorf("derive block %s only supports one input got %d", d.cfg.Name, len(d.cfg.DependsOn))
 	}
-	switch finiteDifferenceType(d.cfg.Attribute.String("derive_type")) {
+	switch finiteDifferenceType(d.cfg.Attribute["derive_type"].(string)) {
 	case backward1st1:
 		d.stencil = backward1st1Stencil
 	case backward1st2:
@@ -119,7 +119,7 @@ func (d *derivative) reset() error {
 	case backward2nd2:
 		d.stencil = backward2nd2Stencil
 	default:
-		return errors.Errorf("unsupported derive_type %s for block %s", d.cfg.Attribute.String("derive_type"), d.cfg.Name)
+		return errors.Errorf("unsupported derive_type %s for block %s", d.cfg.Attribute["derive_type"].(string), d.cfg.Name)
 	}
 	d.px = make([][]float64, len(d.cfg.DependsOn))
 	d.y = make([]*Signal, len(d.cfg.DependsOn))

--- a/control/encoder_speed.go
+++ b/control/encoder_speed.go
@@ -40,7 +40,7 @@ func (b *encoderToRPM) reset() error {
 	if len(b.cfg.DependsOn) != 1 {
 		return errors.Errorf("invalid number of inputs for encoderToRPM block %s expected 1 got %d", b.cfg.Name, len(b.cfg.DependsOn))
 	}
-	b.ticksPerRevolution = b.cfg.Attribute.Int("ticks_per_revolution", 0)
+	b.ticksPerRevolution = b.cfg.Attribute["ticks_per_revolution"].(int) // default 0
 	b.prevEncCount = 0
 	b.y = make([]*Signal, 1)
 	b.y[0] = makeSignal(b.cfg.Name)

--- a/control/endpoint.go
+++ b/control/endpoint.go
@@ -26,27 +26,28 @@ func newEndpoint(config BlockConfig, logger golog.Logger, ctr Controllable) (Blo
 }
 
 func (e *endpoint) Next(ctx context.Context, x []*Signal, dt time.Duration) ([]*Signal, bool) {
-	if len(x) == 1 {
+	switch len(x) {
+	case 1:
 		power := x[0].GetSignalValueAt(0)
 		if e.ctr != nil {
-			err := e.ctr.SetPower(ctx, power, nil)
+			err := e.ctr.SetState(ctx, power)
 			if err != nil {
 				return []*Signal{}, false
 			}
 		}
 		return []*Signal{}, false
-	}
-	if len(x) == 0 {
+	case 0:
 		if e.ctr != nil {
-			pos, err := e.ctr.Position(ctx, nil)
+			pos, err := e.ctr.State(ctx)
 			if err != nil {
 				return []*Signal{}, false
 			}
 			e.y[0].SetSignalValueAt(0, pos)
 		}
 		return e.y, true
+	default:
+		return e.y, false
 	}
-	return e.y, false
 }
 
 func (e *endpoint) reset() error {

--- a/control/filters.go
+++ b/control/filters.go
@@ -67,7 +67,7 @@ func (f *filterStruct) initFilter() error {
 			return errors.Errorf("filter %s of type %s should have a kernel_size field", f.cfg.Name, fType)
 		}
 		flt := firWindowedSinc{
-			smpFreq:    f.cfg.Attribute["fs"].(float64),      //default 0.0
+
 			cutOffFreq: f.cfg.Attribute["fc"].(float64),      // default 0.0,
 			kernelSize: f.cfg.Attribute["kernel_size"].(int), // default 0,
 		}
@@ -90,7 +90,7 @@ func (f *filterStruct) initFilter() error {
 			return errors.Errorf("filter %s of type %s should have a order field", f.cfg.Name, fType)
 		}
 		flt := iirFilter{
-			smpFreq:    f.cfg.Attribute["fs"].(float64), //default 0.0
+
 			n:          f.cfg.Attribute["order"].(int),  // default 0
 			cutOffFreq: f.cfg.Attribute["fc"].(float64), // default 0.0
 			ripple:     0.0,
@@ -122,9 +122,9 @@ func (f *filterStruct) initFilter() error {
 		}
 		flt := iirFilter{
 			smpFreq:    f.cfg.Attribute["fs"].(float64),     // default 0,0
-			n:          f.cfg.Attribute["order"].(int),      //default 0.0),
-			cutOffFreq: f.cfg.Attribute["fc"].(float64),     //default 0.0
-			ripple:     f.cfg.Attribute["ripple"].(float64), //default 0.0
+
+			cutOffFreq: f.cfg.Attribute["fc"].(float64),     // default 0.0
+			ripple:     f.cfg.Attribute["ripple"].(float64), // default 0.0
 			fltType:    f.cfg.Attribute["filter_type"].(string),
 		}
 		f.filter = &flt

--- a/control/filters.go
+++ b/control/filters.go
@@ -67,7 +67,7 @@ func (f *filterStruct) initFilter() error {
 			return errors.Errorf("filter %s of type %s should have a kernel_size field", f.cfg.Name, fType)
 		}
 		flt := firWindowedSinc{
-
+			smpFreq:    f.cfg.Attribute["fs"].(float64),
 			cutOffFreq: f.cfg.Attribute["fc"].(float64),      // default 0.0,
 			kernelSize: f.cfg.Attribute["kernel_size"].(int), // default 0,
 		}
@@ -90,7 +90,7 @@ func (f *filterStruct) initFilter() error {
 			return errors.Errorf("filter %s of type %s should have a order field", f.cfg.Name, fType)
 		}
 		flt := iirFilter{
-
+			smpFreq:    f.cfg.Attribute["fs"].(float64),
 			n:          f.cfg.Attribute["order"].(int),  // default 0
 			cutOffFreq: f.cfg.Attribute["fc"].(float64), // default 0.0
 			ripple:     0.0,
@@ -121,8 +121,8 @@ func (f *filterStruct) initFilter() error {
 			return errors.Errorf("filter %s of type %s should have a filter_type field", f.cfg.Name, fType)
 		}
 		flt := iirFilter{
-			smpFreq:    f.cfg.Attribute["fs"].(float64),     // default 0,0
-
+			smpFreq:    f.cfg.Attribute["fs"].(float64), // default 0,0
+			n:          f.cfg.Attribute["order"].(int),
 			cutOffFreq: f.cfg.Attribute["fc"].(float64),     // default 0.0
 			ripple:     f.cfg.Attribute["ripple"].(float64), // default 0.0
 			fltType:    f.cfg.Attribute["filter_type"].(string),

--- a/control/filters.go
+++ b/control/filters.go
@@ -45,14 +45,14 @@ func (f *filterStruct) initFilter() error {
 	}
 	f.y = make([]*Signal, 1)
 	f.y[0] = makeSignal(f.cfg.Name)
-	fType := f.cfg.Attribute.String("type")
+	fType := f.cfg.Attribute["type"].(string)
 	switch filterType(fType) {
 	case filterFIRMovingAverage:
 		if !f.cfg.Attribute.Has("filter_size") {
 			return errors.Errorf("filter %s of type %s should have a filter_size field", f.cfg.Name, fType)
 		}
 		flt := movingAverageFilter{
-			filterSize: f.cfg.Attribute.Int("filter_size", 0),
+			filterSize: f.cfg.Attribute["filter_size"].(int), // default 0
 		}
 		f.filter = &flt
 		return f.filter.Reset()
@@ -67,9 +67,9 @@ func (f *filterStruct) initFilter() error {
 			return errors.Errorf("filter %s of type %s should have a kernel_size field", f.cfg.Name, fType)
 		}
 		flt := firWindowedSinc{
-			smpFreq:    f.cfg.Attribute.Float64("fs", 0.0),
-			cutOffFreq: f.cfg.Attribute.Float64("fc", 0.0),
-			kernelSize: f.cfg.Attribute.Int("kernel_size", 0),
+			smpFreq:    f.cfg.Attribute["fs"].(float64),      //default 0.0
+			cutOffFreq: f.cfg.Attribute["fc"].(float64),      // default 0.0,
+			kernelSize: f.cfg.Attribute["kernel_size"].(int), // default 0,
 		}
 		f.filter = &flt
 		return f.filter.Reset()
@@ -90,11 +90,11 @@ func (f *filterStruct) initFilter() error {
 			return errors.Errorf("filter %s of type %s should have a order field", f.cfg.Name, fType)
 		}
 		flt := iirFilter{
-			smpFreq:    f.cfg.Attribute.Float64("fs", 0.0),
-			n:          f.cfg.Attribute.Int("order", 0.0),
-			cutOffFreq: f.cfg.Attribute.Float64("fc", 0.0),
+			smpFreq:    f.cfg.Attribute["fs"].(float64), //default 0.0
+			n:          f.cfg.Attribute["order"].(int),  // default 0
+			cutOffFreq: f.cfg.Attribute["fc"].(float64), // default 0.0
 			ripple:     0.0,
-			fltType:    f.cfg.Attribute.String("filter_type"),
+			fltType:    f.cfg.Attribute["filter_type"].(string),
 		}
 		f.filter = &flt
 		return f.filter.Reset()
@@ -121,11 +121,11 @@ func (f *filterStruct) initFilter() error {
 			return errors.Errorf("filter %s of type %s should have a filter_type field", f.cfg.Name, fType)
 		}
 		flt := iirFilter{
-			smpFreq:    f.cfg.Attribute.Float64("fs", 0.0),
-			n:          f.cfg.Attribute.Int("order", 0.0),
-			cutOffFreq: f.cfg.Attribute.Float64("fc", 0.0),
-			ripple:     f.cfg.Attribute.Float64("ripple", 0.0),
-			fltType:    f.cfg.Attribute.String("filter_type"),
+			smpFreq:    f.cfg.Attribute["fs"].(float64),     // default 0,0
+			n:          f.cfg.Attribute["order"].(int),      //default 0.0),
+			cutOffFreq: f.cfg.Attribute["fc"].(float64),     //default 0.0
+			ripple:     f.cfg.Attribute["ripple"].(float64), //default 0.0
+			fltType:    f.cfg.Attribute["filter_type"].(string),
 		}
 		f.filter = &flt
 		return f.filter.Reset()

--- a/control/gain.go
+++ b/control/gain.go
@@ -44,7 +44,10 @@ func (b *gain) reset() error {
 	if len(b.cfg.DependsOn) != 1 {
 		return errors.Errorf("invalid number of inputs for gain block %s expected 1 got %d", b.cfg.Name, len(b.cfg.DependsOn))
 	}
-	b.gain = b.cfg.Attribute.Float64("gain", 1.0)
+	b.gain = b.cfg.Attribute["gain"].(float64)
+	if b.gain == 0 {
+		b.gain = 1.0
+	}
 	b.y = make([]*Signal, 1)
 	b.y[0] = makeSignal(b.cfg.Name)
 	return nil

--- a/control/pid.go
+++ b/control/pid.go
@@ -101,18 +101,26 @@ func (p *basicPID) reset() error {
 	p.kD = p.cfg.Attribute["kD"].(float64)
 	p.kP = p.cfg.Attribute["kP"].(float64)
 
+	// ensure a default of 255
+	p.satLimUp = 255
 	if satLimUp, ok := p.cfg.Attribute["int_sat_lim_up"].(float64); ok {
 		p.satLimUp = satLimUp
 	}
 
+	// ensure a default of 255
+	p.limUp = 255
 	if limup, ok := p.cfg.Attribute["limit_up"].(float64); ok {
 		p.limUp = limup
 	}
 
+	// zero float64 for this value is default in the pid struct
+	// by golang
 	if p.cfg.Attribute.Has("int_sat_lim_lo") {
 		p.satLimLo = p.cfg.Attribute["int_sat_lim_lo"].(float64)
 	}
 
+	//  zero float64 for this value is default in the pid struct
+	// by golang
 	if p.cfg.Attribute.Has("limit_lo") {
 		p.satLimLo = p.cfg.Attribute["limit_lo"].(float64)
 	}
@@ -215,7 +223,7 @@ type pidTuner struct {
 	pPeakL       []float64
 	pFindDir     int
 	tuneMethod   tuneCalcMethod
-	stepPct      float64
+	stepPct      float64 `default:".35"`
 	limUp        float64
 	limLo        float64
 	ssRValue     float64 `default:"2.0"`

--- a/control/pid.go
+++ b/control/pid.go
@@ -102,20 +102,20 @@ func (p *basicPID) reset() error {
 	p.kP = p.cfg.Attribute["kP"].(float64)
 
 	p.satLimUp = 255.0
-	if p.cfg.Attribute["int_sat_lim_up"] != nil {
+	if p.cfg.Attribute.Has("int_sat_lim_up") {
 		p.satLimUp = p.cfg.Attribute["int_sat_lim_up"].(float64)
 	}
 
 	p.limUp = 255.0
-	if p.cfg.Attribute["limit_up"] != nil {
+	if p.cfg.Attribute.Has("limit_up") {
 		p.limUp = p.cfg.Attribute["limit_up"].(float64)
 	}
 
-	if p.cfg.Attribute["int_sat_lim_lo"] != nil {
+	if p.cfg.Attribute.Has("int_sat_lim_lo") {
 		p.satLimLo = p.cfg.Attribute["int_sat_lim_lo"].(float64)
 	}
 
-	if p.cfg.Attribute["limit_lo"] != nil {
+	if p.cfg.Attribute.Has("limit_lo") {
 		p.satLimLo = p.cfg.Attribute["limit_lo"].(float64)
 	}
 
@@ -127,12 +127,12 @@ func (p *basicPID) reset() error {
 		}
 
 		tuneStepPct := 0.35
-		if p.cfg.Attribute["tune_step_pct"] != nil {
+		if p.cfg.Attribute.Has("tune_step_pct") {
 			tuneStepPct = p.cfg.Attribute["tune_step_pct"].(float64)
 		}
 
-		tuneMethod := tuneCalcMethod("")
-		if p.cfg.Attribute["tune_method"] != nil {
+		tuneMethod := tuneMethodZiegerNicholsPID
+		if p.cfg.Attribute.Has("tune_method") {
 			tuneMethod = tuneCalcMethod(p.cfg.Attribute["tune_method"].(string))
 		}
 

--- a/control/pid.go
+++ b/control/pid.go
@@ -29,8 +29,8 @@ type basicPID struct {
 	int      float64
 	sat      int
 	y        []*Signal
-	satLimUp float64
-	limUp    float64
+	satLimUp float64 `default:"255.0"`
+	limUp    float64 `default:"255.0"`
 	satLimLo float64
 	limLo    float64
 	tuner    pidTuner
@@ -101,14 +101,12 @@ func (p *basicPID) reset() error {
 	p.kD = p.cfg.Attribute["kD"].(float64)
 	p.kP = p.cfg.Attribute["kP"].(float64)
 
-	p.satLimUp = 255.0
-	if p.cfg.Attribute.Has("int_sat_lim_up") {
-		p.satLimUp = p.cfg.Attribute["int_sat_lim_up"].(float64)
+	if satLimUp, ok := p.cfg.Attribute["int_sat_lim_up"].(float64); ok {
+		p.satLimUp = satLimUp
 	}
 
-	p.limUp = 255.0
-	if p.cfg.Attribute.Has("limit_up") {
-		p.limUp = p.cfg.Attribute["limit_up"].(float64)
+	if limup, ok := p.cfg.Attribute["limit_up"].(float64); ok {
+		p.limUp = limup
 	}
 
 	if p.cfg.Attribute.Has("int_sat_lim_lo") {
@@ -121,7 +119,7 @@ func (p *basicPID) reset() error {
 
 	p.tuning = false
 	if p.kI == 0.0 && p.kD == 0.0 && p.kP == 0.0 {
-		ssrVal := 2.0
+		var ssrVal float64
 		if p.cfg.Attribute["tune_ssr_value"] != nil {
 			ssrVal = p.cfg.Attribute["tune_ssr_value"].(float64)
 		}
@@ -220,7 +218,7 @@ type pidTuner struct {
 	stepPct      float64
 	limUp        float64
 	limLo        float64
-	ssRValue     float64
+	ssRValue     float64 `default:"2.0"`
 	ccT2         time.Duration
 	ccT3         time.Duration
 	out          float64

--- a/control/pid_test.go
+++ b/control/pid_test.go
@@ -117,7 +117,7 @@ func TestPIDBasicIntegralWindup(t *testing.T) {
 	test.That(t, pid.error, test.ShouldEqual, 0)
 }
 
-func TestPIDTunner(t *testing.T) {
+func TestPIDTuner(t *testing.T) {
 	ctx := context.Background()
 	logger := golog.NewTestLogger(t)
 	cfg := BlockConfig{

--- a/control/sum.go
+++ b/control/sum.go
@@ -59,13 +59,13 @@ func (b *sum) reset() error {
 	if !b.cfg.Attribute.Has("sum_string") {
 		return errors.Errorf("sum block %s doesn't have a sum_string", b.cfg.Name)
 	}
-	if len(b.cfg.DependsOn) != len(b.cfg.Attribute.String("sum_string")) {
+	if len(b.cfg.DependsOn) != len(b.cfg.Attribute["sum_string"].(string)) {
 		return errors.Errorf("invalid number of inputs for sum block %s expected %d got %d",
-			b.cfg.Name, len(b.cfg.Attribute.String("sum_string")),
+			b.cfg.Name, len(b.cfg.Attribute["sum_string"].(string)),
 			len(b.cfg.DependsOn))
 	}
 	b.operation = make(map[string]sumOperand)
-	for idx, c := range b.cfg.Attribute.String("sum_string") {
+	for idx, c := range b.cfg.Attribute["sum_string"].(string) {
 		if c != '+' && c != '-' {
 			return errors.Errorf("expected +/- for sum block %s got %c", b.cfg.Name, c)
 		}

--- a/control/trapezoid_velocity_profile.go
+++ b/control/trapezoid_velocity_profile.go
@@ -105,10 +105,22 @@ func (s *trapezoidVelocityGenerator) reset() error {
 	if !s.cfg.Attribute.Has("max_vel") {
 		return errors.Errorf("trapezoidale velocity profile block %s needs max_vel field", s.cfg.Name)
 	}
-	s.maxAcc = s.cfg.Attribute.Float64("max_acc", 0.0)
-	s.maxVel = s.cfg.Attribute.Float64("max_vel", 0.0)
-	s.posWindow = s.cfg.Attribute.Float64("pos_window", 10.0)
-	s.kppGain = s.cfg.Attribute.Float64("kpp_gain", 0.45)
+	s.maxAcc = s.cfg.Attribute["max_acc"].(float64) // default 0.0
+	s.maxVel = s.cfg.Attribute["max_vel"].(float64) // default 0.0
+
+	s.posWindow = 0
+	if s.cfg.Attribute["pos_window"] != nil {
+		s.posWindow = s.cfg.Attribute["pos_window"].(float64)
+	}
+
+	s.kppGain = 0
+	if s.cfg.Attribute["kpp_gain"] != nil {
+		s.kppGain = s.cfg.Attribute["kpp_gain"].(float64)
+	}
+	if s.kppGain == 0 {
+		s.kppGain = 0.45
+	}
+
 	s.currentPhase = rest
 	s.y = make([]*Signal, 1)
 	s.y[0] = makeSignal(s.cfg.Name)

--- a/control/trapezoid_velocity_profile.go
+++ b/control/trapezoid_velocity_profile.go
@@ -109,12 +109,12 @@ func (s *trapezoidVelocityGenerator) reset() error {
 	s.maxVel = s.cfg.Attribute["max_vel"].(float64) // default 0.0
 
 	s.posWindow = 0
-	if s.cfg.Attribute["pos_window"] != nil {
+	if s.cfg.Attribute.Has("pos_window") {
 		s.posWindow = s.cfg.Attribute["pos_window"].(float64)
 	}
 
 	s.kppGain = 0
-	if s.cfg.Attribute["kpp_gain"] != nil {
+	if s.cfg.Attribute.Has("kpp_gain") {
 		s.kppGain = s.cfg.Attribute["kpp_gain"].(float64)
 	}
 	if s.kppGain == 0 {


### PR DESCRIPTION
This pr changes the attribute map accessors to stop using the possibly deprecated in the future helper functions - another rpr will be made to refactor them into structs. 

Also changes the endpoint's controllable to State and SetSTate and wrap encoded motor's  SetPOwer and Position in those functions to ensure the interface is fulfilled.