### PR TITLE
RSDK-4571: Add a heuristic for detection bounding boxes from ml models

### DIFF
--- a/components/camera/transformpipeline/detector_test.go
+++ b/components/camera/transformpipeline/detector_test.go
@@ -190,7 +190,7 @@ func TestTFLiteDetectionSource(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	ovImg := rimage.ConvertImage(resImg)
 	test.That(t, ovImg.GetXY(624, 402), test.ShouldResemble, rimage.Red)
-	test.That(t, ovImg.GetXY(816, 648), test.ShouldResemble, rimage.Red)
+	test.That(t, ovImg.GetXY(815, 647), test.ShouldResemble, rimage.Red)
 	test.That(t, detector.Close(context.Background()), test.ShouldBeNil)
 }
 

--- a/services/vision/mlvision/detector.go
+++ b/services/vision/mlvision/detector.go
@@ -106,8 +106,9 @@ func attemptToBuildDetector(mlm mlmodel.Service, nameMap *sync.Map) (objectdetec
 		detections := make([]objectdetection.Detection, 0, len(scores))
 		detectionBoxesAreProportional := false
 		for i := 0; i < len(scores); i++ {
-			// heuristic for knowing if bounding boxes are abosolute pixel locations, or
-			// proprotional pixel locations. Absolute bounding boxes will not usually be less than a pixel.
+			// heuristic for knowing if bounding box coodinates are abolute pixel locations, or
+			// proportional pixel locations. Absolute bounding boxes will not usually be less than a pixel
+			// and purely located in the upper left corner.
 			if i == 0 && (locations[0]+locations[1]+locations[2]+locations[3] < 4.) {
 				detectionBoxesAreProportional = true
 			}

--- a/services/vision/mlvision/detector.go
+++ b/services/vision/mlvision/detector.go
@@ -119,10 +119,10 @@ func attemptToBuildDetector(mlm mlmodel.Service, nameMap *sync.Map) (objectdetec
 				xmax = utils.Clamp(locations[4*i+getIndex(boxOrder, 2)], 0, 1) * float64(origW)
 				ymax = utils.Clamp(locations[4*i+getIndex(boxOrder, 3)], 0, 1) * float64(origH)
 			} else {
-				xmin = utils.Clamp(locations[4*i+getIndex(boxOrder, 0)], 0, float64(origW))
-				ymin = utils.Clamp(locations[4*i+getIndex(boxOrder, 1)], 0, float64(origH))
-				xmax = utils.Clamp(locations[4*i+getIndex(boxOrder, 2)], 0, float64(origW))
-				ymax = utils.Clamp(locations[4*i+getIndex(boxOrder, 3)], 0, float64(origH))
+				xmin = utils.Clamp(locations[4*i+getIndex(boxOrder, 0)], 0, float64(origW-1))
+				ymin = utils.Clamp(locations[4*i+getIndex(boxOrder, 1)], 0, float64(origH-1))
+				xmax = utils.Clamp(locations[4*i+getIndex(boxOrder, 2)], 0, float64(origW-1))
+				ymax = utils.Clamp(locations[4*i+getIndex(boxOrder, 3)], 0, float64(origH-1))
 			}
 			rect := image.Rect(int(xmin), int(ymin), int(xmax), int(ymax))
 			labelNum := int(utils.Clamp(categories[i], 0, math.MaxInt))

--- a/services/vision/mlvision/detector.go
+++ b/services/vision/mlvision/detector.go
@@ -106,7 +106,7 @@ func attemptToBuildDetector(mlm mlmodel.Service, nameMap *sync.Map) (objectdetec
 		detections := make([]objectdetection.Detection, 0, len(scores))
 		detectionBoxesAreProportional := false
 		for i := 0; i < len(scores); i++ {
-			// heuristic for knowing if bounding box coodinates are abolute pixel locations, or
+			// heuristic for knowing if bounding box coordinates are abolute pixel locations, or
 			// proportional pixel locations. Absolute bounding boxes will not usually be less than a pixel
 			// and purely located in the upper left corner.
 			if i == 0 && (locations[0]+locations[1]+locations[2]+locations[3] < 4.) {
@@ -114,10 +114,10 @@ func attemptToBuildDetector(mlm mlmodel.Service, nameMap *sync.Map) (objectdetec
 			}
 			var xmin, ymin, xmax, ymax float64
 			if detectionBoxesAreProportional {
-				xmin = utils.Clamp(locations[4*i+getIndex(boxOrder, 0)], 0, 1) * float64(origW)
-				ymin = utils.Clamp(locations[4*i+getIndex(boxOrder, 1)], 0, 1) * float64(origH)
-				xmax = utils.Clamp(locations[4*i+getIndex(boxOrder, 2)], 0, 1) * float64(origW)
-				ymax = utils.Clamp(locations[4*i+getIndex(boxOrder, 3)], 0, 1) * float64(origH)
+				xmin = utils.Clamp(locations[4*i+getIndex(boxOrder, 0)], 0, 1) * float64(origW-1)
+				ymin = utils.Clamp(locations[4*i+getIndex(boxOrder, 1)], 0, 1) * float64(origH-1)
+				xmax = utils.Clamp(locations[4*i+getIndex(boxOrder, 2)], 0, 1) * float64(origW-1)
+				ymax = utils.Clamp(locations[4*i+getIndex(boxOrder, 3)], 0, 1) * float64(origH-1)
 			} else {
 				xmin = utils.Clamp(locations[4*i+getIndex(boxOrder, 0)], 0, float64(origW-1))
 				ymin = utils.Clamp(locations[4*i+getIndex(boxOrder, 1)], 0, float64(origH-1))

--- a/services/vision/mlvision/ml_model_test.go
+++ b/services/vision/mlvision/ml_model_test.go
@@ -172,7 +172,7 @@ func TestNewMLDetector(t *testing.T) {
 	test.That(t, gotDetections[1].Score(), test.ShouldBeGreaterThan, 0.7)
 	test.That(t, gotDetections[0].BoundingBox().Min.X, test.ShouldBeGreaterThan, 124)
 	test.That(t, gotDetections[0].BoundingBox().Min.X, test.ShouldBeLessThan, 127)
-	test.That(t, gotDetections[0].BoundingBox().Min.Y, test.ShouldBeGreaterThan, 41)
+	test.That(t, gotDetections[0].BoundingBox().Min.Y, test.ShouldBeGreaterThan, 40)
 	test.That(t, gotDetections[0].BoundingBox().Min.Y, test.ShouldBeLessThan, 44)
 	test.That(t, gotDetections[0].BoundingBox().Max.X, test.ShouldBeGreaterThan, 196)
 	test.That(t, gotDetections[0].BoundingBox().Max.X, test.ShouldBeLessThan, 202)

--- a/services/vision/mlvision/ml_model_test.go
+++ b/services/vision/mlvision/ml_model_test.go
@@ -196,7 +196,7 @@ func TestNewMLDetector(t *testing.T) {
 	test.That(t, gotDetectionsNL[1].Score(), test.ShouldBeGreaterThan, 0.7)
 	test.That(t, gotDetectionsNL[0].BoundingBox().Min.X, test.ShouldBeGreaterThan, 124)
 	test.That(t, gotDetectionsNL[0].BoundingBox().Min.X, test.ShouldBeLessThan, 127)
-	test.That(t, gotDetectionsNL[0].BoundingBox().Min.Y, test.ShouldBeGreaterThan, 41)
+	test.That(t, gotDetectionsNL[0].BoundingBox().Min.Y, test.ShouldBeGreaterThan, 40)
 	test.That(t, gotDetectionsNL[0].BoundingBox().Min.Y, test.ShouldBeLessThan, 44)
 	test.That(t, gotDetectionsNL[0].BoundingBox().Max.X, test.ShouldBeGreaterThan, 196)
 	test.That(t, gotDetectionsNL[0].BoundingBox().Max.X, test.ShouldBeLessThan, 202)


### PR DESCRIPTION
This is a heuristic fix to take into account different representations of bounding boxes from ML detectors.
- in the proportion representations, the bounding box coordinates are between 0 and 1 and proportion to the distance within the image.
- In the absolute representation, the bounding box coordinates are the actual absolute coordinates within the image.

manually tested on a model with proportional bounding boxes