### PR TITLE
RSDK-3837 - Sessions with remote flaky test fix

### DIFF
--- a/robot/session_test.go
+++ b/robot/session_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"testing"
@@ -427,6 +428,13 @@ func TestSessionsWithRemote(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	motor1, err := motor.FromRobot(roboClient, "rem1:motor1")
+	if err != nil {
+		stack := string(debug.Stack())
+		logger.Errorf(
+			"error accessing remote from roboClient. logging stacktrace for debugging purposes,\n %s",
+			stack,
+		)
+	}
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Log("get position of rem1:motor1 which will not be safety monitored")
@@ -506,6 +514,13 @@ func TestSessionsWithRemote(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	motor2, err := motor.FromRobot(roboClient, "rem1:motor2")
+	if err != nil {
+		stack := string(debug.Stack())
+		logger.Errorf(
+			"error accessing remote from roboClient. logging stacktrace for debugging purposes,\n %s",
+			stack,
+		)
+	}
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Log("set power of rem1:motor2 which will be safety monitored")

--- a/robot/session_test.go
+++ b/robot/session_test.go
@@ -431,7 +431,8 @@ func TestSessionsWithRemote(t *testing.T) {
 	if err != nil {
 		stack := string(debug.Stack())
 		logger.Errorf(
-			"error accessing remote from roboClient. logging stacktrace for debugging purposes,\n %s",
+			"error accessing remote from roboClient: %s. logging stacktrace for debugging purposes,\n %s",
+			err.Error(),
 			stack,
 		)
 	}
@@ -517,7 +518,8 @@ func TestSessionsWithRemote(t *testing.T) {
 	if err != nil {
 		stack := string(debug.Stack())
 		logger.Errorf(
-			"error accessing remote from roboClient. logging stacktrace for debugging purposes,\n %s",
+			"error accessing remote from roboClient: %s. logging stacktrace for debugging purposes,\n %s",
+			err.Error(),
 			stack,
 		)
 	}

--- a/robot/session_test.go
+++ b/robot/session_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
-	"runtime/debug"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -429,12 +429,14 @@ func TestSessionsWithRemote(t *testing.T) {
 
 	motor1, err := motor.FromRobot(roboClient, "rem1:motor1")
 	if err != nil {
-		stack := string(debug.Stack())
-		logger.Errorf(
-			"error accessing remote from roboClient: %s. logging stacktrace for debugging purposes,\n %s",
-			err.Error(),
-			stack,
-		)
+		bufSize := 1 << 20
+		traces := make([]byte, bufSize)
+		traceSize := runtime.Stack(traces, true)
+		message := fmt.Sprintf("error accessing remote from roboClient: %s. logging stack trace for debugging purposes", err.Error())
+		if traceSize == bufSize {
+			message = fmt.Sprintf("%s (warning: backtrace truncated to %v bytes)", message, bufSize)
+		}
+		logger.Errorf("%s,\n %s", message, traces)
 	}
 	test.That(t, err, test.ShouldBeNil)
 
@@ -516,12 +518,14 @@ func TestSessionsWithRemote(t *testing.T) {
 
 	motor2, err := motor.FromRobot(roboClient, "rem1:motor2")
 	if err != nil {
-		stack := string(debug.Stack())
-		logger.Errorf(
-			"error accessing remote from roboClient: %s. logging stacktrace for debugging purposes,\n %s",
-			err.Error(),
-			stack,
-		)
+		bufSize := 1 << 20
+		traces := make([]byte, bufSize)
+		traceSize := runtime.Stack(traces, true)
+		message := fmt.Sprintf("error accessing remote from roboClient: %s. logging stack trace for debugging purposes", err.Error())
+		if traceSize == bufSize {
+			message = fmt.Sprintf("%s (warning: backtrace truncated to %v bytes)", message, bufSize)
+		}
+		logger.Errorf("%s,\n %s", message, traces)
 	}
 	test.That(t, err, test.ShouldBeNil)
 


### PR DESCRIPTION
Was unable to reproduce or make much progress here. As a minimum first step, I'm adding stacktrace logging so that we'll have more information when we next hit the error.

I decided to only log the current thread to avoid overloading debugging efforts with too much extraneous info and this issue doesn't look to me like an async one. This is not a strong preference; happy to log everything if folks feel otherwise.

Note that this screenshot is just to show formatting; I wasn't able to actually reproduce the error so this doesn't actually have anything particularly interesting in it!
![Screen Shot 2023-09-21 at 09 19 45](https://github.com/viamrobotics/rdk/assets/29895141/3627f300-9e30-41d0-8a7e-64f5053c0d13)
