### PR TITLE
[RSDK-5107] Only use software PWM on customlinux boards

### DIFF
--- a/components/board/customlinux/board.go
+++ b/components/board/customlinux/board.go
@@ -88,14 +88,16 @@ func parseRawPinData(pinData []byte, filePath string) ([]genericlinux.PinDefinit
 	}
 
 	var err error
-	for _, pin := range parsedPinData.Pins {
+	for name, pin := range parsedPinData.Pins {
 		err = multierr.Combine(err, pin.Validate(filePath))
 
 		// Until we get hardware PWM working reliably on lots of boards (likely by being able to
 		// set the pin mode directly), we disable all hardware PWM on these boards.
+		// The range operator makes a copy of the value, so to change the original, we need to look
+		// it up in the map again.
 		// TODO(RSDK-5105): Undo this when we're ready to support hardware PWM.
-		pin.PwmChipSysfsDir = ""
-		pin.PwmID = -1
+		parsedPinData.Pins[name].PwmChipSysfsDir = ""
+		parsedPinData.Pins[name].PwmID = -1
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Getting hardware PWM right is turning out harder than hoped. So, to keep pushing forward with the customlinux productionization, Rand suggested that we temporarily only use software PWM, and come back to enable this later. The board definition files should still contain info on which pins have hardware PWM support, we just won't use that right now.

This still needs to be tried out on a couple different boards (ideally some kind of Orange Pi, since those are the ones we've been having the most trouble with recently), on pins both with and without hardware PWM support.