### PR TITLE
[RSDK-5026] Add debugging logs when setting PWM through sysfs

### DIFF
--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/edaniels/golog"
 	"github.com/mkch/gpio"
+	"github.com/pkg/errors"
 	"go.viam.com/utils"
 )
 

--- a/components/board/genericlinux/hw_pwm.go
+++ b/components/board/genericlinux/hw_pwm.go
@@ -121,7 +121,7 @@ func (pwm *pwmDevice) disable() error {
 // Only call this from public functions, to avoid double-wrapping the errors.
 func (pwm *pwmDevice) wrapError(err error) error {
 	// Note that if err is nil, errors.Wrap() will return nil, too.
-	return errors.Wrap(err, fmt.Sprintf("HW PWM chipPath %s, line %d", pwm.chipPath, pwm.line))
+	return errors.Wrapf(err, "HW PWM chipPath %s, line %d", pwm.chipPath, pwm.line)
 }
 
 // SetPwm configures an exported pin and enables its output signal.

--- a/components/board/genericlinux/hw_pwm.go
+++ b/components/board/genericlinux/hw_pwm.go
@@ -40,6 +40,11 @@ func writeValue(filepath string, value uint64, logger golog.Logger) error {
 	// The file permissions (the third argument) aren't important: if the file needs to be created,
 	// something has gone horribly wrong!
 	err := os.WriteFile(filepath, data, 0o600)
+	// Some errors (e.g., trying to unexport an already-unexported pin) should get suppressed. If
+	// we're trying to debug something in here, log the error even if it will later be ignored.
+	if err != nil {
+		logger.Debugf("Encountered error writing to sysfs: %s", err)
+	}
 	return errors.Wrap(err, filepath)
 }
 

--- a/components/board/genericlinux/hw_pwm.go
+++ b/components/board/genericlinux/hw_pwm.go
@@ -34,7 +34,8 @@ func newPwmDevice(chipPath string, line int, logger golog.Logger) *pwmDevice {
 	return &pwmDevice{chipPath: chipPath, line: line, logger: logger}
 }
 
-func writeValue(filepath string, value uint64) error {
+func writeValue(filepath string, value uint64, logger golog.Logger) error {
+	logger.Debugf("Writing %d to %s", value, filepath)
 	data := []byte(fmt.Sprintf("%d", value))
 	// The file permissions (the third argument) aren't important: if the file needs to be created,
 	// something has gone horribly wrong!
@@ -43,7 +44,7 @@ func writeValue(filepath string, value uint64) error {
 }
 
 func (pwm *pwmDevice) writeChip(filename string, value uint64) error {
-	return writeValue(fmt.Sprintf("%s/%s", pwm.chipPath, filename), value)
+	return writeValue(fmt.Sprintf("%s/%s", pwm.chipPath, filename), value, pwm.logger)
 }
 
 func (pwm *pwmDevice) linePath() string {
@@ -51,7 +52,7 @@ func (pwm *pwmDevice) linePath() string {
 }
 
 func (pwm *pwmDevice) writeLine(filename string, value uint64) error {
-	return writeValue(fmt.Sprintf("%s/%s", pwm.linePath(), filename), value)
+	return writeValue(fmt.Sprintf("%s/%s", pwm.linePath(), filename), value, pwm.logger)
 }
 
 // Export tells the OS that this pin is in use, and enables configuration via sysfs.


### PR DESCRIPTION
...and while I was at it, wrap the GPIO-related errors with extra context around which device and which line this was for.

Tried on an Odroid C4: the debugging logs in the PWM stuff work as intended, with output like this when successfully setting a 10 Hz PWM with 50% duty:
```
2023-09-22T19:27:40.955Z	DEBUG	robot_server.rdk:component:board/b	genericlinux/hw_pwm.go:38	Writing 0 to /sys/class/pwm/pwmchip0/export
2023-09-22T19:27:40.957Z	DEBUG	robot_server.rdk:component:board/b	genericlinux/hw_pwm.go:38	Writing 1 to /sys/class/pwm/pwmchip0/pwm0/enable
2023-09-22T19:27:40.958Z	DEBUG	robot_server.rdk:component:board/b	genericlinux/hw_pwm.go:38	Writing 0 to /sys/class/pwm/pwmchip0/pwm0/duty_cycle
2023-09-22T19:27:40.958Z	DEBUG	robot_server.rdk:component:board/b	genericlinux/hw_pwm.go:38	Writing 1000000 to /sys/class/pwm/pwmchip0/pwm0/period
2023-09-22T19:27:40.960Z	DEBUG	robot_server.rdk:component:board/b	genericlinux/hw_pwm.go:38	Writing 100000000 to /sys/class/pwm/pwmchip0/pwm0/period
2023-09-22T19:27:40.960Z	DEBUG	robot_server.rdk:component:board/b	genericlinux/hw_pwm.go:38	Writing 50000000 to /sys/class/pwm/pwmchip0/pwm0/duty_cycle
```
and here are some errors from nonexistent GPIO pins:
```
2023-09-22T19:30:35.619Z   error   robot_server   zap/options.go:212   finished unary call with code Unknown   error rpc error: code = Unknown desc = from GPIO device gpiochip100 line 2: open chip /dev/gpiochip100 failed: no such file or directory   grpc.code Unknown  
2023-09-22T19:30:27.183Z   error   robot_server   zap/options.go:212   finished unary call with code Unknown   error rpc error: code = Unknown desc = from GPIO device gpiochip1 line 900: open GPIO lines [900] on gpiochip1 failed: invalid argument   grpc.code Unknown
```
The first one is for a nonexistent GPIO chip, and the second is for a nonexistent line on a real chip.