### PR TITLE
rename pin configs to board definitions

### DIFF
--- a/components/board/customlinux/board.go
+++ b/components/board/customlinux/board.go
@@ -51,7 +51,7 @@ func pinDefsFromFile(conf resource.Config) (*genericlinux.LinuxBoardConfig, erro
 		return nil, err
 	}
 
-	pinDefs, err := parsePinConfig(newConf.PinConfigFilePath)
+	pinDefs, err := parsePinConfig(newConf.BoardDefsFilePath)
 	if err != nil {
 		return nil, err
 	}

--- a/components/board/customlinux/setup.go
+++ b/components/board/customlinux/setup.go
@@ -11,7 +11,7 @@ import (
 
 // A Config describes the configuration of a board and all of its connected parts.
 type Config struct {
-	PinConfigFilePath string                         `json:"pin_config_file_path"`
+	BoardDefsFilePath string                         `json:"board_defs_file_path"`
 	I2Cs              []board.I2CConfig              `json:"i2cs,omitempty"`
 	SPIs              []board.SPIConfig              `json:"spis,omitempty"`
 	Analogs           []board.AnalogConfig           `json:"analogs,omitempty"`
@@ -20,7 +20,7 @@ type Config struct {
 
 // Validate ensures all parts of the config are valid.
 func (conf *Config) Validate(path string) ([]string, error) {
-	if _, err := os.Stat(conf.PinConfigFilePath); err != nil {
+	if _, err := os.Stat(conf.BoardDefsFilePath); err != nil {
 		return nil, err
 	}
 

--- a/components/board/customlinux/setup_test.go
+++ b/components/board/customlinux/setup_test.go
@@ -48,7 +48,7 @@ func TestConfigValidate(t *testing.T) {
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "no such file or directory")
 
-	validConfig.PinConfigFilePath = "./"
+	validConfig.BoardDefsFilePath = "./"
 	_, err = validConfig.Validate("path")
 	test.That(t, err, test.ShouldBeNil)
 


### PR DESCRIPTION
...as described in the scope doc. The code still compiles, but I haven't yet tried it out further. 

This will require changing our robot config files to use the new key name (`board_defs_file_path`) instead of the old one (`pin_config_file_path`). The reason for the change is that the file contains immutable definitions, rather than mutable configuration options, and although it currently only contains pin stuff it might generalize to board stuff in the future (e.g., maybe we need a section about pinmux registers or something :wink:).