### PR TITLE
[RSDK-3802] remove analogs and interrupts from the customlinux config

### DIFF
--- a/components/board/customlinux/board.go
+++ b/components/board/customlinux/board.go
@@ -107,7 +107,5 @@ func createGenericLinuxConfig(conf *Config) genericlinux.Config {
 	return genericlinux.Config{
 		I2Cs:              conf.I2Cs,
 		SPIs:              conf.SPIs,
-		Analogs:           conf.Analogs,
-		DigitalInterrupts: conf.DigitalInterrupts,
 	}
 }

--- a/components/board/customlinux/board.go
+++ b/components/board/customlinux/board.go
@@ -102,10 +102,3 @@ func parseRawPinData(pinData []byte, filePath string) ([]genericlinux.PinDefinit
 	}
 	return parsedPinData.Pins, nil
 }
-
-func createGenericLinuxConfig(conf *Config) genericlinux.Config {
-	return genericlinux.Config{
-		I2Cs:              conf.I2Cs,
-		SPIs:              conf.SPIs,
-	}
-}

--- a/components/board/customlinux/board.go
+++ b/components/board/customlinux/board.go
@@ -64,8 +64,6 @@ func pinDefsFromFile(conf resource.Config) (*genericlinux.LinuxBoardConfig, erro
 	return &genericlinux.LinuxBoardConfig{
 		I2Cs:              newConf.I2Cs,
 		SPIs:              newConf.SPIs,
-		Analogs:           newConf.Analogs,
-		DigitalInterrupts: newConf.DigitalInterrupts,
 		GpioMappings:      gpioMappings,
 	}, nil
 }

--- a/components/board/customlinux/board.go
+++ b/components/board/customlinux/board.go
@@ -62,9 +62,9 @@ func pinDefsFromFile(conf resource.Config) (*genericlinux.LinuxBoardConfig, erro
 	}
 
 	return &genericlinux.LinuxBoardConfig{
-		I2Cs:              newConf.I2Cs,
-		SPIs:              newConf.SPIs,
-		GpioMappings:      gpioMappings,
+		I2Cs:         newConf.I2Cs,
+		SPIs:         newConf.SPIs,
+		GpioMappings: gpioMappings,
 	}, nil
 }
 

--- a/components/board/customlinux/setup.go
+++ b/components/board/customlinux/setup.go
@@ -24,9 +24,9 @@ func (conf *Config) Validate(path string) ([]string, error) {
 	}
 
 	boardConfig := genericlinux.Config{
-        I2Cs: conf.I2Cs,
-        SPIs: conf.SPIs,
-    }
+		I2Cs: conf.I2Cs,
+		SPIs: conf.SPIs,
+	}
 	if deps, err := boardConfig.Validate(path); err != nil {
 		return deps, err
 	}

--- a/components/board/customlinux/setup.go
+++ b/components/board/customlinux/setup.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/genericlinux"
 )
 
 // A Config describes the configuration of a board and all of its connected parts.
@@ -22,7 +23,10 @@ func (conf *Config) Validate(path string) ([]string, error) {
 		return nil, err
 	}
 
-	boardConfig := createGenericLinuxConfig(conf)
+	boardConfig := genericlinux.Config{
+        I2Cs: conf.I2Cs,
+        SPIs: conf.SPIs,
+    }
 	if deps, err := boardConfig.Validate(path); err != nil {
 		return deps, err
 	}

--- a/components/board/customlinux/setup.go
+++ b/components/board/customlinux/setup.go
@@ -12,9 +12,9 @@ import (
 
 // A Config describes the configuration of a board and all of its connected parts.
 type Config struct {
-	BoardDefsFilePath string                         `json:"board_defs_file_path"`
-	I2Cs              []board.I2CConfig              `json:"i2cs,omitempty"`
-	SPIs              []board.SPIConfig              `json:"spis,omitempty"`
+	BoardDefsFilePath string            `json:"board_defs_file_path"`
+	I2Cs              []board.I2CConfig `json:"i2cs,omitempty"`
+	SPIs              []board.SPIConfig `json:"spis,omitempty"`
 }
 
 // Validate ensures all parts of the config are valid.

--- a/components/board/customlinux/setup.go
+++ b/components/board/customlinux/setup.go
@@ -14,8 +14,6 @@ type Config struct {
 	BoardDefsFilePath string                         `json:"board_defs_file_path"`
 	I2Cs              []board.I2CConfig              `json:"i2cs,omitempty"`
 	SPIs              []board.SPIConfig              `json:"spis,omitempty"`
-	Analogs           []board.AnalogConfig           `json:"analogs,omitempty"`
-	DigitalInterrupts []board.DigitalInterruptConfig `json:"digital_interrupts,omitempty"`
 }
 
 // Validate ensures all parts of the config are valid.

--- a/components/board/customlinux/setup_test.go
+++ b/components/board/customlinux/setup_test.go
@@ -8,7 +8,6 @@ import (
 
 	"go.viam.com/test"
 
-	"go.viam.com/rdk/components/board"
 	"go.viam.com/rdk/components/board/genericlinux"
 )
 

--- a/components/board/customlinux/setup_test.go
+++ b/components/board/customlinux/setup_test.go
@@ -51,16 +51,4 @@ func TestConfigValidate(t *testing.T) {
 	validConfig.BoardDefsFilePath = "./"
 	_, err = validConfig.Validate("path")
 	test.That(t, err, test.ShouldBeNil)
-
-	validConfig.DigitalInterrupts = []board.DigitalInterruptConfig{{}}
-	_, err = validConfig.Validate("path")
-	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, "path.digital_interrupts.0")
-	test.That(t, err.Error(), test.ShouldContainSubstring, `"name" is required`)
-
-	validConfig.DigitalInterrupts = []board.DigitalInterruptConfig{{Name: "20"}}
-	_, err = validConfig.Validate("path")
-	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, "path.digital_interrupts.0")
-	test.That(t, err.Error(), test.ShouldContainSubstring, `"pin" is required`)
 }


### PR DESCRIPTION
...and while I was in here, I noticed that there's a trivial helper function only used in 1 place in a separate file, so I inlined that.

(The linked Jira ticket is about getting ready to document everything, but this PR came because I was trying to write docs and noticed that this never got cleaned up properly.)

The digital interrupts section of the config is used to give human-readable names to a digital interrupt pin. but in the customlinux component, you've already specified your own arbitrary human-readable name for each pin, so there's no reason to have a second one. This was mentioned in the scope doc, and I just didn't clean this part up earlier. Instead of this section, any pin can implicitly be converted into a digital interrupt by just using it as such.

The analogs section of the config might be useful for boards that have built-in ADCs. However, we have never tried supporting one, and currently the genericlinux implementation of this is to assume it's actually an external MCP3xxx chip and not anything built in. This has never sat well with me: I strongly favor having a 1-to-1 mapping between components and pieces of hardware, and I've had enough conversations about this that I think most people strongly agree, too. It's too late to fix this for the pre-existing board components without a breaking change, but we can do it right for the new one, especially now that Hazal has created an [MCP3xxx modular component](https://github.com/viam-labs/mcp300x-adc-sensor) and uploaded it to the registry. It's possible that in the future we'll remove the external-MCP3xxx-centric implementation of analogs from the genericlinux boards and instead add in some built-in analog reader functionality, and this section needs to come back again. but that'll be a completely different implementation, and we shouldn't have it in the meantime.

(The I2Cs and SPIs sections will be removed in https://viam.atlassian.net/browse/RSDK-4806, but we'll get to that later. and at that point, the config will just contain the file path to the board definitions and nothing else!)