### PR TITLE
setup-go caching in CLI build

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -20,10 +20,6 @@ jobs:
   viam-cli:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-go@v4
-      with:
-        go-version: '1.20.x'
-
     - name: Check out code
       if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
       uses: actions/checkout@v3
@@ -32,6 +28,10 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
+
+    - uses: actions/setup-go@v4
+      with:
+        go-version: '1.20.x'
 
     - name: build
       env:


### PR DESCRIPTION
## What changed
- switch order of steps in cli workflow so setup-go happens **after** our codebase is checked out
- setup.go uses go.sum to cache builds when it's present
- this is currently popping warnings in our CI (screenshot), which should go away
## Test run
This hasn't been tested in our CI (PRs use main branch) but I ran on laptop with `act` and got:
```
[Viam CLI/viam-cli]   ✅  Success - Main build
```
## Screenshot
![image](https://github.com/viamrobotics/rdk/assets/7256523/40a88311-0025-42f1-a43c-4c3e2700aaf3)
