### PR TITLE
Rsdk 4886 misc improvements

### DIFF
--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -225,6 +225,76 @@ func createMoveOnMapEnvironment(ctx context.Context, t *testing.T, pcdPath strin
 	return ms
 }
 
+func TestMoveResponseString(t *testing.T) {
+	type testCase struct {
+		description  string
+		expected     string
+		moveResponse moveResponse
+	}
+	testCases := []testCase{
+		{
+			"when success is true and error is nil",
+			"builtin.moveResponse{success: true, err: <nil>}",
+			moveResponse{success: true},
+		},
+		{
+			"when success is true and error is not nil",
+			"builtin.moveResponse{success: true, err: an error}",
+			moveResponse{success: true, err: errors.New("an error")},
+		},
+		{
+			"when success is false and error is nil",
+			"builtin.moveResponse{success: false, err: <nil>}",
+			moveResponse{},
+		},
+		{
+			"when success is false and error is not nil",
+			"builtin.moveResponse{success: false, err: an error}",
+			moveResponse{err: errors.New("an error")},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			test.That(t, tc.moveResponse.String(), test.ShouldEqual, tc.expected)
+		})
+	}
+}
+
+func TestReplanResponseString(t *testing.T) {
+	type testCase struct {
+		description    string
+		expected       string
+		replanResponse replanResponse
+	}
+	testCases := []testCase{
+		{
+			"when replan is true and error is nil",
+			"builtin.replanResponse{replan: true, err: <nil>}",
+			replanResponse{replan: true},
+		},
+		{
+			"when replan is true and error is not nil",
+			"builtin.replanResponse{replan: true, err: an error}",
+			replanResponse{replan: true, err: errors.New("an error")},
+		},
+		{
+			"when replan is false and error is nil",
+			"builtin.replanResponse{replan: false, err: <nil>}",
+			replanResponse{},
+		},
+		{
+			"when replan is false and error is not nil",
+			"builtin.replanResponse{replan: false, err: an error}",
+			replanResponse{err: errors.New("an error")},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			test.That(t, tc.replanResponse.String(), test.ShouldEqual, tc.expected)
+		})
+	}
+}
+
 func TestMoveFailures(t *testing.T) {
 	var err error
 	ms, teardown := setupMotionServiceFromConfig(t, "../data/arm_gantry.json")

--- a/services/motion/builtin/move_attempt.go
+++ b/services/motion/builtin/move_attempt.go
@@ -2,6 +2,7 @@ package builtin
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -15,6 +16,10 @@ import (
 type moveResponse struct {
 	err     error
 	success bool
+}
+
+func (mr moveResponse) String() string {
+	return fmt.Sprintf("builtin.moveResponse{success: %t, err: %v}", mr.success, mr.err)
 }
 
 // moveAttempt is a struct whose lifetime lasts the duration of an attempt to complete a moveRequest

--- a/services/motion/builtin/replanner.go
+++ b/services/motion/builtin/replanner.go
@@ -2,6 +2,7 @@ package builtin
 
 import (
 	"context"
+	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -16,6 +17,10 @@ type replanResponse struct {
 
 // replanFn is an alias for a function that will be polled by a replanner.
 type replanFn func(context.Context, [][]referenceframe.Input, int) (bool, error)
+
+func (rr replanResponse) String() string {
+	return fmt.Sprintf("builtin.replanResponse{replan: %t, err: %v}", rr.replan, rr.err)
+}
 
 // replanner bundles everything needed to execute a function at a given interval and return.
 type replanner struct {

--- a/services/navigation/builtin/builtin_test.go
+++ b/services/navigation/builtin/builtin_test.go
@@ -257,7 +257,7 @@ func TestStartWaypoint(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		cancelCtx, fn := context.WithCancel(ctx)
-		ns.(*builtIn).startWaypoint(cancelCtx, map[string]interface{}{})
+		ns.(*builtIn).startWaypointMode(cancelCtx, map[string]interface{}{})
 		blockTillCallCount(t, 1, callChan, time.Second*5)
 		fn()
 		ns.(*builtIn).activeBackgroundWorkers.Wait()
@@ -267,7 +267,7 @@ func TestStartWaypoint(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		cancelCtx, fn = context.WithCancel(ctx)
-		ns.(*builtIn).startWaypoint(cancelCtx, nil)
+		ns.(*builtIn).startWaypointMode(cancelCtx, nil)
 		blockTillCallCount(t, 1, callChan, time.Second*5)
 		fn()
 		ns.(*builtIn).activeBackgroundWorkers.Wait()
@@ -335,7 +335,7 @@ func TestStartWaypoint(t *testing.T) {
 				test.That(t, err, test.ShouldBeNil)
 			}
 
-			ns.(*builtIn).startWaypoint(ctx, map[string]interface{}{"experimental": true})
+			ns.(*builtIn).startWaypointMode(ctx, map[string]interface{}{"experimental": true})
 
 			// Get the ID of the first waypoint
 			wp1, err := ns.(*builtIn).store.NextWaypoint(ctx)

--- a/services/navigation/builtin/builtin_test.go
+++ b/services/navigation/builtin/builtin_test.go
@@ -3,6 +3,8 @@ package builtin
 import (
 	"context"
 	"errors"
+	"math"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -10,7 +12,7 @@ import (
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
 	"go.viam.com/test"
-	"go.viam.com/utils/testutils"
+	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/base"
 	fakebase "go.viam.com/rdk/components/base/fake"
@@ -24,12 +26,21 @@ import (
 	_ "go.viam.com/rdk/services/motion/builtin"
 	"go.viam.com/rdk/services/navigation"
 	"go.viam.com/rdk/services/slam"
-	fakeslam "go.viam.com/rdk/services/slam/fake"
 	_ "go.viam.com/rdk/services/vision"
 	_ "go.viam.com/rdk/services/vision/colordetector"
 	"go.viam.com/rdk/spatialmath"
 	"go.viam.com/rdk/testutils/inject"
 )
+
+type moveOnGlobeReq struct {
+	componentName      resource.Name
+	destination        *geo.Point
+	heading            float64
+	movementSensorName resource.Name
+	obstacles          []*spatialmath.GeoObstacle
+	motionCfg          *motion.MotionConfiguration
+	extra              map[string]interface{}
+}
 
 func setupNavigationServiceFromConfig(t *testing.T, configFilename string) (navigation.Service, func()) {
 	t.Helper()
@@ -43,7 +54,8 @@ func setupNavigationServiceFromConfig(t *testing.T, configFilename string) (navi
 	svc, err := navigation.FromRobot(myRobot, "test_navigation")
 	test.That(t, err, test.ShouldBeNil)
 	return svc, func() {
-		myRobot.Close(context.Background())
+		err := myRobot.Close(context.Background())
+		test.That(t, err, test.ShouldBeNil)
 	}
 }
 
@@ -173,15 +185,15 @@ func TestStartWaypoint(t *testing.T) {
 
 	ns, err := NewBuiltIn(
 		ctx,
-		resource.Dependencies{injectMS.Name(): injectMS, fakeBase.Name(): fakeBase, injectMovementSensor.Name(): injectMovementSensor},
+		resource.Dependencies{injectMS.Name(): injectMS, fakeBase.Name(): fakeBase, injectMSensor.Name(): injectMSensor},
 		resource.Config{
 			ConvertedAttributes: &Config{
 				Store: navigation.StoreConfig{
 					Type: navigation.StoreTypeMemory,
 				},
-				BaseName:           "test_base",
-				MovementSensorName: "test_movement",
-				MotionServiceName:  "test_motion",
+				BaseName:           fakeBase.Name().Name,
+				MovementSensorName: injectMSensor.Name().Name,
+				MotionServiceName:  injectMS.Name().Name,
 				DegPerSec:          1,
 				MetersPerSec:       1,
 			},
@@ -189,12 +201,162 @@ func TestStartWaypoint(t *testing.T) {
 		logger,
 	)
 	test.That(t, err, test.ShouldBeNil)
-	defer func() {
+	return ns, func() {
 		test.That(t, ns.Close(context.Background()), test.ShouldBeNil)
-	}()
+	}
+}
 
-	t.Run("Reach waypoints successfully", func(t *testing.T) {
-		callChan := make(chan struct{}, 2)
+func blockTillCalledOrTimeout(ctx context.Context, t *testing.T, expectedCall moveOnGlobeReq, callChan chan moveOnGlobeReq) {
+	t.Helper()
+	select {
+	case c := <-callChan:
+		test.That(t, c.componentName, test.ShouldResemble, expectedCall.componentName)
+		test.That(t, c.destination, test.ShouldResemble, expectedCall.destination)
+		test.That(t, c.extra, test.ShouldResemble, expectedCall.extra)
+		// NaN doesn't equal itself so we need this if statement
+		if math.IsNaN(expectedCall.heading) {
+			test.That(t, math.IsNaN(c.heading), test.ShouldBeTrue)
+		} else {
+			test.That(t, c.heading, test.ShouldResemble, expectedCall.heading)
+		}
+		test.That(t, math.IsNaN(c.heading), test.ShouldBeTrue)
+		test.That(t, c.motionCfg, test.ShouldResemble, expectedCall.motionCfg)
+		test.That(t, c.movementSensorName, test.ShouldResemble, expectedCall.movementSensorName)
+		test.That(t, c.obstacles, test.ShouldResemble, expectedCall.obstacles)
+	case <-ctx.Done():
+		t.Error("timed out waiting for test to finish")
+		t.FailNow()
+	}
+}
+
+func fakeBase(ctx context.Context, t *testing.T, logger golog.Logger) base.Base {
+	cfg := resource.Config{
+		Name:  "test_base",
+		API:   base.API,
+		Frame: &referenceframe.LinkConfig{Geometry: &spatialmath.GeometryConfig{R: 100}},
+	}
+
+	fb, err := fakebase.NewBase(ctx, nil, cfg, logger)
+	test.That(t, err, test.ShouldBeNil)
+	return fb
+}
+
+func pollTillWaypointLen(ctx context.Context, t *testing.T, ns navigation.Service, expectedLen int) ([]navigation.Waypoint, error) {
+	t.Helper()
+	timer := time.NewTimer(time.Millisecond * 50)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			t.Error("pollTillWaypointLen timeout reached")
+			return nil, ctx.Err()
+		case <-timer.C:
+			wps, err := ns.Waypoints(ctx, nil)
+			if err != nil {
+				return nil, err
+			}
+
+			if len(wps) == expectedLen {
+				return wps, nil
+			}
+		}
+	}
+}
+
+func wpSimilar(t *testing.T, wp1, wp2 navigation.Waypoint) {
+	t.Helper()
+	test.That(t, wp1.Visited, test.ShouldEqual, wp2.Visited)
+	test.That(t, wp1.LatLongApproxEqual(wp2), test.ShouldBeTrue)
+}
+
+func pointToWP(pt *geo.Point) navigation.Waypoint {
+	return navigation.Waypoint{Lat: pt.Lat(), Long: pt.Lng(), Visited: false}
+}
+
+func TestNavSetup(t *testing.T) {
+	ns, teardown := setupNavigationServiceFromConfig(t, "../data/nav_cfg.json")
+	defer teardown()
+	ctx := context.Background()
+
+	// Mode defaults to manual mode
+	navMode, err := ns.Mode(ctx, nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, navMode, test.ShouldEqual, navigation.ModeManual)
+
+	// Mode is able to be changed to Waypoint mode
+	err = ns.SetMode(ctx, navigation.ModeWaypoint, nil)
+	test.That(t, err, test.ShouldBeNil)
+	navMode, err = ns.Mode(ctx, nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, navMode, test.ShouldEqual, navigation.ModeWaypoint)
+
+	// Set Mode back to default
+	err = ns.SetMode(ctx, navigation.ModeManual, nil)
+	test.That(t, err, test.ShouldBeNil)
+	navMode, err = ns.Mode(ctx, nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, navMode, test.ShouldEqual, navigation.ModeManual)
+
+	// Mocked nav service location is a specific geo coordinate
+	geoPose, err := ns.Location(ctx, nil)
+	test.That(t, err, test.ShouldBeNil)
+	expectedGeoPose := spatialmath.NewGeoPose(geo.NewPoint(40.7, -73.98), 25.)
+	test.That(t, geoPose, test.ShouldResemble, expectedGeoPose)
+
+	// Waypoints default to an empty slice
+	wayPt, err := ns.Waypoints(ctx, nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, wayPt, test.ShouldBeEmpty)
+
+	// Waypoints are able to be added
+	pt := geo.NewPoint(0, 0)
+	err = ns.AddWaypoint(ctx, pt, nil)
+	test.That(t, err, test.ShouldBeNil)
+
+	// Added Waypoints are returned from Waypoints
+	wayPt, err = ns.Waypoints(ctx, nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, len(wayPt), test.ShouldEqual, 1)
+
+	// Added Waypoints can be removed
+	id := wayPt[0].ID
+	err = ns.RemoveWaypoint(ctx, id, nil)
+	test.That(t, err, test.ShouldBeNil)
+
+	// Removed Waypoints are no longer returned from Waypoints
+	wayPt, err = ns.Waypoints(ctx, nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, len(wayPt), test.ShouldEqual, 0)
+
+	// Calling RemoveWaypoint on an already removed waypoint doesn't return an error
+	err = ns.RemoveWaypoint(ctx, id, nil)
+	test.That(t, err, test.ShouldBeNil)
+
+	// The mocked Nav service detects a single obstacle
+	obs, err := ns.GetObstacles(ctx, nil)
+	test.That(t, len(obs), test.ShouldEqual, 1)
+	test.That(t, err, test.ShouldBeNil)
+
+	// The motion config provides a single vision service
+	test.That(t, len(ns.(*builtIn).motionCfg.VisionServices), test.ShouldEqual, 1)
+}
+
+func TestStartWaypoint(t *testing.T) {
+	ctx := context.Background()
+	logger := golog.NewTestLogger(t)
+	b := fakeBase(ctx, t, logger)
+
+	expectedMotionCfg := &motion.MotionConfiguration{
+		LinearMPerSec:     1,
+		AngularDegsPerSec: 1,
+	}
+
+	t.Run("Calls motion.MoveOnGlobe for every waypoint", func(t *testing.T) {
+		callChan := make(chan moveOnGlobeReq)
+		injectMSensor := inject.NewMovementSensor("test_movement")
+
+		injectMS := inject.NewMotionService("test_motion")
 		injectMS.MoveOnGlobeFunc = func(
 			ctx context.Context,
 			componentName resource.Name,
@@ -205,31 +367,97 @@ func TestStartWaypoint(t *testing.T) {
 			motionCfg *motion.MotionConfiguration,
 			extra map[string]interface{},
 		) (bool, error) {
-			err := kinematicBase.GoToInputs(ctx, referenceframe.FloatsToInputs([]float64{destination.Lat(), destination.Lng()}))
-			callChan <- struct{}{}
-			return true, err
+			callChan <- moveOnGlobeReq{
+				componentName:      componentName,
+				destination:        destination,
+				heading:            heading,
+				movementSensorName: movementSensorName,
+				obstacles:          obstacles,
+				motionCfg:          motionCfg,
+				extra:              extra,
+			}
+			return true, nil
 		}
-		pt := geo.NewPoint(1, 0)
-		err = ns.AddWaypoint(ctx, pt, nil)
+		ns, teardown := setupNavService(ctx, t, injectMS, injectMSensor, b, logger)
+		defer teardown()
+
+		// add waypoint 1
+		pt1 := geo.NewPoint(1, 0)
+		err := ns.AddWaypoint(ctx, pt1, nil)
 		test.That(t, err, test.ShouldBeNil)
 
-		pt = geo.NewPoint(3, 1)
-		err = ns.AddWaypoint(ctx, pt, nil)
+		// add waypoint 2
+		pt2 := geo.NewPoint(3, 1)
+		err = ns.AddWaypoint(ctx, pt2, nil)
 		test.That(t, err, test.ShouldBeNil)
 
-		ns.(*builtIn).mode = navigation.ModeManual
+		// test that added waypoints are returned by the waypoints function
+		wps, err := ns.Waypoints(ctx, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(wps), test.ShouldEqual, 2)
+		wpSimilar(t, wps[0], pointToWP(pt1))
+		wpSimilar(t, wps[1], pointToWP(pt2))
+
+		// set mode to Waypoint to begin MoveOnMap calls
 		err = ns.SetMode(ctx, navigation.ModeWaypoint, nil)
 		test.That(t, err, test.ShouldBeNil)
-		blockTillCallCount(t, 2, callChan, time.Second*5)
-		ns.(*builtIn).wholeServiceCancelFunc()
-		ns.(*builtIn).activeBackgroundWorkers.Wait()
 
-		currentInputsShouldEqual(ctx, t, kinematicBase, pt)
+		// confirm mode is now Waypoint
+		mode, err := ns.Mode(ctx, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, mode, test.ShouldEqual, navigation.ModeWaypoint)
+
+		timeoutCtx, cancelFn := context.WithTimeout(context.Background(), time.Second)
+		defer cancelFn()
+
+		// confirm MoveOnGlobe is called for waypoint 1
+		expectedCall1 := moveOnGlobeReq{
+			componentName:      b.Name(),
+			destination:        pt1,
+			heading:            math.NaN(),
+			movementSensorName: injectMSensor.Name(),
+			motionCfg:          expectedMotionCfg,
+			// TODO: fix with RSDK-4583
+			// extra defaults to "motion_profile": "position_only"
+			// extra: map[string]interface{}{"motion_profile": "position_only"},
+		}
+		blockTillCalledOrTimeout(timeoutCtx, t, expectedCall1, callChan)
+
+		// confirm waypoint 1 is eventually removed from the waypoints store after
+		// MoveOnGlobe reports reaching waypoint 1
+		wps1, err := pollTillWaypointLen(timeoutCtx, t, ns, 1)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(wps1), test.ShouldEqual, 1)
+		wpSimilar(t, wps1[0], pointToWP(pt2))
+
+		// confirm MoveOnGlobe is called for waypoint 2
+		expectedCall2 := moveOnGlobeReq{
+			componentName:      b.Name(),
+			destination:        pt2,
+			heading:            math.NaN(),
+			movementSensorName: injectMSensor.Name(),
+			motionCfg:          expectedMotionCfg,
+			// TODO: fix with RSDK-4583
+			// extra defaults to "motion_profile": "position_only"
+			// extra: map[string]interface{}{"motion_profile": "position_only"},
+		}
+		blockTillCalledOrTimeout(timeoutCtx, t, expectedCall2, callChan)
+
+		// confirm waypoint 2 is eventually removed from the waypoints store after
+		// MoveOnGlobe reports reaching waypoint 2
+		// This leaves the waypoint store empty
+		wps2, err := pollTillWaypointLen(timeoutCtx, t, ns, 0)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, wps2, test.ShouldBeEmpty)
 	})
 
-	t.Run("Extra defaults to motion_profile", func(t *testing.T) {
-		callChan := make(chan struct{}, 1)
-		// setup injected MoveOnGlobe to test what extra defaults to from startWaypointExperimental function
+	t.Run("SetMode's extra[motion_profile] defaults to position_mode when extra is non nil & motion_profile is unset", func(t *testing.T) {
+		// TODO: fix with RSDK-4583
+		t.Skip()
+		callChan := make(chan moveOnGlobeReq)
+		injectMSensor := inject.NewMovementSensor("test_movement")
+
+		injectMS := inject.NewMotionService("test_motion")
 		injectMS.MoveOnGlobeFunc = func(
 			ctx context.Context,
 			componentName resource.Name,
@@ -240,41 +468,265 @@ func TestStartWaypoint(t *testing.T) {
 			motionCfg *motion.MotionConfiguration,
 			extra map[string]interface{},
 		) (bool, error) {
-			callChan <- struct{}{}
-			if extra != nil && extra["motion_profile"] != nil {
+			callChan <- moveOnGlobeReq{
+				componentName:      componentName,
+				destination:        destination,
+				heading:            heading,
+				movementSensorName: movementSensorName,
+				obstacles:          obstacles,
+				motionCfg:          motionCfg,
+				extra:              extra,
+			}
+			return true, nil
+		}
+		ns, teardown := setupNavService(ctx, t, injectMS, injectMSensor, b, logger)
+		defer teardown()
+
+		// add waypoint 1
+		pt1 := geo.NewPoint(1, 0)
+		err := ns.AddWaypoint(ctx, pt1, nil)
+		test.That(t, err, test.ShouldBeNil)
+
+		// test that added waypoints are returned by the waypoints function
+		wps, err := ns.Waypoints(ctx, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(wps), test.ShouldEqual, 1)
+		wpSimilar(t, wps[0], pointToWP(pt1))
+
+		// set mode to Waypoint to begin MoveOnMap calls
+		err = ns.SetMode(ctx, navigation.ModeWaypoint, map[string]interface{}{})
+		test.That(t, err, test.ShouldBeNil)
+
+		// confirm mode is now Waypoint
+		mode, err := ns.Mode(ctx, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, mode, test.ShouldEqual, navigation.ModeWaypoint)
+
+		timeoutCtx, cancelFn := context.WithTimeout(context.Background(), time.Second)
+		defer cancelFn()
+
+		// confirm MoveOnGlobe is called for waypoint 1
+		expectedCall1 := moveOnGlobeReq{
+			componentName:      b.Name(),
+			destination:        pt1,
+			heading:            math.NaN(),
+			movementSensorName: injectMSensor.Name(),
+			motionCfg:          expectedMotionCfg,
+			// extra keeps default of "motion_profile": "position_only"
+			extra: map[string]interface{}{"motion_profile": "position_only"},
+		}
+		blockTillCalledOrTimeout(timeoutCtx, t, expectedCall1, callChan)
+	})
+
+	t.Run("SetMode's extra[motion_profile] is able to be overridden to something other than position_mode", func(t *testing.T) {
+		callChan := make(chan moveOnGlobeReq)
+		injectMSensor := inject.NewMovementSensor("test_movement")
+
+		injectMS := inject.NewMotionService("test_motion")
+		injectMS.MoveOnGlobeFunc = func(
+			ctx context.Context,
+			componentName resource.Name,
+			destination *geo.Point,
+			heading float64,
+			movementSensorName resource.Name,
+			obstacles []*spatialmath.GeoObstacle,
+			motionCfg *motion.MotionConfiguration,
+			extra map[string]interface{},
+		) (bool, error) {
+			callChan <- moveOnGlobeReq{
+				componentName:      componentName,
+				destination:        destination,
+				heading:            heading,
+				movementSensorName: movementSensorName,
+				obstacles:          obstacles,
+				motionCfg:          motionCfg,
+				extra:              extra,
+			}
+			return true, nil
+		}
+		ns, teardown := setupNavService(ctx, t, injectMS, injectMSensor, b, logger)
+		defer teardown()
+
+		// add waypoint 1
+		pt1 := geo.NewPoint(1, 0)
+		err := ns.AddWaypoint(ctx, pt1, nil)
+		test.That(t, err, test.ShouldBeNil)
+
+		// set mode to Waypoint to begin MoveOnMap calls
+		err = ns.SetMode(ctx, navigation.ModeWaypoint, map[string]interface{}{"motion_profile": "SOMETHING ELSE"})
+		test.That(t, err, test.ShouldBeNil)
+
+		timeoutCtx, cancelFn := context.WithTimeout(context.Background(), time.Second*5)
+		defer cancelFn()
+
+		// confirm MoveOnGlobe is called for waypoint 1
+		expectedCall1 := moveOnGlobeReq{
+			componentName:      b.Name(),
+			destination:        pt1,
+			heading:            math.NaN(),
+			movementSensorName: injectMSensor.Name(),
+			motionCfg:          expectedMotionCfg,
+			extra:              map[string]interface{}{"motion_profile": "SOMETHING ELSE"},
+		}
+		blockTillCalledOrTimeout(timeoutCtx, t, expectedCall1, callChan)
+	})
+
+	t.Run("MoveOnGlobe error results in retrying the same waypoint until success", func(t *testing.T) {
+		callChan := make(chan moveOnGlobeReq)
+		injectMSensor := inject.NewMovementSensor("test_movement")
+
+		injectMS := inject.NewMotionService("test_motion")
+
+		called := false
+		injectMS.MoveOnGlobeFunc = func(
+			ctx context.Context,
+			componentName resource.Name,
+			destination *geo.Point,
+			heading float64,
+			movementSensorName resource.Name,
+			obstacles []*spatialmath.GeoObstacle,
+			motionCfg *motion.MotionConfiguration,
+			extra map[string]interface{},
+		) (bool, error) {
+			callChan <- moveOnGlobeReq{
+				componentName:      componentName,
+				destination:        destination,
+				heading:            heading,
+				movementSensorName: movementSensorName,
+				obstacles:          obstacles,
+				motionCfg:          motionCfg,
+				extra:              extra,
+			}
+			if called {
 				return true, nil
 			}
-			return false, errors.New("no motion_profile exist")
+			called = true
+			return false, errors.New("move on globe error")
 		}
+		ns, teardown := setupNavService(ctx, t, injectMS, injectMSensor, b, logger)
+		defer teardown()
 
-		// construct new point to navigate to
-		pt := geo.NewPoint(0, 0)
-		err = ns.AddWaypoint(ctx, pt, nil)
+		// add waypoint 1
+		pt1 := geo.NewPoint(1, 0)
+		err := ns.AddWaypoint(ctx, pt1, nil)
 		test.That(t, err, test.ShouldBeNil)
 
-		cancelCtx, fn := context.WithCancel(ctx)
-		ns.(*builtIn).startWaypoint(cancelCtx, map[string]interface{}{})
-		blockTillCallCount(t, 1, callChan, time.Second*5)
-		fn()
-		ns.(*builtIn).activeBackgroundWorkers.Wait()
+		// test that added waypoints are returned by the waypoints function
+		wps, err := ns.Waypoints(ctx, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(wps), test.ShouldEqual, 1)
+		wpSimilar(t, wps[0], pointToWP(pt1))
 
-		// go to same point again
-		err = ns.AddWaypoint(ctx, pt, nil)
+		// set mode to Waypoint to begin MoveOnMap calls
+		err = ns.SetMode(ctx, navigation.ModeWaypoint, nil)
 		test.That(t, err, test.ShouldBeNil)
 
-		cancelCtx, fn = context.WithCancel(ctx)
-		ns.(*builtIn).startWaypoint(cancelCtx, nil)
-		blockTillCallCount(t, 1, callChan, time.Second*5)
-		fn()
-		ns.(*builtIn).activeBackgroundWorkers.Wait()
+		timeoutCtx, cancelFn := context.WithTimeout(context.Background(), time.Second)
+		defer cancelFn()
+
+		// confirm MoveOnGlobe is called for waypoint 1
+		expectedCall1and2 := moveOnGlobeReq{
+			componentName:      b.Name(),
+			destination:        pt1,
+			heading:            math.NaN(),
+			movementSensorName: injectMSensor.Name(),
+			motionCfg:          expectedMotionCfg,
+			// TODO: fix with RSDK-4583
+			// extra defaults to "motion_profile": "position_only"
+			// extra: map[string]interface{}{"motion_profile": "position_only"},
+		}
+		// MoveOnGlobe called twice with same parameters, as nav services
+		// retries first call which returned an error
+		blockTillCalledOrTimeout(timeoutCtx, t, expectedCall1and2, callChan)
+		blockTillCalledOrTimeout(timeoutCtx, t, expectedCall1and2, callChan)
+
+		// confirm waypoint 1 is eventually removed from the waypoints store after
+		// MoveOnGlobe reports reaching waypoint 1
+		wps1, err := pollTillWaypointLen(timeoutCtx, t, ns, 0)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(wps1), test.ShouldEqual, 0)
 	})
 
-	t.Run("Test MoveOnGlobe cancellation and errors", func(t *testing.T) {
-		eventChannel, statusChannel := make(chan string), make(chan string, 1)
-		cancelledContextMsg := "context cancelled"
-		hitAnErrorMsg := "hit an error"
-		arrivedAtWaypointMsg := "arrived at destination"
-		invalidStateMsg := "bad message passed to event channel"
+	t.Run("MoveOnGlobe success false results in retrying the same waypoint until success", func(t *testing.T) {
+		callChan := make(chan moveOnGlobeReq)
+		injectMSensor := inject.NewMovementSensor("test_movement")
+
+		injectMS := inject.NewMotionService("test_motion")
+
+		called := false
+		injectMS.MoveOnGlobeFunc = func(
+			ctx context.Context,
+			componentName resource.Name,
+			destination *geo.Point,
+			heading float64,
+			movementSensorName resource.Name,
+			obstacles []*spatialmath.GeoObstacle,
+			motionCfg *motion.MotionConfiguration,
+			extra map[string]interface{},
+		) (bool, error) {
+			callChan <- moveOnGlobeReq{
+				componentName:      componentName,
+				destination:        destination,
+				heading:            heading,
+				movementSensorName: movementSensorName,
+				obstacles:          obstacles,
+				motionCfg:          motionCfg,
+				extra:              extra,
+			}
+			if called {
+				return true, nil
+			}
+			called = true
+			return false, nil
+		}
+		ns, teardown := setupNavService(ctx, t, injectMS, injectMSensor, b, logger)
+		defer teardown()
+
+		// add waypoint 1
+		pt1 := geo.NewPoint(1, 0)
+		err := ns.AddWaypoint(ctx, pt1, nil)
+		test.That(t, err, test.ShouldBeNil)
+
+		// test that added waypoints are returned by the waypoints function
+		wps, err := ns.Waypoints(ctx, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(wps), test.ShouldEqual, 1)
+		wpSimilar(t, wps[0], pointToWP(pt1))
+
+		// set mode to Waypoint to begin MoveOnMap calls
+		err = ns.SetMode(ctx, navigation.ModeWaypoint, nil)
+		test.That(t, err, test.ShouldBeNil)
+
+		timeoutCtx, cancelFn := context.WithTimeout(context.Background(), time.Second)
+		defer cancelFn()
+
+		// confirm MoveOnGlobe is called for waypoint 1
+		expectedCall1and2 := moveOnGlobeReq{
+			componentName:      b.Name(),
+			destination:        pt1,
+			heading:            math.NaN(),
+			movementSensorName: injectMSensor.Name(),
+			motionCfg:          expectedMotionCfg,
+			// TODO: fix with RSDK-4583
+			// extra defaults to "motion_profile": "position_only"
+			// extra: map[string]interface{}{"motion_profile": "position_only"},
+		}
+		// MoveOnGlobe called twice with same parameters, as nav services
+		// retries first call which returned success false
+		blockTillCalledOrTimeout(timeoutCtx, t, expectedCall1and2, callChan)
+		blockTillCalledOrTimeout(timeoutCtx, t, expectedCall1and2, callChan)
+
+		// confirm waypoint 1 is eventually removed from the waypoints store after
+		// MoveOnGlobe reports reaching waypoint 1
+		wps1, err := pollTillWaypointLen(timeoutCtx, t, ns, 0)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(wps1), test.ShouldEqual, 0)
+	})
+
+	t.Run("Calling RemoveWaypoint on the waypoint in progress cancels current MoveOnGlobe call", func(t *testing.T) {
+		injectMSensor := inject.NewMovementSensor("test_movement")
+
+		injectMS := inject.NewMotionService("test_motion")
 
 		injectMS.MoveOnGlobeFunc = func(
 			ctx context.Context,
@@ -286,201 +738,246 @@ func TestStartWaypoint(t *testing.T) {
 			motionCfg *motion.MotionConfiguration,
 			extra map[string]interface{},
 		) (bool, error) {
-			if ctx.Err() != nil {
-				statusChannel <- cancelledContextMsg
-				return false, ctx.Err()
-			}
-			select {
-			case <-ctx.Done():
-				statusChannel <- cancelledContextMsg
-				return false, ctx.Err()
-			case msg := <-eventChannel:
-				var err error
-				if msg == arrivedAtWaypointMsg {
-					err = kinematicBase.GoToInputs(
-						ctx,
-						referenceframe.FloatsToInputs([]float64{destination.Lat(), destination.Lng()}),
-					)
-				}
+			// always error to prove that the waypoint was removed due to RemoveWaypoint
+			// and not MoveOnGlobe succeeding
+			return false, nil
+		}
+		ns, teardown := setupNavService(ctx, t, injectMS, injectMSensor, b, logger)
+		defer teardown()
 
-				statusChannel <- msg
-				switch {
-				case msg == hitAnErrorMsg:
-					return false, errors.New(hitAnErrorMsg)
-				case msg == arrivedAtWaypointMsg:
-					return true, err
-				default:
-					// should be unreachable
-					return false, errors.New(invalidStateMsg)
-				}
-			}
+		// add waypoint 1
+		pt1 := geo.NewPoint(1, 0)
+		err := ns.AddWaypoint(ctx, pt1, nil)
+		test.That(t, err, test.ShouldBeNil)
+
+		// test that added waypoints are returned by the waypoints function
+		wps, err := ns.Waypoints(ctx, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(wps), test.ShouldEqual, 1)
+		wpSimilar(t, wps[0], pointToWP(pt1))
+
+		// set mode to Waypoint to begin MoveOnMap calls
+		err = ns.SetMode(ctx, navigation.ModeWaypoint, nil)
+		test.That(t, err, test.ShouldBeNil)
+
+		timeoutCtx, cancelFn := context.WithTimeout(context.Background(), time.Second)
+		defer cancelFn()
+
+		// remove the waypoint
+		err = ns.RemoveWaypoint(ctx, wps[0].ID, nil)
+		test.That(t, err, test.ShouldBeNil)
+
+		// confirm waypoint 1 is eventually removed from the waypoints store
+		wps1, err := pollTillWaypointLen(timeoutCtx, t, ns, 0)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(wps1), test.ShouldEqual, 0)
+	})
+
+	t.Run("Calling SetMode Manual pauses MoveOnGlobe calls, setting it back to waypoint resumes", func(t *testing.T) {
+		injectMSensor := inject.NewMovementSensor("test_movement")
+
+		injectMS := inject.NewMotionService("test_motion")
+
+		injectMS.MoveOnGlobeFunc = func(
+			ctx context.Context,
+			componentName resource.Name,
+			destination *geo.Point,
+			heading float64,
+			movementSensorName resource.Name,
+			obstacles []*spatialmath.GeoObstacle,
+			motionCfg *motion.MotionConfiguration,
+			extra map[string]interface{},
+		) (bool, error) {
+			return false, nil
 		}
 
-		pt1, pt2, pt3 := geo.NewPoint(1, 2), geo.NewPoint(2, 3), geo.NewPoint(3, 4)
-		points := []*geo.Point{pt1, pt2, pt3}
-		t.Run("MoveOnGlobe error results in skipping the current waypoint", func(t *testing.T) {
-			// Set manual mode to ensure waypoint loop from prior test exits
-			err = ns.SetMode(ctx, navigation.ModeManual, map[string]interface{}{"experimental": true})
-			test.That(t, err, test.ShouldBeNil)
-			ctx, cancelFunc := context.WithCancel(ctx)
-			defer ns.(*builtIn).activeBackgroundWorkers.Wait()
-			defer cancelFunc()
-			err = deleteAllWaypoints(ctx, ns)
-			for _, pt := range points {
-				err = ns.AddWaypoint(ctx, pt, nil)
-				test.That(t, err, test.ShouldBeNil)
+		ns, teardown := setupNavService(ctx, t, injectMS, injectMSensor, b, logger)
+		defer teardown()
+
+		// add waypoint 1
+		pt1 := geo.NewPoint(1, 0)
+		err := ns.AddWaypoint(ctx, pt1, nil)
+		test.That(t, err, test.ShouldBeNil)
+
+		// test that added waypoints are returned by the waypoints function
+		wps1, err := ns.Waypoints(ctx, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(wps1), test.ShouldEqual, 1)
+		wpSimilar(t, wps1[0], pointToWP(pt1))
+
+		// set mode to Waypoint to begin MoveOnMap calls
+		err = ns.SetMode(ctx, navigation.ModeWaypoint, nil)
+		test.That(t, err, test.ShouldBeNil)
+
+		timeoutCtx, cancelFn := context.WithTimeout(context.Background(), time.Second)
+		defer cancelFn()
+
+		// change mode to stop MoveOnMap calls
+		err = ns.SetMode(ctx, navigation.ModeManual, nil)
+		test.That(t, err, test.ShouldBeNil)
+
+		// confirm first waypoint is still there as MoveOnGlobe
+		// hasn't returned success yet
+		wps2, err := ns.Waypoints(ctx, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, wps2, test.ShouldResemble, wps1)
+
+		callChan := make(chan moveOnGlobeReq)
+		injectMS.MoveOnGlobeFunc = func(
+			ctx context.Context,
+			componentName resource.Name,
+			destination *geo.Point,
+			heading float64,
+			movementSensorName resource.Name,
+			obstacles []*spatialmath.GeoObstacle,
+			motionCfg *motion.MotionConfiguration,
+			extra map[string]interface{},
+		) (bool, error) {
+			callChan <- moveOnGlobeReq{
+				componentName:      componentName,
+				destination:        destination,
+				heading:            heading,
+				movementSensorName: movementSensorName,
+				obstacles:          obstacles,
+				motionCfg:          motionCfg,
+				extra:              extra,
+			}
+			return true, nil
+		}
+
+		// change mode to restart MoveOnMap calls
+		err = ns.SetMode(ctx, navigation.ModeWaypoint, nil)
+		test.That(t, err, test.ShouldBeNil)
+
+		// confirm MoveOnGlobe is called for waypoint 1
+		expectedCall := moveOnGlobeReq{
+			componentName:      b.Name(),
+			destination:        pt1,
+			heading:            math.NaN(),
+			movementSensorName: injectMSensor.Name(),
+			motionCfg: &motion.MotionConfiguration{
+				LinearMPerSec:     1,
+				AngularDegsPerSec: 1,
+			},
+			// TODO: fix with RSDK-4583
+			// extra defaults to "motion_profile": "position_only"
+			// extra: map[string]interface{}{"motion_profile": "position_only"},
+		}
+		// confirm that MoveOnGlobe is called with waypoint 1 after
+		// switching from WaypointMode -> ManualMode -> WaypointMode
+		blockTillCalledOrTimeout(timeoutCtx, t, expectedCall, callChan)
+
+		// confirm waypoint 1 is eventually removed from the waypoints store after
+		// MoveOnGlobe reports reaching waypoint 1
+		wps3, err := pollTillWaypointLen(timeoutCtx, t, ns, 0)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(wps3), test.ShouldEqual, 0)
+	})
+
+	t.Run("Calling RemoveWaypoint on a waypoint that is not in progress does not cancel MoveOnGlobe", func(t *testing.T) {
+		injectMSensor := inject.NewMovementSensor("test_movement")
+
+		injectMS := inject.NewMotionService("test_motion")
+		var successAtomic atomic.Bool
+
+		callChan := make(chan moveOnGlobeReq)
+		successChan := make(chan struct{})
+		injectMS.MoveOnGlobeFunc = func(
+			ctx context.Context,
+			componentName resource.Name,
+			destination *geo.Point,
+			heading float64,
+			movementSensorName resource.Name,
+			obstacles []*spatialmath.GeoObstacle,
+			motionCfg *motion.MotionConfiguration,
+			extra map[string]interface{},
+		) (bool, error) {
+			callChan <- moveOnGlobeReq{
+				componentName:      componentName,
+				destination:        destination,
+				heading:            heading,
+				movementSensorName: movementSensorName,
+				obstacles:          obstacles,
+				motionCfg:          motionCfg,
+				extra:              extra,
+			}
+			success := successAtomic.Load()
+			if success {
+				successChan <- struct{}{}
 			}
 
-			ns.(*builtIn).startWaypoint(ctx, map[string]interface{}{"experimental": true})
+			return success, nil
+		}
 
-			// Get the ID of the first waypoint
-			wp1, err := ns.(*builtIn).store.NextWaypoint(ctx)
-			test.That(t, err, test.ShouldBeNil)
+		ns, teardown := setupNavService(ctx, t, injectMS, injectMSensor, b, logger)
+		defer teardown()
 
-			// Reach the first waypoint
-			eventChannel <- arrivedAtWaypointMsg
-			test.That(t, <-statusChannel, test.ShouldEqual, arrivedAtWaypointMsg)
-			currentInputsShouldEqual(ctx, t, kinematicBase, pt1)
+		// add waypoint 1
+		pt1 := geo.NewPoint(1, 0)
+		err := ns.AddWaypoint(ctx, pt1, nil)
+		test.That(t, err, test.ShouldBeNil)
 
-			// Ensure we aren't querying before the nav service has a chance to mark the previous waypoint visited.
-			wp2, err := ns.(*builtIn).store.NextWaypoint(ctx)
-			test.That(t, err, test.ShouldBeNil)
-			for wp2.ID == wp1.ID {
-				wp2, err = ns.(*builtIn).store.NextWaypoint(ctx)
-				test.That(t, err, test.ShouldBeNil)
-			}
+		// add waypoint 2
+		pt2 := geo.NewPoint(3, 1)
+		err = ns.AddWaypoint(ctx, pt2, nil)
+		test.That(t, err, test.ShouldBeNil)
 
-			// Skip the second waypoint due to an error
-			eventChannel <- hitAnErrorMsg
-			test.That(t, <-statusChannel, test.ShouldEqual, hitAnErrorMsg)
-			currentInputsShouldEqual(ctx, t, kinematicBase, pt1)
+		// test that added waypoints are returned by the waypoints function
+		wps1, err := ns.Waypoints(ctx, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(wps1), test.ShouldEqual, 2)
+		wpSimilar(t, wps1[0], pointToWP(pt1))
+		wpSimilar(t, wps1[1], pointToWP(pt2))
 
-			// Ensure we aren't querying before the nav service has a chance to mark the previous waypoint visited.
-			wp3, err := ns.(*builtIn).store.NextWaypoint(ctx)
-			test.That(t, err, test.ShouldBeNil)
-			for wp3.ID == wp2.ID {
-				wp3, err = ns.(*builtIn).store.NextWaypoint(ctx)
-				test.That(t, err, test.ShouldBeNil)
-			}
+		// set mode to Waypoint to begin MoveOnMap calls
+		err = ns.SetMode(ctx, navigation.ModeWaypoint, nil)
+		test.That(t, err, test.ShouldBeNil)
 
-			// Reach the third waypoint
-			eventChannel <- arrivedAtWaypointMsg
-			test.That(t, <-statusChannel, test.ShouldEqual, arrivedAtWaypointMsg)
-			currentInputsShouldEqual(ctx, t, kinematicBase, pt3)
-		})
-		t.Run("Calling SetMode cancels current and future MoveOnGlobe calls", func(t *testing.T) {
-			// Set manual mode to ensure waypoint loop from prior test exits
-			err = deleteAllWaypoints(ctx, ns)
-			test.That(t, err, test.ShouldBeNil)
-			for _, pt := range points {
-				err = ns.AddWaypoint(ctx, pt, nil)
-				test.That(t, err, test.ShouldBeNil)
-			}
+		timeoutCtx, cancelFn := context.WithTimeout(context.Background(), time.Second)
+		defer cancelFn()
 
-			// start navigation - set ModeManual first to ensure navigation starts up
-			err = ns.SetMode(ctx, navigation.ModeWaypoint, map[string]interface{}{"experimental": true})
+		// confirm MoveOnGlobe is called for waypoint 1
+		expectedCall := moveOnGlobeReq{
+			componentName:      b.Name(),
+			destination:        pt1,
+			heading:            math.NaN(),
+			movementSensorName: injectMSensor.Name(),
+			motionCfg: &motion.MotionConfiguration{
+				LinearMPerSec:     1,
+				AngularDegsPerSec: 1,
+			},
+			// TODO: fix with RSDK-4583
+			// extra defaults to "motion_profile": "position_only"
+			// extra: map[string]interface{}{"motion_profile": "position_only"},
+		}
 
-			// Reach the first waypoint
-			eventChannel <- arrivedAtWaypointMsg
-			test.That(t, <-statusChannel, test.ShouldEqual, arrivedAtWaypointMsg)
-			currentInputsShouldEqual(ctx, t, kinematicBase, pt1)
+		// delete last waypoint waypoint
+		err = ns.RemoveWaypoint(ctx, wps1[1].ID, nil)
+		test.That(t, err, test.ShouldBeNil)
 
-			// Change the mode to manual --> stops navigation to waypoints
-			err = ns.SetMode(ctx, navigation.ModeManual, map[string]interface{}{"experimental": true})
-			test.That(t, err, test.ShouldBeNil)
-			select {
-			case msg := <-statusChannel:
-				test.That(t, msg, test.ShouldEqual, cancelledContextMsg)
-			case <-time.After(5 * time.Second):
-				ns.(*builtIn).activeBackgroundWorkers.Wait()
-			}
-			currentInputsShouldEqual(ctx, t, kinematicBase, pt1)
-		})
+		// confirm last waypoint was removed
+		wps2, err := ns.Waypoints(ctx, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(wps2), test.ShouldEqual, 1)
+		wpSimilar(t, wps2[0], pointToWP(pt1))
 
-		t.Run("Calling RemoveWaypoint on the waypoint in progress cancels current MoveOnGlobe call", func(t *testing.T) {
-			// Set manual mode to ensure waypoint loop from prior test exits
-			err = ns.SetMode(ctx, navigation.ModeManual, map[string]interface{}{"experimental": true})
-			test.That(t, err, test.ShouldBeNil)
-			err = deleteAllWaypoints(ctx, ns)
-			for _, pt := range points {
-				err = ns.AddWaypoint(ctx, pt, nil)
-				test.That(t, err, test.ShouldBeNil)
-			}
+		// unblock the MoveOnGlobe request after removing waypoint 2
+		blockTillCalledOrTimeout(timeoutCtx, t, expectedCall, callChan)
 
-			// start navigation - set ModeManual first to ensure navigation starts up
-			err = ns.SetMode(ctx, navigation.ModeWaypoint, map[string]interface{}{"experimental": true})
+		// set success to true after waypoint 2 has been removed
+		successAtomic.Store(true)
 
-			// Get the ID of the first waypoint
-			wp1, err := ns.(*builtIn).store.NextWaypoint(ctx)
-			test.That(t, err, test.ShouldBeNil)
+		// confirm that MoveOnGlobe is called with waypoint 1 after removing waypoint 2 waypoint
+		blockTillCalledOrTimeout(timeoutCtx, t, expectedCall, callChan)
 
-			// Reach the first waypoint
-			eventChannel <- arrivedAtWaypointMsg
-			test.That(t, <-statusChannel, test.ShouldEqual, arrivedAtWaypointMsg)
-			currentInputsShouldEqual(ctx, t, kinematicBase, pt1)
+		// confirm success has occurred within the timeout
+		test.That(t, utils.SelectContextOrWaitChan(timeoutCtx, successChan), test.ShouldBeTrue)
 
-			// Remove the second waypoint, which is in progress. Ensure we aren't querying before the nav service has a chance to mark
-			// the previous waypoint visited.
-			wp2, err := ns.(*builtIn).store.NextWaypoint(ctx)
-			test.That(t, err, test.ShouldBeNil)
-			for wp2.ID == wp1.ID {
-				wp2, err = ns.(*builtIn).store.NextWaypoint(ctx)
-				test.That(t, err, test.ShouldBeNil)
-			}
-
-			// ensure we actually start the wp2 waypoint before removing it
-			testutils.WaitForAssertion(t, func(tb testing.TB) {
-				tb.Helper()
-				ns.(*builtIn).mu.RLock()
-				svcWp := ns.(*builtIn).waypointInProgress
-				ns.(*builtIn).mu.RUnlock()
-				test.That(tb, wp2.ID, test.ShouldEqual, svcWp.ID)
-			})
-
-			err = ns.RemoveWaypoint(ctx, wp2.ID, nil)
-			test.That(t, err, test.ShouldBeNil)
-			test.That(t, <-statusChannel, test.ShouldEqual, cancelledContextMsg)
-			currentInputsShouldEqual(ctx, t, kinematicBase, pt1)
-
-			// Reach the third waypoint
-			eventChannel <- arrivedAtWaypointMsg
-			test.That(t, <-statusChannel, test.ShouldEqual, arrivedAtWaypointMsg)
-			currentInputsShouldEqual(ctx, t, kinematicBase, pt3)
-		})
-
-		t.Run("Calling RemoveWaypoint on a waypoint that is not in progress does not cancel MoveOnGlobe", func(t *testing.T) {
-			// Set manual mode to ensure waypoint loop from prior test exits
-			err = ns.SetMode(ctx, navigation.ModeManual, map[string]interface{}{"experimental": true})
-			test.That(t, err, test.ShouldBeNil)
-			err = deleteAllWaypoints(ctx, ns)
-			var wp3 navigation.Waypoint
-			for i, pt := range points {
-				if i < 3 {
-					err = ns.AddWaypoint(ctx, pt, nil)
-					test.That(t, err, test.ShouldBeNil)
-				} else {
-					wp3, err = ns.(*builtIn).store.AddWaypoint(ctx, pt)
-					test.That(t, err, test.ShouldBeNil)
-				}
-			}
-
-			// start navigation - set ModeManual first to ensure navigation starts up
-			err = ns.SetMode(ctx, navigation.ModeWaypoint, map[string]interface{}{"experimental": true})
-
-			// Reach the first waypoint
-			eventChannel <- arrivedAtWaypointMsg
-			test.That(t, <-statusChannel, test.ShouldEqual, arrivedAtWaypointMsg)
-			currentInputsShouldEqual(ctx, t, kinematicBase, pt1)
-
-			// Remove the third waypoint, which is not in progress yet
-			err = ns.RemoveWaypoint(ctx, wp3.ID, nil)
-			test.That(t, err, test.ShouldBeNil)
-
-			// Reach the second waypoint
-			eventChannel <- arrivedAtWaypointMsg
-			test.That(t, <-statusChannel, test.ShouldEqual, arrivedAtWaypointMsg)
-			currentInputsShouldEqual(ctx, t, kinematicBase, pt2)
-		})
+		// confirm waypoint 1 is eventually removed from the waypoints store after
+		// MoveOnGlobe reports reaching waypoint 1
+		wps3, err := pollTillWaypointLen(timeoutCtx, t, ns, 0)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(wps3), test.ShouldEqual, 0)
 	})
 }
 
@@ -492,7 +989,7 @@ func TestValidateGeometry(t *testing.T) {
 
 	createBox := func(translation r3.Vector) Config {
 		boxPose := spatialmath.NewPoseFromPoint(translation)
-		geometries, err := spatialmath.NewBox(boxPose, r3.Vector{10, 10, 10}, "")
+		geometries, err := spatialmath.NewBox(boxPose, r3.Vector{X: 10, Y: 10, Z: 10}, "")
 		test.That(t, err, test.ShouldBeNil)
 
 		geoObstacle := spatialmath.NewGeoObstacle(geo.NewPoint(0, 0), []spatialmath.Geometry{geometries})
@@ -505,7 +1002,7 @@ func TestValidateGeometry(t *testing.T) {
 	}
 
 	t.Run("fail case", func(t *testing.T) {
-		cfg = createBox(r3.Vector{10, 10, 10})
+		cfg = createBox(r3.Vector{X: 10, Y: 10, Z: 10})
 		_, err := cfg.Validate("")
 		expectedErr := "geometries specified through the navigation are not allowed to have a translation"
 		test.That(t, err, test.ShouldNotBeNil)

--- a/services/navigation/builtin/builtin_test.go
+++ b/services/navigation/builtin/builtin_test.go
@@ -3,8 +3,6 @@ package builtin
 import (
 	"context"
 	"errors"
-	"math"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -12,7 +10,7 @@ import (
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
 	"go.viam.com/test"
-	"go.viam.com/utils"
+	"go.viam.com/utils/testutils"
 
 	"go.viam.com/rdk/components/base"
 	fakebase "go.viam.com/rdk/components/base/fake"
@@ -26,21 +24,12 @@ import (
 	_ "go.viam.com/rdk/services/motion/builtin"
 	"go.viam.com/rdk/services/navigation"
 	"go.viam.com/rdk/services/slam"
+	fakeslam "go.viam.com/rdk/services/slam/fake"
 	_ "go.viam.com/rdk/services/vision"
 	_ "go.viam.com/rdk/services/vision/colordetector"
 	"go.viam.com/rdk/spatialmath"
 	"go.viam.com/rdk/testutils/inject"
 )
-
-type moveOnGlobeReq struct {
-	componentName      resource.Name
-	destination        *geo.Point
-	heading            float64
-	movementSensorName resource.Name
-	obstacles          []*spatialmath.GeoObstacle
-	motionCfg          *motion.MotionConfiguration
-	extra              map[string]interface{}
-}
 
 func setupNavigationServiceFromConfig(t *testing.T, configFilename string) (navigation.Service, func()) {
 	t.Helper()
@@ -54,8 +43,7 @@ func setupNavigationServiceFromConfig(t *testing.T, configFilename string) (navi
 	svc, err := navigation.FromRobot(myRobot, "test_navigation")
 	test.That(t, err, test.ShouldBeNil)
 	return svc, func() {
-		err := myRobot.Close(context.Background())
-		test.That(t, err, test.ShouldBeNil)
+		myRobot.Close(context.Background())
 	}
 }
 
@@ -138,6 +126,10 @@ func TestNavSetup(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, len(wayPt), test.ShouldEqual, 0)
 
+	// Calling RemoveWaypoint on an already removed waypoint doesn't return an error
+	err = ns.RemoveWaypoint(ctx, id, nil)
+	test.That(t, err, test.ShouldBeNil)
+
 	obs, err := ns.GetObstacles(ctx, nil)
 	test.That(t, len(obs), test.ShouldEqual, 1)
 	test.That(t, err, test.ShouldBeNil)
@@ -185,15 +177,15 @@ func TestStartWaypoint(t *testing.T) {
 
 	ns, err := NewBuiltIn(
 		ctx,
-		resource.Dependencies{injectMS.Name(): injectMS, fakeBase.Name(): fakeBase, injectMSensor.Name(): injectMSensor},
+		resource.Dependencies{injectMS.Name(): injectMS, fakeBase.Name(): fakeBase, injectMovementSensor.Name(): injectMovementSensor},
 		resource.Config{
 			ConvertedAttributes: &Config{
 				Store: navigation.StoreConfig{
 					Type: navigation.StoreTypeMemory,
 				},
-				BaseName:           fakeBase.Name().Name,
-				MovementSensorName: injectMSensor.Name().Name,
-				MotionServiceName:  injectMS.Name().Name,
+				BaseName:           "test_base",
+				MovementSensorName: "test_movement",
+				MotionServiceName:  "test_motion",
 				DegPerSec:          1,
 				MetersPerSec:       1,
 			},
@@ -201,162 +193,12 @@ func TestStartWaypoint(t *testing.T) {
 		logger,
 	)
 	test.That(t, err, test.ShouldBeNil)
-	return ns, func() {
+	defer func() {
 		test.That(t, ns.Close(context.Background()), test.ShouldBeNil)
-	}
-}
+	}()
 
-func blockTillCalledOrTimeout(ctx context.Context, t *testing.T, expectedCall moveOnGlobeReq, callChan chan moveOnGlobeReq) {
-	t.Helper()
-	select {
-	case c := <-callChan:
-		test.That(t, c.componentName, test.ShouldResemble, expectedCall.componentName)
-		test.That(t, c.destination, test.ShouldResemble, expectedCall.destination)
-		test.That(t, c.extra, test.ShouldResemble, expectedCall.extra)
-		// NaN doesn't equal itself so we need this if statement
-		if math.IsNaN(expectedCall.heading) {
-			test.That(t, math.IsNaN(c.heading), test.ShouldBeTrue)
-		} else {
-			test.That(t, c.heading, test.ShouldResemble, expectedCall.heading)
-		}
-		test.That(t, math.IsNaN(c.heading), test.ShouldBeTrue)
-		test.That(t, c.motionCfg, test.ShouldResemble, expectedCall.motionCfg)
-		test.That(t, c.movementSensorName, test.ShouldResemble, expectedCall.movementSensorName)
-		test.That(t, c.obstacles, test.ShouldResemble, expectedCall.obstacles)
-	case <-ctx.Done():
-		t.Error("timed out waiting for test to finish")
-		t.FailNow()
-	}
-}
-
-func fakeBase(ctx context.Context, t *testing.T, logger golog.Logger) base.Base {
-	cfg := resource.Config{
-		Name:  "test_base",
-		API:   base.API,
-		Frame: &referenceframe.LinkConfig{Geometry: &spatialmath.GeometryConfig{R: 100}},
-	}
-
-	fb, err := fakebase.NewBase(ctx, nil, cfg, logger)
-	test.That(t, err, test.ShouldBeNil)
-	return fb
-}
-
-func pollTillWaypointLen(ctx context.Context, t *testing.T, ns navigation.Service, expectedLen int) ([]navigation.Waypoint, error) {
-	t.Helper()
-	timer := time.NewTimer(time.Millisecond * 50)
-	defer timer.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			t.Error("pollTillWaypointLen timeout reached")
-			return nil, ctx.Err()
-		case <-timer.C:
-			wps, err := ns.Waypoints(ctx, nil)
-			if err != nil {
-				return nil, err
-			}
-
-			if len(wps) == expectedLen {
-				return wps, nil
-			}
-		}
-	}
-}
-
-func wpSimilar(t *testing.T, wp1, wp2 navigation.Waypoint) {
-	t.Helper()
-	test.That(t, wp1.Visited, test.ShouldEqual, wp2.Visited)
-	test.That(t, wp1.LatLongApproxEqual(wp2), test.ShouldBeTrue)
-}
-
-func pointToWP(pt *geo.Point) navigation.Waypoint {
-	return navigation.Waypoint{Lat: pt.Lat(), Long: pt.Lng(), Visited: false}
-}
-
-func TestNavSetup(t *testing.T) {
-	ns, teardown := setupNavigationServiceFromConfig(t, "../data/nav_cfg.json")
-	defer teardown()
-	ctx := context.Background()
-
-	// Mode defaults to manual mode
-	navMode, err := ns.Mode(ctx, nil)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, navMode, test.ShouldEqual, navigation.ModeManual)
-
-	// Mode is able to be changed to Waypoint mode
-	err = ns.SetMode(ctx, navigation.ModeWaypoint, nil)
-	test.That(t, err, test.ShouldBeNil)
-	navMode, err = ns.Mode(ctx, nil)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, navMode, test.ShouldEqual, navigation.ModeWaypoint)
-
-	// Set Mode back to default
-	err = ns.SetMode(ctx, navigation.ModeManual, nil)
-	test.That(t, err, test.ShouldBeNil)
-	navMode, err = ns.Mode(ctx, nil)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, navMode, test.ShouldEqual, navigation.ModeManual)
-
-	// Mocked nav service location is a specific geo coordinate
-	geoPose, err := ns.Location(ctx, nil)
-	test.That(t, err, test.ShouldBeNil)
-	expectedGeoPose := spatialmath.NewGeoPose(geo.NewPoint(40.7, -73.98), 25.)
-	test.That(t, geoPose, test.ShouldResemble, expectedGeoPose)
-
-	// Waypoints default to an empty slice
-	wayPt, err := ns.Waypoints(ctx, nil)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, wayPt, test.ShouldBeEmpty)
-
-	// Waypoints are able to be added
-	pt := geo.NewPoint(0, 0)
-	err = ns.AddWaypoint(ctx, pt, nil)
-	test.That(t, err, test.ShouldBeNil)
-
-	// Added Waypoints are returned from Waypoints
-	wayPt, err = ns.Waypoints(ctx, nil)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, len(wayPt), test.ShouldEqual, 1)
-
-	// Added Waypoints can be removed
-	id := wayPt[0].ID
-	err = ns.RemoveWaypoint(ctx, id, nil)
-	test.That(t, err, test.ShouldBeNil)
-
-	// Removed Waypoints are no longer returned from Waypoints
-	wayPt, err = ns.Waypoints(ctx, nil)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, len(wayPt), test.ShouldEqual, 0)
-
-	// Calling RemoveWaypoint on an already removed waypoint doesn't return an error
-	err = ns.RemoveWaypoint(ctx, id, nil)
-	test.That(t, err, test.ShouldBeNil)
-
-	// The mocked Nav service detects a single obstacle
-	obs, err := ns.GetObstacles(ctx, nil)
-	test.That(t, len(obs), test.ShouldEqual, 1)
-	test.That(t, err, test.ShouldBeNil)
-
-	// The motion config provides a single vision service
-	test.That(t, len(ns.(*builtIn).motionCfg.VisionServices), test.ShouldEqual, 1)
-}
-
-func TestStartWaypoint(t *testing.T) {
-	ctx := context.Background()
-	logger := golog.NewTestLogger(t)
-	b := fakeBase(ctx, t, logger)
-
-	expectedMotionCfg := &motion.MotionConfiguration{
-		LinearMPerSec:     1,
-		AngularDegsPerSec: 1,
-	}
-
-	t.Run("Calls motion.MoveOnGlobe for every waypoint", func(t *testing.T) {
-		callChan := make(chan moveOnGlobeReq)
-		injectMSensor := inject.NewMovementSensor("test_movement")
-
-		injectMS := inject.NewMotionService("test_motion")
+	t.Run("Reach waypoints successfully", func(t *testing.T) {
+		callChan := make(chan struct{}, 2)
 		injectMS.MoveOnGlobeFunc = func(
 			ctx context.Context,
 			componentName resource.Name,
@@ -367,97 +209,31 @@ func TestStartWaypoint(t *testing.T) {
 			motionCfg *motion.MotionConfiguration,
 			extra map[string]interface{},
 		) (bool, error) {
-			callChan <- moveOnGlobeReq{
-				componentName:      componentName,
-				destination:        destination,
-				heading:            heading,
-				movementSensorName: movementSensorName,
-				obstacles:          obstacles,
-				motionCfg:          motionCfg,
-				extra:              extra,
-			}
-			return true, nil
+			err := kinematicBase.GoToInputs(ctx, referenceframe.FloatsToInputs([]float64{destination.Lat(), destination.Lng()}))
+			callChan <- struct{}{}
+			return true, err
 		}
-		ns, teardown := setupNavService(ctx, t, injectMS, injectMSensor, b, logger)
-		defer teardown()
-
-		// add waypoint 1
-		pt1 := geo.NewPoint(1, 0)
-		err := ns.AddWaypoint(ctx, pt1, nil)
+		pt := geo.NewPoint(1, 0)
+		err = ns.AddWaypoint(ctx, pt, nil)
 		test.That(t, err, test.ShouldBeNil)
 
-		// add waypoint 2
-		pt2 := geo.NewPoint(3, 1)
-		err = ns.AddWaypoint(ctx, pt2, nil)
+		pt = geo.NewPoint(3, 1)
+		err = ns.AddWaypoint(ctx, pt, nil)
 		test.That(t, err, test.ShouldBeNil)
 
-		// test that added waypoints are returned by the waypoints function
-		wps, err := ns.Waypoints(ctx, nil)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, len(wps), test.ShouldEqual, 2)
-		wpSimilar(t, wps[0], pointToWP(pt1))
-		wpSimilar(t, wps[1], pointToWP(pt2))
-
-		// set mode to Waypoint to begin MoveOnMap calls
+		ns.(*builtIn).mode = navigation.ModeManual
 		err = ns.SetMode(ctx, navigation.ModeWaypoint, nil)
 		test.That(t, err, test.ShouldBeNil)
+		blockTillCallCount(t, 2, callChan, time.Second*5)
+		ns.(*builtIn).wholeServiceCancelFunc()
+		ns.(*builtIn).activeBackgroundWorkers.Wait()
 
-		// confirm mode is now Waypoint
-		mode, err := ns.Mode(ctx, nil)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, mode, test.ShouldEqual, navigation.ModeWaypoint)
-
-		timeoutCtx, cancelFn := context.WithTimeout(context.Background(), time.Second)
-		defer cancelFn()
-
-		// confirm MoveOnGlobe is called for waypoint 1
-		expectedCall1 := moveOnGlobeReq{
-			componentName:      b.Name(),
-			destination:        pt1,
-			heading:            math.NaN(),
-			movementSensorName: injectMSensor.Name(),
-			motionCfg:          expectedMotionCfg,
-			// TODO: fix with RSDK-4583
-			// extra defaults to "motion_profile": "position_only"
-			// extra: map[string]interface{}{"motion_profile": "position_only"},
-		}
-		blockTillCalledOrTimeout(timeoutCtx, t, expectedCall1, callChan)
-
-		// confirm waypoint 1 is eventually removed from the waypoints store after
-		// MoveOnGlobe reports reaching waypoint 1
-		wps1, err := pollTillWaypointLen(timeoutCtx, t, ns, 1)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, len(wps1), test.ShouldEqual, 1)
-		wpSimilar(t, wps1[0], pointToWP(pt2))
-
-		// confirm MoveOnGlobe is called for waypoint 2
-		expectedCall2 := moveOnGlobeReq{
-			componentName:      b.Name(),
-			destination:        pt2,
-			heading:            math.NaN(),
-			movementSensorName: injectMSensor.Name(),
-			motionCfg:          expectedMotionCfg,
-			// TODO: fix with RSDK-4583
-			// extra defaults to "motion_profile": "position_only"
-			// extra: map[string]interface{}{"motion_profile": "position_only"},
-		}
-		blockTillCalledOrTimeout(timeoutCtx, t, expectedCall2, callChan)
-
-		// confirm waypoint 2 is eventually removed from the waypoints store after
-		// MoveOnGlobe reports reaching waypoint 2
-		// This leaves the waypoint store empty
-		wps2, err := pollTillWaypointLen(timeoutCtx, t, ns, 0)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, wps2, test.ShouldBeEmpty)
+		currentInputsShouldEqual(ctx, t, kinematicBase, pt)
 	})
 
-	t.Run("SetMode's extra[motion_profile] defaults to position_mode when extra is non nil & motion_profile is unset", func(t *testing.T) {
-		// TODO: fix with RSDK-4583
-		t.Skip()
-		callChan := make(chan moveOnGlobeReq)
-		injectMSensor := inject.NewMovementSensor("test_movement")
-
-		injectMS := inject.NewMotionService("test_motion")
+	t.Run("Extra defaults to motion_profile", func(t *testing.T) {
+		callChan := make(chan struct{}, 1)
+		// setup injected MoveOnGlobe to test what extra defaults to from startWaypointExperimental function
 		injectMS.MoveOnGlobeFunc = func(
 			ctx context.Context,
 			componentName resource.Name,
@@ -468,265 +244,41 @@ func TestStartWaypoint(t *testing.T) {
 			motionCfg *motion.MotionConfiguration,
 			extra map[string]interface{},
 		) (bool, error) {
-			callChan <- moveOnGlobeReq{
-				componentName:      componentName,
-				destination:        destination,
-				heading:            heading,
-				movementSensorName: movementSensorName,
-				obstacles:          obstacles,
-				motionCfg:          motionCfg,
-				extra:              extra,
-			}
-			return true, nil
-		}
-		ns, teardown := setupNavService(ctx, t, injectMS, injectMSensor, b, logger)
-		defer teardown()
-
-		// add waypoint 1
-		pt1 := geo.NewPoint(1, 0)
-		err := ns.AddWaypoint(ctx, pt1, nil)
-		test.That(t, err, test.ShouldBeNil)
-
-		// test that added waypoints are returned by the waypoints function
-		wps, err := ns.Waypoints(ctx, nil)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, len(wps), test.ShouldEqual, 1)
-		wpSimilar(t, wps[0], pointToWP(pt1))
-
-		// set mode to Waypoint to begin MoveOnMap calls
-		err = ns.SetMode(ctx, navigation.ModeWaypoint, map[string]interface{}{})
-		test.That(t, err, test.ShouldBeNil)
-
-		// confirm mode is now Waypoint
-		mode, err := ns.Mode(ctx, nil)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, mode, test.ShouldEqual, navigation.ModeWaypoint)
-
-		timeoutCtx, cancelFn := context.WithTimeout(context.Background(), time.Second)
-		defer cancelFn()
-
-		// confirm MoveOnGlobe is called for waypoint 1
-		expectedCall1 := moveOnGlobeReq{
-			componentName:      b.Name(),
-			destination:        pt1,
-			heading:            math.NaN(),
-			movementSensorName: injectMSensor.Name(),
-			motionCfg:          expectedMotionCfg,
-			// extra keeps default of "motion_profile": "position_only"
-			extra: map[string]interface{}{"motion_profile": "position_only"},
-		}
-		blockTillCalledOrTimeout(timeoutCtx, t, expectedCall1, callChan)
-	})
-
-	t.Run("SetMode's extra[motion_profile] is able to be overridden to something other than position_mode", func(t *testing.T) {
-		callChan := make(chan moveOnGlobeReq)
-		injectMSensor := inject.NewMovementSensor("test_movement")
-
-		injectMS := inject.NewMotionService("test_motion")
-		injectMS.MoveOnGlobeFunc = func(
-			ctx context.Context,
-			componentName resource.Name,
-			destination *geo.Point,
-			heading float64,
-			movementSensorName resource.Name,
-			obstacles []*spatialmath.GeoObstacle,
-			motionCfg *motion.MotionConfiguration,
-			extra map[string]interface{},
-		) (bool, error) {
-			callChan <- moveOnGlobeReq{
-				componentName:      componentName,
-				destination:        destination,
-				heading:            heading,
-				movementSensorName: movementSensorName,
-				obstacles:          obstacles,
-				motionCfg:          motionCfg,
-				extra:              extra,
-			}
-			return true, nil
-		}
-		ns, teardown := setupNavService(ctx, t, injectMS, injectMSensor, b, logger)
-		defer teardown()
-
-		// add waypoint 1
-		pt1 := geo.NewPoint(1, 0)
-		err := ns.AddWaypoint(ctx, pt1, nil)
-		test.That(t, err, test.ShouldBeNil)
-
-		// set mode to Waypoint to begin MoveOnMap calls
-		err = ns.SetMode(ctx, navigation.ModeWaypoint, map[string]interface{}{"motion_profile": "SOMETHING ELSE"})
-		test.That(t, err, test.ShouldBeNil)
-
-		timeoutCtx, cancelFn := context.WithTimeout(context.Background(), time.Second*5)
-		defer cancelFn()
-
-		// confirm MoveOnGlobe is called for waypoint 1
-		expectedCall1 := moveOnGlobeReq{
-			componentName:      b.Name(),
-			destination:        pt1,
-			heading:            math.NaN(),
-			movementSensorName: injectMSensor.Name(),
-			motionCfg:          expectedMotionCfg,
-			extra:              map[string]interface{}{"motion_profile": "SOMETHING ELSE"},
-		}
-		blockTillCalledOrTimeout(timeoutCtx, t, expectedCall1, callChan)
-	})
-
-	t.Run("MoveOnGlobe error results in retrying the same waypoint until success", func(t *testing.T) {
-		callChan := make(chan moveOnGlobeReq)
-		injectMSensor := inject.NewMovementSensor("test_movement")
-
-		injectMS := inject.NewMotionService("test_motion")
-
-		called := false
-		injectMS.MoveOnGlobeFunc = func(
-			ctx context.Context,
-			componentName resource.Name,
-			destination *geo.Point,
-			heading float64,
-			movementSensorName resource.Name,
-			obstacles []*spatialmath.GeoObstacle,
-			motionCfg *motion.MotionConfiguration,
-			extra map[string]interface{},
-		) (bool, error) {
-			callChan <- moveOnGlobeReq{
-				componentName:      componentName,
-				destination:        destination,
-				heading:            heading,
-				movementSensorName: movementSensorName,
-				obstacles:          obstacles,
-				motionCfg:          motionCfg,
-				extra:              extra,
-			}
-			if called {
+			callChan <- struct{}{}
+			if extra != nil && extra["motion_profile"] != nil {
 				return true, nil
 			}
-			called = true
-			return false, errors.New("move on globe error")
+			return false, errors.New("no motion_profile exist")
 		}
-		ns, teardown := setupNavService(ctx, t, injectMS, injectMSensor, b, logger)
-		defer teardown()
 
-		// add waypoint 1
-		pt1 := geo.NewPoint(1, 0)
-		err := ns.AddWaypoint(ctx, pt1, nil)
+		// construct new point to navigate to
+		pt := geo.NewPoint(0, 0)
+		err = ns.AddWaypoint(ctx, pt, nil)
 		test.That(t, err, test.ShouldBeNil)
 
-		// test that added waypoints are returned by the waypoints function
-		wps, err := ns.Waypoints(ctx, nil)
+		cancelCtx, fn := context.WithCancel(ctx)
+		ns.(*builtIn).startWaypoint(cancelCtx, map[string]interface{}{})
+		blockTillCallCount(t, 1, callChan, time.Second*5)
+		fn()
+		ns.(*builtIn).activeBackgroundWorkers.Wait()
+
+		// go to same point again
+		err = ns.AddWaypoint(ctx, pt, nil)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, len(wps), test.ShouldEqual, 1)
-		wpSimilar(t, wps[0], pointToWP(pt1))
 
-		// set mode to Waypoint to begin MoveOnMap calls
-		err = ns.SetMode(ctx, navigation.ModeWaypoint, nil)
-		test.That(t, err, test.ShouldBeNil)
-
-		timeoutCtx, cancelFn := context.WithTimeout(context.Background(), time.Second)
-		defer cancelFn()
-
-		// confirm MoveOnGlobe is called for waypoint 1
-		expectedCall1and2 := moveOnGlobeReq{
-			componentName:      b.Name(),
-			destination:        pt1,
-			heading:            math.NaN(),
-			movementSensorName: injectMSensor.Name(),
-			motionCfg:          expectedMotionCfg,
-			// TODO: fix with RSDK-4583
-			// extra defaults to "motion_profile": "position_only"
-			// extra: map[string]interface{}{"motion_profile": "position_only"},
-		}
-		// MoveOnGlobe called twice with same parameters, as nav services
-		// retries first call which returned an error
-		blockTillCalledOrTimeout(timeoutCtx, t, expectedCall1and2, callChan)
-		blockTillCalledOrTimeout(timeoutCtx, t, expectedCall1and2, callChan)
-
-		// confirm waypoint 1 is eventually removed from the waypoints store after
-		// MoveOnGlobe reports reaching waypoint 1
-		wps1, err := pollTillWaypointLen(timeoutCtx, t, ns, 0)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, len(wps1), test.ShouldEqual, 0)
+		cancelCtx, fn = context.WithCancel(ctx)
+		ns.(*builtIn).startWaypoint(cancelCtx, nil)
+		blockTillCallCount(t, 1, callChan, time.Second*5)
+		fn()
+		ns.(*builtIn).activeBackgroundWorkers.Wait()
 	})
 
-	t.Run("MoveOnGlobe success false results in retrying the same waypoint until success", func(t *testing.T) {
-		callChan := make(chan moveOnGlobeReq)
-		injectMSensor := inject.NewMovementSensor("test_movement")
-
-		injectMS := inject.NewMotionService("test_motion")
-
-		called := false
-		injectMS.MoveOnGlobeFunc = func(
-			ctx context.Context,
-			componentName resource.Name,
-			destination *geo.Point,
-			heading float64,
-			movementSensorName resource.Name,
-			obstacles []*spatialmath.GeoObstacle,
-			motionCfg *motion.MotionConfiguration,
-			extra map[string]interface{},
-		) (bool, error) {
-			callChan <- moveOnGlobeReq{
-				componentName:      componentName,
-				destination:        destination,
-				heading:            heading,
-				movementSensorName: movementSensorName,
-				obstacles:          obstacles,
-				motionCfg:          motionCfg,
-				extra:              extra,
-			}
-			if called {
-				return true, nil
-			}
-			called = true
-			return false, nil
-		}
-		ns, teardown := setupNavService(ctx, t, injectMS, injectMSensor, b, logger)
-		defer teardown()
-
-		// add waypoint 1
-		pt1 := geo.NewPoint(1, 0)
-		err := ns.AddWaypoint(ctx, pt1, nil)
-		test.That(t, err, test.ShouldBeNil)
-
-		// test that added waypoints are returned by the waypoints function
-		wps, err := ns.Waypoints(ctx, nil)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, len(wps), test.ShouldEqual, 1)
-		wpSimilar(t, wps[0], pointToWP(pt1))
-
-		// set mode to Waypoint to begin MoveOnMap calls
-		err = ns.SetMode(ctx, navigation.ModeWaypoint, nil)
-		test.That(t, err, test.ShouldBeNil)
-
-		timeoutCtx, cancelFn := context.WithTimeout(context.Background(), time.Second)
-		defer cancelFn()
-
-		// confirm MoveOnGlobe is called for waypoint 1
-		expectedCall1and2 := moveOnGlobeReq{
-			componentName:      b.Name(),
-			destination:        pt1,
-			heading:            math.NaN(),
-			movementSensorName: injectMSensor.Name(),
-			motionCfg:          expectedMotionCfg,
-			// TODO: fix with RSDK-4583
-			// extra defaults to "motion_profile": "position_only"
-			// extra: map[string]interface{}{"motion_profile": "position_only"},
-		}
-		// MoveOnGlobe called twice with same parameters, as nav services
-		// retries first call which returned success false
-		blockTillCalledOrTimeout(timeoutCtx, t, expectedCall1and2, callChan)
-		blockTillCalledOrTimeout(timeoutCtx, t, expectedCall1and2, callChan)
-
-		// confirm waypoint 1 is eventually removed from the waypoints store after
-		// MoveOnGlobe reports reaching waypoint 1
-		wps1, err := pollTillWaypointLen(timeoutCtx, t, ns, 0)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, len(wps1), test.ShouldEqual, 0)
-	})
-
-	t.Run("Calling RemoveWaypoint on the waypoint in progress cancels current MoveOnGlobe call", func(t *testing.T) {
-		injectMSensor := inject.NewMovementSensor("test_movement")
-
-		injectMS := inject.NewMotionService("test_motion")
+	t.Run("Test MoveOnGlobe cancellation and errors", func(t *testing.T) {
+		eventChannel, statusChannel := make(chan string), make(chan string, 1)
+		cancelledContextMsg := "context cancelled"
+		hitAnErrorMsg := "hit an error"
+		arrivedAtWaypointMsg := "arrived at destination"
+		invalidStateMsg := "bad message passed to event channel"
 
 		injectMS.MoveOnGlobeFunc = func(
 			ctx context.Context,
@@ -738,246 +290,201 @@ func TestStartWaypoint(t *testing.T) {
 			motionCfg *motion.MotionConfiguration,
 			extra map[string]interface{},
 		) (bool, error) {
-			// always error to prove that the waypoint was removed due to RemoveWaypoint
-			// and not MoveOnGlobe succeeding
-			return false, nil
-		}
-		ns, teardown := setupNavService(ctx, t, injectMS, injectMSensor, b, logger)
-		defer teardown()
-
-		// add waypoint 1
-		pt1 := geo.NewPoint(1, 0)
-		err := ns.AddWaypoint(ctx, pt1, nil)
-		test.That(t, err, test.ShouldBeNil)
-
-		// test that added waypoints are returned by the waypoints function
-		wps, err := ns.Waypoints(ctx, nil)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, len(wps), test.ShouldEqual, 1)
-		wpSimilar(t, wps[0], pointToWP(pt1))
-
-		// set mode to Waypoint to begin MoveOnMap calls
-		err = ns.SetMode(ctx, navigation.ModeWaypoint, nil)
-		test.That(t, err, test.ShouldBeNil)
-
-		timeoutCtx, cancelFn := context.WithTimeout(context.Background(), time.Second)
-		defer cancelFn()
-
-		// remove the waypoint
-		err = ns.RemoveWaypoint(ctx, wps[0].ID, nil)
-		test.That(t, err, test.ShouldBeNil)
-
-		// confirm waypoint 1 is eventually removed from the waypoints store
-		wps1, err := pollTillWaypointLen(timeoutCtx, t, ns, 0)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, len(wps1), test.ShouldEqual, 0)
-	})
-
-	t.Run("Calling SetMode Manual pauses MoveOnGlobe calls, setting it back to waypoint resumes", func(t *testing.T) {
-		injectMSensor := inject.NewMovementSensor("test_movement")
-
-		injectMS := inject.NewMotionService("test_motion")
-
-		injectMS.MoveOnGlobeFunc = func(
-			ctx context.Context,
-			componentName resource.Name,
-			destination *geo.Point,
-			heading float64,
-			movementSensorName resource.Name,
-			obstacles []*spatialmath.GeoObstacle,
-			motionCfg *motion.MotionConfiguration,
-			extra map[string]interface{},
-		) (bool, error) {
-			return false, nil
-		}
-
-		ns, teardown := setupNavService(ctx, t, injectMS, injectMSensor, b, logger)
-		defer teardown()
-
-		// add waypoint 1
-		pt1 := geo.NewPoint(1, 0)
-		err := ns.AddWaypoint(ctx, pt1, nil)
-		test.That(t, err, test.ShouldBeNil)
-
-		// test that added waypoints are returned by the waypoints function
-		wps1, err := ns.Waypoints(ctx, nil)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, len(wps1), test.ShouldEqual, 1)
-		wpSimilar(t, wps1[0], pointToWP(pt1))
-
-		// set mode to Waypoint to begin MoveOnMap calls
-		err = ns.SetMode(ctx, navigation.ModeWaypoint, nil)
-		test.That(t, err, test.ShouldBeNil)
-
-		timeoutCtx, cancelFn := context.WithTimeout(context.Background(), time.Second)
-		defer cancelFn()
-
-		// change mode to stop MoveOnMap calls
-		err = ns.SetMode(ctx, navigation.ModeManual, nil)
-		test.That(t, err, test.ShouldBeNil)
-
-		// confirm first waypoint is still there as MoveOnGlobe
-		// hasn't returned success yet
-		wps2, err := ns.Waypoints(ctx, nil)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, wps2, test.ShouldResemble, wps1)
-
-		callChan := make(chan moveOnGlobeReq)
-		injectMS.MoveOnGlobeFunc = func(
-			ctx context.Context,
-			componentName resource.Name,
-			destination *geo.Point,
-			heading float64,
-			movementSensorName resource.Name,
-			obstacles []*spatialmath.GeoObstacle,
-			motionCfg *motion.MotionConfiguration,
-			extra map[string]interface{},
-		) (bool, error) {
-			callChan <- moveOnGlobeReq{
-				componentName:      componentName,
-				destination:        destination,
-				heading:            heading,
-				movementSensorName: movementSensorName,
-				obstacles:          obstacles,
-				motionCfg:          motionCfg,
-				extra:              extra,
+			if ctx.Err() != nil {
+				statusChannel <- cancelledContextMsg
+				return false, ctx.Err()
 			}
-			return true, nil
-		}
+			select {
+			case <-ctx.Done():
+				statusChannel <- cancelledContextMsg
+				return false, ctx.Err()
+			case msg := <-eventChannel:
+				var err error
+				if msg == arrivedAtWaypointMsg {
+					err = kinematicBase.GoToInputs(
+						ctx,
+						referenceframe.FloatsToInputs([]float64{destination.Lat(), destination.Lng()}),
+					)
+				}
 
-		// change mode to restart MoveOnMap calls
-		err = ns.SetMode(ctx, navigation.ModeWaypoint, nil)
-		test.That(t, err, test.ShouldBeNil)
-
-		// confirm MoveOnGlobe is called for waypoint 1
-		expectedCall := moveOnGlobeReq{
-			componentName:      b.Name(),
-			destination:        pt1,
-			heading:            math.NaN(),
-			movementSensorName: injectMSensor.Name(),
-			motionCfg: &motion.MotionConfiguration{
-				LinearMPerSec:     1,
-				AngularDegsPerSec: 1,
-			},
-			// TODO: fix with RSDK-4583
-			// extra defaults to "motion_profile": "position_only"
-			// extra: map[string]interface{}{"motion_profile": "position_only"},
-		}
-		// confirm that MoveOnGlobe is called with waypoint 1 after
-		// switching from WaypointMode -> ManualMode -> WaypointMode
-		blockTillCalledOrTimeout(timeoutCtx, t, expectedCall, callChan)
-
-		// confirm waypoint 1 is eventually removed from the waypoints store after
-		// MoveOnGlobe reports reaching waypoint 1
-		wps3, err := pollTillWaypointLen(timeoutCtx, t, ns, 0)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, len(wps3), test.ShouldEqual, 0)
-	})
-
-	t.Run("Calling RemoveWaypoint on a waypoint that is not in progress does not cancel MoveOnGlobe", func(t *testing.T) {
-		injectMSensor := inject.NewMovementSensor("test_movement")
-
-		injectMS := inject.NewMotionService("test_motion")
-		var successAtomic atomic.Bool
-
-		callChan := make(chan moveOnGlobeReq)
-		successChan := make(chan struct{})
-		injectMS.MoveOnGlobeFunc = func(
-			ctx context.Context,
-			componentName resource.Name,
-			destination *geo.Point,
-			heading float64,
-			movementSensorName resource.Name,
-			obstacles []*spatialmath.GeoObstacle,
-			motionCfg *motion.MotionConfiguration,
-			extra map[string]interface{},
-		) (bool, error) {
-			callChan <- moveOnGlobeReq{
-				componentName:      componentName,
-				destination:        destination,
-				heading:            heading,
-				movementSensorName: movementSensorName,
-				obstacles:          obstacles,
-				motionCfg:          motionCfg,
-				extra:              extra,
+				statusChannel <- msg
+				switch {
+				case msg == hitAnErrorMsg:
+					return false, errors.New(hitAnErrorMsg)
+				case msg == arrivedAtWaypointMsg:
+					return true, err
+				default:
+					// should be unreachable
+					return false, errors.New(invalidStateMsg)
+				}
 			}
-			success := successAtomic.Load()
-			if success {
-				successChan <- struct{}{}
+		}
+
+		pt1, pt2, pt3 := geo.NewPoint(1, 2), geo.NewPoint(2, 3), geo.NewPoint(3, 4)
+		points := []*geo.Point{pt1, pt2, pt3}
+		t.Run("MoveOnGlobe error results in skipping the current waypoint", func(t *testing.T) {
+			// Set manual mode to ensure waypoint loop from prior test exits
+			err = ns.SetMode(ctx, navigation.ModeManual, map[string]interface{}{"experimental": true})
+			test.That(t, err, test.ShouldBeNil)
+			ctx, cancelFunc := context.WithCancel(ctx)
+			defer ns.(*builtIn).activeBackgroundWorkers.Wait()
+			defer cancelFunc()
+			err = deleteAllWaypoints(ctx, ns)
+			for _, pt := range points {
+				err = ns.AddWaypoint(ctx, pt, nil)
+				test.That(t, err, test.ShouldBeNil)
 			}
 
-			return success, nil
-		}
+			ns.(*builtIn).startWaypoint(ctx, map[string]interface{}{"experimental": true})
 
-		ns, teardown := setupNavService(ctx, t, injectMS, injectMSensor, b, logger)
-		defer teardown()
+			// Get the ID of the first waypoint
+			wp1, err := ns.(*builtIn).store.NextWaypoint(ctx)
+			test.That(t, err, test.ShouldBeNil)
 
-		// add waypoint 1
-		pt1 := geo.NewPoint(1, 0)
-		err := ns.AddWaypoint(ctx, pt1, nil)
-		test.That(t, err, test.ShouldBeNil)
+			// Reach the first waypoint
+			eventChannel <- arrivedAtWaypointMsg
+			test.That(t, <-statusChannel, test.ShouldEqual, arrivedAtWaypointMsg)
+			currentInputsShouldEqual(ctx, t, kinematicBase, pt1)
 
-		// add waypoint 2
-		pt2 := geo.NewPoint(3, 1)
-		err = ns.AddWaypoint(ctx, pt2, nil)
-		test.That(t, err, test.ShouldBeNil)
+			// Ensure we aren't querying before the nav service has a chance to mark the previous waypoint visited.
+			wp2, err := ns.(*builtIn).store.NextWaypoint(ctx)
+			test.That(t, err, test.ShouldBeNil)
+			for wp2.ID == wp1.ID {
+				wp2, err = ns.(*builtIn).store.NextWaypoint(ctx)
+				test.That(t, err, test.ShouldBeNil)
+			}
 
-		// test that added waypoints are returned by the waypoints function
-		wps1, err := ns.Waypoints(ctx, nil)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, len(wps1), test.ShouldEqual, 2)
-		wpSimilar(t, wps1[0], pointToWP(pt1))
-		wpSimilar(t, wps1[1], pointToWP(pt2))
+			// Skip the second waypoint due to an error
+			eventChannel <- hitAnErrorMsg
+			test.That(t, <-statusChannel, test.ShouldEqual, hitAnErrorMsg)
+			currentInputsShouldEqual(ctx, t, kinematicBase, pt1)
 
-		// set mode to Waypoint to begin MoveOnMap calls
-		err = ns.SetMode(ctx, navigation.ModeWaypoint, nil)
-		test.That(t, err, test.ShouldBeNil)
+			// Ensure we aren't querying before the nav service has a chance to mark the previous waypoint visited.
+			wp3, err := ns.(*builtIn).store.NextWaypoint(ctx)
+			test.That(t, err, test.ShouldBeNil)
+			for wp3.ID == wp2.ID {
+				wp3, err = ns.(*builtIn).store.NextWaypoint(ctx)
+				test.That(t, err, test.ShouldBeNil)
+			}
 
-		timeoutCtx, cancelFn := context.WithTimeout(context.Background(), time.Second)
-		defer cancelFn()
+			// Reach the third waypoint
+			eventChannel <- arrivedAtWaypointMsg
+			test.That(t, <-statusChannel, test.ShouldEqual, arrivedAtWaypointMsg)
+			currentInputsShouldEqual(ctx, t, kinematicBase, pt3)
+		})
+		t.Run("Calling SetMode cancels current and future MoveOnGlobe calls", func(t *testing.T) {
+			// Set manual mode to ensure waypoint loop from prior test exits
+			err = deleteAllWaypoints(ctx, ns)
+			test.That(t, err, test.ShouldBeNil)
+			for _, pt := range points {
+				err = ns.AddWaypoint(ctx, pt, nil)
+				test.That(t, err, test.ShouldBeNil)
+			}
 
-		// confirm MoveOnGlobe is called for waypoint 1
-		expectedCall := moveOnGlobeReq{
-			componentName:      b.Name(),
-			destination:        pt1,
-			heading:            math.NaN(),
-			movementSensorName: injectMSensor.Name(),
-			motionCfg: &motion.MotionConfiguration{
-				LinearMPerSec:     1,
-				AngularDegsPerSec: 1,
-			},
-			// TODO: fix with RSDK-4583
-			// extra defaults to "motion_profile": "position_only"
-			// extra: map[string]interface{}{"motion_profile": "position_only"},
-		}
+			// start navigation - set ModeManual first to ensure navigation starts up
+			err = ns.SetMode(ctx, navigation.ModeWaypoint, map[string]interface{}{"experimental": true})
 
-		// delete last waypoint waypoint
-		err = ns.RemoveWaypoint(ctx, wps1[1].ID, nil)
-		test.That(t, err, test.ShouldBeNil)
+			// Reach the first waypoint
+			eventChannel <- arrivedAtWaypointMsg
+			test.That(t, <-statusChannel, test.ShouldEqual, arrivedAtWaypointMsg)
+			currentInputsShouldEqual(ctx, t, kinematicBase, pt1)
 
-		// confirm last waypoint was removed
-		wps2, err := ns.Waypoints(ctx, nil)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, len(wps2), test.ShouldEqual, 1)
-		wpSimilar(t, wps2[0], pointToWP(pt1))
+			// Change the mode to manual --> stops navigation to waypoints
+			err = ns.SetMode(ctx, navigation.ModeManual, map[string]interface{}{"experimental": true})
+			test.That(t, err, test.ShouldBeNil)
+			select {
+			case msg := <-statusChannel:
+				test.That(t, msg, test.ShouldEqual, cancelledContextMsg)
+			case <-time.After(5 * time.Second):
+				ns.(*builtIn).activeBackgroundWorkers.Wait()
+			}
+			currentInputsShouldEqual(ctx, t, kinematicBase, pt1)
+		})
 
-		// unblock the MoveOnGlobe request after removing waypoint 2
-		blockTillCalledOrTimeout(timeoutCtx, t, expectedCall, callChan)
+		t.Run("Calling RemoveWaypoint on the waypoint in progress cancels current MoveOnGlobe call", func(t *testing.T) {
+			// Set manual mode to ensure waypoint loop from prior test exits
+			err = ns.SetMode(ctx, navigation.ModeManual, map[string]interface{}{"experimental": true})
+			test.That(t, err, test.ShouldBeNil)
+			err = deleteAllWaypoints(ctx, ns)
+			for _, pt := range points {
+				err = ns.AddWaypoint(ctx, pt, nil)
+				test.That(t, err, test.ShouldBeNil)
+			}
 
-		// set success to true after waypoint 2 has been removed
-		successAtomic.Store(true)
+			// start navigation - set ModeManual first to ensure navigation starts up
+			err = ns.SetMode(ctx, navigation.ModeWaypoint, map[string]interface{}{"experimental": true})
 
-		// confirm that MoveOnGlobe is called with waypoint 1 after removing waypoint 2 waypoint
-		blockTillCalledOrTimeout(timeoutCtx, t, expectedCall, callChan)
+			// Get the ID of the first waypoint
+			wp1, err := ns.(*builtIn).store.NextWaypoint(ctx)
+			test.That(t, err, test.ShouldBeNil)
 
-		// confirm success has occurred within the timeout
-		test.That(t, utils.SelectContextOrWaitChan(timeoutCtx, successChan), test.ShouldBeTrue)
+			// Reach the first waypoint
+			eventChannel <- arrivedAtWaypointMsg
+			test.That(t, <-statusChannel, test.ShouldEqual, arrivedAtWaypointMsg)
+			currentInputsShouldEqual(ctx, t, kinematicBase, pt1)
 
-		// confirm waypoint 1 is eventually removed from the waypoints store after
-		// MoveOnGlobe reports reaching waypoint 1
-		wps3, err := pollTillWaypointLen(timeoutCtx, t, ns, 0)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, len(wps3), test.ShouldEqual, 0)
+			// Remove the second waypoint, which is in progress. Ensure we aren't querying before the nav service has a chance to mark
+			// the previous waypoint visited.
+			wp2, err := ns.(*builtIn).store.NextWaypoint(ctx)
+			test.That(t, err, test.ShouldBeNil)
+			for wp2.ID == wp1.ID {
+				wp2, err = ns.(*builtIn).store.NextWaypoint(ctx)
+				test.That(t, err, test.ShouldBeNil)
+			}
+
+			// ensure we actually start the wp2 waypoint before removing it
+			testutils.WaitForAssertion(t, func(tb testing.TB) {
+				tb.Helper()
+				ns.(*builtIn).mu.RLock()
+				svcWp := ns.(*builtIn).waypointInProgress
+				ns.(*builtIn).mu.RUnlock()
+				test.That(tb, wp2.ID, test.ShouldEqual, svcWp.ID)
+			})
+
+			err = ns.RemoveWaypoint(ctx, wp2.ID, nil)
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, <-statusChannel, test.ShouldEqual, cancelledContextMsg)
+			currentInputsShouldEqual(ctx, t, kinematicBase, pt1)
+
+			// Reach the third waypoint
+			eventChannel <- arrivedAtWaypointMsg
+			test.That(t, <-statusChannel, test.ShouldEqual, arrivedAtWaypointMsg)
+			currentInputsShouldEqual(ctx, t, kinematicBase, pt3)
+		})
+
+		t.Run("Calling RemoveWaypoint on a waypoint that is not in progress does not cancel MoveOnGlobe", func(t *testing.T) {
+			// Set manual mode to ensure waypoint loop from prior test exits
+			err = ns.SetMode(ctx, navigation.ModeManual, map[string]interface{}{"experimental": true})
+			test.That(t, err, test.ShouldBeNil)
+			err = deleteAllWaypoints(ctx, ns)
+			var wp3 navigation.Waypoint
+			for i, pt := range points {
+				if i < 3 {
+					err = ns.AddWaypoint(ctx, pt, nil)
+					test.That(t, err, test.ShouldBeNil)
+				} else {
+					wp3, err = ns.(*builtIn).store.AddWaypoint(ctx, pt)
+					test.That(t, err, test.ShouldBeNil)
+				}
+			}
+
+			// start navigation - set ModeManual first to ensure navigation starts up
+			err = ns.SetMode(ctx, navigation.ModeWaypoint, map[string]interface{}{"experimental": true})
+
+			// Reach the first waypoint
+			eventChannel <- arrivedAtWaypointMsg
+			test.That(t, <-statusChannel, test.ShouldEqual, arrivedAtWaypointMsg)
+			currentInputsShouldEqual(ctx, t, kinematicBase, pt1)
+
+			// Remove the third waypoint, which is not in progress yet
+			err = ns.RemoveWaypoint(ctx, wp3.ID, nil)
+			test.That(t, err, test.ShouldBeNil)
+
+			// Reach the second waypoint
+			eventChannel <- arrivedAtWaypointMsg
+			test.That(t, <-statusChannel, test.ShouldEqual, arrivedAtWaypointMsg)
+			currentInputsShouldEqual(ctx, t, kinematicBase, pt2)
+		})
 	})
 }
 
@@ -989,7 +496,7 @@ func TestValidateGeometry(t *testing.T) {
 
 	createBox := func(translation r3.Vector) Config {
 		boxPose := spatialmath.NewPoseFromPoint(translation)
-		geometries, err := spatialmath.NewBox(boxPose, r3.Vector{X: 10, Y: 10, Z: 10}, "")
+		geometries, err := spatialmath.NewBox(boxPose, r3.Vector{10, 10, 10}, "")
 		test.That(t, err, test.ShouldBeNil)
 
 		geoObstacle := spatialmath.NewGeoObstacle(geo.NewPoint(0, 0), []spatialmath.Geometry{geometries})
@@ -1002,7 +509,7 @@ func TestValidateGeometry(t *testing.T) {
 	}
 
 	t.Run("fail case", func(t *testing.T) {
-		cfg = createBox(r3.Vector{X: 10, Y: 10, Z: 10})
+		cfg = createBox(r3.Vector{10, 10, 10})
 		_, err := cfg.Validate("")
 		expectedErr := "geometries specified through the navigation are not allowed to have a translation"
 		test.That(t, err, test.ShouldNotBeNil)

--- a/services/navigation/navigation.go
+++ b/services/navigation/navigation.go
@@ -31,12 +31,22 @@ const (
 	ModeWaypoint
 )
 
+func (m Mode) String() string {
+	switch m {
+	case ModeManual:
+		return "Manual"
+	case ModeWaypoint:
+		return "Waypoint"
+	default:
+		return "UNKNOWN"
+	}
+}
+
 // A Service controls the navigation for a robot.
 type Service interface {
 	resource.Resource
 	Mode(ctx context.Context, extra map[string]interface{}) (Mode, error)
 	SetMode(ctx context.Context, mode Mode, extra map[string]interface{}) error
-
 	Location(ctx context.Context, extra map[string]interface{}) (*spatialmath.GeoPose, error)
 
 	// Waypoint

--- a/utils/logger.go
+++ b/utils/logger.go
@@ -1,0 +1,37 @@
+package utils
+
+import (
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// NewFilePathDebugLogger is intended as a debug only tool & should not be used in prod
+// logs using debug configuration to log to both stderr, stdout & a filepath.
+func NewFilePathDebugLogger(filepath, name string) (*zap.SugaredLogger, error) {
+	logger, err := zap.Config{
+		Level:    zap.NewAtomicLevelAt(zap.DebugLevel),
+		Encoding: "console",
+		EncoderConfig: zapcore.EncoderConfig{
+			TimeKey:        "ts",
+			LevelKey:       "level",
+			NameKey:        "logger",
+			CallerKey:      "caller",
+			FunctionKey:    zapcore.OmitKey,
+			MessageKey:     "msg",
+			StacktraceKey:  "stacktrace",
+			LineEnding:     zapcore.DefaultLineEnding,
+			EncodeLevel:    zapcore.CapitalColorLevelEncoder,
+			EncodeTime:     zapcore.ISO8601TimeEncoder,
+			EncodeDuration: zapcore.StringDurationEncoder,
+			EncodeCaller:   zapcore.ShortCallerEncoder,
+		},
+		DisableStacktrace: true,
+		OutputPaths:       []string{filepath, "stdout"},
+		ErrorOutputPaths:  []string{filepath, "stderr"},
+	}.Build()
+	if err != nil {
+		return nil, err
+	}
+
+	return logger.Sugar().Named(name), nil
+}


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-4886)

Also fixes: https://viam.atlassian.net/browse/RSDK-4934

Moves the non ticket related improvements / fixes from https://github.com/viamrobotics/rdk/pull/2919/files#diff-c413f7c41e0f0eba4493f6ea317ff6a9e356e70224e9d0956ae5cb8dacaf8973 into a separate PR.

1. Adds `log_file_path` to nav service
2. Improve logging by adding String methods to `motion.moveResponse` & `motion.replanResponse` & logging in nav interface methods which change state
3. Fix an off by one error in the nav waypoint store which resulted in a panic if a user tries to remove a waypoint from an empty store. https://viam.atlassian.net/browse/RSDK-4934
