### PR TITLE
make intrinsic parameters optional for join_color_depth

### DIFF
--- a/components/camera/align/join.go
+++ b/components/camera/align/join.go
@@ -59,7 +59,7 @@ type joinConfig struct {
 	ImageType            string                             `json:"output_image_type"`
 	Color                string                             `json:"color_camera_name"`
 	Depth                string                             `json:"depth_camera_name"`
-	CameraParameters     *transform.PinholeCameraIntrinsics `json:"intrinsic_parameters"`
+	CameraParameters     *transform.PinholeCameraIntrinsics `json:"intrinsic_parameters,omitempty"`
 	Debug                bool                               `json:"debug,omitempty"`
 	DistortionParameters *transform.BrownConrady            `json:"distortion_parameters,omitempty"`
 }


### PR DESCRIPTION
need to add the omitempty flag for the json so that it does not fill with default 0's if the intrinsic parameters are not in the config.