### PR TITLE
hotfix-bump-motion-TestReplanning-timeout

### DIFF
--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -761,7 +761,7 @@ func TestReplanning(t *testing.T) {
 		moveRequest, err := ms.(*builtIn).newMoveOnGlobeRequest(ctx, kb.Name(), dst, injectedMovementSensor.Name(), nil, motionCfg, nil)
 		test.That(t, err, test.ShouldBeNil)
 
-		ctx, cancel := context.WithTimeout(ctx, 5.0*time.Second)
+		ctx, cancel := context.WithTimeout(ctx, 30.0*time.Second)
 		ma := newMoveAttempt(ctx, moveRequest)
 		ma.start()
 		defer ma.cancel()


### PR DESCRIPTION
Most recent merge into RDK main failed b/c some of the tests of TestReplanning timed out on the arm64 test runner.

This change bumps the timeout from 5 to 30 seconds.