### PR TITLE
DATA-1887 Convert Board to new proto response format

### DIFF
--- a/components/board/collector.go
+++ b/components/board/collector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	pb "go.viam.com/api/component/board/v1"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"go.viam.com/rdk/data"
@@ -26,28 +27,6 @@ func (m method) String() string {
 	return "Unknown"
 }
 
-// AnalogRecords a collection of AnalogRecord.
-type AnalogRecords struct {
-	Readings []AnalogRecord
-}
-
-// AnalogRecord a single analog reading.
-type AnalogRecord struct {
-	AnalogName  string
-	AnalogValue int
-}
-
-// GpioRecords a collection of GpioRecord.
-type GpioRecords struct {
-	Readings []GpioRecord
-}
-
-// GpioRecord a signle gpio reading.
-type GpioRecord struct {
-	GPIOName  string
-	GPIOValue bool
-}
-
 func newAnalogCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
 	board, err := assertBoard(resource)
 	if err != nil {
@@ -55,22 +34,21 @@ func newAnalogCollector(resource interface{}, params data.CollectorParams) (data
 	}
 
 	cFunc := data.CaptureFunc(func(ctx context.Context, arg map[string]*anypb.Any) (interface{}, error) {
-		var readings []AnalogRecord
-		for k := range arg {
-			if reader, ok := board.AnalogReaderByName(k); ok {
-				value, err := reader.Read(ctx, data.FromDMExtraMap)
-				if err != nil {
-					// A modular filter component can be created to filter the readings from a component. The error ErrNoCaptureToStore
-					// is used in the datamanager to exclude readings from being captured and stored.
-					if errors.Is(err, data.ErrNoCaptureToStore) {
-						return nil, err
-					}
-					return nil, data.FailedToReadErr(params.ComponentName, analogs.String(), err)
+		var value int
+		if reader, ok := board.AnalogReaderByName(arg["reader_name"].String()); ok {
+			value, err = reader.Read(ctx, data.FromDMExtraMap)
+			if err != nil {
+				// A modular filter component can be created to filter the readings from a component. The error ErrNoCaptureToStore
+				// is used in the datamanager to exclude readings from being captured and stored.
+				if errors.Is(err, data.ErrNoCaptureToStore) {
+					return nil, err
 				}
-				readings = append(readings, AnalogRecord{AnalogName: k, AnalogValue: value})
+				return nil, data.FailedToReadErr(params.ComponentName, analogs.String(), err)
 			}
 		}
-		return AnalogRecords{Readings: readings}, nil
+		return pb.ReadAnalogReaderResponse{
+			Value: int32(value),
+		}, nil
 	})
 	return data.NewCollector(cFunc, params)
 }
@@ -82,22 +60,21 @@ func newGPIOCollector(resource interface{}, params data.CollectorParams) (data.C
 	}
 
 	cFunc := data.CaptureFunc(func(ctx context.Context, arg map[string]*anypb.Any) (interface{}, error) {
-		var readings []GpioRecord
-		for k := range arg {
-			if gpio, err := board.GPIOPinByName(k); err == nil {
-				value, err := gpio.Get(ctx, data.FromDMExtraMap)
-				if err != nil {
-					// A modular filter component can be created to filter the readings from a component. The error ErrNoCaptureToStore
-					// is used in the datamanager to exclude readings from being captured and stored.
-					if errors.Is(err, data.ErrNoCaptureToStore) {
-						return nil, err
-					}
-					return nil, data.FailedToReadErr(params.ComponentName, gpios.String(), err)
+		var value bool
+		if gpio, err := board.GPIOPinByName(arg["reader_name"].String()); err == nil {
+			value, err = gpio.Get(ctx, data.FromDMExtraMap)
+			if err != nil {
+				// A modular filter component can be created to filter the readings from a component. The error ErrNoCaptureToStore
+				// is used in the datamanager to exclude readings from being captured and stored.
+				if errors.Is(err, data.ErrNoCaptureToStore) {
+					return nil, err
 				}
-				readings = append(readings, GpioRecord{GPIOName: k, GPIOValue: value})
+				return nil, data.FailedToReadErr(params.ComponentName, gpios.String(), err)
 			}
 		}
-		return GpioRecords{Readings: readings}, nil
+		return pb.GetGPIOResponse{
+			High: value,
+		}, nil
 	})
 	return data.NewCollector(cFunc, params)
 }

--- a/services/datamanager/data/collectortests/board/analog_collector.json
+++ b/services/datamanager/data/collectortests/board/analog_collector.json
@@ -1,0 +1,45 @@
+{
+    "network": {
+        "fqdn": "something-unique",
+        "bind_address": ":8080"
+    },
+    "components": [
+        {
+            "name": "board",
+            "model": "fake",
+            "type": "board",
+            "namespace": "rdk",
+            "attributes": {
+                "fail_new": false
+            },
+            "depends_on": [],
+            "service_configs": [
+                {
+                    "type": "data_manager",
+                    "attributes": {
+                        "capture_methods": [
+                            {
+                                "method": "Analogs",
+                                "additional_params": {},
+                                "capture_frequency_hz": 100
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    ],
+    "services": [
+        {
+            "name": "data_manager1",
+            "type": "data_manager",
+            "model": "builtin",
+            "attributes": {
+                "sync_disabled": false,
+                "sync_interval_mins": 0,
+                "capture_dir": "/tmp/capture",
+                "capture_disabled": false
+            }
+        }
+    ]
+}

--- a/services/datamanager/data/collectortests/board/gpio_collector.json
+++ b/services/datamanager/data/collectortests/board/gpio_collector.json
@@ -1,0 +1,45 @@
+{
+    "network": {
+        "fqdn": "something-unique",
+        "bind_address": ":8080"
+    },
+    "components": [
+        {
+            "name": "board",
+            "model": "fake",
+            "type": "board",
+            "namespace": "rdk",
+            "attributes": {
+                "fail_new": false
+            },
+            "depends_on": [],
+            "service_configs": [
+                {
+                    "type": "data_manager",
+                    "attributes": {
+                        "capture_methods": [
+                            {
+                                "method": "Gpios",
+                                "additional_params": {},
+                                "capture_frequency_hz": 100
+                              }
+                        ]
+                    }
+                }
+            ]
+        }
+    ],
+    "services": [
+        {
+            "name": "data_manager1",
+            "type": "data_manager",
+            "model": "builtin",
+            "attributes": {
+                "sync_disabled": false,
+                "sync_interval_mins": 0,
+                "capture_dir": "/tmp/capture",
+                "capture_disabled": false
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This change is to change the board analog and GPIO pins to return single pins based on a pin name thats passed in via the config. I split this change out as the other changes were all identical and I didn't want this lost in there. The collector is per pin instead of returning all pins that are supplied.
**Testing**
Still working on testing, this will be tested manually and tests will be added as part of [DATA-2012](https://viam.atlassian.net/browse/DATA-2012)

[DATA-2012]: https://viam.atlassian.net/browse/DATA-2012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ