### PR TITLE
RSDK-4949 fix panic when no store information is added in config

### DIFF
--- a/services/navigation/builtin/builtin.go
+++ b/services/navigation/builtin/builtin.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	// default configuration for Store parameter
+	// default configuration for Store parameter.
 	defaultStoreType = navigation.StoreTypeMemory
 
 	// desired speeds to maintain for the base.

--- a/services/navigation/builtin/builtin.go
+++ b/services/navigation/builtin/builtin.go
@@ -25,6 +25,10 @@ import (
 )
 
 const (
+	// default configuration for Store parameter
+	defaultStoreType = navigation.StoreTypeMemory
+
+	// desired speeds to maintain for the base.
 	defaultLinearVelocityMPerSec     = 0.5
 	defaultAngularVelocityDegsPerSec = 45
 
@@ -95,7 +99,7 @@ func (conf *Config) Validate(path string) ([]string, error) {
 	deps = append(deps, conf.MovementSensorName)
 
 	if conf.MotionServiceName == "" {
-		conf.MotionServiceName = "builtin"
+		conf.MotionServiceName = resource.DefaultServiceName
 	}
 	deps = append(deps, resource.NewName(motion.API, conf.MotionServiceName).String())
 
@@ -104,6 +108,9 @@ func (conf *Config) Validate(path string) ([]string, error) {
 	}
 
 	// get default speeds from config if set, else defaults from nav services const
+	if conf.Store.Validate(path) != nil {
+		conf.Store.Type = defaultStoreType
+	}
 	if conf.MetersPerSec == 0 {
 		conf.MetersPerSec = defaultLinearVelocityMPerSec
 	}
@@ -213,22 +220,14 @@ func (svc *builtIn) Reconfigure(ctx context.Context, deps resource.Dependencies,
 
 	svc.mu.Lock()
 	defer svc.mu.Unlock()
-	var newStore navigation.NavStore
+
+	// Reconfigure the store if necessary
 	if svc.storeType != string(svcConfig.Store.Type) {
-		switch svcConfig.Store.Type {
-		case navigation.StoreTypeMemory:
-			newStore = navigation.NewMemoryNavigationStore()
-		case navigation.StoreTypeMongoDB:
-			var err error
-			newStore, err = navigation.NewMongoDBNavigationStore(ctx, svcConfig.Store.Config)
-			if err != nil {
-				return err
-			}
-		default:
-			return errors.Errorf("unknown store type %q", svcConfig.Store.Type)
+		newStore, err := navigation.NewStoreFromConfig(ctx, svcConfig.Store)
+		if err != nil {
+			return err
 		}
-	} else {
-		newStore = svc.store
+		svc.store = newStore
 	}
 
 	// Parse obstacles from the passed in configuration
@@ -238,7 +237,6 @@ func (svc *builtIn) Reconfigure(ctx context.Context, deps resource.Dependencies,
 	}
 
 	svc.mode = navigation.ModeManual
-	svc.store = newStore
 	svc.storeType = string(svcConfig.Store.Type)
 	svc.base = base1
 	svc.movementSensor = movementSensor

--- a/services/navigation/store.go
+++ b/services/navigation/store.go
@@ -54,6 +54,7 @@ func (config *StoreConfig) Validate(path string) error {
 	return nil
 }
 
+// NewStoreFromConfig builds a NavStore from the provided StoreConfig and returns it.
 func NewStoreFromConfig(ctx context.Context, conf StoreConfig) (NavStore, error) {
 	switch conf.Type {
 	case StoreTypeMemory:

--- a/services/navigation/store.go
+++ b/services/navigation/store.go
@@ -54,6 +54,17 @@ func (config *StoreConfig) Validate(path string) error {
 	return nil
 }
 
+func NewStoreFromConfig(ctx context.Context, conf StoreConfig) (NavStore, error) {
+	switch conf.Type {
+	case StoreTypeMemory:
+		return NewMemoryNavigationStore(), nil
+	case StoreTypeMongoDB:
+		return NewMongoDBNavigationStore(ctx, conf.Config)
+	default:
+		return nil, errors.Errorf("unknown store type %q", conf.Type)
+	}
+}
+
 // A Waypoint designates a location within a path to navigate to.
 type Waypoint struct {
 	ID      primitive.ObjectID `bson:"_id"`


### PR DESCRIPTION
This PR modifies the validation for the builtin navigation service such that if no store is provided in the config, we use a memory store by default.

This was tested by using the provided bad config below and confirming that it does not panic on startup.  Prior to this fix this same config would cause a panic

```
  {
  "components": [
    {
      "name": "basey",
      "model": "fake",
      "type": "base",
      "namespace": "rdk",
      "attributes": {},
      "depends_on": []
    },
    {
      "name": "movie",
      "model": "fake",
      "type": "movement_sensor",
      "namespace": "rdk",
      "attributes": {},
      "depends_on": []
    }
  ],
  "services": [
    {
      "name": "navy",
      "type": "navigation",
      "namespace": "rdk",
      "attributes": {
        "base": "basey",
        "movement_sensor": "movie",
        "motion_service": "builtin"
      }
    }
  ]
}
```

