### PR TITLE
RSDK-5108: change Ceil to Floor for GroupWorkParallel

### DIFF
--- a/utils/parallel.go
+++ b/utils/parallel.go
@@ -44,9 +44,9 @@ type (
 func GroupWorkParallel(ctx context.Context, totalSize int, before BeforeParallelGroupWorkFunc, groupWork GroupWorkFunc) error {
 	extra := 0
 	if totalSize > ParallelFactor {
-		extra = totalSize % ParallelFactor
+		extra = (totalSize % ParallelFactor)
 	}
-	groupSize := int(math.Ceil(float64(totalSize) / float64(ParallelFactor)))
+	groupSize := int(math.Floor(float64(totalSize) / float64(ParallelFactor)))
 
 	numGroups := ParallelFactor
 	before(numGroups)

--- a/utils/parallel.go
+++ b/utils/parallel.go
@@ -44,7 +44,7 @@ type (
 func GroupWorkParallel(ctx context.Context, totalSize int, before BeforeParallelGroupWorkFunc, groupWork GroupWorkFunc) error {
 	extra := 0
 	if totalSize > ParallelFactor {
-		extra = (totalSize % ParallelFactor)
+		extra = totalSize % ParallelFactor
 	}
 	groupSize := int(math.Floor(float64(totalSize) / float64(ParallelFactor)))
 

--- a/utils/parallel_test.go
+++ b/utils/parallel_test.go
@@ -37,3 +37,39 @@ func TestRunInParallel(t *testing.T) {
 	_, err = RunInParallel(context.Background(), []SimpleFunc{panicFunc})
 	test.That(t, err, test.ShouldNotBeNil)
 }
+
+func TestGroupWorkParallel(t *testing.T) {
+	// Add one slice of ones with another slice of twos and see if the sum of the entire result is correct.
+	N := 5001
+	sliceA := make([]int, N)
+	sliceB := make([]int, N)
+	for i := 0; i < N; i++ {
+		sliceA[i] = 1
+		sliceB[i] = 2
+	}
+	var results []int
+	err := GroupWorkParallel(
+		context.Background(),
+		N,
+		func(numGroups int) {
+			results = make([]int, numGroups)
+		},
+		func(groupNum, groupSize, from, to int) (MemberWorkFunc, GroupWorkDoneFunc) {
+			mySum := 0
+			return func(memberNum, workNum int) {
+					a := sliceA[workNum]
+					b := sliceB[workNum]
+					mySum += a + b
+				}, func() {
+					results[groupNum] = mySum
+				}
+		},
+	)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, len(results), test.ShouldEqual, ParallelFactor)
+	total := 0
+	for _, ans := range results {
+		total += ans
+	}
+	test.That(t, total, test.ShouldEqual, 3*N)
+}


### PR DESCRIPTION
A typo of Ceil vs Floor sometimes caused groupSize to be bigger than it needed to be, which both caused double counting sometimes, and also sometimes caused access to an index beyond the length of the inputs.