### PR TITLE
RSDK-5171 List board definitions packages in CLI 

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -654,7 +654,7 @@ viam module upload --version "0.1.0" --platform "linux/amd64" packaged-module.ta
 					Usage: "upload a board definition file",
 					Description: `Upload a json board definition file for linux boards.
 Example:
-viam board upload --name=orin --org="my org" --version=1.0.0 file.json`,
+viam board upload --name=orin --organization="my org" --version=1.0.0 file.json`,
 					UsageText: "viam board upload <name> <organization> <version> [other options] <file.json>",
 					Flags: []cli.Flag{
 						&cli.StringFlag{
@@ -699,6 +699,22 @@ viam board download --name=test --organization="my org" --version=1.0.0`,
 						},
 					},
 					Action: DownloadBoardDefsAction,
+				},
+				{
+					Name:  "list",
+					Usage: "list all board defintions packages",
+					Description: `list the board defintions packages available from an organization.
+Example:
+viam board list --organization="my org"`,
+					UsageText: "viam board list <organization>[other options]",
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:     organizationFlag,
+							Usage:    "organization that hosts the board definitions files",
+							Required: true,
+						},
+					},
+					Action: ListBoardDefsAction,
 				},
 			},
 		},


### PR DESCRIPTION
CLI command to list the name and version of board definitions packages that are in an organization. 

example output:
<img width="567" alt="Screenshot 2023-09-27 at 3 51 39 PM" src="https://github.com/viamrobotics/rdk/assets/106617921/4683134e-0228-44b0-8a29-e4841b6e1263">

