### PR TITLE
RSDK-5197 - Don't stop module server on web reconfigure 

### DIFF
--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -208,7 +208,7 @@ func (r *localRobot) StartWeb(ctx context.Context, o weboptions.Options) (err er
 
 // StopWeb stops the web server, will be a noop if server is not up.
 func (r *localRobot) StopWeb(ctx context.Context) error {
-	return r.webSvc.Close(ctx)
+	return r.webSvc.Stop()
 }
 
 // WebAddress return the web service's address.

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -207,8 +207,8 @@ func (r *localRobot) StartWeb(ctx context.Context, o weboptions.Options) (err er
 }
 
 // StopWeb stops the web server, will be a noop if server is not up.
-func (r *localRobot) StopWeb(ctx context.Context) error {
-	return r.webSvc.Stop()
+func (r *localRobot) StopWeb() {
+	r.webSvc.Stop()
 }
 
 // WebAddress return the web service's address.

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
-
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	armpb "go.viam.com/api/component/arm/v1"

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
+
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	armpb "go.viam.com/api/component/arm/v1"
@@ -2164,7 +2165,7 @@ func TestReconnectRemote(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	// close/disconnect the robot
-	test.That(t, robot.StopWeb(context.Background()), test.ShouldBeNil)
+	robot.StopWeb()
 	test.That(t, <-remoteRobotClient.Changed(), test.ShouldBeTrue)
 	test.That(t, len(remoteRobotClient.ResourceNames()), test.ShouldEqual, 0)
 	testutils.WaitForAssertion(t, func(tb testing.TB) {

--- a/robot/robot.go
+++ b/robot/robot.go
@@ -101,7 +101,7 @@ type LocalRobot interface {
 	StartWeb(ctx context.Context, o weboptions.Options) error
 
 	// StopWeb stops the web server, will be a noop if server is not up.
-	StopWeb(ctx context.Context) error
+	StopWeb()
 
 	// WebAddress returns the address of the web service.
 	WebAddress() (string, error)

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -188,7 +188,7 @@ type Service interface {
 	Start(context.Context, weboptions.Options) error
 
 	// Stop stops the main web service (but leaves module server socket running.)
-	Stop() error
+	Stop()
 
 	// StartModule starts the module server socket.
 	StartModule(context.Context) error
@@ -410,11 +410,10 @@ func (svc *webService) updateResources(resources map[resource.Name]resource.Reso
 }
 
 // Stop stops the main web service prior to actually closing (it leaves the module server running.)
-func (svc *webService) Stop() error {
+func (svc *webService) Stop() {
 	svc.mu.Lock()
 	defer svc.mu.Unlock()
 	svc.stopWeb()
-	return nil
 }
 
 func (svc *webService) stopWeb() {

--- a/robot/web/web_notc.go
+++ b/robot/web/web_notc.go
@@ -33,19 +33,20 @@ func New(r robot.Robot, logger golog.Logger, opts ...Option) Service {
 type webService struct {
 	resource.Named
 
-	mu                      sync.Mutex
-	r                       robot.Robot
-	rpcServer               rpc.Server
-	modServer               rpc.Server
-	services                map[resource.API]resource.APIResourceCollection[resource.Resource]
-	opts                    options
-	addr                    string
-	modAddr                 string
-	logger                  golog.Logger
-	cancelCtx               context.Context
-	cancelFunc              func()
-	isRunning               bool
-	activeBackgroundWorkers sync.WaitGroup
+	mu         sync.Mutex
+	r          robot.Robot
+	rpcServer  rpc.Server
+	modServer  rpc.Server
+	services   map[resource.API]resource.APIResourceCollection[resource.Resource]
+	opts       options
+	addr       string
+	modAddr    string
+	logger     golog.Logger
+	cancelCtx  context.Context
+	cancelFunc func()
+	isRunning  bool
+	webWorkers sync.WaitGroup
+	modWorkers sync.WaitGroup
 }
 
 // Update updates the web service when the robot has changed.

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -397,10 +397,7 @@ func (s *robotServer) serveWeb(ctx context.Context, cfg *config.Config) (err err
 
 				if !diff.NetworkEqual {
 					// TODO(RSDK-2694): use internal web service reconfiguration instead
-					if err := myRobot.StopWeb(ctx); err != nil {
-						s.logger.Errorw("reconfiguration failed: error stopping web service while reconfiguring", "error", err)
-						continue
-					}
+					myRobot.StopWeb()
 					options, err = s.createWebOptions(processedConfig)
 					if err != nil {
 						s.logger.Errorw("reconfiguration aborted: error creating weboptions", "error", err)


### PR DESCRIPTION
causes really bad issues if someone ever changes the network config and so restarts the web server

as part of this, updated some of the internal interfaces since web.Stop won't ever return an error.

also split up web workers and mod workers so the Wait() is preserved when StopWeb is called