### PR TITLE
[RSDK-5198] Change units in UR driver to match config field units

### DIFF
--- a/components/arm/universalrobots/ur.go
+++ b/components/arm/universalrobots/ur.go
@@ -4,6 +4,7 @@ package universalrobots
 import (
 	"bufio"
 	"context"
+
 	// for embedding model file.
 	_ "embed"
 	"encoding/binary"
@@ -116,7 +117,7 @@ func (ua *URArm) Reconfigure(ctx context.Context, deps resource.Dependencies, co
 		}
 		return nil
 	}
-	ua.speed = newConf.SpeedDegsPerSec
+	ua.speed = rdkutils.DegToRad(newConf.SpeedDegsPerSec)
 	ua.urHostedKinematics = newConf.ArmHostedKinematics
 	return nil
 }
@@ -419,7 +420,7 @@ func (ua *URArm) MoveToJointPositionRadians(ctx context.Context, radians []float
 		radians[3],
 		radians[4],
 		radians[5],
-		ua.speed,
+		0.8*ua.speed,
 		ua.speed,
 	)
 

--- a/components/arm/universalrobots/ur.go
+++ b/components/arm/universalrobots/ur.go
@@ -420,8 +420,8 @@ func (ua *URArm) MoveToJointPositionRadians(ctx context.Context, radians []float
 		radians[3],
 		radians[4],
 		radians[5],
-		5.0*ua.speed,
-		4.0*ua.speed,
+		ua.speed,
+		ua.speed,
 	)
 
 	_, err := ua.connControl.Write([]byte(cmd))

--- a/components/arm/universalrobots/ur.go
+++ b/components/arm/universalrobots/ur.go
@@ -88,7 +88,7 @@ type URArm struct {
 	state                    RobotState
 	runtimeError             error
 	inRemoteMode             bool
-	speed                    float64
+	speedRadPerSec           float64
 	urHostedKinematics       bool
 	dashboardConnection      net.Conn
 	readRobotStateConnection net.Conn
@@ -117,7 +117,7 @@ func (ua *URArm) Reconfigure(ctx context.Context, deps resource.Dependencies, co
 		}
 		return nil
 	}
-	ua.speed = rdkutils.DegToRad(newConf.SpeedDegsPerSec)
+	ua.speedRadPerSec = rdkutils.DegToRad(newConf.SpeedDegsPerSec)
 	ua.urHostedKinematics = newConf.ArmHostedKinematics
 	return nil
 }
@@ -186,7 +186,7 @@ func URArmConnect(ctx context.Context, conf resource.Config, logger golog.Logger
 	newArm := &URArm{
 		Named:                    conf.ResourceName().AsNamed(),
 		connControl:              nil,
-		speed:                    rdkutils.DegToRad(newConf.SpeedDegsPerSec),
+		speedRadPerSec:           rdkutils.DegToRad(newConf.SpeedDegsPerSec),
 		debug:                    false,
 		haveData:                 false,
 		logger:                   logger,
@@ -387,7 +387,7 @@ func (ua *URArm) Stop(ctx context.Context, extra map[string]interface{}) error {
 	}
 	_, done := ua.opMgr.New(ctx)
 	defer done()
-	cmd := fmt.Sprintf("stopj(a=%1.2f)\r\n", 5.0*ua.speed)
+	cmd := fmt.Sprintf("stopj(a=%1.2f)\r\n", 5.0*ua.speedRadPerSec)
 
 	_, err := ua.connControl.Write([]byte(cmd))
 	return err
@@ -420,8 +420,8 @@ func (ua *URArm) MoveToJointPositionRadians(ctx context.Context, radians []float
 		radians[3],
 		radians[4],
 		radians[5],
-		0.8*ua.speed,
-		ua.speed,
+		0.8*ua.speedRadPerSec,
+		ua.speedRadPerSec,
 	)
 
 	_, err := ua.connControl.Write([]byte(cmd))

--- a/components/arm/universalrobots/ur.go
+++ b/components/arm/universalrobots/ur.go
@@ -47,8 +47,8 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 	if cfg.Host == "" {
 		return nil, goutils.NewConfigValidationFieldRequiredError(path, "host")
 	}
-	if cfg.SpeedDegsPerSec > 180 || cfg.SpeedDegsPerSec < 18 {
-		return nil, errors.New("speed for universalrobots has to be between 18 and 180 degrees per second")
+	if cfg.SpeedDegsPerSec > 180 || cfg.SpeedDegsPerSec < 3 {
+		return nil, errors.New("speed for universalrobots has to be between 3 and 180 degrees per second")
 	}
 	return []string{}, nil
 }

--- a/components/arm/universalrobots/ur.go
+++ b/components/arm/universalrobots/ur.go
@@ -4,6 +4,7 @@ package universalrobots
 import (
 	"bufio"
 	"context"
+
 	// for embedding model file.
 	_ "embed"
 	"encoding/binary"
@@ -21,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 	pb "go.viam.com/api/component/arm/v1"
+	rdkutils "go.viam.com/rdk/utils"
 	goutils "go.viam.com/utils"
 
 	"go.viam.com/rdk/components/arm"
@@ -46,7 +48,7 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 	if cfg.Host == "" {
 		return nil, goutils.NewConfigValidationFieldRequiredError(path, "host")
 	}
-	if cfg.Speed > 1 || cfg.Speed < .1 {
+	if cfg.Speed > 180 || cfg.Speed < 18 {
 		return nil, errors.New("speed for universalrobots has to be between .1 and 1")
 	}
 	return []string{}, nil
@@ -165,10 +167,6 @@ func URArmConnect(ctx context.Context, conf resource.Config, logger golog.Logger
 		return nil, err
 	}
 
-	if newConf.Speed > 1 || newConf.Speed < .1 {
-		return nil, errors.New("speed for universalrobots has to be between .1 and 1")
-	}
-
 	model, err := MakeModelFrame(conf.Name)
 	if err != nil {
 		return nil, err
@@ -188,7 +186,7 @@ func URArmConnect(ctx context.Context, conf resource.Config, logger golog.Logger
 	newArm := &URArm{
 		Named:                    conf.ResourceName().AsNamed(),
 		connControl:              nil,
-		speed:                    newConf.Speed,
+		speed:                    rdkutils.DegToRad(newConf.Speed),
 		debug:                    false,
 		haveData:                 false,
 		logger:                   logger,

--- a/components/arm/universalrobots/ur.go
+++ b/components/arm/universalrobots/ur.go
@@ -49,7 +49,7 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 		return nil, goutils.NewConfigValidationFieldRequiredError(path, "host")
 	}
 	if cfg.Speed > 180 || cfg.Speed < 18 {
-		return nil, errors.New("speed for universalrobots has to be between .1 and 1")
+		return nil, errors.New("speed for universalrobots has to be between 18 and 180 degrees per second")
 	}
 	return []string{}, nil
 }

--- a/components/arm/universalrobots/ur.go
+++ b/components/arm/universalrobots/ur.go
@@ -4,7 +4,6 @@ package universalrobots
 import (
 	"bufio"
 	"context"
-
 	// for embedding model file.
 	_ "embed"
 	"encoding/binary"

--- a/components/arm/universalrobots/ur.go
+++ b/components/arm/universalrobots/ur.go
@@ -4,7 +4,6 @@ package universalrobots
 import (
 	"bufio"
 	"context"
-
 	// for embedding model file.
 	_ "embed"
 	"encoding/binary"
@@ -22,7 +21,6 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 	pb "go.viam.com/api/component/arm/v1"
-	rdkutils "go.viam.com/rdk/utils"
 	goutils "go.viam.com/utils"
 
 	"go.viam.com/rdk/components/arm"
@@ -31,6 +29,7 @@ import (
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/spatialmath"
+	rdkutils "go.viam.com/rdk/utils"
 )
 
 // Model is the name of the UR5e model of an arm component.
@@ -38,7 +37,7 @@ var Model = resource.DefaultModelFamily.WithModel("ur5e")
 
 // Config is used for converting config attributes.
 type Config struct {
-	Speed               float64 `json:"speed_degs_per_sec"`
+	SpeedDegsPerSec     float64 `json:"speed_degs_per_sec"`
 	Host                string  `json:"host"`
 	ArmHostedKinematics bool    `json:"arm_hosted_kinematics,omitempty"`
 }
@@ -48,7 +47,7 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 	if cfg.Host == "" {
 		return nil, goutils.NewConfigValidationFieldRequiredError(path, "host")
 	}
-	if cfg.Speed > 180 || cfg.Speed < 18 {
+	if cfg.SpeedDegsPerSec > 180 || cfg.SpeedDegsPerSec < 18 {
 		return nil, errors.New("speed for universalrobots has to be between 18 and 180 degrees per second")
 	}
 	return []string{}, nil
@@ -117,7 +116,7 @@ func (ua *URArm) Reconfigure(ctx context.Context, deps resource.Dependencies, co
 		}
 		return nil
 	}
-	ua.speed = newConf.Speed
+	ua.speed = newConf.SpeedDegsPerSec
 	ua.urHostedKinematics = newConf.ArmHostedKinematics
 	return nil
 }
@@ -186,7 +185,7 @@ func URArmConnect(ctx context.Context, conf resource.Config, logger golog.Logger
 	newArm := &URArm{
 		Named:                    conf.ResourceName().AsNamed(),
 		connControl:              nil,
-		speed:                    rdkutils.DegToRad(newConf.Speed),
+		speed:                    rdkutils.DegToRad(newConf.SpeedDegsPerSec),
 		debug:                    false,
 		haveData:                 false,
 		logger:                   logger,

--- a/components/arm/universalrobots/ur5e_test.go
+++ b/components/arm/universalrobots/ur5e_test.go
@@ -424,7 +424,7 @@ func TestReconfigure(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	ur5e := &URArm{
-		speedRadPerSec:              conf.SpeedDegsPerSec,
+		speedRadPerSec:     conf.SpeedDegsPerSec,
 		urHostedKinematics: conf.ArmHostedKinematics,
 		host:               conf.Host,
 	}

--- a/components/arm/universalrobots/ur5e_test.go
+++ b/components/arm/universalrobots/ur5e_test.go
@@ -424,17 +424,17 @@ func TestReconfigure(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	ur5e := &URArm{
-		speed:              conf.SpeedDegsPerSec,
+		speedRadPerSec:              conf.SpeedDegsPerSec,
 		urHostedKinematics: conf.ArmHostedKinematics,
 		host:               conf.Host,
 	}
 
 	// scenario where we do not reconfigure
 	test.That(t, ur5e.Reconfigure(context.Background(), nil, conf1), test.ShouldBeNil)
-	test.That(t, ur5e.speed, test.ShouldEqual, 0.5)
+	test.That(t, ur5e.speedRadPerSec, test.ShouldEqual, 0.5)
 
 	// scenario where we have to configure
 	test.That(t, ur5e.Reconfigure(context.Background(), nil, conf2), test.ShouldBeNil)
-	test.That(t, ur5e.speed, test.ShouldEqual, 0.5)
+	test.That(t, ur5e.speedRadPerSec, test.ShouldEqual, 0.5)
 	test.That(t, ur5e.host, test.ShouldEqual, "new")
 }

--- a/components/arm/universalrobots/ur5e_test.go
+++ b/components/arm/universalrobots/ur5e_test.go
@@ -431,10 +431,10 @@ func TestReconfigure(t *testing.T) {
 
 	// scenario where we do not reconfigure
 	test.That(t, ur5e.Reconfigure(context.Background(), nil, conf1), test.ShouldBeNil)
-	test.That(t, ur5e.speedRadPerSec, test.ShouldEqual, 0.5)
+	test.That(t, ur5e.speedRadPerSec, test.ShouldEqual, utils.DegToRad(0.5))
 
 	// scenario where we have to configure
 	test.That(t, ur5e.Reconfigure(context.Background(), nil, conf2), test.ShouldBeNil)
-	test.That(t, ur5e.speedRadPerSec, test.ShouldEqual, 0.5)
+	test.That(t, ur5e.speedRadPerSec, test.ShouldEqual, utils.DegToRad(0.5))
 	test.That(t, ur5e.host, test.ShouldEqual, "new")
 }

--- a/components/arm/universalrobots/ur5e_test.go
+++ b/components/arm/universalrobots/ur5e_test.go
@@ -321,7 +321,7 @@ func TestArmReconnection(t *testing.T) {
 	cfg := resource.Config{
 		Name: "testarm",
 		ConvertedAttributes: &Config{
-			Speed:               0.3,
+			SpeedDegsPerSec:     0.3,
 			Host:                "localhost",
 			ArmHostedKinematics: false,
 		},
@@ -396,7 +396,7 @@ func TestReconfigure(t *testing.T) {
 	cfg := resource.Config{
 		Name: "testarm",
 		ConvertedAttributes: &Config{
-			Speed:               0.3,
+			SpeedDegsPerSec:     0.3,
 			Host:                "localhost",
 			ArmHostedKinematics: false,
 		},
@@ -405,7 +405,7 @@ func TestReconfigure(t *testing.T) {
 	conf1 := resource.Config{
 		Name: "testarm",
 		ConvertedAttributes: &Config{
-			Speed:               0.5,
+			SpeedDegsPerSec:     0.5,
 			Host:                "localhost",
 			ArmHostedKinematics: false,
 		},
@@ -414,7 +414,7 @@ func TestReconfigure(t *testing.T) {
 	conf2 := resource.Config{
 		Name: "testarm",
 		ConvertedAttributes: &Config{
-			Speed:               0.5,
+			SpeedDegsPerSec:     0.5,
 			Host:                "new",
 			ArmHostedKinematics: false,
 		},
@@ -424,7 +424,7 @@ func TestReconfigure(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	ur5e := &URArm{
-		speed:              conf.Speed,
+		speed:              conf.SpeedDegsPerSec,
 		urHostedKinematics: conf.ArmHostedKinematics,
 		host:               conf.Host,
 	}


### PR DESCRIPTION
What it says on the tin.

Max speed for ur5e from spec: https://www.universal-robots.com/media/1807465/ur5e-rgb-fact-sheet-landscape-a4.pdf
Movej API in URSCRIPT takes in rad/s for velocity and rad/s^2 for acceleration: https://s3-eu-west-1.amazonaws.com/ur-support-site/115824/scriptManual_SW5.11.pdf

- [x] Creating an app image too - I'd like someone to test this out on a ur5 in lab while I'm remote.