### PR TITLE
feat(cli/auth): allow disabling browser open during login

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -26,9 +26,9 @@ const (
 	apiKeyCreateFlagOrgID = "org-id"
 	apiKeyCreateFlagName  = "name"
 
-	loginBrowserFlag = "disable-browser-open"
-	loginFlagKeyID   = "key-id"
-	loginFlagKey     = "key"
+	loginFlagDisableBrowser = "disable-browser-open"
+	loginFlagKeyID          = "key-id"
+	loginFlagKey            = "key"
 
 	moduleFlagName            = "name"
 	moduleFlagPublicNamespace = "public-namespace"
@@ -93,7 +93,7 @@ var app = &cli.App{
 			HideHelpCommand: true,
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
-					Name:  loginBrowserFlag,
+					Name:  loginFlagDisableBrowser,
 					Usage: "prevent opening the default browser during login",
 				},
 			},

--- a/cli/app.go
+++ b/cli/app.go
@@ -26,8 +26,9 @@ const (
 	apiKeyCreateFlagOrgID = "org-id"
 	apiKeyCreateFlagName  = "name"
 
-	loginFlagKeyID = "key-id"
-	loginFlagKey   = "key"
+	loginBrowserFlag = "disable-browser-open"
+	loginFlagKeyID   = "key-id"
+	loginFlagKey     = "key"
 
 	moduleFlagName            = "name"
 	moduleFlagPublicNamespace = "public-namespace"
@@ -90,7 +91,13 @@ var app = &cli.App{
 			Aliases:         []string{"auth"},
 			Usage:           "login to app.viam.com",
 			HideHelpCommand: true,
-			Action:          LoginAction,
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:  loginBrowserFlag,
+					Usage: "prevent opening the default browser during login",
+				},
+			},
+			Action: LoginAction,
 			Subcommands: []*cli.Command{
 				{
 					Name:   "print-access-token",

--- a/cli/auth.go
+++ b/cli/auth.go
@@ -494,7 +494,7 @@ func (a *authFlow) loginAsUser(ctx context.Context) (*token, error) {
 
 	err = a.directUser(deviceCode)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Unable to open the browser to complete the login flow due to \"%w\". You can use the --disable-browser-open flag to skip this behavior.", err)
 	}
 
 	token, err := a.waitForUser(ctx, deviceCode, discovery)

--- a/cli/auth.go
+++ b/cli/auth.go
@@ -459,24 +459,25 @@ type tokenErrorResponse struct {
 	ErrorDescription string `json:"error_description"`
 }
 
-func newCLIAuthFlow(console io.Writer) *authFlow {
-	return newCLIAuthFlowWithAuthDomain(prodAuthDomain, prodAudience, prodClientID, console)
+func newCLIAuthFlow(console io.Writer, disableBrowserOpen bool) *authFlow {
+	return newCLIAuthFlowWithAuthDomain(prodAuthDomain, prodAudience, prodClientID, console, disableBrowserOpen)
 }
 
-func newStgCLIAuthFlow(console io.Writer) *authFlow {
-	return newCLIAuthFlowWithAuthDomain(stgAuthDomain, stgAudience, stgClientID, console)
+func newStgCLIAuthFlow(console io.Writer, disableBrowserOpen bool) *authFlow {
+	return newCLIAuthFlowWithAuthDomain(stgAuthDomain, stgAudience, stgClientID, console, disableBrowserOpen)
 }
 
-func newCLIAuthFlowWithAuthDomain(authDomain, audience, clientID string, console io.Writer) *authFlow {
+func newCLIAuthFlowWithAuthDomain(authDomain, audience, clientID string, console io.Writer, disableBrowserOpen bool) *authFlow {
 	return &authFlow{
 		clientID:              clientID,
 		scopes:                []string{"email", "openid", "offline_access"},
 		audience:              audience,
 		oidcDiscoveryEndpoint: fmt.Sprintf("%s%s", authDomain, defaultOpenIDDiscoveryPath),
 
-		httpClient: &http.Client{Timeout: time.Second * 30},
-		logger:     golog.Global(),
-		console:    console,
+		disableBrowserOpen: disableBrowserOpen,
+		httpClient:         &http.Client{Timeout: time.Second * 30},
+		logger:             golog.Global(),
+		console:            console,
 	}
 }
 

--- a/cli/auth.go
+++ b/cli/auth.go
@@ -494,7 +494,8 @@ func (a *authFlow) loginAsUser(ctx context.Context) (*token, error) {
 
 	err = a.directUser(deviceCode)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to open the browser to complete the login flow due to \"%w\". You can use the --disable-browser-open flag to skip this behavior.", err)
+		return nil, fmt.Errorf("unable to open the browser to complete the login flow due to %w."+
+			"You can use the --%s flag to skip this behavior", err, loginFlagDisableBrowser)
 	}
 
 	token, err := a.waitForUser(ctx, deviceCode, discovery)

--- a/cli/client.go
+++ b/cli/client.go
@@ -491,10 +491,11 @@ func newViamClient(c *cli.Context) (*viamClient, error) {
 	}
 
 	var authFlow *authFlow
+	disableBrowserOpen := c.Bool(loginBrowserFlag)
 	if isProdBaseURL(baseURL) {
-		authFlow = newCLIAuthFlow(c.App.Writer)
+		authFlow = newCLIAuthFlow(c.App.Writer, disableBrowserOpen)
 	} else {
-		authFlow = newStgCLIAuthFlow(c.App.Writer)
+		authFlow = newStgCLIAuthFlow(c.App.Writer, disableBrowserOpen)
 	}
 
 	return &viamClient{

--- a/cli/client.go
+++ b/cli/client.go
@@ -491,7 +491,7 @@ func newViamClient(c *cli.Context) (*viamClient, error) {
 	}
 
 	var authFlow *authFlow
-	disableBrowserOpen := c.Bool(loginBrowserFlag)
+	disableBrowserOpen := c.Bool(loginFlagDisableBrowser)
 	if isProdBaseURL(baseURL) {
 		authFlow = newCLIAuthFlow(c.App.Writer, disableBrowserOpen)
 	} else {


### PR DESCRIPTION
A person in the Viam discord ran into an error while trying to authenticate with the CLI in a "headless" environment, i.e. Rapsbian Lite or Linux VM, due to the default behavior for opening a browser before waiting for a response from the app to confirm a successful login. 

I noticed an existing field in the `authFlow` struct for disabling this behavior but it wasn't exposed as a CLI flag. This PR exposes a new `--disable-browser-open` boolean flag to `viam login` to resolve the issue described above. 

Please let me know if there's a better way to add this behavior. 

Help text:

<img width="713" alt="image" src="https://github.com/viamrobotics/rdk/assets/3051193/9024359f-c5eb-4e04-9bee-bd2e412fe321">

Error handling:
![image](https://github.com/viamrobotics/rdk/assets/3051193/2f4331e4-f20a-4699-9fd5-c566df552fcb)
