### PR TITLE
[RSDK-4810] Integrate StopPlan and MoveOnGlobeNew with execution_id system

### DIFF
--- a/services/motion/builtin/state/state.go
+++ b/services/motion/builtin/state/state.go
@@ -1,0 +1,635 @@
+// Package state provides apis for motion builtin plan executions
+// and manages the state of those executions
+package state
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	geo "github.com/kellydunn/golang-geo"
+	"github.com/pkg/errors"
+	"go.viam.com/utils"
+
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/services/motion"
+	"go.viam.com/rdk/spatialmath"
+)
+
+var (
+	// ErrUnknownResource indicates that the resource is not known.
+	ErrUnknownResource = errors.New("unknown resource")
+	// ErrNotFound indicates the entity was not found.
+	ErrNotFound  = errors.New("not found")
+	replanReason = "replanning"
+)
+
+type componentState struct {
+	executionIDHistory []motion.ExecutionID
+	executionsByID     map[motion.ExecutionID]stateExecution
+}
+
+type newPlanMsg struct {
+	plan       motion.Plan
+	planStatus motion.PlanStatus
+}
+
+type stateUpdateMsg struct {
+	componentName resource.Name
+	executionID   motion.ExecutionID
+	planID        motion.PlanID
+	planStatus    motion.PlanStatus
+}
+
+// a stateExecution is the struct held in the state that
+// holds the history of plans & plan status updates an
+// execution has exprienced & the waitGroup & cancelFunc
+// required to shut down an execution's goroutine.
+type stateExecution struct {
+	id            motion.ExecutionID
+	componentName resource.Name
+	waitGroup     *sync.WaitGroup
+	cancelFunc    context.CancelFunc
+	history       []motion.PlanWithStatus
+}
+
+func (e *stateExecution) stop() {
+	e.cancelFunc()
+	e.waitGroup.Wait()
+}
+
+func (cs componentState) lastExecution() stateExecution {
+	return cs.executionsByID[cs.lastExecutionID()]
+}
+
+func (cs componentState) lastExecutionID() motion.ExecutionID {
+	return cs.executionIDHistory[0]
+}
+
+// ExecutionReq is the request type for StartExecution.
+type ExecutionReq struct {
+	ComponentName      resource.Name
+	Destination        *geo.Point
+	Heading            float64
+	MovementSensorName resource.Name
+	Obstacles          []*spatialmath.GeoObstacle
+	MotionCfg          *motion.MotionConfiguration
+	Extra              map[string]interface{}
+}
+
+// NewExecutionReq creates an ExecutionReq from a motion.MoveOnGlobeReq.
+func NewExecutionReq(req motion.MoveOnGlobeReq) ExecutionReq {
+	return ExecutionReq{
+		ComponentName:      req.ComponentName,
+		Destination:        req.Destination,
+		Heading:            req.Heading,
+		MovementSensorName: req.MovementSensorName,
+		Obstacles:          req.Obstacles,
+		MotionCfg:          req.MotionCfg,
+		Extra:              req.Extra,
+	}
+}
+
+// execution represents the state of a motion planning execution.
+// it only ever exists in state.StartExecution function & the go routine created
+// its `start()` method.
+type execution struct {
+	id            motion.ExecutionID
+	state         *State
+	componentName resource.Name
+	waitGroup     *sync.WaitGroup
+	cancelCtx     context.Context
+	cancelFunc    context.CancelFunc
+	testConfig    *TestConfig
+	logger        logging.Logger
+}
+
+// NewPlan creates a new motion.Plan from an execution & returns an error if one was not able to be created.
+func (e *execution) newPlan() (motion.Plan, error) {
+	// TODO: Generate steps
+	if e.testConfig.newPlanFailReason != nil {
+		return motion.Plan{}, errors.New(*e.testConfig.newPlanFailReason)
+	}
+	return motion.Plan{ID: uuid.New(), ExecutionID: e.id, ComponentName: e.componentName}, nil
+}
+
+// Start starts an execution with a given plan.
+func (e *execution) start(originalPlan motion.Plan) error {
+	if err := e.notifyStateNewExecution(e.toStateExecution(), originalPlan, time.Now()); err != nil {
+		return err
+	}
+
+	// We need to add to both the state & execution waitgroups
+	// B/c both the state & the stateExecution need to know if this
+	// goroutine have termianted.
+	// state.Stop() needs to wait for ALL execution goroutines to terminate before
+	// returning in order to not leak.
+	// Similarly stateExecution.stop(), which is called by state.StopExecutionByResource
+	// needs to wait for its 1 execution go routine to termiante before returning.
+	// As a result, both waitgroups need to be written to.
+	e.state.waitGroup.Add(1)
+	e.waitGroup.Add(1)
+
+	utils.PanicCapturingGo(func() {
+		defer e.state.waitGroup.Done()
+		defer e.waitGroup.Done()
+
+		lastPlan := originalPlan
+
+		// The exit conditions include:
+		// 1. The execution's context was cancelled, which happens if the state's Stop() was called or
+		// StopExecutionByResource was called for this resource
+		// 2. replanning failed
+		// 3. the execution failed
+		// 4. the execution succeeded
+		// 5. failing to notify the state struct for any reason (should never happen)
+		for {
+			if err := e.cancelCtx.Err(); err != nil {
+				e.logger.Debugf("context done due to %s\n", err)
+				return
+			}
+
+			select {
+			case <-e.cancelCtx.Done():
+				e.logger.Debugf("context done due to %s\n", e.cancelCtx.Err())
+				return
+				// simulates replanning
+			case rr := <-e.testConfig.ReplanRequestChan:
+				e.logger.Debug("replanning")
+				if rr.FailReason != nil {
+					if err := e.notifyStatePlanFailed(lastPlan, *rr.FailReason, time.Now()); err != nil {
+						e.logger.Error(*rr.FailReason)
+					}
+					e.testConfig.ReplanResponseChan <- struct{}{}
+					return
+				}
+				newPlan, err := e.newPlan()
+				if err != nil {
+					msg := "failed to replan for execution %s and component: %s, setting previous plan %s to failed due to error: %s\n"
+					e.logger.Warnf(msg, e.id, e.componentName, lastPlan.ID, err.Error())
+
+					if err := e.notifyStatePlanFailed(lastPlan, err.Error(), time.Now()); err != nil {
+						e.logger.Error(err.Error())
+					}
+					e.testConfig.ReplanResponseChan <- struct{}{}
+					return
+				}
+
+				e.logger.Debugf("updating last plan %s\n", lastPlan.ID)
+				if err := e.notifyStatePlanFailed(lastPlan, replanReason, time.Now()); err != nil {
+					e.logger.Error(err.Error())
+					e.testConfig.ReplanResponseChan <- struct{}{}
+					return
+				}
+				e.logger.Debugf("updating new plan %s\n", newPlan.ID.String())
+				if err = e.notifyStateNewPlan(newPlan, time.Now()); err != nil {
+					e.logger.Error(err.Error())
+					e.testConfig.ReplanResponseChan <- struct{}{}
+					return
+				}
+				lastPlan = newPlan
+				e.testConfig.ReplanResponseChan <- struct{}{}
+
+				// simulates plan reaching terminal state
+			case er := <-e.testConfig.ExecutionRequestChan:
+				if er.FailReason != nil {
+					e.logger.Debugf("plan failed %#v\n", lastPlan)
+					if err := e.notifyStatePlanFailed(lastPlan, *er.FailReason, time.Now()); err != nil {
+						e.logger.Error(err.Error())
+						e.testConfig.ExecutionResponseChan <- struct{}{}
+						return
+					}
+					e.testConfig.ExecutionResponseChan <- struct{}{}
+					return
+				}
+
+				e.logger.Debugf("plan succeeded %#v\n", lastPlan)
+				if err := e.notifyStatePlanSucceeded(lastPlan, time.Now()); err != nil {
+					e.logger.Error(err.Error())
+					e.testConfig.ExecutionResponseChan <- struct{}{}
+					return
+				}
+				e.testConfig.ExecutionResponseChan <- struct{}{}
+				return
+			}
+		}
+	})
+
+	return nil
+}
+
+func (e *execution) toStateExecution() stateExecution {
+	return stateExecution{
+		id:            e.id,
+		componentName: e.componentName,
+		waitGroup:     e.waitGroup,
+		cancelFunc:    e.cancelFunc,
+	}
+}
+
+// NOTE: We hold the lock for both updateStateNewExecution & updateStateNewPlan to ensure no readers
+// are able to see a state where the execution exists but does not have a plan with a status.
+func (e *execution) notifyStateNewExecution(execution stateExecution, plan motion.Plan, time time.Time) error {
+	e.state.mu.Lock()
+	defer e.state.mu.Unlock()
+
+	if err := e.state.updateStateNewExecution(execution); err != nil {
+		return err
+	}
+
+	msg := newPlanMsg{
+		plan:       plan,
+		planStatus: motion.PlanStatus{State: motion.PlanStateInProgress, Timestamp: time},
+	}
+	if err := e.state.updateStateNewPlan(msg); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e *execution) notifyStateNewPlan(plan motion.Plan, time time.Time) error {
+	e.state.mu.Lock()
+	defer e.state.mu.Unlock()
+	return e.state.updateStateNewPlan(newPlanMsg{
+		plan:       plan,
+		planStatus: motion.PlanStatus{State: motion.PlanStateInProgress, Timestamp: time},
+	})
+}
+
+func (e *execution) notifyStatePlanFailed(plan motion.Plan, reason string, time time.Time) error {
+	e.state.mu.Lock()
+	defer e.state.mu.Unlock()
+	return e.state.updateStateStatusUpdate(stateUpdateMsg{
+		componentName: e.componentName,
+		executionID:   e.id,
+		planID:        plan.ID,
+		planStatus:    motion.PlanStatus{State: motion.PlanStateFailed, Timestamp: time, Reason: &reason},
+	})
+}
+
+func (e *execution) notifyStatePlanSucceeded(plan motion.Plan, time time.Time) error {
+	e.state.mu.Lock()
+	defer e.state.mu.Unlock()
+	return e.state.updateStateStatusUpdate(stateUpdateMsg{
+		componentName: e.componentName,
+		executionID:   e.id,
+		planID:        plan.ID,
+		planStatus:    motion.PlanStatus{State: motion.PlanStateSucceeded, Timestamp: time},
+	})
+}
+
+// State is the state of the builtin motion service
+// It keeps track of the builtin motion service's executions.
+type State struct {
+	waitGroup  *sync.WaitGroup
+	cancelCtx  context.Context
+	cancelFunc context.CancelFunc
+	logger     logging.Logger
+	// mu protects the componentStateByComponent
+	mu                        sync.RWMutex
+	componentStateByComponent map[resource.Name]componentState
+}
+
+// NewState creates a new state.
+func NewState(ctx context.Context, logger logging.Logger) *State {
+	cancelCtx, cancelFunc := context.WithCancel(ctx)
+	s := State{
+		cancelCtx:                 cancelCtx,
+		cancelFunc:                cancelFunc,
+		waitGroup:                 &sync.WaitGroup{},
+		componentStateByComponent: make(map[resource.Name]componentState),
+		logger:                    logger,
+	}
+	return &s
+}
+
+// StartExecution creates a new execution from a state.
+func (s *State) StartExecution(req ExecutionReq, tc *TestConfig) (motion.ExecutionID, error) {
+	if err := s.validateNoActiveExecutionID(req.ComponentName); err != nil {
+		return uuid.Nil, err
+	}
+
+	// the state being cancelled should cause all executions derived from that state to also be cancelled
+	cancelCtx, cancelFunc := context.WithCancel(s.cancelCtx)
+	e := execution{
+		id:            uuid.New(),
+		state:         s,
+		componentName: req.ComponentName,
+		cancelCtx:     cancelCtx,
+		cancelFunc:    cancelFunc,
+		waitGroup:     &sync.WaitGroup{},
+		logger:        s.logger,
+		testConfig:    addExtra(tc, req.Extra),
+	}
+
+	p, err := e.newPlan()
+	if err != nil {
+		return uuid.Nil, err
+	}
+
+	if err := e.start(p); err != nil {
+		return uuid.Nil, err
+	}
+
+	return e.id, nil
+}
+
+// Stop stops all executions within the State.
+func (s *State) Stop() {
+	s.cancelFunc()
+	s.waitGroup.Wait()
+}
+
+// StopExecutionByResource stops the active execution with a given resource name in the State.
+func (s *State) StopExecutionByResource(componentName resource.Name) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	componentExectionState, exists := s.componentStateByComponent[componentName]
+
+	// return error if component name is not in StateMap
+	if !exists {
+		return ErrUnknownResource
+	}
+
+	e, exists := componentExectionState.executionsByID[componentExectionState.lastExecutionID()]
+	if !exists {
+		return ErrNotFound
+	}
+
+	// NOTE: This is going to hold the write lock on the state until the execution terminates.
+	// If the execution go routine is not checking the cancelCtx regularly, this could result in the
+	// state lock being held for a long time.
+	e.stop()
+
+	msg := stateUpdateMsg{
+		componentName: e.componentName,
+		executionID:   e.id,
+		planID:        e.history[0].Plan.ID,
+		planStatus:    motion.PlanStatus{State: motion.PlanStateStopped, Timestamp: time.Now()},
+	}
+
+	if err := s.updateStateStatusStopped(msg); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// PlanHistory returns the plans with statuses of the resource
+// By default returns all plans from the most recent execution of the resoure
+// If the ExecutionID is provided, returns the plans of the ExecutionID rather
+// than the most recent execution
+// If LastPlanOnly is provided then only the last plan is returned for the execution
+// with the ExecutionID if it is provided, or the last execution
+// for that component otherwise.
+func (s *State) PlanHistory(req motion.PlanHistoryReq) ([]motion.PlanWithStatus, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	cs, exists := s.componentStateByComponent[req.ComponentName]
+	if !exists {
+		return nil, ErrUnknownResource
+	}
+
+	executionID := req.ExecutionID
+
+	// last plan only
+	if req.LastPlanOnly {
+		if ex := cs.lastExecution(); executionID == uuid.Nil || executionID == ex.id {
+			history := make([]motion.PlanWithStatus, 1)
+			copy(history, ex.history)
+			return history, nil
+		}
+
+		// if executionID is provided & doesn't match the last execution for the component
+		if ex, exists := cs.executionsByID[executionID]; exists {
+			history := make([]motion.PlanWithStatus, 1)
+			copy(history, ex.history)
+			return history, nil
+		}
+		return nil, ErrNotFound
+	}
+
+	// specific execution id when lastPlanOnly is NOT enabled
+	if executionID != uuid.Nil {
+		if ex, exists := cs.executionsByID[executionID]; exists {
+			history := make([]motion.PlanWithStatus, len(ex.history))
+			copy(history, ex.history)
+			return history, nil
+		}
+		return nil, ErrNotFound
+	}
+
+	ex := cs.lastExecution()
+	history := make([]motion.PlanWithStatus, len(cs.lastExecution().history))
+	copy(history, ex.history)
+	return history, nil
+}
+
+// ListPlanStatuses returns the status of plans created by MoveOnGlobe requests
+// that are executing OR are part of an execution which changed it state
+// within the a 24HR TTL OR until the robot reinitializes.
+// If OnlyActivePlans is provided, only returns plans which are in non terminal states.
+func (s *State) ListPlanStatuses(req motion.ListPlanStatusesReq) ([]motion.PlanStatusWithID, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	statuses := []motion.PlanStatusWithID{}
+	if req.OnlyActivePlans {
+		for name := range s.componentStateByComponent {
+			if e, err := s.activeExecution(name); err == nil {
+				statuses = append(statuses, motion.PlanStatusWithID{
+					ExecutionID:   e.id,
+					ComponentName: e.componentName,
+					PlanID:        e.history[0].Plan.ID,
+					Status:        e.history[0].StatusHistory[0],
+				})
+			}
+		}
+		return statuses, nil
+	}
+
+	for _, cs := range s.componentStateByComponent {
+		for _, executionID := range cs.executionIDHistory {
+			e, exists := cs.executionsByID[executionID]
+			if !exists {
+				return nil, errors.New("state is corrupted")
+			}
+			for _, pws := range e.history {
+				statuses = append(statuses, motion.PlanStatusWithID{
+					ExecutionID:   e.id,
+					ComponentName: e.componentName,
+					PlanID:        pws.Plan.ID,
+					Status:        pws.StatusHistory[0],
+				})
+			}
+		}
+	}
+
+	return statuses, nil
+}
+
+// validateNoActiveExecutionID returns an error if there is already an active
+// Execution for the resource name within the State.
+func (s *State) validateNoActiveExecutionID(name resource.Name) error {
+	if es, err := s.activeExecution(name); err == nil {
+		return fmt.Errorf("there is already an active executionID: %s", es.id)
+	}
+	return nil
+}
+
+func (s *State) updateStateNewExecution(newE stateExecution) error {
+	cs, exists := s.componentStateByComponent[newE.componentName]
+
+	if exists {
+		_, exists = cs.executionsByID[newE.id]
+		if exists {
+			return fmt.Errorf("unexpected ExecutionID already exists %s", newE.id)
+		}
+		cs.executionsByID[newE.id] = newE
+		cs.executionIDHistory = append([]motion.ExecutionID{newE.id}, cs.executionIDHistory...)
+		s.componentStateByComponent[newE.componentName] = cs
+	} else {
+		s.componentStateByComponent[newE.componentName] = componentState{
+			executionIDHistory: []motion.ExecutionID{newE.id},
+			executionsByID:     map[motion.ExecutionID]stateExecution{newE.id: newE},
+		}
+	}
+	return nil
+}
+
+func (s *State) updateStateNewPlan(newPlan newPlanMsg) error {
+	if newPlan.planStatus.State != motion.PlanStateInProgress {
+		return errors.New("handleNewPlan received a plan status other than in progress")
+	}
+
+	activeExecutionID := s.componentStateByComponent[newPlan.plan.ComponentName].lastExecutionID()
+	if newPlan.plan.ExecutionID != activeExecutionID {
+		e := "got new plan for inactive execution: active executionID %s, planID: %s, component: %s, plan executionID: %s"
+		return fmt.Errorf(e, activeExecutionID, newPlan.plan.ID, newPlan.plan.ComponentName, newPlan.plan.ExecutionID)
+	}
+	execution := s.componentStateByComponent[newPlan.plan.ComponentName].executionsByID[newPlan.plan.ExecutionID]
+	pws := []motion.PlanWithStatus{{Plan: newPlan.plan, StatusHistory: []motion.PlanStatus{newPlan.planStatus}}}
+	// prepend  to executions.history so that lower indices are newer
+	execution.history = append(pws, execution.history...)
+
+	s.componentStateByComponent[newPlan.plan.ComponentName].executionsByID[newPlan.plan.ExecutionID] = execution
+	return nil
+}
+
+func (s *State) updateStateStatusUpdate(update stateUpdateMsg) error {
+	switch update.planStatus.State {
+	// terminal states
+	case motion.PlanStateSucceeded, motion.PlanStateFailed:
+	default:
+		return fmt.Errorf("unexpected PlanState %v in update %#v", update.planStatus.State, update)
+	}
+	componentExecutions, exists := s.componentStateByComponent[update.componentName]
+	if !exists {
+		return errors.New("updated component doesn't exist")
+	}
+	// copy the execution
+	execution := componentExecutions.executionsByID[update.executionID]
+	lastPlanWithStatus := execution.history[0]
+	if lastPlanWithStatus.Plan.ID != update.planID {
+		return fmt.Errorf("status update for plan %s is not for last plan: %s", update.planID, lastPlanWithStatus.Plan.ID)
+	}
+	lastPlanWithStatus.StatusHistory = append([]motion.PlanStatus{update.planStatus}, lastPlanWithStatus.StatusHistory...)
+	// write updated last plan back to history
+	execution.history[0] = lastPlanWithStatus
+	// write the execution with the new history to the component execution state copy
+	componentExecutions.executionsByID[update.executionID] = execution
+	// write the component execution state copy back to the state
+	s.componentStateByComponent[update.componentName] = componentExecutions
+
+	return nil
+}
+
+// NOTE: This doesn't take locks as the caller already has the lock.
+func (s *State) updateStateStatusStopped(update stateUpdateMsg) error {
+	if update.planStatus.State != motion.PlanStateStopped {
+		return fmt.Errorf("unexpected PlanState %v in update %#v", update.planStatus.State, update)
+	}
+	// copy the execution state of the component
+	componentExecutions, exists := s.componentStateByComponent[update.componentName]
+	if !exists {
+		return errors.New("updated component doesn't exist")
+	}
+	// // set the copy's activeExecutionID to nil
+	// componentExecutions.executionIDHistory = uuid.Nil
+	// copy the execution
+	execution := componentExecutions.executionsByID[update.executionID]
+	lastPlanWithStatus := execution.history[0]
+	if lastPlanWithStatus.Plan.ID != update.planID {
+		return fmt.Errorf("status update for plan %s is not for last plan: %s", update.planID, lastPlanWithStatus.Plan.ID)
+	}
+	lastPlanWithStatus.StatusHistory = append([]motion.PlanStatus{update.planStatus}, lastPlanWithStatus.StatusHistory...)
+	// write updated last plan back to history
+	execution.history[0] = lastPlanWithStatus
+	// write the execution with the new history to the component execution state copy
+	componentExecutions.executionsByID[update.executionID] = execution
+	// write the component execution state copy back to the state
+	s.componentStateByComponent[update.componentName] = componentExecutions
+
+	return nil
+}
+
+func (s *State) activeExecution(name resource.Name) (stateExecution, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if cs, exists := s.componentStateByComponent[name]; exists {
+		es := cs.lastExecution()
+
+		if _, exists := motion.TerminalStateSet[es.history[0].StatusHistory[0].State]; exists {
+			return stateExecution{}, ErrNotFound
+		}
+		return es, nil
+	}
+	return stateExecution{}, ErrUnknownResource
+}
+
+// ReplanRequest is a temporary struct that triggers the execution to replan
+// if FailReason is non nil then the replanning will fail.
+type ReplanRequest struct {
+	FailReason *string
+}
+
+// ExecutionRequest is a temporary struct that triggers the end of an execution
+// if FailReason is non nil then the execution will fail.
+type ExecutionRequest struct {
+	// if nil then the execution succeeded
+	FailReason *string
+}
+
+// TestConfig is a temporary struct that holds channels for testing execution replanning, success & failure.
+type TestConfig struct {
+	// ReplanRequestChan is the channel written to trigger replanning
+	ReplanRequestChan chan ReplanRequest
+	// ReplanResponseChan is written to by the execution after replanning has completed
+	ReplanResponseChan chan struct{}
+	// ExecutionRequestChan is the channel written to trigger execution termination
+	ExecutionRequestChan chan ExecutionRequest
+	// ExecutionResponseChan is written to by the execution after the execution has terminated
+	ExecutionResponseChan chan struct{}
+	newPlanFailReason     *string
+}
+
+func addExtra(tc *TestConfig, extra map[string]interface{}) *TestConfig {
+	if tc == nil {
+		tc = &TestConfig{}
+	}
+	for k, v := range extra {
+		if k == "new_plan_fail_reason" {
+			reason, ok := v.(string)
+			if ok {
+				tc.newPlanFailReason = &reason
+			}
+		}
+	}
+
+	return tc
+}

--- a/services/motion/builtin/state/state_test.go
+++ b/services/motion/builtin/state/state_test.go
@@ -1,0 +1,466 @@
+package state_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/golang/geo/r3"
+	"github.com/google/uuid"
+	geo "github.com/kellydunn/golang-geo"
+	"github.com/pkg/errors"
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/components/base"
+	"go.viam.com/rdk/components/movementsensor"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/services/motion"
+	"go.viam.com/rdk/services/motion/builtin/state"
+	"go.viam.com/rdk/spatialmath"
+)
+
+var replanReason = "replanning"
+
+func TestState(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	myBase := base.Named("mybase")
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("creating & stopping a state with no intermediary calls", func(t *testing.T) {
+		t.Parallel()
+		s := state.NewState(ctx, logger)
+		defer s.Stop()
+	})
+
+	t.Run("starting a new execution & stopping the state", func(t *testing.T) {
+		t.Parallel()
+		s := state.NewState(ctx, logger)
+		defer s.Stop()
+		req := state.NewExecutionReq(motion.MoveOnGlobeReq{ComponentName: myBase})
+		_, err := s.StartExecution(req, nil)
+		test.That(t, err, test.ShouldBeNil)
+	})
+
+	t.Run("starting & stopping an execution & stopping the state", func(t *testing.T) {
+		t.Parallel()
+		s := state.NewState(ctx, logger)
+		defer s.Stop()
+
+		req := state.NewExecutionReq(motion.MoveOnGlobeReq{ComponentName: myBase})
+		_, err := s.StartExecution(req, nil)
+		test.That(t, err, test.ShouldBeNil)
+
+		err = s.StopExecutionByResource(myBase)
+		test.That(t, err, test.ShouldBeNil)
+	})
+
+	t.Run("stopping an execution is idempotnet", func(t *testing.T) {
+		t.Parallel()
+		s := state.NewState(ctx, logger)
+		defer s.Stop()
+		req := state.NewExecutionReq(motion.MoveOnGlobeReq{ComponentName: myBase})
+		_, err := s.StartExecution(req, nil)
+		test.That(t, err, test.ShouldBeNil)
+
+		err = s.StopExecutionByResource(myBase)
+		test.That(t, err, test.ShouldBeNil)
+		err = s.StopExecutionByResource(myBase)
+		test.That(t, err, test.ShouldBeNil)
+	})
+
+	t.Run("stopping the state is idempotnet", func(t *testing.T) {
+		t.Parallel()
+		s := state.NewState(ctx, logger)
+		defer s.Stop()
+		req := state.NewExecutionReq(motion.MoveOnGlobeReq{ComponentName: myBase})
+		_, err := s.StartExecution(req, nil)
+		test.That(t, err, test.ShouldBeNil)
+
+		s.Stop()
+		s.Stop()
+	})
+
+	t.Run("stopping an execution after stopping the state", func(t *testing.T) {
+		t.Parallel()
+		s := state.NewState(ctx, logger)
+		defer s.Stop()
+		req := state.NewExecutionReq(motion.MoveOnGlobeReq{ComponentName: myBase})
+		_, err := s.StartExecution(req, nil)
+		test.That(t, err, test.ShouldBeNil)
+
+		s.Stop()
+
+		err = s.StopExecutionByResource(myBase)
+		test.That(t, err, test.ShouldBeNil)
+	})
+
+	t.Run("querying for an unknown resource returns an unknown resource error", func(t *testing.T) {
+		t.Parallel()
+		s := state.NewState(ctx, logger)
+		defer s.Stop()
+		req := state.NewExecutionReq(motion.MoveOnGlobeReq{ComponentName: myBase})
+		_, err := s.StartExecution(req, nil)
+		test.That(t, err, test.ShouldBeNil)
+		_, err = s.PlanHistory(motion.PlanHistoryReq{})
+		test.That(t, err, test.ShouldBeError, state.ErrUnknownResource)
+	})
+
+	t.Run("end to end test", func(t *testing.T) {
+		t.Parallel()
+		s := state.NewState(ctx, logger)
+		defer s.Stop()
+
+		// no plan statuses as no executions have been created
+		ps, err := s.ListPlanStatuses(motion.ListPlanStatusesReq{})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, ps, test.ShouldBeEmpty)
+
+		preExecution := time.Now()
+		// Failing to plan the first time results in an error
+		errPlanningFailed := errors.New("some reason to fail planning")
+		extra := map[string]interface{}{"new_plan_fail_reason": errPlanningFailed.Error()}
+		req := state.NewExecutionReq(motion.MoveOnGlobeReq{ComponentName: myBase, Extra: extra})
+		id, err := s.StartExecution(req, nil)
+		test.That(t, err, test.ShouldBeError, errPlanningFailed)
+		test.That(t, id, test.ShouldResemble, uuid.Nil)
+
+		// still no plan statuses as no executions have been created
+		ps2, err := s.ListPlanStatuses(motion.ListPlanStatusesReq{})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, ps2, test.ShouldBeEmpty)
+
+		req = state.NewExecutionReq(motion.MoveOnGlobeReq{ComponentName: myBase})
+		executionID1, err := s.StartExecution(req, nil)
+		test.That(t, err, test.ShouldBeNil)
+
+		// we now have a single plan status as an execution has been created
+		ps3, err := s.ListPlanStatuses(motion.ListPlanStatusesReq{})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(ps3), test.ShouldEqual, 1)
+		test.That(t, ps3[0].ExecutionID, test.ShouldResemble, executionID1)
+		test.That(t, ps3[0].ComponentName, test.ShouldResemble, req.ComponentName)
+		test.That(t, ps3[0].PlanID, test.ShouldNotEqual, uuid.Nil)
+		test.That(t, ps3[0].Status.State, test.ShouldEqual, motion.PlanStateInProgress)
+		test.That(t, ps3[0].Status.Reason, test.ShouldBeNil)
+		test.That(t, ps3[0].Status.Timestamp.After(preExecution), test.ShouldBeTrue)
+
+		id, err = s.StartExecution(req, nil)
+		test.That(t, err, test.ShouldBeError, fmt.Errorf("there is already an active executionID: %s", executionID1))
+		test.That(t, id, test.ShouldResemble, uuid.Nil)
+
+		// Returns results if active plans are requested & there are active plans
+		ps4, err := s.ListPlanStatuses(motion.ListPlanStatusesReq{OnlyActivePlans: true})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, ps4, test.ShouldResemble, ps3)
+
+		// We see that the component has an excution with a single plan & that plan
+		// is in progress & has had no other statuses.
+		pws, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(pws), test.ShouldEqual, 1)
+		// plan id is the same as it was in the list status response
+		test.That(t, pws[0].Plan.ID, test.ShouldResemble, ps3[0].PlanID)
+		test.That(t, pws[0].Plan.ExecutionID, test.ShouldEqual, executionID1)
+		test.That(t, pws[0].Plan.ComponentName, test.ShouldResemble, myBase)
+		test.That(t, len(pws[0].StatusHistory), test.ShouldEqual, 1)
+		test.That(t, pws[0].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateInProgress)
+		test.That(t, pws[0].StatusHistory[0].Reason, test.ShouldEqual, nil)
+		test.That(t, pws[0].StatusHistory[0].Timestamp.After(preExecution), test.ShouldBeTrue)
+
+		preStop := time.Now()
+		err = s.StopExecutionByResource(myBase)
+		test.That(t, err, test.ShouldBeNil)
+
+		ps5, err := s.ListPlanStatuses(motion.ListPlanStatusesReq{})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(ps5), test.ShouldEqual, 1)
+		test.That(t, ps5[0].ExecutionID, test.ShouldResemble, executionID1)
+		test.That(t, ps5[0].ComponentName, test.ShouldResemble, req.ComponentName)
+		test.That(t, ps5[0].PlanID, test.ShouldNotEqual, uuid.Nil)
+		// status now shows that the plan is stopped
+		test.That(t, ps5[0].Status.State, test.ShouldEqual, motion.PlanStateStopped)
+		test.That(t, ps5[0].Status.Reason, test.ShouldBeNil)
+		test.That(t, ps5[0].Status.Timestamp.After(preStop), test.ShouldBeTrue)
+
+		// Returns no results if active plans are requested & there are no active plans
+		ps6, err := s.ListPlanStatuses(motion.ListPlanStatusesReq{OnlyActivePlans: true})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, ps6, test.ShouldBeEmpty)
+
+		// We after stoping execution of the base that the same execution has the same
+		// plan, but that that plan's status is now stoped.
+		// The prior status is still in the status history.
+		pws2, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase})
+		test.That(t, err, test.ShouldBeNil)
+
+		test.That(t, len(pws2), test.ShouldEqual, 1)
+		test.That(t, pws2[0].Plan, test.ShouldResemble, pws[0].Plan)
+		test.That(t, len(pws2[0].StatusHistory), test.ShouldEqual, 2)
+		test.That(t, pws2[0].StatusHistory[1], test.ShouldResemble, pws[0].StatusHistory[0])
+		test.That(t, pws2[0].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateStopped)
+		test.That(t, pws2[0].StatusHistory[0].Reason, test.ShouldEqual, nil)
+		test.That(t, pws2[0].StatusHistory[0].Timestamp.After(pws2[0].StatusHistory[1].Timestamp), test.ShouldBeTrue)
+
+		preExecution2 := time.Now()
+		tc2 := &state.TestConfig{
+			ReplanRequestChan:     make(chan state.ReplanRequest),
+			ReplanResponseChan:    make(chan struct{}),
+			ExecutionRequestChan:  make(chan state.ExecutionRequest),
+			ExecutionResponseChan: make(chan struct{}),
+		}
+		executionID2, err := s.StartExecution(req, tc2)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, executionID2, test.ShouldNotResemble, executionID1)
+
+		// We see after starting a new execution that the old execution is no longer returned and that a new plan has been generated
+		pws4, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(pws4), test.ShouldEqual, 1)
+		test.That(t, pws4[0].Plan.ID, test.ShouldNotResemble, pws2[0].Plan.ID)
+		test.That(t, pws4[0].Plan.ExecutionID, test.ShouldNotResemble, pws2[0].Plan.ExecutionID)
+		test.That(t, len(pws4[0].StatusHistory), test.ShouldEqual, 1)
+		test.That(t, pws4[0].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateInProgress)
+		test.That(t, pws4[0].StatusHistory[0].Reason, test.ShouldEqual, nil)
+		test.That(t, pws4[0].StatusHistory[0].Timestamp.After(preExecution2), test.ShouldBeTrue)
+
+		// trigger replanning once
+		execution2Replan1 := time.Now()
+		tc2.ReplanRequestChan <- state.ReplanRequest{}
+		<-tc2.ReplanResponseChan
+
+		pws5, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(pws5), test.ShouldEqual, 2)
+		// Previous plan is moved to higher index
+		test.That(t, pws5[1].Plan, test.ShouldResemble, pws4[0].Plan)
+		// Current plan is a new plan
+		test.That(t, pws5[0].Plan.ID, test.ShouldNotResemble, pws4[0].Plan.ID)
+		// From the same execution (definition of a replan)
+		test.That(t, pws5[0].Plan.ExecutionID, test.ShouldResemble, pws4[0].Plan.ExecutionID)
+		// new current plan has an in progress status & was created after triggering replanning
+		test.That(t, len(pws5[0].StatusHistory), test.ShouldEqual, 1)
+		test.That(t, pws5[0].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateInProgress)
+		test.That(t, pws5[0].StatusHistory[0].Reason, test.ShouldEqual, nil)
+		test.That(t, pws5[0].StatusHistory[0].Timestamp.After(execution2Replan1), test.ShouldBeTrue)
+		// previous plan was moved to failed state due to replanning after replanning was triggered
+		test.That(t, len(pws5[1].StatusHistory), test.ShouldEqual, 2)
+		// oldest satus of previous plan is unchanged, just at a higher index
+		test.That(t, pws5[1].StatusHistory[1], test.ShouldResemble, pws4[0].StatusHistory[0])
+		// last status of the previous plan is failed due to replanning & occurred after replanning was triggered
+		test.That(t, pws5[1].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateFailed)
+		test.That(t, pws5[1].StatusHistory[0].Reason, test.ShouldNotBeNil)
+		test.That(t, *pws5[1].StatusHistory[0].Reason, test.ShouldResemble, replanReason)
+		test.That(t, pws5[1].StatusHistory[0].Timestamp.After(execution2Replan1), test.ShouldBeTrue)
+
+		// only the last plan is returned if LastPlanOnly is true
+		pws6, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase, LastPlanOnly: true})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(pws6), test.ShouldEqual, 1)
+		test.That(t, pws6[0], test.ShouldResemble, pws5[0])
+
+		// only the last plan is returned if LastPlanOnly is true
+		// and the execution id is provided which matches the last execution for the component
+		pws7, err := s.PlanHistory(motion.PlanHistoryReq{
+			ComponentName: myBase,
+			LastPlanOnly:  true,
+			ExecutionID:   pws6[0].Plan.ExecutionID,
+		})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, pws7, test.ShouldResemble, pws6)
+
+		// Succeeded status
+		preSuccessMsg := time.Now()
+		tc2.ExecutionRequestChan <- state.ExecutionRequest{}
+		<-tc2.ExecutionResponseChan
+		pws8, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(pws8), test.ShouldEqual, 2)
+		// last plan is unchanged
+		test.That(t, pws8[1], test.ShouldResemble, pws5[1])
+		// current plan is the same as it was before
+		test.That(t, pws8[0].Plan, test.ShouldResemble, pws6[0].Plan)
+		// current plan now has a new status
+		test.That(t, len(pws8[0].StatusHistory), test.ShouldEqual, 2)
+		test.That(t, pws8[0].StatusHistory[1], test.ShouldResemble, pws6[0].StatusHistory[0])
+		// new status is succeeded
+		test.That(t, pws8[0].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateSucceeded)
+		test.That(t, pws8[0].StatusHistory[0].Reason, test.ShouldBeNil)
+		test.That(t, pws8[0].StatusHistory[0].Timestamp.After(preSuccessMsg), test.ShouldBeTrue)
+
+		// Failed after replanning
+		tc3 := &state.TestConfig{
+			ReplanRequestChan:     make(chan state.ReplanRequest),
+			ReplanResponseChan:    make(chan struct{}),
+			ExecutionRequestChan:  make(chan state.ExecutionRequest),
+			ExecutionResponseChan: make(chan struct{}),
+		}
+		preExecution3 := time.Now()
+		executionID3, err := s.StartExecution(req, tc3)
+		test.That(t, err, test.ShouldBeNil)
+
+		// first replan succeeds
+		execution3Replan1 := time.Now()
+		tc3.ReplanRequestChan <- state.ReplanRequest{}
+		<-tc3.ReplanResponseChan
+
+		// second replan fails
+		execution3Replan2 := time.Now()
+		replanFailReason := "replanning failed under test"
+		tc3.ReplanRequestChan <- state.ReplanRequest{FailReason: &replanFailReason}
+		<-tc3.ReplanResponseChan
+
+		pws9, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase})
+		test.That(t, err, test.ShouldBeNil)
+
+		test.That(t, len(pws9), test.ShouldEqual, 2)
+		test.That(t, pws9[0].Plan.ExecutionID, test.ShouldEqual, executionID3)
+		test.That(t, pws9[1].Plan.ExecutionID, test.ShouldEqual, executionID3)
+		test.That(t, pws9[0].Plan.ID, test.ShouldNotEqual, pws8[1].Plan.ID)
+		test.That(t, len(pws9[1].StatusHistory), test.ShouldEqual, 2)
+		test.That(t, pws9[1].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateFailed)
+		test.That(t, *pws9[1].StatusHistory[0].Reason, test.ShouldResemble, replanReason)
+		test.That(t, pws9[1].StatusHistory[0].Timestamp.After(execution3Replan1), test.ShouldBeTrue)
+		test.That(t, pws9[1].StatusHistory[1].State, test.ShouldEqual, motion.PlanStateInProgress)
+		test.That(t, pws9[1].StatusHistory[1].Reason, test.ShouldBeNil)
+		test.That(t, pws9[1].StatusHistory[1].Timestamp.After(preExecution3), test.ShouldBeTrue)
+		test.That(t, len(pws9[0].StatusHistory), test.ShouldEqual, 2)
+		test.That(t, pws9[0].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateFailed)
+		test.That(t, *pws9[0].StatusHistory[0].Reason, test.ShouldResemble, replanFailReason)
+		test.That(t, pws9[0].StatusHistory[0].Timestamp.After(execution3Replan2), test.ShouldBeTrue)
+		test.That(t, pws9[0].StatusHistory[1].State, test.ShouldEqual, motion.PlanStateInProgress)
+		test.That(t, pws9[0].StatusHistory[1].Reason, test.ShouldBeNil)
+		test.That(t, pws9[0].StatusHistory[1].Timestamp.After(execution3Replan1), test.ShouldBeTrue)
+
+		// Failed at the end of execution
+		tc4 := &state.TestConfig{
+			ReplanRequestChan:     make(chan state.ReplanRequest),
+			ReplanResponseChan:    make(chan struct{}),
+			ExecutionRequestChan:  make(chan state.ExecutionRequest),
+			ExecutionResponseChan: make(chan struct{}),
+		}
+		preExecution4 := time.Now()
+		executionID4, err := s.StartExecution(req, tc4)
+		test.That(t, err, test.ShouldBeNil)
+
+		// first replan succeeds
+		execution4Replan := time.Now()
+		tc4.ReplanRequestChan <- state.ReplanRequest{}
+		<-tc4.ReplanResponseChan
+
+		// then execution fails
+		execution4ExecutionFail := time.Now()
+		executionFailReason := "execution failed under test"
+		tc4.ExecutionRequestChan <- state.ExecutionRequest{FailReason: &executionFailReason}
+		<-tc4.ExecutionResponseChan
+
+		pws10, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase})
+		test.That(t, err, test.ShouldBeNil)
+
+		test.That(t, len(pws10), test.ShouldEqual, 2)
+		test.That(t, pws10[0].Plan.ExecutionID, test.ShouldEqual, executionID4)
+		test.That(t, pws10[1].Plan.ExecutionID, test.ShouldEqual, executionID4)
+		test.That(t, pws10[0].Plan.ID, test.ShouldNotEqual, pws9[1].Plan.ID)
+		test.That(t, len(pws10[1].StatusHistory), test.ShouldEqual, 2)
+		test.That(t, pws10[1].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateFailed)
+		test.That(t, *pws10[1].StatusHistory[0].Reason, test.ShouldResemble, replanReason)
+		test.That(t, pws10[1].StatusHistory[0].Timestamp.After(execution4Replan), test.ShouldBeTrue)
+		test.That(t, pws10[1].StatusHistory[1].State, test.ShouldEqual, motion.PlanStateInProgress)
+		test.That(t, pws10[1].StatusHistory[1].Reason, test.ShouldBeNil)
+		test.That(t, pws10[1].StatusHistory[1].Timestamp.After(preExecution4), test.ShouldBeTrue)
+		test.That(t, len(pws10[0].StatusHistory), test.ShouldEqual, 2)
+		test.That(t, pws10[0].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateFailed)
+		test.That(t, *pws10[0].StatusHistory[0].Reason, test.ShouldResemble, executionFailReason)
+		test.That(t, pws10[0].StatusHistory[0].Timestamp.After(execution4ExecutionFail), test.ShouldBeTrue)
+		test.That(t, pws10[0].StatusHistory[1].State, test.ShouldEqual, motion.PlanStateInProgress)
+		test.That(t, pws10[0].StatusHistory[1].Reason, test.ShouldBeNil)
+		test.That(t, pws10[0].StatusHistory[1].Timestamp.After(execution4Replan), test.ShouldBeTrue)
+
+		// providing an executionID lets you look up the plans from a prior execution
+		pws12, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase, ExecutionID: executionID3})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, pws12, test.ShouldResemble, pws9)
+
+		// providing an executionID with lastPlanOnly gives you the last plan of that execution
+		pws13, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase, ExecutionID: executionID3, LastPlanOnly: true})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(pws13), test.ShouldEqual, 1)
+		test.That(t, pws13[0], test.ShouldResemble, pws9[0])
+
+		// providing an executionID which is not known to the state returns an error
+		pws14, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase, ExecutionID: uuid.New()})
+		test.That(t, err, test.ShouldBeError, state.ErrNotFound)
+		test.That(t, len(pws14), test.ShouldEqual, 0)
+
+		// Returns the last status of all plans that have executed
+		ps7, err := s.ListPlanStatuses(motion.ListPlanStatusesReq{})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(ps7), test.ShouldEqual, 7)
+		test.That(t, ps7[0].ComponentName, test.ShouldResemble, myBase)
+		test.That(t, ps7[0].ExecutionID, test.ShouldResemble, executionID4)
+		test.That(t, ps7[0].PlanID, test.ShouldResemble, pws10[0].Plan.ID)
+		test.That(t, ps7[0].Status, test.ShouldResemble, pws10[0].StatusHistory[0])
+
+		test.That(t, ps7[1].ComponentName, test.ShouldResemble, myBase)
+		test.That(t, ps7[1].ExecutionID, test.ShouldResemble, executionID4)
+		test.That(t, ps7[1].PlanID, test.ShouldResemble, pws10[1].Plan.ID)
+		test.That(t, ps7[1].Status, test.ShouldResemble, pws10[1].StatusHistory[0])
+
+		test.That(t, ps7[2].ComponentName, test.ShouldResemble, myBase)
+		test.That(t, ps7[2].ExecutionID, test.ShouldResemble, executionID3)
+		test.That(t, ps7[2].PlanID, test.ShouldResemble, pws9[0].Plan.ID)
+		test.That(t, ps7[2].Status, test.ShouldResemble, pws9[0].StatusHistory[0])
+
+		test.That(t, ps7[3].ComponentName, test.ShouldResemble, myBase)
+		test.That(t, ps7[3].ExecutionID, test.ShouldResemble, executionID3)
+		test.That(t, ps7[3].PlanID, test.ShouldResemble, pws9[1].Plan.ID)
+		test.That(t, ps7[3].Status, test.ShouldResemble, pws9[1].StatusHistory[0])
+
+		test.That(t, ps7[4].ComponentName, test.ShouldResemble, myBase)
+		test.That(t, ps7[4].ExecutionID, test.ShouldResemble, executionID2)
+		test.That(t, ps7[4].PlanID, test.ShouldResemble, pws8[0].Plan.ID)
+		test.That(t, ps7[4].Status, test.ShouldResemble, pws8[0].StatusHistory[0])
+
+		test.That(t, ps7[5].ComponentName, test.ShouldResemble, myBase)
+		test.That(t, ps7[5].ExecutionID, test.ShouldResemble, executionID2)
+		test.That(t, ps7[5].PlanID, test.ShouldResemble, pws8[1].Plan.ID)
+		test.That(t, ps7[5].Status, test.ShouldResemble, pws8[1].StatusHistory[0])
+
+		test.That(t, ps7[6].ComponentName, test.ShouldResemble, myBase)
+		test.That(t, ps7[6].ExecutionID, test.ShouldResemble, executionID1)
+		test.That(t, ps7[6].PlanID, test.ShouldResemble, pws2[0].Plan.ID)
+		test.That(t, ps7[6].Status, test.ShouldResemble, pws2[0].StatusHistory[0])
+
+		ps8, err := s.ListPlanStatuses(motion.ListPlanStatusesReq{OnlyActivePlans: true})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, ps8, test.ShouldBeEmpty)
+	})
+}
+
+func TestNewExecutionReq(t *testing.T) {
+	b := base.Named("mybase")
+	ms := movementsensor.Named("mySensor")
+	geometries, err := spatialmath.NewBox(spatialmath.NewZeroPose(), r3.Vector{X: 5, Y: 50, Z: 10}, "wall")
+	test.That(t, err, test.ShouldBeNil)
+	gpsPoint := geo.NewPoint(-70, 40)
+	mogReq := motion.MoveOnGlobeReq{
+		ComponentName: b,
+		Heading:       1,
+		Destination:   geo.NewPoint(1, 2),
+		MotionCfg: &motion.MotionConfiguration{
+			PositionPollingFreqHz: 4,
+			ObstaclePollingFreqHz: 1,
+			PlanDeviationMM:       15,
+		},
+		Obstacles:          []*spatialmath.GeoObstacle{spatialmath.NewGeoObstacle(gpsPoint, []spatialmath.Geometry{geometries})},
+		MovementSensorName: ms,
+	}
+	req := state.NewExecutionReq(mogReq)
+	test.That(t, mogReq.ComponentName, test.ShouldResemble, req.ComponentName)
+	test.That(t, mogReq.Heading, test.ShouldAlmostEqual, req.Heading)
+	test.That(t, mogReq.Destination, test.ShouldResemble, req.Destination)
+	test.That(t, mogReq.MotionCfg, test.ShouldResemble, req.MotionCfg)
+	test.That(t, mogReq.Obstacles, test.ShouldResemble, req.Obstacles)
+	test.That(t, mogReq.MovementSensorName, test.ShouldResemble, req.MovementSensorName)
+}

--- a/services/motion/client_test.go
+++ b/services/motion/client_test.go
@@ -368,11 +368,9 @@ func TestClient(t *testing.T) {
 		})
 
 		t.Run("otherwise returns a slice of PlanStautsWithID", func(t *testing.T) {
-			planID, err := uuid.NewUUID()
-			test.That(t, err, test.ShouldBeNil)
+			planID := uuid.New()
 
-			executionID, err := uuid.NewUUID()
-			test.That(t, err, test.ShouldBeNil)
+			executionID := uuid.New()
 
 			status := motion.PlanStatus{State: motion.PlanStateInProgress, Timestamp: time.Now().UTC(), Reason: nil}
 
@@ -394,19 +392,16 @@ func TestClient(t *testing.T) {
 		})
 
 		t.Run("supports returning multiple PlanStautsWithID", func(t *testing.T) {
-			planIDA, err := uuid.NewUUID()
-			test.That(t, err, test.ShouldBeNil)
+			planIDA := uuid.New()
 
-			executionIDA, err := uuid.NewUUID()
+			executionIDA := uuid.New()
 			test.That(t, err, test.ShouldBeNil)
 
 			statusA := motion.PlanStatus{State: motion.PlanStateInProgress, Timestamp: time.Now().UTC(), Reason: nil}
 
-			planIDB, err := uuid.NewUUID()
-			test.That(t, err, test.ShouldBeNil)
+			planIDB := uuid.New()
 
-			executionIDB, err := uuid.NewUUID()
-			test.That(t, err, test.ShouldBeNil)
+			executionIDB := uuid.New()
 
 			reason := "failed reason"
 			statusB := motion.PlanStatus{State: motion.PlanStateInProgress, Timestamp: time.Now().UTC(), Reason: &reason}
@@ -458,10 +453,8 @@ func TestClient(t *testing.T) {
 				{base.Named("mybase"): zeroPose},
 			}
 			reason := "some reason"
-			id, err := uuid.NewUUID()
-			test.That(t, err, test.ShouldBeNil)
-			executionID, err := uuid.NewUUID()
-			test.That(t, err, test.ShouldBeNil)
+			id := uuid.New()
+			executionID := uuid.New()
 
 			timeA := time.Now().UTC()
 			timeB := time.Now().UTC()
@@ -491,10 +484,10 @@ func TestClient(t *testing.T) {
 			steps := []motion.PlanStep{{base.Named("mybase"): zeroPose}}
 			reason := "some reason"
 
-			idA, err := uuid.NewUUID()
+			idA := uuid.New()
 			test.That(t, err, test.ShouldBeNil)
 
-			executionID, err := uuid.NewUUID()
+			executionID := uuid.New()
 			test.That(t, err, test.ShouldBeNil)
 
 			timeAA := time.Now().UTC()
@@ -511,7 +504,7 @@ func TestClient(t *testing.T) {
 				{motion.PlanStateInProgress, timeAA, nil},
 			}
 
-			idB, err := uuid.NewUUID()
+			idB := uuid.New()
 			test.That(t, err, test.ShouldBeNil)
 			timeBA := time.Now().UTC()
 			planB := motion.Plan{

--- a/services/motion/motion.go
+++ b/services/motion/motion.go
@@ -34,7 +34,7 @@ func init() {
 type PlanHistoryReq struct {
 	ComponentName resource.Name
 	LastPlanOnly  bool
-	ExecutionID   uuid.UUID
+	ExecutionID   ExecutionID
 	Extra         map[string]interface{}
 }
 
@@ -76,9 +76,9 @@ type PlanStep map[resource.Name]spatialmath.Pose
 // Has a unique ID, ComponentName, ExecutionID and a sequence of Steps
 // which can be executed to follow the plan.
 type Plan struct {
-	ID            uuid.UUID
+	ID            PlanID
 	ComponentName resource.Name
-	ExecutionID   uuid.UUID
+	ExecutionID   ExecutionID
 	Steps         []PlanStep
 }
 
@@ -102,13 +102,27 @@ const (
 	PlanStateFailed
 )
 
+// TerminalStateSet is a set that defines the PlanState values which are terminal
+// i.e. which represent the end of a plan.
+var TerminalStateSet = map[PlanState]struct{}{
+	PlanStateStopped:   {},
+	PlanStateSucceeded: {},
+	PlanStateFailed:    {},
+}
+
+// PlanID uniquely identifies a Plan.
+type PlanID = uuid.UUID
+
+// ExecutionID uniquely identifies an execution.
+type ExecutionID = uuid.UUID
+
 // PlanStatusWithID describes the state of a given plan at a
 // point in time plus the PlanId, ComponentName and ExecutionID
 // the status is associated with.
 type PlanStatusWithID struct {
-	PlanID        uuid.UUID
+	PlanID        PlanID
 	ComponentName resource.Name
-	ExecutionID   uuid.UUID
+	ExecutionID   ExecutionID
 	Status        PlanStatus
 }
 

--- a/services/motion/motion_test.go
+++ b/services/motion/motion_test.go
@@ -25,11 +25,8 @@ import (
 )
 
 func TestPlanWithStatus(t *testing.T) {
-	planID, err := uuid.NewUUID()
-	test.That(t, err, test.ShouldBeNil)
-
-	executionID, err := uuid.NewUUID()
-	test.That(t, err, test.ShouldBeNil)
+	planID := uuid.New()
+	executionID := uuid.New()
 
 	baseName := base.Named("my-base1")
 	poseA := spatialmath.NewZeroPose()
@@ -331,8 +328,7 @@ func TestPlanStatusWithID(t *testing.T) {
 			err         error
 		}
 
-		id, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
+		id := uuid.New()
 
 		mybase := base.Named("mybase")
 		timestamp := time.Now().UTC()
@@ -421,8 +417,7 @@ func TestPlanStatusWithID(t *testing.T) {
 			result      *pb.PlanStatusWithID
 		}
 
-		id, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
+		id := uuid.New()
 
 		mybase := base.Named("mybase")
 		timestamp := time.Now().UTC()
@@ -602,11 +597,8 @@ func TestPlan(t *testing.T) {
 			err         error
 		}
 
-		planID, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
-
-		executionID, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
+		planID := uuid.New()
+		executionID := uuid.New()
 
 		baseName := base.Named("my-base1")
 		poseA := spatialmath.NewZeroPose()
@@ -711,11 +703,8 @@ func TestPlan(t *testing.T) {
 			result      *pb.Plan
 		}
 
-		planID, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
-
-		executionID, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
+		planID := uuid.New()
+		executionID := uuid.New()
 
 		baseName := base.Named("my-base1")
 		poseA := spatialmath.NewZeroPose()
@@ -901,7 +890,6 @@ func TestConfiguration(t *testing.T) {
 			input       *pb.MotionConfiguration
 			result      *MotionConfiguration
 		}
-
 		linearMPerSec := 1.
 		angularDegsPerSec := 2.
 		planDeviationMM := 3000.
@@ -1376,8 +1364,7 @@ func TestPlanHistoryReq(t *testing.T) {
 			err         error
 		}
 
-		executionID, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
+		executionID := uuid.New()
 		mybase := base.Named("mybase")
 		executionIDStr := executionID.String()
 
@@ -1432,8 +1419,7 @@ func TestPlanHistoryReq(t *testing.T) {
 			err         error
 		}
 
-		executionID, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
+		executionID := uuid.New()
 		mybase := base.Named("mybase")
 		executionIDStr := executionID.String()
 

--- a/services/motion/server_test.go
+++ b/services/motion/server_test.go
@@ -421,20 +421,11 @@ func TestServerListPlanStatuses(t *testing.T) {
 	})
 
 	t.Run("otherwise returns a success response", func(t *testing.T) {
-		executionID, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
-
-		planID1, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
-
-		planID2, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
-
-		planID3, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
-
-		planID4, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
+		executionID := uuid.New()
+		planID1 := uuid.New()
+		planID2 := uuid.New()
+		planID3 := uuid.New()
+		planID4 := uuid.New()
 
 		expectedComponentName := base.Named("test-base")
 		failedReason := "some reason for failure"
@@ -500,8 +491,7 @@ func TestServerGetPlan(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	expectedComponentName := base.Named("test-base")
-	uuidID, err := uuid.NewUUID()
-	test.That(t, err, test.ShouldBeNil)
+	uuidID := uuid.New()
 	id := uuidID.String()
 
 	validGetPlanRequest := &pb.GetPlanRequest{
@@ -539,14 +529,9 @@ func TestServerGetPlan(t *testing.T) {
 	})
 
 	t.Run("otherwise returns a success response", func(t *testing.T) {
-		executionID, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
-
-		planID1, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
-
-		planID2, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
+		executionID := uuid.New()
+		planID1 := uuid.New()
+		planID2 := uuid.New()
 
 		base1 := base.Named("base1")
 		steps := []motion.PlanStep{{base1: spatialmath.NewZeroPose()}}


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-4810) [Other Ticket](https://viam.atlassian.net/browse/RSDK-5158)

Note: 
The internals of the state package could definitely be more intuitive / better layed out. That said, I feel pretty good about the API of the package & the tests so I figure we can improve the internals as needed in the future. This PR is currently blocking the expose paths to users project so I figured getting something up for review as soon as the API was in a good place was reasonable.

- create services/motion/builtin/state package to manage the state of the builtin motion service's executions, which supports starting executions, stopping executions by resource, stopping all executions from a motion/builtin/state struct, recording succeeded & failed replans, recording succeeded & failed ends to executions, recording stopped executions, and recording plan status updates, all such that data can be updated & retrieved efficiently.
- change motion/builtin.MoveOnGlobeNew to call state.StartExecution
- change motion/builtin.StopPlan to call state.StopExecutionByResource
- change motion/builtin.ListPlanStatuses to call state.ListPlanStatuses
- change motion/builtin.PlanHistory to call state.PlanHistory
- change services/motion/builtin to create a new motion/builtin/state on reconfigure & stop the previous state if one exists (to stop any executions from prior to reconfiguration)
- change the name of the motion/builtin lock to follow go & RDK conventions
- change all motion/builtin methods to take a read lock on the builtin struct. Otherwise, they are not threadsafe & bad things could happen if reconfigure gets called in the middle of one of the motion methods executing. After this change reconfigure & any other operation that takes a write lock on the builtin struct can't happen until all methods on the service have terminated & vice versa.
-  update tests to call `motion/builtin.Close()` so that they don't leak resources
- add motion.TerminalStateSet to describe the PlanStates which are terminal


Manual testing (LMK if you want the scripts I used):

https://github.com/viamrobotics/rdk/assets/5927876/c52f48f1-fb72-4618-8670-e9e2bd58e6cc

