### PR TITLE
RSDK-4473 Use direct gRPC connections in web tests that hang

### DIFF
--- a/robot/web/web_test.go
+++ b/robot/web/web_test.go
@@ -254,12 +254,15 @@ func TestWebWithAuth(t *testing.T) {
 					entityName = options.LocalFQDN
 				}
 
+				// TODO(RSDK-4473) Reenable WebRTC when we figure out why multiple
+				// WebRTC connections across unix sockets can create deadlock in CI.
 				conn, err := rgrpc.Dial(context.Background(), addr, logger,
 					rpc.WithAllowInsecureWithCredentialsDowngrade(),
 					rpc.WithEntityCredentials(entityName, rpc.Credentials{
 						Type:    rpc.CredentialsTypeAPIKey,
 						Payload: apiKey,
 					}),
+					rpc.WithForceDirectGRPC(),
 				)
 				test.That(t, err, test.ShouldBeNil)
 				arm1, err := arm.NewClientFromConn(context.Background(), conn, "", arm.Named(arm1String), logger)
@@ -272,12 +275,15 @@ func TestWebWithAuth(t *testing.T) {
 				test.That(t, arm1.Close(context.Background()), test.ShouldBeNil)
 				test.That(t, conn.Close(), test.ShouldBeNil)
 
+				// TODO(RSDK-4473) Reenable WebRTC when we figure out why multiple
+				// WebRTC connections across unix sockets can create deadlock in CI.
 				conn, err = rgrpc.Dial(context.Background(), addr, logger,
 					rpc.WithAllowInsecureWithCredentialsDowngrade(),
 					rpc.WithEntityCredentials(entityName, rpc.Credentials{
 						Type:    rutils.CredentialsTypeRobotLocationSecret,
 						Payload: locationSecrets[0],
 					}),
+					rpc.WithForceDirectGRPC(),
 				)
 				test.That(t, err, test.ShouldBeNil)
 				arm1, err = arm.NewClientFromConn(context.Background(), conn, "", arm.Named(arm1String), logger)
@@ -290,12 +296,15 @@ func TestWebWithAuth(t *testing.T) {
 				test.That(t, arm1.Close(context.Background()), test.ShouldBeNil)
 				test.That(t, conn.Close(), test.ShouldBeNil)
 
+				// TODO(RSDK-4473) Reenable WebRTC when we figure out why multiple
+				// WebRTC connections across unix sockets can create deadlock in CI.
 				conn, err = rgrpc.Dial(context.Background(), addr, logger,
 					rpc.WithAllowInsecureWithCredentialsDowngrade(),
 					rpc.WithEntityCredentials(entityName, rpc.Credentials{
 						Type:    rutils.CredentialsTypeRobotLocationSecret,
 						Payload: locationSecrets[1],
 					}),
+					rpc.WithForceDirectGRPC(),
 				)
 				test.That(t, err, test.ShouldBeNil)
 				arm1, err = arm.NewClientFromConn(context.Background(), conn, "", arm.Named(arm1String), logger)
@@ -318,21 +327,27 @@ func TestWebWithAuth(t *testing.T) {
 							"key-id-1",
 						)
 						test.That(t, err, test.ShouldBeNil)
+						// TODO(RSDK-4473) Reenable WebRTC when we figure out why multiple
+						// WebRTC connections across unix sockets can create deadlock in CI.
 						conn, err = rgrpc.Dial(context.Background(), addr, logger,
 							rpc.WithAllowInsecureWithCredentialsDowngrade(),
 							rpc.WithStaticAuthenticationMaterial(accessToken),
+							rpc.WithForceDirectGRPC(),
 						)
 						test.That(t, err, test.ShouldBeNil)
 						test.That(t, conn.Close(), test.ShouldBeNil)
 					})
 				}
 			} else {
+				// TODO(RSDK-4473) Reenable WebRTC when we figure out why multiple
+				// WebRTC connections across unix sockets can create deadlock in CI.
 				conn, err := rgrpc.Dial(context.Background(), addr, logger,
 					rpc.WithAllowInsecureWithCredentialsDowngrade(),
 					rpc.WithCredentials(rpc.Credentials{
 						Type:    rpc.CredentialsTypeAPIKey,
 						Payload: apiKey,
 					}),
+					rpc.WithForceDirectGRPC(),
 				)
 				test.That(t, err, test.ShouldBeNil)
 
@@ -346,12 +361,15 @@ func TestWebWithAuth(t *testing.T) {
 				test.That(t, arm1.Close(context.Background()), test.ShouldBeNil)
 				test.That(t, conn.Close(), test.ShouldBeNil)
 
+				// TODO(RSDK-4473) Reenable WebRTC when we figure out why multiple
+				// WebRTC connections across unix sockets can create deadlock in CI.
 				conn, err = rgrpc.Dial(context.Background(), addr, logger,
 					rpc.WithAllowInsecureWithCredentialsDowngrade(),
 					rpc.WithCredentials(rpc.Credentials{
 						Type:    rutils.CredentialsTypeRobotLocationSecret,
 						Payload: locationSecrets[0],
 					}),
+					rpc.WithForceDirectGRPC(),
 				)
 				test.That(t, err, test.ShouldBeNil)
 
@@ -581,7 +599,9 @@ func TestWebReconfigure(t *testing.T) {
 	err := svc.Start(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
-	conn, err := rgrpc.Dial(context.Background(), addr, logger)
+	// TODO(RSDK-4473) Reenable WebRTC when we figure out why multiple
+	// WebRTC connections across unix sockets can create deadlock in CI.
+	conn, err := rgrpc.Dial(context.Background(), addr, logger, rpc.WithForceDirectGRPC())
 	test.That(t, err, test.ShouldBeNil)
 
 	arm1, err := arm.NewClientFromConn(context.Background(), conn, "", arm.Named(arm1String), logger)
@@ -602,7 +622,9 @@ func TestWebReconfigure(t *testing.T) {
 	err = svc.Reconfigure(context.Background(), rs, resource.Config{})
 	test.That(t, err, test.ShouldBeNil)
 
-	conn, err = rgrpc.Dial(context.Background(), addr, logger)
+	// TODO(RSDK-4473) Reenable WebRTC when we figure out why multiple
+	// WebRTC connections across unix sockets can create deadlock in CI.
+	conn, err = rgrpc.Dial(context.Background(), addr, logger, rpc.WithForceDirectGRPC())
 	test.That(t, err, test.ShouldBeNil)
 	aClient, err := arm.NewClientFromConn(context.Background(), conn, "", arm.Named(arm1String), logger)
 	test.That(t, err, test.ShouldBeNil)
@@ -629,8 +651,11 @@ func TestWebReconfigure(t *testing.T) {
 
 	err = svc2.Start(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, conn.Close(), test.ShouldBeNil)
 
-	conn, err = rgrpc.Dial(context.Background(), addr, logger)
+	// TODO(RSDK-4473) Reenable WebRTC when we figure out why multiple
+	// WebRTC connections across unix sockets can create deadlock in CI.
+	conn, err = rgrpc.Dial(context.Background(), addr, logger, rpc.WithForceDirectGRPC())
 	test.That(t, err, test.ShouldBeNil)
 
 	arm1, err = arm.NewClientFromConn(context.Background(), conn, "", arm.Named(arm1String), logger)
@@ -639,8 +664,11 @@ func TestWebReconfigure(t *testing.T) {
 	arm1Position, err = arm1.EndPosition(ctx, nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, arm1Position, test.ShouldResemble, newPos)
+	test.That(t, conn.Close(), test.ShouldBeNil)
 
-	conn, err = rgrpc.Dial(context.Background(), addr, logger)
+	// TODO(RSDK-4473) Reenable WebRTC when we figure out why multiple
+	// WebRTC connections across unix sockets can create deadlock in CI.
+	conn, err = rgrpc.Dial(context.Background(), addr, logger, rpc.WithForceDirectGRPC())
 	test.That(t, err, test.ShouldBeNil)
 	aClient2, err := arm.NewClientFromConn(context.Background(), conn, "", arm.Named(arm1String), logger)
 	test.That(t, err, test.ShouldBeNil)
@@ -842,7 +870,9 @@ func TestForeignResource(t *testing.T) {
 	err := svc.Start(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
-	conn, err := rgrpc.Dial(context.Background(), addr, logger)
+	// TODO(RSDK-4473) Reenable WebRTC when we figure out why multiple
+	// WebRTC connections across unix sockets can create deadlock in CI.
+	conn, err := rgrpc.Dial(context.Background(), addr, logger, rpc.WithForceDirectGRPC())
 	test.That(t, err, test.ShouldBeNil)
 
 	myCompClient := gizmopb.NewGizmoServiceClient(conn)
@@ -863,7 +893,10 @@ func TestForeignResource(t *testing.T) {
 	go remoteServer.Serve(listenerR)
 	defer remoteServer.Stop()
 
-	remoteConn, err := rgrpc.Dial(context.Background(), listenerR.Addr().String(), logger)
+	// TODO(RSDK-4473) Reenable WebRTC when we figure out why multiple
+	// WebRTC connections across unix sockets can create deadlock in CI.
+	remoteConn, err := rgrpc.Dial(context.Background(), listenerR.Addr().String(),
+		logger, rpc.WithForceDirectGRPC())
 	test.That(t, err, test.ShouldBeNil)
 
 	resourceAPI := resource.NewAPI(
@@ -893,12 +926,13 @@ func TestForeignResource(t *testing.T) {
 	listener := testutils.ReserveRandomListener(t)
 	addr = listener.Addr().String()
 	options.Network.Listener = listener
-	options.Debug = true
 	svc = web.New(injectRobot, logger)
 	err = svc.Start(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
-	conn, err = rgrpc.Dial(context.Background(), addr, logger, rpc.WithDialDebug())
+	// TODO(RSDK-4473) Reenable WebRTC when we figure out why multiple
+	// WebRTC connections across unix sockets can create deadlock in CI.
+	conn, err = rgrpc.Dial(context.Background(), addr, logger, rpc.WithForceDirectGRPC())
 	test.That(t, err, test.ShouldBeNil)
 
 	myCompClient = gizmopb.NewGizmoServiceClient(conn)


### PR DESCRIPTION
RSDK-4473

Forces a direct gRPC connection to remotes in `TestWebReconfigure`, `TestWebWithAuth` and `TestForeignResource` where possible. Adds a few missing `Close` calls to opened connections.

I found that using `CreateBaseOptionsAndListener` to reserve a remote address and dialing that address with WebRTC can occasionally cause a hang in client message reception when the connection is used for a basic gRPC request. _And_, this only happens when multiple, parallel tests are doing all of those things. I'm not sure why yet, but since the answer is non-obvious, I think we should just force direct gRPC connections in the offending tests for now. I would not be surprised if another test pops up with the same issue, but this should get rid of some of the flakiness in our test suite for the time being.