### PR TITLE
RSDK-4858 - Implement implicit Properties for replay movement sensor

### DIFF
--- a/components/movementsensor/replay/replay.go
+++ b/components/movementsensor/replay/replay.go
@@ -63,24 +63,6 @@ var (
 	// errSessionClosed represents that the session has ended.
 	errSessionClosed = errors.New("session closed")
 
-	// errPositionNotSupported represents that the Position endpoint does not provide any data.
-	errPositionNotSupported = errors.New("Position is not supported")
-
-	// errLinearVelocityNotSupported represents that the LinearVelocity method does not provide any data.
-	errLinearVelocityNotSupported = errors.New("LinearVelocity is not supported")
-
-	// errAngularVelocityNotSupported represents that the AngularVelocity endpoint does not provide any data.
-	errAngularVelocityNotSupported = errors.New("AngularVelocity is not supported")
-
-	// errLinearAccelerationNotSupported represents that the LinearAcceleration endpoint does not provide any data.
-	errLinearAccelerationNotSupported = errors.New("LinearAcceleration is not supported")
-
-	// errCompassHeadingNotSupported represents that the CompassHeading endpoint does not provide any data.
-	errCompassHeadingNotSupported = errors.New("CompassHeading is not supported")
-
-	// errOrientationNotSupported represents that the Orientation endpoint does not provide any data.
-	errOrientationNotSupported = errors.New("Orientation is not supported")
-
 	// methodList is a list of all the base methods possible for a movement sensor to implement.
 	methodList = []method{position, linearVelocity, angularVelocity, linearAcceleration, compassHeading, orientation}
 )
@@ -212,7 +194,7 @@ func (replay *replayMovementSensor) Position(ctx context.Context, extra map[stri
 	}
 
 	if !replay.properties.PositionSupported {
-		return nil, 0, errPositionNotSupported
+		return nil, 0, movementsensor.ErrMethodUnimplementedPosition
 	}
 
 	data, err := replay.getDataFromCache(ctx, position)
@@ -234,7 +216,7 @@ func (replay *replayMovementSensor) LinearVelocity(ctx context.Context, extra ma
 	}
 
 	if !replay.properties.LinearVelocitySupported {
-		return r3.Vector{}, errLinearVelocityNotSupported
+		return r3.Vector{}, movementsensor.ErrMethodUnimplementedLinearVelocity
 	}
 
 	data, err := replay.getDataFromCache(ctx, linearVelocity)
@@ -260,7 +242,7 @@ func (replay *replayMovementSensor) AngularVelocity(ctx context.Context, extra m
 	}
 
 	if !replay.properties.AngularVelocitySupported {
-		return spatialmath.AngularVelocity{}, errAngularVelocityNotSupported
+		return spatialmath.AngularVelocity{}, movementsensor.ErrMethodUnimplementedAngularVelocity
 	}
 
 	data, err := replay.getDataFromCache(ctx, angularVelocity)
@@ -284,7 +266,7 @@ func (replay *replayMovementSensor) LinearAcceleration(ctx context.Context, extr
 	}
 
 	if !replay.properties.LinearAccelerationSupported {
-		return r3.Vector{}, errLinearAccelerationNotSupported
+		return r3.Vector{}, movementsensor.ErrMethodUnimplementedLinearAcceleration
 	}
 
 	data, err := replay.getDataFromCache(ctx, linearAcceleration)
@@ -308,7 +290,7 @@ func (replay *replayMovementSensor) CompassHeading(ctx context.Context, extra ma
 	}
 
 	if !replay.properties.CompassHeadingSupported {
-		return 0., errCompassHeadingNotSupported
+		return 0., movementsensor.ErrMethodUnimplementedCompassHeading
 	}
 
 	data, err := replay.getDataFromCache(ctx, compassHeading)
@@ -328,7 +310,7 @@ func (replay *replayMovementSensor) Orientation(ctx context.Context, extra map[s
 	}
 
 	if !replay.properties.OrientationSupported {
-		return nil, errOrientationNotSupported
+		return nil, movementsensor.ErrMethodUnimplementedOrientation
 	}
 
 	data, err := replay.getDataFromCache(ctx, orientation)

--- a/components/movementsensor/replay/replay.go
+++ b/components/movementsensor/replay/replay.go
@@ -533,9 +533,9 @@ func (replay *replayMovementSensor) attemptToInitializeProperty(ctx context.Cont
 	return initializedProperty, nil
 }
 
-// initializeProperties will set the properties by repeatedly attempting to poll data from all the methods
-// until at least one of them returns data. The properties are set to `true` for the endpoints that
-// returned data.
+// initializeProperties will set the properties by repeatedly polling the cloud for data from
+// the available methods until at least one returns data. The properties are set to
+// `true` for the endpoints that returned data.
 func (replay *replayMovementSensor) initializeProperties(ctx context.Context) error {
 	var initializedAtLeastOneProperty, initializedProperty bool
 	var err error

--- a/components/movementsensor/replay/replay.go
+++ b/components/movementsensor/replay/replay.go
@@ -563,7 +563,9 @@ func (replay *replayMovementSensor) initializeProperties(ctx context.Context) er
 	}
 
 	for method, supported := range dataReceived {
-		replay.setProperty(method, supported)
+		if err := replay.setProperty(method, supported); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/components/movementsensor/replay/replay.go
+++ b/components/movementsensor/replay/replay.go
@@ -531,17 +531,17 @@ func addGRPCMetadata(ctx context.Context, timeRequested, timeReceived *timestamp
 
 func (replay *replayMovementSensor) setProperty(method Method, supported bool) error {
 	switch method {
-	case "LinearVelocity":
+	case linearVelocity:
 		replay.properties.LinearVelocitySupported = supported
-	case "AngularVelocity":
+	case angularVelocity:
 		replay.properties.AngularVelocitySupported = supported
-	case "Orientation":
+	case orientation:
 		replay.properties.OrientationSupported = supported
-	case "Position":
+	case position:
 		replay.properties.PositionSupported = supported
-	case "CompassHeading":
+	case compassHeading:
 		replay.properties.CompassHeadingSupported = supported
-	case "LinearAcceleration":
+	case linearAcceleration:
 		replay.properties.LinearAccelerationSupported = supported
 	default:
 		return errors.New("can't set property, invalid method: " + string(method))
@@ -556,17 +556,17 @@ func (replay *replayMovementSensor) attemptToInitializeProperty(ctx context.Cont
 
 	var initializedProperty bool
 	if replay.closed {
-		return false, errors.New("session closed")
+		return initializedProperty, errors.New("session closed")
 	}
 	if err := replay.updateCache(ctx, method); err != nil && !strings.Contains(err.Error(), ErrEndOfDataset.Error()) {
 		fmt.Println("attemptToInitializeProperty -> method: ", method)
 		fmt.Println("attemptToInitializeProperty -> updateCache --> err: ", err)
-		return false, errors.Wrap(err, "could not update the cache")
+		return initializedProperty, errors.Wrap(err, "could not update the cache")
 	}
 	if len(replay.cache[method]) != 0 {
 		initializedProperty = true
 		if err := replay.setProperty(method, true); err != nil {
-			return false, errors.Wrap(err, "could not set property")
+			return initializedProperty, errors.Wrap(err, "could not set property")
 		}
 	}
 	return initializedProperty, nil

--- a/components/movementsensor/replay/replay.go
+++ b/components/movementsensor/replay/replay.go
@@ -65,6 +65,9 @@ var (
 	// errSessionClosed represents that the session has ended.
 	errSessionClosed = errors.New("session closed")
 
+	// ererMessageNoDataAvailable indicates that no data was available for the given filter.
+	errMessageNoDataAvailable = "no data available for given filter"
+
 	// methodList is a list of all the base methods possible for a movement sensor to implement.
 	methodList = []method{position, linearVelocity, angularVelocity, linearAcceleration, compassHeading, orientation}
 )
@@ -432,7 +435,7 @@ func (replay *replayMovementSensor) Reconfigure(ctx context.Context, deps resour
 	if err := replay.initializeProperties(ctxWithTimeout); err != nil {
 		err = errors.Wrap(err, errPropertiesFailedToInitialize.Error())
 		if errors.Is(err, context.DeadlineExceeded) {
-			err = errors.Wrap(err, "none of the endpoints returned data")
+			err = errors.Wrap(err, errMessageNoDataAvailable)
 		}
 		return err
 	}

--- a/components/movementsensor/replay/replay.go
+++ b/components/movementsensor/replay/replay.go
@@ -163,8 +163,8 @@ type replayMovementSensor struct {
 	cache map[method][]*cacheEntry
 
 	mu                      sync.RWMutex
-	activeBackgroundWorkers sync.WaitGroup
 	closed                  bool
+	activeBackgroundWorkers sync.WaitGroup
 	propertiesStatus        propertiesStatus
 	properties              movementsensor.Properties
 }

--- a/components/movementsensor/replay/replay.go
+++ b/components/movementsensor/replay/replay.go
@@ -483,7 +483,7 @@ func (replay *replayMovementSensor) Reconfigure(ctx context.Context, deps resour
 			if err := replay.initializeProperties(ctx); err != nil {
 				replay.logger.Warn(err)
 			}
-		}(ctx)
+		}(context.Background())
 		if replay.propertiesStatus == notInitialized {
 			replay.propertiesStatus = failedToInitialize
 		}

--- a/components/movementsensor/replay/replay.go
+++ b/components/movementsensor/replay/replay.go
@@ -56,6 +56,29 @@ var (
 
 	// errCloudConnectionFailure represents that the attempt to connect to the cloud failed.
 	errCloudConnectionFailure = errors.New("failure to connect to the cloud")
+	// ErrPropertiesNotInitializedYet represents that the properties are not initialized yet.
+	ErrPropertiesNotInitializedYet = errors.New("Properties are not initialized yet")
+
+	// ErrPropertiesFailedToInitialize represents that the properties failed to initialize.
+	ErrPropertiesFailedToInitialize = errors.New("Properties failed to initialize")
+
+	// ErrLinearVelocityNotSupported represents that the LinearVelocity method does not provide any data.
+	ErrLinearVelocityNotSupported = errors.New("LinearVelocity is not supported")
+
+	// ErrAngularVelocityNotSupported represents that the AngularVelocity endpoint does not provide any data.
+	ErrAngularVelocityNotSupported = errors.New("AngularVelocity is not supported")
+
+	// ErrOrientationNotSupported represents that the Orientation endpoint does not provide any data.
+	ErrOrientationNotSupported = errors.New("Orientation is not supported")
+
+	// ErrPositionNotSupported represents that the Position endpoint does not provide any data.
+	ErrPositionNotSupported = errors.New("Position is not supported")
+
+	// ErrCompassHeadingNotSupported represents that the CompassHeading endpoint does not provide any data.
+	ErrCompassHeadingNotSupported = errors.New("CompassHeading is not supported")
+
+	// ErrLinearAccelerationNotSupported represents that the LinearAcceleration endpoint does not provide any data.
+	ErrLinearAccelerationNotSupported = errors.New("LinearAcceleration is not supported")
 
 	// methodList is a list of all the base methods possible for a movement sensor to implement.
 	methodList = []method{position, linearVelocity, angularVelocity, linearAcceleration, compassHeading, orientation}
@@ -202,7 +225,7 @@ func (replay *replayMovementSensor) Position(ctx context.Context, extra map[stri
 	}
 
 	if !replay.properties.PositionSupported {
-		return nil, 0, errors.New("Position is not supported")
+		return nil, 0, ErrPositionNotSupported
 	}
 
 	data, err := replay.getDataFromCache(ctx, position)
@@ -228,7 +251,7 @@ func (replay *replayMovementSensor) LinearVelocity(ctx context.Context, extra ma
 	}
 
 	if !replay.properties.LinearVelocitySupported {
-		return r3.Vector{}, errors.New("LinearVelocity is not supported")
+		return r3.Vector{}, ErrLinearVelocityNotSupported
 	}
 
 	data, err := replay.getDataFromCache(ctx, linearVelocity)
@@ -258,7 +281,7 @@ func (replay *replayMovementSensor) AngularVelocity(ctx context.Context, extra m
 	}
 
 	if !replay.properties.AngularVelocitySupported {
-		return spatialmath.AngularVelocity{}, errors.New("AngularVelocity is not supported")
+		return spatialmath.AngularVelocity{}, ErrAngularVelocityNotSupported
 	}
 
 	data, err := replay.getDataFromCache(ctx, angularVelocity)
@@ -286,7 +309,7 @@ func (replay *replayMovementSensor) LinearAcceleration(ctx context.Context, extr
 	}
 
 	if !replay.properties.LinearAccelerationSupported {
-		return r3.Vector{}, errors.New("LinearAcceleration is not supported")
+		return r3.Vector{}, ErrLinearAccelerationNotSupported
 	}
 
 	data, err := replay.getDataFromCache(ctx, linearAcceleration)
@@ -314,7 +337,7 @@ func (replay *replayMovementSensor) CompassHeading(ctx context.Context, extra ma
 	}
 
 	if !replay.properties.CompassHeadingSupported {
-		return 0., errors.New("CompassHeading is not supported")
+		return 0., ErrCompassHeadingNotSupported
 	}
 
 	data, err := replay.getDataFromCache(ctx, compassHeading)
@@ -338,7 +361,7 @@ func (replay *replayMovementSensor) Orientation(ctx context.Context, extra map[s
 	}
 
 	if !replay.properties.OrientationSupported {
-		return nil, errors.New("Orientation is not supported")
+		return nil, ErrOrientationNotSupported
 	}
 
 	data, err := replay.getDataFromCache(ctx, orientation)
@@ -612,9 +635,9 @@ func (replay *replayMovementSensor) initializeProperties(ctx context.Context) er
 func (replay *replayMovementSensor) ensurePropertiesAreInitialized(ctx context.Context) error {
 	switch replay.propertiesStatus {
 	case notInitialized:
-		return errors.New("properties are not initialized yet")
+		return ErrPropertiesNotInitializedYet
 	case failedToInitialize:
-		return errors.New("properties failed to initialize")
+		return ErrPropertiesFailedToInitialize
 	default:
 		return nil
 	}

--- a/components/movementsensor/replay/replay.go
+++ b/components/movementsensor/replay/replay.go
@@ -3,7 +3,6 @@ package replay
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -51,34 +50,34 @@ var (
 	// model is the model of a replay movement sensor.
 	model = resource.DefaultModelFamily.WithModel("replay")
 
-	// ErrEndOfDataset represents that the replay sensor has reached the end of the dataset.
-	ErrEndOfDataset = errors.New("reached end of dataset")
+	// errEndOfDataset represents that the replay sensor has reached the end of the dataset.
+	errEndOfDataset = errors.New("reached end of dataset")
 
 	// errCloudConnectionFailure represents that the attempt to connect to the cloud failed.
 	errCloudConnectionFailure = errors.New("failure to connect to the cloud")
 	// ErrPropertiesNotInitializedYet represents that the properties are not initialized yet.
 	ErrPropertiesNotInitializedYet = errors.New("Properties are not initialized yet")
 
-	// ErrPropertiesFailedToInitialize represents that the properties failed to initialize.
-	ErrPropertiesFailedToInitialize = errors.New("Properties failed to initialize")
+	// errPropertiesFailedToInitialize represents that the properties failed to initialize.
+	errPropertiesFailedToInitialize = errors.New("Properties failed to initialize")
 
-	// ErrLinearVelocityNotSupported represents that the LinearVelocity method does not provide any data.
-	ErrLinearVelocityNotSupported = errors.New("LinearVelocity is not supported")
+	// errLinearVelocityNotSupported represents that the LinearVelocity method does not provide any data.
+	errLinearVelocityNotSupported = errors.New("LinearVelocity is not supported")
 
-	// ErrAngularVelocityNotSupported represents that the AngularVelocity endpoint does not provide any data.
-	ErrAngularVelocityNotSupported = errors.New("AngularVelocity is not supported")
+	// errAngularVelocityNotSupported represents that the AngularVelocity endpoint does not provide any data.
+	errAngularVelocityNotSupported = errors.New("AngularVelocity is not supported")
 
-	// ErrOrientationNotSupported represents that the Orientation endpoint does not provide any data.
-	ErrOrientationNotSupported = errors.New("Orientation is not supported")
+	// errOrientationNotSupported represents that the Orientation endpoint does not provide any data.
+	errOrientationNotSupported = errors.New("Orientation is not supported")
 
-	// ErrPositionNotSupported represents that the Position endpoint does not provide any data.
-	ErrPositionNotSupported = errors.New("Position is not supported")
+	// errPositionNotSupported represents that the Position endpoint does not provide any data.
+	errPositionNotSupported = errors.New("Position is not supported")
 
-	// ErrCompassHeadingNotSupported represents that the CompassHeading endpoint does not provide any data.
-	ErrCompassHeadingNotSupported = errors.New("CompassHeading is not supported")
+	// errCompassHeadingNotSupported represents that the CompassHeading endpoint does not provide any data.
+	errCompassHeadingNotSupported = errors.New("CompassHeading is not supported")
 
-	// ErrLinearAccelerationNotSupported represents that the LinearAcceleration endpoint does not provide any data.
-	ErrLinearAccelerationNotSupported = errors.New("LinearAcceleration is not supported")
+	// errLinearAccelerationNotSupported represents that the LinearAcceleration endpoint does not provide any data.
+	errLinearAccelerationNotSupported = errors.New("LinearAcceleration is not supported")
 
 	// methodList is a list of all the base methods possible for a movement sensor to implement.
 	methodList = []method{position, linearVelocity, angularVelocity, linearAcceleration, compassHeading, orientation}
@@ -225,7 +224,7 @@ func (replay *replayMovementSensor) Position(ctx context.Context, extra map[stri
 	}
 
 	if !replay.properties.PositionSupported {
-		return nil, 0, ErrPositionNotSupported
+		return nil, 0, errPositionNotSupported
 	}
 
 	data, err := replay.getDataFromCache(ctx, position)
@@ -251,7 +250,7 @@ func (replay *replayMovementSensor) LinearVelocity(ctx context.Context, extra ma
 	}
 
 	if !replay.properties.LinearVelocitySupported {
-		return r3.Vector{}, ErrLinearVelocityNotSupported
+		return r3.Vector{}, errLinearVelocityNotSupported
 	}
 
 	data, err := replay.getDataFromCache(ctx, linearVelocity)
@@ -281,7 +280,7 @@ func (replay *replayMovementSensor) AngularVelocity(ctx context.Context, extra m
 	}
 
 	if !replay.properties.AngularVelocitySupported {
-		return spatialmath.AngularVelocity{}, ErrAngularVelocityNotSupported
+		return spatialmath.AngularVelocity{}, errAngularVelocityNotSupported
 	}
 
 	data, err := replay.getDataFromCache(ctx, angularVelocity)
@@ -309,7 +308,7 @@ func (replay *replayMovementSensor) LinearAcceleration(ctx context.Context, extr
 	}
 
 	if !replay.properties.LinearAccelerationSupported {
-		return r3.Vector{}, ErrLinearAccelerationNotSupported
+		return r3.Vector{}, errLinearAccelerationNotSupported
 	}
 
 	data, err := replay.getDataFromCache(ctx, linearAcceleration)
@@ -337,7 +336,7 @@ func (replay *replayMovementSensor) CompassHeading(ctx context.Context, extra ma
 	}
 
 	if !replay.properties.CompassHeadingSupported {
-		return 0., ErrCompassHeadingNotSupported
+		return 0., errCompassHeadingNotSupported
 	}
 
 	data, err := replay.getDataFromCache(ctx, compassHeading)
@@ -361,7 +360,7 @@ func (replay *replayMovementSensor) Orientation(ctx context.Context, extra map[s
 	}
 
 	if !replay.properties.OrientationSupported {
-		return nil, ErrOrientationNotSupported
+		return nil, errOrientationNotSupported
 	}
 
 	data, err := replay.getDataFromCache(ctx, orientation)
@@ -517,7 +516,7 @@ func (replay *replayMovementSensor) updateCache(ctx context.Context, method meth
 
 	// Check if data exists
 	if len(resp.GetData()) == 0 {
-		return ErrEndOfDataset
+		return errEndOfDataset
 	}
 	replay.lastData[method] = resp.GetLast()
 
@@ -581,9 +580,7 @@ func (replay *replayMovementSensor) attemptToInitializeProperty(ctx context.Cont
 	if replay.closed {
 		return initializedProperty, errors.New("session closed")
 	}
-	if err := replay.updateCache(ctx, method); err != nil && !strings.Contains(err.Error(), ErrEndOfDataset.Error()) {
-		fmt.Println("attemptToInitializeProperty -> method: ", method)
-		fmt.Println("attemptToInitializeProperty -> updateCache --> err: ", err)
+	if err := replay.updateCache(ctx, method); err != nil && !strings.Contains(err.Error(), errEndOfDataset.Error()) {
 		return initializedProperty, errors.Wrap(err, "could not update the cache")
 	}
 	if len(replay.cache[method]) != 0 {
@@ -598,7 +595,7 @@ func (replay *replayMovementSensor) attemptToInitializeProperty(ctx context.Cont
 // initializeProperties will set the properties by repeatedly attempting to poll data from all the methods
 // until at least one of them returns data.
 func (replay *replayMovementSensor) initializeProperties(ctx context.Context) error {
-	var initializedProperty bool
+	var initializedAtLeastOneProperty, initializedProperty bool
 	var err error
 	// Repeatedly attempt to poll data from the movement sensor for each method until at least
 	// one of the methods receives data.
@@ -608,16 +605,15 @@ func (replay *replayMovementSensor) initializeProperties(ctx context.Context) er
 		}
 		for _, method := range methodList {
 			if initializedProperty, err = replay.attemptToInitializeProperty(ctx, method); err != nil {
-				fmt.Println("In initializeProperties, method: ", method)
-				fmt.Println("error, initializedProperty results: ", initializedProperty, err)
 				return err
 			}
-			fmt.Println("-- In initializeProperties, method: ", method)
-			fmt.Println("-- initializedProperty results: ", initializedProperty)
+			if !initializedAtLeastOneProperty {
+				initializedAtLeastOneProperty = initializedProperty
+			}
 		}
 		// If at least one method successfully managed to initialize, we know that data reached the cloud and
 		// that we can finish initializing the properties.
-		if initializedProperty {
+		if initializedAtLeastOneProperty {
 			// Loop once more through all methods to ensure we didn't miss out on catching that they're supported
 			for _, method := range methodList {
 				if _, err = replay.attemptToInitializeProperty(ctx, method); err != nil {
@@ -635,9 +631,9 @@ func (replay *replayMovementSensor) initializeProperties(ctx context.Context) er
 func (replay *replayMovementSensor) ensurePropertiesAreInitialized(ctx context.Context) error {
 	switch replay.propertiesStatus {
 	case notInitialized:
-		return ErrPropertiesNotInitializedYet
+		return errPropertiesNotInitializedYet
 	case failedToInitialize:
-		return ErrPropertiesFailedToInitialize
+		return errPropertiesFailedToInitialize
 	default:
 		return nil
 	}

--- a/components/movementsensor/replay/replay_test.go
+++ b/components/movementsensor/replay/replay_test.go
@@ -98,7 +98,7 @@ var (
 
 	defaultReplayMovementSensorFunction = linearAcceleration
 
-	allMethodsSupported = map[Method]bool{
+	allMethodsSupported = map[method]bool{
 		position:           true,
 		linearAcceleration: true,
 		angularVelocity:    true,
@@ -107,7 +107,7 @@ var (
 		compassHeading:     true,
 	}
 
-	noMethodsSupported = map[Method]bool{
+	noMethodsSupported = map[method]bool{
 		position:           false,
 		linearAcceleration: false,
 		angularVelocity:    false,
@@ -116,7 +116,7 @@ var (
 		compassHeading:     false,
 	}
 
-	allMethodsReportFailedToInitialize = map[Method]error{
+	allMethodsReportFailedToInitialize = map[method]error{
 		linearAcceleration: errPropertiesFailedToInitialize,
 		angularVelocity:    errPropertiesFailedToInitialize,
 		position:           errPropertiesFailedToInitialize,
@@ -215,7 +215,6 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 		cfg                   *Config
 		startFileNum          map[method]int
 		endFileNum            map[method]int
-		expectedErr           map[method]error
 		propertiesExpectedErr error
 		methodsExpectedErr    map[method]error
 		methodSupported       map[method]bool
@@ -368,22 +367,22 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 					Start: "2000-01-01T12:00:06Z",
 				},
 			},
-			startFileNum: map[Method]int{
+			startFileNum: map[method]int{
 				angularVelocity: 6,
 				linearVelocity:  6,
 				compassHeading:  6,
 			},
-			endFileNum: map[Method]int{
+			endFileNum: map[method]int{
 				angularVelocity: allMethodsMaxDataLength[angularVelocity],
 				linearVelocity:  allMethodsMaxDataLength[linearVelocity],
 				compassHeading:  allMethodsMaxDataLength[compassHeading],
 			},
-			methodsExpectedErr: map[Method]error{
+			methodsExpectedErr: map[method]error{
 				linearAcceleration: errLinearAccelerationNotSupported,
 				position:           errPositionNotSupported,
 				orientation:        errOrientationNotSupported,
 			},
-			methodSupported: map[Method]bool{
+			methodSupported: map[method]bool{
 				linearAcceleration: false,
 				angularVelocity:    true,
 				position:           false,
@@ -404,21 +403,21 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 					Start: "2000-01-01T12:00:08Z",
 				},
 			},
-			startFileNum: map[Method]int{
+			startFileNum: map[method]int{
 				linearVelocity: 8,
 				compassHeading: 8,
 			},
-			endFileNum: map[Method]int{
+			endFileNum: map[method]int{
 				linearVelocity: allMethodsMaxDataLength[linearVelocity],
 				compassHeading: allMethodsMaxDataLength[compassHeading],
 			},
-			methodsExpectedErr: map[Method]error{
+			methodsExpectedErr: map[method]error{
 				linearAcceleration: errLinearAccelerationNotSupported,
 				angularVelocity:    errAngularVelocityNotSupported,
 				position:           errPositionNotSupported,
 				orientation:        errOrientationNotSupported,
 			},
-			methodSupported: map[Method]bool{
+			methodSupported: map[method]bool{
 				linearAcceleration: false,
 				angularVelocity:    false,
 				position:           false,
@@ -439,20 +438,20 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 					Start: "2000-01-01T12:00:10Z",
 				},
 			},
-			startFileNum: map[Method]int{
+			startFileNum: map[method]int{
 				compassHeading: 10,
 			},
-			endFileNum: map[Method]int{
+			endFileNum: map[method]int{
 				compassHeading: allMethodsMaxDataLength[compassHeading],
 			},
-			methodsExpectedErr: map[Method]error{
+			methodsExpectedErr: map[method]error{
 				linearAcceleration: errLinearAccelerationNotSupported,
 				angularVelocity:    errAngularVelocityNotSupported,
 				position:           errPositionNotSupported,
 				linearVelocity:     errLinearVelocityNotSupported,
 				orientation:        errOrientationNotSupported,
 			},
-			methodSupported: map[Method]bool{
+			methodSupported: map[method]bool{
 				linearAcceleration: false,
 				angularVelocity:    false,
 				position:           false,
@@ -475,7 +474,7 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 			},
 			propertiesExpectedErr: errPropertiesFailedToInitialize,
 			methodsExpectedErr:    allMethodsReportFailedToInitialize,
-			methodSupported: map[Method]bool{
+			methodSupported: map[method]bool{
 				linearAcceleration: false,
 				angularVelocity:    false,
 				position:           false,

--- a/components/movementsensor/replay/replay_test.go
+++ b/components/movementsensor/replay/replay_test.go
@@ -107,15 +107,6 @@ var (
 		orientation:        true,
 		compassHeading:     true,
 	}
-
-	noMethodsSupported = map[method]bool{
-		position:           false,
-		linearAcceleration: false,
-		angularVelocity:    false,
-		linearVelocity:     false,
-		orientation:        false,
-		compassHeading:     false,
-	}
 )
 
 func TestNewReplayMovementSensor(t *testing.T) {
@@ -807,7 +798,6 @@ func TestReplayMovementSensorReadings(t *testing.T) {
 }
 
 func TestReplayMovementSensorTimestampsMetadata(t *testing.T) {
-
 	initializePropertiesTimeout = 2 * time.Second
 
 	// Construct replay movement sensor.
@@ -850,7 +840,6 @@ func TestReplayMovementSensorTimestampsMetadata(t *testing.T) {
 }
 
 func TestReplayMovementSensorReconfigure(t *testing.T) {
-
 	initializePropertiesTimeout = 2 * time.Second
 
 	// Construct replay movement sensor

--- a/components/movementsensor/replay/replay_test.go
+++ b/components/movementsensor/replay/replay_test.go
@@ -322,7 +322,7 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 				linearAcceleration: allMethodsMaxDataLength[linearAcceleration],
 				compassHeading:     allMethodsMaxDataLength[compassHeading],
 			},
-			methodsExpectedErr: map[method]error{orientation: errOrientationNotSupported},
+			methodsExpectedErr: map[method]error{orientation: movementsensor.ErrMethodUnimplementedOrientation},
 			methodSupported: map[method]bool{
 				position:           true,
 				linearVelocity:     true,
@@ -355,9 +355,9 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 				compassHeading:  allMethodsMaxDataLength[compassHeading],
 			},
 			methodsExpectedErr: map[method]error{
-				position:           errPositionNotSupported,
-				linearAcceleration: errLinearAccelerationNotSupported,
-				orientation:        errOrientationNotSupported,
+				position:           movementsensor.ErrMethodUnimplementedPosition,
+				linearAcceleration: movementsensor.ErrMethodUnimplementedLinearAcceleration,
+				orientation:        movementsensor.ErrMethodUnimplementedOrientation,
 			},
 			methodSupported: map[method]bool{
 				position:           false,
@@ -389,10 +389,10 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 				compassHeading: allMethodsMaxDataLength[compassHeading],
 			},
 			methodsExpectedErr: map[method]error{
-				position:           errPositionNotSupported,
-				angularVelocity:    errAngularVelocityNotSupported,
-				linearAcceleration: errLinearAccelerationNotSupported,
-				orientation:        errOrientationNotSupported,
+				position:           movementsensor.ErrMethodUnimplementedPosition,
+				angularVelocity:    movementsensor.ErrMethodUnimplementedAngularVelocity,
+				linearAcceleration: movementsensor.ErrMethodUnimplementedLinearAcceleration,
+				orientation:        movementsensor.ErrMethodUnimplementedOrientation,
 			},
 			methodSupported: map[method]bool{
 				position:           false,
@@ -422,11 +422,11 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 				compassHeading: allMethodsMaxDataLength[compassHeading],
 			},
 			methodsExpectedErr: map[method]error{
-				position:           errPositionNotSupported,
-				linearVelocity:     errLinearVelocityNotSupported,
-				angularVelocity:    errAngularVelocityNotSupported,
-				linearAcceleration: errLinearAccelerationNotSupported,
-				orientation:        errOrientationNotSupported,
+				position:           movementsensor.ErrMethodUnimplementedPosition,
+				linearVelocity:     movementsensor.ErrMethodUnimplementedLinearVelocity,
+				angularVelocity:    movementsensor.ErrMethodUnimplementedAngularVelocity,
+				linearAcceleration: movementsensor.ErrMethodUnimplementedLinearAcceleration,
+				orientation:        movementsensor.ErrMethodUnimplementedOrientation,
 			},
 			methodSupported: map[method]bool{
 				position:           false,

--- a/components/movementsensor/replay/replay_test.go
+++ b/components/movementsensor/replay/replay_test.go
@@ -322,7 +322,7 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 				linearAcceleration: allMethodsMaxDataLength[linearAcceleration],
 				compassHeading:     allMethodsMaxDataLength[compassHeading],
 			},
-			methodsExpectedErr: map[method]error{orientation: ErrOrientationNotSupported},
+			methodsExpectedErr: map[method]error{orientation: errOrientationNotSupported},
 			methodSupported: map[method]bool{
 				position:           true,
 				linearVelocity:     true,
@@ -875,7 +875,7 @@ func TestReplayMovementSensorReconfigure(t *testing.T) {
 
 	// Again verify dataset starts from beginning
 	for i := 0; i < allMethodsMaxDataLength[defaultReplayMovementSensorFunction]; i++ {
-		testReplayMovementSensorMethod(ctx, t, replay, defaultReplayMovementSensorFunction, i, nil)
+		testReplayMovementSensorMethodData(ctx, t, replay, defaultReplayMovementSensorFunction, i)
 	}
 
 	// Confirm the end of the dataset was reached when expected

--- a/components/movementsensor/replay/replay_test.go
+++ b/components/movementsensor/replay/replay_test.go
@@ -117,12 +117,12 @@ var (
 	}
 
 	allMethodsReportFailedToInitialize = map[Method]error{
-		linearAcceleration: ErrPropertiesFailedToInitialize,
-		angularVelocity:    ErrPropertiesFailedToInitialize,
-		position:           ErrPropertiesFailedToInitialize,
-		linearVelocity:     ErrPropertiesFailedToInitialize,
-		compassHeading:     ErrPropertiesFailedToInitialize,
-		orientation:        ErrPropertiesFailedToInitialize,
+		linearAcceleration: errPropertiesFailedToInitialize,
+		angularVelocity:    errPropertiesFailedToInitialize,
+		position:           errPropertiesFailedToInitialize,
+		linearVelocity:     errPropertiesFailedToInitialize,
+		compassHeading:     errPropertiesFailedToInitialize,
+		orientation:        errPropertiesFailedToInitialize,
 	}
 )
 
@@ -212,7 +212,6 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 
 	cases := []struct {
 		description           string
-		methods               []method
 		cfg                   *Config
 		startFileNum          map[method]int
 		endFileNum            map[method]int
@@ -229,7 +228,6 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 				LocationID:     validLocationID,
 				OrganizationID: validOrganizationID,
 			},
-			methods:         methodList,
 			startFileNum:    allMethodsMinDataLength,
 			endFileNum:      allMethodsMaxDataLength,
 			methodSupported: allMethodsSupported,
@@ -242,9 +240,8 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 				LocationID:     validLocationID,
 				OrganizationID: validOrganizationID,
 			},
-			methods:               methodList,
 			methodSupported:       noMethodsSupported,
-			propertiesExpectedErr: ErrPropertiesFailedToInitialize,
+			propertiesExpectedErr: errPropertiesFailedToInitialize,
 			methodsExpectedErr:    allMethodsReportFailedToInitialize,
 		},
 		{
@@ -255,9 +252,8 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 				LocationID:     validLocationID,
 				OrganizationID: validOrganizationID,
 			},
-			methods:               methodList,
 			methodSupported:       noMethodsSupported,
-			propertiesExpectedErr: ErrPropertiesFailedToInitialize,
+			propertiesExpectedErr: errPropertiesFailedToInitialize,
 			methodsExpectedErr:    allMethodsReportFailedToInitialize,
 		},
 		{
@@ -268,9 +264,8 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 				LocationID:     "bad_location_id",
 				OrganizationID: validOrganizationID,
 			},
-			methods:               methodList,
 			methodSupported:       noMethodsSupported,
-			propertiesExpectedErr: ErrPropertiesFailedToInitialize,
+			propertiesExpectedErr: errPropertiesFailedToInitialize,
 			methodsExpectedErr:    allMethodsReportFailedToInitialize,
 		},
 		{
@@ -281,9 +276,8 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 				LocationID:     validLocationID,
 				OrganizationID: "bad_organization_id",
 			},
-			methods:               methodList,
 			methodSupported:       noMethodsSupported,
-			propertiesExpectedErr: ErrPropertiesFailedToInitialize,
+			propertiesExpectedErr: errPropertiesFailedToInitialize,
 			methodsExpectedErr:    allMethodsReportFailedToInitialize,
 		},
 		{
@@ -299,9 +293,8 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 					End:   "2000-01-01T12:00:40Z",
 				},
 			},
-			methods:               methodList,
 			methodSupported:       noMethodsSupported,
-			propertiesExpectedErr: ErrPropertiesFailedToInitialize,
+			propertiesExpectedErr: errPropertiesFailedToInitialize,
 			methodsExpectedErr:    allMethodsReportFailedToInitialize,
 		},
 		{
@@ -316,7 +309,6 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 					End: "2000-01-01T12:00:03Z",
 				},
 			},
-			methods:      methodList,
 			startFileNum: allMethodsMinDataLength,
 			endFileNum: map[method]int{
 				linearAcceleration: 3,
@@ -329,7 +321,7 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 			methodSupported: allMethodsSupported,
 		},
 		{
-			description: "Calling methods with start filter",
+			description: "Calling methods with start filter starting at 2",
 			cfg: &Config{
 				Source:         validSource,
 				RobotID:        validRobotID,
@@ -340,7 +332,6 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 					Start: "2000-01-01T12:00:02Z",
 				},
 			},
-			methods: methodList,
 			startFileNum: map[method]int{
 				linearAcceleration: 2,
 				angularVelocity:    2,
@@ -366,6 +357,134 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 			},
 		},
 		{
+			description: "Calling methods with start filter starting at 6",
+			cfg: &Config{
+				Source:         validSource,
+				RobotID:        validRobotID,
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
+				BatchSize:      &batchSizeNonZero,
+				Interval: TimeInterval{
+					Start: "2000-01-01T12:00:06Z",
+				},
+			},
+			startFileNum: map[Method]int{
+				angularVelocity: 6,
+				linearVelocity:  6,
+				compassHeading:  6,
+			},
+			endFileNum: map[Method]int{
+				angularVelocity: allMethodsMaxDataLength[angularVelocity],
+				linearVelocity:  allMethodsMaxDataLength[linearVelocity],
+				compassHeading:  allMethodsMaxDataLength[compassHeading],
+			},
+			methodsExpectedErr: map[Method]error{
+				linearAcceleration: errLinearAccelerationNotSupported,
+				position:           errPositionNotSupported,
+				orientation:        errOrientationNotSupported,
+			},
+			methodSupported: map[Method]bool{
+				linearAcceleration: false,
+				angularVelocity:    true,
+				position:           false,
+				linearVelocity:     true,
+				compassHeading:     true,
+				orientation:        false,
+			},
+		},
+		{
+			description: "Calling methods with start filter starting at 8",
+			cfg: &Config{
+				Source:         validSource,
+				RobotID:        validRobotID,
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
+				BatchSize:      &batchSizeNonZero,
+				Interval: TimeInterval{
+					Start: "2000-01-01T12:00:08Z",
+				},
+			},
+			startFileNum: map[Method]int{
+				linearVelocity: 8,
+				compassHeading: 8,
+			},
+			endFileNum: map[Method]int{
+				linearVelocity: allMethodsMaxDataLength[linearVelocity],
+				compassHeading: allMethodsMaxDataLength[compassHeading],
+			},
+			methodsExpectedErr: map[Method]error{
+				linearAcceleration: errLinearAccelerationNotSupported,
+				angularVelocity:    errAngularVelocityNotSupported,
+				position:           errPositionNotSupported,
+				orientation:        errOrientationNotSupported,
+			},
+			methodSupported: map[Method]bool{
+				linearAcceleration: false,
+				angularVelocity:    false,
+				position:           false,
+				linearVelocity:     true,
+				compassHeading:     true,
+				orientation:        false,
+			},
+		},
+		{
+			description: "Calling methods with start filter starting at 10",
+			cfg: &Config{
+				Source:         validSource,
+				RobotID:        validRobotID,
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
+				BatchSize:      &batchSizeNonZero,
+				Interval: TimeInterval{
+					Start: "2000-01-01T12:00:10Z",
+				},
+			},
+			startFileNum: map[Method]int{
+				compassHeading: 10,
+			},
+			endFileNum: map[Method]int{
+				compassHeading: allMethodsMaxDataLength[compassHeading],
+			},
+			methodsExpectedErr: map[Method]error{
+				linearAcceleration: errLinearAccelerationNotSupported,
+				angularVelocity:    errAngularVelocityNotSupported,
+				position:           errPositionNotSupported,
+				linearVelocity:     errLinearVelocityNotSupported,
+				orientation:        errOrientationNotSupported,
+			},
+			methodSupported: map[Method]bool{
+				linearAcceleration: false,
+				angularVelocity:    false,
+				position:           false,
+				linearVelocity:     false,
+				compassHeading:     true,
+				orientation:        false,
+			},
+		},
+		{
+			description: "Calling methods with start filter starting at 12",
+			cfg: &Config{
+				Source:         validSource,
+				RobotID:        validRobotID,
+				LocationID:     validLocationID,
+				OrganizationID: validOrganizationID,
+				BatchSize:      &batchSizeNonZero,
+				Interval: TimeInterval{
+					Start: "2000-01-01T12:00:12Z",
+				},
+			},
+			propertiesExpectedErr: errPropertiesFailedToInitialize,
+			methodsExpectedErr:    allMethodsReportFailedToInitialize,
+			methodSupported: map[Method]bool{
+				linearAcceleration: false,
+				angularVelocity:    false,
+				position:           false,
+				linearVelocity:     false,
+				compassHeading:     false,
+				orientation:        false,
+			},
+		},
+		{
 			description: "Calling methods with start and end filter",
 			cfg: &Config{
 				Source:         validSource,
@@ -378,7 +497,6 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 					End:   "2000-01-01T12:00:03Z",
 				},
 			},
-			methods: methodList,
 			startFileNum: map[method]int{
 				position:           1,
 				linearVelocity:     1,
@@ -417,7 +535,7 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 			test.That(t, props.LinearVelocitySupported, test.ShouldEqual, tt.methodSupported[linearVelocity])
 			test.That(t, props.CompassHeadingSupported, test.ShouldEqual, tt.methodSupported[compassHeading])
 
-			for _, method := range tt.methods {
+			for _, method := range methodList {
 				if tt.methodsExpectedErr[method] != nil {
 					testReplayMovementSensorMethodError(ctx, t, replay, method, tt.methodsExpectedErr[method])
 				} else {
@@ -428,7 +546,7 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 						}
 					}
 					// Confirm the end of the dataset was reached when expected
-					testReplayMovementSensorMethodError(ctx, t, replay, method, ErrEndOfDataset)
+					testReplayMovementSensorMethodError(ctx, t, replay, method, errEndOfDataset)
 				}
 			}
 
@@ -699,7 +817,7 @@ func TestReplayMovementSensorReadings(t *testing.T) {
 
 	readings, err := replay.Readings(ctx, map[string]interface{}{})
 	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, ErrEndOfDataset.Error())
+	test.That(t, err.Error(), test.ShouldContainSubstring, errEndOfDataset.Error())
 	test.That(t, readings, test.ShouldBeNil)
 
 	err = replay.Close(ctx)
@@ -743,7 +861,7 @@ func TestReplayMovementSensorTimestampsMetadata(t *testing.T) {
 	}
 
 	// Confirm the end of the dataset was reached when expected
-	testReplayMovementSensorMethodError(ctx, t, replay, defaultReplayMovementSensorFunction, ErrEndOfDataset)
+	testReplayMovementSensorMethodError(ctx, t, replay, defaultReplayMovementSensorFunction, errEndOfDataset)
 
 	err = replay.Close(ctx)
 	test.That(t, err, test.ShouldBeNil)
@@ -798,7 +916,7 @@ func TestReplayMovementSensorReconfigure(t *testing.T) {
 	}
 
 	// Confirm the end of the dataset was reached when expected
-	testReplayMovementSensorMethodError(ctx, t, replay, defaultReplayMovementSensorFunction, ErrEndOfDataset)
+	testReplayMovementSensorMethodError(ctx, t, replay, defaultReplayMovementSensorFunction, errEndOfDataset)
 
 	err = replay.Close(ctx)
 	test.That(t, err, test.ShouldBeNil)

--- a/components/movementsensor/replay/replay_test.go
+++ b/components/movementsensor/replay/replay_test.go
@@ -780,7 +780,6 @@ func TestReplayMovementSensorReadings(t *testing.T) {
 }
 
 func TestReplayMovementSensorTimestampsMetadata(t *testing.T) {
-
 	// Construct replay movement sensor.
 	ctx := context.Background()
 	cfg := &Config{
@@ -821,7 +820,6 @@ func TestReplayMovementSensorTimestampsMetadata(t *testing.T) {
 }
 
 func TestReplayMovementSensorReconfigure(t *testing.T) {
-
 	// Construct replay movement sensor
 	cfg := &Config{
 		Source:         validSource,

--- a/components/movementsensor/replay/replay_test.go
+++ b/components/movementsensor/replay/replay_test.go
@@ -325,7 +325,7 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 				compassHeading:     allMethodsMaxDataLength[compassHeading],
 				orientation:        -1,
 			},
-			expectedErr: map[string]error{"Orientation": errors.New("Orientation is not supported")},
+			expectedErr: map[Method]error{orientation: errors.New("Orientation is not supported")},
 		},
 		{
 			description: "Calling methods with start and end filter",
@@ -602,13 +602,13 @@ func TestReplayMovementSensorProperties(t *testing.T) {
 
 	cases := []struct {
 		description           string
-		methods               []string
+		methods               []Method
 		cfg                   *Config
-		startFileNum          map[string]int
-		endFileNum            map[string]int
+		startFileNum          map[Method]int
+		endFileNum            map[Method]int
 		propertiesExpectedErr error
-		methodsExpectedErr    map[string]error
-		methodSupported       map[string]bool
+		methodsExpectedErr    map[Method]error
+		methodSupported       map[Method]bool
 	}{
 		{
 			description: "All methods are supported",
@@ -619,16 +619,16 @@ func TestReplayMovementSensorProperties(t *testing.T) {
 				OrganizationID: validOrganizationID,
 				BatchSize:      &batchSizeNonZero,
 			},
-			methods:      []string{"LinearAcceleration", "AngularVelocity", "Position", "LinearVelocity", "CompassHeading", "Orientation"},
+			methods:      methodList,
 			startFileNum: defaultMinDataLength,
 			endFileNum:   defaultMaxDataLength,
-			methodSupported: map[string]bool{
-				"LinearAcceleration": true,
-				"AngularVelocity":    true,
-				"Position":           true,
-				"LinearVelocity":     true,
-				"CompassHeading":     true,
-				"Orientation":        true,
+			methodSupported: map[Method]bool{
+				linearAcceleration: true,
+				angularVelocity:    true,
+				position:           true,
+				linearVelocity:     true,
+				compassHeading:     true,
+				orientation:        true,
 			},
 		},
 		{
@@ -644,18 +644,18 @@ func TestReplayMovementSensorProperties(t *testing.T) {
 					End:   "2000-01-01T12:00:40Z",
 				},
 			},
-			methods:               []string{"LinearAcceleration"},
-			startFileNum:          map[string]int{"LinearAcceleration": -1},
-			endFileNum:            map[string]int{"LinearAcceleration": -1},
+			methods:               []Method{linearAcceleration},
+			startFileNum:          map[Method]int{linearAcceleration: -1},
+			endFileNum:            map[Method]int{linearAcceleration: -1},
 			propertiesExpectedErr: errors.New("properties failed to initialize"),
-			methodsExpectedErr:    map[string]error{"LinearAcceleration": errors.New("properties are not initialized yet")},
-			methodSupported: map[string]bool{
-				"LinearAcceleration": false,
-				"AngularVelocity":    false,
-				"Position":           false,
-				"LinearVelocity":     false,
-				"CompassHeading":     false,
-				"Orientation":        false,
+			methodsExpectedErr:    map[Method]error{linearAcceleration: errors.New("properties are not initialized yet")},
+			methodSupported: map[Method]bool{
+				linearAcceleration: false,
+				angularVelocity:    false,
+				position:           false,
+				linearVelocity:     false,
+				compassHeading:     false,
+				orientation:        false,
 			},
 		},
 		{
@@ -670,23 +670,23 @@ func TestReplayMovementSensorProperties(t *testing.T) {
 					End: "2000-01-01T12:00:03Z",
 				},
 			},
-			methods:      []string{"LinearAcceleration", "AngularVelocity", "Position", "LinearVelocity", "CompassHeading", "Orientation"},
+			methods:      methodList,
 			startFileNum: defaultMinDataLength,
-			endFileNum: map[string]int{
-				"LinearAcceleration": 3,
-				"AngularVelocity":    3,
-				"Position":           3,
-				"LinearVelocity":     3,
-				"CompassHeading":     3,
-				"Orientation":        2,
+			endFileNum: map[Method]int{
+				linearAcceleration: 3,
+				angularVelocity:    3,
+				position:           3,
+				linearVelocity:     3,
+				compassHeading:     3,
+				orientation:        2,
 			},
-			methodSupported: map[string]bool{
-				"LinearAcceleration": true,
-				"AngularVelocity":    true,
-				"Position":           true,
-				"LinearVelocity":     true,
-				"CompassHeading":     true,
-				"Orientation":        true,
+			methodSupported: map[Method]bool{
+				linearAcceleration: true,
+				angularVelocity:    true,
+				position:           true,
+				linearVelocity:     true,
+				compassHeading:     true,
+				orientation:        true,
 			},
 		},
 		{
@@ -701,31 +701,31 @@ func TestReplayMovementSensorProperties(t *testing.T) {
 					Start: "2000-01-01T12:00:02Z",
 				},
 			},
-			methods: []string{"LinearAcceleration", "AngularVelocity", "Position", "LinearVelocity", "CompassHeading", "Orientation"},
-			startFileNum: map[string]int{
-				"LinearAcceleration": 2,
-				"AngularVelocity":    2,
-				"Position":           2,
-				"LinearVelocity":     2,
-				"CompassHeading":     2,
-				"Orientation":        -1,
+			methods: methodList,
+			startFileNum: map[Method]int{
+				linearAcceleration: 2,
+				angularVelocity:    2,
+				position:           2,
+				linearVelocity:     2,
+				compassHeading:     2,
+				orientation:        -1,
 			},
-			endFileNum: map[string]int{
-				"LinearAcceleration": defaultMaxDataLength["LinearAcceleration"],
-				"AngularVelocity":    defaultMaxDataLength["AngularVelocity"],
-				"Position":           defaultMaxDataLength["Position"],
-				"LinearVelocity":     defaultMaxDataLength["LinearVelocity"],
-				"CompassHeading":     defaultMaxDataLength["CompassHeading"],
-				"Orientation":        -1,
+			endFileNum: map[Method]int{
+				linearAcceleration: defaultMaxDataLength[linearAcceleration],
+				angularVelocity:    defaultMaxDataLength[angularVelocity],
+				position:           defaultMaxDataLength[position],
+				linearVelocity:     defaultMaxDataLength[linearVelocity],
+				compassHeading:     defaultMaxDataLength[compassHeading],
+				orientation:        -1,
 			},
-			methodsExpectedErr: map[string]error{"Orientation": errors.New("Orientation is not supported")},
-			methodSupported: map[string]bool{
-				"LinearAcceleration": true,
-				"AngularVelocity":    true,
-				"Position":           true,
-				"LinearVelocity":     true,
-				"CompassHeading":     true,
-				"Orientation":        false,
+			methodsExpectedErr: map[Method]error{orientation: errors.New("Orientation is not supported")},
+			methodSupported: map[Method]bool{
+				linearAcceleration: true,
+				angularVelocity:    true,
+				position:           true,
+				linearVelocity:     true,
+				compassHeading:     true,
+				orientation:        false,
 			},
 		},
 		{
@@ -741,30 +741,30 @@ func TestReplayMovementSensorProperties(t *testing.T) {
 					End:   "2000-01-01T12:00:03Z",
 				},
 			},
-			methods: []string{"LinearAcceleration", "AngularVelocity", "Position", "LinearVelocity", "CompassHeading", "Orientation"},
-			startFileNum: map[string]int{
-				"LinearAcceleration": 1,
-				"AngularVelocity":    1,
-				"Position":           1,
-				"LinearVelocity":     1,
-				"CompassHeading":     1,
-				"Orientation":        1,
+			methods: methodList,
+			startFileNum: map[Method]int{
+				linearAcceleration: 1,
+				angularVelocity:    1,
+				position:           1,
+				linearVelocity:     1,
+				compassHeading:     1,
+				orientation:        1,
 			},
-			endFileNum: map[string]int{
-				"LinearAcceleration": 3,
-				"AngularVelocity":    3,
-				"Position":           3,
-				"LinearVelocity":     3,
-				"CompassHeading":     3,
-				"Orientation":        defaultMaxDataLength["Orientation"],
+			endFileNum: map[Method]int{
+				linearAcceleration: 3,
+				angularVelocity:    3,
+				position:           3,
+				linearVelocity:     3,
+				compassHeading:     3,
+				orientation:        defaultMaxDataLength[orientation],
 			},
-			methodSupported: map[string]bool{
-				"LinearAcceleration": true,
-				"AngularVelocity":    true,
-				"Position":           true,
-				"LinearVelocity":     true,
-				"CompassHeading":     true,
-				"Orientation":        true,
+			methodSupported: map[Method]bool{
+				linearAcceleration: true,
+				angularVelocity:    true,
+				position:           true,
+				linearVelocity:     true,
+				compassHeading:     true,
+				orientation:        true,
 			},
 		},
 	}
@@ -784,12 +784,12 @@ func TestReplayMovementSensorProperties(t *testing.T) {
 			} else {
 				test.That(t, err, test.ShouldEqual, tt.propertiesExpectedErr)
 			}
-			test.That(t, props.PositionSupported, test.ShouldEqual, tt.methodSupported["Position"])
-			test.That(t, props.OrientationSupported, test.ShouldEqual, tt.methodSupported["Orientation"])
-			test.That(t, props.AngularVelocitySupported, test.ShouldEqual, tt.methodSupported["AngularVelocity"])
-			test.That(t, props.LinearAccelerationSupported, test.ShouldEqual, tt.methodSupported["LinearAcceleration"])
-			test.That(t, props.LinearVelocitySupported, test.ShouldEqual, tt.methodSupported["LinearVelocity"])
-			test.That(t, props.CompassHeadingSupported, test.ShouldEqual, tt.methodSupported["CompassHeading"])
+			test.That(t, props.PositionSupported, test.ShouldEqual, tt.methodSupported[position])
+			test.That(t, props.OrientationSupported, test.ShouldEqual, tt.methodSupported[orientation])
+			test.That(t, props.AngularVelocitySupported, test.ShouldEqual, tt.methodSupported[angularVelocity])
+			test.That(t, props.LinearAccelerationSupported, test.ShouldEqual, tt.methodSupported[linearAcceleration])
+			test.That(t, props.LinearVelocitySupported, test.ShouldEqual, tt.methodSupported[linearVelocity])
+			test.That(t, props.CompassHeadingSupported, test.ShouldEqual, tt.methodSupported[compassHeading])
 
 			for _, method := range tt.methods {
 				// Iterate through all files that meet the provided filter

--- a/components/movementsensor/replay/replay_test.go
+++ b/components/movementsensor/replay/replay_test.go
@@ -324,7 +324,7 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 				position:           3,
 				linearVelocity:     3,
 				compassHeading:     3,
-				orientation:        defaultMaxDataLength[orientation],
+				orientation:        allMethodsMaxDataLength[orientation],
 			},
 			methodSupported: allMethodsSupported,
 		},

--- a/components/movementsensor/replay/replay_test.go
+++ b/components/movementsensor/replay/replay_test.go
@@ -101,11 +101,11 @@ var (
 
 	allMethodsSupported = map[method]bool{
 		position:           true,
-		linearAcceleration: true,
-		angularVelocity:    true,
 		linearVelocity:     true,
-		orientation:        true,
+		angularVelocity:    true,
+		linearAcceleration: true,
 		compassHeading:     true,
+		orientation:        true,
 	}
 )
 
@@ -287,10 +287,10 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 			},
 			startFileNum: allMethodsMinDataLength,
 			endFileNum: map[method]int{
-				linearAcceleration: 3,
-				angularVelocity:    3,
 				position:           3,
 				linearVelocity:     3,
+				angularVelocity:    3,
+				linearAcceleration: 3,
 				compassHeading:     3,
 				orientation:        allMethodsMaxDataLength[orientation],
 			},
@@ -309,10 +309,10 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 				},
 			},
 			startFileNum: map[method]int{
-				linearAcceleration: 2,
-				angularVelocity:    2,
 				position:           2,
 				linearVelocity:     2,
+				angularVelocity:    2,
+				linearAcceleration: 2,
 				compassHeading:     2,
 			},
 			endFileNum: map[method]int{
@@ -345,25 +345,25 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 				},
 			},
 			startFileNum: map[method]int{
-				angularVelocity: 6,
 				linearVelocity:  6,
+				angularVelocity: 6,
 				compassHeading:  6,
 			},
 			endFileNum: map[method]int{
-				angularVelocity: allMethodsMaxDataLength[angularVelocity],
 				linearVelocity:  allMethodsMaxDataLength[linearVelocity],
+				angularVelocity: allMethodsMaxDataLength[angularVelocity],
 				compassHeading:  allMethodsMaxDataLength[compassHeading],
 			},
 			methodsExpectedErr: map[method]error{
-				linearAcceleration: errLinearAccelerationNotSupported,
 				position:           errPositionNotSupported,
+				linearAcceleration: errLinearAccelerationNotSupported,
 				orientation:        errOrientationNotSupported,
 			},
 			methodSupported: map[method]bool{
-				linearAcceleration: false,
-				angularVelocity:    true,
 				position:           false,
 				linearVelocity:     true,
+				angularVelocity:    true,
+				linearAcceleration: false,
 				compassHeading:     true,
 				orientation:        false,
 			},
@@ -389,16 +389,16 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 				compassHeading: allMethodsMaxDataLength[compassHeading],
 			},
 			methodsExpectedErr: map[method]error{
-				linearAcceleration: errLinearAccelerationNotSupported,
-				angularVelocity:    errAngularVelocityNotSupported,
 				position:           errPositionNotSupported,
+				angularVelocity:    errAngularVelocityNotSupported,
+				linearAcceleration: errLinearAccelerationNotSupported,
 				orientation:        errOrientationNotSupported,
 			},
 			methodSupported: map[method]bool{
-				linearAcceleration: false,
-				angularVelocity:    false,
 				position:           false,
 				linearVelocity:     true,
+				angularVelocity:    false,
+				linearAcceleration: false,
 				compassHeading:     true,
 				orientation:        false,
 			},
@@ -422,17 +422,17 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 				compassHeading: allMethodsMaxDataLength[compassHeading],
 			},
 			methodsExpectedErr: map[method]error{
-				linearAcceleration: errLinearAccelerationNotSupported,
-				angularVelocity:    errAngularVelocityNotSupported,
 				position:           errPositionNotSupported,
 				linearVelocity:     errLinearVelocityNotSupported,
+				angularVelocity:    errAngularVelocityNotSupported,
+				linearAcceleration: errLinearAccelerationNotSupported,
 				orientation:        errOrientationNotSupported,
 			},
 			methodSupported: map[method]bool{
-				linearAcceleration: false,
-				angularVelocity:    false,
 				position:           false,
 				linearVelocity:     false,
+				angularVelocity:    false,
+				linearAcceleration: false,
 				compassHeading:     true,
 				orientation:        false,
 			},
@@ -498,11 +498,11 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 				props, err := replay.Properties(ctx, map[string]interface{}{})
 				test.That(t, err, test.ShouldBeNil)
 				test.That(t, props.PositionSupported, test.ShouldEqual, tt.methodSupported[position])
-				test.That(t, props.OrientationSupported, test.ShouldEqual, tt.methodSupported[orientation])
+				test.That(t, props.LinearVelocitySupported, test.ShouldEqual, tt.methodSupported[linearVelocity])
 				test.That(t, props.AngularVelocitySupported, test.ShouldEqual, tt.methodSupported[angularVelocity])
 				test.That(t, props.LinearAccelerationSupported, test.ShouldEqual, tt.methodSupported[linearAcceleration])
-				test.That(t, props.LinearVelocitySupported, test.ShouldEqual, tt.methodSupported[linearVelocity])
 				test.That(t, props.CompassHeadingSupported, test.ShouldEqual, tt.methodSupported[compassHeading])
+				test.That(t, props.OrientationSupported, test.ShouldEqual, tt.methodSupported[orientation])
 
 				for _, method := range methodList {
 					if tt.methodsExpectedErr[method] != nil {
@@ -515,7 +515,7 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 							}
 						}
 						// Confirm the end of the dataset was reached when expected
-						testReplayMovementSensorMethodError(ctx, t, replay, method, errEndOfDataset)
+						testReplayMovementSensorMethodError(ctx, t, replay, method, ErrEndOfDataset)
 					}
 				}
 
@@ -788,7 +788,7 @@ func TestReplayMovementSensorReadings(t *testing.T) {
 
 	readings, err := replay.Readings(ctx, map[string]interface{}{})
 	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, errEndOfDataset.Error())
+	test.That(t, err.Error(), test.ShouldContainSubstring, ErrEndOfDataset.Error())
 	test.That(t, readings, test.ShouldBeNil)
 
 	err = replay.Close(ctx)
@@ -831,7 +831,7 @@ func TestReplayMovementSensorTimestampsMetadata(t *testing.T) {
 	}
 
 	// Confirm the end of the dataset was reached when expected
-	testReplayMovementSensorMethodError(ctx, t, replay, defaultReplayMovementSensorFunction, errEndOfDataset)
+	testReplayMovementSensorMethodError(ctx, t, replay, defaultReplayMovementSensorFunction, ErrEndOfDataset)
 
 	err = replay.Close(ctx)
 	test.That(t, err, test.ShouldBeNil)
@@ -879,7 +879,7 @@ func TestReplayMovementSensorReconfigure(t *testing.T) {
 	}
 
 	// Confirm the end of the dataset was reached when expected
-	testReplayMovementSensorMethodError(ctx, t, replay, defaultReplayMovementSensorFunction, errEndOfDataset)
+	testReplayMovementSensorMethodError(ctx, t, replay, defaultReplayMovementSensorFunction, ErrEndOfDataset)
 
 	err = replay.Close(ctx)
 	test.That(t, err, test.ShouldBeNil)

--- a/components/movementsensor/replay/replay_utils_test.go
+++ b/components/movementsensor/replay/replay_utils_test.go
@@ -101,12 +101,12 @@ func timestampsFromIndex(index int) (*timestamppb.Timestamp, *timestamppb.Timest
 func getNextDataAfterFilter(filter *datapb.Filter, last string) (int, error) {
 	// Basic component part (source) filter
 	if filter.ComponentName != "" && filter.ComponentName != validSource {
-		return 0, errEndOfDataset
+		return 0, ErrEndOfDataset
 	}
 
 	// Basic robot_id filter
 	if filter.RobotId != "" && filter.RobotId != validRobotID {
-		return 0, errEndOfDataset
+		return 0, ErrEndOfDataset
 	}
 
 	// Basic location_id filter
@@ -114,7 +114,7 @@ func getNextDataAfterFilter(filter *datapb.Filter, last string) (int, error) {
 		return 0, errors.New("issue occurred with transmitting LocationIds to the cloud")
 	}
 	if filter.LocationIds[0] != "" && filter.LocationIds[0] != validLocationID {
-		return 0, errEndOfDataset
+		return 0, ErrEndOfDataset
 	}
 
 	// Basic organization_id filter
@@ -122,7 +122,7 @@ func getNextDataAfterFilter(filter *datapb.Filter, last string) (int, error) {
 		return 0, errors.New("issue occurred with transmitting OrganizationIds to the cloud")
 	}
 	if filter.OrganizationIds[0] != "" && filter.OrganizationIds[0] != validOrganizationID {
-		return 0, errEndOfDataset
+		return 0, ErrEndOfDataset
 	}
 
 	// Apply the time-based filter based on the seconds value in the start and end fields. Because our mock data
@@ -157,7 +157,7 @@ func checkDataEndCondition(i, endIntervalIndex, availableDataNum int) (int, erro
 	if i < endIntervalIndex && i < availableDataNum {
 		return i, nil
 	}
-	return 0, errEndOfDataset
+	return 0, ErrEndOfDataset
 }
 
 // createMockCloudDependencies creates a mockDataServiceServer and rpc client connection to it which is then

--- a/components/movementsensor/replay/replay_utils_test.go
+++ b/components/movementsensor/replay/replay_utils_test.go
@@ -272,40 +272,40 @@ func createDataByMovementSensorMethod(method method, index int) *structpb.Struct
 
 // testReplayMovementSensorMethod tests the specified replay movement sensor function, both success and failure cases.
 func testReplayMovementSensorMethod(ctx context.Context, t *testing.T, replay movementsensor.MovementSensor, method method,
-	i int, success bool,
+	i int, expectedErr error,
 ) {
 	var extra map[string]interface{}
 	switch method {
 	case position:
 		point, altitude, err := replay.Position(ctx, extra)
-		if success {
+		if expectedErr == nil {
 			test.That(t, err, test.ShouldBeNil)
 			test.That(t, point, test.ShouldResemble, positionPointData[i])
 			test.That(t, altitude, test.ShouldResemble, positionAltitudeData[i])
 		} else {
 			test.That(t, err, test.ShouldNotBeNil)
-			test.That(t, err.Error(), test.ShouldContainSubstring, ErrEndOfDataset.Error())
+			test.That(t, err.Error(), test.ShouldContainSubstring, expectedErr.Error())
 			test.That(t, point, test.ShouldBeNil)
 			test.That(t, altitude, test.ShouldEqual, 0)
 		}
 	case linearVelocity:
 		data, err := replay.LinearVelocity(ctx, extra)
-		if success {
+		if expectedErr == nil {
 			test.That(t, err, test.ShouldBeNil)
 			test.That(t, data, test.ShouldResemble, linearVelocityData[i])
 		} else {
 			test.That(t, err, test.ShouldNotBeNil)
-			test.That(t, err.Error(), test.ShouldContainSubstring, ErrEndOfDataset.Error())
+			test.That(t, err.Error(), test.ShouldContainSubstring, expectedErr.Error())
 			test.That(t, data, test.ShouldResemble, r3.Vector{})
 		}
 	case angularVelocity:
 		data, err := replay.AngularVelocity(ctx, extra)
-		if success {
+		if expectedErr == nil {
 			test.That(t, err, test.ShouldBeNil)
 			test.That(t, data, test.ShouldResemble, angularVelocityData[i])
 		} else {
 			test.That(t, err, test.ShouldNotBeNil)
-			test.That(t, err.Error(), test.ShouldContainSubstring, ErrEndOfDataset.Error())
+			test.That(t, err.Error(), test.ShouldContainSubstring, expectedErr.Error())
 			test.That(t, data, test.ShouldResemble, spatialmath.AngularVelocity{})
 		}
 	case linearAcceleration:
@@ -320,23 +320,23 @@ func testReplayMovementSensorMethod(ctx context.Context, t *testing.T, replay mo
 		}
 	case compassHeading:
 		data, err := replay.CompassHeading(ctx, extra)
-		if success {
+		if expectedErr == nil {
 			test.That(t, err, test.ShouldBeNil)
 			test.That(t, data, test.ShouldEqual, compassHeadingData[i])
 		} else {
 			test.That(t, err, test.ShouldNotBeNil)
-			test.That(t, err.Error(), test.ShouldContainSubstring, ErrEndOfDataset.Error())
+			test.That(t, err.Error(), test.ShouldContainSubstring, expectedErr.Error())
 			test.That(t, data, test.ShouldEqual, 0)
 		}
 	case orientation:
 		data, err := replay.Orientation(ctx, extra)
-		if success {
+		if expectedErr == nil {
 			test.That(t, err, test.ShouldBeNil)
 			test.That(t, err, test.ShouldBeNil)
 			test.That(t, data, test.ShouldResemble, orientationData[i])
 		} else {
 			test.That(t, err, test.ShouldNotBeNil)
-			test.That(t, err.Error(), test.ShouldContainSubstring, ErrEndOfDataset.Error())
+			test.That(t, err.Error(), test.ShouldContainSubstring, expectedErr.Error())
 			test.That(t, data, test.ShouldBeNil)
 		}
 	}

--- a/components/movementsensor/replay/replay_utils_test.go
+++ b/components/movementsensor/replay/replay_utils_test.go
@@ -270,74 +270,75 @@ func createDataByMovementSensorMethod(method method, index int) *structpb.Struct
 	return &data
 }
 
-// testReplayMovementSensorMethod tests the specified replay movement sensor function, both success and failure cases.
-func testReplayMovementSensorMethod(ctx context.Context, t *testing.T, replay movementsensor.MovementSensor, method method,
-	i int, expectedErr error,
+func testReplayMovementSensorMethodData(ctx context.Context, t *testing.T, replay movementsensor.MovementSensor, method Method,
+	index int) {
+	var extra map[string]interface{}
+	switch method {
+	case position:
+		point, altitude, err := replay.Position(ctx, extra)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, point, test.ShouldResemble, positionPointData[index])
+		test.That(t, altitude, test.ShouldResemble, positionAltitudeData[index])
+	case linearVelocity:
+		data, err := replay.LinearVelocity(ctx, extra)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, data, test.ShouldResemble, linearVelocityData[index])
+	case angularVelocity:
+		data, err := replay.AngularVelocity(ctx, extra)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, data, test.ShouldResemble, angularVelocityData[index])
+	case linearAcceleration:
+		data, err := replay.LinearAcceleration(ctx, extra)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, data, test.ShouldResemble, linearAccelerationData[index])
+	case compassHeading:
+		data, err := replay.CompassHeading(ctx, extra)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, data, test.ShouldEqual, compassHeadingData[index])
+	case orientation:
+		data, err := replay.Orientation(ctx, extra)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, data, test.ShouldResemble, orientationData[index])
+	}
+
+}
+
+func testReplayMovementSensorMethodError(ctx context.Context, t *testing.T, replay movementsensor.MovementSensor, method Method,
+	expectedErr error,
 ) {
 	var extra map[string]interface{}
 	switch method {
 	case position:
 		point, altitude, err := replay.Position(ctx, extra)
-		if expectedErr == nil {
-			test.That(t, err, test.ShouldBeNil)
-			test.That(t, point, test.ShouldResemble, positionPointData[i])
-			test.That(t, altitude, test.ShouldResemble, positionAltitudeData[i])
-		} else {
-			test.That(t, err, test.ShouldNotBeNil)
-			test.That(t, err.Error(), test.ShouldContainSubstring, expectedErr.Error())
-			test.That(t, point, test.ShouldBeNil)
-			test.That(t, altitude, test.ShouldEqual, 0)
-		}
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, expectedErr.Error())
+		test.That(t, point, test.ShouldBeNil)
+		test.That(t, altitude, test.ShouldEqual, 0)
 	case linearVelocity:
 		data, err := replay.LinearVelocity(ctx, extra)
-		if expectedErr == nil {
-			test.That(t, err, test.ShouldBeNil)
-			test.That(t, data, test.ShouldResemble, linearVelocityData[i])
-		} else {
-			test.That(t, err, test.ShouldNotBeNil)
-			test.That(t, err.Error(), test.ShouldContainSubstring, expectedErr.Error())
-			test.That(t, data, test.ShouldResemble, r3.Vector{})
-		}
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, expectedErr.Error())
+		test.That(t, data, test.ShouldResemble, r3.Vector{})
 	case angularVelocity:
 		data, err := replay.AngularVelocity(ctx, extra)
-		if expectedErr == nil {
-			test.That(t, err, test.ShouldBeNil)
-			test.That(t, data, test.ShouldResemble, angularVelocityData[i])
-		} else {
-			test.That(t, err, test.ShouldNotBeNil)
-			test.That(t, err.Error(), test.ShouldContainSubstring, expectedErr.Error())
-			test.That(t, data, test.ShouldResemble, spatialmath.AngularVelocity{})
-		}
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, expectedErr.Error())
+		test.That(t, data, test.ShouldResemble, spatialmath.AngularVelocity{})
 	case linearAcceleration:
 		data, err := replay.LinearAcceleration(ctx, extra)
-		if success {
-			test.That(t, err, test.ShouldBeNil)
-			test.That(t, data, test.ShouldResemble, linearAccelerationData[i])
-		} else {
-			test.That(t, err, test.ShouldNotBeNil)
-			test.That(t, err.Error(), test.ShouldContainSubstring, ErrEndOfDataset.Error())
-			test.That(t, data, test.ShouldResemble, r3.Vector{})
-		}
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, expectedErr.Error())
+		test.That(t, data, test.ShouldResemble, r3.Vector{})
 	case compassHeading:
 		data, err := replay.CompassHeading(ctx, extra)
-		if expectedErr == nil {
-			test.That(t, err, test.ShouldBeNil)
-			test.That(t, data, test.ShouldEqual, compassHeadingData[i])
-		} else {
-			test.That(t, err, test.ShouldNotBeNil)
-			test.That(t, err.Error(), test.ShouldContainSubstring, expectedErr.Error())
-			test.That(t, data, test.ShouldEqual, 0)
-		}
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, expectedErr.Error())
+		test.That(t, data, test.ShouldEqual, 0)
 	case orientation:
 		data, err := replay.Orientation(ctx, extra)
-		if expectedErr == nil {
-			test.That(t, err, test.ShouldBeNil)
-			test.That(t, err, test.ShouldBeNil)
-			test.That(t, data, test.ShouldResemble, orientationData[i])
-		} else {
-			test.That(t, err, test.ShouldNotBeNil)
-			test.That(t, err.Error(), test.ShouldContainSubstring, expectedErr.Error())
-			test.That(t, data, test.ShouldBeNil)
-		}
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, expectedErr.Error())
+		test.That(t, data, test.ShouldBeNil)
 	}
 }

--- a/components/movementsensor/replay/replay_utils_test.go
+++ b/components/movementsensor/replay/replay_utils_test.go
@@ -32,7 +32,7 @@ const (
 	testTime = "2000-01-01T12:00:%02dZ"
 )
 
-var ErrCloudConnection = errors.New("cloud connection error")
+var errTestCloudConnection = errors.New("cloud connection error")
 
 // mockDataServiceServer is a struct that includes unimplemented versions of all the Data Service endpoints. These
 // can be overwritten to allow developers to trigger desired behaviors during testing.

--- a/components/movementsensor/replay/replay_utils_test.go
+++ b/components/movementsensor/replay/replay_utils_test.go
@@ -32,7 +32,7 @@ const (
 	testTime = "2000-01-01T12:00:%02dZ"
 )
 
-var errTestCloudConnection = errors.New("cloud connection error")
+var ErrCloudConnection = errors.New("cloud connection error")
 
 // mockDataServiceServer is a struct that includes unimplemented versions of all the Data Service endpoints. These
 // can be overwritten to allow developers to trigger desired behaviors during testing.
@@ -270,8 +270,9 @@ func createDataByMovementSensorMethod(method method, index int) *structpb.Struct
 	return &data
 }
 
-func testReplayMovementSensorMethodData(ctx context.Context, t *testing.T, replay movementsensor.MovementSensor, method Method,
-	index int) {
+func testReplayMovementSensorMethodData(ctx context.Context, t *testing.T, replay movementsensor.MovementSensor, method method,
+	index int,
+) {
 	var extra map[string]interface{}
 	switch method {
 	case position:
@@ -301,10 +302,9 @@ func testReplayMovementSensorMethodData(ctx context.Context, t *testing.T, repla
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, data, test.ShouldResemble, orientationData[index])
 	}
-
 }
 
-func testReplayMovementSensorMethodError(ctx context.Context, t *testing.T, replay movementsensor.MovementSensor, method Method,
+func testReplayMovementSensorMethodError(ctx context.Context, t *testing.T, replay movementsensor.MovementSensor, method method,
 	expectedErr error,
 ) {
 	var extra map[string]interface{}

--- a/components/movementsensor/replay/replay_utils_test.go
+++ b/components/movementsensor/replay/replay_utils_test.go
@@ -101,12 +101,12 @@ func timestampsFromIndex(index int) (*timestamppb.Timestamp, *timestamppb.Timest
 func getNextDataAfterFilter(filter *datapb.Filter, last string) (int, error) {
 	// Basic component part (source) filter
 	if filter.ComponentName != "" && filter.ComponentName != validSource {
-		return 0, ErrEndOfDataset
+		return 0, errEndOfDataset
 	}
 
 	// Basic robot_id filter
 	if filter.RobotId != "" && filter.RobotId != validRobotID {
-		return 0, ErrEndOfDataset
+		return 0, errEndOfDataset
 	}
 
 	// Basic location_id filter
@@ -114,7 +114,7 @@ func getNextDataAfterFilter(filter *datapb.Filter, last string) (int, error) {
 		return 0, errors.New("issue occurred with transmitting LocationIds to the cloud")
 	}
 	if filter.LocationIds[0] != "" && filter.LocationIds[0] != validLocationID {
-		return 0, ErrEndOfDataset
+		return 0, errEndOfDataset
 	}
 
 	// Basic organization_id filter
@@ -122,7 +122,7 @@ func getNextDataAfterFilter(filter *datapb.Filter, last string) (int, error) {
 		return 0, errors.New("issue occurred with transmitting OrganizationIds to the cloud")
 	}
 	if filter.OrganizationIds[0] != "" && filter.OrganizationIds[0] != validOrganizationID {
-		return 0, ErrEndOfDataset
+		return 0, errEndOfDataset
 	}
 
 	// Apply the time-based filter based on the seconds value in the start and end fields. Because our mock data
@@ -157,7 +157,7 @@ func checkDataEndCondition(i, endIntervalIndex, availableDataNum int) (int, erro
 	if i < endIntervalIndex && i < availableDataNum {
 		return i, nil
 	}
-	return 0, ErrEndOfDataset
+	return 0, errEndOfDataset
 }
 
 // createMockCloudDependencies creates a mockDataServiceServer and rpc client connection to it which is then


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-4858

Implements `Properties` that reflect whether or not the respective endpoint returns data.

Tested by recording fake data with two different combinations of endpoints and then testing the replay movement sensor by polling `Properties` and all endpoints.
