### PR TITLE
DATA-2031 publish CLI for windows

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -41,6 +41,7 @@ jobs:
         GOOS=linux GOARCH=arm64 make cli-ci
         GOOS=darwin GOARCH=amd64 make cli-ci
         GOOS=darwin GOARCH=arm64 make cli-ci
+        GOOS=windows GOARCH=amd64 EXE_SUFFIX=.exe make cli-ci
 
     - name: tagged alias
       env:
@@ -51,6 +52,7 @@ jobs:
         GOOS=linux GOARCH=arm64 make cli-ci
         GOOS=darwin GOARCH=amd64 make cli-ci
         GOOS=darwin GOARCH=arm64 make cli-ci
+        GOOS=windows GOARCH=amd64 EXE_SUFFIX=.exe make cli-ci
 
     - name: Authorize GCP Upload
       uses: google-github-actions/auth@v1

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ cli: bin/$(GOOS)-$(GOARCH)/viam-cli
 cli-ci: bin/$(GOOS)-$(GOARCH)/viam-cli
 	if [ -n "$(CI_RELEASE)" ]; then \
 		mkdir -p bin/deploy-ci/; \
-		cp $< bin/deploy-ci/viam-cli-$(CI_RELEASE)-$(GOOS)-$(GOARCH); \
+		cp $< bin/deploy-ci/viam-cli-$(CI_RELEASE)-$(GOOS)-$(GOARCH)$(EXE_SUFFIX); \
 	fi
 
 build-web: web/runtime-shared/static/control.js

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module go.viam.com/rdk
 
 go 1.19
 
+replace go.viam.com/utils => github.com/viamrobotics/goutils v0.1.45-0.20230929223904-39e77054b23b
+
 require (
 	github.com/AlekSi/gocov-xml v1.0.0
 	github.com/CPRT/roboclaw v0.0.0-20190825181223-76871438befc

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module go.viam.com/rdk
 
 go 1.19
 
-replace go.viam.com/utils => github.com/viamrobotics/goutils v0.1.45-0.20230929223904-39e77054b23b
-
 require (
 	github.com/AlekSi/gocov-xml v1.0.0
 	github.com/CPRT/roboclaw v0.0.0-20190825181223-76871438befc
@@ -87,7 +85,7 @@ require (
 	go.uber.org/zap v1.24.0
 	go.viam.com/api v0.1.203
 	go.viam.com/test v1.1.1-0.20220913152726-5da9916c08a2
-	go.viam.com/utils v0.1.43
+	go.viam.com/utils v0.1.45
 	goji.io v2.0.2+incompatible
 	golang.org/x/image v0.8.0
 	golang.org/x/tools v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -1486,6 +1486,8 @@ github.com/viamrobotics/evdev v0.1.3 h1:mR4HFafvbc5Wx4Vp1AUJp6/aITfVx9AKyXWx+rWj
 github.com/viamrobotics/evdev v0.1.3/go.mod h1:N6nuZmPz7HEIpM7esNWwLxbYzqWqLSZkfI/1Sccckqk=
 github.com/viamrobotics/gostream v0.0.0-20230725145737-ed58004e202e h1:j7vCOikvAE3AxaFUtTfvRS9u6Agmvc5HbxI/TVzNEkg=
 github.com/viamrobotics/gostream v0.0.0-20230725145737-ed58004e202e/go.mod h1:XbqZO/IuYMHmn2L0QWbEwiytLh20nj6gWIeoEHMWLo8=
+github.com/viamrobotics/goutils v0.1.45-0.20230929223904-39e77054b23b h1:M0Ysq7r8W1j+bhkYSYDzlTctkQFGHga7bXxOOfr8FlY=
+github.com/viamrobotics/goutils v0.1.45-0.20230929223904-39e77054b23b/go.mod h1:tjPInze4C0UYFRqL/FU96yqhJpHR1zjiNZ7qChTN/b8=
 github.com/viki-org/dnscache v0.0.0-20130720023526-c70c1f23c5d8/go.mod h1:dniwbG03GafCjFohMDmz6Zc6oCuiqgH6tGNyXTkHzXE=
 github.com/wcharczuk/go-chart v2.0.1+incompatible/go.mod h1:PF5tmL4EIx/7Wf+hEkpCqYi5He4u90sw+0+6FhrryuE=
 github.com/wcharczuk/go-chart/v2 v2.1.0/go.mod h1:yx7MvAVNcP/kN9lKXM/NTce4au4DFN99j6i1OwDclNA=
@@ -1586,8 +1588,6 @@ go.viam.com/api v0.1.203 h1:94ysIF24k80o36WwjyjIfivFi/NZLsy/fS0IX+PZiTQ=
 go.viam.com/api v0.1.203/go.mod h1:CwLz82Ie4+Z2lSH2F0oQGViP4/TV9uxjJs+rqHvFWE8=
 go.viam.com/test v1.1.1-0.20220913152726-5da9916c08a2 h1:oBiK580EnEIzgFLU4lHOXmGAE3MxnVbeR7s1wp/F3Ps=
 go.viam.com/test v1.1.1-0.20220913152726-5da9916c08a2/go.mod h1:XM0tej6riszsiNLT16uoyq1YjuYPWlRBweTPRDanIts=
-go.viam.com/utils v0.1.43 h1:ZNEqvicTBXJ/CGh897vNk6MVzGi98BOzdxTenFF0pv8=
-go.viam.com/utils v0.1.43/go.mod h1:tjPInze4C0UYFRqL/FU96yqhJpHR1zjiNZ7qChTN/b8=
 go4.org v0.0.0-20180809161055-417644f6feb5/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=
 go4.org/unsafe/assume-no-moving-gc v0.0.0-20230525183740-e7c30c78aeb2 h1:WJhcL4p+YeDxmZWg141nRm7XC8IDmhz7lk5GpadO1Sg=
 go4.org/unsafe/assume-no-moving-gc v0.0.0-20230525183740-e7c30c78aeb2/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=

--- a/go.sum
+++ b/go.sum
@@ -1486,8 +1486,6 @@ github.com/viamrobotics/evdev v0.1.3 h1:mR4HFafvbc5Wx4Vp1AUJp6/aITfVx9AKyXWx+rWj
 github.com/viamrobotics/evdev v0.1.3/go.mod h1:N6nuZmPz7HEIpM7esNWwLxbYzqWqLSZkfI/1Sccckqk=
 github.com/viamrobotics/gostream v0.0.0-20230725145737-ed58004e202e h1:j7vCOikvAE3AxaFUtTfvRS9u6Agmvc5HbxI/TVzNEkg=
 github.com/viamrobotics/gostream v0.0.0-20230725145737-ed58004e202e/go.mod h1:XbqZO/IuYMHmn2L0QWbEwiytLh20nj6gWIeoEHMWLo8=
-github.com/viamrobotics/goutils v0.1.45-0.20230929223904-39e77054b23b h1:M0Ysq7r8W1j+bhkYSYDzlTctkQFGHga7bXxOOfr8FlY=
-github.com/viamrobotics/goutils v0.1.45-0.20230929223904-39e77054b23b/go.mod h1:tjPInze4C0UYFRqL/FU96yqhJpHR1zjiNZ7qChTN/b8=
 github.com/viki-org/dnscache v0.0.0-20130720023526-c70c1f23c5d8/go.mod h1:dniwbG03GafCjFohMDmz6Zc6oCuiqgH6tGNyXTkHzXE=
 github.com/wcharczuk/go-chart v2.0.1+incompatible/go.mod h1:PF5tmL4EIx/7Wf+hEkpCqYi5He4u90sw+0+6FhrryuE=
 github.com/wcharczuk/go-chart/v2 v2.1.0/go.mod h1:yx7MvAVNcP/kN9lKXM/NTce4au4DFN99j6i1OwDclNA=
@@ -1588,6 +1586,8 @@ go.viam.com/api v0.1.203 h1:94ysIF24k80o36WwjyjIfivFi/NZLsy/fS0IX+PZiTQ=
 go.viam.com/api v0.1.203/go.mod h1:CwLz82Ie4+Z2lSH2F0oQGViP4/TV9uxjJs+rqHvFWE8=
 go.viam.com/test v1.1.1-0.20220913152726-5da9916c08a2 h1:oBiK580EnEIzgFLU4lHOXmGAE3MxnVbeR7s1wp/F3Ps=
 go.viam.com/test v1.1.1-0.20220913152726-5da9916c08a2/go.mod h1:XM0tej6riszsiNLT16uoyq1YjuYPWlRBweTPRDanIts=
+go.viam.com/utils v0.1.45 h1:/bKlpWMG1kNC1LPx0uxVRTtgconhMq7JQTppiTW00HY=
+go.viam.com/utils v0.1.45/go.mod h1:tjPInze4C0UYFRqL/FU96yqhJpHR1zjiNZ7qChTN/b8=
 go4.org v0.0.0-20180809161055-417644f6feb5/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=
 go4.org/unsafe/assume-no-moving-gc v0.0.0-20230525183740-e7c30c78aeb2 h1:WJhcL4p+YeDxmZWg141nRm7XC8IDmhz7lk5GpadO1Sg=
 go4.org/unsafe/assume-no-moving-gc v0.0.0-20230525183740-e7c30c78aeb2/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=


### PR DESCRIPTION
## What changed
- this is the other half of https://github.com/viamrobotics/goutils/pull/205
- bump to goutils 0.1.45 which includes fixes for windows and 32-bit
- publish windows binary of CLI (with .exe extension)
## Tests
- I ran the binary from `GOOS=windows GOARCH=amd64 EXE_SUFFIX=.exe make cli-ci` on the lab machine, can confirm it at least starts and pops a browser on login