### PR TITLE
APP-2828 Allow string pin names in board card

### DIFF
--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "2.0.21",
+  "version": "2.0.22",
   "license": "Apache-2.0",
   "type": "module",
   "files": [

--- a/web/frontend/src/components/board/index.svelte
+++ b/web/frontend/src/components/board/index.svelte
@@ -143,7 +143,7 @@ const handlePwmFrequencyInput = (event: CustomEvent) => {
           <div class="flex flex-wrap items-end gap-2">
             <v-input
               label="Pin"
-              type="integer"
+              type="text"
               value={getPin}
               on:input={handleGetPinInput}
             />
@@ -174,7 +174,7 @@ const handlePwmFrequencyInput = (event: CustomEvent) => {
           <div class="flex flex-wrap items-end gap-2">
             <v-input
               value={setPin}
-              type="integer"
+              type="text"
               class="mr-2"
               label="Pin"
               on:input={handleSetPinInput}


### PR DESCRIPTION
Some boards use strings for pin names (e.g. revolution pi). This allows arbitrary strings for pin name inputs.

## Testing

- [x] Verified that numeric pins still work a raspberry pi
- [x] Verify that string pins still work on a board with string pins