### PR TITLE
APP-2833: Add Headers for Package File Handler Authentication (secret-based)

### DIFF
--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -384,7 +384,7 @@ func newWithResources(
 	if cfg.Cloud != nil && cfg.Cloud.AppAddress != "" {
 		_, cloudConn, err := r.cloudConnSvc.AcquireConnection(ctx)
 		if err == nil {
-			r.packageManager, err = packages.NewCloudManager(pb.NewPackageServiceClient(cloudConn), cfg.PackagePath, logger)
+			r.packageManager, err = packages.NewCloudManager(cfg.Cloud, pb.NewPackageServiceClient(cloudConn), cfg.PackagePath, logger)
 			if err != nil {
 				return nil, err
 			}

--- a/robot/packages/cloud_package_manager_test.go
+++ b/robot/packages/cloud_package_manager_test.go
@@ -26,7 +26,12 @@ func newPackageManager(t *testing.T,
 	packageDir := t.TempDir()
 	logger.Info(packageDir)
 
-	pm, err := NewCloudManager(client, packageDir, logger)
+	testCloudConfig := &config.Cloud{
+		ID:     "some-id",
+		Secret: "some-secret",
+	}
+
+	pm, err := NewCloudManager(testCloudConfig, client, packageDir, logger)
 	test.That(t, err, test.ShouldBeNil)
 
 	return packageDir, pm


### PR DESCRIPTION
This change requests package files from App using header based auth of part secret.

Testing: I manually tested along with changes in https://github.com/viamrobotics/app/pull/2585/files. I investigated adding unit tests but currently there is mocking in place that does not do file downloads. Instead I think our our manual test cases cover this.