### PR TITLE
RSDK-5177 RSDK-5178 Move common analog config to generic linux only

### DIFF
--- a/components/board/config.go
+++ b/components/board/config.go
@@ -53,24 +53,6 @@ func (config *AnalogConfig) Validate(path string) error {
 	return nil
 }
 
-// AnalogConfig describes the configuration of an analog reader on a board.
-type AnalogConfig struct {
-	Name              string `json:"name"`
-	Pin               string `json:"pin"`         // analog input pin on the ADC itself
-	SPIBus            string `json:"spi_bus"`     // name of the SPI bus (which is configured elsewhere in the config file)
-	ChipSelect        string `json:"chip_select"` // the CS line for the ADC chip, typically a pin number on the board
-	AverageOverMillis int    `json:"average_over_ms,omitempty"`
-	SamplesPerSecond  int    `json:"samples_per_sec,omitempty"`
-}
-
-// Validate ensures all parts of the config are valid.
-func (config *AnalogConfig) Validate(path string) error {
-	if config.Name == "" {
-		return utils.NewConfigValidationFieldRequiredError(path, "name")
-	}
-	return nil
-}
-
 // DigitalInterruptConfig describes the configuration of digital interrupt for a board.
 type DigitalInterruptConfig struct {
 	Name    string `json:"name"`

--- a/components/board/config.go
+++ b/components/board/config.go
@@ -53,6 +53,24 @@ func (config *AnalogConfig) Validate(path string) error {
 	return nil
 }
 
+// AnalogConfig describes the configuration of an analog reader on a board.
+type AnalogConfig struct {
+	Name              string `json:"name"`
+	Pin               string `json:"pin"`         // analog input pin on the ADC itself
+	SPIBus            string `json:"spi_bus"`     // name of the SPI bus (which is configured elsewhere in the config file)
+	ChipSelect        string `json:"chip_select"` // the CS line for the ADC chip, typically a pin number on the board
+	AverageOverMillis int    `json:"average_over_ms,omitempty"`
+	SamplesPerSecond  int    `json:"samples_per_sec,omitempty"`
+}
+
+// Validate ensures all parts of the config are valid.
+func (config *AnalogConfig) Validate(path string) error {
+	if config.Name == "" {
+		return utils.NewConfigValidationFieldRequiredError(path, "name")
+	}
+	return nil
+}
+
 // DigitalInterruptConfig describes the configuration of digital interrupt for a board.
 type DigitalInterruptConfig struct {
 	Name    string `json:"name"`

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -279,12 +279,12 @@ func (b *Board) reconfigureAnalogReaders(ctx context.Context, newConf *LinuxBoar
 		if curr, ok := b.analogReaders[c.Name]; ok {
 			if curr.chipSelect != c.ChipSelect {
 				ar := &board.MCP3008AnalogReader{channel, bus, c.ChipSelect}
-				curr.reset(ctx, curr.chipSelect, board.SmoothAnalogReader(ar, board.AnalogConfig{AverageOverMillis: ac.AverageOverMillis, SamplesPerSecond: ac.SamplesPerSecond}, b.logger))
+				curr.reset(ctx, curr.chipSelect, board.SmoothAnalogReader(ar, board.AnalogConfig{AverageOverMillis: c.AverageOverMillis, SamplesPerSecond: c.SamplesPerSecond}, b.logger))
 			}
 			continue
 		}
 		ar := &board.MCP3008AnalogReader{channel, bus, c.ChipSelect}
-		b.analogReaders[c.Name] = newWrappedAnalogReader(ctx, c.ChipSelect, board.SmoothAnalogReader(ar, board.AnalogConfig{AverageOverMillis: ac.AverageOverMillis, SamplesPerSecond: ac.SamplesPerSecond}, b.logger))
+		b.analogReaders[c.Name] = newWrappedAnalogReader(ctx, c.ChipSelect, board.SmoothAnalogReader(ar, board.AnalogConfig{AverageOverMillis: c.AverageOverMillis, SamplesPerSecond: c.SamplesPerSecond}, b.logger))
 	}
 
 	for name := range b.analogReaders {

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -58,11 +58,11 @@ func NewBoard(
 		cancelCtx:  cancelCtx,
 		cancelFunc: cancelFunc,
 
-		spis:       map[string]*spiBus{},
-		analogs:    map[string]*wrappedAnalog{},
-		i2cs:       map[string]*I2cBus{},
-		gpios:      map[string]*gpioPin{},
-		interrupts: map[string]*digitalInterrupt{},
+		spis:          map[string]*spiBus{},
+		analogReaders: map[string]*wrappedAnalog{},
+		i2cs:          map[string]*I2cBus{},
+		gpios:         map[string]*gpioPin{},
+		interrupts:    map[string]*digitalInterrupt{},
 	}
 
 	if err := b.Reconfigure(ctx, nil, conf); err != nil {
@@ -94,7 +94,7 @@ func (b *Board) Reconfigure(
 	if err := b.reconfigureI2cs(newConf); err != nil {
 		return err
 	}
-	if err := b.reconfigureAnalogs(ctx, newConf); err != nil {
+	if err := b.reconfigureAnalogReaders(ctx, newConf); err != nil {
 		return err
 	}
 	if err := b.reconfigureInterrupts(newConf); err != nil {
@@ -262,9 +262,9 @@ func (b *Board) reconfigureI2cs(newConf *LinuxBoardConfig) error {
 	return nil
 }
 
-func (b *Board) reconfigureAnalogs(ctx context.Context, newConf *LinuxBoardConfig) error {
+func (b *Board) reconfigureAnalogReaders(ctx context.Context, newConf *LinuxBoardConfig) error {
 	stillExists := map[string]struct{}{}
-	for _, c := range newConf.Analogs {
+	for _, c := range newConf.AnalogReaders {
 		channel, err := strconv.Atoi(c.Pin)
 		if err != nil {
 			return errors.Errorf("bad analog pin (%s)", c.Pin)
@@ -276,7 +276,7 @@ func (b *Board) reconfigureAnalogs(ctx context.Context, newConf *LinuxBoardConfi
 		}
 
 		stillExists[c.Name] = struct{}{}
-		if curr, ok := b.analogs[c.Name]; ok {
+		if curr, ok := b.analogReaders[c.Name]; ok {
 			if curr.chipSelect != c.ChipSelect {
 				ar := &board.MCP3008AnalogReader{channel, bus, c.ChipSelect}
 				curr.reset(ctx, curr.chipSelect, board.SmoothAnalogReader(ar, c, b.logger))
@@ -284,15 +284,15 @@ func (b *Board) reconfigureAnalogs(ctx context.Context, newConf *LinuxBoardConfi
 			continue
 		}
 		ar := &board.MCP3008AnalogReader{channel, bus, c.ChipSelect}
-		b.analogs[c.Name] = newWrappedAnalog(ctx, c.ChipSelect, board.SmoothAnalogReader(ar, c, b.logger))
+		b.analogReaders[c.Name] = newWrappedAnalog(ctx, c.ChipSelect, board.SmoothAnalogReader(ar, c, b.logger))
 	}
 
-	for name := range b.analogs {
+	for name := range b.analogReaders {
 		if _, ok := stillExists[name]; ok {
 			continue
 		}
-		b.analogs[name].reset(ctx, "", nil)
-		delete(b.analogs, name)
+		b.analogReaders[name].reset(ctx, "", nil)
+		delete(b.analogReaders, name)
 	}
 	return nil
 }
@@ -402,19 +402,19 @@ func (b *Board) reconfigureInterrupts(newConf *LinuxBoardConfig) error {
 	return nil
 }
 
-type wrappedAnalog struct {
+type wrappedAnalogReader struct {
 	mu         sync.RWMutex
 	chipSelect string
 	reader     *board.AnalogSmoother
 }
 
-func newWrappedAnalog(ctx context.Context, chipSelect string, reader *board.AnalogSmoother) *wrappedAnalog {
-	var wrapped wrappedAnalog
+func newWrappedAnalogReader(ctx context.Context, chipSelect string, reader *board.AnalogSmoother) *wrappedAnalog {
+	var wrapped wrappedAnalogReader
 	wrapped.reset(ctx, chipSelect, reader)
 	return &wrapped
 }
 
-func (a *wrappedAnalog) Read(ctx context.Context, extra map[string]interface{}) (int, error) {
+func (a *wrappedAnalogReader) Read(ctx context.Context, extra map[string]interface{}) (int, error) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	if a.reader == nil {
@@ -423,11 +423,11 @@ func (a *wrappedAnalog) Read(ctx context.Context, extra map[string]interface{}) 
 	return a.reader.Read(ctx, extra)
 }
 
-func (a *wrappedAnalog) Close(ctx context.Context) error {
+func (a *wrappedAnalogReader) Close(ctx context.Context) error {
 	return nil
 }
 
-func (a *wrappedAnalog) reset(ctx context.Context, chipSelect string, reader *board.AnalogSmoother) {
+func (a *wrappedAnalogReader) reset(ctx context.Context, chipSelect string, reader *board.AnalogSmoother) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if a.reader != nil {
@@ -443,11 +443,11 @@ type Board struct {
 	mu            sync.RWMutex
 	convertConfig ConfigConverter
 
-	gpioMappings map[string]GPIOBoardMapping
-	spis         map[string]*spiBus
-	analogs      map[string]*wrappedAnalog
-	i2cs         map[string]*I2cBus
-	logger       golog.Logger
+	gpioMappings  map[string]GPIOBoardMapping
+	spis          map[string]*spiBus
+	analogReaders map[string]*wrappedAnalogReader
+	i2cs          map[string]*I2cBus
+	logger        golog.Logger
 
 	gpios      map[string]*gpioPin
 	interrupts map[string]*digitalInterrupt
@@ -471,7 +471,7 @@ func (b *Board) I2CByName(name string) (board.I2C, bool) {
 
 // AnalogReaderByName returns the analog reader by the given name if it exists.
 func (b *Board) AnalogReaderByName(name string) (board.AnalogReader, bool) {
-	a, ok := b.analogs[name]
+	a, ok := b.analogReaders[name]
 	return a, ok
 }
 
@@ -541,7 +541,7 @@ func (b *Board) I2CNames() []string {
 // AnalogReaderNames returns the names of all known analog readers.
 func (b *Board) AnalogReaderNames() []string {
 	names := []string{}
-	for k := range b.analogs {
+	for k := range b.analogReaders {
 		names = append(names, k)
 	}
 	return names

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -281,14 +281,16 @@ func (b *Board) reconfigureAnalogReaders(ctx context.Context, newConf *LinuxBoar
 				ar := &board.MCP3008AnalogReader{channel, bus, c.ChipSelect}
 				curr.reset(ctx, curr.chipSelect,
 					board.SmoothAnalogReader(ar, board.AnalogConfig{
-						AverageOverMillis: c.AverageOverMillis, SamplesPerSecond: c.SamplesPerSecond}, b.logger))
+						AverageOverMillis: c.AverageOverMillis, SamplesPerSecond: c.SamplesPerSecond,
+					}, b.logger))
 			}
 			continue
 		}
 		ar := &board.MCP3008AnalogReader{channel, bus, c.ChipSelect}
 		b.analogReaders[c.Name] = newWrappedAnalogReader(ctx, c.ChipSelect,
 			board.SmoothAnalogReader(ar, board.AnalogConfig{
-				AverageOverMillis: c.AverageOverMillis, SamplesPerSecond: c.SamplesPerSecond}, b.logger))
+				AverageOverMillis: c.AverageOverMillis, SamplesPerSecond: c.SamplesPerSecond,
+			}, b.logger))
 	}
 
 	for name := range b.analogReaders {

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -279,12 +279,16 @@ func (b *Board) reconfigureAnalogReaders(ctx context.Context, newConf *LinuxBoar
 		if curr, ok := b.analogReaders[c.Name]; ok {
 			if curr.chipSelect != c.ChipSelect {
 				ar := &board.MCP3008AnalogReader{channel, bus, c.ChipSelect}
-				curr.reset(ctx, curr.chipSelect, board.SmoothAnalogReader(ar, board.AnalogConfig{AverageOverMillis: c.AverageOverMillis, SamplesPerSecond: c.SamplesPerSecond}, b.logger))
+				curr.reset(ctx, curr.chipSelect,
+					board.SmoothAnalogReader(ar, board.AnalogConfig{
+						AverageOverMillis: c.AverageOverMillis, SamplesPerSecond: c.SamplesPerSecond}, b.logger))
 			}
 			continue
 		}
 		ar := &board.MCP3008AnalogReader{channel, bus, c.ChipSelect}
-		b.analogReaders[c.Name] = newWrappedAnalogReader(ctx, c.ChipSelect, board.SmoothAnalogReader(ar, board.AnalogConfig{AverageOverMillis: c.AverageOverMillis, SamplesPerSecond: c.SamplesPerSecond}, b.logger))
+		b.analogReaders[c.Name] = newWrappedAnalogReader(ctx, c.ChipSelect,
+			board.SmoothAnalogReader(ar, board.AnalogConfig{
+				AverageOverMillis: c.AverageOverMillis, SamplesPerSecond: c.SamplesPerSecond}, b.logger))
 	}
 
 	for name := range b.analogReaders {

--- a/components/board/genericlinux/board_test.go
+++ b/components/board/genericlinux/board_test.go
@@ -49,7 +49,7 @@ func TestGenericLinux(t *testing.T) {
 		Named:         board.Named("foo").AsNamed(),
 		gpioMappings:  nil,
 		spis:          boardSPIs,
-		analogReaders: map[string]*wrappedAnalogReaders{"an": {}},
+		analogReaders: map[string]*wrappedAnalogReader{"an": {}},
 		logger:        golog.NewTestLogger(t),
 		cancelCtx:     ctx,
 		cancelFunc: func() {
@@ -61,7 +61,7 @@ func TestGenericLinux(t *testing.T) {
 		test.That(t, ans, test.ShouldResemble, []string{"an"})
 
 		an1, ok := b.AnalogReaderByName("an")
-		test.That(t, an1, test.ShouldHaveSameTypeAs, &wrappedAnalogReaders{})
+		test.That(t, an1, test.ShouldHaveSameTypeAs, &wrappedAnalogReader{})
 		test.That(t, ok, test.ShouldBeTrue)
 
 		an2, ok := b.AnalogReaderByName("missing")

--- a/components/board/genericlinux/board_test.go
+++ b/components/board/genericlinux/board_test.go
@@ -46,22 +46,22 @@ func TestGenericLinux(t *testing.T) {
 	boardSPIs["open"].openHandle.bus.bus.Store(&twoStr)
 
 	b = &Board{
-		Named:        board.Named("foo").AsNamed(),
-		gpioMappings: nil,
-		spis:         boardSPIs,
-		analogs:      map[string]*wrappedAnalog{"an": {}},
-		logger:       golog.NewTestLogger(t),
-		cancelCtx:    ctx,
+		Named:         board.Named("foo").AsNamed(),
+		gpioMappings:  nil,
+		spis:          boardSPIs,
+		analogReaders: map[string]*wrappedAnalogReaders{"an": {}},
+		logger:        golog.NewTestLogger(t),
+		cancelCtx:     ctx,
 		cancelFunc: func() {
 		},
 	}
 
-	t.Run("test analogs spis i2cs digital-interrupts and gpio names", func(t *testing.T) {
+	t.Run("test analog-readers spis i2cs digital-interrupts and gpio names", func(t *testing.T) {
 		ans := b.AnalogReaderNames()
 		test.That(t, ans, test.ShouldResemble, []string{"an"})
 
 		an1, ok := b.AnalogReaderByName("an")
-		test.That(t, an1, test.ShouldHaveSameTypeAs, &wrappedAnalog{})
+		test.That(t, an1, test.ShouldHaveSameTypeAs, &wrappedAnalogReaders{})
 		test.That(t, ok, test.ShouldBeTrue)
 
 		an2, ok := b.AnalogReaderByName("missing")
@@ -122,13 +122,13 @@ func TestGenericLinux(t *testing.T) {
 func TestConfigValidate(t *testing.T) {
 	validConfig := Config{}
 
-	validConfig.Analogs = []board.AnalogConfig{{}}
+	validConfig.AnalogReaders = []board.MCP3008AnalogConfig{{}}
 	_, err := validConfig.Validate("path")
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, `path.analogs.0`)
 	test.That(t, err.Error(), test.ShouldContainSubstring, `"name" is required`)
 
-	validConfig.Analogs = []board.AnalogConfig{{Name: "bar"}}
+	validConfig.AnalogReaders = []board.MCP3008AnalogConfig{{Name: "bar"}}
 	_, err = validConfig.Validate("path")
 	test.That(t, err, test.ShouldBeNil)
 

--- a/components/board/genericlinux/config.go
+++ b/components/board/genericlinux/config.go
@@ -12,7 +12,7 @@ import (
 type Config struct {
 	I2Cs              []board.I2CConfig              `json:"i2cs,omitempty"`
 	SPIs              []board.SPIConfig              `json:"spis,omitempty"`
-	Analogs           []board.AnalogConfig           `json:"analogs,omitempty"`
+	AnalogReaders     []board.MCP3008AnalogConfig    `json:"analogs,omitempty"`
 	DigitalInterrupts []board.DigitalInterruptConfig `json:"digital_interrupts,omitempty"`
 	Attributes        utils.AttributeMap             `json:"attributes,omitempty"`
 }
@@ -29,7 +29,7 @@ func (conf *Config) Validate(path string) ([]string, error) {
 			return nil, err
 		}
 	}
-	for idx, c := range conf.Analogs {
+	for idx, c := range conf.AnalogReaders {
 		if err := c.Validate(fmt.Sprintf("%s.%s.%d", path, "analogs", idx)); err != nil {
 			return nil, err
 		}
@@ -52,7 +52,7 @@ func (conf *Config) Validate(path string) ([]string, error) {
 type LinuxBoardConfig struct {
 	I2Cs              []board.I2CConfig
 	SPIs              []board.SPIConfig
-	Analogs           []board.AnalogConfig
+	AnalogReaders     []board.MCP3008AnalogConfig
 	DigitalInterrupts []board.DigitalInterruptConfig
 	GpioMappings      map[string]GPIOBoardMapping
 }
@@ -77,7 +77,7 @@ func ConstPinDefs(gpioMappings map[string]GPIOBoardMapping) ConfigConverter {
 		return &LinuxBoardConfig{
 			I2Cs:              newConf.I2Cs,
 			SPIs:              newConf.SPIs,
-			Analogs:           newConf.Analogs,
+			AnalogReaders:     newConf.AnalogReaders,
 			DigitalInterrupts: newConf.DigitalInterrupts,
 			GpioMappings:      gpioMappings,
 		}, nil

--- a/components/board/mcp3008.go
+++ b/components/board/mcp3008.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"go.uber.org/multierr"
+	"go.viam.com/utils"
 )
 
 // MCP3008AnalogReader implements a board.AnalogReader using an MCP3008 ADC via SPI.
@@ -11,6 +12,24 @@ type MCP3008AnalogReader struct {
 	Channel int
 	Bus     SPI
 	Chip    string
+}
+
+// AnalogConfig describes the configuration of an analog reader on a board.
+type MCP3008AnalogConfig struct {
+	Name              string `json:"name"`
+	Pin               string `json:"pin"`         // analog input pin on the ADC itself
+	SPIBus            string `json:"spi_bus"`     // name of the SPI bus (which is configured elsewhere in the config file)
+	ChipSelect        string `json:"chip_select"` // the CS line for the ADC chip, typically a pin number on the board
+	AverageOverMillis int    `json:"average_over_ms,omitempty"`
+	SamplesPerSecond  int    `json:"samples_per_sec,omitempty"`
+}
+
+// Validate ensures all parts of the config are valid.
+func (config *MCP3008AnalogConfig) Validate(path string) error {
+	if config.Name == "" {
+		return utils.NewConfigValidationFieldRequiredError(path, "name")
+	}
+	return nil
 }
 
 func (mar *MCP3008AnalogReader) Read(ctx context.Context, extra map[string]interface{}) (value int, err error) {

--- a/components/board/mcp3008.go
+++ b/components/board/mcp3008.go
@@ -14,7 +14,7 @@ type MCP3008AnalogReader struct {
 	Chip    string
 }
 
-// AnalogConfig describes the configuration of an analog reader on a board.
+// MCP3008AnalogConfig describes the configuration of a MCP3008 analog reader on a board.
 type MCP3008AnalogConfig struct {
 	Name              string `json:"name"`
 	Pin               string `json:"pin"`         // analog input pin on the ADC itself

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -231,7 +231,9 @@ func (pi *piPigpio) reconfigureAnalogReaders(ctx context.Context, cfg *genericli
 
 		ar := &board.MCP3008AnalogReader{channel, bus, ac.ChipSelect}
 
-		pi.analogReaders[ac.Name] = board.SmoothAnalogReader(ar, board.AnalogConfig{AverageOverMillis: ac.AverageOverMillis, SamplesPerSecond: ac.SamplesPerSecond}, pi.logger)
+		pi.analogReaders[ac.Name] = board.SmoothAnalogReader(ar, board.AnalogConfig{
+			AverageOverMillis: ac.AverageOverMillis, SamplesPerSecond: ac.SamplesPerSecond,
+		}, pi.logger)
 	}
 	return nil
 }

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -36,7 +36,6 @@ import (
 	pb "go.viam.com/api/component/board/v1"
 
 	"go.viam.com/rdk/components/board"
-	"go.viam.com/rdk/components/board/genericlinux"
 	picommon "go.viam.com/rdk/components/board/pi/common"
 	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/resource"
@@ -192,7 +191,7 @@ func (pi *piPigpio) Reconfigure(
 	_ resource.Dependencies,
 	conf resource.Config,
 ) error {
-	cfg, err := resource.NativeConfig[*genericlinux.Config](conf)
+	cfg, err := resource.NativeConfig[*Config](conf)
 	if err != nil {
 		return err
 	}
@@ -224,7 +223,7 @@ func (pi *piPigpio) Reconfigure(
 	return nil
 }
 
-func (pi *piPigpio) reconfigureI2cs(ctx context.Context, cfg *genericlinux.Config) error {
+func (pi *piPigpio) reconfigureI2cs(ctx context.Context, cfg *Config) error {
 	// No need to reconfigure the old I2C buses; just throw them out and make new ones.
 	pi.i2cs = make(map[string]board.I2C, len(cfg.I2Cs))
 	for _, sc := range cfg.I2Cs {
@@ -237,7 +236,7 @@ func (pi *piPigpio) reconfigureI2cs(ctx context.Context, cfg *genericlinux.Confi
 	return nil
 }
 
-func (pi *piPigpio) reconfigureSpis(ctx context.Context, cfg *genericlinux.Config) error {
+func (pi *piPigpio) reconfigureSpis(ctx context.Context, cfg *Config) error {
 	// No need to reconfigure the old SPI buses; just throw them out and make new ones.
 	pi.spis = make(map[string]board.SPI, len(cfg.SPIs))
 	for _, sc := range cfg.SPIs {
@@ -249,7 +248,7 @@ func (pi *piPigpio) reconfigureSpis(ctx context.Context, cfg *genericlinux.Confi
 	return nil
 }
 
-func (pi *piPigpio) reconfigureAnalogReaders(ctx context.Context, cfg *genericlinux.Config) error {
+func (pi *piPigpio) reconfigureAnalogReaders(ctx context.Context, cfg *Config) error {
 	// No need to reconfigure the old analog readers; just throw them out and make new ones.
 	pi.analogReaders = map[string]board.AnalogReader{}
 	for _, ac := range cfg.AnalogReaders {
@@ -299,7 +298,7 @@ func findInterruptBcom(
 	return 0, false
 }
 
-func (pi *piPigpio) reconfigureInterrupts(ctx context.Context, cfg *genericlinux.Config) error {
+func (pi *piPigpio) reconfigureInterrupts(ctx context.Context, cfg *Config) error {
 	// We reuse the old interrupts when possible.
 	oldInterrupts := pi.interrupts
 	oldInterruptsHW := pi.interruptsHW

--- a/components/board/pi/impl/board_test.go
+++ b/components/board/pi/impl/board_test.go
@@ -12,7 +12,6 @@ import (
 	"go.viam.com/test"
 
 	"go.viam.com/rdk/components/board"
-	"go.viam.com/rdk/components/board/genericlinux"
 	picommon "go.viam.com/rdk/components/board/pi/common"
 	"go.viam.com/rdk/components/servo"
 	"go.viam.com/rdk/operation"
@@ -23,7 +22,7 @@ func TestPiPigpio(t *testing.T) {
 	ctx := context.Background()
 	logger := golog.NewTestLogger(t)
 
-	cfg := genericlinux.Config{
+	cfg := Config{
 		DigitalInterrupts: []board.DigitalInterruptConfig{
 			{Name: "i1", Pin: "11"}, // bcom 17
 			{Name: "servo-i", Pin: "22", Type: "servo"},


### PR DESCRIPTION
This combines the two tickets for moving the current common board config for MCP3008 ADC for only pi and generic linux boards. Haven't removed the common config from the other boards yet to avoid breaking changes in this PR. Also changed name `Analogs` to `AnalogReaders` in generic linux. 