### PR TITLE
[RSDK-5240] Let the PCA9685 component talk directly to the I2C bus

### DIFF
--- a/components/board/genericlinux/i2c.go
+++ b/components/board/genericlinux/i2c.go
@@ -154,28 +154,28 @@ func (h *I2cHandle) Close() error {
 	return nil
 }
 
-// GetI2CBus retrieves an I2C interface. If the bus_num is specified, it uses that on the local
+// GetI2CBus retrieves an I2C interface. If the bus number is specified, it uses that on the local
 // machine, and otherwise it tries to get the named bus from the named board.
 // TODO(RSDK-5254): remove this once all I2C devices are talking directly to the bus without going
 // through the board.
-func GetI2CBus(deps resource.Dependencies, board_name string, bus_name string, bus_num int) (board.I2C, error) {
-    if bus_num != 0 {
-        return NewI2cBus(fmt.Sprintf("%d", bus_num))
-    }
+func GetI2CBus(deps resource.Dependencies, boardName, busName string, busNum int) (board.I2C, error) {
+	if busNum != 0 {
+		return NewI2cBus(fmt.Sprintf("%d", busNum))
+	}
 
-    // Otherwise, look things up through the board.
-    b, err := board.FromDependencies(deps, board_name)
-    if err != nil {
-        return nil, err
-    }
-    localBoard, ok := b.(board.LocalBoard)
-    if !ok {
-        return nil, fmt.Errorf("Cannot get I2C bus '%s' from nonlocal board '%s'",
-                               bus_name, board_name)
-    }
-    bus, success := localBoard.I2CByName(bus_name)
-    if !success {
-        return nil, fmt.Errorf("Unknown I2C bus %s on board %s", bus_name, board_name)
-    }
-    return bus, nil
+	// Otherwise, look things up through the board.
+	b, err := board.FromDependencies(deps, boardName)
+	if err != nil {
+		return nil, err
+	}
+	localBoard, ok := b.(board.LocalBoard)
+	if !ok {
+		return nil, fmt.Errorf("cannot get I2C bus '%s' from nonlocal board '%s'",
+			busName, boardName)
+	}
+	bus, success := localBoard.I2CByName(busName)
+	if !success {
+		return nil, fmt.Errorf("unknown I2C bus %s on board %s", busName, boardName)
+	}
+	return bus, nil
 }

--- a/components/board/genericlinux/i2c.go
+++ b/components/board/genericlinux/i2c.go
@@ -158,10 +158,9 @@ func (h *I2cHandle) Close() error {
 // machine, and otherwise it tries to get the named bus from the named board.
 // TODO(RSDK-5254): remove this once all I2C devices are talking directly to the bus without going
 // through the board.
-func GetI2CBus(
-    deps resource.Dependencies, board_name string, bus_name string, bus_num int) (board.I2C, error) {
+func GetI2CBus(deps resource.Dependencies, board_name string, bus_name string, bus_num int) (board.I2C, error) {
     if bus_num != 0 {
-        return NewI2cBus(fmt.Sprintf("%s", bus_num))
+        return NewI2cBus(fmt.Sprintf("%d", bus_num))
     }
 
     // Otherwise, look things up through the board.

--- a/components/board/hat/pca9685/pca9685.go
+++ b/components/board/hat/pca9685/pca9685.go
@@ -138,12 +138,12 @@ func (pca *PCA9685) Reconfigure(ctx context.Context, deps resource.Dependencies,
 		return err
 	}
 
-	bus_num := 0
+	busNum := 0
 	if newConf.I2CBus != nil {
-		bus_num = *newConf.I2CBus
+		busNum = *newConf.I2CBus
 	}
 
-	bus, err := genericlinux.GetI2CBus(deps, newConf.BoardName, newConf.I2CName, bus_num)
+	bus, err := genericlinux.GetI2CBus(deps, newConf.BoardName, newConf.I2CName, busNum)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This has a couple changes:
- In the genericlinux package, there's now a `GetI2CBus` function. If you give it a bus number, it gets the raw I2C bus straight from the OS, and otherwise it tries to get the bus from the board component like we used to do. This way, you can either specify the I2C bus the old way (by naming the board and the entry in the "i2cs" map within the board) or the new way (just name the raw I2C bus on the machine). This function has a TODO to remove it again when all robot configs are converted from the old approach to the new one.
- In the PCA9685 component, make the `board_name` and `bus_name` entries in the config optional, and also add an optional `i2c_bus` int. In the `Validate` function, make sure that either the first two or that last one is present.
- In the PCA9685 component, call `GetI2CBus` to get the bus. It takes in the new `i2c_bus` int if present, and the `board_name` and `bus_name` if it's not present.
- Remove the "return early if nothing has changed" paragraph in the PCA9685's reconfiguration. It was "saving" a trivial amount of work (to the point that the if statement itself might have run slower than the work it saved). It would need adapting as the definition of "if nothing has changed" would need to be updated, but removing it was way easier.

Once this change is in, we can update all the robot configs to use the new approach instead of the old one, and afterwards stop using `GetI2CBus` in favor of just calling `NewI2cBus` ourselves. I can find 13 configs in the database that mention a PCA9685 board.

Tried on a raspberry pi with a PCA9685 with a servo hooked to it: works as normal with both this old config (with trivial parts removed to make it easier to read):
```
"components": [
    {
      "attributes": {
        "i2cs": [
          {
            "bus": "1",
            "name": "main"
          }
        ],
      },
      "model": "pi",
      "name": "board",
      "type": "board"
    },
    {
      "attributes": {
        "board_name": "board",
        "i2c_name": "main"
      },
      "model": "pca9685",
      "name": "pca",
      "type": "board"
    },
    {
      "attributes": {
        "board": "pca",
        "pin": "15"
      },
      "model": "gpio",
      "name": "serv",
      "type": "servo"
    }
  ],
```
and this new config (again with trivial parts removed to make it easier to read):
```
  "components": [
    {
      "model": "pi",
      "name": "board",
      "type": "board",
    },
    {
      "type": "board",
      "attributes": {
        "i2c_bus": 1
      },
      "model": "pca9685",
      "name": "pca"
    },
    {
      "attributes": {
        "board": "pca",
        "pin": "15"
      },
      "model": "gpio",
      "name": "serv",
      "type": "servo"
    }
  ],
```
...and, frankly, it also works if you remove the raspberry pi component entirely, since we're not doing anything with that board specifically.