### PR TITLE
RSDK-5264 remove reserved characters from filenames

### DIFF
--- a/cli/data.go
+++ b/cli/data.go
@@ -425,9 +425,8 @@ func filenameForDownload(meta *datapb.BinaryMetadata) string {
 		fileName = strings.Map(func(c rune) rune {
 			if strings.ContainsRune(windowsReservedChars, c) {
 				return '_'
-			} else {
-				return c
 			}
+			return c
 		}, fileName)
 	}
 	return fileName

--- a/cli/data.go
+++ b/cli/data.go
@@ -399,7 +399,10 @@ func downloadBinary(ctx context.Context, client datapb.DataServiceClient, dst st
 	return nil
 }
 
-// create the destination path
+// non-exhaustive list of characters to strip from filenames on windows
+const windowsReservedChars = ":"
+
+// transform datum's filename to a destination path on this computer
 func filenameForDownload(meta *datapb.BinaryMetadata) string {
 	timeRequested := meta.GetTimeRequested().AsTime().Format(time.RFC3339Nano)
 	fileName := meta.GetFileName()
@@ -419,7 +422,13 @@ func filenameForDownload(meta *datapb.BinaryMetadata) string {
 	}
 
 	if runtime.GOOS == "windows" {
-		panic("todo: windows-specific reserved character rules")
+		fileName = strings.Map(func(c rune) rune {
+			if strings.ContainsRune(windowsReservedChars, c) {
+				return '_'
+			} else {
+				return c
+			}
+		}, fileName)
 	}
 	return fileName
 }

--- a/cli/data.go
+++ b/cli/data.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -346,22 +347,7 @@ func downloadBinary(ctx context.Context, client datapb.DataServiceClient, dst st
 		return err
 	}
 
-	timeRequested := datum.GetMetadata().GetTimeRequested().AsTime().Format(time.RFC3339Nano)
-	fileName := datum.GetMetadata().GetFileName()
-
-	// The file name will end with .gz if the user uploaded a gzipped file. We will unzip it below, so remove the last
-	// .gz from the file name. If the user has gzipped the file multiple times, we will only unzip once.
-	if filepath.Ext(fileName) == gzFileExt {
-		fileName = strings.TrimSuffix(fileName, gzFileExt)
-	}
-
-	if fileName == "" {
-		fileName = timeRequested + "_" + datum.GetMetadata().GetId()
-	} else if filepath.Dir(fileName) == "." {
-		// If the file name does not contain a directory, prepend if with a requested time so that it is sorted.
-		// Otherwise, keep the file name as-is to maintain the directory structure that the user uploaded the file with.
-		fileName = timeRequested + "_" + strings.TrimSuffix(datum.GetMetadata().GetFileName(), datum.GetMetadata().GetFileExt())
-	}
+	fileName := filenameForDownload(datum.GetMetadata())
 
 	jsonPath := filepath.Join(dst, metadataDir, fileName+".json")
 	if err := os.MkdirAll(filepath.Dir(jsonPath), 0o700); err != nil {
@@ -411,6 +397,31 @@ func downloadBinary(ctx context.Context, client datapb.DataServiceClient, dst st
 		return err
 	}
 	return nil
+}
+
+// create the destination path
+func filenameForDownload(meta *datapb.BinaryMetadata) string {
+	timeRequested := meta.GetTimeRequested().AsTime().Format(time.RFC3339Nano)
+	fileName := meta.GetFileName()
+
+	// The file name will end with .gz if the user uploaded a gzipped file. We will unzip it below, so remove the last
+	// .gz from the file name. If the user has gzipped the file multiple times, we will only unzip once.
+	if filepath.Ext(fileName) == gzFileExt {
+		fileName = strings.TrimSuffix(fileName, gzFileExt)
+	}
+
+	if fileName == "" {
+		fileName = timeRequested + "_" + meta.GetId()
+	} else if filepath.Dir(fileName) == "." {
+		// If the file name does not contain a directory, prepend if with a requested time so that it is sorted.
+		// Otherwise, keep the file name as-is to maintain the directory structure that the user uploaded the file with.
+		fileName = timeRequested + "_" + strings.TrimSuffix(meta.GetFileName(), meta.GetFileExt())
+	}
+
+	if runtime.GOOS == "windows" {
+		panic("todo: windows-specific reserved character rules")
+	}
+	return fileName
 }
 
 // tabularData downloads binary data matching filter to dst.

--- a/cli/data.go
+++ b/cli/data.go
@@ -399,10 +399,10 @@ func downloadBinary(ctx context.Context, client datapb.DataServiceClient, dst st
 	return nil
 }
 
-// non-exhaustive list of characters to strip from filenames on windows
+// non-exhaustive list of characters to strip from filenames on windows.
 const windowsReservedChars = ":"
 
-// transform datum's filename to a destination path on this computer
+// transform datum's filename to a destination path on this computer.
 func filenameForDownload(meta *datapb.BinaryMetadata) string {
 	timeRequested := meta.GetTimeRequested().AsTime().Format(time.RFC3339Nano)
 	fileName := meta.GetFileName()

--- a/cli/data_test.go
+++ b/cli/data_test.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"testing"
+
+	datapb "go.viam.com/api/app/data/v1"
+	"go.viam.com/test"
+)
+
+func TestFilenameForDownload(t *testing.T) {
+	const utc0 = "1970-01-01T00:00:00Z"
+	noFilename := filenameForDownload(&datapb.BinaryMetadata{
+		Id: "my-id",
+	})
+	test.That(t, noFilename, test.ShouldEqual, utc0+"_my-id")
+
+	normalExt := filenameForDownload(&datapb.BinaryMetadata{
+		FileName: "whatever.txt",
+	})
+	test.That(t, normalExt, test.ShouldEqual, utc0+"_whatever.txt")
+
+	inFolder := filenameForDownload(&datapb.BinaryMetadata{
+		FileName: "dir/whatever.txt",
+	})
+	test.That(t, inFolder, test.ShouldEqual, "dir/whatever.txt")
+
+	gzAtRoot := filenameForDownload(&datapb.BinaryMetadata{
+		FileName: "whatever.gz",
+	})
+	test.That(t, gzAtRoot, test.ShouldEqual, utc0+"_whatever.gz")
+
+	gzInFolder := filenameForDownload(&datapb.BinaryMetadata{
+		FileName: "dir/whatever.gz",
+	})
+	test.That(t, gzInFolder, test.ShouldEqual, "dir/whatever")
+}


### PR DESCRIPTION
## What changed
- transform `:` to `_` when running `data export` on windows because `:` is not allowed in filenames
- (incidental) factored out `filenameForDownload` from `downloadBinary` so it can be tested in isolation