### PR TITLE
remove unused config value from PCA9685

### DIFF
--- a/components/board/hat/pca9685/pca9685.go
+++ b/components/board/hat/pca9685/pca9685.go
@@ -33,7 +33,6 @@ type Config struct {
 	I2CName        string `json:"i2c_name,omitempty"`
 	I2CBus         *int   `json:"i2c_bus,omitempty"`
 	I2CAddress     *int   `json:"i2c_address,omitempty"`
-	PWMFrequencyHz int    `json:"pwm_frequency_hz,omitempty"`
 }
 
 // Validate ensures all parts of the config are valid.

--- a/components/board/hat/pca9685/pca9685.go
+++ b/components/board/hat/pca9685/pca9685.go
@@ -29,10 +29,10 @@ var (
 
 // Config describes a PCA9685 board attached to some other board via I2C.
 type Config struct {
-	BoardName      string `json:"board_name,omitempty"`
-	I2CName        string `json:"i2c_name,omitempty"`
-	I2CBus         *int   `json:"i2c_bus,omitempty"`
-	I2CAddress     *int   `json:"i2c_address,omitempty"`
+	BoardName  string `json:"board_name,omitempty"`
+	I2CName    string `json:"i2c_name,omitempty"`
+	I2CBus     *int   `json:"i2c_bus,omitempty"`
+	I2CAddress *int   `json:"i2c_address,omitempty"`
 }
 
 // Validate ensures all parts of the config are valid.


### PR DESCRIPTION
This is literally never used, nor do I understand what it could be used for (~~I believe every PWM pin on this board can be set to its own frequency independent of the rest~~ _edit: the board does have just one frequency for all pins. but this config value is still unused_).

I've made a corresponding change to the Docs repo in https://github.com/viamrobotics/docs/pull/1970