### PR TITLE
RSDK-5271 Fix move_request for MoveOnGlobe to always plan relative to the base's current pose

### DIFF
--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -594,7 +594,7 @@ func TestMoveOnGlobe(t *testing.T) {
 	extra["timeout"] = 5.
 
 	dst := geo.NewPoint(gpsPoint.Lat(), gpsPoint.Lng()+1e-5)
-	expectedDst := r3.Vector{380, 0, 0}
+	expectedDst := r3.Vector{0, 380, 0} // Relative pose to the starting point of the base; facing east, Y = forwards
 	epsilonMM := 15.
 
 	t.Run("ensure success to a nearby geo point", func(t *testing.T) {
@@ -849,8 +849,8 @@ func TestCheckPlan(t *testing.T) {
 	})
 	t.Run("with a blocking obstacle - ensure failure", func(t *testing.T) {
 		obstacle, err := spatialmath.NewBox(
-			spatialmath.NewPoseFromPoint(r3.Vector{380, 0, 0}),
-			r3.Vector{10, 10, 1}, "obstacle",
+			spatialmath.NewPoseFromPoint(r3.Vector{0, 380, 0}), // Y means forwards from the base's pose at the start of the motion
+			r3.Vector{10, 10, 10}, "obstacle",
 		)
 		test.That(t, err, test.ShouldBeNil)
 		geoms := []spatialmath.Geometry{obstacle}
@@ -864,7 +864,10 @@ func TestCheckPlan(t *testing.T) {
 	})
 
 	// create camera_origin frame
-	cameraOriginFrame, err := referenceframe.NewStaticFrame("camera-origin", spatialmath.NewPoseFromPoint(r3.Vector{0, -30, 0}))
+	cameraOriginFrame, err := referenceframe.NewStaticFrame(
+		"camera-origin",
+		spatialmath.NewPose(r3.Vector{0, -30, 0}, &spatialmath.OrientationVector{OY: 1}),
+	)
 	test.That(t, err, test.ShouldBeNil)
 	err = newFS.AddFrame(cameraOriginFrame, moveRequest.kinematicBase.Kinematics())
 	test.That(t, err, test.ShouldBeNil)
@@ -876,9 +879,9 @@ func TestCheckPlan(t *testing.T) {
 	)
 	test.That(t, err, test.ShouldBeNil)
 
-	// create cameraFrame and add to framesystem
+	// create cameraFrame and add to framesystem. Camera should be pointed forwards.
 	cameraFrame, err := referenceframe.NewStaticFrameWithGeometry(
-		"camera-frame", spatialmath.NewPoseFromPoint(r3.Vector{0, 0, 0}), cameraGeom,
+		"camera-frame", spatialmath.NewZeroPose(), cameraGeom,
 	)
 	test.That(t, err, test.ShouldBeNil)
 	err = newFS.AddFrame(cameraFrame, cameraOriginFrame)
@@ -888,7 +891,7 @@ func TestCheckPlan(t *testing.T) {
 		// create obstacle
 		obstacle, err := spatialmath.NewBox(
 			spatialmath.NewPoseFromPoint(r3.Vector{1500, -6, 0}),
-			r3.Vector{10, 10, 1}, "obstacle",
+			r3.Vector{10, 10, 10}, "obstacle",
 		)
 		test.That(t, err, test.ShouldBeNil)
 		geoms := []spatialmath.Geometry{obstacle}
@@ -903,8 +906,8 @@ func TestCheckPlan(t *testing.T) {
 	t.Run("ensure transforms of obstacles works - collision with camera", func(t *testing.T) {
 		// create obstacle
 		obstacle, err := spatialmath.NewBox(
-			spatialmath.NewPoseFromPoint(r3.Vector{380, 0, 0}),
-			r3.Vector{10, 10, 1}, "obstacle",
+			spatialmath.NewPoseFromPoint(r3.Vector{0, 0, 380}),
+			r3.Vector{10, 10, 10}, "obstacle",
 		)
 		test.That(t, err, test.ShouldBeNil)
 		geoms := []spatialmath.Geometry{obstacle}

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -864,10 +864,7 @@ func TestCheckPlan(t *testing.T) {
 	})
 
 	// create camera_origin frame
-	cameraOriginFrame, err := referenceframe.NewStaticFrame(
-		"camera-origin",
-		spatialmath.NewPose(r3.Vector{0, -30, 0}, &spatialmath.OrientationVector{OY: 1}),
-	)
+	cameraOriginFrame, err := referenceframe.NewStaticFrame("camera-origin", spatialmath.NewPoseFromPoint(r3.Vector{0, -30, 0}))
 	test.That(t, err, test.ShouldBeNil)
 	err = newFS.AddFrame(cameraOriginFrame, moveRequest.kinematicBase.Kinematics())
 	test.That(t, err, test.ShouldBeNil)
@@ -906,8 +903,8 @@ func TestCheckPlan(t *testing.T) {
 	t.Run("ensure transforms of obstacles works - collision with camera", func(t *testing.T) {
 		// create obstacle
 		obstacle, err := spatialmath.NewBox(
-			spatialmath.NewPoseFromPoint(r3.Vector{0, 0, 380}),
-			r3.Vector{10, 10, 10}, "obstacle",
+			spatialmath.NewPoseFromPoint(r3.Vector{0, 400, 0}),
+			r3.Vector{50, 50, 10}, "obstacle",
 		)
 		test.That(t, err, test.ShouldBeNil)
 		geoms := []spatialmath.Geometry{obstacle}

--- a/services/motion/builtin/move_request.go
+++ b/services/motion/builtin/move_request.go
@@ -152,7 +152,9 @@ func (ms *builtIn) newMoveOnGlobeRequest(
 		return nil, err
 	}
 
-	// Important: this assumes a 0 degree heading. This, and the geoms below, need to be transformed to the correct pose.
+	// Important: GeoPointToPose will create a pose such that incrementing latitude towards north increments +Y, and incrementing
+	// longitude towards east increments +X. Heading is not taken into account. This pose must therefore be transformed based on the
+	// orientation of the base such that it is a pose relative to the base's current location.
 	goalPoseRaw := spatialmath.GeoPointToPose(destination, origin)
 	// construct limits
 	straightlineDistance := goalPoseRaw.Point().Norm()


### PR DESCRIPTION
This corrects a major issue with regard to planning in TP-space; specifically, that all poses (goals, obstacles, etc) must be specified relative to the starting position of the robot; that is, the base being planned for must have a ZeroPose between it and the frame system's World.

Prior to this PR, the heading of the base's starting position was inserted between the base and World for each solve FS call. This had the side effect of transforming *every* PTG transform call by that much resulting in paths that bear little resemblance to a path that would actually get the robot to the goal, unless that heading was 0.

This PR transforms the goal and all geometries to place them at the correct positions relative to the starting pose of the base.

As part of this, tests were also updated such that obstacles are defined relative to the base. Previously they were defined relative to the base's starting position but with +Y = north, which was incorrect; by default the starting pose should be Y = east.

NOTE: A check to ensure that the transform to World is zero was added by @nfranczak here: https://github.com/viamrobotics/rdk/blob/f16bd3a16c03ec59c8780522ee62bdff4ccf88f6/motionplan/motionPlanner.go#L124 so when that is merged we will have that check ensuring correctness here