### PR TITLE
The PCA9685 is Linux-only

### DIFF
--- a/components/board/hat/pca9685/pca9685.go
+++ b/components/board/hat/pca9685/pca9685.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 // Package pca9685 implements a PCA9685 HAT. It's probably also a generic PCA9685
 // but that has not been verified yet.
 package pca9685

--- a/components/board/hat/pca9685/pca9685_nonlinux.go
+++ b/components/board/hat/pca9685/pca9685_nonlinux.go
@@ -1,0 +1,2 @@
+// Package pca9685 is unimplemented for Macs.
+package pca9685


### PR DESCRIPTION
Sorry to break the Mac build! Michael, give this a try and LMK if it works.