### PR TITLE
[DATA-2050] Bug fixes for data export CLI

### DIFF
--- a/cli/data.go
+++ b/cli/data.go
@@ -343,7 +343,7 @@ func downloadBinary(ctx context.Context, client datapb.DataServiceClient, dst st
 
 	datum := data[0]
 
-	fileName := filenameForDownload(datum.GetMetadata())
+	fileName := filenameForDownload(datum.GetMetadata(), runtime.GOOS)
 	// Modify the file name in the metadata to reflect what it will be saved as.
 	metadata := datum.GetMetadata()
 	metadata.FileName = fileName
@@ -406,7 +406,7 @@ func downloadBinary(ctx context.Context, client datapb.DataServiceClient, dst st
 const windowsDarwinReservedChars = ":"
 
 // transform datum's filename to a destination path on this computer.
-func filenameForDownload(meta *datapb.BinaryMetadata) string {
+func filenameForDownload(meta *datapb.BinaryMetadata, runtimeOS string) string {
 	timeRequested := meta.GetTimeRequested().AsTime().Format(time.RFC3339Nano)
 	fileName := meta.GetFileName()
 
@@ -425,7 +425,7 @@ func filenameForDownload(meta *datapb.BinaryMetadata) string {
 		fileName = strings.TrimSuffix(fileName, gzFileExt)
 	}
 
-	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+	if runtimeOS == "windows" || runtimeOS == "darwin" {
 		fileName = strings.Map(func(c rune) rune {
 			if strings.ContainsRune(windowsDarwinReservedChars, c) {
 				return '_'

--- a/cli/data.go
+++ b/cli/data.go
@@ -402,8 +402,8 @@ func downloadBinary(ctx context.Context, client datapb.DataServiceClient, dst st
 	return nil
 }
 
-// non-exhaustive list of characters to strip from filenames on windows.
-const windowsReservedChars = ":"
+// non-exhaustive list of characters to strip from filenames on windows and darwin (macOS).
+const windowsDarwinReservedChars = ":"
 
 // transform datum's filename to a destination path on this computer.
 func filenameForDownload(meta *datapb.BinaryMetadata) string {
@@ -425,9 +425,9 @@ func filenameForDownload(meta *datapb.BinaryMetadata) string {
 		fileName = strings.TrimSuffix(fileName, gzFileExt)
 	}
 
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
 		fileName = strings.Map(func(c rune) rune {
-			if strings.ContainsRune(windowsReservedChars, c) {
+			if strings.ContainsRune(windowsDarwinReservedChars, c) {
 				return '_'
 			}
 			return c

--- a/cli/data_test.go
+++ b/cli/data_test.go
@@ -27,7 +27,7 @@ func TestFilenameForDownload(t *testing.T) {
 	gzAtRoot := filenameForDownload(&datapb.BinaryMetadata{
 		FileName: "whatever.gz",
 	})
-	test.That(t, gzAtRoot, test.ShouldEqual, utc0+"_whatever.gz")
+	test.That(t, gzAtRoot, test.ShouldEqual, utc0+"_whatever")
 
 	gzInFolder := filenameForDownload(&datapb.BinaryMetadata{
 		FileName: "dir/whatever.gz",

--- a/cli/data_test.go
+++ b/cli/data_test.go
@@ -9,28 +9,35 @@ import (
 
 func TestFilenameForDownload(t *testing.T) {
 	const utc0 = "1970-01-01T00:00:00Z"
+	const linux = "linux"
+	const windows = "windows"
 	noFilename := filenameForDownload(&datapb.BinaryMetadata{
 		Id: "my-id",
-	})
+	}, linux)
 	test.That(t, noFilename, test.ShouldEqual, utc0+"_my-id")
 
 	normalExt := filenameForDownload(&datapb.BinaryMetadata{
 		FileName: "whatever.txt",
-	})
+	}, linux)
 	test.That(t, normalExt, test.ShouldEqual, utc0+"_whatever.txt")
+
+	charReplacedTimestamp := filenameForDownload(&datapb.BinaryMetadata{
+		FileName: "whatever.txt",
+	}, windows)
+	test.That(t, charReplacedTimestamp, test.ShouldEqual, "1970-01-01T00_00_00Z_whatever.txt")
 
 	inFolder := filenameForDownload(&datapb.BinaryMetadata{
 		FileName: "dir/whatever.txt",
-	})
+	}, linux)
 	test.That(t, inFolder, test.ShouldEqual, "dir/whatever.txt")
 
 	gzAtRoot := filenameForDownload(&datapb.BinaryMetadata{
 		FileName: "whatever.gz",
-	})
+	}, linux)
 	test.That(t, gzAtRoot, test.ShouldEqual, utc0+"_whatever")
 
 	gzInFolder := filenameForDownload(&datapb.BinaryMetadata{
 		FileName: "dir/whatever.gz",
-	})
+	}, linux)
 	test.That(t, gzInFolder, test.ShouldEqual, "dir/whatever")
 }


### PR DESCRIPTION
* Fix gz file extension naming for non-directory files
* Replace colon characters in filename for macOS since they are also not allowed on that platform.

**Testing**
Manually tested on directory-and-non-directory gzipped-and-non-gzipped files on a Mac.