### PR TITLE
RSDK-5269 - CLI Support single file uploads and auto-compression

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -951,7 +951,7 @@ viam module upload --version "0.1.0" --platform "linux/amd64" ./bin/my-module
 Example uploading a whole directory:
 viam module upload --version "0.1.0" --platform "linux/amd64" ./bin
 
-Example uploading a custom tarball of a binary:
+Example uploading a custom tarball of your module:
 tar -czf packaged-module.tar.gz my-binary   # the meta.json entrypoint is relative to the root of the archive, so it should be "./my-binary"
 viam module upload --version "0.1.0" --platform "linux/amd64" packaged-module.tar.gz
                       `,

--- a/cli/app.go
+++ b/cli/app.go
@@ -945,14 +945,15 @@ After creation, use 'viam module update' to push your new module to app.viam.com
 					Usage: "upload a new version of your module",
 					Description: `Upload an archive containing your module's file(s) for a specified platform
 Example uploading a single file:
-# This will expect an entrypoint of "bin/my-module".
 viam module upload --version "0.1.0" --platform "linux/amd64" ./bin/my-module
+(this example requires the entrypoint in the meta.json to be "./bin/my-module")
 
 Example uploading a whole directory:
 viam module upload --version "0.1.0" --platform "linux/amd64" ./bin
+(this example requires the entrypoint in the meta.json to be inside the bin directory like "./bin/[your path here]")
 
 Example uploading a custom tarball of your module:
-tar -czf packaged-module.tar.gz my-binary   # the meta.json entrypoint is relative to the root of the archive, so it should be "./my-binary"
+tar -czf packaged-module.tar.gz ./src requirements.txt run.sh
 viam module upload --version "0.1.0" --platform "linux/amd64" packaged-module.tar.gz
                       `,
 					UsageText: "viam module upload <version> <platform> [other options] <packaged-module.tar.gz>",

--- a/cli/app.go
+++ b/cli/app.go
@@ -944,8 +944,14 @@ After creation, use 'viam module update' to push your new module to app.viam.com
 					Name:  "upload",
 					Usage: "upload a new version of your module",
 					Description: `Upload an archive containing your module's file(s) for a specified platform
+Example uploading a single file:
+# This will expect an entrypoint of "bin/my-module".
+viam module upload --version "0.1.0" --platform "linux/amd64" ./bin/my-module
 
-Example for linux/amd64:
+Example uploading a whole directory:
+viam module upload --version "0.1.0" --platform "linux/amd64" ./bin
+
+Example uploading a custom tarball of a binary:
 tar -czf packaged-module.tar.gz my-binary   # the meta.json entrypoint is relative to the root of the archive, so it should be "./my-binary"
 viam module upload --version "0.1.0" --platform "linux/amd64" packaged-module.tar.gz
                       `,
@@ -979,8 +985,8 @@ viam module upload --version "0.1.0" --platform "linux/amd64" packaged-module.ta
 							Usage: `platform of the binary you are uploading. Must be one of:
                       linux/amd64
                       linux/arm64
-                      darwin/amd64 (for intel macs)
-                      darwin/arm64 (for non-intel macs)`,
+                      darwin/amd64 (Intel macs)
+                      darwin/arm64 (Apple silicon macs)`,
 							Required: true,
 						},
 						&cli.BoolFlag{

--- a/cli/archive.go
+++ b/cli/archive.go
@@ -1,0 +1,114 @@
+package cli
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"io/fs"
+	"math"
+	"os"
+	"path/filepath"
+
+	"go.viam.com/utils"
+	"golang.org/x/exp/maps"
+)
+
+// getArchiveFilePaths traverses the provided rootpaths recursively,
+// collecting the file paths of all regular files and returns them in a slice.
+// This list of paths should be passed to createArchive.
+func getArchiveFilePaths(rootpaths []string) ([]string, error) {
+	files := map[string]bool{}
+	for _, pathRoot := range rootpaths {
+		err := filepath.WalkDir(filepath.Clean(pathRoot), func(path string, info fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.Type().IsRegular() {
+				files[path] = true
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return maps.Keys(files), nil
+}
+
+// createArchive compresses and archives the provided file paths into a tar.gz format,
+// writing the resulting binary data to the supplied "buf" writer.
+// If "stdout" is provided, the function outputs compression progress information.
+func createArchive(files []string, buf io.Writer, stdout *io.Writer) error {
+	// Create new Writers for gzip and tar
+	// These writers are chained. Writing to the tar writer will
+	// write to the gzip writer which in turn will write to
+	// the "buf" writer
+	gw := gzip.NewWriter(buf)
+	defer utils.UncheckedErrorFunc(gw.Close)
+	tw := tar.NewWriter(gw)
+	defer utils.UncheckedErrorFunc(tw.Close)
+
+	// Close the line with the progress reading
+	defer func() {
+		if stdout != nil {
+			printf(*stdout, "")
+		}
+	}()
+
+	if stdout != nil {
+		fmt.Fprintf(*stdout, "\rCompressing... %d%% (%d/%d files)", 0, 1, len(files)) // no newline
+	}
+	// Iterate over files and add them to the tar archive
+	for i, file := range files {
+		err := addToArchive(tw, file)
+		if err != nil {
+			return err
+		}
+		if stdout != nil {
+			compressPercent := int(math.Ceil(100 * float64(i+1) / float64(len(files))))
+			fmt.Fprintf(*stdout, "\rCompressing... %d%% (%d/%d files)", compressPercent, i+1, len(files)) // no newline
+		}
+	}
+	return nil
+}
+
+func addToArchive(tw *tar.Writer, filename string) error {
+	// Open the file which will be written into the archive
+	//nolint:gosec
+	file, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer utils.UncheckedErrorFunc(file.Close)
+
+	// Get FileInfo about our file providing file size, mode, etc.
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+
+	// Create a tar Header from the FileInfo data
+	header, err := tar.FileInfoHeader(info, info.Name())
+	if err != nil {
+		return err
+	}
+	// See tar.FileInfoHeader:
+	//   Since fs.FileInfo's Name method only returns the base name of
+	//   the file it describes, it may be necessary to modify Header.Name
+	//   to provide the full path name of the file.
+	header.Name = filename
+
+	err = tw.WriteHeader(header)
+	if err != nil {
+		return err
+	}
+
+	// Copy file content to tar archive
+	_, err = io.Copy(tw, file)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cli/archive_test.go
+++ b/cli/archive_test.go
@@ -8,70 +8,82 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"go.viam.com/test"
 )
 
-func TestGetArchiveFilePaths(t *testing.T) {
-	// Create a temporary directory
+func TestArchive(t *testing.T) {
 	tempDir := t.TempDir()
 
-	// Create dummy files
-	files := []string{"file1.txt", "file2.txt"}
-	for _, f := range files {
-		fullPath := filepath.Join(tempDir, f)
+	regularFiles := []string{"file1.txt", "file2.txt"}
+	allFiles := append([]string{"file1link"}, regularFiles...)
+
+	for _, filename := range regularFiles {
+		fullPath := filepath.Join(tempDir, filename)
 		err := os.WriteFile(fullPath, []byte("content"), fs.ModePerm)
 		test.That(t, err, test.ShouldBeNil)
 	}
 
-	// Invoke getArchiveFilePaths function
-	foundFiles, err := getArchiveFilePaths([]string{tempDir})
+	// Create file1link as a symlink to file1.txt
+	linkName := filepath.Join(tempDir, "file1link")
+	err := os.Symlink("file1.txt", linkName)
 	test.That(t, err, test.ShouldBeNil)
 
-	// Validate found files
-	test.That(t, foundFiles, test.ShouldHaveLength, len(files))
-	for _, f := range foundFiles {
-		if _, err := os.Stat(f); os.IsNotExist(err) {
-			t.Errorf("File %s was not found", f)
+	t.Run("archive file paths", func(t *testing.T) {
+		foundFiles, err := getArchiveFilePaths([]string{tempDir})
+		test.That(t, err, test.ShouldBeNil)
+
+		test.That(t, foundFiles, test.ShouldHaveLength, 3)
+		for _, f := range foundFiles {
+			if _, err := os.Stat(f); os.IsNotExist(err) {
+				t.Errorf("file %s was not found", f)
+			}
 		}
-	}
-}
+	})
 
-func TestCreateArchive(t *testing.T) {
-	// Create a temporary directory
-	tempDir := t.TempDir()
-
-	// Create dummy files
-	files := []string{"file1.txt", "file2.txt"}
-	for _, f := range files {
-		fullPath := filepath.Join(tempDir, f)
-		err := os.WriteFile(fullPath, []byte("content"), os.ModePerm)
+	t.Run("create archive", func(t *testing.T) {
+		paths, err := getArchiveFilePaths([]string{tempDir})
 		test.That(t, err, test.ShouldBeNil)
-	}
 
-	// Obtain the paths of dummy files
-	paths, err := getArchiveFilePaths([]string{tempDir})
-	test.That(t, err, test.ShouldBeNil)
-
-	// Invoke createArchive function
-	var buf bytes.Buffer
-	err = createArchive(paths, &buf, nil)
-	test.That(t, err, test.ShouldBeNil)
-
-	// Validate created archive
-	gzr, err := gzip.NewReader(&buf)
-	test.That(t, err, test.ShouldBeNil)
-	defer gzr.Close()
-
-	tr := tar.NewReader(gzr)
-	for _, file := range files {
-		header, err := tr.Next()
+		var buf bytes.Buffer
+		err = createArchive(paths, &buf, nil)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, header.Name, test.ShouldEndWith, file)
-		fileContent := make([]byte, header.Size)
-		_, err = tr.Read(fileContent)
-		test.That(t, err, test.ShouldEqual, io.EOF)
-		test.That(t, string(fileContent), test.ShouldEqual, "content")
-	}
+
+		gzr, err := gzip.NewReader(&buf)
+		test.That(t, err, test.ShouldBeNil)
+		defer gzr.Close()
+
+		tr := tar.NewReader(gzr)
+
+		// Map to track which files we've checked
+		verifiedFiles := make(map[string]bool)
+		for range allFiles {
+			header, err := tr.Next()
+			test.That(t, err, test.ShouldBeNil)
+
+			expectedFile := false
+			for _, fileName := range allFiles {
+				if strings.HasSuffix(header.Name, fileName) {
+					expectedFile = true
+					verifiedFiles[fileName] = true
+					break
+				}
+			}
+			test.That(t, expectedFile, test.ShouldBeTrue)
+
+			fileContent := make([]byte, header.Size)
+			_, err = tr.Read(fileContent)
+			test.That(t, err, test.ShouldEqual, io.EOF)
+			// Note that even the symlink should have a value of `content`
+			test.That(t, string(fileContent), test.ShouldEqual, "content")
+		}
+
+		// Ensure we visited all files
+		test.That(t, len(verifiedFiles), test.ShouldEqual, len(allFiles))
+		for _, file := range allFiles {
+			test.That(t, verifiedFiles[file], test.ShouldBeTrue)
+		}
+	})
 }

--- a/cli/archive_test.go
+++ b/cli/archive_test.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.viam.com/test"
+)
+
+func TestGetArchiveFilePaths(t *testing.T) {
+	// Create a temporary directory
+	tempDir := t.TempDir()
+
+	// Create dummy files
+	files := []string{"file1.txt", "file2.txt"}
+	for _, f := range files {
+		fullPath := filepath.Join(tempDir, f)
+		err := os.WriteFile(fullPath, []byte("content"), fs.ModePerm)
+		test.That(t, err, test.ShouldBeNil)
+	}
+
+	// Invoke getArchiveFilePaths function
+	foundFiles, err := getArchiveFilePaths([]string{tempDir})
+	test.That(t, err, test.ShouldBeNil)
+
+	// Validate found files
+	test.That(t, foundFiles, test.ShouldHaveLength, len(files))
+	for _, f := range foundFiles {
+		if _, err := os.Stat(f); os.IsNotExist(err) {
+			t.Errorf("File %s was not found", f)
+		}
+	}
+}
+
+func TestCreateArchive(t *testing.T) {
+	// Create a temporary directory
+	tempDir := t.TempDir()
+
+	// Create dummy files
+	files := []string{"file1.txt", "file2.txt"}
+	for _, f := range files {
+		fullPath := filepath.Join(tempDir, f)
+		err := os.WriteFile(fullPath, []byte("content"), os.ModePerm)
+		test.That(t, err, test.ShouldBeNil)
+	}
+
+	// Obtain the paths of dummy files
+	paths, err := getArchiveFilePaths([]string{tempDir})
+	test.That(t, err, test.ShouldBeNil)
+
+	// Invoke createArchive function
+	var buf bytes.Buffer
+	err = createArchive(paths, &buf, nil)
+	test.That(t, err, test.ShouldBeNil)
+
+	// Validate created archive
+	gzr, err := gzip.NewReader(&buf)
+	test.That(t, err, test.ShouldBeNil)
+	defer gzr.Close()
+
+	tr := tar.NewReader(gzr)
+	for _, file := range files {
+		header, err := tr.Next()
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, header.Name, test.ShouldEndWith, file)
+		fileContent := make([]byte, header.Size)
+		_, err = tr.Read(fileContent)
+		test.That(t, err, test.ShouldEqual, io.EOF)
+		test.That(t, string(fileContent), test.ShouldEqual, "content")
+	}
+}

--- a/cli/boards.go
+++ b/cli/boards.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"archive/tar"
-	"bufio"
 	"bytes"
 	"compress/gzip"
 	"context"
@@ -153,14 +152,14 @@ func (c *viamClient) uploadBoardDefsFile(
 	}
 	ctx := c.c.Context
 
-	jsonFile, err := os.Open(filepath.Clean(jsonPath))
+	stats, err := os.Stat(filepath.Clean(jsonPath))
 	if err != nil {
 		return nil, err
 	}
 
+	file := new(bytes.Buffer)
 	// Create an archive tar.gz file (required for packages).
-	file, err := createArchive(jsonFile)
-	if err != nil {
+	if err := createArchive([]string{jsonPath}, file, nil); err != nil {
 		return nil, errors.Wrap(err, "error creating archive")
 	}
 
@@ -176,10 +175,6 @@ func (c *viamClient) uploadBoardDefsFile(
 		return nil, errors.Wrapf(err, "error starting CreatePackage stream")
 	}
 
-	stats, err := jsonFile.Stat()
-	if err != nil {
-		return nil, err
-	}
 	boardDefsFile := []*packagepb.FileInfo{{Name: name, Size: uint64(stats.Size())}}
 
 	packageInfo := &packagepb.PackageInfo{
@@ -243,8 +238,7 @@ func (c *viamClient) downloadBoardDefsFile(
 	}
 
 	// download the file from the gcs url into the current directory.
-	err = downloadFile(ctx, currentDir, response.Package.Url)
-	if err != nil {
+	if err := downloadFile(ctx, currentDir, response.Package.Url); err != nil {
 		return err
 	}
 
@@ -311,56 +305,6 @@ func sendPackageRequests(stream packagepb.PackageService_CreatePackageClient,
 	return nil
 }
 
-// createArchive creates a tar.gz from the file provided.
-func createArchive(file *os.File) (*bytes.Buffer, error) {
-	// Create output buffer
-	out := new(bytes.Buffer)
-
-	// These writers are chained. Writing to the tar writer will
-	// write to the gzip writer which in turn will write to
-	// the "out" writer
-	gw := gzip.NewWriter(out)
-	defer utils.UncheckedErrorFunc(gw.Close)
-	tw := tar.NewWriter(gw)
-	defer utils.UncheckedErrorFunc(tw.Close)
-
-	// Get FileInfo about our file providing file size, mode, etc.
-	info, err := file.Stat()
-	if err != nil {
-		return nil, err
-	}
-
-	// the raw file can be 100 times more than the max TAR size.
-	if info.Size() > 100*boardUploadMaximumSize {
-		return nil, errors.New("the json file is too large")
-	}
-	// Create a tar Header from the FileInfo data
-	header, err := tar.FileInfoHeader(info, info.Name())
-	if err != nil {
-		return nil, err
-	}
-
-	// Write file header to the tar archive
-	err = tw.WriteHeader(header)
-	if err != nil {
-		return nil, err
-	}
-
-	// Read the file into a byte slice
-	bytes := make([]byte, info.Size())
-	_, err = bufio.NewReader(file).Read(bytes)
-	if err != nil && !errors.Is(err, io.EOF) {
-		return nil, err
-	}
-
-	// Copy file content to tar archive
-	if _, err := tw.Write(bytes); err != nil {
-		return nil, err
-	}
-
-	return out, nil
-}
-
 // helper function to download a url to a local file.
 func downloadFile(ctx context.Context, filepath, url string) error {
 	getReq, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -374,8 +318,11 @@ func downloadFile(ctx context.Context, filepath, url string) error {
 	if err != nil {
 		return errors.Wrap(err, "error downloading the requested package")
 	}
-
 	defer utils.UncheckedErrorFunc(resp.Body.Close)
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("invalid status code %q for url %q", resp.Status, url)
+	}
 
 	err = untar(filepath, resp.Body)
 	if err != nil {

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -650,7 +650,8 @@ func getEntrypointForVersion(mod *apppb.Module, version string) (string, error) 
 }
 
 func isTarball(path string) bool {
-	return strings.HasSuffix(path, ".tar.gz") || strings.HasSuffix(path, ".tgz")
+	return strings.HasSuffix(strings.ToLower(path), ".tar.gz") ||
+		!strings.HasSuffix(strings.ToLower(path), ".tgz")
 }
 
 func createTarballForUpload(moduleUploadPath string, stdout io.Writer) (string, error) {

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"archive/tar"
+	"bufio"
 	"compress/gzip"
 	"context"
 	"encoding/json"
@@ -177,13 +178,13 @@ func UploadModuleAction(c *cli.Context) error {
 	versionArg := c.String(moduleFlagVersion)
 	platformArg := c.String(moduleFlagPlatform)
 	forceUploadArg := c.Bool(moduleFlagForce)
-	tarballPath := c.Args().First()
+	moduleUploadPath := c.Args().First()
 	if c.Args().Len() > 1 {
 		return errors.New("too many arguments passed to upload command. " +
 			"Make sure to specify flag and optional arguments before the required positional package argument")
 	}
-	if tarballPath == "" {
-		return errors.New("no package to upload -- please provide an archive containing your module. Use --help for more information")
+	if moduleUploadPath == "" {
+		return errors.New("no package to upload -- please provide an path to your module. Use --help for more information")
 	}
 
 	// Clean the version argument to ensure compatibility with github tag standards
@@ -237,6 +238,18 @@ func UploadModuleAction(c *cli.Context) error {
 	moduleID, err = validateModuleID(c, client, nameArg, publicNamespaceArg, orgIDArg)
 	if err != nil {
 		return err
+	}
+	tarballPath := moduleUploadPath
+	if !isTarball(tarballPath) {
+		tarballPath, err = createTarballForUpload(moduleUploadPath, c.App.Writer)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if err := os.Remove(tarballPath); err != nil {
+				Errorf(c.App.ErrWriter, "failed to cleanup temporary module tarball for upload %q", tarballPath)
+			}
+		}()
 	}
 
 	if !forceUploadArg {
@@ -416,11 +429,6 @@ func validateModuleFile(client *viamClient, moduleID moduleID, tarballPath, vers
 	if err != nil {
 		return err
 	}
-	// TODO(APP-2226): support .tar.xz
-	if !strings.HasSuffix(strings.ToLower(file.Name()), ".tar.gz") &&
-		!strings.HasSuffix(strings.ToLower(file.Name()), ".tgz") {
-		return errors.New("you must upload your module in the form of a .tar.gz or .tgz")
-	}
 	archive, err := gzip.NewReader(file)
 	if err != nil {
 		return err
@@ -446,8 +454,8 @@ func validateModuleFile(client *viamClient, moduleID moduleID, tarballPath, vers
 			info := header.FileInfo()
 			if info.Mode().Perm()&0o100 == 0 {
 				return errors.Errorf(
-					"the provided tarball %q contained a file at the entrypoint %q, but that file is not marked as executable",
-					tarballPath, entrypoint)
+					"the provided archive contained a file at the entrypoint %q, but that file is not marked as executable",
+					entrypoint)
 			}
 			// executable file at entrypoint. validation succeeded.
 			return nil
@@ -460,8 +468,8 @@ func validateModuleFile(client *viamClient, moduleID moduleID, tarballPath, vers
 	if len(filesWithSameNameAsEntrypoint) > 0 {
 		extraErrInfo = fmt.Sprintf(". Did you mean to set your entrypoint to %v?", filesWithSameNameAsEntrypoint)
 	}
-	return errors.Errorf("the provided tarball %q does not contain a file at the desired entrypoint %q%s",
-		tarballPath, entrypoint, extraErrInfo)
+	return errors.Errorf("the provided archive does not contain a file at the desired entrypoint %q%s",
+		entrypoint, extraErrInfo)
 }
 
 func visibilityToProto(visibility moduleVisibility) (apppb.Visibility, error) {
@@ -639,4 +647,36 @@ func getEntrypointForVersion(mod *apppb.Module, version string) (string, error) 
 	}
 	// if there is no entrypoint set yet, use the last uploaded entrypoint
 	return mod.Entrypoint, nil
+}
+
+func isTarball(path string) bool {
+	return strings.HasSuffix(path, ".tar.gz") || strings.HasSuffix(path, ".tgz")
+}
+
+func createTarballForUpload(moduleUploadPath string, stdout io.Writer) (string, error) {
+	tmpFile, err := os.CreateTemp("", "module-upload-*.tar.gz")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to create temporary archive file")
+	}
+	defer func() {
+		if err := tmpFile.Close(); err != nil {
+			Errorf(stdout, "failed to close temporary archive file %q", tmpFile.Name())
+		}
+	}()
+
+	tmpFileWriter := bufio.NewWriter(tmpFile)
+	archiveFiles, err := getArchiveFilePaths([]string{moduleUploadPath})
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to find files to compress in %q", moduleUploadPath)
+	}
+	if len(archiveFiles) == 0 {
+		return "", errors.Errorf("failed to find any files in %q", moduleUploadPath)
+	}
+	if err := createArchive(archiveFiles, tmpFileWriter, &stdout); err != nil {
+		return "", errors.Wrap(err, "failed to create temp archive")
+	}
+	if err := tmpFileWriter.Flush(); err != nil {
+		return "", errors.Wrap(err, "failed to flush buffer while creating temp archive")
+	}
+	return tmpFile.Name(), nil
 }


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-5269

This adds the ability to provide a path to a single file or a path to a directory to the `viam module upload` subcommand. Either of these will be automatically compressed and added to a temporary tarball that will be uploaded instead.

There is a bit of optimization left on the table because the validate step scans through the archive (after it has been written) but the additional code complexity to take advantage of this inefficiency did not seem worth the cost. (I tested. The validation step was negligible) 


I added the ability to include a whole directory because this is a common use case for cpp modules to ship separate libraries that are still required (so including the entire install dir is reasonable and we dont need to make people tar it up before they ship it) (open to debate if we want to support this)


**Open question**
Do we want to support uploading a list of files ex:
`viam module upload --platform xxx --version yyy ./src requirements.txt run.sh`
This could eliminate the need for the tar step (which is confusing). However, it also comes at the cost that now people will need to remember what files are required in their module. Fahmina was not opposed but I keep going back and forth. 