### PR TITLE
[DATA-2051] Add Training API methods to CLI 

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -476,9 +476,8 @@ var app = &cli.App{
 									Required: true,
 								},
 								&cli.StringFlag{
-									Name: trainFlagModelVersion,
-									Usage: "version of ML model. defaults to current timestamp " +
-										"if unspecified.",
+									Name:  trainFlagModelVersion,
+									Usage: "version of ML model. defaults to current timestamp if unspecified.",
 								},
 								&cli.StringFlag{
 									Name:  datasetFlagDatasetID,
@@ -583,8 +582,9 @@ var app = &cli.App{
 									Required: true,
 								},
 								&cli.StringFlag{
-									Name:  trainFlagJobStatus,
-									Usage: "training status to filter for. can be one of [unspecified, pending, in_progress, completed, failed, canceled, canceling]",
+									Name: trainFlagJobStatus,
+									Usage: "training status to filter for. can be one of " +
+										"[unspecified, pending, in_progress, completed, failed, canceled, canceling]",
 								},
 							},
 							Action: DataListTrainingJobs,

--- a/cli/app.go
+++ b/cli/app.go
@@ -464,18 +464,21 @@ var app = &cli.App{
 									Required: true,
 								},
 								&cli.StringFlag{
-									Name:     trainFlagModelType,
-									Usage:    "type of model to train. can be one of [single_label_classification, multi_label_classification, or object_detection]",
+									Name: trainFlagModelType,
+									Usage: "type of model to train. can be one of " +
+										"[single_label_classification, multi_label_classification, or object_detection]",
 									Required: true,
 								},
 								&cli.StringSliceFlag{
-									Name:     trainFlagModelLabels,
-									Usage:    "labels to train on. this will either be classification or object detection labels",
+									Name: trainFlagModelLabels,
+									Usage: "labels to train on. " +
+										"this will either be classification or object detection labels",
 									Required: true,
 								},
 								&cli.StringFlag{
-									Name:  trainFlagModelVersion,
-									Usage: "version of ML model. defaults to current timestamp if unspecified.",
+									Name: trainFlagModelVersion,
+									Usage: "version of ML model. defaults to current timestamp " +
+										"if unspecified.",
 								},
 								&cli.StringFlag{
 									Name:  datasetFlagDatasetID,
@@ -532,7 +535,8 @@ var app = &cli.App{
 								&cli.StringSliceFlag{
 									Name: dataFlagTags,
 									Usage: "tags filter. " +
-										"accepts tagged for all tagged data, untagged for all untagged data, or a list of tags for all data matching any of the tags",
+										"accepts tagged for all tagged data, untagged for all untagged data, " +
+										"or a list of tags for all data matching any of the tags",
 								},
 								&cli.StringSliceFlag{
 									Name: dataFlagBboxLabels,

--- a/cli/app.go
+++ b/cli/app.go
@@ -442,6 +442,151 @@ var app = &cli.App{
 						},
 					},
 				},
+				{
+					Name:      "train",
+					Usage:     "train on data",
+					UsageText: "viam data train [other options]",
+					Subcommands: []*cli.Command{
+						{
+							Name:  "submit",
+							Usage: "submits training job on data in Viam cloud",
+							UsageText: fmt.Sprintf("viam data train submit <%s> [other options]",
+								dataFlagOrgIDs),
+							Flags: []cli.Flag{
+								&cli.StringFlag{
+									Name:     trainFlagModelOrgID,
+									Usage:    "org ID to train and save ML model in",
+									Required: true,
+								},
+								&cli.StringFlag{
+									Name:     trainFlagModelName,
+									Usage:    "name of ML model",
+									Required: true,
+								},
+								&cli.StringFlag{
+									Name:     trainFlagModelType,
+									Usage:    "type of model to train. can be one of [single_label_classification, multi_label_classification, or object_detection]",
+									Required: true,
+								},
+								&cli.StringSliceFlag{
+									Name:     trainFlagModelLabels,
+									Usage:    "labels to train on. this will either be classification or object detection labels",
+									Required: true,
+								},
+								&cli.StringFlag{
+									Name:  trainFlagModelVersion,
+									Usage: "version of ML model. defaults to current timestamp if unspecified.",
+								},
+								&cli.StringFlag{
+									Name:  datasetFlagDatasetID,
+									Usage: "dataset ID",
+								},
+								&cli.StringSliceFlag{
+									Name:  dataFlagOrgIDs,
+									Usage: "orgs filter",
+								},
+								&cli.StringSliceFlag{
+									Name:  dataFlagLocationIDs,
+									Usage: "locations filter",
+								},
+								&cli.StringFlag{
+									Name:  dataFlagRobotID,
+									Usage: "robot-id filter",
+								},
+								&cli.StringFlag{
+									Name:  dataFlagPartID,
+									Usage: "part id filter",
+								},
+								&cli.StringFlag{
+									Name:  dataFlagRobotName,
+									Usage: "robot name filter",
+								},
+								&cli.StringFlag{
+									Name:  dataFlagPartName,
+									Usage: "part name filter",
+								},
+								&cli.StringFlag{
+									Name:  dataFlagComponentType,
+									Usage: "component type filter",
+								},
+								&cli.StringFlag{
+									Name:  dataFlagComponentName,
+									Usage: "component name filter",
+								},
+								&cli.StringFlag{
+									Name:  dataFlagMethod,
+									Usage: "method filter",
+								},
+								&cli.StringSliceFlag{
+									Name:  dataFlagMimeTypes,
+									Usage: "mime types filter",
+								},
+								&cli.StringFlag{
+									Name:  dataFlagStart,
+									Usage: "ISO-8601 timestamp indicating the start of the interval filter",
+								},
+								&cli.StringFlag{
+									Name:  dataFlagEnd,
+									Usage: "ISO-8601 timestamp indicating the end of the interval filter",
+								},
+								&cli.StringSliceFlag{
+									Name: dataFlagTags,
+									Usage: "tags filter. " +
+										"accepts tagged for all tagged data, untagged for all untagged data, or a list of tags for all data matching any of the tags",
+								},
+								&cli.StringSliceFlag{
+									Name: dataFlagBboxLabels,
+									Usage: "bbox labels filter. " +
+										"accepts string labels corresponding to bounding boxes within images",
+								},
+							},
+							Action: DataSubmitTrainingJob,
+						},
+						{
+							Name:      "get",
+							Usage:     "gets training job from Viam cloud based on training job ID",
+							UsageText: fmt.Sprintf("viam data train get <%s>", trainFlagJobID),
+							Flags: []cli.Flag{
+								&cli.StringFlag{
+									Name:     trainFlagJobID,
+									Usage:    "training job ID",
+									Required: true,
+								},
+							},
+							Action: DataGetTrainingJob,
+						},
+						{
+							Name:      "cancel",
+							Usage:     "cancels training job in Viam cloud based on training job ID",
+							UsageText: fmt.Sprintf("viam data train cancel <%s>", trainFlagJobID),
+							Flags: []cli.Flag{
+								&cli.StringFlag{
+									Name:     trainFlagJobID,
+									Usage:    "training job ID",
+									Required: true,
+								},
+							},
+							Action: DataCancelTrainingJob,
+						},
+						{
+							Name:      "list",
+							Usage:     "list training jobs in Viam cloud based on organization ID",
+							UsageText: fmt.Sprintf("viam data train list <%s> <%s>", dataFlagOrgID, trainFlagJobStatus),
+							Flags: []cli.Flag{
+								&cli.StringFlag{
+									Name:     dataFlagOrgID,
+									Usage:    "org ID",
+									Required: true,
+								},
+								&cli.StringFlag{
+									Name:  trainFlagJobStatus,
+									Usage: "training status to filter for. can be one of [unspecified, pending, in_progress, completed, failed, canceled, canceling]",
+								},
+							},
+							Action: DataListTrainingJobs,
+						},
+					},
+				},
 			},
 		},
 		{

--- a/cli/app.go
+++ b/cli/app.go
@@ -442,155 +442,6 @@ var app = &cli.App{
 						},
 					},
 				},
-				{
-					Name:      "train",
-					Usage:     "train on data",
-					UsageText: "viam data train [other options]",
-					Subcommands: []*cli.Command{
-						{
-							Name:  "submit",
-							Usage: "submits training job on data in Viam cloud",
-							UsageText: fmt.Sprintf("viam data train submit <%s> [other options]",
-								dataFlagOrgIDs),
-							Flags: []cli.Flag{
-								&cli.StringFlag{
-									Name:     trainFlagModelOrgID,
-									Usage:    "org ID to train and save ML model in",
-									Required: true,
-								},
-								&cli.StringFlag{
-									Name:     trainFlagModelName,
-									Usage:    "name of ML model",
-									Required: true,
-								},
-								&cli.StringFlag{
-									Name: trainFlagModelType,
-									Usage: "type of model to train. can be one of " +
-										"[single_label_classification, multi_label_classification, or object_detection]",
-									Required: true,
-								},
-								&cli.StringSliceFlag{
-									Name: trainFlagModelLabels,
-									Usage: "labels to train on. " +
-										"this will either be classification or object detection labels",
-									Required: true,
-								},
-								&cli.StringFlag{
-									Name:  trainFlagModelVersion,
-									Usage: "version of ML model. defaults to current timestamp if unspecified.",
-								},
-								&cli.StringFlag{
-									Name:  datasetFlagDatasetID,
-									Usage: "dataset ID",
-								},
-								&cli.StringSliceFlag{
-									Name:  dataFlagOrgIDs,
-									Usage: "orgs filter",
-								},
-								&cli.StringSliceFlag{
-									Name:  dataFlagLocationIDs,
-									Usage: "locations filter",
-								},
-								&cli.StringFlag{
-									Name:  dataFlagRobotID,
-									Usage: "robot-id filter",
-								},
-								&cli.StringFlag{
-									Name:  dataFlagPartID,
-									Usage: "part id filter",
-								},
-								&cli.StringFlag{
-									Name:  dataFlagRobotName,
-									Usage: "robot name filter",
-								},
-								&cli.StringFlag{
-									Name:  dataFlagPartName,
-									Usage: "part name filter",
-								},
-								&cli.StringFlag{
-									Name:  dataFlagComponentType,
-									Usage: "component type filter",
-								},
-								&cli.StringFlag{
-									Name:  dataFlagComponentName,
-									Usage: "component name filter",
-								},
-								&cli.StringFlag{
-									Name:  dataFlagMethod,
-									Usage: "method filter",
-								},
-								&cli.StringSliceFlag{
-									Name:  dataFlagMimeTypes,
-									Usage: "mime types filter",
-								},
-								&cli.StringFlag{
-									Name:  dataFlagStart,
-									Usage: "ISO-8601 timestamp indicating the start of the interval filter",
-								},
-								&cli.StringFlag{
-									Name:  dataFlagEnd,
-									Usage: "ISO-8601 timestamp indicating the end of the interval filter",
-								},
-								&cli.StringSliceFlag{
-									Name: dataFlagTags,
-									Usage: "tags filter. " +
-										"accepts tagged for all tagged data, untagged for all untagged data, " +
-										"or a list of tags for all data matching any of the tags",
-								},
-								&cli.StringSliceFlag{
-									Name: dataFlagBboxLabels,
-									Usage: "bbox labels filter. " +
-										"accepts string labels corresponding to bounding boxes within images",
-								},
-							},
-							Action: DataSubmitTrainingJob,
-						},
-						{
-							Name:      "get",
-							Usage:     "gets training job from Viam cloud based on training job ID",
-							UsageText: fmt.Sprintf("viam data train get <%s>", trainFlagJobID),
-							Flags: []cli.Flag{
-								&cli.StringFlag{
-									Name:     trainFlagJobID,
-									Usage:    "training job ID",
-									Required: true,
-								},
-							},
-							Action: DataGetTrainingJob,
-						},
-						{
-							Name:      "cancel",
-							Usage:     "cancels training job in Viam cloud based on training job ID",
-							UsageText: fmt.Sprintf("viam data train cancel <%s>", trainFlagJobID),
-							Flags: []cli.Flag{
-								&cli.StringFlag{
-									Name:     trainFlagJobID,
-									Usage:    "training job ID",
-									Required: true,
-								},
-							},
-							Action: DataCancelTrainingJob,
-						},
-						{
-							Name:      "list",
-							Usage:     "list training jobs in Viam cloud based on organization ID",
-							UsageText: fmt.Sprintf("viam data train list <%s> <%s>", dataFlagOrgID, trainFlagJobStatus),
-							Flags: []cli.Flag{
-								&cli.StringFlag{
-									Name:     dataFlagOrgID,
-									Usage:    "org ID",
-									Required: true,
-								},
-								&cli.StringFlag{
-									Name: trainFlagJobStatus,
-									Usage: "training status to filter for. can be one of " +
-										"[unspecified, pending, in_progress, completed, failed, canceled, canceling]",
-								},
-							},
-							Action: DataListTrainingJobs,
-						},
-					},
-				},
 			},
 		},
 		{
@@ -666,6 +517,155 @@ var app = &cli.App{
 						},
 					},
 					Action: DatasetCreateAction,
+				},
+			},
+		},
+		{
+			Name:      "train",
+			Usage:     "train on data",
+			UsageText: "viam data train [other options]",
+			Subcommands: []*cli.Command{
+				{
+					Name:  "submit",
+					Usage: "submits training job on data in Viam cloud",
+					UsageText: fmt.Sprintf("viam data train submit <%s> [other options]",
+						dataFlagOrgIDs),
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:     trainFlagModelOrgID,
+							Usage:    "org ID to train and save ML model in",
+							Required: true,
+						},
+						&cli.StringFlag{
+							Name:     trainFlagModelName,
+							Usage:    "name of ML model",
+							Required: true,
+						},
+						&cli.StringFlag{
+							Name: trainFlagModelType,
+							Usage: "type of model to train. can be one of " +
+								"[single_label_classification, multi_label_classification, or object_detection]",
+							Required: true,
+						},
+						&cli.StringSliceFlag{
+							Name: trainFlagModelLabels,
+							Usage: "labels to train on. " +
+								"this will either be classification or object detection labels",
+							Required: true,
+						},
+						&cli.StringFlag{
+							Name:  trainFlagModelVersion,
+							Usage: "version of ML model. defaults to current timestamp if unspecified.",
+						},
+						&cli.StringFlag{
+							Name:  datasetFlagDatasetID,
+							Usage: "dataset ID",
+						},
+						&cli.StringSliceFlag{
+							Name:  dataFlagOrgIDs,
+							Usage: "orgs filter",
+						},
+						&cli.StringSliceFlag{
+							Name:  dataFlagLocationIDs,
+							Usage: "locations filter",
+						},
+						&cli.StringFlag{
+							Name:  dataFlagRobotID,
+							Usage: "robot-id filter",
+						},
+						&cli.StringFlag{
+							Name:  dataFlagPartID,
+							Usage: "part id filter",
+						},
+						&cli.StringFlag{
+							Name:  dataFlagRobotName,
+							Usage: "robot name filter",
+						},
+						&cli.StringFlag{
+							Name:  dataFlagPartName,
+							Usage: "part name filter",
+						},
+						&cli.StringFlag{
+							Name:  dataFlagComponentType,
+							Usage: "component type filter",
+						},
+						&cli.StringFlag{
+							Name:  dataFlagComponentName,
+							Usage: "component name filter",
+						},
+						&cli.StringFlag{
+							Name:  dataFlagMethod,
+							Usage: "method filter",
+						},
+						&cli.StringSliceFlag{
+							Name:  dataFlagMimeTypes,
+							Usage: "mime types filter",
+						},
+						&cli.StringFlag{
+							Name:  dataFlagStart,
+							Usage: "ISO-8601 timestamp indicating the start of the interval filter",
+						},
+						&cli.StringFlag{
+							Name:  dataFlagEnd,
+							Usage: "ISO-8601 timestamp indicating the end of the interval filter",
+						},
+						&cli.StringSliceFlag{
+							Name: dataFlagTags,
+							Usage: "tags filter. " +
+								"accepts tagged for all tagged data, untagged for all untagged data, " +
+								"or a list of tags for all data matching any of the tags",
+						},
+						&cli.StringSliceFlag{
+							Name: dataFlagBboxLabels,
+							Usage: "bbox labels filter. " +
+								"accepts string labels corresponding to bounding boxes within images",
+						},
+					},
+					Action: DataSubmitTrainingJob,
+				},
+				{
+					Name:      "get",
+					Usage:     "gets training job from Viam cloud based on training job ID",
+					UsageText: fmt.Sprintf("viam data train get <%s>", trainFlagJobID),
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:     trainFlagJobID,
+							Usage:    "training job ID",
+							Required: true,
+						},
+					},
+					Action: DataGetTrainingJob,
+				},
+				{
+					Name:      "cancel",
+					Usage:     "cancels training job in Viam cloud based on training job ID",
+					UsageText: fmt.Sprintf("viam data train cancel <%s>", trainFlagJobID),
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:     trainFlagJobID,
+							Usage:    "training job ID",
+							Required: true,
+						},
+					},
+					Action: DataCancelTrainingJob,
+				},
+				{
+					Name:      "list",
+					Usage:     "list training jobs in Viam cloud based on organization ID",
+					UsageText: fmt.Sprintf("viam data train list <%s> <%s>", dataFlagOrgID, trainFlagJobStatus),
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:     dataFlagOrgID,
+							Usage:    "org ID",
+							Required: true,
+						},
+						&cli.StringFlag{
+							Name: trainFlagJobStatus,
+							Usage: "training status to filter for. can be one of " +
+								"[unspecified, pending, in_progress, completed, failed, canceled, canceling]",
+						},
+					},
+					Action: DataListTrainingJobs,
 				},
 			},
 		},

--- a/cli/app.go
+++ b/cli/app.go
@@ -523,12 +523,12 @@ var app = &cli.App{
 		{
 			Name:      "train",
 			Usage:     "train on data",
-			UsageText: "viam data train [other options]",
+			UsageText: "viam train [other options]",
 			Subcommands: []*cli.Command{
 				{
 					Name:  "submit",
 					Usage: "submits training job on data in Viam cloud",
-					UsageText: fmt.Sprintf("viam data train submit <%s> [other options]",
+					UsageText: fmt.Sprintf("viam train submit <%s> [other options]",
 						dataFlagOrgIDs),
 					Flags: []cli.Flag{
 						&cli.StringFlag{
@@ -626,7 +626,7 @@ var app = &cli.App{
 				{
 					Name:      "get",
 					Usage:     "gets training job from Viam cloud based on training job ID",
-					UsageText: fmt.Sprintf("viam data train get <%s>", trainFlagJobID),
+					UsageText: fmt.Sprintf("viam train get <%s>", trainFlagJobID),
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:     trainFlagJobID,
@@ -639,7 +639,7 @@ var app = &cli.App{
 				{
 					Name:      "cancel",
 					Usage:     "cancels training job in Viam cloud based on training job ID",
-					UsageText: fmt.Sprintf("viam data train cancel <%s>", trainFlagJobID),
+					UsageText: fmt.Sprintf("viam train cancel <%s>", trainFlagJobID),
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:     trainFlagJobID,
@@ -652,7 +652,7 @@ var app = &cli.App{
 				{
 					Name:      "list",
 					Usage:     "list training jobs in Viam cloud based on organization ID",
-					UsageText: fmt.Sprintf("viam data train list <%s> <%s>", dataFlagOrgID, trainFlagJobStatus),
+					UsageText: fmt.Sprintf("viam train list <%s> <%s>", dataFlagOrgID, trainFlagJobStatus),
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:     dataFlagOrgID,

--- a/cli/auth.go
+++ b/cli/auth.go
@@ -20,6 +20,7 @@ import (
 	"github.com/urfave/cli/v2"
 	datapb "go.viam.com/api/app/data/v1"
 	datasetpb "go.viam.com/api/app/dataset/v1"
+	mltrainingpb "go.viam.com/api/app/mltraining/v1"
 	packagepb "go.viam.com/api/app/packages/v1"
 	apppb "go.viam.com/api/app/v1"
 	"go.viam.com/utils"
@@ -494,6 +495,7 @@ func (c *viamClient) ensureLoggedIn() error {
 	c.dataClient = datapb.NewDataServiceClient(conn)
 	c.packageClient = packagepb.NewPackageServiceClient(conn)
 	c.datasetClient = datasetpb.NewDatasetServiceClient(conn)
+	c.mlTrainingClient = mltrainingpb.NewMLTrainingServiceClient(conn)
 
 	return nil
 }

--- a/cli/client.go
+++ b/cli/client.go
@@ -22,6 +22,7 @@ import (
 	"go.uber.org/zap"
 	datapb "go.viam.com/api/app/data/v1"
 	datasetpb "go.viam.com/api/app/dataset/v1"
+	mltrainingpb "go.viam.com/api/app/mltraining/v1"
 	packagepb "go.viam.com/api/app/packages/v1"
 	apppb "go.viam.com/api/app/v1"
 	"go.viam.com/utils"
@@ -40,15 +41,16 @@ import (
 // viamClient wraps a cli.Context and provides all the CLI command functionality
 // needed to talk to the app and data services but not directly to robot parts.
 type viamClient struct {
-	c             *cli.Context
-	conf          *config
-	client        apppb.AppServiceClient
-	dataClient    datapb.DataServiceClient
-	packageClient packagepb.PackageServiceClient
-	datasetClient datasetpb.DatasetServiceClient
-	baseURL       *url.URL
-	rpcOpts       []rpc.DialOption
-	authFlow      *authFlow
+	c                *cli.Context
+	conf             *config
+	client           apppb.AppServiceClient
+	dataClient       datapb.DataServiceClient
+	packageClient    packagepb.PackageServiceClient
+	datasetClient    datasetpb.DatasetServiceClient
+	mlTrainingClient mltrainingpb.MLTrainingServiceClient
+	baseURL          *url.URL
+	rpcOpts          []rpc.DialOption
+	authFlow         *authFlow
 
 	selectedOrg *apppb.Organization
 	selectedLoc *apppb.Location

--- a/cli/train.go
+++ b/cli/train.go
@@ -31,7 +31,9 @@ func DataSubmitTrainingJob(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	trainingJobID, err := client.dataSubmitTrainingJob(filter, c.String(trainFlagModelOrgID), c.String(trainFlagModelName), c.String(trainFlagModelVersion), c.String(trainFlagModelType), c.StringSlice(trainFlagModelLabels))
+	trainingJobID, err := client.dataSubmitTrainingJob(
+		filter, c.String(trainFlagModelOrgID), c.String(trainFlagModelName), c.String(trainFlagModelVersion), c.String(trainFlagModelType),
+		c.StringSlice(trainFlagModelLabels))
 	if err != nil {
 		return err
 	}
@@ -40,7 +42,9 @@ func DataSubmitTrainingJob(c *cli.Context) error {
 }
 
 // dataSubmitTrainingJob trains on data with the specified filter.
-func (c *viamClient) dataSubmitTrainingJob(filter *datapb.Filter, orgID string, modelName string, modelVersion string, modelType string, labels []string) (string, error) {
+func (c *viamClient) dataSubmitTrainingJob(filter *datapb.Filter, orgID, modelName, modelVersion, modelType string,
+	labels []string,
+) (string, error) {
 	if err := c.ensureLoggedIn(); err != nil {
 		return "", err
 	}
@@ -49,11 +53,15 @@ func (c *viamClient) dataSubmitTrainingJob(filter *datapb.Filter, orgID string, 
 	}
 	modelTypeEnum, ok := mltrainingpb.ModelType_value["MODEL_TYPE_"+strings.ToUpper(modelType)]
 	if !ok || modelTypeEnum == int32(mltrainingpb.ModelType_MODEL_TYPE_UNSPECIFIED) {
-		return "", errors.Errorf("%s must be a valid ModelType, got %s. See `viam data train submit --help` for supported options.", trainFlagModelType, modelType)
+		return "", errors.Errorf("%s must be a valid ModelType, got %s. See `viam data train submit --help` for supported options",
+			trainFlagModelType, modelType)
 	}
 
 	resp, err := c.mlTrainingClient.SubmitTrainingJob(context.Background(),
-		&mltrainingpb.SubmitTrainingJobRequest{Filter: filter, OrganizationId: orgID, ModelName: modelName, ModelVersion: modelVersion, ModelType: mltrainingpb.ModelType(modelTypeEnum), Tags: labels})
+		&mltrainingpb.SubmitTrainingJobRequest{
+			Filter: filter, OrganizationId: orgID, ModelName: modelName, ModelVersion: modelVersion,
+			ModelType: mltrainingpb.ModelType(modelTypeEnum), Tags: labels,
+		})
 	if err != nil {
 		return "", errors.Wrapf(err, "received error from server")
 	}
@@ -105,7 +113,8 @@ func (c *viamClient) dataCancelTrainingJob(trainingJobID string) error {
 	if err := c.ensureLoggedIn(); err != nil {
 		return err
 	}
-	if _, err := c.mlTrainingClient.CancelTrainingJob(context.Background(), &mltrainingpb.CancelTrainingJobRequest{Id: trainingJobID}); err != nil {
+	if _, err := c.mlTrainingClient.CancelTrainingJob(
+		context.Background(), &mltrainingpb.CancelTrainingJobRequest{Id: trainingJobID}); err != nil {
 		return err
 	}
 	return nil
@@ -136,10 +145,14 @@ func (c *viamClient) dataListTrainingJobs(orgID, status string) (interface{}, er
 	}
 	statusEnum, ok := mltrainingpb.TrainingStatus_value["TRAINING_STATUS_"+strings.ToUpper(status)]
 	if !ok {
-		return nil, errors.Errorf("%s must be a valid TrainingStatus, got %s. See `viam data train list --help` for supported options.", trainFlagJobStatus, status)
+		return nil, errors.Errorf("%s must be a valid TrainingStatus, got %s. See `viam data train list --help` for supported options",
+			trainFlagJobStatus, status)
 	}
 
-	resp, err := c.mlTrainingClient.ListTrainingJobs(context.Background(), &mltrainingpb.ListTrainingJobsRequest{OrganizationId: orgID, Status: mltrainingpb.TrainingStatus(statusEnum)})
+	resp, err := c.mlTrainingClient.ListTrainingJobs(context.Background(), &mltrainingpb.ListTrainingJobsRequest{
+		OrganizationId: orgID,
+		Status:         mltrainingpb.TrainingStatus(statusEnum),
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/cli/train.go
+++ b/cli/train.go
@@ -1,0 +1,147 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/urfave/cli/v2"
+	datapb "go.viam.com/api/app/data/v1"
+	mltrainingpb "go.viam.com/api/app/mltraining/v1"
+)
+
+const (
+	trainFlagJobID        = "job-id"
+	trainFlagJobStatus    = "job-status"
+	trainFlagModelOrgID   = "model-org-id"
+	trainFlagModelName    = "model-name"
+	trainFlagModelVersion = "model-version"
+	trainFlagModelType    = "model-type"
+	trainFlagModelLabels  = "model-labels"
+)
+
+// DataSubmitTrainingJob is the corresponding action for 'data train submit'.
+func DataSubmitTrainingJob(c *cli.Context) error {
+	client, err := newViamClient(c)
+	if err != nil {
+		return err
+	}
+	filter, err := createDataFilter(c)
+	if err != nil {
+		return err
+	}
+	trainingJobID, err := client.dataSubmitTrainingJob(filter, c.String(trainFlagModelOrgID), c.String(trainFlagModelName), c.String(trainFlagModelVersion), c.String(trainFlagModelType), c.StringSlice(trainFlagModelLabels))
+	if err != nil {
+		return err
+	}
+	printf(c.App.Writer, "Submitted training job with ID %s", trainingJobID)
+	return nil
+}
+
+// dataSubmitTrainingJob trains on data with the specified filter.
+func (c *viamClient) dataSubmitTrainingJob(filter *datapb.Filter, orgID string, modelName string, modelVersion string, modelType string, labels []string) (string, error) {
+	if err := c.ensureLoggedIn(); err != nil {
+		return "", err
+	}
+	if modelVersion == "" {
+		modelVersion = time.Now().Format("2006-01-02T15-04-05")
+	}
+	modelTypeEnum, ok := mltrainingpb.ModelType_value["MODEL_TYPE_"+strings.ToUpper(modelType)]
+	if !ok || modelTypeEnum == int32(mltrainingpb.ModelType_MODEL_TYPE_UNSPECIFIED) {
+		return "", errors.Errorf("%s must be a valid ModelType, got %s. See `viam data train submit --help` for supported options.", trainFlagModelType, modelType)
+	}
+
+	resp, err := c.mlTrainingClient.SubmitTrainingJob(context.Background(),
+		&mltrainingpb.SubmitTrainingJobRequest{Filter: filter, OrganizationId: orgID, ModelName: modelName, ModelVersion: modelVersion, ModelType: mltrainingpb.ModelType(modelTypeEnum), Tags: labels})
+	if err != nil {
+		return "", errors.Wrapf(err, "received error from server")
+	}
+	return resp.Id, nil
+}
+
+// DataGetTrainingJob is the corresponding action for 'data train get'.
+func DataGetTrainingJob(c *cli.Context) error {
+	client, err := newViamClient(c)
+	if err != nil {
+		return err
+	}
+	metadata, err := client.dataGetTrainingJob(c.String(trainFlagJobID))
+	if err != nil {
+		return err
+	}
+	printf(c.App.Writer, "Training job metadata: %s", metadata)
+	return nil
+}
+
+// dataGetTrainingJob gets a training job with the given ID.
+func (c *viamClient) dataGetTrainingJob(trainingJobID string) (*mltrainingpb.TrainingJobMetadata, error) {
+	if err := c.ensureLoggedIn(); err != nil {
+		return nil, err
+	}
+	resp, err := c.mlTrainingClient.GetTrainingJob(context.Background(), &mltrainingpb.GetTrainingJobRequest{Id: trainingJobID})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Metadata, nil
+}
+
+// DataCancelTrainingJob is the corresponding action for 'data train cancel'.
+func DataCancelTrainingJob(c *cli.Context) error {
+	client, err := newViamClient(c)
+	if err != nil {
+		return err
+	}
+	id := c.String(trainFlagJobID)
+	if err := client.dataCancelTrainingJob(id); err != nil {
+		return err
+	}
+	printf(c.App.Writer, "Successfully sent cancellation request for training job %s", id)
+	return nil
+}
+
+// dataCancelTrainingJob cancels a training job with the given ID.
+func (c *viamClient) dataCancelTrainingJob(trainingJobID string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+	if _, err := c.mlTrainingClient.CancelTrainingJob(context.Background(), &mltrainingpb.CancelTrainingJobRequest{Id: trainingJobID}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// DataListTrainingJobs is the corresponding action for 'data train list'.
+func DataListTrainingJobs(c *cli.Context) error {
+	client, err := newViamClient(c)
+	if err != nil {
+		return err
+	}
+	resp, err := client.dataListTrainingJobs(c.String(dataFlagOrgID), c.String(trainFlagJobStatus))
+	if err != nil {
+		return err
+	}
+	printf(c.App.Writer, "Training jobs: %s", resp)
+	return nil
+}
+
+// dataListTrainingJobs lists training jobs for the given org.
+func (c *viamClient) dataListTrainingJobs(orgID, status string) (interface{}, error) {
+	if err := c.ensureLoggedIn(); err != nil {
+		return nil, err
+	}
+
+	if status == "" {
+		status = "unspecified"
+	}
+	statusEnum, ok := mltrainingpb.TrainingStatus_value["TRAINING_STATUS_"+strings.ToUpper(status)]
+	if !ok {
+		return nil, errors.Errorf("%s must be a valid TrainingStatus, got %s. See `viam data train list --help` for supported options.", trainFlagJobStatus, status)
+	}
+
+	resp, err := c.mlTrainingClient.ListTrainingJobs(context.Background(), &mltrainingpb.ListTrainingJobsRequest{OrganizationId: orgID, Status: mltrainingpb.TrainingStatus(statusEnum)})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Jobs, nil
+}

--- a/cli/train.go
+++ b/cli/train.go
@@ -53,7 +53,7 @@ func (c *viamClient) dataSubmitTrainingJob(filter *datapb.Filter, orgID, modelNa
 	}
 	modelTypeEnum, ok := mltrainingpb.ModelType_value["MODEL_TYPE_"+strings.ToUpper(modelType)]
 	if !ok || modelTypeEnum == int32(mltrainingpb.ModelType_MODEL_TYPE_UNSPECIFIED) {
-		return "", errors.Errorf("%s must be a valid ModelType, got %s. See `viam data train submit --help` for supported options",
+		return "", errors.Errorf("%s must be a valid ModelType, got %s. See `viam train submit --help` for supported options",
 			trainFlagModelType, modelType)
 	}
 
@@ -147,7 +147,7 @@ func (c *viamClient) dataListTrainingJobs(orgID, status string) ([]*mltrainingpb
 	}
 	statusEnum, ok := mltrainingpb.TrainingStatus_value["TRAINING_STATUS_"+strings.ToUpper(status)]
 	if !ok {
-		return nil, errors.Errorf("%s must be a valid TrainingStatus, got %s. See `viam data train list --help` for supported options",
+		return nil, errors.Errorf("%s must be a valid TrainingStatus, got %s. See `viam train list --help` for supported options",
 			trainFlagJobStatus, status)
 	}
 

--- a/cli/train.go
+++ b/cli/train.go
@@ -74,11 +74,11 @@ func DataGetTrainingJob(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	metadata, err := client.dataGetTrainingJob(c.String(trainFlagJobID))
+	job, err := client.dataGetTrainingJob(c.String(trainFlagJobID))
 	if err != nil {
 		return err
 	}
-	printf(c.App.Writer, "Training job metadata: %s", metadata)
+	printf(c.App.Writer, "Training job: %s", job)
 	return nil
 }
 
@@ -126,16 +126,18 @@ func DataListTrainingJobs(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	resp, err := client.dataListTrainingJobs(c.String(dataFlagOrgID), c.String(trainFlagJobStatus))
+	jobs, err := client.dataListTrainingJobs(c.String(dataFlagOrgID), c.String(trainFlagJobStatus))
 	if err != nil {
 		return err
 	}
-	printf(c.App.Writer, "Training jobs: %s", resp)
+	for _, job := range jobs {
+		printf(c.App.Writer, "Training job: %s\n", job)
+	}
 	return nil
 }
 
 // dataListTrainingJobs lists training jobs for the given org.
-func (c *viamClient) dataListTrainingJobs(orgID, status string) (interface{}, error) {
+func (c *viamClient) dataListTrainingJobs(orgID, status string) ([]*mltrainingpb.TrainingJobMetadata, error) {
 	if err := c.ensureLoggedIn(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In order to submit a training job, use the filter commands copied from `Copy export command` in the app UI, just without `data-type` and `destination`. In order get all image data with `mug` and `not-mug` tags in the Viam org, and use it to train a single label classifier to detect mugs, I ran the following command:

`
go run cli/viam/main.go train submit --model-org-id={Viam org ID used to train and save model in} --model-name=mug_classifier_from_cli --model-type=single_label_classification --model-labels=mug --tags=not-mug,mug --org-ids={Viam org id, but could have included other org IDs to grab data from} --mime-types=image/jpeg,image/png
`

This returned the generated training job ID in the Viam cloud, which I could grab the training progress on via:
`
go run cli/viam/main.go train get --job-id={job ID returned above}
`

I could list all training jobs of a certain type
`
 go run cli/viam/main.go train list --org-id={Viam org id} --training-status={in_progress, completed, etc}
`

Cancel the currently training job:
`
 go run cli/viam/main.go train cancel --job-id={job ID returned above}
`

Result:
![image](https://github.com/viamrobotics/rdk/assets/3794748/915fe050-e2c5-4e7a-8077-f36715c7e039)
