### PR TITLE
[RSDK-5225] have robot cli not depend on listrobots

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -710,17 +710,13 @@ func (c *viamClient) robot(orgStr, locStr, robotStr string) (*apppb.Robot, error
 		return nil, err
 	}
 
-	robots, err := c.listRobots(orgStr, locStr)
+	resp, err := c.client.GetRobot(c.c.Context, &apppb.GetRobotRequest{
+		Id: robotStr,
+	})
 	if err != nil {
 		return nil, err
 	}
-
-	for _, robot := range robots {
-		if robot.Id == robotStr || robot.Name == robotStr {
-			return robot, nil
-		}
-	}
-	return nil, errors.Errorf("no robot found for %q", robotStr)
+	return resp.GetRobot(), nil
 }
 
 func (c *viamClient) robotPart(orgStr, locStr, robotStr, partStr string) (*apppb.RobotPart, error) {

--- a/cli/client.go
+++ b/cli/client.go
@@ -710,12 +710,24 @@ func (c *viamClient) robot(orgStr, locStr, robotStr string) (*apppb.Robot, error
 		return nil, err
 	}
 
+	robots, err := c.listRobots(orgStr, locStr)
+	if err != nil {
+		return nil, err
+	}
+	for _, robot := range robots {
+		if robot.Id == robotStr || robot.Name == robotStr {
+			return robot, nil
+		}
+	}
+
+	// check if the robot is a cloud robot using the ID
 	resp, err := c.client.GetRobot(c.c.Context, &apppb.GetRobotRequest{
 		Id: robotStr,
 	})
 	if err != nil {
-		return nil, err
+		return nil, errors.Errorf("no robot found for %q", robotStr)
 	}
+
 	return resp.GetRobot(), nil
 }
 


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-5225

currently when using the CLI, when trying to view a robot using a robotID the CLI will call ListRobots, loop look thru the org/location's robots for a match on robotID. 

This change makes it so the CLI does not depend on ListRobots when using a robotID. 

further context: 
cloud robots(used by cloudslam) are not returned by ListRobots, so we cannot use the CLI to view the logs from a cloud robot unless this change is made