### PR TITLE
UI error handling, loading states

### DIFF
--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -610,10 +610,14 @@
                     <p class="pr-1.5 text-xs text-gray-500">o<sub>x</sub></p>
                     <p>{pose.oX.toFixed(1)}</p>
 
-                    <p class="pl-6 pr-1.5 text-xs text-gray-500">o<sub>y</sub></p>
+                    <p class="pl-6 pr-1.5 text-xs text-gray-500">
+                      o<sub>y</sub>
+                    </p>
                     <p>{pose.oY.toFixed(1)}</p>
 
-                    <p class="pl-6 pr-1.5 text-xs text-gray-500">o<sub>z</sub></p>
+                    <p class="pl-6 pr-1.5 text-xs text-gray-500">
+                      o<sub>z</sub>
+                    </p>
                     <p>{pose.oZ.toFixed(1)}</p>
 
                     <p class="pl-6 pr-1.5 text-xs text-gray-500">&theta;</p>
@@ -640,7 +644,7 @@
               on:click={handle2dRenderClick}
             />
           </div>
-        {:else if overrides?.isCloudSlam && sessionId}
+        {:else if overrides?.isCloudSlam && sessionId && refresh2dRate !== "manual"}
           <div
             class="flex flex-col h-full w-full items-center justify-center gap-4"
           >
@@ -652,7 +656,7 @@
                 <span>Starting slam session in the cloud.</span>
                 <span>This typically takes about 2 minutes.</span>
               {:else}
-                <span>Loading pointcloud...</span>
+                <span>Loading point cloud...</span>
               {/if}
             </div>
           </div>

--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -51,6 +51,7 @@
   let durationInterval: number | undefined;
   let newMapName = "";
   let mapNameError = "";
+  let mappingSessionStarted = false;
 
   $: pointcloudLoaded = !!pointcloud?.length && pose !== undefined;
   $: moveClicked = $operations.find(({ op }) =>
@@ -332,6 +333,7 @@
       try {
         hasActiveSession = true;
         sessionId = await overrides.startMappingSession(mapName);
+        mappingSessionStarted = true;
         startMappingIntervals(Date.now());
       } catch {
         hasActiveSession = false;
@@ -571,84 +573,90 @@
         </div>
       {/if}
 
-      {#if pointcloudLoaded && show2d}
-        <div>
-          <div class="flex flex-row pl-5 py-2 border-b border-b-light">
-            <div class="flex flex-col gap-0.5">
-              <div class="flex gap-2">
-                <p class="text-xs">Current position</p>
-                <button
-                  class="text-xs hover:underline"
-                  on:click={() =>
-                    (labelUnits = labelUnits === "mm" ? "m" : "mm")}
-                >
-                  ({labelUnits})
-                </button>
+      {#if show2d}
+        {#if pointcloudLoaded}
+          <div>
+            <div class="flex flex-row pl-5 py-2 border-b border-b-light">
+              <div class="flex flex-col gap-0.5">
+                <div class="flex gap-2">
+                  <p class="text-xs">Current position</p>
+                  <button
+                    class="text-xs hover:underline"
+                    on:click={() =>
+                      (labelUnits = labelUnits === "mm" ? "m" : "mm")}
+                  >
+                    ({labelUnits})
+                  </button>
+                </div>
+
+                {#if pose}
+                  <div class="flex flex-row items-center">
+                    <p class="items-end pr-1.5 text-xs text-gray-500">x</p>
+                    <p>{(pose.x * unitScale).toFixed(1)}</p>
+
+                    <p class="pl-6 pr-1.5 text-xs text-gray-500">y</p>
+                    <p>{(pose.y * unitScale).toFixed(1)}</p>
+
+                    <p class="pl-6 pr-1.5 text-xs text-gray-500">z</p>
+                    <p>{(pose.z * unitScale).toFixed(1)}</p>
+                  </div>
+                {/if}
+              </div>
+              <div class="flex flex-col gap-0.5 pl-10">
+                <p class="text-xs">Current orientation</p>
+
+                {#if pose}
+                  <div class="flex flex-row items-center">
+                    <p class="pr-1.5 text-xs text-gray-500">o<sub>x</sub></p>
+                    <p>{pose.oX.toFixed(1)}</p>
+
+                    <p class="pl-6 pr-1.5 text-xs text-gray-500">o<sub>y</sub></p>
+                    <p>{pose.oY.toFixed(1)}</p>
+
+                    <p class="pl-6 pr-1.5 text-xs text-gray-500">o<sub>z</sub></p>
+                    <p>{pose.oZ.toFixed(1)}</p>
+
+                    <p class="pl-6 pr-1.5 text-xs text-gray-500">&theta;</p>
+                    <p>{pose.theta.toFixed(1)}</p>
+                  </div>
+                {/if}
               </div>
 
-              {#if pose}
-                <div class="flex flex-row items-center">
-                  <p class="items-end pr-1.5 text-xs text-gray-500">x</p>
-                  <p>{(pose.x * unitScale).toFixed(1)}</p>
-
-                  <p class="pl-6 pr-1.5 text-xs text-gray-500">y</p>
-                  <p>{(pose.y * unitScale).toFixed(1)}</p>
-
-                  <p class="pl-6 pr-1.5 text-xs text-gray-500">z</p>
-                  <p>{(pose.z * unitScale).toFixed(1)}</p>
-                </div>
-              {/if}
-            </div>
-            <div class="flex flex-col gap-0.5 pl-10">
-              <p class="text-xs">Current orientation</p>
-
-              {#if pose}
-                <div class="flex flex-row items-center">
-                  <p class="pr-1.5 text-xs text-gray-500">o<sub>x</sub></p>
-                  <p>{pose.oX.toFixed(1)}</p>
-
-                  <p class="pl-6 pr-1.5 text-xs text-gray-500">o<sub>y</sub></p>
-                  <p>{pose.oY.toFixed(1)}</p>
-
-                  <p class="pl-6 pr-1.5 text-xs text-gray-500">o<sub>z</sub></p>
-                  <p>{pose.oZ.toFixed(1)}</p>
-
-                  <p class="pl-6 pr-1.5 text-xs text-gray-500">&theta;</p>
-                  <p>{pose.theta.toFixed(1)}</p>
-                </div>
-              {/if}
+              <v-button
+                tooltip="Copy pose to clipboard"
+                class="pl-4 pt-2"
+                variant="icon"
+                icon="content-copy"
+                on:click={baseCopyPosition}
+                on:keydown={baseCopyPosition}
+              />
             </div>
 
-            <v-button
-              tooltip="Copy pose to clipboard"
-              class="pl-4 pt-2"
-              variant="icon"
-              icon="content-copy"
-              on:click={baseCopyPosition}
-              on:keydown={baseCopyPosition}
+            <Slam2D
+              {pointcloud}
+              {pose}
+              {destination}
+              helpers={showAxes}
+              on:click={handle2dRenderClick}
             />
           </div>
-
-          <Slam2D
-            {pointcloud}
-            {pose}
-            {destination}
-            helpers={showAxes}
-            on:click={handle2dRenderClick}
-          />
-        </div>
-      {:else if overrides?.isCloudSlam && sessionId}
-        <div
-          class="flex flex-col h-full w-full items-center justify-center gap-4"
-        >
-          <div class="animate-[spin_3s_linear_infinite]">
-            <v-icon name="cog" size="4xl" />
+        {:else if overrides?.isCloudSlam && sessionId}
+          <div
+            class="flex flex-col h-full w-full items-center justify-center gap-4"
+          >
+            <div class="animate-[spin_3s_linear_infinite]">
+              <v-icon name="cog" size="4xl" />
+            </div>
+            <div class="flex flex-col items-center text-xs">
+              {#if mappingSessionStarted}
+                <span>Starting slam session in the cloud.</span>
+                <span>This typically takes about 2 minutes.</span>
+              {:else}
+                <span>Loading pointcloud...</span>
+              {/if}
+            </div>
           </div>
-          <div class="flex flex-col items-center text-xs">
-            <span>Starting slam session in the cloud.</span>
-            <span>This typically takes about 2 minutes.</span>
-          </div>
-        </div>
+        {/if}
       {/if}
     </div>
   </div>

--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -643,7 +643,7 @@
               on:click={handle2dRenderClick}
             />
           </div>
-        {:else if overrides?.isCloudSlam && sessionId && refresh2dRate !== 'manual'}
+        {:else if overrides?.isCloudSlam && sessionId}
           <div
             class="flex flex-col h-full w-full items-center justify-center gap-4"
           >

--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -1,22 +1,22 @@
 <script lang="ts">
   /* eslint-disable require-atomic-updates */
 
-  import * as THREE from "three";
-  import { onMount, onDestroy } from "svelte";
+  import * as THREE from 'three';
+  import { onMount, onDestroy } from 'svelte';
 
-  import { SlamClient, type Pose, type ServiceError } from "@viamrobotics/sdk";
-  import { copyToClipboard } from "@/lib/copy-to-clipboard";
-  import { filterSubtype } from "@/lib/resource";
-  import { moveOnMap, stopMoveOnMap } from "@/api/motion";
-  import { notify } from "@viamrobotics/prime";
-  import { setAsyncInterval } from "@/lib/schedule";
-  import { components } from "@/stores/resources";
-  import Collapse from "@/lib/components/collapse.svelte";
-  import PCD from "@/components/pcd/pcd-view.svelte";
-  import Slam2D from "./2d/index.svelte";
-  import { useRobotClient, useDisconnect } from "@/hooks/robot-client";
-  import type { SLAMOverrides } from "@/types/overrides";
-  import { rcLogConditionally } from "@/lib/log";
+  import { SlamClient, type Pose, type ServiceError } from '@viamrobotics/sdk';
+  import { copyToClipboard } from '@/lib/copy-to-clipboard';
+  import { filterSubtype } from '@/lib/resource';
+  import { moveOnMap, stopMoveOnMap } from '@/api/motion';
+  import { notify } from '@viamrobotics/prime';
+  import { setAsyncInterval } from '@/lib/schedule';
+  import { components } from '@/stores/resources';
+  import Collapse from '@/lib/components/collapse.svelte';
+  import PCD from '@/components/pcd/pcd-view.svelte';
+  import Slam2D from './2d/index.svelte';
+  import { useRobotClient, useDisconnect } from '@/hooks/robot-client';
+  import type { SLAMOverrides } from '@/types/overrides';
+  import { rcLogConditionally } from '@/lib/log';
 
   export let name: string;
   export let overrides: SLAMOverrides | undefined;
@@ -27,15 +27,15 @@
   });
 
   const refreshErrorMessage =
-    "Error refreshing map. The map shown may be stale.";
+    'Error refreshing map. The map shown may be stale.';
 
   let clear2dRefresh: (() => void) | undefined;
   let clear3dRefresh: (() => void) | undefined;
 
   let refreshErrorMessage2d: string | undefined;
   let refreshErrorMessage3d: string | undefined;
-  let refresh2dRate = "manual";
-  let refresh3dRate = "manual";
+  let refresh2dRate = 'manual';
+  let refresh3dRate = 'manual';
   let pointcloud: Uint8Array | undefined;
   let pose: Pose | undefined;
   let lastTimestamp = new Date();
@@ -43,24 +43,23 @@
   let show3d = false;
   let showAxes = true;
   let destination: THREE.Vector2 | undefined;
-  let labelUnits = "m";
+  let labelUnits = 'm';
   let hasActiveSession = false;
-  let sessionId = "";
+  let sessionId = '';
   let mappingSessionEnded = false;
   let sessionDuration = 0;
   let durationInterval: number | undefined;
-  let newMapName = "";
-  let mapNameError = "";
+  let newMapName = '';
+  let mapNameError = '';
   let mappingSessionStarted = false;
 
-  $: pointcloudLoaded = !!pointcloud?.length && pose !== undefined;
+  $: pointcloudLoaded = Boolean(pointcloud?.length) && pose !== undefined;
   $: moveClicked = $operations.find(({ op }) =>
-    op.method.includes("MoveOnMap")
-  );
-  $: unitScale = labelUnits === "m" ? 1 : 1000;
+    op.method.includes('MoveOnMap'));
+  $: unitScale = labelUnits === 'm' ? 1 : 1000;
 
   // get all resources which are bases
-  $: bases = filterSubtype($components, "base");
+  $: bases = filterSubtype($components, 'base');
 
   // allowMove is only true if we have a base, there exists a destination and there is no in-flight MoveOnMap req
   $: allowMove = bases.length === 1 && destination && !moveClicked;
@@ -128,7 +127,7 @@
       refreshErrorMessage2d = undefined;
     } catch (error) {
       refreshErrorMessage2d =
-        error !== null && typeof error === "object" && "message" in error
+        error !== null && typeof error === 'object' && 'message' in error
           ? `${refreshErrorMessage} ${error.message}`
           : `${refreshErrorMessage} ${error}`;
     }
@@ -157,7 +156,7 @@
       refreshErrorMessage3d = undefined;
     } catch (error) {
       refreshErrorMessage3d =
-        error !== null && typeof error === "object" && "message" in error
+        error !== null && typeof error === 'object' && 'message' in error
           ? `${refreshErrorMessage} ${error.message}`
           : `${refreshErrorMessage} ${error}`;
     }
@@ -169,7 +168,7 @@
 
     refreshErrorMessage2d = undefined;
 
-    if (refresh2dRate !== "manual") {
+    if (refresh2dRate !== 'manual') {
       clear2dRefresh = setAsyncInterval(
         refresh2d,
         Number.parseFloat(refresh2dRate) * 1000
@@ -183,7 +182,7 @@
 
     refreshErrorMessage3d = undefined;
 
-    if (refresh3dRate !== "manual") {
+    if (refresh3dRate !== 'manual') {
       clear3dRefresh = setAsyncInterval(
         refresh3d,
         Number.parseFloat(refresh3dRate) * 1000
@@ -194,7 +193,7 @@
   const toggle3dExpand = () => {
     show3d = !show3d;
     if (!show3d) {
-      refresh3dRate = "manual";
+      refresh3dRate = 'manual';
       return;
     }
     updateSLAM3dRefreshFrequency();
@@ -203,19 +202,19 @@
   const toggle2dExpand = () => {
     show2d = !show2d;
     if (!show2d) {
-      refresh2dRate = "manual";
+      refresh2dRate = 'manual';
       return;
     }
     updateSLAM2dRefreshFrequency();
   };
 
   const refresh2dMap = () => {
-    refresh2dRate = "manual";
+    refresh2dRate = 'manual';
     updateSLAM2dRefreshFrequency();
   };
 
   const refresh3dMap = () => {
-    refresh2dRate = "manual";
+    refresh2dRate = 'manual';
     updateSLAM3dRefreshFrequency();
   };
 
@@ -230,7 +229,7 @@
       destination ??= new THREE.Vector2();
       destination.x =
         Number.parseFloat(event.detail.value) *
-        (labelUnits === "mm" ? 0.001 : 1);
+        (labelUnits === 'mm' ? 0.001 : 1);
     }
   };
 
@@ -239,7 +238,7 @@
       destination ??= new THREE.Vector2();
       destination.y =
         Number.parseFloat(event.detail.value) *
-        (labelUnits === "mm" ? 0.001 : 1);
+        (labelUnits === 'mm' ? 0.001 : 1);
     }
   };
 
@@ -326,7 +325,7 @@
       // error may not be present if user has not yet typed in input
       const mapName = overrides.mappingDetails.name || newMapName;
       if (!mapName) {
-        mapNameError = "Please enter a name for this map";
+        mapNameError = 'Please enter a name for this map';
         return;
       }
 
@@ -382,7 +381,7 @@
 
   const handleMapNameChange = (event: CustomEvent) => {
     newMapName = event.detail.value;
-    mapNameError = overrides?.validateMapName(newMapName) || "";
+    mapNameError = overrides?.validateMapName(newMapName) || '';
   };
 </script>
 
@@ -392,7 +391,7 @@
     slot="header"
     variant="danger"
     icon="stop-circle-outline"
-    disabled={moveClicked ? "false" : "true"}
+    disabled={moveClicked ? 'false' : 'true'}
     label="Stop"
     on:click={handleStopMoveClick}
     on:keydown={handleStopMoveClick}
@@ -432,7 +431,7 @@
               <v-input
                 label="Map name"
                 value={newMapName}
-                state={mapNameError ? "error" : ""}
+                state={mapNameError ? 'error' : ''}
                 message={mapNameError}
                 on:input={handleMapNameChange}
               />
@@ -451,7 +450,7 @@
                       class:bg-3={mappingSessionEnded}
                       class:text-default={mappingSessionEnded}
                     >
-                      <span>{mappingSessionEnded ? "Saved" : "Running"}</span>
+                      <span>{mappingSessionEnded ? 'Saved' : 'Running'}</span>
                     </div>
                     <span class="text-subtle-2"
                       >{formatDuration(sessionDuration)}</span
@@ -483,7 +482,7 @@
                 <button
                   class="text-xs hover:underline"
                   on:click={() =>
-                    (labelUnits = labelUnits === "mm" ? "m" : "mm")}
+                    (labelUnits = labelUnits === 'mm' ? 'm' : 'mm')}
                 >
                   ({labelUnits})
                 </button>
@@ -495,8 +494,8 @@
                   incrementor="slider"
                   value={destination
                     ? (destination.x * unitScale).toFixed(5)
-                    : ""}
-                  step={labelUnits === "mm" ? "10" : "1"}
+                    : ''}
+                  step={labelUnits === 'mm' ? '10' : '1'}
                   on:input={handleUpdateDestX}
                 />
                 <v-input
@@ -505,8 +504,8 @@
                   incrementor="slider"
                   value={destination
                     ? (destination.y * unitScale).toFixed(5)
-                    : ""}
-                  step={labelUnits === "mm" ? "10" : "1"}
+                    : ''}
+                  step={labelUnits === 'mm' ? '10' : '1'}
                   on:input={handleUpdateDestY}
                 />
                 <v-button
@@ -514,7 +513,7 @@
                   label="Move"
                   variant="success"
                   icon="play-circle-outline"
-                  disabled={allowMove ? "false" : "true"}
+                  disabled={allowMove ? 'false' : 'true'}
                   on:click={handleMoveClick}
                   on:keydown={handleMoveClick}
                 />
@@ -562,7 +561,7 @@
       <v-switch
         class="pt-2"
         label="Show grid"
-        value={showAxes ? "on" : "off"}
+        value={showAxes ? 'on' : 'off'}
         on:input={toggleAxes}
       />
     </div>
@@ -583,7 +582,7 @@
                   <button
                     class="text-xs hover:underline"
                     on:click={() =>
-                      (labelUnits = labelUnits === "mm" ? "m" : "mm")}
+                      (labelUnits = labelUnits === 'mm' ? 'm' : 'mm')}
                   >
                     ({labelUnits})
                   </button>
@@ -644,7 +643,7 @@
               on:click={handle2dRenderClick}
             />
           </div>
-        {:else if overrides?.isCloudSlam && sessionId && refresh2dRate !== "manual"}
+        {:else if overrides?.isCloudSlam && sessionId && refresh2dRate !== 'manual'}
           <div
             class="flex flex-col h-full w-full items-center justify-center gap-4"
           >
@@ -668,7 +667,7 @@
   <div class="border border-medium border-t-transparent p-4">
     <v-switch
       label="View SLAM map (3D)"
-      value={show3d ? "on" : "off"}
+      value={show3d ? 'on' : 'off'}
       on:input={toggle3dExpand}
     />
     {#if refreshErrorMessage3d && show3d}


### PR DESCRIPTION
This PR handles some UI improvements to the SLAM card, namely:

- Hiding the refresh map error when map is successfully obtained
- Preventing user from adding destination markers when in cloud SLAM mode
- Ensuring that empty point clouds are also accounted for 
- Adding a loading state if user is in cloud SLAM mode and there is not yet a map loaded into frontend
  - The text differs depending on if the user started the session or is coming back to a session they started previously and sets a refresh rate

For the video, I stubbed it to show the loading state - normally the left panel would look different in cloud slam mode.
https://github.com/viamrobotics/rdk/assets/16711130/bc40e301-f593-433e-8610-2c7316945f73

