### PR TITLE
Use the GetImages ResponseMetadata timestamp for the data capture timestamp

### DIFF
--- a/services/datamanager/datasync/upload_data_capture_file.go
+++ b/services/datamanager/datasync/upload_data_capture_file.go
@@ -41,7 +41,7 @@ func uploadDataCaptureFile(ctx context.Context, client v1.DataSyncServiceClient,
 
 		// If the GetImagesResponse metadata contains a capture timestamp, use that to
 		// populate SensorMetadata. Otherwise, use the timestamps that the data management
-		// system sent a GetImageRequest and received the GetImagesResponse.
+		// system stored of when a request was sent and response was received.
 		var timeRequested, timeReceived *timestamppb.Timestamp
 		timeCaptured := res.GetResponseMetadata().GetCapturedAt()
 		if timeCaptured != nil {

--- a/services/datamanager/datasync/upload_data_capture_file.go
+++ b/services/datamanager/datasync/upload_data_capture_file.go
@@ -33,20 +33,18 @@ func uploadDataCaptureFile(ctx context.Context, client v1.DataSyncServiceClient,
 	}
 
 	if md.GetType() == v1.DataType_DATA_TYPE_BINARY_SENSOR && md.GetMethodName() == datacapture.GetImages {
-		timeReq := sensorData[0].GetMetadata().GetTimeRequested()
-		timeRec := sensorData[0].GetMetadata().GetTimeReceived()
-		var getImgsRes pb.GetImagesResponse
-		mp := sensorData[0].GetStruct().AsMap()
-		if err := mapstructure.Decode(mp, &getImgsRes); err != nil {
+		var res pb.GetImagesResponse
+		if err := mapstructure.Decode(sensorData[0].GetStruct().AsMap(), &res); err != nil {
 			return err
 		}
+		captureTimestamp := res.GetResponseMetadata().GetCapturedAt()
 
-		for _, img := range getImgsRes.Images {
+		for _, img := range res.Images {
 			newSensorData := []*v1.SensorData{
 				{
 					Metadata: &v1.SensorMetadata{
-						TimeRequested: timeReq,
-						TimeReceived:  timeRec,
+						TimeRequested: captureTimestamp,
+						TimeReceived:  captureTimestamp,
 					},
 					Data: &v1.SensorData_Binary{
 						Binary: img.GetImage(),

--- a/services/datamanager/datasync/upload_data_capture_file.go
+++ b/services/datamanager/datasync/upload_data_capture_file.go
@@ -41,7 +41,7 @@ func uploadDataCaptureFile(ctx context.Context, client v1.DataSyncServiceClient,
 
 		// If the GetImagesResponse metadata contains a capture timestamp, use that to
 		// populate SensorMetadata. Otherwise, use the timestamps that the data management
-		// system stored of when a request was sent and response was received.
+		// system stored to track when a request was sent and response was received.
 		var timeRequested, timeReceived *timestamppb.Timestamp
 		timeCaptured := res.GetResponseMetadata().GetCapturedAt()
 		if timeCaptured != nil {


### PR DESCRIPTION
Store timestamp from the GetImages response metadata instead of the time that the method was called and complete (requested and received) by the datamangement service.

**Testing**
Tested on a fake camera.