### PR TITLE
RSDK-5325 - MRR should gracefully handle a v prefix for semver

### DIFF
--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -186,7 +186,7 @@ func UploadModuleAction(c *cli.Context) error {
 		return errors.New("no package to upload -- please provide an archive containing your module. Use --help for more information")
 	}
 
-	// Clean the version argument to ensure compatability with github tag standards
+	// Clean the version argument to ensure compatibility with github tag standards
 	versionArg = strings.TrimPrefix(versionArg, "v")
 
 	client, err := newViamClient(c)

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -186,6 +186,9 @@ func UploadModuleAction(c *cli.Context) error {
 		return errors.New("no package to upload -- please provide an archive containing your module. Use --help for more information")
 	}
 
+	// Clean the version argument to ensure compatability with github tag standards
+	versionArg = strings.TrimPrefix(versionArg, "v")
+
 	client, err := newViamClient(c)
 	if err != nil {
 		return err


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-5325
With v:
```
➜  animalsoundspammer git:(main) ✗ viam module upload --platform linux/amd64 --version v1.0.0 ./package/module.tgz
Uploading... 100% (22705662/22705662 bytes)
Version successfully uploaded! you can view your changes online here: https://app.viam.com/module/zack/test_underscore
```
Without v:
```
➜  animalsoundspammer git:(main) ✗ viam module upload --platform linux/amd64 --version 1.0.1 ./package/module.tgz
Uploading... 100% (22705662/22705662 bytes)
Version successfully uploaded! you can view your changes online here: https://app.viam.com/module/zack/test_underscore
```