### PR TITLE
[Idea] Add `module verify` command to CLI

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -990,6 +990,31 @@ viam module upload --version "0.1.0" --platform "linux/amd64" packaged-module.ta
 					},
 					Action: UploadModuleAction,
 				},
+				{
+					Name:  "verify",
+					Usage: "verify that your module qualifies as a Viam module",
+					Description: `Verifies that the provided module can properly function as a Viam module.
+
+A module can be built in any language, with or without support of the Viam SDKs. A module must have the
+following properties.
+  - Is an executable file by UNIX standards. This can be a compiled binary, or a script with the proper
+    shebang to its interpreter, such as Python.
+  - Looks at the first argument passed to it at execution, and uses that as its gRPC socket path.
+  - Listens with plaintext gRPC on that socket.
+  - gRPC must provide the Module service (https://github.com/viamrobotics/api/tree/main/proto/viam/module/v1/module.proto),
+    a reflection service, and any APIs needed for the resources it intends to serve. Note that the "robot"
+    service itself is NOT required.
+  - Handles the Module service's calls for Ready(), and Add/Remove/ReconfigureResource()
+  - Cleanly exits when sent a SIGINT or SIGTERM signal.
+
+See our example modules in Golang, C++ and Python for more information. They all fulfill the above
+requirements.
+  - Golang: https://github.com/viamrobotics/rdk/tree/main/examples/customresources/demos
+  - C++: https://github.com/viamrobotics/viam-cpp-sdk/tree/main/src/viam/examples/modules
+  - Python: https://github.com/viamrobotics/viam-python-sdk/tree/main/examples`,
+					UsageText: "viam module verify <path/to/module>",
+					Action:    VerifyModuleAction,
+				},
 			},
 		},
 		{

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -20,6 +20,8 @@ import (
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	apppb "go.viam.com/api/app/v1"
+	"go.viam.com/utils"
+
 	rconfig "go.viam.com/rdk/config"
 	"go.viam.com/rdk/module/modmanager"
 	modmanageroptions "go.viam.com/rdk/module/modmanager/options"
@@ -304,7 +306,12 @@ func verifyModule(executablePath string, w io.Writer) error {
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(parentAddr)
+	defer utils.UncheckedErrorFunc(func() error {
+		if _, err := os.Stat(parentAddr); err == nil {
+			return os.RemoveAll(parentAddr)
+		}
+		return nil
+	})
 	parentAddr += "/parent.sock"
 
 	// Set up module manager with a dummy RemoveOrphanedResources function; we

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -40,12 +40,23 @@ var (
 	logLevelArgumentTemplate    = "--log-level=%s"
 	errModularResourcesDisabled = errors.New("modular resources disabled in untrusted environment")
 
-	// NOTE(benjirewis): these error messages are referenced in the CLI to
+	// NOTE(benjirewis): the error messages below are referenced in the CLI to
 	// determine why a module may be invalid.
-	ErrMsgCouldNotStartModule     = "error while starting module "
-	ErrMsgCouldNotDialModule      = "error while dialing module "
-	ErrMsgModuleNoReadyResp       = "error while waiting for module to be ready "
-	ErrMsgCouldNotStopModule      = "error while stopping module "
+
+	// ErrMsgCouldNotStartModule is returned when there was an error starting a
+	// module.
+	ErrMsgCouldNotStartModule = "error while starting module "
+	// ErrMsgCouldNotDialModule is returned when there was an error dialing a
+	// module.
+	ErrMsgCouldNotDialModule = "error while dialing module "
+	// ErrMsgModuleNoReadyResp is returned when a module did not respond to a
+	// ready request in time.
+	ErrMsgModuleNoReadyResp = "error while waiting for module to be ready "
+	// ErrMsgCouldNotStopModule is returned when there was an error stopping a
+	// module.
+	ErrMsgCouldNotStopModule = "error while stopping module "
+	// ErrMsgCouldNotCloseModuleConn is returned when there was an error closing
+	// the connection to a module.
 	ErrMsgCouldNotCloseModuleConn = "error while closing connection from module "
 )
 

--- a/module/modmaninterface/interface.go
+++ b/module/modmaninterface/interface.go
@@ -5,6 +5,7 @@ import (
 	"context"
 
 	"go.viam.com/rdk/config"
+	modlib "go.viam.com/rdk/module"
 	"go.viam.com/rdk/resource"
 )
 
@@ -19,6 +20,7 @@ type ModuleManager interface {
 	RemoveResource(ctx context.Context, name resource.Name) error
 	IsModularResource(name resource.Name) bool
 	ValidateConfig(ctx context.Context, cfg resource.Config) ([]string, error)
+	HandlerMap(modName string) (modlib.HandlerMap, error)
 
 	Configs() []config.Module
 	Provides(cfg resource.Config) bool


### PR DESCRIPTION
Adds a `module verify` subcommand to the CLI. `verify` takes a single argument: a path to an executable file that is an alleged Viam module. Then it:

1. Creates a module config with that path
2. Adds that module config to a fake module manager
    a. Asserts that adding did not result in error, and if it did, returns an error about what went wrong
3. Prints what API/model pairs the module serves
4. Removes the module from the fake module manager
    a. Asserts that removing did not result in error, and if it did, returns an error about what went wrong