### PR TITLE
use bookworm sources in appimage

### DIFF
--- a/etc/packaging/appimages/viam-server-aarch64.yml
+++ b/etc/packaging/appimages/viam-server-aarch64.yml
@@ -29,9 +29,9 @@ AppDir:
     - arm64
     allow_unauthenticated: true
     sources:
-    - sourceline: deb [trusted=yes] http://deb.debian.org/debian bullseye main
-    - sourceline: deb [trusted=yes] http://deb.debian.org/debian-security bullseye-security main
-    - sourceline: deb [trusted=yes] http://deb.debian.org/debian bullseye-updates main
+    - sourceline: deb [trusted=yes] http://deb.debian.org/debian bookworm main
+    - sourceline: deb [trusted=yes] http://deb.debian.org/debian-security bookworm-security main
+    - sourceline: deb [trusted=yes] http://deb.debian.org/debian bookworm-updates main
     include:
     - bash
   files:

--- a/etc/packaging/appimages/viam-server-x86_64.yml
+++ b/etc/packaging/appimages/viam-server-x86_64.yml
@@ -29,9 +29,9 @@ AppDir:
     - amd64
     allow_unauthenticated: true
     sources:
-    - sourceline: deb [trusted=yes] http://deb.debian.org/debian bullseye main
-    - sourceline: deb [trusted=yes] http://deb.debian.org/debian-security bullseye-security main
-    - sourceline: deb [trusted=yes] http://deb.debian.org/debian bullseye-updates main
+    - sourceline: deb [trusted=yes] http://deb.debian.org/debian bookworm main
+    - sourceline: deb [trusted=yes] http://deb.debian.org/debian-security bookworm-security main
+    - sourceline: deb [trusted=yes] http://deb.debian.org/debian bookworm-updates main
     include:
     - bash
   files:


### PR DESCRIPTION
## What changed
- Change bullseye -> bookworm in appimages/viam-server-*.yml
## Why
- Our appimages crash on startup with `/tmp/.mount_viam-szc2YKQ/usr/bin/viam-server: /lib/x86_64-linux-gnu/libc.so.6: version 'GLIBC_2.36' not found (required by /tmp/.mount_viam-szc2YKQ/usr/bin/viam-server)` (see appimage-test step [here](https://github.com/viamrobotics/rdk/actions/runs/6484277269/job/17609343723#step:3:84))
- This is because our rdk-devenv base image is bookworm, but our appimages are using bullseye apt repos (my fault)
- In the PR which broke this, I tested the 32-bit appimages but did not test the normal ones :upside_down_face:
## Test
- this starts: https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-server-pr-3058-x86_64.AppImage
## Note
- Appimage has its own static-build step which uses rdk-devenv, not antique2 -- in theory we could use the antique2 static-build output inside appimages