### PR TITLE
APP-2546 - add namespace to organizations list CLI command

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -78,7 +78,11 @@ func (c *viamClient) listOrganizationsAction(cCtx *cli.Context) error {
 		if i == 0 {
 			printf(cCtx.App.Writer, "Organizations for %q:", c.conf.Auth)
 		}
-		printf(cCtx.App.Writer, "\t%s (id: %s)", org.Name, org.Id)
+		printf(cCtx.App.Writer, "\t%s", org.Name)
+		printf(cCtx.App.Writer, "\t\tid: %s", org.Id)
+		if org.PublicNamespace != "" {
+			printf(cCtx.App.Writer, "\t\tnamespace: %s", org.PublicNamespace)
+		}
 	}
 	return nil
 }

--- a/cli/client.go
+++ b/cli/client.go
@@ -78,11 +78,12 @@ func (c *viamClient) listOrganizationsAction(cCtx *cli.Context) error {
 		if i == 0 {
 			printf(cCtx.App.Writer, "Organizations for %q:", c.conf.Auth)
 		}
-		printf(cCtx.App.Writer, "\t%s", org.Name)
-		printf(cCtx.App.Writer, "\t\tid: %s", org.Id)
+		idInfo := fmt.Sprintf("(id: %s)", org.Id)
+		namespaceInfo := ""
 		if org.PublicNamespace != "" {
-			printf(cCtx.App.Writer, "\t\tnamespace: %s", org.PublicNamespace)
+			namespaceInfo = fmt.Sprintf(" (namespace: %s)", org.PublicNamespace)
 		}
+		printf(cCtx.App.Writer, "\t%s %s%s", org.Name, idInfo, namespaceInfo)
 	}
 	return nil
 }

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -80,7 +80,7 @@ func TestListOrganizationsAction(t *testing.T) {
 	listOrganizationsFunc := func(ctx context.Context, in *apppb.ListOrganizationsRequest,
 		opts ...grpc.CallOption,
 	) (*apppb.ListOrganizationsResponse, error) {
-		orgs := []*apppb.Organization{{Name: "jedi"}, {Name: "mandalorians"}}
+		orgs := []*apppb.Organization{{Name: "jedi", PublicNamespace: "anakin"}, {Name: "mandalorians"}}
 		return &apppb.ListOrganizationsResponse{Organizations: orgs}, nil
 	}
 	asc := &inject.AppServiceClient{
@@ -93,6 +93,7 @@ func TestListOrganizationsAction(t *testing.T) {
 	test.That(t, len(out.messages), test.ShouldEqual, 3)
 	test.That(t, out.messages[0], test.ShouldEqual, fmt.Sprintf("Organizations for %q:\n", testEmail))
 	test.That(t, out.messages[1], test.ShouldContainSubstring, "jedi")
+	test.That(t, out.messages[1], test.ShouldContainSubstring, "anakin")
 	test.That(t, out.messages[2], test.ShouldContainSubstring, "mandalorians")
 }
 


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/APP-2546

Any thoughts on how you'd do this? I just put this PR out here to spark discussion. I've liked all your choices for the cli so far. To that end, if you have a different idea, feel free to just submit your own pr and we can close this

Here was what I came up with in 1-2 mins

Option1:
```
Organizations for "zack.porter@viam.com":
	Dan's Org (id: 04307f0a-27c7-4b60-acba-99de6528ec6f)
	Ethan's Org (ethanlook) (id: 42710bbc-538f-437f-9f33-70e497adb057)
	Peter B's Org (peter) (id: a9cbebc7-e812-4ada-b886-b075f45d51e1)
	Roxy's Org (roxy) (id: 2440e58c-038b-4abd-a11b-08b7549ea632)
	SLAM Dev (id: 1d77887c-f295-4517-b562-ef00a4c6122c)
```

Option2:
```
Organizations for "zack.porter@viam.com":
	Dan's Org
		id: 04307f0a-27c7-4b60-acba-99de6528ec6f
	Ethan's Org
		id: 42710bbc-538f-437f-9f33-70e497adb057
		namespace: ethanlook
	Peter B's Org
		id: a9cbebc7-e812-4ada-b886-b075f45d51e1
		namespace: peter
	Roxy's Org
		id: 2440e58c-038b-4abd-a11b-08b7549ea632
		namespace: roxy
	SLAM Dev
		id: 1d77887c-f295-4517-b562-ef00a4c6122c
```

Option 2 seems easier to read (imo) but it becomes a bit harder to do unix like things like `viam organizations list | grep "my-org"` because now the id is on another line. However I also think Option1 wasn't great in that regard... 


(Tests should be adjusted either way)