### PR TITLE
RSDK-5063 upload 32-bit appimage

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -179,7 +179,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [ubuntu-latest, buildjet-2vcpu-ubuntu-2204-arm, [arm64, pi4]]
+        arch: [[ubuntu-latest], [buildjet-2vcpu-ubuntu-2204-arm], [arm64, pi4]]
     needs: appimage
     runs-on: ${{ matrix.arch }}
     timeout-minutes: 15

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -179,13 +179,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-        - arch: ubuntu-latest
-          label: x86_64
-        - arch: buildjet-2vcpu-ubuntu-2204-arm
-          label: aarch64
-        - arch: [arm64, pi4]
-          label: aarch64
+        arch: [ubuntu-latest, buildjet-2vcpu-ubuntu-2204-arm, [arm64, pi4]]
     needs: appimage
     runs-on: ${{ matrix.arch }}
     timeout-minutes: 15

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -249,11 +249,14 @@ jobs:
         name: appimage-armhf
         path: etc/packaging/appimages/deploy
 
+    - name: trace
+      run: find etc/packaging/appimages/deploy
+
     - name: deploy 32-bit
       uses: google-github-actions/upload-cloud-storage@v0.10.4
       with:
         headers: "cache-control: no-cache"
-        path: etc/packaging/appimages/deploy/viam-server-$channel-armhf.AppImage
+        path: etc/packaging/appimages/deploy/viam-server-${{ env.channel }}-armhf.AppImage
         destination: 'packages.viam.com/apps/viam-server/'
         parent: false
 

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -238,6 +238,8 @@ jobs:
     name: AppImage Deploy
     needs: appimage_test
     runs-on: ubuntu-latest
+    env:
+      channel: ${{ github.ref_name == 'main' && 'latest' || github.ref_name }}
 
     steps:
     - name: Authorize GCP
@@ -248,17 +250,28 @@ jobs:
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v1
 
+    - uses: actions/download-artifact@v3
+      with:
+        name: appimage-armhf
+        path: etc/packaging/appimages/deploy
+
+    - name: deploy 32-bit
+      uses: google-github-actions/upload-cloud-storage@v0.10.4
+      with:
+        headers: "cache-control: no-cache"
+        path: etc/packaging/appimages/deploy/viam-server-$channel-armhf.AppImage
+        destination: 'packages.viam.com/apps/viam-server/'
+        parent: false
+
+    - name: short-circuit
+      run: exit 1
+
     - name: Publish AppImage
       run: |
         gsutil mv "gs://packages.viam.com/apps/viam-server/testing/appimage/${{ needs.appimage_test.outputs.date }}/${{ github.sha }}/*" "gs://packages.viam.com/apps/viam-server/"
 
     - name: Output Summary
       run: |
-        channel="${{ github.ref_name }}"
-        # we call our main branch releases "latest"
-        if [ "$channel" == "main" ]; then
-          channel="latest"
-        fi
         echo "### Built AppImages for ${channel}" >> $GITHUB_STEP_SUMMARY
         echo "- arm64: https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-server-${channel}-aarch64.AppImage" >> $GITHUB_STEP_SUMMARY
         echo "- x86_64: https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-server-${channel}-x86_64.AppImage" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -186,15 +186,8 @@ jobs:
           label: aarch64
         - arch: [arm64, pi4]
           label: aarch64
-        - arch: buildjet-2vcpu-ubuntu-2204-arm
-          container:
-            image: debian
-            options: --platform linux/arm/v7
-          # note: `uname -m` will not detect armhf in our 32-on-64 setup, so we provide label in matrix
-          label: armhf
-    needs: [appimage, appimage-32bit]
+    needs: appimage
     runs-on: ${{ matrix.arch }}
-    container: ${{ matrix.container }}
     timeout-minutes: 15
     outputs:
       date: ${{ needs.appimage.outputs.date }}
@@ -219,7 +212,7 @@ jobs:
         export TEST_DIR=`mktemp -d -t test-viam-server-XXXXXX`
         cd $TEST_DIR
 
-        curl -o viam-server https://storage.googleapis.com/packages.viam.com/apps/viam-server/testing/appimage/${{ needs.appimage.outputs.date }}/${{ github.sha }}/viam-server-${channel}-${{ matrix.label }}.AppImage
+        curl -o viam-server https://storage.googleapis.com/packages.viam.com/apps/viam-server/testing/appimage/${{ needs.appimage.outputs.date }}/${{ github.sha }}/viam-server-${channel}-`uname -m`.AppImage
         chmod 755 viam-server
 
         export RAND_PORT=$((30000 + $RANDOM))

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -179,9 +179,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [[ubuntu-latest], [buildjet-2vcpu-ubuntu-2204-arm], [arm64, pi4]]
-    needs: appimage
+        include:
+        - arch: ubuntu-latest
+          label: x86_64
+        - arch: buildjet-2vcpu-ubuntu-2204-arm
+          label: aarch64
+        - arch: [arm64, pi4]
+          label: aarch64
+        - arch: buildjet-2vcpu-ubuntu-2204-arm
+          container:
+            image: debian
+            options: --platform linux/arm/v7
+          # note: `uname -m` will not detect armhf in our 32-on-64 setup, so we provide label in matrix
+          label: armhf
+    needs: [appimage, appimage-32bit]
     runs-on: ${{ matrix.arch }}
+    container: ${{ matrix.container }}
     timeout-minutes: 15
     outputs:
       date: ${{ needs.appimage.outputs.date }}
@@ -206,7 +219,7 @@ jobs:
         export TEST_DIR=`mktemp -d -t test-viam-server-XXXXXX`
         cd $TEST_DIR
 
-        curl -o viam-server https://storage.googleapis.com/packages.viam.com/apps/viam-server/testing/appimage/${{ needs.appimage.outputs.date }}/${{ github.sha }}/viam-server-${channel}-`uname -m`.AppImage
+        curl -o viam-server https://storage.googleapis.com/packages.viam.com/apps/viam-server/testing/appimage/${{ needs.appimage.outputs.date }}/${{ github.sha }}/viam-server-${channel}-${{ matrix.label }}.AppImage
         chmod 755 viam-server
 
         export RAND_PORT=$((30000 + $RANDOM))
@@ -249,4 +262,5 @@ jobs:
         echo "### Built AppImages for ${channel}" >> $GITHUB_STEP_SUMMARY
         echo "- arm64: https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-server-${channel}-aarch64.AppImage" >> $GITHUB_STEP_SUMMARY
         echo "- x86_64: https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-server-${channel}-x86_64.AppImage" >> $GITHUB_STEP_SUMMARY
+        echo "- armhf: https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-server-${channel}-armhf.AppImage" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -223,8 +223,7 @@ jobs:
 
   appimage_deploy:
     name: AppImage Deploy
-    needs: appimage-32bit
-    # needs: [appimage_test, appimage-32bit]
+    needs: [appimage_test, appimage-32bit]
     runs-on: ubuntu-latest
     env:
       channel: ${{ github.ref_name == 'main' && 'latest' || github.ref_name }}
@@ -243,9 +242,6 @@ jobs:
         name: appimage-armhf
         path: etc/packaging/appimages/deploy
 
-    - name: trace
-      run: find etc/packaging/appimages/deploy
-
     - name: deploy 32-bit
       uses: google-github-actions/upload-cloud-storage@v0.10.4
       with:
@@ -253,9 +249,6 @@ jobs:
         path: etc/packaging/appimages/deploy/viam-server-${{ env.channel }}-armhf.AppImage
         destination: 'packages.viam.com/apps/viam-server/'
         parent: false
-
-    - name: short-circuit
-      run: exit 1
 
     - name: Publish AppImage
       run: |

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -156,7 +156,7 @@ jobs:
       run: make appimage-arch
     - uses: actions/upload-artifact@v3
       with:
-        name: appimage-32bit
+        name: appimage-armhf
         path: etc/packaging/appimages/deploy
 
   output_summary:
@@ -229,7 +229,8 @@ jobs:
 
   appimage_deploy:
     name: AppImage Deploy
-    needs: appimage_test
+    needs: appimage-32bit
+    # needs: [appimage_test, appimage-32bit]
     runs-on: ubuntu-latest
     env:
       channel: ${{ github.ref_name == 'main' && 'latest' || github.ref_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,8 @@ jobs:
             image: ghcr.io/viamrobotics/rdk-devenv:armhf-cache
             platform: linux/arm/v7
             platform_name: linux-armv7
-            test_cmd: make cover
+            # note: -race detection not supported on arm 32-bit, and test.sh overrides GOFLAGS
+            test_cmd: go test -v -tags=no_tflite ./...
     runs-on: ${{ matrix.arch }}
     container:
       image: ${{ matrix.image }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,27 +17,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - arch: buildjet-8vcpu-ubuntu-2204
+          - arch: [buildjet-8vcpu-ubuntu-2204]
             image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
             platform: linux/amd64
             platform_name: linux-amd64
-            test_cmd: make test-web
-          - arch: buildjet-8vcpu-ubuntu-2204
-            image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
-            platform: linux/amd64
-            platform_name: linux-amd64
-            test_cmd: make cover
-          - arch: buildjet-8vcpu-ubuntu-2204-arm
+            test_cmd: "make cover test-web"
+          - arch: [buildjet-8vcpu-ubuntu-2204-arm]
             image: ghcr.io/viamrobotics/rdk-devenv:arm64-cache
             platform: linux/arm64
             platform_name: linux-arm64
-            test_cmd: make cover
-          - arch: buildjet-8vcpu-ubuntu-2204-arm
-            image: ghcr.io/viamrobotics/rdk-devenv:armhf-cache
-            platform: linux/arm/v7
-            platform_name: linux-armv7
-            # note: -race detection not supported on arm 32-bit, and test.sh overrides GOFLAGS
-            test_cmd: go test -v -tags=no_tflite ./...
+            test_cmd: "make cover test-web"
     runs-on: ${{ matrix.arch }}
     container:
       image: ${{ matrix.image }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,12 +21,17 @@ jobs:
             image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
             platform: linux/amd64
             platform_name: linux-amd64
-            test_cmd: "make cover test-web"
+            test_cmd: make test-web
+          - arch: buildjet-8vcpu-ubuntu-2204
+            image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
+            platform: linux/amd64
+            platform_name: linux-amd64
+            test_cmd: make cover
           - arch: buildjet-8vcpu-ubuntu-2204-arm
             image: ghcr.io/viamrobotics/rdk-devenv:arm64-cache
             platform: linux/arm64
             platform_name: linux-arm64
-            test_cmd: "make cover test-web"
+            test_cmd: make cover
           - arch: buildjet-8vcpu-ubuntu-2204-arm
             image: ghcr.io/viamrobotics/rdk-devenv:armhf-cache
             platform: linux/arm/v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,16 +17,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - arch: [buildjet-8vcpu-ubuntu-2204]
+          - arch: buildjet-8vcpu-ubuntu-2204
             image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
             platform: linux/amd64
             platform_name: linux-amd64
             test_cmd: "make cover test-web"
-          - arch: [buildjet-8vcpu-ubuntu-2204-arm]
+          - arch: buildjet-8vcpu-ubuntu-2204-arm
             image: ghcr.io/viamrobotics/rdk-devenv:arm64-cache
             platform: linux/arm64
             platform_name: linux-arm64
             test_cmd: "make cover test-web"
+          - arch: buildjet-8vcpu-ubuntu-2204-arm
+            image: ghcr.io/viamrobotics/rdk-devenv:armhf-cache
+            platform: linux/arm/v7
+            platform_name: linux-armv7
+            test_cmd: make cover
     runs-on: ${{ matrix.arch }}
     container:
       image: ${{ matrix.image }}


### PR DESCRIPTION
## What changed
- include 32-bit appimage in 'appimage deploy' step
## Testing
- working run of this [here](https://github.com/viamrobotics/rdk/actions/runs/6499096458) (it runs to the intentional short-circuit step in 'deploy')
- GCS upload went [here](https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-server-test-32bit-armhf.AppImage)