### PR TITLE
fix appimage for RC case

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -223,7 +223,8 @@ jobs:
 
   appimage_deploy:
     name: AppImage Deploy
-    needs: [appimage_test, appimage-32bit]
+    needs: [appimage-32bit]
+    # needs: [appimage_test, appimage-32bit]
     runs-on: ubuntu-latest
     env:
       channel: ${{ github.ref_name == 'main' && 'latest' || github.ref_name }}
@@ -249,6 +250,9 @@ jobs:
         path: etc/packaging/appimages/deploy/viam-server-${{ env.channel }}-armhf.AppImage
         destination: 'packages.viam.com/apps/viam-server/'
         parent: false
+
+    - name: short-circuit
+      run: exit 1
 
     - name: Publish AppImage
       run: |

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -149,7 +149,7 @@ jobs:
       run: pip install appimage-builder git+https://github.com/AppImageCrafters/appimage-builder.git@42d32f11496de43a9f6a9ada7882a11296e357ca
     - name: build
       env:
-        BUILD_CHANNEL: ${{ inputs.release_type }}
+        BUILD_CHANNEL: ${{ github.ref_name == 'main' && 'latest' || github.ref_name }}
         UNAME_M: armv7l
         DPKG_ARCH: armhf
         APPIMAGE_ARCH: armhf

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -223,8 +223,7 @@ jobs:
 
   appimage_deploy:
     name: AppImage Deploy
-    needs: [appimage-32bit]
-    # needs: [appimage_test, appimage-32bit]
+    needs: [appimage_test, appimage-32bit]
     runs-on: ubuntu-latest
     env:
       channel: ${{ github.ref_name == 'main' && 'latest' || github.ref_name }}
@@ -250,9 +249,6 @@ jobs:
         path: etc/packaging/appimages/deploy/viam-server-${{ env.channel }}-armhf.AppImage
         destination: 'packages.viam.com/apps/viam-server/'
         parent: false
-
-    - name: short-circuit
-      run: exit 1
 
     - name: Publish AppImage
       run: |


### PR DESCRIPTION
## What changed
- use same BUILD_CHANNEL logic in `appimage-32bit` job + `deploy` job
## What was wrong
- previously, build_channel for the 32-bit image was `release_type`
- this worked on main branch where `release_type == 'latest'` and `ref_name == 'main'` (and main gets converted to 'latest')
- but not in the RC case, where `release_type == 'rc'` and `ref_name == 1.2.3-rc`
## Test
This runs to short-circuit ([here](https://github.com/viamrobotics/rdk/actions/runs/6500312911/job/17655700179)) from a manual workflow_dispatch