### PR TITLE
[RSDK-5245] [RSDK-5246] Remove board dependency on GPS I2C devices

### DIFF
--- a/components/movementsensor/gpsnmea/gpsnmea.go
+++ b/components/movementsensor/gpsnmea/gpsnmea.go
@@ -133,9 +133,9 @@ func newNMEAGPS(
 
 	switch strings.ToLower(newConf.ConnectionType) {
 	case serialStr:
-		return NewSerialGPSNMEA(ctx, conf.ResourceName(), newConf, logger)
+		return NewSerialGPSNMEA(ctx, conf, logger)
 	case i2cStr:
-		return NewPmtkI2CGPSNMEA(ctx, deps, conf.ResourceName(), newConf, logger)
+		return NewPmtkI2CGPSNMEA(ctx, deps, conf, logger)
 	default:
 		return nil, connectionTypeError(
 			newConf.ConnectionType,

--- a/components/movementsensor/gpsnmea/gpsnmea.go
+++ b/components/movementsensor/gpsnmea/gpsnmea.go
@@ -51,10 +51,9 @@ type SerialConfig struct {
 
 // I2CConfig is used for converting Serial NMEA MovementSensor config attributes.
 type I2CConfig struct {
-	Board       string `json:"board"`
-	I2CBus      string `json:"i2c_bus"`
-	I2CAddr     int    `json:"i2c_addr"`
-	I2CBaudRate int    `json:"i2c_baud_rate,omitempty"`
+	I2CBus      int `json:"i2c_bus"`
+	I2CAddr     int `json:"i2c_addr"`
+	I2CBaudRate int `json:"i2c_baud_rate,omitempty"`
 }
 
 // Validate ensures all parts of the config are valid.
@@ -81,16 +80,12 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 
 // ValidateI2C ensures all parts of the config are valid.
 func (cfg *I2CConfig) validateI2C(path string) error {
-	if cfg.I2CBus == "" {
+	if cfg.I2CBus == 0 {
 		return utils.NewConfigValidationFieldRequiredError(path, "i2c_bus")
 	}
 	if cfg.I2CAddr == 0 {
 		return utils.NewConfigValidationFieldRequiredError(path, "i2c_addr")
 	}
-	if cfg.Board == "" {
-		return utils.NewConfigValidationFieldRequiredError(path, "board")
-	}
-
 	return nil
 }
 

--- a/components/movementsensor/gpsnmea/gpsnmea.go
+++ b/components/movementsensor/gpsnmea/gpsnmea.go
@@ -66,10 +66,6 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 
 	switch strings.ToLower(cfg.ConnectionType) {
 	case i2cStr:
-		if cfg.Board == "" {
-			return nil, utils.NewConfigValidationFieldRequiredError(path, "board")
-		}
-		deps = append(deps, cfg.Board)
 		return deps, cfg.I2CConfig.validateI2C(path)
 	case serialStr:
 		return nil, cfg.SerialConfig.validateSerial(path)

--- a/components/movementsensor/gpsnmea/gpsnmea.go
+++ b/components/movementsensor/gpsnmea/gpsnmea.go
@@ -133,9 +133,9 @@ func newNMEAGPS(
 
 	switch strings.ToLower(newConf.ConnectionType) {
 	case serialStr:
-		return NewSerialGPSNMEA(ctx, conf, logger)
+		return NewSerialGPSNMEA(ctx, conf.ResourceName(), newConf, logger)
 	case i2cStr:
-		return NewPmtkI2CGPSNMEA(ctx, deps, conf, logger)
+		return NewPmtkI2CGPSNMEA(ctx, deps, conf.ResourceName(), newConf, logger)
 	default:
 		return nil, connectionTypeError(
 			newConf.ConnectionType,

--- a/components/movementsensor/gpsnmea/gpsnmea.go
+++ b/components/movementsensor/gpsnmea/gpsnmea.go
@@ -51,9 +51,9 @@ type SerialConfig struct {
 
 // I2CConfig is used for converting Serial NMEA MovementSensor config attributes.
 type I2CConfig struct {
-	I2CBus      int `json:"i2c_bus"`
-	I2CAddr     int `json:"i2c_addr"`
-	I2CBaudRate int `json:"i2c_baud_rate,omitempty"`
+	I2CBus      string `json:"i2c_bus"`
+	I2CAddr     int    `json:"i2c_addr"`
+	I2CBaudRate int    `json:"i2c_baud_rate,omitempty"`
 }
 
 // Validate ensures all parts of the config are valid.
@@ -76,7 +76,7 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 
 // ValidateI2C ensures all parts of the config are valid.
 func (cfg *I2CConfig) validateI2C(path string) error {
-	if cfg.I2CBus == 0 {
+	if cfg.I2CBus == "" {
 		return utils.NewConfigValidationFieldRequiredError(path, "i2c_bus")
 	}
 	if cfg.I2CAddr == 0 {

--- a/components/movementsensor/gpsnmea/pmtkI2C.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C.go
@@ -1,3 +1,4 @@
+//go:build linux
 package gpsnmea
 
 import (
@@ -12,6 +13,7 @@ import (
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/genericlinux"
 	"go.viam.com/rdk/components/movementsensor"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -47,17 +49,10 @@ func NewPmtkI2CGPSNMEA(
 	conf *Config,
 	logger logging.Logger,
 ) (NmeaMovementSensor, error) {
-	b, err := board.FromDependencies(deps, conf.Board)
+	i2cbus, err := genericlinux.GetI2CBus(deps, "", "", conf.I2CConfig.I2CBus)
 	if err != nil {
-		return nil, fmt.Errorf("gps init: failed to find board: %w", err)
-	}
-	localB, ok := b.(board.LocalBoard)
-	if !ok {
-		return nil, fmt.Errorf("board %s is not local", conf.Board)
-	}
-	i2cbus, ok := localB.I2CByName(conf.I2CConfig.I2CBus)
-	if !ok {
-		return nil, fmt.Errorf("gps init: failed to find i2c bus %s", conf.I2CConfig.I2CBus)
+		return nil, fmt.Errorf("gps init: failed to find i2c bus %s: %w",
+		                       conf.I2CConfig.I2CBus, err)
 	}
 	addr := conf.I2CConfig.I2CAddr
 	if addr == -1 {

--- a/components/movementsensor/gpsnmea/pmtkI2C.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C.go
@@ -53,7 +53,7 @@ func NewPmtkI2CGPSNMEA(
 ) (NmeaMovementSensor, error) {
 	// The nil on this next line means "use a real I2C bus, because we're not going to pass in a
 	// mock one."
-	return makePmtkI2cGpsNmea(ctx, deps, name, conf, logger, nil)
+	return makePmtkI2cGpsNmea(ctx, deps, conf, logger, nil)
 }
 
 // makePmtkI2cGpsNmea is only split out for ease of testing: you can pass in your own mock I2C bus,
@@ -61,11 +61,16 @@ func NewPmtkI2CGPSNMEA(
 func makePmtkI2cGpsNmea(
     ctx context.Context,
     deps resource.Dependencies,
-    name resource.Name,
-    conf *Config,
+    config resource.Config,
     logger golog.Logger,
 	i2cbus board.I2C,
 ) (NmeaMovementSensor, error) {
+	name := config.ResourceName()
+	conf, err := resource.NativeConfig[*Config](config)
+    if err != nil {
+        return nil, err
+    }
+
 	if i2cbus == nil {
 		var err error
 		i2cbus, err = genericlinux.GetI2CBus(deps, "", "", conf.I2CConfig.I2CBus)

--- a/components/movementsensor/gpsnmea/pmtkI2C.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C.go
@@ -53,12 +53,13 @@ func NewPmtkI2CGPSNMEA(
 ) (NmeaMovementSensor, error) {
 	// The nil on this next line means "use a real I2C bus, because we're not going to pass in a
 	// mock one."
-	return makePmtkI2cGpsNmea(ctx, deps, name, conf, logger, nil)
+	return MakePmtkI2cGpsNmea(ctx, deps, name, conf, logger, nil)
 }
 
-// makePmtkI2cGpsNmea is only split out for ease of testing: you can pass in your own mock I2C bus,
-// or pass in nil to have it create a real one.
-func makePmtkI2cGpsNmea(
+// MakePmtkI2cGpsNmea is only split out for ease of testing: you can pass in your own mock I2C bus,
+// or pass in nil to have it create a real one. It is public so it can also be called from within
+// the gpsrtkpmtk package.
+func MakePmtkI2cGpsNmea(
 	ctx context.Context,
 	deps resource.Dependencies,
 	name resource.Name,

--- a/components/movementsensor/gpsnmea/pmtkI2C.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C.go
@@ -51,10 +51,28 @@ func NewPmtkI2CGPSNMEA(
 	conf *Config,
 	logger logging.Logger,
 ) (NmeaMovementSensor, error) {
-	i2cbus, err := genericlinux.GetI2CBus(deps, "", "", conf.I2CConfig.I2CBus)
-	if err != nil {
-		return nil, fmt.Errorf("gps init: failed to find i2c bus %s: %w",
-			conf.I2CConfig.I2CBus, err)
+	// The nil on this next line means "use a real I2C bus, because we're not going to pass in a
+	// mock one."
+	return makePmtkI2cGpsNmea(ctx, deps, name, conf, logger, nil)
+}
+
+// makePmtkI2cGpsNmea is only split out for ease of testing: you can pass in your own mock I2C bus,
+// or pass in nil to have it create a real one.
+func makePmtkI2cGpsNmea(
+    ctx context.Context,
+    deps resource.Dependencies,
+    name resource.Name,
+    conf *Config,
+    logger golog.Logger,
+	i2cbus board.I2C,
+) (NmeaMovementSensor, error) {
+	if i2cbus == nil {
+		err error
+		i2cbus, err = genericlinux.GetI2CBus(deps, "", "", conf.I2CConfig.I2CBus)
+		if err != nil {
+			return nil, fmt.Errorf("gps init: failed to find i2c bus %s: %w",
+				conf.I2CConfig.I2CBus, err)
+		}
 	}
 	addr := conf.I2CConfig.I2CAddr
 	if addr == -1 {

--- a/components/movementsensor/gpsnmea/pmtkI2C.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C.go
@@ -59,19 +59,19 @@ func NewPmtkI2CGPSNMEA(
 // makePmtkI2cGpsNmea is only split out for ease of testing: you can pass in your own mock I2C bus,
 // or pass in nil to have it create a real one.
 func makePmtkI2cGpsNmea(
-    ctx context.Context,
-    deps resource.Dependencies,
-    config resource.Config,
-    logger golog.Logger,
-	i2cbus board.I2C,
+	ctx context.Context,
+	deps resource.Dependencies,
+	config resource.Config,
+	logger golog.Logger,
+	i2cBus board.I2C,
 ) (NmeaMovementSensor, error) {
 	name := config.ResourceName()
 	conf, err := resource.NativeConfig[*Config](config)
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-	if i2cbus == nil {
+	if i2cBus == nil {
 		var err error
 		i2cbus, err = genericlinux.GetI2CBus(deps, "", "", conf.I2CConfig.I2CBus)
 		if err != nil {

--- a/components/movementsensor/gpsnmea/pmtkI2C.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C.go
@@ -54,7 +54,7 @@ func NewPmtkI2CGPSNMEA(
 	i2cbus, err := genericlinux.GetI2CBus(deps, "", "", conf.I2CConfig.I2CBus)
 	if err != nil {
 		return nil, fmt.Errorf("gps init: failed to find i2c bus %s: %w",
-		                       conf.I2CConfig.I2CBus, err)
+			conf.I2CConfig.I2CBus, err)
 	}
 	addr := conf.I2CConfig.I2CAddr
 	if addr == -1 {

--- a/components/movementsensor/gpsnmea/pmtkI2C.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C.go
@@ -53,7 +53,7 @@ func NewPmtkI2CGPSNMEA(
 ) (NmeaMovementSensor, error) {
 	i2cbus, err := genericlinux.GetI2CBus(deps, "", "", conf.I2CConfig.I2CBus)
 	if err != nil {
-		return nil, fmt.Errorf("gps init: failed to find i2c bus %d: %w",
+		return nil, fmt.Errorf("gps init: failed to find i2c bus %s: %w",
 		                       conf.I2CConfig.I2CBus, err)
 	}
 	addr := conf.I2CConfig.I2CAddr

--- a/components/movementsensor/gpsnmea/pmtkI2C.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C.go
@@ -1,6 +1,8 @@
 //go:build linux
 package gpsnmea
 
+// Package gpsnmea implements a GPS NMEA component
+
 import (
 	"context"
 	"errors"
@@ -51,7 +53,7 @@ func NewPmtkI2CGPSNMEA(
 ) (NmeaMovementSensor, error) {
 	i2cbus, err := genericlinux.GetI2CBus(deps, "", "", conf.I2CConfig.I2CBus)
 	if err != nil {
-		return nil, fmt.Errorf("gps init: failed to find i2c bus %s: %w",
+		return nil, fmt.Errorf("gps init: failed to find i2c bus %d: %w",
 		                       conf.I2CConfig.I2CBus, err)
 	}
 	addr := conf.I2CConfig.I2CAddr

--- a/components/movementsensor/gpsnmea/pmtkI2C.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C.go
@@ -67,7 +67,7 @@ func makePmtkI2cGpsNmea(
 	i2cbus board.I2C,
 ) (NmeaMovementSensor, error) {
 	if i2cbus == nil {
-		err error
+		var err error
 		i2cbus, err = genericlinux.GetI2CBus(deps, "", "", conf.I2CConfig.I2CBus)
 		if err != nil {
 			return nil, fmt.Errorf("gps init: failed to find i2c bus %s: %w",

--- a/components/movementsensor/gpsnmea/pmtkI2C.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C.go
@@ -1,7 +1,7 @@
 //go:build linux
-package gpsnmea
 
 // Package gpsnmea implements a GPS NMEA component
+package gpsnmea
 
 import (
 	"context"

--- a/components/movementsensor/gpsnmea/pmtkI2C_nonlinux.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C_nonlinux.go
@@ -1,0 +1,26 @@
+//go:build !linux
+
+// Package gpsnmea implements a GPS NMEA component. This file contains just a stub of a constructor
+// for a Linux-only version of the component (using the I2C bus).
+package gpsnmea
+
+import (
+	"context"
+	"errors"
+
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+)
+
+// NewPmtkI2CGPSNMEA implements a gps that communicates over i2c.
+func NewPmtkI2CGPSNMEA(
+	ctx context.Context,
+	deps resource.Dependencies,
+	name resource.Name,
+	conf *Config,
+	logger logging.Logger,
+) (NmeaMovementSensor, error) {
+	// The nil on this next line means "use a real I2C bus, because we're not going to pass in a
+	// mock one."
+	return nil, errors.New("all I2C components are only available on Linux")
+}

--- a/components/movementsensor/gpsnmea/pmtkI2C_test.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C_test.go
@@ -81,7 +81,12 @@ func TestNewI2CMovementSensor(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	ctx := context.Background()
 
-	g, err := newNMEAGPS(ctx, deps, conf, logger)
+	nativeConf, err := resource.NativeConfig[*Config](conf)
+	test.That(t, err, test.ShouldBeNil)
+
+	mockI2cBus = createMockI2c()
+
+	g, err := makePmtkI2CGPSNMEA(ctx, deps, nativeConf, logger, mockI2cBus)
 	test.That(t, g, test.ShouldBeNil)
 	test.That(t, err, test.ShouldBeError,
 		utils.NewUnexpectedTypeError[*Config](conf.ConvertedAttributes))
@@ -97,13 +102,9 @@ func TestNewI2CMovementSensor(t *testing.T) {
 		},
 	}
 	g, err = newNMEAGPS(ctx, deps, conf, logger)
-	g.bus = createMockI2c()
-	passErr := "board " + testBoardName + " is not local"
-	if err == nil || err.Error() != passErr {
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, g.Close(context.Background()), test.ShouldBeNil)
-		test.That(t, g, test.ShouldNotBeNil)
-	}
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, g.Close(context.Background()), test.ShouldBeNil)
+	test.That(t, g, test.ShouldNotBeNil)
 }
 
 func TestReadingsI2C(t *testing.T) {

--- a/components/movementsensor/gpsnmea/pmtkI2C_test.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C_test.go
@@ -86,7 +86,7 @@ func TestNewI2CMovementSensor(t *testing.T) {
 	mockI2c := createMockI2c()
 
 	// This time, we *do* expect to construct a real object, so we need to pass in a mock I2C bus.
-	g2, err := makePmtkI2cGpsNmea(ctx, deps, conf.ResourceName(), config, logger, mockI2c)
+	g2, err := MakePmtkI2cGpsNmea(ctx, deps, conf.ResourceName(), config, logger, mockI2c)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, g2.Close(context.Background()), test.ShouldBeNil)
 	test.That(t, g2, test.ShouldNotBeNil)

--- a/components/movementsensor/gpsnmea/pmtkI2C_test.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C_test.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	testBoardName = "board1"
-	testBusName   = 1
+	testBusName   = "1"
 )
 
 func setupDependencies(t *testing.T) resource.Dependencies {
@@ -51,7 +51,7 @@ func setupDependencies(t *testing.T) resource.Dependencies {
 }
 
 func TestValidateI2C(t *testing.T) {
-	fakecfg := &I2CConfig{I2CBus: 1}
+	fakecfg := &I2CConfig{I2CBus: "1"}
 
 	path := "path"
 	err := fakecfg.validateI2C(path)

--- a/components/movementsensor/gpsnmea/pmtkI2C_test.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C_test.go
@@ -83,7 +83,7 @@ func TestNewI2CMovementSensor(t *testing.T) {
 
 	mockI2cBus := createMockI2c()
 
-	g1, err := makePmtkI2cGpsNmea(ctx, deps, conf.ResourceName(), conf, logger, mockI2cBus)
+	g1, err := makePmtkI2cGpsNmea(ctx, deps, conf, logger, mockI2cBus)
 	test.That(t, g1, test.ShouldBeNil)
 	test.That(t, err, test.ShouldBeError,
 		utils.NewUnexpectedTypeError[*Config](conf.ConvertedAttributes))

--- a/components/movementsensor/gpsnmea/pmtkI2C_test.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C_test.go
@@ -81,13 +81,10 @@ func TestNewI2CMovementSensor(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	ctx := context.Background()
 
-	nativeConf, err := resource.NativeConfig[*Config](conf)
-	test.That(t, err, test.ShouldBeNil)
+	mockI2cBus := createMockI2c()
 
-	mockI2cBus = createMockI2c()
-
-	g, err := makePmtkI2CGPSNMEA(ctx, deps, nativeConf, logger, mockI2cBus)
-	test.That(t, g, test.ShouldBeNil)
+	g1, err := makePmtkI2cGpsNmea(ctx, deps, conf.ResourceName(), conf, logger, mockI2cBus)
+	test.That(t, g1, test.ShouldBeNil)
 	test.That(t, err, test.ShouldBeError,
 		utils.NewUnexpectedTypeError[*Config](conf.ConvertedAttributes))
 
@@ -101,10 +98,10 @@ func TestNewI2CMovementSensor(t *testing.T) {
 			I2CConfig:      &I2CConfig{I2CBus: testBusName},
 		},
 	}
-	g, err = newNMEAGPS(ctx, deps, conf, logger)
+	g2, err := newNMEAGPS(ctx, deps, conf, logger)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, g.Close(context.Background()), test.ShouldBeNil)
-	test.That(t, g, test.ShouldNotBeNil)
+	test.That(t, g2.Close(context.Background()), test.ShouldBeNil)
+	test.That(t, g2, test.ShouldNotBeNil)
 }
 
 func TestReadingsI2C(t *testing.T) {

--- a/components/movementsensor/gpsnmea/pmtkI2C_test.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 package gpsnmea
 
 import (
@@ -50,7 +51,7 @@ func setupDependencies(t *testing.T) resource.Dependencies {
 }
 
 func TestValidateI2C(t *testing.T) {
-	fakecfg := &I2CConfig{Board: testBoardName, I2CBus: "some-bus"}
+	fakecfg := &I2CConfig{I2CBus: 1}
 
 	path := "path"
 	err := fakecfg.validateI2C(path)

--- a/components/movementsensor/gpsnmea/pmtkI2C_test.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C_test.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	testBoardName = "board1"
-	testBusName   = "i2c1"
+	testBusName   = 1
 )
 
 func setupDependencies(t *testing.T) resource.Dependencies {
@@ -87,7 +87,7 @@ func TestNewI2CMovementSensor(t *testing.T) {
 		ConvertedAttributes: &Config{
 			ConnectionType: "I2C",
 			DisableNMEA:    false,
-			I2CConfig:      &I2CConfig{I2CBus: testBusName, Board: testBoardName},
+			I2CConfig:      &I2CConfig{I2CBus: testBusName},
 		},
 	}
 	g, err = newNMEAGPS(ctx, deps, conf, logger)

--- a/components/movementsensor/gpsnmea/pmtkI2C_test.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C_test.go
@@ -1,4 +1,5 @@
 //go:build linux
+
 package gpsnmea
 
 import (

--- a/components/movementsensor/gpsnmea/serial_test.go
+++ b/components/movementsensor/gpsnmea/serial_test.go
@@ -70,7 +70,6 @@ func TestNewSerialMovementSensor(t *testing.T) {
 				SerialPath:     path,
 				SerialBaudRate: 0,
 			},
-			I2CConfig: &I2CConfig{Board: "local"},
 		},
 	}
 	g, err = newNMEAGPS(ctx, deps, cfig, logger)

--- a/components/movementsensor/gpsnmea/serial_test.go
+++ b/components/movementsensor/gpsnmea/serial_test.go
@@ -39,7 +39,7 @@ func TestValidateSerial(t *testing.T) {
 }
 
 func TestNewSerialMovementSensor(t *testing.T) {
-	deps := setupDependencies(t)
+	var deps resource.Dependencies
 	path := "somepath"
 
 	cfig := resource.Config{

--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
@@ -164,7 +164,7 @@ func (g *rtkI2C) Reconfigure(ctx context.Context, deps resource.Dependencies, co
 
 	i2cbus, err := genericlinux.NewI2cBus(newConf.I2CBus)
 	if err != nil {
-		return fmt.Errorf("gps init: failed to find i2c bus %d: %w", newConf.I2CBus, err)
+		return fmt.Errorf("gps init: failed to find i2c bus %s: %w", newConf.I2CBus, err)
 	}
 	g.bus = i2cbus
 

--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
@@ -170,7 +170,7 @@ func (g *rtkI2C) Reconfigure(ctx context.Context, deps resource.Dependencies, co
 		}
 		g.bus = i2cbus
 	} else {
-		g.bus = mockI2c
+		g.bus = g.mockI2c
 	}
 
 	g.ntripconfigMu.Lock()

--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
@@ -163,11 +163,15 @@ func (g *rtkI2C) Reconfigure(ctx context.Context, deps resource.Dependencies, co
 
 	g.addr = byte(newConf.I2CAddr)
 
-	i2cbus, err := genericlinux.NewI2cBus(newConf.I2CBus)
-	if err != nil {
-		return fmt.Errorf("gps init: failed to find i2c bus %s: %w", newConf.I2CBus, err)
+	if g.mockI2c == nil {
+		i2cbus, err := genericlinux.NewI2cBus(newConf.I2CBus)
+		if err != nil {
+			return fmt.Errorf("gps init: failed to find i2c bus %s: %w", newConf.I2CBus, err)
+		}
+		g.bus = i2cbus
+	} else {
+		g.bus = mockI2c
 	}
-	g.bus = i2cbus
 
 	g.ntripconfigMu.Lock()
 	ntripConfig := &rtk.NtripConfig{

--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 // Package gpsrtkpmtk implements a gps using serial connection
 package gpsrtkpmtk
 
@@ -161,7 +163,7 @@ func (g *rtkI2C) Reconfigure(ctx context.Context, deps resource.Dependencies, co
 
 	i2cbus, err := genericlinux.NewI2cBus(fmt.Sprintf("%d", newConf.I2CBus)
 	if err != nil {
-		return fmt.Errorf("gps init: failed to find i2c bus %s: %w", newConf.I2CBus, err)
+		return fmt.Errorf("gps init: failed to find i2c bus %d: %w", newConf.I2CBus, err)
 	}
 	g.bus = i2cbus
 

--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
@@ -49,6 +49,7 @@ import (
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/genericlinux"
 	"go.viam.com/rdk/components/movementsensor"
 	gpsnmea "go.viam.com/rdk/components/movementsensor/gpsnmea"
 	rtk "go.viam.com/rdk/components/movementsensor/rtkutils"
@@ -161,7 +162,7 @@ func (g *rtkI2C) Reconfigure(ctx context.Context, deps resource.Dependencies, co
 
 	g.addr = byte(newConf.I2CAddr)
 
-	i2cbus, err := genericlinux.NewI2cBus(fmt.Sprintf("%d", newConf.I2CBus)
+	i2cbus, err := genericlinux.NewI2cBus(fmt.Sprintf("%d", newConf.I2CBus))
 	if err != nil {
 		return fmt.Errorf("gps init: failed to find i2c bus %d: %w", newConf.I2CBus, err)
 	}
@@ -229,8 +230,7 @@ func newRTKI2C(
 	}
 
 	// Init NMEAMovementSensor
-	nmeaConf.I2CConfig = &gpsnmea.I2CConfig{ // TODO: update this one to match
-		Board:       newConf.Board,
+	nmeaConf.I2CConfig = &gpsnmea.I2CConfig{
 		I2CBus:      newConf.I2CBus,
 		I2CBaudRate: newConf.I2CBaudRate,
 		I2CAddr:     newConf.I2CAddr,

--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
@@ -18,7 +18,7 @@ package gpsrtkpmtk
 		"type": "movement_sensor",
 		"model": "gps-nmea-rtk-pmtk",
 		"attributes": {
-			"i2c_bus": 1,
+			"i2c_bus": "1",
 			"i2c_addr": 66,
 			"i2c_baud_rate": 115200,
 			"ntrip_connect_attempts": 12,
@@ -64,9 +64,9 @@ const i2cStr = "i2c"
 
 // Config is used for converting NMEA MovementSensor with RTK capabilities config attributes.
 type Config struct {
-	I2CBus      int `json:"i2c_bus"`
-	I2CAddr     int `json:"i2c_addr"`
-	I2CBaudRate int `json:"i2c_baud_rate,omitempty"`
+	I2CBus      string `json:"i2c_bus"`
+	I2CAddr     int    `json:"i2c_addr"`
+	I2CBaudRate int    `json:"i2c_baud_rate,omitempty"`
 
 	NtripURL             string `json:"ntrip_url"`
 	NtripConnectAttempts int    `json:"ntrip_connect_attempts,omitempty"`
@@ -92,7 +92,7 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 
 // validateI2C ensures all parts of the config are valid.
 func (cfg *Config) validateI2C(path string) error {
-	if cfg.I2CBus == 0 {
+	if cfg.I2CBus == "" {
 		return utils.NewConfigValidationFieldRequiredError(path, "i2c_bus")
 	}
 	if cfg.I2CAddr == 0 {
@@ -162,7 +162,7 @@ func (g *rtkI2C) Reconfigure(ctx context.Context, deps resource.Dependencies, co
 
 	g.addr = byte(newConf.I2CAddr)
 
-	i2cbus, err := genericlinux.NewI2cBus(fmt.Sprintf("%d", newConf.I2CBus))
+	i2cbus, err := genericlinux.NewI2cBus(newConf.I2CBus)
 	if err != nil {
 		return fmt.Errorf("gps init: failed to find i2c bus %d: %w", newConf.I2CBus, err)
 	}

--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk_nonlinux.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk_nonlinux.go
@@ -1,0 +1,2 @@
+// Package gpsrtkpmtk is unimplemented for non-Linux OSes.
+package gpsrtkpmtk

--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk_test.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 package gpsrtkpmtk
 
 import (
@@ -18,8 +19,7 @@ import (
 const (
 	testRoverName   = "testRover"
 	testStationName = "testStation"
-	testBoardName   = "board1"
-	testBusName     = "bus1"
+	testBusNumber   = 1
 	testi2cAddr     = 44
 )
 
@@ -31,8 +31,7 @@ func TestValidateRTK(t *testing.T) {
 		NtripPass:            "somepass",
 		NtripUser:            "someuser",
 		NtripMountpoint:      "NYC",
-		Board:                testBoardName,
-		I2CBus:               testBusName,
+		I2CBus:               testBusNumber,
 		I2CAddr:              testi2cAddr,
 	}
 	t.Run("valid config", func(t *testing.T) {
@@ -47,8 +46,7 @@ func TestValidateRTK(t *testing.T) {
 			NtripPass:            "somepass",
 			NtripUser:            "someuser",
 			NtripMountpoint:      "NYC",
-			Board:                testBoardName,
-			I2CBus:               testBusName,
+			I2CBus:               testBusNumber,
 			I2CAddr:              testi2cAddr,
 		}
 		_, err := cfg.Validate(path)
@@ -58,13 +56,12 @@ func TestValidateRTK(t *testing.T) {
 
 	t.Run("invalid i2c bus", func(t *testing.T) {
 		cfg := Config{
-			I2CBus:               "",
+			I2CBus:               0,
 			NtripURL:             "http//fakeurl",
 			NtripConnectAttempts: 10,
 			NtripPass:            "somepass",
 			NtripUser:            "someuser",
 			NtripMountpoint:      "NYC",
-			Board:                testBoardName,
 			I2CAddr:              testi2cAddr,
 		}
 		_, err := cfg.Validate(path)
@@ -80,8 +77,7 @@ func TestValidateRTK(t *testing.T) {
 			NtripPass:            "somepass",
 			NtripUser:            "someuser",
 			NtripMountpoint:      "NYC",
-			Board:                testBoardName,
-			I2CBus:               testBusName,
+			I2CBus:               testBusNumber,
 		}
 		_, err := cfg.Validate(path)
 		test.That(t, err, test.ShouldBeError,
@@ -199,8 +195,7 @@ func TestReconfigure(t *testing.T) {
 			NtripPass:            "somepass",
 			NtripUser:            "someuser",
 			NtripMountpoint:      "NYC",
-			Board:                testBoardName,
-			I2CBus:               testBusName,
+			I2CBus:               testBusNumber,
 			I2CAddr:              testi2cAddr,
 			I2CBaudRate:          115200,
 		},

--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk_test.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk_test.go
@@ -15,6 +15,7 @@ import (
 	rtk "go.viam.com/rdk/components/movementsensor/rtkutils"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/testutils/inject"
 )
 
 const (
@@ -188,7 +189,7 @@ func TestReconfigure(t *testing.T) {
 	g := &rtkI2C{
 		wbaud:   9600,
 		addr:    byte(66),
-		mockI2c: mockI2c,
+		mockI2c: &mockI2c,
 	}
 	conf := resource.Config{
 		Name: "reconfig1",

--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk_test.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk_test.go
@@ -184,9 +184,11 @@ func TestReadings(t *testing.T) {
 }
 
 func TestReconfigure(t *testing.T) {
+	mockI2c := inject.I2C{}
 	g := &rtkI2C{
-		wbaud: 9600,
-		addr:  byte(66),
+		wbaud:   9600,
+		addr:    byte(66),
+		mockI2c: mockI2c,
 	}
 	conf := resource.Config{
 		Name: "reconfig1",

--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk_test.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk_test.go
@@ -1,4 +1,5 @@
 //go:build linux
+
 package gpsrtkpmtk
 
 import (

--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk_test.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk_test.go
@@ -56,7 +56,7 @@ func TestValidateRTK(t *testing.T) {
 
 	t.Run("invalid i2c bus", func(t *testing.T) {
 		cfg := Config{
-			I2CBus:               0,
+			I2CBus:               "",
 			NtripURL:             "http//fakeurl",
 			NtripConnectAttempts: 10,
 			NtripPass:            "somepass",

--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk_test.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk_test.go
@@ -20,7 +20,7 @@ const (
 	testRoverName   = "testRover"
 	testStationName = "testStation"
 	testI2cBus      = "1"
-	testi2cAddr     = 44
+	testI2cAddr     = 44
 )
 
 func TestValidateRTK(t *testing.T) {
@@ -32,7 +32,7 @@ func TestValidateRTK(t *testing.T) {
 		NtripUser:            "someuser",
 		NtripMountpoint:      "NYC",
 		I2CBus:               testI2cBus,
-		I2CAddr:              testi2cAddr,
+		I2CAddr:              testI2cAddr,
 	}
 	t.Run("valid config", func(t *testing.T) {
 		_, err := cfg.Validate(path)
@@ -47,7 +47,7 @@ func TestValidateRTK(t *testing.T) {
 			NtripUser:            "someuser",
 			NtripMountpoint:      "NYC",
 			I2CBus:               testI2cBus,
-			I2CAddr:              testi2cAddr,
+			I2CAddr:              testI2cAddr,
 		}
 		_, err := cfg.Validate(path)
 		test.That(t, err, test.ShouldBeError,
@@ -62,7 +62,7 @@ func TestValidateRTK(t *testing.T) {
 			NtripPass:            "somepass",
 			NtripUser:            "someuser",
 			NtripMountpoint:      "NYC",
-			I2CAddr:              testi2cAddr,
+			I2CAddr:              testI2cAddr,
 		}
 		_, err := cfg.Validate(path)
 		test.That(t, err, test.ShouldBeError,
@@ -196,7 +196,7 @@ func TestReconfigure(t *testing.T) {
 			NtripUser:            "someuser",
 			NtripMountpoint:      "NYC",
 			I2CBus:               testI2cBus,
-			I2CAddr:              testi2cAddr,
+			I2CAddr:              testI2cAddr,
 			I2CBaudRate:          115200,
 		},
 	}

--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk_test.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk_test.go
@@ -190,7 +190,7 @@ func TestReconfigure(t *testing.T) {
 		wbaud:   9600,
 		addr:    byte(66),
 		mockI2c: &mockI2c,
-		logger: logging.NewTestLogger(t),
+		logger:  logging.NewTestLogger(t),
 	}
 	conf := resource.Config{
 		Name: "reconfig1",

--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk_test.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk_test.go
@@ -19,7 +19,7 @@ import (
 const (
 	testRoverName   = "testRover"
 	testStationName = "testStation"
-	testBusNumber   = 1
+	testI2cBus      = "1"
 	testi2cAddr     = 44
 )
 
@@ -31,7 +31,7 @@ func TestValidateRTK(t *testing.T) {
 		NtripPass:            "somepass",
 		NtripUser:            "someuser",
 		NtripMountpoint:      "NYC",
-		I2CBus:               testBusNumber,
+		I2CBus:               testI2cBus,
 		I2CAddr:              testi2cAddr,
 	}
 	t.Run("valid config", func(t *testing.T) {
@@ -46,7 +46,7 @@ func TestValidateRTK(t *testing.T) {
 			NtripPass:            "somepass",
 			NtripUser:            "someuser",
 			NtripMountpoint:      "NYC",
-			I2CBus:               testBusNumber,
+			I2CBus:               testI2cBus,
 			I2CAddr:              testi2cAddr,
 		}
 		_, err := cfg.Validate(path)
@@ -77,7 +77,7 @@ func TestValidateRTK(t *testing.T) {
 			NtripPass:            "somepass",
 			NtripUser:            "someuser",
 			NtripMountpoint:      "NYC",
-			I2CBus:               testBusNumber,
+			I2CBus:               testI2cBus,
 		}
 		_, err := cfg.Validate(path)
 		test.That(t, err, test.ShouldBeError,
@@ -195,7 +195,7 @@ func TestReconfigure(t *testing.T) {
 			NtripPass:            "somepass",
 			NtripUser:            "someuser",
 			NtripMountpoint:      "NYC",
-			I2CBus:               testBusNumber,
+			I2CBus:               testI2cBus,
 			I2CAddr:              testi2cAddr,
 			I2CBaudRate:          115200,
 		},

--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk_test.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk_test.go
@@ -28,7 +28,7 @@ const (
 func TestValidateRTK(t *testing.T) {
 	path := "path"
 	cfg := Config{
-		NtripURL:             "http//fakeurl",
+		NtripURL:             "http://fakeurl",
 		NtripConnectAttempts: 10,
 		NtripPass:            "somepass",
 		NtripUser:            "someuser",
@@ -59,7 +59,7 @@ func TestValidateRTK(t *testing.T) {
 	t.Run("invalid i2c bus", func(t *testing.T) {
 		cfg := Config{
 			I2CBus:               "",
-			NtripURL:             "http//fakeurl",
+			NtripURL:             "http://fakeurl",
 			NtripConnectAttempts: 10,
 			NtripPass:            "somepass",
 			NtripUser:            "someuser",
@@ -74,7 +74,7 @@ func TestValidateRTK(t *testing.T) {
 	t.Run("invalid i2c addr", func(t *testing.T) {
 		cfg := Config{
 			I2CAddr:              0,
-			NtripURL:             "http//fakeurl",
+			NtripURL:             "http://fakeurl",
 			NtripConnectAttempts: 10,
 			NtripPass:            "somepass",
 			NtripUser:            "someuser",
@@ -195,7 +195,7 @@ func TestReconfigure(t *testing.T) {
 	conf := resource.Config{
 		Name: "reconfig1",
 		ConvertedAttributes: &Config{
-			NtripURL:             "http//fakeurl",
+			NtripURL:             "http://fakeurl",
 			NtripConnectAttempts: 10,
 			NtripPass:            "somepass",
 			NtripUser:            "someuser",

--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk_test.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk_test.go
@@ -190,6 +190,7 @@ func TestReconfigure(t *testing.T) {
 		wbaud:   9600,
 		addr:    byte(66),
 		mockI2c: &mockI2c,
+		logger: logging.NewTestLogger(t),
 	}
 	conf := resource.Config{
 		Name: "reconfig1",
@@ -205,7 +206,7 @@ func TestReconfigure(t *testing.T) {
 		},
 	}
 	err := g.Reconfigure(context.Background(), nil, conf)
-	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldBeNil)
 	test.That(t, g.wbaud, test.ShouldEqual, 115200)
 	test.That(t, g.addr, test.ShouldEqual, byte(44))
 }

--- a/components/movementsensor/rtkutils/ntrip.go
+++ b/components/movementsensor/rtkutils/ntrip.go
@@ -52,7 +52,6 @@ func NewNtripInfo(cfg *NtripConfig, logger logging.Logger) (*NtripInfo, error) {
 	}
 	n.MaxConnectAttempts = cfg.NtripConnectAttempts
 	if n.MaxConnectAttempts == 10 {
-		fmt.Printf("n is ->%v<-, cfg is ->%v<-, connect attempts is %v\n",n, cfg, cfg.NtripConnectAttempts)
 		logger.Info("ntrip_connect_attempts using default 10")
 	}
 

--- a/components/movementsensor/rtkutils/ntrip.go
+++ b/components/movementsensor/rtkutils/ntrip.go
@@ -52,6 +52,7 @@ func NewNtripInfo(cfg *NtripConfig, logger logging.Logger) (*NtripInfo, error) {
 	}
 	n.MaxConnectAttempts = cfg.NtripConnectAttempts
 	if n.MaxConnectAttempts == 10 {
+		fmt.Printf("n is ->%v<-, cfg is ->%v<-, connect attempts is %v\n",n, cfg, cfg.NtripConnectAttempts)
 		logger.Info("ntrip_connect_attempts using default 10")
 	}
 


### PR DESCRIPTION
The rough idea here is that, when you specify an I2C bus, you give it the bus number instead of a board name and i2c entry on that board. Then, we're not dependent on the board at all, and it's possible to use this sensor even if your board is a modular component running outside the RDK entirely.

This is a breaking change, but there are currently _no_ configs that use `gps-nmea-rtk-pmtk` components, and only 2 that use `gps-nmea` with I2C connections. Of those two, one is owned by @biotinker and he and I are already in contact about updating it, and the other was a PoC that hasn't been online since February. I'll announce the breaking change in the relevant channel anyway. 

I don't have a Mac, and worry that this change might break the build on Macs again. Susmita, could we try building this branch on your machine when it's convenient?