### PR TITLE
[DATA-2022] Allow the user to configure how long the syncer waits to upload a file since it was last modified

### DIFF
--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -366,7 +366,6 @@ func (svc *builtIn) Reconfigure(
 	if svcConfig.CaptureDir == "" {
 		svc.captureDir = viamCaptureDotDir
 	}
-	// if svcConfig.
 	svc.captureDisabled = svcConfig.CaptureDisabled
 	// Service is disabled, so close all collectors and clear the map so we can instantiate new ones if we enable this service.
 	if svc.captureDisabled {


### PR DESCRIPTION
The syncer currently only uploads a file that has not been modified in the last 10 seconds. This value is now configurable based on the needs of the user. The longer term fix is to check for open file descriptors and only close files which do not have open file processes.