### PR TITLE
[RSDK-5240] the I2C bus number should be a string, in case it's not a number

### DIFF
--- a/components/board/genericlinux/i2c.go
+++ b/components/board/genericlinux/i2c.go
@@ -158,9 +158,9 @@ func (h *I2cHandle) Close() error {
 // machine, and otherwise it tries to get the named bus from the named board.
 // TODO(RSDK-5254): remove this once all I2C devices are talking directly to the bus without going
 // through the board.
-func GetI2CBus(deps resource.Dependencies, boardName, busName string, busNum int) (board.I2C, error) {
-	if busNum != 0 {
-		return NewI2cBus(fmt.Sprintf("%d", busNum))
+func GetI2CBus(deps resource.Dependencies, boardName, busName string, busNum string) (board.I2C, error) {
+	if busNum != "" {
+		return NewI2cBus(busNum)
 	}
 
 	// Otherwise, look things up through the board.

--- a/components/board/genericlinux/i2c.go
+++ b/components/board/genericlinux/i2c.go
@@ -155,7 +155,9 @@ func (h *I2cHandle) Close() error {
 }
 
 // GetI2CBus retrieves an I2C interface. If the bus number is specified, it uses that on the local
-// machine, and otherwise it tries to get the named bus from the named board.
+// machine, and otherwise it tries to get the named bus from the named board. Although it would be
+// intuitive for the bus number to be an integer, we keep it as a string because it's possible for
+// a devicetree overlay on some unusual board to make it non-numerical.
 // TODO(RSDK-5254): remove this once all I2C devices are talking directly to the bus without going
 // through the board.
 func GetI2CBus(deps resource.Dependencies, boardName, busName string, busNum string) (board.I2C, error) {

--- a/components/board/genericlinux/i2c.go
+++ b/components/board/genericlinux/i2c.go
@@ -160,7 +160,7 @@ func (h *I2cHandle) Close() error {
 // a devicetree overlay on some unusual board to make it non-numerical.
 // TODO(RSDK-5254): remove this once all I2C devices are talking directly to the bus without going
 // through the board.
-func GetI2CBus(deps resource.Dependencies, boardName, busName string, busNum string) (board.I2C, error) {
+func GetI2CBus(deps resource.Dependencies, boardName, busName, busNum string) (board.I2C, error) {
 	if busNum != "" {
 		return NewI2cBus(busNum)
 	}

--- a/components/board/hat/pca9685/pca9685.go
+++ b/components/board/hat/pca9685/pca9685.go
@@ -33,7 +33,7 @@ var (
 type Config struct {
 	BoardName  string `json:"board_name,omitempty"`
 	I2CName    string `json:"i2c_name,omitempty"`
-	I2CBus     *int   `json:"i2c_bus,omitempty"`
+	I2CBus     string `json:"i2c_bus,omitempty"`
 	I2CAddress *int   `json:"i2c_address,omitempty"`
 }
 
@@ -41,7 +41,7 @@ type Config struct {
 func (conf *Config) Validate(path string) ([]string, error) {
 	var deps []string
 	// Either the i2c bus or both the board name and i2c name is required.
-	if conf.I2CBus == nil {
+	if conf.I2CBus == "" {
 		if conf.BoardName == "" && conf.I2CName == "" {
 			// If all 3 are missing, prefer the i2c_bus approach.
 			return nil, utils.NewConfigValidationFieldRequiredError(path, "i2c_bus")
@@ -139,10 +139,7 @@ func (pca *PCA9685) Reconfigure(ctx context.Context, deps resource.Dependencies,
 		return err
 	}
 
-	busNum := 0
-	if newConf.I2CBus != nil {
-		busNum = *newConf.I2CBus
-	}
+	busNum := newConf.I2CBus
 
 	bus, err := genericlinux.GetI2CBus(deps, newConf.BoardName, newConf.I2CName, busNum)
 	if err != nil {

--- a/components/board/hat/pca9685/pca9685.go
+++ b/components/board/hat/pca9685/pca9685.go
@@ -139,9 +139,7 @@ func (pca *PCA9685) Reconfigure(ctx context.Context, deps resource.Dependencies,
 		return err
 	}
 
-	busNum := newConf.I2CBus
-
-	bus, err := genericlinux.GetI2CBus(deps, newConf.BoardName, newConf.I2CName, busNum)
+	bus, err := genericlinux.GetI2CBus(deps, newConf.BoardName, newConf.I2CName, newConf.I2CBus)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Thanks to @biotinker for pointing out that devicetree overlays might let you name your I2C bus something non-numerical! I'll update the scope doc to match, and here's a PR to update the one component I've migrated so far. 