### PR TITLE
RSDK-5368 Add more safety and inline docs about logical clocks in resource graph

### DIFF
--- a/resource/graph_node.go
+++ b/resource/graph_node.go
@@ -24,7 +24,8 @@ type GraphNode struct {
 	// incremented every time any GraphNode calls SwapResource.
 	graphLogicalClock *atomic.Int64
 	// updatedAt is the value of the graphLogicalClock when it was last
-	// incremented by this GraphNode's SwapResource method.
+	// incremented by this GraphNode's SwapResource method. It is only referenced
+	// in tests.
 	updatedAt int64
 
 	current                   Resource
@@ -68,7 +69,8 @@ func NewConfiguredGraphNode(config Config, res Resource, resModel Model) *GraphN
 }
 
 // UpdatedAt returns the value of the logical clock when SwapResource was last
-// called on this GraphNode (the resource was last updated).
+// called on this GraphNode (the resource was last updated). It's only used
+// for tests.
 func (w *GraphNode) UpdatedAt() int64 {
 	w.mu.RLock()
 	defer w.mu.RUnlock()

--- a/resource/graph_node.go
+++ b/resource/graph_node.go
@@ -15,11 +15,18 @@ import (
 // updated or eventually removed. During its life, errors may be set on the
 // node to indicate that the resource is no longer available to external users.
 type GraphNode struct {
-	// all fields are protected by this mutex right now, including
-	// the pointer to the atomic int.
-	mu                        sync.RWMutex
-	updatedAt                 int64
-	clock                     *atomic.Int64
+	timesReconfigured atomic.Uint64
+
+	// mu guards all fields below.
+	mu sync.RWMutex
+
+	// graphLogicalClock is a pointer to the Graph's logicalClock. It is
+	// incremented every time any GraphNode calls SwapResource.
+	graphLogicalClock *atomic.Int64
+	// updatedAt is the value of the graphLogicalClock when it was last
+	// incremented by this GraphNode's SwapResource method.
+	updatedAt int64
+
 	current                   Resource
 	currentModel              Model
 	config                    Config
@@ -28,7 +35,6 @@ type GraphNode struct {
 	markedForRemoval          bool
 	unresolvedDependencies    []string
 	needsDependencyResolution bool
-	timesReconfigured         atomic.Uint64
 }
 
 var (
@@ -61,13 +67,18 @@ func NewConfiguredGraphNode(config Config, res Resource, resModel Model) *GraphN
 	return node
 }
 
-// UpdatedAt returns the logical time this node was added at.
+// UpdatedAt returns the value of the logical clock when SwapResource was last
+// called on this GraphNode (the resource was last updated).
 func (w *GraphNode) UpdatedAt() int64 {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
 	return w.updatedAt
 }
 
-func (w *GraphNode) setClock(clock *atomic.Int64) {
-	w.clock = clock
+func (w *GraphNode) setGraphLogicalClock(clock *atomic.Int64) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.graphLogicalClock = clock
 }
 
 // Resource returns the underlying resource if it is not pending removal,
@@ -133,7 +144,9 @@ func (w *GraphNode) UnsetResource() {
 // SwapResource emplaces the new resource. It may be the same as before
 // and expects the caller to close the old one. This is considered
 // to be a working resource and as such we unmark it for removal
-// and indicate it no longer needs reconfiguration.
+// and indicate it no longer needs reconfiguration. SwapResource also
+// increments the graphLogicalClock and sets updatedAt for this GraphNode
+// to the new value.
 func (w *GraphNode) SwapResource(newRes Resource, newModel Model) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -147,8 +160,8 @@ func (w *GraphNode) SwapResource(newRes Resource, newModel Model) {
 	// these should already be set
 	w.unresolvedDependencies = nil
 	w.needsDependencyResolution = false
-	if w.clock != nil {
-		w.updatedAt = w.clock.Add(1)
+	if w.graphLogicalClock != nil {
+		w.updatedAt = w.graphLogicalClock.Add(1)
 	}
 }
 
@@ -327,8 +340,8 @@ func (w *GraphNode) replace(other *GraphNode) error {
 
 	other.mu.Lock()
 	w.updatedAt = other.updatedAt
-	if other.clock != nil {
-		w.clock = other.clock
+	if other.graphLogicalClock != nil {
+		w.graphLogicalClock = other.graphLogicalClock
 	}
 	w.current = other.current
 	w.currentModel = other.currentModel
@@ -341,7 +354,7 @@ func (w *GraphNode) replace(other *GraphNode) error {
 
 	// other is now owned by the graph/node and is invalidated
 	other.updatedAt = 0
-	other.clock = nil
+	other.graphLogicalClock = nil
 	other.current = nil
 	other.currentModel = Model{}
 	other.config = Config{}

--- a/resource/resource_graph.go
+++ b/resource/resource_graph.go
@@ -40,8 +40,7 @@ func NewGraph() *Graph {
 	}
 }
 
-// LogicalClock returns the last logical clock value at which a resource
-// updated.
+// LogicalClock returns the logical clock value.
 func (g *Graph) LogicalClock() int64 {
 	return g.logicalClock.Load()
 }

--- a/resource/resource_graph.go
+++ b/resource/resource_graph.go
@@ -23,7 +23,10 @@ type Graph struct {
 	children                resourceDependencies
 	parents                 resourceDependencies
 	transitiveClosureMatrix transitiveClosureMatrix
-	logicalClock            *atomic.Int64
+	// logicalClock keeps track of updates to the graph. Each GraphNode has a
+	// pointer to this logicalClock. Whenever SwapResource is called on a node
+	// (the resource updates), the logicalClock is incremented.
+	logicalClock *atomic.Int64
 }
 
 // NewGraph creates a new resource graph.
@@ -37,8 +40,9 @@ func NewGraph() *Graph {
 	}
 }
 
-// LastUpdatedTime returns the last logical clock time a resource updated.
-func (g *Graph) LastUpdatedTime() int64 {
+// LogicalClock returns the last logical clock value at which a resource
+// updated.
+func (g *Graph) LogicalClock() int64 {
 	return g.logicalClock.Load()
 }
 
@@ -273,7 +277,7 @@ func (g *Graph) addNode(node Name, nodeVal *GraphNode) error {
 		}
 		return val.replace(nodeVal)
 	}
-	nodeVal.setClock(g.logicalClock)
+	nodeVal.setGraphLogicalClock(g.logicalClock)
 	g.nodes[node] = nodeVal
 
 	if _, ok := g.transitiveClosureMatrix[node]; !ok {

--- a/resource/resource_graph.go
+++ b/resource/resource_graph.go
@@ -40,8 +40,8 @@ func NewGraph() *Graph {
 	}
 }
 
-// LogicalClock returns the logical clock value.
-func (g *Graph) LogicalClock() int64 {
+// CurrLogicalClockValue returns current the logical clock value.
+func (g *Graph) CurrLogicalClockValue() int64 {
 	return g.logicalClock.Load()
 }
 

--- a/resource/resource_graph_test.go
+++ b/resource/resource_graph_test.go
@@ -922,7 +922,7 @@ func TestResourceGraphMarkForRemoval(t *testing.T) {
 func TestResourceGraphClock(t *testing.T) {
 	g := NewGraph()
 
-	test.That(t, g.LogicalClock(), test.ShouldEqual, 0)
+	test.That(t, g.CurrLogicalClockValue(), test.ShouldEqual, 0)
 
 	name1 := NewName(apiA, "a")
 	name2 := NewName(apiA, "b")
@@ -940,17 +940,17 @@ func TestResourceGraphClock(t *testing.T) {
 
 	res1 := &someResource{Named: name1.AsNamed()}
 	node1.SwapResource(res1, DefaultModelFamily.WithModel("foo"))
-	test.That(t, g.LogicalClock(), test.ShouldEqual, 1)
+	test.That(t, g.CurrLogicalClockValue(), test.ShouldEqual, 1)
 	test.That(t, node1.UpdatedAt(), test.ShouldEqual, 1)
 	test.That(t, node2.UpdatedAt(), test.ShouldEqual, 0)
 	node1.SwapResource(res1, DefaultModelFamily.WithModel("foo"))
-	test.That(t, g.LogicalClock(), test.ShouldEqual, 2)
+	test.That(t, g.CurrLogicalClockValue(), test.ShouldEqual, 2)
 	test.That(t, node1.UpdatedAt(), test.ShouldEqual, 2)
 
 	node2 = &GraphNode{}
 	test.That(t, g.AddNode(name2, node2), test.ShouldBeNil)
 	node2.SwapResource(res1, DefaultModelFamily.WithModel("foo"))
-	test.That(t, g.LogicalClock(), test.ShouldEqual, 3)
+	test.That(t, g.CurrLogicalClockValue(), test.ShouldEqual, 3)
 	test.That(t, node1.UpdatedAt(), test.ShouldEqual, 2)
 	test.That(t, node2.UpdatedAt(), test.ShouldEqual, 3)
 }

--- a/resource/resource_graph_test.go
+++ b/resource/resource_graph_test.go
@@ -922,7 +922,7 @@ func TestResourceGraphMarkForRemoval(t *testing.T) {
 func TestResourceGraphClock(t *testing.T) {
 	g := NewGraph()
 
-	test.That(t, g.LastUpdatedTime(), test.ShouldEqual, 0)
+	test.That(t, g.LogicalClock(), test.ShouldEqual, 0)
 
 	name1 := NewName(apiA, "a")
 	name2 := NewName(apiA, "b")
@@ -940,17 +940,17 @@ func TestResourceGraphClock(t *testing.T) {
 
 	res1 := &someResource{Named: name1.AsNamed()}
 	node1.SwapResource(res1, DefaultModelFamily.WithModel("foo"))
-	test.That(t, g.LastUpdatedTime(), test.ShouldEqual, 1)
+	test.That(t, g.LogicalClock(), test.ShouldEqual, 1)
 	test.That(t, node1.UpdatedAt(), test.ShouldEqual, 1)
 	test.That(t, node2.UpdatedAt(), test.ShouldEqual, 0)
 	node1.SwapResource(res1, DefaultModelFamily.WithModel("foo"))
-	test.That(t, g.LastUpdatedTime(), test.ShouldEqual, 2)
+	test.That(t, g.LogicalClock(), test.ShouldEqual, 2)
 	test.That(t, node1.UpdatedAt(), test.ShouldEqual, 2)
 
 	node2 = &GraphNode{}
 	test.That(t, g.AddNode(name2, node2), test.ShouldBeNil)
 	node2.SwapResource(res1, DefaultModelFamily.WithModel("foo"))
-	test.That(t, g.LastUpdatedTime(), test.ShouldEqual, 3)
+	test.That(t, g.LogicalClock(), test.ShouldEqual, 3)
 	test.That(t, node1.UpdatedAt(), test.ShouldEqual, 2)
 	test.That(t, node2.UpdatedAt(), test.ShouldEqual, 3)
 }

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -524,7 +524,16 @@ func (r *localRobot) getDependencies(
 		return nil, errors.Errorf("resource has unresolved dependencies: %v", deps)
 	}
 	allDeps := make(resource.Dependencies)
+	var needUpdate bool
 	for _, dep := range r.manager.resources.GetAllParentsOf(rName) {
+		// If any of the dependencies of this resource has an updatedAt value that
+		// is "later" than the last value at which we ran updateWeakDependents,
+		// ensure that we run updateWeakDependents later in this method.
+		if node, ok := r.manager.resources.Node(dep); ok {
+			if r.lastWeakDependentsRound.Load() <= node.UpdatedAt() {
+				needUpdate = true
+			}
+		}
 		// Specifically call ResourceByName and not directly to the manager since this
 		// will only return fully configured and available resources (not marked for removal
 		// and no last error).
@@ -542,8 +551,10 @@ func (r *localRobot) getDependencies(
 		allDeps[weakDepName] = weakDepRes
 	}
 
-	// Try updating weak dependents after any resource gets its dependencies.
-	r.updateWeakDependents(ctx)
+	if needUpdate {
+		r.updateWeakDependents(ctx)
+	}
+
 	return allDeps, nil
 }
 
@@ -649,11 +660,9 @@ func (r *localRobot) newResource(
 }
 
 func (r *localRobot) updateWeakDependents(ctx context.Context) {
-	// Only run updateWeakDependents when the resource graph's logical clock is
-	// now "later" than the value was when we last ran updateWeakDependents.
-	if r.lastWeakDependentsRound.Load() >= r.manager.resources.CurrLogicalClockValue() {
-		return
-	}
+	// Track the current value of the resource graph's logical clock. This will
+	// later be used to determine if updateWeakDependents should be called during
+	// getDependencies.
 	r.lastWeakDependentsRound.Store(r.manager.resources.CurrLogicalClockValue())
 
 	allResources := map[resource.Name]resource.Resource{}

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -524,17 +524,7 @@ func (r *localRobot) getDependencies(
 		return nil, errors.Errorf("resource has unresolved dependencies: %v", deps)
 	}
 	allDeps := make(resource.Dependencies)
-	var needUpdate bool
 	for _, dep := range r.manager.resources.GetAllParentsOf(rName) {
-		if node, ok := r.manager.resources.Node(dep); ok {
-			// If any of the parents of the resource we're getting dependencies for
-			// has an updatedAt value that is "later" than the last value at which we
-			// ran updateWeakDependents, ensure that we run updateWeakDependents
-			// later in this method.
-			if r.lastWeakDependentsRound.Load() <= node.UpdatedAt() {
-				needUpdate = true
-			}
-		}
 		// Specifically call ResourceByName and not directly to the manager since this
 		// will only return fully configured and available resources (not marked for removal
 		// and no last error).
@@ -552,10 +542,8 @@ func (r *localRobot) getDependencies(
 		allDeps[weakDepName] = weakDepRes
 	}
 
-	if needUpdate {
-		r.updateWeakDependents(ctx)
-	}
-
+	// Try updating weak dependents after any resource gets its dependencies.
+	r.updateWeakDependents(ctx)
 	return allDeps, nil
 }
 
@@ -661,10 +649,12 @@ func (r *localRobot) newResource(
 }
 
 func (r *localRobot) updateWeakDependents(ctx context.Context) {
-	// Track the current value of the resource graph's logical clock. This will
-	// later be used to determine if updateWeakDependents should be called during
-	// getDependencies.
-	r.lastWeakDependentsRound.Store(r.manager.resources.LogicalClock())
+	// Only run updateWeakDependents when the resource graph's logical clock is
+	// now "later" than the value was when we last ran updateWeakDependents.
+	if r.lastWeakDependentsRound.Load() >= r.manager.resources.CurrLogicalClockValue() {
+		return
+	}
+	r.lastWeakDependentsRound.Store(r.manager.resources.CurrLogicalClockValue())
 
 	allResources := map[resource.Name]resource.Resource{}
 	internalResources := map[resource.Name]resource.Resource{}


### PR DESCRIPTION
RSDK-5368

The “logical clock” logic shared between local robot, the resource graph and graph nodes represents a somewhat complex system used to determine when `updateWeakDependents` should be run in the local robot. There is both a lack of comments explaining this logic and some inaccurate statements in the existing comments and inline documentation. This PR adds more comments, attempts to fix the inaccuracies, and adds a couple "missing" locks.