### PR TITLE
[DATA-2060] Move corrupted data capture files into a separate directory

### DIFF
--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -107,8 +107,10 @@ type builtIn struct {
 	corruptedFilesDir string
 }
 
-var viamCaptureDotDir = filepath.Join(os.Getenv("HOME"), ".viam", "capture")
-var viamCorruptedDotDir = filepath.Join(os.Getenv("HOME"), ".viam", "corrupted_capture")
+var (
+	viamCaptureDotDir   = filepath.Join(os.Getenv("HOME"), ".viam", "capture")
+	viamCorruptedDotDir = filepath.Join(os.Getenv("HOME"), ".viam", "corrupted_capture")
+)
 
 // NewBuiltIn returns a new data manager service for the given robot.
 func NewBuiltIn(

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -505,7 +505,7 @@ func (svc *builtIn) sync() {
 	}
 }
 
-// nolint
+//nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -505,7 +505,7 @@ func (svc *builtIn) sync() {
 	}
 }
 
-//nolint
+// nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
@@ -513,7 +513,7 @@ func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 			return nil
 		}
 		// Do not sync the files in the corrupted data directory.
-		if info.IsDir() && info.Name() == datasync.CorruptedDir {
+		if info.IsDir() && info.Name() == datasync.FailedDir {
 			return filepath.SkipDir
 		}
 		if info.IsDir() {

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -514,6 +514,7 @@ func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 		if err != nil {
 			return nil
 		}
+		// Do not sync the files in the corrupted data directory.
 		if info.IsDir() && info.Name() == datasync.CorruptedDir {
 			return filepath.SkipDir
 		}

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -105,9 +105,7 @@ type builtIn struct {
 	syncTicker          *clk.Ticker
 }
 
-var (
-	viamCaptureDotDir = filepath.Join(os.Getenv("HOME"), ".viam", "capture")
-)
+var viamCaptureDotDir = filepath.Join(os.Getenv("HOME"), ".viam", "capture")
 
 // NewBuiltIn returns a new data manager service for the given robot.
 func NewBuiltIn(

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -514,6 +514,9 @@ func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 		if err != nil {
 			return nil
 		}
+		if info.IsDir() && info.Name() == datasync.CorruptedDir {
+			return filepath.SkipDir
+		}
 		if info.IsDir() {
 			return nil
 		}
@@ -527,10 +530,6 @@ func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 		}
 		if timeSinceMod >= (time.Duration(lastModifiedMillis)*time.Millisecond) || filepath.Ext(path) == datacapture.FileExt {
 			filePaths = append(filePaths, path)
-		}
-		if info.IsDir() && info.Name() == datasync.CorruptedDir {
-			fmt.Printf("skipping a dir without errors: %+v \n", info.Name())
-			return filepath.SkipDir
 		}
 		return nil
 	})

--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -890,8 +890,8 @@ func (m *mockStreamingDCClient) CloseSend() error {
 }
 
 func getTestSyncerConstructorMock(client mockDataSyncServiceClient) datasync.ManagerConstructor {
-	return func(identity string, _ v1.DataSyncServiceClient, logger golog.Logger, corruptedFilesDir string) (datasync.Manager, error) {
-		return datasync.NewManager(identity, client, logger, corruptedFilesDir)
+	return func(identity string, _ v1.DataSyncServiceClient, logger golog.Logger, viamCaptureDotDir string) (datasync.Manager, error) {
+		return datasync.NewManager(identity, client, logger, viamCaptureDotDir)
 	}
 }
 

--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -890,8 +890,8 @@ func (m *mockStreamingDCClient) CloseSend() error {
 }
 
 func getTestSyncerConstructorMock(client mockDataSyncServiceClient) datasync.ManagerConstructor {
-	return func(identity string, _ v1.DataSyncServiceClient, logger golog.Logger) (datasync.Manager, error) {
-		return datasync.NewManager(identity, client, logger)
+	return func(identity string, _ v1.DataSyncServiceClient, logger golog.Logger, corruptedFilesDir string) (datasync.Manager, error) {
+		return datasync.NewManager(identity, client, logger, corruptedFilesDir)
 	}
 }
 

--- a/services/datamanager/datacapture/data_capture_buffer_test.go
+++ b/services/datamanager/datacapture/data_capture_buffer_test.go
@@ -119,7 +119,7 @@ func TestCaptureQueue(t *testing.T) {
 	}
 }
 
-//nolint
+// nolint
 func getCaptureFiles(dir string) (dcFiles, progFiles []string) {
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {

--- a/services/datamanager/datacapture/data_capture_buffer_test.go
+++ b/services/datamanager/datacapture/data_capture_buffer_test.go
@@ -119,7 +119,7 @@ func TestCaptureQueue(t *testing.T) {
 	}
 }
 
-// nolint
+//nolint
 func getCaptureFiles(dir string) (dcFiles, progFiles []string) {
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -29,6 +29,7 @@ var (
 	maxRetryInterval       = time.Hour
 )
 
+// CorruptedDir is a subdirectory of the capture directory that holds any files that could not be synced.
 const CorruptedDir = "corrupted"
 
 // Manager is responsible for enqueuing files in captureDir and uploading them to the cloud.
@@ -276,7 +277,7 @@ func exponentialRetry(cancelCtx context.Context, fn func(cancelCtx context.Conte
 }
 
 // isRetryableGRPCError returns true if we should retry syncing and otherwise
-// returns false so that the data gets moved to the corrupted data directory
+// returns false so that the data gets moved to the corrupted data directory.
 func isRetryableGRPCError(err error) bool {
 	errStatus := status.Convert(err)
 	return errStatus.Code() != codes.InvalidArgument
@@ -291,7 +292,7 @@ func moveCorruptedData(path, captureDir string) error {
 	}
 	newDir := filepath.Join(captureDir, CorruptedDir, filepath.Dir(relativePath))
 	if err := os.MkdirAll(newDir, 0o700); err != nil {
-		errors.Wrap(err, "error making new directory for corrupted data")
+		return errors.Wrap(err, "error making new directory for corrupted data")
 	}
 	newPath := filepath.Join(newDir, filepath.Base(path))
 	if err := os.Rename(path, newPath); err != nil {

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -29,9 +29,7 @@ var (
 	maxRetryInterval       = time.Hour
 )
 
-const (
-	CorruptedDir = "corrupted"
-)
+const CorruptedDir = "corrupted"
 
 // Manager is responsible for enqueuing files in captureDir and uploading them to the cloud.
 type Manager interface {
@@ -79,9 +77,6 @@ func NewManager(
 		inProgress:        make(map[string]bool),
 		syncErrs:          make(chan error, 10),
 		captureDir:        captureDir,
-	}
-	if err := os.MkdirAll(filepath.Join(captureDir, CorruptedDir), 0o700); err != nil {
-		return nil, err
 	}
 	ret.logRoutine.Add(1)
 	goutils.PanicCapturingGo(func() {
@@ -290,10 +285,11 @@ func moveCorruptedData(path, captureDir string) error {
 	if err != nil {
 		return errors.Wrap(err, "error getting relative path of corrupted data")
 	}
-	newPath := filepath.Join(captureDir, CorruptedDir, relativePath)
-	if err := os.MkdirAll(newPath, 0o700); err != nil {
+	newDir := filepath.Join(captureDir, CorruptedDir, filepath.Dir(relativePath))
+	if err := os.MkdirAll(newDir, 0o700); err != nil {
 		errors.Wrap(err, "error making new directory for corrupted data")
 	}
+	newPath := filepath.Join(newDir, filepath.Base(path))
 	if err := os.Rename(path, newPath); err != nil {
 		return errors.Wrap(err, "error moving corrupted data capture to new directory")
 	}

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -275,11 +275,15 @@ func exponentialRetry(cancelCtx context.Context, fn func(cancelCtx context.Conte
 	}
 }
 
+// isRetryableGRPCError returns true if we should retry syncing and otherwise
+// returns false so that the data gets moved to the corrupted data directory
 func isRetryableGRPCError(err error) bool {
 	errStatus := status.Convert(err)
 	return errStatus.Code() != codes.InvalidArgument
 }
 
+// moveCorruptedData takes any corrupted data in the captureDir and moves it
+// to a new subdirectory "corrupted" that will not be synced.
 func moveCorruptedData(path, captureDir string) error {
 	relativePath, err := filepath.Rel(captureDir, path)
 	if err != nil {

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -286,14 +286,17 @@ func isRetryableGRPCError(err error) bool {
 // moveCorruptedData takes any corrupted data in the captureDir and moves it
 // to a new subdirectory "corrupted" that will not be synced.
 func moveCorruptedData(path, captureDir string) error {
+	// Remove the captureDir part of the path to the corrupted data
 	relativePath, err := filepath.Rel(captureDir, path)
 	if err != nil {
 		return errors.Wrap(err, "error getting relative path of corrupted data")
 	}
+	// Create a new directory captureDir/corrupted/pathToFile
 	newDir := filepath.Join(captureDir, CorruptedDir, filepath.Dir(relativePath))
 	if err := os.MkdirAll(newDir, 0o700); err != nil {
 		return errors.Wrap(err, "error making new directory for corrupted data")
 	}
+	// Move the file from captureDir/pathToFile/file.ext to captureDir/corrupted/pathToFile/file.ext
 	newPath := filepath.Join(newDir, filepath.Base(path))
 	if err := os.Rename(path, newPath); err != nil {
 		return errors.Wrap(err, "error moving corrupted data capture to new directory")

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -57,11 +57,13 @@ type syncer struct {
 }
 
 // ManagerConstructor is a function for building a Manager.
-type ManagerConstructor func(identity string, client v1.DataSyncServiceClient, logger golog.Logger, corruptedFilesDir string) (Manager, error)
+type ManagerConstructor func(
+	identity string, client v1.DataSyncServiceClient, logger golog.Logger, corruptedFilesDir string) (Manager, error)
 
 // NewManager returns a new syncer.
 func NewManager(
-	identity string, client v1.DataSyncServiceClient, logger golog.Logger, corruptedFilesDir string) (Manager, error) {
+	identity string, client v1.DataSyncServiceClient, logger golog.Logger, corruptedFilesDir string,
+) (Manager, error) {
 	cancelCtx, cancelFunc := context.WithCancel(context.Background())
 	ret := syncer{
 		partID:            identity,


### PR DESCRIPTION
We already correctly don't retry upload (until the syncer is restarted, e.g. if the robot restarts or you change a sync configuration) if we get an app server error of `InvalidArgument`. This PR still logs here but also moves the files into a failed directory so that they're not retried even if the syncer/robot is restarted. 

**Testing**
Tested on a fake `.prog` file which failed to read the DataCaptureMetadata.

More testing by (@tahiyasalam)
Tested on many fake `.prog` files that were just text.
Tested on many data capture files with no metadata by returning nil [here](https://github.com/viamrobotics/rdk/blob/c0472a4fe60c8a200706912e45fc43aa2a64b967/services/datamanager/datacapture/data_capture_file.go#L109), with the robot [here](https://app.viam.dev/robot?id=095152bb-cc3e-4eec-bbee-9d5755629640&tab=config%2Cservices) using RDK locally.
In all of these scenarios, the files were written to the `corrupted` data directory and not synced. 
