### PR TITLE
[DATA-2064] Replace reserved characters in the filename in addition to the file directory

### DIFF
--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"strings"
 	"sync"
 	"time"
 
@@ -62,10 +61,6 @@ const defaultCaptureQueueSize = 250
 
 // Default bufio.Writer buffer size in bytes.
 const defaultCaptureBufferSize = 4096
-
-// Non-exhaustive list of characters to strip from file paths, since not allowed
-// on at least Windows and Darwin.
-const filePathReservedChars = ":"
 
 var clock = clk.New()
 
@@ -255,9 +250,9 @@ func (svc *builtIn) initializeOrUpdateCollector(
 	}
 
 	// Create a collector for this resource and method.
-	targetDir := filepath.Join(svc.captureDir, captureMetadata.GetComponentType(), captureMetadata.GetComponentName(),
-		captureMetadata.GetMethodName())
-	targetDir = strings.ReplaceAll(targetDir, filePathReservedChars, "_")
+	targetDir := datacapture.FilePathWithReplacedReservedChars(
+		filepath.Join(svc.captureDir, captureMetadata.GetComponentType(), captureMetadata.GetComponentName(),
+			captureMetadata.GetMethodName()))
 	if err := os.MkdirAll(targetDir, 0o700); err != nil {
 		return nil, err
 	}

--- a/services/datamanager/datacapture/data_capture_file.go
+++ b/services/datamanager/datacapture/data_capture_file.go
@@ -321,8 +321,8 @@ func SensorDataFromFile(f *File) ([]*v1.SensorData, error) {
 // FilePathWithReplacedReservedChars returns the filepath with substitutions
 // for reserved characters if running on Windows or Darwin.
 func FilePathWithReplacedReservedChars(filepath string) string {
-	goOS := runtime.GOOS
-	if goOS == "windows" || goOS == "darwin" {
+	runtimeOS := runtime.GOOS
+	if runtimeOS == "windows" || runtimeOS == "darwin" {
 		return strings.ReplaceAll(filepath, windowsDarwinReservedChars, "_")
 	}
 	return filepath

--- a/services/datamanager/datacapture/data_capture_file.go
+++ b/services/datamanager/datacapture/data_capture_file.go
@@ -318,6 +318,8 @@ func SensorDataFromFile(f *File) ([]*v1.SensorData, error) {
 	return ret, nil
 }
 
+// FilePathwithReplacedReservedChars returns the filepath with substitutions
+// for reserved characters if running on Windows or Darwin.
 func FilePathWithReplacedReservedChars(filepath string) string {
 	goOS := runtime.GOOS
 	if goOS == "windows" || goOS == "darwin" {

--- a/services/datamanager/datacapture/data_capture_file.go
+++ b/services/datamanager/datacapture/data_capture_file.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -31,6 +32,9 @@ const (
 	GetImages      = "GetImages"
 	nextPointCloud = "NextPointCloud"
 	pointCloudMap  = "PointCloudMap"
+	// Non-exhaustive list of characters to strip from file paths, since not allowed
+	// on at least Windows and Darwin.
+	windowsDarwinReservedChars = ":"
 )
 
 // File is the data structure containing data captured by collectors. It is backed by a file on disk containing
@@ -81,7 +85,8 @@ func ReadFile(f *os.File) (*File, error) {
 
 // NewFile creates a new File with the specified md in the specified directory.
 func NewFile(dir string, md *v1.DataCaptureMetadata) (*File, error) {
-	fileName := filepath.Join(dir, getFileTimestampName()) + InProgressFileExt
+	fileName := FilePathWithReplacedReservedChars(
+		filepath.Join(dir, getFileTimestampName()) + InProgressFileExt)
 	//nolint:gosec
 	f, err := os.OpenFile(fileName, os.O_APPEND|os.O_RDWR|os.O_CREATE, 0o600)
 	if err != nil {
@@ -311,4 +316,12 @@ func SensorDataFromFile(f *File) ([]*v1.SensorData, error) {
 		ret = append(ret, next)
 	}
 	return ret, nil
+}
+
+func FilePathWithReplacedReservedChars(filepath string) string {
+	goOS := runtime.GOOS
+	if goOS == "windows" || goOS == "darwin" {
+		return strings.ReplaceAll(filepath, windowsDarwinReservedChars, "_")
+	}
+	return filepath
 }

--- a/services/datamanager/datacapture/data_capture_file.go
+++ b/services/datamanager/datacapture/data_capture_file.go
@@ -318,7 +318,7 @@ func SensorDataFromFile(f *File) ([]*v1.SensorData, error) {
 	return ret, nil
 }
 
-// FilePathwithReplacedReservedChars returns the filepath with substitutions
+// FilePathWithReplacedReservedChars returns the filepath with substitutions
 // for reserved characters if running on Windows or Darwin.
 func FilePathWithReplacedReservedChars(filepath string) string {
 	goOS := runtime.GOOS


### PR DESCRIPTION
 Similar to the CLI, restrict the filepath substitutions to OS where colons are not supported — Windows and Darwin.

**Testing**
Tested locally on capture/sync. File paths have underscores (e.g. `~/.viam/capture/rdk_component_arm/fakearm/JointPositions/2023-10-16T17_37_27.47088-04_00.capture`), but the synced UploadMetadata still contains the correct type with colons (e.g. rdk:component:arm)