### PR TITLE
[RSDK-4174] Update refresh rates for cloudslam

### DIFF
--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -34,7 +34,7 @@
 
   let refreshErrorMessage2d: string | undefined;
   let refreshErrorMessage3d: string | undefined;
-  let refresh2dRate = 'manual';
+  let refresh2dRate = '5';
   let refresh3dRate = 'manual';
   let pointcloud: Uint8Array | undefined;
   let pose: Pose | undefined;
@@ -543,7 +543,9 @@
               <option value="30"> Every 30 seconds </option>
               <option value="10"> Every 10 seconds </option>
               <option value="5"> Every 5 seconds </option>
-              <option value="1"> Every second </option>
+              {#if !overrides}
+                <option value="1"> Every second </option>
+              {/if}
             </select>
             <v-icon
               name="chevron-down"

--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -543,7 +543,7 @@
               <option value="30"> Every 30 seconds </option>
               <option value="10"> Every 10 seconds </option>
               <option value="5"> Every 5 seconds </option>
-              {#if !overrides}
+              {#if !overrides?.isCloudSlam}
                 <option value="1"> Every second </option>
               {/if}
             </select>


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-4174

ticket adjusts the available refresh rates while cloudslam is in use, and additionally sets the default refresh rate to 5Hz instead of manual. The ticket was only supposed to change the refresh rate options so I can remove the default change if preferred.

tested using a local app environment with fake slam. can push the config I used if requested