### PR TITLE
Replace filepath regardless of OS in both collectors and the export CLI

### DIFF
--- a/cli/data.go
+++ b/cli/data.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -20,6 +19,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 	datapb "go.viam.com/api/app/data/v1"
+	"go.viam.com/rdk/services/datamanager/datacapture"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -335,7 +335,7 @@ func downloadBinary(ctx context.Context, client datapb.DataServiceClient, dst st
 
 	datum := data[0]
 
-	fileName := filenameForDownload(datum.GetMetadata(), runtime.GOOS)
+	fileName := filenameForDownload(datum.GetMetadata())
 	// Modify the file name in the metadata to reflect what it will be saved as.
 	metadata := datum.GetMetadata()
 	metadata.FileName = fileName
@@ -394,11 +394,11 @@ func downloadBinary(ctx context.Context, client datapb.DataServiceClient, dst st
 	return nil
 }
 
-// non-exhaustive list of characters to strip from filenames on windows and darwin (macOS).
-const windowsDarwinReservedChars = ":"
+// non-exhaustive list of characters to strip from filenames
+const filePathReservedChars = ":"
 
 // transform datum's filename to a destination path on this computer.
-func filenameForDownload(meta *datapb.BinaryMetadata, runtimeOS string) string {
+func filenameForDownload(meta *datapb.BinaryMetadata) string {
 	timeRequested := meta.GetTimeRequested().AsTime().Format(time.RFC3339Nano)
 	fileName := meta.GetFileName()
 
@@ -417,14 +417,9 @@ func filenameForDownload(meta *datapb.BinaryMetadata, runtimeOS string) string {
 		fileName = strings.TrimSuffix(fileName, gzFileExt)
 	}
 
-	if runtimeOS == "windows" || runtimeOS == "darwin" {
-		fileName = strings.Map(func(c rune) rune {
-			if strings.ContainsRune(windowsDarwinReservedChars, c) {
-				return '_'
-			}
-			return c
-		}, fileName)
-	}
+	// Replace reserved characters.
+	fileName = datacapture.FilePathWithReplacedReservedChars(fileName)
+
 	return fileName
 }
 

--- a/cli/data.go
+++ b/cli/data.go
@@ -19,9 +19,10 @@ import (
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 	datapb "go.viam.com/api/app/data/v1"
-	"go.viam.com/rdk/services/datamanager/datacapture"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"go.viam.com/rdk/services/datamanager/datacapture"
 )
 
 const (
@@ -393,9 +394,6 @@ func downloadBinary(ctx context.Context, client datapb.DataServiceClient, dst st
 	}
 	return nil
 }
-
-// non-exhaustive list of characters to strip from filenames
-const filePathReservedChars = ":"
 
 // transform datum's filename to a destination path on this computer.
 func filenameForDownload(meta *datapb.BinaryMetadata) string {

--- a/cli/data_test.go
+++ b/cli/data_test.go
@@ -9,35 +9,19 @@ import (
 
 func TestFilenameForDownload(t *testing.T) {
 	const utc0 = "1970-01-01T00:00:00Z"
-	const linux = "linux"
-	const windows = "windows"
-	noFilename := filenameForDownload(&datapb.BinaryMetadata{
-		Id: "my-id",
-	}, linux)
-	test.That(t, noFilename, test.ShouldEqual, utc0+"_my-id")
+	const utcReplaced = "1970-01-01T00_00_00Z"
+	noFilename := filenameForDownload(&datapb.BinaryMetadata{Id: "my-id"})
+	test.That(t, noFilename, test.ShouldEqual, utcReplaced+"_my-id")
 
-	normalExt := filenameForDownload(&datapb.BinaryMetadata{
-		FileName: "whatever.txt",
-	}, linux)
-	test.That(t, normalExt, test.ShouldEqual, utc0+"_whatever.txt")
+	normalExt := filenameForDownload(&datapb.BinaryMetadata{FileName: "whatever.txt"})
+	test.That(t, normalExt, test.ShouldEqual, utcReplaced+"_whatever.txt")
 
-	charReplacedTimestamp := filenameForDownload(&datapb.BinaryMetadata{
-		FileName: "whatever.txt",
-	}, windows)
-	test.That(t, charReplacedTimestamp, test.ShouldEqual, "1970-01-01T00_00_00Z_whatever.txt")
-
-	inFolder := filenameForDownload(&datapb.BinaryMetadata{
-		FileName: "dir/whatever.txt",
-	}, linux)
+	inFolder := filenameForDownload(&datapb.BinaryMetadata{FileName: "dir/whatever.txt"})
 	test.That(t, inFolder, test.ShouldEqual, "dir/whatever.txt")
 
-	gzAtRoot := filenameForDownload(&datapb.BinaryMetadata{
-		FileName: "whatever.gz",
-	}, linux)
-	test.That(t, gzAtRoot, test.ShouldEqual, utc0+"_whatever")
+	gzAtRoot := filenameForDownload(&datapb.BinaryMetadata{FileName: "whatever.gz"})
+	test.That(t, gzAtRoot, test.ShouldEqual, utcReplaced+"_whatever")
 
-	gzInFolder := filenameForDownload(&datapb.BinaryMetadata{
-		FileName: "dir/whatever.gz",
-	}, linux)
+	gzInFolder := filenameForDownload(&datapb.BinaryMetadata{FileName: "dir/whatever.gz"})
 	test.That(t, gzInFolder, test.ShouldEqual, "dir/whatever")
 }

--- a/cli/data_test.go
+++ b/cli/data_test.go
@@ -8,19 +8,18 @@ import (
 )
 
 func TestFilenameForDownload(t *testing.T) {
-	const utc0 = "1970-01-01T00:00:00Z"
-	const utcReplaced = "1970-01-01T00_00_00Z"
+	const expectedUTC = "1970-01-01T00_00_00Z"
 	noFilename := filenameForDownload(&datapb.BinaryMetadata{Id: "my-id"})
-	test.That(t, noFilename, test.ShouldEqual, utcReplaced+"_my-id")
+	test.That(t, noFilename, test.ShouldEqual, expectedUTC+"_my-id")
 
 	normalExt := filenameForDownload(&datapb.BinaryMetadata{FileName: "whatever.txt"})
-	test.That(t, normalExt, test.ShouldEqual, utcReplaced+"_whatever.txt")
+	test.That(t, normalExt, test.ShouldEqual, expectedUTC+"_whatever.txt")
 
 	inFolder := filenameForDownload(&datapb.BinaryMetadata{FileName: "dir/whatever.txt"})
 	test.That(t, inFolder, test.ShouldEqual, "dir/whatever.txt")
 
 	gzAtRoot := filenameForDownload(&datapb.BinaryMetadata{FileName: "whatever.gz"})
-	test.That(t, gzAtRoot, test.ShouldEqual, utcReplaced+"_whatever")
+	test.That(t, gzAtRoot, test.ShouldEqual, expectedUTC+"_whatever")
 
 	gzInFolder := filenameForDownload(&datapb.BinaryMetadata{FileName: "dir/whatever.gz"})
 	test.That(t, gzInFolder, test.ShouldEqual, "dir/whatever")

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -251,8 +251,8 @@ func (svc *builtIn) initializeOrUpdateCollector(
 
 	// Create a collector for this resource and method.
 	targetDir := datacapture.FilePathWithReplacedReservedChars(
-		filepath.Join(svc.captureDir, captureMetadata.GetComponentType(), captureMetadata.GetComponentName(),
-			captureMetadata.GetMethodName()))
+		filepath.Join(svc.captureDir, captureMetadata.GetComponentType(),
+			captureMetadata.GetComponentName(), captureMetadata.GetMethodName()))
 	if err := os.MkdirAll(targetDir, 0o700); err != nil {
 		return nil, err
 	}

--- a/services/datamanager/datacapture/data_capture_file.go
+++ b/services/datamanager/datacapture/data_capture_file.go
@@ -32,7 +32,7 @@ const (
 	nextPointCloud = "NextPointCloud"
 	pointCloudMap  = "PointCloudMap"
 	// Non-exhaustive list of characters to strip from file paths, since not allowed
-	// on at least Windows, Darwin, and Ubuntu 20.04.
+	// on certain file systems.
 	filePathReservedChars = ":"
 )
 

--- a/services/datamanager/datacapture/data_capture_file.go
+++ b/services/datamanager/datacapture/data_capture_file.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -33,8 +32,8 @@ const (
 	nextPointCloud = "NextPointCloud"
 	pointCloudMap  = "PointCloudMap"
 	// Non-exhaustive list of characters to strip from file paths, since not allowed
-	// on at least Windows and Darwin.
-	windowsDarwinReservedChars = ":"
+	// on at least Windows, Darwin, and Ubuntu 20.04.
+	filePathReservedChars = ":"
 )
 
 // File is the data structure containing data captured by collectors. It is backed by a file on disk containing
@@ -319,11 +318,7 @@ func SensorDataFromFile(f *File) ([]*v1.SensorData, error) {
 }
 
 // FilePathWithReplacedReservedChars returns the filepath with substitutions
-// for reserved characters if running on Windows or Darwin.
+// for reserved characterw.
 func FilePathWithReplacedReservedChars(filepath string) string {
-	runtimeOS := runtime.GOOS
-	if runtimeOS == "windows" || runtimeOS == "darwin" {
-		return strings.ReplaceAll(filepath, windowsDarwinReservedChars, "_")
-	}
-	return filepath
+	return strings.ReplaceAll(filepath, filePathReservedChars, "_")
 }


### PR DESCRIPTION
Since the filesystem rather than the OS seems to constrain what characters are supported in a filepath, simply always replace reserved characters in both data collection and the export CLI. In both of these use cases, the filepath only affects local capture/export and is not used in the cloud.

Tested capture/sync and export on a Mac.