### PR TITLE
RSDK-3534 Expose `LastReconfigured` timestamp in resource `Status`

### DIFF
--- a/resource/graph_node.go
+++ b/resource/graph_node.go
@@ -356,7 +356,9 @@ func (w *GraphNode) replace(other *GraphNode) error {
 
 	other.mu.Lock()
 	w.updatedAt = other.updatedAt
-	w.graphLogicalClock = other.graphLogicalClock
+	if other.graphLogicalClock != nil {
+		w.graphLogicalClock = other.graphLogicalClock
+	}
 	w.lastReconfigured = other.lastReconfigured
 	w.current = other.current
 	w.currentModel = other.currentModel

--- a/resource/resource_graph_test.go
+++ b/resource/resource_graph_test.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/edaniels/golog"
 	"go.viam.com/test"
@@ -953,6 +954,36 @@ func TestResourceGraphClock(t *testing.T) {
 	test.That(t, g.CurrLogicalClockValue(), test.ShouldEqual, 3)
 	test.That(t, node1.UpdatedAt(), test.ShouldEqual, 2)
 	test.That(t, node2.UpdatedAt(), test.ShouldEqual, 3)
+}
+
+func TestResourceGraphLastReconfigured(t *testing.T) {
+	g := NewGraph()
+
+	name1 := NewName(apiA, "a")
+	node1 := &GraphNode{}
+	test.That(t, g.AddNode(name1, node1), test.ShouldBeNil)
+	// Assert that uninitialized node has a nil lastReconfigured value.
+	test.That(t, node1.LastReconfigured(), test.ShouldBeNil)
+
+	res1 := &someResource{Named: name1.AsNamed()}
+	node1.SwapResource(res1, DefaultModelFamily.WithModel("foo"))
+	lr := node1.LastReconfigured()
+	test.That(t, lr, test.ShouldNotBeNil)
+	// Assert that after SwapResource, node's lastReconfigured time is between
+	// 50ms ago and now.
+	test.That(t, *lr, test.ShouldHappenBetween,
+		time.Now().Add(-50*time.Millisecond), time.Now())
+
+	// Mock a mutation with another SwapResource. Assert that lastReconfigured
+	// value changed.
+	node1.SwapResource(res1, DefaultModelFamily.WithModel("foo"))
+	newLR := node1.LastReconfigured()
+	test.That(t, newLR, test.ShouldNotBeNil)
+	// Assert that after another SwapResource, node's lastReconfigured time is
+	// after old lr value, and new value is between 50ms ago and now and is no
+	test.That(t, *newLR, test.ShouldHappenAfter, *lr)
+	test.That(t, *newLR, test.ShouldHappenBetween,
+		time.Now().Add(-50*time.Millisecond), time.Now())
 }
 
 func TestResourceGraphResolveDependencies(t *testing.T) {

--- a/resource/resource_graph_test.go
+++ b/resource/resource_graph_test.go
@@ -980,7 +980,7 @@ func TestResourceGraphLastReconfigured(t *testing.T) {
 	newLR := node1.LastReconfigured()
 	test.That(t, newLR, test.ShouldNotBeNil)
 	// Assert that after another SwapResource, node's lastReconfigured time is
-	// after old lr value, and new value is between 50ms ago and now and is no
+	// after old lr value and between 50ms ago and now.
 	test.That(t, *newLR, test.ShouldHappenAfter, *lr)
 	test.That(t, *newLR, test.ShouldHappenBetween,
 		time.Now().Add(-50*time.Millisecond), time.Now())

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -887,8 +887,9 @@ func (rc *RobotClient) Status(ctx context.Context, resourceNames []resource.Name
 	for _, status := range resp.Status {
 		statuses = append(
 			statuses, robot.Status{
-				Name:   rprotoutils.ResourceNameFromProto(status.Name),
-				Status: status.Status.AsMap(),
+				Name:             rprotoutils.ResourceNameFromProto(status.Name),
+				LastReconfigured: status.LastReconfigured.AsTime(),
+				Status:           status.Status.AsMap(),
 			})
 	}
 	return statuses, nil

--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -1366,8 +1366,20 @@ func TestClientStatus(t *testing.T) {
 		client, err := New(context.Background(), listener1.Addr().String(), logger)
 		test.That(t, err, test.ShouldBeNil)
 
-		gStatus := robot.Status{Name: movementsensor.Named("gps"), Status: map[string]interface{}{"efg": []string{"hello"}}}
-		aStatus := robot.Status{Name: arm.Named("arm"), Status: struct{}{}}
+		gLastReconfigured, err := time.Parse("2006-01-02 15:04:05", "1998-04-30 19:08:00")
+		test.That(t, err, test.ShouldBeNil)
+		gStatus := robot.Status{
+			Name:             movementsensor.Named("gps"),
+			LastReconfigured: gLastReconfigured,
+			Status:           map[string]interface{}{"efg": []string{"hello"}},
+		}
+		aLastReconfigured, err := time.Parse("2006-01-02 15:04:05", "2011-11-11 00:00:00")
+		test.That(t, err, test.ShouldBeNil)
+		aStatus := robot.Status{
+			Name:             arm.Named("arm"),
+			LastReconfigured: aLastReconfigured,
+			Status:           struct{}{},
+		}
 		statusMap := map[resource.Name]robot.Status{
 			gStatus.Name: gStatus,
 			aStatus.Name: aStatus,
@@ -1383,10 +1395,15 @@ func TestClientStatus(t *testing.T) {
 			gStatus.Name: map[string]interface{}{"efg": []interface{}{"hello"}},
 			aStatus.Name: map[string]interface{}{},
 		}
+		expectedLRs := map[resource.Name]time.Time{
+			gStatus.Name: gLastReconfigured,
+			aStatus.Name: aLastReconfigured,
+		}
 		resp, err := client.Status(context.Background(), []resource.Name{aStatus.Name})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, len(resp), test.ShouldEqual, 1)
 		test.That(t, resp[0].Status, test.ShouldResemble, expected[resp[0].Name])
+		test.That(t, resp[0].LastReconfigured, test.ShouldResemble, expectedLRs[resp[0].Name])
 
 		result := struct{}{}
 		decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{TagName: "json", Result: &result})
@@ -1403,7 +1420,12 @@ func TestClientStatus(t *testing.T) {
 			resp[0].Name: resp[0].Status,
 			resp[1].Name: resp[1].Status,
 		}
+		observedLRs := map[resource.Name]time.Time{
+			resp[0].Name: resp[0].LastReconfigured,
+			resp[1].Name: resp[1].LastReconfigured,
+		}
 		test.That(t, observed, test.ShouldResemble, expected)
+		test.That(t, observedLRs, test.ShouldResemble, expectedLRs)
 
 		err = client.Close(context.Background())
 		test.That(t, err, test.ShouldBeNil)

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -340,8 +340,6 @@ func (r *localRobot) Status(ctx context.Context, resourceNames []resource.Name) 
 					return nil, errors.Wrapf(err, "failed to get status from %q", name)
 				}
 			}
-			r.mu.Lock()
-			r.manager.resources.Node(name)
 			resourceStatus = robot.Status{
 				Name:             name,
 				LastReconfigured: lastReconfiguredMap[name],

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -42,7 +42,8 @@ var _ = robot.LocalRobot(&localRobot{})
 // localRobot satisfies robot.LocalRobot and defers most
 // logic to its manager.
 type localRobot struct {
-	mu            sync.Mutex
+	// statusLock guards calls to the Status method.
+	statusLock    sync.Mutex
 	manager       *resourceManager
 	mostRecentCfg config.Config
 
@@ -234,121 +235,112 @@ func remoteNameByResource(resourceName resource.Name) (string, bool) {
 }
 
 func (r *localRobot) Status(ctx context.Context, resourceNames []resource.Name) ([]robot.Status, error) {
-	r.mu.Lock()
-	resources := make(map[resource.Name]resource.Resource, len(r.manager.resources.Names()))
-	lastReconfiguredMap := make(map[resource.Name]time.Time)
-	for _, name := range r.ResourceNames() {
-		res, err := r.ResourceByName(name)
-		if err != nil {
-			r.mu.Unlock()
-			return nil, resource.NewNotFoundError(name)
-		}
-		resources[name] = res
+	r.statusLock.Lock()
+	defer r.statusLock.Unlock()
 
-		// Use graph node to find lastReconfigured value.
-		if resNode, ok := r.manager.resources.Node(name); ok {
-			switch lr := resNode.LastReconfigured(); {
-			case lr == nil:
-				// Should never happen as ResourceNames only returns configured resources.
-				r.Logger().Errorw(
-					"no lastReconfigured value for resource as it has not been configured",
-					"resource", name,
-				)
-			default:
-				lastReconfiguredMap[name] = *lr
-			}
-		}
-	}
-	r.mu.Unlock()
-
+	// If no resource names are specified, return status of all resources.
 	namesToDedupe := resourceNames
-	// if no names, return all
-	if len(namesToDedupe) == 0 {
-		namesToDedupe = make([]resource.Name, 0, len(resources))
-		for name := range resources {
-			namesToDedupe = append(namesToDedupe, name)
-		}
+	if len(resourceNames) == 0 {
+		namesToDedupe = append(namesToDedupe, r.manager.ResourceNames()...)
 	}
 
-	// dedupe resourceNames
-	deduped := make(map[resource.Name]struct{}, len(namesToDedupe))
+	// Dedupe resources.
+	resourceNameSet := make(map[resource.Name]struct{}, len(namesToDedupe))
 	for _, name := range namesToDedupe {
-		deduped[name] = struct{}{}
+		resourceNameSet[name] = struct{}{}
 	}
 
-	// group each resource name by remote and also get its corresponding name on the remote
-	groupedResources := make(map[string]map[resource.Name]resource.Name)
-	for name := range deduped {
+	// Group remote resource names by owning remote and map those names to
+	// corresponding name on the remote (without the remote prefix).
+	remoteResources := make(map[string]map[resource.Name]resource.Name)
+	for name := range resourceNameSet {
 		remoteName, ok := remoteNameByResource(name)
 		if !ok {
 			continue
 		}
-		mappings, ok := groupedResources[remoteName]
+		mappings, ok := remoteResources[remoteName]
 		if !ok {
 			mappings = make(map[resource.Name]resource.Name)
 		}
 		mappings[name.PopRemote()] = name
-		groupedResources[remoteName] = mappings
+		remoteResources[remoteName] = mappings
 	}
-	// make requests and map it back to the local resource name
-	remoteStatuses := make(map[resource.Name]robot.Status)
-	for remoteName, resourceNamesMappings := range groupedResources {
+
+	// Loop through remotes and get remote resource statuses through remotes.
+	combinedRemoteResourceStatuses := make(map[resource.Name]robot.Status)
+	for remoteName, resourceNameMappings := range remoteResources {
 		remote, ok := r.RemoteByName(remoteName)
 		if !ok {
 			// should never happen
-			r.Logger().Errorw("remote robot not found while creating status", "remote", remoteName)
+			r.Logger().Errorw("remote robot not found in resource graph while creating status",
+				"remote", remoteName)
 			continue
 		}
-		remoteRNames := make([]resource.Name, 0, len(resourceNamesMappings))
-		for n := range resourceNamesMappings {
-			remoteRNames = append(remoteRNames, n)
+		var remoteResourceNames []resource.Name
+		for remoteResourceName := range resourceNameMappings {
+			remoteResourceNames = append(remoteResourceNames, remoteResourceName)
 		}
 
-		s, err := remote.Status(ctx, remoteRNames)
+		// Request status of resources associated with the remote from the remote.
+		remoteResourceStatuses, err := remote.Status(ctx, remoteResourceNames)
 		if err != nil {
 			return nil, err
 		}
-		for _, stat := range s {
-			mappedName, ok := resourceNamesMappings[stat.Name]
+		for _, remoteResourceStatus := range remoteResourceStatuses {
+			mappedName, ok := resourceNameMappings[remoteResourceStatus.Name]
 			if !ok {
 				// should never happen
 				r.Logger().Errorw(
 					"failed to find corresponding resource name for remote resource name while creating status",
-					"resource", stat.Name,
+					"resource", remoteResourceStatus.Name,
 				)
 				continue
 			}
-			stat.Name = mappedName
-			remoteStatuses[mappedName] = stat
+			// Set name to have remote prefix and add to remoteStatuses.
+			remoteResourceStatus.Name = mappedName
+			combinedRemoteResourceStatuses[mappedName] = remoteResourceStatus
 		}
 	}
-	statuses := make([]robot.Status, 0, len(deduped))
-	for name := range deduped {
-		resourceStatus, ok := remoteStatuses[name]
+
+	// Loop through entire resourceNameSet and get status for any local resources.
+	combinedResourceStatuses := make([]robot.Status, 0, len(resourceNameSet))
+	for name := range resourceNameSet {
+		// Just append status if it was a remote resource.
+		resourceStatus, ok := combinedRemoteResourceStatuses[name]
 		if !ok {
-			res, ok := resources[name]
-			if !ok {
-				return nil, resource.NewNotFoundError(name)
+			res, err := r.manager.ResourceByName(name)
+			if err != nil {
+				return nil, err
 			}
-			// if resource API has an associated CreateStatus method, use that
-			// otherwise return an empty status
+
+			// If resource API registration had an associated CreateStatus method,
+			// call that method, otherwise return an empty status.
 			var status interface{} = map[string]interface{}{}
-			var err error
-			if apiReg, ok := resource.LookupGenericAPIRegistration(name.API); ok && apiReg.Status != nil {
+			if apiReg, ok := resource.LookupGenericAPIRegistration(name.API); ok &&
+				apiReg.Status != nil {
 				status, err = apiReg.Status(ctx, res)
 				if err != nil {
 					return nil, errors.Wrapf(err, "failed to get status from %q", name)
 				}
 			}
+			resNode, ok := r.manager.resources.Node(name)
+			if !ok {
+				return nil, resource.NewNotFoundError(name)
+			}
+			lastReconfigured := resNode.LastReconfigured()
+			if lastReconfigured == nil {
+				return nil, errors.Errorf("resource %s queried for status is not configured",
+					name)
+			}
 			resourceStatus = robot.Status{
 				Name:             name,
-				LastReconfigured: lastReconfiguredMap[name],
+				LastReconfigured: *lastReconfigured,
 				Status:           status,
 			}
 		}
-		statuses = append(statuses, resourceStatus)
+		combinedResourceStatuses = append(combinedResourceStatuses, resourceStatus)
 	}
-	return statuses, nil
+	return combinedResourceStatuses, nil
 }
 
 func newWithResources(

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -260,6 +260,11 @@ func TestConfigRemote(t *testing.T) {
 
 	for idx := 0; idx < expectedStatusLength; idx++ {
 		test.That(t, statuses[idx].Status, test.ShouldResemble, map[string]interface{}{})
+		// Assert that last reconfigured values are within last 5s (remote
+		// recently configured all three resources).
+		lr := statuses[idx].LastReconfigured
+		test.That(t, lr, test.ShouldHappenBetween,
+			time.Now().Add(-5*time.Second), time.Now())
 	}
 
 	statuses, err = r2.Status(

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -1093,7 +1093,7 @@ func TestStatus(t *testing.T) {
 		resource.DeregisterAPI(failAPI)
 	}()
 
-	statuses := []robot.Status{{Name: button1, Status: map[string]interface{}{}}}
+	expectedRobotStatus := robot.Status{Name: button1, Status: map[string]interface{}{}}
 	logger := golog.NewTestLogger(t)
 	resourceNames := []resource.Name{working1, button1, fail1}
 	resourceMap := map[resource.Name]resource.Resource{
@@ -1123,7 +1123,11 @@ func TestStatus(t *testing.T) {
 
 		resp, err := r.Status(context.Background(), []resource.Name{button1})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, resp, test.ShouldResemble, statuses)
+		test.That(t, len(resp), test.ShouldEqual, 1)
+		test.That(t, resp[0].Name, test.ShouldResemble, expectedRobotStatus.Name)
+		test.That(t, resp[0].Status, test.ShouldResemble, expectedRobotStatus.Status)
+		test.That(t, resp[0].LastReconfigured, test.ShouldHappenBetween,
+			time.Now().Add(-10*time.Second), time.Now())
 	})
 
 	t.Run("failing resource", func(t *testing.T) {

--- a/robot/robot.go
+++ b/robot/robot.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/edaniels/golog"
 	"github.com/jhump/protoreflect/desc"
@@ -118,12 +119,16 @@ type RemoteRobot interface {
 	Connected() bool
 }
 
-// Status holds a resource name and its corresponding status. Status is expected to be comprised of string keys
-// and values comprised of primitives, list of primitives, maps with string keys (or at least can be decomposed into one),
-// or lists of the forementioned type of maps. Results with other types of data are not guaranteed.
+// Status holds a resource name, the time that resource was last reconfigured
+// (or built), and its corresponding status. Status.Status is expected to be
+// comprised of string keys and values comprised of primitives, list of
+// primitives, maps with string keys (or at least can be decomposed into one),
+// or lists of the forementioned type of maps. Results with other types of data
+// are not guaranteed.
 type Status struct {
-	Name   resource.Name
-	Status interface{}
+	Name             resource.Name
+	LastReconfigured time.Time
+	Status           interface{}
 }
 
 // AllResourcesByName returns an array of all resources that have this short name.

--- a/robot/server/server.go
+++ b/robot/server/server.go
@@ -297,8 +297,9 @@ func (s *Server) GetStatus(ctx context.Context, req *pb.GetStatusRequest) (*pb.G
 		statusesP = append(
 			statusesP,
 			&pb.Status{
-				Name:   protoutils.ResourceNameToProto(status.Name),
-				Status: statusP,
+				Name:             protoutils.ResourceNameToProto(status.Name),
+				LastReconfigured: timestamppb.New(status.LastReconfigured),
+				Status:           statusP,
 			},
 		)
 	}

--- a/robot/server/server_test.go
+++ b/robot/server/server_test.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"go.viam.com/rdk/components/arm"
 	"go.viam.com/rdk/components/movementsensor"
@@ -394,6 +395,12 @@ func TestServerFrameSystemConfig(t *testing.T) {
 }
 
 func TestServerGetStatus(t *testing.T) {
+	// Sample lastReconfigured times to be used across status tests.
+	lastReconfigured, err := time.Parse("2006-01-02 15:04:05", "1998-04-30 19:08:00")
+	test.That(t, err, test.ShouldBeNil)
+	lastReconfigured2, err := time.Parse("2006-01-02 15:04:05", "2011-11-11 00:00:00")
+	test.That(t, err, test.ShouldBeNil)
+
 	t.Run("failed GetStatus", func(t *testing.T) {
 		injectRobot := &inject.Robot{}
 		server := server.New(injectRobot)
@@ -432,10 +439,17 @@ func TestServerGetStatus(t *testing.T) {
 	t.Run("working one status", func(t *testing.T) {
 		injectRobot := &inject.Robot{}
 		server := server.New(injectRobot)
-		aStatus := robot.Status{Name: arm.Named("arm"), Status: struct{}{}}
+		aStatus := robot.Status{
+			Name:             arm.Named("arm"),
+			LastReconfigured: lastReconfigured,
+			Status:           struct{}{},
+		}
 		readings := []robot.Status{aStatus}
 		expected := map[resource.Name]interface{}{
 			aStatus.Name: map[string]interface{}{},
+		}
+		expectedLR := map[resource.Name]time.Time{
+			aStatus.Name: lastReconfigured,
 		}
 		injectRobot.StatusFunc = func(ctx context.Context, resourceNames []resource.Name) ([]robot.Status, error) {
 			test.That(
@@ -457,18 +471,35 @@ func TestServerGetStatus(t *testing.T) {
 		observed := map[resource.Name]interface{}{
 			protoutils.ResourceNameFromProto(resp.Status[0].Name): resp.Status[0].Status.AsMap(),
 		}
+		observedLR := map[resource.Name]time.Time{
+			protoutils.ResourceNameFromProto(resp.Status[0].Name): resp.Status[0].
+				LastReconfigured.AsTime(),
+		}
 		test.That(t, observed, test.ShouldResemble, expected)
+		test.That(t, observedLR, test.ShouldResemble, expectedLR)
 	})
 
 	t.Run("working many statuses", func(t *testing.T) {
 		injectRobot := &inject.Robot{}
 		server := server.New(injectRobot)
-		gStatus := robot.Status{Name: movementsensor.Named("gps"), Status: map[string]interface{}{"efg": []string{"hello"}}}
-		aStatus := robot.Status{Name: arm.Named("arm"), Status: struct{}{}}
+		gStatus := robot.Status{
+			Name:             movementsensor.Named("gps"),
+			LastReconfigured: lastReconfigured,
+			Status:           map[string]interface{}{"efg": []string{"hello"}},
+		}
+		aStatus := robot.Status{
+			Name:             arm.Named("arm"),
+			LastReconfigured: lastReconfigured2,
+			Status:           struct{}{},
+		}
 		statuses := []robot.Status{gStatus, aStatus}
 		expected := map[resource.Name]interface{}{
 			gStatus.Name: map[string]interface{}{"efg": []interface{}{"hello"}},
 			aStatus.Name: map[string]interface{}{},
+		}
+		expectedLRs := map[resource.Name]time.Time{
+			gStatus.Name: lastReconfigured,
+			aStatus.Name: lastReconfigured2,
 		}
 		injectRobot.StatusFunc = func(ctx context.Context, resourceNames []resource.Name) ([]robot.Status, error) {
 			test.That(
@@ -494,7 +525,14 @@ func TestServerGetStatus(t *testing.T) {
 			protoutils.ResourceNameFromProto(resp.Status[0].Name): resp.Status[0].Status.AsMap(),
 			protoutils.ResourceNameFromProto(resp.Status[1].Name): resp.Status[1].Status.AsMap(),
 		}
+		observedLRs := map[resource.Name]time.Time{
+			protoutils.ResourceNameFromProto(resp.Status[0].Name): resp.Status[0].
+				LastReconfigured.AsTime(),
+			protoutils.ResourceNameFromProto(resp.Status[1].Name): resp.Status[1].
+				LastReconfigured.AsTime(),
+		}
 		test.That(t, observed, test.ShouldResemble, expected)
+		test.That(t, observedLRs, test.ShouldResemble, expectedLRs)
 	})
 
 	t.Run("failed StreamStatus", func(t *testing.T) {
@@ -520,7 +558,7 @@ func TestServerGetStatus(t *testing.T) {
 		injectRobot := &inject.Robot{}
 		server := server.New(injectRobot)
 		injectRobot.StatusFunc = func(ctx context.Context, resourceNames []resource.Name) ([]robot.Status, error) {
-			return []robot.Status{{arm.Named("arm"), struct{}{}}}, nil
+			return []robot.Status{{arm.Named("arm"), time.Time{}, struct{}{}}}, nil
 		}
 
 		cancelCtx, cancel := context.WithCancel(context.Background())
@@ -541,7 +579,7 @@ func TestServerGetStatus(t *testing.T) {
 		injectRobot := &inject.Robot{}
 		server := server.New(injectRobot)
 		injectRobot.StatusFunc = func(ctx context.Context, resourceNames []resource.Name) ([]robot.Status, error) {
-			return []robot.Status{{arm.Named("arm"), struct{}{}}}, nil
+			return []robot.Status{{arm.Named("arm"), time.Time{}, struct{}{}}}, nil
 		}
 
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -560,7 +598,13 @@ func TestServerGetStatus(t *testing.T) {
 		injectRobot := &inject.Robot{}
 		server := server.New(injectRobot)
 		injectRobot.StatusFunc = func(ctx context.Context, resourceNames []resource.Name) ([]robot.Status, error) {
-			return []robot.Status{{arm.Named("arm"), struct{}{}}}, nil
+			return []robot.Status{
+				{
+					Name:             arm.Named("arm"),
+					LastReconfigured: lastReconfigured,
+					Status:           struct{}{},
+				},
+			}, nil
 		}
 
 		cancelCtx, cancel := context.WithCancel(context.Background())
@@ -585,10 +629,17 @@ func TestServerGetStatus(t *testing.T) {
 		messages = append(messages, <-messageCh)
 		messages = append(messages, <-messageCh)
 		messages = append(messages, <-messageCh)
+		expectedRobotStatus := []*pb.Status{
+			{
+				Name:             protoutils.ResourceNameToProto(arm.Named("arm")),
+				LastReconfigured: timestamppb.New(lastReconfigured),
+				Status:           expectedStatus,
+			},
+		}
 		test.That(t, messages, test.ShouldResemble, []*pb.StreamStatusResponse{
-			{Status: []*pb.Status{{Name: protoutils.ResourceNameToProto(arm.Named("arm")), Status: expectedStatus}}},
-			{Status: []*pb.Status{{Name: protoutils.ResourceNameToProto(arm.Named("arm")), Status: expectedStatus}}},
-			{Status: []*pb.Status{{Name: protoutils.ResourceNameToProto(arm.Named("arm")), Status: expectedStatus}}},
+			{Status: expectedRobotStatus},
+			{Status: expectedRobotStatus},
+			{Status: expectedRobotStatus},
 		})
 		test.That(t, time.Since(start), test.ShouldBeGreaterThanOrEqualTo, 3*dur)
 		test.That(t, time.Since(start), test.ShouldBeLessThanOrEqualTo, 6*dur)


### PR DESCRIPTION
[RDSK-3534](https://viam.atlassian.net/browse/RSDK-3534)
Scope [here](https://docs.google.com/document/d/19q8tnosleJvNyT1-ikjqOSPqeZeWmOBS1t8yRzOqaSU/edit#heading=h.tcicyojyqi6c).

Upgrades `api` version to [this commit](https://github.com/viamrobotics/api/commit/57108c60d0da8f46df147a496845bdf2160facd6). Adds `*time.Time lastReconfigured` field to resource graph nodes (similar to `updatedAt`, but optionally contains the `time.Time` at which `SwapResource` was called). Exposes that field with `LastReconfigured` method. Adds `LastReconfigured` field to `robot.Status` and fills that field in `localRobot.Status` method. Converts field to proto in `robot/server`. Converts field from proto in `robot/client`. Adds tests for resource graph, robot client, robot servers and remotes.