### PR TITLE
[RSDK-5241] Make the ezopmp motor talk directly to the I2C bus

### DIFF
--- a/components/motor/i2cmotors/ezopmp.go
+++ b/components/motor/i2cmotors/ezopmp.go
@@ -1,7 +1,6 @@
 //go:build linux
 
 // Package ezopmp is a motor driver for the hydrogarden pump
-//
 package ezopmp
 
 import (

--- a/components/motor/i2cmotors/ezopmp.go
+++ b/components/motor/i2cmotors/ezopmp.go
@@ -1,10 +1,10 @@
+//go:build linux
 // Package ezopmp is a motor driver for the hydrogarden pump
 package ezopmp
 
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"math"
 	"strconv"
 	"strings"
@@ -15,6 +15,7 @@ import (
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/genericlinux"
 	"go.viam.com/rdk/components/motor"
 	"go.viam.com/rdk/operation"
 	"go.viam.com/rdk/resource"
@@ -22,7 +23,6 @@ import (
 
 // Config is user config inputs for ezopmp.
 type Config struct {
-	BoardName   string `json:"board"`
 	BusName     string `json:"i2c_bus"`
 	I2CAddress  *byte  `json:"i2c_addr"`
 	MaxReadBits *int   `json:"max_read_bits"`
@@ -31,9 +31,6 @@ type Config struct {
 // Validate ensures all parts of the config are valid.
 func (conf *Config) Validate(path string) ([]string, error) {
 	var deps []string
-	if conf.BoardName == "" {
-		return nil, utils.NewConfigValidationFieldRequiredError(path, "board")
-	}
 
 	if conf.BusName == "" {
 		return nil, utils.NewConfigValidationFieldRequiredError(path, "bus_name")
@@ -47,7 +44,6 @@ func (conf *Config) Validate(path string) ([]string, error) {
 		return nil, utils.NewConfigValidationFieldRequiredError(path, "max_read_bits")
 	}
 
-	deps = append(deps, conf.BoardName)
 	return deps, nil
 }
 
@@ -75,7 +71,6 @@ type Ezopmp struct {
 	resource.Named
 	resource.AlwaysRebuild
 	resource.TriviallyCloseable
-	board       board.Board
 	bus         board.I2C
 	I2CAddress  byte
 	maxReadBits int
@@ -99,23 +94,13 @@ const (
 func NewMotor(ctx context.Context, deps resource.Dependencies, c *Config, name resource.Name,
 	logger golog.Logger,
 ) (motor.Motor, error) {
-	b, err := board.FromDependencies(deps, c.BoardName)
+	bus, err := genericlinux.NewI2cBus(c.BusName)
 	if err != nil {
 		return nil, err
 	}
 
-	localB, ok := b.(board.LocalBoard)
-	if !ok {
-		return nil, fmt.Errorf("board %s is not local", c.BoardName)
-	}
-	bus, ok := localB.I2CByName(c.BusName)
-	if !ok {
-		return nil, errors.Errorf("can't find I2C bus (%s) requested by Motor", c.BusName)
-	}
-
 	m := &Ezopmp{
 		Named:       name.AsNamed(),
-		board:       b,
 		bus:         bus,
 		I2CAddress:  *c.I2CAddress,
 		maxReadBits: *c.MaxReadBits,
@@ -156,10 +141,6 @@ func (m *Ezopmp) findMaxFlowRate(ctx context.Context) (float64, error) {
 
 // Validate if this config is valid.
 func (m *Ezopmp) Validate() error {
-	if m.board == nil {
-		return errors.New("need a board for ezopmp")
-	}
-
 	if m.bus == nil {
 		return errors.New("need a bus for ezopmp")
 	}

--- a/components/motor/i2cmotors/ezopmp.go
+++ b/components/motor/i2cmotors/ezopmp.go
@@ -1,5 +1,7 @@
 //go:build linux
+
 // Package ezopmp is a motor driver for the hydrogarden pump
+//
 package ezopmp
 
 import (

--- a/components/motor/i2cmotors/ezopmp_nonlinux.go
+++ b/components/motor/i2cmotors/ezopmp_nonlinux.go
@@ -1,0 +1,2 @@
+// Package ezopmp is a motor driver for the hydrogarden pump, but our implementation is Linux-only.
+package ezopmp


### PR DESCRIPTION
With this PR, you should be able to use an ezopmp motor with a board implemented as a modular component in a separate process.

This compiles fine, but I don't have a pump to actually try it out further. but the component is not officially documented on our website, there is only a single robot config that includes this component, and it hasn't been online in over a year. So, this component is approximately unused, and if it breaks in some subtle way, we can fix it once we start supporting the component in earnest.