### PR TITLE
Fix Modmanager Module Config Retrieval

### DIFF
--- a/config/module.go
+++ b/config/module.go
@@ -14,6 +14,10 @@ var moduleNameRegEx = regexp.MustCompile(`^[\w-]+$`)
 const reservedModuleName = "parent"
 
 // Module represents an external resource module, with a path to the binary module file.
+//
+// Note to fellow programmers:
+// If you add any new fields, make sure to bring them to the modmanager.module struct and the modmanager.Configs() function
+// Otherwise there will be config diffs on every reconfigure.
 type Module struct {
 	// Name is an arbitrary name used to identify the module, and is used to name it's socket as well.
 	Name string `json:"name"`

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -345,7 +345,12 @@ func (mgr *Manager) Configs() []config.Module {
 	var configs []config.Module
 	for _, mod := range mgr.modules {
 		configs = append(configs, config.Module{
-			Name: mod.name, ExePath: mod.exe, LogLevel: mod.logLevel,
+			Name:        mod.name,
+			ExePath:     mod.exe,
+			LogLevel:    mod.logLevel,
+			Type:        mod.modType,
+			ModuleID:    mod.moduleID,
+			Environment: mod.environment,
 		})
 	}
 	return configs


### PR DESCRIPTION
Without this patch, specifying any of these params triggers config diffs every reconfigure.

This is quite the footgun. It might not be a bad idea to change the modmanger module to store a config.Module rather than its own copy of every field.