### PR TITLE
[DATA-2075] Revert "[DATA-2022] Allow the user to configure how long the syncer waits to upload a file since it was last modified"

### DIFF
--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -62,23 +62,19 @@ const defaultCaptureQueueSize = 250
 // Default bufio.Writer buffer size in bytes.
 const defaultCaptureBufferSize = 4096
 
-// Default time to wait in milliseconds to check if a file has been modified.
-const defaultFileLastModifiedMillis = 10000.0
-
 var clock = clk.New()
 
 var errCaptureDirectoryConfigurationDisabled = errors.New("changing the capture directory is prohibited in this environment")
 
 // Config describes how to configure the service.
 type Config struct {
-	CaptureDir             string                           `json:"capture_dir"`
-	AdditionalSyncPaths    []string                         `json:"additional_sync_paths"`
-	SyncIntervalMins       float64                          `json:"sync_interval_mins"`
-	CaptureDisabled        bool                             `json:"capture_disabled"`
-	ScheduledSyncDisabled  bool                             `json:"sync_disabled"`
-	Tags                   []string                         `json:"tags"`
-	ResourceConfigs        []*datamanager.DataCaptureConfig `json:"resource_configs"`
-	FileLastModifiedMillis int                              `json:"file_last_modified_millis"`
+	CaptureDir            string                           `json:"capture_dir"`
+	AdditionalSyncPaths   []string                         `json:"additional_sync_paths"`
+	SyncIntervalMins      float64                          `json:"sync_interval_mins"`
+	CaptureDisabled       bool                             `json:"capture_disabled"`
+	ScheduledSyncDisabled bool                             `json:"sync_disabled"`
+	Tags                  []string                         `json:"tags"`
+	ResourceConfigs       []*datamanager.DataCaptureConfig `json:"resource_configs"`
 }
 
 // Validate returns components which will be depended upon weakly due to the above matcher.
@@ -89,13 +85,13 @@ func (c *Config) Validate(path string) ([]string, error) {
 // builtIn initializes and orchestrates data capture collectors for registered component/methods.
 type builtIn struct {
 	resource.Named
-	logger                 golog.Logger
-	captureDir             string
-	captureDisabled        bool
-	collectors             map[resourceMethodMetadata]*collectorAndConfig
-	lock                   sync.Mutex
-	backgroundWorkers      sync.WaitGroup
-	fileLastModifiedMillis int
+	logger                      golog.Logger
+	captureDir                  string
+	captureDisabled             bool
+	collectors                  map[resourceMethodMetadata]*collectorAndConfig
+	lock                        sync.Mutex
+	backgroundWorkers           sync.WaitGroup
+	waitAfterLastModifiedMillis int
 
 	additionalSyncPaths []string
 	tags                []string
@@ -119,15 +115,15 @@ func NewBuiltIn(
 	logger golog.Logger,
 ) (datamanager.Service, error) {
 	svc := &builtIn{
-		Named:                  conf.ResourceName().AsNamed(),
-		logger:                 logger,
-		captureDir:             viamCaptureDotDir,
-		collectors:             make(map[resourceMethodMetadata]*collectorAndConfig),
-		syncIntervalMins:       0,
-		additionalSyncPaths:    []string{},
-		tags:                   []string{},
-		fileLastModifiedMillis: defaultFileLastModifiedMillis,
-		syncerConstructor:      datasync.NewManager,
+		Named:                       conf.ResourceName().AsNamed(),
+		logger:                      logger,
+		captureDir:                  viamCaptureDotDir,
+		collectors:                  make(map[resourceMethodMetadata]*collectorAndConfig),
+		syncIntervalMins:            0,
+		additionalSyncPaths:         []string{},
+		tags:                        []string{},
+		waitAfterLastModifiedMillis: 10000,
+		syncerConstructor:           datasync.NewManager,
 	}
 
 	if err := svc.Reconfigure(ctx, deps, conf); err != nil {
@@ -417,17 +413,11 @@ func (svc *builtIn) Reconfigure(
 	svc.collectors = newCollectors
 	svc.additionalSyncPaths = svcConfig.AdditionalSyncPaths
 
-	fileLastModifiedMillis := svcConfig.FileLastModifiedMillis
-	if fileLastModifiedMillis == 0 {
-		fileLastModifiedMillis = defaultFileLastModifiedMillis
-	}
-
 	if svc.syncDisabled != svcConfig.ScheduledSyncDisabled || svc.syncIntervalMins != svcConfig.SyncIntervalMins ||
-		!reflect.DeepEqual(svc.tags, svcConfig.Tags) || svc.fileLastModifiedMillis != fileLastModifiedMillis {
+		!reflect.DeepEqual(svc.tags, svcConfig.Tags) {
 		svc.syncDisabled = svcConfig.ScheduledSyncDisabled
 		svc.syncIntervalMins = svcConfig.SyncIntervalMins
 		svc.tags = svcConfig.Tags
-		svc.fileLastModifiedMillis = fileLastModifiedMillis
 
 		svc.cancelSyncScheduler()
 		if !svc.syncDisabled && svc.syncIntervalMins != 0.0 {
@@ -507,9 +497,9 @@ func (svc *builtIn) uploadData(cancelCtx context.Context, intervalMins float64) 
 
 func (svc *builtIn) sync() {
 	svc.flushCollectors()
-	toSync := getAllFilesToSync(svc.captureDir, svc.fileLastModifiedMillis)
+	toSync := getAllFilesToSync(svc.captureDir, svc.waitAfterLastModifiedMillis)
 	for _, ap := range svc.additionalSyncPaths {
-		toSync = append(toSync, getAllFilesToSync(ap, svc.fileLastModifiedMillis)...)
+		toSync = append(toSync, getAllFilesToSync(ap, svc.waitAfterLastModifiedMillis)...)
 	}
 	for _, p := range toSync {
 		svc.syncer.SyncFile(p)
@@ -530,7 +520,7 @@ func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 		if info.IsDir() {
 			return nil
 		}
-		// If a file was modified within the past lastModifiedMillis, do not sync it (data
+		// If a file was modified within the past lastModifiedMillis seconds, do not sync it (data
 		// may still be being written).
 		timeSinceMod := clock.Since(info.ModTime())
 		// When using a mock clock in tests, this can be negative since the file system will still use the system clock.

--- a/services/datamanager/builtin/export_test.go
+++ b/services/datamanager/builtin/export_test.go
@@ -10,9 +10,9 @@ func (svc *builtIn) SetSyncerConstructor(fn datasync.ManagerConstructor) {
 	svc.syncerConstructor = fn
 }
 
-// SetFileLastModifiedMillis sets the wait time for the syncer to use when initialized/changed in Service.Update.
-func (svc *builtIn) SetFileLastModifiedMillis(s int) {
-	svc.fileLastModifiedMillis = s
+// SetWaitAfterLastModifiedSecs sets the wait time for the syncer to use when initialized/changed in Service.Update.
+func (svc *builtIn) SetWaitAfterLastModifiedMillis(s int) {
+	svc.waitAfterLastModifiedMillis = s
 }
 
 // Make getDurationFromHz global for tests.

--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -367,6 +367,7 @@ func TestArbitraryFileUpload(t *testing.T) {
 
 			// Set up dmsvc config.
 			dmsvc, r := newTestDataManager(t)
+			dmsvc.SetWaitAfterLastModifiedMillis(0)
 			defer dmsvc.Close(context.Background())
 			f := atomic.Bool{}
 			f.Store(tc.serviceFail)
@@ -382,9 +383,6 @@ func TestArbitraryFileUpload(t *testing.T) {
 			cfg.SyncIntervalMins = syncIntervalMins
 			cfg.AdditionalSyncPaths = []string{additionalPathsDir}
 			cfg.CaptureDir = captureDir
-
-			// Ensure that we don't wait to sync files.
-			cfg.FileLastModifiedMillis = -1
 
 			// Start dmsvc.
 			resources := resourcesFromDeps(t, r, deps)

--- a/services/datamanager/internal/data_manager_test_helper.go
+++ b/services/datamanager/internal/data_manager_test_helper.go
@@ -21,5 +21,5 @@ type DMService interface {
 	) error
 	Close(ctx context.Context) error
 	SetSyncerConstructor(fn datasync.ManagerConstructor)
-	SetFileLastModifiedMillis(s int)
+	SetWaitAfterLastModifiedMillis(s int)
 }


### PR DESCRIPTION
Reverts viamrobotics/rdk#3071

Discovered while debugging [DATA-2075](https://viam.atlassian.net/browse/DATA-2075) that this is the commit that introduced the issue. Reverting it for now while I debug/fix.

[DATA-2075]: https://viam.atlassian.net/browse/DATA-2075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ