### PR TITLE
RSDK-5222: Handling ICY related error. 

### DIFF
--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
@@ -38,6 +38,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"strings"
 	"sync"
 
 	"github.com/de-bkg/gognss/pkg/ntrip"
@@ -326,8 +327,13 @@ func (g *rtkI2C) getStream(mountPoint string, maxAttempts int) error {
 	}
 
 	if err != nil {
-		g.logger.Errorf("Can't connect to NTRIP stream: %s", err)
-		return err
+		// if the error is related to ICY, we log it as warning.
+		if strings.Contains(err.Error(), "ICY") {
+			g.logger.Warnf("Can't connect to Ntrip Steam: %s", err)
+		} else {
+			g.logger.Errorf("Can't connect to NTRIP stream: %s", err)
+			return err
+		}
 	}
 
 	g.logger.Debug("Connected to stream")

--- a/components/movementsensor/gpsrtkserial/gpsrtkserial.go
+++ b/components/movementsensor/gpsrtkserial/gpsrtkserial.go
@@ -34,6 +34,7 @@ import (
 	"errors"
 	"io"
 	"math"
+	"strings"
 	"sync"
 
 	"github.com/de-bkg/gognss/pkg/ntrip"
@@ -309,6 +310,7 @@ func (g *rtkSerial) getStream(mountPoint string, maxAttempts int) error {
 			defer g.ntripMu.Unlock()
 			return g.ntripClient.Client.GetStream(mountPoint)
 		}()
+
 		if err == nil {
 			success = true
 		}
@@ -316,8 +318,13 @@ func (g *rtkSerial) getStream(mountPoint string, maxAttempts int) error {
 	}
 
 	if err != nil {
-		g.logger.Errorf("Can't connect to NTRIP stream: %s", err)
-		return err
+		// if the error is related to ICY, we log it as warning.
+		if strings.Contains(err.Error(), "ICY") {
+			g.logger.Warnf("Warning: Can't connect to Ntrip Steam: %s", err)
+		} else {
+			g.logger.Errorf("Can't connect to NTRIP stream: %s", err)
+			return err
+		}
 	}
 
 	if success {

--- a/components/movementsensor/gpsrtkserial/gpsrtkserial.go
+++ b/components/movementsensor/gpsrtkserial/gpsrtkserial.go
@@ -310,7 +310,6 @@ func (g *rtkSerial) getStream(mountPoint string, maxAttempts int) error {
 			defer g.ntripMu.Unlock()
 			return g.ntripClient.Client.GetStream(mountPoint)
 		}()
-
 		if err == nil {
 			success = true
 		}
@@ -320,7 +319,7 @@ func (g *rtkSerial) getStream(mountPoint string, maxAttempts int) error {
 	if err != nil {
 		// if the error is related to ICY, we log it as warning.
 		if strings.Contains(err.Error(), "ICY") {
-			g.logger.Warnf("Warning: Can't connect to Ntrip Steam: %s", err)
+			g.logger.Warnf("Can't connect to Ntrip Steam: %s", err)
 		} else {
 			g.logger.Errorf("Can't connect to NTRIP stream: %s", err)
 			return err


### PR DESCRIPTION
Checking the error to see if it contains "ICY" and logging it as warning since we eventually connect to the Ntrip Server. 

Testing: 
- @benjirewis : since we've only seen this in California, would you be able to test it out? 