### PR TITLE
RSDK-5063 include 32-bit appimage in deployment

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -149,14 +149,14 @@ jobs:
       run: pip install appimage-builder git+https://github.com/AppImageCrafters/appimage-builder.git@42d32f11496de43a9f6a9ada7882a11296e357ca
     - name: build
       env:
-        BUILD_CHANNEL: ${{ inputs.release_type }}
+        BUILD_CHANNEL: ${{ github.ref_name == 'main' && 'latest' || github.ref_name }}
         UNAME_M: armv7l
         DPKG_ARCH: armhf
         APPIMAGE_ARCH: armhf
       run: make appimage-arch
     - uses: actions/upload-artifact@v3
       with:
-        name: appimage-32bit
+        name: appimage-armhf
         path: etc/packaging/appimages/deploy
 
   output_summary:
@@ -223,8 +223,10 @@ jobs:
 
   appimage_deploy:
     name: AppImage Deploy
-    needs: appimage_test
+    needs: [appimage_test, appimage-32bit]
     runs-on: ubuntu-latest
+    env:
+      channel: ${{ github.ref_name == 'main' && 'latest' || github.ref_name }}
 
     steps:
     - name: Authorize GCP
@@ -235,18 +237,27 @@ jobs:
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v1
 
+    - uses: actions/download-artifact@v3
+      with:
+        name: appimage-armhf
+        path: etc/packaging/appimages/deploy
+
+    - name: deploy 32-bit
+      uses: google-github-actions/upload-cloud-storage@v0.10.4
+      with:
+        headers: "cache-control: no-cache"
+        path: etc/packaging/appimages/deploy/viam-server-${{ env.channel }}-armhf.AppImage
+        destination: 'packages.viam.com/apps/viam-server/'
+        parent: false
+
     - name: Publish AppImage
       run: |
         gsutil mv "gs://packages.viam.com/apps/viam-server/testing/appimage/${{ needs.appimage_test.outputs.date }}/${{ github.sha }}/*" "gs://packages.viam.com/apps/viam-server/"
 
     - name: Output Summary
       run: |
-        channel="${{ github.ref_name }}"
-        # we call our main branch releases "latest"
-        if [ "$channel" == "main" ]; then
-          channel="latest"
-        fi
         echo "### Built AppImages for ${channel}" >> $GITHUB_STEP_SUMMARY
         echo "- arm64: https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-server-${channel}-aarch64.AppImage" >> $GITHUB_STEP_SUMMARY
         echo "- x86_64: https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-server-${channel}-x86_64.AppImage" >> $GITHUB_STEP_SUMMARY
+        echo "- armhf: https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-server-${channel}-armhf.AppImage" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/releasecandidate.yml
+++ b/.github/workflows/releasecandidate.yml
@@ -4,7 +4,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
 on:
-  workflow_dispatch:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
@@ -14,37 +13,37 @@ on:
 # Don't forget to tag back to @main before merge.
 
 jobs:
-  # test:
-  #   uses: viamrobotics/rdk/.github/workflows/test.yml@main
-  #   secrets:
-  #     MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
+  test:
+    uses: viamrobotics/rdk/.github/workflows/test.yml@main
+    secrets:
+      MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
 
   appimage:
-    # needs: test
-    uses: ./.github/workflows/appimage.yml
+    needs: test
+    uses: viamrobotics/rdk/.github/workflows/appimage.yml@main
     with:
       release_type: 'rc'
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
-  # staticbuild:
-  #   needs: test
-  #   uses: viamrobotics/rdk/.github/workflows/staticbuild.yml@main
-  #   with:
-  #     release_type: 'rc'
-  #   secrets:
-  #     GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+  staticbuild:
+    needs: test
+    uses: viamrobotics/rdk/.github/workflows/staticbuild.yml@main
+    with:
+      release_type: 'rc'
+    secrets:
+      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
-  # droid:
-  #   needs: test
-  #   uses: viamrobotics/rdk/.github/workflows/droid.yml@main
-  #   with:
-  #     release_type: 'rc'
-  #   secrets:
-  #     GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+  droid:
+    needs: test
+    uses: viamrobotics/rdk/.github/workflows/droid.yml@main
+    with:
+      release_type: 'rc'
+    secrets:
+      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
-  # npm_publish:
-  #   uses: viamrobotics/rdk/.github/workflows/npm-publish.yml@main
-  #   needs: test
-  #   secrets:
-  #     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  npm_publish:
+    uses: viamrobotics/rdk/.github/workflows/npm-publish.yml@main
+    needs: test
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/releasecandidate.yml
+++ b/.github/workflows/releasecandidate.yml
@@ -4,6 +4,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
@@ -13,37 +14,37 @@ on:
 # Don't forget to tag back to @main before merge.
 
 jobs:
-  test:
-    uses: viamrobotics/rdk/.github/workflows/test.yml@main
-    secrets:
-      MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
+  # test:
+  #   uses: viamrobotics/rdk/.github/workflows/test.yml@main
+  #   secrets:
+  #     MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
 
   appimage:
-    needs: test
-    uses: viamrobotics/rdk/.github/workflows/appimage.yml@main
+    # needs: test
+    uses: ./.github/workflows/appimage.yml
     with:
       release_type: 'rc'
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
-  staticbuild:
-    needs: test
-    uses: viamrobotics/rdk/.github/workflows/staticbuild.yml@main
-    with:
-      release_type: 'rc'
-    secrets:
-      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+  # staticbuild:
+  #   needs: test
+  #   uses: viamrobotics/rdk/.github/workflows/staticbuild.yml@main
+  #   with:
+  #     release_type: 'rc'
+  #   secrets:
+  #     GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
-  droid:
-    needs: test
-    uses: viamrobotics/rdk/.github/workflows/droid.yml@main
-    with:
-      release_type: 'rc'
-    secrets:
-      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+  # droid:
+  #   needs: test
+  #   uses: viamrobotics/rdk/.github/workflows/droid.yml@main
+  #   with:
+  #     release_type: 'rc'
+  #   secrets:
+  #     GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
-  npm_publish:
-    uses: viamrobotics/rdk/.github/workflows/npm-publish.yml@main
-    needs: test
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  # npm_publish:
+  #   uses: viamrobotics/rdk/.github/workflows/npm-publish.yml@main
+  #   needs: test
+  #   secrets:
+  #     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/releasecandidate.yml
+++ b/.github/workflows/releasecandidate.yml
@@ -4,10 +4,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
 on:
-  workflow_dispatch:
   push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
 
 # To test workflow updates you need to work in a branch directly on viamrobotics/rdk
 # and tag your working branch instead of @main in any viamrobotics/rdk "uses" below.

--- a/.github/workflows/releasecandidate.yml
+++ b/.github/workflows/releasecandidate.yml
@@ -4,7 +4,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
 on:
+  workflow_dispatch:
   push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
 
 # To test workflow updates you need to work in a branch directly on viamrobotics/rdk
 # and tag your working branch instead of @main in any viamrobotics/rdk "uses" below.


### PR DESCRIPTION
## What changed
Restore 32-bit appimage uploads by reverting f171081d
## Testing
Test run:
- [deploy step](https://github.com/viamrobotics/rdk/actions/runs/6580286212/job/17878197064)
- [links](https://github.com/viamrobotics/rdk/actions/runs/6580286212#summary-17878197064)

These files are indeed in our storage bucket and have the expected executable types:
```sh
$ file viam-server-deploy-appimage-*
viam-server-deploy-appimage-aarch64.AppImage: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 3.7.0, BuildID[sha1]=..., stripped
viam-server-deploy-appimage-armhf.AppImage:   ELF 32-bit LSB pie executable, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-armhf.so.3, for GNU/Linux 3.2.0, BuildID[sha1]=..., stripped
viam-server-deploy-appimage-x86_64.AppImage:  ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=..., for GNU/Linux 2.6.32, stripped
```
## Why this failed before
This is the previous failure: https://github.com/viamrobotics/rdk/actions/runs/6507506375/job/17680520497

I'm guessing it failed because it's a partial rerun (the build is 7:38, the failed upload is 10:09), and the original failure was using a previous, broken version of this.