### PR TITLE
[RSDK-5250] Get the imuvectornav to talk to the SPI bus directly

### DIFF
--- a/components/board/genericlinux/spi.go
+++ b/components/board/genericlinux/spi.go
@@ -17,6 +17,12 @@ import (
 	"go.viam.com/rdk/components/board"
 )
 
+func NewSpiBus(name string) board.SPI {
+	bus = spiBus{}
+	bus.reset(name)
+	return &bus
+}
+
 type spiBus struct {
 	mu         sync.Mutex
 	openHandle *spiHandle

--- a/components/board/genericlinux/spi.go
+++ b/components/board/genericlinux/spi.go
@@ -18,7 +18,7 @@ import (
 )
 
 func NewSpiBus(name string) board.SPI {
-	bus = spiBus{}
+	bus := spiBus{}
 	bus.reset(name)
 	return &bus
 }

--- a/components/board/genericlinux/spi.go
+++ b/components/board/genericlinux/spi.go
@@ -17,6 +17,9 @@ import (
 	"go.viam.com/rdk/components/board"
 )
 
+// NewSpiBus creates a new SPI bus. The name passed in should be the bus number, such as "0" or
+// "1". We don't open this bus until you call spiHandle.Xfer(), so there are no errors to return
+// immediately here.
 func NewSpiBus(name string) board.SPI {
 	bus := spiBus{}
 	bus.reset(name)

--- a/components/movementsensor/imuvectornav/imu.go
+++ b/components/movementsensor/imuvectornav/imu.go
@@ -1,6 +1,6 @@
 //go:build linux
 
-// Package imuvectornav implement vectornav imu
+// Package imuvectornav implements a component for a vectornav IMU.
 package imuvectornav
 
 import (

--- a/components/movementsensor/imuvectornav/imu.go
+++ b/components/movementsensor/imuvectornav/imu.go
@@ -1,4 +1,5 @@
 //go:build linux
+
 // Package imuvectornav implement vectornav imu
 package imuvectornav
 
@@ -122,7 +123,6 @@ func newVectorNav(
 	if err != nil {
 		return nil, err
 	}
-
 
 	speed := *newConf.Speed
 	if speed == 0 {

--- a/components/movementsensor/imuvectornav/imu.go
+++ b/components/movementsensor/imuvectornav/imu.go
@@ -122,21 +122,6 @@ func newVectorNav(
 		return nil, err
 	}
 
-	boardName := newConf.Board
-	b, err := board.FromDependencies(deps, boardName)
-	if err != nil {
-		return nil, errors.Wrap(err, "vectornav init failed")
-	}
-	spiName := newConf.SPI
-	localB, ok := b.(board.LocalBoard)
-	if !ok {
-		return nil, errors.Errorf("vectornav: board %q is not local", boardName)
-	}
-	spiBus, ok := localB.SPIByName(spiName)
-	if !ok {
-		return nil, errors.Errorf("vectornav: couldn't get spi bus %q", spiName)
-	}
-	cs := newConf.CSPin
 
 	speed := *newConf.Speed
 	if speed == 0 {
@@ -146,9 +131,9 @@ func newVectorNav(
 	pfreq := *newConf.Pfreq
 	v := &vectornav{
 		Named:     conf.ResourceName().AsNamed(),
-		bus:       spiBus,
+		bus:       genericlinux.NewSpiBus(newConf.SPI)
 		logger:    logger,
-		cs:        cs,
+		cs:        newConf.CSPin,
 		speed:     speed,
 		busClosed: false,
 		polling:   pfreq,

--- a/components/movementsensor/imuvectornav/imu.go
+++ b/components/movementsensor/imuvectornav/imu.go
@@ -15,6 +15,7 @@ import (
 	goutils "go.viam.com/utils"
 
 	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/genericlinux"
 	"go.viam.com/rdk/components/movementsensor"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/spatialmath"
@@ -131,7 +132,7 @@ func newVectorNav(
 	pfreq := *newConf.Pfreq
 	v := &vectornav{
 		Named:     conf.ResourceName().AsNamed(),
-		bus:       genericlinux.NewSpiBus(newConf.SPI)
+		bus:       genericlinux.NewSpiBus(newConf.SPI),
 		logger:    logger,
 		cs:        newConf.CSPin,
 		speed:     speed,

--- a/components/movementsensor/imuvectornav/imu.go
+++ b/components/movementsensor/imuvectornav/imu.go
@@ -1,3 +1,4 @@
+//go:build linux
 // Package imuvectornav implement vectornav imu
 package imuvectornav
 
@@ -24,7 +25,6 @@ var model = resource.DefaultModelFamily.WithModel("imu-vectornav")
 
 // Config is used for converting a vectornav IMU MovementSensor config attributes.
 type Config struct {
-	Board string `json:"board"`
 	SPI   string `json:"spi"`
 	Speed *int   `json:"spi_baud_rate"`
 	Pfreq *int   `json:"polling_freq_hz"`
@@ -34,10 +34,6 @@ type Config struct {
 // Validate ensures all parts of the config are valid.
 func (cfg *Config) Validate(path string) ([]string, error) {
 	var deps []string
-	if cfg.Board == "" {
-		return nil, goutils.NewConfigValidationFieldRequiredError(path, "board")
-	}
-
 	if cfg.SPI == "" {
 		return nil, goutils.NewConfigValidationFieldRequiredError(path, "spi")
 	}
@@ -53,7 +49,6 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 	if cfg.CSPin == "" {
 		return nil, goutils.NewConfigValidationFieldRequiredError(path, "cs_pin (chip select pin)")
 	}
-	deps = append(deps, cfg.Board)
 	return deps, nil
 }
 

--- a/components/movementsensor/imuvectornav/imu_nonlinux.go
+++ b/components/movementsensor/imuvectornav/imu_nonlinux.go
@@ -1,0 +1,2 @@
+// Package imuvectornav is unimplemented for Macs.
+package imuvectornav


### PR DESCRIPTION
No migration script needed: there are literally no existing configs that use this component. Everything compiles, but I haven't tried this on actual hardware yet. Hopefully @npmenard knows where I can find the hardware to try out...