### PR TITLE
[RSDK-5420] - Handle non positive frequency values for position and obstacle polling

### DIFF
--- a/motionplan/plannerOptions.go
+++ b/motionplan/plannerOptions.go
@@ -60,6 +60,7 @@ const (
 
 var defaultNumThreads = runtime.NumCPU() / 2
 
+// TODO: Make this an enum
 // the set of supported motion profiles.
 const (
 	FreeMotionProfile         = "free"

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -247,6 +247,47 @@ func (ms *builtIn) MoveOnMap(
 	return true, nil
 }
 
+type validatedExtra struct {
+	maxReplans       int
+	replanCostFactor float64
+	motionProfile    string
+	extra            map[string]interface{}
+}
+
+func newValidatedExtra(extra map[string]interface{}) (validatedExtra, error) {
+	maxReplans := -1
+	replanCostFactor := defaultReplanCostFactor
+	motionProfile := ""
+	v := validatedExtra{}
+	if extra == nil {
+		return v, nil
+	}
+	if replansRaw, ok := extra["max_replans"]; ok {
+		if replans, ok := replansRaw.(int); ok {
+			maxReplans = replans
+		}
+	}
+	if profile, ok := extra["motion_profile"]; ok {
+		motionProfile, ok = profile.(string)
+		if !ok {
+			return v, errors.New("could not interpret motion_profile field as string")
+		}
+	}
+	if costFactorRaw, ok := extra["replan_cost_factor"]; ok {
+		costFactor, ok := costFactorRaw.(float64)
+		if !ok {
+			return validatedExtra{}, errors.New("could not interpret replan_cost_factor field as float")
+		}
+		replanCostFactor = costFactor
+	}
+	return validatedExtra{
+		maxReplans:       maxReplans,
+		motionProfile:    motionProfile,
+		replanCostFactor: replanCostFactor,
+		extra:            extra,
+	}, nil
+}
+
 // MoveOnGlobe will move the given component to the given destination on the globe.
 // Bases are the only component that supports this.
 func (ms *builtIn) MoveOnGlobe(
@@ -270,33 +311,17 @@ func (ms *builtIn) MoveOnGlobe(
 		extra,
 	)
 	operation.CancelOtherWithLabel(ctx, builtinOpLabel)
-
-	// ensure arguments are well behaved
-	if motionCfg == nil {
-		motionCfg = &motion.MotionConfiguration{}
-	}
-	if obstacles == nil {
-		obstacles = []*spatialmath.GeoObstacle{}
-	}
-	if destination == nil {
-		return false, errors.New("destination cannot be nil")
-	}
-
-	mr, err := ms.newMoveOnGlobeRequest(ctx, componentName, destination, movementSensorName, obstacles, motionCfg, nil, extra)
+	validatedExtra, err := newValidatedExtra(extra)
 	if err != nil {
 		return false, err
 	}
 
-	maxReplans := -1
-	replanCount := 0
-	if extra != nil {
-		if replansRaw, ok := extra["max_replans"]; ok {
-			if replans, ok := replansRaw.(int); ok {
-				maxReplans = replans
-			}
-		}
+	mr, err := ms.newMoveOnGlobeRequest(ctx, componentName, destination, movementSensorName, obstacles, motionCfg, nil, validatedExtra)
+	if err != nil {
+		return false, err
 	}
 
+	replanCount := 0
 	// start a loop that plans every iteration and exits when something is read from the success channel
 	for {
 		ma := newMoveAttempt(ctx, mr)
@@ -341,14 +366,14 @@ func (ms *builtIn) MoveOnGlobe(
 			ms.logger.Info("obstacle detection triggering a replan")
 		}
 
-		if maxReplans >= 0 {
+		if validatedExtra.maxReplans >= 0 {
 			replanCount++
-			if replanCount > maxReplans {
-				return false, fmt.Errorf("exceeded maximum number of replans: %d", maxReplans)
+			if replanCount > validatedExtra.maxReplans {
+				return false, fmt.Errorf("exceeded maximum number of replans: %d", validatedExtra.maxReplans)
 			}
 		}
 		// TODO: RSDK-4509 obstacles should include any transient obstacles which may have triggered a replan, if any.
-		mr, err = ms.newMoveOnGlobeRequest(ctx, componentName, destination, movementSensorName, obstacles, motionCfg, mr.seedPlan, extra)
+		mr, err = ms.newMoveOnGlobeRequest(ctx, componentName, destination, movementSensorName, obstacles, motionCfg, mr.seedPlan, validatedExtra)
 		if err != nil {
 			return false, err
 		}

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -593,16 +593,417 @@ func TestMoveOnGlobe(t *testing.T) {
 	extra := make(map[string]interface{})
 	extra["motion_profile"] = "position_only"
 	extra["timeout"] = 5.
+	validatedExtra, err := newValidatedExtra(extra)
+	test.That(t, err, test.ShouldBeNil)
 
 	dst := geo.NewPoint(gpsPoint.Lat(), gpsPoint.Lng()+1e-5)
 	expectedDst := r3.Vector{380, 0, 0} // Relative pose to the starting point of the base; facing north, Y = forwards
 	epsilonMM := 15.
 
+	t.Run("returns error when called with an unknown component", func(t *testing.T) {
+		injectedMovementSensor, _, _, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
+		defer ms.Close(ctx)
+		success, err := ms.MoveOnGlobe(
+			ctx,
+			base.Named("non existent base"),
+			geo.NewPoint(0, 0),
+			0,
+			injectedMovementSensor.Name(),
+			nil,
+			nil,
+			nil,
+		)
+		test.That(t, err, test.ShouldBeError, errors.New("resource \"rdk:component:base/non existent base\" not found"))
+		test.That(t, success, test.ShouldBeFalse)
+	})
+
+	t.Run("returns error when called with an unknown movement sensor", func(t *testing.T) {
+		_, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
+		defer ms.Close(ctx)
+		success, err := ms.MoveOnGlobe(
+			ctx,
+			fakeBase.Name(),
+			geo.NewPoint(0, 0),
+			0,
+			movementsensor.Named("non existent movement sensor"),
+			nil,
+			nil,
+			nil,
+		)
+		e := "\"rdk:component:movement_sensor/non existent movement sensor\" missing from dependencies"
+		test.That(t, err, test.ShouldBeError, errors.New(e))
+		test.That(t, success, test.ShouldBeFalse)
+	})
+
+	t.Run("returns error when request would require moving more than 5 km", func(t *testing.T) {
+		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
+		defer ms.Close(ctx)
+		success, err := ms.MoveOnGlobe(
+			ctx,
+			fakeBase.Name(),
+			geo.NewPoint(0, 0),
+			0,
+			injectedMovementSensor.Name(),
+			nil,
+			nil,
+			nil,
+		)
+		test.That(t, err, test.ShouldBeError, errors.New("cannot move more than 5 kilometers"))
+		test.That(t, success, test.ShouldBeFalse)
+	})
+	t.Run("returns error when destination is nil", func(t *testing.T) {
+		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
+		defer ms.Close(ctx)
+		success, err := ms.MoveOnGlobe(
+			ctx,
+			fakeBase.Name(),
+			nil,
+			0,
+			injectedMovementSensor.Name(),
+			nil,
+			nil,
+			nil,
+		)
+		test.That(t, err, test.ShouldBeError, errors.New("destination cannot be nil"))
+		test.That(t, success, test.ShouldBeFalse)
+	})
+
+	t.Run("returns error when destination contains NaN", func(t *testing.T) {
+		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
+		defer ms.Close(ctx)
+		success, err := ms.MoveOnGlobe(
+			ctx,
+			fakeBase.Name(),
+			geo.NewPoint(math.NaN(), 0),
+			0,
+			injectedMovementSensor.Name(),
+			nil,
+			nil,
+			nil,
+		)
+		test.That(t, err, test.ShouldBeError, errors.New("destination may not contain NaN"))
+		test.That(t, success, test.ShouldBeFalse)
+
+		success, err = ms.MoveOnGlobe(
+			ctx,
+			fakeBase.Name(),
+			geo.NewPoint(0, math.NaN()),
+			0,
+			injectedMovementSensor.Name(),
+			nil,
+			nil,
+			nil,
+		)
+		test.That(t, err, test.ShouldBeError, errors.New("destination may not contain NaN"))
+		test.That(t, success, test.ShouldBeFalse)
+
+		success, err = ms.MoveOnGlobe(
+			ctx,
+			fakeBase.Name(),
+			geo.NewPoint(math.NaN(), math.NaN()),
+			0,
+			injectedMovementSensor.Name(),
+			nil,
+			nil,
+			nil,
+		)
+		test.That(t, err, test.ShouldBeError, errors.New("destination may not contain NaN"))
+		test.That(t, success, test.ShouldBeFalse)
+	})
+
+	t.Run("is able to reach a nearby geo point with empty values", func(t *testing.T) {
+		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
+		defer ms.Close(ctx)
+		success, err := ms.MoveOnGlobe(
+			ctx,
+			fakeBase.Name(),
+			dst,
+			0,
+			injectedMovementSensor.Name(),
+			nil,
+			nil,
+			nil,
+		)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, success, test.ShouldBeTrue)
+	})
+
+	t.Run("is able to reach a nearby geo point with a requested NaN heading", func(t *testing.T) {
+		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
+		defer ms.Close(ctx)
+		success, err := ms.MoveOnGlobe(
+			ctx,
+			fakeBase.Name(),
+			dst,
+			math.NaN(),
+			injectedMovementSensor.Name(),
+			nil,
+			nil,
+			nil,
+		)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, success, test.ShouldBeTrue)
+	})
+
+	t.Run("is able to reach a nearby geo point with a requested positive heading", func(t *testing.T) {
+		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
+		defer ms.Close(ctx)
+		success, err := ms.MoveOnGlobe(
+			ctx,
+			fakeBase.Name(),
+			dst,
+			10000000,
+			injectedMovementSensor.Name(),
+			nil,
+			nil,
+			nil,
+		)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, success, test.ShouldBeTrue)
+	})
+
+	t.Run("is able to reach a nearby geo point with a requested negative heading", func(t *testing.T) {
+		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
+		defer ms.Close(ctx)
+		success, err := ms.MoveOnGlobe(
+			ctx,
+			fakeBase.Name(),
+			dst,
+			-10000000,
+			injectedMovementSensor.Name(),
+			nil,
+			nil,
+			nil,
+		)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, success, test.ShouldBeTrue)
+	})
+
+	t.Run("returns an error if the base provided is not a base", func(t *testing.T) {
+		injectedMovementSensor, _, _, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
+		defer ms.Close(ctx)
+		success, err := ms.MoveOnGlobe(
+			ctx,
+			injectedMovementSensor.Name(),
+			dst,
+			90,
+			injectedMovementSensor.Name(),
+			nil,
+			nil,
+			nil,
+		)
+		test.That(t, err, test.ShouldBeError, errors.New("resource \"rdk:component:movement_sensor/test-gps\" not found"))
+		test.That(t, success, test.ShouldBeFalse)
+	})
+
+	t.Run("returns an error if the movement_sensor provided is not a movement_sensor", func(t *testing.T) {
+		_, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
+		defer ms.Close(ctx)
+		success, err := ms.MoveOnGlobe(
+			ctx,
+			fakeBase.Name(),
+			dst,
+			90,
+			fakeBase.Name(),
+			nil,
+			nil,
+			nil,
+		)
+		test.That(t, err, test.ShouldBeError, errors.New("\"rdk:component:base/test-base\" missing from dependencies"))
+		test.That(t, success, test.ShouldBeFalse)
+	})
+
+	t.Run("is able to reach a nearby geo point when the motion configuration is empty", func(t *testing.T) {
+		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
+		defer ms.Close(ctx)
+		success, err := ms.MoveOnGlobe(
+			ctx,
+			fakeBase.Name(),
+			dst,
+			90,
+			injectedMovementSensor.Name(),
+			nil,
+			&motion.MotionConfiguration{},
+			nil,
+		)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, success, test.ShouldBeTrue)
+	})
+
+	t.Run("errors when motion configuration has a negative PlanDeviationMM", func(t *testing.T) {
+		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
+		defer ms.Close(ctx)
+		success, err := ms.MoveOnGlobe(
+			ctx,
+			fakeBase.Name(),
+			dst,
+			90,
+			injectedMovementSensor.Name(),
+			nil,
+			&motion.MotionConfiguration{PlanDeviationMM: -1},
+			nil,
+		)
+		test.That(t, err, test.ShouldBeError, errors.New("PlanDeviationMM may not be negative"))
+		test.That(t, success, test.ShouldBeFalse)
+	})
+
+	t.Run("errors when motion configuration has a NaN PlanDeviationMM", func(t *testing.T) {
+		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
+		defer ms.Close(ctx)
+		success, err := ms.MoveOnGlobe(
+			ctx,
+			fakeBase.Name(),
+			dst,
+			90,
+			injectedMovementSensor.Name(),
+			nil,
+			&motion.MotionConfiguration{PlanDeviationMM: math.NaN()},
+			nil,
+		)
+		test.That(t, err, test.ShouldBeError, errors.New("PlanDeviationMM may not be NaN"))
+		test.That(t, success, test.ShouldBeFalse)
+	})
+
+	t.Run("returns an error when the motion configuration has a negative ObstaclePollingFreqHz", func(t *testing.T) {
+		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
+		defer ms.Close(ctx)
+		success, err := ms.MoveOnGlobe(
+			ctx,
+			fakeBase.Name(),
+			dst,
+			90,
+			injectedMovementSensor.Name(),
+			nil,
+			&motion.MotionConfiguration{ObstaclePollingFreqHz: -1},
+			nil,
+		)
+		test.That(t, err, test.ShouldBeError, errors.New("ObstaclePollingFreqHz may not be negative"))
+		test.That(t, success, test.ShouldBeFalse)
+	})
+
+	t.Run("returns an error when the motion configuration has a NaN ObstaclePollingFreqHz", func(t *testing.T) {
+		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
+		defer ms.Close(ctx)
+		success, err := ms.MoveOnGlobe(
+			ctx,
+			fakeBase.Name(),
+			dst,
+			90,
+			injectedMovementSensor.Name(),
+			nil,
+			&motion.MotionConfiguration{ObstaclePollingFreqHz: math.NaN()},
+			nil,
+		)
+		test.That(t, err, test.ShouldBeError, errors.New("ObstaclePollingFreqHz may not be NaN"))
+		test.That(t, success, test.ShouldBeFalse)
+	})
+
+	t.Run("returns an error when the motion configuration has a negative PositionPollingFreqHz", func(t *testing.T) {
+		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
+		defer ms.Close(ctx)
+		success, err := ms.MoveOnGlobe(
+			ctx,
+			fakeBase.Name(),
+			dst,
+			90,
+			injectedMovementSensor.Name(),
+			nil,
+			&motion.MotionConfiguration{PositionPollingFreqHz: -1},
+			nil,
+		)
+		test.That(t, err, test.ShouldBeError, errors.New("PositionPollingFreqHz may not be negative"))
+		test.That(t, success, test.ShouldBeFalse)
+	})
+
+	t.Run("returns an error when the motion configuration has a NaN PositionPollingFreqHz", func(t *testing.T) {
+		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
+		defer ms.Close(ctx)
+		success, err := ms.MoveOnGlobe(
+			ctx,
+			fakeBase.Name(),
+			dst,
+			90,
+			injectedMovementSensor.Name(),
+			nil,
+			&motion.MotionConfiguration{PositionPollingFreqHz: math.NaN()},
+			nil,
+		)
+		test.That(t, err, test.ShouldBeError, errors.New("PositionPollingFreqHz may not be NaN"))
+		test.That(t, success, test.ShouldBeFalse)
+	})
+
+	t.Run("returns an error when motion configuration has a negative AngularDegsPerSec", func(t *testing.T) {
+		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
+		defer ms.Close(ctx)
+		success, err := ms.MoveOnGlobe(
+			ctx,
+			fakeBase.Name(),
+			dst,
+			90,
+			injectedMovementSensor.Name(),
+			nil,
+			&motion.MotionConfiguration{AngularDegsPerSec: -1},
+			nil,
+		)
+		test.That(t, err, test.ShouldBeError, errors.New("AngularDegsPerSec may not be negative"))
+		test.That(t, success, test.ShouldBeFalse)
+	})
+
+	t.Run("returns an error when motion configuration has a NaN AngularDegsPerSec", func(t *testing.T) {
+		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
+		defer ms.Close(ctx)
+		success, err := ms.MoveOnGlobe(
+			ctx,
+			fakeBase.Name(),
+			dst,
+			90,
+			injectedMovementSensor.Name(),
+			nil,
+			&motion.MotionConfiguration{AngularDegsPerSec: math.NaN()},
+			nil,
+		)
+		test.That(t, err, test.ShouldBeError, errors.New("AngularDegsPerSec may not be NaN"))
+		test.That(t, success, test.ShouldBeFalse)
+	})
+
+	t.Run("returns an error when motion configuration has a negative LinearMPerSec", func(t *testing.T) {
+		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
+		defer ms.Close(ctx)
+		success, err := ms.MoveOnGlobe(
+			ctx,
+			fakeBase.Name(),
+			dst,
+			90,
+			injectedMovementSensor.Name(),
+			nil,
+			&motion.MotionConfiguration{LinearMPerSec: -1},
+			nil,
+		)
+		test.That(t, err, test.ShouldBeError, errors.New("LinearMPerSec may not be negative"))
+		test.That(t, success, test.ShouldBeFalse)
+	})
+
+	t.Run("returns an error when motion configuration has a NaN LinearMPerSec", func(t *testing.T) {
+		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
+		defer ms.Close(ctx)
+		success, err := ms.MoveOnGlobe(
+			ctx,
+			fakeBase.Name(),
+			dst,
+			90,
+			injectedMovementSensor.Name(),
+			nil,
+			&motion.MotionConfiguration{LinearMPerSec: math.NaN()},
+			nil,
+		)
+		test.That(t, err, test.ShouldBeError, errors.New("LinearMPerSec may not be NaN"))
+		test.That(t, success, test.ShouldBeFalse)
+	})
+
 	t.Run("ensure success to a nearby geo point", func(t *testing.T) {
 		t.Parallel()
 		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 		motionCfg := &motion.MotionConfiguration{PositionPollingFreqHz: 4, ObstaclePollingFreqHz: 1, PlanDeviationMM: epsilonMM}
-
 		mr, err := ms.(*builtIn).newMoveOnGlobeRequest(
 			ctx,
 			fakeBase.Name(),
@@ -611,7 +1012,7 @@ func TestMoveOnGlobe(t *testing.T) {
 			[]*spatialmath.GeoObstacle{},
 			motionCfg,
 			nil,
-			extra,
+			validatedExtra,
 		)
 		test.That(t, err, test.ShouldBeNil)
 
@@ -657,7 +1058,7 @@ func TestMoveOnGlobe(t *testing.T) {
 			[]*spatialmath.GeoObstacle{geoObstacle},
 			motionCfg,
 			nil,
-			extra,
+			validatedExtra,
 		)
 		test.That(t, err, test.ShouldBeNil)
 		waypoints, err := mr.plan(ctx)
@@ -715,7 +1116,7 @@ func TestMoveOnGlobe(t *testing.T) {
 			[]*spatialmath.GeoObstacle{geoObstacle},
 			&motion.MotionConfiguration{},
 			nil,
-			extra,
+			validatedExtra,
 		)
 		test.That(t, err, test.ShouldBeNil)
 		plan, err := moveRequest.plan(ctx)
@@ -814,9 +1215,11 @@ func TestCheckPlan(t *testing.T) {
 	injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, originPoint, nil)
 
 	// create motion config
-	motionCfg := make(map[string]interface{})
+	extra := make(map[string]interface{})
 	// fail if we don't find a plan in 15 seconds
-	motionCfg["timeout"] = 15.
+	extra["timeout"] = 15.
+	validatedExtra, err := newValidatedExtra(extra)
+	test.That(t, err, test.ShouldBeNil)
 
 	// get plan and kinematic base
 	moveRequest, err := ms.(*builtIn).newMoveOnGlobeRequest(
@@ -827,7 +1230,7 @@ func TestCheckPlan(t *testing.T) {
 		nil,
 		&motion.MotionConfiguration{PositionPollingFreqHz: 4, ObstaclePollingFreqHz: 1, PlanDeviationMM: 15.},
 		nil,
-		motionCfg,
+		validatedExtra,
 	)
 	test.That(t, err, test.ShouldBeNil)
 

--- a/services/motion/builtin/move_attempt.go
+++ b/services/motion/builtin/move_attempt.go
@@ -52,14 +52,14 @@ func newMoveAttempt(ctx context.Context, request *moveRequest) *moveAttempt {
 
 	// effectively don't poll if the PositionPollingFreqHz is not provided
 	positionPollingFreq := time.Duration(math.MaxInt64)
-	if request.config.PositionPollingFreqHz > 0 {
-		positionPollingFreq = time.Duration(1000/request.config.PositionPollingFreqHz) * time.Millisecond
+	if request.config.positionPollingFreqHz > 0 {
+		positionPollingFreq = time.Duration(1000/request.config.positionPollingFreqHz) * time.Millisecond
 	}
 
 	// effectively don't poll if the ObstaclePollingFreqHz is not provided
 	obstaclePollingFreq := time.Duration(math.MaxInt64)
-	if request.config.ObstaclePollingFreqHz > 0 {
-		obstaclePollingFreq = time.Duration(1000/request.config.ObstaclePollingFreqHz) * time.Millisecond
+	if request.config.obstaclePollingFreqHz > 0 {
+		obstaclePollingFreq = time.Duration(1000/request.config.obstaclePollingFreqHz) * time.Millisecond
 	}
 
 	return &moveAttempt{

--- a/services/motion/builtin/move_attempt.go
+++ b/services/motion/builtin/move_attempt.go
@@ -3,6 +3,7 @@ package builtin
 import (
 	"context"
 	"fmt"
+	"math"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -49,6 +50,18 @@ func newMoveAttempt(ctx context.Context, request *moveRequest) *moveAttempt {
 	var waypointIndex atomic.Int32
 	waypointIndex.Store(1)
 
+	// effectively don't poll if the PositionPollingFreqHz is not provided
+	positionPollingFreq := time.Duration(math.MaxInt64)
+	if request.config.PositionPollingFreqHz > 0 {
+		positionPollingFreq = time.Duration(1000/request.config.PositionPollingFreqHz) * time.Millisecond
+	}
+
+	// effectively don't poll if the ObstaclePollingFreqHz is not provided
+	obstaclePollingFreq := time.Duration(math.MaxInt64)
+	if request.config.ObstaclePollingFreqHz > 0 {
+		obstaclePollingFreq = time.Duration(1000/request.config.ObstaclePollingFreqHz) * time.Millisecond
+	}
+
 	return &moveAttempt{
 		ctx:               cancelCtx,
 		cancelFn:          cancelFn,
@@ -57,8 +70,8 @@ func newMoveAttempt(ctx context.Context, request *moveRequest) *moveAttempt {
 		request:      request,
 		responseChan: make(chan moveResponse),
 
-		position: newReplanner(time.Duration(1000/request.config.PositionPollingFreqHz)*time.Millisecond, request.deviatedFromPlan),
-		obstacle: newReplanner(time.Duration(1000/request.config.ObstaclePollingFreqHz)*time.Millisecond, request.obstaclesIntersectPlan),
+		position: newReplanner(positionPollingFreq, request.deviatedFromPlan),
+		obstacle: newReplanner(obstaclePollingFreq, request.obstaclesIntersectPlan),
 
 		waypointIndex: &waypointIndex,
 	}

--- a/services/motion/motion_test.go
+++ b/services/motion/motion_test.go
@@ -1273,7 +1273,7 @@ func TestMoveOnGlobeReq(t *testing.T) {
 					Destination: &commonpb.GeoPoint{Latitude: 1, Longitude: 2},
 				},
 				result: MoveOnGlobeReq{},
-				err:    errors.New("received nil *commonpb.ResourceName"),
+				err:    errors.New("received nil *commonpb.ResourceName for component name"),
 			},
 			{
 				description: "an empty movement sensor name returns an error",
@@ -1282,7 +1282,7 @@ func TestMoveOnGlobeReq(t *testing.T) {
 					ComponentName: rprotoutils.ResourceNameToProto(mybase),
 				},
 				result: MoveOnGlobeReq{},
-				err:    errors.New("received nil *commonpb.ResourceName"),
+				err:    errors.New("received nil *commonpb.ResourceName for movement sensor name"),
 			},
 			{
 				description: "an empty *pb.MoveOnGlobeNewRequest returns an empty MoveOnGlobeReq",

--- a/services/motion/pbhelpers.go
+++ b/services/motion/pbhelpers.go
@@ -326,13 +326,13 @@ func moveOnGlobeRequestFromProto(req *pb.MoveOnGlobeRequest) (MoveOnGlobeReq, er
 
 	protoComponentName := req.GetComponentName()
 	if protoComponentName == nil {
-		return MoveOnGlobeReq{}, errors.New("received nil *commonpb.ResourceName")
+		return MoveOnGlobeReq{}, errors.New("received nil *commonpb.ResourceName for component name")
 	}
 	componentName := rprotoutils.ResourceNameFromProto(protoComponentName)
 	destination := geo.NewPoint(req.GetDestination().GetLatitude(), req.GetDestination().GetLongitude())
 	protoMovementSensorName := req.GetMovementSensorName()
 	if protoMovementSensorName == nil {
-		return MoveOnGlobeReq{}, errors.New("received nil *commonpb.ResourceName")
+		return MoveOnGlobeReq{}, errors.New("received nil *commonpb.ResourceName for movement sensor name")
 	}
 	movementSensorName := rprotoutils.ResourceNameFromProto(protoMovementSensorName)
 	motionCfg := configurationFromProto(req.MotionConfiguration)


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-5420)

### Goals of this change:
 1. Ensure that all inputs to MoveOnGlobe (other than the `extra` config params being provided to the motion planner package) are within expected ranges & don't contain invalid values such as NaN.
 2. Ensure that if no polling frequencies are provided for replanning pollers, those pollers never execute. This prevents divide by zero issues.

### Changes:
- Change `builtin.newMoveAttempt` to detect if the `PositionPollingFreqHz` and or `ObstaclePollingFreqHz` is 0 & if so, have the corresponding replanners never be scheduled.
-  Add `builtin.ValidatedMotionConfiguration` struct & `builtin.newValidatedMotionCfg` which validates that a `motion.MotionConfig` has valid values & returns either an error if they are invalid, or a  `builtin.ValidatedMotionConfiguration` struct
-  Add `builtin.kbOptionsFromCfg` which converts a `builtin.ValidatedMotionConfiguration`  into `kinematicbase.Options`
- Change `builtin.newMoveOnGlobeRequest` to check if the destination is nil or contains NaNs & return errors if it does.
- Add `builtin.validatedExtra` struct & `builtin.newValidatedExtra` which parses out the `maxReplans`, `replanCostFactor`, and `motionProfile` from the `MoveOnGlobe` `extra` field & ensures it does not contain any values it shouldn't. Returns an error if `extra` is invalid. This consolidates logic which was spread out in the builtin motion service for parsing  & validating the `extra` field
- Change `motoin.moveOnGlobeRequestFromProto` to specify if the nil resource was the component or the movement sensor.