### PR TITLE
[RSDK-5242] make sht3xd talk directly to the I2C bus all the time

### DIFF
--- a/components/sensor/sht3xd/sht3xd.go
+++ b/components/sensor/sht3xd/sht3xd.go
@@ -41,7 +41,7 @@ type Config struct {
 // Validate ensures all parts of the config are valid.
 func (conf *Config) Validate(path string) ([]string, error) {
 	var deps []string
-	if len(conf.I2cBus) == 0 {
+	if conf.I2cBus == "" {
 		return nil, utils.NewConfigValidationFieldRequiredError(path, "i2c_bus")
 	}
 	return deps, nil

--- a/components/sensor/sht3xd/sht3xd.go
+++ b/components/sensor/sht3xd/sht3xd.go
@@ -35,7 +35,7 @@ const (
 // Config is used for converting config attributes.
 type Config struct {
 	Board   string `json:"board,omitempty"`
-	I2CBus  string `json:"i2c_bus"`
+	I2cBus  string `json:"i2c_bus"`
 	I2cAddr int    `json:"i2c_addr,omitempty"`
 }
 
@@ -45,7 +45,7 @@ func (conf *Config) Validate(path string) ([]string, error) {
 	if len(conf.Board) != 0 {
 		deps = append(deps, conf.Board)
 	}
-	if len(conf.I2CBus) == 0 {
+	if len(conf.I2cBus) == 0 {
 		return nil, utils.NewConfigValidationFieldRequiredError(path, "i2c_bus")
 	}
 	return deps, nil
@@ -89,14 +89,14 @@ func newSensor(
 		if !ok {
 			return nil, fmt.Errorf("board %s is not local", conf.Board)
 		}
-		i2cbus, ok = localB.I2CByName(conf.I2CBus)
+		i2cbus, ok = localB.I2CByName(conf.I2cBus)
 		if !ok {
-			return nil, fmt.Errorf("sht3xd init: failed to find i2c bus %s", conf.I2CBus)
+			return nil, fmt.Errorf("sht3xd init: failed to find i2c bus %s", conf.I2cBus)
 		}
 	} else {
-		i2cbus, err = genericlinux.NewI2cBus(conf.I2CBus)
+		i2cbus, err = genericlinux.NewI2cBus(conf.I2cBus)
 		if err != nil {
-			return nil, fmt.Errorf("sht3xd init: failed to find i2c bus %s", conf.I2CBus)
+			return nil, fmt.Errorf("sht3xd init: failed to find i2c bus %s", conf.I2cBus)
 		}
 	}
 	addr := conf.I2cAddr

--- a/components/sensor/sht3xd/sht3xd.go
+++ b/components/sensor/sht3xd/sht3xd.go
@@ -69,7 +69,7 @@ func init() {
 
 func newSensor(
 	ctx context.Context,
-	deps resource.Dependencies,
+	_ resource.Dependencies,
 	name resource.Name,
 	conf *Config,
 	logger golog.Logger,

--- a/components/sensor/sht3xd/sht3xd_nonlinux.go
+++ b/components/sensor/sht3xd/sht3xd_nonlinux.go
@@ -1,2 +1,2 @@
-// Package sht3xd This is blank for non linux
+// Package sht3xd is only supported on Linux machines.
 package sht3xd


### PR DESCRIPTION
It could optionally do that before, but this change removes the choice of going through the board to do it. I don't yet have one of these sensors so haven't tried this on real hardware, but everything compiles, and I think it's a straightforward change. Peter has these sensors and could try it out, or I ought to get one of them this coming week and can try it out then.

There are 3 pre-existing configs that use this component. Two of them have not been online since April, and one hasn't been online since July. The first two look to be 2 identical(?) copies of a BeeRing prototype, and the third claims to be a Mac running a fake board and missing some required fields, so I don't see how that could ever have worked to begin with. @biotinker, you know BeeRing folks; can you let them know about this when the time comes?

I'm tagging Olivia for a review from my team, and Peter because he wrote the original version.