### PR TITLE
RSDK-2493 remove session stop deadline from test

### DIFF
--- a/robot/session_test.go
+++ b/robot/session_test.go
@@ -210,16 +210,9 @@ func TestSessions(t *testing.T) {
 			t.Log("set power of motor1 which will be safety monitored")
 			test.That(t, motor1.SetPower(ctx, 50, nil), test.ShouldBeNil)
 
-			startAt := time.Now()
 			test.That(t, roboClient.Close(ctx), test.ShouldBeNil)
 
 			ensureStop(t, "motor1", stopChNames)
-
-			test.That(t,
-				time.Since(startAt),
-				test.ShouldBeGreaterThanOrEqualTo,
-				float64(windowSize)*.75,
-			)
 
 			dummyMotor1.mu.Lock()
 			stopChs["motor1"].Chan = make(chan struct{})
@@ -245,19 +238,12 @@ func TestSessions(t *testing.T) {
 			_, err = echoMultiClient.Recv() // EOF; okay
 			test.That(t, err, test.ShouldBeError, io.EOF)
 
-			startAt = time.Now()
 			test.That(t, roboClient.Close(ctx), test.ShouldBeNil)
 
 			checkAgainst := []string{"motor1"}
 			ensureStop(t, "motor2", checkAgainst)
 			ensureStop(t, "echo1", checkAgainst)
 			ensureStop(t, "base1", checkAgainst)
-
-			test.That(t,
-				time.Since(startAt),
-				test.ShouldBeGreaterThanOrEqualTo,
-				float64(windowSize)*.75,
-			)
 
 			test.That(t, roboClient.Close(ctx), test.ShouldBeNil)
 
@@ -464,15 +450,9 @@ func TestSessionsWithRemote(t *testing.T) {
 	t.Log("set power of rem1:motor1 which will be safety monitored")
 	test.That(t, motor1.SetPower(ctx, 50, nil), test.ShouldBeNil)
 
-	startAt := time.Now()
 	test.That(t, roboClient.Close(ctx), test.ShouldBeNil)
 
 	ensureStop(t, "remMotor1", stopChNames)
-	test.That(t,
-		time.Since(startAt),
-		test.ShouldBeGreaterThanOrEqualTo,
-		float64(config.DefaultSessionHeartbeatWindow)*.5,
-	)
 
 	dummyRemMotor1.mu.Lock()
 	stopChs["remMotor1"].Chan = make(chan struct{})
@@ -490,16 +470,9 @@ func TestSessionsWithRemote(t *testing.T) {
 	t.Log("set power of rem1:motor1 which will be safety monitored")
 	test.That(t, motor1.SetPower(ctx, 50, nil), test.ShouldBeNil)
 
-	startAt = time.Now()
 	test.That(t, r.Close(ctx), test.ShouldBeNil)
 
 	ensureStop(t, "remMotor1", stopChNames)
-
-	test.That(t,
-		time.Since(startAt),
-		test.ShouldBeGreaterThanOrEqualTo,
-		float64(config.DefaultSessionHeartbeatWindow)*.5,
-	)
 
 	test.That(t, roboClient.Close(ctx), test.ShouldBeNil)
 
@@ -545,19 +518,12 @@ func TestSessionsWithRemote(t *testing.T) {
 	_, err = echoMultiClient.Recv() // EOF; okay
 	test.That(t, err, test.ShouldBeError, io.EOF)
 
-	startAt = time.Now()
 	test.That(t, roboClient.Close(ctx), test.ShouldBeNil)
 
 	checkAgainst := []string{"remMotor1", "motor1", "base1"}
 	ensureStop(t, "remMotor2", checkAgainst)
 	ensureStop(t, "remBase1", checkAgainst)
 	ensureStop(t, "remEcho1", checkAgainst)
-
-	test.That(t,
-		time.Since(startAt),
-		test.ShouldBeGreaterThanOrEqualTo,
-		float64(config.DefaultSessionHeartbeatWindow)*.5,
-	)
 
 	test.That(t, roboClient.Close(ctx), test.ShouldBeNil)
 
@@ -633,7 +599,6 @@ func TestSessionsMixedClients(t *testing.T) {
 		timer.Stop()
 	}
 
-	startAt := time.Now()
 	test.That(t, roboClient2.Close(ctx), test.ShouldBeNil)
 
 	select {
@@ -643,12 +608,6 @@ func TestSessionsMixedClients(t *testing.T) {
 	}
 
 	<-stopChMotor1
-
-	test.That(t,
-		time.Since(startAt),
-		test.ShouldBeGreaterThanOrEqualTo,
-		float64(config.DefaultSessionHeartbeatWindow)*.75,
-	)
 
 	test.That(t, r.Close(ctx), test.ShouldBeNil)
 }
@@ -731,7 +690,6 @@ func TestSessionsMixedOwnersNoAuth(t *testing.T) {
 	test.That(t, resp.Id, test.ShouldEqual, sessID)
 
 	// this is the only one heartbeating so we expect a stop
-	startAt := time.Now()
 	test.That(t, roboClient1.Close(ctx), test.ShouldBeNil)
 
 	select {
@@ -741,12 +699,6 @@ func TestSessionsMixedOwnersNoAuth(t *testing.T) {
 	}
 
 	<-stopChMotor1
-
-	test.That(t,
-		time.Since(startAt),
-		test.ShouldBeGreaterThanOrEqualTo,
-		float64(config.DefaultSessionHeartbeatWindow)*.75,
-	)
 
 	test.That(t, roboClientConn2.Close(), test.ShouldBeNil)
 	test.That(t, r.Close(ctx), test.ShouldBeNil)
@@ -835,7 +787,6 @@ func TestSessionsMixedOwnersImplicitAuth(t *testing.T) {
 	test.That(t, resp.Id, test.ShouldNotEqual, "")
 
 	// this is the only one heartbeating so we expect a stop
-	startAt := time.Now()
 	test.That(t, roboClient1.Close(ctx), test.ShouldBeNil)
 
 	select {
@@ -845,12 +796,6 @@ func TestSessionsMixedOwnersImplicitAuth(t *testing.T) {
 	}
 
 	<-stopChMotor1
-
-	test.That(t,
-		time.Since(startAt),
-		test.ShouldBeGreaterThanOrEqualTo,
-		float64(config.DefaultSessionHeartbeatWindow)*.75,
-	)
 
 	test.That(t, roboClientConn2.Close(), test.ShouldBeNil)
 	test.That(t, r.Close(ctx), test.ShouldBeNil)

--- a/robot/session_test.go
+++ b/robot/session_test.go
@@ -59,6 +59,12 @@ func init() {
 	})
 }
 
+// TODO(NEED TICKET): This test suite checks if stopping a client also stops any
+// components that were started by that client. We also should implement a benchmark
+// suite that measures how long it takes for components to stop.
+//
+// We should NOT add a strict deadline to this test - we had that before and it resulted
+// in flaky tests (see RSDK-2493).
 func TestSessions(t *testing.T) {
 	for _, windowSize := range []time.Duration{
 		config.DefaultSessionHeartbeatWindow,
@@ -211,9 +217,8 @@ func TestSessions(t *testing.T) {
 
 			test.That(t,
 				time.Since(startAt),
-				test.ShouldBeBetweenOrEqual,
+				test.ShouldBeGreaterThanOrEqualTo,
 				float64(windowSize)*.75,
-				float64(windowSize)*1.5,
 			)
 
 			dummyMotor1.mu.Lock()
@@ -250,9 +255,8 @@ func TestSessions(t *testing.T) {
 
 			test.That(t,
 				time.Since(startAt),
-				test.ShouldBeBetweenOrEqual,
+				test.ShouldBeGreaterThanOrEqualTo,
 				float64(windowSize)*.75,
-				float64(windowSize)*1.5,
 			)
 
 			test.That(t, roboClient.Close(ctx), test.ShouldBeNil)
@@ -466,9 +470,8 @@ func TestSessionsWithRemote(t *testing.T) {
 	ensureStop(t, "remMotor1", stopChNames)
 	test.That(t,
 		time.Since(startAt),
-		test.ShouldBeBetweenOrEqual,
+		test.ShouldBeGreaterThanOrEqualTo,
 		float64(config.DefaultSessionHeartbeatWindow)*.5,
-		float64(config.DefaultSessionHeartbeatWindow)*2.5,
 	)
 
 	dummyRemMotor1.mu.Lock()
@@ -494,9 +497,8 @@ func TestSessionsWithRemote(t *testing.T) {
 
 	test.That(t,
 		time.Since(startAt),
-		test.ShouldBeBetweenOrEqual,
+		test.ShouldBeGreaterThanOrEqualTo,
 		float64(config.DefaultSessionHeartbeatWindow)*.5,
-		float64(config.DefaultSessionHeartbeatWindow)*2.5,
 	)
 
 	test.That(t, roboClient.Close(ctx), test.ShouldBeNil)
@@ -553,9 +555,8 @@ func TestSessionsWithRemote(t *testing.T) {
 
 	test.That(t,
 		time.Since(startAt),
-		test.ShouldBeBetweenOrEqual,
+		test.ShouldBeGreaterThanOrEqualTo,
 		float64(config.DefaultSessionHeartbeatWindow)*.5,
-		float64(config.DefaultSessionHeartbeatWindow)*2.5,
 	)
 
 	test.That(t, roboClient.Close(ctx), test.ShouldBeNil)
@@ -645,9 +646,8 @@ func TestSessionsMixedClients(t *testing.T) {
 
 	test.That(t,
 		time.Since(startAt),
-		test.ShouldBeBetweenOrEqual,
+		test.ShouldBeGreaterThanOrEqualTo,
 		float64(config.DefaultSessionHeartbeatWindow)*.75,
-		float64(config.DefaultSessionHeartbeatWindow)*1.5,
 	)
 
 	test.That(t, r.Close(ctx), test.ShouldBeNil)
@@ -744,9 +744,8 @@ func TestSessionsMixedOwnersNoAuth(t *testing.T) {
 
 	test.That(t,
 		time.Since(startAt),
-		test.ShouldBeBetweenOrEqual,
+		test.ShouldBeGreaterThanOrEqualTo,
 		float64(config.DefaultSessionHeartbeatWindow)*.75,
-		float64(config.DefaultSessionHeartbeatWindow)*1.5,
 	)
 
 	test.That(t, roboClientConn2.Close(), test.ShouldBeNil)
@@ -849,9 +848,8 @@ func TestSessionsMixedOwnersImplicitAuth(t *testing.T) {
 
 	test.That(t,
 		time.Since(startAt),
-		test.ShouldBeBetweenOrEqual,
+		test.ShouldBeGreaterThanOrEqualTo,
 		float64(config.DefaultSessionHeartbeatWindow)*.75,
-		float64(config.DefaultSessionHeartbeatWindow)*1.5,
 	)
 
 	test.That(t, roboClientConn2.Close(), test.ShouldBeNil)

--- a/robot/session_test.go
+++ b/robot/session_test.go
@@ -59,7 +59,7 @@ func init() {
 	})
 }
 
-// TODO(NEED TICKET): This test suite checks if stopping a client also stops any
+// TODO(RSDK-5435): This test suite checks if stopping a client also stops any
 // components that were started by that client. We also should implement a benchmark
 // suite that measures how long it takes for components to stop.
 //


### PR DESCRIPTION
Remove the stop deadline checks from sessions tests since it causes flakes. Also remove stop delay checks since it doesn't seem necessary.

Qs:
* [x] It seems like we should replace the deadlines with a [benchmark](https://pkg.go.dev/testing#hdr-Benchmarks) - any alternatives?
* [x] Do we need the [minimum stop delay check](https://github.com/viamrobotics/rdk/pull/3117/commits/66dc02786f7da83862ea39876488786ac136410a) in these tests?