### PR TITLE
RSDK-3514: parametrize gantry testlimit timeout 

### DIFF
--- a/components/gantry/singleaxis/singleaxis.go
+++ b/components/gantry/singleaxis/singleaxis.go
@@ -453,7 +453,11 @@ func (g *singleAxis) testLimit(ctx context.Context, pin int) (float64, error) {
 		}
 
 		elapsed := start.Sub(start)
-		if elapsed > (time.Second * 15) {
+		timeout := 15.0
+		if g.mmPerRevolution != 0 && g.rpm != 0 && g.lengthMm != 0 {
+			timeout = 1 / (g.rpm / 60.0 * g.mmPerRevolution / g.lengthMm) * 1.1
+		}
+		if elapsed > (time.Duration(timeout)) {
 			return 0, errors.New("gantry timed out testing limit")
 		}
 

--- a/components/gantry/singleaxis/singleaxis.go
+++ b/components/gantry/singleaxis/singleaxis.go
@@ -421,10 +421,13 @@ func (g *singleAxis) testLimit(ctx context.Context, pin int) (float64, error) {
 		wrongPin = 0
 	}
 
+	g.logger.Warnf("wrong pin = %v", wrongPin)
+
 	err := g.motor.GoFor(ctx, d*g.rpm, 0, nil)
 	if err != nil {
 		return 0, err
 	}
+	time.Sleep(250 * time.Millisecond)
 
 	start := time.Now()
 	for {
@@ -473,6 +476,7 @@ func (g *singleAxis) testLimit(ctx context.Context, pin int) (float64, error) {
 	// Short pause after stopping to increase the precision of the position of each limit switch
 	position, err := g.motor.Position(ctx, nil)
 	time.Sleep(250 * time.Millisecond)
+	g.logger.Warnf("RETURNING: %v, %v", position, err)
 	return position, err
 }
 

--- a/components/gantry/singleaxis/singleaxis_test.go
+++ b/components/gantry/singleaxis/singleaxis_test.go
@@ -546,6 +546,39 @@ func TestTestLimit(t *testing.T) {
 	test.That(t, pos, test.ShouldEqual, float64(1))
 }
 
+func TestTestLimitTimeout(t *testing.T) {
+	ctx := context.Background()
+	fakegantry := &singleAxis{
+		limitSwitchPins: []string{"1", "2"},
+		motor:           createFakeMotor(),
+		board:           createLimitBoard(),
+		rpm:             float64(30),
+		limitHigh:       true,
+		opMgr:           operation.NewSingleOperationManager(),
+		mmPerRevolution: 10,
+		lengthMm:        100,
+	}
+
+	injectGPIOPin := &inject.GPIOPin{}
+	injectGPIOPin.GetFunc = func(ctx context.Context, extra map[string]interface{}) (bool, error) {
+		return false, nil
+	}
+	injectGPIOPinGood := &inject.GPIOPin{}
+	injectGPIOPinGood.GetFunc = func(ctx context.Context, extra map[string]interface{}) (bool, error) {
+		return false, nil
+	}
+
+	fakegantry.board = &inject.Board{
+		GPIOPinByNameFunc: func(pin string) (board.GPIOPin, error) {
+			return injectGPIOPin, nil
+		},
+	}
+
+	pos, err := fakegantry.testLimit(ctx, 0)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, pos, test.ShouldEqual, float64(1))
+}
+
 func TestLimitHit(t *testing.T) {
 	ctx := context.Background()
 	fakegantry := &singleAxis{

--- a/components/gantry/singleaxis/singleaxis_test.go
+++ b/components/gantry/singleaxis/singleaxis_test.go
@@ -571,7 +571,7 @@ func TestTestLimitTimeout(t *testing.T) {
 	}
 
 	pos, err := fakegantry.testLimit(ctx, 0)
-	test.That(t, err.Error(), test.ShouldContainSubstring, "gantry timed out testing limit")
+	test.That(t, err.Error(), test.ShouldContainSubstring, "timeout = 2.2s")
 	test.That(t, pos, test.ShouldEqual, 0.0)
 }
 

--- a/components/gantry/singleaxis/singleaxis_test.go
+++ b/components/gantry/singleaxis/singleaxis_test.go
@@ -552,7 +552,7 @@ func TestTestLimitTimeout(t *testing.T) {
 		limitSwitchPins: []string{"1", "2"},
 		motor:           createFakeMotor(),
 		board:           createLimitBoard(),
-		rpm:             float64(300),
+		rpm:             float64(3000),
 		limitHigh:       true,
 		opMgr:           operation.NewSingleOperationManager(),
 		mmPerRevolution: 10,
@@ -571,7 +571,7 @@ func TestTestLimitTimeout(t *testing.T) {
 	}
 
 	pos, err := fakegantry.testLimit(ctx, 0)
-	test.That(t, err.Error(), test.ShouldContainSubstring, "timeout = 2.2s")
+	test.That(t, err.Error(), test.ShouldContainSubstring, "timeout = 1s")
 	test.That(t, pos, test.ShouldEqual, 0.0)
 }
 

--- a/components/gantry/singleaxis/singleaxis_test.go
+++ b/components/gantry/singleaxis/singleaxis_test.go
@@ -552,7 +552,7 @@ func TestTestLimitTimeout(t *testing.T) {
 		limitSwitchPins: []string{"1", "2"},
 		motor:           createFakeMotor(),
 		board:           createLimitBoard(),
-		rpm:             float64(30),
+		rpm:             float64(300),
 		limitHigh:       true,
 		opMgr:           operation.NewSingleOperationManager(),
 		mmPerRevolution: 10,
@@ -571,8 +571,8 @@ func TestTestLimitTimeout(t *testing.T) {
 	}
 
 	pos, err := fakegantry.testLimit(ctx, 0)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, pos, test.ShouldEqual, float64(1))
+	test.That(t, err.Error(), test.ShouldContainSubstring, "gantry timed out testing limit")
+	test.That(t, pos, test.ShouldEqual, 0.0)
 }
 
 func TestLimitHit(t *testing.T) {

--- a/components/gantry/singleaxis/singleaxis_test.go
+++ b/components/gantry/singleaxis/singleaxis_test.go
@@ -563,10 +563,6 @@ func TestTestLimitTimeout(t *testing.T) {
 	injectGPIOPin.GetFunc = func(ctx context.Context, extra map[string]interface{}) (bool, error) {
 		return false, nil
 	}
-	injectGPIOPinGood := &inject.GPIOPin{}
-	injectGPIOPinGood.GetFunc = func(ctx context.Context, extra map[string]interface{}) (bool, error) {
-		return false, nil
-	}
 
 	fakegantry.board = &inject.Board{
 		GPIOPinByNameFunc: func(pin string) (board.GPIOPin, error) {


### PR DESCRIPTION
This PR parametrizes gantry testlimit timeout based on `mm_per_rev`, `rpm`, and `length_mm`