### PR TITLE
skip TestCheckPlan

### DIFF
--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -801,6 +801,7 @@ func TestReplanning(t *testing.T) {
 }
 
 func TestCheckPlan(t *testing.T) {
+	t.Skip() // TODO(RSDK-5404): fix flakiness
 	ctx := context.Background()
 	logger := golog.NewTestLogger(t)
 


### PR DESCRIPTION
We add `t.Skip` to `TestCheckPlan` to resolve test failures in CI.
The final fix for the flaky test will be covered in RSDK-5404.