### PR TITLE
RSDK-5403 fix flaky test TestReachOverArm

### DIFF
--- a/motionplan/motionPlanner_test.go
+++ b/motionplan/motionPlanner_test.go
@@ -479,7 +479,6 @@ func TestMultiArmSolve(t *testing.T) {
 }
 
 func TestReachOverArm(t *testing.T) {
-	t.Parallel()
 	// setup frame system with an xarm
 	xarm, err := frame.ParseModelJSONFile(utils.ResolveFile("components/arm/xarm/xarm6_kinematics.json"), "")
 	test.That(t, err, test.ShouldBeNil)


### PR DESCRIPTION
The root of the problem here is believed to be that we are attempting to run this resource intensive plan at a time when the CPU of the CI machine is very busy.  If we remove the `t.Parallel` call this won't be run at the same time as other difficult motion tests and therefore should un-flake the test.  