### PR TITLE
[RSDK-5449] Remove public helper from power sensor, and change name in movement s…

### DIFF
--- a/components/movementsensor/adxl345/adxl345.go
+++ b/components/movementsensor/adxl345/adxl345.go
@@ -535,7 +535,7 @@ func (adxl *adxl345) Accuracy(ctx context.Context, extra map[string]interface{})
 }
 
 func (adxl *adxl345) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
-	readings, err := movementsensor.Readings(ctx, adxl, extra)
+	readings, err := movementsensor.DefaultAPIReadings(ctx, adxl, extra)
 	if err != nil {
 		return nil, err
 	}

--- a/components/movementsensor/fake/movementsensor.go
+++ b/components/movementsensor/fake/movementsensor.go
@@ -86,7 +86,7 @@ func (f *MovementSensor) Accuracy(ctx context.Context, extra map[string]interfac
 
 // Readings gets the readings of a fake movementsensor.
 func (f *MovementSensor) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
-	return movementsensor.Readings(ctx, f, extra)
+	return movementsensor.DefaultAPIReadings(ctx, f, extra)
 }
 
 // Properties returns the properties of a fake movementsensor.

--- a/components/movementsensor/gpsnmea/pmtkI2C.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C.go
@@ -314,7 +314,7 @@ func (g *PmtkI2CNMEAMovementSensor) ReadSatsInView(ctx context.Context) (int, er
 
 // Readings will use return all of the MovementSensor Readings.
 func (g *PmtkI2CNMEAMovementSensor) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
-	readings, err := movementsensor.Readings(ctx, g, extra)
+	readings, err := movementsensor.DefaultAPIReadings(ctx, g, extra)
 	if err != nil {
 		return nil, err
 	}

--- a/components/movementsensor/gpsnmea/serial.go
+++ b/components/movementsensor/gpsnmea/serial.go
@@ -250,7 +250,7 @@ func (g *SerialNMEAMovementSensor) ReadSatsInView(ctx context.Context) (int, err
 
 // Readings will use return all of the MovementSensor Readings.
 func (g *SerialNMEAMovementSensor) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
-	readings, err := movementsensor.Readings(ctx, g, extra)
+	readings, err := movementsensor.DefaultAPIReadings(ctx, g, extra)
 	if err != nil {
 		return nil, err
 	}

--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
@@ -643,7 +643,7 @@ func (g *rtkI2C) Accuracy(ctx context.Context, extra map[string]interface{}) (ma
 
 // Readings will use the default MovementSensor Readings if not provided.
 func (g *rtkI2C) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
-	readings, err := movementsensor.Readings(ctx, g, extra)
+	readings, err := movementsensor.DefaultAPIReadings(ctx, g, extra)
 	if err != nil {
 		return nil, err
 	}

--- a/components/movementsensor/gpsrtkserial/gpsrtkserial.go
+++ b/components/movementsensor/gpsrtkserial/gpsrtkserial.go
@@ -599,7 +599,7 @@ func (g *rtkSerial) Accuracy(ctx context.Context, extra map[string]interface{}) 
 
 // Readings will use the default MovementSensor Readings if not provided.
 func (g *rtkSerial) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
-	readings, err := movementsensor.Readings(ctx, g, extra)
+	readings, err := movementsensor.DefaultAPIReadings(ctx, g, extra)
 	if err != nil {
 		return nil, err
 	}

--- a/components/movementsensor/imuvectornav/imu.go
+++ b/components/movementsensor/imuvectornav/imu.go
@@ -299,7 +299,7 @@ func (vn *vectornav) Properties(ctx context.Context, extra map[string]interface{
 }
 
 func (vn *vectornav) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
-	return movementsensor.Readings(ctx, vn, extra)
+	return movementsensor.DefaultAPIReadings(ctx, vn, extra)
 }
 
 func (vn *vectornav) getReadings(ctx context.Context) error {

--- a/components/movementsensor/imuwit/imu.go
+++ b/components/movementsensor/imuwit/imu.go
@@ -183,7 +183,7 @@ func (imu *wit) Accuracy(ctx context.Context, extra map[string]interface{}) (map
 }
 
 func (imu *wit) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
-	readings, err := movementsensor.Readings(ctx, imu, extra)
+	readings, err := movementsensor.DefaultAPIReadings(ctx, imu, extra)
 	if err != nil {
 		return nil, err
 	}

--- a/components/movementsensor/merged/merged.go
+++ b/components/movementsensor/merged/merged.go
@@ -363,7 +363,7 @@ func (m *merged) Properties(ctx context.Context, extra map[string]interface{}) (
 func (m *merged) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
 	// we're already in lock in this driver
 	// don't lock the mutex again for the Readings call
-	return movementsensor.Readings(ctx, m, extra)
+	return movementsensor.DefaultAPIReadings(ctx, m, extra)
 }
 
 func (m *merged) Close(context.Context) error {

--- a/components/movementsensor/movementsensor.go
+++ b/components/movementsensor/movementsensor.go
@@ -102,8 +102,8 @@ func NamesFromRobot(r robot.Robot) []string {
 	return robot.NamesByAPI(r, API)
 }
 
-// Readings is a helper for getting all readings from a MovementSensor.
-func Readings(ctx context.Context, g MovementSensor, extra map[string]interface{}) (map[string]interface{}, error) {
+// DefaultAPIReadings is a helper for getting all readings from a MovementSensor.
+func DefaultAPIReadings(ctx context.Context, g MovementSensor, extra map[string]interface{}) (map[string]interface{}, error) {
 	readings := map[string]interface{}{}
 
 	pos, altitude, err := g.Position(ctx, extra)

--- a/components/movementsensor/replay/replay.go
+++ b/components/movementsensor/replay/replay.go
@@ -359,7 +359,7 @@ func (replay *replayMovementSensor) Close(ctx context.Context) error {
 
 // Readings returns all available data from the next entry stored in the cache.
 func (replay *replayMovementSensor) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
-	return movementsensor.Readings(ctx, replay, extra)
+	return movementsensor.DefaultAPIReadings(ctx, replay, extra)
 }
 
 // Reconfigure finishes the bring up of the replay movement sensor by evaluating given arguments and setting up the required cloud

--- a/components/movementsensor/rtkutils/gpsrtk.go
+++ b/components/movementsensor/rtkutils/gpsrtk.go
@@ -232,7 +232,7 @@ func (g *RTKMovementSensor) Accuracy(ctx context.Context, extra map[string]inter
 
 // Readings will use the default MovementSensor Readings if not provided.
 func (g *RTKMovementSensor) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
-	readings, err := movementsensor.Readings(ctx, g, extra)
+	readings, err := movementsensor.DefaultAPIReadings(ctx, g, extra)
 	if err != nil {
 		return nil, err
 	}

--- a/components/movementsensor/wheeledodometry/wheeledodometry.go
+++ b/components/movementsensor/wheeledodometry/wheeledodometry.go
@@ -268,7 +268,7 @@ func (o *odometry) Position(ctx context.Context, extra map[string]interface{}) (
 }
 
 func (o *odometry) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
-	readings, err := movementsensor.Readings(ctx, o, extra)
+	readings, err := movementsensor.DefaultAPIReadings(ctx, o, extra)
 	if err != nil {
 		return nil, err
 	}

--- a/components/powersensor/fake/powersensor.go
+++ b/components/powersensor/fake/powersensor.go
@@ -63,41 +63,29 @@ func (f *PowerSensor) Power(ctx context.Context, cmd map[string]interface{}) (fl
 
 // Readings gets the readings of a fake powersensor.
 func (f *PowerSensor) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
-	return defaultAPIReadings(ctx, *f, extra)
+	volts, isAC, err := f.Voltage(ctx, nil)
+	if err != nil {
+		f.logger.Errorf("failed to get voltage reading: %s", err.Error())
+	}
+
+	amps, _, err := f.Current(ctx, nil)
+	if err != nil {
+		f.logger.Errorf("failed to get current reading: %s", err.Error())
+	}
+
+	watts, err := f.Power(ctx, nil)
+	if err != nil {
+		f.logger.Errorf("failed to get power reading: %s", err.Error())
+	}
+	return map[string]interface{}{
+		"volts": volts,
+		"amps":  amps,
+		"is_ac": isAC,
+		"watts": watts,
+	}, nil
 }
 
 // Close closes the fake powersensor.
 func (f *PowerSensor) Close(ctx context.Context) error {
 	return nil
-}
-
-// DefaultAPIReadings is a helper for getting all readings from a PowerSensor.
-func defaultAPIReadings(ctx context.Context, g PowerSensor, extra map[string]interface{}) (map[string]interface{}, error) {
-	readings := map[string]interface{}{}
-
-	vol, isAC, err := g.Voltage(ctx, extra)
-	if err != nil {
-		return nil, err
-	} else {
-		readings["voltage"] = vol
-		readings["is_ac"] = isAC
-	}
-
-	cur, isAC, err := g.Current(ctx, extra)
-	if err != nil {
-		return nil, err
-	} else {
-		readings["current"] = cur
-		readings["is_ac"] = isAC
-	}
-
-	pow, err := g.Power(ctx, extra)
-	if err != nil {
-		return nil, err
-
-	} else {
-		readings["power"] = pow
-	}
-
-	return readings, nil
 }

--- a/components/powersensor/fake/powersensor.go
+++ b/components/powersensor/fake/powersensor.go
@@ -3,7 +3,6 @@ package fake
 
 import (
 	"context"
-	"strings"
 
 	"github.com/edaniels/golog"
 
@@ -78,9 +77,7 @@ func defaultAPIReadings(ctx context.Context, g PowerSensor, extra map[string]int
 
 	vol, isAC, err := g.Voltage(ctx, extra)
 	if err != nil {
-		if !strings.Contains(err.Error(), powersensor.ErrMethodUnimplementedVoltage.Error()) {
-			return nil, err
-		}
+		return nil, err
 	} else {
 		readings["voltage"] = vol
 		readings["is_ac"] = isAC
@@ -88,9 +85,7 @@ func defaultAPIReadings(ctx context.Context, g PowerSensor, extra map[string]int
 
 	cur, isAC, err := g.Current(ctx, extra)
 	if err != nil {
-		if !strings.Contains(err.Error(), powersensor.ErrMethodUnimplementedCurrent.Error()) {
-			return nil, err
-		}
+		return nil, err
 	} else {
 		readings["current"] = cur
 		readings["is_ac"] = isAC
@@ -98,9 +93,8 @@ func defaultAPIReadings(ctx context.Context, g PowerSensor, extra map[string]int
 
 	pow, err := g.Power(ctx, extra)
 	if err != nil {
-		if !strings.Contains(err.Error(), powersensor.ErrMethodUnimplementedPower.Error()) {
-			return nil, err
-		}
+		return nil, err
+
 	} else {
 		readings["power"] = pow
 	}

--- a/components/powersensor/powersensor.go
+++ b/components/powersensor/powersensor.go
@@ -3,7 +3,6 @@ package powersensor
 
 import (
 	"context"
-	"strings"
 
 	pb "go.viam.com/api/component/powersensor/v1"
 
@@ -90,40 +89,4 @@ func FromRobot(r robot.Robot, name string) (PowerSensor, error) {
 // NamesFromRobot is a helper for getting all PowerSensor names from the given Robot.
 func NamesFromRobot(r robot.Robot) []string {
 	return robot.NamesByAPI(r, API)
-}
-
-// Readings is a helper for getting all readings from a PowerSensor.
-func Readings(ctx context.Context, g PowerSensor, extra map[string]interface{}) (map[string]interface{}, error) {
-	readings := map[string]interface{}{}
-
-	vol, isAC, err := g.Voltage(ctx, extra)
-	if err != nil {
-		if !strings.Contains(err.Error(), ErrMethodUnimplementedVoltage.Error()) {
-			return nil, err
-		}
-	} else {
-		readings["voltage"] = vol
-		readings["is_ac"] = isAC
-	}
-
-	cur, isAC, err := g.Current(ctx, extra)
-	if err != nil {
-		if !strings.Contains(err.Error(), ErrMethodUnimplementedCurrent.Error()) {
-			return nil, err
-		}
-	} else {
-		readings["current"] = cur
-		readings["is_ac"] = isAC
-	}
-
-	pow, err := g.Power(ctx, extra)
-	if err != nil {
-		if !strings.Contains(err.Error(), ErrMethodUnimplementedPower.Error()) {
-			return nil, err
-		}
-	} else {
-		readings["power"] = pow
-	}
-
-	return readings, nil
 }


### PR DESCRIPTION
…ensor.

Removed it completely from the power sensor since that was easy - only fake was using it.
Did not do so for the movement sensor, but renamed the function to make it clear that it is not the `Readings` API.  This will need to be changed so we don't bloat the interface at some point.

Tested on app with the get readings RC card. Testing with data capture.