### PR TITLE
Fix npm publish

### DIFF
--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -25,10 +25,10 @@
     "dist"
   ],
   "module": "./dist/rc.js",
-  "types": "./dist/src/main-lib.d.ts",
+  "types": "./dist/main-lib.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/src/main-lib.d.ts",
+      "types": "./dist/main-lib.d.ts",
       "import": "./dist/rc.js"
     }
   },

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -9,7 +9,8 @@
     "start": "vite --host",
     "build": "vite build && npm run copy-prime-assets",
     "build-prod": "vite build --no-sourcemap && npm run copy-prime-assets",
-    "build-npm": "vite build --config vite.lib.config.ts && tsc --project ./tsconfig.lib.json --emitDeclarationOnly",
+    "build-types": "tsc --project tsconfig.build.json",
+    "build-npm": "vite build --config vite.lib.config.ts && npm run build-types",
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "preview": "vite preview",
     "_prettier": "prettier --ignore-path=.eslintignore \"**/*.{ts,js,cjs,svelte,json,html,md}\"",
@@ -24,9 +25,10 @@
     "dist"
   ],
   "module": "./dist/rc.js",
-  "types": "./dist/main-lib.d.ts",
+  "types": "./dist/src/main-lib.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/src/main-lib.d.ts",
       "import": "./dist/rc.js"
     }
   },

--- a/web/frontend/src/main.ts
+++ b/web/frontend/src/main.ts
@@ -3,8 +3,6 @@ import './tailwind.css';
 import './index.css';
 import App from './app.svelte';
 
-export { version } from '../package.json';
-
 export default new App({
   target: document.querySelector('#app')!,
 });

--- a/web/frontend/svelte.config.d.ts
+++ b/web/frontend/svelte.config.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="svelte" />
+declare namespace _default {
+    let preprocess: import("@sveltejs/vite-plugin-svelte").PreprocessorGroup;
+}
+export default _default;

--- a/web/frontend/svelte.config.d.ts
+++ b/web/frontend/svelte.config.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="svelte" />
-declare namespace _default {
-    let preprocess: import("@sveltejs/vite-plugin-svelte").PreprocessorGroup;
-}
-export default _default;

--- a/web/frontend/tsconfig.build.json
+++ b/web/frontend/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "noEmit": false,
     "declaration": true,
-    "emitDeclarationOnly": true
+    "emitDeclarationOnly": true,
+    "rootDir": "src",
   },
-  "exclude": ["**/*.test.ts", "cypress/**/*.ts", "scripts/**/*", "*.config.ts"],
+  "exclude": ["**/*.test.ts", "cypress/**/*.ts", "scripts/**/*", "*.config.ts", "*.config.js"],
 }

--- a/web/frontend/tsconfig.build.json
+++ b/web/frontend/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true
+  },
+  "exclude": ["**/*.test.ts", "cypress/**/*.ts", "scripts/**/*", "*.config.ts"],
+}

--- a/web/frontend/tsconfig.json
+++ b/web/frontend/tsconfig.json
@@ -13,5 +13,6 @@
 
     "noPropertyAccessFromIndexSignature": false,
     "exactOptionalPropertyTypes": false,
-  }
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"]
 }

--- a/web/frontend/tsconfig.json
+++ b/web/frontend/tsconfig.json
@@ -14,5 +14,14 @@
     "noPropertyAccessFromIndexSignature": false,
     "exactOptionalPropertyTypes": false,
   },
-  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.js",
+    "src/**/*.d.ts",
+    "src/**/*.svelte",
+    "cypress/**/*.ts",
+    "scripts/*.js",
+    "*.ts",
+    "*.js"
+  ]
 }

--- a/web/frontend/tsconfig.json
+++ b/web/frontend/tsconfig.json
@@ -17,7 +17,6 @@
   "include": [
     "src/**/*.ts",
     "src/**/*.js",
-    "src/**/*.d.ts",
     "src/**/*.svelte",
     "cypress/**/*.ts",
     "scripts/*.js",

--- a/web/frontend/tsconfig.lib.json
+++ b/web/frontend/tsconfig.lib.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "exclude": [
-    "src/main.ts",
-    "src/tailwind.css"
-  ]
-}


### PR DESCRIPTION
Fixes an issue with npm publish in CI I introduced in https://github.com/viamrobotics/rdk/pull/3116

The issue is that `tsc` is used directly to generate `d.ts` files for npm, and without some kind of `include` or `exclude` rules `tsc` would run on the `dist` directory. I  removed previous include rules [here](https://github.com/viamrobotics/rdk/pull/3116/files#diff-265deb75fe9de6e9c242bfe9e5772af619fa0e04f28a2688d602cf712540232eL15). Strangely, setting `dist` in the `exclude` array instead of this solution doesn't solve the problem. If anyone has a better solution I'd love to know!