### PR TITLE
RSDK-5299 build for macos

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,13 +17,13 @@ jobs:
         go-version: '1.19.x'
     - name: brew
       run: |
-        brew tap "viamrobotics/brews"
-        brew install "pkg-config"
-        brew install "nlopt-static"
-        brew install "x264", args: ["build-from-source"]
-        brew install "jpeg-turbo"
-        brew install "ffmpeg"
-        brew install "tensorflowlite" # Needs to be last
+        brew tap viamrobotics/brews
+        brew install pkg-config
+        brew install nlopt-static
+        brew install x264
+        brew install jpeg-turbo
+        brew install ffmpeg
+        brew install tensorflowlite # Needs to be last
     - name: build
       run: go build ./web/cmd/server
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,8 +15,15 @@ jobs:
     - uses: actions/setup-go@v4
       with:
         go-version: '1.19.x'
-    - name: setup
-      run: etc/setup.sh
+    - name: brew
+      run: |
+        tap "viamrobotics/brews"
+        brew "pkg-config"
+        brew "nlopt-static"
+        brew "x264", args: ["build-from-source"]
+        brew "jpeg-turbo"
+        brew "ffmpeg"
+        brew "tensorflowlite" # Needs to be last
     - name: build
       run: go build ./web/cmd/server
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -29,3 +29,4 @@ jobs:
       with:
         name: viam-server-macos
         path: server
+        retention-days: 5

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,24 @@
+name: MacOS
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
+    - uses: actions/setup-go@v4
+      with:
+        go-version: '1.19.x'
+    - name: homebrew
+      run: echo hello todo
+    - name: build
+      run: go build ./web/cmd/server
+    - uses: actions/upload-artifact@v3
+      with:
+        name: viam-server-macos
+        path: server

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,13 +17,13 @@ jobs:
         go-version: '1.19.x'
     - name: brew
       run: |
-        tap "viamrobotics/brews"
-        brew "pkg-config"
-        brew "nlopt-static"
-        brew "x264", args: ["build-from-source"]
-        brew "jpeg-turbo"
-        brew "ffmpeg"
-        brew "tensorflowlite" # Needs to be last
+        brew tap "viamrobotics/brews"
+        brew install "pkg-config"
+        brew install "nlopt-static"
+        brew install "x264", args: ["build-from-source"]
+        brew install "jpeg-turbo"
+        brew install "ffmpeg"
+        brew install "tensorflowlite" # Needs to be last
     - name: build
       run: go build ./web/cmd/server
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,6 +3,7 @@ name: MacOS
 on:
   workflow_dispatch:
   workflow_call:
+  push: # DONOTMERGE
 
 jobs:
   build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,7 +3,6 @@ name: MacOS
 on:
   workflow_dispatch:
   workflow_call:
-  push: # DONOTMERGE
 
 jobs:
   build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,8 +15,8 @@ jobs:
     - uses: actions/setup-go@v4
       with:
         go-version: '1.19.x'
-    - name: homebrew
-      run: echo hello todo
+    - name: setup
+      run: etc/setup.sh
     - name: build
       run: go build ./web/cmd/server
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/pullrequest-trusted.yml
+++ b/.github/workflows/pullrequest-trusted.yml
@@ -75,5 +75,8 @@ jobs:
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
+  macos:
+    uses: viamrobotics/rdk/.github/workflows/macos.yml@main
+
   license_finder:
     uses: viamrobotics/rdk/.github/workflows/license_finder.yml@main


### PR DESCRIPTION
## What changed
- Add a build step to create a macos binary. Note, this is just for verification, not intended to be used for release.
- Trigger it in pull requests
## Successful run
- https://github.com/viamrobotics/rdk/actions/runs/6632650018
## Notes
- This is slooow, like 15 minutes. See RSDK-5474, we *could* bottle tflite to speed this up. We could also use the `no_tflite` flag to remove that dependency
- Is it worth adding a Brewfile so this shares config with setup.sh?