### PR TITLE
RSDK-5476 TP-space properly smoothing from Move calls

### DIFF
--- a/motionplan/tpSpaceRRT.go
+++ b/motionplan/tpSpaceRRT.go
@@ -41,10 +41,6 @@ const (
 	// When extending the RRT tree towards some point, do not extend more than this many times in a single RRT invocation.
 	defaultMaxReseeds = 50
 
-	// For whatever `refDist` is used for the generation of the original path, scale that by this amount when smoothing.
-	// This can help to find paths.
-	defaultSmoothScaleFactor = 0.5
-
 	// Make an attempt to solve the tree every this many iterations
 	// For a unidirectional solve, this means attempting to reach the goal rather than a random point
 	// For a bidirectional solve, this means trying to connect the two trees directly.
@@ -68,9 +64,6 @@ type tpspaceOptions struct {
 
 	// If the squared norm between two poses is less than this, consider them equal
 	poseSolveDist float64
-
-	// When smoothing, adjust the trajectory path length to be this proportion of the length used for solving
-	smoothScaleFactor float64
 
 	// Make an attempt to solve the tree every this many iterations
 	// For a unidirectional solve, this means attempting to reach the goal rather than a random point
@@ -278,7 +271,12 @@ func (mp *tpSpaceRRTMotionPlanner) planRunner(
 			if reachedDelta <= mp.algOpts.poseSolveDist {
 				// If we've reached the goal, extract the path from the RRT trees and return
 				path := extractPath(rrt.maps.startMap, rrt.maps.goalMap, &nodePair{a: seedReached.node, b: goalReached.node}, false)
-				rrt.solutionChan <- &rrtPlanReturn{steps: path, maps: rrt.maps}
+				correctedPath, err := rectifyTPspacePath(path, mp.frame, spatialmath.NewZeroPose())
+				if err != nil {
+					rrt.solutionChan <- &rrtPlanReturn{planerr: err, maps: rrt.maps}
+					return
+				}
+				rrt.solutionChan <- &rrtPlanReturn{steps: correctedPath, maps: rrt.maps}
 				return
 			}
 		}
@@ -667,7 +665,6 @@ func (mp *tpSpaceRRTMotionPlanner) setupTPSpaceOptions() {
 		addIntermediate:   defaultAddInt,
 		addNodeEvery:      defaultAddNodeEvery,
 		attemptSolveEvery: defaultAttemptSolveEvery,
-		smoothScaleFactor: defaultSmoothScaleFactor,
 
 		poseSolveDist: defaultIdenticalNodeDistance,
 
@@ -743,11 +740,7 @@ func (mp *tpSpaceRRTMotionPlanner) smoothPath(ctx context.Context, path []node) 
 			maxCost = wp.Cost()
 		}
 	}
-	newFrame, err := tpspace.NewPTGFrameFromPTGFrame(mp.frame, maxCost*mp.algOpts.smoothScaleFactor, 0)
-	if err != nil {
-		return path
-	}
-	smoothPlannerMP, err := newTPSpaceMotionPlanner(newFrame, mp.randseed, mp.logger, mp.planOpts)
+	smoothPlannerMP, err := newTPSpaceMotionPlanner(mp.frame, mp.randseed, mp.logger, mp.planOpts)
 	if err != nil {
 		return path
 	}

--- a/motionplan/tpSpaceRRT_test.go
+++ b/motionplan/tpSpaceRRT_test.go
@@ -305,7 +305,6 @@ func TestPtgWithObstacle(t *testing.T) {
 }
 
 func TestTPsmoothing(t *testing.T) {
-	// TODO: this doesn't smooth properly yet. This should be made to smooth better.
 	t.Parallel()
 	logger := golog.NewTestLogger(t)
 	roverGeom, err := spatialmath.NewBox(spatialmath.NewZeroPose(), r3.Vector{10, 10, 10}, "")
@@ -363,7 +362,8 @@ func TestTPsmoothing(t *testing.T) {
 	plan, err = rectifyTPspacePath(plan, tp.frame, spatialmath.NewZeroPose())
 	test.That(t, err, test.ShouldBeNil)
 
-	tp.planOpts.SmoothIter = 20
+	// TODO (RSDK-5104) this should be able to be a smaller value once 5104 is complete
+	tp.planOpts.SmoothIter = 80
 
 	newplan := tp.smoothPath(ctx, plan)
 	test.That(t, newplan, test.ShouldNotBeNil)

--- a/motionplan/tpspace/ptgGroupFrame.go
+++ b/motionplan/tpspace/ptgGroupFrame.go
@@ -154,6 +154,7 @@ func NewPTGFrameFromKinematicOptions(
 
 // NewPTGFrameFromPTGFrame will create a new Frame from a preexisting ptgGroupFrame, allowing the adjustment of `refDist` while keeping
 // other params the same. This may be expanded to allow altering turning radius, geometries, etc.
+// TODO (RSDK-5104) this may be able to be removed.
 func NewPTGFrameFromPTGFrame(frame referenceframe.Frame, refDist float64, trajCount int) (referenceframe.Frame, error) {
 	ptgFrame, ok := frame.(*ptgGroupFrame)
 	if !ok {


### PR DESCRIPTION
`tpspace.NewPTGFrameFromPTGFrame` was failing when being called with a `solverFrame`.

The actual test for this is part of the MoveOnMap PR, which was failing without this fix. This PR was split out so that smoothing could be working again.