### PR TITLE
[RSDK-5243] Use the raw I2C bus when configuring a BME280 sensor

### DIFF
--- a/components/sensor/bme280/bme280.go
+++ b/components/sensor/bme280/bme280.go
@@ -84,6 +84,9 @@ const (
 
 // Config is used for converting config attributes.
 type Config struct {
+	// The I2C bus is almost certainly numeric (e.g., the "7" in /dev/i2c-7), but it is nonetheless
+	// possible for the OS to give its I2C buses a non-numeric identifier, so we store it as a
+	// string.
 	I2CBus  string `json:"i2c_bus"`
 	I2cAddr int    `json:"i2c_addr,omitempty"`
 }

--- a/components/sensor/bme280/bme280.go
+++ b/components/sensor/bme280/bme280.go
@@ -122,7 +122,7 @@ func init() {
 
 func newSensor(
 	ctx context.Context,
-	deps resource.Dependencies,
+	_ resource.Dependencies,
 	name resource.Name,
 	conf *Config,
 	logger golog.Logger,

--- a/components/sensor/bme280/bme280.go
+++ b/components/sensor/bme280/bme280.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 // Package bme280 implements a bme280 sensor for temperature, humidity, and pressure.
 // Code based on https://github.com/sparkfun/SparkFun_bme280_Arduino_Library (MIT license)
 // and also https://github.com/rm-hull/bme280 (MIT License)
@@ -15,6 +17,7 @@ import (
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/genericlinux"
 	"go.viam.com/rdk/components/sensor"
 	"go.viam.com/rdk/resource"
 )
@@ -81,7 +84,6 @@ const (
 
 // Config is used for converting config attributes.
 type Config struct {
-	Board   string `json:"board"`
 	I2CBus  string `json:"i2c_bus"`
 	I2cAddr int    `json:"i2c_addr,omitempty"`
 }
@@ -89,10 +91,6 @@ type Config struct {
 // Validate ensures all parts of the config are valid.
 func (conf *Config) Validate(path string) ([]string, error) {
 	var deps []string
-	if len(conf.Board) == 0 {
-		return nil, utils.NewConfigValidationFieldRequiredError(path, "board")
-	}
-	deps = append(deps, conf.Board)
 	if len(conf.I2CBus) == 0 {
 		return nil, utils.NewConfigValidationFieldRequiredError(path, "i2c bus")
 	}
@@ -126,18 +124,12 @@ func newSensor(
 	conf *Config,
 	logger golog.Logger,
 ) (sensor.Sensor, error) {
-	b, err := board.FromDependencies(deps, conf.Board)
+	i2cbus, err := genericlinux.NewI2cBus(conf.I2CBus)
 	if err != nil {
-		return nil, fmt.Errorf("bme280 init: failed to find board: %w", err)
+		return nil, fmt.Errorf("bme280 init: failed to open i2c bus %s: %w",
+		                       conf.I2CBus, err)
 	}
-	localB, ok := b.(board.LocalBoard)
-	if !ok {
-		return nil, fmt.Errorf("board %s is not local", conf.Board)
-	}
-	i2cbus, ok := localB.I2CByName(conf.I2CBus)
-	if !ok {
-		return nil, fmt.Errorf("bme280 init: failed to find i2c bus %s", conf.I2CBus)
-	}
+
 	addr := conf.I2cAddr
 	if addr == 0 {
 		addr = defaultI2Caddr

--- a/components/sensor/bme280/bme280.go
+++ b/components/sensor/bme280/bme280.go
@@ -127,7 +127,7 @@ func newSensor(
 	i2cbus, err := genericlinux.NewI2cBus(conf.I2CBus)
 	if err != nil {
 		return nil, fmt.Errorf("bme280 init: failed to open i2c bus %s: %w",
-		                       conf.I2CBus, err)
+			conf.I2CBus, err)
 	}
 
 	addr := conf.I2cAddr

--- a/components/sensor/bme280/bme280_nonlinux.go
+++ b/components/sensor/bme280/bme280_nonlinux.go
@@ -1,0 +1,2 @@
+// Package bme280 is only available on Linux.
+package bme280


### PR DESCRIPTION
Before this is merged to RDK, we need to have a migration script merged to app! I'll work on that next...