### PR TITLE
RSDK-5481: Reduce surface area of log creation APIs.

### DIFF
--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -743,7 +743,7 @@ func sameModels(a, b []ModuleComponent) bool {
 
 // UpdateModelsAction figures out the models that a module supports and updates it's metadata file.
 func UpdateModelsAction(c *cli.Context) error {
-	logger := logging.NewDevelopmentLogger("x")
+	logger := logging.NewLogger("x")
 	newModels, err := readModels(c.String("binary"), logger)
 	if err != nil {
 		return err

--- a/components/camera/videosource/logging/logger.go
+++ b/components/camera/videosource/logging/logger.go
@@ -312,7 +312,7 @@ func (l *Logger) write(title string, m InfoMap) {
 
 	t.AppendFooter(table.Row{time.Now().UTC().Format(time.RFC3339)})
 	l.logger.Info(t.Render())
-	l.logger.Info("")
+	l.logger.Info()
 }
 
 func (l *Logger) logError(err error, msg string) {

--- a/components/camera/videosource/logging/logger.go
+++ b/components/camera/videosource/logging/logger.go
@@ -97,7 +97,7 @@ func NewLogger() (*Logger, error) {
 		}
 	}
 
-	cfg := logging.NewDevelopmentLoggerConfig()
+	cfg := logging.NewLoggerConfig()
 	cfg.OutputPaths = []string{filePath}
 
 	// only keep message

--- a/components/camera/videosource/logging/logger.go
+++ b/components/camera/videosource/logging/logger.go
@@ -311,8 +311,8 @@ func (l *Logger) write(title string, m InfoMap) {
 	}
 
 	t.AppendFooter(table.Row{time.Now().UTC().Format(time.RFC3339)})
-	l.logger.Infoln(t.Render())
-	l.logger.Infoln(fmt.Sprintln())
+	l.logger.Info(t.Render())
+	l.logger.Info("")
 }
 
 func (l *Logger) logError(err error, msg string) {

--- a/config/logging_level_test.go
+++ b/config/logging_level_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestConfigDebugFlag(t *testing.T) {
-	logConfig := logging.NewDevelopmentLoggerConfig()
+	logConfig := logging.NewLoggerConfig()
 	logger := logging.FromZapCompatible(zap.Must(logConfig.Build()).Sugar())
 
 	for _, cmdLineValue := range []bool{true, false} {

--- a/data/collector.go
+++ b/data/collector.go
@@ -202,7 +202,7 @@ func (c *collector) getAndPushNextReading() {
 	timeReceived := timestamppb.New(c.clock.Now().UTC())
 	if err != nil {
 		if errors.Is(err, ErrNoCaptureToStore) {
-			c.logger.Debugln("capture filtered out by modular resource")
+			c.logger.Debug("capture filtered out by modular resource")
 			return
 		}
 		c.captureErrors <- errors.Wrap(err, "error while capturing data")

--- a/examples/customresources/demos/complexmodule/client/client.go
+++ b/examples/customresources/demos/complexmodule/client/client.go
@@ -17,7 +17,7 @@ import (
 )
 
 func main() {
-	logger := logging.NewDevelopmentLogger("client")
+	logger := logging.NewLogger("client")
 	robot, err := client.New(
 		context.Background(),
 		"localhost:8080",

--- a/examples/customresources/demos/simplemodule/client/client.go
+++ b/examples/customresources/demos/simplemodule/client/client.go
@@ -12,7 +12,7 @@ import (
 )
 
 func main() {
-	logger := logging.NewDevelopmentLogger("client")
+	logger := logging.NewLogger("client")
 
 	// Connect to the default localhost port for viam-server.
 	robot, err := client.New(

--- a/examples/customresources/demos/simplemodule/module.go
+++ b/examples/customresources/demos/simplemodule/module.go
@@ -19,7 +19,7 @@ import (
 var myModel = resource.NewModel("acme", "demo", "mycounter")
 
 func main() {
-	utils.ContextualMain(mainWithArgs, logging.NewDevelopmentLogger("SimpleModule"))
+	utils.ContextualMain(mainWithArgs, logging.NewLogger("SimpleModule"))
 }
 
 func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) error {

--- a/logging/level.go
+++ b/logging/level.go
@@ -1,0 +1,76 @@
+package logging
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Level is an enum of log levels. Its value can be `DEBUG`, `INFO`, `WARN` or `ERROR`.
+type Level int
+
+const (
+	// This numbering scheme serves two purposes:
+	//   - A statement is logged if its log level matches or exceeds the configured level. I.e:
+	//     Statement(WARN) >= LogConfig(INFO) would be logged because "1" > "0".
+	//   - INFO is the default level. So we start counting at DEBUG=-1 such that INFO is given Go's
+	//     zero-value.
+
+	// DEBUG log level.
+	DEBUG Level = iota - 1
+	// INFO log level.
+	INFO
+	// WARN log level.
+	WARN
+	// ERROR log level.
+	ERROR
+)
+
+func (level Level) String() string {
+	switch level {
+	case DEBUG:
+		return "Debug"
+	case INFO:
+		return "Info"
+	case WARN:
+		return "Warn"
+	case ERROR:
+		return "Error"
+	}
+
+	panic(fmt.Sprintf("unreachable: %d", level))
+}
+
+// LevelFromString parses an input string to a log level. The string must be one of `debug`, `info`,
+// `warn` or `error`. The parsing is case-insensitive. An error is returned if the input does not
+// match one of labeled cases.
+func LevelFromString(inp string) (Level, error) {
+	switch strings.ToLower(inp) {
+	case "debug":
+		return DEBUG, nil
+	case "info":
+		return INFO, nil
+	case "warn":
+		return WARN, nil
+	case "error":
+		return ERROR, nil
+	}
+
+	return DEBUG, fmt.Errorf("unknown log level: %q", inp)
+}
+
+// MarshalJSON converts a log level to a json string.
+func (level Level) MarshalJSON() ([]byte, error) {
+	return json.Marshal(level.String())
+}
+
+// UnmarshalJSON converts a json string to a log level.
+func (level *Level) UnmarshalJSON(data []byte) (err error) {
+	var levelStr string
+	if err := json.Unmarshal(data, &levelStr); err != nil {
+		return err
+	}
+
+	*level, err = LevelFromString(levelStr)
+	return
+}

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -47,16 +47,6 @@ type ZapCompatibleLogger interface {
 	Fatalf(template string, args ...interface{})
 	Fatalln(args ...interface{})
 	Fatalw(msg string, keysAndValues ...interface{})
-
-	Panic(args ...interface{})
-	Panicf(template string, args ...interface{})
-	Panicln(args ...interface{})
-	Panicw(msg string, keysAndValues ...interface{})
-
-	DPanic(args ...interface{})
-	DPanicf(template string, args ...interface{})
-	DPanicln(args ...interface{})
-	DPanicw(msg string, keysAndValues ...interface{})
 }
 
 // zLogger type for logging to. Wraps a zap logger and adds the `AsZap` method to satisfy the

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -25,27 +25,22 @@ type ZapCompatibleLogger interface {
 
 	Debug(args ...interface{})
 	Debugf(template string, args ...interface{})
-	Debugln(args ...interface{})
 	Debugw(msg string, keysAndValues ...interface{})
 
 	Info(args ...interface{})
 	Infof(template string, args ...interface{})
-	Infoln(args ...interface{})
 	Infow(msg string, keysAndValues ...interface{})
 
 	Warn(args ...interface{})
 	Warnf(template string, args ...interface{})
-	Warnln(args ...interface{})
 	Warnw(msg string, keysAndValues ...interface{})
 
 	Error(args ...interface{})
 	Errorf(template string, args ...interface{})
-	Errorln(args ...interface{})
 	Errorw(msg string, keysAndValues ...interface{})
 
 	Fatal(args ...interface{})
 	Fatalf(template string, args ...interface{})
-	Fatalln(args ...interface{})
 	Fatalw(msg string, keysAndValues ...interface{})
 }
 

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -16,8 +16,7 @@ var (
 	globalLogger = NewDebugLogger("startup")
 )
 
-// ReplaceGloabl replaces the global loggers and returns a function to reset
-// the loggers to the previous state.
+// ReplaceGlobal replaces the global loggers.
 func ReplaceGlobal(logger Logger) {
 	globalMu.Lock()
 	globalLogger = logger
@@ -29,7 +28,7 @@ func Global() Logger {
 	return globalLogger
 }
 
-// NewDebugLoggerConfig returns a new default development logger config.
+// NewLoggerConfig returns a new default logger config.
 func NewLoggerConfig() zap.Config {
 	// from https://github.com/uber-go/zap/blob/2314926ec34c23ee21f3dd4399438469668f8097/config.go#L135
 	// but disable stacktraces, use same keys as prod, and color levels.

--- a/module/example_test.go
+++ b/module/example_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	logger     = logging.NewDevelopmentLogger("SimpleModule")
+	logger     = logging.NewLogger("SimpleModule")
 	ctx        = context.Background()
 	myModel    = resource.NewModel("acme", "demo", "mycounter")
 	socketPath = "/tmp/viam-module-example.socket"

--- a/module/module.go
+++ b/module/module.go
@@ -183,7 +183,7 @@ func NewLoggerFromArgs(moduleName string) logging.Logger {
 	if len(os.Args) >= 3 && os.Args[2] == "--log-level=debug" {
 		return logging.NewDebugLogger(moduleName)
 	}
-	return logging.NewDevelopmentLogger(moduleName)
+	return logging.NewLogger(moduleName)
 }
 
 // Start starts the module service and grpc server.

--- a/utils/logger.go
+++ b/utils/logger.go
@@ -1,36 +1,17 @@
 package utils
 
 import (
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-
 	"go.viam.com/rdk/logging"
 )
 
 // NewFilePathDebugLogger is intended as a debug only tool & should not be used in prod
 // logs using debug configuration to log to both stderr, stdout & a filepath.
 func NewFilePathDebugLogger(filepath, name string) (logging.Logger, error) {
-	logger, err := zap.Config{
-		Level:    zap.NewAtomicLevelAt(zap.DebugLevel),
-		Encoding: "console",
-		EncoderConfig: zapcore.EncoderConfig{
-			TimeKey:        "ts",
-			LevelKey:       "level",
-			NameKey:        "logger",
-			CallerKey:      "caller",
-			FunctionKey:    zapcore.OmitKey,
-			MessageKey:     "msg",
-			StacktraceKey:  "stacktrace",
-			LineEnding:     zapcore.DefaultLineEnding,
-			EncodeLevel:    zapcore.CapitalColorLevelEncoder,
-			EncodeTime:     zapcore.ISO8601TimeEncoder,
-			EncodeDuration: zapcore.StringDurationEncoder,
-			EncodeCaller:   zapcore.ShortCallerEncoder,
-		},
-		DisableStacktrace: true,
-		OutputPaths:       []string{filepath, "stdout"},
-		ErrorOutputPaths:  []string{filepath, "stderr"},
-	}.Build()
+	logConfig := logging.NewLoggerConfig()
+	logConfig.OutputPaths = append(logConfig.OutputPaths, filepath)
+	logConfig.ErrorOutputPaths = append(logConfig.ErrorOutputPaths, filepath)
+
+	logger, err := logConfig.Build()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The motivation here is that if i have to implement a new logger, I'd like to match the log output. Zap has a very rich set of customization that would be expensive to keep parity with. Thankfully we only use a small subset of it. This patch/refactor removes unused (or lightly used) code and consolidates the configuration down to (nearly) a single spot.

The [first commit](https://github.com/viamrobotics/rdk/pull/3136/commits/af3ccd8fcbb848214fb0690ad91fe475c0ea5232) actually makes changes. The second only moved code within the logging files. It should be sufficient to just review the first commit and sanity check the latter.

Changes (that I hope to remember to add to the commit message):
* `ReplaceGoabl` -> `ReplaceGlobal`
* The `New*Logger` APIs have been reduced to `NewLogger` and `NewDebugLogger`
  * Strictly speaking, there's some behavior changes due to this that I deemed inconsequential. See below for more details.
* Remove GPC (google cloud provider) loggers. Those were from golog and only used from `viam-robotics/app`.
* Removed Panic/DPanic APIs from Logger.
  * There was one usage of `logger.Panic` and it was confusing to say the least. The behavior was largely retained by separating logger calls + panic call.

Re: Non-GPC `golog.New*Logger` methods, there were 4 public APIs mapping to 3 distinct configurations.
* NewLogger -> NewProductionLogger
* NewProductionLogger
* NewDevelopmentLogger
* NewDebugLogger

The Development and Debug logger were exactly the same except for log level (info vs debug)

The "ProductionLogger" logged at info and had a few differences:
* Used [lower-case uncolored](https://github.com/viamrobotics/rdk/blob/9cde18d23d8a92cc4b6663a17e5305718371ef6c/logging/logger.go#L149) text for error levels in logs ([debug setting](https://github.com/viamrobotics/rdk/blob/9cde18d23d8a92cc4b6663a17e5305718371ef6c/logging/logger.go#L213))
* Encoded [time differently](https://github.com/viamrobotics/rdk/blob/9cde18d23d8a92cc4b6663a17e5305718371ef6c/logging/logger.go#L150) vs [debug](https://github.com/viamrobotics/rdk/blob/9cde18d23d8a92cc4b6663a17e5305718371ef6c/logging/logger.go#L214)
* And [durations](https://github.com/viamrobotics/rdk/blob/9cde18d23d8a92cc4b6663a17e5305718371ef6c/logging/logger.go#L151) [differently](https://github.com/viamrobotics/rdk/blob/9cde18d23d8a92cc4b6663a17e5305718371ef6c/logging/logger.go#L215)

The main viam server only used [development/debug](https://github.com/viamrobotics/rdk/blob/9cde18d23d8a92cc4b6663a17e5305718371ef6c/web/server/entrypoint.go#L71-L75) loggers. There were only a handful of "production logger" instances. Relegated to some CLI programs and a few log lines in other code calling `NewLogger`. There wasn't a lot of meaningful log content in those usages, so I've deemed the usages incidental to using a "production logger" and not intentional.