### PR TITLE
RSDK-5500 consume test32 in rollup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -201,6 +201,8 @@ jobs:
           echo Pi Tests: ${{ needs.test_pi.result }}
           echo Main Tests: ${{ needs.build_and_test.result }}
           echo E2E Tests: ${{ needs.test_e2e.result }}
+          echo 32-bit Tests: ${{ needs.test32.result }}
           [ "${{ needs.test_pi.result }}" == "success" ] && \
           [ "${{ needs.build_and_test.result }}" == "success" ] && \
-          [ "${{ needs.test_e2e.result }}" == "success" ]
+          [ "${{ needs.test_e2e.result }}" == "success" ] && \
+          [ "${{ needs.test32.result }}" == "success" ]


### PR DESCRIPTION
## What changed
- The 'all tests passing' step was consuming test32 but not doing anything with it. Add test32 to printed output and bash test