### PR TITLE
DATA-2090 - Compare ConvertedAttributes in data manager configs

### DIFF
--- a/resource/config.go
+++ b/resource/config.go
@@ -187,7 +187,6 @@ func (conf Config) Equals(other Config) bool {
 	other.cachedImplicitDeps = nil
 	other.cachedErr = nil
 
-	// RSDK-4657: Only compare `Config.Attributes` for equality.
 	conf.ConvertedAttributes = nil
 	other.ConvertedAttributes = nil
 

--- a/resource/config.go
+++ b/resource/config.go
@@ -187,9 +187,6 @@ func (conf Config) Equals(other Config) bool {
 	other.cachedImplicitDeps = nil
 	other.cachedErr = nil
 
-	conf.ConvertedAttributes = nil
-	other.ConvertedAttributes = nil
-
 	//nolint:govet
 	return reflect.DeepEqual(conf, other)
 }

--- a/resource/config.go
+++ b/resource/config.go
@@ -187,6 +187,14 @@ func (conf Config) Equals(other Config) bool {
 	other.cachedImplicitDeps = nil
 	other.cachedErr = nil
 
+	// TODO(RSDK-5523): Once builtin datamanagers' AssociatedConfigLinkers no
+	// longer rely on appensions to the service's ConvertedAttributes field,
+	// continue ignoring ConvertedAttributes for equality for all resources.
+	if conf.API != APINamespaceRDK.WithServiceType("data_manager") {
+		conf.ConvertedAttributes = nil
+		other.ConvertedAttributes = nil
+	}
+
 	//nolint:govet
 	return reflect.DeepEqual(conf, other)
 }


### PR DESCRIPTION
Compares converted attributes for the data manager service removed in https://github.com/viamrobotics/rdk/pull/2897. 

The associated configs linked [here](https://github.com/viamrobotics/rdk/blob/e0d441fc7815cc4eecc5096ed18054307628cba7/services/datamanager/builtin/builtin.go#L44) and used [here](https://github.com/viamrobotics/rdk/blob/e0d441fc7815cc4eecc5096ed18054307628cba7/services/datamanager/builtin/builtin.go#L358) were no longer detecting changes at the resource-level data manager configuration. If one of the flags was changed or the resource itself was entirely removed, a stale ResourceConfig persisted and was not updated within `Reconfigure`.

Confirmed that this fixes data manager capture/sync issues.