### PR TITLE
RSDK-5315 - Fix flaky test in replay movement sensor

### DIFF
--- a/components/movementsensor/replay/replay.go
+++ b/components/movementsensor/replay/replay.go
@@ -29,11 +29,10 @@ import (
 )
 
 const (
-	timeFormat                 = time.RFC3339
-	grpcConnectionTimeout      = 10 * time.Second
-	dataReceivedLoopWaitTime   = time.Second
-	tabularDataByFilterTimeout = 15 * time.Second
-	maxCacheSize               = 1000
+	timeFormat               = time.RFC3339
+	grpcConnectionTimeout    = 10 * time.Second
+	dataReceivedLoopWaitTime = time.Second
+	maxCacheSize             = 1000
 )
 
 type method string

--- a/components/movementsensor/replay/replay.go
+++ b/components/movementsensor/replay/replay.go
@@ -565,7 +565,7 @@ func (replay *replayMovementSensor) setProperty(method method, supported bool) e
 
 // attemptToGetData will try to update the cache for the provided method. Returns a bool that
 // indicates whether or not the endpoint has data.
-func (replay *replayMovementSensor) attemptToGetData(ctx context.Context, method method) (bool, error) {
+func (replay *replayMovementSensor) attemptToGetData(method method) (bool, error) {
 	if replay.closed {
 		return false, errSessionClosed
 	}
@@ -590,7 +590,7 @@ func (replay *replayMovementSensor) initializeProperties(ctx context.Context) er
 			return ctx.Err()
 		}
 		for _, method := range methodList {
-			if dataReceived[method], err = replay.attemptToGetData(ctx, method); err != nil {
+			if dataReceived[method], err = replay.attemptToGetData(method); err != nil {
 				return err
 			}
 		}
@@ -602,7 +602,7 @@ func (replay *replayMovementSensor) initializeProperties(ctx context.Context) er
 	}
 	// Loop once more through all methods to ensure we didn't miss out on catching that they're supported
 	for _, method := range methodList {
-		if dataReceived[method], err = replay.attemptToGetData(ctx, method); err != nil {
+		if dataReceived[method], err = replay.attemptToGetData(method); err != nil {
 			return err
 		}
 	}

--- a/components/movementsensor/replay/replay_test.go
+++ b/components/movementsensor/replay/replay_test.go
@@ -116,8 +116,6 @@ var (
 )
 
 func TestNewReplayMovementSensor(t *testing.T) {
-	// Remove skip once fix is complete: https://viam.atlassian.net/browse/RSDK-5315
-	t.Skip("remove skip once RSDK-5315 bug fix is complete")
 	ctx := context.Background()
 
 	initializePropertiesTimeout = 2 * time.Second

--- a/components/movementsensor/replay/replay_test.go
+++ b/components/movementsensor/replay/replay_test.go
@@ -3,7 +3,6 @@ package replay
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -262,13 +261,7 @@ func TestNewReplayMovementSensor(t *testing.T) {
 			replay, _, serverClose, err := createNewReplayMovementSensor(ctx, t, tt.cfg, tt.validCloudConnection)
 			if tt.expectedErr != nil {
 				test.That(t, err, test.ShouldNotBeNil)
-				if strings.Contains(err.Error(), "rpc error: code = DeadlineExceeded") {
-					errMessage := "Properties failed to initialize: could not update the cache: " +
-						"rpc error: code = DeadlineExceeded desc = context deadline exceeded"
-					test.That(t, err, test.ShouldBeError, errors.New(errMessage))
-				} else {
-					test.That(t, err, test.ShouldBeError, tt.expectedErr)
-				}
+				test.That(t, err, test.ShouldBeError, tt.expectedErr)
 				test.That(t, replay, test.ShouldBeNil)
 			} else {
 				test.That(t, err, test.ShouldBeNil)

--- a/components/movementsensor/replay/replay_test.go
+++ b/components/movementsensor/replay/replay_test.go
@@ -262,7 +262,8 @@ func TestNewReplayMovementSensor(t *testing.T) {
 			if tt.expectedErr != nil {
 				test.That(t, err, test.ShouldNotBeNil)
 				if strings.Contains(err.Error(), "rpc error: code = DeadlineExceeded") {
-					errMessage := "Properties failed to initialize: could not update the cache: rpc error: code = DeadlineExceeded desc = context deadline exceeded"
+					errMessage := "Properties failed to initialize: could not update the cache: " +
+						"rpc error: code = DeadlineExceeded desc = context deadline exceeded"
 					test.That(t, err, test.ShouldBeError, errors.New(errMessage))
 				} else {
 					test.That(t, err, test.ShouldBeError, tt.expectedErr)

--- a/components/movementsensor/replay/replay_test.go
+++ b/components/movementsensor/replay/replay_test.go
@@ -120,6 +120,7 @@ func TestNewReplayMovementSensor(t *testing.T) {
 	ctx := context.Background()
 
 	initializePropertiesTimeout = 2 * time.Second
+	tabularDataByFilterTimeout = 1 * time.Second
 
 	cases := []struct {
 		description          string
@@ -288,6 +289,7 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 	ctx := context.Background()
 
 	initializePropertiesTimeout = 2 * time.Second
+	tabularDataByFilterTimeout = 1 * time.Second
 
 	cases := []struct {
 		description        string

--- a/components/movementsensor/replay/replay_test.go
+++ b/components/movementsensor/replay/replay_test.go
@@ -3,6 +3,7 @@ package replay
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -260,7 +261,12 @@ func TestNewReplayMovementSensor(t *testing.T) {
 			replay, _, serverClose, err := createNewReplayMovementSensor(ctx, t, tt.cfg, tt.validCloudConnection)
 			if tt.expectedErr != nil {
 				test.That(t, err, test.ShouldNotBeNil)
-				test.That(t, err, test.ShouldBeError, tt.expectedErr)
+				if strings.Contains(err.Error(), "rpc error: code = DeadlineExceeded") {
+					errMessage := "Properties failed to initialize: could not update the cache: rpc error: code = DeadlineExceeded desc = context deadline exceeded"
+					test.That(t, err, test.ShouldBeError, errors.New(errMessage))
+				} else {
+					test.That(t, err, test.ShouldBeError, tt.expectedErr)
+				}
 				test.That(t, replay, test.ShouldBeNil)
 			} else {
 				test.That(t, err, test.ShouldBeNil)


### PR DESCRIPTION
Tickets: 
* https://viam.atlassian.net/browse/RSDK-5315
* https://viam.atlassian.net/browse/RSDK-5304

Done:
* The issue was that the context would timeout while requesting data, which changes the error message that's returned.

Tested 100 times:
```bash
➜  replay git:(kk/rsdk-5315-fix-flaky-test go test -run=TestNewReplayMovementSensor -count=100 -timeout 99999s     
PASS
ok      go.viam.com/rdk/components/movementsensor/replay        1111.645s
```