### PR TITLE
RSDK-3236 support for requesting a new path from an existing partial plan

### DIFF
--- a/motionplan/motionPlanner.go
+++ b/motionplan/motionPlanner.go
@@ -190,8 +190,6 @@ func Replan(ctx context.Context, request *PlanRequest, currentPlan Plan, replanC
 		return nil, err
 	}
 	newPlan := sf.inputsToPlan(resultSlices)
-	request.Logger.Debugf("seedplan %v", currentPlan)
-	request.Logger.Debugf("plan %v", newPlan)
 
 	if replanCostFactor > 0 && currentPlan != nil {
 		initialPlanCost := currentPlan.Evaluate(sfPlanner.opt().ScoreFunc)

--- a/motionplan/motionPlanner.go
+++ b/motionplan/motionPlanner.go
@@ -177,13 +177,13 @@ func Replan(ctx context.Context, request *PlanRequest, currentPlan Plan, replanC
 		return nil, err
 	}
 
-	// TODO: RSDK-3236 this should seed off of currentPlan
 	resultSlices, err := sfPlanner.PlanSingleWaypoint(
 		ctx,
 		request.StartConfiguration,
 		request.Goal.Pose(),
 		request.WorldState,
 		request.ConstraintSpecs,
+		currentPlan,
 		request.Options,
 	)
 	if err != nil {

--- a/motionplan/motionPlanner.go
+++ b/motionplan/motionPlanner.go
@@ -190,6 +190,8 @@ func Replan(ctx context.Context, request *PlanRequest, currentPlan Plan, replanC
 		return nil, err
 	}
 	newPlan := sf.inputsToPlan(resultSlices)
+	request.Logger.Debugf("seedplan %v", currentPlan)
+	request.Logger.Debugf("plan %v", newPlan)
 
 	if replanCostFactor > 0 && currentPlan != nil {
 		initialPlanCost := currentPlan.Evaluate(sfPlanner.opt().ScoreFunc)

--- a/motionplan/motionPlanner_test.go
+++ b/motionplan/motionPlanner_test.go
@@ -606,6 +606,7 @@ func TestSolverFrameGeometries(t *testing.T) {
 		spatialmath.NewPoseFromPoint(r3.Vector{300, 300, 100}),
 		nil,
 		nil,
+		nil,
 		map[string]interface{}{"smooth_iter": 5},
 	)
 	test.That(t, err, test.ShouldBeNil)
@@ -720,7 +721,7 @@ func TestMovementWithGripper(t *testing.T) {
 	motionConfig["motion_profile"] = LinearMotionProfile
 	sfPlanner, err := newPlanManager(sf, fs, logger, 1)
 	test.That(t, err, test.ShouldBeNil)
-	solution, err := sfPlanner.PlanSingleWaypoint(context.Background(), zeroPosition, goal, nil, nil, motionConfig)
+	solution, err := sfPlanner.PlanSingleWaypoint(context.Background(), zeroPosition, goal, nil, nil, nil, motionConfig)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, solution, test.ShouldNotBeNil)
 
@@ -734,7 +735,7 @@ func TestMovementWithGripper(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	sfPlanner, err = newPlanManager(sf, fs, logger, 1)
 	test.That(t, err, test.ShouldBeNil)
-	solution, err = sfPlanner.PlanSingleWaypoint(context.Background(), zeroPosition, goal, worldState, nil, nil)
+	solution, err = sfPlanner.PlanSingleWaypoint(context.Background(), zeroPosition, goal, worldState, nil, nil, nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, solution, test.ShouldNotBeNil)
 
@@ -745,13 +746,13 @@ func TestMovementWithGripper(t *testing.T) {
 	zeroPosition = sf.sliceToMap(make([]frame.Input, len(sf.DoF())))
 	sfPlanner, err = newPlanManager(sf, fs, logger, 1)
 	test.That(t, err, test.ShouldBeNil)
-	_, err = sfPlanner.PlanSingleWaypoint(context.Background(), zeroPosition, goal, worldState, nil, motionConfig)
+	_, err = sfPlanner.PlanSingleWaypoint(context.Background(), zeroPosition, goal, worldState, nil, nil, motionConfig)
 	test.That(t, err, test.ShouldNotBeNil)
 
 	// remove linear constraint and try again
 	sfPlanner, err = newPlanManager(sf, fs, logger, 1)
 	test.That(t, err, test.ShouldBeNil)
-	solution, err = sfPlanner.PlanSingleWaypoint(context.Background(), zeroPosition, goal, worldState, nil, nil)
+	solution, err = sfPlanner.PlanSingleWaypoint(context.Background(), zeroPosition, goal, worldState, nil, nil, nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, solution, test.ShouldNotBeNil)
 
@@ -762,7 +763,7 @@ func TestMovementWithGripper(t *testing.T) {
 	zeroPosition = sf.sliceToMap(make([]frame.Input, len(sf.DoF())))
 	sfPlanner, err = newPlanManager(sf, fs, logger, 1)
 	test.That(t, err, test.ShouldBeNil)
-	solution, err = sfPlanner.PlanSingleWaypoint(context.Background(), zeroPosition, goal, worldState, nil, motionConfig)
+	solution, err = sfPlanner.PlanSingleWaypoint(context.Background(), zeroPosition, goal, worldState, nil, nil, motionConfig)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, solution, test.ShouldNotBeNil)
 }

--- a/motionplan/planManager.go
+++ b/motionplan/planManager.go
@@ -692,6 +692,7 @@ func (pm *planManager) planToRRTGoalMap(plan Plan, goal spatialmath.Pose) (*rrtM
 
 	return maps, nil
 }
+
 // Copy any atomic values.
 func deepAtomicCopyMap(opt map[string]interface{}) map[string]interface{} {
 	optCopy := map[string]interface{}{}

--- a/motionplan/planManager.go
+++ b/motionplan/planManager.go
@@ -340,7 +340,7 @@ func (pm *planManager) planParallelRRTMotion(
 
 	// publish endpoint of plan if it is known
 	var nextSeed node
-	if maps != nil && len(maps.goalMap) == 1 {
+	if len(maps.goalMap) == 1 {
 		pm.logger.Debug("only one IK solution, returning endpoint preview")
 		for key := range maps.goalMap {
 			nextSeed = key
@@ -667,21 +667,21 @@ func (pm *planManager) planToRRTGoalMap(plan Plan, goal spatialmath.Pose) (*rrtM
 			return nil, err
 		}
 	}
-	// Fill in costs
-	for i := 1; i < len(planNodes); i++ {
-		cost := pm.opt().DistanceFunc(&ik.Segment{
-			StartConfiguration: planNodes[i-1].Q(),
-			StartPosition:      planNodes[i-1].Pose(),
-			EndConfiguration:   planNodes[i].Q(),
-			EndPosition:        planNodes[i].Pose(),
-			Frame:              pm.frame,
-		})
-		planNodes[i].SetCost(cost)
-	}
 
 	var lastNode node
 	goalMap := map[node]node{}
 	for i := len(planNodes) - 1; i >= 0; i-- {
+		if i != 0 {
+			// Fill in costs
+			cost := pm.opt().DistanceFunc(&ik.Segment{
+				StartConfiguration: planNodes[i-1].Q(),
+				StartPosition:      planNodes[i-1].Pose(),
+				EndConfiguration:   planNodes[i].Q(),
+				EndPosition:        planNodes[i].Pose(),
+				Frame:              pm.frame,
+			})
+			planNodes[i].SetCost(cost)
+		}
 		goalMap[planNodes[i]] = lastNode
 		lastNode = planNodes[i]
 	}

--- a/motionplan/planManager.go
+++ b/motionplan/planManager.go
@@ -243,7 +243,7 @@ func (pm *planManager) planAtomicWaypoints(
 
 	// All goals have been submitted for solving. Reconstruct in order
 	for _, future := range resultPromises {
-		steps, err := future.result(ctx)
+		steps, err := future.result()
 		if err != nil {
 			return nil, err
 		}
@@ -445,7 +445,7 @@ func (pm *planManager) planParallelRRTMotion(
 
 		// If we ran a fallback, retrieve the result and compare to the smoothed path
 		if alternateFuture != nil {
-			alternate, err := alternateFuture.result(ctx)
+			alternate, err := alternateFuture.result()
 			if err == nil {
 				// If the fallback successfully found a path, check if it is better than our smoothed previous path.
 				// The fallback should emerge pre-smoothed, so that should be a non-issue

--- a/motionplan/planManager.go
+++ b/motionplan/planManager.go
@@ -332,8 +332,8 @@ func (pm *planManager) planParallelRRTMotion(
 		}
 	} else {
 		if maps == nil {
-			startNode := &basicNode{q: make([]referenceframe.Input, len(pm.frame.DoF())), cost: 0, pose: spatialmath.NewZeroPose()}
-			goalNode := &basicNode{q: make([]referenceframe.Input, len(pm.frame.DoF())), cost: 0, pose: goal, corner: false}
+			startNode := &basicNode{q: make([]referenceframe.Input, len(pm.frame.DoF())), pose: spatialmath.NewZeroPose()}
+			goalNode := &basicNode{q: make([]referenceframe.Input, len(pm.frame.DoF())), pose: goal}
 			maps = &rrtMaps{
 				startMap: map[node]node{startNode: nil},
 				goalMap:  map[node]node{goalNode: nil},
@@ -684,7 +684,7 @@ func (pm *planManager) planToRRTGoalMap(plan Plan, goal spatialmath.Pose) (*rrtM
 		lastNode = planNodes[i]
 	}
 
-	startNode := &basicNode{q: make([]referenceframe.Input, len(pm.frame.DoF())), cost: 0, pose: spatialmath.NewZeroPose()}
+	startNode := &basicNode{q: make([]referenceframe.Input, len(pm.frame.DoF())), pose: spatialmath.NewZeroPose()}
 	maps := &rrtMaps{
 		startMap: map[node]node{startNode: nil},
 		goalMap:  goalMap,

--- a/motionplan/tpSpaceRRT.go
+++ b/motionplan/tpSpaceRRT.go
@@ -747,6 +747,7 @@ func (mp *tpSpaceRRTMotionPlanner) smoothPath(ctx context.Context, path []node) 
 	smoothPlanner := smoothPlannerMP.(*tpSpaceRRTMotionPlanner)
 	smoothPlanner.algOpts.bidirectional = true
 	for i := 0; i < toIter; i++ {
+		mp.logger.Debugf("TP Space smoothing iteration %d of %d", i, toIter)
 		select {
 		case <-ctx.Done():
 			return path

--- a/motionplan/tpSpaceRRT.go
+++ b/motionplan/tpSpaceRRT.go
@@ -154,7 +154,7 @@ func (mp *tpSpaceRRTMotionPlanner) plan(ctx context.Context,
 	planRunners.Add(1)
 	utils.PanicCapturingGo(func() {
 		defer planRunners.Done()
-		mp.rrtBackgroundRunner(ctx, seed, &rrtParallelPlannerShared{
+		mp.planRunner(ctx, seed, &rrtParallelPlannerShared{
 			&rrtMaps{
 				startMap: map[node]node{startNode: nil},
 				goalMap:  map[node]node{goalNode: nil},
@@ -177,7 +177,7 @@ func (mp *tpSpaceRRTMotionPlanner) plan(ctx context.Context,
 
 // planRunner will execute the plan. Plan() will call planRunner in a separate thread and wait for results.
 // Separating this allows other things to call planRunner in parallel allowing the thread-agnostic Plan to be accessible.
-func (mp *tpSpaceRRTMotionPlanner) rrtBackgroundRunner(
+func (mp *tpSpaceRRTMotionPlanner) planRunner(
 	ctx context.Context,
 	_ []referenceframe.Input, // TODO: this may be needed for smoothing
 	rrt *rrtParallelPlannerShared,

--- a/motionplan/tpSpaceRRT.go
+++ b/motionplan/tpSpaceRRT.go
@@ -154,7 +154,7 @@ func (mp *tpSpaceRRTMotionPlanner) plan(ctx context.Context,
 	planRunners.Add(1)
 	utils.PanicCapturingGo(func() {
 		defer planRunners.Done()
-		mp.planRunner(ctx, seed, &rrtParallelPlannerShared{
+		mp.rrtBackgroundRunner(ctx, seed, &rrtParallelPlannerShared{
 			&rrtMaps{
 				startMap: map[node]node{startNode: nil},
 				goalMap:  map[node]node{goalNode: nil},
@@ -177,7 +177,7 @@ func (mp *tpSpaceRRTMotionPlanner) plan(ctx context.Context,
 
 // planRunner will execute the plan. Plan() will call planRunner in a separate thread and wait for results.
 // Separating this allows other things to call planRunner in parallel allowing the thread-agnostic Plan to be accessible.
-func (mp *tpSpaceRRTMotionPlanner) planRunner(
+func (mp *tpSpaceRRTMotionPlanner) rrtBackgroundRunner(
 	ctx context.Context,
 	_ []referenceframe.Input, // TODO: this may be needed for smoothing
 	rrt *rrtParallelPlannerShared,

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -593,14 +593,18 @@ func TestMoveOnGlobe(t *testing.T) {
 	extra := make(map[string]interface{})
 	extra["motion_profile"] = "position_only"
 	extra["timeout"] = 5.
-	validatedExtra, err := newValidatedExtra(extra)
+	extra["smooth_iter"] = 5.
+	valExtra, err := newValidatedExtra(extra)
 	test.That(t, err, test.ShouldBeNil)
+
+	extraSmooth := map[string]interface{}{"smooth_iter": 5}
 
 	dst := geo.NewPoint(gpsPoint.Lat(), gpsPoint.Lng()+1e-5)
 	expectedDst := r3.Vector{380, 0, 0} // Relative pose to the starting point of the base; facing north, Y = forwards
 	epsilonMM := 15.
 
 	t.Run("returns error when called with an unknown component", func(t *testing.T) {
+		t.Parallel()
 		injectedMovementSensor, _, _, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 		defer ms.Close(ctx)
 		success, err := ms.MoveOnGlobe(
@@ -618,6 +622,7 @@ func TestMoveOnGlobe(t *testing.T) {
 	})
 
 	t.Run("returns error when called with an unknown movement sensor", func(t *testing.T) {
+		t.Parallel()
 		_, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 		defer ms.Close(ctx)
 		success, err := ms.MoveOnGlobe(
@@ -636,6 +641,7 @@ func TestMoveOnGlobe(t *testing.T) {
 	})
 
 	t.Run("returns error when request would require moving more than 5 km", func(t *testing.T) {
+		t.Parallel()
 		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 		defer ms.Close(ctx)
 		success, err := ms.MoveOnGlobe(
@@ -652,6 +658,7 @@ func TestMoveOnGlobe(t *testing.T) {
 		test.That(t, success, test.ShouldBeFalse)
 	})
 	t.Run("returns error when destination is nil", func(t *testing.T) {
+		t.Parallel()
 		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 		defer ms.Close(ctx)
 		success, err := ms.MoveOnGlobe(
@@ -669,6 +676,7 @@ func TestMoveOnGlobe(t *testing.T) {
 	})
 
 	t.Run("returns error when destination contains NaN", func(t *testing.T) {
+		t.Parallel()
 		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 		defer ms.Close(ctx)
 		success, err := ms.MoveOnGlobe(
@@ -712,6 +720,7 @@ func TestMoveOnGlobe(t *testing.T) {
 	})
 
 	t.Run("is able to reach a nearby geo point with empty values", func(t *testing.T) {
+		t.Parallel()
 		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 		defer ms.Close(ctx)
 		success, err := ms.MoveOnGlobe(
@@ -722,13 +731,14 @@ func TestMoveOnGlobe(t *testing.T) {
 			injectedMovementSensor.Name(),
 			nil,
 			nil,
-			nil,
+			extraSmooth,
 		)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, success, test.ShouldBeTrue)
 	})
 
 	t.Run("is able to reach a nearby geo point with a requested NaN heading", func(t *testing.T) {
+		t.Parallel()
 		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 		defer ms.Close(ctx)
 		success, err := ms.MoveOnGlobe(
@@ -739,13 +749,14 @@ func TestMoveOnGlobe(t *testing.T) {
 			injectedMovementSensor.Name(),
 			nil,
 			nil,
-			nil,
+			extraSmooth,
 		)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, success, test.ShouldBeTrue)
 	})
 
 	t.Run("is able to reach a nearby geo point with a requested positive heading", func(t *testing.T) {
+		t.Parallel()
 		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 		defer ms.Close(ctx)
 		success, err := ms.MoveOnGlobe(
@@ -756,13 +767,14 @@ func TestMoveOnGlobe(t *testing.T) {
 			injectedMovementSensor.Name(),
 			nil,
 			nil,
-			nil,
+			extraSmooth,
 		)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, success, test.ShouldBeTrue)
 	})
 
 	t.Run("is able to reach a nearby geo point with a requested negative heading", func(t *testing.T) {
+		t.Parallel()
 		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 		defer ms.Close(ctx)
 		success, err := ms.MoveOnGlobe(
@@ -773,13 +785,14 @@ func TestMoveOnGlobe(t *testing.T) {
 			injectedMovementSensor.Name(),
 			nil,
 			nil,
-			nil,
+			extraSmooth,
 		)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, success, test.ShouldBeTrue)
 	})
 
 	t.Run("returns an error if the base provided is not a base", func(t *testing.T) {
+		t.Parallel()
 		injectedMovementSensor, _, _, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 		defer ms.Close(ctx)
 		success, err := ms.MoveOnGlobe(
@@ -797,6 +810,7 @@ func TestMoveOnGlobe(t *testing.T) {
 	})
 
 	t.Run("returns an error if the movement_sensor provided is not a movement_sensor", func(t *testing.T) {
+		t.Parallel()
 		_, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 		defer ms.Close(ctx)
 		success, err := ms.MoveOnGlobe(
@@ -814,6 +828,7 @@ func TestMoveOnGlobe(t *testing.T) {
 	})
 
 	t.Run("is able to reach a nearby geo point when the motion configuration is empty", func(t *testing.T) {
+		t.Parallel()
 		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 		defer ms.Close(ctx)
 		success, err := ms.MoveOnGlobe(
@@ -824,13 +839,14 @@ func TestMoveOnGlobe(t *testing.T) {
 			injectedMovementSensor.Name(),
 			nil,
 			&motion.MotionConfiguration{},
-			nil,
+			extraSmooth,
 		)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, success, test.ShouldBeTrue)
 	})
 
 	t.Run("errors when motion configuration has a negative PlanDeviationMM", func(t *testing.T) {
+		t.Parallel()
 		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 		defer ms.Close(ctx)
 		success, err := ms.MoveOnGlobe(
@@ -848,6 +864,7 @@ func TestMoveOnGlobe(t *testing.T) {
 	})
 
 	t.Run("errors when motion configuration has a NaN PlanDeviationMM", func(t *testing.T) {
+		t.Parallel()
 		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 		defer ms.Close(ctx)
 		success, err := ms.MoveOnGlobe(
@@ -865,6 +882,7 @@ func TestMoveOnGlobe(t *testing.T) {
 	})
 
 	t.Run("returns an error when the motion configuration has a negative ObstaclePollingFreqHz", func(t *testing.T) {
+		t.Parallel()
 		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 		defer ms.Close(ctx)
 		success, err := ms.MoveOnGlobe(
@@ -882,6 +900,7 @@ func TestMoveOnGlobe(t *testing.T) {
 	})
 
 	t.Run("returns an error when the motion configuration has a NaN ObstaclePollingFreqHz", func(t *testing.T) {
+		t.Parallel()
 		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 		defer ms.Close(ctx)
 		success, err := ms.MoveOnGlobe(
@@ -899,6 +918,7 @@ func TestMoveOnGlobe(t *testing.T) {
 	})
 
 	t.Run("returns an error when the motion configuration has a negative PositionPollingFreqHz", func(t *testing.T) {
+		t.Parallel()
 		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 		defer ms.Close(ctx)
 		success, err := ms.MoveOnGlobe(
@@ -916,6 +936,7 @@ func TestMoveOnGlobe(t *testing.T) {
 	})
 
 	t.Run("returns an error when the motion configuration has a NaN PositionPollingFreqHz", func(t *testing.T) {
+		t.Parallel()
 		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 		defer ms.Close(ctx)
 		success, err := ms.MoveOnGlobe(
@@ -933,6 +954,7 @@ func TestMoveOnGlobe(t *testing.T) {
 	})
 
 	t.Run("returns an error when motion configuration has a negative AngularDegsPerSec", func(t *testing.T) {
+		t.Parallel()
 		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 		defer ms.Close(ctx)
 		success, err := ms.MoveOnGlobe(
@@ -950,6 +972,7 @@ func TestMoveOnGlobe(t *testing.T) {
 	})
 
 	t.Run("returns an error when motion configuration has a NaN AngularDegsPerSec", func(t *testing.T) {
+		t.Parallel()
 		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 		defer ms.Close(ctx)
 		success, err := ms.MoveOnGlobe(
@@ -967,6 +990,7 @@ func TestMoveOnGlobe(t *testing.T) {
 	})
 
 	t.Run("returns an error when motion configuration has a negative LinearMPerSec", func(t *testing.T) {
+		t.Parallel()
 		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 		defer ms.Close(ctx)
 		success, err := ms.MoveOnGlobe(
@@ -984,6 +1008,7 @@ func TestMoveOnGlobe(t *testing.T) {
 	})
 
 	t.Run("returns an error when motion configuration has a NaN LinearMPerSec", func(t *testing.T) {
+		t.Parallel()
 		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 		defer ms.Close(ctx)
 		success, err := ms.MoveOnGlobe(
@@ -1012,7 +1037,7 @@ func TestMoveOnGlobe(t *testing.T) {
 			[]*spatialmath.GeoObstacle{},
 			motionCfg,
 			nil,
-			validatedExtra,
+			valExtra,
 		)
 		test.That(t, err, test.ShouldBeNil)
 
@@ -1058,7 +1083,7 @@ func TestMoveOnGlobe(t *testing.T) {
 			[]*spatialmath.GeoObstacle{geoObstacle},
 			motionCfg,
 			nil,
-			validatedExtra,
+			valExtra,
 		)
 		test.That(t, err, test.ShouldBeNil)
 		waypoints, err := mr.plan(ctx)
@@ -1116,7 +1141,7 @@ func TestMoveOnGlobe(t *testing.T) {
 			[]*spatialmath.GeoObstacle{geoObstacle},
 			&motion.MotionConfiguration{},
 			nil,
-			validatedExtra,
+			valExtra,
 		)
 		test.That(t, err, test.ShouldBeNil)
 		plan, err := moveRequest.plan(ctx)
@@ -1158,7 +1183,7 @@ func TestReplanning(t *testing.T) {
 			name:            "check we dont replan with a good sensor",
 			noise:           r3.Vector{Y: epsilonMM - 0.1},
 			expectedSuccess: true,
-			extra:           map[string]interface{}{},
+			extra:           map[string]interface{}{"smooth_iter": 5},
 		},
 		{
 			// This also checks that `replan` is called under default conditions when "max_replans" is not set
@@ -1166,14 +1191,14 @@ func TestReplanning(t *testing.T) {
 			noise:           r3.Vector{Y: epsilonMM + 0.1},
 			expectedErr:     "unable to create a new plan within replanCostFactor from the original",
 			expectedSuccess: false,
-			extra:           map[string]interface{}{"replan_cost_factor": 0.01},
+			extra:           map[string]interface{}{"replan_cost_factor": 0.01, "smooth_iter": 5},
 		},
 		{
 			name:            "check we replan with a noisy sensor",
 			noise:           r3.Vector{Y: epsilonMM + 0.1},
 			expectedErr:     fmt.Sprintf("exceeded maximum number of replans: %d", 4),
 			expectedSuccess: false,
-			extra:           map[string]interface{}{"replan_cost_factor": 10.0, "max_replans": 4},
+			extra:           map[string]interface{}{"replan_cost_factor": 10.0, "max_replans": 4, "smooth_iter": 5},
 		},
 	}
 

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -720,7 +720,6 @@ func TestMoveOnGlobe(t *testing.T) {
 	})
 
 	t.Run("is able to reach a nearby geo point with empty values", func(t *testing.T) {
-		t.Parallel()
 		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 		defer ms.Close(ctx)
 		success, err := ms.MoveOnGlobe(
@@ -738,7 +737,6 @@ func TestMoveOnGlobe(t *testing.T) {
 	})
 
 	t.Run("is able to reach a nearby geo point with a requested NaN heading", func(t *testing.T) {
-		t.Parallel()
 		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 		defer ms.Close(ctx)
 		success, err := ms.MoveOnGlobe(
@@ -756,7 +754,6 @@ func TestMoveOnGlobe(t *testing.T) {
 	})
 
 	t.Run("is able to reach a nearby geo point with a requested positive heading", func(t *testing.T) {
-		t.Parallel()
 		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 		defer ms.Close(ctx)
 		success, err := ms.MoveOnGlobe(
@@ -774,7 +771,6 @@ func TestMoveOnGlobe(t *testing.T) {
 	})
 
 	t.Run("is able to reach a nearby geo point with a requested negative heading", func(t *testing.T) {
-		t.Parallel()
 		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 		defer ms.Close(ctx)
 		success, err := ms.MoveOnGlobe(
@@ -828,7 +824,6 @@ func TestMoveOnGlobe(t *testing.T) {
 	})
 
 	t.Run("is able to reach a nearby geo point when the motion configuration is empty", func(t *testing.T) {
-		t.Parallel()
 		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 		defer ms.Close(ctx)
 		success, err := ms.MoveOnGlobe(
@@ -1026,7 +1021,6 @@ func TestMoveOnGlobe(t *testing.T) {
 	})
 
 	t.Run("ensure success to a nearby geo point", func(t *testing.T) {
-		t.Parallel()
 		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 		motionCfg := &motion.MotionConfiguration{PositionPollingFreqHz: 4, ObstaclePollingFreqHz: 1, PlanDeviationMM: epsilonMM}
 		mr, err := ms.(*builtIn).newMoveOnGlobeRequest(
@@ -1063,7 +1057,6 @@ func TestMoveOnGlobe(t *testing.T) {
 	})
 
 	t.Run("go around an obstacle", func(t *testing.T) {
-		t.Parallel()
 		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 		motionCfg := &motion.MotionConfiguration{PositionPollingFreqHz: 4, ObstaclePollingFreqHz: 1, PlanDeviationMM: epsilonMM}
 
@@ -1111,7 +1104,6 @@ func TestMoveOnGlobe(t *testing.T) {
 	})
 
 	t.Run("fail because of obstacle", func(t *testing.T) {
-		t.Parallel()
 		injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil)
 
 		// Construct a set of obstacles that entirely enclose the goal point


### PR DESCRIPTION
This PR will pre-construct a goal tree from a pre-existing plan, allowing solving to happen very quickly.

Note that by far most of our runtime is still spent in smoothing, so this only helps to a point.