### PR TITLE
Rework collision geometries for bases

### DIFF
--- a/components/base/kinematicbase/differentialDrive.go
+++ b/components/base/kinematicbase/differentialDrive.go
@@ -56,7 +56,7 @@ func wrapWithDifferentialDriveKinematics(
 	}
 	sphere, err := spatialmath.BoundingSphere(geometry)
 	if err != nil {
-		logger.Warnf("base %s not configured with a geometry, will be considered a point mass for collision detection purposes.")
+		logger.Warn("base %s not configured with a geometry, will be considered a point mass for collision detection purposes.")
 		sphere = spatialmath.NewPoint(r3.Vector{}, b.Name().Name)
 	}
 

--- a/components/base/kinematicbase/differentialDrive.go
+++ b/components/base/kinematicbase/differentialDrive.go
@@ -54,13 +54,21 @@ func wrapWithDifferentialDriveKinematics(
 	if len(geometries) > 0 {
 		geometry = geometries[0]
 	}
-	ddk.executionFrame, err = referenceframe.New2DMobileModelFrame(b.Name().ShortName(), limits, geometry)
+	sphere, err := spatialmath.BoundingSphere(geometry)
+	if err != nil {
+		// default to using a point to represent the base for the purposes of collision handling rather than erroring
+		logger.Warnf("base %s not configured with a geometry, defaulting to considering it a point mass." +
+			"Use caution as collision handling will likely return many false negatives")
+		sphere = spatialmath.NewPoint(r3.Vector{}, b.Name().Name)
+	}
+
+	ddk.executionFrame, err = referenceframe.New2DMobileModelFrame(b.Name().ShortName(), limits, sphere)
 	if err != nil {
 		return nil, err
 	}
 
 	if options.PositionOnlyMode {
-		ddk.planningFrame, err = referenceframe.New2DMobileModelFrame(b.Name().ShortName(), limits[:2], geometry)
+		ddk.planningFrame, err = referenceframe.New2DMobileModelFrame(b.Name().ShortName(), limits[:2], sphere)
 		if err != nil {
 			return nil, err
 		}
@@ -236,43 +244,6 @@ func (ddk *differentialDriveKinematics) inputDiff(current, desired []referencefr
 	headingErr := math.Mod(delta.Orientation().OrientationVectorDegrees().Theta, 360)
 	positionErr := delta.Point().Norm()
 	return positionErr, headingErr, nil
-}
-
-// CollisionGeometry returns a spherical geometry that will encompass the base if it were to rotate the geometry specified in the config
-// 360 degrees about the Z axis of the reference frame specified in the config.
-func CollisionGeometry(cfg *referenceframe.LinkConfig) ([]spatialmath.Geometry, error) {
-	// TODO(RSDK-1014): the orientation of this model will matter for collision checking,
-	// and should match the convention of +Y being forward for bases
-	if cfg == nil || cfg.Geometry == nil {
-		return nil, errors.New("not configured with a geometry use caution if using motion service - collisions will not be accounted for")
-	}
-	geoCfg := cfg.Geometry
-	r := geoCfg.TranslationOffset.Norm()
-	switch geoCfg.Type {
-	case spatialmath.BoxType:
-		r += r3.Vector{X: geoCfg.X, Y: geoCfg.Y, Z: geoCfg.Z}.Norm() / 2
-	case spatialmath.SphereType:
-		r += geoCfg.R
-	case spatialmath.CapsuleType:
-		r += geoCfg.L / 2
-	case spatialmath.UnknownType:
-		// no type specified, iterate through supported types and try to infer intent
-		if norm := (r3.Vector{X: geoCfg.X, Y: geoCfg.Y, Z: geoCfg.Z}).Norm(); norm > 0 {
-			r += norm / 2
-		} else if geoCfg.L != 0 {
-			r += geoCfg.L / 2
-		} else {
-			r += geoCfg.R
-		}
-	case spatialmath.PointType:
-	default:
-		return nil, spatialmath.ErrGeometryTypeUnsupported
-	}
-	sphere, err := spatialmath.NewSphere(spatialmath.NewZeroPose(), r, geoCfg.Label)
-	if err != nil {
-		return nil, err
-	}
-	return []spatialmath.Geometry{sphere}, nil
 }
 
 // newValidRegionCapsule returns a capsule which defines the valid regions for a base to be when moving to a waypoint.

--- a/components/base/kinematicbase/differentialDrive.go
+++ b/components/base/kinematicbase/differentialDrive.go
@@ -56,9 +56,7 @@ func wrapWithDifferentialDriveKinematics(
 	}
 	sphere, err := spatialmath.BoundingSphere(geometry)
 	if err != nil {
-		// default to using a point to represent the base for the purposes of collision handling rather than erroring
-		logger.Warnf("base %s not configured with a geometry, defaulting to considering it a point mass." +
-			"Use caution as collision handling will likely return many false negatives")
+		logger.Warnf("base %s not configured with a geometry, will be considered a point mass for collision detection purposes.")
 		sphere = spatialmath.NewPoint(r3.Vector{}, b.Name().Name)
 	}
 

--- a/components/base/kinematicbase/differentialDrive_test.go
+++ b/components/base/kinematicbase/differentialDrive_test.go
@@ -143,11 +143,6 @@ func buildTestDDK(
 	if err != nil {
 		return nil, err
 	}
-	geometries, err := CollisionGeometry(cfg.Frame)
-	if err != nil {
-		return nil, err
-	}
-	b.(*fakebase.Base).Geometry = geometries
 
 	// make a SLAM service and get its limits
 	fakeSLAM := fake.NewSLAM(slam.Named("test"), logger)

--- a/components/base/wheeled/wheeled_base.go
+++ b/components/base/wheeled/wheeled_base.go
@@ -43,7 +43,6 @@ import (
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/base"
-	"go.viam.com/rdk/components/base/kinematicbase"
 	"go.viam.com/rdk/components/motor"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/operation"
@@ -122,11 +121,14 @@ func (wb *wheeledBase) Reconfigure(ctx context.Context, deps resource.Dependenci
 	wb.mu.Lock()
 	defer wb.mu.Unlock()
 
-	geometries, err := kinematicbase.CollisionGeometry(conf.Frame)
-	if err != nil {
-		wb.logger.Warnf("base %v %s", wb.Name(), err.Error())
+	wb.geometries = []spatialmath.Geometry{}
+	if conf.Frame != nil {
+		frame, err := conf.Frame.ParseConfig()
+		if err != nil {
+			return err
+		}
+		wb.geometries = append(wb.geometries, frame.Geometry())
 	}
-	wb.geometries = geometries
 
 	newConf, err := resource.NativeConfig[*Config](conf)
 	if err != nil {

--- a/components/base/wheeled/wheeled_base_test.go
+++ b/components/base/wheeled/wheeled_base_test.go
@@ -84,7 +84,7 @@ func TestWheelBaseMath(t *testing.T) {
 		test.That(t, props.WidthMeters, test.ShouldEqual, 100*0.001)
 
 		geometries, err := wb.Geometries(ctx, nil)
-		test.That(t, geometries, test.ShouldBeNil)
+		test.That(t, len(geometries), test.ShouldBeZeroValue)
 		test.That(t, err, test.ShouldBeNil)
 
 		err = wb.SetVelocity(ctx, r3.Vector{X: 0, Y: 10, Z: 0}, r3.Vector{X: 0, Y: 0, Z: 10}, nil)

--- a/examples/customresources/models/mybase/mybase.go
+++ b/examples/customresources/models/mybase/mybase.go
@@ -11,7 +11,6 @@ import (
 	"go.uber.org/multierr"
 
 	"go.viam.com/rdk/components/base"
-	"go.viam.com/rdk/components/base/kinematicbase"
 	"go.viam.com/rdk/components/motor"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -68,11 +67,13 @@ func (b *myBase) Reconfigure(ctx context.Context, deps resource.Dependencies, co
 		return errors.Wrapf(err, "unable to get motor %v for mybase", baseConfig.RightMotor)
 	}
 
-	geometries, err := kinematicbase.CollisionGeometry(conf.Frame)
-	if err != nil {
-		b.logger.Warnf("base %v %s", b.Name(), err.Error())
+	if conf.Frame != nil && conf.Frame.Geometry != nil {
+		geometry, err := conf.Frame.Geometry.ParseConfig()
+		if err != nil {
+			return err
+		}
+		b.geometries = []spatialmath.Geometry{geometry}
 	}
-	b.geometries = geometries
 
 	// Good practice to stop motors, but also this effectively tests https://viam.atlassian.net/browse/RSDK-2496
 	return multierr.Combine(b.left.Stop(context.Background(), nil), b.right.Stop(context.Background(), nil))

--- a/spatialmath/errors.go
+++ b/spatialmath/errors.go
@@ -2,9 +2,7 @@ package spatialmath
 
 import "github.com/pkg/errors"
 
-// ErrGeometryTypeUnsupported is an error that is returned when an unsupported GeometryType is specified
-// (either implicitly or explicitly) in a GeometryConfig.
-var ErrGeometryTypeUnsupported = errors.New("unsupported Geometry type")
+var errGeometryTypeUnsupported = errors.New("unsupported Geometry type")
 
 func newBadGeometryDimensionsError(g Geometry) error {
 	return errors.Errorf("Invalid dimension(s) for Geometry type %T", g)

--- a/spatialmath/geometry.go
+++ b/spatialmath/geometry.go
@@ -88,7 +88,7 @@ func NewGeometryConfig(gc Geometry) (*GeometryConfig, error) {
 		config.Type = PointType
 		config.Label = gc.(*point).label
 	default:
-		return nil, fmt.Errorf("%w %s", ErrGeometryTypeUnsupported, fmt.Sprintf("%T", gcType))
+		return nil, fmt.Errorf("%w %s", errGeometryTypeUnsupported, fmt.Sprintf("%T", gcType))
 	}
 	offset := gc.Pose()
 	o := offset.Orientation()
@@ -136,7 +136,7 @@ func (config *GeometryConfig) ParseConfig() (Geometry, error) {
 		}
 		// never try to infer point geometry if nothing is specified
 	}
-	return nil, fmt.Errorf("%w %s", ErrGeometryTypeUnsupported, string(config.Type))
+	return nil, fmt.Errorf("%w %s", errGeometryTypeUnsupported, string(config.Type))
 }
 
 // NewGeometryFromProto instantiates a new Geometry from a protobuf Geometry message.
@@ -154,7 +154,7 @@ func NewGeometryFromProto(geometry *commonpb.Geometry) (Geometry, error) {
 		}
 		return NewSphere(pose, sphere.RadiusMm, geometry.Label)
 	}
-	return nil, ErrGeometryTypeUnsupported
+	return nil, errGeometryTypeUnsupported
 }
 
 // NewGeometriesFromProto converts a list of Geometries from protobuf.

--- a/spatialmath/geometry_test.go
+++ b/spatialmath/geometry_test.go
@@ -84,7 +84,7 @@ func TestGeometryToFromProtobuf(t *testing.T) {
 
 	// test that bad message does not generate error
 	_, err := NewGeometryFromProto(&commonpb.Geometry{Center: PoseToProtobuf(NewZeroPose())})
-	test.That(t, err.Error(), test.ShouldContainSubstring, ErrGeometryTypeUnsupported.Error())
+	test.That(t, err.Error(), test.ShouldContainSubstring, errGeometryTypeUnsupported.Error())
 }
 
 type geometryComparisonTestCase struct {

--- a/spatialmath/geometry_utils.go
+++ b/spatialmath/geometry_utils.go
@@ -81,7 +81,7 @@ func PlaneNormal(p0, p1, p2 r3.Vector) r3.Vector {
 	return p1.Sub(p0).Cross(p2.Sub(p0)).Normalize()
 }
 
-// Bounding sphere returns a spherical geometry centered on the point (0, 0, 0) that will encompass the given geometry
+// BoundingSphere returns a spherical geometry centered on the point (0, 0, 0) that will encompass the given geometry
 // if it were to be rotated 360 degrees about the Z axis.  The label of the new geometry is inherited from the given one.
 func BoundingSphere(geometry Geometry) (Geometry, error) {
 	r := geometry.Pose().Point().Norm()

--- a/spatialmath/geometry_utils.go
+++ b/spatialmath/geometry_utils.go
@@ -94,7 +94,7 @@ func BoundingSphere(geometry Geometry) (Geometry, error) {
 		r += g.length / 2
 	case *point:
 	default:
-		return nil, ErrGeometryTypeUnsupported
+		return nil, errGeometryTypeUnsupported
 	}
 	return NewSphere(NewZeroPose(), r, geometry.Label())
 }

--- a/spatialmath/geometry_utils.go
+++ b/spatialmath/geometry_utils.go
@@ -81,6 +81,24 @@ func PlaneNormal(p0, p1, p2 r3.Vector) r3.Vector {
 	return p1.Sub(p0).Cross(p2.Sub(p0)).Normalize()
 }
 
+// Bounding sphere returns a spherical geometry centered on the point (0, 0, 0) that will encompass the given geometry
+// if it were to be rotated 360 degrees about the Z axis.  The label of the new geometry is inherited from the given one.
+func BoundingSphere(geometry Geometry) (Geometry, error) {
+	r := geometry.Pose().Point().Norm()
+	switch g := geometry.(type) {
+	case *box:
+		r += r3.Vector{X: g.halfSize[0], Y: g.halfSize[1], Z: g.halfSize[2]}.Norm()
+	case *sphere:
+		r += g.radius
+	case *capsule:
+		r += g.length / 2
+	case *point:
+	default:
+		return nil, ErrGeometryTypeUnsupported
+	}
+	return NewSphere(NewZeroPose(), r, geometry.Label())
+}
+
 // closestSegmentTrianglePoints takes a line segment and a triangle, and returns the point on each closest to the other.
 func closestPointsSegmentTriangle(ap1, ap2 r3.Vector, t *triangle) (bestSegPt, bestTriPt r3.Vector) {
 	// The closest triangle point is either on the edge or within the triangle.


### PR DESCRIPTION
This PR does two things
- removes a warning that was occurring when no geometry was configured for a base
- if no frame is specified for the base the kinematic wrapper wrapping it will assign it a point collision geometry