### PR TITLE
[RSDK-5248] make the MPU6050 talk to the I2C bus directly

### DIFF
--- a/components/movementsensor/mpu6050/mpu6050.go
+++ b/components/movementsensor/mpu6050/mpu6050.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 // Package mpu6050 implements the movementsensor interface for an MPU-6050 6-axis accelerometer. A
 // datasheet for this chip is at
 // https://components101.com/sites/default/files/component_datasheet/MPU6050-DataSheet.pdf and a

--- a/components/movementsensor/mpu6050/mpu6050.go
+++ b/components/movementsensor/mpu6050/mpu6050.go
@@ -116,6 +116,21 @@ func NewMpu6050(
 	if err != nil {
 		return nil, err
 	}
+	return makeMpu6050(ctx, deps, conf, logger, bus)
+}
+
+// This function is separated from NewMpu6050 solely so you can inject a mock I2C bus in tests.
+func makeMpu6050(
+	ctx context.Context,
+    deps resource.Dependencies,
+    conf resource.Config,
+    logger logging.Logger,
+	bus board.I2C,
+) (movementsensor.MovementSensor, error) {
+	newConf, err := resource.NativeConfig[*Config](conf)
+	if err != nil {
+		return nil, err
+	}
 
 	var address byte
 	if newConf.UseAlternateI2CAddress {

--- a/components/movementsensor/mpu6050/mpu6050.go
+++ b/components/movementsensor/mpu6050/mpu6050.go
@@ -30,6 +30,7 @@ import (
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/genericlinux"
 	"go.viam.com/rdk/components/movementsensor"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -47,7 +48,6 @@ const (
 
 // Config is used to configure the attributes of the chip.
 type Config struct {
-	BoardName              string `json:"board"`
 	I2cBus                 string `json:"i2c_bus"`
 	UseAlternateI2CAddress bool   `json:"use_alt_i2c_address,omitempty"`
 }
@@ -55,15 +55,11 @@ type Config struct {
 // Validate ensures all parts of the config are valid, and then returns the list of things we
 // depend on.
 func (conf *Config) Validate(path string) ([]string, error) {
-	if conf.BoardName == "" {
-		return nil, utils.NewConfigValidationFieldRequiredError(path, "board")
-	}
 	if conf.I2cBus == "" {
 		return nil, utils.NewConfigValidationFieldRequiredError(path, "i2c_bus")
 	}
 
 	var deps []string
-	deps = append(deps, conf.BoardName)
 	return deps, nil
 }
 
@@ -94,9 +90,8 @@ type mpu6050 struct {
 	logger                  logging.Logger
 }
 
-func addressReadError(err error, address byte, bus, board string) error {
-	msg := fmt.Sprintf("can't read from I2C address %d on bus %s of board %s",
-		address, bus, board)
+func addressReadError(err error, address byte, bus string) error {
+	msg := fmt.Sprintf("can't read from I2C address %d on bus %s", address, bus)
 	return errors.Wrap(err, msg)
 }
 
@@ -117,17 +112,9 @@ func NewMpu6050(
 		return nil, err
 	}
 
-	b, err := board.FromDependencies(deps, newConf.BoardName)
+	bus, err := genericlinux.NewI2cBus(newConf.I2cBus)
 	if err != nil {
 		return nil, err
-	}
-	localB, ok := b.(board.LocalBoard)
-	if !ok {
-		return nil, errors.Errorf("board %s is not local", newConf.BoardName)
-	}
-	bus, ok := localB.I2CByName(newConf.I2cBus)
-	if !ok {
-		return nil, errors.Errorf("can't find I2C bus '%s' for MPU6050 sensor", newConf.I2cBus)
 	}
 
 	var address byte
@@ -155,7 +142,7 @@ func NewMpu6050(
 	// back the device's non-alternative address (0x68)
 	defaultAddress, err := sensor.readByte(ctx, defaultAddressRegister)
 	if err != nil {
-		return nil, addressReadError(err, address, newConf.I2cBus, newConf.BoardName)
+		return nil, addressReadError(err, address, newConf.I2cBus)
 	}
 	if defaultAddress != expectedDefaultAddress {
 		return nil, unexpectedDeviceError(address, defaultAddress)

--- a/components/movementsensor/mpu6050/mpu6050.go
+++ b/components/movementsensor/mpu6050/mpu6050.go
@@ -122,9 +122,9 @@ func NewMpu6050(
 // This function is separated from NewMpu6050 solely so you can inject a mock I2C bus in tests.
 func makeMpu6050(
 	ctx context.Context,
-    deps resource.Dependencies,
-    conf resource.Config,
-    logger logging.Logger,
+	_ resource.Dependencies,
+	conf resource.Config,
+	logger logging.Logger,
 	bus board.I2C,
 ) (movementsensor.MovementSensor, error) {
 	newConf, err := resource.NativeConfig[*Config](conf)

--- a/components/movementsensor/mpu6050/mpu6050_nonlinux.go
+++ b/components/movementsensor/mpu6050/mpu6050_nonlinux.go
@@ -1,0 +1,2 @@
+// Package mpu6050 is only implemented for Linux systems.
+package mpu6050

--- a/components/movementsensor/mpu6050/mpu6050_test.go
+++ b/components/movementsensor/mpu6050/mpu6050_test.go
@@ -38,7 +38,6 @@ func TestValidateConfig(t *testing.T) {
 
 func TestInitializationFailureOnChipCommunication(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	testBoardName := "board"
 	i2cName := "i2c"
 
 	t.Run("fails on read error", func(t *testing.T) {
@@ -59,18 +58,13 @@ func TestInitializationFailureOnChipCommunication(t *testing.T) {
 			return []byte{}, nil
 		}
 		i2cHandle.CloseFunc = func() error { return nil }
-		mockBoard := &inject.Board{}
-		mockBoard.I2CByNameFunc = func(name string) (board.I2C, bool) {
-			i2c := &inject.I2C{}
-			i2c.OpenHandleFunc = func(addr byte) (board.I2CHandle, error) {
-				return i2cHandle, nil
-			}
-			return i2c, true
+		i2c := &inject.I2C{}
+		i2c.OpenHandleFunc = func(addr byte) (board.I2CHandle, error) {
+			return i2cHandle, nil
 		}
-		deps := resource.Dependencies{
-			resource.NewName(board.API, testBoardName): mockBoard,
-		}
-		sensor, err := NewMpu6050(context.Background(), deps, cfg, logger)
+
+		deps := resource.Dependencies{}
+		sensor, err := makeMpu6050(context.Background(), deps, cfg, logger, i2c)
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err, test.ShouldBeError, addressReadError(readErr, expectedDefaultAddress, i2cName))
 		test.That(t, sensor, test.ShouldBeNil)
@@ -94,18 +88,13 @@ func TestInitializationFailureOnChipCommunication(t *testing.T) {
 			return nil, errors.New("unexpected register")
 		}
 		i2cHandle.CloseFunc = func() error { return nil }
-		mockBoard := &inject.Board{}
-		mockBoard.I2CByNameFunc = func(name string) (board.I2C, bool) {
-			i2c := &inject.I2C{}
-			i2c.OpenHandleFunc = func(addr byte) (board.I2CHandle, error) {
-				return i2cHandle, nil
-			}
-			return i2c, true
+		i2c := &inject.I2C{}
+		i2c.OpenHandleFunc = func(addr byte) (board.I2CHandle, error) {
+			return i2cHandle, nil
 		}
-		deps := resource.Dependencies{
-			resource.NewName(board.API, testBoardName): mockBoard,
-		}
-		sensor, err := NewMpu6050(context.Background(), deps, cfg, logger)
+
+		deps := resource.Dependencies{}
+		sensor, err := makeMpu6050(context.Background(), deps, cfg, logger, i2c)
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err, test.ShouldBeError, unexpectedDeviceError(alternateAddress, 0x64))
 		test.That(t, sensor, test.ShouldBeNil)
@@ -114,7 +103,6 @@ func TestInitializationFailureOnChipCommunication(t *testing.T) {
 
 func TestSuccessfulInitializationAndClose(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	testBoardName := "board"
 	i2cName := "i2c"
 
 	cfg := resource.Config{
@@ -142,26 +130,20 @@ func TestSuccessfulInitializationAndClose(t *testing.T) {
 		return nil
 	}
 	i2cHandle.CloseFunc = func() error { return nil }
-	mockBoard := &inject.Board{}
-	mockBoard.I2CByNameFunc = func(name string) (board.I2C, bool) {
-		i2c := &inject.I2C{}
-		i2c.OpenHandleFunc = func(addr byte) (board.I2CHandle, error) {
-			return i2cHandle, nil
-		}
-		return i2c, true
+	i2c := &inject.I2C{}
+	i2c.OpenHandleFunc = func(addr byte) (board.I2CHandle, error) {
+		return i2cHandle, nil
 	}
-	deps := resource.Dependencies{
-		resource.NewName(board.API, testBoardName): mockBoard,
-	}
-	sensor, err := NewMpu6050(context.Background(), deps, cfg, logger)
+
+	deps := resource.Dependencies{}
+	sensor, err := makeMpu6050(context.Background(), deps, cfg, logger, i2c)
 	test.That(t, err, test.ShouldBeNil)
 	err = sensor.Close(context.Background())
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, closeWasCalled, test.ShouldBeTrue)
 }
 
-func setupDependencies(mockData []byte) (resource.Config, resource.Dependencies) {
-	testBoardName := "board"
+func setupDependencies(mockData []byte) (resource.Config, board.I2C) {
 	i2cName := "i2c"
 
 	cfg := resource.Config{
@@ -185,17 +167,11 @@ func setupDependencies(mockData []byte) (resource.Config, resource.Dependencies)
 		return nil
 	}
 	i2cHandle.CloseFunc = func() error { return nil }
-	mockBoard := &inject.Board{}
-	mockBoard.I2CByNameFunc = func(name string) (board.I2C, bool) {
-		i2c := &inject.I2C{}
-		i2c.OpenHandleFunc = func(addr byte) (board.I2CHandle, error) {
-			return i2cHandle, nil
-		}
-		return i2c, true
+	i2c := &inject.I2C{}
+	i2c.OpenHandleFunc = func(addr byte) (board.I2CHandle, error) {
+		return i2cHandle, nil
 	}
-	return cfg, resource.Dependencies{
-		resource.NewName(board.API, testBoardName): mockBoard,
-	}
+	return cfg, i2c
 }
 
 //nolint:dupl
@@ -218,8 +194,9 @@ func TestLinearAcceleration(t *testing.T) {
 	expectedAccelZ := 2.4525
 
 	logger := logging.NewTestLogger(t)
-	cfg, deps := setupDependencies(linearAccelMockData)
-	sensor, err := NewMpu6050(context.Background(), deps, cfg, logger)
+	deps := resource.Dependencies{}
+	cfg, i2c := setupDependencies(linearAccelMockData)
+	sensor, err := makeMpu6050(context.Background(), deps, cfg, logger, i2c)
 	test.That(t, err, test.ShouldBeNil)
 	defer sensor.Close(context.Background())
 	testutils.WaitForAssertion(t, func(tb testing.TB) {
@@ -254,8 +231,9 @@ func TestAngularVelocity(t *testing.T) {
 	expectedAngVelZ := 31.25
 
 	logger := logging.NewTestLogger(t)
-	cfg, deps := setupDependencies(angVelMockData)
-	sensor, err := NewMpu6050(context.Background(), deps, cfg, logger)
+	deps := resource.Dependencies{}
+	cfg, i2c := setupDependencies(angVelMockData)
+	sensor, err := makeMpu6050(context.Background(), deps, cfg, logger, i2c)
 	test.That(t, err, test.ShouldBeNil)
 	defer sensor.Close(context.Background())
 	testutils.WaitForAssertion(t, func(tb testing.TB) {
@@ -280,8 +258,9 @@ func TestTemperature(t *testing.T) {
 	expectedTemp := 18.3
 
 	logger := logging.NewTestLogger(t)
-	cfg, deps := setupDependencies(temperatureMockData)
-	sensor, err := NewMpu6050(context.Background(), deps, cfg, logger)
+	deps := resource.Dependencies{}
+	cfg, i2c := setupDependencies(temperatureMockData)
+	sensor, err := makeMpu6050(context.Background(), deps, cfg, logger, i2c)
 	test.That(t, err, test.ShouldBeNil)
 	defer sensor.Close(context.Background())
 	testutils.WaitForAssertion(t, func(tb testing.TB) {

--- a/components/movementsensor/mpu6050/mpu6050_test.go
+++ b/components/movementsensor/mpu6050/mpu6050_test.go
@@ -17,23 +17,11 @@ import (
 )
 
 func TestValidateConfig(t *testing.T) {
-	t.Run("fails with no I2C bus", func(t *testing.T) {
-		cfg := Config{}
-		deps, err := cfg.Validate("path")
-		expectedErr := utils.NewConfigValidationFieldRequiredError("path", "i2c_bus")
-		test.That(t, err, test.ShouldBeError, expectedErr)
-		test.That(t, deps, test.ShouldBeEmpty)
-	})
-
-	t.Run("no dependencies on success", func(t *testing.T) {
-		cfg := Config{
-			I2cBus: "2",
-		}
-		deps, err := cfg.Validate("path")
-
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, len(deps), test.ShouldEqual, 0)
-	})
+	cfg := Config{}
+	deps, err := cfg.Validate("path")
+	expectedErr := utils.NewConfigValidationFieldRequiredError("path", "i2c_bus")
+	test.That(t, err, test.ShouldBeError, expectedErr)
+	test.That(t, deps, test.ShouldBeEmpty)
 }
 
 func TestInitializationFailureOnChipCommunication(t *testing.T) {

--- a/components/movementsensor/mpu6050/mpu6050_test.go
+++ b/components/movementsensor/mpu6050/mpu6050_test.go
@@ -17,37 +17,22 @@ import (
 )
 
 func TestValidateConfig(t *testing.T) {
-	boardName := "local"
-	t.Run("fails with no board supplied", func(t *testing.T) {
-		cfg := Config{
-			I2cBus: "thing",
-		}
-		deps, err := cfg.Validate("path")
-		expectedErr := utils.NewConfigValidationFieldRequiredError("path", "board")
-		test.That(t, err, test.ShouldBeError, expectedErr)
-		test.That(t, deps, test.ShouldBeEmpty)
-	})
-
 	t.Run("fails with no I2C bus", func(t *testing.T) {
-		cfg := Config{
-			BoardName: boardName,
-		}
+		cfg := Config{}
 		deps, err := cfg.Validate("path")
 		expectedErr := utils.NewConfigValidationFieldRequiredError("path", "i2c_bus")
 		test.That(t, err, test.ShouldBeError, expectedErr)
 		test.That(t, deps, test.ShouldBeEmpty)
 	})
 
-	t.Run("adds board name to dependencies on success", func(t *testing.T) {
+	t.Run("no dependencies on success", func(t *testing.T) {
 		cfg := Config{
-			BoardName: boardName,
 			I2cBus:    "thing2",
 		}
 		deps, err := cfg.Validate("path")
 
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, len(deps), test.ShouldEqual, 1)
-		test.That(t, deps[0], test.ShouldResemble, boardName)
+		test.That(t, len(deps), test.ShouldEqual, 0)
 	})
 }
 
@@ -62,7 +47,6 @@ func TestInitializationFailureOnChipCommunication(t *testing.T) {
 			Model: model,
 			API:   movementsensor.API,
 			ConvertedAttributes: &Config{
-				BoardName: testBoardName,
 				I2cBus:    i2cName,
 			},
 		}
@@ -88,7 +72,7 @@ func TestInitializationFailureOnChipCommunication(t *testing.T) {
 		}
 		sensor, err := NewMpu6050(context.Background(), deps, cfg, logger)
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err, test.ShouldBeError, addressReadError(readErr, expectedDefaultAddress, i2cName, testBoardName))
+		test.That(t, err, test.ShouldBeError, addressReadError(readErr, expectedDefaultAddress, i2cName))
 		test.That(t, sensor, test.ShouldBeNil)
 	})
 
@@ -98,7 +82,6 @@ func TestInitializationFailureOnChipCommunication(t *testing.T) {
 			Model: model,
 			API:   movementsensor.API,
 			ConvertedAttributes: &Config{
-				BoardName:              testBoardName,
 				I2cBus:                 i2cName,
 				UseAlternateI2CAddress: true,
 			},
@@ -139,7 +122,6 @@ func TestSuccessfulInitializationAndClose(t *testing.T) {
 		Model: model,
 		API:   movementsensor.API,
 		ConvertedAttributes: &Config{
-			BoardName:              testBoardName,
 			I2cBus:                 i2cName,
 			UseAlternateI2CAddress: true,
 		},
@@ -187,7 +169,6 @@ func setupDependencies(mockData []byte) (resource.Config, resource.Dependencies)
 		Model: model,
 		API:   movementsensor.API,
 		ConvertedAttributes: &Config{
-			BoardName:              testBoardName,
 			I2cBus:                 i2cName,
 			UseAlternateI2CAddress: true,
 		},

--- a/components/movementsensor/mpu6050/mpu6050_test.go
+++ b/components/movementsensor/mpu6050/mpu6050_test.go
@@ -27,7 +27,7 @@ func TestValidateConfig(t *testing.T) {
 
 	t.Run("no dependencies on success", func(t *testing.T) {
 		cfg := Config{
-			I2cBus:    "thing2",
+			I2cBus:    "2",
 		}
 		deps, err := cfg.Validate("path")
 

--- a/components/movementsensor/mpu6050/mpu6050_test.go
+++ b/components/movementsensor/mpu6050/mpu6050_test.go
@@ -27,7 +27,7 @@ func TestValidateConfig(t *testing.T) {
 
 	t.Run("no dependencies on success", func(t *testing.T) {
 		cfg := Config{
-			I2cBus:    "2",
+			I2cBus: "2",
 		}
 		deps, err := cfg.Validate("path")
 
@@ -46,7 +46,7 @@ func TestInitializationFailureOnChipCommunication(t *testing.T) {
 			Model: model,
 			API:   movementsensor.API,
 			ConvertedAttributes: &Config{
-				I2cBus:    i2cName,
+				I2cBus: i2cName,
 			},
 		}
 		i2cHandle := &inject.I2CHandle{}


### PR DESCRIPTION
...instead of going through the board component to do it.

To get the tests to work, I've split `NewMpu6050` into that function (which constructs a real I2C connection) and `makeMpu6050` (which takes in an I2C connection plus all the same things as `NewMpu6050` and constructs everything else). That latter command can be called during tests to inject a mock I2C bus.

When folks are happy with this code, before I merge this PR I should write a migration script to update the configs in production.

I'm tagging @gvaradarajan for a review because he wrote most of the tests here.