### PR TITLE
 RSDK-4567 hide mmal behind build flags

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,7 +139,7 @@ jobs:
           --platform linux/arm/v7 \
           -v `pwd`:/rdk \
           ghcr.io/viamrobotics/rdk-devenv:armhf-cache \
-          sudo -Hu testbot bash -lc 'cd /rdk && go list -tags=no_tflite ./... | grep -v mmal | xargs go test -v -tags=no_tflite'
+          sudo -Hu testbot bash -lc 'cd /rdk && go test -v -tags=no_tflite ./...'
 
   test_pi:
     name: Test Raspberry Pi Code

--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,11 @@ setup:
 
 build: build-web build-go
 
-# Ignore mmal.
 # Omit test-only packages: that is, packages that have no source files.
 # 	This is done by default if `go build` uses a wildcard, for example, `go build ./...`. Here, we replicate that
 # 	behavior. See https://github.com/golang/go/blob/fa4f951026f697bc042422d95a0806dcbab7ddd0/src/cmd/go/internal/work/build.go#L734
 build-go:
-	go list -f '{{if or .CgoFiles .GoFiles}} {{.Dir}} {{end}}' ./... | grep -v mmal | xargs go build
+	go build ./...
 
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
@@ -65,8 +64,8 @@ lint: lint-go lint-web
 
 lint-go: tool-install
 	go mod tidy
-	export pkgs="`go list -f '{{.Dir}}' ./... | grep -v -e /proto/ -e mmal`" && echo "$$pkgs" | xargs go vet -vettool=$(TOOL_BIN)/combined
-	export GOC=50 pkgs=`go list -f '{{.Dir}}' ./... | grep -v mmal` && echo "$$pkgs" | xargs $(TOOL_BIN)/golangci-lint run -v --fix --config=./etc/.golangci.yaml
+	export pkgs="`go list -f '{{.Dir}}' ./... | grep -v /proto/`" && echo "$$pkgs" | xargs go vet -vettool=$(TOOL_BIN)/combined
+	GOGC=50 $(TOOL_BIN)/golangci-lint run -v --fix --config=./etc/.golangci.yaml
 
 lint-web: check-web
 	npm run lint --prefix web/frontend

--- a/etc/test.sh
+++ b/etc/test.sh
@@ -17,7 +17,7 @@ if [[ "$1" == "race" ]]; then
 fi
 
 # We run analyzetests on every run, pass or fail. We only run analyzecoverage when all tests passed.
-PION_LOG_WARN=webrtc,datachannel,sctp gotestsum --format standard-verbose --jsonfile json.log -- -tags=no_skip $RACE $COVER $(go list ./... | grep -v mmal)
+PION_LOG_WARN=webrtc,datachannel,sctp gotestsum --format standard-verbose --jsonfile json.log -- -tags=no_skip $RACE $COVER ./...
 SUCCESS=$?
 
 cat json.log | go run ./etc/analyzetests/main.go

--- a/gostream/codec/mmal/encoder.go
+++ b/gostream/codec/mmal/encoder.go
@@ -1,3 +1,5 @@
+//go:build mmal
+
 // Package mmal contains the mmal video codec.
 package mmal
 

--- a/gostream/codec/mmal/utils.go
+++ b/gostream/codec/mmal/utils.go
@@ -1,3 +1,5 @@
+//go:build mmal
+
 package mmal
 
 import (


### PR DESCRIPTION
# Description
This PR reverts the changes made in https://github.com/viamrobotics/rdk/pull/3000 to hide mmal and instead hide that lib behind a build flag. 

# Testing 
* Tested the build, test, and linter locally.
* Running the changes to `test.yml` [here](https://github.com/bazile-clyde/rdk/actions/runs/6671417812/job/18133286606) 
