### PR TITLE
Cli fix update-models default module flag value

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -273,9 +273,9 @@ var app = &cli.App{
 							Usage: "mime types filter",
 						},
 						&cli.UintFlag{
-							Name:        dataFlagParallelDownloads,
-							Usage:       "number of download requests to make in parallel",
-							DefaultText: "10",
+							Name:  dataFlagParallelDownloads,
+							Usage: "number of download requests to make in parallel",
+							Value: 100,
 						},
 						&cli.StringFlag{
 							Name:  dataFlagStart,

--- a/cli/app.go
+++ b/cli/app.go
@@ -926,10 +926,10 @@ After creation, use 'viam module update' to push your new module to app.viam.com
 					Usage: "update a module's metadata on app.viam.com",
 					Flags: []cli.Flag{
 						&cli.StringFlag{
-							Name:        moduleFlagPath,
-							Usage:       "path to meta.json",
-							DefaultText: "./meta.json",
-							TakesFile:   true,
+							Name:      moduleFlagPath,
+							Usage:     "path to meta.json",
+							Value:     "./meta.json",
+							TakesFile: true,
 						},
 						&cli.StringFlag{
 							Name:  moduleFlagPublicNamespace,
@@ -947,10 +947,10 @@ After creation, use 'viam module update' to push your new module to app.viam.com
 					Usage: "update a module's metadata file based on models it provides",
 					Flags: []cli.Flag{
 						&cli.StringFlag{
-							Name:        moduleFlagPath,
-							Usage:       "path to meta.json",
-							DefaultText: "./meta.json",
-							TakesFile:   true,
+							Name:      moduleFlagPath,
+							Usage:     "path to meta.json",
+							Value:     "./meta.json",
+							TakesFile: true,
 						},
 						&cli.StringFlag{
 							Name:     "binary",
@@ -980,10 +980,10 @@ viam module upload --version "0.1.0" --platform "linux/amd64" packaged-module.ta
 					UsageText: "viam module upload <version> <platform> [other options] <packaged-module.tar.gz>",
 					Flags: []cli.Flag{
 						&cli.StringFlag{
-							Name:        moduleFlagPath,
-							Usage:       "path to meta.json",
-							DefaultText: "./meta.json",
-							TakesFile:   true,
+							Name:      moduleFlagPath,
+							Usage:     "path to meta.json",
+							Value:     "./meta.json",
+							TakesFile: true,
 						},
 						&cli.StringFlag{
 							Name:  moduleFlagPublicNamespace,

--- a/cli/data.go
+++ b/cli/data.go
@@ -209,7 +209,7 @@ func (c *viamClient) binaryData(dst string, filter *datapb.Filter, parallelDownl
 		}
 	}()
 
-	// In parallel, read from ids and download the binary for each id in batches of defaultParallelDownloads.
+	// In parallel, read from ids and download the binary for each id in batches of parallelDownloads.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()

--- a/cli/data.go
+++ b/cli/data.go
@@ -26,12 +26,11 @@ import (
 )
 
 const (
-	dataDir                  = "data"
-	metadataDir              = "metadata"
-	defaultParallelDownloads = 100
-	maxRetryCount            = 5
-	logEveryN                = 100
-	maxLimit                 = 100
+	dataDir       = "data"
+	metadataDir   = "metadata"
+	maxRetryCount = 5
+	logEveryN     = 100
+	maxLimit      = 100
 
 	dataTypeBinary  = "binary"
 	dataTypeTabular = "tabular"
@@ -183,10 +182,6 @@ func createDataFilter(c *cli.Context) (*datapb.Filter, error) {
 func (c *viamClient) binaryData(dst string, filter *datapb.Filter, parallelDownloads uint) error {
 	if err := c.ensureLoggedIn(); err != nil {
 		return err
-	}
-
-	if parallelDownloads == 0 {
-		parallelDownloads = defaultParallelDownloads
 	}
 
 	ids := make(chan *datapb.BinaryID, parallelDownloads)

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -749,7 +749,13 @@ func UpdateModelsAction(c *cli.Context) error {
 		return err
 	}
 
-	manifest, err := loadManifest(c.String(moduleFlagPath))
+	manifestPathArg := c.String(moduleFlagPath)
+	manifestPath := defaultManifestFilename
+	if manifestPathArg != "" {
+		manifestPath = manifestPathArg
+	}
+
+	manifest, err := loadManifest(manifestPath)
 	if err != nil {
 		return err
 	}
@@ -759,5 +765,5 @@ func UpdateModelsAction(c *cli.Context) error {
 	}
 
 	manifest.Models = newModels
-	return writeManifest(c.String(moduleFlagPath), manifest)
+	return writeManifest(manifestPath, manifest)
 }

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -124,13 +124,9 @@ func CreateModuleAction(c *cli.Context) error {
 func UpdateModuleAction(c *cli.Context) error {
 	publicNamespaceArg := c.String(moduleFlagPublicNamespace)
 	orgIDArg := c.String(moduleFlagOrgID)
-	manifestPathArg := c.String(moduleFlagPath)
 	var moduleID moduleID
 
-	manifestPath := defaultManifestFilename
-	if manifestPathArg != "" {
-		manifestPath = manifestPathArg
-	}
+	manifestPath := c.String(moduleFlagPath)
 
 	client, err := newViamClient(c)
 	if err != nil {
@@ -159,7 +155,7 @@ func UpdateModuleAction(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	printf(c.App.Writer, "Module successfully updated! You can view your changes online here: %s\n", response.GetUrl())
+	printf(c.App.Writer, "Module successfully updated! You can view your changes online here: %s", response.GetUrl())
 
 	// if we have gotten this far it means that moduleID will have a prefix in it
 	// because the validate command resolves the orgId or namespace to the moduleID with the namespace as the priority
@@ -178,7 +174,7 @@ func UpdateModuleAction(c *cli.Context) error {
 
 // UploadModuleAction is the corresponding action for 'module upload'.
 func UploadModuleAction(c *cli.Context) error {
-	manifestPathArg := c.String(moduleFlagPath)
+	manifestPath := c.String(moduleFlagPath)
 	publicNamespaceArg := c.String(moduleFlagPublicNamespace)
 	orgIDArg := c.String(moduleFlagOrgID)
 	nameArg := c.String(moduleFlagName)
@@ -202,10 +198,6 @@ func UploadModuleAction(c *cli.Context) error {
 		return err
 	}
 
-	manifestPath := defaultManifestFilename
-	if manifestPathArg != "" {
-		manifestPath = manifestPathArg
-	}
 	var moduleID moduleID
 	// if the manifest cant be found
 	if _, err := os.Stat(manifestPath); err != nil {
@@ -749,13 +741,7 @@ func UpdateModelsAction(c *cli.Context) error {
 		return err
 	}
 
-	manifestPathArg := c.String(moduleFlagPath)
-	manifestPath := defaultManifestFilename
-	if manifestPathArg != "" {
-		manifestPath = manifestPathArg
-	}
-
-	manifest, err := loadManifest(manifestPath)
+	manifest, err := loadManifest(c.String(moduleFlagPath))
 	if err != nil {
 		return err
 	}
@@ -765,5 +751,5 @@ func UpdateModelsAction(c *cli.Context) error {
 	}
 
 	manifest.Models = newModels
-	return writeManifest(manifestPath, manifest)
+	return writeManifest(c.String(moduleFlagPath), manifest)
 }


### PR DESCRIPTION
Surprisingly, v2 of our cli library does not auto populate empty string flags (and ignores the default value).

This causes `update-models` to try and open "" (and fail) if the `--module` flag is not provided.