### PR TITLE
Remove canon

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         include:
         # rdk-devenv
-        - arch: ubuntu-latest
+        - arch: buildjet-2vcpu-ubuntu-2204
           tag: amd64
           platform: linux/amd64
           image: rdk-devenv
@@ -36,7 +36,7 @@ jobs:
           image: rdk-devenv
           file: etc/Dockerfile.cache
         # antique2
-        - arch: ubuntu-latest
+        - arch: buildjet-2vcpu-ubuntu-2204
           platform: linux/amd64
           image: antique2
           file: etc/Dockerfile.antique-cache

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,22 +14,11 @@ on:
 # Don't forget to tag back to @main before merge.
 
 jobs:
-  canon-cache:
-    name: Build Canon Cache Docker Images
+  docker-cache:
+    name: Build Cache Docker Images
     strategy:
       matrix:
         include:
-        # canon
-        - arch: ubuntu-latest
-          tag: amd64
-          platform: linux/amd64
-          image: canon
-          file: etc/Dockerfile.cache
-        - arch: buildjet-2vcpu-ubuntu-2204-arm
-          tag: arm64
-          platform: linux/arm64
-          image: canon
-          file: etc/Dockerfile.cache
         # rdk-devenv
         - arch: ubuntu-latest
           tag: amd64
@@ -46,17 +35,6 @@ jobs:
           platform: linux/arm/v7
           image: rdk-devenv
           file: etc/Dockerfile.cache
-        # antique
-        - arch: ubuntu-latest
-          platform: linux/amd64
-          image: antique
-          file: etc/Dockerfile.antique-cache
-          tag: amd64
-        - arch: buildjet-2vcpu-ubuntu-2204-arm
-          platform: linux/arm64
-          image: antique
-          file: etc/Dockerfile.antique-cache
-          tag: arm64
         # antique2
         - arch: ubuntu-latest
           platform: linux/amd64
@@ -97,7 +75,7 @@ jobs:
         file: ${{ matrix.file }}
 
   test:
-    needs: canon-cache
+    needs: docker-cache
     uses: viamrobotics/rdk/.github/workflows/test.yml@main
     secrets:
       MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -9,7 +9,7 @@ jobs:
     name: Audit 3rd-Party Licenses
     runs-on: [ubuntu-latest]
     container:
-      image: ghcr.io/viamrobotics/canon:amd64-cache
+      image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
       options: --platform linux/amd64
     timeout-minutes: 30
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository_owner == 'viamrobotics'
     runs-on: [ubuntu-latest]
     container:
-      image: ghcr.io/viamrobotics/canon:amd64-cache
+      image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
 
     steps:
       - name: Checkout


### PR DESCRIPTION
With Clyde's latest changes, the old canon images no longer have everything needed to fully build RDK (docker workflow failed multiple times over the weekend), so removing them from workflows.

Test run here: https://github.com/viamrobotics/rdk/actions/runs/6695691340
