### PR TITLE
RSDK-5537 Relax LastReconfigured test time assertions

### DIFF
--- a/resource/resource_graph_test.go
+++ b/resource/resource_graph_test.go
@@ -971,9 +971,9 @@ func TestResourceGraphLastReconfigured(t *testing.T) {
 	lr := node1.LastReconfigured()
 	test.That(t, lr, test.ShouldNotBeNil)
 	// Assert that after SwapResource, node's lastReconfigured time is between
-	// 50ms ago and now.
+	// 10s ago and now.
 	test.That(t, *lr, test.ShouldHappenBetween,
-		time.Now().Add(-50*time.Millisecond), time.Now())
+		time.Now().Add(-10*time.Second), time.Now())
 
 	// Mock a mutation with another SwapResource. Assert that lastReconfigured
 	// value changed.
@@ -981,10 +981,10 @@ func TestResourceGraphLastReconfigured(t *testing.T) {
 	newLR := node1.LastReconfigured()
 	test.That(t, newLR, test.ShouldNotBeNil)
 	// Assert that after another SwapResource, node's lastReconfigured time is
-	// after old lr value and between 50ms ago and now.
+	// after old lr value and between 10s ago and now.
 	test.That(t, *newLR, test.ShouldHappenAfter, *lr)
 	test.That(t, *newLR, test.ShouldHappenBetween,
-		time.Now().Add(-50*time.Millisecond), time.Now())
+		time.Now().Add(-10*time.Second), time.Now())
 }
 
 func TestResourceGraphResolveDependencies(t *testing.T) {

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -260,11 +260,11 @@ func TestConfigRemote(t *testing.T) {
 
 	for idx := 0; idx < expectedStatusLength; idx++ {
 		test.That(t, statuses[idx].Status, test.ShouldResemble, map[string]interface{}{})
-		// Assert that last reconfigured values are within last 5s (remote
+		// Assert that last reconfigured values are within last hour (remote
 		// recently configured all three resources).
 		lr := statuses[idx].LastReconfigured
 		test.That(t, lr, test.ShouldHappenBetween,
-			time.Now().Add(-5*time.Second), time.Now())
+			time.Now().Add(-1*time.Hour), time.Now())
 	}
 
 	statuses, err = r2.Status(
@@ -1127,7 +1127,7 @@ func TestStatus(t *testing.T) {
 		test.That(t, resp[0].Name, test.ShouldResemble, expectedRobotStatus.Name)
 		test.That(t, resp[0].Status, test.ShouldResemble, expectedRobotStatus.Status)
 		test.That(t, resp[0].LastReconfigured, test.ShouldHappenBetween,
-			time.Now().Add(-10*time.Second), time.Now())
+			time.Now().Add(-1*time.Hour), time.Now())
 	})
 
 	t.Run("failing resource", func(t *testing.T) {


### PR DESCRIPTION
RSDK-5537

Raises times used in assertions for `LastReconfigured` tests. Times like `5 * time.Second` were causing issues on slow test runners. We just want to assert that `LastReconfigured` is non-nil (if a pointer) and contains a reasonable value. 