### PR TITLE
Remove `prime-core` and `prime-blocks` as peer deps.

### DIFF
--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -35,8 +35,6 @@
   "peerDependencies": {
     "@floating-ui/dom": "^1.5.3",
     "@improbable-eng/grpc-web": ">=0.15",
-    "@threlte/core": ">=6.0",
-    "@threlte/extras": ">=7.4",
     "@viamrobotics/prime": ">=0.5",
     "@viamrobotics/rpc": ">=0.1",
     "@viamrobotics/sdk": "0.6.0-rc.0",

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
@@ -38,8 +38,6 @@
     "@threlte/core": ">=6.0",
     "@threlte/extras": ">=7.4",
     "@viamrobotics/prime": ">=0.5",
-    "@viamrobotics/prime-blocks": ">=0.0.14",
-    "@viamrobotics/prime-core": ">=0.0.53",
     "@viamrobotics/rpc": ">=0.1",
     "@viamrobotics/sdk": "0.6.0-rc.0",
     "google-protobuf": ">=3",


### PR DESCRIPTION
This is a temporary measure. Remote control will be moved to use [SvelteKit packaging](https://kit.svelte.dev/docs/packaging). Once that is done we'll be able to sync the version of Svelte between app and remote control and allow Svelte peer dependencies like `prime-core` again without unintended production runtime effects.