### PR TITLE
DATA-1432 - Add commands to interact with a MongoDB Atlas Data Federation instance to CLI

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -59,6 +59,7 @@ const (
 	dataFlagBboxLabels                     = "bbox-labels"
 	dataFlagOrgID                          = "org-id"
 	dataFlagDeleteTabularDataOlderThanDays = "delete-older-than-days"
+	dataFlagDatabasePassword               = "password"
 
 	boardFlagName    = "name"
 	boardFlagPath    = "path"
@@ -376,6 +377,44 @@ var app = &cli.App{
 								},
 							},
 							Action: DataDeleteTabularAction,
+						},
+					},
+				},
+				{
+					Name:      "database",
+					Usage:     "interact with a MongoDB Atlas Data Federation instance",
+					UsageText: "viam data database [other options]",
+					Subcommands: []*cli.Command{
+						{
+							Name:      "configure",
+							Usage:     "configures a database user for Viam's MongoDB Atlas Data Federation instance",
+							UsageText: fmt.Sprintf("viam data database configure <%s> <%s>", dataFlagOrgID, dataFlagDatabasePassword),
+							Flags: []cli.Flag{
+								&cli.StringFlag{
+									Name:     dataFlagOrgID,
+									Usage:    "org ID for the database user being configured",
+									Required: true,
+								},
+								&cli.StringFlag{
+									Name:     dataFlagDatabasePassword,
+									Usage:    "password for the database user being configured",
+									Required: true,
+								},
+							},
+							Action: DataConfigureDatabaseUser,
+						},
+						{
+							Name:      "hostname",
+							Usage:     "gets the hostname to access a MongoDB Atlas Data Federation Instance",
+							UsageText: fmt.Sprintf("viam data database hostname <%s>", dataFlagOrgID),
+							Flags: []cli.Flag{
+								&cli.StringFlag{
+									Name:     dataFlagOrgID,
+									Usage:    "org ID for the database user",
+									Required: true,
+								},
+							},
+							Action: DataGetDatabaseConnection,
 						},
 					},
 				},

--- a/cli/app.go
+++ b/cli/app.go
@@ -387,7 +387,7 @@ var app = &cli.App{
 					Subcommands: []*cli.Command{
 						{
 							Name:      "configure",
-							Usage:     "configures a database user for Viam's MongoDB Atlas Data Federation instance",
+							Usage:     "configures a database user for the Viam org's MongoDB Atlas Data Federation instance",
 							UsageText: fmt.Sprintf("viam data database configure <%s> <%s>", dataFlagOrgID, dataFlagDatabasePassword),
 							Flags: []cli.Flag{
 								&cli.StringFlag{

--- a/cli/data.go
+++ b/cli/data.go
@@ -630,3 +630,57 @@ func (c *viamClient) dataRemoveFromDataset(datasetID, orgID, locationID string, 
 	printf(c.c.App.Writer, "Removed data from dataset ID %s", datasetID)
 	return nil
 }
+
+// DataConfigureDatabaseUser is the corresponding action for 'data database configure'.
+func DataConfigureDatabaseUser(c *cli.Context) error {
+	client, err := newViamClient(c)
+	if err != nil {
+		return err
+	}
+	if err := client.dataConfigureDatabaseUser(c.String(dataFlagOrgID), c.String(dataFlagDatabasePassword)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// dataConfigureDatabaseUser accepts a Viam organization ID and a password for the database user
+// being configured. Viam uses gRPC over TLS, so the entire request will be encrypted while in
+// flight, including the password.
+func (c *viamClient) dataConfigureDatabaseUser(orgID, password string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+	_, err := c.dataClient.ConfigureDatabaseUser(context.Background(),
+		&datapb.ConfigureDatabaseUserRequest{OrganizationId: orgID, Password: password})
+	if err != nil {
+		return errors.Wrapf(err, "received error from server")
+	}
+	printf(c.c.App.Writer, "Configured database user for org %s", orgID)
+	return nil
+}
+
+// DataGetDatabaseConnection is the corresponding action for 'data database hostname'.
+func DataGetDatabaseConnection(c *cli.Context) error {
+	client, err := newViamClient(c)
+	if err != nil {
+		return err
+	}
+	if err := client.dataGetDatabaseConnection(c.String(dataFlagOrgID)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// dataGetDatabaseConnection gets the hostname of the MongoDB Atlas Data Federation instance
+// for the given organization ID.
+func (c *viamClient) dataGetDatabaseConnection(orgID string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+	res, err := c.dataClient.GetDatabaseConnection(context.Background(), &datapb.GetDatabaseConnectionRequest{OrganizationId: orgID})
+	if err != nil {
+		return errors.Wrapf(err, "received error from server")
+	}
+	printf(c.c.App.Writer, "MongoDB Atlas Data Federation instance hostname: %s", res.GetHostname())
+	return nil
+}


### PR DESCRIPTION
**Testing**

Successfully tested configuring a user and getting the hostname on the https://pr-2735-appmain-bplesliplq-uc.a.run.app PR deployment from https://github.com/viamrobotics/app/pull/2735 (with actual values redacted):

```
go run cli/viam/main.go data database hostname --org-id={org-id}
MongoDB Atlas Data Federation instance hostname: {hostname}

go run cli/viam/main.go data database configure --org-id={org-id} --password={new-password}
Configured database user for org {org-id}
```