### PR TITLE
Updating pi OS version requirement from Bullseye to Bookworm

### DIFF
--- a/etc/setup.sh
+++ b/etc/setup.sh
@@ -10,7 +10,7 @@ if [ "`sudo whoami`x" != "rootx" ]; then
 	exit 1
 fi
 
-do_bullseye(){
+do_bookworm(){
 	sudo bash <<-EOS
 	# Basic tools
 	apt-get update && apt-get install -y curl gpg git
@@ -182,13 +182,13 @@ do_brew(){
 # Main install routine
 
 if [ "$(uname)" == "Linux" ]; then
-	if [ "$(grep VERSION_CODENAME /etc/os-release | cut -d= -f2)" == "bullseye" ]; then
+	if [ "$(grep VERSION_CODENAME /etc/os-release | cut -d= -f2)" == "bookworm" ]; then
 		NO_PROFILE=1
-		do_bullseye || exit 1
+		do_bookworm || exit 1
 	elif [ "$(uname -m)" == "x86_64" ]; then
 		do_linux || exit 1
 	else
-		echo -e "\033[41m""Native dev environment is only supported on Debian/Bullseye (x86_64 and aarch64), but brew-based support is available for generic Linux/x86_64 and Darwin (MacOS).""\033[0m"
+		echo -e "\033[41m""Native dev environment is only supported on Debian/Bookworm (x86_64 and aarch64), but brew-based support is available for generic Linux/x86_64 and Darwin (MacOS).""\033[0m"
 		exit 1
 	fi
 elif [ "$(uname)" == "Darwin" ]; then


### PR DESCRIPTION
Updated the pi OS requirement from bullseye to bookworm otherwise the setup script fails to run since it won't match the latest pi OS version check.

Script runs successfully once the version codename is updated.