### PR TITLE
RSDK-5572 - Change agentinfo platform reporting for arm to use new variants

### DIFF
--- a/config/reader.go
+++ b/config/reader.go
@@ -17,6 +17,7 @@ import (
 	"go.viam.com/utils"
 	"go.viam.com/utils/artifact"
 	"go.viam.com/utils/rpc"
+	"golang.org/x/sys/cpu"
 
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -39,7 +40,22 @@ func getAgentInfo() (*apppb.AgentInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	platform := fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
+
+	arch := runtime.GOARCH
+	// "arm" is used for arm32. "arm64" is used for versions after v7
+	if arch == "arm" {
+		// armv7 added LPAE (Large Page Address Extension).
+		// this is an official way to detect armv7
+		// https://go-review.googlesource.com/c/go/+/525637/2/src/internal/cpu/cpu_arm.go#36
+		if cpu.ARM.HasLPAE {
+			arch = "arm32v7"
+		} else {
+			// fallback to armv6
+			arch = "arm32v6"
+		}
+	}
+
+	platform := fmt.Sprintf("%s/%s", runtime.GOOS, arch)
 
 	return &apppb.AgentInfo{
 		Host:        hostname,

--- a/go.mod
+++ b/go.mod
@@ -88,6 +88,7 @@ require (
 	go.viam.com/utils v0.1.52
 	goji.io v2.0.2+incompatible
 	golang.org/x/image v0.12.0
+	golang.org/x/sys v0.13.0
 	golang.org/x/time v0.3.0
 	golang.org/x/tools v0.10.0
 	gonum.org/v1/gonum v0.12.0
@@ -366,7 +367,6 @@ require (
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/oauth2 v0.10.0 // indirect
 	golang.org/x/sync v0.3.0 // indirect
-	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/term v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-5572

Result of testing on physical hardware: 
Tested on RPI0W1.1 (armv6) => success (reports arm32v6)
Tested on RPI4 (32b) => success (reports arm32v7)
