### PR TITLE
APP-3077 - Include additional module platforms

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -1005,10 +1005,17 @@ viam module upload --version "0.1.0" --platform "linux/amd64" packaged-module.ta
 						&cli.StringFlag{
 							Name: moduleFlagPlatform,
 							Usage: `platform of the binary you are uploading. Must be one of:
+                      any           (most Python modules)
+                      any/amd64     (most Docker-based modules)
+                      any/arm64
+                      linux/any     (Python modules that also require OS support)
+                      darwin/any
                       linux/amd64
                       linux/arm64
-                      darwin/amd64 (Intel macs)
-                      darwin/arm64 (Apple silicon macs)`,
+                      linux/arm32v7
+                      linux/arm32v6
+                      darwin/amd64  (Intel macs)
+                      darwin/arm64  (Apple silicon macs)`,
 							Required: true,
 						},
 						&cli.BoolFlag{


### PR DESCRIPTION
Full help msg:
```
NAME:
   viam module upload - upload a new version of your module

USAGE:
   viam module upload <version> <platform> [other options] <packaged-module.tar.gz>

DESCRIPTION:
   Upload an archive containing your module's file(s) for a specified platform
   Example uploading a single file:
   viam module upload --version "0.1.0" --platform "linux/amd64" ./bin/my-module
   (this example requires the entrypoint in the meta.json to be "./bin/my-module")

   Example uploading a whole directory:
   viam module upload --version "0.1.0" --platform "linux/amd64" ./bin
   (this example requires the entrypoint in the meta.json to be inside the bin directory like "./bin/[your path here]")

   Example uploading a custom tarball of your module:
   tar -czf packaged-module.tar.gz ./src requirements.txt run.sh
   viam module upload --version "0.1.0" --platform "linux/amd64" packaged-module.tar.gz


OPTIONS:
   --force           skip validation (may result in non-functional versions) (default: false)
   --module value    path to meta.json (default: "./meta.json")
   --name value      name of the module (used if you don't have a meta.json)
   --org-id value    id of the organization that hosts the module
   --platform value  platform of the binary you are uploading. Must be one of:
                      any           (most Python modules)
                      any/amd64     (most Docker-based modules)
                      any/arm64
                      linux/any     (Python modules that also require OS support)
                      darwin/any
                      linux/amd64
                      linux/arm64
                      linux/arm32v7
                      linux/arm32v6
                      darwin/amd64  (Intel macs)
                      darwin/arm64  (Apple silicon macs)
   --public-namespace value  the public namespace where the module resides (alternative way of specifying the org id)
   --version value           version of the module to upload (semver2.0) ex: "0.1.0"
```


Should be merged after app changes to support these new fields

The help msg is getting a bit long, but I still think it is nice to have this here instead of linking to the docs.