### PR TITLE
RSDK-5095 tp space position only solving should seed the goal tree with different ending orientations

### DIFF
--- a/motionplan/motionPlanner_test.go
+++ b/motionplan/motionPlanner_test.go
@@ -858,17 +858,9 @@ func TestPtgPosOnlyBidirectional(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	// If bidirectional planning worked properly, this plan should wind up at the goal with an orientation of Theta = 180 degrees
-	bidirectionalPlan := []node{}
-	for _, inp := range bidirectionalPlanRaw {
-		thisNode := &basicNode{
-			q:    inp[kinematicFrame.Name()],
-			cost: inp[kinematicFrame.Name()][2].Value,
-		}
-		bidirectionalPlan = append(bidirectionalPlan, thisNode)
-	}
-	bidirectionalPlan, err = rectifyTPspacePath(bidirectionalPlan, kinematicFrame, spatialmath.NewZeroPose())
+	bidirectionalPlan, err := planToTpspaceRec(bidirectionalPlanRaw, kinematicFrame)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, spatialmath.PoseAlmostCoincidentEps(goal, bidirectionalPlan[len(bidirectionalPlan)-1].Pose(), 1), test.ShouldBeTrue)
+	test.That(t, spatialmath.PoseAlmostCoincidentEps(goal, bidirectionalPlan[len(bidirectionalPlan)-1].Pose(), 5), test.ShouldBeTrue)
 	test.That(t, spatialmath.OrientationAlmostEqual(
 		&spatialmath.OrientationVectorDegrees{OZ: 1, Theta: 180},
 		bidirectionalPlan[len(bidirectionalPlan)-1].Pose().Orientation(),

--- a/motionplan/motionPlanner_test.go
+++ b/motionplan/motionPlanner_test.go
@@ -3,7 +3,6 @@ package motionplan
 import (
 	"context"
 	"math"
-	"fmt"
 	"math/rand"
 	"testing"
 
@@ -857,7 +856,6 @@ func TestPtgPosOnlyBidirectional(t *testing.T) {
 
 	firstplan, err := PlanMotion(ctx, planRequest)
 	test.That(t, err, test.ShouldBeNil)
-	fmt.Println("firstplan", firstplan)
 }
 
 func TestValidatePlanRequest(t *testing.T) {

--- a/motionplan/planManager.go
+++ b/motionplan/planManager.go
@@ -223,7 +223,7 @@ func (pm *planManager) planAtomicWaypoints(
 
 		pathPlanner := planners[i]
 
-		maps := &rrtMaps{}
+		var maps *rrtMaps
 		if seedPlan != nil {
 			maps, err = pm.planToRRTGoalMap(seedPlan, goal)
 			if err != nil {
@@ -231,6 +231,9 @@ func (pm *planManager) planAtomicWaypoints(
 			}
 		}
 		if pm.useTPspace && pm.opt().PositionSeeds > 0 && pm.opt().profile == PositionOnlyMotionProfile {
+			if maps == nil {
+				maps = &rrtMaps{}
+			}
 			err = maps.fillPosOnlyGoal(goal, pm.opt().PositionSeeds, len(pm.frame.DoF()))
 			if err != nil {
 				return nil, err

--- a/motionplan/planManager.go
+++ b/motionplan/planManager.go
@@ -713,10 +713,9 @@ func (pm *planManager) fillPosOnlyGoal(maps *rrtMaps, goal spatialmath.Pose) *rr
 	}
 	for i := 0; i < pm.opt().PositionSeeds; i++ {
 		goalNode := &basicNode{
-			q: make([]referenceframe.Input, len(pm.frame.DoF())),
-			pose: spatialmath.NewPose(goal.Point(), &spatialmath.OrientationVectorDegrees{OZ:1, Theta: float64(i) * thetaStep}),
+			q:    make([]referenceframe.Input, len(pm.frame.DoF())),
+			pose: spatialmath.NewPose(goal.Point(), &spatialmath.OrientationVectorDegrees{OZ: 1, Theta: float64(i) * thetaStep}),
 		}
-		fmt.Println("adding", spatialmath.PoseToProtobuf(goalNode.pose))
 		maps.goalMap[goalNode] = nil
 	}
 	return maps

--- a/motionplan/planManager.go
+++ b/motionplan/planManager.go
@@ -230,7 +230,7 @@ func (pm *planManager) planAtomicWaypoints(
 				return nil, err
 			}
 		}
-		if pm.useTPspace && pm.opt().PositionSeeds > 0 {
+		if pm.useTPspace && pm.opt().PositionSeeds > 0 && pm.opt().profile == PositionOnlyMotionProfile {
 			maps = pm.fillPosOnlyGoal(maps, goal)
 		}
 		// Plan the single waypoint, and accumulate objects which will be used to constrauct the plan after all planning has finished
@@ -332,13 +332,12 @@ func (pm *planManager) planParallelRRTMotion(
 		}
 	} else {
 		if maps == nil {
-			startNode := &basicNode{q: make([]referenceframe.Input, len(pm.frame.DoF())), pose: spatialmath.NewZeroPose()}
 			goalNode := &basicNode{q: make([]referenceframe.Input, len(pm.frame.DoF())), pose: goal}
 			maps = &rrtMaps{
-				startMap: map[node]node{startNode: nil},
-				goalMap:  map[node]node{goalNode: nil},
+				goalMap: map[node]node{goalNode: nil},
 			}
-		} else if maps.startMap == nil {
+		}
+		if maps.startMap == nil {
 			startNode := &basicNode{q: make([]referenceframe.Input, len(pm.frame.DoF())), pose: spatialmath.NewZeroPose()}
 			maps.startMap = map[node]node{startNode: nil}
 		}

--- a/motionplan/plannerOptions.go
+++ b/motionplan/plannerOptions.go
@@ -43,6 +43,9 @@ const (
 	// default number of times to try to smooth the path.
 	defaultSmoothIter = 200
 
+	// default number of position only seeds to use for tp-space planning.
+	defaultTPspacePositionOnlySeeds = 16
+
 	// descriptions of constraints.
 	defaultLinearConstraintDesc         = "Constraint to follow linear path"
 	defaultPseudolinearConstraintDesc   = "Constraint to follow pseudolinear path, with tolerance scaled to path length"
@@ -85,6 +88,7 @@ func newBasicPlannerOptions(frame referenceframe.Frame) *plannerOptions {
 	opt.MinScore = defaultMinIkScore
 	opt.Resolution = defaultResolution
 	opt.Timeout = defaultTimeout
+	opt.PositionSeeds = defaultTPspacePositionOnlySeeds
 
 	opt.PlanIter = defaultPlanIter
 	opt.FrameStep = defaultFrameStep

--- a/motionplan/plannerOptions.go
+++ b/motionplan/plannerOptions.go
@@ -151,6 +151,9 @@ type plannerOptions struct {
 	// Number of iterations to mrun before beginning to accept randomly seeded locations.
 	IterBeforeRand int `json:"iter_before_rand"`
 
+	// Number of seeds to pre-generate for bidirectional position-only solving.
+	PositionSeeds int `json:"position_seeds"`
+
 	// This is how far cbirrt will try to extend the map towards a goal per-step. Determined from FrameStep
 	qstep []float64
 

--- a/motionplan/rrt.go
+++ b/motionplan/rrt.go
@@ -4,6 +4,7 @@ package motionplan
 
 import (
 	"context"
+	"errors"
 	"math"
 
 	"go.viam.com/rdk/motionplan/ik"
@@ -60,6 +61,24 @@ type rrtMaps struct {
 	startMap rrtMap
 	goalMap  rrtMap
 	optNode  node // The highest quality IK solution
+}
+
+func (maps *rrtMaps) fillPosOnlyGoal(goal spatialmath.Pose, posSeeds, dof int) error {
+	thetaStep := 360. / float64(posSeeds)
+	if maps == nil {
+		return errors.New("cannot call method fillPosOnlyGoal on nil maps")
+	}
+	if maps.goalMap == nil {
+		maps.goalMap = map[node]node{}
+	}
+	for i := 0; i < posSeeds; i++ {
+		goalNode := &basicNode{
+			q:    make([]referenceframe.Input, dof),
+			pose: spatialmath.NewPose(goal.Point(), &spatialmath.OrientationVectorDegrees{OZ: 1, Theta: float64(i) * thetaStep}),
+		}
+		maps.goalMap[goalNode] = nil
+	}
+	return nil
 }
 
 // initRRTsolutions will create the maps to be used by a RRT-based algorithm. It will generate IK solutions to pre-populate the goal

--- a/motionplan/tpSpaceRRT.go
+++ b/motionplan/tpSpaceRRT.go
@@ -218,7 +218,13 @@ func (mp *tpSpaceRRTMotionPlanner) rrtBackgroundRunner(
 	defer close(m2chan)
 
 	dist := math.Sqrt(mp.planOpts.DistanceFunc(&ik.Segment{StartPosition: startPose, EndPosition: goalPose}))
-	midptNode := &basicNode{pose: spatialmath.Interpolate(startPose, goalPose, 0.5), cost: dist}
+	
+	// The midpoint should not be the 50% interpolation of start/goal poses, but should be the 50% interpolated point with the orientation
+	// pointing at the goal from the start
+	midPt := startPose.Point().Add(goalPose.Point()).Mul(0.5)
+	midOrient := &spatialmath.OrientationVector{OZ: 1, Theta: math.Atan2(-midPt.X, midPt.Y)}
+	
+	midptNode := &basicNode{pose: spatialmath.NewPose(midPt, midOrient), cost: dist}
 	var randPosNode node = midptNode
 
 	for iter := 0; iter < mp.planOpts.PlanIter; iter++ {

--- a/motionplan/tpSpaceRRT.go
+++ b/motionplan/tpSpaceRRT.go
@@ -218,12 +218,12 @@ func (mp *tpSpaceRRTMotionPlanner) rrtBackgroundRunner(
 	defer close(m2chan)
 
 	dist := math.Sqrt(mp.planOpts.DistanceFunc(&ik.Segment{StartPosition: startPose, EndPosition: goalPose}))
-	
+
 	// The midpoint should not be the 50% interpolation of start/goal poses, but should be the 50% interpolated point with the orientation
 	// pointing at the goal from the start
 	midPt := startPose.Point().Add(goalPose.Point()).Mul(0.5)
 	midOrient := &spatialmath.OrientationVector{OZ: 1, Theta: math.Atan2(-midPt.X, midPt.Y)}
-	
+
 	midptNode := &basicNode{pose: spatialmath.NewPose(midPt, midOrient), cost: dist}
 	var randPosNode node = midptNode
 

--- a/motionplan/tpSpaceRRT.go
+++ b/motionplan/tpSpaceRRT.go
@@ -129,7 +129,7 @@ func newTPSpaceMotionPlanner(
 		tpFrame: tpFrame,
 	}
 	tpPlanner.setupTPSpaceOptions()
-	if opt.profile == PositionOnlyMotionProfile {
+	if opt.profile == PositionOnlyMotionProfile && opt.PositionSeeds <= 0 {
 		tpPlanner.algOpts.bidirectional = false
 	}
 
@@ -199,6 +199,8 @@ func (mp *tpSpaceRRTMotionPlanner) rrtBackgroundRunner(
 	}
 	for k, v := range rrt.maps.goalMap {
 		if v == nil {
+			// There may be more than one node in the tree which satisfies the goal, i.e. its parent is nil.
+			// However for the purposes of this we can just take the first one we see.
 			if k.Pose() != nil {
 				goalPose = k.Pose()
 			} else {
@@ -208,6 +210,7 @@ func (mp *tpSpaceRRTMotionPlanner) rrtBackgroundRunner(
 			break
 		}
 	}
+	mp.logger.Debugf("Starting TPspace solving with startMap len %d and goalMap len %d", len(rrt.maps.startMap), len(rrt.maps.goalMap))
 
 	m1chan := make(chan *nodeAndError, 1)
 	m2chan := make(chan *nodeAndError, 1)

--- a/motionplan/tpSpaceRRT_test.go
+++ b/motionplan/tpSpaceRRT_test.go
@@ -546,5 +546,5 @@ func TestPtgCheckPlan(t *testing.T) {
 }
 
 func TestPtgPositionOnlyGoalGeneration(t *testing.T) {
-	
+
 }

--- a/motionplan/tpSpaceRRT_test.go
+++ b/motionplan/tpSpaceRRT_test.go
@@ -102,7 +102,7 @@ func TestPtgRrtBidirectional(t *testing.T) {
 	}
 }
 
-func TestPtgRrtUnidirectional(t *testing.T) {
+func TestPtgPosOnlyUnidirectional(t *testing.T) {
 	t.Parallel()
 	logger := logging.NewTestLogger(t)
 	roverGeom, err := spatialmath.NewBox(spatialmath.NewZeroPose(), r3.Vector{10, 10, 10}, "")
@@ -127,11 +127,15 @@ func TestPtgRrtUnidirectional(t *testing.T) {
 	goalPos := spatialmath.NewPose(r3.Vector{X: 200, Y: 7000, Z: 0}, &spatialmath.OrientationVectorDegrees{OZ: 1, Theta: 90})
 
 	opt := newBasicPlannerOptions(ackermanFrame)
+	opt.profile = PositionOnlyMotionProfile
 	opt.DistanceFunc = ik.SquaredNormNoOrientSegmentMetric
 	opt.goalMetricConstructor = ik.NewPositionOnlyMetric
 	mp, err := newTPSpaceMotionPlanner(ackermanFrame, rand.New(rand.NewSource(42)), logger, opt)
 	test.That(t, err, test.ShouldBeNil)
 	tp, ok := mp.(*tpSpaceRRTMotionPlanner)
+
+	test.That(t, tp.algOpts.bidirectional, test.ShouldBeFalse)
+
 	tp.algOpts.pathdebug = printPath
 	if tp.algOpts.pathdebug {
 		tp.logger.Debug("$type,X,Y")
@@ -539,4 +543,8 @@ func TestPtgCheckPlan(t *testing.T) {
 		err = CheckPlan(ackermanFrame, steps[2:len(steps)-1], worldState, fs, startPose, inputs, errorState, logger)
 		test.That(t, err, test.ShouldBeNil)
 	})
+}
+
+func TestPtgPositionOnlyGoalGeneration(t *testing.T) {
+	
 }

--- a/motionplan/tpSpaceRRT_test.go
+++ b/motionplan/tpSpaceRRT_test.go
@@ -546,5 +546,4 @@ func TestPtgCheckPlan(t *testing.T) {
 }
 
 func TestPtgPositionOnlyGoalGeneration(t *testing.T) {
-
 }

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -498,7 +498,7 @@ func TestMoveOnMapPlans(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	// goal x-position of 1.32m is scaled to be in mm
-	goalInBaseFrame := spatialmath.NewPoseFromPoint(r3.Vector{X: 1.32 * 1000, Y: 0})
+	goalInBaseFrame := spatialmath.NewPose(r3.Vector{X: 1.32 * 1000, Y: 0}, &spatialmath.OrientationVectorDegrees{OZ: 1, Theta: 55})
 	goalInSLAMFrame := spatialmath.PoseBetweenInverse(motion.SLAMOrientationAdjustment, goalInBaseFrame)
 	extra := map[string]interface{}{"smooth_iter": 5}
 	extraPosOnly := map[string]interface{}{"smooth_iter": 5, "motion_profile": "position_only"}


### PR DESCRIPTION
This seeds the goal tree of TPspace RRT with a variety of orientations when in position-only mode, allowing solving to work bidirectionally (faster) in this mode.

As a drive-by I noticed that the initial node used to seed the first iteration of TPspace RRT was not being computed properly, and was instead at an incorrect orientation, which would have mildly negatively impacted path quality and solve times.