### PR TITLE
RSDK-5593 Correct position-only mode. Add test to verify.

### DIFF
--- a/motionplan/tpSpaceRRT.go
+++ b/motionplan/tpSpaceRRT.go
@@ -51,6 +51,9 @@ const (
 
 var defaultGoalMetricConstructor = ik.NewSquaredNormMetric
 
+// This should only be used when bidirectional mode is `false`.
+var defaultPosOnlyGoalMetricConstructor = ik.NewPositionOnlyMetric
+
 type tpspaceOptions struct {
 	goalCheck int // Check if goal is reachable every this many iters
 
@@ -131,6 +134,7 @@ func newTPSpaceMotionPlanner(
 	tpPlanner.setupTPSpaceOptions()
 	if opt.profile == PositionOnlyMotionProfile {
 		tpPlanner.algOpts.bidirectional = false
+		tpPlanner.algOpts.goalMetricConstructor = defaultPosOnlyGoalMetricConstructor
 	}
 
 	return tpPlanner, nil

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -555,6 +555,11 @@ func TestMoveOnMapPlans(t *testing.T) {
 		endPos, err := kb.CurrentPosition(ctx)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, spatialmath.PoseAlmostCoincidentEps(endPos.Pose(), goalInBaseFrame, 10), test.ShouldBeTrue)
+		// Position only mode should not yield the goal orientation.
+		test.That(t, spatialmath.OrientationAlmostEqualEps(
+			endPos.Pose().Orientation(),
+			goalInBaseFrame.Orientation(),
+			1), test.ShouldBeFalse)
 	})
 }
 


### PR DESCRIPTION
There's one function that wasn't being updated properly in pos-only mode, because TPspace needs to use a more complicated goal construction for doing nearest-neighbor

The result being that when checking if we were at the goal, we were properly evaluating the distance to the goal without considering orientation, but when actually extending towards a point (i.e. the goal), we were considering orientation

Result being that even though matching orientation wasn't required for a success, we were still attempting to fulfill orientation