### PR TITLE
RSDK-5613 Scale ultrasonic readings to millimeters

### DIFF
--- a/components/camera/ultrasonic/ultrasonic.go
+++ b/components/camera/ultrasonic/ultrasonic.go
@@ -74,7 +74,7 @@ func (usvs *ultrasonicWrapper) NextPointCloud(ctx context.Context) (pointcloud.P
 		return nil, errors.New("unable to convert distance to float64")
 	}
 	basicData := pointcloud.NewBasicData()
-	distVector := pointcloud.NewVector(0, 0, distFloat)
+	distVector := pointcloud.NewVector(0, 0, distFloat*1000)
 	err = pcToReturn.Set(distVector, basicData)
 	if err != nil {
 		return nil, err

--- a/components/camera/ultrasonic/ultrasonic_test.go
+++ b/components/camera/ultrasonic/ultrasonic_test.go
@@ -83,7 +83,7 @@ func TestUnderlyingSensor(t *testing.T) {
 	})
 
 	test.That(t, count, test.ShouldEqual, 1)
-	test.That(t, values[0], test.ShouldEqual, 3.2)
+	test.That(t, values[0], test.ShouldEqual, 3200)
 	stream, err := cam.Stream(ctx)
 	test.That(t, err, test.ShouldBeNil)
 


### PR DESCRIPTION
Hey yall, in testing we found out that the ultrasonic sensor readings were in meters but treated as millimeters. This is a smale PR to fix that. 