### PR TITLE
[RSDK-5247] Make the ADXL345 talk to the I2C bus directly

### DIFF
--- a/components/movementsensor/adxl345/adxl345.go
+++ b/components/movementsensor/adxl345/adxl345.go
@@ -199,6 +199,10 @@ func NewAdxl345(
 	return makeAdxl345(ctx, deps, conf, logger, bus)
 }
 
+// makeAdxl345 is split out solely to be used during unit tests: it constructs a new object
+// representing an AXDL345 accelerometer, but with the I2C bus already created and passed in as an
+// argument. This lets you inject a mock I2C bus during the tests. It should not be used directly
+// in production code (instead, use NewAdxl345, above).
 func makeAdxl345(
 	ctx context.Context,
 	deps resource.Dependencies,

--- a/components/movementsensor/adxl345/adxl345.go
+++ b/components/movementsensor/adxl345/adxl345.go
@@ -200,10 +200,10 @@ func NewAdxl345(
 }
 
 func makeAdxl345(
-    ctx context.Context,
-    deps resource.Dependencies,
-    conf resource.Config,
-    logger logging.Logger,
+	ctx context.Context,
+	deps resource.Dependencies,
+	conf resource.Config,
+	logger logging.Logger,
 	bus board.I2C,
 ) (movementsensor.MovementSensor, error) {
 	newConf, err := resource.NativeConfig[*Config](conf)

--- a/components/movementsensor/adxl345/adxl345.go
+++ b/components/movementsensor/adxl345/adxl345.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 // Package adxl345 implements the MovementSensor interface for the ADXL345 accelerometer.
 package adxl345
 

--- a/components/movementsensor/adxl345/adxl345.go
+++ b/components/movementsensor/adxl345/adxl345.go
@@ -226,7 +226,7 @@ func NewAdxl345(
 	// back the device ID (0xE5).
 	deviceID, err := sensor.readByte(ctx, deviceIDRegister)
 	if err != nil {
-		return nil, movementsensor.AddressReadError(err, address, newConf.I2cBus, newConf.BoardName)
+		return nil, movementsensor.AddressReadError(err, address, newConf.I2cBus)
 	}
 	if deviceID != expectedDeviceID {
 		return nil, movementsensor.UnexpectedDeviceError(address, deviceID, sensor.Name().Name)

--- a/components/movementsensor/adxl345/adxl345.go
+++ b/components/movementsensor/adxl345/adxl345.go
@@ -194,6 +194,23 @@ func NewAdxl345(
 		return nil, errors.Wrap(err, msg)
 	}
 
+	// The rest of the constructor is separated out so that you can pass in a mock I2C bus during
+	// tests.
+	return makeAdxl345(ctx, deps, conf, logger, bus)
+}
+
+func makeAdxl345(
+    ctx context.Context,
+    deps resource.Dependencies,
+    conf resource.Config,
+    logger logging.Logger,
+	bus board.I2C,
+) (movementsensor.MovementSensor, error) {
+	newConf, err := resource.NativeConfig[*Config](conf)
+	if err != nil {
+		return nil, err
+	}
+
 	var address byte
 	if newConf.UseAlternateI2CAddress {
 		address = 0x1D

--- a/components/movementsensor/adxl345/adxl345_nonlinux.go
+++ b/components/movementsensor/adxl345/adxl345_nonlinux.go
@@ -1,0 +1,2 @@
+// Package adxl345 is Linux-only.
+package adxl345

--- a/components/movementsensor/adxl345/adxl345_test.go
+++ b/components/movementsensor/adxl345/adxl345_test.go
@@ -63,7 +63,7 @@ func sendInterrupt(ctx context.Context, adxl movementsensor.MovementSensor, t *t
 
 func TestValidateConfig(t *testing.T) {
 	boardName := "local"
-	t.Run("fails with no board supplied if you use interrupts", func(t *testing.T) {
+	t.Run("fails when interrupts are used without a supplied board", func(t *testing.T) {
 		tapCfg := TapConfig{
 			AccelerometerPin: 1,
 			InterruptPin:     "on_missing_board",

--- a/components/movementsensor/adxl345/adxl345_test.go
+++ b/components/movementsensor/adxl345/adxl345_test.go
@@ -99,7 +99,7 @@ func TestValidateConfig(t *testing.T) {
 	t.Run("adds board name to dependencies on success with interrupts", func(t *testing.T) {
 		tapCfg := TapConfig{
 			AccelerometerPin: 1,
-			InterruptPin: "on_missing_board",
+			InterruptPin: "on_present_board",
 		}
 		cfg := Config{
 			BoardName: boardName,
@@ -171,8 +171,6 @@ func TestInterrupts(t *testing.T) {
 	i2c := &inject.I2C{}
 	i2c.OpenHandleFunc = func(addr byte) (board.I2CHandle, error) { return i2cHandle, nil }
 
-	mockBoard.I2CByNameFunc = func(name string) (board.I2C, bool) { return i2c, true }
-
 	logger := logging.NewTestLogger(t)
 
 	deps := resource.Dependencies{
@@ -195,7 +193,7 @@ func TestInterrupts(t *testing.T) {
 		API:   movementsensor.API,
 		ConvertedAttributes: &Config{
 			BoardName: "board",
-			I2cBus:    "bus",
+			I2cBus:    "3",
 			SingleTap: tap,
 			FreeFall:  ff,
 		},
@@ -230,7 +228,7 @@ func TestInterrupts(t *testing.T) {
 			API:   movementsensor.API,
 			ConvertedAttributes: &Config{
 				BoardName: "board",
-				I2cBus:    "bus",
+				I2cBus:    "3",
 				SingleTap: tap,
 			},
 		}
@@ -253,7 +251,7 @@ func TestInterrupts(t *testing.T) {
 			API:   movementsensor.API,
 			ConvertedAttributes: &Config{
 				BoardName: "board",
-				I2cBus:    "bus",
+				I2cBus:    "3",
 				FreeFall:  ff,
 			},
 		}

--- a/components/movementsensor/adxl345/adxl345_test.go
+++ b/components/movementsensor/adxl345/adxl345_test.go
@@ -66,10 +66,10 @@ func TestValidateConfig(t *testing.T) {
 	t.Run("fails with no board supplied if you use interrupts", func(t *testing.T) {
 		tapCfg := TapConfig{
 			AccelerometerPin: 1,
-			InterruptPin: "on_missing_board",
+			InterruptPin:     "on_missing_board",
 		}
 		cfg := Config{
-			I2cBus: "3",
+			I2cBus:    "3",
 			SingleTap: &tapCfg,
 		}
 		deps, err := cfg.Validate("path")
@@ -79,8 +79,7 @@ func TestValidateConfig(t *testing.T) {
 	})
 
 	t.Run("fails with no I2C bus", func(t *testing.T) {
-		cfg := Config{
-		}
+		cfg := Config{}
 		deps, err := cfg.Validate("path")
 		expectedErr := utils.NewConfigValidationFieldRequiredError("path", "i2c_bus")
 		test.That(t, err, test.ShouldBeError, expectedErr)
@@ -99,7 +98,7 @@ func TestValidateConfig(t *testing.T) {
 	t.Run("adds board name to dependencies on success with interrupts", func(t *testing.T) {
 		tapCfg := TapConfig{
 			AccelerometerPin: 1,
-			InterruptPin: "on_present_board",
+			InterruptPin:     "on_present_board",
 		}
 		cfg := Config{
 			BoardName: boardName,

--- a/components/movementsensor/adxl345/adxl345_test.go
+++ b/components/movementsensor/adxl345/adxl345_test.go
@@ -22,15 +22,12 @@ func nowNanosTest() uint64 {
 }
 
 func setupDependencies(mockData []byte) (resource.Config, resource.Dependencies, board.I2C) {
-	testBoardName := "board"
-	i2cName := "2"
-
 	cfg := resource.Config{
 		Name:  "movementsensor",
 		Model: model,
 		API:   movementsensor.API,
 		ConvertedAttributes: &Config{
-			I2cBus:                 i2cName,
+			I2cBus:                 "2",
 			UseAlternateI2CAddress: true,
 		},
 	}
@@ -52,13 +49,7 @@ func setupDependencies(mockData []byte) (resource.Config, resource.Dependencies,
 		return i2cHandle, nil
 	}
 
-	mockBoard := &inject.Board{}
-	mockBoard.I2CByNameFunc = func(name string) (board.I2C, bool) {
-		return i2c, true
-	}
-	return cfg, resource.Dependencies{
-		resource.NewName(board.API, testBoardName): mockBoard,
-	}, i2c
+	return cfg, resource.Dependencies{}, i2c
 }
 
 func sendInterrupt(ctx context.Context, adxl movementsensor.MovementSensor, t *testing.T, interrupt board.DigitalInterrupt, key string) {
@@ -125,8 +116,6 @@ func TestValidateConfig(t *testing.T) {
 
 func TestInitializationFailureOnChipCommunication(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	testBoardName := "board"
-	i2cName := "i2c"
 
 	t.Run("fails on read error", func(t *testing.T) {
 		cfg := resource.Config{
@@ -134,8 +123,7 @@ func TestInitializationFailureOnChipCommunication(t *testing.T) {
 			Model: model,
 			API:   movementsensor.API,
 			ConvertedAttributes: &Config{
-				BoardName: testBoardName,
-				I2cBus:    i2cName,
+				I2cBus: "2",
 			},
 		}
 

--- a/components/movementsensor/adxl345/interrupts.go
+++ b/components/movementsensor/adxl345/interrupts.go
@@ -1,3 +1,4 @@
+//go:build linux
 package adxl345
 
 // addresses relevant to interrupts.

--- a/components/movementsensor/adxl345/interrupts.go
+++ b/components/movementsensor/adxl345/interrupts.go
@@ -1,4 +1,7 @@
 //go:build linux
+
+// Package adxl345 is for an ADXL345 accelerometer. This file is for the interrupt-based
+// functionality on the chip.
 package adxl345
 
 // addresses relevant to interrupts.

--- a/components/movementsensor/errors.go
+++ b/components/movementsensor/errors.go
@@ -7,9 +7,8 @@ import (
 )
 
 // AddressReadError returns a standard error for when we cannot read from an I2C bus.
-func AddressReadError(err error, address byte, bus, board string) error {
-	msg := fmt.Sprintf("can't read from I2C address %d on bus %s of board %s",
-		address, bus, board)
+func AddressReadError(err error, address byte, bus string) error {
+	msg := fmt.Sprintf("can't read from I2C address %d on bus %s", address, bus)
 	return errors.Wrap(err, msg)
 }
 


### PR DESCRIPTION
We need to optionally keep the dependency on the board this time, because if you enable any of the interrupts they must still go through the board! but if you _don't_ use interrupts, you don't have a dependency on the board any more.

Github thinks @susmitaSanyal is the person to review this.

To get the tests to work, I split `NewAdxl345` into a part that builds a (real, hardware-backed) I2C bus and a part that takes in an I2C bus and does every thing else, and then we test that second one while passing in a mock I2C bus. and then for tests where we don't do any interrupt-based stuff, we can get rid of the mock board in the dependencies.

Tried on a raspberry pi: we can still talk to the ADXL as expected!

Because we might need to keep the board dependency, the migration script for this component will need to be slightly different from the other migrations. but that's a change for a different PR in a different repo.