### PR TITLE
RSDK-5439 More intelligently set `ResourceConfigurationTimeout` in `TestCrashedModuleReconfigure`

### DIFF
--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -477,7 +477,7 @@ func TestModuleReloading(t *testing.T) {
 			test.That(t, os.Unsetenv(rutils.ResourceConfigurationTimeoutEnvVar),
 				test.ShouldBeNil)
 		}()
-		test.That(t, os.Setenv(rutils.ResourceConfigurationTimeoutEnvVar, "1ns"),
+		test.That(t, os.Setenv(rutils.ResourceConfigurationTimeoutEnvVar, "10ms"),
 			test.ShouldBeNil)
 
 		// This test neither uses a resource manager nor asserts anything about

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -477,7 +477,7 @@ func TestModuleReloading(t *testing.T) {
 			test.That(t, os.Unsetenv(rutils.ResourceConfigurationTimeoutEnvVar),
 				test.ShouldBeNil)
 		}()
-		test.That(t, os.Setenv(rutils.ResourceConfigurationTimeoutEnvVar, "10ms"),
+		test.That(t, os.Setenv(rutils.ResourceConfigurationTimeoutEnvVar, "1ns"),
 			test.ShouldBeNil)
 
 		// This test neither uses a resource manager nor asserts anything about

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
-
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	armpb "go.viam.com/api/component/arm/v1"

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -3133,7 +3133,7 @@ func TestCrashedModuleReconfigure(t *testing.T) {
 		test.That(t, os.Unsetenv(rutils.ResourceConfigurationTimeoutEnvVar),
 			test.ShouldBeNil)
 	}()
-	test.That(t, os.Setenv(rutils.ResourceConfigurationTimeoutEnvVar, "500ms"),
+	test.That(t, os.Setenv(rutils.ResourceConfigurationTimeoutEnvVar, "2s"),
 		test.ShouldBeNil)
 
 	// Manually define model, as importing it can cause double registration.


### PR DESCRIPTION
RSDK-5439

`TestCrashedModuleReconfigure` was flaking because the `ResourceConfigurationTimeout` was being set too low, and occasionally the test module could not even respond to a ready request in time (`ResourceConfigurationTimeout` [governs](https://github.com/viamrobotics/rdk/blob/main/module/modmanager/manager.go#L674) how long we wait for a module to respond to a ready request). We could raise it even higher, but I thought 2s was enough.