### PR TITLE
Talk to the I2C bus your own dang self: PCA9685 redux

### DIFF
--- a/components/board/genericlinux/i2c.go
+++ b/components/board/genericlinux/i2c.go
@@ -5,7 +5,6 @@ package genericlinux
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"periph.io/x/conn/v3/i2c"
@@ -14,7 +13,6 @@ import (
 
 	"go.viam.com/rdk/components/board"
 	"go.viam.com/rdk/logging"
-	"go.viam.com/rdk/resource"
 )
 
 func init() {
@@ -152,32 +150,4 @@ func (h *I2cHandle) Close() error {
 	h.device = nil
 	// Don't close the bus itself: it should remain open for other handles to use
 	return nil
-}
-
-// GetI2CBus retrieves an I2C interface. If the bus number is specified, it uses that on the local
-// machine, and otherwise it tries to get the named bus from the named board. Although it would be
-// intuitive for the bus number to be an integer, we keep it as a string because it's possible for
-// a devicetree overlay on some unusual board to make it non-numerical.
-// TODO(RSDK-5254): remove this once all I2C devices are talking directly to the bus without going
-// through the board.
-func GetI2CBus(deps resource.Dependencies, boardName, busName, busNum string) (board.I2C, error) {
-	if busNum != "" {
-		return NewI2cBus(busNum)
-	}
-
-	// Otherwise, look things up through the board.
-	b, err := board.FromDependencies(deps, boardName)
-	if err != nil {
-		return nil, err
-	}
-	localBoard, ok := b.(board.LocalBoard)
-	if !ok {
-		return nil, fmt.Errorf("cannot get I2C bus '%s' from nonlocal board '%s'",
-			busName, boardName)
-	}
-	bus, success := localBoard.I2CByName(busName)
-	if !success {
-		return nil, fmt.Errorf("unknown I2C bus %s on board %s", busName, boardName)
-	}
-	return bus, nil
 }

--- a/components/board/hat/pca9685/pca9685.go
+++ b/components/board/hat/pca9685/pca9685.go
@@ -42,7 +42,7 @@ func (conf *Config) Validate(path string) ([]string, error) {
 		return nil, utils.NewConfigValidationFieldRequiredError(path, "i2c_bus")
 	}
 
-	if conf.I2CAddress != nill && (*conf.I2CAddress < 0 || *conf.I2CAddress > 255) {
+	if conf.I2CAddress != nil && (*conf.I2CAddress < 0 || *conf.I2CAddress > 255) {
 		return nil, utils.NewConfigValidationError(path, errors.New("i2c_address must be an unsigned byte"))
 	}
 	return deps, nil
@@ -123,8 +123,8 @@ func (pca *PCA9685) Reconfigure(ctx context.Context, deps resource.Dependencies,
 		return err
 	}
 
-	address := defaultAddr
-	if conf.I2CAddress != nil {
+	address := byte(defaultAddr)
+	if newConf.I2CAddress != nil {
 		address = byte(*newConf.I2CAddress)
 	}
 

--- a/components/board/hat/pca9685/pca9685.go
+++ b/components/board/hat/pca9685/pca9685.go
@@ -78,7 +78,6 @@ type PCA9685 struct {
 	referenceClockSpeed int
 	bus                 board.I2C
 	gpioPins            [16]gpioPin
-	boardName           string
 	i2cName             string
 	logger              logging.Logger
 }
@@ -134,7 +133,6 @@ func (pca *PCA9685) Reconfigure(ctx context.Context, deps resource.Dependencies,
 
 	pca.bus = bus
 	pca.address = address
-	pca.boardName = newConf.BoardName
 	pca.i2cName = newConf.I2CName
 	if err := pca.reset(ctx); err != nil {
 		return err

--- a/components/board/hat/pca9685/pca9685.go
+++ b/components/board/hat/pca9685/pca9685.go
@@ -42,10 +42,7 @@ func (conf *Config) Validate(path string) ([]string, error) {
 		return nil, utils.NewConfigValidationFieldRequiredError(path, "i2c_bus")
 	}
 
-	if conf.I2CAddress == nil {
-		conf.I2CAddress = &defaultAddr
-	}
-	if *conf.I2CAddress < 0 || *conf.I2CAddress > 255 {
+	if conf.I2CAddress != nill && (*conf.I2CAddress < 0 || *conf.I2CAddress > 255) {
 		return nil, utils.NewConfigValidationError(path, errors.New("i2c_address must be an unsigned byte"))
 	}
 	return deps, nil
@@ -125,7 +122,11 @@ func (pca *PCA9685) Reconfigure(ctx context.Context, deps resource.Dependencies,
 	if err != nil {
 		return err
 	}
-	address := byte(*newConf.I2CAddress)
+
+	address := defaultAddr
+	if conf.I2CAddress != nil {
+		address = byte(*newConf.I2CAddress)
+	}
 
 	pca.mu.Lock()
 	defer pca.mu.Unlock()

--- a/components/board/hat/pca9685/pca9685.go
+++ b/components/board/hat/pca9685/pca9685.go
@@ -78,7 +78,6 @@ type PCA9685 struct {
 	referenceClockSpeed int
 	bus                 board.I2C
 	gpioPins            [16]gpioPin
-	i2cName             string
 	logger              logging.Logger
 }
 
@@ -133,7 +132,6 @@ func (pca *PCA9685) Reconfigure(ctx context.Context, deps resource.Dependencies,
 
 	pca.bus = bus
 	pca.address = address
-	pca.i2cName = newConf.I2CName
 	if err := pca.reset(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
https://github.com/viamrobotics/rdk/pull/3030 let the PCA9685 board either talk directly to the I2C bus or go through its parent board to get to that bus. https://github.com/viamrobotics/app/pull/2811 will migrate all the relevant configs from the old approach to the new one (and I will run that migration when the next release is cut). This PR removes the old approach entirely.

I haven't tried this on actual hardware yet, but will be sure to do that before merging. 