### PR TITLE
DATA-2107 - Don't sync if selective syncer is broken

### DIFF
--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -363,7 +363,7 @@ func (svc *builtIn) Sync(ctx context.Context, _ map[string]interface{}) error {
 		}
 	}
 
-	svc.sync(ctx)
+	svc.sync()
 	return nil
 }
 
@@ -553,7 +553,7 @@ func (svc *builtIn) uploadData(cancelCtx context.Context, intervalMins float64) 
 						shouldSync = readyToSync(cancelCtx, svc.syncSensor, svc.logger)
 					}
 					if shouldSync {
-						svc.sync(cancelCtx)
+						svc.sync()
 					}
 				}
 				svc.lock.Unlock()
@@ -562,7 +562,7 @@ func (svc *builtIn) uploadData(cancelCtx context.Context, intervalMins float64) 
 	})
 }
 
-func (svc *builtIn) sync(ctx context.Context) {
+func (svc *builtIn) sync() {
 	svc.flushCollectors()
 
 	toSync := getAllFilesToSync(svc.captureDir, svc.fileLastModifiedMillis)

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -574,7 +574,7 @@ func (svc *builtIn) sync() {
 	}
 }
 
-// nolint
+//nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -353,6 +353,8 @@ func (svc *builtIn) initSyncer(ctx context.Context) error {
 //       If so, how could a user cancel it?
 
 // Sync performs a non-scheduled sync of the data in the capture directory.
+// If automated sync is also enabled, calling Sync will upload the files,
+// regardless of whether or not is the scheduled time.
 func (svc *builtIn) Sync(ctx context.Context, _ map[string]interface{}) error {
 	svc.lock.Lock()
 	defer svc.lock.Unlock()
@@ -544,8 +546,7 @@ func (svc *builtIn) uploadData(cancelCtx context.Context, intervalMins float64) 
 			case <-svc.syncTicker.C:
 				svc.lock.Lock()
 				if svc.syncer != nil {
-					// If selective sync is not enabled (false), we default to not sync until the trigger
-					// condition has been checked. Otherwise, the default behavior is to sync.
+					// If selective sync is disabled, sync. If it is enabled, check the condition below.
 					shouldSync := !svc.selectiveSyncEnabled
 					// If selective sync is enabled and the sensor has been properly initialized,
 					// try to get the reading from the selective sensor that indicates whether to sync

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -462,6 +462,8 @@ func (svc *builtIn) Reconfigure(
 		if err != nil {
 			svc.logger.Errorw("unable to initialize selective syncer", "error", err.Error())
 		}
+	} else {
+		svc.selectiveSync = false
 	}
 	if svc.syncSensor != syncSensor {
 		svc.syncSensor = syncSensor

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -462,7 +462,7 @@ func (svc *builtIn) Reconfigure(
 		svc.selectiveSyncEnabled = true
 		syncSensor, err = sensor.FromDependencies(deps, svcConfig.SelectiveSyncerName)
 		if err != nil {
-			svc.logger.Errorw("unable to initialize selective syncer", "error", err.Error())
+			svc.logger.Errorw("unable to initialize selective syncer; will not sync at all until fixed or removed from config", "error", err.Error())
 		}
 	} else {
 		svc.selectiveSyncEnabled = false

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -137,7 +137,7 @@ type builtIn struct {
 	cloudConn           rpc.ClientConn
 	syncTicker          *clk.Ticker
 
-	syncSensor    selectiveSyncer
+	syncSensor           selectiveSyncer
 	selectiveSyncEnabled bool
 }
 
@@ -160,7 +160,7 @@ func NewBuiltIn(
 		tags:                   []string{},
 		fileLastModifiedMillis: defaultFileLastModifiedMillis,
 		syncerConstructor:      datasync.NewManager,
-		selectiveSyncEnabled:          false,
+		selectiveSyncEnabled:   false,
 	}
 
 	if err := svc.Reconfigure(ctx, deps, conf); err != nil {


### PR DESCRIPTION
### Context
Previously, if the selective syncer was enabled but the sensor was improperly initialized, we would sync by default. This was a bug. This PR changes the behavior so that if the selective syncing is enabled but we are unable to initialize the sensor, we do not sync but keep collecting data and trying to reconfigure.

### Testing
- valid selective syncer with sync enabled and disabled, synced on trigger and did not sync respectively
- regular sync with sync enabled disabled did not sync
- invalid selective with sync enabled did not sync