### PR TITLE
fix enable pin bug when turning off gpio motor

### DIFF
--- a/components/motor/gpio/basic.go
+++ b/components/motor/gpio/basic.go
@@ -154,7 +154,7 @@ func (m *Motor) turnOff(ctx context.Context, extra map[string]interface{}) error
 		errs = multierr.Combine(errs, enLowErr)
 	}
 	if m.EnablePinHigh != nil {
-		enHighErr := errors.Wrap(m.EnablePinLow.Set(ctx, true, extra), "unable to disable high signal")
+		enHighErr := errors.Wrap(m.EnablePinHigh.Set(ctx, false, extra), "unable to disable high signal")
 		errs = multierr.Combine(errs, enHighErr)
 	}
 


### PR DESCRIPTION
Bug was introduced in this commit: https://github.com/viamrobotics/rdk/commit/85163fd8a8b452269531054926e4407838aa6964