### PR TITLE
[RSDK-5249] Make the TMC Stepper motor controller talk to the SPI bus directly

### DIFF
--- a/components/motor/tmcstepper/stepper_motor_tmc.go
+++ b/components/motor/tmcstepper/stepper_motor_tmc.go
@@ -28,7 +28,7 @@ type PinConfig struct {
 // TMC5072Config describes the configuration of a motor.
 type TMC5072Config struct {
 	Pins             PinConfig `json:"pins"`
-	BoardName        string    `json:"board"` // used solely for the PinConfig
+	BoardName        string    `json:"board,omitempty"` // used solely for the PinConfig
 	MaxRPM           float64   `json:"max_rpm,omitempty"`
 	MaxAcceleration  float64   `json:"max_acceleration_rpm_per_sec,omitempty"`
 	TicksPerRotation int       `json:"ticks_per_rotation"`

--- a/components/motor/tmcstepper/stepper_motor_tmc.go
+++ b/components/motor/tmcstepper/stepper_motor_tmc.go
@@ -155,7 +155,6 @@ func NewMotor(ctx context.Context, deps resource.Dependencies, c TMC5072Config, 
 	return makeMotor(ctx, deps, c, name, logger, bus)
 }
 
-
 // makeMotor returns a TMC5072 driven motor. It is separate from NewMotor, above, so you can inject
 // a mock SPI bus in here during testing.
 func makeMotor(ctx context.Context, deps resource.Dependencies, c TMC5072Config, name resource.Name,

--- a/components/motor/tmcstepper/stepper_motor_tmc.go
+++ b/components/motor/tmcstepper/stepper_motor_tmc.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 // Package tmcstepper implements a TMC stepper motor.
 package tmcstepper
 

--- a/components/motor/tmcstepper/stepper_motor_tmc.go
+++ b/components/motor/tmcstepper/stepper_motor_tmc.go
@@ -13,6 +13,7 @@ import (
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/genericlinux"
 	"go.viam.com/rdk/components/motor"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/operation"
@@ -47,12 +48,11 @@ var model = resource.DefaultModelFamily.WithModel("TMC5072")
 // Validate ensures all parts of the config are valid.
 func (config *TMC5072Config) Validate(path string) ([]string, error) {
 	var deps []string
-	if config.Pins.EnablePinLow != 0 {
+	if config.Pins.EnablePinLow != "" {
 		if config.BoardName == "" {
 			return nil, utils.NewConfigValidationFieldRequiredError(path, "board")
-		} else {
-			deps = append(deps, config.BoardName)
 		}
+		deps = append(deps, config.BoardName)
 	}
 	if config.SPIBus == "" {
 		return nil, utils.NewConfigValidationFieldRequiredError(path, "spi_bus")
@@ -235,7 +235,7 @@ func NewMotor(ctx context.Context, deps resource.Dependencies, c TMC5072Config, 
 
 	iCfg := c.HoldDelay<<16 | c.RunCurrent<<8 | c.HoldCurrent
 
-	err = multierr.Combine(
+	err := multierr.Combine(
 		m.writeReg(ctx, chopConf, 0x000100C3), // TOFF=3, HSTRT=4, HEND=1, TBL=2, CHM=0 (spreadCycle)
 		m.writeReg(ctx, iHoldIRun, iCfg),
 		m.writeReg(ctx, coolConf, coolConfig), // Sets just the SGThreshold (for now)

--- a/components/motor/tmcstepper/stepper_motor_tmc.go
+++ b/components/motor/tmcstepper/stepper_motor_tmc.go
@@ -151,6 +151,16 @@ const (
 func NewMotor(ctx context.Context, deps resource.Dependencies, c TMC5072Config, name resource.Name,
 	logger logging.Logger,
 ) (motor.Motor, error) {
+	bus := genericlinux.NewSpiBus(c.SPIBus)
+	return makeMotor(ctx, deps, c, name, logger, bus)
+}
+
+
+// makeMotor returns a TMC5072 driven motor. It is separate from NewMotor, above, so you can inject
+// a mock SPI bus in here during testing.
+func makeMotor(ctx context.Context, deps resource.Dependencies, c TMC5072Config, name resource.Name,
+	logger logging.Logger, bus board.SPI,
+) (motor.Motor, error) {
 	if c.CalFactor == 0 {
 		c.CalFactor = 1.0
 	}
@@ -167,7 +177,7 @@ func NewMotor(ctx context.Context, deps resource.Dependencies, c TMC5072Config, 
 
 	m := &Motor{
 		Named:       name.AsNamed(),
-		bus:         genericlinux.NewSpiBus(c.SPIBus),
+		bus:         bus,
 		csPin:       c.ChipSelect,
 		index:       c.Index,
 		stepsPerRev: c.TicksPerRotation * uSteps,

--- a/components/motor/tmcstepper/stepper_motor_tmc_nonlinux.go
+++ b/components/motor/tmcstepper/stepper_motor_tmc_nonlinux.go
@@ -1,0 +1,2 @@
+// Package tmcstepper is only implemented on Linux.
+package tmcstepper

--- a/components/motor/tmcstepper/stepper_motor_tmc_test.go
+++ b/components/motor/tmcstepper/stepper_motor_tmc_test.go
@@ -83,13 +83,11 @@ func TestRPMBounds(t *testing.T) {
 	})
 
 	name := resource.NewName(motor.API, "motor1")
-	m, err := makeMotor(ctx, deps, mc, name, logger, &fakeSpi)
+	motorDep, err := makeMotor(ctx, deps, mc, name, logger, &fakeSpi)
 	test.That(t, err, test.ShouldBeNil)
 	defer func() {
-		test.That(t, m.Close(context.Background()), test.ShouldBeNil)
+		test.That(t, motorDep.Close(context.Background()), test.ShouldBeNil)
 	}()
-	motorDep, ok := m.(motor.Motor)
-	test.That(t, ok, test.ShouldBeTrue)
 
 	test.That(t, motorDep.GoFor(ctx, 0.05, 6.6, nil), test.ShouldNotBeNil)
 	allObs := obs.All()
@@ -161,14 +159,11 @@ func TestTMCStepperMotor(t *testing.T) {
 	})
 
 	name := resource.NewName(motor.API, "motor1")
-	m, err := makeMotor(ctx, deps, mc, name, logger, &fakeSpi)
+	motorDep, err := makeMotor(ctx, deps, mc, name, logger, &fakeSpi)
 	test.That(t, err, test.ShouldBeNil)
 	defer func() {
-		test.That(t, m.Close(context.Background()), test.ShouldBeNil)
+		test.That(t, motorDep.Close(context.Background()), test.ShouldBeNil)
 	}()
-	motorDep, ok := m.(motor.Motor)
-	test.That(t, ok, test.ShouldBeTrue)
-	test.That(t, ok, test.ShouldBeTrue)
 
 	t.Run("motor supports position reporting", func(t *testing.T) {
 		properties, err := motorDep.Properties(ctx, nil)

--- a/components/motor/tmcstepper/stepper_motor_tmc_test.go
+++ b/components/motor/tmcstepper/stepper_motor_tmc_test.go
@@ -1,3 +1,6 @@
+//go:build linux
+
+// Package tmcstepper_test contains unit tests for the TMC stepper motor driver.
 package tmcstepper_test
 
 import (

--- a/components/motor/tmcstepper/stepper_motor_tmc_test.go
+++ b/components/motor/tmcstepper/stepper_motor_tmc_test.go
@@ -1,7 +1,7 @@
 //go:build linux
 
-// Package tmcstepper_test contains unit tests for the TMC stepper motor driver.
-package tmcstepper_test
+// Package tmcstepper contains the TMC stepper motor driver. This file contains unit tests for it.
+package tmcstepper
 
 import (
 	"context"


### PR DESCRIPTION
I haven't yet tried this out on real hardware; that's the next step. and the step after that is to make a migration script in the app repo to update the pre-existing configs. Changes in this PR include:
- the component should only build and only have tests for Linux. The Mac build doesn't have a way to talk to the SPI bus directly.
- We've split `NewMotor` into that function (which constructs an SPI bus and calls the second half), and `makeMotor` (which does everything else). This lets us use `makeMotor` in tests while passing in a fake SPI bus.
- The `"spi_bus"` entry in the config should now describe the actual SPI bus on the OS, such as `"0"` or `"1"`, rather than something named in your board's config like `"main_spi_bus"`. 
- If you haven't configured an enable pin, you don't need a dependency on the board any more! but if you _have_ configured that pin, you'll still need to specify which board the pin is on. This part of the config is awkward and could use further cleanup (there's a whole separate "pins" config section that has at most 1 pin in it!?), but that's a separate topic for another day.
- The tests have been moved from the `tmcstepper_test` package to the `tmcstepper` package. This lets them access private functions like `makeMotor`. 
- The tests have been simplified to construct the motor directly from `makeMotor`. They used to construct an entire component registry and then use it to construct the motor, but there was no obvious way to mock out the SPI bus with that approach.