### PR TITLE
Fix modmanager cleanup directory log bug

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -550,6 +550,10 @@ func (mgr *Manager) CleanModuleDataDirectory() error {
 	if mgr.moduleDataParentDir == "" {
 		return errors.New("cannot clean a root level module data directory")
 	}
+	// Early exit if the moduleDataParentDir has not been created because there is nothing to clean
+	if _, err := os.Stat(mgr.moduleDataParentDir); errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
 	// Absolute path to all dirs that should exist
 	expectedDirs := make(map[string]bool, len(mgr.modules))
 	for _, m := range mgr.modules {


### PR DESCRIPTION
Small bug that crept into the cleanup data directory code -- it prints that it is removing the module data directory even if that directory doesn't exist in the first place. This does not cause any adverse runtime effects, it just prints a weird message every reconfigure for people who don't have modules.

Bad behavior: (highlighted with ******) (this robot does not have any modules)
```
2023-11-09T14:24:44.429Z	INFO	robot_server	config/logging_level.go:34	Log level initialized: info
2023-11-09T14:24:44.429Z	INFO	robot_server	server/entrypoint.go:83	Viam RDK{"git_rev":"ae024968ae6aec8d7e4c41d5659561963a536d15"}
2023-11-09T14:24:44.429Z	INFO	videosource	logging/logger.go:138	Starting videosource logger
********2023-11-09T14:24:46.609Z	INFO	robot_server	modmanager/manager.go:564	Removing module data parent directory "/home/zack/.viam/module-data/b20d003f-f4ee-47c0-b8a5-d47e1e84232b" *******
2023-11-09T14:24:48.673Z	INFO	robot_server	rpc/server.go:556	will run external signaling answerer	{"signaling_address": "app.viam.com:443", "for_hosts": ["hi-tenzing---zack-main.3ce7ycobby.viam.cloud"]}
2023-11-09T14:24:48.678Z	INFO	robot_server	web/web.go:597	serving	{"url":"https://hi-tenzing---zack-main.3ce7ycobby.local.viam.cloud:8080","alt_url":"https://0.0.0.0:8080"}
^C2023-11-09T14:24:52.397Z	INFO	videosource	logging/logger.go:155	Terminating videosource logger
```

(plan to merge if either of the two assigned reviewers approve)