### PR TITLE
Add check for protobuf errors (e.g. invalid wire format)

### DIFF
--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -16,6 +16,7 @@ import (
 	goutils "go.viam.com/utils"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/services/datamanager/datacapture"
@@ -277,7 +278,7 @@ func exponentialRetry(cancelCtx context.Context, fn func(cancelCtx context.Conte
 // returns false so that the data gets moved to the corrupted data directory.
 func isRetryableGRPCError(err error) bool {
 	errStatus := status.Convert(err)
-	return errStatus.Code() != codes.InvalidArgument
+	return errStatus.Code() != codes.InvalidArgument && !errors.Is(err, proto.Error)
 }
 
 // moveFailedData takes any data that could not be synced in the captureDir and


### PR DESCRIPTION
The offending error not exported directly ([here](https://github.com/protocolbuffers/protobuf-go/blob/a8317fb7c5685299af5de3be21c5514f65837202/proto/decode.go#L294)), so instead using [Error](https://github.com/protocolbuffers/protobuf-go/blob/a8317fb7c5685299af5de3be21c5514f65837202/proto/proto.go#L26) from the protobuf package that apparently matches all errors from that package. I think this should be fine, since we likely do not want to retry in this event, since the protobuf errors are not transient.