### PR TITLE
APP-2950: remove package type defaults

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -973,11 +973,6 @@ func (p *PackageConfig) validate(path string) error {
 		return utils.NewConfigValidationError(path, errors.New("empty package id"))
 	}
 
-	if p.Type == "" {
-		// for backwards compatibility
-		p.Type = PackageTypeMlModel
-	}
-
 	if !slices.Contains(SupportedPackageTypes, p.Type) {
 		return utils.NewConfigValidationError(path, errors.Errorf("unsupported package type %q. Must be one of: %v",
 			p.Type, SupportedPackageTypes))

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1158,7 +1158,7 @@ func TestPackageConfig(t *testing.T) {
 				Package: "my_org/my_package",
 				Version: "0",
 			},
-			expectedRealFilePath: filepath.Join(viamDotDir, "packages", ".data", "ml_model", "my_org-my_package-0"),
+			shouldFailValidation: true,
 		},
 		{
 			config: config.PackageConfig{

--- a/config/placeholder_replacement.go
+++ b/config/placeholder_replacement.go
@@ -186,13 +186,18 @@ func (v *placeholderReplacementVisitor) replacePackagePlaceholder(toReplace stri
 		return toReplace, errors.Errorf("failed to find a package named %q for placeholder %q",
 			packageName, toReplace)
 	}
-	if packageType != string(packageConfig.Type) {
-		expectedPlaceholder := fmt.Sprintf("packages.%s.%s", string(packageConfig.Type), packageName)
-		return toReplace,
-			errors.Errorf("placeholder %q is looking for a package of type %q but a package of type %q was found. Try %q",
-				toReplace, packageType, string(packageConfig.Type), expectedPlaceholder)
+	// package match is either of the correct type as the placeholder
+	// or (for backwards compatibility) the placeholder has no type and matches an ml_model package
+	if packageType == string(packageConfig.Type) ||
+		(packageType == "" && packageConfig.Type == PackageTypeMlModel) {
+			return packageConfig.LocalDataDirectory(viamPackagesDir), nil
 	}
-	return packageConfig.LocalDataDirectory(viamPackagesDir), nil
+
+	expectedPlaceholder := fmt.Sprintf("packages.%s.%s", string(packageConfig.Type), packageName)
+	return toReplace,
+		errors.Errorf("placeholder %q is looking for a package of type %q but a package of type %q was found. Try %q",
+			toReplace, packageType, string(packageConfig.Type), expectedPlaceholder)
+
 }
 
 func (v *placeholderReplacementVisitor) replaceEnvironmentPlaceholder(toReplace string) (string, error) {

--- a/config/placeholder_replacement.go
+++ b/config/placeholder_replacement.go
@@ -190,14 +190,13 @@ func (v *placeholderReplacementVisitor) replacePackagePlaceholder(toReplace stri
 	// or (for backwards compatibility) the placeholder has no type and matches an ml_model package
 	if packageType == string(packageConfig.Type) ||
 		(packageType == "" && packageConfig.Type == PackageTypeMlModel) {
-			return packageConfig.LocalDataDirectory(viamPackagesDir), nil
+		return packageConfig.LocalDataDirectory(viamPackagesDir), nil
 	}
 
 	expectedPlaceholder := fmt.Sprintf("packages.%s.%s", string(packageConfig.Type), packageName)
 	return toReplace,
 		errors.Errorf("placeholder %q is looking for a package of type %q but a package of type %q was found. Try %q",
 			toReplace, packageType, string(packageConfig.Type), expectedPlaceholder)
-
 }
 
 func (v *placeholderReplacementVisitor) replaceEnvironmentPlaceholder(toReplace string) (string, error) {

--- a/config/placeholder_replacement.go
+++ b/config/placeholder_replacement.go
@@ -181,10 +181,6 @@ func (v *placeholderReplacementVisitor) replacePackagePlaceholder(toReplace stri
 	}
 	packageType := matches[packagePlaceholderRegexp.SubexpIndex("type")]
 	packageName := matches[packagePlaceholderRegexp.SubexpIndex("name")]
-	if packageType == "" {
-		// for backwards compatibility
-		packageType = string(PackageTypeMlModel)
-	}
 	packageConfig, isPresent := v.packages[packageName]
 	if !isPresent {
 		return toReplace, errors.Errorf("failed to find a package named %q for placeholder %q",

--- a/config/proto_conversions.go
+++ b/config/proto_conversions.go
@@ -879,9 +879,6 @@ func PackageConfigFromProto(proto *pb.PackageConfig) (*PackageConfig, error) {
 // This is required be because app/packages uses a PackageType enum but app/PackageConfig uses a string Type.
 func PackageTypeToProto(t PackageType) (*packagespb.PackageType, error) {
 	switch t {
-	case "":
-		// for backwards compatibility
-		fallthrough
 	case PackageTypeMlModel:
 		return packagespb.PackageType_PACKAGE_TYPE_ML_MODEL.Enum(), nil
 	case PackageTypeModule:

--- a/config/proto_conversions_test.go
+++ b/config/proto_conversions_test.go
@@ -985,7 +985,7 @@ func TestPackageTypeConversion(t *testing.T) {
 	test.That(t, converted, test.ShouldResemble, packagespb.PackageType_PACKAGE_TYPE_MODULE.Enum())
 
 	badType := PackageType("invalid-package-type")
-	converted, err := PackageTypeToProto(badType)
+	converted, err = PackageTypeToProto(badType)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, fmt.Sprint(err), test.ShouldContainSubstring, "invalid-package-type")
 	test.That(t, converted, test.ShouldResemble, packagespb.PackageType_PACKAGE_TYPE_UNSPECIFIED.Enum())

--- a/config/proto_conversions_test.go
+++ b/config/proto_conversions_test.go
@@ -980,12 +980,12 @@ func TestPackageTypeConversion(t *testing.T) {
 	test.That(t, err, test.ShouldNotBeNil)
 
 	moduleType := PackageType("module")
-	converted, err = PackageTypeToProto(moduleType)
+	converted, err := PackageTypeToProto(moduleType)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, converted, test.ShouldResemble, packagespb.PackageType_PACKAGE_TYPE_MODULE.Enum())
 
 	badType := PackageType("invalid-package-type")
-	converted, err = PackageTypeToProto(badType)
+	converted, err := PackageTypeToProto(badType)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, fmt.Sprint(err), test.ShouldContainSubstring, "invalid-package-type")
 	test.That(t, converted, test.ShouldResemble, packagespb.PackageType_PACKAGE_TYPE_UNSPECIFIED.Enum())

--- a/config/proto_conversions_test.go
+++ b/config/proto_conversions_test.go
@@ -976,7 +976,7 @@ func TestDisablePartialStart(t *testing.T) {
 
 func TestPackageTypeConversion(t *testing.T) {
 	emptyType := PackageType("")
-	converted, err := PackageTypeToProto(emptyType)
+	_, err := PackageTypeToProto(emptyType)
 	test.That(t, err, test.ShouldNotBeNil)
 
 	moduleType := PackageType("module")

--- a/config/proto_conversions_test.go
+++ b/config/proto_conversions_test.go
@@ -977,8 +977,7 @@ func TestDisablePartialStart(t *testing.T) {
 func TestPackageTypeConversion(t *testing.T) {
 	emptyType := PackageType("")
 	converted, err := PackageTypeToProto(emptyType)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, converted, test.ShouldResemble, packagespb.PackageType_PACKAGE_TYPE_ML_MODEL.Enum())
+	test.That(t, err, test.ShouldNotBeNil)
 
 	moduleType := PackageType("module")
 	converted, err = PackageTypeToProto(moduleType)


### PR DESCRIPTION
I checked and migrated all robots that had a missing package type before doing this. Now users will get an error in robot logs if type is missing or unsupported.