### PR TITLE
RSDK-5244 Make the AMS encoder talk to i2c bus directly

### DIFF
--- a/components/encoder/ams/ams_as5048.go
+++ b/components/encoder/ams/ams_as5048.go
@@ -142,12 +142,12 @@ func makeAS5048Encoder(ctx context.Context,
 	deps resource.Dependencies,
 	conf resource.Config, logger logging.Logger, bus board.I2C) (encoder.Encoder, error) {
 
-	cancelCtx, cancel := context.WithCancel(context.Background())
-
 	cfg, err := resource.NativeConfig[*Config](conf)
 	if err != nil {
 		return nil, err
 	}
+
+	cancelCtx, cancel := context.WithCancel(context.Background())
 
 	res := &Encoder{
 		Named:        conf.ResourceName().AsNamed(),
@@ -165,7 +165,6 @@ func makeAS5048Encoder(ctx context.Context,
 		return nil, err
 	}
 	return res, nil
-
 }
 
 // Reconfigure reconfigures the encoder atomically.

--- a/components/encoder/ams/ams_as5048.go
+++ b/components/encoder/ams/ams_as5048.go
@@ -137,11 +137,11 @@ func newAS5048Encoder(
 	return makeAS5048Encoder(ctx, deps, conf, logger, bus)
 }
 
-// This function is seperated to inject a mock i2c bus during tests.
+// This function is separated to inject a mock i2c bus during tests.
 func makeAS5048Encoder(ctx context.Context,
 	deps resource.Dependencies,
-	conf resource.Config, logger logging.Logger, bus board.I2C) (encoder.Encoder, error) {
-
+	conf resource.Config, logger logging.Logger, bus board.I2C,
+) (encoder.Encoder, error) {
 	cfg, err := resource.NativeConfig[*Config](conf)
 	if err != nil {
 		return nil, err

--- a/components/encoder/ams/ams_as5048.go
+++ b/components/encoder/ams/ams_as5048.go
@@ -1,8 +1,11 @@
+//go:build linux
+
 // Package ams implements the AMS_AS5048 encoder
 package ams
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"sync"
 	"time"
@@ -11,6 +14,7 @@ import (
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/genericlinux"
 	"go.viam.com/rdk/components/encoder"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -44,7 +48,6 @@ func init() {
 // Config contains the connection information for
 // configuring an AS5048 encoder.
 type Config struct {
-	BoardName string `json:"board"`
 	// We include connection type here in anticipation for
 	// future SPI support
 	ConnectionType string `json:"connection_type"`
@@ -67,9 +70,6 @@ func (conf *Config) Validate(path string) ([]string, error) {
 		return nil, errors.Errorf("%s is not a supported connection type", connType)
 	}
 	if connType == i2cConn {
-		if len(conf.BoardName) == 0 {
-			return nil, errors.New("expected nonempty board")
-		}
 		if conf.I2CConfig == nil {
 			return nil, errors.New("i2c selected as connection type, but no attributes supplied")
 		}
@@ -77,7 +77,6 @@ func (conf *Config) Validate(path string) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		deps = append(deps, conf.BoardName)
 	}
 
 	return deps, nil
@@ -113,6 +112,7 @@ type Encoder struct {
 	positionType            encoder.PositionType
 	i2cBus                  board.I2C
 	i2cAddr                 byte
+	i2cBusName              string
 	cancelCtx               context.Context
 	cancel                  context.CancelFunc
 	activeBackgroundWorkers sync.WaitGroup
@@ -124,13 +124,39 @@ func newAS5048Encoder(
 	conf resource.Config,
 	logger logging.Logger,
 ) (encoder.Encoder, error) {
+	newConf, err := resource.NativeConfig[*Config](conf)
+	if err != nil {
+		return nil, err
+	}
+
+	bus, err := genericlinux.NewI2cBus(newConf.I2CBus)
+	if err != nil {
+		msg := fmt.Sprintf("can't find I2C bus '%q' for AMS encoder", newConf.I2CBus)
+		return nil, errors.Wrap(err, msg)
+	}
+	return makeAS5048Encoder(ctx, deps, conf, logger, bus)
+}
+
+// This function is seperated to inject a mock i2c bus during tests.
+func makeAS5048Encoder(ctx context.Context,
+	deps resource.Dependencies,
+	conf resource.Config, logger logging.Logger, bus board.I2C) (encoder.Encoder, error) {
+
 	cancelCtx, cancel := context.WithCancel(context.Background())
+
+	cfg, err := resource.NativeConfig[*Config](conf)
+	if err != nil {
+		return nil, err
+	}
+
 	res := &Encoder{
 		Named:        conf.ResourceName().AsNamed(),
 		cancelCtx:    cancelCtx,
 		cancel:       cancel,
 		logger:       logger,
 		positionType: encoder.PositionTypeTicks,
+		i2cBus:       bus,
+		i2cBusName:   cfg.I2CBus,
 	}
 	if err := res.Reconfigure(ctx, deps, conf); err != nil {
 		return nil, err
@@ -139,6 +165,7 @@ func newAS5048Encoder(
 		return nil, err
 	}
 	return res, nil
+
 }
 
 // Reconfigure reconfigures the encoder atomically.
@@ -151,28 +178,21 @@ func (enc *Encoder) Reconfigure(
 	if err != nil {
 		return err
 	}
-
-	brd, err := board.FromDependencies(deps, newConf.BoardName)
-	if err != nil {
-		return err
-	}
-	localBoard, ok := brd.(board.LocalBoard)
-	if !ok {
-		return errors.Errorf(
-			"board with name %s does not implement the LocalBoard interface", newConf.BoardName,
-		)
-	}
-	i2c, exists := localBoard.I2CByName(newConf.I2CBus)
-	if !exists {
-		return errors.Errorf("unable to find I2C bus: %s", newConf.I2CBus)
-	}
 	enc.mu.Lock()
 	defer enc.mu.Unlock()
-	if enc.i2cBus == i2c || enc.i2cAddr == byte(newConf.I2CAddr) {
-		return nil
+
+	if enc.i2cBusName != newConf.I2CBus {
+		bus, err := genericlinux.NewI2cBus(newConf.I2CBus)
+		if err != nil {
+			msg := fmt.Sprintf("can't find I2C bus '%q' for AMS encoder", newConf.I2CBus)
+			return errors.Wrap(err, msg)
+		}
+		enc.i2cBusName = newConf.I2CBus
+		enc.i2cBus = bus
 	}
-	enc.i2cBus = i2c
-	enc.i2cAddr = byte(newConf.I2CAddr)
+	if enc.i2cAddr != byte(newConf.I2CAddr) {
+		enc.i2cAddr = byte(newConf.I2CAddr)
+	}
 	return nil
 }
 

--- a/components/encoder/ams/ams_as5048_nonlinux.go
+++ b/components/encoder/ams/ams_as5048_nonlinux.go
@@ -1,0 +1,2 @@
+// Package ams is Lunix-only
+package ams

--- a/components/encoder/ams/ams_as5048_nonlinux.go
+++ b/components/encoder/ams/ams_as5048_nonlinux.go
@@ -1,2 +1,2 @@
-// Package ams is Lunix-only
+// Package ams is Linux-only
 package ams

--- a/components/encoder/ams/ams_as5048_test.go
+++ b/components/encoder/ams/ams_as5048_test.go
@@ -39,7 +39,6 @@ func TestConvertBytesToAngle(t *testing.T) {
 }
 
 func setupDependencies(mockData []byte) (resource.Config, resource.Dependencies, board.I2C) {
-
 	i2cConf := &I2CConfig{
 		I2CBus:  "1",
 		I2CAddr: 64,
@@ -115,7 +114,6 @@ func TestAMSEncoder(t *testing.T) {
 }
 
 func setupDependenciesWithWrite(mockData []byte, writeData map[byte]byte) (resource.Config, resource.Dependencies, board.I2C) {
-
 	i2cConf := &I2CConfig{
 		I2CBus:  "1",
 		I2CAddr: 64,

--- a/components/encoder/ams/ams_as5048_test.go
+++ b/components/encoder/ams/ams_as5048_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package ams
 
 import (
@@ -53,14 +55,19 @@ func setupDependencies(mockData []byte) (resource.Config, resource.Dependencies,
 		},
 	}
 
-	i2c := &inject.I2C{}
-	i2c.ReadByteDataFunc = func(ctx context.Context, register byte) (byte, error) {
+	i2cHandle := &inject.I2CHandle{}
+	i2cHandle.ReadByteDataFunc = func(ctx context.Context, register byte) (byte, error) {
 		return mockData[register], nil
 	}
-	i2c.WriteByteDataFunc = func(ctx context.Context, b1, b2 byte) error {
+	i2cHandle.WriteByteDataFunc = func(ctx context.Context, b1, b2 byte) error {
 		return nil
 	}
-	i2c.CloseFunc = func() error { return nil }
+	i2cHandle.CloseFunc = func() error { return nil }
+
+	i2c := &inject.I2C{}
+	i2c.OpenHandleFunc = func(addr byte) (board.I2CHandle, error) {
+		return i2cHandle, nil
+	}
 
 	return cfg, resource.Dependencies{}, i2c
 }
@@ -124,15 +131,20 @@ func setupDependenciesWithWrite(mockData []byte, writeData map[byte]byte) (resou
 		},
 	}
 
-	i2c := &inject.I2C{}
-	i2c.ReadByteDataFunc = func(ctx context.Context, register byte) (byte, error) {
+	i2cHandle := &inject.I2CHandle{}
+	i2cHandle.ReadByteDataFunc = func(ctx context.Context, register byte) (byte, error) {
 		return mockData[register], nil
 	}
-	i2c.WriteByteDataFunc = func(ctx context.Context, b1, b2 byte) error {
+	i2cHandle.WriteByteDataFunc = func(ctx context.Context, b1, b2 byte) error {
 		writeData[b1] = b2
 		return nil
 	}
-	i2c.CloseFunc = func() error { return nil }
+	i2cHandle.CloseFunc = func() error { return nil }
+
+	i2c := &inject.I2C{}
+	i2c.OpenHandleFunc = func(addr byte) (board.I2CHandle, error) {
+		return i2cHandle, nil
+	}
 	return cfg, resource.Dependencies{}, i2c
 }
 


### PR DESCRIPTION
tested on scuttle AMS encoders. This change also needs a change in app to remove board from the "fancy config" and a migration script. 