### PR TITLE
Hotfix to check if h264 encoder is supported by the OS

### DIFF
--- a/web/server/entrypoint_arm64.go
+++ b/web/server/entrypoint_arm64.go
@@ -5,18 +5,23 @@ package server
 import (
 	"go.viam.com/rdk/gostream"
 	"go.viam.com/rdk/gostream/codec/h264"
-	"go.viam.com/rdk/gostream/codec/h264/ffmpeg/avcodec"
 	"go.viam.com/rdk/gostream/codec/opus"
 	"go.viam.com/rdk/gostream/codec/x264"
 )
 
 func makeStreamConfig() gostream.StreamConfig {
 	var streamConfig gostream.StreamConfig
-	if avcodec.FindEncoderByName(h264.V4l2m2m) != nil {
-		streamConfig.VideoEncoderFactory = h264.NewEncoderFactory()
-	} else {
+
+	// Attempt to create a new encoder with hardcoded parameters
+	// to check if V4l2m2m codec is supported.
+	width, height, keyFrameInterval := 1920, 1080, 30
+	_, err := h264.NewEncoder(width, height, keyFrameInterval, nil)
+	if err != nil {
 		streamConfig.VideoEncoderFactory = x264.NewEncoderFactory()
+	} else {
+		streamConfig.VideoEncoderFactory = h264.NewEncoderFactory()
 	}
+
 	streamConfig.AudioEncoderFactory = opus.NewEncoderFactory()
 	return streamConfig
 }


### PR DESCRIPTION
### Description

Currently, there is an issue setting up the encoder factory on non-raspberrypi arm64 devices where the encoder check thinks that `V4l2m2m` codec is available since it is built into ffmpeg but is not supported by the OS.

This PR simply attempts to open up the encoder to determine if it is actually supported.

___

### Testing

Tested that h264 encoder factory works on RPI and x264 works on Jetson.