### PR TITLE
Fix: improve nav mode types to be resilient to upstream changes

### DIFF
--- a/web/frontend/src/components/navigation/hooks/use-nav-mode.ts
+++ b/web/frontend/src/components/navigation/hooks/use-nav-mode.ts
@@ -2,11 +2,7 @@ import { type ServiceError, navigationApi } from '@viamrobotics/sdk';
 import { useNavClient } from './use-nav-client';
 import { writable } from 'svelte/store';
 
-export type NavigationMode = (
-  typeof navigationApi.Mode.MODE_UNSPECIFIED |
-  typeof navigationApi.Mode.MODE_MANUAL |
-  typeof navigationApi.Mode.MODE_WAYPOINT
-)
+export type NavigationMode = navigationApi.ModeMap[keyof navigationApi.ModeMap];
 
 export const useNavMode = (name: string) => {
   const navClient = useNavClient(name);


### PR DESCRIPTION
See the error on TS-SDK version bump here: https://github.com/viamrobotics/rdk/actions/runs/6815121936

A new value was added to the enum but the typings defined for nav mode in RDK were hard coded. This makes the type dynamic to the possible enum values.