### PR TITLE
RSDK-5708: Modify PowerSensor implementation to follow MovementSensor implementation for the RC card

### DIFF
--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "2.3.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/remote-control",
-      "version": "2.3.0",
+      "version": "2.4.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@improbable-eng/grpc-web": "0.15.0",
@@ -24,7 +24,7 @@
         "@viamrobotics/prime-blocks": "^0.0.14",
         "@viamrobotics/prime-core": "^0.0.53",
         "@viamrobotics/rpc": "0.1.37",
-        "@viamrobotics/sdk": "0.6.0-rc.0",
+        "@viamrobotics/sdk": "0.7.0-rc.2",
         "@viamrobotics/three": "^0.0.2",
         "@viamrobotics/typescript-config": "^0.1.0",
         "cypress": "12.17.3",
@@ -56,13 +56,9 @@
       "peerDependencies": {
         "@floating-ui/dom": "^1.5.3",
         "@improbable-eng/grpc-web": ">=0.15",
-        "@threlte/core": ">=6.0",
-        "@threlte/extras": ">=7.4",
         "@viamrobotics/prime": ">=0.5",
-        "@viamrobotics/prime-blocks": ">=0.0.14",
-        "@viamrobotics/prime-core": ">=0.0.53",
         "@viamrobotics/rpc": ">=0.1",
-        "@viamrobotics/sdk": "0.6.0-rc.0",
+        "@viamrobotics/sdk": "0.7.0-rc.2",
         "google-protobuf": ">=3",
         "tailwindcss": ">=3.3",
         "three": ">=0.155"
@@ -1482,9 +1478,9 @@
       }
     },
     "node_modules/@viamrobotics/sdk": {
-      "version": "0.6.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@viamrobotics/sdk/-/sdk-0.6.0-rc.0.tgz",
-      "integrity": "sha512-D5EFixvhZ4HfYvPqNS/7/ZVVhq/Q5Dmr/Ms/upnZBVWUaUfuy25OjIikA0cz6PBWuSpQK6dyO14jB+Mwz/hltw==",
+      "version": "0.7.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@viamrobotics/sdk/-/sdk-0.7.0-rc.2.tgz",
+      "integrity": "sha512-fSOsS6RzNUnvRU70iYf1h1En6g7mV8+gu6pLCuH+HNVCSQcgEQIxBZSX3VJSydPah9PKZiIIZJXXBdYjLG163A==",
       "dev": true,
       "dependencies": {
         "@viamrobotics/rpc": "^0.1.38",

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -37,7 +37,7 @@
     "@improbable-eng/grpc-web": ">=0.15",
     "@viamrobotics/prime": ">=0.5",
     "@viamrobotics/rpc": ">=0.1",
-    "@viamrobotics/sdk": "0.6.0-rc.0",
+    "@viamrobotics/sdk": "0.7.0-rc.2",
     "google-protobuf": ">=3",
     "tailwindcss": ">=3.3",
     "three": ">=0.155"
@@ -58,7 +58,7 @@
     "@viamrobotics/prime-blocks": "^0.0.14",
     "@viamrobotics/prime-core": "^0.0.53",
     "@viamrobotics/rpc": "0.1.37",
-    "@viamrobotics/sdk": "0.6.0-rc.0",
+    "@viamrobotics/sdk": "0.7.0-rc.2",
     "@viamrobotics/three": "^0.0.2",
     "@viamrobotics/typescript-config": "^0.1.0",
     "cypress": "12.17.3",

--- a/web/frontend/src/api/power-sensor.ts
+++ b/web/frontend/src/api/power-sensor.ts
@@ -1,0 +1,59 @@
+import { type Client, powerSensorApi } from '@viamrobotics/sdk';
+import { rcLogConditionally } from '@/lib/log';
+
+export const getVoltage = async (robotClient: Client, name: string) => {
+  const req = new powerSensorApi.GetVoltageRequest();
+  req.setName(name);
+
+  rcLogConditionally(req);
+
+  const response = await new Promise<powerSensorApi.GetVoltageResponse | null>((resolve, reject) => {
+    robotClient.powerSensorService.getVoltage(req, (error, res) => {
+      if(error) {
+        reject(error);
+      } else {
+        resolve(res);
+      }
+    });
+  });
+
+  return response?.toObject().volts;
+};
+
+export const getCurrent = async (robotClient: Client, name: string) => {
+  const req = new powerSensorApi.GetCurrentRequest();
+  req.setName(name);
+
+  rcLogConditionally(req);
+
+  const response = await new Promise<powerSensorApi.GetCurrentResponse | null>((resolve, reject) => {
+    robotClient.powerSensorService.getCurrent(req, (error, res) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve(res);
+      }
+    });
+  });
+
+  return response?.toObject().amperes;
+};
+
+export const getPower = async (robotClient: Client, name: string) => {
+  const req = new powerSensorApi.GetPowerRequest();
+  req.setName(name);
+
+  rcLogConditionally(req);
+
+  const response = await new Promise<powerSensorApi.GetPowerResponse | null>((resolve, reject) => {
+    robotClient.powerSensorService.getPower(req, (error, res) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve(res);
+      }
+    });
+  });
+
+  return response?.toObject().watts;
+};

--- a/web/frontend/src/components/navigation/index.svelte
+++ b/web/frontend/src/components/navigation/index.svelte
@@ -132,6 +132,7 @@ const handleDeleteWaypoint = async (event: CustomEvent<string>) => {
           [navigationApi.Mode.MODE_UNSPECIFIED]: '',
           [navigationApi.Mode.MODE_MANUAL]: 'Manual',
           [navigationApi.Mode.MODE_WAYPOINT]: 'Waypoint',
+          [navigationApi.Mode.MODE_EXPLORE]: 'Explore',
         }[$mode ?? navigationApi.Mode.MODE_UNSPECIFIED]}
         on:input={handleModeSelect}
       />


### PR DESCRIPTION
this will currently not pass checks because I have made one more typescript change that needs to be reviewed and merged.

Description from JIRA: 
Recently TypeScript SDK changes were made which removed the types MovementSensorReadings and PowerSensorReadings, because there is now an API for MovementSensor and PowerSensor which should make these types obsolete. For MovementSensor, no issues. However for PowerSensor, the RC card is now broken because it relied on that PowerSensorReadings type. 

Ideally, this type wouldn’t be necessary, because MovementSensor and PowerSensor both rely on the same API from common, so neither of them should need a *sensorReadingsType. Since MovementSensor is still working correctly, hoping that power-sensor/index.svelte can be updated accordingly to match the implementation methods in movement-sensor/index.svelte.

This issue is currently blocking the TypeScript SDK version from being bumped in RC for new releases, and if anyone manually bumps the version they will see these issues.