### PR TITLE
RSDK-5709 - Module CWD should not be viam-server CWD

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -786,13 +786,22 @@ func (m *module) startProcess(
 	if err != nil {
 		return err
 	}
+	moduleEnvironment := m.getFullEnvironment(viamHomeDir)
+	// Prefer VIAM_MODULE_ROOT as the current working directory if present but fallback to the directory of the exepath
+	moduleWorkingDirectory, ok := moduleEnvironment["VIAM_MODULE_ROOT"]
+	if !ok {
+		moduleWorkingDirectory = filepath.Dir(absoluteExePath)
+		logger.Warnf("VIAM_MODULE_ROOT was not passed to module %q. Defaulting to %q", m.cfg.Name, moduleWorkingDirectory)
+	} else {
+		logger.Debugf("Starting module %q in working directory %q", m.cfg.Name, moduleWorkingDirectory)
+	}
 
 	pconf := pexec.ProcessConfig{
 		ID:               m.cfg.Name,
 		Name:             absoluteExePath,
 		Args:             []string{m.addr},
-		CWD:              filepath.Dir(absoluteExePath),
-		Environment:      m.getFullEnvironment(viamHomeDir),
+		CWD:              moduleWorkingDirectory,
+		Environment:      moduleEnvironment,
 		Log:              true,
 		OnUnexpectedExit: oue,
 	}

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -780,10 +780,18 @@ func (m *module) startProcess(
 		return err
 	}
 
+	// We evaluate the Module's ExePath absolutely in the viam-server process so that
+	// setting the CWD does not cause issues with relative process names
+	absoluteExePath, err := filepath.Abs(m.cfg.ExePath)
+	if err != nil {
+		return err
+	}
+
 	pconf := pexec.ProcessConfig{
 		ID:               m.cfg.Name,
-		Name:             m.cfg.ExePath,
+		Name:             absoluteExePath,
 		Args:             []string{m.addr},
+		CWD:              filepath.Dir(absoluteExePath),
 		Environment:      m.getFullEnvironment(viamHomeDir),
 		Log:              true,
 		OnUnexpectedExit: oue,

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -662,8 +662,7 @@ func TestDebugModule(t *testing.T) {
 	}
 }
 
-func TestModuleDataDirectoryFullstack(t *testing.T) {
-	logger, logs := logging.NewObservedTestLogger(t)
+func TestModuleMisc(t *testing.T) {
 	ctx := context.Background()
 
 	parentAddr, err := modlib.CreateSocketAddress(t.TempDir(), "parent")
@@ -679,19 +678,6 @@ func TestModuleDataDirectoryFullstack(t *testing.T) {
 	}
 
 	testViamHomeDir := t.TempDir()
-	mgr := NewManager(parentAddr, logger, modmanageroptions.Options{
-		UntrustedEnv: false,
-		ViamHomeDir:  testViamHomeDir,
-	})
-	// Test that cleaning the data directory before it has been created does not produce log messages
-	err = mgr.CleanModuleDataDirectory()
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, logs.FilterMessageSnippet("Removing module data").Len(), test.ShouldEqual, 0)
-
-	// Add the module
-	err = mgr.Add(ctx, modCfg)
-	test.That(t, err, test.ShouldBeNil)
-
 	// Add a component that uses the module
 	myHelperModel := resource.NewModel("rdk", "test", "helper")
 	rNameMyHelper := generic.Named("myhelper")
@@ -700,40 +686,89 @@ func TestModuleDataDirectoryFullstack(t *testing.T) {
 		API:   generic.API,
 		Model: myHelperModel,
 	}
-	_, err = cfgMyHelper.Validate("test", resource.APITypeComponentName)
-	test.That(t, err, test.ShouldBeNil)
 
-	h, err := mgr.AddResource(ctx, cfgMyHelper, nil)
-	test.That(t, err, test.ShouldBeNil)
-	ok := mgr.IsModularResource(rNameMyHelper)
-	test.That(t, ok, test.ShouldBeTrue)
+	t.Run("data directory fullstack", func(t *testing.T) {
+		logger, logs := logging.NewObservedTestLogger(t)
+		mgr := NewManager(parentAddr, logger, modmanageroptions.Options{
+			UntrustedEnv: false,
+			ViamHomeDir:  testViamHomeDir,
+		})
+		// Test that cleaning the data directory before it has been created does not produce log messages
+		err = mgr.CleanModuleDataDirectory()
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, logs.FilterMessageSnippet("Removing module data").Len(), test.ShouldEqual, 0)
 
-	// Create a file in the modules data directory and then verify that it was written
-	resp, err := h.DoCommand(ctx, map[string]interface{}{
-		"command":  "write_data_file",
-		"filename": "data.txt",
-		"contents": "hello, world!",
+		// Add the module
+		err = mgr.Add(ctx, modCfg)
+		test.That(t, err, test.ShouldBeNil)
+
+		_, err = cfgMyHelper.Validate("test", resource.APITypeComponentName)
+		test.That(t, err, test.ShouldBeNil)
+
+		h, err := mgr.AddResource(ctx, cfgMyHelper, nil)
+		test.That(t, err, test.ShouldBeNil)
+		ok := mgr.IsModularResource(rNameMyHelper)
+		test.That(t, ok, test.ShouldBeTrue)
+
+		// Create a file in the modules data directory and then verify that it was written
+		resp, err := h.DoCommand(ctx, map[string]interface{}{
+			"command":  "write_data_file",
+			"filename": "data.txt",
+			"contents": "hello, world!",
+		})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, resp, test.ShouldNotBeNil)
+		dataFullPath, ok := resp["fullpath"].(string)
+		test.That(t, ok, test.ShouldBeTrue)
+		test.That(t, dataFullPath, test.ShouldEqual, filepath.Join(testViamHomeDir, "module-data", "local", "test-module", "data.txt"))
+		dataFileContents, err := os.ReadFile(dataFullPath)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, string(dataFileContents), test.ShouldEqual, "hello, world!")
+
+		err = mgr.RemoveResource(ctx, rNameMyHelper)
+		test.That(t, err, test.ShouldBeNil)
+		_, err = mgr.Remove("test-module")
+		test.That(t, err, test.ShouldBeNil)
+		// test that the data directory is cleaned up
+		err = mgr.CleanModuleDataDirectory()
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, logs.FilterMessageSnippet("Removing module data").Len(), test.ShouldEqual, 1)
+		_, err = os.Stat(filepath.Join(testViamHomeDir, "module-data", "local"))
+		test.That(t, fmt.Sprint(err), test.ShouldContainSubstring, "no such file or directory")
+
+		err = mgr.Close(ctx)
+		test.That(t, err, test.ShouldBeNil)
 	})
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, resp, test.ShouldNotBeNil)
-	dataFullPath, ok := resp["fullpath"].(string)
-	test.That(t, ok, test.ShouldBeTrue)
-	test.That(t, dataFullPath, test.ShouldEqual, filepath.Join(testViamHomeDir, "module-data", "local", "test-module", "data.txt"))
-	dataFileContents, err := os.ReadFile(dataFullPath)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, string(dataFileContents), test.ShouldEqual, "hello, world!")
 
-	err = mgr.RemoveResource(ctx, rNameMyHelper)
-	test.That(t, err, test.ShouldBeNil)
-	_, err = mgr.Remove("test-module")
-	test.That(t, err, test.ShouldBeNil)
-	// test that the data directory is cleaned up
-	err = mgr.CleanModuleDataDirectory()
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, logs.FilterMessageSnippet("Removing module data").Len(), test.ShouldEqual, 1)
-	_, err = os.Stat(filepath.Join(testViamHomeDir, "module-data", "local"))
-	test.That(t, fmt.Sprint(err), test.ShouldContainSubstring, "no such file or directory")
+	t.Run("module working directory", func(t *testing.T) {
+		logger := logging.NewTestLogger(t)
+		mgr := NewManager(parentAddr, logger, modmanageroptions.Options{
+			UntrustedEnv: false,
+			ViamHomeDir:  testViamHomeDir,
+		})
+		// Add the module
+		err = mgr.Add(ctx, modCfg)
+		test.That(t, err, test.ShouldBeNil)
 
-	err = mgr.Close(ctx)
-	test.That(t, err, test.ShouldBeNil)
+		_, err = cfgMyHelper.Validate("test", resource.APITypeComponentName)
+		test.That(t, err, test.ShouldBeNil)
+
+		h, err := mgr.AddResource(ctx, cfgMyHelper, nil)
+		test.That(t, err, test.ShouldBeNil)
+		ok := mgr.IsModularResource(rNameMyHelper)
+		test.That(t, ok, test.ShouldBeTrue)
+
+		// Create a file in the modules data directory and then verify that it was written
+		resp, err := h.DoCommand(ctx, map[string]interface{}{
+			"command": "get_working_directory",
+		})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, resp, test.ShouldNotBeNil)
+		modWorkingDirectory, ok := resp["path"].(string)
+		test.That(t, ok, test.ShouldBeTrue)
+		test.That(t, modWorkingDirectory, test.ShouldEqual, filepath.Dir(modPath))
+
+		err = mgr.Close(ctx)
+		test.That(t, err, test.ShouldBeNil)
+	})
 }

--- a/module/testmodule/main.go
+++ b/module/testmodule/main.go
@@ -95,6 +95,7 @@ func (h *helper) DoCommand(ctx context.Context, req map[string]interface{}) (map
 		//nolint:nilnil
 		return nil, nil
 	case "get_ops":
+		// For testing the module's operation manager
 		ops := myMod.OperationManager().All()
 		var opsOut []string
 		for _, op := range ops {
@@ -102,12 +103,15 @@ func (h *helper) DoCommand(ctx context.Context, req map[string]interface{}) (map
 		}
 		return map[string]interface{}{"ops": opsOut}, nil
 	case "echo":
+		// For testing module liveliness
 		return req, nil
 	case "kill_module":
+		// For testing module reloading & unexpected exists
 		os.Exit(1)
 		// unreachable return statement needed for compilation
 		return nil, errors.New("unreachable error")
 	case "write_data_file":
+		// For testing that the module's data directory has been created and that the VIAM_MODULE_DATA env var exists
 		filename, ok := req["filename"].(string)
 		if !ok {
 			return nil, errors.New("missing 'filename' string")
@@ -122,6 +126,13 @@ func (h *helper) DoCommand(ctx context.Context, req map[string]interface{}) (map
 			return map[string]interface{}{}, err
 		}
 		return map[string]interface{}{"fullpath": dataFilePath}, nil
+	case "get_working_directory":
+		// For testing that modules are started with the correct working directory
+		workingDir, err := os.Getwd()
+		if err != nil {
+			return map[string]interface{}{}, err
+		}
+		return map[string]interface{}{"path": workingDir}, nil
 	default:
 		return nil, fmt.Errorf("unknown command string %s", cmd)
 	}


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-5709

This sets the module CWD to `dirname m.cfg.ExePath`

For reasoning, see the discussion on the linked google doc.

This PR is a measure to arrive at consensus (so discussion is expected and it is totally fine with me if we close this PR and decide to solve this some other way)