### PR TITLE
RSDK-4810-add-state-to-builtin

### DIFF
--- a/services/motion/builtin/state/state.go
+++ b/services/motion/builtin/state/state.go
@@ -1,0 +1,23 @@
+// Package state provides apis for motion builtin plan executions
+// and manages the state of those executions
+package state
+
+import (
+	"context"
+
+	"go.viam.com/rdk/logging"
+)
+
+// State is the state of the builtin motion service
+// It keeps track of the builtin motion service's executions.
+type State struct{}
+
+// NewState creates a new state.
+func NewState(ctx context.Context, logger logging.Logger) *State {
+	s := State{}
+	return &s
+}
+
+// Stop stops all executions within the State.
+func (s *State) Stop() {
+}

--- a/services/motion/builtin/state/state_test.go
+++ b/services/motion/builtin/state/state_test.go
@@ -1,0 +1,22 @@
+package state_test
+
+import (
+	"context"
+	"testing"
+
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/services/motion/builtin/state"
+)
+
+func TestState(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("creating & stopping a state with no intermediary calls", func(t *testing.T) {
+		t.Parallel()
+		s := state.NewState(ctx, logger)
+		defer s.Stop()
+	})
+}

--- a/services/motion/client_test.go
+++ b/services/motion/client_test.go
@@ -368,11 +368,9 @@ func TestClient(t *testing.T) {
 		})
 
 		t.Run("otherwise returns a slice of PlanStautsWithID", func(t *testing.T) {
-			planID, err := uuid.NewUUID()
-			test.That(t, err, test.ShouldBeNil)
+			planID := uuid.New()
 
-			executionID, err := uuid.NewUUID()
-			test.That(t, err, test.ShouldBeNil)
+			executionID := uuid.New()
 
 			status := motion.PlanStatus{State: motion.PlanStateInProgress, Timestamp: time.Now().UTC(), Reason: nil}
 
@@ -394,19 +392,16 @@ func TestClient(t *testing.T) {
 		})
 
 		t.Run("supports returning multiple PlanStautsWithID", func(t *testing.T) {
-			planIDA, err := uuid.NewUUID()
-			test.That(t, err, test.ShouldBeNil)
+			planIDA := uuid.New()
 
-			executionIDA, err := uuid.NewUUID()
+			executionIDA := uuid.New()
 			test.That(t, err, test.ShouldBeNil)
 
 			statusA := motion.PlanStatus{State: motion.PlanStateInProgress, Timestamp: time.Now().UTC(), Reason: nil}
 
-			planIDB, err := uuid.NewUUID()
-			test.That(t, err, test.ShouldBeNil)
+			planIDB := uuid.New()
 
-			executionIDB, err := uuid.NewUUID()
-			test.That(t, err, test.ShouldBeNil)
+			executionIDB := uuid.New()
 
 			reason := "failed reason"
 			statusB := motion.PlanStatus{State: motion.PlanStateInProgress, Timestamp: time.Now().UTC(), Reason: &reason}
@@ -458,10 +453,8 @@ func TestClient(t *testing.T) {
 				{base.Named("mybase"): zeroPose},
 			}
 			reason := "some reason"
-			id, err := uuid.NewUUID()
-			test.That(t, err, test.ShouldBeNil)
-			executionID, err := uuid.NewUUID()
-			test.That(t, err, test.ShouldBeNil)
+			id := uuid.New()
+			executionID := uuid.New()
 
 			timeA := time.Now().UTC()
 			timeB := time.Now().UTC()
@@ -491,10 +484,10 @@ func TestClient(t *testing.T) {
 			steps := []motion.PlanStep{{base.Named("mybase"): zeroPose}}
 			reason := "some reason"
 
-			idA, err := uuid.NewUUID()
+			idA := uuid.New()
 			test.That(t, err, test.ShouldBeNil)
 
-			executionID, err := uuid.NewUUID()
+			executionID := uuid.New()
 			test.That(t, err, test.ShouldBeNil)
 
 			timeAA := time.Now().UTC()
@@ -511,7 +504,7 @@ func TestClient(t *testing.T) {
 				{motion.PlanStateInProgress, timeAA, nil},
 			}
 
-			idB, err := uuid.NewUUID()
+			idB := uuid.New()
 			test.That(t, err, test.ShouldBeNil)
 			timeBA := time.Now().UTC()
 			planB := motion.Plan{

--- a/services/motion/motion.go
+++ b/services/motion/motion.go
@@ -34,7 +34,7 @@ func init() {
 type PlanHistoryReq struct {
 	ComponentName resource.Name
 	LastPlanOnly  bool
-	ExecutionID   uuid.UUID
+	ExecutionID   ExecutionID
 	Extra         map[string]interface{}
 }
 
@@ -76,9 +76,9 @@ type PlanStep map[resource.Name]spatialmath.Pose
 // Has a unique ID, ComponentName, ExecutionID and a sequence of Steps
 // which can be executed to follow the plan.
 type Plan struct {
-	ID            uuid.UUID
+	ID            PlanID
 	ComponentName resource.Name
-	ExecutionID   uuid.UUID
+	ExecutionID   ExecutionID
 	Steps         []PlanStep
 }
 
@@ -102,13 +102,27 @@ const (
 	PlanStateFailed
 )
 
+// TerminalStateSet is a set that defines the PlanState values which are terminal
+// i.e. which represent the end of a plan.
+var TerminalStateSet = map[PlanState]struct{}{
+	PlanStateStopped:   {},
+	PlanStateSucceeded: {},
+	PlanStateFailed:    {},
+}
+
+// PlanID uniquely identifies a Plan.
+type PlanID = uuid.UUID
+
+// ExecutionID uniquely identifies an execution.
+type ExecutionID = uuid.UUID
+
 // PlanStatusWithID describes the state of a given plan at a
 // point in time plus the PlanId, ComponentName and ExecutionID
 // the status is associated with.
 type PlanStatusWithID struct {
-	PlanID        uuid.UUID
+	PlanID        PlanID
 	ComponentName resource.Name
-	ExecutionID   uuid.UUID
+	ExecutionID   ExecutionID
 	Status        PlanStatus
 }
 

--- a/services/motion/motion_test.go
+++ b/services/motion/motion_test.go
@@ -25,11 +25,8 @@ import (
 )
 
 func TestPlanWithStatus(t *testing.T) {
-	planID, err := uuid.NewUUID()
-	test.That(t, err, test.ShouldBeNil)
-
-	executionID, err := uuid.NewUUID()
-	test.That(t, err, test.ShouldBeNil)
+	planID := uuid.New()
+	executionID := uuid.New()
 
 	baseName := base.Named("my-base1")
 	poseA := spatialmath.NewZeroPose()
@@ -331,8 +328,7 @@ func TestPlanStatusWithID(t *testing.T) {
 			err         error
 		}
 
-		id, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
+		id := uuid.New()
 
 		mybase := base.Named("mybase")
 		timestamp := time.Now().UTC()
@@ -421,8 +417,7 @@ func TestPlanStatusWithID(t *testing.T) {
 			result      *pb.PlanStatusWithID
 		}
 
-		id, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
+		id := uuid.New()
 
 		mybase := base.Named("mybase")
 		timestamp := time.Now().UTC()
@@ -602,11 +597,8 @@ func TestPlan(t *testing.T) {
 			err         error
 		}
 
-		planID, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
-
-		executionID, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
+		planID := uuid.New()
+		executionID := uuid.New()
 
 		baseName := base.Named("my-base1")
 		poseA := spatialmath.NewZeroPose()
@@ -711,11 +703,8 @@ func TestPlan(t *testing.T) {
 			result      *pb.Plan
 		}
 
-		planID, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
-
-		executionID, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
+		planID := uuid.New()
+		executionID := uuid.New()
 
 		baseName := base.Named("my-base1")
 		poseA := spatialmath.NewZeroPose()
@@ -901,7 +890,6 @@ func TestConfiguration(t *testing.T) {
 			input       *pb.MotionConfiguration
 			result      *MotionConfiguration
 		}
-
 		linearMPerSec := 1.
 		angularDegsPerSec := 2.
 		planDeviationMM := 3000.
@@ -1376,8 +1364,7 @@ func TestPlanHistoryReq(t *testing.T) {
 			err         error
 		}
 
-		executionID, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
+		executionID := uuid.New()
 		mybase := base.Named("mybase")
 		executionIDStr := executionID.String()
 
@@ -1432,8 +1419,7 @@ func TestPlanHistoryReq(t *testing.T) {
 			err         error
 		}
 
-		executionID, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
+		executionID := uuid.New()
 		mybase := base.Named("mybase")
 		executionIDStr := executionID.String()
 

--- a/services/motion/server_test.go
+++ b/services/motion/server_test.go
@@ -421,20 +421,11 @@ func TestServerListPlanStatuses(t *testing.T) {
 	})
 
 	t.Run("otherwise returns a success response", func(t *testing.T) {
-		executionID, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
-
-		planID1, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
-
-		planID2, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
-
-		planID3, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
-
-		planID4, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
+		executionID := uuid.New()
+		planID1 := uuid.New()
+		planID2 := uuid.New()
+		planID3 := uuid.New()
+		planID4 := uuid.New()
 
 		expectedComponentName := base.Named("test-base")
 		failedReason := "some reason for failure"
@@ -500,8 +491,7 @@ func TestServerGetPlan(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	expectedComponentName := base.Named("test-base")
-	uuidID, err := uuid.NewUUID()
-	test.That(t, err, test.ShouldBeNil)
+	uuidID := uuid.New()
 	id := uuidID.String()
 
 	validGetPlanRequest := &pb.GetPlanRequest{
@@ -539,14 +529,9 @@ func TestServerGetPlan(t *testing.T) {
 	})
 
 	t.Run("otherwise returns a success response", func(t *testing.T) {
-		executionID, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
-
-		planID1, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
-
-		planID2, err := uuid.NewUUID()
-		test.That(t, err, test.ShouldBeNil)
+		executionID := uuid.New()
+		planID1 := uuid.New()
+		planID2 := uuid.New()
 
 		base1 := base.Named("base1")
 		steps := []motion.PlanStep{{base1: spatialmath.NewZeroPose()}}


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-4810) [Other Ticket](https://viam.atlassian.net/browse/RSDK-5158)

This is a sub PR that implements some self contained changes required for the main PR: https://github.com/viamrobotics/rdk/pull/3204

The builtin changes are needed to ensure that motion doesn't break when it reconfigures & that it doesn't leak resources when closed.

The motion.go changes are to provide more descriptive types for users of the API & make the plan state machine more explicit.

The change from uuid.NewUUID -> uuid.New is to remove unnecessary error handling that caused a lot of unnecessary noise in the code.

Changes:

- Rename motion.builtin.lock to motion.builtin.mu (to follow go convention)
- Add state member to motion.builtIn struct 
- Implement Close() for motion builtin which will call Stop() on state if it is not nil
- Change all motion interface methods to take read locks on mu & Close() & reconfigure to take write locks on mu to prevent GRPC methods breaking unpredictably during reconfigure
- Change all tests that construct a motion builtin service to defer `Close()` 
- Change testes to call uuid.New rather than uuid.NewUUID
- Add skeleton of motion.builtin.state package
- Add type aliases for motion.ExecutionID and motion.PlanID
- Add motion.TerminalStateSet to represent the plan states that are terminal (i.e. after which the plan will no longer update)