### PR TITLE
[RSDK-5251] Get the analog readers on all boards to configure their SPI buses themselves

### DIFF
--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -270,10 +270,8 @@ func (b *Board) reconfigureAnalogReaders(ctx context.Context, newConf *LinuxBoar
 			return errors.Errorf("bad analog pin (%s)", c.Pin)
 		}
 
-		bus, ok := b.spis[c.SPIBus]
-		if !ok {
-			return errors.Errorf("can't find SPI bus (%s) requested by AnalogReader", c.SPIBus)
-		}
+		bus := &spiBus{}
+		bus.reset(c.SPIBus)
 
 		stillExists[c.Name] = struct{}{}
 		if curr, ok := b.analogReaders[c.Name]; ok {

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -19,6 +19,7 @@ import (
 	goutils "go.viam.com/utils"
 
 	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/mcp3008helper"
 	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -276,7 +277,7 @@ func (b *Board) reconfigureAnalogReaders(ctx context.Context, newConf *LinuxBoar
 		stillExists[c.Name] = struct{}{}
 		if curr, ok := b.analogReaders[c.Name]; ok {
 			if curr.chipSelect != c.ChipSelect {
-				ar := &board.MCP3008AnalogReader{channel, bus, c.ChipSelect}
+				ar := &mcp3008helper.MCP3008AnalogReader{channel, bus, c.ChipSelect}
 				curr.reset(ctx, curr.chipSelect,
 					board.SmoothAnalogReader(ar, board.AnalogReaderConfig{
 						AverageOverMillis: c.AverageOverMillis, SamplesPerSecond: c.SamplesPerSecond,
@@ -284,7 +285,7 @@ func (b *Board) reconfigureAnalogReaders(ctx context.Context, newConf *LinuxBoar
 			}
 			continue
 		}
-		ar := &board.MCP3008AnalogReader{channel, bus, c.ChipSelect}
+		ar := &mcp3008helper.MCP3008AnalogReader{channel, bus, c.ChipSelect}
 		b.analogReaders[c.Name] = newWrappedAnalogReader(ctx, c.ChipSelect,
 			board.SmoothAnalogReader(ar, board.AnalogReaderConfig{
 				AverageOverMillis: c.AverageOverMillis, SamplesPerSecond: c.SamplesPerSecond,

--- a/components/board/genericlinux/board_test.go
+++ b/components/board/genericlinux/board_test.go
@@ -13,6 +13,7 @@ import (
 	"go.viam.com/test"
 
 	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/mcp3008helper"
 	"go.viam.com/rdk/logging"
 )
 
@@ -122,13 +123,13 @@ func TestGenericLinux(t *testing.T) {
 func TestConfigValidate(t *testing.T) {
 	validConfig := Config{}
 
-	validConfig.AnalogReaders = []board.MCP3008AnalogConfig{{}}
+	validConfig.AnalogReaders = []mcp3008helper.MCP3008AnalogConfig{{}}
 	_, err := validConfig.Validate("path")
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, `path.analogs.0`)
 	test.That(t, err.Error(), test.ShouldContainSubstring, `"name" is required`)
 
-	validConfig.AnalogReaders = []board.MCP3008AnalogConfig{{Name: "bar"}}
+	validConfig.AnalogReaders = []mcp3008helper.MCP3008AnalogConfig{{Name: "bar"}}
 	_, err = validConfig.Validate("path")
 	test.That(t, err, test.ShouldBeNil)
 

--- a/components/board/genericlinux/config.go
+++ b/components/board/genericlinux/config.go
@@ -4,17 +4,18 @@ import (
 	"fmt"
 
 	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/mcp3008helper"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/utils"
 )
 
 // A Config describes the configuration of a board and all of its connected parts.
 type Config struct {
-	I2Cs              []board.I2CConfig              `json:"i2cs,omitempty"`
-	SPIs              []board.SPIConfig              `json:"spis,omitempty"`
-	AnalogReaders     []board.MCP3008AnalogConfig    `json:"analogs,omitempty"`
-	DigitalInterrupts []board.DigitalInterruptConfig `json:"digital_interrupts,omitempty"`
-	Attributes        utils.AttributeMap             `json:"attributes,omitempty"`
+	I2Cs              []board.I2CConfig                   `json:"i2cs,omitempty"`
+	SPIs              []board.SPIConfig                   `json:"spis,omitempty"`
+	AnalogReaders     []mcp3008helper.MCP3008AnalogConfig `json:"analogs,omitempty"`
+	DigitalInterrupts []board.DigitalInterruptConfig      `json:"digital_interrupts,omitempty"`
+	Attributes        utils.AttributeMap                  `json:"attributes,omitempty"`
 }
 
 // Validate ensures all parts of the config are valid.
@@ -52,7 +53,7 @@ func (conf *Config) Validate(path string) ([]string, error) {
 type LinuxBoardConfig struct {
 	I2Cs              []board.I2CConfig
 	SPIs              []board.SPIConfig
-	AnalogReaders     []board.MCP3008AnalogConfig
+	AnalogReaders     []mcp3008helper.MCP3008AnalogConfig
 	DigitalInterrupts []board.DigitalInterruptConfig
 	GpioMappings      map[string]GPIOBoardMapping
 }

--- a/components/board/mcp3008helper/mcp3008.go
+++ b/components/board/mcp3008helper/mcp3008.go
@@ -7,12 +7,14 @@ import (
 
 	"go.uber.org/multierr"
 	"go.viam.com/utils"
+
+	"go.viam.com/rdk/components/board"
 )
 
 // MCP3008AnalogReader implements a board.AnalogReader using an MCP3008 ADC via SPI.
 type MCP3008AnalogReader struct {
 	Channel int
-	Bus     SPI
+	Bus     board.SPI
 	Chip    string
 }
 

--- a/components/board/mcp3008helper/mcp3008.go
+++ b/components/board/mcp3008helper/mcp3008.go
@@ -1,4 +1,6 @@
-package board
+// Package mcp3008helper is shared code for hooking an MCP3008 ADC up to a board. It is used in
+// both the pi and genericlinux board implementations, but does not implement a board directly.
+package mcp3008helper
 
 import (
 	"context"

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -35,6 +35,7 @@ import (
 	pb "go.viam.com/api/component/board/v1"
 
 	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/mcp3008helper"
 	picommon "go.viam.com/rdk/components/board/pi/common"
 	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
@@ -61,11 +62,11 @@ func init() {
 
 // A Config describes the configuration of a board and all of its connected parts.
 type Config struct {
-	I2Cs              []board.I2CConfig              `json:"i2cs,omitempty"`
-	SPIs              []board.SPIConfig              `json:"spis,omitempty"`
-	AnalogReaders     []board.MCP3008AnalogConfig    `json:"analogs,omitempty"`
-	DigitalInterrupts []board.DigitalInterruptConfig `json:"digital_interrupts,omitempty"`
-	Attributes        rdkutils.AttributeMap          `json:"attributes,omitempty"`
+	I2Cs              []board.I2CConfig                   `json:"i2cs,omitempty"`
+	SPIs              []board.SPIConfig                   `json:"spis,omitempty"`
+	AnalogReaders     []mcp3008helper.MCP3008AnalogConfig `json:"analogs,omitempty"`
+	DigitalInterrupts []board.DigitalInterruptConfig      `json:"digital_interrupts,omitempty"`
+	Attributes        rdkutils.AttributeMap               `json:"attributes,omitempty"`
 }
 
 // Validate ensures all parts of the config are valid.
@@ -258,7 +259,7 @@ func (pi *piPigpio) reconfigureAnalogReaders(ctx context.Context, cfg *Config) e
 		}
 
 		bus := &piPigpioSPI{pi: pi, busSelect: ac.SPIBus}
-		ar := &board.MCP3008AnalogReader{channel, bus, ac.ChipSelect}
+		ar := &mcp3008helper.MCP3008AnalogReader{channel, bus, ac.ChipSelect}
 
 		pi.analogReaders[ac.Name] = board.SmoothAnalogReader(ar, board.AnalogReaderConfig{
 			AverageOverMillis: ac.AverageOverMillis, SamplesPerSecond: ac.SamplesPerSecond,

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -257,11 +257,7 @@ func (pi *piPigpio) reconfigureAnalogReaders(ctx context.Context, cfg *Config) e
 			return errors.Errorf("bad analog pin (%s)", ac.Pin)
 		}
 
-		bus, have := pi.spis[ac.SPIBus]
-		if !have {
-			return errors.Errorf("can't find SPI bus (%s) requested by AnalogReader", ac.SPIBus)
-		}
-
+		bus := &piPigpioSPI{pi: pi, busSelect: ac.SPIBus}
 		ar := &board.MCP3008AnalogReader{channel, bus, ac.ChipSelect}
 
 		pi.analogReaders[ac.Name] = board.SmoothAnalogReader(ar, board.AnalogReaderConfig{


### PR DESCRIPTION
Tried on both a raspberry pi and a jetson orin: works on both!

Here's an example of the old config for a board:
```
{
    "model": "pi",
    "name": "main_board",
    "namespace": "rdk",
    "type": "board",
    "attributes": {
        "spis": [
            {
            "bus_select": "0",
            "name": "main_spi_bus"
            }
        ],
        "analogs": [
            {
            "name": "reader",
            "pin": "0",
            "spi_bus": "main_spi_bus",
            "chip_select": "24",
            "average_over_ms": 100,
            "samples_per_sec": 20
            }
        ]
    }
}
```
and here's an example of the new version:
```
{
    "model": "pi",
    "name": "main_board",
    "namespace": "rdk",
    "type": "board",
    "attributes": {
        "spis": [],
        "analogs": [
            {
            "name": "reader",
            "pin": "0",
            "spi_bus": "0",
            "chip_select": "24",
            "average_over_ms": 100,
            "samples_per_sec": 20
            }
        ]
    }
}
```
This shouldn't be merged until we've got a way to migrate the configs for all the boards out there; that's the hard part of this change.