### PR TITLE
RSDK-5365 Do not apply defaultResourcesTimeout in tests

### DIFF
--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -618,6 +618,9 @@ func (rc *RobotClient) resources(ctx context.Context) ([]resource.Name, []resour
 	// pauses for longer than 5s, below calls to ResourceNames or
 	// ResourceRPCSubtypes can result in context errors that appear in client.New
 	// and remote logic.
+	//
+	// TODO(APP-2917): Once we upgrade to go 1.21, replace this if check with if
+	// !testing.Testing().
 	if flag.Lookup("test.v") == nil {
 		var cancel func()
 		ctx, cancel = contextutils.ContextWithTimeoutIfNoDeadline(ctx, defaultResourcesTimeout)

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -3,6 +3,7 @@ package client
 
 import (
 	"context"
+	"flag"
 	"io"
 	"strings"
 	"sync"
@@ -612,8 +613,16 @@ func (rc *RobotClient) createClient(name resource.Name) (resource.Resource, erro
 }
 
 func (rc *RobotClient) resources(ctx context.Context) ([]resource.Name, []resource.RPCAPI, error) {
-	ctx, cancel := contextutils.ContextWithTimeoutIfNoDeadline(ctx, defaultResourcesTimeout)
-	defer cancel()
+	// RSDK-5356 If we are in a testing environment, never apply
+	// defaultResourcesTimeout. Tests run in parallel, and if execution of a test
+	// pauses for longer than 5s, below calls to ResourceNames or
+	// ResourceRPCSubtypes can result in context errors that appear in client.New
+	// and remote logic.
+	if flag.Lookup("test.v") == nil {
+		var cancel func()
+		ctx, cancel = contextutils.ContextWithTimeoutIfNoDeadline(ctx, defaultResourcesTimeout)
+		defer cancel()
+	}
 	resp, err := rc.client.ResourceNames(ctx, &pb.ResourceNamesRequest{})
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
RSDK-5365

Only applies `defaultResourcesTimeout` when not in a test.

My guess is this is also related to the following failures: RSDK-5365, RSDK-4969, RSDK-3837 and RSDK-5595. Curious if you all agree (I'm looking for an inability to connect to a remote after a 5 second gap in logs, and an assertion failure related to not finding expected remote resources).