### PR TITLE
[RSDK-5621] Remove unused I2C- and SPI-related functions

### DIFF
--- a/components/board/board.go
+++ b/components/board/board.go
@@ -91,9 +91,6 @@ type Board interface {
 type LocalBoard interface {
 	Board
 
-	// SPIByName returns an SPI bus by name.
-	SPIByName(name string) (SPI, bool)
-
 	// I2CByName returns an I2C bus by name.
 	I2CByName(name string) (I2C, bool)
 }

--- a/components/board/board.go
+++ b/components/board/board.go
@@ -61,9 +61,6 @@ type Board interface {
 	// GPIOPinByName returns a GPIOPin by name.
 	GPIOPinByName(name string) (GPIOPin, error)
 
-	// SPINames returns the names of all known SPI buses.
-	SPINames() []string
-
 	// AnalogReaderNames returns the names of all known analog readers.
 	AnalogReaderNames() []string
 

--- a/components/board/board.go
+++ b/components/board/board.go
@@ -67,9 +67,6 @@ type Board interface {
 	// DigitalInterruptNames returns the names of all known digital interrupts.
 	DigitalInterruptNames() []string
 
-	// GPIOPinNames returns the names of all known GPIO pins.
-	GPIOPinNames() []string
-
 	// Status returns the current status of the board. Usually you
 	// should use the CreateStatus helper instead of directly calling
 	// this.

--- a/components/board/board.go
+++ b/components/board/board.go
@@ -87,9 +87,6 @@ type Board interface {
 // A LocalBoard represents a Board where you can request SPIs and I2Cs by name.
 type LocalBoard interface {
 	Board
-
-	// I2CByName returns an I2C bus by name.
-	I2CByName(name string) (I2C, bool)
 }
 
 // ModelAttributes provide info related to a board model.

--- a/components/board/board.go
+++ b/components/board/board.go
@@ -84,11 +84,6 @@ type Board interface {
 	WriteAnalog(ctx context.Context, pin string, value int32, extra map[string]interface{}) error
 }
 
-// A LocalBoard represents a Board where you can request SPIs and I2Cs by name.
-type LocalBoard interface {
-	Board
-}
-
 // ModelAttributes provide info related to a board model.
 type ModelAttributes struct {
 	// Remote signifies this board is accessed over a remote connection.

--- a/components/board/board.go
+++ b/components/board/board.go
@@ -64,9 +64,6 @@ type Board interface {
 	// SPINames returns the names of all known SPI buses.
 	SPINames() []string
 
-	// I2CNames returns the names of all known I2C buses.
-	I2CNames() []string
-
 	// AnalogReaderNames returns the names of all known analog readers.
 	AnalogReaderNames() []string
 

--- a/components/board/client.go
+++ b/components/board/client.go
@@ -40,7 +40,6 @@ type boardInfo struct {
 	name                  string
 	analogReaderNames     []string
 	digitalInterruptNames []string
-	gpioPinNames          []string
 }
 
 // NewClientFromConn constructs a new Client from connection passed in.
@@ -103,14 +102,6 @@ func (c *client) DigitalInterruptNames() []string {
 		return []string{}
 	}
 	return copyStringSlice(c.info.digitalInterruptNames)
-}
-
-func (c *client) GPIOPinNames() []string {
-	if c.getCachedStatus() == nil {
-		c.logger.Debugw("no cached status")
-		return []string{}
-	}
-	return copyStringSlice(c.info.gpioPinNames)
 }
 
 // Status uses the cached status or a newly fetched board status to return the state

--- a/components/board/client.go
+++ b/components/board/client.go
@@ -38,7 +38,6 @@ type client struct {
 
 type boardInfo struct {
 	name                  string
-	spiNames              []string
 	analogReaderNames     []string
 	digitalInterruptNames []string
 	gpioPinNames          []string
@@ -88,14 +87,6 @@ func (c *client) GPIOPinByName(name string) (GPIOPin, error) {
 		boardName: c.info.name,
 		pinName:   name,
 	}, nil
-}
-
-func (c *client) SPINames() []string {
-	if c.getCachedStatus() == nil {
-		c.logger.Debugw("no cached status")
-		return []string{}
-	}
-	return copyStringSlice(c.info.spiNames)
 }
 
 func (c *client) AnalogReaderNames() []string {

--- a/components/board/client.go
+++ b/components/board/client.go
@@ -39,7 +39,6 @@ type client struct {
 type boardInfo struct {
 	name                  string
 	spiNames              []string
-	i2cNames              []string
 	analogReaderNames     []string
 	digitalInterruptNames []string
 	gpioPinNames          []string
@@ -97,14 +96,6 @@ func (c *client) SPINames() []string {
 		return []string{}
 	}
 	return copyStringSlice(c.info.spiNames)
-}
-
-func (c *client) I2CNames() []string {
-	if c.getCachedStatus() == nil {
-		c.logger.Debugw("no cached status")
-		return []string{}
-	}
-	return copyStringSlice(c.info.i2cNames)
 }
 
 func (c *client) AnalogReaderNames() []string {

--- a/components/board/client_test.go
+++ b/components/board/client_test.go
@@ -253,9 +253,6 @@ func TestClientWithStatus(t *testing.T) {
 	respSPIs := client.SPINames()
 	test.That(t, respSPIs, test.ShouldResemble, []string{})
 
-	respI2Cs := client.I2CNames()
-	test.That(t, respI2Cs, test.ShouldResemble, []string{})
-
 	err = client.Close(context.Background())
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, conn.Close(), test.ShouldBeNil)
@@ -291,7 +288,6 @@ func TestClientWithoutStatus(t *testing.T) {
 	test.That(t, rClient.AnalogReaderNames(), test.ShouldResemble, []string{})
 	test.That(t, rClient.DigitalInterruptNames(), test.ShouldResemble, []string{})
 	test.That(t, rClient.SPINames(), test.ShouldResemble, []string{})
-	test.That(t, rClient.I2CNames(), test.ShouldResemble, []string{})
 
 	err = rClient.Close(context.Background())
 	test.That(t, err, test.ShouldBeNil)

--- a/components/board/client_test.go
+++ b/components/board/client_test.go
@@ -250,9 +250,6 @@ func TestClientWithStatus(t *testing.T) {
 	respDigitalInterrupts := client.DigitalInterruptNames()
 	test.That(t, respDigitalInterrupts, test.ShouldResemble, []string{"digital1"})
 
-	respSPIs := client.SPINames()
-	test.That(t, respSPIs, test.ShouldResemble, []string{})
-
 	err = client.Close(context.Background())
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, conn.Close(), test.ShouldBeNil)
@@ -287,7 +284,6 @@ func TestClientWithoutStatus(t *testing.T) {
 
 	test.That(t, rClient.AnalogReaderNames(), test.ShouldResemble, []string{})
 	test.That(t, rClient.DigitalInterruptNames(), test.ShouldResemble, []string{})
-	test.That(t, rClient.SPINames(), test.ShouldResemble, []string{})
 
 	err = rClient.Close(context.Background())
 	test.That(t, err, test.ShouldBeNil)

--- a/components/board/fake/board.go
+++ b/components/board/fake/board.go
@@ -254,17 +254,6 @@ func (b *Board) GPIOPinByName(name string) (board.GPIOPin, error) {
 	return p, nil
 }
 
-// SPINames returns the names of all known SPIs.
-func (b *Board) SPINames() []string {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
-	names := []string{}
-	for k := range b.SPIs {
-		names = append(names, k)
-	}
-	return names
-}
-
 // AnalogReaderNames returns the names of all known analog readers.
 func (b *Board) AnalogReaderNames() []string {
 	b.mu.RLock()

--- a/components/board/fake/board.go
+++ b/components/board/fake/board.go
@@ -268,17 +268,6 @@ func (b *Board) DigitalInterruptNames() []string {
 	return names
 }
 
-// GPIOPinNames returns the names of all known GPIO pins.
-func (b *Board) GPIOPinNames() []string {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
-	names := []string{}
-	for k := range b.GPIOPins {
-		names = append(names, k)
-	}
-	return names
-}
-
 // Status returns the current status of the board.
 func (b *Board) Status(ctx context.Context, extra map[string]interface{}) (*commonpb.BoardStatus, error) {
 	return board.CreateStatus(ctx, b, extra)

--- a/components/board/fake/board.go
+++ b/components/board/fake/board.go
@@ -265,17 +265,6 @@ func (b *Board) SPINames() []string {
 	return names
 }
 
-// I2CNames returns the names of all known I2Cs.
-func (b *Board) I2CNames() []string {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
-	names := []string{}
-	for k := range b.I2Cs {
-		names = append(names, k)
-	}
-	return names
-}
-
 // AnalogReaderNames returns the names of all known analog readers.
 func (b *Board) AnalogReaderNames() []string {
 	b.mu.RLock()

--- a/components/board/fake/board.go
+++ b/components/board/fake/board.go
@@ -209,14 +209,6 @@ type Board struct {
 	CloseCount    int
 }
 
-// I2CByName returns the i2c by the given name if it exists.
-func (b *Board) I2CByName(name string) (board.I2C, bool) {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
-	s, ok := b.I2Cs[name]
-	return s, ok
-}
-
 // AnalogReaderByName returns the analog reader by the given name if it exists.
 func (b *Board) AnalogReaderByName(name string) (board.AnalogReader, bool) {
 	b.mu.RLock()

--- a/components/board/fake/board.go
+++ b/components/board/fake/board.go
@@ -209,14 +209,6 @@ type Board struct {
 	CloseCount    int
 }
 
-// SPIByName returns the SPI by the given name if it exists.
-func (b *Board) SPIByName(name string) (board.SPI, bool) {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
-	s, ok := b.SPIs[name]
-	return s, ok
-}
-
 // I2CByName returns the i2c by the given name if it exists.
 func (b *Board) I2CByName(name string) (board.I2C, bool) {
 	b.mu.RLock()

--- a/components/board/fake/board_test.go
+++ b/components/board/fake/board_test.go
@@ -35,7 +35,7 @@ func TestFakeBoard(t *testing.T) {
 	b, err := NewBoard(context.Background(), cfg, logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	_, ok = b.AnalogReaderByName("blue")
+	_, ok := b.AnalogReaderByName("blue")
 	test.That(t, ok, test.ShouldBeTrue)
 
 	_, ok = b.DigitalInterruptByName("i1")

--- a/components/board/fake/board_test.go
+++ b/components/board/fake/board_test.go
@@ -38,9 +38,6 @@ func TestFakeBoard(t *testing.T) {
 	_, ok := b.I2CByName("main")
 	test.That(t, ok, test.ShouldBeTrue)
 
-	_, ok = b.SPIByName("aux")
-	test.That(t, ok, test.ShouldBeTrue)
-
 	_, ok = b.AnalogReaderByName("blue")
 	test.That(t, ok, test.ShouldBeTrue)
 

--- a/components/board/fake/board_test.go
+++ b/components/board/fake/board_test.go
@@ -35,9 +35,6 @@ func TestFakeBoard(t *testing.T) {
 	b, err := NewBoard(context.Background(), cfg, logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	_, ok := b.I2CByName("main")
-	test.That(t, ok, test.ShouldBeTrue)
-
 	_, ok = b.AnalogReaderByName("blue")
 	test.That(t, ok, test.ShouldBeTrue)
 

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -462,12 +462,6 @@ type Board struct {
 	activeBackgroundWorkers sync.WaitGroup
 }
 
-// I2CByName returns the i2c by the given name if it exists.
-func (b *Board) I2CByName(name string) (board.I2C, bool) {
-	i, ok := b.i2cs[name]
-	return i, ok
-}
-
 // AnalogReaderByName returns the analog reader by the given name if it exists.
 func (b *Board) AnalogReaderByName(name string) (board.AnalogReader, bool) {
 	a, ok := b.analogReaders[name]

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -531,18 +531,6 @@ func (b *Board) SPINames() []string {
 	return names
 }
 
-// I2CNames returns the names of all known I2Cs.
-func (b *Board) I2CNames() []string {
-	if len(b.i2cs) == 0 {
-		return nil
-	}
-	names := make([]string, 0, len(b.i2cs))
-	for k := range b.i2cs {
-		names = append(names, k)
-	}
-	return names
-}
-
 // AnalogReaderNames returns the names of all known analog readers.
 func (b *Board) AnalogReaderNames() []string {
 	names := []string{}

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -519,18 +519,6 @@ func (b *Board) DigitalInterruptByName(name string) (board.DigitalInterrupt, boo
 	return interrupt.interrupt, true
 }
 
-// SPINames returns the names of all known SPIs.
-func (b *Board) SPINames() []string {
-	if len(b.spis) == 0 {
-		return nil
-	}
-	names := make([]string, 0, len(b.spis))
-	for k := range b.spis {
-		names = append(names, k)
-	}
-	return names
-}
-
 // AnalogReaderNames returns the names of all known analog readers.
 func (b *Board) AnalogReaderNames() []string {
 	names := []string{}

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -535,18 +535,6 @@ func (b *Board) DigitalInterruptNames() []string {
 	return names
 }
 
-// GPIOPinNames returns the names of all known GPIO pins.
-func (b *Board) GPIOPinNames() []string {
-	if b.gpioMappings == nil {
-		return nil
-	}
-	names := []string{}
-	for k := range b.gpioMappings {
-		names = append(names, k)
-	}
-	return names
-}
-
 // GPIOPinByName returns a GPIOPin by name.
 func (b *Board) GPIOPinByName(pinName string) (board.GPIOPin, error) {
 	if pin, ok := b.gpios[pinName]; ok {

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -462,12 +462,6 @@ type Board struct {
 	activeBackgroundWorkers sync.WaitGroup
 }
 
-// SPIByName returns the SPI by the given name if it exists.
-func (b *Board) SPIByName(name string) (board.SPI, bool) {
-	s, ok := b.spis[name]
-	return s, ok
-}
-
 // I2CByName returns the i2c by the given name if it exists.
 func (b *Board) I2CByName(name string) (board.I2C, bool) {
 	i, ok := b.i2cs[name]

--- a/components/board/genericlinux/board_test.go
+++ b/components/board/genericlinux/board_test.go
@@ -26,7 +26,6 @@ func TestGenericLinux(t *testing.T) {
 
 	t.Run("test empty sysfs board", func(t *testing.T) {
 		test.That(t, b.GPIOPinNames(), test.ShouldBeNil)
-		test.That(t, b.SPINames(), test.ShouldBeNil)
 		_, err := b.GPIOPinByName("10")
 		test.That(t, err, test.ShouldNotBeNil)
 	})
@@ -68,9 +67,6 @@ func TestGenericLinux(t *testing.T) {
 		an2, ok := b.AnalogReaderByName("missing")
 		test.That(t, an2, test.ShouldBeNil)
 		test.That(t, ok, test.ShouldBeFalse)
-
-		sns := b.SPINames()
-		test.That(t, len(sns), test.ShouldEqual, 2)
 
 		sn1, ok := b.SPIByName("closed")
 		test.That(t, sn1, test.ShouldHaveSameTypeAs, &spiBus{})

--- a/components/board/genericlinux/board_test.go
+++ b/components/board/genericlinux/board_test.go
@@ -80,9 +80,6 @@ func TestGenericLinux(t *testing.T) {
 		test.That(t, sn2, test.ShouldBeNil)
 		test.That(t, ok, test.ShouldBeFalse)
 
-		ins := b.I2CNames()
-		test.That(t, ins, test.ShouldBeNil)
-
 		in1, ok := b.I2CByName("in")
 		test.That(t, in1, test.ShouldBeNil)
 		test.That(t, ok, test.ShouldBeFalse)

--- a/components/board/genericlinux/board_test.go
+++ b/components/board/genericlinux/board_test.go
@@ -25,7 +25,6 @@ func TestGenericLinux(t *testing.T) {
 	}
 
 	t.Run("test empty sysfs board", func(t *testing.T) {
-		test.That(t, b.GPIOPinNames(), test.ShouldBeNil)
 		_, err := b.GPIOPinByName("10")
 		test.That(t, err, test.ShouldNotBeNil)
 	})
@@ -78,9 +77,6 @@ func TestGenericLinux(t *testing.T) {
 		dn1, ok := b.DigitalInterruptByName("dn")
 		test.That(t, dn1, test.ShouldBeNil)
 		test.That(t, ok, test.ShouldBeFalse)
-
-		gns := b.GPIOPinNames()
-		test.That(t, gns, test.ShouldResemble, []string(nil))
 
 		gn1, err := b.GPIOPinByName("10")
 		test.That(t, err, test.ShouldNotBeNil)

--- a/components/board/genericlinux/board_test.go
+++ b/components/board/genericlinux/board_test.go
@@ -68,14 +68,6 @@ func TestGenericLinux(t *testing.T) {
 		test.That(t, an2, test.ShouldBeNil)
 		test.That(t, ok, test.ShouldBeFalse)
 
-		sn1, ok := b.SPIByName("closed")
-		test.That(t, sn1, test.ShouldHaveSameTypeAs, &spiBus{})
-		test.That(t, ok, test.ShouldBeTrue)
-
-		sn2, ok := b.SPIByName("missing")
-		test.That(t, sn2, test.ShouldBeNil)
-		test.That(t, ok, test.ShouldBeFalse)
-
 		in1, ok := b.I2CByName("in")
 		test.That(t, in1, test.ShouldBeNil)
 		test.That(t, ok, test.ShouldBeFalse)

--- a/components/board/genericlinux/board_test.go
+++ b/components/board/genericlinux/board_test.go
@@ -67,10 +67,6 @@ func TestGenericLinux(t *testing.T) {
 		test.That(t, an2, test.ShouldBeNil)
 		test.That(t, ok, test.ShouldBeFalse)
 
-		in1, ok := b.I2CByName("in")
-		test.That(t, in1, test.ShouldBeNil)
-		test.That(t, ok, test.ShouldBeFalse)
-
 		dns := b.DigitalInterruptNames()
 		test.That(t, dns, test.ShouldBeNil)
 

--- a/components/board/hat/pca9685/pca9685.go
+++ b/components/board/hat/pca9685/pca9685.go
@@ -186,16 +186,6 @@ func (pca *PCA9685) GPIOPinByName(pin string) (board.GPIOPin, error) {
 	return &pca.gpioPins[pinInt], nil
 }
 
-// GPIOPinNames returns the names of all known GPIO pins.
-func (pca *PCA9685) GPIOPinNames() []string {
-	return []string{
-		"0", "1", "2", "3",
-		"4", "5", "6", "7",
-		"8", "9", "10", "11",
-		"12", "13", "14", "15",
-	}
-}
-
 func (pca *PCA9685) openHandle() (board.I2CHandle, error) {
 	return pca.bus.OpenHandle(pca.address)
 }

--- a/components/board/hat/pca9685/pca9685.go
+++ b/components/board/hat/pca9685/pca9685.go
@@ -271,11 +271,6 @@ func (pca *PCA9685) SPINames() []string {
 	return nil
 }
 
-// I2CNames returns the names of all known I2Cs.
-func (pca *PCA9685) I2CNames() []string {
-	return nil
-}
-
 // AnalogReaderNames returns the names of all known analog readers.
 func (pca *PCA9685) AnalogReaderNames() []string {
 	return nil

--- a/components/board/hat/pca9685/pca9685.go
+++ b/components/board/hat/pca9685/pca9685.go
@@ -276,11 +276,6 @@ func (pca *PCA9685) DigitalInterruptNames() []string {
 	return nil
 }
 
-// SPIByName returns the SPI by the given name if it exists.
-func (pca *PCA9685) SPIByName(name string) (board.SPI, bool) {
-	return nil, false
-}
-
 // I2CByName returns the i2c by the given name if it exists.
 func (pca *PCA9685) I2CByName(name string) (board.I2C, bool) {
 	return nil, false

--- a/components/board/hat/pca9685/pca9685.go
+++ b/components/board/hat/pca9685/pca9685.go
@@ -266,11 +266,6 @@ func (pca *PCA9685) DigitalInterruptNames() []string {
 	return nil
 }
 
-// I2CByName returns the i2c by the given name if it exists.
-func (pca *PCA9685) I2CByName(name string) (board.I2C, bool) {
-	return nil, false
-}
-
 // AnalogReaderByName returns the analog reader by the given name if it exists.
 func (pca *PCA9685) AnalogReaderByName(name string) (board.AnalogReader, bool) {
 	return nil, false

--- a/components/board/hat/pca9685/pca9685.go
+++ b/components/board/hat/pca9685/pca9685.go
@@ -266,11 +266,6 @@ func (pca *PCA9685) SetFrequency(ctx context.Context, frequency float64) error {
 	return nil
 }
 
-// SPINames returns the names of all known SPIs.
-func (pca *PCA9685) SPINames() []string {
-	return nil
-}
-
 // AnalogReaderNames returns the names of all known analog readers.
 func (pca *PCA9685) AnalogReaderNames() []string {
 	return nil

--- a/components/board/numato/board.go
+++ b/components/board/numato/board.go
@@ -368,7 +368,7 @@ func (ar *analogReader) Close(ctx context.Context) error {
 	return nil
 }
 
-func connect(ctx context.Context, name resource.Name, conf *Config, logger logging.Logger) (board.LocalBoard, error) {
+func connect(ctx context.Context, name resource.Name, conf *Config, logger logging.Logger) (board.Board, error) {
 	pins := conf.Pins
 	if pins <= 0 {
 		return nil, errors.New("numato board needs pins set in attributes")

--- a/components/board/numato/board.go
+++ b/components/board/numato/board.go
@@ -257,11 +257,6 @@ func (b *numatoBoard) DigitalInterruptNames() []string {
 	return nil
 }
 
-// GPIOPinNames returns the names of all known GPIO pins.
-func (b *numatoBoard) GPIOPinNames() []string {
-	return nil
-}
-
 // GPIOPinByName returns the GPIO pin by the given name.
 func (b *numatoBoard) GPIOPinByName(pin string) (board.GPIOPin, error) {
 	return &gpioPin{b, pin}, nil

--- a/components/board/numato/board.go
+++ b/components/board/numato/board.go
@@ -253,11 +253,6 @@ func (b *numatoBoard) SPINames() []string {
 	return nil
 }
 
-// I2CNames returns the names of all known I2C busses.
-func (b *numatoBoard) I2CNames() []string {
-	return nil
-}
-
 // AnalogReaderNames returns the names of all known analog readers.
 func (b *numatoBoard) AnalogReaderNames() []string {
 	names := []string{}

--- a/components/board/numato/board.go
+++ b/components/board/numato/board.go
@@ -227,11 +227,6 @@ func (b *numatoBoard) readThread() {
 	}
 }
 
-// I2CByName returns an I2C bus by name.
-func (b *numatoBoard) I2CByName(name string) (board.I2C, bool) {
-	return nil, false
-}
-
 // AnalogReaderByName returns an analog reader by name.
 func (b *numatoBoard) AnalogReaderByName(name string) (board.AnalogReader, bool) {
 	ar, ok := b.analogs[name]

--- a/components/board/numato/board.go
+++ b/components/board/numato/board.go
@@ -248,11 +248,6 @@ func (b *numatoBoard) DigitalInterruptByName(name string) (board.DigitalInterrup
 	return nil, false
 }
 
-// SPINames returns the names of all known SPI busses.
-func (b *numatoBoard) SPINames() []string {
-	return nil
-}
-
 // AnalogReaderNames returns the names of all known analog readers.
 func (b *numatoBoard) AnalogReaderNames() []string {
 	names := []string{}

--- a/components/board/numato/board.go
+++ b/components/board/numato/board.go
@@ -227,11 +227,6 @@ func (b *numatoBoard) readThread() {
 	}
 }
 
-// SPIByName returns an SPI bus by name.
-func (b *numatoBoard) SPIByName(name string) (board.SPI, bool) {
-	return nil, false
-}
-
 // I2CByName returns an I2C bus by name.
 func (b *numatoBoard) I2CByName(name string) (board.I2C, bool) {
 	return nil, false

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -153,7 +153,7 @@ func initializePigpio() error {
 }
 
 // newPigpio makes a new pigpio based Board using the given config.
-func newPigpio(ctx context.Context, name resource.Name, cfg resource.Config, logger logging.Logger) (board.LocalBoard, error) {
+func newPigpio(ctx context.Context, name resource.Name, cfg resource.Config, logger logging.Logger) (board.Board, error) {
 	// this is so we can run it inside a daemon
 	internals := C.gpioCfgGetInternals()
 	internals |= C.PI_CFG_NOSIGHANDLER

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -417,17 +417,6 @@ func (pi *piPigpio) reconfigureInterrupts(ctx context.Context, cfg *Config) erro
 	return nil
 }
 
-// GPIOPinNames returns the names of all known GPIO pins.
-func (pi *piPigpio) GPIOPinNames() []string {
-	pi.mu.Lock()
-	defer pi.mu.Unlock()
-	names := make([]string, 0, len(piHWPinToBroadcom))
-	for k := range piHWPinToBroadcom {
-		names = append(names, k)
-	}
-	return names
-}
-
 // GPIOPinByName returns a GPIOPin by name.
 func (pi *piPigpio) GPIOPinByName(pin string) (board.GPIOPin, error) {
 	pi.mu.Lock()

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -682,20 +682,6 @@ func (s *piPigpioSPIHandle) Close() error {
 	return nil
 }
 
-// SPINames returns the names of all known SPI buses.
-func (pi *piPigpio) SPINames() []string {
-	pi.mu.Lock()
-	defer pi.mu.Unlock()
-	if len(pi.spis) == 0 {
-		return nil
-	}
-	names := make([]string, 0, len(pi.spis))
-	for k := range pi.spis {
-		names = append(names, k)
-	}
-	return names
-}
-
 // AnalogReaderNames returns the names of all known analog readers.
 func (pi *piPigpio) AnalogReaderNames() []string {
 	pi.mu.Lock()

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -696,20 +696,6 @@ func (pi *piPigpio) SPINames() []string {
 	return names
 }
 
-// I2CNames returns the names of all known SPI buses.
-func (pi *piPigpio) I2CNames() []string {
-	pi.mu.Lock()
-	defer pi.mu.Unlock()
-	if len(pi.i2cs) == 0 {
-		return nil
-	}
-	names := make([]string, 0, len(pi.i2cs))
-	for k := range pi.i2cs {
-		names = append(names, k)
-	}
-	return names
-}
-
 // AnalogReaderNames returns the names of all known analog readers.
 func (pi *piPigpio) AnalogReaderNames() []string {
 	pi.mu.Lock()

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -701,14 +701,6 @@ func (pi *piPigpio) AnalogReaderByName(name string) (board.AnalogReader, bool) {
 	return a, ok
 }
 
-// I2CByName returns an I2C by name.
-func (pi *piPigpio) I2CByName(name string) (board.I2C, bool) {
-	pi.mu.Lock()
-	defer pi.mu.Unlock()
-	s, ok := pi.i2cs[name]
-	return s, ok
-}
-
 // DigitalInterruptByName returns a digital interrupt by name.
 // NOTE: During board setup, if a digital interrupt has not been created
 // for a pin, then this function will attempt to create one with the pin

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -712,14 +712,6 @@ func (pi *piPigpio) AnalogReaderByName(name string) (board.AnalogReader, bool) {
 	return a, ok
 }
 
-// SPIByName returns an SPI bus by name.
-func (pi *piPigpio) SPIByName(name string) (board.SPI, bool) {
-	pi.mu.Lock()
-	defer pi.mu.Unlock()
-	s, ok := pi.spis[name]
-	return s, ok
-}
-
 // I2CByName returns an I2C by name.
 func (pi *piPigpio) I2CByName(name string) (board.I2C, bool) {
 	pi.mu.Lock()

--- a/components/movementsensor/rtkutils/gpsrtk_test.go
+++ b/components/movementsensor/rtkutils/gpsrtk_test.go
@@ -49,6 +49,8 @@ const (
 	i2c1.OpenHandleFunc = func(addr byte) (board.I2CHandle, error) {
 		return handle1, nil
 	}
+	// TODO: while this was commented out, we removed this way to get the I2C bus. When it's time
+	// to uncomment this code, make the GPS component talk directly to the mock bus.
 	actualBoard.I2CByNameFunc = func(name string) (board.I2C, bool) {
 		return i2c1, true
 	}

--- a/components/servo/gpio/servo_test.go
+++ b/components/servo/gpio/servo_test.go
@@ -103,9 +103,6 @@ func setupDependencies(t *testing.T) resource.Dependencies {
 
 	deps := make(resource.Dependencies)
 	board1 := inject.NewBoard("mock")
-	board1.GPIOPinNamesFunc = func() []string {
-		return []string{"0", "1"}
-	}
 
 	innerTick1, innerTick2 := 0, 0
 	scale1, scale2 := 255, 4095

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -865,7 +865,7 @@ func TestStopAll(t *testing.T) {
 }
 
 type dummyBoard struct {
-	board.LocalBoard
+	board.Board
 	closeCount int
 }
 

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -873,10 +873,6 @@ func (db *dummyBoard) Name() resource.Name {
 	return board.Named("bad")
 }
 
-func (db *dummyBoard) SPINames() []string {
-	return nil
-}
-
 func (db *dummyBoard) AnalogReaderNames() []string {
 	return nil
 }

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -877,10 +877,6 @@ func (db *dummyBoard) SPINames() []string {
 	return nil
 }
 
-func (db *dummyBoard) I2CNames() []string {
-	return nil
-}
-
 func (db *dummyBoard) AnalogReaderNames() []string {
 	return nil
 }

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -476,9 +476,6 @@ func TestManagerAdd(t *testing.T) {
 	injectBoard.DigitalInterruptNamesFunc = func() []string {
 		return []string{"digital1"}
 	}
-	injectBoard.SPIByNameFunc = func(name string) (board.SPI, bool) {
-		return &inject.SPI{}, true
-	}
 	injectBoard.I2CByNameFunc = func(name string) (board.I2C, bool) {
 		return &inject.I2C{}, true
 	}

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -470,9 +470,6 @@ func TestManagerAdd(t *testing.T) {
 	test.That(t, arm1, test.ShouldEqual, injectArm)
 
 	injectBoard := &inject.Board{}
-	injectBoard.SPINamesFunc = func() []string {
-		return []string{"spi1"}
-	}
 	injectBoard.AnalogReaderNamesFunc = func() []string {
 		return []string{"analog1"}
 	}

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -473,9 +473,6 @@ func TestManagerAdd(t *testing.T) {
 	injectBoard.SPINamesFunc = func() []string {
 		return []string{"spi1"}
 	}
-	injectBoard.I2CNamesFunc = func() []string {
-		return []string{"i2c1"}
-	}
 	injectBoard.AnalogReaderNamesFunc = func() []string {
 		return []string{"analog1"}
 	}

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -476,9 +476,6 @@ func TestManagerAdd(t *testing.T) {
 	injectBoard.DigitalInterruptNamesFunc = func() []string {
 		return []string{"digital1"}
 	}
-	injectBoard.I2CByNameFunc = func(name string) (board.I2C, bool) {
-		return &inject.I2C{}, true
-	}
 	injectBoard.AnalogReaderByNameFunc = func(name string) (board.AnalogReader, bool) {
 		return &fakeboard.AnalogReader{}, true
 	}

--- a/testutils/inject/board.go
+++ b/testutils/inject/board.go
@@ -26,7 +26,6 @@ type Board struct {
 	gpioPinByNameCap           []interface{}
 	AnalogReaderNamesFunc      func() []string
 	DigitalInterruptNamesFunc  func() []string
-	GPIOPinNamesFunc           func() []string
 	CloseFunc                  func(ctx context.Context) error
 	StatusFunc                 func(ctx context.Context, extra map[string]interface{}) (*commonpb.BoardStatus, error)
 	statusCap                  []interface{}
@@ -121,14 +120,6 @@ func (b *Board) DigitalInterruptNames() []string {
 		return b.LocalBoard.DigitalInterruptNames()
 	}
 	return b.DigitalInterruptNamesFunc()
-}
-
-// GPIOPinNames calls the injected GPIOPinNames or the real version.
-func (b *Board) GPIOPinNames() []string {
-	if b.GPIOPinNamesFunc == nil {
-		return b.LocalBoard.GPIOPinNames()
-	}
-	return b.GPIOPinNamesFunc()
 }
 
 // Close calls the injected Close or the real version.

--- a/testutils/inject/board.go
+++ b/testutils/inject/board.go
@@ -16,8 +16,6 @@ type Board struct {
 	board.LocalBoard
 	name                       resource.Name
 	DoFunc                     func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
-	I2CByNameFunc              func(name string) (board.I2C, bool)
-	i2cByNameCap               []interface{}
 	AnalogReaderByNameFunc     func(name string) (board.AnalogReader, bool)
 	analogReaderByNameCap      []interface{}
 	DigitalInterruptByNameFunc func(name string) (board.DigitalInterrupt, bool)
@@ -41,15 +39,6 @@ func NewBoard(name string) *Board {
 // Name returns the name of the resource.
 func (b *Board) Name() resource.Name {
 	return b.name
-}
-
-// I2CByName calls the injected I2CByName or the real version.
-func (b *Board) I2CByName(name string) (board.I2C, bool) {
-	b.i2cByNameCap = []interface{}{name}
-	if b.I2CByNameFunc == nil {
-		return b.LocalBoard.I2CByName(name)
-	}
-	return b.I2CByNameFunc(name)
 }
 
 // AnalogReaderByName calls the injected AnalogReaderByName or the real version.

--- a/testutils/inject/board.go
+++ b/testutils/inject/board.go
@@ -26,7 +26,6 @@ type Board struct {
 	digitalInterruptByNameCap  []interface{}
 	GPIOPinByNameFunc          func(name string) (board.GPIOPin, error)
 	gpioPinByNameCap           []interface{}
-	SPINamesFunc               func() []string
 	AnalogReaderNamesFunc      func() []string
 	DigitalInterruptNamesFunc  func() []string
 	GPIOPinNamesFunc           func() []string
@@ -117,14 +116,6 @@ func (b *Board) GPIOPinByNameCap() []interface{} {
 	}
 	defer func() { b.gpioPinByNameCap = nil }()
 	return b.gpioPinByNameCap
-}
-
-// SPINames calls the injected SPINames or the real version.
-func (b *Board) SPINames() []string {
-	if b.SPINamesFunc == nil {
-		return b.LocalBoard.SPINames()
-	}
-	return b.SPINamesFunc()
 }
 
 // AnalogReaderNames calls the injected AnalogReaderNames or the real version.

--- a/testutils/inject/board.go
+++ b/testutils/inject/board.go
@@ -16,8 +16,6 @@ type Board struct {
 	board.LocalBoard
 	name                       resource.Name
 	DoFunc                     func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
-	SPIByNameFunc              func(name string) (board.SPI, bool)
-	spiByNameCap               []interface{}
 	I2CByNameFunc              func(name string) (board.I2C, bool)
 	i2cByNameCap               []interface{}
 	AnalogReaderByNameFunc     func(name string) (board.AnalogReader, bool)
@@ -44,15 +42,6 @@ func NewBoard(name string) *Board {
 // Name returns the name of the resource.
 func (b *Board) Name() resource.Name {
 	return b.name
-}
-
-// SPIByName calls the injected SPIByName or the real version.
-func (b *Board) SPIByName(name string) (board.SPI, bool) {
-	b.spiByNameCap = []interface{}{name}
-	if b.SPIByNameFunc == nil {
-		return b.LocalBoard.SPIByName(name)
-	}
-	return b.SPIByNameFunc(name)
 }
 
 // I2CByName calls the injected I2CByName or the real version.

--- a/testutils/inject/board.go
+++ b/testutils/inject/board.go
@@ -27,7 +27,6 @@ type Board struct {
 	GPIOPinByNameFunc          func(name string) (board.GPIOPin, error)
 	gpioPinByNameCap           []interface{}
 	SPINamesFunc               func() []string
-	I2CNamesFunc               func() []string
 	AnalogReaderNamesFunc      func() []string
 	DigitalInterruptNamesFunc  func() []string
 	GPIOPinNamesFunc           func() []string
@@ -126,14 +125,6 @@ func (b *Board) SPINames() []string {
 		return b.LocalBoard.SPINames()
 	}
 	return b.SPINamesFunc()
-}
-
-// I2CNames calls the injected SPINames or the real version.
-func (b *Board) I2CNames() []string {
-	if b.I2CNamesFunc == nil {
-		return b.LocalBoard.I2CNames()
-	}
-	return b.I2CNamesFunc()
 }
 
 // AnalogReaderNames calls the injected AnalogReaderNames or the real version.

--- a/testutils/inject/board.go
+++ b/testutils/inject/board.go
@@ -13,7 +13,7 @@ import (
 
 // Board is an injected board.
 type Board struct {
-	board.LocalBoard
+	board.Board
 	name                       resource.Name
 	DoFunc                     func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
 	AnalogReaderByNameFunc     func(name string) (board.AnalogReader, bool)
@@ -45,7 +45,7 @@ func (b *Board) Name() resource.Name {
 func (b *Board) AnalogReaderByName(name string) (board.AnalogReader, bool) {
 	b.analogReaderByNameCap = []interface{}{name}
 	if b.AnalogReaderByNameFunc == nil {
-		return b.LocalBoard.AnalogReaderByName(name)
+		return b.Board.AnalogReaderByName(name)
 	}
 	return b.AnalogReaderByNameFunc(name)
 }
@@ -63,7 +63,7 @@ func (b *Board) AnalogReaderByNameCap() []interface{} {
 func (b *Board) DigitalInterruptByName(name string) (board.DigitalInterrupt, bool) {
 	b.digitalInterruptByNameCap = []interface{}{name}
 	if b.DigitalInterruptByNameFunc == nil {
-		return b.LocalBoard.DigitalInterruptByName(name)
+		return b.Board.DigitalInterruptByName(name)
 	}
 	return b.DigitalInterruptByNameFunc(name)
 }
@@ -81,7 +81,7 @@ func (b *Board) DigitalInterruptByNameCap() []interface{} {
 func (b *Board) GPIOPinByName(name string) (board.GPIOPin, error) {
 	b.gpioPinByNameCap = []interface{}{name}
 	if b.GPIOPinByNameFunc == nil {
-		return b.LocalBoard.GPIOPinByName(name)
+		return b.Board.GPIOPinByName(name)
 	}
 	return b.GPIOPinByNameFunc(name)
 }
@@ -98,7 +98,7 @@ func (b *Board) GPIOPinByNameCap() []interface{} {
 // AnalogReaderNames calls the injected AnalogReaderNames or the real version.
 func (b *Board) AnalogReaderNames() []string {
 	if b.AnalogReaderNamesFunc == nil {
-		return b.LocalBoard.AnalogReaderNames()
+		return b.Board.AnalogReaderNames()
 	}
 	return b.AnalogReaderNamesFunc()
 }
@@ -106,7 +106,7 @@ func (b *Board) AnalogReaderNames() []string {
 // DigitalInterruptNames calls the injected DigitalInterruptNames or the real version.
 func (b *Board) DigitalInterruptNames() []string {
 	if b.DigitalInterruptNamesFunc == nil {
-		return b.LocalBoard.DigitalInterruptNames()
+		return b.Board.DigitalInterruptNames()
 	}
 	return b.DigitalInterruptNamesFunc()
 }
@@ -114,10 +114,10 @@ func (b *Board) DigitalInterruptNames() []string {
 // Close calls the injected Close or the real version.
 func (b *Board) Close(ctx context.Context) error {
 	if b.CloseFunc == nil {
-		if b.LocalBoard == nil {
+		if b.Board == nil {
 			return nil
 		}
-		return b.LocalBoard.Close(ctx)
+		return b.Board.Close(ctx)
 	}
 	return b.CloseFunc(ctx)
 }
@@ -126,7 +126,7 @@ func (b *Board) Close(ctx context.Context) error {
 func (b *Board) Status(ctx context.Context, extra map[string]interface{}) (*commonpb.BoardStatus, error) {
 	b.statusCap = []interface{}{ctx}
 	if b.StatusFunc == nil {
-		return b.LocalBoard.Status(ctx, extra)
+		return b.Board.Status(ctx, extra)
 	}
 	return b.StatusFunc(ctx, extra)
 }
@@ -143,7 +143,7 @@ func (b *Board) StatusCap() []interface{} {
 // DoCommand calls the injected DoCommand or the real version.
 func (b *Board) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
 	if b.DoFunc == nil {
-		return b.LocalBoard.DoCommand(ctx, cmd)
+		return b.Board.DoCommand(ctx, cmd)
 	}
 	return b.DoFunc(ctx, cmd)
 }
@@ -153,7 +153,7 @@ func (b *Board) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[
 // the specified duration.
 func (b *Board) SetPowerMode(ctx context.Context, mode boardpb.PowerMode, duration *time.Duration) error {
 	if b.SetPowerModeFunc == nil {
-		return b.LocalBoard.SetPowerMode(ctx, mode, duration)
+		return b.Board.SetPowerMode(ctx, mode, duration)
 	}
 	return b.SetPowerModeFunc(ctx, mode, duration)
 }
@@ -161,7 +161,7 @@ func (b *Board) SetPowerMode(ctx context.Context, mode boardpb.PowerMode, durati
 // WriteAnalog calls the injected WriteAnalog or the real version.
 func (b *Board) WriteAnalog(ctx context.Context, pin string, value int32, extra map[string]interface{}) error {
 	if b.WriteAnalogFunc == nil {
-		return b.LocalBoard.WriteAnalog(ctx, pin, value, extra)
+		return b.Board.WriteAnalog(ctx, pin, value, extra)
 	}
 	return b.WriteAnalogFunc(ctx, pin, value, extra)
 }


### PR DESCRIPTION
There will be another PR for this ticket to do more of this once #3215 is merged, but this is a start and it's already a pretty big PR, so I'll send this out as-is. Now that all components talk to their I2C and SPI buses directly, there is no need for a component in the RDK to request either the names or access to any named buses from the board. Time to remove that as dead code!

If this PR is large, you can go commit-by-commit to get simpler subpieces. Once #3215 is merged, we can also remove `I2CByName` similar to `SPIByName`, which in turn will let us remove the entire `LocalBoard` struct (so there's no distinction between a board and a local board).

and the next next step is to remove the "i2cs" and "spis" sections from the board configs, but that's a totally different Jira ticket.