### PR TITLE
RSDK-5742 return raw kinematics file from arm server

### DIFF
--- a/components/arm/client.go
+++ b/components/arm/client.go
@@ -195,7 +195,7 @@ func (c *client) updateKinematics(ctx context.Context, extra map[string]interfac
 	case commonpb.KinematicsFileFormat_KINEMATICS_FILE_FORMAT_SVA:
 		return referenceframe.UnmarshalModelJSON(data, c.name)
 	case commonpb.KinematicsFileFormat_KINEMATICS_FILE_FORMAT_URDF:
-		modelconf, err := urdf.ConvertURDFToConfig(data, c.name)
+		modelconf, err := urdf.UnmarshalModelXML(data, c.name)
 		if err != nil {
 			return nil, err
 		}

--- a/components/arm/client_test.go
+++ b/components/arm/client_test.go
@@ -63,7 +63,7 @@ func TestClient(t *testing.T) {
 		return errStopUnimplemented
 	}
 	injectArm.ModelFrameFunc = func() referenceframe.Model {
-		data := []byte("{\"links\": [{\"parent\": \"world\"t}]}")
+		data := []byte("{\"links\": [{\"parent\": \"world\"}]}")
 		model, err := referenceframe.UnmarshalModelJSON(data, "")
 		test.That(t, err, test.ShouldBeNil)
 		return model

--- a/components/arm/client_test.go
+++ b/components/arm/client_test.go
@@ -63,7 +63,7 @@ func TestClient(t *testing.T) {
 		return errStopUnimplemented
 	}
 	injectArm.ModelFrameFunc = func() referenceframe.Model {
-		data := []byte("{\"links\": [{\"parent\": \"world\"}]}")
+		data := []byte("{\"links\": [{\"parent\": \"world\"t}]}")
 		model, err := referenceframe.UnmarshalModelJSON(data, "")
 		test.That(t, err, test.ShouldBeNil)
 		return model

--- a/components/arm/fake/fake.go
+++ b/components/arm/fake/fake.go
@@ -233,7 +233,7 @@ func modelFromName(model, name string) (referenceframe.Model, error) {
 func modelFromPath(modelPath, name string) (referenceframe.Model, error) {
 	switch {
 	case strings.HasSuffix(modelPath, ".urdf"):
-		return urdf.ParseXMLFile(modelPath, name)
+		return urdf.ParseModelXMLFile(modelPath, name)
 	case strings.HasSuffix(modelPath, ".json"):
 		return referenceframe.ParseModelJSONFile(modelPath, name)
 	default:

--- a/components/arm/server.go
+++ b/components/arm/server.go
@@ -11,6 +11,7 @@ import (
 
 	"go.viam.com/rdk/operation"
 	"go.viam.com/rdk/protoutils"
+	"go.viam.com/rdk/referenceframe/urdf"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/spatialmath"
 )
@@ -140,7 +141,7 @@ func (s *serviceServer) GetKinematics(ctx context.Context, req *commonpb.GetKine
 	switch cfg.OriginalFile.Extension {
 	case "json":
 		resp.Format = commonpb.KinematicsFileFormat_KINEMATICS_FILE_FORMAT_SVA
-	case "urdf":
+	case urdf.Extension:
 		resp.Format = commonpb.KinematicsFileFormat_KINEMATICS_FILE_FORMAT_URDF
 	default:
 		resp.Format = commonpb.KinematicsFileFormat_KINEMATICS_FILE_FORMAT_URDF

--- a/components/arm/server.go
+++ b/components/arm/server.go
@@ -132,13 +132,20 @@ func (s *serviceServer) GetKinematics(ctx context.Context, req *commonpb.GetKine
 	if model == nil {
 		return &commonpb.GetKinematicsResponse{Format: commonpb.KinematicsFileFormat_KINEMATICS_FILE_FORMAT_UNSPECIFIED}, nil
 	}
-	filedata, err := model.MarshalJSON()
-	if err != nil {
-		return nil, err
+	cfg := model.ModelConfig()
+	if cfg == nil || cfg.OriginalFile == nil {
+		return &commonpb.GetKinematicsResponse{Format: commonpb.KinematicsFileFormat_KINEMATICS_FILE_FORMAT_UNSPECIFIED}, nil
 	}
-	// Marshalled models always marshal to SVA
-	format := commonpb.KinematicsFileFormat_KINEMATICS_FILE_FORMAT_SVA
-	return &commonpb.GetKinematicsResponse{Format: format, KinematicsData: filedata}, nil
+	resp := &commonpb.GetKinematicsResponse{KinematicsData: cfg.OriginalFile.Bytes}
+	switch cfg.OriginalFile.Extension {
+	case "json":
+		resp.Format = commonpb.KinematicsFileFormat_KINEMATICS_FILE_FORMAT_SVA
+	case "urdf":
+		resp.Format = commonpb.KinematicsFileFormat_KINEMATICS_FILE_FORMAT_URDF
+	default:
+		resp.Format = commonpb.KinematicsFileFormat_KINEMATICS_FILE_FORMAT_URDF
+	}
+	return resp, nil
 }
 
 // DoCommand receives arbitrary commands.

--- a/components/arm/wrapper/wrapper.go
+++ b/components/arm/wrapper/wrapper.go
@@ -204,7 +204,7 @@ func (wrapper *Arm) Geometries(ctx context.Context, extra map[string]interface{}
 func modelFromPath(modelPath, name string) (referenceframe.Model, error) {
 	switch {
 	case strings.HasSuffix(modelPath, ".urdf"):
-		return urdf.ParseXMLFile(modelPath, name)
+		return urdf.ParseModelXMLFile(modelPath, name)
 	case strings.HasSuffix(modelPath, ".json"):
 		return referenceframe.ParseModelJSONFile(modelPath, name)
 	default:

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -803,8 +803,9 @@ func TestModuleMisc(t *testing.T) {
 		test.That(t, resp, test.ShouldNotBeNil)
 		modWorkingDirectory, ok := resp["path"].(string)
 		test.That(t, ok, test.ShouldBeTrue)
-		test.That(t, modWorkingDirectory, test.ShouldEqual, filepath.Dir(modPath))
-
+		// MacOS prepends "/private/" to the filepath so we check the end of the path to account for this
+		// i.e.  '/private/var/folders/p1/nl3sq7jn5nx8tfkdwpz2_g7r0000gn/T/TestModuleMisc1764175663/002'
+		test.That(t, modWorkingDirectory, test.ShouldEndWith, filepath.Dir(modPath))
 		err = mgr.Close(ctx)
 		test.That(t, err, test.ShouldBeNil)
 	})

--- a/motionplan/kinematic_test.go
+++ b/motionplan/kinematic_test.go
@@ -303,7 +303,7 @@ func TestKinematicsJSONvsURDF(t *testing.T) {
 
 	mJSON, err := frame.ParseModelJSONFile(utils.ResolveFile("components/arm/universalrobots/ur5e.json"), "")
 	test.That(t, err, test.ShouldBeNil)
-	mURDF, err := urdf.ParseXMLFile(utils.ResolveFile("referenceframe/urdf/testfiles/ur5_viam.urdf"), "")
+	mURDF, err := urdf.ParseModelXMLFile(utils.ResolveFile("referenceframe/urdf/testfiles/ur5_viam.urdf"), "")
 	test.That(t, err, test.ShouldBeNil)
 
 	seed := rand.New(rand.NewSource(50))

--- a/referenceframe/model_json.go
+++ b/referenceframe/model_json.go
@@ -7,6 +7,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// ErrNoModelInformation is used when there is no model information.
+var ErrNoModelInformation = errors.New("no model information")
+
 // ModelConfig represents all supported fields in a kinematics JSON file.
 type ModelConfig struct {
 	Name         string          `json:"name"`
@@ -14,6 +17,30 @@ type ModelConfig struct {
 	Links        []LinkConfig    `json:"links,omitempty"`
 	Joints       []JointConfig   `json:"joints,omitempty"`
 	DHParams     []DHParamConfig `json:"dhParams,omitempty"`
+	OriginalFile *ModelFile
+}
+
+type ModelFile struct {
+	Bytes     []byte
+	Extension string
+}
+
+// UnmarshalModelJSON will parse the given JSON data into a kinematics model. modelName sets the name of the model,
+// will use the name from the JSON if string is empty.
+func UnmarshalModelJSON(jsonData []byte, modelName string) (Model, error) {
+	m := &ModelConfig{OriginalFile: &ModelFile{Bytes: jsonData, Extension: "json"}}
+
+	// empty data probably means that the robot component has no model information
+	if len(jsonData) == 0 {
+		return nil, ErrNoModelInformation
+	}
+
+	err := json.Unmarshal(jsonData, m)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal json file")
+	}
+
+	return m.ParseConfig(modelName)
 }
 
 // ParseConfig converts the ModelConfig struct into a full Model with the name modelName.
@@ -126,25 +153,4 @@ func ParseModelJSONFile(filename, modelName string) (Model, error) {
 		return nil, errors.Wrap(err, "failed to read json file")
 	}
 	return UnmarshalModelJSON(jsonData, modelName)
-}
-
-// ErrNoModelInformation is used when there is no model information.
-var ErrNoModelInformation = errors.New("no model information")
-
-// UnmarshalModelJSON will parse the given JSON data into a kinematics model. modelName sets the name of the model,
-// will use the name from the JSON if string is empty.
-func UnmarshalModelJSON(jsonData []byte, modelName string) (Model, error) {
-	m := &ModelConfig{}
-
-	// empty data probably means that the robot component has no model information
-	if len(jsonData) == 0 {
-		return nil, ErrNoModelInformation
-	}
-
-	err := json.Unmarshal(jsonData, m)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal json file")
-	}
-
-	return m.ParseConfig(modelName)
 }

--- a/referenceframe/model_json.go
+++ b/referenceframe/model_json.go
@@ -20,6 +20,8 @@ type ModelConfig struct {
 	OriginalFile *ModelFile
 }
 
+// ModelFile is a struct that stores the raw bytes of the file used to create the model as well as its extension,
+// which is useful for knowing how to unmarhsal it.
 type ModelFile struct {
 	Bytes     []byte
 	Extension string

--- a/referenceframe/urdf/model.go
+++ b/referenceframe/urdf/model.go
@@ -14,6 +14,7 @@ import (
 	"go.viam.com/rdk/utils"
 )
 
+// Extension is the file extension associated with URDF files.
 const Extension string = "urdf"
 
 // ModelConfig represents all supported fields in a Universal Robot Description Format (URDF) file.
@@ -43,7 +44,7 @@ type joint struct {
 	Limit   *limit   `xml:"limit,omitempty"`
 }
 
-// NewConfigFromWorldState creates a urdf.Config struct which can be marshalled into xml and will be a
+// NewModelFromWorldState creates a urdf.Config struct which can be marshalled into xml and will be a
 // valid .urdf file representing the geometries in the given worldstate.
 func NewModelFromWorldState(ws *referenceframe.WorldState, name string) (*ModelConfig, error) {
 	// the link we initialize this list with represents the world frame
@@ -77,7 +78,7 @@ func NewModelFromWorldState(ws *referenceframe.WorldState, name string) (*ModelC
 	}, nil
 }
 
-// UnmarshalModel will transfer the given URDF XML data into an equivalent ModelConfig. Direct unmarshaling in the
+// UnmarshalModelXML will transfer the given URDF XML data into an equivalent ModelConfig. Direct unmarshaling in the
 // same fashion as ModelJSON is not possible, as URDF data will need to be evaluated to accommodate differences
 // between the two kinematics encoding schemes.
 func UnmarshalModelXML(xmlData []byte, modelName string) (*referenceframe.ModelConfig, error) {
@@ -229,7 +230,7 @@ func UnmarshalModelXML(xmlData []byte, modelName string) (*referenceframe.ModelC
 	return mc, nil
 }
 
-// ParseXMLFile will read a given file and parse the contained URDF XML data into an equivalent Model.
+// ParseModelXMLFile will read a given file and parse the contained URDF XML data into an equivalent Model.
 func ParseModelXMLFile(filename, modelName string) (referenceframe.Model, error) {
 	//nolint:gosec
 	xmlData, err := os.ReadFile(filename)

--- a/referenceframe/urdf/model_test.go
+++ b/referenceframe/urdf/model_test.go
@@ -14,12 +14,12 @@ import (
 
 func TestParseURDFFile(t *testing.T) {
 	// Test a URDF which has prismatic joints
-	u, err := ParseXMLFile(utils.ResolveFile("referenceframe/urdf/testfiles/example_gantry.urdf"), "")
+	u, err := ParseModelXMLFile(utils.ResolveFile("referenceframe/urdf/testfiles/example_gantry.urdf"), "")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, len(u.DoF()), test.ShouldEqual, 2)
 
 	// Test a URDF will has collision geometries we can evaluate and a DoF of 6
-	u, err = ParseXMLFile(utils.ResolveFile("referenceframe/urdf/testfiles/ur5_viam.urdf"), "")
+	u, err = ParseModelXMLFile(utils.ResolveFile("referenceframe/urdf/testfiles/ur5_viam.urdf"), "")
 	test.That(t, err, test.ShouldBeNil)
 	model, ok := u.(*referenceframe.SimpleModel)
 	test.That(t, ok, test.ShouldBeTrue)
@@ -30,13 +30,13 @@ func TestParseURDFFile(t *testing.T) {
 	test.That(t, len(modelGeo.Geometries()), test.ShouldEqual, 5)
 
 	// Test naming of a URDF to something other than the robot's name element
-	u, err = ParseXMLFile(utils.ResolveFile("referenceframe/urdf/testfiles/ur5_minimal.urdf"), "foo")
+	u, err = ParseModelXMLFile(utils.ResolveFile("referenceframe/urdf/testfiles/ur5_minimal.urdf"), "foo")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, u.Name(), test.ShouldEqual, "foo")
 }
 
 func TestURDFTransforms(t *testing.T) {
-	u, err := ParseXMLFile(utils.ResolveFile("referenceframe/urdf/testfiles/ur5_minimal.urdf"), "")
+	u, err := ParseModelXMLFile(utils.ResolveFile("referenceframe/urdf/testfiles/ur5_minimal.urdf"), "")
 	test.That(t, err, test.ShouldBeNil)
 	simple, ok := u.(*referenceframe.SimpleModel)
 	test.That(t, ok, test.ShouldBeTrue)
@@ -75,7 +75,7 @@ func TestWorlStateConversion(t *testing.T) {
 	)
 	test.That(t, err, test.ShouldBeNil)
 
-	cfg, err := NewConfigFromWorldState(ws, "test")
+	cfg, err := NewModelFromWorldState(ws, "test")
 	test.That(t, err, test.ShouldBeNil)
 	bytes, err := xml.MarshalIndent(cfg, "", "  ")
 	test.That(t, err, test.ShouldBeNil)


### PR DESCRIPTION
This PR makes it possible for an arm model within the RDK to return a kinematic representation in a format other than SVA, which is all that was previously possible.  