### PR TITLE
Add info messages for package download time.

### DIFF
--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -211,7 +211,8 @@ func (m *cloudManager) validateAndGetChangedPackages(packages []config.PackageCo
 			continue
 		}
 		if existing := m.packageIsManaged(p); !existing {
-			changed = append(changed, p)
+			newPackage := p
+			changed = append(changed, newPackage)
 		} else {
 			m.logger.Debug("Package %s:%s already managed, skipping", p.Package, p.Version)
 		}

--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -132,7 +132,8 @@ func (m *cloudManager) Sync(ctx context.Context, packages []config.PackageConfig
 	if !areManaged {
 		m.logger.Info("Package changes have been detected, starting sync")
 	}
-
+	
+	start := time.Now()
 	for idx, p := range packages {
 		if err := ctx.Err(); err != nil {
 			return multierr.Append(outErr, err)
@@ -143,7 +144,6 @@ func (m *cloudManager) Sync(ctx context.Context, packages []config.PackageConfig
 			continue
 		}
 
-		start := time.Now()
 		m.logger.Debugf("Starting package sync [%d/%d] %s:%s", idx+1, len(packages), p.Package, p.Version)
 
 		// Package exists in known cache.
@@ -194,9 +194,10 @@ func (m *cloudManager) Sync(ctx context.Context, packages []config.PackageConfig
 		// add to managed packages
 		newManagedPackages[PackageName(p.Name)] = &managedPackage{thePackage: p, modtime: time.Now()}
 
-		if !areManaged {
-			m.logger.Infof("Package sync complete after %v", time.Since(start))
-		}
+	}
+
+	if !areManaged {
+		m.logger.Infof("Package sync complete after %v", time.Since(start))
 	}
 
 	// swap for new managed packags.

--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -128,7 +128,7 @@ func (m *cloudManager) Sync(ctx context.Context, packages []config.PackageConfig
 
 	newManagedPackages := make(map[PackageName]*managedPackage, len(packages))
 
-	//Add packages that were managed in last sync back to list.
+
 	for _, p := range packages {
 		// Package exists in known cache.
 		if m.packageIsManaged(p) {

--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -128,7 +128,6 @@ func (m *cloudManager) Sync(ctx context.Context, packages []config.PackageConfig
 
 	newManagedPackages := make(map[PackageName]*managedPackage, len(packages))
 
-
 	for _, p := range packages {
 		// Package exists in known cache.
 		if m.packageIsManaged(p) {

--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -132,7 +132,7 @@ func (m *cloudManager) Sync(ctx context.Context, packages []config.PackageConfig
 	if !areManaged {
 		m.logger.Info("Package changes have been detected, starting sync")
 	}
-	
+
 	start := time.Now()
 	for idx, p := range packages {
 		if err := ctx.Err(); err != nil {
@@ -193,7 +193,6 @@ func (m *cloudManager) Sync(ctx context.Context, packages []config.PackageConfig
 
 		// add to managed packages
 		newManagedPackages[PackageName(p.Name)] = &managedPackage{thePackage: p, modtime: time.Now()}
-
 	}
 
 	if !areManaged {


### PR DESCRIPTION
I refactored the logic to detect if there are package changes into a common function. I did this so we could have an overall message that records when the package sync starts (and actually does something) and then print out the total time that processing package downloads took.

I did the refactoring this way because I wanted to log the message only when there are actual package changes that will be made, and don't want to print it out every 10 sec when the sync process runs.

Results in:
```
11/16/23, 4:51:38.315 PM   info   robot_server.package_manager   packages/cloud_package_manager.go:198   Package sync complete after 664.170848ms  
11/16/23, 4:51:37.651 PM   info   robot_server.package_manager   packages/cloud_package_manager.go:133   Package changes have been detected, starting sync
```

Tested on https://app.viam.com/robot?id=2cba54a9-8948-484c-acb0-96517135fa8e&tab=logs by restarting robot and also changing package config.