### PR TITLE
RSDK-4810-spatialmath-and-solverframe

### DIFF
--- a/motionplan/solverFrame.go
+++ b/motionplan/solverFrame.go
@@ -8,6 +8,7 @@ import (
 
 	"go.viam.com/rdk/motionplan/tpspace"
 	frame "go.viam.com/rdk/referenceframe"
+	"go.viam.com/rdk/resource"
 	spatial "go.viam.com/rdk/spatialmath"
 )
 
@@ -362,4 +363,54 @@ func findPivotFrame(frameList1, frameList2 []frame.Frame) (frame.Frame, error) {
 		}
 	}
 	return nil, errors.New("no path from solve frame to goal frame")
+}
+
+// PlanToPlanStepsAndGeoPoses converts a plan to the relative poses the robot will move to (relative to the origin) & the geo poses.
+func PlanToPlanStepsAndGeoPoses(
+	plan Plan,
+	componentName resource.Name,
+	origin spatial.GeoPose,
+	planRequest PlanRequest,
+) ([]map[resource.Name]spatial.Pose, []spatial.GeoPose, error) {
+	sf, err := newSolverFrame(
+		planRequest.FrameSystem,
+		planRequest.Frame.Name(),
+		planRequest.Goal.Parent(),
+		planRequest.StartConfiguration)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	planNodes, err := sf.planToNodes(plan)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	seed, err := sf.mapToSlice(planRequest.StartConfiguration)
+	if err != nil {
+		return nil, nil, err
+	}
+	startPose, err := sf.Transform(seed)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	startPoseWOrientation := spatial.NewPose(planNodes[0].Pose().Point(), startPose.Orientation())
+	runningPoseWOrient := startPoseWOrientation
+	planSteps := make([]map[resource.Name]spatial.Pose, 0, len(planNodes))
+	geoPoses := []spatial.GeoPose{}
+	for _, wp := range planNodes {
+		wpPose, err := sf.Transform(wp.Q())
+		if err != nil {
+			return nil, nil, err
+		}
+
+		runningPoseWOrient = spatial.Compose(runningPoseWOrient, wpPose)
+		planSteps = append(planSteps, map[resource.Name]spatial.Pose{componentName: runningPoseWOrient})
+
+		gp := spatial.PoseToGeoPose(origin, runningPoseWOrient)
+		geoPoses = append(geoPoses, gp)
+	}
+
+	return planSteps, geoPoses, nil
 }

--- a/motionplan/solverFrame.go
+++ b/motionplan/solverFrame.go
@@ -408,8 +408,8 @@ func PlanToPlanStepsAndGeoPoses(
 		runningPoseWOrient = spatial.Compose(runningPoseWOrient, wpPose)
 		planSteps = append(planSteps, map[resource.Name]spatial.Pose{componentName: runningPoseWOrient})
 
-		gp := spatial.PoseToGeoPose(origin, runningPoseWOrient)
-		geoPoses = append(geoPoses, gp)
+		gp := spatial.PoseToGeoPose(&origin, runningPoseWOrient)
+		geoPoses = append(geoPoses, *gp)
 	}
 
 	return planSteps, geoPoses, nil

--- a/motionplan/utils_test.go
+++ b/motionplan/utils_test.go
@@ -4,12 +4,16 @@ import (
 	"math"
 	"testing"
 
+	"github.com/golang/geo/r3"
+	geo "github.com/kellydunn/golang-geo"
 	commonpb "go.viam.com/api/common/v1"
 	"go.viam.com/test"
 
+	"go.viam.com/rdk/components/base"
+	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/motionplan/ik"
 	"go.viam.com/rdk/motionplan/tpspace"
-	"go.viam.com/rdk/referenceframe"
+	frame "go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/spatialmath"
 )
 
@@ -68,28 +72,28 @@ func TestFixOvIncrement(t *testing.T) {
 
 func TestEvaluate(t *testing.T) {
 	plan := Plan{
-		map[string][]referenceframe.Input{"": {{1.}, {2.}, {3.}}},
+		map[string][]frame.Input{"": {{1.}, {2.}, {3.}}},
 	}
 	score := plan.Evaluate(ik.L2InputMetric)
 	test.That(t, score, test.ShouldEqual, math.Inf(1))
 
 	// Test no change
-	plan = append(plan, map[string][]referenceframe.Input{"": {{1.}, {2.}, {3.}}})
+	plan = append(plan, map[string][]frame.Input{"": {{1.}, {2.}, {3.}}})
 	score = plan.Evaluate(ik.L2InputMetric)
 	test.That(t, score, test.ShouldEqual, 0)
 
 	// Test L2 for "", and nothing for plan with only one entry
-	plan = append(plan, map[string][]referenceframe.Input{"": {{4.}, {5.}, {6.}}, "test": {{2.}, {3.}, {4.}}})
+	plan = append(plan, map[string][]frame.Input{"": {{4.}, {5.}, {6.}}, "test": {{2.}, {3.}, {4.}}})
 	score = plan.Evaluate(ik.L2InputMetric)
 	test.That(t, score, test.ShouldEqual, math.Sqrt(27))
 
 	// Test cumulative L2 after returning to original inputs
-	plan = append(plan, map[string][]referenceframe.Input{"": {{1.}, {2.}, {3.}}})
+	plan = append(plan, map[string][]frame.Input{"": {{1.}, {2.}, {3.}}})
 	score = plan.Evaluate(ik.L2InputMetric)
 	test.That(t, score, test.ShouldEqual, math.Sqrt(27)*2)
 
 	// Test that the "test" inputs are properly evaluated after skipping a step
-	plan = append(plan, map[string][]referenceframe.Input{"test": {{3.}, {5.}, {6.}}})
+	plan = append(plan, map[string][]frame.Input{"test": {{3.}, {5.}, {6.}}})
 	score = plan.Evaluate(ik.L2InputMetric)
 	test.That(t, score, test.ShouldEqual, math.Sqrt(27)*2+3)
 
@@ -97,4 +101,230 @@ func TestEvaluate(t *testing.T) {
 	// named input set
 	score = plan.Evaluate(tpspace.PTGSegmentMetric)
 	test.That(t, score, test.ShouldEqual, 18)
+}
+
+func TestPlanToPlanStepsAndGeoPoses(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	sphere, err := spatialmath.NewSphere(spatialmath.NewZeroPose(), 10, "base")
+	test.That(t, err, test.ShouldBeNil)
+	baseName := base.Named("myBase")
+	kinematicFrame, err := tpspace.NewPTGFrameFromKinematicOptions(
+		"itsabase",
+		logger,
+		200, 60, 0, 1000,
+		2,
+		[]spatialmath.Geometry{sphere},
+		false,
+	)
+	test.That(t, err, test.ShouldBeNil)
+	goal := spatialmath.NewPoseFromPoint(r3.Vector{X: 1000, Y: 8000, Z: 0})
+	baseFS := frame.NewEmptyFrameSystem("baseFS")
+	err = baseFS.AddFrame(kinematicFrame, baseFS.World())
+	test.That(t, err, test.ShouldBeNil)
+	planRequest := &PlanRequest{
+		Logger:             logger,
+		Goal:               frame.NewPoseInFrame(frame.World, goal),
+		Frame:              kinematicFrame,
+		FrameSystem:        baseFS,
+		StartConfiguration: frame.StartPositions(baseFS),
+		Options:            map[string]interface{}{"smooth_iter": 0},
+	}
+	plan := Plan{
+		map[string][]frame.Input{
+			"itsabase": {{0}, {0}, {0}},
+			"world":    {},
+		},
+		map[string][]frame.Input{
+			"itsabase": {{5}, {-0.8480042879579467}, {999.9999726352631}},
+			"world":    {},
+		},
+		map[string][]frame.Input{
+			"itsabase": {{5}, {-0.8490767023454777}, {999.9999726346474}},
+			"world":    {},
+		},
+		map[string][]frame.Input{
+			"itsabase": {{1}, {-0.21209039180842176}, {1000}},
+			"world":    {},
+		},
+		map[string][]frame.Input{
+			"itsabase": {{0}, {0.00044190456001478516}, {1000}},
+			"world":    {},
+		},
+		map[string][]frame.Input{
+			"itsabase": {{1}, {-0.9318038198426468}, {28.154612436699026}},
+			"world":    {},
+		},
+		map[string][]frame.Input{
+			"itsabase": {{1}, {2.8385178994421265}, {27.694382041674338}},
+			"world":    {},
+		},
+		map[string][]frame.Input{
+			"itsabase": {{6}, {0.11216682798779984}, {999.9999973004774}},
+			"world":    {},
+		},
+		map[string][]frame.Input{
+			"itsabase": {{6}, {0.011555036037605201}, {999.999997300387}},
+			"world":    {},
+		},
+		map[string][]frame.Input{
+			"itsabase": {{0}, {-0.15509986951180685}, {527.4237036450636}},
+			"world":    {},
+		},
+		map[string][]frame.Input{
+			"itsabase": {{0}, {0.3104320634486429}, {406.313687289847}},
+			"world":    {},
+		},
+		map[string][]frame.Input{
+			"itsabase": {{6}, {0.1619719027689384}, {835.8675981179792}},
+			"world":    {},
+		},
+		map[string][]frame.Input{
+			"itsabase": {{6}, {-0.16177935464497809}, {280.3182867874354}},
+			"world":    {},
+		},
+		map[string][]frame.Input{
+			"itsabase": {{0}, {0}, {0}},
+			"world":    {},
+		},
+	}
+
+	expectedPBPoses := []commonpb.Pose{
+		{X: 0, Y: 0, Z: 0, OX: 0, OY: 0, OZ: 1, Theta: 0},
+		{X: 33.823716950666906, Y: 995.1906975055888, Z: 0, OX: 0, OY: 0, OZ: 1, Theta: 0},
+		{X: 67.73174762780747, Y: 1990.363235889872, Z: 0, OX: 0, OY: 0, OZ: 1, Theta: 0},
+		{X: 242.64104911326686, Y: 2969.667800846239, Z: 0, OX: 0, OY: 0, OZ: 1, Theta: -20.25314054316429},
+		{X: 588.3947613604477, Y: 3907.992630880257, Z: 0, OX: 0, OY: 0, OZ: 1, Theta: -20.22782127692785},
+		{X: 598.7036921283044, Y: 3934.1896129113657, Z: 0, OX: 0, OY: 0, OZ: 1.0000000000000002, Theta: -22.733038691228344},
+		{X: 607.7043545069445, Y: 3960.359640622657, Z: 0, OX: 0, OY: 0, OZ: 0.9999999999999997, Theta: -15.226241234582744},
+		{X: 896.0541805207657, Y: 4917.846783458451, Z: 0, OX: 0, OY: 0, OZ: 1.0000000000000002, Theta: -16.832912695850446},
+		{X: 1188.3866528623023, Y: 5874.1634878309915, Z: 0, OX: 0, OY: 0, OZ: 1.0000000000000004, Theta: -16.998426395119534},
+		{X: 1418.5742933393453, Y: 6348.532364022327, Z: 0, OX: 0, OY: 0, OZ: 0.9999999999999999, Theta: -25.884994321175864},
+		{X: 1475.7704606006394, Y: 6750.48664214989, Z: 0, OX: 0, OY: 0, OZ: 1, Theta: -8.098547260031237},
+		{X: 1624.2929955269274, Y: 7572.94373132755, Z: 0, OX: 0, OY: 0, OZ: 1.0000000000000002, Theta: -10.418623867122113},
+		{X: 1666.406401015521, Y: 7849.98041000934, Z: 0, OX: 0, OY: 0, OZ: 1.0000000000000002, Theta: -8.10130530874526},
+		{X: 1666.406401015521, Y: 7849.98041000934, Z: 0, OX: 0, OY: 0, OZ: 1.0000000000000002, Theta: -8.10130530874526},
+	}
+	expectedPoses := []spatialmath.Pose{}
+	for i := range expectedPBPoses {
+		expectedPoses = append(expectedPoses, spatialmath.NewPoseFromProtobuf(&expectedPBPoses[i]))
+	}
+
+	type testCase struct {
+		msg         string
+		origin      spatialmath.GeoPose
+		expectedGPs []spatialmath.GeoPose
+	}
+
+	//nolint:dupl
+	tcs := []testCase{
+		{
+			msg:    "null island origin & north heading",
+			origin: *spatialmath.NewGeoPose(geo.NewPoint(0, 0), 0),
+			expectedGPs: []spatialmath.GeoPose{
+				*spatialmath.NewGeoPose(geo.NewPoint(0, 0), 0),
+				*spatialmath.NewGeoPose(geo.NewPoint(8.949964962761077e-06, 3.0418397506967887e-07), 0),
+				*spatialmath.NewGeoPose(geo.NewPoint(1.7899766616620807e-05, 6.091261943754186e-07), 0),
+				*spatialmath.NewGeoPose(geo.NewPoint(2.670686415702184e-05, 2.1821234034117234e-06), 20.253140543164307),
+				*spatialmath.NewGeoPose(geo.NewPoint(3.514542208721792e-05, 5.291561187530965e-06), 20.22782127692784),
+				*spatialmath.NewGeoPose(geo.NewPoint(3.538101720672235e-05, 5.384271659385257e-06), 22.73303869122833),
+				*spatialmath.NewGeoPose(geo.NewPoint(3.561636992020488e-05, 5.465216521584129e-06), 15.226241234582744),
+				*spatialmath.NewGeoPose(geo.NewPoint(4.4227258669621044e-05, 8.058408857357672e-06), 16.83291269585044),
+				*spatialmath.NewGeoPose(geo.NewPoint(5.282762141305311e-05, 1.0687417902843484e-05), 16.99842639511951),
+				*spatialmath.NewGeoPose(geo.NewPoint(5.7093723208395436e-05, 1.275754507036777e-05), 25.88499432117584),
+				*spatialmath.NewGeoPose(geo.NewPoint(6.070858487751126e-05, 1.3271922591671265e-05), 8.09854726003124),
+				*spatialmath.NewGeoPose(geo.NewPoint(6.810511917989601e-05, 1.4607617852590454e-05), 10.418623867122108),
+				*spatialmath.NewGeoPose(geo.NewPoint(7.059656988760095e-05, 1.498635280806064e-05), 8.101305308745282),
+				*spatialmath.NewGeoPose(geo.NewPoint(7.059656988760095e-05, 1.498635280806064e-05), 8.101305308745282),
+			},
+		},
+		{
+			msg:    "null island origin & east heading",
+			origin: *spatialmath.NewGeoPose(geo.NewPoint(0, 0), 90),
+			expectedGPs: []spatialmath.GeoPose{
+				*spatialmath.NewGeoPose(geo.NewPoint(0, 0), 90.),
+				*spatialmath.NewGeoPose(geo.NewPoint(-3.0418399446214297e-07, 8.949964948781307e-06), 90.),
+				*spatialmath.NewGeoPose(geo.NewPoint(-6.091262404832106e-07, 1.7899766646051922e-05), 90.),
+				*spatialmath.NewGeoPose(geo.NewPoint(-2.1821233795034082e-06, 2.670686413187438e-05), 110.2531405431643),
+				*spatialmath.NewGeoPose(geo.NewPoint(-5.291561217008132e-06, 3.514542204475805e-05), 110.22782127692784),
+				*spatialmath.NewGeoPose(geo.NewPoint(-5.384271658742659e-06, 3.538101718001091e-05), 112.73303869122833),
+				*spatialmath.NewGeoPose(geo.NewPoint(-5.465216560189554e-06, 3.561636988066373e-05), 105.22624123458274),
+				*spatialmath.NewGeoPose(geo.NewPoint(-8.058408846160474e-06, 4.4227258693742326e-05), 106.83291269585044),
+				*spatialmath.NewGeoPose(geo.NewPoint(-1.0687417931043593e-05, 5.282762144838041e-05), 106.99842639511951),
+				*spatialmath.NewGeoPose(geo.NewPoint(-1.2757545116007572e-05, 5.709372325862088e-05), 115.88499432117584),
+				*spatialmath.NewGeoPose(geo.NewPoint(-1.3271922605945433e-05, 6.0708584870059856e-05), 98.09854726003124),
+				*spatialmath.NewGeoPose(geo.NewPoint(-1.4607617852194795e-05, 6.810511917864972e-05), 100.41862386712211),
+				*spatialmath.NewGeoPose(geo.NewPoint(-1.498635280674151e-05, 7.059656989571761e-05), 98.10130530874528),
+				*spatialmath.NewGeoPose(geo.NewPoint(-1.498635280674151e-05, 7.059656989571761e-05), 98.10130530874528),
+			},
+		},
+		{
+			msg:    "central park origin & west heading",
+			origin: *spatialmath.NewGeoPose(geo.NewPoint(40.770190, -73.977192), 270),
+			expectedGPs: []spatialmath.GeoPose{
+				*spatialmath.NewGeoPose(geo.NewPoint(40.77019, -73.97719199999997), 270),
+				*spatialmath.NewGeoPose(geo.NewPoint(40.770190304183394, -73.97720381771077), 270),
+				*spatialmath.NewGeoPose(geo.NewPoint(40.77019060912384, -73.97721563520601), 270),
+				*spatialmath.NewGeoPose(geo.NewPoint(40.770192182118016, -73.97722726427267), 290.2531405431643),
+				*spatialmath.NewGeoPose(geo.NewPoint(40.77019529155192, -73.97723840671397), 290.22782127692784),
+				*spatialmath.NewGeoPose(geo.NewPoint(40.770195384262244, -73.97723871779857), 292.73303869122833),
+				*spatialmath.NewGeoPose(geo.NewPoint(40.77019546520702, -73.97723902856299), 285.22624123458274),
+				*spatialmath.NewGeoPose(geo.NewPoint(40.77019805839413, -73.97725039855398), 286.83291269585044),
+				*spatialmath.NewGeoPose(geo.NewPoint(40.77020068739694, -73.97726175464722), 286.9984263951195),
+				*spatialmath.NewGeoPose(geo.NewPoint(40.770202757520586, -73.97726738769566), 295.88499432117584),
+				*spatialmath.NewGeoPose(geo.NewPoint(40.77020327189487, -73.97727216083203), 278.09854726003124),
+				*spatialmath.NewGeoPose(geo.NewPoint(40.770204607582954, -73.97728192736587), 280.4186238671221),
+				*spatialmath.NewGeoPose(geo.NewPoint(40.77020498631531, -73.97728521712797), 278.1013053087453),
+				*spatialmath.NewGeoPose(geo.NewPoint(40.77020498631531, -73.97728521712797), 278.1013053087453),
+			},
+		},
+		{
+			msg:    "central park origin & south heading",
+			origin: *spatialmath.NewGeoPose(geo.NewPoint(40.770190, -73.977192), 180),
+			expectedGPs: []spatialmath.GeoPose{
+				*spatialmath.NewGeoPose(geo.NewPoint(40.77019, -73.97719199999997), 180),
+				*spatialmath.NewGeoPose(geo.NewPoint(40.770181050035035, -73.97719240165048), 180),
+				*spatialmath.NewGeoPose(geo.NewPoint(40.77017210023339, -73.97719280430209), 180),
+				*spatialmath.NewGeoPose(geo.NewPoint(40.770163293135816, -73.97719488131769), 200.2531405431643),
+				*spatialmath.NewGeoPose(geo.NewPoint(40.7701548545777, -73.97719898707842), 200.22782127692784),
+				*spatialmath.NewGeoPose(geo.NewPoint(40.77015461898258, -73.97719910949496), 202.73303869122833),
+				*spatialmath.NewGeoPose(geo.NewPoint(40.77015438362986, -73.97719921637616), 195.22624123458274),
+				*spatialmath.NewGeoPose(geo.NewPoint(40.77014577274085, -73.97720264047533), 196.83291269585044),
+				*spatialmath.NewGeoPose(geo.NewPoint(40.77013717237774, -73.97720611186675), 196.9984263951195),
+				*spatialmath.NewGeoPose(geo.NewPoint(40.77013290627557, -73.97720884530038), 205.88499432117584),
+				*spatialmath.NewGeoPose(geo.NewPoint(40.77012929141379, -73.97720952449302), 188.09854726003124),
+				*spatialmath.NewGeoPose(geo.NewPoint(40.77012189487922, -73.97721128816768), 190.4186238671221),
+				*spatialmath.NewGeoPose(geo.NewPoint(40.770119403428424, -73.97721178825562), 188.10130530874528),
+				*spatialmath.NewGeoPose(geo.NewPoint(40.770119403428424, -73.97721178825562), 188.10130530874528),
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.msg, func(t *testing.T) {
+			ps, gps, err := PlanToPlanStepsAndGeoPoses(plan, baseName, tc.origin, *planRequest)
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, len(ps), test.ShouldEqual, len(expectedPoses))
+			for i, step := range ps {
+				if len(step) != 1 {
+					t.Logf("iteration %d expected steps with a single component\n", i)
+					t.FailNow()
+				}
+
+				pose, ok := step[baseName]
+				if !ok {
+					t.Logf("iteration %d expected component %s in the step\n", i, baseName.Name)
+					t.FailNow()
+				}
+
+				test.That(t, spatialmath.PoseAlmostEqual(pose, expectedPoses[i]), test.ShouldBeTrue)
+			}
+
+			test.That(t, len(gps), test.ShouldEqual, len(tc.expectedGPs))
+			for i, gp := range gps {
+				test.That(t, gp.Location().Lat(), test.ShouldAlmostEqual, tc.expectedGPs[i].Location().Lat())
+				test.That(t, gp.Location().Lng(), test.ShouldAlmostEqual, tc.expectedGPs[i].Location().Lng())
+				test.That(t, gp.Heading(), test.ShouldAlmostEqual, tc.expectedGPs[i].Heading())
+			}
+		})
+	}
 }

--- a/services/motion/builtin/move_request.go
+++ b/services/motion/builtin/move_request.go
@@ -408,7 +408,7 @@ func (ms *builtIn) newMoveOnGlobeRequest(
 	// Important: GeoPointToPose will create a pose such that incrementing latitude towards north increments +Y, and incrementing
 	// longitude towards east increments +X. Heading is not taken into account. This pose must therefore be transformed based on the
 	// orientation of the base such that it is a pose relative to the base's current location.
-	goalPoseRaw := spatialmath.GeoPointToPose(req.Destination, origin)
+	goalPoseRaw := spatialmath.NewPoseFromPoint(spatialmath.GeoPointToPoint(req.Destination, origin))
 	// construct limits
 	straightlineDistance := goalPoseRaw.Point().Norm()
 	if straightlineDistance > maxTravelDistanceMM {

--- a/services/motion/localizer.go
+++ b/services/motion/localizer.go
@@ -89,6 +89,6 @@ func (m *movementSensorLocalizer) CurrentPosition(ctx context.Context) (*referen
 		return nil, errors.New("could not get orientation from Localizer")
 	}
 
-	pose := spatialmath.NewPose(spatialmath.GeoPointToPose(gp, m.origin).Point(), o)
+	pose := spatialmath.NewPose(spatialmath.GeoPointToPoint(gp, m.origin), o)
 	return referenceframe.NewPoseInFrame(m.Name().Name, spatialmath.Compose(pose, m.calibration)), nil
 }

--- a/spatialmath/geo_obstacle.go
+++ b/spatialmath/geo_obstacle.go
@@ -1,6 +1,8 @@
 package spatialmath
 
 import (
+	"math"
+
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
 	commonpb "go.viam.com/api/common/v1"
@@ -123,21 +125,43 @@ func GetCartesianDistance(p, q *geo.Point) (float64, float64) {
 	return distAlongLat, distAlongLng
 }
 
-// GeoPointToPose converts p into a Pose
+// GeoPoseToPose returns the pose of point with respect to origin.
+func GeoPoseToPose(point, origin GeoPose) Pose {
+	localBearing := origin.Location().BearingTo(point.Location())
+	absoluteBearing := localBearing - origin.Heading()
+
+	latDist, lngDist := GetCartesianDistance(point.Location(), origin.Location())
+	v := r3.Vector{X: latDist * 1e-6, Y: lngDist * 1e-6, Z: 0}
+
+	nullIsland := geo.NewPoint(0, 0)
+
+	gp := nullIsland.PointAtDistanceAndBearing(v.Norm(), absoluteBearing)
+
+	position := GeoPointToPoint(gp, nullIsland)
+
+	headingChange := math.Mod(origin.Heading()-point.Heading(), 360)
+	if headingChange < 0 {
+		headingChange += 360
+	}
+
+	return NewPose(position, &OrientationVectorDegrees{OZ: 1, Theta: headingChange})
+}
+
+// GeoPointToPoint returns the point (r3.Vector) which translates the origin to the destination geopoint
 // Because the function we use to project a point on a spheroid to a plane is nonlinear, we linearize it about a specified origin point.
-func GeoPointToPose(point, origin *geo.Point) Pose {
+func GeoPointToPoint(point, origin *geo.Point) r3.Vector {
 	latDist, lngDist := GetCartesianDistance(origin, point)
 	azimuth := origin.BearingTo(point)
 
 	switch {
 	case azimuth >= 0 && azimuth <= 90:
-		return NewPoseFromPoint(r3.Vector{latDist, lngDist, 0})
+		return r3.Vector{X: latDist, Y: lngDist, Z: 0}
 	case azimuth > 90 && azimuth <= 180:
-		return NewPoseFromPoint(r3.Vector{latDist, -lngDist, 0})
+		return r3.Vector{X: latDist, Y: -lngDist, Z: 0}
 	case azimuth >= -90 && azimuth < 0:
-		return NewPoseFromPoint(r3.Vector{-latDist, lngDist, 0})
+		return r3.Vector{X: -latDist, Y: lngDist, Z: 0}
 	default:
-		return NewPoseFromPoint(r3.Vector{-latDist, -lngDist, 0})
+		return r3.Vector{X: -latDist, Y: -lngDist, Z: 0}
 	}
 }
 
@@ -148,7 +172,7 @@ func GeoObstaclesToGeometries(obstacles []*GeoObstacle, origin *geo.Point) []Geo
 	// transformed by the specified in GPS coordinates.
 	geoms := []Geometry{}
 	for _, v := range obstacles {
-		relativePose := GeoPointToPose(v.location, origin)
+		relativePose := NewPoseFromPoint(GeoPointToPoint(v.location, origin))
 		for _, geom := range v.geometries {
 			geo := geom.Transform(relativePose)
 			geoms = append(geoms, geo)
@@ -179,4 +203,54 @@ func (gpo *GeoPose) Location() *geo.Point {
 // Heading returns a number from [0-360) where 0 is north.
 func (gpo *GeoPose) Heading() float64 {
 	return gpo.heading
+}
+
+// PoseToGeoPose converts a pose (in MM) into a GeoPose treating relativeTo as the origin.
+func PoseToGeoPose(relativeTo GeoPose, pMM Pose) GeoPose {
+	// we do this b/c plan nodes describe movement in mm
+	// but (p *Point) PointAtDistanceAndBearing expects the pose to be in km
+	kmPoint := r3.Vector{
+		X: pMM.Point().X / 1e6,
+		Y: pMM.Point().Y / 1e6,
+		Z: pMM.Point().Z / 1e6,
+	}
+	p := NewPose(kmPoint, pMM.Orientation())
+
+	// math.Atan2 performs on the unit sphere which is right-handed
+	// we assign newX and newY so we are peforming a left-handed calculation
+	newX := -p.Point().X
+	newY := p.Point().Y
+	bearingRad := math.Atan2(newX, newY)
+
+	// convert bearingRad to degrees
+	bearingDeg := bearingRad * 180 / math.Pi * -1
+
+	// get the maginitude of pose p
+	poseMagnitude := p.Point().Norm()
+
+	// relativeTo Heading is a right-handed value
+	headingInWorld := relativeTo.Heading()
+
+	// get the absolute bearing, i.e. the bearing of pose p from north
+	// normalize to be [0,360)
+	absoluteBearing := math.Mod(bearingDeg+headingInWorld, 360)
+
+	// get the new geopoint at distance poseMagnitude
+	newLoc := relativeTo.Location().PointAtDistanceAndBearing(poseMagnitude, absoluteBearing)
+
+	// get the heading of pose p, this is a right-handed value
+	headingRight := p.Orientation().OrientationVectorDegrees().Theta
+
+	// convert headingRight to be left-handed
+	headingLeft := math.Mod(math.Abs(headingRight-360), 360)
+
+	// get the absolute heading of pose p, i.e. the heading in the world
+	// normalize to be [0,360)
+	absolutePoseHeading := math.Mod(headingLeft+headingInWorld, 360)
+
+	if absolutePoseHeading < 0 {
+		absolutePoseHeading += 360
+	}
+
+	return *NewGeoPose(newLoc, absolutePoseHeading)
 }

--- a/spatialmath/geo_obstacle.go
+++ b/spatialmath/geo_obstacle.go
@@ -6,6 +6,7 @@ import (
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
 	commonpb "go.viam.com/api/common/v1"
+	"go.viam.com/rdk/utils"
 )
 
 // GeoObstacle is a struct to store the location and geometric structure of an obstacle in a geospatial environment.
@@ -126,25 +127,16 @@ func GetCartesianDistance(p, q *geo.Point) (float64, float64) {
 }
 
 // GeoPoseToPose returns the pose of point with respect to origin.
-func GeoPoseToPose(point, origin GeoPose) Pose {
+func GeoPoseToPose(point, origin *GeoPose) Pose {
 	localBearing := origin.Location().BearingTo(point.Location())
 	absoluteBearing := localBearing - origin.Heading()
 
 	latDist, lngDist := GetCartesianDistance(point.Location(), origin.Location())
 	v := r3.Vector{X: latDist * 1e-6, Y: lngDist * 1e-6, Z: 0}
 
-	nullIsland := geo.NewPoint(0, 0)
-
-	gp := nullIsland.PointAtDistanceAndBearing(v.Norm(), absoluteBearing)
-
-	position := GeoPointToPoint(gp, nullIsland)
-
-	headingChange := math.Mod(origin.Heading()-point.Heading(), 360)
-	if headingChange < 0 {
-		headingChange += 360
-	}
-
-	return NewPose(position, &OrientationVectorDegrees{OZ: 1, Theta: headingChange})
+	newPoint := origin.Location().PointAtDistanceAndBearing(v.Norm(), absoluteBearing)
+	headingChange := normalizeAngle(origin.Heading() - point.Heading())
+	return NewPose(GeoPointToPoint(newPoint, origin.Location()), &OrientationVectorDegrees{OZ: 1, Theta: headingChange})
 }
 
 // GeoPointToPoint returns the point (r3.Vector) which translates the origin to the destination geopoint
@@ -205,52 +197,44 @@ func (gpo *GeoPose) Heading() float64 {
 	return gpo.heading
 }
 
-// PoseToGeoPose converts a pose (in MM) into a GeoPose treating relativeTo as the origin.
-func PoseToGeoPose(relativeTo GeoPose, pMM Pose) GeoPose {
-	// we do this b/c plan nodes describe movement in mm
-	// but (p *Point) PointAtDistanceAndBearing expects the pose to be in km
-	kmPoint := r3.Vector{
-		X: pMM.Point().X / 1e6,
-		Y: pMM.Point().Y / 1e6,
-		Z: pMM.Point().Z / 1e6,
-	}
-	p := NewPose(kmPoint, pMM.Orientation())
+// PoseToGeoPose converts a pose (which are always in mm) into a GeoPose treating relativeTo as the origin.
+func PoseToGeoPose(relativeTo *GeoPose, pose Pose) *GeoPose {
+	// poses are always in mm but PointAtDistanceAndBearing expects the pose to be in km so we need to convert
+	mmPoint := pose.Point()
+	kmPoint := r3.Vector{X: mmPoint.X / 1e6, Y: mmPoint.Y / 1e6, Z: mmPoint.Z / 1e6}
 
-	// math.Atan2 performs on the unit sphere which is right-handed
-	// we assign newX and newY so we are peforming a left-handed calculation
-	newX := -p.Point().X
-	newY := p.Point().Y
-	bearingRad := math.Atan2(newX, newY)
-
-	// convert bearingRad to degrees
-	bearingDeg := bearingRad * 180 / math.Pi * -1
-
-	// get the maginitude of pose p
-	poseMagnitude := p.Point().Norm()
-
-	// relativeTo Heading is a right-handed value
+	// calculate the bearing (illustrated on the plot below as angle "x"), to the GeoPose (illustrated as "*")
+	//       |   *
+	//       |x /
+	//       | /
+	//       |/
+	// -----------
+	//       |
+	//       |
+	bearing := utils.RadToDeg(math.Atan2(kmPoint.X, kmPoint.Y))
 	headingInWorld := relativeTo.Heading()
 
 	// get the absolute bearing, i.e. the bearing of pose p from north
-	// normalize to be [0,360)
-	absoluteBearing := math.Mod(bearingDeg+headingInWorld, 360)
+	absoluteBearing := normalizeAngle(bearing + headingInWorld)
 
 	// get the new geopoint at distance poseMagnitude
-	newLoc := relativeTo.Location().PointAtDistanceAndBearing(poseMagnitude, absoluteBearing)
+	newPosition := relativeTo.Location().PointAtDistanceAndBearing(kmPoint.Norm(), absoluteBearing)
 
 	// get the heading of pose p, this is a right-handed value
-	headingRight := p.Orientation().OrientationVectorDegrees().Theta
+	headingRight := pose.Orientation().OrientationVectorDegrees().Theta
 
 	// convert headingRight to be left-handed
 	headingLeft := math.Mod(math.Abs(headingRight-360), 360)
 
-	// get the absolute heading of pose p, i.e. the heading in the world
-	// normalize to be [0,360)
-	absolutePoseHeading := math.Mod(headingLeft+headingInWorld, 360)
+	// return the GeoPose at the new position with the absolute heading of pose p, i.e. the heading in the world
+	return NewGeoPose(newPosition, normalizeAngle(headingLeft+headingInWorld))
+}
 
-	if absolutePoseHeading < 0 {
-		absolutePoseHeading += 360
+// normalizeAngle takes in an angle in degrees and returns an equivalent angle in the domain [0,360)
+func normalizeAngle(degrees float64) float64 {
+	normalized := math.Mod(degrees, 360)
+	if degrees < 0 {
+		normalized += 360
 	}
-
-	return *NewGeoPose(newLoc, absolutePoseHeading)
+	return normalized
 }

--- a/spatialmath/geo_obstacle.go
+++ b/spatialmath/geo_obstacle.go
@@ -136,6 +136,8 @@ func GeoPoseToPose(point, origin *GeoPose) Pose {
 	v := r3.Vector{X: latDist * 1e-6, Y: lngDist * 1e-6, Z: 0}
 
 	newPoint := origin.Location().PointAtDistanceAndBearing(v.Norm(), absoluteBearing)
+
+	// subtracting the point from the origin results in a right handed angle
 	headingChange := normalizeAngle(origin.Heading() - point.Heading())
 	return NewPose(GeoPointToPoint(newPoint, origin.Location()), &OrientationVectorDegrees{OZ: 1, Theta: headingChange})
 }
@@ -201,10 +203,10 @@ func (gpo *GeoPose) Heading() float64 {
 // PoseToGeoPose converts a pose (which are always in mm) into a GeoPose treating relativeTo as the origin.
 func PoseToGeoPose(relativeTo *GeoPose, pose Pose) *GeoPose {
 	// poses are always in mm but PointAtDistanceAndBearing expects the pose to be in km so we need to convert
-	mmPoint := pose.Point()
-	kmPoint := r3.Vector{X: mmPoint.X / 1e6, Y: mmPoint.Y / 1e6, Z: mmPoint.Z / 1e6}
+	kmPoint := pose.Point().Mul(1e-6)
 
 	// calculate the bearing (illustrated on the plot below as angle "x"), to the GeoPose (illustrated as "*")
+	// as we are measuring x from the right side of the vertical axis this angle is left handed
 	//       |   *
 	//       |x /
 	//       | /

--- a/spatialmath/geo_obstacle.go
+++ b/spatialmath/geo_obstacle.go
@@ -6,6 +6,7 @@ import (
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
 	commonpb "go.viam.com/api/common/v1"
+
 	"go.viam.com/rdk/utils"
 )
 
@@ -230,7 +231,7 @@ func PoseToGeoPose(relativeTo *GeoPose, pose Pose) *GeoPose {
 	return NewGeoPose(newPosition, normalizeAngle(headingLeft+headingInWorld))
 }
 
-// normalizeAngle takes in an angle in degrees and returns an equivalent angle in the domain [0,360)
+// normalizeAngle takes in an angle in degrees and returns an equivalent angle in the domain [0,360).
 func normalizeAngle(degrees float64) float64 {
 	normalized := math.Mod(degrees, 360)
 	if degrees < 0 {

--- a/spatialmath/geo_obstacle_test.go
+++ b/spatialmath/geo_obstacle_test.go
@@ -10,7 +10,7 @@ import (
 	"go.viam.com/test"
 )
 
-func TestGeoPose(t *testing.T) {
+func TestGeoPointToPoint(t *testing.T) {
 	origin := geo.NewPoint(0, 0)
 	testCases := []struct {
 		*geo.Point
@@ -28,8 +28,8 @@ func TestGeoPose(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
-			pose := GeoPointToPose(tc.Point, origin)
-			test.That(t, R3VectorAlmostEqual(pose.Point(), tc.Vector, 0.1), test.ShouldBeTrue)
+			point := GeoPointToPoint(tc.Point, origin)
+			test.That(t, R3VectorAlmostEqual(point, tc.Vector, 0.1), test.ShouldBeTrue)
 		})
 	}
 }
@@ -92,4 +92,190 @@ func TestGeoObstacles(t *testing.T) {
 		test.That(t, conv[0].location, test.ShouldResemble, testGeoObst.location)
 		test.That(t, conv[0].geometries, test.ShouldResemble, testGeoObst.geometries)
 	})
+}
+
+func TestPoseToGeoPoint(t *testing.T) {
+	type testCase struct {
+		msg             string
+		relativeTo      GeoPose
+		p               Pose
+		expectedGeoPose GeoPose
+		errMarginMM     float64
+	}
+	mmToMoveOneDegree := 1.1119492664455873e+08
+
+	// values are right handed
+	east := &OrientationVectorDegrees{OZ: 1, Theta: 270}
+	northeast := &OrientationVectorDegrees{OZ: 1, Theta: 315}
+	west := &OrientationVectorDegrees{OZ: 1, Theta: 90}
+	south := &OrientationVectorDegrees{OZ: 1, Theta: 180}
+
+	tcs := []testCase{
+		{
+			msg:             "zero geopose & pose outputs zero geopose",
+			relativeTo:      *NewGeoPose(geo.NewPoint(0, 0), 0),
+			p:               NewZeroPose(),
+			expectedGeoPose: *NewGeoPose(geo.NewPoint(0, 0), 0),
+			errMarginMM:     0.001,
+		},
+		{
+			msg:             "zero geopoint with non zero heading & zero pose outputs same geopose",
+			relativeTo:      *NewGeoPose(geo.NewPoint(0, 0), 90),
+			p:               NewZeroPose(),
+			expectedGeoPose: *NewGeoPose(geo.NewPoint(0, 0), 90),
+			errMarginMM:     0.001,
+		},
+		{
+			msg:             "zero geopose with pose that turns east results in zero geopoint heading east",
+			relativeTo:      *NewGeoPose(geo.NewPoint(0, 0), 0),
+			p:               NewPose(r3.Vector{}, east),
+			expectedGeoPose: *NewGeoPose(geo.NewPoint(0, 0), 90),
+			errMarginMM:     0.001,
+		},
+		{
+			msg:             "nonzero geopose with pose that turns west results in same geopoint heading west",
+			relativeTo:      *NewGeoPose(geo.NewPoint(50, 50), 0),
+			p:               NewPose(r3.Vector{}, west),
+			expectedGeoPose: *NewGeoPose(geo.NewPoint(50, 50), 270),
+			errMarginMM:     0.001,
+		},
+		{
+			msg:             "nonzero geopose facing west with pose that turns east results in same geopoint heading north",
+			relativeTo:      *NewGeoPose(geo.NewPoint(50, 50), 270),
+			p:               NewPose(r3.Vector{}, east),
+			expectedGeoPose: *NewGeoPose(geo.NewPoint(50, 50), 0),
+			errMarginMM:     0.001,
+		},
+		{
+			msg:             "non zero geopose & zero pose outputs same non zero geopose",
+			relativeTo:      *NewGeoPose(geo.NewPoint(40.770301, -73.977308), 90),
+			p:               NewZeroPose(),
+			expectedGeoPose: *NewGeoPose(geo.NewPoint(40.770301, -73.977308), 90),
+			errMarginMM:     0.001,
+		},
+		{
+			msg:             "zero geopose & pose that moves one lat degree north outputs +1 lat degree diff geopose",
+			relativeTo:      *NewGeoPose(geo.NewPoint(0, 0), 0),
+			p:               NewPose(r3.Vector{X: 0, Y: mmToMoveOneDegree, Z: 0}, NewZeroOrientation()),
+			expectedGeoPose: *NewGeoPose(geo.NewPoint(1, 0), 0),
+			errMarginMM:     0.001,
+		},
+		{
+			msg:             "zero geopose & pose that moves one lng degree outputs 1 lat degree diff geopose",
+			relativeTo:      *NewGeoPose(geo.NewPoint(0, 0), 0),
+			p:               NewPose(r3.Vector{X: mmToMoveOneDegree, Y: 0, Z: 0}, NewZeroOrientation()),
+			expectedGeoPose: *NewGeoPose(geo.NewPoint(0, 1), 0),
+			errMarginMM:     0.001,
+		},
+		{
+			msg:             "zero geopose & pose that moves 10 lat degrees north outputs +10 lat degree diff geopose",
+			relativeTo:      *NewGeoPose(geo.NewPoint(0, 0), 0),
+			p:               NewPose(r3.Vector{X: 0, Y: mmToMoveOneDegree * 10, Z: 0}, NewZeroOrientation()),
+			expectedGeoPose: *NewGeoPose(geo.NewPoint(10, 0), 0),
+			errMarginMM:     0.001,
+		},
+		{
+			msg:             "zero geopose & pose that moves 10 lng degrees east outputs +10 lng degree diff geopose",
+			relativeTo:      *NewGeoPose(geo.NewPoint(0, 0), 0),
+			p:               NewPose(r3.Vector{X: mmToMoveOneDegree * 10, Y: 0, Z: 0}, NewZeroOrientation()),
+			expectedGeoPose: *NewGeoPose(geo.NewPoint(0, 10), 0),
+			errMarginMM:     0.001,
+		},
+		{
+			msg: "zero geopose & a pose that moves 1 lat degree north with a south orientation outputs +1" +
+				"lat degree diff geopose facing south",
+			relativeTo:      *NewGeoPose(geo.NewPoint(0, 0), 0),
+			p:               NewPose(r3.Vector{X: 0, Y: mmToMoveOneDegree, Z: 0}, south),
+			expectedGeoPose: *NewGeoPose(geo.NewPoint(1, 0), 180),
+			errMarginMM:     0.001,
+		},
+		{
+			msg: "zero geopose & a pose that moves 1 lat degree south with an east orientation outputs -1" +
+				" lat degree diff geopose facing east",
+			relativeTo:      *NewGeoPose(geo.NewPoint(0, 0), 0),
+			p:               NewPose(r3.Vector{X: 0, Y: -mmToMoveOneDegree, Z: 0}, east),
+			expectedGeoPose: *NewGeoPose(geo.NewPoint(-1, 0), 90),
+			errMarginMM:     0.001,
+		},
+		{
+			msg:             "zero geopose heading south & a pose that rotates east, outputs zero geopose facing west",
+			relativeTo:      *NewGeoPose(geo.NewPoint(0, 0), 180),
+			p:               NewPose(r3.Vector{X: 0, Y: 0, Z: 0}, east),
+			expectedGeoPose: *NewGeoPose(geo.NewPoint(0, 0), 270),
+			errMarginMM:     0.001,
+		},
+		{
+			msg: "zero geopose heading south & a pose that rotates east, outputs zero geopose facing west" +
+				"even when 360 is added multiple times",
+			relativeTo:      *NewGeoPose(geo.NewPoint(0, 0), 180+360+360+360+360),
+			p:               NewPose(r3.Vector{X: 0, Y: 0, Z: 0}, east),
+			expectedGeoPose: *NewGeoPose(geo.NewPoint(0, 0), 270),
+			errMarginMM:     0.001,
+		},
+		{
+			msg:             "zero geopose heading south & a pose that rotates east, outputs zero geopose facing west",
+			relativeTo:      *NewGeoPose(geo.NewPoint(0, 0), 180-360-360-360-360),
+			p:               NewPose(r3.Vector{X: 0, Y: 0, Z: 0}, east),
+			expectedGeoPose: *NewGeoPose(geo.NewPoint(0, 0), 270),
+			errMarginMM:     0.001,
+		},
+		{
+			msg:             "zero geopose heading northwest and pose that rotates northeast",
+			relativeTo:      *NewGeoPose(geo.NewPoint(0, 0), 315),
+			p:               NewPose(r3.Vector{X: mmToMoveOneDegree, Y: mmToMoveOneDegree, Z: 0}, northeast),
+			expectedGeoPose: *NewGeoPose(geo.NewPoint(1.4142135623730947, 0), 0),
+			errMarginMM:     20000,
+		},
+		{
+			msg:             "zero geopose heading north & pose that rotates northeast",
+			relativeTo:      *NewGeoPose(geo.NewPoint(0, 0), 0),
+			p:               NewPose(r3.Vector{X: mmToMoveOneDegree, Y: mmToMoveOneDegree, Z: 0}, northeast),
+			expectedGeoPose: *NewGeoPose(geo.NewPoint(0.9999492250169071, 1.0001015453253934), 45),
+			errMarginMM:     20000,
+		},
+		{
+			msg:             "zero geopose heading east & pose that rotates north",
+			relativeTo:      *NewGeoPose(geo.NewPoint(0, 0), 90),
+			p:               NewPose(r3.Vector{X: mmToMoveOneDegree, Y: mmToMoveOneDegree, Z: 0}, NewZeroOrientation()),
+			expectedGeoPose: *NewGeoPose(geo.NewPoint(-0.9999492250169071, 1.0001015453253934), 90),
+			errMarginMM:     20000,
+		},
+		{
+			msg:             "zero geopose heading east",
+			relativeTo:      *NewGeoPose(geo.NewPoint(0, 0), 90),
+			p:               NewPose(r3.Vector{X: 0, Y: mmToMoveOneDegree, Z: 0}, NewZeroOrientation()),
+			expectedGeoPose: *NewGeoPose(geo.NewPoint(0, 1), 90),
+			errMarginMM:     0.001,
+		},
+		{
+			msg:             "zero geopose heading west",
+			relativeTo:      *NewGeoPose(geo.NewPoint(1, 5), -90),
+			p:               NewPose(r3.Vector{X: mmToMoveOneDegree, Y: mmToMoveOneDegree, Z: 0}, NewZeroOrientation()),
+			expectedGeoPose: *NewGeoPose(geo.NewPoint(1.9997968273479143, 3.9994413235922375), 270),
+			errMarginMM:     20000,
+		},
+		{
+			msg:             "zero geopose heading east",
+			relativeTo:      *NewGeoPose(geo.NewPoint(0, 0), 90),
+			p:               NewPose(r3.Vector{X: mmToMoveOneDegree, Y: mmToMoveOneDegree, Z: 0}, NewZeroOrientation()),
+			expectedGeoPose: *NewGeoPose(geo.NewPoint(-0.9999492250169071, 1.0001015453253934), 90),
+			errMarginMM:     20000,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.msg, func(t *testing.T) {
+			gp := PoseToGeoPose(tc.relativeTo, tc.p)
+			t.Logf("gp: %#v %#v\n", gp.Location(), gp.Heading())
+			test.That(t, gp.Heading(), test.ShouldAlmostEqual, tc.expectedGeoPose.Heading())
+			test.That(t, gp.Location().Lat(), test.ShouldAlmostEqual, tc.expectedGeoPose.Location().Lat())
+			test.That(t, gp.Location().Lng(), test.ShouldAlmostEqual, tc.expectedGeoPose.Location().Lng())
+			geoPointToPose := GeoPoseToPose(gp, tc.relativeTo)
+			msga := "geoPointToPose.Point(): %#v, geoPointToPose.Orientation().OrientationVectorDegrees().: %#v\n"
+			t.Logf(msga, geoPointToPose.Point(), geoPointToPose.Orientation().OrientationVectorDegrees())
+			msgb := "tc.p.Point(): %#v tc.p.Orientation().OrientationVectorDegrees().: %#v\n"
+			t.Logf(msgb, tc.p.Point(), tc.p.Orientation().OrientationVectorDegrees())
+			test.That(t, PoseAlmostEqualEps(geoPointToPose, tc.p, tc.errMarginMM), test.ShouldBeTrue)
+		})
+	}
 }

--- a/spatialmath/geo_obstacle_test.go
+++ b/spatialmath/geo_obstacle_test.go
@@ -8,8 +8,9 @@ import (
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
 	commonpb "go.viam.com/api/common/v1"
-	"go.viam.com/rdk/utils"
 	"go.viam.com/test"
+
+	"go.viam.com/rdk/utils"
 )
 
 func TestGeoPointToPoint(t *testing.T) {
@@ -111,11 +112,11 @@ func TestPoseToGeoPose(t *testing.T) {
 	mmToOneThousandthDegree := 1.1119492664455873e+05
 
 	// values are left handed - north is 0 degrees
-	LHNortheast := 315.
-	LHEast := 270.
+	LHNortheast := 45.
+	LHEast := 90.
 	LHSouth := 180.
-	LHWest := 90.
-	LHNorthwest := 45.
+	LHWest := 270.
+	LHNorthwest := 315.
 
 	// values are right handed - north is 0 degrees
 	RHNortheast := 360 - LHNortheast
@@ -190,7 +191,7 @@ func TestPoseToGeoPose(t *testing.T) {
 		{
 			name:            "zero geopose heading south + pose that rotates east = zero geopose facing west",
 			relativeTo:      NewGeoPose(geo.NewPoint(0, 0), LHSouth-360-360-360-360),
-			pose:            NewPose(r3.Vector{X: 0, Y: 0, Z: 0}, &OrientationVectorDegrees{OZ: 1, Theta: LHEast}),
+			pose:            NewPose(r3.Vector{X: 0, Y: 0, Z: 0}, &OrientationVectorDegrees{OZ: 1, Theta: RHEast}),
 			expectedGeoPose: NewGeoPose(geo.NewPoint(0, 0), LHWest),
 		},
 		{
@@ -200,7 +201,7 @@ func TestPoseToGeoPose(t *testing.T) {
 				r3.Vector{X: mmToOneThousandthDegree, Y: mmToOneThousandthDegree, Z: 0},
 				&OrientationVectorDegrees{OZ: 1, Theta: RHNortheast},
 			),
-			expectedGeoPose: NewGeoPose(geo.NewPoint(0, math.Sqrt2*1e-3), 0),
+			expectedGeoPose: NewGeoPose(geo.NewPoint(math.Sqrt2*1e-3, 0), 0),
 		},
 		{
 			name:       "zero geopose heading north + pose that rotates northeast",
@@ -215,19 +216,19 @@ func TestPoseToGeoPose(t *testing.T) {
 			name:            "zero geopose heading east + pose that rotates north",
 			relativeTo:      NewGeoPose(geo.NewPoint(0, 0), LHWest),
 			pose:            NewPose(r3.Vector{X: mmToOneThousandthDegree, Y: mmToOneThousandthDegree, Z: 0}, NewZeroOrientation()),
-			expectedGeoPose: NewGeoPose(geo.NewPoint(-1e-3, 1e-3), LHWest),
+			expectedGeoPose: NewGeoPose(geo.NewPoint(1e-3, -1e-3), LHWest),
 		},
 		{
 			name:            "zero geopose heading east",
 			relativeTo:      NewGeoPose(geo.NewPoint(1e-3, 5e-3), LHEast),
 			pose:            NewPose(r3.Vector{X: mmToOneThousandthDegree, Y: mmToOneThousandthDegree, Z: 0}, NewZeroOrientation()),
-			expectedGeoPose: NewGeoPose(geo.NewPoint(2e-3, 4e-3), LHEast),
+			expectedGeoPose: NewGeoPose(geo.NewPoint(0, 6e-3), LHEast),
 		},
 		{
 			name:            "zero geopose heading west",
 			relativeTo:      NewGeoPose(geo.NewPoint(0, 0), LHWest),
 			pose:            NewPose(r3.Vector{X: mmToOneThousandthDegree, Y: mmToOneThousandthDegree, Z: 0}, NewZeroOrientation()),
-			expectedGeoPose: NewGeoPose(geo.NewPoint(-1e-3, 1e-3), LHWest),
+			expectedGeoPose: NewGeoPose(geo.NewPoint(1e-3, -1e-3), LHWest),
 		},
 	}
 

--- a/spatialmath/geo_obstacle_test.go
+++ b/spatialmath/geo_obstacle_test.go
@@ -233,13 +233,13 @@ func TestPoseToGeoPose(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			gp := PoseToGeoPose(*tc.relativeTo, tc.pose)
+			gp := PoseToGeoPose(tc.relativeTo, tc.pose)
 			t.Logf("gp: %#v %#v\n", gp.Location(), gp.Heading())
 			t.Logf("tc: %#v %#v\n", tc.expectedGeoPose.Location(), tc.expectedGeoPose.Heading())
 			test.That(t, gp.Heading(), test.ShouldAlmostEqual, tc.expectedGeoPose.Heading())
 			test.That(t, utils.Float64AlmostEqual(gp.Location().Lat(), tc.expectedGeoPose.Location().Lat(), gpsTol), test.ShouldBeTrue)
 			test.That(t, utils.Float64AlmostEqual(gp.Location().Lng(), tc.expectedGeoPose.Location().Lng(), gpsTol), test.ShouldBeTrue)
-			geoPointToPose := GeoPoseToPose(gp, *tc.relativeTo)
+			geoPointToPose := GeoPoseToPose(gp, tc.relativeTo)
 			msga := "geoPointToPose.Point(): %#v, geoPointToPose.Orientation().OrientationVectorDegrees().: %#v\n"
 			t.Logf(msga, geoPointToPose.Point(), geoPointToPose.Orientation().OrientationVectorDegrees())
 			msgb := "tc.p.Point(): %#v tc.p.Orientation().OrientationVectorDegrees().: %#v\n"


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-4810)

This PR adds spatialmath & motionplan helper functions required to convert a motion plan into the geopoints the robot will move to during the plan.

- Add `motionplan.PlanToPlanStepsAndGeoPoses` which converts a plan to the relative poses the robot will move to (relative to the origin) & the geo poses.
- Add `spatialmath.GeoPoseToPose` and `spatialmath.GeoPointToPoint`
- Remove `spatialmath.GeoPointToPose` as it's api was confusing (returned a pose who's orientation was always the zero orientation). Its functionality is now subsumed by  `spatialmath.GeoPointToPoint`