### PR TITLE
RSDK-5791: fix HW encoder failure messages on RPis

### DIFF
--- a/gostream/codec/h264/encoder.go
+++ b/gostream/codec/h264/encoder.go
@@ -56,8 +56,8 @@ func NewEncoder(width, height, keyFrameInterval int, logger golog.Logger) (codec
 		return nil, errors.New("cannot allocate video codec context")
 	}
 
-	h.context.SetEncodeParams(width, height, avcodec.PixelFormat(pixelFormat), false, 10)
-	h.context.SetTimebase(1, keyFrameInterval)
+	h.context.SetEncodeParams(width, height, avcodec.PixelFormat(pixelFormat), false, keyFrameInterval)
+	h.context.SetFramerate(keyFrameInterval)
 
 	h.reader = video.ToI420((video.ReaderFunc)(h.Read))
 

--- a/gostream/codec/h264/ffmpeg/avcodec/avcodec.go
+++ b/gostream/codec/h264/ffmpeg/avcodec/avcodec.go
@@ -82,10 +82,14 @@ func (ctxt *Context) SetEncodeParams(width, height int, pxlFmt PixelFormat, hasB
 	ctxt.pix_fmt = int32(pxlFmt)
 }
 
-// SetTimebase sets the context's time base's numerator (num) and denominator (den)
-func (ctxt *Context) SetTimebase(num, den int) {
-	ctxt.time_base.num = C.int(num)
-	ctxt.time_base.den = C.int(den)
+// SetFramerate sets the context's framerate
+func (ctxt *Context) SetFramerate(fps int) {
+	ctxt.framerate.num = C.int(fps)
+	ctxt.framerate.den = C.int(1)
+
+	// timebase should be 1/framerate
+	ctxt.time_base.num = C.int(1)
+	ctxt.time_base.den = C.int(fps)
 }
 
 // Open2 Initialize the AVCodecContext to use the given AVCodec. Prior to using this


### PR DESCRIPTION
# Description
See [RSDK-5791](https://viam.atlassian.net/browse/RSDK-5791). This PR fixes the two errors in the lines below. They appear on RPis even without a camera component.
```
Nov 16 20:29:01 viamrostwo viam-server[12190]: [h264_v4l2m2m @ 0xffff78000b70] Using device /dev/video11
Nov 16 20:29:01 viamrostwo viam-server[12190]: [h264_v4l2m2m @ 0xffff78000b70] driver 'bcm2835-codec' on card 'bcm2835-codec-encode' in mplane mode
Nov 16 20:29:01 viamrostwo viam-server[12190]: [h264_v4l2m2m @ 0xffff78000b70] requesting formats: output=YU12/yuv420p capture=H264/none
Nov 16 20:29:01 viamrostwo viam-server[12190]: [h264_v4l2m2m @ 0xffff78000b70] Failed to set timeperframeFailed to set gop size: Invalid argument
```

# Testing 
I manually tested this by running the server - you don't need to enable debug logs - and observing the output. You should still see the `h264_v4l2m2m` lines but _not_ the errors in the last line above. 

[RSDK-5791]: https://viam.atlassian.net/browse/RSDK-5791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ