### PR TITLE
RSDK-5806 Set logger.Level not just GlobalLogLevel

### DIFF
--- a/config/logging_level.go
+++ b/config/logging_level.go
@@ -28,8 +28,10 @@ func InitLoggingSettings(logger logging.Logger, cmdLineDebugFlag bool) {
 	globalLogger.cmdLineDebugFlag = cmdLineDebugFlag
 	if cmdLineDebugFlag {
 		logging.GlobalLogLevel.SetLevel(zapcore.DebugLevel)
+		logger.SetLevel(logging.DEBUG)
 	} else {
 		logging.GlobalLogLevel.SetLevel(zapcore.InfoLevel)
+		logger.SetLevel(logging.INFO)
 	}
 	globalLogger.logger.Info("Log level initialized: ", logging.GlobalLogLevel.Level())
 }


### PR DESCRIPTION
RSDK-5806

Actually calls `logger.SetLevel` in `InitLoggingSettings`.

`InitLoggingSettings`, from what I can tell, is what's called on the initial logger passed into `robotimpl.New` from the web server entrypoint to appropriately set the global log level based on the presence of `-debug` and/or "debug" in the JSON config. While this allows correct debug-level logging for most logs, the module manager [checks](https://github.com/viamrobotics/rdk/blob/main/module/modmanager/manager.go#L812) the level of _its_ passed-in logger, not the global log level, to determine if `--log-level=debug` should be passed as a CLI argument to the module process. We _could_ check `logging.GlobalLogLevel` in the module manager, but that means that tests like [`TestDebugModule`](https://github.com/viamrobotics/rdk/blob/main/module/modmanager/manager_test.go#L573) will fail, as it's expected that creating a new module manager with a debug level logger (but not setting the global logger that is global state and may interfere with other tests) will create modules with `--log-level=debug`.

Furthermore, the [initial logger](https://github.com/viamrobotics/rdk/blob/main/web/server/entrypoint.go#L68) created in the web server entrypoint is used throughout the created robot. While a global debug log level is set with `InitLoggingSettings`, and that seems to create correct debug-level logging, it's odd IMO that that logger being passed around only ever technically has info-level logging (the default).