### PR TITLE
[RSDK-5809] Remove board.ModelAttributes

### DIFF
--- a/components/board/board.go
+++ b/components/board/board.go
@@ -72,9 +72,6 @@ type Board interface {
 	// this.
 	Status(ctx context.Context, extra map[string]interface{}) (*commonpb.BoardStatus, error)
 
-	// ModelAttributes returns attributes related to the model of this board.
-	ModelAttributes() ModelAttributes
-
 	// SetPowerMode sets the board to the given power mode. If
 	// provided, the board will exit the given power mode after
 	// the specified duration.
@@ -82,13 +79,6 @@ type Board interface {
 
 	// WriteAnalog writes an analog value to a pin on the board.
 	WriteAnalog(ctx context.Context, pin string, value int32, extra map[string]interface{}) error
-}
-
-// ModelAttributes provide info related to a board model.
-type ModelAttributes struct {
-	// Remote signifies this board is accessed over a remote connection.
-	// e.g. gRPC
-	Remote bool
 }
 
 // SPI represents a shareable SPI bus on the board.

--- a/components/board/client.go
+++ b/components/board/client.go
@@ -164,10 +164,6 @@ func (c *client) status(ctx context.Context) (*commonpb.BoardStatus, error) {
 	return resp.Status, nil
 }
 
-func (c *client) ModelAttributes() ModelAttributes {
-	return ModelAttributes{Remote: true}
-}
-
 func (c *client) SetPowerMode(ctx context.Context, mode pb.PowerMode, duration *time.Duration) error {
 	var dur *durationpb.Duration
 	if duration != nil {

--- a/components/board/fake/board.go
+++ b/components/board/fake/board.go
@@ -265,11 +265,6 @@ func (b *Board) Status(ctx context.Context, extra map[string]interface{}) (*comm
 	return board.CreateStatus(ctx, b, extra)
 }
 
-// ModelAttributes returns attributes related to the model of this board.
-func (b *Board) ModelAttributes() board.ModelAttributes {
-	return board.ModelAttributes{}
-}
-
 // SetPowerMode sets the board to the given power mode. If provided,
 // the board will exit the given power mode after the specified
 // duration.

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -548,11 +548,6 @@ func (b *Board) Status(ctx context.Context, extra map[string]interface{}) (*comm
 	return board.CreateStatus(ctx, b, extra)
 }
 
-// ModelAttributes returns attributes related to the model of this board.
-func (b *Board) ModelAttributes() board.ModelAttributes {
-	return board.ModelAttributes{}
-}
-
 // SetPowerMode sets the board to the given power mode. If provided,
 // the board will exit the given power mode after the specified
 // duration.

--- a/components/board/hat/pca9685/pca9685.go
+++ b/components/board/hat/pca9685/pca9685.go
@@ -151,11 +151,6 @@ func (pca *PCA9685) parsePin(pin string) (int, error) {
 	return int(pinInt), nil
 }
 
-// ModelAttributes returns attributes related to the model of this board.
-func (pca *PCA9685) ModelAttributes() board.ModelAttributes {
-	return board.ModelAttributes{}
-}
-
 // SetPowerMode sets the board to the given power mode. If provided,
 // the board will exit the given power mode after the specified
 // duration.

--- a/components/board/numato/board.go
+++ b/components/board/numato/board.go
@@ -311,11 +311,6 @@ func (b *numatoBoard) Status(ctx context.Context, extra map[string]interface{}) 
 	return board.CreateStatus(ctx, b, extra)
 }
 
-// ModelAttributes returns attributes related to the model of this board.
-func (b *numatoBoard) ModelAttributes() board.ModelAttributes {
-	return board.ModelAttributes{}
-}
-
 func (b *numatoBoard) SetPowerMode(ctx context.Context, mode pb.PowerMode, duration *time.Duration) error {
 	return grpc.UnimplementedError
 }

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -737,10 +737,6 @@ func (pi *piPigpio) DigitalInterruptByName(name string) (board.DigitalInterrupt,
 	return d, ok
 }
 
-func (pi *piPigpio) ModelAttributes() board.ModelAttributes {
-	return board.ModelAttributes{}
-}
-
 func (pi *piPigpio) SetPowerMode(ctx context.Context, mode pb.PowerMode, duration *time.Duration) error {
 	return grpc.UnimplementedError
 }

--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -326,7 +326,6 @@ func TestStatusClient(t *testing.T) {
 	board1, err := board.FromRobot(client, "board1")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, board1, test.ShouldNotBeNil)
-	test.That(t, board1.ModelAttributes(), test.ShouldResemble, board.ModelAttributes{Remote: true})
 
 	_, err = board1.Status(context.Background(), nil)
 	test.That(t, err, test.ShouldNotBeNil)

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -881,10 +881,6 @@ func (db *dummyBoard) DigitalInterruptNames() []string {
 	return nil
 }
 
-func (db *dummyBoard) ModelAttributes() board.ModelAttributes {
-	return board.ModelAttributes{}
-}
-
 func (db *dummyBoard) Close(ctx context.Context) error {
 	db.closeCount++
 	return nil


### PR DESCRIPTION
Turns out this wasn't used anywhere except tests! Super easy to take out: we don't even need to keep it around in some separate non-board package.