### PR TITLE
RSDK-4810 integrate StopPlan and MoveOnGlobeNew with ExecutionId system

### DIFF
--- a/components/base/kinematicbase/ptgKinematics.go
+++ b/components/base/kinematicbase/ptgKinematics.go
@@ -178,11 +178,6 @@ func (ptgk *ptgBaseKinematics) GoToInputs(ctx context.Context, inputs []referenc
 				timestep,
 			)
 
-			if ctx.Err() != nil {
-				ptgk.logger.Debug(ctx.Err().Error())
-				break
-			}
-
 			err := ptgk.Base.SetVelocity(
 				ctx,
 				linVel,

--- a/components/base/kinematicbase/ptgKinematics.go
+++ b/components/base/kinematicbase/ptgKinematics.go
@@ -190,7 +190,6 @@ func (ptgk *ptgBaseKinematics) GoToInputs(ctx context.Context, inputs []referenc
 				nil,
 			)
 			if err != nil {
-				ptgk.logger.Debug(err.Error())
 				stopCtx, cancelFn := context.WithTimeout(context.Background(), time.Second*5)
 				defer cancelFn()
 				return multierr.Combine(err, ptgk.Base.Stop(stopCtx, nil))

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -3,7 +3,6 @@ package builtin
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"sync"
 
@@ -390,12 +389,6 @@ func (ms *builtIn) MoveOnGlobeNew(ctx context.Context, req motion.MoveOnGlobeReq
 	defer ms.mu.RUnlock()
 	// TODO: Deprecated: remove once no motion apis use the opid system
 	operation.CancelOtherWithLabel(ctx, builtinOpLabel)
-	mReq, err := json.Marshal(req)
-	if err != nil {
-		return "", err
-	}
-	ms.logger.Debugf("MoveOnGlobeNew called with %s", string(mReq))
-
 	planExecutorConstructor := func(
 		ctx context.Context,
 		req motion.MoveOnGlobeReq,

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -3,6 +3,7 @@ package builtin
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 
@@ -407,23 +408,18 @@ func (ms *builtIn) MoveOnGlobeNew(ctx context.Context, req motion.MoveOnGlobeReq
 	defer ms.mu.RUnlock()
 	// TODO: Deprecated: remove once no motion apis use the opid system
 	operation.CancelOtherWithLabel(ctx, builtinOpLabel)
-	t := "MoveOnGlobeNew called for component: %s, destination: %+v, heading: %f, movementSensor: %s, obstacles: %v, motionCfg: %#v, extra: %s"
-	ms.logger.Debugf(t,
-		req.ComponentName,
-		req.Destination,
-		req.Heading,
-		req.MovementSensorName,
-		req.Obstacles,
-		req.MotionCfg,
-		req.Extra,
-	)
+	mReq, err := json.Marshal(req)
+	if err != nil {
+		return "", err
+	}
+	ms.logger.Debugf("MoveOnGlobeNew called with %s", string(mReq))
 
 	planExecutorConstructor := func(
 		ctx context.Context,
 		req motion.MoveOnGlobeReq,
 		seedPlan motionplan.Plan,
 		replanCount int,
-	) (state.PlannerExecutor, error) {
+	) (state.PlanExecutor, error) {
 		return ms.newMoveOnGlobeRequest(ctx, req, seedPlan, replanCount)
 	}
 

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -399,7 +399,7 @@ func (ms *builtIn) MoveOnGlobeNew(ctx context.Context, req motion.MoveOnGlobeReq
 		return ms.newMoveOnGlobeRequest(ctx, req, seedPlan, replanCount)
 	}
 
-	id, err := state.StartExecution(ms.state, req.ComponentName, req, planExecutorConstructor)
+	id, err := state.StartExecution(ctx, ms.state, req.ComponentName, req, planExecutorConstructor)
 	if err != nil {
 		return "", err
 	}

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -464,7 +464,10 @@ func (ms *builtIn) StopPlan(
 ) error {
 	ms.mu.RLock()
 	defer ms.mu.RUnlock()
-	return ms.state.StopExecutionByResource(req.ComponentName)
+	ms.logger.Debugf("StopPlan called on component: %s", req.ComponentName)
+	res := ms.state.StopExecutionByResource(req.ComponentName)
+	ms.logger.Debugf("StopPlan res: %s", res)
+	return res
 }
 
 func (ms *builtIn) ListPlanStatuses(

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -387,6 +387,7 @@ func (ms *builtIn) MoveOnGlobe(
 func (ms *builtIn) MoveOnGlobeNew(ctx context.Context, req motion.MoveOnGlobeReq) (string, error) {
 	ms.mu.RLock()
 	defer ms.mu.RUnlock()
+	ms.logger.Debugf("MoveOnGlobeNew called with %s", req)
 	// TODO: Deprecated: remove once no motion apis use the opid system
 	operation.CancelOtherWithLabel(ctx, builtinOpLabel)
 	planExecutorConstructor := func(

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -27,8 +27,6 @@ import (
 	rdkutils "go.viam.com/rdk/utils"
 )
 
-var errUnimplemented = errors.New("unimplemented")
-
 func init() {
 	resource.RegisterDefaultService(
 		motion.API,
@@ -407,7 +405,34 @@ func (ms *builtIn) MoveOnGlobe(
 func (ms *builtIn) MoveOnGlobeNew(ctx context.Context, req motion.MoveOnGlobeReq) (string, error) {
 	ms.mu.RLock()
 	defer ms.mu.RUnlock()
-	return "", errUnimplemented
+	// TODO: Deprecated: remove once no motion apis use the opid system
+	operation.CancelOtherWithLabel(ctx, builtinOpLabel)
+	t := "MoveOnGlobeNew called for component: %s, destination: %+v, heading: %f, movementSensor: %s, obstacles: %v, motionCfg: %#v, extra: %s"
+	ms.logger.Debugf(t,
+		req.ComponentName,
+		req.Destination,
+		req.Heading,
+		req.MovementSensorName,
+		req.Obstacles,
+		req.MotionCfg,
+		req.Extra,
+	)
+
+	planExecutorConstructor := func(
+		ctx context.Context,
+		req motion.MoveOnGlobeReq,
+		seedPlan motionplan.Plan,
+		replanCount int,
+	) (state.PlannerExecutor, error) {
+		return ms.newMoveOnGlobeRequest(ctx, req, seedPlan, replanCount)
+	}
+
+	id, err := state.StartExecution(ms.state, req.ComponentName, req, planExecutorConstructor)
+	if err != nil {
+		return "", err
+	}
+
+	return id.String(), nil
 }
 
 func (ms *builtIn) GetPose(
@@ -439,7 +464,7 @@ func (ms *builtIn) StopPlan(
 ) error {
 	ms.mu.RLock()
 	defer ms.mu.RUnlock()
-	return errUnimplemented
+	return ms.state.StopExecutionByResource(req.ComponentName)
 }
 
 func (ms *builtIn) ListPlanStatuses(
@@ -448,7 +473,7 @@ func (ms *builtIn) ListPlanStatuses(
 ) ([]motion.PlanStatusWithID, error) {
 	ms.mu.RLock()
 	defer ms.mu.RUnlock()
-	return nil, errUnimplemented
+	return ms.state.ListPlanStatuses(req)
 }
 
 func (ms *builtIn) PlanHistory(
@@ -457,5 +482,5 @@ func (ms *builtIn) PlanHistory(
 ) ([]motion.PlanWithStatus, error) {
 	ms.mu.RLock()
 	defer ms.mu.RUnlock()
-	return nil, errUnimplemented
+	return ms.state.PlanHistory(req)
 }

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -464,10 +464,7 @@ func (ms *builtIn) StopPlan(
 ) error {
 	ms.mu.RLock()
 	defer ms.mu.RUnlock()
-	ms.logger.Debugf("StopPlan called on component: %s", req.ComponentName)
-	res := ms.state.StopExecutionByResource(req.ComponentName)
-	ms.logger.Debugf("StopPlan res: %s", res)
-	return res
+	return ms.state.StopExecutionByResource(req.ComponentName)
 }
 
 func (ms *builtIn) ListPlanStatuses(

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	geo "github.com/kellydunn/golang-geo"
 	"github.com/pkg/errors"
+
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	"go.viam.com/test"
@@ -569,7 +570,7 @@ func TestMoveOnMapPlans(t *testing.T) {
 		endPos, err := kb.CurrentPosition(ctx)
 		test.That(t, err, test.ShouldBeNil)
 
-		// test.That(t, spatialmath.PoseAlmostCoincidentEps(endPos.Pose(), goalInBaseFrame, 15), test.ShouldBeTrue)
+		test.That(t, spatialmath.PoseAlmostCoincidentEps(endPos.Pose(), goalInBaseFrame, 15), test.ShouldBeTrue)
 		// Position only mode should not yield the goal orientation.
 		test.That(t, spatialmath.OrientationAlmostEqualEps(
 			endPos.Pose().Orientation(),

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/google/uuid"
 	geo "github.com/kellydunn/golang-geo"
 	"github.com/pkg/errors"
-
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	"go.viam.com/test"

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -1151,7 +1151,7 @@ func TestMoveOnGlobe(t *testing.T) {
 		test.That(t, mr.planRequest.Goal.Pose().Point().X, test.ShouldAlmostEqual, expectedDst.X, epsilonMM)
 		test.That(t, mr.planRequest.Goal.Pose().Point().Y, test.ShouldAlmostEqual, expectedDst.Y, epsilonMM)
 
-		planResp, err := mr.Plan()
+		planResp, err := mr.Plan(ctx)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, len(planResp.Waypoints), test.ShouldBeGreaterThan, 2)
 
@@ -1192,7 +1192,7 @@ func TestMoveOnGlobe(t *testing.T) {
 		}
 		mr, err := ms.(*builtIn).newMoveOnGlobeRequest(ctx, req, nil, 0)
 		test.That(t, err, test.ShouldBeNil)
-		planResp, err := mr.Plan()
+		planResp, err := mr.Plan(ctx)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, len(planResp.Waypoints), test.ShouldBeGreaterThan, 2)
 
@@ -1249,7 +1249,7 @@ func TestMoveOnGlobe(t *testing.T) {
 		}
 		moveRequest, err := ms.(*builtIn).newMoveOnGlobeRequest(ctx, req, nil, 0)
 		test.That(t, err, test.ShouldBeNil)
-		planResp, err := moveRequest.Plan()
+		planResp, err := moveRequest.Plan(ctx)
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, len(planResp.Motionplan), test.ShouldEqual, 0)
 	})

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -1900,7 +1900,7 @@ func TestStopPlan(t *testing.T) {
 
 	req := motion.StopPlanReq{}
 	err := ms.StopPlan(ctx, req)
-	test.That(t, err, test.ShouldBeError, state.ErrUnknownResource)
+	test.That(t, err, test.ShouldBeError, resource.NewNotFoundError(req.ComponentName))
 }
 
 func TestListPlanStatuses(t *testing.T) {
@@ -1925,6 +1925,6 @@ func TestPlanHistory(t *testing.T) {
 	defer ms.Close(ctx)
 	req := motion.PlanHistoryReq{}
 	history, err := ms.PlanHistory(ctx, req)
-	test.That(t, err, test.ShouldEqual, state.ErrUnknownResource)
+	test.That(t, err, test.ShouldResemble, resource.NewNotFoundError(req.ComponentName))
 	test.That(t, history, test.ShouldBeNil)
 }

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/golang/geo/r3"
+	"github.com/google/uuid"
 	geo "github.com/kellydunn/golang-geo"
 	"github.com/pkg/errors"
 	// registers all components.
@@ -567,7 +568,8 @@ func TestMoveOnMapPlans(t *testing.T) {
 		test.That(t, success, test.ShouldBeTrue)
 		endPos, err := kb.CurrentPosition(ctx)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, spatialmath.PoseAlmostCoincidentEps(endPos.Pose(), goalInBaseFrame, 15), test.ShouldBeTrue)
+
+		// test.That(t, spatialmath.PoseAlmostCoincidentEps(endPos.Pose(), goalInBaseFrame, 15), test.ShouldBeTrue)
 		// Position only mode should not yield the goal orientation.
 		test.That(t, spatialmath.OrientationAlmostEqualEps(
 			endPos.Pose().Orientation(),
@@ -1861,19 +1863,44 @@ func TestMoveOnGlobeNew(t *testing.T) {
 		Destination:        dst,
 	}
 	executionID, err := ms.MoveOnGlobeNew(ctx, req)
-	test.That(t, err, test.ShouldBeError, errUnimplemented)
-	test.That(t, executionID, test.ShouldBeEmpty)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, executionID, test.ShouldNotBeEmpty)
+	// should be a valid uuid when parsed
+	_, err = uuid.Parse(executionID)
+	test.That(t, err, test.ShouldBeNil)
+
+	// returns the execution just created in the history
+	ph, err := ms.PlanHistory(ctx, motion.PlanHistoryReq{ComponentName: req.ComponentName})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, len(ph), test.ShouldEqual, 1)
+	test.That(t, ph[0].Plan.ExecutionID.String(), test.ShouldResemble, executionID)
+	test.That(t, len(ph[0].StatusHistory), test.ShouldEqual, 1)
+	test.That(t, ph[0].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateInProgress)
+	test.That(t, len(ph[0].Plan.Steps), test.ShouldNotEqual, 0)
+
+	err = ms.StopPlan(ctx, motion.StopPlanReq{ComponentName: fakeBase.Name()})
+	test.That(t, err, test.ShouldBeNil)
+
+	ph2, err := ms.PlanHistory(ctx, motion.PlanHistoryReq{ComponentName: req.ComponentName})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, len(ph2), test.ShouldEqual, 1)
+	test.That(t, ph2[0].Plan.ExecutionID.String(), test.ShouldResemble, executionID)
+	test.That(t, len(ph2[0].StatusHistory), test.ShouldEqual, 2)
+	test.That(t, ph2[0].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateStopped)
+	test.That(t, ph2[0].StatusHistory[1].State, test.ShouldEqual, motion.PlanStateInProgress)
+	test.That(t, len(ph2[0].Plan.Steps), test.ShouldNotEqual, 0)
 }
 
 func TestStopPlan(t *testing.T) {
 	ctx := context.Background()
 	gpsPoint := geo.NewPoint(0, 0)
-	_, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil, 5)
+	//nolint:dogsled
+	_, _, _, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil, 5)
 	defer ms.Close(ctx)
 
-	req := motion.StopPlanReq{ComponentName: fakeBase.Name()}
+	req := motion.StopPlanReq{}
 	err := ms.StopPlan(ctx, req)
-	test.That(t, err, test.ShouldEqual, errUnimplemented)
+	test.That(t, err, test.ShouldBeError, state.ErrUnknownResource)
 }
 
 func TestListPlanStatuses(t *testing.T) {
@@ -1884,19 +1911,20 @@ func TestListPlanStatuses(t *testing.T) {
 	defer ms.Close(ctx)
 
 	req := motion.ListPlanStatusesReq{}
+	// returns no results as no move on globe calls have been made
 	planStatusesWithIDs, err := ms.ListPlanStatuses(ctx, req)
-	test.That(t, err, test.ShouldEqual, errUnimplemented)
-	test.That(t, planStatusesWithIDs, test.ShouldBeNil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, len(planStatusesWithIDs), test.ShouldEqual, 0)
 }
 
 func TestPlanHistory(t *testing.T) {
 	ctx := context.Background()
 	gpsPoint := geo.NewPoint(0, 0)
-	_, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil, 5)
+	//nolint:dogsled
+	_, _, _, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil, 5)
 	defer ms.Close(ctx)
-
-	req := motion.PlanHistoryReq{ComponentName: fakeBase.Name()}
+	req := motion.PlanHistoryReq{}
 	history, err := ms.PlanHistory(ctx, req)
-	test.That(t, err, test.ShouldEqual, errUnimplemented)
+	test.That(t, err, test.ShouldEqual, state.ErrUnknownResource)
 	test.That(t, history, test.ShouldBeNil)
 }

--- a/services/motion/builtin/move_request.go
+++ b/services/motion/builtin/move_request.go
@@ -747,7 +747,7 @@ func toGeoPosePlanSteps(posesByComponent []map[resource.Name]spatialmath.Pose, g
 		geoPose := geoPoses[i]
 		heading := math.Mod(math.Abs(geoPose.Heading()-360), 360)
 		o := &spatialmath.OrientationVectorDegrees{OZ: 1, Theta: heading}
-		poseContainingGeoPose := spatialmath.NewPose(r3.Vector{X: geoPose.Location().Lat(), Y: geoPose.Location().Lng()}, o)
+		poseContainingGeoPose := spatialmath.NewPose(r3.Vector{X: geoPose.Location().Lng(), Y: geoPose.Location().Lat()}, o)
 		steps = append(steps, map[resource.Name]spatialmath.Pose{resourceName: poseContainingGeoPose})
 	}
 	return steps, nil

--- a/services/motion/builtin/move_request.go
+++ b/services/motion/builtin/move_request.go
@@ -669,6 +669,10 @@ func (mr moveResponse) String() string {
 }
 
 func (mr *moveRequest) start(waypoints [][]referenceframe.Input) {
+	// if Cancel has already been called, start does nothing
+	if mr.ctx.Err() != nil {
+		return
+	}
 	mr.backgroundWorkers.Add(1)
 	goutils.ManagedGo(func() {
 		mr.position.startPolling(mr.ctx, waypoints, mr.waypointIndex)

--- a/services/motion/builtin/state/state.go
+++ b/services/motion/builtin/state/state.go
@@ -112,15 +112,14 @@ func (cs componentState) lastExecutionID() motion.ExecutionID {
 // execution represents the state of a motion planning execution.
 // it only ever exists in state.StartExecution function & the go routine created.
 type execution[R any] struct {
-	id                 motion.ExecutionID
-	state              *State
-	waitGroup          *sync.WaitGroup
-	cancelCtx          context.Context
-	cancelFunc         context.CancelFunc
-	executorCancelCtx  context.Context
-	executorCancelFunc context.CancelFunc
-	logger             logging.Logger
-	// TODO: Make this generic across MoveOnGlobe & MoveOnMap
+	id                      motion.ExecutionID
+	state                   *State
+	waitGroup               *sync.WaitGroup
+	cancelCtx               context.Context
+	cancelFunc              context.CancelFunc
+	executorCancelCtx       context.Context
+	executorCancelFunc      context.CancelFunc
+	logger                  logging.Logger
 	componentName           resource.Name
 	req                     R
 	planExecutorConstructor PlanExecutorConstructor[R]

--- a/services/motion/builtin/state/state.go
+++ b/services/motion/builtin/state/state.go
@@ -4,11 +4,26 @@ package state
 
 import (
 	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"go.viam.com/utils"
 
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/motionplan"
 	"go.viam.com/rdk/referenceframe"
+	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/services/motion"
+)
+
+var (
+	// ErrUnknownResource indicates that the resource is not known.
+	ErrUnknownResource = errors.New("unknown resource")
+	// ErrNotFound indicates the entity was not found.
+	ErrNotFound = errors.New("not found")
 )
 
 // Waypoints represent the waypoints of the plan.
@@ -52,16 +67,523 @@ type PlannerExecutor interface {
 	Cancel()
 }
 
+type componentState struct {
+	executionIDHistory []motion.ExecutionID
+	executionsByID     map[motion.ExecutionID]stateExecution
+}
+
+type newPlanMsg struct {
+	plan       motion.Plan
+	planStatus motion.PlanStatus
+}
+
+type stateUpdateMsg struct {
+	componentName resource.Name
+	executionID   motion.ExecutionID
+	planID        motion.PlanID
+	planStatus    motion.PlanStatus
+}
+
+// a stateExecution is the struct held in the state that
+// holds the history of plans & plan status updates an
+// execution has exprienced & the waitGroup & cancelFunc
+// required to shut down an execution's goroutine.
+type stateExecution struct {
+	id            motion.ExecutionID
+	componentName resource.Name
+	waitGroup     *sync.WaitGroup
+	cancelFunc    context.CancelFunc
+	history       []motion.PlanWithStatus
+}
+
+func (e *stateExecution) stop() {
+	e.cancelFunc()
+	e.waitGroup.Wait()
+}
+
+func (cs componentState) lastExecution() stateExecution {
+	return cs.executionsByID[cs.lastExecutionID()]
+}
+
+func (cs componentState) lastExecutionID() motion.ExecutionID {
+	return cs.executionIDHistory[0]
+}
+
+// execution represents the state of a motion planning execution.
+// it only ever exists in state.StartExecution function & the go routine created.
+type execution[R any] struct {
+	id                 motion.ExecutionID
+	state              *State
+	waitGroup          *sync.WaitGroup
+	cancelCtx          context.Context
+	cancelFunc         context.CancelFunc
+	executorCancelCtx  context.Context
+	executorCancelFunc context.CancelFunc
+	logger             logging.Logger
+	// TODO: Make this generic across MoveOnGlobe & MoveOnMap
+	componentName           resource.Name
+	req                     R
+	planExecutorConstructor PlanExecutorConstructor[R]
+}
+
+type planWithExecutor struct {
+	plan         motion.Plan
+	planExecutor PlannerExecutor
+	waypoints    Waypoints
+	motionplan   motionplan.Plan
+}
+
+// NewPlan creates a new motion.Plan from an execution & returns an error if one was not able to be created.
+func (e *execution[R]) newPlanWithExecutor(seedPlan motionplan.Plan, replanCount int) (planWithExecutor, error) {
+	pe, err := e.planExecutorConstructor(e.executorCancelCtx, e.req, seedPlan, replanCount)
+	if err != nil {
+		return planWithExecutor{}, err
+	}
+	resp, err := pe.Plan()
+	if err != nil {
+		return planWithExecutor{}, err
+	}
+
+	plan := motion.Plan{
+		ID:            uuid.New(),
+		ExecutionID:   e.id,
+		ComponentName: e.componentName,
+		Steps:         resp.PosesByComponent,
+	}
+	return planWithExecutor{plan: plan, planExecutor: pe, waypoints: resp.Waypoints, motionplan: resp.Motionplan}, nil
+}
+
+// Start starts an execution with a given plan.
+func (e *execution[R]) start() error {
+	var replanCount int
+	originalPlanWithExecutor, err := e.newPlanWithExecutor(nil, replanCount)
+	if err != nil {
+		return err
+	}
+	e.notifyStateNewExecution(e.toStateExecution(), originalPlanWithExecutor.plan, time.Now())
+	// We need to add to both the state & execution waitgroups
+	// B/c both the state & the stateExecution need to know if this
+	// goroutine have termianted.
+	// state.Stop() needs to wait for ALL execution goroutines to terminate before
+	// returning in order to not leak.
+	// Similarly stateExecution.stop(), which is called by state.StopExecutionByResource
+	// needs to wait for its 1 execution go routine to termiante before returning.
+	// As a result, both waitgroups need to be written to.
+	e.state.waitGroup.Add(1)
+	e.waitGroup.Add(1)
+
+	utils.PanicCapturingGo(func() {
+		defer e.state.waitGroup.Done()
+		defer e.waitGroup.Done()
+
+		lastPWE := originalPlanWithExecutor
+		// Exit conditions of this loop:
+		// 1. The execution's context was cancelled, which happens if the state's Stop() was called or
+		// StopExecutionByResource was called for this resource
+		// 2. the execution succeeded
+		// 3. the execution failed
+		// 4. replanning failed
+		for {
+			resChan := make(chan struct {
+				resp ExecuteResponse
+				err  error
+			}, 1)
+			utils.PanicCapturingGo(func() {
+				replan, err := lastPWE.planExecutor.Execute(lastPWE.waypoints)
+				resChan <- struct {
+					resp ExecuteResponse
+					err  error
+				}{replan, err}
+			})
+			select {
+			case <-e.cancelCtx.Done():
+				e.notifyStatePlanStopped(lastPWE.plan, time.Now())
+				e.executorCancelFunc()
+				return
+			case res := <-resChan:
+				// failure
+				if res.err != nil {
+					e.notifyStatePlanFailed(lastPWE.plan, res.err.Error(), time.Now())
+					return
+				}
+
+				// success
+				if !res.resp.Replan {
+					e.notifyStatePlanSucceeded(lastPWE.plan, time.Now())
+					return
+				}
+
+				replanCount++
+				newPWE, err := e.newPlanWithExecutor(lastPWE.motionplan, replanCount)
+				// replan failed
+				if err != nil {
+					msg := "failed to replan for execution %s and component: %s, " +
+						"due to replan reason: %s, tried setting previous plan %s " +
+						"to failed due to error: %s\n"
+					e.logger.Warnf(msg, e.id, e.componentName, res.resp.ReplanReason, lastPWE.plan.ID, err.Error())
+
+					e.notifyStatePlanFailed(lastPWE.plan, err.Error(), time.Now())
+					return
+				}
+
+				e.logger.Debugf("updating last plan %s\n", lastPWE.plan.ID)
+				e.notifyStatePlanFailed(lastPWE.plan, res.resp.ReplanReason, time.Now())
+				e.logger.Debugf("updating new plan %s\n", newPWE.plan.ID.String())
+				e.notifyStateNewPlan(newPWE.plan, time.Now())
+				lastPWE = newPWE
+			}
+		}
+	})
+
+	return nil
+}
+
+func (e *execution[R]) toStateExecution() stateExecution {
+	return stateExecution{
+		id:            e.id,
+		componentName: e.componentName,
+		waitGroup:     e.waitGroup,
+		cancelFunc:    e.cancelFunc,
+	}
+}
+
+func (e *execution[R]) notifyStateNewExecution(execution stateExecution, plan motion.Plan, time time.Time) {
+	e.state.mu.Lock()
+	defer e.state.mu.Unlock()
+	// NOTE: We hold the lock for both updateStateNewExecution & updateStateNewPlan to ensure no readers
+	// are able to see a state where the execution exists but does not have a plan with a status.
+	e.state.updateStateNewExecution(execution)
+	e.state.updateStateNewPlan(newPlanMsg{
+		plan:       plan,
+		planStatus: motion.PlanStatus{State: motion.PlanStateInProgress, Timestamp: time},
+	})
+}
+
+func (e *execution[R]) notifyStateNewPlan(plan motion.Plan, time time.Time) {
+	e.state.mu.Lock()
+	defer e.state.mu.Unlock()
+	e.state.updateStateNewPlan(newPlanMsg{
+		plan:       plan,
+		planStatus: motion.PlanStatus{State: motion.PlanStateInProgress, Timestamp: time},
+	})
+}
+
+func (e *execution[R]) notifyStatePlanFailed(plan motion.Plan, reason string, time time.Time) {
+	e.state.mu.Lock()
+	defer e.state.mu.Unlock()
+	e.state.updateStateStatusUpdate(stateUpdateMsg{
+		componentName: e.componentName,
+		executionID:   e.id,
+		planID:        plan.ID,
+		planStatus:    motion.PlanStatus{State: motion.PlanStateFailed, Timestamp: time, Reason: &reason},
+	})
+}
+
+func (e *execution[R]) notifyStatePlanSucceeded(plan motion.Plan, time time.Time) {
+	e.state.mu.Lock()
+	defer e.state.mu.Unlock()
+	e.state.updateStateStatusUpdate(stateUpdateMsg{
+		componentName: e.componentName,
+		executionID:   e.id,
+		planID:        plan.ID,
+		planStatus:    motion.PlanStatus{State: motion.PlanStateSucceeded, Timestamp: time},
+	})
+}
+
+func (e *execution[R]) notifyStatePlanStopped(plan motion.Plan, time time.Time) {
+	e.state.mu.Lock()
+	defer e.state.mu.Unlock()
+	e.state.updateStateStatusUpdate(stateUpdateMsg{
+		componentName: e.componentName,
+		executionID:   e.id,
+		planID:        plan.ID,
+		planStatus:    motion.PlanStatus{State: motion.PlanStateStopped, Timestamp: time},
+	})
+}
+
 // State is the state of the builtin motion service
 // It keeps track of the builtin motion service's executions.
-type State struct{}
+type State struct {
+	waitGroup  *sync.WaitGroup
+	cancelCtx  context.Context
+	cancelFunc context.CancelFunc
+	logger     logging.Logger
+	// mu protects the componentStateByComponent
+	mu                        sync.RWMutex
+	componentStateByComponent map[resource.Name]componentState
+}
 
 // NewState creates a new state.
 func NewState(ctx context.Context, logger logging.Logger) *State {
-	s := State{}
+	cancelCtx, cancelFunc := context.WithCancel(ctx)
+	s := State{
+		cancelCtx:                 cancelCtx,
+		cancelFunc:                cancelFunc,
+		waitGroup:                 &sync.WaitGroup{},
+		componentStateByComponent: make(map[resource.Name]componentState),
+		logger:                    logger,
+	}
 	return &s
+}
+
+// StartExecution creates a new execution from a state.
+func StartExecution[R any](
+	s *State,
+	componentName resource.Name,
+	req R,
+	planExecutorConstructor PlanExecutorConstructor[R],
+) (motion.ExecutionID, error) {
+	if s == nil {
+		return uuid.Nil, errors.New("state is nil")
+	}
+
+	if err := s.ValidateNoActiveExecutionID(componentName); err != nil {
+		return uuid.Nil, err
+	}
+
+	// the state being cancelled should cause all executions derived from that state to also be cancelled
+	cancelCtx, cancelFunc := context.WithCancel(s.cancelCtx)
+	executorCancelCtx, executorCancelFunc := context.WithCancel(context.Background())
+	e := execution[R]{
+		id:                      uuid.New(),
+		state:                   s,
+		cancelCtx:               cancelCtx,
+		cancelFunc:              cancelFunc,
+		executorCancelCtx:       executorCancelCtx,
+		executorCancelFunc:      executorCancelFunc,
+		waitGroup:               &sync.WaitGroup{},
+		logger:                  s.logger,
+		req:                     req,
+		componentName:           componentName,
+		planExecutorConstructor: planExecutorConstructor,
+	}
+
+	if err := e.start(); err != nil {
+		return uuid.Nil, err
+	}
+
+	return e.id, nil
 }
 
 // Stop stops all executions within the State.
 func (s *State) Stop() {
+	s.cancelFunc()
+	s.waitGroup.Wait()
+}
+
+// StopExecutionByResource stops the active execution with a given resource name in the State.
+func (s *State) StopExecutionByResource(componentName resource.Name) error {
+	// Read lock held to get the execution
+	s.mu.RLock()
+	componentExectionState, exists := s.componentStateByComponent[componentName]
+
+	// return error if component name is not in StateMap
+	if !exists {
+		s.mu.RUnlock()
+		return ErrUnknownResource
+	}
+
+	e, exists := componentExectionState.executionsByID[componentExectionState.lastExecutionID()]
+	if !exists {
+		s.mu.RUnlock()
+		return ErrNotFound
+	}
+	s.mu.RUnlock()
+
+	// lock released while waiting for the execution to stop as the execution stopping requires writing to the state
+	// which must take a lock
+	e.stop()
+	return nil
+}
+
+// PlanHistory returns the plans with statuses of the resource
+// By default returns all plans from the most recent execution of the resoure
+// If the ExecutionID is provided, returns the plans of the ExecutionID rather
+// than the most recent execution
+// If LastPlanOnly is provided then only the last plan is returned for the execution
+// with the ExecutionID if it is provided, or the last execution
+// for that component otherwise.
+func (s *State) PlanHistory(req motion.PlanHistoryReq) ([]motion.PlanWithStatus, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	cs, exists := s.componentStateByComponent[req.ComponentName]
+	if !exists {
+		return nil, ErrUnknownResource
+	}
+
+	executionID := req.ExecutionID
+
+	// last plan only
+	if req.LastPlanOnly {
+		if ex := cs.lastExecution(); executionID == uuid.Nil || executionID == ex.id {
+			history := make([]motion.PlanWithStatus, 1)
+			copy(history, ex.history)
+			return history, nil
+		}
+
+		// if executionID is provided & doesn't match the last execution for the component
+		if ex, exists := cs.executionsByID[executionID]; exists {
+			history := make([]motion.PlanWithStatus, 1)
+			copy(history, ex.history)
+			return history, nil
+		}
+		return nil, ErrNotFound
+	}
+
+	// specific execution id when lastPlanOnly is NOT enabled
+	if executionID != uuid.Nil {
+		if ex, exists := cs.executionsByID[executionID]; exists {
+			history := make([]motion.PlanWithStatus, len(ex.history))
+			copy(history, ex.history)
+			return history, nil
+		}
+		return nil, ErrNotFound
+	}
+
+	ex := cs.lastExecution()
+	history := make([]motion.PlanWithStatus, len(cs.lastExecution().history))
+	copy(history, ex.history)
+	return history, nil
+}
+
+// ListPlanStatuses returns the status of plans created by MoveOnGlobe requests
+// that are executing OR are part of an execution which changed it state
+// within the a 24HR TTL OR until the robot reinitializes.
+// If OnlyActivePlans is provided, only returns plans which are in non terminal states.
+func (s *State) ListPlanStatuses(req motion.ListPlanStatusesReq) ([]motion.PlanStatusWithID, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	statuses := []motion.PlanStatusWithID{}
+	if req.OnlyActivePlans {
+		for name := range s.componentStateByComponent {
+			if e, err := s.activeExecution(name); err == nil {
+				statuses = append(statuses, motion.PlanStatusWithID{
+					ExecutionID:   e.id,
+					ComponentName: e.componentName,
+					PlanID:        e.history[0].Plan.ID,
+					Status:        e.history[0].StatusHistory[0],
+				})
+			}
+		}
+		return statuses, nil
+	}
+
+	for _, cs := range s.componentStateByComponent {
+		for _, executionID := range cs.executionIDHistory {
+			e, exists := cs.executionsByID[executionID]
+			if !exists {
+				return nil, errors.New("state is corrupted")
+			}
+			for _, pws := range e.history {
+				statuses = append(statuses, motion.PlanStatusWithID{
+					ExecutionID:   e.id,
+					ComponentName: e.componentName,
+					PlanID:        pws.Plan.ID,
+					Status:        pws.StatusHistory[0],
+				})
+			}
+		}
+	}
+
+	return statuses, nil
+}
+
+// ValidateNoActiveExecutionID returns an error if there is already an active
+// Execution for the resource name within the State.
+func (s *State) ValidateNoActiveExecutionID(name resource.Name) error {
+	if es, err := s.activeExecution(name); err == nil {
+		return fmt.Errorf("there is already an active executionID: %s", es.id)
+	}
+	return nil
+}
+
+func (s *State) updateStateNewExecution(newE stateExecution) {
+	cs, exists := s.componentStateByComponent[newE.componentName]
+
+	if exists {
+		_, exists = cs.executionsByID[newE.id]
+		if exists {
+			err := fmt.Errorf("unexpected ExecutionID already exists %s", newE.id)
+			s.logger.Error(err.Error())
+			return
+		}
+		cs.executionsByID[newE.id] = newE
+		cs.executionIDHistory = append([]motion.ExecutionID{newE.id}, cs.executionIDHistory...)
+		s.componentStateByComponent[newE.componentName] = cs
+	} else {
+		s.componentStateByComponent[newE.componentName] = componentState{
+			executionIDHistory: []motion.ExecutionID{newE.id},
+			executionsByID:     map[motion.ExecutionID]stateExecution{newE.id: newE},
+		}
+	}
+}
+
+func (s *State) updateStateNewPlan(newPlan newPlanMsg) {
+	if newPlan.planStatus.State != motion.PlanStateInProgress {
+		err := errors.New("handleNewPlan received a plan status other than in progress")
+		s.logger.Error(err.Error())
+		return
+	}
+
+	activeExecutionID := s.componentStateByComponent[newPlan.plan.ComponentName].lastExecutionID()
+	if newPlan.plan.ExecutionID != activeExecutionID {
+		e := "got new plan for inactive execution: active executionID %s, planID: %s, component: %s, plan executionID: %s"
+		err := fmt.Errorf(e, activeExecutionID, newPlan.plan.ID, newPlan.plan.ComponentName, newPlan.plan.ExecutionID)
+		s.logger.Error(err.Error())
+		return
+	}
+	execution := s.componentStateByComponent[newPlan.plan.ComponentName].executionsByID[newPlan.plan.ExecutionID]
+	pws := []motion.PlanWithStatus{{Plan: newPlan.plan, StatusHistory: []motion.PlanStatus{newPlan.planStatus}}}
+	// prepend  to executions.history so that lower indices are newer
+	execution.history = append(pws, execution.history...)
+
+	s.componentStateByComponent[newPlan.plan.ComponentName].executionsByID[newPlan.plan.ExecutionID] = execution
+}
+
+func (s *State) updateStateStatusUpdate(update stateUpdateMsg) {
+	switch update.planStatus.State {
+	// terminal states
+	case motion.PlanStateSucceeded, motion.PlanStateFailed, motion.PlanStateStopped:
+	default:
+		err := fmt.Errorf("unexpected PlanState %v in update %#v", update.planStatus.State, update)
+		s.logger.Error(err.Error())
+		return
+	}
+	componentExecutions, exists := s.componentStateByComponent[update.componentName]
+	if !exists {
+		err := errors.New("updated component doesn't exist")
+		s.logger.Error(err.Error())
+		return
+	}
+	// copy the execution
+	execution := componentExecutions.executionsByID[update.executionID]
+	lastPlanWithStatus := execution.history[0]
+	if lastPlanWithStatus.Plan.ID != update.planID {
+		err := fmt.Errorf("status update for plan %s is not for last plan: %s", update.planID, lastPlanWithStatus.Plan.ID)
+		s.logger.Error(err.Error())
+		return
+	}
+	lastPlanWithStatus.StatusHistory = append([]motion.PlanStatus{update.planStatus}, lastPlanWithStatus.StatusHistory...)
+	// write updated last plan back to history
+	execution.history[0] = lastPlanWithStatus
+	// write the execution with the new history to the component execution state copy
+	componentExecutions.executionsByID[update.executionID] = execution
+	// write the component execution state copy back to the state
+	s.componentStateByComponent[update.componentName] = componentExecutions
+}
+
+func (s *State) activeExecution(name resource.Name) (stateExecution, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if cs, exists := s.componentStateByComponent[name]; exists {
+		es := cs.lastExecution()
+
+		if _, exists := motion.TerminalStateSet[es.history[0].StatusHistory[0].State]; exists {
+			return stateExecution{}, ErrNotFound
+		}
+		return es, nil
+	}
+	return stateExecution{}, ErrUnknownResource
 }

--- a/services/motion/builtin/state/state.go
+++ b/services/motion/builtin/state/state.go
@@ -112,13 +112,11 @@ func (cs componentState) lastExecutionID() motion.ExecutionID {
 // execution represents the state of a motion planning execution.
 // it only ever exists in state.StartExecution function & the go routine created.
 type execution[R any] struct {
-	id         motion.ExecutionID
-	state      *State
-	waitGroup  *sync.WaitGroup
-	cancelCtx  context.Context
-	cancelFunc context.CancelFunc
-	// executorCancelCtx       context.Context
-	// executorCancelFunc      context.CancelFunc
+	id                      motion.ExecutionID
+	state                   *State
+	waitGroup               *sync.WaitGroup
+	cancelCtx               context.Context
+	cancelFunc              context.CancelFunc
 	logger                  logging.Logger
 	componentName           resource.Name
 	req                     R
@@ -196,9 +194,7 @@ func (e *execution[R]) start() error {
 			})
 			select {
 			case <-e.cancelCtx.Done():
-				e.logger.Debug("calling Cancel()")
 				lastPWE.planExecutor.Cancel()
-				e.logger.Debug("Cancel() returned")
 				e.notifyStatePlanStopped(lastPWE.plan, time.Now())
 				return
 			case res := <-resChan:
@@ -348,14 +344,11 @@ func StartExecution[R any](
 
 	// the state being cancelled should cause all executions derived from that state to also be cancelled
 	cancelCtx, cancelFunc := context.WithCancel(s.cancelCtx)
-	// executorCancelCtx, executorCancelFunc := context.WithCancel(context.Background())
 	e := execution[R]{
-		id:         uuid.New(),
-		state:      s,
-		cancelCtx:  cancelCtx,
-		cancelFunc: cancelFunc,
-		// executorCancelCtx:       executorCancelCtx,
-		// executorCancelFunc:      executorCancelFunc,
+		id:                      uuid.New(),
+		state:                   s,
+		cancelCtx:               cancelCtx,
+		cancelFunc:              cancelFunc,
 		waitGroup:               &sync.WaitGroup{},
 		logger:                  s.logger,
 		req:                     req,
@@ -372,7 +365,6 @@ func StartExecution[R any](
 
 // Stop stops all executions within the State.
 func (s *State) Stop() {
-	s.logger.Debug("state.Stop() called")
 	s.cancelFunc()
 	s.waitGroup.Wait()
 }

--- a/services/motion/builtin/state/state.go
+++ b/services/motion/builtin/state/state.go
@@ -206,7 +206,7 @@ func (e *execution[R]) start() error {
 					return
 				}
 
-				e.notifyStateRePlan(lastPWE.plan, resp.ReplanReason, newPWE.plan, time.Now())
+				e.notifyStateReplan(lastPWE.plan, resp.ReplanReason, newPWE.plan, time.Now())
 				lastPWE = newPWE
 			}
 		}
@@ -236,7 +236,7 @@ func (e *execution[R]) notifyStateNewExecution(execution stateExecution, plan mo
 	})
 }
 
-func (e *execution[R]) notifyStateRePlan(lastPlan motion.Plan, reason string, newPlan motion.Plan, time time.Time) {
+func (e *execution[R]) notifyStateReplan(lastPlan motion.Plan, reason string, newPlan motion.Plan, time time.Time) {
 	e.state.mu.Lock()
 	defer e.state.mu.Unlock()
 	// NOTE: We hold the lock for both updateStateNewExecution & updateStateNewPlan to ensure no readers

--- a/services/motion/builtin/state/state.go
+++ b/services/motion/builtin/state/state.go
@@ -391,7 +391,9 @@ func (s *State) StopExecutionByResource(componentName resource.Name) error {
 
 	// lock released while waiting for the execution to stop as the execution stopping requires writing to the state
 	// which must take a lock
+	s.logger.Debug("calling stop")
 	e.stop()
+	s.logger.Debug("stop returned")
 	return nil
 }
 

--- a/services/motion/builtin/state/state.go
+++ b/services/motion/builtin/state/state.go
@@ -168,7 +168,6 @@ func (e *execution[R]) start() error {
 	// As a result, both waitgroups need to be written to.
 	e.state.waitGroup.Add(1)
 	e.waitGroup.Add(1)
-
 	utils.PanicCapturingGo(func() {
 		defer e.state.waitGroup.Done()
 		defer e.waitGroup.Done()

--- a/services/motion/builtin/state/state_test.go
+++ b/services/motion/builtin/state/state_test.go
@@ -315,7 +315,7 @@ func TestState(t *testing.T) {
 		executionID1, err := state.StartExecution(s, req.ComponentName, req, executionWaitingForCtxCancelledPlanConstructor)
 		test.That(t, err, test.ShouldBeNil)
 
-		cancelCtx, cancelFn := context.WithTimeout(ctx, time.Millisecond*50)
+		cancelCtx, cancelFn := context.WithTimeout(ctx, time.Millisecond*500)
 		defer cancelFn()
 		// poll until ListPlanStatuses response has length 1
 		resPS, succ := pollUntil(cancelCtx, func() (struct {

--- a/services/motion/builtin/state/state_test.go
+++ b/services/motion/builtin/state/state_test.go
@@ -173,7 +173,7 @@ func TestState(t *testing.T) {
 		t.Parallel()
 		s := state.NewState(ctx, logger)
 		defer s.Stop()
-		_, err := state.StartExecution(s, emptyReq.ComponentName, emptyReq, successPlanConstructor)
+		_, err := state.StartExecution(ctx, s, emptyReq.ComponentName, emptyReq, successPlanConstructor)
 		test.That(t, err, test.ShouldBeNil)
 	})
 
@@ -182,37 +182,37 @@ func TestState(t *testing.T) {
 		s := state.NewState(ctx, logger)
 		defer s.Stop()
 
-		_, err := state.StartExecution(s, emptyReq.ComponentName, emptyReq, executionWaitingForCtxCancelledPlanConstructor)
+		_, err := state.StartExecution(ctx, s, emptyReq.ComponentName, emptyReq, executionWaitingForCtxCancelledPlanConstructor)
 		test.That(t, err, test.ShouldBeNil)
 
 		err = s.StopExecutionByResource(myBase)
 		test.That(t, err, test.ShouldBeNil)
 
-		_, err = state.StartExecution(s, emptyReq.ComponentName, emptyReq, successPlanConstructor)
+		_, err = state.StartExecution(ctx, s, emptyReq.ComponentName, emptyReq, successPlanConstructor)
 		test.That(t, err, test.ShouldBeNil)
 
 		err = s.StopExecutionByResource(myBase)
 		test.That(t, err, test.ShouldBeNil)
 
-		_, err = state.StartExecution(s, emptyReq.ComponentName, emptyReq, replanPlanConstructor)
+		_, err = state.StartExecution(ctx, s, emptyReq.ComponentName, emptyReq, replanPlanConstructor)
 		test.That(t, err, test.ShouldBeNil)
 
 		err = s.StopExecutionByResource(myBase)
 		test.That(t, err, test.ShouldBeNil)
 
-		_, err = state.StartExecution(s, emptyReq.ComponentName, emptyReq, failedExecutionPlanConstructor)
+		_, err = state.StartExecution(ctx, s, emptyReq.ComponentName, emptyReq, failedExecutionPlanConstructor)
 		test.That(t, err, test.ShouldBeNil)
 
 		err = s.StopExecutionByResource(myBase)
 		test.That(t, err, test.ShouldBeNil)
 
-		_, err = state.StartExecution(s, emptyReq.ComponentName, emptyReq, failedPlanningPlanConstructor)
+		_, err = state.StartExecution(ctx, s, emptyReq.ComponentName, emptyReq, failedPlanningPlanConstructor)
 		test.That(t, err, test.ShouldBeError, errors.New("planning failed"))
 
 		err = s.StopExecutionByResource(myBase)
 		test.That(t, err, test.ShouldBeNil)
 
-		_, err = state.StartExecution(s, emptyReq.ComponentName, emptyReq, failedReplanningPlanConstructor)
+		_, err = state.StartExecution(ctx, s, emptyReq.ComponentName, emptyReq, failedReplanningPlanConstructor)
 		test.That(t, err, test.ShouldBeNil)
 
 		err = s.StopExecutionByResource(myBase)
@@ -224,7 +224,7 @@ func TestState(t *testing.T) {
 		s := state.NewState(ctx, logger)
 		defer s.Stop()
 		req := motion.MoveOnGlobeReq{ComponentName: myBase}
-		_, err := state.StartExecution(s, req.ComponentName, req, executionWaitingForCtxCancelledPlanConstructor)
+		_, err := state.StartExecution(ctx, s, req.ComponentName, req, executionWaitingForCtxCancelledPlanConstructor)
 		test.That(t, err, test.ShouldBeNil)
 
 		err = s.StopExecutionByResource(myBase)
@@ -238,7 +238,7 @@ func TestState(t *testing.T) {
 		s := state.NewState(ctx, logger)
 		defer s.Stop()
 		req := motion.MoveOnGlobeReq{ComponentName: myBase}
-		_, err := state.StartExecution(s, req.ComponentName, req, executionWaitingForCtxCancelledPlanConstructor)
+		_, err := state.StartExecution(ctx, s, req.ComponentName, req, executionWaitingForCtxCancelledPlanConstructor)
 		test.That(t, err, test.ShouldBeNil)
 
 		s.Stop()
@@ -250,7 +250,7 @@ func TestState(t *testing.T) {
 		s := state.NewState(ctx, logger)
 		defer s.Stop()
 		req := motion.MoveOnGlobeReq{ComponentName: myBase}
-		_, err := state.StartExecution(s, req.ComponentName, req, executionWaitingForCtxCancelledPlanConstructor)
+		_, err := state.StartExecution(ctx, s, req.ComponentName, req, executionWaitingForCtxCancelledPlanConstructor)
 		test.That(t, err, test.ShouldBeNil)
 
 		s.Stop()
@@ -264,7 +264,7 @@ func TestState(t *testing.T) {
 		s := state.NewState(ctx, logger)
 		defer s.Stop()
 		req := motion.MoveOnGlobeReq{ComponentName: myBase}
-		_, err := state.StartExecution(s, req.ComponentName, req, executionWaitingForCtxCancelledPlanConstructor)
+		_, err := state.StartExecution(ctx, s, req.ComponentName, req, executionWaitingForCtxCancelledPlanConstructor)
 		test.That(t, err, test.ShouldBeNil)
 		req2 := motion.PlanHistoryReq{}
 		_, err = s.PlanHistory(req2)
@@ -284,7 +284,7 @@ func TestState(t *testing.T) {
 		preExecution := time.Now()
 		// Failing to plan the first time results in an error
 		req := motion.MoveOnGlobeReq{ComponentName: myBase}
-		id, err := state.StartExecution(s, req.ComponentName, req, failedPlanningPlanConstructor)
+		id, err := state.StartExecution(ctx, s, req.ComponentName, req, failedPlanningPlanConstructor)
 		test.That(t, err, test.ShouldBeError, errors.New("planning failed"))
 		test.That(t, id, test.ShouldResemble, uuid.Nil)
 
@@ -294,7 +294,7 @@ func TestState(t *testing.T) {
 		test.That(t, ps2, test.ShouldBeEmpty)
 
 		req = motion.MoveOnGlobeReq{ComponentName: myBase}
-		executionID1, err := state.StartExecution(s, req.ComponentName, req, executionWaitingForCtxCancelledPlanConstructor)
+		executionID1, err := state.StartExecution(ctx, s, req.ComponentName, req, executionWaitingForCtxCancelledPlanConstructor)
 		test.That(t, err, test.ShouldBeNil)
 
 		cancelCtx, cancelFn := context.WithTimeout(ctx, time.Millisecond*500)
@@ -329,7 +329,7 @@ func TestState(t *testing.T) {
 		test.That(t, resPS.ps[0].Status.Reason, test.ShouldBeNil)
 		test.That(t, resPS.ps[0].Status.Timestamp.After(preExecution), test.ShouldBeTrue)
 
-		id, err = state.StartExecution(s, req.ComponentName, req, replanPlanConstructor)
+		id, err = state.StartExecution(ctx, s, req.ComponentName, req, replanPlanConstructor)
 		test.That(t, err, test.ShouldBeError, fmt.Errorf("there is already an active executionID: %s", executionID1))
 		test.That(t, id, test.ShouldResemble, uuid.Nil)
 
@@ -393,7 +393,7 @@ func TestState(t *testing.T) {
 		preExecution2 := time.Now()
 		ctxReplanning, triggerReplanning := context.WithCancel(context.Background())
 		ctxExecutionSuccess, triggerExecutionSuccess := context.WithCancel(context.Background())
-		executionID2, err := state.StartExecution(s, req.ComponentName, req, func(
+		executionID2, err := state.StartExecution(ctx, s, req.ComponentName, req, func(
 			ctx context.Context,
 			req motion.MoveOnGlobeReq,
 			seedPlan motionplan.Plan,
@@ -520,7 +520,7 @@ func TestState(t *testing.T) {
 		// // Failed after replanning
 		preExecution3 := time.Now()
 		replanFailReason := errors.New("replanning failed")
-		executionID3, err := state.StartExecution(s, req.ComponentName, req, func(
+		executionID3, err := state.StartExecution(ctx, s, req.ComponentName, req, func(
 			ctx context.Context,
 			req motion.MoveOnGlobeReq,
 			seedPlan motionplan.Plan,
@@ -596,7 +596,7 @@ func TestState(t *testing.T) {
 		// Failed at the end of execution
 		preExecution4 := time.Now()
 		executionFailReason := errors.New("execution failed")
-		executionID4, err := state.StartExecution(s, req.ComponentName, req, func(
+		executionID4, err := state.StartExecution(ctx, s, req.ComponentName, req, func(
 			ctx context.Context,
 			req motion.MoveOnGlobeReq,
 			seedPlan motionplan.Plan,

--- a/services/motion/builtin/state/state_test.go
+++ b/services/motion/builtin/state/state_test.go
@@ -2,16 +2,184 @@ package state_test
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/components/base"
 	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/motionplan"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/services/motion"
 	"go.viam.com/rdk/services/motion/builtin/state"
+	"go.viam.com/rdk/spatialmath"
 )
+
+var replanReason = "replan triggered due to location drift"
+
+// testPlannerExecutor is a mock PlanExecutor implementation.
+type testPlannerExecutor struct {
+	planFunc    func() (state.PlanResponse, error)
+	executeFunc func(state.Waypoints) (state.ExecuteResponse, error)
+	cancelFunc  func()
+}
+
+// by default Plan successfully returns an empty plan.
+func (tpe *testPlannerExecutor) Plan() (state.PlanResponse, error) {
+	if tpe.planFunc != nil {
+		return tpe.planFunc()
+	}
+	return state.PlanResponse{}, nil
+}
+
+// by default Execute returns a success response.
+func (tpe *testPlannerExecutor) Execute(wp state.Waypoints) (state.ExecuteResponse, error) {
+	if tpe.executeFunc != nil {
+		return tpe.executeFunc(wp)
+	}
+	return state.ExecuteResponse{}, nil
+}
+
+// by default Cancel does nothing.
+func (tpe *testPlannerExecutor) Cancel() {
+	if tpe.planFunc != nil {
+		tpe.cancelFunc()
+	}
+}
 
 func TestState(t *testing.T) {
 	logger := logging.NewTestLogger(t)
+	myBase := base.Named("mybase")
 	t.Parallel()
 
+	executionWaitingForCtxCancelledPlanConstructor := func(
+		ctx context.Context,
+		req motion.MoveOnGlobeReq,
+		seedPlan motionplan.Plan,
+		replanCount int,
+	) (state.PlannerExecutor, error) {
+		cancelCtx, cancelFn := context.WithCancel(context.Background())
+		return &testPlannerExecutor{
+			executeFunc: func(wp state.Waypoints) (state.ExecuteResponse, error) {
+				<-cancelCtx.Done()
+				return state.ExecuteResponse{}, cancelCtx.Err()
+			},
+			cancelFunc: cancelFn,
+		}, nil
+	}
+
+	successPlanConstructor := func(
+		ctx context.Context,
+		req motion.MoveOnGlobeReq,
+		seedPlan motionplan.Plan,
+		replanCount int,
+	) (state.PlannerExecutor, error) {
+		cancelCtx, cancelFn := context.WithCancel(context.Background())
+		return &testPlannerExecutor{
+			executeFunc: func(wp state.Waypoints) (state.ExecuteResponse, error) {
+				if err := cancelCtx.Err(); err != nil {
+					return state.ExecuteResponse{}, err
+				}
+				return state.ExecuteResponse{}, nil
+			},
+			cancelFunc: cancelFn,
+		}, nil
+	}
+
+	replanPlanConstructor := func(
+		ctx context.Context,
+		req motion.MoveOnGlobeReq,
+		seedPlan motionplan.Plan,
+		replanCount int,
+	) (state.PlannerExecutor, error) {
+		cancelCtx, cancelFn := context.WithCancel(context.Background())
+		return &testPlannerExecutor{executeFunc: func(wp state.Waypoints) (state.ExecuteResponse, error) {
+			if err := cancelCtx.Err(); err != nil {
+				return state.ExecuteResponse{}, err
+			}
+			return state.ExecuteResponse{Replan: true, ReplanReason: replanReason}, nil
+		}, cancelFunc: cancelFn}, nil
+	}
+
+	failedExecutionPlanConstructor := func(
+		ctx context.Context,
+		_ motion.MoveOnGlobeReq,
+		_ motionplan.Plan,
+		_ int,
+	) (state.PlannerExecutor, error) {
+		cancelCtx, cancelFn := context.WithCancel(context.Background())
+		return &testPlannerExecutor{executeFunc: func(wp state.Waypoints) (state.ExecuteResponse, error) {
+			if err := cancelCtx.Err(); err != nil {
+				return state.ExecuteResponse{}, err
+			}
+			return state.ExecuteResponse{}, errors.New("execution failed")
+		}, cancelFunc: cancelFn}, nil
+	}
+
+	//nolint:unparam
+	failedPlanningPlanConstructor := func(
+		ctx context.Context,
+		_ motion.MoveOnGlobeReq,
+		_ motionplan.Plan,
+		_ int,
+	) (state.PlannerExecutor, error) {
+		cancelCtx, cancelFn := context.WithCancel(context.Background())
+		return &testPlannerExecutor{
+			planFunc: func() (state.PlanResponse, error) {
+				return state.PlanResponse{}, errors.New("planning failed")
+			},
+			executeFunc: func(wp state.Waypoints) (state.ExecuteResponse, error) {
+				t.Log("should not be called as planning failed")
+				t.FailNow()
+
+				if err := cancelCtx.Err(); err != nil {
+					return state.ExecuteResponse{}, err
+				}
+				return state.ExecuteResponse{Replan: true, ReplanReason: replanReason}, nil
+			},
+			cancelFunc: cancelFn,
+		}, nil
+	}
+
+	failedReplanningPlanConstructor := func(
+		ctx context.Context,
+		_ motion.MoveOnGlobeReq,
+		_ motionplan.Plan,
+		replanCount int,
+	) (state.PlannerExecutor, error) {
+		cancelCtx, cancelFn := context.WithCancel(context.Background())
+		// first replan fails during planning
+		if replanCount == 1 {
+			return &testPlannerExecutor{
+				planFunc: func() (state.PlanResponse, error) {
+					return state.PlanResponse{}, errors.New("planning failed")
+				},
+				executeFunc: func(wp state.Waypoints) (state.ExecuteResponse, error) {
+					if err := cancelCtx.Err(); err != nil {
+						return state.ExecuteResponse{}, err
+					}
+					return state.ExecuteResponse{Replan: true, ReplanReason: replanReason}, nil
+				},
+				cancelFunc: cancelFn,
+			}, nil
+		}
+		// first plan generates a plan but execution triggers a replan
+		return &testPlannerExecutor{
+			executeFunc: func(wp state.Waypoints) (state.ExecuteResponse, error) {
+				if err := ctx.Err(); err != nil {
+					return state.ExecuteResponse{}, err
+				}
+				return state.ExecuteResponse{Replan: true, ReplanReason: replanReason}, nil
+			},
+			cancelFunc: cancelFn,
+		}, nil
+	}
+
+	emptyReq := motion.MoveOnGlobeReq{ComponentName: myBase}
 	ctx := context.Background()
 
 	t.Run("creating & stopping a state with no intermediary calls", func(t *testing.T) {
@@ -19,4 +187,574 @@ func TestState(t *testing.T) {
 		s := state.NewState(ctx, logger)
 		defer s.Stop()
 	})
+
+	t.Run("starting a new execution & stopping the state", func(t *testing.T) {
+		t.Parallel()
+		s := state.NewState(ctx, logger)
+		defer s.Stop()
+		_, err := state.StartExecution(s, emptyReq.ComponentName, emptyReq, successPlanConstructor)
+		test.That(t, err, test.ShouldBeNil)
+	})
+
+	t.Run("starting & stopping an execution & stopping the state", func(t *testing.T) {
+		t.Parallel()
+		s := state.NewState(ctx, logger)
+		defer s.Stop()
+
+		_, err := state.StartExecution(s, emptyReq.ComponentName, emptyReq, executionWaitingForCtxCancelledPlanConstructor)
+		test.That(t, err, test.ShouldBeNil)
+
+		err = s.StopExecutionByResource(myBase)
+		test.That(t, err, test.ShouldBeNil)
+
+		_, err = state.StartExecution(s, emptyReq.ComponentName, emptyReq, successPlanConstructor)
+		test.That(t, err, test.ShouldBeNil)
+
+		err = s.StopExecutionByResource(myBase)
+		test.That(t, err, test.ShouldBeNil)
+
+		_, err = state.StartExecution(s, emptyReq.ComponentName, emptyReq, replanPlanConstructor)
+		test.That(t, err, test.ShouldBeNil)
+
+		err = s.StopExecutionByResource(myBase)
+		test.That(t, err, test.ShouldBeNil)
+
+		_, err = state.StartExecution(s, emptyReq.ComponentName, emptyReq, failedExecutionPlanConstructor)
+		test.That(t, err, test.ShouldBeNil)
+
+		err = s.StopExecutionByResource(myBase)
+		test.That(t, err, test.ShouldBeNil)
+
+		_, err = state.StartExecution(s, emptyReq.ComponentName, emptyReq, failedPlanningPlanConstructor)
+		test.That(t, err, test.ShouldBeError, errors.New("planning failed"))
+
+		err = s.StopExecutionByResource(myBase)
+		test.That(t, err, test.ShouldBeNil)
+
+		_, err = state.StartExecution(s, emptyReq.ComponentName, emptyReq, failedReplanningPlanConstructor)
+		test.That(t, err, test.ShouldBeNil)
+
+		err = s.StopExecutionByResource(myBase)
+		test.That(t, err, test.ShouldBeNil)
+	})
+
+	t.Run("stopping an execution is idempotnet", func(t *testing.T) {
+		t.Parallel()
+		s := state.NewState(ctx, logger)
+		defer s.Stop()
+		req := motion.MoveOnGlobeReq{ComponentName: myBase}
+		_, err := state.StartExecution(s, req.ComponentName, req, executionWaitingForCtxCancelledPlanConstructor)
+		test.That(t, err, test.ShouldBeNil)
+
+		err = s.StopExecutionByResource(myBase)
+		test.That(t, err, test.ShouldBeNil)
+		err = s.StopExecutionByResource(myBase)
+		test.That(t, err, test.ShouldBeNil)
+	})
+
+	t.Run("stopping the state is idempotnet", func(t *testing.T) {
+		t.Parallel()
+		s := state.NewState(ctx, logger)
+		defer s.Stop()
+		req := motion.MoveOnGlobeReq{ComponentName: myBase}
+		_, err := state.StartExecution(s, req.ComponentName, req, executionWaitingForCtxCancelledPlanConstructor)
+		test.That(t, err, test.ShouldBeNil)
+
+		s.Stop()
+		s.Stop()
+	})
+
+	t.Run("stopping an execution after stopping the state", func(t *testing.T) {
+		t.Parallel()
+		s := state.NewState(ctx, logger)
+		defer s.Stop()
+		req := motion.MoveOnGlobeReq{ComponentName: myBase}
+		_, err := state.StartExecution(s, req.ComponentName, req, executionWaitingForCtxCancelledPlanConstructor)
+		test.That(t, err, test.ShouldBeNil)
+
+		s.Stop()
+
+		err = s.StopExecutionByResource(myBase)
+		test.That(t, err, test.ShouldBeNil)
+	})
+
+	t.Run("querying for an unknown resource returns an unknown resource error", func(t *testing.T) {
+		t.Parallel()
+		s := state.NewState(ctx, logger)
+		defer s.Stop()
+		req := motion.MoveOnGlobeReq{ComponentName: myBase}
+		_, err := state.StartExecution(s, req.ComponentName, req, executionWaitingForCtxCancelledPlanConstructor)
+		test.That(t, err, test.ShouldBeNil)
+		_, err = s.PlanHistory(motion.PlanHistoryReq{})
+		test.That(t, err, test.ShouldBeError, state.ErrUnknownResource)
+	})
+
+	t.Run("end to end test", func(t *testing.T) {
+		t.Parallel()
+		s := state.NewState(ctx, logger)
+		defer s.Stop()
+
+		// no plan statuses as no executions have been created
+		ps, err := s.ListPlanStatuses(motion.ListPlanStatusesReq{})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, ps, test.ShouldBeEmpty)
+
+		preExecution := time.Now()
+		// Failing to plan the first time results in an error
+		req := motion.MoveOnGlobeReq{ComponentName: myBase}
+		id, err := state.StartExecution(s, req.ComponentName, req, failedPlanningPlanConstructor)
+		test.That(t, err, test.ShouldBeError, errors.New("planning failed"))
+		test.That(t, id, test.ShouldResemble, uuid.Nil)
+
+		// still no plan statuses as no executions have been created
+		ps2, err := s.ListPlanStatuses(motion.ListPlanStatusesReq{})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, ps2, test.ShouldBeEmpty)
+
+		req = motion.MoveOnGlobeReq{ComponentName: myBase}
+		executionID1, err := state.StartExecution(s, req.ComponentName, req, executionWaitingForCtxCancelledPlanConstructor)
+		test.That(t, err, test.ShouldBeNil)
+
+		cancelCtx, cancelFn := context.WithTimeout(ctx, time.Millisecond*50)
+		defer cancelFn()
+		// poll until ListPlanStatuses response has length 1
+		resPS, succ := pollUntil(cancelCtx, func() (struct {
+			ps  []motion.PlanStatusWithID
+			err error
+		}, bool,
+		) {
+			st := struct {
+				ps  []motion.PlanStatusWithID
+				err error
+			}{}
+			ps, err := s.ListPlanStatuses(motion.ListPlanStatusesReq{})
+			if err == nil && len(ps) == 1 {
+				st.ps = ps
+				st.err = err
+				return st, true
+			}
+			return st, false
+		})
+
+		test.That(t, succ, test.ShouldBeTrue)
+		test.That(t, resPS.err, test.ShouldBeNil)
+		// we now have a single plan status as an execution has been created
+		test.That(t, len(resPS.ps), test.ShouldEqual, 1)
+		test.That(t, resPS.ps[0].ExecutionID, test.ShouldResemble, executionID1)
+		test.That(t, resPS.ps[0].ComponentName, test.ShouldResemble, req.ComponentName)
+		test.That(t, resPS.ps[0].PlanID, test.ShouldNotEqual, uuid.Nil)
+		test.That(t, resPS.ps[0].Status.State, test.ShouldEqual, motion.PlanStateInProgress)
+		test.That(t, resPS.ps[0].Status.Reason, test.ShouldBeNil)
+		test.That(t, resPS.ps[0].Status.Timestamp.After(preExecution), test.ShouldBeTrue)
+
+		id, err = state.StartExecution(s, req.ComponentName, req, replanPlanConstructor)
+		test.That(t, err, test.ShouldBeError, fmt.Errorf("there is already an active executionID: %s", executionID1))
+		test.That(t, id, test.ShouldResemble, uuid.Nil)
+
+		// Returns results if active plans are requested & there are active plans
+		ps4, err := s.ListPlanStatuses(motion.ListPlanStatusesReq{OnlyActivePlans: true})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, ps4, test.ShouldResemble, resPS.ps)
+
+		// We see that the component has an excution with a single plan & that plan
+		// is in progress & has had no other statuses.
+		pws, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(pws), test.ShouldEqual, 1)
+		// plan id is the same as it was in the list status response
+		test.That(t, pws[0].Plan.ID, test.ShouldResemble, resPS.ps[0].PlanID)
+		test.That(t, pws[0].Plan.ExecutionID, test.ShouldEqual, executionID1)
+		test.That(t, pws[0].Plan.ComponentName, test.ShouldResemble, myBase)
+		test.That(t, len(pws[0].StatusHistory), test.ShouldEqual, 1)
+		test.That(t, pws[0].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateInProgress)
+		test.That(t, pws[0].StatusHistory[0].Reason, test.ShouldEqual, nil)
+		test.That(t, pws[0].StatusHistory[0].Timestamp.After(preExecution), test.ShouldBeTrue)
+		test.That(t, planStatusTimestampsInOrder(pws[0].StatusHistory), test.ShouldBeTrue)
+
+		preStop := time.Now()
+		// stop the in progress execution
+		err = s.StopExecutionByResource(myBase)
+		test.That(t, err, test.ShouldBeNil)
+
+		ps5, err := s.ListPlanStatuses(motion.ListPlanStatusesReq{})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(ps5), test.ShouldEqual, 1)
+		test.That(t, ps5[0].ExecutionID, test.ShouldResemble, executionID1)
+		test.That(t, ps5[0].ComponentName, test.ShouldResemble, req.ComponentName)
+		test.That(t, ps5[0].PlanID, test.ShouldNotEqual, uuid.Nil)
+		// status now shows that the plan is stopped
+		test.That(t, ps5[0].Status.State, test.ShouldEqual, motion.PlanStateStopped)
+		test.That(t, ps5[0].Status.Reason, test.ShouldBeNil)
+		test.That(t, ps5[0].Status.Timestamp.After(preStop), test.ShouldBeTrue)
+
+		// Returns no results if active plans are requested & there are no active plans
+		ps6, err := s.ListPlanStatuses(motion.ListPlanStatusesReq{OnlyActivePlans: true})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, ps6, test.ShouldBeEmpty)
+
+		// We after stoping execution of the base that the same execution has the same
+		// plan, but that that plan's status is now stoped.
+		// The prior status is still in the status history.
+		pws2, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase})
+		test.That(t, err, test.ShouldBeNil)
+
+		test.That(t, len(pws2), test.ShouldEqual, 1)
+		test.That(t, pws2[0].Plan, test.ShouldResemble, pws[0].Plan)
+		test.That(t, len(pws2[0].StatusHistory), test.ShouldEqual, 2)
+		// previous in progres PlanStatus is now at a higher index
+		test.That(t, pws2[0].StatusHistory[1], test.ShouldResemble, pws[0].StatusHistory[0])
+		// most recent PlanStatus is now that it is stopped
+		test.That(t, pws2[0].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateStopped)
+		test.That(t, pws2[0].StatusHistory[0].Reason, test.ShouldEqual, nil)
+		test.That(t, planStatusTimestampsInOrder(pws2[0].StatusHistory), test.ShouldBeTrue)
+
+		preExecution2 := time.Now()
+		ctxReplanning, triggerReplanning := context.WithCancel(context.Background())
+		ctxExecutionSuccess, triggerExecutionSuccess := context.WithCancel(context.Background())
+		executionID2, err := state.StartExecution(s, req.ComponentName, req, func(
+			ctx context.Context,
+			req motion.MoveOnGlobeReq,
+			seedPlan motionplan.Plan,
+			replanCount int,
+		) (state.PlannerExecutor, error) {
+			return &testPlannerExecutor{
+				executeFunc: func(wp state.Waypoints) (state.ExecuteResponse, error) {
+					if replanCount == 0 {
+						// wait for replanning
+						<-ctxReplanning.Done()
+						return state.ExecuteResponse{Replan: true, ReplanReason: replanReason}, nil
+					}
+					<-ctxExecutionSuccess.Done()
+					return state.ExecuteResponse{}, nil
+				},
+			}, nil
+		})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, executionID2, test.ShouldNotResemble, executionID1)
+
+		// We see after starting a new execution that the old execution is no longer returned and that a new plan has been generated
+		pws4, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(pws4), test.ShouldEqual, 1)
+		test.That(t, pws4[0].Plan.ID, test.ShouldNotResemble, pws2[0].Plan.ID)
+		test.That(t, pws4[0].Plan.ExecutionID, test.ShouldNotResemble, pws2[0].Plan.ExecutionID)
+		test.That(t, len(pws4[0].StatusHistory), test.ShouldEqual, 1)
+		test.That(t, pws4[0].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateInProgress)
+		test.That(t, pws4[0].StatusHistory[0].Reason, test.ShouldEqual, nil)
+		test.That(t, pws4[0].StatusHistory[0].Timestamp.After(preExecution2), test.ShouldBeTrue)
+		test.That(t, planStatusTimestampsInOrder(pws4[0].StatusHistory), test.ShouldBeTrue)
+
+		// trigger replanning once
+		execution2Replan1 := time.Now()
+		triggerReplanning()
+
+		// poll until there are 2 plans in the history
+		resPWS, succ := pollUntil(cancelCtx, func() (pwsRes, bool,
+		) {
+			st := pwsRes{}
+			pws, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase})
+			if err == nil && len(pws) == 2 {
+				st.pws = pws
+				st.err = err
+				return st, true
+			}
+			return st, false
+		})
+
+		test.That(t, succ, test.ShouldBeTrue)
+		test.That(t, resPWS.err, test.ShouldBeNil)
+		test.That(t, len(resPWS.pws), test.ShouldEqual, 2)
+		// Previous plan is moved to higher index
+		test.That(t, resPWS.pws[1].Plan, test.ShouldResemble, pws4[0].Plan)
+		// Current plan is a new plan
+		test.That(t, resPWS.pws[0].Plan.ID, test.ShouldNotResemble, pws4[0].Plan.ID)
+		// From the same execution (definition of a replan)
+		test.That(t, resPWS.pws[0].Plan.ExecutionID, test.ShouldResemble, pws4[0].Plan.ExecutionID)
+		// new current plan has an in progress status & was created after triggering replanning
+		test.That(t, len(resPWS.pws[0].StatusHistory), test.ShouldEqual, 1)
+		test.That(t, resPWS.pws[0].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateInProgress)
+		test.That(t, resPWS.pws[0].StatusHistory[0].Reason, test.ShouldEqual, nil)
+		test.That(t, resPWS.pws[0].StatusHistory[0].Timestamp.After(execution2Replan1), test.ShouldBeTrue)
+		// previous plan was moved to failed state due to replanning after replanning was triggered
+		test.That(t, len(resPWS.pws[1].StatusHistory), test.ShouldEqual, 2)
+		// oldest satus of previous plan is unchanged, just at a higher index
+		test.That(t, resPWS.pws[1].StatusHistory[1], test.ShouldResemble, pws4[0].StatusHistory[0])
+		// last status of the previous plan is failed due to replanning & occurred after replanning was triggered
+		test.That(t, resPWS.pws[1].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateFailed)
+		test.That(t, resPWS.pws[1].StatusHistory[0].Reason, test.ShouldNotBeNil)
+		test.That(t, *resPWS.pws[1].StatusHistory[0].Reason, test.ShouldResemble, replanReason)
+		test.That(t, resPWS.pws[1].StatusHistory[0].Timestamp.After(execution2Replan1), test.ShouldBeTrue)
+		test.That(t, planStatusTimestampsInOrder(resPWS.pws[0].StatusHistory), test.ShouldBeTrue)
+		test.That(t, planStatusTimestampsInOrder(resPWS.pws[1].StatusHistory), test.ShouldBeTrue)
+
+		// only the last plan is returned if LastPlanOnly is true
+		pws6, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase, LastPlanOnly: true})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(pws6), test.ShouldEqual, 1)
+		test.That(t, pws6[0], test.ShouldResemble, resPWS.pws[0])
+
+		// only the last plan is returned if LastPlanOnly is true
+		// and the execution id is provided which matches the last execution for the component
+		pws7, err := s.PlanHistory(motion.PlanHistoryReq{
+			ComponentName: myBase,
+			LastPlanOnly:  true,
+			ExecutionID:   pws6[0].Plan.ExecutionID,
+		})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, pws7, test.ShouldResemble, pws6)
+
+		// Succeeded status
+		preSuccessMsg := time.Now()
+		triggerExecutionSuccess()
+
+		resPWS2, succ := pollUntil(cancelCtx, func() (pwsRes, bool,
+		) {
+			st := pwsRes{}
+			pws, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase})
+			if err == nil && len(pws[0].StatusHistory) == 2 {
+				st.pws = pws
+				st.err = err
+				return st, true
+			}
+			return st, false
+		})
+		//
+		test.That(t, succ, test.ShouldBeTrue)
+		test.That(t, resPWS2.err, test.ShouldBeNil)
+		test.That(t, len(resPWS2.pws), test.ShouldEqual, 2)
+		// last plan is unchanged
+		test.That(t, resPWS2.pws[1], test.ShouldResemble, resPWS.pws[1])
+		// current plan is the same as it was before
+		test.That(t, resPWS2.pws[0].Plan, test.ShouldResemble, pws6[0].Plan)
+		// current plan now has a new status
+		test.That(t, len(resPWS2.pws[0].StatusHistory), test.ShouldEqual, 2)
+		test.That(t, resPWS2.pws[0].StatusHistory[1], test.ShouldResemble, pws6[0].StatusHistory[0])
+		// new status is succeeded
+		test.That(t, resPWS2.pws[0].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateSucceeded)
+		test.That(t, resPWS2.pws[0].StatusHistory[0].Reason, test.ShouldBeNil)
+		test.That(t, resPWS2.pws[0].StatusHistory[0].Timestamp.After(preSuccessMsg), test.ShouldBeTrue)
+		test.That(t, planStatusTimestampsInOrder(resPWS2.pws[0].StatusHistory), test.ShouldBeTrue)
+
+		// // Failed after replanning
+		preExecution3 := time.Now()
+		replanFailReason := errors.New("replanning failed")
+		executionID3, err := state.StartExecution(s, req.ComponentName, req, func(
+			ctx context.Context,
+			req motion.MoveOnGlobeReq,
+			seedPlan motionplan.Plan,
+			replanCount int,
+		) (state.PlannerExecutor, error) {
+			return &testPlannerExecutor{
+				planFunc: func() (state.PlanResponse, error) {
+					// first plan succeeds
+					if replanCount == 0 {
+						pbc := map[resource.Name]spatialmath.Pose{req.ComponentName: spatialmath.NewZeroPose()}
+						return state.PlanResponse{PosesByComponent: []motion.PlanStep{pbc}}, nil
+					}
+					// first replan succeeds
+					if replanCount == 1 {
+						pbc1 := map[resource.Name]spatialmath.Pose{req.ComponentName: spatialmath.NewZeroPose()}
+						pbc2 := map[resource.Name]spatialmath.Pose{req.ComponentName: spatialmath.NewZeroPose()}
+						return state.PlanResponse{PosesByComponent: []motion.PlanStep{pbc1, pbc2}}, nil
+					}
+					// second replan fails
+					return state.PlanResponse{}, replanFailReason
+				},
+				executeFunc: func(wp state.Waypoints) (state.ExecuteResponse, error) {
+					if replanCount == 0 {
+						return state.ExecuteResponse{Replan: true, ReplanReason: replanReason}, nil
+					}
+					if replanCount == 1 {
+						return state.ExecuteResponse{Replan: true, ReplanReason: replanReason}, nil
+					}
+					t.Log("shouldn't execute as first replanning fails")
+					t.FailNow()
+					return state.ExecuteResponse{}, nil
+				},
+			}, nil
+		})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, executionID2, test.ShouldNotResemble, executionID1)
+
+		resPWS3, succ := pollUntil(cancelCtx, func() (pwsRes, bool,
+		) {
+			st := pwsRes{}
+			pws, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase})
+			if err == nil && len(pws) == 2 && len(pws[0].StatusHistory) == 2 {
+				st.pws = pws
+				st.err = err
+				return st, true
+			}
+			return st, false
+		})
+
+		test.That(t, succ, test.ShouldBeTrue)
+		test.That(t, resPWS3.err, test.ShouldBeNil)
+
+		test.That(t, len(resPWS3.pws), test.ShouldEqual, 2)
+		test.That(t, resPWS3.pws[0].Plan.ExecutionID, test.ShouldEqual, executionID3)
+		test.That(t, resPWS3.pws[1].Plan.ExecutionID, test.ShouldEqual, executionID3)
+		test.That(t, resPWS3.pws[0].Plan.ID, test.ShouldNotEqual, resPWS2.pws[1].Plan.ID)
+		test.That(t, len(resPWS3.pws[1].StatusHistory), test.ShouldEqual, 2)
+		test.That(t, resPWS3.pws[1].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateFailed)
+		test.That(t, *resPWS3.pws[1].StatusHistory[0].Reason, test.ShouldResemble, replanReason)
+		test.That(t, resPWS3.pws[1].StatusHistory[1].State, test.ShouldEqual, motion.PlanStateInProgress)
+		test.That(t, resPWS3.pws[1].StatusHistory[1].Reason, test.ShouldBeNil)
+		test.That(t, resPWS3.pws[1].StatusHistory[1].Timestamp.After(preExecution3), test.ShouldBeTrue)
+		test.That(t, len(resPWS3.pws[0].StatusHistory), test.ShouldEqual, 2)
+		test.That(t, resPWS3.pws[0].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateFailed)
+		test.That(t, *resPWS3.pws[0].StatusHistory[0].Reason, test.ShouldResemble, replanFailReason.Error())
+		test.That(t, resPWS3.pws[0].StatusHistory[1].State, test.ShouldEqual, motion.PlanStateInProgress)
+		test.That(t, resPWS3.pws[0].StatusHistory[1].Reason, test.ShouldBeNil)
+		test.That(t, len(resPWS3.pws[0].Plan.Steps), test.ShouldEqual, 2)
+		test.That(t, len(resPWS3.pws[1].Plan.Steps), test.ShouldEqual, 1)
+		test.That(t, planStatusTimestampsInOrder(resPWS3.pws[0].StatusHistory), test.ShouldBeTrue)
+		test.That(t, planStatusTimestampsInOrder(resPWS3.pws[1].StatusHistory), test.ShouldBeTrue)
+
+		// Failed at the end of execution
+		preExecution4 := time.Now()
+		executionFailReason := errors.New("execution failed")
+		executionID4, err := state.StartExecution(s, req.ComponentName, req, func(
+			ctx context.Context,
+			req motion.MoveOnGlobeReq,
+			seedPlan motionplan.Plan,
+			replanCount int,
+		) (state.PlannerExecutor, error) {
+			return &testPlannerExecutor{
+				executeFunc: func(wp state.Waypoints) (state.ExecuteResponse, error) {
+					if replanCount == 0 {
+						return state.ExecuteResponse{Replan: true, ReplanReason: replanReason}, nil
+					}
+					return state.ExecuteResponse{}, executionFailReason
+				},
+			}, nil
+		})
+		test.That(t, err, test.ShouldBeNil)
+
+		resPWS4, succ := pollUntil(cancelCtx, func() (pwsRes, bool,
+		) {
+			st := pwsRes{}
+			pws, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase})
+			if err == nil && len(pws) == 2 && len(pws[0].StatusHistory) == 2 {
+				st.pws = pws
+				st.err = err
+				return st, true
+			}
+			return st, false
+		})
+
+		test.That(t, succ, test.ShouldBeTrue)
+		test.That(t, resPWS4.err, test.ShouldBeNil)
+
+		test.That(t, len(resPWS4.pws), test.ShouldEqual, 2)
+		test.That(t, resPWS4.pws[0].Plan.ExecutionID, test.ShouldEqual, executionID4)
+		test.That(t, resPWS4.pws[1].Plan.ExecutionID, test.ShouldEqual, executionID4)
+		test.That(t, resPWS4.pws[0].Plan.ID, test.ShouldNotEqual, resPWS3.pws[1].Plan.ID)
+		test.That(t, len(resPWS4.pws[1].StatusHistory), test.ShouldEqual, 2)
+		test.That(t, resPWS4.pws[1].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateFailed)
+		test.That(t, *resPWS4.pws[1].StatusHistory[0].Reason, test.ShouldResemble, replanReason)
+		test.That(t, resPWS4.pws[1].StatusHistory[1].State, test.ShouldEqual, motion.PlanStateInProgress)
+		test.That(t, resPWS4.pws[1].StatusHistory[1].Reason, test.ShouldBeNil)
+		test.That(t, resPWS4.pws[1].StatusHistory[1].Timestamp.After(preExecution4), test.ShouldBeTrue)
+		test.That(t, len(resPWS4.pws[0].StatusHistory), test.ShouldEqual, 2)
+		test.That(t, resPWS4.pws[0].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateFailed)
+		test.That(t, *resPWS4.pws[0].StatusHistory[0].Reason, test.ShouldResemble, executionFailReason.Error())
+		test.That(t, resPWS4.pws[0].StatusHistory[1].State, test.ShouldEqual, motion.PlanStateInProgress)
+		test.That(t, resPWS4.pws[0].StatusHistory[1].Reason, test.ShouldBeNil)
+
+		// providing an executionID lets you look up the plans from a prior execution
+		pws12, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase, ExecutionID: executionID3})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, pws12, test.ShouldResemble, resPWS3.pws)
+
+		// providing an executionID with lastPlanOnly gives you the last plan of that execution
+		pws13, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase, ExecutionID: executionID3, LastPlanOnly: true})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(pws13), test.ShouldEqual, 1)
+		test.That(t, pws13[0], test.ShouldResemble, resPWS3.pws[0])
+
+		// providing an executionID which is not known to the state returns an error
+		pws14, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase, ExecutionID: uuid.New()})
+		test.That(t, err, test.ShouldBeError, state.ErrNotFound)
+		test.That(t, len(pws14), test.ShouldEqual, 0)
+
+		// Returns the last status of all plans that have executed
+		ps7, err := s.ListPlanStatuses(motion.ListPlanStatusesReq{})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(ps7), test.ShouldEqual, 7)
+		test.That(t, ps7[0].ComponentName, test.ShouldResemble, myBase)
+		test.That(t, ps7[0].ExecutionID, test.ShouldResemble, executionID4)
+		test.That(t, ps7[0].PlanID, test.ShouldResemble, resPWS4.pws[0].Plan.ID)
+		test.That(t, ps7[0].Status, test.ShouldResemble, resPWS4.pws[0].StatusHistory[0])
+
+		test.That(t, ps7[1].ComponentName, test.ShouldResemble, myBase)
+		test.That(t, ps7[1].ExecutionID, test.ShouldResemble, executionID4)
+		test.That(t, ps7[1].PlanID, test.ShouldResemble, resPWS4.pws[1].Plan.ID)
+		test.That(t, ps7[1].Status, test.ShouldResemble, resPWS4.pws[1].StatusHistory[0])
+
+		test.That(t, ps7[2].ComponentName, test.ShouldResemble, myBase)
+		test.That(t, ps7[2].ExecutionID, test.ShouldResemble, executionID3)
+		test.That(t, ps7[2].PlanID, test.ShouldResemble, resPWS3.pws[0].Plan.ID)
+		test.That(t, ps7[2].Status, test.ShouldResemble, resPWS3.pws[0].StatusHistory[0])
+
+		test.That(t, ps7[3].ComponentName, test.ShouldResemble, myBase)
+		test.That(t, ps7[3].ExecutionID, test.ShouldResemble, executionID3)
+		test.That(t, ps7[3].PlanID, test.ShouldResemble, resPWS3.pws[1].Plan.ID)
+		test.That(t, ps7[3].Status, test.ShouldResemble, resPWS3.pws[1].StatusHistory[0])
+
+		test.That(t, ps7[4].ComponentName, test.ShouldResemble, myBase)
+		test.That(t, ps7[4].ExecutionID, test.ShouldResemble, executionID2)
+		test.That(t, ps7[4].PlanID, test.ShouldResemble, resPWS2.pws[0].Plan.ID)
+		test.That(t, ps7[4].Status, test.ShouldResemble, resPWS2.pws[0].StatusHistory[0])
+
+		test.That(t, ps7[5].ComponentName, test.ShouldResemble, myBase)
+		test.That(t, ps7[5].ExecutionID, test.ShouldResemble, executionID2)
+		test.That(t, ps7[5].PlanID, test.ShouldResemble, resPWS2.pws[1].Plan.ID)
+		test.That(t, ps7[5].Status, test.ShouldResemble, resPWS2.pws[1].StatusHistory[0])
+
+		test.That(t, ps7[6].ComponentName, test.ShouldResemble, myBase)
+		test.That(t, ps7[6].ExecutionID, test.ShouldResemble, executionID1)
+		test.That(t, ps7[6].PlanID, test.ShouldResemble, pws2[0].Plan.ID)
+		test.That(t, ps7[6].Status, test.ShouldResemble, pws2[0].StatusHistory[0])
+
+		ps8, err := s.ListPlanStatuses(motion.ListPlanStatusesReq{OnlyActivePlans: true})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, ps8, test.ShouldBeEmpty)
+	})
+}
+
+func planStatusTimestampsInOrder(ps []motion.PlanStatus) bool {
+	if len(ps) == 0 {
+		return true
+	}
+	last := ps[0].Timestamp
+	for _, p := range ps[1:] {
+		if p.Timestamp.Equal(last) || p.Timestamp.After(last) {
+			return false
+		}
+	}
+	return true
+}
+
+type pwsRes struct {
+	pws []motion.PlanWithStatus
+	err error
+}
+
+// pollUntil polls the funcion f returns a type T and a success boolean
+// pollUntil returns when either the ctx is cancelled or f returns success = true.
+// this is needed so the tests can wait until the state has been updated with the results
+// of the PlanExecutor interface methods.
+func pollUntil[T any](ctx context.Context, f func() (T, bool)) (T, bool) {
+	t, b := f()
+	for {
+		if err := ctx.Err(); err != nil {
+			return t, b
+		}
+
+		t, b = f()
+		if b {
+			return t, b
+		}
+	}
 }

--- a/services/motion/builtin/state/verify_main_test.go
+++ b/services/motion/builtin/state/verify_main_test.go
@@ -1,0 +1,12 @@
+package state
+
+import (
+	"testing"
+
+	testutilsext "go.viam.com/utils/testutils/ext"
+)
+
+// TestMain is used to control the execution of all tests run within this package (including _test packages).
+func TestMain(m *testing.M) {
+	testutilsext.VerifyTestMain(m)
+}

--- a/services/motion/motion.go
+++ b/services/motion/motion.go
@@ -3,6 +3,7 @@ package motion
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -49,6 +50,20 @@ type MoveOnGlobeReq struct {
 	Obstacles          []*spatialmath.GeoObstacle
 	MotionCfg          *MotionConfiguration
 	Extra              map[string]interface{}
+}
+
+func (r MoveOnGlobeReq) String() string {
+	template := "motion.MoveOnGlobeReq{ComponentName: %s, " +
+		"Destination: %+v, Heading: %f, MovementSensorName: %s, " +
+		"Obstacles: %v, MotionCfg: %#v, Extra: %s}"
+	return fmt.Sprintf(template,
+		r.ComponentName,
+		r.Destination,
+		r.Heading,
+		r.MovementSensorName,
+		r.Obstacles,
+		r.MotionCfg,
+		r.Extra)
 }
 
 // MoveOnMapReq describes a request to MoveOnMap.

--- a/services/motion/motion_test.go
+++ b/services/motion/motion_test.go
@@ -991,6 +991,30 @@ func TestConfiguration(t *testing.T) {
 func TestMoveOnGlobeReq(t *testing.T) {
 	name := "somename"
 	dst := geo.NewPoint(1, 2)
+
+	t.Run("String()", func(t *testing.T) {
+		s := "motion.MoveOnGlobeReq{ComponentName: " +
+			"rdk:component:base/my-base, Destination: " +
+			"&{lat:1 lng:2}, Heading: 0.500000, MovementSensorName: " +
+			"rdk:component:movement_sensor/my-movementsensor, " +
+			"Obstacles: [], MotionCfg: &motion.MotionConfiguration{" +
+			"ObstacleDetectors:[]motion.ObstacleDetectorName{" +
+			"motion.ObstacleDetectorName{VisionServiceName:resource.Name{" +
+			"API:resource.API{Type:resource.APIType{Namespace:\"rdk\", Name:\"service\"}, " +
+			"SubtypeName:\"vision\"}, Remote:\"\", Name:\"vision service 1\"}, " +
+			"CameraName:resource.Name{API:resource.API{Type:resource.APIType{" +
+			"Namespace:\"rdk\", Name:\"component\"}, SubtypeName:\"camera\"}, " +
+			"Remote:\"\", Name:\"camera 1\"}}, motion.ObstacleDetectorName{" +
+			"VisionServiceName:resource.Name{API:resource.API{Type:resource.APIType{" +
+			"Namespace:\"rdk\", Name:\"service\"}, SubtypeName:\"vision\"}, " +
+			"Remote:\"\", Name:\"vision service 2\"}, CameraName:resource.Name{" +
+			"API:resource.API{Type:resource.APIType{Namespace:\"rdk\", " +
+			"Name:\"component\"}, SubtypeName:\"camera\"}, Remote:\"\", " +
+			"Name:\"camera 2\"}}}, PositionPollingFreqHz:4, ObstaclePollingFreqHz:5, " +
+			"PlanDeviationMM:3, LinearMPerSec:1, AngularDegsPerSec:2}, Extra: map[]}"
+		test.That(t, validMoveOnGlobeRequest().String(), test.ShouldResemble, s)
+	})
+
 	//nolint:dupl
 	t.Run("toProto", func(t *testing.T) {
 		t.Run("error due to nil destination", func(t *testing.T) {

--- a/spatialmath/geo_obstacle_test.go
+++ b/spatialmath/geo_obstacle_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
 	commonpb "go.viam.com/api/common/v1"
+	"go.viam.com/rdk/utils"
 	"go.viam.com/test"
 
 	"go.viam.com/rdk/utils"

--- a/spatialmath/geo_obstacle_test.go
+++ b/spatialmath/geo_obstacle_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
 	commonpb "go.viam.com/api/common/v1"
-	"go.viam.com/rdk/utils"
 	"go.viam.com/test"
 
 	"go.viam.com/rdk/utils"


### PR DESCRIPTION
First Attempt: https://github.com/viamrobotics/rdk/pull/3010
Second Attempt: https://github.com/viamrobotics/rdk/pull/3238

### Tickets:
https://viam.atlassian.net/browse/RSDK-4810
https://viam.atlassian.net/browse/RSDK-4811
https://viam.atlassian.net/browse/RSDK-4812
https://viam.atlassian.net/browse/RSDK-4814

- change moveReqeusts of type MoveOnGlobe to include steps which are smuggled geoposes.
- create services/motion/builtin/state package to manage the state of the builtin motion service's executions, which supports starting executions, stopping executions by resource, stopping all executions from a motion/builtin/state struct, recording succeeded & failed replans, recording succeeded & failed ends to executions, recording stopped executions, and recording plan status updates, all such that data can be updated & retrieved efficiently.
- change motion/builtin.MoveOnGlobeNew to call state.StartExecution
- change motion/builtin.StopPlan to call state.StopExecutionByResource
- change motion/builtin.ListPlanStatuses to call state.ListPlanStatuses
- change motion/builtin.PlanHistory to call state.PlanHistory
- change services/motion/builtin to create a new motion/builtin/state on reconfigure & stop the previous state if one exists (to stop any executions from prior to reconfiguration)
- change ptgkinematic base to stop the base with a 5 second timeout if the context is cancelled


Manual Testing:
Tested by running the script below using a base & movement sensor simulated in gazebo.

1. Result of running MoveOnGlobeNew & then querying GetPlan to see the plans generated during the execution. In the video below motion replanned twice, resulting in 3 plans:

https://github.com/viamrobotics/rdk/assets/5927876/9d8e41ba-8f3c-4214-8235-9e950f6776f3

2. Result of calling StopPlan:
https://github.com/viamrobotics/rdk/assets/5927876/8931d70b-b43a-4f8e-9fa8-27a6dee6fa49



```go
package main

import (
	"context"
	"encoding/json"
	"fmt"
	"math"
	"os"
	"os/signal"
	"strconv"
	"sync"
	"syscall"
	"time"

	"github.com/edaniels/golog"
	"github.com/google/uuid"
	geo "github.com/kellydunn/golang-geo"
	v1 "go.viam.com/api/service/motion/v1"
	"go.viam.com/rdk/components/base"
	"go.viam.com/rdk/components/movementsensor"
	"go.viam.com/rdk/robot/client"
	"go.viam.com/rdk/services/motion"
	"go.viam.com/utils/rpc"
)

type state struct {
	shutdown    chan os.Signal
	done        chan struct{}
	cancelFn    context.CancelFunc
	m           motion.Service
	req         motion.MoveOnGlobeReq
	executionID string
	heading     float64
	position    *geo.Point
	dest        *geo.Point
	waitGroup   sync.WaitGroup
}

func main() {
	shutdown := make(chan os.Signal, 1)
	done := make(chan struct{}, 1)
	signal.Notify(shutdown, syscall.SIGINT, syscall.SIGTERM)
	if len(os.Args) != 3 {
		fmt.Fprintln(os.Stderr, "usage: <cmd> lat lng")
		return
	}
	logger := golog.NewLoggerForGCP("client")
	lat, err := strconv.ParseFloat(os.Args[1], 64)
	if err != nil {
		fmt.Fprintf(os.Stderr, "lat not able to be parsed %s\n", err)
	}

	lng, err := strconv.ParseFloat(os.Args[2], 64)
	if err != nil {
		fmt.Fprintf(os.Stderr, "lng not able to be parsed %s\n", err)
	}

	dest := geo.NewPoint(lat, lng)

	robot, err := client.New(
		context.Background(),
		"",
		logger,
		client.WithDialOptions(rpc.WithEntityCredentials(
			"",
			rpc.Credentials{
				Type:    rpc.CredentialsTypeAPIKey,
				Payload: "",
			})),
	)
	if err != nil {
		logger.Fatal(err)
	}

	defer robot.Close(context.Background())

	merged, err := movementsensor.FromRobot(robot, "merged")
	if err != nil {
		logger.Fatal(err)
		return
	}
	m, err := motion.FromRobot(robot, "builtin")
	if err != nil {
		logger.Fatal(err)
		return
	}
	position, _, err := merged.Position(context.Background(), nil)
	if err != nil {
		logger.Fatal(err)
		return
	}

	heading, err := merged.CompassHeading(context.Background(), nil)
	if err != nil {
		logger.Fatal(err)
		return
	}

	req := motion.MoveOnGlobeReq{
		ComponentName:      base.Named("base"),
		Destination:        dest,
		MovementSensorName: movementsensor.Named("merged"),
		Heading:            math.NaN(),
		MotionCfg: &motion.MotionConfiguration{
			PositionPollingFreqHz: 1,
			ObstaclePollingFreqHz: 2,
			PlanDeviationMM:       2600,
			LinearMPerSec:         0.3,
			AngularDegsPerSec:     20,
		},
		Extra: map[string]interface{}{"smooth_iter": 20},
	}
	ctx, cancelFn := context.WithCancel(context.Background())
	executionID, err := m.MoveOnGlobeNew(ctx, req)
	if err != nil {
		cancelFn()
		logger.Fatal(err)
		return
	}
	state := &state{
		shutdown:    shutdown,
		done:        done,
		cancelFn:    cancelFn,
		m:           m,
		req:         req,
		executionID: executionID,
		heading:     heading,
		position:    position,
		dest:        dest,
	}
	poll(ctx, state, logger)
	state.waitGroup.Wait()
}

func poll(ctx context.Context, s *state, logger golog.Logger) {
	s.waitGroup.Add(1)
	go func() {
		defer s.waitGroup.Done()
		select {
		case <-s.shutdown:
		case <-s.done:
		}
		s.cancelFn()
		if err := s.m.StopPlan(context.Background(), motion.StopPlanReq{ComponentName: s.req.ComponentName}); err != nil {
			logger.Errorf("error stopping plan: %s", err)
		}
	}()
	fmt.Fprintf(os.Stderr, "executionID: %v\n", s.executionID)
	defer func() {
		s.done <- struct{}{}
	}()
	for {
		lps, err := s.m.ListPlanStatuses(ctx, motion.ListPlanStatusesReq{})
		if err != nil {
			logger.Error(err.Error())
			return
		}
		var found bool
		for _, ps := range lps {
			if ps.ExecutionID.String() == s.executionID {
				found = true
				if ps.Status.State != motion.PlanStateInProgress {
					ph, err := s.m.PlanHistory(ctx, motion.PlanHistoryReq{
						ComponentName: s.req.ComponentName,
						ExecutionID:   uuid.MustParse(s.executionID),
					})
					if err != nil {
						logger.Error(err.Error())
						return

					}
					pwsProto := make([]*v1.PlanWithStatus, 0, len(ph))
					for _, pws := range ph {
						pwsProto = append(pwsProto, pws.ToProto())
					}
					b, err := json.Marshal(map[string]interface{}{
						"start_heading":  s.heading,
						"start_position": map[string]float64{"lat": s.position.Lat(), "lng": s.position.Lng()},
						"goal_position":  map[string]float64{"lat": s.dest.Lat(), "lng": s.dest.Lng()},
						"plan_history":   pwsProto,
					})
					if err != nil {
						logger.Error(err.Error())
						return
					}
					fmt.Println(string(b))
					return
				}
				fmt.Fprintf(os.Stderr, "state: %s\n", ps.Status.State)
				break
			}
		}

		if !found {
			logger.Error("execution id not found in ListPlanStatuses response")
			return
		}
		time.Sleep(time.Second)
	}
}
```