### PR TITLE
RSDK-5818: Check context for mimetype when calling client Classification/Detections

### DIFF
--- a/services/vision/client.go
+++ b/services/vision/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"image"
 
+	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 	commonpb "go.viam.com/api/common/v1"
 	pb "go.viam.com/api/service/vision/v1"
@@ -87,6 +88,9 @@ func (c *client) Detections(ctx context.Context, img image.Image, extra map[stri
 ) ([]objdet.Detection, error) {
 	ctx, span := trace.StartSpan(ctx, "service::vision::client::Detections")
 	defer span.End()
+	if img == nil {
+		return nil, errors.New("nil image input to given client.Detections")
+	}
 	mimeType := gostream.MIMETypeHint(ctx, utils.MimeTypeJPEG)
 	imgBytes, err := rimage.EncodeImage(ctx, img, mimeType)
 	if err != nil {
@@ -153,6 +157,9 @@ func (c *client) Classifications(ctx context.Context, img image.Image,
 ) (classification.Classifications, error) {
 	ctx, span := trace.StartSpan(ctx, "service::vision::client::Classifications")
 	defer span.End()
+	if img == nil {
+		return nil, errors.New("nil image input to given client.Classifications")
+	}
 	mimeType := gostream.MIMETypeHint(ctx, utils.MimeTypeJPEG)
 	imgBytes, err := rimage.EncodeImage(ctx, img, mimeType)
 	if err != nil {

--- a/services/vision/client.go
+++ b/services/vision/client.go
@@ -12,6 +12,7 @@ import (
 	"go.viam.com/utils/protoutils"
 	"go.viam.com/utils/rpc"
 
+	"go.viam.com/rdk/gostream"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/pointcloud"
 	rprotoutils "go.viam.com/rdk/protoutils"
@@ -86,7 +87,7 @@ func (c *client) Detections(ctx context.Context, img image.Image, extra map[stri
 ) ([]objdet.Detection, error) {
 	ctx, span := trace.StartSpan(ctx, "service::vision::client::Detections")
 	defer span.End()
-	mimeType := utils.MimeTypeRawRGBA
+	mimeType := gostream.MIMETypeHint(ctx, utils.MimeTypeJPEG)
 	imgBytes, err := rimage.EncodeImage(ctx, img, mimeType)
 	if err != nil {
 		return nil, err
@@ -152,7 +153,7 @@ func (c *client) Classifications(ctx context.Context, img image.Image,
 ) (classification.Classifications, error) {
 	ctx, span := trace.StartSpan(ctx, "service::vision::client::Classifications")
 	defer span.End()
-	mimeType := utils.MimeTypeRawRGBA
+	mimeType := gostream.MIMETypeHint(ctx, utils.MimeTypeJPEG)
 	imgBytes, err := rimage.EncodeImage(ctx, img, mimeType)
 	if err != nil {
 		return nil, err

--- a/services/vision/client_test.go
+++ b/services/vision/client_test.go
@@ -69,7 +69,7 @@ func TestClient(t *testing.T) {
 		client, err := vision.NewClientFromConn(context.Background(), conn, "", vision.Named(testVisionServiceName), logger)
 		test.That(t, err, test.ShouldBeNil)
 
-		dets, err := client.Detections(context.Background(), &image.RGBA{}, nil)
+		dets, err := client.Detections(context.Background(), image.NewRGBA(image.Rect(0, 0, 10, 20)), nil)
 		test.That(t, err, test.ShouldBeNil)
 
 		test.That(t, dets, test.ShouldNotBeNil)


### PR DESCRIPTION
In maybe the silliest over-sight of the year, we never updated the default mime type for encoding images that we sent over the vision service. We didn't even check for the requested MIME type in the context. We just always assumed raw RGBA encoding.

This should have been fixed with https://viam.atlassian.net/browse/RSDK-1153 when we switched it over for cameras, but forgot to do it for the vision service.

This will speed up the vision service as well, since we won't be encoding/decoding raw images any more over the wire.