### PR TITLE
RSDK-5818: small edge case of empty MIMEType hint

### DIFF
--- a/gostream/media_utils.go
+++ b/gostream/media_utils.go
@@ -89,11 +89,9 @@ func WithMIMETypeHint(ctx context.Context, mimeType string) context.Context {
 // MIMETypeHint gets the hint of what MIME type to use in encoding; if nothing is
 // set, the default provided is used.
 func MIMETypeHint(ctx context.Context, defaultType string) string {
-	if val, ok := ctx.Value(contextValueMIMETypeHint).(string); ok {
-		if val == "" {
-			return defaultType
-		}
-		return val
+	val, ok := ctx.Value(contextValueMIMETypeHint).(string)
+	if !ok || val == "" {
+		return defaultType
 	}
-	return defaultType
+	return val
 }

--- a/gostream/media_utils.go
+++ b/gostream/media_utils.go
@@ -90,6 +90,9 @@ func WithMIMETypeHint(ctx context.Context, mimeType string) context.Context {
 // set, the default provided is used.
 func MIMETypeHint(ctx context.Context, defaultType string) string {
 	if val, ok := ctx.Value(contextValueMIMETypeHint).(string); ok {
+		if val == "" {
+			return defaultType
+		}
 		return val
 	}
 	return defaultType


### PR DESCRIPTION
Encountered a small edge case where the context had an empty mime type in its hint