### PR TITLE
downgrade action step

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -55,7 +55,7 @@ jobs:
         sudo -Hu testbot bash -lc 'make clean-all'
 
     - name: Authorize GCP Upload
-      uses: google-github-actions/auth@v1
+      uses: google-github-actions/auth@v1.1.1
       with:
         credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
 
@@ -230,7 +230,7 @@ jobs:
 
     steps:
     - name: Authorize GCP
-      uses: google-github-actions/auth@v1
+      uses: google-github-actions/auth@v1.1.1
       with:
         credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
 


### PR DESCRIPTION
## What happened
- new release of the gcp auth action breaks compatibility with our environment (release info [here](https://github.com/google-github-actions/auth/releases/tag/v1.2.0))
- specifically because node20 is not compatible with the glibc in our base image
## What changed
- this PR temporarily downgrades to 1.1.1 for old behavior while we investigate what to fix in our base image
## Sample run
- https://github.com/viamrobotics/rdk/actions/runs/6947880375/job/18902654503#step:6:15
- (this failed because I set 'release type' to a bad value, but the auth step succeeded)