### PR TITLE
RSDK-5739 Add Get Analog to board RC card

### DIFF
--- a/components/board/fake/board.go
+++ b/components/board/fake/board.go
@@ -272,7 +272,7 @@ func (b *Board) SetPowerMode(ctx context.Context, mode pb.PowerMode, duration *t
 	return grpc.UnimplementedError
 }
 
-// WriteAnalog writes the value to the given pin. Add to AnalogReaders so you can read the value back.
+// WriteAnalog writes the value to the given pin, which can be read back by adding it to AnalogReaders.
 func (b *Board) WriteAnalog(ctx context.Context, pin string, value int32, extra map[string]interface{}) error {
 	alg := &AnalogReader{pin: pin, Value: int(value)}
 	b.AnalogReaders[pin] = alg

--- a/components/board/fake/board.go
+++ b/components/board/fake/board.go
@@ -272,8 +272,10 @@ func (b *Board) SetPowerMode(ctx context.Context, mode pb.PowerMode, duration *t
 	return grpc.UnimplementedError
 }
 
-// WriteAnalog writes the value to the given pin.
+// WriteAnalog writes the value to the given pin. Add to AnalogReaders so you can read the value back.
 func (b *Board) WriteAnalog(ctx context.Context, pin string, value int32, extra map[string]interface{}) error {
+	alg := &AnalogReader{pin: pin, Value: int(value)}
+	b.AnalogReaders[pin] = alg
 	return nil
 }
 

--- a/web/frontend/src/components/board/index.svelte
+++ b/web/frontend/src/components/board/index.svelte
@@ -142,7 +142,7 @@ const handleReadAnalogPinInput = (event:CustomEvent<{ value: string}>) => {
             {analogName}
           </th>
           <td class="border border-medium p-2">
-            {analog.value || 0 }
+            {analog.value || 0}
           </td>
         </tr>
       {/each}

--- a/web/frontend/src/components/board/index.svelte
+++ b/web/frontend/src/components/board/index.svelte
@@ -23,8 +23,10 @@ let setLevel = '';
 let pwm = '';
 let pwmFrequency = '';
 let getPinMessage = '';
-let analogPin = '';
+let writeAnalogPin = '';
+let analogPinName = '';
 let analogValue = '';
+let readAnalogMessage = '';
 
 const getGPIO = async () => {
   try {
@@ -79,9 +81,18 @@ const setPWMFrequency = async () => {
 
 const writeAnalog = async () => {
   try {
-    await boardClient.writeAnalog(analogPin, Number.parseInt(analogValue, 10));
+    await boardClient.writeAnalog(writeAnalogPin, Number.parseInt(analogValue, 10));
   } catch (error) {
     displayError(error as ServiceError);
+  }
+};
+
+const readAnalog = async () => {
+  try {
+    const value = await boardClient.readAnalogReader(analogPinName);
+    readAnalogMessage = `${analogPinName} value is ${value}`;
+  } catch (error) {
+    notify.danger((error as ServiceError).message);
   }
 };
 
@@ -101,12 +112,16 @@ const handlePwmFrequencyInput = (event: CustomEvent<{ value: string}>) => {
   pwmFrequency = event.detail.value;
 };
 
-const handleAnalogPinInput = (event:CustomEvent<{ value: string}>) => {
-  analogPin = event.detail.value;
+const handleWriteAnalogPinInput = (event:CustomEvent<{ value: string}>) => {
+  writeAnalogPin = event.detail.value;
 };
 
-const handleAnalogValueInput = (event:CustomEvent<{ value: string}>) => {
+const handleWriteAnalogValueInput = (event:CustomEvent<{ value: string}>) => {
   analogValue = event.detail.value;
+};
+
+const handleReadAnalogPinInput = (event:CustomEvent<{ value: string}>) => {
+  analogPinName = event.detail.value;
 };
 
 </script>
@@ -118,7 +133,7 @@ const handleAnalogValueInput = (event:CustomEvent<{ value: string}>) => {
   />
   <div class="overflow-auto border border-t-0 border-medium p-4">
     <h3 class="mb-2">
-      Analog Readers
+      Analogs
     </h3>
     <table class="mb-4 table-auto border border-medium">
       {#each Object.entries(status?.analogs ?? {}) as [analogName, analog] (analogName)}
@@ -127,7 +142,7 @@ const handleAnalogValueInput = (event:CustomEvent<{ value: string}>) => {
             {analogName}
           </th>
           <td class="border border-medium p-2">
-            {analog.value || 0}
+            {analog.value || 0 }
           </td>
         </tr>
       {/each}
@@ -237,31 +252,60 @@ const handleAnalogValueInput = (event:CustomEvent<{ value: string}>) => {
         </td>
       </tr>
     </table>
+
     <h3 class="mb-2">
-      Analog Write
+      Analogs
      </h3>
      <table class="mb-4 w-full table-auto border border-medium">
-     <td class="border border-medium p-2">
+
+      <tr>
+        <th class="border border-medium p-2">
+          Get
+        </th>
+        <td class="p-2">
+          <div class="flex flex-wrap items-end gap-2">
+               <v-input
+                 label="Pin"
+                 type="text"
+                 value={analogPinName}
+                 on:input={handleReadAnalogPinInput}
+               />
+             <v-button
+             class="mr-2"
+             label="Get Analog Value"
+             on:click={readAnalog}
+           />
+           <span class="py-2">
+            {readAnalogMessage}
+          </span>
+        </div>
+      </td>
+      </tr>
+      <tr>
+     <th class="border border-medium p-2">
+          Set
+        </th>
+       <td class="border border-medium p-2">
        <div class="flex flex-wrap items-end gap-2">
          <v-input
            label="Pin"
            type="text"
-           value={analogPin}
-           on:input={handleAnalogPinInput}
+           value={writeAnalogPin}
+           on:input={handleWriteAnalogPinInput}
          />
          <v-input
          label="Value"
          type="text"
          value={analogValue}
-         on:input={handleAnalogValueInput}
+         on:input={handleWriteAnalogValueInput}
        />
        <v-button
        class="mr-2"
        label="Set Analog Value"
        on:click={writeAnalog}
      />
-       </div>
-     </td>
-     </table>
-  </div>
+    </div>
+  </td>
+</tr>
+
 </Collapse>

--- a/web/frontend/src/components/board/index.svelte
+++ b/web/frontend/src/components/board/index.svelte
@@ -90,7 +90,7 @@ const writeAnalog = async () => {
 const readAnalog = async () => {
   try {
     const value = await boardClient.readAnalogReader(analogPinName);
-    readAnalogMessage = `${analogPinName} value is ${value}`;
+    readAnalogMessage = `${analogPinName}: value is ${value}`;
   } catch (error) {
     notify.danger((error as ServiceError).message);
   }

--- a/web/frontend/src/components/board/index.svelte
+++ b/web/frontend/src/components/board/index.svelte
@@ -198,7 +198,6 @@ const handleReadAnalogPinInput = (event:CustomEvent<{ value: string}>) => {
           </div>
         </td>
       </tr>
-
       <tr>
         <th class="border border-medium p-2">
           Set
@@ -257,7 +256,6 @@ const handleReadAnalogPinInput = (event:CustomEvent<{ value: string}>) => {
       Analogs
      </h3>
      <table class="mb-4 w-full table-auto border border-medium">
-
       <tr>
         <th class="border border-medium p-2">
           Get
@@ -277,9 +275,9 @@ const handleReadAnalogPinInput = (event:CustomEvent<{ value: string}>) => {
            />
            <span class="py-2">
             {readAnalogMessage}
-          </span>
-        </div>
-      </td>
+            </span>
+          </div>
+        </td>
       </tr>
       <tr>
      <th class="border border-medium p-2">
@@ -303,9 +301,11 @@ const handleReadAnalogPinInput = (event:CustomEvent<{ value: string}>) => {
        class="mr-2"
        label="Set Analog Value"
        on:click={writeAnalog}
-     />
-    </div>
-  </td>
-</tr>
+      />
+        </div>
+      </td>
+    </tr>
+  </table>
+</div>
 
 </Collapse>


### PR DESCRIPTION
Adds the get analog option to poll the value of an analog pin.

I think we could remove the top analogs section that displays all the analog readers by name and their values now that we have this ? Lmk if I should remove in this PR. 

<img width="1464" alt="Screenshot 2023-11-22 at 10 23 34 AM" src="https://github.com/viamrobotics/rdk/assets/106617921/c65337d6-57d7-4f52-913f-413c1a887ea8">




