### PR TITLE
[RSDK-5828] Move I2C and SPI code to its own package

### DIFF
--- a/components/board/board.go
+++ b/components/board/board.go
@@ -81,33 +81,6 @@ type Board interface {
 	WriteAnalog(ctx context.Context, pin string, value int32, extra map[string]interface{}) error
 }
 
-// SPI represents a shareable SPI bus on the board.
-type SPI interface {
-	// OpenHandle locks the shared bus and returns a handle interface that MUST be closed when done.
-	OpenHandle() (SPIHandle, error)
-	Close(ctx context.Context) error
-}
-
-// SPIHandle is similar to an io handle. It MUST be closed to release the bus.
-type SPIHandle interface {
-	// Xfer performs a single SPI transfer, that is, the complete transaction from chipselect enable to chipselect disable.
-	// SPI transfers are synchronous, number of bytes received will be equal to the number of bytes sent.
-	// Write-only transfers can usually just discard the returned bytes.
-	// Read-only transfers usually transmit a request/address and continue with some number of null bytes to equal the expected size of the
-	// returning data.
-	// Large transmissions are usually broken up into multiple transfers.
-	// There are many different paradigms for most of the above, and implementation details are chip/device specific.
-	Xfer(
-		ctx context.Context,
-		baud uint,
-		chipSelect string,
-		mode uint,
-		tx []byte,
-	) ([]byte, error)
-	// Close closes the handle and releases the lock on the bus.
-	Close() error
-}
-
 // An AnalogReader represents an analog pin reader that resides on a board.
 type AnalogReader interface {
 	// Read reads off the current value.

--- a/components/board/fake/board.go
+++ b/components/board/fake/board.go
@@ -15,7 +15,6 @@ import (
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/board"
-	"go.viam.com/rdk/components/board/genericlinux/buses"
 	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"

--- a/components/board/fake/board.go
+++ b/components/board/fake/board.go
@@ -15,6 +15,7 @@ import (
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/genericlinux/buses"
 	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"

--- a/components/board/fake/board.go
+++ b/components/board/fake/board.go
@@ -18,14 +18,12 @@ import (
 	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
-	rdkutils "go.viam.com/rdk/utils"
 )
 
 // A Config describes the configuration of a fake board and all of its connected parts.
 type Config struct {
 	AnalogReaders     []board.AnalogReaderConfig     `json:"analogs,omitempty"`
 	DigitalInterrupts []board.DigitalInterruptConfig `json:"digital_interrupts,omitempty"`
-	Attributes        rdkutils.AttributeMap          `json:"attributes,omitempty"`
 	FailNew           bool                           `json:"fail_new"`
 }
 

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -19,6 +19,7 @@ import (
 	goutils "go.viam.com/utils"
 
 	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/genericlinux/buses"
 	"go.viam.com/rdk/components/board/mcp3008helper"
 	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
@@ -203,8 +204,7 @@ func (b *Board) reconfigureAnalogReaders(ctx context.Context, newConf *LinuxBoar
 			return errors.Errorf("bad analog pin (%s)", c.Pin)
 		}
 
-		bus := &spiBus{}
-		bus.reset(c.SPIBus)
+		bus := buses.NewSpiBus(c.SPIBus)
 
 		stillExists[c.Name] = struct{}{}
 		if curr, ok := b.analogReaders[c.Name]; ok {

--- a/components/board/genericlinux/buses/i2c_interfaces.go
+++ b/components/board/genericlinux/buses/i2c_interfaces.go
@@ -1,4 +1,5 @@
-package board
+// Package buses offers SPI and I2C buses for generic Linux systems.
+package buses
 
 import (
 	"context"

--- a/components/board/genericlinux/buses/spi.go
+++ b/components/board/genericlinux/buses/spi.go
@@ -1,6 +1,6 @@
 //go:build linux
 
-package genericlinux
+package buses
 
 import (
 	"context"
@@ -13,14 +13,12 @@ import (
 	"periph.io/x/conn/v3/physic"
 	"periph.io/x/conn/v3/spi"
 	"periph.io/x/conn/v3/spi/spireg"
-
-	"go.viam.com/rdk/components/board"
 )
 
 // NewSpiBus creates a new SPI bus. The name passed in should be the bus number, such as "0" or
 // "1". We don't open this bus until you call spiHandle.Xfer(), so there are no errors to return
 // immediately here.
-func NewSpiBus(name string) board.SPI {
+func NewSpiBus(name string) SPI {
 	bus := spiBus{}
 	bus.reset(name)
 	return &bus
@@ -37,7 +35,7 @@ type spiHandle struct {
 	isClosed bool
 }
 
-func (sb *spiBus) OpenHandle() (board.SPIHandle, error) {
+func (sb *spiBus) OpenHandle() (SPIHandle, error) {
 	sb.mu.Lock()
 	sb.openHandle = &spiHandle{bus: sb, isClosed: false}
 	return sb.openHandle, nil

--- a/components/board/genericlinux/buses/spi_interfaces.go
+++ b/components/board/genericlinux/buses/spi_interfaces.go
@@ -1,0 +1,33 @@
+package buses
+
+import (
+	"context"
+)
+
+// SPI represents a shareable SPI bus on a generic Linux board.
+type SPI interface {
+	// OpenHandle locks the shared bus and returns a handle interface that MUST be closed when done.
+	OpenHandle() (SPIHandle, error)
+	Close(ctx context.Context) error
+}
+
+// SPIHandle is similar to an io handle. It MUST be closed to release the bus.
+type SPIHandle interface {
+	// Xfer performs a single SPI transfer, that is, the complete transaction from chipselect
+	// enable to chipselect disable. SPI transfers are synchronous, number of bytes received will
+	// be equal to the number of bytes sent. Write-only transfers can usually just discard the
+	// returned bytes. Read-only transfers usually transmit a request/address and continue with
+	// some number of null bytes to equal the expected size of the returning data. Large
+	// transmissions are usually broken up into multiple transfers. There are many different
+	// paradigms for most of the above, and implementation details are chip/device specific.
+	Xfer(
+		ctx context.Context,
+		baud uint,
+		chipSelect string,
+		mode uint,
+		tx []byte,
+	) ([]byte, error)
+
+	// Close closes the handle and releases the lock on the bus.
+	Close() error
+}

--- a/components/board/genericlinux/config.go
+++ b/components/board/genericlinux/config.go
@@ -6,14 +6,12 @@ import (
 	"go.viam.com/rdk/components/board"
 	"go.viam.com/rdk/components/board/mcp3008helper"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/utils"
 )
 
 // A Config describes the configuration of a board and all of its connected parts.
 type Config struct {
 	AnalogReaders     []mcp3008helper.MCP3008AnalogConfig `json:"analogs,omitempty"`
 	DigitalInterrupts []board.DigitalInterruptConfig      `json:"digital_interrupts,omitempty"`
-	Attributes        utils.AttributeMap                  `json:"attributes,omitempty"`
 }
 
 // Validate ensures all parts of the config are valid.

--- a/components/board/hat/pca9685/pca9685.go
+++ b/components/board/hat/pca9685/pca9685.go
@@ -16,7 +16,7 @@ import (
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/board"
-	"go.viam.com/rdk/components/board/genericlinux"
+	"go.viam.com/rdk/components/board/genericlinux/buses"
 	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -73,7 +73,7 @@ type PCA9685 struct {
 	mu                  sync.RWMutex
 	address             byte
 	referenceClockSpeed int
-	bus                 board.I2C
+	bus                 buses.I2C
 	gpioPins            [16]gpioPin
 	logger              logging.Logger
 }
@@ -118,7 +118,7 @@ func (pca *PCA9685) Reconfigure(ctx context.Context, deps resource.Dependencies,
 		return err
 	}
 
-	bus, err := genericlinux.NewI2cBus(newConf.I2CBus)
+	bus, err := buses.NewI2cBus(newConf.I2CBus)
 	if err != nil {
 		return err
 	}
@@ -181,7 +181,7 @@ func (pca *PCA9685) GPIOPinByName(pin string) (board.GPIOPin, error) {
 	return &pca.gpioPins[pinInt], nil
 }
 
-func (pca *PCA9685) openHandle() (board.I2CHandle, error) {
+func (pca *PCA9685) openHandle() (buses.I2CHandle, error) {
 	return pca.bus.OpenHandle(pca.address)
 }
 
@@ -307,10 +307,10 @@ func (gp *gpioPin) PWM(ctx context.Context, extra map[string]interface{}) (float
 		utils.UncheckedError(handle.Close())
 	}()
 
-	regOnLow := board.I2CRegister{handle, gp.startAddr}
-	regOnHigh := board.I2CRegister{handle, gp.startAddr + 1}
-	regOffLow := board.I2CRegister{handle, gp.startAddr + 2}
-	regOffHigh := board.I2CRegister{handle, gp.startAddr + 3}
+	regOnLow := buses.I2CRegister{handle, gp.startAddr}
+	regOnHigh := buses.I2CRegister{handle, gp.startAddr + 1}
+	regOffLow := buses.I2CRegister{handle, gp.startAddr + 2}
+	regOffHigh := buses.I2CRegister{handle, gp.startAddr + 3}
 
 	onLow, err := regOnLow.ReadByteData(ctx)
 	if err != nil {
@@ -352,10 +352,10 @@ func (gp *gpioPin) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[s
 		utils.UncheckedError(handle.Close())
 	}()
 
-	regOnLow := board.I2CRegister{handle, gp.startAddr}
-	regOnHigh := board.I2CRegister{handle, gp.startAddr + 1}
-	regOffLow := board.I2CRegister{handle, gp.startAddr + 2}
-	regOffHigh := board.I2CRegister{handle, gp.startAddr + 3}
+	regOnLow := buses.I2CRegister{handle, gp.startAddr}
+	regOnHigh := buses.I2CRegister{handle, gp.startAddr + 1}
+	regOffLow := buses.I2CRegister{handle, gp.startAddr + 2}
+	regOffHigh := buses.I2CRegister{handle, gp.startAddr + 3}
 
 	if dutyCycle == 0xffff {
 		// On takes up all steps

--- a/components/board/mcp3008helper/mcp3008.go
+++ b/components/board/mcp3008helper/mcp3008.go
@@ -8,13 +8,13 @@ import (
 	"go.uber.org/multierr"
 	"go.viam.com/utils"
 
-	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/genericlinux/buses"
 )
 
 // MCP3008AnalogReader implements a board.AnalogReader using an MCP3008 ADC via SPI.
 type MCP3008AnalogReader struct {
 	Channel int
-	Bus     board.SPI
+	Bus     buses.SPI
 	Chip    string
 }
 

--- a/components/board/numato/board.go
+++ b/components/board/numato/board.go
@@ -26,7 +26,6 @@ import (
 	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
-	rdkutils "go.viam.com/rdk/utils"
 )
 
 var model = resource.DefaultModelFamily.WithModel("numato")
@@ -36,7 +35,6 @@ var errNoBoard = errors.New("no numato boards found")
 // A Config describes the configuration of a board and all of its connected parts.
 type Config struct {
 	Analogs    []board.AnalogReaderConfig `json:"analogs,omitempty"`
-	Attributes rdkutils.AttributeMap      `json:"attributes,omitempty"`
 	Pins       int                        `json:"pins"`
 }
 
@@ -63,6 +61,10 @@ func init() {
 
 // Validate ensures all parts of the config are valid.
 func (conf *Config) Validate(path string) ([]string, error) {
+	if conf.Pins <= 0 {
+		return nil, utils.NewConfigValidationFieldRequiredError(path, "i2c_bus")
+	}
+
 	for idx, conf := range conf.Analogs {
 		if err := conf.Validate(fmt.Sprintf("%s.%s.%d", path, "analogs", idx)); err != nil {
 			return nil, err
@@ -365,9 +367,6 @@ func (ar *analogReader) Close(ctx context.Context) error {
 
 func connect(ctx context.Context, name resource.Name, conf *Config, logger logging.Logger) (board.Board, error) {
 	pins := conf.Pins
-	if pins <= 0 {
-		return nil, errors.New("numato board needs pins set in attributes")
-	}
 
 	filter := serial.SearchFilter{Type: serial.TypeNumatoGPIO}
 	devs := serial.Search(filter)

--- a/components/board/numato/board.go
+++ b/components/board/numato/board.go
@@ -34,8 +34,8 @@ var errNoBoard = errors.New("no numato boards found")
 
 // A Config describes the configuration of a board and all of its connected parts.
 type Config struct {
-	Analogs    []board.AnalogReaderConfig `json:"analogs,omitempty"`
-	Pins       int                        `json:"pins"`
+	Analogs []board.AnalogReaderConfig `json:"analogs,omitempty"`
+	Pins    int                        `json:"pins"`
 }
 
 func init() {

--- a/components/board/numato/board.go
+++ b/components/board/numato/board.go
@@ -62,7 +62,7 @@ func init() {
 // Validate ensures all parts of the config are valid.
 func (conf *Config) Validate(path string) ([]string, error) {
 	if conf.Pins <= 0 {
-		return nil, utils.NewConfigValidationFieldRequiredError(path, "i2c_bus")
+		return nil, utils.NewConfigValidationFieldRequiredError(path, "pins")
 	}
 
 	for idx, conf := range conf.Analogs {

--- a/components/board/numato/board_test.go
+++ b/components/board/numato/board_test.go
@@ -44,8 +44,8 @@ func TestNumato1(t *testing.T) {
 		ctx,
 		board.Named("foo"),
 		&Config{
-			Analogs:    []board.AnalogReaderConfig{{Name: "foo", Pin: "01"}},
-			Pins:       2,
+			Analogs: []board.AnalogReaderConfig{{Name: "foo", Pin: "01"}},
+			Pins:    2,
 		},
 		logger,
 	)

--- a/components/board/numato/board_test.go
+++ b/components/board/numato/board_test.go
@@ -110,10 +110,14 @@ func TestNumato1(t *testing.T) {
 }
 
 func TestConfigValidate(t *testing.T) {
-	validConfig := Config{}
+	invalidConfig := Config{}
+	_, err := invalidConfig.Validate("path")
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, `"pins" is required`)
 
+	validConfig := Config{Pins: 128}
 	validConfig.Analogs = []board.AnalogReaderConfig{{}}
-	_, err := validConfig.Validate("path")
+	_, err = validConfig.Validate("path")
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, `path.analogs.0`)
 	test.That(t, err.Error(), test.ShouldContainSubstring, `"name" is required`)

--- a/components/board/numato/board_test.go
+++ b/components/board/numato/board_test.go
@@ -9,7 +9,6 @@ import (
 
 	"go.viam.com/rdk/components/board"
 	"go.viam.com/rdk/logging"
-	rutils "go.viam.com/rdk/utils"
 )
 
 func TestMask(t *testing.T) {

--- a/components/board/numato/board_test.go
+++ b/components/board/numato/board_test.go
@@ -45,7 +45,6 @@ func TestNumato1(t *testing.T) {
 		ctx,
 		board.Named("foo"),
 		&Config{
-			Attributes: rutils.AttributeMap{"pins": 128},
 			Analogs:    []board.AnalogReaderConfig{{Name: "foo", Pin: "01"}},
 			Pins:       2,
 		},

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -35,7 +35,6 @@ import (
 	pb "go.viam.com/api/component/board/v1"
 
 	"go.viam.com/rdk/components/board"
-	"go.viam.com/rdk/components/board/genericlinux/buses"
 	"go.viam.com/rdk/components/board/mcp3008helper"
 	picommon "go.viam.com/rdk/components/board/pi/common"
 	"go.viam.com/rdk/grpc"

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -65,7 +65,6 @@ func init() {
 type Config struct {
 	AnalogReaders     []mcp3008helper.MCP3008AnalogConfig `json:"analogs,omitempty"`
 	DigitalInterrupts []board.DigitalInterruptConfig      `json:"digital_interrupts,omitempty"`
-	Attributes        rdkutils.AttributeMap               `json:"attributes,omitempty"`
 }
 
 // Validate ensures all parts of the config are valid.

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -35,6 +35,7 @@ import (
 	pb "go.viam.com/api/component/board/v1"
 
 	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/genericlinux/buses"
 	"go.viam.com/rdk/components/board/mcp3008helper"
 	picommon "go.viam.com/rdk/components/board/pi/common"
 	"go.viam.com/rdk/grpc"

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -35,6 +35,7 @@ import (
 	pb "go.viam.com/api/component/board/v1"
 
 	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/genericlinux/buses"
 	"go.viam.com/rdk/components/board/mcp3008helper"
 	picommon "go.viam.com/rdk/components/board/pi/common"
 	"go.viam.com/rdk/grpc"
@@ -608,7 +609,7 @@ func (s *piPigpioSPIHandle) Xfer(ctx context.Context, baud uint, chipSelect stri
 	return C.GoBytes(rxPtr, (C.int)(count)), nil
 }
 
-func (s *piPigpioSPI) OpenHandle() (board.SPIHandle, error) {
+func (s *piPigpioSPI) OpenHandle() (buses.SPIHandle, error) {
 	s.mu.Lock()
 	s.openHandle = &piPigpioSPIHandle{bus: s, isClosed: false}
 	return s.openHandle, nil

--- a/components/board/pi/impl/i2c.go
+++ b/components/board/pi/impl/i2c.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/genericlinux/buses"
 	picommon "go.viam.com/rdk/components/board/pi/common"
 )
 
@@ -102,7 +102,7 @@ func (s *piPigpioI2CHandle) WriteBlockData(ctx context.Context, register byte, d
 	return nil
 }
 
-func (s *piPigpioI2C) OpenHandle(addr byte) (board.I2CHandle, error) {
+func (s *piPigpioI2C) OpenHandle(addr byte) (buses.I2CHandle, error) {
 	handle := &piPigpioI2CHandle{bus: s}
 
 	// Raspberry Pis are all on i2c bus 1

--- a/components/encoder/ams/ams_as5048.go
+++ b/components/encoder/ams/ams_as5048.go
@@ -13,8 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"go.viam.com/utils"
 
-	"go.viam.com/rdk/components/board"
-	"go.viam.com/rdk/components/board/genericlinux"
+	"go.viam.com/rdk/components/board/genericlinux/buses"
 	"go.viam.com/rdk/components/encoder"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -110,7 +109,7 @@ type Encoder struct {
 	positionOffset          float64
 	rotations               int
 	positionType            encoder.PositionType
-	i2cBus                  board.I2C
+	i2cBus                  buses.I2C
 	i2cAddr                 byte
 	i2cBusName              string // This is nessesary to check whether we need to create a new i2cBus during reconfigure.
 	cancelCtx               context.Context
@@ -133,7 +132,7 @@ func makeAS5048Encoder(
 	deps resource.Dependencies,
 	conf resource.Config,
 	logger logging.Logger,
-	bus board.I2C,
+	bus buses.I2C,
 ) (encoder.Encoder, error) {
 	cfg, err := resource.NativeConfig[*Config](conf)
 	if err != nil {
@@ -175,7 +174,7 @@ func (enc *Encoder) Reconfigure(
 	defer enc.mu.Unlock()
 
 	if enc.i2cBusName != newConf.I2CBus || enc.i2cBus == nil {
-		bus, err := genericlinux.NewI2cBus(newConf.I2CBus)
+		bus, err := buses.NewI2cBus(newConf.I2CBus)
 		if err != nil {
 			msg := fmt.Sprintf("can't find I2C bus '%q' for AMS encoder", newConf.I2CBus)
 			return errors.Wrap(err, msg)

--- a/components/encoder/ams/ams_as5048_test.go
+++ b/components/encoder/ams/ams_as5048_test.go
@@ -10,7 +10,7 @@ import (
 	"go.viam.com/test"
 	"go.viam.com/utils/testutils"
 
-	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/genericlinux/buses"
 	"go.viam.com/rdk/components/encoder"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -38,7 +38,7 @@ func TestConvertBytesToAngle(t *testing.T) {
 	test.That(t, deg, test.ShouldAlmostEqual, 219.990234, 1e-6)
 }
 
-func setupDependencies(mockData []byte) (resource.Config, resource.Dependencies, board.I2C) {
+func setupDependencies(mockData []byte) (resource.Config, resource.Dependencies, buses.I2C) {
 	i2cConf := &I2CConfig{
 		I2CBus:  "1",
 		I2CAddr: 64,
@@ -64,7 +64,7 @@ func setupDependencies(mockData []byte) (resource.Config, resource.Dependencies,
 	i2cHandle.CloseFunc = func() error { return nil }
 
 	i2c := &inject.I2C{}
-	i2c.OpenHandleFunc = func(addr byte) (board.I2CHandle, error) {
+	i2c.OpenHandleFunc = func(addr byte) (buses.I2CHandle, error) {
 		return i2cHandle, nil
 	}
 
@@ -113,7 +113,7 @@ func TestAMSEncoder(t *testing.T) {
 	})
 }
 
-func setupDependenciesWithWrite(mockData []byte, writeData map[byte]byte) (resource.Config, resource.Dependencies, board.I2C) {
+func setupDependenciesWithWrite(mockData []byte, writeData map[byte]byte) (resource.Config, resource.Dependencies, buses.I2C) {
 	i2cConf := &I2CConfig{
 		I2CBus:  "1",
 		I2CAddr: 64,
@@ -140,7 +140,7 @@ func setupDependenciesWithWrite(mockData []byte, writeData map[byte]byte) (resou
 	i2cHandle.CloseFunc = func() error { return nil }
 
 	i2c := &inject.I2C{}
-	i2c.OpenHandleFunc = func(addr byte) (board.I2CHandle, error) {
+	i2c.OpenHandleFunc = func(addr byte) (buses.I2CHandle, error) {
 		return i2cHandle, nil
 	}
 	return cfg, resource.Dependencies{}, i2c

--- a/components/motor/i2cmotors/ezopmp.go
+++ b/components/motor/i2cmotors/ezopmp.go
@@ -14,8 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"go.viam.com/utils"
 
-	"go.viam.com/rdk/components/board"
-	"go.viam.com/rdk/components/board/genericlinux"
+	"go.viam.com/rdk/components/board/genericlinux/buses"
 	"go.viam.com/rdk/components/motor"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/operation"
@@ -72,7 +71,7 @@ type Ezopmp struct {
 	resource.Named
 	resource.AlwaysRebuild
 	resource.TriviallyCloseable
-	bus         board.I2C
+	bus         buses.I2C
 	I2CAddress  byte
 	maxReadBits int
 	logger      logging.Logger
@@ -95,7 +94,7 @@ const (
 func NewMotor(ctx context.Context, deps resource.Dependencies, c *Config, name resource.Name,
 	logger logging.Logger,
 ) (motor.Motor, error) {
-	bus, err := genericlinux.NewI2cBus(c.BusName)
+	bus, err := buses.NewI2cBus(c.BusName)
 	if err != nil {
 		return nil, err
 	}

--- a/components/motor/tmcstepper/stepper_motor_tmc.go
+++ b/components/motor/tmcstepper/stepper_motor_tmc.go
@@ -13,7 +13,7 @@ import (
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/board"
-	"go.viam.com/rdk/components/board/genericlinux"
+	"go.viam.com/rdk/components/board/genericlinux/buses"
 	"go.viam.com/rdk/components/motor"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/operation"
@@ -91,7 +91,7 @@ type Motor struct {
 	resource.Named
 	resource.AlwaysRebuild
 	resource.TriviallyCloseable
-	bus         board.SPI
+	bus         buses.SPI
 	csPin       string
 	index       int
 	enLowPin    board.GPIOPin
@@ -151,14 +151,14 @@ const (
 func NewMotor(ctx context.Context, deps resource.Dependencies, c TMC5072Config, name resource.Name,
 	logger logging.Logger,
 ) (motor.Motor, error) {
-	bus := genericlinux.NewSpiBus(c.SPIBus)
+	bus := buses.NewSpiBus(c.SPIBus)
 	return makeMotor(ctx, deps, c, name, logger, bus)
 }
 
 // makeMotor returns a TMC5072 driven motor. It is separate from NewMotor, above, so you can inject
 // a mock SPI bus in here during testing.
 func makeMotor(ctx context.Context, deps resource.Dependencies, c TMC5072Config, name resource.Name,
-	logger logging.Logger, bus board.SPI,
+	logger logging.Logger, bus buses.SPI,
 ) (motor.Motor, error) {
 	if c.CalFactor == 0 {
 		c.CalFactor = 1.0

--- a/components/motor/tmcstepper/stepper_motor_tmc_test.go
+++ b/components/motor/tmcstepper/stepper_motor_tmc_test.go
@@ -10,7 +10,7 @@ import (
 
 	"go.viam.com/test"
 
-	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/genericlinux/buses"
 	"go.viam.com/rdk/components/motor"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -66,10 +66,10 @@ func (h *fakeSpiHandle) ExpectDone() {
 	test.That(h.tb, h.i, test.ShouldEqual, len(h.tx))
 }
 
-func newFakeSpi(tb testing.TB) (*fakeSpiHandle, board.SPI) {
+func newFakeSpi(tb testing.TB) (*fakeSpiHandle, buses.SPI) {
 	handle := newFakeSpiHandle(tb)
 	fakeSpi := inject.SPI{}
-	fakeSpi.OpenHandleFunc = func() (board.SPIHandle, error) {
+	fakeSpi.OpenHandleFunc = func() (buses.SPIHandle, error) {
 		return &handle, nil
 	}
 

--- a/components/movementsensor/adxl345/adxl345.go
+++ b/components/movementsensor/adxl345/adxl345.go
@@ -31,7 +31,7 @@ import (
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/board"
-	"go.viam.com/rdk/components/board/genericlinux"
+	"go.viam.com/rdk/components/board/genericlinux/buses"
 	"go.viam.com/rdk/components/movementsensor"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -155,7 +155,7 @@ type adxl345 struct {
 	resource.Named
 	resource.AlwaysRebuild
 
-	bus                      board.I2C
+	bus                      buses.I2C
 	i2cAddress               byte
 	logger                   logging.Logger
 	interruptsEnabled        byte
@@ -188,7 +188,7 @@ func NewAdxl345(
 		return nil, err
 	}
 
-	bus, err := genericlinux.NewI2cBus(newConf.I2cBus)
+	bus, err := buses.NewI2cBus(newConf.I2cBus)
 	if err != nil {
 		msg := fmt.Sprintf("can't find I2C bus '%q' for ADXL345 sensor", newConf.I2cBus)
 		return nil, errors.Wrap(err, msg)
@@ -208,7 +208,7 @@ func makeAdxl345(
 	deps resource.Dependencies,
 	conf resource.Config,
 	logger logging.Logger,
-	bus board.I2C,
+	bus buses.I2C,
 ) (movementsensor.MovementSensor, error) {
 	newConf, err := resource.NativeConfig[*Config](conf)
 	if err != nil {

--- a/components/movementsensor/adxl345/adxl345_test.go
+++ b/components/movementsensor/adxl345/adxl345_test.go
@@ -13,6 +13,7 @@ import (
 	"go.viam.com/utils/testutils"
 
 	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/genericlinux/buses"
 	"go.viam.com/rdk/components/movementsensor"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -23,7 +24,7 @@ func nowNanosTest() uint64 {
 	return uint64(time.Now().UnixNano())
 }
 
-func setupDependencies(mockData []byte) (resource.Config, resource.Dependencies, board.I2C) {
+func setupDependencies(mockData []byte) (resource.Config, resource.Dependencies, buses.I2C) {
 	cfg := resource.Config{
 		Name:  "movementsensor",
 		Model: model,
@@ -47,7 +48,7 @@ func setupDependencies(mockData []byte) (resource.Config, resource.Dependencies,
 	i2cHandle.CloseFunc = func() error { return nil }
 
 	i2c := &inject.I2C{}
-	i2c.OpenHandleFunc = func(addr byte) (board.I2CHandle, error) {
+	i2c.OpenHandleFunc = func(addr byte) (buses.I2CHandle, error) {
 		return i2cHandle, nil
 	}
 
@@ -139,7 +140,7 @@ func TestInitializationFailureOnChipCommunication(t *testing.T) {
 		i2cHandle.CloseFunc = func() error { return nil }
 
 		i2c := &inject.I2C{}
-		i2c.OpenHandleFunc = func(addr byte) (board.I2CHandle, error) {
+		i2c.OpenHandleFunc = func(addr byte) (buses.I2CHandle, error) {
 			return i2cHandle, nil
 		}
 
@@ -170,7 +171,7 @@ func TestInterrupts(t *testing.T) {
 	}
 
 	i2c := &inject.I2C{}
-	i2c.OpenHandleFunc = func(addr byte) (board.I2CHandle, error) { return i2cHandle, nil }
+	i2c.OpenHandleFunc = func(addr byte) (buses.I2CHandle, error) { return i2cHandle, nil }
 
 	logger := logging.NewTestLogger(t)
 
@@ -275,7 +276,7 @@ func TestReadInterrupts(t *testing.T) {
 	i2cHandle := &inject.I2CHandle{}
 	i2cHandle.CloseFunc = func() error { return nil }
 	i2c := &inject.I2C{}
-	i2c.OpenHandleFunc = func(addr byte) (board.I2CHandle, error) {
+	i2c.OpenHandleFunc = func(addr byte) (buses.I2CHandle, error) {
 		return i2cHandle, nil
 	}
 

--- a/components/movementsensor/gpsnmea/pmtkI2C.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C.go
@@ -14,8 +14,7 @@ import (
 	geo "github.com/kellydunn/golang-geo"
 	"go.viam.com/utils"
 
-	"go.viam.com/rdk/components/board"
-	"go.viam.com/rdk/components/board/genericlinux"
+	"go.viam.com/rdk/components/board/genericlinux/buses"
 	"go.viam.com/rdk/components/movementsensor"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -38,7 +37,7 @@ type PmtkI2CNMEAMovementSensor struct {
 	lastPosition       movementsensor.LastPosition
 	lastCompassHeading movementsensor.LastCompassHeading
 
-	bus   board.I2C
+	bus   buses.I2C
 	addr  byte
 	wbaud int
 }
@@ -65,11 +64,11 @@ func MakePmtkI2cGpsNmea(
 	name resource.Name,
 	conf *Config,
 	logger logging.Logger,
-	i2cBus board.I2C,
+	i2cBus buses.I2C,
 ) (NmeaMovementSensor, error) {
 	if i2cBus == nil {
 		var err error
-		i2cBus, err = genericlinux.NewI2cBus(conf.I2CConfig.I2CBus)
+		i2cBus, err = buses.NewI2cBus(conf.I2CConfig.I2CBus)
 		if err != nil {
 			return nil, fmt.Errorf("gps init: failed to find i2c bus %s: %w",
 				conf.I2CConfig.I2CBus, err)
@@ -204,7 +203,7 @@ func (g *PmtkI2CNMEAMovementSensor) Start(ctx context.Context) error {
 }
 
 // GetBusAddr returns the bus and address that takes in rtcm corrections.
-func (g *PmtkI2CNMEAMovementSensor) GetBusAddr() (board.I2C, byte) {
+func (g *PmtkI2CNMEAMovementSensor) GetBusAddr() (buses.I2C, byte) {
 	return g.bus, g.addr
 }
 

--- a/components/movementsensor/gpsnmea/pmtkI2C_test.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C_test.go
@@ -9,7 +9,7 @@ import (
 	"go.viam.com/test"
 	gutils "go.viam.com/utils"
 
-	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/genericlinux/buses"
 	"go.viam.com/rdk/components/movementsensor"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -22,7 +22,7 @@ const (
 	testBusName   = "1"
 )
 
-func createMockI2c() board.I2C {
+func createMockI2c() buses.I2C {
 	i2c := &inject.I2C{}
 	handle := &inject.I2CHandle{}
 	handle.WriteFunc = func(ctx context.Context, b []byte) error {
@@ -34,7 +34,7 @@ func createMockI2c() board.I2C {
 	handle.CloseFunc = func() error {
 		return nil
 	}
-	i2c.OpenHandleFunc = func(addr byte) (board.I2CHandle, error) {
+	i2c.OpenHandleFunc = func(addr byte) (buses.I2CHandle, error) {
 		return handle, nil
 	}
 	return i2c

--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
@@ -48,8 +48,7 @@ import (
 	geo "github.com/kellydunn/golang-geo"
 	"go.viam.com/utils"
 
-	"go.viam.com/rdk/components/board"
-	"go.viam.com/rdk/components/board/genericlinux"
+	"go.viam.com/rdk/components/board/genericlinux/buses"
 	"go.viam.com/rdk/components/movementsensor"
 	gpsnmea "go.viam.com/rdk/components/movementsensor/gpsnmea"
 	rtk "go.viam.com/rdk/components/movementsensor/rtkutils"
@@ -140,8 +139,8 @@ type rtkI2C struct {
 	nmeamovementsensor gpsnmea.NmeaMovementSensor
 	correctionWriter   io.ReadWriteCloser
 
-	bus     board.I2C
-	mockI2c board.I2C // Will be nil unless we're in a unit test
+	bus     buses.I2C
+	mockI2c buses.I2C // Will be nil unless we're in a unit test
 	wbaud   int
 	addr    byte
 }
@@ -164,7 +163,7 @@ func (g *rtkI2C) Reconfigure(ctx context.Context, deps resource.Dependencies, co
 	g.addr = byte(newConf.I2CAddr)
 
 	if g.mockI2c == nil {
-		i2cbus, err := genericlinux.NewI2cBus(newConf.I2CBus)
+		i2cbus, err := buses.NewI2cBus(newConf.I2CBus)
 		if err != nil {
 			return fmt.Errorf("gps init: failed to find i2c bus %s: %w", newConf.I2CBus, err)
 		}
@@ -220,7 +219,7 @@ func makeRTKI2C(
 	deps resource.Dependencies,
 	conf resource.Config,
 	logger logging.Logger,
-	mockI2c board.I2C,
+	mockI2c buses.I2C,
 ) (movementsensor.MovementSensor, error) {
 	newConf, err := resource.NativeConfig[*Config](conf)
 	if err != nil {

--- a/components/movementsensor/imuvectornav/imu.go
+++ b/components/movementsensor/imuvectornav/imu.go
@@ -14,8 +14,7 @@ import (
 	"github.com/pkg/errors"
 	goutils "go.viam.com/utils"
 
-	"go.viam.com/rdk/components/board"
-	"go.viam.com/rdk/components/board/genericlinux"
+	"go.viam.com/rdk/components/board/genericlinux/buses"
 	"go.viam.com/rdk/components/movementsensor"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -77,7 +76,7 @@ type vectornav struct {
 
 	cancelFunc              func()
 	activeBackgroundWorkers sync.WaitGroup
-	bus                     board.SPI
+	bus                     buses.SPI
 	cs                      string
 	speed                   int
 	logger                  logging.Logger
@@ -132,7 +131,7 @@ func newVectorNav(
 	pfreq := *newConf.Pfreq
 	v := &vectornav{
 		Named:     conf.ResourceName().AsNamed(),
-		bus:       genericlinux.NewSpiBus(newConf.SPI),
+		bus:       buses.NewSpiBus(newConf.SPI),
 		logger:    logger,
 		cs:        newConf.CSPin,
 		speed:     speed,

--- a/components/movementsensor/mpu6050/mpu6050.go
+++ b/components/movementsensor/mpu6050/mpu6050.go
@@ -31,8 +31,7 @@ import (
 	"github.com/pkg/errors"
 	"go.viam.com/utils"
 
-	"go.viam.com/rdk/components/board"
-	"go.viam.com/rdk/components/board/genericlinux"
+	"go.viam.com/rdk/components/board/genericlinux/buses"
 	"go.viam.com/rdk/components/movementsensor"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -74,7 +73,7 @@ func init() {
 type mpu6050 struct {
 	resource.Named
 	resource.AlwaysRebuild
-	bus        board.I2C
+	bus        buses.I2C
 	i2cAddress byte
 	mu         sync.Mutex
 
@@ -114,7 +113,7 @@ func NewMpu6050(
 		return nil, err
 	}
 
-	bus, err := genericlinux.NewI2cBus(newConf.I2cBus)
+	bus, err := buses.NewI2cBus(newConf.I2cBus)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +126,7 @@ func makeMpu6050(
 	_ resource.Dependencies,
 	conf resource.Config,
 	logger logging.Logger,
-	bus board.I2C,
+	bus buses.I2C,
 ) (movementsensor.MovementSensor, error) {
 	newConf, err := resource.NativeConfig[*Config](conf)
 	if err != nil {

--- a/components/movementsensor/mpu6050/mpu6050_test.go
+++ b/components/movementsensor/mpu6050/mpu6050_test.go
@@ -11,7 +11,7 @@ import (
 	"go.viam.com/utils"
 	"go.viam.com/utils/testutils"
 
-	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/genericlinux/buses"
 	"go.viam.com/rdk/components/movementsensor"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -49,7 +49,7 @@ func TestInitializationFailureOnChipCommunication(t *testing.T) {
 		}
 		i2cHandle.CloseFunc = func() error { return nil }
 		i2c := &inject.I2C{}
-		i2c.OpenHandleFunc = func(addr byte) (board.I2CHandle, error) {
+		i2c.OpenHandleFunc = func(addr byte) (buses.I2CHandle, error) {
 			return i2cHandle, nil
 		}
 
@@ -79,7 +79,7 @@ func TestInitializationFailureOnChipCommunication(t *testing.T) {
 		}
 		i2cHandle.CloseFunc = func() error { return nil }
 		i2c := &inject.I2C{}
-		i2c.OpenHandleFunc = func(addr byte) (board.I2CHandle, error) {
+		i2c.OpenHandleFunc = func(addr byte) (buses.I2CHandle, error) {
 			return i2cHandle, nil
 		}
 
@@ -121,7 +121,7 @@ func TestSuccessfulInitializationAndClose(t *testing.T) {
 	}
 	i2cHandle.CloseFunc = func() error { return nil }
 	i2c := &inject.I2C{}
-	i2c.OpenHandleFunc = func(addr byte) (board.I2CHandle, error) {
+	i2c.OpenHandleFunc = func(addr byte) (buses.I2CHandle, error) {
 		return i2cHandle, nil
 	}
 
@@ -133,7 +133,7 @@ func TestSuccessfulInitializationAndClose(t *testing.T) {
 	test.That(t, closeWasCalled, test.ShouldBeTrue)
 }
 
-func setupDependencies(mockData []byte) (resource.Config, board.I2C) {
+func setupDependencies(mockData []byte) (resource.Config, buses.I2C) {
 	i2cName := "i2c"
 
 	cfg := resource.Config{
@@ -158,7 +158,7 @@ func setupDependencies(mockData []byte) (resource.Config, board.I2C) {
 	}
 	i2cHandle.CloseFunc = func() error { return nil }
 	i2c := &inject.I2C{}
-	i2c.OpenHandleFunc = func(addr byte) (board.I2CHandle, error) {
+	i2c.OpenHandleFunc = func(addr byte) (buses.I2CHandle, error) {
 		return i2cHandle, nil
 	}
 	return cfg, i2c

--- a/components/movementsensor/rtkutils/gpsrtk.go
+++ b/components/movementsensor/rtkutils/gpsrtk.go
@@ -13,7 +13,7 @@ import (
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
 
-	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/genericlinux/buses"
 	"go.viam.com/rdk/components/movementsensor"
 	gpsnmea "go.viam.com/rdk/components/movementsensor/gpsnmea"
 	"go.viam.com/rdk/logging"
@@ -42,7 +42,7 @@ type RTKMovementSensor struct {
 	InputProtocol      string
 	CorrectionWriter   io.ReadWriteCloser
 
-	Bus       board.I2C
+	Bus       buses.I2C
 	Wbaud     int
 	Addr      byte // for i2c only
 	Writepath string

--- a/components/sensor/bme280/bme280.go
+++ b/components/sensor/bme280/bme280.go
@@ -15,8 +15,7 @@ import (
 
 	"go.viam.com/utils"
 
-	"go.viam.com/rdk/components/board"
-	"go.viam.com/rdk/components/board/genericlinux"
+	"go.viam.com/rdk/components/board/genericlinux/buses"
 	"go.viam.com/rdk/components/sensor"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -127,7 +126,7 @@ func newSensor(
 	conf *Config,
 	logger logging.Logger,
 ) (sensor.Sensor, error) {
-	i2cbus, err := genericlinux.NewI2cBus(conf.I2CBus)
+	i2cbus, err := buses.NewI2cBus(conf.I2CBus)
 	if err != nil {
 		return nil, fmt.Errorf("bme280 init: failed to open i2c bus %s: %w",
 			conf.I2CBus, err)
@@ -200,7 +199,7 @@ type bme280 struct {
 	resource.TriviallyCloseable
 	logger logging.Logger
 
-	bus         board.I2C
+	bus         buses.I2C
 	addr        byte
 	calibration map[string]int
 	lastTemp    float64 // Store raw data from temp for humidity calculations

--- a/components/sensor/sht3xd/sht3xd.go
+++ b/components/sensor/sht3xd/sht3xd.go
@@ -14,8 +14,7 @@ import (
 	"go.uber.org/multierr"
 	"go.viam.com/utils"
 
-	"go.viam.com/rdk/components/board"
-	"go.viam.com/rdk/components/board/genericlinux"
+	"go.viam.com/rdk/components/board/genericlinux/buses"
 	"go.viam.com/rdk/components/sensor"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -74,7 +73,7 @@ func newSensor(
 	conf *Config,
 	logger logging.Logger,
 ) (sensor.Sensor, error) {
-	i2cbus, err := genericlinux.NewI2cBus(conf.I2cBus)
+	i2cbus, err := buses.NewI2cBus(conf.I2cBus)
 	if err != nil {
 		return nil, fmt.Errorf("sht3xd init: failed to find i2c bus %s", conf.I2cBus)
 	}
@@ -107,7 +106,7 @@ type sht3xd struct {
 	resource.TriviallyCloseable
 	logger logging.Logger
 
-	bus  board.I2C
+	bus  buses.I2C
 	addr byte
 }
 

--- a/testutils/inject/i2c.go
+++ b/testutils/inject/i2c.go
@@ -3,17 +3,17 @@ package inject
 import (
 	"context"
 
-	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/genericlinux/buses"
 )
 
 // I2C is an injected I2C.
 type I2C struct {
-	board.I2C
-	OpenHandleFunc func(addr byte) (board.I2CHandle, error)
+	buses.I2C
+	OpenHandleFunc func(addr byte) (buses.I2CHandle, error)
 }
 
 // OpenHandle calls the injected OpenHandle or the real version.
-func (s *I2C) OpenHandle(addr byte) (board.I2CHandle, error) {
+func (s *I2C) OpenHandle(addr byte) (buses.I2CHandle, error) {
 	if s.OpenHandleFunc == nil {
 		return s.I2C.OpenHandle(addr)
 	}
@@ -22,7 +22,7 @@ func (s *I2C) OpenHandle(addr byte) (board.I2CHandle, error) {
 
 // I2CHandle is an injected I2CHandle.
 type I2CHandle struct {
-	board.I2CHandle
+	buses.I2CHandle
 	WriteFunc          func(ctx context.Context, tx []byte) error
 	ReadFunc           func(ctx context.Context, count int) ([]byte, error)
 	ReadByteDataFunc   func(ctx context.Context, register byte) (byte, error)

--- a/testutils/inject/spi.go
+++ b/testutils/inject/spi.go
@@ -1,17 +1,17 @@
 package inject
 
 import (
-	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/genericlinux/buses"
 )
 
 // SPI is an injected SPI.
 type SPI struct {
-	board.SPI
-	OpenHandleFunc func() (board.SPIHandle, error)
+	buses.SPI
+	OpenHandleFunc func() (buses.SPIHandle, error)
 }
 
 // OpenHandle calls the injected OpenHandle or the real version.
-func (s *SPI) OpenHandle() (board.SPIHandle, error) {
+func (s *SPI) OpenHandle() (buses.SPIHandle, error) {
 	if s.OpenHandleFunc == nil {
 		return s.SPI.OpenHandle()
 	}


### PR DESCRIPTION
This way, when people use the RDK code as the Golang SDK, they don't mistakenly think this stuff is part of the Board API. There's now a `buses` package inside the `genericlinux` package, which has SPI and I2C stuff. There are separate files for interfaces and implementations, though I'm open to merging them if anyone wants that.

Also, per https://github.com/viamrobotics/rdk/pull/3251#discussion_r1401640479, I removed the unused `Attributes` field from the genericlinux config. Except for the first two commits, each commit ought to be relatively self-contained and reviewable on its own.