### PR TITLE
5883 skip a flaky test

### DIFF
--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -552,6 +552,7 @@ func TestMoveOnMapPlans(t *testing.T) {
 	})
 
 	t.Run("check that position-only mode executes", func(t *testing.T) {
+		// TODO(RSDK-5758): unskip this
 		t.Skip()
 		kb, ms := createMoveOnMapEnvironment(ctx, t, "pointcloud/octagonspace.pcd", 40)
 		defer ms.Close(ctx)

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -552,6 +552,7 @@ func TestMoveOnMapPlans(t *testing.T) {
 	})
 
 	t.Run("check that position-only mode executes", func(t *testing.T) {
+		t.Skip()
 		kb, ms := createMoveOnMapEnvironment(ctx, t, "pointcloud/octagonspace.pcd", 40)
 		defer ms.Close(ctx)
 		success, err := ms.MoveOnMap(


### PR DESCRIPTION
This is one that keeps coming up and is likely the result of a bug that I documented on RSDK-5758. That ticket is still under review and the unskipping of this test will come with its resolution