### PR TITLE
Revert "RSDK-4307: Add max reconfig limit per resource (#3018)"

### DIFF
--- a/resource/graph_node.go
+++ b/resource/graph_node.go
@@ -18,8 +18,6 @@ import (
 // updated or eventually removed. During its life, errors may be set on the
 // node to indicate that the resource is no longer available to external users.
 type GraphNode struct {
-	timesReconfigured atomic.Uint64
-
 	// mu guards all fields below.
 	mu sync.RWMutex
 

--- a/resource/graph_node.go
+++ b/resource/graph_node.go
@@ -45,10 +45,8 @@ type GraphNode struct {
 }
 
 var (
-	// MaxReconfigAttempts is the max number of reconfigure attempts per node/resource.
-	MaxReconfigAttempts uint64 = 5
-	errNotInitalized           = errors.New("resource not initialized yet")
-	errPendingRemoval          = errors.New("resource is pending removal")
+	errNotInitalized  = errors.New("resource not initialized yet")
+	errPendingRemoval = errors.New("resource is pending removal")
 )
 
 // NewUninitializedNode returns a node that is brand new and not yet initialized.
@@ -187,7 +185,6 @@ func (w *GraphNode) SwapResource(newRes Resource, newModel Model) {
 	w.lastErr = nil
 	w.needsReconfigure = false
 	w.markedForRemoval = false
-	w.timesReconfigured.Store(0)
 
 	// these should already be set
 	w.unresolvedDependencies = nil
@@ -246,32 +243,6 @@ func (w *GraphNode) NeedsReconfigure() bool {
 	return !w.markedForRemoval && w.needsReconfigure
 }
 
-func (w *GraphNode) timesReconfiguredErr() error {
-	var noun string
-	if w.IsUninitialized() {
-		noun = "configuration"
-	} else {
-		noun = "reconfiguration"
-	}
-	return errors.Errorf(
-		"%s error: reached max of %d %s attempts for %s",
-		noun,
-		MaxReconfigAttempts,
-		noun,
-		w.config.ResourceName(),
-	)
-}
-
-// CheckReconfigure returns whether or not the resource is able to be (re)configured
-// based on how many previous attempts were made— nil if it is able to be (re)configured,
-// or the appropriate error with the reason why it cannot (re)configure.
-func (w *GraphNode) CheckReconfigure() error {
-	if w.timesReconfigured.Load() < MaxReconfigAttempts {
-		return nil
-	}
-	return w.timesReconfiguredErr()
-}
-
 // hasUnresolvedDependencies returns whether or not this node has any
 // dependencies to be resolved (even if they are empty).
 func (w *GraphNode) hasUnresolvedDependencies() bool {
@@ -293,7 +264,6 @@ func (w *GraphNode) setNeedsReconfigure(newConfig Config, mustReconfigure bool, 
 	if mustReconfigure {
 		w.needsDependencyResolution = true
 	}
-	w.timesReconfigured.Store(0)
 	w.config = newConfig
 	w.needsReconfigure = true
 	w.markedForRemoval = false
@@ -334,12 +304,6 @@ func (w *GraphNode) setDependenciesResolved() {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.needsDependencyResolution = false
-}
-
-// IncrementTimesReconfigured increments the number of times the resource has been
-// reconfigured by 1. Value resetting handled in other methods situationally.
-func (w *GraphNode) IncrementTimesReconfigured() {
-	w.timesReconfigured.Add(1)
 }
 
 // UnresolvedDependencies returns the set of names that are yet to be resolved as

--- a/resource/graph_node_test.go
+++ b/resource/graph_node_test.go
@@ -106,7 +106,7 @@ func lifecycleTest(t *testing.T, node *resource.GraphNode, initialDeps []string)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, res, test.ShouldEqual, ourRes)
 
-	// now it needs udpate
+	// now it needs update
 	node.SetNeedsUpdate()
 	res, err = node.Resource()
 	test.That(t, err, test.ShouldBeNil)

--- a/resource/graph_node_test.go
+++ b/resource/graph_node_test.go
@@ -123,7 +123,7 @@ func lifecycleTest(t *testing.T, node *resource.GraphNode, initialDeps []string)
 	test.That(t, res, test.ShouldEqual, ourRes)
 	test.That(t, node.IsUninitialized(), test.ShouldBeFalse)
 
-	// it finally reconfigured
+	// it reconfigured
 	ourRes2 := &someResource{Resource: testutils.NewUnimplementedResource(generic.Named("foo"))}
 	node.SwapResource(ourRes2, resource.DefaultModelFamily.WithModel("baz"))
 	test.That(t, node.ResourceModel(), test.ShouldResemble, resource.DefaultModelFamily.WithModel("baz"))
@@ -159,7 +159,7 @@ func lifecycleTest(t *testing.T, node *resource.GraphNode, initialDeps []string)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, res, test.ShouldEqual, ourRes2)
 
-	// it finally reconfigured
+	// it reconfigured
 	ourRes3 := &someResource{Resource: testutils.NewUnimplementedResource(generic.Named("fooa"))}
 	node.SwapResource(ourRes3, resource.DefaultModelFamily.WithModel("bazz"))
 	test.That(t, node.ResourceModel(), test.ShouldResemble, resource.DefaultModelFamily.WithModel("bazz"))

--- a/resource/graph_node_test.go
+++ b/resource/graph_node_test.go
@@ -114,12 +114,7 @@ func lifecycleTest(t *testing.T, node *resource.GraphNode, initialDeps []string)
 	test.That(t, node.MarkedForRemoval(), test.ShouldBeFalse)
 
 	// but an error happened
-<<<<<<< HEAD
-	node.IncrementTimesReconfigured()
 	node.LogAndSetLastError(ourErr)
-=======
-	node.SetLastError(ourErr)
->>>>>>> parent of 4be5f0d9c (RSDK-4307: Add max reconfig limit per resource (#3018))
 	_, err = node.Resource()
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, ourErr.Error())
@@ -155,81 +150,14 @@ func lifecycleTest(t *testing.T, node *resource.GraphNode, initialDeps []string)
 	test.That(t, node.Config(), test.ShouldResemble, resource.Config{Attributes: utils.AttributeMap{"1": 2}})
 	test.That(t, node.UnresolvedDependencies(), test.ShouldResemble, []string{"3", "4", "5"})
 
-<<<<<<< HEAD
-	// an error happens 5 (MaxReconfigAttempts) times
-	var i uint64
-	for i = 0; i < resource.MaxReconfigAttempts; i++ {
-		test.That(t, node.CheckReconfigure(), test.ShouldBeNil)
-		node.IncrementTimesReconfigured()
-		node.LogAndSetLastError(ourErr)
-		_, err = node.Resource()
-		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, ourErr.Error())
-		res, err = node.UnsafeResource()
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, res, test.ShouldEqual, ourRes2)
-		test.That(t, node.IsUninitialized(), test.ShouldBeFalse)
-	}
-	test.That(t, node.CheckReconfigure(), test.ShouldNotBeNil)
-	test.That(t, node.CheckReconfigure().Error(), test.ShouldContainSubstring, "reconfiguration error")
-
-	// retry with new config
-	ourConf = resource.Config{Attributes: utils.AttributeMap{"1": 2}}
-	node.SetNewConfig(ourConf, []string{"6", "7", "8"})
-	test.That(t, node.NeedsReconfigure(), test.ShouldBeTrue)
-	test.That(t, node.CheckReconfigure(), test.ShouldBeNil) // test that SetNewConfig resets timesReconfigured
-	ourRes3 := &someResource{Resource: testutils.NewUnimplementedResource(generic.Named("foo"))}
-	node.SwapResource(ourRes3, resource.DefaultModelFamily.WithModel("bazz"))
-	test.That(t, node.NeedsReconfigure(), test.ShouldBeFalse)
-	test.That(t, node.CheckReconfigure(), test.ShouldBeNil)
-	res, err = node.Resource()
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, res, test.ShouldEqual, ourRes3)
-	test.That(t, node.Config(), test.ShouldResemble, resource.Config{Attributes: utils.AttributeMap{"1": 2}})
-
-	// but MaxReconfigAttempts errors happen
-	for i = 0; i < resource.MaxReconfigAttempts; i++ {
-		test.That(t, node.CheckReconfigure(), test.ShouldBeNil)
-		node.IncrementTimesReconfigured()
-		node.LogAndSetLastError(ourErr)
-		_, err = node.Resource()
-		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, ourErr.Error())
-		res, err = node.UnsafeResource()
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, res, test.ShouldEqual, ourRes3)
-	}
-	test.That(t, node.CheckReconfigure(), test.ShouldNotBeNil)
-	test.That(t, node.CheckReconfigure().Error(), test.ShouldContainSubstring, "reconfiguration error")
-
-	// parent was (re)configured
-	node.SetNeedsUpdate()
-	test.That(t, node.CheckReconfigure(), test.ShouldBeNil) // test that SetNeedsUpdate resets timesReconfigured
-
-	// but MaxReconfigAttempts errors happen in spite of this
-	for i = 0; i < resource.MaxReconfigAttempts; i++ {
-		test.That(t, node.CheckReconfigure(), test.ShouldBeNil)
-		node.IncrementTimesReconfigured()
-		node.LogAndSetLastError(ourErr)
-		_, err = node.Resource()
-		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, ourErr.Error())
-		res, err = node.UnsafeResource()
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, res, test.ShouldEqual, ourRes3)
-	}
-	test.That(t, node.CheckReconfigure(), test.ShouldNotBeNil)
-	test.That(t, node.CheckReconfigure().Error(), test.ShouldContainSubstring, "reconfiguration error")
-=======
 	// but an error happened
-	node.SetLastError(ourErr)
+	node.LogAndSetLastError(ourErr)
 	_, err = node.Resource()
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, ourErr.Error())
 	res, err = node.UnsafeResource()
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, res, test.ShouldEqual, ourRes2)
->>>>>>> parent of 4be5f0d9c (RSDK-4307: Add max reconfig limit per resource (#3018))
 
 	// it finally reconfigured
 	ourRes3 := &someResource{Resource: testutils.NewUnimplementedResource(generic.Named("fooa"))}

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -461,21 +461,6 @@ func (manager *resourceManager) Close(ctx context.Context) error {
 	return allErrs
 }
 
-// checkReconfigure returns whether or not the resource can be (re)configured based on the state of the graph node.
-// It also handles error management based on aforementioned state.
-func checkReconfigure(manager *resourceManager, gNode *resource.GraphNode) bool {
-	err := gNode.CheckReconfigure()
-	if err != nil {
-		if res, lastErr := gNode.Resource(); res == nil && lastErr.Error() == err.Error() {
-			manager.logger.Debug(err)
-		} else {
-			gNode.LogAndSetLastError(err)
-		}
-		return false
-	}
-	return true
-}
-
 // completeConfig process the tree in reverse order and attempts to build
 // or reconfigure resources that are wrapped in a placeholderResource.
 func (manager *resourceManager) completeConfig(
@@ -491,11 +476,6 @@ func (manager *resourceManager) completeConfig(
 		if !ok || !gNode.NeedsReconfigure() {
 			continue
 		}
-		shouldTryReconfigure := checkReconfigure(manager, gNode)
-		if !shouldTryReconfigure {
-			continue
-		}
-		gNode.IncrementTimesReconfigured()
 		var verb string
 		if gNode.IsUninitialized() {
 			verb = "configuring"
@@ -576,11 +556,6 @@ func (manager *resourceManager) completeConfig(
 			if !ok || !gNode.NeedsReconfigure() {
 				return
 			}
-			shouldTryReconfigure := checkReconfigure(manager, gNode)
-			if !shouldTryReconfigure {
-				return
-			}
-			gNode.IncrementTimesReconfigured()
 			if !(resName.API.IsComponent() || resName.API.IsService()) {
 				return
 			}


### PR DESCRIPTION
This reverts commit 4be5f0d9c07e9feb9b4f4d971f178e09c30b2279.

This is causing configuration flows to abort too early for cameras.