### PR TITLE
RSDK-5161 make Navigation service use MoveOnGlobeNew

### DIFF
--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/golang/geo/r3"
+	"github.com/google/uuid"
 	geo "github.com/kellydunn/golang-geo"
 	"github.com/pkg/errors"
 	servicepb "go.viam.com/api/service/motion/v1"
@@ -384,7 +385,7 @@ func (ms *builtIn) MoveOnGlobe(
 	}
 }
 
-func (ms *builtIn) MoveOnGlobeNew(ctx context.Context, req motion.MoveOnGlobeReq) (string, error) {
+func (ms *builtIn) MoveOnGlobeNew(ctx context.Context, req motion.MoveOnGlobeReq) (motion.ExecutionID, error) {
 	ms.mu.RLock()
 	defer ms.mu.RUnlock()
 	ms.logger.Debugf("MoveOnGlobeNew called with %s", req)
@@ -401,10 +402,10 @@ func (ms *builtIn) MoveOnGlobeNew(ctx context.Context, req motion.MoveOnGlobeReq
 
 	id, err := state.StartExecution(ctx, ms.state, req.ComponentName, req, planExecutorConstructor)
 	if err != nil {
-		return "", err
+		return uuid.Nil, err
 	}
 
-	return id.String(), nil
+	return id, nil
 }
 
 func (ms *builtIn) GetPose(

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -386,6 +386,9 @@ func (ms *builtIn) MoveOnGlobe(
 }
 
 func (ms *builtIn) MoveOnGlobeNew(ctx context.Context, req motion.MoveOnGlobeReq) (motion.ExecutionID, error) {
+	if err := ctx.Err(); err != nil {
+		return uuid.Nil, err
+	}
 	ms.mu.RLock()
 	defer ms.mu.RUnlock()
 	ms.logger.Debugf("MoveOnGlobeNew called with %s", req)
@@ -435,6 +438,9 @@ func (ms *builtIn) StopPlan(
 	ctx context.Context,
 	req motion.StopPlanReq,
 ) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	ms.mu.RLock()
 	defer ms.mu.RUnlock()
 	return ms.state.StopExecutionByResource(req.ComponentName)
@@ -444,6 +450,9 @@ func (ms *builtIn) ListPlanStatuses(
 	ctx context.Context,
 	req motion.ListPlanStatusesReq,
 ) ([]motion.PlanStatusWithID, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	ms.mu.RLock()
 	defer ms.mu.RUnlock()
 	return ms.state.ListPlanStatuses(req)
@@ -453,6 +462,9 @@ func (ms *builtIn) PlanHistory(
 	ctx context.Context,
 	req motion.PlanHistoryReq,
 ) ([]motion.PlanWithStatus, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	ms.mu.RLock()
 	defer ms.mu.RUnlock()
 	return ms.state.PlanHistory(req)

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	geo "github.com/kellydunn/golang-geo"
 	"github.com/pkg/errors"
+
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	"go.viam.com/test"
@@ -1889,6 +1890,13 @@ func TestMoveOnGlobeNew(t *testing.T) {
 	test.That(t, ph2[0].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateStopped)
 	test.That(t, ph2[0].StatusHistory[1].State, test.ShouldEqual, motion.PlanStateInProgress)
 	test.That(t, len(ph2[0].Plan.Steps), test.ShouldNotEqual, 0)
+
+	// Proves that calling StopPlan after the plan has reached a terminal state is idempotent
+	err = ms.StopPlan(ctx, motion.StopPlanReq{ComponentName: fakeBase.Name()})
+	test.That(t, err, test.ShouldBeNil)
+	ph3, err := ms.PlanHistory(ctx, motion.PlanHistoryReq{ComponentName: req.ComponentName})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, ph3, test.ShouldResemble, ph2)
 }
 
 func TestStopPlan(t *testing.T) {

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -12,9 +12,9 @@ import (
 	"testing"
 
 	"github.com/golang/geo/r3"
-	"github.com/google/uuid"
 	geo "github.com/kellydunn/golang-geo"
 	"github.com/pkg/errors"
+
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	"go.viam.com/test"
@@ -639,7 +639,9 @@ func TestMoveOnMapSubsequent(t *testing.T) {
 		entry1GoalLine = strings.ReplaceAll(entry1GoalLine, ":", "\":")
 
 		posepb := &commonpb.Pose{}
-		json.Unmarshal([]byte(entry1GoalLine), posepb)
+		err := json.Unmarshal([]byte(entry1GoalLine), posepb)
+		test.That(t, err, test.ShouldBeNil)
+
 		return spatialmath.NewPoseFromProtobuf(posepb)
 	}
 	goalPose1 := logLineToGoalPose(goalLogsObserver[0].Entry.Message)
@@ -1865,15 +1867,12 @@ func TestMoveOnGlobeNew(t *testing.T) {
 	executionID, err := ms.MoveOnGlobeNew(ctx, req)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, executionID, test.ShouldNotBeEmpty)
-	// should be a valid uuid when parsed
-	_, err = uuid.Parse(executionID)
-	test.That(t, err, test.ShouldBeNil)
 
 	// returns the execution just created in the history
 	ph, err := ms.PlanHistory(ctx, motion.PlanHistoryReq{ComponentName: req.ComponentName})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, len(ph), test.ShouldEqual, 1)
-	test.That(t, ph[0].Plan.ExecutionID.String(), test.ShouldResemble, executionID)
+	test.That(t, ph[0].Plan.ExecutionID, test.ShouldResemble, executionID)
 	test.That(t, len(ph[0].StatusHistory), test.ShouldEqual, 1)
 	test.That(t, ph[0].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateInProgress)
 	test.That(t, len(ph[0].Plan.Steps), test.ShouldNotEqual, 0)
@@ -1884,7 +1883,7 @@ func TestMoveOnGlobeNew(t *testing.T) {
 	ph2, err := ms.PlanHistory(ctx, motion.PlanHistoryReq{ComponentName: req.ComponentName})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, len(ph2), test.ShouldEqual, 1)
-	test.That(t, ph2[0].Plan.ExecutionID.String(), test.ShouldResemble, executionID)
+	test.That(t, ph2[0].Plan.ExecutionID, test.ShouldResemble, executionID)
 	test.That(t, len(ph2[0].StatusHistory), test.ShouldEqual, 2)
 	test.That(t, ph2[0].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateStopped)
 	test.That(t, ph2[0].StatusHistory[1].State, test.ShouldEqual, motion.PlanStateInProgress)

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
 	"github.com/pkg/errors"
-
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	"go.viam.com/test"

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/google/uuid"
 	geo "github.com/kellydunn/golang-geo"
 	"github.com/pkg/errors"
-
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	"go.viam.com/test"

--- a/services/motion/builtin/state/state_test.go
+++ b/services/motion/builtin/state/state_test.go
@@ -517,7 +517,14 @@ func TestState(t *testing.T) {
 		test.That(t, resPWS2.pws[0].StatusHistory[0].Timestamp.After(preSuccessMsg), test.ShouldBeTrue)
 		test.That(t, planStatusTimestampsInOrder(resPWS2.pws[0].StatusHistory), test.ShouldBeTrue)
 
-		// // Failed after replanning
+		// maintains success state after calling stop
+		err = s.StopExecutionByResource(myBase)
+		test.That(t, err, test.ShouldBeNil)
+		postStopPWS1, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, resPWS2.pws, test.ShouldResemble, postStopPWS1)
+
+		// Failed after replanning
 		preExecution3 := time.Now()
 		replanFailReason := errors.New("replanning failed")
 		executionID3, err := state.StartExecution(ctx, s, req.ComponentName, req, func(
@@ -592,6 +599,13 @@ func TestState(t *testing.T) {
 		test.That(t, len(resPWS3.pws[1].Plan.Steps), test.ShouldEqual, 1)
 		test.That(t, planStatusTimestampsInOrder(resPWS3.pws[0].StatusHistory), test.ShouldBeTrue)
 		test.That(t, planStatusTimestampsInOrder(resPWS3.pws[1].StatusHistory), test.ShouldBeTrue)
+
+		// maintains failed state after calling stop
+		err = s.StopExecutionByResource(myBase)
+		test.That(t, err, test.ShouldBeNil)
+		postStopPWS2, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, resPWS3.pws, test.ShouldResemble, postStopPWS2)
 
 		// Failed at the end of execution
 		preExecution4 := time.Now()

--- a/services/motion/client.go
+++ b/services/motion/client.go
@@ -3,6 +3,7 @@ package motion
 import (
 	"context"
 
+	"github.com/google/uuid"
 	geo "github.com/kellydunn/golang-geo"
 	pb "go.viam.com/api/service/motion/v1"
 	vprotoutils "go.viam.com/utils/protoutils"
@@ -131,18 +132,23 @@ func (c *client) MoveOnGlobe(
 func (c *client) MoveOnGlobeNew(
 	ctx context.Context,
 	req MoveOnGlobeReq,
-) (string, error) {
+) (ExecutionID, error) {
 	protoReq, err := req.toProtoNew(c.name)
 	if err != nil {
-		return "", err
+		return uuid.Nil, err
 	}
 
 	resp, err := c.client.MoveOnGlobeNew(ctx, protoReq)
 	if err != nil {
-		return "", err
+		return uuid.Nil, err
 	}
 
-	return resp.ExecutionId, nil
+	executionID, err := uuid.Parse(resp.ExecutionId)
+	if err != nil {
+		return uuid.Nil, err
+	}
+
+	return executionID, nil
 }
 
 func (c *client) GetPose(

--- a/services/motion/client_test.go
+++ b/services/motion/client_test.go
@@ -245,10 +245,10 @@ func TestClient(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		t.Run("returns error without calling client if params can't be cast to proto", func(t *testing.T) {
-			injectMS.MoveOnGlobeNewFunc = func(ctx context.Context, req motion.MoveOnGlobeReq) (string, error) {
+			injectMS.MoveOnGlobeNewFunc = func(ctx context.Context, req motion.MoveOnGlobeReq) (motion.ExecutionID, error) {
 				t.Log("should not be called")
 				t.FailNow()
-				return "", errors.New("should not be reached")
+				return uuid.Nil, errors.New("should not be reached")
 			}
 
 			req := motion.MoveOnGlobeReq{
@@ -261,13 +261,13 @@ func TestClient(t *testing.T) {
 			executionID, err := client.MoveOnGlobeNew(ctx, req)
 			test.That(t, err, test.ShouldNotBeNil)
 			test.That(t, err, test.ShouldBeError, errors.New("must provide a destination"))
-			test.That(t, executionID, test.ShouldEqual, "")
+			test.That(t, executionID, test.ShouldResemble, uuid.Nil)
 		})
 
 		t.Run("returns error if client returns error", func(t *testing.T) {
 			errExpected := errors.New("some client error")
-			injectMS.MoveOnGlobeNewFunc = func(ctx context.Context, req motion.MoveOnGlobeReq) (string, error) {
-				return "", errExpected
+			injectMS.MoveOnGlobeNewFunc = func(ctx context.Context, req motion.MoveOnGlobeReq) (motion.ExecutionID, error) {
+				return uuid.Nil, errExpected
 			}
 
 			req := motion.MoveOnGlobeReq{
@@ -280,12 +280,12 @@ func TestClient(t *testing.T) {
 			executionID, err := client.MoveOnGlobeNew(ctx, req)
 			test.That(t, err, test.ShouldNotBeNil)
 			test.That(t, err.Error(), test.ShouldContainSubstring, errExpected.Error())
-			test.That(t, executionID, test.ShouldEqual, "")
+			test.That(t, executionID, test.ShouldResemble, uuid.Nil)
 		})
 
 		t.Run("otherwise returns success with an executionID", func(t *testing.T) {
-			expectedExecutionID := "some execution id"
-			injectMS.MoveOnGlobeNewFunc = func(ctx context.Context, req motion.MoveOnGlobeReq) (string, error) {
+			expectedExecutionID := uuid.New()
+			injectMS.MoveOnGlobeNewFunc = func(ctx context.Context, req motion.MoveOnGlobeReq) (motion.ExecutionID, error) {
 				return expectedExecutionID, nil
 			}
 

--- a/services/motion/explore/explore.go
+++ b/services/motion/explore/explore.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	geo "github.com/kellydunn/golang-geo"
 	"github.com/pkg/errors"
 	servicepb "go.viam.com/api/service/motion/v1"
@@ -177,8 +178,8 @@ func (ms *explore) MoveOnGlobe(
 func (ms *explore) MoveOnGlobeNew(
 	ctx context.Context,
 	req motion.MoveOnGlobeReq,
-) (string, error) {
-	return "", errUnimplemented
+) (motion.ExecutionID, error) {
+	return uuid.Nil, errUnimplemented
 }
 
 func (ms *explore) GetPose(

--- a/services/motion/motion.go
+++ b/services/motion/motion.go
@@ -196,7 +196,7 @@ type Service interface {
 	MoveOnGlobeNew(
 		ctx context.Context,
 		req MoveOnGlobeReq,
-	) (string, error)
+	) (ExecutionID, error)
 	GetPose(
 		ctx context.Context,
 		componentName resource.Name,

--- a/services/motion/server.go
+++ b/services/motion/server.go
@@ -106,7 +106,7 @@ func (server *serviceServer) MoveOnGlobeNew(ctx context.Context, req *pb.MoveOnG
 		return nil, err
 	}
 
-	return &pb.MoveOnGlobeNewResponse{ExecutionId: id}, nil
+	return &pb.MoveOnGlobeNewResponse{ExecutionId: id.String()}, nil
 }
 
 func (server *serviceServer) GetPose(ctx context.Context, req *pb.GetPoseRequest) (*pb.GetPoseResponse, error) {

--- a/services/navigation/builtin/builtin.go
+++ b/services/navigation/builtin/builtin.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/golang/geo/r3"
-	"github.com/google/uuid"
 	geo "github.com/kellydunn/golang-geo"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -521,15 +520,11 @@ func (svc *builtIn) moveToWaypoint(ctx context.Context, wp navigation.Waypoint, 
 	}
 	cancelCtx, cancelFn := context.WithCancel(ctx)
 	defer cancelFn()
-	rawExecutionID, err := svc.motionService.MoveOnGlobeNew(cancelCtx, req)
+	executionID, err := svc.motionService.MoveOnGlobeNew(cancelCtx, req)
 	if err != nil {
 		return err
 	}
 
-	executionID, err := uuid.Parse(rawExecutionID)
-	if err != nil {
-		return err
-	}
 	executionWaypoint := executionWaypoint{executionID: executionID, waypoint: wp}
 	if old := svc.activeExecutionWaypoint.Swap(executionWaypoint); old != nil && old != emptyExecutionWaypoint {
 		msg := "unexpected race condition in moveOnGlobeSync, expected " +

--- a/services/navigation/builtin/builtin.go
+++ b/services/navigation/builtin/builtin.go
@@ -44,7 +44,6 @@ var (
 	errNegativeObstaclePollingFrequencyHz = errors.New("obstacle_polling_frequency_hz must be non-negative if set")
 	errNegativePlanDeviationM             = errors.New("plan_deviation_m must be non-negative if set")
 	errNegativeReplanCostFactor           = errors.New("replan_cost_factor must be non-negative if set")
-	errUnimplemented                      = errors.New("unimplemented")
 )
 
 const (
@@ -658,7 +657,6 @@ func (svc *builtIn) Paths(ctx context.Context, extra map[string]interface{}) ([]
 		ExecutionID:   ewp.executionID,
 		LastPlanOnly:  true,
 	})
-
 	if err != nil {
 		return nil, err
 	}

--- a/services/navigation/builtin/builtin.go
+++ b/services/navigation/builtin/builtin.go
@@ -689,7 +689,7 @@ func pollUntilMOGSuccessOrError(
 		case motion.PlanStateFailed:
 			err := errors.New("plan failed")
 			if reason := status.Reason; reason != nil {
-				err = errors.New(*reason)
+				err = errors.Wrap(err, *reason)
 			}
 			return err
 

--- a/services/navigation/builtin/builtin.go
+++ b/services/navigation/builtin/builtin.go
@@ -542,13 +542,9 @@ func (svc *builtIn) moveOnGlobeSync(ctx context.Context, req motion.MoveOnGlobeR
 
 func (svc *builtIn) startWaypointMode(ctx context.Context, extra map[string]interface{}) {
 	if extra == nil {
-		if false {
-			extra = map[string]interface{}{"motion_profile": "position_only"}
-		} // TODO: Fix with RSDK-4583
+		extra = map[string]interface{}{"motion_profile": "position_only"}
 	} else if _, ok := extra["motion_profile"]; !ok {
-		if false {
-			extra["motion_profile"] = "position_only"
-		} // TODO: Fix with RSDK-4583
+		extra["motion_profile"] = "position_only"
 	}
 
 	svc.activeBackgroundWorkers.Add(1)

--- a/services/navigation/builtin/builtin.go
+++ b/services/navigation/builtin/builtin.go
@@ -542,9 +542,18 @@ func (svc *builtIn) moveOnGlobeSync(ctx context.Context, req motion.MoveOnGlobeR
 
 func (svc *builtIn) startWaypointMode(ctx context.Context, extra map[string]interface{}) {
 	if extra == nil {
-		extra = map[string]interface{}{"motion_profile": "position_only"}
-	} else if _, ok := extra["motion_profile"]; !ok {
+		extra = map[string]interface{}{
+			"motion_profile": "position_only",
+			"smooth_iter":    20,
+		}
+	}
+
+	if _, ok := extra["motion_profile"]; !ok {
 		extra["motion_profile"] = "position_only"
+	}
+
+	if _, ok := extra["smooth_iter"]; !ok {
+		extra["smooth_iter"] = 20
 	}
 
 	svc.activeBackgroundWorkers.Add(1)

--- a/services/navigation/builtin/builtin.go
+++ b/services/navigation/builtin/builtin.go
@@ -673,6 +673,10 @@ func pollUntilMOGSuccessOrError(
 	req motion.PlanHistoryReq,
 ) error {
 	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		ph, err := m.PlanHistory(ctx, req)
 		if err != nil {
 			return err

--- a/services/navigation/builtin/builtin.go
+++ b/services/navigation/builtin/builtin.go
@@ -586,6 +586,7 @@ func (svc *builtIn) startWaypointMode(ctx context.Context, extra map[string]inte
 					continue
 				}
 				svc.logger.Warnf("retrying navigation to waypoint %+v since it errored out: %s", wp, err)
+				continue
 			}
 			svc.logger.Infof("reached waypoint: %+v", wp)
 		}

--- a/services/navigation/builtin/builtin.go
+++ b/services/navigation/builtin/builtin.go
@@ -526,7 +526,7 @@ func (svc *builtIn) moveOnGlobeSync(ctx context.Context, req motion.MoveOnGlobeR
 		}
 	}, svc.activeBackgroundWorkers.Done)
 
-	err = pollUntilMOGSuccessOrError(cancelCtx, svc.motionService, time.Millisecond*500,
+	err = pollUntilMOGSuccessOrError(cancelCtx, svc.motionService, time.Millisecond*50,
 		motion.PlanHistoryReq{
 			ComponentName: req.ComponentName,
 			ExecutionID:   executionID,
@@ -561,7 +561,7 @@ func (svc *builtIn) startWaypointMode(ctx context.Context, extra map[string]inte
 
 			wp, err := svc.store.NextWaypoint(ctx)
 			if err != nil {
-				time.Sleep(time.Millisecond * 200)
+				time.Sleep(time.Millisecond * 50)
 				continue
 			}
 			svc.mu.Lock()

--- a/services/navigation/builtin/builtin.go
+++ b/services/navigation/builtin/builtin.go
@@ -659,7 +659,7 @@ func (svc *builtIn) Paths(ctx context.Context, extra map[string]interface{}) ([]
 		geoPoints = append(geoPoints, geoPoint)
 	}
 
-	path, err := navigation.NewPath(ewp.waypoint.ID.String(), geoPoints)
+	path, err := navigation.NewPath(ewp.waypoint.ID, geoPoints)
 	if err != nil {
 		return nil, err
 	}

--- a/services/navigation/builtin/builtin_test.go
+++ b/services/navigation/builtin/builtin_test.go
@@ -642,9 +642,9 @@ func TestPaths(t *testing.T) {
 		// we expect 2 executions to be generated
 		executionID := uuid.New()
 		// MoveOnGlobeNew will behave as if it created a new plan & queue up a goroutine which will then behave as if the plan succeeded
-		s.injectMS.MoveOnGlobeNewFunc = func(ctx context.Context, req motion.MoveOnGlobeReq) (string, error) {
+		s.injectMS.MoveOnGlobeNewFunc = func(ctx context.Context, req motion.MoveOnGlobeReq) (motion.ExecutionID, error) {
 			if err := ctx.Err(); err != nil {
-				return "", err
+				return uuid.Nil, err
 			}
 			s.Lock()
 			defer s.Unlock()
@@ -682,7 +682,7 @@ func TestPaths(t *testing.T) {
 				}
 				t.Error("MoveOnGlobeNew called unexpectedly")
 			}, wg.Done)
-			return executionID.String(), nil
+			return executionID, nil
 		}
 
 		s.injectMS.PlanHistoryFunc = func(ctx context.Context, req motion.PlanHistoryReq) ([]motion.PlanWithStatus, error) {
@@ -779,9 +779,9 @@ func TestStartWaypoint(t *testing.T) {
 		var wg sync.WaitGroup
 		defer wg.Wait()
 		// MoveOnGlobeNew will behave as if it created a new plan & queue up a goroutine which will then behave as if the plan succeeded
-		s.injectMS.MoveOnGlobeNewFunc = func(ctx context.Context, req motion.MoveOnGlobeReq) (string, error) {
+		s.injectMS.MoveOnGlobeNewFunc = func(ctx context.Context, req motion.MoveOnGlobeReq) (motion.ExecutionID, error) {
 			if err := ctx.Err(); err != nil {
-				return "", err
+				return uuid.Nil, err
 			}
 			executionID := executionIDs[(counter.Inc())]
 			s.Lock()
@@ -814,7 +814,7 @@ func TestStartWaypoint(t *testing.T) {
 				}
 				t.Error("MoveOnGlobeNew called unexpectedly")
 			}, wg.Done)
-			return executionID.String(), nil
+			return executionID, nil
 		}
 
 		s.injectMS.PlanHistoryFunc = func(ctx context.Context, req motion.PlanHistoryReq) ([]motion.PlanWithStatus, error) {
@@ -941,9 +941,9 @@ func TestStartWaypoint(t *testing.T) {
 
 		executionID := uuid.New()
 		mogCalled := make(chan struct{}, 1)
-		s.injectMS.MoveOnGlobeNewFunc = func(ctx context.Context, req motion.MoveOnGlobeReq) (string, error) {
+		s.injectMS.MoveOnGlobeNewFunc = func(ctx context.Context, req motion.MoveOnGlobeReq) (motion.ExecutionID, error) {
 			if err := ctx.Err(); err != nil {
-				return "", err
+				return uuid.Nil, err
 			}
 
 			s.Lock()
@@ -953,7 +953,7 @@ func TestStartWaypoint(t *testing.T) {
 			s.mogrs = append(s.mogrs, req)
 			s.Unlock()
 			mogCalled <- struct{}{}
-			return executionID.String(), nil
+			return executionID, nil
 		}
 
 		// PlanHistory always reports execution is in progress
@@ -1049,9 +1049,9 @@ func TestStartWaypoint(t *testing.T) {
 			uuid.New(),
 			uuid.New(),
 		}
-		s.injectMS.MoveOnGlobeNewFunc = func(ctx context.Context, req motion.MoveOnGlobeReq) (string, error) {
+		s.injectMS.MoveOnGlobeNewFunc = func(ctx context.Context, req motion.MoveOnGlobeReq) (motion.ExecutionID, error) {
 			if err := ctx.Err(); err != nil {
-				return "", err
+				return uuid.Nil, err
 			}
 			s.Lock()
 			defer s.Unlock()
@@ -1066,9 +1066,9 @@ func TestStartWaypoint(t *testing.T) {
 			count := mogCounter.Inc()
 			switch count {
 			case 0:
-				return "", errors.New("motion error")
+				return uuid.Nil, errors.New("motion error")
 			case 1:
-				return "", context.Canceled
+				return uuid.Nil, context.Canceled
 			case 2, 3, 4:
 				executionID := executionIDs[count-2]
 				s.pws = []motion.PlanWithStatus{
@@ -1094,11 +1094,11 @@ func TestStartWaypoint(t *testing.T) {
 						}
 					}
 				}, wg.Done)
-				return executionID.String(), nil
+				return executionID, nil
 			default:
 				t.Error("unexpected call to MOG")
 				t.Fail()
-				return "", errors.New("unexpected call to MOG")
+				return uuid.Nil, errors.New("unexpected call to MOG")
 			}
 		}
 
@@ -1197,9 +1197,9 @@ func TestStartWaypoint(t *testing.T) {
 			defer s.closeFunc()
 
 			executionID := uuid.New()
-			s.injectMS.MoveOnGlobeNewFunc = func(ctx context.Context, req motion.MoveOnGlobeReq) (string, error) {
+			s.injectMS.MoveOnGlobeNewFunc = func(ctx context.Context, req motion.MoveOnGlobeReq) (motion.ExecutionID, error) {
 				if err := ctx.Err(); err != nil {
-					return "", err
+					return uuid.Nil, err
 				}
 				s.Lock()
 				defer s.Unlock()
@@ -1217,7 +1217,7 @@ func TestStartWaypoint(t *testing.T) {
 						},
 					},
 				}
-				return executionID.String(), nil
+				return executionID, nil
 			}
 
 			counter := atomic.NewInt32(0)
@@ -1309,9 +1309,9 @@ func TestStartWaypoint(t *testing.T) {
 		var wg sync.WaitGroup
 		defer wg.Wait()
 		// MoveOnGlobeNew will behave as if it created a new plan & queue up a goroutine which will then behave as if the plan succeeded
-		s.injectMS.MoveOnGlobeNewFunc = func(ctx context.Context, req motion.MoveOnGlobeReq) (string, error) {
+		s.injectMS.MoveOnGlobeNewFunc = func(ctx context.Context, req motion.MoveOnGlobeReq) (motion.ExecutionID, error) {
 			if err := ctx.Err(); err != nil {
-				return "", err
+				return uuid.Nil, err
 			}
 			executionID := executionIDs[(counter.Inc())]
 			s.Lock()
@@ -1347,7 +1347,7 @@ func TestStartWaypoint(t *testing.T) {
 					t.Error("MoveOnGlobeNew called unexpectedly")
 				}, wg.Done)
 			}
-			return executionID.String(), nil
+			return executionID, nil
 		}
 
 		planHistoryCalledCtx, planHistoryCalledCancelFn := context.WithTimeout(ctx, time.Millisecond*500)
@@ -1445,9 +1445,9 @@ func TestStartWaypoint(t *testing.T) {
 		pauseMOGSuccess := make(chan struct{})
 		resumeMOGSuccess := make(chan struct{})
 		// MoveOnGlobeNew will behave as if it created a new plan & queue up a goroutine which will then behave as if the plan succeeded
-		s.injectMS.MoveOnGlobeNewFunc = func(ctx context.Context, req motion.MoveOnGlobeReq) (string, error) {
+		s.injectMS.MoveOnGlobeNewFunc = func(ctx context.Context, req motion.MoveOnGlobeReq) (motion.ExecutionID, error) {
 			if err := ctx.Err(); err != nil {
-				return "", err
+				return uuid.Nil, err
 			}
 			executionID := executionIDs[(counter.Inc())]
 			s.Lock()
@@ -1482,7 +1482,7 @@ func TestStartWaypoint(t *testing.T) {
 				}
 				t.Error("MoveOnGlobeNew called unexpectedly")
 			}, wg.Done)
-			return executionID.String(), nil
+			return executionID, nil
 		}
 
 		s.injectMS.PlanHistoryFunc = func(ctx context.Context, req motion.PlanHistoryReq) ([]motion.PlanWithStatus, error) {

--- a/services/navigation/builtin/builtin_test.go
+++ b/services/navigation/builtin/builtin_test.go
@@ -595,7 +595,7 @@ func TestNavSetup(t *testing.T) {
 	test.That(t, len(ns.(*builtIn).motionCfg.ObstacleDetectors), test.ShouldEqual, 1)
 
 	_, err = ns.Paths(ctx, nil)
-	test.That(t, err, test.ShouldBeError, errors.New("unimplemented"))
+	test.That(t, err, test.ShouldBeError, resource.NewNotFoundError(base.Named("test_base")))
 }
 
 func TestStartWaypoint(t *testing.T) {

--- a/services/navigation/builtin/builtin_test.go
+++ b/services/navigation/builtin/builtin_test.go
@@ -1066,7 +1066,7 @@ func TestStartWaypoint(t *testing.T) {
 			}
 			s.mogrs = append(s.mogrs, req)
 
-			// first call returns motion erro
+			// first call returns motion error
 			// second call returns context cancelled
 			// third call returns success
 			count := mogCounter.Inc()

--- a/services/navigation/builtin/builtin_test.go
+++ b/services/navigation/builtin/builtin_test.go
@@ -3,17 +3,20 @@ package builtin
 import (
 	"context"
 	"errors"
+	"math"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/golang/geo/r3"
+	"github.com/google/uuid"
 	geo "github.com/kellydunn/golang-geo"
+	"go.uber.org/atomic"
 	"go.viam.com/test"
-	"go.viam.com/utils/testutils"
+	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/base"
-	fakebase "go.viam.com/rdk/components/base/fake"
-	"go.viam.com/rdk/components/base/kinematicbase"
+	baseFake "go.viam.com/rdk/components/base/fake"
 	"go.viam.com/rdk/components/camera"
 	_ "go.viam.com/rdk/components/camera/fake"
 	"go.viam.com/rdk/components/movementsensor"
@@ -24,15 +27,24 @@ import (
 	"go.viam.com/rdk/resource"
 	robotimpl "go.viam.com/rdk/robot/impl"
 	"go.viam.com/rdk/services/motion"
-	_ "go.viam.com/rdk/services/motion/builtin"
 	"go.viam.com/rdk/services/navigation"
-	"go.viam.com/rdk/services/slam"
-	fakeslam "go.viam.com/rdk/services/slam/fake"
 	"go.viam.com/rdk/services/vision"
 	_ "go.viam.com/rdk/services/vision/colordetector"
 	"go.viam.com/rdk/spatialmath"
 	"go.viam.com/rdk/testutils/inject"
 )
+
+type startWaypointState struct {
+	ns             navigation.Service
+	injectMS       *inject.MotionService
+	base           base.Base
+	movementSensor *inject.MovementSensor
+	closeFunc      func()
+	sync.RWMutex
+	pws   []motion.PlanWithStatus
+	mogrs []motion.MoveOnGlobeReq
+	sprs  []motion.StopPlanReq
+}
 
 func setupNavigationServiceFromConfig(t *testing.T, configFilename string) (navigation.Service, func()) {
 	t.Helper()
@@ -48,42 +60,6 @@ func setupNavigationServiceFromConfig(t *testing.T, configFilename string) (navi
 	return svc, func() {
 		myRobot.Close(context.Background())
 	}
-}
-
-func currentInputsShouldEqual(ctx context.Context, t *testing.T, kinematicBase kinematicbase.KinematicBase, pt *geo.Point) {
-	t.Helper()
-	inputs, err := kinematicBase.CurrentInputs(ctx)
-	test.That(t, err, test.ShouldBeNil)
-	actualPt := geo.NewPoint(inputs[0].Value, inputs[1].Value)
-	test.That(t, actualPt.Lat(), test.ShouldEqual, pt.Lat())
-	test.That(t, actualPt.Lng(), test.ShouldEqual, pt.Lng())
-}
-
-func blockTillCallCount(t *testing.T, callCount int, callChan chan struct{}, timeout time.Duration) {
-	t.Helper()
-	waitForCallsTimeOutCtx, cancelFn := context.WithTimeout(context.Background(), timeout)
-	defer cancelFn()
-	for i := 0; i < callCount; i++ {
-		select {
-		case <-callChan:
-		case <-waitForCallsTimeOutCtx.Done():
-			t.Log("timed out waiting for test to finish")
-			t.FailNow()
-		}
-	}
-}
-
-func deleteAllWaypoints(ctx context.Context, svc navigation.Service) error {
-	waypoints, err := svc.(*builtIn).store.Waypoints(ctx)
-	if err != nil {
-		return err
-	}
-	for _, wp := range waypoints {
-		if err := svc.RemoveWaypoint(ctx, wp.ID, nil); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func TestValidateConfig(t *testing.T) {
@@ -598,374 +574,663 @@ func TestNavSetup(t *testing.T) {
 	test.That(t, err, test.ShouldBeError, resource.NewNotFoundError(base.Named("test_base")))
 }
 
-func TestStartWaypoint(t *testing.T) {
-	// TODO(RSDK-5193): unskip this test
-	t.Skip()
-	ctx := context.Background()
-	logger := logging.NewTestLogger(t)
-
-	injectMS := inject.NewMotionService("test_motion")
-	cfg := resource.Config{
+func setupStartWaypoint(ctx context.Context, t *testing.T, logger logging.Logger) startWaypointState {
+	fakeBase, err := baseFake.NewBase(ctx, nil, resource.Config{
 		Name:  "test_base",
 		API:   base.API,
 		Frame: &referenceframe.LinkConfig{Geometry: &spatialmath.GeometryConfig{R: 100}},
-	}
-
-	fakeBase, err := fakebase.NewBase(ctx, nil, cfg, logger)
-	test.That(t, err, test.ShouldBeNil)
-
-	fakeSlam := fakeslam.NewSLAM(slam.Named("foo"), logger)
-	limits, err := fakeSlam.Limits(ctx)
-	test.That(t, err, test.ShouldBeNil)
-
-	localizer := motion.NewSLAMLocalizer(fakeSlam)
-	test.That(t, err, test.ShouldBeNil)
-
-	// cast fakeBase
-	fake, ok := fakeBase.(*fakebase.Base)
-	test.That(t, ok, test.ShouldBeTrue)
-
-	options := kinematicbase.NewKinematicBaseOptions()
-	options.PositionOnlyMode = false
-
-	// TODO: Test this with PTGs
-	kinematicBase, err := kinematicbase.WrapWithFakeDiffDriveKinematics(ctx, fake, localizer, limits, options, nil)
+	}, logger)
 	test.That(t, err, test.ShouldBeNil)
 
 	injectMovementSensor := inject.NewMovementSensor("test_movement")
-	injectMovementSensor.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
-		inputs, err := kinematicBase.CurrentInputs(ctx)
-		return geo.NewPoint(inputs[0].Value, inputs[1].Value), 0, err
-	}
-
-	ns, err := NewBuiltIn(
-		ctx,
-		resource.Dependencies{injectMS.Name(): injectMS, fakeBase.Name(): fakeBase, injectMovementSensor.Name(): injectMovementSensor},
-		resource.Config{
-			ConvertedAttributes: &Config{
-				Store: navigation.StoreConfig{
-					Type: navigation.StoreTypeMemory,
+	visionService := inject.NewVisionService("vision")
+	camera := inject.NewCamera("camera")
+	config := resource.Config{
+		ConvertedAttributes: &Config{
+			Store: navigation.StoreConfig{
+				Type: navigation.StoreTypeMemory,
+			},
+			BaseName:           "test_base",
+			MovementSensorName: "test_movement",
+			MotionServiceName:  "test_motion",
+			DegPerSec:          1,
+			MetersPerSec:       1,
+			ObstacleDetectors: []*ObstacleDetectorNameConfig{
+				{
+					VisionServiceName: "vision",
+					CameraName:        "camera",
 				},
-				BaseName:           "test_base",
-				MovementSensorName: "test_movement",
-				MotionServiceName:  "test_motion",
-				DegPerSec:          1,
-				MetersPerSec:       1,
 			},
 		},
-		logger,
-	)
+	}
+	injectMS := inject.NewMotionService("test_motion")
+	deps := resource.Dependencies{
+		injectMS.Name():             injectMS,
+		fakeBase.Name():             fakeBase,
+		injectMovementSensor.Name(): injectMovementSensor,
+		visionService.Name():        visionService,
+		camera.Name():               camera,
+	}
+	ns, err := NewBuiltIn(ctx, deps, config, logger)
 	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, ns.Close(context.Background()), test.ShouldBeNil)
-	}()
+	return startWaypointState{
+		ns:             ns,
+		injectMS:       injectMS,
+		base:           fakeBase,
+		movementSensor: injectMovementSensor,
+		closeFunc:      func() { test.That(t, ns.Close(context.Background()), test.ShouldBeNil) },
+	}
+}
+
+func TestStartWaypoint(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewTestLogger(t)
+	points := []*geo.Point{geo.NewPoint(1, 2), geo.NewPoint(2, 3)}
 
 	t.Run("Reach waypoints successfully", func(t *testing.T) {
-		callChan := make(chan struct{}, 2)
-		injectMS.MoveOnGlobeFunc = func(
-			ctx context.Context,
-			componentName resource.Name,
-			destination *geo.Point,
-			heading float64,
-			movementSensorName resource.Name,
-			obstacles []*spatialmath.GeoObstacle,
-			motionCfg *motion.MotionConfiguration,
-			extra map[string]interface{},
-		) (bool, error) {
-			err := kinematicBase.GoToInputs(ctx, referenceframe.FloatsToInputs([]float64{destination.Lat(), destination.Lng()}))
-			callChan <- struct{}{}
-			return true, err
+		s := setupStartWaypoint(ctx, t, logger)
+		defer s.closeFunc()
+
+		// starts in manual mode
+		mode, err := s.ns.Mode(ctx, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, mode, test.ShouldEqual, navigation.ModeManual)
+
+		// we expect 2 executions to be generated
+		executionIDs := []uuid.UUID{
+			uuid.New(),
+			uuid.New(),
 		}
-		pt := geo.NewPoint(1, 0)
-		err = ns.AddWaypoint(ctx, pt, nil)
-		test.That(t, err, test.ShouldBeNil)
-
-		pt = geo.NewPoint(3, 1)
-		err = ns.AddWaypoint(ctx, pt, nil)
-		test.That(t, err, test.ShouldBeNil)
-
-		ns.(*builtIn).mode = navigation.ModeManual
-		err = ns.SetMode(ctx, navigation.ModeWaypoint, nil)
-		test.That(t, err, test.ShouldBeNil)
-		blockTillCallCount(t, 2, callChan, time.Second*5)
-		ns.(*builtIn).wholeServiceCancelFunc()
-		ns.(*builtIn).activeBackgroundWorkers.Wait()
-
-		currentInputsShouldEqual(ctx, t, kinematicBase, pt)
-	})
-
-	t.Run("Extra defaults to motion_profile", func(t *testing.T) {
-		callChan := make(chan struct{}, 1)
-
-		injectMS.MoveOnGlobeFunc = func(
-			ctx context.Context,
-			componentName resource.Name,
-			destination *geo.Point,
-			heading float64,
-			movementSensorName resource.Name,
-			obstacles []*spatialmath.GeoObstacle,
-			motionCfg *motion.MotionConfiguration,
-			extra map[string]interface{},
-		) (bool, error) {
-			callChan <- struct{}{}
-			if extra != nil && extra["motion_profile"] != nil {
-				return true, nil
+		counter := atomic.NewInt32(-1)
+		var wg sync.WaitGroup
+		defer wg.Wait()
+		// MoveOnGlobeNew will behave as if it created a new plan & queue up a goroutine which will then behave as if the plan succeeded
+		s.injectMS.MoveOnGlobeNewFunc = func(ctx context.Context, req motion.MoveOnGlobeReq) (string, error) {
+			executionID := executionIDs[(counter.Inc())]
+			s.Lock()
+			defer s.Unlock()
+			if s.mogrs == nil {
+				s.mogrs = []motion.MoveOnGlobeReq{}
 			}
-			return false, errors.New("no motion_profile exist")
-		}
-
-		// construct new point to navigate to
-		pt := geo.NewPoint(0, 0)
-		err = ns.AddWaypoint(ctx, pt, nil)
-		test.That(t, err, test.ShouldBeNil)
-
-		cancelCtx, fn := context.WithCancel(ctx)
-		ns.(*builtIn).startWaypointMode(cancelCtx, map[string]interface{}{})
-		blockTillCallCount(t, 1, callChan, time.Second*5)
-		fn()
-		ns.(*builtIn).activeBackgroundWorkers.Wait()
-
-		// go to same point again
-		err = ns.AddWaypoint(ctx, pt, nil)
-		test.That(t, err, test.ShouldBeNil)
-
-		cancelCtx, fn = context.WithCancel(ctx)
-		ns.(*builtIn).startWaypointMode(cancelCtx, nil)
-		blockTillCallCount(t, 1, callChan, time.Second*5)
-		fn()
-		ns.(*builtIn).activeBackgroundWorkers.Wait()
-	})
-
-	t.Run("Test MoveOnGlobe cancellation and errors", func(t *testing.T) {
-		eventChannel, statusChannel := make(chan string), make(chan string, 1)
-		cancelledContextMsg := "context cancelled"
-		hitAnErrorMsg := "hit an error"
-		arrivedAtWaypointMsg := "arrived at destination"
-		invalidStateMsg := "bad message passed to event channel"
-
-		injectMS.MoveOnGlobeFunc = func(
-			ctx context.Context,
-			componentName resource.Name,
-			destination *geo.Point,
-			heading float64,
-			movementSensorName resource.Name,
-			obstacles []*spatialmath.GeoObstacle,
-			motionCfg *motion.MotionConfiguration,
-			extra map[string]interface{},
-		) (bool, error) {
-			if ctx.Err() != nil {
-				statusChannel <- cancelledContextMsg
-				return false, ctx.Err()
+			s.mogrs = append(s.mogrs, req)
+			s.pws = []motion.PlanWithStatus{
+				{
+					Plan: motion.Plan{
+						ExecutionID: executionID,
+					},
+					StatusHistory: []motion.PlanStatus{
+						{State: motion.PlanStateInProgress},
+					},
+				},
 			}
-			select {
-			case <-ctx.Done():
-				statusChannel <- cancelledContextMsg
-				return false, ctx.Err()
-			case msg := <-eventChannel:
-				var err error
-				if msg == arrivedAtWaypointMsg {
-					err = kinematicBase.GoToInputs(
-						ctx,
-						referenceframe.FloatsToInputs([]float64{destination.Lat(), destination.Lng()}),
-					)
+			wg.Add(1)
+			utils.ManagedGo(func() {
+				s.Lock()
+				defer s.Unlock()
+				for i, p := range s.pws {
+					if p.Plan.ExecutionID == executionID {
+						succeeded := []motion.PlanStatus{{State: motion.PlanStateSucceeded}}
+						p.StatusHistory = append(succeeded, p.StatusHistory...)
+						s.pws[i] = p
+						return
+					}
 				}
-
-				statusChannel <- msg
-				switch {
-				case msg == hitAnErrorMsg:
-					return false, errors.New(hitAnErrorMsg)
-				case msg == arrivedAtWaypointMsg:
-					return true, err
-				default:
-					// should be unreachable
-					return false, errors.New(invalidStateMsg)
-				}
-			}
+				t.Error("MoveOnGlobeNew called unexpectedly")
+			}, wg.Done)
+			return executionID.String(), nil
 		}
 
-		pt1, pt2, pt3 := geo.NewPoint(1, 2), geo.NewPoint(2, 3), geo.NewPoint(3, 4)
-		points := []*geo.Point{pt1, pt2, pt3}
-		t.Run("MoveOnGlobe error results in skipping the current waypoint", func(t *testing.T) {
-			// Set manual mode to ensure waypoint loop from prior test exits
-			err = ns.SetMode(ctx, navigation.ModeManual, nil)
-			test.That(t, err, test.ShouldBeNil)
-			ctx, cancelFunc := context.WithCancel(ctx)
-			defer ns.(*builtIn).activeBackgroundWorkers.Wait()
-			defer cancelFunc()
-			err = deleteAllWaypoints(ctx, ns)
-			for _, pt := range points {
-				err = ns.AddWaypoint(ctx, pt, nil)
-				test.That(t, err, test.ShouldBeNil)
+		s.injectMS.PlanHistoryFunc = func(ctx context.Context, req motion.PlanHistoryReq) ([]motion.PlanWithStatus, error) {
+			s.RLock()
+			defer s.RUnlock()
+			history := make([]motion.PlanWithStatus, len(s.pws))
+			copy(history, s.pws)
+			return history, nil
+		}
+
+		s.injectMS.StopPlanFunc = func(ctx context.Context, req motion.StopPlanReq) error {
+			s.Lock()
+			defer s.Unlock()
+			if s.sprs == nil {
+				s.sprs = []motion.StopPlanReq{}
 			}
+			s.sprs = append(s.sprs, req)
+			return nil
+		}
 
-			ns.(*builtIn).startWaypointMode(ctx, nil)
+		pt1 := geo.NewPoint(1, 0)
+		err = s.ns.AddWaypoint(ctx, pt1, nil)
+		test.That(t, err, test.ShouldBeNil)
 
-			// Get the ID of the first waypoint
-			wp1, err := ns.(*builtIn).store.NextWaypoint(ctx)
-			test.That(t, err, test.ShouldBeNil)
+		pt2 := geo.NewPoint(3, 1)
+		err = s.ns.AddWaypoint(ctx, pt2, nil)
+		test.That(t, err, test.ShouldBeNil)
 
-			// Reach the first waypoint
-			eventChannel <- arrivedAtWaypointMsg
-			test.That(t, <-statusChannel, test.ShouldEqual, arrivedAtWaypointMsg)
-			currentInputsShouldEqual(ctx, t, kinematicBase, pt1)
+		wps, err := s.ns.Waypoints(ctx, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(wps), test.ShouldEqual, 2)
 
-			// Ensure we aren't querying before the nav service has a chance to mark the previous waypoint visited.
-			wp2, err := ns.(*builtIn).store.NextWaypoint(ctx)
-			test.That(t, err, test.ShouldBeNil)
-			for wp2.ID == wp1.ID {
-				wp2, err = ns.(*builtIn).store.NextWaypoint(ctx)
-				test.That(t, err, test.ShouldBeNil)
-			}
+		err = s.ns.SetMode(ctx, navigation.ModeWaypoint, nil)
+		test.That(t, err, test.ShouldBeNil)
 
-			// Skip the second waypoint due to an error
-			eventChannel <- hitAnErrorMsg
-			test.That(t, <-statusChannel, test.ShouldEqual, hitAnErrorMsg)
-			currentInputsShouldEqual(ctx, t, kinematicBase, pt1)
-
-			// Ensure we aren't querying before the nav service has a chance to mark the previous waypoint visited.
-			wp3, err := ns.(*builtIn).store.NextWaypoint(ctx)
-			test.That(t, err, test.ShouldBeNil)
-			for wp3.ID == wp2.ID {
-				wp3, err = ns.(*builtIn).store.NextWaypoint(ctx)
-				test.That(t, err, test.ShouldBeNil)
-			}
-
-			// Reach the third waypoint
-			eventChannel <- arrivedAtWaypointMsg
-			test.That(t, <-statusChannel, test.ShouldEqual, arrivedAtWaypointMsg)
-			currentInputsShouldEqual(ctx, t, kinematicBase, pt3)
-		})
-
-		// Calling SetMode cancels current and future MoveOnGlobe calls
-		cases := []struct {
-			description string
-			mode        navigation.Mode
-		}{
-			{
-				description: "Calling SetMode manual cancels current and future MoveOnGlobe calls",
-				mode:        navigation.ModeManual,
-			},
-			{
-				description: "Calling SetMode explore cancels current and future MoveOnGlobe calls",
-				mode:        navigation.ModeExplore,
+		expectedMotionCfg := &motion.MotionConfiguration{
+			PositionPollingFreqHz: 2,
+			ObstaclePollingFreqHz: 2,
+			PlanDeviationMM:       1e+12,
+			LinearMPerSec:         1,
+			AngularDegsPerSec:     1,
+			ObstacleDetectors: []motion.ObstacleDetectorName{
+				{
+					VisionServiceName: vision.Named("vision"),
+					CameraName:        camera.Named("camera"),
+				},
 			},
 		}
+		// poll till waypoints is of length 0
+		// query PlanHistory & confirm that you get back UUID 2
+		timeoutCtx, cancelFn := context.WithTimeout(ctx, time.Millisecond*500)
+		defer cancelFn()
+		for {
+			if timeoutCtx.Err() != nil {
+				t.Error("test timed out")
+				t.FailNow()
+			}
+			// once all waypoints have been consumed
+			wps, err := s.ns.Waypoints(ctx, nil)
+			test.That(t, err, test.ShouldBeNil)
+			if len(wps) == 0 {
+				s.RLock()
+				// wait until StopPlan has been called twice
+				if len(s.sprs) == 2 {
+					// MoveOnGlobeNew was called twice, once for each waypoint
+					test.That(t, len(s.mogrs), test.ShouldEqual, 2)
+					test.That(t, s.mogrs[0].ComponentName, test.ShouldResemble, s.base.Name())
+					test.That(t, math.IsNaN(s.mogrs[0].Heading), test.ShouldBeTrue)
+					test.That(t, s.mogrs[0].MovementSensorName, test.ShouldResemble, s.movementSensor.Name())
+					test.That(t, s.mogrs[0].Extra, test.ShouldBeNil)
+					test.That(t, s.mogrs[0].MotionCfg, test.ShouldResemble, expectedMotionCfg)
+					test.That(t, s.mogrs[0].Obstacles, test.ShouldBeNil)
+					// waypoint 1
+					test.That(t, s.mogrs[0].Destination, test.ShouldResemble, pt1)
 
-		for _, tt := range cases {
-			t.Run(tt.description, func(t *testing.T) {
-				// Set manual mode to ensure waypoint loop from prior test exits
-				err = deleteAllWaypoints(ctx, ns)
-				test.That(t, err, test.ShouldBeNil)
-				for _, pt := range points {
-					err = ns.AddWaypoint(ctx, pt, nil)
+					test.That(t, s.mogrs[1].ComponentName, test.ShouldResemble, s.base.Name())
+					test.That(t, math.IsNaN(s.mogrs[1].Heading), test.ShouldBeTrue)
+					test.That(t, s.mogrs[1].MovementSensorName, test.ShouldResemble, s.movementSensor.Name())
+					test.That(t, s.mogrs[1].Extra, test.ShouldBeNil)
+					test.That(t, s.mogrs[0].MotionCfg, test.ShouldResemble, expectedMotionCfg)
+					test.That(t, s.mogrs[1].Obstacles, test.ShouldBeNil)
+					// waypoint 2
+					test.That(t, s.mogrs[1].Destination, test.ShouldResemble, pt2)
+
+					// PlanStop called twice, once for each waypoint
+					test.That(t, s.sprs[0].ComponentName, test.ShouldResemble, s.base.Name())
+					test.That(t, s.sprs[1].ComponentName, test.ShouldResemble, s.base.Name())
+
+					// Motion reports that the last execution succeeded
+					ph, err := s.injectMS.PlanHistory(ctx, motion.PlanHistoryReq{ComponentName: s.base.Name()})
 					test.That(t, err, test.ShouldBeNil)
+					test.That(t, len(ph), test.ShouldEqual, 1)
+					test.That(t, ph[0].Plan.ExecutionID, test.ShouldResemble, executionIDs[1])
+					test.That(t, len(ph[0].StatusHistory), test.ShouldEqual, 2)
+					test.That(t, ph[0].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateSucceeded)
+					s.RUnlock()
+					break
 				}
+				s.RUnlock()
+			}
+		}
+	})
 
-				// start navigation - set ModeManual first to ensure navigation starts up
-				err = ns.SetMode(ctx, navigation.ModeWaypoint, nil)
+	// t.Run("Extra defaults to motion_profile", func(t *testing.T) {
+	// 	callChan := make(chan struct{}, 1)
 
-				// Reach the first waypoint
-				eventChannel <- arrivedAtWaypointMsg
-				test.That(t, <-statusChannel, test.ShouldEqual, arrivedAtWaypointMsg)
-				currentInputsShouldEqual(ctx, t, kinematicBase, pt1)
+	// 	injectMS.MoveOnGlobeFunc = func(
+	// 		ctx context.Context,
+	// 		componentName resource.Name,
+	// 		destination *geo.Point,
+	// 		heading float64,
+	// 		movementSensorName resource.Name,
+	// 		obstacles []*spatialmath.GeoObstacle,
+	// 		motionCfg *motion.MotionConfiguration,
+	// 		extra map[string]interface{},
+	// 	) (bool, error) {
+	// 		callChan <- struct{}{}
+	// 		if extra != nil && extra["motion_profile"] != nil {
+	// 			return true, nil
+	// 		}
+	// 		return false, errors.New("no motion_profile exist")
+	// 	}
 
-				// Change the mode --> stops navigation to waypoints
-				err = ns.SetMode(ctx, tt.mode, nil)
+	// 	// construct new point to navigate to
+	// 	pt := geo.NewPoint(0, 0)
+	// 	err = ns.AddWaypoint(ctx, pt, nil)
+	// 	test.That(t, err, test.ShouldBeNil)
+
+	// 	cancelCtx, fn := context.WithCancel(ctx)
+	// 	ns.(*builtIn).startWaypointMode(cancelCtx, map[string]interface{}{})
+	// 	blockTillCallCount(t, 1, callChan, time.Second*5)
+	// 	fn()
+	// 	ns.(*builtIn).activeBackgroundWorkers.Wait()
+
+	// 	// go to same point again
+	// 	err = ns.AddWaypoint(ctx, pt, nil)
+	// 	test.That(t, err, test.ShouldBeNil)
+
+	// 	cancelCtx, fn = context.WithCancel(ctx)
+	// 	ns.(*builtIn).startWaypointMode(cancelCtx, nil)
+	// 	blockTillCallCount(t, 1, callChan, time.Second*5)
+	// 	fn()
+	// 	ns.(*builtIn).activeBackgroundWorkers.Wait()
+	// })
+
+	// t.Run("MoveOnGlobe error results in skipping the current waypoint", func(t *testing.T) {
+	// 	// Set manual mode to ensure waypoint loop from prior test exits
+	// 	err = ns.SetMode(ctx, navigation.ModeManual, nil)
+	// 	test.That(t, err, test.ShouldBeNil)
+	// 	ctx, cancelFunc := context.WithCancel(ctx)
+	// 	defer ns.(*builtIn).activeBackgroundWorkers.Wait()
+	// 	defer cancelFunc()
+	// 	err = deleteAllWaypoints(ctx, ns)
+	// 	for _, pt := range points {
+	// 		err = ns.AddWaypoint(ctx, pt, nil)
+	// 		test.That(t, err, test.ShouldBeNil)
+	// 	}
+
+	// 	ns.(*builtIn).startWaypointMode(ctx, nil)
+
+	// 	// Get the ID of the first waypoint
+	// 	wp1, err := ns.(*builtIn).store.NextWaypoint(ctx)
+	// 	test.That(t, err, test.ShouldBeNil)
+
+	// 	// Reach the first waypoint
+	// 	eventChannel <- arrivedAtWaypointMsg
+	// 	test.That(t, <-statusChannel, test.ShouldEqual, arrivedAtWaypointMsg)
+	// 	currentInputsShouldEqual(ctx, t, kinematicBase, pt1)
+
+	// 	// Ensure we aren't querying before the nav service has a chance to mark the previous waypoint visited.
+	// 	wp2, err := ns.(*builtIn).store.NextWaypoint(ctx)
+	// 	test.That(t, err, test.ShouldBeNil)
+	// 	for wp2.ID == wp1.ID {
+	// 		wp2, err = ns.(*builtIn).store.NextWaypoint(ctx)
+	// 		test.That(t, err, test.ShouldBeNil)
+	// 	}
+
+	// 	// Skip the second waypoint due to an error
+	// 	eventChannel <- hitAnErrorMsg
+	// 	test.That(t, <-statusChannel, test.ShouldEqual, hitAnErrorMsg)
+	// 	currentInputsShouldEqual(ctx, t, kinematicBase, pt1)
+
+	// 	// Ensure we aren't querying before the nav service has a chance to mark the previous waypoint visited.
+	// 	wp3, err := ns.(*builtIn).store.NextWaypoint(ctx)
+	// 	test.That(t, err, test.ShouldBeNil)
+	// 	for wp3.ID == wp2.ID {
+	// 		wp3, err = ns.(*builtIn).store.NextWaypoint(ctx)
+	// 		test.That(t, err, test.ShouldBeNil)
+	// 	}
+
+	// 	// Reach the third waypoint
+	// 	eventChannel <- arrivedAtWaypointMsg
+	// 	test.That(t, <-statusChannel, test.ShouldEqual, arrivedAtWaypointMsg)
+	// 	currentInputsShouldEqual(ctx, t, kinematicBase, pt3)
+	// })
+
+	// Calling SetMode cancels current and future MoveOnGlobe calls
+	cases := []struct {
+		description string
+		mode        navigation.Mode
+	}{
+		{
+			description: "Calling SetMode manual cancels context of current and future motion calls",
+			mode:        navigation.ModeManual,
+		},
+		{
+			description: "Calling SetMode explore cancels context of current and future motion calls",
+			mode:        navigation.ModeExplore,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.description, func(t *testing.T) {
+			s := setupStartWaypoint(ctx, t, logger)
+			defer s.closeFunc()
+
+			executionID := uuid.New()
+			s.injectMS.MoveOnGlobeNewFunc = func(ctx context.Context, req motion.MoveOnGlobeReq) (string, error) {
+				s.Lock()
+				defer s.Unlock()
+				if s.mogrs == nil {
+					s.mogrs = []motion.MoveOnGlobeReq{}
+				}
+				s.mogrs = append(s.mogrs, req)
+				s.pws = []motion.PlanWithStatus{
+					{
+						Plan: motion.Plan{
+							ExecutionID: executionID,
+						},
+						StatusHistory: []motion.PlanStatus{
+							{State: motion.PlanStateInProgress},
+						},
+					},
+				}
+				return executionID.String(), nil
+			}
+
+			counter := atomic.NewInt32(0)
+			modeFlag := make(chan struct{}, 1)
+			s.injectMS.PlanHistoryFunc = func(ctx context.Context, req motion.PlanHistoryReq) ([]motion.PlanWithStatus, error) {
+				s.RLock()
+				defer s.RUnlock()
+				history := make([]motion.PlanWithStatus, len(s.pws))
+				copy(history, s.pws)
+				count := counter.Inc()
+				if count == 2 {
+					modeFlag <- struct{}{}
+				}
+				return history, nil
+			}
+
+			s.injectMS.StopPlanFunc = func(ctx context.Context, req motion.StopPlanReq) error {
+				s.Lock()
+				defer s.Unlock()
+				if s.sprs == nil {
+					s.sprs = []motion.StopPlanReq{}
+				}
+				s.sprs = append(s.sprs, req)
+				for i, p := range s.pws {
+					if p.Plan.ExecutionID == executionID {
+						stopped := []motion.PlanStatus{{State: motion.PlanStateStopped}}
+						p.StatusHistory = append(stopped, p.StatusHistory...)
+						s.pws[i] = p
+						return nil
+					}
+				}
+				return nil
+			}
+
+			// Set manual mode to ensure waypoint loop from prior test exits
+			for _, pt := range points {
+				err := s.ns.AddWaypoint(ctx, pt, nil)
 				test.That(t, err, test.ShouldBeNil)
-				select {
-				case msg := <-statusChannel:
-					test.That(t, msg, test.ShouldEqual, cancelledContextMsg)
-				case <-time.After(5 * time.Second):
-					ns.(*builtIn).activeBackgroundWorkers.Wait()
-				}
-				currentInputsShouldEqual(ctx, t, kinematicBase, pt1)
-			})
+			}
+			wpBefore, err := s.ns.Waypoints(ctx, nil)
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, len(wpBefore), test.ShouldEqual, 2)
+			test.That(t, wpBefore[0].ToPoint(), test.ShouldResemble, points[0])
+			test.That(t, wpBefore[1].ToPoint(), test.ShouldResemble, points[1])
+
+			// start navigation - set ModeWaypoint first to ensure navigation starts up
+			err = s.ns.SetMode(ctx, navigation.ModeWaypoint, nil)
+			test.That(t, err, test.ShouldBeNil)
+
+			// wait until MoveOnGlobe has been called & are polling the history
+			<-modeFlag
+
+			// Change the mode --> cancels the context
+			err = s.ns.SetMode(ctx, tt.mode, nil)
+			test.That(t, err, test.ShouldBeNil)
+
+			// observe that no waypoints are deleted
+			wpAfter, err := s.ns.Waypoints(ctx, nil)
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, wpAfter, test.ShouldResemble, wpBefore)
+
+			// check the last state of the execution
+			ph, err := s.injectMS.PlanHistory(ctx, motion.PlanHistoryReq{ComponentName: s.base.Name()})
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, len(ph), test.ShouldEqual, 1)
+			test.That(t, len(ph[0].StatusHistory), test.ShouldEqual, 2)
+			// The history reports that the terminal state of the execution is stopped
+			test.That(t, ph[0].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateStopped)
+		})
+	}
+
+	t.Run("Calling RemoveWaypoint on the waypoint in progress cancels current MoveOnGlobe call", func(t *testing.T) {
+		s := setupStartWaypoint(ctx, t, logger)
+		defer s.closeFunc()
+
+		// we expect 2 executions to be generated
+		executionIDs := []uuid.UUID{
+			uuid.New(),
+			uuid.New(),
+		}
+		counter := atomic.NewInt32(-1)
+		var wg sync.WaitGroup
+		defer wg.Wait()
+		// MoveOnGlobeNew will behave as if it created a new plan & queue up a goroutine which will then behave as if the plan succeeded
+		s.injectMS.MoveOnGlobeNewFunc = func(ctx context.Context, req motion.MoveOnGlobeReq) (string, error) {
+			executionID := executionIDs[(counter.Inc())]
+			s.Lock()
+			defer s.Unlock()
+			if s.mogrs == nil {
+				s.mogrs = []motion.MoveOnGlobeReq{}
+			}
+			s.mogrs = append(s.mogrs, req)
+			s.pws = []motion.PlanWithStatus{
+				{
+					Plan: motion.Plan{
+						ExecutionID: executionID,
+					},
+					StatusHistory: []motion.PlanStatus{
+						{State: motion.PlanStateInProgress},
+					},
+				},
+			}
+			// only succeed for the second execution
+			if executionID == executionIDs[1] {
+				wg.Add(1)
+				utils.ManagedGo(func() {
+					s.Lock()
+					defer s.Unlock()
+					for i, p := range s.pws {
+						if p.Plan.ExecutionID == executionID {
+							succeeded := []motion.PlanStatus{{State: motion.PlanStateSucceeded}}
+							p.StatusHistory = append(succeeded, p.StatusHistory...)
+							s.pws[i] = p
+							return
+						}
+					}
+					t.Error("MoveOnGlobeNew called unexpectedly")
+				}, wg.Done)
+			}
+			return executionID.String(), nil
 		}
 
-		t.Run("Calling RemoveWaypoint on the waypoint in progress cancels current MoveOnGlobe call", func(t *testing.T) {
-			// Set manual mode to ensure waypoint loop from prior test exits
-			err = ns.SetMode(ctx, navigation.ModeManual, nil)
-			test.That(t, err, test.ShouldBeNil)
-			err = deleteAllWaypoints(ctx, ns)
-			for _, pt := range points {
-				err = ns.AddWaypoint(ctx, pt, nil)
-				test.That(t, err, test.ShouldBeNil)
+		planHistoryCalledCtx, planHistoryCalledCancelFn := context.WithTimeout(ctx, time.Millisecond*500)
+		defer planHistoryCalledCancelFn()
+		s.injectMS.PlanHistoryFunc = func(ctx context.Context, req motion.PlanHistoryReq) ([]motion.PlanWithStatus, error) {
+			if err := ctx.Err(); err != nil {
+				return nil, err
 			}
+			s.RLock()
+			defer s.RUnlock()
+			history := make([]motion.PlanWithStatus, len(s.pws))
+			copy(history, s.pws)
+			planHistoryCalledCancelFn()
+			return history, nil
+		}
 
-			// start navigation - set ModeManual first to ensure navigation starts up
-			err = ns.SetMode(ctx, navigation.ModeWaypoint, nil)
-
-			// Get the ID of the first waypoint
-			wp1, err := ns.(*builtIn).store.NextWaypoint(ctx)
-			test.That(t, err, test.ShouldBeNil)
-
-			// Reach the first waypoint
-			eventChannel <- arrivedAtWaypointMsg
-			test.That(t, <-statusChannel, test.ShouldEqual, arrivedAtWaypointMsg)
-			currentInputsShouldEqual(ctx, t, kinematicBase, pt1)
-
-			// Remove the second waypoint, which is in progress. Ensure we aren't querying before the nav service has a chance to mark
-			// the previous waypoint visited.
-			wp2, err := ns.(*builtIn).store.NextWaypoint(ctx)
-			test.That(t, err, test.ShouldBeNil)
-			for wp2.ID == wp1.ID {
-				wp2, err = ns.(*builtIn).store.NextWaypoint(ctx)
-				test.That(t, err, test.ShouldBeNil)
+		s.injectMS.StopPlanFunc = func(ctx context.Context, req motion.StopPlanReq) error {
+			s.Lock()
+			defer s.Unlock()
+			if s.sprs == nil {
+				s.sprs = []motion.StopPlanReq{}
 			}
+			s.sprs = append(s.sprs, req)
+			return nil
+		}
 
-			// ensure we actually start the wp2 waypoint before removing it
-			testutils.WaitForAssertion(t, func(tb testing.TB) {
-				tb.Helper()
-				ns.(*builtIn).mu.RLock()
-				svcWp := ns.(*builtIn).waypointInProgress
-				ns.(*builtIn).mu.RUnlock()
-				test.That(tb, wp2.ID, test.ShouldEqual, svcWp.ID)
-			})
-
-			err = ns.RemoveWaypoint(ctx, wp2.ID, nil)
+		// Set manual mode to ensure waypoint loop from prior test exits
+		for _, pt := range points {
+			err := s.ns.AddWaypoint(ctx, pt, nil)
 			test.That(t, err, test.ShouldBeNil)
-			test.That(t, <-statusChannel, test.ShouldEqual, cancelledContextMsg)
-			currentInputsShouldEqual(ctx, t, kinematicBase, pt1)
+		}
 
-			// Reach the third waypoint
-			eventChannel <- arrivedAtWaypointMsg
-			test.That(t, <-statusChannel, test.ShouldEqual, arrivedAtWaypointMsg)
-			currentInputsShouldEqual(ctx, t, kinematicBase, pt3)
-		})
+		wps, err := s.ns.Waypoints(ctx, nil)
+		test.That(t, err, test.ShouldBeNil)
+		wp1 := wps[0]
+		// start navigation - set ModeManual first to ensure navigation starts up
+		err = s.ns.SetMode(ctx, navigation.ModeWaypoint, nil)
+		test.That(t, err, test.ShouldBeNil)
 
-		t.Run("Calling RemoveWaypoint on a waypoint that is not in progress does not cancel MoveOnGlobe", func(t *testing.T) {
-			// Set manual mode to ensure waypoint loop from prior test exits
-			err = ns.SetMode(ctx, navigation.ModeManual, nil)
+		// wait for plan history to be called, indicating that MoveOnGlobe is in progress
+		<-planHistoryCalledCtx.Done()
+
+		err = s.ns.RemoveWaypoint(ctx, wp1.ID, nil)
+		test.That(t, err, test.ShouldBeNil)
+
+		// Reach the second waypoint
+		timeoutCtx, cancelFn := context.WithTimeout(ctx, time.Millisecond*1000)
+		defer cancelFn()
+		for {
+			if timeoutCtx.Err() != nil {
+				t.Error("test timed out")
+				t.FailNow()
+			}
+			// once all waypoints have been consumed
+			wps, err := s.ns.Waypoints(ctx, nil)
 			test.That(t, err, test.ShouldBeNil)
-			err = deleteAllWaypoints(ctx, ns)
-			var wp3 navigation.Waypoint
-			for i, pt := range points {
-				if i < 3 {
-					err = ns.AddWaypoint(ctx, pt, nil)
-					test.That(t, err, test.ShouldBeNil)
-				} else {
-					wp3, err = ns.(*builtIn).store.AddWaypoint(ctx, pt)
-					test.That(t, err, test.ShouldBeNil)
+			if len(wps) == 0 {
+				s.RLock()
+				// // MoveOnGlobeNew was called twice, once for each waypoint
+				test.That(t, len(s.mogrs), test.ShouldEqual, 2)
+				// // waypoint 1
+				test.That(t, s.mogrs[0].Destination, test.ShouldResemble, points[0])
+				// // waypoint 2
+				test.That(t, s.mogrs[1].Destination, test.ShouldResemble, points[1])
+				// Motion reports that the last execution succeeded
+				s.RUnlock()
+
+				ph, err := s.injectMS.PlanHistory(ctx, motion.PlanHistoryReq{ComponentName: s.base.Name()})
+				test.That(t, err, test.ShouldBeNil)
+				test.That(t, len(ph), test.ShouldEqual, 1)
+				test.That(t, ph[0].Plan.ExecutionID, test.ShouldResemble, executionIDs[1])
+				test.That(t, len(ph[0].StatusHistory), test.ShouldEqual, 2)
+				test.That(t, ph[0].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateSucceeded)
+				break
+			}
+		}
+	})
+
+	t.Run("Calling RemoveWaypoint on a waypoint that is not in progress does not cancel MoveOnGlobe", func(t *testing.T) {
+		s := setupStartWaypoint(ctx, t, logger)
+		defer s.closeFunc()
+
+		// we expect 2 executions to be generated
+		executionIDs := []uuid.UUID{
+			uuid.New(),
+			uuid.New(),
+		}
+		counter := atomic.NewInt32(-1)
+		var wg sync.WaitGroup
+		defer wg.Wait()
+		pauseMOGSuccess := make(chan struct{})
+		resumeMOGSuccess := make(chan struct{})
+		// MoveOnGlobeNew will behave as if it created a new plan & queue up a goroutine which will then behave as if the plan succeeded
+		s.injectMS.MoveOnGlobeNewFunc = func(ctx context.Context, req motion.MoveOnGlobeReq) (string, error) {
+			executionID := executionIDs[(counter.Inc())]
+			s.Lock()
+			defer s.Unlock()
+			if s.mogrs == nil {
+				s.mogrs = []motion.MoveOnGlobeReq{}
+			}
+			s.mogrs = append(s.mogrs, req)
+			s.pws = []motion.PlanWithStatus{
+				{
+					Plan: motion.Plan{
+						ExecutionID: executionID,
+					},
+					StatusHistory: []motion.PlanStatus{
+						{State: motion.PlanStateInProgress},
+					},
+				},
+			}
+			wg.Add(1)
+			utils.ManagedGo(func() {
+				pauseMOGSuccess <- struct{}{}
+				<-resumeMOGSuccess
+				s.Lock()
+				defer s.Unlock()
+				for i, p := range s.pws {
+					if p.Plan.ExecutionID == executionID {
+						succeeded := []motion.PlanStatus{{State: motion.PlanStateSucceeded}}
+						p.StatusHistory = append(succeeded, p.StatusHistory...)
+						s.pws[i] = p
+						return
+					}
 				}
+				t.Error("MoveOnGlobeNew called unexpectedly")
+			}, wg.Done)
+			return executionID.String(), nil
+		}
+
+		s.injectMS.PlanHistoryFunc = func(ctx context.Context, req motion.PlanHistoryReq) ([]motion.PlanWithStatus, error) {
+			if err := ctx.Err(); err != nil {
+				return nil, err
 			}
+			s.RLock()
+			defer s.RUnlock()
+			history := make([]motion.PlanWithStatus, len(s.pws))
+			copy(history, s.pws)
+			return history, nil
+		}
 
-			// start navigation - set ModeManual first to ensure navigation starts up
-			err = ns.SetMode(ctx, navigation.ModeWaypoint, nil)
+		s.injectMS.StopPlanFunc = func(ctx context.Context, req motion.StopPlanReq) error {
+			s.Lock()
+			defer s.Unlock()
+			if s.sprs == nil {
+				s.sprs = []motion.StopPlanReq{}
+			}
+			s.sprs = append(s.sprs, req)
+			return nil
+		}
 
-			// Reach the first waypoint
-			eventChannel <- arrivedAtWaypointMsg
-			test.That(t, <-statusChannel, test.ShouldEqual, arrivedAtWaypointMsg)
-			currentInputsShouldEqual(ctx, t, kinematicBase, pt1)
-
-			// Remove the third waypoint, which is not in progress yet
-			err = ns.RemoveWaypoint(ctx, wp3.ID, nil)
+		// Set manual mode to ensure waypoint loop from prior test exits
+		for _, pt := range points {
+			err := s.ns.AddWaypoint(ctx, pt, nil)
 			test.That(t, err, test.ShouldBeNil)
+		}
 
-			// Reach the second waypoint
-			eventChannel <- arrivedAtWaypointMsg
-			test.That(t, <-statusChannel, test.ShouldEqual, arrivedAtWaypointMsg)
-			currentInputsShouldEqual(ctx, t, kinematicBase, pt2)
-		})
+		wps, err := s.ns.Waypoints(ctx, nil)
+		test.That(t, err, test.ShouldBeNil)
+		wp2 := wps[1]
+		// start navigation - set ModeManual first to ensure navigation starts up
+		err = s.ns.SetMode(ctx, navigation.ModeWaypoint, nil)
+		test.That(t, err, test.ShouldBeNil)
+		<-pauseMOGSuccess
+
+		err = s.ns.RemoveWaypoint(ctx, wp2.ID, nil)
+		test.That(t, err, test.ShouldBeNil)
+		resumeMOGSuccess <- struct{}{}
+
+		// Reach the second waypoint
+		timeoutCtx, cancelFn := context.WithTimeout(ctx, time.Millisecond*1000)
+		defer cancelFn()
+		for {
+			if timeoutCtx.Err() != nil {
+				t.Error("test timed out")
+				t.FailNow()
+			}
+			// once all waypoints have been consumed
+			wps, err := s.ns.Waypoints(ctx, nil)
+			test.That(t, err, test.ShouldBeNil)
+			if len(wps) == 0 {
+				s.RLock()
+				// // MoveOnGlobeNew was called once with waypoint 1
+				test.That(t, len(s.mogrs), test.ShouldEqual, 1)
+				// // waypoint 1
+				test.That(t, s.mogrs[0].Destination, test.ShouldResemble, points[0])
+				// Motion reports that the last execution succeeded
+				s.RUnlock()
+
+				ph, err := s.injectMS.PlanHistory(ctx, motion.PlanHistoryReq{ComponentName: s.base.Name()})
+				test.That(t, err, test.ShouldBeNil)
+				test.That(t, len(ph), test.ShouldEqual, 1)
+				test.That(t, ph[0].Plan.ExecutionID, test.ShouldResemble, executionIDs[0])
+				test.That(t, len(ph[0].StatusHistory), test.ShouldEqual, 2)
+				test.That(t, ph[0].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateSucceeded)
+				break
+			}
+		}
 	})
 }
 

--- a/services/navigation/builtin/builtin_test.go
+++ b/services/navigation/builtin/builtin_test.go
@@ -751,7 +751,6 @@ func TestPaths(t *testing.T) {
 			}
 		}
 	})
-
 }
 
 func TestStartWaypoint(t *testing.T) {

--- a/services/navigation/builtin/builtin_test.go
+++ b/services/navigation/builtin/builtin_test.go
@@ -27,6 +27,7 @@ import (
 	"go.viam.com/rdk/resource"
 	robotimpl "go.viam.com/rdk/robot/impl"
 	"go.viam.com/rdk/services/motion"
+	_ "go.viam.com/rdk/services/motion/builtin"
 	"go.viam.com/rdk/services/navigation"
 	"go.viam.com/rdk/services/vision"
 	_ "go.viam.com/rdk/services/vision/colordetector"

--- a/services/navigation/client_test.go
+++ b/services/navigation/client_test.go
@@ -92,7 +92,7 @@ func TestClient(t *testing.T) {
 
 	var receviedPaths []*navigation.Path
 	workingNavigationService.PathsFunc = func(ctx context.Context, extra map[string]interface{}) ([]*navigation.Path, error) {
-		path, err := navigation.NewPath("test", []*geo.Point{geo.NewPoint(0, 0)})
+		path, err := navigation.NewPath(primitive.NewObjectID(), []*geo.Point{geo.NewPoint(0, 0)})
 		test.That(t, err, test.ShouldBeNil)
 		receviedPaths = []*navigation.Path{path}
 		return receviedPaths, nil

--- a/services/navigation/server_test.go
+++ b/services/navigation/server_test.go
@@ -352,7 +352,7 @@ func TestServer(t *testing.T) {
 	})
 
 	t.Run("working Paths", func(t *testing.T) {
-		path, err := navigation.NewPath("test", []*geo.Point{geo.NewPoint(0, 0)})
+		path, err := navigation.NewPath(primitive.NewObjectID(), []*geo.Point{geo.NewPoint(0, 0)})
 		test.That(t, err, test.ShouldBeNil)
 		expectedOutput := []*navigation.Path{path}
 		injectSvc.PathsFunc = func(ctx context.Context, extra map[string]interface{}) ([]*navigation.Path, error) {

--- a/testutils/inject/motion_service.go
+++ b/testutils/inject/motion_service.go
@@ -45,7 +45,7 @@ type MotionService struct {
 	MoveOnGlobeNewFunc func(
 		ctx context.Context,
 		req motion.MoveOnGlobeReq,
-	) (string, error)
+	) (motion.ExecutionID, error)
 	GetPoseFunc func(
 		ctx context.Context,
 		componentName resource.Name,
@@ -127,7 +127,7 @@ func (mgs *MotionService) MoveOnGlobe(
 }
 
 // MoveOnGlobeNew calls the injected MoveOnGlobeNew or the real variant.
-func (mgs *MotionService) MoveOnGlobeNew(ctx context.Context, req motion.MoveOnGlobeReq) (string, error) {
+func (mgs *MotionService) MoveOnGlobeNew(ctx context.Context, req motion.MoveOnGlobeReq) (motion.ExecutionID, error) {
 	if mgs.MoveOnGlobeNewFunc == nil {
 		return mgs.Service.MoveOnGlobeNew(ctx, req)
 	}


### PR DESCRIPTION
Tickets:
https://viam.atlassian.net/browse/RSDK-5161
https://viam.atlassian.net/browse/RSDK-4819
https://viam.atlassian.net/browse/RSDK-5193
https://viam.atlassian.net/browse/RSDK-5525

- Change `nav.SetMode` to call `motion.MoveOnGlobeNew` rather than `motion.MoveOnGlobe` & poll `motion.PlanHistory` until the plan terminates, retrying the waypoint on failure & moving on to the next waypoint on success. Also (for use by nav.Paths) record the executionID & waypoint of the in progress moveOnGlobe call & unset it when moveOnGlobe terminates. 
- Change nav to always set position only mode on motion
- Uncomment the tests cases for `nav.SetMode` that affect waypoints & fix the tests to work with `motion.MoveOnGlobeNew`
- Implement `nav.Paths`
- Change MoveOnGlobeNew's go interface method to return a motion.ExecutionID rather than a string to improve ergonomics.
- Change `nav.Path`'s destinationWaypointID field to be of type primitive.ObjectID rather than string

Manual Testing: In gazebo:
https://github.com/viamrobotics/rdk/assets/5927876/3994873f-18dd-412a-9654-96b31d2327f0



Script used in manual testing:
```go
package main

import (
	"context"
	"fmt"

	"github.com/edaniels/golog"
	"go.viam.com/rdk/robot/client"
	"go.viam.com/rdk/services/navigation"
	"go.viam.com/utils/rpc"
)

func main() {
	logger := golog.NewDevelopmentLogger("client")

	robot, err := client.New(
		context.Background(),
		"",
		logger,
		client.WithDialOptions(rpc.WithEntityCredentials(
			"",
			rpc.Credentials{
				Type:    rpc.CredentialsTypeAPIKey,
				Payload: "",
			})),
	)
	if err != nil {
		logger.Fatal(err)
	}

	defer robot.Close(context.Background())

	n, err := navigation.FromRobot(robot, "nav")
	if err != nil {
		logger.Error(err)
		return
	}

	resp, err := n.Paths(context.Background(), nil)
	if err != nil {
		logger.Error(err)
		return
	}

	for _, r := range resp {
		fmt.Printf("WaypointID: %s\n", r.DestinationWaypointID())
		fmt.Print("GeoPoints:")
		for _, gp := range r.GeoPoints() {
			fmt.Printf("Lat: %f, Lng: %f\n", gp.Lat(), gp.Lng())
		}

	}
}
```