### PR TITLE
RSDK-5508 Test Datarace: go.viam.com/rdk/components/motor/gpio.TestMotorEncoder1

### DIFF
--- a/components/encoder/incremental/incremental_encoder.go
+++ b/components/encoder/incremental/incremental_encoder.go
@@ -322,7 +322,10 @@ func (e *Encoder) RawPosition() int64 {
 
 // Close shuts down the Encoder.
 func (e *Encoder) Close(ctx context.Context) error {
+	e.logger.Info("closing encoder")
 	e.cancelFunc()
+	e.logger.Info("cancelled context")
 	e.activeBackgroundWorkers.Wait()
+	e.logger.Info("background workers done")
 	return nil
 }

--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -512,6 +512,9 @@ func (m *EncodedMotor) ResetZeroPosition(ctx context.Context, offset float64, ex
 	if err := m.encoder.ResetPosition(ctx, extra); err != nil {
 		return err
 	}
+
+	m.stateMu.Lock()
+	defer m.stateMu.Unlock()
 	m.offsetInTicks = -1 * offset * m.ticksPerRotation
 	return nil
 }
@@ -522,8 +525,8 @@ func (m *EncodedMotor) position(ctx context.Context, extra map[string]interface{
 	if err != nil {
 		return 0, err
 	}
-	m.stateMu.Lock()
-	defer m.stateMu.Unlock()
+	m.stateMu.RLock()
+	defer m.stateMu.RUnlock()
 	pos := ticks + m.offsetInTicks
 	return pos, nil
 }


### PR DESCRIPTION
Add a lock to accessing offset in reset zero position for component:gpio:motor, tested with a single and incremental encoder. Ran the test a few hundred times with `go test -race`. Let's see what CI does