### PR TITLE
Using get_images to speed up detection and projections

### DIFF
--- a/components/camera/videosource/static.go
+++ b/components/camera/videosource/static.go
@@ -110,7 +110,7 @@ func (fs *fileSource) Read(ctx context.Context) (image.Image, func(), error) {
 	return img, func() {}, err
 }
 
-// Images returns the saved color and depth image if they are present
+// Images returns the saved color and depth image if they are present.
 func (fs *fileSource) Images(ctx context.Context) ([]camera.NamedImage, resource.ResponseMetadata, error) {
 	if fs.ColorFN == "" && fs.DepthFN == "" {
 		return nil, resource.ResponseMetadata{}, errors.New("no image file to read, so not implemented")
@@ -180,7 +180,7 @@ func (ss *StaticSource) Read(ctx context.Context) (image.Image, func(), error) {
 	return ss.DepthImg, func() {}, nil
 }
 
-// Images returns the saved color and depth image if they are present
+// Images returns the saved color and depth image if they are present.
 func (ss *StaticSource) Images(ctx context.Context) ([]camera.NamedImage, resource.ResponseMetadata, error) {
 	if ss.ColorImg == nil && ss.DepthImg == nil {
 		return nil, resource.ResponseMetadata{}, errors.New("no image files stored, so not implemented")

--- a/components/camera/videosource/static.go
+++ b/components/camera/videosource/static.go
@@ -5,6 +5,7 @@ package videosource
 import (
 	"context"
 	"image"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -109,6 +110,30 @@ func (fs *fileSource) Read(ctx context.Context) (image.Image, func(), error) {
 	return img, func() {}, err
 }
 
+// Images returns the saved color and depth image if they are present
+func (fs *fileSource) Images(ctx context.Context) ([]camera.NamedImage, resource.ResponseMetadata, error) {
+	if fs.ColorFN == "" && fs.DepthFN == "" {
+		return nil, resource.ResponseMetadata{}, errors.New("no image file to read, so not implemented")
+	}
+	imgs := []camera.NamedImage{}
+	if fs.ColorFN != "" {
+		img, err := rimage.NewImageFromFile(fs.ColorFN)
+		if err != nil {
+			return nil, resource.ResponseMetadata{}, err
+		}
+		imgs = append(imgs, camera.NamedImage{img, "color"})
+	}
+	if fs.DepthFN != "" {
+		dm, err := rimage.NewDepthMapFromFile(context.Background(), fs.DepthFN)
+		if err != nil {
+			return nil, resource.ResponseMetadata{}, err
+		}
+		imgs = append(imgs, camera.NamedImage{dm, "depth"})
+	}
+	ts := time.Now()
+	return imgs, resource.ResponseMetadata{CapturedAt: ts}, nil
+}
+
 // NextPointCloud returns the point cloud from projecting the rgb and depth image using the intrinsic parameters,
 // or the pointcloud from file if set.
 func (fs *fileSource) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, error) {
@@ -153,6 +178,22 @@ func (ss *StaticSource) Read(ctx context.Context) (image.Image, func(), error) {
 		return ss.ColorImg, func() {}, nil
 	}
 	return ss.DepthImg, func() {}, nil
+}
+
+// Images returns the saved color and depth image if they are present
+func (ss *StaticSource) Images(ctx context.Context) ([]camera.NamedImage, resource.ResponseMetadata, error) {
+	if ss.ColorImg == nil && ss.DepthImg == nil {
+		return nil, resource.ResponseMetadata{}, errors.New("no image files stored, so not implemented")
+	}
+	imgs := []camera.NamedImage{}
+	if ss.ColorImg != nil {
+		imgs = append(imgs, camera.NamedImage{ss.ColorImg, "color"})
+	}
+	if ss.DepthImg != nil {
+		imgs = append(imgs, camera.NamedImage{ss.DepthImg, "depth"})
+	}
+	ts := time.Now()
+	return imgs, resource.ResponseMetadata{CapturedAt: ts}, nil
 }
 
 // NextPointCloud returns the point cloud from projecting the rgb and depth image using the intrinsic parameters.

--- a/vision/segmentation/detections_to_objects.go
+++ b/vision/segmentation/detections_to_objects.go
@@ -2,6 +2,7 @@ package segmentation
 
 import (
 	"context"
+	"image"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
@@ -57,11 +58,25 @@ func DetectionSegmenter(detector objectdetection.Detector, meanK int, sigma, con
 			return nil, err
 		}
 		// get the 3D detections, and turn them into 2D image and depthmap
-		pc, err := src.NextPointCloud(ctx)
+		imgs, _, err := src.Images(ctx)
 		if err != nil {
 			return nil, errors.Wrapf(err, "detection segmenter")
 		}
-		img, dm, err := proj.PointCloudToRGBD(pc)
+		var img *rimage.Image
+		var dmimg image.Image
+		for _, i := range imgs {
+			this_i := i
+			if i.SourceName == "color" {
+				img = rimage.ConvertImage(this_i.Image)
+			}
+			if i.SourceName == "depth" {
+				dmimg = this_i.Image
+			}
+		}
+		if img == nil || dmimg == nil {
+			return nil, errors.New("source camera's getImages method did not have 'color' and 'depth' images")
+		}
+		dm, err := rimage.ConvertImageToDepthMap(ctx, dmimg)
 		if err != nil {
 			return nil, err
 		}

--- a/vision/segmentation/detections_to_objects.go
+++ b/vision/segmentation/detections_to_objects.go
@@ -65,12 +65,12 @@ func DetectionSegmenter(detector objectdetection.Detector, meanK int, sigma, con
 		var img *rimage.Image
 		var dmimg image.Image
 		for _, i := range imgs {
-			this_i := i
+			thisI := i
 			if i.SourceName == "color" {
-				img = rimage.ConvertImage(this_i.Image)
+				img = rimage.ConvertImage(thisI.Image)
 			}
 			if i.SourceName == "depth" {
-				dmimg = this_i.Image
+				dmimg = thisI.Image
 			}
 		}
 		if img == nil || dmimg == nil {


### PR DESCRIPTION
Now that the getImages method is available, the detection to 3D segments model can be sped up.

Needed to add the Images method to the static source and file source cameras