### PR TITLE
Default to x264 on arm64/linux

### DIFF
--- a/web/server/entrypoint_arm64.go
+++ b/web/server/entrypoint_arm64.go
@@ -4,24 +4,14 @@ package server
 
 import (
 	"go.viam.com/rdk/gostream"
-	"go.viam.com/rdk/gostream/codec/h264"
 	"go.viam.com/rdk/gostream/codec/opus"
 	"go.viam.com/rdk/gostream/codec/x264"
 )
 
 func makeStreamConfig() gostream.StreamConfig {
 	var streamConfig gostream.StreamConfig
-
-	// Attempt to create a new encoder with hardcoded parameters
-	// to check if V4l2m2m codec is supported.
-	width, height, keyFrameInterval := 1920, 1080, 30
-	_, err := h264.NewEncoder(width, height, keyFrameInterval, nil)
-	if err != nil {
-		streamConfig.VideoEncoderFactory = x264.NewEncoderFactory()
-	} else {
-		streamConfig.VideoEncoderFactory = h264.NewEncoderFactory()
-	}
-
+	// TODO(RSDK-5916): support v4l2m2m codec on arm64/rpi
+	streamConfig.VideoEncoderFactory = x264.NewEncoderFactory()
 	streamConfig.AudioEncoderFactory = opus.NewEncoderFactory()
 	return streamConfig
 }


### PR DESCRIPTION
Tested on Raspberry Pi 4 (bullseye) to confirm that streams are working well.