### PR TITLE
[RSDK-5895] Add support for a rpi5 board!

### DIFF
--- a/components/board/genericlinux/pin_types.go
+++ b/components/board/genericlinux/pin_types.go
@@ -59,11 +59,9 @@ func (conf *PinDefinition) Validate(path string) error {
 		return resource.NewConfigValidationFieldRequiredError(path, "device_name")
 	}
 
-	if conf.LineNumber == -1 {
-		return resource.NewConfigValidationFieldRequiredError(path, "line_number")
-	}
-
-	if conf.LineNumber < 0 {
+	// We use -1 as a sentinel value indicating that this pin does not have GPIO capabilities.
+	// Besides that, the line number must be non-negative.
+	if conf.LineNumber < -1 {
 		return resource.NewConfigValidationError(path, errors.New("line_number on gpio chip must be at least zero"))
 	}
 

--- a/components/board/pi5/board.go
+++ b/components/board/pi5/board.go
@@ -1,0 +1,26 @@
+// Package pi5 implements a raspberry pi 5 board.
+package pi5
+
+import (
+	"github.com/pkg/errors"
+	"periph.io/x/host/v3"
+
+	"go.viam.com/rdk/components/board/genericlinux"
+	"go.viam.com/rdk/logging"
+)
+
+const modelName = "pi5"
+
+func init() {
+	if _, err := host.Init(); err != nil {
+		logging.Global().Debugw("error initializing host", "error", err)
+	}
+
+	gpioMappings, err := genericlinux.GetGPIOBoardMappings(modelName, boardInfoMappings)
+	var noBoardErr genericlinux.NoBoardFoundError
+	if errors.As(err, &noBoardErr) {
+		logging.Global().Debugw("error getting pi5 GPIO board mapping", "error", err)
+	}
+
+	genericlinux.RegisterBoard(modelName, gpioMappings)
+}

--- a/components/board/pi5/data.go
+++ b/components/board/pi5/data.go
@@ -2,6 +2,8 @@ package pi5
 
 import "go.viam.com/rdk/components/board/genericlinux"
 
+// Thanks to "Dan Makes Things" at https://www.makerforge.tech/posts/viam-custom-board-pi5/ for
+// collaborating on setting this up!
 var boardInfoMappings = map[string]genericlinux.BoardInformation{
 	"pi5": {
 		PinDefinitions: []genericlinux.PinDefinition{
@@ -22,9 +24,9 @@ var boardInfoMappings = map[string]genericlinux.BoardInformation{
 			{Name: "23", DeviceName: "gpiochip4", LineNumber: 11, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "24", DeviceName: "gpiochip4", LineNumber: 8, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "26", DeviceName: "gpiochip4", LineNumber: 7, PwmChipSysfsDir: "", PwmID: -1},
-			// There ought to be a way to get physical pins 27 and 28 to work, but it's not clear
-			// which ones they are. They have something to do with an I2C bus for writing to an
-			// EEPROM, hence why they're not labeled in the usual way if you run `sudo gpioinfo`.
+			// Per https://www.raspberrypi.com/documentation/computers/images/GPIO-duplicate.png
+			// Physical pins 27 and 28 (shown in white in that diagram) should not be used for
+			// normal GPIO stuff.
 			{Name: "29", DeviceName: "gpiochip4", LineNumber: 5, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "31", DeviceName: "gpiochip4", LineNumber: 6, PwmChipSysfsDir: "", PwmID: -1},
 			// We'd expect pins 32 and 33 to have hardware PWM support, too, but we haven't gotten

--- a/components/board/pi5/data.go
+++ b/components/board/pi5/data.go
@@ -13,7 +13,8 @@ var boardInfoMappings = map[string]genericlinux.BoardInformation{
 			{Name: "8", DeviceName: "gpiochip4", LineNumber: 14, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "10", DeviceName: "gpiochip4", LineNumber: 15, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "11", DeviceName: "gpiochip4", LineNumber: 17, PwmChipSysfsDir: "", PwmID: -1},
-			{Name: "12", DeviceName: "gpiochip4", LineNumber: 18, PwmChipSysfsDir: "1f00098000.pwm", PwmID: 2},
+			// When we can do GPIO and hardware PWM on the same pin, this will have line number 18.
+			{Name: "12", DeviceName: "gpiochip4", LineNumber: -1, PwmChipSysfsDir: "1f00098000.pwm", PwmID: 2},
 			{Name: "13", DeviceName: "gpiochip4", LineNumber: 27, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "15", DeviceName: "gpiochip4", LineNumber: 22, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "16", DeviceName: "gpiochip4", LineNumber: 23, PwmChipSysfsDir: "", PwmID: -1},
@@ -33,7 +34,8 @@ var boardInfoMappings = map[string]genericlinux.BoardInformation{
 			// that to work yet.
 			{Name: "32", DeviceName: "gpiochip4", LineNumber: 12, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "33", DeviceName: "gpiochip4", LineNumber: 13, PwmChipSysfsDir: "", PwmID: -1},
-			{Name: "35", DeviceName: "gpiochip4", LineNumber: 19, PwmChipSysfsDir: "1f00098000.pwm", PwmID: 3},
+			// When we can do GPIO and hardware PWM on the same pin, this will have line number 19.
+			{Name: "35", DeviceName: "gpiochip4", LineNumber: -1, PwmChipSysfsDir: "1f00098000.pwm", PwmID: 3},
 			{Name: "36", DeviceName: "gpiochip4", LineNumber: 16, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "37", DeviceName: "gpiochip4", LineNumber: 26, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "38", DeviceName: "gpiochip4", LineNumber: 20, PwmChipSysfsDir: "", PwmID: -1},

--- a/components/board/pi5/data.go
+++ b/components/board/pi5/data.go
@@ -1,0 +1,42 @@
+package pi5
+
+import "go.viam.com/rdk/components/board/genericlinux"
+
+var boardInfoMappings = map[string]genericlinux.BoardInformation{
+	"pi5": {
+		PinDefinitions: []genericlinux.PinDefinition{
+			{Name: "3", DeviceName: "gpiochip4", LineNumber: 2, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "5", DeviceName: "gpiochip4", LineNumber: 3, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "7", DeviceName: "gpiochip4", LineNumber: 4, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "8", DeviceName: "gpiochip4", LineNumber: 14, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "10", DeviceName: "gpiochip4", LineNumber: 15, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "11", DeviceName: "gpiochip4", LineNumber: 17, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "12", DeviceName: "gpiochip4", LineNumber: 18, PwmChipSysfsDir: "1f00098000.pwm", PwmID: 2},
+			{Name: "13", DeviceName: "gpiochip4", LineNumber: 27, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "15", DeviceName: "gpiochip4", LineNumber: 22, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "16", DeviceName: "gpiochip4", LineNumber: 23, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "18", DeviceName: "gpiochip4", LineNumber: 24, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "19", DeviceName: "gpiochip4", LineNumber: 10, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "21", DeviceName: "gpiochip4", LineNumber: 9, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "22", DeviceName: "gpiochip4", LineNumber: 25, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "23", DeviceName: "gpiochip4", LineNumber: 11, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "24", DeviceName: "gpiochip4", LineNumber: 8, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "26", DeviceName: "gpiochip4", LineNumber: 7, PwmChipSysfsDir: "", PwmID: -1},
+			// There ought to be a way to get physical pins 27 and 28 to work, but it's not clear
+			// which ones they are. They have something to do with an I2C bus for writing to an
+			// EEPROM, hence why they're not labeled in the usual way if you run `sudo gpioinfo`.
+			{Name: "29", DeviceName: "gpiochip4", LineNumber: 5, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "31", DeviceName: "gpiochip4", LineNumber: 6, PwmChipSysfsDir: "", PwmID: -1},
+			// We'd expect pins 32 and 33 to have hardware PWM support, too, but we haven't gotten
+			// that to work yet.
+			{Name: "32", DeviceName: "gpiochip4", LineNumber: 12, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "33", DeviceName: "gpiochip4", LineNumber: 13, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "35", DeviceName: "gpiochip4", LineNumber: 19, PwmChipSysfsDir: "1f00098000.pwm", PwmID: 3},
+			{Name: "36", DeviceName: "gpiochip4", LineNumber: 16, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "37", DeviceName: "gpiochip4", LineNumber: 26, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "38", DeviceName: "gpiochip4", LineNumber: 20, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "40", DeviceName: "gpiochip4", LineNumber: 21, PwmChipSysfsDir: "", PwmID: -1},
+		},
+		Compats: []string{"raspberrypi,5-model-b", "brcm,bcm2712"},
+	},
+}

--- a/components/board/register/register.go
+++ b/components/board/register/register.go
@@ -9,6 +9,7 @@ import (
 	_ "go.viam.com/rdk/components/board/hat/pca9685"
 	_ "go.viam.com/rdk/components/board/jetson"
 	_ "go.viam.com/rdk/components/board/numato"
+	_ "go.viam.com/rdk/components/board/pi5"
 	_ "go.viam.com/rdk/components/board/ti"
 	_ "go.viam.com/rdk/components/board/upboard"
 )


### PR DESCRIPTION
Not tested at all yet; I'll try it out on Monday. but I'm excited to have this already!

Thanks to non-Viam-employee [Dan Makes Things](https://www.makerforge.tech/posts/viam-custom-board-pi5/) for the head-start on this!

**Setup:** first, you need to edit `/boot/config.txt` on your pi5 to add the following line somewhere:
```
dtoverlay=pwm-2chan
```
and then power cycle your machine (I'd expect a reboot would be enough, but that didn't work for me. Maybe I needed to reboot twice?).

**Limitations:**
- ~~In theory, pins 27 and 28 ought to have GPIO capabilities. Dan and I couldn't figure out which lines on the GPIO chip they were, so we skipped them and I left a comment.~~ edit: Rand notes that [these pins should remain unused](https://www.raspberrypi.com/documentation/computers/images/GPIO-duplicate.png) (the white ones in that diagram)
- In theory, pins 32 and 33 ought to have HW PWM capabilities. I couldn't get that to work, though, so I left a comment.