### PR TITLE
RSDK-4028: Render transient obstacles

### DIFF
--- a/etc/configs/fake.json
+++ b/etc/configs/fake.json
@@ -151,7 +151,14 @@
                         },
                         "geometries": [
                             {
-                                "r": 2000
+                                "r": 2000,
+                                "label": "large sphere"
+                            },
+                            {
+                                "type": "capsule",
+                                "r": 500,
+                                "l": 5000,
+                                "label": "long capsule"
                             }
                         ]
                     },
@@ -162,7 +169,8 @@
                         },
                         "geometries": [
                             {
-                                "r": 2000000
+                                "r": 2000000,
+                                "label": "giant sphere"
                             }
                         ]
                     },
@@ -196,7 +204,8 @@
                                         "z": 1,
                                         "th": 0
                                     }
-                                }
+                                },
+                                "label": "myCamera_transientObstacle_capsule"
                             }    
                         ]
                     },

--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -21,7 +21,7 @@
         "@viamrobotics/eslint-config": "^0.2.6",
         "@viamrobotics/prettier-config": "^0.3.4",
         "@viamrobotics/prime": "0.5.2",
-        "@viamrobotics/prime-blocks": "^0.0.14",
+        "@viamrobotics/prime-blocks": "^0.0.18",
         "@viamrobotics/prime-core": "^0.0.53",
         "@viamrobotics/rpc": "0.1.37",
         "@viamrobotics/sdk": "0.7.0-rc.2",
@@ -1402,9 +1402,9 @@
       "dev": true
     },
     "node_modules/@viamrobotics/prime-blocks": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@viamrobotics/prime-blocks/-/prime-blocks-0.0.14.tgz",
-      "integrity": "sha512-ZhW7LnBUDJ2VQUAUdH08z65oQlKZD2jK4n3M+OIh3jfAfcpQoO9M3JXjREanr9Ll3a3L1+HeItipJbZ031srZA==",
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@viamrobotics/prime-blocks/-/prime-blocks-0.0.18.tgz",
+      "integrity": "sha512-XSdiYSaOJz+z31cCKgjRP8tmRHxKrBFYZDlMr+CRFDDkmF2MTx4P/otanXqGY9S+/+22SY8X1NjersAFajnBHg==",
       "dev": true,
       "dependencies": {
         "maplibre-gl": "^3.3.0"

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -55,7 +55,7 @@
     "@viamrobotics/eslint-config": "^0.2.6",
     "@viamrobotics/prettier-config": "^0.3.4",
     "@viamrobotics/prime": "0.5.2",
-    "@viamrobotics/prime-blocks": "^0.0.14",
+    "@viamrobotics/prime-blocks": "^0.0.18",
     "@viamrobotics/prime-core": "^0.0.53",
     "@viamrobotics/rpc": "0.1.37",
     "@viamrobotics/sdk": "0.7.0-rc.2",

--- a/web/frontend/src/api/navigation.ts
+++ b/web/frontend/src/api/navigation.ts
@@ -3,11 +3,23 @@
 import * as THREE from 'three';
 import { NavigationClient, type Waypoint } from '@viamrobotics/sdk';
 import { ViamObject3D } from '@viamrobotics/three';
-import type {
-  BoxGeometry, CapsuleGeometry, Obstacle, SphereGeometry,
-} from './types/navigation';
 import { notify } from '@viamrobotics/prime';
+import { theme } from '@viamrobotics/prime-core/theme';
+import type {
+  Obstacle,
+  BoxGeometry,
+  CapsuleGeometry,
+  SphereGeometry,
+} from '@viamrobotics/prime-blocks';
 export * from './types/navigation';
+
+const STATIC_OBSTACLE_LABEL = 'static';
+const STATIC_OBSTACLE_COLOR = theme.extend.colors.cyberpunk;
+const TRANSIENT_OBSTACLE_LABEL = 'transient';
+const TRANSIENT_OBSTACLE_COLOR = theme.extend.colors.hologram;
+
+/** Transient obstacles will contain this string in the geometry's label. */
+const TRANSIENT_LABEL_SEARCH = 'transientObstacle';
 
 export const formatWaypoints = (list: Waypoint[]) => {
   return list.map((item) => {
@@ -20,14 +32,41 @@ export const formatWaypoints = (list: Waypoint[]) => {
   });
 };
 
-export const getObstacles = async (navClient: NavigationClient): Promise<Obstacle[]> => {
+export const getObstacles = async (
+  navClient: NavigationClient
+): Promise<Obstacle[]> => {
   const list = await navClient.getObstacles();
 
   return list.map((obstacle, index) => {
     const { location } = obstacle;
 
+    /*
+     * Labels are defined on each geometry, not on the
+     * obstacle itself. In practice, obstacles typically
+     * only have a single geometry. This takes the label
+     * on the first geometry and uses that even if there
+     * are multiple geometries.
+     */
+
+    const [geo] = obstacle.geometriesList;
+
+    let name = `Obstacle ${index + 1}`;
+    if (obstacle.geometriesList.length > 1) {
+      name = `${geo?.label} & others`;
+    } else if (geo?.label) {
+      name = geo.label;
+    }
+
+    const isTransient = geo?.label.includes(TRANSIENT_LABEL_SEARCH);
+    const label = isTransient
+      ? TRANSIENT_OBSTACLE_LABEL
+      : STATIC_OBSTACLE_LABEL;
+    const color = isTransient
+      ? TRANSIENT_OBSTACLE_COLOR
+      : STATIC_OBSTACLE_COLOR;
+
     return {
-      name: `Obstacle ${index + 1}`,
+      name,
       location: {
         lng: location?.longitude ?? 0,
         lat: location?.latitude ?? 0,
@@ -48,32 +87,35 @@ export const getObstacles = async (navClient: NavigationClient): Promise<Obstacl
             height: (dimsMm?.z ?? 0) / 1000,
             pose,
           } satisfies BoxGeometry;
-
         } else if (geometry.sphere) {
-
           return {
             type: 'sphere',
-            radius: (geometry.sphere.radiusMm ?? 0) / 1000,
+            radius: geometry.sphere.radiusMm / 1000,
             pose,
           } satisfies SphereGeometry;
-
         } else if (geometry.capsule) {
           const { capsule } = geometry;
 
           return {
             type: 'capsule',
-            radius: (capsule.radiusMm ?? 0) / 1000,
-            length: (capsule.lengthMm ?? 0) / 1000,
+            radius: capsule.radiusMm / 1000,
+            length: capsule.lengthMm / 1000,
             pose,
           } satisfies CapsuleGeometry;
-
         }
 
-        notify.danger('An unsupported geometry was encountered in an obstacle', JSON.stringify(geometry));
+        notify.danger(
+          'An unsupported geometry was encountered in an obstacle',
+          JSON.stringify(geometry)
+        );
         throw new Error(
-          `An unsupported geometry was encountered in an obstacle: ${JSON.stringify(geometry)}`
+          `An unsupported geometry was encountered in an obstacle: ${JSON.stringify(
+            geometry
+          )}`
         );
       }),
+      label,
+      color,
     } satisfies Obstacle;
   });
 };

--- a/web/frontend/src/api/types/navigation.ts
+++ b/web/frontend/src/api/types/navigation.ts
@@ -1,40 +1,12 @@
 import type { navigationApi } from '@viamrobotics/sdk';
-import type { ViamObject3D } from '@viamrobotics/three';
 
 export type NavigationModes =
   | typeof navigationApi.Mode.MODE_MANUAL
   | typeof navigationApi.Mode.MODE_UNSPECIFIED
-  | typeof navigationApi.Mode.MODE_WAYPOINT
+  | typeof navigationApi.Mode.MODE_WAYPOINT;
 
-export interface LngLat { lng: number, lat: number }
-export type Waypoint = LngLat & { id: string }
-
-interface BaseGeometry {
-  pose: ViamObject3D
+export interface LngLat {
+  lng: number;
+  lat: number;
 }
-
-export type CapsuleGeometry = BaseGeometry & {
-  type: 'capsule';
-  radius: number;
-  length: number;
-}
-
-export type SphereGeometry = BaseGeometry & {
-  type: 'sphere';
-  radius: number;
-}
-
-export type BoxGeometry = BaseGeometry & {
-  type: 'box';
-  length: number;
-  width: number;
-  height: number;
-}
-
-export type Geometry = BoxGeometry | SphereGeometry | CapsuleGeometry
-
-export interface Obstacle {
-  name: string;
-  location: LngLat,
-  geometries: Geometry[];
-}
+export type Waypoint = LngLat & { id: string };

--- a/web/frontend/src/components/navigation/lib/geometry.ts
+++ b/web/frontend/src/components/navigation/lib/geometry.ts
@@ -1,4 +1,4 @@
-import type { Geometry, BoxGeometry, CapsuleGeometry, SphereGeometry } from '@/api/navigation';
+import type { Geometry, BoxGeometry, CapsuleGeometry, SphereGeometry } from '@viamrobotics/prime-blocks';
 import type { Shapes } from './types';
 import { ViamObject3D } from '@viamrobotics/three';
 

--- a/web/frontend/src/components/navigation/stores.ts
+++ b/web/frontend/src/components/navigation/stores.ts
@@ -1,6 +1,6 @@
 import { currentWritable } from '@threlte/core';
 import { persisted } from '@viamrobotics/prime-core';
-import type { Obstacle } from '@/api/navigation';
+import type { Obstacle } from '@viamrobotics/prime-blocks';
 
 export const obstacles = currentWritable<Obstacle[]>([]);
 


### PR DESCRIPTION
This renders transient obstacles in a different color than static ones and closes out [RSDK-4028](https://viam.atlassian.net/browse/RSDK-4028).

## Change log

- Bump RC version
- Add labels to fake config for testing
- Update to latest `prime-blocks`
- Use types exposed by `prime-blocks` to avoid duplicated types
- Update obstacle name to use geometry labels
- Render transient obstacles a different color

[RSDK-4028]: https://viam.atlassian.net/browse/RSDK-4028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ