### PR TITLE
RSDK-4512 - Update default motion configuration

### DIFF
--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -290,6 +290,7 @@ func newValidatedExtra(extra map[string]interface{}) (validatedExtra, error) {
 	motionProfile := ""
 	v := validatedExtra{}
 	if extra == nil {
+		v.extra = map[string]interface{}{"smooth_iter": 20}
 		return v, nil
 	}
 	if replansRaw, ok := extra["max_replans"]; ok {
@@ -310,6 +311,11 @@ func newValidatedExtra(extra map[string]interface{}) (validatedExtra, error) {
 		}
 		replanCostFactor = costFactor
 	}
+
+	if _, ok := extra["smooth_iter"]; !ok {
+		extra["smooth_iter"] = 20
+	}
+
 	return validatedExtra{
 		maxReplans:       maxReplans,
 		motionProfile:    motionProfile,

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -43,10 +43,15 @@ func init() {
 }
 
 const (
-	builtinOpLabel              = "motion-service"
-	maxTravelDistanceMM         = 5e6 // this is equivalent to 5km
-	lookAheadDistanceMM float64 = 5e6
-	defaultSmoothIter           = 20
+	builtinOpLabel                   = "motion-service"
+	maxTravelDistanceMM              = 5e6 // this is equivalent to 5km
+	lookAheadDistanceMM      float64 = 5e6
+	defaultSmoothIter                = 20
+	defaultAngularDegsPerSec         = 20.
+	defaultLinearMPerSec             = 0.3
+	defaultObstaclePollingHz         = 1.
+	defaultPlanDeviationM            = 2.6
+	defaultPositionPollingHz         = 1.
 )
 
 // inputEnabledActuator is an actuator that interacts with the frame system.

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -46,6 +46,7 @@ const (
 	builtinOpLabel              = "motion-service"
 	maxTravelDistanceMM         = 5e6 // this is equivalent to 5km
 	lookAheadDistanceMM float64 = 5e6
+	defaultSmoothIter           = 20
 )
 
 // inputEnabledActuator is an actuator that interacts with the frame system.
@@ -290,7 +291,7 @@ func newValidatedExtra(extra map[string]interface{}) (validatedExtra, error) {
 	motionProfile := ""
 	v := validatedExtra{}
 	if extra == nil {
-		v.extra = map[string]interface{}{"smooth_iter": 20}
+		v.extra = map[string]interface{}{"smooth_iter": defaultSmoothIter}
 		return v, nil
 	}
 	if replansRaw, ok := extra["max_replans"]; ok {
@@ -313,7 +314,7 @@ func newValidatedExtra(extra map[string]interface{}) (validatedExtra, error) {
 	}
 
 	if _, ok := extra["smooth_iter"]; !ok {
-		extra["smooth_iter"] = 20
+		extra["smooth_iter"] = defaultSmoothIter
 	}
 
 	return validatedExtra{

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
 	"github.com/pkg/errors"
-
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	"go.viam.com/test"

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -1933,3 +1933,61 @@ func TestPlanHistory(t *testing.T) {
 	test.That(t, err, test.ShouldResemble, resource.NewNotFoundError(req.ComponentName))
 	test.That(t, history, test.ShouldBeNil)
 }
+
+func TestNewValidatedMotionCfg(t *testing.T) {
+	t.Run("returns expected defaults when given nil cfg", func(t *testing.T) {
+		vmc, err := newValidatedMotionCfg(nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, vmc, test.ShouldResemble, &validatedMotionConfiguration{
+			angularDegsPerSec:     defaultAngularDegsPerSec,
+			linearMPerSec:         defaultLinearMPerSec,
+			obstaclePollingFreqHz: defaultObstaclePollingHz,
+			positionPollingFreqHz: defaultPositionPollingHz,
+			planDeviationMM:       defaultPlanDeviationM * 1e3,
+			obstacleDetectors:     nil,
+		})
+	})
+
+	t.Run("returns expected defaults when given zero cfg", func(t *testing.T) {
+		vmc, err := newValidatedMotionCfg(&motion.MotionConfiguration{})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, vmc, test.ShouldResemble, &validatedMotionConfiguration{
+			angularDegsPerSec:     defaultAngularDegsPerSec,
+			linearMPerSec:         defaultLinearMPerSec,
+			obstaclePollingFreqHz: defaultObstaclePollingHz,
+			positionPollingFreqHz: defaultPositionPollingHz,
+			planDeviationMM:       defaultPlanDeviationM * 1e3,
+			obstacleDetectors:     nil,
+		})
+	})
+
+	t.Run("allows overriding defaults", func(t *testing.T) {
+		vmc, err := newValidatedMotionCfg(&motion.MotionConfiguration{
+			AngularDegsPerSec:     10.,
+			LinearMPerSec:         20.,
+			PlanDeviationMM:       30.,
+			PositionPollingFreqHz: 40,
+			ObstaclePollingFreqHz: 50.,
+			ObstacleDetectors: []motion.ObstacleDetectorName{
+				{
+					VisionServiceName: vision.Named("fakeVision"),
+					CameraName:        camera.Named("fakeCamera"),
+				},
+			},
+		})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, vmc, test.ShouldResemble, &validatedMotionConfiguration{
+			angularDegsPerSec:     10.,
+			linearMPerSec:         20.,
+			planDeviationMM:       30.,
+			positionPollingFreqHz: 40.,
+			obstaclePollingFreqHz: 50.,
+			obstacleDetectors: []motion.ObstacleDetectorName{
+				{
+					VisionServiceName: vision.Named("fakeVision"),
+					CameraName:        camera.Named("fakeCamera"),
+				},
+			},
+		})
+	})
+}

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
 	"github.com/pkg/errors"
+
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	"go.viam.com/test"
@@ -1944,7 +1945,7 @@ func TestNewValidatedMotionCfg(t *testing.T) {
 			obstaclePollingFreqHz: defaultObstaclePollingHz,
 			positionPollingFreqHz: defaultPositionPollingHz,
 			planDeviationMM:       defaultPlanDeviationM * 1e3,
-			obstacleDetectors:     nil,
+			obstacleDetectors:     []motion.ObstacleDetectorName{},
 		})
 	})
 
@@ -1957,7 +1958,7 @@ func TestNewValidatedMotionCfg(t *testing.T) {
 			obstaclePollingFreqHz: defaultObstaclePollingHz,
 			positionPollingFreqHz: defaultPositionPollingHz,
 			planDeviationMM:       defaultPlanDeviationM * 1e3,
-			obstacleDetectors:     nil,
+			obstacleDetectors:     []motion.ObstacleDetectorName{},
 		})
 	})
 

--- a/services/motion/builtin/move_request.go
+++ b/services/motion/builtin/move_request.go
@@ -312,37 +312,62 @@ func validateNotNegNorNaN(f float64, name string) error {
 }
 
 func newValidatedMotionCfg(motionCfg *motion.MotionConfiguration) (*validatedMotionConfiguration, error) {
-	vmc := &validatedMotionConfiguration{}
+	empty := &validatedMotionConfiguration{}
+	vmc := &validatedMotionConfiguration{
+		angularDegsPerSec:     defaultAngularDegsPerSec,
+		linearMPerSec:         defaultLinearMPerSec,
+		obstaclePollingFreqHz: defaultObstaclePollingHz,
+		positionPollingFreqHz: defaultPositionPollingHz,
+		planDeviationMM:       defaultPlanDeviationM * 1e3,
+	}
 	if motionCfg == nil {
 		return vmc, nil
 	}
 
 	if err := validateNotNegNorNaN(motionCfg.LinearMPerSec, "LinearMPerSec"); err != nil {
-		return vmc, err
+		return empty, err
 	}
 
 	if err := validateNotNegNorNaN(motionCfg.AngularDegsPerSec, "AngularDegsPerSec"); err != nil {
-		return vmc, err
+		return empty, err
 	}
 
 	if err := validateNotNegNorNaN(motionCfg.PlanDeviationMM, "PlanDeviationMM"); err != nil {
-		return vmc, err
+		return empty, err
 	}
 
 	if err := validateNotNegNorNaN(motionCfg.ObstaclePollingFreqHz, "ObstaclePollingFreqHz"); err != nil {
-		return vmc, err
+		return empty, err
 	}
 
 	if err := validateNotNegNorNaN(motionCfg.PositionPollingFreqHz, "PositionPollingFreqHz"); err != nil {
-		return vmc, err
+		return empty, err
 	}
 
-	vmc.linearMPerSec = motionCfg.LinearMPerSec
-	vmc.angularDegsPerSec = motionCfg.AngularDegsPerSec
-	vmc.planDeviationMM = motionCfg.PlanDeviationMM
-	vmc.obstaclePollingFreqHz = motionCfg.ObstaclePollingFreqHz
-	vmc.positionPollingFreqHz = motionCfg.PositionPollingFreqHz
-	vmc.obstacleDetectors = motionCfg.ObstacleDetectors
+	if motionCfg.LinearMPerSec != 0 {
+		vmc.linearMPerSec = motionCfg.LinearMPerSec
+	}
+
+	if motionCfg.AngularDegsPerSec != 0 {
+		vmc.angularDegsPerSec = motionCfg.AngularDegsPerSec
+	}
+
+	if motionCfg.PlanDeviationMM != 0 {
+		vmc.planDeviationMM = motionCfg.PlanDeviationMM
+	}
+
+	if motionCfg.ObstaclePollingFreqHz != 0 {
+		vmc.obstaclePollingFreqHz = motionCfg.ObstaclePollingFreqHz
+	}
+
+	if motionCfg.PositionPollingFreqHz != 0 {
+		vmc.positionPollingFreqHz = motionCfg.PositionPollingFreqHz
+	}
+
+	if motionCfg.ObstacleDetectors != nil {
+		vmc.obstacleDetectors = motionCfg.ObstacleDetectors
+	}
+
 	return vmc, nil
 }
 

--- a/services/motion/builtin/move_request.go
+++ b/services/motion/builtin/move_request.go
@@ -319,7 +319,9 @@ func newValidatedMotionCfg(motionCfg *motion.MotionConfiguration) (*validatedMot
 		obstaclePollingFreqHz: defaultObstaclePollingHz,
 		positionPollingFreqHz: defaultPositionPollingHz,
 		planDeviationMM:       defaultPlanDeviationM * 1e3,
+		obstacleDetectors:     []motion.ObstacleDetectorName{},
 	}
+
 	if motionCfg == nil {
 		return vmc, nil
 	}

--- a/services/motion/motion_configuration.go
+++ b/services/motion/motion_configuration.go
@@ -8,13 +8,21 @@ import (
 	"go.viam.com/rdk/protoutils"
 )
 
+const (
+	DefaultAngularDegsPerSec = 20.
+	DefaultLinearMPerSec     = 0.3
+	DefaultObstaclePollingHz = 1.
+	DefaultPlanDeviationM    = 2.6
+	DefaultPositionPollingHz = 1.
+)
+
 func configurationFromProto(motionCfg *pb.MotionConfiguration) *MotionConfiguration {
 	obstacleDetectors := []ObstacleDetectorName{}
-	planDeviationM := 0.
-	positionPollingHz := 0.
-	obstaclePollingHz := 0.
-	linearMPerSec := 0.
-	angularDegsPerSec := 0.
+	planDeviationM := DefaultPlanDeviationM
+	positionPollingHz := DefaultPositionPollingHz
+	obstaclePollingHz := DefaultObstaclePollingHz
+	linearMPerSec := DefaultLinearMPerSec
+	angularDegsPerSec := DefaultAngularDegsPerSec
 
 	if motionCfg != nil {
 		if motionCfg.ObstacleDetectors != nil {

--- a/services/motion/motion_configuration.go
+++ b/services/motion/motion_configuration.go
@@ -9,20 +9,20 @@ import (
 )
 
 const (
-	DefaultAngularDegsPerSec = 20.
-	DefaultLinearMPerSec     = 0.3
-	DefaultObstaclePollingHz = 1.
-	DefaultPlanDeviationM    = 2.6
-	DefaultPositionPollingHz = 1.
+	defaultAngularDegsPerSec = 20.
+	defaultLinearMPerSec     = 0.3
+	defaultObstaclePollingHz = 1.
+	defaultPlanDeviationM    = 2.6
+	defaultPositionPollingHz = 1.
 )
 
 func configurationFromProto(motionCfg *pb.MotionConfiguration) *MotionConfiguration {
 	obstacleDetectors := []ObstacleDetectorName{}
-	planDeviationM := DefaultPlanDeviationM
-	positionPollingHz := DefaultPositionPollingHz
-	obstaclePollingHz := DefaultObstaclePollingHz
-	linearMPerSec := DefaultLinearMPerSec
-	angularDegsPerSec := DefaultAngularDegsPerSec
+	planDeviationM := defaultPlanDeviationM
+	positionPollingHz := defaultPositionPollingHz
+	obstaclePollingHz := defaultObstaclePollingHz
+	linearMPerSec := defaultLinearMPerSec
+	angularDegsPerSec := defaultAngularDegsPerSec
 
 	if motionCfg != nil {
 		if motionCfg.ObstacleDetectors != nil {

--- a/services/motion/motion_configuration.go
+++ b/services/motion/motion_configuration.go
@@ -8,21 +8,13 @@ import (
 	"go.viam.com/rdk/protoutils"
 )
 
-const (
-	defaultAngularDegsPerSec = 20.
-	defaultLinearMPerSec     = 0.3
-	defaultObstaclePollingHz = 1.
-	defaultPlanDeviationM    = 2.6
-	defaultPositionPollingHz = 1.
-)
-
 func configurationFromProto(motionCfg *pb.MotionConfiguration) *MotionConfiguration {
 	obstacleDetectors := []ObstacleDetectorName{}
-	planDeviationM := defaultPlanDeviationM
-	positionPollingHz := defaultPositionPollingHz
-	obstaclePollingHz := defaultObstaclePollingHz
-	linearMPerSec := defaultLinearMPerSec
-	angularDegsPerSec := defaultAngularDegsPerSec
+	planDeviationM := 0.
+	positionPollingHz := 0.
+	obstaclePollingHz := 0.
+	linearMPerSec := 0.
+	angularDegsPerSec := 0.
 
 	if motionCfg != nil {
 		if motionCfg.ObstacleDetectors != nil {

--- a/services/motion/motion_test.go
+++ b/services/motion/motion_test.go
@@ -25,12 +25,7 @@ import (
 )
 
 var defaultMotionCfg = MotionConfiguration{
-	AngularDegsPerSec:     defaultAngularDegsPerSec,
-	LinearMPerSec:         defaultLinearMPerSec,
-	ObstacleDetectors:     []ObstacleDetectorName{},
-	ObstaclePollingFreqHz: defaultObstaclePollingHz,
-	PlanDeviationMM:       defaultPlanDeviationM * 1e3,
-	PositionPollingFreqHz: defaultPositionPollingHz,
+	ObstacleDetectors: []ObstacleDetectorName{},
 }
 
 func TestPlanWithStatus(t *testing.T) {

--- a/services/motion/motion_test.go
+++ b/services/motion/motion_test.go
@@ -24,6 +24,15 @@ import (
 	"go.viam.com/rdk/spatialmath"
 )
 
+var defaultMotionCfg = MotionConfiguration{
+	AngularDegsPerSec:     DefaultAngularDegsPerSec,
+	LinearMPerSec:         DefaultLinearMPerSec,
+	ObstacleDetectors:     []ObstacleDetectorName{},
+	ObstaclePollingFreqHz: DefaultObstaclePollingHz,
+	PlanDeviationMM:       DefaultPlanDeviationM * 1e3,
+	PositionPollingFreqHz: DefaultPositionPollingHz,
+}
+
 func TestPlanWithStatus(t *testing.T) {
 	planID := uuid.New()
 	executionID := uuid.New()
@@ -899,14 +908,14 @@ func TestConfiguration(t *testing.T) {
 
 		testCases := []testCase{
 			{
-				description: "when passed a nil pointer returns mostly empty struct",
+				description: "when passed a nil pointer returns default MotionConfiguration struct",
 				input:       nil,
-				result:      &MotionConfiguration{ObstacleDetectors: []ObstacleDetectorName{}},
+				result:      &defaultMotionCfg,
 			},
 			{
-				description: "when passed an empty struct returns mostly empty struct",
+				description: "when passed an empty struct returns default MotionConfiguration struct",
 				input:       &pb.MotionConfiguration{},
-				result:      &MotionConfiguration{ObstacleDetectors: []ObstacleDetectorName{}},
+				result:      &defaultMotionCfg,
 			},
 			{
 				description: "when passed a full struct returns a full struct",
@@ -1180,10 +1189,8 @@ func TestMoveOnGlobeReq(t *testing.T) {
 					ComponentName:      mybase,
 					MovementSensorName: movementsensor.Named("my-movementsensor"),
 					Obstacles:          []*spatialmath.GeoObstacle{},
-					MotionCfg: &MotionConfiguration{
-						ObstacleDetectors: []ObstacleDetectorName{},
-					},
-					Extra: map[string]interface{}{},
+					MotionCfg:          &defaultMotionCfg,
+					Extra:              map[string]interface{}{},
 				},
 			},
 			{
@@ -1310,10 +1317,8 @@ func TestMoveOnGlobeReq(t *testing.T) {
 					ComponentName:      mybase,
 					MovementSensorName: movementsensor.Named("my-movementsensor"),
 					Obstacles:          []*spatialmath.GeoObstacle{},
-					MotionCfg: &MotionConfiguration{
-						ObstacleDetectors: []ObstacleDetectorName{},
-					},
-					Extra: map[string]interface{}{},
+					MotionCfg:          &defaultMotionCfg,
+					Extra:              map[string]interface{}{},
 				},
 			},
 			{

--- a/services/motion/motion_test.go
+++ b/services/motion/motion_test.go
@@ -25,12 +25,12 @@ import (
 )
 
 var defaultMotionCfg = MotionConfiguration{
-	AngularDegsPerSec:     DefaultAngularDegsPerSec,
-	LinearMPerSec:         DefaultLinearMPerSec,
+	AngularDegsPerSec:     defaultAngularDegsPerSec,
+	LinearMPerSec:         defaultLinearMPerSec,
 	ObstacleDetectors:     []ObstacleDetectorName{},
-	ObstaclePollingFreqHz: DefaultObstaclePollingHz,
-	PlanDeviationMM:       DefaultPlanDeviationM * 1e3,
-	PositionPollingFreqHz: DefaultPositionPollingHz,
+	ObstaclePollingFreqHz: defaultObstaclePollingHz,
+	PlanDeviationMM:       defaultPlanDeviationM * 1e3,
+	PositionPollingFreqHz: defaultPositionPollingHz,
 }
 
 func TestPlanWithStatus(t *testing.T) {

--- a/services/navigation/builtin/builtin.go
+++ b/services/navigation/builtin/builtin.go
@@ -54,8 +54,6 @@ const (
 	defaultMapType = navigation.GPSMap
 
 	// desired speeds to maintain for the base.
-	// defaultLinearVelocityMPerSec     = 0.5
-	// defaultAngularVelocityDegsPerSec = 90.
 	defaultLinearMPerSec     = 0.3
 	defaultAngularDegsPerSec = 20.
 

--- a/services/navigation/builtin/builtin.go
+++ b/services/navigation/builtin/builtin.go
@@ -54,19 +54,22 @@ const (
 	defaultMapType = navigation.GPSMap
 
 	// desired speeds to maintain for the base.
-	defaultLinearVelocityMPerSec     = 0.5
-	defaultAngularVelocityDegsPerSec = 90.
+	// defaultLinearVelocityMPerSec     = 0.5
+	// defaultAngularVelocityDegsPerSec = 90.
+	defaultLinearMPerSec     = 0.3
+	defaultAngularDegsPerSec = 20.
 
 	// how far off the path must the robot be to trigger replanning.
-	defaultPlanDeviationM = 1e9
+	defaultPlanDeviationM = 2.6
 
 	// the allowable quality change between the new plan and the remainder
 	// of the original plan.
 	defaultReplanCostFactor = 1.
 
 	// frequency measured in hertz.
-	defaultObstaclePollingFrequencyHz = 2.
-	defaultPositionPollingFrequencyHz = 2.
+	defaultSmoothIter        = 20
+	defaultObstaclePollingHz = 1.
+	defaultPositionPollingHz = 1.
 
 	// frequency in milliseconds.
 	planHistoryPollFrequency = time.Millisecond * 50
@@ -259,19 +262,19 @@ func (svc *builtIn) Reconfigure(ctx context.Context, deps resource.Dependencies,
 	}
 
 	// Set optional variables
-	metersPerSec := defaultLinearVelocityMPerSec
+	metersPerSec := defaultLinearMPerSec
 	if svcConfig.MetersPerSec != 0 {
 		metersPerSec = svcConfig.MetersPerSec
 	}
-	degPerSec := defaultAngularVelocityDegsPerSec
+	degPerSec := defaultAngularDegsPerSec
 	if svcConfig.DegPerSec != 0 {
 		degPerSec = svcConfig.DegPerSec
 	}
-	positionPollingFrequencyHz := defaultPositionPollingFrequencyHz
+	positionPollingFrequencyHz := defaultPositionPollingHz
 	if svcConfig.PositionPollingFrequencyHz != 0 {
 		positionPollingFrequencyHz = svcConfig.PositionPollingFrequencyHz
 	}
-	obstaclePollingFrequencyHz := defaultObstaclePollingFrequencyHz
+	obstaclePollingFrequencyHz := defaultObstaclePollingHz
 	if svcConfig.ObstaclePollingFrequencyHz != 0 {
 		obstaclePollingFrequencyHz = svcConfig.ObstaclePollingFrequencyHz
 	}

--- a/services/navigation/builtin/builtin.go
+++ b/services/navigation/builtin/builtin.go
@@ -65,7 +65,6 @@ const (
 	defaultReplanCostFactor = 1.
 
 	// frequency measured in hertz.
-	defaultSmoothIter        = 20
 	defaultObstaclePollingHz = 1.
 	defaultPositionPollingHz = 1.
 

--- a/services/navigation/builtin/builtin_test.go
+++ b/services/navigation/builtin/builtin_test.go
@@ -210,10 +210,10 @@ func TestNew(t *testing.T) {
 		test.That(t, svcStruct.store, test.ShouldResemble, navigation.NewMemoryNavigationStore())
 
 		test.That(t, svcStruct.motionCfg.ObstacleDetectors, test.ShouldBeNil)
-		test.That(t, svcStruct.motionCfg.AngularDegsPerSec, test.ShouldEqual, defaultAngularVelocityDegsPerSec)
-		test.That(t, svcStruct.motionCfg.LinearMPerSec, test.ShouldEqual, defaultLinearVelocityMPerSec)
-		test.That(t, svcStruct.motionCfg.PositionPollingFreqHz, test.ShouldEqual, defaultPositionPollingFrequencyHz)
-		test.That(t, svcStruct.motionCfg.ObstaclePollingFreqHz, test.ShouldEqual, defaultObstaclePollingFrequencyHz)
+		test.That(t, svcStruct.motionCfg.AngularDegsPerSec, test.ShouldEqual, defaultAngularDegsPerSec)
+		test.That(t, svcStruct.motionCfg.LinearMPerSec, test.ShouldEqual, defaultLinearMPerSec)
+		test.That(t, svcStruct.motionCfg.PositionPollingFreqHz, test.ShouldEqual, defaultPositionPollingHz)
+		test.That(t, svcStruct.motionCfg.ObstaclePollingFreqHz, test.ShouldEqual, defaultObstaclePollingHz)
 		test.That(t, svcStruct.motionCfg.PlanDeviationMM, test.ShouldEqual, defaultPlanDeviationM*1e3)
 	})
 
@@ -857,9 +857,9 @@ func TestStartWaypoint(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		expectedMotionCfg := &motion.MotionConfiguration{
-			PositionPollingFreqHz: 2,
-			ObstaclePollingFreqHz: 2,
-			PlanDeviationMM:       1e+12,
+			PositionPollingFreqHz: 1,
+			ObstaclePollingFreqHz: 1,
+			PlanDeviationMM:       2600,
 			LinearMPerSec:         1,
 			AngularDegsPerSec:     1,
 			ObstacleDetectors: []motion.ObstacleDetectorName{


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-4512)

- Update default motion configuration (used by motion.MoveOnGlobe) to the values used during hardware testing for both motion & nav
```go
	defaultAngularDegsPerSec = 20.
	defaultLinearMPerSec     = 0.3
	defaultObstaclePollingHz = 1.
	defaultPlanDeviationM    = 2.6
	defaultPositionPollingHz = 1.
	defaultSmoothIter           = 20
```