### PR TITLE
Fix camera refresh event and triggering

### DIFF
--- a/web/frontend/src/components/camera/index.svelte
+++ b/web/frontend/src/components/camera/index.svelte
@@ -24,8 +24,10 @@ const setupCamera = (cameraName: string) => {
 
 const handleRefreshInput = (name: string) => {
   return (event: CustomEvent<{ value: string }>) => {
-    // The event is being invoked twice, once as a regular event and once as a
-    // custom event. We need to ignore the regular event.
+    /**
+     * The event is being invoked twice, once as a regular event and once as a
+     * custom event. We need to ignore the regular event.
+     */
     if (!event.detail) {
       return;
     }

--- a/web/frontend/src/components/camera/index.svelte
+++ b/web/frontend/src/components/camera/index.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-
 import type { commonApi } from '@viamrobotics/sdk';
 import Camera from './camera.svelte';
 import PCD from '../pcd/index.svelte';
@@ -25,10 +24,15 @@ const setupCamera = (cameraName: string) => {
 
 const handleRefreshInput = (name: string) => {
   return (event: CustomEvent<{ value: string }>) => {
+    // The event is being invoked twice, once as a regular event and once as a
+    // custom event. We need to ignore the regular event.
+    if (!event.detail) {
+      return;
+    }
+
     refreshFrequency[name] = event.detail.value;
   };
 };
-
 </script>
 
 {#each resources as camera (camera.name)}
@@ -41,7 +45,9 @@ const handleRefreshInput = (name: string) => {
     <div class="flex flex-col gap-4 border border-t-0 border-medium p-4">
       <v-switch
         label={`View ${camera.name}`}
-        aria-label={openCameras[camera.name] ? `Hide Camera: ${camera.name}` : `View Camera: ${camera.name}`}
+        aria-label={openCameras[camera.name]
+          ? `Hide Camera: ${camera.name}`
+          : `View Camera: ${camera.name}`}
         value={openCameras[camera.name] ? 'on' : 'off'}
         on:input={() => setupCamera(camera.name)}
       />
@@ -74,6 +80,7 @@ const handleRefreshInput = (name: string) => {
           cameraName={camera.name}
           showExportScreenshot={true}
           refreshRate={refreshFrequency[camera.name]}
+          {triggerRefresh}
         />
       {/if}
 


### PR DESCRIPTION
Quick fix for camera streaming issues. First the legacy prime select seems to be emitting two events, a regular one and a custom one. I added a check to make sure we only attempt to evaluate the custom event, this should not be a requirement moving forward using prime-core.

Another fix was to pass the `triggerRefresh` value to the `<Camera />` component so manually refreshing cameras will work.