### PR TITLE
RSDK-5758 increase the importance of matching angles in TP-space metrics

### DIFF
--- a/motionplan/motionPlanner_test.go
+++ b/motionplan/motionPlanner_test.go
@@ -824,7 +824,6 @@ func TestReplan(t *testing.T) {
 }
 
 func TestPtgPosOnlyBidirectional(t *testing.T) {
-	t.Skip()
 	ctx := context.Background()
 	logger := logging.NewTestLogger(t)
 

--- a/motionplan/planManager.go
+++ b/motionplan/planManager.go
@@ -25,7 +25,7 @@ import (
 const (
 	defaultOptimalityMultiple      = 2.0
 	defaultFallbackTimeout         = 1.5
-	defaultTPspaceOrientationScale = 60.
+	defaultTPspaceOrientationScale = 500.
 )
 
 // planManager is intended to be the single entry point to motion planners, wrapping all others, dealing with fallbacks, etc.


### PR DESCRIPTION
This change also lets us unskip a previously flaky test relating to bidirectional solving for TP-space RRT