### PR TITLE
RSDK-5942 ptgs should be able to partially extend

### DIFF
--- a/motionplan/tpSpaceRRT.go
+++ b/motionplan/tpSpaceRRT.go
@@ -55,7 +55,7 @@ const (
 
 	// When evaluating the partial node to add to a tree after defaultCollisionWalkbackPct is applied, ensure the trajectory is still at
 	// least this long.
-	defaultMinArcLength = 150
+	defaultMinTrajectoryLength = 150
 )
 
 var defaultGoalMetricConstructor = ik.NewSquaredNormMetric
@@ -502,10 +502,13 @@ func (mp *tpSpaceRRTMotionPlanner) checkTraj(trajK []*tpspace.TrajNode, invert b
 			ok, _ := mp.planOpts.CheckStateConstraints(trajState)
 			if !ok {
 				okDist := trajPt.Dist * defaultCollisionWalkbackPct
-				if okDist > defaultMinArcLength && !invert {
+				if okDist > defaultMinTrajectoryLength && !invert {
 					// Check that okDist is larger than the minimum distance to move to add a partial trajectory.
 					for i := len(passed) - 1; i > 0; i-- {
-						// Return the most recent node whose dist is less than okDist
+						if passed[i].Cost() < defaultMinTrajectoryLength {
+							break
+						}
+						// Return the most recent node whose dist is less than okDist and larger than defaultMinTrajectoryLength
 						if passed[i].Cost() < okDist {
 							return passed[i]
 						}

--- a/motionplan/tpSpaceRRT.go
+++ b/motionplan/tpSpaceRRT.go
@@ -55,7 +55,7 @@ const (
 
 	// When evaluating the partial node to add to a tree after defaultCollisionWalkbackPct is applied, ensure the trajectory is still at
 	// least this long.
-	defaultMinTrajectoryLength = 150
+	defaultMinTrajectoryLength = 350
 )
 
 var defaultGoalMetricConstructor = ik.NewSquaredNormMetric
@@ -452,7 +452,7 @@ func (mp *tpSpaceRRTMotionPlanner) getExtensionCandidate(
 		// add the last node in trajectory
 		arcStartPose = spatialmath.Compose(arcStartPose, goodNode.Pose())
 		successNode = &basicNode{
-			q:      append([]referenceframe.Input{{float64(ptgNum)}}, subNode.Q()...),
+			q:      append([]referenceframe.Input{{float64(ptgNum)}}, goodNode.Q()...),
 			cost:   goodNode.Cost(),
 			pose:   arcStartPose,
 			corner: false,

--- a/motionplan/tpSpaceRRT_test.go
+++ b/motionplan/tpSpaceRRT_test.go
@@ -54,8 +54,8 @@ func TestPtgRrtBidirectional(t *testing.T) {
 	tp.algOpts.pathdebug = printPath
 	if tp.algOpts.pathdebug {
 		tp.logger.Debug("$type,X,Y")
-		tp.logger.Debugf("$SG,%f,%f\n", 0., 0.)
-		tp.logger.Debugf("$SG,%f,%f\n", goalPos.Point().X, goalPos.Point().Y)
+		tp.logger.Debugf("$SG,%f,%f", 0., 0.)
+		tp.logger.Debugf("$SG,%f,%f", goalPos.Point().X, goalPos.Point().Y)
 	}
 	test.That(t, ok, test.ShouldBeTrue)
 	plan, err := tp.plan(ctx, goalPos, nil)
@@ -71,9 +71,9 @@ func TestPtgRrtBidirectional(t *testing.T) {
 			for i, pt := range trajPts {
 				intPose := spatialmath.Compose(lastPose, pt.Pose)
 				if i == 0 {
-					tp.logger.Debugf("$WP,%f,%f\n", intPose.Point().X, intPose.Point().Y)
+					tp.logger.Debugf("$WP,%f,%f", intPose.Point().X, intPose.Point().Y)
 				}
-				tp.logger.Debugf("$FINALPATH,%f,%f\n", intPose.Point().X, intPose.Point().Y)
+				tp.logger.Debugf("$FINALPATH,%f,%f", intPose.Point().X, intPose.Point().Y)
 				if i == len(trajPts)-1 {
 					lastPose = intPose
 					break
@@ -81,7 +81,7 @@ func TestPtgRrtBidirectional(t *testing.T) {
 			}
 		}
 	}
-	tp.planOpts.SmoothIter = 20
+	tp.planOpts.SmoothIter = 0
 	plan = tp.smoothPath(ctx, plan)
 	if tp.algOpts.pathdebug {
 		lastPose = spatialmath.NewZeroPose()
@@ -90,9 +90,9 @@ func TestPtgRrtBidirectional(t *testing.T) {
 			for i, pt := range trajPts {
 				intPose := spatialmath.Compose(lastPose, pt.Pose)
 				if i == 0 {
-					tp.logger.Debugf("$SMOOTHWP,%f,%f\n", intPose.Point().X, intPose.Point().Y)
+					tp.logger.Debugf("$SMOOTHWP,%f,%f", intPose.Point().X, intPose.Point().Y)
 				}
-				tp.logger.Debugf("$SMOOTHPATH,%f,%f\n", intPose.Point().X, intPose.Point().Y)
+				tp.logger.Debugf("$SMOOTHPATH,%f,%f", intPose.Point().X, intPose.Point().Y)
 				if pt.Dist >= mynode.Q()[2].Value {
 					lastPose = intPose
 					break

--- a/motionplan/tpSpaceRRT_test.go
+++ b/motionplan/tpSpaceRRT_test.go
@@ -81,7 +81,7 @@ func TestPtgRrtBidirectional(t *testing.T) {
 			}
 		}
 	}
-	tp.planOpts.SmoothIter = 0
+	tp.planOpts.SmoothIter = 20
 	plan = tp.smoothPath(ctx, plan)
 	if tp.algOpts.pathdebug {
 		lastPose = spatialmath.NewZeroPose()


### PR DESCRIPTION
Currently, if a PTG is evaluated for extendability and hits an obstacle, the whole PTG is discarded.

This PR updates behavior such that for the forwards tree, we are able to extend with the good section of the PTG rather than discarding it entirely.