### PR TITLE
Update error message for parse module ID

### DIFF
--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -489,8 +489,8 @@ func parseModuleID(id string) (moduleID, error) {
 	splitModuleName := strings.Split(id, ":")
 	if len(splitModuleName) != 2 {
 		return moduleID{}, errors.Errorf("invalid module name '%s'."+
-			" Module name must be in the form 'prefix:module-name' for public modules"+
-			" or just 'module-name' for private modules in organizations without a public namespace", id)
+			" Module name must be in the form 'public-namespace:module-name' for public modules"+
+			" or 'org-id:module-name' for private modules in organizations without a public namespace", id)
 	}
 	return moduleID{prefix: splitModuleName[0], name: splitModuleName[1]}, nil
 }


### PR DESCRIPTION
We don't support just a module name as a module ID for private modules. Updated to specify that private modules in orgs without a namespace should prefix with org-id.