### PR TITLE
Update docs link

### DIFF
--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -253,7 +253,7 @@ func UploadModuleAction(c *cli.Context) error {
 	if !forceUploadArg {
 		if err := validateModuleFile(client, moduleID, tarballPath, versionArg); err != nil {
 			return fmt.Errorf(
-				"error validating module: %w. For more details, please visit: https://docs.viam.com/manage/cli/#command-options-3 ",
+				"error validating module: %w. For more details, please visit: https://docs.viam.com/fleet/cli/#module ",
 				err)
 		}
 	}


### PR DESCRIPTION
Update docs link to use `viam module` CLI reference parent header, rather than its `create` | `update` | `upload` subsection table named `Command options`.
- This should help future-proof us as well, since these parent anchor targets only change when eng changes the names of these commands! ;)