### PR TITLE
RSDK-4366 odroid kernel crashes when using pwm

### DIFF
--- a/components/board/genericlinux/hw_pwm.go
+++ b/components/board/genericlinux/hw_pwm.go
@@ -99,7 +99,7 @@ func (pwm *pwmDevice) unexport() error {
 	// On boards like the Odroid C4, there is a race condition in the kernel where, if you unexport
 	// the pin too quickly after changing something else about it (e.g., disabling it), the whole
 	// PWM system gets corrupted. Sleep for a small amount of time to avoid this.
-	time.Sleep(time.Microsecond)
+	time.Sleep(time.Millisecond)
 	if err := pwm.writeChip("unexport", uint64(pwm.line)); err != nil {
 		return err
 	}


### PR DESCRIPTION
increasing sleep time before unexporting to 1 millisecond. There are still issues with switching between GPIO and PWM on the same pin, but the pwm works reliably on pins 7 and 11 if you use them as only pwm pins. 