### PR TITLE
[RSDK-5961] update replaypcd to pull batched data from gcs

### DIFF
--- a/components/camera/replaypcd/replaypcd.go
+++ b/components/camera/replaypcd/replaypcd.go
@@ -458,9 +458,7 @@ func (replay *pcdCamera) initCloudConnection(ctx context.Context) error {
 
 	replay.cloudConn = conn
 	replay.dataClient = dataServiceClient
-	replay.httpClient = &http.Client{
-		Timeout: downloadTimeout,
-	}
+	replay.httpClient = &http.Client{}
 	return nil
 }
 

--- a/components/camera/replaypcd/replaypcd.go
+++ b/components/camera/replaypcd/replaypcd.go
@@ -270,9 +270,6 @@ func (replay *pcdCamera) getDataFromHTTP(ctx context.Context, dataURL, fileID st
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add("organization_id", replay.filter.OrganizationIds[0])
-	req.Header.Add("location_id", replay.filter.LocationIds[0])
-	req.Header.Add("file_id", fileID)
 	req.Header.Add("key_id", replay.APIKeyID)
 	req.Header.Add("key", replay.APIKey)
 

--- a/components/camera/replaypcd/replaypcd.go
+++ b/components/camera/replaypcd/replaypcd.go
@@ -255,7 +255,7 @@ func (replay *pcdCamera) downloadBatch(ctx context.Context) {
 
 		goutils.PanicCapturingGo(func() {
 			defer wg.Done()
-			data.pc, data.err = replay.getDataFromGCS(ctx, data.uri, data.fileID)
+			data.pc, data.err = replay.getDataFromHTTP(ctx, data.uri, data.fileID)
 			if data.err != nil {
 				return
 			}
@@ -264,8 +264,8 @@ func (replay *pcdCamera) downloadBatch(ctx context.Context) {
 	wg.Wait()
 }
 
-// getDataFromGCS makes a request directly to GCS to get the desired camera data.
-func (replay *pcdCamera) getDataFromGCS(ctx context.Context, dataURL, fileID string) (pointcloud.PointCloud, error) {
+// getDataFromHTTP makes a request to an http endpoint app serves, which gets redirected to GCS.
+func (replay *pcdCamera) getDataFromHTTP(ctx context.Context, dataURL, fileID string) (pointcloud.PointCloud, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, dataURL, nil)
 	if err != nil {
 		return nil, err

--- a/components/camera/replaypcd/replaypcd.go
+++ b/components/camera/replaypcd/replaypcd.go
@@ -4,10 +4,12 @@ package replaypcd
 import (
 	"bytes"
 	"context"
+	"net/http"
 	"sync"
 	"time"
 
 	"github.com/pkg/errors"
+	"go.uber.org/multierr"
 	datapb "go.viam.com/api/app/data/v1"
 	goutils "go.viam.com/utils"
 	"go.viam.com/utils/rpc"
@@ -67,10 +69,11 @@ type TimeInterval struct {
 // cacheEntry stores data that was downloaded from a previous operation but has not yet been passed
 // to the caller.
 type cacheEntry struct {
-	id            *datapb.BinaryID
+	fileId        string
 	pc            pointcloud.PointCloud
 	timeRequested *timestamppb.Timestamp
 	timeReceived  *timestamppb.Timestamp
+	uri           string
 	err           error
 }
 
@@ -136,6 +139,7 @@ type pcdCamera struct {
 	cloudConnSvc cloud.ConnectionService
 	cloudConn    rpc.ClientConn
 	dataClient   datapb.DataServiceClient
+	httpClient   *http.Client
 
 	lastData string
 	limit    uint64
@@ -222,11 +226,11 @@ func (replay *pcdCamera) NextPointCloud(ctx context.Context) (pointcloud.PointCl
 	replay.cache = make([]*cacheEntry, len(resp.Data))
 	for i, dataResponse := range resp.Data {
 		md := dataResponse.GetMetadata()
-		replay.cache[i] = &cacheEntry{id: &datapb.BinaryID{
-			FileId:         md.GetId(),
-			OrganizationId: md.GetCaptureMetadata().GetOrganizationId(),
-			LocationId:     md.GetCaptureMetadata().GetLocationId(),
-		}}
+		replay.cache[i] = &cacheEntry{
+			fileId:        md.GetId(),
+			uri:           md.GetUri(),
+			timeRequested: md.GetTimeRequested(),
+			timeReceived:  md.GetTimeReceived()}
 	}
 
 	ctxTimeout, cancelTimeout := context.WithTimeout(ctx, downloadTimeout)
@@ -250,25 +254,45 @@ func (replay *pcdCamera) downloadBatch(ctx context.Context) {
 
 		goutils.PanicCapturingGo(func() {
 			defer wg.Done()
-
-			var resp *datapb.BinaryDataByIDsResponse
-			resp, data.err = replay.dataClient.BinaryDataByIDs(ctx, &datapb.BinaryDataByIDsRequest{
-				BinaryIds:     []*datapb.BinaryID{data.id},
-				IncludeBinary: true,
-			})
+			data.pc, data.err = replay.getDataFromGCS(ctx, data.uri, data.fileId)
 			if data.err != nil {
 				return
-			}
-
-			// Decode response data
-			data.pc, data.err = decodeResponseData(resp.GetData())
-			if data.err == nil {
-				data.timeRequested = resp.GetData()[0].GetMetadata().GetTimeRequested()
-				data.timeReceived = resp.GetData()[0].GetMetadata().GetTimeReceived()
 			}
 		})
 	}
 	wg.Wait()
+}
+
+// getDataFromGCS makes a request to get the desired cartographer-module binary for the job.
+func (replay *pcdCamera) getDataFromGCS(ctx context.Context, dataURL string, fileId string) (pointcloud.PointCloud, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, dataURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("organization_id", replay.filter.OrganizationIds[0])
+	req.Header.Add("location_id", replay.filter.LocationIds[0])
+	req.Header.Add("file_id", fileId)
+	req.Header.Add("key_id", replay.APIKeyID)
+	req.Header.Add("key", replay.APIKey)
+
+	res, err := replay.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	pc, err := pointcloud.ReadPCD(res.Body)
+	if err != nil {
+		return nil, multierr.Combine(err, res.Body.Close())
+	}
+	if res.StatusCode != http.StatusOK {
+		return nil, multierr.Combine(errors.New(res.Status), res.Body.Close())
+	}
+
+	if err := res.Body.Close(); err != nil {
+		return nil, err
+	}
+
+	return pc, nil
 }
 
 // getDataFromCache retrieves the next cached data and removes it from the cache. It assumes the
@@ -438,6 +462,9 @@ func (replay *pcdCamera) initCloudConnection(ctx context.Context) error {
 
 	replay.cloudConn = conn
 	replay.dataClient = dataServiceClient
+	replay.httpClient = &http.Client{
+		Timeout: downloadTimeout,
+	}
 	return nil
 }
 

--- a/components/camera/replaypcd/replaypcd.go
+++ b/components/camera/replaypcd/replaypcd.go
@@ -264,7 +264,7 @@ func (replay *pcdCamera) downloadBatch(ctx context.Context) {
 	wg.Wait()
 }
 
-// getDataFromGCS makes a request to get the desired cartographer-module binary for the job.
+// getDataFromGCS makes a request directly to GCS to get the desired camera data.
 func (replay *pcdCamera) getDataFromGCS(ctx context.Context, dataURL, fileID string) (pointcloud.PointCloud, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, dataURL, nil)
 	if err != nil {

--- a/components/camera/replaypcd/replaypcd_test.go
+++ b/components/camera/replaypcd/replaypcd_test.go
@@ -24,10 +24,11 @@ const (
 	validLocationID     = "location_id"
 	validAPIKey         = "a key"
 	validAPIKeyID       = "a key id"
+	numPCDFilesOriginal = 15
 )
 
 var (
-	numPCDFiles       = 15
+	numPCDFiles       = numPCDFilesOriginal
 	batchSize0        = uint64(0)
 	batchSize1        = uint64(1)
 	batchSize2        = uint64(2)
@@ -388,7 +389,7 @@ func TestReplayPCDNextPointCloud(t *testing.T) {
 func TestReplayPCDLiveNextPointCloud(t *testing.T) {
 	ctx := context.Background()
 
-	numPCDFilesOriginal := numPCDFiles
+	// numPCDFilesOriginal := numPCDFiles
 	numPCDFiles = 10
 	defer func() { numPCDFiles = numPCDFilesOriginal }()
 
@@ -408,6 +409,7 @@ func TestReplayPCDLiveNextPointCloud(t *testing.T) {
 	// Iterate through all files that meet the provided filter
 	i := 0
 	for {
+
 		pc, err := replayCamera.NextPointCloud(ctx)
 		if i == numPCDFiles {
 			test.That(t, err, test.ShouldNotBeNil)

--- a/components/camera/replaypcd/replaypcd_test.go
+++ b/components/camera/replaypcd/replaypcd_test.go
@@ -409,7 +409,6 @@ func TestReplayPCDLiveNextPointCloud(t *testing.T) {
 	// Iterate through all files that meet the provided filter
 	i := 0
 	for {
-
 		pc, err := replayCamera.NextPointCloud(ctx)
 		if i == numPCDFiles {
 			test.That(t, err, test.ShouldNotBeNil)

--- a/components/camera/replaypcd/replaypcd_test.go
+++ b/components/camera/replaypcd/replaypcd_test.go
@@ -389,7 +389,6 @@ func TestReplayPCDNextPointCloud(t *testing.T) {
 func TestReplayPCDLiveNextPointCloud(t *testing.T) {
 	ctx := context.Background()
 
-	// numPCDFilesOriginal := numPCDFiles
 	numPCDFiles = 10
 	defer func() { numPCDFiles = numPCDFilesOriginal }()
 

--- a/components/camera/replaypcd/replaypcd_utils_test.go
+++ b/components/camera/replaypcd/replaypcd_utils_test.go
@@ -36,7 +36,7 @@ const (
 	testTime           = "2000-01-01T12:00:%02dZ"
 	orgID              = "slam_org_id"
 	locationID         = "slam_location_id"
-	testingHttpPattern = "/myurl"
+	testingHTTPPattern = "/myurl"
 )
 
 // mockDataServiceServer is a struct that includes unimplemented versions of all the Data Service endpoints. These
@@ -83,7 +83,7 @@ func (mDServer *mockDataServiceServer) BinaryDataByFilter(ctx context.Context, r
 					OrganizationId: orgID,
 					LocationId:     locationID,
 				},
-				Uri: mDServer.httpMock[newFileNum].URL + testingHttpPattern,
+				Uri: mDServer.httpMock[newFileNum].URL + testingHTTPPattern,
 			},
 		}
 
@@ -109,7 +109,7 @@ func (mDServer *mockDataServiceServer) BinaryDataByFilter(ctx context.Context, r
 						OrganizationId: orgID,
 						LocationId:     locationID,
 					},
-					Uri: mDServer.httpMock[newFileNum+i].URL + testingHttpPattern,
+					Uri: mDServer.httpMock[newFileNum+i].URL + testingHTTPPattern,
 				},
 			}
 			resp.Data = append(resp.Data, &binaryData)
@@ -138,7 +138,7 @@ func createMockCloudDependencies(ctx context.Context, t *testing.T, logger loggi
 	test.That(t, err, test.ShouldBeNil)
 
 	// This creates a mock server for each pcd file used in testing
-	srv := newHTTPMock(testingHttpPattern, http.StatusOK)
+	srv := newHTTPMock(testingHTTPPattern, http.StatusOK)
 	test.That(t, rpcServer.RegisterServiceServer(
 		ctx,
 		&datapb.DataService_ServiceDesc,
@@ -296,7 +296,7 @@ type ctrl struct {
 	pcdFileNumber int
 }
 
-// mockHandler will return the pcd file attached to the mock server
+// mockHandler will return the pcd file attached to the mock server.
 func (c *ctrl) mockHandler(w http.ResponseWriter, r *http.Request) {
 	path := fmt.Sprintf(datasetDirectory, c.pcdFileNumber)
 	pcdFile, _ := getCompressedBytesFromArtifact(path)
@@ -305,7 +305,7 @@ func (c *ctrl) mockHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(pcdFile)
 }
 
-// newHTTPMock creates a set of mock http servers based on the number of PCD files used for testing
+// newHTTPMock creates a set of mock http servers based on the number of PCD files used for testing.
 func newHTTPMock(pattern string, statusCode int) []*httptest.Server {
 	httpServers := []*httptest.Server{}
 	for i := 0; i < numPCDFilesOriginal; i++ {

--- a/components/camera/replaypcd/replaypcd_utils_test.go
+++ b/components/camera/replaypcd/replaypcd_utils_test.go
@@ -314,12 +314,9 @@ func getCompressedBytesFromArtifact(inputPath string) ([]byte, error) {
 
 // getPointCloudFromArtifact will return a point cloud based on the provided artifact path.
 func getPointCloudFromArtifact(i int) (pointcloud.PointCloud, error) {
-
 	path := filepath.Clean(artifact.MustPath(fmt.Sprintf(datasetDirectory, i)))
 	pcdFile, err := os.Open(path)
-
 	if err != nil {
-
 		return nil, err
 	}
 	defer utils.UncheckedErrorFunc(pcdFile.Close)
@@ -339,10 +336,8 @@ type ctrl struct {
 
 func (c *ctrl) mockHandler(w http.ResponseWriter, r *http.Request) {
 	path := fmt.Sprintf(datasetDirectory, c.pcdFileNumber)
-	pcdFile, err := getCompressedBytesFromArtifact(path)
-	if err != nil {
+	pcdFile, _ := getCompressedBytesFromArtifact(path)
 
-	}
 	w.WriteHeader(c.statusCode)
 	w.Write(pcdFile)
 }


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-5961

This PR changes the replaypcd sensor's behavior when caching a batch of data. Before when using a batch size greater than 1, the replaypcd would make BinaryDataByID calls to app to pull down a batch of data. Now the replaypcd sensor will use the url from the BinaryDataByFilter metadata to make an http request for data from gcs directly.


 tested locally using a replay sensor with and without cartographer. Testing with cloudslam soonTM.