### PR TITLE
RSDK-6006 flaky extrinsic_calibration test on golang 1.21

### DIFF
--- a/rimage/transform/cmd/extrinsic_calibration/main.go
+++ b/rimage/transform/cmd/extrinsic_calibration/main.go
@@ -12,8 +12,6 @@ import (
 	"io"
 	"os"
 
-	"gonum.org/v1/gonum/optimize"
-
 	"github.com/pkg/errors"
 	"go.viam.com/utils"
 	"gonum.org/v1/gonum/optimize"

--- a/rimage/transform/cmd/extrinsic_calibration/main_test.go
+++ b/rimage/transform/cmd/extrinsic_calibration/main_test.go
@@ -7,14 +7,27 @@ import (
 	"os"
 	"testing"
 
+
 	"github.com/golang/geo/r2"
 	"github.com/golang/geo/r3"
 	"go.viam.com/test"
+	"gonum.org/v1/gonum/optimize"
 
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/rimage/transform"
+	"go.viam.com/rdk/spatialmath"
 	"go.viam.com/rdk/utils"
 )
+
+type mockPose struct{}
+
+func (m mockPose) Point() r3.Vector {
+	return r3.Vector{}
+}
+
+func (m mockPose) Orientation() spatialmath.Orientation {
+	return spatialmath.NewOrientationVector()
+}
 
 func TestMainCalibrate(t *testing.T) {
 	outDir := t.TempDir()
@@ -32,8 +45,12 @@ func TestMainCalibrate(t *testing.T) {
 	err = os.WriteFile(outDir+"/test.json", b, 0o644)
 	test.That(t, err, test.ShouldBeNil)
 
+	mockCalibrationFn := func(_ *optimize.Problem, _ logging.Logger) (spatialmath.Pose, error) {
+		return mockPose{}, nil
+	}
+
 	// read from temp file and process
-	calibrate(outDir+"/test.json", logger)
+	calibrate(outDir+"/test.json", logger, mockCalibrationFn)
 }
 
 func createInputConfig(c *transform.DepthColorIntrinsicsExtrinsics, n int) *transform.ExtrinsicCalibrationConfig {

--- a/rimage/transform/cmd/extrinsic_calibration/main_test.go
+++ b/rimage/transform/cmd/extrinsic_calibration/main_test.go
@@ -6,8 +6,6 @@ import (
 	"math/rand"
 	"os"
 	"testing"
-
-
 	"github.com/golang/geo/r2"
 	"github.com/golang/geo/r3"
 	"go.viam.com/test"

--- a/rimage/transform/cmd/extrinsic_calibration/main_test.go
+++ b/rimage/transform/cmd/extrinsic_calibration/main_test.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"os"
 	"testing"
+
 	"github.com/golang/geo/r2"
 	"github.com/golang/geo/r3"
 	"go.viam.com/test"


### PR DESCRIPTION
# Description
Fixes the flaky test. I mocked out `transform.RunPinholeExtrinsicCalibration` since it 
1. relied on a random number generator ([link](https://github.com/viamrobotics/rdk/blob/5c1ac8c233d7c9bbcac57b99dc80a909f7cf4a0d/rimage/transform/calibrate_pinhole_extrinsics.go#L50)) and 
2. was only a wrapper around a third-party library function, `optimize.Minimize`

We should _not_ rely on random number generators in unit tests since it is, by design, non-deterministic and can likely result in flaky tests that are difficult to track down. Unit tests should also not test third-party library code. That's better handled in integration or end-to-end tests. 

# Testing
I ran the tests 10,000 times, and each time passed.
```
go test -count 10000 ./rimage/transform/cmd/extrinsic_calibration
```