### PR TITLE
APP-3391: Bump remote-control version

### DIFF
--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/remote-control",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@improbable-eng/grpc-web": "0.15.0",

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
APP-3391

Bump remote-control version after https://github.com/viamrobotics/rdk/pull/3319

Manually bumped the version in `package.json` and then ran `npm i` to make sure `package-lock.json` autogenerated successfully. Let me know if there is any step I missed. 