### PR TITLE
RSDK-4028: Poll for transient obstacles in nav card

### DIFF
--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -43,7 +43,6 @@
         "prettier-plugin-tailwindcss": "^0.5.6",
         "svelte": "^4.1.2",
         "svelte-check": "^3.5.2",
-        "svelte-inview": "^4.0.1",
         "tailwindcss": "3.3.3",
         "three": "0.159.0",
         "three-inspect": "0.3.4",
@@ -6247,15 +6246,6 @@
       },
       "peerDependencies": {
         "svelte": "^3.19.0 || ^4.0.0"
-      }
-    },
-    "node_modules/svelte-inview": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/svelte-inview/-/svelte-inview-4.0.1.tgz",
-      "integrity": "sha512-8NuT/DKFiZAccDw1Z16cIsdZ7K6/BGxrUfDaFaWTCEdn3YqMj1TUAkfmQ08FQ1+INl1G+TQS+ImXIBiiISgXog==",
-      "dev": true,
-      "peerDependencies": {
-        "svelte": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/svelte-preprocess": {

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
@@ -77,7 +77,6 @@
     "prettier-plugin-tailwindcss": "^0.5.6",
     "svelte": "^4.1.2",
     "svelte-check": "^3.5.2",
-    "svelte-inview": "^4.0.1",
     "tailwindcss": "3.3.3",
     "three": "0.159.0",
     "three-inspect": "0.3.4",

--- a/web/frontend/src/api/navigation.ts
+++ b/web/frontend/src/api/navigation.ts
@@ -2,7 +2,7 @@
 
 import * as THREE from 'three';
 import {
-  NavigationClient,
+  type GeoObstacle,
   type Path as SDKPath,
   type Waypoint,
 } from '@viamrobotics/sdk';
@@ -23,8 +23,8 @@ const STATIC_OBSTACLE_COLOR = theme.extend.colors.cyberpunk;
 const TRANSIENT_OBSTACLE_LABEL = 'transient';
 const TRANSIENT_OBSTACLE_COLOR = theme.extend.colors.hologram;
 
-/** Transient obstacles will contain this string in the geometry's label. */
-const TRANSIENT_LABEL_SEARCH = 'transientObstacle';
+/** Transient obstacles will start with this string in the geometry's label. */
+const TRANSIENT_LABEL_SEARCH = 'transient';
 
 export const formatWaypoints = (list: Waypoint[]) => {
   return list.map((item) => {
@@ -37,11 +37,7 @@ export const formatWaypoints = (list: Waypoint[]) => {
   });
 };
 
-export const getObstacles = async (
-  navClient: NavigationClient
-): Promise<Obstacle[]> => {
-  const list = await navClient.getObstacles();
-
+export const formatObstacles = (list: GeoObstacle[]): Obstacle[] => {
   return list.map((obstacle, index) => {
     const { location } = obstacle;
 
@@ -62,7 +58,7 @@ export const getObstacles = async (
       name = geo.label;
     }
 
-    const isTransient = geo?.label.includes(TRANSIENT_LABEL_SEARCH);
+    const isTransient = geo?.label.startsWith(TRANSIENT_LABEL_SEARCH);
     const label = isTransient
       ? TRANSIENT_OBSTACLE_LABEL
       : STATIC_OBSTACLE_LABEL;

--- a/web/frontend/src/components/navigation/hooks/use-obstacles.ts
+++ b/web/frontend/src/components/navigation/hooks/use-obstacles.ts
@@ -1,0 +1,30 @@
+import { formatObstacles } from '@/api/navigation';
+import { type ServiceError } from '@viamrobotics/sdk';
+import type { Obstacle } from '@viamrobotics/prime-blocks';
+import { writable } from 'svelte/store';
+import { useDisconnect } from '@/hooks/robot-client';
+import { setAsyncInterval } from '@/lib/schedule';
+import { useNavClient } from './use-nav-client';
+
+export const useObstacles = (name: string) => {
+  const navClient = useNavClient(name);
+  const obstacles = writable<Obstacle[]>([]);
+  const error = writable<ServiceError | undefined>(undefined);
+
+  const updateObstacles = async () => {
+    try {
+      const response = await navClient.getObstacles();
+      error.set(undefined);
+      obstacles.set(formatObstacles(response));
+    } catch (error_) {
+      error.set(error_ as ServiceError);
+      obstacles.set([]);
+    }
+  };
+
+  const clearUpdateObstacleInterval = setAsyncInterval(updateObstacles, 1000);
+  void updateObstacles();
+  useDisconnect(() => clearUpdateObstacleInterval());
+
+  return { obstacles, error };
+};

--- a/web/frontend/src/components/navigation/index.svelte
+++ b/web/frontend/src/components/navigation/index.svelte
@@ -6,17 +6,14 @@ import { type ServiceError, navigationApi } from '@viamrobotics/sdk';
 import { notify } from '@viamrobotics/prime';
 import { IconButton, Button, persisted } from '@viamrobotics/prime-core';
 import { NavigationMap, type LngLat } from '@viamrobotics/prime-blocks';
-import { getObstacles } from '@/api/navigation';
-import { obstacles } from './stores';
 import Collapse from '@/lib/components/collapse.svelte';
 import LngLatInput from './components/input/lnglat.svelte';
-import { inview } from 'svelte-inview';
 import Waypoints from './components/waypoints.svelte';
 import { useWaypoints } from './hooks/use-waypoints';
 import { useNavMode } from './hooks/use-nav-mode';
-import { useNavClient } from './hooks/use-nav-client';
 import { useBasePose } from './hooks/use-base-pose';
 import type { Map } from 'maplibre-gl';
+import { useObstacles } from './hooks/use-obstacles';
 import { usePaths } from './hooks/use-paths';
 
 export let name: string;
@@ -24,10 +21,10 @@ export let name: string;
 let map: Map | undefined;
 
 const mapPosition = persisted('viam-blocks-navigation-map-center');
-const navClient = useNavClient(name);
 const { waypoints, addWaypoint, deleteWaypoint } = useWaypoints(name);
 const { mode, setMode } = useNavMode(name);
 const { pose } = useBasePose(name);
+const { obstacles } = useObstacles(name);
 const { paths } = usePaths(name);
 
 let centered = false;
@@ -36,14 +33,6 @@ $: if (map && $pose && !centered && !$mapPosition) {
   map.setCenter($pose);
   centered = true;
 }
-
-const handleEnter = async () => {
-  try {
-    $obstacles = await getObstacles(navClient);
-  } catch (error) {
-    notify.danger((error as ServiceError).message);
-  }
-};
 
 const handleModeSelect = async (
   event: CustomEvent<{ value: 'Manual' | 'Waypoint' }>
@@ -104,11 +93,7 @@ const handleDeleteWaypoint = async (event: CustomEvent<string>) => {
     Stop
   </Button>
 
-  <div
-    use:inview
-    on:inview_enter={handleEnter}
-    class="flex flex-col gap-2 border border-t-0 border-medium"
-  >
+  <div class="flex flex-col gap-2 border border-t-0 border-medium">
     <div class="flex flex-wrap items-end justify-between gap-y-2 px-4 py-3">
       <div class="flex gap-1">
         <div class="w-80">

--- a/web/frontend/src/components/navigation/stores.ts
+++ b/web/frontend/src/components/navigation/stores.ts
@@ -1,8 +1,4 @@
-import { currentWritable } from '@threlte/core';
 import { persisted } from '@viamrobotics/prime-core';
-import type { Obstacle } from '@viamrobotics/prime-blocks';
-
-export const obstacles = currentWritable<Obstacle[]>([]);
 
 /** The currently selected tab. */
 export const tab = persisted<'Obstacles' | 'Waypoints'>('cards.navigation.tab', 'Waypoints');


### PR DESCRIPTION
## Change log

- Bump `@viamrobotics/remote-control` version
- Add `useObstacles` hook to poll for obstacles (including transient ones)
    - `getObstacles` => `formatObstacles`
    - Get rid of global `obstacles` store
    - Remove dependency on `svelte-inview`
- Fix criteria for transient obstacles (label starts with `transient`)

![poll-obstacles](https://github.com/viamrobotics/rdk/assets/5910938/2a241d91-530d-47bd-8a92-51b8cba30ac9)
