### PR TITLE
RSDK-5952 - Exit server on ctx cancel even if module is stuck

### DIFF
--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -661,7 +661,7 @@ func readModels(path string, logger logging.Logger) ([]ModuleComponent, error) {
 		ExePath: path,
 	}
 
-	mgr := modmanager.NewManager(parentAddr, logger, modmanageroptions.Options{UntrustedEnv: false})
+	mgr := modmanager.NewManager(context.Background(), parentAddr, logger, modmanageroptions.Options{UntrustedEnv: false})
 	defer vutils.UncheckedErrorFunc(func() error { return mgr.Close(context.Background()) })
 
 	err = mgr.Add(context.TODO(), cfg)

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -539,12 +539,7 @@ func TestModuleReloading(t *testing.T) {
 		oueRestartInterval = 10 * time.Millisecond
 
 		// Lower module startup timeout to avoid waiting for 5 mins.
-		defer func() {
-			test.That(t, os.Unsetenv(rutils.ModuleStartupTimeoutEnvVar),
-				test.ShouldBeNil)
-		}()
-		test.That(t, os.Setenv(rutils.ModuleStartupTimeoutEnvVar, "10ms"),
-			test.ShouldBeNil)
+		t.Setenv(rutils.ModuleStartupTimeoutEnvVar, "10ms")
 
 		// This test neither uses a resource manager nor asserts anything about
 		// the existence of resources in the graph. Use a dummy
@@ -585,12 +580,7 @@ func TestModuleReloading(t *testing.T) {
 		oueRestartInterval = 10 * time.Millisecond
 
 		// Lower module startup timeout to avoid waiting for 5 mins.
-		defer func() {
-			test.That(t, os.Unsetenv(rutils.ModuleStartupTimeoutEnvVar),
-				test.ShouldBeNil)
-		}()
-		test.That(t, os.Setenv(rutils.ModuleStartupTimeoutEnvVar, "30s"),
-			test.ShouldBeNil)
+		t.Setenv(rutils.ModuleStartupTimeoutEnvVar, "30s")
 
 		// This test neither uses a resource manager nor asserts anything about
 		// the existence of resources in the graph. Use a dummy

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -50,7 +50,7 @@ func TestModManagerFunctions(t *testing.T) {
 
 	t.Log("test Helpers")
 	viamHomeTemp := t.TempDir()
-	mgr := NewManager(parentAddr, logger, modmanageroptions.Options{UntrustedEnv: false, ViamHomeDir: viamHomeTemp})
+	mgr := NewManager(ctx, parentAddr, logger, modmanageroptions.Options{UntrustedEnv: false, ViamHomeDir: viamHomeTemp})
 
 	mod := &module{
 		cfg: config.Module{
@@ -104,7 +104,7 @@ func TestModManagerFunctions(t *testing.T) {
 	test.That(t, ok, test.ShouldBeFalse)
 
 	t.Log("test AddModule")
-	mgr = NewManager(parentAddr, logger, modmanageroptions.Options{UntrustedEnv: false})
+	mgr = NewManager(ctx, parentAddr, logger, modmanageroptions.Options{UntrustedEnv: false})
 	test.That(t, err, test.ShouldBeNil)
 
 	modCfg := config.Module{
@@ -229,7 +229,7 @@ func TestModManagerFunctions(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Log("test UntrustedEnv")
-	mgr = NewManager(parentAddr, logger, modmanageroptions.Options{UntrustedEnv: true})
+	mgr = NewManager(ctx, parentAddr, logger, modmanageroptions.Options{UntrustedEnv: true})
 
 	modCfg = config.Module{
 		Name:    "simple-module",
@@ -239,7 +239,7 @@ func TestModManagerFunctions(t *testing.T) {
 	test.That(t, err, test.ShouldEqual, errModularResourcesDisabled)
 
 	t.Log("test empty dir for CleanModuleDataDirectory")
-	mgr = NewManager(parentAddr, logger, modmanageroptions.Options{UntrustedEnv: false, ViamHomeDir: ""})
+	mgr = NewManager(ctx, parentAddr, logger, modmanageroptions.Options{UntrustedEnv: false, ViamHomeDir: ""})
 	err = mgr.CleanModuleDataDirectory()
 	test.That(t, fmt.Sprint(err), test.ShouldContainSubstring, "cannot clean a root level module data directory")
 
@@ -247,7 +247,12 @@ func TestModManagerFunctions(t *testing.T) {
 	viamHomeTemp = t.TempDir()
 	robotCloudID := "a-b-c-d"
 	expectedDataDir := filepath.Join(viamHomeTemp, parentModuleDataFolderName, robotCloudID)
-	mgr = NewManager(parentAddr, logger, modmanageroptions.Options{UntrustedEnv: false, ViamHomeDir: viamHomeTemp, RobotCloudID: robotCloudID})
+	mgr = NewManager(
+		ctx,
+		parentAddr,
+		logger,
+		modmanageroptions.Options{UntrustedEnv: false, ViamHomeDir: viamHomeTemp, RobotCloudID: robotCloudID},
+	)
 	// check that premature clean is okay
 	err = mgr.CleanModuleDataDirectory()
 	test.That(t, err, test.ShouldBeNil)
@@ -319,7 +324,7 @@ func TestModManagerValidation(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Log("adding complex module")
-	mgr := NewManager(parentAddr, logger, modmanageroptions.Options{UntrustedEnv: false})
+	mgr := NewManager(ctx, parentAddr, logger, modmanageroptions.Options{UntrustedEnv: false})
 
 	modCfg := config.Module{
 		Name:    "complex-module",
@@ -390,7 +395,7 @@ func TestModuleReloading(t *testing.T) {
 		dummyRemoveOrphanedResources := func(context.Context, []resource.Name) {
 			dummyRemoveOrphanedResourcesCallCount.Add(1)
 		}
-		mgr := NewManager(parentAddr, logger, modmanageroptions.Options{
+		mgr := NewManager(ctx, parentAddr, logger, modmanageroptions.Options{
 			UntrustedEnv:            false,
 			RemoveOrphanedResources: dummyRemoveOrphanedResources,
 		})
@@ -464,7 +469,7 @@ func TestModuleReloading(t *testing.T) {
 		dummyRemoveOrphanedResources := func(context.Context, []resource.Name) {
 			dummyRemoveOrphanedResourcesCallCount.Add(1)
 		}
-		mgr := NewManager(parentAddr, logger, modmanageroptions.Options{
+		mgr := NewManager(ctx, parentAddr, logger, modmanageroptions.Options{
 			UntrustedEnv:            false,
 			RemoveOrphanedResources: dummyRemoveOrphanedResources,
 		})
@@ -546,7 +551,7 @@ func TestModuleReloading(t *testing.T) {
 		// RemoveOrphanedResources function so orphaned resource logic does not
 		// panic.
 		dummyRemoveOrphanedResources := func(context.Context, []resource.Name) {}
-		mgr := NewManager(parentAddr, logger, modmanageroptions.Options{
+		mgr := NewManager(ctx, parentAddr, logger, modmanageroptions.Options{
 			UntrustedEnv:            false,
 			RemoveOrphanedResources: dummyRemoveOrphanedResources,
 		})
@@ -554,6 +559,53 @@ func TestModuleReloading(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring,
 			"module test-module timed out after 10ms during startup")
+
+		// Assert that number of "fakemodule is running" messages does not increase
+		// over time (the process was stopped).
+		msgNum := logs.FilterMessageSnippet("fakemodule is running").Len()
+		time.Sleep(100 * time.Millisecond)
+		test.That(t, logs.FilterMessageSnippet("fakemodule is running").Len(), test.ShouldEqual, msgNum)
+
+		// Assert that manager removes module.
+		test.That(t, len(mgr.Configs()), test.ShouldEqual, 0)
+
+		err = mgr.Close(ctx)
+		test.That(t, err, test.ShouldBeNil)
+	})
+
+	t.Run("cancelled module process is stopped", func(t *testing.T) {
+		logger, logs := logging.NewObservedTestLogger(t)
+
+		modCfg.ExePath = rutils.ResolveFile("module/testmodule/fakemodule.sh")
+
+		// Lower global timeout early to avoid race with actual restart code.
+		defer func(oriOrigVal time.Duration) {
+			oueRestartInterval = oriOrigVal
+		}(oueRestartInterval)
+		oueRestartInterval = 10 * time.Millisecond
+
+		// Lower module startup timeout to avoid waiting for 5 mins.
+		defer func() {
+			test.That(t, os.Unsetenv(rutils.ModuleStartupTimeoutEnvVar),
+				test.ShouldBeNil)
+		}()
+		test.That(t, os.Setenv(rutils.ModuleStartupTimeoutEnvVar, "30s"),
+			test.ShouldBeNil)
+
+		// This test neither uses a resource manager nor asserts anything about
+		// the existence of resources in the graph. Use a dummy
+		// RemoveOrphanedResources function so orphaned resource logic does not
+		// panic.
+		ctx, cancel := context.WithCancel(ctx)
+		cancel()
+		dummyRemoveOrphanedResources := func(context.Context, []resource.Name) {}
+		mgr := NewManager(ctx, parentAddr, logger, modmanageroptions.Options{
+			UntrustedEnv:            false,
+			RemoveOrphanedResources: dummyRemoveOrphanedResources,
+		})
+		err = mgr.Add(ctx, modCfg)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "context canceled")
 
 		// Assert that number of "fakemodule is running" messages does not increase
 		// over time (the process was stopped).
@@ -632,7 +684,7 @@ func TestDebugModule(t *testing.T) {
 			} else {
 				logger, logs = rtestutils.NewInfoObservedTestLogger(t)
 			}
-			mgr := NewManager(parentAddr, logger, modmanageroptions.Options{UntrustedEnv: false})
+			mgr := NewManager(ctx, parentAddr, logger, modmanageroptions.Options{UntrustedEnv: false})
 			defer mgr.Close(ctx)
 
 			modCfg := config.Module{
@@ -688,7 +740,7 @@ func TestModuleMisc(t *testing.T) {
 
 	t.Run("data directory fullstack", func(t *testing.T) {
 		logger, logs := logging.NewObservedTestLogger(t)
-		mgr := NewManager(parentAddr, logger, modmanageroptions.Options{
+		mgr := NewManager(ctx, parentAddr, logger, modmanageroptions.Options{
 			UntrustedEnv: false,
 			ViamHomeDir:  testViamHomeDir,
 		})
@@ -740,7 +792,7 @@ func TestModuleMisc(t *testing.T) {
 	})
 	t.Run("module working directory", func(t *testing.T) {
 		logger := logging.NewTestLogger(t)
-		mgr := NewManager(parentAddr, logger, modmanageroptions.Options{
+		mgr := NewManager(ctx, parentAddr, logger, modmanageroptions.Options{
 			UntrustedEnv: false,
 			ViamHomeDir:  testViamHomeDir,
 		})
@@ -778,7 +830,7 @@ func TestModuleMisc(t *testing.T) {
 	})
 	t.Run("module working directory fallback", func(t *testing.T) {
 		logger := logging.NewTestLogger(t)
-		mgr := NewManager(parentAddr, logger, modmanageroptions.Options{
+		mgr := NewManager(ctx, parentAddr, logger, modmanageroptions.Options{
 			UntrustedEnv: false,
 			ViamHomeDir:  testViamHomeDir,
 		})

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -454,7 +454,15 @@ func newWithResources(
 		cloudID = cfg.Cloud.ID
 	}
 	// Once web service is started, start module manager
-	r.manager.startModuleManager(r.webSvc.ModuleAddress(), r.removeOrphanedResources, cfg.UntrustedEnv, config.ViamDotDir, cloudID, logger)
+	r.manager.startModuleManager(
+		closeCtx,
+		r.webSvc.ModuleAddress(),
+		r.removeOrphanedResources,
+		cfg.UntrustedEnv,
+		config.ViamDotDir,
+		cloudID,
+		logger,
+	)
 
 	r.activeBackgroundWorkers.Add(1)
 	r.configTicker = time.NewTicker(5 * time.Second)

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -89,6 +89,7 @@ func fromRemoteNameToRemoteNodeName(name string) resource.Name {
 }
 
 func (manager *resourceManager) startModuleManager(
+	ctx context.Context,
 	parentAddr string,
 	removeOrphanedResources func(context.Context, []resource.Name),
 	untrustedEnv bool,
@@ -102,7 +103,7 @@ func (manager *resourceManager) startModuleManager(
 		ViamHomeDir:             viamHomeDir,
 		RobotCloudID:            robotCloudID,
 	}
-	manager.moduleManager = modmanager.NewManager(parentAddr, logger, mmOpts)
+	manager.moduleManager = modmanager.NewManager(ctx, parentAddr, logger, mmOpts)
 }
 
 // addRemote adds a remote to the manager.

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -1851,7 +1851,7 @@ func managerForDummyRobot(robot robot.Robot) *resourceManager {
 
 	// start a dummy module manager so calls to moduleManager.Provides() do not
 	// panic.
-	manager.startModuleManager("", nil, false, "", "", robot.Logger())
+	manager.startModuleManager(context.Background(), "", nil, false, "", "", robot.Logger())
 
 	for _, name := range robot.ResourceNames() {
 		res, err := robot.ResourceByName(name)


### PR DESCRIPTION
@benjirewis - Feels like we should be able to do this without much issue, though I'm not sure if there was a reason why we didn't do this before.

The behavior before was that if you startup the server and realize that the module is broken, ctrl+c ing the server will only exit the server after 90s no matter what. now you can ctrl+c and the server will exit.

However, if you don't ctrl+c the server, the next bit of configuration (next module, starting the webserver) will only start after the startup timeout (5mins). Added another ticket to exit the loop early if the process is not in recovery or running (RSDK-6030).