### PR TITLE
RSDK-6027 - Add wait functionality to cli logs + allow for platform omission

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -1161,9 +1161,12 @@ Example:
 									Required: true,
 								},
 								&cli.StringFlag{
-									Name:     moduleBuildFlagPlatform,
-									Usage:    "build platform to get the logs for. Ex: linux/arm64",
-									Required: true,
+									Name:  moduleBuildFlagPlatform,
+									Usage: "build platform to get the logs for. Ex: linux/arm64. If a platform is not provided, it returns logs for all platforms",
+								},
+								&cli.BoolFlag{
+									Name:  moduleBuildFlagWait,
+									Usage: "wait for the build to finish before outputting any logs",
 								},
 							},
 							Action: ModuleBuildLogsAction,

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -289,7 +289,7 @@ func (c *viamClient) waitForBuildToFinish(buildID, platform string) error {
 				return errors.Wrap(err, "failed to list module build jobs")
 			}
 			if len(jobsResponse.Jobs) == 0 {
-				return fmt.Errorf("build id %q it returned no jobs", buildID)
+				return fmt.Errorf("build id %q returned no jobs", buildID)
 			}
 			// Loop through all the jobs and check if all the matching jobs are done
 			allDone := true

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -494,9 +494,6 @@ func parseModuleID(id string) (moduleID, error) {
 }
 
 func (m *moduleID) String() string {
-	if m.prefix == "" {
-		return m.name
-	}
 	return fmt.Sprintf("%s:%s", m.prefix, m.name)
 }
 


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-6027

Allows for:
 `viam module build logs --id xyz123 --wait` => wait for all platforms to build and then print all logs
`viam module build logs --id xyz123 --platform linux/amd64 (--wait / no wait)` => wait for and print just the logs for that platform
`viam module build list --id xyz123` => can now be run outside of the dir with the meta.json (because it doesn't need it)