### PR TITLE
RSDK-4813 - Evict plan execution information older than TTL 

### DIFF
--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -29,7 +29,7 @@ import (
 
 var (
 	stateTTL              = time.Hour * 24
-	stateTTLCheckInterval = time.Second
+	stateTTLCheckInterval = time.Minute
 )
 
 func init() {
@@ -141,11 +141,7 @@ func (ms *builtIn) Reconfigure(
 		ms.state.Stop()
 	}
 
-	state, err := state.NewState(state.Request{
-		TTL:              stateTTL,
-		TTLCheckInterval: stateTTLCheckInterval,
-		Logger:           ms.logger,
-	})
+	state, err := state.NewState(stateTTL, stateTTLCheckInterval, ms.logger)
 	if err != nil {
 		return err
 	}

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/golang/geo/r3"
 	"github.com/google/uuid"
@@ -25,6 +26,8 @@ import (
 	"go.viam.com/rdk/spatialmath"
 	rdkutils "go.viam.com/rdk/utils"
 )
+
+var stateTTL = time.Hour * 24
 
 func init() {
 	resource.RegisterDefaultService(
@@ -134,7 +137,7 @@ func (ms *builtIn) Reconfigure(
 	if ms.state != nil {
 		ms.state.Stop()
 	}
-	ms.state = state.NewState(context.Background(), ms.logger)
+	ms.state = state.NewState(context.Background(), stateTTL, ms.logger)
 	return nil
 }
 

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -27,7 +27,10 @@ import (
 	rdkutils "go.viam.com/rdk/utils"
 )
 
-var stateTTL = time.Hour * 24
+var (
+	stateTTL              = time.Hour * 24
+	stateTTLCheckInterval = time.Second
+)
 
 func init() {
 	resource.RegisterDefaultService(
@@ -137,7 +140,16 @@ func (ms *builtIn) Reconfigure(
 	if ms.state != nil {
 		ms.state.Stop()
 	}
-	ms.state = state.NewState(context.Background(), stateTTL, ms.logger)
+
+	state, err := state.NewState(state.Request{
+		TTL:              stateTTL,
+		TTLCheckInterval: stateTTLCheckInterval,
+		Logger:           ms.logger,
+	})
+	if err != nil {
+		return err
+	}
+	ms.state = state
 	return nil
 }
 

--- a/services/motion/builtin/state/state.go
+++ b/services/motion/builtin/state/state.go
@@ -5,7 +5,6 @@ package state
 import (
 	"context"
 	"fmt"
-	"sort"
 	"sync"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"go.viam.com/utils"
 	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/motionplan"
@@ -487,8 +487,8 @@ func (s *State) ListPlanStatuses(req motion.ListPlanStatusesReq) ([]motion.PlanS
 
 	statuses := []motion.PlanStatusWithID{}
 	componentNames := maps.Keys(s.componentStateByComponent)
-	sort.Slice(componentNames, func(a, b int) bool {
-		return componentNames[a].String() < componentNames[b].String()
+	slices.SortFunc(componentNames, func(a, b resource.Name) bool {
+		return a.String() < b.String()
 	})
 
 	if req.OnlyActivePlans {

--- a/services/motion/builtin/state/state.go
+++ b/services/motion/builtin/state/state.go
@@ -393,8 +393,6 @@ func StartExecution[R any](
 		return uuid.Nil, err
 	}
 
-	// If the background goroutine hasn't been booted yet, boot it now
-
 	return e.id, nil
 }
 

--- a/services/motion/builtin/state/state.go
+++ b/services/motion/builtin/state/state.go
@@ -323,11 +323,18 @@ func NewState(ctx context.Context, ttl time.Duration, logger logging.Logger) *St
 			}
 			select {
 			case <-cancelCtx.Done():
+				return
 			case <-ticker.C:
+				s.purgeOlderThanTTL()
 			}
 		}
 	}, s.waitGroup.Done)
 	return &s
+}
+
+func (s *State) purgeOlderThanTTL() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 }
 
 // StartExecution creates a new execution from a state.

--- a/services/motion/builtin/state/state.go
+++ b/services/motion/builtin/state/state.go
@@ -294,19 +294,21 @@ type State struct {
 	cancelCtx  context.Context
 	cancelFunc context.CancelFunc
 	logger     logging.Logger
+	ttl        time.Duration
 	// mu protects the componentStateByComponent
 	mu                        sync.RWMutex
 	componentStateByComponent map[resource.Name]componentState
 }
 
 // NewState creates a new state.
-func NewState(ctx context.Context, logger logging.Logger) *State {
+func NewState(ctx context.Context, ttl time.Duration, logger logging.Logger) *State {
 	cancelCtx, cancelFunc := context.WithCancel(ctx)
 	s := State{
 		cancelCtx:                 cancelCtx,
 		cancelFunc:                cancelFunc,
 		waitGroup:                 &sync.WaitGroup{},
 		componentStateByComponent: make(map[resource.Name]componentState),
+		ttl:                       ttl,
 		logger:                    logger,
 	}
 	return &s

--- a/services/motion/builtin/state/state_test.go
+++ b/services/motion/builtin/state/state_test.go
@@ -918,7 +918,7 @@ func TestState(t *testing.T) {
 		//// Previous plan is moved to higher index
 		// test.That(t, resPWS.pws[1].Plan, test.ShouldResemble, pws4[0].Plan)
 		//// Current plan is a new plan
-		//test.That(t, resPWS.pws[0].Plan.ID, test.ShouldNotResemble, pws4[0].Plan.ID)
+		// test.That(t, resPWS.pws[0].Plan.ID, test.ShouldNotResemble, pws4[0].Plan.ID)
 		//// From the same execution (definition of a replan)
 		//test.That(t, resPWS.pws[0].Plan.ExecutionID, test.ShouldResemble, pws4[0].Plan.ExecutionID)
 		//// new current plan has an in progress status & was created after triggering replanning
@@ -971,7 +971,7 @@ func TestState(t *testing.T) {
 		// })
 		////
 		// test.That(t, succ, test.ShouldBeTrue)
-		//test.That(t, resPWS2.err, test.ShouldBeNil)
+		// test.That(t, resPWS2.err, test.ShouldBeNil)
 		//test.That(t, len(resPWS2.pws), test.ShouldEqual, 2)
 		//// last plan is unchanged
 		//test.That(t, resPWS2.pws[1], test.ShouldResemble, resPWS.pws[1])
@@ -991,7 +991,7 @@ func TestState(t *testing.T) {
 		// test.That(t, err, test.ShouldBeNil)
 		// postStopPWS1, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase})
 		// test.That(t, err, test.ShouldBeNil)
-		//test.That(t, resPWS2.pws, test.ShouldResemble, postStopPWS1)
+		// test.That(t, resPWS2.pws, test.ShouldResemble, postStopPWS1)
 
 		//// Failed after replanning
 		// preExecution3 := time.Now()
@@ -1030,7 +1030,7 @@ func TestState(t *testing.T) {
 		//			return state.ExecuteResponse{}, nil
 		//		},
 		//	}, nil
-		//})
+		// })
 		//test.That(t, err, test.ShouldBeNil)
 		//test.That(t, executionID2, test.ShouldNotResemble, executionID1)
 
@@ -1051,7 +1051,7 @@ func TestState(t *testing.T) {
 		// test.That(t, len(resPWS3.pws), test.ShouldEqual, 2)
 
 		// test.That(t, resPWS3.pws[0].Plan.ID, test.ShouldNotEqual, resPWS2.pws[1].Plan.ID)
-		//test.That(t, len(resPWS3.pws[1].StatusHistory), test.ShouldEqual, 2)
+
 		//test.That(t, resPWS3.pws[1].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateFailed)
 		//test.That(t, *resPWS3.pws[1].StatusHistory[0].Reason, test.ShouldResemble, replanReason)
 		//test.That(t, resPWS3.pws[1].StatusHistory[1].State, test.ShouldEqual, motion.PlanStateInProgress)
@@ -1072,7 +1072,7 @@ func TestState(t *testing.T) {
 		// test.That(t, err, test.ShouldBeNil)
 		// postStopPWS2, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase})
 		// test.That(t, err, test.ShouldBeNil)
-		//test.That(t, resPWS3.pws, test.ShouldResemble, postStopPWS2)
+		// test.That(t, resPWS3.pws, test.ShouldResemble, postStopPWS2)
 
 		//// Failed at the end of execution
 		// preExecution4 := time.Now()
@@ -1091,7 +1091,7 @@ func TestState(t *testing.T) {
 		//			return state.ExecuteResponse{}, executionFailReason
 		//		},
 		//	}, nil
-		//})
+		// })
 		//test.That(t, err, test.ShouldBeNil)
 
 		// resPWS4, succ := pollUntil(cancelCtx, func() (pwsRes, bool,
@@ -1111,7 +1111,7 @@ func TestState(t *testing.T) {
 		// test.That(t, len(resPWS4.pws), test.ShouldEqual, 2)
 
 		// test.That(t, resPWS4.pws[0].Plan.ID, test.ShouldNotEqual, resPWS3.pws[1].Plan.ID)
-		//test.That(t, len(resPWS4.pws[1].StatusHistory), test.ShouldEqual, 2)
+
 		//test.That(t, resPWS4.pws[1].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateFailed)
 		//test.That(t, *resPWS4.pws[1].StatusHistory[0].Reason, test.ShouldResemble, replanReason)
 		//test.That(t, resPWS4.pws[1].StatusHistory[1].State, test.ShouldEqual, motion.PlanStateInProgress)
@@ -1144,13 +1144,11 @@ func TestState(t *testing.T) {
 		// test.That(t, err, test.ShouldBeNil)
 		// test.That(t, len(ps7), test.ShouldEqual, 7)
 		// test.That(t, ps7[0].ComponentName, test.ShouldResemble, myBase)
-		//test.That(t, ps7[0].ExecutionID, test.ShouldResemble, executionID4)
+		// test.That(t, ps7[0].ExecutionID, test.ShouldResemble, executionID4)
 		//test.That(t, ps7[0].PlanID, test.ShouldResemble, resPWS4.pws[0].Plan.ID)
 		//test.That(t, ps7[0].Status, test.ShouldResemble, resPWS4.pws[0].StatusHistory[0])
 
 		// test.That(t, ps7[1].ExecutionID, test.ShouldResemble, executionID4)
-
-
 
 		// test.That(t, ps7[2].ComponentName, test.ShouldResemble, myBase)
 

--- a/services/motion/builtin/state/state_test.go
+++ b/services/motion/builtin/state/state_test.go
@@ -19,7 +19,10 @@ import (
 	"go.viam.com/rdk/spatialmath"
 )
 
-var replanReason = "replan triggered due to location drift"
+var (
+	replanReason = "replan triggered due to location drift"
+	ttl          = time.Hour * 24
+)
 
 // testPlannerExecutor is a mock PlannerExecutor implementation.
 type testPlannerExecutor struct {
@@ -165,13 +168,13 @@ func TestState(t *testing.T) {
 
 	t.Run("creating & stopping a state with no intermediary calls", func(t *testing.T) {
 		t.Parallel()
-		s := state.NewState(ctx, logger)
+		s := state.NewState(ctx, ttl, logger)
 		defer s.Stop()
 	})
 
 	t.Run("starting a new execution & stopping the state", func(t *testing.T) {
 		t.Parallel()
-		s := state.NewState(ctx, logger)
+		s := state.NewState(ctx, ttl, logger)
 		defer s.Stop()
 		_, err := state.StartExecution(ctx, s, emptyReq.ComponentName, emptyReq, successPlanConstructor)
 		test.That(t, err, test.ShouldBeNil)
@@ -179,7 +182,7 @@ func TestState(t *testing.T) {
 
 	t.Run("starting & stopping an execution & stopping the state", func(t *testing.T) {
 		t.Parallel()
-		s := state.NewState(ctx, logger)
+		s := state.NewState(ctx, ttl, logger)
 		defer s.Stop()
 
 		_, err := state.StartExecution(ctx, s, emptyReq.ComponentName, emptyReq, executionWaitingForCtxCancelledPlanConstructor)
@@ -221,7 +224,7 @@ func TestState(t *testing.T) {
 
 	t.Run("stopping an execution is idempotnet", func(t *testing.T) {
 		t.Parallel()
-		s := state.NewState(ctx, logger)
+		s := state.NewState(ctx, ttl, logger)
 		defer s.Stop()
 		req := motion.MoveOnGlobeReq{ComponentName: myBase}
 		_, err := state.StartExecution(ctx, s, req.ComponentName, req, executionWaitingForCtxCancelledPlanConstructor)
@@ -235,7 +238,7 @@ func TestState(t *testing.T) {
 
 	t.Run("stopping the state is idempotnet", func(t *testing.T) {
 		t.Parallel()
-		s := state.NewState(ctx, logger)
+		s := state.NewState(ctx, ttl, logger)
 		defer s.Stop()
 		req := motion.MoveOnGlobeReq{ComponentName: myBase}
 		_, err := state.StartExecution(ctx, s, req.ComponentName, req, executionWaitingForCtxCancelledPlanConstructor)
@@ -247,7 +250,7 @@ func TestState(t *testing.T) {
 
 	t.Run("stopping an execution after stopping the state", func(t *testing.T) {
 		t.Parallel()
-		s := state.NewState(ctx, logger)
+		s := state.NewState(ctx, ttl, logger)
 		defer s.Stop()
 		req := motion.MoveOnGlobeReq{ComponentName: myBase}
 		_, err := state.StartExecution(ctx, s, req.ComponentName, req, executionWaitingForCtxCancelledPlanConstructor)
@@ -261,7 +264,7 @@ func TestState(t *testing.T) {
 
 	t.Run("querying for an unknown resource returns an unknown resource error", func(t *testing.T) {
 		t.Parallel()
-		s := state.NewState(ctx, logger)
+		s := state.NewState(ctx, ttl, logger)
 		defer s.Stop()
 		req := motion.MoveOnGlobeReq{ComponentName: myBase}
 		_, err := state.StartExecution(ctx, s, req.ComponentName, req, executionWaitingForCtxCancelledPlanConstructor)
@@ -273,7 +276,7 @@ func TestState(t *testing.T) {
 
 	t.Run("end to end test", func(t *testing.T) {
 		t.Parallel()
-		s := state.NewState(ctx, logger)
+		s := state.NewState(ctx, ttl, logger)
 		defer s.Stop()
 
 		// no plan statuses as no executions have been created

--- a/services/motion/builtin/state/state_test.go
+++ b/services/motion/builtin/state/state_test.go
@@ -916,7 +916,7 @@ func TestState(t *testing.T) {
 		// test.That(t, resPWS.err, test.ShouldBeNil)
 		// test.That(t, len(resPWS.pws), test.ShouldEqual, 2)
 		//// Previous plan is moved to higher index
-		//test.That(t, resPWS.pws[1].Plan, test.ShouldResemble, pws4[0].Plan)
+		// test.That(t, resPWS.pws[1].Plan, test.ShouldResemble, pws4[0].Plan)
 		//// Current plan is a new plan
 		//test.That(t, resPWS.pws[0].Plan.ID, test.ShouldNotResemble, pws4[0].Plan.ID)
 		//// From the same execution (definition of a replan)
@@ -942,7 +942,7 @@ func TestState(t *testing.T) {
 		// pws6, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase, LastPlanOnly: true})
 		// test.That(t, err, test.ShouldBeNil)
 		// test.That(t, len(pws6), test.ShouldEqual, 1)
-		//test.That(t, pws6[0], test.ShouldResemble, resPWS.pws[0])
+		// test.That(t, pws6[0], test.ShouldResemble, resPWS.pws[0])
 
 		//// only the last plan is returned if LastPlanOnly is true
 		//// and the execution id is provided which matches the last execution for the component
@@ -952,7 +952,7 @@ func TestState(t *testing.T) {
 		//	ExecutionID:   pws6[0].Plan.ExecutionID,
 		// })
 		// test.That(t, err, test.ShouldBeNil)
-		//test.That(t, pws7, test.ShouldResemble, pws6)
+		// test.That(t, pws7, test.ShouldResemble, pws6)
 
 		//// Succeeded status
 		// preSuccessMsg := time.Now()
@@ -970,7 +970,7 @@ func TestState(t *testing.T) {
 		//	return st, false
 		// })
 		////
-		//test.That(t, succ, test.ShouldBeTrue)
+		// test.That(t, succ, test.ShouldBeTrue)
 		//test.That(t, resPWS2.err, test.ShouldBeNil)
 		//test.That(t, len(resPWS2.pws), test.ShouldEqual, 2)
 		//// last plan is unchanged
@@ -990,7 +990,7 @@ func TestState(t *testing.T) {
 		// err = s.StopExecutionByResource(myBase)
 		// test.That(t, err, test.ShouldBeNil)
 		// postStopPWS1, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase})
-		//test.That(t, err, test.ShouldBeNil)
+		// test.That(t, err, test.ShouldBeNil)
 		//test.That(t, resPWS2.pws, test.ShouldResemble, postStopPWS1)
 
 		//// Failed after replanning
@@ -1001,7 +1001,7 @@ func TestState(t *testing.T) {
 		//	req motion.MoveOnGlobeReq,
 		//	seedPlan motionplan.Plan,
 		//	replanCount int,
-		//) (state.PlannerExecutor, error) {
+		// ) (state.PlannerExecutor, error) {
 		//	return &testPlannerExecutor{
 		//		planFunc: func(ctx context.Context) (state.PlanResponse, error) {
 		//			// first plan succeeds
@@ -1050,8 +1050,7 @@ func TestState(t *testing.T) {
 
 		// test.That(t, len(resPWS3.pws), test.ShouldEqual, 2)
 
-
-		//test.That(t, resPWS3.pws[0].Plan.ID, test.ShouldNotEqual, resPWS2.pws[1].Plan.ID)
+		// test.That(t, resPWS3.pws[0].Plan.ID, test.ShouldNotEqual, resPWS2.pws[1].Plan.ID)
 		//test.That(t, len(resPWS3.pws[1].StatusHistory), test.ShouldEqual, 2)
 		//test.That(t, resPWS3.pws[1].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateFailed)
 		//test.That(t, *resPWS3.pws[1].StatusHistory[0].Reason, test.ShouldResemble, replanReason)
@@ -1072,7 +1071,7 @@ func TestState(t *testing.T) {
 		// err = s.StopExecutionByResource(myBase)
 		// test.That(t, err, test.ShouldBeNil)
 		// postStopPWS2, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase})
-		//test.That(t, err, test.ShouldBeNil)
+		// test.That(t, err, test.ShouldBeNil)
 		//test.That(t, resPWS3.pws, test.ShouldResemble, postStopPWS2)
 
 		//// Failed at the end of execution
@@ -1083,7 +1082,7 @@ func TestState(t *testing.T) {
 		//	req motion.MoveOnGlobeReq,
 		//	seedPlan motionplan.Plan,
 		//	replanCount int,
-		//) (state.PlannerExecutor, error) {
+		// ) (state.PlannerExecutor, error) {
 		//	return &testPlannerExecutor{
 		//		executeFunc: func(ctx context.Context, wp state.Waypoints) (state.ExecuteResponse, error) {
 		//			if replanCount == 0 {
@@ -1111,8 +1110,7 @@ func TestState(t *testing.T) {
 
 		// test.That(t, len(resPWS4.pws), test.ShouldEqual, 2)
 
-
-		//test.That(t, resPWS4.pws[0].Plan.ID, test.ShouldNotEqual, resPWS3.pws[1].Plan.ID)
+		// test.That(t, resPWS4.pws[0].Plan.ID, test.ShouldNotEqual, resPWS3.pws[1].Plan.ID)
 		//test.That(t, len(resPWS4.pws[1].StatusHistory), test.ShouldEqual, 2)
 		//test.That(t, resPWS4.pws[1].StatusHistory[0].State, test.ShouldEqual, motion.PlanStateFailed)
 		//test.That(t, *resPWS4.pws[1].StatusHistory[0].Reason, test.ShouldResemble, replanReason)
@@ -1134,7 +1132,7 @@ func TestState(t *testing.T) {
 		// pws13, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase, ExecutionID: executionID3, LastPlanOnly: true})
 		// test.That(t, err, test.ShouldBeNil)
 		// test.That(t, len(pws13), test.ShouldEqual, 1)
-		//test.That(t, pws13[0], test.ShouldResemble, resPWS3.pws[0])
+		// test.That(t, pws13[0], test.ShouldResemble, resPWS3.pws[0])
 
 		//// providing an executionID which is not known to the state returns an error
 		// pws14, err := s.PlanHistory(motion.PlanHistoryReq{ComponentName: myBase, ExecutionID: uuid.New()})
@@ -1145,43 +1143,36 @@ func TestState(t *testing.T) {
 		// ps7, err := s.ListPlanStatuses(motion.ListPlanStatusesReq{})
 		// test.That(t, err, test.ShouldBeNil)
 		// test.That(t, len(ps7), test.ShouldEqual, 7)
-		//test.That(t, ps7[0].ComponentName, test.ShouldResemble, myBase)
+		// test.That(t, ps7[0].ComponentName, test.ShouldResemble, myBase)
 		//test.That(t, ps7[0].ExecutionID, test.ShouldResemble, executionID4)
 		//test.That(t, ps7[0].PlanID, test.ShouldResemble, resPWS4.pws[0].Plan.ID)
 		//test.That(t, ps7[0].Status, test.ShouldResemble, resPWS4.pws[0].StatusHistory[0])
 
 		// test.That(t, ps7[1].ExecutionID, test.ShouldResemble, executionID4)
 
-		//test.That(t, ps7[1].Status, test.ShouldResemble, resPWS4.pws[1].StatusHistory[0])
+
 
 		// test.That(t, ps7[2].ComponentName, test.ShouldResemble, myBase)
 
-
-		//test.That(t, ps7[2].Status, test.ShouldResemble, resPWS3.pws[0].StatusHistory[0])
+		// test.That(t, ps7[2].Status, test.ShouldResemble, resPWS3.pws[0].StatusHistory[0])
 
 		// test.That(t, ps7[3].ComponentName, test.ShouldResemble, myBase)
 
-
-		//test.That(t, ps7[3].Status, test.ShouldResemble, resPWS3.pws[1].StatusHistory[0])
+		// test.That(t, ps7[3].Status, test.ShouldResemble, resPWS3.pws[1].StatusHistory[0])
 
 		// test.That(t, ps7[4].ComponentName, test.ShouldResemble, myBase)
 
-
-		//test.That(t, ps7[4].Status, test.ShouldResemble, resPWS2.pws[0].StatusHistory[0])
+		// test.That(t, ps7[4].Status, test.ShouldResemble, resPWS2.pws[0].StatusHistory[0])
 
 		// test.That(t, ps7[5].ComponentName, test.ShouldResemble, myBase)
 
-
-		//test.That(t, ps7[5].Status, test.ShouldResemble, resPWS2.pws[1].StatusHistory[0])
+		// test.That(t, ps7[5].Status, test.ShouldResemble, resPWS2.pws[1].StatusHistory[0])
 
 		// test.That(t, ps7[6].ComponentName, test.ShouldResemble, myBase)
 
-
-		//test.That(t, ps7[6].Status, test.ShouldResemble, pws2[0].StatusHistory[0])
+		// test.That(t, ps7[6].Status, test.ShouldResemble, pws2[0].StatusHistory[0])
 
 		// ps8, err := s.ListPlanStatuses(motion.ListPlanStatusesReq{OnlyActivePlans: true})
-
-
 	})
 }
 


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-4813)


Manually using the following script:
```go
package main

import (
	"context"
	"fmt"
	"log"
	"time"

	"go.viam.com/rdk/logging"
	"go.viam.com/rdk/robot/client"
	"go.viam.com/rdk/services/motion"
	"go.viam.com/utils/rpc"
)

func main() {
	logger := logging.NewLogger("client")
	robot, err := client.New(
		context.Background(),
		"HOST",
		logger,
		client.WithDialOptions(rpc.WithEntityCredentials(
			"KEY",
			rpc.Credentials{
				Type:    rpc.CredentialsTypeAPIKey,
				Payload: "SECRET",
			})),
	)
	if err != nil {
		logger.Fatal(err)
	}

	defer robot.Close(context.Background())
	ms, err := motion.FromRobot(robot, "builtin")
	if err != nil {
		logger.Error(err)
		return
	}
	for {
		ctx, cancelFn := context.WithTimeout(context.Background(), time.Second*5)
		res, err := ms.ListPlanStatuses(ctx, motion.ListPlanStatusesReq{})
		if err != nil {
			cancelFn()
			log.Fatal(err.Error())
		}
		cancelFn()
		for _, r := range res {
			fmt.Printf("%v\n", r)
		}
		fmt.Println()
		time.Sleep(time.Second)
	}
}
```