### PR TITLE
RSDK-5933 Implement dual-gps-rtk movementsensor model

### DIFF
--- a/components/movementsensor/dualgps/dualgps.go
+++ b/components/movementsensor/dualgps/dualgps.go
@@ -21,7 +21,7 @@ import (
 // the default offset between the two gps devices describes a setup where
 // one gps is mounted on the right side of the base and
 // the other gps is mounted on the left side of the base
-// works with gps-rtk modules. This driver si not guaranteed to be performant with
+// works with gps-rtk modules. This driver is not guaranteed to be performant with
 // non-rtk corrected gps modules with larger error in their position.
 //   ___________
 //  |   base    |

--- a/components/movementsensor/dualgps/dualgps.go
+++ b/components/movementsensor/dualgps/dualgps.go
@@ -178,7 +178,7 @@ func (dg *dualGPS) CompassHeading(ctx context.Context, extra map[string]interfac
 		return math.NaN(), err
 	}
 
-	_, heading, _ := getHeading(geoPoint1, geoPoint2, 0)
+	_, heading, _ := getHeading(geoPoint1, geoPoint2, dg.offset)
 	return heading, nil
 }
 

--- a/components/movementsensor/dualgps/dualgps.go
+++ b/components/movementsensor/dualgps/dualgps.go
@@ -54,14 +54,13 @@ func (c *Config) Validate(path string) ([]string, error) {
 	if c.Gps2 == "" {
 		return nil, resource.NewConfigValidationFieldRequiredError(path, "second_gps")
 	}
+	deps = append(deps, c.Gps2)
 
 	if c.Offset != nil && (*c.Offset < 0 || *c.Offset > 360) {
 		return nil, resource.NewConfigValidationError(
 			path,
 			errors.New("this driver only allows offset values from 0 to 360"))
 	}
-	deps = append(deps, c.Gps2)
-
 	return deps, nil
 }
 

--- a/components/movementsensor/dualgps/dualgps.go
+++ b/components/movementsensor/dualgps/dualgps.go
@@ -1,0 +1,226 @@
+package dualgps
+
+import (
+	"context"
+	"math"
+	"sync"
+
+	"github.com/golang/geo/r3"
+	geo "github.com/kellydunn/golang-geo"
+	"go.viam.com/rdk/components/movementsensor"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/spatialmath"
+	"go.viam.com/rdk/utils"
+)
+
+const defaultOffsetDegrees = 90.0
+
+var model = resource.DefaultModelFamily.WithModel("dual-gps")
+
+// Config is used for converting fake movementsensor attributes.
+type Config struct {
+	Gps2   string  `json:"first_gps"`
+	Gps1   string  `json:"second_gps"`
+	Offset float64 `json:"offset_degrees,omitempty"`
+}
+
+func (c *Config) Validate(path string) ([]string, error) {
+	var deps []string
+
+	if c.Gps1 == "" {
+		return nil, resource.NewConfigValidationFieldRequiredError(path, "first_gps")
+	}
+	deps = append(deps, c.Gps1)
+
+	if c.Gps2 == "" {
+		return nil, resource.NewConfigValidationFieldRequiredError(path, "second_gps")
+	}
+	deps = append(deps, c.Gps2)
+
+	return deps, nil
+}
+
+func init() {
+	resource.RegisterComponent(
+		movementsensor.API,
+		model,
+		resource.Registration[movementsensor.MovementSensor, *Config]{Constructor: newDualGPS})
+}
+
+type dualGPS struct {
+	resource.Named
+	logger logging.Logger
+	mu     sync.Mutex
+	offset float64
+
+	gps1 gpsWithLock
+	gps2 gpsWithLock
+}
+
+// newDualGPS makes a new fake movement sensor.
+func newDualGPS(ctx context.Context, deps resource.Dependencies, conf resource.Config, logger logging.Logger,
+) (movementsensor.MovementSensor, error) {
+	dg := dualGPS{
+		Named:  conf.ResourceName().AsNamed(),
+		logger: logger,
+	}
+
+	if err := dg.Reconfigure(ctx, deps, conf); err != nil {
+		return nil, err
+	}
+	return &dg, nil
+}
+
+func (dg *dualGPS) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+	newConf, err := resource.NativeConfig[*Config](conf)
+	if err != nil {
+		return err
+	}
+
+	dg.mu.Lock()
+	defer dg.mu.Unlock()
+
+	first, err := movementsensor.FromDependencies(deps, newConf.Gps1)
+	if err != nil {
+		return err
+	}
+	if newConf.Gps1 != first.Name().ShortName() {
+		dg.gps1.gps = first
+	}
+
+	second, err := movementsensor.FromDependencies(deps, newConf.Gps2)
+	if err != nil {
+		return err
+	}
+	if newConf.Gps2 != second.Name().ShortName() {
+		dg.gps2.gps = second
+	}
+
+	dg.offset = 90
+	if newConf.Offset != 0 {
+		dg.offset = newConf.Offset
+	}
+
+	return nil
+}
+
+type gpsWithLock struct {
+	gps     movementsensor.MovementSensor
+	gpsLock sync.Mutex
+}
+
+func (lgps *gpsWithLock) getPosition(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+	lgps.gpsLock.Lock()
+	defer lgps.gpsLock.Unlock()
+	return lgps.gps.Position(ctx, extra)
+}
+
+// Position gets the position of a fake movementsensor.
+func (dg *dualGPS) Position(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+	// TODO
+	dg.mu.Lock()
+	defer dg.mu.Unlock()
+	return dg.gps1.getPosition(ctx, extra)
+}
+
+// getHeading calculates bearing and absolute heading angles given 2 geoPoint coordinates
+// 0 degrees is North, 90 degrees is East, 180 degrees is South, 270 is West.
+func getHeading(first, second *geo.Point, yawOffset float64) (float64, float64, float64) {
+	// convert latitude and longitude readings from degrees to radians
+	firstLat := utils.DegToRad(first.Lat())
+	firstLong := utils.DegToRad(first.Lng())
+	secondLat := utils.DegToRad(second.Lat())
+	secondLong := utils.DegToRad(second.Lng())
+
+	// calculate bearing from gps1 to gps 2
+	deltaLong := secondLong - firstLong
+	y := math.Sin(deltaLong) * math.Cos(secondLat)
+	x := math.Cos(firstLat)*math.Sin(secondLat) - math.Sin(firstLat)*math.Cos(secondLat)*math.Cos(deltaLong)
+	bearing := utils.RadToDeg(math.Atan2(y, x))
+
+	// maps bearing to 0-360 degrees
+	if bearing < 0 {
+		bearing += 360
+	}
+
+	// calculate absolute heading from bearing, accounting for yaw offset
+	// e.g if the MovementSensor antennas are mounted on the left and right sides of the robot,
+	// the yaw offset would be roughly 90 degrees
+	var standardBearing float64
+	if bearing > 180 {
+		standardBearing = -(360 - bearing)
+	} else {
+		standardBearing = bearing
+	}
+	heading := bearing - yawOffset
+
+	// make heading positive again
+	if heading < 0 {
+		diff := math.Abs(heading)
+		heading = 360 - diff
+	}
+
+	return bearing, heading, standardBearing
+}
+
+// CompassHeading gets the compass headings of a fake movementsensor.
+func (dg *dualGPS) CompassHeading(ctx context.Context, extra map[string]interface{}) (float64, error) {
+	geoPoint1, _, err := dg.gps1.getPosition(context.Background(), extra)
+	if err != nil {
+		return math.NaN(), err
+	}
+
+	geoPoint2, _, err := dg.gps2.getPosition(context.Background(), extra)
+	if err != nil {
+		return math.NaN(), err
+	}
+
+	bearing, _, _ := getHeading(geoPoint1, geoPoint2, 0)
+	return bearing, nil
+}
+
+func (dg *dualGPS) Properties(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+	return &movementsensor.Properties{
+		PositionSupported:           true,
+		CompassHeadingSupported:     true,
+		LinearVelocitySupported:     false,
+		AngularVelocitySupported:    false,
+		OrientationSupported:        false,
+		LinearAccelerationSupported: false,
+	}, nil
+
+}
+
+func (dg *dualGPS) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+	return movementsensor.DefaultAPIReadings(ctx, dg, extra)
+}
+
+// Unimplemented functions
+func (dg *dualGPS) LinearAcceleration(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+	return r3.Vector{}, movementsensor.ErrMethodUnimplementedLinearAcceleration
+}
+
+func (dg *dualGPS) LinearVelocity(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+	return r3.Vector{}, movementsensor.ErrMethodUnimplementedLinearVelocity
+}
+
+func (dg *dualGPS) AngularVelocity(ctx context.Context, extra map[string]interface{}) (spatialmath.AngularVelocity, error) {
+	return spatialmath.AngularVelocity{}, movementsensor.ErrMethodUnimplementedAngularVelocity
+}
+
+func (dg *dualGPS) Orientation(ctx context.Context, extra map[string]interface{}) (spatialmath.Orientation, error) {
+	return spatialmath.NewZeroOrientation(), movementsensor.ErrMethodUnimplementedOrientation
+}
+
+func (dg *dualGPS) Accuracy(ctx context.Context, extra map[string]interface{}) (map[string]float32, error) {
+	return map[string]float32{}, movementsensor.ErrMethodUnimplementedAccuracy
+}
+
+func (dg *dualGPS) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+	return map[string]interface{}{}, resource.ErrDoUnimplemented
+}
+
+func (dg *dualGPS) Close(ctx context.Context) error {
+	return nil
+}

--- a/components/movementsensor/dualgps/dualgps.go
+++ b/components/movementsensor/dualgps/dualgps.go
@@ -122,6 +122,13 @@ func (dg *dualGPS) Reconfigure(ctx context.Context, deps resource.Dependencies, 
 		dg.offset = *newConf.Offset
 	}
 
+	dg.logger.Debug(
+		"using gps named %v as first gps and gps named %v as secodn gps, with an offset of %v",
+		first.Name().ShortName(),
+		second.Name().ShortName(),
+		dg.offset,
+	)
+
 	return nil
 }
 

--- a/components/movementsensor/dualgps/dualgps.go
+++ b/components/movementsensor/dualgps/dualgps.go
@@ -20,8 +20,8 @@ import (
 
 // the default offset between the two gps devices describes a setup where
 // one gps is mounted on the right side of the base and
-// the other gps is mounted on the left side of the base
-// works with gps-rtk modules. This driver is not guaranteed to be performant with
+// the other gps is mounted on the left side of the base.
+// This driver is not guaranteed to be performant with
 // non-rtk corrected gps modules with larger error in their position.
 //   ___________
 //  |   base    |

--- a/components/movementsensor/dualgps/dualgps.go
+++ b/components/movementsensor/dualgps/dualgps.go
@@ -55,7 +55,7 @@ func (c *Config) Validate(path string) ([]string, error) {
 		return nil, resource.NewConfigValidationFieldRequiredError(path, "second_gps")
 	}
 
-	if *c.Offset < 0 || *c.Offset > 360 {
+	if c.Offset != nil && (*c.Offset < 0 || *c.Offset > 360) {
 		return nil, resource.NewConfigValidationError(
 			path,
 			errors.New("this driver only allows offset values from 0 to 360"))
@@ -153,7 +153,7 @@ func getHeading(firstPoint, secondPoint *geo.Point, yawOffset float64,
 		bearing += 360
 	}
 
-	// calculate heading from bearing, accounting for yaw offset between the two gps devices
+	// calculate heading from bearing, accounting for yaw offset between the two gps ©
 	// e.g if the MovementSensor antennas are mounted on the left and right sides of the robot,
 	// the yaw offset would be roughly 90 degrees
 	heading := bearing - yawOffset

--- a/components/movementsensor/dualgps/dualgps.go
+++ b/components/movementsensor/dualgps/dualgps.go
@@ -123,7 +123,7 @@ func (dg *dualGPS) Reconfigure(ctx context.Context, deps resource.Dependencies, 
 	}
 
 	dg.logger.Debug(
-		"using gps named %v as first gps and gps named %v as secodn gps, with an offset of %v",
+		"using gps named %v as first gps and gps named %v as second gps, with an offset of %v",
 		first.Name().ShortName(),
 		second.Name().ShortName(),
 		dg.offset,
@@ -160,7 +160,7 @@ func getHeading(firstPoint, secondPoint *geo.Point, yawOffset float64,
 		bearing += 360
 	}
 
-	// calculate heading from bearing, accounting for yaw offset between the two gps ©
+	// calculate heading from bearing, accounting for yaw offset between the two gps
 	// e.g if the MovementSensor antennas are mounted on the left and right sides of the robot,
 	// the yaw offset would be roughly 90 degrees
 	heading := bearing - yawOffset

--- a/components/movementsensor/dualgps/dualgps_test.go
+++ b/components/movementsensor/dualgps/dualgps_test.go
@@ -61,7 +61,7 @@ func TestCreateValidateAndReconfigure(t *testing.T) {
 	test.That(t, ms, test.ShouldNotBeNil)
 	dgps, ok := ms.(*dualGPS)
 	test.That(t, ok, test.ShouldBeTrue)
-	test.That(t, dgps.gps2.gps.Name().ShortName(), test.ShouldResemble, testGPS2)
+	test.That(t, dgps.gps2.Name().ShortName(), test.ShouldResemble, testGPS2)
 
 	cfg = resource.Config{
 		Name:  testName,
@@ -76,7 +76,7 @@ func TestCreateValidateAndReconfigure(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	dgps, ok = ms.(*dualGPS)
 	test.That(t, ok, test.ShouldBeTrue)
-	test.That(t, dgps.gps2.gps.Name().ShortName(), test.ShouldResemble, testGPS3)
+	test.That(t, dgps.gps2.Name().ShortName(), test.ShouldResemble, testGPS3)
 }
 
 func TestGetHeading(t *testing.T) {

--- a/components/movementsensor/dualgps/dualgps_test.go
+++ b/components/movementsensor/dualgps/dualgps_test.go
@@ -1,0 +1,67 @@
+package dualgps
+
+import (
+	"testing"
+
+	geo "github.com/kellydunn/golang-geo"
+	"go.viam.com/test"
+)
+
+func TestCreateAndReconfigure(t *testing.T) {
+
+}
+
+func TestGetHeading(t *testing.T) {
+	testPos1 := geo.NewPoint(8.46696, -17.03663)
+	testPos2 := geo.NewPoint(65.35996, -17.03663)
+	// test case 1, standard bearing = 0, heading = 270
+	bearing, heading, standardBearing := getHeading(testPos1, testPos2, 90)
+	test.That(t, bearing, test.ShouldAlmostEqual, 0)
+	test.That(t, heading, test.ShouldAlmostEqual, 270)
+	test.That(t, standardBearing, test.ShouldAlmostEqual, 0)
+
+	// test case 2, reversed test case 1.
+	testPos1 = geo.NewPoint(65.35996, -17.03663)
+	testPos2 = geo.NewPoint(8.46696, -17.03663)
+
+	bearing, heading, standardBearing = getHeading(testPos1, testPos2, 90)
+	test.That(t, bearing, test.ShouldAlmostEqual, 180)
+	test.That(t, heading, test.ShouldAlmostEqual, 90)
+	test.That(t, standardBearing, test.ShouldAlmostEqual, 180)
+
+	// test case 2.5, changed yaw offsets
+	testPos1 = geo.NewPoint(65.35996, -17.03663)
+	testPos2 = geo.NewPoint(8.46696, -17.03663)
+
+	bearing, heading, standardBearing = getHeading(testPos1, testPos2, 270)
+	test.That(t, bearing, test.ShouldAlmostEqual, 180)
+	test.That(t, heading, test.ShouldAlmostEqual, 270)
+	test.That(t, standardBearing, test.ShouldAlmostEqual, 180)
+
+	// test case 3
+	testPos1 = geo.NewPoint(8.46696, -17.03663)
+	testPos2 = geo.NewPoint(56.74367734077241, 29.369620000000015)
+
+	bearing, heading, standardBearing = getHeading(testPos1, testPos2, 90)
+	test.That(t, bearing, test.ShouldAlmostEqual, 27.2412, 1e-3)
+	test.That(t, heading, test.ShouldAlmostEqual, 297.24126, 1e-3)
+	test.That(t, standardBearing, test.ShouldAlmostEqual, 27.24126, 1e-3)
+
+	// test case 4, reversed coordinates
+	testPos1 = geo.NewPoint(56.74367734077241, 29.369620000000015)
+	testPos2 = geo.NewPoint(8.46696, -17.03663)
+
+	bearing, heading, standardBearing = getHeading(testPos1, testPos2, 90)
+	test.That(t, bearing, test.ShouldAlmostEqual, 235.6498, 1e-3)
+	test.That(t, heading, test.ShouldAlmostEqual, 145.6498, 1e-3)
+	test.That(t, standardBearing, test.ShouldAlmostEqual, -124.3501, 1e-3)
+
+	// test case 4.5, changed yaw Offset
+	testPos1 = geo.NewPoint(56.74367734077241, 29.369620000000015)
+	testPos2 = geo.NewPoint(8.46696, -17.03663)
+
+	bearing, heading, standardBearing = getHeading(testPos1, testPos2, 270)
+	test.That(t, bearing, test.ShouldAlmostEqual, 235.6498, 1e-3)
+	test.That(t, heading, test.ShouldAlmostEqual, 325.6498, 1e-3)
+	test.That(t, standardBearing, test.ShouldAlmostEqual, -124.3501, 1e-3)
+}

--- a/components/movementsensor/dualgps/dualgps_test.go
+++ b/components/movementsensor/dualgps/dualgps_test.go
@@ -1,13 +1,81 @@
 package dualgps
 
 import (
+	"context"
 	"testing"
 
 	geo "github.com/kellydunn/golang-geo"
+	"go.viam.com/rdk/components/movementsensor"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/testutils/inject"
 	"go.viam.com/test"
 )
 
-func TestCreateAndReconfigure(t *testing.T) {
+const (
+	testName = "test"
+	testGPS1 = "gps1"
+	testGPS2 = "gps2"
+	testGPS3 = "gps3"
+	testPath = "somepath"
+)
+
+func TestCreateValidateAndReconfigure(t *testing.T) {
+	cfg := resource.Config{
+		Name:  testName,
+		Model: model,
+		API:   movementsensor.API,
+		ConvertedAttributes: &Config{
+			Gps1: testGPS1,
+		},
+	}
+	implicits, err := cfg.Validate(testPath, movementsensor.API.SubtypeName)
+	test.That(t, implicits, test.ShouldBeNil)
+	test.That(t, err, test.ShouldBeError, resource.NewConfigValidationFieldRequiredError(testPath, "second_gps"))
+
+	cfg = resource.Config{
+		Name:  testName,
+		Model: model,
+		API:   movementsensor.API,
+		ConvertedAttributes: &Config{
+			Gps1: testGPS1,
+			Gps2: testGPS2,
+		},
+	}
+	implicits, err = cfg.Validate(testPath, movementsensor.API.SubtypeName)
+	test.That(t, implicits, test.ShouldResemble, []string{testGPS1, testGPS2})
+	test.That(t, err, test.ShouldBeNil)
+
+	deps := make(resource.Dependencies)
+	deps[movementsensor.Named(testGPS1)] = inject.NewMovementSensor(testGPS1)
+	deps[movementsensor.Named(testGPS2)] = inject.NewMovementSensor(testGPS2)
+	deps[movementsensor.Named(testGPS3)] = inject.NewMovementSensor(testGPS3)
+
+	ms, err := newDualGPS(
+		context.Background(),
+		deps,
+		cfg,
+		logging.NewDebugLogger("testLogger"))
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, ms, test.ShouldNotBeNil)
+	dgps, ok := ms.(*dualGPS)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, dgps.gps2.gps.Name().ShortName(), test.ShouldResemble, testGPS2)
+
+	cfg = resource.Config{
+		Name:  testName,
+		Model: model,
+		API:   movementsensor.API,
+		ConvertedAttributes: &Config{
+			Gps1: testGPS1,
+			Gps2: testGPS3,
+		},
+	}
+	err = ms.Reconfigure(context.Background(), deps, cfg)
+	test.That(t, err, test.ShouldBeNil)
+	dgps, ok = ms.(*dualGPS)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, dgps.gps2.gps.Name().ShortName(), test.ShouldResemble, testGPS3)
 
 }
 

--- a/components/movementsensor/dualgps/dualgps_test.go
+++ b/components/movementsensor/dualgps/dualgps_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 
 	geo "github.com/kellydunn/golang-geo"
+	"go.viam.com/test"
+
 	"go.viam.com/rdk/components/movementsensor"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/testutils/inject"
-	"go.viam.com/test"
 )
 
 const (
@@ -76,7 +77,6 @@ func TestCreateValidateAndReconfigure(t *testing.T) {
 	dgps, ok = ms.(*dualGPS)
 	test.That(t, ok, test.ShouldBeTrue)
 	test.That(t, dgps.gps2.gps.Name().ShortName(), test.ShouldResemble, testGPS3)
-
 }
 
 func TestGetHeading(t *testing.T) {

--- a/components/movementsensor/properties.go
+++ b/components/movementsensor/properties.go
@@ -7,7 +7,7 @@ import pb "go.viam.com/api/component/movementsensor/v1"
 // The order is in terms of order of derivatives in time
 // with position, orientation, compassheading at the top (zeroth derivative)
 // linear and angular velocities next (first derivative)
-// linear acceleration laste (second derivative).
+// linear acceleration last (second derivative).
 type Properties struct {
 	PositionSupported           bool
 	OrientationSupported        bool

--- a/components/movementsensor/properties.go
+++ b/components/movementsensor/properties.go
@@ -6,11 +6,11 @@ import pb "go.viam.com/api/component/movementsensor/v1"
 // of a movementsensor.
 type Properties struct {
 	PositionSupported           bool
+	OrientationSupported        bool
+	CompassHeadingSupported     bool
 	LinearVelocitySupported     bool
 	AngularVelocitySupported    bool
 	LinearAccelerationSupported bool
-	CompassHeadingSupported     bool
-	OrientationSupported        bool
 }
 
 // ProtoFeaturesToProperties takes a GetPropertiesResponse and returns
@@ -18,11 +18,11 @@ type Properties struct {
 func ProtoFeaturesToProperties(resp *pb.GetPropertiesResponse) *Properties {
 	return &Properties{
 		PositionSupported:           resp.PositionSupported,
+		OrientationSupported:        resp.OrientationSupported,
+		CompassHeadingSupported:     resp.CompassHeadingSupported,
 		LinearVelocitySupported:     resp.LinearVelocitySupported,
 		AngularVelocitySupported:    resp.AngularVelocitySupported,
 		LinearAccelerationSupported: resp.LinearAccelerationSupported,
-		CompassHeadingSupported:     resp.CompassHeadingSupported,
-		OrientationSupported:        resp.OrientationSupported,
 	}
 }
 
@@ -33,10 +33,10 @@ func PropertiesToProtoResponse(
 ) (*pb.GetPropertiesResponse, error) {
 	return &pb.GetPropertiesResponse{
 		PositionSupported:           features.PositionSupported,
+		OrientationSupported:        features.OrientationSupported,
+		CompassHeadingSupported:     features.CompassHeadingSupported,
 		LinearVelocitySupported:     features.LinearVelocitySupported,
 		AngularVelocitySupported:    features.AngularVelocitySupported,
 		LinearAccelerationSupported: features.LinearAccelerationSupported,
-		CompassHeadingSupported:     features.CompassHeadingSupported,
-		OrientationSupported:        features.OrientationSupported,
 	}, nil
 }

--- a/components/movementsensor/properties.go
+++ b/components/movementsensor/properties.go
@@ -4,6 +4,10 @@ import pb "go.viam.com/api/component/movementsensor/v1"
 
 // Properties is a structure representing features
 // of a movementsensor.
+// The order is in terms of order of derivatives in time
+// with position, orientation, compassheading at the top (zeroth derivative)
+// linear and angular velocities next (first derivative)
+// linear acceleration laste (second derivative).
 type Properties struct {
 	PositionSupported           bool
 	OrientationSupported        bool

--- a/components/movementsensor/register/register.go
+++ b/components/movementsensor/register/register.go
@@ -4,6 +4,7 @@ package register
 import (
 	// Load all movementsensors.
 	_ "go.viam.com/rdk/components/movementsensor/adxl345"
+	_ "go.viam.com/rdk/components/movementsensor/dualgps"
 	_ "go.viam.com/rdk/components/movementsensor/fake"
 	_ "go.viam.com/rdk/components/movementsensor/gpsnmea"
 	_ "go.viam.com/rdk/components/movementsensor/gpsrtkpmtk"

--- a/components/movementsensor/utils.go
+++ b/components/movementsensor/utils.go
@@ -6,49 +6,7 @@ import (
 	"sync"
 
 	geo "github.com/kellydunn/golang-geo"
-
-	"go.viam.com/rdk/utils"
 )
-
-// GetHeading calculates bearing and absolute heading angles given 2 MovementSensor coordinates
-// 0 degrees indicate North, 90 degrees indicate East and so on.
-func GetHeading(gps1, gps2 *geo.Point, yawOffset float64) (float64, float64, float64) {
-	// convert latitude and longitude readings from degrees to radians
-	gps1Lat := utils.DegToRad(gps1.Lat())
-	gps1Long := utils.DegToRad(gps1.Lng())
-	gps2Lat := utils.DegToRad(gps2.Lat())
-	gps2Long := utils.DegToRad(gps2.Lng())
-
-	// calculate bearing from gps1 to gps 2
-	dLon := gps2Long - gps1Long
-	y := math.Sin(dLon) * math.Cos(gps2Lat)
-	x := math.Cos(gps1Lat)*math.Sin(gps2Lat) - math.Sin(gps1Lat)*math.Cos(gps2Lat)*math.Cos(dLon)
-	brng := utils.RadToDeg(math.Atan2(y, x))
-
-	// maps bearing to 0-360 degrees
-	if brng < 0 {
-		brng += 360
-	}
-
-	// calculate absolute heading from bearing, accounting for yaw offset
-	// e.g if the MovementSensor antennas are mounted on the left and right sides of the robot,
-	// the yaw offset would be roughly 90 degrees
-	var standardBearing float64
-	if brng > 180 {
-		standardBearing = -(360 - brng)
-	} else {
-		standardBearing = brng
-	}
-	heading := brng - yawOffset
-
-	// make heading positive again
-	if heading < 0 {
-		diff := math.Abs(heading)
-		heading = 360 - diff
-	}
-
-	return brng, heading, standardBearing
-}
 
 var (
 	// ErrMethodUnimplementedAccuracy returns error if the Accuracy method is unimplemented.

--- a/components/movementsensor/utils_test.go
+++ b/components/movementsensor/utils_test.go
@@ -16,7 +16,6 @@ var (
 	nanPos   = geo.NewPoint(math.NaN(), math.NaN())
 )
 
-
 func TestNoErrors(t *testing.T) {
 	le := NewLastError(1, 1)
 	test.That(t, le.Get(), test.ShouldBeNil)

--- a/components/movementsensor/utils_test.go
+++ b/components/movementsensor/utils_test.go
@@ -16,58 +16,6 @@ var (
 	nanPos   = geo.NewPoint(math.NaN(), math.NaN())
 )
 
-func TestGetHeading(t *testing.T) {
-	// test case 1, standard bearing = 0, heading = 270
-	bearing, heading, standardBearing := GetHeading(testPos1, testPos2, 90)
-	test.That(t, bearing, test.ShouldAlmostEqual, 0)
-	test.That(t, heading, test.ShouldAlmostEqual, 270)
-	test.That(t, standardBearing, test.ShouldAlmostEqual, 0)
-
-	// test case 2, reversed test case 1.
-	testPos1 = geo.NewPoint(65.35996, -17.03663)
-	testPos2 = geo.NewPoint(8.46696, -17.03663)
-
-	bearing, heading, standardBearing = GetHeading(testPos1, testPos2, 90)
-	test.That(t, bearing, test.ShouldAlmostEqual, 180)
-	test.That(t, heading, test.ShouldAlmostEqual, 90)
-	test.That(t, standardBearing, test.ShouldAlmostEqual, 180)
-
-	// test case 2.5, changed yaw offsets
-	testPos1 = geo.NewPoint(65.35996, -17.03663)
-	testPos2 = geo.NewPoint(8.46696, -17.03663)
-
-	bearing, heading, standardBearing = GetHeading(testPos1, testPos2, 270)
-	test.That(t, bearing, test.ShouldAlmostEqual, 180)
-	test.That(t, heading, test.ShouldAlmostEqual, 270)
-	test.That(t, standardBearing, test.ShouldAlmostEqual, 180)
-
-	// test case 3
-	testPos1 = geo.NewPoint(8.46696, -17.03663)
-	testPos2 = geo.NewPoint(56.74367734077241, 29.369620000000015)
-
-	bearing, heading, standardBearing = GetHeading(testPos1, testPos2, 90)
-	test.That(t, bearing, test.ShouldAlmostEqual, 27.2412, 1e-3)
-	test.That(t, heading, test.ShouldAlmostEqual, 297.24126, 1e-3)
-	test.That(t, standardBearing, test.ShouldAlmostEqual, 27.24126, 1e-3)
-
-	// test case 4, reversed coordinates
-	testPos1 = geo.NewPoint(56.74367734077241, 29.369620000000015)
-	testPos2 = geo.NewPoint(8.46696, -17.03663)
-
-	bearing, heading, standardBearing = GetHeading(testPos1, testPos2, 90)
-	test.That(t, bearing, test.ShouldAlmostEqual, 235.6498, 1e-3)
-	test.That(t, heading, test.ShouldAlmostEqual, 145.6498, 1e-3)
-	test.That(t, standardBearing, test.ShouldAlmostEqual, -124.3501, 1e-3)
-
-	// test case 4.5, changed yaw Offset
-	testPos1 = geo.NewPoint(56.74367734077241, 29.369620000000015)
-	testPos2 = geo.NewPoint(8.46696, -17.03663)
-
-	bearing, heading, standardBearing = GetHeading(testPos1, testPos2, 270)
-	test.That(t, bearing, test.ShouldAlmostEqual, 235.6498, 1e-3)
-	test.That(t, heading, test.ShouldAlmostEqual, 325.6498, 1e-3)
-	test.That(t, standardBearing, test.ShouldAlmostEqual, -124.3501, 1e-3)
-}
 
 func TestNoErrors(t *testing.T) {
 	le := NewLastError(1, 1)


### PR DESCRIPTION
This PR implements a driver "dual-gps-rtk" that uses two GPS chips mounted on a vehicle to calculate the heading between them with a known offset to the vehicle's heading. See pictures in scope: https://docs.google.com/document/d/1khQS1HBJDZGyUFttJzdmT1dwRMU3lTIaqIK4MY2G7ew/edit#heading=h.tcicyojyqi6c

Not doing- implementing anything other than CompassHeading.

Still has to be tested outdoors.

