### PR TITLE
DATA-2135 - Error and retry if an arbitrary file gets modified during sync time

### DIFF
--- a/services/datamanager/datasync/upload_arbitrary_file.go
+++ b/services/datamanager/datasync/upload_arbitrary_file.go
@@ -31,6 +31,9 @@ func uploadArbitraryFile(ctx context.Context, client v1.DataSyncServiceClient, f
 		return err
 	}
 
+	// Only sync non-datacapture files that have not been modified in the last
+	// defaultFileLastModifiedMillis to avoid uploading files that are being
+	// to written to.
 	info, err := os.Stat(path)
 	if err != nil {
 		return err


### PR DESCRIPTION
Error in `uploadArbiraryFile` if it has been modified in the past 10 seconds, which is the same default as in the data manager.

**Testing**
Wrote to three files: one every 5 seconds, another every 10, another every 20 seconds, and synced files every 6 seconds. The 5 and 10 second files overlapped in a way that they were never passed into `SyncFile` within the data manager based on [this check](https://github.com/viamrobotics/rdk/blob/fa7f86261a32a5b2fda6451b1610f1acef775a72/services/datamanager/builtin/builtin.go#L615-L616). The 20 second file was passed into SyncFile but consistently errored within this new `datasync` check.

Since an error is returned, this correctly gets logged to the console and the sync is retried since it is a [retryable error](https://github.com/viamrobotics/rdk/blob/fa7f86261a32a5b2fda6451b1610f1acef775a72/services/datamanager/datasync/sync.go#L279-L282).

<img width="1298" alt="image" src="https://github.com/viamrobotics/rdk/assets/3794748/210a1b7b-f9a8-4d9f-9d20-4131f037f533">
The result of files roughly every ~20 seconds, all with different contents:
<img width="1170" alt="image" src="https://github.com/viamrobotics/rdk/assets/3794748/f1c7d554-ceab-477a-b29a-f2febced5317">