### PR TITLE
Go 1.21 Parallelism and Test Fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -275,10 +275,10 @@ jobs:
       - name: Check Results
         run: |
           echo Pi Tests: ${{ needs.test_pi.result }}
-          echo Main Tests: ${{ needs.build_and_test.result }}
+          echo Main Tests: ${{ needs.comments.result }}
           echo E2E Tests: ${{ needs.test_e2e.result }}
           echo 32-bit Tests: ${{ needs.test32.result }}
           [ "${{ needs.test_pi.result }}" == "success" ] && \
-          [ "${{ needs.build_and_test.result }}" == "success" ] && \
+          [ "${{ needs.comments.result }}" == "success" ] && \
           [ "${{ needs.test_e2e.result }}" == "success" ] && \
           [ "${{ needs.test32.result }}" == "success" ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,8 @@ env:
   MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
 
 jobs:
-  test:
+  test_go:
+    name: Go Unit Tests
     strategy:
       fail-fast: false
       matrix:
@@ -36,7 +37,6 @@ jobs:
     - uses: actions/checkout@v3
       with:
         ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.event.ref }}
-        fetch-depth: ${{ github.event_name == 'pull_request_target' && '0' || '1' }} # 0 aka full history, so we can analyze history for coverage
 
     - name: Set main env vars
       if: github.event_name != 'pull_request_target'
@@ -54,10 +54,10 @@ jobs:
         echo "GITHUB_X_PR_BASE_SHA=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
         echo "GITHUB_X_PR_BASE_REF=${{ github.event.pull_request.base.ref }}" >> $GITHUB_ENV
 
-    - name: chown
+    - name: Chown
       run: chown -R testbot:testbot .
 
-    - name: Test
+    - name: Run go unit tests
       run: |
         sudo --preserve-env=MONGODB_TEST_OUTPUT_URI,GITHUB_SHA,GITHUB_RUN_ID,GITHUB_RUN_NUMBER,GITHUB_RUN_ATTEMPT,GITHUB_X_PR_BASE_SHA,GITHUB_X_PR_BASE_REF,GITHUB_X_HEAD_REF,GITHUB_X_HEAD_SHA,GITHUB_REPOSITORY -Hu testbot bash -lc 'make test-go'
 
@@ -69,8 +69,9 @@ jobs:
         path: json.log
         retention-days: 30
 
-  lint_and_coverage:
-    # note: we split 'test' and 'coverage' steps because running race-detection + covprofile simultaneously is slow enough to cause flakes
+  test_coverage:
+    name: Go Coverage Tests
+    # note: we split 'test_go' and 'test_coverage' steps because running race-detection + covprofile simultaneously is slow enough to cause flakes
     strategy:
       fail-fast: false
       matrix:
@@ -114,11 +115,9 @@ jobs:
     - name: chown
       run: chown -R testbot:testbot .
 
-    - name: Verify no uncommitted changes from "make build lint"
+    - name: Verify no uncommitted changes from "make build-go lint-go"
       run: |
-        git init
-        git add .
-        sudo -Hu testbot bash -lc 'make build-go lint-go'
+        sudo -Hu testbot bash -lc 'git init && git add . && make build-go lint-go'
         GEN_DIFF=$(git status -s)
 
         if [ -n "$GEN_DIFF" ]; then
@@ -127,7 +126,7 @@ jobs:
             exit 1
         fi
 
-    - name: Test
+    - name: Run go coverage tests
       run: |
         sudo --preserve-env=MONGODB_TEST_OUTPUT_URI,GITHUB_SHA,GITHUB_RUN_ID,GITHUB_RUN_NUMBER,GITHUB_RUN_ATTEMPT,GITHUB_X_PR_BASE_SHA,GITHUB_X_PR_BASE_REF,GITHUB_X_HEAD_REF,GITHUB_X_HEAD_SHA,GITHUB_REPOSITORY -Hu testbot bash -lc 'make cover-only'
 
@@ -141,7 +140,7 @@ jobs:
         retention-days: 1
 
   test32:
-    name: 32-bit test
+    name: Go 32-bit Unit Tests
     runs-on: buildjet-8vcpu-ubuntu-2204-arm
     timeout-minutes: 30
 
@@ -149,7 +148,6 @@ jobs:
     - uses: actions/checkout@v3
       with:
         ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
-        fetch-depth: ${{ github.event_name == 'pull_request_target' && '0' || '1' }} # 0 aka full history, so we can analyze history for coverage
 
     - uses: docker/login-action@v2
       with:
@@ -158,7 +156,7 @@ jobs:
     - uses: docker/setup-qemu-action@v3
     - uses: docker/setup-buildx-action@v3
 
-    - name: Test
+    - name: Run go unit tests
       run: |
         docker run \
           --platform linux/arm/v7 \
@@ -172,71 +170,70 @@ jobs:
     timeout-minutes: 5
 
     steps:
-    - name: Clean Workspace
+    - name: Clean workspace
       run: |
         shopt -s dotglob
         sudo chown -R `whoami` ./
         rm -rf ./*
 
-    - name: Check out main branch code
-      if: github.event_name != 'pull_request_target'
-      uses: actions/checkout@v3
-
-    - name: Check out PR branch code
-      if: github.event_name == 'pull_request_target'
-      uses: actions/checkout@v3
+    - uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
 
-    - name: Test
+    - name: Run go unit tests on Pi
       run: make test-pi
 
-  test_e2e:
-    name: Test End-to-End and web
+  test_web_e2e:
+    name: Test End-to-End and Web
     runs-on: [buildjet-8vcpu-ubuntu-2204]
     container: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
     steps:
-      - name: Check out main branch code
-        if: github.event_name != 'pull_request_target'
-        uses: actions/checkout@v3
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
 
-      - name: Check out PR branch code
-        if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
+    - name: Chown
+      run: chown -R testbot:testbot .
 
-      - name: Install dependencies
-        run: |
-          apt-get update && apt-get -qy install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb netcat-openbsd lsof
+    - name: Verify no uncommitted changes from "make build-web lint-web"
+      run: |
+        sudo -Hu testbot bash -lc 'git init && git add . && make build-web lint-web'
+        GEN_DIFF=$(git status -s)
 
-      - name: chown
-        run: chown -R testbot:testbot .
+        if [ -n "$GEN_DIFF" ]; then
+            echo '"make build-web lint-web" resulted in changes not in git' 1>&2
+            git status
+            exit 1
+        fi
 
-      - name: build and lint
-        run: sudo -Hu testbot bash -lc 'make build-web lint-web'
+    - name: Install dependencies
+      run: |
+        apt-get update && apt-get -qy install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb netcat-openbsd lsof
 
-      - name: Run e2e and web Tests
-        run: sudo -Hu testbot bash -lc 'make test-web test-e2e E2E_ARGS="-k"'
+    - name: Run web tests
+      run: sudo -Hu testbot bash -lc 'make test-web'
+
+    - name: Run e2e tests
+      run: sudo -Hu testbot bash -lc 'make test-e2e E2E_ARGS="-k"'
 
   test_passing:
     name: All Tests Passing
-    needs: [test_pi, test, lint_and_coverage, test_e2e, test32]
+    needs: [test_go, test_coverage, test_web_e2e, test_pi, test32]
     runs-on: [ubuntu-latest]
     if: always()
     steps:
       - name: Check Results
         run: |
-          echo Pi Tests: ${{ needs.test_pi.result }}
-          echo Lint and test: ${{ needs.test.result }}
-          echo Coverage: ${{ needs.lint_and_coverage.result }}
-          echo E2E Tests: ${{ needs.test_e2e.result }}
-          echo 32-bit Tests: ${{ needs.test32.result }}
+          echo Go Unit Tests: ${{ needs.test_go.result }}
+          echo Go 32-bit Tests: ${{ needs.test32.result }}
+          echo Go Pi Tests: ${{ needs.test_pi.result }}
+          echo Go Coverage Tests: ${{ needs.test_coverage.result }}
+          echo Web/E2E Tests: ${{ needs.test_web_e2e.result }}
+          [ "${{ needs.test_go.result }}" == "success" ] && \
+          [ "${{ needs.test32.result }}" == "success" ] && \
           [ "${{ needs.test_pi.result }}" == "success" ] && \
-          [ "${{ needs.test.result }}" == "success" ] && \
-          [ "${{ needs.lint_and_coverage.result }}" == "success" ] && \
-          [ "${{ needs.test_e2e.result }}" == "success" ] && \
-          [ "${{ needs.test32.result }}" == "success" ]
+          [ "${{ needs.test_coverage.result }}" == "success" ] && \
+          [ "${{ needs.test_web_e2e.result }}" == "success" ]
 
       # Now that RDK is public, can't directly comment without token having full read/write access
       # code-coverage-comment.yml will trigger seperately and post the actual comments

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,11 +19,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - arch: [buildjet-8vcpu-ubuntu-2204]
+          - arch: [buildjet-4vcpu-ubuntu-2204]
             image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
             platform: linux/amd64
             platform_name: linux-amd64
-          - arch: [buildjet-8vcpu-ubuntu-2204-arm]
+          - arch: [buildjet-4vcpu-ubuntu-2204-arm]
             image: ghcr.io/viamrobotics/rdk-devenv:arm64-cache
             platform: linux/arm64
             platform_name: linux-arm64
@@ -76,11 +76,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - arch: [buildjet-8vcpu-ubuntu-2204]
+          - arch: [buildjet-4vcpu-ubuntu-2204]
             image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
             platform: linux/amd64
             platform_name: linux-amd64
-          - arch: [buildjet-8vcpu-ubuntu-2204-arm]
+          - arch: [buildjet-4vcpu-ubuntu-2204-arm]
             image: ghcr.io/viamrobotics/rdk-devenv:arm64-cache
             platform: linux/arm64
             platform_name: linux-arm64
@@ -141,7 +141,7 @@ jobs:
 
   test32:
     name: Go 32-bit Unit Tests
-    runs-on: buildjet-8vcpu-ubuntu-2204-arm
+    runs-on: buildjet-4vcpu-ubuntu-2204-arm
     timeout-minutes: 30
 
     steps:
@@ -185,7 +185,7 @@ jobs:
 
   test_web_e2e:
     name: Test End-to-End and Web
-    runs-on: [buildjet-8vcpu-ubuntu-2204]
+    runs-on: [buildjet-4vcpu-ubuntu-2204]
     container: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,50 +13,7 @@ env:
   MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
 
 jobs:
-  lint:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: [buildjet-8vcpu-ubuntu-2204]
-            image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
-            platform: linux/amd64
-            platform_name: linux-amd64
-          - arch: [buildjet-8vcpu-ubuntu-2204-arm]
-            image: ghcr.io/viamrobotics/rdk-devenv:arm64-cache
-            platform: linux/arm64
-            platform_name: linux-arm64
-    runs-on: ${{ matrix.arch }}
-    container:
-      image: ${{ matrix.image }}
-      options: --platform ${{ matrix.platform }}
-    timeout-minutes: 30
-
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.event.ref }}
-        fetch-depth: ${{ github.event_name == 'pull_request_target' && '0' || '1' }} # 0 aka full history, so we can analyze history for coverage
-
-    - name: chown
-      run: chown -R testbot:testbot .
-
-    - name: Verify no uncommitted changes from "make build lint"
-      run: |
-        git init
-        git add .
-        chown -R testbot:testbot .
-        sudo -Hu testbot bash -lc 'make build lint'
-        GEN_DIFF=$(git status -s)
-
-        if [ -n "$GEN_DIFF" ]; then
-            echo '"make build lint" resulted in changes not in git' 1>&2
-            git status
-            exit 1
-        fi
-
   test:
-    needs: [lint]
     strategy:
       fail-fast: false
       matrix:
@@ -102,7 +59,7 @@ jobs:
 
     - name: Test
       run: |
-        sudo --preserve-env=MONGODB_TEST_OUTPUT_URI,GITHUB_SHA,GITHUB_RUN_ID,GITHUB_RUN_NUMBER,GITHUB_RUN_ATTEMPT,GITHUB_X_PR_BASE_SHA,GITHUB_X_PR_BASE_REF,GITHUB_X_HEAD_REF,GITHUB_X_HEAD_SHA,GITHUB_REPOSITORY -Hu testbot bash -lc 'make test-go test-web'
+        sudo --preserve-env=MONGODB_TEST_OUTPUT_URI,GITHUB_SHA,GITHUB_RUN_ID,GITHUB_RUN_NUMBER,GITHUB_RUN_ATTEMPT,GITHUB_X_PR_BASE_SHA,GITHUB_X_PR_BASE_REF,GITHUB_X_HEAD_REF,GITHUB_X_HEAD_SHA,GITHUB_REPOSITORY -Hu testbot bash -lc 'make test-go'
 
     - name: Upload test.json
       if: always()
@@ -112,9 +69,8 @@ jobs:
         path: json.log
         retention-days: 30
 
-  coverage:
+  lint_and_coverage:
     # note: we split 'test' and 'coverage' steps because running race-detection + covprofile simultaneously is slow enough to cause flakes
-    needs: [lint]
     strategy:
       fail-fast: false
       matrix:
@@ -157,6 +113,19 @@ jobs:
 
     - name: chown
       run: chown -R testbot:testbot .
+
+    - name: Verify no uncommitted changes from "make build lint"
+      run: |
+        git init
+        git add .
+        sudo -Hu testbot bash -lc 'make build-go lint-go'
+        GEN_DIFF=$(git status -s)
+
+        if [ -n "$GEN_DIFF" ]; then
+            echo '"make build lint" resulted in changes not in git' 1>&2
+            git status
+            exit 1
+        fi
 
     - name: Test
       run: |
@@ -170,26 +139,6 @@ jobs:
           pr.env
           code-coverage-results.md
         retention-days: 1
-
-  comments:
-    runs-on: ubuntu-latest
-    needs: [test, coverage]
-    steps:
-    # Now that RDK is public, can't directly comment without token having full read/write access
-    # code-coverage-comment.yml will trigger seperately and post the actual comments
-    - name: Prepare code comment
-      run: |
-        echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> pr.env
-
-    - name: Mark appimage label
-      if: contains(github.event.pull_request.labels.*.name, 'appimage') || contains(github.event.pull_request.labels.*.name, 'appimage-ignore-tests')
-      run: |
-        echo "APPIMAGE=true" >> pr.env
-
-    - name: Mark static label
-      if: contains(github.event.pull_request.labels.*.name, 'static-build') || contains(github.event.pull_request.labels.*.name, 'static-ignore-tests')
-      run: |
-        echo "STATIC=true" >> pr.env
 
   test32:
     name: 32-bit test
@@ -243,7 +192,7 @@ jobs:
       run: make test-pi
 
   test_e2e:
-    name: Test End-to-End
+    name: Test End-to-End and web
     runs-on: [buildjet-8vcpu-ubuntu-2204]
     container: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
     steps:
@@ -261,24 +210,43 @@ jobs:
         run: |
           apt-get -qy install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb netcat-openbsd lsof
 
-      - name: Run e2e Tests
-        run: |
-          chown -R testbot:testbot .
-          sudo -Hu testbot bash -lc 'make build-web test-e2e E2E_ARGS="-k"'
+      - name: chown
+        run: chown -R testbot:testbot .
+
+      - name: build and lint
+        run: sudo -Hu testbot bash -lc 'make build-web lint-web'
+
+      - name: Run e2e and web Tests
+        run: sudo -Hu testbot bash -lc 'make test-web test-e2e E2E_ARGS="-k"'
 
   test_passing:
     name: All Tests Passing
-    needs: [test_pi, comments, test_e2e, test32]
+    needs: [test_pi, test, lint_and_coverage, test_e2e, test32]
     runs-on: [ubuntu-latest]
     if: always()
     steps:
       - name: Check Results
         run: |
           echo Pi Tests: ${{ needs.test_pi.result }}
-          echo Main Tests: ${{ needs.comments.result }}
+          echo Lint and test: ${{ needs.test.result }}
+          echo Coverage: ${{ needs.lint_and_coverage.result }}
           echo E2E Tests: ${{ needs.test_e2e.result }}
           echo 32-bit Tests: ${{ needs.test32.result }}
           [ "${{ needs.test_pi.result }}" == "success" ] && \
-          [ "${{ needs.comments.result }}" == "success" ] && \
+          [ "${{ needs.test.result }}" == "success" ] && \
+          [ "${{ needs.lint_and_coverage.result }}" == "success" ] && \
           [ "${{ needs.test_e2e.result }}" == "success" ] && \
           [ "${{ needs.test32.result }}" == "success" ]
+
+      # Now that RDK is public, can't directly comment without token having full read/write access
+      # code-coverage-comment.yml will trigger seperately and post the actual comments
+      - name: Prepare code comment
+        run: echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> pr.env
+
+      - name: Mark appimage label
+        if: contains(github.event.pull_request.labels.*.name, 'appimage') || contains(github.event.pull_request.labels.*.name, 'appimage-ignore-tests')
+        run: echo "APPIMAGE=true" >> pr.env
+
+      - name: Mark static label
+        if: contains(github.event.pull_request.labels.*.name, 'static-build') || contains(github.event.pull_request.labels.*.name, 'static-ignore-tests')
+        run: echo "STATIC=true" >> pr.env

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,11 +19,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - arch: [buildjet-4vcpu-ubuntu-2204]
+          - arch: [buildjet-8vcpu-ubuntu-2204]
             image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
             platform: linux/amd64
             platform_name: linux-amd64
-          - arch: [buildjet-4vcpu-ubuntu-2204-arm]
+          - arch: [buildjet-8vcpu-ubuntu-2204-arm]
             image: ghcr.io/viamrobotics/rdk-devenv:arm64-cache
             platform: linux/arm64
             platform_name: linux-arm64
@@ -76,11 +76,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - arch: [buildjet-4vcpu-ubuntu-2204]
+          - arch: [buildjet-8vcpu-ubuntu-2204]
             image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
             platform: linux/amd64
             platform_name: linux-amd64
-          - arch: [buildjet-4vcpu-ubuntu-2204-arm]
+          - arch: [buildjet-8vcpu-ubuntu-2204-arm]
             image: ghcr.io/viamrobotics/rdk-devenv:arm64-cache
             platform: linux/arm64
             platform_name: linux-arm64
@@ -141,7 +141,7 @@ jobs:
 
   test32:
     name: Go 32-bit Unit Tests
-    runs-on: buildjet-4vcpu-ubuntu-2204-arm
+    runs-on: buildjet-8vcpu-ubuntu-2204-arm
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,7 @@ env:
   MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
 
 jobs:
-  build_and_test:
-    name: Build and Test
+  lint:
     strategy:
       fail-fast: false
       matrix:
@@ -23,12 +22,10 @@ jobs:
             image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
             platform: linux/amd64
             platform_name: linux-amd64
-            test_cmd: "make cover test-web"
           - arch: [buildjet-8vcpu-ubuntu-2204-arm]
             image: ghcr.io/viamrobotics/rdk-devenv:arm64-cache
             platform: linux/arm64
             platform_name: linux-arm64
-            test_cmd: "make cover test-web"
     runs-on: ${{ matrix.arch }}
     container:
       image: ${{ matrix.image }}
@@ -36,16 +33,53 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - name: Check out code
-      if: github.event_name != 'pull_request_target'
-      uses: actions/checkout@v3
-
-    - name: Check out PR branch code
-      if: github.event_name == 'pull_request_target'
-      uses: actions/checkout@v3
+    - uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.pull_request.head.sha }}
-        fetch-depth: 0 # 0 so we can analyze history for coverage
+        ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.event.ref }}
+        fetch-depth: ${{ github.event_name == 'pull_request_target' && '0' || '1' }} # 0 aka full history, so we can analyze history for coverage
+
+    - name: chown
+      run: chown -R testbot:testbot .
+
+    - name: Verify no uncommitted changes from "make build lint"
+      run: |
+        git init
+        git add .
+        chown -R testbot:testbot .
+        sudo -Hu testbot bash -lc 'make build lint'
+        GEN_DIFF=$(git status -s)
+
+        if [ -n "$GEN_DIFF" ]; then
+            echo '"make build lint" resulted in changes not in git' 1>&2
+            git status
+            exit 1
+        fi
+
+  test:
+    needs: [lint]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: [buildjet-8vcpu-ubuntu-2204]
+            image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
+            platform: linux/amd64
+            platform_name: linux-amd64
+          - arch: [buildjet-8vcpu-ubuntu-2204-arm]
+            image: ghcr.io/viamrobotics/rdk-devenv:arm64-cache
+            platform: linux/arm64
+            platform_name: linux-arm64
+    runs-on: ${{ matrix.arch }}
+    container:
+      image: ${{ matrix.image }}
+      options: --platform ${{ matrix.platform }}
+    timeout-minutes: 30
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.event.ref }}
+        fetch-depth: ${{ github.event_name == 'pull_request_target' && '0' || '1' }} # 0 aka full history, so we can analyze history for coverage
 
     - name: Set main env vars
       if: github.event_name != 'pull_request_target'
@@ -63,23 +97,12 @@ jobs:
         echo "GITHUB_X_PR_BASE_SHA=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
         echo "GITHUB_X_PR_BASE_REF=${{ github.event.pull_request.base.ref }}" >> $GITHUB_ENV
 
-    - name: Verify no uncommitted changes from "make build lint"
-      run: |
-        git init
-        git add .
-        chown -R testbot:testbot .
-        sudo -Hu testbot bash -lc 'make build lint'
-        GEN_DIFF=$(git status -s)
-
-        if [ -n "$GEN_DIFF" ]; then
-            echo '"make build lint" resulted in changes not in git' 1>&2
-            git status
-            exit 1
-        fi
+    - name: chown
+      run: chown -R testbot:testbot .
 
     - name: Test
       run: |
-        sudo --preserve-env=MONGODB_TEST_OUTPUT_URI,GITHUB_SHA,GITHUB_RUN_ID,GITHUB_RUN_NUMBER,GITHUB_RUN_ATTEMPT,GITHUB_X_PR_BASE_SHA,GITHUB_X_PR_BASE_REF,GITHUB_X_HEAD_REF,GITHUB_X_HEAD_SHA,GITHUB_REPOSITORY -Hu testbot bash -lc '${{ matrix.test_cmd }}'
+        sudo --preserve-env=MONGODB_TEST_OUTPUT_URI,GITHUB_SHA,GITHUB_RUN_ID,GITHUB_RUN_NUMBER,GITHUB_RUN_ATTEMPT,GITHUB_X_PR_BASE_SHA,GITHUB_X_PR_BASE_REF,GITHUB_X_HEAD_REF,GITHUB_X_HEAD_SHA,GITHUB_REPOSITORY -Hu testbot bash -lc 'make test-go test-web'
 
     - name: Upload test.json
       if: always()
@@ -89,9 +112,71 @@ jobs:
         path: json.log
         retention-days: 30
 
+  coverage:
+    # note: we split 'test' and 'coverage' steps because running race-detection + covprofile simultaneously is slow enough to cause flakes
+    needs: [lint]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: [buildjet-8vcpu-ubuntu-2204]
+            image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
+            platform: linux/amd64
+            platform_name: linux-amd64
+          - arch: [buildjet-8vcpu-ubuntu-2204-arm]
+            image: ghcr.io/viamrobotics/rdk-devenv:arm64-cache
+            platform: linux/arm64
+            platform_name: linux-arm64
+    runs-on: ${{ matrix.arch }}
+    container:
+      image: ${{ matrix.image }}
+      options: --platform ${{ matrix.platform }}
+    timeout-minutes: 30
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.event.ref }}
+        fetch-depth: ${{ github.event_name == 'pull_request_target' && '0' || '1' }} # 0 aka full history, so we can analyze history for coverage
+
+    - name: Set main env vars
+      if: github.event_name != 'pull_request_target'
+      run: |
+        echo "GITHUB_X_HEAD_SHA=${GITHUB_SHA}" >> $GITHUB_ENV
+        echo "GITHUB_X_HEAD_REF=${GITHUB_REF_NAME}" >> $GITHUB_ENV
+
+    - name: Set PR env vars
+      if: github.event_name == 'pull_request_target'
+      env:
+        GITHUB_HEAD_REF_SAN: ${{ github.event.pull_request.head.label }}
+      run: |
+        echo "GITHUB_X_HEAD_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+        echo "GITHUB_X_HEAD_REF=${GITHUB_HEAD_REF_SAN}" >> $GITHUB_ENV
+        echo "GITHUB_X_PR_BASE_SHA=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
+        echo "GITHUB_X_PR_BASE_REF=${{ github.event.pull_request.base.ref }}" >> $GITHUB_ENV
+
+    - name: chown
+      run: chown -R testbot:testbot .
+
+    - name: Test
+      run: |
+        sudo --preserve-env=MONGODB_TEST_OUTPUT_URI,GITHUB_SHA,GITHUB_RUN_ID,GITHUB_RUN_NUMBER,GITHUB_RUN_ATTEMPT,GITHUB_X_PR_BASE_SHA,GITHUB_X_PR_BASE_REF,GITHUB_X_HEAD_REF,GITHUB_X_HEAD_SHA,GITHUB_REPOSITORY -Hu testbot bash -lc 'make cover-only'
+
+    - name: Upload code coverage
+      uses: actions/upload-artifact@v3
+      with:
+        name: pr-code-coverage
+        path: |
+          pr.env
+          code-coverage-results.md
+        retention-days: 1
+
+  comments:
+    runs-on: ubuntu-latest
+    needs: [test, coverage]
+    steps:
     # Now that RDK is public, can't directly comment without token having full read/write access
     # code-coverage-comment.yml will trigger seperately and post the actual comments
-
     - name: Prepare code comment
       run: |
         echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> pr.env
@@ -105,15 +190,6 @@ jobs:
       if: contains(github.event.pull_request.labels.*.name, 'static-build') || contains(github.event.pull_request.labels.*.name, 'static-ignore-tests')
       run: |
         echo "STATIC=true" >> pr.env
-
-    - name: Upload code coverage
-      uses: actions/upload-artifact@v3
-      with:
-        name: pr-code-coverage
-        path: |
-         pr.env
-         code-coverage-results.md
-        retention-days: 1
 
   test32:
     name: 32-bit test
@@ -192,7 +268,7 @@ jobs:
 
   test_passing:
     name: All Tests Passing
-    needs: [test_pi, build_and_test, test_e2e, test32]
+    needs: [test_pi, comments, test_e2e, test32]
     runs-on: [ubuntu-latest]
     if: always()
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -208,7 +208,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get -qy install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb netcat-openbsd lsof
+          apt-get update && apt-get -qy install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb netcat-openbsd lsof
 
       - name: chown
         run: chown -R testbot:testbot .

--- a/Makefile
+++ b/Makefile
@@ -70,11 +70,10 @@ lint-web: check-web
 check-web:
 	npm run check --prefix web/frontend
 
-cover: test-go
-	PATH=$(PATH_WITH_TOOLS) ./etc/test.sh cover
-
 cover-only: tool-install
 	PATH=$(PATH_WITH_TOOLS) ./etc/test.sh cover
+
+cover: test-go cover-only
 
 test: test-go test-web
 

--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,8 @@ lint-web: check-web
 check-web:
 	npm run check --prefix web/frontend
 
-cover: tool-install
-	PATH=$(PATH_WITH_TOOLS) ./etc/test.sh cover-with-race
+cover: test-go
+	PATH=$(PATH_WITH_TOOLS) ./etc/test.sh cover
 
 test: test-go test-web
 

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ lint-go: tool-install
 lint-web: check-web
 	npm run lint --prefix web/frontend
 
-check-web:
+check-web: build-web
 	npm run check --prefix web/frontend
 
 cover-only: tool-install

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,9 @@ check-web:
 cover: test-go
 	PATH=$(PATH_WITH_TOOLS) ./etc/test.sh cover
 
+cover-only: tool-install
+	PATH=$(PATH_WITH_TOOLS) ./etc/test.sh cover
+
 test: test-go test-web
 
 test-no-race: test-go-no-race test-web

--- a/etc/test.sh
+++ b/etc/test.sh
@@ -6,24 +6,30 @@ cd $ROOT_DIR
 
 # Race is unsupported on some linux/arm64 hosts. See https://github.com/golang/go/issues/29948.
 # To run without race, use `make test-no-race` or `make test-go-no-race`.
+# Running race and cover at the same time results in DRAMATIC test slowdowns, especially with parallel processing.
 
-if [[ "$1" == "cover-with-race" ]]; then
+if [[ "$1" == "cover" ]]; then
 	COVER=-coverprofile=coverage.txt
-	RACE=-race
 fi
 
 if [[ "$1" == "race" ]]; then
 	RACE=-race
+	LOGFILE="--jsonfile json.log"
 fi
 
 # We run analyzetests on every run, pass or fail. We only run analyzecoverage when all tests passed.
-PION_LOG_WARN=webrtc,datachannel,sctp gotestsum --format standard-verbose --jsonfile json.log -- -tags=no_skip $RACE $COVER ./...
+PION_LOG_WARN=webrtc,datachannel,sctp gotestsum --format standard-verbose $LOGFILE -- -tags=no_skip $RACE $COVER ./...
 SUCCESS=$?
 
-cat json.log | go run ./etc/analyzetests/main.go
+if [[ $RACE != "" ]]; then
+	cat json.log | go run ./etc/analyzetests/main.go
+	exit $?
+fi
 
 if [ "$SUCCESS" != "0" ]; then
 	exit 1
 fi
 
-cat coverage.txt | go run ./etc/analyzecoverage/main.go
+if [[ $COVER != "" ]]; then
+	cat coverage.txt | go run ./etc/analyzecoverage/main.go
+fi

--- a/services/vision/obstaclesdistance/obstacles_distance_test.go
+++ b/services/vision/obstaclesdistance/obstacles_distance_test.go
@@ -15,9 +15,18 @@ import (
 	"go.viam.com/rdk/rimage"
 	"go.viam.com/rdk/services/vision"
 	"go.viam.com/rdk/testutils/inject"
+	"go.viam.com/rdk/utils"
 )
 
 func TestObstacleDist(t *testing.T) {
+	// Setting a global in utils is unsafe, and was originally in an init() which causes races.
+	// This is still not ideal, but as this is the only test function in this package, it should be okay for now.
+	origParallelFactor := utils.ParallelFactor
+	utils.ParallelFactor = 1
+	defer func() {
+		utils.ParallelFactor = origParallelFactor
+	}()
+
 	inp := DistanceDetectorConfig{
 		NumQueries: 10,
 	}

--- a/utils/parallel.go
+++ b/utils/parallel.go
@@ -16,7 +16,7 @@ import (
 
 // ParallelFactor controls the max level of parallelization. This might be useful
 // to set in tests where too much parallelism actually slows tests down in
-// aggregate.
+// aggregate. MUST NOT be used with t.Parallel() or via init()!
 var ParallelFactor = runtime.GOMAXPROCS(0)
 
 func init() {

--- a/vision/segmentation/chunks_test.go
+++ b/vision/segmentation/chunks_test.go
@@ -10,12 +10,7 @@ import (
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/rimage"
 	"go.viam.com/rdk/rimage/transform"
-	"go.viam.com/rdk/utils"
 )
-
-func init() {
-	utils.ParallelFactor = 1
-}
 
 type chunkImageDebug struct{}
 

--- a/vision/segmentation/er_ccl_clustering_test.go
+++ b/vision/segmentation/er_ccl_clustering_test.go
@@ -20,7 +20,12 @@ import (
 )
 
 func TestERCCL(t *testing.T) {
-	t.Parallel()
+	// Setting a global in utils is unsafe, and is likely to cause races. Cannot be used with t.Parallel()
+	origParallelFactor := utils.ParallelFactor
+	utils.ParallelFactor = 1
+	defer func() {
+		utils.ParallelFactor = origParallelFactor
+	}()
 	logger := logging.NewTestLogger(t)
 	injectCamera := &inject.Camera{}
 	injectCamera.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {

--- a/vision/segmentation/plane_segmentation.go
+++ b/vision/segmentation/plane_segmentation.go
@@ -202,9 +202,9 @@ func findBestEq(ctx context.Context, cloud pc.PointCloud, nIterations int, equat
 						}
 					}
 					// if the current plane contains more pixels than the previously stored one, save this one as the biggest plane
+					groupMu.Lock()
+					defer groupMu.Unlock()
 					if currentInliers > bestInliers {
-						groupMu.Lock()
-						defer groupMu.Unlock()
 						bestEquation = currentEquation
 						bestInliers = currentInliers
 					}

--- a/vision/segmentation/plane_segmentation_test.go
+++ b/vision/segmentation/plane_segmentation_test.go
@@ -19,11 +19,13 @@ import (
 	"go.viam.com/rdk/rimage/transform"
 )
 
-func init() {
-	sortPositions = true
-}
-
 func TestPlaneConfig(t *testing.T) {
+	// Setting a global, so cannot use t.Parallel()
+	sortPositions = true
+	defer func() {
+		sortPositions = false
+	}()
+
 	cfg := VoxelGridPlaneConfig{}
 	// invalid weight threshold
 	cfg.WeightThresh = -2.
@@ -51,6 +53,12 @@ func TestPlaneConfig(t *testing.T) {
 }
 
 func TestSegmentPlaneWRTGround(t *testing.T) {
+	// Setting a global, so cannot use t.Parallel()
+	sortPositions = true
+	defer func() {
+		sortPositions = false
+	}()
+
 	// get depth map
 	d, err := rimage.NewDepthMapFromFile(
 		context.Background(),
@@ -84,6 +92,12 @@ func TestSegmentPlaneWRTGround(t *testing.T) {
 }
 
 func TestSegmentPlane(t *testing.T) {
+	// Setting a global, so cannot use t.Parallel()
+	sortPositions = true
+	defer func() {
+		sortPositions = false
+	}()
+
 	// Intel Sensor Extrinsic data from manufacturer
 	// Intel sensor depth 1024x768 to  RGB 1280x720
 	// Translation Vector : [-0.000828434,0.0139185,-0.0033418]
@@ -129,6 +143,12 @@ func TestSegmentPlane(t *testing.T) {
 }
 
 func TestDepthMapToPointCloud(t *testing.T) {
+	// Setting a global, so cannot use t.Parallel()
+	sortPositions = true
+	defer func() {
+		sortPositions = false
+	}()
+
 	d, err := rimage.NewDepthMapFromFile(
 		context.Background(),
 		artifact.MustPath("vision/segmentation/pointcloudsegmentation/align-test-1615172036.png"))
@@ -142,7 +162,12 @@ func TestDepthMapToPointCloud(t *testing.T) {
 }
 
 func TestProjectPlane3dPointsToRGBPlane(t *testing.T) {
-	t.Parallel()
+	// Setting a global, so cannot use t.Parallel()
+	sortPositions = true
+	defer func() {
+		sortPositions = false
+	}()
+
 	rgb, err := rimage.NewImageFromFile(artifact.MustPath("vision/segmentation/pointcloudsegmentation/align-test-1615172036_color.png"))
 	test.That(t, err, test.ShouldBeNil)
 	d, err := rimage.NewDepthMapFromFile(
@@ -182,6 +207,12 @@ func TestProjectPlane3dPointsToRGBPlane(t *testing.T) {
 }
 
 func BenchmarkPlaneSegmentPointCloud(b *testing.B) {
+	// Setting a global, so cannot use t.Parallel()
+	sortPositions = true
+	defer func() {
+		sortPositions = false
+	}()
+
 	d, err := rimage.NewDepthMapFromFile(
 		context.Background(),
 		artifact.MustPath("vision/segmentation/pointcloudsegmentation/align-test-1615172036.png"))
@@ -202,6 +233,12 @@ func BenchmarkPlaneSegmentPointCloud(b *testing.B) {
 }
 
 func TestPointCloudSplit(t *testing.T) {
+	// Setting a global, so cannot use t.Parallel()
+	sortPositions = true
+	defer func() {
+		sortPositions = false
+	}()
+
 	// make a simple point cloud
 	cloud := pc.New()
 	var err error


### PR DESCRIPTION
tl;dr This attempts to fix some issues around using go 1.21 and testing.

Problem 1: Go 1.21 now imports and init()s packages in a well-defined order. This breaks some stuff in vision that was using init() to set global vars during testing. This attempts to fix those issues as they are effectively "bugs."

Problem 2: A secondary problem is that go test with "-coverprofile" enabled runs *very* slow when combined with "-race" and that problem magnifies the more concurrent processes there are. To fix this, the test.sh and makefile are updated to run seperate -race and then -coverprofile test runs.

These sum to the fact that, due to *bad* behavior happening (e.g. one test/file was setting a global, and it was being applied to ALL tests in the package) we were getting away with the coverage tests not slowing as much. When go1.21 changed things, it exposed this problem, as the segmenter tests were now running truly parallel... which made coverage much slower, even though regular go tests (with OR without -race) are much faster.

The overall test times (with the now-split test runs) are just about the same overall as the previous (wrongly behaving) cover+race test. The good news is, these can/should potentially be split in CI, so they can run in parallel, and can likely reduce the overall CI testing time (in terms of human wait.)

```
This PR go119
#go clean -testcache && time make cover
real	6m25.573s
user	52m59.433s
sys	2m27.864s
```
```
This PR go121
#go clean -testcache && time make cover
real	7m12.095s
user	62m22.795s
sys	2m17.161s
```
```
Tihis PR go121
#go clean -testcache && time make test-go
real	5m16.975s
user	46m52.478s
sys	1m24.302s
```
```
This PR go121 (hacked to not run test-go first as part of "cover")
#go clean -testcache && time make cover
real	2m44.033s
user	18m49.432s
sys	0m55.633s
```
```
Main go119
#go clean -testcache && time make cover (FAILED repeatedly on my machine, due to a bug fix included here)
real	5m51.762s
user	43m35.917s
sys	1m34.114s
```
```
Main go121
#go clean -testcache && time make cover
real	9m51.232s
user	47m31.321s
sys	1m49.398s
```

## test.yml changes
- I parallelized `make cover-only` and `make test-go` per James' speedup suggestion
- see screenshots below for timing. tldr, an arbitrary run of main branch took 20:33 in its longest step, this takes about 15
- sample run here https://github.com/viamrobotics/rdk/actions/runs/7205015526

![image](https://github.com/viamrobotics/rdk/assets/7256523/13e3d706-88a4-470e-8d26-2ecf4cfba405)

![mainyml](https://github.com/viamrobotics/rdk/assets/7256523/e3d1bb0d-3285-4a52-b82f-716de4eba19e)
