### PR TITLE
RSDK-5929: Add tensor names and sizes to logs for easier debugging upon mlmodel failure

### DIFF
--- a/services/vision/mlvision/ml_model.go
+++ b/services/vision/mlvision/ml_model.go
@@ -5,6 +5,7 @@ package mlvision
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"math"
 	"os"
 	"path/filepath"
@@ -132,6 +133,23 @@ func registerMLModelVisionService(
 	if errList[0] != nil && errList[1] != nil && errList[2] != nil {
 		for _, e := range errList {
 			logger.Error(e)
+		}
+		md, err := mlm.Metadata(ctx)
+		if err != nil {
+			logger.Error("could not get metadata from the model")
+		} else {
+			inputs := ""
+			for _, tensor := range md.Inputs {
+				inputs += fmt.Sprintf("%s(%v) ", tensor.Name, tensor.Shape)
+			}
+			outputs := ""
+			for _, tensor := range md.Outputs {
+				outputs += fmt.Sprintf("%s(%v) ", tensor.Name, tensor.Shape)
+			}
+			logger.Infow("the model has the following input and outputs tensors, name(shape)",
+				"inputs", inputs,
+				"outputs", outputs,
+			)
 		}
 	}
 


### PR DESCRIPTION
Sometimes, the shapes or names of the output tensors do not match what ml model expects. 

<img width="1398" alt="Screenshot 2023-12-14 at 2 43 51 PM" src="https://github.com/viamrobotics/rdk/assets/8298653/883517ca-705a-469a-a192-c3d483cd3a7a">

Like in the following example, the input tensor is called "input_tensor" and not "image". And there are more output tensors than necessary for the ml model, and it didn't know that "detection_boxes" or "detection_classes" were where the relevant info was stored. 

Now that the logs shows the names and shapes of the output tensors, it will be easier to rename the output tensors and have the models work with the mlmodel service. In the config for the triton model, I can now do
```
        "tensor_name_remappings": {
          "inputs": {
            "input_tensor": "image"
          },
          "outputs": {
            "detection_scores": "score",
            "detection_boxes": "location",
            "detection_classes": "category"
          }
```
which will fix the problem and the model will work

