### PR TITLE
Add ref to module build start

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -41,6 +41,7 @@ const (
 	moduleFlagForce           = "force"
 
 	moduleBuildFlagPath     = "module"
+	moduleBuildFlagRef      = "ref"
 	moduleBuildFlagCount    = "count"
 	moduleBuildFlagVersion  = "version"
 	moduleBuildFlagBuildID  = "id"
@@ -1124,6 +1125,11 @@ Example:
 									Name:     moduleBuildFlagVersion,
 									Usage:    "version of the module to upload (semver2.0) ex: \"0.1.0\"",
 									Required: true,
+								},
+								&cli.StringFlag{
+									Name:  moduleBuildFlagRef,
+									Usage: "git ref to clone when building your module. This can be a branch name or a commit hash",
+									Value: "main",
 								},
 							},
 							Action: ModuleBuildStartAction,

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -54,7 +54,8 @@ func (c *viamClient) moduleBuildStartAction(cCtx *cli.Context) error {
 	if len(platforms) == 0 {
 		platforms = defaultBuildInfo.Arch
 	}
-	res, err := c.startBuild(manifest.URL, "main", manifest.ModuleID, platforms, version)
+	gitRef := cCtx.String(moduleBuildFlagRef)
+	res, err := c.startBuild(manifest.URL, gitRef, manifest.ModuleID, platforms, version)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
```
➜  cli git:(zp/refcli) ✗ viam module build start --help
NAME:
   viam module build start

USAGE:
   viam module build start [command options] [arguments...]

DESCRIPTION:
   start a remote build

OPTIONS:
   --module value   path to meta.json (default: "./meta.json")
   --ref value      git ref to clone when building your module. This can be a branch name or a commit hash (default: "main")
   --version value  version of the module to upload (semver2.0) ex: "0.1.0"
```