### PR TITLE
RSDK-5962 Double Click Generates 2x Live Mapping Sessions

### DIFF
--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -254,7 +254,9 @@
 
       try {
         hasActiveSession = true;
-        sessionId = await overrides.startMappingSession(mapName);
+        if (!mappingSessionStarted) {
+          sessionId = await overrides.startMappingSession(mapName);
+        }
         mappingSessionStarted = true;
         startMappingIntervals(Date.now());
       } catch {

--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -255,10 +255,10 @@
       try {
         hasActiveSession = true;
         if (!mappingSessionStarted) {
-          sessionId = await overrides.startMappingSession(mapName);
+          mappingSessionStarted = true;
+          sessionId = await overrides.startMappingSession(mapName)
+          startMappingIntervals(Date.now());
         }
-        mappingSessionStarted = true;
-        startMappingIntervals(Date.now());
       } catch {
         hasActiveSession = false;
         sessionDuration = 0;

--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -261,6 +261,7 @@
         }
       } catch {
         hasActiveSession = false;
+        mappingSessionStarted = false;
         sessionDuration = 0;
         clearInterval(durationInterval);
       }


### PR DESCRIPTION
Prevents double clicking on `Start Session` from generating multiple live cloud SLAM sessions

**JIRA Ticket:** https://viam.atlassian.net/browse/RSDK-5962

**Related PRs:** https://github.com/viamrobotics/app/pull/3160