### PR TITLE
RSDK-6076: prevent panic. 

### DIFF
--- a/components/movementsensor/gpsrtkserial/gpsrtkserial.go
+++ b/components/movementsensor/gpsrtkserial/gpsrtkserial.go
@@ -445,7 +445,7 @@ func (g *rtkSerial) connectAndParseSourceTable() error {
 func (g *rtkSerial) connectToNTRIP() error {
 	select {
 	case <-g.cancelCtx.Done():
-		return errors.New("Canceled")
+		return errors.New("context canceled")
 	default:
 	}
 	err := g.connectAndParseSourceTable()

--- a/components/movementsensor/gpsrtkserial/gpsrtkserial.go
+++ b/components/movementsensor/gpsrtkserial/gpsrtkserial.go
@@ -443,6 +443,11 @@ func (g *rtkSerial) connectAndParseSourceTable() error {
 
 // connectToNTRIP connects to NTRIP stream.
 func (g *rtkSerial) connectToNTRIP() error {
+	select {
+	case <-g.cancelCtx.Done():
+		return errors.New("Canceled")
+	default:
+	}
 	err := g.connectAndParseSourceTable()
 	if err != nil {
 		return g.err.Get()

--- a/components/movementsensor/gpsrtkserial/gpsrtkserial.go
+++ b/components/movementsensor/gpsrtkserial/gpsrtkserial.go
@@ -35,6 +35,7 @@ import (
 	"bufio"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"math"
 	"strings"
@@ -333,6 +334,7 @@ func (g *rtkSerial) getStream(mountPoint string, maxAttempts int) error {
 		// if the error is related to ICY, we log it as warning.
 		if strings.Contains(err.Error(), "ICY") {
 			g.logger.Warnf("Detected old HTTP protocol: %s", err)
+			g.err.Set(err)
 		} else {
 			g.logger.Errorf("Can't connect to NTRIP stream: %s", err)
 			return err
@@ -399,6 +401,7 @@ func (g *rtkSerial) connectAndParseSourceTable() error {
 
 	g.urlMutex.Lock()
 	defer g.urlMutex.Unlock()
+
 	err := g.connect(g.ntripClient.URL, g.ntripClient.Username, g.ntripClient.Password, g.ntripClient.MaxConnectAttempts)
 	if err != nil {
 		g.err.Set(err)
@@ -406,7 +409,20 @@ func (g *rtkSerial) connectAndParseSourceTable() error {
 	}
 
 	if !g.ntripClient.Client.IsCasterAlive() {
-		g.logger.Infof("caster %s seems to be down", g.ntripClient.URL)
+		g.logger.Infof("caster %s seems to be down, retrying", g.ntripClient.URL)
+		attempts := 0
+		// we will try to connect to the caster five times if it's down.
+		for attempts < 5 {
+			if !g.ntripClient.Client.IsCasterAlive() {
+				attempts++
+				g.logger.Debugf("attempt(s) to connect to caster: %v ", attempts)
+			} else {
+				break
+			}
+		}
+		if attempts == 5 {
+			return fmt.Errorf("caster %s is down", g.ntripClient.URL)
+		}
 	}
 
 	g.logger.Debug("gettting source table")
@@ -692,6 +708,7 @@ func (g *rtkSerial) Close(ctx context.Context) error {
 	g.ntripMu.Lock()
 	g.cancelFunc()
 
+	g.logger.Debug("Closing GPS RTK Serial")
 	if err := g.nmeamovementsensor.Close(ctx); err != nil {
 		g.ntripMu.Unlock()
 		return err
@@ -727,6 +744,8 @@ func (g *rtkSerial) Close(ctx context.Context) error {
 	if err := g.err.Get(); err != nil && !errors.Is(err, context.Canceled) {
 		return err
 	}
+
+	g.logger.Debug("GPS RTK Serial is closed")
 	return nil
 }
 


### PR DESCRIPTION
Background: 
Sometimes ntrip caster connection is flaky. We rely on getting ntrip stream upon successful connection to caster. This flaky connection causes panic later in the code.

To prevent this, I added a retry logic where we will check for a successful connection 5 times and if we fail after that, we can error out of the function. This prevents the panic later in the code since most flaky connection is resolved within 3 tries. 

This PR also includes fixes for https://viam.atlassian.net/browse/RSDK-6077 and https://viam.atlassian.net/browse/RSDK-6078. 