### PR TITLE
RSDK-6068 Add debug logger statements to wheeled_odometry and merged movement sensor

### DIFF
--- a/components/movementsensor/merged/merged.go
+++ b/components/movementsensor/merged/merged.go
@@ -101,14 +101,15 @@ func (m *merged) Reconfigure(ctx context.Context, deps resource.Dependencies, co
 
 		for _, name := range names {
 			ms, err := movementsensor.FromDependencies(deps, name)
+			msName := ms.Name().ShortName()
 			if err != nil {
-				logger.Debugf("error getting sensor %v from dependencies", ms.Name().ShortName())
+				logger.Debugf("error getting sensor %v from dependencies", msName)
 				continue
 			}
 
 			props, err := ms.Properties(ctx, nil)
 			if err != nil {
-				logger.Debugf("error in getting sensor %v properties", ms.Name().ShortName())
+				logger.Debugf("error in getting sensor %v properties", msName)
 				continue
 			}
 
@@ -139,6 +140,7 @@ func (m *merged) Reconfigure(ctx context.Context, deps resource.Dependencies, co
 			}
 
 			// we've found the sensor that reports everything we want
+			m.logger.Debugf("using sensor %v as %s sensor", msName, propname)
 			return ms, nil
 		}
 

--- a/components/movementsensor/wheeledodometry/wheeledodometry.go
+++ b/components/movementsensor/wheeledodometry/wheeledodometry.go
@@ -152,6 +152,7 @@ func (o *odometry) Reconfigure(ctx context.Context, deps resource.Dependencies, 
 	if o.baseWidth == 0 || o.wheelCircumference == 0 {
 		return errors.New("base width or wheel circumference are 0, movement sensor cannot be created")
 	}
+	o.logger.Debugf("using base %v for wheeled_odometry sensor", newBase.Name().ShortName())
 
 	// check if new motors have been added, or the existing motors have been changed, and update the motorPairs accorodingly
 	for i := range newConf.LeftMotors {
@@ -185,19 +186,14 @@ func (o *odometry) Reconfigure(ctx context.Context, deps resource.Dependencies, 
 		thisPair := motorPair{left: motorLeft, right: motorRight}
 		if i >= len(o.motors) {
 			o.motors = append(o.motors, thisPair)
-			o.logger.Debugf("using motors %v for wheeled odometery", []string{
-				thisPair.left.Name().ShortName(), thisPair.right.Name().ShortName(),
-			},
-			)
 		} else if (o.motors[i].left.Name().ShortName() != newConf.LeftMotors[i]) ||
 			(o.motors[i].right.Name().ShortName() != newConf.RightMotors[i]) {
 			o.motors[i].left = motorLeft
 			o.motors[i].right = motorRight
-			o.logger.Debugf("using motors %v for wheeled odometery", []string{
-				motorLeft.Name().ShortName(), motorRight.Name().ShortName(),
-			},
-			)
 		}
+		o.logger.Debugf("using motors %v for wheeled odometery",
+			[]string{motorLeft.Name().ShortName(), motorRight.Name().ShortName()})
+
 	}
 
 	if len(o.motors) > 1 {

--- a/components/movementsensor/wheeledodometry/wheeledodometry.go
+++ b/components/movementsensor/wheeledodometry/wheeledodometry.go
@@ -185,10 +185,18 @@ func (o *odometry) Reconfigure(ctx context.Context, deps resource.Dependencies, 
 		thisPair := motorPair{left: motorLeft, right: motorRight}
 		if i >= len(o.motors) {
 			o.motors = append(o.motors, thisPair)
+			o.logger.Debugf("using motors %v for wheeled odometery", []string{
+				thisPair.left.Name().ShortName(), thisPair.right.Name().ShortName(),
+			},
+			)
 		} else if (o.motors[i].left.Name().ShortName() != newConf.LeftMotors[i]) ||
 			(o.motors[i].right.Name().ShortName() != newConf.RightMotors[i]) {
 			o.motors[i].left = motorLeft
 			o.motors[i].right = motorRight
+			o.logger.Debugf("using motors %v for wheeled odometery", []string{
+				motorLeft.Name().ShortName(), motorRight.Name().ShortName(),
+			},
+			)
 		}
 	}
 

--- a/components/movementsensor/wheeledodometry/wheeledodometry.go
+++ b/components/movementsensor/wheeledodometry/wheeledodometry.go
@@ -193,7 +193,6 @@ func (o *odometry) Reconfigure(ctx context.Context, deps resource.Dependencies, 
 		}
 		o.logger.Debugf("using motors %v for wheeled odometery",
 			[]string{motorLeft.Name().ShortName(), motorRight.Name().ShortName()})
-
 	}
 
 	if len(o.motors) > 1 {


### PR DESCRIPTION
This adds a log statement to report which named movement sensor (merged) or base and motor pairs (wheeled odometer) is being used in the list or potential dependences given by the user in the config.