### PR TITLE
Replace `useDisconnect` hook with `useConnect`.

### DIFF
--- a/web/frontend/src/components/arm/index.svelte
+++ b/web/frontend/src/components/arm/index.svelte
@@ -26,7 +26,7 @@ export let status: {
   end_position: Record<string, number>
   joint_positions: { values: number[] }
 } | undefined;
-export let onStop: StopCallback
+export let onStop: StopCallback | undefined = undefined
 
 const { robotClient } = useRobotClient();
 
@@ -249,7 +249,7 @@ const armCopyJoints = () => {
   }, {})));
 };
 
-onStop(stop)
+onStop?.(stop)
 
 </script>
 

--- a/web/frontend/src/components/arm/index.svelte
+++ b/web/frontend/src/components/arm/index.svelte
@@ -5,7 +5,7 @@ import { displayError } from '@/lib/error';
 import { roundTo2Decimals } from '@/lib/math';
 import { rcLogConditionally } from '@/lib/log';
 import { useRobotClient } from '@/hooks/robot-client';
-import { useStop } from '@/lib/components/collapse.svelte';
+import { useStop } from '@/lib/components/collapse';
 
 interface ArmStatus {
   pos_pieces: {

--- a/web/frontend/src/components/arm/index.svelte
+++ b/web/frontend/src/components/arm/index.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 import { ArmClient, type Pose, type ServiceError } from '@viamrobotics/sdk';
-import type { StopCallback } from '@/lib/components/collapse.svelte';
 import { copyToClipboard } from '@/lib/copy-to-clipboard';
 import { displayError } from '@/lib/error';
 import { roundTo2Decimals } from '@/lib/math';
 import { rcLogConditionally } from '@/lib/log';
 import { useRobotClient } from '@/hooks/robot-client';
+import { useStop } from '@/lib/components/collapse.svelte';
 
 interface ArmStatus {
   pos_pieces: {
@@ -26,7 +26,6 @@ export let status: {
   end_position: Record<string, number>
   joint_positions: { values: number[] }
 } | undefined;
-export let onStop: StopCallback | undefined = undefined
 
 const { robotClient } = useRobotClient();
 
@@ -87,14 +86,6 @@ let modifyAllStatus: ArmStatus = {
 };
 
 const armClient = new ArmClient($robotClient, name, { requestLogger: rcLogConditionally });
-
-const stop = async () => {
-  try {
-    await armClient.stop();
-  } catch (error) {
-    displayError(error as ServiceError);
-  }
-};
 
 const armModifyAllDoEndPosition = async () => {
   const newPieces = modifyAllStatus.pos_pieces;
@@ -249,7 +240,15 @@ const armCopyJoints = () => {
   }, {})));
 };
 
-onStop?.(stop)
+const { onStop } = useStop()
+
+onStop(async () => {
+  try {
+    await armClient.stop();
+  } catch (error) {
+    displayError(error as ServiceError);
+  }
+})
 
 </script>
 

--- a/web/frontend/src/components/audio-input/index.svelte
+++ b/web/frontend/src/components/audio-input/index.svelte
@@ -2,16 +2,13 @@
 
 import { StreamClient, type ServiceError } from '@viamrobotics/sdk';
 import { displayError } from '@/lib/error';
-import Collapse from '@/lib/components/collapse.svelte';
-import { useRobotClient, useDisconnect } from '@/hooks/robot-client';
+import { useRobotClient, useConnect } from '@/hooks/robot-client';
 
 export let name: string;
 
 const { robotClient } = useRobotClient();
 
 let audio: HTMLAudioElement;
-
-let isOn = false;
 
 const streamClient = new StreamClient($robotClient);
 
@@ -29,52 +26,22 @@ const handleTrack = (event: unknown) => {
   audio.srcObject = eventStream;
 };
 
-const toggleExpand = async () => {
-  isOn = !isOn;
-
+useConnect(() => {
   streamClient.on('track', handleTrack);
+  streamClient.add(name).catch((error) => displayError(error as ServiceError))
 
-  if (isOn) {
-    try {
-      await streamClient.add(name);
-    } catch (error) {
-      displayError(error as ServiceError);
-    }
-    return;
+  return () => {
+    streamClient.remove(name).catch((error) => displayError(error as ServiceError))
+    streamClient.off('track', handleTrack);
   }
-
-  try {
-    await streamClient.remove(name);
-  } catch (error) {
-    displayError(error as ServiceError);
-  }
-};
-
-useDisconnect(() => {
-  streamClient.off('track', handleTrack);
-});
+})
 
 </script>
 
-<Collapse title={name}>
-  <v-breadcrumbs slot="title" crumbs="audio_input" />
-  <div class="h-auto border border-t-0 border-medium p-2">
-    <div class="flex items-center gap-2">
-      <v-switch
-        id="audio-input"
-        label='Listen'
-        value={isOn ? 'on' : 'off'}
-        on:input={toggleExpand}
-      />
-    </div>
-
-    {#if isOn}
-      <audio
-        class='py-2'
-        controls
-        autoplay
-        bind:this={audio}
-      />
-    {/if}
-  </div>
-</Collapse>
+<div class="h-auto border border-t-0 border-medium p-2">
+  <audio
+    class='py-2'
+    controls
+    bind:this={audio}
+  />
+</div>

--- a/web/frontend/src/components/base/index.svelte
+++ b/web/frontend/src/components/base/index.svelte
@@ -10,7 +10,7 @@
   import { clickOutside } from '../../lib/click-outside';
   import { components } from '@/stores/resources';
   import { useConnect, useRobotClient } from '@/hooks/robot-client';
-  import { useStop } from '@/lib/components/collapse.svelte';
+  import { useStop } from '@/lib/components/collapse';
   
   export let name: string;
 
@@ -294,7 +294,7 @@
 
   const { onStop } = useStop()
 
-  onStop(() => stop())
+  onStop(stop)
 
   useConnect(() => {
     for (const camera of cameras) {

--- a/web/frontend/src/components/base/index.svelte
+++ b/web/frontend/src/components/base/index.svelte
@@ -13,7 +13,7 @@
   import type { StopCallback } from '@/lib/components/collapse.svelte';
 
   export let name: string;
-  export let onStop: StopCallback
+  export let onStop: StopCallback | undefined = undefined
 
   const enum Keymap {
     LEFT = 'a',
@@ -293,7 +293,7 @@
     }
   };
 
-  onStop(stop)
+  onStop?.(stop)
 
   useConnect(() => {
     for (const camera of cameras) {

--- a/web/frontend/src/components/base/index.svelte
+++ b/web/frontend/src/components/base/index.svelte
@@ -10,10 +10,9 @@
   import { clickOutside } from '../../lib/click-outside';
   import { components } from '@/stores/resources';
   import { useConnect, useRobotClient } from '@/hooks/robot-client';
-  import type { StopCallback } from '@/lib/components/collapse.svelte';
-
+  import { useStop } from '@/lib/components/collapse.svelte';
+  
   export let name: string;
-  export let onStop: StopCallback | undefined = undefined
 
   const enum Keymap {
     LEFT = 'a',
@@ -293,7 +292,9 @@
     }
   };
 
-  onStop?.(stop)
+  const { onStop } = useStop()
+
+  onStop(() => stop())
 
   useConnect(() => {
     for (const camera of cameras) {

--- a/web/frontend/src/components/board/index.svelte
+++ b/web/frontend/src/components/board/index.svelte
@@ -1,21 +1,23 @@
 <script lang="ts">
-
 import { notify } from '@viamrobotics/prime';
 import { displayError } from '@/lib/error';
 import { rcLogConditionally } from '@/lib/log';
 import { BoardClient, type ServiceError } from '@viamrobotics/sdk';
-import Collapse from '@/lib/components/collapse.svelte';
 import { useRobotClient } from '@/hooks/robot-client';
 
 export let name: string;
-export let status: undefined | {
-  analogs: Record<string, { value: number }>
-  digital_interrupts: Record<string, { value: number }>
-};
+export let status:
+  | undefined
+  | {
+      analogs: Record<string, { value: number }>;
+      digital_interrupts: Record<string, { value: number }>;
+    };
 
 const { robotClient } = useRobotClient();
 
-const boardClient = new BoardClient($robotClient, name, { requestLogger: rcLogConditionally });
+const boardClient = new BoardClient($robotClient, name, {
+  requestLogger: rcLogConditionally,
+});
 
 let getPin = '';
 let setPin = '';
@@ -81,7 +83,10 @@ const setPWMFrequency = async () => {
 
 const writeAnalog = async () => {
   try {
-    await boardClient.writeAnalog(writeAnalogPin, Number.parseInt(analogValue, 10));
+    await boardClient.writeAnalog(
+      writeAnalogPin,
+      Number.parseInt(analogValue, 10)
+    );
   } catch (error) {
     displayError(error as ServiceError);
   }
@@ -96,216 +101,192 @@ const readAnalog = async () => {
   }
 };
 
-const handleGetPinInput = (event: CustomEvent<{ value: string}>) => {
+const handleGetPinInput = (event: CustomEvent<{ value: string }>) => {
   getPin = event.detail.value;
 };
 
-const handleSetPinInput = (event: CustomEvent<{ value: string}>) => {
+const handleSetPinInput = (event: CustomEvent<{ value: string }>) => {
   setPin = event.detail.value;
 };
 
-const handlePwmInput = (event: CustomEvent<{ value: string}>) => {
+const handlePwmInput = (event: CustomEvent<{ value: string }>) => {
   pwm = event.detail.value;
 };
 
-const handlePwmFrequencyInput = (event: CustomEvent<{ value: string}>) => {
+const handlePwmFrequencyInput = (event: CustomEvent<{ value: string }>) => {
   pwmFrequency = event.detail.value;
 };
 
-const handleWriteAnalogPinInput = (event:CustomEvent<{ value: string}>) => {
+const handleWriteAnalogPinInput = (event: CustomEvent<{ value: string }>) => {
   writeAnalogPin = event.detail.value;
 };
 
-const handleWriteAnalogValueInput = (event:CustomEvent<{ value: string}>) => {
+const handleWriteAnalogValueInput = (event: CustomEvent<{ value: string }>) => {
   analogValue = event.detail.value;
 };
 
-const handleReadAnalogPinInput = (event:CustomEvent<{ value: string}>) => {
+const handleReadAnalogPinInput = (event: CustomEvent<{ value: string }>) => {
   analogPinName = event.detail.value;
 };
-
 </script>
 
-<Collapse title={name}>
-  <v-breadcrumbs
-    slot="title"
-    crumbs="board"
-  />
-  <div class="overflow-auto border border-t-0 border-medium p-4">
-    <h3 class="mb-2">
-      Analogs
-    </h3>
-    <table class="mb-4 table-auto border border-medium">
-      {#each Object.entries(status?.analogs ?? {}) as [analogName, analog] (analogName)}
-        <tr>
-          <th class="border border-medium p-2">
-            {analogName}
-          </th>
-          <td class="border border-medium p-2">
-            {analog.value || 0}
-          </td>
-        </tr>
-      {/each}
-    </table>
-
-    <h3 class="mb-2">
-      Digital Interrupts
-    </h3>
-    <table class="mb-4 w-full table-auto border border-medium">
-      {#each Object.entries(status?.digital_interrupts ?? {}) as [interruptName, interrupt] (interruptName)}
-        <tr>
-          <th class="border border-medium p-2">
-            {interruptName}
-          </th>
-          <td class="border border-medium p-2">
-            {interrupt.value || 0}
-          </td>
-        </tr>
-      {/each}
-    </table>
-
-    <h3 class="mb-2">
-      GPIO
-    </h3>
-    <table class="mb-4 w-full table-auto border border-medium">
+<div class="overflow-auto border border-t-0 border-medium p-4">
+  <h3 class="mb-2">Analogs</h3>
+  <table class="mb-4 table-auto border border-medium">
+    {#each Object.entries(status?.analogs ?? {}) as [analogName, analog] (analogName)}
       <tr>
         <th class="border border-medium p-2">
-          Get
+          {analogName}
         </th>
         <td class="border border-medium p-2">
-          <div class="flex flex-wrap items-end gap-2">
-            <v-input
-              label="Pin"
-              type="text"
-              value={getPin}
-              on:input={handleGetPinInput}
-            />
-            <v-button
-              label="Get Pin State"
-              on:click={getGPIO}
-            />
-            <v-button
-              label="Get PWM Duty Cycle"
-              on:click={getPWM}
-            />
-            <v-button
-              label="Get PWM Frequency"
-              on:click={getPWMFrequency}
-            />
-            <span class="py-2">
-              {getPinMessage}
-            </span>
-          </div>
+          {analog.value || 0}
         </td>
       </tr>
-      <tr>
-        <th class="border border-medium p-2">
-          Set
-        </th>
-        <td class="p-2">
-          <div class="flex flex-wrap items-end gap-2">
-            <v-input
-              value={setPin}
-              type="text"
-              class="mr-2"
-              label="Pin"
-              on:input={handleSetPinInput}
-            />
-            <select
-              bind:value={setLevel}
-              class="mr-2 h-[30px] border border-medium bg-white text-sm"
-            >
-              <option>low</option>
-              <option>high</option>
-            </select>
-            <v-button
-              class="mr-2"
-              label="Set Pin State"
-              on:click={setGPIO}
-            />
-            <v-input
-              value={pwm}
-              label="PWM Duty Cycle"
-              type="number"
-              class="mr-2"
-              on:input={handlePwmInput}
-            />
-            <v-button
-              class="mr-2"
-              label="Set PWM Duty Cycle"
-              on:click={setPWM}
-            />
-            <v-input
-              value={pwmFrequency}
-              label="PWM Frequency"
-              type="number"
-              class="mr-2"
-              on:input={handlePwmFrequencyInput}
-            />
-            <v-button
-              class="mr-2"
-              label="Set PWM Frequency"
-              on:click={setPWMFrequency}
-            />
-          </div>
-        </td>
-      </tr>
-    </table>
+    {/each}
+  </table>
 
-    <h3 class="mb-2">
-      Analogs
-     </h3>
-     <table class="mb-4 w-full table-auto border border-medium">
+  <h3 class="mb-2">Digital Interrupts</h3>
+  <table class="mb-4 w-full table-auto border border-medium">
+    {#each Object.entries(status?.digital_interrupts ?? {}) as [interruptName, interrupt] (interruptName)}
       <tr>
         <th class="border border-medium p-2">
-          Get
+          {interruptName}
         </th>
-        <td class="p-2">
-          <div class="flex flex-wrap items-end gap-2">
-               <v-input
-                 label="Pin"
-                 type="text"
-                 value={analogPinName}
-                 on:input={handleReadAnalogPinInput}
-               />
-             <v-button
-             class="mr-2"
-             label="Get Analog Value"
-             on:click={readAnalog}
-           />
-           <span class="py-2">
-            {readAnalogMessage}
-            </span>
-          </div>
+        <td class="border border-medium p-2">
+          {interrupt.value || 0}
         </td>
       </tr>
-      <tr>
-     <th class="border border-medium p-2">
-          Set
-        </th>
-       <td class="border border-medium p-2">
-       <div class="flex flex-wrap items-end gap-2">
-         <v-input
-           label="Pin"
-           type="text"
-           value={writeAnalogPin}
-           on:input={handleWriteAnalogPinInput}
-         />
-         <v-input
-         label="Value"
-         type="text"
-         value={analogValue}
-         on:input={handleWriteAnalogValueInput}
-       />
-       <v-button
-       class="mr-2"
-       label="Set Analog Value"
-       on:click={writeAnalog}
-      />
+    {/each}
+  </table>
+
+  <h3 class="mb-2">GPIO</h3>
+  <table class="mb-4 w-full table-auto border border-medium">
+    <tr>
+      <th class="border border-medium p-2"> Get </th>
+      <td class="border border-medium p-2">
+        <div class="flex flex-wrap items-end gap-2">
+          <v-input
+            label="Pin"
+            type="text"
+            value={getPin}
+            on:input={handleGetPinInput}
+          />
+          <v-button
+            label="Get Pin State"
+            on:click={getGPIO}
+          />
+          <v-button
+            label="Get PWM Duty Cycle"
+            on:click={getPWM}
+          />
+          <v-button
+            label="Get PWM Frequency"
+            on:click={getPWMFrequency}
+          />
+          <span class="py-2">
+            {getPinMessage}
+          </span>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th class="border border-medium p-2"> Set </th>
+      <td class="p-2">
+        <div class="flex flex-wrap items-end gap-2">
+          <v-input
+            value={setPin}
+            type="text"
+            class="mr-2"
+            label="Pin"
+            on:input={handleSetPinInput}
+          />
+          <select
+            bind:value={setLevel}
+            class="mr-2 h-[30px] border border-medium bg-white text-sm"
+          >
+            <option>low</option>
+            <option>high</option>
+          </select>
+          <v-button
+            class="mr-2"
+            label="Set Pin State"
+            on:click={setGPIO}
+          />
+          <v-input
+            value={pwm}
+            label="PWM Duty Cycle"
+            type="number"
+            class="mr-2"
+            on:input={handlePwmInput}
+          />
+          <v-button
+            class="mr-2"
+            label="Set PWM Duty Cycle"
+            on:click={setPWM}
+          />
+          <v-input
+            value={pwmFrequency}
+            label="PWM Frequency"
+            type="number"
+            class="mr-2"
+            on:input={handlePwmFrequencyInput}
+          />
+          <v-button
+            class="mr-2"
+            label="Set PWM Frequency"
+            on:click={setPWMFrequency}
+          />
+        </div>
+      </td>
+    </tr>
+  </table>
+
+  <h3 class="mb-2">Analogs</h3>
+  <table class="mb-4 w-full table-auto border border-medium">
+    <tr>
+      <th class="border border-medium p-2"> Get </th>
+      <td class="p-2">
+        <div class="flex flex-wrap items-end gap-2">
+          <v-input
+            label="Pin"
+            type="text"
+            value={analogPinName}
+            on:input={handleReadAnalogPinInput}
+          />
+          <v-button
+            class="mr-2"
+            label="Get Analog Value"
+            on:click={readAnalog}
+          />
+          <span class="py-2">
+            {readAnalogMessage}
+          </span>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th class="border border-medium p-2"> Set </th>
+      <td class="border border-medium p-2">
+        <div class="flex flex-wrap items-end gap-2">
+          <v-input
+            label="Pin"
+            type="text"
+            value={writeAnalogPin}
+            on:input={handleWriteAnalogPinInput}
+          />
+          <v-input
+            label="Value"
+            type="text"
+            value={analogValue}
+            on:input={handleWriteAnalogValueInput}
+          />
+          <v-button
+            class="mr-2"
+            label="Set Analog Value"
+            on:click={writeAnalog}
+          />
         </div>
       </td>
     </tr>
   </table>
 </div>
-
-</Collapse>

--- a/web/frontend/src/components/camera/camera-manager.ts
+++ b/web/frontend/src/components/camera/camera-manager.ts
@@ -1,5 +1,6 @@
 import { CameraClient, type ServiceError, StreamClient, type Client } from '@viamrobotics/sdk';
 import { displayError } from '../../lib/error';
+import { rcLogConditionally } from '@/lib/log';
 
 export class CameraManager {
   cameraClient: CameraClient;
@@ -13,7 +14,7 @@ export class CameraManager {
     public streamCount = 0,
     public videoStream: MediaStream = new MediaStream()
   ) {
-    this.cameraClient = new CameraClient(client, cameraName);
+    this.cameraClient = new CameraClient(client, cameraName, { requestLogger: rcLogConditionally });
   }
 
   addStream () {

--- a/web/frontend/src/components/camera/camera.svelte
+++ b/web/frontend/src/components/camera/camera.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
 
-import { onMount } from 'svelte';
 import { displayError } from '@/lib/error';
 import { CameraClient, type ServiceError } from '@viamrobotics/sdk';
 import { selectedMap } from '@/lib/camera-state';
-import { useRobotClient, useDisconnect } from '@/hooks/robot-client';
+import { useRobotClient, useConnect } from '@/hooks/robot-client';
 
 export let cameraName: string;
 export let showExportScreenshot: boolean;
@@ -55,25 +54,25 @@ const exportScreenshot = async () => {
   window.open(URL.createObjectURL(blob), '_blank');
 };
 
-onMount(() => {
+useConnect(() => {
   videoEl.srcObject = cameraManager.videoStream;
 
   cameraManager.onOpen = () => {
     videoEl.srcObject = cameraManager.videoStream;
   };
-});
 
-useDisconnect(() => {
-  if (isLive) {
-    cameraManager.removeStream();
+  return () => {
+    if (isLive) {
+      cameraManager.removeStream();
+    }
+
+    cameraManager.onOpen = undefined;
+
+    isLive = false;
+
+    clearFrameInterval();
   }
-
-  cameraManager.onOpen = undefined;
-
-  isLive = false;
-
-  clearFrameInterval();
-});
+})
 
 // on refreshRate change update camera and manage live connections
 $: {

--- a/web/frontend/src/components/camera/index.svelte
+++ b/web/frontend/src/components/camera/index.svelte
@@ -38,12 +38,7 @@ const handleRefreshInput = (name: string) => {
 </script>
 
 {#each resources as camera (camera.name)}
-  <Collapse title={camera.name}>
-    <v-breadcrumbs
-      slot="title"
-      crumbs="camera"
-    />
-
+  <Collapse title={camera.name} crumbs='camera'>
     <div class="flex flex-col gap-4 border border-t-0 border-medium p-4">
       <v-switch
         label={`View ${camera.name}`}

--- a/web/frontend/src/components/do-command/index.svelte
+++ b/web/frontend/src/components/do-command/index.svelte
@@ -4,7 +4,6 @@ import { commonApi } from '@viamrobotics/sdk';
 import { notify } from '@viamrobotics/prime';
 import { resourceNameToString } from '@/lib/resource';
 import { doCommand } from '@/api/do-command';
-import Collapse from '@/lib/components/collapse.svelte';
 import { useRobotClient } from '@/hooks/robot-client';
 
 export let resources: commonApi.ResourceName.AsObject[];
@@ -66,50 +65,48 @@ const namesToPrettySelect = (resourcesToPretty: commonApi.ResourceName.AsObject[
 
 </script>
 
-<Collapse title="DoCommand()">
-  <div class="h-full w-full border border-t-0 border-medium p-4">
-    <v-select
-      label="Selected component"
-      placeholder="Select a component"
-      options={namesToPrettySelect(resources)}
-      value={selectedComponent}
-      disabled={executing ? 'true' : 'false'}
-      class="mb-4"
-      on:input={handleSelectComponent}
-    />
-    <div class="flex h-full w-full flex-row flex-wrap gap-2">
-      <div class="h-full w-full">
-        <p class="text-sm">
-          Input
-        </p>
-        <div class="h-[250px] w-full max-w-full border border-medium p-2">
-          <v-code-editor
-            language="json"
-            value={'{}'}
-            on:input={handleEditorInput}
-          />
-        </div>
-      </div>
-      <div class="flex min-w-[90px] flex-col justify-center">
-        <v-button
-          variant="inverse-primary"
-          label={executing ? 'RUNNING...' : 'DO'}
-          disabled={!selectedComponent || !input || executing ? 'true' : 'false'}
-          on:click={async () => handleDoCommand(selectedComponent, input)}
+<div class="h-full w-full border border-t-0 border-medium p-4">
+  <v-select
+    label="Selected component"
+    placeholder="Select a component"
+    options={namesToPrettySelect(resources)}
+    value={selectedComponent}
+    disabled={executing ? 'true' : 'false'}
+    class="mb-4"
+    on:input={handleSelectComponent}
+  />
+  <div class="flex h-full w-full flex-row flex-wrap gap-2">
+    <div class="h-full w-full">
+      <p class="text-sm">
+        Input
+      </p>
+      <div class="h-[250px] w-full max-w-full border border-medium p-2">
+        <v-code-editor
+          language="json"
+          value={'{}'}
+          on:input={handleEditorInput}
         />
       </div>
-      <div class="h-full w-full">
-        <p class="text-sm">
-          Output
-        </p>
-        <div class="h-[250px] w-full border border-medium p-2">
-          <v-code-editor
-            language="json"
-            value={output}
-            readonly="true"
-          />
-        </div>
+    </div>
+    <div class="flex min-w-[90px] flex-col justify-center">
+      <v-button
+        variant="inverse-primary"
+        label={executing ? 'RUNNING...' : 'DO'}
+        disabled={!selectedComponent || !input || executing ? 'true' : 'false'}
+        on:click={async () => handleDoCommand(selectedComponent, input)}
+      />
+    </div>
+    <div class="h-full w-full">
+      <p class="text-sm">
+        Output
+      </p>
+      <div class="h-[250px] w-full border border-medium p-2">
+        <v-code-editor
+          language="json"
+          value={output}
+          readonly="true"
+        />
       </div>
     </div>
   </div>
-</Collapse>
+</div>

--- a/web/frontend/src/components/gantry/index.svelte
+++ b/web/frontend/src/components/gantry/index.svelte
@@ -3,8 +3,8 @@
 import { gantryApi } from '@viamrobotics/sdk';
 import { displayError } from '@/lib/error';
 import { rcLogConditionally } from '@/lib/log';
-import type { StopCallback } from '@/lib/components/collapse.svelte';
 import { useRobotClient } from '@/hooks/robot-client';
+import { useStop } from '@/lib/components/collapse.svelte';
 
 export let name: string;
 export let status: {
@@ -16,7 +16,6 @@ export let status: {
   lengths_mm: [],
   positions_mm: [],
 };
-export let onStop: StopCallback | undefined = undefined
 
 interface GantryStatus {
   pieces: {
@@ -100,15 +99,15 @@ const gantryModifyAll = () => {
   modifyAll = true;
 };
 
-const stop = () => {
+const { onStop } = useStop()
+
+onStop(() => {
   const req = new gantryApi.StopRequest();
   req.setName(name);
 
   rcLogConditionally(req);
   $robotClient.gantryService.stop(req, displayError);
-};
-
-onStop?.(stop)
+});
 
 </script>
 

--- a/web/frontend/src/components/gantry/index.svelte
+++ b/web/frontend/src/components/gantry/index.svelte
@@ -4,7 +4,7 @@ import { gantryApi } from '@viamrobotics/sdk';
 import { displayError } from '@/lib/error';
 import { rcLogConditionally } from '@/lib/log';
 import { useRobotClient } from '@/hooks/robot-client';
-import { useStop } from '@/lib/components/collapse.svelte';
+import { useStop } from '@/lib/components/collapse';
 
 export let name: string;
 export let status: {

--- a/web/frontend/src/components/gantry/index.svelte
+++ b/web/frontend/src/components/gantry/index.svelte
@@ -16,7 +16,7 @@ export let status: {
   lengths_mm: [],
   positions_mm: [],
 };
-export let onStop: StopCallback
+export let onStop: StopCallback | undefined = undefined
 
 interface GantryStatus {
   pieces: {
@@ -108,7 +108,7 @@ const stop = () => {
   $robotClient.gantryService.stop(req, displayError);
 };
 
-onStop(stop)
+onStop?.(stop)
 
 </script>
 

--- a/web/frontend/src/components/gripper/index.svelte
+++ b/web/frontend/src/components/gripper/index.svelte
@@ -7,7 +7,7 @@ import type { StopCallback } from '@/lib/components/collapse.svelte';
 import { useRobotClient } from '@/hooks/robot-client';
 
 export let name: string;
-export let onStop: StopCallback | undefined;
+export let onStop: StopCallback | undefined = undefined;
 
 const { robotClient } = useRobotClient();
 

--- a/web/frontend/src/components/gripper/index.svelte
+++ b/web/frontend/src/components/gripper/index.svelte
@@ -4,7 +4,7 @@ import { gripperApi } from '@viamrobotics/sdk';
 import { displayError } from '../../lib/error';
 import { rcLogConditionally } from '../../lib/log';
 import { useRobotClient } from '@/hooks/robot-client';
-import { useStop } from '@/lib/components/collapse.svelte';
+import { useStop } from '@/lib/components/collapse';
 
 export let name: string;
 

--- a/web/frontend/src/components/gripper/index.svelte
+++ b/web/frontend/src/components/gripper/index.svelte
@@ -3,21 +3,12 @@
 import { gripperApi } from '@viamrobotics/sdk';
 import { displayError } from '../../lib/error';
 import { rcLogConditionally } from '../../lib/log';
-import type { StopCallback } from '@/lib/components/collapse.svelte';
 import { useRobotClient } from '@/hooks/robot-client';
+import { useStop } from '@/lib/components/collapse.svelte';
 
 export let name: string;
-export let onStop: StopCallback | undefined = undefined;
 
 const { robotClient } = useRobotClient();
-
-const stop = () => {
-  const request = new gripperApi.StopRequest();
-  request.setName(name);
-
-  rcLogConditionally(request);
-  $robotClient.gripperService.stop(request, displayError);
-};
 
 const open = () => {
   const request = new gripperApi.OpenRequest();
@@ -35,7 +26,15 @@ const grab = () => {
   $robotClient.gripperService.grab(request, displayError);
 };
 
-onStop?.(stop)
+const { onStop } = useStop();
+
+onStop(() => {
+  const request = new gripperApi.StopRequest();
+  request.setName(name);
+
+  rcLogConditionally(request);
+  $robotClient.gripperService.stop(request, displayError);
+});
 
 </script>
 

--- a/web/frontend/src/components/gripper/index.svelte
+++ b/web/frontend/src/components/gripper/index.svelte
@@ -3,10 +3,11 @@
 import { gripperApi } from '@viamrobotics/sdk';
 import { displayError } from '../../lib/error';
 import { rcLogConditionally } from '../../lib/log';
-import Collapse from '@/lib/components/collapse.svelte';
+import type { StopCallback } from '@/lib/components/collapse.svelte';
 import { useRobotClient } from '@/hooks/robot-client';
 
 export let name: string;
+export let onStop: StopCallback | undefined;
 
 const { robotClient } = useRobotClient();
 
@@ -34,32 +35,17 @@ const grab = () => {
   $robotClient.gripperService.grab(request, displayError);
 };
 
+onStop?.(stop)
+
 </script>
 
-<Collapse title={name}>
-  <v-breadcrumbs
-    slot="title"
-    crumbs="gripper"
+<div class="flex gap-2 border border-t-0 border-medium p-4">
+  <v-button
+    label="Open"
+    on:click={open}
   />
-  <div
-    slot="header"
-    class="flex items-center justify-between gap-2"
-  >
-    <v-button
-      variant="danger"
-      icon="stop-circle-outline"
-      label="Stop"
-      on:click|stopPropagation={stop}
-    />
-  </div>
-  <div class="flex gap-2 border border-t-0 border-medium p-4">
-    <v-button
-      label="Open"
-      on:click={open}
-    />
-    <v-button
-      label="Grab"
-      on:click={grab}
-    />
-  </div>
-</Collapse>
+  <v-button
+    label="Grab"
+    on:click={grab}
+  />
+</div>

--- a/web/frontend/src/components/input-controller/index.svelte
+++ b/web/frontend/src/components/input-controller/index.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
-
   import type { inputControllerApi } from '@viamrobotics/sdk';
-  import Collapse from '@/lib/components/collapse.svelte';
 
   // TODO (RSDK-4451): Figure out why value is not always defined
   type InputControllerEvent = (Omit<inputControllerApi.Event.AsObject, 'value'> & {value?: number});
@@ -72,29 +70,25 @@
   })(events);
 </script>
 
-<Collapse title={name}>
-  <v-breadcrumbs slot="title" crumbs="input_controller" />
-  <div slot="header" class="flex flex-wrap items-center">
-    {#if connected}
-      <v-badge color="green" label="Connected" />
-    {:else}
-      <v-badge color="gray" label="Disconnected" />
-    {/if}
-  </div>
-  <div class="border border-t-0 border-medium p-4">
-    {#if connected}
-      {#each controls as control (control[0])}
-        <v-input
-          readonly
-          class='w-20'
-          labelposition='left'
-          label={control[0]}
-          value={control[1]}
-        />
-      {/each}
-    {/if}
-  </div>
-</Collapse>
+<div class="border border-t-0 border-medium p-4">
+  {#if connected}
+    <v-badge color="green" label="Connected" />
+  {:else}
+    <v-badge color="gray" label="Disconnected" />
+  {/if}
+
+  {#if connected}
+    {#each controls as control (control[0])}
+      <v-input
+        readonly
+        class='w-20'
+        labelposition='left'
+        label={control[0]}
+        value={control[1]}
+      />
+    {/each}
+  {/if}
+</div>
 
 <style>
   .subtitle {

--- a/web/frontend/src/components/motor/index.svelte
+++ b/web/frontend/src/components/motor/index.svelte
@@ -3,8 +3,8 @@
 import { motorApi, MotorClient, type ServiceError } from '@viamrobotics/sdk';
 import { displayError } from '@/lib/error';
 import { rcLogConditionally } from '@/lib/log';
-import type { StopCallback } from '@/lib/components/collapse.svelte';
 import { useConnect, useRobotClient } from '@/hooks/robot-client';
+import { useStop } from '@/lib/components/collapse.svelte';
 
 export let name: string;
 export let status: undefined | {
@@ -12,7 +12,6 @@ export let status: undefined | {
   position?: number
   is_moving?: boolean
 };
-export let onStop: StopCallback | undefined = undefined;
 
 const motorPosFormat = new Intl.NumberFormat(undefined, {
   maximumFractionDigits: 3,
@@ -173,14 +172,6 @@ const motorRun = async () => {
   }
 };
 
-const motorStop = async () => {
-  try {
-    await motorClient.stop();
-  } catch (error) {
-    displayError(error as ServiceError);
-  }
-};
-
 const init = async () => {
   try {
     properties = await motorClient.getProperties();
@@ -189,8 +180,14 @@ const init = async () => {
   }
 };
 
-onStop?.(() => {
-  motorStop()
+const { onStop } = useStop();
+
+onStop(async () => {
+  try {
+    await motorClient.stop();
+  } catch (error) {
+    displayError(error as ServiceError);
+  }
 })
 
 useConnect(() => {

--- a/web/frontend/src/components/motor/index.svelte
+++ b/web/frontend/src/components/motor/index.svelte
@@ -12,7 +12,7 @@ export let status: undefined | {
   position?: number
   is_moving?: boolean
 };
-export let onStop: StopCallback | undefined
+export let onStop: StopCallback | undefined = undefined;
 
 const motorPosFormat = new Intl.NumberFormat(undefined, {
   maximumFractionDigits: 3,

--- a/web/frontend/src/components/motor/index.svelte
+++ b/web/frontend/src/components/motor/index.svelte
@@ -4,7 +4,7 @@ import { motorApi, MotorClient, type ServiceError } from '@viamrobotics/sdk';
 import { displayError } from '@/lib/error';
 import { rcLogConditionally } from '@/lib/log';
 import { useConnect, useRobotClient } from '@/hooks/robot-client';
-import { useStop } from '@/lib/components/collapse.svelte';
+import { useStop } from '@/lib/components/collapse';
 
 export let name: string;
 export let status: undefined | {
@@ -192,7 +192,6 @@ onStop(async () => {
 
 useConnect(() => {
   init()
-  return () => {}
 })
 
 </script>

--- a/web/frontend/src/components/movement-sensor/index.svelte
+++ b/web/frontend/src/components/movement-sensor/index.svelte
@@ -2,7 +2,6 @@
 
 import { movementSensorApi as movementsensorApi, type ServiceError, type commonApi } from '@viamrobotics/sdk';
 import { displayError } from '@/lib/error';
-import Collapse from '@/lib/components/collapse.svelte';
 import { setAsyncInterval } from '@/lib/schedule';
 import {
   getProperties,
@@ -13,7 +12,7 @@ import {
   getCompassHeading,
   getPosition,
 } from '@/api/movement-sensor';
-import { useRobotClient, useDisconnect } from '@/hooks/robot-client';
+import { useRobotClient, useConnect } from '@/hooks/robot-client';
 
 export let name: string;
 
@@ -27,8 +26,6 @@ let compassHeading: number | undefined;
 let coordinate: commonApi.GeoPoint.AsObject | undefined;
 let altitudeM: number | undefined;
 let properties: movementsensorApi.GetPropertiesResponse.AsObject | undefined;
-
-let clearInterval: (() => void) | undefined;
 
 const refresh = async () => {
   properties = await getProperties($robotClient, name);
@@ -59,220 +56,212 @@ const refresh = async () => {
   }
 };
 
-const handleToggle = (event: CustomEvent<{ open: boolean }>) => {
-  if (event.detail.open) {
-    refresh();
-    clearInterval = setAsyncInterval(refresh, 500);
-  } else {
-    clearInterval?.();
-  }
-};
-
-useDisconnect(() => clearInterval?.());
+useConnect(() => {
+  refresh();
+  const clearInterval = setAsyncInterval(refresh, 500);
+  return () => clearInterval();
+})
 
 </script>
 
-<Collapse title={name} on:toggle={handleToggle}>
-  <v-breadcrumbs slot="title" crumbs="movement_sensor" />
-  <div class="flex flex-wrap gap-4 text-sm border border-t-0 border-medium p-4">
-    {#if properties?.positionSupported}
-      <div class="overflow-auto">
-        <h3 class="mb-1">Position</h3>
-        <table class="w-full border border-t-0 border-medium p-4">
-          <tr>
-            <th class="border border-medium p-2">
-              Latitude
-            </th>
-            <td class="border border-medium p-2">
-              {coordinate?.latitude.toFixed(6)}
-            </td>
-          </tr>
-          <tr>
-            <th class="border border-medium p-2">
-              Longitude
-            </th>
-            <td class="border border-medium p-2">
-              {coordinate?.longitude.toFixed(6)}
-            </td>
-          </tr>
-          <tr>
-            <th class="border border-medium p-2">
-              Altitude (m)
-            </th>
-            <td class="border border-medium p-2">
-              {altitudeM?.toFixed(2)}
-            </td>
-          </tr>
-        </table>
-        <a
-          class="text-[#045681] underline"
-          href={`https://www.google.com/maps/search/${coordinate?.latitude},${coordinate?.longitude}`}
-        >
-          google maps
-        </a>
-      </div>
-    {/if}
+<div class="flex flex-wrap gap-4 text-sm border border-t-0 border-medium p-4">
+  {#if properties?.positionSupported}
+    <div class="overflow-auto">
+      <h3 class="mb-1">Position</h3>
+      <table class="w-full border border-t-0 border-medium p-4">
+        <tr>
+          <th class="border border-medium p-2">
+            Latitude
+          </th>
+          <td class="border border-medium p-2">
+            {coordinate?.latitude.toFixed(6)}
+          </td>
+        </tr>
+        <tr>
+          <th class="border border-medium p-2">
+            Longitude
+          </th>
+          <td class="border border-medium p-2">
+            {coordinate?.longitude.toFixed(6)}
+          </td>
+        </tr>
+        <tr>
+          <th class="border border-medium p-2">
+            Altitude (m)
+          </th>
+          <td class="border border-medium p-2">
+            {altitudeM?.toFixed(2)}
+          </td>
+        </tr>
+      </table>
+      <a
+        class="text-[#045681] underline"
+        href={`https://www.google.com/maps/search/${coordinate?.latitude},${coordinate?.longitude}`}
+      >
+        google maps
+      </a>
+    </div>
+  {/if}
 
-    {#if properties?.orientationSupported}
-      <div class="overflow-auto">
-        <h3 class="mb-1">
-          Orientation (degrees)
-        </h3>
-        <table class="w-full border border-t-0 border-medium p-4">
-          <tr>
-            <th class="border border-medium p-2">
-              OX
-            </th>
-            <td class="border border-medium p-2">
-              {orientation?.oX.toFixed(2)}
-            </td>
-          </tr>
-          <tr>
-            <th class="border border-medium p-2">
-              OY
-            </th>
-            <td class="border border-medium p-2">
-              {orientation?.oY.toFixed(2)}
-            </td>
-          </tr>
-          <tr>
-            <th class="border border-medium p-2">
-              OZ
-            </th>
-            <td class="border border-medium p-2">
-              {orientation?.oZ.toFixed(2)}
-            </td>
-          </tr>
-          <tr>
-            <th class="border border-medium p-2">
-              Theta
-            </th>
-            <td class="border border-medium p-2">
-              {orientation?.theta.toFixed(2)}
-            </td>
-          </tr>
-        </table>
-      </div>
-    {/if}
+  {#if properties?.orientationSupported}
+    <div class="overflow-auto">
+      <h3 class="mb-1">
+        Orientation (degrees)
+      </h3>
+      <table class="w-full border border-t-0 border-medium p-4">
+        <tr>
+          <th class="border border-medium p-2">
+            OX
+          </th>
+          <td class="border border-medium p-2">
+            {orientation?.oX.toFixed(2)}
+          </td>
+        </tr>
+        <tr>
+          <th class="border border-medium p-2">
+            OY
+          </th>
+          <td class="border border-medium p-2">
+            {orientation?.oY.toFixed(2)}
+          </td>
+        </tr>
+        <tr>
+          <th class="border border-medium p-2">
+            OZ
+          </th>
+          <td class="border border-medium p-2">
+            {orientation?.oZ.toFixed(2)}
+          </td>
+        </tr>
+        <tr>
+          <th class="border border-medium p-2">
+            Theta
+          </th>
+          <td class="border border-medium p-2">
+            {orientation?.theta.toFixed(2)}
+          </td>
+        </tr>
+      </table>
+    </div>
+  {/if}
 
-    {#if properties?.angularVelocitySupported}
-      <div class="overflow-auto">
-        <h3 class="mb-1">
-          Angular velocity (degrees/second)
-        </h3>
-        <table class="w-full border border-t-0 border-medium p-4">
-          <tr>
-            <th class="border border-medium p-2">
-              X
-            </th>
-            <td class="border border-medium p-2">
-              {angularVelocity?.x.toFixed(2)}
-            </td>
-          </tr>
-          <tr>
-            <th class="border border-medium p-2">
-              Y
-            </th>
-            <td class="border border-medium p-2">
-              {angularVelocity?.y.toFixed(2)}
-            </td>
-          </tr>
-          <tr>
-            <th class="border border-medium p-2">
-              Z
-            </th>
-            <td class="border border-medium p-2">
-              {angularVelocity?.z.toFixed(2)}
-            </td>
-          </tr>
-        </table>
-      </div>
-    {/if}
+  {#if properties?.angularVelocitySupported}
+    <div class="overflow-auto">
+      <h3 class="mb-1">
+        Angular velocity (degrees/second)
+      </h3>
+      <table class="w-full border border-t-0 border-medium p-4">
+        <tr>
+          <th class="border border-medium p-2">
+            X
+          </th>
+          <td class="border border-medium p-2">
+            {angularVelocity?.x.toFixed(2)}
+          </td>
+        </tr>
+        <tr>
+          <th class="border border-medium p-2">
+            Y
+          </th>
+          <td class="border border-medium p-2">
+            {angularVelocity?.y.toFixed(2)}
+          </td>
+        </tr>
+        <tr>
+          <th class="border border-medium p-2">
+            Z
+          </th>
+          <td class="border border-medium p-2">
+            {angularVelocity?.z.toFixed(2)}
+          </td>
+        </tr>
+      </table>
+    </div>
+  {/if}
 
-    {#if properties?.linearVelocitySupported}
-      <div class="overflow-auto">
-        <h3 class="mb-1">
-          Linear velocity (m/s)
-        </h3>
-        <table class="w-full border border-t-0 border-medium p-4">
-          <tr>
-            <th class="border border-medium p-2">
-              X
-            </th>
-            <td class="border border-medium p-2">
-              {linearVelocity?.x.toFixed(2)}
-            </td>
-          </tr>
-          <tr>
-            <th class="border border-medium p-2">
-              Y
-            </th>
-            <td class="border border-medium p-2">
-              {linearVelocity?.y.toFixed(2)}
-            </td>
-          </tr>
-          <tr>
-            <th class="border border-medium p-2">
-              Z
-            </th>
-            <td class="border border-medium p-2">
-              {linearVelocity?.z.toFixed(2)}
-            </td>
-          </tr>
-        </table>
-      </div>
-    {/if}
+  {#if properties?.linearVelocitySupported}
+    <div class="overflow-auto">
+      <h3 class="mb-1">
+        Linear velocity (m/s)
+      </h3>
+      <table class="w-full border border-t-0 border-medium p-4">
+        <tr>
+          <th class="border border-medium p-2">
+            X
+          </th>
+          <td class="border border-medium p-2">
+            {linearVelocity?.x.toFixed(2)}
+          </td>
+        </tr>
+        <tr>
+          <th class="border border-medium p-2">
+            Y
+          </th>
+          <td class="border border-medium p-2">
+            {linearVelocity?.y.toFixed(2)}
+          </td>
+        </tr>
+        <tr>
+          <th class="border border-medium p-2">
+            Z
+          </th>
+          <td class="border border-medium p-2">
+            {linearVelocity?.z.toFixed(2)}
+          </td>
+        </tr>
+      </table>
+    </div>
+  {/if}
 
-    {#if properties?.linearAccelerationSupported}
-      <div class="overflow-auto">
-        <h3 class="mb-1">
-          Linear acceleration (m/second^2)
-        </h3>
-        <table class="w-full border border-t-0 border-medium p-4">
-          <tr>
-            <th class="border border-medium p-2">
-              X
-            </th>
-            <td class="border border-medium p-2">
-              {linearAcceleration?.x.toFixed(2)}
-            </td>
-          </tr>
-          <tr>
-            <th class="border border-medium p-2">
-              Y
-            </th>
-            <td class="border border-medium p-2">
-              {linearAcceleration?.y.toFixed(2)}
-            </td>
-          </tr>
-          <tr>
-            <th class="border border-medium p-2">
-              Z
-            </th>
-            <td class="border border-medium p-2">
-              {linearAcceleration?.z.toFixed(2)}
-            </td>
-          </tr>
-        </table>
-      </div>
-    {/if}
+  {#if properties?.linearAccelerationSupported}
+    <div class="overflow-auto">
+      <h3 class="mb-1">
+        Linear acceleration (m/second^2)
+      </h3>
+      <table class="w-full border border-t-0 border-medium p-4">
+        <tr>
+          <th class="border border-medium p-2">
+            X
+          </th>
+          <td class="border border-medium p-2">
+            {linearAcceleration?.x.toFixed(2)}
+          </td>
+        </tr>
+        <tr>
+          <th class="border border-medium p-2">
+            Y
+          </th>
+          <td class="border border-medium p-2">
+            {linearAcceleration?.y.toFixed(2)}
+          </td>
+        </tr>
+        <tr>
+          <th class="border border-medium p-2">
+            Z
+          </th>
+          <td class="border border-medium p-2">
+            {linearAcceleration?.z.toFixed(2)}
+          </td>
+        </tr>
+      </table>
+    </div>
+  {/if}
 
-    {#if properties?.compassHeadingSupported}
-      <div class="overflow-auto">
-        <h3 class="mb-1">
-          Compass heading
-        </h3>
-        <table class="w-full border border-t-0 border-medium p-4">
-          <tr>
-            <th class="border border-medium p-2">
-              Compass
-            </th>
-            <td class="border border-medium p-2">
-              {compassHeading?.toFixed(2)}
-            </td>
-          </tr>
-        </table>
-      </div>
-    {/if}
-  </div>
-</Collapse>
+  {#if properties?.compassHeadingSupported}
+    <div class="overflow-auto">
+      <h3 class="mb-1">
+        Compass heading
+      </h3>
+      <table class="w-full border border-t-0 border-medium p-4">
+        <tr>
+          <th class="border border-medium p-2">
+            Compass
+          </th>
+          <td class="border border-medium p-2">
+            {compassHeading?.toFixed(2)}
+          </td>
+        </tr>
+      </table>
+    </div>
+  {/if}
+</div>

--- a/web/frontend/src/components/navigation/hooks/use-base-pose.ts
+++ b/web/frontend/src/components/navigation/hooks/use-base-pose.ts
@@ -3,7 +3,7 @@ import type { GeoPose } from '@viamrobotics/prime-blocks';
 import { useNavClient } from './use-nav-client';
 import { writable, get } from 'svelte/store';
 import { setAsyncInterval } from '@/lib/schedule';
-import { useDisconnect } from '@/hooks/robot-client';
+import { useConnect } from '@/hooks/robot-client';
 
 export const useBasePose = (name: string) => {
   const navClient = useNavClient(name);
@@ -35,10 +35,11 @@ export const useBasePose = (name: string) => {
     }
   };
 
-  updateLocation();
-  const clearUpdateLocationInterval = setAsyncInterval(updateLocation, 300);
-
-  useDisconnect(() => clearUpdateLocationInterval());
+  useConnect(() => {
+    updateLocation();
+    const clear = setAsyncInterval(updateLocation, 300);
+    return () => clear();
+  })
 
   return { pose, error };
 };

--- a/web/frontend/src/components/navigation/hooks/use-obstacles.ts
+++ b/web/frontend/src/components/navigation/hooks/use-obstacles.ts
@@ -2,7 +2,7 @@ import { formatObstacles } from '@/api/navigation';
 import { type ServiceError } from '@viamrobotics/sdk';
 import type { Obstacle } from '@viamrobotics/prime-blocks';
 import { writable } from 'svelte/store';
-import { useDisconnect } from '@/hooks/robot-client';
+import { useConnect } from '@/hooks/robot-client';
 import { setAsyncInterval } from '@/lib/schedule';
 import { useNavClient } from './use-nav-client';
 
@@ -22,9 +22,11 @@ export const useObstacles = (name: string) => {
     }
   };
 
-  const clearUpdateObstacleInterval = setAsyncInterval(updateObstacles, 1000);
-  void updateObstacles();
-  useDisconnect(() => clearUpdateObstacleInterval());
+  useConnect(() => {
+    const clearInterval = setAsyncInterval(updateObstacles, 1000);
+    void updateObstacles();
+    return () => clearInterval()
+  });
 
   return { obstacles, error };
 };

--- a/web/frontend/src/components/navigation/hooks/use-paths.ts
+++ b/web/frontend/src/components/navigation/hooks/use-paths.ts
@@ -2,7 +2,7 @@ import { formatPaths } from '@/api/navigation';
 import { type ServiceError } from '@viamrobotics/sdk';
 import { type Path } from '@viamrobotics/prime-blocks';
 import { writable } from 'svelte/store';
-import { useDisconnect } from '@/hooks/robot-client';
+import { useConnect } from '@/hooks/robot-client';
 import { setAsyncInterval } from '@/lib/schedule';
 import { useNavClient } from './use-nav-client';
 
@@ -22,9 +22,11 @@ export const usePaths = (name: string) => {
     }
   };
 
-  const clearUpdatePathsInterval = setAsyncInterval(updatePaths, 1000);
-  void updatePaths();
-  useDisconnect(() => clearUpdatePathsInterval());
+  useConnect(() => {
+    const clearInterval = setAsyncInterval(updatePaths, 1000);
+    void updatePaths();
+    return () => clearInterval();
+  })
 
   return { paths, error };
 };

--- a/web/frontend/src/components/navigation/hooks/use-waypoints.ts
+++ b/web/frontend/src/components/navigation/hooks/use-waypoints.ts
@@ -2,7 +2,7 @@ import { type LngLat, formatWaypoints } from '@/api/navigation';
 import { type ServiceError } from '@viamrobotics/sdk';
 import { type Waypoint } from '@viamrobotics/prime-blocks';
 import { writable } from 'svelte/store';
-import { useDisconnect } from '@/hooks/robot-client';
+import { useConnect } from '@/hooks/robot-client';
 import { setAsyncInterval } from '@/lib/schedule';
 import { useNavClient } from './use-nav-client';
 
@@ -47,9 +47,11 @@ export const useWaypoints = (name: string) => {
     }
   };
 
-  const clearUpdateWaypointInterval = setAsyncInterval(updateWaypoints, 1000);
-  updateWaypoints();
-  useDisconnect(() => clearUpdateWaypointInterval());
+  useConnect(() => {
+    const clearInterval = setAsyncInterval(updateWaypoints, 1000);
+    void updateWaypoints();
+    return () => clearInterval()
+  })
 
   return { waypoints, error, addWaypoint, deleteWaypoint };
 };

--- a/web/frontend/src/components/navigation/index.svelte
+++ b/web/frontend/src/components/navigation/index.svelte
@@ -14,7 +14,7 @@ import { useBasePose } from './hooks/use-base-pose';
 import type { Map } from 'maplibre-gl';
 import { useObstacles } from './hooks/use-obstacles';
 import { usePaths } from './hooks/use-paths';
-import { useStop } from '@/lib/components/collapse.svelte';
+import { useStop } from '@/lib/components/collapse';
 
 export let name: string;
 

--- a/web/frontend/src/components/navigation/index.svelte
+++ b/web/frontend/src/components/navigation/index.svelte
@@ -14,9 +14,10 @@ import { useBasePose } from './hooks/use-base-pose';
 import type { Map } from 'maplibre-gl';
 import { useObstacles } from './hooks/use-obstacles';
 import { usePaths } from './hooks/use-paths';
+import type { StopCallback } from '@/lib/components/collapse.svelte';
 
 export let name: string;
-export let onStop: (callback: () => Promise<void>) => void
+export let onStop: StopCallback | undefined = undefined;
 
 let map: Map | undefined;
 
@@ -75,7 +76,7 @@ const handleDeleteWaypoint = async (event: CustomEvent<string>) => {
   }
 };
 
-onStop(stopNavigation)
+onStop?.(stopNavigation)
 
 </script>
 

--- a/web/frontend/src/components/navigation/index.svelte
+++ b/web/frontend/src/components/navigation/index.svelte
@@ -4,9 +4,8 @@
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { type ServiceError, navigationApi } from '@viamrobotics/sdk';
 import { notify } from '@viamrobotics/prime';
-import { IconButton, Button, persisted } from '@viamrobotics/prime-core';
+import { IconButton, persisted } from '@viamrobotics/prime-core';
 import { NavigationMap, type LngLat } from '@viamrobotics/prime-blocks';
-import Collapse from '@/lib/components/collapse.svelte';
 import LngLatInput from './components/input/lnglat.svelte';
 import Waypoints from './components/waypoints.svelte';
 import { useWaypoints } from './hooks/use-waypoints';
@@ -17,6 +16,7 @@ import { useObstacles } from './hooks/use-obstacles';
 import { usePaths } from './hooks/use-paths';
 
 export let name: string;
+export let onStop: (callback: () => Promise<void>) => void
 
 let map: Map | undefined;
 
@@ -51,9 +51,7 @@ const handleModeSelect = async (
   }
 };
 
-const stopNavigation = async (event: MouseEvent) => {
-  event.stopPropagation();
-
+const stopNavigation = async () => {
   try {
     await setMode(navigationApi.Mode.MODE_MANUAL);
   } catch (error) {
@@ -76,77 +74,64 @@ const handleDeleteWaypoint = async (event: CustomEvent<string>) => {
     notify.danger((error as ServiceError).message);
   }
 };
+
+onStop(stopNavigation)
+
 </script>
 
-<Collapse title={name}>
-  <v-breadcrumbs
-    slot="title"
-    crumbs="navigation"
-  />
-
-  <Button
-    slot="header"
-    variant="danger"
-    icon="stop-circle-outline"
-    on:click={stopNavigation}
-  >
-    Stop
-  </Button>
-
-  <div class="flex flex-col gap-2 border border-t-0 border-medium">
-    <div class="flex flex-wrap items-end justify-between gap-y-2 px-4 py-3">
-      <div class="flex gap-1">
-        <div class="w-80">
-          <LngLatInput
-            readonly
-            label="Base position"
-            lng={$pose?.lng}
-            lat={$pose?.lat}
-          >
-            <IconButton
-              label="Focus on base"
-              icon="image-filter-center-focus"
-              on:click={() => {
-                if ($pose) {
-                  map?.flyTo({
-                    zoom: 15,
-                    duration: 800,
-                    curve: 0.1,
-                    center: [$pose.lng, $pose.lat],
-                  });
-                }
-              }}
-            />
-          </LngLatInput>
-        </div>
+<div class="flex flex-col gap-2 border border-t-0 border-medium">
+  <div class="flex flex-wrap items-end justify-between gap-y-2 px-4 py-3">
+    <div class="flex gap-1">
+      <div class="w-80">
+        <LngLatInput
+          readonly
+          label="Base position"
+          lng={$pose?.lng}
+          lat={$pose?.lat}
+        >
+          <IconButton
+            label="Focus on base"
+            icon="image-filter-center-focus"
+            on:click={() => {
+              if ($pose) {
+                map?.flyTo({
+                  zoom: 15,
+                  duration: 800,
+                  curve: 0.1,
+                  center: [$pose.lng, $pose.lat],
+                });
+              }
+            }}
+          />
+        </LngLatInput>
       </div>
-
-      <v-radio
-        label="Navigation mode"
-        options="Manual, Waypoint"
-        selected={{
-          [navigationApi.Mode.MODE_UNSPECIFIED]: '',
-          [navigationApi.Mode.MODE_MANUAL]: 'Manual',
-          [navigationApi.Mode.MODE_WAYPOINT]: 'Waypoint',
-          [navigationApi.Mode.MODE_EXPLORE]: 'Explore',
-        }[$mode ?? navigationApi.Mode.MODE_UNSPECIFIED]}
-        on:input={handleModeSelect}
-      />
     </div>
 
-    <div class="relative h-[500px] p-4">
-      <NavigationMap
-        bind:map
-        environment="debug"
-        baseGeoPose={$pose}
-        waypoints={$waypoints}
-        obstacles={$obstacles}
-        paths={$paths}
-        on:add-waypoint={handleAddWaypoint}
-        on:delete-waypoint={handleDeleteWaypoint}
-      >
-        <Waypoints {name} />
-      </NavigationMap>
-    </div>
+    <v-radio
+      label="Navigation mode"
+      options="Manual, Waypoint"
+      selected={{
+        [navigationApi.Mode.MODE_UNSPECIFIED]: '',
+        [navigationApi.Mode.MODE_MANUAL]: 'Manual',
+        [navigationApi.Mode.MODE_WAYPOINT]: 'Waypoint',
+        [navigationApi.Mode.MODE_EXPLORE]: 'Explore',
+      }[$mode ?? navigationApi.Mode.MODE_UNSPECIFIED]}
+      on:input={handleModeSelect}
+    />
   </div>
-</Collapse>
+
+  <div class="relative h-[500px] p-4">
+    <NavigationMap
+      bind:map
+      environment="debug"
+      baseGeoPose={$pose}
+      waypoints={$waypoints}
+      obstacles={$obstacles}
+      paths={$paths}
+      on:add-waypoint={handleAddWaypoint}
+      on:delete-waypoint={handleDeleteWaypoint}
+    >
+      <Waypoints {name} />
+    </NavigationMap>
+  </div>
+</div>

--- a/web/frontend/src/components/navigation/index.svelte
+++ b/web/frontend/src/components/navigation/index.svelte
@@ -14,10 +14,9 @@ import { useBasePose } from './hooks/use-base-pose';
 import type { Map } from 'maplibre-gl';
 import { useObstacles } from './hooks/use-obstacles';
 import { usePaths } from './hooks/use-paths';
-import type { StopCallback } from '@/lib/components/collapse.svelte';
+import { useStop } from '@/lib/components/collapse.svelte';
 
 export let name: string;
-export let onStop: StopCallback | undefined = undefined;
 
 let map: Map | undefined;
 
@@ -52,14 +51,6 @@ const handleModeSelect = async (
   }
 };
 
-const stopNavigation = async () => {
-  try {
-    await setMode(navigationApi.Mode.MODE_MANUAL);
-  } catch (error) {
-    notify.danger((error as ServiceError).message);
-  }
-};
-
 const handleAddWaypoint = async (event: CustomEvent<LngLat>) => {
   try {
     await addWaypoint(event.detail);
@@ -76,7 +67,15 @@ const handleDeleteWaypoint = async (event: CustomEvent<string>) => {
   }
 };
 
-onStop?.(stopNavigation)
+const { onStop } = useStop();
+
+onStop(async () => {
+  try {
+    await setMode(navigationApi.Mode.MODE_MANUAL);
+  } catch (error) {
+    notify.danger((error as ServiceError).message);
+  }
+})
 
 </script>
 

--- a/web/frontend/src/components/power-sensor/index.svelte
+++ b/web/frontend/src/components/power-sensor/index.svelte
@@ -2,10 +2,9 @@
 
 import { type ServiceError } from '@viamrobotics/sdk';
 import { displayError } from '@/lib/error';
-import Collapse from '@/lib/components/collapse.svelte';
 import { setAsyncInterval } from '@/lib/schedule';
 import { getVoltage, getCurrent, getPower } from '@/api/power-sensor';
-import { useRobotClient, useDisconnect } from '@/hooks/robot-client';
+import { useRobotClient, useConnect } from '@/hooks/robot-client';
 
 export let name: string;
 
@@ -14,8 +13,6 @@ const { robotClient } = useRobotClient();
 let voltageValue: number | undefined;
 let currentValue: number | undefined;
 let powerValue: number | undefined;
-
-let clearInterval: (() => void) | undefined;
 
 const refresh = async () => {
   try {
@@ -33,50 +30,43 @@ const refresh = async () => {
   }
 };
 
-const handleToggle = (event: CustomEvent<{ open: boolean }>) => {
-  if (event.detail.open) {
-    refresh();
-    clearInterval = setAsyncInterval(refresh, 500);
-  } else {
-    clearInterval?.();
-  }
-};
-
-useDisconnect(() => clearInterval?.());
+useConnect(() => {
+  refresh();
+  const clearInterval = setAsyncInterval(refresh, 500);
+  return () => clearInterval()
+})
 
 </script>
 
-<Collapse title={name} on:toggle={handleToggle}>
-    <v-breadcrumbs slot="title" crumbs="power_sensor" />
-    <div class="flex flex-wrap gap-5 text-sm border border-t-0 border-medium p-4">
-      {#if voltageValue !== undefined}
-        <div class="overflow-auto">
-          <small class='block pt-1 text-sm text-subtle-2'> voltage (volts)</small>
-          <div class="flex gap-1.5">
-            <small class='block pt-1 text-sm text-subtle-1'>  {voltageValue.toFixed(4)} </small>
-          </div>
-        </div>
-        {/if}
-        {#if currentValue !== undefined}
-        <div class="overflow-auto">
-          <small class='block pt-1 text-sm text-subtle-2'>
-           current (amps)
-          </small>
-          <div class="flex gap-1.5">
-            <small class='block pt-1 text-sm text-subtle-1'> {currentValue.toFixed(4)}</small>
-          </div>
-        </div>
-        {/if}
-        {#if powerValue !== undefined}
-        <div class="overflow-auto">
-          <small class='block pt-1 text-sm text-subtle-2'>
-            power (watts)
-          </small>
-          <div class="flex gap-1.5">
-            <small class='block pt-1 text-sm text-subtle-1'>  {powerValue.toFixed(4)} </small>
-          </div>
-        </div>
-        {/if}
-        </div>
-    </Collapse>
+<div class="flex flex-wrap gap-5 text-sm border border-t-0 border-medium p-4">
+  {#if voltageValue !== undefined}
+    <div class="overflow-auto">
+      <small class='block pt-1 text-sm text-subtle-2'> voltage (volts)</small>
+      <div class="flex gap-1.5">
+        <small class='block pt-1 text-sm text-subtle-1'>  {voltageValue.toFixed(4)} </small>
+      </div>
+    </div>
+    {/if}
+    {#if currentValue !== undefined}
+    <div class="overflow-auto">
+      <small class='block pt-1 text-sm text-subtle-2'>
+        current (amps)
+      </small>
+      <div class="flex gap-1.5">
+        <small class='block pt-1 text-sm text-subtle-1'> {currentValue.toFixed(4)}</small>
+      </div>
+    </div>
+    {/if}
+    {#if powerValue !== undefined}
+    <div class="overflow-auto">
+      <small class='block pt-1 text-sm text-subtle-2'>
+        power (watts)
+      </small>
+      <div class="flex gap-1.5">
+        <small class='block pt-1 text-sm text-subtle-1'>  {powerValue.toFixed(4)} </small>
+      </div>
+    </div>
+    {/if}
+</div>
+
 

--- a/web/frontend/src/components/remote-control-cards.svelte
+++ b/web/frontend/src/components/remote-control-cards.svelte
@@ -24,9 +24,10 @@ import Servo from './servo/index.svelte';
 import Sensors from './sensors/index.svelte';
 import Slam from './slam/index.svelte';
 import Client from '@/lib/components/robot-client.svelte';
+import Collapse from '@/lib/components/collapse.svelte';
 import type { RCOverrides } from '@/types/overrides';
 
-const { resources, components, services, statuses, sensorNames } = useRobotClient();
+const { resources, components, services, statuses, sensorNames, sessionsSupported } = useRobotClient();
 
 export let host: string;
 export let bakedAuth: { authEntity?: string; creds?: Credentials; } | undefined = {};
@@ -94,85 +95,115 @@ const getStatus = (statusMap: Record<string, unknown>, resource: commonApi.Resou
   <div class="flex flex-col gap-4 p-3">
     <!-- ******* BASE *******  -->
     {#each filterSubtype($components, 'base') as { name } (name)}
-      <Base {name} />
+      <Collapse title={name} crumbs='base' hasStop let:onStop>
+        <Base {name} {onStop} />
+      </Collapse>
     {/each}
 
     <!-- ******* SLAM *******  -->
     {#each filterSubtype($services, 'slam') as { name } (name)}
-      <Slam {name} overrides={overrides?.slam} />
+      <Collapse title={name} crumbs="slam" hasStop let:onStop>
+        <Slam {name} overrides={overrides?.slam} {onStop} />
+      </Collapse>
     {/each}
 
     <!-- ******* ENCODER *******  -->
     {#each filterSubtype($components, 'encoder') as { name } (name)}
-      <Encoder {name} />
+      <Collapse title={name} crumbs="encoder">
+        <Encoder {name} />
+      </Collapse>
     {/each}
 
     <!-- ******* GANTRY *******  -->
     {#each filterWithStatus($components, $statuses, 'gantry') as gantry (gantry.name)}
-      <Gantry
-        name={gantry.name}
-        status={getStatus($statuses, gantry)}
-      />
+      <Collapse title={gantry.name} crumbs="gantry" hasStop let:onStop>
+        <Gantry
+          name={gantry.name}
+          status={getStatus($statuses, gantry)}
+          {onStop}
+        />
+      </Collapse>
     {/each}
 
     <!-- ******* MOVEMENT SENSOR *******  -->
     {#each filterSubtype($components, 'movement_sensor') as { name } (name)}
-      <MovementSensor {name} />
+      <Collapse title={name} crumbs="movement_sensor">
+        <MovementSensor {name} />
+      </Collapse>
     {/each}
 
      <!-- ******* POWER SENSOR *******  -->
     {#each filterSubtype($components, 'power_sensor') as { name } (name)}
-      <PowerSensor {name} />
+      <Collapse title={name} crumbs="power_sensor">
+        <PowerSensor {name} />
+      </Collapse>
     {/each}
 
     <!-- ******* ARM *******  -->
     {#each filterSubtype($components, 'arm') as arm (arm.name)}
-      <Arm
-        name={arm.name}
-        status={getStatus($statuses, arm)}
-      />
+      <Collapse title={arm.name} crumbs="arm" hasStop let:onStop>
+        <Arm
+          name={arm.name}
+          status={getStatus($statuses, arm)}
+          {onStop}
+        />
+      </Collapse>
     {/each}
 
     <!-- ******* GRIPPER *******  -->
     {#each filterSubtype($components, 'gripper') as { name } (name)}
-      <Gripper {name} />
+      <Collapse title={name} crumbs="gripper" hasStop let:onStop>
+        <Gripper {name} {onStop} />
+      </Collapse>
     {/each}
 
     <!-- ******* SERVO *******  -->
     {#each filterWithStatus($components, $statuses, 'servo') as servo (servo.name)}
-      <Servo
-        name={servo.name}
-        status={getStatus($statuses, servo)}
-      />
+      <Collapse title={servo.name} crumbs="servo" hasStop let:onStop>
+        <Servo
+          name={servo.name}
+          status={getStatus($statuses, servo)}
+          {onStop}
+        />
+      </Collapse>
     {/each}
 
     <!-- ******* MOTOR *******  -->
     {#each filterWithStatus($components, $statuses, 'motor') as motor (motor.name)}
-      <Motor
-        name={motor.name}
-        status={getStatus($statuses, motor)}
-      />
+      <Collapse title={motor.name} crumbs="motor" hasStop let:onStop>
+        <Motor
+          name={motor.name}
+          status={getStatus($statuses, motor)}
+          {onStop}
+        />
+      </Collapse>
     {/each}
 
     <!-- ******* INPUT VIEW *******  -->
     {#each filteredInputControllerList as controller (controller.name)}
-      <InputController
-        name={controller.name}
-        status={getStatus($statuses, controller)}
-      />
+      <Collapse title={controller.name} crumbs="input_controller">
+        <InputController
+          name={controller.name}
+          status={getStatus($statuses, controller)}
+        />
+      </Collapse>
     {/each}
 
     <!-- ******* WEB CONTROLS *******  -->
     {#each filteredWebGamepads as { name } (name)}
-      <Gamepad {name} />
+      <Collapse title={name} crumbs='input_controller'>
+        <Gamepad {name} />
+      </Collapse>
     {/each}
 
     <!-- ******* BOARD *******  -->
     {#each filterWithStatus($components, $statuses, 'board') as board (board.name)}
-      <Board
-        name={board.name}
-        status={getStatus($statuses, board)}
-      />
+      <Collapse title={board.name} crumbs="board">
+        <Board
+          name={board.name}
+          status={getStatus($statuses, board)}
+        />
+      </Collapse>
     {/each}
 
     <!-- ******* CAMERA *******  -->
@@ -180,28 +211,38 @@ const getStatus = (statusMap: Record<string, unknown>, resource: commonApi.Resou
 
     <!-- ******* NAVIGATION *******  -->
     {#each filterSubtype($services, 'navigation') as { name } (name)}
-      <Navigation {name} />
+      <Collapse title={name} crumbs='navigation' hasStop let:onStop>
+        <Navigation {name} {onStop} />
+      </Collapse>
     {/each}
 
     <!-- ******* SENSOR *******  -->
     {#if Object.keys($sensorNames).length > 0}
-      <Sensors
-        name={filterSubtype($resources, 'sensors', { remote: false })[0]?.name ?? ''}
-        sensorNames={$sensorNames}
-      />
+      <Collapse title="Sensors">
+        <Sensors
+          name={filterSubtype($resources, 'sensors', { remote: false })[0]?.name ?? ''}
+          sensorNames={$sensorNames}
+        />
+      </Collapse>
     {/if}
 
     <!-- ******* AUDIO *******  -->
     {#each filterSubtype($components, 'audio_input') as { name } (name)}
-      <AudioInput {name} />
+      <Collapse title={name} crumbs="audio_input">
+        <AudioInput {name} />
+      </Collapse>
     {/each}
 
     <!-- ******* DO *******  -->
     {#if filterSubtype($components, 'generic').length > 0}
-      <DoCommand resources={filterSubtype($components, 'generic')} />
+      <Collapse title="DoCommand()">
+        <DoCommand resources={filterSubtype($components, 'generic')} />
+      </Collapse>
     {/if}
 
     <!-- ******* OPERATIONS AND SESSIONS *******  -->
-    <OperationsSessions />
+    <Collapse title={$sessionsSupported ? 'Operations & Sessions' : 'Operations'}>
+      <OperationsSessions />
+    </Collapse>
   </div>
 </Client>

--- a/web/frontend/src/components/remote-control-cards.svelte
+++ b/web/frontend/src/components/remote-control-cards.svelte
@@ -95,15 +95,15 @@ const getStatus = (statusMap: Record<string, unknown>, resource: commonApi.Resou
   <div class="flex flex-col gap-4 p-3">
     <!-- ******* BASE *******  -->
     {#each filterSubtype($components, 'base') as { name } (name)}
-      <Collapse title={name} crumbs='base' hasStop let:onStop>
-        <Base {name} {onStop} />
+      <Collapse title={name} crumbs='base' stop>
+        <Base {name} />
       </Collapse>
     {/each}
 
     <!-- ******* SLAM *******  -->
     {#each filterSubtype($services, 'slam') as { name } (name)}
-      <Collapse title={name} crumbs="slam" hasStop let:onStop>
-        <Slam {name} overrides={overrides?.slam} {onStop} />
+      <Collapse title={name} crumbs="slam" stop>
+        <Slam {name} overrides={overrides?.slam} />
       </Collapse>
     {/each}
 
@@ -116,11 +116,10 @@ const getStatus = (statusMap: Record<string, unknown>, resource: commonApi.Resou
 
     <!-- ******* GANTRY *******  -->
     {#each filterWithStatus($components, $statuses, 'gantry') as gantry (gantry.name)}
-      <Collapse title={gantry.name} crumbs="gantry" hasStop let:onStop>
+      <Collapse title={gantry.name} crumbs="gantry" stop>
         <Gantry
           name={gantry.name}
           status={getStatus($statuses, gantry)}
-          {onStop}
         />
       </Collapse>
     {/each}
@@ -141,40 +140,37 @@ const getStatus = (statusMap: Record<string, unknown>, resource: commonApi.Resou
 
     <!-- ******* ARM *******  -->
     {#each filterSubtype($components, 'arm') as arm (arm.name)}
-      <Collapse title={arm.name} crumbs="arm" hasStop let:onStop>
+      <Collapse title={arm.name} crumbs="arm" stop>
         <Arm
           name={arm.name}
           status={getStatus($statuses, arm)}
-          {onStop}
         />
       </Collapse>
     {/each}
 
     <!-- ******* GRIPPER *******  -->
     {#each filterSubtype($components, 'gripper') as { name } (name)}
-      <Collapse title={name} crumbs="gripper" hasStop let:onStop>
-        <Gripper {name} {onStop} />
+      <Collapse title={name} crumbs="gripper" stop>
+        <Gripper {name} />
       </Collapse>
     {/each}
 
     <!-- ******* SERVO *******  -->
     {#each filterWithStatus($components, $statuses, 'servo') as servo (servo.name)}
-      <Collapse title={servo.name} crumbs="servo" hasStop let:onStop>
+      <Collapse title={servo.name} crumbs="servo" stop>
         <Servo
           name={servo.name}
           status={getStatus($statuses, servo)}
-          {onStop}
         />
       </Collapse>
     {/each}
 
     <!-- ******* MOTOR *******  -->
     {#each filterWithStatus($components, $statuses, 'motor') as motor (motor.name)}
-      <Collapse title={motor.name} crumbs="motor" hasStop let:onStop>
+      <Collapse title={motor.name} crumbs="motor" stop>
         <Motor
           name={motor.name}
           status={getStatus($statuses, motor)}
-          {onStop}
         />
       </Collapse>
     {/each}
@@ -211,8 +207,8 @@ const getStatus = (statusMap: Record<string, unknown>, resource: commonApi.Resou
 
     <!-- ******* NAVIGATION *******  -->
     {#each filterSubtype($services, 'navigation') as { name } (name)}
-      <Collapse title={name} crumbs='navigation' hasStop let:onStop>
-        <Navigation {name} {onStop} />
+      <Collapse title={name} crumbs='navigation' stop>
+        <Navigation {name} />
       </Collapse>
     {/each}
 

--- a/web/frontend/src/components/sensors/index.svelte
+++ b/web/frontend/src/components/sensors/index.svelte
@@ -3,7 +3,6 @@
   import { notify } from '@viamrobotics/prime';
   import { resourceNameToString } from '@/lib/resource';
   import { rcLogConditionally } from '@/lib/log';
-  import Collapse from '@/lib/components/collapse.svelte';
   import { useRobotClient } from '@/hooks/robot-client';
 
   interface SensorName {
@@ -71,59 +70,57 @@
   };
 </script>
 
-<Collapse title="Sensors">
-  <div class="overflow-auto border border-t-0 border-medium p-4 text-sm">
-    <table class="w-full table-auto border border-medium">
+<div class="overflow-auto border border-t-0 border-medium p-4 text-sm">
+  <table class="w-full table-auto border border-medium">
+    <tr>
+      <th class="border border-medium p-2"> Name </th>
+      <th class="border border-medium p-2"> Type </th>
+      <th class="border border-medium p-2"> Readings </th>
+      <th class="border border-medium p-2 text-center">
+        <v-button
+          label="Get All Readings"
+          on:click|stopPropagation={() => {
+            getReadings(sensorNames);
+          }}
+        />
+      </th>
+    </tr>
+    {#each sensorNames as sensorName (sensorName.name)}
       <tr>
-        <th class="border border-medium p-2"> Name </th>
-        <th class="border border-medium p-2"> Type </th>
-        <th class="border border-medium p-2"> Readings </th>
-        <th class="border border-medium p-2 text-center">
+        <td class="border border-medium p-2">
+          {sensorName.name}
+        </td>
+        <td class="border border-medium p-2">
+          {sensorName.subtype}
+        </td>
+        <td class="border border-medium p-2">
+          <table style="font-size:.7em; text-align: left;">
+            {#each getData(sensorReadings, sensorName) as [sensorField, sensorValue] (sensorField)}
+              <tr>
+                <th>{sensorField}</th>
+                <td>
+                  {JSON.stringify(sensorValue)}
+                  <!-- eslint-disable-next-line no-underscore-dangle -->
+                  {#if sensorValue._type === 'geopoint'}
+                  <a
+                    href={`https://www.google.com/maps/search/${sensorValue.lat},${sensorValue.lng}`}
+                    >google maps</a
+                  >
+                  {/if}
+                </td>
+              </tr>
+            {/each}
+          </table>
+        </td>
+        <td class="border border-medium p-2 text-center">
           <v-button
-            label="Get All Readings"
+            label="Get Readings"
             on:click|stopPropagation={() => {
-              getReadings(sensorNames);
+              getReadings([sensorName]);
             }}
           />
-        </th>
+        </td>
       </tr>
-      {#each sensorNames as sensorName (sensorName.name)}
-        <tr>
-          <td class="border border-medium p-2">
-            {sensorName.name}
-          </td>
-          <td class="border border-medium p-2">
-            {sensorName.subtype}
-          </td>
-          <td class="border border-medium p-2">
-            <table style="font-size:.7em; text-align: left;">
-              {#each getData(sensorReadings, sensorName) as [sensorField, sensorValue] (sensorField)}
-                <tr>
-                  <th>{sensorField}</th>
-                  <td>
-                    {JSON.stringify(sensorValue)}
-                    <!-- eslint-disable-next-line no-underscore-dangle -->
-                    {#if sensorValue._type === 'geopoint'}
-                    <a
-                      href={`https://www.google.com/maps/search/${sensorValue.lat},${sensorValue.lng}`}
-                      >google maps</a
-                    >
-                    {/if}
-                  </td>
-                </tr>
-              {/each}
-            </table>
-          </td>
-          <td class="border border-medium p-2 text-center">
-            <v-button
-              label="Get Readings"
-              on:click|stopPropagation={() => {
-                getReadings([sensorName]);
-              }}
-            />
-          </td>
-        </tr>
-      {/each}
-    </table>
-  </div>
-</Collapse>
+    {/each}
+  </table>
+</div>

--- a/web/frontend/src/components/servo/index.svelte
+++ b/web/frontend/src/components/servo/index.svelte
@@ -7,8 +7,8 @@ import { move } from '@/api/servo';
 import { useRobotClient } from '@/hooks/robot-client';
 
 export let name: string;
-export let status: undefined | { position_deg: number };
-export let onStop: StopCallback | undefined;
+export let status: { position_deg: number } | undefined = undefined;
+export let onStop: StopCallback | undefined = undefined;
 
 const { robotClient } = useRobotClient();
 

--- a/web/frontend/src/components/servo/index.svelte
+++ b/web/frontend/src/components/servo/index.svelte
@@ -4,7 +4,7 @@ import { displayError } from '@/lib/error';
 import { rcLogConditionally } from '@/lib/log';
 import { move } from '@/api/servo';
 import { useRobotClient } from '@/hooks/robot-client';
-import { useStop } from '@/lib/components/collapse.svelte';
+import { useStop } from '@/lib/components/collapse';
 
 export let name: string;
 export let status: { position_deg: number } | undefined = undefined;

--- a/web/frontend/src/components/servo/index.svelte
+++ b/web/frontend/src/components/servo/index.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
-
 import { type ServiceError, servoApi } from '@viamrobotics/sdk';
 import { displayError } from '@/lib/error';
 import { rcLogConditionally } from '@/lib/log';
-import Collapse from '@/lib/components/collapse.svelte';
+import type { StopCallback } from '@/lib/components/collapse.svelte';
 import { move } from '@/api/servo';
 import { useRobotClient } from '@/hooks/robot-client';
 
 export let name: string;
 export let status: undefined | { position_deg: number };
+export let onStop: StopCallback | undefined;
 
 const { robotClient } = useRobotClient();
 
@@ -31,25 +31,17 @@ const handleMove = async (amount: number) => {
   }
 };
 
+onStop?.(stop)
+
 </script>
 
-<Collapse title={name}>
-  <v-breadcrumbs slot="title" crumbs="servo" />
-  <v-button
-    slot="header"
-    label="Stop"
-    icon="stop-circle-outline"
-    variant="danger"
-    on:click={stop}
-  />
-  <div class="border border-t-0 border-medium p-4">
-    <h3 class="mb-1 text-sm">Angle: {status?.position_deg ?? 0}</h3>
+<div class="border border-t-0 border-medium p-4">
+  <h3 class="mb-1 text-sm">Angle: {status?.position_deg ?? 0}</h3>
 
-    <div class="flex gap-1.5">
-      <v-button label="-10" on:click={async () => handleMove(-10)} />
-      <v-button label="-1" on:click={async () => handleMove(-1)} />
-      <v-button label="1" on:click={async () => handleMove(1)} />
-      <v-button label="10" on:click={async () => handleMove(10)} />
-    </div>
+  <div class="flex gap-1.5">
+    <v-button label="-10" on:click={async () => handleMove(-10)} />
+    <v-button label="-1" on:click={async () => handleMove(-1)} />
+    <v-button label="1" on:click={async () => handleMove(1)} />
+    <v-button label="10" on:click={async () => handleMove(10)} />
   </div>
-</Collapse>
+</div>

--- a/web/frontend/src/components/servo/index.svelte
+++ b/web/frontend/src/components/servo/index.svelte
@@ -2,23 +2,14 @@
 import { type ServiceError, servoApi } from '@viamrobotics/sdk';
 import { displayError } from '@/lib/error';
 import { rcLogConditionally } from '@/lib/log';
-import type { StopCallback } from '@/lib/components/collapse.svelte';
 import { move } from '@/api/servo';
 import { useRobotClient } from '@/hooks/robot-client';
+import { useStop } from '@/lib/components/collapse.svelte';
 
 export let name: string;
 export let status: { position_deg: number } | undefined = undefined;
-export let onStop: StopCallback | undefined = undefined;
 
 const { robotClient } = useRobotClient();
-
-const stop = () => {
-  const req = new servoApi.StopRequest();
-  req.setName(name);
-
-  rcLogConditionally(req);
-  $robotClient.servoService.stop(req, displayError);
-};
 
 const handleMove = async (amount: number) => {
   const oldAngle = status?.position_deg ?? 0;
@@ -31,7 +22,15 @@ const handleMove = async (amount: number) => {
   }
 };
 
-onStop?.(stop)
+const { onStop } = useStop();
+
+onStop(() => {
+  const req = new servoApi.StopRequest();
+  req.setName(name);
+
+  rcLogConditionally(req);
+  $robotClient.servoService.stop(req, displayError);
+})
 
 </script>
 

--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -12,7 +12,7 @@
   import { components } from '@/stores/resources';
   import Dropzone from '@/lib/components/dropzone.svelte';
   import { useRobotClient, useConnect } from '@/hooks/robot-client';
-  import { useStop } from '@/lib/components/collapse.svelte';
+  import { useStop } from '@/lib/components/collapse';
   import type { SLAMOverrides } from '@/types/overrides';
   import { rcLogConditionally } from '@/lib/log';
 

--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -17,8 +17,8 @@
   import { rcLogConditionally } from '@/lib/log';
 
   export let name: string;
-  export let overrides: SLAMOverrides | undefined;
-  export let onStop: StopCallback
+  export let overrides: SLAMOverrides | undefined = undefined;
+  export let onStop: StopCallback | undefined = undefined;
 
   const { robotClient, operations } = useRobotClient();
   const slamClient = new SlamClient($robotClient, name, {
@@ -309,7 +309,7 @@
     }
   };
 
-  onStop(handleStopMoveClick)
+  onStop?.(handleStopMoveClick)
 
   useConnect(() => {
     toggle2dExpand();

--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -10,15 +10,14 @@
   import { notify } from '@viamrobotics/prime';
   import { setAsyncInterval } from '@/lib/schedule';
   import { components } from '@/stores/resources';
-  import type { StopCallback } from '@/lib/components/collapse.svelte';
   import Dropzone from '@/lib/components/dropzone.svelte';
   import { useRobotClient, useConnect } from '@/hooks/robot-client';
+  import { useStop } from '@/lib/components/collapse.svelte';
   import type { SLAMOverrides } from '@/types/overrides';
   import { rcLogConditionally } from '@/lib/log';
 
   export let name: string;
   export let overrides: SLAMOverrides | undefined = undefined;
-  export let onStop: StopCallback | undefined = undefined;
 
   const { robotClient, operations } = useRobotClient();
   const slamClient = new SlamClient($robotClient, name, {
@@ -214,14 +213,6 @@
     }
   };
 
-  const handleStopMoveClick = async () => {
-    try {
-      await stopMoveOnMap($robotClient, $operations);
-    } catch (error) {
-      notify.danger((error as ServiceError).message);
-    }
-  };
-
   const startMappingIntervals = (start: number) => {
     updateSLAM2dRefreshFrequency();
     startDurationTimer(start);
@@ -309,7 +300,15 @@
     }
   };
 
-  onStop?.(handleStopMoveClick)
+  const { onStop } = useStop();
+
+  onStop(async () => {
+    try {
+      await stopMoveOnMap($robotClient, $operations);
+    } catch (error) {
+      notify.danger((error as ServiceError).message);
+    }
+  })
 
   useConnect(() => {
     toggle2dExpand();

--- a/web/frontend/src/hooks/robot-client.ts
+++ b/web/frontend/src/hooks/robot-client.ts
@@ -26,7 +26,7 @@ const context = {
 export const useRobotClient = () => context;
 
 export type DisconnectCallback = () => void
-export type ConnectCallback = () => DisconnectCallback | undefined
+export type ConnectCallback = (() => DisconnectCallback) | (() => void)
 
 /**
  * Pass a callback to this hook that will fire whenever an initial connection or reconnect occurs.
@@ -44,7 +44,8 @@ export type ConnectCallback = () => DisconnectCallback | undefined
 export const useConnect = (callback: ConnectCallback) => {
   const { connectionStatus } = useRobotClient();
 
-  let disconnectCallback: DisconnectCallback | undefined
+  // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+  let disconnectCallback: DisconnectCallback | void
 
   onMount(() => {
     const unsubscribe = connectionStatus.subscribe((value) => {

--- a/web/frontend/src/hooks/robot-client.ts
+++ b/web/frontend/src/hooks/robot-client.ts
@@ -2,7 +2,7 @@ import type { Client, ResponseStream, commonApi, robotApi } from '@viamrobotics/
 import { components, resources, services, statuses } from '@/stores/resources';
 import { currentWritable } from '@threlte/core';
 import { StreamManager } from '@/lib/stream-manager';
-import { onDestroy } from 'svelte';
+import { onMount } from 'svelte';
 
 const context = {
   robotClient: currentWritable<Client>(null!),
@@ -25,28 +25,39 @@ const context = {
 
 export const useRobotClient = () => context;
 
+export type DisconnectCallback = () => void
+export type ConnectCallback = () => DisconnectCallback | undefined
+
 /**
- * This hook will fire whenever a connection occurs.
+ * Pass a callback to this hook that will fire whenever an initial connection or reconnect occurs.
+ * 
+ * The callback can return a disconnection callback that will fire whenever a disconnect or unmount occurs.
+ * 
+ * @example
+ * ```ts
+ * useConnect(() => {
+ *    const clearPoll = startPolling()
+ *    return () => clearPoll()
+ * })
+ * ```
  */
-export const useConnect = (callback: () => void) => {
+export const useConnect = (callback: ConnectCallback) => {
   const { connectionStatus } = useRobotClient();
 
-  const unsub = connectionStatus.subscribe((value) => {
-    if (value === 'connected') {
-      callback();
+  let disconnectCallback: DisconnectCallback | undefined
+
+  onMount(() => {
+    const unsubscribe = connectionStatus.subscribe((value) => {
+      if (value === 'connected') {
+        disconnectCallback = callback();
+      } else if (value === 'reconnecting') {
+        disconnectCallback?.()
+      }
+    })
+
+    return () => {
+      unsubscribe()
+      disconnectCallback?.()
     }
   });
-
-  onDestroy(() => unsub());
-};
-
-/**
- * This hook will fire whenever a disconnect occurs or when a component unmounts.
- */
-export const useDisconnect = (callback: () => void) => {
-  const { statusStream } = useRobotClient();
-
-  statusStream.subscribe((update) => update?.on('end', callback));
-
-  onDestroy(callback);
 };

--- a/web/frontend/src/hooks/robot-client.ts
+++ b/web/frontend/src/hooks/robot-client.ts
@@ -36,8 +36,10 @@ export type ConnectCallback = (() => DisconnectCallback) | (() => void)
  * @example
  * ```ts
  * useConnect(() => {
- *    const clearPoll = startPolling()
- *    return () => clearPoll()
+ *   // This will fire after component mount, once a robot has connected, and on reconnect.
+ *   return () => {
+ *     // This will fire if a robot disconnects, or when the component is destroyed.
+ *   }
  * })
  * ```
  */

--- a/web/frontend/src/lib/components/collapse.svelte
+++ b/web/frontend/src/lib/components/collapse.svelte
@@ -1,20 +1,51 @@
 <script lang='ts' context='module'>
-  export type StopCallback = (callback: () => void) => void
+  import { onMount, createEventDispatcher, tick, getContext, setContext } from 'svelte';
+  import { writable } from 'svelte/store';
+
+  interface CollapseContext {
+    /**
+     * Fires when a stop command is issued from the navbar of the `<Collapse>` component.
+     */
+    onStop(callback: () => void): void
+  }
+
+  export let collapseContextKey = Symbol('Collapse context')
+
+  export const useStop = () => {
+    return getContext<CollapseContext>(collapseContextKey)
+  }
 </script>
 
 <script lang="ts">
-
-import { onMount, createEventDispatcher, tick } from 'svelte';
 import { Button } from '@viamrobotics/prime-core';
 
+/**
+ * The name of the component.
+ */
 export let title = '';
+
+/**
+ * Component metadata.
+ */
 export let crumbs = '';
+
+/**
+ * Whether the card body is displayed or not.
+ */
 export let open = Boolean(localStorage.getItem(`rc.collapse.${title}.open`));
-export let hasStop = false
+
+/**
+ * Whether the component has a stop command. Will render a button to issue commands.
+ */
+export let stop = false
 
 let stopCallback = () => {}
 
-const onStop = (callback: () => void) => { stopCallback = callback }
+setContext<CollapseContext>(collapseContextKey, {
+  onStop(callback: () => void) {
+    stopCallback = callback
+  }
+})
 
 const dispatch = createEventDispatcher();
 
@@ -37,7 +68,7 @@ const handleClick = async (event: Event) => {
 };
 
 const handleStopClick = (event: MouseEvent) => {
-  event.preventDefault()
+  event.stopPropagation()
   stopCallback()
 }
 
@@ -70,7 +101,7 @@ onMount(() => {
     </div>
 
     <div class="h-full flex items-center gap-3">
-      {#if hasStop}
+      {#if stop}
         <Button
           variant="danger"
           icon="stop-circle-outline"
@@ -91,6 +122,6 @@ onMount(() => {
   </button>
 
   {#if open}
-    <slot {onStop} />
+    <slot />
   {/if}
 </div>

--- a/web/frontend/src/lib/components/collapse.svelte
+++ b/web/frontend/src/lib/components/collapse.svelte
@@ -1,28 +1,8 @@
-<script lang='ts' context='module'>
-  import { onMount, createEventDispatcher, tick, getContext, setContext } from 'svelte';
-
-  interface CollapseContext {
-    /**
-     * Fires when a stop command is issued from the navbar of the `<Collapse>` component.
-     */
-    onStop(callback: () => void): void
-  }
-
-  const collapseContextKey = Symbol('Collapse context')
-
-  export const useStop = (): CollapseContext => {
-    const context = getContext<CollapseContext>(collapseContextKey)
-
-    if (!context) {
-      throw new Error('No `useStop` context found. This hook must be called within a child of `<Collapse>`.')
-    }
-
-    return context
-  }
-</script>
 
 <script lang="ts">
+import { onMount, createEventDispatcher, tick, setContext } from 'svelte';
 import { Button } from '@viamrobotics/prime-core';
+import { type CollapseContext, collapseContextKey } from './collapse';
 
 /**
  * The name of the component.
@@ -47,7 +27,7 @@ export let stop = false
 let stopCallback: (() => void) | undefined
 
 setContext<CollapseContext>(collapseContextKey, {
-  onStop(callback: () => void) {
+  onStop: (callback: () => void) => {
     stopCallback = callback
   }
 })

--- a/web/frontend/src/lib/components/collapse.svelte
+++ b/web/frontend/src/lib/components/collapse.svelte
@@ -1,6 +1,5 @@
 <script lang='ts' context='module'>
   import { onMount, createEventDispatcher, tick, getContext, setContext } from 'svelte';
-  import { writable } from 'svelte/store';
 
   interface CollapseContext {
     /**
@@ -9,10 +8,16 @@
     onStop(callback: () => void): void
   }
 
-  export let collapseContextKey = Symbol('Collapse context')
+  const collapseContextKey = Symbol('Collapse context')
 
-  export const useStop = () => {
-    return getContext<CollapseContext>(collapseContextKey)
+  export const useStop = (): CollapseContext => {
+    const context = getContext<CollapseContext>(collapseContextKey)
+
+    if (!context) {
+      throw new Error('No `useStop` context found. This hook must be called within a child of `<Collapse>`.')
+    }
+
+    return context
   }
 </script>
 
@@ -39,7 +44,7 @@ export let open = Boolean(localStorage.getItem(`rc.collapse.${title}.open`));
  */
 export let stop = false
 
-let stopCallback = () => {}
+let stopCallback: (() => void) | undefined
 
 setContext<CollapseContext>(collapseContextKey, {
   onStop(callback: () => void) {
@@ -69,7 +74,7 @@ const handleClick = async (event: Event) => {
 
 const handleStopClick = (event: MouseEvent) => {
   event.stopPropagation()
-  stopCallback()
+  stopCallback?.()
 }
 
 onMount(() => {

--- a/web/frontend/src/lib/components/collapse.ts
+++ b/web/frontend/src/lib/components/collapse.ts
@@ -1,0 +1,22 @@
+
+import { getContext } from 'svelte';
+
+export interface CollapseContext {
+  /**
+   * Fires when a stop command is issued from the navbar of the `<Collapse>` component.
+   */
+  onStop: (callback: () => void) => void
+}
+
+export const collapseContextKey = Symbol('Collapse context')
+
+export const useStop = (): CollapseContext => {
+  const context = getContext<CollapseContext>(collapseContextKey)
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (!context) {
+    throw new Error('No `useStop` context found. This hook must be called within a child of `<Collapse>`.')
+  }
+
+  return context
+}


### PR DESCRIPTION
### Overview

This PR is a small incremental step toward improving connection stability in the RC app before we begin on some of the larger solutions we've been discussing. RC up to this point does not have a holistic way of handling disconnects / reconnects. This PR changes that by introducing a simple way to reactively handle these events:

```ts
useConnect(() => {
  // This will fire after component mount, once a robot has connected, and on reconnect.
  return () => {
    // This will fire if a robot disconnects, or when the component is destroyed.
  }
})
```

Establishing this pattern should also reduce some of the issues that have recently emerged in some components where we see instances of conflicting polling start / end events (the SLAM card notably being an example of this).

To achieve this pattern, the collapsible component was moved out of each card into the `remote-control-cards` component. The effect is that the inner component will not mount, and communication with the robot will not occur, unless a collapsible card is open. This will also make it easier to migrate individual RC cards into app in the future.

### Requests

Check the environment that renders using fake components.

### Notes

Some of these files appear to have large changes in the templating sections, but nothing here was changed other than removing the parent `<Collapsible>`.