### PR TITLE
RSDK-6145 TP-space smoothing is not functioning

### DIFF
--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -45,7 +45,7 @@ const (
 	builtinOpLabel                   = "motion-service"
 	maxTravelDistanceMM              = 5e6 // this is equivalent to 5km
 	lookAheadDistanceMM      float64 = 5e6
-	defaultSmoothIter                = 20
+	defaultSmoothIter                = 30
 	defaultAngularDegsPerSec         = 20.
 	defaultLinearMPerSec             = 0.3
 	defaultObstaclePollingHz         = 1.


### PR DESCRIPTION
The use of `defaultIdenticalNodeDistance` was mostly preventing any smoothing iteration from running, an issue that was exacerbated after merging RSDK-5758.

RSDK-5758 additionally made it unnecessary to run a second iteration of the smoother to reconnect to the goal, accounting for any drift from the smoothing connection. This should improve smoother runtimes substantially.

Accordingly I increased the default number of smoother iterations slightly; experimentation showed 30 providing a large improvement over 20.