### PR TITLE
RSDK-5105 enable hardware pwm on custom linux

### DIFF
--- a/components/board/customlinux/board.go
+++ b/components/board/customlinux/board.go
@@ -84,16 +84,8 @@ func parseRawPinData(pinData []byte, filePath string) ([]genericlinux.PinDefinit
 	}
 
 	var err error
-	for name, pin := range parsedPinData.Pins {
+	for _, pin := range parsedPinData.Pins {
 		err = multierr.Combine(err, pin.Validate(filePath))
-
-		// Until we get hardware PWM working reliably on lots of boards (likely by being able to
-		// set the pin mode directly), we disable all hardware PWM on these boards.
-		// The range operator makes a copy of the value, so to change the original, we need to look
-		// it up in the map again.
-		// TODO(RSDK-5105): Undo this when we're ready to support hardware PWM.
-		parsedPinData.Pins[name].PwmChipSysfsDir = ""
-		parsedPinData.Pins[name].PwmID = -1
 	}
 	if err != nil {
 		return nil, err

--- a/components/board/customlinux/board.go
+++ b/components/board/customlinux/board.go
@@ -88,9 +88,9 @@ func parseRawPinData(pinData []byte, filePath string) ([]genericlinux.PinDefinit
 		err = multierr.Combine(err, pin.Validate(filePath))
 
 		// Until we can reliably switch between gpio and pwm on lots of boards, pins that have
-		// hardware pwm enabled will be hardware pwm only. Disabling gpio functianality on these
+		// hardware pwm enabled will be hardware pwm only. Disabling gpio functionality on these
 		// pins.
-		if parsedPinData.Pins[name].PwmChipSysfsDir != "" {
+		if parsedPinData.Pins[name].PwmChipSysfsDir != "" && parsedPinData.Pins[name].LineNumber >= 0 {
 			logging.Global().Warnf("pin %s can be used for PWM only", parsedPinData.Pins[name].Name)
 			parsedPinData.Pins[name].LineNumber = -1
 		}


### PR DESCRIPTION
all pins that have both gpio and pwm defined in their board defintion files will be hardware pwm only.