### PR TITLE
Stop spamming logs when wit imu disconnects

### DIFF
--- a/components/movementsensor/imuwit/imu.go
+++ b/components/movementsensor/imuwit/imu.go
@@ -312,7 +312,12 @@ func (imu *wit) startUpdateLoop(ctx context.Context, portReader *bufio.Reader, l
 				switch {
 				case err != nil:
 					imu.err.Set(err)
-					logger.CError(ctx, err)
+					if imu.numBadReadings < 20 {
+						logger.CError(ctx, err)
+					} else {
+						logger.CDebug(ctx, err)
+					}
+
 				case len(line) != 11:
 					imu.numBadReadings++
 					return

--- a/components/movementsensor/imuwit/imu.go
+++ b/components/movementsensor/imuwit/imu.go
@@ -312,8 +312,9 @@ func (imu *wit) startUpdateLoop(ctx context.Context, portReader *bufio.Reader, l
 				switch {
 				case err != nil:
 					imu.err.Set(err)
+					imu.numBadReadings++
 					if imu.numBadReadings < 20 {
-						logger.CError(ctx, err)
+						logger.CError(ctx, err, "Check if wit imu is disconnected from port")
 					} else {
 						logger.CDebug(ctx, err)
 					}


### PR DESCRIPTION
If a wit imu is disconnected when viam server is running, we're in danger of forever spamming error logs until the device is connected again. 

This stops spamming these logs after 20 log lines, increments the numBadIMU readings in the the error case, and adds a little more context as to why this error may be happening.

Past a count of 20 log lines, we demote the EOF error that results from disconnecting the serial port to a Debug line.