### PR TITLE
RSDK-5931 - Fix test timeout for TestDataCaptureUploadIntegration

### DIFF
--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -529,7 +529,6 @@ func (svc *builtIn) startSyncScheduler(intervalMins float64) {
 func (svc *builtIn) cancelSyncScheduler() {
 	if svc.syncRoutineCancelFn != nil {
 		svc.syncRoutineCancelFn()
-		svc.backgroundWorkers.Wait()
 		svc.syncRoutineCancelFn = nil
 	}
 }


### PR DESCRIPTION
Ran all `services/datamanager/builtin` tests multiple times using `-c 50` 
Also tried running with a config locally, turning capture on and off