### PR TITLE
[RSDK-1963] servo digital interrupts are only in the raspberry pi code

### DIFF
--- a/components/board/board.go
+++ b/components/board/board.go
@@ -88,11 +88,6 @@ type AnalogReader interface {
 	Close(ctx context.Context) error
 }
 
-// A PostProcessor takes a raw input and transforms it into a new value.
-// Multiple post processors can be stacked on each other. This is currently
-// only used in DigitalInterrupt readings.
-type PostProcessor func(raw int64) int64
-
 // FromDependencies is a helper for getting the named board from a collection of
 // dependencies.
 func FromDependencies(deps resource.Dependencies, name string) (Board, error) {

--- a/components/board/client.go
+++ b/components/board/client.go
@@ -253,10 +253,6 @@ func (dic *digitalInterruptClient) RemoveCallback(c chan Tick) {
 	panic(errUnimplemented)
 }
 
-func (dic *digitalInterruptClient) AddPostProcessor(pp PostProcessor) {
-	panic(errUnimplemented)
-}
-
 // gpioPinClient satisfies a gRPC based board.GPIOPin. Refer to the interface
 // for descriptions of its methods.
 type gpioPinClient struct {

--- a/components/board/config.go
+++ b/components/board/config.go
@@ -53,8 +53,6 @@ func (config *AnalogReaderConfig) Validate(path string) error {
 type DigitalInterruptConfig struct {
 	Name    string `json:"name"`
 	Pin     string `json:"pin"`
-	Type    string `json:"type,omitempty"` // e.g. basic, servo
-	Formula string `json:"formula,omitempty"`
 }
 
 // Validate ensures all parts of the config are valid.

--- a/components/board/config.go
+++ b/components/board/config.go
@@ -51,8 +51,8 @@ func (config *AnalogReaderConfig) Validate(path string) error {
 
 // DigitalInterruptConfig describes the configuration of digital interrupt for a board.
 type DigitalInterruptConfig struct {
-	Name    string `json:"name"`
-	Pin     string `json:"pin"`
+	Name string `json:"name"`
+	Pin  string `json:"pin"`
 }
 
 // Validate ensures all parts of the config are valid.

--- a/components/board/digital_interrupts.go
+++ b/components/board/digital_interrupts.go
@@ -24,8 +24,7 @@ type Tick struct {
 }
 
 // A DigitalInterrupt represents a configured interrupt on the board that
-// when interrupted, calls the added callbacks. Post processors can also
-// be added to modify what Value ultimately returns.
+// when interrupted, calls the added callbacks.
 type DigitalInterrupt interface {
 	// Value returns the current value of the interrupt which is
 	// based on the type of interrupt.

--- a/components/board/digital_interrupts.go
+++ b/components/board/digital_interrupts.go
@@ -100,13 +100,6 @@ type BasicDigitalInterrupt struct {
 	pp  PostProcessor
 }
 
-// Config returns the config used to create this interrupt.
-func (i *BasicDigitalInterrupt) Config(ctx context.Context) (DigitalInterruptConfig, error) {
-	i.mu.RLock()
-	defer i.mu.RUnlock()
-	return i.cfg, nil
-}
-
 // Value returns the amount of ticks that have occurred.
 func (i *BasicDigitalInterrupt) Value(ctx context.Context, extra map[string]interface{}) (int64, error) {
 	i.mu.RLock()
@@ -242,13 +235,6 @@ type ServoDigitalInterrupt struct {
 	mu  sync.RWMutex
 	cfg DigitalInterruptConfig
 	pp  PostProcessor
-}
-
-// Config returns the config the interrupt was created with.
-func (i *ServoDigitalInterrupt) Config(ctx context.Context) (DigitalInterruptConfig, error) {
-	i.mu.RLock()
-	defer i.mu.RUnlock()
-	return i.cfg, nil
 }
 
 // Value will return the window averaged value followed by its post processed

--- a/components/board/digital_interrupts.go
+++ b/components/board/digital_interrupts.go
@@ -41,10 +41,6 @@ type DigitalInterrupt interface {
 	// happens.
 	AddCallback(c chan Tick)
 
-	// AddPostProcessor adds a post processor that should be used to modify
-	// what is returned by Value.
-	AddPostProcessor(pp PostProcessor)
-
 	// RemoveCallback removes a listener for interrupts
 	RemoveCallback(c chan Tick)
 
@@ -58,8 +54,8 @@ type ReconfigurableDigitalInterrupt interface {
 	Reconfigure(cfg DigitalInterruptConfig) error
 }
 
-// A PostProcessor takes a raw input and transforms it into a new value.
-// Multiple post processors can be stacked on each other.
+// A PostProcessor takes a raw input and transforms it into a new value. Multiple post processors
+// can be stacked on each other. PostProcessors are only used in the SDK.
 type PostProcessor func(raw int64) int64
 
 // CreateDigitalInterrupt is a factory method for creating a specific DigitalInterrupt based

--- a/components/board/digital_interrupts.go
+++ b/components/board/digital_interrupts.go
@@ -78,7 +78,6 @@ type BasicDigitalInterrupt struct {
 
 	mu  sync.RWMutex
 	cfg DigitalInterruptConfig
-	pp  PostProcessor
 }
 
 // Value returns the amount of ticks that have occurred.
@@ -86,9 +85,6 @@ func (i *BasicDigitalInterrupt) Value(ctx context.Context, extra map[string]inte
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 	count := atomic.LoadInt64(&i.count)
-	if i.pp != nil {
-		return i.pp(count), nil
-	}
 	return count, nil
 }
 
@@ -141,14 +137,6 @@ func (i *BasicDigitalInterrupt) RemoveCallback(c chan Tick) {
 			break
 		}
 	}
-}
-
-// AddPostProcessor sets the post processor that will modify the value that
-// Value returns.
-func (i *BasicDigitalInterrupt) AddPostProcessor(pp PostProcessor) {
-	i.mu.Lock()
-	defer i.mu.Unlock()
-	i.pp = pp
 }
 
 // Close does nothing.

--- a/components/board/digital_interrupts.go
+++ b/components/board/digital_interrupts.go
@@ -54,10 +54,6 @@ type ReconfigurableDigitalInterrupt interface {
 	Reconfigure(cfg DigitalInterruptConfig) error
 }
 
-// A PostProcessor takes a raw input and transforms it into a new value. Multiple post processors
-// can be stacked on each other. PostProcessors are only used in the SDK.
-type PostProcessor func(raw int64) int64
-
 // CreateDigitalInterrupt is a factory method for creating a specific DigitalInterrupt based
 // on the given config. If no type is specified, a BasicDigitalInterrupt is returned.
 func CreateDigitalInterrupt(cfg DigitalInterruptConfig) (ReconfigurableDigitalInterrupt, error) {

--- a/components/board/digital_interrupts.go
+++ b/components/board/digital_interrupts.go
@@ -61,6 +61,10 @@ type ReconfigurableDigitalInterrupt interface {
 	Reconfigure(cfg DigitalInterruptConfig) error
 }
 
+// A PostProcessor takes a raw input and transforms it into a new value.
+// Multiple post processors can be stacked on each other.
+type PostProcessor func(raw int64) int64
+
 // CreateDigitalInterrupt is a factory method for creating a specific DigitalInterrupt based
 // on the given config. If no type is specified, a BasicDigitalInterrupt is returned.
 func CreateDigitalInterrupt(cfg DigitalInterruptConfig) (ReconfigurableDigitalInterrupt, error) {

--- a/components/board/digital_interrupts_test.go
+++ b/components/board/digital_interrupts_test.go
@@ -16,7 +16,6 @@ func nowNanosecondsTest() uint64 {
 func TestBasicDigitalInterrupt1(t *testing.T) {
 	config := DigitalInterruptConfig{
 		Name:    "i1",
-		Formula: "(+ 1 raw)",
 	}
 
 	i, err := CreateDigitalInterrupt(config)
@@ -24,15 +23,15 @@ func TestBasicDigitalInterrupt1(t *testing.T) {
 
 	intVal, err := i.Value(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, intVal, test.ShouldEqual, int64(1))
+	test.That(t, intVal, test.ShouldEqual, int64(0))
 	test.That(t, i.Tick(context.Background(), true, nowNanosecondsTest()), test.ShouldBeNil)
 	intVal, err = i.Value(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, intVal, test.ShouldEqual, int64(2))
+	test.That(t, intVal, test.ShouldEqual, int64(1))
 	test.That(t, i.Tick(context.Background(), false, nowNanosecondsTest()), test.ShouldBeNil)
 	intVal, err = i.Value(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, intVal, test.ShouldEqual, int64(2))
+	test.That(t, intVal, test.ShouldEqual, int64(1))
 
 	c := make(chan Tick)
 	i.AddCallback(c)
@@ -148,49 +147,4 @@ func TestRemoveCallbackDigitalInterrupt(t *testing.T) {
 	intVal, err = i.Value(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, intVal, test.ShouldEqual, int64(3))
-}
-
-func TestServoInterrupt(t *testing.T) {
-	config := DigitalInterruptConfig{
-		Name: "s1",
-		Type: "servo",
-	}
-
-	s, err := CreateDigitalInterrupt(config)
-	test.That(t, err, test.ShouldBeNil)
-
-	now := uint64(0)
-	for i := 0; i < 20; i++ {
-		test.That(t, s.Tick(context.Background(), true, now), test.ShouldBeNil)
-		now += 1500 * 1000 // this is what we measure
-		test.That(t, s.Tick(context.Background(), false, now), test.ShouldBeNil)
-		now += 1000 * 1000 * 1000 // this is between measurements
-	}
-
-	intVal, err := s.Value(context.Background(), nil)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, intVal, test.ShouldEqual, int64(1500))
-}
-
-func TestServoInterruptWithPP(t *testing.T) {
-	config := DigitalInterruptConfig{
-		Name:    "s1",
-		Type:    "servo",
-		Formula: "(+ 1 raw)",
-	}
-
-	s, err := CreateDigitalInterrupt(config)
-	test.That(t, err, test.ShouldBeNil)
-
-	now := uint64(0)
-	for i := 0; i < 20; i++ {
-		test.That(t, s.Tick(context.Background(), true, now), test.ShouldBeNil)
-		now += 1500 * 1000 // this is what we measure
-		test.That(t, s.Tick(context.Background(), false, now), test.ShouldBeNil)
-		now += 1000 * 1000 * 1000 // this is between measurements
-	}
-
-	intVal, err := s.Value(context.Background(), nil)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, intVal, test.ShouldEqual, int64(1501))
 }

--- a/components/board/digital_interrupts_test.go
+++ b/components/board/digital_interrupts_test.go
@@ -15,7 +15,7 @@ func nowNanosecondsTest() uint64 {
 
 func TestBasicDigitalInterrupt1(t *testing.T) {
 	config := DigitalInterruptConfig{
-		Name:    "i1",
+		Name: "i1",
 	}
 
 	i, err := CreateDigitalInterrupt(config)

--- a/components/board/fake/board.go
+++ b/components/board/fake/board.go
@@ -349,7 +349,6 @@ type DigitalInterruptWrapper struct {
 	di        board.DigitalInterrupt
 	conf      board.DigitalInterruptConfig
 	callbacks map[chan board.Tick]struct{}
-	pps       []board.PostProcessor
 }
 
 // NewDigitalInterruptWrapper returns a new digital interrupt to be used for testing.
@@ -379,9 +378,6 @@ func (s *DigitalInterruptWrapper) reset(conf board.DigitalInterruptConfig) error
 		s.di = di
 		for c := range s.callbacks {
 			s.di.AddCallback(c)
-		}
-		for _, pp := range s.pps {
-			s.di.AddPostProcessor(pp)
 		}
 		return nil
 	}
@@ -418,15 +414,6 @@ func (s *DigitalInterruptWrapper) AddCallback(c chan board.Tick) {
 	defer s.mu.Unlock()
 	s.callbacks[c] = struct{}{}
 	s.di.AddCallback(c)
-}
-
-// AddPostProcessor adds a post processor that should be used to modify
-// what is returned by Value.
-func (s *DigitalInterruptWrapper) AddPostProcessor(pp board.PostProcessor) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.pps = append(s.pps, pp)
-	s.di.AddPostProcessor(pp)
 }
 
 // RemoveCallback removes a listener for interrupts.

--- a/components/board/fake/board_test.go
+++ b/components/board/fake/board_test.go
@@ -19,7 +19,7 @@ func TestFakeBoard(t *testing.T) {
 		},
 		DigitalInterrupts: []board.DigitalInterruptConfig{
 			{Name: "i1", Pin: "35"},
-			{Name: "i2", Pin: "31", Type: "servo"},
+			{Name: "i2", Pin: "31"},
 			{Name: "a", Pin: "38"},
 			{Name: "b", Pin: "40"},
 		},

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -419,11 +419,9 @@ func (b *Board) DigitalInterruptByName(name string) (board.DigitalInterrupt, boo
 		return nil, false
 	}
 
-	const defaultInterruptType = "basic"
 	defaultInterruptConfig := board.DigitalInterruptConfig{
 		Name: name,
 		Pin:  name,
-		Type: defaultInterruptType,
 	}
 	interrupt, err := b.createDigitalInterrupt(
 		b.cancelCtx, defaultInterruptConfig, b.gpioMappings, nil)

--- a/components/board/pi/impl/board_test.go
+++ b/components/board/pi/impl/board_test.go
@@ -23,7 +23,7 @@ func TestPiPigpio(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 
 	cfg := Config{
-		DigitalInterrupts: []board.DigitalInterruptConfig{
+		DigitalInterrupts: []DigitalInterruptConfig{
 			{Name: "i1", Pin: "11"}, // bcom 17
 			{Name: "servo-i", Pin: "22", Type: "servo"},
 		},

--- a/components/board/pi/impl/digital_interrupts.go
+++ b/components/board/pi/impl/digital_interrupts.go
@@ -1,4 +1,4 @@
-package board
+package piimpl
 
 import (
 	"context"

--- a/components/board/pi/impl/digital_interrupts.go
+++ b/components/board/pi/impl/digital_interrupts.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/erh/scheme"
 	"github.com/pkg/errors"
 
 	"go.viam.com/rdk/components/board"
@@ -141,39 +140,6 @@ func (i *BasicDigitalInterrupt) RemoveCallback(c chan board.Tick) {
 // Close does nothing.
 func (i *BasicDigitalInterrupt) Close(ctx context.Context) error {
 	return nil
-}
-
-func processFormula(oldFormula, newFormula, name string) (func(raw int64) int64, bool, error) {
-	if oldFormula == newFormula {
-		return nil, false, nil
-	}
-	x, err := scheme.Parse(newFormula)
-	if err != nil {
-		return nil, false, errors.Wrapf(err, "couldn't parse formula for %s", name)
-	}
-
-	testScope := scheme.Scope{}
-	num := 1.0
-	testScope["raw"] = &scheme.Value{Float: &num}
-	_, err = scheme.Eval(x, testScope)
-	if err != nil {
-		return nil, false, errors.Wrapf(err, "test exec failed for %s", name)
-	}
-
-	return func(raw int64) int64 {
-		scope := scheme.Scope{}
-		rr := float64(raw) // TODO(erh): fix
-		scope["raw"] = &scheme.Value{Float: &rr}
-		res, err := scheme.Eval(x, scope)
-		if err != nil {
-			panic(err)
-		}
-		f, err := res.ToFloat()
-		if err != nil {
-			panic(err)
-		}
-		return int64(f)
-	}, true, nil
 }
 
 // Reconfigure reconfigures this digital interrupt with a new formula.

--- a/components/board/pi/impl/digital_interrupts.go
+++ b/components/board/pi/impl/digital_interrupts.go
@@ -26,38 +26,10 @@ type Tick struct {
 	TimestampNanosec uint64
 }
 
-// A DigitalInterrupt represents a configured interrupt on the board that
-// when interrupted, calls the added callbacks. Post processors can also
-// be added to modify what Value ultimately returns.
-type DigitalInterrupt interface {
-	// Value returns the current value of the interrupt which is
-	// based on the type of interrupt.
-	Value(ctx context.Context, extra map[string]interface{}) (int64, error)
-
-	// Tick is to be called either manually if the interrupt is a proxy to some real
-	// hardware interrupt or for tests.
-	// nanoseconds is from an arbitrary point in time, but always increasing and always needs
-	// to be accurate.
-	Tick(ctx context.Context, high bool, nanoseconds uint64) error
-
-	// AddCallback adds a callback to be sent a low/high value to when a tick
-	// happens.
-	AddCallback(c chan Tick)
-
-	// AddPostProcessor adds a post processor that should be used to modify
-	// what is returned by Value.
-	AddPostProcessor(pp PostProcessor)
-
-	// RemoveCallback removes a listener for interrupts
-	RemoveCallback(c chan Tick)
-
-	Close(ctx context.Context) error
-}
-
 // A ReconfigurableDigitalInterrupt is a simple reconfigurable digital interrupt that expects
 // reconfiguration within the same type.
 type ReconfigurableDigitalInterrupt interface {
-	DigitalInterrupt
+	board.DigitalInterrupt
 	Reconfigure(cfg DigitalInterruptConfig) error
 }
 

--- a/components/board/pi/impl/digital_interrupts.go
+++ b/components/board/pi/impl/digital_interrupts.go
@@ -19,7 +19,6 @@ type DigitalInterruptConfig struct {
 	Name    string `json:"name"`
 	Pin     string `json:"pin"`
 	Type    string `json:"type,omitempty"` // e.g. basic, servo
-	Formula string `json:"formula,omitempty"`
 }
 
 // Validate ensures all parts of the config are valid.
@@ -142,7 +141,7 @@ func (i *BasicDigitalInterrupt) Close(ctx context.Context) error {
 	return nil
 }
 
-// Reconfigure reconfigures this digital interrupt with a new formula.
+// Reconfigure reconfigures this digital interrupt.
 func (i *BasicDigitalInterrupt) Reconfigure(conf DigitalInterruptConfig) error {
 	i.mu.Lock()
 	defer i.mu.Unlock()
@@ -205,7 +204,7 @@ func (i *ServoDigitalInterrupt) RemoveCallback(c chan board.Tick) {
 	panic("servos can't have callback")
 }
 
-// Reconfigure reconfigures this digital interrupt with a new formula.
+// Reconfigure reconfigures this digital interrupt.
 func (i *ServoDigitalInterrupt) Reconfigure(conf DigitalInterruptConfig) error {
 	i.mu.Lock()
 	defer i.mu.Unlock()

--- a/components/board/pi/impl/digital_interrupts.go
+++ b/components/board/pi/impl/digital_interrupts.go
@@ -1,0 +1,316 @@
+package board
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"github.com/erh/scheme"
+	"github.com/pkg/errors"
+
+	"go.viam.com/rdk/utils"
+)
+
+// ServoRollingAverageWindow is how many entries to average over for
+// servo ticks.
+const ServoRollingAverageWindow = 10
+
+// Tick represents a signal received by an interrupt pin. This signal is communicated
+// via registered channel to the various drivers. Depending on board implementation there may be a
+// wraparound in timestamp values past 4294967295000 nanoseconds (~72 minutes) if the value
+// was originally in microseconds as a 32-bit integer. The timestamp in nanoseconds of the
+// tick SHOULD ONLY BE USED FOR CALCULATING THE TIME ELAPSED BETWEEN CONSECUTIVE TICKS AND NOT
+// AS AN ABSOLUTE TIMESTAMP.
+type Tick struct {
+	High             bool
+	TimestampNanosec uint64
+}
+
+// A DigitalInterrupt represents a configured interrupt on the board that
+// when interrupted, calls the added callbacks. Post processors can also
+// be added to modify what Value ultimately returns.
+type DigitalInterrupt interface {
+	// Value returns the current value of the interrupt which is
+	// based on the type of interrupt.
+	Value(ctx context.Context, extra map[string]interface{}) (int64, error)
+
+	// Tick is to be called either manually if the interrupt is a proxy to some real
+	// hardware interrupt or for tests.
+	// nanoseconds is from an arbitrary point in time, but always increasing and always needs
+	// to be accurate.
+	Tick(ctx context.Context, high bool, nanoseconds uint64) error
+
+	// AddCallback adds a callback to be sent a low/high value to when a tick
+	// happens.
+	AddCallback(c chan Tick)
+
+	// AddPostProcessor adds a post processor that should be used to modify
+	// what is returned by Value.
+	AddPostProcessor(pp PostProcessor)
+
+	// RemoveCallback removes a listener for interrupts
+	RemoveCallback(c chan Tick)
+
+	Close(ctx context.Context) error
+}
+
+// A ReconfigurableDigitalInterrupt is a simple reconfigurable digital interrupt that expects
+// reconfiguration within the same type.
+type ReconfigurableDigitalInterrupt interface {
+	DigitalInterrupt
+	Reconfigure(cfg DigitalInterruptConfig) error
+}
+
+// A PostProcessor takes a raw input and transforms it into a new value.
+// Multiple post processors can be stacked on each other.
+type PostProcessor func(raw int64) int64
+
+// CreateDigitalInterrupt is a factory method for creating a specific DigitalInterrupt based
+// on the given config. If no type is specified, a BasicDigitalInterrupt is returned.
+func CreateDigitalInterrupt(cfg DigitalInterruptConfig) (ReconfigurableDigitalInterrupt, error) {
+	if cfg.Type == "" {
+		cfg.Type = "basic"
+	}
+
+	var i ReconfigurableDigitalInterrupt
+	switch cfg.Type {
+	case "basic":
+		i = &BasicDigitalInterrupt{}
+	case "servo":
+		i = &ServoDigitalInterrupt{ra: utils.NewRollingAverage(ServoRollingAverageWindow)}
+	default:
+		panic(errors.Errorf("unknown interrupt type (%s)", cfg.Type))
+	}
+
+	if err := i.Reconfigure(cfg); err != nil {
+		return nil, err
+	}
+	return i, nil
+}
+
+// A BasicDigitalInterrupt records how many ticks/interrupts happen and can
+// report when they happen to interested callbacks.
+type BasicDigitalInterrupt struct {
+	count int64
+
+	callbacks []chan Tick
+
+	mu  sync.RWMutex
+	cfg DigitalInterruptConfig
+	pp  PostProcessor
+}
+
+// Value returns the amount of ticks that have occurred.
+func (i *BasicDigitalInterrupt) Value(ctx context.Context, extra map[string]interface{}) (int64, error) {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	count := atomic.LoadInt64(&i.count)
+	if i.pp != nil {
+		return i.pp(count), nil
+	}
+	return count, nil
+}
+
+// Ticks is really just for testing.
+func (i *BasicDigitalInterrupt) Ticks(ctx context.Context, num int, now uint64) error {
+	for x := 0; x < num; x++ {
+		if err := i.Tick(ctx, true, now+uint64(x)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Tick records an interrupt and notifies any interested callbacks. See comment on
+// the DigitalInterrupt interface for caveats.
+func (i *BasicDigitalInterrupt) Tick(ctx context.Context, high bool, nanoseconds uint64) error {
+	if high {
+		atomic.AddInt64(&i.count, 1)
+	}
+
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	for _, c := range i.callbacks {
+		select {
+		case <-ctx.Done():
+			return errors.New("context cancelled")
+		case c <- Tick{High: high, TimestampNanosec: nanoseconds}:
+		}
+	}
+	return nil
+}
+
+// AddCallback adds a listener for interrupts.
+func (i *BasicDigitalInterrupt) AddCallback(c chan Tick) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.callbacks = append(i.callbacks, c)
+}
+
+// RemoveCallback removes a listener for interrupts.
+func (i *BasicDigitalInterrupt) RemoveCallback(c chan Tick) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	for id := range i.callbacks {
+		if i.callbacks[id] == c {
+			// To remove this item, we replace it with the last item in the list, then truncate the
+			// list by 1.
+			i.callbacks[id] = i.callbacks[len(i.callbacks)-1]
+			i.callbacks = i.callbacks[:len(i.callbacks)-1]
+			break
+		}
+	}
+}
+
+// AddPostProcessor sets the post processor that will modify the value that
+// Value returns.
+func (i *BasicDigitalInterrupt) AddPostProcessor(pp PostProcessor) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.pp = pp
+}
+
+// Close does nothing.
+func (i *BasicDigitalInterrupt) Close(ctx context.Context) error {
+	return nil
+}
+
+func processFormula(oldFormula, newFormula, name string) (func(raw int64) int64, bool, error) {
+	if oldFormula == newFormula {
+		return nil, false, nil
+	}
+	x, err := scheme.Parse(newFormula)
+	if err != nil {
+		return nil, false, errors.Wrapf(err, "couldn't parse formula for %s", name)
+	}
+
+	testScope := scheme.Scope{}
+	num := 1.0
+	testScope["raw"] = &scheme.Value{Float: &num}
+	_, err = scheme.Eval(x, testScope)
+	if err != nil {
+		return nil, false, errors.Wrapf(err, "test exec failed for %s", name)
+	}
+
+	return func(raw int64) int64 {
+		scope := scheme.Scope{}
+		rr := float64(raw) // TODO(erh): fix
+		scope["raw"] = &scheme.Value{Float: &rr}
+		res, err := scheme.Eval(x, scope)
+		if err != nil {
+			panic(err)
+		}
+		f, err := res.ToFloat()
+		if err != nil {
+			panic(err)
+		}
+		return int64(f)
+	}, true, nil
+}
+
+// Reconfigure reconfigures this digital interrupt with a new formula.
+func (i *BasicDigitalInterrupt) Reconfigure(conf DigitalInterruptConfig) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	newFormula, isNew, err := processFormula(i.cfg.Formula, conf.Formula, conf.Name)
+	if err != nil {
+		return err
+	}
+	if !isNew {
+		return nil
+	}
+	i.pp = newFormula
+	i.cfg = conf
+	return nil
+}
+
+// A ServoDigitalInterrupt is an interrupt associated with a servo in order to
+// track the amount of time that has passed between low signals (pulse width). Post processors
+// make meaning of these widths.
+type ServoDigitalInterrupt struct {
+	last uint64
+	ra   *utils.RollingAverage
+
+	mu  sync.RWMutex
+	cfg DigitalInterruptConfig
+	pp  PostProcessor
+}
+
+// Value will return the window averaged value followed by its post processed
+// result.
+func (i *ServoDigitalInterrupt) Value(ctx context.Context, extra map[string]interface{}) (int64, error) {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	v := int64(i.ra.Average())
+	if i.pp != nil {
+		return i.pp(v), nil
+	}
+
+	return v, nil
+}
+
+// Tick records the time between two successive low signals (pulse width). How it is
+// interpreted is based off the consumer of Value.
+func (i *ServoDigitalInterrupt) Tick(ctx context.Context, high bool, now uint64) error {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	diff := now - i.last
+	i.last = now
+
+	if i.last == 0 {
+		return nil
+	}
+
+	if high {
+		// this is time between signals, ignore
+		return nil
+	}
+
+	i.ra.Add(int(diff / 1000))
+	return nil
+}
+
+// AddCallback currently panics.
+func (i *ServoDigitalInterrupt) AddCallback(c chan Tick) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	panic("servos can't have callback")
+}
+
+// RemoveCallback currently panics.
+func (i *ServoDigitalInterrupt) RemoveCallback(c chan Tick) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	panic("servos can't have callback")
+}
+
+// AddPostProcessor sets the post processor that will modify the value that
+// Value returns.
+func (i *ServoDigitalInterrupt) AddPostProcessor(pp PostProcessor) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.pp = pp
+}
+
+// Reconfigure reconfigures this digital interrupt with a new formula.
+func (i *ServoDigitalInterrupt) Reconfigure(conf DigitalInterruptConfig) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	newFormula, isNew, err := processFormula(i.cfg.Formula, conf.Formula, conf.Name)
+	if err != nil {
+		return err
+	}
+	if !isNew {
+		return nil
+	}
+	i.pp = newFormula
+	i.cfg = conf
+	return nil
+}
+
+// Close does nothing.
+func (i *ServoDigitalInterrupt) Close(ctx context.Context) error {
+	return nil
+}

--- a/components/board/pi/impl/digital_interrupts.go
+++ b/components/board/pi/impl/digital_interrupts.go
@@ -15,21 +15,21 @@ import (
 
 // DigitalInterruptConfig describes the configuration of digital interrupt for the board.
 type DigitalInterruptConfig struct {
-    Name    string `json:"name"`
-    Pin     string `json:"pin"`
-    Type    string `json:"type,omitempty"` // e.g. basic, servo
-    Formula string `json:"formula,omitempty"`
+	Name    string `json:"name"`
+	Pin     string `json:"pin"`
+	Type    string `json:"type,omitempty"` // e.g. basic, servo
+	Formula string `json:"formula,omitempty"`
 }
 
 // Validate ensures all parts of the config are valid.
 func (config *DigitalInterruptConfig) Validate(path string) error {
-    if config.Name == "" {
-        return resource.NewConfigValidationFieldRequiredError(path, "name")
-    }
-    if config.Pin == "" {
-        return resource.NewConfigValidationFieldRequiredError(path, "pin")
-    }
-    return nil
+	if config.Name == "" {
+		return resource.NewConfigValidationFieldRequiredError(path, "name")
+	}
+	if config.Pin == "" {
+		return resource.NewConfigValidationFieldRequiredError(path, "pin")
+	}
+	return nil
 }
 
 // ServoRollingAverageWindow is how many entries to average over for

--- a/components/board/pi/impl/digital_interrupts.go
+++ b/components/board/pi/impl/digital_interrupts.go
@@ -1,3 +1,5 @@
+//go:build linux && (arm64 || arm) && !no_pigpio && !no_cgo
+
 package piimpl
 
 import (

--- a/components/board/pi/impl/digital_interrupts.go
+++ b/components/board/pi/impl/digital_interrupts.go
@@ -8,8 +8,29 @@ import (
 	"github.com/erh/scheme"
 	"github.com/pkg/errors"
 
+	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/utils"
 )
+
+// DigitalInterruptConfig describes the configuration of digital interrupt for the board.
+type DigitalInterruptConfig struct {
+    Name    string `json:"name"`
+    Pin     string `json:"pin"`
+    Type    string `json:"type,omitempty"` // e.g. basic, servo
+    Formula string `json:"formula,omitempty"`
+}
+
+// Validate ensures all parts of the config are valid.
+func (config *DigitalInterruptConfig) Validate(path string) error {
+    if config.Name == "" {
+        return resource.NewConfigValidationFieldRequiredError(path, "name")
+    }
+    if config.Pin == "" {
+        return resource.NewConfigValidationFieldRequiredError(path, "pin")
+    }
+    return nil
+}
 
 // ServoRollingAverageWindow is how many entries to average over for
 // servo ticks.

--- a/components/board/pi/impl/digital_interrupts.go
+++ b/components/board/pi/impl/digital_interrupts.go
@@ -16,9 +16,9 @@ import (
 
 // DigitalInterruptConfig describes the configuration of digital interrupt for the board.
 type DigitalInterruptConfig struct {
-	Name    string `json:"name"`
-	Pin     string `json:"pin"`
-	Type    string `json:"type,omitempty"` // e.g. basic, servo
+	Name string `json:"name"`
+	Pin  string `json:"pin"`
+	Type string `json:"type,omitempty"` // e.g. basic, servo
 }
 
 // Validate ensures all parts of the config are valid.

--- a/components/board/pi/impl/digital_interrupts_test.go
+++ b/components/board/pi/impl/digital_interrupts_test.go
@@ -177,8 +177,8 @@ func TestServoInterrupt(t *testing.T) {
 
 func TestServoInterruptWithPP(t *testing.T) {
 	config := DigitalInterruptConfig{
-		Name:    "s1",
-		Type:    "servo",
+		Name: "s1",
+		Type: "servo",
 	}
 
 	s, err := CreateDigitalInterrupt(config)

--- a/components/board/pi/impl/digital_interrupts_test.go
+++ b/components/board/pi/impl/digital_interrupts_test.go
@@ -1,4 +1,4 @@
-package board
+package piimpl
 
 import (
 	"context"

--- a/components/board/pi/impl/digital_interrupts_test.go
+++ b/components/board/pi/impl/digital_interrupts_test.go
@@ -19,7 +19,7 @@ func nowNanosecondsTest() uint64 {
 
 func TestBasicDigitalInterrupt1(t *testing.T) {
 	config := DigitalInterruptConfig{
-		Name:    "i1",
+		Name: "i1",
 	}
 
 	i, err := CreateDigitalInterrupt(config)

--- a/components/board/pi/impl/digital_interrupts_test.go
+++ b/components/board/pi/impl/digital_interrupts_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"go.viam.com/rdk/components/board"
 	"go.viam.com/test"
+
+	"go.viam.com/rdk/components/board"
 )
 
 func nowNanosecondsTest() uint64 {

--- a/components/board/pi/impl/digital_interrupts_test.go
+++ b/components/board/pi/impl/digital_interrupts_test.go
@@ -1,0 +1,196 @@
+package board
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"go.viam.com/test"
+)
+
+func nowNanosecondsTest() uint64 {
+	return uint64(time.Now().UnixNano())
+}
+
+func TestBasicDigitalInterrupt1(t *testing.T) {
+	config := DigitalInterruptConfig{
+		Name:    "i1",
+		Formula: "(+ 1 raw)",
+	}
+
+	i, err := CreateDigitalInterrupt(config)
+	test.That(t, err, test.ShouldBeNil)
+
+	intVal, err := i.Value(context.Background(), nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, intVal, test.ShouldEqual, int64(1))
+	test.That(t, i.Tick(context.Background(), true, nowNanosecondsTest()), test.ShouldBeNil)
+	intVal, err = i.Value(context.Background(), nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, intVal, test.ShouldEqual, int64(2))
+	test.That(t, i.Tick(context.Background(), false, nowNanosecondsTest()), test.ShouldBeNil)
+	intVal, err = i.Value(context.Background(), nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, intVal, test.ShouldEqual, int64(2))
+
+	c := make(chan Tick)
+	i.AddCallback(c)
+
+	timeNanoSec := nowNanosecondsTest()
+	go func() { i.Tick(context.Background(), true, timeNanoSec) }()
+	time.Sleep(1 * time.Microsecond)
+	v := <-c
+	test.That(t, v.High, test.ShouldBeTrue)
+	test.That(t, v.TimestampNanosec, test.ShouldEqual, timeNanoSec)
+
+	timeNanoSec = nowNanosecondsTest()
+	go func() { i.Tick(context.Background(), true, timeNanoSec) }()
+	v = <-c
+	test.That(t, v.High, test.ShouldBeTrue)
+	test.That(t, v.TimestampNanosec, test.ShouldEqual, timeNanoSec)
+
+	i.RemoveCallback(c)
+
+	c = make(chan Tick, 2)
+	i.AddCallback(c)
+	go func() {
+		i.Tick(context.Background(), true, uint64(1))
+		i.Tick(context.Background(), true, uint64(4))
+	}()
+	v = <-c
+	v1 := <-c
+	test.That(t, v.High, test.ShouldBeTrue)
+	test.That(t, v1.High, test.ShouldBeTrue)
+	test.That(t, v1.TimestampNanosec-v.TimestampNanosec, test.ShouldEqual, uint32(3))
+}
+
+func TestRemoveCallbackDigitalInterrupt(t *testing.T) {
+	config := DigitalInterruptConfig{
+		Name: "d1",
+	}
+	i, err := CreateDigitalInterrupt(config)
+	test.That(t, err, test.ShouldBeNil)
+	intVal, err := i.Value(context.Background(), nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, intVal, test.ShouldEqual, int64(0))
+	test.That(t, i.Tick(context.Background(), true, nowNanosecondsTest()), test.ShouldBeNil)
+	intVal, err = i.Value(context.Background(), nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, intVal, test.ShouldEqual, int64(1))
+
+	c1 := make(chan Tick)
+	test.That(t, c1, test.ShouldNotBeNil)
+	i.AddCallback(c1)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	ret := false
+
+	go func() {
+		defer wg.Done()
+		select {
+		case <-context.Background().Done():
+			return
+		default:
+		}
+		select {
+		case <-context.Background().Done():
+			return
+		case tick := <-c1:
+			ret = tick.High
+		}
+	}()
+	test.That(t, i.Tick(context.Background(), true, nowNanosecondsTest()), test.ShouldBeNil)
+	intVal, err = i.Value(context.Background(), nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, intVal, test.ShouldEqual, int64(2))
+	wg.Wait()
+	c2 := make(chan Tick)
+	test.That(t, c2, test.ShouldNotBeNil)
+	i.AddCallback(c2)
+	test.That(t, ret, test.ShouldBeTrue)
+
+	i.RemoveCallback(c1)
+	i.RemoveCallback(c1)
+
+	ret2 := false
+	result := make(chan bool, 1)
+	go func() {
+		defer wg.Done()
+		select {
+		case <-context.Background().Done():
+			return
+		default:
+		}
+		select {
+		case <-context.Background().Done():
+			return
+		case tick := <-c2:
+			ret2 = tick.High
+		}
+	}()
+	wg.Add(1)
+	go func() {
+		err := i.Tick(context.Background(), true, nowNanosecondsTest())
+		if err != nil {
+			result <- true
+		}
+		result <- true
+	}()
+	select {
+	case <-time.After(1 * time.Second):
+		ret = false
+	case ret = <-result:
+	}
+	wg.Wait()
+	test.That(t, ret, test.ShouldBeTrue)
+	test.That(t, ret2, test.ShouldBeTrue)
+	intVal, err = i.Value(context.Background(), nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, intVal, test.ShouldEqual, int64(3))
+}
+
+func TestServoInterrupt(t *testing.T) {
+	config := DigitalInterruptConfig{
+		Name: "s1",
+		Type: "servo",
+	}
+
+	s, err := CreateDigitalInterrupt(config)
+	test.That(t, err, test.ShouldBeNil)
+
+	now := uint64(0)
+	for i := 0; i < 20; i++ {
+		test.That(t, s.Tick(context.Background(), true, now), test.ShouldBeNil)
+		now += 1500 * 1000 // this is what we measure
+		test.That(t, s.Tick(context.Background(), false, now), test.ShouldBeNil)
+		now += 1000 * 1000 * 1000 // this is between measurements
+	}
+
+	intVal, err := s.Value(context.Background(), nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, intVal, test.ShouldEqual, int64(1500))
+}
+
+func TestServoInterruptWithPP(t *testing.T) {
+	config := DigitalInterruptConfig{
+		Name:    "s1",
+		Type:    "servo",
+		Formula: "(+ 1 raw)",
+	}
+
+	s, err := CreateDigitalInterrupt(config)
+	test.That(t, err, test.ShouldBeNil)
+
+	now := uint64(0)
+	for i := 0; i < 20; i++ {
+		test.That(t, s.Tick(context.Background(), true, now), test.ShouldBeNil)
+		now += 1500 * 1000 // this is what we measure
+		test.That(t, s.Tick(context.Background(), false, now), test.ShouldBeNil)
+		now += 1000 * 1000 * 1000 // this is between measurements
+	}
+
+	intVal, err := s.Value(context.Background(), nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, intVal, test.ShouldEqual, int64(1501))
+}

--- a/components/board/pi/impl/digital_interrupts_test.go
+++ b/components/board/pi/impl/digital_interrupts_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"go.viam.com/rdk/components/board"
 	"go.viam.com/test"
 )
 
@@ -34,7 +35,7 @@ func TestBasicDigitalInterrupt1(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, intVal, test.ShouldEqual, int64(2))
 
-	c := make(chan Tick)
+	c := make(chan board.Tick)
 	i.AddCallback(c)
 
 	timeNanoSec := nowNanosecondsTest()
@@ -52,7 +53,7 @@ func TestBasicDigitalInterrupt1(t *testing.T) {
 
 	i.RemoveCallback(c)
 
-	c = make(chan Tick, 2)
+	c = make(chan board.Tick, 2)
 	i.AddCallback(c)
 	go func() {
 		i.Tick(context.Background(), true, uint64(1))
@@ -79,7 +80,7 @@ func TestRemoveCallbackDigitalInterrupt(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, intVal, test.ShouldEqual, int64(1))
 
-	c1 := make(chan Tick)
+	c1 := make(chan board.Tick)
 	test.That(t, c1, test.ShouldNotBeNil)
 	i.AddCallback(c1)
 	var wg sync.WaitGroup
@@ -105,7 +106,7 @@ func TestRemoveCallbackDigitalInterrupt(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, intVal, test.ShouldEqual, int64(2))
 	wg.Wait()
-	c2 := make(chan Tick)
+	c2 := make(chan board.Tick)
 	test.That(t, c2, test.ShouldNotBeNil)
 	i.AddCallback(c2)
 	test.That(t, ret, test.ShouldBeTrue)

--- a/components/board/pi/impl/digital_interrupts_test.go
+++ b/components/board/pi/impl/digital_interrupts_test.go
@@ -1,3 +1,5 @@
+//go:build linux && (arm64 || arm) && !no_pigpio && !no_cgo
+
 package piimpl
 
 import (

--- a/components/board/pi/impl/digital_interrupts_test.go
+++ b/components/board/pi/impl/digital_interrupts_test.go
@@ -20,7 +20,6 @@ func nowNanosecondsTest() uint64 {
 func TestBasicDigitalInterrupt1(t *testing.T) {
 	config := DigitalInterruptConfig{
 		Name:    "i1",
-		Formula: "(+ 1 raw)",
 	}
 
 	i, err := CreateDigitalInterrupt(config)
@@ -28,15 +27,15 @@ func TestBasicDigitalInterrupt1(t *testing.T) {
 
 	intVal, err := i.Value(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, intVal, test.ShouldEqual, int64(1))
+	test.That(t, intVal, test.ShouldEqual, int64(0))
 	test.That(t, i.Tick(context.Background(), true, nowNanosecondsTest()), test.ShouldBeNil)
 	intVal, err = i.Value(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, intVal, test.ShouldEqual, int64(2))
+	test.That(t, intVal, test.ShouldEqual, int64(1))
 	test.That(t, i.Tick(context.Background(), false, nowNanosecondsTest()), test.ShouldBeNil)
 	intVal, err = i.Value(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, intVal, test.ShouldEqual, int64(2))
+	test.That(t, intVal, test.ShouldEqual, int64(1))
 
 	c := make(chan board.Tick)
 	i.AddCallback(c)
@@ -180,7 +179,6 @@ func TestServoInterruptWithPP(t *testing.T) {
 	config := DigitalInterruptConfig{
 		Name:    "s1",
 		Type:    "servo",
-		Formula: "(+ 1 raw)",
 	}
 
 	s, err := CreateDigitalInterrupt(config)
@@ -196,5 +194,5 @@ func TestServoInterruptWithPP(t *testing.T) {
 
 	intVal, err := s.Value(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, intVal, test.ShouldEqual, int64(1501))
+	test.That(t, intVal, test.ShouldEqual, int64(1500))
 }

--- a/components/board/pi/impl/external_hardware_test.go
+++ b/components/board/pi/impl/external_hardware_test.go
@@ -31,7 +31,7 @@ func TestPiHardware(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 
 	cfg := genericlinux.Config{
-		DigitalInterrupts: []board.DigitalInterruptConfig{
+		DigitalInterrupts: []DigitalInterruptConfig{
 			{Name: "i1", Pin: "11"},                     // plug physical 12(18) into this (17)
 			{Name: "servo-i", Pin: "22", Type: "servo"}, // bcom-25
 			{Name: "a", Pin: "33"},                      // bcom 13

--- a/components/board/pi/impl/external_hardware_test.go
+++ b/components/board/pi/impl/external_hardware_test.go
@@ -11,7 +11,6 @@ import (
 	"go.viam.com/test"
 
 	"go.viam.com/rdk/components/board"
-	"go.viam.com/rdk/components/board/genericlinux"
 	picommon "go.viam.com/rdk/components/board/pi/common"
 	"go.viam.com/rdk/components/encoder"
 	"go.viam.com/rdk/components/encoder/incremental"
@@ -30,7 +29,7 @@ func TestPiHardware(t *testing.T) {
 	ctx := context.Background()
 	logger := logging.NewTestLogger(t)
 
-	cfg := genericlinux.Config{
+	cfg := Config{
 		DigitalInterrupts: []DigitalInterruptConfig{
 			{Name: "i1", Pin: "11"},                     // plug physical 12(18) into this (17)
 			{Name: "servo-i", Pin: "22", Type: "servo"}, // bcom-25

--- a/components/encoder/incremental/incremental_test.go
+++ b/components/encoder/incremental/incremental_test.go
@@ -164,13 +164,11 @@ func MakeBoard(t *testing.T) *fakeboard.Board {
 	interrupt11, _ := fakeboard.NewDigitalInterruptWrapper(board.DigitalInterruptConfig{
 		Name: "11",
 		Pin:  "11",
-		Type: "basic",
 	})
 
 	interrupt13, _ := fakeboard.NewDigitalInterruptWrapper(board.DigitalInterruptConfig{
 		Name: "13",
 		Pin:  "13",
-		Type: "basic",
 	})
 
 	interrupts := map[string]*fakeboard.DigitalInterruptWrapper{

--- a/components/encoder/single/single_encoder_test.go
+++ b/components/encoder/single/single_encoder_test.go
@@ -235,7 +235,6 @@ func MakeBoard(t *testing.T) *fakeboard.Board {
 	interrupt, _ := fakeboard.NewDigitalInterruptWrapper(board.DigitalInterruptConfig{
 		Name: "10",
 		Pin:  "10",
-		Type: "basic",
 	})
 
 	interrupts := map[string]*fakeboard.DigitalInterruptWrapper{

--- a/components/motor/gpio/motor_encoder_test.go
+++ b/components/motor/gpio/motor_encoder_test.go
@@ -39,7 +39,6 @@ func MakeSingleBoard(t *testing.T) *fakeboard.Board {
 	interrupt, _ := fakeboard.NewDigitalInterruptWrapper(board.DigitalInterruptConfig{
 		Name: "10",
 		Pin:  "10",
-		Type: "basic",
 	})
 
 	interrupts := map[string]*fakeboard.DigitalInterruptWrapper{
@@ -58,13 +57,11 @@ func MakeIncrementalBoard(t *testing.T) *fakeboard.Board {
 	interrupt11, _ := fakeboard.NewDigitalInterruptWrapper(board.DigitalInterruptConfig{
 		Name: "11",
 		Pin:  "11",
-		Type: "basic",
 	})
 
 	interrupt13, _ := fakeboard.NewDigitalInterruptWrapper(board.DigitalInterruptConfig{
 		Name: "13",
 		Pin:  "13",
-		Type: "basic",
 	})
 
 	interrupts := map[string]*fakeboard.DigitalInterruptWrapper{
@@ -775,9 +772,7 @@ func TestWrapMotorWithEncoder(t *testing.T) {
 		fakeMotor := &fakemotor.Motor{
 			OpMgr: operation.NewSingleOperationManager(),
 		}
-		b.Digitals["a"], _ = fakeboard.NewDigitalInterruptWrapper(board.DigitalInterruptConfig{
-			Type: "basic",
-		})
+		b.Digitals["a"], _ = fakeboard.NewDigitalInterruptWrapper(board.DigitalInterruptConfig{})
 
 		ctx := context.Background()
 		deps := make(resource.Dependencies)
@@ -818,12 +813,8 @@ func TestWrapMotorWithEncoder(t *testing.T) {
 		fakeMotor := &fakemotor.Motor{
 			OpMgr: operation.NewSingleOperationManager(),
 		}
-		b.Digitals["a"], _ = fakeboard.NewDigitalInterruptWrapper(board.DigitalInterruptConfig{
-			Type: "basic",
-		})
-		b.Digitals["b"], _ = fakeboard.NewDigitalInterruptWrapper(board.DigitalInterruptConfig{
-			Type: "basic",
-		})
+		b.Digitals["a"], _ = fakeboard.NewDigitalInterruptWrapper(board.DigitalInterruptConfig{})
+		b.Digitals["b"], _ = fakeboard.NewDigitalInterruptWrapper(board.DigitalInterruptConfig{})
 
 		ctx := context.Background()
 		deps := make(resource.Dependencies)

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/edaniels/golinters v0.0.5-0.20220906153528-641155550742
 	github.com/edaniels/golog v0.0.0-20230215213219-28954395e8d0
 	github.com/edaniels/lidario v0.0.0-20220607182921-5879aa7b96dd
-	github.com/erh/scheme v0.0.0-20210304170849-99d295c6ce9a
 	github.com/fatih/color v1.15.0
 	github.com/fogleman/gg v1.3.0
 	github.com/fsnotify/fsnotify v1.6.0
@@ -129,7 +128,6 @@ require (
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/OpenPeeDeeP/depguard v1.1.1 // indirect
 	github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b // indirect
-	github.com/alecthomas/participle/v2 v2.0.0-alpha3 // indirect
 	github.com/alexkohler/prealloc v1.0.0 // indirect
 	github.com/alingse/asasalint v0.0.11 // indirect
 	github.com/apache/arrow/go/arrow v0.0.0-20201229220542-30ce2eb5d4dc // indirect

--- a/go.sum
+++ b/go.sum
@@ -113,10 +113,6 @@ github.com/ajstarks/deck v0.0.0-20200831202436-30c9fc6549a9/go.mod h1:JynElWSGnm
 github.com/ajstarks/deck/generate v0.0.0-20210309230005-c3f852c02e19/go.mod h1:T13YZdzov6OU0A1+RfKZiZN9ca6VeKdBdyDV+BY97Tk=
 github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b h1:slYM766cy2nI3BwyRiyQj/Ud48djTMtMebDqepE95rw=
 github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b/go.mod h1:1KcenG0jGWcpt8ov532z81sp/kMMUG485J2InIOyADM=
-github.com/alecthomas/participle/v2 v2.0.0-alpha3 h1:7aeHdGgRXADjrDEHwCpXiMMZqppOw2dpQfmVTyBN5cY=
-github.com/alecthomas/participle/v2 v2.0.0-alpha3/go.mod h1:Z1zPLDbcGsVsBYsThKXY00i84575bN/nMczzIrU4rWU=
-github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1 h1:GDQdwm/gAcJcLAKQQZGOJ4knlw+7rfEQQcmwTbt4p5E=
-github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -324,8 +320,6 @@ github.com/envoyproxy/protoc-gen-validate v0.0.14/go.mod h1:iSmxcyjqTsJpI2R4NaDN
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v1.0.2 h1:QkIBuU5k+x7/QXPvPPnWXWlCdaBFApVqftFV6k087DA=
 github.com/envoyproxy/protoc-gen-validate v1.0.2/go.mod h1:GpiZQP3dDbg4JouG/NNS7QWXpgx6x8QiMKdmN72jogE=
-github.com/erh/scheme v0.0.0-20210304170849-99d295c6ce9a h1:tWaYaMR6dQD4Kff5mSUSBoJlmchFp+gD9Zh3D2n1m/g=
-github.com/erh/scheme v0.0.0-20210304170849-99d295c6ce9a/go.mod h1:wIpMZCIb4SObzPwOLao0+RXU14jGgLG0Tk8PzJLYONQ=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 h1:Yzb9+7DPaBjB8zlTR87/ElzFsnQfuHnVUVqpZZIcV5Y=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a2zkGnVExMxdzMo3M0Hi/3sEU+cWnZpSni0O6/Yb/P0=
 github.com/esimonov/ifshort v1.0.1/go.mod h1:yZqNJUrNn20K8Q9n2CrjTKYyVEmX209Hgu+M1LBpeZE=

--- a/testutils/inject/digital_interrupt.go
+++ b/testutils/inject/digital_interrupt.go
@@ -14,7 +14,6 @@ type DigitalInterrupt struct {
 	TickFunc             func(ctx context.Context, high bool, nanoseconds uint64) error
 	tickCap              []interface{}
 	AddCallbackFunc      func(c chan board.Tick)
-	AddPostProcessorFunc func(pp board.PostProcessor)
 }
 
 // Value calls the injected Value or the real version.
@@ -60,13 +59,4 @@ func (d *DigitalInterrupt) AddCallback(c chan board.Tick) {
 		return
 	}
 	d.AddCallbackFunc(c)
-}
-
-// AddPostProcessor calls the injected AddPostProcessor or the real version.
-func (d *DigitalInterrupt) AddPostProcessor(pp board.PostProcessor) {
-	if d.AddPostProcessorFunc == nil {
-		d.DigitalInterrupt.AddPostProcessor(pp)
-		return
-	}
-	d.AddPostProcessorFunc(pp)
 }

--- a/testutils/inject/digital_interrupt.go
+++ b/testutils/inject/digital_interrupt.go
@@ -9,11 +9,11 @@ import (
 // DigitalInterrupt is an injected digital interrupt.
 type DigitalInterrupt struct {
 	board.DigitalInterrupt
-	ValueFunc            func(ctx context.Context, extra map[string]interface{}) (int64, error)
-	valueCap             []interface{}
-	TickFunc             func(ctx context.Context, high bool, nanoseconds uint64) error
-	tickCap              []interface{}
-	AddCallbackFunc      func(c chan board.Tick)
+	ValueFunc       func(ctx context.Context, extra map[string]interface{}) (int64, error)
+	valueCap        []interface{}
+	TickFunc        func(ctx context.Context, high bool, nanoseconds uint64) error
+	tickCap         []interface{}
+	AddCallbackFunc func(c chan board.Tick)
 }
 
 // Value calls the injected Value or the real version.


### PR DESCRIPTION
Github thinks @martha-johnston should review this, so I'll assign to her instead of using the randomizer.

I had this much, much cleaner this morning, where the only part left in the `board` package was the interface, and all the implementation details were left up to the boards. but then it turned out that a bunch of unit tests were using these as well, and I had to put a bunch of stuff back.

Main changes:
- The `PostProcessor` type is defined in board/digital_interrupts.go, rather than board/board.go. 
- There is a copy of all the digital interrupt stuff (including the configs) in board/pi/impl/ now. That component uses this new copy.
- The main (non-pi) version of digital interrupts no longer has a `ServoDigitalInterrupt` implementation.
- The main (non-pi) version of digital interrupt configs no longer takes a Type or Formula.

Part of me wants to go further and remove the `PostProcessor` from everything except the client-side SDK because it's unused everywhere else. but that would probably require a scope doc because it's changing the public interface.