### PR TITLE
[RSDK-6168] Plumb a logger through the customlinux ConfigConverter

### DIFF
--- a/components/board/customlinux/setup_test.go
+++ b/components/board/customlinux/setup_test.go
@@ -9,27 +9,29 @@ import (
 	"go.viam.com/test"
 
 	"go.viam.com/rdk/components/board/genericlinux"
+	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 )
 
 func TestConfigParse(t *testing.T) {
+	logger := logging.NewTestLogger(t)
 	emptyConfig := []byte(`{"pins": [{}]}`)
-	_, err := parseRawPinData(emptyConfig, "path")
+	_, err := parseRawPinData(emptyConfig, "path", logger)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, resource.GetFieldFromFieldRequiredError(err), test.ShouldEqual, "name")
 
 	emptyPWMID := []byte(`{"pins": [{"name": "7", "device_name": "gpiochip1", "line_number": 71, "pwm_chip_sysfs_dir": "hi"}]}`)
-	_, err = parseRawPinData(emptyPWMID, "path")
+	_, err = parseRawPinData(emptyPWMID, "path", logger)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "must supply pwm_id for the pwm chip")
 
 	invalidLineNumber := []byte(`{"pins": [{"name": "7", "device_name": "gpiochip1", "line_number": -2}]}`)
-	_, err = parseRawPinData(invalidLineNumber, "path")
+	_, err = parseRawPinData(invalidLineNumber, "path", logger)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "line_number on gpio chip must be at least zero")
 
 	validConfig := []byte(`{"pins": [{"name": "7", "device_name": "gpiochip1", "line_number": 80}]}`)
-	data, err := parseRawPinData(validConfig, "path")
+	data, err := parseRawPinData(validConfig, "path", logger)
 	correctData := make([]genericlinux.PinDefinition, 1)
 	correctData[0] = genericlinux.PinDefinition{
 		Name:       "7",

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -77,7 +77,7 @@ func (b *Board) Reconfigure(
 	_ resource.Dependencies,
 	conf resource.Config,
 ) error {
-	newConf, err := b.convertConfig(conf)
+	newConf, err := b.convertConfig(conf, b.logger)
 	if err != nil {
 		return err
 	}

--- a/components/board/genericlinux/config.go
+++ b/components/board/genericlinux/config.go
@@ -5,6 +5,7 @@ import (
 
 	"go.viam.com/rdk/components/board"
 	"go.viam.com/rdk/components/board/mcp3008helper"
+	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 )
 
@@ -46,14 +47,14 @@ type LinuxBoardConfig struct {
 // reconfiguration into a LinuxBoardConfig, so that we can reconfigure based on that. We return a
 // pointer to a LinuxBoardConfig instead of the struct itself so that we can return nil if we
 // encounter an error.
-type ConfigConverter = func(resource.Config) (*LinuxBoardConfig, error)
+type ConfigConverter = func(resource.Config, logging.Logger) (*LinuxBoardConfig, error)
 
 // ConstPinDefs takes in a map from pin names to GPIOBoardMapping structs, and returns a
 // ConfigConverter that will use these pin definitions in the underlying config. It is intended to
 // be used for board components whose pin definitions are built into the RDK, such as the
 // BeagleBone or Jetson boards.
 func ConstPinDefs(gpioMappings map[string]GPIOBoardMapping) ConfigConverter {
-	return func(conf resource.Config) (*LinuxBoardConfig, error) {
+	return func(conf resource.Config, logger logging.Logger) (*LinuxBoardConfig, error) {
 		newConf, err := resource.NativeConfig[*Config](conf)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Olivia, is this what you had in mind? The constructor already had a logger present, but the `ConfigConverter` was using the global logger. So, this PR adds a logger to the arguments to that function type. The only other `ConfigConverter` doesn't log anything, so nothing in it changed.

If you intended something else with this ticket, I'm happy to undo/redo anything you want. 