### PR TITLE
APP-3483 fail CLI --wait command when a build fails

### DIFF
--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"io"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"go.uber.org/multierr"
 	buildpb "go.viam.com/api/app/build/v1"
 	"go.viam.com/utils/pexec"
+	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 
 	"go.viam.com/rdk/logging"
@@ -159,6 +161,29 @@ func (c *viamClient) moduleBuildListAction(cCtx *cli.Context) error {
 	return nil
 }
 
+// filterMap is a helper that returns a new map based on k,v pairs that pass predicate.
+func filterMap[K comparable, V any](orig map[K]V, predicate func(K, V) bool) map[K]V {
+	ret := make(map[K]V)
+	for key, val := range orig {
+		if predicate(key, val) {
+			ret[key] = val
+		}
+	}
+	return ret
+}
+
+// anyFailed returns a useful error based on which platforms failed, or nil if all good.
+func buildError(statuses map[string]jobStatus) error {
+	failedPlatforms := filterMap(
+		statuses,
+		func(_ string, s jobStatus) bool { return s != jobStatusDone },
+	)
+	if len(failedPlatforms) == 0 {
+		return nil
+	}
+	return fmt.Errorf("some platforms failed to build: %s", strings.Join(maps.Keys(failedPlatforms), ", "))
+}
+
 // ModuleBuildLogsAction retrieves the logs for a specific build step.
 func ModuleBuildLogsAction(c *cli.Context) error {
 	buildID := c.String(moduleBuildFlagBuildID)
@@ -171,7 +196,11 @@ func ModuleBuildLogsAction(c *cli.Context) error {
 	}
 
 	if shouldWait {
-		if err := client.waitForBuildToFinish(buildID, platform); err != nil {
+		statuses, err := client.waitForBuildToFinish(buildID, platform)
+		if err != nil {
+			return err
+		}
+		if err := buildError(statuses); err != nil {
 			return err
 		}
 	}
@@ -265,38 +294,40 @@ func (c *viamClient) listModuleBuildJobs(moduleIDFilter string, count *int32, bu
 // waitForBuildToFinish calls listModuleBuildJobs every moduleBuildPollingInterval
 // Will wait until the status of the specified job is DONE or FAILED
 // if platform is empty, it waits for all jobs associated with the ID.
-func (c *viamClient) waitForBuildToFinish(buildID, platform string) error {
+func (c *viamClient) waitForBuildToFinish(buildID, platform string) (map[string]jobStatus, error) {
 	// If the platform is not empty, we should check that the platform is actually present on the build
 	// this is mostly to protect against users misspelling the platform
 	if platform != "" {
 		platformsForBuild, err := c.getPlatformsForModuleBuild(buildID)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if !slices.Contains(platformsForBuild, platform) {
-			return fmt.Errorf("platform %q is not present on build %q", platform, buildID)
+			return nil, fmt.Errorf("platform %q is not present on build %q", platform, buildID)
 		}
 	}
+	statuses := make(map[string]jobStatus)
 	ticker := time.NewTicker(moduleBuildPollingInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-c.c.Context.Done():
-			return c.c.Context.Err()
+			return nil, c.c.Context.Err()
 		case <-ticker.C:
 			jobsResponse, err := c.listModuleBuildJobs("", nil, &buildID)
 			if err != nil {
-				return errors.Wrap(err, "failed to list module build jobs")
+				return nil, errors.Wrap(err, "failed to list module build jobs")
 			}
 			if len(jobsResponse.Jobs) == 0 {
-				return fmt.Errorf("build id %q returned no jobs", buildID)
+				return nil, fmt.Errorf("build id %q returned no jobs", buildID)
 			}
 			// Loop through all the jobs and check if all the matching jobs are done
 			allDone := true
 			for _, job := range jobsResponse.Jobs {
 				if platform == "" || job.Platform == platform {
 					status := jobStatusFromProto(job.Status)
+					statuses[job.Platform] = status
 					if status != jobStatusDone && status != jobStatusFailed {
 						allDone = false
 						break
@@ -305,7 +336,7 @@ func (c *viamClient) waitForBuildToFinish(buildID, platform string) error {
 			}
 			// If all jobs are done, return
 			if allDone {
-				return nil
+				return statuses, nil
 			}
 		}
 	}

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -195,12 +195,10 @@ func ModuleBuildLogsAction(c *cli.Context) error {
 		return err
 	}
 
+	var statuses map[string]jobStatus
 	if shouldWait {
-		statuses, err := client.waitForBuildToFinish(buildID, platform)
+		statuses, err = client.waitForBuildToFinish(buildID, platform)
 		if err != nil {
-			return err
-		}
-		if err := buildError(statuses); err != nil {
 			return err
 		}
 	}
@@ -226,6 +224,9 @@ func ModuleBuildLogsAction(c *cli.Context) error {
 		}
 	}
 
+	if err := buildError(statuses); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/utils"
 )
 
 type jobStatus string
@@ -161,20 +162,9 @@ func (c *viamClient) moduleBuildListAction(cCtx *cli.Context) error {
 	return nil
 }
 
-// filterMap is a helper that returns a new map based on k,v pairs that pass predicate.
-func filterMap[K comparable, V any](orig map[K]V, predicate func(K, V) bool) map[K]V {
-	ret := make(map[K]V)
-	for key, val := range orig {
-		if predicate(key, val) {
-			ret[key] = val
-		}
-	}
-	return ret
-}
-
 // anyFailed returns a useful error based on which platforms failed, or nil if all good.
 func buildError(statuses map[string]jobStatus) error {
-	failedPlatforms := filterMap(
+	failedPlatforms := utils.FilterMap(
 		statuses,
 		func(_ string, s jobStatus) bool { return s != jobStatusDone },
 	)

--- a/cli/module_build_test.go
+++ b/cli/module_build_test.go
@@ -110,8 +110,9 @@ func TestModuleBuildWait(t *testing.T) {
 		},
 	}, &map[string]string{}, "token")
 	startWaitTime := time.Now()
-	err := ac.waitForBuildToFinish("xyz123", "")
+	statuses, err := ac.waitForBuildToFinish("xyz123", "")
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, statuses, test.ShouldResemble, map[string]jobStatus{"linux/amd64": "Done"})
 	// ensure that we had to wait for at least 2, but no more than 5 polling intervals
 	test.That(t,
 		time.Since(startWaitTime).Seconds(),

--- a/cli/module_build_test.go
+++ b/cli/module_build_test.go
@@ -85,6 +85,15 @@ xyz123 linux/amd64 Done   1.2.3   1970-01-01T00:00:00Z
 	test.That(t, errOut.messages, test.ShouldHaveLength, 0)
 }
 
+func TestBuildError(t *testing.T) {
+	err := buildError(map[string]jobStatus{"ok": jobStatusDone})
+	test.That(t, err, test.ShouldBeNil)
+	err = buildError(map[string]jobStatus{"bad": jobStatusFailed})
+	test.That(t, err.Error(), test.ShouldEqual, "some platforms failed to build: bad")
+	err = buildError(map[string]jobStatus{"ok": jobStatusDone, "bad": jobStatusFailed})
+	test.That(t, err.Error(), test.ShouldEqual, "some platforms failed to build: bad")
+}
+
 func TestModuleBuildWait(t *testing.T) {
 	// this creates a race condiition if there are multiple tests testing the moduleBuildPollingInterval
 	originalPollingInterval := moduleBuildPollingInterval

--- a/utils/value.go
+++ b/utils/value.go
@@ -10,3 +10,14 @@ func AssertType[T any](from interface{}) (T, error) {
 	}
 	return asserted, nil
 }
+
+// FilterMap is a helper that returns a new map based on k,v pairs that pass predicate.
+func FilterMap[K comparable, V any](orig map[K]V, predicate func(K, V) bool) map[K]V {
+	ret := make(map[K]V)
+	for key, val := range orig {
+		if predicate(key, val) {
+			ret[key] = val
+		}
+	}
+	return ret
+}

--- a/utils/value_test.go
+++ b/utils/value_test.go
@@ -31,3 +31,8 @@ type myAssertInt int
 func (m myAssertInt) method1() error {
 	return errors.New("cool 8)")
 }
+
+func TestFilterMap(t *testing.T) {
+	ret := FilterMap(map[string]int{"x": 1, "y": 2}, func(_ string, val int) bool { return val > 1 })
+	test.That(t, ret, test.ShouldResemble, map[string]int{"y": 2})
+}


### PR DESCRIPTION
## What changed
- previously, the `logs --wait` command would return 0 even if some or all of the platforms failed
- now it will return an error with information about the failed platforms