### PR TITLE
[RSDK-6073] bugfix: initialize the size of the LastError storage

### DIFF
--- a/components/movementsensor/utils.go
+++ b/components/movementsensor/utils.go
@@ -45,7 +45,7 @@ type LastError struct {
 // NewLastError creates a LastError object which will let you retrieve the most recent error if at
 // least `threshold` of the most recent `size` items put into it are non-nil.
 func NewLastError(size, threshold int) LastError {
-	return LastError{errs: make([]error, size), threshold: threshold}
+	return LastError{errs: make([]error, size), threshold: threshold, size: size}
 }
 
 // Set stores an error to be retrieved later.

--- a/components/movementsensor/utils_test.go
+++ b/components/movementsensor/utils_test.go
@@ -40,7 +40,7 @@ func TestTwoErrors(t *testing.T) {
 	test.That(t, err.Error(), test.ShouldEqual, "second")
 }
 
-func TestSetGetSet(t *testing.T) {
+func TestSetGetTwice(t *testing.T) {
 	le := NewLastError(1, 1)
 
 	le.Set(errors.New("first"))

--- a/components/movementsensor/utils_test.go
+++ b/components/movementsensor/utils_test.go
@@ -40,6 +40,18 @@ func TestTwoErrors(t *testing.T) {
 	test.That(t, err.Error(), test.ShouldEqual, "second")
 }
 
+func TestSetGetSet(t *testing.T) {
+	le := NewLastError(1, 1)
+
+	le.Set(errors.New("first"))
+	err := le.Get()
+	test.That(t, err.Error(), test.ShouldEqual, "first")
+
+	le.Set(errors.New("second"))
+	err = le.Get()
+	test.That(t, err.Error(), test.ShouldEqual, "second")
+}
+
 func TestSuppressRareErrors(t *testing.T) {
 	le := NewLastError(2, 2) // Only report if 2 of the last 2 are non-nil errors
 


### PR DESCRIPTION
The problem:
- `NewLastError()` never set the `size`, so it was initialized to 0
- If you call `Get()`, towards the end it sets `errs` to be a list of length `size` (a list of length 0)
- If you then call `Set()` you try to read `errs[0]` and panic because that's now out of range

The fix is easy: just initialize `size` to the right value.

There might need to be a second PR for this ticket, related to all the EOF errors Kat encountered talking to the IMU. but in the meantime, this is an important bugfix.