### PR TITLE
RSDK-2063: Fake motor default attributes and refactor

### DIFF
--- a/components/motor/fake/motor.go
+++ b/components/motor/fake/motor.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 
 	"go.viam.com/rdk/components/board"
+	fakeboard "go.viam.com/rdk/components/board/fake"
 	"go.viam.com/rdk/components/encoder"
 	"go.viam.com/rdk/components/encoder/fake"
 	"go.viam.com/rdk/components/motor"
@@ -18,7 +19,17 @@ import (
 	"go.viam.com/rdk/resource"
 )
 
-var model = resource.DefaultModelFamily.WithModel("fake")
+var (
+	motorModel    = resource.DefaultModelFamily.WithModel("fake")
+	b             board.Board
+	fakeBoardConf = resource.Config{
+		Name: "fakeboard",
+		API:  board.API,
+		ConvertedAttributes: &fakeboard.Config{
+			FailNew: false,
+		},
+	}
+)
 
 const defaultMaxRpm = 100
 
@@ -30,8 +41,8 @@ type PinConfig struct {
 
 // Config describes the configuration of a motor.
 type Config struct {
-	Pins             PinConfig `json:"pins"`
-	BoardName        string    `json:"board"`
+	Pins             PinConfig `json:"pins,omitempty"`
+	BoardName        string    `json:"board,omitempty"`
 	MinPowerPct      float64   `json:"min_power_pct,omitempty"`
 	MaxPowerPct      float64   `json:"max_power_pct,omitempty"`
 	PWMFreq          uint      `json:"pwm_freq,omitempty"`
@@ -57,23 +68,8 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 }
 
 func init() {
-	resource.RegisterComponent(motor.API, model, resource.Registration[motor.Motor, *Config]{
-		Constructor: func(
-			ctx context.Context,
-			deps resource.Dependencies,
-			conf resource.Config,
-			logger logging.Logger,
-		) (motor.Motor, error) {
-			m := &Motor{
-				Named:  conf.ResourceName().AsNamed(),
-				Logger: logger,
-				OpMgr:  operation.NewSingleOperationManager(),
-			}
-			if err := m.Reconfigure(ctx, deps, conf); err != nil {
-				return nil, err
-			}
-			return m, nil
-		},
+	resource.RegisterComponent(motor.API, motorModel, resource.Registration[motor.Motor, *Config]{
+		Constructor: NewMotor,
 	})
 }
 
@@ -97,8 +93,24 @@ type Motor struct {
 	Logger logging.Logger
 }
 
+// NewMotor creates a new fake motor.
+func NewMotor(ctx context.Context, deps resource.Dependencies, conf resource.Config, logger logging.Logger) (motor.Motor, error) {
+	logger.Error("in new motor")
+	m := &Motor{
+		Named:  conf.ResourceName().AsNamed(),
+		Logger: logger,
+		OpMgr:  operation.NewSingleOperationManager(),
+	}
+	if err := m.Reconfigure(ctx, deps, conf); err != nil {
+		return nil, err
+	}
+	logger.Errorf("new motor = %v", m)
+	return m, nil
+}
+
 // Reconfigure atomically reconfigures this motor in place based on the new config.
 func (m *Motor) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+	m.Logger.Error("in reconfigure")
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	newConf, err := resource.NativeConfig[*Config](conf)
@@ -107,20 +119,31 @@ func (m *Motor) Reconfigure(ctx context.Context, deps resource.Dependencies, con
 	}
 	if newConf.BoardName != "" {
 		m.Board = newConf.BoardName
-		b, err := board.FromDependencies(deps, m.Board)
+		b, err = board.FromDependencies(deps, m.Board)
 		if err != nil {
 			return err
 		}
-		if newConf.Pins.PWM != "" {
-			m.PWM, err = b.GPIOPinByName(newConf.Pins.PWM)
-			if err != nil {
-				return err
-			}
-			if err = m.PWM.SetPWMFreq(ctx, newConf.PWMFreq, nil); err != nil {
-				return err
-			}
+	} else {
+		m.Logger.Info("board not provided, using a fake board")
+		m.Board = "fakeboard"
+		b, err = fakeboard.NewBoard(ctx, fakeBoardConf, m.Logger)
+		if err != nil {
+			return err
 		}
 	}
+
+	pwmPin := "1"
+	if newConf.Pins.PWM != "" {
+		pwmPin = newConf.Pins.PWM
+	}
+	m.PWM, err = b.GPIOPinByName(pwmPin)
+	if err != nil {
+		return err
+	}
+	if err = m.PWM.SetPWMFreq(ctx, newConf.PWMFreq, nil); err != nil {
+		return err
+	}
+
 	m.MaxRPM = newConf.MaxRPM
 
 	if m.MaxRPM == 0 {

--- a/components/motor/fake/motor.go
+++ b/components/motor/fake/motor.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	model    = resource.DefaultModelFamily.WithModel("fake")
+	model         = resource.DefaultModelFamily.WithModel("fake")
 	fakeBoardConf = resource.Config{
 		Name: "fakeboard",
 		API:  board.API,
@@ -67,7 +67,7 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 }
 
 func init() {
-	resource.RegisterComponent(motor.API, motorModel, resource.Registration[motor.Motor, *Config]{
+	resource.RegisterComponent(motor.API, model, resource.Registration[motor.Motor, *Config]{
 		Constructor: NewMotor,
 	})
 }

--- a/components/motor/fake/motor.go
+++ b/components/motor/fake/motor.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	motorModel    = resource.DefaultModelFamily.WithModel("fake")
+	model    = resource.DefaultModelFamily.WithModel("fake")
 	fakeBoardConf = resource.Config{
 		Name: "fakeboard",
 		API:  board.API,


### PR DESCRIPTION
Set defaults for pins, max speeds and anything needed for a fake motor to construct.

Refactor the constructor to make the constructor more readable in a NewFakeMotor helper function; this should be exported like all our fake resource functions should be. 
This should be passed to the robot constructor without arguments, same as our cleanest drivers
ie Constructor: NewFakeMotor rather than Constructor:NewFakeMotor(ctx, logger.....)