### PR TITLE
RSDK-6192: Migrate motor control loop to a structure like sensor-controlled control loop

### DIFF
--- a/components/motor/gpio/loop.go
+++ b/components/motor/gpio/loop.go
@@ -91,6 +91,7 @@ func (m *EncodedMotor) validateControlConfig(ctx context.Context) error {
 // trapezoidalVelocityProfile-> sum -> PID -> gain -> endpoint -> derivative back to sum, and endpoint
 // back to trapezoidalVelocityProfile structure. The gain is 0.0039 (1/255) to account for the PID range,
 // the PID values are experimental this structure can change as hardware experiments with an encoded motor require.
+//
 //nolint:unused
 var controlLoopConfig = control.Config{
 	Blocks: []control.BlockConfig{

--- a/components/motor/gpio/loop.go
+++ b/components/motor/gpio/loop.go
@@ -85,3 +85,81 @@ func (m *EncodedMotor) validateControlConfig(ctx context.Context) error {
 	m.logger.CDebugf(ctx, "PID block: %v", pidBlock)
 	return nil
 }
+
+// Control Loop Configuration is embedded in this file so a user does not have to configure the loop
+// from within the attributes of the config file. It sets up a loop that takes a constant ->
+// trapezoidalVelocityProfile-> sum -> PID -> gain -> endpoint -> derivative back to sum, and endpoint
+// back to trapezoidalVelocityProfile structure. The gain is 0.0039 (1/255) to account for the PID range,
+// the PID values are experimental this structure can change as hardware experiments with an encoded motor require.
+var controlLoopConfig = control.Config{
+	Blocks: []control.BlockConfig{
+		{
+			Name: "set_point",
+			Type: "constant",
+			Attribute: rdkutils.AttributeMap{
+				"constant_val": 0,
+			},
+		},
+		{
+			Name: "trapz",
+			Type: "trapezoidalVelocityProfile",
+			Attribute: rdkutils.AttributeMap{
+				"kpp_gain":   0.45,
+				"max_acc":    30000,
+				"max_vel":    4000,
+				"pos_window": 0,
+			},
+			DependsOn: []string{"set_point", "endpoint"},
+		},
+		{
+			Name: "sum",
+			Type: "sum",
+			Attribute: rdkutils.AttributeMap{
+				"sum_string": "+-",
+			},
+			DependsOn: []string{"trapz", "derivative"},
+		},
+		{
+			Name: "PID",
+			Type: "PID",
+			Attribute: rdkutils.AttributeMap{
+				"int_sat_lim_lo": -255,
+				"int_sat_lim_up": 255,
+				"kD":             0,
+				"kI":             0.53977,
+				"kP":             0.048401,
+				"limit_lo":       -255,
+				"limit_up":       255,
+				"tune_method":    "ziegerNicholsSomeOvershoot",
+				"tune_ssr_value": 2,
+				"tune_step_pct":  0.35,
+			},
+			DependsOn: []string{"sum"},
+		},
+		{
+			Name: "gain",
+			Type: "gain",
+			Attribute: rdkutils.AttributeMap{
+				"gain": 0.00392156862,
+			},
+			DependsOn: []string{"PID"},
+		},
+		{
+			Name: "endpoint",
+			Type: "endpoint",
+			Attribute: rdkutils.AttributeMap{
+				"motor_name": "motor",
+			},
+			DependsOn: []string{"gain"},
+		},
+		{
+			Name: "derivative",
+			Type: "derivative",
+			Attribute: rdkutils.AttributeMap{
+				"derive_type": "backward1st1",
+			},
+			DependsOn: []string{"endpoint"},
+		},
+	},
+	Frequency: 100,
+}

--- a/components/motor/gpio/loop.go
+++ b/components/motor/gpio/loop.go
@@ -91,6 +91,7 @@ func (m *EncodedMotor) validateControlConfig(ctx context.Context) error {
 // trapezoidalVelocityProfile-> sum -> PID -> gain -> endpoint -> derivative back to sum, and endpoint
 // back to trapezoidalVelocityProfile structure. The gain is 0.0039 (1/255) to account for the PID range,
 // the PID values are experimental this structure can change as hardware experiments with an encoded motor require.
+//nolint:unused
 var controlLoopConfig = control.Config{
 	Blocks: []control.BlockConfig{
 		{


### PR DESCRIPTION
This is an intermediate step to removing the control config from the robot config. It won't be used until we add PID values to the gpio motor config