### PR TITLE
RSDK-5838 - Remove resource from node if missing dependencies

### DIFF
--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -1645,6 +1645,8 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, ok, test.ShouldBeTrue)
 	})
 
+	// test starts with a working config, then reconfigures into a config where dependencies
+	// fail to reconfigure, and then to a working config again.
 	t.Run("child component fails dep", func(t *testing.T) {
 		resetComponentFailureState()
 		testReconfiguringMismatch = true

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -1952,9 +1952,12 @@ func TestRobotReconfigure(t *testing.T) {
 		_, err = board.FromRobot(robot, "board2")
 		test.That(t, err, test.ShouldBeNil)
 
+		// resources which failed previous reconfiguration attempts because of missing dependencies will be rebuilt,
+		// so reconfCount should be 0. resources which failed previous reconfiguration attempts because of an error
+		// during reconfiguration would not have its reconfCount reset, so reconfCount for mock4 should be 1.
 		mock1, err = robot.ResourceByName(mockNamed("mock1"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, mock1.(*mockFake).reconfCount, test.ShouldEqual, 1)
+		test.That(t, mock1.(*mockFake).reconfCount, test.ShouldEqual, 0)
 
 		mock2, err = robot.ResourceByName(mockNamed("mock2"))
 		test.That(t, err, test.ShouldBeNil)
@@ -1970,7 +1973,7 @@ func TestRobotReconfigure(t *testing.T) {
 
 		mock5, err = robot.ResourceByName(mockNamed("mock5"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, mock5.(*mockFake).reconfCount, test.ShouldEqual, 1)
+		test.That(t, mock5.(*mockFake).reconfCount, test.ShouldEqual, 0)
 
 		// `mock6` is configured to be in a "failing" state.
 		_, err = robot.ResourceByName(mockNamed("mock6"))


### PR DESCRIPTION
causes an issue for modular resources (and probably real resources as well) with remote deps.

when the remote changes for any reason (reconfig, going down) and a dependency is missing, we would close the resource (missing dep) but did not explicitly remove the resource from the node. This meant that when the remote dep came back, we would try to just reconfigure the existing resource.

for modular resources, this is an issue because we already closed it and now the module would be unable to find said resource.

depending on how well written the local resource is, that would cause issues (since we already closed it), but at least for fake components that isn't an issue since we don't check for much during reconfiguration.

### Changes introduced
Beyond just closing the resource, we also remove it from the node. Now we'll try to rebuild the resource continuously, which makes more sense than trying to reconfigure something that's already closed.

the one test change should be sufficient, we are checking that if a dependency fails to reconfigure, the dependents are closed. if we simply remove the dependency from the config, the graph will pre-emptively remove the whole chain of resources, which will not repro the issue.