### PR TITLE
unbreak return code pass-through in test.sh

### DIFF
--- a/etc/test.sh
+++ b/etc/test.sh
@@ -24,7 +24,9 @@ SUCCESS=$?
 
 if [[ $RACE != "" ]]; then
 	cat json.log | go run ./etc/analyzetests/main.go
-	exit $?
+	if [ "$?" != "0" ]; then
+		exit 1
+	fi
 fi
 
 if [ "$SUCCESS" != "0" ]; then

--- a/etc/test.sh
+++ b/etc/test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+TEST_TARGET=${TEST_TARGET:-./...}
 ROOT_DIR="$DIR/../"
 cd $ROOT_DIR
 
@@ -18,7 +19,7 @@ if [[ "$1" == "race" ]]; then
 fi
 
 # We run analyzetests on every run, pass or fail. We only run analyzecoverage when all tests passed.
-PION_LOG_WARN=webrtc,datachannel,sctp gotestsum --format standard-verbose $LOGFILE -- -tags=no_skip $RACE $COVER ./...
+PION_LOG_WARN=webrtc,datachannel,sctp gotestsum --format standard-verbose $LOGFILE -- -tags=no_skip $RACE $COVER $TEST_TARGET
 SUCCESS=$?
 
 if [[ $RACE != "" ]]; then

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2
 	github.com/invopop/jsonschema v0.6.0
+	github.com/ipfs/go-detect-race v0.0.1
 	github.com/jacobsa/go-serial v0.0.0-20180131005756-15cf729a72d4
 	github.com/jedib0t/go-pretty/v6 v6.4.6
 	github.com/jhump/protoreflect v1.15.1

--- a/go.sum
+++ b/go.sum
@@ -728,6 +728,8 @@ github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLf
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/invopop/jsonschema v0.6.0 h1:8e+xY8ZEn8gDHUYylSlLHy22P+SLeIRIHv3nM3hCbmY=
 github.com/invopop/jsonschema v0.6.0/go.mod h1:O9uiLokuu0+MGFlyiaqtWxwqJm41/+8Nj0lD7A36YH0=
+github.com/ipfs/go-detect-race v0.0.1 h1:qX/xay2W3E4Q1U7d9lNs1sU9nvguX0a7319XbyQ6cOk=
+github.com/ipfs/go-detect-race v0.0.1/go.mod h1:8BNT7shDZPo99Q74BpGMK+4D8Mn4j46UU0LZ723meps=
 github.com/jacobsa/go-serial v0.0.0-20180131005756-15cf729a72d4 h1:G2ztCwXov8mRvP0ZfjE6nAlaCX2XbykaeHdbT6KwDz0=
 github.com/jacobsa/go-serial v0.0.0-20180131005756-15cf729a72d4/go.mod h1:2RvX5ZjVtsznNZPEt4xwJXNJrM3VTZoQf7V6gk0ysvs=
 github.com/jdxcode/netrc v0.0.0-20210204082910-926c7f70242a h1:d4+I1YEKVmWZrgkt6jpXBnLgV2ZjO0YxEtLDdfIZfH4=

--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	clk "github.com/benbjohnson/clock"
+	detectrace "github.com/ipfs/go-detect-race"
 	"github.com/pkg/errors"
 	v1 "go.viam.com/api/app/datasync/v1"
 	"go.viam.com/test"
@@ -27,9 +28,18 @@ const (
 	syncInterval     = time.Millisecond * 50
 )
 
+// skipIfRaceMode skips when RACE var is passed in test.sh.
+func skipIfRaceMode(t *testing.T) {
+	// delete this once no longer used
+	// it is a temporary patch from data races being skipped
+	if detectrace.WithRace() {
+		t.Skip("this was affected by the outage in race detection -- skipping temporarily")
+	}
+}
+
 // TODO DATA-849: Add a test that validates that sync interval is accurately respected.
 func TestSyncEnabled(t *testing.T) {
-	t.Skip("this was affected by the outage in race detection -- skipping temporarily")
+	skipIfRaceMode(t)
 	captureInterval := time.Millisecond * 10
 	tests := []struct {
 		name                        string
@@ -601,7 +611,7 @@ func TestStreamingDCUpload(t *testing.T) {
 }
 
 func TestSyncConfigUpdateBehavior(t *testing.T) {
-	t.Skip("this was affected by the outage in race detection -- skipping temporarily")
+	skipIfRaceMode(t)
 	newSyncIntervalMins := 0.009
 	tests := []struct {
 		name                 string

--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -29,6 +29,7 @@ const (
 
 // TODO DATA-849: Add a test that validates that sync interval is accurately respected.
 func TestSyncEnabled(t *testing.T) {
+	t.Skip("this was affected by the outage in race detection -- skipping temporarily")
 	captureInterval := time.Millisecond * 10
 	tests := []struct {
 		name                        string
@@ -600,6 +601,7 @@ func TestStreamingDCUpload(t *testing.T) {
 }
 
 func TestSyncConfigUpdateBehavior(t *testing.T) {
+	t.Skip("this was affected by the outage in race detection -- skipping temporarily")
 	newSyncIntervalMins := 0.009
 	tests := []struct {
 		name                 string


### PR DESCRIPTION
## What changed
- revert a recent change that hid failures in 1 of our 2 test suite runs
- add conditional skips in some places with go-detect-race
- (incidental) add ability to run test.sh on a specific package
## Why
- we broke this last month when prepping the test suite for go 1.21
- the breakage only affects `-race` mode -- any failures that appeared in coverage runs would have still failed the test suite
## Hold merging
- [x] wait until people have had a chance to fix previously uncaught errors