### PR TITLE
Fix panic when MoveOnMap is called incorrectly

### DIFF
--- a/services/motion/builtin/move_request.go
+++ b/services/motion/builtin/move_request.go
@@ -588,6 +588,9 @@ func (ms *builtIn) newMoveOnMapRequest(
 		[]spatialmath.Geometry{octree},
 		valExtra,
 	)
+	if err != nil {
+		return nil, err
+	}
 	mr.requestType = requestTypeMoveOnMap
 	return mr, err
 }


### PR DESCRIPTION
We missed an error check. This PR fixes this