### PR TITLE
APP-2917 increase runner size in docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,7 +25,7 @@ jobs:
           platform: linux/amd64
           image: rdk-devenv
           file: etc/Dockerfile.cache
-        - arch: buildjet-2vcpu-ubuntu-2204-arm
+        - arch: buildjet-4vcpu-ubuntu-2204-arm
           tag: arm64
           platform: linux/arm64
           image: rdk-devenv


### PR DESCRIPTION
## What changed
- 2vcpu -> 4vcpu in the devenv:arm64 run of docker.yml
## Why
- `make lint-go` was failing consistently after go 1.21 upgrade, probably an OOM, example here ([run 1](https://github.com/viamrobotics/rdk/actions/runs/7401700035/attempts/1), [run 2](https://github.com/viamrobotics/rdk/actions/runs/7401700035))
- it succeeded on this branch ([run here](https://github.com/viamrobotics/rdk/actions/runs/7401990917)) (with unrelated downstream failures)