### PR TITLE
RSDK-6248: Add CI failure devops slackbot message to RC runs.

### DIFF
--- a/.github/workflows/releasecandidate.yml
+++ b/.github/workflows/releasecandidate.yml
@@ -48,3 +48,22 @@ jobs:
     needs: test
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  slack-workflow-status:
+    if: ${{ failure() }}
+    name: Post Workflow Status To Slack
+    needs:
+      - test
+      - appimage
+      - staticbuild
+    runs-on: ubuntu-latest
+    permissions:
+      actions: 'read'
+    steps:
+      - name: Slack Workflow Notification
+        uses: Gamesight/slack-workflow-status@master
+        with:
+          repo_token: ${{secrets.GITHUB_TOKEN}}
+          slack_webhook_url: ${{secrets.SLACK_WEBHOOK_URL}}
+          channel: '#team-devops'
+          name: 'Workflow Status'


### PR DESCRIPTION
This was a straight copy from the other yml files. The biggest unknown to me was whether we needed to add the github token/slack webhook url secrets to a new spot. Or if secrets are global to all github actions in a repo.