### PR TITLE
[RSDK-6254] don't check the MPU6050's identity

### DIFF
--- a/components/movementsensor/mpu6050/mpu6050.go
+++ b/components/movementsensor/mpu6050/mpu6050.go
@@ -198,14 +198,6 @@ func makeMpu6050(
 	return sensor, nil
 }
 
-func (mpu *mpu6050) readByte(ctx context.Context, register byte) (byte, error) {
-	result, err := mpu.readBlock(ctx, register, 1)
-	if err != nil {
-		return 0, err
-	}
-	return result[0], err
-}
-
 func (mpu *mpu6050) readBlock(ctx context.Context, register byte, length uint8) ([]byte, error) {
 	handle, err := mpu.bus.OpenHandle(mpu.i2cAddress)
 	if err != nil {

--- a/components/movementsensor/mpu6050/mpu6050.go
+++ b/components/movementsensor/mpu6050/mpu6050.go
@@ -22,7 +22,6 @@ package mpu6050
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -88,11 +87,6 @@ type mpu6050 struct {
 	cancelFunc              func()
 	activeBackgroundWorkers sync.WaitGroup
 	logger                  logging.Logger
-}
-
-func addressReadError(err error, address byte, bus string) error {
-	msg := fmt.Sprintf("can't read from I2C address %d on bus %s", address, bus)
-	return errors.Wrap(err, msg)
 }
 
 // NewMpu6050 constructs a new Mpu6050 object.

--- a/components/movementsensor/mpu6050/mpu6050_test.go
+++ b/components/movementsensor/mpu6050/mpu6050_test.go
@@ -52,7 +52,7 @@ func TestInitializationFailureOnChipCommunication(t *testing.T) {
 		deps := resource.Dependencies{}
 		sensor, err := makeMpu6050(context.Background(), deps, cfg, logger, i2c)
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err, test.ShouldBeError, addressReadError(readErr, expectedDefaultAddress, i2cName))
+		test.That(t, err, test.ShouldBeError, addressReadError(readErr, defaultAddress, i2cName))
 		test.That(t, sensor, test.ShouldBeNil)
 	})
 }
@@ -72,7 +72,7 @@ func TestSuccessfulInitializationAndClose(t *testing.T) {
 	}
 	i2cHandle := &inject.I2CHandle{}
 	i2cHandle.ReadBlockDataFunc = func(ctx context.Context, register byte, numBytes uint8) ([]byte, error) {
-		return []byte{expectedDefaultAddress}, nil
+		return []byte{defaultAddress}, nil
 	}
 	// the only write operations that the sensor implementation performs is
 	// the command to put it into either measurement mode or sleep mode,

--- a/components/movementsensor/mpu6050/mpu6050_test.go
+++ b/components/movementsensor/mpu6050/mpu6050_test.go
@@ -39,9 +39,9 @@ func TestInitializationFailureOnChipCommunication(t *testing.T) {
 			},
 		}
 		i2cHandle := &inject.I2CHandle{}
-		readErr := errors.New("read error")
-		i2cHandle.ReadBlockDataFunc = func(ctx context.Context, register byte, numBytes uint8) ([]byte, error) {
-			return []byte{}, nil
+		writeError := errors.New("write error")
+		i2cHandle.WriteByteDataFunc = func(ctx context.Context, register, data byte) error {
+			return writeError
 		}
 		i2cHandle.CloseFunc = func() error { return nil }
 		i2c := &inject.I2C{}
@@ -52,7 +52,8 @@ func TestInitializationFailureOnChipCommunication(t *testing.T) {
 		deps := resource.Dependencies{}
 		sensor, err := makeMpu6050(context.Background(), deps, cfg, logger, i2c)
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err, test.ShouldBeError, addressReadError(readErr, defaultAddress, i2cName))
+		test.That(t, err, test.ShouldBeError,
+			errors.Errorf("Unable to wake up MPU6050: '%s'", writeError))
 		test.That(t, sensor, test.ShouldBeNil)
 	})
 }


### PR DESCRIPTION
A Discord user has an MPU9250, and was hoping to use our MPU6050 code with it because the two chips have identical data in identical registers (the difference is that the MPU9250 also has a compass, which we don't currently support).

@oliviamiller looked into this, and found that there are [4 official chips](https://sureshjoshi.com/embedded/invensense-imus-what-to-know) that could all work with our component except they have different data in the WHOAMI register. The 4 chips are the MPU6050 (the one we originally supported), MPU6500 (same but smaller and less accurate), MPU9150 (an MPU6050 with a magnetometer added on; we don't yet support the magnetometer readings), and MPU9250 (an MPU6500 with a magnetometer). 

They all have the same data in the same registers, so we should either stop checking WHOAMI, or allow 4 different model numbers. and then Olivia found that you can buy knockoffs from other companies that behave the same except for that register, so let's stop checking it entirely. If someone plugs in the wrong hardware, that's their problem, not ours.

I haven't tested this change, but as long as it compiles I'm fairly confident it'll work correctly. I can test it if you want. 