### PR TITLE
RSDK-5524 - Change rplidar point cloud viewer's default point size from 1 to 3

### DIFF
--- a/web/frontend/src/components/pcd/pcd-view.svelte
+++ b/web/frontend/src/components/pcd/pcd-view.svelte
@@ -289,7 +289,7 @@ $: if (pointcloud) {
       type="number"
       min="0.1"
       step="0.1"
-      value="1"
+      value="3"
       incrementor="slider"
       on:input={handlePointsResize}
     />


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-5524

**Done:**
* Changed camera's PCD default point size from 1 to 3

**Before:**
* <img width="1129" alt="Screenshot 2024-01-09 at 10 08 03 AM" src="https://github.com/viamrobotics/rdk/assets/3912676/07fe4e3f-bd36-407d-a62e-f7b04b5d1ab3">

**After:**
* <img width="1272" alt="Screenshot 2024-01-09 at 10 09 13 AM" src="https://github.com/viamrobotics/rdk/assets/3912676/4b8d6d5b-38f8-4ebf-b770-d15556193a32">
