### PR TITLE
RSDK-6052 - De-duplicate work being done by neighbor manager in IK solving

### DIFF
--- a/motionplan/tpSpaceRRT.go
+++ b/motionplan/tpSpaceRRT.go
@@ -530,6 +530,9 @@ func (mp *tpSpaceRRTMotionPlanner) getExtensionCandidate(
 	}
 
 	bestDist := targetFunc(&ik.State{Position: arcPose})
+	if bestDist != solution.Score {
+		mp.logger.Fatalf("bestDist: %d, solution.Score: %d", bestDist, solution.Score)
+	}
 
 	cand := &candidate{dist: bestDist, treeNode: nearest, newNodes: successNodes}
 	// check if this  successNode is too close to nodes already in the tree, and if so, do not add.

--- a/motionplan/tpSpaceRRT.go
+++ b/motionplan/tpSpaceRRT.go
@@ -466,13 +466,12 @@ func (mp *tpSpaceRRTMotionPlanner) getExtensionCandidate(
 			return nil, errNoNeighbors
 		}
 
-		val, ok := rawVal.(*ik.Solution)
+		solution, ok = rawVal.(*ik.Solution)
 		if !ok {
 			mp.logger.Error("nearest neighbor ik.Solution type conversion failed")
 			return nil, errNoNeighbors
 		}
 
-		solution = val
 		relPose := spatialmath.PoseBetween(nearest.Pose(), randPosNode.Pose())
 		targetFunc = mp.algOpts.goalMetricConstructor(relPose)
 	} else {

--- a/motionplan/tpSpaceRRT.go
+++ b/motionplan/tpSpaceRRT.go
@@ -835,18 +835,13 @@ func (mp *tpSpaceRRTMotionPlanner) make2DTPSpaceDistanceOptions(ptg tpspace.PTGS
 		if seg.StartPosition == nil || seg.EndPosition == nil {
 			return distance
 		}
-		solution, targetFunc, err := mp.ptgSolutionAndMetric(ptg, seg.EndPosition, seg.StartPosition)
+		solution, _, err := mp.ptgSolutionAndMetric(ptg, seg.EndPosition, seg.StartPosition)
 
 		if err != nil || solution == nil {
 			return distance
 		}
 
-		pose, err := ptg.Transform(solution.Configuration)
-		if err != nil {
-			return distance
-		}
-
-		distance = targetFunc(&ik.State{Position: pose})
+		distance = solution.Score
 		m.Store(seg.EndPosition, solution)
 
 		return distance

--- a/motionplan/tpSpaceRRT.go
+++ b/motionplan/tpSpaceRRT.go
@@ -437,58 +437,66 @@ func (mp *tpSpaceRRTMotionPlanner) rrtBackgroundRunner(
 // getExtensionCandidate will return either nil, or the best node on a valid PTG to reach the desired random node and its RRT tree parent.
 func (mp *tpSpaceRRTMotionPlanner) getExtensionCandidate(
 	ctx context.Context,
-	randPosNode node,
+	localGoal node,
 	ptgNum int,
 	curPtg tpspace.PTGSolver,
 	rrt rrtMap,
 	nearest node,
 ) (*candidate, error) {
+	ptgDistOpt, distMap := mp.make2DTPSpaceDistanceOptions(curPtg)
+
 	nm := &neighborManager{nCPU: mp.planOpts.NumThreads / len(mp.tpFrame.PTGSolvers())}
 	nm.parallelNeighbors = 10
 
 	var successNode node
 	// Get the distance function that will find the nearest RRT map node in TP-space of *this* PTG
-	ptgDistOpt := mp.algOpts.distOptions[curPtg]
+	// ptgDistOpt := mp.algOpts.distOptions[curPtg]
 
+	relPose := spatialmath.PoseBetween(nearest.Pose(), localGoal.Pose())
+	targetFunc := mp.algOpts.goalMetricConstructor(relPose)
+	var solution *ik.Solution
 	if nearest == nil {
 		// Get nearest neighbor to rand config in tree using this PTG
 		// TODO: running nearestNeighbor actually involves a ptg.Solve() call, duplicating work.
-		nearest = nm.nearestNeighbor(ctx, ptgDistOpt, randPosNode, rrt)
+		nearest = nm.nearestNeighbor(ctx, ptgDistOpt, localGoal, rrt)
 		if nearest == nil {
 			return nil, errNoNeighbors
+		}
+		key := [2]spatialmath.Pose{localGoal.Pose(), nearest.Pose()}
+		val, ok := distMap.memo[key]
+		if !ok {
+			return nil, errors.New("NICK: this error should never happen")
+		}
+		solution = val
+	} else {
+		seedDist := relPose.Point().Norm()
+		seed := tpspace.PTGIKSeed(curPtg)
+		dof := curPtg.DoF()
+		if seedDist < dof[1].Max {
+			seed[1].Value = seedDist
+		}
+
+		solutionChan := make(chan *ik.Solution, 1)
+		err := curPtg.Solve(context.Background(), solutionChan, seed, targetFunc, 0)
+
+		select {
+		case solution = <-solutionChan:
+		default:
+		}
+		if err != nil || solution == nil {
+			return nil, err
 		}
 	}
 	// TODO: We could potentially improve solving by first getting the rough distance to the randPosNode to any point in the rrt tree,
 	// then dynamically expanding or contracting the limits of IK to be some fraction of that distance.
 
 	// Get cartesian distance from NN to rand
-	var targetFunc ik.StateMetric
-	relPose := spatialmath.PoseBetween(nearest.Pose(), randPosNode.Pose())
-	targetFunc = mp.algOpts.goalMetricConstructor(relPose)
-	seedDist := relPose.Point().Norm()
-	seed := tpspace.PTGIKSeed(curPtg)
-	dof := curPtg.DoF()
-	if seedDist < dof[1].Max {
-		seed[1].Value = seedDist
-	}
-
-	solutionChan := make(chan *ik.Solution, 1)
-	err := curPtg.Solve(context.Background(), solutionChan, seed, targetFunc, 0)
-
-	var bestNode *ik.Solution
-	select {
-	case bestNode = <-solutionChan:
-	default:
-	}
-	if err != nil || bestNode == nil {
-		return nil, err
-	}
 	arcStartPose := nearest.Pose()
 	successNodes := []node{}
 	arcPose := spatialmath.NewZeroPose() // This will be the relative pose that is the delta from one end of the combined traj to the other.
 	// We may produce more than one consecutive arc. Reduce the one configuration to several 2dof arcs
-	for i := 0; i < len(bestNode.Configuration); i += 2 {
-		subNode := newConfigurationNode(bestNode.Configuration[i : i+2])
+	for i := 0; i < len(solution.Configuration); i += 2 {
+		subNode := newConfigurationNode(solution.Configuration[i : i+2])
 
 		// Check collisions along this traj and get the longest distance viable
 		trajK, err := curPtg.Trajectory(subNode.Q()[0].Value, subNode.Q()[1].Value)
@@ -788,50 +796,27 @@ func (mp *tpSpaceRRTMotionPlanner) setupTPSpaceOptions() {
 		goalMetricConstructor: defaultGoalMetricConstructor,
 	}
 
-	for _, curPtg := range mp.tpFrame.PTGSolvers() {
-		tpOpt.distOptions[curPtg] = mp.make2DTPSpaceDistanceOptions(curPtg)
-	}
-
 	mp.algOpts = tpOpt
-}
-
-type distanceAndSolution struct {
-	distance float64
-	solution *ik.Solution
 }
 
 type memoizedDistFunc struct {
 	sync.RWMutex
-	memo map[[2]spatialmath.Pose]distanceAndSolution
+	memo map[[2]spatialmath.Pose]*ik.Solution
 }
 
 // make2DTPSpaceDistanceOptions will create a plannerOptions object with a custom DistanceFunc constructed such that
 // distances can be computed in TP space using the given PTG.
 func (mp *tpSpaceRRTMotionPlanner) make2DTPSpaceDistanceOptions(ptg tpspace.PTGSolver) (*plannerOptions, *memoizedDistFunc) {
-	m := memoizedDistFunc{memo: make(map[[2]spatialmath.Pose]distanceAndSolution)}
+	m := memoizedDistFunc{memo: make(map[[2]spatialmath.Pose]*ik.Solution)}
 	opts := newBasicPlannerOptions(mp.frame)
 	segMetric := func(seg *ik.Segment) float64 {
 		distance := math.Inf(1)
 		var solution *ik.Solution
 		key := [2]spatialmath.Pose{seg.StartPosition, seg.EndPosition}
-		m.RLock()
-		val, ok := m.memo[key]
-		if ok {
-			val = distanceAndSolution{distance: distance, solution: solution}
-			m.Lock()
-			m.memo[key] = val
-			m.Unlock()
-			return val.distance
-		}
-		m.RUnlock()
 		// When running NearestNeighbor:
 		// StartPosition is the seed/query
 		// EndPosition is the pose already in the RRT tree
 		if seg.StartPosition == nil || seg.EndPosition == nil {
-			val = distanceAndSolution{distance: distance, solution: solution}
-			m.Lock()
-			m.memo[key] = val
-			m.Unlock()
 			return distance
 		}
 
@@ -853,27 +838,17 @@ func (mp *tpSpaceRRTMotionPlanner) make2DTPSpaceDistanceOptions(ptg tpspace.PTGS
 		}
 
 		if err != nil || solution == nil {
-			val = distanceAndSolution{distance: distance, solution: solution}
-			m.Lock()
-			m.memo[key] = val
-			m.Unlock()
 			return distance
 		}
 
 		pose, err := ptg.Transform(solution.Configuration)
 		if err != nil {
-			val = distanceAndSolution{distance: distance, solution: solution}
-			m.Lock()
-			m.memo[key] = val
-			m.Unlock()
 			return distance
 		}
 
 		distance = targetFunc(&ik.State{Position: pose})
-		val = distanceAndSolution{distance: distance, solution: solution}
-
 		m.Lock()
-		m.memo[key] = val
+		m.memo[key] = solution
 		m.Unlock()
 
 		return distance

--- a/motionplan/tpSpaceRRT.go
+++ b/motionplan/tpSpaceRRT.go
@@ -825,23 +825,21 @@ func (mp *tpSpaceRRTMotionPlanner) make2DTPSpaceDistanceOptions(ptg tpspace.PTGS
 	m := sync.Map{}
 	opts := newBasicPlannerOptions(mp.frame)
 	segMetric := func(seg *ik.Segment) float64 {
-		distance := math.Inf(1)
 		// When running NearestNeighbor:
 		// StartPosition is the seed/query
 		// EndPosition is the pose already in the RRT tree
 		if seg.StartPosition == nil || seg.EndPosition == nil {
-			return distance
+			return math.Inf(1)
 		}
 		solution, _, err := mp.ptgSolutionAndMetric(ptg, seg.EndPosition, seg.StartPosition)
 
 		if err != nil || solution == nil {
-			return distance
+			return math.Inf(1)
 		}
 
-		distance = solution.Score
 		m.Store(seg.EndPosition, solution)
 
-		return distance
+		return solution.Score
 	}
 	opts.DistanceFunc = segMetric
 	return opts, &m

--- a/motionplan/tpSpaceRRT.go
+++ b/motionplan/tpSpaceRRT.go
@@ -452,9 +452,8 @@ func (mp *tpSpaceRRTMotionPlanner) getExtensionCandidate(
 	// Get the distance function that will find the nearest RRT map node in TP-space of *this* PTG
 	// ptgDistOpt := mp.algOpts.distOptions[curPtg]
 
-	relPose := spatialmath.PoseBetween(nearest.Pose(), localGoal.Pose())
-	targetFunc := mp.algOpts.goalMetricConstructor(relPose)
 	var solution *ik.Solution
+	var targetFunc ik.StateMetric
 	if nearest == nil {
 		// Get nearest neighbor to rand config in tree using this PTG
 		// TODO: running nearestNeighbor actually involves a ptg.Solve() call, duplicating work.
@@ -468,7 +467,11 @@ func (mp *tpSpaceRRTMotionPlanner) getExtensionCandidate(
 			return nil, errors.New("NICK: this error should never happen")
 		}
 		solution = val
+		relPose := spatialmath.PoseBetween(nearest.Pose(), localGoal.Pose())
+		targetFunc = mp.algOpts.goalMetricConstructor(relPose)
 	} else {
+		relPose := spatialmath.PoseBetween(nearest.Pose(), localGoal.Pose())
+		targetFunc = mp.algOpts.goalMetricConstructor(relPose)
 		seedDist := relPose.Point().Norm()
 		seed := tpspace.PTGIKSeed(curPtg)
 		dof := curPtg.DoF()

--- a/motionplan/tpSpaceRRT.go
+++ b/motionplan/tpSpaceRRT.go
@@ -463,11 +463,13 @@ func (mp *tpSpaceRRTMotionPlanner) getExtensionCandidate(
 		}
 		rawVal, ok := distMap.Load(nearest.Pose())
 		if !ok {
-			return nil, errors.New("NICK: this error should never happen")
+			mp.logger.Error("nearest neighbor failed to find nearest pose in distMap")
+			return nil, errNoNeighbors
 		}
 		val, ok := rawVal.(*ik.Solution)
 		if !ok {
-			return nil, errors.New("NICK: this error should never happen either")
+			mp.logger.Error("nearest neighbor ik.Solution type conversion failed")
+			return nil, errNoNeighbors
 		}
 		solution = val
 		relPose := spatialmath.PoseBetween(nearest.Pose(), localGoal.Pose())

--- a/motionplan/tpSpaceRRT.go
+++ b/motionplan/tpSpaceRRT.go
@@ -530,9 +530,6 @@ func (mp *tpSpaceRRTMotionPlanner) getExtensionCandidate(
 	}
 
 	bestDist := targetFunc(&ik.State{Position: arcPose})
-	if bestDist != solution.Score {
-		mp.logger.Fatalf("bestDist: %d, solution.Score: %d", bestDist, solution.Score)
-	}
 
 	cand := &candidate{dist: bestDist, treeNode: nearest, newNodes: successNodes}
 	// check if this  successNode is too close to nodes already in the tree, and if so, do not add.

--- a/motionplan/tpSpaceRRT.go
+++ b/motionplan/tpSpaceRRT.go
@@ -807,6 +807,7 @@ func (mp *tpSpaceRRTMotionPlanner) setupTPSpaceOptions() {
 
 // make2DTPSpaceDistanceOptions will create a plannerOptions object with a custom DistanceFunc constructed such that
 // distances can be computed in TP space using the given PTG.
+// Also returns a pointer to a sync.Map of nearest poses -> ik.Solution so the (expensive to compute) solution can be reused.
 func (mp *tpSpaceRRTMotionPlanner) make2DTPSpaceDistanceOptions(ptg tpspace.PTGSolver) (*plannerOptions, *sync.Map) {
 	m := sync.Map{}
 	opts := newBasicPlannerOptions(mp.frame)


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-6052)

1. Changes the `DistanceFunc` created in `tpSpaceRRTMotionPlanner.make2DTPSpaceDistanceOptions` to cache the `*ik.Solution` results computed for each `nearest` node so that they can be retrieved in `*tpSpaceRRTMotionPlanner.getExtensionCandidate` & don't need to be recomputed again.
2. It turns out the performance uplift is not as great as we would have hoped (only a few percentage points at most) but it does (arguably) improve code clarity.

Sanity checked in gazebo:
https://github.com/viamrobotics/rdk/assets/5927876/068ea883-3198-4f67-8598-463a2cc9baa8

