### PR TITLE
[RSDK-3178] Rename component xArmLite -> lite6

### DIFF
--- a/components/arm/xarm/lite6_kinematics.json
+++ b/components/arm/xarm/lite6_kinematics.json
@@ -1,5 +1,5 @@
 {
-    "name": "xArmLite",
+    "name": "lite6",
     "links": [
         {
             "id": "base",

--- a/components/arm/xarm/xarm.go
+++ b/components/arm/xarm/xarm.go
@@ -1,4 +1,4 @@
-// Package xarm implements some xArms.
+// Package xarm implements some UFactory arms (xArm 6, xArm 7, and Lite 6).
 package xarm
 
 import (
@@ -73,9 +73,9 @@ var xArm7modeljson []byte
 var xArmLitemodeljson []byte
 
 const (
-	ModelName6DOF = "xArm6"    // ModelName6DOF is the name of an xArm6
-	ModelName7DOF = "xArm7"    // ModelName7DOF is the name of an xArm7
-	ModelNameLite = "xArmLite" // ModelNameLite is the name of an xArmLite
+	ModelName6DOF = "xArm6" // ModelName6DOF is the name of a UFactory xArm 6
+	ModelName7DOF = "xArm7" // ModelName7DOF is the name of a UFactory xArm 7
+	ModelNameLite = "lite6" // ModelNameLite is the name of a UFactory Lite 6
 )
 
 // MakeModelFrame returns the kinematics model of the xarm arm, which has all Frame information.

--- a/components/arm/xarm/xarm.go
+++ b/components/arm/xarm/xarm.go
@@ -69,8 +69,8 @@ var xArm6modeljson []byte
 //go:embed xarm7_kinematics.json
 var xArm7modeljson []byte
 
-//go:embed xarmlite_kinematics.json
-var xArmLitemodeljson []byte
+//go:embed lite6_kinematics.json
+var lite6modeljson []byte
 
 const (
 	ModelName6DOF = "xArm6" // ModelName6DOF is the name of a UFactory xArm 6
@@ -84,7 +84,7 @@ func MakeModelFrame(name, modelName string) (referenceframe.Model, error) {
 	case ModelName6DOF:
 		return referenceframe.UnmarshalModelJSON(xArm6modeljson, name)
 	case ModelNameLite:
-		return referenceframe.UnmarshalModelJSON(xArmLitemodeljson, name)
+		return referenceframe.UnmarshalModelJSON(lite6modeljson, name)
 	case ModelName7DOF:
 		return referenceframe.UnmarshalModelJSON(xArm7modeljson, name)
 	default:


### PR DESCRIPTION
UFactory (the company that makes the xArm arms) does not produce any hardware named "xArm Lite." Instead, they make one named "Lite 6" which is similar to the "xArm 6."

Not tested: I can't find one of these in the office, so am unsure how to test. Any advice is appreciated!

I'm also unsure whether to write a config migration, though I'm leaning towards not writing one. There are no fragments and 4 robots that use this component. None of them have been online since August. Two of them only have arm components, and two of them include fake components, which makes me think none of them are "real" robots.

Github thinks I should tag @biotinker on this, and I'm also tagging a random member of Bucket.