### PR TITLE
RSDK-6281 pass extra through the server

### DIFF
--- a/components/camera/client.go
+++ b/components/camera/client.go
@@ -67,7 +67,7 @@ func getExtra(ctx context.Context) (*structpb.Struct, error) {
 	ext := &structpb.Struct{}
 	if extra, ok := FromContext(ctx); ok {
 		var err error
-		if ext, err = goprotoutils.StructToStructPb(*extra); err != nil {
+		if ext, err = goprotoutils.StructToStructPb(extra); err != nil {
 			return nil, err
 		}
 	}

--- a/components/camera/client.go
+++ b/components/camera/client.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"google.golang.org/protobuf/proto"
 	"image"
 	"sync"
 
@@ -14,6 +13,7 @@ import (
 	goutils "go.viam.com/utils"
 	goprotoutils "go.viam.com/utils/protoutils"
 	"go.viam.com/utils/rpc"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"go.viam.com/rdk/data"

--- a/components/camera/client_test.go
+++ b/components/camera/client_test.go
@@ -272,7 +272,7 @@ func TestClient(t *testing.T) {
 		injectCamera.StreamFunc = func(ctx context.Context, errHandlers ...gostream.ErrorHandler) (gostream.VideoStream, error) {
 			extra, ok := camera.FromContext(ctx)
 			test.That(t, ok, test.ShouldBeTrue)
-			test.That(t, *extra, test.ShouldBeEmpty)
+			test.That(t, extra, test.ShouldBeEmpty)
 			return nil, errStreamFailed
 		}
 
@@ -284,14 +284,14 @@ func TestClient(t *testing.T) {
 		injectCamera.StreamFunc = func(ctx context.Context, errHandlers ...gostream.ErrorHandler) (gostream.VideoStream, error) {
 			extra, ok := camera.FromContext(ctx)
 			test.That(t, ok, test.ShouldBeTrue)
-			test.That(t, len(*extra), test.ShouldEqual, 1)
-			test.That(t, (*extra)["hello"], test.ShouldEqual, "world")
+			test.That(t, len(extra), test.ShouldEqual, 1)
+			test.That(t, extra["hello"], test.ShouldEqual, "world")
 			return nil, errStreamFailed
 		}
 
 		// one kvp created with camera.Extra
 		ext := camera.Extra{"hello": "world"}
-		ctx = camera.NewContext(ctx, &ext)
+		ctx = camera.NewContext(ctx, ext)
 		_, _, err = camera.ReadImage(ctx, camClient)
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errStreamFailed.Error())
@@ -299,8 +299,8 @@ func TestClient(t *testing.T) {
 		injectCamera.StreamFunc = func(ctx context.Context, errHandlers ...gostream.ErrorHandler) (gostream.VideoStream, error) {
 			extra, ok := camera.FromContext(ctx)
 			test.That(t, ok, test.ShouldBeTrue)
-			test.That(t, len(*extra), test.ShouldEqual, 1)
-			test.That(t, (*extra)[data.FromDMString], test.ShouldBeTrue)
+			test.That(t, len(extra), test.ShouldEqual, 1)
+			test.That(t, extra[data.FromDMString], test.ShouldBeTrue)
 
 			return nil, errStreamFailed
 		}
@@ -314,15 +314,15 @@ func TestClient(t *testing.T) {
 		injectCamera.StreamFunc = func(ctx context.Context, errHandlers ...gostream.ErrorHandler) (gostream.VideoStream, error) {
 			extra, ok := camera.FromContext(ctx)
 			test.That(t, ok, test.ShouldBeTrue)
-			test.That(t, len(*extra), test.ShouldEqual, 2)
-			test.That(t, (*extra)["hello"], test.ShouldEqual, "world")
-			test.That(t, (*extra)[data.FromDMString], test.ShouldBeTrue)
+			test.That(t, len(extra), test.ShouldEqual, 2)
+			test.That(t, extra["hello"], test.ShouldEqual, "world")
+			test.That(t, extra[data.FromDMString], test.ShouldBeTrue)
 			return nil, errStreamFailed
 		}
 
 		// merge values from data and camera
 		ext = camera.Extra{"hello": "world"}
-		ctx = camera.NewContext(ctx, &ext)
+		ctx = camera.NewContext(ctx, ext)
 		_, _, err = camera.ReadImage(ctx, camClient)
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errStreamFailed.Error())

--- a/components/camera/client_test.go
+++ b/components/camera/client_test.go
@@ -3,7 +3,6 @@ package camera_test
 import (
 	"bytes"
 	"context"
-	"go.viam.com/rdk/data"
 	"image"
 	"image/color"
 	"image/png"
@@ -18,6 +17,7 @@ import (
 	"google.golang.org/grpc/metadata"
 
 	"go.viam.com/rdk/components/camera"
+	"go.viam.com/rdk/data"
 	"go.viam.com/rdk/gostream"
 	viamgrpc "go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"

--- a/components/camera/extra.go
+++ b/components/camera/extra.go
@@ -17,6 +17,6 @@ func NewContext(ctx context.Context, e *Extra) context.Context {
 
 // FromContext returns the Extra value stored in ctx, if any.
 func FromContext(ctx context.Context) (*Extra, bool) {
-	u, ok := ctx.Value(extraKey).(*Extra)
-	return u, ok
+	ext, ok := ctx.Value(extraKey).(*Extra)
+	return ext, ok
 }

--- a/components/camera/extra.go
+++ b/components/camera/extra.go
@@ -1,0 +1,22 @@
+package camera
+
+import "context"
+
+// Extra is the type of value stored in the Contexts.
+type (
+	Extra map[string]interface{}
+	key   int
+)
+
+var extraKey key
+
+// NewContext returns a new Context that carries value Extra.
+func NewContext(ctx context.Context, e *Extra) context.Context {
+	return context.WithValue(ctx, extraKey, e)
+}
+
+// FromContext returns the Extra value stored in ctx, if any.
+func FromContext(ctx context.Context) (*Extra, bool) {
+	u, ok := ctx.Value(extraKey).(*Extra)
+	return u, ok
+}

--- a/components/camera/extra.go
+++ b/components/camera/extra.go
@@ -11,12 +11,12 @@ type (
 var extraKey key
 
 // NewContext returns a new Context that carries value Extra.
-func NewContext(ctx context.Context, e *Extra) context.Context {
+func NewContext(ctx context.Context, e Extra) context.Context {
 	return context.WithValue(ctx, extraKey, e)
 }
 
 // FromContext returns the Extra value stored in ctx, if any.
-func FromContext(ctx context.Context) (*Extra, bool) {
-	ext, ok := ctx.Value(extraKey).(*Extra)
+func FromContext(ctx context.Context) (Extra, bool) {
+	ext, ok := ctx.Value(extraKey).(Extra)
 	return ext, ok
 }

--- a/components/camera/extra_test.go
+++ b/components/camera/extra_test.go
@@ -20,8 +20,8 @@ func TestExtraRoundtrip(t *testing.T) {
 		"even two":    "by two",
 	}
 
-	ctx = NewContext(ctx, &expected)
+	ctx = NewContext(ctx, expected)
 	actual, ok := FromContext(ctx)
 	test.That(t, ok, test.ShouldBeTrue)
-	test.That(t, *actual, test.ShouldEqual, expected)
+	test.That(t, actual, test.ShouldEqual, expected)
 }

--- a/components/camera/extra_test.go
+++ b/components/camera/extra_test.go
@@ -1,0 +1,27 @@
+package camera
+
+import (
+	"context"
+	"testing"
+
+	"go.viam.com/test"
+)
+
+func TestExtraEmpty(t *testing.T) {
+	ctx := context.Background()
+	_, ok := FromContext(ctx)
+	test.That(t, ok, test.ShouldBeFalse)
+}
+
+func TestExtraRoundtrip(t *testing.T) {
+	ctx := context.Background()
+	expected := Extra{
+		"It goes one": "by one",
+		"even two":    "by two",
+	}
+
+	ctx = NewContext(ctx, &expected)
+	actual, ok := FromContext(ctx)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, *actual, test.ShouldEqual, expected)
+}

--- a/components/camera/server.go
+++ b/components/camera/server.go
@@ -74,7 +74,6 @@ func (s *serviceServer) GetImage(
 
 	ext := req.Extra.AsMap()
 	ctx = NewContext(ctx, (*Extra)(&ext))
-	req.Extra.AsMap()
 
 	img, release, err := ReadImage(gostream.WithMIMETypeHint(ctx, req.MimeType), cam)
 	if err != nil {

--- a/components/camera/server.go
+++ b/components/camera/server.go
@@ -73,7 +73,7 @@ func (s *serviceServer) GetImage(
 	req.MimeType = utils.WithLazyMIMEType(req.MimeType)
 
 	ext := req.Extra.AsMap()
-	ctx = NewContext(ctx, (*Extra)(&ext))
+	ctx = NewContext(ctx, ext)
 
 	img, release, err := ReadImage(gostream.WithMIMETypeHint(ctx, req.MimeType), cam)
 	if err != nil {

--- a/components/camera/server.go
+++ b/components/camera/server.go
@@ -11,7 +11,6 @@ import (
 	pb "go.viam.com/api/component/camera/v1"
 	"google.golang.org/genproto/googleapis/api/httpbody"
 
-	"go.viam.com/rdk/data"
 	"go.viam.com/rdk/gostream"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/pointcloud"
@@ -73,10 +72,9 @@ func (s *serviceServer) GetImage(
 
 	req.MimeType = utils.WithLazyMIMEType(req.MimeType)
 
-	// Add 'fromDataManagement' to context to avoid threading extra through gostream API.
-	if req.Extra.AsMap()[data.FromDMString] == true {
-		ctx = context.WithValue(ctx, data.FromDMContextKey{}, true)
-	}
+	ext := req.Extra.AsMap()
+	ctx = NewContext(ctx, (*Extra)(&ext))
+	req.Extra.AsMap()
 
 	img, release, err := ReadImage(gostream.WithMIMETypeHint(ctx, req.MimeType), cam)
 	if err != nil {

--- a/components/camera/server_test.go
+++ b/components/camera/server_test.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"go.viam.com/rdk/data"
-	goprotoutils "go.viam.com/utils/protoutils"
 	"image"
 	"image/png"
 	"sync"
@@ -14,8 +12,10 @@ import (
 
 	pb "go.viam.com/api/component/camera/v1"
 	"go.viam.com/test"
+	goprotoutils "go.viam.com/utils/protoutils"
 
 	"go.viam.com/rdk/components/camera"
+	"go.viam.com/rdk/data"
 	"go.viam.com/rdk/gostream"
 	"go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/resource"
@@ -493,6 +493,7 @@ func TestServer(t *testing.T) {
 				"hello":           "world",
 			},
 		)
+		test.That(t, err, test.ShouldBeNil)
 
 		_, err = cameraServer.GetImage(context.Background(), &pb.GetImageRequest{
 			Name:  testCameraName,

--- a/components/camera/server_test.go
+++ b/components/camera/server_test.go
@@ -426,7 +426,7 @@ func TestServer(t *testing.T) {
 		injectCamera.StreamFunc = func(ctx context.Context, errHandlers ...gostream.ErrorHandler) (gostream.VideoStream, error) {
 			extra, ok := camera.FromContext(ctx)
 			test.That(t, ok, test.ShouldBeTrue)
-			test.That(t, *extra, test.ShouldBeEmpty)
+			test.That(t, extra, test.ShouldBeEmpty)
 			return nil, errStreamFailed
 		}
 
@@ -440,8 +440,8 @@ func TestServer(t *testing.T) {
 		injectCamera.StreamFunc = func(ctx context.Context, errHandlers ...gostream.ErrorHandler) (gostream.VideoStream, error) {
 			extra, ok := camera.FromContext(ctx)
 			test.That(t, ok, test.ShouldBeTrue)
-			test.That(t, len(*extra), test.ShouldEqual, 1)
-			test.That(t, (*extra)["hello"], test.ShouldEqual, "world")
+			test.That(t, len(extra), test.ShouldEqual, 1)
+			test.That(t, extra["hello"], test.ShouldEqual, "world")
 			return nil, errStreamFailed
 		}
 
@@ -459,8 +459,8 @@ func TestServer(t *testing.T) {
 		injectCamera.StreamFunc = func(ctx context.Context, errHandlers ...gostream.ErrorHandler) (gostream.VideoStream, error) {
 			extra, ok := camera.FromContext(ctx)
 			test.That(t, ok, test.ShouldBeTrue)
-			test.That(t, len(*extra), test.ShouldEqual, 1)
-			test.That(t, (*extra)[data.FromDMString], test.ShouldBeTrue)
+			test.That(t, len(extra), test.ShouldEqual, 1)
+			test.That(t, extra[data.FromDMString], test.ShouldBeTrue)
 
 			return nil, errStreamFailed
 		}
@@ -480,9 +480,9 @@ func TestServer(t *testing.T) {
 		injectCamera.StreamFunc = func(ctx context.Context, errHandlers ...gostream.ErrorHandler) (gostream.VideoStream, error) {
 			extra, ok := camera.FromContext(ctx)
 			test.That(t, ok, test.ShouldBeTrue)
-			test.That(t, len(*extra), test.ShouldEqual, 2)
-			test.That(t, (*extra)["hello"], test.ShouldEqual, "world")
-			test.That(t, (*extra)[data.FromDMString], test.ShouldBeTrue)
+			test.That(t, len(extra), test.ShouldEqual, 2)
+			test.That(t, extra["hello"], test.ShouldEqual, "world")
+			test.That(t, extra[data.FromDMString], test.ShouldBeTrue)
 			return nil, errStreamFailed
 		}
 

--- a/data/collector.go
+++ b/data/collector.go
@@ -34,6 +34,7 @@ var sleepCaptureCutoff = 2 * time.Millisecond
 type CaptureFunc func(ctx context.Context, params map[string]*anypb.Any) (interface{}, error)
 
 // FromDMContextKey is used to check whether the context is from data management.
+// Deprecated: use a camera.Extra with camera.NewContext instead.
 type FromDMContextKey struct{}
 
 // FromDMString is used to access the 'fromDataManagement' value from a request's Extra struct.
@@ -327,6 +328,7 @@ func FailedToReadErr(component, method string, err error) error {
 }
 
 // GetExtraFromContext sets the extra struct with "fromDataManagement": true if the flag is true in the context.
+// Deprecated: Use camera.FromContext instead.
 func GetExtraFromContext(ctx context.Context) (*structpb.Struct, error) {
 	extra := make(map[string]interface{})
 	if ctx.Value(FromDMContextKey{}) == true {


### PR DESCRIPTION
# Description
We're making the `extra` value in our context more generic to support more use cases. 

~@kaywux~ @agreenb This will break the hard-coded functionality for data for which this was originally implemented. If that will be difficult to update or will immediately be broken - because it isn't a separate code base pinned to a specific version of the RDK - let me know!

# Testing
I added my own unit test, but @njooma, I'm relying on you to make sure this works as expected with the SDKs.