### PR TITLE
RSDK-6323 GPIO servo display better error message

### DIFF
--- a/web/frontend/src/components/servo/index.svelte
+++ b/web/frontend/src/components/servo/index.svelte
@@ -27,12 +27,13 @@ const handleMove = async (amount: number) => {
   if(angle < 0) {
     displayError("Servo angle must be positive")
   }
-
+  else {
   try {
     await move($robotClient, name, angle);
   } catch (error) {
     displayError(error as ServiceError);
   }
+}
 };
 
 </script>

--- a/web/frontend/src/components/servo/index.svelte
+++ b/web/frontend/src/components/servo/index.svelte
@@ -24,6 +24,10 @@ const handleMove = async (amount: number) => {
   const oldAngle = status?.position_deg ?? 0;
   const angle = oldAngle + amount;
 
+  if(angle < 0) {
+    displayError("Servo angle must be positive")
+  }
+
   try {
     await move($robotClient, name, angle);
   } catch (error) {


### PR DESCRIPTION
When you used the control to go to an angle below zero, a vague "assertion failed" toast came up since the proto angle is an unsigned int. Changed to be more clear.