### PR TITLE
RSDK-6289 pin CI datacenter

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -26,7 +26,7 @@ jobs:
             image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
             platform: linux/amd64
             label: amd64
-          - arch: [buildjet-2vcpu-ubuntu-2204-arm]
+          - arch: [buildjet-2vcpu-ubuntu-2204-arm, buildjet-pinned-location_de_arm]
             image: ghcr.io/viamrobotics/rdk-devenv:arm64-cache
             platform: linux/arm64
             label: arm64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,7 @@ jobs:
 
   test_coverage:
     name: Go Coverage Tests
+    if: false # toggle this off, delete after 3/1/24 if nobody misses it
     # note: we split 'test_go' and 'test_coverage' steps because running race-detection + covprofile simultaneously is slow enough to cause flakes
     strategy:
       fail-fast: false
@@ -218,7 +219,7 @@ jobs:
 
   test_passing:
     name: All Tests Passing
-    needs: [test_go, test_coverage, test_web_e2e, test_pi, test32]
+    needs: [test_go, test_web_e2e, test_pi, test32]
     runs-on: [ubuntu-latest]
     if: always()
     steps:
@@ -227,12 +228,10 @@ jobs:
           echo Go Unit Tests: ${{ needs.test_go.result }}
           echo Go 32-bit Tests: ${{ needs.test32.result }}
           echo Go Pi Tests: ${{ needs.test_pi.result }}
-          echo Go Coverage Tests: ${{ needs.test_coverage.result }}
           echo Web/E2E Tests: ${{ needs.test_web_e2e.result }}
           [ "${{ needs.test_go.result }}" == "success" ] && \
           [ "${{ needs.test32.result }}" == "success" ] && \
           [ "${{ needs.test_pi.result }}" == "success" ] && \
-          [ "${{ needs.test_coverage.result }}" == "success" ] && \
           [ "${{ needs.test_web_e2e.result }}" == "success" ]
 
       # Now that RDK is public, can't directly comment without token having full read/write access

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
             image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
             platform: linux/amd64
             platform_name: linux-amd64
-          - arch: [buildjet-8vcpu-ubuntu-2204-arm]
+          - arch: [buildjet-8vcpu-ubuntu-2204-arm, buildjet-pinned-location_de_arm]
             image: ghcr.io/viamrobotics/rdk-devenv:arm64-cache
             platform: linux/arm64
             platform_name: linux-arm64
@@ -141,7 +141,7 @@ jobs:
 
   test32:
     name: Go 32-bit Unit Tests
-    runs-on: buildjet-8vcpu-ubuntu-2204-arm
+    runs-on: [buildjet-8vcpu-ubuntu-2204-arm, buildjet-pinned-location_de_arm]
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
## What changed
- pin 3 arm64 jobs to a specific datacenter
- remove coverage test run (keep the data race run)
## Why
- in theory reduce CI timeouts in the image pull step
- coverage decision in [slack](https://viaminc.slack.com/archives/C01Q5S8V6TB/p1704920325076189), but basically to speed up tests + halve our flake risk
## Sample run
https://github.com/viamrobotics/rdk/actions/runs/7495123827