### PR TITLE
Set x264 bitrate to 1.2 megabits

### DIFF
--- a/gostream/codec/x264/encoder.go
+++ b/gostream/codec/x264/encoder.go
@@ -20,7 +20,7 @@ type encoder struct {
 }
 
 // Gives suitable results. Probably want to make this configurable this in the future.
-const bitrate = 3_200_000
+const bitrate = 1_200_000
 
 // NewEncoder returns an x264 encoder that can encode images of the given width and height. It will
 // also ensure that it produces key frames at the given interval.


### PR DESCRIPTION
## Description
This PR simply downsizes the x264 encoder bitrate from `3.2 megabits` to `1.2 megabits`.  We have been noticing potential livestream issues in bandwidth constrained WANs. This should only affect 1080+ framesizes because anything smaller will not even hit the 1.2 megabit throughput size.

## Testing
- Tested that larger framesizes (1080p+) still stream with suitable quality to the web application.