### PR TITLE
RSDK-6162 - Add Close to video encoders

### DIFF
--- a/gostream/codec/h264/encoder.go
+++ b/gostream/codec/h264/encoder.go
@@ -66,7 +66,7 @@ func NewEncoder(width, height, keyFrameInterval int, logger golog.Logger) (codec
 	}
 
 	if h.frame = avutil.FrameAlloc(); h.frame == nil {
-		h.context.Close()
+		h.Close()
 		return nil, errors.New("cannot alloc frame")
 	}
 
@@ -145,4 +145,19 @@ loop:
 	}
 
 	return bytes, nil
+}
+
+// Close closes the encoder. It is safe to call this method multiple times.
+// It is also safe to call this method after a call to Encode.
+func (h *encoder) Close() error {
+	if h.frame != nil {
+		avutil.FrameUnref(h.frame)
+		h.frame = nil
+	}
+	if h.context != nil {
+		h.context.FreeContext()
+		h.context = nil
+	}
+
+	return nil
 }

--- a/gostream/codec/video_encoder.go
+++ b/gostream/codec/video_encoder.go
@@ -18,6 +18,7 @@ const DefaultKeyFrameInterval = 30
 // An encoder that produces bytes of different encoding formats per call is invalid.
 type VideoEncoder interface {
 	Encode(ctx context.Context, img image.Image) ([]byte, error)
+	Close() error
 }
 
 // A VideoEncoderFactory produces VideoEncoders and provides information about the underlying encoder itself.

--- a/gostream/codec/vpx/encoder.go
+++ b/gostream/codec/vpx/encoder.go
@@ -87,3 +87,8 @@ func (v *encoder) Encode(_ context.Context, img image.Image) ([]byte, error) {
 	release()
 	return dataCopy, err
 }
+
+// Close closes the encoder.
+func (v *encoder) Close() error {
+	return v.codec.Close()
+}

--- a/gostream/codec/x264/encoder.go
+++ b/gostream/codec/x264/encoder.go
@@ -64,3 +64,8 @@ func (v *encoder) Encode(_ context.Context, img image.Image) ([]byte, error) {
 	release()
 	return dataCopy, err
 }
+
+// Close closes the encoder.
+func (v *encoder) Close() error {
+	return v.codec.Close()
+}

--- a/gostream/stream.go
+++ b/gostream/stream.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/edaniels/golog"
 	"github.com/google/uuid"
+
 	// register screen drivers.
 	_ "github.com/pion/mediadevices/pkg/driver/microphone"
 	"github.com/pion/mediadevices/pkg/prop"
@@ -178,6 +179,9 @@ func (bs *basicStream) Stop() {
 	bs.activeBackgroundWorkers.Wait()
 	if bs.audioEncoder != nil {
 		bs.audioEncoder.Close()
+	}
+	if bs.videoEncoder != nil {
+		bs.videoEncoder.Close()
 	}
 
 	// reset


### PR DESCRIPTION
## Description
This PR adds a `Close` method to the `videoEncoder` interface. 

The `h264` codec uses avcodec`FreeContext` call and the `x264` encoder uses mediadevices built in `Close` function. These calls are hit when the stream calls`Stop`. (See `stream.go` changes).

_Note: PR does not add back in use for h264 hardware encoder._

## Testing
- Tested that this fixes `STREAMON` ioctl errors when using h264 codec. (`[h264_v4l2m2m @ 0x7f6c000e40] VIDIOC_STREAMON failed on output context`)
- Tested there are no regressions with x264 codec.
- Vpx tests are passing