### PR TITLE
skip MoveOnMapNew/Long_Distance

### DIFF
--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -1281,6 +1281,7 @@ func TestMoveOnMapNew(t *testing.T) {
 
 	t.Run("Long distance", func(t *testing.T) {
 		// TODO(RSDK-6326) - fix test failure and unskip
+		t.Skip()
 		if runtime.GOARCH == "arm" {
 			t.Skip("skipping on 32-bit ARM, large maps use too much memory")
 		}

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -1280,6 +1280,7 @@ func TestMoveOnMapNew(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 
 	t.Run("Long distance", func(t *testing.T) {
+		// TODO(RSDK-6326) - fix test failure and unskip
 		if runtime.GOARCH == "arm" {
 			t.Skip("skipping on 32-bit ARM, large maps use too much memory")
 		}


### PR DESCRIPTION
This PR skips MoveOnMapNew/Long_Distance to prevent unit test failures.
https://viam.atlassian.net/browse/RSDK-6326 will un-skip this test and fix the flakiness.