### PR TITLE
unhide CLI module build commands

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -1141,9 +1141,9 @@ viam module upload --version "0.1.0" --platform "linux/amd64" packaged-module.ta
 					Action: UploadModuleAction,
 				},
 				{
-					Name:   "build",
-					Hidden: true,
-					Usage: `build your module on different operating systems and cpu architectures via cloud runners.
+					Name:  "build",
+					Usage: "build your module for different architectures using cloud runners",
+					UsageText: `Build your module on different operating systems and cpu architectures via cloud runners.
 Uses the "build" section of your meta.json.
 Example:
 "build": {
@@ -1156,7 +1156,7 @@ Example:
 					Subcommands: []*cli.Command{
 						{
 							Name:  "local",
-							Usage: "run your module's build commands locally",
+							Usage: "run your meta.json build command locally",
 							Flags: []cli.Flag{
 								&cli.StringFlag{
 									Name:      moduleFlagPath,
@@ -1168,8 +1168,8 @@ Example:
 							Action: ModuleBuildLocalAction,
 						},
 						{
-							Name:        "start",
-							Description: "start a remote build",
+							Name:  "start",
+							Usage: "start a remote build",
 							Flags: []cli.Flag{
 								&cli.StringFlag{
 									Name:      moduleBuildFlagPath,


### PR DESCRIPTION
## What changed
- unhide `viam module build` command from help
- add missing usage
## Example output
```
$ go run ./cli/viam/ module 
NAME:
   viam module - manage your modules in Viam's registry

USAGE:
   viam module command [command options] [arguments...]

COMMANDS:
   create         create & register a module on app.viam.com
   update         update a module's metadata on app.viam.com
   update-models  update a module's metadata file based on models it provides
   upload         upload a new version of your module
   build          build your module for different architectures using cloud runners

OPTIONS:
   --help, -h  show help (default: false)

```

```
$ go run ./cli/viam/ module build
NAME:
   viam module build - build your module for different architectures using cloud runners

USAGE:
   Build your module on different operating systems and cpu architectures via cloud runners.
   Uses the "build" section of your meta.json.
   Example:
   "build": {
      "setup": "setup.sh",                    // optional - command to install your build dependencies
      "build": "make module.tar.gz",          // command that will build your module
      "path" : "module.tar.gz",               // optional - path to your built module
                                              // (passed to the 'viam module upload' command)
      "arch" : ["linux/amd64", "linux/arm64"] // architectures to build for
   }

COMMANDS:
   local      run your module's build commands locally
   start      start a remote build
   list       check on the status of your cloud builds
   logs, log  get the logs from one of your cloud builds
   help, h    Shows a list of commands or help for one command

OPTIONS:
   --help, -h  show help (default: false)

```