### PR TITLE
RSDK-6265 Add check for starting in collision with a pointcloud

### DIFF
--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -314,6 +314,23 @@ func TestMoveOnMapPlans(t *testing.T) {
 		test.That(t, spatialmath.PoseAlmostEqualEps(endPos.Pose(), easyGoalInBaseFrame, 10), test.ShouldBeTrue)
 	})
 
+	t.Run("should fail due to map collision", func(t *testing.T) {
+		_, ms := createMoveOnMapEnvironment(ctx, t, "pointcloud/octagonspace.pcd", 40, spatialmath.NewPoseFromPoint(r3.Vector{X: 0, Y: -500}))
+		defer ms.Close(ctx)
+		easyGoalInBaseFrame := spatialmath.NewPoseFromPoint(r3.Vector{X: 0.277 * 1000, Y: 0.593 * 1000})
+		easyGoalInSLAMFrame := spatialmath.PoseBetweenInverse(motion.SLAMOrientationAdjustment, easyGoalInBaseFrame)
+		success, err := ms.MoveOnMap(
+			context.Background(),
+			base.Named("test-base"),
+			easyGoalInSLAMFrame,
+			slam.Named("test_slam"),
+			extra,
+		)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldEqual, "starting collision between SLAM map and unnamedCollisionGeometry_0, cannot move")
+		test.That(t, success, test.ShouldBeFalse)
+	})
+
 	t.Run("check that position-only mode executes", func(t *testing.T) {
 		kb, ms := createMoveOnMapEnvironment(ctx, t, "pointcloud/octagonspace.pcd", 40, nil)
 		defer ms.Close(ctx)


### PR DESCRIPTION
This PR adds a check whether a motion starts with a moving geometry colliding with a WorldState pointcloud, and if so, errors.