### PR TITLE
APP-3656: Add CODEOWNERS for RC

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# No code owners for all files
+*
+
+# TODO(APP-3043): Remove code owners
+#
+# This code owners is to make sure that the fleet team is aware
+# of any changes that are going into RC while the team is updating
+# the RC implementation in App.
+#
+# Code owners are no longer needed once RDK uses the shared,
+# updated remote control cards from App. For any questions reach
+# out to @ethanlook.
+web/frontend @ethanlook


### PR DESCRIPTION
As we rebuild RC for the robot details redesign, we will rebuild RC in App with styles that match the redesign, comprehensive testing, and restructuring components. To reduce churn in RDK, we will not make these changes in-place in RDK. Instead, we will build the new RC in App and then replace RC in RDK after it is complete.

During this period, RC will still exist in RDK and folks will want to make changes. To make sure that the team is aware of these changes, I am adding myself as a code owner on RC in RDK. This, along with required code owners approval, will make sure that I can incorporate these changes back into the new RC.

Read more about code owners [here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).

## Review requests

Any concerns with using code owners to keep me aware of changes to RC in RDK?