### PR TITLE
RSDK-6393 errors in octree transform are truncating slam maps

### DIFF
--- a/pointcloud/basic_octree.go
+++ b/pointcloud/basic_octree.go
@@ -183,8 +183,11 @@ func (octree *BasicOctree) Transform(pose spatialmath.Pose) spatialmath.Geometry
 
 	octree.Iterate(0, 0, func(p r3.Vector, d Data) bool {
 		tformPt := spatialmath.Compose(pose, spatialmath.NewPoseFromPoint(p)).Point()
+		// We don't do anything with this error, as returning false here merely silently truncates the pointcloud.
+		// Preference is to lose one point than the rest of them.
 		err := newOctree.Set(tformPt, d)
-		return err == nil
+		_ = err
+		return true
 	})
 	return newOctree
 }

--- a/pointcloud/basic_octree.go
+++ b/pointcloud/basic_octree.go
@@ -17,9 +17,9 @@ const (
 	leafNodeFilled
 	// This value allows for high level of granularity in the octree while still allowing for fast access times
 	// even on a pi.
-	maxRecursionDepth = 250 // This gives us enough resolution to model the observable universe in planck lengths.
+	maxRecursionDepth = 250  // This gives us enough resolution to model the observable universe in planck lengths.
 	floatEpsilon      = 1e-6 // This is also effectively half of the minimum side length.
-	nodeRegionOverlap = floatEpsilon/2
+	nodeRegionOverlap = floatEpsilon / 2
 	// TODO (RSDK-3767): pass these in a different way.
 	confidenceThreshold = 50    // value between 0-100, threshold sets the confidence level required for a point to be considered a collision
 	buffer              = 150.0 // max distance from base to point for it to be considered a collision in mm

--- a/pointcloud/basic_octree.go
+++ b/pointcloud/basic_octree.go
@@ -17,9 +17,9 @@ const (
 	leafNodeFilled
 	// This value allows for high level of granularity in the octree while still allowing for fast access times
 	// even on a pi.
-	maxRecursionDepth = 1000
-	nodeRegionOverlap = 1e-6
-	floatEpsilon      = 1e-6
+	maxRecursionDepth = 250 // This gives us enough resolution to model the observable universe in planck lengths.
+	floatEpsilon      = 1e-6 // This is also effectively half of the minimum side length.
+	nodeRegionOverlap = floatEpsilon/2
 	// TODO (RSDK-3767): pass these in a different way.
 	confidenceThreshold = 50    // value between 0-100, threshold sets the confidence level required for a point to be considered a collision
 	buffer              = 150.0 // max distance from base to point for it to be considered a collision in mm

--- a/pointcloud/basic_octree_utils.go
+++ b/pointcloud/basic_octree_utils.go
@@ -103,9 +103,10 @@ func (octree *BasicOctree) splitIntoOctants() error {
 
 // Checks that a point should be inside a basic octree based on its center and defined side length.
 func (octree *BasicOctree) checkPointPlacement(p r3.Vector) bool {
-	return ((math.Abs(octree.center.X-p.X) <= nodeRegionOverlap + octree.sideLength/2.) &&
-		(math.Abs(octree.center.Y-p.Y) <= nodeRegionOverlap + octree.sideLength/2.) &&
-		(math.Abs(octree.center.Z-p.Z) <= nodeRegionOverlap + octree.sideLength/2.))
+	// nodeRegionOverlap must be an absolute value, not proportional, otherwise as side lengths shrink points will be orphaned.
+	return ((math.Abs(octree.center.X-p.X) <= nodeRegionOverlap+octree.sideLength/2.) &&
+		(math.Abs(octree.center.Y-p.Y) <= nodeRegionOverlap+octree.sideLength/2.) &&
+		(math.Abs(octree.center.Z-p.Z) <= nodeRegionOverlap+octree.sideLength/2.))
 }
 
 // helperSet is used by Set to recursive move through a basic octree while tracking recursion depth.

--- a/pointcloud/basic_octree_utils.go
+++ b/pointcloud/basic_octree_utils.go
@@ -103,9 +103,9 @@ func (octree *BasicOctree) splitIntoOctants() error {
 
 // Checks that a point should be inside a basic octree based on its center and defined side length.
 func (octree *BasicOctree) checkPointPlacement(p r3.Vector) bool {
-	return ((math.Abs(octree.center.X-p.X) <= (1+nodeRegionOverlap)*octree.sideLength/2.) &&
-		(math.Abs(octree.center.Y-p.Y) <= (1+nodeRegionOverlap)*octree.sideLength/2.) &&
-		(math.Abs(octree.center.Z-p.Z) <= (1+nodeRegionOverlap)*octree.sideLength/2.))
+	return ((math.Abs(octree.center.X-p.X) <= nodeRegionOverlap + octree.sideLength/2.) &&
+		(math.Abs(octree.center.Y-p.Y) <= nodeRegionOverlap + octree.sideLength/2.) &&
+		(math.Abs(octree.center.Z-p.Z) <= nodeRegionOverlap + octree.sideLength/2.))
 }
 
 // helperSet is used by Set to recursive move through a basic octree while tracking recursion depth.


### PR DESCRIPTION
The issue comes when an octree has a nodeRegionOverlap of, say, 1mm, and a point gets placed in that 1mm border region. Then that octree is split into octants, each of which have border regions of only 0.5mm. If the point is less than 1mm but greater than 0.5mm from the original octree, it will fit into none of the octree's octants and cause an error, truncating the pointcloud.

This PR fixes this issue by making `nodeRegionOverlap` an absolute value such that all octree octants will always have the same buffer region, guaranteeing a point fits.