### PR TITLE
CLI module create behavior with existing meta.jsons

### DIFF
--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -104,8 +104,11 @@ func CreateModuleAction(c *cli.Context) error {
 	modManifest, err := loadManifest(defaultManifestFilename)
 	if err == nil {
 		manifestModuleID, err := parseModuleID(modManifest.ModuleID)
-		if err != nil || manifestModuleID.name != moduleNameArg || (manifestModuleID.prefix != orgIDArg && manifestModuleID.prefix != publicNamespaceArg) {
-			return errors.Errorf("another module's meta.json (%q) already exists in the current directory. Delete it and try again", modManifest.ModuleID)
+		if err != nil ||
+			manifestModuleID.name != moduleNameArg ||
+			(manifestModuleID.prefix != orgIDArg && manifestModuleID.prefix != publicNamespaceArg) {
+			return errors.Errorf("another module's meta.json (%q) already exists in the current directory. Delete it and try again",
+				modManifest.ModuleID)
 		}
 	}
 
@@ -127,8 +130,8 @@ func CreateModuleAction(c *cli.Context) error {
 	if modManifest != nil {
 		// if the original module manifest we read was non-nil, we also want to run an update
 		_, err := client.updateModule(returnedModuleID, *modManifest)
-		// we want to silently fail because this isn't an action the user asked for, so if it fails,
-		// an error message would cause confusion
+		// we want to fail with a warning rather than an error because this isn't an action the user asked for,
+		// so red scary error messages would cause confusion
 		if err != nil {
 			warningf(c.App.Writer, "Tried to update module with info from your meta.json but got: %v", err)
 		} else {
@@ -444,12 +447,6 @@ func validateModuleFile(client *viamClient, moduleID moduleID, tarballPath, vers
 		// if path == entrypoint, we have found the right file
 		if filepath.Clean(path) == filepath.Clean(entrypoint) {
 			info := header.FileInfo()
-			if info.IsDir() {
-				return errors.Errorf(
-					"the module archive contains a directory at the entrypoint %q instead of an executable file",
-					entrypoint)
-			}
-
 			if info.Mode().Perm()&0o100 == 0 {
 				return errors.Errorf(
 					"the archive contained a file at the entrypoint %q, but that file is not marked as executable",

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -107,7 +107,7 @@ func CreateModuleAction(c *cli.Context) error {
 	if _, err := os.Stat(defaultManifestFilename); err == nil {
 		modManifest, err := loadManifest(defaultManifestFilename)
 		if err != nil {
-			return errors.Errorf("another meta.json already exists in the current directory. Delete it and try again")
+			return errors.New("another meta.json already exists in the current directory. Delete it and try again")
 		}
 		manifestModuleID, err := parseModuleID(modManifest.ModuleID)
 		if err != nil ||

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -113,8 +113,8 @@ func CreateModuleAction(c *cli.Context) error {
 		if err != nil ||
 			manifestModuleID.name != moduleNameArg ||
 			(manifestModuleID.prefix != org.GetId() && manifestModuleID.prefix != org.GetPublicNamespace()) {
-			return errors.Errorf("a different module's meta.json (%q) already exists in the current directory. "+
-				"Either delete that meta.json, or edit its module_id to match the args passed to this command",
+			return errors.Errorf("a different module's meta.json already exists in the current directory. "+
+				"Either delete that meta.json, or edit its module_id (%q) to match the args passed to this command",
 				modManifest.ModuleID)
 		}
 		shouldWriteNewEmptyManifest = false

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -135,7 +135,7 @@ func CreateModuleAction(c *cli.Context) error {
 		if err != nil {
 			warningf(c.App.Writer, "Tried to update module with info from your meta.json but got: %v", err)
 		} else {
-			printf(c.App.Writer, "Module successfully updated with info from your existing meta.json!")
+			printf(c.App.Writer, "Module successfully updated with info from your existing meta.json")
 		}
 	} else {
 		// otherwise we should create a new empty meta.json and write that

--- a/cli/print.go
+++ b/cli/print.go
@@ -43,7 +43,7 @@ func infof(w io.Writer, format string, a ...interface{}) {
 // do not currently make use of the variadic `a` parameter but may in the
 // future. unparam will complain until it does.
 //
-
+//nolint:unparam
 func warningf(w io.Writer, format string, a ...interface{}) {
 	if _, err := color.New(color.Bold, color.FgYellow).Fprint(w, "Warning: "); err != nil {
 		log.Fatal(err)

--- a/cli/print.go
+++ b/cli/print.go
@@ -43,7 +43,7 @@ func infof(w io.Writer, format string, a ...interface{}) {
 // do not currently make use of the variadic `a` parameter but may in the
 // future. unparam will complain until it does.
 //
-//nolint:unparam
+
 func warningf(w io.Writer, format string, a ...interface{}) {
 	if _, err := color.New(color.Bold, color.FgYellow).Fprint(w, "Warning: "); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
I was talking with Hazal during the happy-hour and she was voicing how it was unintuitive that she had to both create a meta.json (as the docs and other modules say to do) and yet also not create it until she runs `viam module create`.

This PR updates that behavior so that if a meta.json exists in the current directory (with a matching moduleid as what was requested via the cli args), it will create the module (in the registry) and then update that module (reducing the number of steps by 1)

It maintains the existing behavior for directories where there is no meta.json.



User flow:
1) New user wants to create a module
2) User copies files from some online examples (including a meta.json)
3) They start editing files / get their module to a semi-working state as a local module
4) They edit the meta.json to have the info they expect for their module (including a new module id) (ex `module_id:"abe:mycoolmodule"`)
5) They look online and try to figure out what to do from here. They probably look into `viam module update` or `viam module create`.
5) They run `viam module create --name mycoolmodule --public-namespace abe`
6) Instead of printing an error message (current behavior), the cli just runs the create and update flows (proposed new behavior).


Alternatives / also considered:
`viam module update` -> detect if the module does not exist, create it if it doesn't, then run update.
This /could/ help, but it could also result in lots of user confusion with lots of new modules (when people /think/ that they are renaming their module but they are actually creating new modules)

`viam module create (no args)` -> use name /namespace from meta.json. I also think this will cause user confusion if they copy the meta.json without modifying it.

EDIT:
`viam module create (no args)` -> begin interactive walkthrough where user can enter/edit both the public namespace + name of the module (and maybe enter things like visibility, description, url, etc) (would require more thought)