### PR TITLE
RSDK-6398 copy linter from coverage to unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,17 @@ jobs:
     - name: Chown
       run: chown -R testbot:testbot .
 
+    - name: Verify no uncommitted changes from "make build-go lint-go"
+      run: |
+        sudo -Hu testbot bash -lc 'git init && git add . && make build-go lint-go'
+        GEN_DIFF=$(git status -s)
+
+        if [ -n "$GEN_DIFF" ]; then
+            echo '"make build lint" resulted in changes not in git' 1>&2
+            git status
+            exit 1
+        fi
+
     - name: Run go unit tests
       run: |
         sudo --preserve-env=MONGODB_TEST_OUTPUT_URI,GITHUB_SHA,GITHUB_RUN_ID,GITHUB_RUN_NUMBER,GITHUB_RUN_ATTEMPT,GITHUB_X_PR_BASE_SHA,GITHUB_X_PR_BASE_REF,GITHUB_X_HEAD_REF,GITHUB_X_HEAD_SHA,GITHUB_REPOSITORY -Hu testbot bash -lc 'make test-go'

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -232,7 +232,7 @@ func accurateSleep(ctx context.Context, duration time.Duration) bool {
 		}
 	}
 
-	for time.Now().Sub(startTime) < duration {
+	for time.Since(startTime) < duration {
 		select {
 		case <-ctx.Done():
 			return false

--- a/gostream/codec/h264/encoder.go
+++ b/gostream/codec/h264/encoder.go
@@ -66,7 +66,7 @@ func NewEncoder(width, height, keyFrameInterval int, logger golog.Logger) (codec
 	}
 
 	if h.frame = avutil.FrameAlloc(); h.frame == nil {
-		h.Close()
+		h.Close() //nolint:errcheck
 		return nil, errors.New("cannot alloc frame")
 	}
 

--- a/gostream/stream.go
+++ b/gostream/stream.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/edaniels/golog"
 	"github.com/google/uuid"
-
 	// register screen drivers.
 	_ "github.com/pion/mediadevices/pkg/driver/microphone"
 	"github.com/pion/mediadevices/pkg/prop"

--- a/gostream/stream.go
+++ b/gostream/stream.go
@@ -180,7 +180,7 @@ func (bs *basicStream) Stop() {
 		bs.audioEncoder.Close()
 	}
 	if bs.videoEncoder != nil {
-		bs.videoEncoder.Close()
+		bs.videoEncoder.Close() //nolint:gosec,errcheck
 	}
 
 	// reset


### PR DESCRIPTION
## What changed
- run linter in datarace step, not just coverage
- temporary `//nolint` comments for two locations that are now failing
## Why
- lint previously only ran in the coverage step, removing coverage from our test suite disabled lint
## Test run
- passing [here](https://github.com/viamrobotics/rdk/actions/runs/7612350596/job/20729774629)