### PR TITLE
Show diff when linter creates untracked changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,8 @@ jobs:
         GEN_DIFF=$(git status -s)
 
         if [ -n "$GEN_DIFF" ]; then
+            echo '"make build lint" resulted in the following untracked changes:' 1>&2
+            git diff
             echo '"make build lint" resulted in changes not in git' 1>&2
             git status
             exit 1


### PR DESCRIPTION
The problem: I've made changes to some code that only builds on a raspberry pi. The tests pass, but the linter isn't happy. The linter on my laptop doesn't check this code because it's not running on a pi. I can run it on a pi, but that takes _ages,_ to the point that frankly I'm guessing what the linter might have done and trying to make the same changes blindly (and if that doesn't work, I'll try removing the go build directives at the top of the file, and then perhaps getting annoyed when the linter says this code doesn't compile on a non-pi machine). 

The solution: when the CI check fails, not only run `git status` to show which files changed, run `git diff` to show what the changes were. Run `git diff` first, so that if there is a giant diff, the very last thing (and the thing we jump to when opening the CI output) is the old message.

This helps with my immediate problem, but I haven't thought through whether this is a good change long-term. If you have a reason this is a bad idea, I'm happy to close the PR without merging.
## Test runs
- passing [here](https://github.com/viamrobotics/rdk/actions/runs/7617111829)