### PR TITLE
RSDK-5916 - Add h264 encoder to entrypoint

### DIFF
--- a/gostream/codec/h264/encoder.go
+++ b/gostream/codec/h264/encoder.go
@@ -8,6 +8,7 @@ import "C"
 import (
 	"context"
 	"image"
+	"time"
 	"unsafe"
 
 	"github.com/edaniels/golog"
@@ -27,6 +28,8 @@ const (
 	V4l2m2m = "h264_v4l2m2m"
 	// macroBlock is the encoder boundary block size in bytes.
 	macroBlock = 64
+	// warmupTime is the time to wait for the encoder to warm up in milliseconds.
+	warmupTime = 1000 // 1 second
 )
 
 type encoder struct {
@@ -73,6 +76,9 @@ func NewEncoder(width, height, keyFrameInterval int, logger golog.Logger) (codec
 		}
 		return nil, errors.New("cannot alloc frame")
 	}
+
+	// give the encoder some time to warm up
+	time.Sleep(warmupTime * time.Millisecond)
 
 	return h, nil
 }

--- a/gostream/codec/h264/encoder.go
+++ b/gostream/codec/h264/encoder.go
@@ -68,7 +68,9 @@ func NewEncoder(width, height, keyFrameInterval int, logger golog.Logger) (codec
 	}
 
 	if h.frame = avutil.FrameAlloc(); h.frame == nil {
-		h.Close() //nolint:errcheck
+		if err := h.Close(); err != nil {
+			return nil, errors.Wrap(err, "cannot close codec")
+		}
 		return nil, errors.New("cannot alloc frame")
 	}
 

--- a/gostream/stream.go
+++ b/gostream/stream.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/edaniels/golog"
 	"github.com/google/uuid"
+	// register screen drivers.
 	_ "github.com/pion/mediadevices/pkg/driver/microphone"
 	"github.com/pion/mediadevices/pkg/prop"
 	"github.com/pion/mediadevices/pkg/wave"

--- a/gostream/stream.go
+++ b/gostream/stream.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/edaniels/golog"
 	"github.com/google/uuid"
+
 	// register screen drivers.
 	_ "github.com/pion/mediadevices/pkg/driver/microphone"
 	"github.com/pion/mediadevices/pkg/prop"
@@ -180,7 +181,9 @@ func (bs *basicStream) Stop() {
 		bs.audioEncoder.Close()
 	}
 	if bs.videoEncoder != nil {
-		bs.videoEncoder.Close() //nolint:gosec,errcheck
+		if err := bs.videoEncoder.Close(); err != nil {
+			bs.logger.Error(err)
+		}
 	}
 
 	// reset

--- a/gostream/stream.go
+++ b/gostream/stream.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/edaniels/golog"
 	"github.com/google/uuid"
-
-	// register screen drivers.
 	_ "github.com/pion/mediadevices/pkg/driver/microphone"
 	"github.com/pion/mediadevices/pkg/prop"
 	"github.com/pion/mediadevices/pkg/wave"

--- a/web/server/entrypoint_linux.go
+++ b/web/server/entrypoint_linux.go
@@ -12,7 +12,7 @@ import (
 
 func makeStreamConfig() gostream.StreamConfig {
 	var streamConfig gostream.StreamConfig
-	if avcodec.EncoderIsAvailable("h264_v4l2m2m") {
+	if avcodec.EncoderIsAvailable(h264.V4l2m2m) {
 		streamConfig.VideoEncoderFactory = h264.NewEncoderFactory()
 	} else {
 		streamConfig.VideoEncoderFactory = x264.NewEncoderFactory()

--- a/web/server/entrypoint_linux.go
+++ b/web/server/entrypoint_linux.go
@@ -4,14 +4,19 @@ package server
 
 import (
 	"go.viam.com/rdk/gostream"
+	"go.viam.com/rdk/gostream/codec/h264"
 	"go.viam.com/rdk/gostream/codec/opus"
 	"go.viam.com/rdk/gostream/codec/x264"
+	"go.viam.com/rdk/gostream/ffmpeg/avcodec"
 )
 
 func makeStreamConfig() gostream.StreamConfig {
 	var streamConfig gostream.StreamConfig
-	// TODO(RSDK-5916): support v4l2m2m codec on arm64/rpi
-	streamConfig.VideoEncoderFactory = x264.NewEncoderFactory()
+	if avcodec.EncoderIsAvailable("h264_v4l2m2m") {
+		streamConfig.VideoEncoderFactory = h264.NewEncoderFactory()
+	} else {
+		streamConfig.VideoEncoderFactory = x264.NewEncoderFactory()
+	}
 	streamConfig.AudioEncoderFactory = opus.NewEncoderFactory()
 	return streamConfig
 }


### PR DESCRIPTION
## Description

This PR adds h264 encoder check and initialization to entrypoint. All flaky behavior and encoder bugs have been fixed. Code diff includes linter fixes for encoder closeouts.

## Testing
- Tested that livestreams are robust against start/stops and webrtc session refreshes
- Tested this branch against canary runners overnight
- Tested entrpoint defaults to x264 on non-RPI4 boards
- Tested with multiple input src pixel formats (YUYV, MJPEG)

### CPU Utilization
- Halfed cpu utilization for 1280p video

<img width="678" alt="Screenshot 2024-01-29 at 11 34 48 AM" src="https://github.com/viamrobotics/rdk/assets/12690131/dc03871a-1ede-43a8-a8c8-eeaa2f3e46c4">

<img width="678" alt="Screenshot 2024-01-29 at 11 35 43 AM" src="https://github.com/viamrobotics/rdk/assets/12690131/046a978d-b3a0-4965-a2d6-5db6fe6402f7">
