### PR TITLE
RSDK-6340 Allow streams to restart after disconnect

### DIFF
--- a/components/audioinput/client.go
+++ b/components/audioinput/client.go
@@ -42,6 +42,9 @@ func NewClientFromConn(
 	name resource.Name,
 	logger logging.Logger,
 ) (AudioInput, error) {
+	// TODO(RSDK-6340): This client might still try to create audio streams after this
+	// context is canceled. These subsequent audio streams will not work. To fix this,
+	// use a channel instead of a context like we do in `component/audioinput/client.go`
 	cancelCtx, cancel := context.WithCancel(context.Background())
 	c := pb.NewAudioInputServiceClient(conn)
 	return &client{

--- a/components/audioinput/client.go
+++ b/components/audioinput/client.go
@@ -73,8 +73,8 @@ func (c *client) Stream(
 	errHandlers ...gostream.ErrorHandler,
 ) (gostream.AudioStream, error) {
 	// TODO: add to struct
-	closeCh := make(chan struct{})
-	streamCtx, stream, chunkCh := gostream.NewMediaStreamForChannel[wave.Audio](c.cancelCtx, closeCh)
+	stopCh := make(chan struct{})
+	streamCtx, stream, chunkCh := gostream.NewMediaStreamForChannel[wave.Audio](c.cancelCtx, stopCh)
 
 	chunksClient, err := c.client.Chunks(ctx, &pb.ChunksRequest{
 		Name:         c.name,

--- a/components/audioinput/client.go
+++ b/components/audioinput/client.go
@@ -72,7 +72,9 @@ func (c *client) Stream(
 	ctx context.Context,
 	errHandlers ...gostream.ErrorHandler,
 ) (gostream.AudioStream, error) {
-	streamCtx, stream, chunkCh := gostream.NewMediaStreamForChannel[wave.Audio](c.cancelCtx)
+	// TODO: add to struct
+	closeCh := make(chan struct{})
+	streamCtx, stream, chunkCh := gostream.NewMediaStreamForChannel[wave.Audio](c.cancelCtx, closeCh)
 
 	chunksClient, err := c.client.Chunks(ctx, &pb.ChunksRequest{
 		Name:         c.name,

--- a/components/audioinput/client.go
+++ b/components/audioinput/client.go
@@ -72,9 +72,7 @@ func (c *client) Stream(
 	ctx context.Context,
 	errHandlers ...gostream.ErrorHandler,
 ) (gostream.AudioStream, error) {
-	// TODO: add to struct
-	stopCh := make(chan struct{})
-	streamCtx, stream, chunkCh := gostream.NewMediaStreamForChannel[wave.Audio](c.cancelCtx, stopCh)
+	streamCtx, stream, chunkCh := gostream.NewMediaStreamForChannel[wave.Audio](c.cancelCtx)
 
 	chunksClient, err := c.client.Chunks(ctx, &pb.ChunksRequest{
 		Name:         c.name,

--- a/components/camera/client.go
+++ b/components/camera/client.go
@@ -152,8 +152,9 @@ func (c *client) Stream(
 				return
 			case <-healthyClientCh:
 				if err := stream.Close(ctxWithMIME); err != nil {
-					panic(err)
+					c.logger.Warn("error closing stream", err)
 				}
+				return
 			case frameCh <- gostream.MediaReleasePairWithError[image.Image]{
 				Media:   frame,
 				Release: release,

--- a/components/camera/client.go
+++ b/components/camera/client.go
@@ -292,6 +292,13 @@ func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map
 	return protoutils.DoFromResourceClient(ctx, c.client, c.name, cmd)
 }
 
+// TODO(RSDK-6433): This method can be called more than once during a client's lifecycle.
+// For example, consider a case where a remote camera goes offline and then back online.
+// We will call `Close` on the camera client when we detect the disconnection to remove
+// active streams but then reuse the client when the connection is re-established. It
+// would be ideal if we exposed another interface method (e.g. `HandleDisconnect`) to
+// perform side-effects related to non-permanent close scenarios like this one, and call
+// `Close` when a client is permanently removed.
 func (c *client) Close(ctx context.Context) error {
 	c.mu.Lock()
 	close(c.stopStreamsCh)

--- a/components/camera/client.go
+++ b/components/camera/client.go
@@ -124,6 +124,8 @@ func (c *client) Stream(
 ) (gostream.VideoStream, error) {
 	ctx, span := trace.StartSpan(ctx, "camera::client::Stream")
 
+	// TODO: consider using https://pkg.go.dev/context#WithoutCancel when we upgrade to
+	// go version 1.21
 	cancelCtxWithMIME := gostream.WithMIMETypeHint(c.cancelCtx, gostream.MIMETypeHint(ctx, ""))
 	streamCtx, stream, frameCh := gostream.NewMediaStreamForChannel[image.Image](cancelCtxWithMIME, c.closeCh)
 

--- a/components/camera/client.go
+++ b/components/camera/client.go
@@ -316,10 +316,7 @@ func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map
 // TODO(RSDK-6433): This method can be called more than once during a client's lifecycle.
 // For example, consider a case where a remote camera goes offline and then back online.
 // We will call `Close` on the camera client when we detect the disconnection to remove
-// active streams but then reuse the client when the connection is re-established. It
-// would be ideal if we exposed another interface method (e.g. `HandleDisconnect`) to
-// perform side-effects related to non-permanent close scenarios like this one, and call
-// `Close` when a client is permanently removed.
+// active streams but then reuse the client when the connection is re-established.
 func (c *client) Close(ctx context.Context) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/components/camera/client.go
+++ b/components/camera/client.go
@@ -31,7 +31,6 @@ import (
 type client struct {
 	resource.Named
 	resource.TriviallyReconfigurable
-	resource.TriviallyCloseable
 	mu                      sync.Mutex
 	name                    string
 	conn                    rpc.ClientConn

--- a/components/camera/client.go
+++ b/components/camera/client.go
@@ -121,8 +121,6 @@ func (c *client) Stream(
 	}
 	c.mu.Unlock()
 
-	// TODO: consider using https://pkg.go.dev/context#WithoutCancel when we upgrade to
-	// go version 1.21
 	ctxWithMIME := gostream.WithMIMETypeHint(context.Background(), gostream.MIMETypeHint(ctx, ""))
 	streamCtx, stream, frameCh := gostream.NewMediaStreamForChannel[image.Image](ctxWithMIME)
 

--- a/components/camera/client.go
+++ b/components/camera/client.go
@@ -116,6 +116,28 @@ func (c *client) Stream(
 ) (gostream.VideoStream, error) {
 	ctx, span := trace.StartSpan(ctx, "camera::client::Stream")
 
+	// RSDK-6340: The resource manager closes remote resources when the underlying
+	// connection goes bad. However, when the connection is re-established, the client
+	// objects these resources represent are not re-initialized/marked "healthy".
+	// `healthyClientCh` helps track these transitions between healthy and unhealthy
+	// states.
+	//
+	// When a new `client.Stream()` is created we will either use the existing
+	// `healthyClientCh` or create a new one.
+	//
+	// The goroutine a `Stream()` method spins off will listen to its version of the
+	// `healthyClientCh` to be notified when the connection has died so it can gracefully
+	// terminate.
+	//
+	// When a connection becomes unhealthy, the resource manager will call `Close` on the
+	// camera client object. Closing the client will:
+	// 1. close its `client.healthyClientCh` channel
+	// 2. wait for existing "stream" goroutines to drain
+	// 3. nil out the `client.healthyClientCh` member variable
+	//
+	// New streams concurrent with closing cannot start until this drain completes. There
+	// will never be stream goroutines from the old "generation" running concurrently
+	// with those from the new "generation".
 	c.mu.Lock()
 	if c.healthyClientCh == nil {
 		c.healthyClientCh = make(chan struct{})

--- a/components/camera/client.go
+++ b/components/camera/client.go
@@ -299,7 +299,9 @@ func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map
 // `Close` when a client is permanently removed.
 func (c *client) Close(ctx context.Context) error {
 	c.mu.Lock()
-	close(c.stopStreamsCh)
+	if c.stopStreamsCh != nil {
+		close(c.stopStreamsCh)
+	}
 	c.mu.Unlock()
 	c.activeBackgroundWorkers.Wait()
 	c.mu.Lock()

--- a/components/camera/client_test.go
+++ b/components/camera/client_test.go
@@ -551,3 +551,75 @@ func TestClientWithInterceptor(t *testing.T) {
 
 	test.That(t, conn.Close(), test.ShouldBeNil)
 }
+
+func TestClientStreamAfterClose(t *testing.T) {
+	// Set up gRPC server
+	logger := logging.NewTestLogger(t)
+	listener, err := net.Listen("tcp", "localhost:0")
+	test.That(t, err, test.ShouldBeNil)
+	rpcServer, err := rpc.NewServer(logger.AsZap(), rpc.WithUnauthenticated())
+	test.That(t, err, test.ShouldBeNil)
+
+	// Set up camera that can stream images
+	img := image.NewNRGBA(image.Rect(0, 0, 4, 4))
+	injectCamera := &inject.Camera{}
+	injectCamera.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
+		return camera.Properties{}, nil
+	}
+	injectCamera.StreamFunc = func(ctx context.Context, errHandlers ...gostream.ErrorHandler) (gostream.VideoStream, error) {
+		return gostream.NewEmbeddedVideoStreamFromReader(gostream.VideoReaderFunc(func(ctx context.Context) (image.Image, func(), error) {
+			return img, func() {}, nil
+		})), nil
+	}
+
+	// Register CameraService API in our gRPC server.
+	resources := map[resource.Name]camera.Camera{
+		camera.Named(testCameraName): injectCamera,
+	}
+	cameraSvc, err := resource.NewAPIResourceCollection(camera.API, resources)
+	test.That(t, err, test.ShouldBeNil)
+	resourceAPI, ok, err := resource.LookupAPIRegistration[camera.Camera](camera.API)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, resourceAPI.RegisterRPCService(context.Background(), rpcServer, cameraSvc), test.ShouldBeNil)
+
+	// Start serving requests.
+	go rpcServer.Serve(listener)
+	defer rpcServer.Stop()
+
+	// Make client connection
+	conn, err := viamgrpc.Dial(context.Background(), listener.Addr().String(), logger)
+	test.That(t, err, test.ShouldBeNil)
+	client, err := camera.NewClientFromConn(context.Background(), conn, "", camera.Named(testCameraName), logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	// Get a stream
+	stream, err := client.Stream(context.Background())
+	test.That(t, stream, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldBeNil)
+
+	// Read from stream
+	media, _, err := stream.Next(context.Background())
+	test.That(t, media, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldBeNil)
+
+	// Close client and read from stream
+	test.That(t, client.Close(context.Background()), test.ShouldBeNil)
+	media, _, err = stream.Next(context.Background())
+	test.That(t, media, test.ShouldBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "context canceled")
+
+	// Get a new stream
+	stream, err = client.Stream(context.Background())
+	test.That(t, stream, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldBeNil)
+
+	// Read from the new stream
+	media, _, err = stream.Next(context.Background())
+	test.That(t, media, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldBeNil)
+
+	// Close client and connection
+	test.That(t, client.Close(context.Background()), test.ShouldBeNil)
+	test.That(t, conn.Close(), test.ShouldBeNil)
+}

--- a/gostream/media.go
+++ b/gostream/media.go
@@ -396,7 +396,11 @@ type MediaReleasePairWithError[T any] struct {
 }
 
 // NewMediaStreamForChannel returns a MediaStream backed by a channel.
-func NewMediaStreamForChannel[T any](ctx context.Context, stopCh <-chan struct{}) (context.Context, MediaStream[T], chan<- MediaReleasePairWithError[T]) {
+func NewMediaStreamForChannel[T any](ctx context.Context, stopCh <-chan struct{}) (
+	context.Context,
+	MediaStream[T],
+	chan<- MediaReleasePairWithError[T],
+) {
 	cancelCtx, cancel := context.WithCancel(ctx)
 	ch := make(chan MediaReleasePairWithError[T])
 	return cancelCtx, &mediaStreamFromChannel[T]{

--- a/gostream/media.go
+++ b/gostream/media.go
@@ -417,6 +417,13 @@ func (ms *mediaStreamFromChannel[T]) Next(ctx context.Context) (T, func(), error
 	defer span.End()
 
 	var zero T
+	if ms.cancelCtx.Err() != nil {
+		return zero, nil, ms.cancelCtx.Err()
+	}
+	if ctx.Err() != nil {
+		return zero, nil, ctx.Err()
+	}
+
 	select {
 	case <-ms.cancelCtx.Done():
 		return zero, nil, ms.cancelCtx.Err()

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -164,7 +164,7 @@ func (t TriviallyReconfigurable) Reconfigure(ctx context.Context, deps Dependenc
 
 // TriviallyCloseable is to be embedded by any resource that does not care about
 // handling Closes. When is used, it is assumed that the resource does not need
-// to return errors when furture non-Close methods are called.
+// to return errors when future non-Close methods are called.
 type TriviallyCloseable struct{}
 
 // Close always returns no error.


### PR DESCRIPTION
Replace the camera client's stream cancellation context with a per-stream stop channel, so that we can continue to close streams after a camera client is closed.

### TODO
* [x] ~Make this change for audio client (or add follow-up ticket)~ See https://github.com/viamrobotics/rdk/pull/3467#discussion_r1464101635
* [x] Add a unit test

### Testing
1. Run two instances of RDK locally, with the following two respective configurations in separate terminals

main.json
```
{"network":{"bind_address":"localhost:8081"},"remotes":[{"name":"robot1","address":"something-unique"}]}
```

remote.json
```
{"network":{"fqdn":"something-unique","bind_address":":8080"},"components":[{"name":"camera1","type":"camera","model":"fake","attributes":{"animated":true}}]}
```

2. Visit: http://localhost:8081 and view the stream for `robot1:camera1` - you should see an animated image:

![image](https://github.com/viamrobotics/rdk/assets/7954103/8b402f90-88cc-472a-80ce-83c95c791717)

3. Stop and restart the server running `remote.json` - go back to step 2 and the image should still be animated.