### PR TITLE
APP-3134 RSDK-6391 include stable armhf in appimage workflow

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -178,7 +178,7 @@ jobs:
 
   appimage_test:
     name: AppImage Test
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
+    if: github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:
@@ -227,6 +227,7 @@ jobs:
   appimage_deploy:
     name: AppImage Deploy
     needs: [appimage_test, appimage-32bit]
+    if: always() && needs.appimage-32bit.result == 'success' && contains(fromJSON('["success", "skipped"]'), needs.appimage_test.result)
     runs-on: ubuntu-latest
     env:
       channel: ${{ github.ref_name == 'main' && 'latest' || github.ref_name }}

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -60,12 +60,12 @@ jobs:
         credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
 
     - name: Build and Package (PR)
-      if: contains(github.event.pull_request.labels.*.name, 'appimage') || contains(github.event.pull_request.labels.*.name, 'appimage-ignore-tests')
+      if: inputs.release_type == 'pr'
       run: |
         sudo -Hu testbot bash -lc 'make BUILD_CHANNEL="pr-${{ github.event.pull_request.number }}" appimage'
 
     - name: Upload Files (PR)
-      if: contains(github.event.pull_request.labels.*.name, 'appimage') || contains(github.event.pull_request.labels.*.name, 'appimage-ignore-tests')
+      if: inputs.release_type == 'pr'
       uses: google-github-actions/upload-cloud-storage@v0.10.4
       with:
         headers: "cache-control: no-cache"
@@ -166,7 +166,7 @@ jobs:
     name: Output Summary
     runs-on: ubuntu-latest
     needs: appimage
-    if: contains(github.event.pull_request.labels.*.name, 'appimage') || contains(github.event.pull_request.labels.*.name, 'appimage-ignore-tests')
+    if: inputs.release_type == 'pr'
     steps:
     - name: Display Download Links
       run: |

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -60,12 +60,12 @@ jobs:
         credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
 
     - name: Build and Package (PR)
-      if: inputs.release_type == 'pr'
+      if: contains(github.event.pull_request.labels.*.name, 'appimage') || contains(github.event.pull_request.labels.*.name, 'appimage-ignore-tests')
       run: |
         sudo -Hu testbot bash -lc 'make BUILD_CHANNEL="pr-${{ github.event.pull_request.number }}" appimage'
 
     - name: Upload Files (PR)
-      if: inputs.release_type == 'pr'
+      if: contains(github.event.pull_request.labels.*.name, 'appimage') || contains(github.event.pull_request.labels.*.name, 'appimage-ignore-tests')
       uses: google-github-actions/upload-cloud-storage@v0.10.4
       with:
         headers: "cache-control: no-cache"
@@ -166,7 +166,7 @@ jobs:
     name: Output Summary
     runs-on: ubuntu-latest
     needs: appimage
-    if: inputs.release_type == 'pr'
+    if: contains(github.event.pull_request.labels.*.name, 'appimage') || contains(github.event.pull_request.labels.*.name, 'appimage-ignore-tests')
     steps:
     - name: Display Download Links
       run: |
@@ -178,7 +178,7 @@ jobs:
 
   appimage_test:
     name: AppImage Test
-    if: github.event_name == 'push'
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:
@@ -227,7 +227,6 @@ jobs:
   appimage_deploy:
     name: AppImage Deploy
     needs: [appimage_test, appimage-32bit]
-    if: always() && needs.appimage-32bit.result == 'success' && contains(fromJSON('["success", "skipped"]'), needs.appimage_test.result)
     runs-on: ubuntu-latest
     env:
       channel: ${{ github.ref_name == 'main' && 'latest' || github.ref_name }}

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -100,6 +100,7 @@ jobs:
         parent: false
         gzip: false
 
+  # this job builds the 32-bit RDK binary
   appimage-static-32bit:
     name: static 32-bit for appimage
     runs-on: buildjet-2vcpu-ubuntu-2204-arm
@@ -130,6 +131,7 @@ jobs:
           bin/*/viam-server
           bin/*/aix
 
+  # this job bundles the 32-bit appimage
   # note: this is a separate job because 1) appimage-builder doesn't work on 32-bit, 2) setup-python doesn't work on arm64
   appimage-32bit:
     runs-on: ubuntu-latest
@@ -149,6 +151,7 @@ jobs:
       run: pip install appimage-builder git+https://github.com/AppImageCrafters/appimage-builder.git@42d32f11496de43a9f6a9ada7882a11296e357ca
     - name: build
       env:
+        RELEASE_TYPE: ${{ inputs.release_type }}
         BUILD_CHANNEL: ${{ github.ref_name == 'main' && 'latest' || github.ref_name }}
         UNAME_M: armv7l
         DPKG_ARCH: armhf
@@ -247,7 +250,7 @@ jobs:
       with:
         headers: "cache-control: no-cache"
         path: etc/packaging/appimages/deploy
-        glob: viam-server-${{ env.channel }}-armhf.AppImage*
+        glob: viam-server-*-armhf.AppImage*
         destination: 'packages.viam.com/apps/viam-server/'
         parent: false
 


### PR DESCRIPTION
## What changed
- include RELEASE_TYPE and broaden wildcard for armhf appimage
## Why
- we were uploading viam-server-vx.y.z-armhf appimages on release, but not viam-server-stable-armhf
## Test run
This one failed because my modified pr run wasn't compatible with the deploy step, but the armhf upload paths are correct:
https://github.com/viamrobotics/rdk/actions/runs/7619333281/job/20752458473#step:5:26