### PR TITLE
prepend platform_name to job name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,8 @@ env:
 
 jobs:
   test_go:
-    name: Go Unit Tests
+    # note: we have automations that match on platform_name. be careful changing this.
+    name: ${{ matrix.platform_name }} Go Unit Tests
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What changed
- in CI test.yml, make `matrix.platform_name` the first token
## Why
- our automations need to correlate the json artifact with other information