### PR TITLE
RSDK-6440 - transient obstacles on nav card are incorrectly displayed

### DIFF
--- a/services/navigation/builtin/builtin.go
+++ b/services/navigation/builtin/builtin.go
@@ -758,6 +758,7 @@ func (svc *builtIn) Obstacles(ctx context.Context, extra map[string]interface{})
 
 			// fix axes of geometry's pose such that it is in the cooordinate system of the base
 			manipulatedGeom = manipulatedGeom.Transform(spatialmath.NewPoseFromOrientation(baseToCamera.Pose().Orientation()))
+			manipulatedGeom = manipulatedGeom.Transform(spatialmath.NewPoseFromOrientation(&spatialmath.OrientationVectorDegrees{OZ: 1, Theta: 90}))
 			svc.logger.CDebugf(
 				ctx,
 				"detection %d pose from movementsensor's position with base frame coordinate axes: %v ",

--- a/services/navigation/builtin/builtin_test.go
+++ b/services/navigation/builtin/builtin_test.go
@@ -1747,7 +1747,7 @@ func TestGetObstacles(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, len(dets), test.ShouldEqual, 2)
 	test.That(t, dets[0], test.ShouldResemble, sphereGob)
-	test.That(t, dets[1].Location(), test.ShouldResemble, geo.NewPoint(0.9999998600983906, 1.0000001399229705))
+	test.That(t, dets[1].Location(), test.ShouldResemble, geo.NewPoint(1.0000001399016092, 1.0000001399229705))
 	test.That(t, len(dets[1].Geometries()), test.ShouldEqual, 1)
 	test.That(t, dets[1].Geometries()[0].AlmostEqual(manipulatedBoxGeom), test.ShouldBeTrue)
 	test.That(t, dets[1].Geometries()[0].Label(), test.ShouldEqual, manipulatedBoxGeom.Label())


### PR DESCRIPTION
for a camera placed such that it points in the same way the base drives forward,
for an intel-realsense this frame in the config would be `OX:1, Theta:-90` with parent of base. On the nav rc card we
have
<img width="892" alt="1" src="https://github.com/viamrobotics/rdk/assets/46872531/c1b8f24c-b196-4aad-abc7-d279b8ec2e4a">

but want
<img width="1084" alt="Screenshot 2024-01-24 at 12 11 07 PM" src="https://github.com/viamrobotics/rdk/assets/46872531/2b7491cc-3987-402b-a8db-ab2a62ebc2db">
