### PR TITLE
RSDK-6449 no_cgo camera interface

### DIFF
--- a/components/camera/camera.go
+++ b/components/camera/camera.go
@@ -1,5 +1,3 @@
-//go:build !no_cgo
-
 // Package camera defines an image capturing device.
 package camera
 

--- a/components/camera/register/register.go
+++ b/components/camera/register/register.go
@@ -3,13 +3,5 @@ package register
 
 import (
 	// for cameras.
-	_ "go.viam.com/rdk/components/camera/align"
 	_ "go.viam.com/rdk/components/camera/fake"
-	_ "go.viam.com/rdk/components/camera/ffmpeg"
-	_ "go.viam.com/rdk/components/camera/replaypcd"
-	_ "go.viam.com/rdk/components/camera/rtsp"
-	_ "go.viam.com/rdk/components/camera/transformpipeline"
-	_ "go.viam.com/rdk/components/camera/ultrasonic"
-	_ "go.viam.com/rdk/components/camera/velodyne"
-	_ "go.viam.com/rdk/components/camera/videosource"
 )

--- a/components/camera/register/register_cgo.go
+++ b/components/camera/register/register_cgo.go
@@ -1,0 +1,16 @@
+//go:build !no_cgo
+
+// Package register registers all relevant cameras and also API specific functions
+package register
+
+import (
+	// for cameras.
+	_ "go.viam.com/rdk/components/camera/align"
+	_ "go.viam.com/rdk/components/camera/ffmpeg"
+	_ "go.viam.com/rdk/components/camera/replaypcd"
+	_ "go.viam.com/rdk/components/camera/rtsp"
+	_ "go.viam.com/rdk/components/camera/transformpipeline"
+	_ "go.viam.com/rdk/components/camera/ultrasonic"
+	_ "go.viam.com/rdk/components/camera/velodyne"
+	_ "go.viam.com/rdk/components/camera/videosource"
+)

--- a/components/register/all.go
+++ b/components/register/all.go
@@ -11,7 +11,6 @@ import (
 	_ "go.viam.com/rdk/components/input/register"
 	_ "go.viam.com/rdk/components/motor/register"
 	_ "go.viam.com/rdk/components/movementsensor/register"
-
 	// register APIs without implementations directly.
 	_ "go.viam.com/rdk/components/posetracker"
 	_ "go.viam.com/rdk/components/powersensor/register"

--- a/components/register/all.go
+++ b/components/register/all.go
@@ -4,12 +4,14 @@ package register
 import (
 	// register components.
 	_ "go.viam.com/rdk/components/board/register"
+	_ "go.viam.com/rdk/components/camera/register"
 	_ "go.viam.com/rdk/components/encoder/register"
 	_ "go.viam.com/rdk/components/gantry/register"
 	_ "go.viam.com/rdk/components/generic/register"
 	_ "go.viam.com/rdk/components/input/register"
 	_ "go.viam.com/rdk/components/motor/register"
 	_ "go.viam.com/rdk/components/movementsensor/register"
+
 	// register APIs without implementations directly.
 	_ "go.viam.com/rdk/components/posetracker"
 	_ "go.viam.com/rdk/components/powersensor/register"

--- a/components/register/all_cgo.go
+++ b/components/register/all_cgo.go
@@ -7,6 +7,5 @@ import (
 	_ "go.viam.com/rdk/components/arm/register"
 	_ "go.viam.com/rdk/components/audioinput/register"
 	_ "go.viam.com/rdk/components/base/register"
-	_ "go.viam.com/rdk/components/camera/register"
 	_ "go.viam.com/rdk/components/gripper/register"
 )

--- a/rimage/depthadapter/depth_map_pc.go
+++ b/rimage/depthadapter/depth_map_pc.go
@@ -1,5 +1,3 @@
-//go:build !no_cgo
-
 // Package depthadapter is a simple package that turns a DepthMap into a point cloud using intrinsic parameters of a camera.
 package depthadapter
 

--- a/rimage/transform/brown_conrady.go
+++ b/rimage/transform/brown_conrady.go
@@ -1,5 +1,3 @@
-//go:build !no_cgo
-
 package transform
 
 import "github.com/pkg/errors"

--- a/rimage/transform/camera_system.go
+++ b/rimage/transform/camera_system.go
@@ -1,5 +1,3 @@
-//go:build !no_cgo
-
 package transform
 
 import (

--- a/rimage/transform/distorter.go
+++ b/rimage/transform/distorter.go
@@ -1,5 +1,3 @@
-//go:build !no_cgo
-
 package transform
 
 import "github.com/pkg/errors"

--- a/rimage/transform/pinhole_camera_parameters.go
+++ b/rimage/transform/pinhole_camera_parameters.go
@@ -1,5 +1,3 @@
-//go:build !no_cgo
-
 package transform
 
 import (


### PR DESCRIPTION
## What changed
- components/camera package was previously flagged off in `no_cgo` builds
- now the interface parts of it are available (but most of the implementation is still missing)
- this PR should have no effect on normal builds (x86 / arm64)
## Why
- support camera modules in boutique environments
## Downsides
This change makes it harder to add C dependencies to the camera interface in the future. For example, some pion imports might break now if they go into the wrong file. We can work around with build tags, but it adds friction
## Do not merge
First test webapp control card