### PR TITLE
RSDK-6475 Allow audio streams to restart after disconnect

### DIFF
--- a/components/audioinput/client.go
+++ b/components/audioinput/client.go
@@ -81,7 +81,7 @@ func (c *client) Stream(
 	// terminate.
 	//
 	// When a connection becomes unhealthy, the resource manager will call `Close` on the
-	// camera client object. Closing the client will:
+	// audioinput client object. Closing the client will:
 	// 1. close its `client.healthyClientCh` channel
 	// 2. wait for existing "stream" goroutines to drain
 	// 3. nil out the `client.healthyClientCh` member variable
@@ -212,6 +212,11 @@ func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map
 	return protoutils.DoFromResourceClient(ctx, c.client, c.name, cmd)
 }
 
+// TODO(RSDK-6433): This method can be called more than once during a client's lifecycle.
+// For example, consider a case where a remote audioinput goes offline and then back
+// online. We will call `Close` on the audioinput client when we detect the disconnection
+// to remove active streams but then reuse the client when the connection is
+// re-established.
 func (c *client) Close(ctx context.Context) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/components/audioinput/client_test.go
+++ b/components/audioinput/client_test.go
@@ -141,7 +141,7 @@ func TestClientStreamAfterClose(t *testing.T) {
 	rpcServer, err := rpc.NewServer(logger.AsZap(), rpc.WithUnauthenticated())
 	test.That(t, err, test.ShouldBeNil)
 
-	// Set up camera that can stream images
+	// Set up audioinput that can stream audio
 
 	audioData := &wave.Float32Interleaved{
 		Data: []float32{

--- a/components/audioinput/client_test.go
+++ b/components/audioinput/client_test.go
@@ -132,3 +132,92 @@ func TestClient(t *testing.T) {
 		test.That(t, conn.Close(), test.ShouldBeNil)
 	})
 }
+
+func TestClientStreamAfterClose(t *testing.T) {
+	// Set up gRPC server
+	logger := logging.NewTestLogger(t)
+	listener, err := net.Listen("tcp", "localhost:0")
+	test.That(t, err, test.ShouldBeNil)
+	rpcServer, err := rpc.NewServer(logger.AsZap(), rpc.WithUnauthenticated())
+	test.That(t, err, test.ShouldBeNil)
+
+	// Set up camera that can stream images
+
+	audioData := &wave.Float32Interleaved{
+		Data: []float32{
+			0.1, -0.5, 0.2, -0.6, 0.3, -0.7, 0.4, -0.8, 0.5, -0.9, 0.6, -1.0, 0.7, -1.1, 0.8, -1.2,
+		},
+		Size: wave.ChunkInfo{8, 2, 48000},
+	}
+
+	injectAudioInput := &inject.AudioInput{}
+
+	// good audio input
+	injectAudioInput.StreamFunc = func(ctx context.Context, errHandlers ...gostream.ErrorHandler) (gostream.AudioStream, error) {
+		return gostream.NewEmbeddedAudioStreamFromReader(gostream.AudioReaderFunc(func(ctx context.Context) (wave.Audio, func(), error) {
+			return audioData, func() {}, nil
+		})), nil
+	}
+
+	expectedProps := prop.Audio{
+		ChannelCount:  1,
+		SampleRate:    2,
+		IsBigEndian:   true,
+		IsInterleaved: true,
+		Latency:       5,
+	}
+	injectAudioInput.MediaPropertiesFunc = func(ctx context.Context) (prop.Audio, error) {
+		return expectedProps, nil
+	}
+
+	// Register AudioInputService API in our gRPC server.
+	resources := map[resource.Name]audioinput.AudioInput{
+		audioinput.Named(testAudioInputName): injectAudioInput,
+	}
+	audioinputSvc, err := resource.NewAPIResourceCollection(audioinput.API, resources)
+	test.That(t, err, test.ShouldBeNil)
+	resourceAPI, ok, err := resource.LookupAPIRegistration[audioinput.AudioInput](audioinput.API)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, resourceAPI.RegisterRPCService(context.Background(), rpcServer, audioinputSvc), test.ShouldBeNil)
+
+	// Start serving requests.
+	go rpcServer.Serve(listener)
+	defer rpcServer.Stop()
+
+	// Make client connection
+	conn, err := viamgrpc.Dial(context.Background(), listener.Addr().String(), logger)
+	test.That(t, err, test.ShouldBeNil)
+	client, err := audioinput.NewClientFromConn(context.Background(), conn, "", audioinput.Named(testAudioInputName), logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	// Get a stream
+	stream, err := client.Stream(context.Background())
+	test.That(t, stream, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldBeNil)
+
+	// Read from stream
+	media, _, err := stream.Next(context.Background())
+	test.That(t, media, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldBeNil)
+
+	// Close client and read from stream
+	test.That(t, client.Close(context.Background()), test.ShouldBeNil)
+	media, _, err = stream.Next(context.Background())
+	test.That(t, media, test.ShouldBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "context canceled")
+
+	// Get a new stream
+	stream, err = client.Stream(context.Background())
+	test.That(t, stream, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldBeNil)
+
+	// Read from the new stream
+	media, _, err = stream.Next(context.Background())
+	test.That(t, media, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldBeNil)
+
+	// Close client and connection
+	test.That(t, client.Close(context.Background()), test.ShouldBeNil)
+	test.That(t, conn.Close(), test.ShouldBeNil)
+}


### PR DESCRIPTION
Resolve [this issue](https://github.com/viamrobotics/rdk/pull/3467) for audio streams

### Testing
1. Run two instances of RDK locally, with the following two respective configurations in separate terminals

main.json
```json
{"network":{"bind_address":"localhost:8081"},"remotes":[{"name":"robot1","address":"something-unique"}]}
```

remote.json
```json
{"network":{"fqdn":"something-unique","bind_address":":8080"},"components":[{"name":"audio_input1","type":"audio_input","model":"fake"}]}
```

2. Visit: http://localhost:8081 and open the stream for `robot1:audio_input1` - you should hear a droning tune.

3. Stop server running `remote.json` - the tune from step 2 will cut out.

4. Restart the server running `remote.json` - perform step 2 again and you should be able to hear the tune again (you may have to re-open the stream a few times)