### PR TITLE
RSDK-6401 - Add discovery query capabilities to the modmanager to discover local modular resource registrations

### DIFF
--- a/robot/impl/discovery_test.go
+++ b/robot/impl/discovery_test.go
@@ -39,8 +39,8 @@ var (
 	noDiscoverModel = resource.DefaultModelFamily.WithModel("nodiscoverModel")
 	noDiscoverQ     = resource.DiscoveryQuery{failAPI, noDiscoverModel}
 
-	modManagerAPI   = resource.APINamespace("rdk").WithType("builtin").WithSubtype("module-manager")
-	modManagerModel = resource.ModelNamespaceRDK.WithFamily("builtin").WithModel("module-manager")
+	modManagerAPI   = resource.NewAPI("rdk-internal", "service", "module-manager")
+	modManagerModel = resource.NewModel("rdk-internal", "builtin", "module-manager")
 	modManagerQ     = resource.NewDiscoveryQuery(modManagerAPI, modManagerModel)
 
 	missingQ = resource.NewDiscoveryQuery(failAPI, resource.DefaultModelFamily.WithModel("missing"))

--- a/robot/impl/discovery_test.go
+++ b/robot/impl/discovery_test.go
@@ -196,7 +196,7 @@ func TestDiscovery(t *testing.T) {
 		//nolint:govet // we copy an internal lock -- it is okay
 		complexHandles, ok := resourceHandles["complex"]
 		test.That(t, ok, test.ShouldBeTrue)
-		// this module is changed semi-frequently so I opted for a simpler test
+		// this module is changed semi-frequently so a simpler test is better here
 		test.That(t, len(complexHandles.Handlers), test.ShouldBeGreaterThan, 1)
 	})
 }

--- a/robot/impl/discovery_test.go
+++ b/robot/impl/discovery_test.go
@@ -196,7 +196,7 @@ func TestDiscovery(t *testing.T) {
 		//nolint:govet // we copy an internal lock -- it is okay
 		complexHandles, ok := resourceHandles["complex"]
 		test.That(t, ok, test.ShouldBeTrue)
-		// this module is changed semi-frequently so a simpler test is better here
+		// confirm that complex handlers are also present in the map
 		test.That(t, len(complexHandles.Handlers), test.ShouldBeGreaterThan, 1)
 	})
 }

--- a/robot/impl/discovery_test.go
+++ b/robot/impl/discovery_test.go
@@ -1,4 +1,4 @@
-package robotimpl_test
+package robotimpl
 
 import (
 	"context"
@@ -12,7 +12,6 @@ import (
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot"
-	robotimpl "go.viam.com/rdk/robot/impl"
 	rtestutils "go.viam.com/rdk/testutils"
 )
 
@@ -23,7 +22,7 @@ func setupNewLocalRobot(t *testing.T) robot.LocalRobot {
 	cfg, err := config.Read(context.Background(), "data/fake.json", logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	r, err := robotimpl.New(context.Background(), cfg, logger)
+	r, err := New(context.Background(), cfg, logger)
 	test.That(t, err, test.ShouldBeNil)
 	return r
 }
@@ -151,8 +150,8 @@ func TestDiscovery(t *testing.T) {
 		discoveries, err := r.DiscoverComponents(context.Background(), []resource.DiscoveryQuery{modManagerQ})
 		test.That(t, err, test.ShouldBeNil)
 		expectedHandlerMap := map[string]modulepb.HandlerMap{}
-		expectedDiscovery := map[string]interface{}{
-			"resource_handles": expectedHandlerMap,
+		expectedDiscovery := moduleManagerDiscoveryResult{
+			ResourceHandles: expectedHandlerMap,
 		}
 		test.That(t, discoveries, test.ShouldResemble, []resource.Discovery{{Query: modManagerQ, Results: expectedDiscovery}})
 
@@ -179,10 +178,9 @@ func TestDiscovery(t *testing.T) {
 		discoveries, err = r.DiscoverComponents(context.Background(), []resource.DiscoveryQuery{modManagerQ})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, discoveries, test.ShouldHaveLength, 1)
-		modManagerDiscovery, ok := discoveries[0].Results.(map[string]interface{})
+		modManagerDiscovery, ok := discoveries[0].Results.(moduleManagerDiscoveryResult)
 		test.That(t, ok, test.ShouldBeTrue)
-		resourceHandles := modManagerDiscovery["resource_handles"].(map[string]modulepb.HandlerMap)
-		test.That(t, ok, test.ShouldBeTrue)
+		resourceHandles := modManagerDiscovery.ResourceHandles
 		test.That(t, resourceHandles, test.ShouldHaveLength, 2)
 		//nolint:govet // we copy an internal lock -- it is okay
 		simpleHandles, ok := resourceHandles["simple"]

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -987,6 +987,11 @@ func (r *localRobot) DiscoverComponents(ctx context.Context, qs []resource.Disco
 	return discoveries, nil
 }
 
+// moduleManagerDiscoveryResult is returned from a DiscoveryQuery to rdk:builtin:module-manager.
+type moduleManagerDiscoveryResult struct {
+	ResourceHandles map[string]modulepb.HandlerMap `json:"resource_handles"`
+}
+
 // discoverRobotInternals is used to discover parts of the robot that are not in the resource graph
 // It accepts a query and should return the Discovery Results object along with an ok value.
 func (r *localRobot) discoverRobotInternals(query resource.DiscoveryQuery) (interface{}, bool) {
@@ -997,8 +1002,8 @@ func (r *localRobot) discoverRobotInternals(query resource.DiscoveryQuery) (inte
 		for moduleName, handleMap := range r.manager.moduleManager.Handles() {
 			handles[moduleName] = *handleMap.ToProto()
 		}
-		return map[string]interface{}{
-			"resource_handles": handles,
+		return moduleManagerDiscoveryResult{
+			ResourceHandles: handles,
 		}, true
 	default:
 		return nil, false

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -987,7 +987,7 @@ func (r *localRobot) DiscoverComponents(ctx context.Context, qs []resource.Disco
 	return discoveries, nil
 }
 
-// moduleManagerDiscoveryResult is returned from a DiscoveryQuery to rdk:builtin:module-manager.
+// moduleManagerDiscoveryResult is returned from a DiscoveryQuery to rdk-internal:builtin:module-manager.
 type moduleManagerDiscoveryResult struct {
 	ResourceHandles map[string]modulepb.HandlerMap `json:"resource_handles"`
 }
@@ -997,7 +997,9 @@ type moduleManagerDiscoveryResult struct {
 func (r *localRobot) discoverRobotInternals(query resource.DiscoveryQuery) (interface{}, bool) {
 	switch {
 	// these strings are hardcoded because their existence would be misleading anywhere outside of this function
-	case query.API.String() == "rdk:builtin:module-manager" && query.Model.String() == "rdk:builtin:module-manager":
+	case query.API.String() == "rdk-internal:service:module-manager" &&
+		query.Model.String() == "rdk-internal:builtin:module-manager":
+
 		handles := map[string]modulepb.HandlerMap{}
 		for moduleName, handleMap := range r.manager.moduleManager.Handles() {
 			handles[moduleName] = *handleMap.ToProto()


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-6401

Talked with @maximpertsov in person on Friday who confirmed that while it is strange to query the modmanager as if it was a resource, this is the right / intended usage of the discovery API.

This PR will enable the APP FE to correctly populate the api&model dropdowns for adding a local-module-provided component / service (instead of forcing the user edit the raw JSON)

Also considered adding API routes for this: https://github.com/viamrobotics/api/pull/437 However, it seems like people would rather use the same API routes that already exists.
