### PR TITLE
[RSDK-6491] Remove the DisableNMEA option from NMEA GPS

### DIFF
--- a/components/movementsensor/gpsnmea/gpsnmea.go
+++ b/components/movementsensor/gpsnmea/gpsnmea.go
@@ -33,7 +33,6 @@ func connectionTypeError(connType, serialConn, i2cConn string) error {
 // Config is used for converting NMEA Movement Sensor attibutes.
 type Config struct {
 	ConnectionType string `json:"connection_type"`
-	DisableNMEA    bool   `json:"disable_nmea,omitempty"`
 
 	*SerialConfig `json:"serial_attributes,omitempty"`
 	*I2CConfig    `json:"i2c_attributes,omitempty"`

--- a/components/movementsensor/gpsnmea/pmtkI2C.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C.go
@@ -32,7 +32,6 @@ type PmtkI2CNMEAMovementSensor struct {
 	data                    GPSData
 	activeBackgroundWorkers sync.WaitGroup
 
-	disableNmea        bool
 	err                movementsensor.LastError
 	lastPosition       movementsensor.LastPosition
 	lastCompassHeading movementsensor.LastCompassHeading
@@ -82,22 +81,17 @@ func MakePmtkI2cGpsNmea(
 		conf.I2CConfig.I2CBaudRate = 38400
 		logger.CWarn(ctx, "using default baudrate : 38400")
 	}
-	disableNmea := conf.DisableNMEA
-	if disableNmea {
-		logger.CInfo(ctx, "SerialNMEAMovementSensor: NMEA reading disabled")
-	}
 
 	cancelCtx, cancelFunc := context.WithCancel(context.Background())
 
 	g := &PmtkI2CNMEAMovementSensor{
-		Named:       name.AsNamed(),
-		bus:         i2cBus,
-		addr:        byte(addr),
-		wbaud:       conf.I2CConfig.I2CBaudRate,
-		cancelCtx:   cancelCtx,
-		cancelFunc:  cancelFunc,
-		logger:      logger,
-		disableNmea: disableNmea,
+		Named:      name.AsNamed(),
+		bus:        i2cBus,
+		addr:       byte(addr),
+		wbaud:      conf.I2CConfig.I2CBaudRate,
+		cancelCtx:  cancelCtx,
+		cancelFunc: cancelFunc,
+		logger:     logger,
 		// Overloaded boards can have flaky I2C busses. Only report errors if at least 5 of the
 		// last 10 attempts have failed.
 		err:                movementsensor.NewLastError(10, 5),
@@ -155,47 +149,45 @@ func (g *PmtkI2CNMEAMovementSensor) Start(ctx context.Context) error {
 			default:
 			}
 
-			if !g.disableNmea {
-				// Opening an i2c handle blocks the whole bus, so we open/close each loop so other things also have a chance to use it
-				handle, err := g.bus.OpenHandle(g.addr)
-				// Record the error value no matter what. If it's nil, this will help suppress
-				// ephemeral errors later.
-				g.err.Set(err)
-				if err != nil {
-					g.logger.CErrorf(ctx, "can't open gps i2c handle: %s", err)
-					return
-				}
-				buffer, err := handle.Read(ctx, 1024)
-				g.err.Set(err)
-				hErr := handle.Close()
-				g.err.Set(hErr)
-				if hErr != nil {
-					g.logger.CErrorf(ctx, "failed to close handle: %s", hErr)
-					return
-				}
-				if err != nil {
-					g.logger.CError(ctx, err)
-					continue
-				}
-				for _, b := range buffer {
-					// PMTK uses CRLF line endings to terminate sentences, but just LF to blank data.
-					// Since CR should never appear except at the end of our sentence, we use that to determine sentence end.
-					// LF is merely ignored.
-					if b == 0x0D {
-						if strBuf != "" {
-							g.mu.Lock()
-							err = g.data.ParseAndUpdate(strBuf)
-							g.mu.Unlock()
-							if err != nil {
-								g.logger.CDebugf(ctx, "can't parse nmea sentence: %s, %v", strBuf, err)
-								g.logger.Debug("Check: GPS requires clear sky view." +
-									" Ensure the antenna is outdoors if signal is weak or unavailable indoors.")
-							}
+			// Opening an i2c handle blocks the whole bus, so we open/close each loop so other things also have a chance to use it
+			handle, err := g.bus.OpenHandle(g.addr)
+			// Record the error value no matter what. If it's nil, this will help suppress
+			// ephemeral errors later.
+			g.err.Set(err)
+			if err != nil {
+				g.logger.CErrorf(ctx, "can't open gps i2c handle: %s", err)
+				return
+			}
+			buffer, err := handle.Read(ctx, 1024)
+			g.err.Set(err)
+			hErr := handle.Close()
+			g.err.Set(hErr)
+			if hErr != nil {
+				g.logger.CErrorf(ctx, "failed to close handle: %s", hErr)
+				return
+			}
+			if err != nil {
+				g.logger.CError(ctx, err)
+				continue
+			}
+			for _, b := range buffer {
+				// PMTK uses CRLF line endings to terminate sentences, but just LF to blank data.
+				// Since CR should never appear except at the end of our sentence, we use that to determine sentence end.
+				// LF is merely ignored.
+				if b == 0x0D {
+					if strBuf != "" {
+						g.mu.Lock()
+						err = g.data.ParseAndUpdate(strBuf)
+						g.mu.Unlock()
+						if err != nil {
+							g.logger.CDebugf(ctx, "can't parse nmea sentence: %s, %v", strBuf, err)
+							g.logger.Debug("Check: GPS requires clear sky view." +
+								" Ensure the antenna is outdoors if signal is weak or unavailable indoors.")
 						}
-						strBuf = ""
-					} else if b != 0x0A && b != 0xFF { // adds only valid bytes
-						strBuf += string(b)
 					}
+					strBuf = ""
+				} else if b != 0x0A && b != 0xFF { // adds only valid bytes
+					strBuf += string(b)
 				}
 			}
 		}

--- a/components/movementsensor/gpsnmea/pmtkI2C_test.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C_test.go
@@ -76,7 +76,6 @@ func TestNewI2CMovementSensor(t *testing.T) {
 		API:   movementsensor.API,
 		ConvertedAttributes: &Config{
 			ConnectionType: "I2C",
-			DisableNMEA:    false,
 			I2CConfig:      &I2CConfig{I2CBus: testBusName},
 		},
 	}

--- a/components/movementsensor/gpsnmea/serial.go
+++ b/components/movementsensor/gpsnmea/serial.go
@@ -43,7 +43,6 @@ type SerialNMEAMovementSensor struct {
 
 	dev                io.ReadWriteCloser
 	path               string
-	baudRate           uint
 	correctionBaudRate uint
 	correctionPath     string
 }
@@ -87,7 +86,6 @@ func NewSerialGPSNMEA(ctx context.Context, name resource.Name, conf *Config, log
 		cancelFunc:         cancelFunc,
 		logger:             logger,
 		path:               serialPath,
-		baudRate:           uint(baudRate),
 		disableNmea:        disableNmea,
 		err:                movementsensor.NewLastError(1, 1),
 		lastPosition:       movementsensor.NewLastPosition(),

--- a/components/movementsensor/gpsnmea/serial.go
+++ b/components/movementsensor/gpsnmea/serial.go
@@ -35,7 +35,6 @@ type SerialNMEAMovementSensor struct {
 	data                    GPSData
 	activeBackgroundWorkers sync.WaitGroup
 
-	disableNmea        bool
 	err                movementsensor.LastError
 	lastPosition       movementsensor.LastPosition
 	lastCompassHeading movementsensor.LastCompassHeading
@@ -60,10 +59,6 @@ func NewSerialGPSNMEA(ctx context.Context, name resource.Name, conf *Config, log
 		logger.CInfo(ctx, "SerialNMEAMovementSensor: serial_baud_rate using default 38400")
 	}
 
-	disableNmea := conf.DisableNMEA
-	if disableNmea {
-		logger.CInfo(ctx, "SerialNMEAMovementSensor: NMEA reading disabled")
-	}
 	options := serial.OpenOptions{
 		PortName:        serialPath,
 		BaudRate:        uint(baudRate),
@@ -86,7 +81,6 @@ func NewSerialGPSNMEA(ctx context.Context, name resource.Name, conf *Config, log
 		cancelFunc:         cancelFunc,
 		logger:             logger,
 		path:               serialPath,
-		disableNmea:        disableNmea,
 		err:                movementsensor.NewLastError(1, 1),
 		lastPosition:       movementsensor.NewLastPosition(),
 		lastCompassHeading: movementsensor.NewLastCompassHeading(),
@@ -112,7 +106,7 @@ func (g *SerialNMEAMovementSensor) Start(ctx context.Context) error {
 			default:
 			}
 
-			if !g.disableNmea && !g.isClosed {
+			if !g.isClosed {
 				line, err := r.ReadString('\n')
 				if err != nil {
 					g.logger.CErrorf(ctx, "can't read gps serial %s", err)

--- a/components/movementsensor/gpsnmea/serial_test.go
+++ b/components/movementsensor/gpsnmea/serial_test.go
@@ -64,7 +64,6 @@ func TestNewSerialMovementSensor(t *testing.T) {
 		API:   movementsensor.API,
 		ConvertedAttributes: &Config{
 			ConnectionType: "serial",
-			DisableNMEA:    false,
 			SerialConfig: &SerialConfig{
 				SerialPath:     path,
 				SerialBaudRate: 0,


### PR DESCRIPTION
...and also, don't bother storing the baud rate for later because we never use it later.

This is a breaking change! 

I recommend reviewing while ignoring whitespace changes: I unindented a pretty large block of code, and the linter got another one.