### PR TITLE
[RSDK-5462] miscellaneous cleanup: static functions should not be methods

### DIFF
--- a/components/movementsensor/gpsnmea/pmtkI2C.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C.go
@@ -227,7 +227,7 @@ func (g *PmtkI2CNMEAMovementSensor) Position(ctx context.Context, extra map[stri
 	}
 
 	// updating the last known valid position if the current position is non-zero
-	if !g.lastPosition.IsZeroPosition(currentPosition) && !g.lastPosition.IsPositionNaN(currentPosition) {
+	if !g.lastPosition.IsZeroPosition(currentPosition) && !movementsensor.IsPositionNaN(currentPosition) {
 		g.lastPosition.SetLastPosition(currentPosition)
 	}
 

--- a/components/movementsensor/gpsnmea/pmtkI2C.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C.go
@@ -222,7 +222,7 @@ func (g *PmtkI2CNMEAMovementSensor) Position(ctx context.Context, extra map[stri
 	}
 
 	// updating lastPosition if it is different from the current position
-	if !g.lastPosition.ArePointsEqual(currentPosition, lastPosition) {
+	if !movementsensor.ArePointsEqual(currentPosition, lastPosition) {
 		g.lastPosition.SetLastPosition(currentPosition)
 	}
 

--- a/components/movementsensor/gpsnmea/pmtkI2C.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C.go
@@ -217,7 +217,7 @@ func (g *PmtkI2CNMEAMovementSensor) Position(ctx context.Context, extra map[stri
 	}
 
 	// if current position is (0,0) we will return the last non zero position
-	if g.lastPosition.IsZeroPosition(currentPosition) && !g.lastPosition.IsZeroPosition(lastPosition) {
+	if movementsensor.IsZeroPosition(currentPosition) && !movementsensor.IsZeroPosition(lastPosition) {
 		return lastPosition, g.data.Alt, g.err.Get()
 	}
 
@@ -227,7 +227,7 @@ func (g *PmtkI2CNMEAMovementSensor) Position(ctx context.Context, extra map[stri
 	}
 
 	// updating the last known valid position if the current position is non-zero
-	if !g.lastPosition.IsZeroPosition(currentPosition) && !movementsensor.IsPositionNaN(currentPosition) {
+	if !movementsensor.IsZeroPosition(currentPosition) && !movementsensor.IsPositionNaN(currentPosition) {
 		g.lastPosition.SetLastPosition(currentPosition)
 	}
 

--- a/components/movementsensor/gpsnmea/pmtkI2C.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C.go
@@ -202,8 +202,6 @@ func (g *PmtkI2CNMEAMovementSensor) GetBusAddr() (buses.I2C, byte) {
 }
 
 // Position returns the current geographic location of the MovementSensor.
-//
-//nolint:all
 func (g *PmtkI2CNMEAMovementSensor) Position(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
 	lastPosition := g.lastPosition.GetLastPosition()
 

--- a/components/movementsensor/gpsnmea/serial.go
+++ b/components/movementsensor/gpsnmea/serial.go
@@ -154,7 +154,7 @@ func (g *SerialNMEAMovementSensor) Position(ctx context.Context, extra map[strin
 	}
 
 	// updating lastPosition if it is different from the current position
-	if !g.lastPosition.ArePointsEqual(currentPosition, lastPosition) {
+	if !movementsensor.ArePointsEqual(currentPosition, lastPosition) {
 		g.lastPosition.SetLastPosition(currentPosition)
 	}
 

--- a/components/movementsensor/gpsnmea/serial.go
+++ b/components/movementsensor/gpsnmea/serial.go
@@ -159,7 +159,7 @@ func (g *SerialNMEAMovementSensor) Position(ctx context.Context, extra map[strin
 	}
 
 	// updating the last known valid position if the current position is non-zero
-	if !g.lastPosition.IsZeroPosition(currentPosition) && !g.lastPosition.IsPositionNaN(currentPosition) {
+	if !g.lastPosition.IsZeroPosition(currentPosition) && !movementsensor.IsPositionNaN(currentPosition) {
 		g.lastPosition.SetLastPosition(currentPosition)
 	}
 

--- a/components/movementsensor/gpsnmea/serial.go
+++ b/components/movementsensor/gpsnmea/serial.go
@@ -149,7 +149,7 @@ func (g *SerialNMEAMovementSensor) Position(ctx context.Context, extra map[strin
 	}
 
 	// if current position is (0,0) we will return the last non zero position
-	if g.lastPosition.IsZeroPosition(currentPosition) && !g.lastPosition.IsZeroPosition(lastPosition) {
+	if movementsensor.IsZeroPosition(currentPosition) && !movementsensor.IsZeroPosition(lastPosition) {
 		return lastPosition, g.data.Alt, g.err.Get()
 	}
 
@@ -159,7 +159,7 @@ func (g *SerialNMEAMovementSensor) Position(ctx context.Context, extra map[strin
 	}
 
 	// updating the last known valid position if the current position is non-zero
-	if !g.lastPosition.IsZeroPosition(currentPosition) && !movementsensor.IsPositionNaN(currentPosition) {
+	if !movementsensor.IsZeroPosition(currentPosition) && !movementsensor.IsPositionNaN(currentPosition) {
 		g.lastPosition.SetLastPosition(currentPosition)
 	}
 

--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
@@ -528,7 +528,7 @@ func (g *rtkI2C) Position(ctx context.Context, extra map[string]interface{}) (*g
 	position, alt, err := g.nmeamovementsensor.Position(ctx, extra)
 	if err != nil {
 		// Use the last known valid position if current position is (0,0)/ NaN.
-		if position != nil && (g.lastposition.IsZeroPosition(position) || g.lastposition.IsPositionNaN(position)) {
+		if position != nil && (g.lastposition.IsZeroPosition(position) || movementsensor.IsPositionNaN(position)) {
 			lastPosition := g.lastposition.GetLastPosition()
 			if lastPosition != nil {
 				return lastPosition, alt, nil
@@ -537,7 +537,7 @@ func (g *rtkI2C) Position(ctx context.Context, extra map[string]interface{}) (*g
 		return geo.NewPoint(math.NaN(), math.NaN()), math.NaN(), err
 	}
 
-	if g.lastposition.IsPositionNaN(position) {
+	if movementsensor.IsPositionNaN(position) {
 		position = g.lastposition.GetLastPosition()
 	}
 

--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
@@ -528,7 +528,7 @@ func (g *rtkI2C) Position(ctx context.Context, extra map[string]interface{}) (*g
 	position, alt, err := g.nmeamovementsensor.Position(ctx, extra)
 	if err != nil {
 		// Use the last known valid position if current position is (0,0)/ NaN.
-		if position != nil && (g.lastposition.IsZeroPosition(position) || movementsensor.IsPositionNaN(position)) {
+		if position != nil && (movementsensor.IsZeroPosition(position) || movementsensor.IsPositionNaN(position)) {
 			lastPosition := g.lastposition.GetLastPosition()
 			if lastPosition != nil {
 				return lastPosition, alt, nil

--- a/components/movementsensor/gpsrtkserial/gpsrtkserial.go
+++ b/components/movementsensor/gpsrtkserial/gpsrtkserial.go
@@ -573,7 +573,7 @@ func (g *rtkSerial) Position(ctx context.Context, extra map[string]interface{}) 
 	position, alt, err := g.nmeamovementsensor.Position(ctx, extra)
 	if err != nil {
 		// Use the last known valid position if current position is (0,0)/ NaN.
-		if position != nil && (g.lastposition.IsZeroPosition(position) || g.lastposition.IsPositionNaN(position)) {
+		if position != nil && (g.lastposition.IsZeroPosition(position) || movementsensor.IsPositionNaN(position)) {
 			lastPosition := g.lastposition.GetLastPosition()
 			if lastPosition != nil {
 				return lastPosition, alt, nil
@@ -582,7 +582,7 @@ func (g *rtkSerial) Position(ctx context.Context, extra map[string]interface{}) 
 		return geo.NewPoint(math.NaN(), math.NaN()), math.NaN(), err
 	}
 
-	if g.lastposition.IsPositionNaN(position) {
+	if movementsensor.IsPositionNaN(position) {
 		position = g.lastposition.GetLastPosition()
 	}
 	return position, alt, nil

--- a/components/movementsensor/gpsrtkserial/gpsrtkserial.go
+++ b/components/movementsensor/gpsrtkserial/gpsrtkserial.go
@@ -573,7 +573,7 @@ func (g *rtkSerial) Position(ctx context.Context, extra map[string]interface{}) 
 	position, alt, err := g.nmeamovementsensor.Position(ctx, extra)
 	if err != nil {
 		// Use the last known valid position if current position is (0,0)/ NaN.
-		if position != nil && (g.lastposition.IsZeroPosition(position) || movementsensor.IsPositionNaN(position)) {
+		if position != nil && (movementsensor.IsZeroPosition(position) || movementsensor.IsPositionNaN(position)) {
 			lastPosition := g.lastposition.GetLastPosition()
 			if lastPosition != nil {
 				return lastPosition, alt, nil

--- a/components/movementsensor/utils.go
+++ b/components/movementsensor/utils.go
@@ -133,7 +133,7 @@ func (lp *LastPosition) IsZeroPosition(p *geo.Point) bool {
 }
 
 // IsPositionNaN checks if a geo.Point in math.NaN().
-func (lp *LastPosition) IsPositionNaN(p *geo.Point) bool {
+func IsPositionNaN(p *geo.Point) bool {
 	return math.IsNaN(p.Lng()) && math.IsNaN(p.Lat())
 }
 

--- a/components/movementsensor/utils.go
+++ b/components/movementsensor/utils.go
@@ -120,7 +120,7 @@ func (lp *LastPosition) SetLastPosition(position *geo.Point) {
 }
 
 // ArePointsEqual checks if two geo.Point instances are equal.
-func (lp *LastPosition) ArePointsEqual(p1, p2 *geo.Point) bool {
+func ArePointsEqual(p1, p2 *geo.Point) bool {
 	if p1 == nil || p2 == nil {
 		return p1 == p2
 	}

--- a/components/movementsensor/utils.go
+++ b/components/movementsensor/utils.go
@@ -128,7 +128,7 @@ func (lp *LastPosition) ArePointsEqual(p1, p2 *geo.Point) bool {
 }
 
 // IsZeroPosition checks if a geo.Point represents the zero position (0, 0).
-func (lp *LastPosition) IsZeroPosition(p *geo.Point) bool {
+func IsZeroPosition(p *geo.Point) bool {
 	return p.Lng() == 0 && p.Lat() == 0
 }
 

--- a/components/movementsensor/utils_test.go
+++ b/components/movementsensor/utils_test.go
@@ -88,8 +88,8 @@ func TestPositionLogic(t *testing.T) {
 	test.That(t, lp.ArePointsEqual(testPos2, testPos2), test.ShouldBeTrue)
 	test.That(t, lp.ArePointsEqual(testPos2, testPos1), test.ShouldBeFalse)
 
-	test.That(t, lp.IsZeroPosition(zeroPos), test.ShouldBeTrue)
-	test.That(t, lp.IsZeroPosition(testPos2), test.ShouldBeFalse)
+	test.That(t, IsZeroPosition(zeroPos), test.ShouldBeTrue)
+	test.That(t, IsZeroPosition(testPos2), test.ShouldBeFalse)
 
 	test.That(t, IsPositionNaN(nanPos), test.ShouldBeTrue)
 	test.That(t, IsPositionNaN(testPos1), test.ShouldBeFalse)

--- a/components/movementsensor/utils_test.go
+++ b/components/movementsensor/utils_test.go
@@ -91,8 +91,8 @@ func TestPositionLogic(t *testing.T) {
 	test.That(t, lp.IsZeroPosition(zeroPos), test.ShouldBeTrue)
 	test.That(t, lp.IsZeroPosition(testPos2), test.ShouldBeFalse)
 
-	test.That(t, lp.IsPositionNaN(nanPos), test.ShouldBeTrue)
-	test.That(t, lp.IsPositionNaN(testPos1), test.ShouldBeFalse)
+	test.That(t, IsPositionNaN(nanPos), test.ShouldBeTrue)
+	test.That(t, IsPositionNaN(testPos1), test.ShouldBeFalse)
 }
 
 func TestPMTKFunctions(t *testing.T) {

--- a/components/movementsensor/utils_test.go
+++ b/components/movementsensor/utils_test.go
@@ -85,8 +85,8 @@ func TestLastPosition(t *testing.T) {
 func TestPositionLogic(t *testing.T) {
 	lp := NewLastPosition()
 
-	test.That(t, lp.ArePointsEqual(testPos2, testPos2), test.ShouldBeTrue)
-	test.That(t, lp.ArePointsEqual(testPos2, testPos1), test.ShouldBeFalse)
+	test.That(t, ArePointsEqual(testPos2, testPos2), test.ShouldBeTrue)
+	test.That(t, ArePointsEqual(testPos2, testPos1), test.ShouldBeFalse)
 
 	test.That(t, IsZeroPosition(zeroPos), test.ShouldBeTrue)
 	test.That(t, IsZeroPosition(testPos2), test.ShouldBeFalse)

--- a/components/movementsensor/utils_test.go
+++ b/components/movementsensor/utils_test.go
@@ -83,8 +83,6 @@ func TestLastPosition(t *testing.T) {
 }
 
 func TestPositionLogic(t *testing.T) {
-	lp := NewLastPosition()
-
 	test.That(t, ArePointsEqual(testPos2, testPos2), test.ShouldBeTrue)
 	test.That(t, ArePointsEqual(testPos2, testPos1), test.ShouldBeFalse)
 


### PR DESCRIPTION
I got surprised that functions like `IsZeroPosition` seemed to take two arguments, because I couldn't figure out what the second one would do. On closer inspection, although these things methods on a struct, they never use anything within the struct itself! To avoid this confusion, I've made them functions instead (so they don't operate on a struct to begin with).

As a low-priority stretch goal, I'd prefer to rename `GetLastPosition` and `SetLastPosition` to the more standard `Get` and `Set` so there's less duplication when typing `g.lastPosition.GetLastPosition()`, but that might not be worth the hassle right now. 