### PR TITLE
RSDK-6512: Add buildjet-pinned-location_de_arm to actionlint allow-list.

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -11,3 +11,4 @@ self-hosted-runner:
     - buildjet-8vcpu-ubuntu-2204-arm
     - buildjet-16vcpu-ubuntu-2204-arm
     - buildjet-32vcpu-ubuntu-2204-arm
+    - buildjet-pinned-location_de_arm


### PR DESCRIPTION
Apparently there's a `make lint` command (which runs actionlint) that I don't think gets exercised in CI. Or on most peoples machines for that matter.

https://viaminc.slack.com/archives/C03LCAHM2TT/p1706647821008169