### PR TITLE
RSDK-6430 - Change RC card to use new MoveOnMap signature

### DIFF
--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/remote-control",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@improbable-eng/grpc-web": "0.15.0",

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/web/frontend/src/api/motion.ts
+++ b/web/frontend/src/api/motion.ts
@@ -10,7 +10,7 @@ export const moveOnMap = async (
   x: number,
   y: number
 ): Promise<string | undefined> => {
-  const request = new motionApi.MoveOnMapNewRequest();
+  const request = new motionApi.MoveOnMapRequest();
   /*
    * here we set the name of the motion service the user is using
    */
@@ -57,9 +57,9 @@ export const moveOnMap = async (
     })
   );
 
-  const response = await new Promise<motionApi.MoveOnMapNewResponse | null>(
+  const response = await new Promise<motionApi.MoveOnMapResponse | null>(
     (resolve, reject) => {
-      robotClient.motionService.moveOnMapNew(request, (error, res) => {
+      robotClient.motionService.moveOnMap(request, (error, res) => {
         if (error) {
           reject(error);
         } else {


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-6430)

- Change the RC card to use motion.MoveOnMap rather than the deprecated (and soon to be deleted) motion.MoveOnMapNew
- Cut a new RC Card version `2.10.1`