### PR TITLE
RSDK-6542 - Fix SLAM RC Card incompatible with non builtin bases

### DIFF
--- a/web/frontend/src/api/motion.ts
+++ b/web/frontend/src/api/motion.ts
@@ -1,12 +1,12 @@
 import { type Client, commonApi, motionApi } from '@viamrobotics/sdk';
 import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
 import { getPosition } from './slam';
-import type { ResourceName } from '@viamrobotics/sdk/dist/gen/common/v1/common_pb';
+type ResourceName = commonApi.ResourceName.AsObject;
 
 export const moveOnMap = async (
   robotClient: Client,
-  name: string,
-  componentName: string,
+  slamServiceName: ResourceName,
+  componentName: ResourceName,
   x: number,
   y: number
 ): Promise<string | undefined> => {
@@ -17,7 +17,7 @@ export const moveOnMap = async (
   request.setName('builtin');
 
   // set pose in frame
-  const lastPose = await getPosition(robotClient, name);
+  const lastPose = await getPosition(robotClient, slamServiceName.name);
 
   const destination = new commonApi.Pose();
   destination.setX(x * 1000);
@@ -31,10 +31,10 @@ export const moveOnMap = async (
 
   // set SLAM resource name
   const slamResourceName = new commonApi.ResourceName();
-  slamResourceName.setNamespace('rdk');
-  slamResourceName.setType('service');
-  slamResourceName.setSubtype('slam');
-  slamResourceName.setName(name);
+  slamResourceName.setNamespace(slamServiceName.namespace);
+  slamResourceName.setType(slamServiceName.type);
+  slamResourceName.setSubtype(slamServiceName.subtype);
+  slamResourceName.setName(slamServiceName.name);
   request.setSlamServiceName(slamResourceName);
 
   // set the motion configuration
@@ -43,7 +43,12 @@ export const moveOnMap = async (
   request.setMotionConfiguration(motionCfg);
 
   // set component name
-  request.setComponentName(namedBase(componentName));
+  const baseResourceName = new commonApi.ResourceName();
+  baseResourceName.setNamespace(componentName.namespace);
+  baseResourceName.setType(componentName.type);
+  baseResourceName.setSubtype(componentName.subtype);
+  baseResourceName.setName(componentName.name);
+  request.setComponentName(baseResourceName);
 
   // set extra as position-only constraint
   request.setExtra(
@@ -65,33 +70,4 @@ export const moveOnMap = async (
   );
 
   return response?.getExecutionId();
-};
-
-const namedBase = (componentName: string): ResourceName => {
-  const baseResourceName = new commonApi.ResourceName();
-  baseResourceName.setNamespace('rdk');
-  baseResourceName.setType('component');
-  baseResourceName.setSubtype('base');
-  baseResourceName.setName(componentName);
-  return baseResourceName;
-};
-
-export const stopMoveOnMap = async (
-  robotClient: Client,
-  componentName: string
-) => {
-  const request = new motionApi.StopPlanRequest();
-  // TODO: This needs to be the actual name of the motion service
-  request.setName('builtin');
-  request.setComponentName(namedBase(componentName));
-
-  await new Promise<motionApi.StopPlanResponse | null>((resolve, reject) => {
-    robotClient.motionService.stopPlan(request, (error, res) => {
-      if (error) {
-        reject(error);
-      } else {
-        resolve(res);
-      }
-    });
-  });
 };

--- a/web/frontend/src/components/remote-control-cards.svelte
+++ b/web/frontend/src/components/remote-control-cards.svelte
@@ -109,6 +109,7 @@ const getStatus = (
     {#each filterSubtype($services, 'slam') as { name } (name)}
       <Slam
         {name}
+        motionResourceNames={filterSubtype($services, 'motion')}
         overrides={overrides?.slam}
       />
     {/each}

--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -74,7 +74,7 @@ $: unitScale = labelUnits === 'm' ? 1 : 1000;
 // get all resources which are bases
 $: bases = filterSubtype($components, 'base');
 $: slamResourceName = filterSubtype($services, 'slam').find(
-  (s) => s.name === name
+  (service) => service.name === name
 )!;
 
 // allowMove is only true if we have a base, there exists a destination and there is no in-flight MoveOnMap req


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-6542)

Changes:

1. Pass the full `commonApi.ResourceName` object to roboClient APIs rather than hard coding the namespace, subtype, & type such that they only work with rdk builtin components.
1. Change the signature of the Slam component to take the motion services so the slam card is compatible with non builtin motion services
1. Change the slam card to call `motion.stopPlan` on the motion client rather than `robotClient` as it deletes error prone boilerplate 

Manually tested both on a modular base & fake slam & fake base.