### PR TITLE
RSDK-5905 power sensor bad voltage readings

### DIFF
--- a/components/powersensor/ina/ina.go
+++ b/components/powersensor/ina/ina.go
@@ -209,8 +209,6 @@ func (d *ina) setCalibrationScale(modelName string) error {
 }
 
 func (d *ina) calibrate() error {
-	d.mu.Lock()
-	defer d.mu.Unlock()
 	handle, err := i2c.NewI2C(d.addr, d.bus)
 	if err != nil {
 		d.logger.Errorf("can't open ina i2c: %s", err)

--- a/components/powersensor/ina/ina.go
+++ b/components/powersensor/ina/ina.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"sync"
 
 	"github.com/d2r2/go-i2c"
 	i2clog "github.com/d2r2/go-logger"
@@ -169,6 +170,7 @@ type ina struct {
 	resource.Named
 	resource.AlwaysRebuild
 	resource.TriviallyCloseable
+	mu         sync.Mutex
 	logger     logging.Logger
 	model      string
 	bus        int
@@ -207,6 +209,8 @@ func (d *ina) setCalibrationScale(modelName string) error {
 }
 
 func (d *ina) calibrate() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	handle, err := i2c.NewI2C(d.addr, d.bus)
 	if err != nil {
 		d.logger.Errorf("can't open ina i2c: %s", err)
@@ -230,6 +234,8 @@ func (d *ina) calibrate() error {
 }
 
 func (d *ina) Voltage(ctx context.Context, extra map[string]interface{}) (float64, bool, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	handle, err := i2c.NewI2C(d.addr, d.bus)
 	if err != nil {
 		d.logger.CErrorf(ctx, "can't open ina i2c: %s", err)
@@ -258,6 +264,8 @@ func (d *ina) Voltage(ctx context.Context, extra map[string]interface{}) (float6
 }
 
 func (d *ina) Current(ctx context.Context, extra map[string]interface{}) (float64, bool, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	handle, err := i2c.NewI2C(d.addr, d.bus)
 	if err != nil {
 		d.logger.CErrorf(ctx, "can't open ina i2c: %s", err)
@@ -283,6 +291,8 @@ func (d *ina) Current(ctx context.Context, extra map[string]interface{}) (float6
 }
 
 func (d *ina) Power(ctx context.Context, extra map[string]interface{}) (float64, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	handle, err := i2c.NewI2C(d.addr, d.bus)
 	if err != nil {
 		d.logger.CErrorf(ctx, "can't open ina i2c handle: %s", err)


### PR DESCRIPTION
This PR adds a mutex to protect the i2c bus for the ina219 power sensor, preventing competing bus usage from corrupting values.