### PR TITLE
add comment explaining the mutex in the power monitor

### DIFF
--- a/components/powersensor/ina/ina.go
+++ b/components/powersensor/ina/ina.go
@@ -170,7 +170,14 @@ type ina struct {
 	resource.Named
 	resource.AlwaysRebuild
 	resource.TriviallyCloseable
-	mu         sync.Mutex
+
+	// This mutex is subtly important. The I2C library we're using is not thread safe because
+	// reading from a register is not atomic! So, this mutex is used to ensure that reading from
+	// two different registers in two different goroutines won't have race conditions resulting in
+	// bad data. All the fields in this struct are immutable, but the mutex is still needed to make
+	// interactions with the I2C bus atomic.
+	mu sync.Mutex
+
 	logger     logging.Logger
 	model      string
 	bus        int


### PR DESCRIPTION
Usually, a mutex is used to protect mutable data in a struct from race conditions. The one added in #3523 does not do that because all fields in the struct are immutable, so naively someone might think this mutex is unnecessary and remove it again. So, this comment explains why it's in here.