### PR TITLE
RSDK-6534 - Minimize unnecessary GetPlan error logs

### DIFF
--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -146,7 +146,7 @@ const refreshPaths = async () => {
   try {
     refreshErrorMessagePaths = undefined;
     const base = bases[0]!;
-    const listPlanStatusesResponse = await motionClient.listPlanStatuses();
+    const listPlanStatusesResponse = await motionClient.listPlanStatuses(true);
     const baseHasPlan = listPlanStatusesResponse.planStatusesWithIdsList
       .map((plan) => plan.componentName)
       .find(


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-6534)

Change:

1. Change SLAM RC card's `refreshPaths()` function to call `listPlanStatuses` to list all plans & only call `getPlan` if the base is in the `listPlanStatuses` response. This prevents the RC card from causing the motion service to log errors due to receiving requests for plans for a component that has not yet had any plans created.

Tested using fake slam:
```
{
  "services": [
    {
      "name": "slam",
      "type": "slam",
      "namespace": "rdk",
      "model": "fake"
    }
  ],
  "components": [
    {
      "depends_on": [],
      "name": "base",
      "model": "fake",
      "type": "base",
      "frame": {
        "orientation": {
          "type": "ov_degrees",
          "value": {
            "y": 0,
            "z": 1,
            "th": 0,
            "x": 0
          }
        },
        "geometry": {
          "y": 350,
          "z": 100,
          "translation": {
            "x": 0,
            "y": 0,
            "z": 0
          },
          "x": 350
        },
        "parent": "world",
        "translation": {
          "y": 0,
          "z": 0,
          "x": 0
        }
      },
      "namespace": "rdk",
      "attributes": {}
    }
  ]
}

```