### PR TITLE
RSDK-6555 Correct for IMUs used to provide SLAM orientation

### DIFF
--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -507,7 +507,7 @@ func TestMoveOnMapSubsequent(t *testing.T) {
 
 func TestMoveOnMapAskewIMU(t *testing.T) {
 	ctx := context.Background()
-	askewOrient := &spatialmath.OrientationVectorDegrees{OX: 1, OY: 1, OZ: 1, Theta: 0}
+	askewOrient := &spatialmath.OrientationVectorDegrees{OX: 1, OY: 1, OZ: 1, Theta: 55}
 	// goal x-position of 1.32m is scaled to be in mm
 	goal1SLAMFrame := spatialmath.NewPose(r3.Vector{X: 1.32 * 1000, Y: 0}, &spatialmath.OrientationVectorDegrees{OZ: 1, Theta: 55})
 	goal1BaseFrame := spatialmath.Compose(goal1SLAMFrame, motion.SLAMOrientationAdjustment)

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -505,6 +505,50 @@ func TestMoveOnMapSubsequent(t *testing.T) {
 	test.That(t, spatialmath.PoseAlmostEqualEps(goalPose2, spatialmath.PoseBetween(goal1BaseFrame, goal2BaseFrame), 10), test.ShouldBeTrue)
 }
 
+func TestMoveOnMapAskewIMU(t *testing.T) {
+	ctx := context.Background()
+	askewOrient := &spatialmath.OrientationVectorDegrees{OX: 1, OY: 1, OZ: 1, Theta: 0}
+	// goal x-position of 1.32m is scaled to be in mm
+	goal1SLAMFrame := spatialmath.NewPose(r3.Vector{X: 1.32 * 1000, Y: 0}, &spatialmath.OrientationVectorDegrees{OZ: 1, Theta: 55})
+	goal1BaseFrame := spatialmath.Compose(goal1SLAMFrame, motion.SLAMOrientationAdjustment)
+
+	kb, ms := createMoveOnMapEnvironment(ctx, t, "pointcloud/octagonspace.pcd", 40, spatialmath.NewPoseFromOrientation(askewOrient))
+	defer ms.Close(ctx)
+
+	req := motion.MoveOnMapReq{
+		ComponentName: base.Named("test-base"),
+		Destination:   goal1SLAMFrame,
+		SlamName:      slam.Named("test_slam"),
+		Extra:         map[string]interface{}{"smooth_iter": 5},
+	}
+
+	timeoutCtx, timeoutFn := context.WithTimeout(ctx, time.Second*5)
+	defer timeoutFn()
+	executionID, err := ms.(*builtIn).MoveOnMapNew(timeoutCtx, req)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, executionID, test.ShouldNotResemble, uuid.Nil)
+
+	timeoutCtx, timeoutFn = context.WithTimeout(ctx, time.Second*5)
+	defer timeoutFn()
+	err = motion.PollHistoryUntilSuccessOrError(timeoutCtx, ms, time.Millisecond*5, motion.PlanHistoryReq{
+		ComponentName: req.ComponentName,
+		ExecutionID:   executionID,
+		LastPlanOnly:  true,
+	})
+	test.That(t, err, test.ShouldBeNil)
+
+	endPIF, err := kb.CurrentPosition(ctx)
+	test.That(t, err, test.ShouldBeNil)
+
+	// We need to transform the endPos by the corrected orientation in order to properly place it, otherwise it will go off in +Z somewhere.
+	// In a real robot this will be taken care of by gravity.
+	correctedPose, err := correctStartPose(spatialmath.NewPoseFromOrientation(askewOrient))
+	test.That(t, err, test.ShouldBeNil)
+	endPos := spatialmath.Compose(correctedPose, spatialmath.PoseBetween(spatialmath.NewPoseFromOrientation(askewOrient), endPIF.Pose()))
+
+	test.That(t, spatialmath.PoseAlmostEqualEps(endPos, goal1BaseFrame, 10), test.ShouldBeTrue)
+}
+
 func TestMoveOnMapTimeout(t *testing.T) {
 	ctx := context.Background()
 	logger := logging.NewTestLogger(t)

--- a/services/motion/builtin/builtin_utils_test.go
+++ b/services/motion/builtin/builtin_utils_test.go
@@ -2,6 +2,7 @@ package builtin
 
 import (
 	"context"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -290,4 +291,9 @@ func TestCorrectStartPose(t *testing.T) {
 	corrected, err = correctStartPose(spatialmath.NewPose(r3.Vector{X: 1320, Y: 0}, askewOrient))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, corrected.Orientation().OrientationVectorDegrees().Theta, test.ShouldAlmostEqual, 135.)
+	// -30
+	askewOrient = &spatialmath.OrientationVectorDegrees{OX: 1, OY: math.Sqrt(3), OZ: 1}
+	corrected, err = correctStartPose(spatialmath.NewPose(r3.Vector{X: 1320, Y: 0}, askewOrient))
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, corrected.Orientation().OrientationVectorDegrees().Theta, test.ShouldAlmostEqual, -30.)
 }

--- a/services/motion/builtin/builtin_utils_test.go
+++ b/services/motion/builtin/builtin_utils_test.go
@@ -268,3 +268,26 @@ func createMoveOnMapEnvironment(
 	test.That(t, err, test.ShouldBeNil)
 	return kb, ms
 }
+
+func TestCorrectStartPose(t *testing.T) {
+	// -45
+	askewOrient := &spatialmath.OrientationVectorDegrees{OX: 1, OY: 1, OZ: 1}
+	corrected, err := correctStartPose(spatialmath.NewPose(r3.Vector{X: 1320, Y: 0}, askewOrient))
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, corrected.Orientation().OrientationVectorDegrees().Theta, test.ShouldAlmostEqual, -45.)
+	// 45
+	askewOrient = &spatialmath.OrientationVectorDegrees{OX: -1, OY: 1, OZ: 1}
+	corrected, err = correctStartPose(spatialmath.NewPose(r3.Vector{X: 1320, Y: 0}, askewOrient))
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, corrected.Orientation().OrientationVectorDegrees().Theta, test.ShouldAlmostEqual, 45.)
+	// -135
+	askewOrient = &spatialmath.OrientationVectorDegrees{OX: 1, OY: -1, OZ: 1}
+	corrected, err = correctStartPose(spatialmath.NewPose(r3.Vector{X: 1320, Y: 0}, askewOrient))
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, corrected.Orientation().OrientationVectorDegrees().Theta, test.ShouldAlmostEqual, -135.)
+	// 135
+	askewOrient = &spatialmath.OrientationVectorDegrees{OX: -1, OY: -1, OZ: 1}
+	corrected, err = correctStartPose(spatialmath.NewPose(r3.Vector{X: 1320, Y: 0}, askewOrient))
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, corrected.Orientation().OrientationVectorDegrees().Theta, test.ShouldAlmostEqual, 135.)
+}


### PR DESCRIPTION
If a SLAM service uses an IMU and it is slightly askew at the start of a move, then our orientation will no longer be normal to the XY plane, and we will either 1) think we are leaving the plane when we are not, or 2) be unable to plan.

Being unable to plan is not acceptable as not only can this be triggered by truly miniscule orientation perturbations, but a rover may be driving over uneven ground at query time, and we should be able to determine which way a sloped rover would go if driving straight even if it is currently askew.

To do this, we take the vector representing the rover's direction of movement {0,1,0}, and transform it by the orientation given. The arctangent of the new vector's Y and X components yield the equivalent X-Y normal orientation.

This will be increasingly less reliable as rovers encounter increasingly extreme angles, such as a robot turned onto its side, but should be robust for the usual case of having mild orientation skew due to driving over obstacles.

New tests introduced confirm 1) the mathematical functionality and directionality of the new function, and 2) the ability of a MoveOnMap call to properly drive to the requested X-Y goal when starting at an askew orientation.