### PR TITLE
Bump analyzetests context timeout

### DIFF
--- a/etc/analyzetests/main.go
+++ b/etc/analyzetests/main.go
@@ -37,7 +37,7 @@ func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) err
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 	client, err := mongo.NewClient(options.Client().ApplyURI(mongoURI))
 	if err != nil {


### PR DESCRIPTION
It has started to time out more frequently (I've seen it two times in the last two days)

https://github.com/viamrobotics/rdk/actions/runs/7760606306/job/21167217579?pr=3493
https://github.com/viamrobotics/rdk/actions/runs/7746263818/job/21124304190


Seems like a symptom of more tests and more development.


If someone wants to investigate this, I can create a ticket; voting to just bump the timeout for now.