### PR TITLE
RSDK-6557 fix flaky test TestStartWaypoint

### DIFF
--- a/services/navigation/builtin/builtin_test.go
+++ b/services/navigation/builtin/builtin_test.go
@@ -624,6 +624,59 @@ func setupStartWaypoint(ctx context.Context, t *testing.T, logger logging.Logger
 	}
 }
 
+func setupStartWaypointExplore(ctx context.Context, t *testing.T, logger logging.Logger) startWaypointState {
+	fsSvc, err := framesystem.New(ctx, nil, logger)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, fsSvc, test.ShouldNotBeNil)
+	fakeBase, err := baseFake.NewBase(ctx, nil, resource.Config{
+		Name:  "test_base",
+		API:   base.API,
+		Frame: &referenceframe.LinkConfig{Geometry: &spatialmath.GeometryConfig{R: 100}},
+	}, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	injectMovementSensor := inject.NewMovementSensor("test_movement")
+	visionService := inject.NewVisionService("vision")
+	camera := inject.NewCamera("camera")
+	config := resource.Config{
+		ConvertedAttributes: &Config{
+			Store: navigation.StoreConfig{
+				Type: navigation.StoreTypeMemory,
+			},
+			BaseName:           "test_base",
+			MovementSensorName: "test_movement",
+			MotionServiceName:  "test_motion",
+			DegPerSec:          1,
+			MetersPerSec:       1,
+			ObstacleDetectors: []*ObstacleDetectorNameConfig{
+				{
+					VisionServiceName: "vision",
+					CameraName:        "camera",
+				},
+			},
+		},
+	}
+	injectMS := inject.NewMotionService("test_motion")
+	deps := resource.Dependencies{
+		injectMS.Name():             injectMS,
+		fakeBase.Name():             fakeBase,
+		injectMovementSensor.Name(): injectMovementSensor,
+		visionService.Name():        visionService,
+		camera.Name():               camera,
+		// to placate the explore struct to not panic
+		fsSvc.Name(): fsSvc,
+	}
+	ns, err := NewBuiltIn(ctx, deps, config, logger)
+	test.That(t, err, test.ShouldBeNil)
+	return startWaypointState{
+		ns:             ns,
+		injectMS:       injectMS,
+		base:           fakeBase,
+		movementSensor: injectMovementSensor,
+		closeFunc:      func() { test.That(t, ns.Close(context.Background()), test.ShouldBeNil) },
+	}
+}
+
 func TestPaths(t *testing.T) {
 	ctx := context.Background()
 	logger := logging.NewTestLogger(t)
@@ -1176,25 +1229,33 @@ func TestStartWaypoint(t *testing.T) {
 		}
 	})
 
+	sManual := setupStartWaypoint(ctx, t, logger)
+	sExplore := setupStartWaypointExplore(ctx, t, logger)
 	// Calling SetMode cancels current and future MoveOnGlobe calls
 	cases := []struct {
 		description string
 		mode        navigation.Mode
+		s           *startWaypointState
 	}{
 		{
 			description: "Calling SetMode manual cancels context of current and future motion calls",
 			mode:        navigation.ModeManual,
+			s:           &sManual,
 		},
 		{
 			description: "Calling SetMode explore cancels context of current and future motion calls",
 			mode:        navigation.ModeExplore,
+			s:           &sExplore,
 		},
 	}
 
 	for _, tt := range cases {
 		t.Run(tt.description, func(t *testing.T) {
-			s := setupStartWaypoint(ctx, t, logger)
+			s := tt.s
 			defer s.closeFunc()
+			fsSvc, err := framesystem.New(ctx, nil, logger)
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, fsSvc, test.ShouldNotBeNil)
 
 			executionID := uuid.New()
 			s.injectMS.MoveOnGlobeFunc = func(ctx context.Context, req motion.MoveOnGlobeReq) (motion.ExecutionID, error) {

--- a/services/navigation/builtin/explore.go
+++ b/services/navigation/builtin/explore.go
@@ -18,9 +18,8 @@ func (svc *builtIn) startExploreMode(ctx context.Context) {
 	svc.logger.CDebug(ctx, "startExploreMode called")
 
 	svc.activeBackgroundWorkers.Add(1)
-	utils.PanicCapturingGo(func() {
-		defer svc.activeBackgroundWorkers.Done()
 
+	utils.ManagedGo(func() {
 		// Send motionCfg parameters through extra until motionCfg can be added to Move()
 		extra := map[string]interface{}{"motionCfg": *svc.motionCfg}
 
@@ -43,5 +42,5 @@ func (svc *builtIn) startExploreMode(ctx context.Context) {
 				svc.logger.CDebugf(ctx, "error occurred when moving to point %v: %v", destination, err)
 			}
 		}
-	})
+	}, svc.activeBackgroundWorkers.Done)
 }


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-6557)

1. Fixes `TestStartWaypoint/Reach_waypoints_successfully` by waiting until success goroutine has completed before running test assertions
2. Fixes panic in nav builtin test which exercises explore mode caused by explore mode not being constructed with a framesytsem service