### PR TITLE
RSDK-6514 Improve UR arm driver to use longer timeouts for longer motions

### DIFF
--- a/components/arm/universalrobots/ur5e_test.go
+++ b/components/arm/universalrobots/ur5e_test.go
@@ -179,7 +179,6 @@ func computeUR5ePosition(t *testing.T, jointRadians []float64) spatialmath.Pose 
 		OX: o.At(0, 3) - res.At(0, 3),
 		OY: o.At(1, 3) - res.At(1, 3),
 		OZ: o.At(2, 3) - res.At(2, 3),
-		// Theta: utils.RadToDeg(math.Acos(o.At(0,0))), // TODO(erh): fix this
 	}
 	ov.Normalize()
 
@@ -327,10 +326,10 @@ func TestArmReconnection(t *testing.T) {
 		},
 	}
 
-	arm, err := URArmConnect(parentCtx, cfg, logger)
+	arm, err := urArmConnect(parentCtx, cfg, logger)
 
 	test.That(t, err, test.ShouldBeNil)
-	ua, ok := arm.(*URArm)
+	ua, ok := arm.(*urArm)
 	test.That(t, ok, test.ShouldBeTrue)
 
 	testutils.WaitForAssertion(t, func(tb testing.TB) {
@@ -423,7 +422,7 @@ func TestReconfigure(t *testing.T) {
 	conf, err := resource.NativeConfig[*Config](cfg)
 	test.That(t, err, test.ShouldBeNil)
 
-	ur5e := &URArm{
+	ur5e := &urArm{
 		speedRadPerSec:     conf.SpeedDegsPerSec,
 		urHostedKinematics: conf.ArmHostedKinematics,
 		host:               conf.Host,

--- a/components/arm/universalrobots/ur_parser_test.go
+++ b/components/arm/universalrobots/ur_parser_test.go
@@ -20,10 +20,10 @@ func Test1(t *testing.T) {
 	state, err := readRobotStateMessage(context.Background(), data, logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	test.That(t, int(math.Round(state.Joints[0].AngleValues())), test.ShouldEqual, 90)
-	test.That(t, int(math.Round(state.Joints[1].AngleValues())), test.ShouldEqual, -90)
-	test.That(t, int(math.Round(state.Joints[2].AngleValues())), test.ShouldEqual, 5)
-	test.That(t, int(math.Round(state.Joints[3].AngleValues())), test.ShouldEqual, 10)
-	test.That(t, int(math.Round(state.Joints[4].AngleValues())), test.ShouldEqual, 15)
-	test.That(t, int(math.Round(state.Joints[5].AngleValues())), test.ShouldEqual, 20)
+	test.That(t, int(math.Round(state.Joints[0].degrees())), test.ShouldEqual, 90)
+	test.That(t, int(math.Round(state.Joints[1].degrees())), test.ShouldEqual, -90)
+	test.That(t, int(math.Round(state.Joints[2].degrees())), test.ShouldEqual, 5)
+	test.That(t, int(math.Round(state.Joints[3].degrees())), test.ShouldEqual, 10)
+	test.That(t, int(math.Round(state.Joints[4].degrees())), test.ShouldEqual, 15)
+	test.That(t, int(math.Round(state.Joints[5].degrees())), test.ShouldEqual, 20)
 }


### PR DESCRIPTION
This PR fixes a bug that causes this driver to quit in the middle of a move call if it is not configured to run fast enough.  This is because it had a static timeout of 10 seconds.  This work updates it to use a larger number if it is estimated that the motion will not complete in time.  

In the process of doing this I noticed a lot of places where this driver could be cleaned up and I think since its one of our premier arm drivers we should clean up the code to use best practices where possible and easy.  

It was tested on the Motion team's Arm QA plan, which was previously failing. Testing revealed that this does indeed fix the issue. 