### PR TITLE
Unblock release by removing manifest from main

### DIFF
--- a/.github/workflows/staticbuild.yml
+++ b/.github/workflows/staticbuild.yml
@@ -98,17 +98,6 @@ jobs:
         parent: false
         gzip: false
 
-    - name: Upload Manifest (Testing)
-      if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
-      uses: google-github-actions/upload-cloud-storage@v0.10.4
-      with:
-        headers: "cache-control: no-cache"
-        path: 'etc/packaging/static/manifest/'
-        destination: 'packages.viam.com/apps/viam-subsystems/testing/viam-server/${{ steps.build_date.outputs.date }}/${{ github.sha }}/'
-        glob: 'viam-server-*'
-        parent: false
-        gzip: false
-
   output_summary:
     name: Output Summary
     runs-on: ubuntu-latest
@@ -186,10 +175,6 @@ jobs:
     - name: Publish Static Binary
       run: |
         gsutil mv "gs://packages.viam.com/apps/viam-server/testing/static/${{ needs.static_test.outputs.date }}/${{ github.sha }}/*" "gs://packages.viam.com/apps/viam-server/"
-
-    - name: Publish Subsystem Metadata
-      run: |
-        gsutil mv "gs://packages.viam.com/apps/viam-subsystems/testing/viam-server/${{ needs.static_test.outputs.date }}/${{ github.sha }}/*" "gs://packages.viam.com/apps/viam-subsystems/"
 
     - name: Output Summary
       run: |


### PR DESCRIPTION
Reverts the main part of viamrobotics/rdk#3493

Needed to unblock https://github.com/viamrobotics/rdk/actions/runs/7803011876

The release is using the github actions from main, however, the release is missing the required scripts :facepalm: 

We cannot cherry pick the commit in because the rc has already been published but no artifacts have been generated. (SO claims that we could force push to main to update the tag with my commit but I worry that would break more than we expect)

I will un-revert this after the release artifacts have been generated. 

Postmortem: It would be great if releases ran the same github actions workflows for release as what was ran for the RC. Not sure if this is possible. I should have realized this and it is something I will be more careful about going forward.