### PR TITLE
RSDK-6563 - Expose inflation factor

### DIFF
--- a/components/base/kinematicbase/differentialDrive.go
+++ b/components/base/kinematicbase/differentialDrive.go
@@ -24,7 +24,10 @@ import (
 )
 
 // The pause time when not using a localizer before moving on to next move step.
-const defaultNoLocalizerDelay = 250 * time.Millisecond
+const (
+	defaultNoLocalizerDelay  = 250 * time.Millisecond
+	defaultCollisionBufferMM = 1e-8
+)
 
 var (
 	// errMovementTimeout is used for when a movement call times out after no movement for some time.
@@ -160,7 +163,8 @@ func (ddk *differentialDriveKinematics) GoToInputs(ctx context.Context, desired 
 		// when the base is within the positional threshold of the goal, exit the loop
 		for err := cancelContext.Err(); err == nil; err = cancelContext.Err() {
 			utils.SelectContextOrWait(ctx, 10*time.Millisecond)
-			col, err := validRegion.CollidesWith(spatialmath.NewPoint(r3.Vector{X: current[0].Value, Y: current[1].Value}, ""))
+			point := spatialmath.NewPoint(r3.Vector{X: current[0].Value, Y: current[1].Value}, "")
+			col, err := validRegion.CollidesWith(point, defaultCollisionBufferMM)
 			if err != nil {
 				movementErr <- err
 				return

--- a/components/base/kinematicbase/differentialDrive_test.go
+++ b/components/base/kinematicbase/differentialDrive_test.go
@@ -206,14 +206,14 @@ func TestNewValidRegionCapsule(t *testing.T) {
 	c, err := ddk.newValidRegionCapsule(starting, desired)
 	test.That(t, err, test.ShouldBeNil)
 
-	col, err := c.CollidesWith(spatialmath.NewPoint(r3.Vector{X: -176, Y: 576, Z: 0}, ""))
+	col, err := c.CollidesWith(spatialmath.NewPoint(r3.Vector{X: -176, Y: 576, Z: 0}, ""), defaultCollisionBufferMM)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, col, test.ShouldBeTrue)
 
 	col, err = c.CollidesWith(spatialmath.NewPoint(
 		r3.Vector{X: -defaultPlanDeviationThresholdMM, Y: -defaultPlanDeviationThresholdMM, Z: 0},
 		"",
-	))
+	), defaultCollisionBufferMM)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, col, test.ShouldBeFalse)
 }

--- a/motionplan/collision.go
+++ b/motionplan/collision.go
@@ -197,7 +197,11 @@ type collisionGraph struct {
 // newCollisionGraph instantiates a collisionGraph object and checks for collisions between the x and y sets of geometries
 // collisions that are reported in the reference CollisionSystem argument will be ignored and not stored as edges in the graph.
 // if the set y is nil, the graph will be instantiated with y = x.
-func newCollisionGraph(x, y []spatial.Geometry, reference *collisionGraph, reportDistances bool) (cg *collisionGraph, err error) {
+func newCollisionGraph(x, y []spatial.Geometry,
+	reference *collisionGraph,
+	reportDistances bool,
+	collisionBuffer float64,
+) (cg *collisionGraph, err error) {
 	if y == nil {
 		y = x
 	}
@@ -222,15 +226,15 @@ func newCollisionGraph(x, y []spatial.Geometry, reference *collisionGraph, repor
 				// geometry pair already has distance information associated with it, or is comparing with itself - skip to next pair
 				continue
 			}
-			if reference != nil && reference.collisionBetween(xName, yName) {
+			if reference != nil && reference.collisionBetween(xName, yName, collisionBuffer) {
 				// represent previously seen collisions as NaNs
 				// per IEE standards, any comparison with NaN will return false, so these will never be considered collisions
 				distance = math.NaN()
-			} else if distance, err = cg.checkCollision(xGeometry, yGeometry); err != nil {
+			} else if distance, err = cg.checkCollision(xGeometry, yGeometry, collisionBuffer); err != nil {
 				return nil, err
 			}
 			cg.setDistance(xName, yName, distance)
-			if !reportDistances && distance <= spatial.CollisionBuffer {
+			if !reportDistances && distance <= collisionBuffer {
 				// collision found, can return early
 				return cg, nil
 			}
@@ -241,19 +245,19 @@ func newCollisionGraph(x, y []spatial.Geometry, reference *collisionGraph, repor
 
 // checkCollision takes a pair of geometries and returns the distance between them.
 // If this number is less than the CollisionBuffer they can be considered to be in collision.
-func (cg *collisionGraph) checkCollision(x, y spatial.Geometry) (float64, error) {
+func (cg *collisionGraph) checkCollision(x, y spatial.Geometry, collisionBuffer float64) (float64, error) {
 	// x is the robot geometries and therefore must use the primitives from spatialmath
 	// y is a geometry type that could potentially live outside spatialmath and therefore knows more so we defer to it for collisions
 	if cg.reportDistances {
-		dist, err := x.DistanceFrom(y)
+		dist, err := x.DistanceFrom(y, collisionBuffer)
 		if err != nil {
-			return y.DistanceFrom(x)
+			return y.DistanceFrom(x, collisionBuffer)
 		}
 		return dist, nil
 	}
-	col, err := x.CollidesWith(y)
+	col, err := x.CollidesWith(y, collisionBuffer)
 	if err != nil {
-		col, err = y.CollidesWith(x)
+		col, err = y.CollidesWith(x, collisionBuffer)
 		if err != nil {
 			return math.Inf(-1), err
 		}
@@ -265,19 +269,19 @@ func (cg *collisionGraph) checkCollision(x, y spatial.Geometry) (float64, error)
 }
 
 // collisionBetween returns a bool describing if the collisionGraph has a collision between the two entities that are specified by name.
-func (cg *collisionGraph) collisionBetween(name1, name2 string) bool {
+func (cg *collisionGraph) collisionBetween(name1, name2 string, collisionBuffer float64) bool {
 	if distance, ok := cg.getDistance(name1, name2); ok {
-		return distance <= spatial.CollisionBuffer
+		return distance <= collisionBuffer
 	}
 	return false
 }
 
 // collisions returns a list of all the collisions present in the collisionGraph.
-func (cg *collisionGraph) collisions() []Collision {
+func (cg *collisionGraph) collisions(collisionBuffer float64) []Collision {
 	var collisions []Collision
 	for xName, row := range cg.distances {
 		for yName, distance := range row {
-			if distance <= spatial.CollisionBuffer {
+			if distance <= collisionBuffer {
 				collisions = append(collisions, Collision{xName, yName, distance})
 				if !cg.reportDistances {
 					// collision found, can return early

--- a/motionplan/collision.go
+++ b/motionplan/collision.go
@@ -249,9 +249,9 @@ func (cg *collisionGraph) checkCollision(x, y spatial.Geometry, collisionBufferM
 	// x is the robot geometries and therefore must use the primitives from spatialmath
 	// y is a geometry type that could potentially live outside spatialmath and therefore knows more so we defer to it for collisions
 	if cg.reportDistances {
-		dist, err := x.DistanceFrom(y, collisionBufferMM)
+		dist, err := x.DistanceFrom(y)
 		if err != nil {
-			return y.DistanceFrom(x, collisionBufferMM)
+			return y.DistanceFrom(x)
 		}
 		return dist, nil
 	}

--- a/motionplan/collision_test.go
+++ b/motionplan/collision_test.go
@@ -63,13 +63,13 @@ func TestCheckCollisions(t *testing.T) {
 	obstacles[1].SetLabel("obstacleCube444")
 	obstacles = append(obstacles, bc1.Transform(spatial.NewPoseFromPoint(r3.Vector{6, 6, 6})))
 	obstacles[2].SetLabel("obstacleCube666")
-	cg, err := newCollisionGraph(robot, obstacles, nil, true)
+	cg, err := newCollisionGraph(robot, obstacles, nil, true, defaultCollisionBufferMM)
 	test.That(t, err, test.ShouldBeNil)
 	expectedCollisions := []Collision{
 		{"robotCube333", "obstacleCube444", -1},
 		{"robotCube000", "obstacleCube000", -2},
 	}
-	test.That(t, collisionListsAlmostEqual(cg.collisions(), expectedCollisions), test.ShouldBeTrue)
+	test.That(t, collisionListsAlmostEqual(cg.collisions(defaultCollisionBufferMM), expectedCollisions), test.ShouldBeTrue)
 
 	// case 2: zero position of xArm6 arm - should have number of collisions = to number of geometries - 1
 	// no external geometries considered, self collision only
@@ -77,9 +77,9 @@ func TestCheckCollisions(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	gf, _ := m.Geometries(make([]frame.Input, len(m.DoF())))
 	test.That(t, gf, test.ShouldNotBeNil)
-	cg, err = newCollisionGraph(gf.Geometries(), gf.Geometries(), nil, true)
+	cg, err = newCollisionGraph(gf.Geometries(), gf.Geometries(), nil, true, defaultCollisionBufferMM)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, len(cg.collisions()), test.ShouldEqual, 4)
+	test.That(t, len(cg.collisions(defaultCollisionBufferMM)), test.ShouldEqual, 4)
 }
 
 func TestUniqueCollisions(t *testing.T) {
@@ -90,30 +90,54 @@ func TestUniqueCollisions(t *testing.T) {
 	input := make([]frame.Input, len(m.DoF()))
 	internalGeometries, _ := m.Geometries(input)
 	test.That(t, internalGeometries, test.ShouldNotBeNil)
-	zeroPositionCG, err := newCollisionGraph(internalGeometries.Geometries(), internalGeometries.Geometries(), nil, true)
+	zeroPositionCG, err := newCollisionGraph(
+		internalGeometries.Geometries(),
+		internalGeometries.Geometries(),
+		nil,
+		true,
+		defaultCollisionBufferMM,
+	)
 	test.That(t, err, test.ShouldBeNil)
 
 	// case 1: no self collision - check no new collisions are returned
 	input[0] = frame.Input{Value: 1}
 	internalGeometries, _ = m.Geometries(input)
 	test.That(t, internalGeometries, test.ShouldNotBeNil)
-	cg, err := newCollisionGraph(internalGeometries.Geometries(), internalGeometries.Geometries(), zeroPositionCG, true)
+	cg, err := newCollisionGraph(
+		internalGeometries.Geometries(),
+		internalGeometries.Geometries(),
+		zeroPositionCG,
+		true,
+		defaultCollisionBufferMM,
+	)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, len(cg.collisions()), test.ShouldEqual, 0)
+	test.That(t, len(cg.collisions(defaultCollisionBufferMM)), test.ShouldEqual, 0)
 
 	// case 2: self collision - check only new collisions are returned
 	input[4] = frame.Input{Value: 2}
 	internalGeometries, _ = m.Geometries(input)
 	test.That(t, internalGeometries, test.ShouldNotBeNil)
-	cg, err = newCollisionGraph(internalGeometries.Geometries(), internalGeometries.Geometries(), zeroPositionCG, true)
+	cg, err = newCollisionGraph(
+		internalGeometries.Geometries(),
+		internalGeometries.Geometries(),
+		zeroPositionCG,
+		true,
+		defaultCollisionBufferMM,
+	)
 	test.That(t, err, test.ShouldBeNil)
 	expectedCollisions := []Collision{{"xArm6:base_top", "xArm6:wrist_link", -66.6}, {"xArm6:wrist_link", "xArm6:upper_arm", -48.1}}
-	test.That(t, collisionListsAlmostEqual(cg.collisions(), expectedCollisions), test.ShouldBeTrue)
+	test.That(t, collisionListsAlmostEqual(cg.collisions(defaultCollisionBufferMM), expectedCollisions), test.ShouldBeTrue)
 
 	// case 3: add a collision specification that the last element of expectedCollisions should be ignored
 	zeroPositionCG.addCollisionSpecification(&expectedCollisions[1])
 
-	cg, err = newCollisionGraph(internalGeometries.Geometries(), internalGeometries.Geometries(), zeroPositionCG, true)
+	cg, err = newCollisionGraph(
+		internalGeometries.Geometries(),
+		internalGeometries.Geometries(),
+		zeroPositionCG,
+		true,
+		defaultCollisionBufferMM,
+	)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, collisionListsAlmostEqual(cg.collisions(), expectedCollisions[:1]), test.ShouldBeTrue)
+	test.That(t, collisionListsAlmostEqual(cg.collisions(defaultCollisionBufferMM), expectedCollisions[:1]), test.ShouldBeTrue)
 }

--- a/motionplan/constraint_test.go
+++ b/motionplan/constraint_test.go
@@ -218,7 +218,7 @@ func TestCollisionConstraints(t *testing.T) {
 	sf, err := newSolverFrame(fs, model.Name(), frame.World, frame.StartPositions(fs))
 	test.That(t, err, test.ShouldBeNil)
 	handler := &ConstraintHandler{}
-	collisionConstraints, err := createAllCollisionConstraints(sf, fs, worldState, frame.StartPositions(fs), nil)
+	collisionConstraints, err := createAllCollisionConstraints(sf, fs, worldState, frame.StartPositions(fs), nil, defaultCollisionBufferMM)
 	test.That(t, err, test.ShouldBeNil)
 	for name, constraint := range collisionConstraints {
 		handler.AddStateConstraint(name, constraint)
@@ -255,7 +255,7 @@ func BenchmarkCollisionConstraints(b *testing.B) {
 	sf, err := newSolverFrame(fs, model.Name(), frame.World, frame.StartPositions(fs))
 	test.That(b, err, test.ShouldBeNil)
 	handler := &ConstraintHandler{}
-	collisionConstraints, err := createAllCollisionConstraints(sf, fs, worldState, frame.StartPositions(fs), nil)
+	collisionConstraints, err := createAllCollisionConstraints(sf, fs, worldState, frame.StartPositions(fs), nil, defaultCollisionBufferMM)
 	test.That(b, err, test.ShouldBeNil)
 	for name, constraint := range collisionConstraints {
 		handler.AddStateConstraint(name, constraint)

--- a/motionplan/motionPlanner_test.go
+++ b/motionplan/motionPlanner_test.go
@@ -216,7 +216,7 @@ func simple2DMap() (*planConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	collisionConstraints, err := createAllCollisionConstraints(sf, fs, worldState, frame.StartPositions(fs), nil)
+	collisionConstraints, err := createAllCollisionConstraints(sf, fs, worldState, frame.StartPositions(fs), nil, defaultCollisionBufferMM)
 	if err != nil {
 		return nil, err
 	}
@@ -255,7 +255,7 @@ func simpleXArmMotion() (*planConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	collisionConstraints, err := createAllCollisionConstraints(sf, fs, nil, frame.StartPositions(fs), nil)
+	collisionConstraints, err := createAllCollisionConstraints(sf, fs, nil, frame.StartPositions(fs), nil, defaultCollisionBufferMM)
 	if err != nil {
 		return nil, err
 	}
@@ -291,7 +291,7 @@ func simpleUR5eMotion() (*planConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	collisionConstraints, err := createAllCollisionConstraints(sf, fs, nil, frame.StartPositions(fs), nil)
+	collisionConstraints, err := createAllCollisionConstraints(sf, fs, nil, frame.StartPositions(fs), nil, defaultCollisionBufferMM)
 	if err != nil {
 		return nil, err
 	}

--- a/motionplan/planManager.go
+++ b/motionplan/planManager.go
@@ -497,14 +497,14 @@ func (pm *planManager) plannerSetupFromMoveRequest(
 	opt := newBasicPlannerOptions(pm.frame)
 	opt.extra = planningOpts
 
-	collisionBuffer := defaultCollisionBufferMM
-	collisionBufferRaw, ok := planningOpts["collision_buffer_mm"]
+	collisionBufferMM := defaultCollisionBufferMM
+	collisionBufferMMRaw, ok := planningOpts["collision_buffer_mm"]
 	if ok {
-		collisionBuffer, ok = collisionBufferRaw.(float64)
+		collisionBufferMM, ok = collisionBufferMMRaw.(float64)
 		if !ok {
 			return nil, errors.New("could not interpret collision_buffer_mm field as float64")
 		}
-		if collisionBuffer < 0 {
+		if collisionBufferMM < 0 {
 			return nil, errors.New("collision_buffer_mm can't be negative")
 		}
 	}
@@ -516,7 +516,7 @@ func (pm *planManager) plannerSetupFromMoveRequest(
 		worldState,
 		seedMap,
 		constraints.GetCollisionSpecification(),
-		collisionBuffer,
+		collisionBufferMM,
 	)
 	if err != nil {
 		return nil, err

--- a/motionplan/planManager.go
+++ b/motionplan/planManager.go
@@ -498,11 +498,14 @@ func (pm *planManager) plannerSetupFromMoveRequest(
 	opt.extra = planningOpts
 
 	collisionBuffer := defaultCollisionBufferMM
-	collisionBufferRaw, ok := planningOpts["collision_buffer"]
+	collisionBufferRaw, ok := planningOpts["collision_buffer_mm"]
 	if ok {
 		collisionBuffer, ok = collisionBufferRaw.(float64)
 		if !ok {
-			return nil, errors.New("could not interpret collision_buffer field as float64")
+			return nil, errors.New("could not interpret collision_buffer_mm field as float64")
+		}
+		if collisionBuffer < 0 {
+			return nil, errors.New("collision_buffer_mm can't be negative")
 		}
 	}
 

--- a/motionplan/planManager.go
+++ b/motionplan/planManager.go
@@ -497,6 +497,15 @@ func (pm *planManager) plannerSetupFromMoveRequest(
 	opt := newBasicPlannerOptions(pm.frame)
 	opt.extra = planningOpts
 
+	collisionBuffer := defaultCollisionBufferMM
+	collisionBufferRaw, ok := planningOpts["collision_buffer"]
+	if ok {
+		collisionBuffer, ok = collisionBufferRaw.(float64)
+		if !ok {
+			return nil, errors.New("could not interpret collision_buffer field as float64")
+		}
+	}
+
 	// add collision constraints
 	collisionConstraints, err := createAllCollisionConstraints(
 		pm.frame,
@@ -504,6 +513,7 @@ func (pm *planManager) plannerSetupFromMoveRequest(
 		worldState,
 		seedMap,
 		constraints.GetCollisionSpecification(),
+		collisionBuffer,
 	)
 	if err != nil {
 		return nil, err

--- a/motionplan/plannerOptions.go
+++ b/motionplan/plannerOptions.go
@@ -14,6 +14,8 @@ import (
 
 // default values for planning options.
 const (
+	defaultCollisionBufferMM = 1e-8
+
 	// max linear deviation from straight-line between start and goal, in mm.
 	defaultLinearDeviation = 0.1
 

--- a/motionplan/tpSpaceRRT_test.go
+++ b/motionplan/tpSpaceRRT_test.go
@@ -108,7 +108,14 @@ func TestPtgWithObstacle(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	sf, err := newSolverFrame(fs, ackermanFrame.Name(), referenceframe.World, nil)
 	test.That(t, err, test.ShouldBeNil)
-	collisionConstraints, err := createAllCollisionConstraints(sf, fs, worldState, referenceframe.StartPositions(fs), nil)
+	collisionConstraints, err := createAllCollisionConstraints(
+		sf,
+		fs,
+		worldState,
+		referenceframe.StartPositions(fs),
+		nil,
+		defaultCollisionBufferMM,
+	)
 	test.That(t, err, test.ShouldBeNil)
 
 	for name, constraint := range collisionConstraints {

--- a/pointcloud/basic_octree.go
+++ b/pointcloud/basic_octree.go
@@ -200,7 +200,12 @@ func (octree *BasicOctree) ToProtobuf() *commonpb.Geometry {
 
 // CollidesWithGeometry will return whether a given geometry is in collision with a given point.
 // A point is in collision if its stored probability is >= confidenceThreshold and if it is at most buffer distance away.
-func (octree *BasicOctree) CollidesWithGeometry(geom spatialmath.Geometry, confidenceThreshold int, buffer float64) (bool, error) {
+func (octree *BasicOctree) CollidesWithGeometry(
+	geom spatialmath.Geometry,
+	confidenceThreshold int,
+	buffer,
+	collisionBuffer float64,
+) (bool, error) {
 	if octree.MaxVal() < confidenceThreshold {
 		return false, nil
 	}
@@ -216,7 +221,7 @@ func (octree *BasicOctree) CollidesWithGeometry(geom spatialmath.Geometry, confi
 		}
 
 		// Check whether our geom collides with the area represented by the octree. If false, we can skip
-		collide, err := geom.CollidesWith(ocbox)
+		collide, err := geom.CollidesWith(ocbox, collisionBuffer)
 		if err != nil {
 			return false, err
 		}
@@ -224,7 +229,7 @@ func (octree *BasicOctree) CollidesWithGeometry(geom spatialmath.Geometry, confi
 			return false, nil
 		}
 		for _, child := range octree.node.children {
-			collide, err = child.CollidesWithGeometry(geom, confidenceThreshold, buffer)
+			collide, err = child.CollidesWithGeometry(geom, confidenceThreshold, buffer, collisionBuffer)
 			if err != nil {
 				return false, err
 			}
@@ -241,7 +246,7 @@ func (octree *BasicOctree) CollidesWithGeometry(geom spatialmath.Geometry, confi
 			return false, err
 		}
 
-		ptCollide, err := geom.CollidesWith(ptGeom)
+		ptCollide, err := geom.CollidesWith(ptGeom, collisionBuffer)
 		if err != nil {
 			return false, err
 		}
@@ -251,14 +256,14 @@ func (octree *BasicOctree) CollidesWithGeometry(geom spatialmath.Geometry, confi
 }
 
 // CollidesWith checks if the given octree collides with the given geometry and returns true if it does.
-func (octree *BasicOctree) CollidesWith(geom spatialmath.Geometry) (bool, error) {
-	return octree.CollidesWithGeometry(geom, confidenceThreshold, buffer)
+func (octree *BasicOctree) CollidesWith(geom spatialmath.Geometry, collisionBuffer float64) (bool, error) {
+	return octree.CollidesWithGeometry(geom, confidenceThreshold, buffer, collisionBuffer)
 }
 
 // DistanceFrom returns the distance from the given octree to the given geometry.
 // TODO (RSDK-3743): Implement BasicOctree Geometry functions.
-func (octree *BasicOctree) DistanceFrom(geom spatialmath.Geometry) (float64, error) {
-	collides, err := octree.CollidesWith(geom)
+func (octree *BasicOctree) DistanceFrom(geom spatialmath.Geometry, collisionBuffer float64) (float64, error) {
+	collides, err := octree.CollidesWith(geom, collisionBuffer)
 	if err != nil {
 		return math.Inf(1), err
 	}
@@ -270,7 +275,7 @@ func (octree *BasicOctree) DistanceFrom(geom spatialmath.Geometry) (float64, err
 
 // EncompassedBy returns true if the given octree is within the given geometry.
 // TODO (RSDK-3743): Implement BasicOctree Geometry functions.
-func (octree *BasicOctree) EncompassedBy(geom spatialmath.Geometry) (bool, error) {
+func (octree *BasicOctree) EncompassedBy(geom spatialmath.Geometry, collisionBuffer float64) (bool, error) {
 	return false, errors.New("not implemented")
 }
 

--- a/pointcloud/basic_octree.go
+++ b/pointcloud/basic_octree.go
@@ -262,8 +262,8 @@ func (octree *BasicOctree) CollidesWith(geom spatialmath.Geometry, collisionBuff
 
 // DistanceFrom returns the distance from the given octree to the given geometry.
 // TODO (RSDK-3743): Implement BasicOctree Geometry functions.
-func (octree *BasicOctree) DistanceFrom(geom spatialmath.Geometry, collisionBufferMM float64) (float64, error) {
-	collides, err := octree.CollidesWith(geom, collisionBufferMM)
+func (octree *BasicOctree) DistanceFrom(geom spatialmath.Geometry) (float64, error) {
+	collides, err := octree.CollidesWith(geom, floatEpsilon)
 	if err != nil {
 		return math.Inf(1), err
 	}
@@ -275,7 +275,7 @@ func (octree *BasicOctree) DistanceFrom(geom spatialmath.Geometry, collisionBuff
 
 // EncompassedBy returns true if the given octree is within the given geometry.
 // TODO (RSDK-3743): Implement BasicOctree Geometry functions.
-func (octree *BasicOctree) EncompassedBy(geom spatialmath.Geometry, collisionBufferMM float64) (bool, error) {
+func (octree *BasicOctree) EncompassedBy(geom spatialmath.Geometry) (bool, error) {
 	return false, errors.New("not implemented")
 }
 

--- a/pointcloud/basic_octree.go
+++ b/pointcloud/basic_octree.go
@@ -204,7 +204,7 @@ func (octree *BasicOctree) CollidesWithGeometry(
 	geom spatialmath.Geometry,
 	confidenceThreshold int,
 	buffer,
-	collisionBuffer float64,
+	collisionBufferMM float64,
 ) (bool, error) {
 	if octree.MaxVal() < confidenceThreshold {
 		return false, nil
@@ -221,7 +221,7 @@ func (octree *BasicOctree) CollidesWithGeometry(
 		}
 
 		// Check whether our geom collides with the area represented by the octree. If false, we can skip
-		collide, err := geom.CollidesWith(ocbox, collisionBuffer)
+		collide, err := geom.CollidesWith(ocbox, collisionBufferMM)
 		if err != nil {
 			return false, err
 		}
@@ -229,7 +229,7 @@ func (octree *BasicOctree) CollidesWithGeometry(
 			return false, nil
 		}
 		for _, child := range octree.node.children {
-			collide, err = child.CollidesWithGeometry(geom, confidenceThreshold, buffer, collisionBuffer)
+			collide, err = child.CollidesWithGeometry(geom, confidenceThreshold, buffer, collisionBufferMM)
 			if err != nil {
 				return false, err
 			}
@@ -246,7 +246,7 @@ func (octree *BasicOctree) CollidesWithGeometry(
 			return false, err
 		}
 
-		ptCollide, err := geom.CollidesWith(ptGeom, collisionBuffer)
+		ptCollide, err := geom.CollidesWith(ptGeom, collisionBufferMM)
 		if err != nil {
 			return false, err
 		}
@@ -256,14 +256,14 @@ func (octree *BasicOctree) CollidesWithGeometry(
 }
 
 // CollidesWith checks if the given octree collides with the given geometry and returns true if it does.
-func (octree *BasicOctree) CollidesWith(geom spatialmath.Geometry, collisionBuffer float64) (bool, error) {
-	return octree.CollidesWithGeometry(geom, confidenceThreshold, buffer, collisionBuffer)
+func (octree *BasicOctree) CollidesWith(geom spatialmath.Geometry, collisionBufferMM float64) (bool, error) {
+	return octree.CollidesWithGeometry(geom, confidenceThreshold, buffer, collisionBufferMM)
 }
 
 // DistanceFrom returns the distance from the given octree to the given geometry.
 // TODO (RSDK-3743): Implement BasicOctree Geometry functions.
-func (octree *BasicOctree) DistanceFrom(geom spatialmath.Geometry, collisionBuffer float64) (float64, error) {
-	collides, err := octree.CollidesWith(geom, collisionBuffer)
+func (octree *BasicOctree) DistanceFrom(geom spatialmath.Geometry, collisionBufferMM float64) (float64, error) {
+	collides, err := octree.CollidesWith(geom, collisionBufferMM)
 	if err != nil {
 		return math.Inf(1), err
 	}
@@ -275,7 +275,7 @@ func (octree *BasicOctree) DistanceFrom(geom spatialmath.Geometry, collisionBuff
 
 // EncompassedBy returns true if the given octree is within the given geometry.
 // TODO (RSDK-3743): Implement BasicOctree Geometry functions.
-func (octree *BasicOctree) EncompassedBy(geom spatialmath.Geometry, collisionBuffer float64) (bool, error) {
+func (octree *BasicOctree) EncompassedBy(geom spatialmath.Geometry, collisionBufferMM float64) (bool, error) {
 	return false, errors.New("not implemented")
 }
 

--- a/pointcloud/basic_octree_utils_test.go
+++ b/pointcloud/basic_octree_utils_test.go
@@ -330,7 +330,7 @@ func TestBasicOctreeCollision(t *testing.T) {
 		// create a non-colliding obstacle far away from any octree point
 		far, err := spatialmath.NewBox(spatialmath.NewZeroPose(), r3.Vector{1, 2, 3}, "far")
 		test.That(t, err, test.ShouldBeNil)
-		collides, err := basicOct.CollidesWithGeometry(far, 80, 1.0)
+		collides, err := basicOct.CollidesWithGeometry(far, 80, 1.0, 1e-8)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, collides, test.ShouldBeFalse)
 	})
@@ -339,7 +339,7 @@ func TestBasicOctreeCollision(t *testing.T) {
 		// create a non-colliding obstacle near an octree point
 		near, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{-2443, 0, 3855}), r3.Vector{1, 2, 3}, "near")
 		test.That(t, err, test.ShouldBeNil)
-		collides, err := basicOct.CollidesWithGeometry(near, 80, 1.0)
+		collides, err := basicOct.CollidesWithGeometry(near, 80, 1.0, 1e-8)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, collides, test.ShouldBeFalse)
 	})
@@ -348,7 +348,7 @@ func TestBasicOctreeCollision(t *testing.T) {
 		// create a non-colliding obstacle near an octree point
 		near, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{-2443, 0, 3855}), r3.Vector{1, 2, 3}, "near")
 		test.That(t, err, test.ShouldBeNil)
-		collides, err := basicOct.CollidesWithGeometry(near, 80, 10.0)
+		collides, err := basicOct.CollidesWithGeometry(near, 80, 10.0, 1e-8)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, collides, test.ShouldBeTrue)
 	})
@@ -357,7 +357,7 @@ func TestBasicOctreeCollision(t *testing.T) {
 		// create a colliding obstacle overlapping an octree point that has sub-threshold probability
 		lowprob, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{-2471, 0, 3790}), r3.Vector{3, 2, 3}, "lowprob")
 		test.That(t, err, test.ShouldBeNil)
-		collides, err := basicOct.CollidesWithGeometry(lowprob, 80, 1.0)
+		collides, err := basicOct.CollidesWithGeometry(lowprob, 80, 1.0, 1e-8)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, collides, test.ShouldBeFalse)
 	})
@@ -366,7 +366,7 @@ func TestBasicOctreeCollision(t *testing.T) {
 		// create a colliding obstacle overlapping an octree point
 		hit, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{-2443, 0, 3855}), r3.Vector{12, 2, 30}, "hit")
 		test.That(t, err, test.ShouldBeNil)
-		collides, err := basicOct.CollidesWithGeometry(hit, 80, 1.0)
+		collides, err := basicOct.CollidesWithGeometry(hit, 80, 1.0, 1e-8)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, collides, test.ShouldBeTrue)
 	})

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -2011,6 +2011,7 @@ func TestMoveOnMapNew(t *testing.T) {
 		test.That(t, err, test.ShouldBeError, errors.New("no need to move, already within planDeviationMM"))
 		test.That(t, executionID, test.ShouldResemble, uuid.Nil)
 	})
+
 	t.Run("pass when within plan dev m of goal without position_only due to theta difference in goal", func(t *testing.T) {
 		_, ms := createMoveOnMapEnvironment(ctx, t, "pointcloud/octagonspace.pcd", 40, nil)
 		defer ms.Close(ctx)
@@ -2268,13 +2269,147 @@ func TestMoveCallInputs(t *testing.T) {
 			test.That(t, err, test.ShouldBeError, errors.New("LinearMPerSec may not be NaN"))
 			test.That(t, executionID, test.ShouldResemble, uuid.Nil)
 		})
+
+		t.Run("collision_buffer_mm validtations", func(t *testing.T) {
+			t.Run("fail when collision_buffer_mm is not a float", func(t *testing.T) {
+				_, ms := createMoveOnMapEnvironment(ctx, t, "pointcloud/octagonspace.pcd", 40, nil)
+				defer ms.Close(ctx)
+
+				req := motion.MoveOnMapReq{
+					ComponentName: base.Named("test-base"),
+					Destination:   spatialmath.NewZeroPose(),
+					SlamName:      slam.Named("test_slam"),
+					MotionCfg:     &motion.MotionConfiguration{},
+					Extra:         map[string]interface{}{"collision_buffer_mm": "not a float"},
+				}
+
+				timeoutCtx, timeoutFn := context.WithTimeout(ctx, time.Second*5)
+				defer timeoutFn()
+				executionID, err := ms.(*builtIn).MoveOnMapNew(timeoutCtx, req)
+				test.That(t, err, test.ShouldBeError, errors.New("could not interpret collision_buffer_mm field as float64"))
+				test.That(t, executionID, test.ShouldNotBeEmpty)
+			})
+
+			t.Run("fail when collision_buffer_mm is negative", func(t *testing.T) {
+				_, ms := createMoveOnMapEnvironment(ctx, t, "pointcloud/octagonspace.pcd", 40, nil)
+				defer ms.Close(ctx)
+
+				req := motion.MoveOnMapReq{
+					ComponentName: base.Named("test-base"),
+					Destination:   spatialmath.NewZeroPose(),
+					SlamName:      slam.Named("test_slam"),
+					MotionCfg:     &motion.MotionConfiguration{},
+					Extra:         map[string]interface{}{"collision_buffer_mm": -1.},
+				}
+
+				timeoutCtx, timeoutFn := context.WithTimeout(ctx, time.Second*5)
+				defer timeoutFn()
+				executionID, err := ms.(*builtIn).MoveOnMapNew(timeoutCtx, req)
+				test.That(t, err, test.ShouldBeError, errors.New("collision_buffer_mm can't be negative"))
+				test.That(t, executionID, test.ShouldResemble, uuid.Nil)
+			})
+
+			t.Run("fail when collisions are predicted within the collision buffer", func(t *testing.T) {
+				_, ms := createMoveOnMapEnvironment(ctx, t, "pointcloud/octagonspace.pcd", 40, nil)
+				defer ms.Close(ctx)
+
+				req := motion.MoveOnMapReq{
+					ComponentName: base.Named("test-base"),
+					Destination:   spatialmath.NewZeroPose(),
+					SlamName:      slam.Named("test_slam"),
+					MotionCfg:     &motion.MotionConfiguration{},
+					Extra:         map[string]interface{}{"collision_buffer_mm": 200.},
+				}
+
+				timeoutCtx, timeoutFn := context.WithTimeout(ctx, time.Second*5)
+				defer timeoutFn()
+				executionID, err := ms.(*builtIn).MoveOnMapNew(timeoutCtx, req)
+				test.That(t, err, test.ShouldBeError, errors.New("starting collision between SLAM map and unnamedCollisionGeometry_0, cannot move"))
+				test.That(t, executionID, test.ShouldResemble, uuid.Nil)
+			})
+
+			t.Run("pass when collision_buffer_mm is a small positive float", func(t *testing.T) {
+				_, ms := createMoveOnMapEnvironment(ctx, t, "pointcloud/octagonspace.pcd", 40, nil)
+				defer ms.Close(ctx)
+
+				req := motion.MoveOnMapReq{
+					ComponentName: base.Named("test-base"),
+					Destination:   spatialmath.NewZeroPose(),
+					SlamName:      slam.Named("test_slam"),
+					MotionCfg:     &motion.MotionConfiguration{},
+					Extra:         map[string]interface{}{"collision_buffer_mm": 1e-5},
+				}
+
+				timeoutCtx, timeoutFn := context.WithTimeout(ctx, time.Second*5)
+				defer timeoutFn()
+				executionID, err := ms.(*builtIn).MoveOnMapNew(timeoutCtx, req)
+				test.That(t, err, test.ShouldBeNil)
+				test.That(t, executionID, test.ShouldNotResemble, uuid.Nil)
+			})
+
+			t.Run("pass when collision_buffer_mm is a positive float", func(t *testing.T) {
+				_, ms := createMoveOnMapEnvironment(ctx, t, "pointcloud/octagonspace.pcd", 40, nil)
+				defer ms.Close(ctx)
+
+				req := motion.MoveOnMapReq{
+					ComponentName: base.Named("test-base"),
+					Destination:   spatialmath.NewZeroPose(),
+					SlamName:      slam.Named("test_slam"),
+					MotionCfg:     &motion.MotionConfiguration{},
+					Extra:         map[string]interface{}{"collision_buffer_mm": 0.1},
+				}
+
+				timeoutCtx, timeoutFn := context.WithTimeout(ctx, time.Second*5)
+				defer timeoutFn()
+				executionID, err := ms.(*builtIn).MoveOnMapNew(timeoutCtx, req)
+				test.That(t, err, test.ShouldBeNil)
+				test.That(t, executionID, test.ShouldNotResemble, uuid.Nil)
+			})
+
+			t.Run("pass when extra is empty", func(t *testing.T) {
+				_, ms := createMoveOnMapEnvironment(ctx, t, "pointcloud/octagonspace.pcd", 40, nil)
+				defer ms.Close(ctx)
+
+				req := motion.MoveOnMapReq{
+					ComponentName: base.Named("test-base"),
+					Destination:   spatialmath.NewZeroPose(),
+					SlamName:      slam.Named("test_slam"),
+					MotionCfg:     &motion.MotionConfiguration{},
+					Extra:         map[string]interface{}{},
+				}
+
+				timeoutCtx, timeoutFn := context.WithTimeout(ctx, time.Second*5)
+				defer timeoutFn()
+				executionID, err := ms.(*builtIn).MoveOnMapNew(timeoutCtx, req)
+				test.That(t, err, test.ShouldBeNil)
+				test.That(t, executionID, test.ShouldNotResemble, uuid.Nil)
+			})
+
+			t.Run("passes validations when extra is nil", func(t *testing.T) {
+				_, ms := createMoveOnMapEnvironment(ctx, t, "pointcloud/octagonspace.pcd", 40, nil)
+				defer ms.Close(ctx)
+
+				req := motion.MoveOnMapReq{
+					ComponentName: base.Named("test-base"),
+					Destination:   spatialmath.NewZeroPose(),
+					SlamName:      slam.Named("test_slam"),
+					MotionCfg:     &motion.MotionConfiguration{},
+				}
+
+				timeoutCtx, timeoutFn := context.WithTimeout(ctx, time.Second*5)
+				defer timeoutFn()
+				executionID, err := ms.(*builtIn).MoveOnMapNew(timeoutCtx, req)
+				test.That(t, err, test.ShouldBeNil)
+				test.That(t, executionID, test.ShouldNotResemble, uuid.Nil)
+			})
+		})
 	})
 
 	t.Run("MoveOnGlobe", func(t *testing.T) {
 		t.Parallel()
 		// Near antarctica 🐧
 		gpsPoint := geo.NewPoint(-70, 40)
-		dst := geo.NewPoint(gpsPoint.Lat(), gpsPoint.Lng()+1e-5)
+		dst := geo.NewPoint(gpsPoint.Lat(), gpsPoint.Lng()+1e-4)
 		// create motion config
 		extra := map[string]interface{}{
 			"motion_profile": "position_only",
@@ -2551,6 +2686,103 @@ func TestMoveCallInputs(t *testing.T) {
 			executionID, err := ms.MoveOnGlobe(ctx, req)
 			test.That(t, err, test.ShouldBeError, errors.New("LinearMPerSec may not be NaN"))
 			test.That(t, executionID, test.ShouldResemble, uuid.Nil)
+		})
+
+		t.Run("collision_buffer_mm validtations", func(t *testing.T) {
+			t.Run("fail when collision_buffer_mm is not a float", func(t *testing.T) {
+				injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil, 5)
+				defer ms.Close(ctx)
+				req := motion.MoveOnGlobeReq{
+					ComponentName:      fakeBase.Name(),
+					MovementSensorName: injectedMovementSensor.Name(),
+					Heading:            90,
+					Destination:        dst,
+					MotionCfg:          &motion.MotionConfiguration{},
+					Extra:              map[string]interface{}{"collision_buffer_mm": "not a float"},
+				}
+				executionID, err := ms.MoveOnGlobe(ctx, req)
+				test.That(t, err, test.ShouldBeError, errors.New("could not interpret collision_buffer_mm field as float64"))
+				test.That(t, executionID, test.ShouldResemble, uuid.Nil)
+			})
+
+			t.Run("fail when collision_buffer_mm is negative", func(t *testing.T) {
+				injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil, 5)
+				defer ms.Close(ctx)
+				req := motion.MoveOnGlobeReq{
+					ComponentName:      fakeBase.Name(),
+					MovementSensorName: injectedMovementSensor.Name(),
+					Heading:            90,
+					Destination:        dst,
+					MotionCfg:          &motion.MotionConfiguration{},
+					Extra:              map[string]interface{}{"collision_buffer_mm": -1.},
+				}
+				executionID, err := ms.MoveOnGlobe(ctx, req)
+				test.That(t, err, test.ShouldBeError, errors.New("collision_buffer_mm can't be negative"))
+				test.That(t, executionID, test.ShouldResemble, uuid.Nil)
+			})
+
+			t.Run("pass when collision_buffer_mm is a small positive float", func(t *testing.T) {
+				injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil, 5)
+				defer ms.Close(ctx)
+				req := motion.MoveOnGlobeReq{
+					ComponentName:      fakeBase.Name(),
+					MovementSensorName: injectedMovementSensor.Name(),
+					Heading:            90,
+					Destination:        dst,
+					MotionCfg:          &motion.MotionConfiguration{},
+					Extra:              map[string]interface{}{"collision_buffer_mm": 1e-5},
+				}
+				executionID, err := ms.MoveOnGlobe(ctx, req)
+				test.That(t, err, test.ShouldBeNil)
+				test.That(t, executionID, test.ShouldNotResemble, uuid.Nil)
+			})
+
+			t.Run("pass when collision_buffer_mm is a positive float", func(t *testing.T) {
+				injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil, 5)
+				defer ms.Close(ctx)
+				req := motion.MoveOnGlobeReq{
+					ComponentName:      fakeBase.Name(),
+					MovementSensorName: injectedMovementSensor.Name(),
+					Heading:            90,
+					Destination:        dst,
+					MotionCfg:          &motion.MotionConfiguration{},
+					Extra:              map[string]interface{}{"collision_buffer_mm": 10.},
+				}
+				executionID, err := ms.MoveOnGlobe(ctx, req)
+				test.That(t, err, test.ShouldBeNil)
+				test.That(t, executionID, test.ShouldNotResemble, uuid.Nil)
+			})
+
+			t.Run("pass when extra is empty", func(t *testing.T) {
+				injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil, 5)
+				defer ms.Close(ctx)
+				req := motion.MoveOnGlobeReq{
+					ComponentName:      fakeBase.Name(),
+					MovementSensorName: injectedMovementSensor.Name(),
+					Heading:            90,
+					Destination:        dst,
+					MotionCfg:          &motion.MotionConfiguration{},
+					Extra:              map[string]interface{}{},
+				}
+				executionID, err := ms.MoveOnGlobe(ctx, req)
+				test.That(t, err, test.ShouldBeNil)
+				test.That(t, executionID, test.ShouldNotResemble, uuid.Nil)
+			})
+
+			t.Run("passes validations when extra is nil", func(t *testing.T) {
+				injectedMovementSensor, _, fakeBase, ms := createMoveOnGlobeEnvironment(ctx, t, gpsPoint, nil, 5)
+				defer ms.Close(ctx)
+				req := motion.MoveOnGlobeReq{
+					ComponentName:      fakeBase.Name(),
+					MovementSensorName: injectedMovementSensor.Name(),
+					Heading:            90,
+					Destination:        dst,
+					MotionCfg:          &motion.MotionConfiguration{},
+				}
+				executionID, err := ms.MoveOnGlobe(ctx, req)
+				test.That(t, err, test.ShouldBeNil)
+				test.That(t, executionID, test.ShouldNotResemble, uuid.Nil)
+			})
 		})
 	})
 }

--- a/services/motion/explore/explore_test.go
+++ b/services/motion/explore/explore_test.go
@@ -22,11 +22,12 @@ import (
 )
 
 var (
-	testBaseName         = resource.NewName(base.API, "test_base")
-	testCameraName1      = resource.NewName(camera.API, "test_camera1")
-	testCameraName2      = resource.NewName(camera.API, "test_camera2")
-	testFrameServiceName = resource.NewName(framesystem.API, "test_fs")
-	defaultMotionCfg     = motion.MotionConfiguration{
+	testBaseName             = resource.NewName(base.API, "test_base")
+	testCameraName1          = resource.NewName(camera.API, "test_camera1")
+	testCameraName2          = resource.NewName(camera.API, "test_camera2")
+	testFrameServiceName     = resource.NewName(framesystem.API, "test_fs")
+	defaultCollisionBufferMM = 1e-8
+	defaultMotionCfg         = motion.MotionConfiguration{
 		AngularDegsPerSec:     0.25,
 		LinearMPerSec:         0.1,
 		ObstaclePollingFreqHz: 2,
@@ -229,7 +230,7 @@ func TestExploreCheckForObstacles(t *testing.T) {
 				test.That(t, err, test.ShouldBeNil)
 
 				for _, obs := range tt.obstacle {
-					collisionDetected, err := geometriesContainsPoint(obstacles.Geometries(), obs.position)
+					collisionDetected, err := geometriesContainsPoint(obstacles.Geometries(), obs.position, defaultCollisionBufferMM)
 					test.That(t, err, test.ShouldBeNil)
 					test.That(t, collisionDetected, test.ShouldBeTrue)
 				}

--- a/services/motion/explore/explore_utils_test.go
+++ b/services/motion/explore/explore_utils_test.go
@@ -164,7 +164,7 @@ func createCameraLink(camName, baseFrame string) (*referenceframe.LinkInFrame, e
 }
 
 // geometriesContainsPoint is a helper function to test if a point is in a given geometry.
-func geometriesContainsPoint(geometries []spatialmath.Geometry, point r3.Vector, collisionBuffer float64) (bool, error) {
+func geometriesContainsPoint(geometries []spatialmath.Geometry, point r3.Vector, collisionBufferMM float64) (bool, error) {
 	var collisionDetected bool
 	for _, geo := range geometries {
 		pointGeoCfg := spatialmath.GeometryConfig{
@@ -175,7 +175,7 @@ func geometriesContainsPoint(geometries []spatialmath.Geometry, point r3.Vector,
 		if err != nil {
 			return false, err
 		}
-		collides, err := geo.CollidesWith(pointGeo, collisionBuffer)
+		collides, err := geo.CollidesWith(pointGeo, collisionBufferMM)
 		if err != nil {
 			return false, err
 		}

--- a/services/motion/explore/explore_utils_test.go
+++ b/services/motion/explore/explore_utils_test.go
@@ -164,7 +164,7 @@ func createCameraLink(camName, baseFrame string) (*referenceframe.LinkInFrame, e
 }
 
 // geometriesContainsPoint is a helper function to test if a point is in a given geometry.
-func geometriesContainsPoint(geometries []spatialmath.Geometry, point r3.Vector) (bool, error) {
+func geometriesContainsPoint(geometries []spatialmath.Geometry, point r3.Vector, collisionBuffer float64) (bool, error) {
 	var collisionDetected bool
 	for _, geo := range geometries {
 		pointGeoCfg := spatialmath.GeometryConfig{
@@ -175,7 +175,7 @@ func geometriesContainsPoint(geometries []spatialmath.Geometry, point r3.Vector)
 		if err != nil {
 			return false, err
 		}
-		collides, err := geo.CollidesWith(pointGeo)
+		collides, err := geo.CollidesWith(pointGeo, collisionBuffer)
 		if err != nil {
 			return false, err
 		}

--- a/spatialmath/box.go
+++ b/spatialmath/box.go
@@ -311,7 +311,7 @@ func boxVsBoxDistance(a, b *box) float64 {
 	centerDist := b.pose.Point().Sub(a.pose.Point())
 
 	// check if there is a distance between bounding spheres to potentially exit early
-	if boundingSphereDist := centerDist.Norm() - a.boundingSphereR - b.boundingSphereR; boundingSphereDist > defaultCollisionBuffer {
+	if boundingSphereDist := centerDist.Norm() - a.boundingSphereR - b.boundingSphereR; boundingSphereDist > defaultCollisionBufferMM {
 		return boundingSphereDist
 	}
 
@@ -352,7 +352,7 @@ func boxVsBoxDistance(a, b *box) float64 {
 // boxInBox returns a bool describing if the inner box is completely encompassed by the outer box.
 func boxInBox(inner, outer *box) bool {
 	for _, vertex := range inner.vertices() {
-		if !pointVsBoxCollision(vertex, outer, defaultCollisionBuffer) {
+		if !pointVsBoxCollision(vertex, outer, defaultCollisionBufferMM) {
 			return false
 		}
 	}
@@ -362,7 +362,7 @@ func boxInBox(inner, outer *box) bool {
 // boxInSphere returns a bool describing if the given box is completely encompassed by the given sphere.
 func boxInSphere(b *box, s *sphere) bool {
 	for _, vertex := range b.vertices() {
-		if sphereVsPointDistance(s, vertex) > defaultCollisionBuffer {
+		if sphereVsPointDistance(s, vertex) > defaultCollisionBufferMM {
 			return false
 		}
 	}
@@ -372,7 +372,7 @@ func boxInSphere(b *box, s *sphere) bool {
 // boxInCapsule returns a bool describing if the given box is completely encompassed by the given capsule.
 func boxInCapsule(b *box, c *capsule) bool {
 	for _, vertex := range b.vertices() {
-		if capsuleVsPointDistance(c, vertex) > defaultCollisionBuffer {
+		if capsuleVsPointDistance(c, vertex) > defaultCollisionBufferMM {
 			return false
 		}
 	}

--- a/spatialmath/box.go
+++ b/spatialmath/box.go
@@ -145,31 +145,31 @@ func (b *box) ToProtobuf() *commonpb.Geometry {
 }
 
 // CollidesWith checks if the given box collides with the given geometry and returns true if it does.
-func (b *box) CollidesWith(g Geometry, collisionBuffer float64) (bool, error) {
+func (b *box) CollidesWith(g Geometry, collisionBufferMM float64) (bool, error) {
 	if other, ok := g.(*box); ok {
-		return boxVsBoxCollision(b, other, collisionBuffer), nil
+		return boxVsBoxCollision(b, other, collisionBufferMM), nil
 	}
 	if other, ok := g.(*sphere); ok {
-		return sphereVsBoxCollision(other, b, collisionBuffer), nil
+		return sphereVsBoxCollision(other, b, collisionBufferMM), nil
 	}
 	if other, ok := g.(*capsule); ok {
-		return capsuleVsBoxCollision(other, b, collisionBuffer), nil
+		return capsuleVsBoxCollision(other, b, collisionBufferMM), nil
 	}
 	if other, ok := g.(*point); ok {
-		return pointVsBoxCollision(other.position, b, collisionBuffer), nil
+		return pointVsBoxCollision(other.position, b, collisionBufferMM), nil
 	}
 	return true, newCollisionTypeUnsupportedError(b, g)
 }
 
-func (b *box) DistanceFrom(g Geometry, collisionBuffer float64) (float64, error) {
+func (b *box) DistanceFrom(g Geometry, collisionBufferMM float64) (float64, error) {
 	if other, ok := g.(*box); ok {
-		return boxVsBoxDistance(b, other, collisionBuffer), nil
+		return boxVsBoxDistance(b, other, collisionBufferMM), nil
 	}
 	if other, ok := g.(*sphere); ok {
 		return sphereVsBoxDistance(other, b), nil
 	}
 	if other, ok := g.(*capsule); ok {
-		return capsuleVsBoxDistance(other, b, collisionBuffer), nil
+		return capsuleVsBoxDistance(other, b, collisionBufferMM), nil
 	}
 	if other, ok := g.(*point); ok {
 		return pointVsBoxDistance(other.position, b), nil
@@ -177,15 +177,15 @@ func (b *box) DistanceFrom(g Geometry, collisionBuffer float64) (float64, error)
 	return math.Inf(-1), newCollisionTypeUnsupportedError(b, g)
 }
 
-func (b *box) EncompassedBy(g Geometry, collisionBuffer float64) (bool, error) {
+func (b *box) EncompassedBy(g Geometry, collisionBufferMM float64) (bool, error) {
 	if other, ok := g.(*box); ok {
-		return boxInBox(b, other, collisionBuffer), nil
+		return boxInBox(b, other, collisionBufferMM), nil
 	}
 	if other, ok := g.(*sphere); ok {
-		return boxInSphere(b, other, collisionBuffer), nil
+		return boxInSphere(b, other, collisionBufferMM), nil
 	}
 	if other, ok := g.(*capsule); ok {
-		return boxInCapsule(b, other, collisionBuffer), nil
+		return boxInCapsule(b, other, collisionBufferMM), nil
 	}
 	if _, ok := g.(*point); ok {
 		return false, nil
@@ -265,11 +265,11 @@ func (b *box) rotationMatrix() *RotationMatrix {
 // boxVsBoxCollision takes two boxes as arguments and returns a bool describing if they are in collision,
 // true == collision / false == no collision.
 // Since the separating axis test can exit early if no collision is found, it is efficient to avoid calling boxVsBoxDistance.
-func boxVsBoxCollision(a, b *box, collisionBuffer float64) bool {
+func boxVsBoxCollision(a, b *box, collisionBufferMM float64) bool {
 	centerDist := b.pose.Point().Sub(a.pose.Point())
 
 	// check if there is a distance between bounding spheres to potentially exit early
-	if centerDist.Norm()-(a.boundingSphereR+b.boundingSphereR) > collisionBuffer {
+	if centerDist.Norm()-(a.boundingSphereR+b.boundingSphereR) > collisionBufferMM {
 		return false
 	}
 
@@ -277,10 +277,10 @@ func boxVsBoxCollision(a, b *box, collisionBuffer float64) bool {
 	rmB := b.rotationMatrix()
 
 	for i := 0; i < 3; i++ {
-		if separatingAxisTest(centerDist, rmA.Row(i), a.halfSize, b.halfSize, rmA, rmB) > collisionBuffer {
+		if separatingAxisTest(centerDist, rmA.Row(i), a.halfSize, b.halfSize, rmA, rmB) > collisionBufferMM {
 			return false
 		}
-		if separatingAxisTest(centerDist, rmB.Row(i), a.halfSize, b.halfSize, rmA, rmB) > collisionBuffer {
+		if separatingAxisTest(centerDist, rmB.Row(i), a.halfSize, b.halfSize, rmA, rmB) > collisionBufferMM {
 			return false
 		}
 		for j := 0; j < 3; j++ {
@@ -288,7 +288,7 @@ func boxVsBoxCollision(a, b *box, collisionBuffer float64) bool {
 
 			// if edges are parallel, this check is already accounted for by one of the face projections, so skip this case
 			if !utils.Float64AlmostEqual(crossProductPlane.Norm(), 0, floatEpsilon) {
-				if separatingAxisTest(centerDist, crossProductPlane, a.halfSize, b.halfSize, rmA, rmB) > collisionBuffer {
+				if separatingAxisTest(centerDist, crossProductPlane, a.halfSize, b.halfSize, rmA, rmB) > collisionBufferMM {
 					return false
 				}
 			}
@@ -307,11 +307,11 @@ func boxVsBoxCollision(a, b *box, collisionBuffer float64) bool {
 // references:  https://comp.graphics.algorithms.narkive.com/jRAgjIUh/obb-obb-distance-calculation
 //
 //	https://dyn4j.org/2010/01/sat/#sat-nointer
-func boxVsBoxDistance(a, b *box, collisionBuffer float64) float64 {
+func boxVsBoxDistance(a, b *box, collisionBufferMM float64) float64 {
 	centerDist := b.pose.Point().Sub(a.pose.Point())
 
 	// check if there is a distance between bounding spheres to potentially exit early
-	if boundingSphereDist := centerDist.Norm() - a.boundingSphereR - b.boundingSphereR; boundingSphereDist > collisionBuffer {
+	if boundingSphereDist := centerDist.Norm() - a.boundingSphereR - b.boundingSphereR; boundingSphereDist > collisionBufferMM {
 		return boundingSphereDist
 	}
 
@@ -350,9 +350,9 @@ func boxVsBoxDistance(a, b *box, collisionBuffer float64) float64 {
 }
 
 // boxInBox returns a bool describing if the inner box is completely encompassed by the outer box.
-func boxInBox(inner, outer *box, collisionBuffer float64) bool {
+func boxInBox(inner, outer *box, collisionBufferMM float64) bool {
 	for _, vertex := range inner.vertices() {
-		if !pointVsBoxCollision(vertex, outer, collisionBuffer) {
+		if !pointVsBoxCollision(vertex, outer, collisionBufferMM) {
 			return false
 		}
 	}
@@ -360,9 +360,9 @@ func boxInBox(inner, outer *box, collisionBuffer float64) bool {
 }
 
 // boxInSphere returns a bool describing if the given box is completely encompassed by the given sphere.
-func boxInSphere(b *box, s *sphere, collisionBuffer float64) bool {
+func boxInSphere(b *box, s *sphere, collisionBufferMM float64) bool {
 	for _, vertex := range b.vertices() {
-		if sphereVsPointDistance(s, vertex) > collisionBuffer {
+		if sphereVsPointDistance(s, vertex) > collisionBufferMM {
 			return false
 		}
 	}
@@ -370,9 +370,9 @@ func boxInSphere(b *box, s *sphere, collisionBuffer float64) bool {
 }
 
 // boxInCapsule returns a bool describing if the given box is completely encompassed by the given capsule.
-func boxInCapsule(b *box, c *capsule, collisionBuffer float64) bool {
+func boxInCapsule(b *box, c *capsule, collisionBufferMM float64) bool {
 	for _, vertex := range b.vertices() {
-		if capsuleVsPointDistance(c, vertex) > collisionBuffer {
+		if capsuleVsPointDistance(c, vertex) > collisionBufferMM {
 			return false
 		}
 	}

--- a/spatialmath/box.go
+++ b/spatialmath/box.go
@@ -161,15 +161,15 @@ func (b *box) CollidesWith(g Geometry, collisionBufferMM float64) (bool, error) 
 	return true, newCollisionTypeUnsupportedError(b, g)
 }
 
-func (b *box) DistanceFrom(g Geometry, collisionBufferMM float64) (float64, error) {
+func (b *box) DistanceFrom(g Geometry) (float64, error) {
 	if other, ok := g.(*box); ok {
-		return boxVsBoxDistance(b, other, collisionBufferMM), nil
+		return boxVsBoxDistance(b, other), nil
 	}
 	if other, ok := g.(*sphere); ok {
 		return sphereVsBoxDistance(other, b), nil
 	}
 	if other, ok := g.(*capsule); ok {
-		return capsuleVsBoxDistance(other, b, collisionBufferMM), nil
+		return capsuleVsBoxDistance(other, b), nil
 	}
 	if other, ok := g.(*point); ok {
 		return pointVsBoxDistance(other.position, b), nil
@@ -177,15 +177,15 @@ func (b *box) DistanceFrom(g Geometry, collisionBufferMM float64) (float64, erro
 	return math.Inf(-1), newCollisionTypeUnsupportedError(b, g)
 }
 
-func (b *box) EncompassedBy(g Geometry, collisionBufferMM float64) (bool, error) {
+func (b *box) EncompassedBy(g Geometry) (bool, error) {
 	if other, ok := g.(*box); ok {
-		return boxInBox(b, other, collisionBufferMM), nil
+		return boxInBox(b, other), nil
 	}
 	if other, ok := g.(*sphere); ok {
-		return boxInSphere(b, other, collisionBufferMM), nil
+		return boxInSphere(b, other), nil
 	}
 	if other, ok := g.(*capsule); ok {
-		return boxInCapsule(b, other, collisionBufferMM), nil
+		return boxInCapsule(b, other), nil
 	}
 	if _, ok := g.(*point); ok {
 		return false, nil
@@ -307,11 +307,11 @@ func boxVsBoxCollision(a, b *box, collisionBufferMM float64) bool {
 // references:  https://comp.graphics.algorithms.narkive.com/jRAgjIUh/obb-obb-distance-calculation
 //
 //	https://dyn4j.org/2010/01/sat/#sat-nointer
-func boxVsBoxDistance(a, b *box, collisionBufferMM float64) float64 {
+func boxVsBoxDistance(a, b *box) float64 {
 	centerDist := b.pose.Point().Sub(a.pose.Point())
 
 	// check if there is a distance between bounding spheres to potentially exit early
-	if boundingSphereDist := centerDist.Norm() - a.boundingSphereR - b.boundingSphereR; boundingSphereDist > collisionBufferMM {
+	if boundingSphereDist := centerDist.Norm() - a.boundingSphereR - b.boundingSphereR; boundingSphereDist > defaultCollisionBuffer {
 		return boundingSphereDist
 	}
 
@@ -350,9 +350,9 @@ func boxVsBoxDistance(a, b *box, collisionBufferMM float64) float64 {
 }
 
 // boxInBox returns a bool describing if the inner box is completely encompassed by the outer box.
-func boxInBox(inner, outer *box, collisionBufferMM float64) bool {
+func boxInBox(inner, outer *box) bool {
 	for _, vertex := range inner.vertices() {
-		if !pointVsBoxCollision(vertex, outer, collisionBufferMM) {
+		if !pointVsBoxCollision(vertex, outer, defaultCollisionBuffer) {
 			return false
 		}
 	}
@@ -360,9 +360,9 @@ func boxInBox(inner, outer *box, collisionBufferMM float64) bool {
 }
 
 // boxInSphere returns a bool describing if the given box is completely encompassed by the given sphere.
-func boxInSphere(b *box, s *sphere, collisionBufferMM float64) bool {
+func boxInSphere(b *box, s *sphere) bool {
 	for _, vertex := range b.vertices() {
-		if sphereVsPointDistance(s, vertex) > collisionBufferMM {
+		if sphereVsPointDistance(s, vertex) > defaultCollisionBuffer {
 			return false
 		}
 	}
@@ -370,9 +370,9 @@ func boxInSphere(b *box, s *sphere, collisionBufferMM float64) bool {
 }
 
 // boxInCapsule returns a bool describing if the given box is completely encompassed by the given capsule.
-func boxInCapsule(b *box, c *capsule, collisionBufferMM float64) bool {
+func boxInCapsule(b *box, c *capsule) bool {
 	for _, vertex := range b.vertices() {
-		if capsuleVsPointDistance(c, vertex) > collisionBufferMM {
+		if capsuleVsPointDistance(c, vertex) > defaultCollisionBuffer {
 			return false
 		}
 	}

--- a/spatialmath/capsule.go
+++ b/spatialmath/capsule.go
@@ -252,7 +252,7 @@ func capsuleVsBoxDistance(c *capsule, other *box) float64 {
 	dist := capsuleBoxSeparatingAxisDistance(c, other)
 	// Separating axis theorum provides accurate penetration depth but is not accurate for separation
 	// if we are not in collision, convert box to mesh and determine triangle-capsule separation distance
-	if dist > defaultCollisionBuffer {
+	if dist > defaultCollisionBufferMM {
 		return capsuleVsMeshDistance(c, other.toMesh())
 	}
 	return dist
@@ -334,7 +334,7 @@ func capsuleBoxSeparatingAxisDistance(c *capsule, b *box) float64 {
 	centerDist := b.pose.Point().Sub(c.center)
 
 	// check if there is a distance between bounding spheres to potentially exit early
-	if boundingSphereDist := centerDist.Norm() - ((c.length / 2) + b.boundingSphereR); boundingSphereDist > defaultCollisionBuffer {
+	if boundingSphereDist := centerDist.Norm() - ((c.length / 2) + b.boundingSphereR); boundingSphereDist > defaultCollisionBufferMM {
 		return boundingSphereDist
 	}
 	rmA := c.rotationMatrix()

--- a/spatialmath/capsule_test.go
+++ b/spatialmath/capsule_test.go
@@ -19,6 +19,7 @@ func TestCapsuleConstruction(t *testing.T) {
 }
 
 func TestBoxCapsuleCollision(t *testing.T) {
+	collisionBuffer := 1e-8
 	pt := r3.Vector{-178.95551585002903, 15.388321162835881, -10.110465843295357}
 	ov := &OrientationVectorDegrees{OX: -0.43716334939336904, OY: -0.3861114135400337, OZ: -0.812284545144919, Theta: -180}
 	pose := NewPose(pt, ov)
@@ -29,11 +30,11 @@ func TestBoxCapsuleCollision(t *testing.T) {
 	box1, err := NewBox(NewPoseFromPoint(box1Pt), r3.Vector{X: 900, Y: 2000, Z: 100}, "")
 	test.That(t, err, test.ShouldBeNil)
 
-	col, err := c.CollidesWith(box1)
+	col, err := c.CollidesWith(box1, collisionBuffer)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, col, test.ShouldBeTrue)
 
-	dist, err := c.DistanceFrom(box1)
+	dist, err := c.DistanceFrom(box1, collisionBuffer)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, dist, test.ShouldAlmostEqual, -29.69, 1e-3)
 }

--- a/spatialmath/capsule_test.go
+++ b/spatialmath/capsule_test.go
@@ -19,7 +19,6 @@ func TestCapsuleConstruction(t *testing.T) {
 }
 
 func TestBoxCapsuleCollision(t *testing.T) {
-	collisionBufferMM := 1e-8
 	pt := r3.Vector{-178.95551585002903, 15.388321162835881, -10.110465843295357}
 	ov := &OrientationVectorDegrees{OX: -0.43716334939336904, OY: -0.3861114135400337, OZ: -0.812284545144919, Theta: -180}
 	pose := NewPose(pt, ov)
@@ -30,7 +29,7 @@ func TestBoxCapsuleCollision(t *testing.T) {
 	box1, err := NewBox(NewPoseFromPoint(box1Pt), r3.Vector{X: 900, Y: 2000, Z: 100}, "")
 	test.That(t, err, test.ShouldBeNil)
 
-	col, err := c.CollidesWith(box1, collisionBufferMM)
+	col, err := c.CollidesWith(box1, defaultCollisionBufferMM)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, col, test.ShouldBeTrue)
 

--- a/spatialmath/capsule_test.go
+++ b/spatialmath/capsule_test.go
@@ -34,7 +34,7 @@ func TestBoxCapsuleCollision(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, col, test.ShouldBeTrue)
 
-	dist, err := c.DistanceFrom(box1, collisionBufferMM)
+	dist, err := c.DistanceFrom(box1)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, dist, test.ShouldAlmostEqual, -29.69, 1e-3)
 }

--- a/spatialmath/capsule_test.go
+++ b/spatialmath/capsule_test.go
@@ -19,7 +19,7 @@ func TestCapsuleConstruction(t *testing.T) {
 }
 
 func TestBoxCapsuleCollision(t *testing.T) {
-	collisionBuffer := 1e-8
+	collisionBufferMM := 1e-8
 	pt := r3.Vector{-178.95551585002903, 15.388321162835881, -10.110465843295357}
 	ov := &OrientationVectorDegrees{OX: -0.43716334939336904, OY: -0.3861114135400337, OZ: -0.812284545144919, Theta: -180}
 	pose := NewPose(pt, ov)
@@ -30,11 +30,11 @@ func TestBoxCapsuleCollision(t *testing.T) {
 	box1, err := NewBox(NewPoseFromPoint(box1Pt), r3.Vector{X: 900, Y: 2000, Z: 100}, "")
 	test.That(t, err, test.ShouldBeNil)
 
-	col, err := c.CollidesWith(box1, collisionBuffer)
+	col, err := c.CollidesWith(box1, collisionBufferMM)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, col, test.ShouldBeTrue)
 
-	dist, err := c.DistanceFrom(box1, collisionBuffer)
+	dist, err := c.DistanceFrom(box1, collisionBufferMM)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, dist, test.ShouldAlmostEqual, -29.69, 1e-3)
 }

--- a/spatialmath/geometry.go
+++ b/spatialmath/geometry.go
@@ -40,7 +40,7 @@ const (
 	PointType   = GeometryType("point")
 
 	// objects must be separated by this many mm to not be in collision.
-	defaultCollisionBuffer = 1e-8
+	defaultCollisionBufferMM = 1e-8
 
 	// Point density corresponding to how many points per square mm.
 	defaultPointDensity = .5

--- a/spatialmath/geometry.go
+++ b/spatialmath/geometry.go
@@ -19,8 +19,8 @@ type Geometry interface {
 	// If DistanceFrom is negative, it represents the penetration depth of the two geometries, which are in collision.
 	// Penetration depth magnitude is defined as the minimum translation which would result in the geometries not colliding.
 	// For certain entity pairs (box-box) this may be a conservative estimate of separation distance rather than exact.
-	DistanceFrom(Geometry, float64) (float64, error)
-	EncompassedBy(Geometry, float64) (bool, error)
+	DistanceFrom(Geometry) (float64, error)
+	EncompassedBy(Geometry) (bool, error)
 	SetLabel(string) // SetLabel sets the name of the geometry
 	Label() string   // Label is the name of the geometry
 	String() string  // String is a string representation of the geometry data structure
@@ -38,7 +38,9 @@ const (
 	SphereType  = GeometryType("sphere")
 	CapsuleType = GeometryType("capsule")
 	PointType   = GeometryType("point")
-	// CollisionBuffer = 1e-8 // objects must be separated by this many mm to not be in collision.
+
+	// objects must be separated by this many mm to not be in collision.
+	defaultCollisionBuffer = 1e-8
 
 	// Point density corresponding to how many points per square mm.
 	defaultPointDensity = .5

--- a/spatialmath/geometry.go
+++ b/spatialmath/geometry.go
@@ -15,12 +15,12 @@ type Geometry interface {
 	AlmostEqual(Geometry) bool
 	Transform(Pose) Geometry
 	ToProtobuf() *commonpb.Geometry
-	CollidesWith(Geometry) (bool, error)
+	CollidesWith(Geometry, float64) (bool, error)
 	// If DistanceFrom is negative, it represents the penetration depth of the two geometries, which are in collision.
 	// Penetration depth magnitude is defined as the minimum translation which would result in the geometries not colliding.
 	// For certain entity pairs (box-box) this may be a conservative estimate of separation distance rather than exact.
-	DistanceFrom(Geometry) (float64, error)
-	EncompassedBy(Geometry) (bool, error)
+	DistanceFrom(Geometry, float64) (float64, error)
+	EncompassedBy(Geometry, float64) (bool, error)
 	SetLabel(string) // SetLabel sets the name of the geometry
 	Label() string   // Label is the name of the geometry
 	String() string  // String is a string representation of the geometry data structure
@@ -33,12 +33,12 @@ type GeometryType string
 
 // The set of allowed representations for orientation.
 const (
-	UnknownType     = GeometryType("")
-	BoxType         = GeometryType("box")
-	SphereType      = GeometryType("sphere")
-	CapsuleType     = GeometryType("capsule")
-	PointType       = GeometryType("point")
-	CollisionBuffer = 1e-8 // objects must be separated by this many mm to not be in collision
+	UnknownType = GeometryType("")
+	BoxType     = GeometryType("box")
+	SphereType  = GeometryType("sphere")
+	CapsuleType = GeometryType("capsule")
+	PointType   = GeometryType("point")
+	// CollisionBuffer = 1e-8 // objects must be separated by this many mm to not be in collision.
 
 	// Point density corresponding to how many points per square mm.
 	defaultPointDensity = .5

--- a/spatialmath/geometry_test.go
+++ b/spatialmath/geometry_test.go
@@ -96,20 +96,20 @@ type geometryComparisonTestCase struct {
 
 func testGeometryCollision(t *testing.T, cases []geometryComparisonTestCase) {
 	t.Helper()
-	collisionBuffer := 1e-8
+	collisionBufferMM := 1e-8
 	for _, c := range cases {
 		for i := 0; i < 2; i++ {
 			t.Run(fmt.Sprintf("%s %T %T collision", c.testname, c.geometries[i], c.geometries[(i+1)%2]), func(t *testing.T) {
 				fn := test.ShouldBeFalse
-				if c.expected <= collisionBuffer {
+				if c.expected <= collisionBufferMM {
 					fn = test.ShouldBeTrue
 				}
-				collides, err := c.geometries[i].CollidesWith(c.geometries[(i+1)%2], collisionBuffer)
+				collides, err := c.geometries[i].CollidesWith(c.geometries[(i+1)%2], collisionBufferMM)
 				test.That(t, err, test.ShouldBeNil)
 				test.That(t, collides, fn)
 			})
 			t.Run(fmt.Sprintf("%s %T %T distance", c.testname, c.geometries[i], c.geometries[(i+1)%2]), func(t *testing.T) {
-				distance, err := c.geometries[i].DistanceFrom(c.geometries[(i+1)%2], collisionBuffer)
+				distance, err := c.geometries[i].DistanceFrom(c.geometries[(i+1)%2], collisionBufferMM)
 				test.That(t, err, test.ShouldBeNil)
 				test.That(t, distance, test.ShouldAlmostEqual, c.expected, 1e-3)
 			})
@@ -429,14 +429,14 @@ func TestPointVsSphereCollision(t *testing.T) {
 
 func testGeometryEncompassed(t *testing.T, cases []geometryComparisonTestCase) {
 	t.Helper()
-	collisionBuffer := 1e-8
+	collisionBufferMM := 1e-8
 	for _, c := range cases {
 		t.Run(c.testname, func(t *testing.T) {
 			fn := test.ShouldBeTrue
 			if c.expected > 0.0 {
 				fn = test.ShouldBeFalse
 			}
-			collides, err := c.geometries[0].EncompassedBy(c.geometries[1], collisionBuffer)
+			collides, err := c.geometries[0].EncompassedBy(c.geometries[1], collisionBufferMM)
 			test.That(t, err, test.ShouldBeNil)
 			test.That(t, collides, fn)
 		})

--- a/spatialmath/geometry_test.go
+++ b/spatialmath/geometry_test.go
@@ -96,19 +96,20 @@ type geometryComparisonTestCase struct {
 
 func testGeometryCollision(t *testing.T, cases []geometryComparisonTestCase) {
 	t.Helper()
+	collisionBuffer := 1e-8
 	for _, c := range cases {
 		for i := 0; i < 2; i++ {
 			t.Run(fmt.Sprintf("%s %T %T collision", c.testname, c.geometries[i], c.geometries[(i+1)%2]), func(t *testing.T) {
 				fn := test.ShouldBeFalse
-				if c.expected <= CollisionBuffer {
+				if c.expected <= collisionBuffer {
 					fn = test.ShouldBeTrue
 				}
-				collides, err := c.geometries[i].CollidesWith(c.geometries[(i+1)%2])
+				collides, err := c.geometries[i].CollidesWith(c.geometries[(i+1)%2], collisionBuffer)
 				test.That(t, err, test.ShouldBeNil)
 				test.That(t, collides, fn)
 			})
 			t.Run(fmt.Sprintf("%s %T %T distance", c.testname, c.geometries[i], c.geometries[(i+1)%2]), func(t *testing.T) {
-				distance, err := c.geometries[i].DistanceFrom(c.geometries[(i+1)%2])
+				distance, err := c.geometries[i].DistanceFrom(c.geometries[(i+1)%2], collisionBuffer)
 				test.That(t, err, test.ShouldBeNil)
 				test.That(t, distance, test.ShouldAlmostEqual, c.expected, 1e-3)
 			})
@@ -428,13 +429,14 @@ func TestPointVsSphereCollision(t *testing.T) {
 
 func testGeometryEncompassed(t *testing.T, cases []geometryComparisonTestCase) {
 	t.Helper()
+	collisionBuffer := 1e-8
 	for _, c := range cases {
 		t.Run(c.testname, func(t *testing.T) {
 			fn := test.ShouldBeTrue
 			if c.expected > 0.0 {
 				fn = test.ShouldBeFalse
 			}
-			collides, err := c.geometries[0].EncompassedBy(c.geometries[1])
+			collides, err := c.geometries[0].EncompassedBy(c.geometries[1], collisionBuffer)
 			test.That(t, err, test.ShouldBeNil)
 			test.That(t, collides, fn)
 		})

--- a/spatialmath/geometry_test.go
+++ b/spatialmath/geometry_test.go
@@ -109,7 +109,7 @@ func testGeometryCollision(t *testing.T, cases []geometryComparisonTestCase) {
 				test.That(t, collides, fn)
 			})
 			t.Run(fmt.Sprintf("%s %T %T distance", c.testname, c.geometries[i], c.geometries[(i+1)%2]), func(t *testing.T) {
-				distance, err := c.geometries[i].DistanceFrom(c.geometries[(i+1)%2], collisionBufferMM)
+				distance, err := c.geometries[i].DistanceFrom(c.geometries[(i+1)%2])
 				test.That(t, err, test.ShouldBeNil)
 				test.That(t, distance, test.ShouldAlmostEqual, c.expected, 1e-3)
 			})
@@ -429,14 +429,13 @@ func TestPointVsSphereCollision(t *testing.T) {
 
 func testGeometryEncompassed(t *testing.T, cases []geometryComparisonTestCase) {
 	t.Helper()
-	collisionBufferMM := 1e-8
 	for _, c := range cases {
 		t.Run(c.testname, func(t *testing.T) {
 			fn := test.ShouldBeTrue
 			if c.expected > 0.0 {
 				fn = test.ShouldBeFalse
 			}
-			collides, err := c.geometries[0].EncompassedBy(c.geometries[1], collisionBufferMM)
+			collides, err := c.geometries[0].EncompassedBy(c.geometries[1])
 			test.That(t, err, test.ShouldBeNil)
 			test.That(t, collides, fn)
 		})

--- a/spatialmath/geometry_test.go
+++ b/spatialmath/geometry_test.go
@@ -96,15 +96,14 @@ type geometryComparisonTestCase struct {
 
 func testGeometryCollision(t *testing.T, cases []geometryComparisonTestCase) {
 	t.Helper()
-	collisionBufferMM := 1e-8
 	for _, c := range cases {
 		for i := 0; i < 2; i++ {
 			t.Run(fmt.Sprintf("%s %T %T collision", c.testname, c.geometries[i], c.geometries[(i+1)%2]), func(t *testing.T) {
 				fn := test.ShouldBeFalse
-				if c.expected <= collisionBufferMM {
+				if c.expected <= defaultCollisionBufferMM {
 					fn = test.ShouldBeTrue
 				}
-				collides, err := c.geometries[i].CollidesWith(c.geometries[(i+1)%2], collisionBufferMM)
+				collides, err := c.geometries[i].CollidesWith(c.geometries[(i+1)%2], defaultCollisionBufferMM)
 				test.That(t, err, test.ShouldBeNil)
 				test.That(t, collides, fn)
 			})

--- a/spatialmath/point.go
+++ b/spatialmath/point.go
@@ -112,7 +112,7 @@ func (pt *point) DistanceFrom(g Geometry) (float64, error) {
 
 // EncompassedBy returns a bool describing if the given point is completely encompassed by the given geometry.
 func (pt *point) EncompassedBy(g Geometry) (bool, error) {
-	return pt.CollidesWith(g, defaultCollisionBuffer)
+	return pt.CollidesWith(g, defaultCollisionBufferMM)
 }
 
 // pointVsBoxCollision takes a box and a point as arguments and returns a bool describing if they are in collision. \

--- a/spatialmath/point.go
+++ b/spatialmath/point.go
@@ -77,9 +77,9 @@ func (pt *point) ToProtobuf() *commonpb.Geometry {
 }
 
 // CollidesWith checks if the given point collides with the given geometry and returns true if it does.
-func (pt *point) CollidesWith(g Geometry, collisionBuffer float64) (bool, error) {
+func (pt *point) CollidesWith(g Geometry, collisionBufferMM float64) (bool, error) {
 	if other, ok := g.(*box); ok {
-		return pointVsBoxCollision(pt.position, other, collisionBuffer), nil
+		return pointVsBoxCollision(pt.position, other, collisionBufferMM), nil
 	}
 	if other, ok := g.(*sphere); ok {
 		return sphereVsPointDistance(other, pt.position) <= 0, nil
@@ -94,7 +94,7 @@ func (pt *point) CollidesWith(g Geometry, collisionBuffer float64) (bool, error)
 }
 
 // CollidesWith checks if the given point collides with the given geometry and returns true if it does.
-func (pt *point) DistanceFrom(g Geometry, collisionBuffer float64) (float64, error) {
+func (pt *point) DistanceFrom(g Geometry, collisionBufferMM float64) (float64, error) {
 	if other, ok := g.(*box); ok {
 		return pointVsBoxDistance(pt.position, other), nil
 	}
@@ -111,14 +111,14 @@ func (pt *point) DistanceFrom(g Geometry, collisionBuffer float64) (float64, err
 }
 
 // EncompassedBy returns a bool describing if the given point is completely encompassed by the given geometry.
-func (pt *point) EncompassedBy(g Geometry, collisionBuffer float64) (bool, error) {
-	return pt.CollidesWith(g, collisionBuffer)
+func (pt *point) EncompassedBy(g Geometry, collisionBufferMM float64) (bool, error) {
+	return pt.CollidesWith(g, collisionBufferMM)
 }
 
 // pointVsBoxCollision takes a box and a point as arguments and returns a bool describing if they are in collision. \
 // true == collision / false == no collision.
-func pointVsBoxCollision(pt r3.Vector, b *box, collisionBuffer float64) bool {
-	return b.closestPoint(pt).Sub(pt).Norm() <= collisionBuffer
+func pointVsBoxCollision(pt r3.Vector, b *box, collisionBufferMM float64) bool {
+	return b.closestPoint(pt).Sub(pt).Norm() <= collisionBufferMM
 }
 
 // pointVsBoxDistance takes a box and a point as arguments and returns a floating point number.  If this number is nonpositive it represents

--- a/spatialmath/point.go
+++ b/spatialmath/point.go
@@ -94,7 +94,7 @@ func (pt *point) CollidesWith(g Geometry, collisionBufferMM float64) (bool, erro
 }
 
 // CollidesWith checks if the given point collides with the given geometry and returns true if it does.
-func (pt *point) DistanceFrom(g Geometry, collisionBufferMM float64) (float64, error) {
+func (pt *point) DistanceFrom(g Geometry) (float64, error) {
 	if other, ok := g.(*box); ok {
 		return pointVsBoxDistance(pt.position, other), nil
 	}
@@ -111,8 +111,8 @@ func (pt *point) DistanceFrom(g Geometry, collisionBufferMM float64) (float64, e
 }
 
 // EncompassedBy returns a bool describing if the given point is completely encompassed by the given geometry.
-func (pt *point) EncompassedBy(g Geometry, collisionBufferMM float64) (bool, error) {
-	return pt.CollidesWith(g, collisionBufferMM)
+func (pt *point) EncompassedBy(g Geometry) (bool, error) {
+	return pt.CollidesWith(g, defaultCollisionBuffer)
 }
 
 // pointVsBoxCollision takes a box and a point as arguments and returns a bool describing if they are in collision. \

--- a/spatialmath/point.go
+++ b/spatialmath/point.go
@@ -77,9 +77,9 @@ func (pt *point) ToProtobuf() *commonpb.Geometry {
 }
 
 // CollidesWith checks if the given point collides with the given geometry and returns true if it does.
-func (pt *point) CollidesWith(g Geometry) (bool, error) {
+func (pt *point) CollidesWith(g Geometry, collisionBuffer float64) (bool, error) {
 	if other, ok := g.(*box); ok {
-		return pointVsBoxCollision(pt.position, other), nil
+		return pointVsBoxCollision(pt.position, other, collisionBuffer), nil
 	}
 	if other, ok := g.(*sphere); ok {
 		return sphereVsPointDistance(other, pt.position) <= 0, nil
@@ -94,7 +94,7 @@ func (pt *point) CollidesWith(g Geometry) (bool, error) {
 }
 
 // CollidesWith checks if the given point collides with the given geometry and returns true if it does.
-func (pt *point) DistanceFrom(g Geometry) (float64, error) {
+func (pt *point) DistanceFrom(g Geometry, collisionBuffer float64) (float64, error) {
 	if other, ok := g.(*box); ok {
 		return pointVsBoxDistance(pt.position, other), nil
 	}
@@ -111,14 +111,14 @@ func (pt *point) DistanceFrom(g Geometry) (float64, error) {
 }
 
 // EncompassedBy returns a bool describing if the given point is completely encompassed by the given geometry.
-func (pt *point) EncompassedBy(g Geometry) (bool, error) {
-	return pt.CollidesWith(g)
+func (pt *point) EncompassedBy(g Geometry, collisionBuffer float64) (bool, error) {
+	return pt.CollidesWith(g, collisionBuffer)
 }
 
 // pointVsBoxCollision takes a box and a point as arguments and returns a bool describing if they are in collision. \
 // true == collision / false == no collision.
-func pointVsBoxCollision(pt r3.Vector, b *box) bool {
-	return b.closestPoint(pt).Sub(pt).Norm() <= CollisionBuffer
+func pointVsBoxCollision(pt r3.Vector, b *box, collisionBuffer float64) bool {
+	return b.closestPoint(pt).Sub(pt).Norm() <= collisionBuffer
 }
 
 // pointVsBoxDistance takes a box and a point as arguments and returns a floating point number.  If this number is nonpositive it represents

--- a/spatialmath/sphere.go
+++ b/spatialmath/sphere.go
@@ -90,23 +90,23 @@ func (s *sphere) ToProtobuf() *commonpb.Geometry {
 }
 
 // CollidesWith checks if the given sphere collides with the given geometry and returns true if it does.
-func (s *sphere) CollidesWith(g Geometry, collisionBuffer float64) (bool, error) {
+func (s *sphere) CollidesWith(g Geometry, collisionBufferMM float64) (bool, error) {
 	if other, ok := g.(*sphere); ok {
-		return sphereVsSphereDistance(s, other) <= collisionBuffer, nil
+		return sphereVsSphereDistance(s, other) <= collisionBufferMM, nil
 	}
 	if other, ok := g.(*capsule); ok {
-		return capsuleVsSphereDistance(other, s) <= collisionBuffer, nil
+		return capsuleVsSphereDistance(other, s) <= collisionBufferMM, nil
 	}
 	if other, ok := g.(*box); ok {
-		return sphereVsBoxCollision(s, other, collisionBuffer), nil
+		return sphereVsBoxCollision(s, other, collisionBufferMM), nil
 	}
 	if other, ok := g.(*point); ok {
-		return sphereVsPointDistance(s, other.position) <= collisionBuffer, nil
+		return sphereVsPointDistance(s, other.position) <= collisionBufferMM, nil
 	}
 	return true, newCollisionTypeUnsupportedError(s, g)
 }
 
-func (s *sphere) DistanceFrom(g Geometry, collisionBuffer float64) (float64, error) {
+func (s *sphere) DistanceFrom(g Geometry, collisionBufferMM float64) (float64, error) {
 	if other, ok := g.(*box); ok {
 		return sphereVsBoxDistance(s, other), nil
 	}
@@ -122,7 +122,7 @@ func (s *sphere) DistanceFrom(g Geometry, collisionBuffer float64) (float64, err
 	return math.Inf(-1), newCollisionTypeUnsupportedError(s, g)
 }
 
-func (s *sphere) EncompassedBy(g Geometry, collisionBuffer float64) (bool, error) {
+func (s *sphere) EncompassedBy(g Geometry, collisionBufferMM float64) (bool, error) {
 	if other, ok := g.(*sphere); ok {
 		return sphereInSphere(s, other), nil
 	}
@@ -156,8 +156,8 @@ func sphereVsSphereDistance(a, s *sphere) float64 {
 // sphereVsBoxDistance takes a box and a sphere as arguments and returns a bool describing if they are in collision
 // true == collision / false == no collision.
 // Reference: https://github.com/gszauer/GamePhysicsCookbook/blob/a0b8ee0c39fed6d4b90bb6d2195004dfcf5a1115/Code/Geometry3D.cpp#L326
-func sphereVsBoxCollision(s *sphere, b *box, collisionBuffer float64) bool {
-	return s.pose.Point().Sub(b.closestPoint(s.pose.Point())).Norm() <= s.radius+collisionBuffer
+func sphereVsBoxCollision(s *sphere, b *box, collisionBufferMM float64) bool {
+	return s.pose.Point().Sub(b.closestPoint(s.pose.Point())).Norm() <= s.radius+collisionBufferMM
 }
 
 // sphereVsBoxDistance takes a box and a sphere as arguments and returns a floating point number.  If this number is nonpositive it

--- a/spatialmath/sphere.go
+++ b/spatialmath/sphere.go
@@ -90,23 +90,23 @@ func (s *sphere) ToProtobuf() *commonpb.Geometry {
 }
 
 // CollidesWith checks if the given sphere collides with the given geometry and returns true if it does.
-func (s *sphere) CollidesWith(g Geometry) (bool, error) {
+func (s *sphere) CollidesWith(g Geometry, collisionBuffer float64) (bool, error) {
 	if other, ok := g.(*sphere); ok {
-		return sphereVsSphereDistance(s, other) <= CollisionBuffer, nil
+		return sphereVsSphereDistance(s, other) <= collisionBuffer, nil
 	}
 	if other, ok := g.(*capsule); ok {
-		return capsuleVsSphereDistance(other, s) <= CollisionBuffer, nil
+		return capsuleVsSphereDistance(other, s) <= collisionBuffer, nil
 	}
 	if other, ok := g.(*box); ok {
-		return sphereVsBoxCollision(s, other), nil
+		return sphereVsBoxCollision(s, other, collisionBuffer), nil
 	}
 	if other, ok := g.(*point); ok {
-		return sphereVsPointDistance(s, other.position) <= CollisionBuffer, nil
+		return sphereVsPointDistance(s, other.position) <= collisionBuffer, nil
 	}
 	return true, newCollisionTypeUnsupportedError(s, g)
 }
 
-func (s *sphere) DistanceFrom(g Geometry) (float64, error) {
+func (s *sphere) DistanceFrom(g Geometry, collisionBuffer float64) (float64, error) {
 	if other, ok := g.(*box); ok {
 		return sphereVsBoxDistance(s, other), nil
 	}
@@ -122,7 +122,7 @@ func (s *sphere) DistanceFrom(g Geometry) (float64, error) {
 	return math.Inf(-1), newCollisionTypeUnsupportedError(s, g)
 }
 
-func (s *sphere) EncompassedBy(g Geometry) (bool, error) {
+func (s *sphere) EncompassedBy(g Geometry, collisionBuffer float64) (bool, error) {
 	if other, ok := g.(*sphere); ok {
 		return sphereInSphere(s, other), nil
 	}
@@ -156,8 +156,8 @@ func sphereVsSphereDistance(a, s *sphere) float64 {
 // sphereVsBoxDistance takes a box and a sphere as arguments and returns a bool describing if they are in collision
 // true == collision / false == no collision.
 // Reference: https://github.com/gszauer/GamePhysicsCookbook/blob/a0b8ee0c39fed6d4b90bb6d2195004dfcf5a1115/Code/Geometry3D.cpp#L326
-func sphereVsBoxCollision(s *sphere, b *box) bool {
-	return s.pose.Point().Sub(b.closestPoint(s.pose.Point())).Norm() <= s.radius+CollisionBuffer
+func sphereVsBoxCollision(s *sphere, b *box, collisionBuffer float64) bool {
+	return s.pose.Point().Sub(b.closestPoint(s.pose.Point())).Norm() <= s.radius+collisionBuffer
 }
 
 // sphereVsBoxDistance takes a box and a sphere as arguments and returns a floating point number.  If this number is nonpositive it

--- a/spatialmath/sphere.go
+++ b/spatialmath/sphere.go
@@ -106,7 +106,7 @@ func (s *sphere) CollidesWith(g Geometry, collisionBufferMM float64) (bool, erro
 	return true, newCollisionTypeUnsupportedError(s, g)
 }
 
-func (s *sphere) DistanceFrom(g Geometry, collisionBufferMM float64) (float64, error) {
+func (s *sphere) DistanceFrom(g Geometry) (float64, error) {
 	if other, ok := g.(*box); ok {
 		return sphereVsBoxDistance(s, other), nil
 	}
@@ -122,7 +122,7 @@ func (s *sphere) DistanceFrom(g Geometry, collisionBufferMM float64) (float64, e
 	return math.Inf(-1), newCollisionTypeUnsupportedError(s, g)
 }
 
-func (s *sphere) EncompassedBy(g Geometry, collisionBufferMM float64) (bool, error) {
+func (s *sphere) EncompassedBy(g Geometry) (bool, error) {
 	if other, ok := g.(*sphere); ok {
 		return sphereInSphere(s, other), nil
 	}


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-6563)

- Delete the `spatialmath.CollisionBuffer` global
- Change the following `Geometry` interface methods to take a new `collisionBufferMM float64` parameter:
  - `CollidesWith(Geometry, float64) (bool, error)`
  - `DistanceFrom(Geometry, float64) (float64, error)`
  - `EncompassedBy(Geometry, float64) (bool, error)`
- Change all code that ends up calling those `Geometry` interface methods to provide a `collisionBufferMM float64` parameter
- Change the `motionplan.Replan` function to take an extra parameter of `"collision_buffer_mm"` and return errors if it is not a positive float64 & use it over the default if it is a positive float64
- Add tests to `motionplan.Replan`,  `motion.MoveOnMap` and `motion.MoveOnGlobe` that prove they validate & use the  `"collision_buffer_mm"` extra param

Open Questions for Reviewers:
- I didn't have to change many tests to make this change which is a signal to me that we may be under-testing these interface methods & their implementations. Do we need to add any additional testing before/during this change to be confident that these functions work?
- I didn't expect to need to change `DistanceFrom` nor `EncompassedBy` but some of the implementations of those methods relied on the `spatialmath.CollisionBuffer` global. That seems like a smell to me. Does changing all these interface methods to take this new parameter make sense or is it indicative that our implementations of some of these methods are wrong & need to be changed before we make this interface change?
- I see that the pointcloud package functions take both a `buffer` & now a `collisionBufferMM`. Are these 2 parameters doing the same job? If so, should we consolidate? If not, what exactly is `buffer`? Can we please give it a better name?