### PR TITLE
RSDK-6429 bump exp/slices

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -394,5 +394,5 @@ require (
 	github.com/kylelemons/go-gypsy v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/ziutek/mymysql v1.5.4 // indirect
-	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
+	golang.org/x/exp v0.0.0-20230725012225-302865e7556b
 )

--- a/go.sum
+++ b/go.sum
@@ -1538,8 +1538,8 @@ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20200331195152-e8c3332aa8e5/go.mod h1:4M0jN8W1tt0AVLNr8HDosyJCDCDuyL9N9+3m7wDWgKw=
-golang.org/x/exp v0.0.0-20230321023759-10a507213a29 h1:ooxPy7fPvB4kwsA2h+iBNHkAbp/4JxTSwCmvdjEYmug=
-golang.org/x/exp v0.0.0-20230321023759-10a507213a29/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
+golang.org/x/exp v0.0.0-20230725012225-302865e7556b h1:tK7yjGqVRzYdXsBcfD2MLhFAhHfDgGLm2rY1ub7FA9k=
+golang.org/x/exp v0.0.0-20230725012225-302865e7556b/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/exp/typeparams v0.0.0-20220428152302-39d4317da171/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/exp/typeparams v0.0.0-20230203172020-98cc5a0785f9 h1:6WHiuFL9FNjg8RljAaT7FNUuKDbvMqS1i5cr2OE2sLQ=
 golang.org/x/exp/typeparams v0.0.0-20230203172020-98cc5a0785f9/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=

--- a/resource/resource_graph_export.go
+++ b/resource/resource_graph_export.go
@@ -6,8 +6,9 @@ import (
 	"fmt"
 	"strings"
 
-	"cmp"
 	"golang.org/x/exp/slices"
+
+	"go.viam.com/rdk/utils"
 )
 
 // blockWriter wraps a bytes.Buffer and adds some structured methods (`NewBlock`/`EndBlock`) for
@@ -93,7 +94,7 @@ func nodesSortedByName(nodes graphNodes) []nameNode {
 		ret = append(ret, nameNode{name, node})
 	}
 	slices.SortFunc(ret, func(left, right nameNode) int {
-		return cmp.Compare(left.Name.String(), right.Name.String())
+		return utils.Compare(left.Name.String(), right.Name.String())
 	})
 
 	return ret
@@ -165,10 +166,10 @@ func edgesSortedByName(deps resourceDependencies) []edge {
 
 	slices.SortFunc(ret, func(left, right edge) int {
 		if left.source == right.source {
-			return cmp.Compare(left.dest.String(), right.dest.String())
+			return utils.Compare(left.dest.String(), right.dest.String())
 		}
 
-		return cmp.Compare(left.source.String(), right.source.String())
+		return utils.Compare(left.source.String(), right.source.String())
 	})
 
 	return ret

--- a/resource/resource_graph_export.go
+++ b/resource/resource_graph_export.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"cmp"
 	"golang.org/x/exp/slices"
 )
 
@@ -91,8 +92,8 @@ func nodesSortedByName(nodes graphNodes) []nameNode {
 	for name, node := range nodes {
 		ret = append(ret, nameNode{name, node})
 	}
-	slices.SortFunc(ret, func(left, right nameNode) bool {
-		return left.Name.String() < right.Name.String()
+	slices.SortFunc(ret, func(left, right nameNode) int {
+		return cmp.Compare(left.Name.String(), right.Name.String())
 	})
 
 	return ret
@@ -162,12 +163,12 @@ func edgesSortedByName(deps resourceDependencies) []edge {
 		}
 	}
 
-	slices.SortFunc(ret, func(left, right edge) bool {
+	slices.SortFunc(ret, func(left, right edge) int {
 		if left.source == right.source {
-			return left.dest.String() < right.dest.String()
+			return cmp.Compare(left.dest.String(), right.dest.String())
 		}
 
-		return left.source.String() < right.source.String()
+		return cmp.Compare(left.source.String(), right.source.String())
 	})
 
 	return ret

--- a/services/motion/builtin/state/state.go
+++ b/services/motion/builtin/state/state.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"cmp"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"go.viam.com/utils"
@@ -20,6 +19,7 @@ import (
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/services/motion"
+	rutils "go.viam.com/rdk/utils"
 )
 
 // Waypoints represent the waypoints of the plan.
@@ -489,7 +489,7 @@ func (s *State) ListPlanStatuses(req motion.ListPlanStatusesReq) ([]motion.PlanS
 	statuses := []motion.PlanStatusWithID{}
 	componentNames := maps.Keys(s.componentStateByComponent)
 	slices.SortFunc(componentNames, func(a, b resource.Name) int {
-		return cmp.Compare(a.String(), b.String())
+		return rutils.Compare(a.String(), b.String())
 	})
 
 	if req.OnlyActivePlans {

--- a/services/motion/builtin/state/state.go
+++ b/services/motion/builtin/state/state.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"cmp"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"go.viam.com/utils"
@@ -487,8 +488,8 @@ func (s *State) ListPlanStatuses(req motion.ListPlanStatusesReq) ([]motion.PlanS
 
 	statuses := []motion.PlanStatusWithID{}
 	componentNames := maps.Keys(s.componentStateByComponent)
-	slices.SortFunc(componentNames, func(a, b resource.Name) bool {
-		return a.String() < b.String()
+	slices.SortFunc(componentNames, func(a, b resource.Name) int {
+		return cmp.Compare(a.String(), b.String())
 	})
 
 	if req.OnlyActivePlans {

--- a/utils/value.go
+++ b/utils/value.go
@@ -53,3 +53,22 @@ func SafeTestingRand() Rand {
 	}
 	return randWrapper{}
 }
+
+// Ordered is a clone of cmp.Ordered. Delete me after go1.12.
+type Ordered interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr |
+		~float32 | ~float64 |
+		~string
+}
+
+// Compare is a clone of cmp.Compare. Delete me after go1.21 and use the original.
+func Compare[T Ordered](a, b T) int {
+	if a < b {
+		return -1
+	}
+	if a == b {
+		return 0
+	}
+	return 1
+}

--- a/utils/value_test.go
+++ b/utils/value_test.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"testing"
 
+	"cmp"
 	"github.com/pkg/errors"
 	"go.viam.com/test"
 )
@@ -51,4 +52,13 @@ func TestSafeRand(t *testing.T) {
 	instance := SafeTestingRand()
 	source := rand.New(rand.NewSource(0))
 	test.That(t, instance.Float64(), test.ShouldEqual, source.Float64())
+}
+
+func TestCompare(t *testing.T) {
+	test.That(t, cmp.Compare(0, 1), test.ShouldEqual, Compare(0, 1))
+	test.That(t, cmp.Compare(1, 1), test.ShouldEqual, Compare(1, 1))
+	test.That(t, cmp.Compare(1, 0), test.ShouldEqual, Compare(1, 0))
+	test.That(t, cmp.Compare("a", "b"), test.ShouldEqual, Compare("a", "b"))
+	test.That(t, cmp.Compare("b", "b"), test.ShouldEqual, Compare("b", "b"))
+	test.That(t, cmp.Compare("b", "a"), test.ShouldEqual, Compare("b", "a"))
 }

--- a/utils/value_test.go
+++ b/utils/value_test.go
@@ -5,7 +5,6 @@ import (
 	"os/exec"
 	"testing"
 
-	"cmp"
 	"github.com/pkg/errors"
 	"go.viam.com/test"
 )
@@ -54,11 +53,13 @@ func TestSafeRand(t *testing.T) {
 	test.That(t, instance.Float64(), test.ShouldEqual, source.Float64())
 }
 
-func TestCompare(t *testing.T) {
+// Commented block because importing cmp breaks our linter, but it passes.
+// Delete me after go1.21.
+/* func TestCompare(t *testing.T) {
 	test.That(t, cmp.Compare(0, 1), test.ShouldEqual, Compare(0, 1))
 	test.That(t, cmp.Compare(1, 1), test.ShouldEqual, Compare(1, 1))
 	test.That(t, cmp.Compare(1, 0), test.ShouldEqual, Compare(1, 0))
 	test.That(t, cmp.Compare("a", "b"), test.ShouldEqual, Compare("a", "b"))
 	test.That(t, cmp.Compare("b", "b"), test.ShouldEqual, Compare("b", "b"))
 	test.That(t, cmp.Compare("b", "a"), test.ShouldEqual, Compare("b", "a"))
-}
+} */

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -13,6 +13,7 @@ import (
 	"runtime/pprof"
 	"time"
 
+	"cmp"
 	"github.com/invopop/jsonschema"
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
@@ -465,11 +466,11 @@ func dumpResourceRegistrations(outputPath string) error {
 	}
 
 	// sort the list alphabetically by API+Model
-	slices.SortFunc(resources, func(a, b resourceRegistration) bool {
+	slices.SortFunc(resources, func(a, b resourceRegistration) int {
 		if a.API != b.API {
-			return a.API < b.API
+			return cmp.Compare(a.API, b.API)
 		}
-		return a.Model < b.Model
+		return cmp.Compare(a.Model, b.Model)
 	})
 
 	// marshall and print the registrations to the provided file

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -13,7 +13,6 @@ import (
 	"runtime/pprof"
 	"time"
 
-	"cmp"
 	"github.com/invopop/jsonschema"
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
@@ -468,9 +467,9 @@ func dumpResourceRegistrations(outputPath string) error {
 	// sort the list alphabetically by API+Model
 	slices.SortFunc(resources, func(a, b resourceRegistration) int {
 		if a.API != b.API {
-			return cmp.Compare(a.API, b.API)
+			return rutils.Compare(a.API, b.API)
 		}
-		return cmp.Compare(a.Model, b.Model)
+		return rutils.Compare(a.Model, b.Model)
 	})
 
 	// marshall and print the registrations to the provided file


### PR DESCRIPTION
## What changed
- bump golang.org/x/exp to get the new exp/slices interface
- fix `slices.SortFunc` calls
- add local `cmp.Compare` until we move to go1.21
## Why
- a downstream repo with a transitive dependency on recent x/exp failed to build. go.mod min version selection uses the newer one, which broke our SortFunc calls. exp/slices changed the interface [here](https://cs.opensource.google/go/x/exp/+/302865e7556b4ae5de27248ce625d443ef4ad3ed) to be compatible with the go 1.21 standard library
## Note
- this change will cause a compile error on downstream repos that depend on the old exp/slices