### PR TITLE
[RSDK-5462] Remove duplicate functions when connecting to ntrip URLs

### DIFF
--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
@@ -42,7 +42,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/de-bkg/gognss/pkg/ntrip"
 	"github.com/go-gnss/rtcm/rtcm3"
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
@@ -287,24 +286,6 @@ func (g *rtkI2C) start() error {
 	return g.err.Get()
 }
 
-// connect attempts to connect to ntrip client until successful connection or timeout.
-func (g *rtkI2C) connect(casterAddr, user, pwd string, maxAttempts int) error {
-	g.logger.Info("starting connect")
-	for attempts := 0; attempts < maxAttempts; attempts++ {
-		ntripclient, err := ntrip.NewClient(casterAddr, ntrip.Options{Username: user, Password: pwd})
-		if err == nil {
-			g.logger.Debug("Connected to NTRIP caster")
-			g.ntripMu.Lock()
-			g.ntripClient.Client = ntripclient
-			g.ntripMu.Unlock()
-			return g.err.Get()
-		}
-	}
-
-	errMsg := fmt.Sprintf("Can't connect to NTRIP caster after %d attempts", maxAttempts)
-	return errors.New(errMsg)
-}
-
 // getStream attempts to connect to ntrip stream until successful connection or timeout.
 func (g *rtkI2C) getStream(mountPoint string, maxAttempts int) error {
 	success := false
@@ -357,7 +338,7 @@ func (g *rtkI2C) receiveAndWriteI2C(ctx context.Context) {
 	if err := g.cancelCtx.Err(); err != nil {
 		return
 	}
-	err := g.connect(g.ntripClient.URL, g.ntripClient.Username, g.ntripClient.Password, g.ntripClient.MaxConnectAttempts)
+	err := g.ntripClient.Connect(g.cancelCtx, g.logger)
 	if err != nil {
 		g.err.Set(err)
 		return

--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk_test.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk_test.go
@@ -86,30 +86,6 @@ func TestValidateRTK(t *testing.T) {
 	})
 }
 
-func TestConnect(t *testing.T) {
-	logger := logging.NewTestLogger(t)
-	ctx := context.Background()
-	cancelCtx, cancelFunc := context.WithCancel(ctx)
-	g := rtkI2C{
-		cancelCtx:  cancelCtx,
-		cancelFunc: cancelFunc,
-		logger:     logger,
-	}
-
-	url := "http://fakeurl"
-	username := "user"
-	password := "pwd"
-
-	// create new ntrip client and connect
-	err := g.connect("invalidurl", username, password, 10)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `Can't connect to NTRIP caster`)
-
-	g.ntripClient = makeMockNtripClient()
-
-	err = g.connect(url, username, password, 10)
-	test.That(t, err, test.ShouldBeNil)
-}
-
 func TestReadings(t *testing.T) {
 	var (
 		alt   = 50.5
@@ -237,9 +213,4 @@ func (c *CustomMovementSensor) Position(ctx context.Context, extra map[string]in
 	}
 	// Fallback to the default implementation if PositionFunc is not set.
 	return c.MovementSensor.Position(ctx, extra)
-}
-
-// mock ntripinfo client.
-func makeMockNtripClient() *rtk.NtripInfo {
-	return &rtk.NtripInfo{}
 }

--- a/components/movementsensor/gpsrtkserial/gpsrtkserial_test.go
+++ b/components/movementsensor/gpsrtkserial/gpsrtkserial_test.go
@@ -63,29 +63,6 @@ func TestValidateRTK(t *testing.T) {
 	})
 }
 
-func TestConnect(t *testing.T) {
-	logger := logging.NewTestLogger(t)
-	ctx := context.Background()
-	cancelCtx, cancelFunc := context.WithCancel(ctx)
-	g := rtkSerial{
-		cancelCtx:  cancelCtx,
-		cancelFunc: cancelFunc,
-		logger:     logger,
-	}
-
-	url := "http://fakeurl"
-	username := "user"
-	password := "pwd"
-
-	err := g.connect("invalidurl", username, password, 10)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `address must start with http://`)
-
-	g.ntripClient = makeMockNtripClient()
-
-	err = g.connect(url, username, password, 10)
-	test.That(t, err, test.ShouldBeNil)
-}
-
 func TestReadings(t *testing.T) {
 	var (
 		alt   = 50.5
@@ -212,9 +189,4 @@ func (c *CustomMovementSensor) Position(ctx context.Context, extra map[string]in
 	}
 	// Fallback to the default implementation if PositionFunc is not set.
 	return c.MovementSensor.Position(ctx, extra)
-}
-
-// mock ntripinfo client.
-func makeMockNtripClient() *rtk.NtripInfo {
-	return &rtk.NtripInfo{}
 }

--- a/components/movementsensor/rtkutils/ntrip.go
+++ b/components/movementsensor/rtkutils/ntrip.go
@@ -58,8 +58,8 @@ type NtripConfig struct {
 	NtripURL             string `json:"ntrip_url"`
 	NtripConnectAttempts int    `json:"ntrip_connect_attempts,omitempty"`
 	NtripMountpoint      string `json:"ntrip_mountpoint,omitempty"`
-	NtripPass            string `json:"ntrip_password,omitempty"`
 	NtripUser            string `json:"ntrip_username,omitempty"`
+	NtripPass            string `json:"ntrip_password,omitempty"`
 }
 
 // Sourcetable struct contains the stream.

--- a/components/movementsensor/rtkutils/ntrip.go
+++ b/components/movementsensor/rtkutils/ntrip.go
@@ -45,8 +45,8 @@ const (
 // NtripInfo contains the information necessary to connect to a mountpoint.
 type NtripInfo struct {
 	URL                string
-	Username           string
-	Password           string
+	username           string
+	password           string
 	MountPoint         string
 	Client             *ntrip.Client
 	Stream             io.ReadCloser
@@ -99,12 +99,12 @@ func NewNtripInfo(cfg *NtripConfig, logger logging.Logger) (*NtripInfo, error) {
 	if n.URL == "" {
 		return nil, fmt.Errorf("NTRIP expected non-empty string for %q", cfg.NtripURL)
 	}
-	n.Username = cfg.NtripUser
-	if n.Username == "" {
+	n.username = cfg.NtripUser
+	if n.username == "" {
 		logger.Info("ntrip_username set to empty")
 	}
-	n.Password = cfg.NtripPass
-	if n.Password == "" {
+	n.password = cfg.NtripPass
+	if n.password == "" {
 		logger.Info("ntrip_password set to empty")
 	}
 	n.MountPoint = cfg.NtripMountpoint
@@ -234,7 +234,7 @@ func (n *NtripInfo) Connect(ctx context.Context, logger logging.Logger) error {
 		default:
 		}
 
-		c, err = ntrip.NewClient(n.URL, ntrip.Options{Username: n.Username, Password: n.Password})
+		c, err = ntrip.NewClient(n.URL, ntrip.Options{Username: n.username, Password: n.password})
 		if err == nil {
 			break
 		}

--- a/components/movementsensor/rtkutils/ntrip.go
+++ b/components/movementsensor/rtkutils/ntrip.go
@@ -112,8 +112,9 @@ func NewNtripInfo(cfg *NtripConfig, logger logging.Logger) (*NtripInfo, error) {
 		logger.Info("ntrip_mountpoint set to empty")
 	}
 	n.MaxConnectAttempts = cfg.NtripConnectAttempts
-	if n.MaxConnectAttempts == 10 {
+	if n.MaxConnectAttempts == 0 {
 		logger.Info("ntrip_connect_attempts using default 10")
+		n.MaxConnectAttempts = 10
 	}
 
 	logger.Debug("Returning n")

--- a/components/movementsensor/rtkutils/ntrip_test.go
+++ b/components/movementsensor/rtkutils/ntrip_test.go
@@ -28,8 +28,8 @@ func TestConnectSucceeds(t *testing.T) {
 		NtripURL: "http://fakeurl",
 		NtripConnectAttempts: 10,
 		NtripMountpoint: "",
-		NtripPass: "pwd",
 		NtripUser: "user",
+		NtripPass: "pwd",
 	}
 
 	ntripInfo, err := NewNtripInfo(&config, logger)

--- a/components/movementsensor/rtkutils/ntrip_test.go
+++ b/components/movementsensor/rtkutils/ntrip_test.go
@@ -1,0 +1,33 @@
+package rtkutils
+
+import (
+	"context"
+	"testing"
+
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/logging"
+)
+
+func TestConnect(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	cancelCtx, _ := context.WithCancel(context.Background())
+
+	ntripInfo := &NtripInfo{}
+	err := ntripInfo.Connect(cancelCtx, logger)
+	test.That(t, err.Error(), test.ShouldContainSubstring, `address must start with http://`)
+
+	config := NtripConfig{
+		NtripURL: "http://fakeurl",
+		NtripConnectAttempts: 10,
+		NtripMountpoint: "",
+		NtripPass: "pwd",
+		NtripUser: "user",
+	}
+
+	ntripInfo, err = NewNtripInfo(&config, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	err = ntripInfo.Connect(cancelCtx, logger)
+	test.That(t, err, test.ShouldBeNil)
+}

--- a/components/movementsensor/rtkutils/ntrip_test.go
+++ b/components/movementsensor/rtkutils/ntrip_test.go
@@ -9,14 +9,20 @@ import (
 	"go.viam.com/rdk/logging"
 )
 
-func TestConnect(t *testing.T) {
+func TestConnectInvalidURL(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	cancelCtx, _ := context.WithCancel(context.Background())
 
+	// Note: if MaxConnectAttempts is 0, we don't bother trying to connect.
 	ntripInfo := &NtripInfo{MaxConnectAttempts: 1}
 	err := ntripInfo.Connect(cancelCtx, logger)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, `address must start with http://`)
+}
+
+func TestConnectSucceeds(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	cancelCtx, _ := context.WithCancel(context.Background())
 
 	config := NtripConfig{
 		NtripURL: "http://fakeurl",
@@ -26,7 +32,7 @@ func TestConnect(t *testing.T) {
 		NtripUser: "user",
 	}
 
-	ntripInfo, err = NewNtripInfo(&config, logger)
+	ntripInfo, err := NewNtripInfo(&config, logger)
 	test.That(t, err, test.ShouldBeNil)
 
 	err = ntripInfo.Connect(cancelCtx, logger)

--- a/components/movementsensor/rtkutils/ntrip_test.go
+++ b/components/movementsensor/rtkutils/ntrip_test.go
@@ -13,8 +13,9 @@ func TestConnect(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	cancelCtx, _ := context.WithCancel(context.Background())
 
-	ntripInfo := &NtripInfo{}
+	ntripInfo := &NtripInfo{MaxConnectAttempts: 1}
 	err := ntripInfo.Connect(cancelCtx, logger)
+	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, `address must start with http://`)
 
 	config := NtripConfig{

--- a/components/movementsensor/rtkutils/ntrip_test.go
+++ b/components/movementsensor/rtkutils/ntrip_test.go
@@ -11,7 +11,8 @@ import (
 
 func TestConnectInvalidURL(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	cancelCtx, _ := context.WithCancel(context.Background())
+	cancelCtx, cancelFn := context.WithCancel(context.Background())
+	defer cancelFn()
 
 	// Note: if MaxConnectAttempts is 0, we don't bother trying to connect.
 	ntripInfo := &NtripInfo{MaxConnectAttempts: 1}
@@ -22,14 +23,15 @@ func TestConnectInvalidURL(t *testing.T) {
 
 func TestConnectSucceeds(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	cancelCtx, _ := context.WithCancel(context.Background())
+	cancelCtx, cancelFn := context.WithCancel(context.Background())
+	defer cancelFn()
 
 	config := NtripConfig{
-		NtripURL: "http://fakeurl",
+		NtripURL:             "http://fakeurl",
 		NtripConnectAttempts: 10,
-		NtripMountpoint: "",
-		NtripUser: "user",
-		NtripPass: "pwd",
+		NtripMountpoint:      "",
+		NtripUser:            "user",
+		NtripPass:            "pwd",
 	}
 
 	ntripInfo, err := NewNtripInfo(&config, logger)

--- a/components/movementsensor/rtkutils/vrs.go
+++ b/components/movementsensor/rtkutils/vrs.go
@@ -19,7 +19,7 @@ func ConnectToVirtualBase(ntripInfo *NtripInfo,
 	logger logging.Logger,
 ) *bufio.ReadWriter {
 	mp := "/" + ntripInfo.MountPoint
-	credentials := ntripInfo.Username + ":" + ntripInfo.Password
+	credentials := ntripInfo.username + ":" + ntripInfo.password
 	credentialsBase64 := base64.StdEncoding.EncodeToString([]byte(credentials))
 
 	// Process the server URL


### PR DESCRIPTION
There's probably going to be another one or two of these, but this PR is already big enough.

- The `rtkI2C.connect()` function used approximately nothing from the `rtkI2C` struct but a bunch of stuff from `rtkI2C.NtripInfo`.
- Similarly, the `rtkSerial.connect()` function did roughly the same thing.
- So, let's put that in the `NtripInfo` struct instead, and just call it from two places. Similarly, the two sets of tests can be de-duplicated into just one location.

This PR should be easy to review commit-by-commit: the last few commits aren't exactly on the same topic as the rest.

Tried on `piworld`, both with a bare nmea component, and both an I2C and a serial RTK component: we've still got the race conditions from the double-start, resulting in a bunch of checksum errors, but it's nonetheless connecting and receiving data, which is the part this PR modifies.