### PR TITLE
Make GoToInputs variadic

### DIFF
--- a/components/arm/arm.go
+++ b/components/arm/arm.go
@@ -174,7 +174,7 @@ func GoToWaypoints(ctx context.Context, a Arm, waypoints [][]referenceframe.Inpu
 
 // CheckDesiredJointPositions validates that the desired joint positions either bring the joint back
 // in bounds or do not move the joint more out of bounds.
-func CheckDesiredJointPositions(ctx context.Context, a Arm, desiredJoints *pb.JointPositions) error {
+func CheckDesiredJointPositions(ctx context.Context, a Arm, desiredInputs []referenceframe.Input) error {
 	currentJointPos, err := a.JointPositions(ctx, nil)
 	if err != nil {
 		return err
@@ -182,8 +182,7 @@ func CheckDesiredJointPositions(ctx context.Context, a Arm, desiredJoints *pb.Jo
 	model := a.ModelFrame()
 	checkPositions := model.InputFromProtobuf(currentJointPos)
 	limits := model.DoF()
-	inputs := model.InputFromProtobuf(desiredJoints)
-	for i, val := range inputs {
+	for i, val := range desiredInputs {
 		max := limits[i].Max
 		min := limits[i].Min
 		currPosition := checkPositions[i]

--- a/components/arm/arm_test.go
+++ b/components/arm/arm_test.go
@@ -21,6 +21,7 @@ import (
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/spatialmath"
 	"go.viam.com/rdk/testutils/inject"
+	"go.viam.com/rdk/utils"
 )
 
 const (
@@ -257,32 +258,30 @@ func TestOOBArm(t *testing.T) {
 	})
 
 	t.Run("MoveToJointPositions fails if more OOB", func(t *testing.T) {
-		vals := &pb.JointPositions{Values: []float64{0, 0, 0, 0, 0, 800}}
+		vals := referenceframe.FloatsToInputs([]float64{0, 0, 0, 0, 0, 800})
 		err := arm.CheckDesiredJointPositions(context.Background(), injectedArm, vals)
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(
 			t,
 			err.Error(),
 			test.ShouldEqual,
-			"joint 5 needs to be within range [-6.283185307179586, 12.566370614359172] and cannot be moved to 13.962634015954636",
+			"joint 5 needs to be within range [-6.283185307179586, 12.566370614359172] and cannot be moved to 800",
 		)
 	})
 
 	t.Run("GoToInputs fails if more OOB", func(t *testing.T) {
 		goal := []referenceframe.Input{{Value: 11}, {Value: 10}, {Value: 10}, {Value: 11}, {Value: 10}, {Value: 10}}
-		model := injectedArm.Arm.ModelFrame()
-		positionDegs := model.ProtobufFromInput(goal)
-		err := arm.CheckDesiredJointPositions(context.Background(), injectedArm, positionDegs)
+		err := arm.CheckDesiredJointPositions(context.Background(), injectedArm, goal)
 		test.That(
 			t,
 			err.Error(),
 			test.ShouldEqual,
-			"joint 0 needs to be within range [-6.283185307179586, 6.283185307179586] and cannot be moved to 11.000000000000002",
+			"joint 0 needs to be within range [-6.283185307179586, 6.283185307179586] and cannot be moved to 11",
 		)
 	})
 
 	t.Run("MoveToJointPositions works if more in bounds", func(t *testing.T) {
-		vals := &pb.JointPositions{Values: []float64{0, 0, 0, 0, 0, 400}}
+		vals := referenceframe.FloatsToInputs([]float64{0, 0, 0, 0, 0, utils.DegToRad(400)})
 		err := arm.CheckDesiredJointPositions(context.Background(), injectedArm, vals)
 		test.That(t, err, test.ShouldBeNil)
 	})

--- a/components/arm/client.go
+++ b/components/arm/client.go
@@ -141,11 +141,17 @@ func (c *client) CurrentInputs(ctx context.Context) ([]referenceframe.Input, err
 	return c.model.InputFromProtobuf(resp), nil
 }
 
-func (c *client) GoToInputs(ctx context.Context, goal []referenceframe.Input) error {
+func (c *client) GoToInputs(ctx context.Context, inputSteps ...[]referenceframe.Input) error {
 	if c.model == nil {
 		return errArmClientModelNotValid
 	}
-	return c.MoveToJointPositions(ctx, c.model.ProtobufFromInput(goal), nil)
+	for _, goal := range inputSteps {
+		err := c.MoveToJointPositions(ctx, c.model.ProtobufFromInput(goal), nil)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {

--- a/components/arm/eva/eva.go
+++ b/components/arm/eva/eva.go
@@ -155,7 +155,8 @@ func (e *eva) MoveToPosition(ctx context.Context, pos spatialmath.Pose, extra ma
 
 func (e *eva) MoveToJointPositions(ctx context.Context, newPositions *pb.JointPositions, extra map[string]interface{}) error {
 	// check that joint positions are not out of bounds
-	if err := arm.CheckDesiredJointPositions(ctx, e, newPositions); err != nil {
+	inputs := e.ModelFrame().InputFromProtobuf(newPositions)
+	if err := arm.CheckDesiredJointPositions(ctx, e, inputs); err != nil {
 		return err
 	}
 	ctx, done := e.opMgr.New(ctx)
@@ -391,11 +392,10 @@ func (e *eva) CurrentInputs(ctx context.Context) ([]referenceframe.Input, error)
 
 func (e *eva) GoToInputs(ctx context.Context, inputSteps ...[]referenceframe.Input) error {
 	for _, goal := range inputSteps {
-		positionDegs := e.model.ProtobufFromInput(goal)
-		if err := arm.CheckDesiredJointPositions(ctx, e, positionDegs); err != nil {
+		if err := arm.CheckDesiredJointPositions(ctx, e, goal); err != nil {
 			return err
 		}
-		err := e.MoveToJointPositions(ctx, positionDegs, nil)
+		err := e.MoveToJointPositions(ctx, e.model.ProtobufFromInput(goal), nil)
 		if err != nil {
 			return err
 		}

--- a/components/arm/eva/eva.go
+++ b/components/arm/eva/eva.go
@@ -389,12 +389,18 @@ func (e *eva) CurrentInputs(ctx context.Context) ([]referenceframe.Input, error)
 	return e.model.InputFromProtobuf(res), nil
 }
 
-func (e *eva) GoToInputs(ctx context.Context, goal []referenceframe.Input) error {
-	positionDegs := e.model.ProtobufFromInput(goal)
-	if err := arm.CheckDesiredJointPositions(ctx, e, positionDegs); err != nil {
-		return err
+func (e *eva) GoToInputs(ctx context.Context, inputSteps ...[]referenceframe.Input) error {
+	for _, goal := range inputSteps {
+		positionDegs := e.model.ProtobufFromInput(goal)
+		if err := arm.CheckDesiredJointPositions(ctx, e, positionDegs); err != nil {
+			return err
+		}
+		err := e.MoveToJointPositions(ctx, positionDegs, nil)
+		if err != nil {
+			return err
+		}
 	}
-	return e.MoveToJointPositions(ctx, positionDegs, nil)
+	return nil
 }
 
 func (e *eva) Close(ctx context.Context) error {

--- a/components/arm/fake/fake.go
+++ b/components/arm/fake/fake.go
@@ -144,12 +144,12 @@ func (a *Arm) MoveToPosition(ctx context.Context, pos spatialmath.Pose, extra ma
 
 // MoveToJointPositions sets the joints.
 func (a *Arm) MoveToJointPositions(ctx context.Context, joints *pb.JointPositions, extra map[string]interface{}) error {
-	if err := arm.CheckDesiredJointPositions(ctx, a, joints); err != nil {
+	inputs := a.model.InputFromProtobuf(joints)
+	if err := arm.CheckDesiredJointPositions(ctx, a, inputs); err != nil {
 		return err
 	}
 	a.mu.RLock()
 	defer a.mu.RUnlock()
-	inputs := a.model.InputFromProtobuf(joints)
 	pos, err := a.model.Transform(inputs)
 	if err != nil {
 		return err
@@ -190,7 +190,7 @@ func (a *Arm) GoToInputs(ctx context.Context, inputSteps ...[]referenceframe.Inp
 		a.mu.RLock()
 		positionDegs := a.model.ProtobufFromInput(goal)
 		a.mu.RUnlock()
-		if err := arm.CheckDesiredJointPositions(ctx, a, positionDegs); err != nil {
+		if err := arm.CheckDesiredJointPositions(ctx, a, goal); err != nil {
 			return err
 		}
 		err := a.MoveToJointPositions(ctx, positionDegs, nil)

--- a/components/arm/fake/fake.go
+++ b/components/arm/fake/fake.go
@@ -185,14 +185,20 @@ func (a *Arm) CurrentInputs(ctx context.Context) ([]referenceframe.Input, error)
 }
 
 // GoToInputs TODO.
-func (a *Arm) GoToInputs(ctx context.Context, goal []referenceframe.Input) error {
-	a.mu.RLock()
-	positionDegs := a.model.ProtobufFromInput(goal)
-	a.mu.RUnlock()
-	if err := arm.CheckDesiredJointPositions(ctx, a, positionDegs); err != nil {
-		return err
+func (a *Arm) GoToInputs(ctx context.Context, inputSteps ...[]referenceframe.Input) error {
+	for _, goal := range inputSteps {
+		a.mu.RLock()
+		positionDegs := a.model.ProtobufFromInput(goal)
+		a.mu.RUnlock()
+		if err := arm.CheckDesiredJointPositions(ctx, a, positionDegs); err != nil {
+			return err
+		}
+		err := a.MoveToJointPositions(ctx, positionDegs, nil)
+		if err != nil {
+			return err
+		}
 	}
-	return a.MoveToJointPositions(ctx, positionDegs, nil)
+	return nil
 }
 
 // Close does nothing.

--- a/components/arm/universalrobots/ur.go
+++ b/components/arm/universalrobots/ur.go
@@ -377,7 +377,8 @@ func (ua *urArm) MoveToPosition(ctx context.Context, pos spatialmath.Pose, extra
 // MoveToJointPositions moves the UR arm to the specified joint positions.
 func (ua *urArm) MoveToJointPositions(ctx context.Context, joints *pb.JointPositions, extra map[string]interface{}) error {
 	// check that joint positions are not out of bounds
-	if err := arm.CheckDesiredJointPositions(ctx, ua, joints); err != nil {
+	inputs := ua.ModelFrame().InputFromProtobuf(joints)
+	if err := arm.CheckDesiredJointPositions(ctx, ua, inputs); err != nil {
 		return err
 	}
 	return ua.moveToJointPositionRadians(ctx, referenceframe.JointPositionsToRadians(joints))
@@ -503,11 +504,10 @@ func (ua *urArm) CurrentInputs(ctx context.Context) ([]referenceframe.Input, err
 func (ua *urArm) GoToInputs(ctx context.Context, inputSteps ...[]referenceframe.Input) error {
 	for _, goal := range inputSteps {
 		// check that joint positions are not out of bounds
-		positionDegs := ua.model.ProtobufFromInput(goal)
-		if err := arm.CheckDesiredJointPositions(ctx, ua, positionDegs); err != nil {
+		if err := arm.CheckDesiredJointPositions(ctx, ua, goal); err != nil {
 			return err
 		}
-		err := ua.MoveToJointPositions(ctx, positionDegs, nil)
+		err := ua.MoveToJointPositions(ctx, ua.model.ProtobufFromInput(goal), nil)
 		if err != nil {
 			return err
 		}

--- a/components/arm/universalrobots/ur.go
+++ b/components/arm/universalrobots/ur.go
@@ -500,13 +500,19 @@ func (ua *urArm) CurrentInputs(ctx context.Context) ([]referenceframe.Input, err
 }
 
 // GoToInputs moves the UR arm to the Inputs specified.
-func (ua *urArm) GoToInputs(ctx context.Context, goal []referenceframe.Input) error {
-	// check that joint positions are not out of bounds
-	positionDegs := ua.model.ProtobufFromInput(goal)
-	if err := arm.CheckDesiredJointPositions(ctx, ua, positionDegs); err != nil {
-		return err
+func (ua *urArm) GoToInputs(ctx context.Context, inputSteps ...[]referenceframe.Input) error {
+	for _, goal := range inputSteps {
+		// check that joint positions are not out of bounds
+		positionDegs := ua.model.ProtobufFromInput(goal)
+		if err := arm.CheckDesiredJointPositions(ctx, ua, positionDegs); err != nil {
+			return err
+		}
+		err := ua.MoveToJointPositions(ctx, positionDegs, nil)
+		if err != nil {
+			return err
+		}
 	}
-	return ua.MoveToJointPositions(ctx, positionDegs, nil)
+	return nil
 }
 
 // Geometries returns the list of geometries associated with the resource, in any order. The poses of the geometries reflect their

--- a/components/arm/wrapper/wrapper.go
+++ b/components/arm/wrapper/wrapper.go
@@ -126,7 +126,8 @@ func (wrapper *Arm) MoveToPosition(ctx context.Context, pos spatialmath.Pose, ex
 // MoveToJointPositions sets the joints.
 func (wrapper *Arm) MoveToJointPositions(ctx context.Context, joints *pb.JointPositions, extra map[string]interface{}) error {
 	// check that joint positions are not out of bounds
-	if err := arm.CheckDesiredJointPositions(ctx, wrapper, joints); err != nil {
+	inputs := wrapper.model.InputFromProtobuf(joints)
+	if err := arm.CheckDesiredJointPositions(ctx, wrapper, inputs); err != nil {
 		return err
 	}
 	ctx, done := wrapper.opMgr.New(ctx)
@@ -179,11 +180,10 @@ func (wrapper *Arm) CurrentInputs(ctx context.Context) ([]referenceframe.Input, 
 func (wrapper *Arm) GoToInputs(ctx context.Context, inputSteps ...[]referenceframe.Input) error {
 	for _, goal := range inputSteps {
 		// check that joint positions are not out of bounds
-		positionDegs := wrapper.model.ProtobufFromInput(goal)
-		if err := arm.CheckDesiredJointPositions(ctx, wrapper, positionDegs); err != nil {
+		if err := arm.CheckDesiredJointPositions(ctx, wrapper, goal); err != nil {
 			return err
 		}
-		err := wrapper.MoveToJointPositions(ctx, positionDegs, nil)
+		err := wrapper.MoveToJointPositions(ctx, wrapper.model.ProtobufFromInput(goal), nil)
 		if err != nil {
 			return err
 		}

--- a/components/arm/wrapper/wrapper.go
+++ b/components/arm/wrapper/wrapper.go
@@ -176,13 +176,19 @@ func (wrapper *Arm) CurrentInputs(ctx context.Context) ([]referenceframe.Input, 
 }
 
 // GoToInputs moves the arm to the specified goal inputs.
-func (wrapper *Arm) GoToInputs(ctx context.Context, goal []referenceframe.Input) error {
-	// check that joint positions are not out of bounds
-	positionDegs := wrapper.model.ProtobufFromInput(goal)
-	if err := arm.CheckDesiredJointPositions(ctx, wrapper, positionDegs); err != nil {
-		return err
+func (wrapper *Arm) GoToInputs(ctx context.Context, inputSteps ...[]referenceframe.Input) error {
+	for _, goal := range inputSteps {
+		// check that joint positions are not out of bounds
+		positionDegs := wrapper.model.ProtobufFromInput(goal)
+		if err := arm.CheckDesiredJointPositions(ctx, wrapper, positionDegs); err != nil {
+			return err
+		}
+		err := wrapper.MoveToJointPositions(ctx, positionDegs, nil)
+		if err != nil {
+			return err
+		}
 	}
-	return wrapper.MoveToJointPositions(ctx, positionDegs, nil)
+	return nil
 }
 
 // Geometries returns the list of geometries associated with the resource, in any order. The poses of the geometries reflect their

--- a/components/arm/xarm/xarm.go
+++ b/components/arm/xarm/xarm.go
@@ -191,11 +191,10 @@ func (x *xArm) CurrentInputs(ctx context.Context) ([]referenceframe.Input, error
 func (x *xArm) GoToInputs(ctx context.Context, inputSteps ...[]referenceframe.Input) error {
 	for _, goal := range inputSteps {
 		// check that joint positions are not out of bounds
-		positionDegs := x.model.ProtobufFromInput(goal)
-		if err := arm.CheckDesiredJointPositions(ctx, x, positionDegs); err != nil {
+		if err := arm.CheckDesiredJointPositions(ctx, x, goal); err != nil {
 			return err
 		}
-		err := x.MoveToJointPositions(ctx, positionDegs, nil)
+		err := x.MoveToJointPositions(ctx, x.model.ProtobufFromInput(goal), nil)
 		if err != nil {
 			return err
 		}

--- a/components/arm/xarm/xarm.go
+++ b/components/arm/xarm/xarm.go
@@ -188,13 +188,19 @@ func (x *xArm) CurrentInputs(ctx context.Context) ([]referenceframe.Input, error
 	return x.model.InputFromProtobuf(res), nil
 }
 
-func (x *xArm) GoToInputs(ctx context.Context, goal []referenceframe.Input) error {
-	// check that joint positions are not out of bounds
-	positionDegs := x.model.ProtobufFromInput(goal)
-	if err := arm.CheckDesiredJointPositions(ctx, x, positionDegs); err != nil {
-		return err
+func (x *xArm) GoToInputs(ctx context.Context, inputSteps ...[]referenceframe.Input) error {
+	for _, goal := range inputSteps {
+		// check that joint positions are not out of bounds
+		positionDegs := x.model.ProtobufFromInput(goal)
+		if err := arm.CheckDesiredJointPositions(ctx, x, positionDegs); err != nil {
+			return err
+		}
+		err := x.MoveToJointPositions(ctx, positionDegs, nil)
+		if err != nil {
+			return err
+		}
 	}
-	return x.MoveToJointPositions(ctx, positionDegs, nil)
+	return nil
 }
 
 func (x *xArm) Geometries(ctx context.Context, extra map[string]interface{}) ([]spatialmath.Geometry, error) {

--- a/components/base/kinematicbase/differentialDrive.go
+++ b/components/base/kinematicbase/differentialDrive.go
@@ -130,6 +130,16 @@ func (ddk *differentialDriveKinematics) CurrentInputs(ctx context.Context) ([]re
 	return []referenceframe.Input{{Value: pt.X}, {Value: pt.Y}, {Value: theta}}, nil
 }
 
+func (ddk *differentialDriveKinematics) GoToInputs(ctx context.Context, desiredSteps ...[]referenceframe.Input) error {
+	for _, desired := range desiredSteps {
+		err := ddk.goToInputs(ctx, desired)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (ddk *differentialDriveKinematics) goToInputs(ctx context.Context, desired []referenceframe.Input) error {
 	// create capsule which defines the valid region for a base to be when driving to desired waypoint
 	// deviationThreshold defines max distance base can be from path without error being thrown
@@ -240,16 +250,6 @@ func (ddk *differentialDriveKinematics) goToInputs(ctx context.Context, desired 
 			return errMovementTimeout
 		}
 	}
-}
-
-func (ddk *differentialDriveKinematics) GoToInputs(ctx context.Context, desiredSteps ...[]referenceframe.Input) error {
-	for _, desired := range desiredSteps {
-		err := ddk.goToInputs(ctx, desired)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // issueCommand issues a relevant command to move the base to the given desired inputs and returns the boolean describing

--- a/components/base/kinematicbase/differentialDrive.go
+++ b/components/base/kinematicbase/differentialDrive.go
@@ -130,122 +130,123 @@ func (ddk *differentialDriveKinematics) CurrentInputs(ctx context.Context) ([]re
 	return []referenceframe.Input{{Value: pt.X}, {Value: pt.Y}, {Value: theta}}, nil
 }
 
-func (ddk *differentialDriveKinematics) GoToInputs(ctx context.Context, desiredSteps ...[]referenceframe.Input) (err error) {
-	for _, desired := range desiredSteps {
-		// create capsule which defines the valid region for a base to be when driving to desired waypoint
-		// deviationThreshold defines max distance base can be from path without error being thrown
-		current, inputsErr := ddk.CurrentInputs(ctx)
-		if inputsErr != nil {
-			return inputsErr
-		}
-		validRegion, capsuleErr := ddk.newValidRegionCapsule(current, desired)
-		if capsuleErr != nil {
-			return capsuleErr
-		}
-		movementErr := make(chan error, 1)
-		defer close(movementErr)
+func (ddk *differentialDriveKinematics) goToInputs(ctx context.Context, desired []referenceframe.Input) error {
+	// create capsule which defines the valid region for a base to be when driving to desired waypoint
+	// deviationThreshold defines max distance base can be from path without error being thrown
+	var err error
+	current, inputsErr := ddk.CurrentInputs(ctx)
+	if inputsErr != nil {
+		return inputsErr
+	}
+	validRegion, capsuleErr := ddk.newValidRegionCapsule(current, desired)
+	if capsuleErr != nil {
+		return capsuleErr
+	}
+	movementErr := make(chan error, 1)
+	defer close(movementErr)
 
-		cancelContext, cancel := context.WithCancel(ctx)
-		defer cancel()
+	cancelContext, cancel := context.WithCancel(ctx)
+	defer cancel()
 
-		if ddk.Localizer == nil {
-			defer func() {
-				ddk.mutex.Lock()
-				defer ddk.mutex.Unlock()
-				ddk.noLocalizerCacheInputs = originInputs
-			}()
-		}
+	if ddk.Localizer == nil {
+		defer func() {
+			ddk.mutex.Lock()
+			defer ddk.mutex.Unlock()
+			ddk.noLocalizerCacheInputs = originInputs
+		}()
+	}
 
-		utils.PanicCapturingGo(func() {
-			// this loop polls the error state and issues a corresponding command to move the base to the objective
-			// when the base is within the positional threshold of the goal, exit the loop
-			for err := cancelContext.Err(); err == nil; err = cancelContext.Err() {
-				utils.SelectContextOrWait(ctx, 10*time.Millisecond)
-				col, err := validRegion.CollidesWith(spatialmath.NewPoint(r3.Vector{X: current[0].Value, Y: current[1].Value}, ""))
-				if err != nil {
-					movementErr <- err
-					return
-				}
-				if !col {
-					movementErr <- errors.New("base has deviated too far from path")
-					return
-				}
-
-				// get to the x, y location first - note that from the base's perspective +y is forward
-				desiredHeading := math.Atan2(desired[1].Value-current[1].Value, desired[0].Value-current[0].Value)
-				commanded, err := ddk.issueCommand(cancelContext, current, []referenceframe.Input{desired[0], desired[1], {Value: desiredHeading}})
-				if err != nil {
-					movementErr <- err
-					return
-				}
-
-				if !commanded {
-					// no command to move to the x, y location was issued, correct the heading and then exit
-					// 2DOF model indicates position-only mode so heading doesn't need to be corrected, exit function
-					if len(ddk.planningFrame.DoF()) == 2 {
-						movementErr <- err
-						return
-					}
-					if commanded, err := ddk.issueCommand(cancelContext, current, []referenceframe.Input{current[0], current[1], desired[2]}); err == nil {
-						if !commanded {
-							movementErr <- nil
-							return
-						}
-					} else {
-						movementErr <- err
-						return
-					}
-				}
-				current, err = ddk.CurrentInputs(cancelContext)
-				if err != nil {
-					movementErr <- err
-					return
-				}
-				ddk.logger.CInfof(ctx, "current inputs: %v", current)
-			}
-			movementErr <- err
-		})
-
-		// watching for movement timeout
-		lastUpdate := time.Now()
-		var prevInputs []referenceframe.Input
-
-		done := false
-		for {
-			utils.SelectContextOrWait(ctx, 100*time.Millisecond)
-			select {
-			case err := <-movementErr:
-				if err != nil {
-					return err
-				}
-				done = true
-			default:
-			}
-			if done {
-				break
-			}
-
-			currentInputs, err := ddk.CurrentInputs(ctx)
+	utils.PanicCapturingGo(func() {
+		// this loop polls the error state and issues a corresponding command to move the base to the objective
+		// when the base is within the positional threshold of the goal, exit the loop
+		for err := cancelContext.Err(); err == nil; err = cancelContext.Err() {
+			utils.SelectContextOrWait(ctx, 10*time.Millisecond)
+			col, err := validRegion.CollidesWith(spatialmath.NewPoint(r3.Vector{X: current[0].Value, Y: current[1].Value}, ""))
 			if err != nil {
-				cancel()
-				<-movementErr
-				return err
+				movementErr <- err
+				return
 			}
-			if prevInputs == nil {
-				prevInputs = currentInputs
+			if !col {
+				movementErr <- errors.New("base has deviated too far from path")
+				return
 			}
-			positionChange := ik.L2InputMetric(&ik.Segment{
-				StartConfiguration: prevInputs,
-				EndConfiguration:   currentInputs,
-			})
-			if positionChange > ddk.options.MinimumMovementThresholdMM {
-				lastUpdate = time.Now()
-				prevInputs = currentInputs
-			} else if time.Since(lastUpdate) > ddk.options.Timeout {
-				cancel()
-				<-movementErr
-				return errMovementTimeout
+
+			// get to the x, y location first - note that from the base's perspective +y is forward
+			desiredHeading := math.Atan2(desired[1].Value-current[1].Value, desired[0].Value-current[0].Value)
+			commanded, err := ddk.issueCommand(cancelContext, current, []referenceframe.Input{desired[0], desired[1], {Value: desiredHeading}})
+			if err != nil {
+				movementErr <- err
+				return
 			}
+
+			if !commanded {
+				// no command to move to the x, y location was issued, correct the heading and then exit
+				// 2DOF model indicates position-only mode so heading doesn't need to be corrected, exit function
+				if len(ddk.planningFrame.DoF()) == 2 {
+					movementErr <- err
+					return
+				}
+				if commanded, err := ddk.issueCommand(cancelContext, current, []referenceframe.Input{current[0], current[1], desired[2]}); err == nil {
+					if !commanded {
+						movementErr <- nil
+						return
+					}
+				} else {
+					movementErr <- err
+					return
+				}
+			}
+			current, err = ddk.CurrentInputs(cancelContext)
+			if err != nil {
+				movementErr <- err
+				return
+			}
+			ddk.logger.CInfof(ctx, "current inputs: %v", current)
+		}
+		movementErr <- err
+	})
+
+	// watching for movement timeout
+	lastUpdate := time.Now()
+	var prevInputs []referenceframe.Input
+
+	for {
+		utils.SelectContextOrWait(ctx, 100*time.Millisecond)
+		select {
+		case err := <-movementErr:
+			return err
+		default:
+		}
+
+		currentInputs, err := ddk.CurrentInputs(ctx)
+		if err != nil {
+			cancel()
+			<-movementErr
+			return err
+		}
+		if prevInputs == nil {
+			prevInputs = currentInputs
+		}
+		positionChange := ik.L2InputMetric(&ik.Segment{
+			StartConfiguration: prevInputs,
+			EndConfiguration:   currentInputs,
+		})
+		if positionChange > ddk.options.MinimumMovementThresholdMM {
+			lastUpdate = time.Now()
+			prevInputs = currentInputs
+		} else if time.Since(lastUpdate) > ddk.options.Timeout {
+			cancel()
+			<-movementErr
+			return errMovementTimeout
+		}
+	}
+}
+
+func (ddk *differentialDriveKinematics) GoToInputs(ctx context.Context, desiredSteps ...[]referenceframe.Input) error {
+	for _, desired := range desiredSteps {
+		err := ddk.goToInputs(ctx, desired)
+		if err != nil {
+			return err
 		}
 	}
 	return nil

--- a/components/base/kinematicbase/fake_kinematics.go
+++ b/components/base/kinematicbase/fake_kinematics.go
@@ -84,17 +84,19 @@ func (fk *fakeDiffDriveKinematics) CurrentInputs(ctx context.Context) ([]referen
 	return fk.inputs, nil
 }
 
-func (fk *fakeDiffDriveKinematics) GoToInputs(ctx context.Context, inputs []referenceframe.Input) error {
-	_, err := fk.planningFrame.Transform(inputs)
-	if err != nil {
-		return err
-	}
-	fk.lock.Lock()
-	fk.inputs = inputs
-	fk.lock.Unlock()
+func (fk *fakeDiffDriveKinematics) GoToInputs(ctx context.Context, inputSteps ...[]referenceframe.Input) error {
+	for _, inputs := range inputSteps {
+		_, err := fk.planningFrame.Transform(inputs)
+		if err != nil {
+			return err
+		}
+		fk.lock.Lock()
+		fk.inputs = inputs
+		fk.lock.Unlock()
 
-	// Sleep for a short amount to time to simulate a base taking some amount of time to reach the inputs
-	time.Sleep(150 * time.Millisecond)
+		// Sleep for a short amount to time to simulate a base taking some amount of time to reach the inputs
+		time.Sleep(150 * time.Millisecond)
+	}
 	return nil
 }
 
@@ -211,16 +213,18 @@ func (fk *fakePTGKinematics) CurrentInputs(ctx context.Context) ([]referencefram
 	return make([]referenceframe.Input, 3), nil
 }
 
-func (fk *fakePTGKinematics) GoToInputs(ctx context.Context, inputs []referenceframe.Input) error {
-	newPose, err := fk.frame.Transform(inputs)
-	if err != nil {
-		return err
-	}
+func (fk *fakePTGKinematics) GoToInputs(ctx context.Context, inputSteps ...[]referenceframe.Input) error {
+	for _, inputs := range inputSteps {
+		newPose, err := fk.frame.Transform(inputs)
+		if err != nil {
+			return err
+		}
 
-	fk.lock.Lock()
-	fk.origin = referenceframe.NewPoseInFrame(fk.origin.Parent(), spatialmath.Compose(fk.origin.Pose(), newPose))
-	fk.lock.Unlock()
-	time.Sleep(time.Duration(fk.sleepTime) * time.Millisecond)
+		fk.lock.Lock()
+		fk.origin = referenceframe.NewPoseInFrame(fk.origin.Parent(), spatialmath.Compose(fk.origin.Pose(), newPose))
+		fk.lock.Unlock()
+		time.Sleep(time.Duration(fk.sleepTime) * time.Millisecond)
+	}
 	return nil
 }
 

--- a/components/base/kinematicbase/ptgKinematics.go
+++ b/components/base/kinematicbase/ptgKinematics.go
@@ -163,6 +163,19 @@ func (ptgk *ptgBaseKinematics) CurrentInputs(ctx context.Context) ([]referencefr
 	return ptgk.currentInput, nil
 }
 
+func (ptgk *ptgBaseKinematics) GoToInputs(ctx context.Context, inputSteps ...[]referenceframe.Input) error {
+	for _, inputs := range inputSteps {
+		err := ptgk.goToInputs(ctx, inputs)
+		if err != nil {
+			return err
+		}
+	}
+
+	stopCtx, cancelFn := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancelFn()
+	return ptgk.Base.Stop(stopCtx, nil)
+}
+
 func (ptgk *ptgBaseKinematics) goToInputs(ctx context.Context, inputs []referenceframe.Input) error {
 	if len(inputs) != 3 {
 		return errors.New("inputs to ptg kinematic base must be length 3")
@@ -236,19 +249,6 @@ func (ptgk *ptgBaseKinematics) goToInputs(ctx context.Context, inputs []referenc
 		}
 	}
 	return nil
-}
-
-func (ptgk *ptgBaseKinematics) GoToInputs(ctx context.Context, inputSteps ...[]referenceframe.Input) error {
-	for _, inputs := range inputSteps {
-		err := ptgk.goToInputs(ctx, inputs)
-		if err != nil {
-			return err
-		}
-	}
-
-	stopCtx, cancelFn := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancelFn()
-	return ptgk.Base.Stop(stopCtx, nil)
 }
 
 func (ptgk *ptgBaseKinematics) ErrorState(ctx context.Context, plan [][]referenceframe.Input, currentNode int) (spatialmath.Pose, error) {

--- a/components/base/kinematicbase/ptgKinematics.go
+++ b/components/base/kinematicbase/ptgKinematics.go
@@ -163,76 +163,78 @@ func (ptgk *ptgBaseKinematics) CurrentInputs(ctx context.Context) ([]referencefr
 	return ptgk.currentInput, nil
 }
 
-func (ptgk *ptgBaseKinematics) GoToInputs(ctx context.Context, inputs []referenceframe.Input) (err error) {
-	if len(inputs) != 3 {
-		return errors.New("inputs to ptg kinematic base must be length 3")
-	}
+func (ptgk *ptgBaseKinematics) GoToInputs(ctx context.Context, inputSteps ...[]referenceframe.Input) (err error) {
+	for _, inputs := range inputSteps {
+		if len(inputs) != 3 {
+			return errors.New("inputs to ptg kinematic base must be length 3")
+		}
 
-	defer func() {
-		ptgk.inputLock.Lock()
-		ptgk.currentInput = zeroInput
-		ptgk.inputLock.Unlock()
-	}()
+		defer func() {
+			ptgk.inputLock.Lock()
+			ptgk.currentInput = zeroInput
+			ptgk.inputLock.Unlock()
+		}()
 
-	ptgk.logger.CDebugf(ctx, "GoToInputs going to %v", inputs)
+		ptgk.logger.CDebugf(ctx, "GoToInputs going to %v", inputs)
 
-	selectedPTG := ptgk.ptgs[int(math.Round(inputs[ptgIndex].Value))]
+		selectedPTG := ptgk.ptgs[int(math.Round(inputs[ptgIndex].Value))]
 
-	selectedTraj, err := selectedPTG.Trajectory(
-		inputs[trajectoryIndexWithinPTG].Value,
-		inputs[distanceAlongTrajectoryIndex].Value,
-		stepDistResolution,
-	)
-	if err != nil {
-		stopCtx, cancelFn := context.WithTimeout(context.Background(), time.Second*5)
-		defer cancelFn()
-		return multierr.Combine(err, ptgk.Base.Stop(stopCtx, nil))
-	}
-	arcSteps := ptgk.trajectoryToArcSteps(selectedTraj)
-
-	for _, step := range arcSteps {
-		ptgk.inputLock.Lock() // In the case where there's actual contention here, this could cause timing issues; how to solve?
-		ptgk.currentInput = []referenceframe.Input{inputs[0], inputs[1], {0}}
-		ptgk.inputLock.Unlock()
-
-		timestep := time.Duration(step.timestepSeconds*1000*1000) * time.Microsecond
-
-		ptgk.logger.CDebugf(ctx,
-			"setting velocity to linear %v angular %v and running velocity step for %s",
-			step.linVelMMps,
-			step.angVelDegps,
-			timestep,
-		)
-
-		err := ptgk.Base.SetVelocity(
-			ctx,
-			step.linVelMMps,
-			step.angVelDegps,
-			nil,
+		selectedTraj, err := selectedPTG.Trajectory(
+			inputs[trajectoryIndexWithinPTG].Value,
+			inputs[distanceAlongTrajectoryIndex].Value,
+			stepDistResolution,
 		)
 		if err != nil {
 			stopCtx, cancelFn := context.WithTimeout(context.Background(), time.Second*5)
 			defer cancelFn()
 			return multierr.Combine(err, ptgk.Base.Stop(stopCtx, nil))
 		}
-		utils.PanicCapturingGo(func() {
-			// We need to update currentInputs as we move through the arc.
-			for timeElapsed := 0.; timeElapsed <= step.timestepSeconds; timeElapsed += inputUpdateStep {
-				distIncVel := step.linVelMMps.Y
-				if distIncVel == 0 {
-					distIncVel = step.angVelDegps.Z
-				}
-				ptgk.inputLock.Lock()
-				ptgk.currentInput = []referenceframe.Input{inputs[0], inputs[1], {math.Abs(distIncVel) * timeElapsed}}
-				ptgk.inputLock.Unlock()
-				utils.SelectContextOrWait(ctx, time.Duration(inputUpdateStep*1000*1000)*time.Microsecond)
-			}
-		})
+		arcSteps := ptgk.trajectoryToArcSteps(selectedTraj)
 
-		if !utils.SelectContextOrWait(ctx, timestep) {
-			ptgk.logger.CDebug(ctx, ctx.Err().Error())
-			// context cancelled
-			break
+		for _, step := range arcSteps {
+			ptgk.inputLock.Lock() // In the case where there's actual contention here, this could cause timing issues; how to solve?
+			ptgk.currentInput = []referenceframe.Input{inputs[0], inputs[1], {0}}
+			ptgk.inputLock.Unlock()
+
+			timestep := time.Duration(step.timestepSeconds*1000*1000) * time.Microsecond
+
+			ptgk.logger.CDebugf(ctx,
+				"setting velocity to linear %v angular %v and running velocity step for %s",
+				step.linVelMMps,
+				step.angVelDegps,
+				timestep,
+			)
+
+			err := ptgk.Base.SetVelocity(
+				ctx,
+				step.linVelMMps,
+				step.angVelDegps,
+				nil,
+			)
+			if err != nil {
+				stopCtx, cancelFn := context.WithTimeout(context.Background(), time.Second*5)
+				defer cancelFn()
+				return multierr.Combine(err, ptgk.Base.Stop(stopCtx, nil))
+			}
+			utils.PanicCapturingGo(func() {
+				// We need to update currentInputs as we move through the arc.
+				for timeElapsed := 0.; timeElapsed <= step.timestepSeconds; timeElapsed += inputUpdateStep {
+					distIncVel := step.linVelMMps.Y
+					if distIncVel == 0 {
+						distIncVel = step.angVelDegps.Z
+					}
+					ptgk.inputLock.Lock()
+					ptgk.currentInput = []referenceframe.Input{inputs[0], inputs[1], {math.Abs(distIncVel) * timeElapsed}}
+					ptgk.inputLock.Unlock()
+					utils.SelectContextOrWait(ctx, time.Duration(inputUpdateStep*1000*1000)*time.Microsecond)
+				}
+			})
+
+			if !utils.SelectContextOrWait(ctx, timestep) {
+				ptgk.logger.CDebug(ctx, ctx.Err().Error())
+				// context cancelled
+				break
+			}
 		}
 	}
 

--- a/components/gantry/client.go
+++ b/components/gantry/client.go
@@ -122,9 +122,15 @@ func (c *client) CurrentInputs(ctx context.Context) ([]referenceframe.Input, err
 	return referenceframe.FloatsToInputs(res), nil
 }
 
-func (c *client) GoToInputs(ctx context.Context, goal []referenceframe.Input) error {
-	speeds := []float64{}
-	return c.MoveToPosition(ctx, referenceframe.InputsToFloats(goal), speeds, nil)
+func (c *client) GoToInputs(ctx context.Context, inputSteps ...[]referenceframe.Input) error {
+	for _, goal := range inputSteps {
+		speeds := []float64{}
+		err := c.MoveToPosition(ctx, referenceframe.InputsToFloats(goal), speeds, nil)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {

--- a/components/gantry/fake/gantry.go
+++ b/components/gantry/fake/gantry.go
@@ -112,6 +112,12 @@ func (g *Gantry) CurrentInputs(ctx context.Context) ([]referenceframe.Input, err
 }
 
 // GoToInputs moves using the Gantry frames..
-func (g *Gantry) GoToInputs(ctx context.Context, goal []referenceframe.Input) error {
-	return g.MoveToPosition(ctx, referenceframe.InputsToFloats(goal), g.speedsMmPerSec, nil)
+func (g *Gantry) GoToInputs(ctx context.Context, inputSteps ...[]referenceframe.Input) error {
+	for _, goal := range inputSteps {
+		err := g.MoveToPosition(ctx, referenceframe.InputsToFloats(goal), g.speedsMmPerSec, nil)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/components/gantry/multiaxis/multiaxis.go
+++ b/components/gantry/multiaxis/multiaxis.go
@@ -162,12 +162,12 @@ func (g *multiAxis) MoveToPosition(ctx context.Context, positions, speeds []floa
 
 // GoToInputs moves the gantry to a goal position in the Gantry frame.
 func (g *multiAxis) GoToInputs(ctx context.Context, inputSteps ...[]referenceframe.Input) error {
+	ctx, done := g.opMgr.New(ctx)
+	defer done()
 	for _, goal := range inputSteps {
 		if len(g.subAxes) == 0 {
 			return errors.New("no subaxes found for inputs")
 		}
-		ctx, done := g.opMgr.New(ctx)
-		defer done()
 
 		// MoveToPosition will use the default gantry speed when an empty float is passed in
 		speeds := []float64{}

--- a/components/gantry/multiaxis/multiaxis.go
+++ b/components/gantry/multiaxis/multiaxis.go
@@ -161,16 +161,22 @@ func (g *multiAxis) MoveToPosition(ctx context.Context, positions, speeds []floa
 }
 
 // GoToInputs moves the gantry to a goal position in the Gantry frame.
-func (g *multiAxis) GoToInputs(ctx context.Context, goal []referenceframe.Input) error {
-	if len(g.subAxes) == 0 {
-		return errors.New("no subaxes found for inputs")
-	}
-	ctx, done := g.opMgr.New(ctx)
-	defer done()
+func (g *multiAxis) GoToInputs(ctx context.Context, inputSteps ...[]referenceframe.Input) error {
+	for _, goal := range inputSteps {
+		if len(g.subAxes) == 0 {
+			return errors.New("no subaxes found for inputs")
+		}
+		ctx, done := g.opMgr.New(ctx)
+		defer done()
 
-	// MoveToPosition will use the default gantry speed when an empty float is passed in
-	speeds := []float64{}
-	return g.MoveToPosition(ctx, referenceframe.InputsToFloats(goal), speeds, nil)
+		// MoveToPosition will use the default gantry speed when an empty float is passed in
+		speeds := []float64{}
+		err := g.MoveToPosition(ctx, referenceframe.InputsToFloats(goal), speeds, nil)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Position returns the position in millimeters.

--- a/components/gantry/multiaxis/multiaxis.go
+++ b/components/gantry/multiaxis/multiaxis.go
@@ -162,8 +162,6 @@ func (g *multiAxis) MoveToPosition(ctx context.Context, positions, speeds []floa
 
 // GoToInputs moves the gantry to a goal position in the Gantry frame.
 func (g *multiAxis) GoToInputs(ctx context.Context, inputSteps ...[]referenceframe.Input) error {
-	ctx, done := g.opMgr.New(ctx)
-	defer done()
 	for _, goal := range inputSteps {
 		if len(g.subAxes) == 0 {
 			return errors.New("no subaxes found for inputs")

--- a/components/gantry/singleaxis/singleaxis.go
+++ b/components/gantry/singleaxis/singleaxis.go
@@ -632,9 +632,9 @@ func (g *singleAxis) CurrentInputs(ctx context.Context) ([]referenceframe.Input,
 
 // GoToInputs moves the gantry to a goal position in the Gantry frame.
 func (g *singleAxis) GoToInputs(ctx context.Context, inputSteps ...[]referenceframe.Input) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	for _, goal := range inputSteps {
-		g.mu.Lock()
-		defer g.mu.Unlock()
 		speed := []float64{}
 		err := g.MoveToPosition(ctx, referenceframe.InputsToFloats(goal), speed, nil)
 		if err != nil {

--- a/components/gantry/singleaxis/singleaxis.go
+++ b/components/gantry/singleaxis/singleaxis.go
@@ -631,9 +631,15 @@ func (g *singleAxis) CurrentInputs(ctx context.Context) ([]referenceframe.Input,
 }
 
 // GoToInputs moves the gantry to a goal position in the Gantry frame.
-func (g *singleAxis) GoToInputs(ctx context.Context, goal []referenceframe.Input) error {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	speed := []float64{}
-	return g.MoveToPosition(ctx, referenceframe.InputsToFloats(goal), speed, nil)
+func (g *singleAxis) GoToInputs(ctx context.Context, inputSteps ...[]referenceframe.Input) error {
+	for _, goal := range inputSteps {
+		g.mu.Lock()
+		defer g.mu.Unlock()
+		speed := []float64{}
+		err := g.MoveToPosition(ctx, referenceframe.InputsToFloats(goal), speed, nil)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/components/gantry/singleaxis/singleaxis_test.go
+++ b/components/gantry/singleaxis/singleaxis_test.go
@@ -869,4 +869,10 @@ func TestGoToInputs(t *testing.T) {
 	inputs = []referenceframe.Input{{Value: 1.0}}
 	err = fakegantry.GoToInputs(ctx, inputs)
 	test.That(t, err, test.ShouldBeNil)
+
+	err = fakegantry.GoToInputs(ctx, inputs, inputs)
+	test.That(t, err, test.ShouldBeNil)
+
+	err = fakegantry.GoToInputs(ctx)
+	test.That(t, err, test.ShouldBeNil)
 }

--- a/referenceframe/primitives.go
+++ b/referenceframe/primitives.go
@@ -61,7 +61,7 @@ func JointPositionsFromRadians(radians []float64) *pb.JointPositions {
 // Input units are always in meters or radians.
 type InputEnabled interface {
 	CurrentInputs(ctx context.Context) ([]Input, error)
-	GoToInputs(ctx context.Context, goal []Input) error
+	GoToInputs(context.Context, ...[]Input) error
 }
 
 // InterpolateInputs will return a set of inputs that are the specified percent between the two given sets of

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -508,8 +508,9 @@ func TestMoveOnMapSubsequent(t *testing.T) {
 	test.That(t, spatialmath.PoseAlmostEqualEps(goalPose2, spatialmath.PoseBetween(goal1BaseFrame, goal2BaseFrame), 10), test.ShouldBeTrue)
 }
 
-func TestMoveOnMapAskewIMUTestMoveOnMapAskewIMU(t *testing.T) {
+func TestMoveOnMapAskewIMU(t *testing.T) {
 	t.Parallel()
+	extraPosOnly := map[string]interface{}{"smooth_iter": 5, "motion_profile": "position_only"}
 	t.Run("Askew but valid base should be able to plan", func(t *testing.T) {
 		t.Parallel()
 		ctx := context.Background()
@@ -526,7 +527,7 @@ func TestMoveOnMapAskewIMUTestMoveOnMapAskewIMU(t *testing.T) {
 			ComponentName: base.Named("test-base"),
 			Destination:   goal1SLAMFrame,
 			SlamName:      slam.Named("test_slam"),
-			Extra:         map[string]interface{}{"smooth_iter": 5},
+			Extra:         extraPosOnly,
 		}
 
 		timeoutCtx, timeoutFn := context.WithTimeout(ctx, time.Second*5)
@@ -535,7 +536,7 @@ func TestMoveOnMapAskewIMUTestMoveOnMapAskewIMU(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, executionID, test.ShouldNotResemble, uuid.Nil)
 
-		timeoutCtx, timeoutFn = context.WithTimeout(ctx, time.Second*5)
+		timeoutCtx, timeoutFn = context.WithTimeout(ctx, time.Second*15)
 		defer timeoutFn()
 		err = motion.PollHistoryUntilSuccessOrError(timeoutCtx, ms, time.Millisecond*5, motion.PlanHistoryReq{
 			ComponentName: req.ComponentName,
@@ -568,10 +569,10 @@ func TestMoveOnMapAskewIMUTestMoveOnMapAskewIMU(t *testing.T) {
 			ComponentName: base.Named("test-base"),
 			Destination:   goal1SLAMFrame,
 			SlamName:      slam.Named("test_slam"),
-			Extra:         map[string]interface{}{"smooth_iter": 5},
+			Extra:         extraPosOnly,
 		}
 
-		timeoutCtx, timeoutFn := context.WithTimeout(ctx, time.Second*5)
+		timeoutCtx, timeoutFn := context.WithTimeout(ctx, time.Second*15)
 		defer timeoutFn()
 		_, err := ms.(*builtIn).MoveOnMap(timeoutCtx, req)
 		test.That(t, err, test.ShouldNotBeNil)

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -933,7 +933,7 @@ func TestStoppableMoveFunctions(t *testing.T) {
 			calledStopFunc = true
 			return nil
 		}
-		injectArm.GoToInputsFunc = func(ctx context.Context, goal []referenceframe.Input) error {
+		injectArm.GoToInputsFunc = func(ctx context.Context, goal ...[]referenceframe.Input) error {
 			return failToReachGoalError
 		}
 		injectArm.ModelFrameFunc = func() referenceframe.Model {

--- a/testutils/inject/arm.go
+++ b/testutils/inject/arm.go
@@ -25,7 +25,7 @@ type Arm struct {
 	CloseFunc                func(ctx context.Context) error
 	ModelFrameFunc           func() referenceframe.Model
 	CurrentInputsFunc        func(ctx context.Context) ([]referenceframe.Input, error)
-	GoToInputsFunc           func(ctx context.Context, goal []referenceframe.Input) error
+	GoToInputsFunc           func(ctx context.Context, inputSteps ...[]referenceframe.Input) error
 }
 
 // NewArm returns a new injected arm.
@@ -126,9 +126,9 @@ func (a *Arm) CurrentInputs(ctx context.Context) ([]referenceframe.Input, error)
 }
 
 // GoToInputs calls the injected GoToInputs or the real version.
-func (a *Arm) GoToInputs(ctx context.Context, goal []referenceframe.Input) error {
+func (a *Arm) GoToInputs(ctx context.Context, inputSteps ...[]referenceframe.Input) error {
 	if a.GoToInputsFunc == nil {
-		return a.Arm.GoToInputs(ctx, goal)
+		return a.Arm.GoToInputs(ctx, inputSteps...)
 	}
-	return a.GoToInputsFunc(ctx, goal)
+	return a.GoToInputsFunc(ctx, inputSteps...)
 }


### PR DESCRIPTION
This PR changes the signature of our InputEnabled interface to be variadic. This allows for components executing inputs to be aware of more than one intended configuration at a time, allowing for blending between trajectories, and correction if going off course.

Use of a variadic function allows essentially all calling code to persist as-is, unlike for example changing the signature to `[][]Input`.

As `InputEnabled` is an interface used purely in Go within RDK, there are no grpc API changes associated with this update.