### PR TITLE
RSDK-6282 fix PID autotuning in sensor controlled base

### DIFF
--- a/components/base/sensorcontrolled/sensorcontrolled.go
+++ b/components/base/sensorcontrolled/sensorcontrolled.go
@@ -253,8 +253,6 @@ func (sb *sensorBase) Stop(ctx context.Context, extra map[string]interface{}) er
 }
 
 func (sb *sensorBase) stopLoop() {
-	sb.mu.Lock()
-	defer sb.mu.Unlock()
 	if sb.loop != nil {
 		sb.loop.Stop()
 		sb.loop = nil

--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -642,5 +642,5 @@ func (m *EncodedMotor) Close(ctx context.Context) error {
 	}
 	m.cancel()
 	m.activeBackgroundWorkers.Wait()
-	return m.real.Stop(ctx, nil)
+	return nil
 }


### PR DESCRIPTION
locking around the loop.Stop call caused a deadlock or something in auto tuning. removed that and spammed base calls on the RC card and everything seems to be working so I think the true fix was the stop we added at the beginning of set velocity