### PR TITLE
[RSDK-6525] Start pulling the data-reading code out of the data-interpretation code for NMEA

### DIFF
--- a/components/movementsensor/gpsnmea/data_reader.go
+++ b/components/movementsensor/gpsnmea/data_reader.go
@@ -13,9 +13,9 @@ import (
 )
 
 // DataReader represents a way to get data from a GPS NMEA device. We can read data from it using
-// the channel in Lines, and we can close the device when we're done.
+// the channel in Messages, and we can close the device when we're done.
 type DataReader interface {
-	Lines() chan string
+	Messages() chan string
 	Close() error
 }
 
@@ -76,9 +76,9 @@ func (dr *SerialDataReader) start() {
 	})
 }
 
-// Lines returns the channel of complete NMEA sentences we have read off of the device. It's part
+// Messages returns the channel of complete NMEA sentences we have read off of the device. It's part
 // of the DataReader interface.
-func (dr *SerialDataReader) Lines() chan string {
+func (dr *SerialDataReader) Messages() chan string {
 	return dr.data
 }
 

--- a/components/movementsensor/gpsnmea/data_reader.go
+++ b/components/movementsensor/gpsnmea/data_reader.go
@@ -1,11 +1,15 @@
 package gpsnmea
 
 import (
+	"bufio"
 	"context"
 	"io"
 	"sync"
 
 	"github.com/jacobsa/go-serial/serial"
+	"go.viam.com/utils"
+
+	"go.viam.com/rdk/logging"
 )
 
 // DataReader represents a way to get data from a GPS NMEA device. We can read data from it using
@@ -23,10 +27,11 @@ type SerialDataReader struct {
 	cancelCtx               context.Context
 	cancelFunc              func()
 	activeBackgroundWorkers sync.WaitGroup
+	logger                  logging.Logger
 }
 
 // NewSerialDataReader constructs a new DataReader that gets its NMEA messages over a serial port.
-func NewSerialDataReader(options serial.OpenOptions) (DataReader, error) {
+func NewSerialDataReader(options serial.OpenOptions, logger logging.Logger) (DataReader, error) {
 	dev, err := serial.Open(options)
 	if err != nil {
 		return nil, err
@@ -35,22 +40,58 @@ func NewSerialDataReader(options serial.OpenOptions) (DataReader, error) {
 	data := make(chan string)
 	cancelCtx, cancelFunc := context.WithCancel(context.Background())
 
-	reader := SerialDataReader{dev: dev, data: data, cancelCtx: cancelCtx, cancelFunc: cancelFunc}
+	reader := SerialDataReader{
+		dev:        dev,
+		data:       data,
+		cancelCtx:  cancelCtx,
+		cancelFunc: cancelFunc,
+		logger:     logger,
+	}
 	reader.start()
 
 	return &reader, nil
 }
 
 func (dr *SerialDataReader) start() {
-	// TODO
+	dr.activeBackgroundWorkers.Add(1)
+	utils.PanicCapturingGo(func() {
+		defer dr.activeBackgroundWorkers.Done()
+		defer close(dr.data)
+
+		r := bufio.NewReader(dr.dev)
+		for {
+			select {
+			case <-dr.cancelCtx.Done():
+				return
+			default:
+			}
+
+			line, err := r.ReadString('\n')
+			if err != nil {
+				dr.logger.CErrorf(dr.cancelCtx, "can't read gps serial %s", err)
+				continue // The line has bogus data; don't put it in the channel.
+			}
+			dr.data <- line
+		}
+	})
 }
 
+// Lines returns the channel of complete NMEA sentences we have read off of the device. It's part
+// of the DataReader interface.
 func (dr *SerialDataReader) Lines() chan string {
 	return dr.data
 }
 
+// Close is part of the DataReader interface. It shuts everything down, including our connection to
+// the serial port.
 func (dr *SerialDataReader) Close() error {
 	dr.cancelFunc()
+	// If the background coroutine is trying to put a new line of data into the channel, it won't
+	// notice that we've canceled it until something tries taking the line out of the channel. So,
+	// let's try to read that out so the coroutine isn't stuck. If the background coroutine shut
+	// itself down already, the channel will be closed and reading something out of it will just
+	// return the empty string.
+	<-dr.data
 	dr.activeBackgroundWorkers.Wait()
-	return nil
+	return dr.dev.Close()
 }

--- a/components/movementsensor/gpsnmea/data_reader.go
+++ b/components/movementsensor/gpsnmea/data_reader.go
@@ -1,0 +1,56 @@
+package gpsnmea
+
+import (
+	"context"
+	"io"
+	"sync"
+
+	"github.com/jacobsa/go-serial/serial"
+)
+
+// DataReader represents a way to get data from a GPS NMEA device. We can read data from it using
+// the channel in Lines, and we can close the device when we're done.
+type DataReader interface {
+	Lines() chan string
+	Close() error
+}
+
+// SerialDataReader implements the DataReader interface by interacting with the device over a
+// serial port.
+type SerialDataReader struct {
+	dev                     io.ReadWriteCloser
+	data                    chan string
+	cancelCtx               context.Context
+	cancelFunc              func()
+	activeBackgroundWorkers sync.WaitGroup
+}
+
+// NewSerialDataReader constructs a new DataReader that gets its NMEA messages over a serial port.
+func NewSerialDataReader(options serial.OpenOptions) (DataReader, error) {
+	dev, err := serial.Open(options)
+	if err != nil {
+		return nil, err
+	}
+
+	data := make(chan string)
+	cancelCtx, cancelFunc := context.WithCancel(context.Background())
+
+	reader := SerialDataReader{dev: dev, data: data, cancelCtx: cancelCtx, cancelFunc: cancelFunc}
+	reader.start()
+
+	return &reader, nil
+}
+
+func (dr *SerialDataReader) start() {
+	// TODO
+}
+
+func (dr *SerialDataReader) Lines() chan string {
+	return dr.data
+}
+
+func (dr *SerialDataReader) Close() error {
+	dr.cancelFunc()
+	dr.activeBackgroundWorkers.Wait()
+	return nil
+}

--- a/components/movementsensor/gpsnmea/serial.go
+++ b/components/movementsensor/gpsnmea/serial.go
@@ -2,10 +2,8 @@
 package gpsnmea
 
 import (
-	"bufio"
 	"context"
 	"fmt"
-	"io"
 	"math"
 	"sync"
 
@@ -39,7 +37,7 @@ type SerialNMEAMovementSensor struct {
 	lastCompassHeading movementsensor.LastCompassHeading
 	isClosed           bool
 
-	dev  io.ReadWriteCloser
+	dev DataReader
 }
 
 // NewSerialGPSNMEA gps that communicates over serial.
@@ -63,7 +61,7 @@ func NewSerialGPSNMEA(ctx context.Context, name resource.Name, conf *Config, log
 		MinimumReadSize: 4,
 	}
 
-	dev, err := serial.Open(options)
+	dev, err := NewSerialDataReader(options, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -93,32 +91,24 @@ func (g *SerialNMEAMovementSensor) Start(ctx context.Context) error {
 	g.activeBackgroundWorkers.Add(1)
 	utils.PanicCapturingGo(func() {
 		defer g.activeBackgroundWorkers.Done()
-		r := bufio.NewReader(g.dev)
 		for {
 			select {
 			case <-g.cancelCtx.Done():
 				return
-			default:
+			case line := <-g.dev.Lines():
+				// Update our struct's gps data in-place
+				g.mu.Lock()
+				err := g.data.ParseAndUpdate(line)
+				g.mu.Unlock()
+				if err != nil {
+					g.logger.CWarnf(ctx, "can't parse nmea sentence: %#v", err)
+					g.logger.Debug("Check: GPS requires clear sky view." +
+						"Ensure the antenna is outdoors if signal is weak or unavailable indoors.")
+				}
 			}
 
 			if g.isClosed { // There's no coming back from this. We're done.
 				return
-			}
-
-			line, err := r.ReadString('\n')
-			if err != nil {
-				g.logger.CErrorf(ctx, "can't read gps serial %s", err)
-				g.err.Set(err)
-				return
-			}
-			// Update our struct's gps data in-place
-			g.mu.Lock()
-			err = g.data.ParseAndUpdate(line)
-			g.mu.Unlock()
-			if err != nil {
-				g.logger.CWarnf(ctx, "can't parse nmea sentence: %#v", err)
-				g.logger.Debug("Check: GPS requires clear sky view." +
-					"Ensure the antenna is outdoors if signal is weak or unavailable indoors.")
 			}
 		}
 	})

--- a/components/movementsensor/gpsnmea/serial.go
+++ b/components/movementsensor/gpsnmea/serial.go
@@ -92,7 +92,7 @@ func (g *SerialNMEAMovementSensor) Start(ctx context.Context) error {
 	utils.PanicCapturingGo(func() {
 		defer g.activeBackgroundWorkers.Done()
 
-		lines := g.dev.Lines()
+		messages := g.dev.Messages()
 		for {
 			// First, check if we're supposed to shut down.
 			select {
@@ -105,10 +105,10 @@ func (g *SerialNMEAMovementSensor) Start(ctx context.Context) error {
 			select {
 			case <-g.cancelCtx.Done():
 				return
-			case line := <-lines:
+			case message := <-messages:
 				// Update our struct's gps data in-place
 				g.mu.Lock()
-				err := g.data.ParseAndUpdate(line)
+				err := g.data.ParseAndUpdate(message)
 				g.mu.Unlock()
 				if err != nil {
 					g.logger.CWarnf(ctx, "can't parse nmea sentence: %#v", err)

--- a/components/movementsensor/gpsnmea/serial.go
+++ b/components/movementsensor/gpsnmea/serial.go
@@ -40,7 +40,6 @@ type SerialNMEAMovementSensor struct {
 	isClosed           bool
 
 	dev  io.ReadWriteCloser
-	path string
 }
 
 // NewSerialGPSNMEA gps that communicates over serial.
@@ -77,7 +76,6 @@ func NewSerialGPSNMEA(ctx context.Context, name resource.Name, conf *Config, log
 		cancelCtx:          cancelCtx,
 		cancelFunc:         cancelFunc,
 		logger:             logger,
-		path:               serialPath,
 		err:                movementsensor.NewLastError(1, 1),
 		lastPosition:       movementsensor.NewLastPosition(),
 		lastCompassHeading: movementsensor.NewLastCompassHeading(),


### PR DESCRIPTION
I recommend reviewing this commit-by-commit!

I want feedback now, before this goes further. The general change is:
- Create a new `DataReader` interface that provides a channel full of NMEA sentences from a device
- Create a `SerialDataReader` struct that implements this interface for a serial device
- Use the `SerialDataReader` in the `SerialNMEAMovementSensor`

Future changes I anticipate, once this is in:
- Create an `I2cDataReader` that also implements `DataReader` for an I2C device.
- Make `NewSerialGPSNMEA` and `NewPmtkI2CGPSNMEA` both return the same struct, except that they pass in different implementations of `DataReader` to that struct. Get rid of all the duplicated code between `gpsnmea/pmtI2C.go` and `gpsnmea/serial.go`

Tried on `piworld`: gps-nmea (serial) and gps-nmea-rtk-i2c appear to work normally. The gps-nmea-rtk-serial device is currently unplugged, but I'll double-check that still works later when it's plugged in again. I've also double-checked that it shuts down relatively quickly, too (no hanging on `Close()`)!