### PR TITLE
RSDK-6570: i2c parser bug

### DIFF
--- a/components/movementsensor/gpsnmea/pmtkI2C.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C.go
@@ -176,6 +176,12 @@ func (g *PmtkI2CNMEAMovementSensor) Start(ctx context.Context) error {
 				// LF is merely ignored.
 				if b == 0x0D {
 					if strBuf != "" {
+						// sometimes we miss "$" on the first message of the buffer. Here we are adding the missing
+						// "$" to a valid nmea string.
+						if strBuf[0] == 0x47 {
+							strBuf = "$" + strBuf
+						}
+
 						g.mu.Lock()
 						err = g.data.ParseAndUpdate(strBuf)
 						g.mu.Unlock()
@@ -186,7 +192,7 @@ func (g *PmtkI2CNMEAMovementSensor) Start(ctx context.Context) error {
 						}
 					}
 					strBuf = ""
-				} else if b != 0x0A && b != 0xFF { // adds only valid bytes
+				} else if b != 0x0A && b < 0x7F { // adds only valid bytes
 					strBuf += string(b)
 				}
 			}

--- a/components/movementsensor/gpsnmea/pmtkI2C.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C.go
@@ -178,7 +178,7 @@ func (g *PmtkI2CNMEAMovementSensor) Start(ctx context.Context) error {
 					if strBuf != "" {
 						// sometimes we miss "$" on the first message of the buffer. Here we are adding the missing
 						// "$" to a valid nmea string.
-						if strBuf[0] == 0x47 {
+						if strBuf[0] == 0x47 { // 0x47 is the ASCII value
 							strBuf = "$" + strBuf
 						}
 

--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
@@ -276,11 +276,6 @@ func (g *rtkI2C) start() error {
 	// TODO(RDK-1639): Test out what happens if we call this line and then the ReceiveAndWrite*
 	// correction data goes wrong. Could anything worse than uncorrected data occur?
 
-	if err := g.nmeamovementsensor.Start(g.cancelCtx); err != nil {
-		g.lastposition.GetLastPosition()
-		return err
-	}
-
 	g.activeBackgroundWorkers.Add(1)
 	utils.PanicCapturingGo(func() { g.receiveAndWriteI2C(g.cancelCtx) })
 


### PR DESCRIPTION
We are encountering two issues with I2C connection. 
1. Frequently the NMEA packets will start without "$"
2. Sometimes packets will contain half of an NMEA message. 
This PR includes these two fixes. 

Tested: in NY cors against gpsrtkPMTK. 