### PR TITLE
Data 2275/log capture frequency

### DIFF
--- a/data/registry.go
+++ b/data/registry.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/benbjohnson/clock"
@@ -46,6 +47,10 @@ func (p CollectorParams) Validate() error {
 type MethodMetadata struct {
 	API        resource.API
 	MethodName string
+}
+
+func (m MethodMetadata) String() string {
+	return fmt.Sprintf("Api: %v, Method Name: %s", m.API, m.MethodName)
 }
 
 var collectorRegistry = map[MethodMetadata]CollectorConstructor{}

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -230,7 +230,7 @@ type resourceMethodMetadata struct {
 }
 
 func (r resourceMethodMetadata) String() string {
-	return fmt.Sprintf("Resource Name: %s, Method Params: %s, Method Metadata: [%v]", r.ResourceName, r.MethodParams, r.MethodMetadata)
+	return fmt.Sprintf("[API: %s, Resource Name: %s, Method Name: %s, Method Params: %s]", r.MethodMetadata.API, r.ResourceName, r.MethodMetadata.MethodName, r.MethodParams)
 }
 
 // Get time.Duration from hz.
@@ -464,7 +464,7 @@ func (svc *builtIn) Reconfigure(
 				} else {
 					syncVal = "will"
 				}
-				svc.logger.Infof("capture frequency for %s is set to %f/s and %s sync", componentMethodMetadata, resConf.CaptureFrequencyHz, syncVal)
+				svc.logger.Infof("capture frequency for %s is set to %.2fHz and %s sync", componentMethodMetadata, resConf.CaptureFrequencyHz, syncVal)
 			}
 
 			// we need this map to keep track of if state has changed in the configs
@@ -625,7 +625,7 @@ func (svc *builtIn) sync() {
 	}
 }
 
-//nolint
+// nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -624,7 +624,7 @@ func (svc *builtIn) sync() {
 	}
 }
 
-// nolint
+//nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -230,7 +230,9 @@ type resourceMethodMetadata struct {
 }
 
 func (r resourceMethodMetadata) String() string {
-	return fmt.Sprintf("[API: %s, Resource Name: %s, Method Name: %s, Method Params: %s]", r.MethodMetadata.API, r.ResourceName, r.MethodMetadata.MethodName, r.MethodParams)
+	return fmt.Sprintf(
+		"[API: %s, Resource Name: %s, Method Name: %s, Method Params: %s]",
+		r.MethodMetadata.API, r.ResourceName, r.MethodMetadata.MethodName, r.MethodParams)
 }
 
 // Get time.Duration from hz.
@@ -472,7 +474,6 @@ func (svc *builtIn) Reconfigure(
 			svc.componentMethodFrequencyHz[componentMethodMetadata] = resConf.CaptureFrequencyHz
 
 			if !resConf.Disabled && resConf.CaptureFrequencyHz > 0 {
-
 				// We only use service-level tags.
 				resConf.Tags = svcConfig.Tags
 
@@ -625,7 +626,7 @@ func (svc *builtIn) sync() {
 	}
 }
 
-// nolint
+//nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -444,7 +444,7 @@ func (svc *builtIn) Reconfigure(
 				continue
 			}
 
-			// Create component/method metadata to check if the collector exists.
+			// Create component/method metadata
 			methodMetadata := data.MethodMetadata{
 				API:        resConf.Name.API,
 				MethodName: resConf.Method,
@@ -457,14 +457,12 @@ func (svc *builtIn) Reconfigure(
 			}
 			_, ok := svc.componentMethodFrequencyHz[componentMethodMetadata]
 
-			// only log if it's new or if it's been reset
+			// Only log capture frequency if the component frequency is new or the frequency has changed
 			// otherwise we'll be logging way too much
 			if !ok || (ok && resConf.CaptureFrequencyHz != svc.componentMethodFrequencyHz[componentMethodMetadata]) {
-				syncVal := ""
+				syncVal := "will"
 				if resConf.CaptureFrequencyHz == 0 {
-					syncVal = "will not"
-				} else {
-					syncVal = "will"
+					syncVal += " not"
 				}
 				svc.logger.Infof("capture frequency for %s is set to %.2fHz and %s sync", componentMethodMetadata, resConf.CaptureFrequencyHz, syncVal)
 			}
@@ -626,7 +624,7 @@ func (svc *builtIn) sync() {
 	}
 }
 
-//nolint
+// nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {


### PR DESCRIPTION
Forgive me if this sucks and I'm not following standards. Also, new to go -- so if the code needs cleanup, please please please let me know.

As per https://viam.atlassian.net/browse/DATA-2275 we want to log when capture frequency has not been set. To help things along, I've also added to the builtin service a map of state so that we can keep track of state changes so that we don't log the same message over and over again as this method is called many times by many different services.

Manually tested this via setting up a fake app on the website and running locally and then changing the value in the Data capture configuration - Frequency slot.
1. Start with blank
2. Start with 1 and then change to 0
3. Start with 0 and then change to 1

Example log: `2024-02-09T16:20:27.166Z        INFO    robot_server.rdk:service:data_manager/Data-Management-Service   builtin/builtin.go:467  capture frequency for [API: rdk:component:camera, Resource Name: fake_camera, Method Name: ReadImage, Method Params: map[mime_type:image/jpeg]] is set to 0.00Hz and will not sync`

**Update** Image of logs when started with blank and updated to 4

<img width="1459" alt="Screenshot 2024-02-12 at 10 06 55 AM" src="https://github.com/viamrobotics/rdk/assets/4420609/fcd02d66-3262-40b8-b0ad-d47a0b415029">
