### PR TITLE
RSDK-5634 - uncomment tests

### DIFF
--- a/motionplan/motionPlanner_test.go
+++ b/motionplan/motionPlanner_test.go
@@ -770,8 +770,6 @@ func TestMovementWithGripper(t *testing.T) {
 }
 
 func TestReplan(t *testing.T) {
-	// TODO(RSDK-5634): this should be unskipped when this bug is fixed
-	t.Skip()
 	ctx := context.Background()
 	logger := logging.NewTestLogger(t)
 

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -655,15 +655,14 @@ func TestPositionalReplanning(t *testing.T) {
 			expectedSuccess: true,
 			extra:           map[string]interface{}{"smooth_iter": 5},
 		},
-		// TODO(RSDK-5634): this should be uncommented when this bug is fixed
-		// {
-		// 	// This also checks that `replan` is called under default conditions when "max_replans" is not set
-		// 	name:            "check we fail to replan with a low cost factor",
-		// 	noise:           r3.Vector{Y: epsilonMM + 0.1},
-		// 	expectedErr:     "unable to create a new plan within replanCostFactor from the original",
-		// 	expectedSuccess: false,
-		// 	extra:           map[string]interface{}{"replan_cost_factor": 0.01, "smooth_iter": 5},
-		// },
+		{
+			// This also checks that `replan` is called under default conditions when "max_replans" is not set
+			name:            "check we fail to replan with a low cost factor",
+			noise:           r3.Vector{Y: epsilonMM + 0.1},
+			expectedErr:     "unable to create a new plan within replanCostFactor from the original",
+			expectedSuccess: false,
+			extra:           map[string]interface{}{"replan_cost_factor": 0.01, "smooth_iter": 5},
+		},
 		{
 			name:            "check we replan with a noisy sensor",
 			noise:           r3.Vector{Y: epsilonMM + 0.1},

--- a/services/motion/builtin/move_request.go
+++ b/services/motion/builtin/move_request.go
@@ -94,7 +94,6 @@ func (mr *moveRequest) Plan(ctx context.Context) (state.PlanResponse, error) {
 	}
 	mr.planRequest.StartConfiguration = map[string][]referenceframe.Input{mr.kinematicBase.Kinematics().Name(): inputs}
 
-	// TODO(RSDK-5634): this should pass in mr.seedplan and the appropriate replanCostFactor once this bug is found and fixed.
 	plan, err := motionplan.Replan(ctx, mr.planRequest, nil, 0)
 	if err != nil {
 		return state.PlanResponse{}, err


### PR DESCRIPTION
There were comments referring to this ticket https://viam.atlassian.net/browse/RSDK-5634 saying we should uncomment the tests when the ticket is done. 

The ticket is done (and has been for some time).

This PR uncomments the tests.