### PR TITLE
RSDK-6437 fix TestNewBoard flaky test

### DIFF
--- a/components/board/analog_smoother.go
+++ b/components/board/analog_smoother.go
@@ -109,6 +109,11 @@ func (as *AnalogSmoother) Start(ctx context.Context) {
 	as.activeBackgroundWorkers.Add(1)
 	goutils.ManagedGo(func() {
 		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
 			start := time.Now()
 			reading, err := as.Raw.Read(ctx, nil)
 			as.lastError.Store(&errValue{err != nil, err})

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -361,7 +361,7 @@ func (a *wrappedAnalogReader) Read(ctx context.Context, extra map[string]interfa
 }
 
 func (a *wrappedAnalogReader) Close(ctx context.Context) error {
-	return nil
+	return a.reader.Close(ctx)
 }
 
 func (a *wrappedAnalogReader) reset(ctx context.Context, chipSelect string, reader *board.AnalogSmoother) {
@@ -505,6 +505,9 @@ func (b *Board) Close(ctx context.Context) error {
 	}
 	for _, interrupt := range b.interrupts {
 		err = multierr.Combine(err, interrupt.Close())
+	}
+	for _, reader := range b.analogReaders {
+		err = multierr.Combine(err, reader.Close(ctx))
 	}
 	return err
 }

--- a/components/board/genericlinux/board_test.go
+++ b/components/board/genericlinux/board_test.go
@@ -96,7 +96,6 @@ func TestConfigValidate(t *testing.T) {
 }
 
 func TestNewBoard(t *testing.T) {
-	t.Skip("RSDK-6437")
 	logger := logging.NewTestLogger(t)
 	ctx := context.Background()
 
@@ -129,6 +128,7 @@ func TestNewBoard(t *testing.T) {
 	b, err := NewBoard(ctx, config, ConstPinDefs(testBoardMappings), logger)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, b, test.ShouldNotBeNil)
+	defer b.Close(ctx)
 
 	ans := b.AnalogReaderNames()
 	test.That(t, ans, test.ShouldResemble, []string{"an1"})


### PR DESCRIPTION

Didn't close board in test and analog smoother wasn't shutting down properly.
```
go test -timeout 30s -race -count 1000 -run ^TestNewBoard$ go.viam.com/rdk/components/board/genericlinux
ok      go.viam.com/rdk/components/board/genericlinux   2.057s
```