### PR TITLE
RSDK-6618: Allow remapping of tensor names in vision mlmodel, transpose image channels

### DIFF
--- a/services/mlmodel/mlmodel.go
+++ b/services/mlmodel/mlmodel.go
@@ -42,7 +42,7 @@ func TensorsToProto(ts ml.Tensors) (*servicepb.FlatTensors, error) {
 	for name, t := range ts {
 		tp, err := tensorToProto(t)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to convert tensor to proto message")
+			return nil, errors.Wrapf(err, "failed to convert tensor %q to proto message", name)
 		}
 		pbts.Tensors[name] = tp
 	}

--- a/services/mlmodel/mlmodel.go
+++ b/services/mlmodel/mlmodel.go
@@ -69,6 +69,12 @@ func tensorToProto(t *tensor.Dense) (*servicepb.FlatTensor, error) {
 				Data: dataSlice,
 			},
 		}
+	case uint8:
+		ftpb.Tensor = &servicepb.FlatTensor_Uint8Tensor{
+			Uint8Tensor: &servicepb.FlatTensorDataUInt8{
+				Data: []uint8{dataSlice},
+			},
+		}
 	case []int16:
 		ftpb.Tensor = &servicepb.FlatTensor_Int16Tensor{
 			Int16Tensor: &servicepb.FlatTensorDataInt16{
@@ -121,6 +127,12 @@ func tensorToProto(t *tensor.Dense) (*servicepb.FlatTensor, error) {
 				Data: dataSlice,
 			},
 		}
+	case float32:
+		ftpb.Tensor = &servicepb.FlatTensor_FloatTensor{
+			FloatTensor: &servicepb.FlatTensorDataFloat{
+				Data: []float32{dataSlice},
+			},
+		}
 	case []float64:
 		ftpb.Tensor = &servicepb.FlatTensor_DoubleTensor{
 			DoubleTensor: &servicepb.FlatTensorDataDouble{
@@ -128,7 +140,7 @@ func tensorToProto(t *tensor.Dense) (*servicepb.FlatTensor, error) {
 			},
 		}
 	default:
-		return nil, errors.Errorf("cannot turn underlying tensor data of type %T into proto message", dataSlice)
+		return nil, errors.Errorf("cannot turn underlying tensor data of type %T into proto message and data is %v", data, dataSlice)
 	}
 	return ftpb, nil
 }

--- a/services/mlmodel/mlmodel.go
+++ b/services/mlmodel/mlmodel.go
@@ -140,7 +140,7 @@ func tensorToProto(t *tensor.Dense) (*servicepb.FlatTensor, error) {
 			},
 		}
 	default:
-		return nil, errors.Errorf("cannot turn underlying tensor data of type %T into proto message and data is %v", data, dataSlice)
+		return nil, errors.Errorf("cannot turn underlying tensor data of type %T into proto message", data)
 	}
 	return ftpb, nil
 }

--- a/services/vision/mlvision/classifier.go
+++ b/services/vision/mlvision/classifier.go
@@ -87,7 +87,7 @@ func attemptToBuildClassifier(mlm mlmodel.Service, inNameMap, outNameMap *sync.M
 			}
 			err = inMap[inputName].Transpose()
 			if err != nil {
-				return nil, errors.New("could not transponse tensor of input image")
+				return nil, errors.New("could not transponse the data of the tensor of input image")
 			}
 		}
 		outMap, err := mlm.Infer(ctx, inMap)

--- a/services/vision/mlvision/classifier.go
+++ b/services/vision/mlvision/classifier.go
@@ -19,6 +19,7 @@ import (
 
 const (
 	classifierProbabilityName = "probability"
+	classifierInputName       = "image"
 )
 
 func attemptToBuildClassifier(mlm mlmodel.Service, inNameMap, outNameMap *sync.Map) (classification.Classifier, error) {
@@ -59,7 +60,7 @@ func attemptToBuildClassifier(mlm mlmodel.Service, inNameMap, outNameMap *sync.M
 		if (origW != resizeW) || (origH != resizeH) {
 			resized = resize.Resize(uint(resizeW), uint(resizeH), img, resize.Bilinear)
 		}
-		inputName := "image"
+		inputName := classifierInputName
 		if mapName, ok := inNameMap.Load(inputName); ok {
 			if name, ok := mapName.(string); ok {
 				inputName = name

--- a/services/vision/mlvision/classifier.go
+++ b/services/vision/mlvision/classifier.go
@@ -76,7 +76,7 @@ func attemptToBuildClassifier(mlm mlmodel.Service, inNameMap, outNameMap *sync.M
 				tensor.WithBacking(rimage.ImageToFloatBuffer(resized)),
 			)
 		default:
-			return nil, errors.New("invalid input type. try uint8 or float32")
+			return nil, errors.Errorf("invalid input type of %s. try uint8 or float32", inType)
 		}
 		outMap, err := mlm.Infer(ctx, inMap)
 		if err != nil {

--- a/services/vision/mlvision/detector.go
+++ b/services/vision/mlvision/detector.go
@@ -23,6 +23,7 @@ const (
 	detectorLocationName = "location"
 	detectorCategoryName = "category"
 	detectorScoreName    = "score"
+	detectorInputName    = "image"
 )
 
 func attemptToBuildDetector(mlm mlmodel.Service, inNameMap, outNameMap *sync.Map) (objectdetection.Detector, error) {
@@ -69,7 +70,7 @@ func attemptToBuildDetector(mlm mlmodel.Service, inNameMap, outNameMap *sync.Map
 		if (origW != resizeW) || (origH != resizeH) {
 			resized = resize.Resize(uint(resizeW), uint(resizeH), img, resize.Bilinear)
 		}
-		inputName := "image"
+		inputName := detectorInputName
 		if mapName, ok := inNameMap.Load(inputName); ok {
 			if name, ok := mapName.(string); ok {
 				inputName = name

--- a/services/vision/mlvision/detector.go
+++ b/services/vision/mlvision/detector.go
@@ -19,7 +19,13 @@ import (
 	"go.viam.com/rdk/vision/objectdetection"
 )
 
-func attemptToBuildDetector(mlm mlmodel.Service, nameMap *sync.Map) (objectdetection.Detector, error) {
+const (
+	detectorLocationName = "location"
+	detectorCategoryName = "category"
+	detectorScoreName    = "score"
+)
+
+func attemptToBuildDetector(mlm mlmodel.Service, inNameMap, outNameMap *sync.Map) (objectdetection.Detector, error) {
 	md, err := mlm.Metadata(context.Background())
 	if err != nil {
 		return nil, errors.New("could not get any metadata")
@@ -61,15 +67,21 @@ func attemptToBuildDetector(mlm mlmodel.Service, nameMap *sync.Map) (objectdetec
 		if (origW != resizeW) || (origH != resizeH) {
 			resized = resize.Resize(uint(resizeW), uint(resizeH), img, resize.Bilinear)
 		}
+		inputName := "image"
+		if mapName, ok := inNameMap.Load(inputName); ok {
+			if name, ok := mapName.(string); ok {
+				inputName = name
+			}
+		}
 		inMap := ml.Tensors{}
 		switch inType {
 		case UInt8:
-			inMap["image"] = tensor.New(
+			inMap[inputName] = tensor.New(
 				tensor.WithShape(1, resized.Bounds().Dy(), resized.Bounds().Dx(), 3),
 				tensor.WithBacking(rimage.ImageToUInt8Buffer(resized)),
 			)
 		case Float32:
-			inMap["image"] = tensor.New(
+			inMap[inputName] = tensor.New(
 				tensor.WithShape(1, resized.Bounds().Dy(), resized.Bounds().Dx(), 3),
 				tensor.WithBacking(rimage.ImageToFloatBuffer(resized)),
 			)
@@ -81,8 +93,8 @@ func attemptToBuildDetector(mlm mlmodel.Service, nameMap *sync.Map) (objectdetec
 			return nil, err
 		}
 
-		// use the nameMap to find the tensor names, or guess and cache the names
-		locationName, categoryName, scoreName, err := findDetectionTensorNames(outMap, nameMap)
+		// use the outNameMap to find the tensor names, or guess and cache the names
+		locationName, categoryName, scoreName, err := findDetectionTensorNames(outMap, outNameMap)
 		if err != nil {
 			return nil, err
 		}
@@ -144,9 +156,9 @@ func attemptToBuildDetector(mlm mlmodel.Service, nameMap *sync.Map) (objectdetec
 // the returned tensor order is location, category, score. It caches results.
 func findDetectionTensorNames(outMap ml.Tensors, nameMap *sync.Map) (string, string, string, error) {
 	// first try the nameMap
-	loc, okLoc := nameMap.Load("location")
-	cat, okCat := nameMap.Load("category")
-	score, okScores := nameMap.Load("score")
+	loc, okLoc := nameMap.Load(detectorLocationName)
+	cat, okCat := nameMap.Load(detectorCategoryName)
+	score, okScores := nameMap.Load(detectorScoreName)
 	if okLoc && okCat && okScores { // names are known
 		locString, ok := loc.(string)
 		if !ok {
@@ -163,23 +175,23 @@ func findDetectionTensorNames(outMap ml.Tensors, nameMap *sync.Map) (string, str
 		return locString, catString, scoreString, nil
 	}
 	// next, if nameMap is not set, just see if the outMap has expected names
-	_, okLoc = outMap["location"]
-	_, okCat = outMap["category"]
-	_, okScores = outMap["score"]
+	_, okLoc = outMap[detectorLocationName]
+	_, okCat = outMap[detectorCategoryName]
+	_, okScores = outMap[detectorScoreName]
 	if okLoc && okCat && okScores { // names are as expected
-		nameMap.Store("location", "location")
-		nameMap.Store("category", "category")
-		nameMap.Store("score", "score")
-		return "location", "category", "score", nil
+		nameMap.Store(detectorLocationName, detectorLocationName)
+		nameMap.Store(detectorCategoryName, detectorCategoryName)
+		nameMap.Store(detectorScoreName, detectorScoreName)
+		return detectorLocationName, detectorCategoryName, detectorScoreName, nil
 	}
 	// last, do a hack-y thing to try to guess the tensor names for the detection output tensors
 	locationName, categoryName, scoreName, err := guessDetectionTensorNames(outMap)
 	if err != nil {
 		return "", "", "", err
 	}
-	nameMap.Store("location", locationName)
-	nameMap.Store("category", categoryName)
-	nameMap.Store("score", scoreName)
+	nameMap.Store(detectorLocationName, locationName)
+	nameMap.Store(detectorCategoryName, categoryName)
+	nameMap.Store(detectorScoreName, scoreName)
 	return locationName, categoryName, scoreName, nil
 }
 
@@ -190,20 +202,20 @@ func guessDetectionTensorNames(outMap ml.Tensors) (string, string, string, error
 	foundTensor := map[string]bool{}
 	mappedNames := map[string]string{}
 	outNames := tensorNames(outMap)
-	_, okLoc := outMap["location"]
+	_, okLoc := outMap[detectorLocationName]
 	if okLoc {
-		foundTensor["location"] = true
-		mappedNames["location"] = "location"
+		foundTensor[detectorLocationName] = true
+		mappedNames[detectorLocationName] = detectorLocationName
 	}
-	_, okCat := outMap["category"]
+	_, okCat := outMap[detectorCategoryName]
 	if okCat {
-		foundTensor["category"] = true
-		mappedNames["category"] = "category"
+		foundTensor[detectorCategoryName] = true
+		mappedNames[detectorCategoryName] = detectorCategoryName
 	}
-	_, okScores := outMap["score"]
+	_, okScores := outMap[detectorScoreName]
 	if okScores {
-		foundTensor["score"] = true
-		mappedNames["score"] = "score"
+		foundTensor[detectorScoreName] = true
+		mappedNames[detectorScoreName] = detectorScoreName
 	}
 	// first find how many detections there were
 	// this will be used to find the other tensors
@@ -233,12 +245,12 @@ func guessDetectionTensorNames(outMap ml.Tensors) (string, string, string, error
 				continue
 			}
 			if t.Dims() == 3 {
-				mappedNames["location"] = name
+				mappedNames[detectorLocationName] = name
 				foundTensor[name] = true
 				break
 			}
 		}
-		if _, ok := mappedNames["location"]; !ok {
+		if _, ok := mappedNames[detectorLocationName]; !ok {
 			return "", "", "", errors.Errorf("could not find an output tensor named 'location' among [%s]", strings.Join(outNames, ", "))
 		}
 	}
@@ -253,7 +265,7 @@ func guessDetectionTensorNames(outMap ml.Tensors) (string, string, string, error
 			if t.Dims() == 2 {
 				if dt == tensor.Int || dt == tensor.Int32 || dt == tensor.Int64 ||
 					dt == tensor.Uint32 || dt == tensor.Uint64 || dt == tensor.Int8 || dt == tensor.Uint8 {
-					mappedNames["category"] = name
+					mappedNames[detectorCategoryName] = name
 					foundTensor[name] = true
 					break
 				}
@@ -280,13 +292,13 @@ func guessDetectionTensorNames(outMap ml.Tensors) (string, string, string, error
 					return "", "", "", err
 				}
 				if math.Mod(val[0], 1) == 0 {
-					mappedNames["category"] = name
+					mappedNames[detectorCategoryName] = name
 					foundTensor[name] = true
 					break
 				}
 			}
 		}
-		if _, ok := mappedNames["category"]; !ok {
+		if _, ok := mappedNames[detectorCategoryName]; !ok {
 			return "", "", "", errors.Errorf("could not find an output tensor named 'category' among [%s]", strings.Join(outNames, ", "))
 		}
 	}
@@ -298,16 +310,16 @@ func guessDetectionTensorNames(outMap ml.Tensors) (string, string, string, error
 			}
 			dt := t.Dtype()
 			if t.Dims() == 2 && (dt == tensor.Float32 || dt == tensor.Float64) {
-				mappedNames["score"] = name
+				mappedNames[detectorScoreName] = name
 				foundTensor[name] = true
 				break
 			}
 		}
-		if _, ok := mappedNames["score"]; !ok {
+		if _, ok := mappedNames[detectorScoreName]; !ok {
 			return "", "", "", errors.Errorf("could not find an output tensor named 'score' among [%s]", strings.Join(outNames, ", "))
 		}
 	}
-	return mappedNames["location"], mappedNames["category"], mappedNames["score"], nil
+	return mappedNames[detectorLocationName], mappedNames[detectorCategoryName], mappedNames[detectorScoreName], nil
 }
 
 // In the case that the model provided is not a detector, attemptToBuildDetector will return a

--- a/services/vision/mlvision/detector.go
+++ b/services/vision/mlvision/detector.go
@@ -47,7 +47,9 @@ func attemptToBuildDetector(mlm mlmodel.Service, inNameMap, outNameMap *sync.Map
 		return nil, errors.Errorf("invalid length of shape array (expected 4, got %d)", shapeLen)
 	}
 
+	channelsFirst := false // if channelFirst is true, then shape is (1, 3, height, width)
 	if shape := md.Inputs[0].Shape; getIndex(shape, 3) == 1 {
+		channelsFirst = true
 		inHeight, inWidth = shape[2], shape[3]
 	} else {
 		inHeight, inWidth = shape[1], shape[2]
@@ -87,6 +89,16 @@ func attemptToBuildDetector(mlm mlmodel.Service, inNameMap, outNameMap *sync.Map
 			)
 		default:
 			return nil, errors.Errorf("invalid input type of %s. try uint8 or float32", inType)
+		}
+		if channelsFirst {
+			err := inMap[inputName].T(0, 3, 1, 2)
+			if err != nil {
+				return nil, errors.New("could not transponse tensor of input image")
+			}
+			err = inMap[inputName].Transpose()
+			if err != nil {
+				return nil, errors.New("could not transponse tensor of input image")
+			}
 		}
 		outMap, err := mlm.Infer(ctx, inMap)
 		if err != nil {

--- a/services/vision/mlvision/detector.go
+++ b/services/vision/mlvision/detector.go
@@ -86,7 +86,7 @@ func attemptToBuildDetector(mlm mlmodel.Service, inNameMap, outNameMap *sync.Map
 				tensor.WithBacking(rimage.ImageToFloatBuffer(resized)),
 			)
 		default:
-			return nil, errors.New("invalid input type. try uint8 or float32")
+			return nil, errors.Errorf("invalid input type of %s. try uint8 or float32", inType)
 		}
 		outMap, err := mlm.Infer(ctx, inMap)
 		if err != nil {

--- a/services/vision/mlvision/detector.go
+++ b/services/vision/mlvision/detector.go
@@ -97,7 +97,7 @@ func attemptToBuildDetector(mlm mlmodel.Service, inNameMap, outNameMap *sync.Map
 			}
 			err = inMap[inputName].Transpose()
 			if err != nil {
-				return nil, errors.New("could not transponse tensor of input image")
+				return nil, errors.New("could not transponse the data of the tensor of input image")
 			}
 		}
 		outMap, err := mlm.Infer(ctx, inMap)

--- a/services/vision/mlvision/ml_model.go
+++ b/services/vision/mlvision/ml_model.go
@@ -58,7 +58,9 @@ func init() {
 
 // MLModelConfig specifies the parameters needed to turn an ML model into a vision Model.
 type MLModelConfig struct {
-	ModelName string `json:"mlmodel_name"`
+	ModelName        string            `json:"mlmodel_name"`
+	RemapInputNames  map[string]string `json:"remap_input_names"`
+	RemapOutputNames map[string]string `json:"remap_output_names"`
 }
 
 // Validate will add the ModelName as an implicit dependency to the robot.
@@ -84,12 +86,18 @@ func registerMLModelVisionService(
 		return nil, err
 	}
 
-	// the nameMap that associates the tensor names as they are found in the model, to
-	// what the vision service expects. This might not be necessary any more once we
-	// get the vision service to have rename maps in its configs.
-	nameMap := &sync.Map{}
+	// the Maps that associates the tensor names as they are found in the model, to
+	// what the vision service expects.
+	inNameMap := &sync.Map{}
+	for oldName, newName := range params.RemapInputNames {
+		inNameMap.Store(newName, oldName)
+	}
+	outNameMap := &sync.Map{}
+	for oldName, newName := range params.RemapOutputNames {
+		outNameMap.Store(newName, oldName)
+	}
 	var errList []error
-	classifierFunc, err := attemptToBuildClassifier(mlm, nameMap)
+	classifierFunc, err := attemptToBuildClassifier(mlm, inNameMap, outNameMap)
 	if err != nil {
 		logger.CDebugw(ctx, "unable to use ml model as a classifier, will attempt to evaluate as"+
 			"detector and segmenter", "model", params.ModelName, "error", err)
@@ -105,7 +113,7 @@ func registerMLModelVisionService(
 		}
 	}
 
-	detectorFunc, err := attemptToBuildDetector(mlm, nameMap)
+	detectorFunc, err := attemptToBuildDetector(mlm, inNameMap, outNameMap)
 	if err != nil {
 		logger.CDebugw(ctx, "unable to use ml model as a detector, will attempt to evaluate as 3D segmenter",
 			"model", params.ModelName, "error", err)
@@ -121,7 +129,7 @@ func registerMLModelVisionService(
 		}
 	}
 
-	segmenter3DFunc, err := attemptToBuild3DSegmenter(mlm, nameMap)
+	segmenter3DFunc, err := attemptToBuild3DSegmenter(mlm, inNameMap, outNameMap)
 	errList = append(errList, err)
 	if err != nil {
 		logger.CDebugw(ctx, "unable to use ml model as 3D segmenter", "model", params.ModelName, "error", err)

--- a/services/vision/mlvision/ml_model.go
+++ b/services/vision/mlvision/ml_model.go
@@ -172,6 +172,9 @@ func getLabelsFromMetadata(md mlmodel.MLMetadata) []string {
 	}
 
 	if labelPath, ok := md.Outputs[0].Extra["labels"].(string); ok {
+		if labelPath == "" { // no label file specified
+			return nil
+		}
 		var labels []string
 		f, err := os.Open(filepath.Clean(labelPath))
 		if err != nil {

--- a/services/vision/mlvision/ml_model_test.go
+++ b/services/vision/mlvision/ml_model_test.go
@@ -91,15 +91,16 @@ func TestAddingIncorrectModelTypeToModel(t *testing.T) {
 	mlm, err := getTestMlModel(modelLocDetector)
 	test.That(t, err, test.ShouldBeNil)
 
-	nameMap := &sync.Map{}
-	classifier, err := attemptToBuildClassifier(mlm, nameMap)
+	inNameMap := &sync.Map{}
+	outNameMap := &sync.Map{}
+	classifier, err := attemptToBuildClassifier(mlm, inNameMap, outNameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, classifier, test.ShouldNotBeNil)
 
 	err = checkIfClassifierWorks(ctx, classifier)
 	test.That(t, err, test.ShouldNotBeNil)
 
-	detector, err := attemptToBuildDetector(mlm, nameMap)
+	detector, err := attemptToBuildDetector(mlm, inNameMap, outNameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, detector, test.ShouldNotBeNil)
 
@@ -111,8 +112,9 @@ func TestAddingIncorrectModelTypeToModel(t *testing.T) {
 	mlm, err = getTestMlModel(modelLocClassifier)
 	test.That(t, err, test.ShouldBeNil)
 
-	nameMap = &sync.Map{}
-	classifier, err = attemptToBuildClassifier(mlm, nameMap)
+	inNameMap = &sync.Map{}
+	outNameMap = &sync.Map{}
+	classifier, err = attemptToBuildClassifier(mlm, inNameMap, outNameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, classifier, test.ShouldNotBeNil)
 
@@ -122,7 +124,7 @@ func TestAddingIncorrectModelTypeToModel(t *testing.T) {
 	mlm, err = getTestMlModel(modelLocClassifier)
 	test.That(t, err, test.ShouldBeNil)
 
-	detector, err = attemptToBuildDetector(mlm, nameMap)
+	detector, err = attemptToBuildDetector(mlm, inNameMap, outNameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, detector, test.ShouldNotBeNil)
 
@@ -163,8 +165,9 @@ func TestNewMLDetector(t *testing.T) {
 	test.That(t, check.Outputs[1].Name, test.ShouldResemble, "category")
 	test.That(t, check.Outputs[0].Extra["labels"], test.ShouldNotBeNil)
 
-	nameMap := &sync.Map{}
-	gotDetector, err := attemptToBuildDetector(out, nameMap)
+	inNameMap := &sync.Map{}
+	outNameMap := &sync.Map{}
+	gotDetector, err := attemptToBuildDetector(out, inNameMap, outNameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotDetector, test.ShouldNotBeNil)
 
@@ -188,8 +191,9 @@ func TestNewMLDetector(t *testing.T) {
 	outNL, err := tflitecpu.NewTFLiteCPUModel(ctx, &noLabelCfg, mlmodel.Named("myOtherMLDet"))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, outNL, test.ShouldNotBeNil)
-	nameMap = &sync.Map{}
-	gotDetectorNL, err := attemptToBuildDetector(outNL, nameMap)
+	inNameMap = &sync.Map{}
+	outNameMap = &sync.Map{}
+	gotDetectorNL, err := attemptToBuildDetector(outNL, inNameMap, outNameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotDetectorNL, test.ShouldNotBeNil)
 	gotDetectionsNL, err := gotDetectorNL(ctx, pic)
@@ -238,8 +242,9 @@ func TestNewMLClassifier(t *testing.T) {
 	test.That(t, check.Outputs[0].Name, test.ShouldResemble, "probability")
 	test.That(t, check.Outputs[0].Extra["labels"], test.ShouldNotBeNil)
 
-	nameMap := &sync.Map{}
-	gotClassifier, err := attemptToBuildClassifier(out, nameMap)
+	inNameMap := &sync.Map{}
+	outNameMap := &sync.Map{}
+	gotClassifier, err := attemptToBuildClassifier(out, inNameMap, outNameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotClassifier, test.ShouldNotBeNil)
 
@@ -257,8 +262,9 @@ func TestNewMLClassifier(t *testing.T) {
 	outNL, err := tflitecpu.NewTFLiteCPUModel(ctx, &noLabelCfg, mlmodel.Named("myOtherMLClassif"))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, outNL, test.ShouldNotBeNil)
-	nameMap = &sync.Map{}
-	gotClassifierNL, err := attemptToBuildClassifier(outNL, nameMap)
+	inNameMap = &sync.Map{}
+	outNameMap = &sync.Map{}
+	gotClassifierNL, err := attemptToBuildClassifier(outNL, inNameMap, outNameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotClassifierNL, test.ShouldNotBeNil)
 	gotClassificationsNL, err := gotClassifierNL(ctx, pic)
@@ -300,8 +306,9 @@ func TestMoreMLDetectors(t *testing.T) {
 	test.That(t, check.Inputs[0].DataType, test.ShouldResemble, "float32")
 	test.That(t, len(check.Outputs), test.ShouldEqual, 4)
 
-	nameMap := &sync.Map{}
-	gotDetector, err := attemptToBuildDetector(outModel, nameMap)
+	inNameMap := &sync.Map{}
+	outNameMap := &sync.Map{}
+	gotDetector, err := attemptToBuildDetector(outModel, inNameMap, outNameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotDetector, test.ShouldNotBeNil)
 
@@ -331,8 +338,9 @@ func TestMoreMLClassifiers(t *testing.T) {
 	test.That(t, check, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldBeNil)
 
-	nameMap := &sync.Map{}
-	gotClassifier, err := attemptToBuildClassifier(outModel, nameMap)
+	inNameMap := &sync.Map{}
+	outNameMap := &sync.Map{}
+	gotClassifier, err := attemptToBuildClassifier(outModel, inNameMap, outNameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotClassifier, test.ShouldNotBeNil)
 
@@ -359,8 +367,9 @@ func TestMoreMLClassifiers(t *testing.T) {
 	test.That(t, check, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldBeNil)
 
-	nameMap = &sync.Map{}
-	gotClassifier, err = attemptToBuildClassifier(outModel, nameMap)
+	inNameMap = &sync.Map{}
+	outNameMap = &sync.Map{}
+	gotClassifier, err = attemptToBuildClassifier(outModel, inNameMap, outNameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotClassifier, test.ShouldNotBeNil)
 	gotClassifications, err = gotClassifier(ctx, pic)
@@ -433,8 +442,9 @@ func TestOneClassifierOnManyCameras(t *testing.T) {
 	out, err := tflitecpu.NewTFLiteCPUModel(ctx, &cfg, mlmodel.Named("testClassifier"))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, out, test.ShouldNotBeNil)
-	nameMap := &sync.Map{}
-	outClassifier, err := attemptToBuildClassifier(out, nameMap)
+	inNameMap := &sync.Map{}
+	outNameMap := &sync.Map{}
+	outClassifier, err := attemptToBuildClassifier(out, inNameMap, outNameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, outClassifier, test.ShouldNotBeNil)
 	valuePanda, valueLion := classifyTwoImages(picPanda, picLion, outClassifier)
@@ -452,12 +462,14 @@ func TestMultipleClassifiersOneModel(t *testing.T) {
 	out, err := tflitecpu.NewTFLiteCPUModel(ctx, &cfg, mlmodel.Named("testClassifier"))
 	test.That(t, err, test.ShouldBeNil)
 
-	nameMap := &sync.Map{}
-	Classifier1, err := attemptToBuildClassifier(out, nameMap)
+	inNameMap := &sync.Map{}
+	outNameMap := &sync.Map{}
+	Classifier1, err := attemptToBuildClassifier(out, inNameMap, outNameMap)
 	test.That(t, err, test.ShouldBeNil)
 
-	nameMap = &sync.Map{}
-	Classifier2, err := attemptToBuildClassifier(out, nameMap)
+	inNameMap = &sync.Map{}
+	outNameMap = &sync.Map{}
+	Classifier2, err := attemptToBuildClassifier(out, inNameMap, outNameMap)
 	test.That(t, err, test.ShouldBeNil)
 
 	picPanda, err := rimage.NewImageFromFile(artifact.MustPath("vision/tflite/redpanda.jpeg"))

--- a/services/vision/mlvision/segmenter3d.go
+++ b/services/vision/mlvision/segmenter3d.go
@@ -9,6 +9,6 @@ import (
 )
 
 // TODO: RSDK-2665, build 3D segmenter from ML models.
-func attemptToBuild3DSegmenter(mlm mlmodel.Service, nameMap *sync.Map) (segmentation.Segmenter, error) {
+func attemptToBuild3DSegmenter(mlm mlmodel.Service, inNameMap, outNameMap *sync.Map) (segmentation.Segmenter, error) {
 	return nil, errors.New("cannot use model as a 3D segmenter: vision 3D segmenters from ML models are currently not supported")
 }


### PR DESCRIPTION
This change adds a new optional config parameter to the mlmodel vision service, which allows you to rename your input and output tensor names on the fly so that you can have your mlmodel work with the vision service.

For example, if your mlmodel has an input tensor called "input_0", and output tensors "detection_classes", "detection_boxes", and "detection_scores", but the vision service expects that the input tensor is called "image", and other names for the outputs, too. you can easily fix this in the config by doing 

```
   {
      "type": "vision",
      "model": "mlmodel",
      "attributes": {
        "remap_output_names": {
          "detection_classes": "category",
          "detection_boxes": "location",
          "detection_scores": "score"
        },
        "mlmodel_name": "onnx",
        "remap_input_names": {
          "input_tensor": "image"
        }
      },
      "name": "onnx-vision"
    }
```

This PR also adds more capabilities to models that expected the image to come in with shape [1, 3, height, width], rather than the standard [1, height, width, 3]