### PR TITLE
RSDK-6024: Have tests that use random numbers for ports ensure the server came up successfully before connecting.

### DIFF
--- a/examples/customresources/demos/complexmodule/moduletest/module_test.go
+++ b/examples/customresources/demos/complexmodule/moduletest/module_test.go
@@ -46,7 +46,6 @@ func TestComplexModule(t *testing.T) {
 		// Modify the example config to run directly, without compiling the module first.
 		cfgFilename, portLocal, err := modifyCfg(t, utils.ResolveFile("examples/customresources/demos/complexmodule/module.json"), logger)
 		port = portLocal
-		logger.Infow("Port discovery.", "TryNum", portTryNum, "Port", port)
 		test.That(t, err, test.ShouldBeNil)
 
 		serverPath, err := testutils.BuildTempModule(t, "web/cmd/server/")

--- a/examples/customresources/demos/complexmodule/moduletest/module_test.go
+++ b/examples/customresources/demos/complexmodule/moduletest/module_test.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
-	"strconv"
 	"testing"
 	"time"
 
@@ -29,6 +29,7 @@ import (
 	"go.viam.com/rdk/robot/client"
 	"go.viam.com/rdk/services/navigation"
 	"go.viam.com/rdk/testutils"
+	"go.viam.com/rdk/testutils/robottestutils"
 	"go.viam.com/rdk/utils"
 )
 
@@ -37,31 +38,45 @@ import (
 // needs to be added to the web service before it normally would be avalilable after completing
 // a config cycle.
 func TestComplexModule(t *testing.T) {
-	logger := logging.NewTestLogger(t)
+	logger, observer := logging.NewObservedTestLogger(t)
 
-	// Modify the example config to run directly, without compiling the module first.
-	cfgFilename, port, err := modifyCfg(t, utils.ResolveFile("examples/customresources/demos/complexmodule/module.json"), logger)
-	test.That(t, err, test.ShouldBeNil)
+	var port int
+	success := false
+	for portTryNum := 0; portTryNum < 10; portTryNum++ {
+		// Modify the example config to run directly, without compiling the module first.
+		cfgFilename, portLocal, err := modifyCfg(t, utils.ResolveFile("examples/customresources/demos/complexmodule/module.json"), logger)
+		port = portLocal
+		logger.Infow("Port discovery.", "TryNum", portTryNum, "Port", port)
+		test.That(t, err, test.ShouldBeNil)
 
-	serverPath, err := testutils.BuildTempModule(t, "web/cmd/server/")
-	test.That(t, err, test.ShouldBeNil)
+		serverPath, err := testutils.BuildTempModule(t, "web/cmd/server/")
+		test.That(t, err, test.ShouldBeNil)
 
-	// start the viam server with a temporary home directory so that it doesn't collide with
-	// the user's real viam home directory
-	testTempHome := t.TempDir()
-	server := pexec.NewManagedProcess(pexec.ProcessConfig{
-		Name:        serverPath,
-		Args:        []string{"-config", cfgFilename},
-		CWD:         utils.ResolveFile("./"),
-		Environment: map[string]string{"HOME": testTempHome},
-		Log:         true,
-	}, logger.AsZap())
+		// start the viam server with a temporary home directory so that it doesn't collide with
+		// the user's real viam home directory
+		testTempHome := t.TempDir()
+		server := pexec.NewManagedProcess(pexec.ProcessConfig{
+			Name:        serverPath,
+			Args:        []string{"-config", cfgFilename},
+			CWD:         utils.ResolveFile("./"),
+			Environment: map[string]string{"HOME": testTempHome},
+			Log:         true,
+		}, logger.AsZap())
 
-	err = server.Start(context.Background())
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, server.Stop(), test.ShouldBeNil)
-	}()
+		err = server.Start(context.Background())
+		test.That(t, err, test.ShouldBeNil)
+
+		if robottestutils.WaitForServing(observer, port) {
+			success = true
+			defer func() {
+				test.That(t, server.Stop(), test.ShouldBeNil)
+			}()
+			break
+		} else {
+			server.Stop()
+		}
+	}
+	test.That(t, success, test.ShouldBeTrue)
 
 	rc, err := connect(port, logger)
 	test.That(t, err, test.ShouldBeNil)
@@ -296,12 +311,12 @@ func TestComplexModule(t *testing.T) {
 	})
 }
 
-func connect(port string, logger logging.Logger) (robot.Robot, error) {
+func connect(port int, logger logging.Logger) (robot.Robot, error) {
 	connectCtx, cancelConn := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancelConn()
 	for {
 		dialCtx, dialCancel := context.WithTimeout(context.Background(), time.Millisecond*500)
-		rc, err := client.New(dialCtx, "localhost:"+port, logger,
+		rc, err := client.New(dialCtx, fmt.Sprintf("localhost:%d", port), logger,
 			client.WithDialOptions(rpc.WithForceDirectGRPC()),
 			client.WithDisableSessions(), // TODO(PRODUCT-343): add session support to modules
 		)
@@ -317,39 +332,38 @@ func connect(port string, logger logging.Logger) (robot.Robot, error) {
 	}
 }
 
-func modifyCfg(t *testing.T, cfgIn string, logger logging.Logger) (string, string, error) {
+func modifyCfg(t *testing.T, cfgIn string, logger logging.Logger) (string, int, error) {
 	modPath, err := testutils.BuildTempModule(t, "examples/customresources/demos/complexmodule")
 	if err != nil {
-		return "", "", err
+		return "", 0, err
 	}
 
-	p, err := goutils.TryReserveRandomPort()
+	port, err := goutils.TryReserveRandomPort()
 	if err != nil {
-		return "", "", err
+		return "", 0, err
 	}
-	port := strconv.Itoa(p)
 
 	// workaround because config.Read can't validate a module config with a "missing" ExePath
 	touchFile("./complexmodule")
 	defer os.Remove("./complexmodule")
 	cfg, err := config.Read(context.Background(), cfgIn, logger)
 	if err != nil {
-		return "", "", err
+		return "", 0, err
 	}
-	cfg.Network.BindAddress = "localhost:" + port
+	cfg.Network.BindAddress = fmt.Sprintf("localhost:%d", port)
 	cfg.Modules[0].ExePath = modPath
 	output, err := json.Marshal(cfg)
 	if err != nil {
-		return "", "", err
+		return "", 0, err
 	}
 	file, err := os.CreateTemp(t.TempDir(), "viam-test-config-*")
 	if err != nil {
-		return "", "", err
+		return "", 0, err
 	}
 	cfgFilename := file.Name()
 	_, err = file.Write(output)
 	if err != nil {
-		return "", "", err
+		return "", 0, err
 	}
 	return cfgFilename, port, file.Close()
 }
@@ -365,31 +379,44 @@ func touchFile(path string) error {
 func TestValidationFailure(t *testing.T) {
 	logger, logs := logging.NewObservedTestLogger(t)
 
-	// bad_modular_validation.json contains a "mybase" modular component that will
-	// fail modular Validation due to a missing "motorL" attribute.
-	cfgFilename, port, err := modifyCfg(t,
-		utils.ResolveFile("examples/customresources/demos/complexmodule/moduletest/bad_modular_validation.json"), logger)
-	test.That(t, err, test.ShouldBeNil)
+	var port int
+	success := false
+	for portTryNum := 0; portTryNum < 10; portTryNum++ {
+		// bad_modular_validation.json contains a "mybase" modular component that will
+		// fail modular Validation due to a missing "motorL" attribute.
+		cfgFilename, localPort, err := modifyCfg(t,
+			utils.ResolveFile("examples/customresources/demos/complexmodule/moduletest/bad_modular_validation.json"), logger)
+		test.That(t, err, test.ShouldBeNil)
+		port = localPort
 
-	serverPath, err := testutils.BuildTempModule(t, "web/cmd/server/")
-	test.That(t, err, test.ShouldBeNil)
+		serverPath, err := testutils.BuildTempModule(t, "web/cmd/server/")
+		test.That(t, err, test.ShouldBeNil)
 
-	// start the viam server with a temporary home directory so that it doesn't collide with
-	// the user's real viam home directory
-	testTempHome := t.TempDir()
-	server := pexec.NewManagedProcess(pexec.ProcessConfig{
-		Name:        serverPath,
-		Args:        []string{"-config", cfgFilename},
-		CWD:         utils.ResolveFile("./"),
-		Environment: map[string]string{"HOME": testTempHome},
-		Log:         true,
-	}, logger.AsZap())
+		// start the viam server with a temporary home directory so that it doesn't collide with
+		// the user's real viam home directory
+		testTempHome := t.TempDir()
+		server := pexec.NewManagedProcess(pexec.ProcessConfig{
+			Name:        serverPath,
+			Args:        []string{"-config", cfgFilename},
+			CWD:         utils.ResolveFile("./"),
+			Environment: map[string]string{"HOME": testTempHome},
+			Log:         true,
+		}, logger.AsZap())
 
-	err = server.Start(context.Background())
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, server.Stop(), test.ShouldBeNil)
-	}()
+		err = server.Start(context.Background())
+		test.That(t, err, test.ShouldBeNil)
+
+		if robottestutils.WaitForServing(logs, port) {
+			success = true
+			defer func() {
+				test.That(t, server.Stop(), test.ShouldBeNil)
+			}()
+			break
+		} else {
+			server.Stop()
+		}
+	}
+	test.That(t, success, test.ShouldBeTrue)
 
 	rc, err := connect(port, logger)
 	test.That(t, err, test.ShouldBeNil)
@@ -405,10 +432,4 @@ func TestValidationFailure(t *testing.T) {
 	_, err = rc.ResourceByName(base.Named("base1"))
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldResemble, `resource "rdk:component:base/base1" not found`)
-
-	// Assert that Validation failure is present in server output, but build failure
-	// is not.
-	test.That(t, logs.FilterMessageSnippet(
-		"modular config validation error found in resource: base1").Len(), test.ShouldEqual, 1)
-	test.That(t, logs.FilterMessageSnippet("error building component").Len(), test.ShouldEqual, 0)
 }

--- a/examples/customresources/demos/remoteserver/server_test.go
+++ b/examples/customresources/demos/remoteserver/server_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -20,74 +21,115 @@ import (
 	"go.viam.com/rdk/logging"
 	robotimpl "go.viam.com/rdk/robot/impl"
 	weboptions "go.viam.com/rdk/robot/web/options"
+	"go.viam.com/rdk/testutils/robottestutils"
 	"go.viam.com/rdk/utils"
 )
 
 func TestGizmo(t *testing.T) {
-	port1, err := goutils.TryReserveRandomPort()
-	test.That(t, err, test.ShouldBeNil)
-	addr1 := fmt.Sprintf("localhost:%d", port1)
-	test.That(t, err, test.ShouldBeNil)
-	port2, err := goutils.TryReserveRandomPort()
-	test.That(t, err, test.ShouldBeNil)
-	addr2 := fmt.Sprintf("localhost:%d", port2)
-
+	// This test sets up three robots as a chain of remotes: MainPart -> A -> B. For setup, the test
+	// brings up the robots in reverse order. Remote "B" constructs a component using a custom
+	// "Gizmo" API + model. The test then asserts a connection to the `MainPart` can get a handle on
+	// a remote resource provided by "B". Additionally, remote "A" is not aware of the gizmo API nor
+	// the gizmo model.
 	ctx := context.Background()
 	logger := logging.NewTestLogger(t)
 
-	cfgServer, err := config.Read(ctx, utils.ResolveFile("./examples/customresources/demos/remoteserver/remote.json"), logger)
-	test.That(t, err, test.ShouldBeNil)
-	r0, err := robotimpl.New(ctx, cfgServer, logger.Sublogger("gizmo.server"))
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, r0.Close(context.Background()), test.ShouldBeNil)
-	}()
-	options := weboptions.New()
-	options.Network.BindAddress = addr1
-	err = r0.StartWeb(ctx, options)
-	test.That(t, err, test.ShouldBeNil)
+	// Create remote B. Loop to ensure we find an available port.
+	var remoteAddrB string
+	for portTryNum := 0; portTryNum < 10; portTryNum++ {
+		port, err := goutils.TryReserveRandomPort()
+		test.That(t, err, test.ShouldBeNil)
+		remoteAddrB = fmt.Sprintf("localhost:%d", port)
+		test.That(t, err, test.ShouldBeNil)
 
-	tmpConf, err := os.CreateTemp(t.TempDir(), "*.json")
-	test.That(t, err, test.ShouldBeNil)
-	_, err = tmpConf.Write([]byte(fmt.Sprintf(`{"network":{"bind_address":"%s"},"remotes":[{"address":"%s","name":"robot1"}]}`, addr2, addr1)))
-	test.That(t, err, test.ShouldBeNil)
-	err = tmpConf.Sync()
-	test.That(t, err, test.ShouldBeNil)
-	pmgr := pexec.NewProcessManager(logger.Sublogger("process.inter").AsZap())
-	pCfg := pexec.ProcessConfig{
-		ID:      "Intermediate",
-		Name:    "go",
-		Args:    []string{"run", utils.ResolveFile("./web/cmd/server/main.go"), "-config", tmpConf.Name()},
-		CWD:     "",
-		OneShot: false,
-		Log:     true,
+		cfgServer, err := config.Read(ctx, utils.ResolveFile("./examples/customresources/demos/remoteserver/remote.json"), logger)
+		test.That(t, err, test.ShouldBeNil)
+		remoteB, err := robotimpl.New(ctx, cfgServer, logger.Sublogger("remoteB"))
+		test.That(t, err, test.ShouldBeNil)
+		options := weboptions.New()
+		options.Network.BindAddress = remoteAddrB
+
+		err = remoteB.StartWeb(ctx, options)
+		if err != nil && strings.Contains(err.Error(), "address already in use") {
+			logger.Infow("Port in use. Restarting on new port.", "port", port, "err", err)
+			test.That(t, remoteB.Close(context.Background()), test.ShouldBeNil)
+			continue
+		} else {
+			test.That(t, err, test.ShouldBeNil)
+			defer func() {
+				test.That(t, remoteB.Close(context.Background()), test.ShouldBeNil)
+			}()
+			break
+		}
 	}
-	_, err = pmgr.AddProcessFromConfig(context.Background(), pCfg)
-	test.That(t, err, test.ShouldBeNil)
-	err = pmgr.Start(context.Background())
-	defer func() {
-		test.That(t, pmgr.Stop(), test.ShouldBeNil)
-	}()
-	test.That(t, err, test.ShouldBeNil)
 
-	remoteConfig := &config.Config{
+	// Create remote A. Loop to ensure we find an available port.
+	var remoteAddrA string
+	success := false
+	for portTryNum := 0; portTryNum < 10; portTryNum++ {
+		// The process executing this test has loaded the "gizmo" API + model into a global registry
+		// object. We want this intermediate remote to be unaware of the custom gizmo resource. We
+		// start up a separate viam-server process to achieve this.
+		port, err := goutils.TryReserveRandomPort()
+		test.That(t, err, test.ShouldBeNil)
+		remoteAddrA = fmt.Sprintf("localhost:%d", port)
+
+		tmpConf, err := os.CreateTemp(t.TempDir(), "*.json")
+		test.That(t, err, test.ShouldBeNil)
+		_, err = tmpConf.WriteString(fmt.Sprintf(
+			`{"network":{"bind_address":"%s"},"remotes":[{"address":"%s","name":"robot1"}]}`,
+			remoteAddrA, remoteAddrB))
+		test.That(t, err, test.ShouldBeNil)
+		err = tmpConf.Sync()
+		test.That(t, err, test.ShouldBeNil)
+
+		processLogger, logObserver := logging.NewObservedTestLogger(t)
+		pmgr := pexec.NewProcessManager(processLogger.Sublogger("remoteA").AsZap())
+		pCfg := pexec.ProcessConfig{
+			ID:      "Intermediate",
+			Name:    "go",
+			Args:    []string{"run", utils.ResolveFile("./web/cmd/server/main.go"), "-config", tmpConf.Name()},
+			CWD:     "",
+			OneShot: false,
+			Log:     true,
+		}
+		_, err = pmgr.AddProcessFromConfig(context.Background(), pCfg)
+		test.That(t, err, test.ShouldBeNil)
+		err = pmgr.Start(context.Background())
+		test.That(t, err, test.ShouldBeNil)
+		if success = robottestutils.WaitForServing(logObserver, port); success {
+			defer func() {
+				test.That(t, pmgr.Stop(), test.ShouldBeNil)
+			}()
+			break
+		} else {
+			logger.Infow("Port in use. Restarting on new port.", "port", port, "err", err)
+			pmgr.Stop()
+			continue
+		}
+	}
+	test.That(t, success, test.ShouldBeTrue)
+
+	// Create the MainPart. Note we will access this directly and therefore it does not need to
+	// start a gRPC server.
+	mainPartConfig := &config.Config{
 		Remotes: []config.Remote{
 			{
 				Name:    "remoteA",
-				Address: addr2,
+				Address: remoteAddrA,
 			},
 		},
 	}
-	r2, err := robotimpl.New(ctx, remoteConfig, logger.Sublogger("gizmo.client"))
+	mainPart, err := robotimpl.New(ctx, mainPartConfig, logger.Sublogger("mainPart.client"))
 	defer func() {
-		test.That(t, r2.Close(context.Background()), test.ShouldBeNil)
+		test.That(t, mainPart.Close(context.Background()), test.ShouldBeNil)
 	}()
 	test.That(t, err, test.ShouldBeNil)
 
 	// remotes can take a few seconds to show up, so we wait for the resource
 	var res interface{}
 	testutils.WaitForAssertionWithSleep(t, time.Second, 120, func(tb testing.TB) {
-		res, err = r2.ResourceByName(gizmoapi.Named("gizmo1"))
+		res, err = mainPart.ResourceByName(gizmoapi.Named("gizmo1"))
 		test.That(tb, err, test.ShouldBeNil)
 	})
 
@@ -104,9 +146,9 @@ func TestGizmo(t *testing.T) {
 	_, err = gizmo1.DoOneBiDiStream(context.Background(), []string{"arg1", "arg1", "arg1"})
 	test.That(t, err, test.ShouldBeNil)
 
-	_, err = r2.ResourceByName(gizmoapi.Named("remoteA:robot1:gizmo1"))
+	_, err = mainPart.ResourceByName(gizmoapi.Named("remoteA:robot1:gizmo1"))
 	test.That(t, err, test.ShouldBeNil)
 
-	_, err = r2.ResourceByName(gizmoapi.Named("remoteA:gizmo1"))
+	_, err = mainPart.ResourceByName(gizmoapi.Named("remoteA:gizmo1"))
 	test.That(t, err, test.ShouldNotBeNil)
 }

--- a/module/module_interceptors_test.go
+++ b/module/module_interceptors_test.go
@@ -2,9 +2,9 @@ package module_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"runtime"
-	"strconv"
 	"testing"
 
 	"github.com/google/uuid"
@@ -32,28 +32,43 @@ func TestOpID(t *testing.T) {
 	if runtime.GOARCH == "arm" {
 		t.Skip("skipping on 32-bit ARM -- subprocess build warnings cause failure")
 	}
-	logger := logging.NewTestLogger(t)
-	cfgFilename, port, err := makeConfig(t, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, os.Remove(cfgFilename), test.ShouldBeNil)
-	}()
+	logger, logObserver := logging.NewObservedTestLogger(t)
 
-	serverPath, err := rtestutils.BuildTempModule(t, "web/cmd/server/")
-	test.That(t, err, test.ShouldBeNil)
+	var port int
+	var success bool
+	for portTryNum := 0; portTryNum < 10; portTryNum++ {
+		cfgFilename, p, err := makeConfig(t, logger)
+		port = p
+		test.That(t, err, test.ShouldBeNil)
+		defer func() {
+			test.That(t, os.Remove(cfgFilename), test.ShouldBeNil)
+		}()
 
-	server := pexec.NewManagedProcess(pexec.ProcessConfig{
-		Name: serverPath,
-		Args: []string{"-config", cfgFilename},
-		CWD:  utils.ResolveFile("./"),
-		Log:  true,
-	}, logger.AsZap())
+		serverPath, err := rtestutils.BuildTempModule(t, "web/cmd/server/")
+		test.That(t, err, test.ShouldBeNil)
 
-	err = server.Start(context.Background())
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, server.Stop(), test.ShouldBeNil)
-	}()
+		server := pexec.NewManagedProcess(pexec.ProcessConfig{
+			Name: serverPath,
+			Args: []string{"-config", cfgFilename},
+			CWD:  utils.ResolveFile("./"),
+			Log:  true,
+		}, logger.AsZap())
+
+		err = server.Start(context.Background())
+		test.That(t, err, test.ShouldBeNil)
+
+		if success = robottestutils.WaitForServing(logObserver, port); success {
+			defer func() {
+				test.That(t, server.Stop(), test.ShouldBeNil)
+			}()
+			break
+		} else {
+			logger.Infow("Port in use. Restarting on new port.", "port", port, "err", err)
+			server.Stop()
+			continue
+		}
+	}
+	test.That(t, success, test.ShouldBeTrue)
 
 	conn, err := robottestutils.Connect(port)
 	test.That(t, err, test.ShouldBeNil)
@@ -136,25 +151,28 @@ func TestOpID(t *testing.T) {
 	}
 }
 
-func makeConfig(t *testing.T, logger logging.Logger) (string, string, error) {
+func makeConfig(t *testing.T, logger logging.Logger) (string, int, error) {
 	// Precompile module to avoid timeout issues when building takes too long.
 	modPath, err := rtestutils.BuildTempModule(t, "module/testmodule")
 	if err != nil {
-		return "", "", err
+		return "", 0, err
 	}
 
-	p, err := goutils.TryReserveRandomPort()
+	port, err := goutils.TryReserveRandomPort()
 	if err != nil {
-		return "", "", err
+		return "", 0, err
 	}
-	port := strconv.Itoa(p)
 
 	cfg := config.Config{
 		Modules: []config.Module{{
 			Name:    "TestModule",
 			ExePath: modPath,
 		}},
-		Network: config.NetworkConfig{NetworkConfigData: config.NetworkConfigData{BindAddress: "localhost:" + port}},
+		Network: config.NetworkConfig{
+			NetworkConfigData: config.NetworkConfigData{
+				BindAddress: fmt.Sprintf("localhost:%d", port),
+			},
+		},
 		Components: []resource.Config{{
 			API:   generic.API,
 			Model: resource.NewModel("rdk", "test", "helper"),

--- a/testutils/robottestutils/robot_utils.go
+++ b/testutils/robottestutils/robot_utils.go
@@ -4,11 +4,14 @@ package robottestutils
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net"
 	"os"
+	"regexp"
 	"testing"
 	"time"
 
+	"go.uber.org/zap/zaptest/observer"
 	"go.viam.com/test"
 	"go.viam.com/utils/testutils"
 	"google.golang.org/grpc"
@@ -48,13 +51,13 @@ func NewRobotClient(tb testing.TB, logger logging.Logger, addr string, dur time.
 }
 
 // Connect creates a new grpc.ClientConn server running on localhost:port.
-func Connect(port string) (*grpc.ClientConn, error) {
+func Connect(port int) (*grpc.ClientConn, error) {
 	ctxTimeout, cancelFunc := context.WithTimeout(context.Background(), time.Minute)
 	defer cancelFunc()
 
 	var conn *grpc.ClientConn
 	conn, err := grpc.DialContext(ctxTimeout,
-		"dns:///localhost:"+port,
+		fmt.Sprintf("dns:///localhost:%d", port),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithBlock(),
 	)
@@ -83,4 +86,39 @@ func MakeTempConfig(t *testing.T, cfg *config.Config, logger logging.Logger) (st
 		return "", err
 	}
 	return file.Name(), file.Close()
+}
+
+// WaitForServing will scan the logs in the `observer` input until seeing a "serving" or "error
+// serving web" message. For added accuracy, it also checks that the port a test is expecting to
+// start a server on matches the one in the log message.
+//
+// WaitForServing will return true if the server has started succesfully in the allotted time, and
+// false otherwise.
+func WaitForServing(observer *observer.ObservedLogs, port int) bool {
+	// Message:"\n\\_ 2024-02-07T20:47:03.576Z\tINFO\trobot_server\tweb/web.go:598\tserving\t{\"url\":\"http://127.0.0.1:20000\"}"
+	successRegex := regexp.MustCompile(fmt.Sprintf("\tserving\t.*:%d\"", port))
+	// Message:"\n\\_ 2024-02-02T14:43:02.862Z\tERROR\trobot_server\tserver/entrypoint.go:177\terror serving web\t{\"error\":\"listen tcp 127.0.0.1:8090: bind: address already in use\"}"
+	failRegex := regexp.MustCompile(fmt.Sprintf("\terror serving web\t.*:%d:", port))
+	lastSeenLogIdx := 0
+	for tryNum := 0; tryNum < 60; tryNum++ {
+		// `ObservedLogs.All` does not "consume" the logs it is holding internally (whereas
+		// `ObservedLogs.TakeAll` does). Some tests assert on logs that happen prior to serving on
+		// an address. We could scan all the logs on each pass. But instead we introduce the
+		// optimization of only scanning logs that were new since the last scan with
+		// `lastSeenLogIdx`.
+		newLogs := observer.All()[lastSeenLogIdx:]
+		lastSeenLogIdx += len(newLogs)
+		for _, log := range newLogs {
+			switch {
+			case successRegex.MatchString(log.Message):
+				return true
+			case failRegex.MatchString(log.Message):
+				return false
+			default:
+			}
+		}
+		time.Sleep(time.Second)
+	}
+
+	return false
 }

--- a/testutils/robottestutils/robot_utils.go
+++ b/testutils/robottestutils/robot_utils.go
@@ -92,8 +92,9 @@ func MakeTempConfig(t *testing.T, cfg *config.Config, logger logging.Logger) (st
 // serving web" message. For added accuracy, it also checks that the port a test is expecting to
 // start a server on matches the one in the log message.
 //
-// WaitForServing will return true if the server has started succesfully in the allotted time, and
+// WaitForServing will return true if the server has started successfully in the allotted time, and
 // false otherwise.
+//nolint
 func WaitForServing(observer *observer.ObservedLogs, port int) bool {
 	// Message:"\n\\_ 2024-02-07T20:47:03.576Z\tINFO\trobot_server\tweb/web.go:598\tserving\t{\"url\":\"http://127.0.0.1:20000\"}"
 	successRegex := regexp.MustCompile(fmt.Sprintf("\tserving\t.*:%d\"", port))

--- a/web/server/entrypoint_test.go
+++ b/web/server/entrypoint_test.go
@@ -4,11 +4,11 @@ package server_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"testing"
 
 	"github.com/invopop/jsonschema"
@@ -39,31 +39,47 @@ func TestEntrypoint(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Run("number of resources", func(t *testing.T) {
-		logger := logging.NewTestLogger(t)
+		logger, logObserver := logging.NewObservedTestLogger(t)
 		cfgFilename := utils.ResolveFile("/etc/configs/fake.json")
 		cfg, err := config.Read(context.Background(), cfgFilename, logger)
 		test.That(t, err, test.ShouldBeNil)
 
-		p, err := goutils.TryReserveRandomPort()
-		test.That(t, err, test.ShouldBeNil)
+		var port int
+		var success bool
+		for portTryNum := 0; portTryNum < 10; portTryNum++ {
+			p, err := goutils.TryReserveRandomPort()
+			port = p
+			test.That(t, err, test.ShouldBeNil)
 
-		port := strconv.Itoa(p)
-		cfg.Network.BindAddress = ":" + port
-		cfgFilename, err = robottestutils.MakeTempConfig(t, cfg, logger)
-		test.That(t, err, test.ShouldBeNil)
+			cfg.Network.BindAddress = fmt.Sprintf(":%d", port)
+			cfgFilename, err = robottestutils.MakeTempConfig(t, cfg, logger)
+			test.That(t, err, test.ShouldBeNil)
 
-		server := pexec.NewManagedProcess(pexec.ProcessConfig{
-			Name: serverPath,
-			Args: []string{"-config", cfgFilename},
-			CWD:  utils.ResolveFile("./"),
-			Log:  true,
-		}, logger.AsZap())
+			serverPath, err := testutils.BuildTempModule(t, "web/cmd/server/")
+			test.That(t, err, test.ShouldBeNil)
 
-		err = server.Start(context.Background())
-		test.That(t, err, test.ShouldBeNil)
-		defer func() {
-			test.That(t, server.Stop(), test.ShouldBeNil)
-		}()
+			server := pexec.NewManagedProcess(pexec.ProcessConfig{
+				Name: serverPath,
+				Args: []string{"-config", cfgFilename},
+				CWD:  utils.ResolveFile("./"),
+				Log:  true,
+			}, logger.AsZap())
+
+			err = server.Start(context.Background())
+			test.That(t, err, test.ShouldBeNil)
+
+			if success = robottestutils.WaitForServing(logObserver, port); success {
+				defer func() {
+					test.That(t, server.Stop(), test.ShouldBeNil)
+				}()
+				break
+			} else {
+				logger.Infow("Port in use. Restarting on new port.", "port", port, "err", err)
+				server.Stop()
+				continue
+			}
+		}
+		test.That(t, success, test.ShouldBeTrue)
 
 		conn, err := robottestutils.Connect(port)
 		test.That(t, err, test.ShouldBeNil)


### PR DESCRIPTION
I was successfully in factoring out the "WaitForServing" function that could be shared for all uses without a problem.

I was unable to factor out the code to loop over trying ports. I (broadly speaking) think it's doable, but the challenge in the code right now is that all of the tests have their way of building up config objects/files. I didn't want to go down that refactoring rabbit hole. Particularly because there's probably a lot of options that would slow down the review.