### PR TITLE
RSDK-6599 Add non-erroring GetAccuracy implementations to FIX RC Card polling of API

### DIFF
--- a/components/movementsensor/adxl345/adxl345.go
+++ b/components/movementsensor/adxl345/adxl345.go
@@ -147,7 +147,7 @@ func init() {
 		movementsensor.API,
 		model,
 		resource.Registration[movementsensor.MovementSensor, *Config]{
-			Constructor: NewAdxl345,
+			Constructor: newAdxl345,
 		})
 }
 
@@ -176,8 +176,8 @@ type adxl345 struct {
 	activeBackgroundWorkers sync.WaitGroup
 }
 
-// NewAdxl345 is a constructor to create a new object representing an ADXL345 accelerometer.
-func NewAdxl345(
+// newAdxl345 is a constructor to create a new object representing an ADXL345 accelerometer.
+func newAdxl345(
 	ctx context.Context,
 	deps resource.Dependencies,
 	conf resource.Config,

--- a/components/movementsensor/adxl345/adxl345.go
+++ b/components/movementsensor/adxl345/adxl345.go
@@ -567,7 +567,8 @@ func (adxl *adxl345) Position(ctx context.Context, extra map[string]interface{})
 }
 
 func (adxl *adxl345) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
-	return nil, movementsensor.ErrMethodUnimplementedAccuracy
+	// this driver is unable to provide positional or compass heading data
+	return movementsensor.UnimplementedAccuracies()
 }
 
 func (adxl *adxl345) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {

--- a/components/movementsensor/dualgps/dualgps.go
+++ b/components/movementsensor/dualgps/dualgps.go
@@ -264,7 +264,7 @@ func (dg *dualGPS) Orientation(ctx context.Context, extra map[string]interface{}
 }
 
 func (dg *dualGPS) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
-	// RSDK-6389: for this driver, find the highest value VDOP and HDOP to show the worst accuracy in position
+	// TODO: RSDK-6389: for this driver, find the highest value VDOP and HDOP to show the worst accuracy in position
 	// check the fix and return the compass error using a calculation based on the fix and variation
 	// of the two positions.
 	// return the NMEA Fix that appears from either gps in this order: (worst) 0, 1, 2, 5, 4 (best), or -1 if

--- a/components/movementsensor/dualgps/dualgps.go
+++ b/components/movementsensor/dualgps/dualgps.go
@@ -264,7 +264,12 @@ func (dg *dualGPS) Orientation(ctx context.Context, extra map[string]interface{}
 }
 
 func (dg *dualGPS) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
-	return nil, movementsensor.ErrMethodUnimplementedAccuracy
+	// RSDK-6389: for this driver, find the highest value VDOP and HDOP to show the worst accuracy in position
+	// check the fix and return the compass error using a calculation based on the fix and variation
+	// of the two positions.
+	// return the NMEA Fix that appears from either gps in this order: (worst) 0, 1, 2, 5, 4 (best), or -1 if
+	// it is not any of these (other nmea GGA fixes indicate simulated or deadreckoning gps devices)
+	return movementsensor.UnimplementedAccuracies()
 }
 
 func (dg *dualGPS) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {

--- a/components/movementsensor/fake/movementsensor.go
+++ b/components/movementsensor/fake/movementsensor.go
@@ -83,10 +83,10 @@ func (f *MovementSensor) DoCommand(ctx context.Context, cmd map[string]interface
 func (f *MovementSensor) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
 	acc := movementsensor.Accuracy{
 		AccuracyMap:        map[string]float32{},
-		Hdop:               1,
-		Vdop:               2,
+		Hdop:               0,
+		Vdop:               0,
 		NmeaFix:            4,
-		CompassDegreeError: 0.1,
+		CompassDegreeError: 0,
 	}
 
 	return &acc, nil

--- a/components/movementsensor/fake/movementsensor.go
+++ b/components/movementsensor/fake/movementsensor.go
@@ -83,10 +83,10 @@ func (f *MovementSensor) DoCommand(ctx context.Context, cmd map[string]interface
 func (f *MovementSensor) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
 	acc := movementsensor.Accuracy{
 		AccuracyMap:        map[string]float32{},
-		Hdop:               0,
-		Vdop:               0,
+		Hdop:               1,
+		Vdop:               2,
 		NmeaFix:            4,
-		CompassDegreeError: 0,
+		CompassDegreeError: 0.1,
 	}
 
 	return &acc, nil

--- a/components/movementsensor/imuvectornav/imu.go
+++ b/components/movementsensor/imuvectornav/imu.go
@@ -280,7 +280,7 @@ func (vn *vectornav) Position(ctx context.Context, extra map[string]interface{})
 }
 
 func (vn *vectornav) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
-	// RSDK-6389 check the vectornav's datasheet to determine what is best to return from the vector nav.
+	// TODO:  RSDK-6389 check the vectornav's datasheet to determine what is best to return from the vector nav.
 	// can be done in a seprate ticket from the one mentioned in this comment.
 	return movementsensor.UnimplementedAccuracies()
 }

--- a/components/movementsensor/imuvectornav/imu.go
+++ b/components/movementsensor/imuvectornav/imu.go
@@ -280,7 +280,9 @@ func (vn *vectornav) Position(ctx context.Context, extra map[string]interface{})
 }
 
 func (vn *vectornav) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
-	return nil, movementsensor.ErrMethodUnimplementedAccuracy
+	// RSDK-6389 check the vectornav's datasheet to determine what is best to return from the vector nav.
+	// can be done in a seprate ticket from the one mentioned in this comment.
+	return movementsensor.UnimplementedAccuracies()
 }
 
 func (vn *vectornav) GetMagnetometer(ctx context.Context) (r3.Vector, error) {

--- a/components/movementsensor/imuwit/imu.go
+++ b/components/movementsensor/imuwit/imu.go
@@ -202,7 +202,12 @@ func (imu *wit) Position(ctx context.Context, extra map[string]interface{}) (*ge
 
 func (imu *wit) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error,
 ) {
-	return nil, movementsensor.ErrMethodUnimplementedAccuracy
+	// RSDK-6389 return the compass heading from the datasheet of the witIMU if the pitch angle is less than 45 degrees
+	// and the roll angle is near zero
+	// mag projects at angles over this threshold cannot be determined because of the larger contribution of other
+	// orientations to the true compass heading
+	// return NaN for compass accuracy otherwise.
+	return movementsensor.UnimplementedAccuracies()
 }
 
 func (imu *wit) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {

--- a/components/movementsensor/imuwit/imu.go
+++ b/components/movementsensor/imuwit/imu.go
@@ -202,7 +202,7 @@ func (imu *wit) Position(ctx context.Context, extra map[string]interface{}) (*ge
 
 func (imu *wit) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error,
 ) {
-	// RSDK-6389 return the compass heading from the datasheet of the witIMU if the pitch angle is less than 45 degrees
+	// TODO: RSDK-6389 return the compass heading from the datasheet of the witIMU if the pitch angle is less than 45 degrees
 	// and the roll angle is near zero
 	// mag projects at angles over this threshold cannot be determined because of the larger contribution of other
 	// orientations to the true compass heading

--- a/components/movementsensor/merged/merged.go
+++ b/components/movementsensor/merged/merged.go
@@ -295,6 +295,10 @@ func (m *merged) Accuracy(ctx context.Context, extra map[string]interface{}) (*m
 		}
 	}
 
+	hdop := float32(math.NaN())
+	vdop := float32(math.NaN())
+	nmeaFix := int32(-1)
+
 	if m.pos != nil {
 		posAcc, err := m.pos.Accuracy(ctx, extra)
 		if err != nil {
@@ -309,8 +313,12 @@ func (m *merged) Accuracy(ctx context.Context, extra map[string]interface{}) (*m
 		if posAcc != nil {
 			maps.Copy(accMap, mapWithSensorName(m.pos.Name().ShortName(), posAcc.AccuracyMap))
 		}
+		hdop = posAcc.Hdop
+		vdop = posAcc.Vdop
+		nmeaFix = posAcc.NmeaFix
 	}
 
+	compassDegreeError := float32(math.NaN())
 	if m.compass != nil {
 		compassAcc, err := m.compass.Accuracy(ctx, extra)
 		if err != nil {
@@ -325,6 +333,7 @@ func (m *merged) Accuracy(ctx context.Context, extra map[string]interface{}) (*m
 		if compassAcc != nil {
 			maps.Copy(accMap, mapWithSensorName(m.compass.Name().ShortName(), compassAcc.AccuracyMap))
 		}
+		compassDegreeError = compassAcc.CompassDegreeError
 	}
 
 	if m.linVel != nil {
@@ -377,10 +386,10 @@ func (m *merged) Accuracy(ctx context.Context, extra map[string]interface{}) (*m
 
 	acc := movementsensor.Accuracy{
 		AccuracyMap:        accMap,
-		Hdop:               float32(math.NaN()),
-		Vdop:               float32(math.NaN()),
-		NmeaFix:            -1,
-		CompassDegreeError: float32(math.NaN()),
+		Hdop:               hdop,
+		Vdop:               vdop,
+		NmeaFix:            nmeaFix,
+		CompassDegreeError: compassDegreeError,
 	}
 
 	return &acc, errs

--- a/components/movementsensor/movementsensor.go
+++ b/components/movementsensor/movementsensor.go
@@ -3,6 +3,7 @@ package movementsensor
 
 import (
 	"context"
+	"math"
 	"strings"
 
 	"github.com/golang/geo/r3"
@@ -153,4 +154,19 @@ func DefaultAPIReadings(ctx context.Context, g MovementSensor, extra map[string]
 	}
 
 	return readings, nil
+}
+
+// UnimplementedAccuracies returns accuracy values that will not show up on movement sensor's RC card
+// or be useable for a caller of the GetAccuracies method. The RC card currently continuosly polls accuracies,
+// so a nil error must be rturned from the GetAccuracies call.
+// It contains NaN definitiions for accuracies returned in floats, an invalid integer value for the NMEAFix of a gps
+// and an empty map of other accuracies.
+func UnimplementedAccuracies() (*Accuracy, error) {
+	return &Accuracy{
+		AccuracyMap:        map[string]float32{},
+		Hdop:               float32(math.NaN()),
+		Vdop:               float32(math.NaN()),
+		NmeaFix:            int32(-1),
+		CompassDegreeError: float32(math.NaN()),
+	}, nil
 }

--- a/components/movementsensor/movementsensor.go
+++ b/components/movementsensor/movementsensor.go
@@ -157,7 +157,7 @@ func DefaultAPIReadings(ctx context.Context, g MovementSensor, extra map[string]
 }
 
 // UnimplementedAccuracies returns accuracy values that will not show up on movement sensor's RC card
-// or be useable for a caller of the GetAccuracies method. The RC card currently continuosly polls accuracies,
+// or be useable for a caller of the GetAccuracies method. The RC card currently continuously polls accuracies,
 // so a nil error must be rturned from the GetAccuracies call.
 // It contains NaN definitiions for accuracies returned in floats, an invalid integer value for the NMEAFix of a gps
 // and an empty map of other accuracies.

--- a/components/movementsensor/mpu6050/mpu6050.go
+++ b/components/movementsensor/mpu6050/mpu6050.go
@@ -66,7 +66,7 @@ func (conf *Config) Validate(path string) ([]string, error) {
 
 func init() {
 	resource.RegisterComponent(movementsensor.API, model, resource.Registration[movementsensor.MovementSensor, *Config]{
-		Constructor: NewMpu6050,
+		Constructor: newMpu6050,
 	})
 }
 
@@ -101,8 +101,8 @@ func unexpectedDeviceError(address, defaultAddress byte) error {
 		address, defaultAddress)
 }
 
-// NewMpu6050 constructs a new Mpu6050 object.
-func NewMpu6050(
+// newMpu6050 constructs a new Mpu6050 object.
+func newMpu6050(
 	ctx context.Context,
 	deps resource.Dependencies,
 	conf resource.Config,

--- a/components/movementsensor/mpu6050/mpu6050.go
+++ b/components/movementsensor/mpu6050/mpu6050.go
@@ -322,7 +322,7 @@ func (mpu *mpu6050) Position(ctx context.Context, extra map[string]interface{}) 
 }
 
 func (mpu *mpu6050) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
-	return nil, movementsensor.ErrMethodUnimplementedAccuracy
+	return movementsensor.UnimplementedAccuracies()
 }
 
 func (mpu *mpu6050) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {

--- a/components/movementsensor/replay/replay.go
+++ b/components/movementsensor/replay/replay.go
@@ -342,7 +342,7 @@ func (replay *replayMovementSensor) Properties(ctx context.Context, extra map[st
 // Accuracy is currently not defined for replay movement sensors.
 func (replay *replayMovementSensor) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error,
 ) {
-	return nil, movementsensor.ErrMethodUnimplementedAccuracy
+	return movementsensor.UnimplementedAccuracies()
 }
 
 // Close stops the replay movement sensor, closes its channels and its connections to the cloud.

--- a/components/movementsensor/replay/replay_test.go
+++ b/components/movementsensor/replay/replay_test.go
@@ -764,8 +764,8 @@ func TestUnimplementedFunctionAccuracy(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	acc, err := replay.Accuracy(ctx, map[string]interface{}{})
-	test.That(t, err, test.ShouldResemble, movementsensor.ErrMethodUnimplementedAccuracy)
-	test.That(t, acc, test.ShouldBeNil)
+	test.That(t, err, test.ShouldResemble, nil)
+	test.That(t, acc, test.ShouldNotBeNil)
 
 	err = replay.Close(ctx)
 	test.That(t, err, test.ShouldBeNil)

--- a/components/movementsensor/replay/replay_test.go
+++ b/components/movementsensor/replay/replay_test.go
@@ -764,7 +764,7 @@ func TestUnimplementedFunctionAccuracy(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	acc, err := replay.Accuracy(ctx, map[string]interface{}{})
-	test.That(t, err, test.ShouldResemble, nil)
+	test.That(t, err, test.ShouldBeNil)
 	test.That(t, acc, test.ShouldNotBeNil)
 
 	err = replay.Close(ctx)

--- a/components/movementsensor/wheeledodometry/wheeledodometry.go
+++ b/components/movementsensor/wheeledodometry/wheeledodometry.go
@@ -286,8 +286,9 @@ func (o *odometry) Readings(ctx context.Context, extra map[string]interface{}) (
 	return readings, nil
 }
 
-func (o *odometry) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
-	return &movementsensor.Accuracy{}, nil
+func (o *odometry) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error,
+) {
+	return movementsensor.UnimplementedAccuracies()
 }
 
 func (o *odometry) Properties(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {


### PR DESCRIPTION
The RC card currently polls GetAccuracy, sees an error and refuses to show up since it is unimplemented in most drivers.
This PR adds a helper function that will not error, but populates the drivers with the values that will indicate to the RC card to hide the CompassHeading, HDOP, VDOP, and NMEAFIX from the card for drivers that cannot report them.