### PR TITLE
RSDK-6094 Further improve CLI usage strings

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -76,17 +76,19 @@ const (
 	dataFlagDatabasePassword               = "password"
 )
 
-// createUsageText is a helper for formatting the flags, if otherOptions is set to true
-// then [other options] is appended to the end of the text.
-func createUsageText(command string, requiredFlags []string, otherOptions bool) string {
-	formattedFlags := make([]string, len(requiredFlags)+1)
-	for i, flag := range requiredFlags {
-		formattedFlags[i] = fmt.Sprintf("--%s=<%s>", flag, flag)
+// createUsageText is a helper for formatting UsageTexts. The created UsageText
+// contains "viam", the command, requiredFlags, [other options] if otherOptions
+// is true, and all passed-in arguments in that order.
+func createUsageText(command string, requiredFlags []string, otherOptions bool, arguments ...string) string {
+	formatted := []string{"viam", command}
+	for _, flag := range requiredFlags {
+		formatted = append(formatted, fmt.Sprintf("--%s=<%s>", flag, flag))
 	}
 	if otherOptions {
-		formattedFlags[len(requiredFlags)] = "[other options]"
+		formatted = append(formatted, "[other options]")
 	}
-	return fmt.Sprintf("%s %s", command, strings.Join(formattedFlags, " "))
+	formatted = append(formatted, arguments...)
+	return strings.Join(formatted, " ")
 }
 
 var app = &cli.App{
@@ -131,8 +133,9 @@ var app = &cli.App{
 					Action: PrintAccessTokenAction,
 				},
 				{
-					Name:  "api-key",
-					Usage: "authenticate with an api key",
+					Name:      "api-key",
+					Usage:     "authenticate with an api key",
+					UsageText: createUsageText("auth api-key", []string{loginFlagKeyID, loginFlagKey}, false),
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:     loginFlagKeyID,
@@ -171,8 +174,9 @@ var app = &cli.App{
 					Action: ListOrganizationsAction,
 				},
 				{
-					Name:  "api-key",
-					Usage: "work with an organization's api keys",
+					Name:      "api-key",
+					Usage:     "work with an organization's api keys",
+					UsageText: createUsageText("organizations api-key", []string{apiKeyCreateFlagOrgID}, true),
 					Subcommands: []*cli.Command{
 						{
 							Name:  "create",
@@ -211,8 +215,9 @@ var app = &cli.App{
 					Usage: "work with an api-key for your location",
 					Subcommands: []*cli.Command{
 						{
-							Name:  "create",
-							Usage: "create an api key for your location",
+							Name:      "create",
+							Usage:     "create an api key for your location",
+							UsageText: createUsageText("api-key create", []string{apiKeyCreateFlagOrgID}, true),
 							Flags: []cli.Flag{
 								&cli.StringFlag{
 									Name:     apiKeyFlagLocationID,
@@ -243,7 +248,7 @@ var app = &cli.App{
 				{
 					Name:      "export",
 					Usage:     "download data from Viam cloud",
-					UsageText: createUsageText("viam data export", []string{dataFlagDestination, dataFlagDataType}, true),
+					UsageText: createUsageText("data export", []string{dataFlagDestination, dataFlagDataType}, true),
 					Flags: []cli.Flag{
 						&cli.PathFlag{
 							Name:     dataFlagDestination,
@@ -335,7 +340,7 @@ var app = &cli.App{
 						{
 							Name:      "binary",
 							Usage:     "delete binary data from Viam cloud",
-							UsageText: createUsageText("viam data delete binary", nil, true),
+							UsageText: createUsageText("data delete binary", nil, true),
 							Flags: []cli.Flag{
 								&cli.StringSliceFlag{
 									Name:  dataFlagOrgIDs,
@@ -397,7 +402,7 @@ var app = &cli.App{
 						{
 							Name:      "tabular",
 							Usage:     "delete tabular data from Viam cloud",
-							UsageText: createUsageText("viam data delete tabular", []string{dataFlagOrgID, dataFlagDeleteTabularDataOlderThanDays}, false),
+							UsageText: createUsageText("data delete tabular", []string{dataFlagOrgID, dataFlagDeleteTabularDataOlderThanDays}, false),
 							Flags: []cli.Flag{
 								&cli.StringFlag{
 									Name:     dataFlagOrgID,
@@ -417,12 +422,12 @@ var app = &cli.App{
 				{
 					Name:      "database",
 					Usage:     "interact with a MongoDB Atlas Data Federation instance",
-					UsageText: "viam data database [other options]",
+					UsageText: createUsageText("data database", nil, true),
 					Subcommands: []*cli.Command{
 						{
 							Name:      "configure",
 							Usage:     "configures a database user for the Viam org's MongoDB Atlas Data Federation instance",
-							UsageText: createUsageText("viam data database configure", []string{dataFlagOrgID, dataFlagDatabasePassword}, false),
+							UsageText: createUsageText("data database configure", []string{dataFlagOrgID, dataFlagDatabasePassword}, false),
 							Flags: []cli.Flag{
 								&cli.StringFlag{
 									Name:     dataFlagOrgID,
@@ -440,7 +445,7 @@ var app = &cli.App{
 						{
 							Name:      "hostname",
 							Usage:     "gets the hostname to access a MongoDB Atlas Data Federation Instance",
-							UsageText: createUsageText("viam data database hostname", []string{dataFlagOrgID}, false),
+							UsageText: createUsageText("data database hostname", []string{dataFlagOrgID}, false),
 							Flags: []cli.Flag{
 								&cli.StringFlag{
 									Name:     dataFlagOrgID,
@@ -455,7 +460,7 @@ var app = &cli.App{
 				{
 					Name:      "dataset",
 					Usage:     "add or remove data from datasets",
-					UsageText: createUsageText("viam data dataset", nil, true),
+					UsageText: createUsageText("data dataset", nil, true),
 					Subcommands: []*cli.Command{
 						{
 							Name:  "add",
@@ -464,7 +469,7 @@ var app = &cli.App{
 								{
 									Name:  "ids",
 									Usage: "adds binary data with file IDs in a single org and location to dataset",
-									UsageText: createUsageText("viam data dataset add ids", []string{
+									UsageText: createUsageText("data dataset add ids", []string{
 										datasetFlagDatasetID, dataFlagOrgID,
 										dataFlagLocationID, dataFlagFileIDs,
 									}, false),
@@ -495,7 +500,7 @@ var app = &cli.App{
 
 								{
 									Name:      "filter",
-									UsageText: createUsageText("viam data dataset add filter", []string{datasetFlagDatasetID}, true),
+									UsageText: createUsageText("data dataset add filter", []string{datasetFlagDatasetID}, true),
 									Flags: []cli.Flag{
 										&cli.StringFlag{
 											Name:     datasetFlagDatasetID,
@@ -574,7 +579,7 @@ var app = &cli.App{
 						{
 							Name:  "remove",
 							Usage: "removes binary data with file IDs in a single org and location from dataset",
-							UsageText: createUsageText("viam data dataset remove",
+							UsageText: createUsageText("data dataset remove",
 								[]string{datasetFlagDatasetID, dataFlagOrgID, dataFlagLocationID, dataFlagFileIDs}, false),
 							Flags: []cli.Flag{
 								&cli.StringFlag{
@@ -612,7 +617,7 @@ var app = &cli.App{
 				{
 					Name:      "create",
 					Usage:     "create a new dataset",
-					UsageText: createUsageText("viam dataset create", []string{dataFlagOrgID, datasetFlagName}, false),
+					UsageText: createUsageText("dataset create", []string{dataFlagOrgID, datasetFlagName}, false),
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:     dataFlagOrgID,
@@ -630,7 +635,7 @@ var app = &cli.App{
 				{
 					Name:  "rename",
 					Usage: "rename an existing dataset",
-					UsageText: createUsageText("viam dataset rename",
+					UsageText: createUsageText("dataset rename",
 						[]string{datasetFlagDatasetID, datasetFlagName}, false),
 					Flags: []cli.Flag{
 						&cli.StringFlag{
@@ -666,7 +671,7 @@ var app = &cli.App{
 				{
 					Name:      "delete",
 					Usage:     "delete a dataset",
-					UsageText: createUsageText("viam dataset delete", []string{datasetFlagDatasetID}, false),
+					UsageText: createUsageText("dataset delete", []string{datasetFlagDatasetID}, false),
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:     datasetFlagDatasetID,
@@ -686,7 +691,7 @@ var app = &cli.App{
 				{
 					Name:  "submit",
 					Usage: "submits training job on data in Viam cloud",
-					UsageText: createUsageText("viam train submit",
+					UsageText: createUsageText("train submit",
 						[]string{datasetFlagDatasetID, trainFlagModelOrgID, trainFlagModelName, trainFlagModelType, trainFlagModelLabels}, true),
 					Flags: []cli.Flag{
 						&cli.StringFlag{
@@ -726,7 +731,7 @@ var app = &cli.App{
 				{
 					Name:      "get",
 					Usage:     "gets training job from Viam cloud based on training job ID",
-					UsageText: createUsageText("viam train get", []string{trainFlagJobID}, false),
+					UsageText: createUsageText("train get", []string{trainFlagJobID}, false),
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:     trainFlagJobID,
@@ -739,7 +744,7 @@ var app = &cli.App{
 				{
 					Name:      "cancel",
 					Usage:     "cancels training job in Viam cloud based on training job ID",
-					UsageText: createUsageText("viam train cancel", []string{trainFlagJobID}, false),
+					UsageText: createUsageText("train cancel", []string{trainFlagJobID}, false),
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:     trainFlagJobID,
@@ -752,7 +757,7 @@ var app = &cli.App{
 				{
 					Name:      "list",
 					Usage:     "list training jobs in Viam cloud based on organization ID",
-					UsageText: createUsageText("viam train list", []string{dataFlagOrgID, trainFlagJobStatus}, false),
+					UsageText: createUsageText("train list", []string{dataFlagOrgID, trainFlagJobStatus}, false),
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:     dataFlagOrgID,
@@ -763,6 +768,7 @@ var app = &cli.App{
 							Name: trainFlagJobStatus,
 							Usage: "training status to filter for. can be one of " +
 								"[unspecified, pending, in_progress, completed, failed, canceled, canceling]",
+							Required: true,
 						},
 					},
 					Action: DataListTrainingJobs,
@@ -795,8 +801,9 @@ var app = &cli.App{
 					Usage: "work with a machine's api keys",
 					Subcommands: []*cli.Command{
 						{
-							Name:  "create",
-							Usage: "create an api-key for your machine",
+							Name:      "create",
+							Usage:     "create an api-key for your machine",
+							UsageText: createUsageText("machines api-key create", []string{apiKeyFlagMachineID}, true),
 							Flags: []cli.Flag{
 								&AliasStringFlag{
 									cli.StringFlag{
@@ -823,7 +830,7 @@ var app = &cli.App{
 				{
 					Name:      "status",
 					Usage:     "display machine status",
-					UsageText: createUsageText("viam machines status", []string{machineFlag}, true),
+					UsageText: createUsageText("machines status", []string{machineFlag}, true),
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:        organizationFlag,
@@ -847,7 +854,7 @@ var app = &cli.App{
 					Name:      "logs",
 					Aliases:   []string{"log"},
 					Usage:     "display machine logs",
-					UsageText: createUsageText("viam machines logs", []string{machineFlag}, true),
+					UsageText: createUsageText("machines logs", []string{machineFlag}, true),
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:        organizationFlag,
@@ -879,7 +886,7 @@ var app = &cli.App{
 						{
 							Name:      "status",
 							Usage:     "display part status",
-							UsageText: createUsageText("viam machines part status", []string{machineFlag, partFlag}, true),
+							UsageText: createUsageText("machines part status", []string{machineFlag, partFlag}, true),
 							Flags: []cli.Flag{
 								&cli.StringFlag{
 									Name:        organizationFlag,
@@ -907,7 +914,7 @@ var app = &cli.App{
 							Name:      "logs",
 							Aliases:   []string{"log"},
 							Usage:     "display part logs",
-							UsageText: createUsageText("viam machines part logs", []string{machineFlag, partFlag}, true),
+							UsageText: createUsageText("machines part logs", []string{machineFlag, partFlag}, true),
 							Flags: []cli.Flag{
 								&cli.StringFlag{
 									Name:        organizationFlag,
@@ -943,10 +950,9 @@ var app = &cli.App{
 						{
 							Name:  "run",
 							Usage: "run a command on a machine part",
-							UsageText: createUsageText("viam machines part run", []string{
-								organizationFlag,
-								locationFlag, machineFlag, partFlag, "[other options]", "<service.method>",
-							}, false),
+							UsageText: createUsageText("machines part run", []string{
+								organizationFlag, locationFlag, machineFlag, partFlag,
+							}, true, "<service.method>"),
 							Flags: []cli.Flag{
 								&cli.StringFlag{
 									Name:     organizationFlag,
@@ -982,7 +988,7 @@ var app = &cli.App{
 							Name:        "shell",
 							Usage:       "start a shell on a machine part",
 							Description: `In order to use the shell command, the machine must have a valid shell type service.`,
-							UsageText:   createUsageText("viam machines part shell", []string{organizationFlag, locationFlag, machineFlag, partFlag}, false),
+							UsageText:   createUsageText("machines part shell", []string{organizationFlag, locationFlag, machineFlag, partFlag}, false),
 							Flags: []cli.Flag{
 								&cli.StringFlag{
 									Name:     organizationFlag,
@@ -1027,7 +1033,7 @@ you won't have to pass a namespace or org-id in future commands. Otherwise there
 and you will have to provide the org-id to future cli commands. You cannot make your module public until you claim an org-id.
 
 After creation, use 'viam module update' to push your new module to app.viam.com.`,
-					UsageText: createUsageText("viam module create", []string{moduleFlagName}, true),
+					UsageText: createUsageText("module create", []string{moduleFlagName}, true),
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:     moduleFlagName,
@@ -1046,9 +1052,8 @@ After creation, use 'viam module update' to push your new module to app.viam.com
 					Action: CreateModuleAction,
 				},
 				{
-					Name:      "update",
-					Usage:     "update a module's metadata on app.viam.com",
-					UsageText: createUsageText("viam module update", []string{moduleFlagPath}, false),
+					Name:  "update",
+					Usage: "update a module's metadata on app.viam.com",
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:      moduleFlagPath,
@@ -1062,7 +1067,7 @@ After creation, use 'viam module update' to push your new module to app.viam.com
 				{
 					Name:      "update-models",
 					Usage:     "update a module's metadata file based on models it provides",
-					UsageText: createUsageText("viam module update-models", []string{moduleFlagPath, moduleFlagBinary}, false),
+					UsageText: createUsageText("module update-models", []string{moduleFlagBinary}, true),
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:      moduleFlagPath,
@@ -1094,7 +1099,7 @@ Example uploading a custom tarball of your module:
 tar -czf packaged-module.tar.gz ./src requirements.txt run.sh
 viam module upload --version "0.1.0" --platform "linux/amd64" packaged-module.tar.gz
                       `,
-					UsageText: createUsageText("viam module upload", []string{moduleFlagVersion, moduleFlagPlatform}, true),
+					UsageText: createUsageText("module upload", []string{moduleFlagVersion, moduleFlagPlatform}, true, "<packaged-module.tag.gz>"),
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:      moduleFlagPath,
@@ -1174,8 +1179,9 @@ Example:
 							Action: ModuleBuildLocalAction,
 						},
 						{
-							Name:  "start",
-							Usage: "start a remote build",
+							Name:      "start",
+							Usage:     "start a remote build",
+							UsageText: createUsageText("module build start", []string{moduleBuildFlagVersion}, true),
 							Flags: []cli.Flag{
 								&cli.StringFlag{
 									Name:      moduleBuildFlagPath,
@@ -1220,9 +1226,10 @@ Example:
 							Action: ModuleBuildListAction,
 						},
 						{
-							Name:    "logs",
-							Aliases: []string{"log"},
-							Usage:   "get the logs from one of your cloud builds",
+							Name:      "logs",
+							Aliases:   []string{"log"},
+							Usage:     "get the logs from one of your cloud builds",
+							UsageText: createUsageText("module build logs", []string{moduleBuildFlagBuildID}, true),
 							Flags: []cli.Flag{
 								&cli.StringFlag{
 									Name:     moduleBuildFlagBuildID,

--- a/cli/app.go
+++ b/cli/app.go
@@ -42,6 +42,7 @@ const (
 	moduleFlagVersion         = "version"
 	moduleFlagPlatform        = "platform"
 	moduleFlagForce           = "force"
+	moduleFlagBinary          = "binary"
 
 	moduleBuildFlagPath     = "module"
 	moduleBuildFlagRef      = "ref"
@@ -77,13 +78,13 @@ const (
 
 // createUsageText is a helper for formatting the flags, if otherOptions is set to true
 // then [other options] is appended to the end of the text.
-func createUsageText(command string, flags []string, otherOptions bool) string {
-	formattedFlags := make([]string, len(flags)+1)
-	for i, flag := range flags {
+func createUsageText(command string, requiredFlags []string, otherOptions bool) string {
+	formattedFlags := make([]string, len(requiredFlags)+1)
+	for i, flag := range requiredFlags {
 		formattedFlags[i] = fmt.Sprintf("--%s=<%s>", flag, flag)
 	}
 	if otherOptions {
-		formattedFlags[len(flags)] = "[other options]"
+		formattedFlags[len(requiredFlags)] = "[other options]"
 	}
 	return fmt.Sprintf("%s %s", command, strings.Join(formattedFlags, " "))
 }
@@ -396,7 +397,7 @@ var app = &cli.App{
 						{
 							Name:      "tabular",
 							Usage:     "delete tabular data from Viam cloud",
-							UsageText: createUsageText("viam data delete tabular", nil, true),
+							UsageText: createUsageText("viam data delete tabular", []string{dataFlagOrgID, dataFlagDeleteTabularDataOlderThanDays}, false),
 							Flags: []cli.Flag{
 								&cli.StringFlag{
 									Name:     dataFlagOrgID,
@@ -822,7 +823,7 @@ var app = &cli.App{
 				{
 					Name:      "status",
 					Usage:     "display machine status",
-					UsageText: "viam machines status <machine> [other options]",
+					UsageText: createUsageText("viam machines status", []string{machineFlag}, true),
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:        organizationFlag,
@@ -846,7 +847,7 @@ var app = &cli.App{
 					Name:      "logs",
 					Aliases:   []string{"log"},
 					Usage:     "display machine logs",
-					UsageText: "viam machines logs <machine> [other options]",
+					UsageText: createUsageText("viam machines logs", []string{machineFlag}, true),
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:        organizationFlag,
@@ -878,7 +879,7 @@ var app = &cli.App{
 						{
 							Name:      "status",
 							Usage:     "display part status",
-							UsageText: "viam machines part status <machine> <part> [other options]",
+							UsageText: createUsageText("viam machines part status", []string{machineFlag, partFlag}, true),
 							Flags: []cli.Flag{
 								&cli.StringFlag{
 									Name:        organizationFlag,
@@ -906,7 +907,7 @@ var app = &cli.App{
 							Name:      "logs",
 							Aliases:   []string{"log"},
 							Usage:     "display part logs",
-							UsageText: "viam machines part logs <machine> <part> [other options]",
+							UsageText: createUsageText("viam machines part logs", []string{machineFlag, partFlag}, true),
 							Flags: []cli.Flag{
 								&cli.StringFlag{
 									Name:        organizationFlag,
@@ -942,7 +943,7 @@ var app = &cli.App{
 						{
 							Name:      "run",
 							Usage:     "run a command on a machine part",
-							UsageText: "viam machines part run <organization> <location> <machine> <part> [other options] <service.method>",
+							UsageText: createUsageText("viam machines part run", []string{organizationFlag, locationFlag, machineFlag, partFlag, "[other options]", "<service.method>"}, false),
 							Flags: []cli.Flag{
 								&cli.StringFlag{
 									Name:     organizationFlag,
@@ -978,7 +979,7 @@ var app = &cli.App{
 							Name:        "shell",
 							Usage:       "start a shell on a machine part",
 							Description: `In order to use the shell command, the machine must have a valid shell type service.`,
-							UsageText:   "viam machines part shell <organization> <location> <machine> <part>",
+							UsageText:   createUsageText("viam machines part shell", []string{organizationFlag, locationFlag, machineFlag, partFlag}, false),
 							Flags: []cli.Flag{
 								&cli.StringFlag{
 									Name:     organizationFlag,
@@ -1023,7 +1024,7 @@ you won't have to pass a namespace or org-id in future commands. Otherwise there
 and you will have to provide the org-id to future cli commands. You cannot make your module public until you claim an org-id.
 
 After creation, use 'viam module update' to push your new module to app.viam.com.`,
-					UsageText: "viam module create <name> [other options]",
+					UsageText: createUsageText("viam module create", []string{moduleFlagName}, true),
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:     moduleFlagName,
@@ -1042,8 +1043,9 @@ After creation, use 'viam module update' to push your new module to app.viam.com
 					Action: CreateModuleAction,
 				},
 				{
-					Name:  "update",
-					Usage: "update a module's metadata on app.viam.com",
+					Name:      "update",
+					Usage:     "update a module's metadata on app.viam.com",
+					UsageText: createUsageText("viam module update", []string{moduleFlagPath}, false),
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:      moduleFlagPath,
@@ -1055,8 +1057,9 @@ After creation, use 'viam module update' to push your new module to app.viam.com
 					Action: UpdateModuleAction,
 				},
 				{
-					Name:  "update-models",
-					Usage: "update a module's metadata file based on models it provides",
+					Name:      "update-models",
+					Usage:     "update a module's metadata file based on models it provides",
+					UsageText: createUsageText("viam module update-models", []string{moduleFlagPath, moduleFlagBinary}, false),
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:      moduleFlagPath,
@@ -1065,7 +1068,7 @@ After creation, use 'viam module update' to push your new module to app.viam.com
 							TakesFile: true,
 						},
 						&cli.StringFlag{
-							Name:     "binary",
+							Name:     moduleFlagBinary,
 							Usage:    "binary for the module to run (has to work on this os/processor)",
 							Required: true,
 						},
@@ -1088,7 +1091,7 @@ Example uploading a custom tarball of your module:
 tar -czf packaged-module.tar.gz ./src requirements.txt run.sh
 viam module upload --version "0.1.0" --platform "linux/amd64" packaged-module.tar.gz
                       `,
-					UsageText: "viam module upload <version> <platform> [other options] <packaged-module.tar.gz>",
+					UsageText: createUsageText("viam module upload", []string{moduleFlagVersion, moduleFlagPlatform}, true),
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:      moduleFlagPath,

--- a/cli/app.go
+++ b/cli/app.go
@@ -135,7 +135,7 @@ var app = &cli.App{
 				{
 					Name:      "api-key",
 					Usage:     "authenticate with an api key",
-					UsageText: createUsageText("auth api-key", []string{loginFlagKeyID, loginFlagKey}, false),
+					UsageText: createUsageText("login api-key", []string{loginFlagKeyID, loginFlagKey}, false),
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:     loginFlagKeyID,

--- a/cli/app.go
+++ b/cli/app.go
@@ -943,8 +943,10 @@ var app = &cli.App{
 						{
 							Name:  "run",
 							Usage: "run a command on a machine part",
-							UsageText: createUsageText("viam machines part run", []string{organizationFlag,
-								locationFlag, machineFlag, partFlag, "[other options]", "<service.method>"}, false),
+							UsageText: createUsageText("viam machines part run", []string{
+								organizationFlag,
+								locationFlag, machineFlag, partFlag, "[other options]", "<service.method>",
+							}, false),
 							Flags: []cli.Flag{
 								&cli.StringFlag{
 									Name:     organizationFlag,

--- a/cli/app.go
+++ b/cli/app.go
@@ -25,19 +25,20 @@ const (
 	runFlagData   = "data"
 	runFlagStream = "stream"
 
-	apiKeyCreateFlagOrgID  = "org-id"
-	apiKeyCreateFlagName   = "name"
-	apiKeyFlagMachineID    = "machine-id"
-	apiKeyFlagAliasRobotID = "robot-id"
-	apiKeyFlagLocationID   = "location-id"
-
 	loginFlagDisableBrowser = "disable-browser-open"
 	loginFlagKeyID          = "key-id"
 	loginFlagKey            = "key"
 
+	// Flags shared by api-key, module and data subcommands.
+	generalFlagOrgID        = "org-id"
+	generalFlagLocationID   = "location-id"
+	generalFlagMachineID    = "machine-id"
+	generalFlagAliasRobotID = "robot-id"
+
+	apiKeyCreateFlagName = "name"
+
 	moduleFlagName            = "name"
 	moduleFlagPublicNamespace = "public-namespace"
-	moduleFlagOrgID           = "org-id"
 	moduleFlagPath            = "module"
 	moduleFlagVersion         = "version"
 	moduleFlagPlatform        = "platform"
@@ -56,8 +57,6 @@ const (
 	dataFlagDataType                       = "data-type"
 	dataFlagOrgIDs                         = "org-ids"
 	dataFlagLocationIDs                    = "location-ids"
-	dataFlagMachineID                      = "machine-id"
-	dataFlagAliasRobotID                   = "robot-id"
 	dataFlagPartID                         = "part-id"
 	dataFlagMachineName                    = "machine-name"
 	dataFlagAliasRobotName                 = "robot-name"
@@ -71,7 +70,6 @@ const (
 	dataFlagParallelDownloads              = "parallel"
 	dataFlagTags                           = "tags"
 	dataFlagBboxLabels                     = "bbox-labels"
-	dataFlagOrgID                          = "org-id"
 	dataFlagDeleteTabularDataOlderThanDays = "delete-older-than-days"
 	dataFlagDatabasePassword               = "password"
 )
@@ -176,14 +174,14 @@ var app = &cli.App{
 				{
 					Name:      "api-key",
 					Usage:     "work with an organization's api keys",
-					UsageText: createUsageText("organizations api-key", []string{apiKeyCreateFlagOrgID}, true),
+					UsageText: createUsageText("organizations api-key", []string{generalFlagOrgID}, true),
 					Subcommands: []*cli.Command{
 						{
 							Name:  "create",
 							Usage: "create an api key for your organization",
 							Flags: []cli.Flag{
 								&cli.StringFlag{
-									Name:     apiKeyCreateFlagOrgID,
+									Name:     generalFlagOrgID,
 									Required: true,
 									Usage:    "the org to create an api key for",
 								},
@@ -217,10 +215,10 @@ var app = &cli.App{
 						{
 							Name:      "create",
 							Usage:     "create an api key for your location",
-							UsageText: createUsageText("api-key create", []string{apiKeyCreateFlagOrgID}, true),
+							UsageText: createUsageText("api-key create", []string{generalFlagOrgID}, true),
 							Flags: []cli.Flag{
 								&cli.StringFlag{
-									Name:     apiKeyFlagLocationID,
+									Name:     generalFlagLocationID,
 									Required: true,
 									Usage:    "the location to create an api-key for",
 								},
@@ -229,7 +227,7 @@ var app = &cli.App{
 									Usage: "the name of the key (defaults to your login info with the current time)",
 								},
 								&cli.StringFlag{
-									Name: apiKeyCreateFlagOrgID,
+									Name: generalFlagOrgID,
 									Usage: "the org-id to attach the key to" +
 										"If not provided, will attempt to attach itself to the org of the location if only one org is attached to the location",
 								},
@@ -270,8 +268,8 @@ var app = &cli.App{
 						},
 						&AliasStringFlag{
 							cli.StringFlag{
-								Name:    dataFlagMachineID,
-								Aliases: []string{dataFlagAliasRobotID},
+								Name:    generalFlagMachineID,
+								Aliases: []string{generalFlagAliasRobotID},
 								Usage:   "machine id filter",
 							},
 						},
@@ -352,8 +350,8 @@ var app = &cli.App{
 								},
 								&AliasStringFlag{
 									cli.StringFlag{
-										Name:    dataFlagMachineID,
-										Aliases: []string{dataFlagAliasRobotID},
+										Name:    generalFlagMachineID,
+										Aliases: []string{generalFlagAliasRobotID},
 										Usage:   "machine id filter",
 									},
 								},
@@ -402,10 +400,10 @@ var app = &cli.App{
 						{
 							Name:      "tabular",
 							Usage:     "delete tabular data from Viam cloud",
-							UsageText: createUsageText("data delete tabular", []string{dataFlagOrgID, dataFlagDeleteTabularDataOlderThanDays}, false),
+							UsageText: createUsageText("data delete tabular", []string{generalFlagOrgID, dataFlagDeleteTabularDataOlderThanDays}, false),
 							Flags: []cli.Flag{
 								&cli.StringFlag{
-									Name:     dataFlagOrgID,
+									Name:     generalFlagOrgID,
 									Usage:    "org",
 									Required: true,
 								},
@@ -427,10 +425,10 @@ var app = &cli.App{
 						{
 							Name:      "configure",
 							Usage:     "configures a database user for the Viam org's MongoDB Atlas Data Federation instance",
-							UsageText: createUsageText("data database configure", []string{dataFlagOrgID, dataFlagDatabasePassword}, false),
+							UsageText: createUsageText("data database configure", []string{generalFlagOrgID, dataFlagDatabasePassword}, false),
 							Flags: []cli.Flag{
 								&cli.StringFlag{
-									Name:     dataFlagOrgID,
+									Name:     generalFlagOrgID,
 									Usage:    "org ID for the database user being configured",
 									Required: true,
 								},
@@ -445,10 +443,10 @@ var app = &cli.App{
 						{
 							Name:      "hostname",
 							Usage:     "gets the hostname to access a MongoDB Atlas Data Federation Instance",
-							UsageText: createUsageText("data database hostname", []string{dataFlagOrgID}, false),
+							UsageText: createUsageText("data database hostname", []string{generalFlagOrgID}, false),
 							Flags: []cli.Flag{
 								&cli.StringFlag{
-									Name:     dataFlagOrgID,
+									Name:     generalFlagOrgID,
 									Usage:    "org ID for the database user",
 									Required: true,
 								},
@@ -470,7 +468,7 @@ var app = &cli.App{
 									Name:  "ids",
 									Usage: "adds binary data with file IDs in a single org and location to dataset",
 									UsageText: createUsageText("data dataset add ids", []string{
-										datasetFlagDatasetID, dataFlagOrgID,
+										datasetFlagDatasetID, generalFlagOrgID,
 										dataFlagLocationID, dataFlagFileIDs,
 									}, false),
 									Flags: []cli.Flag{
@@ -480,7 +478,7 @@ var app = &cli.App{
 											Required: true,
 										},
 										&cli.StringFlag{
-											Name:     dataFlagOrgID,
+											Name:     generalFlagOrgID,
 											Usage:    "org ID to which data belongs",
 											Required: true,
 										},
@@ -517,8 +515,8 @@ var app = &cli.App{
 										},
 										&AliasStringFlag{
 											cli.StringFlag{
-												Name:    dataFlagMachineID,
-												Aliases: []string{dataFlagAliasRobotID},
+												Name:    generalFlagMachineID,
+												Aliases: []string{generalFlagAliasRobotID},
 												Usage:   "machine id filter",
 											},
 										},
@@ -580,7 +578,7 @@ var app = &cli.App{
 							Name:  "remove",
 							Usage: "removes binary data with file IDs in a single org and location from dataset",
 							UsageText: createUsageText("data dataset remove",
-								[]string{datasetFlagDatasetID, dataFlagOrgID, dataFlagLocationID, dataFlagFileIDs}, false),
+								[]string{datasetFlagDatasetID, generalFlagOrgID, dataFlagLocationID, dataFlagFileIDs}, false),
 							Flags: []cli.Flag{
 								&cli.StringFlag{
 									Name:     datasetFlagDatasetID,
@@ -588,7 +586,7 @@ var app = &cli.App{
 									Required: true,
 								},
 								&cli.StringFlag{
-									Name:     dataFlagOrgID,
+									Name:     generalFlagOrgID,
 									Usage:    "org ID to which data belongs",
 									Required: true,
 								},
@@ -617,10 +615,10 @@ var app = &cli.App{
 				{
 					Name:      "create",
 					Usage:     "create a new dataset",
-					UsageText: createUsageText("dataset create", []string{dataFlagOrgID, datasetFlagName}, false),
+					UsageText: createUsageText("dataset create", []string{generalFlagOrgID, datasetFlagName}, false),
 					Flags: []cli.Flag{
 						&cli.StringFlag{
-							Name:     dataFlagOrgID,
+							Name:     generalFlagOrgID,
 							Required: true,
 							Usage:    "org ID for which dataset will be created",
 						},
@@ -655,14 +653,14 @@ var app = &cli.App{
 					Name:  "list",
 					Usage: "list dataset information from specified IDs or for an org ID",
 					UsageText: fmt.Sprintf("viam dataset list [--%s=<%s> | --%s=<%s>]",
-						datasetFlagDatasetIDs, datasetFlagDatasetIDs, dataFlagOrgID, dataFlagOrgID),
+						datasetFlagDatasetIDs, datasetFlagDatasetIDs, generalFlagOrgID, generalFlagOrgID),
 					Flags: []cli.Flag{
 						&cli.StringSliceFlag{
 							Name:  datasetFlagDatasetIDs,
 							Usage: "dataset IDs of datasets to be listed",
 						},
 						&cli.StringFlag{
-							Name:  dataFlagOrgID,
+							Name:  generalFlagOrgID,
 							Usage: "org ID for which datasets will be listed",
 						},
 					},
@@ -757,10 +755,10 @@ var app = &cli.App{
 				{
 					Name:      "list",
 					Usage:     "list training jobs in Viam cloud based on organization ID",
-					UsageText: createUsageText("train list", []string{dataFlagOrgID, trainFlagJobStatus}, false),
+					UsageText: createUsageText("train list", []string{generalFlagOrgID, trainFlagJobStatus}, false),
 					Flags: []cli.Flag{
 						&cli.StringFlag{
-							Name:     dataFlagOrgID,
+							Name:     generalFlagOrgID,
 							Usage:    "org ID",
 							Required: true,
 						},
@@ -803,12 +801,12 @@ var app = &cli.App{
 						{
 							Name:      "create",
 							Usage:     "create an api-key for your machine",
-							UsageText: createUsageText("machines api-key create", []string{apiKeyFlagMachineID}, true),
+							UsageText: createUsageText("machines api-key create", []string{generalFlagMachineID}, true),
 							Flags: []cli.Flag{
 								&AliasStringFlag{
 									cli.StringFlag{
-										Name:     apiKeyFlagMachineID,
-										Aliases:  []string{apiKeyFlagAliasRobotID},
+										Name:     generalFlagMachineID,
+										Aliases:  []string{generalFlagAliasRobotID},
 										Required: true,
 										Usage:    "the machine to create an api-key for",
 									},
@@ -818,7 +816,7 @@ var app = &cli.App{
 									Usage: "the name of the key (defaults to your login info with the current time)",
 								},
 								&cli.StringFlag{
-									Name: apiKeyCreateFlagOrgID,
+									Name: generalFlagOrgID,
 									Usage: "the org-id to attach this api-key to. If not provided," +
 										"we will attempt to use the org attached to the machine if only one exists",
 								},
@@ -1045,7 +1043,7 @@ After creation, use 'viam module update' to push your new module to app.viam.com
 							Usage: "the public namespace where the module will reside (alternative way of specifying the org id)",
 						},
 						&cli.StringFlag{
-							Name:  moduleFlagOrgID,
+							Name:  generalFlagOrgID,
 							Usage: "id of the organization that will host the module",
 						},
 					},
@@ -1112,7 +1110,7 @@ viam module upload --version "0.1.0" --platform "linux/amd64" packaged-module.ta
 							Usage: "the public namespace where the module resides (alternative way of specifying the org id)",
 						},
 						&cli.StringFlag{
-							Name:  moduleFlagOrgID,
+							Name:  generalFlagOrgID,
 							Usage: "id of the organization that hosts the module",
 						},
 						&cli.StringFlag{

--- a/cli/app.go
+++ b/cli/app.go
@@ -941,9 +941,10 @@ var app = &cli.App{
 							Action: RobotsPartLogsAction,
 						},
 						{
-							Name:      "run",
-							Usage:     "run a command on a machine part",
-							UsageText: createUsageText("viam machines part run", []string{organizationFlag, locationFlag, machineFlag, partFlag, "[other options]", "<service.method>"}, false),
+							Name:  "run",
+							Usage: "run a command on a machine part",
+							UsageText: createUsageText("viam machines part run", []string{organizationFlag,
+								locationFlag, machineFlag, partFlag, "[other options]", "<service.method>"}, false),
 							Flags: []cli.Flag{
 								&cli.StringFlag{
 									Name:     organizationFlag,

--- a/cli/app.go
+++ b/cli/app.go
@@ -763,9 +763,8 @@ var app = &cli.App{
 							Required: true,
 						},
 						&cli.StringFlag{
-							Name: trainFlagJobStatus,
-							Usage: "training status to filter for. can be one of " +
-								"[unspecified, pending, in_progress, completed, failed, canceled, canceling]",
+							Name:     trainFlagJobStatus,
+							Usage:    "training status to filter for. can be one of " + allTrainingStatusValues(),
 							Required: true,
 						},
 					},

--- a/cli/auth.go
+++ b/cli/auth.go
@@ -293,7 +293,7 @@ func (c *viamClient) organizationsAPIKeyCreateAction(cCtx *cli.Context) error {
 	if err := c.ensureLoggedIn(); err != nil {
 		return err
 	}
-	orgID := cCtx.String(apiKeyCreateFlagOrgID)
+	orgID := cCtx.String(generalFlagOrgID)
 	keyName := cCtx.String(apiKeyCreateFlagName)
 	if keyName == "" {
 		keyName = c.generateDefaultKeyName()
@@ -348,8 +348,8 @@ func (c *viamClient) locationAPIKeyCreateAction(cCtx *cli.Context) error {
 		return err
 	}
 
-	locationID := cCtx.String(apiKeyFlagLocationID)
-	orgID := cCtx.String(apiKeyCreateFlagOrgID)
+	locationID := cCtx.String(generalFlagLocationID)
+	orgID := cCtx.String(generalFlagOrgID)
 	keyName := cCtx.String(apiKeyCreateFlagName)
 
 	if locationID == "" {
@@ -407,9 +407,9 @@ func (c *viamClient) robotAPIKeyCreateAction(cCtx *cli.Context) error {
 		return err
 	}
 
-	robotID := cCtx.String(apiKeyFlagMachineID)
+	robotID := cCtx.String(generalFlagMachineID)
 	keyName := cCtx.String(apiKeyCreateFlagName)
-	orgID := cCtx.String(dataFlagOrgID)
+	orgID := cCtx.String(generalFlagOrgID)
 
 	if robotID == "" {
 		return errors.New("cannot create an api-key for a machine without an ID")

--- a/cli/auth_test.go
+++ b/cli/auth_test.go
@@ -77,8 +77,8 @@ func TestRobotAPIKeyCreateAction(t *testing.T) {
 	}
 
 	flags := make(map[string]string)
-	flags[apiKeyCreateFlagOrgID] = fakeOrgID
-	flags[apiKeyFlagMachineID] = fakeRobotID
+	flags[generalFlagOrgID] = fakeOrgID
+	flags[generalFlagMachineID] = fakeRobotID
 	flags[apiKeyCreateFlagName] = "my-name"
 	cCtx, ac, out, errOut := setup(asc, nil, nil, &flags, "token")
 
@@ -99,8 +99,8 @@ func TestRobotAPIKeyCreateAction(t *testing.T) {
 	test.That(t, strings.Join(out.messages, " "), test.ShouldContainSubstring, "using default key name of")
 
 	// test without an orgID
-	cCtx.Set(apiKeyCreateFlagOrgID, "")
-	test.That(t, cCtx.Value(apiKeyCreateFlagOrgID), test.ShouldEqual, "")
+	cCtx.Set(generalFlagOrgID, "")
+	test.That(t, cCtx.Value(generalFlagOrgID), test.ShouldEqual, "")
 
 	test.That(t, ac.robotAPIKeyCreateAction(cCtx), test.ShouldBeNil)
 	test.That(t, len(errOut.messages), test.ShouldEqual, 0)
@@ -113,8 +113,8 @@ func TestRobotAPIKeyCreateAction(t *testing.T) {
 	test.That(t, allMessages, test.ShouldContainSubstring, "Key Value: key-yyy")
 
 	// test without a robot ID should fail
-	cCtx.Set(apiKeyFlagMachineID, "")
-	test.That(t, cCtx.Value(apiKeyFlagMachineID), test.ShouldEqual, "")
+	cCtx.Set(generalFlagMachineID, "")
+	test.That(t, cCtx.Value(generalFlagMachineID), test.ShouldEqual, "")
 	err := ac.robotAPIKeyCreateAction(cCtx)
 	test.That(t, err, test.ShouldNotBeNil)
 
@@ -132,8 +132,8 @@ func TestRobotAPIKeyCreateAction(t *testing.T) {
 	}
 
 	flags = make(map[string]string)
-	flags[apiKeyFlagMachineID] = fakeRobotID
-	flags[apiKeyCreateFlagOrgID] = ""
+	flags[generalFlagMachineID] = fakeRobotID
+	flags[generalFlagOrgID] = ""
 	flags[apiKeyCreateFlagName] = "test-me"
 	cCtx, ac, out, _ = setup(asc, nil, nil, &flags, "token")
 	err = ac.robotAPIKeyCreateAction(cCtx)
@@ -158,8 +158,8 @@ func TestLocationAPIKeyCreateAction(t *testing.T) {
 	}
 
 	flags := make(map[string]string)
-	flags[apiKeyFlagLocationID] = ""
-	flags[apiKeyCreateFlagOrgID] = ""
+	flags[generalFlagLocationID] = ""
+	flags[generalFlagOrgID] = ""
 	flags[apiKeyCreateFlagName] = "" // testing no locationID
 
 	cCtx, ac, out, errOut := setup(asc, nil, nil, &flags, "token")
@@ -168,7 +168,7 @@ func TestLocationAPIKeyCreateAction(t *testing.T) {
 	test.That(t, len(errOut.messages), test.ShouldEqual, 0)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "cannot create an api-key for a location without an ID")
 
-	cCtx.Set(apiKeyFlagLocationID, fakeLocID)
+	cCtx.Set(generalFlagLocationID, fakeLocID)
 	// will create an api-key with a default name
 	test.That(t, ac.locationAPIKeyCreateAction(cCtx), test.ShouldBeNil)
 	allMessages := strings.Join(out.messages, " ")
@@ -179,8 +179,8 @@ func TestLocationAPIKeyCreateAction(t *testing.T) {
 	test.That(t, allMessages, test.ShouldContainSubstring, "Key Value: key-yyy")
 
 	// test with an orgID is fine
-	cCtx.Set(apiKeyCreateFlagOrgID, fakeOrgID)
-	test.That(t, ac.c.Value(apiKeyCreateFlagOrgID), test.ShouldNotBeEmpty)
+	cCtx.Set(generalFlagOrgID, fakeOrgID)
+	test.That(t, ac.c.Value(generalFlagOrgID), test.ShouldNotBeEmpty)
 	test.That(t, ac.locationAPIKeyCreateAction(cCtx), test.ShouldBeNil)
 	allMessages = strings.Join(out.messages, " ")
 
@@ -199,8 +199,8 @@ func TestLocationAPIKeyCreateAction(t *testing.T) {
 	}
 
 	flags = make(map[string]string)
-	flags[apiKeyFlagLocationID] = fakeLocID
-	flags[apiKeyCreateFlagOrgID] = ""
+	flags[generalFlagLocationID] = fakeLocID
+	flags[generalFlagOrgID] = ""
 	flags[apiKeyCreateFlagName] = "test-name"
 
 	cCtx, ac, _, _ = setup(asc, nil, nil, &flags, "token")

--- a/cli/data.go
+++ b/cli/data.go
@@ -93,7 +93,7 @@ func DataDeleteTabularAction(c *cli.Context) error {
 		return err
 	}
 
-	if err := client.deleteTabularData(c.String(dataFlagOrgID), c.Int(dataFlagDeleteTabularDataOlderThanDays)); err != nil {
+	if err := client.deleteTabularData(c.String(generalFlagOrgID), c.Int(dataFlagDeleteTabularDataOlderThanDays)); err != nil {
 		return err
 	}
 	return nil
@@ -108,8 +108,8 @@ func createDataFilter(c *cli.Context) (*datapb.Filter, error) {
 	if c.StringSlice(dataFlagLocationIDs) != nil {
 		filter.LocationIds = c.StringSlice(dataFlagLocationIDs)
 	}
-	if c.String(dataFlagMachineID) != "" {
-		filter.RobotId = c.String(dataFlagMachineID)
+	if c.String(generalFlagMachineID) != "" {
+		filter.RobotId = c.String(generalFlagMachineID)
 	}
 	if c.String(dataFlagPartID) != "" {
 		filter.PartId = c.String(dataFlagPartID)
@@ -585,7 +585,7 @@ func DataAddToDatasetByIDs(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	if err := client.dataAddToDatasetByIDs(c.String(datasetFlagDatasetID), c.String(dataFlagOrgID),
+	if err := client.dataAddToDatasetByIDs(c.String(datasetFlagDatasetID), c.String(generalFlagOrgID),
 		c.String(dataFlagLocationID), c.StringSlice(dataFlagFileIDs)); err != nil {
 		return err
 	}
@@ -655,7 +655,7 @@ func DataRemoveFromDataset(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	if err := client.dataRemoveFromDataset(c.String(datasetFlagDatasetID), c.String(dataFlagOrgID),
+	if err := client.dataRemoveFromDataset(c.String(datasetFlagDatasetID), c.String(generalFlagOrgID),
 		c.String(dataFlagLocationID), c.StringSlice(dataFlagFileIDs)); err != nil {
 		return err
 	}
@@ -691,7 +691,7 @@ func DataConfigureDatabaseUser(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	if err := client.dataConfigureDatabaseUser(c.String(dataFlagOrgID), c.String(dataFlagDatabasePassword)); err != nil {
+	if err := client.dataConfigureDatabaseUser(c.String(generalFlagOrgID), c.String(dataFlagDatabasePassword)); err != nil {
 		return err
 	}
 	return nil
@@ -719,7 +719,7 @@ func DataGetDatabaseConnection(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	if err := client.dataGetDatabaseConnection(c.String(dataFlagOrgID)); err != nil {
+	if err := client.dataGetDatabaseConnection(c.String(generalFlagOrgID)); err != nil {
 		return err
 	}
 	return nil

--- a/cli/dataset.go
+++ b/cli/dataset.go
@@ -22,7 +22,7 @@ func DatasetCreateAction(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	if err := client.createDataset(c.String(dataFlagOrgID), c.String(datasetFlagName)); err != nil {
+	if err := client.createDataset(c.String(generalFlagOrgID), c.String(datasetFlagName)); err != nil {
 		return err
 	}
 	return nil
@@ -75,7 +75,7 @@ func DatasetListAction(c *cli.Context) error {
 		return err
 	}
 	datasetIDs := c.StringSlice(datasetFlagDatasetIDs)
-	orgID := c.String(dataFlagOrgID)
+	orgID := c.String(generalFlagOrgID)
 
 	if orgID != "" && datasetIDs != nil {
 		return errors.New("must specify either dataset IDs or organization ID, got both")

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -88,7 +88,7 @@ const (
 func CreateModuleAction(c *cli.Context) error {
 	moduleNameArg := c.String(moduleFlagName)
 	publicNamespaceArg := c.String(moduleFlagPublicNamespace)
-	orgIDArg := c.String(moduleFlagOrgID)
+	orgIDArg := c.String(generalFlagOrgID)
 
 	client, err := newViamClient(c)
 	if err != nil {
@@ -201,7 +201,7 @@ func UpdateModuleAction(c *cli.Context) error {
 func UploadModuleAction(c *cli.Context) error {
 	manifestPath := c.String(moduleFlagPath)
 	publicNamespaceArg := c.String(moduleFlagPublicNamespace)
-	orgIDArg := c.String(moduleFlagOrgID)
+	orgIDArg := c.String(generalFlagOrgID)
 	nameArg := c.String(moduleFlagName)
 	versionArg := c.String(moduleFlagVersion)
 	platformArg := c.String(moduleFlagPlatform)

--- a/cli/train.go
+++ b/cli/train.go
@@ -123,7 +123,7 @@ func DataListTrainingJobs(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	jobs, err := client.dataListTrainingJobs(c.String(dataFlagOrgID), c.String(trainFlagJobStatus))
+	jobs, err := client.dataListTrainingJobs(c.String(generalFlagOrgID), c.String(trainFlagJobStatus))
 	if err != nil {
 		return err
 	}

--- a/cli/train.go
+++ b/cli/train.go
@@ -18,6 +18,8 @@ const (
 	trainFlagModelVersion = "model-version"
 	trainFlagModelType    = "model-type"
 	trainFlagModelLabels  = "model-labels"
+
+	trainingStatusPrefix = "TRAINING_STATUS_"
 )
 
 // DataSubmitTrainingJob is the corresponding action for 'data train submit'.
@@ -142,7 +144,7 @@ func (c *viamClient) dataListTrainingJobs(orgID, status string) ([]*mltrainingpb
 	if status == "" {
 		status = "unspecified"
 	}
-	statusEnum, ok := mltrainingpb.TrainingStatus_value["TRAINING_STATUS_"+strings.ToUpper(status)]
+	statusEnum, ok := mltrainingpb.TrainingStatus_value[trainingStatusPrefix+strings.ToUpper(status)]
 	if !ok {
 		return nil, errors.Errorf("%s must be a valid TrainingStatus, got %s. See `viam train list --help` for supported options",
 			trainFlagJobStatus, status)
@@ -156,4 +158,18 @@ func (c *viamClient) dataListTrainingJobs(orgID, status string) ([]*mltrainingpb
 		return nil, err
 	}
 	return resp.Jobs, nil
+}
+
+// allTrainingStatusValues returns the accepted values for the trainFlagJobStatus flag.
+func allTrainingStatusValues() string {
+	var formattedStatuses []string
+	for status := range mltrainingpb.TrainingStatus_value {
+		formattedStatus := strings.ToLower(strings.TrimPrefix(status, trainingStatusPrefix))
+		formattedStatuses = append(formattedStatuses, formattedStatus)
+	}
+	var allStatuses string
+	if len(formattedStatuses) > 0 {
+		allStatuses = "[" + strings.Join(formattedStatuses, ", ") + "]"
+	}
+	return allStatuses
 }

--- a/cli/train.go
+++ b/cli/train.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 	mltrainingpb "go.viam.com/api/app/mltraining/v1"
+	"golang.org/x/exp/slices"
 )
 
 const (
@@ -167,9 +168,7 @@ func allTrainingStatusValues() string {
 		formattedStatus := strings.ToLower(strings.TrimPrefix(status, trainingStatusPrefix))
 		formattedStatuses = append(formattedStatuses, formattedStatus)
 	}
-	var allStatuses string
-	if len(formattedStatuses) > 0 {
-		allStatuses = "[" + strings.Join(formattedStatuses, ", ") + "]"
-	}
-	return allStatuses
+
+	slices.Sort(formattedStatuses)
+	return "[" + strings.Join(formattedStatuses, ", ") + "]"
 }


### PR DESCRIPTION
[RSDK-6094](https://viam.atlassian.net/browse/RSDK-6094)

Uses `createUsageText` for more CLI commands that previously had the format `viam module upload <version> <platform> [other options] <packaged-module.tar.gz>`, so the format now looks like `viam module upload --version=<version> --platform=<platform> [other options] <packaged-module.tag.gz>`. Cleans up existing `UsageText`s.

[RSDK-6094]: https://viam.atlassian.net/browse/RSDK-6094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ