### PR TITLE
RSDK-6625 - Invalid ffmpeg config causes config loop

### DIFF
--- a/components/camera/ffmpeg/ffmpeg.go
+++ b/components/camera/ffmpeg/ffmpeg.go
@@ -120,6 +120,10 @@ func NewFFMPEGCamera(ctx context.Context, conf *Config, logger logging.Logger) (
 				return
 			}
 			if cmd.ProcessState.ExitCode() != 0 {
+				// A bad ffmpeg resource configuration can cause the ffmpeg program to exit
+				// with a non-zero code. This goroutine will infinitely loop until the user
+				// fixes the configuration. A change in configuration Closes this object,
+				// canceling the cancelableCtx.
 				panic(err)
 			}
 		}

--- a/components/camera/ffmpeg/ffmpeg.go
+++ b/components/camera/ffmpeg/ffmpeg.go
@@ -102,6 +102,11 @@ func NewFFMPEGCamera(ctx context.Context, conf *Config, logger logging.Logger) (
 
 	ffCam.activeBackgroundWorkers.Add(1)
 	viamutils.ManagedGo(func() {
+		select {
+		case <-cancelableCtx.Done():
+			return
+		default:
+		}
 		stream := ffmpeg.Input(conf.VideoPath, conf.InputKWArgs)
 		for _, filter := range conf.Filters {
 			stream = stream.Filter(filter.Name, filter.Args, filter.KWArgs)


### PR DESCRIPTION
issue is ffmpeg builtin model has a go routine that will never exit (because of ManagedGo) if it panics.
another possible fix is to remove the panic, but seems like that was intentional so that we retry? @bazile-clyde 

and thus, the reconfiguration will hang on Close and mean that the new config never gets loaded in