### PR TITLE
Use `any` instead of `interface{}`

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -991,7 +991,7 @@ func (c *viamClient) startRobotPartShell(
 		return errors.New("could not get shell service from machine part")
 	}
 
-	input, output, err := shellSvc.Shell(c.c.Context, map[string]interface{}{})
+	input, output, err := shellSvc.Shell(c.c.Context, map[string]any{})
 	if err != nil {
 		return err
 	}

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -112,7 +112,7 @@ func TestListOrganizationsAction(t *testing.T) {
 }
 
 func TestTabularDataByFilterAction(t *testing.T) {
-	pbStruct, err := protoutils.StructToStructPb(map[string]interface{}{"bool": true, "string": "true", "float": float64(1)})
+	pbStruct, err := protoutils.StructToStructPb(map[string]any{"bool": true, "string": "true", "float": float64(1)})
 	test.That(t, err, test.ShouldBeNil)
 
 	// calls to `TabularDataByFilter` will repeat so long as data continue to be returned,

--- a/cli/print.go
+++ b/cli/print.go
@@ -22,12 +22,12 @@ const asciiViam = `
 `
 
 // printf prints a message with no prefix.
-func printf(w io.Writer, format string, a ...interface{}) {
+func printf(w io.Writer, format string, a ...any) {
 	fmt.Fprintf(w, format+"\n", a...)
 }
 
 // infof prints a message prefixed with a bold cyan "Info: ".
-func infof(w io.Writer, format string, a ...interface{}) {
+func infof(w io.Writer, format string, a ...any) {
 	// NOTE(benjirewis): for some reason, both errcheck and gosec complain about
 	// Fprint's "unchecked error" here. Fatally log any errors write errors here
 	// and below.
@@ -44,7 +44,7 @@ func infof(w io.Writer, format string, a ...interface{}) {
 // future. unparam will complain until it does.
 //
 //nolint:unparam
-func warningf(w io.Writer, format string, a ...interface{}) {
+func warningf(w io.Writer, format string, a ...any) {
 	if _, err := color.New(color.Bold, color.FgYellow).Fprint(w, "Warning: "); err != nil {
 		log.Fatal(err)
 	}
@@ -53,7 +53,7 @@ func warningf(w io.Writer, format string, a ...interface{}) {
 
 // Errorf prints a message prefixed with a bold red "Error: " prefix and exits with 1.
 // It also capitalizes the first letter of the message.
-func Errorf(w io.Writer, format string, a ...interface{}) {
+func Errorf(w io.Writer, format string, a ...any) {
 	if _, err := color.New(color.Bold, color.FgRed).Fprint(w, "Error: "); err != nil {
 		log.Fatal(err)
 	}

--- a/components/arm/arm.go
+++ b/components/arm/arm.go
@@ -72,18 +72,18 @@ type Arm interface {
 	referenceframe.InputEnabled
 
 	// EndPosition returns the current position of the arm.
-	EndPosition(ctx context.Context, extra map[string]interface{}) (spatialmath.Pose, error)
+	EndPosition(ctx context.Context, extra map[string]any) (spatialmath.Pose, error)
 
 	// MoveToPosition moves the arm to the given absolute position.
 	// This will block until done or a new operation cancels this one
-	MoveToPosition(ctx context.Context, pose spatialmath.Pose, extra map[string]interface{}) error
+	MoveToPosition(ctx context.Context, pose spatialmath.Pose, extra map[string]any) error
 
 	// MoveToJointPositions moves the arm's joints to the given positions.
 	// This will block until done or a new operation cancels this one
-	MoveToJointPositions(ctx context.Context, positionDegs *pb.JointPositions, extra map[string]interface{}) error
+	MoveToJointPositions(ctx context.Context, positionDegs *pb.JointPositions, extra map[string]any) error
 
 	// JointPositions returns the current joint positions of the arm.
-	JointPositions(ctx context.Context, extra map[string]interface{}) (*pb.JointPositions, error)
+	JointPositions(ctx context.Context, extra map[string]any) (*pb.JointPositions, error)
 }
 
 // FromDependencies is a helper for getting the named arm from a collection of

--- a/components/arm/arm_test.go
+++ b/components/arm/arm_test.go
@@ -44,9 +44,9 @@ func TestStatusValid(t *testing.T) {
 		t,
 		newStruct.AsMap(),
 		test.ShouldResemble,
-		map[string]interface{}{
-			"end_position":    map[string]interface{}{"o_z": 1.0, "x": 1.0, "y": 2.0, "z": 3.0},
-			"joint_positions": map[string]interface{}{"values": []interface{}{1.1, 2.2, 3.3}},
+		map[string]any{
+			"end_position":    map[string]any{"o_z": 1.0, "x": 1.0, "y": 2.0, "z": 3.0},
+			"joint_positions": map[string]any{"values": []any{1.1, 2.2, 3.3}},
 			"is_moving":       true,
 		},
 	)
@@ -73,7 +73,7 @@ func TestCreateStatus(t *testing.T) {
 	injectArm := &inject.Arm{}
 
 	//nolint:unparam
-	successfulJointPositionsFunc := func(context.Context, map[string]interface{}) (*pb.JointPositions, error) {
+	successfulJointPositionsFunc := func(context.Context, map[string]any) (*pb.JointPositions, error) {
 		return successfulStatus.JointPositions, nil
 	}
 
@@ -125,7 +125,7 @@ func TestCreateStatus(t *testing.T) {
 		moving := statusMap["is_moving"].(bool)
 		test.That(t, moving, test.ShouldEqual, expectedStatus.IsMoving)
 
-		jPosFace := statusMap["joint_positions"].(map[string]interface{})["values"].([]interface{})
+		jPosFace := statusMap["joint_positions"].(map[string]any)["values"].([]any)
 		actualJointPositions := []float64{
 			jPosFace[0].(float64), jPosFace[1].(float64), jPosFace[2].(float64),
 			jPosFace[3].(float64), jPosFace[4].(float64), jPosFace[5].(float64),
@@ -161,7 +161,7 @@ func TestCreateStatus(t *testing.T) {
 		injectArm.ModelFrameFunc = successfulModelFrameFunc
 
 		errFail := errors.New("can't get joint positions")
-		injectArm.JointPositionsFunc = func(ctx context.Context, extra map[string]interface{}) (*pb.JointPositions, error) {
+		injectArm.JointPositionsFunc = func(ctx context.Context, extra map[string]any) (*pb.JointPositions, error) {
 			return nil, errFail
 		}
 
@@ -174,7 +174,7 @@ func TestCreateStatus(t *testing.T) {
 		injectArm.IsMovingFunc = successfulIsMovingFunc
 		injectArm.ModelFrameFunc = successfulModelFrameFunc
 
-		injectArm.JointPositionsFunc = func(ctx context.Context, extra map[string]interface{}) (*pb.JointPositions, error) {
+		injectArm.JointPositionsFunc = func(ctx context.Context, extra map[string]any) (*pb.JointPositions, error) {
 			return nil, nil //nolint:nilnil
 		}
 
@@ -231,7 +231,7 @@ func TestOOBArm(t *testing.T) {
 	}
 
 	jPositions := pb.JointPositions{Values: []float64{0, 0, 0, 0, 0, 720}}
-	injectedArm.JointPositionsFunc = func(ctx context.Context, extra map[string]interface{}) (*pb.JointPositions, error) {
+	injectedArm.JointPositionsFunc = func(ctx context.Context, extra map[string]any) (*pb.JointPositions, error) {
 		return &jPositions, nil
 	}
 

--- a/components/arm/client.go
+++ b/components/arm/client.go
@@ -58,7 +58,7 @@ func NewClientFromConn(
 	return c, nil
 }
 
-func (c *client) EndPosition(ctx context.Context, extra map[string]interface{}) (spatialmath.Pose, error) {
+func (c *client) EndPosition(ctx context.Context, extra map[string]any) (spatialmath.Pose, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return nil, err
@@ -73,7 +73,7 @@ func (c *client) EndPosition(ctx context.Context, extra map[string]interface{}) 
 	return spatialmath.NewPoseFromProtobuf(resp.Pose), nil
 }
 
-func (c *client) MoveToPosition(ctx context.Context, pose spatialmath.Pose, extra map[string]interface{}) error {
+func (c *client) MoveToPosition(ctx context.Context, pose spatialmath.Pose, extra map[string]any) error {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return err
@@ -86,7 +86,7 @@ func (c *client) MoveToPosition(ctx context.Context, pose spatialmath.Pose, extr
 	return err
 }
 
-func (c *client) MoveToJointPositions(ctx context.Context, positions *pb.JointPositions, extra map[string]interface{}) error {
+func (c *client) MoveToJointPositions(ctx context.Context, positions *pb.JointPositions, extra map[string]any) error {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return err
@@ -99,7 +99,7 @@ func (c *client) MoveToJointPositions(ctx context.Context, positions *pb.JointPo
 	return err
 }
 
-func (c *client) JointPositions(ctx context.Context, extra map[string]interface{}) (*pb.JointPositions, error) {
+func (c *client) JointPositions(ctx context.Context, extra map[string]any) (*pb.JointPositions, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return nil, err
@@ -114,7 +114,7 @@ func (c *client) JointPositions(ctx context.Context, extra map[string]interface{
 	return resp.Positions, nil
 }
 
-func (c *client) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (c *client) Stop(ctx context.Context, extra map[string]any) error {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return err
@@ -148,7 +148,7 @@ func (c *client) GoToInputs(ctx context.Context, goal []referenceframe.Input) er
 	return c.MoveToJointPositions(ctx, c.model.ProtobufFromInput(goal), nil)
 }
 
-func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (c *client) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	return rprotoutils.DoFromResourceClient(ctx, c.client, c.name, cmd)
 }
 
@@ -160,7 +160,7 @@ func (c *client) IsMoving(ctx context.Context) (bool, error) {
 	return resp.IsMoving, nil
 }
 
-func (c *client) Geometries(ctx context.Context, extra map[string]interface{}) ([]spatialmath.Geometry, error) {
+func (c *client) Geometries(ctx context.Context, extra map[string]any) ([]spatialmath.Geometry, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return nil, err
@@ -175,7 +175,7 @@ func (c *client) Geometries(ctx context.Context, extra map[string]interface{}) (
 	return spatialmath.NewGeometriesFromProto(resp.GetGeometries())
 }
 
-func (c *client) updateKinematics(ctx context.Context, extra map[string]interface{}) (referenceframe.Model, error) {
+func (c *client) updateKinematics(ctx context.Context, extra map[string]any) (referenceframe.Model, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return nil, err

--- a/components/arm/client_test.go
+++ b/components/arm/client_test.go
@@ -33,32 +33,32 @@ func TestClient(t *testing.T) {
 	var (
 		capArmPos      spatialmath.Pose
 		capArmJointPos *componentpb.JointPositions
-		extraOptions   map[string]interface{}
+		extraOptions   map[string]any
 	)
 
 	pos1 := spatialmath.NewPoseFromPoint(r3.Vector{X: 1, Y: 2, Z: 3})
 	jointPos1 := &componentpb.JointPositions{Values: []float64{1.0, 2.0, 3.0}}
 	injectArm := &inject.Arm{}
-	injectArm.EndPositionFunc = func(ctx context.Context, extra map[string]interface{}) (spatialmath.Pose, error) {
+	injectArm.EndPositionFunc = func(ctx context.Context, extra map[string]any) (spatialmath.Pose, error) {
 		extraOptions = extra
 		return pos1, nil
 	}
-	injectArm.JointPositionsFunc = func(ctx context.Context, extra map[string]interface{}) (*componentpb.JointPositions, error) {
+	injectArm.JointPositionsFunc = func(ctx context.Context, extra map[string]any) (*componentpb.JointPositions, error) {
 		extraOptions = extra
 		return jointPos1, nil
 	}
-	injectArm.MoveToPositionFunc = func(ctx context.Context, ap spatialmath.Pose, extra map[string]interface{}) error {
+	injectArm.MoveToPositionFunc = func(ctx context.Context, ap spatialmath.Pose, extra map[string]any) error {
 		capArmPos = ap
 		extraOptions = extra
 		return nil
 	}
 
-	injectArm.MoveToJointPositionsFunc = func(ctx context.Context, jp *componentpb.JointPositions, extra map[string]interface{}) error {
+	injectArm.MoveToJointPositionsFunc = func(ctx context.Context, jp *componentpb.JointPositions, extra map[string]any) error {
 		capArmJointPos = jp
 		extraOptions = extra
 		return nil
 	}
-	injectArm.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	injectArm.StopFunc = func(ctx context.Context, extra map[string]any) error {
 		extraOptions = extra
 		return errStopUnimplemented
 	}
@@ -72,22 +72,22 @@ func TestClient(t *testing.T) {
 	pos2 := spatialmath.NewPoseFromPoint(r3.Vector{X: 4, Y: 5, Z: 6})
 	jointPos2 := &componentpb.JointPositions{Values: []float64{4.0, 5.0, 6.0}}
 	injectArm2 := &inject.Arm{}
-	injectArm2.EndPositionFunc = func(ctx context.Context, extra map[string]interface{}) (spatialmath.Pose, error) {
+	injectArm2.EndPositionFunc = func(ctx context.Context, extra map[string]any) (spatialmath.Pose, error) {
 		return pos2, nil
 	}
-	injectArm2.JointPositionsFunc = func(ctx context.Context, extra map[string]interface{}) (*componentpb.JointPositions, error) {
+	injectArm2.JointPositionsFunc = func(ctx context.Context, extra map[string]any) (*componentpb.JointPositions, error) {
 		return jointPos2, nil
 	}
-	injectArm2.MoveToPositionFunc = func(ctx context.Context, ap spatialmath.Pose, extra map[string]interface{}) error {
+	injectArm2.MoveToPositionFunc = func(ctx context.Context, ap spatialmath.Pose, extra map[string]any) error {
 		capArmPos = ap
 		return nil
 	}
 
-	injectArm2.MoveToJointPositionsFunc = func(ctx context.Context, jp *componentpb.JointPositions, extra map[string]interface{}) error {
+	injectArm2.MoveToJointPositionsFunc = func(ctx context.Context, jp *componentpb.JointPositions, extra map[string]any) error {
 		capArmJointPos = jp
 		return nil
 	}
-	injectArm2.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	injectArm2.StopFunc = func(ctx context.Context, extra map[string]any) error {
 		return nil
 	}
 	injectArm2.ModelFrameFunc = func() referenceframe.Model {
@@ -146,31 +146,31 @@ func TestClient(t *testing.T) {
 		test.That(t, resp["command"], test.ShouldEqual, testutils.TestCommand["command"])
 		test.That(t, resp["data"], test.ShouldEqual, testutils.TestCommand["data"])
 
-		pos, err := arm1Client.EndPosition(context.Background(), map[string]interface{}{"foo": "EndPosition"})
+		pos, err := arm1Client.EndPosition(context.Background(), map[string]any{"foo": "EndPosition"})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, spatialmath.PoseAlmostEqual(pos, pos1), test.ShouldBeTrue)
-		test.That(t, extraOptions, test.ShouldResemble, map[string]interface{}{"foo": "EndPosition"})
+		test.That(t, extraOptions, test.ShouldResemble, map[string]any{"foo": "EndPosition"})
 
-		jointPos, err := arm1Client.JointPositions(context.Background(), map[string]interface{}{"foo": "JointPositions"})
+		jointPos, err := arm1Client.JointPositions(context.Background(), map[string]any{"foo": "JointPositions"})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, jointPos.String(), test.ShouldResemble, jointPos1.String())
-		test.That(t, extraOptions, test.ShouldResemble, map[string]interface{}{"foo": "JointPositions"})
+		test.That(t, extraOptions, test.ShouldResemble, map[string]any{"foo": "JointPositions"})
 
-		err = arm1Client.MoveToPosition(context.Background(), pos2, map[string]interface{}{"foo": "MoveToPosition"})
+		err = arm1Client.MoveToPosition(context.Background(), pos2, map[string]any{"foo": "MoveToPosition"})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, spatialmath.PoseAlmostEqual(capArmPos, pos2), test.ShouldBeTrue)
 
-		test.That(t, extraOptions, test.ShouldResemble, map[string]interface{}{"foo": "MoveToPosition"})
+		test.That(t, extraOptions, test.ShouldResemble, map[string]any{"foo": "MoveToPosition"})
 
-		err = arm1Client.MoveToJointPositions(context.Background(), jointPos2, map[string]interface{}{"foo": "MoveToJointPositions"})
+		err = arm1Client.MoveToJointPositions(context.Background(), jointPos2, map[string]any{"foo": "MoveToJointPositions"})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, capArmJointPos.String(), test.ShouldResemble, jointPos2.String())
-		test.That(t, extraOptions, test.ShouldResemble, map[string]interface{}{"foo": "MoveToJointPositions"})
+		test.That(t, extraOptions, test.ShouldResemble, map[string]any{"foo": "MoveToJointPositions"})
 
-		err = arm1Client.Stop(context.Background(), map[string]interface{}{"foo": "Stop"})
+		err = arm1Client.Stop(context.Background(), map[string]any{"foo": "Stop"})
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errStopUnimplemented.Error())
-		test.That(t, extraOptions, test.ShouldResemble, map[string]interface{}{"foo": "Stop"})
+		test.That(t, extraOptions, test.ShouldResemble, map[string]any{"foo": "Stop"})
 
 		test.That(t, arm1Client.Close(context.Background()), test.ShouldBeNil)
 		test.That(t, conn.Close(), test.ShouldBeNil)

--- a/components/arm/collectors.go
+++ b/components/arm/collectors.go
@@ -32,13 +32,13 @@ func (m method) String() string {
 
 // newEndPositionCollector returns a collector to register an end position method. If one is already registered
 // with the same MethodMetadata it will panic.
-func newEndPositionCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+func newEndPositionCollector(resource any, params data.CollectorParams) (data.Collector, error) {
 	arm, err := assertArm(resource)
 	if err != nil {
 		return nil, err
 	}
 
-	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (interface{}, error) {
+	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (any, error) {
 		v, err := arm.EndPosition(ctx, data.FromDMExtraMap)
 		if err != nil {
 			// A modular filter component can be created to filter the readings from a component. The error ErrNoCaptureToStore
@@ -66,13 +66,13 @@ func newEndPositionCollector(resource interface{}, params data.CollectorParams) 
 
 // newJointPositionsCollector returns a collector to register a joint positions method. If one is already registered
 // with the same MethodMetadata it will panic.
-func newJointPositionsCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+func newJointPositionsCollector(resource any, params data.CollectorParams) (data.Collector, error) {
 	arm, err := assertArm(resource)
 	if err != nil {
 		return nil, err
 	}
 
-	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (interface{}, error) {
+	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (any, error) {
 		v, err := arm.JointPositions(ctx, data.FromDMExtraMap)
 		if err != nil {
 			// A modular filter component can be created to filter the readings from a component. The error ErrNoCaptureToStore
@@ -89,7 +89,7 @@ func newJointPositionsCollector(resource interface{}, params data.CollectorParam
 	return data.NewCollector(cFunc, params)
 }
 
-func assertArm(resource interface{}) (Arm, error) {
+func assertArm(resource any) (Arm, error) {
 	arm, ok := resource.(Arm)
 	if !ok {
 		return nil, data.InvalidInterfaceErr(API)

--- a/components/arm/collectors_test.go
+++ b/components/arm/collectors_test.go
@@ -90,10 +90,10 @@ func TestCollectors(t *testing.T) {
 
 func newArm() arm.Arm {
 	a := &inject.Arm{}
-	a.EndPositionFunc = func(ctx context.Context, extra map[string]interface{}) (spatialmath.Pose, error) {
+	a.EndPositionFunc = func(ctx context.Context, extra map[string]any) (spatialmath.Pose, error) {
 		return spatialmath.NewPoseFromPoint(r3.Vector{X: 1, Y: 2, Z: 3}), nil
 	}
-	a.JointPositionsFunc = func(ctx context.Context, extra map[string]interface{}) (*pb.JointPositions, error) {
+	a.JointPositionsFunc = func(ctx context.Context, extra map[string]any) (*pb.JointPositions, error) {
 		return &pb.JointPositions{
 			Values: floatList,
 		}, nil

--- a/components/arm/fake/fake.go
+++ b/components/arm/fake/fake.go
@@ -127,7 +127,7 @@ func (a *Arm) ModelFrame() referenceframe.Model {
 }
 
 // EndPosition returns the set position.
-func (a *Arm) EndPosition(ctx context.Context, extra map[string]interface{}) (spatialmath.Pose, error) {
+func (a *Arm) EndPosition(ctx context.Context, extra map[string]any) (spatialmath.Pose, error) {
 	joints, err := a.JointPositions(ctx, extra)
 	if err != nil {
 		return nil, err
@@ -138,12 +138,12 @@ func (a *Arm) EndPosition(ctx context.Context, extra map[string]interface{}) (sp
 }
 
 // MoveToPosition sets the position.
-func (a *Arm) MoveToPosition(ctx context.Context, pos spatialmath.Pose, extra map[string]interface{}) error {
+func (a *Arm) MoveToPosition(ctx context.Context, pos spatialmath.Pose, extra map[string]any) error {
 	return arm.Move(ctx, a.logger, a, pos)
 }
 
 // MoveToJointPositions sets the joints.
-func (a *Arm) MoveToJointPositions(ctx context.Context, joints *pb.JointPositions, extra map[string]interface{}) error {
+func (a *Arm) MoveToJointPositions(ctx context.Context, joints *pb.JointPositions, extra map[string]any) error {
 	if err := arm.CheckDesiredJointPositions(ctx, a, joints); err != nil {
 		return err
 	}
@@ -160,13 +160,13 @@ func (a *Arm) MoveToJointPositions(ctx context.Context, joints *pb.JointPosition
 }
 
 // JointPositions returns joints.
-func (a *Arm) JointPositions(ctx context.Context, extra map[string]interface{}) (*pb.JointPositions, error) {
+func (a *Arm) JointPositions(ctx context.Context, extra map[string]any) (*pb.JointPositions, error) {
 	retJoint := &pb.JointPositions{Values: a.joints.Values}
 	return retJoint, nil
 }
 
 // Stop doesn't do anything for a fake arm.
-func (a *Arm) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (a *Arm) Stop(ctx context.Context, extra map[string]any) error {
 	return nil
 }
 
@@ -205,7 +205,7 @@ func (a *Arm) Close(ctx context.Context) error {
 
 // Geometries returns the list of geometries associated with the resource, in any order. The poses of the geometries reflect their
 // current location relative to the frame of the resource.
-func (a *Arm) Geometries(ctx context.Context, extra map[string]interface{}) ([]spatialmath.Geometry, error) {
+func (a *Arm) Geometries(ctx context.Context, extra map[string]any) ([]spatialmath.Geometry, error) {
 	inputs, err := a.CurrentInputs(ctx)
 	if err != nil {
 		return nil, err

--- a/components/arm/server.go
+++ b/components/arm/server.go
@@ -24,7 +24,7 @@ type serviceServer struct {
 
 // NewRPCServiceServer constructs an arm gRPC service server.
 // It is intentionally untyped to prevent use outside of tests.
-func NewRPCServiceServer(coll resource.APIResourceCollection[Arm]) interface{} {
+func NewRPCServiceServer(coll resource.APIResourceCollection[Arm]) any {
 	return &serviceServer{coll: coll}
 }
 

--- a/components/arm/universalrobots/ur.go
+++ b/components/arm/universalrobots/ur.go
@@ -331,7 +331,7 @@ func (ua *urArm) getState() (robotState, error) {
 }
 
 // JointPositions gets the current joint positions of the UR arm.
-func (ua *urArm) JointPositions(ctx context.Context, extra map[string]interface{}) (*pb.JointPositions, error) {
+func (ua *urArm) JointPositions(ctx context.Context, extra map[string]any) (*pb.JointPositions, error) {
 	radians := []float64{}
 	state, err := ua.getState()
 	if err != nil {
@@ -344,7 +344,7 @@ func (ua *urArm) JointPositions(ctx context.Context, extra map[string]interface{
 }
 
 // EndPosition computes and returns the current cartesian position.
-func (ua *urArm) EndPosition(ctx context.Context, extra map[string]interface{}) (spatialmath.Pose, error) {
+func (ua *urArm) EndPosition(ctx context.Context, extra map[string]any) (spatialmath.Pose, error) {
 	joints, err := ua.JointPositions(ctx, extra)
 	if err != nil {
 		return nil, err
@@ -355,7 +355,7 @@ func (ua *urArm) EndPosition(ctx context.Context, extra map[string]interface{}) 
 // MoveToPosition moves the arm to the specified cartesian position.
 // If the UR arm was configured with "arm_hosted_kinematics = 'true'" or extra["arm_hosted_kinematics"] = true is specified at runtime
 // this command will use the kinematics hosted by the Universal Robots arm.
-func (ua *urArm) MoveToPosition(ctx context.Context, pos spatialmath.Pose, extra map[string]interface{}) error {
+func (ua *urArm) MoveToPosition(ctx context.Context, pos spatialmath.Pose, extra map[string]any) error {
 	if !ua.inRemoteMode {
 		return errors.New("UR5 is in local mode; use the polyscope to switch it to remote control mode")
 	}
@@ -375,7 +375,7 @@ func (ua *urArm) MoveToPosition(ctx context.Context, pos spatialmath.Pose, extra
 }
 
 // MoveToJointPositions moves the UR arm to the specified joint positions.
-func (ua *urArm) MoveToJointPositions(ctx context.Context, joints *pb.JointPositions, extra map[string]interface{}) error {
+func (ua *urArm) MoveToJointPositions(ctx context.Context, joints *pb.JointPositions, extra map[string]any) error {
 	// check that joint positions are not out of bounds
 	if err := arm.CheckDesiredJointPositions(ctx, ua, joints); err != nil {
 		return err
@@ -384,7 +384,7 @@ func (ua *urArm) MoveToJointPositions(ctx context.Context, joints *pb.JointPosit
 }
 
 // Stop stops the arm with some deceleration.
-func (ua *urArm) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (ua *urArm) Stop(ctx context.Context, extra map[string]any) error {
 	if !ua.inRemoteMode {
 		return errors.New("UR5 is in local mode; use the polyscope to switch it to remote control mode")
 	}
@@ -511,7 +511,7 @@ func (ua *urArm) GoToInputs(ctx context.Context, goal []referenceframe.Input) er
 
 // Geometries returns the list of geometries associated with the resource, in any order. The poses of the geometries reflect their
 // current location relative to the frame of the resource.
-func (ua *urArm) Geometries(ctx context.Context, extra map[string]interface{}) ([]spatialmath.Geometry, error) {
+func (ua *urArm) Geometries(ctx context.Context, extra map[string]any) ([]spatialmath.Geometry, error) {
 	// TODO (pl): RSDK-3316 abstract this to general arm function
 	inputs, err := ua.CurrentInputs(ctx)
 	if err != nil {

--- a/components/arm/wrapper/wrapper.go
+++ b/components/arm/wrapper/wrapper.go
@@ -105,7 +105,7 @@ func (wrapper *Arm) ModelFrame() referenceframe.Model {
 }
 
 // EndPosition returns the set position.
-func (wrapper *Arm) EndPosition(ctx context.Context, extra map[string]interface{}) (spatialmath.Pose, error) {
+func (wrapper *Arm) EndPosition(ctx context.Context, extra map[string]any) (spatialmath.Pose, error) {
 	wrapper.mu.RLock()
 	defer wrapper.mu.RUnlock()
 
@@ -117,14 +117,14 @@ func (wrapper *Arm) EndPosition(ctx context.Context, extra map[string]interface{
 }
 
 // MoveToPosition sets the position.
-func (wrapper *Arm) MoveToPosition(ctx context.Context, pos spatialmath.Pose, extra map[string]interface{}) error {
+func (wrapper *Arm) MoveToPosition(ctx context.Context, pos spatialmath.Pose, extra map[string]any) error {
 	ctx, done := wrapper.opMgr.New(ctx)
 	defer done()
 	return arm.Move(ctx, wrapper.logger, wrapper, pos)
 }
 
 // MoveToJointPositions sets the joints.
-func (wrapper *Arm) MoveToJointPositions(ctx context.Context, joints *pb.JointPositions, extra map[string]interface{}) error {
+func (wrapper *Arm) MoveToJointPositions(ctx context.Context, joints *pb.JointPositions, extra map[string]any) error {
 	// check that joint positions are not out of bounds
 	if err := arm.CheckDesiredJointPositions(ctx, wrapper, joints); err != nil {
 		return err
@@ -138,7 +138,7 @@ func (wrapper *Arm) MoveToJointPositions(ctx context.Context, joints *pb.JointPo
 }
 
 // JointPositions returns the set joints.
-func (wrapper *Arm) JointPositions(ctx context.Context, extra map[string]interface{}) (*pb.JointPositions, error) {
+func (wrapper *Arm) JointPositions(ctx context.Context, extra map[string]any) (*pb.JointPositions, error) {
 	wrapper.mu.RLock()
 	defer wrapper.mu.RUnlock()
 
@@ -150,7 +150,7 @@ func (wrapper *Arm) JointPositions(ctx context.Context, extra map[string]interfa
 }
 
 // Stop stops the actual arm.
-func (wrapper *Arm) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (wrapper *Arm) Stop(ctx context.Context, extra map[string]any) error {
 	ctx, done := wrapper.opMgr.New(ctx)
 	defer done()
 
@@ -187,7 +187,7 @@ func (wrapper *Arm) GoToInputs(ctx context.Context, goal []referenceframe.Input)
 
 // Geometries returns the list of geometries associated with the resource, in any order. The poses of the geometries reflect their
 // current location relative to the frame of the resource.
-func (wrapper *Arm) Geometries(ctx context.Context, extra map[string]interface{}) ([]spatialmath.Geometry, error) {
+func (wrapper *Arm) Geometries(ctx context.Context, extra map[string]any) ([]spatialmath.Geometry, error) {
 	inputs, err := wrapper.CurrentInputs(ctx)
 	if err != nil {
 		return nil, err

--- a/components/arm/xarm/xarm.go
+++ b/components/arm/xarm/xarm.go
@@ -197,7 +197,7 @@ func (x *xArm) GoToInputs(ctx context.Context, goal []referenceframe.Input) erro
 	return x.MoveToJointPositions(ctx, positionDegs, nil)
 }
 
-func (x *xArm) Geometries(ctx context.Context, extra map[string]interface{}) ([]spatialmath.Geometry, error) {
+func (x *xArm) Geometries(ctx context.Context, extra map[string]any) ([]spatialmath.Geometry, error) {
 	inputs, err := x.CurrentInputs(ctx)
 	if err != nil {
 		return nil, err

--- a/components/arm/xarm/xarm_comm.go
+++ b/components/arm/xarm/xarm_comm.go
@@ -351,7 +351,7 @@ func (x *xArm) Close(ctx context.Context) error {
 }
 
 // MoveToJointPositions moves the arm to the requested joint positions.
-func (x *xArm) MoveToJointPositions(ctx context.Context, newPositions *pb.JointPositions, extra map[string]interface{}) error {
+func (x *xArm) MoveToJointPositions(ctx context.Context, newPositions *pb.JointPositions, extra map[string]any) error {
 	ctx, done := x.opMgr.New(ctx)
 	defer done()
 	if !x.started {
@@ -419,7 +419,7 @@ func (x *xArm) MoveToJointPositions(ctx context.Context, newPositions *pb.JointP
 }
 
 // EndPosition computes and returns the current cartesian position.
-func (x *xArm) EndPosition(ctx context.Context, extra map[string]interface{}) (spatialmath.Pose, error) {
+func (x *xArm) EndPosition(ctx context.Context, extra map[string]any) (spatialmath.Pose, error) {
 	joints, err := x.JointPositions(ctx, extra)
 	if err != nil {
 		return nil, err
@@ -428,7 +428,7 @@ func (x *xArm) EndPosition(ctx context.Context, extra map[string]interface{}) (s
 }
 
 // MoveToPosition moves the arm to the specified cartesian position.
-func (x *xArm) MoveToPosition(ctx context.Context, pos spatialmath.Pose, extra map[string]interface{}) error {
+func (x *xArm) MoveToPosition(ctx context.Context, pos spatialmath.Pose, extra map[string]any) error {
 	ctx, done := x.opMgr.New(ctx)
 	defer done()
 	if !x.started {
@@ -447,7 +447,7 @@ func (x *xArm) MoveToPosition(ctx context.Context, pos spatialmath.Pose, extra m
 }
 
 // JointPositions returns the current positions of all joints.
-func (x *xArm) JointPositions(ctx context.Context, extra map[string]interface{}) (*pb.JointPositions, error) {
+func (x *xArm) JointPositions(ctx context.Context, extra map[string]any) (*pb.JointPositions, error) {
 	c := x.newCmd(regMap["JointPos"])
 
 	jData, err := x.send(ctx, c, true)
@@ -464,7 +464,7 @@ func (x *xArm) JointPositions(ctx context.Context, extra map[string]interface{})
 }
 
 // Stop stops the xArm but also reinitializes the arm so it can take commands again.
-func (x *xArm) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (x *xArm) Stop(ctx context.Context, extra map[string]any) error {
 	ctx, done := x.opMgr.New(ctx)
 	defer done()
 	x.started = false

--- a/components/arm/xarm/xarm_test.go
+++ b/components/arm/xarm/xarm_test.go
@@ -82,7 +82,7 @@ func TestWriteViam(t *testing.T) {
 	})
 	test.That(t, err, test.ShouldBeNil)
 
-	opt := map[string]interface{}{"motion_profile": motionplan.LinearMotionProfile}
+	opt := map[string]any{"motion_profile": motionplan.LinearMotionProfile}
 	goToGoal := func(seedMap map[string][]frame.Input, goal spatial.Pose) map[string][]frame.Input {
 		plan, err := motionplan.PlanMotion(ctx, &motionplan.PlanRequest{
 			Logger:             logger,

--- a/components/audioinput/client.go
+++ b/components/audioinput/client.go
@@ -208,7 +208,7 @@ func (c *client) MediaProperties(ctx context.Context) (prop.Audio, error) {
 	}, nil
 }
 
-func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (c *client) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	return protoutils.DoFromResourceClient(ctx, c.client, c.name, cmd)
 }
 

--- a/components/audioinput/fake/audio_input.go
+++ b/components/audioinput/fake/audio_input.go
@@ -138,16 +138,16 @@ func (i *audioInput) MediaProperties(_ context.Context) (prop.Audio, error) {
 }
 
 // DoCommand allows setting of tone.
-func (i *audioInput) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (i *audioInput) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 	newTone, ok := cmd["set_tone_hz"].(float64)
 	if !ok {
-		return map[string]interface{}{}, nil
+		return map[string]any{}, nil
 	}
 	oldTone := i.toneHz
 	i.toneHz = newTone
-	return map[string]interface{}{"prev_tone_hz": oldTone}, nil
+	return map[string]any{"prev_tone_hz": oldTone}, nil
 }
 
 // Close stops the generator routine.

--- a/components/audioinput/server.go
+++ b/components/audioinput/server.go
@@ -50,7 +50,7 @@ type serviceServer struct {
 
 // NewRPCServiceServer constructs an audio input gRPC service server.
 // It is intentionally untyped to prevent use outside of tests.
-func NewRPCServiceServer(coll resource.APIResourceCollection[AudioInput]) interface{} {
+func NewRPCServiceServer(coll resource.APIResourceCollection[AudioInput]) any {
 	return &serviceServer{coll: coll}
 }
 

--- a/components/base/base.go
+++ b/components/base/base.go
@@ -42,23 +42,23 @@ type Base interface {
 	// MoveStraight moves the robot straight a given distance at a given speed.
 	// If a distance or speed of zero is given, the base will stop.
 	// This method blocks until completed or cancelled
-	MoveStraight(ctx context.Context, distanceMm int, mmPerSec float64, extra map[string]interface{}) error
+	MoveStraight(ctx context.Context, distanceMm int, mmPerSec float64, extra map[string]any) error
 
 	// Spin spins the robot by a given angle in degrees at a given speed.
 	// If a speed of 0 the base will stop.
 	// Given a positive speed and a positive angle, the base turns to the left (for built-in RDK drivers)
 	// This method blocks until completed or cancelled
-	Spin(ctx context.Context, angleDeg, degsPerSec float64, extra map[string]interface{}) error
+	Spin(ctx context.Context, angleDeg, degsPerSec float64, extra map[string]any) error
 
 	// For linear power, positive Y moves forwards for built-in RDK drivers
 	// For angular power, positive Z turns to the left for built-in RDK drivers
-	SetPower(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error
+	SetPower(ctx context.Context, linear, angular r3.Vector, extra map[string]any) error
 
 	// linear is in mmPerSec (positive Y moves forwards for built-in RDK drivers)
 	// angular is in degsPerSec (positive Z turns to the left for built-in RDK drivers)
-	SetVelocity(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error
+	SetVelocity(ctx context.Context, linear, angular r3.Vector, extra map[string]any) error
 
-	Properties(ctx context.Context, extra map[string]interface{}) (Properties, error)
+	Properties(ctx context.Context, extra map[string]any) (Properties, error)
 }
 
 // FromDependencies is a helper for getting the named base from a collection of

--- a/components/base/base_test.go
+++ b/components/base/base_test.go
@@ -29,7 +29,7 @@ func TestStatusValid(t *testing.T) {
 		t,
 		newStruct.AsMap(),
 		test.ShouldResemble,
-		map[string]interface{}{
+		map[string]any{
 			"is_moving": true,
 		},
 	)

--- a/components/base/client.go
+++ b/components/base/client.go
@@ -44,7 +44,7 @@ func NewClientFromConn(
 	}, nil
 }
 
-func (c *client) MoveStraight(ctx context.Context, distanceMm int, mmPerSec float64, extra map[string]interface{}) error {
+func (c *client) MoveStraight(ctx context.Context, distanceMm int, mmPerSec float64, extra map[string]any) error {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return err
@@ -61,7 +61,7 @@ func (c *client) MoveStraight(ctx context.Context, distanceMm int, mmPerSec floa
 	return nil
 }
 
-func (c *client) Spin(ctx context.Context, angleDeg, degsPerSec float64, extra map[string]interface{}) error {
+func (c *client) Spin(ctx context.Context, angleDeg, degsPerSec float64, extra map[string]any) error {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return err
@@ -78,7 +78,7 @@ func (c *client) Spin(ctx context.Context, angleDeg, degsPerSec float64, extra m
 	return nil
 }
 
-func (c *client) SetPower(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error {
+func (c *client) SetPower(ctx context.Context, linear, angular r3.Vector, extra map[string]any) error {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return err
@@ -95,7 +95,7 @@ func (c *client) SetPower(ctx context.Context, linear, angular r3.Vector, extra 
 	return nil
 }
 
-func (c *client) SetVelocity(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error {
+func (c *client) SetVelocity(ctx context.Context, linear, angular r3.Vector, extra map[string]any) error {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return err
@@ -112,7 +112,7 @@ func (c *client) SetVelocity(ctx context.Context, linear, angular r3.Vector, ext
 	return nil
 }
 
-func (c *client) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (c *client) Stop(ctx context.Context, extra map[string]any) error {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return err
@@ -124,7 +124,7 @@ func (c *client) Stop(ctx context.Context, extra map[string]interface{}) error {
 	return nil
 }
 
-func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (c *client) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	return rprotoutils.DoFromResourceClient(ctx, c.client, c.name, cmd)
 }
 
@@ -136,7 +136,7 @@ func (c *client) IsMoving(ctx context.Context) (bool, error) {
 	return resp.IsMoving, nil
 }
 
-func (c *client) Properties(ctx context.Context, extra map[string]interface{}) (Properties, error) {
+func (c *client) Properties(ctx context.Context, extra map[string]any) (Properties, error) {
 	ext, err := structpb.NewStruct(extra)
 	if err != nil {
 		return Properties{}, err
@@ -150,7 +150,7 @@ func (c *client) Properties(ctx context.Context, extra map[string]interface{}) (
 	return ProtoFeaturesToProperties(resp), nil
 }
 
-func (c *client) Geometries(ctx context.Context, extra map[string]interface{}) ([]spatialmath.Geometry, error) {
+func (c *client) Geometries(ctx context.Context, extra map[string]any) ([]spatialmath.Geometry, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return nil, err

--- a/components/base/client_test.go
+++ b/components/base/client_test.go
@@ -20,31 +20,31 @@ import (
 
 func setupWorkingBase(
 	workingBase *inject.Base,
-	argsReceived map[string][]interface{},
+	argsReceived map[string][]any,
 	expectedFeatures base.Properties,
 	geometries []spatialmath.Geometry,
 ) {
 	workingBase.MoveStraightFunc = func(
 		_ context.Context, distanceMm int,
 		mmPerSec float64,
-		extra map[string]interface{},
+		extra map[string]any,
 	) error {
-		argsReceived["MoveStraight"] = []interface{}{distanceMm, mmPerSec, extra}
+		argsReceived["MoveStraight"] = []any{distanceMm, mmPerSec, extra}
 		return nil
 	}
 
 	workingBase.SpinFunc = func(
-		_ context.Context, angleDeg, degsPerSec float64, extra map[string]interface{},
+		_ context.Context, angleDeg, degsPerSec float64, extra map[string]any,
 	) error {
-		argsReceived["Spin"] = []interface{}{angleDeg, degsPerSec, extra}
+		argsReceived["Spin"] = []any{angleDeg, degsPerSec, extra}
 		return nil
 	}
 
-	workingBase.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	workingBase.StopFunc = func(ctx context.Context, extra map[string]any) error {
 		return nil
 	}
 
-	workingBase.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (base.Properties, error) {
+	workingBase.PropertiesFunc = func(ctx context.Context, extra map[string]any) (base.Properties, error) {
 		return expectedFeatures, nil
 	}
 
@@ -57,22 +57,22 @@ func setupBrokenBase(brokenBase *inject.Base) {
 	brokenBase.MoveStraightFunc = func(
 		ctx context.Context,
 		distanceMm int, mmPerSec float64,
-		extra map[string]interface{},
+		extra map[string]any,
 	) error {
 		return errMoveStraight
 	}
 	brokenBase.SpinFunc = func(
 		ctx context.Context,
 		angleDeg, degsPerSec float64,
-		extra map[string]interface{},
+		extra map[string]any,
 	) error {
 		return errSpinFailed
 	}
-	brokenBase.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	brokenBase.StopFunc = func(ctx context.Context, extra map[string]any) error {
 		return errStopFailed
 	}
 
-	brokenBase.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (base.Properties, error) {
+	brokenBase.PropertiesFunc = func(ctx context.Context, extra map[string]any) (base.Properties, error) {
 		return base.Properties{}, errPropertiesFailed
 	}
 }
@@ -84,7 +84,7 @@ func TestClient(t *testing.T) {
 	rpcServer, err := rpc.NewServer(logger.AsZap(), rpc.WithUnauthenticated())
 	test.That(t, err, test.ShouldBeNil)
 
-	argsReceived := map[string][]interface{}{}
+	argsReceived := map[string][]any{}
 
 	workingBase := &inject.Base{}
 	expectedFeatures := base.Properties{
@@ -132,7 +132,7 @@ func TestClient(t *testing.T) {
 	}()
 
 	t.Run("working base client", func(t *testing.T) {
-		expectedExtra := map[string]interface{}{"foo": "bar"}
+		expectedExtra := map[string]any{"foo": "bar"}
 
 		t.Run("working MoveStraight", func(t *testing.T) {
 			distance := 42
@@ -141,10 +141,10 @@ func TestClient(t *testing.T) {
 				context.Background(),
 				distance,
 				mmPerSec,
-				map[string]interface{}{"foo": "bar"},
+				map[string]any{"foo": "bar"},
 			)
 			test.That(t, err, test.ShouldBeNil)
-			expectedArgs := []interface{}{distance, mmPerSec, expectedExtra}
+			expectedArgs := []any{distance, mmPerSec, expectedExtra}
 			test.That(t, argsReceived["MoveStraight"], test.ShouldResemble, expectedArgs)
 		})
 
@@ -162,9 +162,9 @@ func TestClient(t *testing.T) {
 				context.Background(),
 				angleDeg,
 				degsPerSec,
-				map[string]interface{}{"foo": "bar"})
+				map[string]any{"foo": "bar"})
 			test.That(t, err, test.ShouldBeNil)
-			expectedArgs := []interface{}{angleDeg, degsPerSec, expectedExtra}
+			expectedArgs := []any{angleDeg, degsPerSec, expectedExtra}
 			test.That(t, argsReceived["Spin"], test.ShouldResemble, expectedArgs)
 		})
 
@@ -199,7 +199,7 @@ func TestClient(t *testing.T) {
 
 		err = client.Spin(context.Background(), angleDeg, degsPerSec, nil)
 		test.That(t, err, test.ShouldBeNil)
-		expectedArgs := []interface{}{angleDeg, degsPerSec, map[string]interface{}{}}
+		expectedArgs := []any{angleDeg, degsPerSec, map[string]any{}}
 		test.That(t, argsReceived["Spin"], test.ShouldResemble, expectedArgs)
 
 		test.That(t, conn.Close(), test.ShouldBeNil)

--- a/components/base/fake/fake.go
+++ b/components/base/fake/fake.go
@@ -58,27 +58,27 @@ func NewBase(_ context.Context, _ resource.Dependencies, conf resource.Config, l
 }
 
 // MoveStraight does nothing.
-func (b *Base) MoveStraight(ctx context.Context, distanceMm int, mmPerSec float64, extra map[string]interface{}) error {
+func (b *Base) MoveStraight(ctx context.Context, distanceMm int, mmPerSec float64, extra map[string]any) error {
 	return nil
 }
 
 // Spin does nothing.
-func (b *Base) Spin(ctx context.Context, angleDeg, degsPerSec float64, extra map[string]interface{}) error {
+func (b *Base) Spin(ctx context.Context, angleDeg, degsPerSec float64, extra map[string]any) error {
 	return nil
 }
 
 // SetPower does nothing.
-func (b *Base) SetPower(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error {
+func (b *Base) SetPower(ctx context.Context, linear, angular r3.Vector, extra map[string]any) error {
 	return nil
 }
 
 // SetVelocity does nothing.
-func (b *Base) SetVelocity(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error {
+func (b *Base) SetVelocity(ctx context.Context, linear, angular r3.Vector, extra map[string]any) error {
 	return nil
 }
 
 // Stop does nothing.
-func (b *Base) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (b *Base) Stop(ctx context.Context, extra map[string]any) error {
 	return nil
 }
 
@@ -94,7 +94,7 @@ func (b *Base) Close(ctx context.Context) error {
 }
 
 // Properties returns the base's properties.
-func (b *Base) Properties(ctx context.Context, extra map[string]interface{}) (base.Properties, error) {
+func (b *Base) Properties(ctx context.Context, extra map[string]any) (base.Properties, error) {
 	return base.Properties{
 		TurningRadiusMeters:      b.TurningRadius,
 		WidthMeters:              b.WidthMeters,
@@ -103,6 +103,6 @@ func (b *Base) Properties(ctx context.Context, extra map[string]interface{}) (ba
 }
 
 // Geometries returns the geometries associated with the fake base.
-func (b *Base) Geometries(ctx context.Context, extra map[string]interface{}) ([]spatialmath.Geometry, error) {
+func (b *Base) Geometries(ctx context.Context, extra map[string]any) ([]spatialmath.Geometry, error) {
 	return b.Geometry, nil
 }

--- a/components/base/kinematicbase/fake_kinematics_test.go
+++ b/components/base/kinematicbase/fake_kinematics_test.go
@@ -34,13 +34,13 @@ func TestNewFakeDiffDriveKinematics(t *testing.T) {
 	b, err := fakebase.NewBase(ctx, resource.Dependencies{}, conf, logger)
 	test.That(t, err, test.ShouldBeNil)
 	ms := inject.NewMovementSensor("test")
-	ms.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+	ms.PositionFunc = func(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 		return geo.NewPoint(0, 0), 0, nil
 	}
-	ms.CompassHeadingFunc = func(ctx context.Context, extra map[string]interface{}) (float64, error) {
+	ms.CompassHeadingFunc = func(ctx context.Context, extra map[string]any) (float64, error) {
 		return 0, nil
 	}
-	ms.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+	ms.PropertiesFunc = func(ctx context.Context, extra map[string]any) (*movementsensor.Properties, error) {
 		return &movementsensor.Properties{CompassHeadingSupported: true}, nil
 	}
 	localizer := motion.NewMovementSensorLocalizer(ms, geo.NewPoint(0, 0), spatialmath.NewZeroPose())
@@ -77,13 +77,13 @@ func TestNewFakePTGKinematics(t *testing.T) {
 	b, err := fakebase.NewBase(ctx, resource.Dependencies{}, conf, logger)
 	test.That(t, err, test.ShouldBeNil)
 	ms := inject.NewMovementSensor("test")
-	ms.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+	ms.PositionFunc = func(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 		return geo.NewPoint(0, 0), 0, nil
 	}
-	ms.CompassHeadingFunc = func(ctx context.Context, extra map[string]interface{}) (float64, error) {
+	ms.CompassHeadingFunc = func(ctx context.Context, extra map[string]any) (float64, error) {
 		return 0, nil
 	}
-	ms.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+	ms.PropertiesFunc = func(ctx context.Context, extra map[string]any) (*movementsensor.Properties, error) {
 		return &movementsensor.Properties{CompassHeadingSupported: true}, nil
 	}
 

--- a/components/base/kinematicbase/ptgKinematics.go
+++ b/components/base/kinematicbase/ptgKinematics.go
@@ -355,6 +355,6 @@ func correctAngularVelocityWithTurnRadius(logger logging.Logger, turnRadMeters, 
 	return rdkutils.RadToDeg(angVelocityRadps), nil
 }
 
-func (ptgk *ptgBaseKinematics) Geometries(ctx context.Context, extra map[string]interface{}) ([]spatialmath.Geometry, error) {
+func (ptgk *ptgBaseKinematics) Geometries(ctx context.Context, extra map[string]any) ([]spatialmath.Geometry, error) {
 	return ptgk.geometries, nil
 }

--- a/components/base/sensorcontrolled/sensorcontrolled.go
+++ b/components/base/sensorcontrolled/sensorcontrolled.go
@@ -229,7 +229,7 @@ func (sb *sensorBase) isPolling() bool {
 }
 
 func (sb *sensorBase) MoveStraight(
-	ctx context.Context, distanceMm int, mmPerSec float64, extra map[string]interface{},
+	ctx context.Context, distanceMm int, mmPerSec float64, extra map[string]any,
 ) error {
 	sb.stopLoop()
 	ctx, done := sb.opMgr.New(ctx)
@@ -240,14 +240,14 @@ func (sb *sensorBase) MoveStraight(
 }
 
 func (sb *sensorBase) SetPower(
-	ctx context.Context, linear, angular r3.Vector, extra map[string]interface{},
+	ctx context.Context, linear, angular r3.Vector, extra map[string]any,
 ) error {
 	sb.opMgr.CancelRunning(ctx)
 	sb.setPolling(false)
 	return sb.controlledBase.SetPower(ctx, linear, angular, extra)
 }
 
-func (sb *sensorBase) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (sb *sensorBase) Stop(ctx context.Context, extra map[string]any) error {
 	sb.opMgr.CancelRunning(ctx)
 	if sb.sensorLoopDone != nil {
 		sb.sensorLoopDone()
@@ -267,11 +267,11 @@ func (sb *sensorBase) IsMoving(ctx context.Context) (bool, error) {
 	return sb.controlledBase.IsMoving(ctx)
 }
 
-func (sb *sensorBase) Properties(ctx context.Context, extra map[string]interface{}) (base.Properties, error) {
+func (sb *sensorBase) Properties(ctx context.Context, extra map[string]any) (base.Properties, error) {
 	return sb.controlledBase.Properties(ctx, extra)
 }
 
-func (sb *sensorBase) Geometries(ctx context.Context, extra map[string]interface{}) ([]spatialmath.Geometry, error) {
+func (sb *sensorBase) Geometries(ctx context.Context, extra map[string]any) ([]spatialmath.Geometry, error) {
 	return sb.controlledBase.Geometries(ctx, extra)
 }
 

--- a/components/base/sensorcontrolled/sensorcontrolled_test.go
+++ b/components/base/sensorcontrolled/sensorcontrolled_test.go
@@ -92,7 +92,7 @@ func TestSpinWithMSMath(t *testing.T) {
 
 	for _, yaw := range yaws {
 		ms := &inject.MovementSensor{
-			OrientationFunc: func(ctx context.Context, extra map[string]interface{}) (spatialmath.Orientation, error) {
+			OrientationFunc: func(ctx context.Context, extra map[string]any) (spatialmath.Orientation, error) {
 				return &spatialmath.EulerAngles{Yaw: yaw}, nil
 			},
 		}
@@ -256,11 +256,11 @@ func TestHasOverShot(t *testing.T) {
 
 func TestSpinWithMovementSensor(t *testing.T) {
 	ms := inject.NewMovementSensor("spinny")
-	ms.OrientationFunc = func(ctx context.Context, extra map[string]interface{}) (spatialmath.Orientation, error) {
+	ms.OrientationFunc = func(ctx context.Context, extra map[string]any) (spatialmath.Orientation, error) {
 		return spatialmath.NewZeroOrientation(), nil
 	}
 	wb := inject.NewBase("fakey-basey")
-	wb.SetVelocityFunc = func(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error {
+	wb.SetVelocityFunc = func(ctx context.Context, linear, angular r3.Vector, extra map[string]any) error {
 		return nil
 	}
 
@@ -304,11 +304,11 @@ func createDependencies(t *testing.T) resource.Dependencies {
 	counter := 0
 
 	deps[movementsensor.Named("ms")] = &inject.MovementSensor{
-		PropertiesFuncExtraCap: map[string]interface{}{},
-		PropertiesFunc: func(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+		PropertiesFuncExtraCap: map[string]any{},
+		PropertiesFunc: func(ctx context.Context, extra map[string]any) (*movementsensor.Properties, error) {
 			return &movementsensor.Properties{OrientationSupported: true}, nil
 		},
-		OrientationFunc: func(ctx context.Context, extra map[string]interface{}) (spatialmath.Orientation, error) {
+		OrientationFunc: func(ctx context.Context, extra map[string]any) (spatialmath.Orientation, error) {
 			counter++
 			return &spatialmath.EulerAngles{Roll: 0, Pitch: 0, Yaw: utils.RadToDeg(float64(counter))}, nil
 		},
@@ -322,13 +322,13 @@ func createDependencies(t *testing.T) resource.Dependencies {
 func addBaseDependency(deps resource.Dependencies) resource.Dependencies {
 	deps[base.Named(("test_base"))] = &inject.Base{
 		DoFunc: testutils.EchoFunc,
-		MoveStraightFunc: func(ctx context.Context, distanceMm int, mmPerSec float64, extra map[string]interface{}) error {
+		MoveStraightFunc: func(ctx context.Context, distanceMm int, mmPerSec float64, extra map[string]any) error {
 			return nil
 		},
-		SpinFunc: func(ctx context.Context, angleDeg, degsPerSec float64, extra map[string]interface{}) error {
+		SpinFunc: func(ctx context.Context, angleDeg, degsPerSec float64, extra map[string]any) error {
 			return nil
 		},
-		StopFunc: func(ctx context.Context, extra map[string]interface{}) error {
+		StopFunc: func(ctx context.Context, extra map[string]any) error {
 			return nil
 		},
 		IsMovingFunc: func(context.Context) (bool, error) {
@@ -337,13 +337,13 @@ func addBaseDependency(deps resource.Dependencies) resource.Dependencies {
 		CloseFunc: func(ctx context.Context) error {
 			return nil
 		},
-		SetPowerFunc: func(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error {
+		SetPowerFunc: func(ctx context.Context, linear, angular r3.Vector, extra map[string]any) error {
 			return nil
 		},
-		SetVelocityFunc: func(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error {
+		SetVelocityFunc: func(ctx context.Context, linear, angular r3.Vector, extra map[string]any) error {
 			return nil
 		},
-		PropertiesFunc: func(ctx context.Context, extra map[string]interface{}) (base.Properties, error) {
+		PropertiesFunc: func(ctx context.Context, extra map[string]any) (base.Properties, error) {
 			return base.Properties{
 				TurningRadiusMeters: 0.1,
 				WidthMeters:         0.1,
@@ -433,7 +433,7 @@ func msDependencies(t *testing.T, msNames []string,
 		ms := inject.NewMovementSensor(msName)
 		switch {
 		case strings.Contains(msName, "orientation"):
-			ms.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+			ms.PropertiesFunc = func(ctx context.Context, extra map[string]any) (*movementsensor.Properties, error) {
 				return &movementsensor.Properties{
 					OrientationSupported: true,
 				}, nil
@@ -441,7 +441,7 @@ func msDependencies(t *testing.T, msNames []string,
 			deps[movementsensor.Named(msName)] = ms
 
 		case strings.Contains(msName, "setvel"):
-			ms.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+			ms.PropertiesFunc = func(ctx context.Context, extra map[string]any) (*movementsensor.Properties, error) {
 				return &movementsensor.Properties{
 					AngularVelocitySupported: true,
 					LinearVelocitySupported:  true,
@@ -450,7 +450,7 @@ func msDependencies(t *testing.T, msNames []string,
 			deps[movementsensor.Named(msName)] = ms
 
 		case strings.Contains(msName, "Bad"):
-			ms.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+			ms.PropertiesFunc = func(ctx context.Context, extra map[string]any) (*movementsensor.Properties, error) {
 				return &movementsensor.Properties{
 					OrientationSupported:     true,
 					AngularVelocitySupported: true,

--- a/components/base/sensorcontrolled/spin.go
+++ b/components/base/sensorcontrolled/spin.go
@@ -19,7 +19,7 @@ const (
 )
 
 // Spin commands a base to turn about its center at a angular speed and for a specific angle.
-func (sb *sensorBase) Spin(ctx context.Context, angleDeg, degsPerSec float64, extra map[string]interface{}) error {
+func (sb *sensorBase) Spin(ctx context.Context, angleDeg, degsPerSec float64, extra map[string]any) error {
 	sb.stopLoop()
 	if math.Abs(angleDeg) >= 360.0 {
 		sb.setPolling(false)

--- a/components/base/sensorcontrolled/velocities.go
+++ b/components/base/sensorcontrolled/velocities.go
@@ -116,7 +116,7 @@ func (sb *sensorBase) autoTuningProcess(ctx context.Context, linear, angular bas
 }
 
 func (sb *sensorBase) SetVelocity(
-	ctx context.Context, linear, angular r3.Vector, extra map[string]interface{},
+	ctx context.Context, linear, angular r3.Vector, extra map[string]any,
 ) error {
 	sb.opMgr.CancelRunning(ctx)
 	// stop any previous base movement
@@ -166,7 +166,7 @@ func (sb *sensorBase) SetVelocity(
 // AngularVelocity API calls of the movementsensor attached to the sensor base
 // and logs them for toruble shooting.
 // This function can eventually be removed.
-func (sb *sensorBase) pollsensors(ctx context.Context, extra map[string]interface{}) {
+func (sb *sensorBase) pollsensors(ctx context.Context, extra map[string]any) {
 	sb.activeBackgroundWorkers.Add(1)
 	utils.ManagedGo(func() {
 		ticker := time.NewTicker(velocitiesPollTime)

--- a/components/base/server.go
+++ b/components/base/server.go
@@ -21,7 +21,7 @@ type serviceServer struct {
 
 // NewRPCServiceServer constructs a base gRPC service server.
 // It is intentionally untyped to prevent use outside of tests.
-func NewRPCServiceServer(coll resource.APIResourceCollection[Base]) interface{} {
+func NewRPCServiceServer(coll resource.APIResourceCollection[Base]) any {
 	return &serviceServer{coll: coll}
 }
 

--- a/components/base/server_test.go
+++ b/components/base/server_test.go
@@ -46,7 +46,7 @@ func TestServer(t *testing.T) {
 		workingBase.MoveStraightFunc = func(
 			ctx context.Context, distanceMm int,
 			mmPerSec float64,
-			extra map[string]interface{},
+			extra map[string]any,
 		) error {
 			return nil
 		}
@@ -63,7 +63,7 @@ func TestServer(t *testing.T) {
 		brokenBase.MoveStraightFunc = func(
 			ctx context.Context, distanceMm int,
 			mmPerSec float64,
-			extra map[string]interface{},
+			extra map[string]any,
 		) error {
 			return errMoveStraight
 		}
@@ -94,7 +94,7 @@ func TestServer(t *testing.T) {
 		workingBase.SpinFunc = func(
 			ctx context.Context,
 			angleDeg, degsPerSec float64,
-			extra map[string]interface{},
+			extra map[string]any,
 		) error {
 			return nil
 		}
@@ -111,7 +111,7 @@ func TestServer(t *testing.T) {
 		brokenBase.SpinFunc = func(
 			ctx context.Context,
 			angleDeg, degsPerSec float64,
-			extra map[string]interface{},
+			extra map[string]any,
 		) error {
 			return errSpinFailed
 		}
@@ -139,7 +139,7 @@ func TestServer(t *testing.T) {
 		turnRadius := 0.1
 		width := 0.2
 		// on a successful get properties
-		workingBase.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (base.Properties, error) {
+		workingBase.PropertiesFunc = func(ctx context.Context, extra map[string]any) (base.Properties, error) {
 			return base.Properties{
 				TurningRadiusMeters: turnRadius,
 				WidthMeters:         width,
@@ -151,7 +151,7 @@ func TestServer(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		// on a failing get properties
-		brokenBase.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (base.Properties, error) {
+		brokenBase.PropertiesFunc = func(ctx context.Context, extra map[string]any) (base.Properties, error) {
 			return base.Properties{}, errPropertiesFailed
 		}
 		req = &pb.GetPropertiesRequest{Name: failBaseName}
@@ -168,7 +168,7 @@ func TestServer(t *testing.T) {
 
 	t.Run("Stop", func(t *testing.T) {
 		// on successful stop
-		workingBase.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
+		workingBase.StopFunc = func(ctx context.Context, extra map[string]any) error {
 			return nil
 		}
 		req := &pb.StopRequest{Name: testBaseName}
@@ -177,7 +177,7 @@ func TestServer(t *testing.T) {
 		test.That(t, resp, test.ShouldResemble, &pb.StopResponse{})
 
 		// on failing stop
-		brokenBase.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
+		brokenBase.StopFunc = func(ctx context.Context, extra map[string]any) error {
 			return errStopFailed
 		}
 		req = &pb.StopRequest{Name: failBaseName}

--- a/components/base/wheeled/wheeled_base.go
+++ b/components/base/wheeled/wheeled_base.go
@@ -233,7 +233,7 @@ func createWheeledBase(
 }
 
 // Spin commands a base to turn about its center at a angular speed and for a specific angle.
-func (wb *wheeledBase) Spin(ctx context.Context, angleDeg, degsPerSec float64, extra map[string]interface{}) error {
+func (wb *wheeledBase) Spin(ctx context.Context, angleDeg, degsPerSec float64, extra map[string]any) error {
 	ctx, done := wb.opMgr.New(ctx)
 	defer done()
 	wb.logger.CDebugf(ctx, "received a Spin with angleDeg:%.2f, degsPerSec:%.2f", angleDeg, degsPerSec)
@@ -254,7 +254,7 @@ func (wb *wheeledBase) Spin(ctx context.Context, angleDeg, degsPerSec float64, e
 }
 
 // MoveStraight commands a base to drive forward or backwards  at a linear speed and for a specific distance.
-func (wb *wheeledBase) MoveStraight(ctx context.Context, distanceMm int, mmPerSec float64, extra map[string]interface{}) error {
+func (wb *wheeledBase) MoveStraight(ctx context.Context, distanceMm int, mmPerSec float64, extra map[string]any) error {
 	wb.logger.CDebugf(ctx, "received a MoveStraight with distanceMM:%d, mmPerSec:%.2f", distanceMm, mmPerSec)
 
 	// Stop the motors if the speed or distance are 0
@@ -348,7 +348,7 @@ func (wb *wheeledBase) differentialDrive(forward, left float64) (float64, float6
 }
 
 // SetVelocity commands the base to move at the input linear and angular velocities.
-func (wb *wheeledBase) SetVelocity(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error {
+func (wb *wheeledBase) SetVelocity(ctx context.Context, linear, angular r3.Vector, extra map[string]any) error {
 	wb.logger.CDebugf(ctx,
 		"received a SetVelocity with linear.X: %.2f, linear.Y: %.2f linear.Z: %.2f(mmPerSec),"+
 			" angular.X: %.2f, angular.Y: %.2f, angular.Z: %.2f",
@@ -373,7 +373,7 @@ func (wb *wheeledBase) SetVelocity(ctx context.Context, linear, angular r3.Vecto
 }
 
 // SetPower commands the base motors to run at powers corresponding to input linear and angular powers.
-func (wb *wheeledBase) SetPower(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error {
+func (wb *wheeledBase) SetPower(ctx context.Context, linear, angular r3.Vector, extra map[string]any) error {
 	wb.opMgr.CancelRunning(ctx)
 
 	wb.logger.CDebugf(ctx,
@@ -457,7 +457,7 @@ func (wb *wheeledBase) straightDistanceToMotorInputs(distanceMm int, mmPerSec fl
 }
 
 // Stop commands the base to stop moving.
-func (wb *wheeledBase) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (wb *wheeledBase) Stop(ctx context.Context, extra map[string]any) error {
 	stopFuncs := func() []rdkutils.SimpleFunc {
 		ret := []rdkutils.SimpleFunc{}
 
@@ -499,7 +499,7 @@ func (wb *wheeledBase) Close(ctx context.Context) error {
 	return wb.Stop(ctx, nil)
 }
 
-func (wb *wheeledBase) Properties(ctx context.Context, extra map[string]interface{}) (base.Properties, error) {
+func (wb *wheeledBase) Properties(ctx context.Context, extra map[string]any) (base.Properties, error) {
 	return base.Properties{
 		TurningRadiusMeters:      0.0,
 		WidthMeters:              float64(wb.widthMm) * 0.001,              // convert to meters from mm
@@ -507,6 +507,6 @@ func (wb *wheeledBase) Properties(ctx context.Context, extra map[string]interfac
 	}, nil
 }
 
-func (wb *wheeledBase) Geometries(ctx context.Context, extra map[string]interface{}) ([]spatialmath.Geometry, error) {
+func (wb *wheeledBase) Geometries(ctx context.Context, extra map[string]any) ([]spatialmath.Geometry, error) {
 	return wb.geometries, nil
 }

--- a/components/base/wheeled/wheeled_base_test.go
+++ b/components/base/wheeled/wheeled_base_test.go
@@ -22,7 +22,7 @@ import (
 
 func createFakeMotor() motor.Motor {
 	return &inject.Motor{
-		StopFunc: func(ctx context.Context, extra map[string]interface{}) error { return errors.New("stop error") },
+		StopFunc: func(ctx context.Context, extra map[string]any) error { return errors.New("stop error") },
 	}
 }
 

--- a/components/board/analog_smoother.go
+++ b/components/board/analog_smoother.go
@@ -60,7 +60,7 @@ func (as *AnalogSmoother) Close(ctx context.Context) error {
 }
 
 // Read returns the smoothed out reading.
-func (as *AnalogSmoother) Read(ctx context.Context, extra map[string]interface{}) (int, error) {
+func (as *AnalogSmoother) Read(ctx context.Context, extra map[string]any) (int, error) {
 	if as.data == nil { // We're using raw data, and not averaging
 		return as.lastData, nil
 	}

--- a/components/board/analog_smoother_test.go
+++ b/components/board/analog_smoother_test.go
@@ -21,7 +21,7 @@ type testReader struct {
 	stop bool
 }
 
-func (t *testReader) Read(ctx context.Context, extra map[string]interface{}) (int, error) {
+func (t *testReader) Read(ctx context.Context, extra map[string]any) (int, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if t.stop || t.n >= t.lim {

--- a/components/board/board.go
+++ b/components/board/board.go
@@ -18,7 +18,7 @@ import (
 
 func init() {
 	resource.RegisterAPI(API, resource.APIRegistration[Board]{
-		Status: func(ctx context.Context, b Board) (interface{}, error) {
+		Status: func(ctx context.Context, b Board) (any, error) {
 			return b.Status(ctx, nil)
 		},
 		RPCServiceServerConstructor: NewRPCServiceServer,
@@ -70,7 +70,7 @@ type Board interface {
 	// Status returns the current status of the board. Usually you
 	// should use the CreateStatus helper instead of directly calling
 	// this.
-	Status(ctx context.Context, extra map[string]interface{}) (*commonpb.BoardStatus, error)
+	Status(ctx context.Context, extra map[string]any) (*commonpb.BoardStatus, error)
 
 	// SetPowerMode sets the board to the given power mode. If
 	// provided, the board will exit the given power mode after
@@ -78,13 +78,13 @@ type Board interface {
 	SetPowerMode(ctx context.Context, mode pb.PowerMode, duration *time.Duration) error
 
 	// WriteAnalog writes an analog value to a pin on the board.
-	WriteAnalog(ctx context.Context, pin string, value int32, extra map[string]interface{}) error
+	WriteAnalog(ctx context.Context, pin string, value int32, extra map[string]any) error
 }
 
 // An AnalogReader represents an analog pin reader that resides on a board.
 type AnalogReader interface {
 	// Read reads off the current value.
-	Read(ctx context.Context, extra map[string]interface{}) (int, error)
+	Read(ctx context.Context, extra map[string]any) (int, error)
 	Close(ctx context.Context) error
 }
 

--- a/components/board/client.go
+++ b/components/board/client.go
@@ -106,7 +106,7 @@ func (c *client) DigitalInterruptNames() []string {
 
 // Status uses the cached status or a newly fetched board status to return the state
 // of the board.
-func (c *client) Status(ctx context.Context, extra map[string]interface{}) (*commonpb.BoardStatus, error) {
+func (c *client) Status(ctx context.Context, extra map[string]any) (*commonpb.BoardStatus, error) {
 	if status := c.getCachedStatus(); status != nil {
 		return status, nil
 	}
@@ -173,12 +173,12 @@ func (c *client) SetPowerMode(ctx context.Context, mode pb.PowerMode, duration *
 	return err
 }
 
-func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (c *client) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	return rprotoutils.DoFromResourceClient(ctx, c.client, c.info.name, cmd)
 }
 
 // WriteAnalog writes the analog value to the specified pin.
-func (c *client) WriteAnalog(ctx context.Context, pin string, value int32, extra map[string]interface{}) error {
+func (c *client) WriteAnalog(ctx context.Context, pin string, value int32, extra map[string]any) error {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return err
@@ -201,7 +201,7 @@ type analogReaderClient struct {
 	analogReaderName string
 }
 
-func (arc *analogReaderClient) Read(ctx context.Context, extra map[string]interface{}) (int, error) {
+func (arc *analogReaderClient) Read(ctx context.Context, extra map[string]any) (int, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return 0, err
@@ -225,7 +225,7 @@ type digitalInterruptClient struct {
 	digitalInterruptName string
 }
 
-func (dic *digitalInterruptClient) Value(ctx context.Context, extra map[string]interface{}) (int64, error) {
+func (dic *digitalInterruptClient) Value(ctx context.Context, extra map[string]any) (int64, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return 0, err
@@ -261,7 +261,7 @@ type gpioPinClient struct {
 	pinName   string
 }
 
-func (gpc *gpioPinClient) Set(ctx context.Context, high bool, extra map[string]interface{}) error {
+func (gpc *gpioPinClient) Set(ctx context.Context, high bool, extra map[string]any) error {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return err
@@ -275,7 +275,7 @@ func (gpc *gpioPinClient) Set(ctx context.Context, high bool, extra map[string]i
 	return err
 }
 
-func (gpc *gpioPinClient) Get(ctx context.Context, extra map[string]interface{}) (bool, error) {
+func (gpc *gpioPinClient) Get(ctx context.Context, extra map[string]any) (bool, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return false, err
@@ -291,7 +291,7 @@ func (gpc *gpioPinClient) Get(ctx context.Context, extra map[string]interface{})
 	return resp.High, nil
 }
 
-func (gpc *gpioPinClient) PWM(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (gpc *gpioPinClient) PWM(ctx context.Context, extra map[string]any) (float64, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return math.NaN(), err
@@ -307,7 +307,7 @@ func (gpc *gpioPinClient) PWM(ctx context.Context, extra map[string]interface{})
 	return resp.DutyCyclePct, nil
 }
 
-func (gpc *gpioPinClient) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[string]interface{}) error {
+func (gpc *gpioPinClient) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[string]any) error {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return err
@@ -321,7 +321,7 @@ func (gpc *gpioPinClient) SetPWM(ctx context.Context, dutyCyclePct float64, extr
 	return err
 }
 
-func (gpc *gpioPinClient) PWMFreq(ctx context.Context, extra map[string]interface{}) (uint, error) {
+func (gpc *gpioPinClient) PWMFreq(ctx context.Context, extra map[string]any) (uint, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return 0, err
@@ -337,7 +337,7 @@ func (gpc *gpioPinClient) PWMFreq(ctx context.Context, extra map[string]interfac
 	return uint(resp.FrequencyHz), nil
 }
 
-func (gpc *gpioPinClient) SetPWMFreq(ctx context.Context, freqHz uint, extra map[string]interface{}) error {
+func (gpc *gpioPinClient) SetPWMFreq(ctx context.Context, freqHz uint, extra map[string]any) error {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return err

--- a/components/board/client_test.go
+++ b/components/board/client_test.go
@@ -63,7 +63,7 @@ func TestWorkingClient(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	injectBoard := &inject.Board{}
 
-	injectBoard.StatusFunc = func(ctx context.Context, extra map[string]interface{}) (*commonpb.BoardStatus, error) {
+	injectBoard.StatusFunc = func(ctx context.Context, extra map[string]any) (*commonpb.BoardStatus, error) {
 		return nil, viamgrpc.UnimplementedError
 	}
 
@@ -73,8 +73,8 @@ func TestWorkingClient(t *testing.T) {
 	testWorkingClient := func(t *testing.T, client board.Board) {
 		t.Helper()
 
-		expectedExtra := map[string]interface{}{"foo": "bar", "baz": []interface{}{1., 2., 3.}}
-		var actualExtra map[string]interface{}
+		expectedExtra := map[string]any{"foo": "bar", "baz": []any{1., 2., 3.}}
+		var actualExtra map[string]any
 
 		// DoCommand
 		injectBoard.DoFunc = testutils.EchoFunc
@@ -85,14 +85,14 @@ func TestWorkingClient(t *testing.T) {
 
 		// Status
 		injectStatus := &commonpb.BoardStatus{}
-		injectBoard.StatusFunc = func(ctx context.Context, extra map[string]interface{}) (*commonpb.BoardStatus, error) {
+		injectBoard.StatusFunc = func(ctx context.Context, extra map[string]any) (*commonpb.BoardStatus, error) {
 			actualExtra = extra
 			return injectStatus, nil
 		}
 		respStatus, err := client.Status(context.Background(), expectedExtra)
 		test.That(t, respStatus, test.ShouldResemble, injectStatus)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, injectBoard.StatusCap()[1:], test.ShouldResemble, []interface{}{})
+		test.That(t, injectBoard.StatusCap()[1:], test.ShouldResemble, []any{})
 		test.That(t, actualExtra, test.ShouldResemble, expectedExtra)
 		actualExtra = nil
 
@@ -102,7 +102,7 @@ func TestWorkingClient(t *testing.T) {
 		}
 
 		// Set
-		injectGPIOPin.SetFunc = func(ctx context.Context, high bool, extra map[string]interface{}) error {
+		injectGPIOPin.SetFunc = func(ctx context.Context, high bool, extra map[string]any) error {
 			actualExtra = extra
 			return nil
 		}
@@ -110,41 +110,41 @@ func TestWorkingClient(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		err = onePin.Set(context.Background(), true, expectedExtra)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, injectGPIOPin.SetCap()[1:], test.ShouldResemble, []interface{}{true})
+		test.That(t, injectGPIOPin.SetCap()[1:], test.ShouldResemble, []any{true})
 		test.That(t, actualExtra, test.ShouldResemble, expectedExtra)
 		actualExtra = nil
 
 		// Get
-		injectGPIOPin.GetFunc = func(ctx context.Context, extra map[string]interface{}) (bool, error) {
+		injectGPIOPin.GetFunc = func(ctx context.Context, extra map[string]any) (bool, error) {
 			actualExtra = extra
 			return true, nil
 		}
 		isHigh, err := onePin.Get(context.Background(), expectedExtra)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, isHigh, test.ShouldBeTrue)
-		test.That(t, injectGPIOPin.GetCap()[1:], test.ShouldResemble, []interface{}{})
+		test.That(t, injectGPIOPin.GetCap()[1:], test.ShouldResemble, []any{})
 		test.That(t, actualExtra, test.ShouldResemble, expectedExtra)
 		actualExtra = nil
 
 		// SetPWM
-		injectGPIOPin.SetPWMFunc = func(ctx context.Context, dutyCyclePct float64, extra map[string]interface{}) error {
+		injectGPIOPin.SetPWMFunc = func(ctx context.Context, dutyCyclePct float64, extra map[string]any) error {
 			actualExtra = extra
 			return nil
 		}
 		err = onePin.SetPWM(context.Background(), 0.03, expectedExtra)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, injectGPIOPin.SetPWMCap()[1:], test.ShouldResemble, []interface{}{0.03})
+		test.That(t, injectGPIOPin.SetPWMCap()[1:], test.ShouldResemble, []any{0.03})
 		test.That(t, actualExtra, test.ShouldResemble, expectedExtra)
 		actualExtra = nil
 
 		// SetPWMFreq
-		injectGPIOPin.SetPWMFreqFunc = func(ctx context.Context, freqHz uint, extra map[string]interface{}) error {
+		injectGPIOPin.SetPWMFreqFunc = func(ctx context.Context, freqHz uint, extra map[string]any) error {
 			actualExtra = extra
 			return nil
 		}
 		err = onePin.SetPWMFreq(context.Background(), 11233, expectedExtra)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, injectGPIOPin.SetPWMFreqCap()[1:], test.ShouldResemble, []interface{}{uint(11233)})
+		test.That(t, injectGPIOPin.SetPWMFreqCap()[1:], test.ShouldResemble, []any{uint(11233)})
 		test.That(t, actualExtra, test.ShouldResemble, expectedExtra)
 		actualExtra = nil
 
@@ -155,10 +155,10 @@ func TestWorkingClient(t *testing.T) {
 		}
 		analog1, ok := injectBoard.AnalogReaderByName("analog1")
 		test.That(t, ok, test.ShouldBeTrue)
-		test.That(t, injectBoard.AnalogReaderByNameCap(), test.ShouldResemble, []interface{}{"analog1"})
+		test.That(t, injectBoard.AnalogReaderByNameCap(), test.ShouldResemble, []any{"analog1"})
 
 		// Analog Reader:Read
-		injectAnalogReader.ReadFunc = func(ctx context.Context, extra map[string]interface{}) (int, error) {
+		injectAnalogReader.ReadFunc = func(ctx context.Context, extra map[string]any) (int, error) {
 			actualExtra = extra
 			return 6, nil
 		}
@@ -169,7 +169,7 @@ func TestWorkingClient(t *testing.T) {
 		actualExtra = nil
 
 		// write analog
-		injectBoard.WriteAnalogFunc = func(ctx context.Context, pin string, value int32, extra map[string]interface{}) error {
+		injectBoard.WriteAnalogFunc = func(ctx context.Context, pin string, value int32, extra map[string]any) error {
 			actualExtra = extra
 			return nil
 		}
@@ -185,10 +185,10 @@ func TestWorkingClient(t *testing.T) {
 		}
 		digital1, ok := injectBoard.DigitalInterruptByName("digital1")
 		test.That(t, ok, test.ShouldBeTrue)
-		test.That(t, injectBoard.DigitalInterruptByNameCap(), test.ShouldResemble, []interface{}{"digital1"})
+		test.That(t, injectBoard.DigitalInterruptByNameCap(), test.ShouldResemble, []any{"digital1"})
 
 		// Digital Interrupt:Value
-		injectDigitalInterrupt.ValueFunc = func(ctx context.Context, extra map[string]interface{}) (int64, error) {
+		injectDigitalInterrupt.ValueFunc = func(ctx context.Context, extra map[string]any) (int64, error) {
 			actualExtra = extra
 			return 287, nil
 		}
@@ -234,7 +234,7 @@ func TestClientWithStatus(t *testing.T) {
 	}
 
 	injectBoard := &inject.Board{}
-	injectBoard.StatusFunc = func(ctx context.Context, extra map[string]interface{}) (*commonpb.BoardStatus, error) {
+	injectBoard.StatusFunc = func(ctx context.Context, extra map[string]any) (*commonpb.BoardStatus, error) {
 		return injectStatus, nil
 	}
 
@@ -246,7 +246,7 @@ func TestClientWithStatus(t *testing.T) {
 	client, err := board.NewClientFromConn(context.Background(), conn, "", board.Named(testBoardName), logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	test.That(t, injectBoard.StatusCap()[1:], test.ShouldResemble, []interface{}{})
+	test.That(t, injectBoard.StatusCap()[1:], test.ShouldResemble, []any{})
 
 	respAnalogReaders := client.AnalogReaderNames()
 	test.That(t, respAnalogReaders, test.ShouldResemble, []string{"analog1"})
@@ -284,7 +284,7 @@ func TestClientWithoutStatus(t *testing.T) {
 	rClient, err := resourceAPI.RPCClient(context.Background(), conn, "", board.Named(testBoardName), logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	test.That(t, injectBoard.StatusCap()[1:], test.ShouldResemble, []interface{}{})
+	test.That(t, injectBoard.StatusCap()[1:], test.ShouldResemble, []any{})
 
 	test.That(t, rClient.AnalogReaderNames(), test.ShouldResemble, []string{})
 	test.That(t, rClient.DigitalInterruptNames(), test.ShouldResemble, []string{})

--- a/components/board/collector.go
+++ b/components/board/collector.go
@@ -31,13 +31,13 @@ func (m method) String() string {
 
 // newAnalogCollector returns a collector to register an analog reading method. If one is already registered
 // with the same MethodMetadata it will panic.
-func newAnalogCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+func newAnalogCollector(resource any, params data.CollectorParams) (data.Collector, error) {
 	board, err := assertBoard(resource)
 	if err != nil {
 		return nil, err
 	}
 
-	cFunc := data.CaptureFunc(func(ctx context.Context, arg map[string]*anypb.Any) (interface{}, error) {
+	cFunc := data.CaptureFunc(func(ctx context.Context, arg map[string]*anypb.Any) (any, error) {
 		var value int
 		if _, ok := arg[analogReaderNameKey]; !ok {
 			return nil, data.FailedToReadErr(params.ComponentName, analogs.String(),
@@ -63,13 +63,13 @@ func newAnalogCollector(resource interface{}, params data.CollectorParams) (data
 
 // newGPIOCollector returns a collector to register a gpio get method. If one is already registered
 // with the same MethodMetadata it will panic.
-func newGPIOCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+func newGPIOCollector(resource any, params data.CollectorParams) (data.Collector, error) {
 	board, err := assertBoard(resource)
 	if err != nil {
 		return nil, err
 	}
 
-	cFunc := data.CaptureFunc(func(ctx context.Context, arg map[string]*anypb.Any) (interface{}, error) {
+	cFunc := data.CaptureFunc(func(ctx context.Context, arg map[string]*anypb.Any) (any, error) {
 		var value bool
 		if _, ok := arg[gpioPinNameKey]; !ok {
 			return nil, data.FailedToReadErr(params.ComponentName, gpios.String(),
@@ -93,7 +93,7 @@ func newGPIOCollector(resource interface{}, params data.CollectorParams) (data.C
 	return data.NewCollector(cFunc, params)
 }
 
-func assertBoard(resource interface{}) (Board, error) {
+func assertBoard(resource any) (Board, error) {
 	board, ok := resource.(Board)
 	if !ok {
 		return nil, data.InvalidInterfaceErr(API)

--- a/components/board/collectors_test.go
+++ b/components/board/collectors_test.go
@@ -96,14 +96,14 @@ func TestCollectors(t *testing.T) {
 func newBoard() board.Board {
 	b := &inject.Board{}
 	analogReader := &inject.AnalogReader{}
-	analogReader.ReadFunc = func(ctx context.Context, extra map[string]interface{}) (int, error) {
+	analogReader.ReadFunc = func(ctx context.Context, extra map[string]any) (int, error) {
 		return 1, nil
 	}
 	b.AnalogReaderByNameFunc = func(name string) (board.AnalogReader, bool) {
 		return analogReader, true
 	}
 	gpioPin := &inject.GPIOPin{}
-	gpioPin.GetFunc = func(ctx context.Context, extra map[string]interface{}) (bool, error) {
+	gpioPin.GetFunc = func(ctx context.Context, extra map[string]any) (bool, error) {
 		return true, nil
 	}
 	b.GPIOPinByNameFunc = func(name string) (board.GPIOPin, error) {
@@ -112,7 +112,7 @@ func newBoard() board.Board {
 	return b
 }
 
-func convertInterfaceToAny(v interface{}) *anypb.Any {
+func convertInterfaceToAny(v any) *anypb.Any {
 	anyValue := &anypb.Any{}
 
 	bytes, err := json.Marshal(v)

--- a/components/board/digital_interrupts.go
+++ b/components/board/digital_interrupts.go
@@ -28,7 +28,7 @@ type Tick struct {
 type DigitalInterrupt interface {
 	// Value returns the current value of the interrupt which is
 	// based on the type of interrupt.
-	Value(ctx context.Context, extra map[string]interface{}) (int64, error)
+	Value(ctx context.Context, extra map[string]any) (int64, error)
 
 	// Tick is to be called either manually if the interrupt is a proxy to some real
 	// hardware interrupt or for tests.
@@ -76,7 +76,7 @@ type BasicDigitalInterrupt struct {
 }
 
 // Value returns the amount of ticks that have occurred.
-func (i *BasicDigitalInterrupt) Value(ctx context.Context, extra map[string]interface{}) (int64, error) {
+func (i *BasicDigitalInterrupt) Value(ctx context.Context, extra map[string]any) (int64, error) {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 	count := atomic.LoadInt64(&i.count)

--- a/components/board/fake/board.go
+++ b/components/board/fake/board.go
@@ -208,7 +208,7 @@ func (b *Board) DigitalInterruptNames() []string {
 }
 
 // Status returns the current status of the board.
-func (b *Board) Status(ctx context.Context, extra map[string]interface{}) (*commonpb.BoardStatus, error) {
+func (b *Board) Status(ctx context.Context, extra map[string]any) (*commonpb.BoardStatus, error) {
 	return board.CreateStatus(ctx, b, extra)
 }
 
@@ -220,7 +220,7 @@ func (b *Board) SetPowerMode(ctx context.Context, mode pb.PowerMode, duration *t
 }
 
 // WriteAnalog writes the value to the given pin, which can be read back by adding it to AnalogReaders.
-func (b *Board) WriteAnalog(ctx context.Context, pin string, value int32, extra map[string]interface{}) error {
+func (b *Board) WriteAnalog(ctx context.Context, pin string, value int32, extra map[string]any) error {
 	alg := &AnalogReader{pin: pin, Value: int(value)}
 	b.AnalogReaders[pin] = alg
 	return nil
@@ -262,7 +262,7 @@ func (a *AnalogReader) reset(pin string) {
 	a.Mu.Unlock()
 }
 
-func (a *AnalogReader) Read(ctx context.Context, extra map[string]interface{}) (int, error) {
+func (a *AnalogReader) Read(ctx context.Context, extra map[string]any) (int, error) {
 	a.Mu.RLock()
 	defer a.Mu.RUnlock()
 	return a.Value, nil
@@ -291,7 +291,7 @@ type GPIOPin struct {
 }
 
 // Set sets the pin to either low or high.
-func (gp *GPIOPin) Set(ctx context.Context, high bool, extra map[string]interface{}) error {
+func (gp *GPIOPin) Set(ctx context.Context, high bool, extra map[string]any) error {
 	gp.mu.Lock()
 	defer gp.mu.Unlock()
 
@@ -302,7 +302,7 @@ func (gp *GPIOPin) Set(ctx context.Context, high bool, extra map[string]interfac
 }
 
 // Get gets the high/low state of the pin.
-func (gp *GPIOPin) Get(ctx context.Context, extra map[string]interface{}) (bool, error) {
+func (gp *GPIOPin) Get(ctx context.Context, extra map[string]any) (bool, error) {
 	gp.mu.Lock()
 	defer gp.mu.Unlock()
 
@@ -310,7 +310,7 @@ func (gp *GPIOPin) Get(ctx context.Context, extra map[string]interface{}) (bool,
 }
 
 // PWM gets the pin's given duty cycle.
-func (gp *GPIOPin) PWM(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (gp *GPIOPin) PWM(ctx context.Context, extra map[string]any) (float64, error) {
 	gp.mu.Lock()
 	defer gp.mu.Unlock()
 
@@ -318,7 +318,7 @@ func (gp *GPIOPin) PWM(ctx context.Context, extra map[string]interface{}) (float
 }
 
 // SetPWM sets the pin to the given duty cycle.
-func (gp *GPIOPin) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[string]interface{}) error {
+func (gp *GPIOPin) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[string]any) error {
 	gp.mu.Lock()
 	defer gp.mu.Unlock()
 
@@ -327,7 +327,7 @@ func (gp *GPIOPin) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[s
 }
 
 // PWMFreq gets the PWM frequency of the pin.
-func (gp *GPIOPin) PWMFreq(ctx context.Context, extra map[string]interface{}) (uint, error) {
+func (gp *GPIOPin) PWMFreq(ctx context.Context, extra map[string]any) (uint, error) {
 	gp.mu.Lock()
 	defer gp.mu.Unlock()
 
@@ -335,7 +335,7 @@ func (gp *GPIOPin) PWMFreq(ctx context.Context, extra map[string]interface{}) (u
 }
 
 // SetPWMFreq sets the given pin to the given PWM frequency.
-func (gp *GPIOPin) SetPWMFreq(ctx context.Context, freqHz uint, extra map[string]interface{}) error {
+func (gp *GPIOPin) SetPWMFreq(ctx context.Context, freqHz uint, extra map[string]any) error {
 	gp.mu.Lock()
 	defer gp.mu.Unlock()
 
@@ -391,7 +391,7 @@ func (s *DigitalInterruptWrapper) reset(conf board.DigitalInterruptConfig) error
 
 // Value returns the current value of the interrupt which is
 // based on the type of interrupt.
-func (s *DigitalInterruptWrapper) Value(ctx context.Context, extra map[string]interface{}) (int64, error) {
+func (s *DigitalInterruptWrapper) Value(ctx context.Context, extra map[string]any) (int64, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.di.Value(ctx, extra)

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -351,7 +351,7 @@ func newWrappedAnalogReader(ctx context.Context, chipSelect string, reader *boar
 	return &wrapped
 }
 
-func (a *wrappedAnalogReader) Read(ctx context.Context, extra map[string]interface{}) (int, error) {
+func (a *wrappedAnalogReader) Read(ctx context.Context, extra map[string]any) (int, error) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	if a.reader == nil {
@@ -472,7 +472,7 @@ func (b *Board) GPIOPinByName(pinName string) (board.GPIOPin, error) {
 }
 
 // Status returns the current status of the board.
-func (b *Board) Status(ctx context.Context, extra map[string]interface{}) (*commonpb.BoardStatus, error) {
+func (b *Board) Status(ctx context.Context, extra map[string]any) (*commonpb.BoardStatus, error) {
 	return board.CreateStatus(ctx, b, extra)
 }
 
@@ -488,7 +488,7 @@ func (b *Board) SetPowerMode(
 }
 
 // WriteAnalog writes the value to the given pin.
-func (b *Board) WriteAnalog(ctx context.Context, pin string, value int32, extra map[string]interface{}) error {
+func (b *Board) WriteAnalog(ctx context.Context, pin string, value int32, extra map[string]any) error {
 	return nil
 }
 

--- a/components/board/genericlinux/digital_interrupts.go
+++ b/components/board/genericlinux/digital_interrupts.go
@@ -107,12 +107,12 @@ type gpioInterruptWrapperPin struct {
 }
 
 func (gp gpioInterruptWrapperPin) Set(
-	ctx context.Context, isHigh bool, extra map[string]interface{},
+	ctx context.Context, isHigh bool, extra map[string]any,
 ) error {
 	return errors.New("cannot set value of a digital interrupt pin")
 }
 
-func (gp gpioInterruptWrapperPin) Get(ctx context.Context, extra map[string]interface{}) (result bool, err error) {
+func (gp gpioInterruptWrapperPin) Get(ctx context.Context, extra map[string]any) (result bool, err error) {
 	value, err := gp.interrupt.line.Value()
 	if err != nil {
 		return false, err
@@ -122,24 +122,24 @@ func (gp gpioInterruptWrapperPin) Get(ctx context.Context, extra map[string]inte
 	return (value != 0), nil
 }
 
-func (gp gpioInterruptWrapperPin) PWM(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (gp gpioInterruptWrapperPin) PWM(ctx context.Context, extra map[string]any) (float64, error) {
 	return 0, errors.New("cannot get PWM of a digital interrupt pin")
 }
 
 func (gp gpioInterruptWrapperPin) SetPWM(
-	ctx context.Context, dutyCyclePct float64, extra map[string]interface{},
+	ctx context.Context, dutyCyclePct float64, extra map[string]any,
 ) error {
 	return errors.New("cannot set PWM of a digital interrupt pin")
 }
 
 func (gp gpioInterruptWrapperPin) PWMFreq(
-	ctx context.Context, extra map[string]interface{},
+	ctx context.Context, extra map[string]any,
 ) (uint, error) {
 	return 0, errors.New("cannot get PWM freq of a digital interrupt pin")
 }
 
 func (gp gpioInterruptWrapperPin) SetPWMFreq(
-	ctx context.Context, freqHz uint, extra map[string]interface{},
+	ctx context.Context, freqHz uint, extra map[string]any,
 ) error {
 	return errors.New("cannot set PWM freq of a digital interrupt pin")
 }

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -107,7 +107,7 @@ func (pin *gpioPin) closeGpioFd() error {
 
 // This helps implement the board.GPIOPin interface for gpioPin.
 func (pin *gpioPin) Set(ctx context.Context, isHigh bool,
-	extra map[string]interface{},
+	extra map[string]any,
 ) (err error) {
 	pin.mu.Lock()
 	defer pin.mu.Unlock()
@@ -143,7 +143,7 @@ func (pin *gpioPin) setInternal(isHigh bool) (err error) {
 
 // This helps implement the board.GPIOPin interface for gpioPin.
 func (pin *gpioPin) Get(
-	ctx context.Context, extra map[string]interface{},
+	ctx context.Context, extra map[string]any,
 ) (result bool, err error) {
 	pin.mu.Lock()
 	defer pin.mu.Unlock()
@@ -292,7 +292,7 @@ func (pin *gpioPin) softwarePwmLoop() {
 }
 
 // This helps implement the board.GPIOPin interface for gpioPin.
-func (pin *gpioPin) PWM(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (pin *gpioPin) PWM(ctx context.Context, extra map[string]any) (float64, error) {
 	pin.mu.Lock()
 	defer pin.mu.Unlock()
 
@@ -300,7 +300,7 @@ func (pin *gpioPin) PWM(ctx context.Context, extra map[string]interface{}) (floa
 }
 
 // This helps implement the board.GPIOPin interface for gpioPin.
-func (pin *gpioPin) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[string]interface{}) error {
+func (pin *gpioPin) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[string]any) error {
 	pin.mu.Lock()
 	defer pin.mu.Unlock()
 
@@ -309,7 +309,7 @@ func (pin *gpioPin) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[
 }
 
 // This helps implement the board.GPIOPin interface for gpioPin.
-func (pin *gpioPin) PWMFreq(ctx context.Context, extra map[string]interface{}) (uint, error) {
+func (pin *gpioPin) PWMFreq(ctx context.Context, extra map[string]any) (uint, error) {
 	pin.mu.Lock()
 	defer pin.mu.Unlock()
 
@@ -317,7 +317,7 @@ func (pin *gpioPin) PWMFreq(ctx context.Context, extra map[string]interface{}) (
 }
 
 // This helps implement the board.GPIOPin interface for gpioPin.
-func (pin *gpioPin) SetPWMFreq(ctx context.Context, freqHz uint, extra map[string]interface{}) error {
+func (pin *gpioPin) SetPWMFreq(ctx context.Context, freqHz uint, extra map[string]any) error {
 	pin.mu.Lock()
 	defer pin.mu.Unlock()
 

--- a/components/board/gpio_pin.go
+++ b/components/board/gpio_pin.go
@@ -5,21 +5,21 @@ import "context"
 // A GPIOPin represents an individual GPIO pin on a board.
 type GPIOPin interface {
 	// Set sets the pin to either low or high.
-	Set(ctx context.Context, high bool, extra map[string]interface{}) error
+	Set(ctx context.Context, high bool, extra map[string]any) error
 
 	// Get gets the high/low state of the pin.
-	Get(ctx context.Context, extra map[string]interface{}) (bool, error)
+	Get(ctx context.Context, extra map[string]any) (bool, error)
 
 	// PWM gets the pin's given duty cycle.
-	PWM(ctx context.Context, extra map[string]interface{}) (float64, error)
+	PWM(ctx context.Context, extra map[string]any) (float64, error)
 
 	// SetPWM sets the pin to the given duty cycle.
-	SetPWM(ctx context.Context, dutyCyclePct float64, extra map[string]interface{}) error
+	SetPWM(ctx context.Context, dutyCyclePct float64, extra map[string]any) error
 
 	// PWMFreq gets the PWM frequency of the pin.
-	PWMFreq(ctx context.Context, extra map[string]interface{}) (uint, error)
+	PWMFreq(ctx context.Context, extra map[string]any) (uint, error)
 
 	// SetPWMFreq sets the given pin to the given PWM frequency. For Raspberry Pis,
 	// 0 will use a default PWM frequency of 800.
-	SetPWMFreq(ctx context.Context, freqHz uint, extra map[string]interface{}) error
+	SetPWMFreq(ctx context.Context, freqHz uint, extra map[string]any) error
 }

--- a/components/board/hat/pca9685/pca9685.go
+++ b/components/board/hat/pca9685/pca9685.go
@@ -159,12 +159,12 @@ func (pca *PCA9685) SetPowerMode(ctx context.Context, mode pb.PowerMode, duratio
 }
 
 // WriteAnalog writes the value to the given pin.
-func (pca *PCA9685) WriteAnalog(ctx context.Context, pin string, value int32, extra map[string]interface{}) error {
+func (pca *PCA9685) WriteAnalog(ctx context.Context, pin string, value int32, extra map[string]any) error {
 	return grpc.UnimplementedError
 }
 
 // Status returns the board status which is always empty.
-func (pca *PCA9685) Status(ctx context.Context, extra map[string]interface{}) (*commonpb.BoardStatus, error) {
+func (pca *PCA9685) Status(ctx context.Context, extra map[string]any) (*commonpb.BoardStatus, error) {
 	return &commonpb.BoardStatus{}, nil
 }
 
@@ -278,7 +278,7 @@ type gpioPin struct {
 	startAddr byte
 }
 
-func (gp *gpioPin) Get(ctx context.Context, extra map[string]interface{}) (bool, error) {
+func (gp *gpioPin) Get(ctx context.Context, extra map[string]any) (bool, error) {
 	dutyCycle, err := gp.PWM(ctx, extra)
 	if err != nil {
 		return false, err
@@ -286,7 +286,7 @@ func (gp *gpioPin) Get(ctx context.Context, extra map[string]interface{}) (bool,
 	return dutyCycle != 0, nil
 }
 
-func (gp *gpioPin) Set(ctx context.Context, high bool, extra map[string]interface{}) error {
+func (gp *gpioPin) Set(ctx context.Context, high bool, extra map[string]any) error {
 	var dutyCyclePct float64
 	if high {
 		dutyCyclePct = 1
@@ -295,7 +295,7 @@ func (gp *gpioPin) Set(ctx context.Context, high bool, extra map[string]interfac
 	return gp.SetPWM(ctx, dutyCyclePct, extra)
 }
 
-func (gp *gpioPin) PWM(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (gp *gpioPin) PWM(ctx context.Context, extra map[string]any) (float64, error) {
 	gp.pca.mu.RLock()
 	defer gp.pca.mu.RUnlock()
 
@@ -338,7 +338,7 @@ func (gp *gpioPin) PWM(ctx context.Context, extra map[string]interface{}) (float
 	return float64(offVal<<4) / 0xffff, nil
 }
 
-func (gp *gpioPin) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[string]interface{}) error {
+func (gp *gpioPin) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[string]any) error {
 	gp.pca.mu.RLock()
 	defer gp.pca.mu.RUnlock()
 
@@ -396,7 +396,7 @@ func (gp *gpioPin) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[s
 	return nil
 }
 
-func (gp *gpioPin) PWMFreq(ctx context.Context, extra map[string]interface{}) (uint, error) {
+func (gp *gpioPin) PWMFreq(ctx context.Context, extra map[string]any) (uint, error) {
 	gp.pca.mu.RLock()
 	defer gp.pca.mu.RUnlock()
 
@@ -407,7 +407,7 @@ func (gp *gpioPin) PWMFreq(ctx context.Context, extra map[string]interface{}) (u
 	return uint(freqHz), nil
 }
 
-func (gp *gpioPin) SetPWMFreq(ctx context.Context, freqHz uint, extra map[string]interface{}) error {
+func (gp *gpioPin) SetPWMFreq(ctx context.Context, freqHz uint, extra map[string]any) error {
 	gp.pca.mu.RLock()
 	defer gp.pca.mu.RUnlock()
 

--- a/components/board/mcp3008helper/mcp3008.go
+++ b/components/board/mcp3008helper/mcp3008.go
@@ -36,7 +36,7 @@ func (config *MCP3008AnalogConfig) Validate(path string) error {
 	return nil
 }
 
-func (mar *MCP3008AnalogReader) Read(ctx context.Context, extra map[string]interface{}) (value int, err error) {
+func (mar *MCP3008AnalogReader) Read(ctx context.Context, extra map[string]any) (value int, err error) {
 	var tx [3]byte
 	tx[0] = 1                            // start bit
 	tx[1] = byte((8 + mar.Channel) << 4) // single-ended

--- a/components/board/numato/board.go
+++ b/components/board/numato/board.go
@@ -264,7 +264,7 @@ type gpioPin struct {
 	pin string
 }
 
-func (gp *gpioPin) Set(ctx context.Context, high bool, extra map[string]interface{}) error {
+func (gp *gpioPin) Set(ctx context.Context, high bool, extra map[string]any) error {
 	fixedPin := gp.b.fixPin(gp.pin)
 	if high {
 		return gp.b.doSend(ctx, fmt.Sprintf("gpio set %s", fixedPin))
@@ -272,7 +272,7 @@ func (gp *gpioPin) Set(ctx context.Context, high bool, extra map[string]interfac
 	return gp.b.doSend(ctx, fmt.Sprintf("gpio clear %s", fixedPin))
 }
 
-func (gp *gpioPin) Get(ctx context.Context, extra map[string]interface{}) (bool, error) {
+func (gp *gpioPin) Get(ctx context.Context, extra map[string]any) (bool, error) {
 	fixedPin := gp.b.fixPin(gp.pin)
 	res, err := gp.b.doSendReceive(ctx, fmt.Sprintf("gpio read %s", fixedPin))
 	if err != nil {
@@ -281,11 +281,11 @@ func (gp *gpioPin) Get(ctx context.Context, extra map[string]interface{}) (bool,
 	return res[len(res)-1] == '1', nil
 }
 
-func (gp *gpioPin) PWM(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (gp *gpioPin) PWM(ctx context.Context, extra map[string]any) (float64, error) {
 	return math.NaN(), errors.New("numato doesn't support PWM")
 }
 
-func (gp *gpioPin) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[string]interface{}) error {
+func (gp *gpioPin) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[string]any) error {
 	if dutyCyclePct == 1.0 {
 		return gp.Set(ctx, true, extra)
 	}
@@ -295,11 +295,11 @@ func (gp *gpioPin) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[s
 	return errors.New("numato doesn't support pwm")
 }
 
-func (gp *gpioPin) PWMFreq(ctx context.Context, extra map[string]interface{}) (uint, error) {
+func (gp *gpioPin) PWMFreq(ctx context.Context, extra map[string]any) (uint, error) {
 	return 0, errors.New("numato doesn't support PWMFreq")
 }
 
-func (gp *gpioPin) SetPWMFreq(ctx context.Context, freqHz uint, extra map[string]interface{}) error {
+func (gp *gpioPin) SetPWMFreq(ctx context.Context, freqHz uint, extra map[string]any) error {
 	if freqHz == 0 {
 		return nil
 	}
@@ -309,7 +309,7 @@ func (gp *gpioPin) SetPWMFreq(ctx context.Context, freqHz uint, extra map[string
 // Status returns the current status of the board. Usually you
 // should use the CreateStatus helper instead of directly calling
 // this.
-func (b *numatoBoard) Status(ctx context.Context, extra map[string]interface{}) (*commonpb.BoardStatus, error) {
+func (b *numatoBoard) Status(ctx context.Context, extra map[string]any) (*commonpb.BoardStatus, error) {
 	return board.CreateStatus(ctx, b, extra)
 }
 
@@ -318,7 +318,7 @@ func (b *numatoBoard) SetPowerMode(ctx context.Context, mode pb.PowerMode, durat
 }
 
 // WriteAnalog writes the value to the given pin.
-func (b *numatoBoard) WriteAnalog(ctx context.Context, pin string, value int32, extra map[string]interface{}) error {
+func (b *numatoBoard) WriteAnalog(ctx context.Context, pin string, value int32, extra map[string]any) error {
 	return grpc.UnimplementedError
 }
 
@@ -353,7 +353,7 @@ type analogReader struct {
 	pin string
 }
 
-func (ar *analogReader) Read(ctx context.Context, extra map[string]interface{}) (int, error) {
+func (ar *analogReader) Read(ctx context.Context, extra map[string]any) (int, error) {
 	res, err := ar.b.doSendReceive(ctx, fmt.Sprintf("adc read %s", ar.pin))
 	if err != nil {
 		return 0, err

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -386,27 +386,27 @@ type gpioPin struct {
 	bcom int
 }
 
-func (gp gpioPin) Set(ctx context.Context, high bool, extra map[string]interface{}) error {
+func (gp gpioPin) Set(ctx context.Context, high bool, extra map[string]any) error {
 	return gp.pi.SetGPIOBcom(gp.bcom, high)
 }
 
-func (gp gpioPin) Get(ctx context.Context, extra map[string]interface{}) (bool, error) {
+func (gp gpioPin) Get(ctx context.Context, extra map[string]any) (bool, error) {
 	return gp.pi.GetGPIOBcom(gp.bcom)
 }
 
-func (gp gpioPin) PWM(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (gp gpioPin) PWM(ctx context.Context, extra map[string]any) (float64, error) {
 	return gp.pi.pwmBcom(gp.bcom)
 }
 
-func (gp gpioPin) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[string]interface{}) error {
+func (gp gpioPin) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[string]any) error {
 	return gp.pi.SetPWMBcom(gp.bcom, dutyCyclePct)
 }
 
-func (gp gpioPin) PWMFreq(ctx context.Context, extra map[string]interface{}) (uint, error) {
+func (gp gpioPin) PWMFreq(ctx context.Context, extra map[string]any) (uint, error) {
 	return gp.pi.pwmFreqBcom(gp.bcom)
 }
 
-func (gp gpioPin) SetPWMFreq(ctx context.Context, freqHz uint, extra map[string]interface{}) error {
+func (gp gpioPin) SetPWMFreq(ctx context.Context, freqHz uint, extra map[string]any) error {
 	return gp.pi.SetPWMFreqBcom(gp.bcom, freqHz)
 }
 
@@ -695,7 +695,7 @@ func (pi *piPigpio) SetPowerMode(ctx context.Context, mode pb.PowerMode, duratio
 }
 
 // WriteAnalog writes the value to the given pin.
-func (pi *piPigpio) WriteAnalog(ctx context.Context, pin string, value int32, extra map[string]interface{}) error {
+func (pi *piPigpio) WriteAnalog(ctx context.Context, pin string, value int32, extra map[string]any) error {
 	return grpc.UnimplementedError
 }
 
@@ -748,7 +748,7 @@ func (pi *piPigpio) Close(ctx context.Context) error {
 }
 
 // Status returns the current status of the board.
-func (pi *piPigpio) Status(ctx context.Context, extra map[string]interface{}) (*commonpb.BoardStatus, error) {
+func (pi *piPigpio) Status(ctx context.Context, extra map[string]any) (*commonpb.BoardStatus, error) {
 	return board.CreateStatus(ctx, pi, extra)
 }
 

--- a/components/board/pi/impl/digital_interrupts.go
+++ b/components/board/pi/impl/digital_interrupts.go
@@ -78,7 +78,7 @@ type BasicDigitalInterrupt struct {
 }
 
 // Value returns the amount of ticks that have occurred.
-func (i *BasicDigitalInterrupt) Value(ctx context.Context, extra map[string]interface{}) (int64, error) {
+func (i *BasicDigitalInterrupt) Value(ctx context.Context, extra map[string]any) (int64, error) {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 	count := atomic.LoadInt64(&i.count)
@@ -162,7 +162,7 @@ type ServoDigitalInterrupt struct {
 
 // Value will return the window averaged value followed by its post processed
 // result.
-func (i *ServoDigitalInterrupt) Value(ctx context.Context, extra map[string]interface{}) (int64, error) {
+func (i *ServoDigitalInterrupt) Value(ctx context.Context, extra map[string]any) (int64, error) {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 	v := int64(i.ra.Average())

--- a/components/board/pi/impl/servo.go
+++ b/components/board/pi/impl/servo.go
@@ -121,7 +121,7 @@ type piPigpioServo struct {
 
 // Move moves the servo to the given angle (0-180 degrees)
 // This will block until done or a new operation cancels this one
-func (s *piPigpioServo) Move(ctx context.Context, angle uint32, extra map[string]interface{}) error {
+func (s *piPigpioServo) Move(ctx context.Context, angle uint32, extra map[string]any) error {
 	ctx, done := s.opMgr.New(ctx)
 	defer done()
 
@@ -171,7 +171,7 @@ func (s *piPigpioServo) pigpioErrors(res int) error {
 }
 
 // Position returns the current set angle (degrees) of the servo.
-func (s *piPigpioServo) Position(ctx context.Context, extra map[string]interface{}) (uint32, error) {
+func (s *piPigpioServo) Position(ctx context.Context, extra map[string]any) (uint32, error) {
 	res := C.gpioGetServoPulsewidth(s.pin)
 	err := s.pigpioErrors(int(res))
 	if int(res) != 0 {
@@ -198,7 +198,7 @@ func pulseWidthToAngle(pulseWidth, maxRotation int) int {
 }
 
 // Stop stops the servo. It is assumed the servo stops immediately.
-func (s *piPigpioServo) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (s *piPigpioServo) Stop(ctx context.Context, extra map[string]any) error {
 	_, done := s.opMgr.New(ctx)
 	defer done()
 	getPos := C.gpioServo(s.pin, C.uint(0))

--- a/components/board/server.go
+++ b/components/board/server.go
@@ -20,7 +20,7 @@ type serviceServer struct {
 
 // NewRPCServiceServer constructs an board gRPC service server.
 // It is intentionally untyped to prevent use outside of tests.
-func NewRPCServiceServer(coll resource.APIResourceCollection[Board]) interface{} {
+func NewRPCServiceServer(coll resource.APIResourceCollection[Board]) any {
 	return &serviceServer{coll: coll}
 }
 

--- a/components/board/server_test.go
+++ b/components/board/server_test.go
@@ -46,7 +46,7 @@ func TestServerStatus(t *testing.T) {
 		},
 	}
 
-	expectedExtra := map[string]interface{}{"foo": "bar", "baz": []interface{}{1., 2., 3.}}
+	expectedExtra := map[string]any{"foo": "bar", "baz": []any{1., 2., 3.}}
 	pbExpectedExtra, err := protoutils.StructToStructPb(expectedExtra)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -54,7 +54,7 @@ func TestServerStatus(t *testing.T) {
 		injectResult *commonpb.BoardStatus
 		injectErr    error
 		req          *request
-		expCapArgs   []interface{}
+		expCapArgs   []any
 		expResp      *response
 		expRespErr   string
 	}{
@@ -62,7 +62,7 @@ func TestServerStatus(t *testing.T) {
 			injectResult: status,
 			injectErr:    nil,
 			req:          &request{Name: missingBoardName},
-			expCapArgs:   []interface{}(nil),
+			expCapArgs:   []any(nil),
 			expResp:      nil,
 			expRespErr:   errNotFound.Error(),
 		},
@@ -70,7 +70,7 @@ func TestServerStatus(t *testing.T) {
 			injectResult: status,
 			injectErr:    errFoo,
 			req:          &request{Name: testBoardName},
-			expCapArgs:   []interface{}{ctx},
+			expCapArgs:   []any{ctx},
 			expResp:      nil,
 			expRespErr:   errFoo.Error(),
 		},
@@ -78,7 +78,7 @@ func TestServerStatus(t *testing.T) {
 			injectResult: status,
 			injectErr:    nil,
 			req:          &request{Name: testBoardName, Extra: pbExpectedExtra},
-			expCapArgs:   []interface{}{ctx},
+			expCapArgs:   []any{ctx},
 			expResp:      &response{Status: status},
 			expRespErr:   "",
 		},
@@ -89,9 +89,9 @@ func TestServerStatus(t *testing.T) {
 			server, injectBoard, err := newServer()
 			test.That(t, err, test.ShouldBeNil)
 
-			var actualExtra map[string]interface{}
+			var actualExtra map[string]any
 
-			injectBoard.StatusFunc = func(ctx context.Context, extra map[string]interface{}) (*commonpb.BoardStatus, error) {
+			injectBoard.StatusFunc = func(ctx context.Context, extra map[string]any) (*commonpb.BoardStatus, error) {
 				actualExtra = extra
 				return tc.injectResult, tc.injectErr
 			}
@@ -114,32 +114,32 @@ func TestServerSetGPIO(t *testing.T) {
 	type request = pb.SetGPIORequest
 	ctx := context.Background()
 
-	expectedExtra := map[string]interface{}{"foo": "bar", "baz": []interface{}{1., 2., 3.}}
+	expectedExtra := map[string]any{"foo": "bar", "baz": []any{1., 2., 3.}}
 	pbExpectedExtra, err := protoutils.StructToStructPb(expectedExtra)
 	test.That(t, err, test.ShouldBeNil)
 
 	tests := []struct {
 		injectErr  error
 		req        *request
-		expCapArgs []interface{}
+		expCapArgs []any
 		expRespErr string
 	}{
 		{
 			injectErr:  nil,
 			req:        &request{Name: missingBoardName},
-			expCapArgs: []interface{}(nil),
+			expCapArgs: []any(nil),
 			expRespErr: errNotFound.Error(),
 		},
 		{
 			injectErr:  errFoo,
 			req:        &request{Name: testBoardName, Pin: "one", High: true},
-			expCapArgs: []interface{}{ctx, true},
+			expCapArgs: []any{ctx, true},
 			expRespErr: errFoo.Error(),
 		},
 		{
 			injectErr:  nil,
 			req:        &request{Name: testBoardName, Pin: "one", High: true, Extra: pbExpectedExtra},
-			expCapArgs: []interface{}{ctx, true},
+			expCapArgs: []any{ctx, true},
 			expRespErr: "",
 		},
 	}
@@ -149,14 +149,14 @@ func TestServerSetGPIO(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			server, injectBoard, err := newServer()
 			test.That(t, err, test.ShouldBeNil)
-			var actualExtra map[string]interface{}
+			var actualExtra map[string]any
 
 			injectGPIOPin := &inject.GPIOPin{}
 			injectBoard.GPIOPinByNameFunc = func(name string) (board.GPIOPin, error) {
 				return injectGPIOPin, nil
 			}
 
-			injectGPIOPin.SetFunc = func(ctx context.Context, high bool, extra map[string]interface{}) error {
+			injectGPIOPin.SetFunc = func(ctx context.Context, high bool, extra map[string]any) error {
 				actualExtra = extra
 				return tc.injectErr
 			}
@@ -179,7 +179,7 @@ func TestServerGetGPIO(t *testing.T) {
 	type response = pb.GetGPIOResponse
 	ctx := context.Background()
 
-	expectedExtra := map[string]interface{}{"foo": "bar", "baz": []interface{}{1., 2., 3.}}
+	expectedExtra := map[string]any{"foo": "bar", "baz": []any{1., 2., 3.}}
 	pbExpectedExtra, err := protoutils.StructToStructPb(expectedExtra)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -187,7 +187,7 @@ func TestServerGetGPIO(t *testing.T) {
 		injectResult bool
 		injectErr    error
 		req          *request
-		expCapArgs   []interface{}
+		expCapArgs   []any
 		expResp      *response
 		expRespErr   string
 	}{
@@ -195,7 +195,7 @@ func TestServerGetGPIO(t *testing.T) {
 			injectResult: false,
 			injectErr:    nil,
 			req:          &request{Name: missingBoardName},
-			expCapArgs:   []interface{}(nil),
+			expCapArgs:   []any(nil),
 			expResp:      nil,
 			expRespErr:   errNotFound.Error(),
 		},
@@ -203,7 +203,7 @@ func TestServerGetGPIO(t *testing.T) {
 			injectResult: false,
 			injectErr:    errFoo,
 			req:          &request{Name: testBoardName, Pin: "one"},
-			expCapArgs:   []interface{}{ctx},
+			expCapArgs:   []any{ctx},
 			expResp:      nil,
 			expRespErr:   errFoo.Error(),
 		},
@@ -211,7 +211,7 @@ func TestServerGetGPIO(t *testing.T) {
 			injectResult: true,
 			injectErr:    nil,
 			req:          &request{Name: testBoardName, Pin: "one", Extra: pbExpectedExtra},
-			expCapArgs:   []interface{}{ctx},
+			expCapArgs:   []any{ctx},
 			expResp:      &response{High: true},
 			expRespErr:   "",
 		},
@@ -222,14 +222,14 @@ func TestServerGetGPIO(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			server, injectBoard, err := newServer()
 			test.That(t, err, test.ShouldBeNil)
-			var actualExtra map[string]interface{}
+			var actualExtra map[string]any
 
 			injectGPIOPin := &inject.GPIOPin{}
 			injectBoard.GPIOPinByNameFunc = func(name string) (board.GPIOPin, error) {
 				return injectGPIOPin, nil
 			}
 
-			injectGPIOPin.GetFunc = func(ctx context.Context, extra map[string]interface{}) (bool, error) {
+			injectGPIOPin.GetFunc = func(ctx context.Context, extra map[string]any) (bool, error) {
 				actualExtra = extra
 				return tc.injectResult, tc.injectErr
 			}
@@ -254,7 +254,7 @@ func TestServerPWM(t *testing.T) {
 	type response = pb.PWMResponse
 	ctx := context.Background()
 
-	expectedExtra := map[string]interface{}{"foo": "bar", "baz": []interface{}{1., 2., 3.}}
+	expectedExtra := map[string]any{"foo": "bar", "baz": []any{1., 2., 3.}}
 	pbExpectedExtra, err := protoutils.StructToStructPb(expectedExtra)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -262,7 +262,7 @@ func TestServerPWM(t *testing.T) {
 		injectResult float64
 		injectErr    error
 		req          *request
-		expCapArgs   []interface{}
+		expCapArgs   []any
 		expResp      *response
 		expRespErr   string
 	}{
@@ -270,7 +270,7 @@ func TestServerPWM(t *testing.T) {
 			injectResult: 0,
 			injectErr:    nil,
 			req:          &request{Name: missingBoardName},
-			expCapArgs:   []interface{}(nil),
+			expCapArgs:   []any(nil),
 			expResp:      nil,
 			expRespErr:   errNotFound.Error(),
 		},
@@ -278,7 +278,7 @@ func TestServerPWM(t *testing.T) {
 			injectResult: 0,
 			injectErr:    errFoo,
 			req:          &request{Name: testBoardName, Pin: "one"},
-			expCapArgs:   []interface{}{ctx},
+			expCapArgs:   []any{ctx},
 			expResp:      nil,
 			expRespErr:   errFoo.Error(),
 		},
@@ -286,7 +286,7 @@ func TestServerPWM(t *testing.T) {
 			injectResult: 0.1,
 			injectErr:    nil,
 			req:          &request{Name: testBoardName, Pin: "one", Extra: pbExpectedExtra},
-			expCapArgs:   []interface{}{ctx},
+			expCapArgs:   []any{ctx},
 			expResp:      &response{DutyCyclePct: 0.1},
 			expRespErr:   "",
 		},
@@ -296,14 +296,14 @@ func TestServerPWM(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			server, injectBoard, err := newServer()
 			test.That(t, err, test.ShouldBeNil)
-			var actualExtra map[string]interface{}
+			var actualExtra map[string]any
 
 			injectGPIOPin := &inject.GPIOPin{}
 			injectBoard.GPIOPinByNameFunc = func(name string) (board.GPIOPin, error) {
 				return injectGPIOPin, nil
 			}
 
-			injectGPIOPin.PWMFunc = func(ctx context.Context, extra map[string]interface{}) (float64, error) {
+			injectGPIOPin.PWMFunc = func(ctx context.Context, extra map[string]any) (float64, error) {
 				actualExtra = extra
 				return tc.injectResult, tc.injectErr
 			}
@@ -326,32 +326,32 @@ func TestServerSetPWM(t *testing.T) {
 	type request = pb.SetPWMRequest
 	ctx := context.Background()
 
-	expectedExtra := map[string]interface{}{"foo": "bar", "baz": []interface{}{1., 2., 3.}}
+	expectedExtra := map[string]any{"foo": "bar", "baz": []any{1., 2., 3.}}
 	pbExpectedExtra, err := protoutils.StructToStructPb(expectedExtra)
 	test.That(t, err, test.ShouldBeNil)
 
 	tests := []struct {
 		injectErr  error
 		req        *request
-		expCapArgs []interface{}
+		expCapArgs []any
 		expRespErr string
 	}{
 		{
 			injectErr:  nil,
 			req:        &request{Name: missingBoardName},
-			expCapArgs: []interface{}(nil),
+			expCapArgs: []any(nil),
 			expRespErr: errNotFound.Error(),
 		},
 		{
 			injectErr:  errFoo,
 			req:        &request{Name: testBoardName, Pin: "one", DutyCyclePct: 0.03},
-			expCapArgs: []interface{}{ctx, 0.03},
+			expCapArgs: []any{ctx, 0.03},
 			expRespErr: errFoo.Error(),
 		},
 		{
 			injectErr:  nil,
 			req:        &request{Name: testBoardName, Pin: "one", DutyCyclePct: 0.03, Extra: pbExpectedExtra},
-			expCapArgs: []interface{}{ctx, 0.03},
+			expCapArgs: []any{ctx, 0.03},
 			expRespErr: "",
 		},
 	}
@@ -361,14 +361,14 @@ func TestServerSetPWM(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			server, injectBoard, err := newServer()
 			test.That(t, err, test.ShouldBeNil)
-			var actualExtra map[string]interface{}
+			var actualExtra map[string]any
 
 			injectGPIOPin := &inject.GPIOPin{}
 			injectBoard.GPIOPinByNameFunc = func(name string) (board.GPIOPin, error) {
 				return injectGPIOPin, nil
 			}
 
-			injectGPIOPin.SetPWMFunc = func(ctx context.Context, dutyCyclePct float64, extra map[string]interface{}) error {
+			injectGPIOPin.SetPWMFunc = func(ctx context.Context, dutyCyclePct float64, extra map[string]any) error {
 				actualExtra = extra
 				return tc.injectErr
 			}
@@ -392,7 +392,7 @@ func TestServerPWMFrequency(t *testing.T) {
 	type response = pb.PWMFrequencyResponse
 	ctx := context.Background()
 
-	expectedExtra := map[string]interface{}{"foo": "bar", "baz": []interface{}{1., 2., 3.}}
+	expectedExtra := map[string]any{"foo": "bar", "baz": []any{1., 2., 3.}}
 	pbExpectedExtra, err := protoutils.StructToStructPb(expectedExtra)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -400,7 +400,7 @@ func TestServerPWMFrequency(t *testing.T) {
 		injectResult uint
 		injectErr    error
 		req          *request
-		expCapArgs   []interface{}
+		expCapArgs   []any
 		expResp      *response
 		expRespErr   string
 	}{
@@ -408,7 +408,7 @@ func TestServerPWMFrequency(t *testing.T) {
 			injectResult: 0,
 			injectErr:    nil,
 			req:          &request{Name: missingBoardName},
-			expCapArgs:   []interface{}(nil),
+			expCapArgs:   []any(nil),
 			expResp:      nil,
 			expRespErr:   errNotFound.Error(),
 		},
@@ -416,7 +416,7 @@ func TestServerPWMFrequency(t *testing.T) {
 			injectResult: 0,
 			injectErr:    errFoo,
 			req:          &request{Name: testBoardName, Pin: "one"},
-			expCapArgs:   []interface{}{ctx},
+			expCapArgs:   []any{ctx},
 			expResp:      nil,
 			expRespErr:   errFoo.Error(),
 		},
@@ -424,7 +424,7 @@ func TestServerPWMFrequency(t *testing.T) {
 			injectResult: 1,
 			injectErr:    nil,
 			req:          &request{Name: testBoardName, Pin: "one", Extra: pbExpectedExtra},
-			expCapArgs:   []interface{}{ctx},
+			expCapArgs:   []any{ctx},
 			expResp:      &response{FrequencyHz: 1},
 			expRespErr:   "",
 		},
@@ -434,14 +434,14 @@ func TestServerPWMFrequency(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			server, injectBoard, err := newServer()
 			test.That(t, err, test.ShouldBeNil)
-			var actualExtra map[string]interface{}
+			var actualExtra map[string]any
 
 			injectGPIOPin := &inject.GPIOPin{}
 			injectBoard.GPIOPinByNameFunc = func(name string) (board.GPIOPin, error) {
 				return injectGPIOPin, nil
 			}
 
-			injectGPIOPin.PWMFreqFunc = func(ctx context.Context, extra map[string]interface{}) (uint, error) {
+			injectGPIOPin.PWMFreqFunc = func(ctx context.Context, extra map[string]any) (uint, error) {
 				actualExtra = extra
 				return tc.injectResult, tc.injectErr
 			}
@@ -464,32 +464,32 @@ func TestServerSetPWMFrequency(t *testing.T) {
 	type request = pb.SetPWMFrequencyRequest
 	ctx := context.Background()
 
-	expectedExtra := map[string]interface{}{"foo": "bar", "baz": []interface{}{1., 2., 3.}}
+	expectedExtra := map[string]any{"foo": "bar", "baz": []any{1., 2., 3.}}
 	pbExpectedExtra, err := protoutils.StructToStructPb(expectedExtra)
 	test.That(t, err, test.ShouldBeNil)
 
 	tests := []struct {
 		injectErr  error
 		req        *request
-		expCapArgs []interface{}
+		expCapArgs []any
 		expRespErr string
 	}{
 		{
 			injectErr:  nil,
 			req:        &request{Name: missingBoardName},
-			expCapArgs: []interface{}(nil),
+			expCapArgs: []any(nil),
 			expRespErr: errNotFound.Error(),
 		},
 		{
 			injectErr:  errFoo,
 			req:        &request{Name: testBoardName, Pin: "one", FrequencyHz: 123123},
-			expCapArgs: []interface{}{ctx, uint(123123)},
+			expCapArgs: []any{ctx, uint(123123)},
 			expRespErr: errFoo.Error(),
 		},
 		{
 			injectErr:  nil,
 			req:        &request{Name: testBoardName, Pin: "one", FrequencyHz: 123123, Extra: pbExpectedExtra},
-			expCapArgs: []interface{}{ctx, uint(123123)},
+			expCapArgs: []any{ctx, uint(123123)},
 			expRespErr: "",
 		},
 	}
@@ -499,14 +499,14 @@ func TestServerSetPWMFrequency(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			server, injectBoard, err := newServer()
 			test.That(t, err, test.ShouldBeNil)
-			var actualExtra map[string]interface{}
+			var actualExtra map[string]any
 
 			injectGPIOPin := &inject.GPIOPin{}
 			injectBoard.GPIOPinByNameFunc = func(name string) (board.GPIOPin, error) {
 				return injectGPIOPin, nil
 			}
 
-			injectGPIOPin.SetPWMFreqFunc = func(ctx context.Context, freqHz uint, extra map[string]interface{}) error {
+			injectGPIOPin.SetPWMFreqFunc = func(ctx context.Context, freqHz uint, extra map[string]any) error {
 				actualExtra = extra
 				return tc.injectErr
 			}
@@ -530,7 +530,7 @@ func TestServerReadAnalogReader(t *testing.T) {
 	type response = pb.ReadAnalogReaderResponse
 	ctx := context.Background()
 
-	expectedExtra := map[string]interface{}{"foo": "bar", "baz": []interface{}{1., 2., 3.}}
+	expectedExtra := map[string]any{"foo": "bar", "baz": []any{1., 2., 3.}}
 	pbExpectedExtra, err := protoutils.StructToStructPb(expectedExtra)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -540,8 +540,8 @@ func TestServerReadAnalogReader(t *testing.T) {
 		injectResult           int
 		injectErr              error
 		req                    *request
-		expCapAnalogReaderArgs []interface{}
-		expCapArgs             []interface{}
+		expCapAnalogReaderArgs []any
+		expCapArgs             []any
 		expResp                *response
 		expRespErr             string
 	}{
@@ -551,8 +551,8 @@ func TestServerReadAnalogReader(t *testing.T) {
 			injectResult:           0,
 			injectErr:              nil,
 			req:                    &request{BoardName: missingBoardName},
-			expCapAnalogReaderArgs: []interface{}(nil),
-			expCapArgs:             []interface{}(nil),
+			expCapAnalogReaderArgs: []any(nil),
+			expCapArgs:             []any(nil),
 			expResp:                nil,
 			expRespErr:             errNotFound.Error(),
 		},
@@ -562,8 +562,8 @@ func TestServerReadAnalogReader(t *testing.T) {
 			injectResult:           0,
 			injectErr:              nil,
 			req:                    &request{BoardName: testBoardName, AnalogReaderName: "analog1"},
-			expCapAnalogReaderArgs: []interface{}{"analog1"},
-			expCapArgs:             []interface{}(nil),
+			expCapAnalogReaderArgs: []any{"analog1"},
+			expCapArgs:             []any(nil),
 			expResp:                nil,
 			expRespErr:             "unknown analog reader: analog1",
 		},
@@ -573,8 +573,8 @@ func TestServerReadAnalogReader(t *testing.T) {
 			injectResult:           0,
 			injectErr:              errFoo,
 			req:                    &request{BoardName: testBoardName, AnalogReaderName: "analog1"},
-			expCapAnalogReaderArgs: []interface{}{"analog1"},
-			expCapArgs:             []interface{}{ctx},
+			expCapAnalogReaderArgs: []any{"analog1"},
+			expCapArgs:             []any{ctx},
 			expResp:                nil,
 			expRespErr:             errFoo.Error(),
 		},
@@ -584,8 +584,8 @@ func TestServerReadAnalogReader(t *testing.T) {
 			injectResult:           8,
 			injectErr:              nil,
 			req:                    &request{BoardName: testBoardName, AnalogReaderName: "analog1", Extra: pbExpectedExtra},
-			expCapAnalogReaderArgs: []interface{}{"analog1"},
-			expCapArgs:             []interface{}{ctx},
+			expCapAnalogReaderArgs: []any{"analog1"},
+			expCapArgs:             []any{ctx},
 			expResp:                &response{Value: 8},
 			expRespErr:             "",
 		},
@@ -595,14 +595,14 @@ func TestServerReadAnalogReader(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			server, injectBoard, err := newServer()
 			test.That(t, err, test.ShouldBeNil)
-			var actualExtra map[string]interface{}
+			var actualExtra map[string]any
 
 			injectBoard.AnalogReaderByNameFunc = func(name string) (board.AnalogReader, bool) {
 				return tc.injectAnalogReader, tc.injectAnalogReaderOk
 			}
 
 			if tc.injectAnalogReader != nil {
-				tc.injectAnalogReader.ReadFunc = func(ctx context.Context, extra map[string]interface{}) (int, error) {
+				tc.injectAnalogReader.ReadFunc = func(ctx context.Context, extra map[string]any) (int, error) {
 					actualExtra = extra
 					return tc.injectResult, tc.injectErr
 				}
@@ -628,7 +628,7 @@ func TestServerWriteAnalog(t *testing.T) {
 	type response = pb.WriteAnalogResponse
 	ctx := context.Background()
 
-	expectedExtra := map[string]interface{}{"foo": "bar", "baz": []interface{}{1., 2., 3.}}
+	expectedExtra := map[string]any{"foo": "bar", "baz": []any{1., 2., 3.}}
 	pbExpectedExtra, err := protoutils.StructToStructPb(expectedExtra)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -636,7 +636,7 @@ func TestServerWriteAnalog(t *testing.T) {
 		name           string
 		injectErr      error
 		req            *request
-		expCaptureArgs []interface{}
+		expCaptureArgs []any
 		expResp        *response
 		expRespErr     string
 	}{
@@ -668,9 +668,9 @@ func TestServerWriteAnalog(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			server, injectBoard, err := newServer()
 			test.That(t, err, test.ShouldBeNil)
-			var actualExtra map[string]interface{}
+			var actualExtra map[string]any
 
-			injectBoard.WriteAnalogFunc = func(ctx context.Context, pin string, value int32, extra map[string]interface{}) error {
+			injectBoard.WriteAnalogFunc = func(ctx context.Context, pin string, value int32, extra map[string]any) error {
 				actualExtra = extra
 				return tc.injectErr
 			}
@@ -693,7 +693,7 @@ func TestServerGetDigitalInterruptValue(t *testing.T) {
 	type response = pb.GetDigitalInterruptValueResponse
 	ctx := context.Background()
 
-	expectedExtra := map[string]interface{}{"foo": "bar", "baz": []interface{}{1., 2., 3.}}
+	expectedExtra := map[string]any{"foo": "bar", "baz": []any{1., 2., 3.}}
 	pbExpectedExtra, err := protoutils.StructToStructPb(expectedExtra)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -703,8 +703,8 @@ func TestServerGetDigitalInterruptValue(t *testing.T) {
 		injectResult               int64
 		injectErr                  error
 		req                        *request
-		expCapDigitalInterruptArgs []interface{}
-		expCapArgs                 []interface{}
+		expCapDigitalInterruptArgs []any
+		expCapArgs                 []any
 		expResp                    *response
 		expRespErr                 string
 	}{
@@ -714,8 +714,8 @@ func TestServerGetDigitalInterruptValue(t *testing.T) {
 			injectResult:               0,
 			injectErr:                  nil,
 			req:                        &request{BoardName: missingBoardName},
-			expCapDigitalInterruptArgs: []interface{}(nil),
-			expCapArgs:                 []interface{}(nil),
+			expCapDigitalInterruptArgs: []any(nil),
+			expCapArgs:                 []any(nil),
 			expResp:                    nil,
 			expRespErr:                 errNotFound.Error(),
 		},
@@ -725,8 +725,8 @@ func TestServerGetDigitalInterruptValue(t *testing.T) {
 			injectResult:               0,
 			injectErr:                  nil,
 			req:                        &request{BoardName: testBoardName, DigitalInterruptName: "digital1"},
-			expCapDigitalInterruptArgs: []interface{}{"digital1"},
-			expCapArgs:                 []interface{}(nil),
+			expCapDigitalInterruptArgs: []any{"digital1"},
+			expCapArgs:                 []any(nil),
 			expResp:                    nil,
 			expRespErr:                 "unknown digital interrupt: digital1",
 		},
@@ -736,8 +736,8 @@ func TestServerGetDigitalInterruptValue(t *testing.T) {
 			injectResult:               0,
 			injectErr:                  errFoo,
 			req:                        &request{BoardName: testBoardName, DigitalInterruptName: "digital1"},
-			expCapDigitalInterruptArgs: []interface{}{"digital1"},
-			expCapArgs:                 []interface{}{ctx},
+			expCapDigitalInterruptArgs: []any{"digital1"},
+			expCapArgs:                 []any{ctx},
 			expResp:                    nil,
 			expRespErr:                 errFoo.Error(),
 		},
@@ -747,8 +747,8 @@ func TestServerGetDigitalInterruptValue(t *testing.T) {
 			injectResult:               42,
 			injectErr:                  nil,
 			req:                        &request{BoardName: testBoardName, DigitalInterruptName: "digital1", Extra: pbExpectedExtra},
-			expCapDigitalInterruptArgs: []interface{}{"digital1"},
-			expCapArgs:                 []interface{}{ctx},
+			expCapDigitalInterruptArgs: []any{"digital1"},
+			expCapArgs:                 []any{ctx},
 			expResp:                    &response{Value: 42},
 			expRespErr:                 "",
 		},
@@ -758,14 +758,14 @@ func TestServerGetDigitalInterruptValue(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			server, injectBoard, err := newServer()
 			test.That(t, err, test.ShouldBeNil)
-			var actualExtra map[string]interface{}
+			var actualExtra map[string]any
 
 			injectBoard.DigitalInterruptByNameFunc = func(name string) (board.DigitalInterrupt, bool) {
 				return tc.injectDigitalInterrupt, tc.injectDigitalInterruptOk
 			}
 
 			if tc.injectDigitalInterrupt != nil {
-				tc.injectDigitalInterrupt.ValueFunc = func(ctx context.Context, extra map[string]interface{}) (int64, error) {
+				tc.injectDigitalInterrupt.ValueFunc = func(ctx context.Context, extra map[string]any) (int64, error) {
 					actualExtra = extra
 					return tc.injectResult, tc.injectErr
 				}

--- a/components/board/status.go
+++ b/components/board/status.go
@@ -11,7 +11,7 @@ import (
 // CreateStatus constructs a new up to date status from the given board.
 // The operation can take time and be expensive, so it can be cancelled by the
 // given context.
-func CreateStatus(ctx context.Context, b Board, extra map[string]interface{}) (*commonpb.BoardStatus, error) {
+func CreateStatus(ctx context.Context, b Board, extra map[string]any) (*commonpb.BoardStatus, error) {
 	var status commonpb.BoardStatus
 
 	if names := b.AnalogReaderNames(); len(names) != 0 {

--- a/components/board/status_test.go
+++ b/components/board/status_test.go
@@ -20,9 +20,9 @@ func TestStatusValid(t *testing.T) {
 		t,
 		newStruct.AsMap(),
 		test.ShouldResemble,
-		map[string]interface{}{
-			"analogs":            map[string]interface{}{"analog1": map[string]interface{}{}},
-			"digital_interrupts": map[string]interface{}{"encoder": map[string]interface{}{}},
+		map[string]any{
+			"analogs":            map[string]any{"analog1": map[string]any{}},
+			"digital_interrupts": map[string]any{"encoder": map[string]any{}},
 		},
 	)
 

--- a/components/camera/align/extrinsics.go
+++ b/components/camera/align/extrinsics.go
@@ -62,7 +62,7 @@ func init() {
 // extrinsicsConfig is the attribute struct for aligning.
 type extrinsicsConfig struct {
 	CameraParameters     *transform.PinholeCameraIntrinsics `json:"intrinsic_parameters"`
-	IntrinsicExtrinsic   interface{}                        `json:"camera_system"`
+	IntrinsicExtrinsic   any                                `json:"camera_system"`
 	ImageType            string                             `json:"output_image_type"`
 	Color                string                             `json:"color_camera_name"`
 	Depth                string                             `json:"depth_camera_name"`

--- a/components/camera/camera.go
+++ b/components/camera/camera.go
@@ -244,7 +244,7 @@ func WrapVideoSourceWithProjector(
 type videoSource struct {
 	videoSource  gostream.VideoSource
 	videoStream  gostream.VideoStream
-	actualSource interface{}
+	actualSource any
 	system       *transform.PinholeCameraModel
 	imageType    ImageType
 }
@@ -304,7 +304,7 @@ func (vs *videoSource) Projector(ctx context.Context) (transform.Projector, erro
 	return vs.system.PinholeCameraIntrinsics, nil
 }
 
-func (vs *videoSource) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (vs *videoSource) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	if res, ok := vs.videoSource.(resource.Resource); ok {
 		return res.DoCommand(ctx, cmd)
 	}

--- a/components/camera/client.go
+++ b/components/camera/client.go
@@ -309,7 +309,7 @@ func (c *client) Properties(ctx context.Context) (Properties, error) {
 	return result, nil
 }
 
-func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (c *client) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	return protoutils.DoFromResourceClient(ctx, c.client, c.name, cmd)
 }
 

--- a/components/camera/collectors.go
+++ b/components/camera/collectors.go
@@ -38,13 +38,13 @@ func (m method) String() string {
 
 // TODO: add tests for this file.
 
-func newNextPointCloudCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+func newNextPointCloudCollector(resource any, params data.CollectorParams) (data.Collector, error) {
 	camera, err := assertCamera(resource)
 	if err != nil {
 		return nil, err
 	}
 
-	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (interface{}, error) {
+	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (any, error) {
 		_, span := trace.StartSpan(ctx, "camera::data::collector::CaptureFunc::NextPointCloud")
 		defer span.End()
 
@@ -74,7 +74,7 @@ func newNextPointCloudCollector(resource interface{}, params data.CollectorParam
 	return data.NewCollector(cFunc, params)
 }
 
-func newReadImageCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+func newReadImageCollector(resource any, params data.CollectorParams) (data.Collector, error) {
 	camera, err := assertCamera(resource)
 	if err != nil {
 		return nil, err
@@ -90,7 +90,7 @@ func newReadImageCollector(resource interface{}, params data.CollectorParams) (d
 		}
 	}
 
-	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (interface{}, error) {
+	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (any, error) {
 		_, span := trace.StartSpan(ctx, "camera::data::collector::CaptureFunc::ReadImage")
 		defer span.End()
 
@@ -126,12 +126,12 @@ func newReadImageCollector(resource interface{}, params data.CollectorParams) (d
 	return data.NewCollector(cFunc, params)
 }
 
-func newGetImagesCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+func newGetImagesCollector(resource any, params data.CollectorParams) (data.Collector, error) {
 	camera, err := assertCamera(resource)
 	if err != nil {
 		return nil, err
 	}
-	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (interface{}, error) {
+	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (any, error) {
 		_, span := trace.StartSpan(ctx, "camera::data::collector::CaptureFunc::GetImages")
 		defer span.End()
 
@@ -166,7 +166,7 @@ func newGetImagesCollector(resource interface{}, params data.CollectorParams) (d
 	return data.NewCollector(cFunc, params)
 }
 
-func assertCamera(resource interface{}) (Camera, error) {
+func assertCamera(resource any) (Camera, error) {
 	cam, ok := resource.(Camera)
 	if !ok {
 		return nil, data.InvalidInterfaceErr(API)

--- a/components/camera/extra.go
+++ b/components/camera/extra.go
@@ -4,7 +4,7 @@ import "context"
 
 // Extra is the type of value stored in the Contexts.
 type (
-	Extra map[string]interface{}
+	Extra map[string]any
 	key   int
 )
 

--- a/components/camera/ffmpeg/ffmpeg.go
+++ b/components/camera/ffmpeg/ffmpeg.go
@@ -30,16 +30,16 @@ type Config struct {
 	DistortionParameters *transform.BrownConrady            `json:"distortion_parameters,omitempty"`
 	Debug                bool                               `json:"debug,omitempty"`
 	VideoPath            string                             `json:"video_path"`
-	InputKWArgs          map[string]interface{}             `json:"input_kw_args,omitempty"`
+	InputKWArgs          map[string]any                     `json:"input_kw_args,omitempty"`
 	Filters              []FilterConfig                     `json:"filters,omitempty"`
-	OutputKWArgs         map[string]interface{}             `json:"output_kw_args,omitempty"`
+	OutputKWArgs         map[string]any                     `json:"output_kw_args,omitempty"`
 }
 
 // FilterConfig is a struct to used to configure ffmpeg filters.
 type FilterConfig struct {
-	Name   string                 `json:"name"`
-	Args   []string               `json:"args"`
-	KWArgs map[string]interface{} `json:"kw_args"`
+	Name   string         `json:"name"`
+	Args   []string       `json:"args"`
+	KWArgs map[string]any `json:"kw_args"`
 }
 
 var model = resource.DefaultModelFamily.WithModel("ffmpeg")
@@ -79,7 +79,7 @@ func NewFFMPEGCamera(ctx context.Context, conf *Config, logger logging.Logger) (
 		return nil, err
 	}
 	// parse attributes into ffmpeg keyword maps
-	outArgs := make(map[string]interface{}, len(conf.OutputKWArgs))
+	outArgs := make(map[string]any, len(conf.OutputKWArgs))
 	for key, value := range conf.OutputKWArgs {
 		outArgs[key] = value
 	}

--- a/components/camera/server.go
+++ b/components/camera/server.go
@@ -30,7 +30,7 @@ type serviceServer struct {
 
 // NewRPCServiceServer constructs an camera gRPC service server.
 // It is intentionally untyped to prevent use outside of tests.
-func NewRPCServiceServer(coll resource.APIResourceCollection[Camera]) interface{} {
+func NewRPCServiceServer(coll resource.APIResourceCollection[Camera]) any {
 	logger := logging.NewLogger("camserver")
 	imgTypes := make(map[string]ImageType)
 	return &serviceServer{coll: coll, logger: logger, imgTypes: imgTypes}

--- a/components/camera/server_test.go
+++ b/components/camera/server_test.go
@@ -466,7 +466,7 @@ func TestServer(t *testing.T) {
 		}
 
 		// one kvp created with data.FromDMContextKey
-		ext, err = goprotoutils.StructToStructPb(map[string]interface{}{data.FromDMString: true})
+		ext, err = goprotoutils.StructToStructPb(map[string]any{data.FromDMString: true})
 		test.That(t, err, test.ShouldBeNil)
 
 		_, err = cameraServer.GetImage(context.Background(), &pb.GetImageRequest{
@@ -488,7 +488,7 @@ func TestServer(t *testing.T) {
 
 		// use values from data and camera
 		ext, err = goprotoutils.StructToStructPb(
-			map[string]interface{}{
+			map[string]any{
 				data.FromDMString: true,
 				"hello":           "world",
 			},

--- a/components/camera/transformpipeline/classifier.go
+++ b/components/camera/transformpipeline/classifier.go
@@ -55,7 +55,7 @@ func newClassificationsTransform(
 	if props.DistortionParams != nil {
 		cameraModel.Distortion = props.DistortionParams
 	}
-	validLabels := make(map[string]interface{})
+	validLabels := make(map[string]any)
 	for _, l := range conf.ValidLabels {
 		validLabels[strings.ToLower(l)] = struct{}{}
 	}
@@ -96,7 +96,7 @@ func (cs *classifierSource) Read(ctx context.Context) (image.Image, func(), erro
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "could not get next source image")
 	}
-	classifications, err := srv.Classifications(ctx, img, int(cs.maxClassifications), map[string]interface{}{})
+	classifications, err := srv.Classifications(ctx, img, int(cs.maxClassifications), map[string]any{})
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "could not get classifications")
 	}

--- a/components/camera/transformpipeline/detector.go
+++ b/components/camera/transformpipeline/detector.go
@@ -56,7 +56,7 @@ func newDetectionsTransform(
 		cameraModel.Distortion = props.DistortionParams
 	}
 	confFilter := objectdetection.NewScoreFilter(conf.ConfidenceThreshold)
-	validLabels := make(map[string]interface{})
+	validLabels := make(map[string]any)
 	for _, l := range conf.ValidLabels {
 		validLabels[strings.ToLower(l)] = struct{}{}
 	}
@@ -89,7 +89,7 @@ func (ds *detectorSource) Read(ctx context.Context) (image.Image, func(), error)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not get next source image: %w", err)
 	}
-	dets, err := srv.Detections(ctx, img, map[string]interface{}{})
+	dets, err := srv.Detections(ctx, img, map[string]any{})
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not get detections: %w", err)
 	}

--- a/components/camera/transformpipeline/segmenter.go
+++ b/components/camera/transformpipeline/segmenter.go
@@ -82,7 +82,7 @@ func (ss *segmenterSource) NextPointCloud(ctx context.Context) (pointcloud.Point
 	}
 
 	// apply service
-	clouds, err := srv.GetObjectPointClouds(ctx, ss.cameraName, map[string]interface{}{})
+	clouds, err := srv.GetObjectPointClouds(ctx, ss.cameraName, map[string]any{})
 	if err != nil {
 		return nil, fmt.Errorf("could not get point clouds: %w", err)
 	}

--- a/components/camera/transformpipeline/segmenter_test.go
+++ b/components/camera/transformpipeline/segmenter_test.go
@@ -100,7 +100,7 @@ func TestTransformSegmenterFunctionality(t *testing.T) {
 	}
 
 	vizServ.GetObjectPointCloudsFunc = func(ctx context.Context, cameraName string,
-		extra map[string]interface{},
+		extra map[string]any,
 	) ([]*vision.Object, error) {
 		segments := make([]pc.PointCloud, 3)
 		segments[0] = pc.New()

--- a/components/camera/transformpipeline/transform.go
+++ b/components/camera/transformpipeline/transform.go
@@ -38,7 +38,7 @@ type emptyConfig struct{}
 // transformRegistration holds pertinent information regarding the available transforms.
 type transformRegistration struct {
 	name        string
-	retType     interface{}
+	retType     any
 	description string
 }
 

--- a/components/camera/ultrasonic/ultrasonic_test.go
+++ b/components/camera/ultrasonic/ultrasonic_test.go
@@ -37,7 +37,7 @@ func setupDependencies(t *testing.T) resource.Dependencies {
 		return injectDigi, true
 	}
 	pin := &inject.GPIOPin{}
-	pin.SetFunc = func(ctx context.Context, high bool, extra map[string]interface{}) error {
+	pin.SetFunc = func(ctx context.Context, high bool, extra map[string]any) error {
 		return nil
 	}
 	actualBoard.GPIOPinByNameFunc = func(name string) (board.GPIOPin, error) {
@@ -63,8 +63,8 @@ func TestUnderlyingSensor(t *testing.T) {
 	ctx := context.Background()
 
 	fakeUS := inject.NewSensor("mySensor")
-	fakeUS.ReadingsFunc = func(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
-		return map[string]interface{}{"distance": 3.2}, nil
+	fakeUS.ReadingsFunc = func(ctx context.Context, extra map[string]any) (map[string]any, error) {
+		return map[string]any{"distance": 3.2}, nil
 	}
 	logger := logging.NewTestLogger(t)
 	cam, err := cameraFromSensor(ctx, name, fakeUS, logger)

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -46,7 +46,7 @@ func init() {
 		ModelWebcam,
 		resource.Registration[camera.Camera, *WebcamConfig]{
 			Constructor: NewWebcam,
-			Discover: func(ctx context.Context, logger logging.Logger) (interface{}, error) {
+			Discover: func(ctx context.Context, logger logging.Logger) (any, error) {
 				return Discover(ctx, getVideoDrivers, logger)
 			},
 		})

--- a/components/encoder/ams/ams_as5048.go
+++ b/components/encoder/ams/ams_as5048.go
@@ -189,7 +189,7 @@ func (enc *Encoder) Reconfigure(
 }
 
 func (enc *Encoder) startPositionLoop(ctx context.Context) error {
-	if err := enc.ResetPosition(ctx, map[string]interface{}{}); err != nil {
+	if err := enc.ResetPosition(ctx, map[string]any{}); err != nil {
 		return err
 	}
 	enc.activeBackgroundWorkers.Add(1)
@@ -268,7 +268,7 @@ func (enc *Encoder) updatePosition(ctx context.Context) error {
 // motor to 1. Any other value will result in completely incorrect
 // position measurements by the motor.
 func (enc *Encoder) Position(
-	ctx context.Context, positionType encoder.PositionType, extra map[string]interface{},
+	ctx context.Context, positionType encoder.PositionType, extra map[string]any,
 ) (float64, encoder.PositionType, error) {
 	enc.mu.RLock()
 	defer enc.mu.RUnlock()
@@ -284,7 +284,7 @@ func (enc *Encoder) Position(
 // ResetPosition sets the current position measured by the encoder to be
 // considered its new zero position.
 func (enc *Encoder) ResetPosition(
-	ctx context.Context, extra map[string]interface{},
+	ctx context.Context, extra map[string]any,
 ) error {
 	enc.mu.Lock()
 	defer enc.mu.Unlock()
@@ -330,7 +330,7 @@ func (enc *Encoder) ResetPosition(
 }
 
 // Properties returns a list of all the position types that are supported by a given encoder.
-func (enc *Encoder) Properties(ctx context.Context, extra map[string]interface{}) (encoder.Properties, error) {
+func (enc *Encoder) Properties(ctx context.Context, extra map[string]any) (encoder.Properties, error) {
 	return encoder.Properties{
 		TicksCountSupported:   true,
 		AngleDegreesSupported: true,

--- a/components/encoder/client.go
+++ b/components/encoder/client.go
@@ -46,7 +46,7 @@ func NewClientFromConn(
 func (c *client) Position(
 	ctx context.Context,
 	positionType PositionType,
-	extra map[string]interface{},
+	extra map[string]any,
 ) (float64, PositionType, error) {
 	ext, err := structpb.NewStruct(extra)
 	if err != nil {
@@ -64,7 +64,7 @@ func (c *client) Position(
 
 // ResetPosition sets the current position of
 // the encoder to be its new zero position.
-func (c *client) ResetPosition(ctx context.Context, extra map[string]interface{}) error {
+func (c *client) ResetPosition(ctx context.Context, extra map[string]any) error {
 	ext, err := structpb.NewStruct(extra)
 	if err != nil {
 		return err
@@ -75,7 +75,7 @@ func (c *client) ResetPosition(ctx context.Context, extra map[string]interface{}
 }
 
 // Properties returns a list of all the position types that are supported by a given encoder.
-func (c *client) Properties(ctx context.Context, extra map[string]interface{}) (Properties, error) {
+func (c *client) Properties(ctx context.Context, extra map[string]any) (Properties, error) {
 	ext, err := structpb.NewStruct(extra)
 	if err != nil {
 		return Properties{}, err
@@ -88,6 +88,6 @@ func (c *client) Properties(ctx context.Context, extra map[string]interface{}) (
 	return ProtoFeaturesToProperties(resp), nil
 }
 
-func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (c *client) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	return protoutils.DoFromResourceClient(ctx, c.client, c.name, cmd)
 }

--- a/components/encoder/client_test.go
+++ b/components/encoder/client_test.go
@@ -33,21 +33,21 @@ func TestClient(t *testing.T) {
 	workingEncoder := &inject.Encoder{}
 	failingEncoder := &inject.Encoder{}
 
-	var actualExtra map[string]interface{}
+	var actualExtra map[string]any
 
-	workingEncoder.ResetPositionFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	workingEncoder.ResetPositionFunc = func(ctx context.Context, extra map[string]any) error {
 		actualExtra = extra
 		return nil
 	}
 	workingEncoder.PositionFunc = func(
 		ctx context.Context,
 		positionType encoder.PositionType,
-		extra map[string]interface{},
+		extra map[string]any,
 	) (float64, encoder.PositionType, error) {
 		actualExtra = extra
 		return 42.0, encoder.PositionTypeUnspecified, nil
 	}
-	workingEncoder.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (encoder.Properties, error) {
+	workingEncoder.PropertiesFunc = func(ctx context.Context, extra map[string]any) (encoder.Properties, error) {
 		actualExtra = extra
 		return encoder.Properties{
 			TicksCountSupported:   true,
@@ -55,17 +55,17 @@ func TestClient(t *testing.T) {
 		}, nil
 	}
 
-	failingEncoder.ResetPositionFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	failingEncoder.ResetPositionFunc = func(ctx context.Context, extra map[string]any) error {
 		return errSetToZeroFailed
 	}
 	failingEncoder.PositionFunc = func(
 		ctx context.Context,
 		positionType encoder.PositionType,
-		extra map[string]interface{},
+		extra map[string]any,
 	) (float64, encoder.PositionType, error) {
 		return 0, encoder.PositionTypeUnspecified, errPositionUnavailable
 	}
-	failingEncoder.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (encoder.Properties, error) {
+	failingEncoder.PropertiesFunc = func(ctx context.Context, extra map[string]any) (encoder.Properties, error) {
 		return encoder.Properties{}, errGetPropertiesFailed
 	}
 
@@ -111,12 +111,12 @@ func TestClient(t *testing.T) {
 		pos, positionType, err := workingEncoderClient.Position(
 			context.Background(),
 			encoder.PositionTypeUnspecified,
-			map[string]interface{}{"foo": "bar", "baz": []interface{}{1., 2., 3.}})
+			map[string]any{"foo": "bar", "baz": []any{1., 2., 3.}})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, pos, test.ShouldEqual, 42.0)
 		test.That(t, positionType, test.ShouldEqual, pb.PositionType_POSITION_TYPE_UNSPECIFIED)
 
-		test.That(t, actualExtra, test.ShouldResemble, map[string]interface{}{"foo": "bar", "baz": []interface{}{1., 2., 3.}})
+		test.That(t, actualExtra, test.ShouldResemble, map[string]any{"foo": "bar", "baz": []any{1., 2., 3.}})
 
 		test.That(t, workingEncoderClient.Close(context.Background()), test.ShouldBeNil)
 

--- a/components/encoder/collectors.go
+++ b/components/encoder/collectors.go
@@ -25,13 +25,13 @@ func (m method) String() string {
 
 // newTicksCountCollector returns a collector to register a ticks count method. If one is already registered
 // with the same MethodMetadata it will panic.
-func newTicksCountCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+func newTicksCountCollector(resource any, params data.CollectorParams) (data.Collector, error) {
 	encoder, err := assertEncoder(resource)
 	if err != nil {
 		return nil, err
 	}
 
-	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (interface{}, error) {
+	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (any, error) {
 		v, positionType, err := encoder.Position(ctx, PositionTypeUnspecified, data.FromDMExtraMap)
 		if err != nil {
 			// A modular filter component can be created to filter the readings from a component. The error ErrNoCaptureToStore
@@ -49,7 +49,7 @@ func newTicksCountCollector(resource interface{}, params data.CollectorParams) (
 	return data.NewCollector(cFunc, params)
 }
 
-func assertEncoder(resource interface{}) (Encoder, error) {
+func assertEncoder(resource any) (Encoder, error) {
 	encoder, ok := resource.(Encoder)
 	if !ok {
 		return nil, data.InvalidInterfaceErr(API)

--- a/components/encoder/collectors_test.go
+++ b/components/encoder/collectors_test.go
@@ -56,7 +56,7 @@ func newEncoder() encoder.Encoder {
 	e := &inject.Encoder{}
 	e.PositionFunc = func(ctx context.Context,
 		positionType encoder.PositionType,
-		extra map[string]interface{},
+		extra map[string]any,
 	) (float64, encoder.PositionType, error) {
 		return 1.0, encoder.PositionTypeTicks, nil
 	}

--- a/components/encoder/encoder.go
+++ b/components/encoder/encoder.go
@@ -62,13 +62,13 @@ type Encoder interface {
 	resource.Resource
 
 	// Position returns the current position in terms of ticks or degrees, and whether it is a relative or absolute position.
-	Position(ctx context.Context, positionType PositionType, extra map[string]interface{}) (float64, PositionType, error)
+	Position(ctx context.Context, positionType PositionType, extra map[string]any) (float64, PositionType, error)
 
 	// ResetPosition sets the current position of the motor to be its new zero position.
-	ResetPosition(ctx context.Context, extra map[string]interface{}) error
+	ResetPosition(ctx context.Context, extra map[string]any) error
 
 	// Properties returns a list of all the position types that are supported by a given encoder
-	Properties(ctx context.Context, extra map[string]interface{}) (Properties, error)
+	Properties(ctx context.Context, extra map[string]any) (Properties, error)
 }
 
 // Named is a helper for getting the named Encoder's typed resource name.

--- a/components/encoder/fake/encoder.go
+++ b/components/encoder/fake/encoder.go
@@ -97,7 +97,7 @@ type fakeEncoder struct {
 func (e *fakeEncoder) Position(
 	ctx context.Context,
 	positionType encoder.PositionType,
-	extra map[string]interface{},
+	extra map[string]any,
 ) (float64, encoder.PositionType, error) {
 	if positionType == encoder.PositionTypeDegrees {
 		return math.NaN(), encoder.PositionTypeUnspecified, encoder.NewPositionTypeUnsupportedError(positionType)
@@ -134,7 +134,7 @@ func (e *fakeEncoder) start(cancelCtx context.Context) {
 
 // ResetPosition sets the current position of the motor (adjusted by a given offset)
 // to be its new zero position.
-func (e *fakeEncoder) ResetPosition(ctx context.Context, extra map[string]interface{}) error {
+func (e *fakeEncoder) ResetPosition(ctx context.Context, extra map[string]any) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.position = int64(0)
@@ -142,7 +142,7 @@ func (e *fakeEncoder) ResetPosition(ctx context.Context, extra map[string]interf
 }
 
 // Properties returns a list of all the position types that are supported by a given encoder.
-func (e *fakeEncoder) Properties(ctx context.Context, extra map[string]interface{}) (encoder.Properties, error) {
+func (e *fakeEncoder) Properties(ctx context.Context, extra map[string]any) (encoder.Properties, error) {
 	return encoder.Properties{
 		TicksCountSupported:   true,
 		AngleDegreesSupported: false,

--- a/components/encoder/incremental/incremental_encoder.go
+++ b/components/encoder/incremental/incremental_encoder.go
@@ -290,7 +290,7 @@ func (e *Encoder) Start(ctx context.Context) {
 func (e *Encoder) Position(
 	ctx context.Context,
 	positionType encoder.PositionType,
-	extra map[string]interface{},
+	extra map[string]any,
 ) (float64, encoder.PositionType, error) {
 	if positionType == encoder.PositionTypeDegrees {
 		return math.NaN(), encoder.PositionTypeUnspecified, encoder.NewPositionTypeUnsupportedError(positionType)
@@ -301,14 +301,14 @@ func (e *Encoder) Position(
 
 // ResetPosition sets the current position of the motor (adjusted by a given offset)
 // to be its new zero position.
-func (e *Encoder) ResetPosition(ctx context.Context, extra map[string]interface{}) error {
+func (e *Encoder) ResetPosition(ctx context.Context, extra map[string]any) error {
 	atomic.StoreInt64(&e.position, 0)
 	atomic.StoreInt64(&e.pRaw, atomic.LoadInt64(&e.pRaw)&0x1)
 	return nil
 }
 
 // Properties returns a list of all the position types that are supported by a given encoder.
-func (e *Encoder) Properties(ctx context.Context, extra map[string]interface{}) (encoder.Properties, error) {
+func (e *Encoder) Properties(ctx context.Context, extra map[string]any) (encoder.Properties, error) {
 	return encoder.Properties{
 		TicksCountSupported:   true,
 		AngleDegreesSupported: false,

--- a/components/encoder/server.go
+++ b/components/encoder/server.go
@@ -17,7 +17,7 @@ type serviceServer struct {
 }
 
 // NewRPCServiceServer constructs an Encoder gRPC service serviceServer.
-func NewRPCServiceServer(coll resource.APIResourceCollection[Encoder]) interface{} {
+func NewRPCServiceServer(coll resource.APIResourceCollection[Encoder]) any {
 	return &serviceServer{coll: coll}
 }
 

--- a/components/encoder/server_test.go
+++ b/components/encoder/server_test.go
@@ -50,7 +50,7 @@ func TestServerGetPosition(t *testing.T) {
 	failingEncoder.PositionFunc = func(
 		ctx context.Context,
 		positionType encoder.PositionType,
-		extra map[string]interface{},
+		extra map[string]any,
 	) (float64, encoder.PositionType, error) {
 		return 0, encoder.PositionTypeUnspecified, errPositionUnavailable
 	}
@@ -64,7 +64,7 @@ func TestServerGetPosition(t *testing.T) {
 	workingEncoder.PositionFunc = func(
 		ctx context.Context,
 		positionType encoder.PositionType,
-		extra map[string]interface{},
+		extra map[string]any,
 	) (float64, encoder.PositionType, error) {
 		return 42.0, encoder.PositionTypeUnspecified, nil
 	}
@@ -83,7 +83,7 @@ func TestServerResetPosition(t *testing.T) {
 	test.That(t, resp, test.ShouldBeNil)
 	test.That(t, err, test.ShouldNotBeNil)
 
-	failingEncoder.ResetPositionFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	failingEncoder.ResetPositionFunc = func(ctx context.Context, extra map[string]any) error {
 		return errSetToZeroFailed
 	}
 	req = pb.ResetPositionRequest{Name: failEncoderName}
@@ -92,7 +92,7 @@ func TestServerResetPosition(t *testing.T) {
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldBeError, errSetToZeroFailed)
 
-	workingEncoder.ResetPositionFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	workingEncoder.ResetPositionFunc = func(ctx context.Context, extra map[string]any) error {
 		return nil
 	}
 	req = pb.ResetPositionRequest{Name: testEncoderName}
@@ -110,7 +110,7 @@ func TestServerGetProperties(t *testing.T) {
 	test.That(t, resp, test.ShouldBeNil)
 	test.That(t, err, test.ShouldNotBeNil)
 
-	failingEncoder.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (encoder.Properties, error) {
+	failingEncoder.PropertiesFunc = func(ctx context.Context, extra map[string]any) (encoder.Properties, error) {
 		return encoder.Properties{}, errPropertiesNotFound
 	}
 	req = pb.GetPropertiesRequest{Name: failEncoderName}
@@ -119,7 +119,7 @@ func TestServerGetProperties(t *testing.T) {
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldBeError, errPropertiesNotFound)
 
-	workingEncoder.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (encoder.Properties, error) {
+	workingEncoder.PropertiesFunc = func(ctx context.Context, extra map[string]any) (encoder.Properties, error) {
 		return encoder.Properties{
 			TicksCountSupported:   true,
 			AngleDegreesSupported: false,
@@ -134,13 +134,13 @@ func TestServerGetProperties(t *testing.T) {
 func TestServerExtraParams(t *testing.T) {
 	encoderServer, workingEncoder, _, _ := newServer()
 
-	var actualExtra map[string]interface{}
-	workingEncoder.ResetPositionFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	var actualExtra map[string]any
+	workingEncoder.ResetPositionFunc = func(ctx context.Context, extra map[string]any) error {
 		actualExtra = extra
 		return nil
 	}
 
-	expectedExtra := map[string]interface{}{"foo": "bar", "baz": []interface{}{1., 2., 3.}}
+	expectedExtra := map[string]any{"foo": "bar", "baz": []any{1., 2., 3.}}
 
 	ext, err := protoutils.StructToStructPb(expectedExtra)
 	test.That(t, err, test.ShouldBeNil)

--- a/components/encoder/single/single_encoder.go
+++ b/components/encoder/single/single_encoder.go
@@ -219,7 +219,7 @@ func (e *Encoder) Start(ctx context.Context) {
 func (e *Encoder) Position(
 	ctx context.Context,
 	positionType encoder.PositionType,
-	extra map[string]interface{},
+	extra map[string]any,
 ) (float64, encoder.PositionType, error) {
 	if positionType == encoder.PositionTypeDegrees {
 		return math.NaN(), encoder.PositionTypeUnspecified, encoder.NewPositionTypeUnsupportedError(positionType)
@@ -229,14 +229,14 @@ func (e *Encoder) Position(
 }
 
 // ResetPosition sets the current position of the motor (adjusted by a given offset).
-func (e *Encoder) ResetPosition(ctx context.Context, extra map[string]interface{}) error {
+func (e *Encoder) ResetPosition(ctx context.Context, extra map[string]any) error {
 	offsetInt := int64(math.Round(0))
 	atomic.StoreInt64(&e.position, offsetInt)
 	return nil
 }
 
 // Properties returns a list of all the position types that are supported by a given encoder.
-func (e *Encoder) Properties(ctx context.Context, extra map[string]interface{}) (encoder.Properties, error) {
+func (e *Encoder) Properties(ctx context.Context, extra map[string]any) (encoder.Properties, error) {
 	return encoder.Properties{
 		TicksCountSupported:   true,
 		AngleDegreesSupported: false,

--- a/components/gantry/client.go
+++ b/components/gantry/client.go
@@ -41,7 +41,7 @@ func NewClientFromConn(
 	}, nil
 }
 
-func (c *client) Position(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+func (c *client) Position(ctx context.Context, extra map[string]any) ([]float64, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return nil, err
@@ -56,7 +56,7 @@ func (c *client) Position(ctx context.Context, extra map[string]interface{}) ([]
 	return resp.PositionsMm, nil
 }
 
-func (c *client) Lengths(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+func (c *client) Lengths(ctx context.Context, extra map[string]any) ([]float64, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return nil, err
@@ -71,7 +71,7 @@ func (c *client) Lengths(ctx context.Context, extra map[string]interface{}) ([]f
 	return lengths.LengthsMm, nil
 }
 
-func (c *client) Home(ctx context.Context, extra map[string]interface{}) (bool, error) {
+func (c *client) Home(ctx context.Context, extra map[string]any) (bool, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return false, err
@@ -86,7 +86,7 @@ func (c *client) Home(ctx context.Context, extra map[string]interface{}) (bool, 
 	return homed.Homed, nil
 }
 
-func (c *client) MoveToPosition(ctx context.Context, positionsMm, speedsMmPerSec []float64, extra map[string]interface{}) error {
+func (c *client) MoveToPosition(ctx context.Context, positionsMm, speedsMmPerSec []float64, extra map[string]any) error {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return err
@@ -100,7 +100,7 @@ func (c *client) MoveToPosition(ctx context.Context, positionsMm, speedsMmPerSec
 	return err
 }
 
-func (c *client) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (c *client) Stop(ctx context.Context, extra map[string]any) error {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return err
@@ -127,7 +127,7 @@ func (c *client) GoToInputs(ctx context.Context, goal []referenceframe.Input) er
 	return c.MoveToPosition(ctx, referenceframe.InputsToFloats(goal), speeds, nil)
 }
 
-func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (c *client) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	return rprotoutils.DoFromResourceClient(ctx, c.client, c.name, cmd)
 }
 

--- a/components/gantry/client_test.go
+++ b/components/gantry/client_test.go
@@ -28,27 +28,27 @@ func TestClient(t *testing.T) {
 
 	pos1 := []float64{1.0, 2.0, 3.0}
 	len1 := []float64{2.0, 3.0, 4.0}
-	var extra1 map[string]interface{}
+	var extra1 map[string]any
 	injectGantry := &inject.Gantry{}
-	injectGantry.PositionFunc = func(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+	injectGantry.PositionFunc = func(ctx context.Context, extra map[string]any) ([]float64, error) {
 		extra1 = extra
 		return pos1, nil
 	}
-	injectGantry.MoveToPositionFunc = func(ctx context.Context, pos, speed []float64, extra map[string]interface{}) error {
+	injectGantry.MoveToPositionFunc = func(ctx context.Context, pos, speed []float64, extra map[string]any) error {
 		gantryPos = pos
 		gantrySpeed = speed
 		extra1 = extra
 		return nil
 	}
-	injectGantry.LengthsFunc = func(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+	injectGantry.LengthsFunc = func(ctx context.Context, extra map[string]any) ([]float64, error) {
 		extra1 = extra
 		return len1, nil
 	}
-	injectGantry.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	injectGantry.StopFunc = func(ctx context.Context, extra map[string]any) error {
 		extra1 = extra
 		return errStopFailed
 	}
-	injectGantry.HomeFunc = func(ctx context.Context, extra map[string]interface{}) (bool, error) {
+	injectGantry.HomeFunc = func(ctx context.Context, extra map[string]any) (bool, error) {
 		extra1 = extra
 		return true, nil
 	}
@@ -56,27 +56,27 @@ func TestClient(t *testing.T) {
 	pos2 := []float64{4.0, 5.0, 6.0}
 	speed2 := []float64{100.0, 80.0, 120.0}
 	len2 := []float64{5.0, 6.0, 7.0}
-	var extra2 map[string]interface{}
+	var extra2 map[string]any
 	injectGantry2 := &inject.Gantry{}
-	injectGantry2.PositionFunc = func(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+	injectGantry2.PositionFunc = func(ctx context.Context, extra map[string]any) ([]float64, error) {
 		extra2 = extra
 		return pos2, nil
 	}
-	injectGantry2.MoveToPositionFunc = func(ctx context.Context, pos, speed []float64, extra map[string]interface{}) error {
+	injectGantry2.MoveToPositionFunc = func(ctx context.Context, pos, speed []float64, extra map[string]any) error {
 		gantryPos = pos
 		gantrySpeed = speed
 		extra2 = extra
 		return nil
 	}
-	injectGantry2.LengthsFunc = func(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+	injectGantry2.LengthsFunc = func(ctx context.Context, extra map[string]any) ([]float64, error) {
 		extra2 = extra
 		return len2, nil
 	}
-	injectGantry2.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	injectGantry2.StopFunc = func(ctx context.Context, extra map[string]any) error {
 		extra2 = extra
 		return nil
 	}
-	injectGantry2.HomeFunc = func(ctx context.Context, extra map[string]interface{}) (bool, error) {
+	injectGantry2.HomeFunc = func(ctx context.Context, extra map[string]any) (bool, error) {
 		extra2 = extra
 		return false, errHomingFailed
 	}
@@ -118,31 +118,31 @@ func TestClient(t *testing.T) {
 		test.That(t, resp["command"], test.ShouldEqual, testutils.TestCommand["command"])
 		test.That(t, resp["data"], test.ShouldEqual, testutils.TestCommand["data"])
 
-		pos, err := gantry1Client.Position(context.Background(), map[string]interface{}{"foo": 123, "bar": "234"})
+		pos, err := gantry1Client.Position(context.Background(), map[string]any{"foo": 123, "bar": "234"})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, pos, test.ShouldResemble, pos1)
-		test.That(t, extra1, test.ShouldResemble, map[string]interface{}{"foo": 123., "bar": "234"})
+		test.That(t, extra1, test.ShouldResemble, map[string]any{"foo": 123., "bar": "234"})
 
-		err = gantry1Client.MoveToPosition(context.Background(), pos2, speed2, map[string]interface{}{"foo": 234, "bar": "345"})
+		err = gantry1Client.MoveToPosition(context.Background(), pos2, speed2, map[string]any{"foo": 234, "bar": "345"})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, gantryPos, test.ShouldResemble, pos2)
 		test.That(t, gantrySpeed, test.ShouldResemble, speed2)
-		test.That(t, extra1, test.ShouldResemble, map[string]interface{}{"foo": 234., "bar": "345"})
+		test.That(t, extra1, test.ShouldResemble, map[string]any{"foo": 234., "bar": "345"})
 
-		lens, err := gantry1Client.Lengths(context.Background(), map[string]interface{}{"foo": 345, "bar": "456"})
+		lens, err := gantry1Client.Lengths(context.Background(), map[string]any{"foo": 345, "bar": "456"})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, lens, test.ShouldResemble, len1)
-		test.That(t, extra1, test.ShouldResemble, map[string]interface{}{"foo": 345., "bar": "456"})
+		test.That(t, extra1, test.ShouldResemble, map[string]any{"foo": 345., "bar": "456"})
 
-		homed, err := gantry1Client.Home(context.Background(), map[string]interface{}{"foo": 345, "bar": "456"})
+		homed, err := gantry1Client.Home(context.Background(), map[string]any{"foo": 345, "bar": "456"})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, homed, test.ShouldBeTrue)
-		test.That(t, extra1, test.ShouldResemble, map[string]interface{}{"foo": 345., "bar": "456"})
+		test.That(t, extra1, test.ShouldResemble, map[string]any{"foo": 345., "bar": "456"})
 
-		err = gantry1Client.Stop(context.Background(), map[string]interface{}{"foo": 456, "bar": "567"})
+		err = gantry1Client.Stop(context.Background(), map[string]any{"foo": 456, "bar": "567"})
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errStopFailed.Error())
-		test.That(t, extra1, test.ShouldResemble, map[string]interface{}{"foo": 456., "bar": "567"})
+		test.That(t, extra1, test.ShouldResemble, map[string]any{"foo": 456., "bar": "567"})
 
 		test.That(t, gantry1Client.Close(context.Background()), test.ShouldBeNil)
 		test.That(t, conn.Close(), test.ShouldBeNil)
@@ -154,19 +154,19 @@ func TestClient(t *testing.T) {
 		client2, err := resourceAPI.RPCClient(context.Background(), conn, "", gantry.Named(testGantryName2), logger)
 		test.That(t, err, test.ShouldBeNil)
 
-		pos, err := client2.Position(context.Background(), map[string]interface{}{"foo": "123", "bar": 234})
+		pos, err := client2.Position(context.Background(), map[string]any{"foo": "123", "bar": 234})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, pos, test.ShouldResemble, pos2)
-		test.That(t, extra2, test.ShouldResemble, map[string]interface{}{"foo": "123", "bar": 234.})
+		test.That(t, extra2, test.ShouldResemble, map[string]any{"foo": "123", "bar": 234.})
 
-		homed, err := client2.Home(context.Background(), map[string]interface{}{"foo": 345, "bar": "456"})
+		homed, err := client2.Home(context.Background(), map[string]any{"foo": 345, "bar": "456"})
 		test.That(t, err.Error(), test.ShouldContainSubstring, errHomingFailed.Error())
 		test.That(t, homed, test.ShouldBeFalse)
-		test.That(t, extra2, test.ShouldResemble, map[string]interface{}{"foo": 345., "bar": "456"})
+		test.That(t, extra2, test.ShouldResemble, map[string]any{"foo": 345., "bar": "456"})
 
-		err = client2.Stop(context.Background(), map[string]interface{}{"foo": "234", "bar": 345})
+		err = client2.Stop(context.Background(), map[string]any{"foo": "234", "bar": 345})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, extra2, test.ShouldResemble, map[string]interface{}{"foo": "234", "bar": 345.})
+		test.That(t, extra2, test.ShouldResemble, map[string]any{"foo": "234", "bar": 345.})
 
 		test.That(t, conn.Close(), test.ShouldBeNil)
 	})

--- a/components/gantry/collectors.go
+++ b/components/gantry/collectors.go
@@ -29,13 +29,13 @@ func (m method) String() string {
 
 // newPositionCollector returns a collector to register a position method. If one is already registered
 // with the same MethodMetadata it will panic.
-func newPositionCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+func newPositionCollector(resource any, params data.CollectorParams) (data.Collector, error) {
 	gantry, err := assertGantry(resource)
 	if err != nil {
 		return nil, err
 	}
 
-	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (interface{}, error) {
+	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (any, error) {
 		v, err := gantry.Position(ctx, data.FromDMExtraMap)
 		if err != nil {
 			// A modular filter component can be created to filter the readings from a component. The error ErrNoCaptureToStore
@@ -54,13 +54,13 @@ func newPositionCollector(resource interface{}, params data.CollectorParams) (da
 
 // newLengthsCollector returns a collector to register a lengths method. If one is already registered
 // with the same MethodMetadata it will panic.
-func newLengthsCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+func newLengthsCollector(resource any, params data.CollectorParams) (data.Collector, error) {
 	gantry, err := assertGantry(resource)
 	if err != nil {
 		return nil, err
 	}
 
-	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (interface{}, error) {
+	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (any, error) {
 		v, err := gantry.Lengths(ctx, data.FromDMExtraMap)
 		if err != nil {
 			// A modular filter component can be created to filter the readings from a component. The error ErrNoCaptureToStore
@@ -85,7 +85,7 @@ func scaleMetersToMm(meters []float64) []float64 {
 	return ret
 }
 
-func assertGantry(resource interface{}) (Gantry, error) {
+func assertGantry(resource any) (Gantry, error) {
 	gantry, ok := resource.(Gantry)
 	if !ok {
 		return nil, data.InvalidInterfaceErr(API)

--- a/components/gantry/collectors_test.go
+++ b/components/gantry/collectors_test.go
@@ -77,10 +77,10 @@ func TestGantryCollectors(t *testing.T) {
 
 func newGantry() gantry.Gantry {
 	g := &inject.Gantry{}
-	g.PositionFunc = func(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+	g.PositionFunc = func(ctx context.Context, extra map[string]any) ([]float64, error) {
 		return floatList, nil
 	}
-	g.LengthsFunc = func(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+	g.LengthsFunc = func(ctx context.Context, extra map[string]any) ([]float64, error) {
 		return floatList, nil
 	}
 	return g

--- a/components/gantry/fake/gantry.go
+++ b/components/gantry/fake/gantry.go
@@ -59,30 +59,30 @@ type Gantry struct {
 }
 
 // Position returns the position in meters.
-func (g *Gantry) Position(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+func (g *Gantry) Position(ctx context.Context, extra map[string]any) ([]float64, error) {
 	return g.positionsMm, nil
 }
 
 // Lengths returns the position in meters.
-func (g *Gantry) Lengths(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+func (g *Gantry) Lengths(ctx context.Context, extra map[string]any) ([]float64, error) {
 	return g.lengths, nil
 }
 
 // Home runs the homing sequence of the gantry and returns true once completed.
-func (g *Gantry) Home(ctx context.Context, extra map[string]interface{}) (bool, error) {
+func (g *Gantry) Home(ctx context.Context, extra map[string]any) (bool, error) {
 	g.logger.CInfo(ctx, "homing")
 	return true, nil
 }
 
 // MoveToPosition is in meters.
-func (g *Gantry) MoveToPosition(ctx context.Context, positionsMm, speedsMmPerSec []float64, extra map[string]interface{}) error {
+func (g *Gantry) MoveToPosition(ctx context.Context, positionsMm, speedsMmPerSec []float64, extra map[string]any) error {
 	g.positionsMm = positionsMm
 	g.speedsMmPerSec = speedsMmPerSec
 	return nil
 }
 
 // Stop doesn't do anything for a fake gantry.
-func (g *Gantry) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (g *Gantry) Stop(ctx context.Context, extra map[string]any) error {
 	return nil
 }
 

--- a/components/gantry/gantry.go
+++ b/components/gantry/gantry.go
@@ -48,17 +48,17 @@ type Gantry interface {
 	referenceframe.InputEnabled
 
 	// Position returns the position in meters
-	Position(ctx context.Context, extra map[string]interface{}) ([]float64, error)
+	Position(ctx context.Context, extra map[string]any) ([]float64, error)
 
 	// MoveToPosition is in meters
 	// This will block until done or a new operation cancels this one
-	MoveToPosition(ctx context.Context, positionsMm, speedsMmPerSec []float64, extra map[string]interface{}) error
+	MoveToPosition(ctx context.Context, positionsMm, speedsMmPerSec []float64, extra map[string]any) error
 
 	// Lengths is the length of gantries in meters
-	Lengths(ctx context.Context, extra map[string]interface{}) ([]float64, error)
+	Lengths(ctx context.Context, extra map[string]any) ([]float64, error)
 
 	// Home runs the homing sequence of the gantry and returns true once completed
-	Home(ctx context.Context, extra map[string]interface{}) (bool, error)
+	Home(ctx context.Context, extra map[string]any) (bool, error)
 }
 
 // FromDependencies is a helper for getting the named gantry from a collection of

--- a/components/gantry/gantry_test.go
+++ b/components/gantry/gantry_test.go
@@ -34,9 +34,9 @@ func TestStatusValid(t *testing.T) {
 		t,
 		newStruct.AsMap(),
 		test.ShouldResemble,
-		map[string]interface{}{
-			"lengths_mm":   []interface{}{4.4, 5.5, 6.6},
-			"positions_mm": []interface{}{1.1, 2.2, 3.3},
+		map[string]any{
+			"lengths_mm":   []any{4.4, 5.5, 6.6},
+			"positions_mm": []any{1.1, 2.2, 3.3},
 			"is_moving":    true,
 		},
 	)
@@ -57,10 +57,10 @@ func TestCreateStatus(t *testing.T) {
 	}
 
 	injectGantry := &inject.Gantry{}
-	injectGantry.PositionFunc = func(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+	injectGantry.PositionFunc = func(ctx context.Context, extra map[string]any) ([]float64, error) {
 		return status.PositionsMm, nil
 	}
-	injectGantry.LengthsFunc = func(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+	injectGantry.LengthsFunc = func(ctx context.Context, extra map[string]any) ([]float64, error) {
 		return status.LengthsMm, nil
 	}
 	injectGantry.IsMovingFunc = func(context.Context) (bool, error) {
@@ -97,7 +97,7 @@ func TestCreateStatus(t *testing.T) {
 
 	t.Run("fail on Lengths", func(t *testing.T) {
 		errFail := errors.New("can't get lengths")
-		injectGantry.LengthsFunc = func(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+		injectGantry.LengthsFunc = func(ctx context.Context, extra map[string]any) ([]float64, error) {
 			return nil, errFail
 		}
 		_, err := gantry.CreateStatus(context.Background(), injectGantry)
@@ -106,7 +106,7 @@ func TestCreateStatus(t *testing.T) {
 
 	t.Run("fail on Positions", func(t *testing.T) {
 		errFail := errors.New("can't get positions")
-		injectGantry.PositionFunc = func(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+		injectGantry.PositionFunc = func(ctx context.Context, extra map[string]any) ([]float64, error) {
 			return nil, errFail
 		}
 		_, err := gantry.CreateStatus(context.Background(), injectGantry)

--- a/components/gantry/multiaxis/multiaxis.go
+++ b/components/gantry/multiaxis/multiaxis.go
@@ -95,7 +95,7 @@ func newMultiAxis(
 }
 
 // Home runs the homing sequence of the gantry and returns true once completed.
-func (g *multiAxis) Home(ctx context.Context, extra map[string]interface{}) (bool, error) {
+func (g *multiAxis) Home(ctx context.Context, extra map[string]any) (bool, error) {
 	for _, subAx := range g.subAxes {
 		homed, err := subAx.Home(ctx, nil)
 		if err != nil {
@@ -109,7 +109,7 @@ func (g *multiAxis) Home(ctx context.Context, extra map[string]interface{}) (boo
 }
 
 // MoveToPosition moves along an axis using inputs in millimeters.
-func (g *multiAxis) MoveToPosition(ctx context.Context, positions, speeds []float64, extra map[string]interface{}) error {
+func (g *multiAxis) MoveToPosition(ctx context.Context, positions, speeds []float64, extra map[string]any) error {
 	ctx, done := g.opMgr.New(ctx)
 	defer done()
 
@@ -174,7 +174,7 @@ func (g *multiAxis) GoToInputs(ctx context.Context, goal []referenceframe.Input)
 }
 
 // Position returns the position in millimeters.
-func (g *multiAxis) Position(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+func (g *multiAxis) Position(ctx context.Context, extra map[string]any) ([]float64, error) {
 	positions := []float64{}
 	for _, subAx := range g.subAxes {
 		pos, err := subAx.Position(ctx, extra)
@@ -187,7 +187,7 @@ func (g *multiAxis) Position(ctx context.Context, extra map[string]interface{}) 
 }
 
 // Lengths returns the physical lengths of all axes of a multi-axis Gantry.
-func (g *multiAxis) Lengths(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+func (g *multiAxis) Lengths(ctx context.Context, extra map[string]any) ([]float64, error) {
 	lengths := []float64{}
 	for _, subAx := range g.subAxes {
 		lng, err := subAx.Lengths(ctx, extra)
@@ -200,7 +200,7 @@ func (g *multiAxis) Lengths(ctx context.Context, extra map[string]interface{}) (
 }
 
 // Stop stops the subaxes of the gantry simultaneously.
-func (g *multiAxis) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (g *multiAxis) Stop(ctx context.Context, extra map[string]any) error {
 	ctx, done := g.opMgr.New(ctx)
 	defer done()
 	for _, subAx := range g.subAxes {

--- a/components/gantry/multiaxis/multiaxis_test.go
+++ b/components/gantry/multiaxis/multiaxis_test.go
@@ -19,19 +19,19 @@ import (
 
 func createFakeOneaAxis(length float64, positions []float64) *inject.Gantry {
 	fakesingleaxis := inject.NewGantry("fake")
-	fakesingleaxis.PositionFunc = func(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+	fakesingleaxis.PositionFunc = func(ctx context.Context, extra map[string]any) ([]float64, error) {
 		return positions, nil
 	}
-	fakesingleaxis.MoveToPositionFunc = func(ctx context.Context, pos, speed []float64, extra map[string]interface{}) error {
+	fakesingleaxis.MoveToPositionFunc = func(ctx context.Context, pos, speed []float64, extra map[string]any) error {
 		return nil
 	}
-	fakesingleaxis.LengthsFunc = func(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+	fakesingleaxis.LengthsFunc = func(ctx context.Context, extra map[string]any) ([]float64, error) {
 		return []float64{length}, nil
 	}
-	fakesingleaxis.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	fakesingleaxis.StopFunc = func(ctx context.Context, extra map[string]any) error {
 		return nil
 	}
-	fakesingleaxis.HomeFunc = func(ctx context.Context, extra map[string]interface{}) (bool, error) {
+	fakesingleaxis.HomeFunc = func(ctx context.Context, extra map[string]any) (bool, error) {
 		return true, nil
 	}
 	fakesingleaxis.CloseFunc = func(ctx context.Context) error {
@@ -45,15 +45,15 @@ func createFakeOneaAxis(length float64, positions []float64) *inject.Gantry {
 
 func createFakeDeps() resource.Dependencies {
 	fakeGantry1 := inject.NewGantry("1")
-	fakeGantry1.LengthsFunc = func(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+	fakeGantry1.LengthsFunc = func(ctx context.Context, extra map[string]any) ([]float64, error) {
 		return []float64{1}, nil
 	}
 	fakeGantry2 := inject.NewGantry("2")
-	fakeGantry2.LengthsFunc = func(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+	fakeGantry2.LengthsFunc = func(ctx context.Context, extra map[string]any) ([]float64, error) {
 		return []float64{1}, nil
 	}
 	fakeGantry3 := inject.NewGantry("3")
-	fakeGantry3.LengthsFunc = func(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+	fakeGantry3.LengthsFunc = func(ctx context.Context, extra map[string]any) ([]float64, error) {
 		return []float64{1}, nil
 	}
 	fakeMotor := &fm.Motor{
@@ -323,10 +323,10 @@ func TestModelFrame(t *testing.T) {
 func createComplexDeps() resource.Dependencies {
 	position1 := []float64{6, 5}
 	mAx1 := inject.NewGantry("1")
-	mAx1.PositionFunc = func(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+	mAx1.PositionFunc = func(ctx context.Context, extra map[string]any) ([]float64, error) {
 		return position1, nil
 	}
-	mAx1.MoveToPositionFunc = func(ctx context.Context, pos, speeds []float64, extra map[string]interface{}) error {
+	mAx1.MoveToPositionFunc = func(ctx context.Context, pos, speeds []float64, extra map[string]any) error {
 		if move, _ := extra["move"].(bool); move {
 			position1[0] += pos[0]
 			position1[1] += pos[1]
@@ -334,19 +334,19 @@ func createComplexDeps() resource.Dependencies {
 
 		return nil
 	}
-	mAx1.LengthsFunc = func(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+	mAx1.LengthsFunc = func(ctx context.Context, extra map[string]any) ([]float64, error) {
 		return []float64{100, 101}, nil
 	}
-	mAx1.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	mAx1.StopFunc = func(ctx context.Context, extra map[string]any) error {
 		return nil
 	}
 
 	position2 := []float64{9, 8, 7}
 	mAx2 := inject.NewGantry("2")
-	mAx2.PositionFunc = func(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+	mAx2.PositionFunc = func(ctx context.Context, extra map[string]any) ([]float64, error) {
 		return position2, nil
 	}
-	mAx2.MoveToPositionFunc = func(ctx context.Context, pos, speeds []float64, extra map[string]interface{}) error {
+	mAx2.MoveToPositionFunc = func(ctx context.Context, pos, speeds []float64, extra map[string]any) error {
 		if move, _ := extra["move"].(bool); move {
 			position2[0] += pos[0]
 			position2[1] += pos[1]
@@ -354,10 +354,10 @@ func createComplexDeps() resource.Dependencies {
 		}
 		return nil
 	}
-	mAx2.LengthsFunc = func(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+	mAx2.LengthsFunc = func(ctx context.Context, extra map[string]any) ([]float64, error) {
 		return []float64{102, 103, 104}, nil
 	}
-	mAx2.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	mAx2.StopFunc = func(ctx context.Context, extra map[string]any) error {
 		return nil
 	}
 
@@ -405,7 +405,7 @@ func TestComplexMultiAxis(t *testing.T) {
 	t.Run(
 		"test that multiaxis moves and each subaxes moves correctly",
 		func(t *testing.T) {
-			extra := map[string]interface{}{"move": true}
+			extra := map[string]any{"move": true}
 			err = g.MoveToPosition(ctx, []float64{1, 2, 3, 4, 5}, []float64{100, 200, 300, 200, 100}, extra)
 			test.That(t, err, test.ShouldBeNil)
 

--- a/components/gantry/server.go
+++ b/components/gantry/server.go
@@ -20,7 +20,7 @@ type serviceServer struct {
 
 // NewRPCServiceServer constructs an gantry gRPC service server.
 // It is intentionally untyped to prevent use outside of tests.
-func NewRPCServiceServer(coll resource.APIResourceCollection[Gantry]) interface{} {
+func NewRPCServiceServer(coll resource.APIResourceCollection[Gantry]) any {
 	return &serviceServer{coll: coll}
 }
 

--- a/components/gantry/server_test.go
+++ b/components/gantry/server_test.go
@@ -47,48 +47,48 @@ func TestServer(t *testing.T) {
 	pos1 := []float64{1.0, 2.0, 3.0}
 	speed1 := []float64{100.0, 200.0, 300.0}
 	len1 := []float64{2.0, 3.0, 4.0}
-	extra1 := map[string]interface{}{}
-	injectGantry.PositionFunc = func(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+	extra1 := map[string]any{}
+	injectGantry.PositionFunc = func(ctx context.Context, extra map[string]any) ([]float64, error) {
 		extra1 = extra
 		return pos1, nil
 	}
-	injectGantry.HomeFunc = func(ctx context.Context, extra map[string]interface{}) (bool, error) {
+	injectGantry.HomeFunc = func(ctx context.Context, extra map[string]any) (bool, error) {
 		extra1 = extra
 		return true, nil
 	}
-	injectGantry.MoveToPositionFunc = func(ctx context.Context, pos, speed []float64, extra map[string]interface{}) error {
+	injectGantry.MoveToPositionFunc = func(ctx context.Context, pos, speed []float64, extra map[string]any) error {
 		gantryPos = pos
 		gantrySpeed = speed
 		extra1 = extra
 		return nil
 	}
-	injectGantry.LengthsFunc = func(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+	injectGantry.LengthsFunc = func(ctx context.Context, extra map[string]any) ([]float64, error) {
 		extra1 = extra
 		return len1, nil
 	}
-	injectGantry.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	injectGantry.StopFunc = func(ctx context.Context, extra map[string]any) error {
 		extra1 = extra
 		return nil
 	}
 
 	pos2 := []float64{4.0, 5.0, 6.0}
 	speed2 := []float64{100.0, 80.0, 120.0}
-	injectGantry2.PositionFunc = func(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+	injectGantry2.PositionFunc = func(ctx context.Context, extra map[string]any) ([]float64, error) {
 		return nil, errPositionFailed
 	}
-	injectGantry2.HomeFunc = func(ctx context.Context, extra map[string]interface{}) (bool, error) {
+	injectGantry2.HomeFunc = func(ctx context.Context, extra map[string]any) (bool, error) {
 		extra1 = extra
 		return false, errHomingFailed
 	}
-	injectGantry2.MoveToPositionFunc = func(ctx context.Context, pos, speed []float64, extra map[string]interface{}) error {
+	injectGantry2.MoveToPositionFunc = func(ctx context.Context, pos, speed []float64, extra map[string]any) error {
 		gantryPos = pos
 		gantrySpeed = speed
 		return errMoveToPositionFailed
 	}
-	injectGantry2.LengthsFunc = func(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+	injectGantry2.LengthsFunc = func(ctx context.Context, extra map[string]any) ([]float64, error) {
 		return nil, errLengthsFailed
 	}
-	injectGantry2.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	injectGantry2.StopFunc = func(ctx context.Context, extra map[string]any) error {
 		return errStopFailed
 	}
 
@@ -98,12 +98,12 @@ func TestServer(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errGantryNotFound.Error())
 
-		ext, err := protoutils.StructToStructPb(map[string]interface{}{"foo": "123", "bar": 234})
+		ext, err := protoutils.StructToStructPb(map[string]any{"foo": "123", "bar": 234})
 		test.That(t, err, test.ShouldBeNil)
 		resp, err := gantryServer.GetPosition(context.Background(), &pb.GetPositionRequest{Name: testGantryName, Extra: ext})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, resp.PositionsMm, test.ShouldResemble, pos1)
-		test.That(t, extra1, test.ShouldResemble, map[string]interface{}{"foo": "123", "bar": 234.})
+		test.That(t, extra1, test.ShouldResemble, map[string]any{"foo": "123", "bar": 234.})
 
 		_, err = gantryServer.GetPosition(context.Background(), &pb.GetPositionRequest{Name: failGantryName})
 		test.That(t, err, test.ShouldNotBeNil)
@@ -118,7 +118,7 @@ func TestServer(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errGantryNotFound.Error())
 
-		ext, err := protoutils.StructToStructPb(map[string]interface{}{"foo": "234", "bar": 345})
+		ext, err := protoutils.StructToStructPb(map[string]any{"foo": "234", "bar": 345})
 		test.That(t, err, test.ShouldBeNil)
 		_, err = gantryServer.MoveToPosition(
 			context.Background(),
@@ -127,7 +127,7 @@ func TestServer(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, gantryPos, test.ShouldResemble, pos2)
 		test.That(t, gantrySpeed, test.ShouldResemble, speed2)
-		test.That(t, extra1, test.ShouldResemble, map[string]interface{}{"foo": "234", "bar": 345.})
+		test.That(t, extra1, test.ShouldResemble, map[string]any{"foo": "234", "bar": 345.})
 
 		_, err = gantryServer.MoveToPosition(
 			context.Background(),
@@ -145,12 +145,12 @@ func TestServer(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errGantryNotFound.Error())
 
-		ext, err := protoutils.StructToStructPb(map[string]interface{}{"foo": 123, "bar": "234"})
+		ext, err := protoutils.StructToStructPb(map[string]any{"foo": 123, "bar": "234"})
 		test.That(t, err, test.ShouldBeNil)
 		resp, err := gantryServer.GetLengths(context.Background(), &pb.GetLengthsRequest{Name: testGantryName, Extra: ext})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, resp.LengthsMm, test.ShouldResemble, len1)
-		test.That(t, extra1, test.ShouldResemble, map[string]interface{}{"foo": 123., "bar": "234"})
+		test.That(t, extra1, test.ShouldResemble, map[string]any{"foo": 123., "bar": "234"})
 
 		_, err = gantryServer.GetLengths(context.Background(), &pb.GetLengthsRequest{Name: failGantryName})
 		test.That(t, err, test.ShouldNotBeNil)
@@ -162,12 +162,12 @@ func TestServer(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errGantryNotFound.Error())
 
-		ext, err := protoutils.StructToStructPb(map[string]interface{}{"foo": 123, "bar": "234"})
+		ext, err := protoutils.StructToStructPb(map[string]any{"foo": 123, "bar": "234"})
 		test.That(t, err, test.ShouldBeNil)
 		resp, err := gantryServer.Home(context.Background(), &pb.HomeRequest{Name: testGantryName, Extra: ext})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, resp.Homed, test.ShouldBeTrue)
-		test.That(t, extra1, test.ShouldResemble, map[string]interface{}{"foo": 123., "bar": "234"})
+		test.That(t, extra1, test.ShouldResemble, map[string]any{"foo": 123., "bar": "234"})
 
 		resp, err = gantryServer.Home(context.Background(), &pb.HomeRequest{Name: failGantryName})
 		test.That(t, err, test.ShouldNotBeNil)
@@ -180,11 +180,11 @@ func TestServer(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errGantryNotFound.Error())
 
-		ext, err := protoutils.StructToStructPb(map[string]interface{}{"foo": 234, "bar": "123"})
+		ext, err := protoutils.StructToStructPb(map[string]any{"foo": 234, "bar": "123"})
 		test.That(t, err, test.ShouldBeNil)
 		_, err = gantryServer.Stop(context.Background(), &pb.StopRequest{Name: testGantryName, Extra: ext})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, extra1, test.ShouldResemble, map[string]interface{}{"foo": 234., "bar": "123"})
+		test.That(t, extra1, test.ShouldResemble, map[string]any{"foo": 234., "bar": "123"})
 
 		_, err = gantryServer.Stop(context.Background(), &pb.StopRequest{Name: failGantryName})
 		test.That(t, err, test.ShouldNotBeNil)

--- a/components/gantry/singleaxis/singleaxis.go
+++ b/components/gantry/singleaxis/singleaxis.go
@@ -231,7 +231,7 @@ func (g *singleAxis) Reconfigure(ctx context.Context, deps resource.Dependencies
 }
 
 // Home runs the homing sequence of the gantry, starts checkHit in the background, and returns true once completed.
-func (g *singleAxis) Home(ctx context.Context, extra map[string]interface{}) (bool, error) {
+func (g *singleAxis) Home(ctx context.Context, extra map[string]any) (bool, error) {
 	if g.cancelFunc != nil {
 		g.cancelFunc()
 		g.activeBackgroundWorkers.Wait()
@@ -494,7 +494,7 @@ func (g *singleAxis) limitHit(ctx context.Context, limitPin int) (bool, error) {
 }
 
 // Position returns the position in millimeters.
-func (g *singleAxis) Position(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+func (g *singleAxis) Position(ctx context.Context, extra map[string]any) ([]float64, error) {
 	pos, err := g.motor.Position(ctx, extra)
 	if err != nil {
 		return []float64{}, err
@@ -506,14 +506,14 @@ func (g *singleAxis) Position(ctx context.Context, extra map[string]interface{})
 }
 
 // Lengths returns the physical lengths of an axis of a Gantry.
-func (g *singleAxis) Lengths(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+func (g *singleAxis) Lengths(ctx context.Context, extra map[string]any) ([]float64, error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	return []float64{g.lengthMm}, nil
 }
 
 // MoveToPosition moves along an axis using inputs in millimeters.
-func (g *singleAxis) MoveToPosition(ctx context.Context, positions, speeds []float64, extra map[string]interface{}) error {
+func (g *singleAxis) MoveToPosition(ctx context.Context, positions, speeds []float64, extra map[string]any) error {
 	if g.positionRange == 0 {
 		return errors.Errorf("cannot move to position until gantry '%v' is homed", g.Named.Name().ShortName())
 	}
@@ -568,7 +568,7 @@ func (g *singleAxis) MoveToPosition(ctx context.Context, positions, speeds []flo
 }
 
 // Stop stops the motor of the gantry.
-func (g *singleAxis) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (g *singleAxis) Stop(ctx context.Context, extra map[string]any) error {
 	ctx, done := g.opMgr.New(ctx)
 	defer done()
 	return g.motor.Stop(ctx, extra)

--- a/components/generic/client.go
+++ b/components/generic/client.go
@@ -40,7 +40,7 @@ func NewClientFromConn(
 	}, nil
 }
 
-func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (c *client) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	command, err := protoutils.StructToStructPb(cmd)
 	if err != nil {
 		return nil, err

--- a/components/generic/client_test.go
+++ b/components/generic/client_test.go
@@ -34,9 +34,9 @@ func TestClient(t *testing.T) {
 	workingGeneric.DoFunc = testutils.EchoFunc
 	failingGeneric.DoFunc = func(
 		ctx context.Context,
-		cmd map[string]interface{},
+		cmd map[string]any,
 	) (
-		map[string]interface{},
+		map[string]any,
 		error,
 	) {
 		return nil, errDoFailed

--- a/components/generic/fake/fake_test.go
+++ b/components/generic/fake/fake_test.go
@@ -15,7 +15,7 @@ func TestDoCommand(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 
 	gen := newGeneric(generic.Named("foo"), logger)
-	cmd := map[string]interface{}{"bar": "baz"}
+	cmd := map[string]any{"bar": "baz"}
 	resp, err := gen.DoCommand(ctx, cmd)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, resp, test.ShouldResemble, cmd)

--- a/components/generic/fake/generic.go
+++ b/components/generic/fake/generic.go
@@ -36,6 +36,6 @@ type Generic struct {
 }
 
 // DoCommand echos input back to the caller.
-func (fg *Generic) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (fg *Generic) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	return cmd, nil
 }

--- a/components/generic/server.go
+++ b/components/generic/server.go
@@ -18,7 +18,7 @@ type serviceServer struct {
 }
 
 // NewRPCServiceServer constructs an generic gRPC service serviceServer.
-func NewRPCServiceServer(coll resource.APIResourceCollection[resource.Resource]) interface{} {
+func NewRPCServiceServer(coll resource.APIResourceCollection[resource.Resource]) any {
 	return &serviceServer{coll: coll}
 }
 

--- a/components/generic/server_test.go
+++ b/components/generic/server_test.go
@@ -38,18 +38,18 @@ func TestGenericDo(t *testing.T) {
 
 	workingGeneric.DoFunc = func(
 		ctx context.Context,
-		cmd map[string]interface{},
+		cmd map[string]any,
 	) (
-		map[string]interface{},
+		map[string]any,
 		error,
 	) {
 		return cmd, nil
 	}
 	failingGeneric.DoFunc = func(
 		ctx context.Context,
-		cmd map[string]interface{},
+		cmd map[string]any,
 	) (
-		map[string]interface{},
+		map[string]any,
 		error,
 	) {
 		return nil, errDoFailed

--- a/components/gripper/client.go
+++ b/components/gripper/client.go
@@ -43,7 +43,7 @@ func NewClientFromConn(
 	}, nil
 }
 
-func (c *client) Open(ctx context.Context, extra map[string]interface{}) error {
+func (c *client) Open(ctx context.Context, extra map[string]any) error {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return err
@@ -55,7 +55,7 @@ func (c *client) Open(ctx context.Context, extra map[string]interface{}) error {
 	return err
 }
 
-func (c *client) Grab(ctx context.Context, extra map[string]interface{}) (bool, error) {
+func (c *client) Grab(ctx context.Context, extra map[string]any) (bool, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return false, err
@@ -70,7 +70,7 @@ func (c *client) Grab(ctx context.Context, extra map[string]interface{}) (bool, 
 	return resp.Success, nil
 }
 
-func (c *client) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (c *client) Stop(ctx context.Context, extra map[string]any) error {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return err
@@ -87,7 +87,7 @@ func (c *client) ModelFrame() referenceframe.Model {
 	return nil
 }
 
-func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (c *client) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	return rprotoutils.DoFromResourceClient(ctx, c.client, c.name, cmd)
 }
 
@@ -99,7 +99,7 @@ func (c *client) IsMoving(ctx context.Context) (bool, error) {
 	return resp.IsMoving, nil
 }
 
-func (c *client) Geometries(ctx context.Context, extra map[string]interface{}) ([]spatialmath.Geometry, error) {
+func (c *client) Geometries(ctx context.Context, extra map[string]any) ([]spatialmath.Geometry, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return nil, err

--- a/components/gripper/client_test.go
+++ b/components/gripper/client_test.go
@@ -24,33 +24,33 @@ func TestClient(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	var gripperOpen string
-	var extraOptions map[string]interface{}
+	var extraOptions map[string]any
 
 	grabbed1 := true
 	injectGripper := &inject.Gripper{}
-	injectGripper.OpenFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	injectGripper.OpenFunc = func(ctx context.Context, extra map[string]any) error {
 		extraOptions = extra
 		gripperOpen = testGripperName
 		return nil
 	}
-	injectGripper.GrabFunc = func(ctx context.Context, extra map[string]interface{}) (bool, error) {
+	injectGripper.GrabFunc = func(ctx context.Context, extra map[string]any) (bool, error) {
 		extraOptions = extra
 		return grabbed1, nil
 	}
-	injectGripper.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	injectGripper.StopFunc = func(ctx context.Context, extra map[string]any) error {
 		extraOptions = extra
 		return nil
 	}
 
 	injectGripper2 := &inject.Gripper{}
-	injectGripper2.OpenFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	injectGripper2.OpenFunc = func(ctx context.Context, extra map[string]any) error {
 		gripperOpen = failGripperName
 		return errCantOpen
 	}
-	injectGripper2.GrabFunc = func(ctx context.Context, extra map[string]interface{}) (bool, error) {
+	injectGripper2.GrabFunc = func(ctx context.Context, extra map[string]any) (bool, error) {
 		return false, errCantGrab
 	}
-	injectGripper2.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	injectGripper2.StopFunc = func(ctx context.Context, extra map[string]any) error {
 		return errStopUnimplemented
 	}
 
@@ -90,19 +90,19 @@ func TestClient(t *testing.T) {
 		test.That(t, resp["command"], test.ShouldEqual, testutils.TestCommand["command"])
 		test.That(t, resp["data"], test.ShouldEqual, testutils.TestCommand["data"])
 
-		extra := map[string]interface{}{"foo": "Open"}
+		extra := map[string]any{"foo": "Open"}
 		err = gripper1Client.Open(context.Background(), extra)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, extraOptions, test.ShouldResemble, extra)
 		test.That(t, gripperOpen, test.ShouldEqual, testGripperName)
 
-		extra = map[string]interface{}{"foo": "Grab"}
+		extra = map[string]any{"foo": "Grab"}
 		grabbed, err := gripper1Client.Grab(context.Background(), extra)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, extraOptions, test.ShouldResemble, extra)
 		test.That(t, grabbed, test.ShouldEqual, grabbed1)
 
-		extra = map[string]interface{}{"foo": "Stop"}
+		extra = map[string]any{"foo": "Stop"}
 		test.That(t, gripper1Client.Stop(context.Background(), extra), test.ShouldBeNil)
 		test.That(t, extraOptions, test.ShouldResemble, extra)
 
@@ -117,7 +117,7 @@ func TestClient(t *testing.T) {
 		client2, err := resourceAPI.RPCClient(context.Background(), conn, "", gripper.Named(failGripperName), logger)
 		test.That(t, err, test.ShouldBeNil)
 
-		extra := map[string]interface{}{}
+		extra := map[string]any{}
 		err = client2.Open(context.Background(), extra)
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errCantOpen.Error())

--- a/components/gripper/fake/gripper.go
+++ b/components/gripper/fake/gripper.go
@@ -68,17 +68,17 @@ func (g *Gripper) ModelFrame() referenceframe.Model {
 }
 
 // Open does nothing.
-func (g *Gripper) Open(ctx context.Context, extra map[string]interface{}) error {
+func (g *Gripper) Open(ctx context.Context, extra map[string]any) error {
 	return nil
 }
 
 // Grab does nothing.
-func (g *Gripper) Grab(ctx context.Context, extra map[string]interface{}) (bool, error) {
+func (g *Gripper) Grab(ctx context.Context, extra map[string]any) (bool, error) {
 	return false, nil
 }
 
 // Stop doesn't do anything for a fake gripper.
-func (g *Gripper) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (g *Gripper) Stop(ctx context.Context, extra map[string]any) error {
 	return nil
 }
 
@@ -88,7 +88,7 @@ func (g *Gripper) IsMoving(ctx context.Context) (bool, error) {
 }
 
 // Geometries returns the geometries associated with the fake base.
-func (g *Gripper) Geometries(ctx context.Context, extra map[string]interface{}) ([]spatialmath.Geometry, error) {
+func (g *Gripper) Geometries(ctx context.Context, extra map[string]any) ([]spatialmath.Geometry, error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	return g.geometries, nil

--- a/components/gripper/gripper.go
+++ b/components/gripper/gripper.go
@@ -42,12 +42,12 @@ type Gripper interface {
 
 	// Open opens the gripper.
 	// This will block until done or a new operation cancels this one
-	Open(ctx context.Context, extra map[string]interface{}) error
+	Open(ctx context.Context, extra map[string]any) error
 
 	// Grab makes the gripper grab.
 	// returns true if we grabbed something.
 	// This will block until done or a new operation cancels this one
-	Grab(ctx context.Context, extra map[string]interface{}) (bool, error)
+	Grab(ctx context.Context, extra map[string]any) (bool, error)
 }
 
 // FromRobot is a helper for getting the named Gripper from the given Robot.

--- a/components/gripper/robotiq/gripper.go
+++ b/components/gripper/robotiq/gripper.go
@@ -214,7 +214,7 @@ func (g *robotiqGripper) SetPos(ctx context.Context, pos string) (bool, error) {
 }
 
 // Open TODO.
-func (g *robotiqGripper) Open(ctx context.Context, extra map[string]interface{}) error {
+func (g *robotiqGripper) Open(ctx context.Context, extra map[string]any) error {
 	ctx, done := g.opMgr.New(ctx)
 	defer done()
 
@@ -232,7 +232,7 @@ func (g *robotiqGripper) Close(ctx context.Context) error {
 }
 
 // Grab returns true iff grabbed something.
-func (g *robotiqGripper) Grab(ctx context.Context, extra map[string]interface{}) (bool, error) {
+func (g *robotiqGripper) Grab(ctx context.Context, extra map[string]any) (bool, error) {
 	ctx, done := g.opMgr.New(ctx)
 	defer done()
 
@@ -255,7 +255,7 @@ func (g *robotiqGripper) Grab(ctx context.Context, extra map[string]interface{})
 
 // Calibrate TODO.
 func (g *robotiqGripper) Calibrate(ctx context.Context) error {
-	err := g.Open(ctx, map[string]interface{}{})
+	err := g.Open(ctx, map[string]any{})
 	if err != nil {
 		return err
 	}
@@ -282,7 +282,7 @@ func (g *robotiqGripper) Calibrate(ctx context.Context) error {
 }
 
 // Stop is unimplemented for robotiqGripper.
-func (g *robotiqGripper) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (g *robotiqGripper) Stop(ctx context.Context, extra map[string]any) error {
 	// RSDK-388: Implement Stop
 	err := g.Set("GTO", "0")
 	if err != nil {
@@ -302,6 +302,6 @@ func (g *robotiqGripper) ModelFrame() referenceframe.Model {
 }
 
 // Geometries returns the geometries associated with robotiqGripper.
-func (g *robotiqGripper) Geometries(ctx context.Context, extra map[string]interface{}) ([]spatialmath.Geometry, error) {
+func (g *robotiqGripper) Geometries(ctx context.Context, extra map[string]any) ([]spatialmath.Geometry, error) {
 	return g.geometries, nil
 }

--- a/components/gripper/server.go
+++ b/components/gripper/server.go
@@ -21,7 +21,7 @@ type serviceServer struct {
 
 // NewRPCServiceServer constructs an gripper gRPC service server.
 // It is intentionally untyped to prevent use outside of tests.
-func NewRPCServiceServer(coll resource.APIResourceCollection[Gripper]) interface{} {
+func NewRPCServiceServer(coll resource.APIResourceCollection[Gripper]) any {
 	return &serviceServer{coll: coll}
 }
 

--- a/components/gripper/server_test.go
+++ b/components/gripper/server_test.go
@@ -40,31 +40,31 @@ func TestServer(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	var gripperOpen string
-	var extraOptions map[string]interface{}
+	var extraOptions map[string]any
 
 	success1 := true
-	injectGripper.OpenFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	injectGripper.OpenFunc = func(ctx context.Context, extra map[string]any) error {
 		extraOptions = extra
 		gripperOpen = testGripperName
 		return nil
 	}
-	injectGripper.GrabFunc = func(ctx context.Context, extra map[string]interface{}) (bool, error) {
+	injectGripper.GrabFunc = func(ctx context.Context, extra map[string]any) (bool, error) {
 		extraOptions = extra
 		return success1, nil
 	}
-	injectGripper.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	injectGripper.StopFunc = func(ctx context.Context, extra map[string]any) error {
 		extraOptions = extra
 		return nil
 	}
 
-	injectGripper2.OpenFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	injectGripper2.OpenFunc = func(ctx context.Context, extra map[string]any) error {
 		gripperOpen = testGripperName2
 		return errCantOpen
 	}
-	injectGripper2.GrabFunc = func(ctx context.Context, extra map[string]interface{}) (bool, error) {
+	injectGripper2.GrabFunc = func(ctx context.Context, extra map[string]any) (bool, error) {
 		return false, errCantGrab
 	}
-	injectGripper2.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	injectGripper2.StopFunc = func(ctx context.Context, extra map[string]any) error {
 		return errStopUnimplemented
 	}
 
@@ -73,7 +73,7 @@ func TestServer(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errGripperNotFound.Error())
 
-		extra := map[string]interface{}{"foo": "Open"}
+		extra := map[string]any{"foo": "Open"}
 		ext, err := protoutils.StructToStructPb(extra)
 		test.That(t, err, test.ShouldBeNil)
 		_, err = gripperServer.Open(context.Background(), &pb.OpenRequest{Name: testGripperName, Extra: ext})
@@ -92,7 +92,7 @@ func TestServer(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errGripperNotFound.Error())
 
-		extra := map[string]interface{}{"foo": "Grab"}
+		extra := map[string]any{"foo": "Grab"}
 		ext, err := protoutils.StructToStructPb(extra)
 		test.That(t, err, test.ShouldBeNil)
 		resp, err := gripperServer.Grab(context.Background(), &pb.GrabRequest{Name: testGripperName, Extra: ext})
@@ -111,7 +111,7 @@ func TestServer(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errGripperNotFound.Error())
 
-		extra := map[string]interface{}{"foo": "Stop"}
+		extra := map[string]any{"foo": "Stop"}
 		ext, err := protoutils.StructToStructPb(extra)
 		test.That(t, err, test.ShouldBeNil)
 		_, err = gripperServer.Stop(context.Background(), &pb.StopRequest{Name: testGripperName, Extra: ext})

--- a/components/gripper/softrobotics/gripper.go
+++ b/components/gripper/softrobotics/gripper.go
@@ -141,7 +141,7 @@ func newGripper(b board.Board, conf resource.Config, logger logging.Logger) (gri
 }
 
 // Stop TODO.
-func (g *softGripper) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (g *softGripper) Stop(ctx context.Context, extra map[string]any) error {
 	ctx, done := g.opMgr.New(ctx)
 	defer done()
 	return multierr.Combine(
@@ -152,7 +152,7 @@ func (g *softGripper) Stop(ctx context.Context, extra map[string]interface{}) er
 }
 
 // Open TODO.
-func (g *softGripper) Open(ctx context.Context, extra map[string]interface{}) error {
+func (g *softGripper) Open(ctx context.Context, extra map[string]any) error {
 	ctx, done := g.opMgr.New(ctx)
 	defer done()
 
@@ -187,7 +187,7 @@ func (g *softGripper) Open(ctx context.Context, extra map[string]interface{}) er
 }
 
 // Grab TODO.
-func (g *softGripper) Grab(ctx context.Context, extra map[string]interface{}) (bool, error) {
+func (g *softGripper) Grab(ctx context.Context, extra map[string]any) (bool, error) {
 	ctx, done := g.opMgr.New(ctx)
 	defer done()
 
@@ -232,6 +232,6 @@ func (g *softGripper) ModelFrame() referenceframe.Model {
 }
 
 // Geometries returns the geometries associated with the softGripper.
-func (g *softGripper) Geometries(ctx context.Context, extra map[string]interface{}) ([]spatialmath.Geometry, error) {
+func (g *softGripper) Geometries(ctx context.Context, extra map[string]any) ([]spatialmath.Geometry, error) {
 	return g.geometries, nil
 }

--- a/components/input/client.go
+++ b/components/input/client.go
@@ -60,7 +60,7 @@ func NewClientFromConn(
 	}, nil
 }
 
-func (c *client) Controls(ctx context.Context, extra map[string]interface{}) ([]Control, error) {
+func (c *client) Controls(ctx context.Context, extra map[string]any) ([]Control, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return nil, err
@@ -79,7 +79,7 @@ func (c *client) Controls(ctx context.Context, extra map[string]interface{}) ([]
 	return controls, nil
 }
 
-func (c *client) Events(ctx context.Context, extra map[string]interface{}) (map[Control]Event, error) {
+func (c *client) Events(ctx context.Context, extra map[string]any) (map[Control]Event, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return nil, err
@@ -105,7 +105,7 @@ func (c *client) Events(ctx context.Context, extra map[string]interface{}) (map[
 }
 
 // TriggerEvent allows directly sending an Event (such as a button press) from external code.
-func (c *client) TriggerEvent(ctx context.Context, event Event, extra map[string]interface{}) error {
+func (c *client) TriggerEvent(ctx context.Context, event Event, extra map[string]any) error {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return err
@@ -131,7 +131,7 @@ func (c *client) RegisterControlCallback(
 	control Control,
 	triggers []EventType,
 	ctrlFunc ControlFunction,
-	extra map[string]interface{},
+	extra map[string]any,
 ) error {
 	c.mu.Lock()
 	if c.callbacks == nil {
@@ -367,6 +367,6 @@ func (c *client) Close(ctx context.Context) error {
 	return nil
 }
 
-func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (c *client) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	return rprotoutils.DoFromResourceClient(ctx, c.client, c.name, cmd)
 }

--- a/components/input/fake/input.go
+++ b/components/input/fake/input.go
@@ -112,7 +112,7 @@ func (c *InputController) Reconfigure(ctx context.Context, deps resource.Depende
 }
 
 // Controls lists the inputs of the gamepad.
-func (c *InputController) Controls(ctx context.Context, extra map[string]interface{}) ([]input.Control, error) {
+func (c *InputController) Controls(ctx context.Context, extra map[string]any) ([]input.Control, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if len(c.controls) == 0 {
@@ -130,7 +130,7 @@ func (c *InputController) eventVal() float64 {
 }
 
 // Events returns the a specified or random input.Event (the current state) for AbsoluteX.
-func (c *InputController) Events(ctx context.Context, extra map[string]interface{}) (map[input.Control]input.Event, error) {
+func (c *InputController) Events(ctx context.Context, extra map[string]any) (map[input.Control]input.Event, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	eventsOut := make(map[input.Control]input.Event)
@@ -146,7 +146,7 @@ func (c *InputController) RegisterControlCallback(
 	control input.Control,
 	triggers []input.EventType,
 	ctrlFunc input.ControlFunction,
-	extra map[string]interface{},
+	extra map[string]any,
 ) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -194,7 +194,7 @@ func (c *InputController) startCallbackLoop() {
 }
 
 // TriggerEvent allows directly sending an Event (such as a button press) from external code.
-func (c *InputController) TriggerEvent(ctx context.Context, event input.Event, extra map[string]interface{}) error {
+func (c *InputController) TriggerEvent(ctx context.Context, event input.Event, extra map[string]any) error {
 	return errors.New("unsupported")
 }
 

--- a/components/input/gamepad/gamepad_linux.go
+++ b/components/input/gamepad/gamepad_linux.go
@@ -371,7 +371,7 @@ func (g *gamepad) Close(ctx context.Context) error {
 }
 
 // Controls lists the inputs of the gamepad.
-func (g *gamepad) Controls(ctx context.Context, extra map[string]interface{}) ([]input.Control, error) {
+func (g *gamepad) Controls(ctx context.Context, extra map[string]any) ([]input.Control, error) {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
 	if g.dev == nil && len(g.controls) == 0 {
@@ -382,7 +382,7 @@ func (g *gamepad) Controls(ctx context.Context, extra map[string]interface{}) ([
 }
 
 // Events returns the last input.Event (the current state).
-func (g *gamepad) Events(ctx context.Context, extra map[string]interface{}) (map[input.Control]input.Event, error) {
+func (g *gamepad) Events(ctx context.Context, extra map[string]any) (map[input.Control]input.Event, error) {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
 	out := make(map[input.Control]input.Event)
@@ -398,7 +398,7 @@ func (g *gamepad) RegisterControlCallback(
 	control input.Control,
 	triggers []input.EventType,
 	ctrlFunc input.ControlFunction,
-	extra map[string]interface{},
+	extra map[string]any,
 ) error {
 	g.mu.Lock()
 	defer g.mu.Unlock()

--- a/components/input/gpio/gpio.go
+++ b/components/input/gpio/gpio.go
@@ -149,7 +149,7 @@ type Controller struct {
 }
 
 // Controls lists the inputs.
-func (c *Controller) Controls(ctx context.Context, extra map[string]interface{}) ([]input.Control, error) {
+func (c *Controller) Controls(ctx context.Context, extra map[string]any) ([]input.Control, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	out := append([]input.Control(nil), c.controls...)
@@ -157,7 +157,7 @@ func (c *Controller) Controls(ctx context.Context, extra map[string]interface{})
 }
 
 // Events returns the last input.Event (the current state) of each control.
-func (c *Controller) Events(ctx context.Context, extra map[string]interface{}) (map[input.Control]input.Event, error) {
+func (c *Controller) Events(ctx context.Context, extra map[string]any) (map[input.Control]input.Event, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	out := make(map[input.Control]input.Event)
@@ -173,7 +173,7 @@ func (c *Controller) RegisterControlCallback(
 	control input.Control,
 	triggers []input.EventType,
 	ctrlFunc input.ControlFunction,
-	extra map[string]interface{},
+	extra map[string]any,
 ) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/components/input/gpio/gpio_test.go
+++ b/components/input/gpio/gpio_test.go
@@ -116,7 +116,7 @@ func setup(t *testing.T) *setupResult {
 		func(ctx context.Context, event input.Event) {
 			atomic.AddInt64(&s.btn1Callbacks, 1)
 		},
-		map[string]interface{}{},
+		map[string]any{},
 	)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -124,7 +124,7 @@ func setup(t *testing.T) *setupResult {
 		func(ctx context.Context, event input.Event) {
 			atomic.AddInt64(&s.btn2Callbacks, 1)
 		},
-		map[string]interface{}{},
+		map[string]any{},
 	)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -135,7 +135,7 @@ func setup(t *testing.T) *setupResult {
 			s.axisMu.Unlock()
 			atomic.AddInt64(&s.axis1Callbacks, 1)
 		},
-		map[string]interface{}{},
+		map[string]any{},
 	)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -146,7 +146,7 @@ func setup(t *testing.T) *setupResult {
 			s.axisMu.Unlock()
 			atomic.AddInt64(&s.axis2Callbacks, 1)
 		},
-		map[string]interface{}{},
+		map[string]any{},
 	)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -154,7 +154,7 @@ func setup(t *testing.T) *setupResult {
 		func(ctx context.Context, event input.Event) {
 			atomic.AddInt64(&s.axis3Callbacks, 1)
 		},
-		map[string]interface{}{},
+		map[string]any{},
 	)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -247,7 +247,7 @@ func TestGPIOInput(t *testing.T) {
 		defer teardown(t, s)
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			state, err := (s.dev).Events(s.ctx, map[string]interface{}{})
+			state, err := (s.dev).Events(s.ctx, map[string]any{})
 			test.That(tb, err, test.ShouldBeNil)
 			test.That(tb, state["ButtonNorth"].Value, test.ShouldEqual, 0)
 			test.That(tb, state["ButtonNorth"].Event, test.ShouldEqual, input.Connect)
@@ -266,7 +266,7 @@ func TestGPIOInput(t *testing.T) {
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			state, err := s.dev.Events(s.ctx, map[string]interface{}{})
+			state, err := s.dev.Events(s.ctx, map[string]any{})
 			test.That(tb, err, test.ShouldBeNil)
 			test.That(tb, state["ButtonNorth"].Value, test.ShouldEqual, 1)
 			test.That(tb, state["ButtonNorth"].Event, test.ShouldEqual, input.ButtonPress)
@@ -278,7 +278,7 @@ func TestGPIOInput(t *testing.T) {
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			state, err := s.dev.Events(s.ctx, map[string]interface{}{})
+			state, err := s.dev.Events(s.ctx, map[string]any{})
 			test.That(tb, err, test.ShouldBeNil)
 			test.That(tb, state["ButtonNorth"].Value, test.ShouldEqual, 0)
 			test.That(tb, state["ButtonNorth"].Event, test.ShouldEqual, input.ButtonRelease)
@@ -302,7 +302,7 @@ func TestGPIOInput(t *testing.T) {
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			state, err := s.dev.Events(s.ctx, map[string]interface{}{})
+			state, err := s.dev.Events(s.ctx, map[string]any{})
 			test.That(tb, err, test.ShouldBeNil)
 			test.That(tb, state["ButtonNorth"].Value, test.ShouldEqual, 1)
 			test.That(tb, state["ButtonNorth"].Event, test.ShouldEqual, input.ButtonPress)
@@ -323,7 +323,7 @@ func TestGPIOInput(t *testing.T) {
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			state, err := s.dev.Events(s.ctx, map[string]interface{}{})
+			state, err := s.dev.Events(s.ctx, map[string]any{})
 			test.That(tb, err, test.ShouldBeNil)
 			test.That(tb, state["ButtonSouth"].Value, test.ShouldEqual, 0)
 			test.That(tb, state["ButtonSouth"].Event, test.ShouldEqual, input.ButtonRelease)
@@ -335,7 +335,7 @@ func TestGPIOInput(t *testing.T) {
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			state, err := s.dev.Events(s.ctx, map[string]interface{}{})
+			state, err := s.dev.Events(s.ctx, map[string]any{})
 			test.That(tb, err, test.ShouldBeNil)
 			test.That(tb, state["ButtonSouth"].Value, test.ShouldEqual, 1)
 			test.That(tb, state["ButtonSouth"].Event, test.ShouldEqual, input.ButtonPress)
@@ -358,7 +358,7 @@ func TestGPIOInput(t *testing.T) {
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			state, err := s.dev.Events(s.ctx, map[string]interface{}{})
+			state, err := s.dev.Events(s.ctx, map[string]any{})
 			test.That(tb, err, test.ShouldBeNil)
 			test.That(tb, state["ButtonSouth"].Value, test.ShouldEqual, 1)
 			test.That(tb, state["ButtonSouth"].Event, test.ShouldEqual, input.ButtonPress)
@@ -375,7 +375,7 @@ func TestGPIOInput(t *testing.T) {
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			state, err := s.dev.Events(s.ctx, map[string]interface{}{})
+			state, err := s.dev.Events(s.ctx, map[string]any{})
 			test.That(tb, err, test.ShouldBeNil)
 			test.That(tb, state["AbsoluteX"].Value, test.ShouldAlmostEqual, 0, 0.005)
 			test.That(tb, state["AbsoluteX"].Event, test.ShouldEqual, input.Connect)
@@ -385,7 +385,7 @@ func TestGPIOInput(t *testing.T) {
 		s.b.AnalogReaders["analog1"].Set(1023)
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			state, err := s.dev.Events(s.ctx, map[string]interface{}{})
+			state, err := s.dev.Events(s.ctx, map[string]any{})
 			test.That(tb, err, test.ShouldBeNil)
 			test.That(tb, state["AbsoluteX"].Value, test.ShouldAlmostEqual, 1, 0.005)
 			test.That(tb, state["AbsoluteX"].Event, test.ShouldEqual, input.PositionChangeAbs)
@@ -395,7 +395,7 @@ func TestGPIOInput(t *testing.T) {
 		s.b.AnalogReaders["analog1"].Set(511)
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			state, err := s.dev.Events(s.ctx, map[string]interface{}{})
+			state, err := s.dev.Events(s.ctx, map[string]any{})
 			test.That(tb, err, test.ShouldBeNil)
 			test.That(tb, state["AbsoluteX"].Value, test.ShouldAlmostEqual, 0.5, 0.005)
 			test.That(tb, state["AbsoluteX"].Event, test.ShouldEqual, input.PositionChangeAbs)
@@ -410,7 +410,7 @@ func TestGPIOInput(t *testing.T) {
 		s.b.AnalogReaders["analog2"].Set(511)
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			state, err := s.dev.Events(s.ctx, map[string]interface{}{})
+			state, err := s.dev.Events(s.ctx, map[string]any{})
 			test.That(tb, err, test.ShouldBeNil)
 			test.That(tb, state["AbsoluteY"].Value, test.ShouldAlmostEqual, 0, 0.005)
 			test.That(tb, state["AbsoluteY"].Event, test.ShouldEqual, input.PositionChangeAbs)
@@ -420,7 +420,7 @@ func TestGPIOInput(t *testing.T) {
 		s.b.AnalogReaders["analog2"].Set(511 + 20)
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			state, err := s.dev.Events(s.ctx, map[string]interface{}{})
+			state, err := s.dev.Events(s.ctx, map[string]any{})
 			test.That(tb, err, test.ShouldBeNil)
 			test.That(tb, state["AbsoluteY"].Value, test.ShouldAlmostEqual, 0.04, 0.005)
 			test.That(tb, state["AbsoluteY"].Event, test.ShouldEqual, input.PositionChangeAbs)
@@ -430,7 +430,7 @@ func TestGPIOInput(t *testing.T) {
 		s.b.AnalogReaders["analog2"].Set(511 - 20)
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			state, err := s.dev.Events(s.ctx, map[string]interface{}{})
+			state, err := s.dev.Events(s.ctx, map[string]any{})
 			test.That(tb, err, test.ShouldBeNil)
 			test.That(tb, state["AbsoluteY"].Value, test.ShouldAlmostEqual, -0.04, 0.005)
 			test.That(tb, state["AbsoluteY"].Event, test.ShouldEqual, input.PositionChangeAbs)
@@ -440,7 +440,7 @@ func TestGPIOInput(t *testing.T) {
 		s.b.AnalogReaders["analog2"].Set(511 + 19)
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			state, err := s.dev.Events(s.ctx, map[string]interface{}{})
+			state, err := s.dev.Events(s.ctx, map[string]any{})
 			test.That(tb, err, test.ShouldBeNil)
 			test.That(tb, state["AbsoluteY"].Value, test.ShouldAlmostEqual, 0, 0.005)
 			test.That(tb, state["AbsoluteY"].Event, test.ShouldEqual, input.PositionChangeAbs)
@@ -450,7 +450,7 @@ func TestGPIOInput(t *testing.T) {
 		s.b.AnalogReaders["analog2"].Set(511 - 19)
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			state, err := s.dev.Events(s.ctx, map[string]interface{}{})
+			state, err := s.dev.Events(s.ctx, map[string]any{})
 			test.That(tb, err, test.ShouldBeNil)
 			test.That(tb, state["AbsoluteY"].Value, test.ShouldAlmostEqual, 0, 0.005)
 			test.That(tb, state["AbsoluteY"].Event, test.ShouldEqual, input.PositionChangeAbs)
@@ -465,7 +465,7 @@ func TestGPIOInput(t *testing.T) {
 		s.b.AnalogReaders["analog2"].Set(600)
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			state, err := s.dev.Events(s.ctx, map[string]interface{}{})
+			state, err := s.dev.Events(s.ctx, map[string]any{})
 			test.That(tb, err, test.ShouldBeNil)
 			test.That(tb, state["AbsoluteY"].Value, test.ShouldAlmostEqual, 0.17, 0.005)
 			test.That(tb, state["AbsoluteY"].Event, test.ShouldEqual, input.PositionChangeAbs)
@@ -476,7 +476,7 @@ func TestGPIOInput(t *testing.T) {
 		time.Sleep(time.Millisecond * 30)
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			state, err := s.dev.Events(s.ctx, map[string]interface{}{})
+			state, err := s.dev.Events(s.ctx, map[string]any{})
 			test.That(tb, err, test.ShouldBeNil)
 			test.That(tb, state["AbsoluteY"].Value, test.ShouldAlmostEqual, 0.17, 0.005)
 			test.That(tb, state["AbsoluteY"].Event, test.ShouldEqual, input.PositionChangeAbs)
@@ -487,7 +487,7 @@ func TestGPIOInput(t *testing.T) {
 		time.Sleep(time.Millisecond * 30)
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			state, err := s.dev.Events(s.ctx, map[string]interface{}{})
+			state, err := s.dev.Events(s.ctx, map[string]any{})
 			test.That(tb, err, test.ShouldBeNil)
 			test.That(tb, state["AbsoluteY"].Value, test.ShouldAlmostEqual, 0.17, 0.005)
 			test.That(tb, state["AbsoluteY"].Event, test.ShouldEqual, input.PositionChangeAbs)
@@ -497,7 +497,7 @@ func TestGPIOInput(t *testing.T) {
 		s.b.AnalogReaders["analog2"].Set(600 - 15)
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			state, err := s.dev.Events(s.ctx, map[string]interface{}{})
+			state, err := s.dev.Events(s.ctx, map[string]any{})
 			test.That(tb, err, test.ShouldBeNil)
 			test.That(tb, state["AbsoluteY"].Value, test.ShouldAlmostEqual, 0.14, 0.005)
 			test.That(tb, state["AbsoluteY"].Event, test.ShouldEqual, input.PositionChangeAbs)
@@ -512,7 +512,7 @@ func TestGPIOInput(t *testing.T) {
 		s.b.AnalogReaders["analog3"].Set(5000)
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			state, err := s.dev.Events(s.ctx, map[string]interface{}{})
+			state, err := s.dev.Events(s.ctx, map[string]any{})
 			test.That(tb, err, test.ShouldBeNil)
 			test.That(tb, state["AbsoluteRX"].Value, test.ShouldAlmostEqual, -1, 0.005)
 			test.That(tb, state["AbsoluteRX"].Event, test.ShouldEqual, input.PositionChangeAbs)
@@ -522,7 +522,7 @@ func TestGPIOInput(t *testing.T) {
 		s.b.AnalogReaders["analog3"].Set(-1000)
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			state, err := s.dev.Events(s.ctx, map[string]interface{}{})
+			state, err := s.dev.Events(s.ctx, map[string]any{})
 			test.That(tb, err, test.ShouldBeNil)
 			test.That(tb, state["AbsoluteRX"].Value, test.ShouldAlmostEqual, 0.2, 0.005)
 			test.That(tb, state["AbsoluteRX"].Event, test.ShouldEqual, input.PositionChangeAbs)
@@ -537,7 +537,7 @@ func TestGPIOInput(t *testing.T) {
 		s.b.AnalogReaders["analog3"].Set(-6000)
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			state, err := s.dev.Events(s.ctx, map[string]interface{}{})
+			state, err := s.dev.Events(s.ctx, map[string]any{})
 			test.That(tb, err, test.ShouldBeNil)
 			test.That(tb, state["AbsoluteRX"].Value, test.ShouldAlmostEqual, 1, 0.005)
 			test.That(tb, state["AbsoluteRX"].Event, test.ShouldEqual, input.PositionChangeAbs)
@@ -547,7 +547,7 @@ func TestGPIOInput(t *testing.T) {
 		s.b.AnalogReaders["analog3"].Set(6000)
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			state, err := s.dev.Events(s.ctx, map[string]interface{}{})
+			state, err := s.dev.Events(s.ctx, map[string]any{})
 			test.That(tb, err, test.ShouldBeNil)
 			test.That(tb, state["AbsoluteRX"].Value, test.ShouldAlmostEqual, -1, 0.005)
 			test.That(tb, state["AbsoluteRX"].Event, test.ShouldEqual, input.PositionChangeAbs)
@@ -557,7 +557,7 @@ func TestGPIOInput(t *testing.T) {
 		s.b.AnalogReaders["analog3"].Set(0)
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			state, err := s.dev.Events(s.ctx, map[string]interface{}{})
+			state, err := s.dev.Events(s.ctx, map[string]any{})
 			test.That(tb, err, test.ShouldBeNil)
 			test.That(tb, state["AbsoluteRX"].Value, test.ShouldAlmostEqual, 0, 0.005)
 			test.That(tb, state["AbsoluteRX"].Event, test.ShouldEqual, input.PositionChangeAbs)

--- a/components/input/input.go
+++ b/components/input/input.go
@@ -39,10 +39,10 @@ type Controller interface {
 	resource.Resource
 
 	// Controls returns a list of Controls provided by the Controller
-	Controls(ctx context.Context, extra map[string]interface{}) ([]Control, error)
+	Controls(ctx context.Context, extra map[string]any) ([]Control, error)
 
 	// Events returns most recent Event for each input (which should be the current state)
-	Events(ctx context.Context, extra map[string]interface{}) (map[Control]Event, error)
+	Events(ctx context.Context, extra map[string]any) (map[Control]Event, error)
 
 	// RegisterCallback registers a callback that will fire on given EventTypes for a given Control.
 	// The callback is called on the same goroutine as the firer and if any long operation is to occur,
@@ -52,7 +52,7 @@ type Controller interface {
 		control Control,
 		triggers []EventType,
 		ctrlFunc ControlFunction,
-		extra map[string]interface{},
+		extra map[string]any,
 	) error
 }
 
@@ -133,7 +133,7 @@ type Event struct {
 // Triggerable is used by the WebGamepad interface to inject events.
 type Triggerable interface {
 	// TriggerEvent allows directly sending an Event (such as a button press) from external code
-	TriggerEvent(ctx context.Context, event Event, extra map[string]interface{}) error
+	TriggerEvent(ctx context.Context, event Event, extra map[string]any) error
 }
 
 // FromDependencies is a helper for getting the named input controller from a collection of
@@ -154,7 +154,7 @@ func NamesFromRobot(r robot.Robot) []string {
 
 // CreateStatus creates a status from the input controller.
 func CreateStatus(ctx context.Context, c Controller) (*pb.Status, error) {
-	eventsIn, err := c.Events(ctx, map[string]interface{}{})
+	eventsIn, err := c.Events(ctx, map[string]any{})
 	if err != nil {
 		return nil, err
 	}

--- a/components/input/input_test.go
+++ b/components/input/input_test.go
@@ -29,7 +29,7 @@ func TestCreateStatus(t *testing.T) {
 		},
 	}
 	injectInputController := &inject.InputController{}
-	injectInputController.EventsFunc = func(ctx context.Context, extra map[string]interface{}) (map[input.Control]input.Event, error) {
+	injectInputController.EventsFunc = func(ctx context.Context, extra map[string]any) (map[input.Control]input.Event, error) {
 		eventsOut := make(map[input.Control]input.Event)
 		eventsOut[input.AbsoluteX] = event
 		return eventsOut, nil
@@ -43,7 +43,7 @@ func TestCreateStatus(t *testing.T) {
 
 	t.Run("fail on Events", func(t *testing.T) {
 		errFail := errors.New("can't get events")
-		injectInputController.EventsFunc = func(ctx context.Context, extra map[string]interface{}) (map[input.Control]input.Event, error) {
+		injectInputController.EventsFunc = func(ctx context.Context, extra map[string]any) (map[input.Control]input.Event, error) {
 			return nil, errFail
 		}
 		_, err := input.CreateStatus(context.Background(), injectInputController)

--- a/components/input/mux/mux.go
+++ b/components/input/mux/mux.go
@@ -127,7 +127,7 @@ func (m *mux) Close(ctx context.Context) error {
 }
 
 // Controls lists the unique input.Controls for the combined sources.
-func (m *mux) Controls(ctx context.Context, extra map[string]interface{}) ([]input.Control, error) {
+func (m *mux) Controls(ctx context.Context, extra map[string]any) ([]input.Control, error) {
 	controlMap := make(map[input.Control]bool)
 	var ok bool
 	var errs error
@@ -154,7 +154,7 @@ func (m *mux) Controls(ctx context.Context, extra map[string]interface{}) ([]inp
 }
 
 // Events returns the last input.Event (the current state).
-func (m *mux) Events(ctx context.Context, extra map[string]interface{}) (map[input.Control]input.Event, error) {
+func (m *mux) Events(ctx context.Context, extra map[string]any) (map[input.Control]input.Event, error) {
 	eventsOut := make(map[input.Control]input.Event)
 	var ok bool
 	var errs error
@@ -184,7 +184,7 @@ func (m *mux) RegisterControlCallback(
 	control input.Control,
 	triggers []input.EventType,
 	ctrlFunc input.ControlFunction,
-	extra map[string]interface{},
+	extra map[string]any,
 ) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/components/input/server.go
+++ b/components/input/server.go
@@ -21,7 +21,7 @@ type serviceServer struct {
 
 // NewRPCServiceServer constructs an input controller gRPC service server.
 // It is intentionally untyped to prevent use outside of tests.
-func NewRPCServiceServer(coll resource.APIResourceCollection[Controller]) interface{} {
+func NewRPCServiceServer(coll resource.APIResourceCollection[Controller]) any {
 	return &serviceServer{coll: coll}
 }
 

--- a/components/input/server_test.go
+++ b/components/input/server_test.go
@@ -66,12 +66,12 @@ func TestServer(t *testing.T) {
 	inputControllerServer, injectInputController, injectInputController2, err := newServer()
 	test.That(t, err, test.ShouldBeNil)
 
-	var extraOptions map[string]interface{}
-	injectInputController.ControlsFunc = func(ctx context.Context, extra map[string]interface{}) ([]input.Control, error) {
+	var extraOptions map[string]any
+	injectInputController.ControlsFunc = func(ctx context.Context, extra map[string]any) ([]input.Control, error) {
 		extraOptions = extra
 		return []input.Control{input.AbsoluteX, input.ButtonStart}, nil
 	}
-	injectInputController.EventsFunc = func(ctx context.Context, extra map[string]interface{}) (map[input.Control]input.Event, error) {
+	injectInputController.EventsFunc = func(ctx context.Context, extra map[string]any) (map[input.Control]input.Event, error) {
 		extraOptions = extra
 		eventsOut := make(map[input.Control]input.Event)
 		eventsOut[input.AbsoluteX] = input.Event{Time: time.Now(), Event: input.PositionChangeAbs, Control: input.AbsoluteX, Value: 0.7}
@@ -83,7 +83,7 @@ func TestServer(t *testing.T) {
 		control input.Control,
 		triggers []input.EventType,
 		ctrlFunc input.ControlFunction,
-		extra map[string]interface{},
+		extra map[string]any,
 	) error {
 		extraOptions = extra
 		outEvent := input.Event{Time: time.Now(), Event: triggers[0], Control: input.ButtonStart, Value: 0.0}
@@ -91,10 +91,10 @@ func TestServer(t *testing.T) {
 		return nil
 	}
 
-	injectInputController2.ControlsFunc = func(ctx context.Context, extra map[string]interface{}) ([]input.Control, error) {
+	injectInputController2.ControlsFunc = func(ctx context.Context, extra map[string]any) ([]input.Control, error) {
 		return nil, errControlsFailed
 	}
-	injectInputController2.EventsFunc = func(ctx context.Context, extra map[string]interface{}) (map[input.Control]input.Event, error) {
+	injectInputController2.EventsFunc = func(ctx context.Context, extra map[string]any) (map[input.Control]input.Event, error) {
 		return nil, errEventsFailed
 	}
 	injectInputController2.RegisterControlCallbackFunc = func(
@@ -102,7 +102,7 @@ func TestServer(t *testing.T) {
 		control input.Control,
 		triggers []input.EventType,
 		ctrlFunc input.ControlFunction,
-		extra map[string]interface{},
+		extra map[string]any,
 	) error {
 		return errRegisterFailed
 	}
@@ -115,7 +115,7 @@ func TestServer(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errNotFound.Error())
 
-		extra := map[string]interface{}{"foo": "Controls"}
+		extra := map[string]any{"foo": "Controls"}
 		ext, err := protoutils.StructToStructPb(extra)
 		test.That(t, err, test.ShouldBeNil)
 		resp, err := inputControllerServer.GetControls(
@@ -142,7 +142,7 @@ func TestServer(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errNotFound.Error())
 
-		extra := map[string]interface{}{"foo": "Events"}
+		extra := map[string]any{"foo": "Events"}
 		ext, err := protoutils.StructToStructPb(extra)
 		test.That(t, err, test.ShouldBeNil)
 		startTime := time.Now()
@@ -197,7 +197,7 @@ func TestServer(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errNotFound.Error())
 
-		extra := map[string]interface{}{"foo": "StreamEvents"}
+		extra := map[string]any{"foo": "StreamEvents"}
 		ext, err := protoutils.StructToStructPb(extra)
 		test.That(t, err, test.ShouldBeNil)
 		eventReqList := &pb.StreamEventsRequest{
@@ -228,10 +228,10 @@ func TestServer(t *testing.T) {
 			input.ButtonStart,
 			[]input.EventType{input.ButtonRelease},
 			relayFunc,
-			map[string]interface{}{},
+			map[string]any{},
 		)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, extraOptions, test.ShouldResemble, map[string]interface{}{})
+		test.That(t, extraOptions, test.ShouldResemble, map[string]any{})
 
 		s.fail = true
 
@@ -275,7 +275,7 @@ func TestServer(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errNotFound.Error())
 
-		injectInputController.TriggerEventFunc = func(ctx context.Context, event input.Event, extra map[string]interface{}) error {
+		injectInputController.TriggerEventFunc = func(ctx context.Context, event input.Event, extra map[string]any) error {
 			return errors.New("can't inject event")
 		}
 
@@ -303,12 +303,12 @@ func TestServer(t *testing.T) {
 
 		var injectedEvent input.Event
 
-		injectInputController.TriggerEventFunc = func(ctx context.Context, event input.Event, extra map[string]interface{}) error {
+		injectInputController.TriggerEventFunc = func(ctx context.Context, event input.Event, extra map[string]any) error {
 			extraOptions = extra
 			injectedEvent = event
 			return nil
 		}
-		extra := map[string]interface{}{"foo": "TriggerEvent"}
+		extra := map[string]any{"foo": "TriggerEvent"}
 		ext, err := protoutils.StructToStructPb(extra)
 		test.That(t, err, test.ShouldBeNil)
 		_, err = inputControllerServer.TriggerEvent(

--- a/components/input/webgamepad/webgamepad.go
+++ b/components/input/webgamepad/webgamepad.go
@@ -79,13 +79,13 @@ func (w *webGamepad) makeCallbacks(ctx context.Context, eventOut input.Event) {
 }
 
 // Controls lists the inputs of the gamepad.
-func (w *webGamepad) Controls(ctx context.Context, extra map[string]interface{}) ([]input.Control, error) {
+func (w *webGamepad) Controls(ctx context.Context, extra map[string]any) ([]input.Control, error) {
 	out := append([]input.Control(nil), w.controls...)
 	return out, nil
 }
 
 // Events returns the last input.Event (the current state).
-func (w *webGamepad) Events(ctx context.Context, extra map[string]interface{}) (map[input.Control]input.Event, error) {
+func (w *webGamepad) Events(ctx context.Context, extra map[string]any) (map[input.Control]input.Event, error) {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
 	out := make(map[input.Control]input.Event)
@@ -101,7 +101,7 @@ func (w *webGamepad) RegisterControlCallback(
 	control input.Control,
 	triggers []input.EventType,
 	ctrlFunc input.ControlFunction,
-	extra map[string]interface{},
+	extra map[string]any,
 ) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -121,7 +121,7 @@ func (w *webGamepad) RegisterControlCallback(
 }
 
 // TriggerEvent allows directly sending an Event (such as a button press) from external code.
-func (w *webGamepad) TriggerEvent(ctx context.Context, event input.Event, extra map[string]interface{}) error {
+func (w *webGamepad) TriggerEvent(ctx context.Context, event input.Event, extra map[string]any) error {
 	w.makeCallbacks(ctx, event)
 	return nil
 }

--- a/components/motor/client.go
+++ b/components/motor/client.go
@@ -40,7 +40,7 @@ func NewClientFromConn(
 	}, nil
 }
 
-func (c *client) SetPower(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
+func (c *client) SetPower(ctx context.Context, powerPct float64, extra map[string]any) error {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return err
@@ -54,7 +54,7 @@ func (c *client) SetPower(ctx context.Context, powerPct float64, extra map[strin
 	return err
 }
 
-func (c *client) GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]interface{}) error {
+func (c *client) GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]any) error {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return err
@@ -69,7 +69,7 @@ func (c *client) GoFor(ctx context.Context, rpm, revolutions float64, extra map[
 	return err
 }
 
-func (c *client) GoTo(ctx context.Context, rpm, positionRevolutions float64, extra map[string]interface{}) error {
+func (c *client) GoTo(ctx context.Context, rpm, positionRevolutions float64, extra map[string]any) error {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return err
@@ -84,7 +84,7 @@ func (c *client) GoTo(ctx context.Context, rpm, positionRevolutions float64, ext
 	return err
 }
 
-func (c *client) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]interface{}) error {
+func (c *client) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]any) error {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return err
@@ -98,7 +98,7 @@ func (c *client) ResetZeroPosition(ctx context.Context, offset float64, extra ma
 	return err
 }
 
-func (c *client) Position(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (c *client) Position(ctx context.Context, extra map[string]any) (float64, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return 0, err
@@ -111,7 +111,7 @@ func (c *client) Position(ctx context.Context, extra map[string]interface{}) (fl
 	return resp.GetPosition(), nil
 }
 
-func (c *client) Properties(ctx context.Context, extra map[string]interface{}) (Properties, error) {
+func (c *client) Properties(ctx context.Context, extra map[string]any) (Properties, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return Properties{}, err
@@ -124,7 +124,7 @@ func (c *client) Properties(ctx context.Context, extra map[string]interface{}) (
 	return ProtoFeaturesToProperties(resp), nil
 }
 
-func (c *client) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (c *client) Stop(ctx context.Context, extra map[string]any) error {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return err
@@ -134,7 +134,7 @@ func (c *client) Stop(ctx context.Context, extra map[string]interface{}) error {
 	return err
 }
 
-func (c *client) IsPowered(ctx context.Context, extra map[string]interface{}) (bool, float64, error) {
+func (c *client) IsPowered(ctx context.Context, extra map[string]any) (bool, float64, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return false, 0.0, err
@@ -147,7 +147,7 @@ func (c *client) IsPowered(ctx context.Context, extra map[string]interface{}) (b
 	return resp.GetIsOn(), resp.GetPowerPct(), nil
 }
 
-func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (c *client) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	return rprotoutils.DoFromResourceClient(ctx, c.client, c.name, cmd)
 }
 

--- a/components/motor/client_test.go
+++ b/components/motor/client_test.go
@@ -26,67 +26,67 @@ func TestClient(t *testing.T) {
 	workingMotor := &inject.Motor{}
 	failingMotor := &inject.Motor{}
 
-	var actualExtra map[string]interface{}
+	var actualExtra map[string]any
 	var actualPowerPct float64
 
-	workingMotor.SetPowerFunc = func(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
+	workingMotor.SetPowerFunc = func(ctx context.Context, powerPct float64, extra map[string]any) error {
 		actualExtra = extra
 		actualPowerPct = powerPct
 		return nil
 	}
-	workingMotor.GoForFunc = func(ctx context.Context, rpm, rotations float64, extra map[string]interface{}) error {
+	workingMotor.GoForFunc = func(ctx context.Context, rpm, rotations float64, extra map[string]any) error {
 		actualExtra = extra
 		return nil
 	}
-	workingMotor.GoToFunc = func(ctx context.Context, rpm, position float64, extra map[string]interface{}) error {
+	workingMotor.GoToFunc = func(ctx context.Context, rpm, position float64, extra map[string]any) error {
 		actualExtra = extra
 		return nil
 	}
-	workingMotor.ResetZeroPositionFunc = func(ctx context.Context, offset float64, extra map[string]interface{}) error {
+	workingMotor.ResetZeroPositionFunc = func(ctx context.Context, offset float64, extra map[string]any) error {
 		actualExtra = extra
 		return nil
 	}
-	workingMotor.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (float64, error) {
+	workingMotor.PositionFunc = func(ctx context.Context, extra map[string]any) (float64, error) {
 		actualExtra = extra
 		return 42.0, nil
 	}
-	workingMotor.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (motor.Properties, error) {
+	workingMotor.PropertiesFunc = func(ctx context.Context, extra map[string]any) (motor.Properties, error) {
 		actualExtra = extra
 		return motor.Properties{
 			PositionReporting: true,
 		}, nil
 	}
-	workingMotor.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	workingMotor.StopFunc = func(ctx context.Context, extra map[string]any) error {
 		actualExtra = extra
 		return nil
 	}
-	workingMotor.IsPoweredFunc = func(ctx context.Context, extra map[string]interface{}) (bool, float64, error) {
+	workingMotor.IsPoweredFunc = func(ctx context.Context, extra map[string]any) (bool, float64, error) {
 		actualExtra = extra
 		return true, actualPowerPct, nil
 	}
 
-	failingMotor.SetPowerFunc = func(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
+	failingMotor.SetPowerFunc = func(ctx context.Context, powerPct float64, extra map[string]any) error {
 		return errSetPowerFailed
 	}
-	failingMotor.GoForFunc = func(ctx context.Context, rpm, rotations float64, extra map[string]interface{}) error {
+	failingMotor.GoForFunc = func(ctx context.Context, rpm, rotations float64, extra map[string]any) error {
 		return errGoForFailed
 	}
-	failingMotor.GoToFunc = func(ctx context.Context, rpm, position float64, extra map[string]interface{}) error {
+	failingMotor.GoToFunc = func(ctx context.Context, rpm, position float64, extra map[string]any) error {
 		return errGoToFailed
 	}
-	failingMotor.ResetZeroPositionFunc = func(ctx context.Context, offset float64, extra map[string]interface{}) error {
+	failingMotor.ResetZeroPositionFunc = func(ctx context.Context, offset float64, extra map[string]any) error {
 		return errResetZeroFailed
 	}
-	failingMotor.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (float64, error) {
+	failingMotor.PositionFunc = func(ctx context.Context, extra map[string]any) (float64, error) {
 		return 0, errPositionUnavailable
 	}
-	failingMotor.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (motor.Properties, error) {
+	failingMotor.PropertiesFunc = func(ctx context.Context, extra map[string]any) (motor.Properties, error) {
 		return motor.Properties{}, errPropertiesNotFound
 	}
-	failingMotor.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	failingMotor.StopFunc = func(ctx context.Context, extra map[string]any) error {
 		return errStopFailed
 	}
-	failingMotor.IsPoweredFunc = func(ctx context.Context, extra map[string]interface{}) (bool, float64, error) {
+	failingMotor.IsPoweredFunc = func(ctx context.Context, extra map[string]any) (bool, float64, error) {
 		return false, 0.0, errIsPoweredFailed
 	}
 
@@ -151,11 +151,11 @@ func TestClient(t *testing.T) {
 
 		isOn, powerPct, err := workingMotorClient.IsPowered(
 			context.Background(),
-			map[string]interface{}{"foo": "bar", "baz": []interface{}{1., 2., 3.}})
+			map[string]any{"foo": "bar", "baz": []any{1., 2., 3.}})
 		test.That(t, isOn, test.ShouldBeTrue)
 		test.That(t, powerPct, test.ShouldEqual, 42.0)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, actualExtra, test.ShouldResemble, map[string]interface{}{"foo": "bar", "baz": []interface{}{1., 2., 3.}})
+		test.That(t, actualExtra, test.ShouldResemble, map[string]any{"foo": "bar", "baz": []any{1., 2., 3.}})
 
 		test.That(t, workingMotorClient.Close(context.Background()), test.ShouldBeNil)
 

--- a/components/motor/collectors.go
+++ b/components/motor/collectors.go
@@ -29,13 +29,13 @@ func (m method) String() string {
 
 // newPositionCollector returns a collector to register a position method. If one is already registered
 // with the same MethodMetadata it will panic.
-func newPositionCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+func newPositionCollector(resource any, params data.CollectorParams) (data.Collector, error) {
 	motor, err := assertMotor(resource)
 	if err != nil {
 		return nil, err
 	}
 
-	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (interface{}, error) {
+	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (any, error) {
 		v, err := motor.Position(ctx, data.FromDMExtraMap)
 		if err != nil {
 			// A modular filter component can be created to filter the readings from a component. The error ErrNoCaptureToStore
@@ -54,13 +54,13 @@ func newPositionCollector(resource interface{}, params data.CollectorParams) (da
 
 // newIsPoweredCollector returns a collector to register an is powered method. If one is already registered
 // with the same MethodMetadata it will panic.
-func newIsPoweredCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+func newIsPoweredCollector(resource any, params data.CollectorParams) (data.Collector, error) {
 	motor, err := assertMotor(resource)
 	if err != nil {
 		return nil, err
 	}
 
-	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (interface{}, error) {
+	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (any, error) {
 		v, powerPct, err := motor.IsPowered(ctx, data.FromDMExtraMap)
 		if err != nil {
 			// A modular filter component can be created to filter the readings from a component. The error ErrNoCaptureToStore
@@ -78,7 +78,7 @@ func newIsPoweredCollector(resource interface{}, params data.CollectorParams) (d
 	return data.NewCollector(cFunc, params)
 }
 
-func assertMotor(resource interface{}) (Motor, error) {
+func assertMotor(resource any) (Motor, error) {
 	motor, ok := resource.(Motor)
 	if !ok {
 		return nil, data.InvalidInterfaceErr(API)

--- a/components/motor/collectors_test.go
+++ b/components/motor/collectors_test.go
@@ -76,10 +76,10 @@ func TestMotorCollectors(t *testing.T) {
 
 func newMotor() motor.Motor {
 	m := &inject.Motor{}
-	m.IsPoweredFunc = func(ctx context.Context, extra map[string]interface{}) (bool, float64, error) {
+	m.IsPoweredFunc = func(ctx context.Context, extra map[string]any) (bool, float64, error) {
 		return false, .5, nil
 	}
-	m.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (float64, error) {
+	m.PositionFunc = func(ctx context.Context, extra map[string]any) (float64, error) {
 		return 1.0, nil
 	}
 	return m

--- a/components/motor/dimensionengineering/sabertooth.go
+++ b/components/motor/dimensionengineering/sabertooth.go
@@ -270,7 +270,7 @@ func NewMotor(ctx context.Context, c *Config, name resource.Name, logger logging
 }
 
 // IsPowered returns if the motor is currently on or off.
-func (m *Motor) IsPowered(ctx context.Context, extra map[string]interface{}) (bool, float64, error) {
+func (m *Motor) IsPowered(ctx context.Context, extra map[string]any) (bool, float64, error) {
 	return m.isOn, m.currentPowerPct, nil
 }
 
@@ -336,7 +336,7 @@ func (c *controller) sendCmd(cmd *command) error {
 
 // SetPower instructs the motor to go in a specific direction at a percentage
 // of power between -1 and 1.
-func (m *Motor) SetPower(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
+func (m *Motor) SetPower(ctx context.Context, powerPct float64, extra map[string]any) error {
 	if math.Abs(powerPct) < m.minPowerPct {
 		return m.Stop(ctx, extra)
 	}
@@ -392,7 +392,7 @@ func (m *Motor) SetPower(ctx context.Context, powerPct float64, extra map[string
 // GoFor moves an inputted number of revolutions at the given rpm, no encoder is present
 // for this so power is determined via a linear relationship with the maxRPM and the distance
 // traveled is a time based estimation based on desired RPM.
-func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]interface{}) error {
+func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]any) error {
 	if m.maxRPM == 0 {
 		return motor.NewZeroRPMError()
 	}
@@ -416,23 +416,23 @@ func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[s
 // GoTo instructs the motor to go to a specific position (provided in revolutions from home/zero),
 // at a specific speed. Regardless of the directionality of the RPM this function will move the motor
 // towards the specified target/position.
-func (m *Motor) GoTo(ctx context.Context, rpm, position float64, extra map[string]interface{}) error {
+func (m *Motor) GoTo(ctx context.Context, rpm, position float64, extra map[string]any) error {
 	return motor.NewGoToUnsupportedError(fmt.Sprintf("Channel %d on Sabertooth %d", m.Channel, m.c.address))
 }
 
 // ResetZeroPosition defines the current position to be zero (+/- offset).
-func (m *Motor) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]interface{}) error {
+func (m *Motor) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]any) error {
 	return motor.NewResetZeroPositionUnsupportedError(fmt.Sprintf("Channel %d on Sabertooth %d",
 		m.Channel, m.c.address))
 }
 
 // Position reports the position in revolutions.
-func (m *Motor) Position(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (m *Motor) Position(ctx context.Context, extra map[string]any) (float64, error) {
 	return 0, nil
 }
 
 // Stop turns the power to the motor off immediately, without any gradual step down.
-func (m *Motor) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (m *Motor) Stop(ctx context.Context, extra map[string]any) error {
 	m.c.mu.Lock()
 	defer m.c.mu.Unlock()
 
@@ -456,7 +456,7 @@ func (m *Motor) IsMoving(ctx context.Context) (bool, error) {
 }
 
 // DoCommand executes additional commands beyond the Motor{} interface.
-func (m *Motor) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (m *Motor) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	name, ok := cmd["command"]
 	if !ok {
 		return nil, errors.New("missing 'command' value")
@@ -465,7 +465,7 @@ func (m *Motor) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[
 }
 
 // Properties returns the additional properties supported by this motor.
-func (m *Motor) Properties(ctx context.Context, extra map[string]interface{}) (motor.Properties, error) {
+func (m *Motor) Properties(ctx context.Context, extra map[string]any) (motor.Properties, error) {
 	return motor.Properties{PositionReporting: false}, nil
 }
 

--- a/components/motor/dmc4000/dmc.go
+++ b/components/motor/dmc4000/dmc.go
@@ -444,7 +444,7 @@ func (m *Motor) posToSteps(pos float64) int32 {
 
 // SetPower instructs the motor to go in a specific direction at a percentage
 // of power between -1 and 1. Scaled to MaxRPM.
-func (m *Motor) SetPower(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
+func (m *Motor) SetPower(ctx context.Context, powerPct float64, extra map[string]any) error {
 	powerPct = math.Min(powerPct, 1.0)
 	powerPct = math.Max(powerPct, -1.0)
 
@@ -500,7 +500,7 @@ func (m *Motor) stopJog() error {
 // revolutions at a given speed in revolutions per minute. Both the RPM and the revolutions
 // can be assigned negative values to move in a backwards direction. Note: if both are
 // negative the motor will spin in the forward direction.
-func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]interface{}) error {
+func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]any) error {
 	switch speed := math.Abs(rpm); {
 	case speed < 0.1:
 		m.c.logger.CWarn(ctx, "motor speed is nearly 0 rev_per_min")
@@ -537,7 +537,7 @@ func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[s
 // GoTo instructs the motor to go to a specific position (provided in revolutions from home/zero),
 // at a specific speed. Regardless of the directionality of the RPM this function will move the motor
 // towards the specified target/position.
-func (m *Motor) GoTo(ctx context.Context, rpm, position float64, extra map[string]interface{}) error {
+func (m *Motor) GoTo(ctx context.Context, rpm, position float64, extra map[string]any) error {
 	ctx, done := m.opMgr.New(ctx)
 	defer done()
 
@@ -556,7 +556,7 @@ func (m *Motor) GoTo(ctx context.Context, rpm, position float64, extra map[strin
 }
 
 // ResetZeroPosition defines the current position to be zero (+/- offset).
-func (m *Motor) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]interface{}) error {
+func (m *Motor) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]any) error {
 	m.c.mu.Lock()
 	defer m.c.mu.Unlock()
 	_, err := m.c.sendCmd(fmt.Sprintf("DP%s=%d", m.Axis, int(-1*offset*float64(m.TicksPerRotation))))
@@ -567,14 +567,14 @@ func (m *Motor) ResetZeroPosition(ctx context.Context, offset float64, extra map
 }
 
 // Position reports the position in revolutions.
-func (m *Motor) Position(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (m *Motor) Position(ctx context.Context, extra map[string]any) (float64, error) {
 	m.c.mu.Lock()
 	defer m.c.mu.Unlock()
 	return m.doPosition()
 }
 
 // Stop turns the power to the motor off immediately, without any gradual step down.
-func (m *Motor) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (m *Motor) Stop(ctx context.Context, extra map[string]any) error {
 	m.c.mu.Lock()
 	defer m.c.mu.Unlock()
 
@@ -606,7 +606,7 @@ func (m *Motor) IsMoving(ctx context.Context) (bool, error) {
 }
 
 // IsPowered returns whether or not the motor is currently moving.
-func (m *Motor) IsPowered(ctx context.Context, extra map[string]interface{}) (bool, float64, error) {
+func (m *Motor) IsPowered(ctx context.Context, extra map[string]any) (bool, float64, error) {
 	on, err := m.IsMoving(ctx)
 	if err != nil {
 		return on, m.powerPct, errors.Wrap(err, "error in IsPowered")
@@ -783,7 +783,7 @@ func (m *Motor) doPosition() (float64, error) {
 }
 
 // DoCommand executes additional commands beyond the Motor{} interface.
-func (m *Motor) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (m *Motor) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	name, ok := cmd["command"]
 	if !ok {
 		return nil, errors.New("missing 'command' value")
@@ -809,7 +809,7 @@ func (m *Motor) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[
 		m.c.mu.Lock()
 		defer m.c.mu.Unlock()
 		retVal, err := m.c.sendCmd(raw.(string))
-		ret := map[string]interface{}{"return": retVal}
+		ret := map[string]any{"return": retVal}
 		return ret, err
 	default:
 		return nil, fmt.Errorf("no such command: %s", name)
@@ -817,6 +817,6 @@ func (m *Motor) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[
 }
 
 // Properties returns the additional properties supported by this motor.
-func (m *Motor) Properties(ctx context.Context, extra map[string]interface{}) (motor.Properties, error) {
+func (m *Motor) Properties(ctx context.Context, extra map[string]any) (motor.Properties, error) {
 	return motor.Properties{PositionReporting: true}, nil
 }

--- a/components/motor/dmc4000/dmc4000_test.go
+++ b/components/motor/dmc4000/dmc4000_test.go
@@ -17,8 +17,8 @@ import (
 // check is essentially test.That with tb.Error instead of tb.Fatal (Fatal exits and leaves the go routines stuck waiting).
 func check(
 	resChan chan string,
-	actual interface{},
-	assert func(actual interface{}, expected ...interface{}) string, expected ...interface{},
+	actual any,
+	assert func(actual any, expected ...any) string, expected ...any,
 ) {
 	if result := assert(actual, expected...); result != "" {
 		resChan <- result
@@ -663,7 +663,7 @@ func TestDMC4000Motor(t *testing.T) {
 			[]string{"testTX"},
 			[]string{" testRX\r\n:"},
 		)
-		resp, err := motorDep.DoCommand(ctx, map[string]interface{}{"command": "raw", "raw_input": "testTX"})
+		resp, err := motorDep.DoCommand(ctx, map[string]any{"command": "raw", "raw_input": "testTX"})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, resp["return"], test.ShouldEqual, "testRX")
 		waitTx(t, resChan)
@@ -705,7 +705,7 @@ func TestDMC4000Motor(t *testing.T) {
 				" 0\r\n:",
 			},
 		)
-		resp, err := motorDep.DoCommand(ctx, map[string]interface{}{"command": "home"})
+		resp, err := motorDep.DoCommand(ctx, map[string]any{"command": "home"})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, resp, test.ShouldBeNil)
 		waitTx(t, resChan)

--- a/components/motor/fake/motor.go
+++ b/components/motor/fake/motor.go
@@ -173,7 +173,7 @@ func (m *Motor) Reconfigure(ctx context.Context, deps resource.Dependencies, con
 }
 
 // Position returns motor position in rotations.
-func (m *Motor) Position(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (m *Motor) Position(ctx context.Context, extra map[string]any) (float64, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -194,14 +194,14 @@ func (m *Motor) Position(ctx context.Context, extra map[string]interface{}) (flo
 }
 
 // Properties returns the status of whether the motor supports certain optional properties.
-func (m *Motor) Properties(ctx context.Context, extra map[string]interface{}) (motor.Properties, error) {
+func (m *Motor) Properties(ctx context.Context, extra map[string]any) (motor.Properties, error) {
 	return motor.Properties{
 		PositionReporting: m.PositionReporting,
 	}, nil
 }
 
 // SetPower sets the given power percentage.
-func (m *Motor) SetPower(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
+func (m *Motor) SetPower(ctx context.Context, powerPct float64, extra map[string]any) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -276,7 +276,7 @@ func goForMath(maxRPM, rpm, revolutions float64) (float64, time.Duration, float6
 
 // GoFor sets the given direction and an arbitrary power percentage.
 // If rpm is 0, the motor should immediately move to the final position.
-func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]interface{}) error {
+func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]any) error {
 	switch speed := math.Abs(rpm); {
 	case speed < 0.1:
 		m.Logger.CWarn(ctx, "motor speed is nearly 0 rev_per_min")
@@ -320,7 +320,7 @@ func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[s
 }
 
 // GoTo sets the given direction and an arbitrary power percentage for now.
-func (m *Motor) GoTo(ctx context.Context, rpm, pos float64, extra map[string]interface{}) error {
+func (m *Motor) GoTo(ctx context.Context, rpm, pos float64, extra map[string]any) error {
 	if m.Encoder == nil {
 		return errors.New("encoder is not defined")
 	}
@@ -367,7 +367,7 @@ func (m *Motor) GoTo(ctx context.Context, rpm, pos float64, extra map[string]int
 }
 
 // Stop has the motor pretend to be off.
-func (m *Motor) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (m *Motor) Stop(ctx context.Context, extra map[string]any) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -383,7 +383,7 @@ func (m *Motor) Stop(ctx context.Context, extra map[string]interface{}) error {
 }
 
 // ResetZeroPosition resets the zero position.
-func (m *Motor) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]interface{}) error {
+func (m *Motor) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]any) error {
 	if m.Encoder == nil {
 		return errors.New("encoder is not defined")
 	}
@@ -401,7 +401,7 @@ func (m *Motor) ResetZeroPosition(ctx context.Context, offset float64, extra map
 }
 
 // IsPowered returns if the motor is pretending to be on or not, and its power level.
-func (m *Motor) IsPowered(ctx context.Context, extra map[string]interface{}) (bool, float64, error) {
+func (m *Motor) IsPowered(ctx context.Context, extra map[string]any) (bool, float64, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return math.Abs(m.powerPct) >= 0.005, m.powerPct, nil

--- a/components/motor/gpio/basic.go
+++ b/components/motor/gpio/basic.go
@@ -133,19 +133,19 @@ type Motor struct {
 }
 
 // Position always returns 0.
-func (m *Motor) Position(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (m *Motor) Position(ctx context.Context, extra map[string]any) (float64, error) {
 	return 0, nil
 }
 
 // Properties returns the status of whether the motor supports certain optional properties.
-func (m *Motor) Properties(ctx context.Context, extra map[string]interface{}) (motor.Properties, error) {
+func (m *Motor) Properties(ctx context.Context, extra map[string]any) (motor.Properties, error) {
 	return motor.Properties{
 		PositionReporting: false,
 	}, nil
 }
 
 // turnOff turns down the motor entirely by setting all the pins accordingly.
-func (m *Motor) turnOff(ctx context.Context, extra map[string]interface{}) error {
+func (m *Motor) turnOff(ctx context.Context, extra map[string]any) error {
 	var errs error
 	m.powerPct = 0.0
 	m.on = false
@@ -173,7 +173,7 @@ func (m *Motor) turnOff(ctx context.Context, extra map[string]interface{}) error
 
 // setPWM sets the associated pins (as discovered) and sets PWM to the given power percentage.
 // Anything calling setPWM MUST lock the motor's mutex prior.
-func (m *Motor) setPWM(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
+func (m *Motor) setPWM(ctx context.Context, powerPct float64, extra map[string]any) error {
 	var errs error
 	powerPct = math.Min(powerPct, m.maxPowerPct)
 	powerPct = math.Max(powerPct, -1*m.maxPowerPct)
@@ -224,7 +224,7 @@ func (m *Motor) setPWM(ctx context.Context, powerPct float64, extra map[string]i
 
 // SetPower instructs the motor to operate at an rpm, where the sign of the rpm
 // indicates direction.
-func (m *Motor) SetPower(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
+func (m *Motor) SetPower(ctx context.Context, powerPct float64, extra map[string]any) error {
 	m.opMgr.CancelRunning(ctx)
 	if math.Abs(powerPct) <= 0.01 {
 		return m.Stop(ctx, extra)
@@ -289,7 +289,7 @@ func goForMath(maxRPM, rpm, revolutions float64) (float64, time.Duration) {
 // GoFor moves an inputted number of revolutions at the given rpm, no encoder is present
 // for this so power is determined via a linear relationship with the maxRPM and the distance
 // traveled is a time based estimation based on desired RPM.
-func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]interface{}) error {
+func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]any) error {
 	if m.maxRPM == 0 {
 		return errors.New("not supported, define max_rpm attribute != 0")
 	}
@@ -320,14 +320,14 @@ func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[s
 }
 
 // IsPowered returns if the motor is currently on or off.
-func (m *Motor) IsPowered(ctx context.Context, extra map[string]interface{}) (bool, float64, error) {
+func (m *Motor) IsPowered(ctx context.Context, extra map[string]any) (bool, float64, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.on, m.powerPct, nil
 }
 
 // Stop turns the power to the motor off immediately, without any gradual step down, by setting the appropriate pins to low states.
-func (m *Motor) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (m *Motor) Stop(ctx context.Context, extra map[string]any) error {
 	m.opMgr.CancelRunning(ctx)
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -342,11 +342,11 @@ func (m *Motor) IsMoving(ctx context.Context) (bool, error) {
 }
 
 // GoTo is not supported.
-func (m *Motor) GoTo(ctx context.Context, rpm, positionRevolutions float64, extra map[string]interface{}) error {
+func (m *Motor) GoTo(ctx context.Context, rpm, positionRevolutions float64, extra map[string]any) error {
 	return motor.NewGoToUnsupportedError(m.Name().ShortName())
 }
 
 // ResetZeroPosition is not supported.
-func (m *Motor) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]interface{}) error {
+func (m *Motor) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]any) error {
 	return motor.NewResetZeroPositionUnsupportedError(m.Name().ShortName())
 }

--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -368,7 +368,7 @@ func (m *EncodedMotor) directionMovingInLock() float64 {
 
 // SetPower sets the percentage of power the motor should employ between -1 and 1.
 // Negative power implies a backward directional rotational.
-func (m *EncodedMotor) SetPower(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
+func (m *EncodedMotor) SetPower(ctx context.Context, powerPct float64, extra map[string]any) error {
 	m.opMgr.CancelRunning(ctx)
 	m.stateMu.Lock()
 	defer m.stateMu.Unlock()
@@ -397,7 +397,7 @@ func (m *EncodedMotor) setPower(ctx context.Context, powerPct float64, internal 
 // negative the motor will spin in the forward direction.
 // If revolutions is 0, this will run the motor at rpm indefinitely
 // If revolutions != 0, this will block until the number of revolutions has been completed or another operation comes in.
-func (m *EncodedMotor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]interface{}) error {
+func (m *EncodedMotor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]any) error {
 	ctx, done := m.opMgr.New(ctx)
 	defer done()
 	if err := m.goForInternal(ctx, rpm, revolutions); err != nil {
@@ -531,7 +531,7 @@ func (m *EncodedMotor) goForInternal(ctx context.Context, rpm, revolutions float
 // at a specific speed. Regardless of the directionality of the RPM this function will move the motor
 // towards the specified target/position
 // This will block until the position has been reached.
-func (m *EncodedMotor) GoTo(ctx context.Context, rpm, targetPosition float64, extra map[string]interface{}) error {
+func (m *EncodedMotor) GoTo(ctx context.Context, rpm, targetPosition float64, extra map[string]any) error {
 	pos, err := m.position(ctx, extra)
 	if err != nil {
 		return err
@@ -548,7 +548,7 @@ func (m *EncodedMotor) GoTo(ctx context.Context, rpm, targetPosition float64, ex
 }
 
 // ResetZeroPosition sets the current position (+/- offset) to be the new zero (home) position.
-func (m *EncodedMotor) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]interface{}) error {
+func (m *EncodedMotor) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]any) error {
 	if err := m.Stop(ctx, extra); err != nil {
 		return err
 	}
@@ -563,7 +563,7 @@ func (m *EncodedMotor) ResetZeroPosition(ctx context.Context, offset float64, ex
 }
 
 // report position in ticks.
-func (m *EncodedMotor) position(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (m *EncodedMotor) position(ctx context.Context, extra map[string]any) (float64, error) {
 	ticks, _, err := m.encoder.Position(ctx, encoder.PositionTypeTicks, extra)
 	if err != nil {
 		return 0, err
@@ -577,7 +577,7 @@ func (m *EncodedMotor) position(ctx context.Context, extra map[string]interface{
 // Position reports the position of the motor based on its encoder. If it's not supported, the returned
 // data is undefined. The unit returned is the number of revolutions which is intended to be fed
 // back into calls of GoFor.
-func (m *EncodedMotor) Position(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (m *EncodedMotor) Position(ctx context.Context, extra map[string]any) (float64, error) {
 	ticks, err := m.position(ctx, extra)
 	if err != nil {
 		return 0, err
@@ -587,7 +587,7 @@ func (m *EncodedMotor) Position(ctx context.Context, extra map[string]interface{
 }
 
 // Properties returns whether or not the motor supports certain optional properties.
-func (m *EncodedMotor) Properties(ctx context.Context, extra map[string]interface{}) (motor.Properties, error) {
+func (m *EncodedMotor) Properties(ctx context.Context, extra map[string]any) (motor.Properties, error) {
 	return motor.Properties{
 		PositionReporting: true,
 	}, nil
@@ -595,7 +595,7 @@ func (m *EncodedMotor) Properties(ctx context.Context, extra map[string]interfac
 
 // IsPowered returns whether or not the motor is currently on, and the percent power (between 0
 // and 1, if the motor is off then the percent power will be 0).
-func (m *EncodedMotor) IsPowered(ctx context.Context, extra map[string]interface{}) (bool, float64, error) {
+func (m *EncodedMotor) IsPowered(ctx context.Context, extra map[string]any) (bool, float64, error) {
 	return m.real.IsPowered(ctx, extra)
 }
 
@@ -619,7 +619,7 @@ func (m *EncodedMotor) GetMotorState(ctx context.Context) EncodedMotorState {
 }
 
 // Stop stops rpmMonitor and stops the real motor.
-func (m *EncodedMotor) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (m *EncodedMotor) Stop(ctx context.Context, extra map[string]any) error {
 	m.stateMu.Lock()
 	m.state.goalRPM = 0
 	m.state.regulated = false

--- a/components/motor/gpio/motor_encoder_test.go
+++ b/components/motor/gpio/motor_encoder_test.go
@@ -358,7 +358,7 @@ func TestMotorEncoder1(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)
 		wg.Add(1)
 		go func() {
-			motorDep.GoFor(ctx, 100, 100, map[string]interface{}{})
+			motorDep.GoFor(ctx, 100, 100, map[string]any{})
 			wg.Done()
 		}()
 		cancel()

--- a/components/motor/gpiostepper/gpiostepper.go
+++ b/components/motor/gpiostepper/gpiostepper.go
@@ -206,7 +206,7 @@ type gpioStepper struct {
 }
 
 // SetPower sets the percentage of power the motor should employ between 0-1.
-func (m *gpioStepper) SetPower(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
+func (m *gpioStepper) SetPower(ctx context.Context, powerPct float64, extra map[string]any) error {
 	if math.Abs(powerPct) <= .0001 {
 		m.stop()
 		return nil
@@ -315,7 +315,7 @@ func (m *gpioStepper) doStep(ctx context.Context, forward bool) error {
 // revolutions at a given speed in revolutions per minute. Both the RPM and the revolutions
 // can be assigned negative values to move in a backwards direction. Note: if both are negative
 // the motor will spin in the forward direction.
-func (m *gpioStepper) GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]interface{}) error {
+func (m *gpioStepper) GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]any) error {
 	ctx, done := m.opMgr.New(ctx)
 	defer done()
 
@@ -382,7 +382,7 @@ func (m *gpioStepper) goForInternal(ctx context.Context, rpm, revolutions float6
 // GoTo instructs the motor to go to a specific position (provided in revolutions from home/zero),
 // at a specific RPM. Regardless of the directionality of the RPM this function will move the motor
 // towards the specified target.
-func (m *gpioStepper) GoTo(ctx context.Context, rpm, positionRevolutions float64, extra map[string]interface{}) error {
+func (m *gpioStepper) GoTo(ctx context.Context, rpm, positionRevolutions float64, extra map[string]any) error {
 	curPos, err := m.Position(ctx, extra)
 	if err != nil {
 		return errors.Wrapf(err, "error in GoTo from motor (%s)", m.Name().Name)
@@ -401,7 +401,7 @@ func (m *gpioStepper) GoTo(ctx context.Context, rpm, positionRevolutions float64
 }
 
 // Set the current position (+/- offset) to be the new zero (home) position.
-func (m *gpioStepper) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]interface{}) error {
+func (m *gpioStepper) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]any) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	m.stepPosition = int64(-1 * offset * float64(m.stepsPerRotation))
@@ -412,14 +412,14 @@ func (m *gpioStepper) ResetZeroPosition(ctx context.Context, offset float64, ext
 // Position reports the position of the motor based on its encoder. If it's not supported, the returned
 // data is undefined. The unit returned is the number of revolutions which is intended to be fed
 // back into calls of GoFor.
-func (m *gpioStepper) Position(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (m *gpioStepper) Position(ctx context.Context, extra map[string]any) (float64, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	return float64(m.stepPosition) / float64(m.stepsPerRotation), nil
 }
 
 // Properties returns the status of whether the motor supports certain optional properties.
-func (m *gpioStepper) Properties(ctx context.Context, extra map[string]interface{}) (motor.Properties, error) {
+func (m *gpioStepper) Properties(ctx context.Context, extra map[string]any) (motor.Properties, error) {
 	return motor.Properties{
 		PositionReporting: true,
 	}, nil
@@ -433,7 +433,7 @@ func (m *gpioStepper) IsMoving(ctx context.Context) (bool, error) {
 }
 
 // Stop turns the power to the motor off immediately, without any gradual step down.
-func (m *gpioStepper) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (m *gpioStepper) Stop(ctx context.Context, extra map[string]any) error {
 	m.stop()
 	m.lock.Lock()
 	defer m.lock.Unlock()
@@ -449,7 +449,7 @@ func (m *gpioStepper) stop() {
 // IsPowered returns whether or not the motor is currently on. It also returns the percent power
 // that the motor has, but stepper motors only have this set to 0% or 100%, so it's a little
 // redundant.
-func (m *gpioStepper) IsPowered(ctx context.Context, extra map[string]interface{}) (bool, float64, error) {
+func (m *gpioStepper) IsPowered(ctx context.Context, extra map[string]any) (bool, float64, error) {
 	on, err := m.IsMoving(ctx)
 	if err != nil {
 		return on, 0.0, errors.Wrapf(err, "error in IsPowered from motor (%s)", m.Name().Name)

--- a/components/motor/gpiostepper/gpiostepper_test.go
+++ b/components/motor/gpiostepper/gpiostepper_test.go
@@ -372,7 +372,7 @@ func TestRunning(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)
 		wg.Add(1)
 		go func() {
-			m.GoFor(ctx, 100, 100, map[string]interface{}{})
+			m.GoFor(ctx, 100, 100, map[string]any{})
 			wg.Done()
 		}()
 
@@ -419,7 +419,7 @@ func TestRunning(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)
 		wg.Add(1)
 		go func() {
-			m.GoFor(ctx, 100, 100, map[string]interface{}{})
+			m.GoFor(ctx, 100, 100, map[string]any{})
 			wg.Done()
 		}()
 

--- a/components/motor/i2cmotors/ezopmp.go
+++ b/components/motor/i2cmotors/ezopmp.go
@@ -225,7 +225,7 @@ func (m *Ezopmp) writeRegWithCheck(ctx context.Context, command []byte) error {
 // SetPower sets the percentage of power the motor should employ between -1 and 1.
 // Negative power implies a backward directional rotational
 // for this pump, it goes between 0.5ml to 105ml/min.
-func (m *Ezopmp) SetPower(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
+func (m *Ezopmp) SetPower(ctx context.Context, powerPct float64, extra map[string]any) error {
 	m.opMgr.CancelRunning(ctx)
 
 	powerPct = math.Min(powerPct, m.maxPowerPct)
@@ -251,7 +251,7 @@ func (m *Ezopmp) SetPower(ctx context.Context, powerPct float64, extra map[strin
 
 // GoFor sets a constant flow rate
 // mLPerMin = rpm, mins = revolutions.
-func (m *Ezopmp) GoFor(ctx context.Context, mLPerMin, mins float64, extra map[string]interface{}) error {
+func (m *Ezopmp) GoFor(ctx context.Context, mLPerMin, mins float64, extra map[string]any) error {
 	switch speed := math.Abs(mLPerMin); {
 	case speed < 0.1:
 		m.logger.CWarn(ctx, "motor speed is nearly 0 rev_per_min")
@@ -275,7 +275,7 @@ func (m *Ezopmp) GoFor(ctx context.Context, mLPerMin, mins float64, extra map[st
 
 // GoTo uses the Dose Over Time Command in the EZO-PMP datasheet
 // mLPerMin = rpm, mins = revolutions.
-func (m *Ezopmp) GoTo(ctx context.Context, mLPerMin, mins float64, extra map[string]interface{}) error {
+func (m *Ezopmp) GoTo(ctx context.Context, mLPerMin, mins float64, extra map[string]any) error {
 	switch speed := math.Abs(mLPerMin); {
 	case speed < 0.5:
 		return errors.New("cannot move this slowly")
@@ -292,13 +292,13 @@ func (m *Ezopmp) GoTo(ctx context.Context, mLPerMin, mins float64, extra map[str
 }
 
 // ResetZeroPosition clears the amount of volume that has been dispensed.
-func (m *Ezopmp) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]interface{}) error {
+func (m *Ezopmp) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]any) error {
 	m.logger.CWarnf(ctx, "cannot reset position of motor (%v) because position refers to the total volume dispensed", m.Name().ShortName())
 	return motor.NewResetZeroPositionUnsupportedError(m.Name().ShortName())
 }
 
 // Position will return the total volume dispensed.
-func (m *Ezopmp) Position(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (m *Ezopmp) Position(ctx context.Context, extra map[string]any) (float64, error) {
 	command := []byte(totVolDispensed)
 	writeErr := m.writeReg(ctx, command)
 	if writeErr != nil {
@@ -314,14 +314,14 @@ func (m *Ezopmp) Position(ctx context.Context, extra map[string]interface{}) (fl
 }
 
 // Properties returns the status of optional properties on the motor.
-func (m *Ezopmp) Properties(ctx context.Context, extra map[string]interface{}) (motor.Properties, error) {
+func (m *Ezopmp) Properties(ctx context.Context, extra map[string]any) (motor.Properties, error) {
 	return motor.Properties{
 		PositionReporting: true,
 	}, nil
 }
 
 // Stop turns the power to the motor off immediately, without any gradual step down.
-func (m *Ezopmp) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (m *Ezopmp) Stop(ctx context.Context, extra map[string]any) error {
 	m.opMgr.CancelRunning(ctx)
 	command := []byte(stop)
 	return m.writeRegWithCheck(ctx, command)
@@ -334,7 +334,7 @@ func (m *Ezopmp) IsMoving(ctx context.Context) (bool, error) {
 }
 
 // IsPowered returns whether or not the motor is currently on, and how much power it's getting.
-func (m *Ezopmp) IsPowered(ctx context.Context, extra map[string]interface{}) (bool, float64, error) {
+func (m *Ezopmp) IsPowered(ctx context.Context, extra map[string]any) (bool, float64, error) {
 	command := []byte(dispenseStatus)
 	writeErr := m.writeReg(ctx, command)
 	if writeErr != nil {

--- a/components/motor/motor.go
+++ b/components/motor/motor.go
@@ -41,7 +41,7 @@ type Motor interface {
 
 	// SetPower sets the percentage of power the motor should employ between -1 and 1.
 	// Negative power implies a backward directional rotational
-	SetPower(ctx context.Context, powerPct float64, extra map[string]interface{}) error
+	SetPower(ctx context.Context, powerPct float64, extra map[string]any) error
 
 	// GoFor instructs the motor to go in a specific direction for a specific amount of
 	// revolutions at a given speed in revolutions per minute. Both the RPM and the revolutions
@@ -49,28 +49,28 @@ type Motor interface {
 	// negative the motor will spin in the forward direction.
 	// If revolutions is 0, this will run the motor at rpm indefinitely
 	// If revolutions != 0, this will block until the number of revolutions has been completed or another operation comes in.
-	GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]interface{}) error
+	GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]any) error
 
 	// GoTo instructs the motor to go to a specific position (provided in revolutions from home/zero),
 	// at a specific speed. Regardless of the directionality of the RPM this function will move the motor
 	// towards the specified target/position
 	// This will block until the position has been reached
-	GoTo(ctx context.Context, rpm, positionRevolutions float64, extra map[string]interface{}) error
+	GoTo(ctx context.Context, rpm, positionRevolutions float64, extra map[string]any) error
 
 	// Set the current position (+/- offset) to be the new zero (home) position.
-	ResetZeroPosition(ctx context.Context, offset float64, extra map[string]interface{}) error
+	ResetZeroPosition(ctx context.Context, offset float64, extra map[string]any) error
 
 	// Position reports the position of the motor based on its encoder. If it's not supported, the returned
 	// data is undefined. The unit returned is the number of revolutions which is intended to be fed
 	// back into calls of GoFor.
-	Position(ctx context.Context, extra map[string]interface{}) (float64, error)
+	Position(ctx context.Context, extra map[string]any) (float64, error)
 
 	// Properties returns whether or not the motor supports certain optional properties.
-	Properties(ctx context.Context, extra map[string]interface{}) (Properties, error)
+	Properties(ctx context.Context, extra map[string]any) (Properties, error)
 
 	// IsPowered returns whether or not the motor is currently on, and the percent power (between 0
 	// and 1, if the motor is off then the percent power will be 0).
-	IsPowered(ctx context.Context, extra map[string]interface{}) (bool, float64, error)
+	IsPowered(ctx context.Context, extra map[string]any) (bool, float64, error)
 }
 
 // Named is a helper for getting the named Motor's typed resource name.

--- a/components/motor/motor_test.go
+++ b/components/motor/motor_test.go
@@ -29,7 +29,7 @@ func TestStatusValid(t *testing.T) {
 		t,
 		newStruct.AsMap(),
 		test.ShouldResemble,
-		map[string]interface{}{"is_powered": true, "position": 7.7, "is_moving": true},
+		map[string]any{"is_powered": true, "position": 7.7, "is_moving": true},
 	)
 
 	convMap := &pb.Status{}
@@ -42,7 +42,7 @@ func TestStatusValid(t *testing.T) {
 	status = &pb.Status{Position: 7.7}
 	newStruct, err = protoutils.StructToStructPb(status)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, newStruct.AsMap(), test.ShouldResemble, map[string]interface{}{"position": 7.7})
+	test.That(t, newStruct.AsMap(), test.ShouldResemble, map[string]any{"position": 7.7})
 
 	convMap = &pb.Status{}
 	decoder, err = mapstructure.NewDecoder(&mapstructure.DecoderConfig{TagName: "json", Result: &convMap})
@@ -56,13 +56,13 @@ func TestCreateStatus(t *testing.T) {
 	status := &pb.Status{IsPowered: true, Position: 7.7, IsMoving: true}
 
 	injectMotor := &inject.Motor{}
-	injectMotor.IsPoweredFunc = func(ctx context.Context, extra map[string]interface{}) (bool, float64, error) {
+	injectMotor.IsPoweredFunc = func(ctx context.Context, extra map[string]any) (bool, float64, error) {
 		return status.IsPowered, 1.0, nil
 	}
-	injectMotor.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (motor.Properties, error) {
+	injectMotor.PropertiesFunc = func(ctx context.Context, extra map[string]any) (motor.Properties, error) {
 		return motor.Properties{PositionReporting: true}, nil
 	}
-	injectMotor.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (float64, error) {
+	injectMotor.PositionFunc = func(ctx context.Context, extra map[string]any) (float64, error) {
 		return status.Position, nil
 	}
 	injectMotor.IsMovingFunc = func(context.Context) (bool, error) {
@@ -95,7 +95,7 @@ func TestCreateStatus(t *testing.T) {
 
 	t.Run("fail on Position", func(t *testing.T) {
 		errFail := errors.New("can't get position")
-		injectMotor.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (float64, error) {
+		injectMotor.PositionFunc = func(ctx context.Context, extra map[string]any) (float64, error) {
 			return 0, errFail
 		}
 		_, err := motor.CreateStatus(context.Background(), injectMotor)
@@ -103,7 +103,7 @@ func TestCreateStatus(t *testing.T) {
 	})
 
 	t.Run("position not supported", func(t *testing.T) {
-		injectMotor.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (motor.Properties, error) {
+		injectMotor.PropertiesFunc = func(ctx context.Context, extra map[string]any) (motor.Properties, error) {
 			return motor.Properties{PositionReporting: false}, nil
 		}
 
@@ -114,7 +114,7 @@ func TestCreateStatus(t *testing.T) {
 
 	t.Run("fail on Properties", func(t *testing.T) {
 		errFail := errors.New("can't get properties")
-		injectMotor.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (motor.Properties, error) {
+		injectMotor.PropertiesFunc = func(ctx context.Context, extra map[string]any) (motor.Properties, error) {
 			return motor.Properties{}, errFail
 		}
 		_, err := motor.CreateStatus(context.Background(), injectMotor)
@@ -123,7 +123,7 @@ func TestCreateStatus(t *testing.T) {
 
 	t.Run("fail on IsPowered", func(t *testing.T) {
 		errFail := errors.New("can't get is powered")
-		injectMotor.IsPoweredFunc = func(ctx context.Context, extra map[string]interface{}) (bool, float64, error) {
+		injectMotor.IsPoweredFunc = func(ctx context.Context, extra map[string]any) (bool, float64, error) {
 			return false, 0.0, errFail
 		}
 		_, err := motor.CreateStatus(context.Background(), injectMotor)

--- a/components/motor/roboclaw/roboclaw.go
+++ b/components/motor/roboclaw/roboclaw.go
@@ -217,7 +217,7 @@ type roboclawMotor struct {
 	powerPct float64
 }
 
-func (m *roboclawMotor) SetPower(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
+func (m *roboclawMotor) SetPower(ctx context.Context, powerPct float64, extra map[string]any) error {
 	m.opMgr.CancelRunning(ctx)
 
 	if powerPct > 1 {
@@ -252,7 +252,7 @@ func goForMath(rpm, revolutions float64) (float64, time.Duration) {
 	return powerPct, waitDur
 }
 
-func (m *roboclawMotor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]interface{}) error {
+func (m *roboclawMotor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]any) error {
 	speed := math.Abs(rpm)
 	if speed < 0.1 {
 		m.logger.CWarn(ctx, "motor speed is nearly 0 rev_per_min")
@@ -302,7 +302,7 @@ func (m *roboclawMotor) GoFor(ctx context.Context, rpm, revolutions float64, ext
 	return m.opMgr.WaitTillNotPowered(ctx, time.Millisecond, m, m.Stop)
 }
 
-func (m *roboclawMotor) GoTo(ctx context.Context, rpm, positionRevolutions float64, extra map[string]interface{}) error {
+func (m *roboclawMotor) GoTo(ctx context.Context, rpm, positionRevolutions float64, extra map[string]any) error {
 	if m.conf.TicksPerRotation == 0 {
 		return errors.New("roboclaw needs an encoder connected to use GoTo")
 	}
@@ -313,7 +313,7 @@ func (m *roboclawMotor) GoTo(ctx context.Context, rpm, positionRevolutions float
 	return m.GoFor(ctx, rpm, positionRevolutions-pos, extra)
 }
 
-func (m *roboclawMotor) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]interface{}) error {
+func (m *roboclawMotor) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]any) error {
 	newTicks := int32(-1 * offset * float64(m.conf.TicksPerRotation))
 	switch m.conf.Channel {
 	case 1:
@@ -325,7 +325,7 @@ func (m *roboclawMotor) ResetZeroPosition(ctx context.Context, offset float64, e
 	}
 }
 
-func (m *roboclawMotor) Position(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (m *roboclawMotor) Position(ctx context.Context, extra map[string]any) (float64, error) {
 	var ticks uint32
 	var err error
 
@@ -343,13 +343,13 @@ func (m *roboclawMotor) Position(ctx context.Context, extra map[string]interface
 	return float64(ticks) / float64(m.conf.TicksPerRotation), nil
 }
 
-func (m *roboclawMotor) Properties(ctx context.Context, extra map[string]interface{}) (motor.Properties, error) {
+func (m *roboclawMotor) Properties(ctx context.Context, extra map[string]any) (motor.Properties, error) {
 	return motor.Properties{
 		PositionReporting: true,
 	}, nil
 }
 
-func (m *roboclawMotor) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (m *roboclawMotor) Stop(ctx context.Context, extra map[string]any) error {
 	return m.SetPower(ctx, 0, extra)
 }
 
@@ -358,7 +358,7 @@ func (m *roboclawMotor) IsMoving(ctx context.Context) (bool, error) {
 	return on, err
 }
 
-func (m *roboclawMotor) IsPowered(ctx context.Context, extra map[string]interface{}) (bool, float64, error) {
+func (m *roboclawMotor) IsPowered(ctx context.Context, extra map[string]any) (bool, float64, error) {
 	pow1, pow2, err := m.conn.ReadPWMs(m.addr)
 	if err != nil {
 		return false, 0.0, err

--- a/components/motor/server.go
+++ b/components/motor/server.go
@@ -19,7 +19,7 @@ type serviceServer struct {
 
 // NewRPCServiceServer constructs a motor gRPC service server.
 // It is intentionally untyped to prevent use outside of tests.
-func NewRPCServiceServer(coll resource.APIResourceCollection[Motor]) interface{} {
+func NewRPCServiceServer(coll resource.APIResourceCollection[Motor]) any {
 	return &serviceServer{coll: coll}
 }
 

--- a/components/motor/server_test.go
+++ b/components/motor/server_test.go
@@ -52,7 +52,7 @@ func TestServerSetPower(t *testing.T) {
 	test.That(t, resp, test.ShouldBeNil)
 	test.That(t, err, test.ShouldNotBeNil)
 
-	failingMotor.SetPowerFunc = func(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
+	failingMotor.SetPowerFunc = func(ctx context.Context, powerPct float64, extra map[string]any) error {
 		return errSetPowerFailed
 	}
 	req = pb.SetPowerRequest{Name: failMotorName, PowerPct: 0.5}
@@ -60,7 +60,7 @@ func TestServerSetPower(t *testing.T) {
 	test.That(t, resp, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldNotBeNil)
 
-	workingMotor.SetPowerFunc = func(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
+	workingMotor.SetPowerFunc = func(ctx context.Context, powerPct float64, extra map[string]any) error {
 		return nil
 	}
 	req = pb.SetPowerRequest{Name: testMotorName, PowerPct: 0.5}
@@ -79,7 +79,7 @@ func TestServerGoFor(t *testing.T) {
 	test.That(t, resp, test.ShouldBeNil)
 	test.That(t, err, test.ShouldNotBeNil)
 
-	failingMotor.GoForFunc = func(ctx context.Context, rpm, rotations float64, extra map[string]interface{}) error {
+	failingMotor.GoForFunc = func(ctx context.Context, rpm, rotations float64, extra map[string]any) error {
 		return errGoForFailed
 	}
 	req = pb.GoForRequest{Name: failMotorName, Rpm: 42.0, Revolutions: 42.1}
@@ -87,7 +87,7 @@ func TestServerGoFor(t *testing.T) {
 	test.That(t, resp, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldNotBeNil)
 
-	workingMotor.GoForFunc = func(ctx context.Context, rpm, rotations float64, extra map[string]interface{}) error {
+	workingMotor.GoForFunc = func(ctx context.Context, rpm, rotations float64, extra map[string]any) error {
 		return nil
 	}
 	req = pb.GoForRequest{Name: testMotorName, Rpm: 42.0, Revolutions: 42.1}
@@ -106,7 +106,7 @@ func TestServerPosition(t *testing.T) {
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, resource.IsNotFoundError(err), test.ShouldBeTrue)
 
-	failingMotor.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (float64, error) {
+	failingMotor.PositionFunc = func(ctx context.Context, extra map[string]any) (float64, error) {
 		return 0, errPositionUnavailable
 	}
 	req = pb.GetPositionRequest{Name: failMotorName}
@@ -114,7 +114,7 @@ func TestServerPosition(t *testing.T) {
 	test.That(t, resp, test.ShouldBeNil)
 	test.That(t, err, test.ShouldNotBeNil)
 
-	workingMotor.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (float64, error) {
+	workingMotor.PositionFunc = func(ctx context.Context, extra map[string]any) (float64, error) {
 		return 42.0, nil
 	}
 	req = pb.GetPositionRequest{Name: testMotorName}
@@ -132,7 +132,7 @@ func TestServerGetProperties(t *testing.T) {
 	test.That(t, resp, test.ShouldBeNil)
 	test.That(t, err, test.ShouldNotBeNil)
 
-	failingMotor.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (motor.Properties, error) {
+	failingMotor.PropertiesFunc = func(ctx context.Context, extra map[string]any) (motor.Properties, error) {
 		return motor.Properties{}, errGetPropertiesFailed
 	}
 	req = pb.GetPropertiesRequest{Name: failMotorName}
@@ -140,7 +140,7 @@ func TestServerGetProperties(t *testing.T) {
 	test.That(t, resp, test.ShouldBeNil)
 	test.That(t, err, test.ShouldNotBeNil)
 
-	workingMotor.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (motor.Properties, error) {
+	workingMotor.PropertiesFunc = func(ctx context.Context, extra map[string]any) (motor.Properties, error) {
 		return motor.Properties{
 			PositionReporting: true,
 		}, nil
@@ -160,7 +160,7 @@ func TestServerStop(t *testing.T) {
 	test.That(t, resp, test.ShouldBeNil)
 	test.That(t, err, test.ShouldNotBeNil)
 
-	failingMotor.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	failingMotor.StopFunc = func(ctx context.Context, extra map[string]any) error {
 		return errStopFailed
 	}
 	req = pb.StopRequest{Name: failMotorName}
@@ -168,7 +168,7 @@ func TestServerStop(t *testing.T) {
 	test.That(t, resp, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldNotBeNil)
 
-	workingMotor.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	workingMotor.StopFunc = func(ctx context.Context, extra map[string]any) error {
 		return nil
 	}
 	req = pb.StopRequest{Name: testMotorName}
@@ -186,7 +186,7 @@ func TestServerIsOn(t *testing.T) {
 	test.That(t, resp, test.ShouldBeNil)
 	test.That(t, err, test.ShouldNotBeNil)
 
-	failingMotor.IsPoweredFunc = func(ctx context.Context, extra map[string]interface{}) (bool, float64, error) {
+	failingMotor.IsPoweredFunc = func(ctx context.Context, extra map[string]any) (bool, float64, error) {
 		return false, 0.0, errIsPoweredFailed
 	}
 	req = pb.IsPoweredRequest{Name: failMotorName}
@@ -194,7 +194,7 @@ func TestServerIsOn(t *testing.T) {
 	test.That(t, resp, test.ShouldBeNil)
 	test.That(t, err, test.ShouldNotBeNil)
 
-	workingMotor.IsPoweredFunc = func(ctx context.Context, extra map[string]interface{}) (bool, float64, error) {
+	workingMotor.IsPoweredFunc = func(ctx context.Context, extra map[string]any) (bool, float64, error) {
 		return true, 1.0, nil
 	}
 	req = pb.IsPoweredRequest{Name: testMotorName}
@@ -214,7 +214,7 @@ func TestServerGoTo(t *testing.T) {
 	test.That(t, resp, test.ShouldBeNil)
 	test.That(t, err, test.ShouldNotBeNil)
 
-	failingMotor.GoToFunc = func(ctx context.Context, rpm, position float64, extra map[string]interface{}) error {
+	failingMotor.GoToFunc = func(ctx context.Context, rpm, position float64, extra map[string]any) error {
 		return errGoToFailed
 	}
 	req = pb.GoToRequest{Name: failMotorName, Rpm: 20.0, PositionRevolutions: 2.5}
@@ -222,7 +222,7 @@ func TestServerGoTo(t *testing.T) {
 	test.That(t, resp, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldNotBeNil)
 
-	workingMotor.GoToFunc = func(ctx context.Context, rpm, position float64, extra map[string]interface{}) error {
+	workingMotor.GoToFunc = func(ctx context.Context, rpm, position float64, extra map[string]any) error {
 		return nil
 	}
 	req = pb.GoToRequest{Name: testMotorName, Rpm: 20.0, PositionRevolutions: 2.5}
@@ -241,7 +241,7 @@ func TestServerResetZeroPosition(t *testing.T) {
 	test.That(t, resp, test.ShouldBeNil)
 	test.That(t, err, test.ShouldNotBeNil)
 
-	failingMotor.ResetZeroPositionFunc = func(ctx context.Context, offset float64, extra map[string]interface{}) error {
+	failingMotor.ResetZeroPositionFunc = func(ctx context.Context, offset float64, extra map[string]any) error {
 		return errResetZeroFailed
 	}
 	req = pb.ResetZeroPositionRequest{Name: failMotorName, Offset: 1.1}
@@ -249,7 +249,7 @@ func TestServerResetZeroPosition(t *testing.T) {
 	test.That(t, resp, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldNotBeNil)
 
-	workingMotor.ResetZeroPositionFunc = func(ctx context.Context, offset float64, extra map[string]interface{}) error {
+	workingMotor.ResetZeroPositionFunc = func(ctx context.Context, offset float64, extra map[string]any) error {
 		return nil
 	}
 	req = pb.ResetZeroPositionRequest{Name: testMotorName, Offset: 1.1}
@@ -261,13 +261,13 @@ func TestServerResetZeroPosition(t *testing.T) {
 func TestServerExtraParams(t *testing.T) {
 	motorServer, workingMotor, _, _ := newServer()
 
-	var actualExtra map[string]interface{}
-	workingMotor.ResetZeroPositionFunc = func(ctx context.Context, offset float64, extra map[string]interface{}) error {
+	var actualExtra map[string]any
+	workingMotor.ResetZeroPositionFunc = func(ctx context.Context, offset float64, extra map[string]any) error {
 		actualExtra = extra
 		return nil
 	}
 
-	expectedExtra := map[string]interface{}{"foo": "bar", "baz": []interface{}{1., 2., 3.}}
+	expectedExtra := map[string]any{"foo": "bar", "baz": []any{1., 2., 3.}}
 
 	ext, err := protoutils.StructToStructPb(expectedExtra)
 	test.That(t, err, test.ShouldBeNil)

--- a/components/motor/tmcstepper/stepper_motor_tmc.go
+++ b/components/motor/tmcstepper/stepper_motor_tmc.go
@@ -388,7 +388,7 @@ func (m *Motor) GetSG(ctx context.Context) (int32, error) {
 }
 
 // Position gives the current motor position.
-func (m *Motor) Position(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (m *Motor) Position(ctx context.Context, extra map[string]any) (float64, error) {
 	rawPos, err := m.readReg(ctx, xActual)
 	if err != nil {
 		return 0, errors.Wrapf(err, "error in Position from motor (%s)", m.motorName)
@@ -397,7 +397,7 @@ func (m *Motor) Position(ctx context.Context, extra map[string]interface{}) (flo
 }
 
 // Properties returns the status of optional properties on the motor.
-func (m *Motor) Properties(ctx context.Context, extra map[string]interface{}) (motor.Properties, error) {
+func (m *Motor) Properties(ctx context.Context, extra map[string]any) (motor.Properties, error) {
 	return motor.Properties{
 		PositionReporting: true,
 	}, nil
@@ -405,7 +405,7 @@ func (m *Motor) Properties(ctx context.Context, extra map[string]interface{}) (m
 
 // SetPower sets the motor at a particular rpm based on the percent of
 // maxRPM supplied by powerPct (between -1 and 1).
-func (m *Motor) SetPower(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
+func (m *Motor) SetPower(ctx context.Context, powerPct float64, extra map[string]any) error {
 	m.opMgr.CancelRunning(ctx)
 	m.powerPct = powerPct
 	return m.doJog(ctx, powerPct*m.maxRPM)
@@ -441,7 +441,7 @@ func (m *Motor) doJog(ctx context.Context, rpm float64) error {
 // GoFor turns in the given direction the given number of times at the given speed.
 // Both the RPM and the revolutions can be assigned negative values to move in a backwards direction.
 // Note: if both are negative the motor will spin in the forward direction.
-func (m *Motor) GoFor(ctx context.Context, rpm, rotations float64, extra map[string]interface{}) error {
+func (m *Motor) GoFor(ctx context.Context, rpm, rotations float64, extra map[string]any) error {
 	if math.Abs(rpm) < 0.1 {
 		m.logger.CWarn(ctx, "motor speed is nearly 0 rev_per_min")
 		return motor.NewZeroRPMError()
@@ -486,7 +486,7 @@ func (m *Motor) rpmsToA(acc float64) int32 {
 // GoTo moves to the specified position in terms of (provided in revolutions from home/zero),
 // at a specific speed. Regardless of the directionality of the RPM this function will move the
 // motor towards the specified target.
-func (m *Motor) GoTo(ctx context.Context, rpm, positionRevolutions float64, extra map[string]interface{}) error {
+func (m *Motor) GoTo(ctx context.Context, rpm, positionRevolutions float64, extra map[string]any) error {
 	ctx, done := m.opMgr.New(ctx)
 	defer done()
 
@@ -517,7 +517,7 @@ func (m *Motor) GoTo(ctx context.Context, rpm, positionRevolutions float64, extr
 }
 
 // IsPowered returns true if the motor is currently moving.
-func (m *Motor) IsPowered(ctx context.Context, extra map[string]interface{}) (bool, float64, error) {
+func (m *Motor) IsPowered(ctx context.Context, extra map[string]any) (bool, float64, error) {
 	on, err := m.IsMoving(ctx)
 	if err != nil {
 		return on, m.powerPct, errors.Wrapf(err, "error in IsPowered from motor (%s)", m.motorName)
@@ -554,7 +554,7 @@ func (m *Motor) Enable(ctx context.Context, turnOn bool) error {
 }
 
 // Stop stops the motor.
-func (m *Motor) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (m *Motor) Stop(ctx context.Context, extra map[string]any) error {
 	m.opMgr.CancelRunning(ctx)
 	return m.doJog(ctx, 0)
 }
@@ -663,7 +663,7 @@ func (m *Motor) goTillStop(ctx context.Context, rpm float64, stopFunc func(ctx c
 
 // ResetZeroPosition sets the current position of the motor specified by the request
 // (adjusted by a given offset) to be its new zero position.
-func (m *Motor) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]interface{}) error {
+func (m *Motor) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]any) error {
 	on, _, err := m.IsPowered(ctx, extra)
 	if err != nil {
 		return errors.Wrapf(err, "error in ResetZeroPosition from motor (%s)", m.motorName)
@@ -686,7 +686,7 @@ const (
 )
 
 // DoCommand executes additional commands beyond the Motor{} interface.
-func (m *Motor) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (m *Motor) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	name, ok := cmd["command"]
 	if !ok {
 		return nil, errors.Errorf("missing %s value", Command)

--- a/components/motor/ulnstepper/28byj-48.go
+++ b/components/motor/ulnstepper/28byj-48.go
@@ -246,7 +246,7 @@ func (m *uln28byj) setPins(ctx context.Context, pins [4]bool) error {
 // revolutions at a given speed in revolutions per minute. Both the RPM and the revolutions
 // can be assigned negative values to move in a backwards direction. Note: if both are negative
 // the motor will spin in the forward direction.
-func (m *uln28byj) GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]interface{}) error {
+func (m *uln28byj) GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]any) error {
 	ctx, done := m.opMgr.New(ctx)
 	defer done()
 
@@ -295,7 +295,7 @@ func (m *uln28byj) goMath(ctx context.Context, rpm, revolutions float64) (int64,
 // GoTo instructs the motor to go to a specific position (provided in revolutions from home/zero),
 // at a specific RPM. Regardless of the directionality of the RPM this function will move the motor
 // towards the specified target.
-func (m *uln28byj) GoTo(ctx context.Context, rpm, positionRevolutions float64, extra map[string]interface{}) error {
+func (m *uln28byj) GoTo(ctx context.Context, rpm, positionRevolutions float64, extra map[string]any) error {
 	curPos, err := m.Position(ctx, extra)
 	if err != nil {
 		return errors.Wrapf(err, "error in GoTo from motor (%s)", m.motorName)
@@ -312,7 +312,7 @@ func (m *uln28byj) GoTo(ctx context.Context, rpm, positionRevolutions float64, e
 }
 
 // Set the current position (+/- offset) to be the new zero (home) position.
-func (m *uln28byj) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]interface{}) error {
+func (m *uln28byj) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]any) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	m.stepPosition = int64(-1 * offset * float64(m.ticksPerRotation))
@@ -321,20 +321,20 @@ func (m *uln28byj) ResetZeroPosition(ctx context.Context, offset float64, extra 
 }
 
 // SetPower is invalid for this motor.
-func (m *uln28byj) SetPower(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
+func (m *uln28byj) SetPower(ctx context.Context, powerPct float64, extra map[string]any) error {
 	return errors.Errorf("raw power not supported in stepper motor (%s)", m.motorName)
 }
 
 // Position reports the current step position of the motor. If it's not supported, the returned
 // data is undefined.
-func (m *uln28byj) Position(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (m *uln28byj) Position(ctx context.Context, extra map[string]any) (float64, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	return float64(m.stepPosition) / float64(m.ticksPerRotation), nil
 }
 
 // Properties returns the status of whether the motor supports certain optional properties.
-func (m *uln28byj) Properties(ctx context.Context, extra map[string]interface{}) (motor.Properties, error) {
+func (m *uln28byj) Properties(ctx context.Context, extra map[string]any) (motor.Properties, error) {
 	return motor.Properties{
 		PositionReporting: true,
 	}, nil
@@ -348,7 +348,7 @@ func (m *uln28byj) IsMoving(ctx context.Context) (bool, error) {
 }
 
 // Stop turns the power to the motor off immediately, without any gradual step down.
-func (m *uln28byj) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (m *uln28byj) Stop(ctx context.Context, extra map[string]any) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	m.targetStepPosition = m.stepPosition
@@ -358,7 +358,7 @@ func (m *uln28byj) Stop(ctx context.Context, extra map[string]interface{}) error
 // IsPowered returns whether or not the motor is currently on. It also returns the percent power
 // that the motor has, but stepper motors only have this set to 0% or 100%, so it's a little
 // redundant.
-func (m *uln28byj) IsPowered(ctx context.Context, extra map[string]interface{}) (bool, float64, error) {
+func (m *uln28byj) IsPowered(ctx context.Context, extra map[string]any) (bool, float64, error) {
 	on, err := m.IsMoving(ctx)
 	if err != nil {
 		return on, 0.0, errors.Wrapf(err, "error in IsPowered from motor (%s)", m.motorName)

--- a/components/motor/ulnstepper/28byj-48_test.go
+++ b/components/motor/ulnstepper/28byj-48_test.go
@@ -337,7 +337,7 @@ type mockGPIOPin struct {
 	pinStates []bool
 }
 
-func (m *mockGPIOPin) Set(ctx context.Context, high bool, extra map[string]interface{}) error {
+func (m *mockGPIOPin) Set(ctx context.Context, high bool, extra map[string]any) error {
 	m.pinStates = append(m.pinStates, high)
 	return nil
 }

--- a/components/movementsensor/adxl345/adxl345.go
+++ b/components/movementsensor/adxl345/adxl345.go
@@ -534,15 +534,15 @@ func toLinearAcceleration(data []byte) r3.Vector {
 	}
 }
 
-func (adxl *adxl345) AngularVelocity(ctx context.Context, extra map[string]interface{}) (spatialmath.AngularVelocity, error) {
+func (adxl *adxl345) AngularVelocity(ctx context.Context, extra map[string]any) (spatialmath.AngularVelocity, error) {
 	return spatialmath.AngularVelocity{}, movementsensor.ErrMethodUnimplementedAngularVelocity
 }
 
-func (adxl *adxl345) LinearVelocity(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+func (adxl *adxl345) LinearVelocity(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 	return r3.Vector{}, movementsensor.ErrMethodUnimplementedLinearVelocity
 }
 
-func (adxl *adxl345) LinearAcceleration(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+func (adxl *adxl345) LinearAcceleration(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 	adxl.mu.Lock()
 	defer adxl.mu.Unlock()
 	lastError := adxl.err.Get()
@@ -554,24 +554,24 @@ func (adxl *adxl345) LinearAcceleration(ctx context.Context, extra map[string]in
 	return adxl.linearAcceleration, nil
 }
 
-func (adxl *adxl345) Orientation(ctx context.Context, extra map[string]interface{}) (spatialmath.Orientation, error) {
+func (adxl *adxl345) Orientation(ctx context.Context, extra map[string]any) (spatialmath.Orientation, error) {
 	return spatialmath.NewOrientationVector(), movementsensor.ErrMethodUnimplementedOrientation
 }
 
-func (adxl *adxl345) CompassHeading(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (adxl *adxl345) CompassHeading(ctx context.Context, extra map[string]any) (float64, error) {
 	return 0, movementsensor.ErrMethodUnimplementedCompassHeading
 }
 
-func (adxl *adxl345) Position(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+func (adxl *adxl345) Position(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 	return geo.NewPoint(0, 0), 0, movementsensor.ErrMethodUnimplementedPosition
 }
 
-func (adxl *adxl345) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
+func (adxl *adxl345) Accuracy(ctx context.Context, extra map[string]any) (*movementsensor.Accuracy, error) {
 	// this driver is unable to provide positional or compass heading data
 	return movementsensor.UnimplementedAccuracies()
 }
 
-func (adxl *adxl345) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+func (adxl *adxl345) Readings(ctx context.Context, extra map[string]any) (map[string]any, error) {
 	readings, err := movementsensor.DefaultAPIReadings(ctx, adxl, extra)
 	if err != nil {
 		return nil, err
@@ -586,7 +586,7 @@ func (adxl *adxl345) Readings(ctx context.Context, extra map[string]interface{})
 	return readings, adxl.err.Get()
 }
 
-func (adxl *adxl345) Properties(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+func (adxl *adxl345) Properties(ctx context.Context, extra map[string]any) (*movementsensor.Properties, error) {
 	return &movementsensor.Properties{
 		LinearAccelerationSupported: true,
 	}, nil

--- a/components/movementsensor/adxl345/adxl345_test.go
+++ b/components/movementsensor/adxl345/adxl345_test.go
@@ -57,7 +57,7 @@ func setupDependencies(mockData []byte) (resource.Config, resource.Dependencies,
 func sendInterrupt(ctx context.Context, adxl movementsensor.MovementSensor, t *testing.T, interrupt board.DigitalInterrupt, key string) {
 	interrupt.Tick(ctx, true, nowNanosTest())
 	testutils.WaitForAssertion(t, func(tb testing.TB) {
-		readings, err := adxl.Readings(ctx, map[string]interface{}{})
+		readings, err := adxl.Readings(ctx, map[string]any{})
 		test.That(tb, err, test.ShouldBeNil)
 		test.That(tb, readings[key], test.ShouldNotBeZeroValue)
 	})
@@ -204,7 +204,7 @@ func TestInterrupts(t *testing.T) {
 		adxl, err := makeAdxl345(ctx, deps, cfg, logger, i2c)
 		test.That(t, err, test.ShouldBeNil)
 
-		readings, err := adxl.Readings(ctx, map[string]interface{}{})
+		readings, err := adxl.Readings(ctx, map[string]any{})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, readings["freefall_count"], test.ShouldEqual, 0)
 		test.That(t, readings["single_tap_count"], test.ShouldEqual, 0)
@@ -216,7 +216,7 @@ func TestInterrupts(t *testing.T) {
 
 		sendInterrupt(ctx, adxl, t, interrupt, "freefall_count")
 
-		readings, err := adxl.Readings(ctx, map[string]interface{}{})
+		readings, err := adxl.Readings(ctx, map[string]any{})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, readings["freefall_count"], test.ShouldEqual, 1)
 		test.That(t, readings["single_tap_count"], test.ShouldEqual, 1)
@@ -239,7 +239,7 @@ func TestInterrupts(t *testing.T) {
 
 		sendInterrupt(ctx, adxl, t, interrupt, "single_tap_count")
 
-		readings, err := adxl.Readings(ctx, map[string]interface{}{})
+		readings, err := adxl.Readings(ctx, map[string]any{})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, readings["freefall_count"], test.ShouldEqual, 0)
 		test.That(t, readings["single_tap_count"], test.ShouldEqual, 1)
@@ -262,7 +262,7 @@ func TestInterrupts(t *testing.T) {
 
 		sendInterrupt(ctx, adxl, t, interrupt, "freefall_count")
 
-		readings, err := adxl.Readings(ctx, map[string]interface{}{})
+		readings, err := adxl.Readings(ctx, map[string]any{})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, readings["freefall_count"], test.ShouldEqual, 1)
 		test.That(t, readings["single_tap_count"], test.ShouldEqual, 0)

--- a/components/movementsensor/client.go
+++ b/components/movementsensor/client.go
@@ -43,7 +43,7 @@ func NewClientFromConn(
 	}, nil
 }
 
-func (c *client) Position(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+func (c *client) Position(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 	ext, err := structpb.NewStruct(extra)
 	if err != nil {
 		return nil, 0, err
@@ -60,7 +60,7 @@ func (c *client) Position(ctx context.Context, extra map[string]interface{}) (*g
 		nil
 }
 
-func (c *client) LinearVelocity(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+func (c *client) LinearVelocity(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 	ext, err := structpb.NewStruct(extra)
 	if err != nil {
 		return r3.Vector{}, err
@@ -75,7 +75,7 @@ func (c *client) LinearVelocity(ctx context.Context, extra map[string]interface{
 	return protoutils.ConvertVectorProtoToR3(resp.LinearVelocity), nil
 }
 
-func (c *client) AngularVelocity(ctx context.Context, extra map[string]interface{}) (spatialmath.AngularVelocity, error) {
+func (c *client) AngularVelocity(ctx context.Context, extra map[string]any) (spatialmath.AngularVelocity, error) {
 	ext, err := structpb.NewStruct(extra)
 	if err != nil {
 		return spatialmath.AngularVelocity{}, err
@@ -90,7 +90,7 @@ func (c *client) AngularVelocity(ctx context.Context, extra map[string]interface
 	return spatialmath.AngularVelocity(protoutils.ConvertVectorProtoToR3(resp.AngularVelocity)), nil
 }
 
-func (c *client) LinearAcceleration(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+func (c *client) LinearAcceleration(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 	ext, err := structpb.NewStruct(extra)
 	if err != nil {
 		return r3.Vector{}, err
@@ -105,7 +105,7 @@ func (c *client) LinearAcceleration(ctx context.Context, extra map[string]interf
 	return protoutils.ConvertVectorProtoToR3(resp.LinearAcceleration), nil
 }
 
-func (c *client) CompassHeading(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (c *client) CompassHeading(ctx context.Context, extra map[string]any) (float64, error) {
 	ext, err := structpb.NewStruct(extra)
 	if err != nil {
 		return 0, err
@@ -120,7 +120,7 @@ func (c *client) CompassHeading(ctx context.Context, extra map[string]interface{
 	return resp.Value, nil
 }
 
-func (c *client) Orientation(ctx context.Context, extra map[string]interface{}) (spatialmath.Orientation, error) {
+func (c *client) Orientation(ctx context.Context, extra map[string]any) (spatialmath.Orientation, error) {
 	ext, err := structpb.NewStruct(extra)
 	if err != nil {
 		return spatialmath.NewZeroOrientation(), err
@@ -135,7 +135,7 @@ func (c *client) Orientation(ctx context.Context, extra map[string]interface{}) 
 	return protoutils.ConvertProtoToOrientation(resp.Orientation), nil
 }
 
-func (c *client) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+func (c *client) Readings(ctx context.Context, extra map[string]any) (map[string]any, error) {
 	ext, err := structpb.NewStruct(extra)
 	if err != nil {
 		return nil, err
@@ -151,7 +151,7 @@ func (c *client) Readings(ctx context.Context, extra map[string]interface{}) (ma
 	return protoutils.ReadingProtoToGo(resp.Readings)
 }
 
-func (c *client) Accuracy(ctx context.Context, extra map[string]interface{}) (*Accuracy, error,
+func (c *client) Accuracy(ctx context.Context, extra map[string]any) (*Accuracy, error,
 ) {
 	ext, err := structpb.NewStruct(extra)
 	if err != nil {
@@ -167,7 +167,7 @@ func (c *client) Accuracy(ctx context.Context, extra map[string]interface{}) (*A
 	return protoFeaturesToAccuracy(resp), nil
 }
 
-func (c *client) Properties(ctx context.Context, extra map[string]interface{}) (*Properties, error) {
+func (c *client) Properties(ctx context.Context, extra map[string]any) (*Properties, error) {
 	ext, err := structpb.NewStruct(extra)
 	if err != nil {
 		return nil, err
@@ -182,6 +182,6 @@ func (c *client) Properties(ctx context.Context, extra map[string]interface{}) (
 	return ProtoFeaturesToProperties(resp), nil
 }
 
-func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (c *client) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	return protoutils.DoFromResourceClient(ctx, c.client, c.name, cmd)
 }

--- a/components/movementsensor/client_test.go
+++ b/components/movementsensor/client_test.go
@@ -52,7 +52,7 @@ func TestClient(t *testing.T) {
 	props := &movementsensor.Properties{LinearVelocitySupported: true}
 	aclZ := 1.0
 	acy := &movementsensor.Accuracy{AccuracyMap: map[string]float32{"x": 1.1}}
-	rs := map[string]interface{}{
+	rs := map[string]any{
 		"position":            loc,
 		"altitude":            alt,
 		"linear_velocity":     r3.Vector{X: 0, Y: speed, Z: 0},
@@ -63,52 +63,52 @@ func TestClient(t *testing.T) {
 	}
 
 	injectMovementSensor := &inject.MovementSensor{}
-	injectMovementSensor.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+	injectMovementSensor.PositionFunc = func(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 		return loc, alt, nil
 	}
-	injectMovementSensor.LinearVelocityFunc = func(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+	injectMovementSensor.LinearVelocityFunc = func(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 		return r3.Vector{X: 0, Y: speed, Z: 0}, nil
 	}
-	injectMovementSensor.LinearAccelerationFunc = func(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+	injectMovementSensor.LinearAccelerationFunc = func(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 		return r3.Vector{X: 0, Y: 0, Z: aclZ}, nil
 	}
-	injectMovementSensor.AngularVelocityFunc = func(ctx context.Context, extra map[string]interface{}) (spatialmath.AngularVelocity, error) {
+	injectMovementSensor.AngularVelocityFunc = func(ctx context.Context, extra map[string]any) (spatialmath.AngularVelocity, error) {
 		return spatialmath.AngularVelocity{X: 0, Y: 0, Z: ang}, nil
 	}
-	injectMovementSensor.OrientationFunc = func(ctx context.Context, extra map[string]interface{}) (spatialmath.Orientation, error) {
+	injectMovementSensor.OrientationFunc = func(ctx context.Context, extra map[string]any) (spatialmath.Orientation, error) {
 		return ori, nil
 	}
-	injectMovementSensor.CompassHeadingFunc = func(ctx context.Context, extra map[string]interface{}) (float64, error) { return heading, nil }
-	injectMovementSensor.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+	injectMovementSensor.CompassHeadingFunc = func(ctx context.Context, extra map[string]any) (float64, error) { return heading, nil }
+	injectMovementSensor.PropertiesFunc = func(ctx context.Context, extra map[string]any) (*movementsensor.Properties, error) {
 		return props, nil
 	}
-	injectMovementSensor.AccuracyFunc = func(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
+	injectMovementSensor.AccuracyFunc = func(ctx context.Context, extra map[string]any) (*movementsensor.Accuracy, error) {
 		return acy, nil
 	}
-	injectMovementSensor.ReadingsFunc = func(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+	injectMovementSensor.ReadingsFunc = func(ctx context.Context, extra map[string]any) (map[string]any, error) {
 		return rs, nil
 	}
 
 	injectMovementSensor2 := &inject.MovementSensor{}
-	injectMovementSensor2.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+	injectMovementSensor2.PositionFunc = func(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 		return nil, 0, errLocation
 	}
-	injectMovementSensor2.LinearVelocityFunc = func(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+	injectMovementSensor2.LinearVelocityFunc = func(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 		return r3.Vector{}, errLinearVelocity
 	}
-	injectMovementSensor2.LinearAccelerationFunc = func(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+	injectMovementSensor2.LinearAccelerationFunc = func(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 		return r3.Vector{}, errLinearAcceleration
 	}
-	injectMovementSensor2.AngularVelocityFunc = func(ctx context.Context, extra map[string]interface{}) (spatialmath.AngularVelocity, error) {
+	injectMovementSensor2.AngularVelocityFunc = func(ctx context.Context, extra map[string]any) (spatialmath.AngularVelocity, error) {
 		return spatialmath.AngularVelocity{}, errAngularVelocity
 	}
-	injectMovementSensor2.OrientationFunc = func(ctx context.Context, extra map[string]interface{}) (spatialmath.Orientation, error) {
+	injectMovementSensor2.OrientationFunc = func(ctx context.Context, extra map[string]any) (spatialmath.Orientation, error) {
 		return nil, errOrientation
 	}
-	injectMovementSensor2.CompassHeadingFunc = func(ctx context.Context, extra map[string]interface{}) (float64, error) {
+	injectMovementSensor2.CompassHeadingFunc = func(ctx context.Context, extra map[string]any) (float64, error) {
 		return 0, errCompassHeading
 	}
-	injectMovementSensor2.ReadingsFunc = func(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+	injectMovementSensor2.ReadingsFunc = func(ctx context.Context, extra map[string]any) (map[string]any, error) {
 		return nil, errReadingsFailed
 	}
 
@@ -148,48 +148,48 @@ func TestClient(t *testing.T) {
 		test.That(t, resp["command"], test.ShouldEqual, testutils.TestCommand["command"])
 		test.That(t, resp["data"], test.ShouldEqual, testutils.TestCommand["data"])
 
-		loc1, alt1, err := gps1Client.Position(context.Background(), map[string]interface{}{"foo": "bar"})
+		loc1, alt1, err := gps1Client.Position(context.Background(), map[string]any{"foo": "bar"})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, loc1, test.ShouldResemble, loc)
 		test.That(t, alt1, test.ShouldAlmostEqual, alt)
-		test.That(t, injectMovementSensor.PositionFuncExtraCap, test.ShouldResemble, map[string]interface{}{"foo": "bar"})
+		test.That(t, injectMovementSensor.PositionFuncExtraCap, test.ShouldResemble, map[string]any{"foo": "bar"})
 
-		vel1, err := gps1Client.LinearVelocity(context.Background(), map[string]interface{}{"foo": "bar"})
+		vel1, err := gps1Client.LinearVelocity(context.Background(), map[string]any{"foo": "bar"})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, vel1.Y, test.ShouldAlmostEqual, speed)
-		test.That(t, injectMovementSensor.LinearVelocityFuncExtraCap, test.ShouldResemble, map[string]interface{}{"foo": "bar"})
+		test.That(t, injectMovementSensor.LinearVelocityFuncExtraCap, test.ShouldResemble, map[string]any{"foo": "bar"})
 
-		av1, err := gps1Client.AngularVelocity(context.Background(), map[string]interface{}{"foo": "bar"})
+		av1, err := gps1Client.AngularVelocity(context.Background(), map[string]any{"foo": "bar"})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, av1.Z, test.ShouldAlmostEqual, ang)
-		test.That(t, injectMovementSensor.AngularVelocityFuncExtraCap, test.ShouldResemble, map[string]interface{}{"foo": "bar"})
+		test.That(t, injectMovementSensor.AngularVelocityFuncExtraCap, test.ShouldResemble, map[string]any{"foo": "bar"})
 
-		o1, err := gps1Client.Orientation(context.Background(), map[string]interface{}{"foo": "bar"})
+		o1, err := gps1Client.Orientation(context.Background(), map[string]any{"foo": "bar"})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, o1.OrientationVectorDegrees(), test.ShouldResemble, ori.OrientationVectorDegrees())
-		test.That(t, injectMovementSensor.OrientationFuncExtraCap, test.ShouldResemble, map[string]interface{}{"foo": "bar"})
+		test.That(t, injectMovementSensor.OrientationFuncExtraCap, test.ShouldResemble, map[string]any{"foo": "bar"})
 
-		ch, err := gps1Client.CompassHeading(context.Background(), map[string]interface{}{"foo": "bar"})
+		ch, err := gps1Client.CompassHeading(context.Background(), map[string]any{"foo": "bar"})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, ch, test.ShouldResemble, heading)
-		test.That(t, injectMovementSensor.CompassHeadingFuncExtraCap, test.ShouldResemble, map[string]interface{}{"foo": "bar"})
+		test.That(t, injectMovementSensor.CompassHeadingFuncExtraCap, test.ShouldResemble, map[string]any{"foo": "bar"})
 
-		props1, err := gps1Client.Properties(context.Background(), map[string]interface{}{"foo": "bar"})
+		props1, err := gps1Client.Properties(context.Background(), map[string]any{"foo": "bar"})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, props1.LinearVelocitySupported, test.ShouldResemble, props.LinearVelocitySupported)
-		test.That(t, injectMovementSensor.PropertiesFuncExtraCap, test.ShouldResemble, map[string]interface{}{"foo": "bar"})
+		test.That(t, injectMovementSensor.PropertiesFuncExtraCap, test.ShouldResemble, map[string]any{"foo": "bar"})
 
-		acc1, err := gps1Client.Accuracy(context.Background(), map[string]interface{}{"foo": "bar"})
+		acc1, err := gps1Client.Accuracy(context.Background(), map[string]any{"foo": "bar"})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, acc1, test.ShouldResemble, acy)
-		test.That(t, injectMovementSensor.AccuracyFuncExtraCap, test.ShouldResemble, map[string]interface{}{"foo": "bar"})
+		test.That(t, injectMovementSensor.AccuracyFuncExtraCap, test.ShouldResemble, map[string]any{"foo": "bar"})
 
-		la1, err := gps1Client.LinearAcceleration(context.Background(), map[string]interface{}{"foo": "bar"})
+		la1, err := gps1Client.LinearAcceleration(context.Background(), map[string]any{"foo": "bar"})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, la1.Z, test.ShouldResemble, aclZ)
-		test.That(t, injectMovementSensor.LinearAccelerationExtraCap, test.ShouldResemble, map[string]interface{}{"foo": "bar"})
+		test.That(t, injectMovementSensor.LinearAccelerationExtraCap, test.ShouldResemble, map[string]any{"foo": "bar"})
 
-		rs1, err := gps1Client.Readings(context.Background(), map[string]interface{}{"foo": "bar"})
+		rs1, err := gps1Client.Readings(context.Background(), map[string]any{"foo": "bar"})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, rs1["position"], test.ShouldResemble, rs["position"])
 		test.That(t, rs1["altitude"], test.ShouldResemble, rs["altitude"])
@@ -210,23 +210,23 @@ func TestClient(t *testing.T) {
 		client2, err := resourceAPI.RPCClient(context.Background(), conn, "", movementsensor.Named(failMovementSensorName), logger)
 		test.That(t, err, test.ShouldBeNil)
 
-		_, _, err = client2.Position(context.Background(), make(map[string]interface{}))
+		_, _, err = client2.Position(context.Background(), make(map[string]any))
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errLocation.Error())
 
-		_, err = client2.LinearVelocity(context.Background(), make(map[string]interface{}))
+		_, err = client2.LinearVelocity(context.Background(), make(map[string]any))
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errLinearVelocity.Error())
 
-		_, err = client2.LinearAcceleration(context.Background(), make(map[string]interface{}))
+		_, err = client2.LinearAcceleration(context.Background(), make(map[string]any))
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errLinearAcceleration.Error())
 
-		_, err = client2.AngularVelocity(context.Background(), make(map[string]interface{}))
+		_, err = client2.AngularVelocity(context.Background(), make(map[string]any))
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errAngularVelocity.Error())
 
-		_, err = client2.(sensor.Sensor).Readings(context.Background(), make(map[string]interface{}))
+		_, err = client2.(sensor.Sensor).Readings(context.Background(), make(map[string]any))
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errReadingsFailed.Error())
 

--- a/components/movementsensor/collectors.go
+++ b/components/movementsensor/collectors.go
@@ -45,7 +45,7 @@ func (m method) String() string {
 	return "Unknown"
 }
 
-func assertMovementSensor(resource interface{}) (MovementSensor, error) {
+func assertMovementSensor(resource any) (MovementSensor, error) {
 	ms, ok := resource.(MovementSensor)
 	if !ok {
 		return nil, data.InvalidInterfaceErr(API)
@@ -55,13 +55,13 @@ func assertMovementSensor(resource interface{}) (MovementSensor, error) {
 
 // newLinearVelocityCollector returns a collector to register a linear velocity method. If one is already registered
 // with the same MethodMetadata it will panic.
-func newLinearVelocityCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+func newLinearVelocityCollector(resource any, params data.CollectorParams) (data.Collector, error) {
 	ms, err := assertMovementSensor(resource)
 	if err != nil {
 		return nil, err
 	}
 
-	cFunc := data.CaptureFunc(func(ctx context.Context, extra map[string]*anypb.Any) (interface{}, error) {
+	cFunc := data.CaptureFunc(func(ctx context.Context, extra map[string]*anypb.Any) (any, error) {
 		vec, err := ms.LinearVelocity(ctx, data.FromDMExtraMap)
 		if err != nil {
 			// A modular filter component can be created to filter the readings from a component. The error ErrNoCaptureToStore
@@ -84,13 +84,13 @@ func newLinearVelocityCollector(resource interface{}, params data.CollectorParam
 
 // newPositionCollector returns a collector to register a position method. If one is already registered
 // with the same MethodMetadata it will panic.
-func newPositionCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+func newPositionCollector(resource any, params data.CollectorParams) (data.Collector, error) {
 	ms, err := assertMovementSensor(resource)
 	if err != nil {
 		return nil, err
 	}
 
-	cFunc := data.CaptureFunc(func(ctx context.Context, extra map[string]*anypb.Any) (interface{}, error) {
+	cFunc := data.CaptureFunc(func(ctx context.Context, extra map[string]*anypb.Any) (any, error) {
 		pos, altitude, err := ms.Position(ctx, data.FromDMExtraMap)
 		if err != nil {
 			// A modular filter component can be created to filter the readings from a component. The error ErrNoCaptureToStore
@@ -118,13 +118,13 @@ func newPositionCollector(resource interface{}, params data.CollectorParams) (da
 
 // newAngularVelocityCollector returns a collector to register an angular velocity method. If one is already registered
 // with the same MethodMetadata it will panic.
-func newAngularVelocityCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+func newAngularVelocityCollector(resource any, params data.CollectorParams) (data.Collector, error) {
 	ms, err := assertMovementSensor(resource)
 	if err != nil {
 		return nil, err
 	}
 
-	cFunc := data.CaptureFunc(func(ctx context.Context, extra map[string]*anypb.Any) (interface{}, error) {
+	cFunc := data.CaptureFunc(func(ctx context.Context, extra map[string]*anypb.Any) (any, error) {
 		vel, err := ms.AngularVelocity(ctx, data.FromDMExtraMap)
 		if err != nil {
 			// A modular filter component can be created to filter the readings from a component. The error ErrNoCaptureToStore
@@ -147,13 +147,13 @@ func newAngularVelocityCollector(resource interface{}, params data.CollectorPara
 
 // newCompassHeadingCollector returns a collector to register a compass heading method. If one is already registered
 // with the same MethodMetadata it will panic.
-func newCompassHeadingCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+func newCompassHeadingCollector(resource any, params data.CollectorParams) (data.Collector, error) {
 	ms, err := assertMovementSensor(resource)
 	if err != nil {
 		return nil, err
 	}
 
-	cFunc := data.CaptureFunc(func(ctx context.Context, extra map[string]*anypb.Any) (interface{}, error) {
+	cFunc := data.CaptureFunc(func(ctx context.Context, extra map[string]*anypb.Any) (any, error) {
 		heading, err := ms.CompassHeading(ctx, data.FromDMExtraMap)
 		if err != nil {
 			// A modular filter component can be created to filter the readings from a component. The error ErrNoCaptureToStore
@@ -172,13 +172,13 @@ func newCompassHeadingCollector(resource interface{}, params data.CollectorParam
 
 // newLinearAccelerationCollector returns a collector to register a linear acceleration method. If one is already registered
 // with the same MethodMetadata it will panic.
-func newLinearAccelerationCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+func newLinearAccelerationCollector(resource any, params data.CollectorParams) (data.Collector, error) {
 	ms, err := assertMovementSensor(resource)
 	if err != nil {
 		return nil, err
 	}
 
-	cFunc := data.CaptureFunc(func(ctx context.Context, extra map[string]*anypb.Any) (interface{}, error) {
+	cFunc := data.CaptureFunc(func(ctx context.Context, extra map[string]*anypb.Any) (any, error) {
 		accel, err := ms.LinearAcceleration(ctx, data.FromDMExtraMap)
 		if err != nil {
 			// A modular filter component can be created to filter the readings from a component. The error ErrNoCaptureToStore
@@ -201,13 +201,13 @@ func newLinearAccelerationCollector(resource interface{}, params data.CollectorP
 
 // newOrientationCollector returns a collector to register an orientation method. If one is already registered
 // with the same MethodMetadata it will panic.
-func newOrientationCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+func newOrientationCollector(resource any, params data.CollectorParams) (data.Collector, error) {
 	ms, err := assertMovementSensor(resource)
 	if err != nil {
 		return nil, err
 	}
 
-	cFunc := data.CaptureFunc(func(ctx context.Context, extra map[string]*anypb.Any) (interface{}, error) {
+	cFunc := data.CaptureFunc(func(ctx context.Context, extra map[string]*anypb.Any) (any, error) {
 		orient, err := ms.Orientation(ctx, data.FromDMExtraMap)
 		if err != nil {
 			// A modular filter component can be created to filter the readings from a component. The error ErrNoCaptureToStore
@@ -235,13 +235,13 @@ func newOrientationCollector(resource interface{}, params data.CollectorParams) 
 
 // newReadingsCollector returns a collector to register a readings method. If one is already registered
 // with the same MethodMetadata it will panic.
-func newReadingsCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+func newReadingsCollector(resource any, params data.CollectorParams) (data.Collector, error) {
 	ms, err := assertMovementSensor(resource)
 	if err != nil {
 		return nil, err
 	}
 
-	cFunc := data.CaptureFunc(func(ctx context.Context, arg map[string]*anypb.Any) (interface{}, error) {
+	cFunc := data.CaptureFunc(func(ctx context.Context, arg map[string]*anypb.Any) (any, error) {
 		values, err := ms.Readings(ctx, data.FromDMExtraMap)
 		if err != nil {
 			// A modular filter component can be created to filter the readings from a component. The error ErrNoCaptureToStore

--- a/components/movementsensor/collectors_test.go
+++ b/components/movementsensor/collectors_test.go
@@ -125,29 +125,29 @@ func TestMovementSensorCollectors(t *testing.T) {
 
 func newMovementSensor() movementsensor.MovementSensor {
 	m := &inject.MovementSensor{}
-	m.LinearVelocityFunc = func(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+	m.LinearVelocityFunc = func(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 		return vec, nil
 	}
-	m.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+	m.PositionFunc = func(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 		return geo.NewPoint(1.0, 2.0), 3.0, nil
 	}
-	m.AngularVelocityFunc = func(ctx context.Context, extra map[string]interface{}) (spatialmath.AngularVelocity, error) {
+	m.AngularVelocityFunc = func(ctx context.Context, extra map[string]any) (spatialmath.AngularVelocity, error) {
 		return spatialmath.AngularVelocity{
 			X: 1.0,
 			Y: 2.0,
 			Z: 3.0,
 		}, nil
 	}
-	m.CompassHeadingFunc = func(ctx context.Context, extra map[string]interface{}) (float64, error) {
+	m.CompassHeadingFunc = func(ctx context.Context, extra map[string]any) (float64, error) {
 		return 1.0, nil
 	}
-	m.LinearAccelerationFunc = func(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+	m.LinearAccelerationFunc = func(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 		return vec, nil
 	}
-	m.OrientationFunc = func(ctx context.Context, extra map[string]interface{}) (spatialmath.Orientation, error) {
+	m.OrientationFunc = func(ctx context.Context, extra map[string]any) (spatialmath.Orientation, error) {
 		return spatialmath.NewZeroOrientation(), nil
 	}
-	m.ReadingsFunc = func(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+	m.ReadingsFunc = func(ctx context.Context, extra map[string]any) (map[string]any, error) {
 		return readingMap, nil
 	}
 	return m

--- a/components/movementsensor/dualgps/dualgps.go
+++ b/components/movementsensor/dualgps/dualgps.go
@@ -177,7 +177,7 @@ func getHeading(firstPoint, secondPoint *geo.Point, yawOffset float64,
 	return bearing, heading, standardBearing
 }
 
-func (dg *dualGPS) CompassHeading(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (dg *dualGPS) CompassHeading(ctx context.Context, extra map[string]any) (float64, error) {
 	dg.mu.Lock()
 	defer dg.mu.Unlock()
 
@@ -195,7 +195,7 @@ func (dg *dualGPS) CompassHeading(ctx context.Context, extra map[string]interfac
 	return heading, nil
 }
 
-func (dg *dualGPS) Properties(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+func (dg *dualGPS) Properties(ctx context.Context, extra map[string]any) (*movementsensor.Properties, error) {
 	return &movementsensor.Properties{
 		CompassHeadingSupported:     true,
 		PositionSupported:           true,
@@ -206,11 +206,11 @@ func (dg *dualGPS) Properties(ctx context.Context, extra map[string]interface{})
 	}, nil
 }
 
-func (dg *dualGPS) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+func (dg *dualGPS) Readings(ctx context.Context, extra map[string]any) (map[string]any, error) {
 	return movementsensor.DefaultAPIReadings(ctx, dg, extra)
 }
 
-func (dg *dualGPS) Position(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+func (dg *dualGPS) Position(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 	dg.mu.Lock()
 	defer dg.mu.Unlock()
 
@@ -247,23 +247,23 @@ func (dg *dualGPS) Position(ctx context.Context, extra map[string]interface{}) (
 }
 
 // Unimplemented functions.
-func (dg *dualGPS) LinearAcceleration(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+func (dg *dualGPS) LinearAcceleration(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 	return r3.Vector{}, movementsensor.ErrMethodUnimplementedLinearAcceleration
 }
 
-func (dg *dualGPS) LinearVelocity(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+func (dg *dualGPS) LinearVelocity(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 	return r3.Vector{}, movementsensor.ErrMethodUnimplementedLinearVelocity
 }
 
-func (dg *dualGPS) AngularVelocity(ctx context.Context, extra map[string]interface{}) (spatialmath.AngularVelocity, error) {
+func (dg *dualGPS) AngularVelocity(ctx context.Context, extra map[string]any) (spatialmath.AngularVelocity, error) {
 	return spatialmath.AngularVelocity{}, movementsensor.ErrMethodUnimplementedAngularVelocity
 }
 
-func (dg *dualGPS) Orientation(ctx context.Context, extra map[string]interface{}) (spatialmath.Orientation, error) {
+func (dg *dualGPS) Orientation(ctx context.Context, extra map[string]any) (spatialmath.Orientation, error) {
 	return spatialmath.NewZeroOrientation(), movementsensor.ErrMethodUnimplementedOrientation
 }
 
-func (dg *dualGPS) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
+func (dg *dualGPS) Accuracy(ctx context.Context, extra map[string]any) (*movementsensor.Accuracy, error) {
 	// TODO: RSDK-6389: for this driver, find the highest value VDOP and HDOP to show the worst accuracy in position
 	// check the fix and return the compass error using a calculation based on the fix and variation
 	// of the two positions.
@@ -272,8 +272,8 @@ func (dg *dualGPS) Accuracy(ctx context.Context, extra map[string]interface{}) (
 	return movementsensor.UnimplementedAccuracies()
 }
 
-func (dg *dualGPS) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
-	return map[string]interface{}{}, resource.ErrDoUnimplemented
+func (dg *dualGPS) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
+	return map[string]any{}, resource.ErrDoUnimplemented
 }
 
 func (dg *dualGPS) Close(ctx context.Context) error {

--- a/components/movementsensor/dualgps/dualgps_test.go
+++ b/components/movementsensor/dualgps/dualgps_test.go
@@ -26,10 +26,10 @@ const (
 
 func makeNewFakeGPS(name string, point *geo.Point, alt float64, err error) *inject.MovementSensor {
 	ms := inject.NewMovementSensor(name)
-	ms.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+	ms.PositionFunc = func(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 		return point, alt, err
 	}
-	ms.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+	ms.PropertiesFunc = func(ctx context.Context, extra map[string]any) (*movementsensor.Properties, error) {
 		return &movementsensor.Properties{PositionSupported: true}, nil
 	}
 	return ms

--- a/components/movementsensor/fake/movementsensor.go
+++ b/components/movementsensor/fake/movementsensor.go
@@ -44,43 +44,43 @@ type MovementSensor struct {
 }
 
 // Position gets the position of a fake movementsensor.
-func (f *MovementSensor) Position(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+func (f *MovementSensor) Position(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 	p := geo.NewPoint(40.7, -73.98)
 	return p, 50.5, nil
 }
 
 // LinearVelocity gets the linear velocity of a fake movementsensor.
-func (f *MovementSensor) LinearVelocity(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+func (f *MovementSensor) LinearVelocity(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 	return r3.Vector{Y: 5.4}, nil
 }
 
 // LinearAcceleration gets the linear acceleration of a fake movementsensor.
-func (f *MovementSensor) LinearAcceleration(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+func (f *MovementSensor) LinearAcceleration(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 	return r3.Vector{X: 2.2, Y: 4.5, Z: 2}, nil
 }
 
 // AngularVelocity gets the angular velocity of a fake movementsensor.
-func (f *MovementSensor) AngularVelocity(ctx context.Context, extra map[string]interface{}) (spatialmath.AngularVelocity, error) {
+func (f *MovementSensor) AngularVelocity(ctx context.Context, extra map[string]any) (spatialmath.AngularVelocity, error) {
 	return spatialmath.AngularVelocity{Z: 1}, nil
 }
 
 // CompassHeading gets the compass headings of a fake movementsensor.
-func (f *MovementSensor) CompassHeading(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (f *MovementSensor) CompassHeading(ctx context.Context, extra map[string]any) (float64, error) {
 	return 25, nil
 }
 
 // Orientation gets the orientation of a fake movementsensor.
-func (f *MovementSensor) Orientation(ctx context.Context, extra map[string]interface{}) (spatialmath.Orientation, error) {
+func (f *MovementSensor) Orientation(ctx context.Context, extra map[string]any) (spatialmath.Orientation, error) {
 	return spatialmath.NewZeroOrientation(), nil
 }
 
 // DoCommand uses a map string to run custom functionality of a fake movementsensor.
-func (f *MovementSensor) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
-	return map[string]interface{}{}, nil
+func (f *MovementSensor) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
+	return map[string]any{}, nil
 }
 
 // Accuracy gets the accuracy of a fake movementsensor.
-func (f *MovementSensor) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
+func (f *MovementSensor) Accuracy(ctx context.Context, extra map[string]any) (*movementsensor.Accuracy, error) {
 	acc := movementsensor.Accuracy{
 		AccuracyMap:        map[string]float32{},
 		Hdop:               0,
@@ -93,12 +93,12 @@ func (f *MovementSensor) Accuracy(ctx context.Context, extra map[string]interfac
 }
 
 // Readings gets the readings of a fake movementsensor.
-func (f *MovementSensor) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+func (f *MovementSensor) Readings(ctx context.Context, extra map[string]any) (map[string]any, error) {
 	return movementsensor.DefaultAPIReadings(ctx, f, extra)
 }
 
 // Properties returns the properties of a fake movementsensor.
-func (f *MovementSensor) Properties(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+func (f *MovementSensor) Properties(ctx context.Context, extra map[string]any) (*movementsensor.Properties, error) {
 	return &movementsensor.Properties{
 		LinearVelocitySupported:     true,
 		AngularVelocitySupported:    true,

--- a/components/movementsensor/gpsnmea/component.go
+++ b/components/movementsensor/gpsnmea/component.go
@@ -86,7 +86,7 @@ func (g *NMEAMovementSensor) Start(ctx context.Context) error {
 }
 
 // Position returns the position and altitide of the sensor, or an error.
-func (g *NMEAMovementSensor) Position(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+func (g *NMEAMovementSensor) Position(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
 
@@ -111,7 +111,7 @@ func (g *NMEAMovementSensor) Position(ctx context.Context, extra map[string]inte
 }
 
 // Accuracy returns the accuracy map, hDOP, vDOP, Fixquality and compass heading error.
-func (g *NMEAMovementSensor) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error,
+func (g *NMEAMovementSensor) Accuracy(ctx context.Context, extra map[string]any) (*movementsensor.Accuracy, error,
 ) {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
@@ -128,7 +128,7 @@ func (g *NMEAMovementSensor) Accuracy(ctx context.Context, extra map[string]inte
 // LinearVelocity returns the sensor's linear velocity. It requires having a compass heading, so we
 // know which direction our speed is in. We assume all of this speed is horizontal, and not in
 // gaining/losing altitude.
-func (g *NMEAMovementSensor) LinearVelocity(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+func (g *NMEAMovementSensor) LinearVelocity(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
 
@@ -144,22 +144,22 @@ func (g *NMEAMovementSensor) LinearVelocity(ctx context.Context, extra map[strin
 }
 
 // LinearAcceleration returns the sensor's linear acceleration.
-func (g *NMEAMovementSensor) LinearAcceleration(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+func (g *NMEAMovementSensor) LinearAcceleration(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 	return r3.Vector{}, movementsensor.ErrMethodUnimplementedLinearAcceleration
 }
 
 // AngularVelocity returns the sensor's angular velocity.
-func (g *NMEAMovementSensor) AngularVelocity(ctx context.Context, extra map[string]interface{}) (spatialmath.AngularVelocity, error) {
+func (g *NMEAMovementSensor) AngularVelocity(ctx context.Context, extra map[string]any) (spatialmath.AngularVelocity, error) {
 	return spatialmath.AngularVelocity{}, movementsensor.ErrMethodUnimplementedAngularVelocity
 }
 
 // Orientation returns the sensor's orientation.
-func (g *NMEAMovementSensor) Orientation(ctx context.Context, extra map[string]interface{}) (spatialmath.Orientation, error) {
+func (g *NMEAMovementSensor) Orientation(ctx context.Context, extra map[string]any) (spatialmath.Orientation, error) {
 	return spatialmath.NewOrientationVector(), movementsensor.ErrMethodUnimplementedOrientation
 }
 
 // CompassHeading returns the heading, from the range 0->360.
-func (g *NMEAMovementSensor) CompassHeading(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (g *NMEAMovementSensor) CompassHeading(ctx context.Context, extra map[string]any) (float64, error) {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
 
@@ -192,7 +192,7 @@ func (g *NMEAMovementSensor) ReadSatsInView(ctx context.Context) (int, error) {
 }
 
 // Readings will use return all of the MovementSensor Readings.
-func (g *NMEAMovementSensor) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+func (g *NMEAMovementSensor) Readings(ctx context.Context, extra map[string]any) (map[string]any, error) {
 	readings, err := movementsensor.DefaultAPIReadings(ctx, g, extra)
 	if err != nil {
 		return nil, err
@@ -213,7 +213,7 @@ func (g *NMEAMovementSensor) Readings(ctx context.Context, extra map[string]inte
 }
 
 // Properties returns what movement sensor capabilities we have.
-func (g *NMEAMovementSensor) Properties(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+func (g *NMEAMovementSensor) Properties(ctx context.Context, extra map[string]any) (*movementsensor.Properties, error) {
 	return &movementsensor.Properties{
 		LinearVelocitySupported: true,
 		PositionSupported:       true,

--- a/components/movementsensor/gpsnmea/pmtkI2C.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C.go
@@ -208,7 +208,7 @@ func (g *PmtkI2CNMEAMovementSensor) GetBusAddr() (buses.I2C, byte) {
 }
 
 // Position returns the current geographic location of the MovementSensor.
-func (g *PmtkI2CNMEAMovementSensor) Position(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+func (g *PmtkI2CNMEAMovementSensor) Position(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 	lastPosition := g.lastPosition.GetLastPosition()
 
 	g.mu.RLock()
@@ -239,7 +239,7 @@ func (g *PmtkI2CNMEAMovementSensor) Position(ctx context.Context, extra map[stri
 }
 
 // Accuracy returns the accuracy, hDOP and vDOP.
-func (g *PmtkI2CNMEAMovementSensor) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
+func (g *PmtkI2CNMEAMovementSensor) Accuracy(ctx context.Context, extra map[string]any) (*movementsensor.Accuracy, error) {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
 	acc := movementsensor.Accuracy{
@@ -253,7 +253,7 @@ func (g *PmtkI2CNMEAMovementSensor) Accuracy(ctx context.Context, extra map[stri
 }
 
 // LinearVelocity returns the current speed of the MovementSensor.
-func (g *PmtkI2CNMEAMovementSensor) LinearVelocity(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+func (g *PmtkI2CNMEAMovementSensor) LinearVelocity(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
 	if math.IsNaN(g.data.CompassHeading) {
@@ -267,7 +267,7 @@ func (g *PmtkI2CNMEAMovementSensor) LinearVelocity(ctx context.Context, extra ma
 }
 
 // LinearAcceleration returns the current linear acceleration of the MovementSensor.
-func (g *PmtkI2CNMEAMovementSensor) LinearAcceleration(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+func (g *PmtkI2CNMEAMovementSensor) LinearAcceleration(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
 	return r3.Vector{}, movementsensor.ErrMethodUnimplementedLinearAcceleration
@@ -276,7 +276,7 @@ func (g *PmtkI2CNMEAMovementSensor) LinearAcceleration(ctx context.Context, extr
 // AngularVelocity not supported.
 func (g *PmtkI2CNMEAMovementSensor) AngularVelocity(
 	ctx context.Context,
-	extra map[string]interface{},
+	extra map[string]any,
 ) (spatialmath.AngularVelocity, error) {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
@@ -284,7 +284,7 @@ func (g *PmtkI2CNMEAMovementSensor) AngularVelocity(
 }
 
 // CompassHeading returns the compass heading in degree (0->360).
-func (g *PmtkI2CNMEAMovementSensor) CompassHeading(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (g *PmtkI2CNMEAMovementSensor) CompassHeading(ctx context.Context, extra map[string]any) (float64, error) {
 	lastHeading := g.lastCompassHeading.GetLastCompassHeading()
 
 	g.mu.RLock()
@@ -304,14 +304,14 @@ func (g *PmtkI2CNMEAMovementSensor) CompassHeading(ctx context.Context, extra ma
 }
 
 // Orientation not supporter.
-func (g *PmtkI2CNMEAMovementSensor) Orientation(ctx context.Context, extra map[string]interface{}) (spatialmath.Orientation, error) {
+func (g *PmtkI2CNMEAMovementSensor) Orientation(ctx context.Context, extra map[string]any) (spatialmath.Orientation, error) {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
 	return nil, movementsensor.ErrMethodUnimplementedOrientation
 }
 
 // Properties what can I do!
-func (g *PmtkI2CNMEAMovementSensor) Properties(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+func (g *PmtkI2CNMEAMovementSensor) Properties(ctx context.Context, extra map[string]any) (*movementsensor.Properties, error) {
 	return &movementsensor.Properties{
 		LinearVelocitySupported: true,
 		PositionSupported:       true,
@@ -334,7 +334,7 @@ func (g *PmtkI2CNMEAMovementSensor) ReadSatsInView(ctx context.Context) (int, er
 }
 
 // Readings will use return all of the MovementSensor Readings.
-func (g *PmtkI2CNMEAMovementSensor) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+func (g *PmtkI2CNMEAMovementSensor) Readings(ctx context.Context, extra map[string]any) (map[string]any, error) {
 	readings, err := movementsensor.DefaultAPIReadings(ctx, g, extra)
 	if err != nil {
 		return nil, err

--- a/components/movementsensor/gpsnmea/pmtkI2C_test.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C_test.go
@@ -118,12 +118,12 @@ func TestReadingsI2C(t *testing.T) {
 	test.That(t, bus, test.ShouldBeNil)
 	test.That(t, addr, test.ShouldEqual, 66)
 
-	loc1, alt1, err := g.Position(ctx, make(map[string]interface{}))
+	loc1, alt1, err := g.Position(ctx, make(map[string]any))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, loc1, test.ShouldEqual, loc)
 	test.That(t, alt1, test.ShouldEqual, alt)
 
-	speed1, err := g.LinearVelocity(ctx, make(map[string]interface{}))
+	speed1, err := g.LinearVelocity(ctx, make(map[string]any))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, speed1.Y, test.ShouldEqual, speed)
 

--- a/components/movementsensor/gpsnmea/serial_test.go
+++ b/components/movementsensor/gpsnmea/serial_test.go
@@ -98,12 +98,12 @@ func TestReadingsSerial(t *testing.T) {
 		FixQuality: fix,
 	}
 
-	loc1, alt1, err := g.Position(ctx, make(map[string]interface{}))
+	loc1, alt1, err := g.Position(ctx, make(map[string]any))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, loc1, test.ShouldEqual, loc)
 	test.That(t, alt1, test.ShouldEqual, alt)
 
-	speed1, err := g.LinearVelocity(ctx, make(map[string]interface{}))
+	speed1, err := g.LinearVelocity(ctx, make(map[string]any))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, speed1.Y, test.ShouldEqual, speed)
 

--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
@@ -488,7 +488,7 @@ func (g *rtkI2C) getNtripConnectionStatus() (bool, error) {
 }
 
 // Position returns the current geographic location of the MOVEMENTSENSOR.
-func (g *rtkI2C) Position(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+func (g *rtkI2C) Position(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 	g.ntripMu.Lock()
 	lastError := g.err.Get()
 	if lastError != nil {
@@ -521,7 +521,7 @@ func (g *rtkI2C) Position(ctx context.Context, extra map[string]interface{}) (*g
 }
 
 // LinearVelocity passthrough.
-func (g *rtkI2C) LinearVelocity(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+func (g *rtkI2C) LinearVelocity(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 	g.ntripMu.Lock()
 	lastError := g.err.Get()
 	if lastError != nil {
@@ -534,7 +534,7 @@ func (g *rtkI2C) LinearVelocity(ctx context.Context, extra map[string]interface{
 }
 
 // LinearAcceleration passthrough.
-func (g *rtkI2C) LinearAcceleration(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+func (g *rtkI2C) LinearAcceleration(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 	lastError := g.err.Get()
 	if lastError != nil {
 		return r3.Vector{}, lastError
@@ -543,7 +543,7 @@ func (g *rtkI2C) LinearAcceleration(ctx context.Context, extra map[string]interf
 }
 
 // AngularVelocity passthrough.
-func (g *rtkI2C) AngularVelocity(ctx context.Context, extra map[string]interface{}) (spatialmath.AngularVelocity, error) {
+func (g *rtkI2C) AngularVelocity(ctx context.Context, extra map[string]any) (spatialmath.AngularVelocity, error) {
 	g.ntripMu.Lock()
 	lastError := g.err.Get()
 	if lastError != nil {
@@ -556,7 +556,7 @@ func (g *rtkI2C) AngularVelocity(ctx context.Context, extra map[string]interface
 }
 
 // CompassHeading passthrough.
-func (g *rtkI2C) CompassHeading(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (g *rtkI2C) CompassHeading(ctx context.Context, extra map[string]any) (float64, error) {
 	g.ntripMu.Lock()
 	lastError := g.err.Get()
 	if lastError != nil {
@@ -569,7 +569,7 @@ func (g *rtkI2C) CompassHeading(ctx context.Context, extra map[string]interface{
 }
 
 // Orientation passthrough.
-func (g *rtkI2C) Orientation(ctx context.Context, extra map[string]interface{}) (spatialmath.Orientation, error) {
+func (g *rtkI2C) Orientation(ctx context.Context, extra map[string]any) (spatialmath.Orientation, error) {
 	g.ntripMu.Lock()
 	lastError := g.err.Get()
 	if lastError != nil {
@@ -607,7 +607,7 @@ func (g *rtkI2C) readSatsInView(ctx context.Context) (int, error) {
 }
 
 // Properties passthrough.
-func (g *rtkI2C) Properties(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+func (g *rtkI2C) Properties(ctx context.Context, extra map[string]any) (*movementsensor.Properties, error) {
 	lastError := g.err.Get()
 	if lastError != nil {
 		return &movementsensor.Properties{}, lastError
@@ -617,7 +617,7 @@ func (g *rtkI2C) Properties(ctx context.Context, extra map[string]interface{}) (
 }
 
 // Accuracy passthrough.
-func (g *rtkI2C) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
+func (g *rtkI2C) Accuracy(ctx context.Context, extra map[string]any) (*movementsensor.Accuracy, error) {
 	lastError := g.err.Get()
 	if lastError != nil {
 		return nil, lastError
@@ -627,7 +627,7 @@ func (g *rtkI2C) Accuracy(ctx context.Context, extra map[string]interface{}) (*m
 }
 
 // Readings will use the default MovementSensor Readings if not provided.
-func (g *rtkI2C) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+func (g *rtkI2C) Readings(ctx context.Context, extra map[string]any) (map[string]any, error) {
 	readings, err := movementsensor.DefaultAPIReadings(ctx, g, extra)
 	if err != nil {
 		return nil, err

--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk_test.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk_test.go
@@ -106,55 +106,55 @@ func TestReadings(t *testing.T) {
 		MovementSensor: &fake.MovementSensor{},
 	}
 
-	mockSensor.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+	mockSensor.PositionFunc = func(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 		return loc, alt, nil
 	}
 
 	g.nmeamovementsensor = mockSensor
 
 	// Normal position
-	loc1, alt1, err := g.Position(ctx, make(map[string]interface{}))
+	loc1, alt1, err := g.Position(ctx, make(map[string]any))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, loc1, test.ShouldResemble, loc)
 	test.That(t, alt1, test.ShouldEqual, alt)
 
-	speed1, err := g.LinearVelocity(ctx, make(map[string]interface{}))
+	speed1, err := g.LinearVelocity(ctx, make(map[string]any))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, speed1.Y, test.ShouldEqual, speed)
 	test.That(t, speed1.X, test.ShouldEqual, 0)
 	test.That(t, speed1.Z, test.ShouldEqual, 0)
 
 	// Zero position with latitude 0 and longitude 0.
-	mockSensor.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+	mockSensor.PositionFunc = func(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 		return geo.NewPoint(0, 0), 0, nil
 	}
 
-	loc2, alt2, err := g.Position(ctx, make(map[string]interface{}))
+	loc2, alt2, err := g.Position(ctx, make(map[string]any))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, loc2, test.ShouldResemble, geo.NewPoint(0, 0))
 	test.That(t, alt2, test.ShouldEqual, 0)
 
-	speed2, err := g.LinearVelocity(ctx, make(map[string]interface{}))
+	speed2, err := g.LinearVelocity(ctx, make(map[string]any))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, speed2.Y, test.ShouldEqual, speed)
 	test.That(t, speed2.X, test.ShouldEqual, 0)
 	test.That(t, speed2.Z, test.ShouldEqual, 0)
 
 	// Position with NaN values.
-	mockSensor.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+	mockSensor.PositionFunc = func(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 		return geo.NewPoint(math.NaN(), math.NaN()), math.NaN(), nil
 	}
 
 	g.lastposition.SetLastPosition(loc1)
 
-	loc3, alt3, err := g.Position(ctx, make(map[string]interface{}))
+	loc3, alt3, err := g.Position(ctx, make(map[string]any))
 	test.That(t, err, test.ShouldBeNil)
 
 	// last known valid position should be returned when current position is NaN()
 	test.That(t, loc3, test.ShouldResemble, loc1)
 	test.That(t, math.IsNaN(alt3), test.ShouldBeTrue)
 
-	speed3, err := g.LinearVelocity(ctx, make(map[string]interface{}))
+	speed3, err := g.LinearVelocity(ctx, make(map[string]any))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, speed3.Y, test.ShouldEqual, speed)
 }
@@ -204,10 +204,10 @@ func TestCloseRTK(t *testing.T) {
 
 type CustomMovementSensor struct {
 	*fake.MovementSensor
-	PositionFunc func(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error)
+	PositionFunc func(ctx context.Context, extra map[string]any) (*geo.Point, float64, error)
 }
 
-func (c *CustomMovementSensor) Position(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+func (c *CustomMovementSensor) Position(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 	if c.PositionFunc != nil {
 		return c.PositionFunc(ctx, extra)
 	}

--- a/components/movementsensor/gpsrtkserial/gpsrtkserial.go
+++ b/components/movementsensor/gpsrtkserial/gpsrtkserial.go
@@ -474,7 +474,7 @@ func (g *rtkSerial) receiveAndWriteSerial() {
 }
 
 // Position returns the current geographic location of the MOVEMENTSENSOR.
-func (g *rtkSerial) Position(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+func (g *rtkSerial) Position(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 	g.mu.Lock()
 	lastError := g.err.Get()
 	if lastError != nil {
@@ -506,7 +506,7 @@ func (g *rtkSerial) Position(ctx context.Context, extra map[string]interface{}) 
 }
 
 // LinearVelocity passthrough.
-func (g *rtkSerial) LinearVelocity(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+func (g *rtkSerial) LinearVelocity(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	lastError := g.err.Get()
@@ -518,7 +518,7 @@ func (g *rtkSerial) LinearVelocity(ctx context.Context, extra map[string]interfa
 }
 
 // LinearAcceleration passthrough.
-func (g *rtkSerial) LinearAcceleration(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+func (g *rtkSerial) LinearAcceleration(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 	lastError := g.err.Get()
 	if lastError != nil {
 		return r3.Vector{}, lastError
@@ -527,7 +527,7 @@ func (g *rtkSerial) LinearAcceleration(ctx context.Context, extra map[string]int
 }
 
 // AngularVelocity passthrough.
-func (g *rtkSerial) AngularVelocity(ctx context.Context, extra map[string]interface{}) (spatialmath.AngularVelocity, error) {
+func (g *rtkSerial) AngularVelocity(ctx context.Context, extra map[string]any) (spatialmath.AngularVelocity, error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
@@ -540,7 +540,7 @@ func (g *rtkSerial) AngularVelocity(ctx context.Context, extra map[string]interf
 }
 
 // CompassHeading passthrough.
-func (g *rtkSerial) CompassHeading(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (g *rtkSerial) CompassHeading(ctx context.Context, extra map[string]any) (float64, error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
@@ -552,7 +552,7 @@ func (g *rtkSerial) CompassHeading(ctx context.Context, extra map[string]interfa
 }
 
 // Orientation passthrough.
-func (g *rtkSerial) Orientation(ctx context.Context, extra map[string]interface{}) (spatialmath.Orientation, error) {
+func (g *rtkSerial) Orientation(ctx context.Context, extra map[string]any) (spatialmath.Orientation, error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
@@ -589,7 +589,7 @@ func (g *rtkSerial) readSatsInView(ctx context.Context) (int, error) {
 }
 
 // Properties passthrough.
-func (g *rtkSerial) Properties(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+func (g *rtkSerial) Properties(ctx context.Context, extra map[string]any) (*movementsensor.Properties, error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
@@ -602,7 +602,7 @@ func (g *rtkSerial) Properties(ctx context.Context, extra map[string]interface{}
 }
 
 // Accuracy passthrough.
-func (g *rtkSerial) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error,
+func (g *rtkSerial) Accuracy(ctx context.Context, extra map[string]any) (*movementsensor.Accuracy, error,
 ) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
@@ -616,7 +616,7 @@ func (g *rtkSerial) Accuracy(ctx context.Context, extra map[string]interface{}) 
 }
 
 // Readings will use the default MovementSensor Readings if not provided.
-func (g *rtkSerial) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+func (g *rtkSerial) Readings(ctx context.Context, extra map[string]any) (map[string]any, error) {
 	readings, err := movementsensor.DefaultAPIReadings(ctx, g, extra)
 	if err != nil {
 		return nil, err

--- a/components/movementsensor/gpsrtkserial/gpsrtkserial_test.go
+++ b/components/movementsensor/gpsrtkserial/gpsrtkserial_test.go
@@ -83,54 +83,54 @@ func TestReadings(t *testing.T) {
 		MovementSensor: &fake.MovementSensor{},
 	}
 
-	mockSensor.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+	mockSensor.PositionFunc = func(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 		return loc, alt, nil
 	}
 
 	g.nmeamovementsensor = mockSensor
 
 	// Normal position
-	loc1, alt1, err := g.Position(ctx, make(map[string]interface{}))
+	loc1, alt1, err := g.Position(ctx, make(map[string]any))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, loc1, test.ShouldResemble, loc)
 	test.That(t, alt1, test.ShouldEqual, alt)
 
-	speed1, err := g.LinearVelocity(ctx, make(map[string]interface{}))
+	speed1, err := g.LinearVelocity(ctx, make(map[string]any))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, speed1.Y, test.ShouldEqual, speed)
 	test.That(t, speed1.X, test.ShouldEqual, 0)
 	test.That(t, speed1.Z, test.ShouldEqual, 0)
 
 	// Zero position with latitude 0 and longitude 0.
-	mockSensor.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+	mockSensor.PositionFunc = func(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 		return geo.NewPoint(0, 0), 0, nil
 	}
 
-	loc2, alt2, err := g.Position(ctx, make(map[string]interface{}))
+	loc2, alt2, err := g.Position(ctx, make(map[string]any))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, loc2, test.ShouldResemble, geo.NewPoint(0, 0))
 	test.That(t, alt2, test.ShouldEqual, 0)
 
-	speed2, err := g.LinearVelocity(ctx, make(map[string]interface{}))
+	speed2, err := g.LinearVelocity(ctx, make(map[string]any))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, speed2.Y, test.ShouldEqual, speed)
 	test.That(t, speed2.X, test.ShouldEqual, 0)
 	test.That(t, speed2.Z, test.ShouldEqual, 0)
 
 	// Position with NaN values.
-	mockSensor.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+	mockSensor.PositionFunc = func(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 		return geo.NewPoint(math.NaN(), math.NaN()), math.NaN(), nil
 	}
 	g.lastposition.SetLastPosition(loc1)
 
-	loc3, alt3, err := g.Position(ctx, make(map[string]interface{}))
+	loc3, alt3, err := g.Position(ctx, make(map[string]any))
 	test.That(t, err, test.ShouldBeNil)
 
 	// last known valid position should be returned when current position is NaN()
 	test.That(t, loc3, test.ShouldResemble, loc1)
 	test.That(t, math.IsNaN(alt3), test.ShouldBeTrue)
 
-	speed3, err := g.LinearVelocity(ctx, make(map[string]interface{}))
+	speed3, err := g.LinearVelocity(ctx, make(map[string]any))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, speed3.Y, test.ShouldEqual, speed)
 }
@@ -180,10 +180,10 @@ func TestCloseRTK(t *testing.T) {
 
 type CustomMovementSensor struct {
 	*fake.MovementSensor
-	PositionFunc func(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error)
+	PositionFunc func(ctx context.Context, extra map[string]any) (*geo.Point, float64, error)
 }
 
-func (c *CustomMovementSensor) Position(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+func (c *CustomMovementSensor) Position(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 	if c.PositionFunc != nil {
 		return c.PositionFunc(ctx, extra)
 	}

--- a/components/movementsensor/imuvectornav/imu.go
+++ b/components/movementsensor/imuvectornav/imu.go
@@ -247,39 +247,39 @@ func newVectorNav(
 	return v, nil
 }
 
-func (vn *vectornav) AngularVelocity(ctx context.Context, extra map[string]interface{}) (spatialmath.AngularVelocity, error) {
+func (vn *vectornav) AngularVelocity(ctx context.Context, extra map[string]any) (spatialmath.AngularVelocity, error) {
 	vn.mu.Lock()
 	defer vn.mu.Unlock()
 	return vn.angularVelocity, nil
 }
 
-func (vn *vectornav) LinearAcceleration(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+func (vn *vectornav) LinearAcceleration(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 	vn.mu.Lock()
 	defer vn.mu.Unlock()
 	return vn.acceleration, nil
 }
 
-func (vn *vectornav) Orientation(ctx context.Context, extra map[string]interface{}) (spatialmath.Orientation, error) {
+func (vn *vectornav) Orientation(ctx context.Context, extra map[string]any) (spatialmath.Orientation, error) {
 	vn.mu.Lock()
 	defer vn.mu.Unlock()
 	return &vn.orientation, nil
 }
 
-func (vn *vectornav) CompassHeading(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (vn *vectornav) CompassHeading(ctx context.Context, extra map[string]any) (float64, error) {
 	vn.mu.Lock()
 	defer vn.mu.Unlock()
 	return vn.orientation.Yaw, nil
 }
 
-func (vn *vectornav) LinearVelocity(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+func (vn *vectornav) LinearVelocity(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 	return r3.Vector{}, movementsensor.ErrMethodUnimplementedLinearVelocity
 }
 
-func (vn *vectornav) Position(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+func (vn *vectornav) Position(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 	return nil, 0, movementsensor.ErrMethodUnimplementedPosition
 }
 
-func (vn *vectornav) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
+func (vn *vectornav) Accuracy(ctx context.Context, extra map[string]any) (*movementsensor.Accuracy, error) {
 	// TODO:  RSDK-6389 check the vectornav's datasheet to determine what is best to return from the vector nav.
 	// can be done in a seprate ticket from the one mentioned in this comment.
 	return movementsensor.UnimplementedAccuracies()
@@ -291,7 +291,7 @@ func (vn *vectornav) GetMagnetometer(ctx context.Context) (r3.Vector, error) {
 	return vn.magnetometer, nil
 }
 
-func (vn *vectornav) Properties(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+func (vn *vectornav) Properties(ctx context.Context, extra map[string]any) (*movementsensor.Properties, error) {
 	return &movementsensor.Properties{
 		AngularVelocitySupported:    true,
 		OrientationSupported:        true,
@@ -299,7 +299,7 @@ func (vn *vectornav) Properties(ctx context.Context, extra map[string]interface{
 	}, nil
 }
 
-func (vn *vectornav) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+func (vn *vectornav) Readings(ctx context.Context, extra map[string]any) (map[string]any, error) {
 	return movementsensor.DefaultAPIReadings(ctx, vn, extra)
 }
 

--- a/components/movementsensor/imuwit/imu.go
+++ b/components/movementsensor/imuwit/imu.go
@@ -116,26 +116,26 @@ func (imu *wit) Reconfigure(ctx context.Context, deps resource.Dependencies, con
 	return nil
 }
 
-func (imu *wit) AngularVelocity(ctx context.Context, extra map[string]interface{}) (spatialmath.AngularVelocity, error) {
+func (imu *wit) AngularVelocity(ctx context.Context, extra map[string]any) (spatialmath.AngularVelocity, error) {
 	imu.mu.Lock()
 	defer imu.mu.Unlock()
 	return imu.angularVelocity, imu.err.Get()
 }
 
-func (imu *wit) LinearVelocity(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+func (imu *wit) LinearVelocity(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 	imu.mu.Lock()
 	defer imu.mu.Unlock()
 	return r3.Vector{}, movementsensor.ErrMethodUnimplementedLinearVelocity
 }
 
-func (imu *wit) Orientation(ctx context.Context, extra map[string]interface{}) (spatialmath.Orientation, error) {
+func (imu *wit) Orientation(ctx context.Context, extra map[string]any) (spatialmath.Orientation, error) {
 	imu.mu.Lock()
 	defer imu.mu.Unlock()
 	return &imu.orientation, imu.err.Get()
 }
 
 // LinearAcceleration returns linear acceleration in mm_per_sec_per_sec.
-func (imu *wit) LinearAcceleration(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+func (imu *wit) LinearAcceleration(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 	imu.mu.Lock()
 	defer imu.mu.Unlock()
 	return imu.acceleration, imu.err.Get()
@@ -148,7 +148,7 @@ func (imu *wit) getMagnetometer() (r3.Vector, error) {
 	return imu.magnetometer, imu.err.Get()
 }
 
-func (imu *wit) CompassHeading(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (imu *wit) CompassHeading(ctx context.Context, extra map[string]any) (float64, error) {
 	var err error
 
 	imu.mu.Lock()
@@ -196,11 +196,11 @@ func (imu *wit) calculateTiltCompensation(roll, pitch float64) (float64, float64
 	return xComp, yComp
 }
 
-func (imu *wit) Position(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+func (imu *wit) Position(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 	return geo.NewPoint(0, 0), 0, movementsensor.ErrMethodUnimplementedPosition
 }
 
-func (imu *wit) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error,
+func (imu *wit) Accuracy(ctx context.Context, extra map[string]any) (*movementsensor.Accuracy, error,
 ) {
 	// TODO: RSDK-6389 return the compass heading from the datasheet of the witIMU if the pitch angle is less than 45 degrees
 	// and the roll angle is near zero
@@ -210,7 +210,7 @@ func (imu *wit) Accuracy(ctx context.Context, extra map[string]interface{}) (*mo
 	return movementsensor.UnimplementedAccuracies()
 }
 
-func (imu *wit) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+func (imu *wit) Readings(ctx context.Context, extra map[string]any) (map[string]any, error) {
 	readings, err := movementsensor.DefaultAPIReadings(ctx, imu, extra)
 	if err != nil {
 		return nil, err
@@ -225,7 +225,7 @@ func (imu *wit) Readings(ctx context.Context, extra map[string]interface{}) (map
 	return readings, err
 }
 
-func (imu *wit) Properties(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+func (imu *wit) Properties(ctx context.Context, extra map[string]any) (*movementsensor.Properties, error) {
 	imu.mu.Lock()
 	defer imu.mu.Unlock()
 

--- a/components/movementsensor/merged/merged.go
+++ b/components/movementsensor/merged/merged.go
@@ -192,7 +192,7 @@ func (m *merged) Reconfigure(ctx context.Context, deps resource.Dependencies, co
 	return nil
 }
 
-func (m *merged) Position(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+func (m *merged) Position(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -203,7 +203,7 @@ func (m *merged) Position(ctx context.Context, extra map[string]interface{}) (*g
 	return m.pos.Position(ctx, extra)
 }
 
-func (m *merged) Orientation(ctx context.Context, extra map[string]interface{}) (spatialmath.Orientation, error) {
+func (m *merged) Orientation(ctx context.Context, extra map[string]any) (spatialmath.Orientation, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -219,7 +219,7 @@ func (m *merged) Orientation(ctx context.Context, extra map[string]interface{}) 
 	return m.ori.Orientation(ctx, extra)
 }
 
-func (m *merged) CompassHeading(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (m *merged) CompassHeading(ctx context.Context, extra map[string]any) (float64, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -230,7 +230,7 @@ func (m *merged) CompassHeading(ctx context.Context, extra map[string]interface{
 	return m.compass.CompassHeading(ctx, extra)
 }
 
-func (m *merged) LinearVelocity(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+func (m *merged) LinearVelocity(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -241,7 +241,7 @@ func (m *merged) LinearVelocity(ctx context.Context, extra map[string]interface{
 	return m.linVel.LinearVelocity(ctx, extra)
 }
 
-func (m *merged) AngularVelocity(ctx context.Context, extra map[string]interface{}) (spatialmath.AngularVelocity, error) {
+func (m *merged) AngularVelocity(ctx context.Context, extra map[string]any) (spatialmath.AngularVelocity, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -252,7 +252,7 @@ func (m *merged) AngularVelocity(ctx context.Context, extra map[string]interface
 	return m.angVel.AngularVelocity(ctx, extra)
 }
 
-func (m *merged) LinearAcceleration(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+func (m *merged) LinearAcceleration(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -271,7 +271,7 @@ func mapWithSensorName(name string, accMap map[string]float32) map[string]float3
 	return result
 }
 
-func (m *merged) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
+func (m *merged) Accuracy(ctx context.Context, extra map[string]any) (*movementsensor.Accuracy, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -395,7 +395,7 @@ func (m *merged) Accuracy(ctx context.Context, extra map[string]interface{}) (*m
 	return &acc, errs
 }
 
-func (m *merged) Properties(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+func (m *merged) Properties(ctx context.Context, extra map[string]any) (*movementsensor.Properties, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -409,7 +409,7 @@ func (m *merged) Properties(ctx context.Context, extra map[string]interface{}) (
 	}, nil
 }
 
-func (m *merged) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+func (m *merged) Readings(ctx context.Context, extra map[string]any) (map[string]any, error) {
 	// we're already in lock in this driver
 	// don't lock the mutex again for the Readings call
 	return movementsensor.DefaultAPIReadings(ctx, m, extra)

--- a/components/movementsensor/merged/merged_test.go
+++ b/components/movementsensor/merged/merged_test.go
@@ -72,14 +72,14 @@ func setupMovementSensor(
 	errAcc, oriPropsErr bool,
 ) movementsensor.MovementSensor {
 	ms := inject.NewMovementSensor(name)
-	ms.PropertiesFunc = func(ctx context.Context, extra map[string]interface{},
+	ms.PropertiesFunc = func(ctx context.Context, extra map[string]any,
 	) (*movementsensor.Properties, error) {
 		if oriPropsErr && strings.Contains(name, "goodOri") {
 			return &prop, errProps
 		}
 		return &prop, nil
 	}
-	ms.AccuracyFunc = func(ctx context.Context, exta map[string]interface{}) (*movementsensor.Accuracy, error,
+	ms.AccuracyFunc = func(ctx context.Context, exta map[string]any) (*movementsensor.Accuracy, error,
 	) {
 		if errAcc {
 			return nil, errAccuracy
@@ -96,27 +96,27 @@ func setupMovementSensor(
 
 	switch {
 	case strings.Contains(name, "Ori"):
-		ms.OrientationFunc = func(ctx context.Context, extra map[string]interface{}) (spatialmath.Orientation, error) {
+		ms.OrientationFunc = func(ctx context.Context, extra map[string]any) (spatialmath.Orientation, error) {
 			return testori, nil
 		}
 	case strings.Contains(name, "Pos"):
-		ms.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+		ms.PositionFunc = func(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 			return testgeopoint, testalt, nil
 		}
 	case strings.Contains(name, "Compass"):
-		ms.CompassHeadingFunc = func(ctx context.Context, extra map[string]interface{}) (float64, error) {
+		ms.CompassHeadingFunc = func(ctx context.Context, extra map[string]any) (float64, error) {
 			return testcompass, nil
 		}
 	case strings.Contains(name, "AngVel"):
-		ms.AngularVelocityFunc = func(ctx context.Context, extra map[string]interface{}) (spatialmath.AngularVelocity, error) {
+		ms.AngularVelocityFunc = func(ctx context.Context, extra map[string]any) (spatialmath.AngularVelocity, error) {
 			return testangvel, nil
 		}
 	case strings.Contains(name, "LinVel"):
-		ms.LinearVelocityFunc = func(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+		ms.LinearVelocityFunc = func(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 			return testlinvel, nil
 		}
 	case strings.Contains(name, "LinAcc"):
-		ms.LinearAccelerationFunc = func(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+		ms.LinearAccelerationFunc = func(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 			return testlinacc, nil
 		}
 	}
@@ -256,7 +256,7 @@ func TestCreation(t *testing.T) {
 
 	readings, err := ms.Readings(ctx, nil)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, readings, test.ShouldResemble, map[string]interface{}{
+	test.That(t, readings, test.ShouldResemble, map[string]any{
 		"linear_velocity":  linvel,
 		"angular_velocity": angvel,
 	})
@@ -334,7 +334,7 @@ func TestCreation(t *testing.T) {
 
 	readings, err = ms.Readings(ctx, nil)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, readings, test.ShouldResemble, map[string]interface{}{
+	test.That(t, readings, test.ShouldResemble, map[string]any{
 		"orientation":         ori,
 		"position":            pos,
 		"altitude":            alt,

--- a/components/movementsensor/movementsensor.go
+++ b/components/movementsensor/movementsensor.go
@@ -68,14 +68,14 @@ func Named(name string) resource.Name {
 type MovementSensor interface {
 	resource.Sensor
 	resource.Resource
-	Position(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error)                // (lat, long), altitude (m)
-	LinearVelocity(ctx context.Context, extra map[string]interface{}) (r3.Vector, error)                    // m / sec
-	AngularVelocity(ctx context.Context, extra map[string]interface{}) (spatialmath.AngularVelocity, error) // deg / sec
-	LinearAcceleration(ctx context.Context, extra map[string]interface{}) (r3.Vector, error)
-	CompassHeading(ctx context.Context, extra map[string]interface{}) (float64, error) // [0->360)
-	Orientation(ctx context.Context, extra map[string]interface{}) (spatialmath.Orientation, error)
-	Properties(ctx context.Context, extra map[string]interface{}) (*Properties, error)
-	Accuracy(ctx context.Context, extra map[string]interface{}) (*Accuracy, error)
+	Position(ctx context.Context, extra map[string]any) (*geo.Point, float64, error)                // (lat, long), altitude (m)
+	LinearVelocity(ctx context.Context, extra map[string]any) (r3.Vector, error)                    // m / sec
+	AngularVelocity(ctx context.Context, extra map[string]any) (spatialmath.AngularVelocity, error) // deg / sec
+	LinearAcceleration(ctx context.Context, extra map[string]any) (r3.Vector, error)
+	CompassHeading(ctx context.Context, extra map[string]any) (float64, error) // [0->360)
+	Orientation(ctx context.Context, extra map[string]any) (spatialmath.Orientation, error)
+	Properties(ctx context.Context, extra map[string]any) (*Properties, error)
+	Accuracy(ctx context.Context, extra map[string]any) (*Accuracy, error)
 }
 
 // FromDependencies is a helper for getting the named movementsensor from a collection of
@@ -95,8 +95,8 @@ func NamesFromRobot(r robot.Robot) []string {
 }
 
 // DefaultAPIReadings is a helper for getting all readings from a MovementSensor.
-func DefaultAPIReadings(ctx context.Context, g MovementSensor, extra map[string]interface{}) (map[string]interface{}, error) {
-	readings := map[string]interface{}{}
+func DefaultAPIReadings(ctx context.Context, g MovementSensor, extra map[string]any) (map[string]any, error) {
+	readings := map[string]any{}
 
 	pos, altitude, err := g.Position(ctx, extra)
 	if err != nil {

--- a/components/movementsensor/mpu6050/mpu6050.go
+++ b/components/movementsensor/mpu6050/mpu6050.go
@@ -288,17 +288,17 @@ func toLinearAcceleration(data []byte) r3.Vector {
 	}
 }
 
-func (mpu *mpu6050) AngularVelocity(ctx context.Context, extra map[string]interface{}) (spatialmath.AngularVelocity, error) {
+func (mpu *mpu6050) AngularVelocity(ctx context.Context, extra map[string]any) (spatialmath.AngularVelocity, error) {
 	mpu.mu.Lock()
 	defer mpu.mu.Unlock()
 	return mpu.angularVelocity, mpu.err.Get()
 }
 
-func (mpu *mpu6050) LinearVelocity(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+func (mpu *mpu6050) LinearVelocity(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 	return r3.Vector{}, movementsensor.ErrMethodUnimplementedLinearVelocity
 }
 
-func (mpu *mpu6050) LinearAcceleration(ctx context.Context, exta map[string]interface{}) (r3.Vector, error) {
+func (mpu *mpu6050) LinearAcceleration(ctx context.Context, exta map[string]any) (r3.Vector, error) {
 	mpu.mu.Lock()
 	defer mpu.mu.Unlock()
 
@@ -309,27 +309,27 @@ func (mpu *mpu6050) LinearAcceleration(ctx context.Context, exta map[string]inte
 	return mpu.linearAcceleration, nil
 }
 
-func (mpu *mpu6050) Orientation(ctx context.Context, extra map[string]interface{}) (spatialmath.Orientation, error) {
+func (mpu *mpu6050) Orientation(ctx context.Context, extra map[string]any) (spatialmath.Orientation, error) {
 	return spatialmath.NewOrientationVector(), movementsensor.ErrMethodUnimplementedOrientation
 }
 
-func (mpu *mpu6050) CompassHeading(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (mpu *mpu6050) CompassHeading(ctx context.Context, extra map[string]any) (float64, error) {
 	return 0, movementsensor.ErrMethodUnimplementedCompassHeading
 }
 
-func (mpu *mpu6050) Position(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+func (mpu *mpu6050) Position(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 	return geo.NewPoint(0, 0), 0, movementsensor.ErrMethodUnimplementedPosition
 }
 
-func (mpu *mpu6050) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
+func (mpu *mpu6050) Accuracy(ctx context.Context, extra map[string]any) (*movementsensor.Accuracy, error) {
 	return movementsensor.UnimplementedAccuracies()
 }
 
-func (mpu *mpu6050) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+func (mpu *mpu6050) Readings(ctx context.Context, extra map[string]any) (map[string]any, error) {
 	mpu.mu.Lock()
 	defer mpu.mu.Unlock()
 
-	readings := make(map[string]interface{})
+	readings := make(map[string]any)
 	readings["linear_acceleration"] = mpu.linearAcceleration
 	readings["temperature_celsius"] = mpu.temperature
 	readings["angular_velocity"] = mpu.angularVelocity
@@ -337,7 +337,7 @@ func (mpu *mpu6050) Readings(ctx context.Context, extra map[string]interface{}) 
 	return readings, mpu.err.Get()
 }
 
-func (mpu *mpu6050) Properties(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+func (mpu *mpu6050) Properties(ctx context.Context, extra map[string]any) (*movementsensor.Properties, error) {
 	return &movementsensor.Properties{
 		AngularVelocitySupported:    true,
 		LinearAccelerationSupported: true,

--- a/components/movementsensor/replay/replay.go
+++ b/components/movementsensor/replay/replay.go
@@ -198,7 +198,7 @@ func newReplayMovementSensor(ctx context.Context, deps resource.Dependencies, co
 }
 
 // Position returns the next position from the cache, in the form of a geo.Point and altitude.
-func (replay *replayMovementSensor) Position(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+func (replay *replayMovementSensor) Position(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 	replay.mu.Lock()
 	defer replay.mu.Unlock()
 	if replay.closed {
@@ -222,7 +222,7 @@ func (replay *replayMovementSensor) Position(ctx context.Context, extra map[stri
 }
 
 // LinearVelocity returns the next linear velocity from the cache in the form of an r3.Vector.
-func (replay *replayMovementSensor) LinearVelocity(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+func (replay *replayMovementSensor) LinearVelocity(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 	replay.mu.Lock()
 	defer replay.mu.Unlock()
 	if replay.closed {
@@ -242,7 +242,7 @@ func (replay *replayMovementSensor) LinearVelocity(ctx context.Context, extra ma
 }
 
 // AngularVelocity returns the next angular velocity from the cache in the form of a spatialmath.AngularVelocity (r3.Vector).
-func (replay *replayMovementSensor) AngularVelocity(ctx context.Context, extra map[string]interface{}) (
+func (replay *replayMovementSensor) AngularVelocity(ctx context.Context, extra map[string]any) (
 	spatialmath.AngularVelocity, error,
 ) {
 	replay.mu.Lock()
@@ -268,7 +268,7 @@ func (replay *replayMovementSensor) AngularVelocity(ctx context.Context, extra m
 }
 
 // LinearAcceleration returns the next linear acceleration from the cache in the form of an r3.Vector.
-func (replay *replayMovementSensor) LinearAcceleration(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+func (replay *replayMovementSensor) LinearAcceleration(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 	replay.mu.Lock()
 	defer replay.mu.Unlock()
 	if replay.closed {
@@ -288,7 +288,7 @@ func (replay *replayMovementSensor) LinearAcceleration(ctx context.Context, extr
 }
 
 // CompassHeading returns the next compass heading from the cache as a float64.
-func (replay *replayMovementSensor) CompassHeading(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (replay *replayMovementSensor) CompassHeading(ctx context.Context, extra map[string]any) (float64, error) {
 	replay.mu.Lock()
 	defer replay.mu.Unlock()
 	if replay.closed {
@@ -308,7 +308,7 @@ func (replay *replayMovementSensor) CompassHeading(ctx context.Context, extra ma
 }
 
 // Orientation returns the next orientation from the cache as a spatialmath.Orientation created from a spatialmath.OrientationVector.
-func (replay *replayMovementSensor) Orientation(ctx context.Context, extra map[string]interface{}) (spatialmath.Orientation, error) {
+func (replay *replayMovementSensor) Orientation(ctx context.Context, extra map[string]any) (spatialmath.Orientation, error) {
 	replay.mu.Lock()
 	defer replay.mu.Unlock()
 	if replay.closed {
@@ -333,14 +333,14 @@ func (replay *replayMovementSensor) Orientation(ctx context.Context, extra map[s
 }
 
 // Properties returns the available properties for the given replay movement sensor.
-func (replay *replayMovementSensor) Properties(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+func (replay *replayMovementSensor) Properties(ctx context.Context, extra map[string]any) (*movementsensor.Properties, error) {
 	replay.mu.Lock()
 	defer replay.mu.Unlock()
 	return &replay.properties, nil
 }
 
 // Accuracy is currently not defined for replay movement sensors.
-func (replay *replayMovementSensor) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error,
+func (replay *replayMovementSensor) Accuracy(ctx context.Context, extra map[string]any) (*movementsensor.Accuracy, error,
 ) {
 	return movementsensor.UnimplementedAccuracies()
 }
@@ -356,7 +356,7 @@ func (replay *replayMovementSensor) Close(ctx context.Context) error {
 }
 
 // Readings returns all available data from the next entry stored in the cache.
-func (replay *replayMovementSensor) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+func (replay *replayMovementSensor) Readings(ctx context.Context, extra map[string]any) (map[string]any, error) {
 	return movementsensor.DefaultAPIReadings(ctx, replay, extra)
 }
 

--- a/components/movementsensor/replay/replay_test.go
+++ b/components/movementsensor/replay/replay_test.go
@@ -522,7 +522,7 @@ func TestReplayMovementSensorFunctions(t *testing.T) {
 			test.That(t, err, test.ShouldBeNil)
 			test.That(t, replay, test.ShouldNotBeNil)
 
-			actualProperties, err := replay.Properties(ctx, map[string]interface{}{})
+			actualProperties, err := replay.Properties(ctx, map[string]any{})
 			test.That(t, err, test.ShouldBeNil)
 			test.That(t, actualProperties, test.ShouldResemble, tt.expectedProperties)
 
@@ -763,7 +763,7 @@ func TestUnimplementedFunctionAccuracy(t *testing.T) {
 	replay, _, serverClose, err := createNewReplayMovementSensor(ctx, t, cfg, true)
 	test.That(t, err, test.ShouldBeNil)
 
-	acc, err := replay.Accuracy(ctx, map[string]interface{}{})
+	acc, err := replay.Accuracy(ctx, map[string]any{})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, acc, test.ShouldNotBeNil)
 
@@ -790,7 +790,7 @@ func TestReplayMovementSensorReadings(t *testing.T) {
 
 	// For loop depends on the data length of orientation as it has the fewest points of data
 	for i := 0; i < allMethodsMaxDataLength[orientation]; i++ {
-		readings, err := replay.Readings(ctx, map[string]interface{}{})
+		readings, err := replay.Readings(ctx, map[string]any{})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, readings["position"], test.ShouldResemble, positionPointData[i])
 		test.That(t, readings["altitude"], test.ShouldResemble, positionAltitudeData[i])
@@ -801,7 +801,7 @@ func TestReplayMovementSensorReadings(t *testing.T) {
 		test.That(t, readings["orientation"], test.ShouldResemble, orientationData[i])
 	}
 
-	readings, err := replay.Readings(ctx, map[string]interface{}{})
+	readings, err := replay.Readings(ctx, map[string]any{})
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, ErrEndOfDataset.Error())
 	test.That(t, readings, test.ShouldBeNil)

--- a/components/movementsensor/replay/replay_utils_test.go
+++ b/components/movementsensor/replay/replay_utils_test.go
@@ -277,7 +277,7 @@ func createDataByMovementSensorMethod(method method, index int) *structpb.Struct
 func testReplayMovementSensorMethodData(ctx context.Context, t *testing.T, replay movementsensor.MovementSensor, method method,
 	index int,
 ) {
-	var extra map[string]interface{}
+	var extra map[string]any
 	switch method {
 	case position:
 		point, altitude, err := replay.Position(ctx, extra)
@@ -311,7 +311,7 @@ func testReplayMovementSensorMethodData(ctx context.Context, t *testing.T, repla
 func testReplayMovementSensorMethodError(ctx context.Context, t *testing.T, replay movementsensor.MovementSensor, method method,
 	expectedErr error,
 ) {
-	var extra map[string]interface{}
+	var extra map[string]any
 	switch method {
 	case position:
 		point, altitude, err := replay.Position(ctx, extra)

--- a/components/movementsensor/server.go
+++ b/components/movementsensor/server.go
@@ -17,7 +17,7 @@ type serviceServer struct {
 }
 
 // NewRPCServiceServer constructs an MovementSensor gRPC service serviceServer.
-func NewRPCServiceServer(coll resource.APIResourceCollection[MovementSensor]) interface{} {
+func NewRPCServiceServer(coll resource.APIResourceCollection[MovementSensor]) any {
 	return &serviceServer{coll: coll}
 }
 

--- a/components/movementsensor/wheeledodometry/wheeledodometry.go
+++ b/components/movementsensor/wheeledodometry/wheeledodometry.go
@@ -228,36 +228,36 @@ func newWheeledOdometry(
 	return o, nil
 }
 
-func (o *odometry) AngularVelocity(ctx context.Context, extra map[string]interface{}) (spatialmath.AngularVelocity, error) {
+func (o *odometry) AngularVelocity(ctx context.Context, extra map[string]any) (spatialmath.AngularVelocity, error) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	return o.angularVelocity, nil
 }
 
-func (o *odometry) LinearAcceleration(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+func (o *odometry) LinearAcceleration(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 	return r3.Vector{}, movementsensor.ErrMethodUnimplementedLinearAcceleration
 }
 
-func (o *odometry) Orientation(ctx context.Context, extra map[string]interface{}) (spatialmath.Orientation, error) {
+func (o *odometry) Orientation(ctx context.Context, extra map[string]any) (spatialmath.Orientation, error) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	ov := &spatialmath.OrientationVector{Theta: o.orientation.Yaw, OX: 0, OY: 0, OZ: 1}
 	return ov, nil
 }
 
-func (o *odometry) CompassHeading(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (o *odometry) CompassHeading(ctx context.Context, extra map[string]any) (float64, error) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	return 0, movementsensor.ErrMethodUnimplementedCompassHeading
 }
 
-func (o *odometry) LinearVelocity(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+func (o *odometry) LinearVelocity(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	return o.linearVelocity, nil
 }
 
-func (o *odometry) Position(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+func (o *odometry) Position(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
@@ -270,7 +270,7 @@ func (o *odometry) Position(ctx context.Context, extra map[string]interface{}) (
 	return o.coord, o.position.Z, nil
 }
 
-func (o *odometry) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+func (o *odometry) Readings(ctx context.Context, extra map[string]any) (map[string]any, error) {
 	readings, err := movementsensor.DefaultAPIReadings(ctx, o, extra)
 	if err != nil {
 		return nil, err
@@ -286,12 +286,12 @@ func (o *odometry) Readings(ctx context.Context, extra map[string]interface{}) (
 	return readings, nil
 }
 
-func (o *odometry) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error,
+func (o *odometry) Accuracy(ctx context.Context, extra map[string]any) (*movementsensor.Accuracy, error,
 ) {
 	return movementsensor.UnimplementedAccuracies()
 }
 
-func (o *odometry) Properties(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+func (o *odometry) Properties(ctx context.Context, extra map[string]any) (*movementsensor.Properties, error) {
 	return &movementsensor.Properties{
 		LinearVelocitySupported:  true,
 		AngularVelocitySupported: true,

--- a/components/movementsensor/wheeledodometry/wheeledodometry_test.go
+++ b/components/movementsensor/wheeledodometry/wheeledodometry_test.go
@@ -39,14 +39,14 @@ var position = positions{
 	rightPos: 0.0,
 }
 
-var relativePos = map[string]interface{}{returnRelative: true}
+var relativePos = map[string]any{returnRelative: true}
 
 func createFakeMotor(dir bool) motor.Motor {
 	return &inject.Motor{
-		PropertiesFunc: func(ctx context.Context, extra map[string]interface{}) (motor.Properties, error) {
+		PropertiesFunc: func(ctx context.Context, extra map[string]any) (motor.Properties, error) {
 			return motor.Properties{PositionReporting: true}, nil
 		},
-		PositionFunc: func(ctx context.Context, extra map[string]interface{}) (float64, error) {
+		PositionFunc: func(ctx context.Context, extra map[string]any) (float64, error) {
 			position.mu.Lock()
 			defer position.mu.Unlock()
 			if dir {
@@ -65,14 +65,14 @@ func createFakeMotor(dir bool) motor.Motor {
 			}
 			return false, nil
 		},
-		ResetZeroPositionFunc: func(ctx context.Context, offset float64, extra map[string]interface{}) error {
+		ResetZeroPositionFunc: func(ctx context.Context, offset float64, extra map[string]any) error {
 			position.mu.Lock()
 			defer position.mu.Unlock()
 			position.leftPos = 0
 			position.rightPos = 0
 			return nil
 		},
-		StopFunc: func(ctx context.Context, extra map[string]interface{}) error {
+		StopFunc: func(ctx context.Context, extra map[string]any) error {
 			return nil
 		},
 	}
@@ -80,7 +80,7 @@ func createFakeMotor(dir bool) motor.Motor {
 
 func createFakeBase(circ, width, rad float64) base.Base {
 	return &inject.Base{
-		PropertiesFunc: func(ctx context.Context, extra map[string]interface{}) (base.Properties, error) {
+		PropertiesFunc: func(ctx context.Context, extra map[string]any) (base.Properties, error) {
 			return base.Properties{WheelCircumferenceMeters: circ, WidthMeters: width, TurningRadiusMeters: rad}, nil
 		},
 	}

--- a/components/posetracker/client.go
+++ b/components/posetracker/client.go
@@ -41,7 +41,7 @@ func NewClientFromConn(
 }
 
 func (c *client) Poses(
-	ctx context.Context, bodyNames []string, extra map[string]interface{},
+	ctx context.Context, bodyNames []string, extra map[string]any,
 ) (BodyToPoseInFrame, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
@@ -63,10 +63,10 @@ func (c *client) Poses(
 	return result, nil
 }
 
-func (c *client) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+func (c *client) Readings(ctx context.Context, extra map[string]any) (map[string]any, error) {
 	return Readings(ctx, c)
 }
 
-func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (c *client) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	return rprotoutils.DoFromResourceClient(ctx, c.client, c.name, cmd)
 }

--- a/components/posetracker/client_test.go
+++ b/components/posetracker/client_test.go
@@ -45,7 +45,7 @@ func TestClient(t *testing.T) {
 		nonZeroPoseBody:  referenceframe.NewPoseInFrame(bodyFrame, pose),
 		nonZeroPoseBody2: referenceframe.NewPoseInFrame(otherBodyFrame, pose2),
 	}
-	var extraOptions map[string]interface{}
+	var extraOptions map[string]any
 	poseTester := func(
 		t *testing.T, receivedPoseInFrames posetracker.BodyToPoseInFrame,
 		bodyName string,
@@ -59,14 +59,14 @@ func TestClient(t *testing.T) {
 		test.That(t, poseEqualToExpected, test.ShouldBeTrue)
 	}
 
-	workingPT.PosesFunc = func(ctx context.Context, bodyNames []string, extra map[string]interface{}) (
+	workingPT.PosesFunc = func(ctx context.Context, bodyNames []string, extra map[string]any) (
 		posetracker.BodyToPoseInFrame, error,
 	) {
 		extraOptions = extra
 		return allBodiesToPoseInFrames, nil
 	}
 
-	failingPT.PosesFunc = func(ctx context.Context, bodyNames []string, extra map[string]interface{}) (
+	failingPT.PosesFunc = func(ctx context.Context, bodyNames []string, extra map[string]any) (
 		posetracker.BodyToPoseInFrame, error,
 	) {
 		return nil, errPoseFailed
@@ -103,9 +103,9 @@ func TestClient(t *testing.T) {
 
 	t.Run("client tests for working pose tracker", func(t *testing.T) {
 		bodyToPoseInFrame, err := workingPTClient.Poses(
-			context.Background(), []string{zeroPoseBody, nonZeroPoseBody}, map[string]interface{}{"foo": "Poses"})
+			context.Background(), []string{zeroPoseBody, nonZeroPoseBody}, map[string]any{"foo": "Poses"})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, extraOptions, test.ShouldResemble, map[string]interface{}{"foo": "Poses"})
+		test.That(t, extraOptions, test.ShouldResemble, map[string]any{"foo": "Poses"})
 
 		// DoCommand
 		resp, err := workingPTClient.DoCommand(context.Background(), testutils.TestCommand)
@@ -123,9 +123,9 @@ func TestClient(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		client, err := resourceAPI.RPCClient(context.Background(), conn, "", posetracker.Named(workingPTName), logger)
 		test.That(t, err, test.ShouldBeNil)
-		bodyToPoseInFrame, err := client.Poses(context.Background(), []string{}, map[string]interface{}{"foo": "PosesDialed"})
+		bodyToPoseInFrame, err := client.Poses(context.Background(), []string{}, map[string]any{"foo": "PosesDialed"})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, extraOptions, test.ShouldResemble, map[string]interface{}{"foo": "PosesDialed"})
+		test.That(t, extraOptions, test.ShouldResemble, map[string]any{"foo": "PosesDialed"})
 
 		poseTester(t, bodyToPoseInFrame, nonZeroPoseBody2)
 		poseTester(t, bodyToPoseInFrame, nonZeroPoseBody)

--- a/components/posetracker/pose_tracker.go
+++ b/components/posetracker/pose_tracker.go
@@ -41,7 +41,7 @@ type BodyToPoseInFrame map[string]*referenceframe.PoseInFrame
 // given in the context of the PoseTracker's frame of reference.
 type PoseTracker interface {
 	sensor.Sensor
-	Poses(ctx context.Context, bodyNames []string, extra map[string]interface{}) (BodyToPoseInFrame, error)
+	Poses(ctx context.Context, bodyNames []string, extra map[string]any) (BodyToPoseInFrame, error)
 }
 
 // FromRobot is a helper for getting the named force matrix sensor from the given Robot.
@@ -50,12 +50,12 @@ func FromRobot(r robot.Robot, name string) (PoseTracker, error) {
 }
 
 // Readings is a helper for getting all readings from a PoseTracker.
-func Readings(ctx context.Context, poseTracker PoseTracker) (map[string]interface{}, error) {
-	poseLookup, err := poseTracker.Poses(ctx, []string{}, map[string]interface{}{})
+func Readings(ctx context.Context, poseTracker PoseTracker) (map[string]any, error) {
+	poseLookup, err := poseTracker.Poses(ctx, []string{}, map[string]any{})
 	if err != nil {
 		return nil, err
 	}
-	result := map[string]interface{}{}
+	result := map[string]any{}
 	for bodyName, poseInFrame := range poseLookup {
 		result[bodyName] = poseInFrame
 	}

--- a/components/posetracker/server.go
+++ b/components/posetracker/server.go
@@ -18,7 +18,7 @@ type serviceServer struct {
 
 // NewRPCServiceServer constructs a pose tracker gRPC service server.
 // It is intentionally untyped to prevent use outside of tests.
-func NewRPCServiceServer(coll resource.APIResourceCollection[PoseTracker]) interface{} {
+func NewRPCServiceServer(coll resource.APIResourceCollection[PoseTracker]) any {
 	return &serviceServer{coll: coll}
 }
 

--- a/components/posetracker/server_test.go
+++ b/components/posetracker/server_test.go
@@ -45,8 +45,8 @@ func TestGetPoses(t *testing.T) {
 	ptServer, workingPT, failingPT, err := newServer()
 	test.That(t, err, test.ShouldBeNil)
 
-	var extraOptions map[string]interface{}
-	workingPT.PosesFunc = func(ctx context.Context, bodyNames []string, extra map[string]interface{}) (
+	var extraOptions map[string]any
+	workingPT.PosesFunc = func(ctx context.Context, bodyNames []string, extra map[string]any) (
 		posetracker.BodyToPoseInFrame, error,
 	) {
 		extraOptions = extra
@@ -56,7 +56,7 @@ func TestGetPoses(t *testing.T) {
 		}, nil
 	}
 
-	failingPT.PosesFunc = func(ctx context.Context, bodyNames []string, extra map[string]interface{}) (
+	failingPT.PosesFunc = func(ctx context.Context, bodyNames []string, extra map[string]any) (
 		posetracker.BodyToPoseInFrame, error,
 	) {
 		return nil, errPoseFailed
@@ -71,7 +71,7 @@ func TestGetPoses(t *testing.T) {
 		test.That(t, resp, test.ShouldBeNil)
 	})
 
-	ext, err := protoutils.StructToStructPb(map[string]interface{}{"foo": "GetPosesRequest"})
+	ext, err := protoutils.StructToStructPb(map[string]any{"foo": "GetPosesRequest"})
 	test.That(t, err, test.ShouldBeNil)
 	req := pb.GetPosesRequest{
 		Name: workingPTName, BodyNames: []string{bodyName}, Extra: ext,
@@ -81,10 +81,10 @@ func TestGetPoses(t *testing.T) {
 	}
 	resp1, err := ptServer.GetPoses(context.Background(), &req)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, extraOptions, test.ShouldResemble, map[string]interface{}{"foo": "GetPosesRequest"})
+	test.That(t, extraOptions, test.ShouldResemble, map[string]any{"foo": "GetPosesRequest"})
 	resp2, err := ptServer.GetPoses(context.Background(), &req2)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, extraOptions, test.ShouldResemble, map[string]interface{}{})
+	test.That(t, extraOptions, test.ShouldResemble, map[string]any{})
 
 	workingTestCases := []struct {
 		testStr string

--- a/components/powersensor/client.go
+++ b/components/powersensor/client.go
@@ -41,7 +41,7 @@ func NewClientFromConn(
 }
 
 // Voltage returns the voltage reading in volts and a bool returning true if the voltage is AC.
-func (c *client) Voltage(ctx context.Context, extra map[string]interface{}) (float64, bool, error) {
+func (c *client) Voltage(ctx context.Context, extra map[string]any) (float64, bool, error) {
 	ext, err := structpb.NewStruct(extra)
 	if err != nil {
 		return 0, false, err
@@ -59,7 +59,7 @@ func (c *client) Voltage(ctx context.Context, extra map[string]interface{}) (flo
 }
 
 // Current returns the current reading in amperes and a bool returning true if the current is AC.
-func (c *client) Current(ctx context.Context, extra map[string]interface{}) (float64, bool, error) {
+func (c *client) Current(ctx context.Context, extra map[string]any) (float64, bool, error) {
 	ext, err := structpb.NewStruct(extra)
 	if err != nil {
 		return 0, false, err
@@ -77,7 +77,7 @@ func (c *client) Current(ctx context.Context, extra map[string]interface{}) (flo
 }
 
 // Power returns the power reading in watts.
-func (c *client) Power(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (c *client) Power(ctx context.Context, extra map[string]any) (float64, error) {
 	ext, err := structpb.NewStruct(extra)
 	if err != nil {
 		return 0, err
@@ -92,7 +92,7 @@ func (c *client) Power(ctx context.Context, extra map[string]interface{}) (float
 	return resp.Watts, nil
 }
 
-func (c *client) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+func (c *client) Readings(ctx context.Context, extra map[string]any) (map[string]any, error) {
 	ext, err := structpb.NewStruct(extra)
 	if err != nil {
 		return nil, err
@@ -108,6 +108,6 @@ func (c *client) Readings(ctx context.Context, extra map[string]interface{}) (ma
 	return protoutils.ReadingProtoToGo(resp.Readings)
 }
 
-func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (c *client) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	return protoutils.DoFromResourceClient(ctx, c.client, c.name, cmd)
 }

--- a/components/powersensor/client_test.go
+++ b/components/powersensor/client_test.go
@@ -33,27 +33,27 @@ func TestClient(t *testing.T) {
 	workingPowerSensor := &inject.PowerSensor{}
 	failingPowerSensor := &inject.PowerSensor{}
 
-	workingPowerSensor.VoltageFunc = func(ctx context.Context, extra map[string]interface{}) (float64, bool, error) {
+	workingPowerSensor.VoltageFunc = func(ctx context.Context, extra map[string]any) (float64, bool, error) {
 		return testVolts, testIsAC, nil
 	}
 
-	workingPowerSensor.CurrentFunc = func(ctx context.Context, extra map[string]interface{}) (float64, bool, error) {
+	workingPowerSensor.CurrentFunc = func(ctx context.Context, extra map[string]any) (float64, bool, error) {
 		return testAmps, testIsAC, nil
 	}
 
-	workingPowerSensor.PowerFunc = func(ctx context.Context, extra map[string]interface{}) (float64, error) {
+	workingPowerSensor.PowerFunc = func(ctx context.Context, extra map[string]any) (float64, error) {
 		return testWatts, nil
 	}
 
-	failingPowerSensor.VoltageFunc = func(ctx context.Context, extra map[string]interface{}) (float64, bool, error) {
+	failingPowerSensor.VoltageFunc = func(ctx context.Context, extra map[string]any) (float64, bool, error) {
 		return 0, false, errVoltageFailed
 	}
 
-	failingPowerSensor.CurrentFunc = func(ctx context.Context, extra map[string]interface{}) (float64, bool, error) {
+	failingPowerSensor.CurrentFunc = func(ctx context.Context, extra map[string]any) (float64, bool, error) {
 		return 0, false, errCurrentFailed
 	}
 
-	failingPowerSensor.PowerFunc = func(ctx context.Context, extra map[string]interface{}) (float64, error) {
+	failingPowerSensor.PowerFunc = func(ctx context.Context, extra map[string]any) (float64, error) {
 		return 0, errPowerFailed
 	}
 
@@ -93,17 +93,17 @@ func TestClient(t *testing.T) {
 		test.That(t, resp["command"], test.ShouldEqual, testutils.TestCommand["command"])
 		test.That(t, resp["data"], test.ShouldEqual, testutils.TestCommand["data"])
 
-		volts, isAC, err := client.Voltage(context.Background(), make(map[string]interface{}))
+		volts, isAC, err := client.Voltage(context.Background(), make(map[string]any))
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, volts, test.ShouldEqual, testVolts)
 		test.That(t, isAC, test.ShouldEqual, testIsAC)
 
-		amps, isAC, err := client.Current(context.Background(), make(map[string]interface{}))
+		amps, isAC, err := client.Current(context.Background(), make(map[string]any))
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, amps, test.ShouldEqual, testAmps)
 		test.That(t, isAC, test.ShouldEqual, testIsAC)
 
-		watts, err := client.Power(context.Background(), make(map[string]interface{}))
+		watts, err := client.Power(context.Background(), make(map[string]any))
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, watts, test.ShouldEqual, testWatts)
 
@@ -117,19 +117,19 @@ func TestClient(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Run("client tests with failing power sensor", func(t *testing.T) {
-		volts, isAC, err := client.Voltage(context.Background(), make(map[string]interface{}))
+		volts, isAC, err := client.Voltage(context.Background(), make(map[string]any))
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errVoltageFailed.Error())
 		test.That(t, volts, test.ShouldEqual, 0)
 		test.That(t, isAC, test.ShouldEqual, false)
 
-		amps, isAC, err := client.Current(context.Background(), make(map[string]interface{}))
+		amps, isAC, err := client.Current(context.Background(), make(map[string]any))
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errCurrentFailed.Error())
 		test.That(t, amps, test.ShouldEqual, 0)
 		test.That(t, isAC, test.ShouldEqual, false)
 
-		watts, err := client.Power(context.Background(), make(map[string]interface{}))
+		watts, err := client.Power(context.Background(), make(map[string]any))
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errPowerFailed.Error())
 		test.That(t, watts, test.ShouldEqual, 0)

--- a/components/powersensor/collectors.go
+++ b/components/powersensor/collectors.go
@@ -35,7 +35,7 @@ func (m method) String() string {
 	return "Unknown"
 }
 
-func assertPowerSensor(resource interface{}) (PowerSensor, error) {
+func assertPowerSensor(resource any) (PowerSensor, error) {
 	ps, ok := resource.(PowerSensor)
 	if !ok {
 		return nil, data.InvalidInterfaceErr(API)
@@ -45,13 +45,13 @@ func assertPowerSensor(resource interface{}) (PowerSensor, error) {
 
 // newVoltageCollector returns a collector to register a voltage method. If one is already registered
 // with the same MethodMetadata it will panic.
-func newVoltageCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+func newVoltageCollector(resource any, params data.CollectorParams) (data.Collector, error) {
 	ps, err := assertPowerSensor(resource)
 	if err != nil {
 		return nil, err
 	}
 
-	cFunc := data.CaptureFunc(func(ctx context.Context, extra map[string]*anypb.Any) (interface{}, error) {
+	cFunc := data.CaptureFunc(func(ctx context.Context, extra map[string]*anypb.Any) (any, error) {
 		volts, isAc, err := ps.Voltage(ctx, data.FromDMExtraMap)
 		if err != nil {
 			// A modular filter component can be created to filter the readings from a component. The error ErrNoCaptureToStore
@@ -71,13 +71,13 @@ func newVoltageCollector(resource interface{}, params data.CollectorParams) (dat
 
 // newCurrentCollector returns a collector to register a current method. If one is already registered
 // with the same MethodMetadata it will panic.
-func newCurrentCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+func newCurrentCollector(resource any, params data.CollectorParams) (data.Collector, error) {
 	ps, err := assertPowerSensor(resource)
 	if err != nil {
 		return nil, err
 	}
 
-	cFunc := data.CaptureFunc(func(ctx context.Context, extra map[string]*anypb.Any) (interface{}, error) {
+	cFunc := data.CaptureFunc(func(ctx context.Context, extra map[string]*anypb.Any) (any, error) {
 		curr, isAc, err := ps.Current(ctx, data.FromDMExtraMap)
 		if err != nil {
 			// A modular filter component can be created to filter the readings from a component. The error ErrNoCaptureToStore
@@ -97,13 +97,13 @@ func newCurrentCollector(resource interface{}, params data.CollectorParams) (dat
 
 // newPowerCollector returns a collector to register a power method. If one is already registered
 // with the same MethodMetadata it will panic.
-func newPowerCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+func newPowerCollector(resource any, params data.CollectorParams) (data.Collector, error) {
 	ps, err := assertPowerSensor(resource)
 	if err != nil {
 		return nil, err
 	}
 
-	cFunc := data.CaptureFunc(func(ctx context.Context, extra map[string]*anypb.Any) (interface{}, error) {
+	cFunc := data.CaptureFunc(func(ctx context.Context, extra map[string]*anypb.Any) (any, error) {
 		pwr, err := ps.Power(ctx, data.FromDMExtraMap)
 		if err != nil {
 			// A modular filter component can be created to filter the readings from a component. The error ErrNoCaptureToStore
@@ -122,13 +122,13 @@ func newPowerCollector(resource interface{}, params data.CollectorParams) (data.
 
 // newReadingsCollector returns a collector to register a readings method. If one is already registered
 // with the same MethodMetadata it will panic.
-func newReadingsCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+func newReadingsCollector(resource any, params data.CollectorParams) (data.Collector, error) {
 	ps, err := assertPowerSensor(resource)
 	if err != nil {
 		return nil, err
 	}
 
-	cFunc := data.CaptureFunc(func(ctx context.Context, arg map[string]*anypb.Any) (interface{}, error) {
+	cFunc := data.CaptureFunc(func(ctx context.Context, arg map[string]*anypb.Any) (any, error) {
 		values, err := ps.Readings(ctx, data.FromDMExtraMap)
 		if err != nil {
 			// A modular filter component can be created to filter the readings from a component. The error ErrNoCaptureToStore

--- a/components/powersensor/collectors_test.go
+++ b/components/powersensor/collectors_test.go
@@ -92,16 +92,16 @@ func TestPowerSensorCollectors(t *testing.T) {
 
 func newPowerSensor() powersensor.PowerSensor {
 	p := &inject.PowerSensor{}
-	p.VoltageFunc = func(ctx context.Context, extra map[string]interface{}) (float64, bool, error) {
+	p.VoltageFunc = func(ctx context.Context, extra map[string]any) (float64, bool, error) {
 		return 1.0, false, nil
 	}
-	p.CurrentFunc = func(ctx context.Context, extra map[string]interface{}) (float64, bool, error) {
+	p.CurrentFunc = func(ctx context.Context, extra map[string]any) (float64, bool, error) {
 		return 1.0, false, nil
 	}
-	p.PowerFunc = func(ctx context.Context, extra map[string]interface{}) (float64, error) {
+	p.PowerFunc = func(ctx context.Context, extra map[string]any) (float64, error) {
 		return 1.0, nil
 	}
-	p.ReadingsFunc = func(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+	p.ReadingsFunc = func(ctx context.Context, extra map[string]any) (map[string]any, error) {
 		return readingMap, nil
 	}
 	return p

--- a/components/powersensor/fake/powersensor.go
+++ b/components/powersensor/fake/powersensor.go
@@ -41,27 +41,27 @@ type PowerSensor struct {
 }
 
 // DoCommand uses a map string to run custom functionality of a fake powersensor.
-func (f *PowerSensor) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
-	return map[string]interface{}{}, nil
+func (f *PowerSensor) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
+	return map[string]any{}, nil
 }
 
 // Voltage gets the voltage and isAC of a fake powersensor.
-func (f *PowerSensor) Voltage(ctx context.Context, cmd map[string]interface{}) (float64, bool, error) {
+func (f *PowerSensor) Voltage(ctx context.Context, cmd map[string]any) (float64, bool, error) {
 	return 1.5, true, nil
 }
 
 // Current gets the current and isAC of a fake powersensor.
-func (f *PowerSensor) Current(ctx context.Context, cmd map[string]interface{}) (float64, bool, error) {
+func (f *PowerSensor) Current(ctx context.Context, cmd map[string]any) (float64, bool, error) {
 	return 2.2, true, nil
 }
 
 // Power gets the power of a fake powersensor.
-func (f *PowerSensor) Power(ctx context.Context, cmd map[string]interface{}) (float64, error) {
+func (f *PowerSensor) Power(ctx context.Context, cmd map[string]any) (float64, error) {
 	return 9.8, nil
 }
 
 // Readings gets the readings of a fake powersensor.
-func (f *PowerSensor) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+func (f *PowerSensor) Readings(ctx context.Context, extra map[string]any) (map[string]any, error) {
 	volts, isAC, err := f.Voltage(ctx, nil)
 	if err != nil {
 		f.logger.CErrorf(ctx, "failed to get voltage reading: %s", err.Error())
@@ -76,7 +76,7 @@ func (f *PowerSensor) Readings(ctx context.Context, extra map[string]interface{}
 	if err != nil {
 		f.logger.CErrorf(ctx, "failed to get power reading: %s", err.Error())
 	}
-	return map[string]interface{}{
+	return map[string]any{
 		"volts": volts,
 		"amps":  amps,
 		"is_ac": isAC,

--- a/components/powersensor/ina/ina.go
+++ b/components/powersensor/ina/ina.go
@@ -238,7 +238,7 @@ func (d *ina) calibrate() error {
 	return nil
 }
 
-func (d *ina) Voltage(ctx context.Context, extra map[string]interface{}) (float64, bool, error) {
+func (d *ina) Voltage(ctx context.Context, extra map[string]any) (float64, bool, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	handle, err := i2c.NewI2C(d.addr, d.bus)
@@ -268,7 +268,7 @@ func (d *ina) Voltage(ctx context.Context, extra map[string]interface{}) (float6
 	return voltage, isAC, nil
 }
 
-func (d *ina) Current(ctx context.Context, extra map[string]interface{}) (float64, bool, error) {
+func (d *ina) Current(ctx context.Context, extra map[string]any) (float64, bool, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	handle, err := i2c.NewI2C(d.addr, d.bus)
@@ -295,7 +295,7 @@ func (d *ina) Current(ctx context.Context, extra map[string]interface{}) (float6
 	return current, isAC, nil
 }
 
-func (d *ina) Power(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (d *ina) Power(ctx context.Context, extra map[string]any) (float64, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	handle, err := i2c.NewI2C(d.addr, d.bus)
@@ -321,7 +321,7 @@ func (d *ina) Power(ctx context.Context, extra map[string]interface{}) (float64,
 }
 
 // Readings returns a map with voltage, current, power and isAC.
-func (d *ina) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+func (d *ina) Readings(ctx context.Context, extra map[string]any) (map[string]any, error) {
 	volts, isAC, err := d.Voltage(ctx, nil)
 	if err != nil {
 		d.logger.CErrorf(ctx, "failed to get voltage reading: %s", err.Error())
@@ -336,7 +336,7 @@ func (d *ina) Readings(ctx context.Context, extra map[string]interface{}) (map[s
 	if err != nil {
 		d.logger.CErrorf(ctx, "failed to get power reading: %s", err.Error())
 	}
-	return map[string]interface{}{
+	return map[string]any{
 		"volts": volts,
 		"amps":  amps,
 		"is_ac": isAC,

--- a/components/powersensor/powersensor.go
+++ b/components/powersensor/powersensor.go
@@ -51,9 +51,9 @@ func Named(name string) resource.Name {
 type PowerSensor interface {
 	resource.Sensor
 	resource.Resource
-	Voltage(ctx context.Context, extra map[string]interface{}) (float64, bool, error)
-	Current(ctx context.Context, extra map[string]interface{}) (float64, bool, error)
-	Power(ctx context.Context, extra map[string]interface{}) (float64, error)
+	Voltage(ctx context.Context, extra map[string]any) (float64, bool, error)
+	Current(ctx context.Context, extra map[string]any) (float64, bool, error)
+	Power(ctx context.Context, extra map[string]any) (float64, error)
 }
 
 // FromDependencies is a helper for getting the named PowerSensor from a collection of

--- a/components/powersensor/renogy/renogy.go
+++ b/components/powersensor/renogy/renogy.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	model    = resource.DefaultModelFamily.WithModel("renogy")
-	readings map[string]interface{}
+	readings map[string]any
 )
 
 const (
@@ -134,7 +134,7 @@ func (r *Renogy) getHandler() *modbus.RTUClientHandler {
 }
 
 // Voltage returns the voltage of the battery and a boolean IsAc.
-func (r *Renogy) Voltage(ctx context.Context, extra map[string]interface{}) (float64, bool, error) {
+func (r *Renogy) Voltage(ctx context.Context, extra map[string]any) (float64, bool, error) {
 	// Read the battery voltage.
 	volts, err := r.readRegister(r.client, battVoltReg, 1)
 	if err != nil {
@@ -145,7 +145,7 @@ func (r *Renogy) Voltage(ctx context.Context, extra map[string]interface{}) (flo
 
 // Current returns the load's current and boolean isAC.
 // If the controller does not have a load input, will return zero.
-func (r *Renogy) Current(ctx context.Context, extra map[string]interface{}) (float64, bool, error) {
+func (r *Renogy) Current(ctx context.Context, extra map[string]any) (float64, bool, error) {
 	// read the load current.
 	loadCurrent, err := r.readRegister(r.client, loadAmpReg, 2)
 	if err != nil {
@@ -156,7 +156,7 @@ func (r *Renogy) Current(ctx context.Context, extra map[string]interface{}) (flo
 }
 
 // Power returns the power of the load. If the controller does not have a load input, will return zero.
-func (r *Renogy) Power(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (r *Renogy) Power(ctx context.Context, extra map[string]any) (float64, error) {
 	// reads the load wattage.
 	loadPower, err := r.readRegister(r.client, loadWattReg, 1)
 	if err != nil {
@@ -167,8 +167,8 @@ func (r *Renogy) Power(ctx context.Context, extra map[string]interface{}) (float
 }
 
 // Readings returns a list of all readings from the sensor.
-func (r *Renogy) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
-	readings = make(map[string]interface{})
+func (r *Renogy) Readings(ctx context.Context, extra map[string]any) (map[string]any, error) {
+	readings = make(map[string]any)
 
 	// add all readings.
 	r.addReading(solarVoltReg, 1, "SolarVolt")

--- a/components/powersensor/server.go
+++ b/components/powersensor/server.go
@@ -16,7 +16,7 @@ type serviceServer struct {
 }
 
 // NewRPCServiceServer constructs a PowerSesnsor gRPC service serviceServer.
-func NewRPCServiceServer(coll resource.APIResourceCollection[PowerSensor]) interface{} {
+func NewRPCServiceServer(coll resource.APIResourceCollection[PowerSensor]) any {
 	return &serviceServer{coll: coll}
 }
 

--- a/components/powersensor/server_test.go
+++ b/components/powersensor/server_test.go
@@ -54,7 +54,7 @@ func TestServerGetVoltage(t *testing.T) {
 	isAC := false
 
 	// successful
-	testPowerSensor.VoltageFunc = func(ctx context.Context, extra map[string]interface{}) (float64, bool, error) {
+	testPowerSensor.VoltageFunc = func(ctx context.Context, extra map[string]any) (float64, bool, error) {
 		return volts, isAC, nil
 	}
 	req := &pb.GetVoltageRequest{Name: workingPowerSensorName}
@@ -64,7 +64,7 @@ func TestServerGetVoltage(t *testing.T) {
 	test.That(t, resp.IsAc, test.ShouldEqual, isAC)
 
 	// fails on bad power sensor
-	failingPowerSensor.VoltageFunc = func(ctx context.Context, extra map[string]interface{}) (float64, bool, error) {
+	failingPowerSensor.VoltageFunc = func(ctx context.Context, extra map[string]any) (float64, bool, error) {
 		return 0, false, errVoltageFailed
 	}
 	req = &pb.GetVoltageRequest{Name: failingPowerSensorName}
@@ -88,7 +88,7 @@ func TestServerGetCurrent(t *testing.T) {
 	isAC := false
 
 	// successful
-	testPowerSensor.CurrentFunc = func(ctx context.Context, extra map[string]interface{}) (float64, bool, error) {
+	testPowerSensor.CurrentFunc = func(ctx context.Context, extra map[string]any) (float64, bool, error) {
 		return amps, isAC, nil
 	}
 	req := &pb.GetCurrentRequest{Name: workingPowerSensorName}
@@ -98,7 +98,7 @@ func TestServerGetCurrent(t *testing.T) {
 	test.That(t, resp.IsAc, test.ShouldEqual, isAC)
 
 	// fails on bad power sensor
-	failingPowerSensor.CurrentFunc = func(ctx context.Context, extra map[string]interface{}) (float64, bool, error) {
+	failingPowerSensor.CurrentFunc = func(ctx context.Context, extra map[string]any) (float64, bool, error) {
 		return 0, false, errCurrentFailed
 	}
 	req = &pb.GetCurrentRequest{Name: failingPowerSensorName}
@@ -120,7 +120,7 @@ func TestServerGetPower(t *testing.T) {
 	watts := 4.8
 
 	// successful
-	testPowerSensor.PowerFunc = func(ctx context.Context, extra map[string]interface{}) (float64, error) {
+	testPowerSensor.PowerFunc = func(ctx context.Context, extra map[string]any) (float64, error) {
 		return watts, nil
 	}
 	req := &pb.GetPowerRequest{Name: workingPowerSensorName}
@@ -129,7 +129,7 @@ func TestServerGetPower(t *testing.T) {
 	test.That(t, resp.Watts, test.ShouldEqual, watts)
 
 	// fails on bad power sensor
-	failingPowerSensor.PowerFunc = func(ctx context.Context, extra map[string]interface{}) (float64, error) {
+	failingPowerSensor.PowerFunc = func(ctx context.Context, extra map[string]any) (float64, error) {
 		return 0, errPowerFailed
 	}
 	req = &pb.GetPowerRequest{Name: failingPowerSensorName}
@@ -149,15 +149,15 @@ func TestServerGetReadings(t *testing.T) {
 	powerSensorServer, testPowerSensor, failingPowerSensor, err := newServer()
 	test.That(t, err, test.ShouldBeNil)
 
-	rs := map[string]interface{}{"a": 1.1, "b": 2.2}
+	rs := map[string]any{"a": 1.1, "b": 2.2}
 
-	var extraCap map[string]interface{}
-	testPowerSensor.ReadingsFunc = func(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+	var extraCap map[string]any
+	testPowerSensor.ReadingsFunc = func(ctx context.Context, extra map[string]any) (map[string]any, error) {
 		extraCap = extra
 		return rs, nil
 	}
 
-	failingPowerSensor.ReadingsFunc = func(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+	failingPowerSensor.ReadingsFunc = func(ctx context.Context, extra map[string]any) (map[string]any, error) {
 		return nil, errReadingsFailed
 	}
 
@@ -167,13 +167,13 @@ func TestServerGetReadings(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		expected[k] = vv
 	}
-	extra, err := protoutils.StructToStructPb(map[string]interface{}{"foo": "bar"})
+	extra, err := protoutils.StructToStructPb(map[string]any{"foo": "bar"})
 	test.That(t, err, test.ShouldBeNil)
 
 	resp, err := powerSensorServer.GetReadings(context.Background(), &commonpb.GetReadingsRequest{Name: workingPowerSensorName, Extra: extra})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, resp.Readings, test.ShouldResemble, expected)
-	test.That(t, extraCap, test.ShouldResemble, map[string]interface{}{"foo": "bar"})
+	test.That(t, extraCap, test.ShouldResemble, map[string]any{"foo": "bar"})
 
 	_, err = powerSensorServer.GetReadings(context.Background(), &commonpb.GetReadingsRequest{Name: failingPowerSensorName})
 	test.That(t, err, test.ShouldNotBeNil)

--- a/components/sensor/bme280/bme280.go
+++ b/components/sensor/bme280/bme280.go
@@ -204,7 +204,7 @@ type bme280 struct {
 }
 
 // Readings returns a list containing single item (current temperature).
-func (s *bme280) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+func (s *bme280) Readings(ctx context.Context, extra map[string]any) (map[string]any, error) {
 	handle, err := s.bus.OpenHandle(s.addr)
 	if err != nil {
 		s.logger.CErrorf(ctx, "can't open bme280 i2c %s", err)
@@ -226,7 +226,7 @@ func (s *bme280) Readings(ctx context.Context, extra map[string]interface{}) (ma
 	temp := s.readTemperatureCelsius(buffer)
 	humid := s.readHumidity(buffer)
 	dewPt := s.calculateDewPoint(temp, humid)
-	return map[string]interface{}{
+	return map[string]any{
 		"temperature_celsius":    temp,
 		"dew_point_celsius":      dewPt,
 		"temperature_fahrenheit": temp*1.8 + 32,

--- a/components/sensor/client.go
+++ b/components/sensor/client.go
@@ -41,7 +41,7 @@ func NewClientFromConn(
 	}, nil
 }
 
-func (c *client) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+func (c *client) Readings(ctx context.Context, extra map[string]any) (map[string]any, error) {
 	ext, err := structpb.NewStruct(extra)
 	if err != nil {
 		return nil, err
@@ -57,6 +57,6 @@ func (c *client) Readings(ctx context.Context, extra map[string]interface{}) (ma
 	return protoutils.ReadingProtoToGo(resp.Readings)
 }
 
-func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (c *client) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	return protoutils.DoFromResourceClient(ctx, c.client, c.name, cmd)
 }

--- a/components/sensor/client_test.go
+++ b/components/sensor/client_test.go
@@ -30,17 +30,17 @@ func TestClient(t *testing.T) {
 	rpcServer, err := rpc.NewServer(logger.AsZap(), rpc.WithUnauthenticated())
 	test.That(t, err, test.ShouldBeNil)
 
-	rs := map[string]interface{}{"a": 1.1, "b": 2.2}
+	rs := map[string]any{"a": 1.1, "b": 2.2}
 
-	var extraCap map[string]interface{}
+	var extraCap map[string]any
 	injectSensor := &inject.Sensor{}
-	injectSensor.ReadingsFunc = func(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+	injectSensor.ReadingsFunc = func(ctx context.Context, extra map[string]any) (map[string]any, error) {
 		extraCap = extra
 		return rs, nil
 	}
 
 	injectSensor2 := &inject.Sensor{}
-	injectSensor2.ReadingsFunc = func(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+	injectSensor2.ReadingsFunc = func(ctx context.Context, extra map[string]any) (map[string]any, error) {
 		return nil, errReadingsFailed
 	}
 
@@ -81,16 +81,16 @@ func TestClient(t *testing.T) {
 		test.That(t, resp["command"], test.ShouldEqual, testutils.TestCommand["command"])
 		test.That(t, resp["data"], test.ShouldEqual, testutils.TestCommand["data"])
 
-		rs1, err := sensor1Client.Readings(context.Background(), make(map[string]interface{}))
+		rs1, err := sensor1Client.Readings(context.Background(), make(map[string]any))
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, rs1, test.ShouldResemble, rs)
-		test.That(t, extraCap, test.ShouldResemble, make(map[string]interface{}))
+		test.That(t, extraCap, test.ShouldResemble, make(map[string]any))
 
 		// With extra params
-		rs1, err = sensor1Client.Readings(context.Background(), map[string]interface{}{"foo": "bar"})
+		rs1, err = sensor1Client.Readings(context.Background(), map[string]any{"foo": "bar"})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, rs1, test.ShouldResemble, rs)
-		test.That(t, extraCap, test.ShouldResemble, map[string]interface{}{"foo": "bar"})
+		test.That(t, extraCap, test.ShouldResemble, map[string]any{"foo": "bar"})
 
 		test.That(t, sensor1Client.Close(context.Background()), test.ShouldBeNil)
 		test.That(t, conn.Close(), test.ShouldBeNil)
@@ -102,7 +102,7 @@ func TestClient(t *testing.T) {
 		client2, err := resourceAPI.RPCClient(context.Background(), conn, "", sensor.Named(failSensorName), logger)
 		test.That(t, err, test.ShouldBeNil)
 
-		_, err = client2.Readings(context.Background(), make(map[string]interface{}))
+		_, err = client2.Readings(context.Background(), make(map[string]any))
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errReadingsFailed.Error())
 

--- a/components/sensor/collector.go
+++ b/components/sensor/collector.go
@@ -26,13 +26,13 @@ func (m method) String() string {
 
 // newReadingsCollector returns a collector to register a sensor reading method. If one is already registered
 // with the same MethodMetadata it will panic.
-func newReadingsCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+func newReadingsCollector(resource any, params data.CollectorParams) (data.Collector, error) {
 	sensorResource, err := assertSensor(resource)
 	if err != nil {
 		return nil, err
 	}
 
-	cFunc := data.CaptureFunc(func(ctx context.Context, arg map[string]*anypb.Any) (interface{}, error) {
+	cFunc := data.CaptureFunc(func(ctx context.Context, arg map[string]*anypb.Any) (any, error) {
 		values, err := sensorResource.Readings(ctx, data.FromDMExtraMap)
 		if err != nil {
 			// A modular filter component can be created to filter the readings from a component. The error ErrNoCaptureToStore
@@ -53,7 +53,7 @@ func newReadingsCollector(resource interface{}, params data.CollectorParams) (da
 	return data.NewCollector(cFunc, params)
 }
 
-func assertSensor(resource interface{}) (Sensor, error) {
+func assertSensor(resource any) (Sensor, error) {
 	sensorResource, ok := resource.(Sensor)
 	if !ok {
 		return nil, data.InvalidInterfaceErr(API)

--- a/components/sensor/collector_test.go
+++ b/components/sensor/collector_test.go
@@ -51,7 +51,7 @@ func TestSensorCollector(t *testing.T) {
 
 func newSensor() sensor.Sensor {
 	s := &inject.Sensor{}
-	s.ReadingsFunc = func(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+	s.ReadingsFunc = func(ctx context.Context, extra map[string]any) (map[string]any, error) {
 		return readingMap, nil
 	}
 	return s

--- a/components/sensor/ds18b20/ds18b20.go
+++ b/components/sensor/ds18b20/ds18b20.go
@@ -87,10 +87,10 @@ func (s *Sensor) ReadTemperatureCelsius(ctx context.Context) (float64, error) {
 }
 
 // Readings returns a list containing single item (current temperature).
-func (s *Sensor) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+func (s *Sensor) Readings(ctx context.Context, extra map[string]any) (map[string]any, error) {
 	temp, err := s.ReadTemperatureCelsius(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return map[string]interface{}{"degrees_celsius": temp}, nil
+	return map[string]any{"degrees_celsius": temp}, nil
 }

--- a/components/sensor/fake/sensor.go
+++ b/components/sensor/fake/sensor.go
@@ -41,8 +41,8 @@ type Sensor struct {
 }
 
 // Readings always returns the set values.
-func (s *Sensor) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+func (s *Sensor) Readings(ctx context.Context, extra map[string]any) (map[string]any, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return map[string]interface{}{"a": 1, "b": 2, "c": 3}, nil
+	return map[string]any{"a": 1, "b": 2, "c": 3}, nil
 }

--- a/components/sensor/server.go
+++ b/components/sensor/server.go
@@ -18,7 +18,7 @@ type serviceServer struct {
 }
 
 // NewRPCServiceServer constructs an sensor gRPC service serviceServer.
-func NewRPCServiceServer(coll resource.APIResourceCollection[Sensor]) interface{} {
+func NewRPCServiceServer(coll resource.APIResourceCollection[Sensor]) any {
 	return &serviceServer{coll: coll}
 }
 

--- a/components/sensor/server_test.go
+++ b/components/sensor/server_test.go
@@ -36,15 +36,15 @@ func TestServer(t *testing.T) {
 	sensorServer, injectSensor, injectSensor2, err := newServer()
 	test.That(t, err, test.ShouldBeNil)
 
-	rs := map[string]interface{}{"a": 1.1, "b": 2.2}
+	rs := map[string]any{"a": 1.1, "b": 2.2}
 
-	var extraCap map[string]interface{}
-	injectSensor.ReadingsFunc = func(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+	var extraCap map[string]any
+	injectSensor.ReadingsFunc = func(ctx context.Context, extra map[string]any) (map[string]any, error) {
 		extraCap = extra
 		return rs, nil
 	}
 
-	injectSensor2.ReadingsFunc = func(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+	injectSensor2.ReadingsFunc = func(ctx context.Context, extra map[string]any) (map[string]any, error) {
 		return nil, errReadingsFailed
 	}
 
@@ -55,13 +55,13 @@ func TestServer(t *testing.T) {
 			test.That(t, err, test.ShouldBeNil)
 			expected[k] = vv
 		}
-		extra, err := protoutils.StructToStructPb(map[string]interface{}{"foo": "bar"})
+		extra, err := protoutils.StructToStructPb(map[string]any{"foo": "bar"})
 		test.That(t, err, test.ShouldBeNil)
 
 		resp, err := sensorServer.GetReadings(context.Background(), &commonpb.GetReadingsRequest{Name: testSensorName, Extra: extra})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, resp.Readings, test.ShouldResemble, expected)
-		test.That(t, extraCap, test.ShouldResemble, map[string]interface{}{"foo": "bar"})
+		test.That(t, extraCap, test.ShouldResemble, map[string]any{"foo": "bar"})
 
 		_, err = sensorServer.GetReadings(context.Background(), &commonpb.GetReadingsRequest{Name: failSensorName})
 		test.That(t, err, test.ShouldNotBeNil)

--- a/components/sensor/sht3xd/sht3xd.go
+++ b/components/sensor/sht3xd/sht3xd.go
@@ -110,7 +110,7 @@ type sht3xd struct {
 }
 
 // Readings returns a list containing two items (current temperature and humidity).
-func (s *sht3xd) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+func (s *sht3xd) Readings(ctx context.Context, extra map[string]any) (map[string]any, error) {
 	tryRead := func() ([]byte, error) {
 		handle, err := s.bus.OpenHandle(s.addr)
 		if err != nil {
@@ -148,7 +148,7 @@ func (s *sht3xd) Readings(ctx context.Context, extra map[string]interface{}) (ma
 
 	temp := 175.0*float64(tempRaw)/65535.0 - 45.0
 	humid := 100.0 * float64(humidRaw) / 65535.0
-	return map[string]interface{}{
+	return map[string]any{
 		"temperature_celsius":   temp,
 		"relative_humidity_pct": humid, // TODO(RSDK-1903)
 	}, nil

--- a/components/sensor/ultrasonic/ultrasonic.go
+++ b/components/sensor/ultrasonic/ultrasonic.go
@@ -128,7 +128,7 @@ func (s *Sensor) namedError(err error) error {
 }
 
 // Readings returns the calculated distance.
-func (s *Sensor) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+func (s *Sensor) Readings(ctx context.Context, extra map[string]any) (map[string]any, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -182,7 +182,7 @@ func (s *Sensor) Readings(ctx context.Context, extra map[string]interface{}) (ma
 	// and the speed of sound (343 m/s)
 	secondsElapsed := float64(timeA-timeB) / math.Pow10(9)
 	distMeters := secondsElapsed * 343.0 / 2.0
-	return map[string]interface{}{"distance": distMeters}, nil
+	return map[string]any{"distance": distMeters}, nil
 }
 
 // Close remove interrupt callback of ultrasonic sensor.

--- a/components/sensor/ultrasonic/ultrasonic_test.go
+++ b/components/sensor/ultrasonic/ultrasonic_test.go
@@ -34,7 +34,7 @@ func setupDependencies(t *testing.T) resource.Dependencies {
 		return injectDigi, true
 	}
 	pin := &inject.GPIOPin{}
-	pin.SetFunc = func(ctx context.Context, high bool, extra map[string]interface{}) error {
+	pin.SetFunc = func(ctx context.Context, high bool, extra map[string]any) error {
 		return nil
 	}
 	actualBoard.GPIOPinByNameFunc = func(name string) (board.GPIOPin, error) {

--- a/components/servo/client.go
+++ b/components/servo/client.go
@@ -40,7 +40,7 @@ func NewClientFromConn(
 	}, nil
 }
 
-func (c *client) Move(ctx context.Context, angleDeg uint32, extra map[string]interface{}) error {
+func (c *client) Move(ctx context.Context, angleDeg uint32, extra map[string]any) error {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return err
@@ -52,7 +52,7 @@ func (c *client) Move(ctx context.Context, angleDeg uint32, extra map[string]int
 	return nil
 }
 
-func (c *client) Position(ctx context.Context, extra map[string]interface{}) (uint32, error) {
+func (c *client) Position(ctx context.Context, extra map[string]any) (uint32, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return 0, err
@@ -65,7 +65,7 @@ func (c *client) Position(ctx context.Context, extra map[string]interface{}) (ui
 	return resp.PositionDeg, nil
 }
 
-func (c *client) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (c *client) Stop(ctx context.Context, extra map[string]any) error {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return err
@@ -74,7 +74,7 @@ func (c *client) Stop(ctx context.Context, extra map[string]interface{}) error {
 	return err
 }
 
-func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (c *client) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	return rprotoutils.DoFromResourceClient(ctx, c.client, c.name, cmd)
 }
 

--- a/components/servo/client_test.go
+++ b/components/servo/client_test.go
@@ -29,31 +29,31 @@ func TestClient(t *testing.T) {
 	rpcServer, err := rpc.NewServer(logger.AsZap(), rpc.WithUnauthenticated())
 	test.That(t, err, test.ShouldBeNil)
 
-	var actualExtra map[string]interface{}
+	var actualExtra map[string]any
 
 	workingServo := &inject.Servo{}
 	failingServo := &inject.Servo{}
 
-	workingServo.MoveFunc = func(ctx context.Context, angle uint32, extra map[string]interface{}) error {
+	workingServo.MoveFunc = func(ctx context.Context, angle uint32, extra map[string]any) error {
 		actualExtra = extra
 		return nil
 	}
-	workingServo.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (uint32, error) {
+	workingServo.PositionFunc = func(ctx context.Context, extra map[string]any) (uint32, error) {
 		actualExtra = extra
 		return 20, nil
 	}
-	workingServo.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	workingServo.StopFunc = func(ctx context.Context, extra map[string]any) error {
 		actualExtra = extra
 		return nil
 	}
 
-	failingServo.MoveFunc = func(ctx context.Context, angle uint32, extra map[string]interface{}) error {
+	failingServo.MoveFunc = func(ctx context.Context, angle uint32, extra map[string]any) error {
 		return errMoveFailed
 	}
-	failingServo.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (uint32, error) {
+	failingServo.PositionFunc = func(ctx context.Context, extra map[string]any) (uint32, error) {
 		return 0, errPositionUnreadable
 	}
-	failingServo.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	failingServo.StopFunc = func(ctx context.Context, extra map[string]any) error {
 		return errStopFailed
 	}
 
@@ -93,17 +93,17 @@ func TestClient(t *testing.T) {
 		test.That(t, resp["command"], test.ShouldEqual, testutils.TestCommand["command"])
 		test.That(t, resp["data"], test.ShouldEqual, testutils.TestCommand["data"])
 
-		err = workingServoClient.Move(context.Background(), 20, map[string]interface{}{"foo": "Move"})
+		err = workingServoClient.Move(context.Background(), 20, map[string]any{"foo": "Move"})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, actualExtra, test.ShouldResemble, map[string]interface{}{"foo": "Move"})
+		test.That(t, actualExtra, test.ShouldResemble, map[string]any{"foo": "Move"})
 
-		currentDeg, err := workingServoClient.Position(context.Background(), map[string]interface{}{"foo": "Position"})
+		currentDeg, err := workingServoClient.Position(context.Background(), map[string]any{"foo": "Position"})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, currentDeg, test.ShouldEqual, 20)
-		test.That(t, actualExtra, test.ShouldResemble, map[string]interface{}{"foo": "Position"})
+		test.That(t, actualExtra, test.ShouldResemble, map[string]any{"foo": "Position"})
 
-		test.That(t, workingServoClient.Stop(context.Background(), map[string]interface{}{"foo": "Stop"}), test.ShouldBeNil)
-		test.That(t, actualExtra, test.ShouldResemble, map[string]interface{}{"foo": "Stop"})
+		test.That(t, workingServoClient.Stop(context.Background(), map[string]any{"foo": "Stop"}), test.ShouldBeNil)
+		test.That(t, actualExtra, test.ShouldResemble, map[string]any{"foo": "Stop"})
 
 		test.That(t, workingServoClient.Close(context.Background()), test.ShouldBeNil)
 

--- a/components/servo/collectors.go
+++ b/components/servo/collectors.go
@@ -25,13 +25,13 @@ func (m method) String() string {
 
 // newPositionCollector returns a collector to register a position method. If one is already registered
 // with the same MethodMetadata it will panic.
-func newPositionCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+func newPositionCollector(resource any, params data.CollectorParams) (data.Collector, error) {
 	servo, err := assertServo(resource)
 	if err != nil {
 		return nil, err
 	}
 
-	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (interface{}, error) {
+	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (any, error) {
 		pos, err := servo.Position(ctx, data.FromDMExtraMap)
 		if err != nil {
 			// A modular filter component can be created to filter the readings from a component. The error ErrNoCaptureToStore
@@ -48,7 +48,7 @@ func newPositionCollector(resource interface{}, params data.CollectorParams) (da
 	return data.NewCollector(cFunc, params)
 }
 
-func assertServo(resource interface{}) (Servo, error) {
+func assertServo(resource any) (Servo, error) {
 	servo, ok := resource.(Servo)
 	if !ok {
 		return nil, data.InvalidInterfaceErr(API)

--- a/components/servo/collectors_test.go
+++ b/components/servo/collectors_test.go
@@ -52,7 +52,7 @@ func TestServoCollector(t *testing.T) {
 
 func newServo() servo.Servo {
 	s := &inject.Servo{}
-	s.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (uint32, error) {
+	s.PositionFunc = func(ctx context.Context, extra map[string]any) (uint32, error) {
 		return 1.0, nil
 	}
 	return s

--- a/components/servo/fake/servo.go
+++ b/components/servo/fake/servo.go
@@ -35,18 +35,18 @@ type Servo struct {
 }
 
 // Move sets the given angle.
-func (s *Servo) Move(ctx context.Context, angleDeg uint32, extra map[string]interface{}) error {
+func (s *Servo) Move(ctx context.Context, angleDeg uint32, extra map[string]any) error {
 	s.angle = angleDeg
 	return nil
 }
 
 // Position returns the set angle.
-func (s *Servo) Position(ctx context.Context, extra map[string]interface{}) (uint32, error) {
+func (s *Servo) Position(ctx context.Context, extra map[string]any) (uint32, error) {
 	return s.angle, nil
 }
 
 // Stop doesn't do anything for a fake servo.
-func (s *Servo) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (s *Servo) Stop(ctx context.Context, extra map[string]any) error {
 	return nil
 }
 

--- a/components/servo/gpio/servo.go
+++ b/components/servo/gpio/servo.go
@@ -325,7 +325,7 @@ func (s *servoGPIO) findPWMResolution(ctx context.Context) error {
 
 // Move moves the servo to the given angle (0-180 degrees)
 // This will block until done or a new operation cancels this one.
-func (s *servoGPIO) Move(ctx context.Context, ang uint32, extra map[string]interface{}) error {
+func (s *servoGPIO) Move(ctx context.Context, ang uint32, extra map[string]any) error {
 	ctx, done := s.opMgr.New(ctx)
 	defer done()
 
@@ -353,7 +353,7 @@ func (s *servoGPIO) Move(ctx context.Context, ang uint32, extra map[string]inter
 }
 
 // Position returns the current set angle (degrees) of the servo.
-func (s *servoGPIO) Position(ctx context.Context, extra map[string]interface{}) (uint32, error) {
+func (s *servoGPIO) Position(ctx context.Context, extra map[string]any) (uint32, error) {
 	pct, err := s.pin.PWM(ctx, nil)
 	if err != nil {
 		return 0, errors.Wrap(err, "couldn't get servo pin duty cycle")
@@ -373,7 +373,7 @@ func (s *servoGPIO) Position(ctx context.Context, extra map[string]interface{}) 
 }
 
 // Stop stops the servo. It is assumed the servo stops immediately.
-func (s *servoGPIO) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (s *servoGPIO) Stop(ctx context.Context, extra map[string]any) error {
 	ctx, done := s.opMgr.New(ctx)
 	defer done()
 	// Turning the pin all the way off (i.e., setting the duty cycle to 0%) will cut power to the

--- a/components/servo/gpio/servo_test.go
+++ b/components/servo/gpio/servo_test.go
@@ -104,34 +104,34 @@ func setupDependencies(t *testing.T) resource.Dependencies {
 	scale1, scale2 := 255, 4095
 
 	pin0 := &inject.GPIOPin{}
-	pin0.PWMFunc = func(ctx context.Context, extra map[string]interface{}) (float64, error) {
+	pin0.PWMFunc = func(ctx context.Context, extra map[string]any) (float64, error) {
 		pct := float64(innerTick1) / float64(scale1)
 		return pct, nil
 	}
-	pin0.PWMFreqFunc = func(ctx context.Context, extra map[string]interface{}) (uint, error) {
+	pin0.PWMFreqFunc = func(ctx context.Context, extra map[string]any) (uint, error) {
 		return 50, nil
 	}
-	pin0.SetPWMFunc = func(ctx context.Context, dutyCyclePct float64, extra map[string]interface{}) error {
+	pin0.SetPWMFunc = func(ctx context.Context, dutyCyclePct float64, extra map[string]any) error {
 		innerTick1 = utils.ScaleByPct(scale1, dutyCyclePct)
 		return nil
 	}
-	pin0.SetPWMFreqFunc = func(ctx context.Context, freqHz uint, extra map[string]interface{}) error {
+	pin0.SetPWMFreqFunc = func(ctx context.Context, freqHz uint, extra map[string]any) error {
 		return nil
 	}
 
 	pin1 := &inject.GPIOPin{}
-	pin1.PWMFunc = func(ctx context.Context, extra map[string]interface{}) (float64, error) {
+	pin1.PWMFunc = func(ctx context.Context, extra map[string]any) (float64, error) {
 		pct := float64(innerTick2) / float64(scale2)
 		return pct, nil
 	}
-	pin1.PWMFreqFunc = func(ctx context.Context, extra map[string]interface{}) (uint, error) {
+	pin1.PWMFreqFunc = func(ctx context.Context, extra map[string]any) (uint, error) {
 		return 50, nil
 	}
-	pin1.SetPWMFunc = func(ctx context.Context, dutyCyclePct float64, extra map[string]interface{}) error {
+	pin1.SetPWMFunc = func(ctx context.Context, dutyCyclePct float64, extra map[string]any) error {
 		innerTick2 = utils.ScaleByPct(scale2, dutyCyclePct)
 		return nil
 	}
-	pin1.SetPWMFreqFunc = func(ctx context.Context, freqHz uint, extra map[string]interface{}) error {
+	pin1.SetPWMFreqFunc = func(ctx context.Context, freqHz uint, extra map[string]any) error {
 		return nil
 	}
 

--- a/components/servo/server.go
+++ b/components/servo/server.go
@@ -19,7 +19,7 @@ type serviceServer struct {
 
 // NewRPCServiceServer constructs a servo gRPC service server.
 // It is intentionally untyped to prevent use outside of tests.
-func NewRPCServiceServer(coll resource.APIResourceCollection[Servo]) interface{} {
+func NewRPCServiceServer(coll resource.APIResourceCollection[Servo]) any {
 	return &serviceServer{coll: coll}
 }
 

--- a/components/servo/server_test.go
+++ b/components/servo/server_test.go
@@ -38,17 +38,17 @@ func TestServoMove(t *testing.T) {
 	servoServer, workingServo, failingServo, err := newServer()
 	test.That(t, err, test.ShouldBeNil)
 
-	var actualExtra map[string]interface{}
+	var actualExtra map[string]any
 
-	workingServo.MoveFunc = func(ctx context.Context, angle uint32, extra map[string]interface{}) error {
+	workingServo.MoveFunc = func(ctx context.Context, angle uint32, extra map[string]any) error {
 		actualExtra = extra
 		return nil
 	}
-	failingServo.MoveFunc = func(ctx context.Context, angle uint32, extra map[string]interface{}) error {
+	failingServo.MoveFunc = func(ctx context.Context, angle uint32, extra map[string]any) error {
 		return errMoveFailed
 	}
 
-	extra := map[string]interface{}{"foo": "Move"}
+	extra := map[string]any{"foo": "Move"}
 	ext, err := protoutils.StructToStructPb(extra)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -73,17 +73,17 @@ func TestServoMove(t *testing.T) {
 func TestServoGetPosition(t *testing.T) {
 	servoServer, workingServo, failingServo, _ := newServer()
 
-	var actualExtra map[string]interface{}
+	var actualExtra map[string]any
 
-	workingServo.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (uint32, error) {
+	workingServo.PositionFunc = func(ctx context.Context, extra map[string]any) (uint32, error) {
 		actualExtra = extra
 		return 20, nil
 	}
-	failingServo.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (uint32, error) {
+	failingServo.PositionFunc = func(ctx context.Context, extra map[string]any) (uint32, error) {
 		return 0, errPositionUnreadable
 	}
 
-	extra := map[string]interface{}{"foo": "Move"}
+	extra := map[string]any{"foo": "Move"}
 	ext, err := protoutils.StructToStructPb(extra)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -108,17 +108,17 @@ func TestServoGetPosition(t *testing.T) {
 func TestServoStop(t *testing.T) {
 	servoServer, workingServo, failingServo, _ := newServer()
 
-	var actualExtra map[string]interface{}
+	var actualExtra map[string]any
 
-	workingServo.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	workingServo.StopFunc = func(ctx context.Context, extra map[string]any) error {
 		actualExtra = extra
 		return nil
 	}
-	failingServo.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
+	failingServo.StopFunc = func(ctx context.Context, extra map[string]any) error {
 		return errStopFailed
 	}
 
-	extra := map[string]interface{}{"foo": "Move"}
+	extra := map[string]any{"foo": "Move"}
 	ext, err := protoutils.StructToStructPb(extra)
 	test.That(t, err, test.ShouldBeNil)
 

--- a/components/servo/servo.go
+++ b/components/servo/servo.go
@@ -37,10 +37,10 @@ type Servo interface {
 
 	// Move moves the servo to the given angle (0-180 degrees)
 	// This will block until done or a new operation cancels this one
-	Move(ctx context.Context, angleDeg uint32, extra map[string]interface{}) error
+	Move(ctx context.Context, angleDeg uint32, extra map[string]any) error
 
 	// Position returns the current set angle (degrees) of the servo.
-	Position(ctx context.Context, extra map[string]interface{}) (uint32, error)
+	Position(ctx context.Context, extra map[string]any) (uint32, error)
 }
 
 // Named is a helper for getting the named Servo's typed resource name.

--- a/components/servo/servo_test.go
+++ b/components/servo/servo_test.go
@@ -17,7 +17,7 @@ func TestCreateStatus(t *testing.T) {
 	status := &pb.Status{PositionDeg: uint32(8), IsMoving: true}
 
 	injectServo := &inject.Servo{}
-	injectServo.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (uint32, error) {
+	injectServo.PositionFunc = func(ctx context.Context, extra map[string]any) (uint32, error) {
 		return status.PositionDeg, nil
 	}
 	injectServo.IsMovingFunc = func(context.Context) (bool, error) {
@@ -50,7 +50,7 @@ func TestCreateStatus(t *testing.T) {
 
 	t.Run("fail on Position", func(t *testing.T) {
 		errFail := errors.New("can't get position")
-		injectServo.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (uint32, error) {
+		injectServo.PositionFunc = func(ctx context.Context, extra map[string]any) (uint32, error) {
 			return 0, errFail
 		}
 		_, err := servo.CreateStatus(context.Background(), injectServo)

--- a/config/diff_test.go
+++ b/config/diff_test.go
@@ -69,14 +69,14 @@ func TestDiffConfigs(t *testing.T) {
 
 				API: board.API,
 				Attributes: utils.AttributeMap{
-					"analogs": []interface{}{
-						map[string]interface{}{
+					"analogs": []any{
+						map[string]any{
 							"name": "analog1",
 							"pin":  "0",
 						},
 					},
-					"digital_interrupts": []interface{}{
-						map[string]interface{}{
+					"digital_interrupts": []any{
+						map[string]any{
 							"name": "encoder",
 							"pin":  "14",
 						},
@@ -156,14 +156,14 @@ func TestDiffConfigs(t *testing.T) {
 
 				API: board.API,
 				Attributes: utils.AttributeMap{
-					"analogs": []interface{}{
-						map[string]interface{}{
+					"analogs": []any{
+						map[string]any{
 							"name": "analog1",
 							"pin":  "1",
 						},
 					},
-					"digital_interrupts": []interface{}{
-						map[string]interface{}{
+					"digital_interrupts": []any{
+						map[string]any{
 							"name": "encoder",
 							"pin":  "15",
 						},
@@ -285,8 +285,8 @@ func TestDiffConfigs(t *testing.T) {
 							API:   board.API,
 							Model: fakeModel,
 							Attributes: utils.AttributeMap{
-								"digital_interrupts": []interface{}{
-									map[string]interface{}{
+								"digital_interrupts": []any{
+									map[string]any{
 										"name": "encoder2",
 										"pin":  "16",
 									},
@@ -333,8 +333,8 @@ func TestDiffConfigs(t *testing.T) {
 							API:   board.API,
 							Model: fakeModel,
 							Attributes: utils.AttributeMap{
-								"analogs": []interface{}{
-									map[string]interface{}{
+								"analogs": []any{
+									map[string]any{
 										"name": "analog1",
 										"pin":  "1",
 									},

--- a/config/placeholder_replacement.go
+++ b/config/placeholder_replacement.go
@@ -69,7 +69,7 @@ func (c *Config) ReplacePlaceholders() error {
 }
 
 func walkTypedAttributes[T any](visitor *placeholderReplacementVisitor, attributes T) (T, error) {
-	var asIfc interface{} = attributes
+	var asIfc any = attributes
 	if walker, ok := asIfc.(utils.Walker); ok {
 		newAttrs, err := walker.Walk(visitor)
 		if err != nil {
@@ -113,7 +113,7 @@ func newPlaceholderReplacementVisitor(cfg *Config) *placeholderReplacementVisito
 // placeholder causes otherwise valid placeholders to appear invalid to the user (there is also no guaranteed order that an
 // attribute map is traversed, so if there is a single invalid placeholder, the set of other placeholders that fail to be resolved would
 // be non-deterministic).
-func (v *placeholderReplacementVisitor) Visit(data interface{}) (interface{}, error) {
+func (v *placeholderReplacementVisitor) Visit(data any) (any, error) {
 	t := reflect.TypeOf(data)
 
 	var s string

--- a/config/proto_conversions_test.go
+++ b/config/proto_conversions_test.go
@@ -755,7 +755,7 @@ func keysetToInterface(t *testing.T, keyset jwks.KeySet) *structpb.Struct {
 	jwksAsJSON, err := json.Marshal(keyset)
 	test.That(t, err, test.ShouldBeNil)
 
-	jwksAsInterface := map[string]interface{}{}
+	jwksAsInterface := map[string]any{}
 	err = json.Unmarshal(jwksAsJSON, &jwksAsInterface)
 	test.That(t, err, test.ShouldBeNil)
 

--- a/config/reader.go
+++ b/config/reader.go
@@ -492,7 +492,7 @@ func processConfig(unprocessedConfig *Config, fromCloud bool, logger logging.Log
 				continue
 			}
 
-			var convertedAttrs interface{} = associatedConf.Attributes
+			var convertedAttrs any = associatedConf.Attributes
 			if conv.AttributeMapConverter != nil {
 				converted, err := conv.AttributeMapConverter(associatedConf.Attributes)
 				if err != nil {

--- a/config/testutils/fake_cloud.go
+++ b/config/testutils/fake_cloud.go
@@ -193,7 +193,7 @@ func (s *FakeCloudServer) robotSecretAuthenticate(ctx context.Context, entity, p
 	return map[string]string{}, nil
 }
 
-func (s *FakeCloudServer) robotSecretEntityDataLoad(ctx context.Context, claims rpc.Claims) (interface{}, error) {
+func (s *FakeCloudServer) robotSecretEntityDataLoad(ctx context.Context, claims rpc.Claims) (any, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/data/collector.go
+++ b/data/collector.go
@@ -31,7 +31,7 @@ import (
 var sleepCaptureCutoff = 2 * time.Millisecond
 
 // CaptureFunc allows the creation of simple Capturers with anonymous functions.
-type CaptureFunc func(ctx context.Context, params map[string]*anypb.Any) (interface{}, error)
+type CaptureFunc func(ctx context.Context, params map[string]*anypb.Any) (any, error)
 
 // FromDMContextKey is used to check whether the context is from data management.
 // Deprecated: use a camera.Extra with camera.NewContext instead.
@@ -41,7 +41,7 @@ type FromDMContextKey struct{}
 const FromDMString = "fromDataManagement"
 
 // FromDMExtraMap is a map with 'fromDataManagement' set to true.
-var FromDMExtraMap = map[string]interface{}{FromDMString: true}
+var FromDMExtraMap = map[string]any{FromDMString: true}
 
 // ErrNoCaptureToStore is returned when a modular filter resource filters the capture coming from the base resource.
 var ErrNoCaptureToStore = status.Error(codes.FailedPrecondition, "no capture from filter module")
@@ -330,7 +330,7 @@ func FailedToReadErr(component, method string, err error) error {
 // GetExtraFromContext sets the extra struct with "fromDataManagement": true if the flag is true in the context.
 // Deprecated: Use camera.FromContext instead.
 func GetExtraFromContext(ctx context.Context) (*structpb.Struct, error) {
-	extra := make(map[string]interface{})
+	extra := make(map[string]any)
 	if ctx.Value(FromDMContextKey{}) == true {
 		extra[FromDMString] = true
 	}

--- a/data/collector_test.go
+++ b/data/collector_test.go
@@ -35,10 +35,10 @@ func (r *structReading) toProto() *structpb.Struct {
 }
 
 var (
-	structCapturer = CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (interface{}, error) {
+	structCapturer = CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (any, error) {
 		return dummyStructReading, nil
 	})
-	binaryCapturer = CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (interface{}, error) {
+	binaryCapturer = CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (any, error) {
 		return dummyBytesReading, nil
 	})
 	dummyStructReading      = structReading{}
@@ -252,7 +252,7 @@ func TestCtxCancelledNotLoggedAfterClose(t *testing.T) {
 	tmpDir := t.TempDir()
 	target := datacapture.NewBuffer(tmpDir, &v1.DataCaptureMetadata{})
 	captured := make(chan struct{})
-	errorCapturer := CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (interface{}, error) {
+	errorCapturer := CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (any, error) {
 		select {
 		case <-ctx.Done():
 			return nil, fmt.Errorf("arbitrary wrapping message: %w", ctx.Err())

--- a/data/registry.go
+++ b/data/registry.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CollectorConstructor contains a function for constructing an instance of a Collector.
-type CollectorConstructor func(resource interface{}, params CollectorParams) (Collector, error)
+type CollectorConstructor func(resource any, params CollectorParams) (Collector, error)
 
 // CollectorParams contain the parameters needed to construct a Collector.
 type CollectorParams struct {

--- a/data/registry_test.go
+++ b/data/registry_test.go
@@ -8,7 +8,7 @@ import (
 	"go.viam.com/rdk/resource"
 )
 
-var dummyCollectorConstructor = func(i interface{}, params CollectorParams) (Collector, error) {
+var dummyCollectorConstructor = func(i any, params CollectorParams) (Collector, error) {
 	return &collector{}, nil
 }
 
@@ -22,7 +22,7 @@ func TestRegister(t *testing.T) {
 		API:        resource.APINamespaceRDK.WithComponentType("type"),
 		MethodName: "method",
 	}
-	dummyCollectorConstructor = func(i interface{}, params CollectorParams) (Collector, error) {
+	dummyCollectorConstructor = func(i any, params CollectorParams) (Collector, error) {
 		return &collector{}, nil
 	}
 

--- a/etc/analyzecoverage/main.go
+++ b/etc/analyzecoverage/main.go
@@ -162,7 +162,7 @@ func mainWithArgs(ctx context.Context, _ []string, logger logging.Logger) error 
 		return nil
 	}
 
-	resultsIfc := make([]interface{}, 0, len(covResults))
+	resultsIfc := make([]any, 0, len(covResults))
 	for _, res := range covResults {
 		resultsIfc = append(resultsIfc, res)
 	}

--- a/etc/analyzetests/main.go
+++ b/etc/analyzetests/main.go
@@ -127,7 +127,7 @@ func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) err
 		return nil
 	}
 
-	resultsIfc := make([]interface{}, 0, len(results))
+	resultsIfc := make([]any, 0, len(results))
 	for _, res := range results {
 		resultsIfc = append(resultsIfc, res)
 	}

--- a/etc/subsystem_manifest/main.go
+++ b/etc/subsystem_manifest/main.go
@@ -111,7 +111,7 @@ func getViamServerMetadata(path string) (*viamServerMetadata, error) {
 	if err != nil {
 		return nil, err
 	}
-	// We could pass the file through as an interface{} instead of unmarshalling
+	// We could pass the file through as an any instead of unmarshalling
 	// and re-marshalling, but this reduces the odds of drift between viam-server and this script
 	dumpedResourceRegistrations := []dumpedResourceRegistration{}
 	if err := json.Unmarshal(resourcesBytes, &dumpedResourceRegistrations); err != nil {

--- a/examples/customresources/apis/gizmoapi/gizmoapi.go
+++ b/examples/customresources/apis/gizmoapi/gizmoapi.go
@@ -63,7 +63,7 @@ type serviceServer struct {
 }
 
 // NewRPCServiceServer returns a new RPC server for the gizmo API.
-func NewRPCServiceServer(coll resource.APIResourceCollection[Gizmo]) interface{} {
+func NewRPCServiceServer(coll resource.APIResourceCollection[Gizmo]) any {
 	return &serviceServer{coll: coll}
 }
 
@@ -318,7 +318,7 @@ func (c *client) DoTwo(ctx context.Context, arg1 bool) (string, error) {
 	return resp.Ret1, nil
 }
 
-func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (c *client) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	command, err := protoutils.StructToStructPb(cmd)
 	if err != nil {
 		return nil, err

--- a/examples/customresources/apis/summationapi/summationapi.go
+++ b/examples/customresources/apis/summationapi/summationapi.go
@@ -55,7 +55,7 @@ type serviceServer struct {
 }
 
 // NewRPCServiceServer returns a new RPC server for the summation API.
-func NewRPCServiceServer(coll resource.APIResourceCollection[Summation]) interface{} {
+func NewRPCServiceServer(coll resource.APIResourceCollection[Summation]) any {
 	return &serviceServer{coll: coll}
 }
 

--- a/examples/customresources/demos/complexmodule/client/client.go
+++ b/examples/customresources/demos/complexmodule/client/client.go
@@ -135,7 +135,7 @@ func main() {
 	}
 
 	logger.Info("generic echo")
-	testCmd := map[string]interface{}{"foo": "bar"}
+	testCmd := map[string]any{"foo": "bar"}
 	ret, err := mybase.DoCommand(context.Background(), testCmd)
 	if err != nil {
 		logger.Fatal(err)

--- a/examples/customresources/demos/complexmodule/moduletest/module_test.go
+++ b/examples/customresources/demos/complexmodule/moduletest/module_test.go
@@ -148,7 +148,7 @@ func TestComplexModule(t *testing.T) {
 		mybase := res.(base.Base)
 
 		// Test generic echo
-		testCmd := map[string]interface{}{"foo": "bar"}
+		testCmd := map[string]any{"foo": "bar"}
 		ret, err := mybase.DoCommand(context.Background(), testCmd)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, ret, test.ShouldResemble, testCmd)

--- a/examples/customresources/demos/remoteserver/server_test.go
+++ b/examples/customresources/demos/remoteserver/server_test.go
@@ -127,7 +127,7 @@ func TestGizmo(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	// remotes can take a few seconds to show up, so we wait for the resource
-	var res interface{}
+	var res any
 	testutils.WaitForAssertionWithSleep(t, time.Second, 120, func(tb testing.TB) {
 		res, err = mainPart.ResourceByName(gizmoapi.Named("gizmo1"))
 		test.That(tb, err, test.ShouldBeNil)

--- a/examples/customresources/demos/simplemodule/client/client.go
+++ b/examples/customresources/demos/simplemodule/client/client.go
@@ -43,7 +43,7 @@ func main() {
 	// Only on restart of the server will they get reset.
 	for name, c := range []resource.Resource{counter1, counter2} {
 		// Get the starting value of the given counter.
-		ret, err := counter1.DoCommand(context.Background(), map[string]interface{}{"command": "get"})
+		ret, err := counter1.DoCommand(context.Background(), map[string]any{"command": "get"})
 		if err != nil {
 			logger.Fatal(err)
 		}
@@ -52,7 +52,7 @@ func main() {
 		for n := 0; n < 20; n++ {
 			//nolint:gosec
 			val := rand.Intn(100)
-			ret, err := c.DoCommand(context.Background(), map[string]interface{}{"command": "add", "value": val})
+			ret, err := c.DoCommand(context.Background(), map[string]any{"command": "add", "value": val})
 			if err != nil {
 				logger.Fatal(err)
 			}

--- a/examples/customresources/demos/simplemodule/module.go
+++ b/examples/customresources/demos/simplemodule/module.go
@@ -79,7 +79,7 @@ func (c *counter) Reconfigure(ctx context.Context, deps resource.Dependencies, c
 
 // DoCommand is the only method of this component. It looks up the "real" command from the map it's passed.
 // Because of this, any arbitrary commands can be received, and any data returned.
-func (c *counter) DoCommand(ctx context.Context, req map[string]interface{}) (map[string]interface{}, error) {
+func (c *counter) DoCommand(ctx context.Context, req map[string]any) (map[string]any, error) {
 	// We look for a map key called "command"
 	cmd, ok := req["command"]
 	if !ok {
@@ -88,7 +88,7 @@ func (c *counter) DoCommand(ctx context.Context, req map[string]interface{}) (ma
 
 	// If it's "get" we return the current total.
 	if cmd == "get" {
-		return map[string]interface{}{"total": atomic.LoadInt64(&c.total)}, nil
+		return map[string]any{"total": atomic.LoadInt64(&c.total)}, nil
 	}
 
 	// If it's "add" we atomically add a second key "value" to the total.
@@ -103,7 +103,7 @@ func (c *counter) DoCommand(ctx context.Context, req map[string]interface{}) (ma
 		}
 		atomic.AddInt64(&c.total, int64(val))
 		// We return the new total after the addition.
-		return map[string]interface{}{"total": atomic.LoadInt64(&c.total)}, nil
+		return map[string]any{"total": atomic.LoadInt64(&c.total)}, nil
 	}
 	// The command must've been something else.
 	return nil, fmt.Errorf("unknown command string %s", cmd)

--- a/examples/customresources/models/mybase/mybase.go
+++ b/examples/customresources/models/mybase/mybase.go
@@ -80,7 +80,7 @@ func (b *myBase) Reconfigure(ctx context.Context, deps resource.Dependencies, co
 }
 
 // DoCommand simply echos whatever was sent.
-func (b *myBase) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (b *myBase) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	return cmd, nil
 }
 
@@ -115,22 +115,22 @@ type myBase struct {
 }
 
 // MoveStraight does nothing.
-func (b *myBase) MoveStraight(ctx context.Context, distanceMm int, mmPerSec float64, extra map[string]interface{}) error {
+func (b *myBase) MoveStraight(ctx context.Context, distanceMm int, mmPerSec float64, extra map[string]any) error {
 	return errUnimplemented
 }
 
 // Spin does nothing.
-func (b *myBase) Spin(ctx context.Context, angleDeg, degsPerSec float64, extra map[string]interface{}) error {
+func (b *myBase) Spin(ctx context.Context, angleDeg, degsPerSec float64, extra map[string]any) error {
 	return errUnimplemented
 }
 
 // SetVelocity does nothing.
-func (b *myBase) SetVelocity(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error {
+func (b *myBase) SetVelocity(ctx context.Context, linear, angular r3.Vector, extra map[string]any) error {
 	return errUnimplemented
 }
 
 // SetPower computes relative power between the wheels and sets power for both motors.
-func (b *myBase) SetPower(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error {
+func (b *myBase) SetPower(ctx context.Context, linear, angular r3.Vector, extra map[string]any) error {
 	b.logger.CDebugf(ctx, "SetPower Linear: %.2f Angular: %.2f", linear.Y, angular.Z)
 	if math.Abs(linear.Y) < 0.01 && math.Abs(angular.Z) < 0.01 {
 		return b.Stop(ctx, extra)
@@ -142,7 +142,7 @@ func (b *myBase) SetPower(ctx context.Context, linear, angular r3.Vector, extra 
 }
 
 // Stop halts motion.
-func (b *myBase) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (b *myBase) Stop(ctx context.Context, extra map[string]any) error {
 	b.logger.CDebug(ctx, "Stop")
 	err1 := b.left.Stop(ctx, extra)
 	err2 := b.right.Stop(ctx, extra)
@@ -164,7 +164,7 @@ func (b *myBase) IsMoving(ctx context.Context) (bool, error) {
 }
 
 // Properties returns details about the physics of the base.
-func (b *myBase) Properties(ctx context.Context, extra map[string]interface{}) (base.Properties, error) {
+func (b *myBase) Properties(ctx context.Context, extra map[string]any) (base.Properties, error) {
 	return base.Properties{
 		TurningRadiusMeters: myBaseTurningRadiusM,
 		WidthMeters:         myBaseWidthMm * 0.001, // converting millimeters to meters
@@ -172,7 +172,7 @@ func (b *myBase) Properties(ctx context.Context, extra map[string]interface{}) (
 }
 
 // Geometries returns physical dimensions.
-func (b *myBase) Geometries(ctx context.Context, extra map[string]interface{}) ([]spatialmath.Geometry, error) {
+func (b *myBase) Geometries(ctx context.Context, extra map[string]any) ([]spatialmath.Geometry, error) {
 	return b.geometries, nil
 }
 

--- a/examples/customresources/models/mygizmo/mygizmo.go
+++ b/examples/customresources/models/mygizmo/mygizmo.go
@@ -119,6 +119,6 @@ func (g *myActualGizmo) DoTwo(ctx context.Context, arg1 bool) (string, error) {
 	return fmt.Sprintf("arg1=%t", arg1), nil
 }
 
-func (g *myActualGizmo) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (g *myActualGizmo) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	return cmd, nil
 }

--- a/examples/customresources/models/mynavigation/mynavigation.go
+++ b/examples/customresources/models/mynavigation/mynavigation.go
@@ -81,22 +81,22 @@ type navSvc struct {
 	waypoints   []navigation.Waypoint
 }
 
-func (svc *navSvc) Mode(ctx context.Context, extra map[string]interface{}) (navigation.Mode, error) {
+func (svc *navSvc) Mode(ctx context.Context, extra map[string]any) (navigation.Mode, error) {
 	return 0, nil
 }
 
-func (svc *navSvc) SetMode(ctx context.Context, mode navigation.Mode, extra map[string]interface{}) error {
+func (svc *navSvc) SetMode(ctx context.Context, mode navigation.Mode, extra map[string]any) error {
 	return nil
 }
 
-func (svc *navSvc) Location(ctx context.Context, extra map[string]interface{}) (*spatialmath.GeoPose, error) {
+func (svc *navSvc) Location(ctx context.Context, extra map[string]any) (*spatialmath.GeoPose, error) {
 	svc.waypointsMu.RLock()
 	defer svc.waypointsMu.RUnlock()
 	geoPose := spatialmath.NewGeoPose(svc.loc, 0)
 	return geoPose, nil
 }
 
-func (svc *navSvc) Waypoints(ctx context.Context, extra map[string]interface{}) ([]navigation.Waypoint, error) {
+func (svc *navSvc) Waypoints(ctx context.Context, extra map[string]any) ([]navigation.Waypoint, error) {
 	svc.waypointsMu.RLock()
 	defer svc.waypointsMu.RUnlock()
 	wpsCopy := make([]navigation.Waypoint, len(svc.waypoints))
@@ -104,14 +104,14 @@ func (svc *navSvc) Waypoints(ctx context.Context, extra map[string]interface{}) 
 	return wpsCopy, nil
 }
 
-func (svc *navSvc) AddWaypoint(ctx context.Context, point *geo.Point, extra map[string]interface{}) error {
+func (svc *navSvc) AddWaypoint(ctx context.Context, point *geo.Point, extra map[string]any) error {
 	svc.waypointsMu.Lock()
 	defer svc.waypointsMu.Unlock()
 	svc.waypoints = append(svc.waypoints, navigation.Waypoint{Lat: point.Lat(), Long: point.Lng()})
 	return nil
 }
 
-func (svc *navSvc) RemoveWaypoint(ctx context.Context, id primitive.ObjectID, extra map[string]interface{}) error {
+func (svc *navSvc) RemoveWaypoint(ctx context.Context, id primitive.ObjectID, extra map[string]any) error {
 	svc.waypointsMu.Lock()
 	defer svc.waypointsMu.Unlock()
 	newWps := make([]navigation.Waypoint, 0, len(svc.waypoints)-1)
@@ -125,11 +125,11 @@ func (svc *navSvc) RemoveWaypoint(ctx context.Context, id primitive.ObjectID, ex
 	return nil
 }
 
-func (svc *navSvc) Obstacles(ctx context.Context, extra map[string]interface{}) ([]*spatialmath.GeoObstacle, error) {
+func (svc *navSvc) Obstacles(ctx context.Context, extra map[string]any) ([]*spatialmath.GeoObstacle, error) {
 	return []*spatialmath.GeoObstacle{}, errUnimplemented
 }
 
-func (svc *navSvc) Paths(ctx context.Context, extra map[string]interface{}) ([]*navigation.Path, error) {
+func (svc *navSvc) Paths(ctx context.Context, extra map[string]any) ([]*navigation.Path, error) {
 	return []*navigation.Path{}, errUnimplemented
 }
 

--- a/examples/mysensor/client/client.go
+++ b/examples/mysensor/client/client.go
@@ -25,7 +25,7 @@ func main() {
 	if err != nil {
 		logger.Error(err)
 	}
-	reading, err := sensor.Readings(context.Background(), make(map[string]interface{}))
+	reading, err := sensor.Readings(context.Background(), make(map[string]any))
 	if err != nil {
 		logger.Error(err)
 	}

--- a/examples/mysensor/server/server.go
+++ b/examples/mysensor/server/server.go
@@ -45,8 +45,8 @@ type mySensor struct {
 }
 
 // Readings always returns "hello world".
-func (s *mySensor) Readings(ctx context.Context, _ map[string]interface{}) (map[string]interface{}, error) {
-	return map[string]interface{}{"hello": "world"}, nil
+func (s *mySensor) Readings(ctx context.Context, _ map[string]any) (map[string]any, error) {
+	return map[string]any{"hello": "world"}, nil
 }
 
 func main() {

--- a/gostream/cmd/stream_audio/main.go
+++ b/gostream/cmd/stream_audio/main.go
@@ -170,7 +170,7 @@ func decodeAndPlayTrack(ctx context.Context, track *webrtc.TrackRemote) {
 			const maxOpusFrameSizeMs = 60
 			maxFrameSize := float32(channels) * maxOpusFrameSizeMs * float32(sampleRate) / 1000
 			dataPool := sync.Pool{
-				New: func() interface{} {
+				New: func() any {
 					newData := make([]float32, int(maxFrameSize))
 					return &newData
 				},

--- a/logging/context.go
+++ b/logging/context.go
@@ -55,7 +55,7 @@ const dtNameMetadataKey = "dtName"
 func UnaryClientInterceptor(
 	ctx context.Context,
 	method string,
-	req, reply interface{},
+	req, reply any,
 	cc *grpc.ClientConn,
 	invoker grpc.UnaryInvoker,
 	opts ...grpc.CallOption,
@@ -71,10 +71,10 @@ func UnaryClientInterceptor(
 // attaches any information to a debug context.
 func UnaryServerInterceptor(
 	ctx context.Context,
-	req interface{},
+	req any,
 	info *grpc.UnaryServerInfo,
 	handler grpc.UnaryHandler,
-) (interface{}, error) {
+) (any, error) {
 	meta, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		return handler(ctx, req)

--- a/logging/impl.go
+++ b/logging/impl.go
@@ -94,7 +94,7 @@ func (imp *impl) Sync() error {
 	return multierr.Combine(errs...)
 }
 
-func (imp *impl) With(args ...interface{}) *zap.SugaredLogger {
+func (imp *impl) With(args ...any) *zap.SugaredLogger {
 	return imp.AsZap().With(args...)
 }
 
@@ -163,7 +163,7 @@ func (imp *impl) log(entry *LogEntry) {
 }
 
 // Constructs the log message by forwarding to `fmt.Sprint`. `traceKey` may be the empty string.
-func (imp *impl) format(logLevel Level, traceKey string, args ...interface{}) *LogEntry {
+func (imp *impl) format(logLevel Level, traceKey string, args ...any) *LogEntry {
 	logEntry := imp.NewLogEntry()
 	logEntry.Level = logLevel.AsZap()
 	logEntry.Message = fmt.Sprint(args...)
@@ -175,7 +175,7 @@ func (imp *impl) format(logLevel Level, traceKey string, args ...interface{}) *L
 }
 
 // Constructs the log message by forwarding to `fmt.Sprintf`. `traceKey` may be the empty string.
-func (imp *impl) formatf(logLevel Level, traceKey, template string, args ...interface{}) *LogEntry {
+func (imp *impl) formatf(logLevel Level, traceKey, template string, args ...any) *LogEntry {
 	logEntry := imp.NewLogEntry()
 	logEntry.Level = logLevel.AsZap()
 	logEntry.Message = fmt.Sprintf(template, args...)
@@ -190,7 +190,7 @@ func (imp *impl) formatf(logLevel Level, traceKey, template string, args ...inte
 // counterpart is the value. The keys are expected to be strings. The values are json
 // serialized. Only public fields are included in the serialization. `traceKey` may be the empty
 // string.
-func (imp *impl) formatw(logLevel Level, traceKey, msg string, keysAndValues ...interface{}) *LogEntry {
+func (imp *impl) formatw(logLevel Level, traceKey, msg string, keysAndValues ...any) *LogEntry {
 	logEntry := imp.NewLogEntry()
 	logEntry.Level = logLevel.AsZap()
 	logEntry.Message = msg
@@ -221,14 +221,14 @@ func (imp *impl) formatw(logLevel Level, traceKey, msg string, keysAndValues ...
 	return logEntry
 }
 
-func (imp *impl) Debug(args ...interface{}) {
+func (imp *impl) Debug(args ...any) {
 	imp.testHelper()
 	if imp.shouldLog(DEBUG) {
 		imp.log(imp.format(DEBUG, emptyTraceKey, args...))
 	}
 }
 
-func (imp *impl) CDebug(ctx context.Context, args ...interface{}) {
+func (imp *impl) CDebug(ctx context.Context, args ...any) {
 	imp.testHelper()
 	dbgName := GetName(ctx)
 
@@ -238,14 +238,14 @@ func (imp *impl) CDebug(ctx context.Context, args ...interface{}) {
 	}
 }
 
-func (imp *impl) Debugf(template string, args ...interface{}) {
+func (imp *impl) Debugf(template string, args ...any) {
 	imp.testHelper()
 	if imp.shouldLog(DEBUG) {
 		imp.log(imp.formatf(DEBUG, emptyTraceKey, template, args...))
 	}
 }
 
-func (imp *impl) CDebugf(ctx context.Context, template string, args ...interface{}) {
+func (imp *impl) CDebugf(ctx context.Context, template string, args ...any) {
 	imp.testHelper()
 	dbgName := GetName(ctx)
 
@@ -255,14 +255,14 @@ func (imp *impl) CDebugf(ctx context.Context, template string, args ...interface
 	}
 }
 
-func (imp *impl) Debugw(msg string, keysAndValues ...interface{}) {
+func (imp *impl) Debugw(msg string, keysAndValues ...any) {
 	imp.testHelper()
 	if imp.shouldLog(DEBUG) {
 		imp.log(imp.formatw(DEBUG, emptyTraceKey, msg, keysAndValues...))
 	}
 }
 
-func (imp *impl) CDebugw(ctx context.Context, msg string, keysAndValues ...interface{}) {
+func (imp *impl) CDebugw(ctx context.Context, msg string, keysAndValues ...any) {
 	imp.testHelper()
 	dbgName := GetName(ctx)
 
@@ -272,14 +272,14 @@ func (imp *impl) CDebugw(ctx context.Context, msg string, keysAndValues ...inter
 	}
 }
 
-func (imp *impl) Info(args ...interface{}) {
+func (imp *impl) Info(args ...any) {
 	imp.testHelper()
 	if imp.shouldLog(INFO) {
 		imp.log(imp.format(INFO, emptyTraceKey, args...))
 	}
 }
 
-func (imp *impl) CInfo(ctx context.Context, args ...interface{}) {
+func (imp *impl) CInfo(ctx context.Context, args ...any) {
 	imp.testHelper()
 	dbgName := GetName(ctx)
 
@@ -289,14 +289,14 @@ func (imp *impl) CInfo(ctx context.Context, args ...interface{}) {
 	}
 }
 
-func (imp *impl) Infof(template string, args ...interface{}) {
+func (imp *impl) Infof(template string, args ...any) {
 	imp.testHelper()
 	if imp.shouldLog(INFO) {
 		imp.log(imp.formatf(INFO, emptyTraceKey, template, args...))
 	}
 }
 
-func (imp *impl) CInfof(ctx context.Context, template string, args ...interface{}) {
+func (imp *impl) CInfof(ctx context.Context, template string, args ...any) {
 	imp.testHelper()
 	dbgName := GetName(ctx)
 
@@ -306,14 +306,14 @@ func (imp *impl) CInfof(ctx context.Context, template string, args ...interface{
 	}
 }
 
-func (imp *impl) Infow(msg string, keysAndValues ...interface{}) {
+func (imp *impl) Infow(msg string, keysAndValues ...any) {
 	imp.testHelper()
 	if imp.shouldLog(INFO) {
 		imp.log(imp.formatw(INFO, emptyTraceKey, msg, keysAndValues...))
 	}
 }
 
-func (imp *impl) CInfow(ctx context.Context, msg string, keysAndValues ...interface{}) {
+func (imp *impl) CInfow(ctx context.Context, msg string, keysAndValues ...any) {
 	imp.testHelper()
 	dbgName := GetName(ctx)
 
@@ -323,14 +323,14 @@ func (imp *impl) CInfow(ctx context.Context, msg string, keysAndValues ...interf
 	}
 }
 
-func (imp *impl) Warn(args ...interface{}) {
+func (imp *impl) Warn(args ...any) {
 	imp.testHelper()
 	if imp.shouldLog(WARN) {
 		imp.log(imp.format(WARN, emptyTraceKey, args...))
 	}
 }
 
-func (imp *impl) CWarn(ctx context.Context, args ...interface{}) {
+func (imp *impl) CWarn(ctx context.Context, args ...any) {
 	imp.testHelper()
 	dbgName := GetName(ctx)
 
@@ -340,14 +340,14 @@ func (imp *impl) CWarn(ctx context.Context, args ...interface{}) {
 	}
 }
 
-func (imp *impl) Warnf(template string, args ...interface{}) {
+func (imp *impl) Warnf(template string, args ...any) {
 	imp.testHelper()
 	if imp.shouldLog(WARN) {
 		imp.log(imp.formatf(WARN, emptyTraceKey, template, args...))
 	}
 }
 
-func (imp *impl) CWarnf(ctx context.Context, template string, args ...interface{}) {
+func (imp *impl) CWarnf(ctx context.Context, template string, args ...any) {
 	imp.testHelper()
 	dbgName := GetName(ctx)
 
@@ -357,14 +357,14 @@ func (imp *impl) CWarnf(ctx context.Context, template string, args ...interface{
 	}
 }
 
-func (imp *impl) Warnw(msg string, keysAndValues ...interface{}) {
+func (imp *impl) Warnw(msg string, keysAndValues ...any) {
 	imp.testHelper()
 	if imp.shouldLog(WARN) {
 		imp.log(imp.formatw(WARN, emptyTraceKey, msg, keysAndValues...))
 	}
 }
 
-func (imp *impl) CWarnw(ctx context.Context, msg string, keysAndValues ...interface{}) {
+func (imp *impl) CWarnw(ctx context.Context, msg string, keysAndValues ...any) {
 	imp.testHelper()
 	dbgName := GetName(ctx)
 
@@ -374,14 +374,14 @@ func (imp *impl) CWarnw(ctx context.Context, msg string, keysAndValues ...interf
 	}
 }
 
-func (imp *impl) Error(args ...interface{}) {
+func (imp *impl) Error(args ...any) {
 	imp.testHelper()
 	if imp.shouldLog(ERROR) {
 		imp.log(imp.format(ERROR, emptyTraceKey, args...))
 	}
 }
 
-func (imp *impl) CError(ctx context.Context, args ...interface{}) {
+func (imp *impl) CError(ctx context.Context, args ...any) {
 	imp.testHelper()
 	dbgName := GetName(ctx)
 
@@ -391,14 +391,14 @@ func (imp *impl) CError(ctx context.Context, args ...interface{}) {
 	}
 }
 
-func (imp *impl) Errorf(template string, args ...interface{}) {
+func (imp *impl) Errorf(template string, args ...any) {
 	imp.testHelper()
 	if imp.shouldLog(ERROR) {
 		imp.log(imp.formatf(ERROR, emptyTraceKey, template, args...))
 	}
 }
 
-func (imp *impl) CErrorf(ctx context.Context, template string, args ...interface{}) {
+func (imp *impl) CErrorf(ctx context.Context, template string, args ...any) {
 	imp.testHelper()
 	dbgName := GetName(ctx)
 
@@ -408,14 +408,14 @@ func (imp *impl) CErrorf(ctx context.Context, template string, args ...interface
 	}
 }
 
-func (imp *impl) Errorw(msg string, keysAndValues ...interface{}) {
+func (imp *impl) Errorw(msg string, keysAndValues ...any) {
 	imp.testHelper()
 	if imp.shouldLog(ERROR) {
 		imp.log(imp.formatw(ERROR, emptyTraceKey, msg, keysAndValues...))
 	}
 }
 
-func (imp *impl) CErrorw(ctx context.Context, msg string, keysAndValues ...interface{}) {
+func (imp *impl) CErrorw(ctx context.Context, msg string, keysAndValues ...any) {
 	imp.testHelper()
 	dbgName := GetName(ctx)
 
@@ -426,19 +426,19 @@ func (imp *impl) CErrorw(ctx context.Context, msg string, keysAndValues ...inter
 }
 
 // These Fatal* methods log as errors then exit the process.
-func (imp *impl) Fatal(args ...interface{}) {
+func (imp *impl) Fatal(args ...any) {
 	imp.testHelper()
 	imp.log(imp.format(ERROR, emptyTraceKey, args...))
 	os.Exit(1)
 }
 
-func (imp *impl) Fatalf(template string, args ...interface{}) {
+func (imp *impl) Fatalf(template string, args ...any) {
 	imp.testHelper()
 	imp.log(imp.formatf(ERROR, emptyTraceKey, template, args...))
 	os.Exit(1)
 }
 
-func (imp *impl) Fatalw(msg string, keysAndValues ...interface{}) {
+func (imp *impl) Fatalw(msg string, keysAndValues ...any) {
 	imp.testHelper()
 	imp.log(imp.formatw(ERROR, emptyTraceKey, msg, keysAndValues...))
 	os.Exit(1)

--- a/logging/impl_test.go
+++ b/logging/impl_test.go
@@ -38,7 +38,7 @@ type StructWithAnonymousStruct struct {
 
 // A custom `test.That` assertion function that takes the log line as a third argument for
 // outputting a better message and a fourth for outputting the log line being tested.
-func EqualsWithLogLine(actual interface{}, otherArgs ...interface{}) string {
+func EqualsWithLogLine(actual any, otherArgs ...any) string {
 	if len(otherArgs) != 3 {
 		panic("EqualsWithMessage requires 4 inputs: actual, expected, message, log line.")
 	}

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -17,21 +17,21 @@ type Logger interface {
 	AddAppender(appender Appender)
 	AsZap() *zap.SugaredLogger
 
-	CDebug(ctx context.Context, args ...interface{})
-	CDebugf(ctx context.Context, template string, args ...interface{})
-	CDebugw(ctx context.Context, msg string, keysAndValues ...interface{})
+	CDebug(ctx context.Context, args ...any)
+	CDebugf(ctx context.Context, template string, args ...any)
+	CDebugw(ctx context.Context, msg string, keysAndValues ...any)
 
-	CInfo(ctx context.Context, args ...interface{})
-	CInfof(ctx context.Context, template string, args ...interface{})
-	CInfow(ctx context.Context, msg string, keysAndValues ...interface{})
+	CInfo(ctx context.Context, args ...any)
+	CInfof(ctx context.Context, template string, args ...any)
+	CInfow(ctx context.Context, msg string, keysAndValues ...any)
 
-	CWarn(ctx context.Context, args ...interface{})
-	CWarnf(ctx context.Context, template string, args ...interface{})
-	CWarnw(ctx context.Context, msg string, keysAndValues ...interface{})
+	CWarn(ctx context.Context, args ...any)
+	CWarnf(ctx context.Context, template string, args ...any)
+	CWarnw(ctx context.Context, msg string, keysAndValues ...any)
 
-	CError(ctx context.Context, args ...interface{})
-	CErrorf(ctx context.Context, template string, args ...interface{})
-	CErrorw(ctx context.Context, msg string, keysAndValues ...interface{})
+	CError(ctx context.Context, args ...any)
+	CErrorf(ctx context.Context, template string, args ...any)
+	CErrorw(ctx context.Context, msg string, keysAndValues ...any)
 }
 
 // ZapCompatibleLogger is a backwards compatibility layer for existing usages of the RDK as a
@@ -42,28 +42,28 @@ type ZapCompatibleLogger interface {
 	Level() zapcore.Level
 	Named(name string) *zap.SugaredLogger
 	Sync() error
-	With(args ...interface{}) *zap.SugaredLogger
+	With(args ...any) *zap.SugaredLogger
 	WithOptions(opts ...zap.Option) *zap.SugaredLogger
 
-	Debug(args ...interface{})
-	Debugf(template string, args ...interface{})
-	Debugw(msg string, keysAndValues ...interface{})
+	Debug(args ...any)
+	Debugf(template string, args ...any)
+	Debugw(msg string, keysAndValues ...any)
 
-	Info(args ...interface{})
-	Infof(template string, args ...interface{})
-	Infow(msg string, keysAndValues ...interface{})
+	Info(args ...any)
+	Infof(template string, args ...any)
+	Infow(msg string, keysAndValues ...any)
 
-	Warn(args ...interface{})
-	Warnf(template string, args ...interface{})
-	Warnw(msg string, keysAndValues ...interface{})
+	Warn(args ...any)
+	Warnf(template string, args ...any)
+	Warnw(msg string, keysAndValues ...any)
 
-	Error(args ...interface{})
-	Errorf(template string, args ...interface{})
-	Errorw(msg string, keysAndValues ...interface{})
+	Error(args ...any)
+	Errorf(template string, args ...any)
+	Errorw(msg string, keysAndValues ...any)
 
-	Fatal(args ...interface{})
-	Fatalf(template string, args ...interface{})
-	Fatalw(msg string, keysAndValues ...interface{})
+	Fatal(args ...any)
+	Fatalf(template string, args ...any)
+	Fatalw(msg string, keysAndValues ...any)
 }
 
 // FromZapCompatible upconverts a ZapCompatibleLogger to a logging.Logger. If the argument already
@@ -116,50 +116,50 @@ func (logger zLogger) Sublogger(name string) Logger {
 	return &zLogger{logger.AsZap().Named(name)}
 }
 
-func (logger zLogger) CDebug(ctx context.Context, args ...interface{}) {
+func (logger zLogger) CDebug(ctx context.Context, args ...any) {
 	logger.Debug(args...)
 }
 
-func (logger zLogger) CDebugf(ctx context.Context, template string, args ...interface{}) {
+func (logger zLogger) CDebugf(ctx context.Context, template string, args ...any) {
 	logger.Debugf(template, args...)
 }
 
-func (logger zLogger) CDebugw(ctx context.Context, msg string, keysAndValues ...interface{}) {
+func (logger zLogger) CDebugw(ctx context.Context, msg string, keysAndValues ...any) {
 	logger.Debugw(msg, keysAndValues...)
 }
 
-func (logger zLogger) CInfo(ctx context.Context, args ...interface{}) {
+func (logger zLogger) CInfo(ctx context.Context, args ...any) {
 	logger.Info(args...)
 }
 
-func (logger zLogger) CInfof(ctx context.Context, template string, args ...interface{}) {
+func (logger zLogger) CInfof(ctx context.Context, template string, args ...any) {
 	logger.Infof(template, args...)
 }
 
-func (logger zLogger) CInfow(ctx context.Context, msg string, keysAndValues ...interface{}) {
+func (logger zLogger) CInfow(ctx context.Context, msg string, keysAndValues ...any) {
 	logger.Infow(msg, keysAndValues...)
 }
 
-func (logger zLogger) CWarn(ctx context.Context, args ...interface{}) {
+func (logger zLogger) CWarn(ctx context.Context, args ...any) {
 	logger.Warn(args...)
 }
 
-func (logger zLogger) CWarnf(ctx context.Context, template string, args ...interface{}) {
+func (logger zLogger) CWarnf(ctx context.Context, template string, args ...any) {
 	logger.Warnf(template, args...)
 }
 
-func (logger zLogger) CWarnw(ctx context.Context, msg string, keysAndValues ...interface{}) {
+func (logger zLogger) CWarnw(ctx context.Context, msg string, keysAndValues ...any) {
 	logger.Warnw(msg, keysAndValues...)
 }
 
-func (logger zLogger) CError(ctx context.Context, args ...interface{}) {
+func (logger zLogger) CError(ctx context.Context, args ...any) {
 	logger.Error(args...)
 }
 
-func (logger zLogger) CErrorf(ctx context.Context, template string, args ...interface{}) {
+func (logger zLogger) CErrorf(ctx context.Context, template string, args ...any) {
 	logger.Errorf(template, args...)
 }
 
-func (logger zLogger) CErrorw(ctx context.Context, msg string, keysAndValues ...interface{}) {
+func (logger zLogger) CErrorw(ctx context.Context, msg string, keysAndValues ...any) {
 	logger.Errorw(msg, keysAndValues...)
 }

--- a/ml/inference/inference.go
+++ b/ml/inference/inference.go
@@ -14,7 +14,7 @@ type MLModel interface {
 	Infer(inputTensors ml.Tensors) (ml.Tensors, error)
 
 	// Metadata gets the entire model metadata structure from file
-	Metadata() (interface{}, error)
+	Metadata() (any, error)
 
 	// Close closes the model and interpreter that allows inferences to be made, opens up space in memory.
 	// All models must be closed when done using

--- a/ml/inference/tflite.go
+++ b/ml/inference/tflite.go
@@ -96,7 +96,7 @@ func createTFLiteInterpreterOptions(numThreads int) (*tflite.InterpreterOptions,
 
 	options.SetNumThread(numThreads)
 
-	options.SetErrorReporter(func(msg string, userData interface{}) {
+	options.SetErrorReporter(func(msg string, userData any) {
 		log.Println(msg)
 	}, nil)
 

--- a/ml/inference/tflite_metadata/ContentProperties.go
+++ b/ml/inference/tflite_metadata/ContentProperties.go
@@ -43,7 +43,7 @@ func (v ContentProperties) String() string {
 
 type ContentPropertiesT struct {
 	Type  ContentProperties
-	Value interface{}
+	Value any
 }
 
 func (t *ContentPropertiesT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {

--- a/ml/inference/tflite_metadata/ProcessUnitOptions.go
+++ b/ml/inference/tflite_metadata/ProcessUnitOptions.go
@@ -49,7 +49,7 @@ func (v ProcessUnitOptions) String() string {
 
 type ProcessUnitOptionsT struct {
 	Type  ProcessUnitOptions
-	Value interface{}
+	Value any
 }
 
 func (t *ProcessUnitOptionsT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {

--- a/module/example_test.go
+++ b/module/example_test.go
@@ -114,7 +114,7 @@ func (c *counter) Reconfigure(ctx context.Context, deps resource.Dependencies, c
 
 // DoCommand is the only method of this component. It looks up the "real" command from the map it's passed.
 // Because of this, any arbitrary commands can be received, and any data returned.
-func (c *counter) DoCommand(ctx context.Context, req map[string]interface{}) (map[string]interface{}, error) {
+func (c *counter) DoCommand(ctx context.Context, req map[string]any) (map[string]any, error) {
 	// We look for a map key called "command"
 	cmd, ok := req["command"]
 	if !ok {
@@ -123,7 +123,7 @@ func (c *counter) DoCommand(ctx context.Context, req map[string]interface{}) (ma
 
 	// If it's "get" we return the current total.
 	if cmd == "get" {
-		return map[string]interface{}{"total": atomic.LoadInt64(&c.total)}, nil
+		return map[string]any{"total": atomic.LoadInt64(&c.total)}, nil
 	}
 
 	// If it's "add" we atomically add a second key "value" to the total.
@@ -138,7 +138,7 @@ func (c *counter) DoCommand(ctx context.Context, req map[string]interface{}) (ma
 		}
 		atomic.AddInt64(&c.total, int64(val))
 		// We return the new total after the addition.
-		return map[string]interface{}{"total": atomic.LoadInt64(&c.total)}, nil
+		return map[string]any{"total": atomic.LoadInt64(&c.total)}, nil
 	}
 	// The command must've been something else.
 	return nil, fmt.Errorf("unknown command string %s", cmd)

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -133,7 +133,7 @@ func TestModManagerFunctions(t *testing.T) {
 	counter, err := mgr.AddResource(ctx, cfgCounter1, nil)
 	test.That(t, err, test.ShouldBeNil)
 
-	ret, err := counter.DoCommand(ctx, map[string]interface{}{"command": "get"})
+	ret, err := counter.DoCommand(ctx, map[string]any{"command": "get"})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, ret["total"], test.ShouldEqual, 0)
 
@@ -155,14 +155,14 @@ func TestModManagerFunctions(t *testing.T) {
 
 	t.Log("test ReconfigureResource")
 	// Reconfigure should replace the proxied object, resetting the counter
-	ret, err = counter.DoCommand(ctx, map[string]interface{}{"command": "add", "value": 73})
+	ret, err = counter.DoCommand(ctx, map[string]any{"command": "add", "value": 73})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, ret["total"], test.ShouldEqual, 73)
 
 	err = mgr.ReconfigureResource(ctx, cfgCounter1, nil)
 	test.That(t, err, test.ShouldBeNil)
 
-	ret, err = counter.DoCommand(ctx, map[string]interface{}{"command": "get"})
+	ret, err = counter.DoCommand(ctx, map[string]any{"command": "get"})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, ret["total"], test.ShouldEqual, 0)
 
@@ -176,7 +176,7 @@ func TestModManagerFunctions(t *testing.T) {
 	err = mgr.RemoveResource(ctx, rNameCounter1)
 	test.That(t, err, test.ShouldNotBeNil)
 
-	_, err = counter.DoCommand(ctx, map[string]interface{}{"command": "get"})
+	_, err = counter.DoCommand(ctx, map[string]any{"command": "get"})
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "not found")
 
@@ -185,7 +185,7 @@ func TestModManagerFunctions(t *testing.T) {
 	_, err = mgr.AddResource(ctx, cfgCounter1, nil)
 	test.That(t, err, test.ShouldBeNil)
 	// Add 24 to counter and ensure 'total' gets reset after reconfiguration.
-	ret, err = counter.DoCommand(ctx, map[string]interface{}{"command": "add", "value": 24})
+	ret, err = counter.DoCommand(ctx, map[string]any{"command": "add", "value": 24})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, ret["total"], test.ShouldEqual, 24)
 
@@ -200,7 +200,7 @@ func TestModManagerFunctions(t *testing.T) {
 	// counter1 should still be provided by reconfigured module.
 	ok = mgr.IsModularResource(rNameCounter1)
 	test.That(t, ok, test.ShouldBeTrue)
-	ret, err = counter.DoCommand(ctx, map[string]interface{}{"command": "get"})
+	ret, err = counter.DoCommand(ctx, map[string]any{"command": "get"})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, ret["total"], test.ShouldEqual, 0)
 
@@ -218,7 +218,7 @@ func TestModManagerFunctions(t *testing.T) {
 
 	ok = mgr.IsModularResource(rNameCounter1)
 	test.That(t, ok, test.ShouldBeFalse)
-	_, err = counter.DoCommand(ctx, map[string]interface{}{"command": "get"})
+	_, err = counter.DoCommand(ctx, map[string]any{"command": "get"})
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "the client connection is closing")
 
@@ -303,7 +303,7 @@ func TestModManagerValidation(t *testing.T) {
 		Name:  "mybase1",
 		API:   base.API,
 		Model: myBaseModel,
-		Attributes: map[string]interface{}{
+		Attributes: map[string]any{
 			"motorL": "motor1",
 			"motorR": "motor2",
 		},
@@ -408,7 +408,7 @@ func TestModuleReloading(t *testing.T) {
 		ok := mgr.IsModularResource(rNameMyHelper)
 		test.That(t, ok, test.ShouldBeTrue)
 
-		resp, err := h.DoCommand(ctx, map[string]interface{}{"command": "echo"})
+		resp, err := h.DoCommand(ctx, map[string]any{"command": "echo"})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, resp, test.ShouldNotBeNil)
 		test.That(t, resp["command"], test.ShouldEqual, "echo")
@@ -416,7 +416,7 @@ func TestModuleReloading(t *testing.T) {
 		// Run 'kill_module' command through helper resource to cause module to exit
 		// with error. Assert that after module is restarted, helper is modularly
 		// managed again and remains functional.
-		_, err = h.DoCommand(ctx, map[string]interface{}{"command": "kill_module"})
+		_, err = h.DoCommand(ctx, map[string]any{"command": "kill_module"})
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring,
 			"error reading from server")
@@ -429,7 +429,7 @@ func TestModuleReloading(t *testing.T) {
 
 		ok = mgr.IsModularResource(rNameMyHelper)
 		test.That(t, ok, test.ShouldBeTrue)
-		resp, err = h.DoCommand(ctx, map[string]interface{}{"command": "echo"})
+		resp, err = h.DoCommand(ctx, map[string]any{"command": "echo"})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, resp, test.ShouldNotBeNil)
 		test.That(t, resp["command"], test.ShouldEqual, "echo")
@@ -482,7 +482,7 @@ func TestModuleReloading(t *testing.T) {
 		ok := mgr.IsModularResource(rNameMyHelper)
 		test.That(t, ok, test.ShouldBeTrue)
 
-		resp, err := h.DoCommand(ctx, map[string]interface{}{"command": "echo"})
+		resp, err := h.DoCommand(ctx, map[string]any{"command": "echo"})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, resp, test.ShouldNotBeNil)
 		test.That(t, resp["command"], test.ShouldEqual, "echo")
@@ -496,7 +496,7 @@ func TestModuleReloading(t *testing.T) {
 		// Run 'kill_module' command through helper resource to cause module to
 		// exit with error. Assert that after three restart errors occur, helper is
 		// not modularly managed and commands return error.
-		_, err = h.DoCommand(ctx, map[string]interface{}{"command": "kill_module"})
+		_, err = h.DoCommand(ctx, map[string]any{"command": "kill_module"})
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring,
 			"error reading from server")
@@ -509,7 +509,7 @@ func TestModuleReloading(t *testing.T) {
 
 		ok = mgr.IsModularResource(rNameMyHelper)
 		test.That(t, ok, test.ShouldBeFalse)
-		_, err = h.DoCommand(ctx, map[string]interface{}{"command": "echo"})
+		_, err = h.DoCommand(ctx, map[string]any{"command": "echo"})
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring,
 			"connection is closing")
@@ -752,7 +752,7 @@ func TestModuleMisc(t *testing.T) {
 		test.That(t, ok, test.ShouldBeTrue)
 
 		// Create a file in the modules data directory and then verify that it was written
-		resp, err := h.DoCommand(ctx, map[string]interface{}{
+		resp, err := h.DoCommand(ctx, map[string]any{
 			"command":  "write_data_file",
 			"filename": "data.txt",
 			"contents": "hello, world!",
@@ -806,7 +806,7 @@ func TestModuleMisc(t *testing.T) {
 		test.That(t, ok, test.ShouldBeTrue)
 
 		// Create a file in the modules data directory and then verify that it was written
-		resp, err := h.DoCommand(ctx, map[string]interface{}{
+		resp, err := h.DoCommand(ctx, map[string]any{
 			"command": "get_working_directory",
 		})
 		test.That(t, err, test.ShouldBeNil)
@@ -837,7 +837,7 @@ func TestModuleMisc(t *testing.T) {
 		test.That(t, ok, test.ShouldBeTrue)
 
 		// Create a file in the modules data directory and then verify that it was written
-		resp, err := h.DoCommand(ctx, map[string]interface{}{
+		resp, err := h.DoCommand(ctx, map[string]any{
 			"command": "get_working_directory",
 		})
 		test.That(t, err, test.ShouldBeNil)

--- a/module/module_interceptors_test.go
+++ b/module/module_interceptors_test.go
@@ -89,7 +89,7 @@ func TestOpID(t *testing.T) {
 			syncChan := make(chan string)
 			// in the background, run a operation that sleeps for one second, and capture it's header
 			go func() {
-				cmd, err := structpb.NewStruct(map[string]interface{}{"command": "sleep"})
+				cmd, err := structpb.NewStruct(map[string]any{"command": "sleep"})
 				test.That(t, err, test.ShouldBeNil)
 
 				var hdr metadata.MD
@@ -118,13 +118,13 @@ func TestOpID(t *testing.T) {
 			testutils.WaitForAssertion(t, func(tb testing.TB) {
 				tb.Helper()
 				// as soon as we see the op in the parent, check the operations in the module
-				cmd, err := structpb.NewStruct(map[string]interface{}{"command": "get_ops"})
+				cmd, err := structpb.NewStruct(map[string]any{"command": "get_ops"})
 				test.That(tb, err, test.ShouldBeNil)
 				resp, err := gc.DoCommand(ctx, &commonpb.DoCommandRequest{Name: "helper1", Command: cmd})
 				test.That(tb, err, test.ShouldBeNil)
 				ret, ok := resp.GetResult().AsMap()["ops"]
 				test.That(tb, ok, test.ShouldBeTrue)
-				retList, ok := ret.([]interface{})
+				retList, ok := ret.([]any)
 				test.That(tb, ok, test.ShouldBeTrue)
 				test.That(tb, len(retList), test.ShouldBeGreaterThan, 1)
 				for _, v := range retList {

--- a/module/module_test.go
+++ b/module/module_test.go
@@ -275,7 +275,7 @@ func TestModuleFunctions(t *testing.T) {
 		test.That(t, ret, test.ShouldBeTrue)
 
 		// Test generic echo
-		testCmd := map[string]interface{}{"foo": "bar"}
+		testCmd := map[string]any{"foo": "bar"}
 		retCmd, err := gClient.DoCommand(context.Background(), testCmd)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, retCmd, test.ShouldResemble, testCmd)
@@ -298,7 +298,7 @@ func TestModuleFunctions(t *testing.T) {
 		test.That(t, ret, test.ShouldBeFalse)
 
 		// Test generic echo
-		testCmd := map[string]interface{}{"foo": "bar"}
+		testCmd := map[string]any{"foo": "bar"}
 		retCmd, err := gClient.DoCommand(context.Background(), testCmd)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, retCmd, test.ShouldResemble, testCmd)
@@ -313,7 +313,7 @@ func TestModuleFunctions(t *testing.T) {
 		test.That(t, err.Error(), test.ShouldContainSubstring, "not found")
 
 		// Test generic echo
-		testCmd := map[string]interface{}{"foo": "bar"}
+		testCmd := map[string]any{"foo": "bar"}
 		retCmd, err := gClient.DoCommand(context.Background(), testCmd)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "not found")
 		test.That(t, retCmd, test.ShouldBeNil)
@@ -621,7 +621,7 @@ func TestAttributeConversion(t *testing.T) {
 
 		// TODO(RSDK-6022): use datamanager.DataCaptureConfigs once resource.Name can be properly marshalled/unmarshalled
 		dummySvcCfg := rutils.AttributeMap{
-			"capture_methods": []interface{}{map[string]interface{}{"name": "rdk:service:shell/mymock2", "method": "Something"}},
+			"capture_methods": []any{map[string]any{"name": "rdk:service:shell/mymock2", "method": "Something"}},
 		}
 		mockServiceCfg, err := protoutils.StructToStructPb(dummySvcCfg)
 		test.That(t, err, test.ShouldBeNil)
@@ -655,7 +655,7 @@ func TestAttributeConversion(t *testing.T) {
 		th.mockReconfigConf.Attributes = mockAttrs
 
 		dummySvcCfg2 := rutils.AttributeMap{
-			"capture_methods": []interface{}{map[string]interface{}{"name": "rdk:service:shell/mymock2", "method": "Something2"}},
+			"capture_methods": []any{map[string]any{"name": "rdk:service:shell/mymock2", "method": "Something2"}},
 		}
 		mockServiceCfg, err = protoutils.StructToStructPb(dummySvcCfg2)
 		test.That(t, err, test.ShouldBeNil)

--- a/module/multiversionmodule/module.go
+++ b/module/multiversionmodule/module.go
@@ -111,6 +111,6 @@ func (c *component) Reconfigure(ctx context.Context, deps resource.Dependencies,
 }
 
 // DoCommand does nothing for now.
-func (c *component) DoCommand(ctx context.Context, req map[string]interface{}) (map[string]interface{}, error) {
-	return map[string]interface{}{}, nil
+func (c *component) DoCommand(ctx context.Context, req map[string]any) (map[string]any, error) {
+	return map[string]any{}, nil
 }

--- a/module/server.go
+++ b/module/server.go
@@ -80,7 +80,7 @@ func (s *Server) Stop() error {
 func (s *Server) RegisterServiceServer(
 	ctx context.Context,
 	svcDesc *grpc.ServiceDesc,
-	svcServer interface{},
+	svcServer any,
 	svcHandlers ...rpc.RegisterServiceHandlerFromEndpointFunc,
 ) error {
 	s.server.RegisterService(svcDesc, svcServer)

--- a/module/testmodule/main.go
+++ b/module/testmodule/main.go
@@ -83,7 +83,7 @@ type helper struct {
 // DoCommand is the only method of this component. It looks up the "real" command from the map it's passed.
 //
 
-func (h *helper) DoCommand(ctx context.Context, req map[string]interface{}) (map[string]interface{}, error) {
+func (h *helper) DoCommand(ctx context.Context, req map[string]any) (map[string]any, error) {
 	cmd, ok := req["command"]
 	if !ok {
 		return nil, errors.New("missing 'command' string")
@@ -101,7 +101,7 @@ func (h *helper) DoCommand(ctx context.Context, req map[string]interface{}) (map
 		for _, op := range ops {
 			opsOut = append(opsOut, op.ID.String())
 		}
-		return map[string]interface{}{"ops": opsOut}, nil
+		return map[string]any{"ops": opsOut}, nil
 	case "echo":
 		// For testing module liveliness
 		return req, nil
@@ -123,16 +123,16 @@ func (h *helper) DoCommand(ctx context.Context, req map[string]interface{}) (map
 		dataFilePath := filepath.Join(os.Getenv("VIAM_MODULE_DATA"), filename)
 		err := os.WriteFile(dataFilePath, []byte(contents), 0o600)
 		if err != nil {
-			return map[string]interface{}{}, err
+			return map[string]any{}, err
 		}
-		return map[string]interface{}{"fullpath": dataFilePath}, nil
+		return map[string]any{"fullpath": dataFilePath}, nil
 	case "get_working_directory":
 		// For testing that modules are started with the correct working directory
 		workingDir, err := os.Getwd()
 		if err != nil {
-			return map[string]interface{}{}, err
+			return map[string]any{}, err
 		}
-		return map[string]interface{}{"path": workingDir}, nil
+		return map[string]any{"path": workingDir}, nil
 	case "log":
 		level, err := logging.LevelFromString(req["level"].(string))
 		if err != nil {
@@ -174,47 +174,47 @@ type testMotor struct {
 var _ motor.Motor = &testMotor{}
 
 // SetPower trivially implements motor.Motor.
-func (tm *testMotor) SetPower(_ context.Context, _ float64, _ map[string]interface{}) error {
+func (tm *testMotor) SetPower(_ context.Context, _ float64, _ map[string]any) error {
 	return nil
 }
 
 // GoFor trivially implements motor.Motor.
-func (tm *testMotor) GoFor(_ context.Context, _, _ float64, _ map[string]interface{}) error {
+func (tm *testMotor) GoFor(_ context.Context, _, _ float64, _ map[string]any) error {
 	return nil
 }
 
 // GoTo trivially implements motor.Motor.
-func (tm *testMotor) GoTo(_ context.Context, _, _ float64, _ map[string]interface{}) error {
+func (tm *testMotor) GoTo(_ context.Context, _, _ float64, _ map[string]any) error {
 	return nil
 }
 
 // ResetZeroPosition trivially implements motor.Motor.
-func (tm *testMotor) ResetZeroPosition(_ context.Context, _ float64, _ map[string]interface{}) error {
+func (tm *testMotor) ResetZeroPosition(_ context.Context, _ float64, _ map[string]any) error {
 	return nil
 }
 
 // Position trivially implements motor.Motor.
-func (tm *testMotor) Position(_ context.Context, _ map[string]interface{}) (float64, error) {
+func (tm *testMotor) Position(_ context.Context, _ map[string]any) (float64, error) {
 	return 0.0, nil
 }
 
 // Properties trivially implements motor.Motor.
-func (tm *testMotor) Properties(_ context.Context, _ map[string]interface{}) (motor.Properties, error) {
+func (tm *testMotor) Properties(_ context.Context, _ map[string]any) (motor.Properties, error) {
 	return motor.Properties{}, nil
 }
 
 // Stop trivially implements motor.Motor.
-func (tm *testMotor) Stop(_ context.Context, _ map[string]interface{}) error {
+func (tm *testMotor) Stop(_ context.Context, _ map[string]any) error {
 	return nil
 }
 
 // IsPowered trivally implements motor.Motor.
-func (tm *testMotor) IsPowered(_ context.Context, _ map[string]interface{}) (bool, float64, error) {
+func (tm *testMotor) IsPowered(_ context.Context, _ map[string]any) (bool, float64, error) {
 	return false, 0.0, nil
 }
 
 // DoCommand trivially implements motor.Motor.
-func (tm *testMotor) DoCommand(_ context.Context, _ map[string]interface{}) (map[string]interface{}, error) {
+func (tm *testMotor) DoCommand(_ context.Context, _ map[string]any) (map[string]any, error) {
 	//nolint:nilnil
 	return nil, nil
 }

--- a/motionplan/motionPlanner.go
+++ b/motionplan/motionPlanner.go
@@ -50,7 +50,7 @@ type PlanRequest struct {
 	StartConfiguration map[string][]frame.Input
 	WorldState         *frame.WorldState
 	ConstraintSpecs    *pb.Constraints
-	Options            map[string]interface{}
+	Options            map[string]any
 }
 
 // validatePlanRequest ensures PlanRequests are not malformed.
@@ -110,7 +110,7 @@ func PlanFrameMotion(ctx context.Context,
 	f frame.Frame,
 	seed []frame.Input,
 	constraintSpec *pb.Constraints,
-	planningOpts map[string]interface{},
+	planningOpts map[string]any,
 ) ([][]frame.Input, error) {
 	// ephemerally create a framesystem containing just the frame for the solve
 	fs := frame.NewEmptyFrameSystem("")

--- a/motionplan/motionPlanner_test.go
+++ b/motionplan/motionPlanner_test.go
@@ -439,7 +439,7 @@ func TestArmAndGantrySolve(t *testing.T) {
 		Frame:              fs.Frame("xArmVgripper"),
 		StartConfiguration: positions,
 		FrameSystem:        fs,
-		Options:            map[string]interface{}{"smooth_iter": 5},
+		Options:            map[string]any{"smooth_iter": 5},
 	})
 	test.That(t, err, test.ShouldBeNil)
 	solvedPose, err := fs.Transform(
@@ -462,7 +462,7 @@ func TestMultiArmSolve(t *testing.T) {
 		Frame:              fs.Frame("xArmVgripper"),
 		StartConfiguration: positions,
 		FrameSystem:        fs,
-		Options:            map[string]interface{}{"max_ik_solutions": 10, "timeout": 150.0, "smooth_iter": 5},
+		Options:            map[string]any{"max_ik_solutions": 10, "timeout": 150.0, "smooth_iter": 5},
 	})
 	test.That(t, err, test.ShouldBeNil)
 
@@ -494,7 +494,7 @@ func TestReachOverArm(t *testing.T) {
 	fs.AddFrame(xarm, offset)
 
 	// plan to a location, it should interpolate to get there
-	opts := map[string]interface{}{"timeout": 150.0}
+	opts := map[string]any{"timeout": 150.0}
 	plan, err := PlanMotion(context.Background(), &PlanRequest{
 		Logger:             logger,
 		Goal:               goal,
@@ -513,7 +513,7 @@ func TestReachOverArm(t *testing.T) {
 	fs.AddFrame(ur5, fs.World())
 
 	// the plan should no longer be able to interpolate, but it should still be able to get there
-	opts = map[string]interface{}{"timeout": 150.0, "smooth_iter": 5}
+	opts = map[string]any{"timeout": 150.0, "smooth_iter": 5}
 	plan, err = PlanMotion(context.Background(), &PlanRequest{
 		Logger:             logger,
 		Goal:               goal,
@@ -608,7 +608,7 @@ func TestSolverFrameGeometries(t *testing.T) {
 		nil,
 		nil,
 		nil,
-		map[string]interface{}{"smooth_iter": 5},
+		map[string]any{"smooth_iter": 5},
 	)
 	test.That(t, err, test.ShouldBeNil)
 	gf, _ := sf.Geometries(position[len(position)-1])
@@ -718,7 +718,7 @@ func TestMovementWithGripper(t *testing.T) {
 	zeroPosition := sf.sliceToMap(make([]frame.Input, len(sf.DoF())))
 
 	// linearly plan with the gripper
-	motionConfig := make(map[string]interface{})
+	motionConfig := make(map[string]any)
 	motionConfig["motion_profile"] = LinearMotionProfile
 	sfPlanner, err := newPlanManager(sf, fs, logger, 1)
 	test.That(t, err, test.ShouldBeNil)
@@ -843,7 +843,7 @@ func TestPtgPosOnlyBidirectional(t *testing.T) {
 
 	goal := spatialmath.NewPoseFromPoint(r3.Vector{1000, -8000, 0})
 
-	extra := map[string]interface{}{"motion_profile": "position_only", "position_seeds": 2, "smooth_iter": 5}
+	extra := map[string]any{"motion_profile": "position_only", "position_seeds": 2, "smooth_iter": 5}
 
 	baseFS := frame.NewEmptyFrameSystem("baseFS")
 	err = baseFS.AddFrame(kinematicFrame, baseFS.World())

--- a/motionplan/planManager.go
+++ b/motionplan/planManager.go
@@ -62,7 +62,7 @@ func (pm *planManager) PlanSingleWaypoint(ctx context.Context,
 	worldState *referenceframe.WorldState,
 	constraintSpec *pb.Constraints,
 	seedPlan Plan,
-	motionConfig map[string]interface{},
+	motionConfig map[string]any,
 ) ([][]referenceframe.Input, error) {
 	seed, err := pm.frame.mapToSlice(seedMap)
 	if err != nil {
@@ -480,13 +480,13 @@ func (pm *planManager) planParallelRRTMotion(
 	}
 }
 
-// This is where the map[string]interface{} passed in via `extra` is used to decide how planning happens.
+// This is where the map[string]any passed in via `extra` is used to decide how planning happens.
 func (pm *planManager) plannerSetupFromMoveRequest(
 	from, to spatialmath.Pose,
 	seedMap map[string][]referenceframe.Input,
 	worldState *referenceframe.WorldState,
 	constraints *pb.Constraints,
-	planningOpts map[string]interface{},
+	planningOpts map[string]any,
 ) (*plannerOptions, error) {
 	planAlg := ""
 
@@ -517,7 +517,7 @@ func (pm *planManager) plannerSetupFromMoveRequest(
 		planAlg = "cbirrt"
 	}
 
-	// error handling around extracting motion_profile information from map[string]interface{}
+	// error handling around extracting motion_profile information from map[string]any
 	var motionProfile string
 	profile, ok := planningOpts["motion_profile"]
 	if ok {
@@ -709,8 +709,8 @@ func (pm *planManager) planToRRTGoalMap(plan Plan, goal spatialmath.Pose) (*rrtM
 }
 
 // Copy any atomic values.
-func deepAtomicCopyMap(opt map[string]interface{}) map[string]interface{} {
-	optCopy := map[string]interface{}{}
+func deepAtomicCopyMap(opt map[string]any) map[string]any {
+	optCopy := map[string]any{}
 	for k, v := range opt {
 		optCopy[k] = v
 	}

--- a/motionplan/plannerOptions.go
+++ b/motionplan/plannerOptions.go
@@ -118,7 +118,7 @@ type plannerOptions struct {
 	goalArcScore          ik.SegmentMetric
 	pathMetric            ik.StateMetric // Distance function which converges on the valid manifold of intermediate path states
 
-	extra map[string]interface{}
+	extra map[string]any
 
 	// For the below values, if left uninitialized, default values will be used. To disable, set < 0
 	// Max number of ik solutions to consider

--- a/motionplan/utils_test.go
+++ b/motionplan/utils_test.go
@@ -129,7 +129,7 @@ func TestPlanToPlanStepsAndGeoPoses(t *testing.T) {
 		Frame:              kinematicFrame,
 		FrameSystem:        baseFS,
 		StartConfiguration: frame.StartPositions(baseFS),
-		Options:            map[string]interface{}{"smooth_iter": 0},
+		Options:            map[string]any{"smooth_iter": 0},
 	}
 	plan := Plan{
 		map[string][]frame.Input{

--- a/operation/manager.go
+++ b/operation/manager.go
@@ -118,17 +118,17 @@ func (sm *SingleOperationManager) NewTimedWaitOp(ctx context.Context, dur time.D
 // powered, the power percent (between 0 and 1, or between -1 and 1 for motors that support
 // negative power), and any error that occurred while obtaining these.
 type IsPoweredInterface interface {
-	IsPowered(ctx context.Context, extra map[string]interface{}) (bool, float64, error)
+	IsPowered(ctx context.Context, extra map[string]any) (bool, float64, error)
 }
 
 // WaitTillNotPowered waits until IsPowered returns false.
 func (sm *SingleOperationManager) WaitTillNotPowered(ctx context.Context, pollTime time.Duration, powered IsPoweredInterface,
-	stop func(context.Context, map[string]interface{}) error,
+	stop func(context.Context, map[string]any) error,
 ) (err error) {
 	// Defers a function that will stop and clean up if the context errors
 	defer func(ctx context.Context) {
 		if errors.Is(ctx.Err(), context.Canceled) {
-			err = multierr.Combine(ctx.Err(), stop(ctx, map[string]interface{}{}))
+			err = multierr.Combine(ctx.Err(), stop(ctx, map[string]any{}))
 		} else {
 			err = ctx.Err()
 		}

--- a/operation/manager_test.go
+++ b/operation/manager_test.go
@@ -176,15 +176,15 @@ type mock struct {
 	stopCount int
 }
 
-func (m *mock) stop(ctx context.Context, extra map[string]interface{}) error {
+func (m *mock) stop(ctx context.Context, extra map[string]any) error {
 	m.stopCount++
 	return nil
 }
 
-func (m *mock) stopFail(ctx context.Context, extra map[string]interface{}) error {
+func (m *mock) stopFail(ctx context.Context, extra map[string]any) error {
 	return errors.New("Stop failed")
 }
 
-func (m *mock) IsPowered(ctx context.Context, extra map[string]interface{}) (bool, float64, error) {
+func (m *mock) IsPowered(ctx context.Context, extra map[string]any) (bool, float64, error) {
 	return true, 1, nil
 }

--- a/operation/opid.go
+++ b/operation/opid.go
@@ -28,7 +28,7 @@ type Operation struct {
 	ID        uuid.UUID
 	SessionID uuid.UUID
 	Method    string
-	Arguments interface{}
+	Arguments any
 	Started   time.Time
 
 	myManager *Manager
@@ -120,11 +120,11 @@ func (m *Manager) FindString(id string) *Operation {
 }
 
 // Create puts an operation on this context.
-func (m *Manager) Create(ctx context.Context, method string, args interface{}) (context.Context, func()) {
+func (m *Manager) Create(ctx context.Context, method string, args any) (context.Context, func()) {
 	return m.createWithID(ctx, uuid.New(), method, args)
 }
 
-func (m *Manager) createWithID(ctx context.Context, id uuid.UUID, method string, args interface{}) (context.Context, func()) {
+func (m *Manager) createWithID(ctx context.Context, id uuid.UUID, method string, args any) (context.Context, func()) {
 	if ctx.Value(opidKey) != nil {
 		panic("operations cannot be nested")
 	}

--- a/operation/web.go
+++ b/operation/web.go
@@ -17,7 +17,7 @@ const opidMetadataKey = "opid"
 func UnaryClientInterceptor(
 	ctx context.Context,
 	method string,
-	req, reply interface{},
+	req, reply any,
 	cc *grpc.ClientConn,
 	invoker grpc.UnaryInvoker,
 	opts ...grpc.CallOption,
@@ -49,10 +49,10 @@ func StreamClientInterceptor(
 // ID, the new operation will have the same ID.
 func (m *Manager) UnaryServerInterceptor(
 	ctx context.Context,
-	req interface{},
+	req any,
 	info *grpc.UnaryServerInfo,
 	handler grpc.UnaryHandler,
-) (interface{}, error) {
+) (any, error) {
 	ctx, done := m.CreateFromIncomingContext(ctx, info.FullMethod)
 	defer done()
 	if op := Get(ctx); op != nil && op.ID.String() != "" {
@@ -65,7 +65,7 @@ func (m *Manager) UnaryServerInterceptor(
 // it to the stream response handler. If the incoming RPC metadata contains an operation
 // ID, the new operation will have the same ID.
 func (m *Manager) StreamServerInterceptor(
-	srv interface{},
+	srv any,
 	ss grpc.ServerStream,
 	info *grpc.StreamServerInfo,
 	handler grpc.StreamHandler,

--- a/protoutils/messages.go
+++ b/protoutils/messages.go
@@ -110,7 +110,7 @@ func ConvertStringMapToAnyPBMap(params map[string]string) (map[string]*anypb.Any
 
 // MessageToProtoV1 converts a message to a protov1.Message. It is
 // assumed it is either a proto.Message or a protov1.Message.
-func MessageToProtoV1(msg interface{}) protov1.Message {
+func MessageToProtoV1(msg any) protov1.Message {
 	switch v := msg.(type) {
 	case proto.Message:
 		return protov1.MessageV1(v)
@@ -129,8 +129,8 @@ type ClientDoCommander interface {
 
 // DoFromResourceClient is a helper to allow DoCommand() calls from any client.
 func DoFromResourceClient(ctx context.Context, svc ClientDoCommander, name string,
-	cmd map[string]interface{},
-) (map[string]interface{}, error) {
+	cmd map[string]any,
+) (map[string]any, error) {
 	command, err := protoutils.StructToStructPb(cmd)
 	if err != nil {
 		return nil, err

--- a/protoutils/sensor.go
+++ b/protoutils/sensor.go
@@ -19,31 +19,31 @@ const (
 	typeAxisAngle                = "r4aa"
 )
 
-func goToProto(v interface{}) (*structpb.Value, error) {
+func goToProto(v any) (*structpb.Value, error) {
 	switch x := v.(type) {
 	case spatialmath.AngularVelocity:
-		v = map[string]interface{}{
+		v = map[string]any{
 			"x":     x.X,
 			"y":     x.Y,
 			"z":     x.Z,
 			"_type": typeAngularVelocity,
 		}
 	case r3.Vector:
-		v = map[string]interface{}{
+		v = map[string]any{
 			"x":     x.X,
 			"y":     x.Y,
 			"z":     x.Z,
 			"_type": typeVector3,
 		}
 	case *spatialmath.EulerAngles:
-		v = map[string]interface{}{
+		v = map[string]any{
 			"roll":  x.Roll,
 			"pitch": x.Pitch,
 			"yaw":   x.Yaw,
 			"_type": typeEuler,
 		}
 	case *spatialmath.Quaternion:
-		v = map[string]interface{}{
+		v = map[string]any{
 			"r":     x.Real,
 			"i":     x.Imag,
 			"j":     x.Jmag,
@@ -51,7 +51,7 @@ func goToProto(v interface{}) (*structpb.Value, error) {
 			"_type": typeQuat,
 		}
 	case *spatialmath.OrientationVector:
-		v = map[string]interface{}{
+		v = map[string]any{
 			"theta": x.Theta,
 			"ox":    x.OX,
 			"oy":    x.OY,
@@ -59,7 +59,7 @@ func goToProto(v interface{}) (*structpb.Value, error) {
 			"_type": typeOrientationVector,
 		}
 	case *spatialmath.OrientationVectorDegrees:
-		v = map[string]interface{}{
+		v = map[string]any{
 			"theta": x.Theta,
 			"ox":    x.OX,
 			"oy":    x.OY,
@@ -67,7 +67,7 @@ func goToProto(v interface{}) (*structpb.Value, error) {
 			"_type": typeOrientationVectorDegrees,
 		}
 	case *spatialmath.R4AA:
-		v = map[string]interface{}{
+		v = map[string]any{
 			"theta": x.Theta,
 			"rx":    x.RX,
 			"ry":    x.RY,
@@ -76,7 +76,7 @@ func goToProto(v interface{}) (*structpb.Value, error) {
 		}
 	case spatialmath.Orientation:
 		deg := x.OrientationVectorDegrees()
-		v = map[string]interface{}{
+		v = map[string]any{
 			"theta": deg.Theta,
 			"ox":    deg.OX,
 			"oy":    deg.OY,
@@ -84,7 +84,7 @@ func goToProto(v interface{}) (*structpb.Value, error) {
 			"_type": typeOrientationVectorDegrees,
 		}
 	case *geo.Point:
-		v = map[string]interface{}{
+		v = map[string]any{
 			"lat":   x.Lat(),
 			"lng":   x.Lng(),
 			"_type": typeGeopoint,
@@ -95,7 +95,7 @@ func goToProto(v interface{}) (*structpb.Value, error) {
 }
 
 // ReadingGoToProto converts go readings to proto readings.
-func ReadingGoToProto(readings map[string]interface{}) (map[string]*structpb.Value, error) {
+func ReadingGoToProto(readings map[string]any) (map[string]*structpb.Value, error) {
 	m := map[string]*structpb.Value{}
 
 	for k, v := range readings {
@@ -110,17 +110,17 @@ func ReadingGoToProto(readings map[string]interface{}) (map[string]*structpb.Val
 }
 
 // ReadingProtoToGo converts proto readings to go readings.
-func ReadingProtoToGo(readings map[string]*structpb.Value) (map[string]interface{}, error) {
-	m := map[string]interface{}{}
+func ReadingProtoToGo(readings map[string]*structpb.Value) (map[string]any, error) {
+	m := map[string]any{}
 	for k, v := range readings {
 		m[k] = cleanSensorType(v.AsInterface())
 	}
 	return m, nil
 }
 
-func cleanSensorType(v interface{}) interface{} {
+func cleanSensorType(v any) any {
 	switch x := v.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		switch x["_type"] {
 		case typeAngularVelocity:
 			return spatialmath.AngularVelocity{

--- a/protoutils/sensor_test.go
+++ b/protoutils/sensor_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestRoundtrip(t *testing.T) {
-	m1 := map[string]interface{}{
+	m1 := map[string]any{
 		"d":   5.4,
 		"av":  spatialmath.AngularVelocity{1, 2, 3},
 		"vv":  r3.Vector{1, 2, 3},

--- a/referenceframe/frame_system.go
+++ b/referenceframe/frame_system.go
@@ -534,7 +534,7 @@ func (part *FrameSystemPart) ToProtobuf() (*pb.FrameSystemConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	var modelJSON map[string]interface{}
+	var modelJSON map[string]any
 	if part.ModelFrame != nil {
 		bytes, err := part.ModelFrame.MarshalJSON()
 		if err != nil {

--- a/referenceframe/frame_system_test.go
+++ b/referenceframe/frame_system_test.go
@@ -19,7 +19,7 @@ import (
 func TestFrameModelPart(t *testing.T) {
 	jsonData, err := os.ReadFile(rdkutils.ResolveFile("config/data/model_frame.json"))
 	test.That(t, err, test.ShouldBeNil)
-	var modelJSONMap map[string]interface{}
+	var modelJSONMap map[string]any
 	json.Unmarshal(jsonData, &modelJSONMap)
 	model, err := UnmarshalModelJSON(jsonData, "")
 	test.That(t, err, test.ShouldBeNil)

--- a/referenceframe/worldstate.go
+++ b/referenceframe/worldstate.go
@@ -113,7 +113,7 @@ func (ws *WorldState) String() string {
 	t.AppendHeader(table.Row{"Name", "Geometry Type", "Parent"})
 	for _, geometries := range ws.obstacles {
 		for _, geometry := range geometries.geometries {
-			t.AppendRow([]interface{}{
+			t.AppendRow([]any{
 				geometry.Label(),
 				geometry.String(),
 				geometries.frame,

--- a/referenceframe/worldstate_test.go
+++ b/referenceframe/worldstate_test.go
@@ -59,17 +59,17 @@ func TestString(t *testing.T) {
 
 	testTable := table.NewWriter()
 	testTable.AppendHeader(table.Row{"Name", "Geometry Type", "Parent"})
-	testTable.AppendRow([]interface{}{
+	testTable.AppendRow([]any{
 		"foo",
 		foo.String(),
 		"world",
 	})
-	testTable.AppendRow([]interface{}{
+	testTable.AppendRow([]any{
 		"bar",
 		bar.String(),
 		"world",
 	})
-	testTable.AppendRow([]interface{}{
+	testTable.AppendRow([]any{
 		"testgeo",
 		testgeo.String(),
 		"camera",

--- a/resource/config.go
+++ b/resource/config.go
@@ -65,7 +65,7 @@ type configData struct {
 
 // UnmarshalJSON unmarshals JSON into the config.
 func (conf *Config) UnmarshalJSON(data []byte) error {
-	var m map[string]interface{}
+	var m map[string]any
 	if err := json.Unmarshal(data, &m); err != nil {
 		return err
 	}
@@ -137,7 +137,7 @@ func NewEmptyConfig(name Name, model Model) Config {
 type AssociatedResourceConfig struct {
 	API                 API
 	Attributes          utils.AttributeMap
-	ConvertedAttributes interface{}
+	ConvertedAttributes any
 	RemoteName          string
 }
 
@@ -315,7 +315,7 @@ type ConfigValidator interface {
 func TransformAttributeMap[T any](attributes utils.AttributeMap) (T, error) {
 	var out T
 
-	var forResult interface{}
+	var forResult any
 
 	toT := reflect.TypeOf(out)
 	if toT == nil {

--- a/resource/discovery.go
+++ b/resource/discovery.go
@@ -15,7 +15,7 @@ type (
 	}
 
 	// DiscoveryFunc is a function that discovers component configurations.
-	DiscoveryFunc func(ctx context.Context, logger logging.Logger) (interface{}, error)
+	DiscoveryFunc func(ctx context.Context, logger logging.Logger) (any, error)
 
 	// Discovery holds a Query and a corresponding discovered component configuration. A
 	// discovered component configuration can be comprised of primitives, a list of
@@ -24,7 +24,7 @@ type (
 	// guaranteed.
 	Discovery struct {
 		Query   DiscoveryQuery
-		Results interface{}
+		Results any
 	}
 
 	// DiscoverError indicates that a Discover function has returned an error.

--- a/resource/errors.go
+++ b/resource/errors.go
@@ -75,7 +75,7 @@ func DependencyNotFoundError(name Name) error {
 }
 
 // DependencyTypeError is used when a resource doesn't implement the expected interface.
-func DependencyTypeError[T Resource](name Name, actual interface{}) error {
+func DependencyTypeError[T Resource](name Name, actual any) error {
 	// This error represents a coding error. Include a stack trace for diagnostics.
 	return errors.Errorf("dependency %q should be an implementation of %s but it was a %T", name, utils.TypeStr[T](), actual)
 }

--- a/resource/graph_node_test.go
+++ b/resource/graph_node_test.go
@@ -177,7 +177,7 @@ func lifecycleTest(t *testing.T, node *resource.GraphNode, initialDeps []string)
 	test.That(t, ourRes.closeCap, test.ShouldBeEmpty)
 	test.That(t, ourRes2.closeCap, test.ShouldBeEmpty)
 	test.That(t, ourRes3.closeCap, test.ShouldHaveLength, 1)
-	test.That(t, ourRes3.closeCap, test.ShouldResemble, []interface{}{"hi"})
+	test.That(t, ourRes3.closeCap, test.ShouldResemble, []any{"hi"})
 
 	test.That(t, node.IsUninitialized(), test.ShouldBeTrue)
 	_, err = node.Resource()
@@ -202,7 +202,7 @@ func lifecycleTest(t *testing.T, node *resource.GraphNode, initialDeps []string)
 	test.That(t, ourRes2.closeCap, test.ShouldBeEmpty)
 	test.That(t, ourRes3.closeCap, test.ShouldHaveLength, 1)
 	test.That(t, ourRes4.closeCap, test.ShouldHaveLength, 1)
-	test.That(t, ourRes4.closeCap, test.ShouldResemble, []interface{}{"bye"})
+	test.That(t, ourRes4.closeCap, test.ShouldResemble, []any{"bye"})
 
 	test.That(t, node.IsUninitialized(), test.ShouldBeTrue)
 	_, err = node.Resource()
@@ -212,7 +212,7 @@ func lifecycleTest(t *testing.T, node *resource.GraphNode, initialDeps []string)
 
 type someResource struct {
 	resource.Resource
-	closeCap  []interface{}
+	closeCap  []any
 	shoudlErr bool
 }
 

--- a/resource/matcher.go
+++ b/resource/matcher.go
@@ -29,7 +29,7 @@ func (sm SubtypeMatcher) IsMatch(r Resource) bool {
 
 // InterfaceMatcher matches resources that fulfill the given interface.
 type InterfaceMatcher struct {
-	Interface interface{}
+	Interface any
 }
 
 // IsMatch returns true if the given resource fulfills the InterfaceMatcher's Interface.

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -55,7 +55,7 @@ type Resource interface {
 	Reconfigure(ctx context.Context, deps Dependencies, conf Config) error
 
 	// DoCommand sends/receives arbitrary data
-	DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
+	DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error)
 
 	// Close must safely shut down the resource and prevent further use.
 	// Close must be idempotent.
@@ -131,7 +131,7 @@ func ContainsReservedCharacter(val string) error {
 // of all readings that it is sensing.
 type Sensor interface {
 	// Readings return data specific to the type of sensor and can be of any type.
-	Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error)
+	Readings(ctx context.Context, extra map[string]any) (map[string]any, error)
 }
 
 // Actuator is any resource that can move.
@@ -140,14 +140,14 @@ type Actuator interface {
 	IsMoving(context.Context) (bool, error)
 
 	// Stop stops all movement for the resource
-	Stop(context.Context, map[string]interface{}) error
+	Stop(context.Context, map[string]any) error
 }
 
 // Shaped is any resource that can have geometries.
 type Shaped interface {
 	// Geometries returns the list of geometries associated with the resource, in any order. The poses of the geometries reflect their
 	// current location relative to the frame of the resource.
-	Geometries(context.Context, map[string]interface{}) ([]spatialmath.Geometry, error)
+	Geometries(context.Context, map[string]any) ([]spatialmath.Geometry, error)
 }
 
 // ErrDoUnimplemented is returned if the DoCommand methods is not implemented.
@@ -200,7 +200,7 @@ func (a AlwaysRebuild) Reconfigure(ctx context.Context, deps Dependencies, conf 
 // Named is to be embedded by any resource that just needs to return a name.
 type Named interface {
 	Name() Name
-	DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
+	DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error)
 }
 
 type selfNamed struct {
@@ -213,7 +213,7 @@ func (s selfNamed) Name() Name {
 }
 
 // DoCommand always returns unimplemented but can be implemented by the embedder.
-func (s selfNamed) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (s selfNamed) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	return nil, ErrDoUnimplemented
 }
 

--- a/resource/resource_registry_test.go
+++ b/resource/resource_registry_test.go
@@ -75,12 +75,12 @@ func TestComponentRegistry(t *testing.T) {
 }
 
 func TestResourceAPIRegistry(t *testing.T) {
-	statf := func(context.Context, arm.Arm) (interface{}, error) {
+	statf := func(context.Context, arm.Arm) (any, error) {
 		return nil, errors.New("one")
 	}
 	var capColl resource.APIResourceCollection[arm.Arm]
 
-	sf := func(apiResColl resource.APIResourceCollection[arm.Arm]) interface{} {
+	sf := func(apiResColl resource.APIResourceCollection[arm.Arm]) any {
 		capColl = apiResColl
 		return 5
 	}
@@ -197,10 +197,10 @@ func (st *someType) UpdateResourceNames(updater func(old resource.Name) resource
 }
 
 func TestResourceAPIRegistryWithAssociation(t *testing.T) {
-	statf := func(context.Context, arm.Arm) (interface{}, error) {
+	statf := func(context.Context, arm.Arm) (any, error) {
 		return nil, errors.New("one")
 	}
-	sf := func(apiResColl resource.APIResourceCollection[arm.Arm]) interface{} {
+	sf := func(apiResColl resource.APIResourceCollection[arm.Arm]) any {
 		return nil
 	}
 
@@ -224,7 +224,7 @@ func TestResourceAPIRegistryWithAssociation(t *testing.T) {
 }
 
 func TestDiscoveryFunctions(t *testing.T) {
-	df := func(ctx context.Context, logger logging.Logger) (interface{}, error) {
+	df := func(ctx context.Context, logger logging.Logger) (any, error) {
 		return []resource.Discovery{}, nil
 	}
 	validAPIQuery := resource.NewDiscoveryQuery(acme.API, resource.Model{Name: "some model"})

--- a/rimage/lazy_encoded.go
+++ b/rimage/lazy_encoded.go
@@ -14,11 +14,11 @@ type LazyEncodedImage struct {
 	mimeType string
 
 	decodeOnce   sync.Once
-	decodeErr    interface{}
+	decodeErr    any
 	decodedImage image.Image
 
 	decodeConfigOnce sync.Once
-	decodeConfigErr  interface{}
+	decodeConfigErr  any
 	bounds           *image.Rectangle
 	colorModel       color.Model
 }

--- a/rimage/test_helper.go
+++ b/rimage/test_helper.go
@@ -95,7 +95,7 @@ func (pCtx *ProcessorContext) currentImgConfigFile() string {
 }
 
 // CurrentImgConfig TODO.
-func (pCtx *ProcessorContext) CurrentImgConfig(out interface{}) error {
+func (pCtx *ProcessorContext) CurrentImgConfig(out any) error {
 	fn := pCtx.currentImgConfigFile()
 
 	//nolint:gosec

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -62,7 +62,7 @@ type reconfigurableClientConn struct {
 func (c *reconfigurableClientConn) Invoke(
 	ctx context.Context,
 	method string,
-	args, reply interface{},
+	args, reply any,
 	opts ...googlegrpc.CallOption,
 ) error {
 	c.connMu.RLock()
@@ -181,7 +181,7 @@ func (rc *RobotClient) notConnectedToRemoteError() error {
 func (rc *RobotClient) handleUnaryDisconnect(
 	ctx context.Context,
 	method string,
-	req, reply interface{},
+	req, reply any,
 	cc *googlegrpc.ClientConn,
 	invoker googlegrpc.UnaryInvoker,
 	opts ...googlegrpc.CallOption,
@@ -209,7 +209,7 @@ type handleDisconnectClientStream struct {
 	*RobotClient
 }
 
-func (cs *handleDisconnectClientStream) RecvMsg(m interface{}) error {
+func (cs *handleDisconnectClientStream) RecvMsg(m any) error {
 	if err := cs.RobotClient.checkConnected(); err != nil {
 		return status.Error(codes.Unavailable, err.Error())
 	}
@@ -918,7 +918,7 @@ func (rc *RobotClient) Status(ctx context.Context, resourceNames []resource.Name
 }
 
 // StopAll cancels all current and outstanding operations for the robot and stops all actuators and movement.
-func (rc *RobotClient) StopAll(ctx context.Context, extra map[resource.Name]map[string]interface{}) error {
+func (rc *RobotClient) StopAll(ctx context.Context, extra map[resource.Name]map[string]any) error {
 	e := []*pb.StopExtraParameters{}
 	for name, params := range extra {
 		param, err := protoutils.StructToStructPb(params)

--- a/robot/client/client_session.go
+++ b/robot/client/client_session.go
@@ -172,7 +172,7 @@ func (rc *RobotClient) useSessionInRequest(ctx context.Context, method string) b
 func (rc *RobotClient) sessionUnaryClientInterceptor(
 	ctx context.Context,
 	method string,
-	req, reply interface{},
+	req, reply any,
 	cc *grpc.ClientConn,
 	invoker grpc.UnaryInvoker,
 	opts ...grpc.CallOption,
@@ -223,12 +223,12 @@ type firstMessageClientStreamWrapper struct {
 	safetyMonitorFromHeaders func(hdr metadata.MD)
 
 	mu        sync.RWMutex
-	sendMsgs  []interface{}
+	sendMsgs  []any
 	closeSend bool
 	firstRecv bool
 }
 
-func (w *firstMessageClientStreamWrapper) SendMsg(m interface{}) error {
+func (w *firstMessageClientStreamWrapper) SendMsg(m any) error {
 	w.mu.Lock()
 	if !w.firstRecv {
 		w.sendMsgs = append(w.sendMsgs, m)
@@ -244,7 +244,7 @@ func (w *firstMessageClientStreamWrapper) CloseSend() error {
 	return w.ClientStream.CloseSend()
 }
 
-func (w *firstMessageClientStreamWrapper) RecvMsg(m interface{}) error {
+func (w *firstMessageClientStreamWrapper) RecvMsg(m any) error {
 	w.mu.Lock()
 	if w.firstRecv {
 		w.mu.Unlock()

--- a/robot/client/client_session_test.go
+++ b/robot/client/client_session_test.go
@@ -46,7 +46,7 @@ var echoAPI = resource.APINamespaceRDK.WithComponentType("echo")
 
 func init() {
 	resource.RegisterAPI(echoAPI, resource.APIRegistration[resource.Resource]{
-		RPCServiceServerConstructor: func(apiResColl resource.APIResourceCollection[resource.Resource]) interface{} {
+		RPCServiceServerConstructor: func(apiResColl resource.APIResourceCollection[resource.Resource]) any {
 			return &echoServer{coll: apiResColl}
 		},
 		RPCServiceHandler: echopb.RegisterEchoResourceServiceHandlerFromEndpoint,
@@ -667,10 +667,10 @@ func (mgr *sessionManager) sessionFromMetadata(ctx context.Context) (context.Con
 
 func (mgr *sessionManager) UnaryServerInterceptor(
 	ctx context.Context,
-	req interface{},
+	req any,
 	info *grpc.UnaryServerInfo,
 	handler grpc.UnaryHandler,
-) (interface{}, error) {
+) (any, error) {
 	ctx, err := mgr.sessionFromMetadata(ctx)
 	if err != nil {
 		return nil, err
@@ -681,7 +681,7 @@ func (mgr *sessionManager) UnaryServerInterceptor(
 // StreamServerInterceptor associates the current session (if present) in the current context before
 // passing it to the stream response handler.
 func (mgr *sessionManager) StreamServerInterceptor(
-	srv interface{},
+	srv any,
 	ss grpc.ServerStream,
 	info *grpc.StreamServerInfo,
 	handler grpc.StreamHandler,

--- a/robot/framesystem/framesystem.go
+++ b/robot/framesystem/framesystem.go
@@ -82,7 +82,7 @@ type Config struct {
 func (cfg Config) String() string {
 	t := table.NewWriter()
 	t.AppendHeader(table.Row{"#", "Name", "Parent", "Translation", "Orientation", "Geometry"})
-	t.AppendRow([]interface{}{"0", referenceframe.World, "", "", "", ""})
+	t.AppendRow([]any{"0", referenceframe.World, "", "", "", ""})
 	for i, part := range cfg.Parts {
 		pose := part.FrameConfig.Pose()
 		tra := pose.Point()
@@ -91,7 +91,7 @@ func (cfg Config) String() string {
 		if gc := part.FrameConfig.Geometry(); gc != nil {
 			geomString = gc.String()
 		}
-		t.AppendRow([]interface{}{
+		t.AppendRow([]any{
 			fmt.Sprintf("%d", i+1),
 			part.FrameConfig.Name(),
 			part.FrameConfig.Parent(),

--- a/robot/impl/discovery_test.go
+++ b/robot/impl/discovery_test.go
@@ -45,7 +45,7 @@ var (
 
 	missingQ = resource.NewDiscoveryQuery(failAPI, resource.DefaultModelFamily.WithModel("missing"))
 
-	workingDiscovery = map[string]interface{}{"position": "up"}
+	workingDiscovery = map[string]any{"position": "up"}
 	errFailed        = errors.New("can't get discovery")
 )
 
@@ -56,7 +56,7 @@ func init() {
 		) (resource.Resource, error) {
 			return nil, errors.New("no")
 		},
-		Discover: func(ctx context.Context, logger logging.Logger) (interface{}, error) {
+		Discover: func(ctx context.Context, logger logging.Logger) (any, error) {
 			return workingDiscovery, nil
 		},
 	})
@@ -67,7 +67,7 @@ func init() {
 		) (resource.Resource, error) {
 			return nil, errors.New("no")
 		},
-		Discover: func(ctx context.Context, logger logging.Logger) (interface{}, error) {
+		Discover: func(ctx context.Context, logger logging.Logger) (any, error) {
 			return nil, errFailed
 		},
 	})

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -158,7 +158,7 @@ func (r *localRobot) Close(ctx context.Context) error {
 }
 
 // StopAll cancels all current and outstanding operations for the robot and stops all actuators and movement.
-func (r *localRobot) StopAll(ctx context.Context, extra map[resource.Name]map[string]interface{}) error {
+func (r *localRobot) StopAll(ctx context.Context, extra map[resource.Name]map[string]any) error {
 	// Stop all operations
 	for _, op := range r.OperationManager().All() {
 		op.Cancel()
@@ -321,7 +321,7 @@ func (r *localRobot) Status(ctx context.Context, resourceNames []resource.Name) 
 
 			// If resource API registration had an associated CreateStatus method,
 			// call that method, otherwise return an empty status.
-			var status interface{} = map[string]interface{}{}
+			var status any = map[string]any{}
 			if apiReg, ok := resource.LookupGenericAPIRegistration(name.API); ok &&
 				apiReg.Status != nil {
 				status, err = apiReg.Status(ctx, res)
@@ -1001,7 +1001,7 @@ type moduleManagerDiscoveryResult struct {
 
 // discoverRobotInternals is used to discover parts of the robot that are not in the resource graph
 // It accepts a query and should return the Discovery Results object along with an ok value.
-func (r *localRobot) discoverRobotInternals(query resource.DiscoveryQuery) (interface{}, bool) {
+func (r *localRobot) discoverRobotInternals(query resource.DiscoveryQuery) (any, bool) {
 	switch {
 	// these strings are hardcoded because their existence would be misleading anywhere outside of this function
 	case query.API.String() == "rdk-internal:service:module-manager" &&

--- a/robot/impl/resource_manager_modular_test.go
+++ b/robot/impl/resource_manager_modular_test.go
@@ -513,7 +513,7 @@ func TestDynamicModuleLogging(t *testing.T) {
 	// 2023-12-06T15:55:32.590-0500	INFO	process.helperModule_/tmp/TestDynamicModuleLogging3790223620/001/testmodule.StdOut	pexec/managed_process.go:244
 	// \_ 2023-12-06T15:55:32.590-0500	INFO	TestModule.rdk:component:generic/helper	testmodule/main.go:147	special rare log line
 	logLine := "special rare log line"
-	testCmd := map[string]interface{}{"command": "log", "msg": logLine, "level": "info"}
+	testCmd := map[string]any{"command": "log", "msg": logLine, "level": "info"}
 	_, err = client.DoCommand(ctx, testCmd)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -525,7 +525,7 @@ func TestDynamicModuleLogging(t *testing.T) {
 
 	// The module is currently configured to log at info. If the module tries to log at debug,
 	// nothing new should be observed.
-	testCmd = map[string]interface{}{"command": "log", "msg": logLine, "level": "debug"}
+	testCmd = map[string]any{"command": "log", "msg": logLine, "level": "debug"}
 	_, err = client.DoCommand(ctx, testCmd)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -538,7 +538,7 @@ func TestDynamicModuleLogging(t *testing.T) {
 
 	// Trying to log again at DEBUG should see our log line pattern show up a second time. Now with
 	// DEBUG in the output string.
-	testCmd = map[string]interface{}{"command": "log", "msg": logLine, "level": "debug"}
+	testCmd = map[string]any{"command": "log", "msg": logLine, "level": "debug"}
 	_, err = client.DoCommand(ctx, testCmd)
 	test.That(t, err, test.ShouldBeNil)
 

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -503,7 +503,7 @@ func TestManagerAdd(t *testing.T) {
 		grabPose *referenceframe.PoseInFrame,
 		worldState *referenceframe.WorldState,
 		constraints *motionpb.Constraints,
-		extra map[string]interface{},
+		extra map[string]any,
 	) (bool, error) {
 		return false, nil
 	}
@@ -517,7 +517,7 @@ func TestManagerAdd(t *testing.T) {
 	injectVisionService.GetObjectPointCloudsFunc = func(
 		ctx context.Context,
 		cameraName string,
-		extra map[string]interface{},
+		extra map[string]any,
 	) ([]*viz.Object, error) {
 		return []*viz.Object{viz.NewEmptyObject()}, nil
 	}
@@ -1842,7 +1842,7 @@ func (rr *dummyRobot) Close(ctx context.Context) error {
 	return rr.robot.Close(ctx)
 }
 
-func (rr *dummyRobot) StopAll(ctx context.Context, extra map[resource.Name]map[string]interface{}) error {
+func (rr *dummyRobot) StopAll(ctx context.Context, extra map[resource.Name]map[string]any) error {
 	return rr.robot.StopAll(ctx, extra)
 }
 

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -2276,13 +2276,13 @@ func TestSensorsServiceReconfigure(t *testing.T) {
 		svc, err := sensors.FromRobot(robot, resource.DefaultServiceName)
 		test.That(t, err, test.ShouldBeNil)
 
-		foundSensors, err := svc.Sensors(context.Background(), map[string]interface{}{})
+		foundSensors, err := svc.Sensors(context.Background(), map[string]any{})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, foundSensors, test.ShouldBeEmpty)
 
 		robot.Reconfigure(context.Background(), cfg)
 
-		foundSensors, err = svc.Sensors(context.Background(), map[string]interface{}{})
+		foundSensors, err = svc.Sensors(context.Background(), map[string]any{})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, rdktestutils.NewResourceNameSet(foundSensors...), test.ShouldResemble, rdktestutils.NewResourceNameSet(sensorNames...))
 	})
@@ -2297,13 +2297,13 @@ func TestSensorsServiceReconfigure(t *testing.T) {
 		svc, err := sensors.FromRobot(robot, resource.DefaultServiceName)
 		test.That(t, err, test.ShouldBeNil)
 
-		foundSensors, err := svc.Sensors(context.Background(), map[string]interface{}{})
+		foundSensors, err := svc.Sensors(context.Background(), map[string]any{})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, rdktestutils.NewResourceNameSet(foundSensors...), test.ShouldResemble, rdktestutils.NewResourceNameSet(sensorNames...))
 
 		robot.Reconfigure(context.Background(), emptyCfg)
 
-		foundSensors, err = svc.Sensors(context.Background(), map[string]interface{}{})
+		foundSensors, err = svc.Sensors(context.Background(), map[string]any{})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, foundSensors, test.ShouldBeEmpty)
 	})
@@ -2318,13 +2318,13 @@ func TestSensorsServiceReconfigure(t *testing.T) {
 		svc, err := sensors.FromRobot(robot, resource.DefaultServiceName)
 		test.That(t, err, test.ShouldBeNil)
 
-		foundSensors, err := svc.Sensors(context.Background(), map[string]interface{}{})
+		foundSensors, err := svc.Sensors(context.Background(), map[string]any{})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, rdktestutils.NewResourceNameSet(foundSensors...), test.ShouldResemble, rdktestutils.NewResourceNameSet(sensorNames...))
 
 		robot.Reconfigure(context.Background(), cfg)
 
-		foundSensors, err = svc.Sensors(context.Background(), map[string]interface{}{})
+		foundSensors, err = svc.Sensors(context.Background(), map[string]any{})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, rdktestutils.NewResourceNameSet(foundSensors...), test.ShouldResemble, rdktestutils.NewResourceNameSet(sensorNames...))
 	})
@@ -2664,9 +2664,9 @@ func TestStatusServiceUpdate(t *testing.T) {
 		movementsensor.Named("movement_sensor1"),
 		movementsensor.Named("movement_sensor2"),
 	}
-	expected := map[resource.Name]interface{}{
-		movementsensor.Named("movement_sensor1"): map[string]interface{}{},
-		movementsensor.Named("movement_sensor2"): map[string]interface{}{},
+	expected := map[resource.Name]any{
+		movementsensor.Named("movement_sensor1"): map[string]any{},
+		movementsensor.Named("movement_sensor2"): map[string]any{},
 	}
 
 	t.Run("empty to not empty", func(t *testing.T) {

--- a/robot/robot.go
+++ b/robot/robot.go
@@ -84,7 +84,7 @@ type Robot interface {
 	Close(ctx context.Context) error
 
 	// StopAll cancels all current and outstanding operations for the robot and stops all actuators and movement
-	StopAll(ctx context.Context, extra map[resource.Name]map[string]interface{}) error
+	StopAll(ctx context.Context, extra map[resource.Name]map[string]any) error
 }
 
 // A LocalRobot is a Robot that can have its parts modified.
@@ -133,7 +133,7 @@ type RemoteRobot interface {
 type Status struct {
 	Name             resource.Name
 	LastReconfigured time.Time
-	Status           interface{}
+	Status           any
 }
 
 // AllResourcesByName returns an array of all resources that have this short name.
@@ -200,7 +200,7 @@ func ResourceFromProtoMessage(
 	robot Robot,
 	msg *dynamic.Message,
 	api resource.API,
-) (interface{}, resource.Name, error) {
+) (any, resource.Name, error) {
 	// we assume a convention that there will be a field called name that will be the resource
 	// name and a string.
 	if !msg.HasFieldName("name") {

--- a/robot/server/server.go
+++ b/robot/server/server.go
@@ -91,7 +91,7 @@ func (s *Server) GetOperations(ctx context.Context, req *pb.GetOperationsRequest
 	return res, nil
 }
 
-func convertInterfaceToStruct(i interface{}) (*structpb.Struct, error) {
+func convertInterfaceToStruct(i any) (*structpb.Struct, error) {
 	if i == nil {
 		return &structpb.Struct{}, nil
 	}
@@ -339,7 +339,7 @@ func (s *Server) StreamStatus(req *pb.StreamStatusRequest, streamServer pb.Robot
 
 // StopAll will stop all current and outstanding operations for the robot and stops all actuators and movement.
 func (s *Server) StopAll(ctx context.Context, req *pb.StopAllRequest) (*pb.StopAllResponse, error) {
-	extra := map[resource.Name]map[string]interface{}{}
+	extra := map[resource.Name]map[string]any{}
 	for _, e := range req.Extra {
 		extra[protoutils.ResourceNameFromProto(e.Name)] = e.Params.AsMap()
 	}

--- a/robot/server/server_test.go
+++ b/robot/server/server_test.go
@@ -96,7 +96,7 @@ func TestServer(t *testing.T) {
 			test.That(t, len(resp.Discovery), test.ShouldEqual, 1)
 
 			observed := resp.Discovery[0].Results.AsMap()
-			expected := map[string]interface{}{}
+			expected := map[string]any{}
 			expectedQ := &pb.DiscoveryQuery{Subtype: "rdk:component:arm", Model: "rdk:builtin:some-arm"}
 			test.That(t, resp.Discovery[0].Query, test.ShouldResemble, expectedQ)
 			test.That(t, observed, test.ShouldResemble, expected)
@@ -111,7 +111,7 @@ func TestServer(t *testing.T) {
 			test.That(t, len(resp.Discovery), test.ShouldEqual, 1)
 
 			observed := resp.Discovery[0].Results.AsMap()
-			expected := map[string]interface{}{}
+			expected := map[string]any{}
 			expectedQ := &pb.DiscoveryQuery{Subtype: "arm", Model: "some-arm"}
 			test.That(t, resp.Discovery[0].Query, test.ShouldResemble, expectedQ)
 			test.That(t, observed, test.ShouldResemble, expected)
@@ -445,8 +445,8 @@ func TestServerGetStatus(t *testing.T) {
 			Status:           struct{}{},
 		}
 		readings := []robot.Status{aStatus}
-		expected := map[resource.Name]interface{}{
-			aStatus.Name: map[string]interface{}{},
+		expected := map[resource.Name]any{
+			aStatus.Name: map[string]any{},
 		}
 		expectedLR := map[resource.Name]time.Time{
 			aStatus.Name: lastReconfigured,
@@ -468,7 +468,7 @@ func TestServerGetStatus(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, len(resp.Status), test.ShouldEqual, 1)
 
-		observed := map[resource.Name]interface{}{
+		observed := map[resource.Name]any{
 			protoutils.ResourceNameFromProto(resp.Status[0].Name): resp.Status[0].Status.AsMap(),
 		}
 		observedLR := map[resource.Name]time.Time{
@@ -485,7 +485,7 @@ func TestServerGetStatus(t *testing.T) {
 		gStatus := robot.Status{
 			Name:             movementsensor.Named("gps"),
 			LastReconfigured: lastReconfigured,
-			Status:           map[string]interface{}{"efg": []string{"hello"}},
+			Status:           map[string]any{"efg": []string{"hello"}},
 		}
 		aStatus := robot.Status{
 			Name:             arm.Named("arm"),
@@ -493,9 +493,9 @@ func TestServerGetStatus(t *testing.T) {
 			Status:           struct{}{},
 		}
 		statuses := []robot.Status{gStatus, aStatus}
-		expected := map[resource.Name]interface{}{
-			gStatus.Name: map[string]interface{}{"efg": []interface{}{"hello"}},
-			aStatus.Name: map[string]interface{}{},
+		expected := map[resource.Name]any{
+			gStatus.Name: map[string]any{"efg": []any{"hello"}},
+			aStatus.Name: map[string]any{},
 		}
 		expectedLRs := map[resource.Name]time.Time{
 			gStatus.Name: lastReconfigured,
@@ -521,7 +521,7 @@ func TestServerGetStatus(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, len(resp.Status), test.ShouldEqual, 2)
 
-		observed := map[resource.Name]interface{}{
+		observed := map[resource.Name]any{
 			protoutils.ResourceNameFromProto(resp.Status[0].Name): resp.Status[0].Status.AsMap(),
 			protoutils.ResourceNameFromProto(resp.Status[1].Name): resp.Status[1].Status.AsMap(),
 		}
@@ -623,7 +623,7 @@ func TestServerGetStatus(t *testing.T) {
 			streamErr = server.StreamStatus(&pb.StreamStatusRequest{Every: durationpb.New(dur)}, streamServer)
 			close(done)
 		}()
-		expectedStatus, err := vprotoutils.StructToStructPb(map[string]interface{}{})
+		expectedStatus, err := vprotoutils.StructToStructPb(map[string]any{})
 		test.That(t, err, test.ShouldBeNil)
 		var messages []*pb.StreamStatusResponse
 		messages = append(messages, <-messageCh)

--- a/robot/session_test.go
+++ b/robot/session_test.go
@@ -42,7 +42,7 @@ var echoAPI = resource.APINamespaceRDK.WithComponentType("echo")
 
 func init() {
 	resource.RegisterAPI(echoAPI, resource.APIRegistration[resource.Resource]{
-		RPCServiceServerConstructor: func(apiResColl resource.APIResourceCollection[resource.Resource]) interface{} {
+		RPCServiceServerConstructor: func(apiResColl resource.APIResourceCollection[resource.Resource]) any {
 			return &echoServer{coll: apiResColl}
 		},
 		RPCServiceHandler: echopb.RegisterTestEchoServiceHandlerFromEndpoint,
@@ -809,38 +809,38 @@ type dummyMotor struct {
 	stopCh chan struct{}
 }
 
-func (dm *dummyMotor) SetPower(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
+func (dm *dummyMotor) SetPower(ctx context.Context, powerPct float64, extra map[string]any) error {
 	return nil
 }
 
-func (dm *dummyMotor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]interface{}) error {
+func (dm *dummyMotor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]any) error {
 	return nil
 }
 
-func (dm *dummyMotor) GoTo(ctx context.Context, rpm, positionRevolutions float64, extra map[string]interface{}) error {
+func (dm *dummyMotor) GoTo(ctx context.Context, rpm, positionRevolutions float64, extra map[string]any) error {
 	return nil
 }
 
-func (dm *dummyMotor) Position(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (dm *dummyMotor) Position(ctx context.Context, extra map[string]any) (float64, error) {
 	return 2, nil
 }
 
-func (dm *dummyMotor) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (dm *dummyMotor) Stop(ctx context.Context, extra map[string]any) error {
 	dm.mu.Lock()
 	defer dm.mu.Unlock()
 	close(dm.stopCh)
 	return nil
 }
 
-func (dm *dummyMotor) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]interface{}) error {
+func (dm *dummyMotor) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]any) error {
 	return nil
 }
 
-func (dm *dummyMotor) Properties(ctx context.Context, extra map[string]interface{}) (motor.Properties, error) {
+func (dm *dummyMotor) Properties(ctx context.Context, extra map[string]any) (motor.Properties, error) {
 	return motor.Properties{}, nil
 }
 
-func (dm *dummyMotor) IsPowered(ctx context.Context, extra map[string]interface{}) (bool, float64, error) {
+func (dm *dummyMotor) IsPowered(ctx context.Context, extra map[string]any) (bool, float64, error) {
 	return false, 0, nil
 }
 
@@ -856,26 +856,26 @@ type dummyBase struct {
 	stopCh chan struct{}
 }
 
-func (db *dummyBase) SetPower(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error {
+func (db *dummyBase) SetPower(ctx context.Context, linear, angular r3.Vector, extra map[string]any) error {
 	return nil
 }
 
-func (db *dummyBase) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (db *dummyBase) Stop(ctx context.Context, extra map[string]any) error {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 	close(db.stopCh)
 	return nil
 }
 
-func (db *dummyBase) MoveStraight(ctx context.Context, distanceMm int, mmPerSec float64, extra map[string]interface{}) error {
+func (db *dummyBase) MoveStraight(ctx context.Context, distanceMm int, mmPerSec float64, extra map[string]any) error {
 	return nil
 }
 
-func (db *dummyBase) Spin(ctx context.Context, angleDeg, degsPerSec float64, extra map[string]interface{}) error {
+func (db *dummyBase) Spin(ctx context.Context, angleDeg, degsPerSec float64, extra map[string]any) error {
 	return nil
 }
 
-func (db *dummyBase) SetVelocity(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error {
+func (db *dummyBase) SetVelocity(ctx context.Context, linear, angular r3.Vector, extra map[string]any) error {
 	return nil
 }
 
@@ -883,11 +883,11 @@ func (db *dummyBase) IsMoving(context.Context) (bool, error) {
 	return false, nil
 }
 
-func (db *dummyBase) Properties(ctx context.Context, extra map[string]interface{}) (base.Properties, error) {
+func (db *dummyBase) Properties(ctx context.Context, extra map[string]any) (base.Properties, error) {
 	return base.Properties{}, nil
 }
 
-func (db *dummyBase) Geometries(ctx context.Context, extra map[string]interface{}) ([]spatialmath.Geometry, error) {
+func (db *dummyBase) Geometries(ctx context.Context, extra map[string]any) ([]spatialmath.Geometry, error) {
 	return []spatialmath.Geometry{}, nil
 }
 
@@ -915,7 +915,7 @@ type dummyClient struct {
 	client echopb.TestEchoServiceClient
 }
 
-func (c *dummyClient) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (c *dummyClient) Stop(ctx context.Context, extra map[string]any) error {
 	_, err := c.client.Stop(ctx, &echopb.StopRequest{Name: c.name})
 	return err
 }
@@ -937,7 +937,7 @@ func (e *dummyEcho) EchoMultiple(ctx context.Context) error {
 	return nil
 }
 
-func (e *dummyEcho) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (e *dummyEcho) Stop(ctx context.Context, extra map[string]any) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	close(e.stopCh)

--- a/robot/session_web.go
+++ b/robot/session_web.go
@@ -35,7 +35,7 @@ func (m *SessionManager) safetyMonitoredTypeAndMethod(method string) (*resource.
 	return subType, methodDesc, true
 }
 
-func (m *SessionManager) safetyMonitoredResourceFromUnary(req interface{}, method string) resource.Name {
+func (m *SessionManager) safetyMonitoredResourceFromUnary(req any, method string) resource.Name {
 	subType, _, ok := m.safetyMonitoredTypeAndMethod(method)
 	if !ok {
 		return resource.Name{}
@@ -66,7 +66,7 @@ type firstMessageServerStreamWrapper struct {
 	firstMsg *dynamic.Message
 }
 
-func (w *firstMessageServerStreamWrapper) RecvMsg(m interface{}) error {
+func (w *firstMessageServerStreamWrapper) RecvMsg(m any) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.firstMsg != nil {
@@ -135,10 +135,10 @@ func (m *SessionManager) ServerInterceptors() session.ServerInterceptors {
 // passing it to the unary response handler.
 func (m *SessionManager) UnaryServerInterceptor(
 	ctx context.Context,
-	req interface{},
+	req any,
 	info *grpc.UnaryServerInfo,
 	handler grpc.UnaryHandler,
-) (interface{}, error) {
+) (any, error) {
 	if exemptFromSession[info.FullMethod] {
 		return handler(ctx, req)
 	}
@@ -153,7 +153,7 @@ func (m *SessionManager) UnaryServerInterceptor(
 // StreamServerInterceptor associates the current session (if present) in the current context before
 // passing it to the stream response handler.
 func (m *SessionManager) StreamServerInterceptor(
-	srv interface{},
+	srv any,
 	ss grpc.ServerStream,
 	info *grpc.StreamServerInfo,
 	handler grpc.StreamHandler,

--- a/robot/web/web_test.go
+++ b/robot/web/web_test.go
@@ -759,7 +759,7 @@ func TestWebReconfigure(t *testing.T) {
 	// add arm to robot and then update
 	injectArm := &inject.Arm{}
 	newPos := spatialmath.NewPoseFromPoint(r3.Vector{X: 1, Y: 3, Z: 6})
-	injectArm.EndPositionFunc = func(ctx context.Context, extra map[string]interface{}) (spatialmath.Pose, error) {
+	injectArm.EndPositionFunc = func(ctx context.Context, extra map[string]any) (spatialmath.Pose, error) {
 		return newPos, nil
 	}
 	rs := map[resource.Name]resource.Resource{arm.Named(arm1String): injectArm}
@@ -825,7 +825,7 @@ func TestWebReconfigure(t *testing.T) {
 	arm2 := "arm2"
 	injectArm2 := &inject.Arm{}
 	pos2 := spatialmath.NewPoseFromPoint(r3.Vector{X: 2, Y: 3, Z: 4})
-	injectArm2.EndPositionFunc = func(ctx context.Context, extra map[string]interface{}) (spatialmath.Pose, error) {
+	injectArm2.EndPositionFunc = func(ctx context.Context, extra map[string]any) (spatialmath.Pose, error) {
 		return pos2, nil
 	}
 	rs[arm.Named(arm2)] = injectArm2
@@ -1000,7 +1000,7 @@ func setupRobotCtx(t *testing.T) (context.Context, robot.Robot) {
 	t.Helper()
 
 	injectArm := &inject.Arm{}
-	injectArm.EndPositionFunc = func(ctx context.Context, extra map[string]interface{}) (spatialmath.Pose, error) {
+	injectArm.EndPositionFunc = func(ctx context.Context, extra map[string]any) (spatialmath.Pose, error) {
 		return pos, nil
 	}
 	injectRobot := &inject.Robot{}
@@ -1139,7 +1139,7 @@ func TestRawClientOperation(t *testing.T) {
 	// Need an unfiltered streaming call to test interceptors
 	echoAPI := resource.NewAPI("rdk", "component", "echo")
 	resource.RegisterAPI(echoAPI, resource.APIRegistration[resource.Resource]{
-		RPCServiceServerConstructor: func(apiResColl resource.APIResourceCollection[resource.Resource]) interface{} { return &echoServer{} },
+		RPCServiceServerConstructor: func(apiResColl resource.APIResourceCollection[resource.Resource]) any { return &echoServer{} },
 		RPCServiceHandler:           echopb.RegisterTestEchoServiceHandlerFromEndpoint,
 		RPCServiceDesc:              &echopb.TestEchoService_ServiceDesc,
 	})
@@ -1373,7 +1373,7 @@ func signJWKBasedExternalAccessToken(
 	entity, aud, iss, keyID string,
 ) (string, error) {
 	token := &jwt.Token{
-		Header: map[string]interface{}{
+		Header: map[string]any{
 			"typ": "JWT",
 			"alg": jwt.SigningMethodRS256.Alg(),
 			"kid": keyID,

--- a/ros/rosbag_parser.go
+++ b/ros/rosbag_parser.go
@@ -66,7 +66,7 @@ func WriteTopicsJSON(rb *rosbag.RosBag, startTime, endTime int64, topicsFilter [
 }
 
 // AllMessagesForTopic returns all messages for a specific topic in the ros bag.
-func AllMessagesForTopic(rb *rosbag.RosBag, topic string) ([]map[string]interface{}, error) {
+func AllMessagesForTopic(rb *rosbag.RosBag, topic string) ([]map[string]any, error) {
 	if err := rb.ParseTopicsToJSON(
 		"",
 		func(int64) bool { return true },
@@ -81,7 +81,7 @@ func AllMessagesForTopic(rb *rosbag.RosBag, topic string) ([]map[string]interfac
 		return nil, errors.Errorf("no messages for topic %s", topic)
 	}
 
-	all := []map[string]interface{}{}
+	all := []map[string]any{}
 
 	for {
 		data, err := msgs.ReadBytes('\n')
@@ -91,7 +91,7 @@ func AllMessagesForTopic(rb *rosbag.RosBag, topic string) ([]map[string]interfac
 			}
 			return nil, err
 		}
-		message := map[string]interface{}{}
+		message := map[string]any{}
 		err = json.Unmarshal(data, &message)
 		if err != nil {
 			return nil, err

--- a/services/baseremotecontrol/builtin/builtin.go
+++ b/services/baseremotecontrol/builtin/builtin.go
@@ -210,7 +210,7 @@ func (svc *builtIn) registerCallbacks(ctx context.Context, state *throttleState)
 		// Connect and Disconnect events should both stop the base completely.
 		svc.mu.RLock()
 		defer svc.mu.RUnlock()
-		err := svc.base.Stop(ctx, map[string]interface{}{})
+		err := svc.base.Stop(ctx, map[string]any{})
 		if err != nil {
 			svc.logger.CError(ctx, err)
 		}
@@ -231,14 +231,14 @@ func (svc *builtIn) registerCallbacks(ctx context.Context, state *throttleState)
 					control,
 					[]input.EventType{input.ButtonChange},
 					remoteCtl,
-					map[string]interface{}{},
+					map[string]any{},
 				)
 			} else {
 				err = svc.inputController.RegisterControlCallback(ctx,
 					control,
 					[]input.EventType{input.PositionChangeAbs},
 					remoteCtl,
-					map[string]interface{}{},
+					map[string]any{},
 				)
 			}
 			if err != nil {
@@ -248,7 +248,7 @@ func (svc *builtIn) registerCallbacks(ctx context.Context, state *throttleState)
 				control,
 				[]input.EventType{input.Connect, input.Disconnect},
 				connect,
-				map[string]interface{}{},
+				map[string]any{},
 			)
 			if err != nil {
 				return err

--- a/services/baseremotecontrol/builtin/builtin_ext_test.go
+++ b/services/baseremotecontrol/builtin/builtin_ext_test.go
@@ -34,7 +34,7 @@ func TestSafetyMonitoring(t *testing.T) {
 	injectBase := inject.NewBase(myBaseName.ShortName())
 
 	setPowerFirst := make(chan struct{})
-	injectBase.SetPowerFunc = func(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error {
+	injectBase.SetPowerFunc = func(ctx context.Context, linear, angular r3.Vector, extra map[string]any) error {
 		close(setPowerFirst)
 		return nil
 	}
@@ -51,7 +51,7 @@ func TestSafetyMonitoring(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	type triggerer interface {
-		TriggerEvent(ctx context.Context, event input.Event, extra map[string]interface{}) error
+		TriggerEvent(ctx context.Context, event input.Event, extra map[string]any) error
 	}
 	test.That(t, gamepad.(triggerer).TriggerEvent(ctx, input.Event{
 		Event:   input.PositionChangeAbs,
@@ -63,7 +63,7 @@ func TestSafetyMonitoring(t *testing.T) {
 
 	safetyFirst := make(chan struct{})
 	setPowerSecond := make(chan struct{})
-	injectBase.SetPowerFunc = func(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error {
+	injectBase.SetPowerFunc = func(ctx context.Context, linear, angular r3.Vector, extra map[string]any) error {
 		<-safetyFirst
 		close(setPowerSecond)
 		return nil
@@ -115,7 +115,7 @@ func TestConnectStopsBase(t *testing.T) {
 	t.Run("connect", func(t *testing.T) {
 		// Use an injected Stop function and a channel to ensure stop is called on connect.
 		stop := make(chan struct{})
-		injectBase.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
+		injectBase.StopFunc = func(ctx context.Context, extra map[string]any) error {
 			close(stop)
 			return nil
 		}
@@ -132,7 +132,7 @@ func TestConnectStopsBase(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		type triggerer interface {
-			TriggerEvent(ctx context.Context, event input.Event, extra map[string]interface{}) error
+			TriggerEvent(ctx context.Context, event input.Event, extra map[string]any) error
 		}
 		test.That(t, gamepad.(triggerer).TriggerEvent(ctx, input.Event{
 			Event:   input.Connect,
@@ -147,7 +147,7 @@ func TestConnectStopsBase(t *testing.T) {
 	t.Run("disconnect", func(t *testing.T) {
 		// Use an injected Stop function and a channel to ensure stop is called on disconnect.
 		stop := make(chan struct{})
-		injectBase.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
+		injectBase.StopFunc = func(ctx context.Context, extra map[string]any) error {
 			close(stop)
 			return nil
 		}
@@ -164,7 +164,7 @@ func TestConnectStopsBase(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		type triggerer interface {
-			TriggerEvent(ctx context.Context, event input.Event, extra map[string]interface{}) error
+			TriggerEvent(ctx context.Context, event input.Event, extra map[string]any) error
 		}
 		test.That(t, gamepad.(triggerer).TriggerEvent(ctx, input.Event{
 			Event:   input.Disconnect,
@@ -188,7 +188,7 @@ func TestReconfigure(t *testing.T) {
 	injectBase := inject.NewBase(myBaseName.ShortName())
 
 	setPowerVal := make(chan r3.Vector)
-	injectBase.SetPowerFunc = func(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error {
+	injectBase.SetPowerFunc = func(ctx context.Context, linear, angular r3.Vector, extra map[string]any) error {
 		setPowerVal <- angular
 		return nil
 	}
@@ -205,7 +205,7 @@ func TestReconfigure(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	type triggerer interface {
-		TriggerEvent(ctx context.Context, event input.Event, extra map[string]interface{}) error
+		TriggerEvent(ctx context.Context, event input.Event, extra map[string]any) error
 	}
 
 	test.That(t, gamepad.(triggerer).TriggerEvent(ctx, input.Event{
@@ -280,7 +280,7 @@ func TestReconfigure(t *testing.T) {
 	injectBase2 := inject.NewBase(myBaseName2.ShortName())
 
 	setPowerVal2 := make(chan r3.Vector)
-	injectBase2.SetPowerFunc = func(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error {
+	injectBase2.SetPowerFunc = func(ctx context.Context, linear, angular r3.Vector, extra map[string]any) error {
 		setPowerVal2 <- angular
 		return nil
 	}

--- a/services/baseremotecontrol/builtin/builtin_test.go
+++ b/services/baseremotecontrol/builtin/builtin_test.go
@@ -43,7 +43,7 @@ func TestBaseRemoteControl(t *testing.T) {
 		control input.Control,
 		triggers []input.EventType,
 		ctrlFunc input.ControlFunction,
-		extra map[string]interface{},
+		extra map[string]any,
 	) error {
 		return nil
 	}

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -35,7 +35,7 @@ func init() {
 		resource.DefaultServiceModel,
 		resource.Registration[datamanager.Service, *Config]{
 			Constructor: NewBuiltIn,
-			AssociatedConfigLinker: func(conf *Config, resAssociation interface{}) error {
+			AssociatedConfigLinker: func(conf *Config, resAssociation any) error {
 				capConf, err := utils.AssertType[*datamanager.DataCaptureConfigs](resAssociation)
 				if err != nil {
 					return err
@@ -370,7 +370,7 @@ func (svc *builtIn) initSyncer(ctx context.Context) error {
 // Sync performs a non-scheduled sync of the data in the capture directory.
 // If automated sync is also enabled, calling Sync will upload the files,
 // regardless of whether or not is the scheduled time.
-func (svc *builtIn) Sync(ctx context.Context, _ map[string]interface{}) error {
+func (svc *builtIn) Sync(ctx context.Context, _ map[string]any) error {
 	svc.lock.Lock()
 	if svc.syncer == nil {
 		err := svc.initSyncer(ctx)

--- a/services/datamanager/builtin/builtin_test.go
+++ b/services/datamanager/builtin/builtin_test.go
@@ -38,13 +38,13 @@ func getInjectedRobot() *inject.Robot {
 	}
 
 	injectedArm := &inject.Arm{}
-	injectedArm.EndPositionFunc = func(ctx context.Context, extra map[string]interface{}) (spatialmath.Pose, error) {
+	injectedArm.EndPositionFunc = func(ctx context.Context, extra map[string]any) (spatialmath.Pose, error) {
 		return spatialmath.NewPoseFromPoint(r3.Vector{X: 1, Y: 2, Z: 3}), nil
 	}
 	rs[arm.Named("arm1")] = injectedArm
 
 	injectedRemoteArm := &inject.Arm{}
-	injectedRemoteArm.EndPositionFunc = func(ctx context.Context, extra map[string]interface{}) (spatialmath.Pose, error) {
+	injectedRemoteArm.EndPositionFunc = func(ctx context.Context, extra map[string]any) (spatialmath.Pose, error) {
 		return spatialmath.NewZeroPose(), nil
 	}
 	rs[arm.Named("remote1:remoteArm")] = injectedRemoteArm

--- a/services/datamanager/builtin/capture_test.go
+++ b/services/datamanager/builtin/capture_test.go
@@ -235,7 +235,7 @@ func TestSwitchResource(t *testing.T) {
 	for resource := range resources {
 		if resource.Name == "arm1" {
 			newResource := inject.NewArm(resource.Name)
-			newResource.EndPositionFunc = func(ctx context.Context, extra map[string]interface{}) (spatialmath.Pose, error) {
+			newResource.EndPositionFunc = func(ctx context.Context, extra map[string]any) (spatialmath.Pose, error) {
 				// Return a different value from the initial arm1 resource.
 				return spatialmath.NewPoseFromPoint(r3.Vector{X: 888, Y: 888, Z: 888}), nil
 			}

--- a/services/datamanager/client.go
+++ b/services/datamanager/client.go
@@ -41,7 +41,7 @@ func NewClientFromConn(
 	return c, nil
 }
 
-func (c *client) Sync(ctx context.Context, extra map[string]interface{}) error {
+func (c *client) Sync(ctx context.Context, extra map[string]any) error {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return err
@@ -53,6 +53,6 @@ func (c *client) Sync(ctx context.Context, extra map[string]interface{}) error {
 	return nil
 }
 
-func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (c *client) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	return rprotoutils.DoFromResourceClient(ctx, c.client, c.name, cmd)
 }

--- a/services/datamanager/client_test.go
+++ b/services/datamanager/client_test.go
@@ -26,7 +26,7 @@ func TestClient(t *testing.T) {
 	rpcServer, err := rpc.NewServer(logger.AsZap(), rpc.WithUnauthenticated())
 	test.That(t, err, test.ShouldBeNil)
 
-	var extraOptions map[string]interface{}
+	var extraOptions map[string]any
 
 	injectDS := &inject.DataManagerService{}
 	svcName := datamanager.Named(testDataManagerServiceName)
@@ -60,11 +60,11 @@ func TestClient(t *testing.T) {
 		client, err := datamanager.NewClientFromConn(context.Background(), conn, "", svcName, logger)
 		test.That(t, err, test.ShouldBeNil)
 
-		injectDS.SyncFunc = func(ctx context.Context, extra map[string]interface{}) error {
+		injectDS.SyncFunc = func(ctx context.Context, extra map[string]any) error {
 			extraOptions = extra
 			return nil
 		}
-		extra := map[string]interface{}{"foo": "Sync"}
+		extra := map[string]any{"foo": "Sync"}
 		err = client.Sync(context.Background(), extra)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, extraOptions, test.ShouldResemble, extra)
@@ -88,11 +88,11 @@ func TestClient(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		passedErr := errors.New("fake sync error")
-		injectDS.SyncFunc = func(ctx context.Context, extra map[string]interface{}) error {
+		injectDS.SyncFunc = func(ctx context.Context, extra map[string]any) error {
 			return passedErr
 		}
 
-		err = client2.Sync(context.Background(), map[string]interface{}{})
+		err = client2.Sync(context.Background(), map[string]any{})
 		test.That(t, err.Error(), test.ShouldContainSubstring, passedErr.Error())
 		test.That(t, client2.Close(context.Background()), test.ShouldBeNil)
 		test.That(t, conn.Close(), test.ShouldBeNil)

--- a/services/datamanager/data_manager.go
+++ b/services/datamanager/data_manager.go
@@ -42,7 +42,7 @@ func init() {
 // Service defines what a Data Manager Service should expose to the users.
 type Service interface {
 	resource.Resource
-	Sync(ctx context.Context, extra map[string]interface{}) error
+	Sync(ctx context.Context, extra map[string]any) error
 }
 
 // SubtypeName is the name of the type of service.
@@ -107,8 +107,8 @@ var ShouldSyncKey = "should_sync"
 
 // CreateShouldSyncReading is a helper for creating the expected reading for a modular sensor
 // that passes a bool to the datamanager to indicate whether or not we want to sync.
-func CreateShouldSyncReading(toSync bool) map[string]interface{} {
-	readings := map[string]interface{}{}
+func CreateShouldSyncReading(toSync bool) map[string]any {
+	readings := map[string]any{}
 	readings[ShouldSyncKey] = toSync
 	return readings
 }

--- a/services/datamanager/internal/data_manager_test_helper.go
+++ b/services/datamanager/internal/data_manager_test_helper.go
@@ -13,7 +13,7 @@ import (
 // updating processes in the data manager service. These functions are not exported to the user. This resolves
 // a circular import caused by the inject package.
 type DMService interface {
-	Sync(ctx context.Context, extra map[string]interface{}) error
+	Sync(ctx context.Context, extra map[string]any) error
 	Reconfigure(
 		ctx context.Context,
 		deps resource.Dependencies,

--- a/services/datamanager/server.go
+++ b/services/datamanager/server.go
@@ -19,7 +19,7 @@ type serviceServer struct {
 
 // NewRPCServiceServer constructs a datamanager gRPC service server.
 // It is intentionally untyped to prevent use outside of tests.
-func NewRPCServiceServer(coll resource.APIResourceCollection[Service]) interface{} {
+func NewRPCServiceServer(coll resource.APIResourceCollection[Service]) any {
 	return &serviceServer{coll: coll}
 }
 

--- a/services/datamanager/server_test.go
+++ b/services/datamanager/server_test.go
@@ -25,7 +25,7 @@ func newServer(resourceMap map[resource.Name]datamanager.Service) (pb.DataManage
 }
 
 func TestServerSync(t *testing.T) {
-	var extraOptions map[string]interface{}
+	var extraOptions map[string]any
 
 	tests := map[string]struct {
 		resourceMap   map[resource.Name]datamanager.Service
@@ -38,7 +38,7 @@ func TestServerSync(t *testing.T) {
 		"returns error": {
 			resourceMap: map[resource.Name]datamanager.Service{
 				datamanager.Named(testDataManagerServiceName): &inject.DataManagerService{
-					SyncFunc: func(ctx context.Context, extra map[string]interface{}) error {
+					SyncFunc: func(ctx context.Context, extra map[string]any) error {
 						return errors.New("fake sync error")
 					},
 				},
@@ -48,7 +48,7 @@ func TestServerSync(t *testing.T) {
 		"returns response": {
 			resourceMap: map[resource.Name]datamanager.Service{
 				datamanager.Named(testDataManagerServiceName): &inject.DataManagerService{
-					SyncFunc: func(ctx context.Context, extra map[string]interface{}) error {
+					SyncFunc: func(ctx context.Context, extra map[string]any) error {
 						extraOptions = extra
 						return nil
 					},
@@ -57,7 +57,7 @@ func TestServerSync(t *testing.T) {
 			expectedError: nil,
 		},
 	}
-	extra := map[string]interface{}{"foo": "Sync"}
+	extra := map[string]any{"foo": "Sync"}
 	ext, err := protoutils.StructToStructPb(extra)
 	test.That(t, err, test.ShouldBeNil)
 

--- a/services/generic/client.go
+++ b/services/generic/client.go
@@ -40,7 +40,7 @@ func NewClientFromConn(
 	}, nil
 }
 
-func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (c *client) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	command, err := protoutils.StructToStructPb(cmd)
 	if err != nil {
 		return nil, err

--- a/services/generic/client_test.go
+++ b/services/generic/client_test.go
@@ -34,9 +34,9 @@ func TestClient(t *testing.T) {
 	workingGeneric.DoFunc = testutils.EchoFunc
 	failingGeneric.DoFunc = func(
 		ctx context.Context,
-		cmd map[string]interface{},
+		cmd map[string]any,
 	) (
-		map[string]interface{},
+		map[string]any,
 		error,
 	) {
 		return nil, errDoFailed

--- a/services/generic/fake/fake_test.go
+++ b/services/generic/fake/fake_test.go
@@ -15,7 +15,7 @@ func TestDoCommand(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 
 	gen := newGeneric(generic.Named("foo"), logger)
-	cmd := map[string]interface{}{"bar": "baz"}
+	cmd := map[string]any{"bar": "baz"}
 	resp, err := gen.DoCommand(ctx, cmd)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, resp, test.ShouldResemble, cmd)

--- a/services/generic/fake/generic.go
+++ b/services/generic/fake/generic.go
@@ -36,6 +36,6 @@ type Generic struct {
 }
 
 // DoCommand echos input back to the caller.
-func (fg *Generic) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (fg *Generic) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	return cmd, nil
 }

--- a/services/generic/server.go
+++ b/services/generic/server.go
@@ -18,7 +18,7 @@ type serviceServer struct {
 }
 
 // NewRPCServiceServer constructs an generic gRPC service serviceServer.
-func NewRPCServiceServer(coll resource.APIResourceCollection[resource.Resource]) interface{} {
+func NewRPCServiceServer(coll resource.APIResourceCollection[resource.Resource]) any {
 	return &serviceServer{coll: coll}
 }
 

--- a/services/generic/server_test.go
+++ b/services/generic/server_test.go
@@ -38,18 +38,18 @@ func TestGenericDo(t *testing.T) {
 
 	workingGeneric.DoFunc = func(
 		ctx context.Context,
-		cmd map[string]interface{},
+		cmd map[string]any,
 	) (
-		map[string]interface{},
+		map[string]any,
 		error,
 	) {
 		return cmd, nil
 	}
 	failingGeneric.DoFunc = func(
 		ctx context.Context,
-		cmd map[string]interface{},
+		cmd map[string]any,
 	) (
-		map[string]interface{},
+		map[string]any,
 		error,
 	) {
 		return nil, errDoFailed

--- a/services/mlmodel/mlmodel.go
+++ b/services/mlmodel/mlmodel.go
@@ -27,7 +27,7 @@ func init() {
 
 // Service defines the ML Model interface, which takes a map of inputs, runs it through
 // an inference engine, and creates a map of outputs. Metadata is necessary in order to build
-// the struct that will decode that map[string]interface{} correctly.
+// the struct that will decode that map[string]any correctly.
 type Service interface {
 	resource.Resource
 	Infer(ctx context.Context, tensors ml.Tensors) (ml.Tensors, error)
@@ -199,7 +199,7 @@ type TensorInfo struct {
 	DataType        string // e.g. uint8, float32, int
 	Shape           []int  // number of dimensions in the array
 	AssociatedFiles []File
-	Extra           map[string]interface{}
+	Extra           map[string]any
 }
 
 // toProto turns the TensorInfo struct into a protobuf message.

--- a/services/mlmodel/server.go
+++ b/services/mlmodel/server.go
@@ -17,7 +17,7 @@ type serviceServer struct {
 
 // NewRPCServiceServer constructs a ML Model gRPC service server.
 // It is intentionally untyped to prevent use outside of tests.
-func NewRPCServiceServer(coll resource.APIResourceCollection[Service]) interface{} {
+func NewRPCServiceServer(coll resource.APIResourceCollection[Service]) any {
 	return &serviceServer{coll: coll}
 }
 

--- a/services/mlmodel/tflitecpu/tflite_cpu.go
+++ b/services/mlmodel/tflitecpu/tflite_cpu.go
@@ -197,7 +197,7 @@ func (m *Model) Metadata(ctx context.Context) (mlmodel.MLMetadata, error) {
 		td := getTensorInfo(outputT)
 		td.DataType = strings.ToLower(m.model.Info.OutputTensorTypes[i]) // grab from model info, not metadata
 		if i == 0 && m.conf.LabelPath != "" {
-			td.Extra = map[string]interface{}{"labels": m.conf.LabelPath}
+			td.Extra = map[string]any{"labels": m.conf.LabelPath}
 		}
 		outputList = append(outputList, td)
 	}
@@ -220,7 +220,7 @@ func getTensorInfo(inputT *tflite_metadata.TensorMetadataT) mlmodel.TensorInfo {
 	// Add bounding box info to Extra
 	if strings.Contains(inputT.Name, "location") && inputT.Content.ContentProperties.Value != nil {
 		if order, ok := inputT.Content.ContentProperties.Value.(*tflite_metadata.BoundingBoxPropertiesT); ok {
-			td.Extra = map[string]interface{}{
+			td.Extra = map[string]any{
 				"boxOrder": order.Index,
 			}
 		}
@@ -270,7 +270,7 @@ func (m *Model) blindFillMetadata() mlmodel.MLMetadata {
 		var td mlmodel.TensorInfo
 		td.DataType = strings.ToLower(m.model.Info.OutputTensorTypes[i])
 		if i == 0 && m.conf.LabelPath != "" {
-			td.Extra = map[string]interface{}{"labels": m.conf.LabelPath}
+			td.Extra = map[string]any{"labels": m.conf.LabelPath}
 		}
 		outputList = append(outputList, td)
 	}

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -178,7 +178,7 @@ func (ms *builtIn) Move(
 	destination *referenceframe.PoseInFrame,
 	worldState *referenceframe.WorldState,
 	constraints *servicepb.Constraints,
-	extra map[string]interface{},
+	extra map[string]any,
 ) (bool, error) {
 	ms.mu.RLock()
 	defer ms.mu.RUnlock()
@@ -294,16 +294,16 @@ type validatedExtra struct {
 	maxReplans       int
 	replanCostFactor float64
 	motionProfile    string
-	extra            map[string]interface{}
+	extra            map[string]any
 }
 
-func newValidatedExtra(extra map[string]interface{}) (validatedExtra, error) {
+func newValidatedExtra(extra map[string]any) (validatedExtra, error) {
 	maxReplans := -1
 	replanCostFactor := defaultReplanCostFactor
 	motionProfile := ""
 	v := validatedExtra{}
 	if extra == nil {
-		v.extra = map[string]interface{}{"smooth_iter": defaultSmoothIter}
+		v.extra = map[string]any{"smooth_iter": defaultSmoothIter}
 		return v, nil
 	}
 	if replansRaw, ok := extra["max_replans"]; ok {
@@ -360,7 +360,7 @@ func (ms *builtIn) GetPose(
 	componentName resource.Name,
 	destinationFrame string,
 	supplementalTransforms []*referenceframe.LinkInFrame,
-	extra map[string]interface{},
+	extra map[string]any,
 ) (*referenceframe.PoseInFrame, error) {
 	ms.mu.RLock()
 	defer ms.mu.RUnlock()

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -152,7 +152,7 @@ func TestMove(t *testing.T) {
 		ms, teardown := setupMotionServiceFromConfig(t, "../data/moving_arm.json")
 		defer teardown()
 		grabPose := referenceframe.NewPoseInFrame("pieceArm", spatialmath.NewPoseFromPoint(r3.Vector{X: 0, Y: -30, Z: -50}))
-		_, err = ms.Move(ctx, arm.Named("pieceArm"), grabPose, nil, nil, map[string]interface{}{})
+		_, err = ms.Move(ctx, arm.Named("pieceArm"), grabPose, nil, nil, map[string]any{})
 		test.That(t, err, test.ShouldBeNil)
 	})
 
@@ -160,7 +160,7 @@ func TestMove(t *testing.T) {
 		ms, teardown := setupMotionServiceFromConfig(t, "../data/moving_arm.json")
 		defer teardown()
 		grabPose := referenceframe.NewPoseInFrame("pieceGripper", spatialmath.NewPoseFromPoint(r3.Vector{X: 0, Y: -30, Z: -50}))
-		_, err = ms.Move(ctx, gripper.Named("pieceGripper"), grabPose, nil, nil, map[string]interface{}{})
+		_, err = ms.Move(ctx, gripper.Named("pieceGripper"), grabPose, nil, nil, map[string]any{})
 		test.That(t, err, test.ShouldBeNil)
 	})
 
@@ -239,7 +239,7 @@ func TestMoveOnMapLongDistance(t *testing.T) {
 		t.Skip("skipping on 32-bit ARM, large maps use too much memory")
 	}
 	ctx := context.Background()
-	extra := map[string]interface{}{"smooth_iter": 0, "motion_profile": "position_only"}
+	extra := map[string]any{"smooth_iter": 0, "motion_profile": "position_only"}
 	// goal position is scaled to be in mm
 	goalInBaseFrame := spatialmath.NewPoseFromPoint(r3.Vector{X: -32.508 * 1000, Y: -2.092 * 1000})
 	goalInSLAMFrame := spatialmath.PoseBetweenInverse(motion.SLAMOrientationAdjustment, goalInBaseFrame)
@@ -286,8 +286,8 @@ func TestMoveOnMapPlans(t *testing.T) {
 	// Orientation theta should be at least 3 degrees away from an integer multiple of 22.5 to ensure the position-only test functions.
 	goalInBaseFrame := spatialmath.NewPose(r3.Vector{X: 1.32 * 1000, Y: 0}, &spatialmath.OrientationVectorDegrees{OZ: 1, Theta: 33})
 	goalInSLAMFrame := spatialmath.PoseBetweenInverse(motion.SLAMOrientationAdjustment, goalInBaseFrame)
-	extra := map[string]interface{}{"smooth_iter": 0}
-	extraPosOnly := map[string]interface{}{"smooth_iter": 5, "motion_profile": "position_only"}
+	extra := map[string]any{"smooth_iter": 0}
+	extraPosOnly := map[string]any{"smooth_iter": 5, "motion_profile": "position_only"}
 
 	// RSDK-6444
 	//nolint:dupl
@@ -435,7 +435,7 @@ func TestMoveOnMapSubsequent(t *testing.T) {
 		ComponentName: base.Named("test-base"),
 		Destination:   goal1SLAMFrame,
 		SlamName:      slam.Named("test_slam"),
-		Extra:         map[string]interface{}{"smooth_iter": 5},
+		Extra:         map[string]any{"smooth_iter": 5},
 	}
 
 	timeoutCtx, timeoutFn := context.WithTimeout(ctx, time.Second*5)
@@ -465,7 +465,7 @@ func TestMoveOnMapSubsequent(t *testing.T) {
 		ComponentName: base.Named("test-base"),
 		Destination:   goal2SLAMFrame,
 		SlamName:      slam.Named("test_slam"),
-		Extra:         map[string]interface{}{"smooth_iter": 5},
+		Extra:         map[string]any{"smooth_iter": 5},
 	}
 	timeoutCtx, timeoutFn = context.WithTimeout(ctx, time.Second*5)
 	defer timeoutFn()
@@ -511,7 +511,7 @@ func TestMoveOnMapSubsequent(t *testing.T) {
 
 func TestMoveOnMapAskewIMU(t *testing.T) {
 	t.Parallel()
-	extraPosOnly := map[string]interface{}{"smooth_iter": 5, "motion_profile": "position_only"}
+	extraPosOnly := map[string]any{"smooth_iter": 5, "motion_profile": "position_only"}
 	t.Run("Askew but valid base should be able to plan", func(t *testing.T) {
 		t.Parallel()
 		ctx := context.Background()
@@ -616,7 +616,7 @@ func TestMoveOnMapTimeout(t *testing.T) {
 
 	easyGoal := spatialmath.NewPoseFromPoint(r3.Vector{X: 1001, Y: 1001})
 	// create motion config
-	extra := make(map[string]interface{})
+	extra := make(map[string]any)
 	extra["timeout"] = 0.01
 	executionID, err := ms.MoveOnMap(
 		context.Background(),
@@ -645,7 +645,7 @@ func TestPositionalReplanning(t *testing.T) {
 		noise           r3.Vector
 		expectedSuccess bool
 		expectedErr     string
-		extra           map[string]interface{}
+		extra           map[string]any
 	}
 
 	testCases := []testCase{
@@ -653,7 +653,7 @@ func TestPositionalReplanning(t *testing.T) {
 			name:            "check we dont replan with a good sensor",
 			noise:           r3.Vector{Y: epsilonMM - 0.1},
 			expectedSuccess: true,
-			extra:           map[string]interface{}{"smooth_iter": 5},
+			extra:           map[string]any{"smooth_iter": 5},
 		},
 		// TODO(RSDK-5634): this should be uncommented when this bug is fixed
 		// {
@@ -662,14 +662,14 @@ func TestPositionalReplanning(t *testing.T) {
 		// 	noise:           r3.Vector{Y: epsilonMM + 0.1},
 		// 	expectedErr:     "unable to create a new plan within replanCostFactor from the original",
 		// 	expectedSuccess: false,
-		// 	extra:           map[string]interface{}{"replan_cost_factor": 0.01, "smooth_iter": 5},
+		// 	extra:           map[string]any{"replan_cost_factor": 0.01, "smooth_iter": 5},
 		// },
 		{
 			name:            "check we replan with a noisy sensor",
 			noise:           r3.Vector{Y: epsilonMM + 0.1},
 			expectedErr:     fmt.Sprintf("exceeded maximum number of replans: %d: plan failed", 4),
 			expectedSuccess: false,
-			extra:           map[string]interface{}{"replan_cost_factor": 10.0, "max_replans": 4, "smooth_iter": 5},
+			extra:           map[string]any{"replan_cost_factor": 10.0, "max_replans": 4, "smooth_iter": 5},
 		},
 	}
 
@@ -722,7 +722,7 @@ func TestObstacleReplanning(t *testing.T) {
 
 	type testCase struct {
 		name            string
-		getPCfunc       func(ctx context.Context, cameraName string, extra map[string]interface{}) ([]*viz.Object, error)
+		getPCfunc       func(ctx context.Context, cameraName string, extra map[string]any) ([]*viz.Object, error)
 		expectedSuccess bool
 		expectedErr     string
 	}
@@ -735,12 +735,12 @@ func TestObstacleReplanning(t *testing.T) {
 		PositionPollingFreqHz: 1, ObstaclePollingFreqHz: 100, PlanDeviationMM: epsilonMM, ObstacleDetectors: obstacleDetectorSlice,
 	}
 
-	extra := map[string]interface{}{"max_replans": 0, "max_ik_solutions": 1, "smooth_iter": 1}
+	extra := map[string]any{"max_replans": 0, "max_ik_solutions": 1, "smooth_iter": 1}
 
 	testCases := []testCase{
 		{
 			name: "ensure no replan from discovered obstacles",
-			getPCfunc: func(ctx context.Context, cameraName string, extra map[string]interface{}) ([]*viz.Object, error) {
+			getPCfunc: func(ctx context.Context, cameraName string, extra map[string]any) ([]*viz.Object, error) {
 				obstaclePosition := spatialmath.NewPoseFromPoint(r3.Vector{X: -1000, Y: -1000, Z: 0})
 				box, err := spatialmath.NewBox(obstaclePosition, r3.Vector{X: 10, Y: 10, Z: 10}, "test-case-2")
 				test.That(t, err, test.ShouldBeNil)
@@ -754,7 +754,7 @@ func TestObstacleReplanning(t *testing.T) {
 		},
 		{
 			name: "ensure replan due to obstacle collision",
-			getPCfunc: func(ctx context.Context, cameraName string, extra map[string]interface{}) ([]*viz.Object, error) {
+			getPCfunc: func(ctx context.Context, cameraName string, extra map[string]any) ([]*viz.Object, error) {
 				obstaclePosition := spatialmath.NewPoseFromPoint(r3.Vector{X: 1100, Y: 0, Z: 0})
 				box, err := spatialmath.NewBox(obstaclePosition, r3.Vector{X: 100, Y: 100, Z: 10}, "test-case-1")
 				test.That(t, err, test.ShouldBeNil)
@@ -832,35 +832,35 @@ func TestGetPose(t *testing.T) {
 	ms, teardown := setupMotionServiceFromConfig(t, "../data/arm_gantry.json")
 	defer teardown()
 
-	pose, err := ms.GetPose(context.Background(), arm.Named("gantry1"), "", nil, map[string]interface{}{})
+	pose, err := ms.GetPose(context.Background(), arm.Named("gantry1"), "", nil, map[string]any{})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, pose.Parent(), test.ShouldEqual, referenceframe.World)
 	test.That(t, pose.Pose().Point().X, test.ShouldAlmostEqual, 1.2)
 	test.That(t, pose.Pose().Point().Y, test.ShouldAlmostEqual, 0)
 	test.That(t, pose.Pose().Point().Z, test.ShouldAlmostEqual, 0)
 
-	pose, err = ms.GetPose(context.Background(), arm.Named("arm1"), "", nil, map[string]interface{}{})
+	pose, err = ms.GetPose(context.Background(), arm.Named("arm1"), "", nil, map[string]any{})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, pose.Parent(), test.ShouldEqual, referenceframe.World)
 	test.That(t, pose.Pose().Point().X, test.ShouldAlmostEqual, 501.2)
 	test.That(t, pose.Pose().Point().Y, test.ShouldAlmostEqual, 0)
 	test.That(t, pose.Pose().Point().Z, test.ShouldAlmostEqual, 300)
 
-	pose, err = ms.GetPose(context.Background(), arm.Named("arm1"), "gantry1", nil, map[string]interface{}{})
+	pose, err = ms.GetPose(context.Background(), arm.Named("arm1"), "gantry1", nil, map[string]any{})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, pose.Parent(), test.ShouldEqual, "gantry1")
 	test.That(t, pose.Pose().Point().X, test.ShouldAlmostEqual, 500)
 	test.That(t, pose.Pose().Point().Y, test.ShouldAlmostEqual, 0)
 	test.That(t, pose.Pose().Point().Z, test.ShouldAlmostEqual, 300)
 
-	pose, err = ms.GetPose(context.Background(), arm.Named("gantry1"), "gantry1", nil, map[string]interface{}{})
+	pose, err = ms.GetPose(context.Background(), arm.Named("gantry1"), "gantry1", nil, map[string]any{})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, pose.Parent(), test.ShouldEqual, "gantry1")
 	test.That(t, pose.Pose().Point().X, test.ShouldAlmostEqual, 0)
 	test.That(t, pose.Pose().Point().Y, test.ShouldAlmostEqual, 0)
 	test.That(t, pose.Pose().Point().Z, test.ShouldAlmostEqual, 0)
 
-	pose, err = ms.GetPose(context.Background(), arm.Named("arm1"), "arm1", nil, map[string]interface{}{})
+	pose, err = ms.GetPose(context.Background(), arm.Named("arm1"), "arm1", nil, map[string]any{})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, pose.Parent(), test.ShouldEqual, "arm1")
 	test.That(t, pose.Pose().Point().X, test.ShouldAlmostEqual, 0)
@@ -873,7 +873,7 @@ func TestGetPose(t *testing.T) {
 		referenceframe.NewLinkInFrame("testFrame", testPose, "testFrame2", nil),
 	}
 
-	pose, err = ms.GetPose(context.Background(), arm.Named("arm1"), "testFrame2", transforms, map[string]interface{}{})
+	pose, err = ms.GetPose(context.Background(), arm.Named("arm1"), "testFrame2", transforms, map[string]any{})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, pose.Pose().Point().X, test.ShouldAlmostEqual, -501.2)
 	test.That(t, pose.Pose().Point().Y, test.ShouldAlmostEqual, 0)
@@ -886,7 +886,7 @@ func TestGetPose(t *testing.T) {
 	transforms = []*referenceframe.LinkInFrame{
 		referenceframe.NewLinkInFrame("noParent", testPose, "testFrame", nil),
 	}
-	pose, err = ms.GetPose(context.Background(), arm.Named("arm1"), "testFrame", transforms, map[string]interface{}{})
+	pose, err = ms.GetPose(context.Background(), arm.Named("arm1"), "testFrame", transforms, map[string]any{})
 	test.That(t, err, test.ShouldBeError, referenceframe.NewParentFrameMissingError("testFrame", "noParent"))
 	test.That(t, pose, test.ShouldBeNil)
 }
@@ -902,7 +902,7 @@ func TestStoppableMoveFunctions(t *testing.T) {
 		test.That(t, success, test.ShouldBeFalse)
 		test.That(t, calledStopFunc, test.ShouldBeTrue)
 	}
-	extra := map[string]interface{}{"smooth_iter": 5}
+	extra := map[string]any{"smooth_iter": 5}
 
 	t.Run("successfully stop arms", func(t *testing.T) {
 		armName := "test-arm"
@@ -931,7 +931,7 @@ func TestStoppableMoveFunctions(t *testing.T) {
 		injectArm := &inject.Arm{
 			Arm: fakeArm,
 		}
-		injectArm.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
+		injectArm.StopFunc = func(ctx context.Context, extra map[string]any) error {
 			calledStopFunc = true
 			return nil
 		}
@@ -942,7 +942,7 @@ func TestStoppableMoveFunctions(t *testing.T) {
 			model, _ := ur.MakeModelFrame("ur5e")
 			return model
 		}
-		injectArm.MoveToPositionFunc = func(ctx context.Context, to spatialmath.Pose, extra map[string]interface{}) error {
+		injectArm.MoveToPositionFunc = func(ctx context.Context, to spatialmath.Pose, extra map[string]any) error {
 			return failToReachGoalError
 		}
 
@@ -991,23 +991,23 @@ func TestStoppableMoveFunctions(t *testing.T) {
 		injectBase.GeometriesFunc = func(ctx context.Context) ([]spatialmath.Geometry, error) {
 			return []spatialmath.Geometry{geometry}, nil
 		}
-		injectBase.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (base.Properties, error) {
+		injectBase.PropertiesFunc = func(ctx context.Context, extra map[string]any) (base.Properties, error) {
 			return base.Properties{
 				TurningRadiusMeters: 0,
 				WidthMeters:         600 * 0.001,
 			}, nil
 		}
-		injectBase.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
+		injectBase.StopFunc = func(ctx context.Context, extra map[string]any) error {
 			calledStopFunc = true
 			return nil
 		}
-		injectBase.SpinFunc = func(ctx context.Context, angleDeg, degsPerSec float64, extra map[string]interface{}) error {
+		injectBase.SpinFunc = func(ctx context.Context, angleDeg, degsPerSec float64, extra map[string]any) error {
 			return failToReachGoalError
 		}
-		injectBase.MoveStraightFunc = func(ctx context.Context, distanceMm int, mmPerSec float64, extra map[string]interface{}) error {
+		injectBase.MoveStraightFunc = func(ctx context.Context, distanceMm int, mmPerSec float64, extra map[string]any) error {
 			return failToReachGoalError
 		}
-		injectBase.SetVelocityFunc = func(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error {
+		injectBase.SetVelocityFunc = func(ctx context.Context, linear, angular r3.Vector, extra map[string]any) error {
 			return failToReachGoalError
 		}
 
@@ -1199,7 +1199,7 @@ func TestMoveOnGlobe(t *testing.T) {
 	expectedDst := r3.Vector{X: 2662.16, Y: 0, Z: 0} // Relative pose to the starting point of the base; facing north, Y = forwards
 	epsilonMM := 15.
 	// create motion config
-	extra := map[string]interface{}{
+	extra := map[string]any{
 		"motion_profile": "position_only",
 		"timeout":        5.,
 		"smooth_iter":    5.,
@@ -1476,7 +1476,7 @@ func TestMoveOnGlobe(t *testing.T) {
 func TestMoveOnMapStaticObs(t *testing.T) {
 	ctx := context.Background()
 	logger := logging.NewTestLogger(t)
-	extra := map[string]interface{}{
+	extra := map[string]any{
 		"motion_profile": "position_only",
 		"timeout":        5.,
 		"smooth_iter":    10.,
@@ -1493,7 +1493,7 @@ func TestMoveOnMapStaticObs(t *testing.T) {
 	injectBase.GeometriesFunc = func(ctx context.Context) ([]spatialmath.Geometry, error) {
 		return []spatialmath.Geometry{geometry}, nil
 	}
-	injectBase.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (base.Properties, error) {
+	injectBase.PropertiesFunc = func(ctx context.Context, extra map[string]any) (base.Properties, error) {
 		return base.Properties{TurningRadiusMeters: 0, WidthMeters: 0.6}, nil
 	}
 
@@ -1650,7 +1650,7 @@ func TestMoveOnMapNew(t *testing.T) {
 		if runtime.GOARCH == "arm" {
 			t.Skip("skipping on 32-bit ARM, large maps use too much memory")
 		}
-		extra := map[string]interface{}{"smooth_iter": 0, "motion_profile": "position_only"}
+		extra := map[string]any{"smooth_iter": 0, "motion_profile": "position_only"}
 		// goal position is scaled to be in mm
 		goalInBaseFrame := spatialmath.NewPoseFromPoint(r3.Vector{X: -32.508 * 1000, Y: -2.092 * 1000})
 		goalInSLAMFrame := spatialmath.PoseBetweenInverse(motion.SLAMOrientationAdjustment, goalInBaseFrame)
@@ -1696,8 +1696,8 @@ func TestMoveOnMapNew(t *testing.T) {
 		// Orientation theta should be at least 3 degrees away from an integer multiple of 22.5 to ensure the position-only test functions.
 		goalInBaseFrame := spatialmath.NewPose(r3.Vector{X: 1.32 * 1000, Y: 0}, &spatialmath.OrientationVectorDegrees{OZ: 1, Theta: 33})
 		goalInSLAMFrame := spatialmath.PoseBetweenInverse(motion.SLAMOrientationAdjustment, goalInBaseFrame)
-		extra := map[string]interface{}{"smooth_iter": 0}
-		extraPosOnly := map[string]interface{}{"smooth_iter": 5, "motion_profile": "position_only"}
+		extra := map[string]any{"smooth_iter": 0}
+		extraPosOnly := map[string]any{"smooth_iter": 5, "motion_profile": "position_only"}
 
 		// RSDK-6444
 		//nolint:dupl
@@ -1823,7 +1823,7 @@ func TestMoveOnMapNew(t *testing.T) {
 			ComponentName: base.Named("test-base"),
 			Destination:   goal1SLAMFrame,
 			SlamName:      slam.Named("test_slam"),
-			Extra:         map[string]interface{}{"smooth_iter": 5},
+			Extra:         map[string]any{"smooth_iter": 5},
 		}
 
 		timeoutCtx, timeoutFn := context.WithTimeout(ctx, time.Second*5)
@@ -1853,7 +1853,7 @@ func TestMoveOnMapNew(t *testing.T) {
 			ComponentName: base.Named("test-base"),
 			Destination:   goal2SLAMFrame,
 			SlamName:      slam.Named("test_slam"),
-			Extra:         map[string]interface{}{"smooth_iter": 5},
+			Extra:         map[string]any{"smooth_iter": 5},
 		}
 		timeoutCtx, timeoutFn = context.WithTimeout(ctx, time.Second*5)
 		defer timeoutFn()
@@ -1932,7 +1932,7 @@ func TestMoveOnMapNew(t *testing.T) {
 			ComponentName: base.Named("test-base"),
 			Destination:   spatialmath.NewPoseFromPoint(r3.Vector{X: 1001, Y: 1001}),
 			SlamName:      slam.Named("test_slam"),
-			Extra:         map[string]interface{}{"timeout": 0.01},
+			Extra:         map[string]any{"timeout": 0.01},
 		}
 
 		timeoutCtx, timeoutFn := context.WithTimeout(ctx, time.Second*5)
@@ -1955,7 +1955,7 @@ func TestMoveOnMapNew(t *testing.T) {
 				PlanDeviationMM: 1,
 			},
 			SlamName: slam.Named("test_slam"),
-			Extra:    map[string]interface{}{"smooth_iter": 0},
+			Extra:    map[string]any{"smooth_iter": 0},
 		}
 
 		timeoutCtx, timeoutFn := context.WithTimeout(ctx, time.Second*5)
@@ -2002,7 +2002,7 @@ func TestMoveOnMapNew(t *testing.T) {
 			Destination:   spatialmath.NewZeroPose(),
 			SlamName:      slam.Named("test_slam"),
 			MotionCfg:     &motion.MotionConfiguration{},
-			Extra:         map[string]interface{}{"motion_profile": "position_only"},
+			Extra:         map[string]any{"motion_profile": "position_only"},
 		}
 
 		timeoutCtx, timeoutFn := context.WithTimeout(ctx, time.Second*5)
@@ -2276,7 +2276,7 @@ func TestMoveCallInputs(t *testing.T) {
 		gpsPoint := geo.NewPoint(-70, 40)
 		dst := geo.NewPoint(gpsPoint.Lat(), gpsPoint.Lng()+1e-5)
 		// create motion config
-		extra := map[string]interface{}{
+		extra := map[string]any{
 			"motion_profile": "position_only",
 			"timeout":        5.,
 			"smooth_iter":    5.,

--- a/services/motion/builtin/builtin_utils_test.go
+++ b/services/motion/builtin/builtin_utils_test.go
@@ -62,13 +62,13 @@ func getPointCloudMap(path string) (func() ([]byte, error), error) {
 
 func createInjectedMovementSensor(name string, gpsPoint *geo.Point) *inject.MovementSensor {
 	injectedMovementSensor := inject.NewMovementSensor(name)
-	injectedMovementSensor.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+	injectedMovementSensor.PositionFunc = func(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 		return gpsPoint, 0, nil
 	}
-	injectedMovementSensor.CompassHeadingFunc = func(ctx context.Context, extra map[string]interface{}) (float64, error) {
+	injectedMovementSensor.CompassHeadingFunc = func(ctx context.Context, extra map[string]any) (float64, error) {
 		return 0, nil
 	}
-	injectedMovementSensor.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+	injectedMovementSensor.PropertiesFunc = func(ctx context.Context, extra map[string]any) (*movementsensor.Properties, error) {
 		return &movementsensor.Properties{CompassHeadingSupported: true}, nil
 	}
 
@@ -163,7 +163,7 @@ func createMoveOnGlobeEnvironment(ctx context.Context, t *testing.T, origin *geo
 
 	// create injected MovementSensor
 	dynamicMovementSensor := inject.NewMovementSensor("test-gps")
-	dynamicMovementSensor.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+	dynamicMovementSensor.PositionFunc = func(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 		poseInFrame, err := kb.CurrentPosition(ctx)
 		test.That(t, err, test.ShouldBeNil)
 		heading := poseInFrame.Pose().Orientation().OrientationVectorDegrees().Theta
@@ -171,10 +171,10 @@ func createMoveOnGlobeEnvironment(ctx context.Context, t *testing.T, origin *geo
 		pt := origin.PointAtDistanceAndBearing(distance*1e-6, heading)
 		return pt, 0, nil
 	}
-	dynamicMovementSensor.CompassHeadingFunc = func(ctx context.Context, extra map[string]interface{}) (float64, error) {
+	dynamicMovementSensor.CompassHeadingFunc = func(ctx context.Context, extra map[string]any) (float64, error) {
 		return 0, nil
 	}
-	dynamicMovementSensor.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+	dynamicMovementSensor.PropertiesFunc = func(ctx context.Context, extra map[string]any) (*movementsensor.Properties, error) {
 		return &movementsensor.Properties{CompassHeadingSupported: true}, nil
 	}
 

--- a/services/motion/client.go
+++ b/services/motion/client.go
@@ -48,7 +48,7 @@ func (c *client) Move(
 	destination *referenceframe.PoseInFrame,
 	worldState *referenceframe.WorldState,
 	constraints *pb.Constraints,
-	extra map[string]interface{},
+	extra map[string]any,
 ) (bool, error) {
 	ext, err := vprotoutils.StructToStructPb(extra)
 	if err != nil {
@@ -139,7 +139,7 @@ func (c *client) GetPose(
 	componentName resource.Name,
 	destinationFrame string,
 	supplementalTransforms []*referenceframe.LinkInFrame,
-	extra map[string]interface{},
+	extra map[string]any,
 ) (*referenceframe.PoseInFrame, error) {
 	ext, err := vprotoutils.StructToStructPb(extra)
 	if err != nil {
@@ -227,6 +227,6 @@ func (c *client) PlanHistory(
 	return append([]PlanWithStatus{pws}, statusHistory...), nil
 }
 
-func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (c *client) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	return protoutils.DoFromResourceClient(ctx, c.client, c.name, cmd)
 }

--- a/services/motion/client_test.go
+++ b/services/motion/client_test.go
@@ -97,7 +97,7 @@ func TestClient(t *testing.T) {
 			destination *referenceframe.PoseInFrame,
 			worldState *referenceframe.WorldState,
 			constraints *servicepb.Constraints,
-			extra map[string]interface{},
+			extra map[string]any,
 		) (bool, error) {
 			return success, nil
 		}
@@ -106,7 +106,7 @@ func TestClient(t *testing.T) {
 			componentName resource.Name,
 			destinationFrame string,
 			supplementalTransforms []*referenceframe.LinkInFrame,
-			extra map[string]interface{},
+			extra map[string]any,
 		) (*referenceframe.PoseInFrame, error) {
 			for _, tf := range supplementalTransforms {
 				receivedTransforms[tf.Name()] = tf
@@ -134,7 +134,7 @@ func TestClient(t *testing.T) {
 		for _, tf := range transforms {
 			tfMap[tf.Name()] = tf
 		}
-		poseResult, err := client.GetPose(context.Background(), arm.Named("arm1"), "foo", transforms, map[string]interface{}{})
+		poseResult, err := client.GetPose(context.Background(), arm.Named("arm1"), "foo", transforms, map[string]any{})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, poseResult.Parent(), test.ShouldEqual, "fooarm1")
 		test.That(t, poseResult.Pose().Point().X, test.ShouldEqual, 1)
@@ -173,7 +173,7 @@ func TestClient(t *testing.T) {
 			grabPose *referenceframe.PoseInFrame,
 			worldState *referenceframe.WorldState,
 			constraints *servicepb.Constraints,
-			extra map[string]interface{},
+			extra map[string]any,
 		) (bool, error) {
 			return false, passedErr
 		}
@@ -183,7 +183,7 @@ func TestClient(t *testing.T) {
 			componentName resource.Name,
 			destinationFrame string,
 			supplementalTransform []*referenceframe.LinkInFrame,
-			extra map[string]interface{},
+			extra map[string]any,
 		) (*referenceframe.PoseInFrame, error) {
 			return nil, passedErr
 		}
@@ -194,7 +194,7 @@ func TestClient(t *testing.T) {
 		test.That(t, resp, test.ShouldEqual, false)
 
 		// GetPose
-		_, err = client2.GetPose(context.Background(), arm.Named("arm1"), "foo", nil, map[string]interface{}{})
+		_, err = client2.GetPose(context.Background(), arm.Named("arm1"), "foo", nil, map[string]any{})
 		test.That(t, err.Error(), test.ShouldContainSubstring, passedErr.Error())
 		test.That(t, client2.Close(context.Background()), test.ShouldBeNil)
 		test.That(t, conn.Close(), test.ShouldBeNil)

--- a/services/motion/explore/explore.go
+++ b/services/motion/explore/explore.go
@@ -174,7 +174,7 @@ func (ms *explore) GetPose(
 	componentName resource.Name,
 	destinationFrame string,
 	supplementalTransforms []*referenceframe.LinkInFrame,
-	extra map[string]interface{},
+	extra map[string]any,
 ) (*referenceframe.PoseInFrame, error) {
 	return nil, errUnimplemented
 }
@@ -221,7 +221,7 @@ func (ms *explore) Move(
 	destination *referenceframe.PoseInFrame,
 	worldState *referenceframe.WorldState,
 	constraints *servicepb.Constraints,
-	extra map[string]interface{},
+	extra map[string]any,
 ) (bool, error) {
 	ms.resourceMutex.Lock()
 	defer ms.resourceMutex.Unlock()
@@ -553,7 +553,7 @@ func (ms *explore) createMotionPlan(
 	ctx context.Context,
 	kb kinematicbase.KinematicBase,
 	destination *referenceframe.PoseInFrame,
-	extra map[string]interface{},
+	extra map[string]any,
 ) (motionplan.Plan, error) {
 	if destination.Pose().Point().Norm() >= defaultMoveLimitMM {
 		return nil, errors.Errorf("destination %v is above the defined limit of %v", destination.Pose().Point().String(), defaultMoveLimitMM)
@@ -605,7 +605,7 @@ func (ms *explore) createMotionPlan(
 }
 
 // parseMotionConfig extracts the MotionConfiguration from extra's.
-func parseMotionConfig(extra map[string]interface{}) (motion.MotionConfiguration, error) {
+func parseMotionConfig(extra map[string]any) (motion.MotionConfiguration, error) {
 	motionCfgInterface, ok := extra["motionCfg"]
 	if !ok {
 		return motion.MotionConfiguration{}, errors.New("no motionCfg provided")

--- a/services/motion/explore/explore_utils_test.go
+++ b/services/motion/explore/explore_utils_test.go
@@ -87,7 +87,7 @@ func createFakeCamera(ctx context.Context, logger logging.Logger, name string) (
 func createMockVisionService(visionSvcNum string, obstacles []obstacleMetadata) vSvc.Service {
 	mockVisionService := &inject.VisionService{}
 
-	mockVisionService.GetObjectPointCloudsFunc = func(ctx context.Context, cameraName string, extra map[string]interface{},
+	mockVisionService.GetObjectPointCloudsFunc = func(ctx context.Context, cameraName string, extra map[string]any,
 	) ([]*vision.Object, error) {
 		var vObjects []*vision.Object
 		for _, obs := range obstacles {

--- a/services/motion/localizer_test.go
+++ b/services/motion/localizer_test.go
@@ -16,13 +16,13 @@ import (
 
 func createInjectedCompassMovementSensor(name string, gpsPoint *geo.Point) *inject.MovementSensor {
 	injectedMovementSensor := inject.NewMovementSensor(name)
-	injectedMovementSensor.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+	injectedMovementSensor.PositionFunc = func(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 		return gpsPoint, 0, nil
 	}
-	injectedMovementSensor.CompassHeadingFunc = func(ctx context.Context, extra map[string]interface{}) (float64, error) {
+	injectedMovementSensor.CompassHeadingFunc = func(ctx context.Context, extra map[string]any) (float64, error) {
 		return 0, nil
 	}
-	injectedMovementSensor.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+	injectedMovementSensor.PropertiesFunc = func(ctx context.Context, extra map[string]any) (*movementsensor.Properties, error) {
 		return &movementsensor.Properties{CompassHeadingSupported: true}, nil
 	}
 
@@ -31,13 +31,13 @@ func createInjectedCompassMovementSensor(name string, gpsPoint *geo.Point) *inje
 
 func createInjectedOrientationMovementSensor(orient spatialmath.Orientation) *inject.MovementSensor {
 	injectedMovementSensor := inject.NewMovementSensor("")
-	injectedMovementSensor.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+	injectedMovementSensor.PositionFunc = func(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 		return geo.NewPoint(0, 0), 0, nil
 	}
-	injectedMovementSensor.OrientationFunc = func(ctx context.Context, extra map[string]interface{}) (spatialmath.Orientation, error) {
+	injectedMovementSensor.OrientationFunc = func(ctx context.Context, extra map[string]any) (spatialmath.Orientation, error) {
 		return orient, nil
 	}
-	injectedMovementSensor.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+	injectedMovementSensor.PropertiesFunc = func(ctx context.Context, extra map[string]any) (*movementsensor.Properties, error) {
 		return &movementsensor.Properties{OrientationSupported: true}, nil
 	}
 
@@ -66,7 +66,7 @@ func TestLocalizerOrientation(t *testing.T) {
 	)
 
 	// Update compass heading to point northwest
-	movementSensor.CompassHeadingFunc = func(ctx context.Context, extra map[string]interface{}) (float64, error) {
+	movementSensor.CompassHeadingFunc = func(ctx context.Context, extra map[string]any) (float64, error) {
 		return 315, nil
 	}
 
@@ -80,7 +80,7 @@ func TestLocalizerOrientation(t *testing.T) {
 	)
 
 	// Update compass heading to point east
-	movementSensor.CompassHeadingFunc = func(ctx context.Context, extra map[string]interface{}) (float64, error) {
+	movementSensor.CompassHeadingFunc = func(ctx context.Context, extra map[string]any) (float64, error) {
 		return 90, nil
 	}
 	pif, err = localizer.CurrentPosition(ctx)

--- a/services/motion/motion.go
+++ b/services/motion/motion.go
@@ -38,7 +38,7 @@ type PlanHistoryReq struct {
 	// Optional, when not uuid.Nil it specifies the ExecutionID of the plans that should be returned.
 	// Can be used to query plans from executions before the most recent one.
 	ExecutionID ExecutionID
-	Extra       map[string]interface{}
+	Extra       map[string]any
 }
 
 // MoveOnGlobeReq describes the request to the MoveOnGlobe interface method.
@@ -56,7 +56,7 @@ type MoveOnGlobeReq struct {
 	Obstacles []*spatialmath.GeoObstacle
 	// Optional motion configuration
 	MotionCfg *MotionConfiguration
-	Extra     map[string]interface{}
+	Extra     map[string]any
 }
 
 func (r MoveOnGlobeReq) String() string {
@@ -80,7 +80,7 @@ type MoveOnMapReq struct {
 	SlamName      resource.Name
 	MotionCfg     *MotionConfiguration
 	Obstacles     []spatialmath.Geometry
-	Extra         map[string]interface{}
+	Extra         map[string]any
 }
 
 func (r MoveOnMapReq) String() string {
@@ -99,14 +99,14 @@ func (r MoveOnMapReq) String() string {
 type StopPlanReq struct {
 	// ComponentName of the plan which should be stopped
 	ComponentName resource.Name
-	Extra         map[string]interface{}
+	Extra         map[string]any
 }
 
 // ListPlanStatusesReq describes the request to ListPlanStatuses().
 type ListPlanStatusesReq struct {
 	// If true then only active plans will be returned.
 	OnlyActivePlans bool
-	Extra           map[string]interface{}
+	Extra           map[string]any
 }
 
 // Plan represents a motion plan.
@@ -190,7 +190,7 @@ type Service interface {
 		destination *referenceframe.PoseInFrame,
 		worldState *referenceframe.WorldState,
 		constraints *pb.Constraints,
-		extra map[string]interface{},
+		extra map[string]any,
 	) (bool, error)
 	MoveOnMap(
 		ctx context.Context,
@@ -209,7 +209,7 @@ type Service interface {
 		componentName resource.Name,
 		destinationFrame string,
 		supplementalTransforms []*referenceframe.LinkInFrame,
-		extra map[string]interface{},
+		extra map[string]any,
 	) (*referenceframe.PoseInFrame, error)
 	StopPlan(
 		ctx context.Context,

--- a/services/motion/motion_test.go
+++ b/services/motion/motion_test.go
@@ -1153,7 +1153,7 @@ func TestMoveOnGlobeReq(t *testing.T) {
 					MovementSensorName: movementsensor.Named("my-movementsensor"),
 					Obstacles:          []*spatialmath.GeoObstacle{},
 					MotionCfg:          &defaultMotionCfg,
-					Extra:              map[string]interface{}{},
+					Extra:              map[string]any{},
 				},
 			},
 			{
@@ -1187,7 +1187,7 @@ func TestMoveOnGlobeReq(t *testing.T) {
 						PositionPollingFreqHz: positionPollingFreqHz,
 						ObstaclePollingFreqHz: obstaclePollingFreqHz,
 					},
-					Extra: map[string]interface{}{},
+					Extra: map[string]any{},
 				},
 			},
 		}
@@ -1247,7 +1247,7 @@ func TestMoveOnMapReq(t *testing.T) {
 		SlamName:      mySlam,
 		MotionCfg:     motionCfg,
 		Obstacles:     []spatialmath.Geometry{},
-		Extra:         map[string]interface{}{},
+		Extra:         map[string]any{},
 	}
 
 	// RSDK-6444
@@ -1477,7 +1477,7 @@ func TestMoveOnMapReq(t *testing.T) {
 					Destination:   spatialmath.NewZeroPose(),
 					SlamName:      mySlam,
 					MotionCfg:     motionCfg,
-					Extra:         map[string]interface{}{},
+					Extra:         map[string]any{},
 				},
 				err: nil,
 			},
@@ -1502,7 +1502,7 @@ func TestMoveOnMapReq(t *testing.T) {
 						LinearMPerSec:         0,
 						AngularDegsPerSec:     0,
 					},
-					Extra: map[string]interface{}{},
+					Extra: map[string]any{},
 				},
 				err: nil,
 			},
@@ -1595,7 +1595,7 @@ func TestMoveOnMapReq(t *testing.T) {
 						AngularDegsPerSec:     0,
 					},
 					Obstacles: []spatialmath.Geometry{},
-					Extra:     map[string]interface{}{},
+					Extra:     map[string]any{},
 				},
 				err: nil,
 			},
@@ -1620,7 +1620,7 @@ func TestMoveOnMapReq(t *testing.T) {
 						AngularDegsPerSec:     0,
 					},
 					Obstacles: []spatialmath.Geometry{spatialmath.NewPoint(r3.Vector{2, 2, 2}, "pt")},
-					Extra:     map[string]interface{}{},
+					Extra:     map[string]any{},
 				},
 				err: nil,
 			},
@@ -1732,7 +1732,7 @@ func TestPlanHistoryReq(t *testing.T) {
 				input: &pb.GetPlanRequest{
 					ComponentName: rprotoutils.ResourceNameToProto(resource.Name{}),
 				},
-				result: PlanHistoryReq{Extra: map[string]interface{}{}},
+				result: PlanHistoryReq{Extra: map[string]any{}},
 			},
 			{
 				description: "full struct returns a full struct",
@@ -1747,7 +1747,7 @@ func TestPlanHistoryReq(t *testing.T) {
 					ComponentName: mybase,
 					ExecutionID:   executionID,
 					LastPlanOnly:  true,
-					Extra:         map[string]interface{}{},
+					Extra:         map[string]any{},
 				},
 			},
 		}

--- a/services/motion/server.go
+++ b/services/motion/server.go
@@ -20,7 +20,7 @@ type serviceServer struct {
 
 // NewRPCServiceServer constructs a motion gRPC service server.
 // It is intentionally untyped to prevent use outside of tests.
-func NewRPCServiceServer(coll resource.APIResourceCollection[Service]) interface{} {
+func NewRPCServiceServer(coll resource.APIResourceCollection[Service]) any {
 	return &serviceServer{coll: coll}
 }
 

--- a/services/motion/server_test.go
+++ b/services/motion/server_test.go
@@ -66,7 +66,7 @@ func TestServerMove(t *testing.T) {
 		destination *referenceframe.PoseInFrame,
 		worldState *referenceframe.WorldState,
 		constraints *pb.Constraints,
-		extra map[string]interface{},
+		extra map[string]any,
 	) (bool, error) {
 		return false, passedErr
 	}
@@ -81,7 +81,7 @@ func TestServerMove(t *testing.T) {
 		destination *referenceframe.PoseInFrame,
 		worldState *referenceframe.WorldState,
 		constraints *pb.Constraints,
-		extra map[string]interface{},
+		extra map[string]any,
 	) (bool, error) {
 		return true, nil
 	}

--- a/services/navigation/builtin/builtin.go
+++ b/services/navigation/builtin/builtin.go
@@ -410,13 +410,13 @@ func (svc *builtIn) Reconfigure(ctx context.Context, deps resource.Dependencies,
 	return nil
 }
 
-func (svc *builtIn) Mode(ctx context.Context, extra map[string]interface{}) (navigation.Mode, error) {
+func (svc *builtIn) Mode(ctx context.Context, extra map[string]any) (navigation.Mode, error) {
 	svc.mu.RLock()
 	defer svc.mu.RUnlock()
 	return svc.mode, nil
 }
 
-func (svc *builtIn) SetMode(ctx context.Context, mode navigation.Mode, extra map[string]interface{}) error {
+func (svc *builtIn) SetMode(ctx context.Context, mode navigation.Mode, extra map[string]any) error {
 	svc.actionMu.Lock()
 	defer svc.actionMu.Unlock()
 
@@ -457,7 +457,7 @@ func (svc *builtIn) SetMode(ctx context.Context, mode navigation.Mode, extra map
 	return nil
 }
 
-func (svc *builtIn) Location(ctx context.Context, extra map[string]interface{}) (*spatialmath.GeoPose, error) {
+func (svc *builtIn) Location(ctx context.Context, extra map[string]any) (*spatialmath.GeoPose, error) {
 	svc.mu.RLock()
 	defer svc.mu.RUnlock()
 
@@ -476,7 +476,7 @@ func (svc *builtIn) Location(ctx context.Context, extra map[string]interface{}) 
 	return geoPose, err
 }
 
-func (svc *builtIn) Waypoints(ctx context.Context, extra map[string]interface{}) ([]navigation.Waypoint, error) {
+func (svc *builtIn) Waypoints(ctx context.Context, extra map[string]any) ([]navigation.Waypoint, error) {
 	wps, err := svc.store.Waypoints(ctx)
 	if err != nil {
 		return nil, err
@@ -486,13 +486,13 @@ func (svc *builtIn) Waypoints(ctx context.Context, extra map[string]interface{})
 	return wpsCopy, nil
 }
 
-func (svc *builtIn) AddWaypoint(ctx context.Context, point *geo.Point, extra map[string]interface{}) error {
+func (svc *builtIn) AddWaypoint(ctx context.Context, point *geo.Point, extra map[string]any) error {
 	svc.logger.CInfof(ctx, "AddWaypoint called with %#v", *point)
 	_, err := svc.store.AddWaypoint(ctx, point)
 	return err
 }
 
-func (svc *builtIn) RemoveWaypoint(ctx context.Context, id primitive.ObjectID, extra map[string]interface{}) error {
+func (svc *builtIn) RemoveWaypoint(ctx context.Context, id primitive.ObjectID, extra map[string]any) error {
 	svc.mu.Lock()
 	defer svc.mu.Unlock()
 	svc.logger.CInfof(ctx, "RemoveWaypoint called with waypointID: %s", id)
@@ -531,7 +531,7 @@ func (svc *builtIn) Close(ctx context.Context) error {
 	return svc.store.Close(ctx)
 }
 
-func (svc *builtIn) moveToWaypoint(ctx context.Context, wp navigation.Waypoint, extra map[string]interface{}) error {
+func (svc *builtIn) moveToWaypoint(ctx context.Context, wp navigation.Waypoint, extra map[string]any) error {
 	req := motion.MoveOnGlobeReq{
 		ComponentName:      svc.base.Name(),
 		Destination:        wp.ToPoint(),
@@ -585,9 +585,9 @@ func (svc *builtIn) moveToWaypoint(ctx context.Context, wp navigation.Waypoint, 
 	return svc.waypointReached(cancelCtx)
 }
 
-func (svc *builtIn) startWaypointMode(ctx context.Context, extra map[string]interface{}) {
+func (svc *builtIn) startWaypointMode(ctx context.Context, extra map[string]any) {
 	if extra == nil {
-		extra = map[string]interface{}{}
+		extra = map[string]any{}
 	}
 
 	extra["motion_profile"] = "position_only"
@@ -638,7 +638,7 @@ func (svc *builtIn) waypointIsDeleted() bool {
 	return svc.waypointInProgress == nil
 }
 
-func (svc *builtIn) Obstacles(ctx context.Context, extra map[string]interface{}) ([]*spatialmath.GeoObstacle, error) {
+func (svc *builtIn) Obstacles(ctx context.Context, extra map[string]any) ([]*spatialmath.GeoObstacle, error) {
 	svc.mu.RLock()
 	defer svc.mu.RUnlock()
 
@@ -799,7 +799,7 @@ func (svc *builtIn) Obstacles(ctx context.Context, extra map[string]interface{})
 	return geoObstacles, nil
 }
 
-func (svc *builtIn) Paths(ctx context.Context, extra map[string]interface{}) ([]*navigation.Path, error) {
+func (svc *builtIn) Paths(ctx context.Context, extra map[string]any) ([]*navigation.Path, error) {
 	svc.mu.RLock()
 	defer svc.mu.RUnlock()
 

--- a/services/navigation/builtin/builtin_test.go
+++ b/services/navigation/builtin/builtin_test.go
@@ -954,7 +954,7 @@ func TestStartWaypoint(t *testing.T) {
 					test.That(t, math.IsNaN(s.mogrs[0].Heading), test.ShouldBeTrue)
 					test.That(t, s.mogrs[0].MovementSensorName, test.ShouldResemble, s.movementSensor.Name())
 
-					test.That(t, s.mogrs[0].Extra, test.ShouldResemble, map[string]interface{}{
+					test.That(t, s.mogrs[0].Extra, test.ShouldResemble, map[string]any{
 						"motion_profile": "position_only",
 					})
 					test.That(t, s.mogrs[0].MotionCfg, test.ShouldResemble, expectedMotionCfg)
@@ -965,7 +965,7 @@ func TestStartWaypoint(t *testing.T) {
 					test.That(t, s.mogrs[1].ComponentName, test.ShouldResemble, s.base.Name())
 					test.That(t, math.IsNaN(s.mogrs[1].Heading), test.ShouldBeTrue)
 					test.That(t, s.mogrs[1].MovementSensorName, test.ShouldResemble, s.movementSensor.Name())
-					test.That(t, s.mogrs[1].Extra, test.ShouldResemble, map[string]interface{}{
+					test.That(t, s.mogrs[1].Extra, test.ShouldResemble, map[string]any{
 						"motion_profile": "position_only",
 					})
 					test.That(t, s.mogrs[1].MotionCfg, test.ShouldResemble, expectedMotionCfg)
@@ -1060,7 +1060,7 @@ func TestStartWaypoint(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		// SetMode with empty map
-		err = s.ns.SetMode(ctx, navigation.ModeWaypoint, map[string]interface{}{})
+		err = s.ns.SetMode(ctx, navigation.ModeWaypoint, map[string]any{})
 		test.That(t, err, test.ShouldBeNil)
 		<-mogCalled
 
@@ -1068,7 +1068,7 @@ func TestStartWaypoint(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		// SetMode with motion_profile set
-		err = s.ns.SetMode(ctx, navigation.ModeWaypoint, map[string]interface{}{"some_other": "config_param"})
+		err = s.ns.SetMode(ctx, navigation.ModeWaypoint, map[string]any{"some_other": "config_param"})
 		test.That(t, err, test.ShouldBeNil)
 		<-mogCalled
 
@@ -1083,13 +1083,13 @@ func TestStartWaypoint(t *testing.T) {
 			s.RLock()
 			if len(s.mogrs) == 3 {
 				// MoveOnGlobe was called twice, once for each waypoint
-				test.That(t, s.mogrs[0].Extra, test.ShouldResemble, map[string]interface{}{
+				test.That(t, s.mogrs[0].Extra, test.ShouldResemble, map[string]any{
 					"motion_profile": "position_only",
 				})
-				test.That(t, s.mogrs[1].Extra, test.ShouldResemble, map[string]interface{}{
+				test.That(t, s.mogrs[1].Extra, test.ShouldResemble, map[string]any{
 					"motion_profile": "position_only",
 				})
-				test.That(t, s.mogrs[2].Extra, test.ShouldResemble, map[string]interface{}{
+				test.That(t, s.mogrs[2].Extra, test.ShouldResemble, map[string]any{
 					"motion_profile": "position_only",
 					"some_other":     "config_param",
 				})
@@ -1776,21 +1776,21 @@ func TestGetObstacles(t *testing.T) {
 	ns.(*builtIn).fsService = fsSvc
 
 	// set injectMovementSensor functions
-	injectMovementSensor.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+	injectMovementSensor.PositionFunc = func(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 		return geo.NewPoint(1, 1), 0, nil
 	}
-	injectMovementSensor.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+	injectMovementSensor.PropertiesFunc = func(ctx context.Context, extra map[string]any) (*movementsensor.Properties, error) {
 		return &movementsensor.Properties{
 			CompassHeadingSupported: true,
 		}, nil
 	}
-	injectMovementSensor.CompassHeadingFunc = func(ctx context.Context, extra map[string]interface{}) (float64, error) {
+	injectMovementSensor.CompassHeadingFunc = func(ctx context.Context, extra map[string]any) (float64, error) {
 		// this is a left-handed value
 		return 315, nil
 	}
 
 	// set injectedVis functions
-	injectedVis.GetObjectPointCloudsFunc = func(ctx context.Context, cameraName string, extra map[string]interface{}) ([]*viz.Object, error) {
+	injectedVis.GetObjectPointCloudsFunc = func(ctx context.Context, cameraName string, extra map[string]any) ([]*viz.Object, error) {
 		boxGeom, err := spatialmath.NewBox(
 			spatialmath.NewPose(r3.Vector{-10, 0, 11}, &spatialmath.OrientationVectorDegrees{OZ: -1, OX: 1}),
 			r3.Vector{5, 5, 1},

--- a/services/navigation/builtin/explore.go
+++ b/services/navigation/builtin/explore.go
@@ -21,7 +21,7 @@ func (svc *builtIn) startExploreMode(ctx context.Context) {
 
 	utils.ManagedGo(func() {
 		// Send motionCfg parameters through extra until motionCfg can be added to Move()
-		extra := map[string]interface{}{"motionCfg": *svc.motionCfg}
+		extra := map[string]any{"motionCfg": *svc.motionCfg}
 
 		for {
 			if ctx.Err() != nil {

--- a/services/navigation/builtin/explore_test.go
+++ b/services/navigation/builtin/explore_test.go
@@ -24,7 +24,7 @@ func TestExploreMode(t *testing.T) {
 	mockExploreMotionService := &inject.MotionService{}
 	mockExploreMotionService.MoveFunc = func(ctx context.Context, componentName resource.Name,
 		destination *frame.PoseInFrame, worldState *frame.WorldState, constraints *v1.Constraints,
-		extra map[string]interface{},
+		extra map[string]any,
 	) (bool, error) {
 		points = append(points, destination.Pose().Point())
 		return false, errors.New("expected error")

--- a/services/navigation/client.go
+++ b/services/navigation/client.go
@@ -45,7 +45,7 @@ func NewClientFromConn(
 	return c, nil
 }
 
-func (c *client) Mode(ctx context.Context, extra map[string]interface{}) (Mode, error) {
+func (c *client) Mode(ctx context.Context, extra map[string]any) (Mode, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return 0, err
@@ -69,7 +69,7 @@ func (c *client) Mode(ctx context.Context, extra map[string]interface{}) (Mode, 
 	}
 }
 
-func (c *client) SetMode(ctx context.Context, mode Mode, extra map[string]interface{}) error {
+func (c *client) SetMode(ctx context.Context, mode Mode, extra map[string]any) error {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return err
@@ -92,7 +92,7 @@ func (c *client) SetMode(ctx context.Context, mode Mode, extra map[string]interf
 	return nil
 }
 
-func (c *client) Location(ctx context.Context, extra map[string]interface{}) (*spatialmath.GeoPose, error) {
+func (c *client) Location(ctx context.Context, extra map[string]any) (*spatialmath.GeoPose, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return nil, err
@@ -108,7 +108,7 @@ func (c *client) Location(ctx context.Context, extra map[string]interface{}) (*s
 	return geoPose, nil
 }
 
-func (c *client) Waypoints(ctx context.Context, extra map[string]interface{}) ([]Waypoint, error) {
+func (c *client) Waypoints(ctx context.Context, extra map[string]any) ([]Waypoint, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return nil, err
@@ -134,7 +134,7 @@ func (c *client) Waypoints(ctx context.Context, extra map[string]interface{}) ([
 	return result, nil
 }
 
-func (c *client) AddWaypoint(ctx context.Context, point *geo.Point, extra map[string]interface{}) error {
+func (c *client) AddWaypoint(ctx context.Context, point *geo.Point, extra map[string]any) error {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return err
@@ -155,7 +155,7 @@ func (c *client) AddWaypoint(ctx context.Context, point *geo.Point, extra map[st
 	return nil
 }
 
-func (c *client) RemoveWaypoint(ctx context.Context, id primitive.ObjectID, extra map[string]interface{}) error {
+func (c *client) RemoveWaypoint(ctx context.Context, id primitive.ObjectID, extra map[string]any) error {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return err
@@ -168,7 +168,7 @@ func (c *client) RemoveWaypoint(ctx context.Context, id primitive.ObjectID, extr
 	return nil
 }
 
-func (c *client) Obstacles(ctx context.Context, extra map[string]interface{}) ([]*spatialmath.GeoObstacle, error) {
+func (c *client) Obstacles(ctx context.Context, extra map[string]any) ([]*spatialmath.GeoObstacle, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return nil, err
@@ -190,7 +190,7 @@ func (c *client) Obstacles(ctx context.Context, extra map[string]interface{}) ([
 	return geos, nil
 }
 
-func (c *client) Paths(ctx context.Context, extra map[string]interface{}) ([]*Path, error) {
+func (c *client) Paths(ctx context.Context, extra map[string]any) ([]*Path, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return nil, err
@@ -220,6 +220,6 @@ func (c *client) Properties(ctx context.Context) (Properties, error) {
 	return prop, nil
 }
 
-func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (c *client) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	return rprotoutils.DoFromResourceClient(ctx, c.client, c.name, cmd)
 }

--- a/services/navigation/navigation.go
+++ b/services/navigation/navigation.go
@@ -83,18 +83,18 @@ type Properties struct {
 // A Service controls the navigation for a robot.
 type Service interface {
 	resource.Resource
-	Mode(ctx context.Context, extra map[string]interface{}) (Mode, error)
-	SetMode(ctx context.Context, mode Mode, extra map[string]interface{}) error
-	Location(ctx context.Context, extra map[string]interface{}) (*spatialmath.GeoPose, error)
+	Mode(ctx context.Context, extra map[string]any) (Mode, error)
+	SetMode(ctx context.Context, mode Mode, extra map[string]any) error
+	Location(ctx context.Context, extra map[string]any) (*spatialmath.GeoPose, error)
 
 	// Waypoint
-	Waypoints(ctx context.Context, extra map[string]interface{}) ([]Waypoint, error)
-	AddWaypoint(ctx context.Context, point *geo.Point, extra map[string]interface{}) error
-	RemoveWaypoint(ctx context.Context, id primitive.ObjectID, extra map[string]interface{}) error
+	Waypoints(ctx context.Context, extra map[string]any) ([]Waypoint, error)
+	AddWaypoint(ctx context.Context, point *geo.Point, extra map[string]any) error
+	RemoveWaypoint(ctx context.Context, id primitive.ObjectID, extra map[string]any) error
 
-	Obstacles(ctx context.Context, extra map[string]interface{}) ([]*spatialmath.GeoObstacle, error)
+	Obstacles(ctx context.Context, extra map[string]any) ([]*spatialmath.GeoObstacle, error)
 
-	Paths(ctx context.Context, extra map[string]interface{}) ([]*Path, error)
+	Paths(ctx context.Context, extra map[string]any) ([]*Path, error)
 
 	Properties(ctx context.Context) (Properties, error)
 }

--- a/services/navigation/server.go
+++ b/services/navigation/server.go
@@ -22,7 +22,7 @@ type serviceServer struct {
 
 // NewRPCServiceServer constructs a navigation gRPC service server.
 // It is intentionally untyped to prevent use outside of tests.
-func NewRPCServiceServer(coll resource.APIResourceCollection[Service]) interface{} {
+func NewRPCServiceServer(coll resource.APIResourceCollection[Service]) any {
 	return &serviceServer{coll: coll}
 }
 

--- a/services/navigation/store.go
+++ b/services/navigation/store.go
@@ -42,8 +42,8 @@ const (
 
 // StoreConfig describes how to configure data storage.
 type StoreConfig struct {
-	Type   storeType              `json:"type"`
-	Config map[string]interface{} `json:"config"`
+	Type   storeType      `json:"type"`
+	Config map[string]any `json:"config"`
 }
 
 // Validate ensures all parts of the config are valid.
@@ -206,7 +206,7 @@ var (
 )
 
 // NewMongoDBNavigationStore creates a new navigation store using MongoDB.
-func NewMongoDBNavigationStore(ctx context.Context, config map[string]interface{}) (*MongoDBNavigationStore, error) {
+func NewMongoDBNavigationStore(ctx context.Context, config map[string]any) (*MongoDBNavigationStore, error) {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 

--- a/services/sensors/builtin/builtin.go
+++ b/services/sensors/builtin/builtin.go
@@ -48,7 +48,7 @@ type builtIn struct {
 }
 
 // Sensors returns all sensors in the robot.
-func (s *builtIn) Sensors(ctx context.Context, extra map[string]interface{}) ([]resource.Name, error) {
+func (s *builtIn) Sensors(ctx context.Context, extra map[string]any) ([]resource.Name, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -60,7 +60,7 @@ func (s *builtIn) Sensors(ctx context.Context, extra map[string]interface{}) ([]
 }
 
 // Readings returns the readings of the resources specified.
-func (s *builtIn) Readings(ctx context.Context, sensorNames []resource.Name, extra map[string]interface{}) ([]sensors.Readings, error) {
+func (s *builtIn) Readings(ctx context.Context, sensorNames []resource.Name, extra map[string]any) ([]sensors.Readings, error) {
 	s.mu.RLock()
 	// make a copy of sensors and then unlock
 	sensorsMap := make(map[resource.Name]sensor.Sensor, len(s.sensors))

--- a/services/sensors/builtin/builtin_test.go
+++ b/services/sensors/builtin/builtin_test.go
@@ -41,7 +41,7 @@ func TestGetSensors(t *testing.T) {
 		err = svc.Reconfigure(context.Background(), resourceMap, resource.Config{})
 		test.That(t, err, test.ShouldBeNil)
 
-		names, err := svc.Sensors(context.Background(), map[string]interface{}{})
+		names, err := svc.Sensors(context.Background(), map[string]any{})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, names, test.ShouldBeEmpty)
 	})
@@ -56,7 +56,7 @@ func TestGetSensors(t *testing.T) {
 		err = svc.Reconfigure(context.Background(), resourceMap, resource.Config{})
 		test.That(t, err, test.ShouldBeNil)
 
-		sNames1, err := svc.Sensors(context.Background(), map[string]interface{}{})
+		sNames1, err := svc.Sensors(context.Background(), map[string]any{})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(
 			t,
@@ -76,7 +76,7 @@ func TestGetSensors(t *testing.T) {
 		err = svc.Reconfigure(context.Background(), resourceMap, resource.Config{})
 		test.That(t, err, test.ShouldBeNil)
 
-		sNames1, err := svc.Sensors(context.Background(), map[string]interface{}{})
+		sNames1, err := svc.Sensors(context.Background(), map[string]any{})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, testutils.NewResourceNameSet(sNames1...), test.ShouldResemble, testutils.NewResourceNameSet(sensorNames...))
 	})
@@ -98,14 +98,14 @@ func TestReadings(t *testing.T) {
 		err = svc.Reconfigure(context.Background(), resourceMap, resource.Config{})
 		test.That(t, err, test.ShouldBeNil)
 
-		_, err = svc.Readings(context.Background(), []resource.Name{movementsensor.Named("imu")}, map[string]interface{}{})
+		_, err = svc.Readings(context.Background(), []resource.Name{movementsensor.Named("imu")}, map[string]any{})
 		test.That(t, err.Error(), test.ShouldContainSubstring, "not a registered sensor")
 	})
 
 	t.Run("failing sensor", func(t *testing.T) {
 		injectSensor := &inject.Sensor{}
 		passedErr := errors.New("can't get readings")
-		injectSensor.ReadingsFunc = func(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+		injectSensor.ReadingsFunc = func(ctx context.Context, extra map[string]any) (map[string]any, error) {
 			return nil, passedErr
 		}
 		failMap := map[resource.Name]resource.Resource{
@@ -118,27 +118,27 @@ func TestReadings(t *testing.T) {
 		err = svc.Reconfigure(context.Background(), failMap, resource.Config{})
 		test.That(t, err, test.ShouldBeNil)
 
-		_, err = svc.Readings(context.Background(), []resource.Name{movementsensor.Named("imu")}, map[string]interface{}{})
+		_, err = svc.Readings(context.Background(), []resource.Name{movementsensor.Named("imu")}, map[string]any{})
 		test.That(t, err, test.ShouldBeError, errors.Wrapf(passedErr, "failed to get reading from %q", movementsensor.Named("imu")))
 	})
 
 	t.Run("many sensors", func(t *testing.T) {
-		readings1 := map[string]interface{}{"a": 1.1, "b": 2.2}
+		readings1 := map[string]any{"a": 1.1, "b": 2.2}
 		injectSensor := &inject.Sensor{}
-		injectSensor.ReadingsFunc = func(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+		injectSensor.ReadingsFunc = func(ctx context.Context, extra map[string]any) (map[string]any, error) {
 			return readings1, nil
 		}
-		readings2 := map[string]interface{}{"a": 2.2, "b": 3.3}
+		readings2 := map[string]any{"a": 2.2, "b": 3.3}
 		injectSensor2 := &inject.Sensor{}
-		injectSensor2.ReadingsFunc = func(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+		injectSensor2.ReadingsFunc = func(ctx context.Context, extra map[string]any) (map[string]any, error) {
 			return readings2, nil
 		}
 		injectSensor3 := &inject.Sensor{}
 		passedErr := errors.New("can't read")
-		injectSensor3.ReadingsFunc = func(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+		injectSensor3.ReadingsFunc = func(ctx context.Context, extra map[string]any) (map[string]any, error) {
 			return nil, passedErr
 		}
-		expected := map[resource.Name]interface{}{
+		expected := map[resource.Name]any{
 			movementsensor.Named("imu"): readings1,
 			movementsensor.Named("gps"): readings2,
 		}
@@ -151,10 +151,10 @@ func TestReadings(t *testing.T) {
 		err = svc.Reconfigure(context.Background(), resourceMap, resource.Config{})
 		test.That(t, err, test.ShouldBeNil)
 
-		_, err = svc.Readings(context.Background(), []resource.Name{movementsensor.Named("imu2")}, map[string]interface{}{})
+		_, err = svc.Readings(context.Background(), []resource.Name{movementsensor.Named("imu2")}, map[string]any{})
 		test.That(t, err.Error(), test.ShouldContainSubstring, "not a registered sensor")
 
-		readings, err := svc.Readings(context.Background(), []resource.Name{movementsensor.Named("imu")}, map[string]interface{}{})
+		readings, err := svc.Readings(context.Background(), []resource.Name{movementsensor.Named("imu")}, map[string]any{})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, len(readings), test.ShouldEqual, 1)
 		reading := readings[0]
@@ -164,7 +164,7 @@ func TestReadings(t *testing.T) {
 		readings, err = svc.Readings(
 			context.Background(),
 			[]resource.Name{movementsensor.Named("imu"), movementsensor.Named("imu"), movementsensor.Named("imu")},
-			map[string]interface{}{},
+			map[string]any{},
 		)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, len(readings), test.ShouldEqual, 1)
@@ -175,14 +175,14 @@ func TestReadings(t *testing.T) {
 		readings, err = svc.Readings(
 			context.Background(),
 			[]resource.Name{movementsensor.Named("imu"), movementsensor.Named("gps")},
-			map[string]interface{}{},
+			map[string]any{},
 		)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, len(readings), test.ShouldEqual, 2)
 		test.That(t, readings[0].Readings, test.ShouldResemble, expected[readings[0].Name])
 		test.That(t, readings[1].Readings, test.ShouldResemble, expected[readings[1].Name])
 
-		_, err = svc.Readings(context.Background(), sensorNames, map[string]interface{}{})
+		_, err = svc.Readings(context.Background(), sensorNames, map[string]any{})
 		test.That(t, err, test.ShouldBeError, errors.Wrapf(passedErr, "failed to get reading from %q", movementsensor.Named("gps2")))
 	})
 }
@@ -202,7 +202,7 @@ func TestReconfigure(t *testing.T) {
 		err = svc.Reconfigure(context.Background(), resourceMap, resource.Config{})
 		test.That(t, err, test.ShouldBeNil)
 
-		sNames1, err := svc.Sensors(context.Background(), map[string]interface{}{})
+		sNames1, err := svc.Sensors(context.Background(), map[string]any{})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, testutils.NewResourceNameSet(sNames1...), test.ShouldResemble, testutils.NewResourceNameSet(sensorNames...))
 
@@ -215,7 +215,7 @@ func TestReconfigure(t *testing.T) {
 		)
 		test.That(t, err, test.ShouldBeNil)
 
-		sNames1, err = svc.Sensors(context.Background(), map[string]interface{}{})
+		sNames1, err = svc.Sensors(context.Background(), map[string]any{})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, sNames1, test.ShouldBeEmpty)
 	})
@@ -226,7 +226,7 @@ func TestReconfigure(t *testing.T) {
 		err = svc.Reconfigure(context.Background(), resourceMap, resource.Config{})
 		test.That(t, err, test.ShouldBeNil)
 
-		sNames1, err := svc.Sensors(context.Background(), map[string]interface{}{})
+		sNames1, err := svc.Sensors(context.Background(), map[string]any{})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, testutils.NewResourceNameSet(sNames1...), test.ShouldResemble, testutils.NewResourceNameSet(sensorNames...))
 
@@ -237,7 +237,7 @@ func TestReconfigure(t *testing.T) {
 		)
 		test.That(t, err, test.ShouldBeNil)
 
-		sNames1, err = svc.Sensors(context.Background(), map[string]interface{}{})
+		sNames1, err = svc.Sensors(context.Background(), map[string]any{})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(
 			t,
@@ -253,7 +253,7 @@ func TestReconfigure(t *testing.T) {
 		err = svc.Reconfigure(context.Background(), resourceMap, resource.Config{})
 		test.That(t, err, test.ShouldBeNil)
 
-		sNames1, err := svc.Sensors(context.Background(), map[string]interface{}{})
+		sNames1, err := svc.Sensors(context.Background(), map[string]any{})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, testutils.NewResourceNameSet(sNames1...), test.ShouldResemble, testutils.NewResourceNameSet(sensorNames...))
 
@@ -264,7 +264,7 @@ func TestReconfigure(t *testing.T) {
 		)
 		test.That(t, err, test.ShouldBeNil)
 
-		sNames1, err = svc.Sensors(context.Background(), map[string]interface{}{})
+		sNames1, err = svc.Sensors(context.Background(), map[string]any{})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, testutils.NewResourceNameSet(sNames1...), test.ShouldResemble, testutils.NewResourceNameSet(sensorNames...))
 	})

--- a/services/sensors/client.go
+++ b/services/sensors/client.go
@@ -44,7 +44,7 @@ func NewClientFromConn(
 	return c, nil
 }
 
-func (c *client) Sensors(ctx context.Context, extra map[string]interface{}) ([]resource.Name, error) {
+func (c *client) Sensors(ctx context.Context, extra map[string]any) ([]resource.Name, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return nil, err
@@ -60,7 +60,7 @@ func (c *client) Sensors(ctx context.Context, extra map[string]interface{}) ([]r
 	return sensorNames, nil
 }
 
-func (c *client) Readings(ctx context.Context, sensorNames []resource.Name, extra map[string]interface{}) ([]Readings, error) {
+func (c *client) Readings(ctx context.Context, sensorNames []resource.Name, extra map[string]any) ([]Readings, error) {
 	names := make([]*commonpb.ResourceName, 0, len(sensorNames))
 	for _, name := range sensorNames {
 		names = append(names, rprotoutils.ResourceNameToProto(name))
@@ -89,6 +89,6 @@ func (c *client) Readings(ctx context.Context, sensorNames []resource.Name, extr
 	return readings, nil
 }
 
-func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (c *client) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	return rprotoutils.DoFromResourceClient(ctx, c.client, c.name, cmd)
 }

--- a/services/sensors/sensors.go
+++ b/services/sensors/sensors.go
@@ -23,14 +23,14 @@ func init() {
 // A Readings ties both the sensor name and its reading together.
 type Readings struct {
 	Name     resource.Name
-	Readings map[string]interface{}
+	Readings map[string]any
 }
 
 // A Service centralizes all sensors into one place.
 type Service interface {
 	resource.Resource
-	Sensors(ctx context.Context, extra map[string]interface{}) ([]resource.Name, error)
-	Readings(ctx context.Context, sensorNames []resource.Name, extra map[string]interface{}) ([]Readings, error)
+	Sensors(ctx context.Context, extra map[string]any) ([]resource.Name, error)
+	Readings(ctx context.Context, sensorNames []resource.Name, extra map[string]any) ([]Readings, error)
 }
 
 // SubtypeName is the name of the type of service.

--- a/services/sensors/server.go
+++ b/services/sensors/server.go
@@ -21,7 +21,7 @@ type serviceServer struct {
 
 // NewRPCServiceServer constructs a sensors gRPC service server.
 // It is intentionally untyped to prevent use outside of tests.
-func NewRPCServiceServer(coll resource.APIResourceCollection[Service]) interface{} {
+func NewRPCServiceServer(coll resource.APIResourceCollection[Service]) any {
 	return &serviceServer{coll: coll}
 }
 

--- a/services/sensors/server_test.go
+++ b/services/sensors/server_test.go
@@ -45,7 +45,7 @@ func TestServerGetSensors(t *testing.T) {
 		server, err := newServer(sMap)
 		test.That(t, err, test.ShouldBeNil)
 		passedErr := errors.New("can't get sensors")
-		injectSensors.SensorsFunc = func(ctx context.Context, extra map[string]interface{}) ([]resource.Name, error) {
+		injectSensors.SensorsFunc = func(ctx context.Context, extra map[string]any) ([]resource.Name, error) {
 			return nil, passedErr
 		}
 		_, err = server.GetSensors(context.Background(), &pb.GetSensorsRequest{Name: testSvcName1.ShortName()})
@@ -60,13 +60,13 @@ func TestServerGetSensors(t *testing.T) {
 		server, err := newServer(sMap)
 		test.That(t, err, test.ShouldBeNil)
 
-		var extraOptions map[string]interface{}
+		var extraOptions map[string]any
 		names := []resource.Name{movementsensor.Named("gps"), movementsensor.Named("imu")}
-		injectSensors.SensorsFunc = func(ctx context.Context, extra map[string]interface{}) ([]resource.Name, error) {
+		injectSensors.SensorsFunc = func(ctx context.Context, extra map[string]any) ([]resource.Name, error) {
 			extraOptions = extra
 			return names, nil
 		}
-		extra := map[string]interface{}{"foo": "Sensors"}
+		extra := map[string]any{"foo": "Sensors"}
 		ext, err := protoutils.StructToStructPb(extra)
 		test.That(t, err, test.ShouldBeNil)
 
@@ -100,7 +100,7 @@ func TestServerGetReadings(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		passedErr := errors.New("can't get readings")
 		injectSensors.ReadingsFunc = func(
-			ctx context.Context, sensors []resource.Name, extra map[string]interface{},
+			ctx context.Context, sensors []resource.Name, extra map[string]any,
 		) ([]sensors.Readings, error) {
 			return nil, passedErr
 		}
@@ -119,21 +119,21 @@ func TestServerGetReadings(t *testing.T) {
 		}
 		server, err := newServer(sMap)
 		test.That(t, err, test.ShouldBeNil)
-		iReading := sensors.Readings{Name: movementsensor.Named("imu"), Readings: map[string]interface{}{"a": 1.2, "b": 2.3, "c": 3.4}}
-		gReading := sensors.Readings{Name: movementsensor.Named("gps"), Readings: map[string]interface{}{"a": 4.5, "b": 5.6, "c": 6.7}}
+		iReading := sensors.Readings{Name: movementsensor.Named("imu"), Readings: map[string]any{"a": 1.2, "b": 2.3, "c": 3.4}}
+		gReading := sensors.Readings{Name: movementsensor.Named("gps"), Readings: map[string]any{"a": 4.5, "b": 5.6, "c": 6.7}}
 		readings := []sensors.Readings{iReading, gReading}
-		expected := map[resource.Name]interface{}{
+		expected := map[resource.Name]any{
 			iReading.Name: iReading.Readings,
 			gReading.Name: gReading.Readings,
 		}
-		var extraOptions map[string]interface{}
+		var extraOptions map[string]any
 		injectSensors.ReadingsFunc = func(
-			ctx context.Context, sensors []resource.Name, extra map[string]interface{},
+			ctx context.Context, sensors []resource.Name, extra map[string]any,
 		) ([]sensors.Readings, error) {
 			extraOptions = extra
 			return readings, nil
 		}
-		extra := map[string]interface{}{"foo": "Readings"}
+		extra := map[string]any{"foo": "Readings"}
 		ext, err := protoutils.StructToStructPb(extra)
 		test.That(t, err, test.ShouldBeNil)
 
@@ -147,15 +147,15 @@ func TestServerGetReadings(t *testing.T) {
 		test.That(t, len(resp.Readings), test.ShouldEqual, 2)
 		test.That(t, extraOptions, test.ShouldResemble, extra)
 
-		conv := func(rs map[string]*structpb.Value) map[string]interface{} {
-			r := map[string]interface{}{}
+		conv := func(rs map[string]*structpb.Value) map[string]any {
+			r := map[string]any{}
 			for k, value := range rs {
 				r[k] = value.AsInterface()
 			}
 			return r
 		}
 
-		observed := map[resource.Name]interface{}{
+		observed := map[resource.Name]any{
 			rprotoutils.ResourceNameFromProto(resp.Readings[0].Name): conv(resp.Readings[0].Readings),
 			rprotoutils.ResourceNameFromProto(resp.Readings[1].Name): conv(resp.Readings[1].Readings),
 		}

--- a/services/shell/builtin/builtin.go
+++ b/services/shell/builtin/builtin.go
@@ -44,7 +44,7 @@ type builtIn struct {
 	activeBackgroundWorkers sync.WaitGroup
 }
 
-func (svc *builtIn) Shell(ctx context.Context, extra map[string]interface{}) (chan<- string, <-chan shell.Output, error) {
+func (svc *builtIn) Shell(ctx context.Context, extra map[string]any) (chan<- string, <-chan shell.Output, error) {
 	if runtime.GOOS == "windows" {
 		return nil, nil, errors.New("shell not supported on windows yet; sorry")
 	}

--- a/services/shell/client.go
+++ b/services/shell/client.go
@@ -45,7 +45,7 @@ func NewClientFromConn(
 	return c, nil
 }
 
-func (c *client) Shell(ctx context.Context, extra map[string]interface{}) (chan<- string, <-chan Output, error) {
+func (c *client) Shell(ctx context.Context, extra map[string]any) (chan<- string, <-chan Output, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return nil, nil, err
@@ -126,6 +126,6 @@ func (c *client) Shell(ctx context.Context, extra map[string]interface{}) (chan<
 	return input, output, nil
 }
 
-func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (c *client) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	return rprotoutils.DoFromResourceClient(ctx, c.client, c.name, cmd)
 }

--- a/services/shell/server.go
+++ b/services/shell/server.go
@@ -22,7 +22,7 @@ type serviceServer struct {
 
 // NewRPCServiceServer constructs a framesystem gRPC service server.
 // It is intentionally untyped to prevent use outside of tests.
-func NewRPCServiceServer(coll resource.APIResourceCollection[Service]) interface{} {
+func NewRPCServiceServer(coll resource.APIResourceCollection[Service]) any {
 	return &serviceServer{coll: coll}
 }
 

--- a/services/shell/shell.go
+++ b/services/shell/shell.go
@@ -21,7 +21,7 @@ func init() {
 // A Service handles shells for a local robot.
 type Service interface {
 	resource.Resource
-	Shell(ctx context.Context, extra map[string]interface{}) (input chan<- string, output <-chan Output, retErr error)
+	Shell(ctx context.Context, extra map[string]any) (input chan<- string, output <-chan Output, retErr error)
 }
 
 // Output reflects an instance of shell output on either stdout or stderr.

--- a/services/slam/client.go
+++ b/services/slam/client.go
@@ -108,7 +108,7 @@ func (c *client) Properties(ctx context.Context) (Properties, error) {
 	return prop, err
 }
 
-func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (c *client) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	ctx, span := trace.StartSpan(ctx, "slam::client::DoCommand")
 	defer span.End()
 

--- a/services/slam/collector.go
+++ b/services/slam/collector.go
@@ -27,13 +27,13 @@ func (m method) String() string {
 	return "Unknown"
 }
 
-func newPositionCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+func newPositionCollector(resource any, params data.CollectorParams) (data.Collector, error) {
 	slam, err := assertSLAM(resource)
 	if err != nil {
 		return nil, err
 	}
 
-	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (interface{}, error) {
+	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (any, error) {
 		pose, componentRef, err := slam.Position(ctx)
 		if err != nil {
 			return nil, data.FailedToReadErr(params.ComponentName, position.String(), err)
@@ -43,13 +43,13 @@ func newPositionCollector(resource interface{}, params data.CollectorParams) (da
 	return data.NewCollector(cFunc, params)
 }
 
-func newPointCloudMapCollector(resource interface{}, params data.CollectorParams) (data.Collector, error) {
+func newPointCloudMapCollector(resource any, params data.CollectorParams) (data.Collector, error) {
 	slam, err := assertSLAM(resource)
 	if err != nil {
 		return nil, err
 	}
 
-	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (interface{}, error) {
+	cFunc := data.CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (any, error) {
 		f, err := slam.PointCloudMap(ctx)
 		if err != nil {
 			return nil, data.FailedToReadErr(params.ComponentName, pointCloudMap.String(), err)
@@ -65,7 +65,7 @@ func newPointCloudMapCollector(resource interface{}, params data.CollectorParams
 	return data.NewCollector(cFunc, params)
 }
 
-func assertSLAM(resource interface{}) (Service, error) {
+func assertSLAM(resource any) (Service, error) {
 	slamService, ok := resource.(Service)
 	if !ok {
 		return nil, data.InvalidInterfaceErr(API)

--- a/services/slam/server.go
+++ b/services/slam/server.go
@@ -22,7 +22,7 @@ type serviceServer struct {
 
 // NewRPCServiceServer constructs a the slam gRPC service server.
 // It is intentionally untyped to prevent use outside of tests.
-func NewRPCServiceServer(coll resource.APIResourceCollection[Service]) interface{} {
+func NewRPCServiceServer(coll resource.APIResourceCollection[Service]) any {
 	return &serviceServer{coll: coll}
 }
 

--- a/services/vision/client.go
+++ b/services/vision/client.go
@@ -56,7 +56,7 @@ func NewClientFromConn(
 func (c *client) DetectionsFromCamera(
 	ctx context.Context,
 	cameraName string,
-	extra map[string]interface{},
+	extra map[string]any,
 ) ([]objdet.Detection, error) {
 	ctx, span := trace.StartSpan(ctx, "service::vision::client::DetectionsFromCamera")
 	defer span.End()
@@ -84,7 +84,7 @@ func (c *client) DetectionsFromCamera(
 	return detections, nil
 }
 
-func (c *client) Detections(ctx context.Context, img image.Image, extra map[string]interface{},
+func (c *client) Detections(ctx context.Context, img image.Image, extra map[string]any,
 ) ([]objdet.Detection, error) {
 	ctx, span := trace.StartSpan(ctx, "service::vision::client::Detections")
 	defer span.End()
@@ -127,7 +127,7 @@ func (c *client) ClassificationsFromCamera(
 	ctx context.Context,
 	cameraName string,
 	n int,
-	extra map[string]interface{},
+	extra map[string]any,
 ) (classification.Classifications, error) {
 	ctx, span := trace.StartSpan(ctx, "service::vision::client::ClassificationsFromCamera")
 	defer span.End()
@@ -153,7 +153,7 @@ func (c *client) ClassificationsFromCamera(
 }
 
 func (c *client) Classifications(ctx context.Context, img image.Image,
-	n int, extra map[string]interface{},
+	n int, extra map[string]any,
 ) (classification.Classifications, error) {
 	ctx, span := trace.StartSpan(ctx, "service::vision::client::Classifications")
 	defer span.End()
@@ -192,7 +192,7 @@ func (c *client) Classifications(ctx context.Context, img image.Image,
 func (c *client) GetObjectPointClouds(
 	ctx context.Context,
 	cameraName string,
-	extra map[string]interface{},
+	extra map[string]any,
 ) ([]*vision.Object, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
@@ -242,7 +242,7 @@ func protoToObjects(pco []*commonpb.PointCloudObject) ([]*vision.Object, error) 
 	return objects, nil
 }
 
-func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (c *client) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	ctx, span := trace.StartSpan(ctx, "service::vision::client::DoCommand")
 	defer span.End()
 

--- a/services/vision/client_test.go
+++ b/services/vision/client_test.go
@@ -29,14 +29,14 @@ func TestClient(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	srv := &inject.VisionService{}
-	srv.DetectionsFunc = func(ctx context.Context, img image.Image, extra map[string]interface{}) ([]objectdetection.Detection, error) {
+	srv.DetectionsFunc = func(ctx context.Context, img image.Image, extra map[string]any) ([]objectdetection.Detection, error) {
 		det1 := objectdetection.NewDetection(image.Rect(5, 10, 15, 20), 0.5, "yes")
 		return []objectdetection.Detection{det1}, nil
 	}
 	srv.DetectionsFromCameraFunc = func(
 		ctx context.Context,
 		camName string,
-		extra map[string]interface{},
+		extra map[string]any,
 	) ([]objectdetection.Detection, error) {
 		det1 := objectdetection.NewDetection(image.Rect(0, 0, 10, 20), 0.8, "camera")
 		return []objectdetection.Detection{det1}, nil

--- a/services/vision/detectionstosegments/detections_to_3dsegments_test.go
+++ b/services/vision/detectionstosegments/detections_to_3dsegments_test.go
@@ -79,12 +79,12 @@ func Test3DSegmentsFromDetector(t *testing.T) {
 	test.That(t, seg.Name(), test.ShouldResemble, name3)
 
 	// fails on not finding camera
-	_, err = seg.GetObjectPointClouds(context.Background(), "no_camera", map[string]interface{}{})
+	_, err = seg.GetObjectPointClouds(context.Background(), "no_camera", map[string]any{})
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "not found")
 
 	// fails since camera cannot return images
-	_, err = seg.GetObjectPointClouds(context.Background(), "fakeCamera", map[string]interface{}{})
+	_, err = seg.GetObjectPointClouds(context.Background(), "fakeCamera", map[string]any{})
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "no images")
 
@@ -117,7 +117,7 @@ func Test3DSegmentsFromDetector(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		return cloud, nil
 	}
-	objects, err := seg.GetObjectPointClouds(context.Background(), "fakeCamera", map[string]interface{}{})
+	objects, err := seg.GetObjectPointClouds(context.Background(), "fakeCamera", map[string]any{})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, len(objects), test.ShouldEqual, 1)
 	test.That(t, objects[0].Size(), test.ShouldEqual, 2)

--- a/services/vision/mlvision/ml_model.go
+++ b/services/vision/mlvision/ml_model.go
@@ -271,7 +271,7 @@ func convertNumberSlice[T1, T2 number](t1 []T1) []T2 {
 	return t2
 }
 
-func convertToFloat64Slice(slice interface{}) ([]float64, error) {
+func convertToFloat64Slice(slice any) ([]float64, error) {
 	switch v := slice.(type) {
 	case []float64:
 		return v, nil

--- a/services/vision/obstaclespointcloud/obstacles_pointcloud_test.go
+++ b/services/vision/obstaclespointcloud/obstacles_pointcloud_test.go
@@ -60,12 +60,12 @@ func TestRadiusClusteringSegmentation(t *testing.T) {
 	test.That(t, seg.Name(), test.ShouldResemble, name)
 
 	// fails on not finding camera
-	_, err = seg.GetObjectPointClouds(context.Background(), "no_camera", map[string]interface{}{})
+	_, err = seg.GetObjectPointClouds(context.Background(), "no_camera", map[string]any{})
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "not found")
 
 	// fails since camera cannot generate point clouds
-	_, err = seg.GetObjectPointClouds(context.Background(), "fakeCamera", map[string]interface{}{})
+	_, err = seg.GetObjectPointClouds(context.Background(), "fakeCamera", map[string]any{})
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "no pointcloud")
 
@@ -92,7 +92,7 @@ func TestRadiusClusteringSegmentation(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		return cloud, nil
 	}
-	objects, err := seg.GetObjectPointClouds(context.Background(), "fakeCamera", map[string]interface{}{})
+	objects, err := seg.GetObjectPointClouds(context.Background(), "fakeCamera", map[string]any{})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, len(objects), test.ShouldEqual, 2)
 	// does not implement detector

--- a/services/vision/server.go
+++ b/services/vision/server.go
@@ -25,7 +25,7 @@ type serviceServer struct {
 
 // NewRPCServiceServer constructs a vision gRPC service server.
 // It is intentionally untyped to prevent use outside of tests.
-func NewRPCServiceServer(coll resource.APIResourceCollection[Service]) interface{} {
+func NewRPCServiceServer(coll resource.APIResourceCollection[Service]) any {
 	return &serviceServer{coll: coll}
 }
 

--- a/services/vision/server_test.go
+++ b/services/vision/server_test.go
@@ -49,7 +49,7 @@ func TestVisionServerFailures(t *testing.T) {
 	// correct server with error returned
 	injectVS := &inject.VisionService{}
 	passedErr := errors.New("fake error")
-	injectVS.DetectionsFunc = func(ctx context.Context, img image.Image, extra map[string]interface{}) ([]objectdetection.Detection, error) {
+	injectVS.DetectionsFunc = func(ctx context.Context, img image.Image, extra map[string]any) ([]objectdetection.Detection, error) {
 		return nil, passedErr
 	}
 	m = map[resource.Name]vision.Service{
@@ -75,7 +75,7 @@ func TestServerGetDetections(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	imgBytes, err := rimage.EncodeImage(context.Background(), img, utils.MimeTypeJPEG)
 	test.That(t, err, test.ShouldBeNil)
-	extra := map[string]interface{}{"foo": "GetDetections"}
+	extra := map[string]any{"foo": "GetDetections"}
 	ext, err := protoutils.StructToStructPb(extra)
 	detectRequest := &pb.GetDetectionsRequest{
 		Name:     testVisionServiceName,
@@ -85,7 +85,7 @@ func TestServerGetDetections(t *testing.T) {
 		MimeType: utils.MimeTypeJPEG,
 		Extra:    ext,
 	}
-	injectVS.DetectionsFunc = func(ctx context.Context, img image.Image, extra map[string]interface{}) ([]objectdetection.Detection, error) {
+	injectVS.DetectionsFunc = func(ctx context.Context, img image.Image, extra map[string]any) ([]objectdetection.Detection, error) {
 		det1 := objectdetection.NewDetection(image.Rectangle{}, 0.5, "yes")
 		return []objectdetection.Detection{det1}, nil
 	}

--- a/services/vision/vision.go
+++ b/services/vision/vision.go
@@ -31,23 +31,23 @@ func init() {
 // A Service that implements various computer vision algorithms like detection and segmentation.
 type Service interface {
 	resource.Resource
-	DetectionsFromCamera(ctx context.Context, cameraName string, extra map[string]interface{}) ([]objectdetection.Detection, error)
-	Detections(ctx context.Context, img image.Image, extra map[string]interface{}) ([]objectdetection.Detection, error)
+	DetectionsFromCamera(ctx context.Context, cameraName string, extra map[string]any) ([]objectdetection.Detection, error)
+	Detections(ctx context.Context, img image.Image, extra map[string]any) ([]objectdetection.Detection, error)
 	// classifier methods
 	ClassificationsFromCamera(
 		ctx context.Context,
 		cameraName string,
 		n int,
-		extra map[string]interface{},
+		extra map[string]any,
 	) (classification.Classifications, error)
 	Classifications(
 		ctx context.Context,
 		img image.Image,
 		n int,
-		extra map[string]interface{},
+		extra map[string]any,
 	) (classification.Classifications, error)
 	// segmenter methods
-	GetObjectPointClouds(ctx context.Context, cameraName string, extra map[string]interface{}) ([]*viz.Object, error)
+	GetObjectPointClouds(ctx context.Context, cameraName string, extra map[string]any) ([]*viz.Object, error)
 }
 
 // SubtypeName is the name of the type of service.
@@ -109,7 +109,7 @@ func NewService(
 func (vm *vizModel) Detections(
 	ctx context.Context,
 	img image.Image,
-	extra map[string]interface{},
+	extra map[string]any,
 ) ([]objectdetection.Detection, error) {
 	ctx, span := trace.StartSpan(ctx, "service::vision::Detections::"+vm.Named.Name().String())
 	defer span.End()
@@ -123,7 +123,7 @@ func (vm *vizModel) Detections(
 func (vm *vizModel) DetectionsFromCamera(
 	ctx context.Context,
 	cameraName string,
-	extra map[string]interface{},
+	extra map[string]any,
 ) ([]objectdetection.Detection, error) {
 	ctx, span := trace.StartSpan(ctx, "service::vision::DetectionsFromCamera::"+vm.Named.Name().String())
 	defer span.End()
@@ -147,7 +147,7 @@ func (vm *vizModel) Classifications(
 	ctx context.Context,
 	img image.Image,
 	n int,
-	extra map[string]interface{},
+	extra map[string]any,
 ) (classification.Classifications, error) {
 	ctx, span := trace.StartSpan(ctx, "service::vision::Classifications::"+vm.Named.Name().String())
 	defer span.End()
@@ -166,7 +166,7 @@ func (vm *vizModel) ClassificationsFromCamera(
 	ctx context.Context,
 	cameraName string,
 	n int,
-	extra map[string]interface{},
+	extra map[string]any,
 ) (classification.Classifications, error) {
 	ctx, span := trace.StartSpan(ctx, "service::vision::ClassificationsFromCamera::"+vm.Named.Name().String())
 	defer span.End()
@@ -190,7 +190,7 @@ func (vm *vizModel) ClassificationsFromCamera(
 }
 
 // GetObjectPointClouds returns all the found objects in a 3D image if the model implements Segmenter3D.
-func (vm *vizModel) GetObjectPointClouds(ctx context.Context, cameraName string, extra map[string]interface{}) ([]*viz.Object, error) {
+func (vm *vizModel) GetObjectPointClouds(ctx context.Context, cameraName string, extra map[string]any) ([]*viz.Object, error) {
 	if vm.segmenter3DFunc == nil {
 		return nil, errors.Errorf("vision model %q does not implement a 3D segmenter", vm.Named.Name().String())
 	}

--- a/services/vision/vision_test.go
+++ b/services/vision/vision_test.go
@@ -20,7 +20,7 @@ const (
 
 func TestFromRobot(t *testing.T) {
 	svc1 := &inject.VisionService{}
-	svc1.DetectionsFunc = func(ctx context.Context, img image.Image, extra map[string]interface{}) ([]objectdetection.Detection, error) {
+	svc1.DetectionsFunc = func(ctx context.Context, img image.Image, extra map[string]any) ([]objectdetection.Detection, error) {
 		det1 := objectdetection.NewDetection(image.Rectangle{}, 0.5, "yes")
 		return []objectdetection.Detection{det1}, nil
 	}

--- a/session/manager.go
+++ b/session/manager.go
@@ -25,12 +25,12 @@ type Manager interface {
 type ServerInterceptors struct {
 	UnaryServerInterceptor func(
 		ctx context.Context,
-		req interface{},
+		req any,
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
-	) (interface{}, error)
+	) (any, error)
 	StreamServerInterceptor func(
-		srv interface{},
+		srv any,
 		ss grpc.ServerStream,
 		info *grpc.StreamServerInfo,
 		handler grpc.StreamHandler,

--- a/spatialmath/pose.go
+++ b/spatialmath/pose.go
@@ -27,12 +27,12 @@ type Pose interface {
 }
 
 // PoseMap encodes the orientation interface to something serializable and human readable.
-func PoseMap(p Pose) (map[string]interface{}, error) {
+func PoseMap(p Pose) (map[string]any, error) {
 	oc, err := NewOrientationConfig(p.Orientation().AxisAngles())
 	if err != nil {
 		return nil, err
 	}
-	return map[string]interface{}{
+	return map[string]any{
 		"point":       p.Point(),
 		"orientation": oc,
 	}, nil

--- a/testutils/inject/analog_reader.go
+++ b/testutils/inject/analog_reader.go
@@ -9,13 +9,13 @@ import (
 // AnalogReader is an injected analog reader.
 type AnalogReader struct {
 	board.AnalogReader
-	ReadFunc func(ctx context.Context, extra map[string]interface{}) (int, error)
-	readCap  []interface{}
+	ReadFunc func(ctx context.Context, extra map[string]any) (int, error)
+	readCap  []any
 }
 
 // Read calls the injected Read or the real version.
-func (a *AnalogReader) Read(ctx context.Context, extra map[string]interface{}) (int, error) {
-	a.readCap = []interface{}{ctx}
+func (a *AnalogReader) Read(ctx context.Context, extra map[string]any) (int, error) {
+	a.readCap = []any{ctx}
 	if a.ReadFunc == nil {
 		return a.AnalogReader.Read(ctx, extra)
 	}
@@ -23,7 +23,7 @@ func (a *AnalogReader) Read(ctx context.Context, extra map[string]interface{}) (
 }
 
 // ReadCap returns the last parameters received by Read, and then clears them.
-func (a *AnalogReader) ReadCap() []interface{} {
+func (a *AnalogReader) ReadCap() []any {
 	if a == nil {
 		return nil
 	}

--- a/testutils/inject/arm.go
+++ b/testutils/inject/arm.go
@@ -15,12 +15,12 @@ import (
 type Arm struct {
 	arm.Arm
 	name                     resource.Name
-	DoFunc                   func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
-	EndPositionFunc          func(ctx context.Context, extra map[string]interface{}) (spatialmath.Pose, error)
-	MoveToPositionFunc       func(ctx context.Context, to spatialmath.Pose, extra map[string]interface{}) error
-	MoveToJointPositionsFunc func(ctx context.Context, pos *pb.JointPositions, extra map[string]interface{}) error
-	JointPositionsFunc       func(ctx context.Context, extra map[string]interface{}) (*pb.JointPositions, error)
-	StopFunc                 func(ctx context.Context, extra map[string]interface{}) error
+	DoFunc                   func(ctx context.Context, cmd map[string]any) (map[string]any, error)
+	EndPositionFunc          func(ctx context.Context, extra map[string]any) (spatialmath.Pose, error)
+	MoveToPositionFunc       func(ctx context.Context, to spatialmath.Pose, extra map[string]any) error
+	MoveToJointPositionsFunc func(ctx context.Context, pos *pb.JointPositions, extra map[string]any) error
+	JointPositionsFunc       func(ctx context.Context, extra map[string]any) (*pb.JointPositions, error)
+	StopFunc                 func(ctx context.Context, extra map[string]any) error
 	IsMovingFunc             func(context.Context) (bool, error)
 	CloseFunc                func(ctx context.Context) error
 	ModelFrameFunc           func() referenceframe.Model
@@ -39,7 +39,7 @@ func (a *Arm) Name() resource.Name {
 }
 
 // EndPosition calls the injected EndPosition or the real version.
-func (a *Arm) EndPosition(ctx context.Context, extra map[string]interface{}) (spatialmath.Pose, error) {
+func (a *Arm) EndPosition(ctx context.Context, extra map[string]any) (spatialmath.Pose, error) {
 	if a.EndPositionFunc == nil {
 		return a.Arm.EndPosition(ctx, extra)
 	}
@@ -47,7 +47,7 @@ func (a *Arm) EndPosition(ctx context.Context, extra map[string]interface{}) (sp
 }
 
 // MoveToPosition calls the injected MoveToPosition or the real version.
-func (a *Arm) MoveToPosition(ctx context.Context, to spatialmath.Pose, extra map[string]interface{}) error {
+func (a *Arm) MoveToPosition(ctx context.Context, to spatialmath.Pose, extra map[string]any) error {
 	if a.MoveToPositionFunc == nil {
 		return a.Arm.MoveToPosition(ctx, to, extra)
 	}
@@ -55,7 +55,7 @@ func (a *Arm) MoveToPosition(ctx context.Context, to spatialmath.Pose, extra map
 }
 
 // MoveToJointPositions calls the injected MoveToJointPositions or the real version.
-func (a *Arm) MoveToJointPositions(ctx context.Context, jp *pb.JointPositions, extra map[string]interface{}) error {
+func (a *Arm) MoveToJointPositions(ctx context.Context, jp *pb.JointPositions, extra map[string]any) error {
 	if a.MoveToJointPositionsFunc == nil {
 		return a.Arm.MoveToJointPositions(ctx, jp, extra)
 	}
@@ -63,7 +63,7 @@ func (a *Arm) MoveToJointPositions(ctx context.Context, jp *pb.JointPositions, e
 }
 
 // JointPositions calls the injected JointPositions or the real version.
-func (a *Arm) JointPositions(ctx context.Context, extra map[string]interface{}) (*pb.JointPositions, error) {
+func (a *Arm) JointPositions(ctx context.Context, extra map[string]any) (*pb.JointPositions, error) {
 	if a.JointPositionsFunc == nil {
 		return a.Arm.JointPositions(ctx, extra)
 	}
@@ -71,7 +71,7 @@ func (a *Arm) JointPositions(ctx context.Context, extra map[string]interface{}) 
 }
 
 // Stop calls the injected Stop or the real version.
-func (a *Arm) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (a *Arm) Stop(ctx context.Context, extra map[string]any) error {
 	if a.StopFunc == nil {
 		return a.Arm.Stop(ctx, extra)
 	}
@@ -98,7 +98,7 @@ func (a *Arm) Close(ctx context.Context) error {
 }
 
 // DoCommand calls the injected DoCommand or the real version.
-func (a *Arm) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (a *Arm) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	if a.DoFunc == nil {
 		return a.Arm.DoCommand(ctx, cmd)
 	}

--- a/testutils/inject/audioinput.go
+++ b/testutils/inject/audioinput.go
@@ -17,7 +17,7 @@ import (
 type AudioInput struct {
 	audioinput.AudioInput
 	name       resource.Name
-	DoFunc     func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
+	DoFunc     func(ctx context.Context, cmd map[string]any) (map[string]any, error)
 	StreamFunc func(
 		ctx context.Context,
 		errHandlers ...gostream.ErrorHandler,
@@ -70,7 +70,7 @@ func (ai *AudioInput) Close(ctx context.Context) error {
 }
 
 // DoCommand calls the injected DoCommand or the real version.
-func (ai *AudioInput) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (ai *AudioInput) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	if ai.DoFunc == nil {
 		return ai.AudioInput.DoCommand(ctx, cmd)
 	}

--- a/testutils/inject/base.go
+++ b/testutils/inject/base.go
@@ -14,15 +14,15 @@ import (
 type Base struct {
 	base.Base
 	name             resource.Name
-	DoFunc           func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
-	MoveStraightFunc func(ctx context.Context, distanceMm int, mmPerSec float64, extra map[string]interface{}) error
-	SpinFunc         func(ctx context.Context, angleDeg, degsPerSec float64, extra map[string]interface{}) error
-	StopFunc         func(ctx context.Context, extra map[string]interface{}) error
+	DoFunc           func(ctx context.Context, cmd map[string]any) (map[string]any, error)
+	MoveStraightFunc func(ctx context.Context, distanceMm int, mmPerSec float64, extra map[string]any) error
+	SpinFunc         func(ctx context.Context, angleDeg, degsPerSec float64, extra map[string]any) error
+	StopFunc         func(ctx context.Context, extra map[string]any) error
 	IsMovingFunc     func(context.Context) (bool, error)
 	CloseFunc        func(ctx context.Context) error
-	SetPowerFunc     func(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error
-	SetVelocityFunc  func(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error
-	PropertiesFunc   func(ctx context.Context, extra map[string]interface{}) (base.Properties, error)
+	SetPowerFunc     func(ctx context.Context, linear, angular r3.Vector, extra map[string]any) error
+	SetVelocityFunc  func(ctx context.Context, linear, angular r3.Vector, extra map[string]any) error
+	PropertiesFunc   func(ctx context.Context, extra map[string]any) (base.Properties, error)
 	GeometriesFunc   func(ctx context.Context) ([]spatialmath.Geometry, error)
 }
 
@@ -37,7 +37,7 @@ func (b *Base) Name() resource.Name {
 }
 
 // MoveStraight calls the injected MoveStraight or the real version.
-func (b *Base) MoveStraight(ctx context.Context, distanceMm int, mmPerSec float64, extra map[string]interface{}) error {
+func (b *Base) MoveStraight(ctx context.Context, distanceMm int, mmPerSec float64, extra map[string]any) error {
 	if b.MoveStraightFunc == nil {
 		return b.Base.MoveStraight(ctx, distanceMm, mmPerSec, extra)
 	}
@@ -45,7 +45,7 @@ func (b *Base) MoveStraight(ctx context.Context, distanceMm int, mmPerSec float6
 }
 
 // Spin calls the injected Spin or the real version.
-func (b *Base) Spin(ctx context.Context, angleDeg, degsPerSec float64, extra map[string]interface{}) error {
+func (b *Base) Spin(ctx context.Context, angleDeg, degsPerSec float64, extra map[string]any) error {
 	if b.SpinFunc == nil {
 		return b.Base.Spin(ctx, angleDeg, degsPerSec, extra)
 	}
@@ -53,7 +53,7 @@ func (b *Base) Spin(ctx context.Context, angleDeg, degsPerSec float64, extra map
 }
 
 // Stop calls the injected Stop or the real version.
-func (b *Base) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (b *Base) Stop(ctx context.Context, extra map[string]any) error {
 	if b.StopFunc == nil {
 		return b.Base.Stop(ctx, extra)
 	}
@@ -80,7 +80,7 @@ func (b *Base) Close(ctx context.Context) error {
 }
 
 // DoCommand calls the injected DoCommand or the real version.
-func (b *Base) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (b *Base) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	if b.DoFunc == nil {
 		return b.Base.DoCommand(ctx, cmd)
 	}
@@ -88,7 +88,7 @@ func (b *Base) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[s
 }
 
 // SetPower calls the injected SetPower or the real version.
-func (b *Base) SetPower(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error {
+func (b *Base) SetPower(ctx context.Context, linear, angular r3.Vector, extra map[string]any) error {
 	if b.SetPowerFunc == nil {
 		return b.Base.SetPower(ctx, linear, angular, extra)
 	}
@@ -96,7 +96,7 @@ func (b *Base) SetPower(ctx context.Context, linear, angular r3.Vector, extra ma
 }
 
 // SetVelocity calls the injected SetVelocity or the real version.
-func (b *Base) SetVelocity(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error {
+func (b *Base) SetVelocity(ctx context.Context, linear, angular r3.Vector, extra map[string]any) error {
 	if b.SetVelocityFunc == nil {
 		return b.Base.SetVelocity(ctx, linear, angular, extra)
 	}
@@ -104,7 +104,7 @@ func (b *Base) SetVelocity(ctx context.Context, linear, angular r3.Vector, extra
 }
 
 // Properties returns the base's properties.
-func (b *Base) Properties(ctx context.Context, extra map[string]interface{}) (base.Properties, error) {
+func (b *Base) Properties(ctx context.Context, extra map[string]any) (base.Properties, error) {
 	if b.PropertiesFunc == nil {
 		return b.Base.Properties(ctx, extra)
 	}
@@ -112,7 +112,7 @@ func (b *Base) Properties(ctx context.Context, extra map[string]interface{}) (ba
 }
 
 // Geometries returns the base's geometries.
-func (b *Base) Geometries(ctx context.Context, extra map[string]interface{}) ([]spatialmath.Geometry, error) {
+func (b *Base) Geometries(ctx context.Context, extra map[string]any) ([]spatialmath.Geometry, error) {
 	if b.GeometriesFunc == nil {
 		return b.Base.Geometries(ctx, extra)
 	}

--- a/testutils/inject/board.go
+++ b/testutils/inject/board.go
@@ -15,20 +15,20 @@ import (
 type Board struct {
 	board.Board
 	name                       resource.Name
-	DoFunc                     func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
+	DoFunc                     func(ctx context.Context, cmd map[string]any) (map[string]any, error)
 	AnalogReaderByNameFunc     func(name string) (board.AnalogReader, bool)
-	analogReaderByNameCap      []interface{}
+	analogReaderByNameCap      []any
 	DigitalInterruptByNameFunc func(name string) (board.DigitalInterrupt, bool)
-	digitalInterruptByNameCap  []interface{}
+	digitalInterruptByNameCap  []any
 	GPIOPinByNameFunc          func(name string) (board.GPIOPin, error)
-	gpioPinByNameCap           []interface{}
+	gpioPinByNameCap           []any
 	AnalogReaderNamesFunc      func() []string
 	DigitalInterruptNamesFunc  func() []string
 	CloseFunc                  func(ctx context.Context) error
-	StatusFunc                 func(ctx context.Context, extra map[string]interface{}) (*commonpb.BoardStatus, error)
-	statusCap                  []interface{}
+	StatusFunc                 func(ctx context.Context, extra map[string]any) (*commonpb.BoardStatus, error)
+	statusCap                  []any
 	SetPowerModeFunc           func(ctx context.Context, mode boardpb.PowerMode, duration *time.Duration) error
-	WriteAnalogFunc            func(ctx context.Context, pin string, value int32, extra map[string]interface{}) error
+	WriteAnalogFunc            func(ctx context.Context, pin string, value int32, extra map[string]any) error
 }
 
 // NewBoard returns a new injected board.
@@ -43,7 +43,7 @@ func (b *Board) Name() resource.Name {
 
 // AnalogReaderByName calls the injected AnalogReaderByName or the real version.
 func (b *Board) AnalogReaderByName(name string) (board.AnalogReader, bool) {
-	b.analogReaderByNameCap = []interface{}{name}
+	b.analogReaderByNameCap = []any{name}
 	if b.AnalogReaderByNameFunc == nil {
 		return b.Board.AnalogReaderByName(name)
 	}
@@ -51,7 +51,7 @@ func (b *Board) AnalogReaderByName(name string) (board.AnalogReader, bool) {
 }
 
 // AnalogReaderByNameCap returns the last parameters received by AnalogReaderByName, and then clears them.
-func (b *Board) AnalogReaderByNameCap() []interface{} {
+func (b *Board) AnalogReaderByNameCap() []any {
 	if b == nil {
 		return nil
 	}
@@ -61,7 +61,7 @@ func (b *Board) AnalogReaderByNameCap() []interface{} {
 
 // DigitalInterruptByName calls the injected DigitalInterruptByName or the real version.
 func (b *Board) DigitalInterruptByName(name string) (board.DigitalInterrupt, bool) {
-	b.digitalInterruptByNameCap = []interface{}{name}
+	b.digitalInterruptByNameCap = []any{name}
 	if b.DigitalInterruptByNameFunc == nil {
 		return b.Board.DigitalInterruptByName(name)
 	}
@@ -69,7 +69,7 @@ func (b *Board) DigitalInterruptByName(name string) (board.DigitalInterrupt, boo
 }
 
 // DigitalInterruptByNameCap returns the last parameters received by DigitalInterruptByName, and then clears them.
-func (b *Board) DigitalInterruptByNameCap() []interface{} {
+func (b *Board) DigitalInterruptByNameCap() []any {
 	if b == nil {
 		return nil
 	}
@@ -79,7 +79,7 @@ func (b *Board) DigitalInterruptByNameCap() []interface{} {
 
 // GPIOPinByName calls the injected GPIOPinByName or the real version.
 func (b *Board) GPIOPinByName(name string) (board.GPIOPin, error) {
-	b.gpioPinByNameCap = []interface{}{name}
+	b.gpioPinByNameCap = []any{name}
 	if b.GPIOPinByNameFunc == nil {
 		return b.Board.GPIOPinByName(name)
 	}
@@ -87,7 +87,7 @@ func (b *Board) GPIOPinByName(name string) (board.GPIOPin, error) {
 }
 
 // GPIOPinByNameCap returns the last parameters received by GPIOPinByName, and then clears them.
-func (b *Board) GPIOPinByNameCap() []interface{} {
+func (b *Board) GPIOPinByNameCap() []any {
 	if b == nil {
 		return nil
 	}
@@ -123,8 +123,8 @@ func (b *Board) Close(ctx context.Context) error {
 }
 
 // Status calls the injected Status or the real version.
-func (b *Board) Status(ctx context.Context, extra map[string]interface{}) (*commonpb.BoardStatus, error) {
-	b.statusCap = []interface{}{ctx}
+func (b *Board) Status(ctx context.Context, extra map[string]any) (*commonpb.BoardStatus, error) {
+	b.statusCap = []any{ctx}
 	if b.StatusFunc == nil {
 		return b.Board.Status(ctx, extra)
 	}
@@ -132,7 +132,7 @@ func (b *Board) Status(ctx context.Context, extra map[string]interface{}) (*comm
 }
 
 // StatusCap returns the last parameters received by Status, and then clears them.
-func (b *Board) StatusCap() []interface{} {
+func (b *Board) StatusCap() []any {
 	if b == nil {
 		return nil
 	}
@@ -141,7 +141,7 @@ func (b *Board) StatusCap() []interface{} {
 }
 
 // DoCommand calls the injected DoCommand or the real version.
-func (b *Board) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (b *Board) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	if b.DoFunc == nil {
 		return b.Board.DoCommand(ctx, cmd)
 	}
@@ -159,7 +159,7 @@ func (b *Board) SetPowerMode(ctx context.Context, mode boardpb.PowerMode, durati
 }
 
 // WriteAnalog calls the injected WriteAnalog or the real version.
-func (b *Board) WriteAnalog(ctx context.Context, pin string, value int32, extra map[string]interface{}) error {
+func (b *Board) WriteAnalog(ctx context.Context, pin string, value int32, extra map[string]any) error {
 	if b.WriteAnalogFunc == nil {
 		return b.Board.WriteAnalog(ctx, pin, value, extra)
 	}

--- a/testutils/inject/camera.go
+++ b/testutils/inject/camera.go
@@ -16,7 +16,7 @@ import (
 type Camera struct {
 	camera.Camera
 	name       resource.Name
-	DoFunc     func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
+	DoFunc     func(ctx context.Context, cmd map[string]any) (map[string]any, error)
 	ImagesFunc func(ctx context.Context) ([]camera.NamedImage, resource.ResponseMetadata, error)
 	StreamFunc func(
 		ctx context.Context,
@@ -96,7 +96,7 @@ func (c *Camera) Close(ctx context.Context) error {
 }
 
 // DoCommand calls the injected DoCommand or the real version.
-func (c *Camera) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (c *Camera) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	if c.DoFunc == nil {
 		return c.Camera.DoCommand(ctx, cmd)
 	}

--- a/testutils/inject/datamanager_service.go
+++ b/testutils/inject/datamanager_service.go
@@ -12,9 +12,9 @@ import (
 type DataManagerService struct {
 	datamanager.Service
 	name          resource.Name
-	SyncFunc      func(ctx context.Context, extra map[string]interface{}) error
+	SyncFunc      func(ctx context.Context, extra map[string]any) error
 	DoCommandFunc func(ctx context.Context,
-		cmd map[string]interface{}) (map[string]interface{}, error)
+		cmd map[string]any) (map[string]any, error)
 	CloseFunc func(ctx context.Context) error
 }
 
@@ -29,7 +29,7 @@ func (svc *DataManagerService) Name() resource.Name {
 }
 
 // Sync calls the injected Sync or the real variant.
-func (svc *DataManagerService) Sync(ctx context.Context, extra map[string]interface{}) error {
+func (svc *DataManagerService) Sync(ctx context.Context, extra map[string]any) error {
 	if svc.SyncFunc == nil {
 		return svc.Service.Sync(ctx, extra)
 	}
@@ -38,8 +38,8 @@ func (svc *DataManagerService) Sync(ctx context.Context, extra map[string]interf
 
 // DoCommand calls the injected DoCommand or the real variant.
 func (svc *DataManagerService) DoCommand(ctx context.Context,
-	cmd map[string]interface{},
-) (map[string]interface{}, error) {
+	cmd map[string]any,
+) (map[string]any, error) {
 	if svc.DoCommandFunc == nil {
 		return svc.Service.DoCommand(ctx, cmd)
 	}

--- a/testutils/inject/digital_interrupt.go
+++ b/testutils/inject/digital_interrupt.go
@@ -9,16 +9,16 @@ import (
 // DigitalInterrupt is an injected digital interrupt.
 type DigitalInterrupt struct {
 	board.DigitalInterrupt
-	ValueFunc       func(ctx context.Context, extra map[string]interface{}) (int64, error)
-	valueCap        []interface{}
+	ValueFunc       func(ctx context.Context, extra map[string]any) (int64, error)
+	valueCap        []any
 	TickFunc        func(ctx context.Context, high bool, nanoseconds uint64) error
-	tickCap         []interface{}
+	tickCap         []any
 	AddCallbackFunc func(c chan board.Tick)
 }
 
 // Value calls the injected Value or the real version.
-func (d *DigitalInterrupt) Value(ctx context.Context, extra map[string]interface{}) (int64, error) {
-	d.valueCap = []interface{}{ctx}
+func (d *DigitalInterrupt) Value(ctx context.Context, extra map[string]any) (int64, error) {
+	d.valueCap = []any{ctx}
 	if d.ValueFunc == nil {
 		return d.DigitalInterrupt.Value(ctx, extra)
 	}
@@ -26,7 +26,7 @@ func (d *DigitalInterrupt) Value(ctx context.Context, extra map[string]interface
 }
 
 // ValueCap returns the last parameters received by Value, and then clears them.
-func (d *DigitalInterrupt) ValueCap() []interface{} {
+func (d *DigitalInterrupt) ValueCap() []any {
 	if d == nil {
 		return nil
 	}
@@ -36,7 +36,7 @@ func (d *DigitalInterrupt) ValueCap() []interface{} {
 
 // Tick calls the injected Tick or the real version.
 func (d *DigitalInterrupt) Tick(ctx context.Context, high bool, nanoseconds uint64) error {
-	d.tickCap = []interface{}{ctx, high, nanoseconds}
+	d.tickCap = []any{ctx, high, nanoseconds}
 	if d.TickFunc == nil {
 		return d.DigitalInterrupt.Tick(ctx, high, nanoseconds)
 	}
@@ -44,7 +44,7 @@ func (d *DigitalInterrupt) Tick(ctx context.Context, high bool, nanoseconds uint
 }
 
 // TickCap returns the last parameters received by Tick, and then clears them.
-func (d *DigitalInterrupt) TickCap() []interface{} {
+func (d *DigitalInterrupt) TickCap() []any {
 	if d == nil {
 		return nil
 	}

--- a/testutils/inject/encoder.go
+++ b/testutils/inject/encoder.go
@@ -11,13 +11,13 @@ import (
 type Encoder struct {
 	encoder.Encoder
 	name              resource.Name
-	DoFunc            func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
-	ResetPositionFunc func(ctx context.Context, extra map[string]interface{}) error
+	DoFunc            func(ctx context.Context, cmd map[string]any) (map[string]any, error)
+	ResetPositionFunc func(ctx context.Context, extra map[string]any) error
 	PositionFunc      func(ctx context.Context,
 		positionType encoder.PositionType,
-		extra map[string]interface{},
+		extra map[string]any,
 	) (float64, encoder.PositionType, error)
-	PropertiesFunc func(ctx context.Context, extra map[string]interface{}) (encoder.Properties, error)
+	PropertiesFunc func(ctx context.Context, extra map[string]any) (encoder.Properties, error)
 }
 
 // NewEncoder returns a new injected Encoder.
@@ -31,7 +31,7 @@ func (e *Encoder) Name() resource.Name {
 }
 
 // ResetPosition calls the injected Zero or the real version.
-func (e *Encoder) ResetPosition(ctx context.Context, extra map[string]interface{}) error {
+func (e *Encoder) ResetPosition(ctx context.Context, extra map[string]any) error {
 	if e.ResetPositionFunc == nil {
 		return e.Encoder.ResetPosition(ctx, extra)
 	}
@@ -42,7 +42,7 @@ func (e *Encoder) ResetPosition(ctx context.Context, extra map[string]interface{
 func (e *Encoder) Position(
 	ctx context.Context,
 	positionType encoder.PositionType,
-	extra map[string]interface{},
+	extra map[string]any,
 ) (float64, encoder.PositionType, error) {
 	if e.PositionFunc == nil {
 		return e.Encoder.Position(ctx, positionType, extra)
@@ -51,7 +51,7 @@ func (e *Encoder) Position(
 }
 
 // Properties calls the injected Properties or the real version.
-func (e *Encoder) Properties(ctx context.Context, extra map[string]interface{}) (encoder.Properties, error) {
+func (e *Encoder) Properties(ctx context.Context, extra map[string]any) (encoder.Properties, error) {
 	if e.PropertiesFunc == nil {
 		return e.Encoder.Properties(ctx, extra)
 	}
@@ -59,7 +59,7 @@ func (e *Encoder) Properties(ctx context.Context, extra map[string]interface{}) 
 }
 
 // DoCommand calls the injected DoCommand or the real version.
-func (e *Encoder) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (e *Encoder) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	if e.DoFunc == nil {
 		return e.Encoder.DoCommand(ctx, cmd)
 	}

--- a/testutils/inject/framesystem_service.go
+++ b/testutils/inject/framesystem_service.go
@@ -33,8 +33,8 @@ type FrameSystemService struct {
 	) (referenceframe.FrameSystem, error)
 	DoCommandFunc func(
 		ctx context.Context,
-		cmd map[string]interface{},
-	) (map[string]interface{}, error)
+		cmd map[string]any,
+	) (map[string]any, error)
 	CloseFunc func(ctx context.Context) error
 }
 
@@ -100,8 +100,8 @@ func (fs *FrameSystemService) FrameSystem(
 
 // DoCommand calls the injected DoCommand or the real variant.
 func (fs *FrameSystemService) DoCommand(ctx context.Context,
-	cmd map[string]interface{},
-) (map[string]interface{}, error) {
+	cmd map[string]any,
+) (map[string]any, error) {
 	if fs.DoCommandFunc == nil {
 		return fs.Service.DoCommand(ctx, cmd)
 	}

--- a/testutils/inject/gantry.go
+++ b/testutils/inject/gantry.go
@@ -12,12 +12,12 @@ import (
 type Gantry struct {
 	gantry.Gantry
 	name               resource.Name
-	DoFunc             func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
-	PositionFunc       func(ctx context.Context, extra map[string]interface{}) ([]float64, error)
-	MoveToPositionFunc func(ctx context.Context, pos, speed []float64, extra map[string]interface{}) error
-	LengthsFunc        func(ctx context.Context, extra map[string]interface{}) ([]float64, error)
-	StopFunc           func(ctx context.Context, extra map[string]interface{}) error
-	HomeFunc           func(ctx context.Context, extra map[string]interface{}) (bool, error)
+	DoFunc             func(ctx context.Context, cmd map[string]any) (map[string]any, error)
+	PositionFunc       func(ctx context.Context, extra map[string]any) ([]float64, error)
+	MoveToPositionFunc func(ctx context.Context, pos, speed []float64, extra map[string]any) error
+	LengthsFunc        func(ctx context.Context, extra map[string]any) ([]float64, error)
+	StopFunc           func(ctx context.Context, extra map[string]any) error
+	HomeFunc           func(ctx context.Context, extra map[string]any) (bool, error)
 	IsMovingFunc       func(context.Context) (bool, error)
 	CloseFunc          func(ctx context.Context) error
 	ModelFrameFunc     func() referenceframe.Model
@@ -34,7 +34,7 @@ func (g *Gantry) Name() resource.Name {
 }
 
 // Position calls the injected Position or the real version.
-func (g *Gantry) Position(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+func (g *Gantry) Position(ctx context.Context, extra map[string]any) ([]float64, error) {
 	if g.PositionFunc == nil {
 		return g.Gantry.Position(ctx, extra)
 	}
@@ -42,7 +42,7 @@ func (g *Gantry) Position(ctx context.Context, extra map[string]interface{}) ([]
 }
 
 // MoveToPosition calls the injected MoveToPosition or the real version.
-func (g *Gantry) MoveToPosition(ctx context.Context, positions, speeds []float64, extra map[string]interface{}) error {
+func (g *Gantry) MoveToPosition(ctx context.Context, positions, speeds []float64, extra map[string]any) error {
 	if g.MoveToPositionFunc == nil {
 		return g.Gantry.MoveToPosition(ctx, positions, speeds, extra)
 	}
@@ -50,7 +50,7 @@ func (g *Gantry) MoveToPosition(ctx context.Context, positions, speeds []float64
 }
 
 // Lengths calls the injected Lengths or the real version.
-func (g *Gantry) Lengths(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
+func (g *Gantry) Lengths(ctx context.Context, extra map[string]any) ([]float64, error) {
 	if g.LengthsFunc == nil {
 		return g.Gantry.Lengths(ctx, extra)
 	}
@@ -58,7 +58,7 @@ func (g *Gantry) Lengths(ctx context.Context, extra map[string]interface{}) ([]f
 }
 
 // Stop calls the injected Stop or the real version.
-func (g *Gantry) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (g *Gantry) Stop(ctx context.Context, extra map[string]any) error {
 	if g.StopFunc == nil {
 		return g.Gantry.Stop(ctx, extra)
 	}
@@ -66,7 +66,7 @@ func (g *Gantry) Stop(ctx context.Context, extra map[string]interface{}) error {
 }
 
 // Home calls the injected Home or the real version.
-func (g *Gantry) Home(ctx context.Context, extra map[string]interface{}) (bool, error) {
+func (g *Gantry) Home(ctx context.Context, extra map[string]any) (bool, error) {
 	if g.HomeFunc == nil {
 		return g.Gantry.Home(ctx, extra)
 	}
@@ -101,7 +101,7 @@ func (g *Gantry) Close(ctx context.Context) error {
 }
 
 // DoCommand calls the injected DoCommand or the real version.
-func (g *Gantry) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (g *Gantry) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	if g.DoFunc == nil {
 		return g.Gantry.DoCommand(ctx, cmd)
 	}

--- a/testutils/inject/generic_component.go
+++ b/testutils/inject/generic_component.go
@@ -11,7 +11,7 @@ import (
 type GenericComponent struct {
 	resource.Resource
 	name   resource.Name
-	DoFunc func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
+	DoFunc func(ctx context.Context, cmd map[string]any) (map[string]any, error)
 }
 
 // NewGenericComponent returns a new injected generic component.
@@ -25,7 +25,7 @@ func (g *GenericComponent) Name() resource.Name {
 }
 
 // DoCommand calls the injected DoCommand or the real version.
-func (g *GenericComponent) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (g *GenericComponent) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	if g.DoFunc == nil {
 		return g.Resource.DoCommand(ctx, cmd)
 	}

--- a/testutils/inject/generic_service.go
+++ b/testutils/inject/generic_service.go
@@ -11,7 +11,7 @@ import (
 type GenericService struct {
 	resource.Resource
 	name   resource.Name
-	DoFunc func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
+	DoFunc func(ctx context.Context, cmd map[string]any) (map[string]any, error)
 }
 
 // NewGenericService returns a new injected generic service.
@@ -25,7 +25,7 @@ func (g *GenericService) Name() resource.Name {
 }
 
 // DoCommand calls the injected DoCommand or the real version.
-func (g *GenericService) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (g *GenericService) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	if g.DoFunc == nil {
 		return g.Resource.DoCommand(ctx, cmd)
 	}

--- a/testutils/inject/gpio_pin.go
+++ b/testutils/inject/gpio_pin.go
@@ -10,23 +10,23 @@ import (
 type GPIOPin struct {
 	board.GPIOPin
 
-	SetFunc        func(ctx context.Context, high bool, extra map[string]interface{}) error
-	setCap         []interface{}
-	GetFunc        func(ctx context.Context, extra map[string]interface{}) (bool, error)
-	getCap         []interface{}
-	PWMFunc        func(ctx context.Context, extra map[string]interface{}) (float64, error)
-	pwmCap         []interface{}
-	SetPWMFunc     func(ctx context.Context, dutyCyclePct float64, extra map[string]interface{}) error
-	setPWMCap      []interface{}
-	PWMFreqFunc    func(ctx context.Context, extra map[string]interface{}) (uint, error)
-	pwmFreqCap     []interface{}
-	SetPWMFreqFunc func(ctx context.Context, freqHz uint, extra map[string]interface{}) error
-	setPWMFreqCap  []interface{}
+	SetFunc        func(ctx context.Context, high bool, extra map[string]any) error
+	setCap         []any
+	GetFunc        func(ctx context.Context, extra map[string]any) (bool, error)
+	getCap         []any
+	PWMFunc        func(ctx context.Context, extra map[string]any) (float64, error)
+	pwmCap         []any
+	SetPWMFunc     func(ctx context.Context, dutyCyclePct float64, extra map[string]any) error
+	setPWMCap      []any
+	PWMFreqFunc    func(ctx context.Context, extra map[string]any) (uint, error)
+	pwmFreqCap     []any
+	SetPWMFreqFunc func(ctx context.Context, freqHz uint, extra map[string]any) error
+	setPWMFreqCap  []any
 }
 
 // Set calls the injected Set or the real version.
-func (gp *GPIOPin) Set(ctx context.Context, high bool, extra map[string]interface{}) error {
-	gp.setCap = []interface{}{ctx, high}
+func (gp *GPIOPin) Set(ctx context.Context, high bool, extra map[string]any) error {
+	gp.setCap = []any{ctx, high}
 	if gp.SetFunc == nil {
 		return gp.GPIOPin.Set(ctx, high, extra)
 	}
@@ -34,8 +34,8 @@ func (gp *GPIOPin) Set(ctx context.Context, high bool, extra map[string]interfac
 }
 
 // Get calls the injected Get or the real version.
-func (gp *GPIOPin) Get(ctx context.Context, extra map[string]interface{}) (bool, error) {
-	gp.getCap = []interface{}{ctx}
+func (gp *GPIOPin) Get(ctx context.Context, extra map[string]any) (bool, error) {
+	gp.getCap = []any{ctx}
 	if gp.GetFunc == nil {
 		return gp.GPIOPin.Get(ctx, extra)
 	}
@@ -43,8 +43,8 @@ func (gp *GPIOPin) Get(ctx context.Context, extra map[string]interface{}) (bool,
 }
 
 // PWM calls the injected PWM or the real version.
-func (gp *GPIOPin) PWM(ctx context.Context, extra map[string]interface{}) (float64, error) {
-	gp.pwmCap = []interface{}{ctx}
+func (gp *GPIOPin) PWM(ctx context.Context, extra map[string]any) (float64, error) {
+	gp.pwmCap = []any{ctx}
 	if gp.PWMFunc == nil {
 		return gp.GPIOPin.PWM(ctx, extra)
 	}
@@ -52,8 +52,8 @@ func (gp *GPIOPin) PWM(ctx context.Context, extra map[string]interface{}) (float
 }
 
 // SetPWM calls the injected SetPWM or the real version.
-func (gp *GPIOPin) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[string]interface{}) error {
-	gp.setPWMCap = []interface{}{ctx, dutyCyclePct}
+func (gp *GPIOPin) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[string]any) error {
+	gp.setPWMCap = []any{ctx, dutyCyclePct}
 	if gp.SetPWMFunc == nil {
 		return gp.GPIOPin.SetPWM(ctx, dutyCyclePct, extra)
 	}
@@ -61,8 +61,8 @@ func (gp *GPIOPin) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[s
 }
 
 // PWMFreq calls the injected PWMFreq or the real version.
-func (gp *GPIOPin) PWMFreq(ctx context.Context, extra map[string]interface{}) (uint, error) {
-	gp.pwmFreqCap = []interface{}{ctx}
+func (gp *GPIOPin) PWMFreq(ctx context.Context, extra map[string]any) (uint, error) {
+	gp.pwmFreqCap = []any{ctx}
 	if gp.PWMFreqFunc == nil {
 		return gp.GPIOPin.PWMFreq(ctx, extra)
 	}
@@ -70,8 +70,8 @@ func (gp *GPIOPin) PWMFreq(ctx context.Context, extra map[string]interface{}) (u
 }
 
 // SetPWMFreq calls the injected SetPWMFreq or the real version.
-func (gp *GPIOPin) SetPWMFreq(ctx context.Context, freqHz uint, extra map[string]interface{}) error {
-	gp.setPWMFreqCap = []interface{}{ctx, freqHz}
+func (gp *GPIOPin) SetPWMFreq(ctx context.Context, freqHz uint, extra map[string]any) error {
+	gp.setPWMFreqCap = []any{ctx, freqHz}
 	if gp.SetPWMFreqFunc == nil {
 		return gp.GPIOPin.SetPWMFreq(ctx, freqHz, extra)
 	}
@@ -79,7 +79,7 @@ func (gp *GPIOPin) SetPWMFreq(ctx context.Context, freqHz uint, extra map[string
 }
 
 // SetCap returns the last parameters received by Set, and then clears them.
-func (gp *GPIOPin) SetCap() []interface{} {
+func (gp *GPIOPin) SetCap() []any {
 	if gp == nil {
 		return nil
 	}
@@ -88,7 +88,7 @@ func (gp *GPIOPin) SetCap() []interface{} {
 }
 
 // GetCap returns the last parameters received by Get, and then clears them.
-func (gp *GPIOPin) GetCap() []interface{} {
+func (gp *GPIOPin) GetCap() []any {
 	if gp == nil {
 		return nil
 	}
@@ -97,7 +97,7 @@ func (gp *GPIOPin) GetCap() []interface{} {
 }
 
 // PWMCap returns the last parameters received by PWM, and then clears them.
-func (gp *GPIOPin) PWMCap() []interface{} {
+func (gp *GPIOPin) PWMCap() []any {
 	if gp == nil {
 		return nil
 	}
@@ -106,7 +106,7 @@ func (gp *GPIOPin) PWMCap() []interface{} {
 }
 
 // SetPWMCap returns the last parameters received by SetPWM, and then clears them.
-func (gp *GPIOPin) SetPWMCap() []interface{} {
+func (gp *GPIOPin) SetPWMCap() []any {
 	if gp == nil {
 		return nil
 	}
@@ -115,7 +115,7 @@ func (gp *GPIOPin) SetPWMCap() []interface{} {
 }
 
 // PWMFreqCap returns the last parameters received by PWMFreq, and then clears them.
-func (gp *GPIOPin) PWMFreqCap() []interface{} {
+func (gp *GPIOPin) PWMFreqCap() []any {
 	if gp == nil {
 		return nil
 	}
@@ -124,7 +124,7 @@ func (gp *GPIOPin) PWMFreqCap() []interface{} {
 }
 
 // SetPWMFreqCap returns the last parameters received by SetPWMFreq, and then clears them.
-func (gp *GPIOPin) SetPWMFreqCap() []interface{} {
+func (gp *GPIOPin) SetPWMFreqCap() []any {
 	if gp == nil {
 		return nil
 	}

--- a/testutils/inject/gripper.go
+++ b/testutils/inject/gripper.go
@@ -11,10 +11,10 @@ import (
 type Gripper struct {
 	gripper.Gripper
 	name         resource.Name
-	DoFunc       func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
-	OpenFunc     func(ctx context.Context, extra map[string]interface{}) error
-	GrabFunc     func(ctx context.Context, extra map[string]interface{}) (bool, error)
-	StopFunc     func(ctx context.Context, extra map[string]interface{}) error
+	DoFunc       func(ctx context.Context, cmd map[string]any) (map[string]any, error)
+	OpenFunc     func(ctx context.Context, extra map[string]any) error
+	GrabFunc     func(ctx context.Context, extra map[string]any) (bool, error)
+	StopFunc     func(ctx context.Context, extra map[string]any) error
 	IsMovingFunc func(context.Context) (bool, error)
 	CloseFunc    func(ctx context.Context) error
 }
@@ -30,7 +30,7 @@ func (g *Gripper) Name() resource.Name {
 }
 
 // Open calls the injected Open or the real version.
-func (g *Gripper) Open(ctx context.Context, extra map[string]interface{}) error {
+func (g *Gripper) Open(ctx context.Context, extra map[string]any) error {
 	if g.OpenFunc == nil {
 		return g.Gripper.Open(ctx, extra)
 	}
@@ -38,7 +38,7 @@ func (g *Gripper) Open(ctx context.Context, extra map[string]interface{}) error 
 }
 
 // Grab calls the injected Grab or the real version.
-func (g *Gripper) Grab(ctx context.Context, extra map[string]interface{}) (bool, error) {
+func (g *Gripper) Grab(ctx context.Context, extra map[string]any) (bool, error) {
 	if g.GrabFunc == nil {
 		return g.Gripper.Grab(ctx, extra)
 	}
@@ -46,7 +46,7 @@ func (g *Gripper) Grab(ctx context.Context, extra map[string]interface{}) (bool,
 }
 
 // Stop calls the injected Stop or the real version.
-func (g *Gripper) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (g *Gripper) Stop(ctx context.Context, extra map[string]any) error {
 	if g.StopFunc == nil {
 		return g.Gripper.Stop(ctx, extra)
 	}
@@ -73,7 +73,7 @@ func (g *Gripper) Close(ctx context.Context) error {
 }
 
 // DoCommand calls the injected DoCommand or the real version.
-func (g *Gripper) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (g *Gripper) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	if g.DoFunc == nil {
 		return g.Gripper.DoCommand(ctx, cmd)
 	}

--- a/testutils/inject/input.go
+++ b/testutils/inject/input.go
@@ -11,15 +11,15 @@ import (
 type InputController struct {
 	input.Controller
 	name                        resource.Name
-	DoFunc                      func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
-	ControlsFunc                func(ctx context.Context, extra map[string]interface{}) ([]input.Control, error)
-	EventsFunc                  func(ctx context.Context, extra map[string]interface{}) (map[input.Control]input.Event, error)
+	DoFunc                      func(ctx context.Context, cmd map[string]any) (map[string]any, error)
+	ControlsFunc                func(ctx context.Context, extra map[string]any) ([]input.Control, error)
+	EventsFunc                  func(ctx context.Context, extra map[string]any) (map[input.Control]input.Event, error)
 	RegisterControlCallbackFunc func(
 		ctx context.Context,
 		control input.Control,
 		triggers []input.EventType,
 		ctrlFunc input.ControlFunction,
-		extra map[string]interface{},
+		extra map[string]any,
 	) error
 }
 
@@ -34,7 +34,7 @@ func (s *InputController) Name() resource.Name {
 }
 
 // Controls calls the injected function or the real version.
-func (s *InputController) Controls(ctx context.Context, extra map[string]interface{}) ([]input.Control, error) {
+func (s *InputController) Controls(ctx context.Context, extra map[string]any) ([]input.Control, error) {
 	if s.ControlsFunc == nil {
 		return s.Controller.Controls(ctx, extra)
 	}
@@ -42,7 +42,7 @@ func (s *InputController) Controls(ctx context.Context, extra map[string]interfa
 }
 
 // Events calls the injected function or the real version.
-func (s *InputController) Events(ctx context.Context, extra map[string]interface{}) (map[input.Control]input.Event, error) {
+func (s *InputController) Events(ctx context.Context, extra map[string]any) (map[input.Control]input.Event, error) {
 	if s.EventsFunc == nil {
 		return s.Controller.Events(ctx, extra)
 	}
@@ -55,7 +55,7 @@ func (s *InputController) RegisterControlCallback(
 	control input.Control,
 	triggers []input.EventType,
 	ctrlFunc input.ControlFunction,
-	extra map[string]interface{},
+	extra map[string]any,
 ) error {
 	if s.RegisterControlCallbackFunc == nil {
 		return s.RegisterControlCallback(ctx, control, triggers, ctrlFunc, extra)
@@ -64,7 +64,7 @@ func (s *InputController) RegisterControlCallback(
 }
 
 // DoCommand calls the injected DoCommand or the real version.
-func (s *InputController) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (s *InputController) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	if s.DoFunc == nil {
 		return s.Controller.DoCommand(ctx, cmd)
 	}
@@ -76,11 +76,11 @@ type TriggerableInputController struct {
 	InputController
 	input.Triggerable
 
-	TriggerEventFunc func(ctx context.Context, event input.Event, extra map[string]interface{}) error
+	TriggerEventFunc func(ctx context.Context, event input.Event, extra map[string]any) error
 }
 
 // TriggerEvent calls the injected function or the real version.
-func (s *TriggerableInputController) TriggerEvent(ctx context.Context, event input.Event, extra map[string]interface{}) error {
+func (s *TriggerableInputController) TriggerEvent(ctx context.Context, event input.Event, extra map[string]any) error {
 	if s.TriggerEventFunc == nil {
 		return s.TriggerEvent(ctx, event, extra)
 	}

--- a/testutils/inject/motion_service.go
+++ b/testutils/inject/motion_service.go
@@ -21,7 +21,7 @@ type MotionService struct {
 		grabPose *referenceframe.PoseInFrame,
 		worldState *referenceframe.WorldState,
 		constraints *servicepb.Constraints,
-		extra map[string]interface{},
+		extra map[string]any,
 	) (bool, error)
 	MoveOnMapFunc func(
 		ctx context.Context,
@@ -40,7 +40,7 @@ type MotionService struct {
 		componentName resource.Name,
 		destinationFrame string,
 		supplementalTransforms []*referenceframe.LinkInFrame,
-		extra map[string]interface{},
+		extra map[string]any,
 	) (*referenceframe.PoseInFrame, error)
 	StopPlanFunc func(
 		ctx context.Context,
@@ -55,7 +55,7 @@ type MotionService struct {
 		req motion.PlanHistoryReq,
 	) ([]motion.PlanWithStatus, error)
 	DoCommandFunc func(ctx context.Context,
-		cmd map[string]interface{}) (map[string]interface{}, error)
+		cmd map[string]any) (map[string]any, error)
 	CloseFunc func(ctx context.Context) error
 }
 
@@ -76,7 +76,7 @@ func (mgs *MotionService) Move(
 	destination *referenceframe.PoseInFrame,
 	worldState *referenceframe.WorldState,
 	constraints *servicepb.Constraints,
-	extra map[string]interface{},
+	extra map[string]any,
 ) (bool, error) {
 	if mgs.MoveFunc == nil {
 		return mgs.Service.Move(ctx, componentName, destination, worldState, constraints, extra)
@@ -120,7 +120,7 @@ func (mgs *MotionService) GetPose(
 	componentName resource.Name,
 	destinationFrame string,
 	supplementalTransforms []*referenceframe.LinkInFrame,
-	extra map[string]interface{},
+	extra map[string]any,
 ) (*referenceframe.PoseInFrame, error) {
 	if mgs.GetPoseFunc == nil {
 		return mgs.Service.GetPose(ctx, componentName, destinationFrame, supplementalTransforms, extra)
@@ -163,8 +163,8 @@ func (mgs *MotionService) PlanHistory(
 
 // DoCommand calls the injected DoCommand or the real variant.
 func (mgs *MotionService) DoCommand(ctx context.Context,
-	cmd map[string]interface{},
-) (map[string]interface{}, error) {
+	cmd map[string]any,
+) (map[string]any, error) {
 	if mgs.DoCommandFunc == nil {
 		return mgs.Service.DoCommand(ctx, cmd)
 	}

--- a/testutils/inject/motor.go
+++ b/testutils/inject/motor.go
@@ -11,15 +11,15 @@ import (
 type Motor struct {
 	motor.Motor
 	name                  resource.Name
-	DoFunc                func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
-	SetPowerFunc          func(ctx context.Context, powerPct float64, extra map[string]interface{}) error
-	GoForFunc             func(ctx context.Context, rpm, rotations float64, extra map[string]interface{}) error
-	GoToFunc              func(ctx context.Context, rpm, position float64, extra map[string]interface{}) error
-	ResetZeroPositionFunc func(ctx context.Context, offset float64, extra map[string]interface{}) error
-	PositionFunc          func(ctx context.Context, extra map[string]interface{}) (float64, error)
-	PropertiesFunc        func(ctx context.Context, extra map[string]interface{}) (motor.Properties, error)
-	StopFunc              func(ctx context.Context, extra map[string]interface{}) error
-	IsPoweredFunc         func(ctx context.Context, extra map[string]interface{}) (bool, float64, error)
+	DoFunc                func(ctx context.Context, cmd map[string]any) (map[string]any, error)
+	SetPowerFunc          func(ctx context.Context, powerPct float64, extra map[string]any) error
+	GoForFunc             func(ctx context.Context, rpm, rotations float64, extra map[string]any) error
+	GoToFunc              func(ctx context.Context, rpm, position float64, extra map[string]any) error
+	ResetZeroPositionFunc func(ctx context.Context, offset float64, extra map[string]any) error
+	PositionFunc          func(ctx context.Context, extra map[string]any) (float64, error)
+	PropertiesFunc        func(ctx context.Context, extra map[string]any) (motor.Properties, error)
+	StopFunc              func(ctx context.Context, extra map[string]any) error
+	IsPoweredFunc         func(ctx context.Context, extra map[string]any) (bool, float64, error)
 	IsMovingFunc          func(context.Context) (bool, error)
 }
 
@@ -34,7 +34,7 @@ func (m *Motor) Name() resource.Name {
 }
 
 // SetPower calls the injected Power or the real version.
-func (m *Motor) SetPower(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
+func (m *Motor) SetPower(ctx context.Context, powerPct float64, extra map[string]any) error {
 	if m.SetPowerFunc == nil {
 		return m.Motor.SetPower(ctx, powerPct, extra)
 	}
@@ -42,7 +42,7 @@ func (m *Motor) SetPower(ctx context.Context, powerPct float64, extra map[string
 }
 
 // GoFor calls the injected GoFor or the real version.
-func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]interface{}) error {
+func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]any) error {
 	if m.GoForFunc == nil {
 		return m.Motor.GoFor(ctx, rpm, revolutions, extra)
 	}
@@ -50,7 +50,7 @@ func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[s
 }
 
 // GoTo calls the injected GoTo or the real version.
-func (m *Motor) GoTo(ctx context.Context, rpm, positionRevolutions float64, extra map[string]interface{}) error {
+func (m *Motor) GoTo(ctx context.Context, rpm, positionRevolutions float64, extra map[string]any) error {
 	if m.GoToFunc == nil {
 		return m.Motor.GoTo(ctx, rpm, positionRevolutions, extra)
 	}
@@ -58,7 +58,7 @@ func (m *Motor) GoTo(ctx context.Context, rpm, positionRevolutions float64, extr
 }
 
 // ResetZeroPosition calls the injected Zero or the real version.
-func (m *Motor) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]interface{}) error {
+func (m *Motor) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]any) error {
 	if m.ResetZeroPositionFunc == nil {
 		return m.Motor.ResetZeroPosition(ctx, offset, extra)
 	}
@@ -66,7 +66,7 @@ func (m *Motor) ResetZeroPosition(ctx context.Context, offset float64, extra map
 }
 
 // Position calls the injected Position or the real version.
-func (m *Motor) Position(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (m *Motor) Position(ctx context.Context, extra map[string]any) (float64, error) {
 	if m.PositionFunc == nil {
 		return m.Motor.Position(ctx, extra)
 	}
@@ -74,7 +74,7 @@ func (m *Motor) Position(ctx context.Context, extra map[string]interface{}) (flo
 }
 
 // Properties calls the injected Properties or the real version.
-func (m *Motor) Properties(ctx context.Context, extra map[string]interface{}) (motor.Properties, error) {
+func (m *Motor) Properties(ctx context.Context, extra map[string]any) (motor.Properties, error) {
 	if m.PropertiesFunc == nil {
 		return m.Motor.Properties(ctx, extra)
 	}
@@ -82,7 +82,7 @@ func (m *Motor) Properties(ctx context.Context, extra map[string]interface{}) (m
 }
 
 // Stop calls the injected Off or the real version.
-func (m *Motor) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (m *Motor) Stop(ctx context.Context, extra map[string]any) error {
 	if m.StopFunc == nil {
 		return m.Motor.Stop(ctx, extra)
 	}
@@ -90,7 +90,7 @@ func (m *Motor) Stop(ctx context.Context, extra map[string]interface{}) error {
 }
 
 // IsPowered calls the injected IsPowered or the real version.
-func (m *Motor) IsPowered(ctx context.Context, extra map[string]interface{}) (bool, float64, error) {
+func (m *Motor) IsPowered(ctx context.Context, extra map[string]any) (bool, float64, error) {
 	if m.IsPoweredFunc == nil {
 		return m.Motor.IsPowered(ctx, extra)
 	}
@@ -98,7 +98,7 @@ func (m *Motor) IsPowered(ctx context.Context, extra map[string]interface{}) (bo
 }
 
 // DoCommand calls the injected DoCommand or the real version.
-func (m *Motor) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (m *Motor) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	if m.DoFunc == nil {
 		return m.Motor.DoCommand(ctx, cmd)
 	}

--- a/testutils/inject/movementsensor.go
+++ b/testutils/inject/movementsensor.go
@@ -17,25 +17,25 @@ type MovementSensor struct {
 	movementsensor.MovementSensor
 	name                        resource.Name
 	Mu                          sync.RWMutex
-	PositionFuncExtraCap        map[string]interface{}
-	PositionFunc                func(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error)
-	LinearVelocityFuncExtraCap  map[string]interface{}
-	LinearVelocityFunc          func(ctx context.Context, extra map[string]interface{}) (r3.Vector, error)
-	AngularVelocityFuncExtraCap map[string]interface{}
-	AngularVelocityFunc         func(ctx context.Context, extra map[string]interface{}) (spatialmath.AngularVelocity, error)
-	CompassHeadingFuncExtraCap  map[string]interface{}
-	CompassHeadingFunc          func(ctx context.Context, extra map[string]interface{}) (float64, error)
-	LinearAccelerationExtraCap  map[string]interface{}
-	LinearAccelerationFunc      func(ctx context.Context, extra map[string]interface{}) (r3.Vector, error)
-	OrientationFuncExtraCap     map[string]interface{}
-	OrientationFunc             func(ctx context.Context, extra map[string]interface{}) (spatialmath.Orientation, error)
-	PropertiesFuncExtraCap      map[string]interface{}
-	PropertiesFunc              func(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error)
-	AccuracyFuncExtraCap        map[string]interface{}
-	AccuracyFunc                func(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error)
-	ReadingsFuncExtraCap        map[string]interface{}
-	ReadingsFunc                func(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error)
-	DoFunc                      func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
+	PositionFuncExtraCap        map[string]any
+	PositionFunc                func(ctx context.Context, extra map[string]any) (*geo.Point, float64, error)
+	LinearVelocityFuncExtraCap  map[string]any
+	LinearVelocityFunc          func(ctx context.Context, extra map[string]any) (r3.Vector, error)
+	AngularVelocityFuncExtraCap map[string]any
+	AngularVelocityFunc         func(ctx context.Context, extra map[string]any) (spatialmath.AngularVelocity, error)
+	CompassHeadingFuncExtraCap  map[string]any
+	CompassHeadingFunc          func(ctx context.Context, extra map[string]any) (float64, error)
+	LinearAccelerationExtraCap  map[string]any
+	LinearAccelerationFunc      func(ctx context.Context, extra map[string]any) (r3.Vector, error)
+	OrientationFuncExtraCap     map[string]any
+	OrientationFunc             func(ctx context.Context, extra map[string]any) (spatialmath.Orientation, error)
+	PropertiesFuncExtraCap      map[string]any
+	PropertiesFunc              func(ctx context.Context, extra map[string]any) (*movementsensor.Properties, error)
+	AccuracyFuncExtraCap        map[string]any
+	AccuracyFunc                func(ctx context.Context, extra map[string]any) (*movementsensor.Accuracy, error)
+	ReadingsFuncExtraCap        map[string]any
+	ReadingsFunc                func(ctx context.Context, extra map[string]any) (map[string]any, error)
+	DoFunc                      func(ctx context.Context, cmd map[string]any) (map[string]any, error)
 	CloseFunc                   func() error
 }
 
@@ -61,7 +61,7 @@ func (i *MovementSensor) Close(ctx context.Context) error {
 }
 
 // DoCommand calls the injected DoCommand or the real version.
-func (i *MovementSensor) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (i *MovementSensor) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	if i.DoFunc == nil {
 		return i.MovementSensor.DoCommand(ctx, cmd)
 	}
@@ -69,7 +69,7 @@ func (i *MovementSensor) DoCommand(ctx context.Context, cmd map[string]interface
 }
 
 // Position func or passthrough.
-func (i *MovementSensor) Position(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+func (i *MovementSensor) Position(ctx context.Context, extra map[string]any) (*geo.Point, float64, error) {
 	i.Mu.Lock()
 	defer i.Mu.Unlock()
 	if i.PositionFunc == nil {
@@ -80,7 +80,7 @@ func (i *MovementSensor) Position(ctx context.Context, extra map[string]interfac
 }
 
 // LinearVelocity func or passthrough.
-func (i *MovementSensor) LinearVelocity(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+func (i *MovementSensor) LinearVelocity(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 	if i.LinearVelocityFunc == nil {
 		return i.MovementSensor.LinearVelocity(ctx, extra)
 	}
@@ -89,7 +89,7 @@ func (i *MovementSensor) LinearVelocity(ctx context.Context, extra map[string]in
 }
 
 // AngularVelocity func or passthrough.
-func (i *MovementSensor) AngularVelocity(ctx context.Context, extra map[string]interface{}) (spatialmath.AngularVelocity, error) {
+func (i *MovementSensor) AngularVelocity(ctx context.Context, extra map[string]any) (spatialmath.AngularVelocity, error) {
 	if i.AngularVelocityFunc == nil {
 		return i.MovementSensor.AngularVelocity(ctx, extra)
 	}
@@ -98,7 +98,7 @@ func (i *MovementSensor) AngularVelocity(ctx context.Context, extra map[string]i
 }
 
 // LinearAcceleration func or passthrough.
-func (i *MovementSensor) LinearAcceleration(ctx context.Context, extra map[string]interface{}) (r3.Vector, error) {
+func (i *MovementSensor) LinearAcceleration(ctx context.Context, extra map[string]any) (r3.Vector, error) {
 	if i.LinearAccelerationFunc == nil {
 		return i.MovementSensor.LinearAcceleration(ctx, extra)
 	}
@@ -107,7 +107,7 @@ func (i *MovementSensor) LinearAcceleration(ctx context.Context, extra map[strin
 }
 
 // Orientation func or passthrough.
-func (i *MovementSensor) Orientation(ctx context.Context, extra map[string]interface{}) (spatialmath.Orientation, error) {
+func (i *MovementSensor) Orientation(ctx context.Context, extra map[string]any) (spatialmath.Orientation, error) {
 	if i.OrientationFunc == nil {
 		return i.MovementSensor.Orientation(ctx, extra)
 	}
@@ -116,7 +116,7 @@ func (i *MovementSensor) Orientation(ctx context.Context, extra map[string]inter
 }
 
 // CompassHeading func or passthrough.
-func (i *MovementSensor) CompassHeading(ctx context.Context, extra map[string]interface{}) (float64, error) {
+func (i *MovementSensor) CompassHeading(ctx context.Context, extra map[string]any) (float64, error) {
 	if i.CompassHeadingFunc == nil {
 		return i.MovementSensor.CompassHeading(ctx, extra)
 	}
@@ -125,7 +125,7 @@ func (i *MovementSensor) CompassHeading(ctx context.Context, extra map[string]in
 }
 
 // Properties func or passthrough.
-func (i *MovementSensor) Properties(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+func (i *MovementSensor) Properties(ctx context.Context, extra map[string]any) (*movementsensor.Properties, error) {
 	if i.PropertiesFunc == nil {
 		return i.MovementSensor.Properties(ctx, extra)
 	}
@@ -134,7 +134,7 @@ func (i *MovementSensor) Properties(ctx context.Context, extra map[string]interf
 }
 
 // Accuracy func or passthrough.
-func (i *MovementSensor) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error,
+func (i *MovementSensor) Accuracy(ctx context.Context, extra map[string]any) (*movementsensor.Accuracy, error,
 ) {
 	if i.AccuracyFunc == nil {
 		return i.MovementSensor.Accuracy(ctx, extra)
@@ -144,7 +144,7 @@ func (i *MovementSensor) Accuracy(ctx context.Context, extra map[string]interfac
 }
 
 // Readings func or passthrough.
-func (i *MovementSensor) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+func (i *MovementSensor) Readings(ctx context.Context, extra map[string]any) (map[string]any, error) {
 	if i.ReadingsFunc == nil {
 		return i.MovementSensor.Readings(ctx, extra)
 	}

--- a/testutils/inject/navigation_service.go
+++ b/testutils/inject/navigation_service.go
@@ -15,21 +15,21 @@ import (
 type NavigationService struct {
 	navigation.Service
 	name        resource.Name
-	ModeFunc    func(ctx context.Context, extra map[string]interface{}) (navigation.Mode, error)
-	SetModeFunc func(ctx context.Context, mode navigation.Mode, extra map[string]interface{}) error
+	ModeFunc    func(ctx context.Context, extra map[string]any) (navigation.Mode, error)
+	SetModeFunc func(ctx context.Context, mode navigation.Mode, extra map[string]any) error
 
-	LocationFunc func(ctx context.Context, extra map[string]interface{}) (*spatialmath.GeoPose, error)
+	LocationFunc func(ctx context.Context, extra map[string]any) (*spatialmath.GeoPose, error)
 
-	WaypointsFunc      func(ctx context.Context, extra map[string]interface{}) ([]navigation.Waypoint, error)
-	AddWaypointFunc    func(ctx context.Context, point *geo.Point, extra map[string]interface{}) error
-	RemoveWaypointFunc func(ctx context.Context, id primitive.ObjectID, extra map[string]interface{}) error
+	WaypointsFunc      func(ctx context.Context, extra map[string]any) ([]navigation.Waypoint, error)
+	AddWaypointFunc    func(ctx context.Context, point *geo.Point, extra map[string]any) error
+	RemoveWaypointFunc func(ctx context.Context, id primitive.ObjectID, extra map[string]any) error
 
-	ObstaclesFunc func(ctx context.Context, extra map[string]interface{}) ([]*spatialmath.GeoObstacle, error)
-	PathsFunc     func(ctx context.Context, extra map[string]interface{}) ([]*navigation.Path, error)
+	ObstaclesFunc func(ctx context.Context, extra map[string]any) ([]*spatialmath.GeoObstacle, error)
+	PathsFunc     func(ctx context.Context, extra map[string]any) ([]*navigation.Path, error)
 
 	PropertiesFunc func(ctx context.Context) (navigation.Properties, error)
 
-	DoCommandFunc func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
+	DoCommandFunc func(ctx context.Context, cmd map[string]any) (map[string]any, error)
 	CloseFunc     func(ctx context.Context) error
 }
 
@@ -44,7 +44,7 @@ func (ns *NavigationService) Name() resource.Name {
 }
 
 // Mode calls the injected ModeFunc or the real version.
-func (ns *NavigationService) Mode(ctx context.Context, extra map[string]interface{}) (navigation.Mode, error) {
+func (ns *NavigationService) Mode(ctx context.Context, extra map[string]any) (navigation.Mode, error) {
 	if ns.ModeFunc == nil {
 		return ns.Service.Mode(ctx, extra)
 	}
@@ -52,7 +52,7 @@ func (ns *NavigationService) Mode(ctx context.Context, extra map[string]interfac
 }
 
 // SetMode calls the injected SetModeFunc or the real version.
-func (ns *NavigationService) SetMode(ctx context.Context, mode navigation.Mode, extra map[string]interface{}) error {
+func (ns *NavigationService) SetMode(ctx context.Context, mode navigation.Mode, extra map[string]any) error {
 	if ns.SetModeFunc == nil {
 		return ns.Service.SetMode(ctx, mode, extra)
 	}
@@ -60,7 +60,7 @@ func (ns *NavigationService) SetMode(ctx context.Context, mode navigation.Mode, 
 }
 
 // Location calls the injected LocationFunc or the real version.
-func (ns *NavigationService) Location(ctx context.Context, extra map[string]interface{}) (*spatialmath.GeoPose, error) {
+func (ns *NavigationService) Location(ctx context.Context, extra map[string]any) (*spatialmath.GeoPose, error) {
 	if ns.LocationFunc == nil {
 		return ns.Service.Location(ctx, extra)
 	}
@@ -68,7 +68,7 @@ func (ns *NavigationService) Location(ctx context.Context, extra map[string]inte
 }
 
 // Waypoints calls the injected WaypointsFunc or the real version.
-func (ns *NavigationService) Waypoints(ctx context.Context, extra map[string]interface{}) ([]navigation.Waypoint, error) {
+func (ns *NavigationService) Waypoints(ctx context.Context, extra map[string]any) ([]navigation.Waypoint, error) {
 	if ns.WaypointsFunc == nil {
 		return ns.Service.Waypoints(ctx, extra)
 	}
@@ -76,7 +76,7 @@ func (ns *NavigationService) Waypoints(ctx context.Context, extra map[string]int
 }
 
 // AddWaypoint calls the injected AddWaypointFunc or the real version.
-func (ns *NavigationService) AddWaypoint(ctx context.Context, point *geo.Point, extra map[string]interface{}) error {
+func (ns *NavigationService) AddWaypoint(ctx context.Context, point *geo.Point, extra map[string]any) error {
 	if ns.AddWaypointFunc == nil {
 		return ns.Service.AddWaypoint(ctx, point, extra)
 	}
@@ -84,7 +84,7 @@ func (ns *NavigationService) AddWaypoint(ctx context.Context, point *geo.Point, 
 }
 
 // RemoveWaypoint calls the injected RemoveWaypointFunc or the real version.
-func (ns *NavigationService) RemoveWaypoint(ctx context.Context, id primitive.ObjectID, extra map[string]interface{}) error {
+func (ns *NavigationService) RemoveWaypoint(ctx context.Context, id primitive.ObjectID, extra map[string]any) error {
 	if ns.RemoveWaypointFunc == nil {
 		return ns.Service.RemoveWaypoint(ctx, id, extra)
 	}
@@ -92,7 +92,7 @@ func (ns *NavigationService) RemoveWaypoint(ctx context.Context, id primitive.Ob
 }
 
 // Obstacles calls the injected Obstacles or the real version.
-func (ns *NavigationService) Obstacles(ctx context.Context, extra map[string]interface{}) ([]*spatialmath.GeoObstacle, error) {
+func (ns *NavigationService) Obstacles(ctx context.Context, extra map[string]any) ([]*spatialmath.GeoObstacle, error) {
 	if ns.ObstaclesFunc == nil {
 		return ns.Service.Obstacles(ctx, extra)
 	}
@@ -100,7 +100,7 @@ func (ns *NavigationService) Obstacles(ctx context.Context, extra map[string]int
 }
 
 // Paths calls the injected Paths or the real version.
-func (ns *NavigationService) Paths(ctx context.Context, extra map[string]interface{}) ([]*navigation.Path, error) {
+func (ns *NavigationService) Paths(ctx context.Context, extra map[string]any) ([]*navigation.Path, error) {
 	if ns.PathsFunc == nil {
 		return ns.Service.Paths(ctx, extra)
 	}
@@ -117,8 +117,8 @@ func (ns *NavigationService) Properties(ctx context.Context) (navigation.Propert
 
 // DoCommand calls the injected DoCommand or the real variant.
 func (ns *NavigationService) DoCommand(ctx context.Context,
-	cmd map[string]interface{},
-) (map[string]interface{}, error) {
+	cmd map[string]any,
+) (map[string]any, error) {
 	if ns.DoCommandFunc == nil {
 		return ns.Service.DoCommand(ctx, cmd)
 	}

--- a/testutils/inject/pose_tracker.go
+++ b/testutils/inject/pose_tracker.go
@@ -11,8 +11,8 @@ import (
 type PoseTracker struct {
 	posetracker.PoseTracker
 	name      resource.Name
-	PosesFunc func(ctx context.Context, bodyNames []string, extra map[string]interface{}) (posetracker.BodyToPoseInFrame, error)
-	DoFunc    func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
+	PosesFunc func(ctx context.Context, bodyNames []string, extra map[string]any) (posetracker.BodyToPoseInFrame, error)
+	DoFunc    func(ctx context.Context, cmd map[string]any) (map[string]any, error)
 }
 
 // NewPoseTracker returns a new injected pose tracker.
@@ -27,7 +27,7 @@ func (pT *PoseTracker) Name() resource.Name {
 
 // Poses calls the injected Poses or the real version.
 func (pT *PoseTracker) Poses(
-	ctx context.Context, bodyNames []string, extra map[string]interface{},
+	ctx context.Context, bodyNames []string, extra map[string]any,
 ) (posetracker.BodyToPoseInFrame, error) {
 	if pT.PosesFunc == nil {
 		return pT.PoseTracker.Poses(ctx, bodyNames, extra)
@@ -36,7 +36,7 @@ func (pT *PoseTracker) Poses(
 }
 
 // DoCommand calls the injected DoCommand or the real version.
-func (pT *PoseTracker) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (pT *PoseTracker) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	if pT.DoFunc == nil {
 		return pT.PoseTracker.DoCommand(ctx, cmd)
 	}

--- a/testutils/inject/powersensor.go
+++ b/testutils/inject/powersensor.go
@@ -11,11 +11,11 @@ import (
 type PowerSensor struct {
 	powersensor.PowerSensor
 	name         resource.Name
-	VoltageFunc  func(ctx context.Context, extra map[string]interface{}) (float64, bool, error)
-	CurrentFunc  func(ctx context.Context, extra map[string]interface{}) (float64, bool, error)
-	PowerFunc    func(ctx context.Context, extra map[string]interface{}) (float64, error)
-	ReadingsFunc func(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error)
-	DoFunc       func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
+	VoltageFunc  func(ctx context.Context, extra map[string]any) (float64, bool, error)
+	CurrentFunc  func(ctx context.Context, extra map[string]any) (float64, bool, error)
+	PowerFunc    func(ctx context.Context, extra map[string]any) (float64, error)
+	ReadingsFunc func(ctx context.Context, extra map[string]any) (map[string]any, error)
+	DoFunc       func(ctx context.Context, cmd map[string]any) (map[string]any, error)
 }
 
 // NewPowerSensor returns a new injected movement sensor.
@@ -29,7 +29,7 @@ func (i *PowerSensor) Name() resource.Name {
 }
 
 // DoCommand calls the injected DoCommand or the real version.
-func (i *PowerSensor) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (i *PowerSensor) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	if i.DoFunc == nil {
 		return i.PowerSensor.DoCommand(ctx, cmd)
 	}
@@ -37,7 +37,7 @@ func (i *PowerSensor) DoCommand(ctx context.Context, cmd map[string]interface{})
 }
 
 // Voltage func or passthrough.
-func (i *PowerSensor) Voltage(ctx context.Context, cmd map[string]interface{}) (float64, bool, error) {
+func (i *PowerSensor) Voltage(ctx context.Context, cmd map[string]any) (float64, bool, error) {
 	if i.VoltageFunc == nil {
 		return i.PowerSensor.Voltage(ctx, cmd)
 	}
@@ -45,7 +45,7 @@ func (i *PowerSensor) Voltage(ctx context.Context, cmd map[string]interface{}) (
 }
 
 // Current func or passthrough.
-func (i *PowerSensor) Current(ctx context.Context, cmd map[string]interface{}) (float64, bool, error) {
+func (i *PowerSensor) Current(ctx context.Context, cmd map[string]any) (float64, bool, error) {
 	if i.CurrentFunc == nil {
 		return i.PowerSensor.Current(ctx, cmd)
 	}
@@ -53,7 +53,7 @@ func (i *PowerSensor) Current(ctx context.Context, cmd map[string]interface{}) (
 }
 
 // Power func or passthrough.
-func (i *PowerSensor) Power(ctx context.Context, cmd map[string]interface{}) (float64, error) {
+func (i *PowerSensor) Power(ctx context.Context, cmd map[string]any) (float64, error) {
 	if i.PowerFunc == nil {
 		return i.PowerSensor.Power(ctx, cmd)
 	}
@@ -61,7 +61,7 @@ func (i *PowerSensor) Power(ctx context.Context, cmd map[string]interface{}) (fl
 }
 
 // Readings func or passthrough.
-func (i *PowerSensor) Readings(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (i *PowerSensor) Readings(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	if i.ReadingsFunc == nil {
 		return i.PowerSensor.Readings(ctx, cmd)
 	}

--- a/testutils/inject/robot.go
+++ b/testutils/inject/robot.go
@@ -36,7 +36,7 @@ type Robot struct {
 	ConfigFunc             func() *config.Config
 	LoggerFunc             func() logging.Logger
 	CloseFunc              func(ctx context.Context) error
-	StopAllFunc            func(ctx context.Context, extra map[resource.Name]map[string]interface{}) error
+	StopAllFunc            func(ctx context.Context, extra map[resource.Name]map[string]any) error
 	FrameSystemConfigFunc  func(ctx context.Context) (*framesystem.Config, error)
 	TransformPoseFunc      func(
 		ctx context.Context,
@@ -206,7 +206,7 @@ func (r *Robot) Close(ctx context.Context) error {
 }
 
 // StopAll calls the injected StopAll or the real version.
-func (r *Robot) StopAll(ctx context.Context, extra map[resource.Name]map[string]interface{}) error {
+func (r *Robot) StopAll(ctx context.Context, extra map[resource.Name]map[string]any) error {
 	r.Mu.RLock()
 	defer r.Mu.RUnlock()
 	if r.StopAllFunc == nil {

--- a/testutils/inject/sensor.go
+++ b/testutils/inject/sensor.go
@@ -11,8 +11,8 @@ import (
 type Sensor struct {
 	sensor.Sensor
 	name         resource.Name
-	DoFunc       func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
-	ReadingsFunc func(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error)
+	DoFunc       func(ctx context.Context, cmd map[string]any) (map[string]any, error)
+	ReadingsFunc func(ctx context.Context, extra map[string]any) (map[string]any, error)
 }
 
 // NewSensor returns a new injected sensor.
@@ -26,7 +26,7 @@ func (s *Sensor) Name() resource.Name {
 }
 
 // Readings calls the injected Readings or the real version.
-func (s *Sensor) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+func (s *Sensor) Readings(ctx context.Context, extra map[string]any) (map[string]any, error) {
 	if s.ReadingsFunc == nil {
 		return s.Sensor.Readings(ctx, extra)
 	}
@@ -34,7 +34,7 @@ func (s *Sensor) Readings(ctx context.Context, extra map[string]interface{}) (ma
 }
 
 // DoCommand calls the injected DoCommand or the real version.
-func (s *Sensor) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (s *Sensor) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	if s.DoFunc == nil {
 		return s.Sensor.DoCommand(ctx, cmd)
 	}

--- a/testutils/inject/sensors.go
+++ b/testutils/inject/sensors.go
@@ -11,10 +11,10 @@ import (
 type SensorsService struct {
 	sensors.Service
 	name          resource.Name
-	SensorsFunc   func(ctx context.Context, extra map[string]interface{}) ([]resource.Name, error)
-	ReadingsFunc  func(ctx context.Context, resources []resource.Name, extra map[string]interface{}) ([]sensors.Readings, error)
+	SensorsFunc   func(ctx context.Context, extra map[string]any) ([]resource.Name, error)
+	ReadingsFunc  func(ctx context.Context, resources []resource.Name, extra map[string]any) ([]sensors.Readings, error)
 	DoCommandFunc func(ctx context.Context,
-		cmd map[string]interface{}) (map[string]interface{}, error)
+		cmd map[string]any) (map[string]any, error)
 }
 
 // NewSensorsService returns a new injected sensors service.
@@ -28,7 +28,7 @@ func (s *SensorsService) Name() resource.Name {
 }
 
 // Sensors call the injected Sensors or the real one.
-func (s *SensorsService) Sensors(ctx context.Context, extra map[string]interface{}) ([]resource.Name, error) {
+func (s *SensorsService) Sensors(ctx context.Context, extra map[string]any) ([]resource.Name, error) {
 	if s.SensorsFunc == nil {
 		return s.Service.Sensors(ctx, extra)
 	}
@@ -36,7 +36,7 @@ func (s *SensorsService) Sensors(ctx context.Context, extra map[string]interface
 }
 
 // Readings call the injected Readings or the real one.
-func (s *SensorsService) Readings(ctx context.Context, names []resource.Name, extra map[string]interface{}) ([]sensors.Readings, error) {
+func (s *SensorsService) Readings(ctx context.Context, names []resource.Name, extra map[string]any) ([]sensors.Readings, error) {
 	if s.ReadingsFunc == nil {
 		return s.Service.Readings(ctx, names, extra)
 	}
@@ -45,8 +45,8 @@ func (s *SensorsService) Readings(ctx context.Context, names []resource.Name, ex
 
 // DoCommand calls the injected DoCommand or the real variant.
 func (s *SensorsService) DoCommand(ctx context.Context,
-	cmd map[string]interface{},
-) (map[string]interface{}, error) {
+	cmd map[string]any,
+) (map[string]any, error) {
 	if s.DoCommandFunc == nil {
 		return s.Service.DoCommand(ctx, cmd)
 	}

--- a/testutils/inject/servo.go
+++ b/testutils/inject/servo.go
@@ -11,10 +11,10 @@ import (
 type Servo struct {
 	servo.Servo
 	name         resource.Name
-	DoFunc       func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
-	MoveFunc     func(ctx context.Context, angleDeg uint32, extra map[string]interface{}) error
-	PositionFunc func(ctx context.Context, extra map[string]interface{}) (uint32, error)
-	StopFunc     func(ctx context.Context, extra map[string]interface{}) error
+	DoFunc       func(ctx context.Context, cmd map[string]any) (map[string]any, error)
+	MoveFunc     func(ctx context.Context, angleDeg uint32, extra map[string]any) error
+	PositionFunc func(ctx context.Context, extra map[string]any) (uint32, error)
+	StopFunc     func(ctx context.Context, extra map[string]any) error
 	IsMovingFunc func(context.Context) (bool, error)
 }
 
@@ -29,7 +29,7 @@ func (s *Servo) Name() resource.Name {
 }
 
 // Move calls the injected Move or the real version.
-func (s *Servo) Move(ctx context.Context, angleDeg uint32, extra map[string]interface{}) error {
+func (s *Servo) Move(ctx context.Context, angleDeg uint32, extra map[string]any) error {
 	if s.MoveFunc == nil {
 		return s.Servo.Move(ctx, angleDeg, extra)
 	}
@@ -37,7 +37,7 @@ func (s *Servo) Move(ctx context.Context, angleDeg uint32, extra map[string]inte
 }
 
 // Position calls the injected Current or the real version.
-func (s *Servo) Position(ctx context.Context, extra map[string]interface{}) (uint32, error) {
+func (s *Servo) Position(ctx context.Context, extra map[string]any) (uint32, error) {
 	if s.PositionFunc == nil {
 		return s.Servo.Position(ctx, extra)
 	}
@@ -45,7 +45,7 @@ func (s *Servo) Position(ctx context.Context, extra map[string]interface{}) (uin
 }
 
 // Stop calls the injected Stop or the real version.
-func (s *Servo) Stop(ctx context.Context, extra map[string]interface{}) error {
+func (s *Servo) Stop(ctx context.Context, extra map[string]any) error {
 	if s.StopFunc == nil {
 		return s.Servo.Stop(ctx, extra)
 	}
@@ -53,7 +53,7 @@ func (s *Servo) Stop(ctx context.Context, extra map[string]interface{}) error {
 }
 
 // DoCommand calls the injected DoCommand or the real version.
-func (s *Servo) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (s *Servo) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	if s.DoFunc == nil {
 		return s.Servo.DoCommand(ctx, cmd)
 	}

--- a/testutils/inject/shell_service.go
+++ b/testutils/inject/shell_service.go
@@ -12,7 +12,7 @@ type ShellService struct {
 	shell.Service
 	name          resource.Name
 	DoCommandFunc func(ctx context.Context,
-		cmd map[string]interface{}) (map[string]interface{}, error)
+		cmd map[string]any) (map[string]any, error)
 	ReconfigureFunc func(ctx context.Context, deps resource.Dependencies, conf resource.Config) error
 	CloseFunc       func(ctx context.Context) error
 }
@@ -29,8 +29,8 @@ func (s *ShellService) Name() resource.Name {
 
 // DoCommand calls the injected DoCommand or the real variant.
 func (s *ShellService) DoCommand(ctx context.Context,
-	cmd map[string]interface{},
-) (map[string]interface{}, error) {
+	cmd map[string]any,
+) (map[string]any, error) {
 	if s.DoCommandFunc == nil {
 		return s.Service.DoCommand(ctx, cmd)
 	}

--- a/testutils/inject/slam_service.go
+++ b/testutils/inject/slam_service.go
@@ -16,7 +16,7 @@ type SLAMService struct {
 	PointCloudMapFunc func(ctx context.Context) (func() ([]byte, error), error)
 	InternalStateFunc func(ctx context.Context) (func() ([]byte, error), error)
 	PropertiesFunc    func(ctx context.Context) (slam.Properties, error)
-	DoCommandFunc     func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
+	DoCommandFunc     func(ctx context.Context, cmd map[string]any) (map[string]any, error)
 	CloseFunc         func(ctx context.Context) error
 }
 
@@ -64,8 +64,8 @@ func (slamSvc *SLAMService) Properties(ctx context.Context) (slam.Properties, er
 
 // DoCommand calls the injected DoCommand or the real variant.
 func (slamSvc *SLAMService) DoCommand(ctx context.Context,
-	cmd map[string]interface{},
-) (map[string]interface{}, error) {
+	cmd map[string]any,
+) (map[string]any, error) {
 	if slamSvc.DoCommandFunc == nil {
 		return slamSvc.Service.DoCommand(ctx, cmd)
 	}

--- a/testutils/inject/vision_service.go
+++ b/testutils/inject/vision_service.go
@@ -16,20 +16,20 @@ type VisionService struct {
 	vision.Service
 	name                     resource.Name
 	DetectionsFromCameraFunc func(
-		ctx context.Context, cameraName string, extra map[string]interface{},
+		ctx context.Context, cameraName string, extra map[string]any,
 	) ([]objectdetection.Detection, error)
 	DetectionsFunc func(
-		ctx context.Context, img image.Image, extra map[string]interface{},
+		ctx context.Context, img image.Image, extra map[string]any,
 	) ([]objectdetection.Detection, error)
 	// classification functions
 	ClassificationsFromCameraFunc func(ctx context.Context, cameraName string,
-		n int, extra map[string]interface{}) (classification.Classifications, error)
+		n int, extra map[string]any) (classification.Classifications, error)
 	ClassificationsFunc func(ctx context.Context, img image.Image,
-		n int, extra map[string]interface{}) (classification.Classifications, error)
+		n int, extra map[string]any) (classification.Classifications, error)
 	// segmentation functions
-	GetObjectPointCloudsFunc func(ctx context.Context, cameraName string, extra map[string]interface{}) ([]*viz.Object, error)
+	GetObjectPointCloudsFunc func(ctx context.Context, cameraName string, extra map[string]any) ([]*viz.Object, error)
 	DoCommandFunc            func(ctx context.Context,
-		cmd map[string]interface{}) (map[string]interface{}, error)
+		cmd map[string]any) (map[string]any, error)
 	CloseFunc func(ctx context.Context) error
 }
 
@@ -44,7 +44,7 @@ func (vs *VisionService) Name() resource.Name {
 }
 
 // DetectionsFromCamera calls the injected DetectionsFromCamera or the real variant.
-func (vs *VisionService) DetectionsFromCamera(ctx context.Context, cameraName string, extra map[string]interface{},
+func (vs *VisionService) DetectionsFromCamera(ctx context.Context, cameraName string, extra map[string]any,
 ) ([]objectdetection.Detection, error) {
 	if vs.DetectionsFunc == nil {
 		return vs.Service.DetectionsFromCamera(ctx, cameraName, extra)
@@ -53,7 +53,7 @@ func (vs *VisionService) DetectionsFromCamera(ctx context.Context, cameraName st
 }
 
 // Detections calls the injected Detect or the real variant.
-func (vs *VisionService) Detections(ctx context.Context, img image.Image, extra map[string]interface{},
+func (vs *VisionService) Detections(ctx context.Context, img image.Image, extra map[string]any,
 ) ([]objectdetection.Detection, error) {
 	if vs.DetectionsFunc == nil {
 		return vs.Service.Detections(ctx, img, extra)
@@ -63,7 +63,7 @@ func (vs *VisionService) Detections(ctx context.Context, img image.Image, extra 
 
 // ClassificationsFromCamera calls the injected Classifer or the real variant.
 func (vs *VisionService) ClassificationsFromCamera(ctx context.Context,
-	cameraName string, n int, extra map[string]interface{},
+	cameraName string, n int, extra map[string]any,
 ) (classification.Classifications, error) {
 	if vs.ClassificationsFromCameraFunc == nil {
 		return vs.Service.ClassificationsFromCamera(ctx, cameraName, n, extra)
@@ -73,7 +73,7 @@ func (vs *VisionService) ClassificationsFromCamera(ctx context.Context,
 
 // Classifications calls the injected Classifier or the real variant.
 func (vs *VisionService) Classifications(ctx context.Context, img image.Image,
-	n int, extra map[string]interface{},
+	n int, extra map[string]any,
 ) (classification.Classifications, error) {
 	if vs.ClassificationsFunc == nil {
 		return vs.Service.Classifications(ctx, img, n, extra)
@@ -84,7 +84,7 @@ func (vs *VisionService) Classifications(ctx context.Context, img image.Image,
 // GetObjectPointClouds calls the injected GetObjectPointClouds or the real variant.
 func (vs *VisionService) GetObjectPointClouds(
 	ctx context.Context,
-	cameraName string, extra map[string]interface{},
+	cameraName string, extra map[string]any,
 ) ([]*viz.Object, error) {
 	if vs.GetObjectPointCloudsFunc == nil {
 		return vs.Service.GetObjectPointClouds(ctx, cameraName, extra)
@@ -94,8 +94,8 @@ func (vs *VisionService) GetObjectPointClouds(
 
 // DoCommand calls the injected DoCommand or the real variant.
 func (vs *VisionService) DoCommand(ctx context.Context,
-	cmd map[string]interface{},
-) (map[string]interface{}, error) {
+	cmd map[string]any,
+) (map[string]any, error) {
 	if vs.DoCommandFunc == nil {
 		return vs.Service.DoCommand(ctx, cmd)
 	}

--- a/testutils/proto_utils.go
+++ b/testutils/proto_utils.go
@@ -4,7 +4,7 @@ import "go.viam.com/utils/protoutils"
 
 // ToProtoMapIgnoreOmitEmpty is a helper to convert an interface
 // to a map to compare against a structpb.
-func ToProtoMapIgnoreOmitEmpty(data interface{}) map[string]interface{} {
+func ToProtoMapIgnoreOmitEmpty(data any) map[string]any {
 	ret, err := protoutils.StructToStructPbIgnoreOmitEmpty(data)
 	if err != nil {
 		return nil

--- a/testutils/resource_utils.go
+++ b/testutils/resource_utils.go
@@ -23,12 +23,12 @@ type unimplResource struct {
 
 var (
 	// EchoFunc is a helper to echo out the say command passsed in a Do.
-	EchoFunc = func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+	EchoFunc = func(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 		return cmd, nil
 	}
 
 	// TestCommand is a dummy command to send for a DoCommand.
-	TestCommand = map[string]interface{}{"command": "test", "data": 500}
+	TestCommand = map[string]any{"command": "test", "data": 500}
 )
 
 // NewResourceNameSet returns a flattened set of name strings from

--- a/utils/attribute_map.go
+++ b/utils/attribute_map.go
@@ -8,7 +8,7 @@ import (
 
 // An AttributeMap is a convenience wrapper for pulling out
 // typed information from a map.
-type AttributeMap map[string]interface{}
+type AttributeMap map[string]any
 
 // Has returns whether or not the given name is in the map.
 func (am AttributeMap) Has(name string) bool {
@@ -27,7 +27,7 @@ func (am AttributeMap) IntSlice(name string) []int {
 		return []int{}
 	}
 
-	if slice, ok := x.([]interface{}); ok {
+	if slice, ok := x.([]any); ok {
 		ints := make([]int, 0, len(slice))
 		for _, v := range slice {
 			if i, ok := v.(int); ok {
@@ -55,7 +55,7 @@ func (am AttributeMap) Float64Slice(name string) []float64 {
 		return []float64{}
 	}
 
-	if slice, ok := x.([]interface{}); ok {
+	if slice, ok := x.([]any); ok {
 		float64s := make([]float64, 0, len(slice))
 		for _, v := range slice {
 			if i, ok := v.(float64); ok {
@@ -81,7 +81,7 @@ func (am AttributeMap) StringSlice(name string) []string {
 		return []string{}
 	}
 
-	if slice, ok := x.([]interface{}); ok {
+	if slice, ok := x.([]any); ok {
 		strings := make([]string, 0, len(slice))
 		for _, v := range slice {
 			if s, ok := v.(string); ok {
@@ -187,7 +187,7 @@ func (am AttributeMap) BoolSlice(name string, def bool) []bool {
 		return []bool{}
 	}
 
-	if slice, ok := x.([]interface{}); ok {
+	if slice, ok := x.([]any); ok {
 		bools := make([]bool, 0, len(slice))
 		for _, v := range slice {
 			if b, ok := v.(bool); ok {
@@ -203,7 +203,7 @@ func (am AttributeMap) BoolSlice(name string, def bool) []bool {
 }
 
 // Walk implements the Walker interface.
-func (am AttributeMap) Walk(visitor Visitor) (interface{}, error) {
+func (am AttributeMap) Walk(visitor Visitor) (any, error) {
 	w := attrWalker{visitor: visitor}
 	m, err := w.walkMap(am)
 	if err != nil {
@@ -217,14 +217,14 @@ type attrWalker struct {
 	visitor Visitor
 }
 
-func (w *attrWalker) walkMap(data interface{}) (map[string]interface{}, error) {
+func (w *attrWalker) walkMap(data any) (map[string]any, error) {
 	s := reflect.ValueOf(data)
 	if s.Kind() != reflect.Map {
 		return nil, errors.Errorf("data of type %T is not a map", data)
 	}
 
 	iter := reflect.ValueOf(data).MapRange()
-	result := map[string]interface{}{}
+	result := map[string]any{}
 	var err error
 	for iter.Next() {
 		k := iter.Key()
@@ -240,7 +240,7 @@ func (w *attrWalker) walkMap(data interface{}) (map[string]interface{}, error) {
 	return result, nil
 }
 
-func (w *attrWalker) walkInterface(data interface{}) (interface{}, error) {
+func (w *attrWalker) walkInterface(data any) (any, error) {
 	if data == nil {
 		return data, nil
 	}
@@ -250,7 +250,7 @@ func (w *attrWalker) walkInterface(data interface{}) (interface{}, error) {
 		t = t.Elem()
 	}
 
-	var newData interface{}
+	var newData any
 	var err error
 	switch t.Kind() {
 	case reflect.Struct:
@@ -287,13 +287,13 @@ func (w *attrWalker) walkInterface(data interface{}) (interface{}, error) {
 	return newData, nil
 }
 
-func (w *attrWalker) walkSlice(data interface{}) ([]interface{}, error) {
+func (w *attrWalker) walkSlice(data any) ([]any, error) {
 	s := reflect.ValueOf(data)
 	if s.Kind() != reflect.Slice {
 		return nil, errors.Errorf("data of type %T is not a slice", data)
 	}
 
-	newList := make([]interface{}, 0, s.Len())
+	newList := make([]any, 0, s.Len())
 	for i := 0; i < s.Len(); i++ {
 		value := s.Index(i).Interface()
 		data, err := w.walkInterface(value)
@@ -305,7 +305,7 @@ func (w *attrWalker) walkSlice(data interface{}) ([]interface{}, error) {
 	return newList, nil
 }
 
-func (w *attrWalker) walkStruct(data interface{}) (interface{}, error) {
+func (w *attrWalker) walkStruct(data any) (any, error) {
 	t := reflect.TypeOf(data)
 	if t.Kind() == reflect.Ptr {
 		t = t.Elem()
@@ -313,7 +313,7 @@ func (w *attrWalker) walkStruct(data interface{}) (interface{}, error) {
 	if t.Kind() != reflect.Struct {
 		return nil, errors.Errorf("data of type %T is not a struct", data)
 	}
-	res := map[string]interface{}{}
+	res := map[string]any{}
 	value := reflect.ValueOf(data)
 	if value.Kind() == reflect.Ptr && value.IsNil() {
 		return res, nil

--- a/utils/attribute_map_test.go
+++ b/utils/attribute_map_test.go
@@ -12,16 +12,16 @@ var sampleAttributeMap = AttributeMap{
 	"ok_boolean_true":    true,
 	"bad_boolean_false":  0,
 	"bad_boolean_true":   "true",
-	"good_int_slice":     []interface{}{1, 2, 3},
+	"good_int_slice":     []any{1, 2, 3},
 	"bad_int_slice":      "this is not an int slice",
-	"bad_int_slice_2":    []interface{}{1, 2, "3"},
-	"good_string_slice":  []interface{}{"1", "2", "3"},
+	"bad_int_slice_2":    []any{1, 2, "3"},
+	"good_string_slice":  []any{"1", "2", "3"},
 	"bad_string_slice":   123,
-	"bad_string_slice_2": []interface{}{"1", "2", 3},
-	"good_float64_slice": []interface{}{1.1, 2.2, 3.3},
-	"bad_float64_slice":  []interface{}{int(1), "2", 3.3},
-	"good_boolean_slice": []interface{}{true, true, false},
-	"bad_boolean_slice":  []interface{}{"true", "F", false},
+	"bad_string_slice_2": []any{"1", "2", 3},
+	"good_float64_slice": []any{1.1, 2.2, 3.3},
+	"bad_float64_slice":  []any{int(1), "2", 3.3},
+	"good_boolean_slice": []any{true, true, false},
+	"bad_boolean_slice":  []any{"true", "F", false},
 }
 
 func TestAttributeMap(t *testing.T) {
@@ -147,17 +147,17 @@ func TestAttributeMapWalk(t *testing.T) {
 	expectedAttrs := AttributeMap{
 		"one":       float64(1),
 		"file_path": "/this/is/a/path",
-		"data": map[string]interface{}{
+		"data": map[string]any{
 			"StringValue":    "/some/path",
 			"StringPtrValue": "some string val",
-			"StringArray":    []interface{}{"one", "two", "three"},
+			"StringArray":    []any{"one", "two", "three"},
 			"BoolValue":      true,
-			"ByteArray":      []interface{}{byte('h'), byte('e'), byte('l'), byte('l'), byte('o')},
-			"Data":           map[string]interface{}{"Other": "this is a string"},
-			"DataPtr":        map[string]interface{}{"Other": "/some/other/path"},
-			"DataMapStr": map[string]interface{}{
-				"other1": map[string]interface{}{"Other": "/its/another/path"},
-				"other2": map[string]interface{}{"Other": "hello2"},
+			"ByteArray":      []any{byte('h'), byte('e'), byte('l'), byte('l'), byte('o')},
+			"Data":           map[string]any{"Other": "this is a string"},
+			"DataPtr":        map[string]any{"Other": "/some/other/path"},
+			"DataMapStr": map[string]any{
+				"other1": map[string]any{"Other": "/its/another/path"},
+				"other2": map[string]any{"Other": "hello2"},
 			},
 		},
 	}
@@ -168,7 +168,7 @@ func TestAttributeMapWalk(t *testing.T) {
 // to. This makes testing easier since we can compare values with values.
 type indirectVisitor struct{}
 
-func (v *indirectVisitor) Visit(data interface{}) (interface{}, error) {
+func (v *indirectVisitor) Visit(data any) (any, error) {
 	val := reflect.ValueOf(data)
 	val = reflect.Indirect(val)
 	return val.Interface(), nil

--- a/utils/contextutils/context.go
+++ b/utils/contextutils/context.go
@@ -44,7 +44,7 @@ func ContextWithMetadata(ctx context.Context) (context.Context, map[string][]str
 func ContextWithMetadataUnaryClientInterceptor(
 	ctx context.Context,
 	method string,
-	req, reply interface{},
+	req, reply any,
 	cc *grpc.ClientConn,
 	invoker grpc.UnaryInvoker,
 	opts ...grpc.CallOption,

--- a/utils/errors.go
+++ b/utils/errors.go
@@ -16,7 +16,7 @@ func NewRemoteResourceClashError(name string) error {
 }
 
 // NewUnexpectedTypeError is used when there is a type mismatch.
-func NewUnexpectedTypeError[ExpectedT any](actual interface{}) error {
+func NewUnexpectedTypeError[ExpectedT any](actual any) error {
 	return errors.Errorf("expected %s but got %T", TypeStr[ExpectedT](), actual)
 }
 

--- a/utils/errors_test.go
+++ b/utils/errors_test.go
@@ -28,5 +28,5 @@ func TestNewUnexpectedTypeError(t *testing.T) {
 
 type (
 	someStruct struct{}
-	someIfc    interface{}
+	someIfc    any
 )

--- a/utils/value.go
+++ b/utils/value.go
@@ -7,7 +7,7 @@ import (
 
 // AssertType attempts to assert that the given interface argument is
 // the given type parameter.
-func AssertType[T any](from interface{}) (T, error) {
+func AssertType[T any](from any) (T, error) {
 	var zero T
 	asserted, ok := from.(T)
 	if !ok {

--- a/utils/variables.go
+++ b/utils/variables.go
@@ -25,7 +25,7 @@ type TypedName struct {
 }
 
 // JSONTags returns a slice of strings of the variable names in the JSON tags of a struct.
-func JSONTags(s interface{}) []TypedName {
+func JSONTags(s any) []TypedName {
 	tags := []TypedName{}
 	val := reflect.ValueOf(s)
 	for i := 0; i < val.Type().NumField(); i++ {

--- a/utils/walker_visitor.go
+++ b/utils/walker_visitor.go
@@ -3,11 +3,11 @@ package utils
 // Walker is a portion of the config that can be walked.
 type Walker interface {
 	// Walk walks a structure and returns a new structure, with or without modifications.
-	Walk(Visitor) (interface{}, error)
+	Walk(Visitor) (any, error)
 }
 
 // Visitor defines an interface for visiting and potentially modifying portions of the config.
 type Visitor interface {
 	// Visit visits a node and returns a new node, with or without modifications.
-	Visit(interface{}) (interface{}, error)
+	Visit(any) (any, error)
 }

--- a/vision/classification/postprocessor.go
+++ b/vision/classification/postprocessor.go
@@ -21,7 +21,7 @@ func NewScoreFilter(conf float64) Postprocessor {
 
 // NewLabelFilter returns a function that filters out classifications without one of the chosen labels.
 // Does not filter when input is empty.
-func NewLabelFilter(labels map[string]interface{}) Postprocessor {
+func NewLabelFilter(labels map[string]any) Postprocessor {
 	return func(in Classifications) Classifications {
 		if len(labels) < 1 {
 			return in

--- a/vision/objectdetection/postprocessor.go
+++ b/vision/objectdetection/postprocessor.go
@@ -36,7 +36,7 @@ func NewScoreFilter(conf float64) Postprocessor {
 
 // NewLabelFilter returns a function that filters out detections without one of the chosen labels.
 // Does not filter when input is empty.
-func NewLabelFilter(labels map[string]interface{}) Postprocessor {
+func NewLabelFilter(labels map[string]any) Postprocessor {
 	return func(in []Detection) []Detection {
 		if len(labels) < 1 {
 			return in

--- a/vision/training.go
+++ b/vision/training.go
@@ -20,7 +20,7 @@ type TrainingImage struct {
 	ID       primitive.ObjectID `bson:"_id" json:"id,omitempty"`
 	Data     []byte
 	Labels   []string
-	MetaData map[string]interface{}
+	MetaData map[string]any
 }
 
 // ImageTrainingStore TODO.
@@ -69,7 +69,7 @@ func (its *ImageTrainingStore) StoreImageFromDisk(ctx context.Context, fn string
 	if err != nil {
 		return primitive.ObjectID{}, err
 	}
-	md := map[string]interface{}{"filename": fn}
+	md := map[string]any{"filename": fn}
 	return its.StoreImage(ctx, img, md, labels)
 }
 
@@ -77,7 +77,7 @@ func (its *ImageTrainingStore) StoreImageFromDisk(ctx context.Context, fn string
 func (its *ImageTrainingStore) StoreImage(
 	ctx context.Context,
 	img image.Image,
-	metaData map[string]interface{},
+	metaData map[string]any,
 	labels []string,
 ) (primitive.ObjectID, error) {
 	ti := TrainingImage{}

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -81,7 +81,7 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 
 	// Always log the version, return early if the '-version' flag was provided
 	// fmt.Println would be better but fails linting. Good enough.
-	var versionFields []interface{}
+	var versionFields []any
 	if config.Version != "" {
 		versionFields = append(versionFields, "version", config.Version)
 	}


### PR DESCRIPTION
Since go 1.18 go has defined the `any = interface{}` type alias https://go.dev/ref/spec#Predeclared_identifiers

See:
`go/src/builtin/builtin.go:96`:
```golang
// any is an alias for interface{} and is equivalent to interface{} in all ways.
type any = interface{}

```

`any` seems more readable to me than the elusive `interface{}` (which was confusing when I was first learning go). 

This mirrors [this commit to the golang repo](https://github.com/golang/go/commit/2580d0e08d5e9f979b943758d3c49877fb2324cb) by Russ Cox


However, I don't really care too much and if people are opposed, we can just close this and continue using `interface{}`. 

Generated by recursively replacing `interface{}` with `any` and then running:
`git add $(git status | grep ".go" | grep -v ".pb.go" | awk '{print $2}')`


[rdk pr] https://github.com/viamrobotics/rdk/pull/3573
[app pr] https://github.com/viamrobotics/app/pull/3654