### PR TITLE
[RSDK-5462] don't deadlock on opening I2C handles in the RTK code

### DIFF
--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
@@ -350,7 +350,7 @@ func (g *rtkI2C) receiveAndWriteI2C(ctx context.Context) {
 		g.err.Set(err)
 		return
 	}
-	// TODO: defer closing the handle here, so it doesn't lock up on error
+	defer utils.UncheckedErrorFunc(handle.Close)
 
 	// Send GLL, RMC, VTG, GGA, GSA, and GSV sentences each 1000ms
 	baudcmd := fmt.Sprintf("PMTK251,%d", g.wbaud)
@@ -420,14 +420,6 @@ func (g *rtkI2C) receiveAndWriteI2C(ctx context.Context) {
 		default:
 		}
 
-		// establish I2C connection
-		handle, err := g.bus.OpenHandle(g.addr)
-		if err != nil {
-			g.logger.CErrorf(ctx, "can't open gps i2c %s", err)
-			g.err.Set(err)
-			return
-		}
-
 		msg, err := scanner.NextMessage()
 		if err != nil {
 			g.ntripMu.Lock()
@@ -467,13 +459,6 @@ func (g *rtkI2C) receiveAndWriteI2C(ctx context.Context) {
 				g.ntripMu.Unlock()
 				continue
 			}
-		}
-		// close I2C
-		err = handle.Close()
-		if err != nil {
-			g.logger.CDebug(ctx, "failed to close handle: %s", err)
-			g.err.Set(err)
-			return
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes a bug exacerbated by https://github.com/viamrobotics/rdk/pull/3070: when a genericlinux I2C bus has an open handle, no other handles can be opened on it. Before #3070, the bug already existed on non-rpi4 boards, but now it occurs on the rpi4's as well. Perhaps having these locks in the I2C interface at all is a mistake, since other I2C handles can be opened on the same physical wires as long as you use a separate `buses.i2cBus` object to open them. but that's a discussion for another day.

Tried on the `piworld` board: on the main branch, the I2C RTK device never gets a fix greater than 1 (using NMEA messages only), and it does not shut down quickly. On this branch, its fix can get to 2 (using both NMEA and NTRIP messages), and hitting control-C shuts down the server relatively quickly. I also plugged an ADXL345 accelerometer into the same I2C bus, to demonstrate that the two components can both use the bus at the same time (i.e., it's not a problem that the RTK component opens its handle and doesn't close it until the entire component shuts down). 