### PR TITLE
APP-3923: catch errors with GetAccuracy in movement sensor card

### DIFF
--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "2.10.3",
+  "version": "2.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/remote-control",
-      "version": "2.10.3",
+      "version": "2.11.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@improbable-eng/grpc-web": "0.15.0",

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "2.10.3",
+  "version": "2.11.0",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
`getAccuracy` calls were throwing errors when unimplemented, which borks the whole card.

## Change log

- Move `getProperties` call into try/catch, just in case
- Add separate try/catch for calling `getAccuracy`
  - See comment

## Review requests

Just code review should suffice, we'll test E2E when upgrading version in App. I tested running locally and it worked.

## TODO

- [x] Minor version bump