### PR TITLE
[RSDK-5462] More gps cleanup

### DIFF
--- a/components/movementsensor/rtkutils/ntrip.go
+++ b/components/movementsensor/rtkutils/ntrip.go
@@ -223,6 +223,8 @@ func parseStream(line string) (Stream, error) {
 
 // Connect attempts to initialize a new ntrip client.
 func (n *NtripInfo) Connect(ctx context.Context, logger logging.Logger) error {
+	// If we're unable to connect after multiple attempts, we return the last error. Declare the
+	// error variable out here so its lifetime is more than just the for loop.
 	var c *ntrip.Client
 	var err error
 

--- a/components/movementsensor/rtkutils/ntrip.go
+++ b/components/movementsensor/rtkutils/ntrip.go
@@ -235,19 +235,15 @@ func (n *NtripInfo) Connect(ctx context.Context, logger logging.Logger) error {
 		}
 
 		c, err = ntrip.NewClient(n.URL, ntrip.Options{Username: n.username, Password: n.password})
-		if err == nil {
-			break
+		if err == nil { // Success!
+			logger.Info("Connected to NTRIP caster")
+			n.Client = c
+			return nil
 		}
 	}
 
-	if err != nil {
-		logger.Errorf("Can't connect to NTRIP caster: %s", err)
-		return err
-	}
-
-	logger.Info("Connected to NTRIP caster")
-	n.Client = c
-	return nil
+	logger.Errorf("Can't connect to NTRIP caster: %s", err)
+	return err
 }
 
 // HasStream checks if the sourcetable contains the given mountpoint in it's stream.

--- a/components/movementsensor/rtkutils/ntrip.go
+++ b/components/movementsensor/rtkutils/ntrip.go
@@ -221,10 +221,9 @@ func parseStream(line string) (Stream, error) {
 	}, nil
 }
 
-// Connect attempts to initialize a new ntrip client.
+// Connect attempts to initialize a new ntrip client. If we're unable to connect after multiple
+// attempts, we return the last error.
 func (n *NtripInfo) Connect(ctx context.Context, logger logging.Logger) error {
-	// If we're unable to connect after multiple attempts, we return the last error. Declare the
-	// error variable out here so its lifetime is more than just the for loop.
 	var c *ntrip.Client
 	var err error
 


### PR DESCRIPTION
No behavioral changes are intended. This is a follow-up to https://github.com/viamrobotics/rdk/pull/3548: I removed the duplicated code, but didn't notice that the control flow within that code was so messy. 

Before this PR, when we have successfully connected, `err` would be `nil`, so we would break out of the for loop. We could get out of the for loop either by successfully connecting or by failing to connect too many times, so we'd then check if the error is not `nil` to find out which situation we're in, and then store the client and return. After this PR, when we successfully connect, we just store the client and return, and if we ever get out of the for loop, it's because we were unable to connect after the maximum number of attempts.

My next instinct was to make `c` and `err` local within the for loop, and stop declaring them before their first use. However, this makes it difficult to return the most recent error, if you get past the for loop. So, I added in a comment about that (but don't really like the way it's phrased; if you've got a better suggestion, I'm all for it!).