### PR TITLE
[RSDK-4975] CLI update warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BUILD_CHANNEL ?= local
 PATH_WITH_TOOLS="`pwd`/$(TOOL_BIN):`pwd`/node_modules/.bin:${PATH}"
 
 GIT_REVISION = $(shell git rev-parse HEAD | tr -d '\n')
-TAG_VERSION?=$(shell git tag --points-at | sort -Vr | head -n1)
+TAG_VERSION?=$(shell git tag --points-at | sort -Vr | head -n1 | grep . || echo "(dev)")
 DATE_COMPILED?=$(shell date +'%Y-%m-%d')
 LDFLAGS = -ldflags "-s -w -extld="$(shell pwd)/etc/ld_wrapper.sh" -X 'go.viam.com/rdk/config.Version=${TAG_VERSION}' -X 'go.viam.com/rdk/config.GitRevision=${GIT_REVISION}' -X 'go.viam.com/rdk/config.DateCompiled=${DATE_COMPILED}'"
 ifeq ($(shell command -v dpkg >/dev/null && dpkg --print-architecture),armhf)

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ PATH_WITH_TOOLS="`pwd`/$(TOOL_BIN):`pwd`/node_modules/.bin:${PATH}"
 
 GIT_REVISION = $(shell git rev-parse HEAD | tr -d '\n')
 TAG_VERSION?=$(shell git tag --points-at | sort -Vr | head -n1)
-LDFLAGS = -ldflags "-s -w -extld="$(shell pwd)/etc/ld_wrapper.sh" -X 'go.viam.com/rdk/config.Version=${TAG_VERSION}' -X 'go.viam.com/rdk/config.GitRevision=${GIT_REVISION}'"
+DATE_COMPILED?=$(shell date +'%Y-%m-d')
+LDFLAGS = -ldflags "-s -w -extld="$(shell pwd)/etc/ld_wrapper.sh" -X 'go.viam.com/rdk/config.Version=${TAG_VERSION}' -X 'go.viam.com/rdk/config.GitRevision=${GIT_REVISION}' -X 'go.viam.com/rdk/config.DateCompiled=${DATE_COMPILED}'"
 ifeq ($(shell command -v dpkg >/dev/null && dpkg --print-architecture),armhf)
 GOFLAGS += -tags=no_tflite
 endif

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PATH_WITH_TOOLS="`pwd`/$(TOOL_BIN):`pwd`/node_modules/.bin:${PATH}"
 
 GIT_REVISION = $(shell git rev-parse HEAD | tr -d '\n')
 TAG_VERSION?=$(shell git tag --points-at | sort -Vr | head -n1)
-DATE_COMPILED?=$(shell date +'%Y-%m-d')
+DATE_COMPILED?=$(shell date +'%Y-%m-%d')
 LDFLAGS = -ldflags "-s -w -extld="$(shell pwd)/etc/ld_wrapper.sh" -X 'go.viam.com/rdk/config.Version=${TAG_VERSION}' -X 'go.viam.com/rdk/config.GitRevision=${GIT_REVISION}' -X 'go.viam.com/rdk/config.DateCompiled=${DATE_COMPILED}'"
 ifeq ($(shell command -v dpkg >/dev/null && dpkg --print-architecture),armhf)
 GOFLAGS += -tags=no_tflite

--- a/cli/app.go
+++ b/cli/app.go
@@ -19,8 +19,8 @@ const (
 	aliasRobotFlag   = "robot"
 	partFlag         = "part"
 
-  // quiet any warnings
-  quietFlag        = "quiet"
+	// quiet any warnings.
+	quietFlag = "quiet"
 
 	logsFlagErrors = "errors"
 	logsFlagTail   = "tail"
@@ -114,8 +114,9 @@ var app = &cli.App{
 		},
 		&cli.BoolFlag{
 			Name:    quietFlag,
+			Value:   false,
 			Aliases: []string{"q"},
-			Usage:   "suppress warnings; ie version warning, etc",
+			Usage:   "suppress warnings",
 		},
 	},
 	Commands: []*cli.Command{
@@ -131,8 +132,8 @@ var app = &cli.App{
 					Usage: "prevent opening the default browser during login",
 				},
 			},
-      Action: LoginAction,
-      Before: CheckVersionUpdate,
+			Action: LoginAction,
+			After:  CheckUpdateAction,
 			Subcommands: []*cli.Command{
 				{
 					Name:   "print-access-token",
@@ -163,13 +164,8 @@ var app = &cli.App{
 			Name:   "logout",
 			Usage:  "logout from current session",
 			Action: LogoutAction,
-    },
-    {
-      Name:   "check-update",
-      Usage:  "checks if there is a newer stable version available",
-      Action: CheckVersionUpdate,
-    },
-    {
+		},
+		{
 			Name:   "whoami",
 			Usage:  "get currently logged-in user",
 			Action: WhoAmIAction,

--- a/cli/app.go
+++ b/cli/app.go
@@ -19,6 +19,9 @@ const (
 	aliasRobotFlag   = "robot"
 	partFlag         = "part"
 
+  // quiet any warnings
+  quietFlag        = "quiet"
+
 	logsFlagErrors = "errors"
 	logsFlagTail   = "tail"
 
@@ -109,6 +112,11 @@ var app = &cli.App{
 			Aliases: []string{"vvv"},
 			Usage:   "enable debug logging",
 		},
+		&cli.BoolFlag{
+			Name:    quietFlag,
+			Aliases: []string{"q"},
+			Usage:   "suppress warnings; ie version warning, etc",
+		},
 	},
 	Commands: []*cli.Command{
 		{
@@ -123,7 +131,8 @@ var app = &cli.App{
 					Usage: "prevent opening the default browser during login",
 				},
 			},
-			Action: LoginAction,
+      Action: LoginAction,
+      Before: CheckVersionUpdate,
 			Subcommands: []*cli.Command{
 				{
 					Name:   "print-access-token",
@@ -154,8 +163,13 @@ var app = &cli.App{
 			Name:   "logout",
 			Usage:  "logout from current session",
 			Action: LogoutAction,
-		},
-		{
+    },
+    {
+      Name:   "check-update",
+      Usage:  "checks if there is a newer stable version available",
+      Action: CheckVersionUpdate,
+    },
+    {
 			Name:   "whoami",
 			Usage:  "get currently logged-in user",
 			Action: WhoAmIAction,

--- a/cli/app.go
+++ b/cli/app.go
@@ -19,7 +19,7 @@ const (
 	aliasRobotFlag   = "robot"
 	partFlag         = "part"
 
-	// quiet any warnings.
+	// TODO: RSDK-6683
 	quietFlag = "quiet"
 
 	logsFlagErrors = "errors"

--- a/cli/app.go
+++ b/cli/app.go
@@ -19,7 +19,7 @@ const (
 	aliasRobotFlag   = "robot"
 	partFlag         = "part"
 
-	// TODO: RSDK-6683
+	// TODO: RSDK-6683.
 	quietFlag = "quiet"
 
 	logsFlagErrors = "errors"

--- a/cli/client.go
+++ b/cli/client.go
@@ -388,7 +388,7 @@ func RobotsPartShellAction(c *cli.Context) error {
 }
 
 // checkUpdateResponse holds the values used to hold release information.
-type checkUpdateResponse struct {
+type getLatestReleaseResponse struct {
 	Name       string `json:"name"`
 	TagName    string `json:"tag_name"`
 	TarballURL string `json:"tarball_url"`
@@ -398,7 +398,7 @@ func getLatestReleaseVersion() (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	resp := checkUpdateResponse{}
+	resp := getLatestReleaseResponse{}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rdkReleaseURL, nil)
 	if err != nil {

--- a/cli/client.go
+++ b/cli/client.go
@@ -427,6 +427,12 @@ func CheckUpdateAction(c *cli.Context) error {
 	}
 
 	dateCompiledRaw := rconfig.DateCompiled
+
+	// `go build` will not set the compilation flags needed for this check
+	if dateCompiledRaw == "" {
+		return nil
+	}
+
 	dateCompiled, err := time.Parse("2006-01-02", dateCompiledRaw)
 	if err != nil {
 		warningf(c.App.ErrWriter, "CLI Update Check: failed to parse compilation date: %w", err)

--- a/cli/client.go
+++ b/cli/client.go
@@ -479,14 +479,15 @@ func CheckUpdateAction(c *cli.Context) error {
 
 	conf.LatestVersion = latestVersion.String()
 
+	err = storeConfigToCache(conf)
+	if err != nil {
+		utils.UncheckedError(err)
+	}
+
 	appVersion := rconfig.Version
 	if appVersion == "(dev)" {
 		warningf(c.App.ErrWriter, "CLI Update Check: Your CLI is more than 6 weeks old. "+
 			"Consider updating to version: %s", latestVersion.Original())
-		err = storeConfigToCache(conf)
-		if err != nil {
-			utils.UncheckedError(err)
-		}
 		return nil
 	}
 
@@ -498,11 +499,6 @@ func CheckUpdateAction(c *cli.Context) error {
 
 	if localVersion.LessThan(latestVersion) {
 		warningf(c.App.ErrWriter, "CLI Update Check: Your CLI is out of date. Consider updating to version %s", latestVersion.Original())
-	}
-
-	err = storeConfigToCache(conf)
-	if err != nil {
-		utils.UncheckedError(err)
 	}
 
 	return nil

--- a/cli/client.go
+++ b/cli/client.go
@@ -419,10 +419,10 @@ func CheckUpdateAction(c *cli.Context) error {
 
 	if conf.LastUpdateCheck == "" {
 		conf.LastUpdateCheck = time.Now().Format("2006-01-02")
-	  err := storeConfigToCache(conf)
-    if err != nil { 
+		err := storeConfigToCache(conf)
+		if err != nil {
 			utils.UncheckedError(err)
-    }
+		}
 	} else {
 		lastCheck, err := time.Parse("2006-01-02", conf.LastUpdateCheck)
 		if err != nil {

--- a/cli/client.go
+++ b/cli/client.go
@@ -419,6 +419,10 @@ func CheckUpdateAction(c *cli.Context) error {
 
 	if conf.LastUpdateCheck == "" {
 		conf.LastUpdateCheck = time.Now().Format("2021-01-01")
+	  err := storeConfigToCache(conf)
+    if err != nil { 
+			utils.UncheckedError(err)
+    }
 	} else {
 		lastCheck, err := time.Parse("2006-01-02", conf.LastUpdateCheck)
 		if err != nil {

--- a/cli/client.go
+++ b/cli/client.go
@@ -455,7 +455,7 @@ func CheckUpdateAction(c *cli.Context) error {
 			warningf(c.App.ErrWriter, "CLI Update Check: failed to parse date of last check: %w", err)
 			return nil
 		}
-		if time.Since(lastCheck) < time.Hour*24*7 {
+		if time.Since(lastCheck) < time.Hour*24*3 {
 			return nil
 		}
 	}

--- a/cli/client.go
+++ b/cli/client.go
@@ -460,8 +460,8 @@ func CheckUpdateAction(c *cli.Context) error {
 
 	// The latest version info is cached to limit api calls to once every three days
 	if time.Since(lastCheck) < time.Hour*24*3 && conf.LatestVersion != "" {
-    warningf(c.App.ErrWriter, "CLI Update Check: Your CLI is more than 6 weeks old. "+
-      "Consider updating to version: %s", conf.LatestVersion)
+		warningf(c.App.ErrWriter, "CLI Update Check: Your CLI is more than 6 weeks old. "+
+			"Consider updating to version: %s", conf.LatestVersion)
 		return nil
 	}
 
@@ -483,10 +483,10 @@ func CheckUpdateAction(c *cli.Context) error {
 	if appVersion == "(dev)" {
 		warningf(c.App.ErrWriter, "CLI Update Check: Your CLI is more than 6 weeks old. "+
 			"Consider updating to version: %s", latestVersion.Original())
-    err = storeConfigToCache(conf)
-    if err != nil {
-      utils.UncheckedError(err)
-    }
+		err = storeConfigToCache(conf)
+		if err != nil {
+			utils.UncheckedError(err)
+		}
 		return nil
 	}
 

--- a/cli/client.go
+++ b/cli/client.go
@@ -418,7 +418,7 @@ func CheckUpdateAction(c *cli.Context) error {
 	}
 
 	if conf.LastUpdateCheck == "" {
-		conf.LastUpdateCheck = time.Now().Format("2021-01-01")
+		conf.LastUpdateCheck = time.Now().Format("2006-01-02")
 	  err := storeConfigToCache(conf)
     if err != nil { 
 			utils.UncheckedError(err)

--- a/cli/config.go
+++ b/cli/config.go
@@ -54,6 +54,7 @@ type config struct {
 	BaseURL         string     `json:"base_url"`
 	Auth            authMethod `json:"auth"`
 	LastUpdateCheck string     `json:"last_update_check"`
+	LatestVersion   string     `json:"latest_version"`
 }
 
 func (conf *config) tryUnmarshallWithToken(configBytes []byte) error {

--- a/cli/config.go
+++ b/cli/config.go
@@ -51,8 +51,9 @@ func storeConfigToCache(cfg *config) error {
 }
 
 type config struct {
-	BaseURL string     `json:"base_url"`
-	Auth    authMethod `json:"auth"`
+	BaseURL         string     `json:"base_url"`
+	Auth            authMethod `json:"auth"`
+	LastUpdateCheck string     `json:"last_update_check"`
 }
 
 func (conf *config) tryUnmarshallWithToken(configBytes []byte) error {

--- a/cli/print.go
+++ b/cli/print.go
@@ -43,7 +43,7 @@ func infof(w io.Writer, format string, a ...interface{}) {
 // do not currently make use of the variadic `a` parameter but may in the
 // future. unparam will complain until it does.
 //
-//nolint:unparam
+
 func warningf(w io.Writer, format string, a ...interface{}) {
 	if _, err := color.New(color.Bold, color.FgYellow).Fprint(w, "Warning: "); err != nil {
 		log.Fatal(err)

--- a/cli/print.go
+++ b/cli/print.go
@@ -38,12 +38,6 @@ func infof(w io.Writer, format string, a ...interface{}) {
 }
 
 // warningf prints a message prefixed with a bold yellow "Warning: ".
-//
-// NOTE(benjirewis): we disable the unparam linter here. Our usages of warningf
-// do not currently make use of the variadic `a` parameter but may in the
-// future. unparam will complain until it does.
-//
-
 func warningf(w io.Writer, format string, a ...interface{}) {
 	if _, err := color.New(color.Bold, color.FgYellow).Fprint(w, "Warning: "); err != nil {
 		log.Fatal(err)

--- a/config/reader.go
+++ b/config/reader.go
@@ -26,9 +26,9 @@ import (
 
 // RDK versioning variables which are replaced by LD flags.
 var (
-	Version       = ""
-	GitRevision   = ""
-	DateCompiled  = ""
+	Version      = ""
+	GitRevision  = ""
+	DateCompiled = ""
 )
 
 func getAgentInfo() (*apppb.AgentInfo, error) {

--- a/config/reader.go
+++ b/config/reader.go
@@ -26,8 +26,9 @@ import (
 
 // RDK versioning variables which are replaced by LD flags.
 var (
-	Version     = ""
-	GitRevision = ""
+	Version       = ""
+	GitRevision   = ""
+	DateCompiled  = ""
 )
 
 func getAgentInfo() (*apppb.AgentInfo, error) {

--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -1,59 +1,59 @@
 ---
 - - :permit
   - MIT
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2022-08-01 21:53:06.561636718 Z
 - - :permit
   - New BSD
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2022-08-15 13:09:14.673806968 Z
 - - :permit
   - Apache 2.0
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2022-08-15 13:15:11.855751606 Z
 - - :permit
   - Simplified BSD
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2022-08-15 13:17:08.745016552 Z
 - - :permit
   - ISC
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2022-08-15 13:37:40.979906881 Z
 - - :license
   - github.com/ajstarks/svgo
   - Creative Commons Attribution 4.0 International Public License
-  - :who: 
+  - :who:
     :license_links: https://github.com/ajstarks/svgo/blob/1546f124cd8b0cba8d505fa2ddb110c211670c59/LICENSE
     :versions: []
     :when: 2022-08-15 14:34:00.115389050 Z
 - - :license
   - github.com/go-fonts/liberation
   - New BSD
-  - :who: 
+  - :who:
     :license_links: https://github.com/go-fonts/liberation/blob/0c2fdab5e932afd0923f4f71ae23691a66305ef6/LICENSE
     :versions: []
     :when: 2022-08-15 14:47:01.153930427 Z
 - - :license
   - github.com/go-gl/mathgl
   - New BSD
-  - :who: 
+  - :who:
     :license_links: https://github.com/go-gl/mathgl/blob/45f44e1fbc36e29eb200186c5fd63828a2ffc540/LICENSE
     :versions: []
     :when: 2022-08-15 14:51:09.537862545 Z
 - - :license
   - github.com/go-latex/latex
   - New BSD
-  - :who: 
+  - :who:
     :why: 'TODO(RSDK-583): why is license finder unable to detect this license automatically?'
     :license_links: https://github.com/go-latex/latex/blob/c0d11ff05a81a63afdffbba6e577b2a3a6e69c85/LICENSE
     :versions: []
@@ -61,7 +61,7 @@
 - - :license
   - github.com/improbable-eng/grpc-web
   - Apache License 2.0
-  - :who: 
+  - :who:
     :why: 'TODO(RSDK-583): why is license finder unable to detect this license automatically?'
     :license_links: https://github.com/improbable-eng/grpc-web/blob/90ce72a31aa7bdfd6eae03fc735953902949c0de/LICENSE.txt
     :versions: []
@@ -69,7 +69,7 @@
 - - :license
   - github.com/jmespath/go-jmespath
   - Apache License 2.0
-  - :who: 
+  - :who:
     :why: 'TODO(RSDK-583): why is license finder unable to detect this license automatically?'
     :license_links: https://github.com/jmespath/go-jmespath/blob/b0104c826a24d7c202da8e1dbfb9ea4cfa35d774/LICENSE
     :versions: []
@@ -77,7 +77,7 @@
 - - :license
   - github.com/xdg-go/pbkdf2
   - Apache License 2.0
-  - :who: 
+  - :who:
     :why: 'TODO(RSDK-583): why is license finder unable to detect this license automatically?'
     :license_links: https://github.com/xdg-go/pbkdf2/blob/7f452ef1dac88350356f1bb84a23748205e64b96/LICENSE
     :versions: []
@@ -85,7 +85,7 @@
 - - :license
   - github.com/xdg-go/scram
   - Apache License 2.0
-  - :who: 
+  - :who:
     :why: 'TODO(RSDK-583): why is license finder unable to detect this license automatically?'
     :license_links: https://github.com/xdg-go/scram/blob/ef29d5590bacede26100601bb2f7d9bb08bacc75/LICENSE
     :versions: []
@@ -93,7 +93,7 @@
 - - :license
   - github.com/xdg-go/stringprep
   - Apache License 2.0
-  - :who: 
+  - :who:
     :why: 'TODO(RSDK-583): why is license finder unable to detect this license automatically?'
     :license_links: https://github.com/xdg-go/stringprep/blob/eb5c8f240eb1ea3fe0144fd4d3e0c305492d8eb1/LICENSE
     :versions: []
@@ -101,7 +101,7 @@
 - - :license
   - go-hep.org/x/hep
   - New BSD
-  - :who: 
+  - :who:
     :why: 'TODO(RSDK-583): why is license finder unable to detect this license automatically?'
     :license_links: https://github.com/go-hep/hep/blob/535619c28f900dcd37c522f2b9d593ec61b7b8dd/LICENSE
     :versions: []
@@ -109,40 +109,40 @@
 - - :license
   - gonum.org/v1/plot
   - New BSD
-  - :who: 
+  - :who:
     :why: 'TODO(RSDK-583): why is license finder unable to detect this license automatically?'
     :license_links: https://github.com/gonum/plot/blob/c2b63591159b9dceb2cbf953702691d2a2fe7a6d/LICENSE
     :versions: []
     :when: 2022-08-15 15:56:25.026774237 Z
 - - :permit
   - Creative Commons Attribution 4.0 International Public License
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2022-08-29 22:26:18.925886068 Z
 - - :permit
   - GPLv3
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2022-08-30 15:22:06.823924964 Z
 - - :license
   - github.com/gen2brain/malgo
   - The Unlicense
-  - :who: 
+  - :who:
     :license_links: https://github.com/gen2brain/malgo/blob/6af716cf2273f0675789cc1366977970e31b2239/LICENSE
     :versions: []
     :when: 2022-08-30 15:37:02.011437856 Z
 - - :license
   - github.com/goburrow/modbus
   - New BSD
-  - :who: 
+  - :who:
     :why: https://github.com/goburrow/modbus/blob/606c02f4eef527a1d4cf7d8733d5fd7ba34f91d8/LICENSE
     :versions: []
     :when: 2022-09-14 16:27:17.872831000 Z
 - - :approve
   - github.com/ziutek/mymysql
-  - :who: 
+  - :who:
     :why: license language is compatible with AGPL
     :versions: []
     :when: 2022-09-14 16:27:17.872831000 Z
@@ -150,7 +150,7 @@
 - - :license
   - github.com/golang/freetype
   - GPLv2+
-  - :who: 
+  - :who:
     :why: we are allowed to choose one of two licenses (freetype or GPL version 2
       or higher) - we are choosing the latter
     :versions: []
@@ -158,15 +158,15 @@
     :license_links: https://github.com/golang/freetype/blob/e2365dfdc4a05e4b8299a783240d4a7d5a65d4e4/LICENSE
 - - :permit
   - The Unlicense
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2022-08-30 16:12:12.044846522 Z
     :license_links: https://unlicense.org
 - - :license
   - github.com/gonum/blas
   - New BSD
-  - :who: 
+  - :who:
     :why: 'TODO(RSDK-582): this library is deprecated but still an indirect dependency
       to RDK'
     :license_links: https://github.com/gonum/license/blob/59758bd3db1383fa1f02f88eceee1f8568a87039/LICENSE
@@ -175,7 +175,7 @@
 - - :license
   - github.com/gonum/lapack
   - New BSD
-  - :who: 
+  - :who:
     :why: 'TODO(RSDK-582): this library is deprecated but still an indirect dependency
       to RDK'
     :license_links: https://github.com/gonum/license/blob/59758bd3db1383fa1f02f88eceee1f8568a87039/LICENSE
@@ -184,7 +184,7 @@
 - - :license
   - github.com/gonum/matrix
   - New BSD
-  - :who: 
+  - :who:
     :why: 'TODO(RSDK-582): this library is deprecated but still an indirect dependency
       to RDK'
     :license_links: https://github.com/gonum/license/blob/59758bd3db1383fa1f02f88eceee1f8568a87039/LICENSE
@@ -193,27 +193,27 @@
 - - :license
   - "@viamrobotics/rpc"
   - MIT
-  - :who: 
+  - :who:
     :why: 'TODO(RSDK-583): why is license finder unable to detect this license automatically?'
     :license_links: https://github.com/viamrobotics/goutils/blob/6684974ace14045e04d479777852602817e03313/LICENSE
     :versions: []
     :when: 2022-08-31 20:08:14.585047144 Z
 - - :approve
   - github.com/viamrobotics/evdev
-  - :who: 
+  - :who:
     :why: license language is compatible with AGPL
     :license_links: https://github.com/viamrobotics/evdev/blob/5a415229fba9557cca9bfedc7ba89cb48f28fab0/LICENSE
     :versions: []
     :when: 2022-08-31 20:13:08.147340927 Z
 - - :permit
   - GPLv2+
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2022-09-16 15:13:54.129990412 Z
 - - :approve
   - github.com/opencensus-integrations/gomongowrapper
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2023-01-30 21:31:27.476042000 Z

--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -1,59 +1,59 @@
 ---
 - - :permit
   - MIT
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2022-08-01 21:53:06.561636718 Z
 - - :permit
   - New BSD
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2022-08-15 13:09:14.673806968 Z
 - - :permit
   - Apache 2.0
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2022-08-15 13:15:11.855751606 Z
 - - :permit
   - Simplified BSD
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2022-08-15 13:17:08.745016552 Z
 - - :permit
   - ISC
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2022-08-15 13:37:40.979906881 Z
 - - :license
   - github.com/ajstarks/svgo
   - Creative Commons Attribution 4.0 International Public License
-  - :who:
+  - :who: 
     :license_links: https://github.com/ajstarks/svgo/blob/1546f124cd8b0cba8d505fa2ddb110c211670c59/LICENSE
     :versions: []
     :when: 2022-08-15 14:34:00.115389050 Z
 - - :license
   - github.com/go-fonts/liberation
   - New BSD
-  - :who:
+  - :who: 
     :license_links: https://github.com/go-fonts/liberation/blob/0c2fdab5e932afd0923f4f71ae23691a66305ef6/LICENSE
     :versions: []
     :when: 2022-08-15 14:47:01.153930427 Z
 - - :license
   - github.com/go-gl/mathgl
   - New BSD
-  - :who:
+  - :who: 
     :license_links: https://github.com/go-gl/mathgl/blob/45f44e1fbc36e29eb200186c5fd63828a2ffc540/LICENSE
     :versions: []
     :when: 2022-08-15 14:51:09.537862545 Z
 - - :license
   - github.com/go-latex/latex
   - New BSD
-  - :who:
+  - :who: 
     :why: 'TODO(RSDK-583): why is license finder unable to detect this license automatically?'
     :license_links: https://github.com/go-latex/latex/blob/c0d11ff05a81a63afdffbba6e577b2a3a6e69c85/LICENSE
     :versions: []
@@ -61,7 +61,7 @@
 - - :license
   - github.com/improbable-eng/grpc-web
   - Apache License 2.0
-  - :who:
+  - :who: 
     :why: 'TODO(RSDK-583): why is license finder unable to detect this license automatically?'
     :license_links: https://github.com/improbable-eng/grpc-web/blob/90ce72a31aa7bdfd6eae03fc735953902949c0de/LICENSE.txt
     :versions: []
@@ -69,7 +69,7 @@
 - - :license
   - github.com/jmespath/go-jmespath
   - Apache License 2.0
-  - :who:
+  - :who: 
     :why: 'TODO(RSDK-583): why is license finder unable to detect this license automatically?'
     :license_links: https://github.com/jmespath/go-jmespath/blob/b0104c826a24d7c202da8e1dbfb9ea4cfa35d774/LICENSE
     :versions: []
@@ -77,7 +77,7 @@
 - - :license
   - github.com/xdg-go/pbkdf2
   - Apache License 2.0
-  - :who:
+  - :who: 
     :why: 'TODO(RSDK-583): why is license finder unable to detect this license automatically?'
     :license_links: https://github.com/xdg-go/pbkdf2/blob/7f452ef1dac88350356f1bb84a23748205e64b96/LICENSE
     :versions: []
@@ -85,7 +85,7 @@
 - - :license
   - github.com/xdg-go/scram
   - Apache License 2.0
-  - :who:
+  - :who: 
     :why: 'TODO(RSDK-583): why is license finder unable to detect this license automatically?'
     :license_links: https://github.com/xdg-go/scram/blob/ef29d5590bacede26100601bb2f7d9bb08bacc75/LICENSE
     :versions: []
@@ -93,7 +93,7 @@
 - - :license
   - github.com/xdg-go/stringprep
   - Apache License 2.0
-  - :who:
+  - :who: 
     :why: 'TODO(RSDK-583): why is license finder unable to detect this license automatically?'
     :license_links: https://github.com/xdg-go/stringprep/blob/eb5c8f240eb1ea3fe0144fd4d3e0c305492d8eb1/LICENSE
     :versions: []
@@ -101,7 +101,7 @@
 - - :license
   - go-hep.org/x/hep
   - New BSD
-  - :who:
+  - :who: 
     :why: 'TODO(RSDK-583): why is license finder unable to detect this license automatically?'
     :license_links: https://github.com/go-hep/hep/blob/535619c28f900dcd37c522f2b9d593ec61b7b8dd/LICENSE
     :versions: []
@@ -109,40 +109,40 @@
 - - :license
   - gonum.org/v1/plot
   - New BSD
-  - :who:
+  - :who: 
     :why: 'TODO(RSDK-583): why is license finder unable to detect this license automatically?'
     :license_links: https://github.com/gonum/plot/blob/c2b63591159b9dceb2cbf953702691d2a2fe7a6d/LICENSE
     :versions: []
     :when: 2022-08-15 15:56:25.026774237 Z
 - - :permit
   - Creative Commons Attribution 4.0 International Public License
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2022-08-29 22:26:18.925886068 Z
 - - :permit
   - GPLv3
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2022-08-30 15:22:06.823924964 Z
 - - :license
   - github.com/gen2brain/malgo
   - The Unlicense
-  - :who:
+  - :who: 
     :license_links: https://github.com/gen2brain/malgo/blob/6af716cf2273f0675789cc1366977970e31b2239/LICENSE
     :versions: []
     :when: 2022-08-30 15:37:02.011437856 Z
 - - :license
   - github.com/goburrow/modbus
   - New BSD
-  - :who:
+  - :who: 
     :why: https://github.com/goburrow/modbus/blob/606c02f4eef527a1d4cf7d8733d5fd7ba34f91d8/LICENSE
     :versions: []
     :when: 2022-09-14 16:27:17.872831000 Z
 - - :approve
   - github.com/ziutek/mymysql
-  - :who:
+  - :who: 
     :why: license language is compatible with AGPL
     :versions: []
     :when: 2022-09-14 16:27:17.872831000 Z
@@ -150,7 +150,7 @@
 - - :license
   - github.com/golang/freetype
   - GPLv2+
-  - :who:
+  - :who: 
     :why: we are allowed to choose one of two licenses (freetype or GPL version 2
       or higher) - we are choosing the latter
     :versions: []
@@ -158,15 +158,15 @@
     :license_links: https://github.com/golang/freetype/blob/e2365dfdc4a05e4b8299a783240d4a7d5a65d4e4/LICENSE
 - - :permit
   - The Unlicense
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2022-08-30 16:12:12.044846522 Z
     :license_links: https://unlicense.org
 - - :license
   - github.com/gonum/blas
   - New BSD
-  - :who:
+  - :who: 
     :why: 'TODO(RSDK-582): this library is deprecated but still an indirect dependency
       to RDK'
     :license_links: https://github.com/gonum/license/blob/59758bd3db1383fa1f02f88eceee1f8568a87039/LICENSE
@@ -175,7 +175,7 @@
 - - :license
   - github.com/gonum/lapack
   - New BSD
-  - :who:
+  - :who: 
     :why: 'TODO(RSDK-582): this library is deprecated but still an indirect dependency
       to RDK'
     :license_links: https://github.com/gonum/license/blob/59758bd3db1383fa1f02f88eceee1f8568a87039/LICENSE
@@ -184,7 +184,7 @@
 - - :license
   - github.com/gonum/matrix
   - New BSD
-  - :who:
+  - :who: 
     :why: 'TODO(RSDK-582): this library is deprecated but still an indirect dependency
       to RDK'
     :license_links: https://github.com/gonum/license/blob/59758bd3db1383fa1f02f88eceee1f8568a87039/LICENSE
@@ -193,27 +193,27 @@
 - - :license
   - "@viamrobotics/rpc"
   - MIT
-  - :who:
+  - :who: 
     :why: 'TODO(RSDK-583): why is license finder unable to detect this license automatically?'
     :license_links: https://github.com/viamrobotics/goutils/blob/6684974ace14045e04d479777852602817e03313/LICENSE
     :versions: []
     :when: 2022-08-31 20:08:14.585047144 Z
 - - :approve
   - github.com/viamrobotics/evdev
-  - :who:
+  - :who: 
     :why: license language is compatible with AGPL
     :license_links: https://github.com/viamrobotics/evdev/blob/5a415229fba9557cca9bfedc7ba89cb48f28fab0/LICENSE
     :versions: []
     :when: 2022-08-31 20:13:08.147340927 Z
 - - :permit
   - GPLv2+
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2022-09-16 15:13:54.129990412 Z
 - - :approve
   - github.com/opencensus-integrations/gomongowrapper
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-01-30 21:31:27.476042000 Z

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/AlekSi/gocov-xml v1.0.0
 	github.com/CPRT/roboclaw v0.0.0-20190825181223-76871438befc
+	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/a8m/envsubst v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,8 @@ github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy86
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
+github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/Masterminds/sprig v2.15.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/Masterminds/sprig v2.22.0+incompatible h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZCSYp4Z0m2dk6cEM60=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=


### PR DESCRIPTION
RSDK-4975

On installs older than one week, warns users when their CLI is out of date against the latest stable release.