### PR TITLE
RSDK-6672: Object detection without category tensor

### DIFF
--- a/.artifact/tree.json
+++ b/.artifact/tree.json
@@ -52285,6 +52285,10 @@
         "hash": "3118459d58736a16b8e022e569de260c",
         "size": 21967062
       },
+      "person.jpg": {
+        "hash": "92397b49c891f2bdcd0ea44941ed9033",
+        "size": 35262
+      },
       "redpanda.jpeg": {
         "hash": "0394b41317317b30a6bc01fa7a18617b",
         "size": 654771
@@ -52292,6 +52296,10 @@
       "ssdmobilenet.tflite": {
         "hash": "4c421353bf0a105c5ffba593ffee4099",
         "size": 27523960
+      },
+      "yolov4-tiny-416_person.tflite": {
+        "hash": "e0ff04ba988900cae64020c7bcc5b93a",
+        "size": 23549400
       }
     },
     "white1.png": {

--- a/services/vision/mlvision/detector.go
+++ b/services/vision/mlvision/detector.go
@@ -131,8 +131,12 @@ func attemptToBuildDetector(mlm mlmodel.Service, inNameMap, outNameMap *sync.Map
 		// sometimes categories are stuffed into the score output. separate them out.
 		if !hasCategoryTensor {
 			shape := outMap[scoreName].Shape()
-			if len(shape) == 3 && shape[2] != 1 { // cartegories are stored in 3rd dimension
-				scores, categories, err = extractCategoriesFromScores(scores, shape[2])
+			if len(shape) == 3 { // cartegories are stored in 3rd dimension
+				nCategories := shape[2]              // nCategories usually in 3rd dim, but sometimes in 2nd
+				if 4*nCategories == len(locations) { // it's actually in 2nd dim
+					nCategories = shape[1]
+				}
+				scores, categories, err = extractCategoriesFromScores(scores, nCategories)
 				if err != nil {
 					return nil, errors.Wrap(err, "could not extract categories from score tensor")
 				}

--- a/services/vision/mlvision/ml_model.go
+++ b/services/vision/mlvision/ml_model.go
@@ -99,13 +99,21 @@ func registerMLModelVisionService(
 	}
 	if len(params.BoxOrder) != 0 {
 		if len(params.BoxOrder) != 4 {
-			return nil, errors.Errorf("attribute xmin_ymin_xmax_ymax_order for model %q must have only 4 entries in the list. Got %v", params.ModelName, params.BoxOrder)
+			return nil, errors.Errorf(
+				"attribute xmin_ymin_xmax_ymax_order for model %q must have only 4 entries in the list. Got %v",
+				params.ModelName,
+				params.BoxOrder,
+			)
 		}
 		checkOrder := map[int]bool{0: false, 1: false, 2: false, 3: false}
 		for _, entry := range params.BoxOrder {
 			val, ok := checkOrder[entry]
 			if !ok || val { // if val is true, it means value was repeated
-				return nil, errors.Errorf("attribute xmin_ymin_xmax_ymax_order for model %q can only have entries 0, 1, 2 and 3, and only one instance of each. Got %v", params.ModelName, params.BoxOrder)
+				return nil, errors.Errorf(
+					"attribute xmin_ymin_xmax_ymax_order for model %q can only have entries 0, 1, 2 and 3, and only one instance of each. Got %v",
+					params.ModelName,
+					params.BoxOrder,
+				)
 			}
 			checkOrder[entry] = true
 		}

--- a/services/vision/mlvision/ml_model.go
+++ b/services/vision/mlvision/ml_model.go
@@ -61,6 +61,7 @@ type MLModelConfig struct {
 	ModelName        string            `json:"mlmodel_name"`
 	RemapInputNames  map[string]string `json:"remap_input_names"`
 	RemapOutputNames map[string]string `json:"remap_output_names"`
+	BoxOrder         []int             `json:"xmin_ymin_xmax_ymax_order"`
 }
 
 // Validate will add the ModelName as an implicit dependency to the robot.
@@ -96,6 +97,19 @@ func registerMLModelVisionService(
 	for oldName, newName := range params.RemapOutputNames {
 		outNameMap.Store(newName, oldName)
 	}
+	if len(params.BoxOrder) != 0 {
+		if len(params.BoxOrder) != 4 {
+			return nil, errors.Errorf("attribute xmin_ymin_xmax_ymax_order for model %q must have only 4 entries in the list. Got %v", params.ModelName, params.BoxOrder)
+		}
+		checkOrder := map[int]bool{0: false, 1: false, 2: false, 3: false}
+		for _, entry := range params.BoxOrder {
+			val, ok := checkOrder[entry]
+			if !ok || val { // if val is true, it means value was repeated
+				return nil, errors.Errorf("attribute xmin_ymin_xmax_ymax_order for model %q can only have entries 0, 1, 2 and 3, and only one instance of each. Got %v", params.ModelName, params.BoxOrder)
+			}
+			checkOrder[entry] = true
+		}
+	}
 	var errList []error
 	classifierFunc, err := attemptToBuildClassifier(mlm, inNameMap, outNameMap)
 	if err != nil {
@@ -113,7 +127,7 @@ func registerMLModelVisionService(
 		}
 	}
 
-	detectorFunc, err := attemptToBuildDetector(mlm, inNameMap, outNameMap)
+	detectorFunc, err := attemptToBuildDetector(mlm, inNameMap, outNameMap, params.BoxOrder)
 	if err != nil {
 		logger.CDebugw(ctx, "unable to use ml model as a detector, will attempt to evaluate as 3D segmenter",
 			"model", params.ModelName, "error", err)

--- a/services/vision/mlvision/ml_model_test.go
+++ b/services/vision/mlvision/ml_model_test.go
@@ -100,7 +100,7 @@ func TestAddingIncorrectModelTypeToModel(t *testing.T) {
 	err = checkIfClassifierWorks(ctx, classifier)
 	test.That(t, err, test.ShouldNotBeNil)
 
-	detector, err := attemptToBuildDetector(mlm, inNameMap, outNameMap)
+	detector, err := attemptToBuildDetector(mlm, inNameMap, outNameMap, nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, detector, test.ShouldNotBeNil)
 
@@ -124,7 +124,7 @@ func TestAddingIncorrectModelTypeToModel(t *testing.T) {
 	mlm, err = getTestMlModel(modelLocClassifier)
 	test.That(t, err, test.ShouldBeNil)
 
-	detector, err = attemptToBuildDetector(mlm, inNameMap, outNameMap)
+	detector, err = attemptToBuildDetector(mlm, inNameMap, outNameMap, nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, detector, test.ShouldNotBeNil)
 
@@ -167,7 +167,7 @@ func TestNewMLDetector(t *testing.T) {
 
 	inNameMap := &sync.Map{}
 	outNameMap := &sync.Map{}
-	gotDetector, err := attemptToBuildDetector(out, inNameMap, outNameMap)
+	gotDetector, err := attemptToBuildDetector(out, inNameMap, outNameMap, nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotDetector, test.ShouldNotBeNil)
 
@@ -193,7 +193,7 @@ func TestNewMLDetector(t *testing.T) {
 	test.That(t, outNL, test.ShouldNotBeNil)
 	inNameMap = &sync.Map{}
 	outNameMap = &sync.Map{}
-	gotDetectorNL, err := attemptToBuildDetector(outNL, inNameMap, outNameMap)
+	gotDetectorNL, err := attemptToBuildDetector(outNL, inNameMap, outNameMap, nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotDetectorNL, test.ShouldNotBeNil)
 	gotDetectionsNL, err := gotDetectorNL(ctx, pic)
@@ -308,7 +308,7 @@ func TestMoreMLDetectors(t *testing.T) {
 
 	inNameMap := &sync.Map{}
 	outNameMap := &sync.Map{}
-	gotDetector, err := attemptToBuildDetector(outModel, inNameMap, outNameMap)
+	gotDetector, err := attemptToBuildDetector(outModel, inNameMap, outNameMap, nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotDetector, test.ShouldNotBeNil)
 
@@ -340,7 +340,7 @@ func TestMoreMLClassifiers(t *testing.T) {
 
 	inNameMap := &sync.Map{}
 	outNameMap := &sync.Map{}
-	gotClassifier, err := attemptToBuildClassifier(outModel, inNameMap, outNameMap)
+	gotClassifier, err := attemptToBuildClassifier(outModel, inNameMap, outNameMap, false)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotClassifier, test.ShouldNotBeNil)
 

--- a/services/vision/mlvision/ml_model_test.go
+++ b/services/vision/mlvision/ml_model_test.go
@@ -340,7 +340,7 @@ func TestMoreMLClassifiers(t *testing.T) {
 
 	inNameMap := &sync.Map{}
 	outNameMap := &sync.Map{}
-	gotClassifier, err := attemptToBuildClassifier(outModel, inNameMap, outNameMap, false)
+	gotClassifier, err := attemptToBuildClassifier(outModel, inNameMap, outNameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotClassifier, test.ShouldNotBeNil)
 


### PR DESCRIPTION
These edits allow the vision service to create an object detector without the requirement of having a categories tensor. 

This might be the case when a detector is only detecting one category, or the author decides to stuff the category information in another dimension. 

This also adds an optional parameter allowing the user to specify the bounding box order for their model