### PR TITLE
rsdk-6560 its not really a warning, everything will still work

### DIFF
--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -657,7 +657,6 @@ func (r *localRobot) newResource(
 	if resInfo.DeprecatedRobotConstructor == nil {
 		return nil, errors.Errorf("invariant: no constructor for %q", conf.API)
 	}
-	r.logger.CWarnw(ctx, "using deprecated robot constructor", "api", resName.API, "model", conf.Model)
 	return resInfo.DeprecatedRobotConstructor(ctx, r, conf, gNode.Logger())
 }
 


### PR DESCRIPTION
The warning is more for developers, not users. It should be removed. We already have a ticket to remove the deprecated robot constructor in the camera transform and vision service (RSDK-6566, RSDK-2808)