### PR TITLE
revert GIT_TAG to latest hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BUILD_CHANNEL ?= local
 PATH_WITH_TOOLS="`pwd`/$(TOOL_BIN):`pwd`/node_modules/.bin:${PATH}"
 
 GIT_REVISION = $(shell git rev-parse HEAD | tr -d '\n')
-TAG_VERSION?=$(shell git tag --points-at | sort -Vr | head -n1 | grep . || echo "(dev)")
+TAG_VERSION?=$(shell git tag --points-at | sort -Vr | head -n1)
 DATE_COMPILED?=$(shell date +'%Y-%m-%d')
 LDFLAGS = -ldflags "-s -w -extld="$(shell pwd)/etc/ld_wrapper.sh" -X 'go.viam.com/rdk/config.Version=${TAG_VERSION}' -X 'go.viam.com/rdk/config.GitRevision=${GIT_REVISION}' -X 'go.viam.com/rdk/config.DateCompiled=${DATE_COMPILED}'"
 ifeq ($(shell command -v dpkg >/dev/null && dpkg --print-architecture),armhf)

--- a/cli/client.go
+++ b/cli/client.go
@@ -540,6 +540,9 @@ func VersionAction(c *cli.Context) error {
 	}
 
 	appVersion := rconfig.Version
+	if appVersion == "" {
+		appVersion = "(dev)"
+	}
 	printf(c.App.Writer, "Version %s Git=%s API=%s", appVersion, version, apiVersion)
 	return nil
 }

--- a/cli/client.go
+++ b/cli/client.go
@@ -491,7 +491,7 @@ func CheckUpdateAction(c *cli.Context) error {
 	}
 
 	appVersion := rconfig.Version
-	if appVersion == "(dev)" {
+	if appVersion == "" {
 		warningf(c.App.ErrWriter, "CLI Update Check: Your CLI is more than 6 weeks old. "+
 			"Consider updating to version: %s", latestVersion.Original())
 		return nil


### PR DESCRIPTION
This PR reverts a change made to the Makefile which sets the GIT_TAG to (dev) when there is no release version associated with the build. This change mistakenly propagated to the App view.