### PR TITLE
RSDK-6280 Better logic for module logging fields

### DIFF
--- a/examples/customresources/demos/simplemodule/module.go
+++ b/examples/customresources/demos/simplemodule/module.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"sync/atomic"
-	"time"
 
 	"github.com/pkg/errors"
 	"go.viam.com/utils"
@@ -47,15 +46,6 @@ func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) err
 	if err != nil {
 		return err
 	}
-
-	// TODO(benji): remove this example logging.
-	time.Sleep(time.Second) // sleep to ensure module -> parent connection occurs.
-	type myStruct struct {
-		String string
-	}
-	logger.Infow("info log", "string", "stringValue", "int", 2, "float", 1.23,
-		"bool", false, "struct", &myStruct{"string"}, "time", time.Now(),
-		"float32", float32(1.32), "uint", uint64(123))
 
 	// This will block (leaving the module running) until the context is cancelled.
 	// The utils.ContextualMain catches OS signals and will cancel our context for us when one is sent for shutdown/termination.

--- a/examples/customresources/demos/simplemodule/module.go
+++ b/examples/customresources/demos/simplemodule/module.go
@@ -53,7 +53,7 @@ func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) err
 	type myStruct struct {
 		String string
 	}
-	logger.Infow("info log", "string", "stringValue", "int", 2, "float", 1.23, "bool", false, "struct", &myStruct{"string"}, "time", time.Now())
+	logger.Infow("info log", "string", "stringValue", "int", 2, "float", 1.23, "bool", false, "struct", &myStruct{"string"}, "time", time.Now(), "float32", float32(1.32), "uint", uint64(123))
 
 	// This will block (leaving the module running) until the context is cancelled.
 	// The utils.ContextualMain catches OS signals and will cancel our context for us when one is sent for shutdown/termination.

--- a/examples/customresources/demos/simplemodule/module.go
+++ b/examples/customresources/demos/simplemodule/module.go
@@ -53,7 +53,9 @@ func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) err
 	type myStruct struct {
 		String string
 	}
-	logger.Infow("info log", "string", "stringValue", "int", 2, "float", 1.23, "bool", false, "struct", &myStruct{"string"}, "time", time.Now(), "float32", float32(1.32), "uint", uint64(123))
+	logger.Infow("info log", "string", "stringValue", "int", 2, "float", 1.23,
+		"bool", false, "struct", &myStruct{"string"}, "time", time.Now(),
+		"float32", float32(1.32), "uint", uint64(123))
 
 	// This will block (leaving the module running) until the context is cancelled.
 	// The utils.ContextualMain catches OS signals and will cancel our context for us when one is sent for shutdown/termination.

--- a/examples/customresources/demos/simplemodule/module.go
+++ b/examples/customresources/demos/simplemodule/module.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"sync/atomic"
+	"time"
 
 	"github.com/pkg/errors"
 	"go.viam.com/utils"
@@ -46,6 +47,13 @@ func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) err
 	if err != nil {
 		return err
 	}
+
+	// TODO(benji): remove this example logging.
+	time.Sleep(time.Second) // sleep to ensure module -> parent connection occurs.
+	type myStruct struct {
+		String string
+	}
+	logger.Infow("info log", "string", "stringValue", "int", 2, "float", 1.23, "bool", false, "struct", &myStruct{"string"}, "time", time.Now())
 
 	// This will block (leaving the module running) until the context is cancelled.
 	// The utils.ContextualMain catches OS signals and will cancel our context for us when one is sent for shutdown/termination.

--- a/logging/proto_conversions.go
+++ b/logging/proto_conversions.go
@@ -72,7 +72,7 @@ func FieldKeyAndValueFromProto(field *structpb.Struct) (string, any, error) {
 		fieldValue = zf.String
 	case zapcore.TimeType:
 		// Ignore *time.Location stored in zf.Interface; we'll use the UTC default.
-		fieldValue = time.Unix(0, zf.Integer)
+		fieldValue = time.Unix(0, zf.Integer).In(time.UTC)
 	default:
 		fieldValue = zf.Interface
 	}

--- a/logging/proto_conversions.go
+++ b/logging/proto_conversions.go
@@ -27,10 +27,6 @@ func FieldKeyAndValueFromProto(field *structpb.Struct) (string, any, error) {
 		return "", nil, err
 	}
 
-	if zf.Type == zapcore.ErrorType {
-		fmt.Printf("zf: %v\n", zf)
-	}
-
 	// This code is modeled after zapcore.Field.AddTo:
 	// https://github.com/uber-go/zap/blob/fcf8ee58669e358bbd6460bef5c2ee7a53c0803a/zapcore/field.go#L114
 	//nolint:exhaustive

--- a/logging/proto_conversions.go
+++ b/logging/proto_conversions.go
@@ -1,0 +1,69 @@
+package logging
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// FieldKeyAndValueFromProto examines a *structpb.Struct and returns its key
+// string and native golang value.
+func FieldKeyAndValueFromProto(field *structpb.Struct) (string, any, error) {
+	var fieldValue any
+
+	fieldJSON, err := json.Marshal(field)
+	if err != nil {
+		return "", nil, err
+	}
+
+	var zf zap.Field
+	if err := json.Unmarshal(fieldJSON, &zf); err != nil {
+		return "", nil, err
+	}
+
+	if zf.Type == zapcore.ErrorType {
+		fmt.Printf("zf: %v\n", zf)
+	}
+
+	// This code is modeled after zapcore.Field.AddTo:
+	// https://github.com/uber-go/zap/blob/fcf8ee58669e358bbd6460bef5c2ee7a53c0803a/zapcore/field.go#L114
+	//nolint:exhaustive
+	switch zf.Type {
+	case zapcore.BoolType:
+		fieldValue = zf.Integer == 1
+	case zapcore.DurationType:
+		fieldValue = time.Duration(zf.Integer)
+	case zapcore.Float64Type:
+		// Converting floats to proto sometimes introduces small amounts of loss
+		// (e.g. an extra .0000000000073). Use a hacky combination of math, fmt,
+		// and strconv to use only up to 5 decimal places.
+		fieldValue, err = strconv.ParseFloat(
+			fmt.Sprintf("%.5f", math.Float64frombits(uint64(zf.Integer))), 64)
+		if err != nil {
+			return "", nil, err
+		}
+	case zapcore.Float32Type:
+		fieldValue, err = strconv.ParseFloat(
+			fmt.Sprintf("%.5f", math.Float32frombits(uint32(zf.Integer))), 32)
+		if err != nil {
+			return "", nil, err
+		}
+	case zapcore.Int64Type, zapcore.Int32Type, zapcore.Int16Type, zapcore.Int8Type:
+		fieldValue = zf.Integer
+	case zapcore.StringType, zapcore.ErrorType:
+		fieldValue = zf.String
+	case zapcore.TimeType:
+		// Ignore *time.Location stored in zf.Interface; we'll use the UTC default.
+		fieldValue = time.Unix(0, zf.Integer)
+	default:
+		fieldValue = zf.Interface
+	}
+
+	return zf.Key, fieldValue, nil
+}

--- a/logging/proto_conversions.go
+++ b/logging/proto_conversions.go
@@ -36,17 +36,19 @@ func FieldKeyAndValueFromProto(field *structpb.Struct) (string, any, error) {
 	case zapcore.DurationType:
 		fieldValue = time.Duration(zf.Integer)
 	case zapcore.Float64Type:
-		// Converting floats to proto sometimes introduces small amounts of loss
-		// (e.g. an extra .0000000000073). Use a hacky combination of math, fmt,
-		// and strconv to use only up to 5 decimal places.
+		// Zap encodes floats with very large int64s. Proto conversions have some
+		// loss with very large int64s.
+		// See https://pkg.go.dev/google.golang.org/protobuf@v1.32.0/types/known/structpb#NewValue.
+		//
+		// Use a hacky combination of math, fmt, and strconv to use only up to 10 decimal places.
 		fieldValue, err = strconv.ParseFloat(
-			fmt.Sprintf("%.5f", math.Float64frombits(uint64(zf.Integer))), 64)
+			fmt.Sprintf("%.10f", math.Float64frombits(uint64(zf.Integer))), 64)
 		if err != nil {
 			return "", nil, err
 		}
 	case zapcore.Float32Type:
 		fieldValue, err = strconv.ParseFloat(
-			fmt.Sprintf("%.5f", math.Float32frombits(uint32(zf.Integer))), 32)
+			fmt.Sprintf("%.10f", math.Float32frombits(uint32(zf.Integer))), 32)
 		if err != nil {
 			return "", nil, err
 		}

--- a/logging/proto_conversions.go
+++ b/logging/proto_conversions.go
@@ -71,7 +71,7 @@ func FieldKeyAndValueFromProto(field *structpb.Struct) (string, any, error) {
 	case zapcore.StringType, zapcore.ErrorType:
 		fieldValue = zf.String
 	case zapcore.TimeType:
-		// Ignore *time.Location stored in zf.Interface; we'll use the UTC default.
+		// Ignore *time.Location stored in zf.Interface; we'll force UTC.
 		fieldValue = time.Unix(0, zf.Integer).In(time.UTC)
 	default:
 		fieldValue = zf.Interface

--- a/logging/proto_conversions_test.go
+++ b/logging/proto_conversions_test.go
@@ -12,7 +12,7 @@ import (
 func TestFieldConversion(t *testing.T) {
 	t.Parallel()
 
-	testTime, err := time.Parse(DefaultTimeFormatStr, "2024-03-01T11:39:40.897-0500")
+	testTime, err := time.Parse(DefaultTimeFormatStr, "2024-03-01T11:39:40.897Z")
 	test.That(t, err, test.ShouldBeNil)
 
 	type s struct {
@@ -97,7 +97,7 @@ func TestFieldConversion(t *testing.T) {
 				Interface: time.Local,
 				Integer:   testTime.UnixNano(),
 			},
-			// Ensure that UTC is used instead of the EST from original time.
+			// Ensure that UTC is used instead of the Local location from original time.
 			expectedVal: testTime.In(time.UTC),
 		},
 		{

--- a/logging/proto_conversions_test.go
+++ b/logging/proto_conversions_test.go
@@ -97,7 +97,8 @@ func TestFieldConversion(t *testing.T) {
 				Interface: time.Local,
 				Integer:   testTime.UnixNano(),
 			},
-			expectedVal: testTime,
+			// Ensure that UTC is used instead of the EST from original time.
+			expectedVal: testTime.In(time.UTC),
 		},
 		{
 			field: zap.Field{

--- a/logging/proto_conversions_test.go
+++ b/logging/proto_conversions_test.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -51,11 +52,27 @@ func TestFieldConversion(t *testing.T) {
 		},
 		{
 			field: zap.Field{
+				Key:     "big float64",
+				Type:    zapcore.Float64Type,
+				Integer: int64(math.Float64bits(math.MaxFloat64)),
+			},
+			expectedVal: math.MaxFloat64,
+		},
+		{
+			field: zap.Field{
 				Key:     "float32",
 				Type:    zapcore.Float32Type,
 				Integer: 1068037571,
 			},
 			expectedVal: float32(1.32),
+		},
+		{
+			field: zap.Field{
+				Key:     "big float32",
+				Type:    zapcore.Float32Type,
+				Integer: int64(math.Float32bits(math.MaxFloat32)),
+			},
+			expectedVal: float32(math.MaxFloat32),
 		},
 		{
 			field: zap.Field{

--- a/logging/proto_conversions_test.go
+++ b/logging/proto_conversions_test.go
@@ -1,0 +1,127 @@
+package logging
+
+import (
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.viam.com/test"
+)
+
+func TestFieldConversion(t *testing.T) {
+	t.Parallel()
+
+	testTime, err := time.Parse(DefaultTimeFormatStr, "2024-03-01T11:39:40.897-0500")
+	test.That(t, err, test.ShouldBeNil)
+
+	type s struct {
+		Field1 string
+		Field2 bool
+	}
+	testStruct := &s{"foo", true}
+
+	testCases := []struct {
+		field       zap.Field
+		expectedVal any
+	}{
+		{
+			field: zap.Field{
+				Key:     "boolean",
+				Type:    zapcore.BoolType,
+				Integer: 0,
+			},
+			expectedVal: false,
+		},
+		{
+			field: zap.Field{
+				Key:     "duration",
+				Type:    zapcore.DurationType,
+				Integer: time.Hour.Nanoseconds(),
+			},
+			expectedVal: time.Hour,
+		},
+		{
+			field: zap.Field{
+				Key:     "float64",
+				Type:    zapcore.Float64Type,
+				Integer: 4608218246714312622,
+			},
+			expectedVal: float64(1.23),
+		},
+		{
+			field: zap.Field{
+				Key:     "float32",
+				Type:    zapcore.Float32Type,
+				Integer: 1068037571,
+			},
+			expectedVal: float32(1.32),
+		},
+		{
+			field: zap.Field{
+				Key:     "int",
+				Type:    zapcore.Int64Type,
+				Integer: -1234567891011,
+			},
+			expectedVal: int64(-1234567891011),
+		},
+		{
+			field: zap.Field{
+				Key:     "uint",
+				Type:    zapcore.Uint64Type,
+				Integer: 1234567891011,
+			},
+			expectedVal: uint64(1234567891011),
+		},
+		{
+			field: zap.Field{
+				Key:    "string",
+				Type:   zapcore.StringType,
+				String: "foobar",
+			},
+			expectedVal: "foobar",
+		},
+		{
+			field: zap.Field{
+				Key:    "error",
+				Type:   zapcore.ErrorType,
+				String: "error message",
+			},
+			// Error types retain only their message. Stacks are contained in log.Stack.
+			expectedVal: "error message",
+		},
+		{
+			field: zap.Field{
+				Key:       "time",
+				Type:      zapcore.TimeType,
+				Interface: time.Local,
+				Integer:   testTime.UnixNano(),
+			},
+			expectedVal: testTime,
+		},
+		{
+			field: zap.Field{
+				Key:       "struct",
+				Type:      zapcore.ReflectType,
+				Interface: testStruct,
+			},
+			// Types of structs cannot actually be preserved; we convert to
+			// map[string]interface{}.
+			expectedVal: map[string]interface{}{"Field1": "foo", "Field2": true},
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.field.Key, func(t *testing.T) {
+			t.Parallel()
+
+			field, err := FieldToProto(tc.field)
+			test.That(t, err, test.ShouldBeNil)
+
+			key, val, err := FieldKeyAndValueFromProto(field)
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, key, test.ShouldEqual, tc.field.Key)
+			test.That(t, val, test.ShouldResemble, tc.expectedVal)
+		})
+	}
+}

--- a/module/log.go
+++ b/module/log.go
@@ -48,7 +48,7 @@ func (ma *moduleAppender) Write(log zapcore.Entry, fields []zapcore.Field) error
 	// Insert field of `{"module_log_ts": "2006-01-02T15:04:05.000Z0700"}` to
 	// encode the time the module wrote this log.
 	timeStr := log.Time.Format(logging.DefaultTimeFormatStr)
-	fields = append(fields, zapcore.Field{Key: moduleTSLogKey, String: timeStr})
+	fields = append(fields, zapcore.Field{Key: moduleTSLogKey, String: timeStr, Type: zapcore.StringType})
 	return ma.module.parent.Log(moduleLogCtx, log, fields)
 }
 

--- a/module/log.go
+++ b/module/log.go
@@ -10,12 +10,6 @@ import (
 	"go.viam.com/rdk/logging"
 )
 
-const (
-	// moduleTSLogKey is the key used in conjunction with the timestamp of module logs sent back to
-	// the RDK.
-	moduleTSLogKey = "module_log_ts"
-)
-
 type moduleAppender struct {
 	stdoutAppender *logging.ConsoleAppender
 
@@ -44,11 +38,6 @@ func (ma *moduleAppender) Write(log zapcore.Entry, fields []zapcore.Field) error
 	// down or otherwise unreachable.
 	moduleLogCtx, moduleLogCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer moduleLogCancel()
-
-	// Insert field of `{"module_log_ts": "2006-01-02T15:04:05.000Z0700"}` to
-	// encode the time the module wrote this log.
-	timeStr := log.Time.Format(logging.DefaultTimeFormatStr)
-	fields = append(fields, zapcore.Field{Key: moduleTSLogKey, String: timeStr, Type: zapcore.StringType})
 	return ma.module.parent.Log(moduleLogCtx, log, fields)
 }
 

--- a/module/module.go
+++ b/module/module.go
@@ -269,7 +269,7 @@ func (m *Module) connectParent(ctx context.Context) error {
 	// moduleLoggers may be creating the client connection below, so use a
 	// different logger here to avoid a deadlock where the client connection
 	// tries to recursively connect to the parent.
-	clientLogger := logging.NewBlankLogger("module-connection")
+	clientLogger := logging.NewLogger("module-connection")
 	clientLogger.SetLevel(m.logger.GetLevel())
 	// TODO(PRODUCT-343): add session support to modules
 	rc, err := client.New(ctx, "unix://"+m.parentAddr, clientLogger, client.WithDisableSessions())

--- a/module/module.go
+++ b/module/module.go
@@ -269,7 +269,8 @@ func (m *Module) connectParent(ctx context.Context) error {
 	// moduleLoggers may be creating the client connection below, so use a
 	// different logger here to avoid a deadlock where the client connection
 	// tries to recursively connect to the parent.
-	clientLogger := logging.NewDebugLogger("module-connection")
+	clientLogger := logging.NewBlankLogger("module-connection")
+	clientLogger.SetLevel(m.logger.GetLevel())
 	// TODO(PRODUCT-343): add session support to modules
 	rc, err := client.New(ctx, "unix://"+m.parentAddr, clientLogger, client.WithDisableSessions())
 	if err != nil {

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -917,7 +917,7 @@ func (rc *RobotClient) Log(ctx context.Context, log zapcore.Entry, fields []zap.
 		Logs: []*commonpb.LogEntry{{
 			// Leave out Host; Host is not currently meaningful.
 			Level:      log.Level.String(),
-			Time:       timestamppb.New(time.Now()),
+			Time:       timestamppb.New(log.Time),
 			LoggerName: log.LoggerName,
 			Message:    message,
 			// Leave out Caller; Caller is already in Message field above. We put

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -903,10 +903,11 @@ func (rc *RobotClient) Log(ctx context.Context, log zapcore.Entry, fields []zapc
 
 	fieldsP := make([]*structpb.Struct, 0, len(fields))
 	for _, field := range fields {
-		// If field is some non-string-encoded, non-integer-encoded type
-		// (field.Interface != nil), force it into a string with `%+v`. We do not
-		// have a great way of ensuring all types are maintained across the wire.
-		if field.String == "" && field.Interface != nil {
+		// If field is some non-time, non-string-encoded, non-integer-encoded type,
+		// force it into a string with `%+v`. We do not have a great way of
+		// ensuring all types are maintained across the wire. Time types will be
+		// handled server-side.
+		if field.Type != zapcore.TimeType && field.String == "" && field.Interface != nil {
 			field.String = fmt.Sprintf("%+v", field.Interface)
 			field.Type = zapcore.StringType
 		}

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"math"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -906,17 +905,7 @@ func (rc *RobotClient) Log(ctx context.Context, log zapcore.Entry, fields []zap.
 
 	fieldsP := make([]*structpb.Struct, 0, len(fields))
 	for _, field := range fields {
-		// Zap encodes float64s with very large int64s. Proto conversions have some
-		// loss with very large int64s. float32s are also encoded with int64s, but
-		// the int64 encodings are not large enough to cause loss in conversion.
-		// See https://pkg.go.dev/google.golang.org/protobuf@v1.32.0/types/known/structpb#NewValue.
-		//
-		// Use a hacky combination of fmt and math to store float64s as strings.
-		if field.Type == zapcore.Float64Type {
-			field.String = fmt.Sprintf("%f", math.Float64frombits(uint64(field.Integer)))
-		}
-
-		fieldP, err := protoutils.StructToStructPb(field)
+		fieldP, err := logging.FieldToProto(field)
 		if err != nil {
 			return err
 		}

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jhump/protoreflect/grpcreflect"
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	commonpb "go.viam.com/api/common/v1"
 	pb "go.viam.com/api/robot/v1"
@@ -898,7 +899,7 @@ func (rc *RobotClient) StopAll(ctx context.Context, extra map[resource.Name]map[
 
 // Log sends a log entry to the server. To be used by Golang modules wanting to
 // log over gRPC and not by normal Golang SDK clients.
-func (rc *RobotClient) Log(ctx context.Context, log zapcore.Entry, fields []zapcore.Field) error {
+func (rc *RobotClient) Log(ctx context.Context, log zapcore.Entry, fields []zap.Field) error {
 	message := fmt.Sprintf("%v\t%v", log.Caller.TrimmedPath(), log.Message)
 
 	fieldsP := make([]*structpb.Struct, 0, len(fields))

--- a/robot/impl/resource_manager_modular_test.go
+++ b/robot/impl/resource_manager_modular_test.go
@@ -521,7 +521,7 @@ func TestDynamicModuleLogging(t *testing.T) {
 	testutils.WaitForAssertion(t, func(tb testing.TB) {
 		tb.Helper()
 		test.That(tb, observer.FilterMessageSnippet(infoLogLine).Len(), test.ShouldEqual, 1)
-		test.That(tb, observer.FilterMessageSnippet(infoLogLine).FilterFieldKey("module_log_ts").Len(), test.ShouldEqual, 1)
+		test.That(tb, observer.FilterMessageSnippet(infoLogLine).FilterFieldKey("log_ts").Len(), test.ShouldEqual, 1)
 		test.That(tb, observer.FilterMessageSnippet(infoLogLine).FilterFieldKey("foo").Len(), test.ShouldEqual, 1)
 	})
 

--- a/robot/impl/resource_manager_modular_test.go
+++ b/robot/impl/resource_manager_modular_test.go
@@ -521,8 +521,8 @@ func TestDynamicModuleLogging(t *testing.T) {
 	testutils.WaitForAssertion(t, func(tb testing.TB) {
 		tb.Helper()
 		test.That(tb, observer.FilterMessageSnippet(infoLogLine).Len(), test.ShouldEqual, 1)
-		test.That(tb, observer.FilterMessageSnippet(infoLogLine).FilterMessageSnippet("module_log_ts").Len(), test.ShouldEqual, 1)
-		test.That(tb, observer.FilterMessageSnippet(infoLogLine).FilterMessageSnippet("foo").Len(), test.ShouldEqual, 1)
+		test.That(tb, observer.FilterMessageSnippet(infoLogLine).FilterFieldKey("module_log_ts").Len(), test.ShouldEqual, 1)
+		test.That(tb, observer.FilterMessageSnippet(infoLogLine).FilterFieldKey("foo").Len(), test.ShouldEqual, 1)
 	})
 
 	// The module is currently configured to log at info. If the module tries to log at debug,

--- a/robot/server/server.go
+++ b/robot/server/server.go
@@ -432,11 +432,7 @@ func (s *Server) Log(ctx context.Context, req *pb.LogRequest) (*pb.LogResponse, 
 	for _, fieldP := range log.Fields {
 		key, val, err := logging.FieldKeyAndValueFromProto(fieldP)
 		if err != nil {
-			// Only warn the error and skip the field: old logs may have malformed
-			// fields.
-			l.Warn("logger named %q sent a log over gRPC with a malformed field %+v",
-				log.LoggerName, fieldP)
-			continue
+			return nil, err
 		}
 		fields = append(fields, key, val)
 	}

--- a/robot/server/server.go
+++ b/robot/server/server.go
@@ -425,7 +425,7 @@ func (s *Server) Log(ctx context.Context, req *pb.LogRequest) (*pb.LogResponse, 
 	for _, fieldP := range log.Fields {
 		key, val, err := logging.FieldKeyAndValueFromProto(fieldP)
 		if err != nil {
-			return nil, nil
+			return nil, err
 		}
 		fields = append(fields, key, val)
 	}


### PR DESCRIPTION
RSDK-6280

Uses the module's log level for the logger used in `parent -> module` connection establishment. Tries to actually send module log fields across the wire, unmarshal them to `zap.Field`s in the RDK, and output them with the logger. Adds new conversion functions `FieldToProto` and `FieldKeyAndValueFromProto` and tests for them.