### PR TITLE
Add local robot test helper

### DIFF
--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
-
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	armpb "go.viam.com/api/component/arm/v1"

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -83,11 +83,8 @@ func TestConfig1(t *testing.T) {
 	cfg, err := config.Read(context.Background(), "data/cfgtest1.json", logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	r, err := robotimpl.New(context.Background(), cfg, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-	}()
+	r, shutdown := initTestRobot(t, context.Background(), cfg, logger)
+	defer shutdown()
 
 	c1, err := camera.FromRobot(r, "c1")
 	test.That(t, err, test.ShouldBeNil)
@@ -105,9 +102,8 @@ func TestConfigFake(t *testing.T) {
 	cfg, err := config.Read(context.Background(), "data/fake.json", logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	r, err := robotimpl.New(context.Background(), cfg, logger)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, r.Close(context.Background()), test.ShouldBeNil)
+	_, shutdown := initTestRobot(t, context.Background(), cfg, logger)
+	shutdown()
 }
 
 // this serves as a test for updateWeakDependents as the web service defines a weak
@@ -119,11 +115,8 @@ func TestConfigRemote(t *testing.T) {
 
 	ctx := context.Background()
 
-	r, err := robotimpl.New(ctx, cfg, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-	}()
+	r, shutdown := initTestRobot(t, ctx, cfg, logger)
+	defer shutdown()
 
 	options, _, addr := robottestutils.CreateBaseOptionsAndListener(t)
 	err = r.StartWeb(ctx, options)
@@ -180,8 +173,8 @@ func TestConfigRemote(t *testing.T) {
 	}
 
 	ctx2 := context.Background()
-	r2, err := robotimpl.New(ctx2, remoteConfig, logger)
-	test.That(t, err, test.ShouldBeNil)
+	r2, shutdown := initTestRobot(t, ctx2, remoteConfig, logger)
+	defer shutdown()
 
 	expected := []resource.Name{
 		motion.Named(resource.DefaultServiceName),
@@ -309,8 +302,6 @@ func TestConfigRemote(t *testing.T) {
 	fsConfig, err := r2.FrameSystemConfig(context.Background())
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, fsConfig.Parts, test.ShouldHaveLength, 12)
-
-	test.That(t, r2.Close(context.Background()), test.ShouldBeNil)
 }
 
 func TestConfigRemoteWithAuth(t *testing.T) {
@@ -330,11 +321,8 @@ func TestConfigRemoteWithAuth(t *testing.T) {
 	} {
 		t.Run(tc.Case, func(t *testing.T) {
 			ctx := context.Background()
-			r, err := robotimpl.New(ctx, cfg, logger)
-			test.That(t, err, test.ShouldBeNil)
-			defer func() {
-				test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-			}()
+			r, shutdown := initTestRobot(t, ctx, cfg, logger)
+			defer shutdown()
 
 			options, _, addr := robottestutils.CreateBaseOptionsAndListener(t)
 			options.Managed = tc.Managed
@@ -390,11 +378,8 @@ func TestConfigRemoteWithAuth(t *testing.T) {
 				},
 			}
 
-			remoteRobot, err := robotimpl.New(context.Background(), remoteConfig, logger)
-			defer func() {
-				test.That(t, remoteRobot.Close(context.Background()), test.ShouldBeNil)
-			}()
-			test.That(t, err, test.ShouldBeNil)
+			_, shutdown = initTestRobot(t, context.Background(), remoteConfig, logger)
+			defer shutdown()
 
 			remoteConfig.Remotes[0].Auth.Credentials = &rpc.Credentials{
 				Type:    rpc.CredentialsTypeAPIKey,
@@ -408,56 +393,43 @@ func TestConfigRemoteWithAuth(t *testing.T) {
 			var r2 robot.LocalRobot
 			if tc.Managed {
 				remoteConfig.Remotes[0].Auth.Entity = "wrong"
-				managedRemote, err := robotimpl.New(context.Background(), remoteConfig, logger)
-				defer func() {
-					test.That(t, managedRemote.Close(context.Background()), test.ShouldBeNil)
-				}()
-				test.That(t, err, test.ShouldBeNil)
+				_, shutdown = initTestRobot(t, context.Background(), remoteConfig, logger)
+				defer shutdown()
 
 				remoteConfig.AllowInsecureCreds = true
 
-				r3, err := robotimpl.New(context.Background(), remoteConfig, logger)
-				defer func() {
-					test.That(t, r3.Close(context.Background()), test.ShouldBeNil)
-				}()
-				test.That(t, err, test.ShouldBeNil)
-				test.That(t, r3, test.ShouldNotBeNil)
+				r3, shutdown := initTestRobot(t, context.Background(), remoteConfig, logger)
+				defer shutdown()
 				remoteBot, ok := r3.RemoteByName("foo")
 				test.That(t, ok, test.ShouldBeFalse)
 				test.That(t, remoteBot, test.ShouldBeNil)
 
 				remoteConfig.Remotes[0].Auth.Entity = entityName
 				remoteConfig.Remotes[1].Auth.Entity = entityName
-				r2, err = robotimpl.New(context.Background(), remoteConfig, logger)
-				test.That(t, err, test.ShouldBeNil)
-				test.That(t, r2.Close(context.Background()), test.ShouldBeNil)
+				_, shutdown = initTestRobot(t, context.Background(), remoteConfig, logger)
+				shutdown()
 
-				test.That(t, err, test.ShouldBeNil)
 				ctx2 := context.Background()
 				remoteConfig.Remotes[0].Address = options.LocalFQDN
 				if tc.EntityName != "" {
 					remoteConfig.Remotes[1].Address = options.FQDN
 				}
-				r2, err = robotimpl.New(ctx2, remoteConfig, logger)
-				test.That(t, err, test.ShouldBeNil)
+				r2, shutdown = initTestRobot(t, ctx2, remoteConfig, logger)
+				defer shutdown()
 			} else {
-				unmanagedRobot, err := robotimpl.New(context.Background(), remoteConfig, logger)
-				test.That(t, err, test.ShouldBeNil)
-				defer func() {
-					test.That(t, unmanagedRobot.Close(context.Background()), test.ShouldBeNil)
-				}()
+				_, shutdown = initTestRobot(t, context.Background(), remoteConfig, logger)
+				defer shutdown()
 
 				remoteConfig.AllowInsecureCreds = true
 
-				r2, err = robotimpl.New(context.Background(), remoteConfig, logger)
-				test.That(t, err, test.ShouldBeNil)
-				test.That(t, r2.Close(context.Background()), test.ShouldBeNil)
+				//nolint:ineffassign,staticcheck
+				r2, shutdown := initTestRobot(t, context.Background(), remoteConfig, logger)
+				shutdown()
 
-				test.That(t, err, test.ShouldBeNil)
 				ctx2 := context.Background()
 				remoteConfig.Remotes[0].Address = options.LocalFQDN
-				r2, err = robotimpl.New(ctx2, remoteConfig, logger)
-				test.That(t, err, test.ShouldBeNil)
+				r2, shutdown = initTestRobot(t, ctx2, remoteConfig, logger)
+				defer shutdown()
 
 				_, err = r2.ResourceByName(motion.Named(resource.DefaultServiceName))
 				test.That(t, err, test.ShouldBeNil)
@@ -538,9 +510,6 @@ func TestConfigRemoteWithAuth(t *testing.T) {
 			err = decoder.Decode(statuses[1].Status)
 			test.That(t, err, test.ShouldBeNil)
 			test.That(t, convMap, test.ShouldResemble, armStatus)
-
-			test.That(t, r2.Close(context.Background()), test.ShouldBeNil)
-			test.That(t, r.Close(context.Background()), test.ShouldBeNil)
 		})
 	}
 }
@@ -552,11 +521,8 @@ func TestConfigRemoteWithTLSAuth(t *testing.T) {
 
 	ctx := context.Background()
 
-	r, err := robotimpl.New(ctx, cfg, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-	}()
+	r, shutdown := initTestRobot(t, ctx, cfg, logger)
+	defer shutdown()
 
 	altName := primitive.NewObjectID().Hex()
 	cert, certFile, keyFile, certPool, err := testutils.GenerateSelfSignedCertificate("somename", altName)
@@ -618,32 +584,26 @@ func TestConfigRemoteWithTLSAuth(t *testing.T) {
 		},
 	}
 
-	_r, err := robotimpl.New(context.Background(), remoteConfig, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, _r.Close(context.Background()), test.ShouldBeNil)
-	}()
+	_, shutdown = initTestRobot(t, context.Background(), remoteConfig, logger)
+	defer shutdown()
 
 	// use secret
 	remoteConfig.Remotes[0].Auth.Credentials = &rpc.Credentials{
 		Type:    rutils.CredentialsTypeRobotLocationSecret,
 		Payload: locationSecret,
 	}
-	r2, err := robotimpl.New(context.Background(), remoteConfig, logger)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, r2.Close(context.Background()), test.ShouldBeNil)
+	_, shutdown = initTestRobot(t, context.Background(), remoteConfig, logger)
+	shutdown()
 
 	// use cert
 	remoteTLSConfig.Certificates = []tls.Certificate{cert}
-	r2, err = robotimpl.New(context.Background(), remoteConfig, logger)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, r2.Close(context.Background()), test.ShouldBeNil)
+	_, shutdown = initTestRobot(t, context.Background(), remoteConfig, logger)
+	shutdown()
 
 	// use cert with mDNS
 	remoteConfig.Remotes[0].Address = options.FQDN
-	r2, err = robotimpl.New(context.Background(), remoteConfig, logger)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, r2.Close(context.Background()), test.ShouldBeNil)
+	_, shutdown = initTestRobot(t, context.Background(), remoteConfig, logger)
+	shutdown()
 
 	// use signaling creds
 	remoteConfig.Remotes[0].Address = addr
@@ -654,21 +614,18 @@ func TestConfigRemoteWithTLSAuth(t *testing.T) {
 		Type:    rutils.CredentialsTypeRobotLocationSecret,
 		Payload: locationSecret,
 	}
-	r2, err = robotimpl.New(context.Background(), remoteConfig, logger)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, r2.Close(context.Background()), test.ShouldBeNil)
+	_, shutdown = initTestRobot(t, context.Background(), remoteConfig, logger)
+	shutdown()
 
 	// use cert with mDNS while signaling present
-	test.That(t, err, test.ShouldBeNil)
 	ctx2 := context.Background()
 	remoteConfig.Remotes[0].Auth.SignalingCreds = &rpc.Credentials{
 		Type:    rutils.CredentialsTypeRobotLocationSecret,
 		Payload: locationSecret + "bad",
 	}
 	remoteConfig.Remotes[0].Address = options.FQDN
-	r2, err = robotimpl.New(ctx2, remoteConfig, logger)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, err, test.ShouldBeNil)
+	r2, shutdown := initTestRobot(t, ctx2, remoteConfig, logger)
+	defer shutdown()
 
 	expected := []resource.Name{
 		motion.Named(resource.DefaultServiceName),
@@ -722,9 +679,6 @@ func TestConfigRemoteWithTLSAuth(t *testing.T) {
 	err = decoder.Decode(statuses[0].Status)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, convMap, test.ShouldResemble, armStatus)
-
-	test.That(t, r2.Close(context.Background()), test.ShouldBeNil)
-	test.That(t, r.Close(context.Background()), test.ShouldBeNil)
 }
 
 type dummyArm struct {
@@ -815,11 +769,8 @@ func TestStopAll(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	ctx := context.Background()
-	r, err := robotimpl.New(ctx, cfg, logger)
-	defer func() {
-		test.That(t, r.Close(ctx), test.ShouldBeNil)
-	}()
-	test.That(t, err, test.ShouldBeNil)
+	r, shutdown := initTestRobot(t, ctx, cfg, logger)
+	defer shutdown()
 
 	test.That(t, dummyArm1.stopCount, test.ShouldEqual, 0)
 	test.That(t, dummyArm2.stopCount, test.ShouldEqual, 0)
@@ -942,10 +893,8 @@ func TestNewTeardown(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	ctx := context.Background()
-	r, err := robotimpl.New(ctx, cfg, logger)
-	test.That(t, err, test.ShouldBeNil)
-	err = r.Close(ctx)
-	test.That(t, err, test.ShouldBeNil)
+	_, shutdown := initTestRobot(t, ctx, cfg, logger)
+	shutdown()
 	test.That(t, dummyBoard1.closeCount, test.ShouldEqual, 1)
 }
 
@@ -956,8 +905,8 @@ func TestMetadataUpdate(t *testing.T) {
 
 	ctx := context.Background()
 
-	r, err := robotimpl.New(ctx, cfg, logger)
-	test.That(t, err, test.ShouldBeNil)
+	r, shutdown := initTestRobot(t, ctx, cfg, logger)
+	defer shutdown()
 
 	resources := r.ResourceNames()
 	test.That(t, err, test.ShouldBeNil)
@@ -992,8 +941,8 @@ func TestSensorsService(t *testing.T) {
 	cfg, err := config.Read(context.Background(), "data/fake.json", logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	r, err := robotimpl.New(context.Background(), cfg, logger)
-	test.That(t, err, test.ShouldBeNil)
+	r, shutdown := initTestRobot(t, context.Background(), cfg, logger)
+	defer shutdown()
 
 	svc, err := sensors.FromRobot(r, resource.DefaultServiceName)
 	test.That(t, err, test.ShouldBeNil)
@@ -1012,8 +961,6 @@ func TestSensorsService(t *testing.T) {
 	readings, err = svc.Readings(context.Background(), sensorNames, map[string]interface{}{})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, len(readings), test.ShouldEqual, 2)
-
-	test.That(t, r.Close(context.Background()), test.ShouldBeNil)
 }
 
 func TestStatusService(t *testing.T) {
@@ -1021,8 +968,8 @@ func TestStatusService(t *testing.T) {
 	cfg, err := config.Read(context.Background(), "data/fake.json", logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	r, err := robotimpl.New(context.Background(), cfg, logger)
-	test.That(t, err, test.ShouldBeNil)
+	r, shutdown := initTestRobot(t, context.Background(), cfg, logger)
+	defer shutdown()
 
 	resourceNames := []resource.Name{arm.Named("pieceArm"), movementsensor.Named("movement_sensor1")}
 	rArm, err := arm.FromRobot(r, "pieceArm")
@@ -1049,7 +996,6 @@ func TestStatusService(t *testing.T) {
 	for idx := 0; idx < expectedStatusLength; idx++ {
 		test.That(t, statuses[idx].Status, test.ShouldResemble, expected[statuses[idx].Name])
 	}
-	test.That(t, r.Close(context.Background()), test.ShouldBeNil)
 }
 
 func TestStatus(t *testing.T) {
@@ -1298,11 +1244,8 @@ func TestStatusRemote(t *testing.T) {
 	}
 	test.That(t, remoteConfig.Ensure(false, logger), test.ShouldBeNil)
 	ctx := context.Background()
-	r, err := robotimpl.New(ctx, remoteConfig, logger)
-	defer func() {
-		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-	}()
-	test.That(t, err, test.ShouldBeNil)
+	r, shutdown := initTestRobot(t, ctx, remoteConfig, logger)
+	defer shutdown()
 
 	test.That(
 		t,
@@ -1377,13 +1320,10 @@ func TestGetRemoteResourceAndGrandFather(t *testing.T) {
 		Remotes:  []config.Remote{},
 	}
 
-	r0, err := robotimpl.New(ctx, remoteRemoteConfig, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, r0.Close(context.Background()), test.ShouldBeNil)
-	}()
+	r0, shutdown := initTestRobot(t, ctx, remoteRemoteConfig, logger)
+	defer shutdown()
 
-	err = r0.StartWeb(ctx, options)
+	err := r0.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
 	r0arm1, err := r0.ResourceByName(arm.Named("arm1"))
@@ -1412,19 +1352,13 @@ func TestGetRemoteResourceAndGrandFather(t *testing.T) {
 		Name:    "foo",
 		Address: addr1,
 	})
-	r1, err := robotimpl.New(ctx, cfg, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, r1.Close(context.Background()), test.ShouldBeNil)
-	}()
+	r1, shutdown := initTestRobot(t, ctx, cfg, logger)
+	defer shutdown()
 	err = r1.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
-	r, err := robotimpl.New(ctx, remoteConfig, logger)
-	defer func() {
-		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-	}()
-	test.That(t, err, test.ShouldBeNil)
+	r, shutdown := initTestRobot(t, ctx, remoteConfig, logger)
+	defer shutdown()
 
 	test.That(
 		t,
@@ -1509,12 +1443,9 @@ func TestValidationErrorOnReconfigure(t *testing.T) {
 		}},
 		Cloud: &config.Cloud{},
 	}
-	r, err := robotimpl.New(ctx, badConfig, logger)
-	defer func() {
-		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-	}()
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, r, test.ShouldNotBeNil)
+	r, shutdown := initTestRobot(t, ctx, badConfig, logger)
+	defer shutdown()
+
 	// Test Component Error
 	name := base.Named("test")
 	noBase, err := r.ResourceByName(name)
@@ -1563,14 +1494,11 @@ func TestConfigStartsInvalidReconfiguresValid(t *testing.T) {
 		}},
 	}
 	test.That(t, badConfig.Ensure(false, logger), test.ShouldBeNil)
-	r, err := robotimpl.New(ctx, badConfig, logger)
-	defer func() {
-		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-	}()
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, r, test.ShouldNotBeNil)
+	r, shutdown := initTestRobot(t, ctx, badConfig, logger)
+	defer shutdown()
+
 	options1, _, addr1 := robottestutils.CreateBaseOptionsAndListener(t)
-	err = r.StartWeb(context.Background(), options1)
+	err := r.StartWeb(context.Background(), options1)
 	test.That(t, err, test.ShouldBeNil)
 
 	goodConfig := &config.Config{
@@ -1651,14 +1579,10 @@ func TestConfigStartsValidReconfiguresInvalid(t *testing.T) {
 		Components: []resource.Config{armConfig},
 	}
 
-	robotRemote, err := robotimpl.New(ctx, &cfg, logger)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, robotRemote, test.ShouldNotBeNil)
-	defer func() {
-		test.That(t, robotRemote.Close(context.Background()), test.ShouldBeNil)
-	}()
+	robotRemote, shutdown := initTestRobot(t, ctx, &cfg, logger)
+	defer shutdown()
 	options1, _, addr1 := robottestutils.CreateBaseOptionsAndListener(t)
-	err = robotRemote.StartWeb(context.Background(), options1)
+	err := robotRemote.StartWeb(context.Background(), options1)
 	test.That(t, err, test.ShouldBeNil)
 
 	goodConfig := &config.Config{
@@ -1684,12 +1608,8 @@ func TestConfigStartsValidReconfiguresInvalid(t *testing.T) {
 		}},
 	}
 	test.That(t, goodConfig.Ensure(false, logger), test.ShouldBeNil)
-	r, err := robotimpl.New(ctx, goodConfig, logger)
-	defer func() {
-		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-	}()
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, r, test.ShouldNotBeNil)
+	r, shutdown := initTestRobot(t, ctx, goodConfig, logger)
+	defer shutdown()
 
 	badConfig := &config.Config{
 		Components: []resource.Config{
@@ -1791,12 +1711,8 @@ func TestResourceStartsOnReconfigure(t *testing.T) {
 		},
 	}
 	test.That(t, goodConfig.Ensure(false, logger), test.ShouldBeNil)
-	r, err := robotimpl.New(ctx, badConfig, logger)
-	defer func() {
-		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-	}()
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, r, test.ShouldNotBeNil)
+	r, shutdown := initTestRobot(t, ctx, badConfig, logger)
+	defer shutdown()
 
 	noBase, err := r.ResourceByName(base.Named("fake0"))
 	test.That(
@@ -1827,8 +1743,7 @@ func TestResourceStartsOnReconfigure(t *testing.T) {
 
 func TestConfigProcess(t *testing.T) {
 	logger, logs := logging.NewObservedTestLogger(t)
-
-	r, err := robotimpl.New(context.Background(), &config.Config{
+	_, shutdown := initTestRobot(t, context.Background(), &config.Config{
 		Processes: []pexec.ProcessConfig{
 			{
 				ID:      "1",
@@ -1839,8 +1754,7 @@ func TestConfigProcess(t *testing.T) {
 			},
 		},
 	}, logger)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, r.Close(context.Background()), test.ShouldBeNil)
+	shutdown()
 	test.That(t, logs.FilterField(zap.String("output", "heythere\n")).Len(), test.ShouldEqual, 1)
 }
 
@@ -1868,11 +1782,8 @@ func TestConfigPackages(t *testing.T) {
 		PackagePath: packageDir,
 	}
 
-	r, err := robotimpl.New(ctx, robotConfig, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-	}()
+	r, shutdown := initTestRobot(t, ctx, robotConfig, logger)
+	defer shutdown()
 
 	_, err = r.PackageManager().PackagePath("some-name-1")
 	test.That(t, err, test.ShouldEqual, packages.ErrPackageMissing)
@@ -1944,11 +1855,8 @@ func TestConfigMethod(t *testing.T) {
 	complexPath, err := rtestutils.BuildTempModule(t, "examples/customresources/demos/complexmodule")
 	test.That(t, err, test.ShouldBeNil)
 
-	r, err := robotimpl.New(context.Background(), &config.Config{}, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-	}()
+	r, shutdown := initTestRobot(t, context.Background(), &config.Config{}, logger)
+	defer shutdown()
 
 	// Assert that Config method returns the three default services: data_manager,
 	// motion and sensors.
@@ -1965,11 +1873,9 @@ func TestConfigMethod(t *testing.T) {
 	// will be returned by Config.
 	remoteCfg, err := config.Read(context.Background(), "data/remote_fake.json", logger)
 	test.That(t, err, test.ShouldBeNil)
-	remoteRobot, err := robotimpl.New(ctx, remoteCfg, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, remoteRobot.Close(context.Background()), test.ShouldBeNil)
-	}()
+	remoteRobot, shutdown := initTestRobot(t, ctx, remoteCfg, logger)
+	defer shutdown()
+
 	options, _, addr := robottestutils.CreateBaseOptionsAndListener(t)
 	err = remoteRobot.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
@@ -2126,13 +2032,9 @@ func TestReconnectRemote(t *testing.T) {
 		Components: []resource.Config{armConfig},
 	}
 
-	robot, err := robotimpl.New(ctx, &cfg, logger)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, robot, test.ShouldNotBeNil)
-	defer func() {
-		test.That(t, robot.Close(context.Background()), test.ShouldBeNil)
-	}()
-	err = robot.StartWeb(ctx, options)
+	robot, shutdown := initTestRobot(t, ctx, &cfg, logger)
+	defer shutdown()
+	err := robot.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
 	// start the second robot
@@ -2149,12 +2051,8 @@ func TestReconnectRemote(t *testing.T) {
 		Remotes: []config.Remote{remoteConf},
 	}
 
-	robot1, err := robotimpl.New(ctx, &cfg1, logger)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, robot, test.ShouldNotBeNil)
-	defer func() {
-		test.That(t, robot1.Close(context.Background()), test.ShouldBeNil)
-	}()
+	robot1, shutdown := initTestRobot(t, ctx, &cfg1, logger)
+	defer shutdown()
 
 	err = robot1.StartWeb(ctx1, options1)
 	test.That(t, err, test.ShouldBeNil)
@@ -2240,13 +2138,9 @@ func TestReconnectRemoteChangeConfig(t *testing.T) {
 		Components: []resource.Config{armConfig},
 	}
 
-	robot, err := robotimpl.New(ctx, &cfg, logger)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, robot, test.ShouldNotBeNil)
-	defer func() {
-		test.That(t, robot.Close(context.Background()), test.ShouldBeNil)
-	}()
-	err = robot.StartWeb(ctx, options)
+	robot, shutdown := initTestRobot(t, ctx, &cfg, logger)
+	defer shutdown()
+	err := robot.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
 	// start the second robot
@@ -2262,12 +2156,8 @@ func TestReconnectRemoteChangeConfig(t *testing.T) {
 		Remotes: []config.Remote{remoteConf},
 	}
 
-	robot1, err := robotimpl.New(ctx, &cfg1, logger)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, robot, test.ShouldNotBeNil)
-	defer func() {
-		test.That(t, robot1.Close(context.Background()), test.ShouldBeNil)
-	}()
+	robot1, shutdown := initTestRobot(t, ctx, &cfg1, logger)
+	defer shutdown()
 
 	err = robot1.StartWeb(ctx1, options1)
 	test.That(t, err, test.ShouldBeNil)
@@ -2324,9 +2214,8 @@ func TestReconnectRemoteChangeConfig(t *testing.T) {
 	options = weboptions.New()
 	options.Network.BindAddress = ""
 	options.Network.Listener = listener
-	robot, err = robotimpl.New(ctx, &cfg, logger)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, robot, test.ShouldNotBeNil)
+	robot, shutdown = initTestRobot(t, ctx, &cfg, logger)
+	defer shutdown()
 	err = robot.StartWeb(ctx2, options)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -2385,11 +2274,8 @@ func TestCheckMaxInstanceValid(t *testing.T) {
 			},
 		},
 	}
-	r, err := robotimpl.New(context.Background(), cfg, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-	}()
+	r, shutdown := initTestRobot(t, context.Background(), cfg, logger)
+	defer shutdown()
 	res, err := r.ResourceByName(motion.Named("fake1"))
 	test.That(t, res, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldBeNil)
@@ -2438,11 +2324,8 @@ func TestCheckMaxInstanceInvalid(t *testing.T) {
 			},
 		},
 	}
-	r, err := robotimpl.New(context.Background(), cfg, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-	}()
+	r, shutdown := initTestRobot(t, context.Background(), cfg, logger)
+	defer shutdown()
 	maxInstance := 0
 	for _, name := range r.ResourceNames() {
 		if name.API == datamanager.API {
@@ -2465,13 +2348,10 @@ func TestCheckMaxInstanceSkipRemote(t *testing.T) {
 	ctx := context.Background()
 	logger := logging.NewTestLogger(t)
 
-	r0, err := robotimpl.New(ctx, &config.Config{}, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, r0.Close(context.Background()), test.ShouldBeNil)
-	}()
+	r0, shutdown := initTestRobot(t, ctx, &config.Config{}, logger)
+	defer shutdown()
 
-	err = r0.StartWeb(ctx, options)
+	err := r0.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
 	remoteConfig := &config.Config{
@@ -2495,11 +2375,8 @@ func TestCheckMaxInstanceSkipRemote(t *testing.T) {
 		},
 	}
 
-	r, err := robotimpl.New(ctx, remoteConfig, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-	}()
+	r, shutdown := initTestRobot(t, ctx, remoteConfig, logger)
+	defer shutdown()
 
 	maxInstance := 0
 	for _, name := range r.ResourceNames() {
@@ -2548,11 +2425,8 @@ func TestDependentResources(t *testing.T) {
 			},
 		},
 	}
-	r, err := robotimpl.New(ctx, cfg, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-	}()
+	r, shutdown := initTestRobot(t, ctx, cfg, logger)
+	defer shutdown()
 
 	// Assert that removing base 'b' removes motors 'm' and 'm1' and slam service 's'.
 	cfg2 := &config.Config{
@@ -2632,11 +2506,8 @@ func TestOrphanedResources(t *testing.T) {
 	summationAPI := resource.APINamespace("acme").WithServiceType("summation")
 	helperModel := resource.NewModel("rdk", "test", "helper")
 
-	r, err := robotimpl.New(ctx, &config.Config{}, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-	}()
+	r, shutdown := initTestRobot(t, ctx, &config.Config{}, logger)
+	defer shutdown()
 
 	t.Run("manual reconfiguration", func(t *testing.T) {
 		cfg := &config.Config{
@@ -2929,11 +2800,8 @@ func TestDependentAndOrphanedResources(t *testing.T) {
 		},
 	}
 	test.That(t, cfg.Ensure(false, logger), test.ShouldBeNil)
-	r, err := robotimpl.New(ctx, cfg, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-	}()
+	r, shutdown := initTestRobot(t, ctx, cfg, logger)
+	defer shutdown()
 
 	// Assert that reconfiguring module 'mod' to a new module that does not handle
 	// 'g' removes modular component 'g' and its dependent 'd' and leaves 'm' as-is.
@@ -3050,11 +2918,8 @@ func TestModuleDebugReconfigure(t *testing.T) {
 			},
 		},
 	}
-	r, err := robotimpl.New(ctx, cfg, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-	}()
+	r, shutdown := initTestRobot(t, ctx, cfg, logger)
+	defer shutdown()
 
 	time.Sleep(2 * time.Second)
 	test.That(t, logs.FilterMessageSnippet("debug mode enabled").Len(),
@@ -3095,11 +2960,8 @@ func TestResourcelessModuleRemove(t *testing.T) {
 			},
 		},
 	}
-	r, err := robotimpl.New(ctx, cfg, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-	}()
+	r, shutdown := initTestRobot(t, ctx, cfg, logger)
+	defer shutdown()
 
 	// Reconfigure to an empty config and assert that the testmodule process
 	// is stopped.
@@ -3136,11 +2998,8 @@ func TestCrashedModuleReconfigure(t *testing.T) {
 			},
 		},
 	}
-	r, err := robotimpl.New(ctx, cfg, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-	}()
+	r, shutdown := initTestRobot(t, ctx, cfg, logger)
+	defer shutdown()
 
 	_, err = r.ResourceByName(generic.Named("h"))
 	test.That(t, err, test.ShouldBeNil)
@@ -3228,11 +3087,8 @@ func TestImplicitDepsAcrossModules(t *testing.T) {
 			},
 		},
 	}
-	r, err := robotimpl.New(ctx, cfg, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-	}()
+	r, shutdown := initTestRobot(t, ctx, cfg, logger)
+	defer shutdown()
 
 	_, err = r.ResourceByName(base.Named("b"))
 	test.That(t, err, test.ShouldBeNil)
@@ -3284,11 +3140,8 @@ func TestResourceByNameAcrossRemotes(t *testing.T) {
 			},
 		},
 	}
-	robot4, err := robotimpl.New(ctx, cfg4, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, robot4.Close(ctx), test.ShouldBeNil)
-	}()
+	robot4, shutdown := initTestRobot(t, ctx, cfg4, logger)
+	defer shutdown()
 	addr4 := startWeb(robot4)
 	test.That(t, addr4, test.ShouldNotBeBlank)
 
@@ -3300,11 +3153,8 @@ func TestResourceByNameAcrossRemotes(t *testing.T) {
 			},
 		},
 	}
-	robot3, err := robotimpl.New(ctx, cfg3, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, robot3.Close(ctx), test.ShouldBeNil)
-	}()
+	robot3, shutdown := initTestRobot(t, ctx, cfg3, logger)
+	defer shutdown()
 	addr3 := startWeb(robot3)
 	test.That(t, addr3, test.ShouldNotBeBlank)
 
@@ -3326,11 +3176,8 @@ func TestResourceByNameAcrossRemotes(t *testing.T) {
 			},
 		},
 	}
-	robot2, err := robotimpl.New(ctx, cfg2, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, robot2.Close(ctx), test.ShouldBeNil)
-	}()
+	robot2, shutdown := initTestRobot(t, ctx, cfg2, logger)
+	defer shutdown()
 	addr2 := startWeb(robot2)
 	test.That(t, addr2, test.ShouldNotBeBlank)
 
@@ -3352,17 +3199,14 @@ func TestResourceByNameAcrossRemotes(t *testing.T) {
 			},
 		},
 	}
-	robot1, err := robotimpl.New(ctx, cfg1, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, robot1.Close(ctx), test.ShouldBeNil)
-	}()
+	robot1, shutdown := initTestRobot(t, ctx, cfg1, logger)
+	defer shutdown()
 
 	// Ensure that "e" can be retrieved by short and simple names from all
 	// robots. Also ensure "m1" and "m2" can be retrieved from robot1 and robot2
 	// (they built properly).
 
-	_, err = robot4.ResourceByName(encoder.Named("e"))
+	_, err := robot4.ResourceByName(encoder.Named("e"))
 	test.That(t, err, test.ShouldBeNil)
 
 	_, err = robot3.ResourceByName(encoder.Named("e"))
@@ -3390,12 +3234,9 @@ func TestCloudMetadata(t *testing.T) {
 	ctx := context.Background()
 	t.Run("no cloud data", func(t *testing.T) {
 		cfg := &config.Config{}
-		robot, err := robotimpl.New(ctx, cfg, logger)
-		test.That(t, err, test.ShouldBeNil)
-		defer func() {
-			test.That(t, robot.Close(ctx), test.ShouldBeNil)
-		}()
-		_, err = robot.GetCloudMetadata(ctx)
+		robot, shutdown := initTestRobot(t, ctx, cfg, logger)
+		defer shutdown()
+		_, err := robot.GetCloudMetadata(ctx)
 		test.That(t, err, test.ShouldBeError, errors.New("cloud metadata not available"))
 	})
 	t.Run("with cloud data", func(t *testing.T) {
@@ -3406,11 +3247,8 @@ func TestCloudMetadata(t *testing.T) {
 				PrimaryOrgID: "the-primary-org",
 			},
 		}
-		robot, err := robotimpl.New(ctx, cfg, logger)
-		test.That(t, err, test.ShouldBeNil)
-		defer func() {
-			test.That(t, robot.Close(ctx), test.ShouldBeNil)
-		}()
+		robot, shutdown := initTestRobot(t, ctx, cfg, logger)
+		defer shutdown()
 		md, err := robot.GetCloudMetadata(ctx)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, md, test.ShouldResemble, cloud.Metadata{
@@ -3419,4 +3257,16 @@ func TestCloudMetadata(t *testing.T) {
 			LocationID:   "the-location",
 		})
 	})
+}
+
+//nolint:revive
+func initTestRobot(t *testing.T, ctx context.Context, cfg *config.Config, logger logging.Logger) (robot.LocalRobot, func()) {
+	t.Helper()
+
+	r, err := robotimpl.New(ctx, cfg, logger)
+	test.That(t, r, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldBeNil)
+	return r, func() {
+		test.That(t, r.Close(ctx), test.ShouldBeNil)
+	}
 }

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
+
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	armpb "go.viam.com/api/component/arm/v1"
@@ -422,8 +423,7 @@ func TestConfigRemoteWithAuth(t *testing.T) {
 
 				remoteConfig.AllowInsecureCreds = true
 
-				//nolint:ineffassign,staticcheck
-				r2, shutdown := initTestRobot(t, context.Background(), remoteConfig, logger)
+				_, shutdown := initTestRobot(t, context.Background(), remoteConfig, logger)
 				shutdown()
 
 				ctx2 := context.Background()

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -3258,7 +3258,7 @@ func TestCloudMetadata(t *testing.T) {
 	})
 }
 
-//nolint:revive
+//revive:disable-next-line:context-as-argument
 func initTestRobot(t *testing.T, ctx context.Context, cfg *config.Config, logger logging.Logger) (robot.LocalRobot, func()) {
 	t.Helper()
 


### PR DESCRIPTION
Add a helper to encapsulate basic setup and teardown that we do throughout the local robot test suite. Noticed this while working on https://github.com/viamrobotics/rdk/pull/3599