### PR TITLE
Rename .data -> data directory

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1071,8 +1071,15 @@ func (p *PackageConfig) LocalDownloadPath(packagesDir string) string {
 }
 
 // LocalDataParentDirectory returns the folder that will contain the all packages of this type.
-// Ex: /home/user/.viam/packages/.data/ml_model.
+// Ex: /home/user/.viam/packages/data/ml_model.
 func (p *PackageConfig) LocalDataParentDirectory(packagesDir string) string {
+	return filepath.Join(packagesDir, "data", string(p.Type))
+}
+
+// LocalLegacyDataParentDirectory returns the old private directory.
+// This can be cleaned up after a few RDK releases (APP-4066)
+// Ex: /home/user/.viam/packages/.data/ml_model.
+func (p *PackageConfig) LocalLegacyDataParentDirectory(packagesDir string) string {
 	return filepath.Join(packagesDir, ".data", string(p.Type))
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -1078,9 +1078,9 @@ func (p *PackageConfig) LocalDataParentDirectory(packagesDir string) string {
 
 // LocalLegacyDataParentDirectory returns the old private directory.
 // This can be cleaned up after a few RDK releases (APP-4066)
-// Ex: /home/user/.viam/packages/.data/ml_model.
-func (p *PackageConfig) LocalLegacyDataParentDirectory(packagesDir string) string {
-	return filepath.Join(packagesDir, ".data", string(p.Type))
+// Ex: /home/user/.viam/packages/.data/.
+func (p *PackageConfig) LocalLegacyDataRootDirectory(packagesDir string) string {
+	return filepath.Join(packagesDir, ".data")
 }
 
 // SanitizedName returns the package name for the symlink/filepath of the package on the system.

--- a/config/config.go
+++ b/config/config.go
@@ -1060,7 +1060,7 @@ func (p PackageConfig) Equals(other PackageConfig) bool {
 }
 
 // LocalDataDirectory returns the folder where the package should be extracted.
-// Ex: /home/user/.viam/packages/.data/ml_model/orgid_ballClassifier_0.1.2.
+// Ex: /home/user/.viam/packages/data/ml_model/orgid_ballClassifier_0.1.2.
 func (p *PackageConfig) LocalDataDirectory(packagesDir string) string {
 	return filepath.Join(p.LocalDataParentDirectory(packagesDir), p.SanitizedName())
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1076,7 +1076,7 @@ func (p *PackageConfig) LocalDataParentDirectory(packagesDir string) string {
 	return filepath.Join(packagesDir, "data", string(p.Type))
 }
 
-// LocalLegacyDataParentDirectory returns the old private directory.
+// LocalLegacyDataRootDirectory returns the old private directory.
 // This can be cleaned up after a few RDK releases (APP-4066)
 // Ex: /home/user/.viam/packages/.data/.
 func (p *PackageConfig) LocalLegacyDataRootDirectory(packagesDir string) string {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1183,7 +1183,7 @@ func TestPackageConfig(t *testing.T) {
 				Package: "my_org/my_module",
 				Version: "1.2",
 			},
-			expectedRealFilePath: filepath.Join(viamDotDir, "packages", ".data", "module", "my_org-my_module-1_2"),
+			expectedRealFilePath: filepath.Join(viamDotDir, "packages", "data", "module", "my_org-my_module-1_2"),
 		},
 		{
 			config: config.PackageConfig{
@@ -1192,7 +1192,7 @@ func TestPackageConfig(t *testing.T) {
 				Package: "my_org/my_ml_model",
 				Version: "latest",
 			},
-			expectedRealFilePath: filepath.Join(viamDotDir, "packages", ".data", "ml_model", "my_org-my_ml_model-latest"),
+			expectedRealFilePath: filepath.Join(viamDotDir, "packages", "data", "ml_model", "my_org-my_ml_model-latest"),
 		},
 		{
 			config: config.PackageConfig{
@@ -1201,7 +1201,7 @@ func TestPackageConfig(t *testing.T) {
 				Package: "my_org/my_slam_map",
 				Version: "latest",
 			},
-			expectedRealFilePath: filepath.Join(viamDotDir, "packages", ".data", "slam_map", "my_org-my_slam_map-latest"),
+			expectedRealFilePath: filepath.Join(viamDotDir, "packages", "data", "slam_map", "my_org-my_slam_map-latest"),
 		},
 		{
 			config: config.PackageConfig{

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -1903,11 +1903,11 @@ func TestConfigPackages(t *testing.T) {
 
 	path1, err := r.PackageManager().PackagePath("some-name-1")
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, path1, test.ShouldEqual, path.Join(packageDir, ".data", "ml_model", "package-1-v1"))
+	test.That(t, path1, test.ShouldEqual, path.Join(packageDir, "data", "ml_model", "package-1-v1"))
 
 	path2, err := r.PackageManager().PackagePath("some-name-2")
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, path2, test.ShouldEqual, path.Join(packageDir, ".data", "ml_model", "package-2-v2"))
+	test.That(t, path2, test.ShouldEqual, path.Join(packageDir, "data", "ml_model", "package-2-v2"))
 }
 
 // removeDefaultServices removes default services and returns the removed

--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -73,7 +73,7 @@ func NewCloudManager(
 	packagesDir string,
 	logger logging.Logger,
 ) (ManagerSyncer, error) {
-	packagesDataDir := filepath.Join(packagesDir, ".data")
+	packagesDataDir := filepath.Join(packagesDir, "data")
 
 	if err := os.MkdirAll(packagesDir, 0o700); err != nil {
 		return nil, err

--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -295,7 +295,7 @@ func (m *cloudManager) Cleanup(ctx context.Context) error {
 	return allErrors
 }
 
-// symlink packages/package-name to packages/.data/ml_model/orgid-package-name-ver for backwards compatablility
+// symlink packages/package-name to packages/data/ml_model/orgid-package-name-ver for backwards compatablility
 // TODO(RSDK-4386) Preserved for backwards compatibility. Could be removed or extended to other types in the future.
 func (m *cloudManager) mLModelSymlinkCreation(p config.PackageConfig) error {
 	symlinkPath, err := safeJoin(m.packagesDir, p.Name)
@@ -366,8 +366,9 @@ func (m *cloudManager) downloadPackage(ctx context.Context, url string, p config
 
 	// Delete legacy directory, silently fail if the cleanup fails
 	// This can be cleaned up after a few RDK releases (APP-4066)
-	//nolint:errcheck
-	_ = os.RemoveAll(p.LocalLegacyDataParentDirectory(m.packagesDir))
+	if err := os.RemoveAll(p.LocalLegacyDataRootDirectory(m.packagesDir)); err != nil {
+		utils.UncheckedError(err)
+	}
 
 	// Force redownload of package archive.
 	if err := m.cleanup(p); err != nil {

--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -369,6 +369,9 @@ func (m *cloudManager) downloadPackage(ctx context.Context, url string, p config
 	if err := os.RemoveAll(p.LocalLegacyDataRootDirectory(m.packagesDir)); err != nil {
 		utils.UncheckedError(err)
 	}
+	if err := os.Remove(p.LocalLegacyDataRootDirectory(m.packagesDir)); err != nil {
+		utils.UncheckedError(err)
+	}
 
 	// Force redownload of package archive.
 	if err := m.cleanup(p); err != nil {

--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -249,7 +249,7 @@ func (m *cloudManager) Cleanup(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	// A packageTypeDir is a directory that contains all of the packages for the specified type. ex: .data/ml_model
+	// A packageTypeDir is a directory that contains all of the packages for the specified type. ex: data/ml_model
 	for _, packageTypeDir := range topLevelFiles {
 		packageTypeDirName, err := safeJoin(m.packagesDataDir, packageTypeDir.Name())
 		if err != nil {
@@ -257,7 +257,7 @@ func (m *cloudManager) Cleanup(ctx context.Context) error {
 			continue
 		}
 
-		// There should be no non-dir files in the packages/.data dir. Delete any that exist
+		// There should be no non-dir files in the packages/data dir. Delete any that exist
 		if packageTypeDir.Type()&os.ModeDir != os.ModeDir {
 			allErrors = multierr.Append(allErrors, os.Remove(packageTypeDirName))
 			continue
@@ -295,7 +295,7 @@ func (m *cloudManager) Cleanup(ctx context.Context) error {
 	return allErrors
 }
 
-// symlink packages/package-name to packages/data/ml_model/orgid-package-name-ver for backwards compatablility
+// symlink packages/package-name to packages/data/ml_model/orgid-package-name-ver for backwards compatibility
 // TODO(RSDK-4386) Preserved for backwards compatibility. Could be removed or extended to other types in the future.
 func (m *cloudManager) mLModelSymlinkCreation(p config.PackageConfig) error {
 	symlinkPath, err := safeJoin(m.packagesDir, p.Name)
@@ -367,9 +367,6 @@ func (m *cloudManager) downloadPackage(ctx context.Context, url string, p config
 	// Delete legacy directory, silently fail if the cleanup fails
 	// This can be cleaned up after a few RDK releases (APP-4066)
 	if err := os.RemoveAll(p.LocalLegacyDataRootDirectory(m.packagesDir)); err != nil {
-		utils.UncheckedError(err)
-	}
-	if err := os.Remove(p.LocalLegacyDataRootDirectory(m.packagesDir)); err != nil {
 		utils.UncheckedError(err)
 	}
 

--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -364,6 +364,11 @@ func (m *cloudManager) downloadPackage(ctx context.Context, url string, p config
 		return err
 	}
 
+	// Delete legacy directory, silently fail if the cleanup fails
+	// This can be cleaned up after a few RDK releases (APP-4066)
+	//nolint:errcheck
+	_ = os.RemoveAll(p.LocalLegacyDataParentDirectory(m.packagesDir))
+
 	// Force redownload of package archive.
 	if err := m.cleanup(p); err != nil {
 		m.logger.Debug(err)

--- a/robot/packages/cloud_package_manager_test.go
+++ b/robot/packages/cloud_package_manager_test.go
@@ -269,7 +269,7 @@ func validatePackageDir(t *testing.T, dir string, input []config.PackageConfig) 
 	// check all known packages exist and are linked to the correct package dir.
 	for _, p := range input {
 		logicalPath := filepath.Join(dir, p.Name)
-		dataPath := filepath.Join(dir, ".data", string(p.Type), p.SanitizedName())
+		dataPath := filepath.Join(dir, "data", string(p.Type), p.SanitizedName())
 
 		info, err := os.Stat(logicalPath)
 		test.That(t, err, test.ShouldBeNil)
@@ -288,8 +288,8 @@ func validatePackageDir(t *testing.T, dir string, input []config.PackageConfig) 
 		test.That(t, info.IsDir(), test.ShouldBeTrue)
 	}
 
-	// find any dangling files in the package dir or .data sub dir
-	// packageDir will contain either symlinks to the packages or the .data directory.
+	// find any dangling files in the package dir or data sub dir
+	// packageDir will contain either symlinks to the packages or the data directory.
 	files, err := os.ReadDir(dir)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -301,15 +301,15 @@ func validatePackageDir(t *testing.T, dir string, input []config.PackageConfig) 
 			continue
 		}
 
-		// skip over any directories including the .data
-		if f.IsDir() && f.Name() == ".data" {
+		// skip over any directories including the data
+		if f.IsDir() && f.Name() == "data" {
 			continue
 		}
 
 		t.Fatalf("found unknown file in package dir %s", f.Name())
 	}
 
-	typeFolders, err := os.ReadDir(filepath.Join(dir, ".data"))
+	typeFolders, err := os.ReadDir(filepath.Join(dir, "data"))
 	test.That(t, err, test.ShouldBeNil)
 
 	for _, typeFile := range typeFolders {
@@ -317,7 +317,7 @@ func validatePackageDir(t *testing.T, dir string, input []config.PackageConfig) 
 		if !ok {
 			t.Errorf("found unknown file in package data dir %s", typeFile.Name())
 		}
-		foundFiles, err := os.ReadDir(filepath.Join(dir, ".data", typeFile.Name()))
+		foundFiles, err := os.ReadDir(filepath.Join(dir, "data", typeFile.Name()))
 		test.That(t, err, test.ShouldBeNil)
 		for _, packageFile := range foundFiles {
 			if !slices.Contains(expectedPackages, packageFile.Name()) {


### PR DESCRIPTION
Since the `.viam` directory is already private, there isn't a need to add additional private directories underneath it. This makes it so that `.data` is removed in favor of data. Since the packages are downloaded on each viam-server restart, I felt that it wasn't necessary to do a rename/move of the existing folder.

Symlinks are regenerated and don't need to be rewritten.

Tested using the PR app image:

stable:
```
datadir@datadir:~ $ sudo ls -al /root/.viam/packages
total 16
drwx------ 3 root root 4096 Feb 26 16:37 .
drwxr-xr-x 5 root root 4096 Feb 26 16:37 ..
drwx------ 4 root root 4096 Feb 26 16:37 .data
lrwxrwxrwx 1 root root   71 Feb 26 16:37 pet-feeder -> /root/.viam/packages/.data/ml_model/viam-pet-feeder-2023-11-27T13-28-53
```

pr-3608 after an initial install of stable:
```
datadir@datadir:~ $ sudo ls -al /root/.viam/packages
total 16
drwx------ 3 root root 4096 Feb 26 16:38 .
drwxr-xr-x 5 root root 4096 Feb 26 16:38 ..
drwx------ 4 root root 4096 Feb 26 16:38 data
lrwxrwxrwx 1 root root   70 Feb 26 16:38 pet-feeder -> /root/.viam/packages/data/ml_model/viam-pet-feeder-2023-11-27T13-28-53
```