### PR TITLE
RSDK-6344 - Fix socket clashes on reconfigured modules

### DIFF
--- a/grpc/conn.go
+++ b/grpc/conn.go
@@ -15,7 +15,8 @@ type ReconfigurableClientConn struct {
 	conn   rpc.ClientConn
 }
 
-// Invoke invokes using the underlying client connection.
+// Invoke invokes using the underlying client connection. In the case of c.conn being closed in the middle of
+// an Invoke call, it is expected that c.conn can handle that and return a well-formed error.
 func (c *ReconfigurableClientConn) Invoke(
 	ctx context.Context,
 	method string,
@@ -31,7 +32,8 @@ func (c *ReconfigurableClientConn) Invoke(
 	return conn.Invoke(ctx, method, args, reply, opts...)
 }
 
-// NewStream creates a new stream using the underlying client connection.
+// NewStream creates a new stream using the underlying client connection. In the case of c.conn being closed in the middle of
+// a NewStream call, it is expected that c.conn can handle that and return a well-formed error.
 func (c *ReconfigurableClientConn) NewStream(
 	ctx context.Context,
 	desc *googlegrpc.StreamDesc,
@@ -47,7 +49,8 @@ func (c *ReconfigurableClientConn) NewStream(
 	return conn.NewStream(ctx, desc, method, opts...)
 }
 
-// ReplaceConn replaces the underlying client connection with the connection passed in.
+// ReplaceConn replaces the underlying client connection with the connection passed in. This does not close the
+// old connection, the caller is expected to close it if needed.
 func (c *ReconfigurableClientConn) ReplaceConn(conn rpc.ClientConn) {
 	c.connMu.Lock()
 	c.conn = conn

--- a/grpc/conn.go
+++ b/grpc/conn.go
@@ -1,0 +1,67 @@
+package grpc
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"go.viam.com/utils/rpc"
+	googlegrpc "google.golang.org/grpc"
+)
+
+// ReconfigurableClientConn allows for the underlying client connections to be swapped under the hood.
+type ReconfigurableClientConn struct {
+	connMu sync.RWMutex
+	conn   rpc.ClientConn
+}
+
+// Invoke invokes using the underlying client connection.
+func (c *ReconfigurableClientConn) Invoke(
+	ctx context.Context,
+	method string,
+	args, reply interface{},
+	opts ...googlegrpc.CallOption,
+) error {
+	c.connMu.RLock()
+	conn := c.conn
+	c.connMu.RUnlock()
+	if conn == nil {
+		return errors.New("not connected")
+	}
+	return conn.Invoke(ctx, method, args, reply, opts...)
+}
+
+// NewStream creates a new stream using the underlying client connection.
+func (c *ReconfigurableClientConn) NewStream(
+	ctx context.Context,
+	desc *googlegrpc.StreamDesc,
+	method string,
+	opts ...googlegrpc.CallOption,
+) (googlegrpc.ClientStream, error) {
+	c.connMu.RLock()
+	conn := c.conn
+	c.connMu.RUnlock()
+	if conn == nil {
+		return nil, errors.New("not connected")
+	}
+	return conn.NewStream(ctx, desc, method, opts...)
+}
+
+// ReplaceConn replaces the underlying client connection with the connection passed in.
+func (c *ReconfigurableClientConn) ReplaceConn(conn rpc.ClientConn) {
+	c.connMu.Lock()
+	c.conn = conn
+	c.connMu.Unlock()
+}
+
+// Close attempts to close the underlying client connection if there is one.
+func (c *ReconfigurableClientConn) Close() error {
+	c.connMu.Lock()
+	defer c.connMu.Unlock()
+	if c.conn == nil {
+		return nil
+	}
+	conn := c.conn
+	c.conn = nil
+	return conn.Close()
+}

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -245,6 +245,9 @@ func (mgr *Manager) Reconfigure(ctx context.Context, conf config.Module) ([]reso
 		return handledResourceNames, err
 	}
 
+	mod.cfg = conf
+	mod.resources = map[resource.Name]*addedResource{}
+
 	if err := mgr.startModule(ctx, mod); err != nil {
 		// If re-addition fails, assume all handled resources are orphaned.
 		return handledResourceNames, err

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -70,7 +70,7 @@ type module struct {
 	dataDir   string
 	process   pexec.ManagedProcess
 	handles   modlib.HandlerMap
-	conn      *grpc.ClientConn
+	conn      rdkgrpc.ReconfigurableClientConn
 	client    pb.ModuleServiceClient
 	addr      string
 	resources map[resource.Name]*addedResource
@@ -124,7 +124,7 @@ func (mgr *Manager) Close(ctx context.Context) error {
 	}
 	var err error
 	for _, mod := range mgr.modules {
-		err = multierr.Combine(err, mgr.remove(mod, false))
+		err = multierr.Combine(err, mgr.closeModule(mod, false))
 	}
 	return err
 }
@@ -147,10 +147,10 @@ func (mgr *Manager) Handles() map[string]modlib.HandlerMap {
 func (mgr *Manager) Add(ctx context.Context, conf config.Module) error {
 	mgr.mu.Lock()
 	defer mgr.mu.Unlock()
-	return mgr.add(ctx, conf, nil)
+	return mgr.add(ctx, conf)
 }
 
-func (mgr *Manager) add(ctx context.Context, conf config.Module, conn *grpc.ClientConn) error {
+func (mgr *Manager) add(ctx context.Context, conf config.Module) error {
 	if mgr.untrustedEnv {
 		return errModularResourcesDisabled
 	}
@@ -174,10 +174,16 @@ func (mgr *Manager) add(ctx context.Context, conf config.Module, conn *grpc.Clie
 	mod := &module{
 		cfg:       conf,
 		dataDir:   moduleDataDir,
-		conn:      conn,
 		resources: map[resource.Name]*addedResource{},
 	}
 
+	if err := mgr.startModule(ctx, mod); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (mgr *Manager) startModule(ctx context.Context, mod *module) error {
 	// add calls startProcess, which can also be called by the OUE handler in the attemptRestart
 	// call. Both of these involve owning a lock, so in unhappy cases of malformed modules
 	// this can lead to a deadlock. To prevent this, we set inStartup here to indicate to
@@ -205,7 +211,6 @@ func (mgr *Manager) add(ctx context.Context, conf config.Module, conn *grpc.Clie
 		return errors.WithMessage(err, "error while starting module "+mod.cfg.Name)
 	}
 
-	// dial will re-use mod.conn if it's non-nil (module being added in a Reconfigure).
 	if err := mod.dial(); err != nil {
 		return errors.WithMessage(err, "error while dialing module "+mod.cfg.Name)
 	}
@@ -215,8 +220,7 @@ func (mgr *Manager) add(ctx context.Context, conf config.Module, conn *grpc.Clie
 	}
 
 	mod.registerResources(mgr, mgr.logger)
-	mgr.modules[conf.Name] = mod
-
+	mgr.modules[mod.cfg.Name] = mod
 	success = true
 	return nil
 }
@@ -236,12 +240,12 @@ func (mgr *Manager) Reconfigure(ctx context.Context, conf config.Module) ([]reso
 		handledResourceNames = append(handledResourceNames, name)
 	}
 
-	if err := mgr.remove(mod, true); err != nil {
+	if err := mgr.closeModule(mod, true); err != nil {
 		// If removal fails, assume all handled resources are orphaned.
 		return handledResourceNames, err
 	}
 
-	if err := mgr.add(ctx, conf, nil); err != nil {
+	if err := mgr.startModule(ctx, mod); err != nil {
 		// If re-addition fails, assume all handled resources are orphaned.
 		return handledResourceNames, err
 	}
@@ -276,7 +280,7 @@ func (mgr *Manager) Remove(modName string) ([]resource.Name, error) {
 	// pendingRemoval for eventual removal after last handled resource has been
 	// closed.
 	if len(handledResources) == 0 {
-		return nil, mgr.remove(mod, false)
+		return nil, mgr.closeModule(mod, false)
 	}
 
 	var orphanedResourceNames []resource.Name
@@ -287,7 +291,7 @@ func (mgr *Manager) Remove(modName string) ([]resource.Name, error) {
 	return orphanedResourceNames, nil
 }
 
-func (mgr *Manager) remove(mod *module, reconfigure bool) error {
+func (mgr *Manager) closeModule(mod *module, reconfigure bool) error {
 	// resource manager should've removed these cleanly if this isn't a reconfigure
 	if !reconfigure && len(mod.resources) != 0 {
 		mgr.logger.Warnw("forcing removal of module with active resources", "module", mod.cfg.Name)
@@ -307,10 +311,8 @@ func (mgr *Manager) remove(mod *module, reconfigure bool) error {
 		return errors.WithMessage(err, "error while stopping module "+mod.cfg.Name)
 	}
 
-	if mod.conn != nil {
-		if err := mod.conn.Close(); err != nil {
-			return errors.WithMessage(err, "error while closing connection from module "+mod.cfg.Name)
-		}
+	if err := mod.conn.Close(); err != nil {
+		return errors.WithMessage(err, "error while closing connection from module "+mod.cfg.Name)
 	}
 
 	mod.deregisterResources()
@@ -354,9 +356,9 @@ func (mgr *Manager) addResource(ctx context.Context, conf resource.Config, deps 
 	apiInfo, ok := resource.LookupGenericAPIRegistration(conf.API)
 	if !ok || apiInfo.RPCClient == nil {
 		mgr.logger.Warnf("no built-in grpc client for modular resource %s", conf.ResourceName())
-		return rdkgrpc.NewForeignResource(conf.ResourceName(), mod.conn), nil
+		return rdkgrpc.NewForeignResource(conf.ResourceName(), &mod.conn), nil
 	}
-	return apiInfo.RPCClient(ctx, mod.conn, "", conf.ResourceName(), mgr.logger)
+	return apiInfo.RPCClient(ctx, &mod.conn, "", conf.ResourceName(), mgr.logger)
 }
 
 // ReconfigureResource updates/reconfigures a modular component with a new configuration.
@@ -426,7 +428,7 @@ func (mgr *Manager) RemoveResource(ctx context.Context, name resource.Name) erro
 
 	// if the module is marked for removal, actually remove it when the final resource is closed
 	if mod.pendingRemoval && len(mod.resources) == 0 {
-		err = multierr.Combine(err, mgr.remove(mod, false))
+		err = multierr.Combine(err, mgr.closeModule(mod, false))
 	}
 	return err
 }
@@ -619,6 +621,12 @@ func (mgr *Manager) newOnUnexpectedExitHandler(mod *module) func(exitCode int) b
 			"exit_code", exitCode,
 		)
 
+		// close client connection, we will re-dial as part of restart attempts.
+		if err := mod.conn.Close(); err != nil {
+			mgr.logger.Warnw("error while closing connection to crashed module, continuing restart attempt",
+				"module", mod.cfg.Name, "error", err)
+		}
+
 		// If attemptRestart returns any orphaned resource names, restart failed,
 		// and we should remove orphaned resources. Since we handle process
 		// restarting ourselves, return false here so goutils knows not to attempt
@@ -699,8 +707,6 @@ func (mgr *Manager) attemptRestart(ctx context.Context, mod *module) []resource.
 		utils.SelectContextOrWait(ctx, time.Duration(attempt)*oueRestartInterval)
 	}
 
-	// dial will re-use mod.conn; old connection can still be used when module
-	// crashes.
 	if err := mod.dial(); err != nil {
 		mgr.logger.Errorw("error while dialing restarted module",
 			"module", mod.cfg.Name, "error", err)
@@ -719,29 +725,28 @@ func (mgr *Manager) attemptRestart(ctx context.Context, mod *module) []resource.
 	return nil
 }
 
-// dial will use m.conn to make a new module service client or Dial m.addr if
-// m.conn is nil.
+// dial will Dial the module and replace the underlying connection (if it exists) in m.conn.
 func (m *module) dial() error {
-	if m.conn == nil {
-		// TODO(PRODUCT-343): session support probably means interceptors here
-		var err error
-		m.conn, err = grpc.Dial(
-			"unix://"+m.addr,
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-			grpc.WithChainUnaryInterceptor(
-				grpc_retry.UnaryClientInterceptor(),
-				operation.UnaryClientInterceptor,
-			),
-			grpc.WithChainStreamInterceptor(
-				grpc_retry.StreamClientInterceptor(),
-				operation.StreamClientInterceptor,
-			),
-		)
-		if err != nil {
-			return errors.WithMessage(err, "module startup failed")
-		}
+	// TODO(PRODUCT-343): session support probably means interceptors here
+	var err error
+	conn, err := grpc.Dial(
+		"unix://"+m.addr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithChainUnaryInterceptor(
+			grpc_retry.UnaryClientInterceptor(),
+			operation.UnaryClientInterceptor,
+		),
+		grpc.WithChainStreamInterceptor(
+			grpc_retry.StreamClientInterceptor(),
+			operation.StreamClientInterceptor,
+		),
+	)
+	if err != nil {
+		return errors.WithMessage(err, "module startup failed")
 	}
-	m.client = pb.NewModuleServiceClient(m.conn)
+
+	m.conn.ReplaceConn(conn)
+	m.client = pb.NewModuleServiceClient(&m.conn)
 	return nil
 }
 
@@ -758,7 +763,7 @@ func (m *module) checkReady(ctx context.Context, parentAddr string, logger loggi
 		}
 
 		if resp.Ready {
-			m.handles, err = modlib.NewHandlerMapFromProto(ctx, resp.Handlermap, m.conn)
+			m.handles, err = modlib.NewHandlerMapFromProto(ctx, resp.Handlermap, &m.conn)
 			return err
 		}
 	}
@@ -772,7 +777,9 @@ func (m *module) startProcess(
 	viamHomeDir string,
 ) error {
 	var err error
-	if m.addr, err = modlib.CreateSocketAddress(filepath.Dir(parentAddr), m.cfg.Name); err != nil {
+	// append a random alpha string to the module name while creating a socket address to avoid conflicts
+	if m.addr, err = modlib.CreateSocketAddress(
+		filepath.Dir(parentAddr), fmt.Sprintf("%s-%s", m.cfg.Name, utils.RandomAlphaString(5))); err != nil {
 		return err
 	}
 
@@ -916,14 +923,12 @@ func (m *module) cleanupAfterStartupFailure(mgr *Manager, afterCrash bool) {
 		}
 		mgr.logger.Errorw(msg, "module", m.cfg.Name, "error", err)
 	}
-	if m.conn != nil {
-		if err := m.conn.Close(); err != nil {
-			msg := "error while closing connection to module that failed to start"
-			if afterCrash {
-				msg = "error while closing connection to crashed module"
-			}
-			mgr.logger.Errorw(msg, "module", m.cfg.Name, "error", err)
+	if err := m.conn.Close(); err != nil {
+		msg := "error while closing connection to module that failed to start"
+		if afterCrash {
+			msg = "error while closing connection to crashed module"
 		}
+		mgr.logger.Errorw(msg, "module", m.cfg.Name, "error", err)
 	}
 
 	// Remove module from rMap and mgr.modules if startup failure was after crash.

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -250,6 +250,8 @@ func (mgr *Manager) Reconfigure(ctx context.Context, conf config.Module) ([]reso
 		return handledResourceNames, err
 	}
 
+	mgr.logger.Debugw("successfully reconfigured and reconnected to module", "module", mod.cfg.Name, "module address", mod.addr)
+
 	// add old module process' resources to new module; warn if new module cannot
 	// handle old resource and consider that resource orphaned.
 	var orphanedResourceNames []resource.Name
@@ -744,7 +746,6 @@ func (m *module) dial() error {
 	if err != nil {
 		return errors.WithMessage(err, "module startup failed")
 	}
-
 	m.conn.ReplaceConn(conn)
 	m.client = pb.NewModuleServiceClient(&m.conn)
 	return nil

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -782,6 +782,7 @@ func (m *module) startProcess(
 ) error {
 	var err error
 	// append a random alpha string to the module name while creating a socket address to avoid conflicts
+	// with old versions of the module.
 	if m.addr, err = modlib.CreateSocketAddress(
 		filepath.Dir(parentAddr), fmt.Sprintf("%s-%s", m.cfg.Name, utils.RandomAlphaString(5))); err != nil {
 		return err

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -73,12 +73,6 @@ func TestModManagerFunctions(t *testing.T) {
 	err = mod.dial()
 	test.That(t, err, test.ShouldBeNil)
 
-	// check that dial can re-use connections.
-	oldConn := &mod.conn
-	err = mod.dial()
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, &mod.conn, test.ShouldEqual, oldConn)
-
 	err = mod.checkReady(ctx, parentAddr, logger)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -224,7 +218,7 @@ func TestModManagerFunctions(t *testing.T) {
 	test.That(t, ok, test.ShouldBeFalse)
 	_, err = counter.DoCommand(ctx, map[string]interface{}{"command": "get"})
 	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, "the client connection is closing")
+	test.That(t, err.Error(), test.ShouldContainSubstring, "not connected")
 
 	err = counter.Close(ctx)
 	test.That(t, err, test.ShouldBeNil)
@@ -523,8 +517,7 @@ func TestModuleReloading(t *testing.T) {
 		test.That(t, ok, test.ShouldBeFalse)
 		_, err = h.DoCommand(ctx, map[string]interface{}{"command": "echo"})
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring,
-			"connection is closing")
+		test.That(t, err.Error(), test.ShouldContainSubstring, "not connected")
 
 		err = mgr.Close(ctx)
 		test.That(t, err, test.ShouldBeNil)

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -74,10 +74,10 @@ func TestModManagerFunctions(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	// check that dial can re-use connections.
-	oldConn := mod.conn
+	oldConn := &mod.conn
 	err = mod.dial()
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, mod.conn, test.ShouldEqual, oldConn)
+	test.That(t, &mod.conn, test.ShouldEqual, oldConn)
 
 	err = mod.checkReady(ctx, parentAddr, logger)
 	test.That(t, err, test.ShouldBeNil)

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -87,7 +87,6 @@ func TestModManagerFunctions(t *testing.T) {
 	_, ok = resource.LookupRegistration(generic.API, myCounterModel)
 	test.That(t, ok, test.ShouldBeFalse)
 
-	test.That(t, mgr.Close(ctx), test.ShouldBeNil)
 	test.That(t, mod.process.Stop(), test.ShouldBeNil)
 
 	modEnv := mod.getFullEnvironment(viamHomeTemp)
@@ -115,6 +114,9 @@ func TestModManagerFunctions(t *testing.T) {
 	// check that we're still able to use the old client
 	_, err = oldClient.Ready(ctx, &v1.ReadyRequest{ParentAddress: parentAddr})
 	test.That(t, err, test.ShouldBeNil)
+
+	test.That(t, mod.process.Stop(), test.ShouldBeNil)
+	test.That(t, mgr.Close(ctx), test.ShouldBeNil)
 
 	t.Log("test AddModule")
 	mgr = NewManager(ctx, parentAddr, logger, modmanageroptions.Options{UntrustedEnv: false})

--- a/module/module.go
+++ b/module/module.go
@@ -104,7 +104,7 @@ func (h HandlerMap) ToProto() *pb.HandlerMap {
 }
 
 // NewHandlerMapFromProto converts protobuf to HandlerMap.
-func NewHandlerMapFromProto(ctx context.Context, pMap *pb.HandlerMap, conn *grpc.ClientConn) (HandlerMap, error) {
+func NewHandlerMapFromProto(ctx context.Context, pMap *pb.HandlerMap, conn rpc.ClientConn) (HandlerMap, error) {
 	hMap := make(HandlerMap)
 	refClient := grpcreflect.NewClientV1Alpha(ctx, reflectpb.NewServerReflectionClient(conn))
 	defer refClient.Reset()


### PR DESCRIPTION
fixes by creating a unique sock address for each module lifetime, and adding a reconfigurable client connection to swap for existing connection/clients