### PR TITLE
[RSDK-6178] Don't allow extremely large fake camera resolutions.

### DIFF
--- a/components/camera/fake/camera.go
+++ b/components/camera/fake/camera.go
@@ -19,7 +19,10 @@ import (
 	"go.viam.com/rdk/rimage/transform"
 )
 
-var model = resource.DefaultModelFamily.WithModel("fake")
+var (
+	model = resource.DefaultModelFamily.WithModel("fake")
+	
+)
 
 const (
 	initialWidth  = 1280

--- a/components/camera/fake/camera.go
+++ b/components/camera/fake/camera.go
@@ -19,10 +19,7 @@ import (
 	"go.viam.com/rdk/rimage/transform"
 )
 
-var (
-	model = resource.DefaultModelFamily.WithModel("fake")
-	
-)
+var model = resource.DefaultModelFamily.WithModel("fake")
 
 const (
 	initialWidth  = 1280
@@ -78,7 +75,7 @@ type Config struct {
 // Validate checks that the config attributes are valid for a fake camera.
 func (conf *Config) Validate(path string) ([]string, error) {
 	if conf.Height > 10000 || conf.Width > 10000 {
-		return nil, errors.New("maximum supported pixel height or width for fake cameras is 4000 pixels")
+		return nil, errors.New("maximum supported pixel height or width for fake cameras is 10000 pixels")
 	}
 
 	if conf.Height < 0 || conf.Width < 0 {

--- a/components/camera/fake/camera.go
+++ b/components/camera/fake/camera.go
@@ -75,11 +75,11 @@ type Config struct {
 // Validate checks that the config attributes are valid for a fake camera.
 func (conf *Config) Validate(path string) ([]string, error) {
 	if conf.Height > 10000 || conf.Width > 10000 {
-		return nil, errors.Errorf("maximum supported pixel height or width for fake cameras is 4000 pixels")
+		return nil, errors.New("maximum supported pixel height or width for fake cameras is 4000 pixels")
 	}
 
 	if conf.Height < 0 || conf.Width < 0 {
-		return nil, errors.Errorf("cannot use negative pixel height and width for fake cameras")
+		return nil, errors.New("cannot use negative pixel height and width for fake cameras")
 	}
 
 	if conf.Height%2 != 0 {

--- a/components/camera/fake/camera.go
+++ b/components/camera/fake/camera.go
@@ -30,21 +30,14 @@ func init() {
 	resource.RegisterComponent(
 		camera.API,
 		model,
-		resource.Registration[camera.Camera, *Config]{
-			Constructor: func(
-				ctx context.Context,
-				_ resource.Dependencies,
-				cfg resource.Config,
-				logger logging.Logger,
-			) (camera.Camera, error) {
-				return NewCamera(ctx, cfg, logger)
-			},
-		})
+		resource.Registration[camera.Camera, *Config]{Constructor: NewCamera},
+	)
 }
 
 // NewCamera returns a new fake camera.
 func NewCamera(
 	ctx context.Context,
+	_ resource.Dependencies,
 	conf resource.Config,
 	logger logging.Logger,
 ) (camera.Camera, error) {
@@ -81,12 +74,22 @@ type Config struct {
 
 // Validate checks that the config attributes are valid for a fake camera.
 func (conf *Config) Validate(path string) ([]string, error) {
+	if conf.Height > 10000 || conf.Width > 10000 {
+		return nil, errors.Errorf("maximum supported pixel height or width for fake cameras is 4000 pixels")
+	}
+
+	if conf.Height < 0 || conf.Width < 0 {
+		return nil, errors.Errorf("cannot use negative pixel height and width for fake cameras")
+	}
+
 	if conf.Height%2 != 0 {
 		return nil, errors.Errorf("odd-number resolutions cannot be rendered, cannot use a height of %d", conf.Height)
 	}
+
 	if conf.Width%2 != 0 {
 		return nil, errors.Errorf("odd-number resolutions cannot be rendered, cannot use a width of %d", conf.Width)
 	}
+
 	return nil, nil
 }
 

--- a/components/camera/fake/camera_test.go
+++ b/components/camera/fake/camera_test.go
@@ -100,7 +100,6 @@ func cameraTest(
 }
 
 func TestCameraValidationAndCreation(t *testing.T) {
-
 	attrCfg := &Config{Width: 200000, Height: 10}
 	cfg := resource.Config{
 		Name:                "test1",
@@ -141,4 +140,3 @@ func TestCameraValidationAndCreation(t *testing.T) {
 
 	test.That(t, camera.Close(context.Background()), test.ShouldBeNil)
 }
-

--- a/components/camera/fake/camera_test.go
+++ b/components/camera/fake/camera_test.go
@@ -7,6 +7,8 @@ import (
 	"go.viam.com/test"
 
 	"go.viam.com/rdk/components/camera"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/rimage/transform"
 )
 
@@ -96,3 +98,47 @@ func cameraTest(
 	err = cam.Close(context.Background())
 	test.That(t, err, test.ShouldBeNil)
 }
+
+func TestCameraValidationAndCreation(t *testing.T) {
+
+	attrCfg := &Config{Width: 200000, Height: 10}
+	cfg := resource.Config{
+		Name:                "test1",
+		API:                 camera.API,
+		Model:               model,
+		ConvertedAttributes: attrCfg,
+	}
+
+	// error with a ridiculously large pixel value
+	deps, err := cfg.Validate("", camera.API.SubtypeName)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, deps, test.ShouldBeNil)
+
+	// error with a zero pixel value
+	attrCfg.Width = 0
+	cfg.ConvertedAttributes = attrCfg
+	deps, err = cfg.Validate("", camera.API.SubtypeName)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, deps, test.ShouldBeNil)
+
+	// error with a negative pixel value
+	attrCfg.Width = -20
+	cfg.ConvertedAttributes = attrCfg
+	deps, err = cfg.Validate("", camera.API.SubtypeName)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, deps, test.ShouldBeNil)
+
+	attrCfg.Width = 10
+	cfg.ConvertedAttributes = attrCfg
+	deps, err = cfg.Validate("", camera.API.SubtypeName)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, deps, test.ShouldBeNil)
+
+	logger := logging.NewTestLogger(t)
+	camera, err := NewCamera(context.Background(), nil, cfg, logger)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, camera, test.ShouldNotBeNil)
+
+	test.That(t, camera.Close(context.Background()), test.ShouldBeNil)
+}
+

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -159,7 +159,7 @@ func setupInjectRobot(logger logging.Logger) *inject.Robot {
 				case camera.API:
 					conf := resource.NewEmptyConfig(name, resource.DefaultModelFamily.WithModel("fake"))
 					conf.ConvertedAttributes = &fakecamera.Config{}
-					return fakecamera.NewCamera(context.Background(), conf, logger)
+					return fakecamera.NewCamera(context.Background(), resource.Dependencies{}, conf, logger)
 				case gripper.API:
 					return &fakegripper.Gripper{Named: name.AsNamed()}, nil
 				case input.API:

--- a/services/motion/explore/explore_utils_test.go
+++ b/services/motion/explore/explore_utils_test.go
@@ -79,7 +79,7 @@ func createFakeCamera(ctx context.Context, logger logging.Logger, name string) (
 			Height: 1000,
 		},
 	}
-	return cameraFake.NewCamera(ctx, fakeCameraCfg, logger)
+	return cameraFake.NewCamera(ctx, resource.Dependencies{}, fakeCameraCfg, logger)
 }
 
 // createMockVisionService instantiates a mock vision service with a custom version of GetObjectPointCloud that returns


### PR DESCRIPTION
I confirmed that a resolution of 40000 pixels for width and height causes viam-server to crash on a mac, and no image to be shown on the RC card.

With the new limits in the Validate field we at least guard against bringing up the server and getting it into a state where it cannot shut down cleanly.

Camera can show images with the config:
```
{
  "width": 10000,
  "height": 10000
}
```

<img width="645" alt="Screenshot 2024-02-26 at 19 10 47" src="https://github.com/viamrobotics/rdk/assets/35934754/e7ba0e9d-1e8f-4edc-b92c-0d3d9cb6bb30">

Complains when we go above 10000 and does not show or build the resource
<img width="1447" alt="Screenshot 2024-02-26 at 18 37 46" src="https://github.com/viamrobotics/rdk/assets/35934754/d3b0d8f2-e93c-49f7-ad13-d48f18109d72">

And viam server stops cleanly after a restart or SIGINT.
![Screenshot 2024-02-26 at 19 12 43](https://github.com/viamrobotics/rdk/assets/35934754/ce7089a1-2683-45ad-9fce-e859d350dae0)


Without this Validate check, allowing a fake camera to construct itself with just a fake camera configured at best causes the server to hang on shutdown, or crashes viam-server according to the QA testers.

<img width="1185" alt="Screenshot 2024-02-26 at 19 14 26" src="https://github.com/viamrobotics/rdk/assets/35934754/da7bd982-be99-4298-98ca-59a7552e7287">
