### PR TITLE
RSDK-6751: Add preprocessing options to input image for the mlmodel vision service

### DIFF
--- a/rimage/image_file.go
+++ b/rimage/image_file.go
@@ -400,15 +400,22 @@ func IsImageFile(fn string) bool {
 
 // ImageToUInt8Buffer reads an image into a byte slice in the most common sense way.
 // Left to right like a book; R, then G, then B. No funny stuff. Assumes values should be between 0-255.
-func ImageToUInt8Buffer(img image.Image) []byte {
+// if  changeToBGR is true, then R and B get swapped.
+func ImageToUInt8Buffer(img image.Image, changeToBGR bool) []byte {
 	output := make([]byte, img.Bounds().Dx()*img.Bounds().Dy()*3)
 	for y := 0; y < img.Bounds().Dy(); y++ {
 		for x := 0; x < img.Bounds().Dx(); x++ {
 			r, g, b, a := img.At(x, y).RGBA()
 			rr, gg, bb, _ := rgbaTo8Bit(r, g, b, a)
-			output[(y*img.Bounds().Dx()+x)*3+0] = rr
-			output[(y*img.Bounds().Dx()+x)*3+1] = gg
-			output[(y*img.Bounds().Dx()+x)*3+2] = bb
+			if changeToBGR {
+				output[(y*img.Bounds().Dx()+x)*3+0] = bb
+				output[(y*img.Bounds().Dx()+x)*3+1] = gg
+				output[(y*img.Bounds().Dx()+x)*3+2] = rr
+			} else {
+				output[(y*img.Bounds().Dx()+x)*3+0] = rr
+				output[(y*img.Bounds().Dx()+x)*3+1] = gg
+				output[(y*img.Bounds().Dx()+x)*3+2] = bb
+			}
 		}
 	}
 	return output
@@ -416,15 +423,35 @@ func ImageToUInt8Buffer(img image.Image) []byte {
 
 // ImageToFloatBuffer reads an image into a byte slice (buffer) the most common sense way.
 // Left to right like a book; R, then G, then B. No funny stuff. Assumes values between -1 and 1.
-func ImageToFloatBuffer(img image.Image) []float32 {
+// if  changeToBGR is true, then R and B get swapped.
+// if meanValue and stdDev are not length 0, use those instead to normalize the bytes.
+func ImageToFloatBuffer(img image.Image, changeToBGR bool, meanValue, stdDev []float32) []float32 {
 	output := make([]float32, img.Bounds().Dx()*img.Bounds().Dy()*3)
+	if len(meanValue) == 0 {
+		meanValue = []float32{0.5, 0.5, 0.5}
+	}
+	if len(stdDev) == 0 {
+		stdDev = []float32{0.5, 0.5, 0.5}
+	}
 	for y := 0; y < img.Bounds().Dy(); y++ {
 		for x := 0; x < img.Bounds().Dx(); x++ {
 			r, g, b, a := img.At(x, y).RGBA()
-			rr, gg, bb := float32(r)/float32(a)*2-1, float32(g)/float32(a)*2-1, float32(b)/float32(a)*2-1
-			output[(y*img.Bounds().Dx()+x)*3+0] = rr
-			output[(y*img.Bounds().Dx()+x)*3+1] = gg
-			output[(y*img.Bounds().Dx()+x)*3+2] = bb
+			r8, g8, b8, _ := rgbaTo8Bit(r, g, b, a)
+			if changeToBGR {
+				bb := ((float32(b8) / 255.0) - meanValue[0]) / stdDev[0]
+				gg := ((float32(g8) / 255.0) - meanValue[1]) / stdDev[1]
+				rr := ((float32(r8) / 255.0) - meanValue[2]) / stdDev[2]
+				output[(y*img.Bounds().Dx()+x)*3+0] = bb
+				output[(y*img.Bounds().Dx()+x)*3+1] = gg
+				output[(y*img.Bounds().Dx()+x)*3+2] = rr
+			} else {
+				rr := ((float32(r8) / 255.0) - meanValue[0]) / stdDev[0]
+				gg := ((float32(g8) / 255.0) - meanValue[1]) / stdDev[1]
+				bb := ((float32(b8) / 255.0) - meanValue[2]) / stdDev[2]
+				output[(y*img.Bounds().Dx()+x)*3+0] = rr
+				output[(y*img.Bounds().Dx()+x)*3+1] = gg
+				output[(y*img.Bounds().Dx()+x)*3+2] = bb
+			}
 		}
 	}
 	return output

--- a/rimage/image_file.go
+++ b/rimage/image_file.go
@@ -458,7 +458,7 @@ func ImageToFloatBuffer(img image.Image, changeToBGR bool, meanValue, stdDev []f
 }
 
 // rgbaTo8Bit converts the uint32s from RGBA() to uint8s.
-func rgbaTo8Bit(r, g, b, a uint32) (rr, gg, bb, aa uint8) {
+func rgbaTo8Bit(r, g, b, a uint32) (rr, gg, bb, aa uint8) { //nolint:unparam
 	r >>= 8
 	rr = uint8(r)
 	g >>= 8

--- a/services/mlmodel/tflitecpu/tflite_cpu_test.go
+++ b/services/mlmodel/tflitecpu/tflite_cpu_test.go
@@ -65,7 +65,7 @@ func TestTFLiteCPUDetector(t *testing.T) {
 	pic, err := rimage.NewImageFromFile(artifact.MustPath("vision/tflite/dogscute.jpeg"))
 	test.That(t, err, test.ShouldBeNil)
 	resized := resize.Resize(uint(got.metadata.Inputs[0].Shape[1]), uint(got.metadata.Inputs[0].Shape[2]), pic, resize.Bilinear)
-	imgBytes := rimage.ImageToUInt8Buffer(resized)
+	imgBytes := rimage.ImageToUInt8Buffer(resized, false)
 	test.That(t, imgBytes, test.ShouldNotBeNil)
 	inputMap := ml.Tensors{}
 	inputMap["image"] = tensor.New(
@@ -126,7 +126,7 @@ func TestTFLiteCPUClassifier(t *testing.T) {
 	pic, err := rimage.NewImageFromFile(artifact.MustPath("vision/tflite/lion.jpeg"))
 	test.That(t, err, test.ShouldBeNil)
 	resized := resize.Resize(uint(got.metadata.Inputs[0].Shape[1]), uint(got.metadata.Inputs[0].Shape[2]), pic, resize.Bilinear)
-	imgBytes := rimage.ImageToUInt8Buffer(resized)
+	imgBytes := rimage.ImageToUInt8Buffer(resized, false)
 	test.That(t, imgBytes, test.ShouldNotBeNil)
 	inputMap := ml.Tensors{}
 	inputMap["images"] = tensor.New(
@@ -224,7 +224,7 @@ func TestTFLiteCPUClient(t *testing.T) {
 	pic, err := rimage.NewImageFromFile(artifact.MustPath("vision/tflite/dogscute.jpeg"))
 	test.That(t, err, test.ShouldBeNil)
 	resized := resize.Resize(320, 320, pic, resize.Bilinear)
-	imgBytes := rimage.ImageToUInt8Buffer(resized)
+	imgBytes := rimage.ImageToUInt8Buffer(resized, false)
 	test.That(t, imgBytes, test.ShouldNotBeNil)
 	inputMap := ml.Tensors{}
 	inputMap["image"] = tensor.New(

--- a/services/vision/mlvision/classifier.go
+++ b/services/vision/mlvision/classifier.go
@@ -22,7 +22,10 @@ const (
 	classifierInputName       = "image"
 )
 
-func attemptToBuildClassifier(mlm mlmodel.Service, inNameMap, outNameMap *sync.Map, params *MLModelConfig) (classification.Classifier, error) {
+func attemptToBuildClassifier(mlm mlmodel.Service,
+	inNameMap, outNameMap *sync.Map,
+	params *MLModelConfig,
+) (classification.Classifier, error) {
 	md, err := mlm.Metadata(context.Background())
 	if err != nil {
 		return nil, errors.New("could not get any metadata")

--- a/services/vision/mlvision/classifier.go
+++ b/services/vision/mlvision/classifier.go
@@ -71,12 +71,12 @@ func attemptToBuildClassifier(mlm mlmodel.Service, inNameMap, outNameMap *sync.M
 		case UInt8:
 			inMap[inputName] = tensor.New(
 				tensor.WithShape(1, resized.Bounds().Dy(), resized.Bounds().Dx(), 3),
-				tensor.WithBacking(rimage.ImageToUInt8Buffer(resized, params.isBGR)),
+				tensor.WithBacking(rimage.ImageToUInt8Buffer(resized, params.IsBGR)),
 			)
 		case Float32:
 			inMap[inputName] = tensor.New(
 				tensor.WithShape(1, resized.Bounds().Dy(), resized.Bounds().Dx(), 3),
-				tensor.WithBacking(rimage.ImageToFloatBuffer(resized, params.isBGR, params.MeanValue, params.StdDev)),
+				tensor.WithBacking(rimage.ImageToFloatBuffer(resized, params.IsBGR, params.MeanValue, params.StdDev)),
 			)
 		default:
 			return nil, errors.Errorf("invalid input type of %s. try uint8 or float32", inType)

--- a/services/vision/mlvision/classifier.go
+++ b/services/vision/mlvision/classifier.go
@@ -22,7 +22,7 @@ const (
 	classifierInputName       = "image"
 )
 
-func attemptToBuildClassifier(mlm mlmodel.Service, inNameMap, outNameMap *sync.Map) (classification.Classifier, error) {
+func attemptToBuildClassifier(mlm mlmodel.Service, inNameMap, outNameMap *sync.Map, params *MLModelConfig) (classification.Classifier, error) {
 	md, err := mlm.Metadata(context.Background())
 	if err != nil {
 		return nil, errors.New("could not get any metadata")
@@ -71,12 +71,12 @@ func attemptToBuildClassifier(mlm mlmodel.Service, inNameMap, outNameMap *sync.M
 		case UInt8:
 			inMap[inputName] = tensor.New(
 				tensor.WithShape(1, resized.Bounds().Dy(), resized.Bounds().Dx(), 3),
-				tensor.WithBacking(rimage.ImageToUInt8Buffer(resized)),
+				tensor.WithBacking(rimage.ImageToUInt8Buffer(resized, params.isBGR)),
 			)
 		case Float32:
 			inMap[inputName] = tensor.New(
 				tensor.WithShape(1, resized.Bounds().Dy(), resized.Bounds().Dx(), 3),
-				tensor.WithBacking(rimage.ImageToFloatBuffer(resized)),
+				tensor.WithBacking(rimage.ImageToFloatBuffer(resized, params.isBGR, params.MeanValue, params.StdDev)),
 			)
 		default:
 			return nil, errors.Errorf("invalid input type of %s. try uint8 or float32", inType)

--- a/services/vision/mlvision/detector.go
+++ b/services/vision/mlvision/detector.go
@@ -26,7 +26,10 @@ const (
 	detectorInputName    = "image"
 )
 
-func attemptToBuildDetector(mlm mlmodel.Service, inNameMap, outNameMap *sync.Map, params *MLModelConfig) (objectdetection.Detector, error) {
+func attemptToBuildDetector(mlm mlmodel.Service,
+	inNameMap, outNameMap *sync.Map,
+	params *MLModelConfig,
+) (objectdetection.Detector, error) {
 	md, err := mlm.Metadata(context.Background())
 	if err != nil {
 		return nil, errors.New("could not get any metadata")

--- a/services/vision/mlvision/detector.go
+++ b/services/vision/mlvision/detector.go
@@ -26,7 +26,7 @@ const (
 	detectorInputName    = "image"
 )
 
-func attemptToBuildDetector(mlm mlmodel.Service, inNameMap, outNameMap *sync.Map, paramBoxOrder []int) (objectdetection.Detector, error) {
+func attemptToBuildDetector(mlm mlmodel.Service, inNameMap, outNameMap *sync.Map, params *MLModelConfig) (objectdetection.Detector, error) {
 	md, err := mlm.Metadata(context.Background())
 	if err != nil {
 		return nil, errors.New("could not get any metadata")
@@ -40,8 +40,8 @@ func attemptToBuildDetector(mlm mlmodel.Service, inNameMap, outNameMap *sync.Map
 	inType := md.Inputs[0].DataType
 	labels := getLabelsFromMetadata(md)
 	var boxOrder []int
-	if len(paramBoxOrder) == 4 {
-		boxOrder = paramBoxOrder
+	if len(params.BoxOrder) == 4 {
+		boxOrder = params.BoxOrder
 	} else {
 		boxOrder, err = getBoxOrderFromMetadata(md)
 		if err != nil || len(boxOrder) < 4 {
@@ -86,12 +86,12 @@ func attemptToBuildDetector(mlm mlmodel.Service, inNameMap, outNameMap *sync.Map
 		case UInt8:
 			inMap[inputName] = tensor.New(
 				tensor.WithShape(1, resized.Bounds().Dy(), resized.Bounds().Dx(), 3),
-				tensor.WithBacking(rimage.ImageToUInt8Buffer(resized)),
+				tensor.WithBacking(rimage.ImageToUInt8Buffer(resized, params.isBGR)),
 			)
 		case Float32:
 			inMap[inputName] = tensor.New(
 				tensor.WithShape(1, resized.Bounds().Dy(), resized.Bounds().Dx(), 3),
-				tensor.WithBacking(rimage.ImageToFloatBuffer(resized)),
+				tensor.WithBacking(rimage.ImageToFloatBuffer(resized, params.isBGR, params.MeanValue, params.StdDev)),
 			)
 		default:
 			return nil, errors.Errorf("invalid input type of %s. try uint8 or float32", inType)

--- a/services/vision/mlvision/detector.go
+++ b/services/vision/mlvision/detector.go
@@ -86,12 +86,12 @@ func attemptToBuildDetector(mlm mlmodel.Service, inNameMap, outNameMap *sync.Map
 		case UInt8:
 			inMap[inputName] = tensor.New(
 				tensor.WithShape(1, resized.Bounds().Dy(), resized.Bounds().Dx(), 3),
-				tensor.WithBacking(rimage.ImageToUInt8Buffer(resized, params.isBGR)),
+				tensor.WithBacking(rimage.ImageToUInt8Buffer(resized, params.IsBGR)),
 			)
 		case Float32:
 			inMap[inputName] = tensor.New(
 				tensor.WithShape(1, resized.Bounds().Dy(), resized.Bounds().Dx(), 3),
-				tensor.WithBacking(rimage.ImageToFloatBuffer(resized, params.isBGR, params.MeanValue, params.StdDev)),
+				tensor.WithBacking(rimage.ImageToFloatBuffer(resized, params.IsBGR, params.MeanValue, params.StdDev)),
 			)
 		default:
 			return nil, errors.Errorf("invalid input type of %s. try uint8 or float32", inType)

--- a/services/vision/mlvision/ml_model.go
+++ b/services/vision/mlvision/ml_model.go
@@ -62,12 +62,30 @@ type MLModelConfig struct {
 	RemapInputNames  map[string]string `json:"remap_input_names"`
 	RemapOutputNames map[string]string `json:"remap_output_names"`
 	BoxOrder         []int             `json:"xmin_ymin_xmax_ymax_order"`
+	MeanValue        []float32         `json:"input_image_mean_value"`
+	StdDev           []float32         `json:"input_image_std_dev"`
+	isBGR            bool              `json:"input_image_bgr"`
 }
 
 // Validate will add the ModelName as an implicit dependency to the robot.
 func (conf *MLModelConfig) Validate(path string) ([]string, error) {
 	if conf.ModelName == "" {
 		return nil, errors.New("mlmodel_name cannot be empty")
+	}
+	if len(conf.MeanValue) != 0 {
+		if len(conf.MeanValue) < 3 {
+			return nil, errors.New("input_image_mean_value attribute must have at least 3 values")
+		}
+	}
+	if len(conf.StdDev) != 0 {
+		if len(conf.StdDev) < 3 {
+			return nil, errors.New("input_image_std_dev attribute must have at least 3 values")
+		}
+	}
+	for _, v := range conf.StdDev {
+		if v == 0.0 {
+			return nil, errors.New("input_image_std_dev is not allowed to have 0 values, will cause division by 0")
+		}
 	}
 	return []string{conf.ModelName}, nil
 }
@@ -119,7 +137,7 @@ func registerMLModelVisionService(
 		}
 	}
 	var errList []error
-	classifierFunc, err := attemptToBuildClassifier(mlm, inNameMap, outNameMap)
+	classifierFunc, err := attemptToBuildClassifier(mlm, inNameMap, outNameMap, params)
 	if err != nil {
 		logger.CDebugw(ctx, "unable to use ml model as a classifier, will attempt to evaluate as"+
 			"detector and segmenter", "model", params.ModelName, "error", err)
@@ -135,7 +153,7 @@ func registerMLModelVisionService(
 		}
 	}
 
-	detectorFunc, err := attemptToBuildDetector(mlm, inNameMap, outNameMap, params.BoxOrder)
+	detectorFunc, err := attemptToBuildDetector(mlm, inNameMap, outNameMap, params)
 	if err != nil {
 		logger.CDebugw(ctx, "unable to use ml model as a detector, will attempt to evaluate as 3D segmenter",
 			"model", params.ModelName, "error", err)

--- a/services/vision/mlvision/ml_model.go
+++ b/services/vision/mlvision/ml_model.go
@@ -62,9 +62,12 @@ type MLModelConfig struct {
 	RemapInputNames  map[string]string `json:"remap_input_names"`
 	RemapOutputNames map[string]string `json:"remap_output_names"`
 	BoxOrder         []int             `json:"xmin_ymin_xmax_ymax_order"`
-	MeanValue        []float32         `json:"input_image_mean_value"`
-	StdDev           []float32         `json:"input_image_std_dev"`
-	IsBGR            bool              `json:"input_image_bgr"`
+	// optional parameter used to normalize the input image if the ML Model expects it
+	MeanValue []float32 `json:"input_image_mean_value"`
+	// optional parameter used to normalize the input image if the ML Model expects it
+	StdDev []float32 `json:"input_image_std_dev"`
+	// optional parameter used to change the input image to BGR format if the ML Model expects it
+	IsBGR bool `json:"input_image_bgr"`
 }
 
 // Validate will add the ModelName as an implicit dependency to the robot.
@@ -74,12 +77,12 @@ func (conf *MLModelConfig) Validate(path string) ([]string, error) {
 	}
 	if len(conf.MeanValue) != 0 {
 		if len(conf.MeanValue) < 3 {
-			return nil, errors.New("input_image_mean_value attribute must have at least 3 values")
+			return nil, errors.New("input_image_mean_value attribute must have at least 3 values, one for each color channel")
 		}
 	}
 	if len(conf.StdDev) != 0 {
 		if len(conf.StdDev) < 3 {
-			return nil, errors.New("input_image_std_dev attribute must have at least 3 values")
+			return nil, errors.New("input_image_std_dev attribute must have at least 3 values, one for each color channel")
 		}
 	}
 	for _, v := range conf.StdDev {

--- a/services/vision/mlvision/ml_model.go
+++ b/services/vision/mlvision/ml_model.go
@@ -64,7 +64,7 @@ type MLModelConfig struct {
 	BoxOrder         []int             `json:"xmin_ymin_xmax_ymax_order"`
 	MeanValue        []float32         `json:"input_image_mean_value"`
 	StdDev           []float32         `json:"input_image_std_dev"`
-	isBGR            bool              `json:"input_image_bgr"`
+	IsBGR            bool              `json:"input_image_bgr"`
 }
 
 // Validate will add the ModelName as an implicit dependency to the robot.

--- a/services/vision/mlvision/ml_model_test.go
+++ b/services/vision/mlvision/ml_model_test.go
@@ -93,14 +93,15 @@ func TestAddingIncorrectModelTypeToModel(t *testing.T) {
 
 	inNameMap := &sync.Map{}
 	outNameMap := &sync.Map{}
-	classifier, err := attemptToBuildClassifier(mlm, inNameMap, outNameMap)
+	conf := &MLModelConfig{}
+	classifier, err := attemptToBuildClassifier(mlm, inNameMap, outNameMap, conf)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, classifier, test.ShouldNotBeNil)
 
 	err = checkIfClassifierWorks(ctx, classifier)
 	test.That(t, err, test.ShouldNotBeNil)
 
-	detector, err := attemptToBuildDetector(mlm, inNameMap, outNameMap, nil)
+	detector, err := attemptToBuildDetector(mlm, inNameMap, outNameMap, conf)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, detector, test.ShouldNotBeNil)
 
@@ -114,7 +115,7 @@ func TestAddingIncorrectModelTypeToModel(t *testing.T) {
 
 	inNameMap = &sync.Map{}
 	outNameMap = &sync.Map{}
-	classifier, err = attemptToBuildClassifier(mlm, inNameMap, outNameMap)
+	classifier, err = attemptToBuildClassifier(mlm, inNameMap, outNameMap, conf)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, classifier, test.ShouldNotBeNil)
 
@@ -124,7 +125,7 @@ func TestAddingIncorrectModelTypeToModel(t *testing.T) {
 	mlm, err = getTestMlModel(modelLocClassifier)
 	test.That(t, err, test.ShouldBeNil)
 
-	detector, err = attemptToBuildDetector(mlm, inNameMap, outNameMap, nil)
+	detector, err = attemptToBuildDetector(mlm, inNameMap, outNameMap, conf)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, detector, test.ShouldNotBeNil)
 
@@ -167,7 +168,8 @@ func TestNewMLDetector(t *testing.T) {
 
 	inNameMap := &sync.Map{}
 	outNameMap := &sync.Map{}
-	gotDetector, err := attemptToBuildDetector(out, inNameMap, outNameMap, nil)
+	conf := &MLModelConfig{}
+	gotDetector, err := attemptToBuildDetector(out, inNameMap, outNameMap, conf)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotDetector, test.ShouldNotBeNil)
 
@@ -193,7 +195,8 @@ func TestNewMLDetector(t *testing.T) {
 	test.That(t, outNL, test.ShouldNotBeNil)
 	inNameMap = &sync.Map{}
 	outNameMap = &sync.Map{}
-	gotDetectorNL, err := attemptToBuildDetector(outNL, inNameMap, outNameMap, nil)
+	conf = &MLModelConfig{}
+	gotDetectorNL, err := attemptToBuildDetector(outNL, inNameMap, outNameMap, conf)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotDetectorNL, test.ShouldNotBeNil)
 	gotDetectionsNL, err := gotDetectorNL(ctx, pic)
@@ -244,7 +247,8 @@ func TestNewMLClassifier(t *testing.T) {
 
 	inNameMap := &sync.Map{}
 	outNameMap := &sync.Map{}
-	gotClassifier, err := attemptToBuildClassifier(out, inNameMap, outNameMap)
+	conf := &MLModelConfig{}
+	gotClassifier, err := attemptToBuildClassifier(out, inNameMap, outNameMap, conf)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotClassifier, test.ShouldNotBeNil)
 
@@ -264,7 +268,8 @@ func TestNewMLClassifier(t *testing.T) {
 	test.That(t, outNL, test.ShouldNotBeNil)
 	inNameMap = &sync.Map{}
 	outNameMap = &sync.Map{}
-	gotClassifierNL, err := attemptToBuildClassifier(outNL, inNameMap, outNameMap)
+	conf = &MLModelConfig{}
+	gotClassifierNL, err := attemptToBuildClassifier(outNL, inNameMap, outNameMap, conf)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotClassifierNL, test.ShouldNotBeNil)
 	gotClassificationsNL, err := gotClassifierNL(ctx, pic)
@@ -308,7 +313,8 @@ func TestMLDetectorWithNoCategory(t *testing.T) {
 	outNameMap := &sync.Map{}
 	outNameMap.Store("location", "Identity")
 	outNameMap.Store("score", "Identity_1")
-	gotDetector, err := attemptToBuildDetector(outModel, inNameMap, outNameMap, nil)
+	conf := &MLModelConfig{}
+	gotDetector, err := attemptToBuildDetector(outModel, inNameMap, outNameMap, conf)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotDetector, test.ShouldNotBeNil)
 
@@ -348,7 +354,8 @@ func TestMoreMLDetectors(t *testing.T) {
 
 	inNameMap := &sync.Map{}
 	outNameMap := &sync.Map{}
-	gotDetector, err := attemptToBuildDetector(outModel, inNameMap, outNameMap, nil)
+	conf := &MLModelConfig{}
+	gotDetector, err := attemptToBuildDetector(outModel, inNameMap, outNameMap, conf)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotDetector, test.ShouldNotBeNil)
 
@@ -380,7 +387,8 @@ func TestMoreMLClassifiers(t *testing.T) {
 
 	inNameMap := &sync.Map{}
 	outNameMap := &sync.Map{}
-	gotClassifier, err := attemptToBuildClassifier(outModel, inNameMap, outNameMap)
+	conf := &MLModelConfig{}
+	gotClassifier, err := attemptToBuildClassifier(outModel, inNameMap, outNameMap, conf)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotClassifier, test.ShouldNotBeNil)
 
@@ -409,7 +417,8 @@ func TestMoreMLClassifiers(t *testing.T) {
 
 	inNameMap = &sync.Map{}
 	outNameMap = &sync.Map{}
-	gotClassifier, err = attemptToBuildClassifier(outModel, inNameMap, outNameMap)
+	conf = &MLModelConfig{}
+	gotClassifier, err = attemptToBuildClassifier(outModel, inNameMap, outNameMap, conf)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotClassifier, test.ShouldNotBeNil)
 	gotClassifications, err = gotClassifier(ctx, pic)
@@ -484,7 +493,8 @@ func TestOneClassifierOnManyCameras(t *testing.T) {
 	test.That(t, out, test.ShouldNotBeNil)
 	inNameMap := &sync.Map{}
 	outNameMap := &sync.Map{}
-	outClassifier, err := attemptToBuildClassifier(out, inNameMap, outNameMap)
+	conf := &MLModelConfig{}
+	outClassifier, err := attemptToBuildClassifier(out, inNameMap, outNameMap, conf)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, outClassifier, test.ShouldNotBeNil)
 	valuePanda, valueLion := classifyTwoImages(picPanda, picLion, outClassifier)
@@ -504,12 +514,14 @@ func TestMultipleClassifiersOneModel(t *testing.T) {
 
 	inNameMap := &sync.Map{}
 	outNameMap := &sync.Map{}
-	Classifier1, err := attemptToBuildClassifier(out, inNameMap, outNameMap)
+	conf := &MLModelConfig{}
+	Classifier1, err := attemptToBuildClassifier(out, inNameMap, outNameMap, conf)
 	test.That(t, err, test.ShouldBeNil)
 
 	inNameMap = &sync.Map{}
 	outNameMap = &sync.Map{}
-	Classifier2, err := attemptToBuildClassifier(out, inNameMap, outNameMap)
+	conf = &MLModelConfig{}
+	Classifier2, err := attemptToBuildClassifier(out, inNameMap, outNameMap, conf)
 	test.That(t, err, test.ShouldBeNil)
 
 	picPanda, err := rimage.NewImageFromFile(artifact.MustPath("vision/tflite/redpanda.jpeg"))


### PR DESCRIPTION
This adds three optional attributes for pre-processing the input image:

input_image_bgr (optional): a bool value: Set this to be true if the ML model expect the input image to have BGR pixels, rather than RGB pixels.

input_image_mean_value (optional): a []float list: If the ML model expects the input image to be normalized, what is the mean value of the RGB (or BGR) values. If left blank, a default will be applied.  

input_image_std_dev (optional): a []float list: If the ML model expects the input image to be normalized, what is the standard deviation of the RGB (or BGR) values. If left blank, a default will be applied.  