### PR TITLE
RSDK-6174: CompassDegreeError for imu

### DIFF
--- a/components/movementsensor/imuwit/imu.go
+++ b/components/movementsensor/imuwit/imu.go
@@ -45,8 +45,10 @@ import (
 	rutils "go.viam.com/rdk/utils"
 )
 
-var model = resource.DefaultModelFamily.WithModel("imu-wit")
-var compassAccuracy = 0.5
+var (
+	model           = resource.DefaultModelFamily.WithModel("imu-wit")
+	compassAccuracy = 0.5
+)
 
 var baudRateList = []uint{115200, 9600, 0}
 

--- a/components/movementsensor/imuwit/imu.go
+++ b/components/movementsensor/imuwit/imu.go
@@ -46,7 +46,10 @@ import (
 )
 
 var (
-	model           = resource.DefaultModelFamily.WithModel("imu-wit")
+	model = resource.DefaultModelFamily.WithModel("imu-wit")
+
+	// This is the dynamic integral cumulative error.
+	// Data acquired from datasheets of supported models. Links above.
 	compassAccuracy = 0.5
 )
 
@@ -205,11 +208,13 @@ func (imu *wit) Position(ctx context.Context, extra map[string]interface{}) (*ge
 
 func (imu *wit) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error,
 ) {
-	// return the compass heading from the datasheet (0.5) of the witIMU if the pitch angle is less than 45 degrees
-	// and the roll angle is near zero
+	// return the compass heading error from the datasheet (0.5) of the witIMU if
+	// the pitch angle is less than 45 degrees and the roll angle is near zero
 	// mag projects at angles over this threshold cannot be determined because of the larger contribution of other
 	// orientations to the true compass heading
 	// return NaN for compass accuracy otherwise.
+	imu.mu.Lock()
+	defer imu.mu.Unlock()
 
 	roll := imu.orientation.Roll
 	pitch := imu.orientation.Pitch


### PR DESCRIPTION
This PR includes CompassDegreeError accuracy value for imu. If pitch is less than 45 degree and roll is between -1 and 1 we will display CompassDegreeError of 0.5 which is defined in the datasheet. 