### PR TITLE
RSDK-6344 Read partial config when getting cached TLS information

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -619,6 +619,7 @@ func (config *Cloud) Validate(path string, fromCloud bool) error {
 	return nil
 }
 
+// ValidateTLS ensures TLS fields are valid.
 func (config *Cloud) ValidateTLS(path string) error {
 	if config.TLSCertificate == "" {
 		return resource.NewConfigValidationFieldRequiredError(path, "tls_certificate")

--- a/config/config.go
+++ b/config/config.go
@@ -621,10 +621,10 @@ func (config *Cloud) Validate(path string, fromCloud bool) error {
 
 func (config *Cloud) ValidateTLS(path string) error {
 	if config.TLSCertificate == "" {
-		resource.NewConfigValidationFieldRequiredError(path, "tls_certificate")
+		return resource.NewConfigValidationFieldRequiredError(path, "tls_certificate")
 	}
 	if config.TLSPrivateKey == "" {
-		resource.NewConfigValidationFieldRequiredError(path, "tls_private_key")
+		return resource.NewConfigValidationFieldRequiredError(path, "tls_private_key")
 	}
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -619,6 +619,16 @@ func (config *Cloud) Validate(path string, fromCloud bool) error {
 	return nil
 }
 
+func (config *Cloud) ValidateTLS(path string) error {
+	if config.TLSCertificate == "" {
+		resource.NewConfigValidationFieldRequiredError(path, "tls_certificate")
+	}
+	if config.TLSPrivateKey == "" {
+		resource.NewConfigValidationFieldRequiredError(path, "tls_private_key")
+	}
+	return nil
+}
+
 // LocationSecret describes a location secret that can be used to authenticate to the rdk.
 type LocationSecret struct {
 	ID string `json:"id"`

--- a/config/reader.go
+++ b/config/reader.go
@@ -230,9 +230,8 @@ func readFromCloud(
 	tlsCertificate := cfg.Cloud.TLSCertificate
 	tlsPrivateKey := cfg.Cloud.TLSPrivateKey
 	if !cached {
-		// get cached certificate data
-		// read cached config from fs.
-		// process the config with fromReader() use processed config as cachedConfig to update the cert data.
+		// Try to get TLS information from the cached config (if it exists) even if we
+		// got a new config from the cloud.
 		unprocessedCachedConfig, err := readFromCache(cloudCfg.ID)
 		switch {
 		case os.IsNotExist(err):

--- a/config/reader.go
+++ b/config/reader.go
@@ -226,29 +226,17 @@ func readFromCloud(
 		return nil, errors.New("expected config to have cloud section")
 	}
 
-	// empty if not cached, since its a separate request, which we check next
-	tlsCertificate := cfg.Cloud.TLSCertificate
-	tlsPrivateKey := cfg.Cloud.TLSPrivateKey
+	tls := tlsConfig{
+		// both fields are empty if not cached, since its a separate request, which we
+		// check next
+		certificate: cfg.Cloud.TLSCertificate,
+		privateKey:  cfg.Cloud.TLSPrivateKey,
+	}
 	if !cached {
 		// Try to get TLS information from the cached config (if it exists) even if we
 		// got a new config from the cloud.
-		unprocessedCachedConfig, err := readFromCache(cloudCfg.ID)
-		switch {
-		case os.IsNotExist(err):
-			logger.Warn("No cached config, using cloud TLS config.")
-		case err != nil:
+		if err := tls.readFromCache(cloudCfg.ID, logger); err != nil {
 			return nil, err
-		case unprocessedCachedConfig.Cloud == nil:
-			logger.Warn("Cached config is not a cloud config, using cloud TLS config.")
-		default:
-			if err := unprocessedCachedConfig.Cloud.ValidateTLS("cloud"); err != nil {
-				logger.Warn("Detected failure to process the cached config when retrieving TLS config, clearing cache.")
-				clearCache(cloudCfg.ID)
-				return nil, err
-			}
-
-			tlsCertificate = unprocessedCachedConfig.Cloud.TLSCertificate
-			tlsPrivateKey = unprocessedCachedConfig.Cloud.TLSPrivateKey
 		}
 	}
 
@@ -256,7 +244,7 @@ func readFromCloud(
 		checkForNewCert = true
 	}
 
-	if checkForNewCert || tlsCertificate == "" || tlsPrivateKey == "" {
+	if checkForNewCert || tls.certificate == "" || tls.privateKey == "" {
 		logger.Debug("reading tlsCertificate from the cloud")
 		// Use the SignalingInsecure from the Cloud config returned from the app not the initial config.
 
@@ -265,13 +253,13 @@ func readFromCloud(
 			if !errors.Is(err, context.DeadlineExceeded) {
 				return nil, err
 			}
-			if tlsCertificate == "" || tlsPrivateKey == "" {
+			if tls.certificate == "" || tls.privateKey == "" {
 				return nil, errors.Wrap(err, "error getting certificate data from cloud; try again later")
 			}
 			logger.Warnw("failed to refresh certificate data; using cached for now", "error", err)
 		} else {
-			tlsCertificate = certData.TLSCertificate
-			tlsPrivateKey = certData.TLSPrivateKey
+			tls.certificate = certData.TLSCertificate
+			tls.privateKey = certData.TLSPrivateKey
 		}
 	}
 
@@ -292,20 +280,47 @@ func readFromCloud(
 		to.Cloud.ManagedBy = managedBy
 		to.Cloud.LocationSecret = locationSecret
 		to.Cloud.LocationSecrets = locationSecrets
-		to.Cloud.TLSCertificate = tlsCertificate
-		to.Cloud.TLSPrivateKey = tlsPrivateKey
+		to.Cloud.TLSCertificate = tls.certificate
+		to.Cloud.TLSPrivateKey = tls.privateKey
 	}
 
 	mergeCloudConfig(cfg)
 	// TODO(RSDK-1960): add more tests around config caching
-	unprocessedConfig.Cloud.TLSCertificate = tlsCertificate
-	unprocessedConfig.Cloud.TLSPrivateKey = tlsPrivateKey
+	unprocessedConfig.Cloud.TLSCertificate = tls.certificate
+	unprocessedConfig.Cloud.TLSPrivateKey = tls.privateKey
 
 	if err := storeToCache(cloudCfg.ID, unprocessedConfig); err != nil {
 		logger.Errorw("failed to cache config", "error", err)
 	}
 
 	return cfg, nil
+}
+
+type tlsConfig struct {
+	certificate string
+	privateKey  string
+}
+
+func (tls *tlsConfig) readFromCache(id string, logger logging.Logger) error {
+	cachedCfg, err := readFromCache(id)
+	switch {
+	case os.IsNotExist(err):
+		logger.Warn("No cached config, using cloud TLS config.")
+	case err != nil:
+		return err
+	case cachedCfg.Cloud == nil:
+		logger.Warn("Cached config is not a cloud config, using cloud TLS config.")
+	default:
+		if err := cachedCfg.Cloud.ValidateTLS("cloud"); err != nil {
+			logger.Warn("Detected failure to process the cached config when retrieving TLS config, clearing cache.")
+			clearCache(id)
+			return err
+		}
+
+		tls.certificate = cachedCfg.Cloud.TLSCertificate
+		tls.privateKey = cachedCfg.Cloud.TLSPrivateKey
+	}
+	return nil
 }
 
 // Read reads a config from the given file.


### PR DESCRIPTION
When RDK pulls a new cloud config file, it still tries to read TLS certificate data from the cached config if it exists. However, RDK validates the entire config file at this step and fails hard if there is any validation errors (aborting startup). 

Since RDK only needs TLS data at this point, it should not validate the cached config for anything beyond the relevant TLS fields.