### PR TITLE
RSDK-6761 Remove hardware encoder default

### DIFF
--- a/gostream/codec/x264/encoder.go
+++ b/gostream/codec/x264/encoder.go
@@ -20,7 +20,7 @@ type encoder struct {
 }
 
 // Gives suitable results. Probably want to make this configurable this in the future.
-const bitrate = 1_200_000
+const bitrate = 3_200_000
 
 // NewEncoder returns an x264 encoder that can encode images of the given width and height. It will
 // also ensure that it produces key frames at the given interval.

--- a/web/server/entrypoint_linux.go
+++ b/web/server/entrypoint_linux.go
@@ -4,19 +4,13 @@ package server
 
 import (
 	"go.viam.com/rdk/gostream"
-	"go.viam.com/rdk/gostream/codec/h264"
 	"go.viam.com/rdk/gostream/codec/opus"
 	"go.viam.com/rdk/gostream/codec/x264"
-	"go.viam.com/rdk/gostream/ffmpeg/avcodec"
 )
 
 func makeStreamConfig() gostream.StreamConfig {
 	var streamConfig gostream.StreamConfig
-	if avcodec.EncoderIsAvailable(h264.V4l2m2m) {
-		streamConfig.VideoEncoderFactory = h264.NewEncoderFactory()
-	} else {
-		streamConfig.VideoEncoderFactory = x264.NewEncoderFactory()
-	}
 	streamConfig.AudioEncoderFactory = opus.NewEncoderFactory()
+	streamConfig.VideoEncoderFactory = x264.NewEncoderFactory()
 	return streamConfig
 }


### PR DESCRIPTION
## Description
Currently the encoder factory in the linux entrypoint will use the `v4l2m2m` hardware encoder interface if available. Although it has the benefit of offloading cpu utilization, there have been a few regressions:

- Image quality is not as good as `x264` given the same bitrate.
- Edge case issues with unusual frame-sizes and aspect ratios.
- Flaky behavior in hardware encoder bringup.

This PR simply reverts back to using x264 as the default option.

## Testing
- Tested on RPI4 board.
- Verified that diff resolves issues with soleng PI4 module setup.
- Verified that diff resolves issues with large frame sizes from wanview RTSP feeds.