### PR TITLE
APP-3700: Run Update on every Upload in Module CLI

### DIFF
--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -260,8 +260,7 @@ func UploadModuleAction(c *cli.Context) error {
 
 		_, err = client.updateModule(moduleID, manifest)
 		if err != nil {
-			printf(c.App.Writer, "Module update failed. Please correct the following issues in your meta.json:")
-			return err
+			return errors.Wrap(err, "Module update failed. Please correct the following issues in your meta.json")
 		}
 	}
 

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -252,10 +252,17 @@ func UploadModuleAction(c *cli.Context) error {
 			return errors.Errorf("module name %q was supplied on the command line but the meta.json has a module ID of %q", nameArg,
 				moduleID.name)
 		}
-	}
-	moduleID, err = validateModuleID(client, moduleID.String(), publicNamespaceArg, orgIDArg)
-	if err != nil {
-		return err
+
+		moduleID, err = validateModuleID(client, moduleID.String(), publicNamespaceArg, orgIDArg)
+		if err != nil {
+			return err
+		}
+
+		_, err = client.updateModule(moduleID, manifest)
+		if err != nil {
+			printf(c.App.Writer, "Module update failed. Please correct the following issues in your meta.json:")
+			return err
+		}
 	}
 
 	tarballPath := moduleUploadPath


### PR DESCRIPTION
Did manual testing with a few situations to make sure we have the correct user experience here. I never ran `update` as a step in the flow.

```
go run cli/viam/main.go --base-url="https://app.viam.dev" module create --public-namespace test --name test456

michaellee@RyMongo-531 rdk % go run cli/viam/main.go --base-url="https://app.viam.dev" module create --public-namespace test-leave --name test456

Info: Using "https://app.viam.dev" as base URL value
Successfully created 'test-leave:test456'
You can view it here: https://app.viam.dev/module/test-leave/test456
Configuration for the module has been written to meta.json

michaellee@RyMongo-531 rdk % go run cli/viam/main.go --base-url="https://app.viam.dev" module upload --version 1.2.3 --platform linux/arm64 meta.json
Info: Using "https://app.viam.dev" as base URL value
Module update failed. Please correct the following issues in your meta.json:
Error: Rpc error: code = InvalidArgument desc = description is required

<edit the file to be correct>

michaellee@RyMongo-531 rdk % go run cli/viam/main.go --base-url="https://app.viam.dev" module upload --version 1.2.3 --platform linux/arm64 meta.json
Info: Using "https://app.viam.dev" as base URL value
Compressing... 100% (1/1 files)
Uploading... 100% (253/253 bytes)
Version successfully uploaded! you can view your changes online here: https://app.viam.dev/module/test-leave/test456
```