### PR TITLE
RSDK-6769 clearer curl failures

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -178,7 +178,6 @@ jobs:
 
   appimage_test:
     name: AppImage Test
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -209,7 +209,7 @@ jobs:
         export TEST_DIR=`mktemp -d -t test-viam-server-XXXXXX`
         cd $TEST_DIR
 
-        curl -o viam-server https://storage.googleapis.com/packages.viam.com/apps/viam-server/testing/appimage/${{ needs.appimage.outputs.date }}/${{ github.sha }}/viam-server-${channel}-`uname -m`.AppImage
+        curl --fail -o viam-server https://storage.googleapis.com/packages.viam.com/apps/viam-server/testing/appimage/${{ needs.appimage.outputs.date }}/${{ github.sha }}/viam-server-${channel}-`uname -m`.AppImage
         chmod 755 viam-server
 
         export RAND_PORT=$((30000 + $RANDOM))

--- a/.github/workflows/pullrequest-trusted.yml
+++ b/.github/workflows/pullrequest-trusted.yml
@@ -38,7 +38,7 @@ jobs:
     if: |
        always() && !cancelled() && contains(github.event.pull_request.labels.*.name, 'safe to test') &&
        contains(github.event.pull_request.labels.*.name, 'appimage-ignore-tests')
-    uses: viamrobotics/rdk/.github/workflows/appimage.yml@main
+    uses: viamrobotics/rdk/.github/workflows/appimage.yml
     with:
       release_type: 'pr'
     secrets:
@@ -61,7 +61,7 @@ jobs:
     if: |
        always() && !cancelled() && contains(github.event.pull_request.labels.*.name, 'safe to test') &&
        contains(github.event.pull_request.labels.*.name, 'static-ignore-tests')
-    uses: viamrobotics/rdk/.github/workflows/staticbuild.yml@main
+    uses: viamrobotics/rdk/.github/workflows/staticbuild.yml
     with:
       release_type: 'pr'
     secrets:

--- a/.github/workflows/staticbuild.yml
+++ b/.github/workflows/staticbuild.yml
@@ -154,7 +154,7 @@ jobs:
         export TEST_DIR=`mktemp -d -t test-viam-server-XXXXXX`
         cd $TEST_DIR
 
-        curl -o viam-server https://storage.googleapis.com/packages.viam.com/apps/viam-server/testing/static/${{ needs.static.outputs.date }}/${{ github.sha }}/viam-server-${channel}-`uname -m`
+        curl --fail -o viam-server https://storage.googleapis.com/packages.viam.com/apps/viam-server/testing/static/${{ needs.static.outputs.date }}/${{ github.sha }}/viam-server-${channel}-`uname -m`
         chmod 755 viam-server
 
         export RAND_PORT=$((30000 + $RANDOM))

--- a/.github/workflows/staticbuild.yml
+++ b/.github/workflows/staticbuild.yml
@@ -125,7 +125,6 @@ jobs:
 
   static_test:
     name: Static Test
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What changed
- add `--fail` to curl calls in appimage + staticbuild
## Why
Clearer error: fail at curl step instead of XML parse failure followed by retries attempting to contact port.

Example of XML error is [here](https://github.com/viamrobotics/rdk/actions/runs/8085328019/job/22134916528#step:3:76):

```
./viam-server: line 1: syntax error near unexpected token `<'
./viam-server: line 1: `<?xml version='1.0' encoding='UTF-8'?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Details>No such object: packages.viam.com/apps/viam-server/testing/appimage/YMD/SHA/viam-server-latest-x86_64.AppImage</Details></Error>'
```

## Test runs
- [appimage](https://github.com/viamrobotics/rdk/actions/runs/8099981063/job/22136968919?pr=3626)
- [staticbuild](https://github.com/viamrobotics/rdk/actions/runs/8099981063/job/22136967825?pr=3626)