### PR TITLE
revert `location_de_arm` pin

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -26,7 +26,7 @@ jobs:
             image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
             platform: linux/amd64
             label: amd64
-          - arch: [buildjet-2vcpu-ubuntu-2204-arm, buildjet-pinned-location_de_arm]
+          - arch: [buildjet-2vcpu-ubuntu-2204-arm]
             image: ghcr.io/viamrobotics/rdk-devenv:arm64-cache
             platform: linux/arm64
             label: arm64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
             image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
             platform: linux/amd64
             platform_name: linux-amd64
-          - arch: [buildjet-8vcpu-ubuntu-2204-arm, buildjet-pinned-location_de_arm]
+          - arch: [buildjet-8vcpu-ubuntu-2204-arm]
             image: ghcr.io/viamrobotics/rdk-devenv:arm64-cache
             platform: linux/arm64
             platform_name: linux-arm64
@@ -156,7 +156,7 @@ jobs:
 
   test32:
     name: Go 32-bit Unit Tests
-    runs-on: [buildjet-8vcpu-ubuntu-2204-arm, buildjet-pinned-location_de_arm]
+    runs-on: [buildjet-8vcpu-ubuntu-2204-arm]
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
## What changed
- Undo datacenter pins in CI
## Why
This was a workaround for slow docker pulls, but introduced a new failure where we waited forever for a runner. The slow pull failure condition was preferable because:

| failure condition | hang time |
---|---
slow docker pull | timeout-minutes (30 minutes)
waiting for runner in pinned datacenter | forever

we prefer the failure condition that manifests sooner, because it allows the next commit on `main` branch to start