### PR TITLE
RSDK-1960, RSDK-539 Test entire config flow

### DIFF
--- a/config/reader.go
+++ b/config/reader.go
@@ -126,33 +126,6 @@ func clearCache(id string) {
 	})
 }
 
-type tlsConfig struct {
-	certificate string
-	privateKey  string
-}
-
-func (tls *tlsConfig) readFromCache(id string, logger logging.Logger) error {
-	cachedCfg, err := readFromCache(id)
-	switch {
-	case os.IsNotExist(err):
-		logger.Warn("No cached config, using cloud TLS config.")
-	case err != nil:
-		return err
-	case cachedCfg.Cloud == nil:
-		logger.Warn("Cached config is not a cloud config, using cloud TLS config.")
-	default:
-		if err := cachedCfg.Cloud.ValidateTLS("cloud"); err != nil {
-			logger.Warn("Detected failure to process the cached config when retrieving TLS config, clearing cache.")
-			clearCache(id)
-			return err
-		}
-
-		tls.certificate = cachedCfg.Cloud.TLSCertificate
-		tls.privateKey = cachedCfg.Cloud.TLSPrivateKey
-	}
-	return nil
-}
-
 type cloudRobotService struct {
 	client apppb.RobotServiceClient
 }
@@ -317,6 +290,33 @@ func (svc *cloudRobotService) readFromCloud(
 	}
 
 	return cfg, nil
+}
+
+type tlsConfig struct {
+	certificate string
+	privateKey  string
+}
+
+func (tls *tlsConfig) readFromCache(id string, logger logging.Logger) error {
+	cachedCfg, err := readFromCache(id)
+	switch {
+	case os.IsNotExist(err):
+		logger.Warn("No cached config, using cloud TLS config.")
+	case err != nil:
+		return err
+	case cachedCfg.Cloud == nil:
+		logger.Warn("Cached config is not a cloud config, using cloud TLS config.")
+	default:
+		if err := cachedCfg.Cloud.ValidateTLS("cloud"); err != nil {
+			logger.Warn("Detected failure to process the cached config when retrieving TLS config, clearing cache.")
+			clearCache(id)
+			return err
+		}
+
+		tls.certificate = cachedCfg.Cloud.TLSCertificate
+		tls.privateKey = cachedCfg.Cloud.TLSPrivateKey
+	}
+	return nil
 }
 
 // Read reads a config from the given file.

--- a/config/reader.go
+++ b/config/reader.go
@@ -345,19 +345,27 @@ func ReadLocalConfig(
 	return fromReader(ctx, filePath, bytes.NewReader(buf), logger, nil)
 }
 
-type remoteReaderFactory func(ctx context.Context, cloud *Cloud, logger logging.Logger) (remoteReader, func() error, error)
+type remoteReaderFactory func(
+	ctx context.Context,
+	cloud *Cloud,
+	logger logging.Logger,
+) (*remoteReader, func() error, error)
 
-func newRemoteReader(ctx context.Context, cloud *Cloud, logger logging.Logger) (remoteReader, func() error, error) {
+func newRemoteReader(
+	ctx context.Context,
+	cloud *Cloud,
+	logger logging.Logger,
+) (*remoteReader, func() error, error) {
 	conn, err := CreateNewGRPCClient(ctx, cloud, logger)
 	if err != nil {
-		return remoteReader{}, func() error { return nil }, err
+		return nil, func() error { return nil }, err
 	}
 
 	rr := remoteReader{apppb.NewRobotServiceClient(conn)}
 	closeFunc := func() error {
 		return conn.Close()
 	}
-	return rr, closeFunc, nil
+	return &rr, closeFunc, nil
 }
 
 // FromReader reads a config from the given reader and specifies

--- a/config/reader.go
+++ b/config/reader.go
@@ -134,7 +134,6 @@ func (svc *cloudRobotService) readCertificateDataFromCloudGRPC(
 	ctx context.Context,
 	signalingInsecure bool,
 	cloudConfigFromDisk *Cloud,
-	logger logging.Logger,
 ) (tlsConfig, error) {
 	res, err := svc.client.Certificate(ctx, &apppb.CertificateRequest{Id: cloudConfigFromDisk.ID})
 	if err != nil {
@@ -245,7 +244,7 @@ func (svc *cloudRobotService) readFromCloud(
 		logger.Debug("reading tlsCertificate from the cloud")
 		// Use the SignalingInsecure from the Cloud config returned from the app not the initial config.
 
-		certData, err := svc.readCertificateDataFromCloudGRPC(ctx, cfg.Cloud.SignalingInsecure, cloudCfg, logger)
+		certData, err := svc.readCertificateDataFromCloudGRPC(ctx, cfg.Cloud.SignalingInsecure, cloudCfg)
 		if err != nil {
 			if !errors.Is(err, context.DeadlineExceeded) {
 				return nil, err

--- a/config/reader.go
+++ b/config/reader.go
@@ -601,7 +601,12 @@ func processConfig(unprocessedConfig *Config, fromCloud bool, logger logging.Log
 
 // getFromCloudOrCache returns the config from the gRPC endpoint. If failures during cloud lookup fallback to the
 // local cache if the error indicates it should.
-func (rr *remoteReader) getFromCloudOrCache(ctx context.Context, cloudCfg *Cloud, shouldReadFromCache bool, logger logging.Logger) (*Config, bool, error) {
+func (rr *remoteReader) getFromCloudOrCache(
+	ctx context.Context,
+	cloudCfg *Cloud,
+	shouldReadFromCache bool,
+	logger logging.Logger,
+) (*Config, bool, error) {
 	var cached bool
 	cfg, errorShouldCheckCache, err := rr.getFromCloudGRPC(ctx, cloudCfg, logger)
 	if err != nil {

--- a/config/reader.go
+++ b/config/reader.go
@@ -281,7 +281,6 @@ func (svc *cloudRobotService) readFromCloud(
 	}
 
 	mergeCloudConfig(cfg)
-	// TODO(RSDK-1960): add more tests around config caching
 	unprocessedConfig.Cloud.TLSCertificate = tls.certificate
 	unprocessedConfig.Cloud.TLSPrivateKey = tls.privateKey
 

--- a/config/reader_test.go
+++ b/config/reader_test.go
@@ -50,8 +50,12 @@ func TestFromReader(t *testing.T) {
 	const robotPartID = "forCachingTest"
 
 	rsc := initTestRobotServiceClient(t)
-	newTestReader := func(ctx context.Context, cloud *Cloud, logger logging.Logger) (remoteReader, func() error, error) {
-		return remoteReader{rsc}, func() error { return nil }, nil
+	newTestReader := func(
+		ctx context.Context,
+		cloud *Cloud,
+		logger logging.Logger,
+	) (*remoteReader, func() error, error) {
+		return &remoteReader{rsc}, func() error { return nil }, nil
 	}
 
 	clearCache(robotPartID)

--- a/config/reader_test.go
+++ b/config/reader_test.go
@@ -2,18 +2,17 @@ package config
 
 import (
 	"context"
+	"errors"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
-	"errors"
-
 	"github.com/google/uuid"
+	apppb "go.viam.com/api/app/v1"
 	"go.viam.com/test"
 	"google.golang.org/grpc"
 
-	apppb "go.viam.com/api/app/v1"
 	"go.viam.com/rdk/logging"
 )
 

--- a/config/reader_test.go
+++ b/config/reader_test.go
@@ -49,9 +49,8 @@ func TestFromReader(t *testing.T) {
 	const robotPartID = "forCachingTest"
 
 	rsc := initTestRobotServiceClient(t)
-	newRemoteReader := func(ctx context.Context, cloud *Cloud, logger logging.Logger) (remoteReader, func() error, error) {
-		rr := remoteReader{rsc}
-		return rr, func() error { return nil }, nil
+	newTestReader := func(ctx context.Context, cloud *Cloud, logger logging.Logger) (remoteReader, func() error, error) {
+		return remoteReader{rsc}, func() error { return nil }, nil
 	}
 
 	logger := logging.NewTestLogger(t)
@@ -60,7 +59,7 @@ func TestFromReader(t *testing.T) {
 
 	_, err := readFromCache(robotPartID)
 	test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
-	gotCfg, err := fromReader(ctx, "", strings.NewReader(cfgText), logger, newRemoteReader)
+	gotCfg, err := fromReader(ctx, "", strings.NewReader(cfgText), logger, newTestReader)
 	test.That(t, err, test.ShouldBeNil)
 	defer clearCache(robotPartID)
 

--- a/config/reader_test.go
+++ b/config/reader_test.go
@@ -52,8 +52,8 @@ func (c *InjectRobotServiceClient) NeedsRestart(ctx context.Context, in *apppb.N
 	return nil, errors.New("failed to get needs restart")
 }
 
-func createInjectRobotService(ctx context.Context, cloud *Cloud, logger logging.Logger) (cloudRobotService, func() error, error) {
-	svc := cloudRobotService{&InjectRobotServiceClient{}}
+func createInjectRobotService(ctx context.Context, cloud *Cloud, logger logging.Logger) (remoteReader, func() error, error) {
+	svc := remoteReader{&InjectRobotServiceClient{}}
 	return svc, func() error { return nil }, nil
 }
 
@@ -106,7 +106,7 @@ func TestStoreToCache(t *testing.T) {
 	err = storeToCache(cfg.Cloud.ID, cfg)
 	test.That(t, err, test.ShouldBeNil)
 
-	svc := cloudRobotService{client: &InjectRobotServiceClient{}}
+	svc := remoteReader{client: &InjectRobotServiceClient{}}
 
 	// read config from cloud, confirm consistency
 	cloudCfg, err := svc.readFromCloud(ctx, cfg, nil, true, false, logger)

--- a/config/watcher.go
+++ b/config/watcher.go
@@ -70,15 +70,13 @@ func newCloudWatcher(ctx context.Context, config *Config, logger logging.Logger)
 			}
 
 			if rr == nil {
-				var reader remoteReader
 				var err error
-				reader, closeFunc, err = newRemoteReader(ctx, config.Cloud, logger)
+				rr, closeFunc, err = newRemoteReader(ctx, config.Cloud, logger)
 				if err != nil {
 					rr = nil
 					logger.Warn("failed to connect to app")
 					continue
 				}
-				rr = &reader
 			}
 			newConfig, err := rr.readFromCloud(cancelCtx, config, prevCfg, false, checkForNewCert, logger)
 			if err != nil {

--- a/config/watcher.go
+++ b/config/watcher.go
@@ -65,7 +65,7 @@ func newCloudWatcher(ctx context.Context, config *Config, logger logging.Logger)
 		return nil
 	}
 	defer utils.UncheckedErrorFunc(conn.Close)
-	svc := remoteReader{apppb.NewRobotServiceClient(conn)}
+	rr := remoteReader{apppb.NewRobotServiceClient(conn)}
 
 	var prevCfg *Config
 	utils.ManagedGo(func() {
@@ -78,7 +78,7 @@ func newCloudWatcher(ctx context.Context, config *Config, logger logging.Logger)
 				checkForNewCert = true
 			}
 
-			newConfig, err := svc.readFromCloud(cancelCtx, config, prevCfg, false, checkForNewCert, logger)
+			newConfig, err := rr.readFromCloud(cancelCtx, config, prevCfg, false, checkForNewCert, logger)
 			if err != nil {
 				logger.Errorw("error reading cloud config", "error", err)
 				continue

--- a/config/watcher.go
+++ b/config/watcher.go
@@ -65,7 +65,7 @@ func newCloudWatcher(ctx context.Context, config *Config, logger logging.Logger)
 		return nil
 	}
 	defer utils.UncheckedErrorFunc(conn.Close)
-	svc := cloudRobotService{apppb.NewRobotServiceClient(conn)}
+	svc := remoteReader{apppb.NewRobotServiceClient(conn)}
 
 	var prevCfg *Config
 	utils.ManagedGo(func() {

--- a/testutils/injectpb/robot_service_client.go
+++ b/testutils/injectpb/robot_service_client.go
@@ -1,0 +1,49 @@
+package injectpb
+
+import (
+	"context"
+
+	pb "go.viam.com/api/app/v1"
+	"google.golang.org/grpc"
+)
+
+// RobotServiceClient is an injected RobotServiceClient.
+type RobotServiceClient struct {
+	pb.RobotServiceClient
+	ConfigFunc       func(ctx context.Context, in *pb.ConfigRequest, opts ...grpc.CallOption) (*pb.ConfigResponse, error)
+	CertificateFunc  func(ctx context.Context, in *pb.CertificateRequest, opts ...grpc.CallOption) (*pb.CertificateResponse, error)
+	LogFunc          func(ctx context.Context, in *pb.LogRequest, opts ...grpc.CallOption) (*pb.LogResponse, error)
+	NeedsRestartFunc func(ctx context.Context, in *pb.NeedsRestartRequest, opts ...grpc.CallOption) (*pb.NeedsRestartResponse, error)
+}
+
+// Config calls the injected ConfigFunc or the real version.
+func (rsc *RobotServiceClient) Config(ctx context.Context, in *pb.ConfigRequest, opts ...grpc.CallOption) (*pb.ConfigResponse, error) {
+	if rsc.ConfigFunc == nil {
+		return rsc.Config(ctx, in, opts...)
+	}
+	return rsc.ConfigFunc(ctx, in, opts...)
+}
+
+// Certificate calls the injected CertificateFunc or the real version.
+func (rsc *RobotServiceClient) Certificate(ctx context.Context, in *pb.CertificateRequest, opts ...grpc.CallOption) (*pb.CertificateResponse, error) {
+	if rsc.CertificateFunc == nil {
+		return rsc.Certificate(ctx, in, opts...)
+	}
+	return rsc.CertificateFunc(ctx, in, opts...)
+}
+
+// Log calls the injected LogFunc or the real version.
+func (rsc *RobotServiceClient) Log(ctx context.Context, in *pb.LogRequest, opts ...grpc.CallOption) (*pb.LogResponse, error) {
+	if rsc.LogFunc == nil {
+		return rsc.Log(ctx, in, opts...)
+	}
+	return rsc.LogFunc(ctx, in, opts...)
+}
+
+// NeedsRestart calls the injected NeedsRestartFunc or the real version.
+func (rsc *RobotServiceClient) NeedsRestart(ctx context.Context, in *pb.NeedsRestartRequest, opts ...grpc.CallOption) (*pb.NeedsRestartResponse, error) {
+	if rsc.NeedsRestartFunc == nil {
+		return rsc.NeedsRestart(ctx, in, opts...)
+	}
+	return rsc.NeedsRestartFunc(ctx, in, opts...)
+}

--- a/testutils/injectpb/robot_service_client.go
+++ b/testutils/injectpb/robot_service_client.go
@@ -51,7 +51,11 @@ func (rsc *RobotServiceClient) Log(
 }
 
 // NeedsRestart calls the injected NeedsRestartFunc or the real version.
-func (rsc *RobotServiceClient) NeedsRestart(ctx context.Context, in *pb.NeedsRestartRequest, opts ...grpc.CallOption) (*pb.NeedsRestartResponse, error) {
+func (rsc *RobotServiceClient) NeedsRestart(
+	ctx context.Context,
+	in *pb.NeedsRestartRequest,
+	opts ...grpc.CallOption,
+) (*pb.NeedsRestartResponse, error) {
 	if rsc.NeedsRestartFunc == nil {
 		return rsc.NeedsRestart(ctx, in, opts...)
 	}

--- a/testutils/injectpb/robot_service_client.go
+++ b/testutils/injectpb/robot_service_client.go
@@ -1,3 +1,5 @@
+// Package injectpb provides dependency injected structures for mocking protobuf
+// interfaces.
 package injectpb
 
 import (
@@ -25,7 +27,11 @@ func (rsc *RobotServiceClient) Config(ctx context.Context, in *pb.ConfigRequest,
 }
 
 // Certificate calls the injected CertificateFunc or the real version.
-func (rsc *RobotServiceClient) Certificate(ctx context.Context, in *pb.CertificateRequest, opts ...grpc.CallOption) (*pb.CertificateResponse, error) {
+func (rsc *RobotServiceClient) Certificate(
+	ctx context.Context,
+	in *pb.CertificateRequest,
+	opts ...grpc.CallOption,
+) (*pb.CertificateResponse, error) {
 	if rsc.CertificateFunc == nil {
 		return rsc.Certificate(ctx, in, opts...)
 	}
@@ -33,7 +39,11 @@ func (rsc *RobotServiceClient) Certificate(ctx context.Context, in *pb.Certifica
 }
 
 // Log calls the injected LogFunc or the real version.
-func (rsc *RobotServiceClient) Log(ctx context.Context, in *pb.LogRequest, opts ...grpc.CallOption) (*pb.LogResponse, error) {
+func (rsc *RobotServiceClient) Log(
+	ctx context.Context,
+	in *pb.LogRequest,
+	opts ...grpc.CallOption,
+) (*pb.LogResponse, error) {
 	if rsc.LogFunc == nil {
 		return rsc.Log(ctx, in, opts...)
 	}


### PR DESCRIPTION
Stub out network calls and test the entire config reader flow