### PR TITLE
services/shell: Add TERM=xterm-256color when not present

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -1150,9 +1150,9 @@ func (c *viamClient) startRobotPartShell(
 		// NOTE(benjirewis): Linux systems seem to need both "raw" (no processing) and "-echo"
 		// (no echoing back inputted characters) in order to allow the input and output loops
 		// below to completely control the terminal.
-		args := []string{"raw", "-echo"}
+		args := []string{"raw", "-echo", "-echoctl"}
 		if !isRaw {
-			args = []string{"-raw", "echo"}
+			args = []string{"-raw", "echo", "echoctl"}
 		}
 
 		rawMode := exec.Command("stty", args...)

--- a/services/shell/builtin/builtin.go
+++ b/services/shell/builtin/builtin.go
@@ -56,6 +56,9 @@ func (svc *builtIn) Shell(ctx context.Context, extra map[string]interface{}) (ch
 	ctxCancel, cancel := context.WithCancel(ctx)
 	//nolint:gosec
 	cmd := exec.CommandContext(ctxCancel, defaultShellPath, "-i")
+	if _, ok := os.LookupEnv("TERM"); !ok {
+		cmd.Env = append(cmd.Env, "TERM=xterm-256color")
+	}
 	f, err := pty.Start(cmd)
 	if err != nil {
 		cancel()


### PR DESCRIPTION
This happens in particular if the SHELL profile does not contain any TERM env var. It's harmless to add xterm with 256 color support nowadays (i.e. for decades now)

- driveby fix to not echo control characters