### PR TITLE
RSDK-6348/error frequency

### DIFF
--- a/data/collector.go
+++ b/data/collector.go
@@ -46,6 +46,9 @@ var FromDMExtraMap = map[string]interface{}{FromDMString: true}
 // ErrNoCaptureToStore is returned when a modular filter resource filters the capture coming from the base resource.
 var ErrNoCaptureToStore = status.Error(codes.FailedPrecondition, "no capture from filter module")
 
+// If an error is ongoing, the frequency (in seconds) with which to suppress identical error logs.
+var IdenticalErrorLogFrequency = 2
+
 // Collector collects data to some target.
 type Collector interface {
 	Close()
@@ -54,20 +57,21 @@ type Collector interface {
 }
 
 type collector struct {
-	clock          clock.Clock
-	captureResults chan *v1.SensorData
-	captureErrors  chan error
-	interval       time.Duration
-	params         map[string]*anypb.Any
-	lock           sync.Mutex
-	logger         logging.Logger
-	captureWorkers sync.WaitGroup
-	logRoutine     sync.WaitGroup
-	cancelCtx      context.Context
-	cancel         context.CancelFunc
-	captureFunc    CaptureFunc
-	closed         bool
-	target         datacapture.BufferedWriter
+	clock            clock.Clock
+	captureResults   chan *v1.SensorData
+	captureErrors    chan error
+	interval         time.Duration
+	params           map[string]*anypb.Any
+	lock             sync.Mutex
+	logger           logging.Logger
+	captureWorkers   sync.WaitGroup
+	logRoutine       sync.WaitGroup
+	cancelCtx        context.Context
+	cancel           context.CancelFunc
+	captureFunc      CaptureFunc
+	closed           bool
+	target           datacapture.BufferedWriter
+	lastLoggedErrors map[string]int64
 }
 
 // Close closes the channels backing the Collector. It should always be called before disposing of a Collector to avoid
@@ -183,7 +187,6 @@ func (c *collector) tickerBasedCapture(started chan struct{}) {
 			close(c.captureResults)
 			return
 		}
-
 		select {
 		case <-c.cancelCtx.Done():
 			captureWorkers.Wait()
@@ -280,17 +283,18 @@ func NewCollector(captureFunc CaptureFunc, params CollectorParams) (Collector, e
 		c = params.Clock
 	}
 	return &collector{
-		captureResults: make(chan *v1.SensorData, params.QueueSize),
-		captureErrors:  make(chan error, params.QueueSize),
-		interval:       params.Interval,
-		params:         params.MethodParams,
-		logger:         params.Logger,
-		cancelCtx:      cancelCtx,
-		cancel:         cancelFunc,
-		captureFunc:    captureFunc,
-		target:         params.Target,
-		clock:          c,
-		closed:         false,
+		captureResults:   make(chan *v1.SensorData, params.QueueSize),
+		captureErrors:    make(chan error, params.QueueSize),
+		interval:         params.Interval,
+		params:           params.MethodParams,
+		logger:           params.Logger,
+		cancelCtx:        cancelCtx,
+		cancel:           cancelFunc,
+		captureFunc:      captureFunc,
+		target:           params.Target,
+		clock:            c,
+		closed:           false,
+		lastLoggedErrors: make(map[string]int64, 0),
 	}, nil
 }
 
@@ -305,6 +309,7 @@ func (c *collector) writeCaptureResults() error {
 
 func (c *collector) logCaptureErrs() {
 	for err := range c.captureErrors {
+		now := c.clock.Now().Unix()
 		if c.closed {
 			// Don't log context cancellation errors if the collector has already been closed. This means the collector
 			// cancelled the context, and the context cancellation error is expected.
@@ -312,7 +317,11 @@ func (c *collector) logCaptureErrs() {
 				continue
 			}
 		}
-		c.logger.Error(err)
+		// Only log a specific error message if we haven't logged it in the past 2 seconds.
+		if lastLogged, ok := c.lastLoggedErrors[err.Error()]; (ok && int(now-lastLogged) > IdenticalErrorLogFrequency) || !ok {
+			c.logger.Error((err))
+			c.lastLoggedErrors[err.Error()] = now
+		}
 	}
 }
 

--- a/data/collector.go
+++ b/data/collector.go
@@ -47,7 +47,7 @@ var FromDMExtraMap = map[string]interface{}{FromDMString: true}
 var ErrNoCaptureToStore = status.Error(codes.FailedPrecondition, "no capture from filter module")
 
 // If an error is ongoing, the frequency (in seconds) with which to suppress identical error logs.
-var IdenticalErrorLogFrequency = 2
+const IdenticalErrorLogFrequencyHz = 2
 
 // Collector collects data to some target.
 type Collector interface {
@@ -318,7 +318,7 @@ func (c *collector) logCaptureErrs() {
 			}
 		}
 		// Only log a specific error message if we haven't logged it in the past 2 seconds.
-		if lastLogged, ok := c.lastLoggedErrors[err.Error()]; (ok && int(now-lastLogged) > IdenticalErrorLogFrequency) || !ok {
+		if lastLogged, ok := c.lastLoggedErrors[err.Error()]; (ok && int(now-lastLogged) > IdenticalErrorLogFrequencyHz) || !ok {
 			c.logger.Error((err))
 			c.lastLoggedErrors[err.Error()] = now
 		}

--- a/data/collector.go
+++ b/data/collector.go
@@ -47,7 +47,7 @@ var FromDMExtraMap = map[string]interface{}{FromDMString: true}
 var ErrNoCaptureToStore = status.Error(codes.FailedPrecondition, "no capture from filter module")
 
 // If an error is ongoing, the frequency (in seconds) with which to suppress identical error logs.
-const IdenticalErrorLogFrequencyHz = 2
+const identicalErrorLogFrequencyHz = 2
 
 // Collector collects data to some target.
 type Collector interface {
@@ -318,7 +318,7 @@ func (c *collector) logCaptureErrs() {
 			}
 		}
 		// Only log a specific error message if we haven't logged it in the past 2 seconds.
-		if lastLogged, ok := c.lastLoggedErrors[err.Error()]; (ok && int(now-lastLogged) > IdenticalErrorLogFrequencyHz) || !ok {
+		if lastLogged, ok := c.lastLoggedErrors[err.Error()]; (ok && int(now-lastLogged) > identicalErrorLogFrequencyHz) || !ok {
 			c.logger.Error((err))
 			c.lastLoggedErrors[err.Error()] = now
 		}

--- a/data/collector_test.go
+++ b/data/collector_test.go
@@ -314,8 +314,10 @@ func TestLogErrorsOnlyOnce(t *testing.T) {
 
 	close(wrote)
 	test.That(t, logs.FilterLevelExact(zapcore.ErrorLevel).Len(), test.ShouldEqual, 1)
-	mockClock.Add(4 * time.Second)
+	mockClock.Add(3 * time.Second)
 	test.That(t, logs.FilterLevelExact(zapcore.ErrorLevel).Len(), test.ShouldEqual, 2)
+	mockClock.Add(3 * time.Second)
+	test.That(t, logs.FilterLevelExact(zapcore.ErrorLevel).Len(), test.ShouldEqual, 3)
 	// Close and validate no additional writes occur even after an additional interval.
 	c.Close()
 }

--- a/data/collector_test.go
+++ b/data/collector_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/benbjohnson/clock"
+	"github.com/pkg/errors"
 	"go.uber.org/zap/zapcore"
 	v1 "go.viam.com/api/app/datasync/v1"
 	"go.viam.com/test"
@@ -287,7 +288,7 @@ func TestLogErrorsOnlyOnce(t *testing.T) {
 	buf := datacapture.NewBuffer(tmpDir, &md)
 	wrote := make(chan struct{})
 	errorCapturer := CaptureFunc(func(ctx context.Context, _ map[string]*anypb.Any) (interface{}, error) {
-		return nil, fmt.Errorf("I am an error")
+		return nil, errors.New("I am an error")
 	})
 	target := &signalingBuffer{
 		bw:    buf,
@@ -334,7 +335,7 @@ func validateReadings(t *testing.T, act []*v1.SensorData, n int) {
 	}
 }
 
-// nolint
+//nolint
 func getAllFiles(dir string) []os.FileInfo {
 	var files []os.FileInfo
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {


### PR DESCRIPTION

As per https://viam.atlassian.net/browse/RSDK-6348?atlOrigin=eyJpIjoiZWI0Y2JjNDYzZmZjNDliMGI0NzE1M2VkYTMxOThiNjkiLCJwIjoiaiJ9 we have an issue where, if something goes wrong, there's the possibility (and reality) that we'll log the same error message millions of times until it's resolved. This fix adds a map of

String: ErrorMessage -> Timestamp: LastLogged

and ensures that identical error messages only show up a maximum of once every 2 seconds.

Open to changing the frequency if anyone has any thoughts on the matter.


EDIT

Here is a screenshot of testing where I return an error from the webcam component:

<img width="1213" alt="Screenshot 2024-03-05 at 3 05 42 PM" src="https://github.com/viamrobotics/rdk/assets/4420609/4c198b48-2a86-4af2-ab16-acd59921331e">

Note the errors come in every 3 seconds
