### PR TITLE
RSDK-5755: Utilize control loop context for closing control loops in motor encoder

### DIFF
--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -427,7 +427,7 @@ func (m *EncodedMotor) GoFor(ctx context.Context, rpm, revolutions float64, extr
 func (m *EncodedMotor) goForInternal(ctx context.Context, rpm, revolutions float64) error {
 	if m.loop == nil {
 		// create new control loop if control config exists
-		if m.cfg.ControlParameters != nil {
+		if len(m.controlLoopConfig.Blocks) != 0 {
 			if err := m.startControlLoop(); err != nil {
 				return err
 			}

--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -425,19 +425,17 @@ func (m *EncodedMotor) GoFor(ctx context.Context, rpm, revolutions float64, extr
 }
 
 func (m *EncodedMotor) goForInternal(ctx context.Context, rpm, revolutions float64) error {
-	if m.loop != nil {
-		if err := m.Stop(ctx, nil); err != nil {
-			m.logger.Error(err)
+	if m.loop == nil {
+		// create new control loop if control config exists
+		if m.cfg.ControlParameters != nil {
+			if err := m.startControlLoop(); err != nil {
+				return err
+			}
+		} else {
+			m.rpmMonitorStart()
 		}
 	}
-	// create new control loop if control config exists
-	if m.cfg.ControlParameters != nil {
-		if err := m.startControlLoop(); err != nil {
-			return err
-		}
-	} else {
-		m.rpmMonitorStart()
-	}
+
 	m.state.direction = sign(rpm * revolutions)
 
 	switch speed := math.Abs(rpm); {
@@ -615,9 +613,8 @@ func (m *EncodedMotor) Stop(ctx context.Context, extra map[string]interface{}) e
 
 // Close cleanly shuts down the motor.
 func (m *EncodedMotor) Close(ctx context.Context) error {
-	if m.loop != nil {
-		m.loop.Stop()
-		m.loop = nil
+	if err := m.Stop(ctx, nil); err != nil {
+		return err
 	}
 	m.cancel()
 	m.activeBackgroundWorkers.Wait()

--- a/control/control_loop.go
+++ b/control/control_loop.go
@@ -293,9 +293,9 @@ func (l *Loop) Stop() {
 		l.logger.Debug("closing loop")
 		l.ct.ticker.Stop()
 		close(l.ct.stop)
+		l.cancel()
 		l.activeBackgroundWorkers.Wait()
 		l.running = false
-		l.cancel()
 	}
 }
 

--- a/control/control_loop.go
+++ b/control/control_loop.go
@@ -295,6 +295,7 @@ func (l *Loop) Stop() {
 		close(l.ct.stop)
 		l.activeBackgroundWorkers.Wait()
 		l.running = false
+		l.cancel()
 	}
 }
 

--- a/control/control_loop.go
+++ b/control/control_loop.go
@@ -304,7 +304,7 @@ func (l *Loop) GetConfig(ctx context.Context) Config {
 }
 
 // MonitorTuning waits for tuning to start, and then returns once it's done.
-func (l *Loop) MonitorTuning(ctx context.Context) error {
+func (l *Loop) MonitorTuning(ctx context.Context) {
 	// wait until tuning has started
 	for {
 		tuning := l.GetTuning(ctx)
@@ -319,8 +319,6 @@ func (l *Loop) MonitorTuning(ctx context.Context) error {
 			break
 		}
 	}
-
-	return nil
 }
 
 // GetTuning returns the current tuning value.

--- a/control/setup_control.go
+++ b/control/setup_control.go
@@ -160,9 +160,7 @@ func (p *PIDLoop) TunePIDLoop(ctx context.Context, cancelFunc context.CancelFunc
 				errs = multierr.Combine(errs, err)
 			}
 
-			if err := p.ControlLoop.MonitorTuning(ctx); err != nil {
-				errs = multierr.Combine(errs, err)
-			}
+			p.ControlLoop.MonitorTuning(ctx)
 		}
 		if p.Options.SensorFeedback2DVelocityControl {
 			// check if linear needs to be tuned
@@ -196,9 +194,7 @@ func (p *PIDLoop) tuneSinglePID(ctx context.Context, blockIndex int) error {
 		return err
 	}
 
-	if err := p.ControlLoop.MonitorTuning(ctx); err != nil {
-		return err
-	}
+	p.ControlLoop.MonitorTuning(ctx)
 
 	p.ControlLoop.Stop()
 	p.ControlLoop = nil


### PR DESCRIPTION
To make sure the loopCancelCtx is actually cancelled at stop, `cancel()` is now called in `loop.Stop`.

Additional changes in this PR include removing unnecessary stopping and restarting of the control loop when a new `GoFor` call is made, and removing an always nil returned error from `MonitorTuning`