### PR TITLE
RSDK-6824: change from topN to up-to topN

### DIFF
--- a/vision/classification/classifier.go
+++ b/vision/classification/classifier.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"image"
 	"sort"
-
-	"github.com/pkg/errors"
 )
 
 // Classification returns a confidence score of the classification and a label of the class.
@@ -22,7 +20,7 @@ type Classifications []Classification
 // TopN finds the N Classifications with the highest confidence scores.
 func (cc Classifications) TopN(n int) (Classifications, error) {
 	if len(cc) < n {
-		return nil, errors.Errorf("cannot produce top %v results from list of length %v", n, len(cc))
+		n = len(cc)
 	}
 	sort.Slice(cc, func(i, j int) bool { return cc[i].Score() > cc[j].Score() })
 	return cc[0:n], nil


### PR DESCRIPTION
Before there was an error if you requested top N classifications but actually number of classifications were less than N. Now it checks before returning