### PR TITLE
RSDK-6823: Motor doesn't stop after controls auto tuning on PI5

### DIFF
--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -91,6 +91,7 @@ func newEncodedMotor(
 		opMgr:             operation.NewSingleOperationManager(),
 		startedRPMMonitor: false,
 		loop:              nil,
+		controlLoopConfig: control.Config{},
 	}
 
 	props, err := realEncoder.Properties(context.Background(), nil)

--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -362,7 +362,10 @@ func (m *EncodedMotor) SetPower(ctx context.Context, powerPct float64, extra map
 // setPower assumes the state lock is held.
 func (m *EncodedMotor) setPower(ctx context.Context, powerPct float64, internal bool) error {
 	dir := sign(powerPct)
-	if math.Abs(powerPct) < 0.1 && m.loop == nil {
+	// If the control config exists, a control loop must exist, so the motor should be allowed to run at a power lower than 10%.
+	// In the case that the motor is tuning, m.loop will be nil, but m.controlLoopConfig.Blocks will not be empty,
+	// which is why m.loop is not checked here.
+	if math.Abs(powerPct) < 0.1 && len(m.controlLoopConfig.Blocks) == 0 {
 		m.state.lastPowerPct = 0.1 * dir
 	} else {
 		m.state.lastPowerPct = powerPct


### PR DESCRIPTION
Actually not a PI5 issue, it's an uncovered bug from the addition of controls helper functions on motors that have incremental encoders. Because the tuning process is running in the background, `m.loop` is nil until the motor reconfigures with non-zero PID values. When the motor is tuning and the loop tries to set the power to (essentially) 0, `setPower` forces the power to be 0.1 because loop is still nil, which causes the motor to keep moving.

This change to check `len(m.controlLoopConfig.Blocks)` instead of `m.loop` shouldn't cause any issues because in order for there to be a controlLoopConfig by the time it gets to a setPower call (that originates from a GoFor call), there should a loop.

This check should potentially be removed anyways, because I'm not 100% sure why we want to force setPower to be minimum 10%