### PR TITLE
 RSDK-6837/make-closing-threadsafe #3661 

### DIFF
--- a/data/collector.go
+++ b/data/collector.go
@@ -80,7 +80,6 @@ func (c *collector) Close() {
 	if c.closed {
 		return
 	}
-	c.closed = true
 
 	c.cancel()
 	c.captureWorkers.Wait()
@@ -93,6 +92,7 @@ func (c *collector) Close() {
 	c.logRoutine.Wait()
 	//nolint:errcheck
 	_ = c.logger.Sync()
+	c.closed = true
 }
 
 func (c *collector) Flush() {

--- a/data/collector.go
+++ b/data/collector.go
@@ -85,6 +85,9 @@ func (c *collector) Close() {
 	c.captureWorkers.Wait()
 	c.lock.Lock()
 	defer c.lock.Unlock()
+	if c.closed {
+		return
+	}
 	if err := c.target.Flush(); err != nil {
 		c.logger.Errorw("failed to flush capture data", "error", err)
 	}

--- a/data/collector_test.go
+++ b/data/collector_test.go
@@ -319,7 +319,6 @@ func TestLogErrorsOnlyOnce(t *testing.T) {
 	test.That(t, logs.FilterLevelExact(zapcore.ErrorLevel).Len(), test.ShouldEqual, 2)
 	mockClock.Add(3 * time.Second)
 	test.That(t, logs.FilterLevelExact(zapcore.ErrorLevel).Len(), test.ShouldEqual, 3)
-	// Close and validate no additional writes occur even after an additional interval.
 	c.Close()
 }
 


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-6837

This test was broken because of a race condition introduced by the test.

This was tested by running it with the -race flag and getting the OK.

Also, c.closed is only used in these two spots so it feels safe to move.
<img width="932" alt="Screenshot 2024-03-06 at 4 49 51 PM" src="https://github.com/viamrobotics/rdk/assets/4420609/6f92f1af-6348-427e-9000-c08272dac128">

EDIT: Tested by running and trying to use the app online without any unexpected behavior
