### PR TITLE
RSDK-6877, RSDK-6878 - Aggressive timeouts on first config reads

### DIFF
--- a/config/watcher.go
+++ b/config/watcher.go
@@ -61,7 +61,7 @@ func newCloudWatcher(ctx context.Context, config *Config, logger logging.Logger)
 			// have first read with the watcher happen much faster in case the request timed out on the initial read on server startup
 			interval := config.Cloud.RefreshInterval
 			if firstRead {
-				interval = interval / 5
+				interval /= 5
 				firstRead = false
 			}
 			if !utils.SelectContextOrWait(cancelCtx, interval) {

--- a/config/watcher.go
+++ b/config/watcher.go
@@ -54,12 +54,17 @@ func newCloudWatcher(ctx context.Context, config *Config, logger logging.Logger)
 
 	nextCheckForNewCert := time.Now().Add(checkForNewCertInterval)
 
-	ticker := time.NewTicker(config.Cloud.RefreshInterval)
-
 	var prevCfg *Config
 	utils.ManagedGo(func() {
+		firstRead := true
 		for {
-			if !utils.SelectContextOrWait(cancelCtx, config.Cloud.RefreshInterval) {
+			// have first read with the watcher happen much faster in case the request timed out on the initial read on server startup
+			interval := config.Cloud.RefreshInterval
+			if firstRead {
+				interval = interval / 5
+				firstRead = false
+			}
+			if !utils.SelectContextOrWait(cancelCtx, interval) {
 				return
 			}
 			var checkForNewCert bool
@@ -85,7 +90,6 @@ func newCloudWatcher(ctx context.Context, config *Config, logger logging.Logger)
 			}
 		}
 	}, func() {
-		ticker.Stop()
 		close(watcherDoneCh)
 	})
 	return &cloudWatcher{


### PR DESCRIPTION
tested locally, also we weren't timing out our watcher reads at all before...

instead of adding another arg into the method, used `shouldReadFromCache` to determine whether or not we're in an initial read situation. @maximpertsov 's work around testing and creating a remoteReader struct should make that easier (possibly through a struct var)

also removes a ticker that we don't use