### PR TITLE
RSDK-6904 - Deferred Package Manager

### DIFF
--- a/robot/packages/deferred_package_manager.go
+++ b/robot/packages/deferred_package_manager.go
@@ -1,0 +1,155 @@
+package packages
+
+import (
+	"context"
+	"errors"
+	"os"
+	"sync"
+	"time"
+
+	pb "go.viam.com/api/app/packages/v1"
+	"go.viam.com/utils/rpc"
+
+	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+)
+
+type deferredPackageManager struct {
+	resource.Named
+	resource.TriviallyReconfigurable
+	connectionChan   chan DeferredConnectionResponse
+	noopManager      noopManager
+	cloudManager     ManagerSyncer
+	cloudManagerArgs cloudManagerConstructorArgs
+	logger           logging.Logger
+	cloudManagerLock sync.Mutex
+}
+type cloudManagerConstructorArgs struct {
+	cloudConfig *config.Cloud
+	packagesDir string
+	logger      logging.Logger
+}
+
+// DeferredConnectionResponse is an entry on the connectionChan
+// used to pass a connection from local_robot to here.
+type DeferredConnectionResponse struct {
+	CloudConn rpc.ClientConn
+	Err       error
+}
+
+var (
+	_ Manager       = (*deferredPackageManager)(nil)
+	_ ManagerSyncer = (*deferredPackageManager)(nil)
+)
+
+// DeferredServiceName is used to refer to/depend on this service internally.
+var DeferredServiceName = resource.NewName(resource.APINamespaceRDKInternal.WithServiceType(SubtypeName), "deferred-manager")
+
+// NewDeferredPackageManager returns a package manager that wraps a CloudPackageManager and a channel that is establishing
+// a connection to app. It starts up instantly and behaves as a noop package manager until a connection to app has been established.
+func NewDeferredPackageManager(
+	connectionChan chan DeferredConnectionResponse,
+	cloudConfig *config.Cloud,
+	packagesDir string,
+	logger logging.Logger,
+) ManagerSyncer {
+	return &deferredPackageManager{
+		Named:            DeferredServiceName.AsNamed(),
+		logger:           logger,
+		cloudManagerArgs: cloudManagerConstructorArgs{cloudConfig, packagesDir, logger},
+		connectionChan:   connectionChan,
+		noopManager:      noopManager{Named: InternalServiceName.AsNamed()},
+	}
+}
+
+func (m *deferredPackageManager) getCloudManager(wait bool) ManagerSyncer {
+	m.cloudManagerLock.Lock()
+	defer m.cloudManagerLock.Unlock()
+	// early exit if the cloud manager already exists
+	if m.cloudManager != nil {
+		return m.cloudManager
+	}
+	var response *DeferredConnectionResponse
+	m.logger.Error("wooooooooooooooo")
+	m.logger.Error(time.Now().Format(time.RFC3339Nano))
+	if wait {
+		res := <-m.connectionChan
+		response = &res
+	} else {
+		select {
+		case res := <-m.connectionChan:
+			response = &res
+		default:
+		}
+	}
+	m.logger.Error(time.Now().Format(time.RFC3339Nano))
+	if response == nil {
+		return nil
+	}
+	// because we have pulled this failed result from the connectionChan,
+	// it will retry
+	if response.Err != nil {
+		m.logger.Warnf("failed to establish a connection to app.viam %w", response.Err)
+		return nil
+	}
+	var err error
+	m.cloudManager, err = NewCloudManager(
+		m.cloudManagerArgs.cloudConfig,
+		pb.NewPackageServiceClient(response.CloudConn),
+		m.cloudManagerArgs.packagesDir,
+		m.cloudManagerArgs.logger,
+	)
+	if err != nil {
+		m.logger.Warnf("failed to create cloud package manager %w", response.Err)
+	}
+	return m.cloudManager
+}
+
+// isMissingPackages is used pre-sync to determine if we should force-wait for the connection
+// to be established.
+func (m *deferredPackageManager) isMissingPackages(packages []config.PackageConfig) bool {
+	for _, pkg := range packages {
+		dir := pkg.LocalDataDirectory(m.cloudManagerArgs.packagesDir)
+		if _, err := os.Stat(dir); err != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// PackagePath returns the package if it exists and already download. If it does not exist it returns a ErrPackageMissing error.
+func (m *deferredPackageManager) PackagePath(name PackageName) (string, error) {
+	if mgr := m.getCloudManager(false); mgr != nil {
+		return mgr.PackagePath(name)
+	}
+	return m.noopManager.PackagePath(name)
+}
+
+// Close manager.
+func (m *deferredPackageManager) Close(ctx context.Context) error {
+	if mgr := m.getCloudManager(false); mgr != nil {
+		return mgr.Close(ctx)
+	}
+	return m.noopManager.Close(ctx)
+}
+
+// SyncAll syncs all given packages and removes any not in the list from the local file system.
+func (m *deferredPackageManager) Sync(ctx context.Context, packages []config.PackageConfig) error {
+	shouldWait := m.isMissingPackages(packages)
+	if mgr := m.getCloudManager(shouldWait); mgr != nil {
+		return mgr.Sync(ctx, packages)
+	}
+	if shouldWait {
+		return errors.New("failed to sync packages due to a bad connection with app.viam")
+	}
+	return m.noopManager.Sync(ctx, packages)
+}
+
+// Cleanup removes all unknown packages from the working directory.
+func (m *deferredPackageManager) Cleanup(ctx context.Context) error {
+	if mgr := m.getCloudManager(false); mgr != nil {
+		return mgr.Cleanup(ctx)
+	}
+	return m.noopManager.Cleanup(ctx)
+}

--- a/robot/packages/deferred_package_manager_test.go
+++ b/robot/packages/deferred_package_manager_test.go
@@ -138,6 +138,7 @@ func TestDeferredPackageManager(t *testing.T) {
 			}
 		})
 		test.That(t, pm.getCloudManager(true), test.ShouldNotBeNil)
+		test.That(t, pm.Sync(ctx, []config.PackageConfig{}), test.ShouldBeNil)
 
 		badFile := filepath.Join(packagesDir, "data", "badfile.txt")
 		err := os.WriteFile(badFile, []byte("hello"), 0o700)

--- a/robot/packages/deferred_package_manager_test.go
+++ b/robot/packages/deferred_package_manager_test.go
@@ -1,0 +1,204 @@
+package packages
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	pb "go.viam.com/api/app/packages/v1"
+	"go.viam.com/test"
+	"go.viam.com/utils"
+
+	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/logging"
+	putils "go.viam.com/rdk/robot/packages/testutils"
+)
+
+func TestDeferredPackageManager(t *testing.T) {
+	makeFakeClient := func(t *testing.T) (pb.PackageServiceClient, *putils.FakePackagesClientAndGCSServer, func()) {
+		t.Helper()
+		logger := logging.NewTestLogger(t)
+		ctx := context.Background()
+		fakeServer, err := putils.NewFakePackageServer(ctx, logger)
+		test.That(t, err, test.ShouldBeNil)
+
+		client, conn, err := fakeServer.Client(ctx)
+		test.That(t, err, test.ShouldBeNil)
+		return client, fakeServer, func() {
+			fakeServer.Shutdown()
+			conn.Close()
+		}
+	}
+	makePM := func(t *testing.T) (*deferredPackageManager, chan DeferredConnectionResponse, string) {
+		t.Helper()
+		connectionChan := make(chan DeferredConnectionResponse)
+		cloudConfig := &config.Cloud{
+			ID:     "some-id",
+			Secret: "some-secret",
+		}
+		packagesDir := t.TempDir()
+		logger := logging.NewTestLogger(t)
+
+		pm := NewDeferredPackageManager(connectionChan, cloudConfig, packagesDir, logger).(*deferredPackageManager)
+		return pm, connectionChan, packagesDir
+	}
+
+	t.Run("getCloudManager", func(t *testing.T) {
+		client, _, closeFake := makeFakeClient(t)
+		defer closeFake()
+		pm, connectionChan, _ := makePM(t)
+
+		// Assert that the cloud manager is nil initially
+		test.That(t, pm.getCloudManager(false), test.ShouldBeNil)
+
+		// Send a client to the connection channel
+		utils.PanicCapturingGo(func() {
+			connectionChan <- DeferredConnectionResponse{
+				Client: client,
+				Err:    nil,
+			}
+		})
+
+		// Assert that the cloud manager is not nil after receiving a client
+		test.That(t, pm.getCloudManager(true), test.ShouldNotBeNil)
+	})
+
+	t.Run("isMissingPackages", func(t *testing.T) {
+		pm, _, packagesDir := makePM(t)
+
+		// Create a package config
+		packages := []config.PackageConfig{
+			{
+				Name:    "some-name",
+				Package: "org1/test-model",
+				Version: "v1",
+				Type:    "ml_model",
+			},
+		}
+
+		// Assert that the package is missing initially
+		test.That(t, pm.isMissingPackages(packages), test.ShouldBeTrue)
+
+		// Create a directory for the package
+		err := os.MkdirAll(packages[0].LocalDataDirectory(packagesDir), os.ModePerm)
+		test.That(t, err, test.ShouldBeNil)
+
+		// Assert that the package is not missing after creating the directory
+		test.That(t, pm.isMissingPackages(packages), test.ShouldBeFalse)
+	})
+
+	t.Run("sync", func(t *testing.T) {
+		ctx := context.Background()
+
+		client, fakeServer, closeFake := makeFakeClient(t)
+		defer closeFake()
+
+		pm, connectionChan, packagesDir := makePM(t)
+
+		// Send a client to the connection channel
+		utils.PanicCapturingGo(func() {
+			connectionChan <- DeferredConnectionResponse{
+				Client: client,
+				Err:    nil,
+			}
+		})
+
+		// Create a package config
+		pkg := config.PackageConfig{
+			Name:    "some-name",
+			Package: "org1/test-model",
+			Version: "v1",
+			Type:    "ml_model",
+		}
+		fakeServer.StorePackage(pkg)
+
+		// Sync the package
+		err := pm.Sync(ctx, []config.PackageConfig{pkg})
+		test.That(t, err, test.ShouldBeNil)
+
+		// Assert that the package exists in the file system
+		_, err = os.Stat(pkg.LocalDataDirectory(packagesDir))
+		test.That(t, err, test.ShouldBeNil)
+	})
+
+	t.Run("cleanup", func(t *testing.T) {
+		ctx := context.Background()
+		client, _, closeFake := makeFakeClient(t)
+		defer closeFake()
+
+		pm, connectionChan, packagesDir := makePM(t)
+
+		// Send a client to the connection channel
+		utils.PanicCapturingGo(func() {
+			connectionChan <- DeferredConnectionResponse{
+				Client: client,
+				Err:    nil,
+			}
+		})
+		test.That(t, pm.getCloudManager(true), test.ShouldNotBeNil)
+
+		badFile := filepath.Join(packagesDir, "data", "badfile.txt")
+		err := os.WriteFile(badFile, []byte("hello"), 0o700)
+		test.That(t, err, test.ShouldBeNil)
+		// Assert that the package exists in the file system
+		_, err = os.Stat(badFile)
+		test.That(t, err, test.ShouldBeNil)
+		err = pm.Cleanup(ctx)
+		test.That(t, err, test.ShouldBeNil)
+		// Assert that the package was cleaned from the file system
+		_, err = os.Stat(badFile)
+		test.That(t, err, test.ShouldNotBeNil)
+	})
+
+	t.Run("sync with failure", func(t *testing.T) {
+		ctx := context.Background()
+		pm, connectionChan, _ := makePM(t)
+
+		// Simulate a connection failure
+		utils.PanicCapturingGo(func() {
+			connectionChan <- DeferredConnectionResponse{Err: errors.New("connection failure")}
+		})
+
+		// Test syncing with a package
+		err := pm.Sync(ctx, []config.PackageConfig{{Name: "some-package", Package: "org1/test-model", Version: "v1", Type: "ml_model"}})
+		test.That(t, err, test.ShouldNotBeNil)
+	})
+
+	t.Run("packagePath", func(t *testing.T) {
+		ctx := context.Background()
+
+		client, fakeServer, closeFake := makeFakeClient(t)
+		defer closeFake()
+		pm, connectionChan, packagesDir := makePM(t)
+
+		// Send a client to the connection channel
+		utils.PanicCapturingGo(func() {
+			connectionChan <- DeferredConnectionResponse{
+				Client: client,
+				Err:    nil,
+			}
+		})
+
+		// Create a package config
+		pkg := config.PackageConfig{
+			Name:    "some-name",
+			Package: "org1/test-model",
+			Version: "v1",
+			Type:    "ml_model",
+		}
+		fakeServer.StorePackage(pkg)
+
+		// Sync the package
+		err := pm.Sync(ctx, []config.PackageConfig{pkg})
+		test.That(t, err, test.ShouldBeNil)
+
+		// Get the package path
+		path, err := pm.PackagePath(PackageName(pkg.Name))
+		test.That(t, err, test.ShouldBeNil)
+
+		// Assert that the package path is correct
+		test.That(t, path, test.ShouldEqual, pkg.LocalDataDirectory(packagesDir))
+	})
+}


### PR DESCRIPTION
Ticket : https://viam.atlassian.net/browse/RSDK-6904

// DeferredPackageManager wraps a CloudPackageManager and a goroutine that is establishing a connection to app. It starts up
// instantly and behaves as a noop package manager until a connection to app has been established.
//
// Raison d'être: AquireConnection will waste 5 seconds timing out on robots that have no internet connection but have downloaded
// all of their cloud_packages
//
// This puts an optimization on top of that behavior: On the first start of the package manager, if all of the expected packages are
// present on the system, put the connection establishment in a goroutine and use a noop_package_manager for the first Sync.
// If there are missing packages, this will still block to prevent a half-started robot.


Immediate-term: customers want/need this behavior

Short-term: we might want to refactor some of this behavior into cloud-package manager instead of this wrapper

Long-term: we should slot packages into our giant graph-refactor.