### PR TITLE
RSDK-5300 Error log proto conversion issues

### DIFF
--- a/config/proto_conversions.go
+++ b/config/proto_conversions.go
@@ -848,7 +848,7 @@ func toRDKSlice[PT, RT any](
 	for _, proto := range protoList {
 		rdk, err := toRDK(proto)
 		if err != nil {
-			logger.Debugw("error converting from proto to config", "type", reflect.TypeOf(proto).String(), "error", err)
+			logger.Errorw("error converting from proto to config", "type", reflect.TypeOf(proto).String(), "error", err)
 			if disablePartialStart {
 				return nil, err
 			}


### PR DESCRIPTION
RSDK-5300

Changes the `Debugw` log that contains errors encountering when converting to proto to an `Errorw`.