### PR TITLE
rpmMonitor refactor cont.

### DIFF
--- a/components/motor/gpio/loop.go
+++ b/components/motor/gpio/loop.go
@@ -9,7 +9,7 @@ import (
 // SetState sets the state of the motor for the built-in control loop.
 func (m *EncodedMotor) SetState(ctx context.Context, state []*control.Signal) error {
 	power := state[0].GetSignalValueAt(0)
-	return m.SetPower(ctx, power, nil)
+	return m.setPower(ctx, power)
 }
 
 // State gets the state of the motor for the built-in control loop.


### PR DESCRIPTION
The main goal of this PR is to remove as many state items as possible. currently have gotten it down to only `lastPowerPct`. There's a couple of other changes to hopefully make rpmMonitor related things simpler and more readable. 

Still need to try and removes `state.lastPowerPct` and fix the tests 