### PR TITLE
RSDK-7008: lock module manager while adding in parallel

### DIFF
--- a/examples/customresources/demos/complexmodule/moduletest/module_test.go
+++ b/examples/customresources/demos/complexmodule/moduletest/module_test.go
@@ -48,8 +48,7 @@ func TestComplexModule(t *testing.T) {
 		port = portLocal
 		test.That(t, err, test.ShouldBeNil)
 
-		serverPath, err := testutils.BuildTempModule(t, "web/cmd/server/")
-		test.That(t, err, test.ShouldBeNil)
+		serverPath := testutils.BuildTempModule(t, "web/cmd/server/")
 
 		// start the viam server with a temporary home directory so that it doesn't collide with
 		// the user's real viam home directory
@@ -332,10 +331,7 @@ func connect(port int, logger logging.Logger) (robot.Robot, error) {
 }
 
 func modifyCfg(t *testing.T, cfgIn string, logger logging.Logger) (string, int, error) {
-	modPath, err := testutils.BuildTempModule(t, "examples/customresources/demos/complexmodule")
-	if err != nil {
-		return "", 0, err
-	}
+	modPath := testutils.BuildTempModule(t, "examples/customresources/demos/complexmodule")
 
 	port, err := goutils.TryReserveRandomPort()
 	if err != nil {
@@ -388,8 +384,7 @@ func TestValidationFailure(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		port = localPort
 
-		serverPath, err := testutils.BuildTempModule(t, "web/cmd/server/")
-		test.That(t, err, test.ShouldBeNil)
+		serverPath := testutils.BuildTempModule(t, "web/cmd/server/")
 
 		// start the viam server with a temporary home directory so that it doesn't collide with
 		// the user's real viam home directory

--- a/examples/customresources/demos/simplemodule/module.go
+++ b/examples/customresources/demos/simplemodule/module.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"sync/atomic"
 
 	"github.com/pkg/errors"
@@ -105,6 +106,19 @@ func (c *counter) DoCommand(ctx context.Context, req map[string]interface{}) (ma
 		// We return the new total after the addition.
 		return map[string]interface{}{"total": atomic.LoadInt64(&c.total)}, nil
 	}
+
+	if cmd == "echo" {
+		// For testing module liveliness
+		return req, nil
+	}
+
+	if cmd == "kill_module" {
+		// For testing module reloading & unexpected exists
+		os.Exit(1)
+		// unreachable return statement needed for compilation
+		return nil, errors.New("unreachable error")
+	}
+
 	// The command must've been something else.
 	return nil, fmt.Errorf("unknown command string %s", cmd)
 }

--- a/examples/customresources/demos/simplemodule/module.go
+++ b/examples/customresources/demos/simplemodule/module.go
@@ -5,7 +5,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 	"sync/atomic"
 
 	"github.com/pkg/errors"
@@ -106,19 +105,6 @@ func (c *counter) DoCommand(ctx context.Context, req map[string]interface{}) (ma
 		// We return the new total after the addition.
 		return map[string]interface{}{"total": atomic.LoadInt64(&c.total)}, nil
 	}
-
-	if cmd == "echo" {
-		// For testing module liveliness
-		return req, nil
-	}
-
-	if cmd == "kill_module" {
-		// For testing module reloading & unexpected exists
-		os.Exit(1)
-		// unreachable return statement needed for compilation
-		return nil, errors.New("unreachable error")
-	}
-
 	// The command must've been something else.
 	return nil, fmt.Errorf("unknown command string %s", cmd)
 }

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -749,7 +749,7 @@ func (mgr *Manager) newOnUnexpectedExitHandler(mod *module) func(exitCode int) b
 		// Finally, handle orphaned resources.
 		var orphanedResourceNames []resource.Name
 		for name, res := range mod.resources {
-			if _, err := mgr.addResource(mgr.restartCtx, res.conf, res.deps); err != nil {
+			if _, err := mgr.AddResource(mgr.restartCtx, res.conf, res.deps); err != nil {
 				mgr.logger.Warnw("error while re-adding resource to module",
 					"resource", name, "module", mod.cfg.Name, "error", err)
 				mgr.rMap.Delete(name)

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -195,9 +195,10 @@ func (mgr *Manager) Handles() map[string]modlib.HandlerMap {
 //
 // Each module configuration should have a unique name - if duplicate names are detected,
 // then only the first duplicate instance will be processed and the rest will be ignored.
-//
-// This method is not thread-safe.
 func (mgr *Manager) Add(ctx context.Context, confs ...config.Module) error {
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+
 	if mgr.untrustedEnv {
 		return errModularResourcesDisabled
 	}

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -947,16 +947,6 @@ func TestTwoModulesRestart(t *testing.T) {
 			test.ShouldEqual, 2)
 	})
 
-	// for name := range models {
-	// 	resName := generic.Named(name)
-	// 	ok = mgr.IsModularResource(resName)
-	// 	test.That(t, ok, test.ShouldBeTrue)
-	// 	resp, err = res.DoCommand(ctx, map[string]interface{}{"command": "echo"})
-	// 	test.That(t, err, test.ShouldBeNil)
-	// 	test.That(t, resp, test.ShouldNotBeNil)
-	// 	test.That(t, resp["command"], test.ShouldEqual, "echo")
-	// }
-
 	err = mgr.Close(ctx)
 	test.That(t, err, test.ShouldBeNil)
 

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -878,8 +878,8 @@ func TestTwoModulesRestart(t *testing.T) {
 			Type:    config.ModuleTypeLocal,
 		},
 		{
-			Name:    "simple",
-			ExePath: rtestutils.BuildTempModuleNew(t, "examples/customresources/demos/simplemodule"),
+			Name:    "test-module2",
+			ExePath: rtestutils.BuildTempModuleNew(t, "module/testmodule2"),
 			Type:    config.ModuleTypeLocal,
 		},
 	}
@@ -911,7 +911,7 @@ func TestTwoModulesRestart(t *testing.T) {
 	// Add resources and ensure "echo" works correctly.
 	models := map[string]resource.Model{
 		"myhelper":  resource.NewModel("rdk", "test", "helper"),
-		"mycounter": resource.NewModel("acme", "demo", "mycounter"),
+		"myhelper2": resource.NewModel("rdk", "test", "helper2"),
 	}
 	for name, model := range models {
 		resName := generic.Named(name)

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -957,6 +957,6 @@ func TestTwoModulesRestart(t *testing.T) {
 	test.That(t, logs.FilterMessageSnippet("error while restarting crashed module").Len(),
 		test.ShouldEqual, 0)
 
-	// Assert that RemoveOrphanedResources was called once.
+	// Assert that RemoveOrphanedResources was called once for each module.
 	test.That(t, dummyRemoveOrphanedResourcesCallCount.Load(), test.ShouldEqual, 2)
 }

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -31,10 +31,8 @@ func TestModManagerFunctions(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 
 	// Precompile module copies to avoid timeout issues when building takes too long.
-	modPath, err := rtestutils.BuildTempModule(t, "examples/customresources/demos/simplemodule")
-	test.That(t, err, test.ShouldBeNil)
-	modPath2, err := rtestutils.BuildTempModule(t, "examples/customresources/demos/simplemodule")
-	test.That(t, err, test.ShouldBeNil)
+	modPath := rtestutils.BuildTempModule(t, "examples/customresources/demos/simplemodule")
+	modPath2 := rtestutils.BuildTempModule(t, "examples/customresources/demos/simplemodule")
 
 	myCounterModel := resource.NewModel("acme", "demo", "mycounter")
 	rNameCounter1 := resource.NewName(generic.API, "counter1")
@@ -43,7 +41,7 @@ func TestModManagerFunctions(t *testing.T) {
 		API:   generic.API,
 		Model: myCounterModel,
 	}
-	_, err = cfgCounter1.Validate("test", resource.APITypeComponentName)
+	_, err := cfgCounter1.Validate("test", resource.APITypeComponentName)
 	test.That(t, err, test.ShouldBeNil)
 
 	parentAddr, err := modlib.CreateSocketAddress(t.TempDir(), "parent")
@@ -310,8 +308,7 @@ func TestModManagerValidation(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 
 	// Precompile module to avoid timeout issues when building takes too long.
-	modPath, err := rtestutils.BuildTempModule(t, "examples/customresources/demos/complexmodule")
-	test.That(t, err, test.ShouldBeNil)
+	modPath := rtestutils.BuildTempModule(t, "examples/customresources/demos/complexmodule")
 
 	myBaseModel := resource.NewModel("acme", "demo", "mybase")
 	cfgMyBase1 := resource.Config{
@@ -323,7 +320,7 @@ func TestModManagerValidation(t *testing.T) {
 			"motorR": "motor2",
 		},
 	}
-	_, err = cfgMyBase1.Validate("test", resource.APITypeComponentName)
+	_, err := cfgMyBase1.Validate("test", resource.APITypeComponentName)
 	test.That(t, err, test.ShouldBeNil)
 	// cfgMyBase2 is missing required attributes "motorL" and "motorR" and should
 	// cause module Validation error.
@@ -412,9 +409,7 @@ func TestModuleReloading(t *testing.T) {
 		logger, logs := logging.NewObservedTestLogger(t)
 
 		// Precompile module to avoid timeout issues when building takes too long.
-		modPath, err := rtestutils.BuildTempModule(t, "module/testmodule")
-		test.That(t, err, test.ShouldBeNil)
-		modCfg.ExePath = modPath
+		modCfg.ExePath = rtestutils.BuildTempModule(t, "module/testmodule")
 
 		// This test neither uses a resource manager nor asserts anything about
 		// the existence of resources in the graph. Use a dummy
@@ -479,9 +474,7 @@ func TestModuleReloading(t *testing.T) {
 		logger, logs := logging.NewObservedTestLogger(t)
 
 		// Precompile module to avoid timeout issues when building takes too long.
-		modPath, err := rtestutils.BuildTempModule(t, "module/testmodule")
-		test.That(t, err, test.ShouldBeNil)
-		modCfg.ExePath = modPath
+		modCfg.ExePath = rtestutils.BuildTempModule(t, "module/testmodule")
 
 		// This test neither uses a resource manager nor asserts anything about
 		// the existence of resources in the graph. Use a dummy
@@ -511,7 +504,7 @@ func TestModuleReloading(t *testing.T) {
 
 		// Remove testmodule binary, so process cannot be successfully restarted
 		// after crash.
-		err = os.Remove(modPath)
+		err = os.Remove(modCfg.ExePath)
 		test.That(t, err, test.ShouldBeNil)
 
 		// Run 'kill_module' command through helper resource to cause module to
@@ -622,8 +615,7 @@ func TestDebugModule(t *testing.T) {
 	ctx := context.Background()
 
 	// Precompile module to avoid timeout issues when building takes too long.
-	modPath, err := rtestutils.BuildTempModule(t, "module/testmodule")
-	test.That(t, err, test.ShouldBeNil)
+	modPath := rtestutils.BuildTempModule(t, "module/testmodule")
 
 	parentAddr, err := modlib.CreateSocketAddress(t.TempDir(), "parent")
 	test.That(t, err, test.ShouldBeNil)
@@ -725,8 +717,7 @@ func TestModuleMisc(t *testing.T) {
 	}()
 
 	// Build the testmodule
-	modPath, err := rtestutils.BuildTempModule(t, "module/testmodule")
-	test.That(t, err, test.ShouldBeNil)
+	modPath := rtestutils.BuildTempModule(t, "module/testmodule")
 	modCfg := config.Module{
 		Name:    "test-module",
 		ExePath: modPath,
@@ -874,12 +865,12 @@ func TestTwoModulesRestart(t *testing.T) {
 	modCfgs := []config.Module{
 		{
 			Name:    "test-module",
-			ExePath: rtestutils.BuildTempModuleNew(t, "module/testmodule"),
+			ExePath: rtestutils.BuildTempModule(t, "module/testmodule"),
 			Type:    config.ModuleTypeLocal,
 		},
 		{
 			Name:    "test-module2",
-			ExePath: rtestutils.BuildTempModuleNew(t, "module/testmodule2"),
+			ExePath: rtestutils.BuildTempModule(t, "module/testmodule2"),
 			Type:    config.ModuleTypeLocal,
 		},
 	}

--- a/module/module_interceptors_test.go
+++ b/module/module_interceptors_test.go
@@ -46,11 +46,8 @@ func TestOpID(t *testing.T) {
 			test.That(t, os.Remove(cfgFilename), test.ShouldBeNil)
 		}()
 
-		serverPath, err := rtestutils.BuildTempModule(t, "web/cmd/server/")
-		test.That(t, err, test.ShouldBeNil)
-
 		server := pexec.NewManagedProcess(pexec.ProcessConfig{
-			Name: serverPath,
+			Name: rtestutils.BuildTempModule(t, "web/cmd/server/"),
 			Args: []string{"-config", cfgFilename},
 			CWD:  utils.ResolveFile("./"),
 			Log:  true,
@@ -155,10 +152,7 @@ func TestOpID(t *testing.T) {
 
 func makeConfig(t *testing.T, logger logging.Logger) (string, int, error) {
 	// Precompile module to avoid timeout issues when building takes too long.
-	modPath, err := rtestutils.BuildTempModule(t, "module/testmodule")
-	if err != nil {
-		return "", 0, err
-	}
+	modPath := rtestutils.BuildTempModule(t, "module/testmodule")
 
 	port, err := goutils.TryReserveRandomPort()
 	if err != nil {

--- a/module/testmodule2/.gitignore
+++ b/module/testmodule2/.gitignore
@@ -1,0 +1,1 @@
+testmodule

--- a/module/testmodule2/main.go
+++ b/module/testmodule2/main.go
@@ -1,0 +1,228 @@
+// Package main is a module for testing, with an inline generic component to return internal data and perform other test functions.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/pkg/errors"
+	"go.viam.com/utils"
+
+	"go.viam.com/rdk/components/generic"
+	"go.viam.com/rdk/components/motor"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/module"
+	"go.viam.com/rdk/resource"
+)
+
+// TODO(RSDK-7044): this entire module is a copy of `module/testmodule` but with
+// resources in a different namespace. It exists to support tests that require more than
+// one module. It would be better to have a facility to create test modules on demand.
+var (
+	helperModel    = resource.NewModel("rdk", "test", "helper2")
+	testMotorModel = resource.NewModel("rdk", "test", "motor2")
+	myMod          *module.Module
+)
+
+func main() {
+	utils.ContextualMain(mainWithArgs, module.NewLoggerFromArgs("TestModule2"))
+}
+
+func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) error {
+	logger.Debug("debug mode enabled")
+
+	var err error
+	myMod, err = module.NewModuleFromArgs(ctx, logger)
+	if err != nil {
+		return err
+	}
+
+	resource.RegisterComponent(
+		generic.API,
+		helperModel,
+		resource.Registration[resource.Resource, resource.NoNativeConfig]{Constructor: newHelper})
+	err = myMod.AddModelFromRegistry(ctx, generic.API, helperModel)
+	if err != nil {
+		return err
+	}
+
+	resource.RegisterComponent(
+		motor.API,
+		testMotorModel,
+		resource.Registration[resource.Resource, resource.NoNativeConfig]{Constructor: newTestMotor})
+	err = myMod.AddModelFromRegistry(ctx, motor.API, testMotorModel)
+	if err != nil {
+		return err
+	}
+
+	err = myMod.Start(ctx)
+	defer myMod.Close(ctx)
+	if err != nil {
+		return err
+	}
+	<-ctx.Done()
+	return nil
+}
+
+func newHelper(
+	ctx context.Context, deps resource.Dependencies, conf resource.Config, logger logging.Logger,
+) (resource.Resource, error) {
+	return &helper{
+		Named:  conf.ResourceName().AsNamed(),
+		logger: logger,
+	}, nil
+}
+
+type helper struct {
+	resource.Named
+	resource.TriviallyReconfigurable
+	resource.TriviallyCloseable
+	logger logging.Logger
+}
+
+// DoCommand is the only method of this component. It looks up the "real" command from the map it's passed.
+//
+
+func (h *helper) DoCommand(ctx context.Context, req map[string]interface{}) (map[string]interface{}, error) {
+	cmd, ok := req["command"]
+	if !ok {
+		return nil, errors.New("missing 'command' string")
+	}
+
+	switch req["command"] {
+	case "sleep":
+		time.Sleep(time.Second * 1)
+		//nolint:nilnil
+		return nil, nil
+	case "get_ops":
+		// For testing the module's operation manager
+		ops := myMod.OperationManager().All()
+		var opsOut []string
+		for _, op := range ops {
+			opsOut = append(opsOut, op.ID.String())
+		}
+		return map[string]interface{}{"ops": opsOut}, nil
+	case "echo":
+		// For testing module liveliness
+		return req, nil
+	case "kill_module":
+		// For testing module reloading & unexpected exists
+		os.Exit(1)
+		// unreachable return statement needed for compilation
+		return nil, errors.New("unreachable error")
+	case "write_data_file":
+		// For testing that the module's data directory has been created and that the VIAM_MODULE_DATA env var exists
+		filename, ok := req["filename"].(string)
+		if !ok {
+			return nil, errors.New("missing 'filename' string")
+		}
+		contents, ok := req["contents"].(string)
+		if !ok {
+			return nil, errors.New("missing 'contents' string")
+		}
+		dataFilePath := filepath.Join(os.Getenv("VIAM_MODULE_DATA"), filename)
+		err := os.WriteFile(dataFilePath, []byte(contents), 0o600)
+		if err != nil {
+			return map[string]interface{}{}, err
+		}
+		return map[string]interface{}{"fullpath": dataFilePath}, nil
+	case "get_working_directory":
+		// For testing that modules are started with the correct working directory
+		workingDir, err := os.Getwd()
+		if err != nil {
+			return map[string]interface{}{}, err
+		}
+		return map[string]interface{}{"path": workingDir}, nil
+	case "log":
+		level, err := logging.LevelFromString(req["level"].(string))
+		if err != nil {
+			return nil, err
+		}
+
+		msg := req["msg"].(string)
+		switch level {
+		case logging.DEBUG:
+			h.logger.CDebugw(ctx, msg, "foo", "bar")
+		case logging.INFO:
+			h.logger.CInfow(ctx, msg, "foo", "bar")
+		case logging.WARN:
+			h.logger.CWarnw(ctx, msg, "foo", "bar")
+		case logging.ERROR:
+			h.logger.CErrorw(ctx, msg, "foo", "bar")
+		}
+
+		return map[string]any{}, nil
+	default:
+		return nil, fmt.Errorf("unknown command string %s", cmd)
+	}
+}
+
+func newTestMotor(
+	ctx context.Context, deps resource.Dependencies, conf resource.Config, logger logging.Logger,
+) (resource.Resource, error) {
+	return &testMotor{
+		Named: conf.ResourceName().AsNamed(),
+	}, nil
+}
+
+type testMotor struct {
+	resource.Named
+	resource.TriviallyReconfigurable
+	resource.TriviallyCloseable
+}
+
+var _ motor.Motor = &testMotor{}
+
+// SetPower trivially implements motor.Motor.
+func (tm *testMotor) SetPower(_ context.Context, _ float64, _ map[string]interface{}) error {
+	return nil
+}
+
+// GoFor trivially implements motor.Motor.
+func (tm *testMotor) GoFor(_ context.Context, _, _ float64, _ map[string]interface{}) error {
+	return nil
+}
+
+// GoTo trivially implements motor.Motor.
+func (tm *testMotor) GoTo(_ context.Context, _, _ float64, _ map[string]interface{}) error {
+	return nil
+}
+
+// ResetZeroPosition trivially implements motor.Motor.
+func (tm *testMotor) ResetZeroPosition(_ context.Context, _ float64, _ map[string]interface{}) error {
+	return nil
+}
+
+// Position trivially implements motor.Motor.
+func (tm *testMotor) Position(_ context.Context, _ map[string]interface{}) (float64, error) {
+	return 0.0, nil
+}
+
+// Properties trivially implements motor.Motor.
+func (tm *testMotor) Properties(_ context.Context, _ map[string]interface{}) (motor.Properties, error) {
+	return motor.Properties{}, nil
+}
+
+// Stop trivially implements motor.Motor.
+func (tm *testMotor) Stop(_ context.Context, _ map[string]interface{}) error {
+	return nil
+}
+
+// IsPowered trivally implements motor.Motor.
+func (tm *testMotor) IsPowered(_ context.Context, _ map[string]interface{}) (bool, float64, error) {
+	return false, 0.0, nil
+}
+
+// DoCommand trivially implements motor.Motor.
+func (tm *testMotor) DoCommand(_ context.Context, _ map[string]interface{}) (map[string]interface{}, error) {
+	//nolint:nilnil
+	return nil, nil
+}
+
+// IsMoving trivially implements motor.Motor.
+func (tm *testMotor) IsMoving(context.Context) (bool, error) {
+	return false, nil
+}

--- a/module/testmodule2/run.sh
+++ b/module/testmodule2/run.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+cd `dirname $0`
+
+go build ./
+exec ./testmodule $@

--- a/robot/impl/discovery_test.go
+++ b/robot/impl/discovery_test.go
@@ -156,10 +156,8 @@ func TestDiscovery(t *testing.T) {
 		test.That(t, discoveries, test.ShouldResemble, []resource.Discovery{{Query: modManagerQ, Results: expectedDiscovery}})
 
 		// add modules
-		complexPath, err := rtestutils.BuildTempModule(t, "examples/customresources/demos/complexmodule")
-		test.That(t, err, test.ShouldBeNil)
-		simplePath, err := rtestutils.BuildTempModule(t, "examples/customresources/demos/simplemodule")
-		test.That(t, err, test.ShouldBeNil)
+		complexPath := rtestutils.BuildTempModule(t, "examples/customresources/demos/complexmodule")
+		simplePath := rtestutils.BuildTempModule(t, "examples/customresources/demos/simplemodule")
 		cfg := &config.Config{
 			Modules: []config.Module{
 				{

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -1851,8 +1851,7 @@ func TestConfigMethod(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 
 	// Precompile complex module to avoid timeout issues when building takes too long.
-	complexPath, err := rtestutils.BuildTempModule(t, "examples/customresources/demos/complexmodule")
-	test.That(t, err, test.ShouldBeNil)
+	complexPath := rtestutils.BuildTempModule(t, "examples/customresources/demos/complexmodule")
 
 	r, shutdown := initTestRobot(t, context.Background(), &config.Config{}, logger)
 	defer shutdown()
@@ -2491,12 +2490,9 @@ func TestOrphanedResources(t *testing.T) {
 	logger, logs := logging.NewObservedTestLogger(t)
 
 	// Precompile modules to avoid timeout issues when building takes too long.
-	complexPath, err := rtestutils.BuildTempModule(t, "examples/customresources/demos/complexmodule")
-	test.That(t, err, test.ShouldBeNil)
-	simplePath, err := rtestutils.BuildTempModule(t, "examples/customresources/demos/simplemodule")
-	test.That(t, err, test.ShouldBeNil)
-	testPath, err := rtestutils.BuildTempModule(t, "module/testmodule")
-	test.That(t, err, test.ShouldBeNil)
+	complexPath := rtestutils.BuildTempModule(t, "examples/customresources/demos/complexmodule")
+	simplePath := rtestutils.BuildTempModule(t, "examples/customresources/demos/simplemodule")
+	testPath := rtestutils.BuildTempModule(t, "module/testmodule")
 
 	// Manually define models, as importing them can cause double registration.
 	gizmoModel := resource.NewModel("acme", "demo", "mygizmo")
@@ -2671,8 +2667,7 @@ func TestOrphanedResources(t *testing.T) {
 		// Assert that replacing testmodule binary with disguised simplemodule
 		// binary and killing testmodule orphans helper 'h' (not reachable), as
 		// simplemodule binary cannot manage helper 'h'.
-		tmpPath, err := rtestutils.BuildTempModule(t, "examples/customresources/demos/simplemodule")
-		test.That(t, err, test.ShouldBeNil)
+		tmpPath := rtestutils.BuildTempModule(t, "examples/customresources/demos/simplemodule")
 		err = os.Rename(tmpPath, testPath)
 		test.That(t, err, test.ShouldBeNil)
 		_, err = h.DoCommand(ctx, map[string]interface{}{"command": "kill_module"})
@@ -2726,10 +2721,8 @@ func TestDependentAndOrphanedResources(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 
 	// Precompile modules to avoid timeout issues when building takes too long.
-	complexPath, err := rtestutils.BuildTempModule(t, "examples/customresources/demos/complexmodule")
-	test.That(t, err, test.ShouldBeNil)
-	simplePath, err := rtestutils.BuildTempModule(t, "examples/customresources/demos/simplemodule")
-	test.That(t, err, test.ShouldBeNil)
+	complexPath := rtestutils.BuildTempModule(t, "examples/customresources/demos/complexmodule")
+	simplePath := rtestutils.BuildTempModule(t, "examples/customresources/demos/simplemodule")
 
 	// Manually define gizmo model, as importing it from mygizmo can cause double
 	// registration.
@@ -2902,8 +2895,7 @@ func TestModuleDebugReconfigure(t *testing.T) {
 	logger, logs := rtestutils.NewInfoObservedTestLogger(t)
 
 	// Precompile module to avoid timeout issues when building takes too long.
-	testPath, err := rtestutils.BuildTempModule(t, "module/testmodule")
-	test.That(t, err, test.ShouldBeNil)
+	testPath := rtestutils.BuildTempModule(t, "module/testmodule")
 
 	// Create robot with testmodule with LogLevel unset and assert that after two
 	// seconds, "debug mode enabled" debug log is not output by testmodule.
@@ -2946,8 +2938,7 @@ func TestResourcelessModuleRemove(t *testing.T) {
 	logger, logs := logging.NewObservedTestLogger(t)
 
 	// Precompile module to avoid timeout issues when building takes too long.
-	testPath, err := rtestutils.BuildTempModule(t, "module/testmodule")
-	test.That(t, err, test.ShouldBeNil)
+	testPath := rtestutils.BuildTempModule(t, "module/testmodule")
 
 	cfg := &config.Config{
 		Modules: []config.Module{
@@ -2974,8 +2965,7 @@ func TestCrashedModuleReconfigure(t *testing.T) {
 	ctx := context.Background()
 	logger, logs := logging.NewObservedTestLogger(t)
 
-	testPath, err := rtestutils.BuildTempModule(t, "module/testmodule")
-	test.That(t, err, test.ShouldBeNil)
+	testPath := rtestutils.BuildTempModule(t, "module/testmodule")
 
 	// Manually define model, as importing it can cause double registration.
 	helperModel := resource.NewModel("rdk", "test", "helper")
@@ -2998,7 +2988,7 @@ func TestCrashedModuleReconfigure(t *testing.T) {
 	r, shutdown := initTestRobot(t, ctx, cfg, logger)
 	defer shutdown()
 
-	_, err = r.ResourceByName(generic.Named("h"))
+	_, err := r.ResourceByName(generic.Named("h"))
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Run("reconfiguration timeout", func(t *testing.T) {
@@ -3042,10 +3032,8 @@ func TestImplicitDepsAcrossModules(t *testing.T) {
 	logger, _ := logging.NewObservedTestLogger(t)
 
 	// Precompile modules to avoid timeout issues when building takes too long.
-	complexPath, err := rtestutils.BuildTempModule(t, "examples/customresources/demos/complexmodule")
-	test.That(t, err, test.ShouldBeNil)
-	testPath, err := rtestutils.BuildTempModule(t, "module/testmodule")
-	test.That(t, err, test.ShouldBeNil)
+	complexPath := rtestutils.BuildTempModule(t, "examples/customresources/demos/complexmodule")
+	testPath := rtestutils.BuildTempModule(t, "module/testmodule")
 
 	// Manually define models, as importing them can cause double registration.
 	myBaseModel := resource.NewModel("acme", "demo", "mybase")
@@ -3087,7 +3075,7 @@ func TestImplicitDepsAcrossModules(t *testing.T) {
 	r, shutdown := initTestRobot(t, ctx, cfg, logger)
 	defer shutdown()
 
-	_, err = r.ResourceByName(base.Named("b"))
+	_, err := r.ResourceByName(base.Named("b"))
 	test.That(t, err, test.ShouldBeNil)
 	_, err = r.ResourceByName(motor.Named("m1"))
 	test.That(t, err, test.ShouldBeNil)

--- a/robot/impl/resource_manager_modular_test.go
+++ b/robot/impl/resource_manager_modular_test.go
@@ -476,8 +476,7 @@ func (m *dummyModMan) Close(ctx context.Context) error {
 }
 
 func TestDynamicModuleLogging(t *testing.T) {
-	modPath, err := rtestutils.BuildTempModule(t, "module/testmodule")
-	test.That(t, err, test.ShouldBeNil)
+	modPath := rtestutils.BuildTempModule(t, "module/testmodule")
 
 	ctx := context.Background()
 	logger, observer := logging.NewObservedTestLogger(t)
@@ -556,10 +555,8 @@ func TestTwoModulesSameName(t *testing.T) {
 	ctx := context.Background()
 	logger := logging.NewTestLogger(t)
 
-	simplePath, err := rtestutils.BuildTempModule(t, "examples/customresources/demos/simplemodule")
-	test.That(t, err, test.ShouldBeNil)
-	complexPath, err := rtestutils.BuildTempModule(t, "examples/customresources/demos/complexmodule")
-	test.That(t, err, test.ShouldBeNil)
+	simplePath := rtestutils.BuildTempModule(t, "examples/customresources/demos/simplemodule")
+	complexPath := rtestutils.BuildTempModule(t, "examples/customresources/demos/complexmodule")
 
 	cfg := &config.Config{
 		Modules: []config.Module{

--- a/testutils/file_utils.go
+++ b/testutils/file_utils.go
@@ -1,39 +1,20 @@
 package testutils
 
 import (
-	"fmt"
 	"os/exec"
 	"path/filepath"
 	"sync"
 	"testing"
 
-	"go.uber.org/multierr"
 	v1 "go.viam.com/api/app/datasync/v1"
 
 	"go.viam.com/rdk/utils"
 )
 
-// BuildTempModule will run "go build ." in the provided RDK directory and return
-// the path to the built temporary file and any build related errors.
-func BuildTempModule(tb testing.TB, dir string) (string, error) {
-	tb.Helper()
-	modPath := filepath.Join(tb.TempDir(), filepath.Base(dir))
-	//nolint:gosec
-	builder := exec.Command("go", "build", "-o", modPath, ".")
-	builder.Dir = utils.ResolveFile(dir)
-	out, err := builder.CombinedOutput()
-	if len(out) != 0 || err != nil {
-		return modPath, multierr.Combine(err, fmt.Errorf(`output from "go build .": %s`, out))
-	}
-	return modPath, nil
-}
-
-// BuildTempModuleNew will run "go build ." in the provided RDK directory and return the
-// path to the built temporary file. This function will fail if there are any
-// build-related errors.
-//
-// TODO: replace all instances of `BuildTempModule` with this function!
-func BuildTempModuleNew(tb testing.TB, dir string) string {
+// BuildTempModule will run "go build ." in the provided RDK directory and return the
+// path to the built temporary file. This function will fail the current test if there
+// are any build-related errors.
+func BuildTempModule(tb testing.TB, dir string) string {
 	tb.Helper()
 	modPath := filepath.Join(tb.TempDir(), filepath.Base(dir))
 	//nolint:gosec

--- a/testutils/file_utils.go
+++ b/testutils/file_utils.go
@@ -28,6 +28,30 @@ func BuildTempModule(tb testing.TB, dir string) (string, error) {
 	return modPath, nil
 }
 
+// TODO: replace all instances of `BuildTempModule` with this function!
+//
+// BuildTempModuleNew will run "go build ." in the provided RDK directory and return the
+// path to the built temporary file. This function will fail if there are any
+// build-related errors.
+func BuildTempModuleNew(tb testing.TB, dir string) string {
+	tb.Helper()
+	modPath := filepath.Join(tb.TempDir(), filepath.Base(dir))
+	//nolint:gosec
+	builder := exec.Command("go", "build", "-o", modPath, ".")
+	builder.Dir = utils.ResolveFile(dir)
+	out, err := builder.CombinedOutput()
+	if len(out) != 0 {
+		tb.Errorf(`output from "go build .": %s`, out)
+	}
+	if err != nil {
+		tb.Error(err)
+	}
+	if tb.Failed() {
+		tb.Fatalf("failed to build temporary module for testing")
+	}
+	return modPath
+}
+
 // MockBuffer is a buffered writer that just appends data to an array to read
 // without needing a real file system for testing.
 type MockBuffer struct {

--- a/testutils/file_utils.go
+++ b/testutils/file_utils.go
@@ -28,11 +28,11 @@ func BuildTempModule(tb testing.TB, dir string) (string, error) {
 	return modPath, nil
 }
 
-// TODO: replace all instances of `BuildTempModule` with this function!
-//
 // BuildTempModuleNew will run "go build ." in the provided RDK directory and return the
 // path to the built temporary file. This function will fail if there are any
 // build-related errors.
+//
+// TODO: replace all instances of `BuildTempModule` with this function!
 func BuildTempModuleNew(tb testing.TB, dir string) string {
 	tb.Helper()
 	modPath := filepath.Join(tb.TempDir(), filepath.Base(dir))

--- a/web/server/entrypoint_test.go
+++ b/web/server/entrypoint_test.go
@@ -35,8 +35,7 @@ func TestEntrypoint(t *testing.T) {
 	if runtime.GOARCH == "arm" {
 		t.Skip("skipping on 32-bit ARM, subprocess build warnings cause failure")
 	}
-	serverPath, err := testutils.BuildTempModule(t, "web/cmd/server/")
-	test.That(t, err, test.ShouldBeNil)
+	serverPath := testutils.BuildTempModule(t, "web/cmd/server/")
 
 	t.Run("number of resources", func(t *testing.T) {
 		logger, logObserver := logging.NewObservedTestLogger(t)
@@ -55,9 +54,7 @@ func TestEntrypoint(t *testing.T) {
 			cfgFilename, err = robottestutils.MakeTempConfig(t, cfg, logger)
 			test.That(t, err, test.ShouldBeNil)
 
-			serverPath, err := testutils.BuildTempModule(t, "web/cmd/server/")
-			test.That(t, err, test.ShouldBeNil)
-
+			serverPath := testutils.BuildTempModule(t, "web/cmd/server/")
 			server := pexec.NewManagedProcess(pexec.ProcessConfig{
 				Name: serverPath,
 				Args: []string{"-config", cfgFilename},


### PR DESCRIPTION
Follow-up to https://github.com/viamrobotics/rdk/pull/3641 - we [stopped locking on individual module adds](https://github.com/viamrobotics/rdk/pull/3641/files#diff-a4308b77f384da81096eda21bf023471e80818dda86e74f9335f99a6a57d07c9L148-L149) to enable parallel adding, but there's no reason we can't lock while adding a batch.

Also adds:
* A new test module that isn't simple or complex module, to support testing scenarios that involve two modules
* Improves the `BuildTempModule` testing helper