### PR TITLE
RSDK-6908 Do not drop net logger batches

### DIFF
--- a/logging/net_appender.go
+++ b/logging/net_appender.go
@@ -248,8 +248,8 @@ func (nl *NetAppender) syncOnce() (bool, error) {
 	nl.toLogMutex.Lock()
 	defer nl.toLogMutex.Unlock()
 
-	// If we've overflowed more times than the size of the batch we wrote, do not
-	// mutate toLog at all.
+	// Remove successfully synced logs from the queue. If we've overflowed more times than the size of the batch
+	//  we wrote, do not mutate toLog at all.
 	if batchSize > nl.toLogOverflowsSinceLastSync {
 		nl.toLog = nl.toLog[batchSize-nl.toLogOverflowsSinceLastSync:]
 	}

--- a/logging/net_appender.go
+++ b/logging/net_appender.go
@@ -19,7 +19,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-const (
+var (
 	defaultMaxQueueSize = 20000
 	writeBatchSize      = 100
 )
@@ -63,8 +63,11 @@ type NetAppender struct {
 	hostname     string
 	remoteWriter *remoteLogWriterGRPC
 
-	toLogMutex   sync.Mutex
-	toLog        []*commonpb.LogEntry
+	// toLogMutex guards toLog and toLogOverflowsSinceLastSync.
+	toLogMutex                  sync.Mutex
+	toLog                       []*commonpb.LogEntry
+	toLogOverflowsSinceLastSync int
+
 	maxQueueSize int
 
 	cancelCtx               context.Context
@@ -155,6 +158,8 @@ func (nl *NetAppender) Write(e zapcore.Entry, f []zapcore.Field) error {
 	return nil
 }
 
+// addToQueue adds a LogEntry to the net appender's queue, discarding the
+// oldest entry in the queue if the size of the queue has overflowed.
 func (nl *NetAppender) addToQueue(logEntry *commonpb.LogEntry) {
 	nl.toLogMutex.Lock()
 	defer nl.toLogMutex.Unlock()
@@ -162,10 +167,14 @@ func (nl *NetAppender) addToQueue(logEntry *commonpb.LogEntry) {
 	if len(nl.toLog) >= nl.maxQueueSize {
 		// TODO(erh): sample?
 		nl.toLog = nl.toLog[1:]
+		nl.toLogOverflowsSinceLastSync++
 	}
 	nl.toLog = append(nl.toLog, logEntry)
 }
 
+// addBatchToQueue adds a slice of LogEntrys to the net appender's queue,
+// trimming the front of the batch to be less than maxQueueSize, and discarding
+// the oldest len(batch) entries in the queue if the queue has overflowed.
 func (nl *NetAppender) addBatchToQueue(batch []*commonpb.LogEntry) {
 	if len(batch) == 0 {
 		return
@@ -180,7 +189,9 @@ func (nl *NetAppender) addBatchToQueue(batch []*commonpb.LogEntry) {
 
 	if len(nl.toLog)+len(batch) >= nl.maxQueueSize {
 		// TODO(erh): sample?
-		nl.toLog = nl.toLog[len(nl.toLog)+len(batch)-nl.maxQueueSize:]
+		overflow := len(nl.toLog) + len(batch) - nl.maxQueueSize
+		nl.toLog = nl.toLog[overflow:]
+		nl.toLogOverflowsSinceLastSync += overflow
 	}
 
 	nl.toLog = append(nl.toLog, batch...)
@@ -209,9 +220,7 @@ func (nl *NetAppender) backgroundWorker() {
 }
 
 // Returns whether there is more work to do or if an error was encountered
-// while trying to ship logs over the network. May be run concurrently with
-// addToQueue and addBatchToQueue but expects that no logs will be removed
-// from queue during syncing.
+// while trying to ship logs over the network.
 func (nl *NetAppender) syncOnce() (bool, error) {
 	nl.toLogMutex.Lock()
 
@@ -225,8 +234,10 @@ func (nl *NetAppender) syncOnce() (bool, error) {
 		batchSize = len(nl.toLog)
 	}
 
-	// Pull a batch from the queue, unlock mutex, and return an error if write
-	// fails. Lock mutex again to remove batch from queue only if write succeeded.
+	// Read a batch from the queue, unlock mutex, and return an error if write
+	// fails. Lock mutex again to remove batch from queue only if write succeeded
+	// and front of queue was not mutated by addToQueue/addBatchToQueue throwing
+	// away the oldest logs due to overflows beyond maxQueueSize.
 	batch := nl.toLog[:batchSize]
 	nl.toLogMutex.Unlock()
 
@@ -236,7 +247,13 @@ func (nl *NetAppender) syncOnce() (bool, error) {
 
 	nl.toLogMutex.Lock()
 	defer nl.toLogMutex.Unlock()
-	nl.toLog = nl.toLog[batchSize:]
+
+	// If we've overflowed more times than the size of the batch we wrote, do not
+	// mutate toLog at all.
+	if batchSize > nl.toLogOverflowsSinceLastSync {
+		nl.toLog = nl.toLog[batchSize-nl.toLogOverflowsSinceLastSync:]
+	}
+	nl.toLogOverflowsSinceLastSync = 0
 	return len(nl.toLog) > 0, nil
 }
 

--- a/logging/net_appender_test.go
+++ b/logging/net_appender_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"sync"
 	"testing"
+	"time"
 
 	apppb "go.viam.com/api/app/v1"
 	commonpb "go.viam.com/api/common/v1"
@@ -177,4 +178,54 @@ func TestNetLoggerBatchFailureAndRetry(t *testing.T) {
 		test.That(t, server.service.logs[i].Message, test.ShouldEqual, "Some-info")
 	}
 	test.That(t, server.service.logs[numLogs-1].Message, test.ShouldEqual, "New info")
+}
+
+func TestNetLoggerOverflowDuringWrite(t *testing.T) {
+	// Lower defaultMaxQueueSize for test.
+	originalDefaultMaxQueueSize := defaultMaxQueueSize
+	defaultMaxQueueSize = 10
+	defer func() {
+		defaultMaxQueueSize = originalDefaultMaxQueueSize
+	}()
+
+	server := makeServerForRobotLogger(t)
+	defer server.stop()
+
+	netAppender, err := NewNetAppender(server.cloudConfig)
+	test.That(t, err, test.ShouldBeNil)
+	logger := NewDebugLogger("test logger")
+	logger.AddAppender(netAppender)
+
+	// Lock server logsMu to mimic network latency for log syncing. Inject max
+	// number of logs into netAppender queue. Wait for a Sync: syncOnce should
+	// read the created, injected batch, send it to the server, and hang on
+	// receiving a non-nil err.
+	server.service.logsMu.Lock()
+	for i := 0; i < defaultMaxQueueSize; i++ {
+		netAppender.addToQueue(&commonpb.LogEntry{Message: fmt.Sprint(i)})
+	}
+
+	// Sleep to ensure syncOnce happens (normally every 100ms) and hangs in
+	// receiving non-nil error from write to remote.
+	time.Sleep(300 * time.Millisecond)
+
+	// This "10" log should "overflow" the netAppender queue and remove the "0"
+	// (oldest) log. syncOnce should sense that an overflow occured and only
+	// remove "1"-"9" from the queue.
+	logger.Info("10")
+	server.service.logsMu.Unlock()
+
+	// Close net appender to cause final syncOnce that sends batch of logs after
+	// overflow was accounted for: ["10"].
+	netAppender.Close()
+
+	// Server should have received logs with Messages: ["0", "1", "2", "3", "4",
+	// "5", "6", "7", "8", "9", "10"].
+	server.service.logsMu.Lock()
+	defer server.service.logsMu.Unlock()
+	test.That(t, server.service.logs, test.ShouldHaveLength, 11)
+	for i := 0; i < 11; i++ {
+		// First batch of "0"-"10".
+		test.That(t, server.service.logs[i].Message, test.ShouldEqual, fmt.Sprint(i))
+	}
 }

--- a/logging/net_appender_test.go
+++ b/logging/net_appender_test.go
@@ -210,7 +210,7 @@ func TestNetLoggerOverflowDuringWrite(t *testing.T) {
 	time.Sleep(300 * time.Millisecond)
 
 	// This "10" log should "overflow" the netAppender queue and remove the "0"
-	// (oldest) log. syncOnce should sense that an overflow occured and only
+	// (oldest) log. syncOnce should sense that an overflow occurred and only
 	// remove "1"-"9" from the queue.
 	logger.Info("10")
 	server.service.logsMu.Unlock()

--- a/logging/net_appender_test.go
+++ b/logging/net_appender_test.go
@@ -130,3 +130,51 @@ func TestNetLoggerBatchWrites(t *testing.T) {
 		test.That(t, server.service.logs[i].Message, test.ShouldEqual, "Some-info")
 	}
 }
+
+func TestNetLoggerBatchFailureAndRetry(t *testing.T) {
+	server := makeServerForRobotLogger(t)
+	defer server.stop()
+
+	netAppender, err := NewNetAppender(server.cloudConfig)
+	test.That(t, err, test.ShouldBeNil)
+	logger := NewDebugLogger("test logger")
+	// The stdout appender is not necessary for test correctness. But it does provide information in
+	// the output w.r.t the injected grpc errors.
+	logger.AddAppender(netAppender)
+
+	// This test will first log 10 "Some-info" logs. Followed by a single "New info" log.
+	numLogs := 11
+
+	// Inject a failure into the server handling `Log` requests.
+	server.service.logsMu.Lock()
+	server.service.logFailForSizeCount = numLogs
+	server.service.logsMu.Unlock()
+
+	for i := 0; i < numLogs-1; i++ {
+		logger.Info("Some-info")
+	}
+
+	// This test requires at least three syncs for the logs to be guaranteed received by the
+	// server. Once the log queue is full of size ten batches, the first sync will decrement
+	// `logFailForSizeCount` to 1 and return an error. The second will decrement it to a negative
+	// value and return an error. The third will succeed.
+	//
+	// This test depends on the `Close` method performing a `Sync`.
+	//
+	// The `netAppender` also has a background worker syncing on its own cadence. This complicates
+	// exactly which syncs do what work and which ones return errors.
+	netAppender.Sync()
+
+	logger.Info("New info")
+
+	netAppender.Sync()
+	netAppender.Close()
+
+	server.service.logsMu.Lock()
+	defer server.service.logsMu.Unlock()
+	test.That(t, server.service.logs, test.ShouldHaveLength, numLogs)
+	for i := 0; i < numLogs-1; i++ {
+		test.That(t, server.service.logs[i].Message, test.ShouldEqual, "Some-info")
+	}
+	test.That(t, server.service.logs[numLogs-1].Message, test.ShouldEqual, "New info")
+}


### PR DESCRIPTION
RSDK-6908

Stops unconditionally removing batches from the net logger queue for every `write`; only removes batches from queue in the case of `write` success. Keeps the mutex unlocked during actual `write` I/O. Re-adds test removed in https://github.com/viamrobotics/rdk/pull/3678 to ensure batches are not dropped.