### PR TITLE
Allow IsPowered to return negative power percentages.

### DIFF
--- a/components/motor/gpio/basic.go
+++ b/components/motor/gpio/basic.go
@@ -177,8 +177,13 @@ func (m *Motor) setPWM(ctx context.Context, powerPct float64, extra map[string]i
 	var errs error
 	powerPct = math.Min(powerPct, m.maxPowerPct)
 	powerPct = math.Max(powerPct, -1*m.maxPowerPct)
+	if math.Abs(powerPct) < m.minPowerPct{
+		powerPct = sign(powerPct) * m.minPowerPct
+	}
+	m.powerPct = powerPct
 
 	m.on = true
+
 	if m.EnablePinLow != nil {
 		errs = multierr.Combine(errs, m.EnablePinLow.Set(ctx, false, extra))
 	}
@@ -214,7 +219,6 @@ func (m *Motor) setPWM(ctx context.Context, powerPct float64, extra map[string]i
 	}
 
 	powerPct = math.Max(math.Abs(powerPct), m.minPowerPct)
-	m.powerPct = powerPct
 	return multierr.Combine(
 		errs,
 		pwmPin.SetPWMFreq(ctx, m.pwmFreq, extra),

--- a/components/motor/gpio/basic.go
+++ b/components/motor/gpio/basic.go
@@ -177,7 +177,7 @@ func (m *Motor) setPWM(ctx context.Context, powerPct float64, extra map[string]i
 	var errs error
 	powerPct = math.Min(powerPct, m.maxPowerPct)
 	powerPct = math.Max(powerPct, -1*m.maxPowerPct)
-	if math.Abs(powerPct) < m.minPowerPct{
+	if math.Abs(powerPct) < m.minPowerPct {
 		powerPct = sign(powerPct) * m.minPowerPct
 	}
 	m.powerPct = powerPct

--- a/components/motor/gpio/basic_test.go
+++ b/components/motor/gpio/basic_test.go
@@ -95,7 +95,7 @@ func TestMotorABPWM(t *testing.T) {
 		on, powerPct, err = m.IsPowered(ctx, nil)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, on, test.ShouldBeTrue)
-		test.That(t, powerPct, test.ShouldEqual, 0.44)
+		test.That(t, powerPct, test.ShouldEqual, -0.44)
 
 		test.That(t, m.SetPower(ctx, 0, nil), test.ShouldBeNil)
 		test.That(t, mustGetGPIOPinByName(b, "1").Get(context.Background()), test.ShouldEqual, false)


### PR DESCRIPTION
I am pretty sure this was not written expecting that PowerPct would always return positive. Just an oversight on taking the absolute value of the power percentage.

Still need to fix tests, but it should be returning negative percentages even when on now.


Please 

- [x] Test on hardware after I rebase - I will add the app image label to this pr.