### PR TITLE
RSDK-6843 ptg motion plans should not be required to start at the origin

### DIFF
--- a/components/base/kinematicbase/ptgKinematics_test.go
+++ b/components/base/kinematicbase/ptgKinematics_test.go
@@ -81,6 +81,7 @@ func TestPTGKinematicsNoGeom(t *testing.T) {
 		Goal:               dstPIF,
 		Frame:              f,
 		StartConfiguration: inputMap,
+		StartPose:          spatialmath.NewZeroPose(),
 		FrameSystem:        fs,
 	})
 	test.That(t, err, test.ShouldBeNil)
@@ -174,6 +175,7 @@ func TestPTGKinematicsWithGeom(t *testing.T) {
 		StartConfiguration: inputMap,
 		FrameSystem:        fs,
 		WorldState:         worldState,
+		StartPose:          spatialmath.NewZeroPose(),
 	})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, plan, test.ShouldNotBeNil)

--- a/motionplan/motionPlanner.go
+++ b/motionplan/motionPlanner.go
@@ -150,14 +150,6 @@ func Replan(ctx context.Context, request *PlanRequest, currentPlan Plan, replanC
 		return nil, errors.New("solver frame has no degrees of freedom, cannot perform inverse kinematics")
 	}
 
-	//~ request.Logger.CInfof(ctx,
-		//~ "planning motion for frame %s\nGoal: %v\nStarting seed map %v\n, startPose %v\n, worldstate: %v\n",
-		//~ request.Frame.Name(),
-		//~ frame.PoseInFrameToProtobuf(request.Goal),
-		//~ request.StartConfiguration,
-		//~ spatialmath.PoseToProtobuf(startPose),
-		//~ request.WorldState.String(),
-	//~ )
 	request.Logger.CDebugf(ctx, "constraint specs for this step: %v", request.ConstraintSpecs)
 	request.Logger.CDebugf(ctx, "motion config for this step: %v", request.Options)
 

--- a/motionplan/motionPlanner.go
+++ b/motionplan/motionPlanner.go
@@ -47,6 +47,7 @@ type PlanRequest struct {
 	Goal               *frame.PoseInFrame
 	Frame              frame.Frame
 	FrameSystem        frame.FrameSystem
+	StartPose          spatialmath.Pose
 	StartConfiguration map[string][]frame.Input
 	WorldState         *frame.WorldState
 	ConstraintSpecs    *pb.Constraints
@@ -148,31 +149,15 @@ func Replan(ctx context.Context, request *PlanRequest, currentPlan Plan, replanC
 	if len(sf.DoF()) == 0 {
 		return nil, errors.New("solver frame has no degrees of freedom, cannot perform inverse kinematics")
 	}
-	seed, err := sf.mapToSlice(request.StartConfiguration)
-	if err != nil {
-		return nil, err
-	}
-	startPose, err := sf.Transform(seed)
-	if err != nil {
-		return nil, err
-	}
-	// make sure there is no transformation between the PTG frame and World frame in the Solver frame
-	// TODO: RSDK-5391 this will trigger currently if we try to call Plan() on a robot which is currently executing another motion plan.
-	// Additionally, when RSDK-5391 is done, we will need to alter this such that the pose returned by `CurrentInputs` does not
-	// break this. We may want to as part of that ticket migrate the functionality of service/motion/builtin/relativeMoveRequestFromAbsolute
-	// to this package.
-	if len(sf.PTGSolvers()) > 0 && !spatialmath.PoseAlmostEqual(startPose, spatialmath.NewZeroPose()) {
-		return nil, errors.New("cannot have non-zero transformation between the PTG frame and World frame in the Solver frame")
-	}
 
-	request.Logger.CInfof(ctx,
-		"planning motion for frame %s\nGoal: %v\nStarting seed map %v\n, startPose %v\n, worldstate: %v\n",
-		request.Frame.Name(),
-		frame.PoseInFrameToProtobuf(request.Goal),
-		request.StartConfiguration,
-		spatialmath.PoseToProtobuf(startPose),
-		request.WorldState.String(),
-	)
+	//~ request.Logger.CInfof(ctx,
+		//~ "planning motion for frame %s\nGoal: %v\nStarting seed map %v\n, startPose %v\n, worldstate: %v\n",
+		//~ request.Frame.Name(),
+		//~ frame.PoseInFrameToProtobuf(request.Goal),
+		//~ request.StartConfiguration,
+		//~ spatialmath.PoseToProtobuf(startPose),
+		//~ request.WorldState.String(),
+	//~ )
 	request.Logger.CDebugf(ctx, "constraint specs for this step: %v", request.ConstraintSpecs)
 	request.Logger.CDebugf(ctx, "motion config for this step: %v", request.Options)
 
@@ -185,15 +170,7 @@ func Replan(ctx context.Context, request *PlanRequest, currentPlan Plan, replanC
 		return nil, err
 	}
 
-	newPlan, err := sfPlanner.PlanSingleWaypoint(
-		ctx,
-		request.StartConfiguration,
-		request.Goal.Pose(),
-		request.WorldState,
-		request.ConstraintSpecs,
-		currentPlan,
-		request.Options,
-	)
+	newPlan, err := sfPlanner.PlanSingleWaypoint(ctx, request, currentPlan)
 	if err != nil {
 		return nil, err
 	}

--- a/motionplan/motionPlanner_test.go
+++ b/motionplan/motionPlanner_test.go
@@ -703,19 +703,19 @@ func TestSolverFrameGeometries(t *testing.T) {
 
 	sfPlanner, err := newPlanManager(sf, fs, logger, 1)
 	test.That(t, err, test.ShouldBeNil)
-	
+
 	request := &PlanRequest{
-		Logger: logger,
-		Frame: fs.Frame("xArmVgripper"),
-		FrameSystem: fs,
+		Logger:             logger,
+		Frame:              fs.Frame("xArmVgripper"),
+		FrameSystem:        fs,
 		StartConfiguration: sf.sliceToMap(make([]frame.Input, len(sf.DoF()))),
-		Goal: frame.NewPoseInFrame(frame.World, spatialmath.NewPoseFromPoint(r3.Vector{300, 300, 100})),
-		Options: map[string]interface{}{"smooth_iter": 5},
+		Goal:               frame.NewPoseInFrame(frame.World, spatialmath.NewPoseFromPoint(r3.Vector{300, 300, 100})),
+		Options:            map[string]interface{}{"smooth_iter": 5},
 	}
-	
+
 	err = request.validatePlanRequest()
 	test.That(t, err, test.ShouldBeNil)
-	
+
 	plan, err := sfPlanner.PlanSingleWaypoint(
 		context.Background(),
 		request,
@@ -831,9 +831,9 @@ func TestMovementWithGripper(t *testing.T) {
 	goal := spatialmath.NewPose(r3.Vector{500, 0, -300}, &spatialmath.OrientationVector{OZ: -1})
 	zeroPosition := sf.sliceToMap(make([]frame.Input, len(sf.DoF())))
 	request := &PlanRequest{
-		Logger: logger,
+		Logger:             logger,
 		StartConfiguration: zeroPosition,
-		Goal: frame.NewPoseInFrame(frame.World, goal),
+		Goal:               frame.NewPoseInFrame(frame.World, goal),
 	}
 
 	// linearly plan with the gripper

--- a/motionplan/planManager.go
+++ b/motionplan/planManager.go
@@ -507,6 +507,11 @@ func (pm *planManager) plannerSetupFromMoveRequest(
 	}
 	movingRobotGeometries := movingGeometriesInFrame.Geometries() // solver frame returns geoms in frame World
 	if pm.useTPspace {
+		// If we are starting a ptg plan at a different place than the origin, then that translation must be represented in the geometries,
+		// all of which need to be in the "correct" position when transformed to the world frame.
+		// At this point in the plan manager, a ptg plan is moving to a goal in the world frame, and the start pose is the base's location
+		// relative to world. Since nothing providing a geometry knows anything about where the base is relative to world, any geometries
+		// need to be transformed by the start position to place them correctly in world.
 		startGeoms := make([]spatialmath.Geometry, 0, len(movingRobotGeometries))
 		for _, geometry := range movingRobotGeometries {
 			startGeoms = append(startGeoms, geometry.Transform(from))

--- a/motionplan/planManager.go
+++ b/motionplan/planManager.go
@@ -502,12 +502,10 @@ func (pm *planManager) plannerSetupFromMoveRequest(
 
 	// create robot collision entities
 	movingGeometriesInFrame, err := pm.frame.Geometries(frameInputs)
-	movingRobotGeometries := movingGeometriesInFrame.Geometries() // solver frame returns geoms in frame World
 	if err != nil {
-		if len(movingRobotGeometries) == 0 {
-			return nil, err // no geometries defined for frame
-		}
+		return nil, err // no geometries defined for frame
 	}
+	movingRobotGeometries := movingGeometriesInFrame.Geometries() // solver frame returns geoms in frame World
 	if pm.useTPspace {
 		startGeoms := make([]spatialmath.Geometry, 0, len(movingRobotGeometries))
 		for _, geometry := range movingRobotGeometries {

--- a/motionplan/plan_test.go
+++ b/motionplan/plan_test.go
@@ -153,6 +153,7 @@ func TestNewGeoPlan(t *testing.T) {
 	goal := spatialmath.NewPoseFromPoint(r3.Vector{X: 1000, Y: 8000, Z: 0})
 	plan, err := Replan(context.Background(), &PlanRequest{
 		Logger:             logging.NewTestLogger(t),
+		StartPose:          spatialmath.NewZeroPose(),
 		Goal:               referenceframe.NewPoseInFrame(referenceframe.World, goal),
 		Frame:              kinematicFrame,
 		FrameSystem:        baseFS,

--- a/motionplan/plannerOptions.go
+++ b/motionplan/plannerOptions.go
@@ -165,6 +165,8 @@ type plannerOptions struct {
 	// This is how far cbirrt will try to extend the map towards a goal per-step. Determined from FrameStep
 	qstep []float64
 
+	StartPose spatialmath.Pose // The starting pose of the plan. Useful when planning for frames with relative inputs.
+
 	// DistanceFunc is the function that the planner will use to measure the degree of "closeness" between two states of the robot
 	DistanceFunc ik.SegmentMetric
 

--- a/motionplan/tpSpaceRRT.go
+++ b/motionplan/tpSpaceRRT.go
@@ -161,7 +161,7 @@ func (mp *tpSpaceRRTMotionPlanner) plan(ctx context.Context, goal spatialmath.Po
 	mp.planOpts.SetGoal(goal)
 	solutionChan := make(chan *rrtSolution, 1)
 
-	seedPos := spatialmath.NewZeroPose()
+	seedPos := mp.opt().StartPose
 
 	startNode := &basicNode{q: make([]referenceframe.Input, len(mp.frame.DoF())), cost: 0, pose: seedPos, corner: false}
 	maps := &rrtMaps{startMap: map[node]node{startNode: nil}}

--- a/motionplan/tpSpaceRRT_test.go
+++ b/motionplan/tpSpaceRRT_test.go
@@ -110,7 +110,7 @@ func TestPtgWithObstacle(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	sf, err := newSolverFrame(fs, ackermanFrame.Name(), referenceframe.World, nil)
 	test.That(t, err, test.ShouldBeNil)
-	
+
 	seedMap := referenceframe.StartPositions(fs)
 	frameInputs, err := sf.mapToSlice(seedMap)
 	test.That(t, err, test.ShouldBeNil)
@@ -143,7 +143,7 @@ func TestPtgWithObstacle(t *testing.T) {
 		nil,
 		defaultCollisionBufferMM,
 	)
-	
+
 	test.That(t, err, test.ShouldBeNil)
 
 	for name, constraint := range collisionConstraints {

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -235,7 +235,7 @@ func TestMoveWithObstacles(t *testing.T) {
 	})
 }
 
-func TestMoveOnMapAskewIMUTestMoveOnMapAskewIMU(t *testing.T) {
+func TestMoveOnMapAskewIMU(t *testing.T) {
 	t.Parallel()
 	extraPosOnly := map[string]interface{}{"smooth_iter": 5, "motion_profile": "position_only"}
 	t.Run("Askew but valid base should be able to plan", func(t *testing.T) {
@@ -1593,6 +1593,7 @@ func TestMoveOnMap(t *testing.T) {
 				},
 			)
 			test.That(t, err, test.ShouldNotBeNil)
+			logger.Debug(err.Error())
 			test.That(t, strings.Contains(err.Error(), "starting collision between SLAM map and "), test.ShouldBeTrue)
 			test.That(t, executionID, test.ShouldResemble, uuid.Nil)
 		})
@@ -1661,6 +1662,7 @@ func TestMoveOnMap(t *testing.T) {
 
 		endPos, err = kb.CurrentPosition(ctx)
 		test.That(t, err, test.ShouldBeNil)
+		logger.Debug(spatialmath.PoseToProtobuf(endPos.Pose()))
 		test.That(t, spatialmath.PoseAlmostEqualEps(endPos.Pose(), goal2BaseFrame, 5), test.ShouldBeTrue)
 
 		plans, err := ms.PlanHistory(ctx, motion.PlanHistoryReq{

--- a/services/motion/builtin/move_request.go
+++ b/services/motion/builtin/move_request.go
@@ -557,7 +557,7 @@ func (ms *builtIn) newMoveOnGlobeRequest(
 
 	geomsRaw := spatialmath.GeoObstaclesToGeometries(obstacles, origin)
 
-	mr, err := ms.relativeMoveRequestFromAbsolute(
+	mr, err := ms.createBaseMoveRequest(
 		ctx,
 		motionCfg,
 		ms.logger,
@@ -657,7 +657,7 @@ func (ms *builtIn) newMoveOnMapRequest(
 
 	req.Obstacles = append(req.Obstacles, octree)
 
-	mr, err := ms.relativeMoveRequestFromAbsolute(
+	mr, err := ms.createBaseMoveRequest(
 		ctx,
 		motionCfg,
 		ms.logger,
@@ -674,7 +674,7 @@ func (ms *builtIn) newMoveOnMapRequest(
 	return mr, nil
 }
 
-func (ms *builtIn) relativeMoveRequestFromAbsolute(
+func (ms *builtIn) createBaseMoveRequest(
 	ctx context.Context,
 	motionCfg *validatedMotionConfiguration,
 	logger logging.Logger,
@@ -705,32 +705,26 @@ func (ms *builtIn) relativeMoveRequestFromAbsolute(
 		return nil, err
 	}
 	startPose := startPoseIF.Pose()
-	startPoseInv := spatialmath.PoseInverse(startPose)
 
-	goal := referenceframe.NewPoseInFrame(referenceframe.World, spatialmath.PoseBetween(startPose, goalPoseInWorld))
+	goal := referenceframe.NewPoseInFrame(referenceframe.World, goalPoseInWorld)
 
 	// Here we determine if we already are at the goal
 	// If our motion profile is position_only then, we only check against our current & desired position
 	// Conversely if our motion profile is anything else, then we also need to check again our
 	// current & desired orientation
 	if valExtra.motionProfile == motionplan.PositionOnlyMotionProfile {
-		if spatialmath.PoseAlmostCoincidentEps(goal.Pose(), spatialmath.NewZeroPose(), motionCfg.planDeviationMM) {
+		if spatialmath.PoseAlmostCoincidentEps(goal.Pose(), startPose, motionCfg.planDeviationMM) {
+			
 			return nil, errGoalWithinPlanDeviation
 		}
 	} else {
 		if spatialmath.OrientationAlmostEqual(goal.Pose().Orientation(), spatialmath.NewZeroPose().Orientation()) &&
-			spatialmath.PoseAlmostCoincidentEps(goal.Pose(), spatialmath.NewZeroPose(), motionCfg.planDeviationMM) {
+			spatialmath.PoseAlmostCoincidentEps(goal.Pose(), startPose, motionCfg.planDeviationMM) {
 			return nil, errGoalWithinPlanDeviation
 		}
 	}
 
-	// convert GeoObstacles into GeometriesInFrame with respect to the base's starting point
-	geoms := make([]spatialmath.Geometry, 0, len(worldObstacles))
-	for _, geom := range worldObstacles {
-		geoms = append(geoms, geom.Transform(startPoseInv))
-	}
-
-	gif := referenceframe.NewGeometriesInFrame(referenceframe.World, geoms)
+	gif := referenceframe.NewGeometriesInFrame(referenceframe.World, worldObstacles)
 	worldState, err := referenceframe.NewWorldState([]*referenceframe.GeometriesInFrame{gif}, nil)
 	if err != nil {
 		return nil, err
@@ -786,6 +780,7 @@ func (ms *builtIn) relativeMoveRequestFromAbsolute(
 			Frame:              kinematicFrame,
 			FrameSystem:        baseOnlyFS,
 			StartConfiguration: currentInputs,
+			StartPose:          startPose,
 			WorldState:         worldState,
 			Options:            valExtra.extra,
 		},

--- a/services/motion/builtin/move_request.go
+++ b/services/motion/builtin/move_request.go
@@ -714,7 +714,6 @@ func (ms *builtIn) createBaseMoveRequest(
 	// current & desired orientation
 	if valExtra.motionProfile == motionplan.PositionOnlyMotionProfile {
 		if spatialmath.PoseAlmostCoincidentEps(goal.Pose(), startPose, motionCfg.planDeviationMM) {
-			
 			return nil, errGoalWithinPlanDeviation
 		}
 	} else {


### PR DESCRIPTION
This PR updates TP-space planning in `motionplan` to remove the requirement that obstacles, goals, etc all be transformed to be relative to the base.

Instead, we now pass a `StartPose` as part of the `PlanRequest` which allows us to correctly position the seed node of the TPspace RRT tree.

This also includes a minor refactor of `planManager` which adds `planRelativeWaypoint` to consolidate planner setup there.