### PR TITLE
[RSDK-6975] Leading zeroes in hash seem to break module download

### DIFF
--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -496,12 +496,18 @@ func (m *cloudManager) downloadFileFromGCSURL(
 }
 
 func trimLeadingZeroes(data []byte) []byte {
+	if len(data) == 0 {
+		return []byte{}
+	}
+
 	for i, b := range data {
 		if b != 0x00 {
 			return data[i:]
 		}
 	}
-	return data // return the original slice if it's all zeroes or empty
+
+	// If all bytes are zero, return a single zero byte
+	return []byte{0x00}
 }
 
 func unpackFile(ctx context.Context, fromFile, toDir string) error {

--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -481,7 +481,7 @@ func (m *cloudManager) downloadFileFromGCSURL(
 
 	checksumBytes, err := base64.StdEncoding.DecodeString(checksum)
 	if err != nil {
-		return "", "", errors.Wrap(err, "failed to decode expected checksum")
+		return "", "", errors.Wrapf(err, "failed to decode expected checksum: %s", checksum)
 	}
 
 	trimmedChecksumBytes := trimLeadingZeroes(checksumBytes)
@@ -489,7 +489,13 @@ func (m *cloudManager) downloadFileFromGCSURL(
 
 	if !bytes.Equal(trimmedOutHashBytes, trimmedChecksumBytes) {
 		utils.UncheckedError(os.Remove(downloadPath))
-		return checksum, contentType, errors.Errorf("download did not match expected hash %x != %x", trimmedChecksumBytes, trimmedOutHashBytes)
+		return checksum, contentType, errors.Errorf(
+			"download did not match expected hash:\n"+
+				"  pre-trimmed: %x vs. %x\n"+
+				"  trimmed:     %x vs. %x",
+			checksumBytes, hash.Sum(nil),
+			trimmedChecksumBytes, trimmedOutHashBytes,
+		)
 	}
 
 	return checksum, contentType, nil

--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -483,10 +483,9 @@ func (m *cloudManager) downloadFileFromGCSURL(
 	if err != nil {
 		return "", "", errors.Wrap(err, "failed to decode expected checksum")
 	}
-	outHashBytes := hash.Sum(nil)
 
 	trimmedChecksumBytes := trimLeadingZeroes(checksumBytes)
-	trimmedOutHashBytes := trimLeadingZeroes(outHashBytes)
+	trimmedOutHashBytes := trimLeadingZeroes(hash.Sum(nil))
 
 	if !bytes.Equal(trimmedOutHashBytes, trimmedChecksumBytes) {
 		utils.UncheckedError(os.Remove(downloadPath))

--- a/robot/packages/cloud_package_manager_test.go
+++ b/robot/packages/cloud_package_manager_test.go
@@ -200,7 +200,7 @@ func TestCloud(t *testing.T) {
 
 		err = pm.Sync(ctx, input)
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "download did not match expected hash")
+		test.That(t, err.Error(), test.ShouldContainSubstring, "failed to decode")
 
 		err = pm.Cleanup(ctx)
 		test.That(t, err, test.ShouldBeNil)

--- a/robot/packages/cloud_package_manager_test.go
+++ b/robot/packages/cloud_package_manager_test.go
@@ -215,17 +215,16 @@ func TestCloud(t *testing.T) {
 		fakeServer.SetChecksumWithLeadingZeroes(true)
 
 		input := []config.PackageConfig{
-			{Name: "some-name-1", Package: "org1/test-model", Version: "v1", Type: "ml_model"},
+			{Name: "some-name", Package: "org1/test-model", Version: "v1", Type: "ml_model"},
+			{Name: "some-name-2", Package: "org1/test-model", Version: "v2", Type: "ml_model"},
 		}
 		fakeServer.StorePackage(input...)
 
 		err = pm.Sync(ctx, input)
 		test.That(t, err, test.ShouldBeNil)
 
-		err = pm.Cleanup(ctx)
-		test.That(t, err, test.ShouldBeNil)
-
-		validatePackageDir(t, packageDir, []config.PackageConfig{})
+		// validate dir should be empty
+		validatePackageDir(t, packageDir, input)
 	})
 
 	t.Run("invalid gcs download", func(t *testing.T) {

--- a/robot/packages/cloud_package_manager_test.go
+++ b/robot/packages/cloud_package_manager_test.go
@@ -208,6 +208,26 @@ func TestCloud(t *testing.T) {
 		validatePackageDir(t, packageDir, []config.PackageConfig{})
 	})
 
+	t.Run("leading zeroes checksum", func(t *testing.T) {
+		packageDir, pm := newPackageManager(t, client, fakeServer, logger)
+		defer utils.UncheckedErrorFunc(func() error { return pm.Close(context.Background()) })
+
+		fakeServer.SetChecksumWithLeadingZeroes(true)
+
+		input := []config.PackageConfig{
+			{Name: "some-name-1", Package: "org1/test-model", Version: "v1", Type: "ml_model"},
+		}
+		fakeServer.StorePackage(input...)
+
+		err = pm.Sync(ctx, input)
+		test.That(t, err, test.ShouldBeNil)
+
+		err = pm.Cleanup(ctx)
+		test.That(t, err, test.ShouldBeNil)
+
+		validatePackageDir(t, packageDir, []config.PackageConfig{})
+	})
+
 	t.Run("invalid gcs download", func(t *testing.T) {
 		packageDir, pm := newPackageManager(t, client, fakeServer, logger)
 		defer utils.UncheckedErrorFunc(func() error { return pm.Close(context.Background()) })

--- a/robot/packages/cloud_package_manager_test.go
+++ b/robot/packages/cloud_package_manager_test.go
@@ -462,3 +462,38 @@ func TestMissingDirEntry(t *testing.T) {
 	err = unpackFile(context.Background(), file.Name(), dest)
 	test.That(t, err, test.ShouldBeNil)
 }
+
+func TestTrimLeadingZeroes(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    []byte
+		expected []byte
+	}{
+		{
+			name:     "Empty slice",
+			input:    []byte{},
+			expected: []byte{},
+		},
+		{
+			name:     "Single zero byte",
+			input:    []byte{0x00},
+			expected: []byte{0x00},
+		},
+		{
+			name:     "Leading zeroes trimmed",
+			input:    []byte{0x00, 0x00, 0x03, 0x04, 0x05},
+			expected: []byte{0x03, 0x04, 0x05},
+		},
+		{
+			name:     "All zero bytes",
+			input:    []byte{0x00, 0x00, 0x00},
+			expected: []byte{0x00},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			test.That(t, trimLeadingZeroes(tc.input), test.ShouldEqual, tc.expected)
+		})
+	}
+}

--- a/robot/packages/cloud_package_manager_test.go
+++ b/robot/packages/cloud_package_manager_test.go
@@ -493,7 +493,7 @@ func TestTrimLeadingZeroes(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			test.That(t, trimLeadingZeroes(tc.input), test.ShouldEqual, tc.expected)
+			test.That(t, trimLeadingZeroes(tc.input), test.ShouldResemble, tc.expected)
 		})
 	}
 }

--- a/robot/packages/testutils/fake_package_server.go
+++ b/robot/packages/testutils/fake_package_server.go
@@ -227,7 +227,14 @@ func (c *FakePackagesClientAndGCSServer) servePackage(w http.ResponseWriter, r *
 	}
 
 	if c.hasLeadingZeroesChecksum {
-		c.testPackageChecksum = "00" + c.testPackageChecksum
+		decodedBytes, err := base64.StdEncoding.DecodeString(c.testPackageChecksum)
+		if err != nil {
+			c.logger.Error(err)
+			return
+		}
+
+		prependedBytes := append([]byte{0x00, 0x00}, decodedBytes...)
+		c.testPackageChecksum = base64.StdEncoding.EncodeToString(prependedBytes)
 	}
 
 	w.Header().Set("Content-Type", "application/x-gzip")

--- a/robot/packages/testutils/fake_package_server.go
+++ b/robot/packages/testutils/fake_package_server.go
@@ -290,6 +290,7 @@ func (c *FakePackagesClientAndGCSServer) Clear() {
 	defer c.mu.Unlock()
 
 	c.packages = make(map[string]*pb.Package)
+	c.hasLeadingZeroesChecksum = false
 	c.invalidChecksum = false
 	c.invalidTar = false
 	c.invalidHTTPRes = false


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-6975

Test:

systemd viam-server fails to download `oak` module version 0.1.4

static build off this branch is able to