### PR TITLE
RSDK-6946: compass heading from vtg messge

### DIFF
--- a/components/movementsensor/gpsutils/nmeaParser.go
+++ b/components/movementsensor/gpsutils/nmeaParser.go
@@ -203,6 +203,13 @@ func (g *NmeaParser) updateGLL(gll nmea.GLL) error {
 func (g *NmeaParser) updateVTG(vtg nmea.VTG) error {
 	// VTG provides ground speed
 	g.Speed = vtg.GroundSpeedKPH * kphToMPerSec
+
+	// Check if the true heading is provided before updating
+	if vtg.TrueTrack != 0 {
+		// Update the true heading in degrees
+		g.CompassHeading = vtg.TrueTrack
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
VTG message provides true track which is the heading relative to the Earth's geographical poles. This PR checks if this information is provided in the VTG message and updates compass heading based on true track. 