### PR TITLE
RSDK-7005 Add timeout for closing resources

### DIFF
--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -414,6 +414,11 @@ func (manager *resourceManager) mergeResourceRPCAPIsWithRemote(r robot.Robot, ty
 func (manager *resourceManager) closeResource(ctx context.Context, res resource.Resource) error {
 	manager.logger.CInfow(ctx, "Now removing resource", "resource", res.Name())
 
+	// TODO(RSDK-6626): We should be resilient to builtin resource `Close` calls
+	// hanging and not respecting the context created below. We will likely need
+	// a goroutine/timer setup here similar to that in the (re)configuration
+	// code.
+	//
 	// Avoid hangs in Close/RemoveResource with resourceCloseTimeout.
 	closeCtx, cancel := context.WithTimeout(ctx, resourceCloseTimeout)
 	defer cancel()

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -3790,8 +3790,7 @@ func TestResourceCloseNoHang(t *testing.T) {
 
 	test.That(t, r.Close(context.Background()), test.ShouldBeNil)
 	test.That(t, mf.closeCtxDeadline, test.ShouldNotBeNil)
-	test.That(t, mf.closeCtxDeadline, test.ShouldHappenWithin,
-		resourceCloseTimeout, time.Now())
+	test.That(t, time.Now().Add(resourceCloseTimeout), test.ShouldHappenOnOrAfter, mf.closeCtxDeadline)
 }
 
 type mockFake struct {

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -3795,7 +3795,7 @@ func TestResourceCloseNoHang(t *testing.T) {
 	}()
 
 	// Assert that this Close does not hang for an hour even with
-	// time.Sleep(time.Hour) in mockFake's Close method.
+	// time.Sleep(time.Minute) in mockFake's Close method.
 	testutils.WaitForAssertion(t, func(tb testing.TB) {
 		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
 	})
@@ -3846,7 +3846,7 @@ func (m *mockFake) Close(ctx context.Context) error {
 	m.closeCount++
 
 	if m.shouldHangOnClose {
-		timer := time.NewTimer(time.Hour)
+		timer := time.NewTimer(time.Minute)
 		select {
 		case <-timer.C:
 		case <-ctx.Done():


### PR DESCRIPTION
RSDK-7005

Adds a 30 second timeout for `closeResource` in the resource manager. Adds a test to ensure timeout is respected.

If builtin resources wrote a hanging `Close` method, Golang modular resources wrote a hanging `Close` method, Python modular resources wrote a hanging `close` method, or C++ modular resources wrote a hanging destructor, the RDK would hang in shutdown. `localRobot.Close()` closes the resource manager, which calls `closeResource` for every graph node. `closeResource` had no, existing associated timeout.

cc @viamrobotics/netcode .