### PR TITLE
RSDK-7042 Add better info logs wrt (re)configuration

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -226,6 +226,7 @@ func (mgr *Manager) Add(ctx context.Context, confs ...config.Module) error {
 		go func(i int, conf config.Module) {
 			defer wg.Done()
 
+			mgr.logger.CInfow(ctx, "now adding module", "module", conf.Name)
 			err := mgr.add(ctx, conf)
 			if err != nil {
 				mgr.logger.CErrorw(ctx, "error adding module", "module", conf.Name, "error", err)
@@ -328,6 +329,9 @@ func (mgr *Manager) Reconfigure(ctx context.Context, conf config.Module) ([]reso
 	if !exists {
 		return nil, errors.Errorf("cannot reconfigure module %s as it does not exist", conf.Name)
 	}
+
+	mgr.logger.CInfow(ctx, "now reconfiguring module", "module", conf.Name)
+
 	handledResources := mod.resources
 	var handledResourceNames []resource.Name
 	for name := range handledResources {
@@ -373,6 +377,9 @@ func (mgr *Manager) Remove(modName string) ([]resource.Name, error) {
 	if !exists {
 		return nil, errors.Errorf("cannot remove module %s as it does not exist", modName)
 	}
+
+	mgr.logger.Infow("now removing module", "module", modName)
+
 	handledResources := mod.resources
 
 	// If module handles no resources, remove it now. Otherwise mark it

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -362,7 +362,8 @@ func (mgr *Manager) Reconfigure(ctx context.Context, conf config.Module) ([]reso
 		return handledResourceNames, err
 	}
 
-	mgr.logger.CDebugw(ctx, "New module process is running and responding to gRPC requests", "module", mod.cfg.Name, "module address", mod.addr)
+	mgr.logger.CDebugw(ctx, "New module process is running and responding to gRPC requests", "module",
+		mod.cfg.Name, "module address", mod.addr)
 
 	// add old module process' resources to new module; warn if new module cannot
 	// handle old resource and consider that resource orphaned.
@@ -373,7 +374,8 @@ func (mgr *Manager) Reconfigure(ctx context.Context, conf config.Module) ([]reso
 				"resource", name, "module", conf.Name, "error", err)
 			orphanedResourceNames = append(orphanedResourceNames, name)
 		} else {
-			mgr.logger.CDebugw(ctx, "Successfully re-added resource from module after module reconfiguration", "module", mod.cfg.Name, "resource", name)
+			mgr.logger.CDebugw(ctx, "Successfully re-added resource from module after module reconfiguration",
+				"module", mod.cfg.Name, "resource", name)
 		}
 	}
 	return orphanedResourceNames, nil
@@ -934,7 +936,8 @@ func (m *module) startProcess(
 	moduleWorkingDirectory, ok := moduleEnvironment["VIAM_MODULE_ROOT"]
 	if !ok {
 		moduleWorkingDirectory = filepath.Dir(absoluteExePath)
-		logger.CWarnw(ctx, "VIAM_MODULE_ROOT was not passed to module. Defaulting to module's working directory", "module", m.cfg.Name, "dir", moduleWorkingDirectory)
+		logger.CWarnw(ctx, "VIAM_MODULE_ROOT was not passed to module. Defaulting to module's working directory",
+			"module", m.cfg.Name, "dir", moduleWorkingDirectory)
 	} else {
 		logger.CDebugw(ctx, "Starting module in working directory", "module", m.cfg.Name, "dir", moduleWorkingDirectory)
 	}

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -369,7 +369,7 @@ func (mgr *Manager) Reconfigure(ctx context.Context, conf config.Module) ([]reso
 	var orphanedResourceNames []resource.Name
 	for name, res := range handledResources {
 		if _, err := mgr.addResource(ctx, res.conf, res.deps); err != nil {
-			mgr.logger.Warnw("Error while re-adding resource to module",
+			mgr.logger.CWarnw(ctx, "Error while re-adding resource to module",
 				"resource", name, "module", conf.Name, "error", err)
 			orphanedResourceNames = append(orphanedResourceNames, name)
 		} else {

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -362,7 +362,7 @@ func (mgr *Manager) Reconfigure(ctx context.Context, conf config.Module) ([]reso
 		return handledResourceNames, err
 	}
 
-	mgr.logger.CDebugw(ctx, "New module process is running and responding to gRPC requests", "module",
+	mgr.logger.CInfow(ctx, "New module process is running and responding to gRPC requests", "module",
 		mod.cfg.Name, "module address", mod.addr)
 
 	// add old module process' resources to new module; warn if new module cannot
@@ -374,7 +374,7 @@ func (mgr *Manager) Reconfigure(ctx context.Context, conf config.Module) ([]reso
 				"resource", name, "module", conf.Name, "error", err)
 			orphanedResourceNames = append(orphanedResourceNames, name)
 		} else {
-			mgr.logger.CDebugw(ctx, "Successfully re-added resource from module after module reconfiguration",
+			mgr.logger.CInfow(ctx, "Successfully re-added resource from module after module reconfiguration",
 				"module", mod.cfg.Name, "resource", name)
 		}
 	}
@@ -422,7 +422,7 @@ func (mgr *Manager) closeModule(mod *module, reconfigure bool) error {
 		if err != nil {
 			mgr.logger.Errorw("Error removing resource", "module", mod.cfg.Name, "resource", res.Name, "error", err)
 		} else {
-			mgr.logger.Debugw("Successfully removed resource from module", "module", mod.cfg.Name, "resource", res.Name)
+			mgr.logger.Infow("Successfully removed resource from module", "module", mod.cfg.Name, "resource", res.Name)
 		}
 	}
 
@@ -444,7 +444,7 @@ func (mgr *Manager) closeModule(mod *module, reconfigure bool) error {
 	})
 	mgr.modules.Delete(mod.cfg.Name)
 
-	mgr.logger.Debugw("Module successfully closed", "module", mod.cfg.Name)
+	mgr.logger.Infow("Module successfully closed", "module", mod.cfg.Name)
 	return nil
 }
 
@@ -460,6 +460,8 @@ func (mgr *Manager) addResource(ctx context.Context, conf resource.Config, deps 
 	if !ok {
 		return nil, errors.Errorf("no active module registered to serve resource api %s and model %s", conf.API, conf.Model)
 	}
+
+	mgr.logger.CInfow(ctx, "Adding resource to module", "resource", conf.Name, "module", mod.cfg.Name)
 
 	confProto, err := config.ComponentConfigToProto(&conf)
 	if err != nil {
@@ -489,6 +491,8 @@ func (mgr *Manager) ReconfigureResource(ctx context.Context, conf resource.Confi
 	if !ok {
 		return errors.Errorf("no module registered to serve resource api %s and model %s", conf.API, conf.Model)
 	}
+
+	mgr.logger.CInfow(ctx, "Reconfiguring resource for module", "resource", conf.Name, "module", mod.cfg.Name)
 
 	confProto, err := config.ComponentConfigToProto(&conf)
 	if err != nil {
@@ -540,6 +544,9 @@ func (mgr *Manager) RemoveResource(ctx context.Context, name resource.Name) erro
 	if !ok {
 		return errors.Errorf("resource %+v not found in module", name)
 	}
+
+	mgr.logger.CInfow(ctx, "Removing resource for module", "resource", name.String(), "module", mod.cfg.Name)
+
 	mgr.rMap.Delete(name)
 	delete(mod.resources, name)
 	_, err := mod.client.RemoveResource(ctx, &pb.RemoveResourceRequest{Name: name.String()})
@@ -939,7 +946,7 @@ func (m *module) startProcess(
 		logger.CWarnw(ctx, "VIAM_MODULE_ROOT was not passed to module. Defaulting to module's working directory",
 			"module", m.cfg.Name, "dir", moduleWorkingDirectory)
 	} else {
-		logger.CDebugw(ctx, "Starting module in working directory", "module", m.cfg.Name, "dir", moduleWorkingDirectory)
+		logger.CInfow(ctx, "Starting module in working directory", "module", m.cfg.Name, "dir", moduleWorkingDirectory)
 	}
 
 	pconf := pexec.ProcessConfig{

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -216,7 +216,7 @@ func (mgr *Manager) Add(ctx context.Context, confs ...config.Module) error {
 
 		// this is done in config validation but partial start rules require us to check again
 		if err := conf.Validate(""); err != nil {
-			mgr.logger.CErrorw(ctx, "module config validation error; skipping", "module", conf.Name, "error", err)
+			mgr.logger.CErrorw(ctx, "Module config validation error; skipping", "module", conf.Name, "error", err)
 			errs[i] = err
 			continue
 		}
@@ -226,10 +226,10 @@ func (mgr *Manager) Add(ctx context.Context, confs ...config.Module) error {
 		go func(i int, conf config.Module) {
 			defer wg.Done()
 
-			mgr.logger.CInfow(ctx, "now adding module", "module", conf.Name)
+			mgr.logger.CInfow(ctx, "Now adding module", "module", conf.Name)
 			err := mgr.add(ctx, conf)
 			if err != nil {
-				mgr.logger.CErrorw(ctx, "error adding module", "module", conf.Name, "error", err)
+				mgr.logger.CErrorw(ctx, "Error adding module", "module", conf.Name, "error", err)
 				errs[i] = err
 				return
 			}
@@ -237,12 +237,21 @@ func (mgr *Manager) Add(ctx context.Context, confs ...config.Module) error {
 	}
 	wg.Wait()
 
-	return multierr.Combine(errs...)
+	combinedErr := multierr.Combine(errs...)
+	if combinedErr == nil {
+		var addedModNames []string
+		for modName := range seen {
+			addedModNames = append(addedModNames, modName)
+		}
+		mgr.logger.CInfow(ctx, "Modules successfully added", "modules", addedModNames)
+	}
+	return combinedErr
 }
 
 func (mgr *Manager) add(ctx context.Context, conf config.Module) error {
 	_, exists := mgr.modules.Load(conf.Name)
 	if exists {
+		mgr.logger.CWarnw(ctx, "Not adding module that already exists", "module", conf.Name)
 		return nil
 	}
 
@@ -330,13 +339,13 @@ func (mgr *Manager) Reconfigure(ctx context.Context, conf config.Module) ([]reso
 		return nil, errors.Errorf("cannot reconfigure module %s as it does not exist", conf.Name)
 	}
 
-	mgr.logger.CInfow(ctx, "now reconfiguring module", "module", conf.Name)
-
 	handledResources := mod.resources
 	var handledResourceNames []resource.Name
 	for name := range handledResources {
 		handledResourceNames = append(handledResourceNames, name)
 	}
+
+	mgr.logger.CInfow(ctx, "Module configuration changed. Stopping the existing module process", "module", conf.Name)
 
 	if err := mgr.closeModule(mod, true); err != nil {
 		// If removal fails, assume all handled resources are orphaned.
@@ -346,23 +355,25 @@ func (mgr *Manager) Reconfigure(ctx context.Context, conf config.Module) ([]reso
 	mod.cfg = conf
 	mod.resources = map[resource.Name]*addedResource{}
 
+	mgr.logger.CInfow(ctx, "Existing module process stopped. Starting new module process", "module", conf.Name)
+
 	if err := mgr.startModule(ctx, mod); err != nil {
 		// If re-addition fails, assume all handled resources are orphaned.
 		return handledResourceNames, err
 	}
 
-	mgr.logger.Debugw("successfully reconfigured and reconnected to module", "module", mod.cfg.Name, "module address", mod.addr)
+	mgr.logger.Debugw("New module process is running and responding to gRPC requests", "module", mod.cfg.Name, "module address", mod.addr)
 
 	// add old module process' resources to new module; warn if new module cannot
 	// handle old resource and consider that resource orphaned.
 	var orphanedResourceNames []resource.Name
 	for name, res := range handledResources {
 		if _, err := mgr.addResource(ctx, res.conf, res.deps); err != nil {
-			mgr.logger.Warnf("error while re-adding resource %s to module %s: %v",
-				name, conf.Name, err)
+			mgr.logger.Warnf("Error while re-adding resource to module",
+				"resource", name, "module", conf.Name, "error", err)
 			orphanedResourceNames = append(orphanedResourceNames, name)
 		} else {
-			mgr.logger.Debugw("successfully re-added resource from module after module reconfiguration", "module", mod.cfg.Name, "resource", name)
+			mgr.logger.Debugw("Successfully re-added resource from module after module reconfiguration", "module", mod.cfg.Name, "resource", name)
 		}
 	}
 	return orphanedResourceNames, nil
@@ -378,7 +389,7 @@ func (mgr *Manager) Remove(modName string) ([]resource.Name, error) {
 		return nil, errors.Errorf("cannot remove module %s as it does not exist", modName)
 	}
 
-	mgr.logger.Infow("now removing module", "module", modName)
+	mgr.logger.Infow("Now removing module", "module", modName)
 
 	handledResources := mod.resources
 
@@ -400,16 +411,16 @@ func (mgr *Manager) Remove(modName string) ([]resource.Name, error) {
 func (mgr *Manager) closeModule(mod *module, reconfigure bool) error {
 	// resource manager should've removed these cleanly if this isn't a reconfigure
 	if !reconfigure && len(mod.resources) != 0 {
-		mgr.logger.Warnw("forcing removal of module with active resources", "module", mod.cfg.Name)
+		mgr.logger.Warnw("Forcing removal of module with active resources", "module", mod.cfg.Name)
 	}
 
 	// need to actually close the resources within the module itself before stopping
 	for res := range mod.resources {
 		_, err := mod.client.RemoveResource(context.Background(), &pb.RemoveResourceRequest{Name: res.String()})
 		if err != nil {
-			mgr.logger.Errorw("error removing resource", "module", mod.cfg.Name, "resource", res.Name, "error", err)
+			mgr.logger.Errorw("Error removing resource", "module", mod.cfg.Name, "resource", res.Name, "error", err)
 		} else {
-			mgr.logger.Debugw("successfully removed resource from module", "module", mod.cfg.Name, "resource", res.Name)
+			mgr.logger.Debugw("Successfully removed resource from module", "module", mod.cfg.Name, "resource", res.Name)
 		}
 	}
 
@@ -431,7 +442,7 @@ func (mgr *Manager) closeModule(mod *module, reconfigure bool) error {
 	})
 	mgr.modules.Delete(mod.cfg.Name)
 
-	mgr.logger.Debugw("module successfully closed", "module", mod.cfg.Name)
+	mgr.logger.Debugw("Module successfully closed", "module", mod.cfg.Name)
 	return nil
 }
 
@@ -462,7 +473,7 @@ func (mgr *Manager) addResource(ctx context.Context, conf resource.Config, deps 
 
 	apiInfo, ok := resource.LookupGenericAPIRegistration(conf.API)
 	if !ok || apiInfo.RPCClient == nil {
-		mgr.logger.Warnf("no built-in grpc client for modular resource %s", conf.ResourceName())
+		mgr.logger.Warnw("No built-in grpc client for modular resource", "resource", conf.ResourceName())
 		return rdkgrpc.NewForeignResource(conf.ResourceName(), &mod.conn), nil
 	}
 	return apiInfo.RPCClient(ctx, &mod.conn, "", conf.ResourceName(), mgr.logger)
@@ -616,7 +627,7 @@ func (mgr *Manager) ResolveImplicitDependenciesInConfig(ctx context.Context, con
 			if mgr.Provides(c) {
 				implicitDeps, err := mgr.ValidateConfig(ctx, c)
 				if err != nil {
-					mgr.logger.Errorw("modular config validation error found in resource: "+c.Name, "error", err)
+					mgr.logger.Errorw("Modular config validation error found in resource: "+c.Name, "error", err)
 					continue
 				}
 
@@ -729,14 +740,14 @@ func (mgr *Manager) newOnUnexpectedExitHandler(mod *module) func(exitCode int) b
 
 		// Log error immediately, as this is unexpected behavior.
 		mgr.logger.Errorw(
-			"module has unexpectedly exited, attempting to restart it",
+			"Module has unexpectedly exited. Attempting to restart it",
 			"module", mod.cfg.Name,
 			"exit_code", exitCode,
 		)
 
 		// close client connection, we will re-dial as part of restart attempts.
 		if err := mod.conn.Close(); err != nil {
-			mgr.logger.Warnw("error while closing connection to crashed module, continuing restart attempt",
+			mgr.logger.Warnw("Error while closing connection to crashed module. Continuing restart attempt",
 				"module", mod.cfg.Name, "error", err)
 		}
 
@@ -757,7 +768,7 @@ func (mgr *Manager) newOnUnexpectedExitHandler(mod *module) func(exitCode int) b
 		var orphanedResourceNames []resource.Name
 		for name, res := range mod.resources {
 			if _, err := mgr.AddResource(mgr.restartCtx, res.conf, res.deps); err != nil {
-				mgr.logger.Warnw("error while re-adding resource to module",
+				mgr.logger.Warnw("Error while re-adding resource to module",
 					"resource", name, "module", mod.cfg.Name, "error", err)
 				mgr.rMap.Delete(name)
 				delete(mod.resources, name)
@@ -768,7 +779,7 @@ func (mgr *Manager) newOnUnexpectedExitHandler(mod *module) func(exitCode int) b
 			mgr.removeOrphanedResources(mgr.restartCtx, orphanedResourceNames)
 		}
 
-		mgr.logger.Infow("module successfully restarted", "module", mod.cfg.Name)
+		mgr.logger.Infow("Module successfully restarted", "module", mod.cfg.Name)
 		return false
 	}
 }
@@ -805,8 +816,8 @@ func (mgr *Manager) attemptRestart(ctx context.Context, mod *module) []resource.
 	// Attempt to restart module process 3 times.
 	for attempt := 1; attempt < 4; attempt++ {
 		if err := mgr.startModuleProcess(mod); err != nil {
-			mgr.logger.Errorf("attempt %d: error while restarting crashed module %s: %v",
-				attempt, mod.cfg.Name, err)
+			mgr.logger.Errorw("Error while restarting crashed module", "restart attempt",
+				attempt, "module", mod.cfg.Name, "error", err)
 			if attempt == 3 {
 				// return early upon last attempt failure.
 				return orphanedResourceNames
@@ -820,13 +831,13 @@ func (mgr *Manager) attemptRestart(ctx context.Context, mod *module) []resource.
 	}
 
 	if err := mod.dial(); err != nil {
-		mgr.logger.Errorw("error while dialing restarted module",
+		mgr.logger.Errorw("Error while dialing restarted module",
 			"module", mod.cfg.Name, "error", err)
 		return orphanedResourceNames
 	}
 
 	if err := mod.checkReady(ctx, mgr.parentAddr, mgr.logger); err != nil {
-		mgr.logger.Errorw("error while waiting for restarted module to be ready",
+		mgr.logger.Errorw("Error while waiting for restarted module to be ready",
 			"module", mod.cfg.Name, "error", err)
 		return orphanedResourceNames
 	}
@@ -874,7 +885,7 @@ func (m *module) checkReady(ctx context.Context, parentAddr string, logger loggi
 			select {
 			case <-slowTicker.C:
 				elapsed := time.Since(startTime).Seconds()
-				logger.Warnf("waiting %q for module to be ready. Elapsed %.2f seconds", m.cfg.Name, elapsed)
+				logger.Warnw("Waiting for module to be ready", "module", m.cfg.Name, "time elapsed", elapsed)
 				slowTicker.Reset(5 * time.Second)
 			case <-ctxTimeout.Done():
 				return
@@ -966,7 +977,7 @@ func (m *module) startProcess(
 			return ctxTimeout.Err()
 		case <-slowTicker.C:
 			elapsed := time.Since(startTime).Seconds()
-			logger.Warnf("%q slow startup detected. Elapsed %.2f seconds", m.cfg.Name, elapsed)
+			logger.Warnf("Slow module startup detected", "module", m.cfg.Name, "time elapsed", elapsed)
 			slowTicker.Reset(5 * time.Second)
 		default:
 		}
@@ -1011,7 +1022,7 @@ func (m *module) registerResources(mgr modmaninterface.ModuleManager, logger log
 		switch {
 		case api.API.IsComponent():
 			for _, model := range models {
-				logger.Infow("registering component from module", "module", m.cfg.Name, "API", api.API, "model", model)
+				logger.Infow("Registering component from module", "module", m.cfg.Name, "API", api.API, "model", model)
 				resource.RegisterComponent(api.API, model, resource.Registration[resource.Resource, resource.NoNativeConfig]{
 					Constructor: func(
 						ctx context.Context,
@@ -1025,7 +1036,7 @@ func (m *module) registerResources(mgr modmaninterface.ModuleManager, logger log
 			}
 		case api.API.IsService():
 			for _, model := range models {
-				logger.Infow("registering service from module", "module", m.cfg.Name, "API", api.API, "model", model)
+				logger.Infow("Registering service from module", "module", m.cfg.Name, "API", api.API, "model", model)
 				resource.RegisterService(api.API, model, resource.Registration[resource.Resource, resource.NoNativeConfig]{
 					Constructor: func(
 						ctx context.Context,
@@ -1038,7 +1049,7 @@ func (m *module) registerResources(mgr modmaninterface.ModuleManager, logger log
 				})
 			}
 		default:
-			logger.Errorf("invalid module type: %s", api.API.Type)
+			logger.Errorw("Invalid module type", "API type", api.API.Type)
 		}
 	}
 }
@@ -1054,22 +1065,22 @@ func (m *module) deregisterResources() {
 
 func (m *module) cleanupAfterStartupFailure(logger logging.Logger) {
 	if err := m.stopProcess(); err != nil {
-		msg := "error while stopping process of module that failed to start"
+		msg := "Error while stopping process of module that failed to start"
 		logger.Errorw(msg, "module", m.cfg.Name, "error", err)
 	}
 	if err := m.conn.Close(); err != nil {
-		msg := "error while closing connection to module that failed to start"
+		msg := "Error while closing connection to module that failed to start"
 		logger.Errorw(msg, "module", m.cfg.Name, "error", err)
 	}
 }
 
 func (m *module) cleanupAfterCrash(mgr *Manager) {
 	if err := m.stopProcess(); err != nil {
-		msg := "error while stopping process of crashed module"
+		msg := "Error while stopping process of crashed module"
 		mgr.logger.Errorw(msg, "module", m.cfg.Name, "error", err)
 	}
 	if err := m.conn.Close(); err != nil {
-		msg := "error while closing connection to crashed module"
+		msg := "Error while closing connection to crashed module"
 		mgr.logger.Errorw(msg, "module", m.cfg.Name, "error", err)
 	}
 	mgr.rMap.Range(func(r resource.Name, mod *module) bool {

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -1032,7 +1032,7 @@ func (m *module) registerResources(mgr modmaninterface.ModuleManager, logger log
 		switch {
 		case api.API.IsComponent():
 			for _, model := range models {
-				logger.Infow("Registering component from module", "module", m.cfg.Name, "API", api.API, "model", model)
+				logger.Infow("Registering component API and model from module", "module", m.cfg.Name, "API", api.API, "model", model)
 				resource.RegisterComponent(api.API, model, resource.Registration[resource.Resource, resource.NoNativeConfig]{
 					Constructor: func(
 						ctx context.Context,
@@ -1046,7 +1046,7 @@ func (m *module) registerResources(mgr modmaninterface.ModuleManager, logger log
 			}
 		case api.API.IsService():
 			for _, model := range models {
-				logger.Infow("Registering service from module", "module", m.cfg.Name, "API", api.API, "model", model)
+				logger.Infow("Registering service API and model from module", "module", m.cfg.Name, "API", api.API, "model", model)
 				resource.RegisterService(api.API, model, resource.Registration[resource.Resource, resource.NoNativeConfig]{
 					Constructor: func(
 						ctx context.Context,

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -446,7 +446,7 @@ func TestModuleReloading(t *testing.T) {
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			test.That(tb, logs.FilterMessageSnippet("module successfully restarted").Len(),
+			test.That(tb, logs.FilterMessageSnippet("Module successfully restarted").Len(),
 				test.ShouldEqual, 1)
 		})
 
@@ -462,9 +462,9 @@ func TestModuleReloading(t *testing.T) {
 
 		// Assert that logs reflect that test-module crashed and there were no
 		// errors during restart.
-		test.That(t, logs.FilterMessageSnippet("module has unexpectedly exited").Len(),
+		test.That(t, logs.FilterMessageSnippet("Module has unexpectedly exited").Len(),
 			test.ShouldEqual, 1)
-		test.That(t, logs.FilterMessageSnippet("error while restarting crashed module").Len(),
+		test.That(t, logs.FilterMessageSnippet("Error while restarting crashed module").Len(),
 			test.ShouldEqual, 0)
 
 		// Assert that RemoveOrphanedResources was called once.
@@ -516,7 +516,7 @@ func TestModuleReloading(t *testing.T) {
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			test.That(tb, logs.FilterMessageSnippet("error while restarting crashed module").Len(),
+			test.That(tb, logs.FilterMessageSnippet("Error while restarting crashed module").Len(),
 				test.ShouldEqual, 3)
 		})
 
@@ -531,9 +531,9 @@ func TestModuleReloading(t *testing.T) {
 
 		// Assert that logs reflect that test-module crashed and was not
 		// successfully restarted.
-		test.That(t, logs.FilterMessageSnippet("module has unexpectedly exited").Len(),
+		test.That(t, logs.FilterMessageSnippet("Module has unexpectedly exited").Len(),
 			test.ShouldEqual, 1)
-		test.That(t, logs.FilterMessageSnippet("module successfully restarted").Len(),
+		test.That(t, logs.FilterMessageSnippet("Module successfully restarted").Len(),
 			test.ShouldEqual, 0)
 
 		// Assert that RemoveOrphanedResources was called once.
@@ -934,7 +934,7 @@ func TestTwoModulesRestart(t *testing.T) {
 
 	testutils.WaitForAssertion(t, func(tb testing.TB) {
 		tb.Helper()
-		test.That(tb, logs.FilterMessageSnippet("module successfully restarted").Len(),
+		test.That(tb, logs.FilterMessageSnippet("Module successfully restarted").Len(),
 			test.ShouldEqual, 2)
 	})
 
@@ -943,9 +943,9 @@ func TestTwoModulesRestart(t *testing.T) {
 
 	// Assert that logs reflect that test-module crashed and there were no
 	// errors during restart.
-	test.That(t, logs.FilterMessageSnippet("module has unexpectedly exited").Len(),
+	test.That(t, logs.FilterMessageSnippet("Module has unexpectedly exited").Len(),
 		test.ShouldEqual, 2)
-	test.That(t, logs.FilterMessageSnippet("error while restarting crashed module").Len(),
+	test.That(t, logs.FilterMessageSnippet("Error while restarting crashed module").Len(),
 		test.ShouldEqual, 0)
 
 	// Assert that RemoveOrphanedResources was called once for each module.

--- a/module/version_reconfigure_test.go
+++ b/module/version_reconfigure_test.go
@@ -65,7 +65,7 @@ func TestValidationFailureDuringReconfiguration(t *testing.T) {
 
 	// Assert that there were no validation or component building errors
 	test.That(t, logs.FilterMessageSnippet(
-		"modular config validation error found in resource: generic1").Len(), test.ShouldEqual, 0)
+		"modular resource config validation error").Len(), test.ShouldEqual, 0)
 	test.That(t, logs.FilterMessageSnippet("error building component").Len(), test.ShouldEqual, 0)
 
 	// Read the config, swap to `run_version2.sh`, and overwrite the config, triggering a
@@ -86,7 +86,7 @@ func TestValidationFailureDuringReconfiguration(t *testing.T) {
 	// Race condition safety: Resource removal should occur after modular resource validation (during completeConfig), so if
 	// ResourceByName is failing, these errors should already be present
 	test.That(t, logs.FilterMessageSnippet(
-		"modular config validation error found in resource: generic1").Len(), test.ShouldEqual, 1)
+		"modular resource config validation error").Len(), test.ShouldEqual, 1)
 	test.That(t, logs.FilterMessageSnippet("error building component").Len(), test.ShouldEqual, 0)
 }
 
@@ -137,7 +137,7 @@ func TestVersionBumpWithNewImplicitDeps(t *testing.T) {
 
 	// Assert that there were no validation or component building errors
 	test.That(t, logs.FilterMessageSnippet(
-		"modular config validation error found in resource: generic1").Len(), test.ShouldEqual, 0)
+		"modular resource config validation error").Len(), test.ShouldEqual, 0)
 	test.That(t, logs.FilterMessageSnippet("error building component").Len(), test.ShouldEqual, 0)
 
 	// Swap in `run_version3.sh`. Version 3 requires `generic1` to have a `motor` in its
@@ -155,7 +155,7 @@ func TestVersionBumpWithNewImplicitDeps(t *testing.T) {
 	// Race condition safety: Resource removal should occur after modular resource validation (during completeConfig), so if
 	// ResourceByName is failing, these errors should already be present
 	test.That(t, logs.FilterMessageSnippet(
-		"modular config validation error found in resource: generic1").Len(), test.ShouldEqual, 1)
+		"modular resource config validation error").Len(), test.ShouldEqual, 1)
 	test.That(t, logs.FilterMessageSnippet("error building component").Len(), test.ShouldEqual, 0)
 
 	// Update the generic1 configuration to have a `motor` attribute. The following reconfiguration

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -1115,6 +1115,8 @@ func (r *localRobot) Reconfigure(ctx context.Context, newConfig *config.Config) 
 		return
 	}
 
+	r.logger.CInfo(ctx, "Reconfiguring robot")
+
 	if r.revealSensitiveConfigDiffs {
 		r.logger.CDebugf(ctx, "(re)configuring with %+v", diff)
 	}

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -1155,7 +1155,7 @@ func (r *localRobot) Reconfigure(ctx context.Context, newConfig *config.Config) 
 	allErrs = multierr.Combine(allErrs, r.manager.moduleManager.CleanModuleDataDirectory())
 
 	if allErrs != nil {
-		r.logger.CErrorw(ctx, "the following errors were gathered during reconfiguration", "errors", allErrs)
+		r.logger.CErrorw(ctx, "The following errors were gathered during reconfiguration", "errors", allErrs)
 	} else {
 		r.logger.CInfow(ctx, "Robot successfully reconfigured")
 	}

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -1115,7 +1115,7 @@ func (r *localRobot) Reconfigure(ctx context.Context, newConfig *config.Config) 
 		return
 	}
 
-	r.logger.CInfo(ctx, "Reconfiguring robot")
+	r.logger.CInfo(ctx, "(Re)configuring robot")
 
 	if r.revealSensitiveConfigDiffs {
 		r.logger.CDebugf(ctx, "(re)configuring with %+v", diff)
@@ -1159,7 +1159,7 @@ func (r *localRobot) Reconfigure(ctx context.Context, newConfig *config.Config) 
 	if allErrs != nil {
 		r.logger.CErrorw(ctx, "The following errors were gathered during reconfiguration", "errors", allErrs)
 	} else {
-		r.logger.CInfow(ctx, "Robot successfully reconfigured")
+		r.logger.CInfow(ctx, "Robot successfully (re)configured")
 	}
 }
 

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -1156,6 +1156,8 @@ func (r *localRobot) Reconfigure(ctx context.Context, newConfig *config.Config) 
 
 	if allErrs != nil {
 		r.logger.CErrorw(ctx, "the following errors were gathered during reconfiguration", "errors", allErrs)
+	} else {
+		r.logger.CInfow(ctx, "Robot successfully reconfigured")
 	}
 }
 

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -2632,11 +2632,11 @@ func TestOrphanedResources(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "rpc error")
 
-		// Wait for "attempt 3" in logs.
+		// Wait for 3 restart attempts in logs.
 		testutils.WaitForAssertionWithSleep(t, time.Second, 20, func(tb testing.TB) {
 			tb.Helper()
-			test.That(tb, logs.FilterMessageSnippet("attempt 3").Len(),
-				test.ShouldEqual, 1)
+			test.That(tb, logs.FilterFieldKey("restart attempt").Len(),
+				test.ShouldEqual, 3)
 		})
 		time.Sleep(2 * time.Second)
 
@@ -2674,11 +2674,11 @@ func TestOrphanedResources(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "rpc error")
 
-		// Wait for "attempt 3" in logs.
+		// Wait for 3 restart attempts in logs.
 		testutils.WaitForAssertionWithSleep(t, time.Second, 20, func(tb testing.TB) {
 			tb.Helper()
-			test.That(tb, logs.FilterMessageSnippet("attempt 3").Len(),
-				test.ShouldEqual, 1)
+			test.That(tb, logs.FilterFieldKey("restart attempt").Len(),
+				test.ShouldEqual, 3)
 		})
 		time.Sleep(2 * time.Second)
 

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -410,6 +410,8 @@ func (manager *resourceManager) mergeResourceRPCAPIsWithRemote(r robot.Robot, ty
 }
 
 func (manager *resourceManager) closeResource(ctx context.Context, res resource.Resource) error {
+	manager.logger.CInfow(ctx, fmt.Sprintf("now removing resource"), "resource", res.Name())
+
 	allErrs := res.Close(ctx)
 
 	resName := res.Name()
@@ -516,7 +518,7 @@ func (manager *resourceManager) completeConfig(
 		} else {
 			verb = "reconfiguring"
 		}
-		manager.logger.CDebugw(ctx, fmt.Sprintf("now %s a remote", verb), "resource", resName)
+		manager.logger.CInfow(ctx, fmt.Sprintf("now %s a remote", verb), "resource", resName)
 		switch resName.API {
 		case client.RemoteAPI:
 			remConf, err := resource.NativeConfig[*config.Remote](gNode.Config())
@@ -609,7 +611,7 @@ func (manager *resourceManager) completeConfig(
 			} else {
 				verb = "reconfiguring"
 			}
-			manager.logger.CDebugw(ctx, fmt.Sprintf("now %s resource", verb), "resource", resName)
+			manager.logger.CInfow(ctx, fmt.Sprintf("now %s resource", verb), "resource", resName)
 
 			// this is done in config validation but partial start rules require us to check again
 			if _, err := conf.Validate("", resName.API.Type.Name); err != nil {
@@ -754,7 +756,7 @@ func (manager *resourceManager) processRemote(
 	gNode *resource.GraphNode,
 ) (*client.RobotClient, error) {
 	dialOpts := remoteDialOptions(config, manager.opts)
-	manager.logger.CDebugw(ctx, "connecting now to remote", "remote", config.Name)
+	manager.logger.CInfow(ctx, "connecting now to remote", "remote", config.Name)
 	robotClient, err := dialRobotClient(ctx, config, gNode.Logger(), dialOpts...)
 	if err != nil {
 		if errors.Is(err, rpc.ErrInsecureWithCredentials) {
@@ -766,7 +768,7 @@ func (manager *resourceManager) processRemote(
 		}
 		return nil, errors.Errorf("couldn't connect to robot remote (%s): %s", config.Address, err)
 	}
-	manager.logger.CDebugw(ctx, "connected now to remote", "remote", config.Name)
+	manager.logger.CInfow(ctx, "connected now to remote", "remote", config.Name)
 	return robotClient, nil
 }
 

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -410,7 +410,7 @@ func (manager *resourceManager) mergeResourceRPCAPIsWithRemote(r robot.Robot, ty
 }
 
 func (manager *resourceManager) closeResource(ctx context.Context, res resource.Resource) error {
-	manager.logger.CInfow(ctx, fmt.Sprintf("now removing resource"), "resource", res.Name())
+	manager.logger.CInfow(ctx, "Now removing resource", "resource", res.Name())
 
 	allErrs := res.Close(ctx)
 
@@ -518,7 +518,7 @@ func (manager *resourceManager) completeConfig(
 		} else {
 			verb = "reconfiguring"
 		}
-		manager.logger.CInfow(ctx, fmt.Sprintf("now %s a remote", verb), "resource", resName)
+		manager.logger.CInfow(ctx, fmt.Sprintf("Now %s a remote", verb), "resource", resName)
 		switch resName.API {
 		case client.RemoteAPI:
 			remConf, err := resource.NativeConfig[*config.Remote](gNode.Config())
@@ -611,7 +611,7 @@ func (manager *resourceManager) completeConfig(
 			} else {
 				verb = "reconfiguring"
 			}
-			manager.logger.CInfow(ctx, fmt.Sprintf("now %s resource", verb), "resource", resName)
+			manager.logger.CInfow(ctx, fmt.Sprintf("Now %s resource", verb), "resource", resName)
 
 			// this is done in config validation but partial start rules require us to check again
 			if _, err := conf.Validate("", resName.API.Type.Name); err != nil {
@@ -756,7 +756,7 @@ func (manager *resourceManager) processRemote(
 	gNode *resource.GraphNode,
 ) (*client.RobotClient, error) {
 	dialOpts := remoteDialOptions(config, manager.opts)
-	manager.logger.CInfow(ctx, "connecting now to remote", "remote", config.Name)
+	manager.logger.CInfow(ctx, "Connecting now to remote", "remote", config.Name)
 	robotClient, err := dialRobotClient(ctx, config, gNode.Logger(), dialOpts...)
 	if err != nil {
 		if errors.Is(err, rpc.ErrInsecureWithCredentials) {
@@ -768,7 +768,7 @@ func (manager *resourceManager) processRemote(
 		}
 		return nil, errors.Errorf("couldn't connect to robot remote (%s): %s", config.Address, err)
 	}
-	manager.logger.CInfow(ctx, "connected now to remote", "remote", config.Name)
+	manager.logger.CInfow(ctx, "Connected now to remote", "remote", config.Name)
 	return robotClient, nil
 }
 
@@ -861,7 +861,7 @@ func (manager *resourceManager) processResource(
 			return nil, false, err
 		}
 	} else {
-		manager.logger.CDebugw(ctx, "resource models differ so it must be rebuilt",
+		manager.logger.CInfow(ctx, "Resource models differ so resource must be rebuilt",
 			"name", resName, "old_model", gNode.ResourceModel(), "new_model", conf.Model)
 	}
 


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-7042

Adds (or bumps to `Info`) logs for:
- Adding a module
- Reconfiguring a module
- Removing a module
- Successful add of a batch of modules
- Adding (configuring) a resource
- Reconfiguring a resource
- Removing a resource
- Adding (configuring) a modular resource
- Reconfiguring a modular resource
- Removing a modular resource
- Connecting to a remote
- Successful connection a remote
- Successful reconfiguration of a robot

Uses upper-cased log messages and prefers structured logging where possible in the module manager and in a few places in the resource manager.

cc @viamrobotics/netcode 

Here is an example of what logs look like now for a complex set of reconfigurations/state changes (a run of `TestOrphanedResources`). I'll update this file as we make more changes to the logs in this PR.

[orphaned_resources_output.txt](https://github.com/viamrobotics/rdk/files/14696668/orphaned_resources_output.txt)

`TestOrphanedResources` does the following:
- Initializes a robot with an empty config
- Manual reconfiguration (subtest):
    - `Reconfigure`s robot to have a complex module, a "gizmo" component and a "summation" service
    - `Reconfigure`s robot to change the complex module to the simple module
    - `Reconfigure`s robot to have no module at all
- Automatic reconfiguration (subtest):
    - `Reconfigure`s robot to have a test module and a "helper" component
    - Removes the test module's binary while robot is running
    - Kills current test module running process to mimic an "unexpected exit"
    - Re-adds the test module's binary
    - `Reconfigure`s robot to have no module at all
    - `Reconfigure`s robot to have a test module and a "helper" component 
