### PR TITLE
RSDK-367 prune extraneous methods from `Geometry` interface

### DIFF
--- a/components/base/client_test.go
+++ b/components/base/client_test.go
@@ -183,7 +183,7 @@ func TestClient(t *testing.T) {
 			geometries, err := workingBaseClient.Geometries(context.Background(), nil)
 			test.That(t, err, test.ShouldBeNil)
 			for i, geometry := range geometries {
-				test.That(t, geometry.AlmostEqual(expectedGeometries[i]), test.ShouldBeTrue)
+				test.That(t, spatialmath.GeometriesAlmostEqual(geometry, expectedGeometries[i]), test.ShouldBeTrue)
 			}
 		})
 	})

--- a/components/base/kinematicbase/differentialDrive_test.go
+++ b/components/base/kinematicbase/differentialDrive_test.go
@@ -75,7 +75,10 @@ func TestWrapWithDifferentialDriveKinematics(t *testing.T) {
 			test.That(t, limits[1].Max, test.ShouldBeGreaterThan, 0)
 			geometry, err := ddk.executionFrame.(*referenceframe.SimpleModel).Geometries(make([]referenceframe.Input, len(limits)))
 			test.That(t, err, test.ShouldBeNil)
-			equivalent := geometry.GeometryByName(testCfg.Name + ":" + testCfg.Frame.Geometry.Label).AlmostEqual(expectedSphere)
+			equivalent := spatialmath.GeometriesAlmostEqual(
+				geometry.GeometryByName(testCfg.Name+":"+testCfg.Frame.Geometry.Label),
+				expectedSphere,
+			)
 			test.That(t, equivalent, test.ShouldBeTrue)
 		})
 	}

--- a/pointcloud/pointcloud_utils_test.go
+++ b/pointcloud/pointcloud_utils_test.go
@@ -54,7 +54,7 @@ func TestBoundingBoxFromPointCloud(t *testing.T) {
 		box, err := BoundingBoxFromPointCloudWithLabel(c.pc, "box")
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, box, test.ShouldNotBeNil)
-		test.That(t, box.AlmostEqual(expectedBox), test.ShouldBeTrue)
+		test.That(t, spatialmath.GeometriesAlmostEqual(box, expectedBox), test.ShouldBeTrue)
 		test.That(t, box.Label(), test.ShouldEqual, "box")
 	}
 }

--- a/referenceframe/frame_system_test.go
+++ b/referenceframe/frame_system_test.go
@@ -261,7 +261,7 @@ func TestFrameSystemGeometries(t *testing.T) {
 		g0, ok := geometries[name0]
 		test.That(t, ok, test.ShouldBeTrue)
 		test.That(t, g0.Parent(), test.ShouldResemble, World)
-		test.That(t, g0.Geometries()[0].AlmostEqual(box0), test.ShouldBeTrue)
+		test.That(t, spatial.GeometriesAlmostEqual(g0.Geometries()[0], box0), test.ShouldBeTrue)
 		g1, ok := geometries[name1]
 		test.That(t, ok, test.ShouldBeTrue)
 		test.That(t, g1.Parent(), test.ShouldResemble, World)

--- a/referenceframe/frame_test.go
+++ b/referenceframe/frame_test.go
@@ -129,7 +129,7 @@ func TestGeometries(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	geometries, err := tf.Geometries(FloatsToInputs([]float64{10}))
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, expectedBox.AlmostEqual(geometries.Geometries()[0]), test.ShouldBeTrue)
+	test.That(t, spatial.GeometriesAlmostEqual(expectedBox, geometries.Geometries()[0]), test.ShouldBeTrue)
 
 	// test erroring correctly from trying to create a geometry for a rotational frame
 	rf, err := NewRotationalFrame("", spatial.R4AA{3.7, 2.1, 3.1, 4.1}, Limit{5, 6})
@@ -144,7 +144,7 @@ func TestGeometries(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	geometries, err = sf.Geometries([]Input{})
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, expectedBox.AlmostEqual(geometries.Geometries()[0]), test.ShouldBeTrue)
+	test.That(t, spatial.GeometriesAlmostEqual(expectedBox, geometries.Geometries()[0]), test.ShouldBeTrue)
 }
 
 func TestSerializationStatic(t *testing.T) {

--- a/referenceframe/transformable_test.go
+++ b/referenceframe/transformable_test.go
@@ -35,9 +35,9 @@ func TestGeometriesInFrame(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	gF := NewGeometriesInFrame("frame", geometryList)
 	test.That(t, gF.Parent(), test.ShouldEqual, "frame")
-	test.That(t, one.AlmostEqual(gF.GeometryByName("one")), test.ShouldBeTrue)
+	test.That(t, spatial.GeometriesAlmostEqual(one, gF.GeometryByName("one")), test.ShouldBeTrue)
 	convertedGF, err := ProtobufToGeometriesInFrame(GeometriesInFrameToProtobuf(gF))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gF.Parent(), test.ShouldEqual, convertedGF.Parent())
-	test.That(t, one.AlmostEqual(convertedGF.GeometryByName("one")), test.ShouldBeTrue)
+	test.That(t, spatial.GeometriesAlmostEqual(one, convertedGF.GeometryByName("one")), test.ShouldBeTrue)
 }

--- a/referenceframe/urdf/geometry_test.go
+++ b/referenceframe/urdf/geometry_test.go
@@ -46,7 +46,7 @@ func TestGeometrySerialization(t *testing.T) {
 			xml.Unmarshal(bytes, &urdf2)
 			g2, err := urdf2.toGeometry()
 			test.That(t, err, test.ShouldBeNil)
-			test.That(t, tc.g.AlmostEqual(g2), test.ShouldBeTrue)
+			test.That(t, spatialmath.GeometriesAlmostEqual(tc.g, g2), test.ShouldBeTrue)
 		})
 	}
 }

--- a/referenceframe/worldstate.go
+++ b/referenceframe/worldstate.go
@@ -1,6 +1,7 @@
 package referenceframe
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/jedib0t/go-pretty/v6/table"
@@ -115,7 +116,7 @@ func (ws *WorldState) String() string {
 		for _, geometry := range geometries.geometries {
 			t.AppendRow([]interface{}{
 				geometry.Label(),
-				geometry.String(),
+				fmt.Sprint(geometry),
 				geometries.frame,
 			})
 		}

--- a/referenceframe/worldstate_test.go
+++ b/referenceframe/worldstate_test.go
@@ -1,6 +1,7 @@
 package referenceframe
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/jedib0t/go-pretty/v6/table"
@@ -61,17 +62,17 @@ func TestString(t *testing.T) {
 	testTable.AppendHeader(table.Row{"Name", "Geometry Type", "Parent"})
 	testTable.AppendRow([]interface{}{
 		"foo",
-		foo.String(),
+		foo.(fmt.Stringer).String(),
 		"world",
 	})
 	testTable.AppendRow([]interface{}{
 		"bar",
-		bar.String(),
+		bar.(fmt.Stringer).String(),
 		"world",
 	})
 	testTable.AppendRow([]interface{}{
 		"testgeo",
-		testgeo.String(),
+		testgeo.(fmt.Stringer).String(),
 		"camera",
 	})
 

--- a/robot/framesystem/framesystem.go
+++ b/robot/framesystem/framesystem.go
@@ -89,7 +89,7 @@ func (cfg Config) String() string {
 		ori := pose.Orientation().EulerAngles()
 		geomString := ""
 		if gc := part.FrameConfig.Geometry(); gc != nil {
-			geomString = gc.String()
+			geomString = fmt.Sprint(gc)
 		}
 		t.AppendRow([]interface{}{
 			fmt.Sprintf("%d", i+1),

--- a/services/motion/client_test.go
+++ b/services/motion/client_test.go
@@ -267,7 +267,8 @@ func TestClient(t *testing.T) {
 			expectedExecutionID := uuid.New()
 			injectMS.MoveOnMapFunc = func(ctx context.Context, req motion.MoveOnMapReq) (motion.ExecutionID, error) {
 				test.That(t, len(req.Obstacles), test.ShouldEqual, 1)
-				test.That(t, req.Obstacles[0].AlmostEqual(spatialmath.NewPoint(r3.Vector{2, 2, 2}, "pt")), test.ShouldBeTrue)
+				equal := spatialmath.GeometriesAlmostEqual(req.Obstacles[0], spatialmath.NewPoint(r3.Vector{2, 2, 2}, "pt"))
+				test.That(t, equal, test.ShouldBeTrue)
 				return expectedExecutionID, nil
 			}
 

--- a/services/motion/server_test.go
+++ b/services/motion/server_test.go
@@ -421,7 +421,8 @@ func TestServerMoveOnMap(t *testing.T) {
 		firstExecutionID := uuid.New()
 		injectMS.MoveOnMapFunc = func(ctx context.Context, req motion.MoveOnMapReq) (motion.ExecutionID, error) {
 			test.That(t, len(req.Obstacles), test.ShouldEqual, 1)
-			test.That(t, req.Obstacles[0].AlmostEqual(spatialmath.NewPoint(r3.Vector{2, 2, 2}, "pt")), test.ShouldBeTrue)
+			equal := spatialmath.GeometriesAlmostEqual(req.Obstacles[0], spatialmath.NewPoint(r3.Vector{2, 2, 2}, "pt"))
+			test.That(t, equal, test.ShouldBeTrue)
 			return firstExecutionID, nil
 		}
 

--- a/services/navigation/builtin/builtin_test.go
+++ b/services/navigation/builtin/builtin_test.go
@@ -1824,7 +1824,7 @@ func TestGetObstacles(t *testing.T) {
 	test.That(t, dets[0], test.ShouldResemble, sphereGob)
 	test.That(t, dets[1].Location(), test.ShouldResemble, geo.NewPoint(0.9999998600983906, 1.0000001399229705))
 	test.That(t, len(dets[1].Geometries()), test.ShouldEqual, 1)
-	test.That(t, dets[1].Geometries()[0].AlmostEqual(manipulatedBoxGeom), test.ShouldBeTrue)
+	test.That(t, spatialmath.GeometriesAlmostEqual(dets[1].Geometries()[0], manipulatedBoxGeom), test.ShouldBeTrue)
 	test.That(t, dets[1].Geometries()[0].Label(), test.ShouldEqual, manipulatedBoxGeom.Label())
 }
 

--- a/spatialmath/box.go
+++ b/spatialmath/box.go
@@ -106,7 +106,7 @@ func (b *box) Pose() Pose {
 }
 
 // AlmostEqual compares the box with another geometry and checks if they are equivalent.
-func (b *box) AlmostEqual(g Geometry) bool {
+func (b *box) almostEqual(g Geometry) bool {
 	other, ok := g.(*box)
 	if !ok {
 		return false

--- a/spatialmath/box_test.go
+++ b/spatialmath/box_test.go
@@ -34,8 +34,8 @@ func TestBoxAlmostEqual(t *testing.T) {
 	original := makeTestBox(NewZeroOrientation(), r3.Vector{}, r3.Vector{1, 1, 1}, "")
 	good := makeTestBox(NewZeroOrientation(), r3.Vector{1e-16, 1e-16, 1e-16}, r3.Vector{1 + 1e-16, 1 + 1e-16, 1 + 1e-16}, "")
 	bad := makeTestBox(NewZeroOrientation(), r3.Vector{1e-2, 1e-2, 1e-2}, r3.Vector{1 + 1e-2, 1 + 1e-2, 1 + 1e-2}, "")
-	test.That(t, original.AlmostEqual(good), test.ShouldBeTrue)
-	test.That(t, original.AlmostEqual(bad), test.ShouldBeFalse)
+	test.That(t, original.(*box).almostEqual(good), test.ShouldBeTrue)
+	test.That(t, original.(*box).almostEqual(bad), test.ShouldBeFalse)
 }
 
 func TestBoxVertices(t *testing.T) {

--- a/spatialmath/capsule.go
+++ b/spatialmath/capsule.go
@@ -104,7 +104,7 @@ func (c *capsule) Pose() Pose {
 }
 
 // AlmostEqual compares the capsule with another geometry and checks if they are equivalent.
-func (c *capsule) AlmostEqual(g Geometry) bool {
+func (c *capsule) almostEqual(g Geometry) bool {
 	other, ok := g.(*capsule)
 	if !ok {
 		return false

--- a/spatialmath/geometry.go
+++ b/spatialmath/geometry.go
@@ -9,7 +9,7 @@ import (
 	commonpb "go.viam.com/api/common/v1"
 )
 
-// Geometry is an interface defining a 3D solid
+// Geometry is an interface defining a 3D solid.
 type Geometry interface {
 	// Pose returns the Pose of the center of the Geometry
 	Pose() Pose
@@ -166,6 +166,7 @@ func (config *GeometryConfig) ToProtobuf() (*commonpb.Geometry, error) {
 	return creator.ToProtobuf(), nil
 }
 
+// GeometriesAlmostEqual returns a bool describing if the two input Geometries are equal.
 func GeometriesAlmostEqual(a, b Geometry) bool {
 	switch gType := a.(type) {
 	case *box:

--- a/spatialmath/geometry_test.go
+++ b/spatialmath/geometry_test.go
@@ -58,7 +58,7 @@ func TestGeometrySerializationJSON(t *testing.T) {
 			test.That(t, err, test.ShouldBeNil)
 			newVc, err := config.ParseConfig()
 			test.That(t, err, test.ShouldBeNil)
-			test.That(t, gc.Transform(pose).AlmostEqual(newVc.Transform(pose)), test.ShouldBeTrue)
+			test.That(t, GeometriesAlmostEqual(gc.Transform(pose), newVc.Transform(pose)), test.ShouldBeTrue)
 			test.That(t, config.Label, test.ShouldEqual, testCase.name)
 		})
 	}
@@ -78,7 +78,7 @@ func TestGeometryToFromProtobuf(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			newVol, err := NewGeometryFromProto(testCase.geometry.ToProtobuf())
 			test.That(t, err, test.ShouldBeNil)
-			test.That(t, testCase.geometry.AlmostEqual(newVol), test.ShouldBeTrue)
+			test.That(t, GeometriesAlmostEqual(testCase.geometry, newVol), test.ShouldBeTrue)
 			test.That(t, testCase.geometry.Label(), test.ShouldEqual, testCase.name)
 		})
 	}

--- a/spatialmath/point.go
+++ b/spatialmath/point.go
@@ -50,7 +50,7 @@ func (pt *point) Pose() Pose {
 }
 
 // AlmostEqual compares the point with another geometry and checks if they are equivalent.
-func (pt *point) AlmostEqual(g Geometry) bool {
+func (pt *point) almostEqual(g Geometry) bool {
 	other, ok := g.(*point)
 	if !ok {
 		return false
@@ -88,7 +88,7 @@ func (pt *point) CollidesWith(g Geometry, collisionBufferMM float64) (bool, erro
 		return capsuleVsPointDistance(other, pt.position) <= 0, nil
 	}
 	if other, ok := g.(*point); ok {
-		return pt.AlmostEqual(other), nil
+		return pt.almostEqual(other), nil
 	}
 	return true, newCollisionTypeUnsupportedError(pt, g)
 }

--- a/spatialmath/point_test.go
+++ b/spatialmath/point_test.go
@@ -24,6 +24,6 @@ func TestPointAlmostEqual(t *testing.T) {
 	original := NewPoint(r3.Vector{}, "")
 	good := NewPoint(r3.Vector{1e-18, 1e-18, 1e-18}, "")
 	bad := NewPoint(r3.Vector{1e-2, 1e-2, 1e-2}, "")
-	test.That(t, original.AlmostEqual(good), test.ShouldBeTrue)
-	test.That(t, original.AlmostEqual(bad), test.ShouldBeFalse)
+	test.That(t, original.(*point).almostEqual(good), test.ShouldBeTrue)
+	test.That(t, original.(*point).almostEqual(bad), test.ShouldBeFalse)
 }

--- a/spatialmath/sphere.go
+++ b/spatialmath/sphere.go
@@ -63,7 +63,7 @@ func (s *sphere) Pose() Pose {
 }
 
 // AlmostEqual compares the sphere with another geometry and checks if they are equivalent.
-func (s *sphere) AlmostEqual(g Geometry) bool {
+func (s *sphere) almostEqual(g Geometry) bool {
 	other, ok := g.(*sphere)
 	if !ok {
 		return false

--- a/spatialmath/sphere_test.go
+++ b/spatialmath/sphere_test.go
@@ -34,8 +34,8 @@ func TestSphereAlmostEqual(t *testing.T) {
 	original := makeTestSphere(r3.Vector{}, 1, "")
 	good := makeTestSphere(r3.Vector{1e-16, 1e-16, 1e-16}, 1+1e-16, "")
 	bad := makeTestSphere(r3.Vector{1e-2, 1e-2, 1e-2}, 1+1e-2, "")
-	test.That(t, original.AlmostEqual(good), test.ShouldBeTrue)
-	test.That(t, original.AlmostEqual(bad), test.ShouldBeFalse)
+	test.That(t, original.(*sphere).almostEqual(good), test.ShouldBeTrue)
+	test.That(t, original.(*sphere).almostEqual(bad), test.ShouldBeFalse)
 }
 
 func TestSpherePC(t *testing.T) {

--- a/vision/object_test.go
+++ b/vision/object_test.go
@@ -33,7 +33,7 @@ func TestObjectCreation(t *testing.T) {
 	test.That(t, obj.PointCloud, test.ShouldResemble, pc)
 	expectedBox, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{0.5, 0.5, 0}), r3.Vector{1, 1, 0}, "")
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, obj.Geometry.AlmostEqual(expectedBox), test.ShouldBeTrue)
+	test.That(t, spatialmath.GeometriesAlmostEqual(obj.Geometry, expectedBox), test.ShouldBeTrue)
 }
 
 func TestObjectCreationWithLabel(t *testing.T) {

--- a/vision/segmentation/radius_clustering_test.go
+++ b/vision/segmentation/radius_clustering_test.go
@@ -9,6 +9,7 @@ import (
 
 	"go.viam.com/rdk/logging"
 	pc "go.viam.com/rdk/pointcloud"
+	"go.viam.com/rdk/spatialmath"
 	"go.viam.com/rdk/testutils/inject"
 	"go.viam.com/rdk/utils"
 	"go.viam.com/rdk/vision"
@@ -117,7 +118,7 @@ func testSegmentation(t *testing.T, segments []*vision.Object, expectedLabel str
 		}
 		test.That(t, box, test.ShouldNotBeNil)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, box.AlmostEqual(seg.Geometry), test.ShouldBeTrue)
+		test.That(t, spatialmath.GeometriesAlmostEqual(box, seg.Geometry), test.ShouldBeTrue)
 		test.That(t, box.Label(), test.ShouldEqual, expectedLabel)
 	}
 }

--- a/vision/segmentation/segments_test.go
+++ b/vision/segmentation/segments_test.go
@@ -152,6 +152,6 @@ func testPointCloudBoundingBox(t *testing.T, cloud pc.PointCloud, center, dims r
 		test.That(t, err, test.ShouldBeNil)
 		boxExpected, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(center), dims, "")
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, box.AlmostEqual(boxExpected), test.ShouldBeTrue)
+		test.That(t, spatialmath.GeometriesAlmostEqual(box, boxExpected), test.ShouldBeTrue)
 	}
 }


### PR DESCRIPTION
This PR cuts the `AlmostEqual` and `String` methods from the `Geometry` interface to make it easier for implementers of this interface to add a new `Geometry`