### PR TITLE
RSDK-6984: optimizing sourcetable parser

### DIFF
--- a/components/movementsensor/gpsrtkserial/gpsrtkserial.go
+++ b/components/movementsensor/gpsrtkserial/gpsrtkserial.go
@@ -352,7 +352,7 @@ func (g *rtkSerial) connectAndParseSourceTable() error {
 	g.logger.Debugf("sourceTable is: %v\n", srcTable)
 
 	g.logger.Debug("got sourcetable, parsing it...")
-	g.isVirtualBase, err = gpsutils.FindLineWithMountPoint(srcTable, g.ntripClient.MountPoint)
+	g.isVirtualBase, err = gpsutils.IsVRS(srcTable, g.ntripClient.MountPoint)
 	if err != nil {
 		g.logger.Errorf("can't find mountpoint in source table, found err %v\n", err)
 		return err

--- a/components/movementsensor/gpsrtkserial/gpsrtkserial.go
+++ b/components/movementsensor/gpsrtkserial/gpsrtkserial.go
@@ -352,7 +352,7 @@ func (g *rtkSerial) connectAndParseSourceTable() error {
 	g.logger.Debugf("sourceTable is: %v\n", srcTable)
 
 	g.logger.Debug("got sourcetable, parsing it...")
-	g.isVirtualBase, err = gpsutils.IsVRS(srcTable, g.ntripClient.MountPoint)
+	g.isVirtualBase, err = gpsutils.HasVRSStream(srcTable, g.ntripClient.MountPoint)
 	if err != nil {
 		g.logger.Errorf("can't find mountpoint in source table, found err %v\n", err)
 		return err

--- a/components/movementsensor/gpsutils/ntrip.go
+++ b/components/movementsensor/gpsutils/ntrip.go
@@ -152,11 +152,13 @@ Loop:
 		case "NET":
 			continue
 		case "STR":
-			str, err := parseStream(ln)
-			if err != nil {
-				return nil, fmt.Errorf("error while parsing stream: %w", err)
+			if fields[mp] == n.MountPoint {
+				str, err := parseStream(ln)
+				if err != nil {
+					return nil, fmt.Errorf("error while parsing stream: %w", err)
+				}
+				st.Streams = append(st.Streams, str)
 			}
-			st.Streams = append(st.Streams, str)
 		case "ENDSOURCETABLE":
 			break Loop
 		default:

--- a/components/movementsensor/gpsutils/vrs.go
+++ b/components/movementsensor/gpsutils/vrs.go
@@ -92,9 +92,8 @@ func ContainsGGAMessage(data []byte) bool {
 	return strings.Contains(dataStr, "GGA")
 }
 
-// IsVRS parses the given source-table returns the NMEA field associated with
-// the given mountpoint.
-func IsVRS(sourceTable *Sourcetable, mountPoint string) (bool, error) {
+// HasVRSStream returns the NMEA field associated with the given mountpoint.
+func HasVRSStream(sourceTable *Sourcetable, mountPoint string) (bool, error) {
 	stream, isFound := sourceTable.HasStream(mountPoint)
 
 	if !isFound {

--- a/components/movementsensor/gpsutils/vrs.go
+++ b/components/movementsensor/gpsutils/vrs.go
@@ -92,7 +92,8 @@ func ContainsGGAMessage(data []byte) bool {
 	return strings.Contains(dataStr, "GGA")
 }
 
-// HasVRSStream returns the NMEA field associated with the given mountpoint.
+// HasVRSStream returns the NMEA field associated with the given mountpoint
+// and whether it is a Virtual Reference Station.
 func HasVRSStream(sourceTable *Sourcetable, mountPoint string) (bool, error) {
 	stream, isFound := sourceTable.HasStream(mountPoint)
 

--- a/components/movementsensor/gpsutils/vrs.go
+++ b/components/movementsensor/gpsutils/vrs.go
@@ -92,9 +92,9 @@ func ContainsGGAMessage(data []byte) bool {
 	return strings.Contains(dataStr, "GGA")
 }
 
-// FindLineWithMountPoint parses the given source-table returns the NMEA field associated with
+// IsVRS parses the given source-table returns the NMEA field associated with
 // the given mountpoint.
-func FindLineWithMountPoint(sourceTable *Sourcetable, mountPoint string) (bool, error) {
+func IsVRS(sourceTable *Sourcetable, mountPoint string) (bool, error) {
 	stream, isFound := sourceTable.HasStream(mountPoint)
 
 	if !isFound {


### PR DESCRIPTION
`rtk2go.com `source table often comes with incomplete information. `ParseSoutcetable `calls `parseStream` at every line of the source table and we encounter error. This PR avoids that by only calling `parseStream` when we see the mount point. This reduces function calls when parsing the source table and avoids running into error on mount points that we don't care about.