### PR TITLE
RSDK-7035 Do not re-add old resources as part of module `Reconfigure`

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -613,7 +613,8 @@ func (mgr *Manager) ResolveImplicitDependenciesInConfig(ctx context.Context, con
 			// If component is in conf.Modified, the user modified a module and its component at the same time. Remove that
 			// resource from conf.Modified and put it in conf.Added so the restarted module receives an AddResourceRequest
 			// and not a ReconfigureResourceRequest.
-			slices.DeleteFunc(conf.Modified.Components, func(elem resource.Config) bool { return elem.Name == c.Name })
+			conf.Modified.Components = slices.DeleteFunc(
+				conf.Modified.Components, func(elem resource.Config) bool { return elem.Name == c.Name })
 			conf.Added.Components = append(conf.Added.Components, c)
 		}
 	}
@@ -629,7 +630,8 @@ func (mgr *Manager) ResolveImplicitDependenciesInConfig(ctx context.Context, con
 			// If service is in conf.Modified, the user modified a module and its service at the same time. Remove that
 			// resource from conf.Modified and put it in conf.Added so the restarted module receives an AddResourceRequest
 			// and not a ReconfigureResourceRequest.
-			slices.DeleteFunc(conf.Modified.Services, func(elem resource.Config) bool { return elem.Name == s.Name })
+			conf.Modified.Services = slices.DeleteFunc(
+				conf.Modified.Services, func(elem resource.Config) bool { return elem.Name == s.Name })
 			conf.Added.Services = append(conf.Added.Services, s)
 		}
 	}

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -613,11 +613,7 @@ func (mgr *Manager) ResolveImplicitDependenciesInConfig(ctx context.Context, con
 			// If component is in conf.Modified, the user modified a module and its component at the same time. Remove that
 			// resource from conf.Modified and put it in conf.Added so the restarted module receives an AddResourceRequest
 			// and not a ReconfigureResourceRequest.
-			for i, modifiedComponent := range conf.Modified.Components {
-				if modifiedComponent.Name == c.Name {
-					conf.Modified.Components = append(conf.Modified.Components[:i], conf.Modified.Components[i+1:]...)
-				}
-			}
+			slices.DeleteFunc(conf.Modified.Components, func(elem resource.Config) bool { return elem.Name == c.Name })
 			conf.Added.Components = append(conf.Added.Components, c)
 		}
 	}
@@ -633,12 +629,8 @@ func (mgr *Manager) ResolveImplicitDependenciesInConfig(ctx context.Context, con
 			// If service is in conf.Modified, the user modified a module and its service at the same time. Remove that
 			// resource from conf.Modified and put it in conf.Added so the restarted module receives an AddResourceRequest
 			// and not a ReconfigureResourceRequest.
-			for i, modifiedService := range conf.Modified.Services {
-				if modifiedService.Name == s.Name {
-					conf.Modified.Services = append(conf.Modified.Services[:i], conf.Modified.Services[i+1:]...)
-				}
-			}
-			conf.Modified.Services = append(conf.Modified.Services, s)
+			slices.DeleteFunc(conf.Modified.Services, func(elem resource.Config) bool { return elem.Name == s.Name })
+			conf.Added.Services = append(conf.Added.Services, s)
 		}
 	}
 

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -208,26 +208,12 @@ func TestModManagerFunctions(t *testing.T) {
 	// Reconfigure module with new ExePath.
 	orphanedResourceNames, err := mgr.Reconfigure(ctx, modCfg)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, orphanedResourceNames, test.ShouldBeNil)
-
-	// counter1 should still be provided by reconfigured module.
-	ok = mgr.IsModularResource(rNameCounter1)
-	test.That(t, ok, test.ShouldBeTrue)
-	ret, err = counter.DoCommand(ctx, map[string]interface{}{"command": "get"})
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, ret["total"], test.ShouldEqual, 0)
+	test.That(t, orphanedResourceNames, test.ShouldResemble, []resource.Name{rNameCounter1})
 
 	t.Log("test RemoveModule")
 	orphanedResourceNames, err = mgr.Remove("simple-module")
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, orphanedResourceNames, test.ShouldResemble, []resource.Name{rNameCounter1})
-
-	// module will only really go away after resources within it are removed/closed
-	ok = mgr.IsModularResource(rNameCounter1)
-	test.That(t, ok, test.ShouldBeTrue)
-
-	err = mgr.RemoveResource(ctx, rNameCounter1)
-	test.That(t, err, test.ShouldBeNil)
+	test.That(t, orphanedResourceNames, test.ShouldBeNil)
 
 	ok = mgr.IsModularResource(rNameCounter1)
 	test.That(t, ok, test.ShouldBeFalse)

--- a/module/testmodule/main.go
+++ b/module/testmodule/main.go
@@ -75,9 +75,9 @@ func newHelper(
 
 type helper struct {
 	resource.Named
-	resource.TriviallyReconfigurable
 	resource.TriviallyCloseable
-	logger logging.Logger
+	logger              logging.Logger
+	numReconfigurations int
 }
 
 // DoCommand is the only method of this component. It looks up the "real" command from the map it's passed.
@@ -152,9 +152,16 @@ func (h *helper) DoCommand(ctx context.Context, req map[string]interface{}) (map
 		}
 
 		return map[string]any{}, nil
+	case "get_num_reconfigurations":
+		return map[string]any{"num_reconfigurations": h.numReconfigurations}, nil
 	default:
 		return nil, fmt.Errorf("unknown command string %s", cmd)
 	}
+}
+
+func (h *helper) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+	h.numReconfigurations++
+	return nil
 }
 
 func newTestMotor(

--- a/module/testmodule/main.go
+++ b/module/testmodule/main.go
@@ -168,6 +168,7 @@ func (h *helper) DoCommand(ctx context.Context, req map[string]interface{}) (map
 	}
 }
 
+// Reconfigure increments numReconfigurations.
 func (h *helper) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
 	h.numReconfigurations++
 	return nil
@@ -176,7 +177,7 @@ func (h *helper) Reconfigure(ctx context.Context, deps resource.Dependencies, co
 func newOther(
 	ctx context.Context, deps resource.Dependencies, conf resource.Config, logger logging.Logger,
 ) (resource.Resource, error) {
-	return &helper{
+	return &other{
 		Named: conf.ResourceName().AsNamed(),
 	}, nil
 }
@@ -202,6 +203,7 @@ func (o *other) DoCommand(ctx context.Context, req map[string]interface{}) (map[
 	}
 }
 
+// Reconfigure increments numReconfigurations.
 func (o *other) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
 	o.numReconfigurations++
 	return nil

--- a/module/testmodule/main.go
+++ b/module/testmodule/main.go
@@ -16,10 +16,12 @@ import (
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/module"
 	"go.viam.com/rdk/resource"
+	genericservice "go.viam.com/rdk/services/generic"
 )
 
 var (
 	helperModel    = resource.NewModel("rdk", "test", "helper")
+	otherModel     = resource.NewModel("rdk", "test", "other")
 	testMotorModel = resource.NewModel("rdk", "test", "motor")
 	myMod          *module.Module
 )
@@ -42,6 +44,15 @@ func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) err
 		helperModel,
 		resource.Registration[resource.Resource, resource.NoNativeConfig]{Constructor: newHelper})
 	err = myMod.AddModelFromRegistry(ctx, generic.API, helperModel)
+	if err != nil {
+		return err
+	}
+
+	resource.RegisterService(
+		genericservice.API,
+		otherModel,
+		resource.Registration[resource.Resource, resource.NoNativeConfig]{Constructor: newOther})
+	err = myMod.AddModelFromRegistry(ctx, genericservice.API, otherModel)
 	if err != nil {
 		return err
 	}
@@ -80,9 +91,7 @@ type helper struct {
 	numReconfigurations int
 }
 
-// DoCommand is the only method of this component. It looks up the "real" command from the map it's passed.
-//
-
+// DoCommand looks up the "real" command from the map it's passed.
 func (h *helper) DoCommand(ctx context.Context, req map[string]interface{}) (map[string]interface{}, error) {
 	cmd, ok := req["command"]
 	if !ok {
@@ -161,6 +170,40 @@ func (h *helper) DoCommand(ctx context.Context, req map[string]interface{}) (map
 
 func (h *helper) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
 	h.numReconfigurations++
+	return nil
+}
+
+func newOther(
+	ctx context.Context, deps resource.Dependencies, conf resource.Config, logger logging.Logger,
+) (resource.Resource, error) {
+	return &helper{
+		Named: conf.ResourceName().AsNamed(),
+	}, nil
+}
+
+type other struct {
+	resource.Named
+	resource.TriviallyCloseable
+	numReconfigurations int
+}
+
+// DoCommand looks up the "real" command from the map it's passed.
+func (o *other) DoCommand(ctx context.Context, req map[string]interface{}) (map[string]interface{}, error) {
+	cmd, ok := req["command"]
+	if !ok {
+		return nil, errors.New("missing 'command' string")
+	}
+
+	switch req["command"] {
+	case "get_num_reconfigurations":
+		return map[string]any{"num_reconfigurations": o.numReconfigurations}, nil
+	default:
+		return nil, fmt.Errorf("unknown command string %s", cmd)
+	}
+}
+
+func (o *other) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+	o.numReconfigurations++
 	return nil
 }
 

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -3114,6 +3114,34 @@ func TestModularResourceReconfigurationCount(t *testing.T) {
 	test.That(t, resp, test.ShouldNotBeNil)
 	test.That(t, resp["num_reconfigurations"], test.ShouldEqual, 1)
 
+	cfg4 := &config.Config{
+		Modules: []config.Module{
+			{
+				Name:    "mod",
+				ExePath: testPath,
+			},
+		},
+		Components: []resource.Config{
+			{
+				Name:  "h",
+				Model: helperModel,
+				API:   generic.API,
+				Attributes: rutils.AttributeMap{
+					"bar": "baz",
+				},
+			},
+		},
+	}
+	r.Reconfigure(ctx, cfg4)
+
+	// Assert that if module is reconfigured (`LogLevel` removed), _and_ helper
+	// is reconfigured (attributes changed), helper is only constructed in new
+	// module process and not `Reconfigure`d.
+	resp, err = h.DoCommand(ctx, map[string]any{"command": "get_num_reconfigurations"})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, resp, test.ShouldNotBeNil)
+	test.That(t, resp["num_reconfigurations"], test.ShouldEqual, 0)
+
 	// Assert that helper is only constructed after module crash/successful
 	// restart and has not `Reconfigure`d.
 	_, err = h.DoCommand(ctx, map[string]any{"command": "kill_module"})


### PR DESCRIPTION
RSDK-7035

Stops attempting to add the old module process' resources back to the new module process as part of module reconfiguration. Uses `ResolveImplicitDependenciesInConfig` to put all resources handled by a reconfigured module in `conf.Added.Components/Services` instead of `conf.Modified.Components/Services`. Adds test that modular resources do not `Reconfigure` after their module reconfigures or crashes w/ successful restart. Adds info-logs to indicate that a reconfigured or removed module's resources will be re-added or removed, respectively.

We had an issue where reconfiguring a module would stop the old process, start the new process, add the old process' resources to the new process, and _then_ **reconfigure the new resources** in the new process to have correct implicit dependencies. That extra reconfigure was unnecessary and caused problems in users' modules that didn't expect a modular resource to be constructed and then immediately reconfigured upon module reconfiguration. With this PR, module reconfiguration now stops the old process, starts the new process, and adds the old process' resources to the new process with correct implicit dependencies (no extra reconfigurations of modular resources).

cc @viamrobotics/netcode @zaporter-work @abe-winter 