### PR TITLE
RSDK-7064 - Logger panics if sync called concurrently

### DIFF
--- a/data/collector.go
+++ b/data/collector.go
@@ -93,8 +93,6 @@ func (c *collector) Close() {
 	}
 	close(c.captureErrors)
 	c.logRoutine.Wait()
-	//nolint:errcheck
-	_ = c.logger.Sync()
 	c.closed = true
 }
 

--- a/logging/net_appender.go
+++ b/logging/net_appender.go
@@ -253,8 +253,8 @@ func (nl *NetAppender) syncOnce() (bool, error) {
 	defer nl.toLogMutex.Unlock()
 
 	// Remove successfully synced logs from the queue. If we've overflowed more times than the size of the batch
-	// we wrote, do not mutate toLog at all. If we've synced more logs than there are logs left, empty out toLog
-	// to prevent panics.
+	// we wrote, do not mutate toLog at all. If we've synced more logs than there are logs left, set idx to length
+	// of array to prevent panics.
 	if batchSize > nl.toLogOverflowsSinceLastSync {
 		idx := min(batchSize-nl.toLogOverflowsSinceLastSync, len(nl.toLog))
 		nl.toLog = nl.toLog[idx:]

--- a/logging/net_appender.go
+++ b/logging/net_appender.go
@@ -253,9 +253,11 @@ func (nl *NetAppender) syncOnce() (bool, error) {
 	defer nl.toLogMutex.Unlock()
 
 	// Remove successfully synced logs from the queue. If we've overflowed more times than the size of the batch
-	//  we wrote, do not mutate toLog at all.
+	// we wrote, do not mutate toLog at all. If we've synced more logs than there are logs left, empty out toLog
+	// to prevent panics.
 	if batchSize > nl.toLogOverflowsSinceLastSync {
-		nl.toLog = nl.toLog[batchSize-nl.toLogOverflowsSinceLastSync:]
+		idx := min(batchSize-nl.toLogOverflowsSinceLastSync, len(nl.toLog))
+		nl.toLog = nl.toLog[idx:]
 	}
 	nl.toLogOverflowsSinceLastSync = 0
 	return len(nl.toLog) > 0, nil

--- a/logging/net_appender_test.go
+++ b/logging/net_appender_test.go
@@ -119,7 +119,7 @@ func TestNetLoggerBatchWrites(t *testing.T) {
 		logger.Info("Some-info")
 	}
 
-	netAppender.Sync()
+	netAppender.sync()
 	netAppender.Close()
 
 	server.service.logsMu.Lock()
@@ -164,11 +164,11 @@ func TestNetLoggerBatchFailureAndRetry(t *testing.T) {
 	//
 	// The `netAppender` also has a background worker syncing on its own cadence. This complicates
 	// exactly which syncs do what work and which ones return errors.
-	netAppender.Sync()
+	netAppender.sync()
 
 	logger.Info("New info")
 
-	netAppender.Sync()
+	netAppender.sync()
 	netAppender.Close()
 
 	server.service.logsMu.Lock()

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -99,8 +99,6 @@ func (s *syncer) Close() {
 	s.backgroundWorkers.Wait()
 	close(s.syncErrs)
 	s.logRoutine.Wait()
-	//nolint:errcheck
-	_ = s.logger.Sync()
 }
 
 func (s *syncer) SetArbitraryFileTags(tags []string) {
@@ -143,9 +141,9 @@ func (s *syncer) SyncFile(path string) {
 				if err != nil {
 					// Don't log if the file does not exist, because that means it was successfully synced and deleted
 					// in between paths being built and this executing.
-					if !errors.Is(err, os.ErrNotExist) {
-						s.logger.Errorw("error opening file", "error", err)
-					}
+					// if !errors.Is(err, os.ErrNotExist) {
+					// 	s.logger.Errorw("error opening file", "error", err)
+					// }
 					return
 				}
 
@@ -257,7 +255,7 @@ func (s *syncer) logSyncErrs() {
 				continue
 			}
 		}
-		s.logger.Error(err)
+		// s.logger.Error(err)
 	}
 }
 

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -141,9 +141,9 @@ func (s *syncer) SyncFile(path string) {
 				if err != nil {
 					// Don't log if the file does not exist, because that means it was successfully synced and deleted
 					// in between paths being built and this executing.
-					// if !errors.Is(err, os.ErrNotExist) {
-					// 	s.logger.Errorw("error opening file", "error", err)
-					// }
+					if !errors.Is(err, os.ErrNotExist) {
+						s.logger.Errorw("error opening file", "error", err)
+					}
 					return
 				}
 
@@ -255,7 +255,7 @@ func (s *syncer) logSyncErrs() {
 				continue
 			}
 		}
-		// s.logger.Error(err)
+		s.logger.Error(err)
 	}
 }
 


### PR DESCRIPTION
almost always guaranteed to run into a panic when shutting down a viam-server if a data collector is present in config

Culprit is calling Sync concurrently in data manager shutdown. while we could remove all references to logger.Sync to our codebase, that doesn't stop future regressions. We could also try and think of a way to make this threadsafe, but unless we make logger more complicated and slower, I don't think we would be able to avoid double logs. Therefore, I think the best solution is to make sync() single threaded and remove the possibility of others calling into net appender's sync

Also did fix the actual panic so that the logger can continue working and not affect normal usage

cc @agreenb - the logger will flush its own logs eventually, so removing the Sync calls in datamanager shouldn't be an issue
```goroutine 31 [running]:
runtime/debug.Stack()
        /opt/homebrew/Cellar/go@1.21/1.21.8/libexec/src/runtime/debug/stack.go:24 +0x64
runtime/debug.PrintStack()
        /opt/homebrew/Cellar/go@1.21/1.21.8/libexec/src/runtime/debug/stack.go:16 +0x1c
go.viam.com/utils.PanicCapturingGoWithCallback.func1.1()
      go/pkg/mod/go.viam.com/utils@v0.1.67/runtime.go:154 +0x40
panic({0x102f419c0?, 0x14001223368?})
        /opt/homebrew/Cellar/go@1.21/1.21.8/libexec/src/runtime/panic.go:914 +0x218
go.viam.com/utils.ManagedGo.func1.1()
       go/pkg/mod/go.viam.com/utils@v0.1.67/runtime.go:177 +0x5c
panic({0x102f419c0?, 0x14001223368?})
        /opt/homebrew/Cellar/go@1.21/1.21.8/libexec/src/runtime/panic.go:914 +0x218
go.viam.com/rdk/logging.(*NetAppender).syncOnce(0x14000977e80)
       rdk/logging/net_appender.go:262 +0x460
go.viam.com/rdk/logging.(*NetAppender).Sync(...)
       rdk/logging/net_appender.go:271
go.viam.com/rdk/logging.(*NetAppender).backgroundWorker(0x14000977e80)
        rdk/logging/net_appender.go:214 +0x138
go.viam.com/utils.ManagedGo.func1()
       go.viam.com/utils@v0.1.67/runtime.go:180 +0x54
go.viam.com/utils.PanicCapturingGoWithCallback.func1()
        go.viam.com/utils@v0.1.67/runtime.go:164 +0x54
created by go.viam.com/utils.PanicCapturingGoWithCallback in goroutine 1
        go.viam.com/utils@v0.1.67/runtime.go:151 +0x70
2024-03-22T16:21:28.820-0400    ERROR   utils@v0.1.67/runtime.go:155    panic while running function    {"error": "runtime error: slice bounds out of range [9:4]"}```