### PR TITLE
RSDK-6054 - Ticker in a busy loop

### DIFF
--- a/examples/customresources/demos/complexmodule/module.json
+++ b/examples/customresources/demos/complexmodule/module.json
@@ -2,7 +2,7 @@
 	"modules": [
 		{
 			"name": "AcmeModule",
-			"executable_path": "./complexmodule",
+			"executable_path": "./run.sh",
 			"log_level": "debug"
 		}
 	],

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -321,7 +321,7 @@ func (mgr *Manager) startModule(ctx context.Context, mod *module) error {
 			select {
 			case <-slowTicker.C:
 				elapsed := time.Since(startTime).Seconds()
-				mgr.logger.CWarnw(ctx, "Still waiting for module to startup", "module", mod.cfg.Name, "time elapsed", elapsed)
+				mgr.logger.CWarnw(ctx, "Waiting for module to startup", "module", mod.cfg.Name, "time elapsed", elapsed)
 				if firstTick {
 					slowTicker.Reset(3 * time.Second)
 					firstTick = false
@@ -856,7 +856,7 @@ func (mgr *Manager) attemptRestart(ctx context.Context, mod *module) []resource.
 			select {
 			case <-slowTicker.C:
 				elapsed := time.Since(startTime).Seconds()
-				mgr.logger.CWarnw(ctx, "Still waiting for module to restart", "module", mod.cfg.Name, "time elapsed", elapsed)
+				mgr.logger.CWarnw(ctx, "Waiting for module to restart", "module", mod.cfg.Name, "time elapsed", elapsed)
 				if firstTick {
 					slowTicker.Reset(3 * time.Second)
 					firstTick = false
@@ -932,7 +932,7 @@ func (m *module) checkReady(ctx context.Context, parentAddr string, logger loggi
 	ctxTimeout, cancelFunc := context.WithTimeout(ctx, rutils.GetModuleStartupTimeout(logger))
 	defer cancelFunc()
 
-	logger.CInfow(ctx, "Waiting for module to be ready", "module", m.cfg.Name)
+	logger.CInfow(ctx, "Waiting for module to get ready", "module", m.cfg.Name)
 	for {
 		req := &pb.ReadyRequest{ParentAddress: parentAddr}
 		// 5000 is an arbitrarily high number of attempts (context timeout should hit long before)
@@ -1006,7 +1006,7 @@ func (m *module) startProcess(
 	checkTicker := time.NewTicker(100 * time.Millisecond)
 	defer checkTicker.Stop()
 
-	logger.CInfow(ctx, "Waiting for module to startup", "module", m.cfg.Name)
+	logger.CInfow(ctx, "Starting up module", "module", m.cfg.Name)
 	ctxTimeout, cancel := context.WithTimeout(ctx, rutils.GetModuleStartupTimeout(logger))
 	defer cancel()
 	for {


### PR DESCRIPTION
while fixing it, went ahead and pulled the slow startup logs into a higher function, so that we don't get two tickers with slightly different messages for each module. Attached a run

```2024-03-22T21:49:47.609Z        INFO    robot_server    modmanager/manager.go:1014      Starting up module      {"module":"AcmeModule"}
2024-03-22T21:49:49.607Z        WARN    robot_server    modmanager/manager.go:326       Waiting for module to complete startup and registration {"module":"AcmeModule","time elapsed":2.000197583}
2024-03-22T21:49:52.607Z        WARN    robot_server    modmanager/manager.go:326       Waiting for module to complete startup and registration {"module":"AcmeModule","time elapsed":5.000611708}
2024-03-22T21:49:57.608Z        WARN    robot_server    modmanager/manager.go:326       Waiting for module to complete startup and registration {"module":"AcmeModule","time elapsed":10.000834916}
2024-03-22T21:49:58.610Z        INFO    robot_server    modmanager/manager.go:940       Waiting for module to respond to ready request  {"module":"AcmeModule"}
2024-03-22T21:50:02.608Z        WARN    robot_server    modmanager/manager.go:326       Waiting for module to complete startup and registration {"module":"AcmeModule","time elapsed":15.001345083}
2024-03-22T21:50:07.608Z        WARN    robot_server    modmanager/manager.go:326       Waiting for module to complete startup and registration {"module":"AcmeModule","time elapsed":20.001581583}
```