### PR TITLE
bump golang version in cli job

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -31,7 +31,7 @@ jobs:
 
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.20.x'
+        go-version: '1.21.x'
 
     - name: build
       env:


### PR DESCRIPTION
## What changed
- bump setup-go in cli job from 1.20 -> 1.21
## Why
- cli job is failing on main
- guessing this isn't exercised in PRs so we didn't discover until merging
- the `go build ./...` command technically exercised this part of the codebase, but in an environment that had go 1.21
## Test run
https://github.com/viamrobotics/rdk/actions/runs/8423487311/job/23065230004