### PR TITLE
[RSDK-7071] Remove lscpu call in camera logger that causes orange pi board to hang

### DIFF
--- a/components/camera/videosource/logging/logger.go
+++ b/components/camera/videosource/logging/logger.go
@@ -245,7 +245,6 @@ func (l *Logger) init(ctx context.Context) {
 		"processor": runCommand(ctx, "uname", "--processor"),
 		"platform":  runCommand(ctx, "uname", "--hardware-platform"),
 		"OS":        runCommand(ctx, "uname", "--operating-system"),
-		"lscpu":     runCommand(ctx, "lscpu"),
 		"model":     runCommand(ctx, "cat", "/proc/device-tree/model"),
 	})
 }


### PR DESCRIPTION
[RSDK-7071](https://viam.atlassian.net/browse/RSDK-7071)

[RSDK-7071]: https://viam.atlassian.net/browse/RSDK-7071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ