### PR TITLE
RSDK-7011, RSDK-7030 - Update initial config flow

### DIFF
--- a/config/reader.go
+++ b/config/reader.go
@@ -196,6 +196,21 @@ func isLocationSecretsEqual(prevCloud, cloud *Cloud) bool {
 	return true
 }
 
+func getTimeoutCtx(ctx context.Context, shouldReadFromCache bool, id string) (context.Context, func()) {
+	timeout := readTimeout
+
+	// use shouldReadFromCache to determine whether this is part of initial read or not, but only shorten timeout
+	// if cached config exists
+	cachedConfigExists := false
+	if _, err := os.Stat(getCloudCacheFilePath(id)); err == nil {
+		cachedConfigExists = true
+	}
+	if shouldReadFromCache && cachedConfigExists {
+		timeout = initialReadTimeout
+	}
+	return context.WithTimeout(ctx, timeout)
+}
+
 // readFromCloud fetches a robot config from the cloud based
 // on the given config.
 func readFromCloud(
@@ -251,16 +266,8 @@ func readFromCloud(
 
 	if checkForNewCert || tls.certificate == "" || tls.privateKey == "" {
 		logger.Debug("reading tlsCertificate from the cloud")
-		var (
-			ctxWithTimeout context.Context
-			cancel         func()
-		)
-		// use shouldReadFromCache determine whether this is part of initial read or not
-		if shouldReadFromCache {
-			ctxWithTimeout, cancel = context.WithTimeout(ctx, initialReadTimeout)
-		} else {
-			ctxWithTimeout, cancel = context.WithTimeout(ctx, readTimeout)
-		}
+
+		ctxWithTimeout, cancel := getTimeoutCtx(ctx, shouldReadFromCache, cloudCfg.ID)
 		// Use the SignalingInsecure from the Cloud config returned from the app not the initial config.
 		certData, err := readCertificateDataFromCloudGRPC(ctxWithTimeout, cfg.Cloud.SignalingInsecure, cloudCfg, logger)
 		if err != nil {
@@ -594,18 +601,9 @@ func processConfig(unprocessedConfig *Config, fromCloud bool, logger logging.Log
 // getFromCloudOrCache returns the config from the gRPC endpoint. If failures during cloud lookup fallback to the
 // local cache if the error indicates it should.
 func getFromCloudOrCache(ctx context.Context, cloudCfg *Cloud, shouldReadFromCache bool, logger logging.Logger) (*Config, bool, error) {
-	var (
-		cached bool
+	var cached bool
 
-		ctxWithTimeout context.Context
-		cancel         func()
-	)
-	// use shouldReadFromCache determine whether this is part of initial read or not
-	if shouldReadFromCache {
-		ctxWithTimeout, cancel = context.WithTimeout(ctx, initialReadTimeout)
-	} else {
-		ctxWithTimeout, cancel = context.WithTimeout(ctx, readTimeout)
-	}
+	ctxWithTimeout, cancel := getTimeoutCtx(ctx, shouldReadFromCache, cloudCfg.ID)
 	defer cancel()
 
 	cfg, errorShouldCheckCache, err := getFromCloudGRPC(ctxWithTimeout, cloudCfg, logger)
@@ -621,7 +619,12 @@ func getFromCloudOrCache(ctx context.Context, cloudCfg *Cloud, shouldReadFromCac
 				// return cache err
 				return nil, cached, cacheErr
 			}
-			logger.Warnw("unable to get cloud config; using cached version", "error", err)
+
+			lastUpdated := "unknown"
+			if fInfo, err := os.Stat(getCloudCacheFilePath(cloudCfg.ID)); err == nil {
+				lastUpdated = fInfo.ModTime().Format(time.RFC3339)
+			}
+			logger.Warnw("unable to get cloud config; using cached version", "config last updated", lastUpdated, "error", err)
 			cached = true
 			return cachedConfig, cached, nil
 		}

--- a/config/reader.go
+++ b/config/reader.go
@@ -622,7 +622,8 @@ func getFromCloudOrCache(ctx context.Context, cloudCfg *Cloud, shouldReadFromCac
 
 			lastUpdated := "unknown"
 			if fInfo, err := os.Stat(getCloudCacheFilePath(cloudCfg.ID)); err == nil {
-				lastUpdated = fInfo.ModTime().Format(time.RFC3339)
+				// Use logging.DefaultTimeFormatStr since this time will be logged.
+				lastUpdated = fInfo.ModTime().Format(logging.DefaultTimeFormatStr)
 			}
 			logger.Warnw("unable to get cloud config; using cached version", "config last updated", lastUpdated, "error", err)
 			cached = true

--- a/robot/session_manager.go
+++ b/robot/session_manager.go
@@ -58,7 +58,7 @@ func (m *SessionManager) All() []*session.Session {
 }
 
 func (m *SessionManager) expireLoop(ctx context.Context) {
-	ticker := time.NewTicker(10 * time.Millisecond)
+	ticker := time.NewTicker(1 * time.Millisecond)
 	defer ticker.Stop()
 
 	for {

--- a/robot/session_manager.go
+++ b/robot/session_manager.go
@@ -58,7 +58,7 @@ func (m *SessionManager) All() []*session.Session {
 }
 
 func (m *SessionManager) expireLoop(ctx context.Context) {
-	ticker := time.NewTicker(1 * time.Millisecond)
+	ticker := time.NewTicker(10 * time.Millisecond)
 	defer ticker.Stop()
 
 	for {


### PR DESCRIPTION
update so that we only shorten timeout to 1s if cached config exists. Prevents slow I/O from stopping server startup
also log the last modified time for cached config if we use it to start up
```
2024-03-25T18:50:39.112Z        WARN    robot_server    config/reader.go:627    unable to get cloud config; using cached version        {"config last updated":"2024-03-25T14:50:23-04:00","error":"context deadline exceeded"}
```
no new tests because there isn't a way to ensure that timeout changed (hard to test that timeout is between 1 and 5s, for example) without running into possible race conditions

tested locally, seems correct