### PR TITLE
RSDK-6951 - Test Datarace: go.viam.com/rdk/robot.TestSessionManager

### DIFF
--- a/robot/session_manager_test.go
+++ b/robot/session_manager_test.go
@@ -25,7 +25,6 @@ func TestSessionManager(t *testing.T) {
 	}
 
 	sm := robot.NewSessionManager(r, config.DefaultSessionHeartbeatWindow)
-	defer sm.Close()
 
 	// Start two arbitrary sessions.
 	fooSess, err := sm.Start(ctx, "foo")
@@ -51,6 +50,8 @@ func TestSessionManager(t *testing.T) {
 
 	// Assert that fooSess and barSess can be found with All.
 	allSessions := sm.All()
+	sm.Close()
+
 	test.That(t, len(allSessions), test.ShouldEqual, 2)
 	test.That(t, allSessions[0], test.ShouldBeIn, fooSess, barSess)
 	test.That(t, allSessions[1], test.ShouldBeIn, fooSess, barSess)


### PR DESCRIPTION
data race happening because we access a lock at the same time as we're deep equaling the session struct.

can reliably repro locally if I update the loop to run every 1ms and >30k times

simple fix is to remove the access (e.g. stop the background loop that session manager runs) by closing session manager before checking the equality