### PR TITLE
RSDK-7075 Fix modular resource reconfiguration test

### DIFF
--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -3205,7 +3205,7 @@ func TestModularResourceReconfigurationCount(t *testing.T) {
 
 	testutils.WaitForAssertion(t, func(tb testing.TB) {
 		tb.Helper()
-		test.That(tb, logs.FilterMessage("Module successfully restarted").Len(), test.ShouldEqual, 1)
+		test.That(tb, logs.FilterMessageSnippet("Module successfully restarted").Len(), test.ShouldEqual, 1)
 	})
 
 	resp, err = h.DoCommand(ctx, map[string]any{"command": "get_num_reconfigurations"})


### PR DESCRIPTION
RSDK-7075

The merge of https://github.com/viamrobotics/rdk/pull/3726 and https://github.com/viamrobotics/rdk/pull/3731 happened too close to each other. `TestModularResourceReconfigurationCount`, added in #3726, was waiting for the exact log message: `Module successfully restarted`, but #3731 changed the timing and contents of that message slightly. The CI required to merge #3731 ran without this test, so we didn't see the failure until merge (apparently git merge conflicts didn't catch it).