### PR TITLE
RSDK-7049 - Do not restart module if in shutdown

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -839,9 +839,7 @@ func (mgr *Manager) newOnUnexpectedExitHandler(mod *module) func(exitCode int) b
 
 		// Log error immediately, as this is unexpected behavior.
 		mgr.logger.Errorw(
-			"Module has unexpectedly exited. Attempting to restart it",
-			"module", mod.cfg.Name,
-			"exit_code", exitCode,
+			"Module has unexpectedly exited.", "module", mod.cfg.Name, "exit_code", exitCode,
 		)
 
 		// close client connection, we will re-dial as part of restart attempts.
@@ -916,12 +914,24 @@ func (mgr *Manager) attemptRestart(ctx context.Context, mod *module) []resource.
 	// already.
 	rutils.RemoveFileNoError(mod.addr)
 
-	var success bool
+	var (
+		success, processRestarted bool
+	)
 	defer func() {
 		if !success {
-			mod.cleanupAfterCrash(mgr)
+			mod.cleanupAfterCrash(mgr, processRestarted)
 		}
 	}()
+
+	if ctx.Err() != nil {
+		mgr.logger.Infow(
+			"Will not attempt to restart crashed module", "module", mod.cfg.Name, "reason", ctx.Err().Error(),
+		)
+		return orphanedResourceNames
+	}
+	mgr.logger.Infow(
+		"Attempting to restart crashed module", "module", mod.cfg.Name,
+	)
 
 	// No need to check mgr.untrustedEnv, as we're restarting the same
 	// executable we were given for initial module addition.
@@ -945,6 +955,7 @@ func (mgr *Manager) attemptRestart(ctx context.Context, mod *module) []resource.
 		// Wait with a bit of backoff.
 		utils.SelectContextOrWait(ctx, time.Duration(attempt)*oueRestartInterval)
 	}
+	processRestarted = true
 
 	if err := mod.dial(); err != nil {
 		mgr.logger.CErrorw(ctx, "Error while dialing restarted module",
@@ -1201,10 +1212,12 @@ func (m *module) cleanupAfterStartupFailure(logger logging.Logger) {
 	}
 }
 
-func (m *module) cleanupAfterCrash(mgr *Manager) {
-	if err := m.stopProcess(); err != nil {
-		msg := "Error while stopping process of crashed module"
-		mgr.logger.Errorw(msg, "module", m.cfg.Name, "error", err)
+func (m *module) cleanupAfterCrash(mgr *Manager, processRestarted bool) {
+	if processRestarted {
+		if err := m.stopProcess(); err != nil {
+			msg := "Error while stopping process of crashed module"
+			mgr.logger.Errorw(msg, "module", m.cfg.Name, "error", err)
+		}
 	}
 	if m.sharedConn != nil {
 		if err := m.sharedConn.Close(); err != nil {

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -916,13 +916,13 @@ func (mgr *Manager) attemptRestart(ctx context.Context, mod *module) []resource.
 
 	var success, processRestarted bool
 	defer func() {
-		if processRestarted {
-			if err := mod.stopProcess(); err != nil {
-				msg := "Error while stopping process of crashed module"
-				mgr.logger.Errorw(msg, "module", mod.cfg.Name, "error", err)
-			}
-		}
 		if !success {
+			if processRestarted {
+				if err := mod.stopProcess(); err != nil {
+					msg := "Error while stopping process of crashed module"
+					mgr.logger.Errorw(msg, "module", mod.cfg.Name, "error", err)
+				}
+			}
 			mod.cleanupAfterCrash(mgr)
 		}
 	}()

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -525,6 +525,66 @@ func TestModuleReloading(t *testing.T) {
 		// Assert that RemoveOrphanedResources was called once.
 		test.That(t, dummyRemoveOrphanedResourcesCallCount.Load(), test.ShouldEqual, 1)
 	})
+	t.Run("do not restart if context canceled", func(t *testing.T) {
+		logger, logs := logging.NewObservedTestLogger(t)
+
+		// Precompile module to avoid timeout issues when building takes too long.
+		modCfg.ExePath = rtestutils.BuildTempModule(t, "module/testmodule")
+
+		// This test neither uses a resource manager nor asserts anything about
+		// the existence of resources in the graph. Use a dummy
+		// RemoveOrphanedResources function so orphaned resource logic does not
+		// panic.
+		var dummyRemoveOrphanedResourcesCallCount atomic.Uint64
+		dummyRemoveOrphanedResources := func(context.Context, []resource.Name) {
+			dummyRemoveOrphanedResourcesCallCount.Add(1)
+		}
+		mgr := NewManager(ctx, parentAddr, logger, modmanageroptions.Options{
+			UntrustedEnv:            false,
+			RemoveOrphanedResources: dummyRemoveOrphanedResources,
+		})
+		err = mgr.Add(ctx, modCfg)
+		test.That(t, err, test.ShouldBeNil)
+
+		// Add helper resource and ensure "echo" works correctly.
+		h, err := mgr.AddResource(ctx, cfgMyHelper, nil)
+		test.That(t, err, test.ShouldBeNil)
+		ok := mgr.IsModularResource(rNameMyHelper)
+		test.That(t, ok, test.ShouldBeTrue)
+
+		mgr.(*Manager).restartCtxCancel()
+
+		// Run 'kill_module' command through helper resource to cause module to
+		// exit with error. Assert that we do not restart the module if context is cancelled.
+		_, err = h.DoCommand(ctx, map[string]interface{}{"command": "kill_module"})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "rpc error")
+
+		testutils.WaitForAssertion(t, func(tb testing.TB) {
+			tb.Helper()
+			test.That(tb, logs.FilterMessageSnippet("Will not attempt to restart crashed module").Len(),
+				test.ShouldEqual, 1)
+		})
+
+		ok = mgr.IsModularResource(rNameMyHelper)
+		test.That(t, ok, test.ShouldBeFalse)
+		_, err = h.DoCommand(ctx, map[string]interface{}{"command": "echo"})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "not connected")
+
+		err = mgr.Close(ctx)
+		test.That(t, err, test.ShouldBeNil)
+
+		// Assert that logs reflect that test-module crashed and was not
+		// successfully restarted.
+		test.That(t, logs.FilterMessageSnippet("Module has unexpectedly exited").Len(),
+			test.ShouldEqual, 1)
+		test.That(t, logs.FilterMessageSnippet("Module successfully restarted").Len(),
+			test.ShouldEqual, 0)
+
+		// Assert that RemoveOrphanedResources was called once.
+		test.That(t, dummyRemoveOrphanedResourcesCallCount.Load(), test.ShouldEqual, 1)
+	})
 	t.Run("timed out module process is stopped", func(t *testing.T) {
 		logger, logs := logging.NewObservedTestLogger(t)
 


### PR DESCRIPTION
the current behavior will restart modules if it crashes (like if a sigterm gets sent to it) even if server is in shutdown - this prevents process from restarting and also does not log that RDK will attempt to restart it

logs after changes (if in shutdown):
```
2024-03-25T21:20:34.386Z        ERROR   robot_server    modmanager/manager.go:841       Module has unexpectedly exited.{"module":"AcmeModule","exit_code":0}
2024-03-25T21:20:34.386Z        INFO    robot_server    modmanager/manager.go:927       Will not attempt to restart crashed module  {"module":"AcmeModule","reason":"context canceled"}
```
if not in shutdown:
```
2024-03-25T21:18:15.111Z        ERROR   robot_server    modmanager/manager.go:841       Module has unexpectedly exited. {"module":"AcmeModule","exit_code":0}
2024-03-25T21:18:15.112Z        INFO    robot_server    modmanager/manager.go:932       Attempting to restart crashed module    {"module":"AcmeModule"}
```
