### PR TITLE
RSDK-7061 - Pull the mapping mode out of Properties

### DIFF
--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "0.23.2",
+  "version": "0.23.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/remote-control",
-      "version": "0.23.2",
+      "version": "0.23.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@improbable-eng/grpc-web": "0.15.0",
@@ -49,6 +49,7 @@
         "three": "0.159.0",
         "three-inspect": "0.3.4",
         "trzy": "0.3.11",
+        "type-fest": "^4.14.0",
         "typescript": "5.2.2",
         "vite": "4.4.9",
         "vite-plugin-css-injected-by-js": "3.3.0",
@@ -3533,6 +3534,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globals/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/globby": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -6670,12 +6683,12 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.14.0.tgz",
+      "integrity": "sha512-on5/Cw89wwqGZQu+yWO0gGMGu8VNxsaW9SB2HE8yJjllEk7IDTwnSN1dUVldYILhYPN5HzD7WAaw2cc/jBfn0Q==",
       "dev": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -83,6 +83,7 @@
     "three": "0.159.0",
     "three-inspect": "0.3.4",
     "trzy": "0.3.11",
+    "type-fest": "^4.14.0",
     "typescript": "5.2.2",
     "vite": "4.4.9",
     "vite-plugin-css-injected-by-js": "3.3.0",

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "0.23.2",
+  "version": "0.23.3",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -69,6 +69,7 @@ let motionPath: Float32Array | undefined;
 let mappingSessionStarted = false;
 let isLocalizingMode: boolean | undefined;
 let lastReconfigured: Timestamp | undefined;
+let mappingMode: string;
 
 $: pointcloudLoaded = Boolean(pointcloud?.length) && pose !== undefined;
 $: moveClicked = Boolean(executionID);
@@ -92,6 +93,38 @@ const startDurationTimer = (start: number) => {
     sessionDuration = Date.now() - start;
   }, 400);
 };
+
+const setMappingMode = async () => {
+  console.log("in setMappingMode, slamModel: ", overrides?.slamModel)
+  console.log("in setMappingMode, overrides.mode: ", overrides?.mappingDetails.mode)
+  console.log("in setMappingMode, mappingMode: ", mappingMode)
+  // modes: 'localize' | 'create' | 'update' | 'undefined'
+  mappingMode = overrides?.mappingDetails.mode || 'undefined';
+  if (overrides?.slamModel !== 'viam:slam:cartographer') {
+    try {
+        const props = await slamClient.getProperties();
+        switch (props.mappingMode) {
+          case slamApi.MappingMode.MAPPING_MODE_CREATE_NEW_MAP:
+            mappingMode = 'create';
+            break;
+          case slamApi.MappingMode.MAPPING_MODE_LOCALIZE_ONLY:
+            mappingMode = 'localize';
+            break;
+          case slamApi.MappingMode.MAPPING_MODE_UPDATE_EXISTING_MAP:
+            mappingMode = 'update';
+            break;
+          case slamApi.MappingMode.MAPPING_MODE_UNSPECIFIED:
+            mappingMode = 'undefined';
+            break;
+          default:
+            mappingMode = 'undefined';
+        }
+    } catch (error) {
+      notify.danger('can not get slam properties', (error as string));
+    }
+  }
+  console.log("in setMappingMode, mappingMode: ", mappingMode)
+}
 
 const refresh2d = async () => {
   refreshPaths();
@@ -429,6 +462,8 @@ const handleDrop = (event: CustomEvent<string>) =>
 
 onMount(async () => {
   if (overrides?.isCloudSlam) {
+    await setMappingMode();
+
     const activeSession = await overrides.getActiveMappingSession();
 
     if (activeSession) {
@@ -475,11 +510,11 @@ useConnect(() => {
       <div class="flex flex-col gap-6 pb-4">
         {#if overrides?.isCloudSlam && overrides.mappingDetails}
           <header class="flex flex-col justify-between gap-3 text-xs">
-            {#if overrides.mappingDetails.mode}
+            {#if mappingMode !== 'undefined'}
               <div class="flex flex-col">
                 <span class="font-bold text-gray-800">Mapping mode</span>
                 <span class="capitalize text-subtle-2"
-                  >{overrides.mappingDetails.mode}</span
+                  >{mappingMode}</span
                 >
               </div>
             {/if}

--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -69,7 +69,7 @@ let motionPath: Float32Array | undefined;
 let mappingSessionStarted = false;
 let isLocalizingMode: boolean | undefined;
 let lastReconfigured: Timestamp | undefined;
-let mappingMode: string;
+let mappingMode = 'undefined';
 
 $: pointcloudLoaded = Boolean(pointcloud?.length) && pose !== undefined;
 $: moveClicked = Boolean(executionID);
@@ -95,36 +95,36 @@ const startDurationTimer = (start: number) => {
 };
 
 const setMappingMode = async () => {
-  console.log("in setMappingMode, slamModel: ", overrides?.slamModel)
-  console.log("in setMappingMode, overrides.mode: ", overrides?.mappingDetails.mode)
-  console.log("in setMappingMode, mappingMode: ", mappingMode)
-  // modes: 'localize' | 'create' | 'update' | 'undefined'
-  mappingMode = overrides?.mappingDetails.mode || 'undefined';
+  mappingMode = overrides?.mappingDetails.mode ?? 'undefined';
   if (overrides?.slamModel !== 'viam:slam:cartographer') {
     try {
-        const props = await slamClient.getProperties();
-        switch (props.mappingMode) {
-          case slamApi.MappingMode.MAPPING_MODE_CREATE_NEW_MAP:
-            mappingMode = 'create';
-            break;
-          case slamApi.MappingMode.MAPPING_MODE_LOCALIZE_ONLY:
-            mappingMode = 'localize';
-            break;
-          case slamApi.MappingMode.MAPPING_MODE_UPDATE_EXISTING_MAP:
-            mappingMode = 'update';
-            break;
-          case slamApi.MappingMode.MAPPING_MODE_UNSPECIFIED:
-            mappingMode = 'undefined';
-            break;
-          default:
-            mappingMode = 'undefined';
+      const props = await slamClient.getProperties();
+      switch (props.mappingMode) {
+        case slamApi.MappingMode.MAPPING_MODE_CREATE_NEW_MAP: {
+          mappingMode = 'create';
+          break;
         }
+        case slamApi.MappingMode.MAPPING_MODE_LOCALIZE_ONLY: {
+          mappingMode = 'localize';
+          break;
+        }
+        case slamApi.MappingMode.MAPPING_MODE_UPDATE_EXISTING_MAP: {
+          mappingMode = 'update';
+          break;
+        }
+        case slamApi.MappingMode.MAPPING_MODE_UNSPECIFIED: {
+          mappingMode = 'undefined';
+          break;
+        }
+        default: {
+          mappingMode = 'undefined';
+        }
+      }
     } catch (error) {
-      notify.danger('can not get slam properties', (error as string));
+      notify.danger('can not get slam properties', error as string);
     }
   }
-  console.log("in setMappingMode, mappingMode: ", mappingMode)
-}
+};
 
 const refresh2d = async () => {
   refreshPaths();
@@ -513,9 +513,7 @@ useConnect(() => {
             {#if mappingMode !== 'undefined'}
               <div class="flex flex-col">
                 <span class="font-bold text-gray-800">Mapping mode</span>
-                <span class="capitalize text-subtle-2"
-                  >{mappingMode}</span
-                >
+                <span class="capitalize text-subtle-2">{mappingMode}</span>
               </div>
             {/if}
             <div class="flex gap-8">

--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -84,6 +84,13 @@ $: slamResourceName = filterSubtype($services, 'slam').find(
 // allowMove is only true if we have a base, there exists a destination and there is no in-flight MoveOnMap req
 $: allowMove = bases.length === 1 && destination && !moveClicked;
 
+const mappingModeToDisplayText = {
+  [slamApi.MappingMode.MAPPING_MODE_CREATE_NEW_MAP]: 'create',
+  [slamApi.MappingMode.MAPPING_MODE_LOCALIZE_ONLY]: 'localize',
+  [slamApi.MappingMode.MAPPING_MODE_UPDATE_EXISTING_MAP]: 'update',
+  [slamApi.MappingMode.MAPPING_MODE_UNSPECIFIED]: 'undefined',
+} as const;
+
 const deleteDestinationMarker = () => {
   destination = undefined;
 };
@@ -96,30 +103,15 @@ const startDurationTimer = (start: number) => {
 
 const setMappingMode = async () => {
   mappingMode = overrides?.mappingDetails.mode ?? 'undefined';
-  if (overrides?.slamModel !== 'viam:slam:cartographer') {
+  console.log('in setMappingMode: slamModel:', overrides?.slamModel);
+  if (
+    overrides?.slamModel !== undefined &&
+    overrides.slamModel !== 'viam:slam:cartographer'
+  ) {
+    console.log('in setMappingMode: entered the if statement');
     try {
       const props = await slamClient.getProperties();
-      switch (props.mappingMode) {
-        case slamApi.MappingMode.MAPPING_MODE_CREATE_NEW_MAP: {
-          mappingMode = 'create';
-          break;
-        }
-        case slamApi.MappingMode.MAPPING_MODE_LOCALIZE_ONLY: {
-          mappingMode = 'localize';
-          break;
-        }
-        case slamApi.MappingMode.MAPPING_MODE_UPDATE_EXISTING_MAP: {
-          mappingMode = 'update';
-          break;
-        }
-        case slamApi.MappingMode.MAPPING_MODE_UNSPECIFIED: {
-          mappingMode = 'undefined';
-          break;
-        }
-        default: {
-          mappingMode = 'undefined';
-        }
-      }
+      mappingMode = mappingModeToDisplayText[props.mappingMode];
     } catch (error) {
       notify.danger('can not get slam properties', error as string);
     }

--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -103,12 +103,10 @@ const startDurationTimer = (start: number) => {
 
 const setMappingMode = async () => {
   mappingMode = overrides?.mappingDetails.mode ?? 'undefined';
-  console.log('in setMappingMode: slamModel:', overrides?.slamModel);
   if (
     overrides?.slamModel !== undefined &&
     overrides.slamModel !== 'viam:slam:cartographer'
   ) {
-    console.log('in setMappingMode: entered the if statement');
     try {
       const props = await slamClient.getProperties();
       mappingMode = mappingModeToDisplayText[props.mappingMode];

--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -104,13 +104,11 @@ const startDurationTimer = (start: number) => {
 };
 
 const setMappingMode = async () => {
-  mappingMode =
-    overrides?.mappingDetails.mode ??
-    slamApi.MappingMode.MAPPING_MODE_UNSPECIFIED;
   try {
     const props = await slamClient.getProperties();
     mappingMode = props.mappingMode;
   } catch (error) {
+    mappingMode = slamApi.MappingMode.MAPPING_MODE_UNSPECIFIED;
     notify.danger('can not get slam properties', error as string);
   }
 };

--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -104,7 +104,8 @@ const startDurationTimer = (start: number) => {
 const setMappingMode = async () => {
   mappingMode = overrides?.mappingDetails.mode ?? 'undefined';
   if (
-    overrides?.slamModel !== '' &&
+    overrides !== undefined &&
+    overrides.slamModel !== '' &&
     overrides.slamModel !== 'viam:slam:cartographer'
   ) {
     try {

--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -28,7 +28,7 @@ import { grpc } from '@improbable-eng/grpc-web';
 import type { Timestamp } from 'google-protobuf/google/protobuf/timestamp_pb';
 import type { ValueOf } from 'type-fest';
 type ResourceName = commonApi.ResourceName.AsObject;
-type MappingMode = ValueOf<typeof slamApi.MappingMode>
+type MappingMode = ValueOf<typeof slamApi.MappingMode>;
 
 export let name: string;
 export let motionResourceNames: ResourceName[];
@@ -71,7 +71,7 @@ let motionPath: Float32Array | undefined;
 let mappingSessionStarted = false;
 let isLocalizingMode: boolean | undefined;
 let lastReconfigured: Timestamp | undefined;
-let mappingMode: MappingMode = slamApi.MappingMode.MAPPING_MODE_UNSPECIFIED
+let mappingMode: MappingMode = slamApi.MappingMode.MAPPING_MODE_UNSPECIFIED;
 
 $: pointcloudLoaded = Boolean(pointcloud?.length) && pose !== undefined;
 $: moveClicked = Boolean(executionID);
@@ -104,7 +104,9 @@ const startDurationTimer = (start: number) => {
 };
 
 const setMappingMode = async () => {
-  mappingMode = overrides?.mappingDetails.mode ?? slamApi.MappingMode.MAPPING_MODE_UNSPECIFIED;
+  mappingMode =
+    overrides?.mappingDetails.mode ??
+    slamApi.MappingMode.MAPPING_MODE_UNSPECIFIED;
   try {
     const props = await slamClient.getProperties();
     mappingMode = props.mappingMode;
@@ -500,7 +502,9 @@ useConnect(() => {
             {#if mappingMode !== slamApi.MappingMode.MAPPING_MODE_UNSPECIFIED}
               <div class="flex flex-col">
                 <span class="font-bold text-gray-800">Mapping mode</span>
-                <span class="capitalize text-subtle-2">{mappingModeToDisplayText[mappingMode]}</span>
+                <span class="capitalize text-subtle-2"
+                  >{mappingModeToDisplayText[mappingMode]}</span
+                >
               </div>
             {/if}
             <div class="flex gap-8">

--- a/web/frontend/src/components/slam/index.svelte
+++ b/web/frontend/src/components/slam/index.svelte
@@ -104,7 +104,7 @@ const startDurationTimer = (start: number) => {
 const setMappingMode = async () => {
   mappingMode = overrides?.mappingDetails.mode ?? 'undefined';
   if (
-    overrides?.slamModel !== undefined &&
+    overrides?.slamModel !== '' &&
     overrides.slamModel !== 'viam:slam:cartographer'
   ) {
     try {

--- a/web/frontend/src/types/overrides.ts
+++ b/web/frontend/src/types/overrides.ts
@@ -19,7 +19,7 @@ export interface MappingMetadata {
 }
 
 interface MappingDetails {
-  mode?: 'localize' | 'create' | 'update';
+  mode: string;
   name?: string;
   version?: string;
 }
@@ -49,6 +49,7 @@ export interface SLAMOverrides {
   viewMap: (sessionId: string) => void;
   validateMapName: (mapName: string) => string;
   mappingDetails: MappingDetails;
+  slamModel: string;
   isCloudSlam: boolean;
 }
 export interface RCOverrides {

--- a/web/frontend/src/types/overrides.ts
+++ b/web/frontend/src/types/overrides.ts
@@ -1,7 +1,5 @@
 import type { Pose } from '@viamrobotics/sdk';
 import type { Timestamp } from 'google-protobuf/google/protobuf/timestamp_pb';
-import type { ValueOf } from 'type-fest';
-import { slamApi } from '@viamrobotics/sdk';
 
 export interface MappingMetadata {
   id: string;
@@ -21,7 +19,6 @@ export interface MappingMetadata {
 }
 
 interface MappingDetails {
-  mode: ValueOf<typeof slamApi.MappingMode>;
   name?: string;
   version?: string;
 }

--- a/web/frontend/src/types/overrides.ts
+++ b/web/frontend/src/types/overrides.ts
@@ -1,5 +1,7 @@
 import type { Pose } from '@viamrobotics/sdk';
 import type { Timestamp } from 'google-protobuf/google/protobuf/timestamp_pb';
+import type { ValueOf } from 'type-fest';
+import { slamApi } from '@viamrobotics/sdk';
 
 export interface MappingMetadata {
   id: string;
@@ -19,7 +21,7 @@ export interface MappingMetadata {
 }
 
 interface MappingDetails {
-  mode: 'localize' | 'create' | 'update' | 'undefined';
+  mode:  ValueOf<typeof slamApi.MappingMode>;
   name?: string;
   version?: string;
 }
@@ -49,7 +51,6 @@ export interface SLAMOverrides {
   viewMap: (sessionId: string) => void;
   validateMapName: (mapName: string) => string;
   mappingDetails: MappingDetails;
-  slamModel: string;
   isCloudSlam: boolean;
 }
 export interface RCOverrides {

--- a/web/frontend/src/types/overrides.ts
+++ b/web/frontend/src/types/overrides.ts
@@ -21,7 +21,7 @@ export interface MappingMetadata {
 }
 
 interface MappingDetails {
-  mode:  ValueOf<typeof slamApi.MappingMode>;
+  mode: ValueOf<typeof slamApi.MappingMode>;
   name?: string;
   version?: string;
 }

--- a/web/frontend/src/types/overrides.ts
+++ b/web/frontend/src/types/overrides.ts
@@ -19,7 +19,7 @@ export interface MappingMetadata {
 }
 
 interface MappingDetails {
-  mode: string;
+  mode: 'localize' | 'create' | 'update' | 'undefined';
   name?: string;
   version?: string;
 }


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-7061

Done:
* Set the `mappingMode` based on the mapping mode returned from `slamClient.getProperties()`

Tested:
* With latest App + cartographer & fake slam
* With this PR: https://github.com/viamrobotics/app/pull/4112
* With modules as they're going to be implemented by the end of this project

Related PR:
* https://github.com/viamrobotics/app/pull/4112
  * Removes `overrides.mappingDetails.mode`; will be merged once RDK is released