### PR TITLE
DATA-2433 - Add HTTP request to download binary

### DIFF
--- a/cli/data.go
+++ b/cli/data.go
@@ -416,7 +416,7 @@ func downloadBinary(ctx context.Context, client datapb.DataServiceClient, dst st
 	var resp *datapb.BinaryDataByIDsResponse
 	var err error
 	largeFile := false
-	// To begin, we assume the file is large and try getting the binary directly
+	// To begin, we assume the file is small and downloadable, so we try getting the binary directly
 	for count := 0; count < maxRetryCount; count++ {
 		resp, err = client.BinaryDataByIDs(ctx, &datapb.BinaryDataByIDsRequest{
 			BinaryIds:     []*datapb.BinaryID{id},

--- a/cli/data.go
+++ b/cli/data.go
@@ -427,10 +427,15 @@ func downloadBinary(ctx context.Context, client datapb.DataServiceClient, dst st
 	// For large files, we get the metadata but not the binary itself
 	if err != nil && status.Code(err) == codes.ResourceExhausted {
 		largeFile = true
-		resp, err = client.BinaryDataByIDs(ctx, &datapb.BinaryDataByIDsRequest{
-			BinaryIds:     []*datapb.BinaryID{id},
-			IncludeBinary: !largeFile,
-		})
+		for count := 0; count < maxRetryCount; count++ {
+			resp, err = client.BinaryDataByIDs(ctx, &datapb.BinaryDataByIDsRequest{
+				BinaryIds:     []*datapb.BinaryID{id},
+				IncludeBinary: !largeFile,
+			})
+			if err == nil {
+				break
+			}
+		}
 	}
 	if err != nil {
 		return errors.Wrapf(err, serverErrorMessage)

--- a/cli/data.go
+++ b/cli/data.go
@@ -416,7 +416,7 @@ func downloadBinary(ctx context.Context, client datapb.DataServiceClient, dst st
 	var resp *datapb.BinaryDataByIDsResponse
 	var err error
 	largeFile := false
-	// To begin, we assume the file is large and try downloading getting the binary directly
+	// To begin, we assume the file is large and try getting the binary directly
 	for count := 0; count < maxRetryCount; count++ {
 		resp, err = client.BinaryDataByIDs(ctx, &datapb.BinaryDataByIDsRequest{
 			BinaryIds:     []*datapb.BinaryID{id},

--- a/cli/data.go
+++ b/cli/data.go
@@ -416,6 +416,7 @@ func downloadBinary(ctx context.Context, client datapb.DataServiceClient, dst st
 	var resp *datapb.BinaryDataByIDsResponse
 	var err error
 	largeFile := false
+	// To begin, we assume the file is large and try downloading getting the binary directly
 	for count := 0; count < maxRetryCount; count++ {
 		resp, err = client.BinaryDataByIDs(ctx, &datapb.BinaryDataByIDsRequest{
 			BinaryIds:     []*datapb.BinaryID{id},


### PR DESCRIPTION
Previously it was impossible to export large files. Now, we use the URI from the metadata to download if we received an error that it was too large. 

Can try the following command in `Data/ML Dev` in staging

`viam data export --org-ids=f87b919c-63b2-4d32-b676-0b55393938d7 --data-type=binary --mime-types=application/octet-stream --destination=large_file_export` which should result in an error

`go run cli/viam/main.go data export --org-ids=f87b919c-63b2-4d32-b676-0b55393938d7 --data-type=binary --mime-types=application/octet-stream --destination=large_file_export` off of this branch, which should successfully download everything
