### PR TITLE
RSDK-7022 Add count option to CLI log commands

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -988,8 +988,8 @@ var app = &cli.App{
 						},
 						&cli.IntFlag{
 							Name:        logsFlagCount,
-							Usage:       "number of logs to fetch (max 10000)",
-							DefaultText: "100",
+							Usage:       fmt.Sprintf("number of logs to fetch (max %v)", maxNumLogs),
+							DefaultText: fmt.Sprintf("%v", defaultNumLogs),
 						},
 					},
 					Action: RobotsLogsAction,

--- a/cli/app.go
+++ b/cli/app.go
@@ -24,6 +24,7 @@ const (
 
 	logsFlagErrors = "errors"
 	logsFlagTail   = "tail"
+	logsFlagCount  = "count"
 
 	runFlagData   = "data"
 	runFlagStream = "stream"
@@ -985,6 +986,11 @@ var app = &cli.App{
 							Name:  logsFlagErrors,
 							Usage: "show only errors",
 						},
+						&cli.IntFlag{
+							Name:        logsFlagCount,
+							Usage:       "number of logs to fetch (max 10000)",
+							DefaultText: "100",
+						},
 					},
 					Action: RobotsLogsAction,
 				},
@@ -1053,6 +1059,11 @@ var app = &cli.App{
 									Name:    logsFlagTail,
 									Aliases: []string{"f"},
 									Usage:   "follow logs",
+								},
+								&cli.IntFlag{
+									Name:        logsFlagCount,
+									Usage:       "number of logs to fetch (max 10000)",
+									DefaultText: "100",
 								},
 							},
 							Action: RobotsPartLogsAction,

--- a/cli/app.go
+++ b/cli/app.go
@@ -1062,8 +1062,8 @@ var app = &cli.App{
 								},
 								&cli.IntFlag{
 									Name:        logsFlagCount,
-									Usage:       "number of logs to fetch (max 10000)",
-									DefaultText: "100",
+									Usage:       fmt.Sprintf("number of logs to fetch (max %v)", maxNumLogs),
+									DefaultText: fmt.Sprintf("%v", defaultNumLogs),
 								},
 							},
 							Action: RobotsPartLogsAction,

--- a/cli/auth_test.go
+++ b/cli/auth_test.go
@@ -76,7 +76,7 @@ func TestRobotAPIKeyCreateAction(t *testing.T) {
 		CreateKeyFunc: createKeyFunc,
 	}
 
-	flags := make(map[string]string)
+	flags := make(map[string]any)
 	flags[generalFlagOrgID] = fakeOrgID
 	flags[generalFlagMachineID] = fakeRobotID
 	flags[apiKeyCreateFlagName] = "my-name"
@@ -131,7 +131,7 @@ func TestRobotAPIKeyCreateAction(t *testing.T) {
 		CreateKeyFunc: createKeyFunc,
 	}
 
-	flags = make(map[string]string)
+	flags = make(map[string]any)
 	flags[generalFlagMachineID] = fakeRobotID
 	flags[generalFlagOrgID] = ""
 	flags[apiKeyCreateFlagName] = "test-me"
@@ -157,7 +157,7 @@ func TestLocationAPIKeyCreateAction(t *testing.T) {
 		CreateKeyFunc: createKeyFunc,
 	}
 
-	flags := make(map[string]string)
+	flags := make(map[string]any)
 	flags[generalFlagLocationID] = ""
 	flags[generalFlagOrgID] = ""
 	flags[apiKeyCreateFlagName] = "" // testing no locationID
@@ -198,7 +198,7 @@ func TestLocationAPIKeyCreateAction(t *testing.T) {
 		CreateKeyFunc: createKeyFunc,
 	}
 
-	flags = make(map[string]string)
+	flags = make(map[string]any)
 	flags[generalFlagLocationID] = fakeLocID
 	flags[generalFlagOrgID] = ""
 	flags[apiKeyCreateFlagName] = "test-name"

--- a/cli/client.go
+++ b/cli/client.go
@@ -950,7 +950,7 @@ func (c *viamClient) robotPartLogs(orgStr, locStr, robotStr, partStr string, err
 
 		pageToken = resp.NextPageToken
 		if remainder := numLogs - i; remainder < 100 {
-			resp.Logs = resp.Logs[remainder:]
+			resp.Logs = resp.Logs[:remainder]
 		}
 		logs = append(logs, resp.Logs...)
 	}

--- a/cli/client.go
+++ b/cli/client.go
@@ -936,7 +936,7 @@ func (c *viamClient) robotPartLogs(orgStr, locStr, robotStr, partStr string, err
 
 	// Use page tokens to get batches of 100 up to numLogs and throw away any
 	// extra logs in last batch.
-	var logs []*commonpb.LogEntry
+	logs := make([]*commonpb.LogEntry, 0, numLogs)
 	var pageToken string
 	for i := 0; i < numLogs; i += 100 {
 		resp, err := c.client.GetRobotPartLogs(c.c.Context, &apppb.GetRobotPartLogsRequest{

--- a/cli/client.go
+++ b/cli/client.go
@@ -45,9 +45,13 @@ import (
 )
 
 const (
-	rdkReleaseURL  = "https://api.github.com/repos/viamrobotics/rdk/releases/latest"
+	rdkReleaseURL = "https://api.github.com/repos/viamrobotics/rdk/releases/latest"
+	// defaultNumLogs is the same as the number of logs currently returned by app
+	// in a single GetRobotPartLogsResponse.
 	defaultNumLogs = 100
-	maxNumLogs     = 10000
+	// maxNumLogs is an arbitrary limit used to stop CLI users from overwhelming
+	// our logs DB with heavy reads.
+	maxNumLogs = 10000
 )
 
 // viamClient wraps a cli.Context and provides all the CLI command functionality

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -279,9 +279,8 @@ func TestGetRobotPartLogs(t *testing.T) {
 	getRobotPartLogsFunc := func(ctx context.Context, in *apppb.GetRobotPartLogsRequest,
 		opts ...grpc.CallOption,
 	) (*apppb.GetRobotPartLogsResponse, error) {
-		// Accept fake page tokens of "2"-"100" and release logs in batches of 100
-		// in oldest->newest order to mimic app's behavior. The first page token
-		// will be "", which should be interpreted as "1".
+		// Accept fake page tokens of "2"-"100" and release logs in batches of 100.
+		// The first page token will be "", which should be interpreted as "1".
 		pt := 1
 		if receivedPt := in.PageToken; receivedPt != nil && *receivedPt != "" {
 			var err error
@@ -289,7 +288,7 @@ func TestGetRobotPartLogs(t *testing.T) {
 			test.That(t, err, test.ShouldBeNil)
 		}
 		resp := &apppb.GetRobotPartLogsResponse{
-			Logs:          logs[len(logs)-pt*100 : len(logs)-(pt-1)*100],
+			Logs:          logs[(pt-1)*100 : pt*100],
 			NextPageToken: fmt.Sprintf("%d", pt+1),
 		}
 		return resp, nil
@@ -342,12 +341,9 @@ func TestGetRobotPartLogs(t *testing.T) {
 		// followed by maxNumLogs messages.
 		test.That(t, len(out.messages), test.ShouldEqual, defaultNumLogs+1)
 		test.That(t, out.messages[0], test.ShouldEqual, "jedi -> naboo -> r2d2\n")
-		// Logs should be printed in order newest->oldest (9999->9000).
-		expectedLogNumber := maxNumLogs - 1
+		// Logs should be printed in order newest->oldest ("0"->"99").
 		for i := 1; i <= defaultNumLogs; i++ {
-			test.That(t, out.messages[i], test.ShouldContainSubstring,
-				fmt.Sprintf("%d", expectedLogNumber))
-			expectedLogNumber--
+			test.That(t, out.messages[i], test.ShouldContainSubstring, fmt.Sprintf("%d", i-1))
 		}
 	})
 	t.Run("178 count", func(t *testing.T) {
@@ -363,12 +359,9 @@ func TestGetRobotPartLogs(t *testing.T) {
 		// followed by 178 messages.
 		test.That(t, len(out.messages), test.ShouldEqual, 179)
 		test.That(t, out.messages[0], test.ShouldEqual, "jedi -> naboo -> r2d2\n")
-		// Logs should be printed in order newest->oldest (9999->9822).
-		expectedLogNumber := maxNumLogs - 1
+		// Logs should be printed in order newest->oldest ("0"->"177").
 		for i := 1; i <= 178; i++ {
-			test.That(t, out.messages[i], test.ShouldContainSubstring,
-				fmt.Sprintf("%d", expectedLogNumber))
-			expectedLogNumber--
+			test.That(t, out.messages[i], test.ShouldContainSubstring, fmt.Sprintf("%d", i-1))
 		}
 	})
 	t.Run("max count", func(t *testing.T) {
@@ -385,12 +378,9 @@ func TestGetRobotPartLogs(t *testing.T) {
 		test.That(t, len(out.messages), test.ShouldEqual, maxNumLogs+1)
 		test.That(t, out.messages[0], test.ShouldEqual, "jedi -> naboo -> r2d2\n")
 
-		// Logs should be printed in order newest->oldest (9999->0).
-		expectedLogNumber := maxNumLogs - 1
+		// Logs should be printed in order newest->oldest ("0"->"9999").
 		for i := 1; i <= maxNumLogs; i++ {
-			test.That(t, out.messages[i], test.ShouldContainSubstring,
-				fmt.Sprintf("%d", expectedLogNumber))
-			expectedLogNumber--
+			test.That(t, out.messages[i], test.ShouldContainSubstring, fmt.Sprintf("%d", i-1))
 		}
 	})
 	t.Run("negative count", func(t *testing.T) {
@@ -408,12 +398,9 @@ func TestGetRobotPartLogs(t *testing.T) {
 		// followed by maxNumLogs messages.
 		test.That(t, len(out.messages), test.ShouldEqual, defaultNumLogs+1)
 		test.That(t, out.messages[0], test.ShouldEqual, "jedi -> naboo -> r2d2\n")
-		// Logs should be printed in order newest->oldest (99->0).
-		expectedLogNumber := maxNumLogs - 1
+		// Logs should be printed in order newest->oldest ("0"->"99").
 		for i := 1; i <= defaultNumLogs; i++ {
-			test.That(t, out.messages[i], test.ShouldContainSubstring,
-				fmt.Sprintf("%d", expectedLogNumber))
-			expectedLogNumber--
+			test.That(t, out.messages[i], test.ShouldContainSubstring, fmt.Sprintf("%d", i-1))
 		}
 	})
 	t.Run("count too high", func(t *testing.T) {

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -341,9 +341,12 @@ func TestGetRobotPartLogs(t *testing.T) {
 		// followed by maxNumLogs messages.
 		test.That(t, len(out.messages), test.ShouldEqual, defaultNumLogs+1)
 		test.That(t, out.messages[0], test.ShouldEqual, "jedi -> naboo -> r2d2\n")
-		// Logs should be printed in order newest->oldest ("0"->"99").
+		// Logs should be printed in order oldest->newest ("99"->"0").
+		expectedLogNum := defaultNumLogs - 1
 		for i := 1; i <= defaultNumLogs; i++ {
-			test.That(t, out.messages[i], test.ShouldContainSubstring, fmt.Sprintf("%d", i-1))
+			test.That(t, out.messages[i], test.ShouldContainSubstring,
+				fmt.Sprintf("%d", expectedLogNum))
+			expectedLogNum--
 		}
 	})
 	t.Run("178 count", func(t *testing.T) {
@@ -359,9 +362,12 @@ func TestGetRobotPartLogs(t *testing.T) {
 		// followed by 178 messages.
 		test.That(t, len(out.messages), test.ShouldEqual, 179)
 		test.That(t, out.messages[0], test.ShouldEqual, "jedi -> naboo -> r2d2\n")
-		// Logs should be printed in order newest->oldest ("0"->"177").
+		// Logs should be printed in order oldest->newest ("177"->"0").
+		expectedLogNum := 177
 		for i := 1; i <= 178; i++ {
-			test.That(t, out.messages[i], test.ShouldContainSubstring, fmt.Sprintf("%d", i-1))
+			test.That(t, out.messages[i], test.ShouldContainSubstring,
+				fmt.Sprintf("%d", expectedLogNum))
+			expectedLogNum--
 		}
 	})
 	t.Run("max count", func(t *testing.T) {
@@ -378,9 +384,12 @@ func TestGetRobotPartLogs(t *testing.T) {
 		test.That(t, len(out.messages), test.ShouldEqual, maxNumLogs+1)
 		test.That(t, out.messages[0], test.ShouldEqual, "jedi -> naboo -> r2d2\n")
 
-		// Logs should be printed in order newest->oldest ("0"->"9999").
+		// Logs should be printed in order oldest->newest ("9999"->"0").
+		expectedLogNum := maxNumLogs - 1
 		for i := 1; i <= maxNumLogs; i++ {
-			test.That(t, out.messages[i], test.ShouldContainSubstring, fmt.Sprintf("%d", i-1))
+			test.That(t, out.messages[i], test.ShouldContainSubstring,
+				fmt.Sprintf("%d", expectedLogNum))
+			expectedLogNum--
 		}
 	})
 	t.Run("negative count", func(t *testing.T) {
@@ -398,9 +407,12 @@ func TestGetRobotPartLogs(t *testing.T) {
 		// followed by maxNumLogs messages.
 		test.That(t, len(out.messages), test.ShouldEqual, defaultNumLogs+1)
 		test.That(t, out.messages[0], test.ShouldEqual, "jedi -> naboo -> r2d2\n")
-		// Logs should be printed in order newest->oldest ("0"->"99").
+		// Logs should be printed in order oldest->oldest ("99"->"0").
+		expectedLogNum := defaultNumLogs - 1
 		for i := 1; i <= defaultNumLogs; i++ {
-			test.That(t, out.messages[i], test.ShouldContainSubstring, fmt.Sprintf("%d", i-1))
+			test.That(t, out.messages[i], test.ShouldContainSubstring,
+				fmt.Sprintf("%d", expectedLogNum))
+			expectedLogNum--
 		}
 	})
 	t.Run("count too high", func(t *testing.T) {

--- a/cli/module_build_test.go
+++ b/cli/module_build_test.go
@@ -52,7 +52,7 @@ func TestStartBuild(t *testing.T) {
 		StartBuildFunc: func(ctx context.Context, in *v1.StartBuildRequest, opts ...grpc.CallOption) (*v1.StartBuildResponse, error) {
 			return &v1.StartBuildResponse{BuildId: "xyz123"}, nil
 		},
-	}, &map[string]string{moduleBuildFlagPath: manifest, moduleBuildFlagVersion: "1.2.3"}, "token")
+	}, &map[string]any{moduleBuildFlagPath: manifest, moduleBuildFlagVersion: "1.2.3"}, "token")
 	err := ac.moduleBuildStartAction(cCtx)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, out.messages, test.ShouldHaveLength, 1)
@@ -75,7 +75,7 @@ func TestListBuild(t *testing.T) {
 				},
 			}}, nil
 		},
-	}, &map[string]string{moduleBuildFlagPath: manifest}, "token")
+	}, &map[string]any{moduleBuildFlagPath: manifest}, "token")
 	err := ac.moduleBuildListAction(cCtx)
 	test.That(t, err, test.ShouldBeNil)
 	joinedOutput := strings.Join(out.messages, "")
@@ -117,7 +117,7 @@ func TestModuleBuildWait(t *testing.T) {
 				},
 			}}, nil
 		},
-	}, &map[string]string{}, "token")
+	}, &map[string]any{}, "token")
 	startWaitTime := time.Now()
 	statuses, err := ac.waitForBuildToFinish("xyz123", "")
 	test.That(t, err, test.ShouldBeNil)
@@ -150,7 +150,7 @@ func TestModuleGetPlatformsForModule(t *testing.T) {
 				},
 			}}, nil
 		},
-	}, &map[string]string{}, "token")
+	}, &map[string]any{}, "token")
 	platforms, err := ac.getPlatformsForModuleBuild("xyz123")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, platforms, test.ShouldResemble, []string{"linux/amd64", "linux/arm64"})
@@ -183,7 +183,7 @@ func TestLocalBuild(t *testing.T) {
 
 	// run the build local action
 	cCtx, ac, out, errOut := setup(&inject.AppServiceClient{}, nil, &inject.BuildServiceClient{},
-		&map[string]string{moduleBuildFlagPath: manifest, moduleBuildFlagVersion: "1.2.3"}, "token")
+		&map[string]any{moduleBuildFlagPath: manifest, moduleBuildFlagVersion: "1.2.3"}, "token")
 
 	err = ac.moduleBuildLocalAction(cCtx)
 	test.That(t, err, test.ShouldBeNil)

--- a/testutils/inject/app_service_client.go
+++ b/testutils/inject/app_service_client.go
@@ -12,8 +12,16 @@ type AppServiceClient struct {
 	apppb.AppServiceClient
 	ListOrganizationsFunc func(ctx context.Context, in *apppb.ListOrganizationsRequest,
 		opts ...grpc.CallOption) (*apppb.ListOrganizationsResponse, error)
+	ListLocationsFunc func(ctx context.Context, in *apppb.ListLocationsRequest,
+		opts ...grpc.CallOption) (*apppb.ListLocationsResponse, error)
+	ListRobotsFunc func(ctx context.Context, in *apppb.ListRobotsRequest,
+		opts ...grpc.CallOption) (*apppb.ListRobotsResponse, error)
 	CreateKeyFunc func(ctx context.Context, in *apppb.CreateKeyRequest,
 		opts ...grpc.CallOption) (*apppb.CreateKeyResponse, error)
+	GetRobotPartsFunc func(ctx context.Context, in *apppb.GetRobotPartsRequest,
+		opts ...grpc.CallOption) (*apppb.GetRobotPartsResponse, error)
+	GetRobotPartLogsFunc func(ctx context.Context, in *apppb.GetRobotPartLogsRequest,
+		opts ...grpc.CallOption) (*apppb.GetRobotPartLogsResponse, error)
 }
 
 // ListOrganizations calls the injected ListOrganizationsFunc or the real version.
@@ -26,6 +34,26 @@ func (asc *AppServiceClient) ListOrganizations(ctx context.Context, in *apppb.Li
 	return asc.ListOrganizationsFunc(ctx, in, opts...)
 }
 
+// ListLocations calls the injected ListLocationsFunc or the real version.
+func (asc *AppServiceClient) ListLocations(ctx context.Context, in *apppb.ListLocationsRequest,
+	opts ...grpc.CallOption,
+) (*apppb.ListLocationsResponse, error) {
+	if asc.ListLocationsFunc == nil {
+		return asc.AppServiceClient.ListLocations(ctx, in, opts...)
+	}
+	return asc.ListLocationsFunc(ctx, in, opts...)
+}
+
+// ListRobots calls the injected ListRobotsFunc or the real version.
+func (asc *AppServiceClient) ListRobots(ctx context.Context, in *apppb.ListRobotsRequest,
+	opts ...grpc.CallOption,
+) (*apppb.ListRobotsResponse, error) {
+	if asc.ListRobotsFunc == nil {
+		return asc.AppServiceClient.ListRobots(ctx, in, opts...)
+	}
+	return asc.ListRobotsFunc(ctx, in, opts...)
+}
+
 // CreateKey calls the injected CreateKeyFunc or the real version.
 func (asc *AppServiceClient) CreateKey(ctx context.Context, in *apppb.CreateKeyRequest,
 	opts ...grpc.CallOption,
@@ -34,4 +62,24 @@ func (asc *AppServiceClient) CreateKey(ctx context.Context, in *apppb.CreateKeyR
 		return asc.AppServiceClient.CreateKey(ctx, in, opts...)
 	}
 	return asc.CreateKeyFunc(ctx, in, opts...)
+}
+
+// GetRobotParts calls the injected GetRobotPartsFunc or the real version.
+func (asc *AppServiceClient) GetRobotParts(ctx context.Context, in *apppb.GetRobotPartsRequest,
+	opts ...grpc.CallOption,
+) (*apppb.GetRobotPartsResponse, error) {
+	if asc.GetRobotPartsFunc == nil {
+		return asc.AppServiceClient.GetRobotParts(ctx, in, opts...)
+	}
+	return asc.GetRobotPartsFunc(ctx, in, opts...)
+}
+
+// GetRobotPartLogs calls the injected GetRobotPartLogsFunc or the real version.
+func (asc *AppServiceClient) GetRobotPartLogs(ctx context.Context, in *apppb.GetRobotPartLogsRequest,
+	opts ...grpc.CallOption,
+) (*apppb.GetRobotPartLogsResponse, error) {
+	if asc.GetRobotPartLogsFunc == nil {
+		return asc.AppServiceClient.GetRobotPartLogs(ctx, in, opts...)
+	}
+	return asc.GetRobotPartLogsFunc(ctx, in, opts...)
 }


### PR DESCRIPTION
RSDK-7022

Adds `--count` flag to `viam machine logs` and `viam machine part logs` to fetch more than 100 logs (defaults to 100, maxes out at 10000). Adds tests for `--count`.