### PR TITLE
[DOCS-2044] Add code example to robot.TransformPose

### DIFF
--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -806,6 +806,14 @@ func (rc *RobotClient) FrameSystemConfig(ctx context.Context) (*framesystem.Conf
 }
 
 // TransformPose will transform the pose of the requested poseInFrame to the desired frame in the robot's frame system.
+//
+//	  import (
+//		  "go.viam.com/rdk/referenceframe"
+//		  "go.viam.com/rdk/spatialmath"
+//	  )
+//
+//	  baseOrigin := referenceframe.NewPoseInFrame("test-base", spatialmath.NewZeroPose())
+//	  movementSensorToBase, err := robot.TransformPose(ctx, baseOrigin, "my-movement-sensor", nil)
 func (rc *RobotClient) TransformPose(
 	ctx context.Context,
 	query *referenceframe.PoseInFrame,


### PR DESCRIPTION
[DOCS-2044](https://viam.atlassian.net/browse/DOCS-2044
)

The docs team will use this PR as an example on how to move the existing Go code examples in docs.viam to the SDK. The goal is that the repo would be the source of truth for SDK API documentation.  

[DOCS-2044]: https://viam.atlassian.net/browse/DOCS-2044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ