### PR TITLE
RSDK-7041: encoded motor with controls moves in the wrong direction before correcting

### DIFF
--- a/components/motor/gpio/loop.go
+++ b/components/motor/gpio/loop.go
@@ -8,6 +8,9 @@ import (
 
 // SetState sets the state of the motor for the built-in control loop.
 func (m *EncodedMotor) SetState(ctx context.Context, state []*control.Signal) error {
+	if !m.loop.GetStatus() {
+		return nil
+	}
 	power := state[0].GetSignalValueAt(0)
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -286,6 +286,7 @@ func (m *EncodedMotor) directionMovingInLock() float64 {
 // SetPower sets the percentage of power the motor should employ between -1 and 1.
 // Negative power implies a backward directional rotational.
 func (m *EncodedMotor) SetPower(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
+	m.opMgr.CancelRunning(ctx)
 	if m.rpmMonitorDone != nil {
 		m.rpmMonitorDone()
 	}
@@ -400,6 +401,7 @@ func (m *EncodedMotor) goForInternal(ctx context.Context, rpm, goalPos, directio
 		}
 	}
 
+	m.ResumeLoop()
 	// set control loop values
 	velVal := math.Abs(rpm * m.ticksPerRotation / 60)
 	// when rev = 0, only velocity is controlled
@@ -488,13 +490,20 @@ func (m *EncodedMotor) IsMoving(ctx context.Context) (bool, error) {
 	return m.real.IsMoving(ctx)
 }
 
+func (m *EncodedMotor) PauseLoop() {
+	m.loop.SetStatus(false)
+}
+
+func (m *EncodedMotor) ResumeLoop() {
+	m.loop.SetStatus(true)
+}
+
 // Stop stops rpmMonitor and stops the real motor.
 func (m *EncodedMotor) Stop(ctx context.Context, extra map[string]interface{}) error {
 	// after the motor is created, Stop is called, but if the PID controller
 	// is auto-tuning, the loop needs to keep running
 	if m.loop != nil && !m.loop.GetTuning(ctx) {
-		m.loop.Stop()
-		m.loop = nil
+		m.PauseLoop()
 	}
 	if m.rpmMonitorDone != nil {
 		m.rpmMonitorDone()
@@ -506,6 +515,10 @@ func (m *EncodedMotor) Stop(ctx context.Context, extra map[string]interface{}) e
 func (m *EncodedMotor) Close(ctx context.Context) error {
 	if err := m.Stop(ctx, nil); err != nil {
 		return err
+	}
+	if m.loop != nil {
+		m.loop.Stop()
+		m.loop = nil
 	}
 	m.cancel()
 	m.activeBackgroundWorkers.Wait()

--- a/control/control_loop.go
+++ b/control/control_loop.go
@@ -289,14 +289,20 @@ func (l *Loop) startBenchmark(loops int) error {
 
 // Stop stops then loop.
 func (l *Loop) Stop() {
-	if l.running {
-		l.running = false
-		l.logger.Debug("closing loop")
-		l.ct.ticker.Stop()
-		close(l.ct.stop)
-		l.cancel()
-		l.activeBackgroundWorkers.Wait()
-	}
+	l.running = false
+	l.logger.Debug("closing loop")
+	l.ct.ticker.Stop()
+	close(l.ct.stop)
+	l.cancel()
+	l.activeBackgroundWorkers.Wait()
+}
+
+func (l *Loop) SetStatus(on bool) {
+	l.running = on
+}
+
+func (l *Loop) GetStatus() bool {
+	return l.running
 }
 
 // GetConfig return the control loop config.

--- a/control/sum.go
+++ b/control/sum.go
@@ -41,7 +41,7 @@ func (b *sum) Next(ctx context.Context, x []*Signal, dt time.Duration) ([]*Signa
 	y := make([]float64, len(x)/2)
 	half := len(x) / 2
 
-	// loop through the first set of inputs and add or subract from the corresponding output
+	// loop through the first set of inputs and add or subtract from the corresponding output
 	for i := 0; i < half; i++ {
 		op, ok := b.operation[x[i].name]
 		if !ok {


### PR DESCRIPTION
I think the issue comes from the derivative block. When a new loop is started and the endpoint position is not 0, it results in a large negative error, which causes the motor to move backwards before correcting and moving forward. It wasn't clear to me how to fix this, maybe someone with more controls knowledge has an idea.

I found that if the loop was not brand new, the motor starts off in the right direction, so I added a way to pause and resume the loop rather than stopping it and restarting it each time. Even if there is a better derivative problem I am in favor of keeping this so that there's less stopping/starting of loops, but maybe it's bad to have the loop constantly running in the background? 