### PR TITLE
APP-4406 add fsync in unpackFile

### DIFF
--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -591,6 +591,9 @@ func unpackFile(ctx context.Context, fromFile, toDir string) error {
 			if _, err := io.CopyN(outFile, tarReader, maxPackageSize); err != nil && !errors.Is(err, io.EOF) {
 				return errors.Wrapf(err, "failed to copy file %s", path)
 			}
+			if err := outFile.Sync(); err != nil {
+				return errors.Wrapf(err, "failed to sync %s", path)
+			}
 			utils.UncheckedError(outFile.Close())
 		case tar.TypeLink:
 			name := header.Linkname


### PR DESCRIPTION
## What changed
- fsync files after unpacking from tar
## Why
- we've seen files get truncated when someone yanks a power cord after provisioning a device
## Other bulletproofing
- look into fsyncing symlinks + directories