### PR TITLE
RSDK-7004: update wheeled odometer when base dependency update

### DIFF
--- a/components/movementsensor/wheeledodometry/wheeledodometry_test.go
+++ b/components/movementsensor/wheeledodometry/wheeledodometry_test.go
@@ -158,8 +158,10 @@ func TestReconfigure(t *testing.T) {
 	err = fakeSensor.Reconfigure(ctx, newDeps, newconf)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, od.timeIntervalMSecs, test.ShouldEqual, 500)
-	test.That(t, od.baseWidth, test.ShouldEqual, 0.2)
-	test.That(t, od.wheelCircumference, test.ShouldEqual, 0.2)
+	props, err := od.base.Properties(ctx, nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, props.WidthMeters, test.ShouldEqual, 0.2)
+	test.That(t, props.WheelCircumferenceMeters, test.ShouldEqual, 0.2)
 
 	newDeps = make(resource.Dependencies)
 	newDeps[base.Named(newBaseName)] = createFakeBase(0.2, 0.2, 0)
@@ -179,8 +181,10 @@ func TestReconfigure(t *testing.T) {
 	err = fakeSensor.Reconfigure(ctx, newDeps, newconf)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, od.timeIntervalMSecs, test.ShouldEqual, 200)
-	test.That(t, od.baseWidth, test.ShouldEqual, 0.2)
-	test.That(t, od.wheelCircumference, test.ShouldEqual, 0.2)
+	props, err = od.base.Properties(ctx, nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, props.WidthMeters, test.ShouldEqual, 0.2)
+	test.That(t, props.WheelCircumferenceMeters, test.ShouldEqual, 0.2)
 }
 
 func TestValidateConfig(t *testing.T) {
@@ -248,16 +252,16 @@ func TestValidateConfig(t *testing.T) {
 func TestSpin(t *testing.T) {
 	left := createFakeMotor(true)
 	right := createFakeMotor(false)
+	base := createFakeBase(0.2, 0.2, 0.1)
 	ctx := context.Background()
 	_ = left.ResetZeroPosition(ctx, 0, nil)
 	_ = right.ResetZeroPosition(ctx, 0, nil)
 
 	od := &odometry{
-		lastLeftPos:        0,
-		lastRightPos:       0,
-		baseWidth:          1,
-		wheelCircumference: 1,
-		timeIntervalMSecs:  500,
+		lastLeftPos:       0,
+		lastRightPos:      0,
+		base:              base,
+		timeIntervalMSecs: 500,
 	}
 	od.motors = append(od.motors, motorPair{left, right})
 	od.trackPosition(context.Background())
@@ -300,16 +304,16 @@ func TestSpin(t *testing.T) {
 func TestMoveStraight(t *testing.T) {
 	left := createFakeMotor(true)
 	right := createFakeMotor(false)
+	base := createFakeBase(0.2, 0.2, 0.1)
 	ctx := context.Background()
 	_ = left.ResetZeroPosition(ctx, 0, nil)
 	_ = right.ResetZeroPosition(ctx, 0, nil)
 
 	od := &odometry{
-		lastLeftPos:        0,
-		lastRightPos:       0,
-		baseWidth:          1,
-		wheelCircumference: 1,
-		timeIntervalMSecs:  500,
+		lastLeftPos:       0,
+		lastRightPos:      0,
+		base:              base,
+		timeIntervalMSecs: 500,
 	}
 	od.motors = append(od.motors, motorPair{left, right})
 	od.trackPosition(context.Background())
@@ -340,16 +344,16 @@ func TestMoveStraight(t *testing.T) {
 func TestComplicatedPath(t *testing.T) {
 	left := createFakeMotor(true)
 	right := createFakeMotor(false)
+	base := createFakeBase(0.2, 0.2, 0.1)
 	ctx := context.Background()
 	_ = left.ResetZeroPosition(ctx, 0, nil)
 	_ = right.ResetZeroPosition(ctx, 0, nil)
 
 	od := &odometry{
-		lastLeftPos:        0,
-		lastRightPos:       0,
-		baseWidth:          1,
-		wheelCircumference: 1,
-		timeIntervalMSecs:  500,
+		lastLeftPos:       0,
+		lastRightPos:      0,
+		base:              base,
+		timeIntervalMSecs: 500,
 	}
 	od.motors = append(od.motors, motorPair{left, right})
 	od.trackPosition(context.Background())
@@ -430,16 +434,16 @@ func TestComplicatedPath(t *testing.T) {
 func TestVelocities(t *testing.T) {
 	left := createFakeMotor(true)
 	right := createFakeMotor(false)
+	base := createFakeBase(0.2, 0.2, 0.1)
 	ctx := context.Background()
 	_ = left.ResetZeroPosition(ctx, 0, nil)
 	_ = right.ResetZeroPosition(ctx, 0, nil)
 
 	od := &odometry{
-		lastLeftPos:        0,
-		lastRightPos:       0,
-		baseWidth:          1,
-		wheelCircumference: 1,
-		timeIntervalMSecs:  500,
+		lastLeftPos:       0,
+		lastRightPos:      0,
+		base:              base,
+		timeIntervalMSecs: 500,
 	}
 	od.motors = append(od.motors, motorPair{left, right})
 	od.trackPosition(context.Background())


### PR DESCRIPTION
this worked with a quick test but I'm not confident it won't cause issues without being careful about accessing the properties. should I just wait for that reconfigure ticket to potentially be implemented? 