### PR TITLE
RSDK-6234 remove attribute converter from builtin navigation service

### DIFF
--- a/components/arm/arm_test.go
+++ b/components/arm/arm_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/golang/geo/r3"
-	"github.com/mitchellh/mapstructure"
 	pb "go.viam.com/api/component/arm/v1"
 	"go.viam.com/test"
 	"go.viam.com/utils/protoutils"

--- a/components/base/base_test.go
+++ b/components/base/base_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 	commonpb "go.viam.com/api/common/v1"
 	"go.viam.com/test"
 	"go.viam.com/utils/protoutils"

--- a/components/board/status_test.go
+++ b/components/board/status_test.go
@@ -3,7 +3,7 @@ package board_test
 import (
 	"testing"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 	commonpb "go.viam.com/api/common/v1"
 	"go.viam.com/test"
 	"go.viam.com/utils/protoutils"

--- a/components/gantry/gantry_test.go
+++ b/components/gantry/gantry_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/pkg/errors"
 	pb "go.viam.com/api/component/gantry/v1"
 	"go.viam.com/test"

--- a/components/motor/motor_test.go
+++ b/components/motor/motor_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/pkg/errors"
 	pb "go.viam.com/api/component/motor/v1"
 	"go.viam.com/test"

--- a/config/proto_conversions_test.go
+++ b/config/proto_conversions_test.go
@@ -26,6 +26,15 @@ import (
 	"go.viam.com/rdk/utils"
 )
 
+var testOrientation, _ = spatial.NewOrientationConfig(spatial.NewZeroOrientation())
+
+var testFrame = &referenceframe.LinkConfig{
+	Parent:      "world",
+	Translation: r3.Vector{X: 1, Y: 2, Z: 3},
+	Orientation: testOrientation,
+	Geometry:    &spatial.GeometryConfig{Type: "box", X: 1, Y: 2, Z: 1},
+}
+
 var testComponent = resource.Config{
 	Name:      "some-name",
 	API:       resource.NewAPI("some-namespace", "component", "some-type"),
@@ -59,29 +68,13 @@ var testComponent = resource.Config{
 			},
 		},
 	},
-	Frame: &referenceframe.LinkConfig{
-		Parent:      "world",
-		Translation: r3.Vector{X: 1, Y: 2, Z: 3},
-		Orientation: &spatial.OrientationConfig{
-			Type:  spatial.OrientationVectorDegreesType,
-			Value: json.RawMessage([]byte(`{"th":0,"x":0,"y":0,"z":1}`)),
-		},
-		Geometry: &spatial.GeometryConfig{Type: "box", X: 1, Y: 2, Z: 1},
-	},
+	Frame: testFrame,
 }
 
 var testRemote = Remote{
 	Name:    "some-name",
 	Address: "localohst:8080",
-	Frame: &referenceframe.LinkConfig{
-		Parent:      "world",
-		Translation: r3.Vector{X: 1, Y: 2, Z: 3},
-		Orientation: &spatial.OrientationConfig{
-			Type:  spatial.OrientationVectorDegreesType,
-			Value: json.RawMessage([]byte(`{"th":0,"x":0,"y":0,"z":1}`)),
-		},
-		Geometry: &spatial.GeometryConfig{Type: "box", X: 1, Y: 2, Z: 1},
-	},
+	Frame:   testFrame,
 	Auth: RemoteAuth{
 		Entity: "some-entity",
 		Credentials: &rpc.Credentials{

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/go-gl/mathgl v1.0.0
 	github.com/go-gnss/rtcm v0.0.3
 	github.com/go-nlopt/nlopt v0.0.0-20230219125344-443d3362dcb5
+	github.com/go-viper/mapstructure/v2 v2.0.0-alpha.1
 	github.com/goccy/go-graphviz v0.1.3-0.20240305010347-606fdf55b06d
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
@@ -58,7 +59,6 @@ require (
 	github.com/mattn/go-tflite v1.0.4
 	github.com/matttproud/golang_protobuf_extensions v1.0.4
 	github.com/mitchellh/copystructure v1.2.0
-	github.com/mitchellh/mapstructure v1.5.0
 	github.com/mkch/gpio v0.0.0-20190919032813-8327cd97d95e
 	github.com/montanaflynn/stats v0.7.0
 	github.com/muesli/clusters v0.0.0-20200529215643-2700303c1762
@@ -266,6 +266,7 @@ require (
 	github.com/mgechev/revive v1.2.5 // indirect
 	github.com/miekg/dns v1.1.53 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moricho/tparallel v0.2.1 // indirect
 	github.com/nakabonne/nestif v0.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -460,6 +460,8 @@ github.com/go-toolsmith/typep v1.0.0/go.mod h1:JSQCQMUPdRlMZFswiq3TGpNp1GMktqkR2
 github.com/go-toolsmith/typep v1.0.2/go.mod h1:JSQCQMUPdRlMZFswiq3TGpNp1GMktqkR2Ns5AIQkATU=
 github.com/go-toolsmith/typep v1.1.0 h1:fIRYDyF+JywLfqzyhdiHzRop/GQDxxNhLGQ6gFUNHus=
 github.com/go-toolsmith/typep v1.1.0/go.mod h1:fVIw+7zjdsMxDA3ITWnH1yOiw1rnTQKCsF/sk2H/qig=
+github.com/go-viper/mapstructure/v2 v2.0.0-alpha.1 h1:TQcrn6Wq+sKGkpyPvppOz99zsMBaUOKXq6HSv655U1c=
+github.com/go-viper/mapstructure/v2 v2.0.0-alpha.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/go-xmlfmt/xmlfmt v0.0.0-20191208150333-d5b6f63a941b/go.mod h1:aUCEOzzezBEjDBbFBoSiya/gduyIiWYRP6CnSFIV8AM=
 github.com/go-xmlfmt/xmlfmt v1.1.2 h1:Nea7b4icn8s57fTx1M5AI4qQT5HEM3rVUO8MuE6g80U=
 github.com/go-xmlfmt/xmlfmt v1.1.2/go.mod h1:aUCEOzzezBEjDBbFBoSiya/gduyIiWYRP6CnSFIV8AM=

--- a/resource/config.go
+++ b/resource/config.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/pkg/errors"
 
 	"go.viam.com/rdk/logging"

--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -16,10 +16,10 @@ import (
 	"time"
 
 	"github.com/edaniels/golog"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/golang/geo/r3"
 	"github.com/google/uuid"
 	"github.com/jhump/protoreflect/grpcreflect"
-	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	commonpb "go.viam.com/api/common/v1"
 	armpb "go.viam.com/api/component/arm/v1"

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
-
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	armpb "go.viam.com/api/component/arm/v1"

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -13,11 +13,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/golang/geo/r3"
-	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
+
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	armpb "go.viam.com/api/component/arm/v1"

--- a/services/datamanager/datasync/upload_data_capture_file.go
+++ b/services/datamanager/datasync/upload_data_capture_file.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/docker/go-units"
-	mapstructure "github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/pkg/errors"
 	v1 "go.viam.com/api/app/datasync/v1"
 	pb "go.viam.com/api/component/camera/v1"

--- a/services/navigation/builtin/builtin.go
+++ b/services/navigation/builtin/builtin.go
@@ -3,7 +3,6 @@ package builtin
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"math"
 	"strconv"
@@ -77,20 +76,6 @@ const (
 func init() {
 	resource.RegisterService(navigation.API, resource.DefaultServiceModel, resource.Registration[navigation.Service, *Config]{
 		Constructor: NewBuiltIn,
-		// TODO: We can move away from using AttributeMapConverter if we change the way
-		// that we allow orientations to be specified within orientation_json.go
-		AttributeMapConverter: func(attributes rdkutils.AttributeMap) (*Config, error) {
-			b, err := json.Marshal(attributes)
-			if err != nil {
-				return nil, err
-			}
-
-			var cfg Config
-			if err := json.Unmarshal(b, &cfg); err != nil {
-				return nil, err
-			}
-			return &cfg, nil
-		},
 	})
 }
 

--- a/spatialmath/data/orientations.json
+++ b/spatialmath/data/orientations.json
@@ -38,7 +38,8 @@
         "type": "euler_angles",
         "value": {
             "yaw": 45,
-            "roll": 0
+            "roll": 0,
+            "pitch": 0
         }
     },
     "axisangle": {

--- a/spatialmath/orientation_json.go
+++ b/spatialmath/orientation_json.go
@@ -35,7 +35,9 @@ func NewOrientationConfig(o Orientation) (*OrientationConfig, error) {
 		return nil, err
 	}
 	value := map[string]any{}
-	json.Unmarshal(bytes, &value)
+	if err := json.Unmarshal(bytes, &value); err != nil {
+		return nil, err
+	}
 
 	switch oType := o.(type) {
 	case *R4AA:
@@ -47,13 +49,6 @@ func NewOrientationConfig(o Orientation) (*OrientationConfig, error) {
 	case *EulerAngles:
 		return &OrientationConfig{Type: EulerAnglesType, Value: value}, nil
 	case *Quaternion:
-		oj := quaternionJSONFromQuaternion(oType)
-		bytes, err := json.Marshal(oj)
-		if err != nil {
-			return nil, err
-		}
-		value := map[string]any{}
-		json.Unmarshal(bytes, &value)
 		return &OrientationConfig{Type: QuaternionType, Value: value}, nil
 	default:
 		return nil, newOrientationTypeUnsupportedError(fmt.Sprintf("%T", oType))
@@ -62,7 +57,7 @@ func NewOrientationConfig(o Orientation) (*OrientationConfig, error) {
 
 // ParseConfig will use the Type in OrientationConfig and convert into the correct struct that implements Orientation.
 func (config *OrientationConfig) ParseConfig() (Orientation, error) {
-	rawJson, err := json.Marshal(config.Value)
+	bytes, err := json.Marshal(config.Value)
 	if err != nil {
 		return nil, err
 	}
@@ -73,35 +68,35 @@ func (config *OrientationConfig) ParseConfig() (Orientation, error) {
 		return NewZeroOrientation(), nil
 	case OrientationVectorDegreesType:
 		var o OrientationVectorDegrees
-		err = json.Unmarshal(rawJson, &o)
+		err = json.Unmarshal(bytes, &o)
 		if err != nil {
 			return nil, err
 		}
 		return &o, o.IsValid()
 	case OrientationVectorRadiansType:
 		var o OrientationVector
-		err = json.Unmarshal(rawJson, &o)
+		err = json.Unmarshal(bytes, &o)
 		if err != nil {
 			return nil, err
 		}
 		return &o, o.IsValid()
 	case AxisAnglesType:
 		var o R4AA
-		err = json.Unmarshal(rawJson, &o)
+		err = json.Unmarshal(bytes, &o)
 		if err != nil {
 			return nil, err
 		}
 		return &o, nil
 	case EulerAnglesType:
 		var o EulerAngles
-		err = json.Unmarshal(rawJson, &o)
+		err = json.Unmarshal(bytes, &o)
 		if err != nil {
 			return nil, err
 		}
 		return &o, nil
 	case QuaternionType:
 		var oj quaternionJSON
-		err = json.Unmarshal(rawJson, &oj)
+		err = json.Unmarshal(bytes, &oj)
 		if err != nil {
 			return nil, err
 		}

--- a/spatialmath/orientation_json_test.go
+++ b/spatialmath/orientation_json_test.go
@@ -48,9 +48,7 @@ func TestOrientation(t *testing.T) {
 	oc, err := NewOrientationConfig(o)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, oc.Type, test.ShouldEqual, string(OrientationVectorDegreesType))
-	bytes, err := json.Marshal(o)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, oc.Value, test.ShouldResemble, json.RawMessage(bytes))
+	test.That(t, oc, test.ShouldResemble, &ro)
 
 	// OrientationVector Radians Config
 	ro = OrientationConfig{}
@@ -62,9 +60,7 @@ func TestOrientation(t *testing.T) {
 	oc, err = NewOrientationConfig(o)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, oc.Type, test.ShouldEqual, string(OrientationVectorRadiansType))
-	bytes, err = json.Marshal(o)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, oc.Value, test.ShouldResemble, json.RawMessage(bytes))
+	test.That(t, oc, test.ShouldResemble, &ro)
 
 	// Euler Angles
 	ro = OrientationConfig{}
@@ -76,9 +72,7 @@ func TestOrientation(t *testing.T) {
 	oc, err = NewOrientationConfig(o)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, oc.Type, test.ShouldEqual, string(EulerAnglesType))
-	bytes, err = json.Marshal(o)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, oc.Value, test.ShouldResemble, json.RawMessage(bytes))
+	test.That(t, oc, test.ShouldResemble, &ro)
 
 	// Axis angles Config
 	ro = OrientationConfig{}
@@ -90,9 +84,7 @@ func TestOrientation(t *testing.T) {
 	oc, err = NewOrientationConfig(o)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, oc.Type, test.ShouldEqual, string(AxisAnglesType))
-	bytes, err = json.Marshal(o)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, oc.Value, test.ShouldResemble, json.RawMessage(bytes))
+	test.That(t, oc, test.ShouldResemble, &ro)
 
 	// Quaternion Config
 	ro = OrientationConfig{}
@@ -108,7 +100,7 @@ func TestOrientation(t *testing.T) {
 	oc, err = NewOrientationConfig(o)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, oc.Type, test.ShouldEqual, string(QuaternionType))
-	bytes, err = json.Marshal(o)
+	bytes, err := json.Marshal(o)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, oc.Value, test.ShouldResemble, json.RawMessage(bytes))
 }

--- a/spatialmath/orientation_json_test.go
+++ b/spatialmath/orientation_json_test.go
@@ -100,9 +100,9 @@ func TestOrientation(t *testing.T) {
 	oc, err = NewOrientationConfig(o)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, oc.Type, test.ShouldEqual, string(QuaternionType))
-	bytes, err := json.Marshal(o)
+	o2, err := oc.ParseConfig()
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, oc.Value, test.ShouldResemble, json.RawMessage(bytes))
+	test.That(t, OrientationAlmostEqual(o, o2), test.ShouldBeTrue)
 }
 
 func loadOrientationTests(t *testing.T) map[string]json.RawMessage {

--- a/vision/segmentation/color_objects.go
+++ b/vision/segmentation/color_objects.go
@@ -3,7 +3,7 @@ package segmentation
 import (
 	"fmt"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/pkg/errors"
 
 	"go.viam.com/rdk/utils"

--- a/vision/segmentation/detections_to_objects.go
+++ b/vision/segmentation/detections_to_objects.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"image"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/pkg/errors"
 
 	"go.viam.com/rdk/components/camera"

--- a/vision/segmentation/er_ccl_clustering.go
+++ b/vision/segmentation/er_ccl_clustering.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"math"
 
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/golang/geo/r3"
-	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 
 	"go.viam.com/rdk/components/camera"

--- a/vision/segmentation/radius_clustering.go
+++ b/vision/segmentation/radius_clustering.go
@@ -3,8 +3,8 @@ package segmentation
 import (
 	"context"
 
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/golang/geo/r3"
-	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 
 	"go.viam.com/rdk/components/camera"

--- a/vision/segmentation/radius_clustering_voxel.go
+++ b/vision/segmentation/radius_clustering_voxel.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/golang/geo/r3"
-	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 
 	"go.viam.com/rdk/components/camera"


### PR DESCRIPTION
The use of custom attribute map converters in the RDK creates a lot of special casing in the code and makes the code less readable. It is also another area where users can inject their own code in a module (while separated into a different process in a module, still not great) and cause issues. Besides that, this means that certain operations that should be run during reconfiguration now runs every time the config is read, which increases overhead.

We should migrate all existing custom AttributeMapConverters to be part of the reconfiguration step and remove the ability to define custom AttributeMapConverters.