### PR TITLE
rsdk-7157: change text on errors for clarity, and add new error

### DIFF
--- a/vision/objectdetection/color_detector.go
+++ b/vision/objectdetection/color_detector.go
@@ -31,7 +31,8 @@ func NewColorDetector(cfg *ColorDetectorConfig) (Detector, error) {
 	}
 	hue, s, v := col.HsvNormal()
 	if s == 0 { // color detector cannot detect black/white/grayscale
-		return nil, errors.New("the chosen color to detect has a saturation of 0. The color detector cannot detect black, white or grayscale colors.")
+		return nil, errors.New("the chosen color to detect has a saturation of 0. " +
+			"The color detector cannot detect black, white or grayscale colors.")
 	}
 	tol := cfg.HueTolerance
 	sat := cfg.SaturationCutoff

--- a/vision/objectdetection/color_detector.go
+++ b/vision/objectdetection/color_detector.go
@@ -30,6 +30,9 @@ func NewColorDetector(cfg *ColorDetectorConfig) (Detector, error) {
 		return nil, err
 	}
 	hue, s, v := col.HsvNormal()
+	if s == 0 { // color detector cannot detect black/white/grayscale
+		return nil, errors.New("the chosen color to detect has a saturation of 0. The color detector cannot detect black, white or grayscale colors.")
+	}
 	tol := cfg.HueTolerance
 	sat := cfg.SaturationCutoff
 	if sat == 0 {
@@ -50,10 +53,10 @@ func NewColorDetector(cfg *ColorDetectorConfig) (Detector, error) {
 		return nil, errors.Errorf("value_cutoff_pct must be between 0.0 and 1.0. Got %.5f", val)
 	}
 	if s < sat {
-		return nil, errors.Errorf("requested detect_color has saturation of %.5f which is less than saturation_cutoff_pct %.5f", s, sat)
+		return nil, errors.Errorf("the chosen color to detect has a saturation of %.5f which is less than saturation_cutoff_pct %.5f", s, sat)
 	}
 	if v < val {
-		return nil, errors.Errorf("requested detect_color has value of %.5f which is less than value_cutoff_pct %.5f", v, val)
+		return nil, errors.Errorf("the chosen color to detect has a value of %.5f which is less than value_cutoff_pct %.5f", v, val)
 	}
 
 	var valid validPixelFunc

--- a/vision/objectdetection/color_detector.go
+++ b/vision/objectdetection/color_detector.go
@@ -37,11 +37,11 @@ func NewColorDetector(cfg *ColorDetectorConfig) (Detector, error) {
 	tol := cfg.HueTolerance
 	sat := cfg.SaturationCutoff
 	if sat == 0 {
-		sat = 0.2
+		sat = 0.2 // saturation less than .2 look very washed out and grayscale
 	}
 	val := cfg.ValueCutoff
 	if val == 0 {
-		val = 0.3
+		val = 0.3 // values less than .3 look very dark and hard to distinguish from black
 	}
 
 	if tol > 1.0 || tol <= 0.0 {

--- a/vision/objectdetection/color_detector_test.go
+++ b/vision/objectdetection/color_detector_test.go
@@ -49,6 +49,13 @@ func TestColorDetector(t *testing.T) {
 	)
 
 	cfg.ValueCutoff = 0.3
+	cfg.DetectColorString = "#000000" // black
+	_, err = NewColorDetector(cfg)
+	test.That(t, err.Error(), test.ShouldContainSubstring,
+		"the chosen color to detect has a saturation of 0",
+	)
+
+	cfg.DetectColorString = "#4F3815" // an orange color
 	det, err := NewColorDetector(cfg)
 	test.That(t, err, test.ShouldBeNil)
 	result, err := det(ctx, img)

--- a/vision/objectdetection/color_detector_test.go
+++ b/vision/objectdetection/color_detector_test.go
@@ -12,6 +12,8 @@ import (
 	"go.viam.com/rdk/rimage"
 )
 
+const colorHexString = "#4F3815" // an orange color
+
 func TestColorDetector(t *testing.T) {
 	// make the original source
 	img, err := rimage.NewImageFromFile(artifact.MustPath("vision/objectdetection/detection_test.jpg"))
@@ -21,7 +23,7 @@ func TestColorDetector(t *testing.T) {
 	cfg := &ColorDetectorConfig{
 		SegmentSize:       150000,
 		HueTolerance:      8.0,
-		DetectColorString: "#4F3815", // an orange color
+		DetectColorString: colorHexString,
 	}
 	_, err = NewColorDetector(cfg)
 	test.That(t, err, test.ShouldBeError, errors.New("hue_tolerance_pct must be between 0.0 and 1.0. Got 8.00000"))
@@ -55,7 +57,7 @@ func TestColorDetector(t *testing.T) {
 		"the chosen color to detect has a saturation of 0",
 	)
 
-	cfg.DetectColorString = "#4F3815" // an orange color
+	cfg.DetectColorString = colorHexString
 	det, err := NewColorDetector(cfg)
 	test.That(t, err, test.ShouldBeNil)
 	result, err := det(ctx, img)

--- a/vision/objectdetection/color_detector_test.go
+++ b/vision/objectdetection/color_detector_test.go
@@ -39,13 +39,13 @@ func TestColorDetector(t *testing.T) {
 	cfg.ValueCutoff = 1.
 	_, err = NewColorDetector(cfg)
 	test.That(t, err, test.ShouldBeError,
-		errors.New("requested detect_color has saturation of 0.73333 which is less than saturation_cutoff_pct 1.00000"),
+		errors.New("the chosen color to detect has a saturation of 0.73333 which is less than saturation_cutoff_pct 1.00000"),
 	)
 
 	cfg.SaturationCutoff = 0.2
 	_, err = NewColorDetector(cfg)
 	test.That(t, err, test.ShouldBeError,
-		errors.New("requested detect_color has value of 0.30980 which is less than value_cutoff_pct 1.00000"),
+		errors.New("the chosen color to detect has a value of 0.30980 which is less than value_cutoff_pct 1.00000"),
 	)
 
 	cfg.ValueCutoff = 0.3


### PR DESCRIPTION
The color detector can't detect black, white, or grayscale colors, so explicitly make that clear by making colors with saturation of 0 an error.