### PR TITLE
RSDK-7077 fix bug in builtin nav service when moving to a sufficiently close waypoint

### DIFF
--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -1784,7 +1784,7 @@ func TestMoveOnMap(t *testing.T) {
 		timeoutCtx, timeoutFn := context.WithTimeout(ctx, time.Second*5)
 		defer timeoutFn()
 		executionID, err := ms.(*builtIn).MoveOnMap(timeoutCtx, req)
-		test.That(t, err, test.ShouldBeError, errors.New("no need to move, already within planDeviationMM"))
+		test.That(t, err, test.ShouldBeError, motion.ErrGoalWithinPlanDeviation)
 		test.That(t, executionID, test.ShouldResemble, uuid.Nil)
 	})
 

--- a/services/motion/builtin/move_request.go
+++ b/services/motion/builtin/move_request.go
@@ -718,7 +718,8 @@ func (ms *builtIn) createBaseMoveRequest(
 		if spatialmath.PoseAlmostCoincidentEps(goal.Pose(), startPose, motionCfg.planDeviationMM) {
 			return nil, motion.ErrGoalWithinPlanDeviation
 		}
-	} else if spatialmath.PoseAlmostEqualEps(goal.Pose(), startPose, motionCfg.planDeviationMM) {
+	} else if spatialmath.OrientationAlmostEqual(goal.Pose().Orientation(), spatialmath.NewZeroPose().Orientation()) &&
+		spatialmath.PoseAlmostCoincidentEps(goal.Pose(), startPose, motionCfg.planDeviationMM) {
 		return nil, motion.ErrGoalWithinPlanDeviation
 	}
 

--- a/services/motion/builtin/move_request.go
+++ b/services/motion/builtin/move_request.go
@@ -33,8 +33,6 @@ const (
 	baseStopTimeout         = time.Second * 5
 )
 
-var errGoalWithinPlanDeviation = errors.New("no need to move, already within planDeviationMM")
-
 // validatedMotionConfiguration is a copy of the motion.MotionConfiguration type
 // which has been validated to conform to the expectations of the builtin
 // motion servicl.
@@ -718,13 +716,10 @@ func (ms *builtIn) createBaseMoveRequest(
 	// current & desired orientation
 	if valExtra.motionProfile == motionplan.PositionOnlyMotionProfile {
 		if spatialmath.PoseAlmostCoincidentEps(goal.Pose(), startPose, motionCfg.planDeviationMM) {
-			return nil, errGoalWithinPlanDeviation
+			return nil, motion.ErrGoalWithinPlanDeviation
 		}
-	} else {
-		if spatialmath.OrientationAlmostEqual(goal.Pose().Orientation(), spatialmath.NewZeroPose().Orientation()) &&
-			spatialmath.PoseAlmostCoincidentEps(goal.Pose(), startPose, motionCfg.planDeviationMM) {
-			return nil, errGoalWithinPlanDeviation
-		}
+	} else if spatialmath.PoseAlmostEqualEps(goal.Pose(), startPose, motionCfg.planDeviationMM) {
+		return nil, motion.ErrGoalWithinPlanDeviation
 	}
 
 	gif := referenceframe.NewGeometriesInFrame(referenceframe.World, worldObstacles)

--- a/services/motion/builtin/state/state.go
+++ b/services/motion/builtin/state/state.go
@@ -170,7 +170,7 @@ func (e *execution[R]) start(ctx context.Context) error {
 			resp, err := lastPWE.executor.Execute(e.cancelCtx, lastPWE.plan.Plan)
 
 			switch {
-			// stoped
+			// stopped
 			case errors.Is(err, context.Canceled):
 				e.notifyStatePlanStopped(lastPWE.plan, time.Now())
 				return

--- a/services/motion/errors.go
+++ b/services/motion/errors.go
@@ -2,5 +2,5 @@ package motion
 
 import "github.com/pkg/errors"
 
-// ErrGoalWithinPlanDeviation is an error describing when planning fails becuase there is nothing to be done.
+// ErrGoalWithinPlanDeviation is an error describing when planning fails because there is nothing to be done.
 var ErrGoalWithinPlanDeviation = errors.New("no need to move, already within planDeviationMM")

--- a/services/motion/errors.go
+++ b/services/motion/errors.go
@@ -1,0 +1,6 @@
+package motion
+
+import "github.com/pkg/errors"
+
+// ErrGoalWithinPlanDeviation is an error describing when planning fails becuase there is nothing to be done
+var ErrGoalWithinPlanDeviation = errors.New("no need to move, already within planDeviationMM")

--- a/services/motion/errors.go
+++ b/services/motion/errors.go
@@ -2,5 +2,5 @@ package motion
 
 import "github.com/pkg/errors"
 
-// ErrGoalWithinPlanDeviation is an error describing when planning fails becuase there is nothing to be done
+// ErrGoalWithinPlanDeviation is an error describing when planning fails becuase there is nothing to be done.
 var ErrGoalWithinPlanDeviation = errors.New("no need to move, already within planDeviationMM")

--- a/services/navigation/builtin/builtin.go
+++ b/services/navigation/builtin/builtin.go
@@ -529,7 +529,10 @@ func (svc *builtIn) moveToWaypoint(ctx context.Context, wp navigation.Waypoint, 
 	cancelCtx, cancelFn := context.WithCancel(ctx)
 	defer cancelFn()
 	executionID, err := svc.motionService.MoveOnGlobe(cancelCtx, req)
-	if err != nil {
+	if errors.Is(err, motion.ErrGoalWithinPlanDeviation) {
+		// make an exception for the error that is raised when motion is not possible because already at goal.
+		return svc.waypointReached(cancelCtx)
+	} else if err != nil {
 		return err
 	}
 
@@ -561,8 +564,8 @@ func (svc *builtIn) moveToWaypoint(ctx context.Context, wp navigation.Waypoint, 
 			ComponentName: req.ComponentName,
 			ExecutionID:   executionID,
 			LastPlanOnly:  true,
-		})
-
+		},
+	)
 	if err != nil {
 		return err
 	}

--- a/services/navigation/builtin/builtin_test.go
+++ b/services/navigation/builtin/builtin_test.go
@@ -1371,6 +1371,38 @@ func TestStartWaypoint(t *testing.T) {
 		})
 	}
 
+	t.Run("motion error returned when within planDeviation results in visiting waypoint", func(t *testing.T) {
+		s := setupStartWaypoint(ctx, t, logger)
+		defer s.closeFunc()
+
+		s.injectMS.MoveOnGlobeFunc = func(ctx context.Context, req motion.MoveOnGlobeReq) (motion.ExecutionID, error) {
+			return uuid.Nil, motion.ErrGoalWithinPlanDeviation
+		}
+
+		cancelCtx, cancelFn := context.WithTimeout(ctx, time.Millisecond*10)
+		defer cancelFn()
+
+		err := s.ns.AddWaypoint(cancelCtx, geo.NewPoint(1, 2), nil)
+		test.That(t, err, test.ShouldBeNil)
+		err = s.ns.SetMode(cancelCtx, navigation.ModeWaypoint, nil)
+		test.That(t, err, test.ShouldBeNil)
+		wps, err := s.ns.Waypoints(cancelCtx, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(wps), test.ShouldEqual, 1)
+
+		for {
+			if cancelCtx.Err() != nil {
+				t.Error("test timed out")
+				t.FailNow()
+			}
+			wps, err := s.ns.Waypoints(cancelCtx, nil)
+			test.That(t, err, test.ShouldBeNil)
+			if len(wps) == 0 {
+				break
+			}
+		}
+	})
+
 	t.Run("Calling RemoveWaypoint on the waypoint in progress cancels current MoveOnGlobe call", func(t *testing.T) {
 		s := setupStartWaypoint(ctx, t, logger)
 		defer s.closeFunc()

--- a/services/navigation/builtin/builtin_test.go
+++ b/services/navigation/builtin/builtin_test.go
@@ -1379,7 +1379,7 @@ func TestStartWaypoint(t *testing.T) {
 			return uuid.Nil, motion.ErrGoalWithinPlanDeviation
 		}
 
-		cancelCtx, cancelFn := context.WithTimeout(ctx, time.Millisecond*10)
+		cancelCtx, cancelFn := context.WithTimeout(ctx, time.Millisecond*200)
 		defer cancelFn()
 
 		err := s.ns.AddWaypoint(cancelCtx, geo.NewPoint(1, 2), nil)


### PR DESCRIPTION
This PR fixes the bug where motion returns an error when we are close to the next goal waypoint and the builtin nav service enters an infinite loop of trying to navigate to it anyway.  