### PR TITLE
RSDK-7213 Default geometry fix for wheeled bases

### DIFF
--- a/components/base/wheeled/wheeled_base.go
+++ b/components/base/wheeled/wheeled_base.go
@@ -126,7 +126,9 @@ func (wb *wheeledBase) Reconfigure(ctx context.Context, deps resource.Dependenci
 		if err != nil {
 			return err
 		}
-		wb.geometries = append(wb.geometries, frame.Geometry())
+		if geom := frame.Geometry(); geom != nil {
+			wb.geometries = append(wb.geometries, geom)
+		}
 	}
 
 	newConf, err := resource.NativeConfig[*Config](conf)


### PR DESCRIPTION
Default geometries apparently never worked on hardware bases.