### PR TITLE
[APP-3853] Remove non-ASCII characters from sensor-reading errors

### DIFF
--- a/protoutils/sensor.go
+++ b/protoutils/sensor.go
@@ -101,8 +101,8 @@ func goToProto(v interface{}) (*structpb.Value, error) {
 	// parsing of those requires that they must be entirely ASCII. So, we need to ensure that any
 	// errors from here do not contain non-breaking spaces.
 	if err != nil {
-		ascii := strings.Replace(
-			err.Error(), " " /* non-breaking space */, " " /* normal space */, -1 /* replace all */)
+		ascii := strings.ReplaceAll(
+			err.Error(), " " /* non-breaking space */, " " /* normal space */)
 		err = errors.New(ascii)
 	}
 	return vv, err

--- a/protoutils/sensor_test.go
+++ b/protoutils/sensor_test.go
@@ -2,6 +2,7 @@ package protoutils
 
 import (
 	"testing"
+	"time"
 
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
@@ -30,4 +31,14 @@ func TestRoundtrip(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	test.That(t, m2, test.ShouldResemble, m1)
+}
+
+func TestInvalidValue(t *testing.T) {
+	data := map[string]interface{}{
+		"now": time.Now(),
+	}
+
+	_, err := ReadingGoToProto(data)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldEqual, "proto: invalid type: time.Time")
 }


### PR DESCRIPTION
See comment in the code for the explanation, and see the ticket for how we tracked that down.