### PR TITLE
[Webhooks]: Implement POC of DataCaptureWebhook with generics.

### DIFF
--- a/components/servo/collectors.go
+++ b/components/servo/collectors.go
@@ -41,6 +41,14 @@ func newPositionCollector(resource interface{}, params data.CollectorParams) (da
 			}
 			return nil, data.FailedToReadErr(params.ComponentName, position.String(), err)
 		}
+		if params.WebhookConfig != nil {
+			if params.WebhookConfig.Comparator(pos, pos) { //make them always equal to make webhook URL included
+				return pb.GetPositionResponse{
+					PositionDeg: pos,
+					WebhookUrl:  params.WebhookConfig.URL,
+				}, nil
+			}
+		}
 		return pb.GetPositionResponse{
 			PositionDeg: pos,
 		}, nil

--- a/components/servo/collectors.go
+++ b/components/servo/collectors.go
@@ -45,12 +45,13 @@ func newPositionCollector(resource interface{}, params data.CollectorParams) (da
 			if params.WebhookConfig.Comparator(pos, pos) { //make them always equal to make webhook URL included
 				return pb.GetPositionResponse{
 					PositionDeg: pos,
-					WebhookUrl:  params.WebhookConfig.URL,
+					WebhookUrl:  "https://us-central1-staging-cloud-web-app.cloudfunctions.net/app-3198-2",
 				}, nil
 			}
 		}
 		return pb.GetPositionResponse{
 			PositionDeg: pos,
+			WebhookUrl:  "https://us-central1-staging-cloud-web-app.cloudfunctions.net/app-3198-2", // comment this out
 		}, nil
 	})
 	return data.NewCollector(cFunc, params)

--- a/data/registry.go
+++ b/data/registry.go
@@ -28,7 +28,7 @@ type CollectorParams struct {
 	BufferSize    int
 	Logger        logging.Logger
 	Clock         clock.Clock
-	WebhookConfig *webhook.DataCaptureWebhook[uint32]
+	WebhookConfig *webhook.WebhookConfig
 }
 
 // Validate validates that p contains all required parameters.

--- a/data/registry.go
+++ b/data/registry.go
@@ -12,6 +12,7 @@ import (
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/services/datamanager/datacapture"
+	"go.viam.com/rdk/webhook"
 )
 
 // CollectorConstructor contains a function for constructing an instance of a Collector.
@@ -27,6 +28,7 @@ type CollectorParams struct {
 	BufferSize    int
 	Logger        logging.Logger
 	Clock         clock.Clock
+	WebhookConfig *webhook.DataCaptureWebhook[uint32]
 }
 
 // Validate validates that p contains all required parameters.

--- a/go.mod
+++ b/go.mod
@@ -394,3 +394,5 @@ require (
 	github.com/ziutek/mymysql v1.5.4 // indirect
 	golang.org/x/exp v0.0.0-20230725012225-302865e7556b
 )
+
+replace go.viam.com/api => github.com/viamrobotics/api v0.1.283-0.20240404220204-f201d644f511

--- a/go.sum
+++ b/go.sum
@@ -1417,6 +1417,8 @@ github.com/valyala/quicktemplate v1.6.3/go.mod h1:fwPzK2fHuYEODzJ9pkw0ipCPNHZ2tD
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 github.com/viam-labs/go-libjpeg v0.3.1 h1:J/byavXHFqRI1PFPrnPbP+wFCr1y+Cn1CwKXrORCPD0=
 github.com/viam-labs/go-libjpeg v0.3.1/go.mod h1:b0ISpf9lJv9MO1h1gXAmSA/osG19cKGYjfYc6aeEjqs=
+github.com/viamrobotics/api v0.1.283-0.20240404220204-f201d644f511 h1:UOaZT3TUG43cTd+xpL40zuEbGtTDgecsbyG1NrfNaSw=
+github.com/viamrobotics/api v0.1.283-0.20240404220204-f201d644f511/go.mod h1:msa4TPrMVeRDcG4YzKA/S6wLEUC7GyHQE973JklrQ10=
 github.com/viamrobotics/evdev v0.1.3 h1:mR4HFafvbc5Wx4Vp1AUJp6/aITfVx9AKyXWx+rWjpfc=
 github.com/viamrobotics/evdev v0.1.3/go.mod h1:N6nuZmPz7HEIpM7esNWwLxbYzqWqLSZkfI/1Sccckqk=
 github.com/viki-org/dnscache v0.0.0-20130720023526-c70c1f23c5d8/go.mod h1:dniwbG03GafCjFohMDmz6Zc6oCuiqgH6tGNyXTkHzXE=
@@ -1507,8 +1509,6 @@ go.uber.org/zap v1.18.1/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=
 go.uber.org/zap v1.23.0/go.mod h1:D+nX8jyLsMHMYrln8A0rJjFt/T/9/bGgIhAqxv5URuY=
 go.uber.org/zap v1.24.0 h1:FiJd5l1UOLj0wCgbSE0rwwXHzEdAZS6hiiSnxJN/D60=
 go.uber.org/zap v1.24.0/go.mod h1:2kMP+WWQ8aoFoedH3T2sq6iJ2yDWpHbP0f6MQbS9Gkg=
-go.viam.com/api v0.1.281 h1:Jz7aoolG0jt52/eYMYTqBa/OnYwiLFXUARQepZ692kI=
-go.viam.com/api v0.1.281/go.mod h1:msa4TPrMVeRDcG4YzKA/S6wLEUC7GyHQE973JklrQ10=
 go.viam.com/test v1.1.1-0.20220913152726-5da9916c08a2 h1:oBiK580EnEIzgFLU4lHOXmGAE3MxnVbeR7s1wp/F3Ps=
 go.viam.com/test v1.1.1-0.20220913152726-5da9916c08a2/go.mod h1:XM0tej6riszsiNLT16uoyq1YjuYPWlRBweTPRDanIts=
 go.viam.com/utils v0.1.71 h1:k2wz3VqIiBZqBNVGw16EIeOa9PFyanCzze5yxmfsws8=

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -316,6 +316,7 @@ func (svc *builtIn) initializeOrUpdateCollector(
 		BufferSize:    captureBufferSize,
 		Logger:        svc.logger,
 		Clock:         clock,
+		WebhookConfig: config.WebhookConfig,
 	}
 	collector, err := (*collectorConstructor)(res, params)
 	if err != nil {
@@ -615,7 +616,7 @@ func (svc *builtIn) sync() {
 	}
 }
 
-//nolint
+// nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/services/datamanager/data_manager.go
+++ b/services/datamanager/data_manager.go
@@ -11,6 +11,7 @@ import (
 
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/utils"
+	"go.viam.com/rdk/webhook"
 )
 
 func init() {
@@ -65,7 +66,17 @@ func newAssociatedConfig(attributes utils.AttributeMap) (*AssociatedConfig, erro
 	if err := json.Unmarshal(md, &conf); err != nil {
 		return nil, err
 	}
-	return &conf, nil
+	// Will be able to remove, this just generates an AssociatedConfig that includes
+	// a WebhookConfig values that are non-nil.
+	confWithDataCaptureWebhooks := &AssociatedConfig{
+		CaptureMethods: make([]*DataCaptureConfig, len(conf.CaptureMethods)),
+	}
+	for i, cm := range conf.CaptureMethods {
+		confWithDataCaptureWebhooks.CaptureMethods[i] = cm
+		confWithDataCaptureWebhooks.CaptureMethods[i].WebhookConfig =
+			webhook.NewDataCaptureWebhook[uint32]("https://us-central1-staging-cloud-web-app.cloudfunctions.net/app-3198-2")
+	}
+	return confWithDataCaptureWebhooks, nil
 }
 
 // Equals describes if an DataCaptureConfigs is equal to a given AssociatedConfig.
@@ -115,15 +126,16 @@ func (ac *AssociatedConfig) Link(conf *resource.Config) {
 
 // DataCaptureConfig is used to initialize a collector for a component or remote.
 type DataCaptureConfig struct {
-	Name               resource.Name     `json:"name"`
-	Method             string            `json:"method"`
-	CaptureFrequencyHz float32           `json:"capture_frequency_hz"`
-	CaptureQueueSize   int               `json:"capture_queue_size"`
-	CaptureBufferSize  int               `json:"capture_buffer_size"`
-	AdditionalParams   map[string]string `json:"additional_params"`
-	Disabled           bool              `json:"disabled"`
-	Tags               []string          `json:"tags,omitempty"`
-	CaptureDirectory   string            `json:"capture_directory"`
+	Name               resource.Name                       `json:"name"`
+	Method             string                              `json:"method"`
+	CaptureFrequencyHz float32                             `json:"capture_frequency_hz"`
+	CaptureQueueSize   int                                 `json:"capture_queue_size"`
+	CaptureBufferSize  int                                 `json:"capture_buffer_size"`
+	AdditionalParams   map[string]string                   `json:"additional_params"`
+	Disabled           bool                                `json:"disabled"`
+	Tags               []string                            `json:"tags,omitempty"`
+	CaptureDirectory   string                              `json:"capture_directory"`
+	WebhookConfig      *webhook.DataCaptureWebhook[uint32] `json:"webhook_config,omitempty"`
 }
 
 // Equals checks if one capture config is equal to another.

--- a/services/datamanager/data_manager.go
+++ b/services/datamanager/data_manager.go
@@ -66,17 +66,7 @@ func newAssociatedConfig(attributes utils.AttributeMap) (*AssociatedConfig, erro
 	if err := json.Unmarshal(md, &conf); err != nil {
 		return nil, err
 	}
-	// Will be able to remove, this just generates an AssociatedConfig that includes
-	// a WebhookConfig values that are non-nil.
-	confWithDataCaptureWebhooks := &AssociatedConfig{
-		CaptureMethods: make([]*DataCaptureConfig, len(conf.CaptureMethods)),
-	}
-	for i, cm := range conf.CaptureMethods {
-		confWithDataCaptureWebhooks.CaptureMethods[i] = cm
-		confWithDataCaptureWebhooks.CaptureMethods[i].WebhookConfig =
-			webhook.NewDataCaptureWebhook[uint32]("https://us-central1-staging-cloud-web-app.cloudfunctions.net/app-3198-2")
-	}
-	return confWithDataCaptureWebhooks, nil
+	return &conf, nil
 }
 
 // Equals describes if an DataCaptureConfigs is equal to a given AssociatedConfig.
@@ -126,16 +116,16 @@ func (ac *AssociatedConfig) Link(conf *resource.Config) {
 
 // DataCaptureConfig is used to initialize a collector for a component or remote.
 type DataCaptureConfig struct {
-	Name               resource.Name                       `json:"name"`
-	Method             string                              `json:"method"`
-	CaptureFrequencyHz float32                             `json:"capture_frequency_hz"`
-	CaptureQueueSize   int                                 `json:"capture_queue_size"`
-	CaptureBufferSize  int                                 `json:"capture_buffer_size"`
-	AdditionalParams   map[string]string                   `json:"additional_params"`
-	Disabled           bool                                `json:"disabled"`
-	Tags               []string                            `json:"tags,omitempty"`
-	CaptureDirectory   string                              `json:"capture_directory"`
-	WebhookConfig      *webhook.DataCaptureWebhook[uint32] `json:"webhook_config,omitempty"`
+	Name               resource.Name          `json:"name"`
+	Method             string                 `json:"method"`
+	CaptureFrequencyHz float32                `json:"capture_frequency_hz"`
+	CaptureQueueSize   int                    `json:"capture_queue_size"`
+	CaptureBufferSize  int                    `json:"capture_buffer_size"`
+	AdditionalParams   map[string]string      `json:"additional_params"`
+	Disabled           bool                   `json:"disabled"`
+	Tags               []string               `json:"tags,omitempty"`
+	CaptureDirectory   string                 `json:"capture_directory"`
+	WebhookConfig      *webhook.WebhookConfig `json:"webhook_config,omitempty"`
 }
 
 // Equals checks if one capture config is equal to another.

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -1,0 +1,16 @@
+package webhook
+
+// Define a generic function type that takes two arguments of the same type T and returns a bool.
+type Compare[T comparable] func(a, b T) bool
+
+type DataCaptureWebhook[T comparable] struct {
+	Comparator Compare[T]
+	URL        string
+}
+
+func NewDataCaptureWebhook[T comparable](url string) *DataCaptureWebhook[T] {
+	return &DataCaptureWebhook[T]{
+		Comparator: func(a, b T) bool { return a == b },
+		URL:        url,
+	}
+}

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -8,9 +8,42 @@ type DataCaptureWebhook[T comparable] struct {
 	URL        string
 }
 
-func NewDataCaptureWebhook[T comparable](url string) *DataCaptureWebhook[T] {
-	return &DataCaptureWebhook[T]{
-		Comparator: func(a, b T) bool { return a == b },
-		URL:        url,
+func NewDataCaptureWebhook[T comparable](c *WebhookConfig) DataCaptureWebhook[T] {
+	if c == nil {
+		// An "empty" data capture webhook does not pass a webhook url through to
+		// the data capture flow (and thus no webhooks will be emitted).
+		return DataCaptureWebhook[T]{Comparator: func(a, b T) bool { return false }}
 	}
+	var fn Compare[T]
+	switch c.Comparator {
+	case "eq":
+		fn = func(a, b T) bool {
+			return a == b
+		}
+	case "neq":
+		fn = func(a, b T) bool {
+			return a != b
+		}
+	default:
+		// Could not configure the data capture webhook properly, so return a
+		// data capture webhook that is essentially a no-op.
+		return DataCaptureWebhook[T]{Comparator: func(a, b T) bool { return false }}
+	}
+	return DataCaptureWebhook[T]{
+		Comparator: fn,
+		URL:        (c.Emit)["url"][0],
+	}
+}
+
+func (dcw *DataCaptureWebhook[T]) Compare(a, b T) string {
+	if dcw.Comparator(a, b) {
+		return dcw.URL
+	}
+	return ""
+}
+
+type WebhookConfig struct {
+	Comparator string                `json:"comparator"` // should not be omitempty, we need this!
+	Value      any                   `json:"value"`      // should not be omitempty, we need this!
+	Emit       map[string]([]string) `json:"emit"`       // should not be omitempty, we need this!
 }


### PR DESCRIPTION
POC of conditional webhooks - this design checks a condition inside of the data capture func (used the servo collector as the example) and - based on the webhook condition - embeds a webhook URL inside of the data capture response that gets piped through to the viam web app.

On the [receive side](https://github.com/viamrobotics/app/pull/4310/files), in app's datasync flow we check for the existence of a webhook URL - if it exists we fire the webhook to that URL. The nice aspect of this design is that we don't need any DB calls and we don't need to deserialize the data in the app at all (we know whether it should be sent if the URL exists).