### PR TITLE
[RSDK-7223] move-camera-rtp-passthrough-to-own-package

### DIFF
--- a/components/camera/camera.go
+++ b/components/camera/camera.go
@@ -85,9 +85,9 @@ type Camera interface {
 // A VideoSource represents anything that can capture frames.
 type VideoSource interface {
 	projectorProvider
-	// A VideoCodecStreamSource allows modules to passthrough RTP packets over used by viam-server's camera client to stream video over webrtc.
+	// A RTPPassthroughSource allows modules to passthrough RTP packets over used by viam-server's camera client to stream video over webrtc.
 	// currently only available to go modules.
-	VideoCodecStreamSource(ctx context.Context) (rtppassthrough.Source, error)
+	RTPPassthroughSource(ctx context.Context) (rtppassthrough.Source, error)
 	// Images is used for getting simultaneous images from different imagers,
 	// along with associated metadata (just timestamp for now). It's not for getting a time series of images from the same imager.
 	Images(ctx context.Context) ([]NamedImage, resource.ResponseMetadata, error)
@@ -188,7 +188,7 @@ func NewVideoSourceFromReader(
 	}, nil
 }
 
-func (vs *videoSource) VideoCodecStreamSource(ctx context.Context) (rtppassthrough.Source, error) {
+func (vs *videoSource) RTPPassthroughSource(ctx context.Context) (rtppassthrough.Source, error) {
 	if vs.videoCodecStreamSource != nil {
 		return vs.videoCodecStreamSource, nil
 	}

--- a/components/camera/camera.go
+++ b/components/camera/camera.go
@@ -146,7 +146,11 @@ type sourceBasedCamera struct {
 	logging.Logger
 }
 
-func (vs *sourceBasedCamera) SubscribeRTP(ctx context.Context, bufferSize int, packetsCB rtppassthrough.PacketCallback) (rtppassthrough.SubscriptionID, error) {
+func (vs *sourceBasedCamera) SubscribeRTP(
+	ctx context.Context,
+	bufferSize int,
+	packetsCB rtppassthrough.PacketCallback,
+) (rtppassthrough.SubscriptionID, error) {
 	if vs.rtpPassthroughSource != nil {
 		return vs.rtpPassthroughSource.SubscribeRTP(ctx, bufferSize, packetsCB)
 	}

--- a/components/camera/camera_test.go
+++ b/components/camera/camera_test.go
@@ -11,6 +11,7 @@ import (
 	"go.viam.com/utils/artifact"
 
 	"go.viam.com/rdk/components/camera"
+	"go.viam.com/rdk/components/camera/rtppassthrough"
 	"go.viam.com/rdk/gostream"
 	"go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/resource"
@@ -63,12 +64,12 @@ type dummyvcss struct{}
 func (s *dummyvcss) SubscribeRTP(
 	ctx context.Context,
 	bufferSize int,
-	packetsCB camera.PacketCallback,
-) (camera.StreamSubscriptionID, error) {
+	packetsCB rtppassthrough.PacketCallback,
+) (rtppassthrough.SubscriptionID, error) {
 	return uuid.Nil, errors.New("SubscribeRTP error")
 }
 
-func (s *dummyvcss) Unsubscribe(ctx context.Context, id camera.StreamSubscriptionID) error {
+func (s *dummyvcss) Unsubscribe(ctx context.Context, id rtppassthrough.SubscriptionID) error {
 	return errors.New("Unsubscribe error")
 }
 

--- a/components/camera/camera_test.go
+++ b/components/camera/camera_test.go
@@ -5,13 +5,11 @@ import (
 	"image"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"go.viam.com/test"
 	"go.viam.com/utils/artifact"
 
 	"go.viam.com/rdk/components/camera"
-	"go.viam.com/rdk/components/camera/rtppassthrough"
 	"go.viam.com/rdk/gostream"
 	"go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/resource"
@@ -59,28 +57,6 @@ func (s *simpleSourceWithPCD) Close(ctx context.Context) error {
 	return nil
 }
 
-type dummyvcss struct{}
-
-func (s *dummyvcss) SubscribeRTP(
-	ctx context.Context,
-	bufferSize int,
-	packetsCB rtppassthrough.PacketCallback,
-) (rtppassthrough.SubscriptionID, error) {
-	return uuid.Nil, errors.New("SubscribeRTP error")
-}
-
-func (s *dummyvcss) Unsubscribe(ctx context.Context, id rtppassthrough.SubscriptionID) error {
-	return errors.New("Unsubscribe error")
-}
-
-func (s *dummyvcss) Read(ctx context.Context) (image.Image, func(), error) {
-	return nil, func() {}, errors.New("Read error")
-}
-
-func (s *dummyvcss) Close(ctx context.Context) error {
-	return nil
-}
-
 func TestNewPinholeModelWithBrownConradyDistortion(t *testing.T) {
 	intrinsics := &transform.PinholeCameraIntrinsics{
 		Width:  10,
@@ -109,27 +85,6 @@ func TestNewPinholeModelWithBrownConradyDistortion(t *testing.T) {
 	pinholeCameraModel4 := camera.NewPinholeModelWithBrownConradyDistortion(nil, nil)
 	test.That(t, pinholeCameraModel4, test.ShouldResemble, expected4)
 	test.That(t, pinholeCameraModel4.Distortion, test.ShouldBeNil)
-}
-
-func TestNewVideoSourceFromReader(t *testing.T) {
-	t.Run("if reader is a VideoCodecStreamSource, returns a VideoSource "+
-		"whose VideoCodecStreamSource method returns the reader", func(t *testing.T) {
-		reader := &dummyvcss{}
-		cam1, err := camera.NewVideoSourceFromReader(context.Background(), reader, nil, camera.UnspecifiedStream)
-		test.That(t, err, test.ShouldBeNil)
-		vcss, err := cam1.RTPPassthroughSource(context.Background())
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, vcss, test.ShouldEqual, reader)
-	})
-
-	t.Run("otherwise returns a VideoSource whose VideoCodecStreamSource method returns an error", func(t *testing.T) {
-		reader := &simpleSource{"rimage/board1_small"}
-		cam1, err := camera.NewVideoSourceFromReader(context.Background(), reader, nil, camera.UnspecifiedStream)
-		test.That(t, err, test.ShouldBeNil)
-		vcss, err := cam1.RTPPassthroughSource(context.Background())
-		test.That(t, err, test.ShouldBeError, errors.New("VideoCodecStreamSource unimplemented"))
-		test.That(t, vcss, test.ShouldBeNil)
-	})
 }
 
 func TestNewCamera(t *testing.T) {

--- a/components/camera/camera_test.go
+++ b/components/camera/camera_test.go
@@ -117,7 +117,7 @@ func TestNewVideoSourceFromReader(t *testing.T) {
 		reader := &dummyvcss{}
 		cam1, err := camera.NewVideoSourceFromReader(context.Background(), reader, nil, camera.UnspecifiedStream)
 		test.That(t, err, test.ShouldBeNil)
-		vcss, err := cam1.VideoCodecStreamSource(context.Background())
+		vcss, err := cam1.RTPPassthroughSource(context.Background())
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, vcss, test.ShouldEqual, reader)
 	})
@@ -126,7 +126,7 @@ func TestNewVideoSourceFromReader(t *testing.T) {
 		reader := &simpleSource{"rimage/board1_small"}
 		cam1, err := camera.NewVideoSourceFromReader(context.Background(), reader, nil, camera.UnspecifiedStream)
 		test.That(t, err, test.ShouldBeNil)
-		vcss, err := cam1.VideoCodecStreamSource(context.Background())
+		vcss, err := cam1.RTPPassthroughSource(context.Background())
 		test.That(t, err, test.ShouldBeError, errors.New("VideoCodecStreamSource unimplemented"))
 		test.That(t, vcss, test.ShouldBeNil)
 	})

--- a/components/camera/client.go
+++ b/components/camera/client.go
@@ -377,7 +377,7 @@ func (c *client) Close(ctx context.Context) error {
 	return nil
 }
 
-func (c *client) VideoCodecStreamSource(ctx context.Context) (rtppassthrough.Source, error) {
+func (c *client) RTPPassthroughSource(ctx context.Context) (rtppassthrough.Source, error) {
 	// check if a peer connection is available with the camera
 	// otherwise no webrtc passthrough streams are available
 	_, ok := c.conn.(*rdkgrpc.SharedConn)

--- a/components/camera/client.go
+++ b/components/camera/client.go
@@ -377,17 +377,6 @@ func (c *client) Close(ctx context.Context) error {
 	return nil
 }
 
-func (c *client) RTPPassthroughSource(ctx context.Context) (rtppassthrough.Source, error) {
-	// check if a peer connection is available with the camera
-	// otherwise no webrtc passthrough streams are available
-	_, ok := c.conn.(*rdkgrpc.SharedConn)
-	if c.conn.PeerConn() != nil && ok {
-		return c, nil
-	}
-
-	return nil, errors.New("no WebRTC peer connection")
-}
-
 func (c *client) SubscribeRTP(
 	ctx context.Context,
 	bufferSize int,

--- a/components/camera/replaypcd/replaypcd.go
+++ b/components/camera/replaypcd/replaypcd.go
@@ -18,7 +18,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"go.viam.com/rdk/components/camera"
-	"go.viam.com/rdk/components/camera/rtppassthrough"
 	"go.viam.com/rdk/gostream"
 	"go.viam.com/rdk/internal/cloud"
 	"go.viam.com/rdk/logging"
@@ -165,10 +164,6 @@ func newPCDCamera(
 	}
 
 	return cam, nil
-}
-
-func (replay *pcdCamera) RTPPassthroughSource(ctx context.Context) (rtppassthrough.Source, error) {
-	return nil, errors.New("pcdCamera does not implement VideoCodecStreamSource")
 }
 
 // NextPointCloud returns the next point cloud retrieved from cloud storage based on the applied filter.

--- a/components/camera/replaypcd/replaypcd.go
+++ b/components/camera/replaypcd/replaypcd.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"go.viam.com/rdk/components/camera"
+	"go.viam.com/rdk/components/camera/rtppassthrough"
 	"go.viam.com/rdk/gostream"
 	"go.viam.com/rdk/internal/cloud"
 	"go.viam.com/rdk/logging"
@@ -166,7 +167,7 @@ func newPCDCamera(
 	return cam, nil
 }
 
-func (replay *pcdCamera) VideoCodecStreamSource(ctx context.Context) (camera.VideoCodecStreamSource, error) {
+func (replay *pcdCamera) VideoCodecStreamSource(ctx context.Context) (rtppassthrough.Source, error) {
 	return nil, errors.New("pcdCamera does not implement VideoCodecStreamSource")
 }
 

--- a/components/camera/replaypcd/replaypcd.go
+++ b/components/camera/replaypcd/replaypcd.go
@@ -167,7 +167,7 @@ func newPCDCamera(
 	return cam, nil
 }
 
-func (replay *pcdCamera) VideoCodecStreamSource(ctx context.Context) (rtppassthrough.Source, error) {
+func (replay *pcdCamera) RTPPassthroughSource(ctx context.Context) (rtppassthrough.Source, error) {
 	return nil, errors.New("pcdCamera does not implement VideoCodecStreamSource")
 }
 

--- a/components/camera/replaypcd/replaypcd_test.go
+++ b/components/camera/replaypcd/replaypcd_test.go
@@ -821,21 +821,3 @@ func TestReplayPCDReconfigure(t *testing.T) {
 
 	test.That(t, serverClose(), test.ShouldBeNil)
 }
-
-func TestVideoCodecStreamSource(t *testing.T) {
-	ctx := context.Background()
-	cfg := &Config{
-		Source:         validSource,
-		RobotID:        validRobotID,
-		LocationID:     validLocationID,
-		OrganizationID: validOrganizationID,
-		BatchSize:      &batchSize1,
-	}
-	replayCamera, _, serverClose, err := createNewReplayPCDCamera(ctx, t, cfg, true)
-	test.That(t, err, test.ShouldBeNil)
-	defer serverClose()
-	test.That(t, replayCamera, test.ShouldNotBeNil)
-	vcss, err := replayCamera.RTPPassthroughSource(ctx)
-	test.That(t, err, test.ShouldBeError, errors.New("pcdCamera does not implement VideoCodecStreamSource"))
-	test.That(t, vcss, test.ShouldBeNil)
-}

--- a/components/camera/replaypcd/replaypcd_test.go
+++ b/components/camera/replaypcd/replaypcd_test.go
@@ -835,7 +835,7 @@ func TestVideoCodecStreamSource(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	defer serverClose()
 	test.That(t, replayCamera, test.ShouldNotBeNil)
-	vcss, err := replayCamera.VideoCodecStreamSource(ctx)
+	vcss, err := replayCamera.RTPPassthroughSource(ctx)
 	test.That(t, err, test.ShouldBeError, errors.New("pcdCamera does not implement VideoCodecStreamSource"))
 	test.That(t, vcss, test.ShouldBeNil)
 }

--- a/components/camera/rtppassthrough/rtppassthrough.go
+++ b/components/camera/rtppassthrough/rtppassthrough.go
@@ -1,0 +1,18 @@
+// Package rtppassthrough defines a source of RTP packets
+package rtppassthrough
+
+import (
+	"context"
+
+	"github.com/pion/rtp"
+)
+
+type (
+	// PacketCallback is the signature of the SubscribeRTP callback.
+	PacketCallback func(pkts []*rtp.Packet) error
+	// Source is a source of video codec data.
+	Source interface {
+		SubscribeRTP(ctx context.Context, bufferSize int, packetsCB PacketCallback) (SubscriptionID, error)
+		Unsubscribe(ctx context.Context, id SubscriptionID) error
+	}
+)

--- a/components/camera/rtppassthrough/stream_subscription.go
+++ b/components/camera/rtppassthrough/stream_subscription.go
@@ -1,4 +1,4 @@
-package camera
+package rtppassthrough
 
 // heavily inspired by https://github.com/bluenviron/mediamtx/blob/main/internal/asyncwriter/async_writer.go
 
@@ -26,8 +26,8 @@ import (
 	"go.viam.com/utils"
 )
 
-// StreamSubscriptionID is the id of a StreamSubscription.
-type StreamSubscriptionID = uuid.UUID
+// SubscriptionID is the id of a StreamSubscription.
+type SubscriptionID = uuid.UUID
 
 var (
 	// ErrQueueFull indicates the StreamSubscription's queue is full and that
@@ -47,7 +47,7 @@ var (
 // dropping stale packets is desirable to minimize latency.
 type StreamSubscription struct {
 	buffer  *ringbuffer.RingBuffer
-	id      StreamSubscriptionID
+	id      SubscriptionID
 	onError func(error)
 	err     atomic.Value
 	wg      sync.WaitGroup

--- a/components/camera/rtppassthrough/stream_subscription.go
+++ b/components/camera/rtppassthrough/stream_subscription.go
@@ -53,7 +53,7 @@ type StreamSubscription struct {
 	wg      sync.WaitGroup
 }
 
-// NewStreamSubscription allocates a VideoCodecStreamSubscription.
+// NewStreamSubscription allocates an rtp passthrough stream subscription.
 func NewStreamSubscription(queueSize int, onError func(error)) (*StreamSubscription, error) {
 	if queueSize < 0 {
 		return nil, ErrNegativeQueueSize

--- a/components/camera/rtppassthrough/stream_subscription_test.go
+++ b/components/camera/rtppassthrough/stream_subscription_test.go
@@ -1,4 +1,4 @@
-package camera
+package rtppassthrough
 
 import (
 	"testing"

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -24,6 +24,7 @@ import (
 
 	"go.viam.com/rdk/components/camera"
 	jetsoncamera "go.viam.com/rdk/components/camera/platforms/jetson"
+	"go.viam.com/rdk/components/camera/rtppassthrough"
 	debugLogger "go.viam.com/rdk/components/camera/videosource/logging"
 	"go.viam.com/rdk/gostream"
 	"go.viam.com/rdk/logging"
@@ -315,7 +316,7 @@ func NewWebcam(
 	return cam, nil
 }
 
-func (c *monitoredWebcam) VideoCodecStreamSource(ctx context.Context) (camera.VideoCodecStreamSource, error) {
+func (c *monitoredWebcam) VideoCodecStreamSource(ctx context.Context) (rtppassthrough.Source, error) {
 	return nil, errors.New("monitoredWebcam does not implement VideoCodecStreamSource")
 }
 

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -316,7 +316,7 @@ func NewWebcam(
 	return cam, nil
 }
 
-func (c *monitoredWebcam) VideoCodecStreamSource(ctx context.Context) (rtppassthrough.Source, error) {
+func (c *monitoredWebcam) RTPPassthroughSource(ctx context.Context) (rtppassthrough.Source, error) {
 	return nil, errors.New("monitoredWebcam does not implement VideoCodecStreamSource")
 }
 

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -24,7 +24,6 @@ import (
 
 	"go.viam.com/rdk/components/camera"
 	jetsoncamera "go.viam.com/rdk/components/camera/platforms/jetson"
-	"go.viam.com/rdk/components/camera/rtppassthrough"
 	debugLogger "go.viam.com/rdk/components/camera/videosource/logging"
 	"go.viam.com/rdk/gostream"
 	"go.viam.com/rdk/logging"
@@ -314,10 +313,6 @@ func NewWebcam(
 	}
 
 	return cam, nil
-}
-
-func (c *monitoredWebcam) RTPPassthroughSource(ctx context.Context) (rtppassthrough.Source, error) {
-	return nil, errors.New("monitoredWebcam does not implement VideoCodecStreamSource")
 }
 
 type noopCloser struct {

--- a/module/module.go
+++ b/module/module.go
@@ -460,7 +460,7 @@ func (m *Module) AddResource(ctx context.Context, req *pb.AddResourceRequest) (*
 
 	var vcss rtppassthrough.Source
 	if cam, ok := res.(camera.VideoSource); ok {
-		if v, err := cam.VideoCodecStreamSource(ctx); err == nil {
+		if v, err := cam.RTPPassthroughSource(ctx); err == nil {
 			vcss = v
 		}
 	}
@@ -566,7 +566,7 @@ func (m *Module) ReconfigureResource(ctx context.Context, req *pb.ReconfigureRes
 	}
 	var vcss rtppassthrough.Source
 	if cam, ok := newRes.(camera.VideoSource); ok {
-		if v, err := cam.VideoCodecStreamSource(ctx); err == nil {
+		if v, err := cam.RTPPassthroughSource(ctx); err == nil {
 			vcss = v
 		}
 	}

--- a/robot/web/web_c.go
+++ b/robot/web/web_c.go
@@ -311,17 +311,17 @@ func (svc *webService) startVideoStream(
 	}, svc.webWorkers.Done)
 }
 
-func (svc *webService) videoCodecStreamSource(ctx context.Context, stream gostream.Stream) (rtppassthrough.Source, error) {
+func (svc *webService) videoCodecStreamSource(stream gostream.Stream) (rtppassthrough.Source, error) {
 	res, err := svc.r.ResourceByName(camera.Named(stream.Name()))
 	if err != nil {
 		return nil, err
 	}
-	cam, ok := res.(camera.Camera)
+	rtpPassthroughSource, ok := res.(rtppassthrough.Source)
 	if !ok {
-		return nil, errors.Errorf("expected %s to implement camera.Camera", stream.Name())
+		return nil, errors.Errorf("expected %s to implement rtppassthrough.Source", stream.Name())
 	}
 
-	return cam.RTPPassthroughSource(ctx)
+	return rtpPassthroughSource, nil
 }
 
 func subscribeRTP(
@@ -364,7 +364,7 @@ func (svc *webService) streamH264Passthrough(
 	case <-readyCh:
 	}
 
-	h264Stream, err := svc.videoCodecStreamSource(ctx, stream)
+	h264Stream, err := svc.videoCodecStreamSource(stream)
 	if err != nil {
 		return errors.Wrap(errH264PassthroughNotSupported, err.Error())
 	}

--- a/robot/web/web_c.go
+++ b/robot/web/web_c.go
@@ -321,7 +321,7 @@ func (svc *webService) videoCodecStreamSource(ctx context.Context, stream gostre
 		return nil, errors.Errorf("expected %s to implement camera.Camera", stream.Name())
 	}
 
-	return cam.VideoCodecStreamSource(ctx)
+	return cam.RTPPassthroughSource(ctx)
 }
 
 func subscribeRTP(

--- a/robot/web/web_c.go
+++ b/robot/web/web_c.go
@@ -24,6 +24,7 @@ import (
 
 	"go.viam.com/rdk/components/audioinput"
 	"go.viam.com/rdk/components/camera"
+	"go.viam.com/rdk/components/camera/rtppassthrough"
 	"go.viam.com/rdk/gostream"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -310,7 +311,7 @@ func (svc *webService) startVideoStream(
 	}, svc.webWorkers.Done)
 }
 
-func (svc *webService) videoCodecStreamSource(ctx context.Context, stream gostream.Stream) (camera.VideoCodecStreamSource, error) {
+func (svc *webService) videoCodecStreamSource(ctx context.Context, stream gostream.Stream) (rtppassthrough.Source, error) {
 	res, err := svc.r.ResourceByName(camera.Named(stream.Name()))
 	if err != nil {
 		return nil, err
@@ -326,8 +327,8 @@ func (svc *webService) videoCodecStreamSource(ctx context.Context, stream gostre
 func subscribeRTP(
 	ctx context.Context,
 	stream gostream.Stream,
-	h264Stream camera.VideoCodecStreamSource,
-	packetCallback camera.PacketCallback,
+	h264Stream rtppassthrough.Source,
+	packetCallback rtppassthrough.PacketCallback,
 	logger logging.Logger,
 ) (context.CancelFunc, error) {
 	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, subscribeRTPTimeout)

--- a/testutils/inject/camera.go
+++ b/testutils/inject/camera.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 
 	"go.viam.com/rdk/components/camera"
+	"go.viam.com/rdk/components/camera/rtppassthrough"
 	"go.viam.com/rdk/gostream"
 	"go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/resource"
@@ -25,7 +26,7 @@ type Camera struct {
 	NextPointCloudFunc         func(ctx context.Context) (pointcloud.PointCloud, error)
 	ProjectorFunc              func(ctx context.Context) (transform.Projector, error)
 	PropertiesFunc             func(ctx context.Context) (camera.Properties, error)
-	VideoCodecStreamSourceFunc func(ctx context.Context) (camera.VideoCodecStreamSource, error)
+	VideoCodecStreamSourceFunc func(ctx context.Context) (rtppassthrough.Source, error)
 	CloseFunc                  func(ctx context.Context) error
 }
 
@@ -116,7 +117,7 @@ func (c *Camera) DoCommand(ctx context.Context, cmd map[string]interface{}) (map
 }
 
 // VideoCodecStreamSource calls the injected VideoCodecStreamSource or the real version.
-func (c *Camera) VideoCodecStreamSource(ctx context.Context) (camera.VideoCodecStreamSource, error) {
+func (c *Camera) VideoCodecStreamSource(ctx context.Context) (rtppassthrough.Source, error) {
 	if c.VideoCodecStreamSourceFunc != nil {
 		return c.VideoCodecStreamSourceFunc(ctx)
 	}

--- a/testutils/inject/camera.go
+++ b/testutils/inject/camera.go
@@ -122,7 +122,7 @@ func (c *Camera) VideoCodecStreamSource(ctx context.Context) (rtppassthrough.Sou
 		return c.VideoCodecStreamSourceFunc(ctx)
 	}
 	if c.Camera != nil {
-		return c.Camera.VideoCodecStreamSource(ctx)
+		return c.Camera.RTPPassthroughSource(ctx)
 	}
 	return nil, errors.New("VideoCodecStreamSource unimplemented")
 }


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-7223)

Fixes build issue introduced in: https://github.com/viamrobotics/rdk/pull/3723

Moves RTP Passthrough features into submodule of camera so that building the viam CLI doesn't fail due to the camera package pulling in unneeded C deps as a side effect of module depending on the rtp passthrough interface.

I also renamed some types to shorten names & make it clearer that these features are about RTP passthrough. 

Cameras supporting RTP passthrough will need to implement the `camera/rtppassthrough.Source` interface and no longer need to implement the `VideoCodecStreamSource` method. 


Tested for compatibility with old modules & passthrough modules with:
```json
{
  "modules": [
    {
      "name": "rtsp-nick",
      "executable_path": "/Users/nicksanford/code/viamrtsp/bin/viamrtsp",
      "type": "local"
    },
    {
      "executable_path": "/Users/nicksanford/code/robotModules/new/modmain",
      "name": "nicks-fake-new",
      "type": "local"
    },
    {
      "executable_path": "/Users/nicksanford/code/robotModules/old/modmain",
      "name": "nicks-fake-old",
      "type": "local"
    },
    {
      "module_id": "viam-labs:overlay-fps",
      "name": "viam-labs_overlay-fps1",
      "type": "registry",
      "version": "0.0.4"
    }
  ],
  "components": [
    {
      "attributes": {
        "rtp_passthrough": true,
        "rtsp_address": "rtsp://localhost:8554/live1"
      },
      "depends_on": [],
      "name": "rtsp-passthrough",
      "model": "erh:viamrtsp:rtsp-h264",
      "type": "camera",
      "namespace": "rdk"
    },
    {
      "depends_on": [
        "rtsp-passthrough"
      ],
      "model": "viam-labs:camera:overlay-fps",
      "name": "fps-h2641",
      "namespace": "rdk",
      "type": "camera",
      "attributes": {
        "camera_name": "rtsp-passthrough"
      }
    },
    {
      "attributes": {
        "rtsp_address": "rtsp://localhost:8554/live1"
      },
      "depends_on": [],
      "name": "rtsp",
      "model": "erh:viamrtsp:rtsp-h264",
      "type": "camera",
      "namespace": "rdk"
    },
    {
      "depends_on": [],
      "model": "nicks-old:camera:fake",
      "name": "nicks-old",
      "namespace": "rdk",
      "type": "camera",
      "attributes": {
        "animated": true
      }
    },
    {
      "depends_on": [],
      "model": "nicks-new:camera:fake",
      "name": "nicks-new",
      "namespace": "rdk",
      "type": "camera",
      "attributes": {
        "animated": true
      }
    },
    {
      "depends_on": [],
      "model": "rdk:builtin:fake",
      "name": "local",
      "namespace": "rdk",
      "type": "camera",
      "attributes": {
        "animated": true
      }
    }
  ]
}
```