### PR TITLE
Fix Status for names with machine part id

### DIFF
--- a/resource/resource_graph_test.go
+++ b/resource/resource_graph_test.go
@@ -186,9 +186,9 @@ func TestResourceGraphGetParentsAndChildren(t *testing.T) {
 		NewName(apiA, "Z")), test.ShouldBeFalse)
 
 	for _, p := range g.GetAllParentsOf(NewName(apiA, "F")) {
-		g.removeChild(NewName(apiA, "F"), p)
+		g.removeChild(fromName(NewName(apiA, "F")), fromName(p))
 	}
-	g.remove(NewName(apiA, "F"))
+	g.remove(fromName(NewName(apiA, "F")))
 	out = g.TopologicalSort()
 	test.That(t, newResourceNameSet(out[0:3]...), test.ShouldResemble,
 		newResourceNameSet([]Name{
@@ -742,7 +742,7 @@ func TestResourceGraphReplaceNodesParents(t *testing.T) {
 		}
 	}
 	for n := range gB.nodes {
-		test.That(t, gA.ReplaceNodesParents(n, gB), test.ShouldBeNil)
+		test.That(t, gA.ReplaceNodesParents(n.toName(), gB), test.ShouldBeNil)
 	}
 	out = gA.TopologicalSort()
 	test.That(t, newResourceNameSet(out[0:3]...), test.ShouldResemble,
@@ -816,7 +816,7 @@ func TestResourceGraphCopyNodeAndChildren(t *testing.T) {
 	}...))
 
 	for n := range gA.nodes {
-		test.That(t, gB.CopyNodeAndChildren(n, gA), test.ShouldBeNil)
+		test.That(t, gB.CopyNodeAndChildren(n.toName(), gA), test.ShouldBeNil)
 	}
 	out = gB.TopologicalSort()
 	test.That(t, newResourceNameSet(out[0:4]...), test.ShouldResemble,
@@ -863,7 +863,7 @@ func TestResourceGraphRandomRemoval(t *testing.T) {
 		}
 	}
 
-	g.remove(name)
+	g.remove(fromName(name))
 	test.That(t, g.GetAllParentsOf(name), test.ShouldBeEmpty)
 	test.That(t, g.GetAllChildrenOf(name), test.ShouldBeEmpty)
 }
@@ -1033,7 +1033,7 @@ func TestResourceGraphResolveDependencies(t *testing.T) {
 	test.That(t, node3.hasUnresolvedDependencies(), test.ShouldBeTrue)
 	test.That(t, node4.hasUnresolvedDependencies(), test.ShouldBeTrue)
 
-	g.remove(name3)
+	g.remove(fromName(name3))
 	test.That(t, g.ResolveDependencies(logger), test.ShouldBeNil)
 
 	test.That(t, node1.UnresolvedDependencies(), test.ShouldResemble, []string{"d"})

--- a/resource/visualizer.go
+++ b/resource/visualizer.go
@@ -165,7 +165,7 @@ func getRemoteNames(nodes graphNodes) []string {
 func nodesSortedByName(nodes graphNodes) []nameNode {
 	var ret []nameNode
 	for name, node := range nodes {
-		ret = append(ret, nameNode{name, node})
+		ret = append(ret, nameNode{name.toName(), node})
 	}
 	slices.SortFunc(ret, func(left, right nameNode) int {
 		return utils.Compare(left.Name.String(), right.Name.String())
@@ -234,7 +234,7 @@ func edgesSortedByName(deps resourceDependencies) []edge {
 		for childName := range children {
 			// In our vernacular, children depend on parents. Edges are drawn leaving children and
 			// arriving at parents.
-			ret = append(ret, edge{childName, parentName})
+			ret = append(ret, edge{childName.toName(), parentName.toName()})
 		}
 	}
 

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -1163,7 +1163,10 @@ func TestStatusRemote(t *testing.T) {
 
 	gServer1 := grpc.NewServer()
 	gServer2 := grpc.NewServer()
-	resourcesFunc := func() []resource.Name { return []resource.Name{arm.Named("arm1"), arm.Named("arm2")} }
+	partID := "abcde"
+	resourcesFunc := func() []resource.Name {
+		return []resource.Name{arm.Named("arm1").WithPartID(partID), arm.Named("arm2").WithPartID(partID)}
+	}
 	statusCallCount := 0
 
 	// TODO: RSDK-882 will update this so that this is not necessary
@@ -1198,7 +1201,7 @@ func TestStatusRemote(t *testing.T) {
 		statuses := make([]robot.Status, 0, len(resourceNames))
 		for _, n := range resourceNames {
 			statuses = append(statuses, robot.Status{
-				Name:             n,
+				Name:             n.WithPartID("12345"),
 				LastReconfigured: lastReconfigured,
 				Status:           armStatus,
 			})
@@ -1215,7 +1218,7 @@ func TestStatusRemote(t *testing.T) {
 		statuses := make([]robot.Status, 0, len(resourceNames))
 		for _, n := range resourceNames {
 			statuses = append(statuses, robot.Status{
-				Name:             n,
+				Name:             n.WithPartID("67890"),
 				LastReconfigured: lastReconfigured,
 				Status:           armStatus,
 			})
@@ -1326,6 +1329,8 @@ func TestGetRemoteResourceAndGrandFather(t *testing.T) {
 	err := r0.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
+	_, err = r0.ResourceByName(arm.Named("arm1").WithPartID("abcde"))
+	test.That(t, err, test.ShouldBeNil)
 	r0arm1, err := r0.ResourceByName(arm.Named("arm1"))
 	test.That(t, err, test.ShouldBeNil)
 	r0Arm, ok := r0arm1.(arm.Arm)

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -184,6 +184,7 @@ func (manager *resourceManager) updateRemoteResourceNames(
 	anythingChanged := false
 
 	for _, resName := range newResources {
+		resName = resName.WithoutPartID()
 		remoteResName := resName
 		res, err := rr.ResourceByName(remoteResName) // this returns a remote known OR foreign resource client
 		if err != nil {


### PR DESCRIPTION
realized we couldn't look at the status of a robot with remotes because of the part IDs (lots of resource not found)

ended up adding nameWithoutPartID to the the resource graph, but did not add to the robot client map. Reasoning is to keep this change simpler without resorting to an internal package. Could add to client map later, but would want to keep that change separate

also added a few extra tests