### PR TITLE
RSDK-6989 setup.sh maintenance

### DIFF
--- a/etc/setup.sh
+++ b/etc/setup.sh
@@ -160,8 +160,8 @@ do_brew(){
 	tap  "viamrobotics/brews"
 
 	# pinned
-	brew "node@18", link: true, conflicts_with: ["node"]
 	brew "go@1.21", link: true, conflicts_with: ["go"]
+	brew "node@18", link: true, conflicts_with: ["node"]
 
 	# unpinned
 	brew "canon"

--- a/etc/setup.sh
+++ b/etc/setup.sh
@@ -160,7 +160,6 @@ do_brew(){
 	tap  "viamrobotics/brews"
 
 	# pinned
-	brew "go@1.20", link: true, conflicts_with: ["go"]
 	brew "node@18", link: true, conflicts_with: ["node"]
 
 	# unpinned
@@ -181,6 +180,9 @@ do_brew(){
 		echo "Package installation failed when running brew command, please retry."
 		exit 1
 	fi
+
+	# replace default go (1.22+, from canon build) with pinned go@1.21
+	brew unlink go && brew install go@1.21 && brew link go@1.21
 
 	# due to a missing bottle in homebrew, this has to be installed on its own
 	brew install upx

--- a/etc/setup.sh
+++ b/etc/setup.sh
@@ -161,6 +161,7 @@ do_brew(){
 
 	# pinned
 	brew "node@18", link: true, conflicts_with: ["node"]
+	brew "go@1.21", link: true, conflicts_with: ["go"]
 
 	# unpinned
 	brew "canon"
@@ -181,8 +182,8 @@ do_brew(){
 		exit 1
 	fi
 
-	# replace default go (1.22+, from canon build) with pinned go@1.21
-	brew unlink go && brew install go@1.21 && brew link go@1.21
+	# replace default go (currently 1.22, from canon build) with pinned go@1.21
+	brew link --overwrite go@1.21
 
 	# due to a missing bottle in homebrew, this has to be installed on its own
 	brew install upx

--- a/etc/setup.sh
+++ b/etc/setup.sh
@@ -61,9 +61,19 @@ do_piOS(){
 }
 
 do_linux(){
+	COLOR_RED='\033[0;31m'
+	COLOR_NULL='\033[0m'
 	if apt-get --version > /dev/null 2>&1; then
 		# Debian/Ubuntu
 		INSTALL_CMD="apt-get install --assume-yes build-essential procps curl file git debianutils"
+		if [ $(source /etc/os-release && echo $VERSION_CODENAME) = focal ]; then
+			echo -e ${COLOR_RED}WARNING:${COLOR_NULL} Ubuntu focal has known issues. Your build may fail.
+			read -p "Continue? (y/n) " yesno
+			if [ $yesno != y ]; then
+				echo Okay, quitting
+				exit 0
+			fi
+		fi
 	elif pacman --version > /dev/null 2>&1; then
 		# Arch
 		INSTALL_CMD="pacman -Sy --needed --noconfirm base-devel procps-ng curl git which"


### PR DESCRIPTION
## What changed
- in etc/setup.sh, bump our go from 1.20 -> 1.21
- force-link go@1.21 at the end of the setup process (canon's unpinned `go` is giving 1.22)
- emit loud warning when running on focal (old ubuntu). another approach here would be to proceed, but exclude tensorflowlite (which is broken on focal)
## Possible other changes
- remove license finder in Brewfile + pi_OS? (which also means skipping ruby install). We use this in CI, but may not need it in most local dev setups
## Test run
(`go version` at the end is the key line -- previously would have been 1.22.x)
```bash
$ docker run -it --rm -v $PWD:/rdk ubuntu:latest
root@b105f1bcb227:/# cd /rdk/
root@b105f1bcb227:/rdk# apt update && apt install -qy git make vim sudo
root@b105f1bcb227:/rdk# etc/setup.sh 
...
Dev environment setup is complete!
Don't forget to restart your shell, or execute: source ~/.viamdevrc
root@b105f1bcb227:/rdk# source ~/.viamdevrc 
root@b105f1bcb227:/rdk# go version
go version go1.21.9 linux/amd64
```