### PR TITLE
temporary skips in TestEncodedMotor

### DIFF
--- a/components/motor/gpio/motor_encoder_test.go
+++ b/components/motor/gpio/motor_encoder_test.go
@@ -169,6 +169,7 @@ func TestEncodedMotor(t *testing.T) {
 	})
 
 	t.Run("encoded motor test GoFor forward", func(t *testing.T) {
+		t.Skip("temporary skip for flake")
 		test.That(t, m.goForInternal(context.Background(), 10, 1, 1), test.ShouldBeNil)
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()

--- a/components/motor/gpio/motor_encoder_test.go
+++ b/components/motor/gpio/motor_encoder_test.go
@@ -180,6 +180,7 @@ func TestEncodedMotor(t *testing.T) {
 	})
 
 	t.Run("encoded motor test GoFor backwards", func(t *testing.T) {
+		t.Skip("temporary skip for flake")
 		test.That(t, m.goForInternal(context.Background(), -10, -1, -1), test.ShouldBeNil)
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()

--- a/components/motor/gpio/motor_encoder_test.go
+++ b/components/motor/gpio/motor_encoder_test.go
@@ -191,6 +191,7 @@ func TestEncodedMotor(t *testing.T) {
 	})
 
 	t.Run("encoded motor test goForMath", func(t *testing.T) {
+		t.Skip("temporary skip for flake")
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
 			test.That(tb, m.ResetZeroPosition(context.Background(), 0, nil), test.ShouldBeNil)
@@ -218,6 +219,7 @@ func TestEncodedMotor(t *testing.T) {
 	})
 
 	t.Run("encoded motor test SetPower interrupts GoFor", func(t *testing.T) {
+		t.Skip("temporary skip for flake")
 		go func() {
 			test.That(t, m.goForInternal(context.Background(), 10, 1, 1), test.ShouldBeNil)
 		}()


### PR DESCRIPTION
## What changed
- skip some tests in `TestEncodedMotor`