### PR TITLE
[APP-4566] Tag 'latest' release with build timestamp

### DIFF
--- a/.github/workflows/staticbuild.yml
+++ b/.github/workflows/staticbuild.yml
@@ -73,10 +73,15 @@ jobs:
         parent: false
         gzip: false
 
+    - name: Set Date Version (Latest)
+      id: date_version
+      if: inputs.release_type == 'latest'
+      run: echo "date=`date +%Y%m%d%H%M%S`" >> $GITHUB_OUTPUT
+
     - name: Build (Latest)
       if: inputs.release_type == 'latest'
       run: |
-        sudo -Hu testbot bash -lc 'make RELEASE_TYPE="latest" BUILD_CHANNEL="${{date +%Y%m%d%H%M%S}}" static-release'
+        sudo -Hu testbot bash -lc 'make RELEASE_TYPE="latest" BUILD_CHANNEL="${{steps.date_version.outputs.date}}" static-release'
 
     - name: Build (Tagged)
       if: inputs.release_type == 'stable' || inputs.release_type == 'rc'

--- a/.github/workflows/staticbuild.yml
+++ b/.github/workflows/staticbuild.yml
@@ -16,8 +16,20 @@ on:
         required: true
 
 jobs:
+  build_timestamp:
+    name: Set Build Timestamp 
+    runs-on: ubuntu-latest
+    outputs:
+      date: ${{ steps.build_time.outputs.date }}
+    steps:
+    - name: Build Time
+      id: build_time
+      if: inputs.release_type == 'latest'
+      run: echo "date=`date +%Y%m%d%H%M%S`" >> $GITHUB_OUTPUT
+
   static:
     name: Antique Build
+    needs: build_timestamp
     strategy:
       fail-fast: false
       matrix:
@@ -73,15 +85,10 @@ jobs:
         parent: false
         gzip: false
 
-    - name: Set Date Version (Latest)
-      id: date_version
-      if: inputs.release_type == 'latest'
-      run: echo "date=`date +%Y%m%d%H%M%S`" >> $GITHUB_OUTPUT
-
     - name: Build (Latest)
       if: inputs.release_type == 'latest'
       run: |
-        sudo -Hu testbot bash -lc 'make RELEASE_TYPE="latest" BUILD_CHANNEL="${{steps.date_version.outputs.date}}" static-release'
+        sudo -Hu testbot bash -lc 'make RELEASE_TYPE="latest" BUILD_CHANNEL="${{needs.build_timestamp.outputs.date}}" static-release'
 
     - name: Build (Tagged)
       if: inputs.release_type == 'stable' || inputs.release_type == 'rc'

--- a/.github/workflows/staticbuild.yml
+++ b/.github/workflows/staticbuild.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Build (Latest)
       if: inputs.release_type == 'latest'
       run: |
-        sudo -Hu testbot bash -lc 'make BUILD_CHANNEL="latest" static-release'
+        sudo -Hu testbot bash -lc 'make RELEASE_TYPE="latest" BUILD_CHANNEL="${{date +%Y%m%d%H%M%S}}" static-release'
 
     - name: Build (Tagged)
       if: inputs.release_type == 'stable' || inputs.release_type == 'rc'

--- a/packaging.make
+++ b/packaging.make
@@ -43,8 +43,8 @@ static-release: server-static-compressed
 	rm -rf etc/packaging/static/deploy/
 	mkdir -p etc/packaging/static/deploy/
 	cp $(BIN_OUTPUT_PATH)/viam-server etc/packaging/static/deploy/viam-server-${BUILD_CHANNEL}-${UNAME_M}
-	if [ "${RELEASE_TYPE}" = "stable" ]; then \
-		cp $(BIN_OUTPUT_PATH)/viam-server etc/packaging/static/deploy/viam-server-stable-${UNAME_M}; \
+	if [ "${RELEASE_TYPE}" = "stable" || "${RELEASE_TYPE}" = "latest" ]; then \
+		cp $(BIN_OUTPUT_PATH)/viam-server etc/packaging/static/deploy/viam-server-${RELEASE_TYPE}-${UNAME_M}; \
 	fi
 	rm -rf etc/packaging/static/manifest/
 	mkdir -p etc/packaging/static/manifest/


### PR DESCRIPTION
Use a sortable key for latest viam-server build so we can enable users to configure latest as release channel in Viam Agent config.

[APP-4566](https://viam.atlassian.net/browse/APP-4566)

[APP-4566]: https://viam.atlassian.net/browse/APP-4566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ