### PR TITLE
RSDK-6925 better helpers for resource manager tests

### DIFF
--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
-
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	armpb "go.viam.com/api/component/arm/v1"

--- a/robot/impl/resource_manager_modular_test.go
+++ b/robot/impl/resource_manager_modular_test.go
@@ -49,8 +49,7 @@ func TestModularResources(t *testing.T) {
 			state:      make(map[resource.Name]bool),
 		}
 
-		r, err := New(context.Background(), &config.Config{}, logger)
-		test.That(t, err, test.ShouldBeNil)
+		r := setupLocalRobot(t, context.Background(), &config.Config{}, logger)
 		actualR := r.(*localRobot)
 		actualR.manager.moduleManager = mod
 
@@ -574,12 +573,7 @@ func TestTwoModulesSameName(t *testing.T) {
 		// duplicate module name, but still start up the first of the two modules.
 		DisablePartialStart: false,
 	}
-	r, err := New(ctx, cfg, logger)
-	test.That(t, r, test.ShouldNotBeNil)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, r.Close(ctx), test.ShouldBeNil)
-	}()
+	r := setupLocalRobot(t, ctx, cfg, logger)
 
 	rr, ok := r.(*localRobot)
 	test.That(t, ok, test.ShouldBeTrue)

--- a/robot/impl/resource_manager_modular_test.go
+++ b/robot/impl/resource_manager_modular_test.go
@@ -37,7 +37,9 @@ func TestModularResources(t *testing.T) {
 		svcModel = resource.ModelNamespace("acme").WithFamily("signage").WithModel("handheld")
 	)
 
-	setupTest := func(t *testing.T) (*localRobot, *dummyModMan, func()) {
+	setupTest := func(t *testing.T) (*localRobot, *dummyModMan) {
+		t.Helper()
+
 		logger := logging.NewTestLogger(t)
 		compAPISvc, err := resource.NewAPIResourceCollection[resource.Resource](compAPI, nil)
 		test.That(t, err, test.ShouldBeNil)
@@ -55,6 +57,9 @@ func TestModularResources(t *testing.T) {
 
 		resource.RegisterAPI(compAPI,
 			resource.APIRegistration[resource.Resource]{ReflectRPCServiceDesc: &desc.ServiceDescriptor{}})
+		t.Cleanup(func() {
+			resource.DeregisterAPI(compAPI)
+		})
 		resource.RegisterComponent(compAPI, compModel, resource.Registration[resource.Resource, resource.NoNativeConfig]{
 			Constructor: func(
 				ctx context.Context,
@@ -64,6 +69,9 @@ func TestModularResources(t *testing.T) {
 			) (resource.Resource, error) {
 				return mod.AddResource(ctx, conf, modmanager.DepsToNames(deps))
 			},
+		})
+		t.Cleanup(func() {
+			resource.Deregister(compAPI, compModel)
 		})
 		resource.RegisterComponent(compAPI, compModel2, resource.Registration[resource.Resource, resource.NoNativeConfig]{
 			Constructor: func(
@@ -75,9 +83,15 @@ func TestModularResources(t *testing.T) {
 				return mod.AddResource(ctx, conf, modmanager.DepsToNames(deps))
 			},
 		})
+		t.Cleanup(func() {
+			resource.Deregister(compAPI, compModel2)
+		})
 
 		resource.RegisterAPI(svcAPI,
 			resource.APIRegistration[resource.Resource]{ReflectRPCServiceDesc: &desc.ServiceDescriptor{}})
+		t.Cleanup(func() {
+			resource.DeregisterAPI(svcAPI)
+		})
 		resource.Register(svcAPI, svcModel, resource.Registration[resource.Resource, resource.NoNativeConfig]{
 			Constructor: func(
 				ctx context.Context,
@@ -88,21 +102,15 @@ func TestModularResources(t *testing.T) {
 				return mod.AddResource(ctx, conf, modmanager.DepsToNames(deps))
 			},
 		})
-
-		return actualR, mod, func() {
-			// deregister to not interfere with other tests or when test.count > 1
-			resource.Deregister(compAPI, compModel)
-			resource.Deregister(compAPI, compModel2)
+		t.Cleanup(func() {
 			resource.Deregister(svcAPI, svcModel)
-			resource.DeregisterAPI(compAPI)
-			resource.DeregisterAPI(svcAPI)
-			test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-		}
+		})
+
+		return actualR, mod
 	}
 
 	t.Run("process component", func(t *testing.T) {
-		r, mod, teardown := setupTest(t)
-		defer teardown()
+		r, mod := setupTest(t)
 
 		// modular
 		cfg := resource.Config{Name: "oneton", API: compAPI, Model: compModel, Attributes: utils.AttributeMap{"arg1": "one"}}
@@ -176,8 +184,7 @@ func TestModularResources(t *testing.T) {
 	})
 
 	t.Run("process service", func(t *testing.T) {
-		r, mod, teardown := setupTest(t)
-		defer teardown()
+		r, mod := setupTest(t)
 
 		// modular
 		cfg := resource.Config{
@@ -244,8 +251,7 @@ func TestModularResources(t *testing.T) {
 	})
 
 	t.Run("close", func(t *testing.T) {
-		r, mod, teardown := setupTest(t)
-		defer teardown()
+		r, mod := setupTest(t)
 
 		compCfg := resource.Config{Name: "oneton", API: compAPI, Model: compModel, Attributes: utils.AttributeMap{"arg1": "one"}}
 		_, err := compCfg.Validate("test", resource.APITypeComponentName)
@@ -287,8 +293,7 @@ func TestModularResources(t *testing.T) {
 	})
 
 	t.Run("builtin depends on previously removed but now added modular", func(t *testing.T) {
-		r, _, teardown := setupTest(t)
-		defer teardown()
+		r, _ := setupTest(t)
 
 		// modular we do not want
 		cfg := resource.Config{Name: "oneton2", API: compAPI, Model: compModel, Attributes: utils.AttributeMap{"arg1": "one"}}
@@ -344,8 +349,7 @@ func TestModularResources(t *testing.T) {
 	})
 
 	t.Run("change model", func(t *testing.T) {
-		r, _, teardown := setupTest(t)
-		defer teardown()
+		r, _ := setupTest(t)
 
 		cfg := resource.Config{Name: "oneton", API: compAPI, Model: compModel, Attributes: utils.AttributeMap{"arg1": "one"}}
 		_, err := cfg.Validate("test", resource.APITypeComponentName)

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -1845,20 +1845,3 @@ func managerForDummyRobot(t *testing.T, robot robot.Robot) *resourceManager {
 	}
 	return manager
 }
-
-func setupLocalRobot(
-	t *testing.T,
-	ctx context.Context,
-	cfg *config.Config,
-	logger logging.Logger,
-) robot.LocalRobot {
-	t.Helper()
-
-	r, err := New(ctx, cfg, logger)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, r, test.ShouldNotBeNil)
-	t.Cleanup(func() {
-		test.That(t, r.Close(ctx), test.ShouldBeNil)
-	})
-	return r
-}

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -184,10 +184,7 @@ func TestManagerForRemoteRobot(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	injectRobot := setupInjectRobot(logger)
 
-	manager := managerForDummyRobot(injectRobot)
-	defer func() {
-		test.That(t, manager.Close(context.Background()), test.ShouldBeNil)
-	}()
+	manager := managerForDummyRobot(t, injectRobot)
 
 	armNames := []resource.Name{arm.Named("arm1"), arm.Named("arm2")}
 	baseNames := []resource.Name{base.Named("base1"), base.Named("base2")}
@@ -249,19 +246,16 @@ func TestManagerMergeNamesWithRemotes(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	injectRobot := setupInjectRobot(logger)
 
-	manager := managerForDummyRobot(injectRobot)
-	defer func() {
-		test.That(t, manager.Close(context.Background()), test.ShouldBeNil)
-	}()
+	manager := managerForDummyRobot(t, injectRobot)
 	manager.addRemote(
 		context.Background(),
-		newDummyRobot(setupInjectRobot(logger)),
+		newDummyRobot(t, setupInjectRobot(logger)),
 		nil,
 		config.Remote{Name: "remote1"},
 	)
 	manager.addRemote(
 		context.Background(),
-		newDummyRobot(setupInjectRobot(logger)),
+		newDummyRobot(t, setupInjectRobot(logger)),
 		nil,
 		config.Remote{Name: "remote2"},
 	)
@@ -379,10 +373,7 @@ func TestManagerResourceRemoteName(t *testing.T) {
 	}
 	injectRobot.LoggerFunc = func() logging.Logger { return logger }
 
-	manager := managerForDummyRobot(injectRobot)
-	defer func() {
-		test.That(t, manager.Close(context.Background()), test.ShouldBeNil)
-	}()
+	manager := managerForDummyRobot(t, injectRobot)
 
 	injectRemote := &inject.Robot{}
 	injectRemote.ResourceNamesFunc = func() []resource.Name { return rdktestutils.AddSuffixes(armNames, "") }
@@ -393,7 +384,7 @@ func TestManagerResourceRemoteName(t *testing.T) {
 	injectRemote.LoggerFunc = func() logging.Logger { return logger }
 	manager.addRemote(
 		context.Background(),
-		newDummyRobot(injectRemote),
+		newDummyRobot(t, injectRemote),
 		nil,
 		config.Remote{Name: "remote1"},
 	)
@@ -414,19 +405,16 @@ func TestManagerWithSameNameInRemoteNoPrefix(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	injectRobot := setupInjectRobot(logger)
 
-	manager := managerForDummyRobot(injectRobot)
-	defer func() {
-		test.That(t, manager.Close(context.Background()), test.ShouldBeNil)
-	}()
+	manager := managerForDummyRobot(t, injectRobot)
 	manager.addRemote(
 		context.Background(),
-		newDummyRobot(setupInjectRobot(logger)),
+		newDummyRobot(t, setupInjectRobot(logger)),
 		nil,
 		config.Remote{Name: "remote1"},
 	)
 	manager.addRemote(
 		context.Background(),
-		newDummyRobot(setupInjectRobot(logger)),
+		newDummyRobot(t, setupInjectRobot(logger)),
 		nil,
 		config.Remote{Name: "remote2"},
 	)
@@ -441,13 +429,10 @@ func TestManagerWithSameNameInBaseAndRemote(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	injectRobot := setupInjectRobot(logger)
 
-	manager := managerForDummyRobot(injectRobot)
-	defer func() {
-		test.That(t, manager.Close(context.Background()), test.ShouldBeNil)
-	}()
+	manager := managerForDummyRobot(t, injectRobot)
 	manager.addRemote(
 		context.Background(),
-		newDummyRobot(setupInjectRobot(logger)),
+		newDummyRobot(t, setupInjectRobot(logger)),
 		nil,
 		config.Remote{Name: "remote1"},
 	)
@@ -740,17 +725,17 @@ func TestManagerNewComponent(t *testing.T) {
 func managerForTest(ctx context.Context, t *testing.T, l logging.Logger) *resourceManager {
 	t.Helper()
 	injectRobot := setupInjectRobot(l)
-	manager := managerForDummyRobot(injectRobot)
+	manager := managerForDummyRobot(t, injectRobot)
 
 	manager.addRemote(
 		context.Background(),
-		newDummyRobot(setupInjectRobot(l)),
+		newDummyRobot(t, setupInjectRobot(l)),
 		nil,
 		config.Remote{Name: "remote1"},
 	)
 	manager.addRemote(
 		context.Background(),
-		newDummyRobot(setupInjectRobot(l)),
+		newDummyRobot(t, setupInjectRobot(l)),
 		nil,
 		config.Remote{Name: "remote2"},
 	)
@@ -1421,10 +1406,7 @@ func TestManagerResourceRPCAPIs(t *testing.T) {
 		return nil, resource.NewNotFoundError(name)
 	}
 
-	manager := managerForDummyRobot(injectRobot)
-	defer func() {
-		test.That(t, manager.Close(context.Background()), test.ShouldBeNil)
-	}()
+	manager := managerForDummyRobot(t, injectRobot)
 
 	api1 := resource.APINamespace("acme").WithComponentType("huwat")
 	api2 := resource.APINamespace("acme").WithComponentType("wat")
@@ -1478,7 +1460,7 @@ func TestManagerResourceRPCAPIs(t *testing.T) {
 
 	manager.addRemote(
 		context.Background(),
-		newDummyRobot(injectRobotRemote1),
+		newDummyRobot(t, injectRobotRemote1),
 		nil,
 		config.Remote{Name: "remote1"},
 	)
@@ -1520,7 +1502,7 @@ func TestManagerResourceRPCAPIs(t *testing.T) {
 
 	manager.addRemote(
 		context.Background(),
-		newDummyRobot(injectRobotRemote2),
+		newDummyRobot(t, injectRobotRemote2),
 		nil,
 		config.Remote{Name: "remote2"},
 	)
@@ -1573,10 +1555,7 @@ func TestManagerEmptyResourceDesc(t *testing.T) {
 		return rdktestutils.NewUnimplementedResource(name), nil
 	}
 
-	manager := managerForDummyRobot(injectRobot)
-	defer func() {
-		test.That(t, manager.Close(context.Background()), test.ShouldBeNil)
-	}()
+	manager := managerForDummyRobot(t, injectRobot)
 
 	apis := manager.ResourceRPCAPIs()
 	test.That(t, apis, test.ShouldHaveLength, 0)
@@ -1618,10 +1597,7 @@ func TestReconfigure(t *testing.T) {
 		resource.Deregister(api, resource.DefaultServiceModel)
 	}()
 
-	manager := managerForDummyRobot(r)
-	defer func() {
-		test.That(t, manager.Close(ctx), test.ShouldBeNil)
-	}()
+	manager := managerForDummyRobot(t, r)
 
 	svc1 := resource.Config{
 		Name:  "somesvc",
@@ -1657,9 +1633,8 @@ func TestResourceCreationPanic(t *testing.T) {
 	r, err := New(ctx, &config.Config{}, logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	manager := managerForDummyRobot(r)
+	manager := managerForDummyRobot(t, r)
 	defer func() {
-		test.That(t, manager.Close(ctx), test.ShouldBeNil)
 		test.That(t, r.Close(ctx), test.ShouldBeNil)
 	}()
 
@@ -1749,8 +1724,10 @@ type dummyRobot struct {
 
 // newDummyRobot returns a new dummy robot wrapping a given robot.Robot
 // and its configuration.
-func newDummyRobot(robot robot.Robot) *dummyRobot {
-	remoteManager := managerForDummyRobot(robot)
+func newDummyRobot(t *testing.T, robot robot.Robot) *dummyRobot {
+	t.Helper()
+
+	remoteManager := managerForDummyRobot(t, robot)
 	remote := &dummyRobot{
 		Named:   resource.NewName(client.RemoteAPI, "something").AsNamed(),
 		robot:   robot,
@@ -1855,10 +1832,15 @@ func (rr *dummyRobot) StopAll(ctx context.Context, extra map[resource.Name]map[s
 	return rr.robot.StopAll(ctx, extra)
 }
 
-// managerForDummyRobot integrates all parts from a given robot
-// except for its remotes.
-func managerForDummyRobot(robot robot.Robot) *resourceManager {
+// managerForDummyRobot integrates all parts from a given robot except for its remotes.
+// It also close itself when the test and all subtests complete.
+func managerForDummyRobot(t *testing.T, robot robot.Robot) *resourceManager {
+	t.Helper()
+
 	manager := newResourceManager(resourceManagerOptions{}, robot.Logger().Sublogger("manager"))
+	t.Cleanup(func() {
+		test.That(t, manager.Close(context.Background()), test.ShouldBeNil)
+	})
 
 	// start a dummy module manager so calls to moduleManager.Provides() do not
 	// panic.
@@ -1871,7 +1853,7 @@ func managerForDummyRobot(robot robot.Robot) *resourceManager {
 			continue
 		}
 		gNode := resource.NewConfiguredGraphNode(resource.Config{}, res, unknownModel)
-		manager.resources.AddNode(name, gNode)
+		test.That(t, manager.resources.AddNode(name, gNode), test.ShouldBeNil)
 	}
 	return manager
 }

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -2222,10 +2222,6 @@ func TestSensorsServiceReconfigure(t *testing.T) {
 
 	t.Run("empty to two sensors", func(t *testing.T) {
 		robot := setupLocalRobot(t, context.Background(), emptyCfg, logger)
-		test.That(t, err, test.ShouldBeNil)
-		defer func() {
-			test.That(t, robot.Close(context.Background()), test.ShouldBeNil)
-		}()
 
 		svc, err := sensors.FromRobot(robot, resource.DefaultServiceName)
 		test.That(t, err, test.ShouldBeNil)
@@ -2243,10 +2239,6 @@ func TestSensorsServiceReconfigure(t *testing.T) {
 
 	t.Run("two sensors to empty", func(t *testing.T) {
 		robot := setupLocalRobot(t, context.Background(), cfg, logger)
-		test.That(t, err, test.ShouldBeNil)
-		defer func() {
-			test.That(t, robot.Close(context.Background()), test.ShouldBeNil)
-		}()
 
 		svc, err := sensors.FromRobot(robot, resource.DefaultServiceName)
 		test.That(t, err, test.ShouldBeNil)
@@ -2264,10 +2256,6 @@ func TestSensorsServiceReconfigure(t *testing.T) {
 
 	t.Run("two sensors to two sensors", func(t *testing.T) {
 		robot := setupLocalRobot(t, context.Background(), cfg, logger)
-		test.That(t, err, test.ShouldBeNil)
-		defer func() {
-			test.That(t, robot.Close(context.Background()), test.ShouldBeNil)
-		}()
 
 		svc, err := sensors.FromRobot(robot, resource.DefaultServiceName)
 		test.That(t, err, test.ShouldBeNil)
@@ -2603,8 +2591,8 @@ func TestStatusServiceUpdate(t *testing.T) {
 
 	emptyCfg, err := config.Read(context.Background(), "data/diff_config_empty.json", logger)
 	test.That(t, err, test.ShouldBeNil)
-	cfg, err := config.Read(context.Background(), "data/fake.json", logger)
-	test.That(t, err, test.ShouldBeNil)
+	cfg, cfgErr := config.Read(context.Background(), "data/fake.json", logger)
+	test.That(t, cfgErr, test.ShouldBeNil)
 
 	resourceNames := []resource.Name{
 		movementsensor.Named("movement_sensor1"),
@@ -2617,12 +2605,8 @@ func TestStatusServiceUpdate(t *testing.T) {
 
 	t.Run("empty to not empty", func(t *testing.T) {
 		robot := setupLocalRobot(t, context.Background(), emptyCfg, logger)
-		test.That(t, err, test.ShouldBeNil)
-		defer func() {
-			test.That(t, robot.Close(context.Background()), test.ShouldBeNil)
-		}()
 
-		_, err = robot.Status(context.Background(), resourceNames)
+		_, err := robot.Status(context.Background(), resourceNames)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "not found")
 
 		robot.Reconfigure(context.Background(), cfg)
@@ -2636,10 +2620,6 @@ func TestStatusServiceUpdate(t *testing.T) {
 
 	t.Run("not empty to empty", func(t *testing.T) {
 		robot := setupLocalRobot(t, context.Background(), cfg, logger)
-		test.That(t, err, test.ShouldBeNil)
-		defer func() {
-			test.That(t, robot.Close(context.Background()), test.ShouldBeNil)
-		}()
 
 		statuses, err := robot.Status(context.Background(), resourceNames)
 		test.That(t, err, test.ShouldBeNil)
@@ -2655,10 +2635,6 @@ func TestStatusServiceUpdate(t *testing.T) {
 
 	t.Run("no change", func(t *testing.T) {
 		robot := setupLocalRobot(t, context.Background(), cfg, logger)
-		test.That(t, err, test.ShouldBeNil)
-		defer func() {
-			test.That(t, robot.Close(context.Background()), test.ShouldBeNil)
-		}()
 
 		statuses, err := robot.Status(context.Background(), resourceNames)
 		test.That(t, err, test.ShouldBeNil)
@@ -2684,17 +2660,12 @@ func TestRemoteRobotsGold(t *testing.T) {
 	ctx := context.Background()
 
 	remote1 := setupLocalRobot(t, ctx, cfg, logger.Sublogger("remote1"))
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, remote1.Close(context.Background()), test.ShouldBeNil)
-	}()
 
 	options, _, addr1 := robottestutils.CreateBaseOptionsAndListener(t)
 	err = remote1.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
 	remote2 := setupLocalRobot(t, ctx, cfg, logger.Sublogger("remote2"))
-	test.That(t, err, test.ShouldBeNil)
 
 	options, listener2, addr2 := robottestutils.CreateBaseOptionsAndListener(t)
 
@@ -2732,10 +2703,6 @@ func TestRemoteRobotsGold(t *testing.T) {
 		},
 	}
 	r := setupLocalRobot(t, ctx, localConfig, logger.Sublogger("local"))
-	defer func() {
-		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-	}()
-	test.That(t, err, test.ShouldBeNil)
 	test.That(
 		t,
 		rdktestutils.NewResourceNameSet(r.ResourceNames()...),
@@ -2819,11 +2786,6 @@ func TestRemoteRobotsGold(t *testing.T) {
 	})
 
 	remote3 := setupLocalRobot(t, ctx, cfg, logger.Sublogger("remote3"))
-	test.That(t, err, test.ShouldBeNil)
-
-	defer func() {
-		test.That(t, remote3.Close(context.Background()), test.ShouldBeNil)
-	}()
 
 	// Note: There's a slight chance this test can fail if someone else
 	// claims the port we just released by closing the server.
@@ -2887,10 +2849,6 @@ func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
 		},
 	}
 	r := setupLocalRobot(t, ctx, localConfig, logger.Sublogger("local"))
-	defer func() {
-		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-	}()
-	test.That(t, err, test.ShouldBeNil)
 	test.That(
 		t,
 		rdktestutils.NewResourceNameSet(r.ResourceNames()...),
@@ -2944,11 +2902,6 @@ func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
 	})
 
 	foo2 := setupLocalRobot(t, ctx, fooCfg, logger.Sublogger("foo2"))
-	test.That(t, err, test.ShouldBeNil)
-
-	defer func() {
-		test.That(t, foo2.Close(context.Background()), test.ShouldBeNil)
-	}()
 
 	// Note: There's a slight chance this test can fail if someone else
 	// claims the port we just released by closing the server.
@@ -3112,10 +3065,6 @@ func TestInferRemoteRobotDependencyAmbiguous(t *testing.T) {
 		},
 	}
 	r := setupLocalRobot(t, ctx, localConfig, logger.Sublogger("local"))
-	defer func() {
-		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-	}()
-	test.That(t, err, test.ShouldBeNil)
 
 	expectedSet := rdktestutils.NewResourceNameSet(
 		motion.Named(resource.DefaultServiceName),

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -127,12 +127,7 @@ func TestRobotReconfigure(t *testing.T) {
 		conf1 := ConfigFromFile(t, "data/diff_config_1.json")
 
 		ctx := context.Background()
-		robot, err := New(ctx, conf1, logger)
-		test.That(t, err, test.ShouldBeNil)
-
-		defer func() {
-			test.That(t, robot.Close(context.Background()), test.ShouldBeNil)
-		}()
+		robot := setupLocalRobot(t, ctx, conf1, logger)
 
 		resources := robot.ResourceNames()
 		test.That(t, len(resources), test.ShouldEqual, 8)
@@ -219,7 +214,7 @@ func TestRobotReconfigure(t *testing.T) {
 			)...))
 		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
 
-		_, err = arm.FromRobot(robot, "arm1")
+		_, err := arm.FromRobot(robot, "arm1")
 		test.That(t, err, test.ShouldBeNil)
 
 		_, err = base.FromRobot(robot, "base1")
@@ -255,11 +250,7 @@ func TestRobotReconfigure(t *testing.T) {
 		logger := logging.NewTestLogger(t)
 		conf1 := ConfigFromFile(t, "data/diff_config_1.json")
 		conf3 := ConfigFromFile(t, "data/diff_config_4_bad.json")
-		robot, err := New(context.Background(), conf1, logger)
-		test.That(t, err, test.ShouldBeNil)
-		defer func() {
-			test.That(t, robot.Close(context.Background()), test.ShouldBeNil)
-		}()
+		robot := setupLocalRobot(t, context.Background(), conf1, logger)
 
 		armNames := []resource.Name{arm.Named("arm1")}
 		baseNames := []resource.Name{base.Named("base1")}
@@ -399,11 +390,7 @@ func TestRobotReconfigure(t *testing.T) {
 		logger := logging.NewTestLogger(t)
 		conf1 := ConfigFromFile(t, "data/diff_config_deps1.json")
 		conf2 := ConfigFromFile(t, "data/diff_config_deps10.json")
-		robot, err := New(context.Background(), conf1, logger)
-		test.That(t, err, test.ShouldBeNil)
-		defer func() {
-			test.That(t, robot.Close(context.Background()), test.ShouldBeNil)
-		}()
+		robot := setupLocalRobot(t, context.Background(), conf1, logger)
 
 		armNames := []resource.Name{arm.Named("arm1")}
 		baseNames := []resource.Name{base.Named("base1")}
@@ -492,7 +479,7 @@ func TestRobotReconfigure(t *testing.T) {
 			)...))
 		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
 
-		_, err = arm.FromRobot(robot, "arm1")
+		_, err := arm.FromRobot(robot, "arm1")
 		test.That(t, err, test.ShouldBeNil)
 
 		_, err = arm.FromRobot(robot, "arm2")
@@ -552,11 +539,8 @@ func TestRobotReconfigure(t *testing.T) {
 		logger := logging.NewTestLogger(t)
 		conf3 := ConfigFromFile(t, "data/diff_config_deps3.json")
 		conf2 := ConfigFromFile(t, "data/diff_config_deps2.json")
-		robot, err := New(context.Background(), conf3, logger)
-		test.That(t, err, test.ShouldBeNil)
-		defer func() {
-			test.That(t, robot.Close(context.Background()), test.ShouldBeNil)
-		}()
+		robot := setupLocalRobot(t, context.Background(), conf3, logger)
+
 		armNames := []resource.Name{arm.Named("arm1"), arm.Named("arm2")}
 		baseNames := []resource.Name{base.Named("base1"), base.Named("base2")}
 		motorNames := []resource.Name{motor.Named("m1"), motor.Named("m2"), motor.Named("m3"), motor.Named("m4")}
@@ -715,11 +699,8 @@ func TestRobotReconfigure(t *testing.T) {
 		logger := logging.NewTestLogger(t)
 		conf2 := ConfigFromFile(t, "data/diff_config_deps2.json")
 		conf4 := ConfigFromFile(t, "data/diff_config_deps4.json")
-		robot, err := New(context.Background(), conf2, logger)
-		test.That(t, err, test.ShouldBeNil)
-		defer func() {
-			test.That(t, robot.Close(context.Background()), test.ShouldBeNil)
-		}()
+		robot := setupLocalRobot(t, context.Background(), conf2, logger)
+
 		armNames := []resource.Name{arm.Named("arm1"), arm.Named("arm2")}
 		baseNames := []resource.Name{base.Named("base1"), base.Named("base2")}
 		motorNames := []resource.Name{motor.Named("m1"), motor.Named("m2"), motor.Named("m3"), motor.Named("m4")}
@@ -856,11 +837,8 @@ func TestRobotReconfigure(t *testing.T) {
 		logger := logging.NewTestLogger(t)
 		conf2 := ConfigFromFile(t, "data/diff_config_deps2.json")
 		conf6 := ConfigFromFile(t, "data/diff_config_deps6.json")
-		robot, err := New(context.Background(), conf2, logger)
-		test.That(t, err, test.ShouldBeNil)
-		defer func() {
-			test.That(t, robot.Close(context.Background()), test.ShouldBeNil)
-		}()
+		robot := setupLocalRobot(t, context.Background(), conf2, logger)
+
 		armNames := []resource.Name{arm.Named("arm1"), arm.Named("arm2")}
 		baseNames := []resource.Name{base.Named("base1"), base.Named("base2")}
 		motorNames := []resource.Name{motor.Named("m1"), motor.Named("m2"), motor.Named("m3"), motor.Named("m4")}
@@ -1042,11 +1020,7 @@ func TestRobotReconfigure(t *testing.T) {
 		cempty := ConfigFromFile(t, "data/diff_config_empty.json")
 		conf6 := ConfigFromFile(t, "data/diff_config_deps6.json")
 		ctx := context.Background()
-		robot, err := New(ctx, cempty, logger)
-		test.That(t, err, test.ShouldBeNil)
-		defer func() {
-			test.That(t, robot.Close(context.Background()), test.ShouldBeNil)
-		}()
+		robot := setupLocalRobot(t, ctx, cempty, logger)
 
 		resources := robot.ResourceNames()
 		test.That(t, len(resources), test.ShouldEqual, 3)
@@ -1112,7 +1086,7 @@ func TestRobotReconfigure(t *testing.T) {
 			)...))
 		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
 
-		_, err = arm.FromRobot(robot, "arm1")
+		_, err := arm.FromRobot(robot, "arm1")
 		test.That(t, err, test.ShouldBeNil)
 
 		_, err = arm.FromRobot(robot, "arm3")
@@ -1182,11 +1156,8 @@ func TestRobotReconfigure(t *testing.T) {
 		logger := logging.NewTestLogger(t)
 		conf4 := ConfigFromFile(t, "data/diff_config_deps4.json")
 		conf7 := ConfigFromFile(t, "data/diff_config_deps7.json")
-		robot, err := New(context.Background(), conf4, logger)
-		test.That(t, err, test.ShouldBeNil)
-		defer func() {
-			test.That(t, robot.Close(context.Background()), test.ShouldBeNil)
-		}()
+		robot := setupLocalRobot(t, context.Background(), conf4, logger)
+
 		boardNames := []resource.Name{board.Named("board1"), board.Named("board2")}
 		test.That(t, utils.NewStringSet(robot.RemoteNames()...), test.ShouldBeEmpty)
 		test.That(
@@ -1221,7 +1192,7 @@ func TestRobotReconfigure(t *testing.T) {
 			)...))
 		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
 
-		_, err = arm.FromRobot(robot, "arm1")
+		_, err := arm.FromRobot(robot, "arm1")
 		test.That(t, err, test.ShouldNotBeNil)
 
 		_, err = arm.FromRobot(robot, "arm2")
@@ -1382,11 +1353,8 @@ func TestRobotReconfigure(t *testing.T) {
 		logger := logging.NewTestLogger(t)
 		conf7 := ConfigFromFile(t, "data/diff_config_deps7.json")
 		conf8 := ConfigFromFile(t, "data/diff_config_deps8.json")
-		robot, err := New(context.Background(), conf7, logger)
-		test.That(t, err, test.ShouldBeNil)
-		defer func() {
-			test.That(t, robot.Close(context.Background()), test.ShouldBeNil)
-		}()
+		robot := setupLocalRobot(t, context.Background(), conf7, logger)
+
 		boardNames := []resource.Name{board.Named("board1"), board.Named("board2")}
 		motorNames := []resource.Name{motor.Named("m1")}
 		encoderNames := []resource.Name{encoder.Named("e1")}
@@ -1437,7 +1405,7 @@ func TestRobotReconfigure(t *testing.T) {
 			)...))
 		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
 
-		_, err = arm.FromRobot(robot, "arm1")
+		_, err := arm.FromRobot(robot, "arm1")
 		test.That(t, err, test.ShouldNotBeNil)
 
 		_, err = arm.FromRobot(robot, "arm2")
@@ -1650,11 +1618,8 @@ func TestRobotReconfigure(t *testing.T) {
 		logger := logging.NewTestLogger(t)
 		conf7 := ConfigFromFile(t, "data/diff_config_deps7.json")
 		conf9 := ConfigFromFile(t, "data/diff_config_deps9_bad.json")
-		robot, err := New(context.Background(), conf7, logger)
-		test.That(t, err, test.ShouldBeNil)
-		defer func() {
-			test.That(t, robot.Close(context.Background()), test.ShouldBeNil)
-		}()
+		robot := setupLocalRobot(t, context.Background(), conf7, logger)
+
 		boardNames := []resource.Name{board.Named("board1"), board.Named("board2")}
 		motorNames := []resource.Name{motor.Named("m1")}
 		encoderNames := []resource.Name{encoder.Named("e1")}
@@ -2028,11 +1993,7 @@ func TestRobotReconfigure(t *testing.T) {
 		logger := logging.NewTestLogger(t)
 		conf1 := ConfigFromFile(t, "data/diff_config_deps11.json")
 		conf2 := ConfigFromFile(t, "data/diff_config_deps12.json")
-		robot, err := New(context.Background(), conf1, logger)
-		test.That(t, err, test.ShouldBeNil)
-		defer func() {
-			test.That(t, robot.Close(context.Background()), test.ShouldBeNil)
-		}()
+		robot := setupLocalRobot(t, context.Background(), conf1, logger)
 
 		armNames := []resource.Name{arm.Named("mock7")}
 		mockNames := []resource.Name{
@@ -2053,7 +2014,7 @@ func TestRobotReconfigure(t *testing.T) {
 				resource.DefaultServices(),
 				mockNames,
 			)...))
-		_, err = robot.ResourceByName(mockNamed("mock1"))
+		_, err := robot.ResourceByName(mockNamed("mock1"))
 		test.That(t, err, test.ShouldNotBeNil)
 		_, err = arm.FromRobot(robot, "mock7")
 		test.That(t, err, test.ShouldBeNil)
@@ -2081,11 +2042,8 @@ func TestRobotReconfigure(t *testing.T) {
 		resetComponentFailureState()
 		logger := logging.NewTestLogger(t)
 		tempDir := t.TempDir()
-		robot, err := New(context.Background(), &config.Config{}, logger)
-		test.That(t, err, test.ShouldBeNil)
-		defer func() {
-			test.That(t, robot.Close(context.Background()), test.ShouldBeNil)
-		}()
+		robot := setupLocalRobot(t, context.Background(), &config.Config{}, logger)
+
 		// create a unexecutable file
 		noExecF, err := os.CreateTemp(tempDir, "noexec*.sh")
 		test.That(t, err, test.ShouldBeNil)
@@ -2263,7 +2221,7 @@ func TestSensorsServiceReconfigure(t *testing.T) {
 	sensorNames := []resource.Name{movementsensor.Named("movement_sensor1"), movementsensor.Named("movement_sensor2")}
 
 	t.Run("empty to two sensors", func(t *testing.T) {
-		robot, err := New(context.Background(), emptyCfg, logger)
+		robot := setupLocalRobot(t, context.Background(), emptyCfg, logger)
 		test.That(t, err, test.ShouldBeNil)
 		defer func() {
 			test.That(t, robot.Close(context.Background()), test.ShouldBeNil)
@@ -2284,7 +2242,7 @@ func TestSensorsServiceReconfigure(t *testing.T) {
 	})
 
 	t.Run("two sensors to empty", func(t *testing.T) {
-		robot, err := New(context.Background(), cfg, logger)
+		robot := setupLocalRobot(t, context.Background(), cfg, logger)
 		test.That(t, err, test.ShouldBeNil)
 		defer func() {
 			test.That(t, robot.Close(context.Background()), test.ShouldBeNil)
@@ -2305,7 +2263,7 @@ func TestSensorsServiceReconfigure(t *testing.T) {
 	})
 
 	t.Run("two sensors to two sensors", func(t *testing.T) {
-		robot, err := New(context.Background(), cfg, logger)
+		robot := setupLocalRobot(t, context.Background(), cfg, logger)
 		test.That(t, err, test.ShouldBeNil)
 		defer func() {
 			test.That(t, robot.Close(context.Background()), test.ShouldBeNil)
@@ -2374,11 +2332,7 @@ func TestUpdateWeakDependents(t *testing.T) {
 	var emptyCfg config.Config
 	test.That(t, emptyCfg.Ensure(false, logger), test.ShouldBeNil)
 
-	robot, err := New(context.Background(), &emptyCfg, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, robot.Close(context.Background()), test.ShouldBeNil)
-	}()
+	robot := setupLocalRobot(t, context.Background(), &emptyCfg, logger)
 
 	// Register a `Resource` that generates weak dependencies. Specifically instance of
 	// this resource will depend on every `component` resource. See the definition of
@@ -2424,7 +2378,7 @@ func TestUpdateWeakDependents(t *testing.T) {
 	test.That(t, weakCfg1.Ensure(false, logger), test.ShouldBeNil)
 	robot.Reconfigure(context.Background(), &weakCfg1)
 
-	_, err = robot.ResourceByName(weak1Name)
+	_, err := robot.ResourceByName(weak1Name)
 	test.That(t, err, test.ShouldNotBeNil)
 	// Assert that the explicit dependency was observed.
 	test.That(t, err.Error(), test.ShouldContainSubstring, "unresolved dependencies")
@@ -2609,11 +2563,7 @@ func TestDefaultServiceReconfigure(t *testing.T) {
 			},
 		},
 	}
-	robot, err := New(context.Background(), cfg1, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, robot.Close(context.Background()), test.ShouldBeNil)
-	}()
+	robot := setupLocalRobot(t, context.Background(), cfg1, logger)
 
 	test.That(
 		t,
@@ -2666,7 +2616,7 @@ func TestStatusServiceUpdate(t *testing.T) {
 	}
 
 	t.Run("empty to not empty", func(t *testing.T) {
-		robot, err := New(context.Background(), emptyCfg, logger)
+		robot := setupLocalRobot(t, context.Background(), emptyCfg, logger)
 		test.That(t, err, test.ShouldBeNil)
 		defer func() {
 			test.That(t, robot.Close(context.Background()), test.ShouldBeNil)
@@ -2685,7 +2635,7 @@ func TestStatusServiceUpdate(t *testing.T) {
 	})
 
 	t.Run("not empty to empty", func(t *testing.T) {
-		robot, err := New(context.Background(), cfg, logger)
+		robot := setupLocalRobot(t, context.Background(), cfg, logger)
 		test.That(t, err, test.ShouldBeNil)
 		defer func() {
 			test.That(t, robot.Close(context.Background()), test.ShouldBeNil)
@@ -2704,7 +2654,7 @@ func TestStatusServiceUpdate(t *testing.T) {
 	})
 
 	t.Run("no change", func(t *testing.T) {
-		robot, err := New(context.Background(), cfg, logger)
+		robot := setupLocalRobot(t, context.Background(), cfg, logger)
 		test.That(t, err, test.ShouldBeNil)
 		defer func() {
 			test.That(t, robot.Close(context.Background()), test.ShouldBeNil)
@@ -2733,7 +2683,7 @@ func TestRemoteRobotsGold(t *testing.T) {
 
 	ctx := context.Background()
 
-	remote1, err := New(ctx, cfg, logger.Sublogger("remote1"))
+	remote1 := setupLocalRobot(t, ctx, cfg, logger.Sublogger("remote1"))
 	test.That(t, err, test.ShouldBeNil)
 	defer func() {
 		test.That(t, remote1.Close(context.Background()), test.ShouldBeNil)
@@ -2743,7 +2693,7 @@ func TestRemoteRobotsGold(t *testing.T) {
 	err = remote1.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
-	remote2, err := New(ctx, cfg, logger.Sublogger("remote2"))
+	remote2 := setupLocalRobot(t, ctx, cfg, logger.Sublogger("remote2"))
 	test.That(t, err, test.ShouldBeNil)
 
 	options, listener2, addr2 := robottestutils.CreateBaseOptionsAndListener(t)
@@ -2781,7 +2731,7 @@ func TestRemoteRobotsGold(t *testing.T) {
 			},
 		},
 	}
-	r, err := New(ctx, localConfig, logger.Sublogger("local"))
+	r := setupLocalRobot(t, ctx, localConfig, logger.Sublogger("local"))
 	defer func() {
 		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
 	}()
@@ -2868,7 +2818,7 @@ func TestRemoteRobotsGold(t *testing.T) {
 		)
 	})
 
-	remote3, err := New(ctx, cfg, logger.Sublogger("remote3"))
+	remote3 := setupLocalRobot(t, ctx, cfg, logger.Sublogger("remote3"))
 	test.That(t, err, test.ShouldBeNil)
 
 	defer func() {
@@ -2911,11 +2861,10 @@ func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
 
 	ctx := context.Background()
 
-	foo, err := New(ctx, fooCfg, logger.Sublogger("foo"))
-	test.That(t, err, test.ShouldBeNil)
+	foo := setupLocalRobot(t, ctx, fooCfg, logger.Sublogger("foo"))
 
 	options, listener1, addr1 := robottestutils.CreateBaseOptionsAndListener(t)
-	err = foo.StartWeb(ctx, options)
+	err := foo.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
 	localConfig := &config.Config{
@@ -2937,7 +2886,7 @@ func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
 			},
 		},
 	}
-	r, err := New(ctx, localConfig, logger.Sublogger("local"))
+	r := setupLocalRobot(t, ctx, localConfig, logger.Sublogger("local"))
 	defer func() {
 		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
 	}()
@@ -2994,7 +2943,7 @@ func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
 		)
 	})
 
-	foo2, err := New(ctx, fooCfg, logger.Sublogger("foo2"))
+	foo2 := setupLocalRobot(t, ctx, fooCfg, logger.Sublogger("foo2"))
 	test.That(t, err, test.ShouldBeNil)
 
 	defer func() {
@@ -3037,8 +2986,7 @@ func TestInferRemoteRobotDependencyConnectAfterStartup(t *testing.T) {
 
 	ctx := context.Background()
 
-	foo, err := New(ctx, fooCfg, logger.Sublogger("foo"))
-	test.That(t, err, test.ShouldBeNil)
+	foo := setupLocalRobot(t, ctx, fooCfg, logger.Sublogger("foo"))
 
 	options, _, addr1 := robottestutils.CreateBaseOptionsAndListener(t)
 
@@ -3061,11 +3009,7 @@ func TestInferRemoteRobotDependencyConnectAfterStartup(t *testing.T) {
 			},
 		},
 	}
-	r, err := New(ctx, localConfig, logger.Sublogger("local"))
-	defer func() {
-		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-	}()
-	test.That(t, err, test.ShouldBeNil)
+	r := setupLocalRobot(t, ctx, localConfig, logger.Sublogger("local"))
 	test.That(
 		t,
 		rdktestutils.NewResourceNameSet(r.ResourceNames()...),
@@ -3076,7 +3020,7 @@ func TestInferRemoteRobotDependencyConnectAfterStartup(t *testing.T) {
 			datamanager.Named(resource.DefaultServiceName),
 		),
 	)
-	err = foo.StartWeb(ctx, options)
+	err := foo.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
 	rr, ok := r.(*localRobot)
@@ -3133,20 +3077,11 @@ func TestInferRemoteRobotDependencyAmbiguous(t *testing.T) {
 
 	ctx := context.Background()
 
-	foo, err := New(ctx, remoteCfg, logger.Sublogger("foo"))
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, foo.Close(context.Background()), test.ShouldBeNil)
-	}()
-
-	bar, err := New(ctx, remoteCfg, logger.Sublogger("bar"))
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, bar.Close(context.Background()), test.ShouldBeNil)
-	}()
+	foo := setupLocalRobot(t, ctx, remoteCfg, logger.Sublogger("foo"))
+	bar := setupLocalRobot(t, ctx, remoteCfg, logger.Sublogger("bar"))
 
 	options1, _, addr1 := robottestutils.CreateBaseOptionsAndListener(t)
-	err = foo.StartWeb(ctx, options1)
+	err := foo.StartWeb(ctx, options1)
 	test.That(t, err, test.ShouldBeNil)
 
 	options2, _, addr2 := robottestutils.CreateBaseOptionsAndListener(t)
@@ -3176,7 +3111,7 @@ func TestInferRemoteRobotDependencyAmbiguous(t *testing.T) {
 			},
 		},
 	}
-	r, err := New(ctx, localConfig, logger.Sublogger("local"))
+	r := setupLocalRobot(t, ctx, localConfig, logger.Sublogger("local"))
 	defer func() {
 		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
 	}()
@@ -3289,11 +3224,7 @@ func TestReconfigureModelRebuild(t *testing.T) {
 
 	ctx := context.Background()
 
-	r, err := New(ctx, cfg, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-	}()
+	r := setupLocalRobot(t, ctx, cfg, logger)
 
 	name1 := mockNamed("one")
 	res1, err := r.ResourceByName(name1)
@@ -3381,11 +3312,7 @@ func TestReconfigureModelSwitch(t *testing.T) {
 
 	ctx := context.Background()
 
-	r, err := New(ctx, cfg, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-	}()
+	r := setupLocalRobot(t, ctx, cfg, logger)
 
 	name1 := mockNamed("one")
 	res1, err := r.ResourceByName(name1)
@@ -3460,12 +3387,8 @@ func TestReconfigureModelSwitchErr(t *testing.T) {
 
 	ctx := context.Background()
 
-	r, err := New(ctx, cfg, logger)
-	test.That(t, err, test.ShouldBeNil)
+	r := setupLocalRobot(t, ctx, cfg, logger)
 	test.That(t, newCount, test.ShouldEqual, 1)
-	defer func() {
-		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-	}()
 
 	name1 := mockNamed("one")
 	res1, err := r.ResourceByName(name1)
@@ -3547,11 +3470,7 @@ func TestReconfigureRename(t *testing.T) {
 
 	ctx := context.Background()
 
-	r, err := New(ctx, cfg, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-	}()
+	r := setupLocalRobot(t, ctx, cfg, logger)
 
 	name1 := mockNamed("one")
 	name2 := mockNamed("two")
@@ -3634,14 +3553,12 @@ func TestResourceConstructTimeout(t *testing.T) {
 				test.ShouldBeNil)
 		}()
 
-		r, err := New(context.Background(), cfg, logger)
-		test.That(t, err, test.ShouldBeNil)
+		r := setupLocalRobot(t, context.Background(), cfg, logger)
 		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
 	})
 	t.Run("reconfigure", func(t *testing.T) {
 		timeout = rutils.DefaultResourceConfigurationTimeout
-		r, err := New(context.Background(), cfg, logger)
-		test.That(t, err, test.ShouldBeNil)
+		r := setupLocalRobot(t, context.Background(), cfg, logger)
 
 		timeout = 200 * time.Millisecond
 		test.That(t, os.Setenv(rutils.ResourceConfigurationTimeoutEnvVar, timeout.String()),
@@ -3672,7 +3589,6 @@ func TestResourceConstructTimeout(t *testing.T) {
 		}
 
 		r.Reconfigure(context.Background(), newCfg)
-		test.That(t, err, test.ShouldBeNil)
 		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
 	})
 }
@@ -3730,8 +3646,7 @@ func TestResourceConstructCtxCancel(t *testing.T) {
 		contructCount = 0
 		ctxWithCancel, cancel := context.WithCancel(context.Background())
 		cFunc.c = cancel
-		r, err := New(ctxWithCancel, cfg, logger)
-		test.That(t, err, test.ShouldBeNil)
+		r := setupLocalRobot(t, ctxWithCancel, cfg, logger)
 		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
 
 		wg.Wait()
@@ -3739,14 +3654,12 @@ func TestResourceConstructCtxCancel(t *testing.T) {
 	})
 	t.Run("reconfigure", func(t *testing.T) {
 		contructCount = 0
-		r, err := New(context.Background(), &config.Config{}, logger)
-		test.That(t, err, test.ShouldBeNil)
+		r := setupLocalRobot(t, context.Background(), &config.Config{}, logger)
 		test.That(t, contructCount, test.ShouldEqual, 0)
 
 		ctxWithCancel, cancel := context.WithCancel(context.Background())
 		cFunc.c = cancel
 		r.Reconfigure(ctxWithCancel, cfg)
-		test.That(t, err, test.ShouldBeNil)
 		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
 
 		wg.Wait()
@@ -3785,8 +3698,7 @@ func TestResourceCloseNoHang(t *testing.T) {
 			},
 		},
 	}
-	r, err := New(context.Background(), cfg, logger)
-	test.That(t, err, test.ShouldBeNil)
+	r := setupLocalRobot(t, context.Background(), cfg, logger)
 
 	test.That(t, r.Close(context.Background()), test.ShouldBeNil)
 	test.That(t, mf.closeCtxDeadline, test.ShouldNotBeNil)

--- a/robot/impl/utils.go
+++ b/robot/impl/utils.go
@@ -1,0 +1,31 @@
+package robotimpl
+
+import (
+	"context"
+	"testing"
+
+	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/robot"
+	"go.viam.com/test"
+)
+
+// TODO: this duplicates robotimpltest.LocalRobot
+//
+//revive:disable-next-line:context-as-argument
+func setupLocalRobot(
+	t *testing.T,
+	ctx context.Context,
+	cfg *config.Config,
+	logger logging.Logger,
+) robot.LocalRobot {
+	t.Helper()
+
+	r, err := New(ctx, cfg, logger)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, r, test.ShouldNotBeNil)
+	t.Cleanup(func() {
+		test.That(t, r.Close(ctx), test.ShouldBeNil)
+	})
+	return r
+}

--- a/robot/impl/utils.go
+++ b/robot/impl/utils.go
@@ -11,10 +11,10 @@ import (
 	"go.viam.com/rdk/robot"
 )
 
-// TODO: this duplicates `robotimpltest.LocalRobot` for tests that are in the `robotimpl`
-// package. Importing `robotimpl.LocalRobot` for those tests creates a circular import,
-// and changing those tests to be in the `robotimpl_test` package causes failures because
-// they test private methods.
+// TODO(RSDK-7299): This function duplicates `robotimpltest.LocalRobot` for tests that
+// are in the `robotimpl` package. Importing `robotimpl.LocalRobot` for those tests
+// creates a circular import, and changing those tests to be in the `robotimpl_test`
+// package causes failures because they test private methods.
 func setupLocalRobot(
 	t *testing.T,
 	ctx context.Context,

--- a/robot/impl/utils.go
+++ b/robot/impl/utils.go
@@ -10,7 +10,10 @@ import (
 	"go.viam.com/test"
 )
 
-// TODO: this duplicates robotimpltest.LocalRobot
+// TODO: this duplicates `robotimpltest.LocalRobot` for tests that are in the `robotimpl`
+// package. Importing `robotimpl.LocalRobot` for those tests creates a circular import,
+// and changing those tests to be in the `robotimpl_test` package causes failures because
+// they test private methods.
 //
 //revive:disable-next-line:context-as-argument
 func setupLocalRobot(

--- a/robot/impl/utils.go
+++ b/robot/impl/utils.go
@@ -15,8 +15,6 @@ import (
 // package. Importing `robotimpl.LocalRobot` for those tests creates a circular import,
 // and changing those tests to be in the `robotimpl_test` package causes failures because
 // they test private methods.
-//
-//nolint:revive
 func setupLocalRobot(
 	t *testing.T,
 	ctx context.Context,

--- a/robot/impl/utils.go
+++ b/robot/impl/utils.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"go.viam.com/test"
+
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/robot"
-	"go.viam.com/test"
 )
 
 // TODO: this duplicates `robotimpltest.LocalRobot` for tests that are in the `robotimpl`
@@ -15,7 +16,7 @@ import (
 // and changing those tests to be in the `robotimpl_test` package causes failures because
 // they test private methods.
 //
-//revive:disable-next-line:context-as-argument
+//nolint:revive
 func setupLocalRobot(
 	t *testing.T,
 	ctx context.Context,

--- a/robot/impltest/local_robot.go
+++ b/robot/impltest/local_robot.go
@@ -16,8 +16,6 @@ import (
 // LocalRobot returns a new robot with parts sourced from the given config, or fails the
 // test if it cannot. It automatically closes itself after the test and all subtests
 // complete.
-//
-//nolint:revive
 func LocalRobot(
 	t *testing.T,
 	ctx context.Context,

--- a/robot/impltest/local_robot.go
+++ b/robot/impltest/local_robot.go
@@ -1,21 +1,23 @@
+// Package robotimpltest contains utilities for testing robotimpl functionality
 package robotimpltest
 
 import (
 	"context"
 	"testing"
 
+	"go.viam.com/test"
+
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/robot"
 	robotimpl "go.viam.com/rdk/robot/impl"
-	"go.viam.com/test"
 )
 
 // LocalRobot returns a new robot with parts sourced from the given config, or fails the
 // test if it cannot. It automatically closes itself after the test and all subtests
 // complete.
 //
-//revive:disable-next-line:context-as-argument
+//nolint:revive
 func LocalRobot(
 	t *testing.T,
 	ctx context.Context,

--- a/robot/impltest/local_robot.go
+++ b/robot/impltest/local_robot.go
@@ -1,0 +1,34 @@
+package robotimpltest
+
+import (
+	"context"
+	"testing"
+
+	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/robot"
+	robotimpl "go.viam.com/rdk/robot/impl"
+	"go.viam.com/test"
+)
+
+// LocalRobot returns a new robot with parts sourced from the given config, or fails the
+// test if it cannot. It automatically closes itself after the test and all subtests
+// complete.
+//
+//revive:disable-next-line:context-as-argument
+func LocalRobot(
+	t *testing.T,
+	ctx context.Context,
+	cfg *config.Config,
+	logger logging.Logger,
+) robot.LocalRobot {
+	t.Helper()
+
+	r, err := robotimpl.New(ctx, cfg, logger)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, r, test.ShouldNotBeNil)
+	t.Cleanup(func() {
+		test.That(t, r.Close(ctx), test.ShouldBeNil)
+	})
+	return r
+}


### PR DESCRIPTION
Adds a test helper version of [robotimpl.New](https://pkg.go.dev/go.viam.com/rdk/robot/impl#New), which creates a local robot and automatically closes itself, and also fails tests on any failure. This fairly small helper ends up eliminating a lot of boilerplate code.

In addition, this PR also converts `defer` calls in test helpers to use [T.Cleanup](https://pkg.go.dev/testing#T.Cleanup) instead.

* [x] Depends on: https://github.com/viamrobotics/rdk/pull/3800