### PR TITLE
RSDK-6810: Hack to add DoCommand for sensors and cameras

### DIFF
--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/remote-control",
-      "version": "0.24.0",
+      "version": "0.24.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@improbable-eng/grpc-web": "0.15.0",

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/web/frontend/src/api/do-command.ts
+++ b/web/frontend/src/api/do-command.ts
@@ -1,4 +1,5 @@
 import {
+  CameraClient,
   commonApi,
   doCommandFromClient,
   SensorClient,
@@ -29,7 +30,7 @@ export interface DoCommandClient {
 }
 
 export const doCommand = async (
-  client: DoCommandClient | SensorClient,
+  client: DoCommandClient | SensorClient | CameraClient,
   name: string,
   command: string
 ) => {
@@ -43,7 +44,7 @@ export const doCommand = async (
   });
 
   // TODO(RSDK-7272): Figure out long-term solution for DoCommand in RC
-  if (client instanceof SensorClient) {
+  if (client instanceof SensorClient || client instanceof CameraClient) {
     return client.doCommand(parsedCommand);
   }
   return doCommandFromClient(client, name, parsedCommand);

--- a/web/frontend/src/api/do-command.ts
+++ b/web/frontend/src/api/do-command.ts
@@ -1,6 +1,7 @@
 import {
   commonApi,
   doCommandFromClient,
+  SensorClient,
   type ServiceError,
   type StructType,
 } from '@viamrobotics/sdk';
@@ -28,7 +29,7 @@ export interface DoCommandClient {
 }
 
 export const doCommand = async (
-  client: DoCommandClient,
+  client: DoCommandClient | SensorClient,
   name: string,
   command: string
 ) => {
@@ -41,5 +42,9 @@ export const doCommand = async (
     command: parsedCommand,
   });
 
+  // TODO(RSDK-7272): Figure out long-term solution for DoCommand in RC
+  if (client instanceof SensorClient) {
+    return client.doCommand(parsedCommand);
+  }
   return doCommandFromClient(client, name, parsedCommand);
 };

--- a/web/frontend/src/components/do-command/get-client-by-type.ts
+++ b/web/frontend/src/components/do-command/get-client-by-type.ts
@@ -1,4 +1,4 @@
-import type { RobotClient } from '@viamrobotics/sdk';
+import { SensorClient, type RobotClient } from '@viamrobotics/sdk';
 
 const CLIENT_TYPES = {
   arm: 'armService',
@@ -20,10 +20,19 @@ const CLIENT_TYPES = {
   vision: 'visionService',
 } as const;
 
-export const getClientByType = (robotClient: RobotClient, type: string) => {
-  if (!Object.hasOwn(CLIENT_TYPES, type)) {
-    return null;
+export const getClientByType = (
+  robotClient: RobotClient,
+  type: string,
+  name: string
+) => {
+  if (Object.hasOwn(CLIENT_TYPES, type)) {
+    return robotClient[CLIENT_TYPES[type as keyof typeof CLIENT_TYPES]];
   }
 
-  return robotClient[CLIENT_TYPES[type as keyof typeof CLIENT_TYPES]];
+  // TODO(RSDK-7272): Figure out long-term solution for DoCommand in RC
+  if (type === 'sensor') {
+    return new SensorClient(robotClient, name);
+  }
+
+  return null;
 };

--- a/web/frontend/src/components/do-command/get-client-by-type.ts
+++ b/web/frontend/src/components/do-command/get-client-by-type.ts
@@ -1,4 +1,8 @@
-import { SensorClient, type RobotClient } from '@viamrobotics/sdk';
+import {
+  SensorClient,
+  type RobotClient,
+  CameraClient,
+} from '@viamrobotics/sdk';
 
 const CLIENT_TYPES = {
   arm: 'armService',
@@ -32,6 +36,8 @@ export const getClientByType = (
   // TODO(RSDK-7272): Figure out long-term solution for DoCommand in RC
   if (type === 'sensor') {
     return new SensorClient(robotClient, name);
+  } else if (type === 'camera') {
+    return new CameraClient(robotClient, name);
   }
 
   return null;

--- a/web/frontend/src/components/do-command/index.svelte
+++ b/web/frontend/src/components/do-command/index.svelte
@@ -29,8 +29,9 @@ const handleDoCommand = async (
     return;
   }
 
-  const client = getClientByType($robotClient, type);
+  const client = getClientByType($robotClient, type, name);
   if (!client) {
+    notify.danger(`Could not find client for ${name}`);
     return;
   }
 


### PR DESCRIPTION
This is a hack to make the DoCommand card work for sensors and cameras, which is currently blocking a customer.

## Change log

- Show a notification when there is not a client
- Use the `SensorClient` for sensors
- Use the `CameraClient` for cameras
- Bump package version

## Review requests

Code review should work here. @zaporter-work and I can verify together offline.