### PR TITLE
RSDK-7271 - fix spurious reconfiguration bug in builtin data service

### DIFF
--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -614,7 +614,7 @@ func (svc *builtIn) sync() {
 	}
 }
 
-// nolint
+//nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
@@ -668,10 +668,13 @@ func (svc *builtIn) updateDataCaptureConfigs(
 			continue
 		}
 
+		captureCopies := make([]datamanager.DataCaptureConfig, len(associatedConf.CaptureMethods))
 		for _, method := range associatedConf.CaptureMethods {
 			method.CaptureDirectory = captureDir
+			captureCopies = append(captureCopies, method)
 		}
-		resourceCaptureConfigMap[res] = associatedConf.CaptureMethods
+		svc.logger.Warn(captureCopies)
+		resourceCaptureConfigMap[res] = captureCopies
 	}
 	return resourceCaptureConfigMap, nil
 }

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -241,7 +241,7 @@ var metadataToAdditionalParamFields = map[string]string{
 func (svc *builtIn) initializeOrUpdateCollector(
 	res resource.Resource,
 	md resourceMethodMetadata,
-	config *datamanager.DataCaptureConfig,
+	config datamanager.DataCaptureConfig,
 ) (
 	*collectorAndConfig, error,
 ) {
@@ -260,7 +260,7 @@ func (svc *builtIn) initializeOrUpdateCollector(
 	// TODO(DATA-451): validate method params
 
 	if storedCollectorAndConfig, ok := svc.collectors[md]; ok {
-		if storedCollectorAndConfig.Config.Equals(config) && res == storedCollectorAndConfig.Resource {
+		if storedCollectorAndConfig.Config.Equals(&config) && res == storedCollectorAndConfig.Resource {
 			// If the attributes have not changed, do nothing and leave the existing collector.
 			return svc.collectors[md], nil
 		}
@@ -323,7 +323,7 @@ func (svc *builtIn) initializeOrUpdateCollector(
 	}
 	collector.Collect()
 
-	return &collectorAndConfig{res, collector, *config}, nil
+	return &collectorAndConfig{res, collector, config}, nil
 }
 
 func (svc *builtIn) closeSyncer() {
@@ -534,7 +534,6 @@ func (svc *builtIn) Reconfigure(
 			svc.closeSyncer()
 		}
 	}
-
 	return nil
 }
 
@@ -615,7 +614,7 @@ func (svc *builtIn) sync() {
 	}
 }
 
-//nolint
+// nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
@@ -655,8 +654,8 @@ func (svc *builtIn) updateDataCaptureConfigs(
 	resources resource.Dependencies,
 	conf resource.Config,
 	captureDir string,
-) (map[resource.Resource][]*datamanager.DataCaptureConfig, error) {
-	resourceCaptureConfigMap := make(map[resource.Resource][]*datamanager.DataCaptureConfig)
+) (map[resource.Resource][]datamanager.DataCaptureConfig, error) {
+	resourceCaptureConfigMap := make(map[resource.Resource][]datamanager.DataCaptureConfig)
 	for name, assocCfg := range conf.AssociatedAttributes {
 		associatedConf, err := utils.AssertType[*datamanager.AssociatedConfig](assocCfg)
 		if err != nil {

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -242,9 +242,7 @@ func (svc *builtIn) initializeOrUpdateCollector(
 	res resource.Resource,
 	md resourceMethodMetadata,
 	config datamanager.DataCaptureConfig,
-) (
-	*collectorAndConfig, error,
-) {
+) (*collectorAndConfig, error) {
 	// Build metadata.
 	captureMetadata, err := datacapture.BuildCaptureMetadata(
 		config.Name.API,
@@ -673,7 +671,6 @@ func (svc *builtIn) updateDataCaptureConfigs(
 			method.CaptureDirectory = captureDir
 			captureCopies = append(captureCopies, method)
 		}
-		svc.logger.Warn(captureCopies)
 		resourceCaptureConfigMap[res] = captureCopies
 	}
 	return resourceCaptureConfigMap, nil

--- a/services/datamanager/data_manager.go
+++ b/services/datamanager/data_manager.go
@@ -53,7 +53,7 @@ func FromDependencies(deps resource.Dependencies, name string) (Service, error) 
 
 // AssociatedConfig specify a list of methods to capture on resources and implements the resource.AssociatedConfig interface.
 type AssociatedConfig struct {
-	CaptureMethods []*DataCaptureConfig `json:"capture_methods"`
+	CaptureMethods []DataCaptureConfig `json:"capture_methods"`
 }
 
 func newAssociatedConfig(attributes utils.AttributeMap) (*AssociatedConfig, error) {
@@ -80,7 +80,7 @@ func (ac *AssociatedConfig) Equals(other resource.AssociatedConfig) bool {
 	// naively iterate over the list of capture methods and determine if they are the same
 	// note that two lists with capture methods [a, b] and [b, a] will not be equal as they are out of order
 	for i := 0; i < len(ac.CaptureMethods); i++ {
-		if !ac.CaptureMethods[i].Equals(ac2.CaptureMethods[i]) {
+		if !ac.CaptureMethods[i].Equals(&ac2.CaptureMethods[i]) {
 			return false
 		}
 	}
@@ -102,7 +102,7 @@ func (ac *AssociatedConfig) Link(conf *resource.Config) {
 
 	// infer name from first index in CaptureMethods
 	name := ac.CaptureMethods[0].Name
-	captureMethodCopies := make([]*DataCaptureConfig, 0, len(ac.CaptureMethods))
+	captureMethodCopies := make([]DataCaptureConfig, 0, len(ac.CaptureMethods))
 	for _, method := range ac.CaptureMethods {
 		methodCopy := method
 		captureMethodCopies = append(captureMethodCopies, methodCopy)

--- a/temp.json
+++ b/temp.json
@@ -1,0 +1,1 @@
+{"cloud":{"app_address":"https://app.viam.com:443","id":"60ce58f3-88d4-48aa-813a-98e491c1c02e","secret":"eosmdijltcnog18a19o3qp1r6ru251u81fyfy8mnprmre2kb"}}

--- a/temp.json
+++ b/temp.json
@@ -1,1 +1,0 @@
-{"cloud":{"app_address":"https://app.viam.com:443","id":"60ce58f3-88d4-48aa-813a-98e491c1c02e","secret":"eosmdijltcnog18a19o3qp1r6ru251u81fyfy8mnprmre2kb"}}


### PR DESCRIPTION
This PR fixes a bug that exists in the builtin data service that occurs if a user specifies a default path to save files in the capture configuration.  It is fixed by changing a pointer to a `DataConfigMethod` to an instance of the struct itself.  When this happens the deep copy happening in the `Link` function works as intended (where before it did not) allowing the `builtin` struct to modify its internal representation of `DataConfigMethods` without it affecting the raw json that is compared during equality check.

Its worth pointing out here that anyone attempting to write an `AssociatedConfig` needs to write the deep copy method correctly when linking and that there might be a structural improvement that could be made by removing `Link` from the interface and handling the deep copy generally at the robot scope rather than the resource scope.  Tagging @cheukt here as he may be interested in this suggestion.  

Example config that now works where before it did not:
```{
  "components": [
    {
      "name": "sensor",
      "model": "fake",
      "type": "sensor",
      "namespace": "rdk",
      "attributes": {},
      "depends_on": [],
      "service_configs": [
        {
          "type": "data_manager",
          "attributes": {
            "capture_methods": [
              {
                "additional_params": {},
                "capture_frequency_hz": 0.5,
                "method": "Readings"
              }
            ]
          }
        }
      ]
    }
  ],
  "services": [
    {
      "name": "data",
      "type": "data_manager",
      "namespace": "rdk",
      "attributes": {
        "sync_interval_mins": 0.1,
        "capture_dir": "/home/awinter/0410-tmp-capture",
        "tags": [],
        "additional_sync_paths": []
      }
    }
  ]
}
```