### PR TITLE
Create pinwrappers package

### DIFF
--- a/components/board/digital_interrupts.go
+++ b/components/board/digital_interrupts.go
@@ -2,15 +2,7 @@ package board
 
 import (
 	"context"
-	"sync"
-	"sync/atomic"
-
-	"github.com/pkg/errors"
 )
-
-// ServoRollingAverageWindow is how many entries to average over for
-// servo ticks.
-const ServoRollingAverageWindow = 10
 
 // Tick represents a signal received by an interrupt pin. This signal is communicated
 // via registered channel to the various drivers. Depending on board implementation there may be a
@@ -45,105 +37,4 @@ type DigitalInterrupt interface {
 	RemoveCallback(c chan Tick)
 
 	Close(ctx context.Context) error
-}
-
-// A ReconfigurableDigitalInterrupt is a simple reconfigurable digital interrupt that expects
-// reconfiguration within the same type.
-type ReconfigurableDigitalInterrupt interface {
-	DigitalInterrupt
-	Reconfigure(cfg DigitalInterruptConfig) error
-}
-
-// CreateDigitalInterrupt is a factory method for creating a specific DigitalInterrupt based
-// on the given config. If no type is specified, a BasicDigitalInterrupt is returned.
-func CreateDigitalInterrupt(cfg DigitalInterruptConfig) (ReconfigurableDigitalInterrupt, error) {
-	i := &BasicDigitalInterrupt{}
-
-	if err := i.Reconfigure(cfg); err != nil {
-		return nil, err
-	}
-	return i, nil
-}
-
-// A BasicDigitalInterrupt records how many ticks/interrupts happen and can
-// report when they happen to interested callbacks.
-type BasicDigitalInterrupt struct {
-	count int64
-
-	callbacks []chan Tick
-
-	mu  sync.RWMutex
-	cfg DigitalInterruptConfig
-}
-
-// Value returns the amount of ticks that have occurred.
-func (i *BasicDigitalInterrupt) Value(ctx context.Context, extra map[string]interface{}) (int64, error) {
-	i.mu.RLock()
-	defer i.mu.RUnlock()
-	count := atomic.LoadInt64(&i.count)
-	return count, nil
-}
-
-// Ticks is really just for testing.
-func (i *BasicDigitalInterrupt) Ticks(ctx context.Context, num int, now uint64) error {
-	for x := 0; x < num; x++ {
-		if err := i.Tick(ctx, true, now+uint64(x)); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// Tick records an interrupt and notifies any interested callbacks. See comment on
-// the DigitalInterrupt interface for caveats.
-func (i *BasicDigitalInterrupt) Tick(ctx context.Context, high bool, nanoseconds uint64) error {
-	if high {
-		atomic.AddInt64(&i.count, 1)
-	}
-	i.mu.RLock()
-	defer i.mu.RUnlock()
-	for _, c := range i.callbacks {
-		select {
-		case <-ctx.Done():
-			return errors.New("context cancelled")
-		case c <- Tick{Name: i.cfg.Name, High: high, TimestampNanosec: nanoseconds}:
-		}
-	}
-	return nil
-}
-
-// AddCallback adds a listener for interrupts.
-func (i *BasicDigitalInterrupt) AddCallback(c chan Tick) {
-	i.mu.Lock()
-	defer i.mu.Unlock()
-	i.callbacks = append(i.callbacks, c)
-}
-
-// RemoveCallback removes a listener for interrupts.
-func (i *BasicDigitalInterrupt) RemoveCallback(c chan Tick) {
-	i.mu.Lock()
-	defer i.mu.Unlock()
-	for id := range i.callbacks {
-		if i.callbacks[id] == c {
-			// To remove this item, we replace it with the last item in the list, then truncate the
-			// list by 1.
-			i.callbacks[id] = i.callbacks[len(i.callbacks)-1]
-			i.callbacks = i.callbacks[:len(i.callbacks)-1]
-			break
-		}
-	}
-}
-
-// Close does nothing.
-func (i *BasicDigitalInterrupt) Close(ctx context.Context) error {
-	return nil
-}
-
-// Reconfigure reconfigures this digital interrupt with a new formula.
-func (i *BasicDigitalInterrupt) Reconfigure(conf DigitalInterruptConfig) error {
-	i.mu.Lock()
-	defer i.mu.Unlock()
-
-	i.cfg = conf
-	return nil
 }

--- a/components/board/fake/board.go
+++ b/components/board/fake/board.go
@@ -15,6 +15,7 @@ import (
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/pinwrappers"
 	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -370,7 +371,7 @@ type DigitalInterruptWrapper struct {
 
 // NewDigitalInterruptWrapper returns a new digital interrupt to be used for testing.
 func NewDigitalInterruptWrapper(conf board.DigitalInterruptConfig) (*DigitalInterruptWrapper, error) {
-	di, err := board.CreateDigitalInterrupt(conf)
+	di, err := pinwrappers.CreateDigitalInterrupt(conf)
 	if err != nil {
 		return nil, err
 	}
@@ -384,10 +385,10 @@ func NewDigitalInterruptWrapper(conf board.DigitalInterruptConfig) (*DigitalInte
 func (s *DigitalInterruptWrapper) reset(conf board.DigitalInterruptConfig) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	reconf, isReconf := s.di.(board.ReconfigurableDigitalInterrupt)
+	reconf, isReconf := s.di.(pinwrappers.ReconfigurableDigitalInterrupt)
 	if conf.Name != s.conf.Name || !isReconf {
 		// rebuild
-		di, err := board.CreateDigitalInterrupt(conf)
+		di, err := pinwrappers.CreateDigitalInterrupt(conf)
 		if err != nil {
 			return err
 		}

--- a/components/board/genericlinux/digital_interrupts.go
+++ b/components/board/genericlinux/digital_interrupts.go
@@ -14,11 +14,12 @@ import (
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/pinwrappers"
 )
 
 type digitalInterrupt struct {
 	boardWorkers *sync.WaitGroup
-	interrupt    board.ReconfigurableDigitalInterrupt
+	interrupt    pinwrappers.ReconfigurableDigitalInterrupt
 	line         *gpio.LineWithEvent
 	cancelCtx    context.Context
 	cancelFunc   func()
@@ -32,7 +33,7 @@ func (b *Board) createDigitalInterrupt(
 	// If we are reconfiguring a board, we might already have channels subscribed and listening for
 	// updates from an old interrupt that we're creating on a new pin. In that case, reuse the part
 	// that holds the callbacks.
-	oldCallbackHolder board.ReconfigurableDigitalInterrupt,
+	oldCallbackHolder pinwrappers.ReconfigurableDigitalInterrupt,
 ) (*digitalInterrupt, error) {
 	mapping, ok := gpioMappings[config.Pin]
 	if !ok {
@@ -51,9 +52,9 @@ func (b *Board) createDigitalInterrupt(
 		return nil, err
 	}
 
-	var interrupt board.ReconfigurableDigitalInterrupt
+	var interrupt pinwrappers.ReconfigurableDigitalInterrupt
 	if oldCallbackHolder == nil {
-		interrupt, err = board.CreateDigitalInterrupt(config)
+		interrupt, err = pinwrappers.CreateDigitalInterrupt(config)
 		if err != nil {
 			return nil, multierr.Combine(err, line.Close())
 		}

--- a/components/board/numato/board.go
+++ b/components/board/numato/board.go
@@ -23,6 +23,7 @@ import (
 	"go.viam.com/utils/serial"
 
 	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/pinwrappers"
 	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -406,7 +407,7 @@ func connect(ctx context.Context, name resource.Name, conf *Config, logger loggi
 	b.analogs = map[string]board.AnalogReader{}
 	for _, c := range conf.Analogs {
 		r := &analogReader{b, c.Pin}
-		b.analogs[c.Name] = board.SmoothAnalogReader(r, c, logger)
+		b.analogs[c.Name] = pinwrappers.SmoothAnalogReader(r, c, logger)
 	}
 
 	b.lines = make(chan string)

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -38,6 +38,7 @@ import (
 	"go.viam.com/rdk/components/board/genericlinux/buses"
 	"go.viam.com/rdk/components/board/mcp3008helper"
 	picommon "go.viam.com/rdk/components/board/pi/common"
+	"go.viam.com/rdk/components/board/pinwrappers"
 	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -231,7 +232,7 @@ func (pi *piPigpio) reconfigureAnalogReaders(ctx context.Context, cfg *Config) e
 		bus := &piPigpioSPI{pi: pi, busSelect: ac.SPIBus}
 		ar := &mcp3008helper.MCP3008AnalogReader{channel, bus, ac.ChipSelect}
 
-		pi.analogReaders[ac.Name] = board.SmoothAnalogReader(ar, board.AnalogReaderConfig{
+		pi.analogReaders[ac.Name] = pinwrappers.SmoothAnalogReader(ar, board.AnalogReaderConfig{
 			AverageOverMillis: ac.AverageOverMillis, SamplesPerSecond: ac.SamplesPerSecond,
 		}, pi.logger)
 	}

--- a/components/board/pinwrappers/analog_smoother_test.go
+++ b/components/board/pinwrappers/analog_smoother_test.go
@@ -1,4 +1,4 @@
-package board
+package pinwrappers
 
 import (
 	"context"
@@ -10,6 +10,7 @@ import (
 	"go.viam.com/test"
 	"go.viam.com/utils/testutils"
 
+	"go.viam.com/rdk/components/board"
 	"go.viam.com/rdk/logging"
 )
 
@@ -47,7 +48,7 @@ func TestAnalogSmoother1(t *testing.T) {
 	}()
 
 	logger := logging.NewTestLogger(t)
-	as := SmoothAnalogReader(&testReader, AnalogReaderConfig{
+	as := SmoothAnalogReader(&testReader, board.AnalogReaderConfig{
 		AverageOverMillis: 10,
 		SamplesPerSecond:  10000,
 	}, logger)

--- a/components/board/pinwrappers/analogs.go
+++ b/components/board/pinwrappers/analogs.go
@@ -1,4 +1,4 @@
-package board
+package pinwrappers
 
 import (
 	"context"
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	goutils "go.viam.com/utils"
 
+	"go.viam.com/rdk/components/board"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/utils"
 )
@@ -17,7 +18,7 @@ var errStopReading = errors.New("stop reading")
 
 // An AnalogSmoother smooths the readings out from an underlying reader.
 type AnalogSmoother struct {
-	Raw                     AnalogReader
+	Raw                     board.AnalogReader
 	AverageOverMillis       int
 	SamplesPerSecond        int
 	data                    *utils.RollingAverage
@@ -29,7 +30,7 @@ type AnalogSmoother struct {
 }
 
 // SmoothAnalogReader wraps the given reader in a smoother.
-func SmoothAnalogReader(r AnalogReader, c AnalogReaderConfig, logger logging.Logger) *AnalogSmoother {
+func SmoothAnalogReader(r board.AnalogReader, c board.AnalogReaderConfig, logger logging.Logger) *AnalogSmoother {
 	cancelCtx, cancel := context.WithCancel(context.Background())
 	smoother := &AnalogSmoother{
 		Raw:               r,

--- a/components/board/pinwrappers/digital_interrupts.go
+++ b/components/board/pinwrappers/digital_interrupts.go
@@ -1,0 +1,113 @@
+// Package pinwrapers implements interfaces that wrap the basic board interface and return types, and expands them with new
+// methods and interfaces for the built in board models. Current expands analog reader and digital interrupt.
+package pinwrappers
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+
+	"go.viam.com/rdk/components/board"
+)
+
+// A ReconfigurableDigitalInterrupt is a simple reconfigurable digital interrupt that expects
+// reconfiguration within the same type.
+type ReconfigurableDigitalInterrupt interface {
+	board.DigitalInterrupt
+	Reconfigure(cfg board.DigitalInterruptConfig) error
+}
+
+// CreateDigitalInterrupt is a factory method for creating a specific DigitalInterrupt based
+// on the given config. If no type is specified, a BasicDigitalInterrupt is returned.
+func CreateDigitalInterrupt(cfg board.DigitalInterruptConfig) (ReconfigurableDigitalInterrupt, error) {
+	i := &BasicDigitalInterrupt{}
+
+	if err := i.Reconfigure(cfg); err != nil {
+		return nil, err
+	}
+	return i, nil
+}
+
+// A BasicDigitalInterrupt records how many ticks/interrupts happen and can
+// report when they happen to interested callbacks.
+type BasicDigitalInterrupt struct {
+	count int64
+
+	callbacks []chan board.Tick
+
+	mu  sync.RWMutex
+	cfg board.DigitalInterruptConfig
+}
+
+// Value returns the amount of ticks that have occurred.
+func (i *BasicDigitalInterrupt) Value(ctx context.Context, extra map[string]interface{}) (int64, error) {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	count := atomic.LoadInt64(&i.count)
+	return count, nil
+}
+
+// Ticks is really just for testing.
+func (i *BasicDigitalInterrupt) Ticks(ctx context.Context, num int, now uint64) error {
+	for x := 0; x < num; x++ {
+		if err := i.Tick(ctx, true, now+uint64(x)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Tick records an interrupt and notifies any interested callbacks. See comment on
+// the DigitalInterrupt interface for caveats.
+func (i *BasicDigitalInterrupt) Tick(ctx context.Context, high bool, nanoseconds uint64) error {
+	if high {
+		atomic.AddInt64(&i.count, 1)
+	}
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	for _, c := range i.callbacks {
+		select {
+		case <-ctx.Done():
+			return errors.New("context cancelled")
+		case c <- board.Tick{Name: i.cfg.Name, High: high, TimestampNanosec: nanoseconds}:
+		}
+	}
+	return nil
+}
+
+// AddCallback adds a listener for interrupts.
+func (i *BasicDigitalInterrupt) AddCallback(c chan board.Tick) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.callbacks = append(i.callbacks, c)
+}
+
+// RemoveCallback removes a listener for interrupts.
+func (i *BasicDigitalInterrupt) RemoveCallback(c chan board.Tick) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	for id := range i.callbacks {
+		if i.callbacks[id] == c {
+			// To remove this item, we replace it with the last item in the list, then truncate the
+			// list by 1.
+			i.callbacks[id] = i.callbacks[len(i.callbacks)-1]
+			i.callbacks = i.callbacks[:len(i.callbacks)-1]
+			break
+		}
+	}
+}
+
+// Close does nothing.
+func (i *BasicDigitalInterrupt) Close(ctx context.Context) error {
+	return nil
+}
+
+// Reconfigure reconfigures this digital interrupt with a new formula.
+func (i *BasicDigitalInterrupt) Reconfigure(conf board.DigitalInterruptConfig) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	i.cfg = conf
+	return nil
+}

--- a/components/board/pinwrappers/digital_interrupts.go
+++ b/components/board/pinwrappers/digital_interrupts.go
@@ -1,4 +1,4 @@
-// Package pinwrapers implements interfaces that wrap the basic board interface and return types, and expands them with new
+// Package pinwrappers implements interfaces that wrap the basic board interface and return types, and expands them with new
 // methods and interfaces for the built in board models. Current expands analog reader and digital interrupt.
 package pinwrappers
 

--- a/components/board/pinwrappers/digital_interrupts_test.go
+++ b/components/board/pinwrappers/digital_interrupts_test.go
@@ -1,4 +1,4 @@
-package board
+package pinwrappers
 
 import (
 	"context"
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"go.viam.com/test"
+
+	"go.viam.com/rdk/components/board"
 )
 
 func nowNanosecondsTest() uint64 {
@@ -14,7 +16,7 @@ func nowNanosecondsTest() uint64 {
 }
 
 func TestBasicDigitalInterrupt1(t *testing.T) {
-	config := DigitalInterruptConfig{
+	config := board.DigitalInterruptConfig{
 		Name: "i1",
 	}
 
@@ -33,7 +35,7 @@ func TestBasicDigitalInterrupt1(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, intVal, test.ShouldEqual, int64(1))
 
-	c := make(chan Tick)
+	c := make(chan board.Tick)
 	i.AddCallback(c)
 
 	timeNanoSec := nowNanosecondsTest()
@@ -51,7 +53,7 @@ func TestBasicDigitalInterrupt1(t *testing.T) {
 
 	i.RemoveCallback(c)
 
-	c = make(chan Tick, 2)
+	c = make(chan board.Tick, 2)
 	i.AddCallback(c)
 	go func() {
 		i.Tick(context.Background(), true, uint64(1))
@@ -65,7 +67,7 @@ func TestBasicDigitalInterrupt1(t *testing.T) {
 }
 
 func TestRemoveCallbackDigitalInterrupt(t *testing.T) {
-	config := DigitalInterruptConfig{
+	config := board.DigitalInterruptConfig{
 		Name: "d1",
 	}
 	i, err := CreateDigitalInterrupt(config)
@@ -78,7 +80,7 @@ func TestRemoveCallbackDigitalInterrupt(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, intVal, test.ShouldEqual, int64(1))
 
-	c1 := make(chan Tick)
+	c1 := make(chan board.Tick)
 	test.That(t, c1, test.ShouldNotBeNil)
 	i.AddCallback(c1)
 	var wg sync.WaitGroup
@@ -104,7 +106,7 @@ func TestRemoveCallbackDigitalInterrupt(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, intVal, test.ShouldEqual, int64(2))
 	wg.Wait()
-	c2 := make(chan Tick)
+	c2 := make(chan board.Tick)
 	test.That(t, c2, test.ShouldNotBeNil)
 	i.AddCallback(c2)
 	test.That(t, ret, test.ShouldBeTrue)

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -33,6 +33,7 @@ import (
 	fakebase "go.viam.com/rdk/components/base/fake"
 	"go.viam.com/rdk/components/board"
 	fakeboard "go.viam.com/rdk/components/board/fake"
+	"go.viam.com/rdk/components/board/pinwrappers"
 	"go.viam.com/rdk/components/camera"
 	fakecamera "go.viam.com/rdk/components/camera/fake"
 	"go.viam.com/rdk/components/gripper"
@@ -481,7 +482,7 @@ func TestManagerAdd(t *testing.T) {
 		return &fakeboard.AnalogReader{}, true
 	}
 	injectBoard.DigitalInterruptByNameFunc = func(name string) (board.DigitalInterrupt, bool) {
-		return &fakeboard.DigitalInterruptWrapper{}, true
+		return &pinwrappers.BasicDigitalInterrupt{}, true
 	}
 
 	cfg = &resource.Config{

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -481,7 +481,7 @@ func TestManagerAdd(t *testing.T) {
 		return &fakeboard.AnalogReader{}, true
 	}
 	injectBoard.DigitalInterruptByNameFunc = func(name string) (board.DigitalInterrupt, bool) {
-		return &board.BasicDigitalInterrupt{}, true
+		return &fakeboard.DigitalInterruptWrapper{}, true
 	}
 
 	cfg = &resource.Config{


### PR DESCRIPTION
This PR:
- Moves the entire file containing Reconfigurable Analog Readers and AnalogSmoothers to the new pinwrappers package.
- Moves the lines creating basic digital interrupts from `board/digitalinterrupts.go` to the `digital_interrupts.go` file in the pinwrappers package.
- changes any usage of these wrappers the board drivers to the new package.

A few things to note: 
- The only actual board that uses the Analog smoother with a physically builtin analog reader is the numato board.
- generic linux use reconfigurable digital interrupts, so does the pi.
-  generic linux and the pi use the smooth analog reader when configured with an the MCP3008 chip.
- I'm not sure certain methods in the BasicDigitalInterrupt interface are actually being used anywhere.

Further code cleanup can be done, but I'll leave that to another PR.

ToDo:
- [x] test on a pi4
- [x] test on a pi5
- [x] test analogs on a numato board