### PR TITLE
Defend against nil, nil returns in modular Movement Sensors. 

### DIFF
--- a/components/movementsensor/accuracy.go
+++ b/components/movementsensor/accuracy.go
@@ -58,7 +58,7 @@ func accuracyToProtoResponse(acc *Accuracy) (*pb.GetAccuracyResponse, error) {
 	if acc == nil {
 		uacc := UnimplementedOptionalAccuracies()
 		return &pb.GetAccuracyResponse{
-			Accuracy:            acc.AccuracyMap,
+			Accuracy:            map[string]float32{},
 			PositionHdop:        &uacc.Hdop,
 			PositionVdop:        &uacc.Vdop,
 			PositionNmeaGgaFix:  &uacc.NmeaFix,

--- a/components/movementsensor/accuracy.go
+++ b/components/movementsensor/accuracy.go
@@ -79,7 +79,6 @@ func protoFeaturesToAccuracy(resp *pb.GetAccuracyResponse) *Accuracy {
 // used by the server
 func accuracyToProtoResponse(acc *Accuracy) (*pb.GetAccuracyResponse, error) {
 	uacc := UnimplementedOptionalAccuracies()
-
 	if acc == nil {
 		return &pb.GetAccuracyResponse{
 			Accuracy:            map[string]float32{},
@@ -90,11 +89,31 @@ func accuracyToProtoResponse(acc *Accuracy) (*pb.GetAccuracyResponse, error) {
 		}, nil
 	}
 
+	hdop := uacc.Hdop
+	if acc.Hdop > 0 {
+		hdop = acc.Hdop
+	}
+
+	vdop := uacc.Vdop
+	if acc.Vdop > 0 {
+		vdop = acc.Vdop
+	}
+
+	compass := uacc.CompassDegreeError
+	if acc.CompassDegreeError > 0 {
+		compass = acc.CompassDegreeError
+	}
+
+	nmeaFix := uacc.NmeaFix
+	if &acc.NmeaFix != nil {
+		nmeaFix = acc.NmeaFix
+	}
+
 	return &pb.GetAccuracyResponse{
 		Accuracy:            acc.AccuracyMap,
-		PositionHdop:        &acc.Hdop,
-		PositionVdop:        &acc.Vdop,
-		PositionNmeaGgaFix:  &acc.NmeaFix,
-		CompassDegreesError: &acc.CompassDegreeError,
+		PositionHdop:        &hdop,
+		PositionVdop:        &vdop,
+		PositionNmeaGgaFix:  &nmeaFix,
+		CompassDegreesError: &compass,
 	}, nil
 }

--- a/components/movementsensor/accuracy.go
+++ b/components/movementsensor/accuracy.go
@@ -39,24 +39,48 @@ type Accuracy struct {
 
 // ProtoFeaturesToAccuracy converts a GetAccuracyResponse from a protocol buffer (protobuf)
 // into an Accuracy struct.
+// used by the client.
 func protoFeaturesToAccuracy(resp *pb.GetAccuracyResponse) *Accuracy {
+	uacc := UnimplementedOptionalAccuracies()
 	if resp == nil {
 		return UnimplementedOptionalAccuracies()
 	}
 
+	hdop := resp.PositionHdop
+	if &hdop == nil {
+		hdop = &uacc.Hdop
+	}
+
+	vdop := resp.PositionVdop
+	if &vdop == nil {
+		vdop = &uacc.Vdop
+	}
+
+	compass := resp.CompassDegreesError
+	if &compass == nil {
+		compass = &uacc.CompassDegreeError
+	}
+
+	nmeaFix := resp.PositionNmeaGgaFix
+	if &nmeaFix == nil {
+		nmeaFix = &uacc.NmeaFix
+	}
+
 	return &Accuracy{
 		AccuracyMap:        resp.Accuracy,
-		Hdop:               *resp.PositionHdop,
-		Vdop:               *resp.PositionVdop,
-		NmeaFix:            *resp.PositionNmeaGgaFix,
-		CompassDegreeError: *resp.CompassDegreesError,
+		Hdop:               *hdop,
+		Vdop:               *vdop,
+		NmeaFix:            *nmeaFix,
+		CompassDegreeError: *compass,
 	}
 }
 
 // AccuracyToProtoResponse converts an Accuracy struct into a protobuf GetAccuracyResponse.
+// used by the server
 func accuracyToProtoResponse(acc *Accuracy) (*pb.GetAccuracyResponse, error) {
+	uacc := UnimplementedOptionalAccuracies()
+
 	if acc == nil {
-		uacc := UnimplementedOptionalAccuracies()
 		return &pb.GetAccuracyResponse{
 			Accuracy:            map[string]float32{},
 			PositionHdop:        &uacc.Hdop,
@@ -65,6 +89,7 @@ func accuracyToProtoResponse(acc *Accuracy) (*pb.GetAccuracyResponse, error) {
 			CompassDegreesError: &uacc.CompassDegreeError,
 		}, nil
 	}
+
 	return &pb.GetAccuracyResponse{
 		Accuracy:            acc.AccuracyMap,
 		PositionHdop:        &acc.Hdop,

--- a/components/movementsensor/accuracy.go
+++ b/components/movementsensor/accuracy.go
@@ -1,8 +1,6 @@
 package movementsensor
 
 import (
-	"math"
-
 	pb "go.viam.com/api/component/movementsensor/v1"
 )
 
@@ -42,23 +40,23 @@ type Accuracy struct {
 // ProtoFeaturesToAccuracy converts a GetAccuracyResponse from a protocol buffer (protobuf)
 // into an Accuracy struct.
 func protoFeaturesToAccuracy(resp *pb.GetAccuracyResponse) *Accuracy {
-	hdop, vdop, compass, nmeaFix := checkForEmptyOptionals(
-		resp.PositionHdop, resp.PositionVdop,
-		resp.CompassDegreesError, resp.PositionNmeaGgaFix,
-	)
+	if resp == nil {
+		return UnimplementedOptionalAccuracies()
+	}
+
 	return &Accuracy{
 		AccuracyMap:        resp.Accuracy,
-		Hdop:               *hdop,
-		Vdop:               *vdop,
-		NmeaFix:            *nmeaFix,
-		CompassDegreeError: *compass,
+		Hdop:               *resp.PositionHdop,
+		Vdop:               *resp.PositionVdop,
+		NmeaFix:            *resp.PositionNmeaGgaFix,
+		CompassDegreeError: *resp.CompassDegreesError,
 	}
 }
 
 // AccuracyToProtoResponse converts an Accuracy struct into a protobuf GetAccuracyResponse.
 func accuracyToProtoResponse(acc *Accuracy) (*pb.GetAccuracyResponse, error) {
 	if acc == nil {
-		uacc := UnimplementedAccuracies()
+		uacc := UnimplementedOptionalAccuracies()
 		return &pb.GetAccuracyResponse{
 			Accuracy:            acc.AccuracyMap,
 			PositionHdop:        &uacc.Hdop,
@@ -68,41 +66,10 @@ func accuracyToProtoResponse(acc *Accuracy) (*pb.GetAccuracyResponse, error) {
 		}, nil
 	}
 	return &pb.GetAccuracyResponse{
-		Accuracy:            map[string]float32{},
+		Accuracy:            acc.AccuracyMap,
 		PositionHdop:        &acc.Hdop,
 		PositionVdop:        &acc.Vdop,
 		PositionNmeaGgaFix:  &acc.NmeaFix,
 		CompassDegreesError: &acc.CompassDegreeError,
 	}, nil
-}
-
-func checkForEmptyOptionals(
-	hdop, vdop, compass *float32, nmeaFix *int32,
-) (*float32, *float32, *float32, *int32) {
-	nan32 := convertNaN64to32()
-
-	if hdop == nil {
-		hdop = nan32
-	}
-
-	if vdop == nil {
-		vdop = nan32
-	}
-
-	if nmeaFix == nil {
-		invalidFix32 := int32(-1)
-		nmeaFix = &invalidFix32
-	}
-
-	if compass == nil {
-		compass = nan32
-	}
-
-	return hdop, vdop, compass, nmeaFix
-}
-
-func convertNaN64to32() *float32 {
-	nan := math.NaN()
-	nan32 := float32(nan)
-	return &nan32
 }

--- a/components/movementsensor/accuracy.go
+++ b/components/movementsensor/accuracy.go
@@ -47,22 +47,22 @@ func protoFeaturesToAccuracy(resp *pb.GetAccuracyResponse) *Accuracy {
 	}
 
 	hdop := resp.PositionHdop
-	if &hdop == nil {
+	if hdop == nil {
 		hdop = &uacc.Hdop
 	}
 
 	vdop := resp.PositionVdop
-	if &vdop == nil {
+	if vdop == nil {
 		vdop = &uacc.Vdop
 	}
 
 	compass := resp.CompassDegreesError
-	if &compass == nil {
+	if compass == nil {
 		compass = &uacc.CompassDegreeError
 	}
 
 	nmeaFix := resp.PositionNmeaGgaFix
-	if &nmeaFix == nil {
+	if nmeaFix == nil {
 		nmeaFix = &uacc.NmeaFix
 	}
 
@@ -76,7 +76,7 @@ func protoFeaturesToAccuracy(resp *pb.GetAccuracyResponse) *Accuracy {
 }
 
 // AccuracyToProtoResponse converts an Accuracy struct into a protobuf GetAccuracyResponse.
-// used by the server
+// used by the server.
 func accuracyToProtoResponse(acc *Accuracy) (*pb.GetAccuracyResponse, error) {
 	uacc := UnimplementedOptionalAccuracies()
 	if acc == nil {
@@ -84,8 +84,9 @@ func accuracyToProtoResponse(acc *Accuracy) (*pb.GetAccuracyResponse, error) {
 			Accuracy:            map[string]float32{},
 			PositionHdop:        &uacc.Hdop,
 			PositionVdop:        &uacc.Vdop,
-			PositionNmeaGgaFix:  &uacc.NmeaFix,
 			CompassDegreesError: &uacc.CompassDegreeError,
+			// default value of the GGA NMEA Fix when Accuracy struct is nil is -1 - a meaningless value in terms of GGA Fixes.
+			PositionNmeaGgaFix: &uacc.NmeaFix,
 		}, nil
 	}
 
@@ -104,16 +105,12 @@ func accuracyToProtoResponse(acc *Accuracy) (*pb.GetAccuracyResponse, error) {
 		compass = acc.CompassDegreeError
 	}
 
-	nmeaFix := uacc.NmeaFix
-	if &acc.NmeaFix != nil {
-		nmeaFix = acc.NmeaFix
-	}
-
 	return &pb.GetAccuracyResponse{
 		Accuracy:            acc.AccuracyMap,
 		PositionHdop:        &hdop,
 		PositionVdop:        &vdop,
-		PositionNmeaGgaFix:  &nmeaFix,
 		CompassDegreesError: &compass,
+		// default value of the GGA NMEA Fix when Accuracy struct is non-nil is 0 - invalid GGA Fix.
+		PositionNmeaGgaFix: &acc.NmeaFix,
 	}, nil
 }

--- a/components/movementsensor/adxl345/adxl345.go
+++ b/components/movementsensor/adxl345/adxl345.go
@@ -546,7 +546,7 @@ func (adxl *adxl345) Position(ctx context.Context, extra map[string]interface{})
 
 func (adxl *adxl345) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
 	// this driver is unable to provide positional or compass heading data
-	return movementsensor.UnimplementedAccuracies()
+	return movementsensor.UnimplementedAccuracies(), nil
 }
 
 func (adxl *adxl345) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {

--- a/components/movementsensor/adxl345/adxl345.go
+++ b/components/movementsensor/adxl345/adxl345.go
@@ -546,7 +546,7 @@ func (adxl *adxl345) Position(ctx context.Context, extra map[string]interface{})
 
 func (adxl *adxl345) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
 	// this driver is unable to provide positional or compass heading data
-	return movementsensor.UnimplementedAccuracies(), nil
+	return movementsensor.UnimplementedOptionalAccuracies(), nil
 }
 
 func (adxl *adxl345) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {

--- a/components/movementsensor/client_test.go
+++ b/components/movementsensor/client_test.go
@@ -12,7 +12,6 @@ import (
 	"go.viam.com/utils/rpc"
 
 	"go.viam.com/rdk/components/movementsensor"
-	"go.viam.com/rdk/components/sensor"
 	viamgrpc "go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -110,6 +109,12 @@ func TestClient(t *testing.T) {
 	}
 	injectMovementSensor2.ReadingsFunc = func(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
 		return nil, errReadingsFailed
+	}
+	injectMovementSensor2.AccuracyFunc = func(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
+		return nil, errAccuracy
+	}
+	injectMovementSensor2.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
+		return nil, errProperties
 	}
 
 	gpsSvc, err := resource.NewAPIResourceCollection(movementsensor.API, map[resource.Name]movementsensor.MovementSensor{
@@ -226,9 +231,17 @@ func TestClient(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errAngularVelocity.Error())
 
-		_, err = client2.(sensor.Sensor).Readings(context.Background(), make(map[string]interface{}))
+		_, err = client2.Readings(context.Background(), make(map[string]interface{}))
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errReadingsFailed.Error())
+
+		_, err = client2.Accuracy(context.Background(), make(map[string]interface{}))
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, errAccuracy.Error())
+
+		_, err = client2.Properties(context.Background(), make(map[string]interface{}))
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, errProperties.Error())
 
 		test.That(t, client2.Close(context.Background()), test.ShouldBeNil)
 		test.That(t, conn.Close(), test.ShouldBeNil)

--- a/components/movementsensor/client_test.go
+++ b/components/movementsensor/client_test.go
@@ -3,6 +3,7 @@ package movementsensor_test
 import (
 	"context"
 	"errors"
+	"math"
 	"net"
 	"testing"
 
@@ -186,7 +187,8 @@ func TestClient(t *testing.T) {
 
 		acc1, err := gps1Client.Accuracy(context.Background(), map[string]interface{}{"foo": "bar"})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, acc1, test.ShouldResemble, acy)
+		test.That(t, acc1.AccuracyMap, test.ShouldResemble, acy.AccuracyMap)
+		test.That(t, math.IsNaN(float64(acc1.Hdop)), test.ShouldBeTrue)
 		test.That(t, injectMovementSensor.AccuracyFuncExtraCap, test.ShouldResemble, map[string]interface{}{"foo": "bar"})
 
 		la1, err := gps1Client.LinearAcceleration(context.Background(), map[string]interface{}{"foo": "bar"})

--- a/components/movementsensor/dualgps/dualgps.go
+++ b/components/movementsensor/dualgps/dualgps.go
@@ -269,7 +269,7 @@ func (dg *dualGPS) Accuracy(ctx context.Context, extra map[string]interface{}) (
 	// of the two positions.
 	// return the NMEA Fix that appears from either gps in this order: (worst) 0, 1, 2, 5, 4 (best), or -1 if
 	// it is not any of these (other nmea GGA fixes indicate simulated or deadreckoning gps devices)
-	return movementsensor.UnimplementedAccuracies()
+	return movementsensor.UnimplementedAccuracies(), nil
 }
 
 func (dg *dualGPS) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {

--- a/components/movementsensor/dualgps/dualgps.go
+++ b/components/movementsensor/dualgps/dualgps.go
@@ -269,7 +269,7 @@ func (dg *dualGPS) Accuracy(ctx context.Context, extra map[string]interface{}) (
 	// of the two positions.
 	// return the NMEA Fix that appears from either gps in this order: (worst) 0, 1, 2, 5, 4 (best), or -1 if
 	// it is not any of these (other nmea GGA fixes indicate simulated or deadreckoning gps devices)
-	return movementsensor.UnimplementedAccuracies(), nil
+	return movementsensor.UnimplementedOptionalAccuracies(), nil
 }
 
 func (dg *dualGPS) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {

--- a/components/movementsensor/fake/movementsensor.go
+++ b/components/movementsensor/fake/movementsensor.go
@@ -81,14 +81,14 @@ func (f *MovementSensor) DoCommand(ctx context.Context, cmd map[string]interface
 
 // Accuracy gets the accuracy of a fake movementsensor.
 func (f *MovementSensor) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
-	acc := movementsensor.Accuracy{
+	acc := &movementsensor.Accuracy{
 		AccuracyMap:        map[string]float32{},
 		Hdop:               0,
 		Vdop:               0,
 		NmeaFix:            4,
 		CompassDegreeError: 0,
 	}
-	return &acc, nil
+	return acc, nil
 }
 
 // Readings gets the readings of a fake movementsensor.

--- a/components/movementsensor/fake/movementsensor.go
+++ b/components/movementsensor/fake/movementsensor.go
@@ -81,11 +81,14 @@ func (f *MovementSensor) DoCommand(ctx context.Context, cmd map[string]interface
 
 // Accuracy gets the accuracy of a fake movementsensor.
 func (f *MovementSensor) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
-	// acc := movementsensor.Accuracy{
-	// 	AccuracyMap: map[string]float32{},
-	// }
-
-	return nil, nil
+	acc := movementsensor.Accuracy{
+		AccuracyMap:        map[string]float32{},
+		Hdop:               0,
+		Vdop:               0,
+		NmeaFix:            4,
+		CompassDegreeError: 0,
+	}
+	return &acc, nil
 }
 
 // Readings gets the readings of a fake movementsensor.

--- a/components/movementsensor/fake/movementsensor.go
+++ b/components/movementsensor/fake/movementsensor.go
@@ -81,15 +81,11 @@ func (f *MovementSensor) DoCommand(ctx context.Context, cmd map[string]interface
 
 // Accuracy gets the accuracy of a fake movementsensor.
 func (f *MovementSensor) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
-	acc := movementsensor.Accuracy{
-		AccuracyMap:        map[string]float32{},
-		Hdop:               0,
-		Vdop:               0,
-		NmeaFix:            4,
-		CompassDegreeError: 0,
-	}
+	// acc := movementsensor.Accuracy{
+	// 	AccuracyMap: map[string]float32{},
+	// }
 
-	return &acc, nil
+	return nil, nil
 }
 
 // Readings gets the readings of a fake movementsensor.

--- a/components/movementsensor/imuvectornav/imu.go
+++ b/components/movementsensor/imuvectornav/imu.go
@@ -282,7 +282,7 @@ func (vn *vectornav) Position(ctx context.Context, extra map[string]interface{})
 func (vn *vectornav) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
 	// TODO:  RSDK-6389 check the vectornav's datasheet to determine what is best to return from the vector nav.
 	// can be done in a seprate ticket from the one mentioned in this comment.
-	return movementsensor.UnimplementedAccuracies()
+	return movementsensor.UnimplementedAccuracies(), nil
 }
 
 func (vn *vectornav) GetMagnetometer(ctx context.Context) (r3.Vector, error) {

--- a/components/movementsensor/imuvectornav/imu.go
+++ b/components/movementsensor/imuvectornav/imu.go
@@ -282,7 +282,7 @@ func (vn *vectornav) Position(ctx context.Context, extra map[string]interface{})
 func (vn *vectornav) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
 	// TODO:  RSDK-6389 check the vectornav's datasheet to determine what is best to return from the vector nav.
 	// can be done in a seprate ticket from the one mentioned in this comment.
-	return movementsensor.UnimplementedAccuracies(), nil
+	return movementsensor.UnimplementedOptionalAccuracies(), nil
 }
 
 func (vn *vectornav) GetMagnetometer(ctx context.Context) (r3.Vector, error) {

--- a/components/movementsensor/movementsensor.go
+++ b/components/movementsensor/movementsensor.go
@@ -162,10 +162,13 @@ func DefaultAPIReadings(ctx context.Context, g MovementSensor, extra map[string]
 // It contains NaN definitiions for accuracies returned in floats, an invalid integer value for the NMEAFix of a gps
 // and an empty map of other accuracies.
 func UnimplementedOptionalAccuracies() *Accuracy {
+	nan32Bit := float32(math.NaN())
+	nmeaInvalid := int32(-1)
+
 	return &Accuracy{
-		Hdop:               float32(math.NaN()),
-		Vdop:               float32(math.NaN()),
-		NmeaFix:            int32(-1),
-		CompassDegreeError: float32(math.NaN()),
+		Hdop:               nan32Bit,
+		Vdop:               nan32Bit,
+		NmeaFix:            nmeaInvalid,
+		CompassDegreeError: nan32Bit,
 	}
 }

--- a/components/movementsensor/movementsensor.go
+++ b/components/movementsensor/movementsensor.go
@@ -156,14 +156,13 @@ func DefaultAPIReadings(ctx context.Context, g MovementSensor, extra map[string]
 	return readings, nil
 }
 
-// UnimplementedAccuracies returns accuracy values that will not show up on movement sensor's RC card
+// UnimplementedOptionalAccuracies returns accuracy values that will not show up on movement sensor's RC card
 // or be useable for a caller of the GetAccuracies method. The RC card currently continuously polls accuracies,
 // so a nil error must be rturned from the GetAccuracies call.
 // It contains NaN definitiions for accuracies returned in floats, an invalid integer value for the NMEAFix of a gps
 // and an empty map of other accuracies.
-func UnimplementedAccuracies() *Accuracy {
+func UnimplementedOptionalAccuracies() *Accuracy {
 	return &Accuracy{
-		AccuracyMap:        map[string]float32{},
 		Hdop:               float32(math.NaN()),
 		Vdop:               float32(math.NaN()),
 		NmeaFix:            int32(-1),

--- a/components/movementsensor/movementsensor.go
+++ b/components/movementsensor/movementsensor.go
@@ -161,12 +161,12 @@ func DefaultAPIReadings(ctx context.Context, g MovementSensor, extra map[string]
 // so a nil error must be rturned from the GetAccuracies call.
 // It contains NaN definitiions for accuracies returned in floats, an invalid integer value for the NMEAFix of a gps
 // and an empty map of other accuracies.
-func UnimplementedAccuracies() (*Accuracy, error) {
+func UnimplementedAccuracies() *Accuracy {
 	return &Accuracy{
 		AccuracyMap:        map[string]float32{},
 		Hdop:               float32(math.NaN()),
 		Vdop:               float32(math.NaN()),
 		NmeaFix:            int32(-1),
 		CompassDegreeError: float32(math.NaN()),
-	}, nil
+	}
 }

--- a/components/movementsensor/mpu6050/mpu6050.go
+++ b/components/movementsensor/mpu6050/mpu6050.go
@@ -322,7 +322,7 @@ func (mpu *mpu6050) Position(ctx context.Context, extra map[string]interface{}) 
 }
 
 func (mpu *mpu6050) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
-	return movementsensor.UnimplementedAccuracies(), nil
+	return movementsensor.UnimplementedOptionalAccuracies(), nil
 }
 
 func (mpu *mpu6050) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {

--- a/components/movementsensor/mpu6050/mpu6050.go
+++ b/components/movementsensor/mpu6050/mpu6050.go
@@ -322,7 +322,7 @@ func (mpu *mpu6050) Position(ctx context.Context, extra map[string]interface{}) 
 }
 
 func (mpu *mpu6050) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
-	return movementsensor.UnimplementedAccuracies()
+	return movementsensor.UnimplementedAccuracies(), nil
 }
 
 func (mpu *mpu6050) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {

--- a/components/movementsensor/replay/replay.go
+++ b/components/movementsensor/replay/replay.go
@@ -372,7 +372,7 @@ func (replay *replayMovementSensor) Properties(ctx context.Context, extra map[st
 // Accuracy is currently not defined for replay movement sensors.
 func (replay *replayMovementSensor) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error,
 ) {
-	return movementsensor.UnimplementedAccuracies(), nil
+	return movementsensor.UnimplementedOptionalAccuracies(), nil
 }
 
 // Close stops the replay movement sensor, closes its channels and its connections to the cloud.

--- a/components/movementsensor/replay/replay.go
+++ b/components/movementsensor/replay/replay.go
@@ -372,7 +372,7 @@ func (replay *replayMovementSensor) Properties(ctx context.Context, extra map[st
 // Accuracy is currently not defined for replay movement sensors.
 func (replay *replayMovementSensor) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error,
 ) {
-	return movementsensor.UnimplementedAccuracies()
+	return movementsensor.UnimplementedAccuracies(), nil
 }
 
 // Close stops the replay movement sensor, closes its channels and its connections to the cloud.

--- a/components/movementsensor/server.go
+++ b/components/movementsensor/server.go
@@ -175,7 +175,7 @@ func (s *serviceServer) GetAccuracy(
 	if accuracy != nil {
 		return accuracyToProtoResponse(accuracy)
 	}
-	return accuracyToProtoResponse(UnimplementedAccuracies())
+	return accuracyToProtoResponse(UnimplementedOptionalAccuracies())
 }
 
 // DoCommand receives arbitrary commands.

--- a/components/movementsensor/server.go
+++ b/components/movementsensor/server.go
@@ -173,20 +173,7 @@ func (s *serviceServer) GetAccuracy(
 	}
 
 	uacc := UnimplementedOptionalAccuracies()
-
 	if accuracy != nil {
-		// check optional accuracies
-		switch {
-		case &accuracy.Hdop == nil:
-			accuracy.Hdop = uacc.Hdop
-		case &accuracy.Vdop == nil:
-			accuracy.Vdop = uacc.Vdop
-		case &accuracy.CompassDegreeError == nil:
-			accuracy.CompassDegreeError = uacc.CompassDegreeError
-		case &accuracy.NmeaFix == nil:
-			accuracy.NmeaFix = uacc.NmeaFix
-		}
-
 		return accuracyToProtoResponse(accuracy)
 	}
 	return accuracyToProtoResponse(uacc)

--- a/components/movementsensor/server.go
+++ b/components/movementsensor/server.go
@@ -172,10 +172,24 @@ func (s *serviceServer) GetAccuracy(
 		return nil, err
 	}
 
+	uacc := UnimplementedOptionalAccuracies()
+
 	if accuracy != nil {
+		// check optional accuracies
+		switch {
+		case &accuracy.Hdop == nil:
+			accuracy.Hdop = uacc.Hdop
+		case &accuracy.Vdop == nil:
+			accuracy.Vdop = uacc.Vdop
+		case &accuracy.CompassDegreeError == nil:
+			accuracy.CompassDegreeError = uacc.CompassDegreeError
+		case &accuracy.NmeaFix == nil:
+			accuracy.NmeaFix = uacc.NmeaFix
+		}
+
 		return accuracyToProtoResponse(accuracy)
 	}
-	return accuracyToProtoResponse(UnimplementedOptionalAccuracies())
+	return accuracyToProtoResponse(uacc)
 }
 
 // DoCommand receives arbitrary commands.

--- a/components/movementsensor/server.go
+++ b/components/movementsensor/server.go
@@ -171,7 +171,11 @@ func (s *serviceServer) GetAccuracy(
 	if err != nil {
 		return nil, err
 	}
-	return accuracyToProtoResponse(accuracy)
+
+	if accuracy != nil {
+		return accuracyToProtoResponse(accuracy)
+	}
+	return accuracyToProtoResponse(UnimplementedAccuracies())
 }
 
 // DoCommand receives arbitrary commands.

--- a/components/movementsensor/server_test.go
+++ b/components/movementsensor/server_test.go
@@ -3,6 +3,7 @@ package movementsensor_test
 import (
 	"context"
 	"errors"
+	"math"
 	"testing"
 
 	"github.com/golang/geo/r3"
@@ -250,5 +251,17 @@ func TestServer(t *testing.T) {
 		_, err = gpsServer.GetAccuracy(context.Background(), &pb.GetAccuracyRequest{Name: missingMovementSensorName})
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, resource.IsNotFoundError(err), test.ShouldBeTrue)
+
+		injectMovementSensor2.AccuracyFunc = func(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
+			return nil, nil
+		}
+		uacc, err := gpsServer.GetAccuracy(context.Background(), &pb.GetAccuracyRequest{Name: failMovementSensorName})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, uacc.Accuracy, test.ShouldResemble, map[string]float32(nil))
+		test.That(t, math.IsNaN(float64(*uacc.PositionHdop)), test.ShouldBeTrue)
+		test.That(t, math.IsNaN(float64(*uacc.PositionVdop)), test.ShouldBeTrue)
+		test.That(t, math.IsNaN(float64(*uacc.CompassDegreesError)), test.ShouldBeTrue)
+		test.That(t, *uacc.PositionNmeaGgaFix, test.ShouldResemble, int32(-1))
+
 	})
 }

--- a/components/movementsensor/server_test.go
+++ b/components/movementsensor/server_test.go
@@ -253,6 +253,7 @@ func TestServer(t *testing.T) {
 		test.That(t, resource.IsNotFoundError(err), test.ShouldBeTrue)
 
 		injectMovementSensor2.AccuracyFunc = func(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
+			//nolint:nilnil
 			return nil, nil
 		}
 		uacc, err := gpsServer.GetAccuracy(context.Background(), &pb.GetAccuracyRequest{Name: failMovementSensorName})
@@ -262,6 +263,5 @@ func TestServer(t *testing.T) {
 		test.That(t, math.IsNaN(float64(*uacc.PositionVdop)), test.ShouldBeTrue)
 		test.That(t, math.IsNaN(float64(*uacc.CompassDegreesError)), test.ShouldBeTrue)
 		test.That(t, *uacc.PositionNmeaGgaFix, test.ShouldResemble, int32(-1))
-
 	})
 }

--- a/components/movementsensor/server_test.go
+++ b/components/movementsensor/server_test.go
@@ -252,6 +252,7 @@ func TestServer(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, resource.IsNotFoundError(err), test.ShouldBeTrue)
 
+		// test that server protext client against a nil accuracy return
 		injectMovementSensor2.AccuracyFunc = func(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
 			//nolint:nilnil
 			return nil, nil
@@ -260,6 +261,19 @@ func TestServer(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, uacc.Accuracy, test.ShouldResemble, map[string]float32(nil))
 		test.That(t, math.IsNaN(float64(*uacc.PositionHdop)), test.ShouldBeTrue)
+		test.That(t, math.IsNaN(float64(*uacc.PositionVdop)), test.ShouldBeTrue)
+		test.That(t, math.IsNaN(float64(*uacc.CompassDegreesError)), test.ShouldBeTrue)
+		test.That(t, *uacc.PositionNmeaGgaFix, test.ShouldResemble, int32(-1))
+
+		// check that server populates optionals correctly if they are undefined
+		injectMovementSensor2.AccuracyFunc = func(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error) {
+			nilOptionals := &movementsensor.Accuracy{AccuracyMap: map[string]float32{"foo": 1.1}}
+			return nilOptionals, nil
+		}
+		uacc, err = gpsServer.GetAccuracy(context.Background(), &pb.GetAccuracyRequest{Name: failMovementSensorName})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, uacc.Accuracy, test.ShouldResemble, map[string]float32{"foo": 1.1})
+		test.That(t, uacc., test.ShouldBeEqual, )
 		test.That(t, math.IsNaN(float64(*uacc.PositionVdop)), test.ShouldBeTrue)
 		test.That(t, math.IsNaN(float64(*uacc.CompassDegreesError)), test.ShouldBeTrue)
 		test.That(t, *uacc.PositionNmeaGgaFix, test.ShouldResemble, int32(-1))

--- a/components/movementsensor/server_test.go
+++ b/components/movementsensor/server_test.go
@@ -273,9 +273,10 @@ func TestServer(t *testing.T) {
 		uacc, err = gpsServer.GetAccuracy(context.Background(), &pb.GetAccuracyRequest{Name: failMovementSensorName})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, uacc.Accuracy, test.ShouldResemble, map[string]float32{"foo": 1.1})
-		test.That(t, uacc., test.ShouldBeEqual, )
+		test.That(t, math.IsNaN(float64(*uacc.PositionHdop)), test.ShouldBeTrue)
 		test.That(t, math.IsNaN(float64(*uacc.PositionVdop)), test.ShouldBeTrue)
 		test.That(t, math.IsNaN(float64(*uacc.CompassDegreesError)), test.ShouldBeTrue)
-		test.That(t, *uacc.PositionNmeaGgaFix, test.ShouldResemble, int32(-1))
+		// zero is an invlaid fix, and our default fix if accuracy is implemented
+		test.That(t, *uacc.PositionNmeaGgaFix, test.ShouldResemble, int32(0))
 	})
 }

--- a/components/movementsensor/wheeledodometry/wheeledodometry.go
+++ b/components/movementsensor/wheeledodometry/wheeledodometry.go
@@ -318,7 +318,7 @@ func (o *odometry) Readings(ctx context.Context, extra map[string]interface{}) (
 
 func (o *odometry) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error,
 ) {
-	return movementsensor.UnimplementedAccuracies(), nil
+	return movementsensor.UnimplementedOptionalAccuracies(), nil
 }
 
 func (o *odometry) Properties(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {

--- a/components/movementsensor/wheeledodometry/wheeledodometry.go
+++ b/components/movementsensor/wheeledodometry/wheeledodometry.go
@@ -318,7 +318,7 @@ func (o *odometry) Readings(ctx context.Context, extra map[string]interface{}) (
 
 func (o *odometry) Accuracy(ctx context.Context, extra map[string]interface{}) (*movementsensor.Accuracy, error,
 ) {
-	return movementsensor.UnimplementedAccuracies()
+	return movementsensor.UnimplementedAccuracies(), nil
 }
 
 func (o *odometry) Properties(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {


### PR DESCRIPTION
Since the server functions return pointer to accuracies, this is totally legal:
```go
func (ms *ms) Accuracy(ctx context.Context, extra map[string]interface{}) (*Accuracy, error)
       return nil, nil
```

Which was causing the server to panic because of a nil pointer dereference:
```
2024-04-15T10:11:57.049-0400	ERROR	robot_server	rpc/server.go:318	panicked while calling unary server method	{"error": "rpc error: code = Internal desc = runtime error: invalid memory address or nil pointer dereference", "errorVerbose": "rpc error: code = Internal desc = runtime error: invalid memory address or nil pointer dereference
go.viam.com/rdk/components/movementsensor.accuracyToProtoResponse
\t/Users/randhidayah/viam/rdk/components/movementsensor/accuracy.go:62
go.viam.com/rdk/components/movementsensor.(*serviceServer).GetAccuracy
\t/Users/randhidayah/viam/rdk/components/movementsensor/server.go:174
```

I added some defensive checks so that the response converters return default values if the proto response is nil.
I also added tests to client and server code to make sure this doesn't happen again.

This also makes it so that the RC Card will not show Accuracies if the module or driver returns a nil nil in the accuracy response, changed `builtin:movementsensor:fake` and checked the RC Card shows, addressing [RSDK-6623]( https://viam.atlassian.net/browse/RSDK-6623?atlOrigin=eyJpIjoiMGU5NGM5NmZhZDllNGQ3YmJiMzE3NWEwYTFlODkyNmEiLCJwIjoiaiJ9)
<img width="968" alt="Screenshot 2024-04-15 at 12 08 42" src="https://github.com/viamrobotics/rdk/assets/35934754/2ef87997-1f54-43fa-91d9-248e9c6053e2">

With a happy viam server:
<img width="624" alt="Screenshot 2024-04-15 at 12 09 23" src="https://github.com/viamrobotics/rdk/assets/35934754/7123bb46-eb7b-40c9-95b6-9bc81658b274">

 

[RSDK-6623]: https://viam.atlassian.net/browse/RSDK-6623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ