### PR TITLE
RSDK-6934 - Add ticker for slow resource (re)configuration

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -290,32 +290,6 @@ func (mgr *Manager) startModuleProcess(mod *module) error {
 	)
 }
 
-func (mgr *Manager) startSlowStartupLogTicker(ctx context.Context, msg, modName string) func() {
-	slowTicker := time.NewTicker(2 * time.Second)
-	firstTick := true
-
-	ctxWithCancel, cancel := context.WithCancel(ctx)
-	startTime := time.Now()
-	go func() {
-		for {
-			select {
-			case <-slowTicker.C:
-				elapsed := time.Since(startTime).Seconds()
-				mgr.logger.CWarnw(ctx, msg, "module", modName, "time elapsed", elapsed)
-				if firstTick {
-					slowTicker.Reset(3 * time.Second)
-					firstTick = false
-				} else {
-					slowTicker.Reset(5 * time.Second)
-				}
-			case <-ctxWithCancel.Done():
-				return
-			}
-		}
-	}()
-	return func() { slowTicker.Stop(); cancel() }
-}
-
 func (mgr *Manager) startModule(ctx context.Context, mod *module) error {
 	// add calls startProcess, which can also be called by the OUE handler in the attemptRestart
 	// call. Both of these involve owning a lock, so in unhappy cases of malformed modules
@@ -339,7 +313,8 @@ func (mgr *Manager) startModule(ctx context.Context, mod *module) error {
 		}
 	}
 
-	cleanup := mgr.startSlowStartupLogTicker(ctx, "Waiting for module to complete startup and registration", mod.cfg.Name)
+	cleanup := rutils.SlowStartupLogger(
+		ctx, "Waiting for module to complete startup and registration", "module", mod.cfg.Name, mgr.logger)
 	defer cleanup()
 
 	if err := mgr.startModuleProcess(mod); err != nil {
@@ -898,7 +873,8 @@ func (mgr *Manager) attemptRestart(ctx context.Context, mod *module) []resource.
 	// No need to check mgr.untrustedEnv, as we're restarting the same
 	// executable we were given for initial module addition.
 
-	cleanup := mgr.startSlowStartupLogTicker(ctx, "Waiting for module to complete restart and re-registration", mod.cfg.Name)
+	cleanup := rutils.SlowStartupLogger(
+		ctx, "Waiting for module to complete restart and re-registration", "module", mod.cfg.Name, mgr.logger)
 	defer cleanup()
 
 	// Attempt to restart module process 3 times.

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -697,6 +697,11 @@ func (r *localRobot) updateWeakDependents(ctx context.Context) {
 	processInternalResources := func(resName resource.Name, res resource.Resource, resChan chan struct{}) {
 		ctxWithTimeout, timeoutCancel := context.WithTimeout(ctx, timeout)
 		defer timeoutCancel()
+
+		cleanup := utils.SlowStartupLogger(
+			ctx, "Waiting for internal resource to complete reconfiguration during weak dependencies update", "resource", resName.String(), r.logger)
+		defer cleanup()
+
 		r.reconfigureWorkers.Add(1)
 		goutils.PanicCapturingGo(func() {
 			defer func() {
@@ -780,10 +785,19 @@ func (r *localRobot) updateWeakDependents(ctx context.Context) {
 		conf := conf
 		ctxWithTimeout, timeoutCancel := context.WithTimeout(ctx, timeout)
 		defer timeoutCancel()
+
+		cleanup := utils.SlowStartupLogger(
+			ctx,
+			"Waiting for resource to complete reconfiguration during weak dependencies update",
+			"resource",
+			conf.ResourceName().String(),
+			r.logger,
+		)
 		resChan := make(chan struct{}, 1)
 		r.reconfigureWorkers.Add(1)
 		goutils.PanicCapturingGo(func() {
 			defer func() {
+				cleanup()
 				resChan <- struct{}{}
 				r.reconfigureWorkers.Done()
 			}()

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -597,10 +597,14 @@ func (manager *resourceManager) completeConfig(
 		resName := resName
 		ctxWithTimeout, timeoutCancel := context.WithTimeout(ctx, timeout)
 		defer timeoutCancel()
-		robot.reconfigureWorkers.Add(1)
 
+		cleanup := rutils.SlowStartupLogger(
+			ctx, "Waiting for resource to complete (re)configuration", "resource", resName.String(), manager.logger)
+
+		robot.reconfigureWorkers.Add(1)
 		goutils.PanicCapturingGo(func() {
 			defer func() {
+				cleanup()
 				resChan <- struct{}{}
 				robot.reconfigureWorkers.Done()
 			}()

--- a/utils/ticker.go
+++ b/utils/ticker.go
@@ -1,0 +1,35 @@
+package utils
+
+import (
+	"context"
+	"time"
+
+	"go.viam.com/rdk/logging"
+)
+
+// SlowStartupLogger starts a goroutine that logs every few seconds as long as the context has not timed out or was not cancelled.
+func SlowStartupLogger(ctx context.Context, msg, fieldName, fieldVal string, logger logging.Logger) func() {
+	slowTicker := time.NewTicker(2 * time.Second)
+	firstTick := true
+
+	ctxWithCancel, cancel := context.WithCancel(ctx)
+	startTime := time.Now()
+	go func() {
+		for {
+			select {
+			case <-slowTicker.C:
+				elapsed := time.Since(startTime).Seconds()
+				logger.CWarnw(ctx, msg, fieldName, fieldVal, "time elapsed", elapsed)
+				if firstTick {
+					slowTicker.Reset(3 * time.Second)
+					firstTick = false
+				} else {
+					slowTicker.Reset(5 * time.Second)
+				}
+			case <-ctxWithCancel.Done():
+				return
+			}
+		}
+	}()
+	return func() { slowTicker.Stop(); cancel() }
+}


### PR DESCRIPTION
RDK now warns on slow resource startup/reconfiguration

`2024-04-15T21:05:02.960Z        WARN    robot_server    utils/ticker.go:22      Waiting for resource to complete (re)configuration      {"resource":"rdk:component:encoder/encoder2","time elapsed":2.000306042}
2024-04-15T21:05:05.961Z        WARN    robot_server    utils/ticker.go:22      Waiting for resource to complete (re)configuration      {"resource":"rdk:component:encoder/encoder2","time elapsed":5.000861625}`