### PR TITLE
[APP-4529] fake arm shows nothing on rc card

### DIFF
--- a/components/arm/fake/fake.go
+++ b/components/arm/fake/fake.go
@@ -114,7 +114,7 @@ func (a *Arm) Reconfigure(ctx context.Context, deps resource.Dependencies, conf 
 	if len(model.DoF()) == 0 {
 		a.logger.Info("fake arm built with zero degrees-of-freedom, nothing will show up on the Control tab " +
 			"you have either given a kinematics file that resulted in a zero degrees-of-freedom arm or omitted both" +
-			"the arm-model and model path from attributes")
+			"the arm-model and model-path from attributes")
 	}
 
 	a.mu.Lock()

--- a/components/arm/fake/fake.go
+++ b/components/arm/fake/fake.go
@@ -111,6 +111,12 @@ func (a *Arm) Reconfigure(ctx context.Context, deps resource.Dependencies, conf 
 		return err
 	}
 
+	if len(model.DoF()) == 0 {
+		a.logger.Info("fakre arm built but no degrees of freedom detected, nothing will show up on the Control tab" +
+			"you have either given a kinematics file that resulted in a zero degree of freedom arm or omitted both" +
+			"the arm-model and model path from attributes")
+	}
+
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.joints = &pb.JointPositions{Values: make([]float64, len(model.DoF()))}

--- a/components/arm/fake/fake.go
+++ b/components/arm/fake/fake.go
@@ -112,8 +112,8 @@ func (a *Arm) Reconfigure(ctx context.Context, deps resource.Dependencies, conf 
 	}
 
 	if len(model.DoF()) == 0 {
-		a.logger.Info("fakre arm built but no degrees of freedom detected, nothing will show up on the Control tab" +
-			"you have either given a kinematics file that resulted in a zero degree of freedom arm or omitted both" +
+		a.logger.Info("fake arm built with zero degrees-of-freedom, nothing will show up on the Control tab " +
+			"you have either given a kinematics file that resulted in a zero degrees-of-freedom arm or omitted both" +
 			"the arm-model and model path from attributes")
 	}
 

--- a/components/arm/fake/fake.go
+++ b/components/arm/fake/fake.go
@@ -111,7 +111,8 @@ func (a *Arm) Reconfigure(ctx context.Context, deps resource.Dependencies, conf 
 		return err
 	}
 
-	if len(model.DoF()) == 0 {
+	dof := len(model.DoF())
+	if dof == 0 {
 		a.logger.Info("fake arm built with zero degrees-of-freedom, nothing will show up on the Control tab " +
 			"you have either given a kinematics file that resulted in a zero degrees-of-freedom arm or omitted both" +
 			"the arm-model and model-path from attributes")
@@ -119,7 +120,7 @@ func (a *Arm) Reconfigure(ctx context.Context, deps resource.Dependencies, conf 
 
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	a.joints = &pb.JointPositions{Values: make([]float64, len(model.DoF()))}
+	a.joints = &pb.JointPositions{Values: make([]float64, dof)}
 	a.model = model
 
 	return nil


### PR DESCRIPTION
Naomi noticed the fake arm does not show up on the RC card when configured with nothing. This is expected since omitting both a kinematics file and a model name builds a zero-degrees-of-freedom arm (i.e., no joints—there's nothing to control).

To keep the behaviour as is but surface what's happening to a user, I added a viam-server-side info log. The arm is there—you can get it from the resource graph in client code and use the arm APIs. 

Verified adding a model path or name works as expected, you get button for joints equal to the degrees of freedom specified by the kinematics model or model name of that arm.

An alternative is creating a 1-dof arm by default.

This is what shows up now:
<img width="1108" alt="Screenshot 2024-04-16 at 21 13 47" src="https://github.com/viamrobotics/rdk/assets/35934754/6887e176-8c74-4369-9e11-7d311dab7330">
