### PR TITLE
DATA-2483 Add infrastructure for thread to poll filesystem

### DIFF
--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -55,7 +55,7 @@ const defaultCaptureBufferSize = 4096
 // Default time to wait in milliseconds to check if a file has been modified.
 const defaultFileLastModifiedMillis = 10000.0
 
-// Default time between disk size checks
+// Default time between disk size checks.
 const filesystemPollInterval = 30 * time.Second
 
 var clock = clk.New()
@@ -642,7 +642,7 @@ func (svc *builtIn) sync() {
 	}
 }
 
-// nolint
+//nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
@@ -710,6 +710,7 @@ func generateMetadataKey(component, method string) string {
 	return fmt.Sprintf("%s/%s", component, method)
 }
 
+//nolint:unparam
 func pollFilesystem(ctx context.Context, wg *sync.WaitGroup, captureDir string, logger logging.Logger) {
 	for {
 		t := time.NewTimer(filesystemPollInterval)

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -173,7 +173,6 @@ func (svc *builtIn) Close(_ context.Context) error {
 		svc.syncRoutineCancelFn()
 	}
 	if svc.fileDeletionRoutineCancelFn != nil {
-		svc.logger.Debug("cancelling file deletion in close")
 		svc.fileDeletionRoutineCancelFn()
 	}
 
@@ -439,9 +438,6 @@ func (svc *builtIn) Reconfigure(
 
 	if svc.fileDeletionRoutineCancelFn != nil {
 		svc.fileDeletionRoutineCancelFn()
-	}
-	if svc.fileDeletionWg != nil {
-		svc.fileDeletionWg.Wait()
 	}
 
 	// Initialize or add collectors based on changes to the component configurations.

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -645,7 +645,7 @@ func (svc *builtIn) sync() {
 	}
 }
 
-// nolint
+//nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -646,7 +646,7 @@ func (svc *builtIn) sync() {
 	}
 }
 
-//nolint
+// nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
@@ -716,7 +716,7 @@ func generateMetadataKey(component, method string) string {
 
 //nolint:unparam
 func pollFilesystem(ctx context.Context, wg *sync.WaitGroup, captureDir string, syncer *datasync.Manager, logger logging.Logger) {
-	t := clock.Ticker(filesystemPollInterval)
+	t := time.NewTicker(filesystemPollInterval)
 	defer t.Stop()
 	defer wg.Done()
 	for {

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -646,7 +646,7 @@ func (svc *builtIn) sync() {
 	}
 }
 
-// nolint
+//nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -709,7 +709,6 @@ func generateMetadataKey(component, method string) string {
 }
 
 func pollFilesystem(ctx context.Context, wg *sync.WaitGroup, captureDir string, logger logging.Logger) {
-	logger.Debug("Starting to poll fs")
 	for {
 		select {
 		case <-ctx.Done():

--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -688,11 +688,12 @@ func TestSyncConfigUpdateBehavior(t *testing.T) {
 			newBuildInSvc := dmsvc.(*builtIn)
 			newTicker := newBuildInSvc.syncTicker
 			newSyncer := newBuildInSvc.syncer
+			newFileDeletionBackgroundWorker := newBuildInSvc.fileDeletionBackgroundWorkers
 
 			if tc.newSyncDisabled {
 				test.That(t, newSyncer, test.ShouldBeNil)
 			}
-
+			test.That(t, newFileDeletionBackgroundWorker, test.ShouldNotBeNil)
 			if tc.initSyncDisabled != tc.newSyncDisabled ||
 				tc.initSyncIntervalMins != tc.newSyncIntervalMins {
 				test.That(t, initTicker, test.ShouldNotEqual, newTicker)


### PR DESCRIPTION
Hey yall, this PR is to add the necessary fields/goroutines to poll the filesystem at a regular interval. 

**Implementation details**
There is no real difference between the implementation here and the tech spec (yay). I added a cancel function and waitgroup to the service struct. These fields are intialized in reconfigure and any access to them is guarded by a nil check (pls point out if I missed a spot). Each time reconfigure is called, we cancel the context and wait for the currently executing thread to finish. 
If capture is enabled, we create a new context and wait group and kickoff the go routine. For now, this routine just prints once every 30 seconds if debug is enabled. 
If capture is disabled, we dont start the thread and nil out the cancel func and wait group.

In close, we cancel the context and wait for the thread to finish its work.

**Testing**
So far I have only tested this on my mac by seeing when polling was printed and manually either doing something to cause data to reconfigure or exiting rdk. I tested reconfigure by adding a new datacapture method and seeing that the robot reconfigured quickly (no 30 second wait) and shut down the robot and checked there were no go routine leaks. 