### PR TITLE
APP-4665 collapse cloud-build logs

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -49,13 +49,14 @@ const (
 	moduleFlagForce           = "force"
 	moduleFlagBinary          = "binary"
 
-	moduleBuildFlagPath     = "module"
-	moduleBuildFlagRef      = "ref"
-	moduleBuildFlagCount    = "count"
-	moduleBuildFlagVersion  = "version"
-	moduleBuildFlagBuildID  = "id"
-	moduleBuildFlagPlatform = "platform"
-	moduleBuildFlagWait     = "wait"
+	moduleBuildFlagPath      = "module"
+	moduleBuildFlagRef       = "ref"
+	moduleBuildFlagCount     = "count"
+	moduleBuildFlagVersion   = "version"
+	moduleBuildFlagBuildID   = "id"
+	moduleBuildFlagPlatform  = "platform"
+	moduleBuildFlagWait      = "wait"
+	moduleBuildFlagGroupLogs = "group-logs"
 
 	mlTrainingFlagPath      = "path"
 	mlTrainingFlagName      = "name"
@@ -1372,6 +1373,10 @@ Example:
 								&cli.BoolFlag{
 									Name:  moduleBuildFlagWait,
 									Usage: "wait for the build to finish before outputting any logs",
+								},
+								&cli.BoolFlag{
+									Name:  moduleBuildFlagGroupLogs,
+									Usage: "write ::group:: commands so github action logs collapse",
 								},
 							},
 							Action: ModuleBuildLogsAction,

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -220,13 +220,13 @@ func ModuleBuildLogsAction(c *cli.Context) error {
 		for _, platform := range platforms {
 			if groupLogs {
 				statusEmoji := "❓"
-				switch statuses[platform] {
+				switch statuses[platform] { //nolint: exhaustive
 				case jobStatusDone:
 					statusEmoji = "✅"
 				case jobStatusFailed:
 					statusEmoji = "❌"
 				}
-				fmt.Fprintf(os.Stdout, "::group::{%s %s}\n", statusEmoji, platform)
+				printf(os.Stdout, "::group::{%s %s}", statusEmoji, platform)
 			}
 			infof(c.App.Writer, "Logs for %q", platform)
 			err := client.printModuleBuildLogs(buildID, platform)
@@ -234,7 +234,7 @@ func ModuleBuildLogsAction(c *cli.Context) error {
 				combinedErr = multierr.Combine(combinedErr, client.printModuleBuildLogs(buildID, platform))
 			}
 			if groupLogs {
-				fmt.Fprint(os.Stdout, "::endgroup::\n")
+				printf(os.Stdout, "::endgroup::")
 			}
 		}
 		if combinedErr != nil {

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -192,6 +193,7 @@ func ModuleBuildLogsAction(c *cli.Context) error {
 	buildID := c.String(moduleBuildFlagBuildID)
 	platform := c.String(moduleBuildFlagPlatform)
 	shouldWait := c.Bool(moduleBuildFlagWait)
+	groupLogs := c.Bool(moduleBuildFlagGroupLogs)
 
 	client, err := newViamClient(c)
 	if err != nil {
@@ -216,10 +218,23 @@ func ModuleBuildLogsAction(c *cli.Context) error {
 		}
 		var combinedErr error
 		for _, platform := range platforms {
+			if groupLogs {
+				statusEmoji := "❓"
+				switch statuses[platform] {
+				case jobStatusDone:
+					statusEmoji = "✅"
+				case jobStatusFailed:
+					statusEmoji = "❌"
+				}
+				fmt.Fprintf(os.Stdout, "::group::{%s %s}\n", statusEmoji, platform)
+			}
 			infof(c.App.Writer, "Logs for %q", platform)
 			err := client.printModuleBuildLogs(buildID, platform)
 			if err != nil {
 				combinedErr = multierr.Combine(combinedErr, client.printModuleBuildLogs(buildID, platform))
+			}
+			if groupLogs {
+				fmt.Fprint(os.Stdout, "::endgroup::\n")
 			}
 		}
 		if combinedErr != nil {


### PR DESCRIPTION
## What changed
- add `--group-logs` param to ModuleBuildLogsAction
- when present, this flag adds a `::group::` wrapper to each platform in the logs output
- should match expected format in [their docs here](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines)
## Why
Currently, when multiple platforms are present in this output, it's difficult to read the logs. When one of them fails, it's difficult to know which.
## Example output
```log
::group::{✅ linux/amd64}
Info: Logs for "linux/amd64"
Info: viam version
...
Total size uploaded: 1.7 KiB
::endgroup::
```