### PR TITLE
DATA-2565 - Retry sync for up to a day

### DIFF
--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -28,7 +28,7 @@ var (
 	InitialWaitTimeMillis = atomic.NewInt32(1000)
 	// RetryExponentialFactor defines the factor by which the retry wait time increases.
 	RetryExponentialFactor = atomic.NewInt32(2)
-	maxRetryInterval       = time.Hour
+	maxRetryInterval       = 24 * time.Hour
 )
 
 // FailedDir is a subdirectory of the capture directory that holds any files that could not be synced.


### PR DESCRIPTION
We use a exponential backoff algorithm, multiplying the previous time by 2 until min(maxRetryInterval, nextWait). So after 1 hour, we will retry sync at 2, 4, 8, 16, 24 hrs.