### PR TITLE
use StoppableWorkers in the IMU Wit components

### DIFF
--- a/components/movementsensor/imuwit/imu.go
+++ b/components/movementsensor/imuwit/imu.go
@@ -291,12 +291,12 @@ func newWit(
 	}
 
 	portReader := bufio.NewReader(i.port)
-	i.startUpdateLoop(context.Background(), portReader, logger)
+	i.startUpdateLoop(portReader, logger)
 
 	return &i, nil
 }
 
-func (imu *wit) startUpdateLoop(ctx context.Context, portReader *bufio.Reader, logger logging.Logger) {
+func (imu *wit) startUpdateLoop(portReader *bufio.Reader, logger logging.Logger) {
 	imu.hasMagnetometer = false
 	imu.workers = rutils.NewStoppableWorkers(func(ctx context.Context) {
 		defer utils.UncheckedErrorFunc(func() error {

--- a/components/movementsensor/imuwit/imu.go
+++ b/components/movementsensor/imuwit/imu.go
@@ -88,21 +88,21 @@ func init() {
 type wit struct {
 	resource.Named
 	resource.AlwaysRebuild
-	angularVelocity         spatialmath.AngularVelocity
-	orientation             spatialmath.EulerAngles
-	acceleration            r3.Vector
-	magnetometer            r3.Vector
-	compassheading          float64
-	numBadReadings          uint32
-	err                     movementsensor.LastError
-	hasMagnetometer         bool
-	mu                      sync.Mutex
-	reconfigMu              sync.Mutex
-	port                    io.ReadWriteCloser
-	workers                 rutils.StoppableWorkers
-	logger                  logging.Logger
-	baudRate                uint
-	serialPath              string
+	angularVelocity spatialmath.AngularVelocity
+	orientation     spatialmath.EulerAngles
+	acceleration    r3.Vector
+	magnetometer    r3.Vector
+	compassheading  float64
+	numBadReadings  uint32
+	err             movementsensor.LastError
+	hasMagnetometer bool
+	mu              sync.Mutex
+	reconfigMu      sync.Mutex
+	port            io.ReadWriteCloser
+	workers         rutils.StoppableWorkers
+	logger          logging.Logger
+	baudRate        uint
+	serialPath      string
 }
 
 func (imu *wit) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {


### PR DESCRIPTION
We've had a pattern of creating an `activeBackgroundWorkers` group to track our goroutines, with a context that gets canceled within `Close()`, followed by waiting for the workers to shut down. In my 20% time, I've abstracted this pattern out to a separate struct (see #3597; thanks @dgottlieb for the feedback on that!), and in this PR I'm using it in the IMU Wit code. 

It might be simplest to review the two commits separately: the second one just changes a bunch of whitespace to make the linter happy.

Similar PRs will be coming for the other places where we use this pattern...