### PR TITLE
Change xarm, pca, and webcam attribute requirements.

### DIFF
--- a/components/arm/xarm/xarm.go
+++ b/components/arm/xarm/xarm.go
@@ -26,8 +26,6 @@ type Config struct {
 	Port         int     `json:"port,omitempty" jsonschema="default=502"`
 	Speed        float32 `json:"speed_degs_per_sec,omitempty" jsonschema=default=20"`
 	Acceleration float32 `json:"acceleration_degs_per_sec_per_sec,omitempty"`
-
-	parsedPort string
 }
 
 // Validate validates the config.

--- a/components/arm/xarm/xarm.go
+++ b/components/arm/xarm/xarm.go
@@ -24,7 +24,7 @@ import (
 type Config struct {
 	Host         string  `json:"host"`
 	Port         int     `json:"port,omitempty" jsonschema="default=502"`
-	Speed        float32 `json:"speed_degs_per_sec,omitempty" jsonschema=default=20"`
+	Speed        float32 `json:"speed_degs_per_sec,omitempty" jsonschema="default=20"`
 	Acceleration float32 `json:"acceleration_degs_per_sec_per_sec,omitempty"`
 }
 

--- a/components/arm/xarm/xarm.go
+++ b/components/arm/xarm/xarm.go
@@ -23,8 +23,8 @@ import (
 // Config is used for converting config attributes.
 type Config struct {
 	Host         string  `json:"host"`
-	Port         int     `json:"port,omitempty" jsonschema="default=502"`
-	Speed        float32 `json:"speed_degs_per_sec,omitempty" jsonschema="default=20"`
+	Port         int     `json:"port,omitempty"`
+	Speed        float32 `json:"speed_degs_per_sec,omitempty"`
 	Acceleration float32 `json:"acceleration_degs_per_sec_per_sec,omitempty"`
 }
 

--- a/components/arm/xarm/xarm_test.go
+++ b/components/arm/xarm/xarm_test.go
@@ -132,7 +132,6 @@ func TestReconfigure(t *testing.T) {
 			Speed:        0.3,
 			Host:         host1,
 			Port:         int(port1),
-			parsedPort:   port1Str,
 			Acceleration: 0.1,
 		},
 	}
@@ -143,7 +142,6 @@ func TestReconfigure(t *testing.T) {
 			Speed:        0.5,
 			Host:         host1,
 			Port:         int(port1),
-			parsedPort:   port1Str,
 			Acceleration: 0.3,
 		},
 	}
@@ -154,7 +152,6 @@ func TestReconfigure(t *testing.T) {
 			Speed:        0.6,
 			Host:         host2,
 			Port:         int(port2),
-			parsedPort:   port2Str,
 			Acceleration: 0.34,
 		},
 	}

--- a/components/board/hat/pca9685/pca9685.go
+++ b/components/board/hat/pca9685/pca9685.go
@@ -31,7 +31,7 @@ var (
 
 // Config describes a PCA9685 board attached to some other board via I2C.
 type Config struct {
-	I2CBus     string `json:"i2c_bus,omitempty"`
+	I2CBus     string `json:"i2c_bus"`
 	I2CAddress *int   `json:"i2c_address,omitempty"`
 }
 

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -169,7 +169,7 @@ type WebcamConfig struct {
 	DistortionParameters *transform.BrownConrady            `json:"distortion_parameters,omitempty"`
 	Debug                bool                               `json:"debug,omitempty"`
 	Format               string                             `json:"format,omitempty"`
-	Path                 string                             `json:"video_path,omitempty"`
+	Path                 string                             `json:"video_path"`
 	Width                int                                `json:"width_px,omitempty"`
 	Height               int                                `json:"height_px,omitempty"`
 	FrameRate            float32                            `json:"frame_rate,omitempty"`


### PR DESCRIPTION
An ask from fleet to change the following attributes:
- webcam "device_path" -> required
- xarm "speed", "host", "acceleration" -> optional. Did a little cleanup here too so that we 
a) don't change the config from app in Validation (an anti pattern)
b) add some schema clauses for defaults. We don't use these tags directly. These are checked in Reconfiguration and set for the driver that actually interfaces with hardware.
- pca -> "i2c_bus" required.

TODO
- [x] Test on xarm
@mcous this won't be reflected in app until it pulls in the next rdk right? What's a quick and dirty way to verify that r2d2 adheres to these changes? Particularly interested in the json schema now breaking anything.