### PR TITLE
[RSDK-6243] read analogs at expected rate even with errors

### DIFF
--- a/components/board/pinwrappers/analogs.go
+++ b/components/board/pinwrappers/analogs.go
@@ -113,16 +113,16 @@ func (as *AnalogSmoother) Start() {
 			start := time.Now()
 			reading, err := as.Raw.Read(ctx, nil)
 			as.lastError.Store(&errValue{err != nil, err})
-			if err != nil {
-				if errors.Is(err, errStopReading) {
-					break
-				}
-				as.logger.CInfow(ctx, "error reading analog", "error", err)
-			} else { // No error: store the successful reading
+			if err == nil {
 				as.lastData = reading
 				if as.data != nil {
 					as.data.Add(reading)
 				}
+			} else { // Non-nil error
+				if errors.Is(err, errStopReading) {
+					break
+				}
+				as.logger.CInfow(ctx, "error reading analog", "error", err)
 			}
 
 			end := time.Now()

--- a/components/board/pinwrappers/analogs.go
+++ b/components/board/pinwrappers/analogs.go
@@ -104,7 +104,6 @@ func (as *AnalogSmoother) Start() {
 	}
 
 	as.workers = utils.NewStoppableWorkers(func(ctx context.Context) {
-		var consecutiveErrors int
 		for {
 			select {
 			case <-ctx.Done():
@@ -119,14 +118,8 @@ func (as *AnalogSmoother) Start() {
 					break
 				}
 				as.logger.CInfow(ctx, "error reading analog", "error", err)
-				consecutiveErrors++
-				if consecutiveErrors > 100 {
-					as.logger.CError(ctx, "too many errors on analog reader, giving up")
-					return // Stop spamming the logs
-				}
 				continue
 			}
-			consecutiveErrors = 0
 
 			as.lastData = reading
 			if as.data != nil {

--- a/components/board/pinwrappers/analogs.go
+++ b/components/board/pinwrappers/analogs.go
@@ -118,12 +118,11 @@ func (as *AnalogSmoother) Start() {
 					break
 				}
 				as.logger.CInfow(ctx, "error reading analog", "error", err)
-				continue
-			}
-
-			as.lastData = reading
-			if as.data != nil {
-				as.data.Add(reading)
+			} else { // No error: store the successful reading
+				as.lastData = reading
+				if as.data != nil {
+					as.data.Add(reading)
+				}
 			}
 
 			end := time.Now()

--- a/components/board/pinwrappers/analogs.go
+++ b/components/board/pinwrappers/analogs.go
@@ -104,6 +104,7 @@ func (as *AnalogSmoother) Start() {
 	}
 
 	as.workers = utils.NewStoppableWorkers(func(ctx context.Context) {
+		var consecutiveErrors int
 		for {
 			select {
 			case <-ctx.Done():
@@ -118,8 +119,14 @@ func (as *AnalogSmoother) Start() {
 					break
 				}
 				as.logger.CInfow(ctx, "error reading analog", "error", err)
+				consecutiveErrors++
+				if consecutiveErrors > 100 {
+					as.logger.CError(ctx, "too many errors on analog reader, giving up")
+					return // Stop spamming the logs
+				}
 				continue
 			}
+			consecutiveErrors = 0
 
 			as.lastData = reading
 			if as.data != nil {


### PR DESCRIPTION
Thanks to @cheukt for some of the investigation on this!

If you configure an analog reader but don't have the hardware set up, before this PR you get into a tight retry loop, and can log errors thousands of times per second. Now, you only log the errors as fast as you were supposed to read the analog.

This PR has an alternate implementation, where we try to read the analogs as quickly as before but shut down the entire goroutine if we get 100 errors in a row. I tentatively prefer this version instead (so it starts working if you plug in the right hardware, even if you don't then reconfigure your board), but am open to either approach.