### PR TITLE
RSDK-7383 pin macos in CI

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
## What changed
- pin macos.yml macos runner version
## Passing builds
- macos-12 https://github.com/viamrobotics/rdk/actions/runs/8792719380/job/24129397979
- macos-13 https://github.com/viamrobotics/rdk/actions/runs/8792969817/job/24130089706
## Why
Our macos-latest jobs went from 12 -> 14 and started failing. We should investigate but for now I'm pinning the image to get builds green.

The failure:
```
# github.com/mattn/go-tflite
In file included from ../../../go/pkg/mod/github.com/mattn/go-tflite@v1.0.4/tflite.go:5:
./tflite.go.h:8:10: fatal error: 'tensorflow/lite/c/c_api.h' file not found
#include <tensorflow/lite/c/c_api.h>
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

[Passing job (old)](https://github.com/viamrobotics/rdk/actions/runs/8790733687/job/24124159229)
```
Image: macos-12
  Version: 20240412.2
  Included Software: https://github.com/actions/runner-images/blob/macOS-12/20240412.2/images/macos/macos-12-Readme.md
  Image Release: https://github.com/actions/runner-images/releases/tag/macOS-12%2F20240412.2
```

[Failing job (new)](https://github.com/viamrobotics/rdk/actions/runs/8791591973/job/24127560279?pr=3834#step:5:1)
```
Image: macos-14-arm64
  Version: 20240415.6
  Included Software: https://github.com/actions/runner-images/blob/macos-14-arm64/20240415.6/images/macos/macos-14-arm64-Readme.md
  Image Release: https://github.com/actions/runner-images/releases/tag/macos-14-arm64%2F20240415.6
```