### PR TITLE
RSDK-7303, RSDK-7360 - Test Datarace - local robot

### DIFF
--- a/robot/impl/utils.go
+++ b/robot/impl/utils.go
@@ -25,7 +25,6 @@ func setupLocalRobot(
 
 	r, err := New(ctx, cfg, logger)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, r, test.ShouldNotBeNil)
 	t.Cleanup(func() {
 		test.That(t, r.Close(ctx), test.ShouldBeNil)
 	})

--- a/robot/impltest/local_robot.go
+++ b/robot/impltest/local_robot.go
@@ -26,7 +26,6 @@ func LocalRobot(
 
 	r, err := robotimpl.New(ctx, cfg, logger)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, r, test.ShouldNotBeNil)
 	t.Cleanup(func() {
 		test.That(t, r.Close(ctx), test.ShouldBeNil)
 	})


### PR DESCRIPTION
both ran into a race with an atomic value store when trying to assert local robot is not nil, which isn't necessary if err is already checked. There isn't a way to prevent this race, as there's no way from the test side to know when the local robot is updating