### PR TITLE
Don't use public archive errors package in Components

### DIFF
--- a/components/arm/eva/eva.go
+++ b/components/arm/eva/eva.go
@@ -6,18 +6,16 @@ package eva
 import (
 	"bytes"
 	"context"
-
 	// for embedding model file.
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
-
-	"errors"
 
 	"go.uber.org/multierr"
 	pb "go.viam.com/api/component/arm/v1"

--- a/components/arm/fake/fake.go
+++ b/components/arm/fake/fake.go
@@ -3,11 +3,10 @@ package fake
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
-
-	"errors"
 
 	pb "go.viam.com/api/component/arm/v1"
 

--- a/components/arm/fake/fake.go
+++ b/components/arm/fake/fake.go
@@ -3,10 +3,12 @@ package fake
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	pb "go.viam.com/api/component/arm/v1"
 
 	"go.viam.com/rdk/components/arm"
@@ -239,7 +241,7 @@ func modelFromName(model, name string) (referenceframe.Model, error) {
 	case eva.Model.Name:
 		return eva.MakeModelFrame(name)
 	default:
-		return nil, errors.Errorf("fake arm cannot be created, unsupported arm-model: %s", model)
+		return nil, fmt.Errorf("fake arm cannot be created, unsupported arm-model: %s", model)
 	}
 }
 

--- a/components/arm/server_test.go
+++ b/components/arm/server_test.go
@@ -2,9 +2,8 @@ package arm_test
 
 import (
 	"context"
-	"testing"
-
 	"errors"
+	"testing"
 
 	"github.com/golang/geo/r3"
 	commonpb "go.viam.com/api/common/v1"
@@ -26,7 +25,7 @@ var (
 	errGetJointsFailed           = errors.New("can't get joint positions")
 	errMoveToPositionFailed      = errors.New("can't move to pose")
 	errMoveToJointPositionFailed = errors.New("can't move to joint positions")
-	errStopUnimplemented         = errors.New("Stop unimplemented")
+	errStopUnimplemented         = errors.New("stop unimplemented")
 	errArmUnimplemented          = errors.New("not found")
 )
 

--- a/components/arm/server_test.go
+++ b/components/arm/server_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"testing"
 
+	"errors"
+
 	"github.com/golang/geo/r3"
-	"github.com/pkg/errors"
 	commonpb "go.viam.com/api/common/v1"
 	pb "go.viam.com/api/component/arm/v1"
 	"go.viam.com/test"

--- a/components/arm/universalrobots/ur.go
+++ b/components/arm/universalrobots/ur.go
@@ -4,10 +4,10 @@ package universalrobots
 import (
 	"bufio"
 	"context"
-
 	// for embedding model file.
 	_ "embed"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -17,8 +17,6 @@ import (
 	"sync"
 	"syscall"
 	"time"
-
-	"errors"
 
 	"go.uber.org/multierr"
 	pb "go.viam.com/api/component/arm/v1"

--- a/components/arm/universalrobots/ur_parser.go
+++ b/components/arm/universalrobots/ur_parser.go
@@ -4,11 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"time"
-
-	"errors"
 
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/utils"

--- a/components/arm/universalrobots/ur_parser.go
+++ b/components/arm/universalrobots/ur_parser.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/pkg/errors"
+	"errors"
 
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/utils"
@@ -286,7 +286,7 @@ func readURRobotMessage(ctx context.Context, buf []byte, logger logging.Logger) 
 		scriptLineNumber := binary.BigEndian.Uint32(buf)
 		scriptColumnNumber := binary.BigEndian.Uint32(buf[4:])
 		msg := string(buf[9:])
-		runtimeErr := errors.Errorf("runtime error at line: %d col: %d msg: %s", scriptLineNumber, scriptColumnNumber, msg)
+		runtimeErr := fmt.Errorf("runtime error at line: %d col: %d msg: %s", scriptLineNumber, scriptColumnNumber, msg)
 		return runtimeErr
 	default:
 		logger.CDebugf(ctx, "unknown robotMessageType: %d ts: %v %v\n", robotMessageType, ts, buf)

--- a/components/arm/xarm/xarm.go
+++ b/components/arm/xarm/xarm.go
@@ -9,7 +9,7 @@ import (
 	"net"
 	"sync"
 
-	"github.com/pkg/errors"
+	"errors"
 
 	"go.viam.com/rdk/components/arm"
 	"go.viam.com/rdk/logging"
@@ -172,7 +172,7 @@ func (x *xArm) Reconfigure(ctx context.Context, deps resource.Dependencies, conf
 		x.conn = newConn
 
 		if err := x.start(ctx); err != nil {
-			return errors.Wrap(err, "failed to start on reconfigure")
+			return errors.Join(err, errors.New("failed to start on reconfigure"))
 		}
 	}
 

--- a/components/arm/xarm/xarm.go
+++ b/components/arm/xarm/xarm.go
@@ -5,11 +5,10 @@ import (
 	"context"
 	// for embedding model file.
 	_ "embed"
+	"errors"
 	"fmt"
 	"net"
 	"sync"
-
-	"errors"
 
 	"go.viam.com/rdk/components/arm"
 	"go.viam.com/rdk/logging"

--- a/components/audioinput/client.go
+++ b/components/audioinput/client.go
@@ -2,13 +2,15 @@ package audioinput
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"math"
 	"sync"
 
+	"errors"
+
 	"github.com/pion/mediadevices/pkg/prop"
 	"github.com/pion/mediadevices/pkg/wave"
-	"github.com/pkg/errors"
 	pb "go.viam.com/api/component/audioinput/v1"
 	"go.viam.com/utils"
 	"go.viam.com/utils/rpc"
@@ -166,7 +168,7 @@ func (c *client) Stream(
 				case pb.SampleFormat_SAMPLE_FORMAT_UNSPECIFIED:
 					fallthrough
 				default:
-					nextErr = errors.Errorf("unknown type of audio sample format %v", infoProto.SampleFormat)
+					nextErr = fmt.Errorf("unknown type of audio sample format %v", infoProto.SampleFormat)
 				}
 			}
 

--- a/components/audioinput/client.go
+++ b/components/audioinput/client.go
@@ -2,12 +2,11 @@ package audioinput
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math"
 	"sync"
-
-	"errors"
 
 	"github.com/pion/mediadevices/pkg/prop"
 	"github.com/pion/mediadevices/pkg/wave"

--- a/components/audioinput/server.go
+++ b/components/audioinput/server.go
@@ -9,11 +9,12 @@ import (
 	"time"
 	"unsafe"
 
+	"errors"
+
 	"github.com/go-audio/audio"
 	"github.com/go-audio/transforms"
 	"github.com/go-audio/wav"
 	"github.com/pion/mediadevices/pkg/wave"
-	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 	commonpb "go.viam.com/api/common/v1"
 	pb "go.viam.com/api/component/audioinput/v1"
@@ -88,7 +89,7 @@ func (s *serviceServer) Chunks(req *pb.ChunksRequest, server pb.AudioInputServic
 	case pb.SampleFormat_SAMPLE_FORMAT_FLOAT32_INTERLEAVED:
 		sf = wave.Float32SampleFormat
 	default:
-		return errors.Errorf("unknown type of audio sample format %v", req.SampleFormat)
+		return fmt.Errorf("unknown type of audio sample format %v", req.SampleFormat)
 	}
 
 	if err := server.Send(&pb.ChunksResponse{
@@ -145,7 +146,7 @@ func (s *serviceServer) Chunks(req *pb.ChunksRequest, server pb.AudioInputServic
 				return err
 			}
 		default:
-			return errors.Errorf("unknown type of audio buffer %T", chunk)
+			return fmt.Errorf("unknown type of audio buffer %T", chunk)
 		}
 
 		return server.Send(&pb.ChunksResponse{
@@ -281,7 +282,7 @@ func (s *serviceServer) Record(
 
 			return wavEnc.Write(buf.AsIntBuffer())
 		default:
-			return errors.Errorf("unknown type of audio buffer %T", chunk)
+			return fmt.Errorf("unknown type of audio buffer %T", chunk)
 		}
 	}
 	numChunks := int(duration.Seconds() * float64(info.SamplingRate/info.Len))

--- a/components/audioinput/server.go
+++ b/components/audioinput/server.go
@@ -4,12 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"time"
 	"unsafe"
-
-	"errors"
 
 	"github.com/go-audio/audio"
 	"github.com/go-audio/transforms"

--- a/components/base/sensorcontrolled/sensorcontrolled.go
+++ b/components/base/sensorcontrolled/sensorcontrolled.go
@@ -3,11 +3,10 @@ package sensorcontrolled
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
-
-	"errors"
 
 	"github.com/golang/geo/r3"
 

--- a/components/base/sensorcontrolled/sensorcontrolled.go
+++ b/components/base/sensorcontrolled/sensorcontrolled.go
@@ -3,11 +3,13 @@ package sensorcontrolled
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
+	"errors"
+
 	"github.com/golang/geo/r3"
-	"github.com/pkg/errors"
 
 	"go.viam.com/rdk/components/base"
 	"go.viam.com/rdk/components/movementsensor"
@@ -130,7 +132,7 @@ func (sb *sensorBase) Reconfigure(ctx context.Context, deps resource.Dependencie
 	for _, name := range newConf.MovementSensor {
 		ms, err := movementsensor.FromDependencies(deps, name)
 		if err != nil {
-			return errors.Wrapf(err, "no movement sensor named (%s)", name)
+			return errors.Join(err, fmt.Errorf("no movement sensor named (%s)", name))
 		}
 		sb.allSensors = append(sb.allSensors, ms)
 	}
@@ -182,7 +184,7 @@ func (sb *sensorBase) Reconfigure(ctx context.Context, deps resource.Dependencie
 
 	sb.controlledBase, err = base.FromDependencies(deps, newConf.Base)
 	if err != nil {
-		return errors.Wrapf(err, "no base named (%s)", newConf.Base)
+		return errors.Join(err, fmt.Errorf("no base named (%s)", newConf.Base))
 	}
 
 	if sb.velocities != nil && len(newConf.ControlParameters) != 0 {

--- a/components/base/server_test.go
+++ b/components/base/server_test.go
@@ -2,9 +2,8 @@ package base_test
 
 import (
 	"context"
-	"testing"
-
 	"errors"
+	"testing"
 
 	pb "go.viam.com/api/component/base/v1"
 	"go.viam.com/test"

--- a/components/base/server_test.go
+++ b/components/base/server_test.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	pb "go.viam.com/api/component/base/v1"
 	"go.viam.com/test"
 

--- a/components/base/wheeled/wheeled_base.go
+++ b/components/base/wheeled/wheeled_base.go
@@ -37,8 +37,9 @@ import (
 	"math"
 	"sync"
 
+	"errors"
+
 	"github.com/golang/geo/r3"
-	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 
 	"go.viam.com/rdk/components/base"
@@ -153,7 +154,7 @@ func (wb *wheeledBase) Reconfigure(ctx context.Context, deps resource.Dependenci
 				}
 				m, err := motor.FromDependencies(deps, name)
 				if err != nil {
-					return newMotors, errors.Wrapf(err, "no %s motor named (%s)", whichMotor, name)
+					return newMotors, errors.Join(err, fmt.Errorf("no %s motor named (%s)", whichMotor, name))
 				}
 				newMotors = append(newMotors, m)
 			}
@@ -169,7 +170,7 @@ func (wb *wheeledBase) Reconfigure(ctx context.Context, deps resource.Dependenci
 					for _, name := range fromConfig {
 						m, err := motor.FromDependencies(deps, name)
 						if err != nil {
-							return newMotors, errors.Wrapf(err, "no %s motor named (%s)", whichMotor, name)
+							return newMotors, errors.Join(err, fmt.Errorf("no %s motor named (%s)", whichMotor, name))
 						}
 						newMotors = append(newMotors, m)
 					}
@@ -244,7 +245,7 @@ func (wb *wheeledBase) Spin(ctx context.Context, angleDeg, degsPerSec float64, e
 	if math.Abs(degsPerSec) < 0.0001 {
 		err := wb.Stop(ctx, nil)
 		if err != nil {
-			return errors.Errorf("error when trying to spin at a speed of 0: %v", err)
+			return fmt.Errorf("error when trying to spin at a speed of 0: %v", err)
 		}
 		return err
 	}
@@ -263,7 +264,7 @@ func (wb *wheeledBase) MoveStraight(ctx context.Context, distanceMm int, mmPerSe
 	if math.Abs(mmPerSec) < 0.0001 || distanceMm == 0 {
 		err := wb.Stop(ctx, nil)
 		if err != nil {
-			return errors.Errorf("error when trying to move straight at a speed and/or distance of 0: %v", err)
+			return fmt.Errorf("error when trying to move straight at a speed and/or distance of 0: %v", err)
 		}
 		return err
 	}

--- a/components/base/wheeled/wheeled_base.go
+++ b/components/base/wheeled/wheeled_base.go
@@ -33,11 +33,10 @@ package wheeled
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"sync"
-
-	"errors"
 
 	"github.com/golang/geo/r3"
 	"go.uber.org/multierr"
@@ -245,7 +244,7 @@ func (wb *wheeledBase) Spin(ctx context.Context, angleDeg, degsPerSec float64, e
 	if math.Abs(degsPerSec) < 0.0001 {
 		err := wb.Stop(ctx, nil)
 		if err != nil {
-			return fmt.Errorf("error when trying to spin at a speed of 0: %v", err)
+			return fmt.Errorf("error when trying to spin at a speed of 0: %w", err)
 		}
 		return err
 	}
@@ -264,7 +263,7 @@ func (wb *wheeledBase) MoveStraight(ctx context.Context, distanceMm int, mmPerSe
 	if math.Abs(mmPerSec) < 0.0001 || distanceMm == 0 {
 		err := wb.Stop(ctx, nil)
 		if err != nil {
-			return fmt.Errorf("error when trying to move straight at a speed and/or distance of 0: %v", err)
+			return fmt.Errorf("error when trying to move straight at a speed and/or distance of 0: %w", err)
 		}
 		return err
 	}

--- a/components/board/beaglebone/board.go
+++ b/components/board/beaglebone/board.go
@@ -2,7 +2,8 @@
 package beaglebone
 
 import (
-	"github.com/pkg/errors"
+	"errors"
+
 	"periph.io/x/host/v3"
 
 	"go.viam.com/rdk/components/board/genericlinux"

--- a/components/board/client.go
+++ b/components/board/client.go
@@ -3,11 +3,10 @@ package board
 
 import (
 	"context"
+	"errors"
 	"math"
 	"sync"
 	"time"
-
-	"errors"
 
 	commonpb "go.viam.com/api/common/v1"
 	pb "go.viam.com/api/component/board/v1"

--- a/components/board/client.go
+++ b/components/board/client.go
@@ -7,7 +7,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	commonpb "go.viam.com/api/common/v1"
 	pb "go.viam.com/api/component/board/v1"
 	"go.viam.com/utils/protoutils"
@@ -129,7 +130,7 @@ func (c *client) Status(ctx context.Context, extra map[string]interface{}) (*com
 func (c *client) refresh(ctx context.Context) error {
 	status, err := c.status(ctx)
 	if err != nil {
-		return errors.Wrap(err, "status call failed")
+		return errors.Join(err, errors.New("status call failed"))
 	}
 	c.storeStatus(status)
 

--- a/components/board/collector.go
+++ b/components/board/collector.go
@@ -3,7 +3,8 @@ package board
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	pb "go.viam.com/api/component/board/v1"
 	"google.golang.org/protobuf/types/known/anypb"
 

--- a/components/board/collector.go
+++ b/components/board/collector.go
@@ -2,7 +2,6 @@ package board
 
 import (
 	"context"
-
 	"errors"
 
 	pb "go.viam.com/api/component/board/v1"
@@ -44,7 +43,7 @@ func newAnalogCollector(resource interface{}, params data.CollectorParams) (data
 		var value int
 		if _, ok := arg[analogReaderNameKey]; !ok {
 			return nil, data.FailedToReadErr(params.ComponentName, analogs.String(),
-				errors.New("Must supply reader_name in additional_params for analog collector"))
+				errors.New("must supply reader_name in additional_params for analog collector"))
 		}
 		if reader, err := board.AnalogByName(arg[analogReaderNameKey].String()); err == nil {
 			value, err = reader.Read(ctx, data.FromDMExtraMap)
@@ -76,7 +75,7 @@ func newGPIOCollector(resource interface{}, params data.CollectorParams) (data.C
 		var value bool
 		if _, ok := arg[gpioPinNameKey]; !ok {
 			return nil, data.FailedToReadErr(params.ComponentName, gpios.String(),
-				errors.New("Must supply pin_name in additional params for gpio collector"))
+				errors.New("must supply pin_name in additional params for gpio collector"))
 		}
 		if gpio, err := board.GPIOPinByName(arg[gpioPinNameKey].String()); err == nil {
 			value, err = gpio.Get(ctx, data.FromDMExtraMap)

--- a/components/board/fake/board.go
+++ b/components/board/fake/board.go
@@ -8,7 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	"go.uber.org/multierr"
 	commonpb "go.viam.com/api/common/v1"
 	pb "go.viam.com/api/component/board/v1"
@@ -163,7 +164,7 @@ func (b *Board) AnalogByName(name string) (board.Analog, error) {
 	defer b.mu.RUnlock()
 	a, ok := b.Analogs[name]
 	if !ok {
-		return nil, errors.Errorf("can't find AnalogReader (%s)", name)
+		return nil, fmt.Errorf("can't find AnalogReader (%s)", name)
 	}
 	return a, nil
 }
@@ -236,7 +237,7 @@ func (b *Board) StreamTicks(ctx context.Context, interruptNames []string, ch cha
 	for _, name := range interruptNames {
 		interrupt, ok := b.DigitalInterruptByName(name)
 		if !ok {
-			return errors.Errorf("unknown digital interrupt: %s", name)
+			return fmt.Errorf("unknown digital interrupt: %s", name)
 		}
 		interrupts = append(interrupts, interrupt)
 	}

--- a/components/board/fake/board.go
+++ b/components/board/fake/board.go
@@ -3,12 +3,11 @@ package fake
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"sync"
 	"time"
-
-	"errors"
 
 	"go.uber.org/multierr"
 	commonpb "go.viam.com/api/common/v1"

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -7,12 +7,11 @@ package genericlinux
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"sync"
 	"time"
-
-	"errors"
 
 	"go.uber.org/multierr"
 	commonpb "go.viam.com/api/common/v1"

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -12,7 +12,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	"go.uber.org/multierr"
 	commonpb "go.viam.com/api/common/v1"
 	pb "go.viam.com/api/component/board/v1"
@@ -202,7 +203,7 @@ func (b *Board) reconfigureAnalogReaders(ctx context.Context, newConf *LinuxBoar
 	for _, c := range newConf.AnalogReaders {
 		channel, err := strconv.Atoi(c.Pin)
 		if err != nil {
-			return errors.Errorf("bad analog pin (%s)", c.Pin)
+			return fmt.Errorf("bad analog pin (%s)", c.Pin)
 		}
 
 		bus := buses.NewSpiBus(c.SPIBus)
@@ -401,7 +402,7 @@ type Board struct {
 func (b *Board) AnalogByName(name string) (board.Analog, error) {
 	a, ok := b.analogReaders[name]
 	if !ok {
-		return nil, errors.Errorf("can't find AnalogReader (%s)", name)
+		return nil, fmt.Errorf("can't find AnalogReader (%s)", name)
 	}
 	return a, nil
 }
@@ -476,7 +477,7 @@ func (b *Board) GPIOPinByName(pinName string) (board.GPIOPin, error) {
 		return &gpioInterruptWrapperPin{*interrupt}, nil
 	}
 
-	return nil, errors.Errorf("cannot find GPIO for unknown pin: %s", pinName)
+	return nil, fmt.Errorf("cannot find GPIO for unknown pin: %s", pinName)
 }
 
 // Status returns the current status of the board.
@@ -506,7 +507,7 @@ func (b *Board) StreamTicks(ctx context.Context, interruptNames []string, ch cha
 	for _, name := range interruptNames {
 		interrupt, ok := b.DigitalInterruptByName(name)
 		if !ok {
-			return errors.Errorf("unknown digital interrupt: %s", name)
+			return fmt.Errorf("unknown digital interrupt: %s", name)
 		}
 		interrupts = append(interrupts, interrupt)
 	}

--- a/components/board/genericlinux/board_nonlinux.go
+++ b/components/board/genericlinux/board_nonlinux.go
@@ -7,7 +7,7 @@ package genericlinux
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"errors"
 
 	"go.viam.com/rdk/components/board"
 	"go.viam.com/rdk/logging"

--- a/components/board/genericlinux/board_nonlinux.go
+++ b/components/board/genericlinux/board_nonlinux.go
@@ -6,7 +6,6 @@ package genericlinux
 
 import (
 	"context"
-
 	"errors"
 
 	"go.viam.com/rdk/components/board"

--- a/components/board/genericlinux/buses/spi.go
+++ b/components/board/genericlinux/buses/spi.go
@@ -8,7 +8,8 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	"go.uber.org/multierr"
 	"periph.io/x/conn/v3/physic"
 	"periph.io/x/conn/v3/spi"

--- a/components/board/genericlinux/buses/spi.go
+++ b/components/board/genericlinux/buses/spi.go
@@ -4,11 +4,10 @@ package buses
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
-
-	"errors"
 
 	"go.uber.org/multierr"
 	"periph.io/x/conn/v3/physic"

--- a/components/board/genericlinux/digital_interrupts.go
+++ b/components/board/genericlinux/digital_interrupts.go
@@ -6,10 +6,9 @@ package genericlinux
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
-
-	"errors"
 
 	"github.com/mkch/gpio"
 	"go.uber.org/multierr"

--- a/components/board/genericlinux/digital_interrupts.go
+++ b/components/board/genericlinux/digital_interrupts.go
@@ -6,10 +6,12 @@ package genericlinux
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
+	"errors"
+
 	"github.com/mkch/gpio"
-	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 	"go.viam.com/utils"
 
@@ -37,7 +39,7 @@ func (b *Board) createDigitalInterrupt(
 ) (*digitalInterrupt, error) {
 	mapping, ok := gpioMappings[config.Pin]
 	if !ok {
-		return nil, errors.Errorf("unknown interrupt pin %s", config.Pin)
+		return nil, fmt.Errorf("unknown interrupt pin %s", config.Pin)
 	}
 
 	chip, err := gpio.OpenChip(mapping.GPIOChipDev)

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -6,11 +6,10 @@ package genericlinux
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
-
-	"errors"
 
 	"github.com/mkch/gpio"
 	"go.viam.com/utils"

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -6,11 +6,13 @@ package genericlinux
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
+	"errors"
+
 	"github.com/mkch/gpio"
-	"github.com/pkg/errors"
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/logging"
@@ -40,7 +42,7 @@ type gpioPin struct {
 }
 
 func (pin *gpioPin) wrapError(err error) error {
-	return errors.Wrapf(err, "from GPIO device %s line %d", pin.devicePath, pin.offset)
+	return errors.Join(err, fmt.Errorf("from GPIO device %s line %d", pin.devicePath, pin.offset))
 }
 
 // This is a private helper function that should only be called when the mutex is locked. It sets

--- a/components/board/genericlinux/hw_pwm.go
+++ b/components/board/genericlinux/hw_pwm.go
@@ -11,7 +11,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	goutils "go.viam.com/utils"
 
 	"go.viam.com/rdk/logging"
@@ -46,7 +47,7 @@ func writeValue(filepath string, value uint64, logger logging.Logger) error {
 	if err != nil {
 		logger.Debugf("Encountered error writing to sysfs: %s", err)
 	}
-	return errors.Wrap(err, filepath)
+	return errors.Join(err, fmt.Errorf("error writing to filepath %s", filepath))
 }
 
 func (pwm *pwmDevice) writeChip(filename string, value uint64) error {
@@ -121,8 +122,8 @@ func (pwm *pwmDevice) disable() error {
 
 // Only call this from public functions, to avoid double-wrapping the errors.
 func (pwm *pwmDevice) wrapError(err error) error {
-	// Note that if err is nil, errors.Wrap() will return nil, too.
-	return errors.Wrapf(err, "HW PWM chipPath %s, line %d", pwm.chipPath, pwm.line)
+	// Note that if err is nil, errors.Join() will return nil, too.
+	return errors.Join(err, fmt.Errorf("HW PWM chipPath %s, line %d", pwm.chipPath, pwm.line))
 }
 
 // SetPwm configures an exported pin and enables its output signal.

--- a/components/board/genericlinux/hw_pwm.go
+++ b/components/board/genericlinux/hw_pwm.go
@@ -6,12 +6,11 @@
 package genericlinux
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sync"
 	"time"
-
-	"errors"
 
 	goutils "go.viam.com/utils"
 

--- a/components/board/genericlinux/pin_types.go
+++ b/components/board/genericlinux/pin_types.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/pkg/errors"
+	"errors"
 
 	"go.viam.com/rdk/resource"
 )

--- a/components/board/genericlinux/pin_types.go
+++ b/components/board/genericlinux/pin_types.go
@@ -2,9 +2,8 @@ package genericlinux
 
 import (
 	"encoding/json"
-	"fmt"
-
 	"errors"
+	"fmt"
 
 	"go.viam.com/rdk/resource"
 )

--- a/components/board/hat/pca9685/pca9685.go
+++ b/components/board/hat/pca9685/pca9685.go
@@ -6,11 +6,13 @@ package pca9685
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	commonpb "go.viam.com/api/common/v1"
 	pb "go.viam.com/api/component/board/v1"
 	"go.viam.com/utils"
@@ -146,7 +148,7 @@ func (pca *PCA9685) parsePin(pin string) (int, error) {
 		return 0, err
 	}
 	if pinInt < 0 || int(pinInt) >= len(pca.gpioPins) {
-		return 0, errors.Errorf("channel number must be between [0, %d)", len(pca.gpioPins))
+		return 0, fmt.Errorf("channel number must be between [0, %d)", len(pca.gpioPins))
 	}
 	return int(pinInt), nil
 }

--- a/components/board/hat/pca9685/pca9685.go
+++ b/components/board/hat/pca9685/pca9685.go
@@ -6,12 +6,11 @@ package pca9685
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"sync"
 	"time"
-
-	"errors"
 
 	commonpb "go.viam.com/api/common/v1"
 	pb "go.viam.com/api/component/board/v1"

--- a/components/board/jetson/board.go
+++ b/components/board/jetson/board.go
@@ -2,7 +2,8 @@
 package jetson
 
 import (
-	"github.com/pkg/errors"
+	"errors"
+
 	"periph.io/x/host/v3"
 
 	"go.viam.com/rdk/components/board/genericlinux"

--- a/components/board/pi/common/config.go
+++ b/components/board/pi/common/config.go
@@ -1,7 +1,7 @@
 package picommon
 
 import (
-	"github.com/pkg/errors"
+	"errors"
 
 	"go.viam.com/rdk/resource"
 )

--- a/components/board/pi/common/errors.go
+++ b/components/board/pi/common/errors.go
@@ -1,6 +1,8 @@
 package picommon
 
-import "github.com/pkg/errors"
+import (
+	"fmt"
+)
 
 // PiGPIOErrorMap maps the error codes to the human readable error names. This can be found at the pigpio C interface.
 var PiGPIOErrorMap = map[int]string{
@@ -160,7 +162,7 @@ var PiGPIOErrorMap = map[int]string{
 func ConvertErrorCodeToMessage(errorCode int, message string) error {
 	errorMessage, exists := PiGPIOErrorMap[errorCode]
 	if exists {
-		return errors.Errorf("%s: %s", message, errorMessage)
+		return fmt.Errorf("%s: %s", message, errorMessage)
 	}
-	return errors.Errorf("%s: %d", message, errorCode)
+	return fmt.Errorf("%s: %d", message, errorCode)
 }

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -22,14 +22,13 @@ import "C"
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"os"
 	"strconv"
 	"sync"
 	"time"
-
-	"errors"
 
 	"go.uber.org/multierr"
 	commonpb "go.viam.com/api/common/v1"
@@ -360,13 +359,13 @@ func (pi *piPigpio) reconfigureInterrupts(ctx context.Context, cfg *Config) erro
 		name, ok := findInterruptName(interrupt, oldInterrupts)
 		if !ok {
 			// This should never happen
-			return fmt.Errorf("Logic bug: found old interrupt %s without old name!?", interrupt)
+			return fmt.Errorf("logic bug: found old interrupt %s without old name!?", interrupt)
 		}
 
 		bcom, ok := findInterruptBcom(interrupt, oldInterruptsHW)
 		if !ok {
 			// This should never happen, either
-			return fmt.Errorf("Logic bug: found old interrupt %s without old bcom!?", interrupt)
+			return fmt.Errorf("logic bug: found old interrupt %s without old bcom!?", interrupt)
 		}
 
 		if expectedBcom, ok := broadcomPinFromHardwareLabel(name); ok && bcom == expectedBcom {

--- a/components/board/pi/impl/digital_interrupts.go
+++ b/components/board/pi/impl/digital_interrupts.go
@@ -4,11 +4,10 @@ package piimpl
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
-
-	"errors"
 
 	"go.viam.com/rdk/components/board"
 	"go.viam.com/rdk/resource"

--- a/components/board/pi/impl/digital_interrupts.go
+++ b/components/board/pi/impl/digital_interrupts.go
@@ -4,10 +4,11 @@ package piimpl
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"sync/atomic"
 
-	"github.com/pkg/errors"
+	"errors"
 
 	"go.viam.com/rdk/components/board"
 	"go.viam.com/rdk/resource"
@@ -57,7 +58,7 @@ func CreateDigitalInterrupt(cfg DigitalInterruptConfig) (ReconfigurableDigitalIn
 	case "servo":
 		i = &ServoDigitalInterrupt{ra: utils.NewRollingAverage(ServoRollingAverageWindow)}
 	default:
-		panic(errors.Errorf("unknown interrupt type (%s)", cfg.Type))
+		panic(fmt.Errorf("unknown interrupt type (%s)", cfg.Type))
 	}
 
 	if err := i.Reconfigure(cfg); err != nil {

--- a/components/board/pi/impl/i2c.go
+++ b/components/board/pi/impl/i2c.go
@@ -10,9 +10,8 @@ import "C"
 
 import (
 	"context"
-	"fmt"
-
 	"errors"
+	"fmt"
 
 	"go.viam.com/rdk/components/board/genericlinux/buses"
 	picommon "go.viam.com/rdk/components/board/pi/common"
@@ -76,7 +75,7 @@ func (s *piPigpioI2CHandle) WriteByteData(ctx context.Context, register, data by
 
 func (s *piPigpioI2CHandle) ReadBlockData(ctx context.Context, register byte, numBytes uint8) ([]byte, error) {
 	if numBytes > 32 { // A limitation from the underlying pigpio.h library
-		return nil, errors.New("Cannot read more than 32 bytes from I2C")
+		return nil, errors.New("cannot read more than 32 bytes from I2C")
 	}
 
 	data := make([]byte, numBytes)
@@ -91,7 +90,7 @@ func (s *piPigpioI2CHandle) ReadBlockData(ctx context.Context, register byte, nu
 func (s *piPigpioI2CHandle) WriteBlockData(ctx context.Context, register byte, data []byte) error {
 	numBytes := len(data)
 	if numBytes > 32 { // A limitation from the underlying pigpio.h library
-		return errors.New("Cannot write more than 32 bytes from I2C")
+		return errors.New("cannot write more than 32 bytes from I2C")
 	}
 
 	response := C.i2cWriteI2CBlockData(

--- a/components/board/pi/impl/i2c.go
+++ b/components/board/pi/impl/i2c.go
@@ -12,7 +12,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
+	"errors"
 
 	"go.viam.com/rdk/components/board/genericlinux/buses"
 	picommon "go.viam.com/rdk/components/board/pi/common"

--- a/components/board/pi/impl/servo.go
+++ b/components/board/pi/impl/servo.go
@@ -10,10 +10,9 @@ import "C"
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
-
-	"errors"
 
 	"go.viam.com/utils"
 

--- a/components/board/pi/impl/servo.go
+++ b/components/board/pi/impl/servo.go
@@ -13,7 +13,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	"go.viam.com/utils"
 
 	picommon "go.viam.com/rdk/components/board/pi/common"
@@ -48,7 +49,7 @@ func init() {
 
 				bcom, have := broadcomPinFromHardwareLabel(newConf.Pin)
 				if !have {
-					return nil, errors.Errorf("no hw mapping for %s", newConf.Pin)
+					return nil, fmt.Errorf("no hw mapping for %s", newConf.Pin)
 				}
 
 				theServo := &piPigpioServo{
@@ -147,7 +148,7 @@ func (s *piPigpioServo) Move(ctx context.Context, angle uint32, extra map[string
 		time.Sleep(time.Duration(holdTime)) // time before a stop is sent
 		setPos := C.gpioServo(s.pin, C.uint(0))
 		if setPos < 0 {
-			return errors.Errorf("servo on pin %s failed with code %d", s.pinname, setPos)
+			return fmt.Errorf("servo on pin %s failed with code %d", s.pinname, setPos)
 		}
 	}
 	return nil
@@ -157,9 +158,9 @@ func (s *piPigpioServo) Move(ctx context.Context, angle uint32, extra map[string
 func (s *piPigpioServo) pigpioErrors(res int) error {
 	switch {
 	case res == C.PI_NOT_SERVO_GPIO:
-		return errors.Errorf("gpioservo pin %s is not set up to send and receive pulsewidths", s.pinname)
+		return fmt.Errorf("gpioservo pin %s is not set up to send and receive pulsewidths", s.pinname)
 	case res == C.PI_BAD_PULSEWIDTH:
-		return errors.Errorf("gpioservo on pin %s trying to reach out of range position", s.pinname)
+		return fmt.Errorf("gpioservo on pin %s trying to reach out of range position", s.pinname)
 	case res == 0:
 		return nil
 	case res < 0 && res != C.PI_BAD_PULSEWIDTH && res != C.PI_NOT_SERVO_GPIO:

--- a/components/board/pi/pi_notsupported.go
+++ b/components/board/pi/pi_notsupported.go
@@ -4,7 +4,6 @@ package pi
 
 import (
 	"context"
-
 	"errors"
 
 	"go.viam.com/rdk/components/board"

--- a/components/board/pi/pi_notsupported.go
+++ b/components/board/pi/pi_notsupported.go
@@ -5,7 +5,7 @@ package pi
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"errors"
 
 	"go.viam.com/rdk/components/board"
 	"go.viam.com/rdk/components/board/genericlinux"

--- a/components/board/pi5/board.go
+++ b/components/board/pi5/board.go
@@ -2,7 +2,8 @@
 package pi5
 
 import (
-	"github.com/pkg/errors"
+	"errors"
+
 	"periph.io/x/host/v3"
 
 	"go.viam.com/rdk/components/board/genericlinux"

--- a/components/board/pinwrappers/analogs.go
+++ b/components/board/pinwrappers/analogs.go
@@ -2,10 +2,9 @@ package pinwrappers
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"time"
-
-	"errors"
 
 	goutils "go.viam.com/utils"
 

--- a/components/board/pinwrappers/analogs.go
+++ b/components/board/pinwrappers/analogs.go
@@ -5,7 +5,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	goutils "go.viam.com/utils"
 
 	"go.viam.com/rdk/components/board"

--- a/components/board/server.go
+++ b/components/board/server.go
@@ -3,8 +3,8 @@ package board
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	commonpb "go.viam.com/api/common/v1"
 	pb "go.viam.com/api/component/board/v1"
 	"go.viam.com/utils"
@@ -198,7 +198,7 @@ func (s *serviceServer) GetDigitalInterruptValue(
 
 	interrupt, ok := b.DigitalInterruptByName(req.DigitalInterruptName)
 	if !ok {
-		return nil, errors.Errorf("unknown digital interrupt: %s", req.DigitalInterruptName)
+		return nil, fmt.Errorf("unknown digital interrupt: %s", req.DigitalInterruptName)
 	}
 
 	val, err := interrupt.Value(ctx, req.Extra.AsMap())

--- a/components/board/server_test.go
+++ b/components/board/server_test.go
@@ -6,7 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	commonpb "go.viam.com/api/common/v1"
 	pb "go.viam.com/api/component/board/v1"
 	"go.viam.com/test"

--- a/components/board/server_test.go
+++ b/components/board/server_test.go
@@ -2,11 +2,10 @@ package board_test
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
-
-	"errors"
 
 	commonpb "go.viam.com/api/common/v1"
 	pb "go.viam.com/api/component/board/v1"

--- a/components/board/status.go
+++ b/components/board/status.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	commonpb "go.viam.com/api/common/v1"
 )
 
@@ -23,7 +24,7 @@ func CreateStatus(ctx context.Context, b Board, extra map[string]interface{}) (*
 			}
 			val, err := x.Read(ctx, extra)
 			if err != nil {
-				return nil, errors.Wrapf(err, "couldn't read analog (%s)", name)
+				return nil, errors.Join(err, fmt.Errorf("couldn't read analog (%s)", name))
 			}
 			status.Analogs[name] = &commonpb.AnalogStatus{Value: int32(val)}
 		}

--- a/components/board/status.go
+++ b/components/board/status.go
@@ -2,9 +2,8 @@ package board
 
 import (
 	"context"
-	"fmt"
-
 	"errors"
+	"fmt"
 
 	commonpb "go.viam.com/api/common/v1"
 )

--- a/components/board/ti/board.go
+++ b/components/board/ti/board.go
@@ -2,7 +2,8 @@
 package ti
 
 import (
-	"github.com/pkg/errors"
+	"errors"
+
 	"periph.io/x/host/v3"
 
 	"go.viam.com/rdk/components/board/genericlinux"

--- a/components/board/upboard/board.go
+++ b/components/board/upboard/board.go
@@ -8,7 +8,8 @@ package upboard
 */
 
 import (
-	"github.com/pkg/errors"
+	"errors"
+
 	"periph.io/x/host/v3"
 
 	"go.viam.com/rdk/components/board/genericlinux"

--- a/components/camera/align/extrinsics.go
+++ b/components/camera/align/extrinsics.go
@@ -6,7 +6,8 @@ import (
 	"fmt"
 	"image"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	"go.opencensus.io/trace"
 	"go.uber.org/multierr"
 
@@ -145,7 +146,7 @@ func newColorDepthExtrinsics(
 		return nil, transform.ErrNoIntrinsics
 	}
 	if conf.CameraParameters.Height <= 0 || conf.CameraParameters.Width <= 0 {
-		return nil, errors.Errorf(
+		return nil, fmt.Errorf(
 			"got illegal negative dimensions for width_px and height_px (%d, %d) fields set"+
 				"in intrinsic_parameters for align_color_depth_extrinsics camera",
 			conf.CameraParameters.Width, conf.CameraParameters.Height)
@@ -212,10 +213,10 @@ func (cde *colorDepthExtrinsics) NextPointCloud(ctx context.Context) (pointcloud
 	}
 	col, dm := camera.SimultaneousColorDepthNext(ctx, cde.color, cde.depth)
 	if col == nil {
-		return nil, errors.Errorf("could not get color image from source camera %q for join_color_depth camera", cde.colorName)
+		return nil, fmt.Errorf("could not get color image from source camera %q for join_color_depth camera", cde.colorName)
 	}
 	if dm == nil {
-		return nil, errors.Errorf("could not get depth image from source camera %q for join_color_depth camera", cde.depthName)
+		return nil, fmt.Errorf("could not get depth image from source camera %q for join_color_depth camera", cde.depthName)
 	}
 	if cde.aligner == nil {
 		return cde.projector.RGBDToPointCloud(rimage.ConvertImage(col), dm)

--- a/components/camera/align/extrinsics.go
+++ b/components/camera/align/extrinsics.go
@@ -3,10 +3,9 @@ package align
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"image"
-
-	"errors"
 
 	"go.opencensus.io/trace"
 	"go.uber.org/multierr"

--- a/components/camera/align/homography.go
+++ b/components/camera/align/homography.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 	"image"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	"go.opencensus.io/trace"
 	"go.uber.org/multierr"
 
@@ -107,10 +108,10 @@ func newColorDepthHomography(ctx context.Context, color, depth camera.VideoSourc
 		return nil, errors.New("homography field in attributes cannot be empty")
 	}
 	if conf.CameraParameters == nil {
-		return nil, errors.Wrap(transform.ErrNoIntrinsics, "intrinsic_parameters field in attributes cannot be empty")
+		return nil, transform.ErrNoIntrinsics
 	}
 	if conf.CameraParameters.Height <= 0 || conf.CameraParameters.Width <= 0 {
-		return nil, errors.Errorf(
+		return nil, fmt.Errorf(
 			"got illegal zero or negative dimensions for width_px and height_px (%d, %d) fields set in intrinsic_parameters"+
 				" for align_color_depth_homography camera",
 			conf.CameraParameters.Width, conf.CameraParameters.Height)
@@ -181,10 +182,10 @@ func (acd *colorDepthHomography) NextPointCloud(ctx context.Context) (pointcloud
 	}
 	col, dm := camera.SimultaneousColorDepthNext(ctx, acd.color, acd.depth)
 	if col == nil {
-		return nil, errors.Errorf("could not get color image from source camera %q for join_color_depth camera", acd.colorName)
+		return nil, fmt.Errorf("could not get color image from source camera %q for join_color_depth camera", acd.colorName)
 	}
 	if dm == nil {
-		return nil, errors.Errorf("could not get depth image from source camera %q for join_color_depth camera", acd.depthName)
+		return nil, fmt.Errorf("could not get depth image from source camera %q for join_color_depth camera", acd.depthName)
 	}
 	if acd.aligner == nil {
 		return acd.projector.RGBDToPointCloud(rimage.ConvertImage(col), dm)

--- a/components/camera/align/homography.go
+++ b/components/camera/align/homography.go
@@ -2,10 +2,9 @@ package align
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"image"
-
-	"errors"
 
 	"go.opencensus.io/trace"
 	"go.uber.org/multierr"

--- a/components/camera/align/join.go
+++ b/components/camera/align/join.go
@@ -4,10 +4,9 @@ package align
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"image"
-
-	"errors"
 
 	"go.opencensus.io/trace"
 	"go.uber.org/multierr"
@@ -195,7 +194,7 @@ func (jcd *joinColorDepth) nextPointCloudFromImages(ctx context.Context) (pointc
 		if img.SourceName == "depth" {
 			dm, err = rimage.ConvertImageToDepthMap(ctx, img.Image)
 			if err != nil {
-				return nil, errors.Join(err, fmt.Errorf("image called 'depth' from Images not actually a depth map"))
+				return nil, errors.Join(err, errors.New("image called 'depth' from Images not actually a depth map"))
 			}
 		}
 	}

--- a/components/camera/camera.go
+++ b/components/camera/camera.go
@@ -3,12 +3,11 @@ package camera
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"image"
 	"sync"
 	"time"
-
-	"errors"
 
 	"github.com/google/uuid"
 	"github.com/pion/mediadevices/pkg/prop"
@@ -316,7 +315,7 @@ func (vs *videoSource) Images(ctx context.Context) ([]NamedImage, resource.Respo
 	}
 	img, release, err := ReadImage(ctx, vs.videoSource)
 	if err != nil {
-		return nil, resource.ResponseMetadata{}, errors.Join(err, fmt.Errorf("videoSource: call to get Images failed"))
+		return nil, resource.ResponseMetadata{}, errors.Join(err, errors.New("videoSource: call to get Images failed"))
 	}
 	defer func() {
 		if release != nil {
@@ -344,7 +343,7 @@ func (vs *videoSource) NextPointCloud(ctx context.Context) (pointcloud.PointClou
 	}
 	dm, err := rimage.ConvertImageToDepthMap(ctx, img)
 	if err != nil {
-		return nil, errors.Join(err, fmt.Errorf("cannot project to a point cloud"))
+		return nil, errors.Join(err, errors.New("cannot project to a point cloud"))
 	}
 	return depthadapter.ToPointCloud(dm, vs.system.PinholeCameraIntrinsics), nil
 }

--- a/components/camera/camera_test.go
+++ b/components/camera/camera_test.go
@@ -2,10 +2,9 @@ package camera_test
 
 import (
 	"context"
+	"errors"
 	"image"
 	"testing"
-
-	"errors"
 
 	"go.viam.com/test"
 	"go.viam.com/utils/artifact"

--- a/components/camera/camera_test.go
+++ b/components/camera/camera_test.go
@@ -5,7 +5,8 @@ import (
 	"image"
 	"testing"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	"go.viam.com/test"
 	"go.viam.com/utils/artifact"
 

--- a/components/camera/client.go
+++ b/components/camera/client.go
@@ -10,10 +10,11 @@ import (
 	"sync"
 	"time"
 
+	"errors"
+
 	"github.com/google/uuid"
 	"github.com/pion/rtp"
 	"github.com/pion/webrtc/v3"
-	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 	"go.uber.org/multierr"
 	pb "go.viam.com/api/component/camera/v1"
@@ -232,7 +233,7 @@ func (c *client) Images(ctx context.Context) ([]NamedImage, resource.ResponseMet
 		Name: c.name,
 	})
 	if err != nil {
-		return nil, resource.ResponseMetadata{}, errors.Wrap(err, "camera client: could not gets images from the camera")
+		return nil, resource.ResponseMetadata{}, errors.Join(err, errors.New("camera client: could not gets images from the camera"))
 	}
 
 	images := make([]NamedImage, 0, len(resp.Images))
@@ -549,7 +550,7 @@ func (c *client) unsubscribeAll() error {
 		timeoutCancel()
 		if err != nil {
 			c.logger.Warnw("unsubscribeAll RemoveStream returned err", "name", c.Name(), "err", err)
-			errAgg = multierr.Combine(errAgg, errors.Wrapf(err, "error calling RemoveStream with name: %s", c.Name()))
+			errAgg = multierr.Combine(errAgg, errors.Join(err, fmt.Errorf("error calling RemoveStream with name: %s", c.Name())))
 		}
 	}
 

--- a/components/camera/client.go
+++ b/components/camera/client.go
@@ -3,14 +3,13 @@ package camera
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"image"
 	"io"
 	"slices"
 	"sync"
 	"time"
-
-	"errors"
 
 	"github.com/google/uuid"
 	"github.com/pion/rtp"
@@ -40,11 +39,11 @@ import (
 
 var (
 	// ErrNoPeerConnection indicates there was no peer connection.
-	ErrNoPeerConnection = errors.New("No PeerConnection")
+	ErrNoPeerConnection = errors.New("no PeerConnection")
 	// ErrNoSharedPeerConnection indicates there was no shared peer connection.
-	ErrNoSharedPeerConnection = errors.New("No Shared PeerConnection")
+	ErrNoSharedPeerConnection = errors.New("no Shared PeerConnection")
 	// ErrUnknownStreamSubscriptionID indicates that a StreamSubscriptionID is unknown.
-	ErrUnknownStreamSubscriptionID    = errors.New("StreamSubscriptionID Unknown")
+	ErrUnknownStreamSubscriptionID    = errors.New("unknown StreamSubscriptionID")
 	unsubscribeAllRemoveStreamTimeout = time.Second
 )
 

--- a/components/camera/collectors.go
+++ b/components/camera/collectors.go
@@ -3,9 +3,8 @@ package camera
 import (
 	"bytes"
 	"context"
-	"fmt"
-
 	"errors"
+	"fmt"
 
 	"go.opencensus.io/trace"
 	pb "go.viam.com/api/component/camera/v1"
@@ -68,7 +67,7 @@ func newNextPointCloudCollector(resource interface{}, params data.CollectorParam
 			buf.Grow(headerSize + v.Size()*4*4) // 4 numbers per point, each 4 bytes
 			err = pointcloud.ToPCD(v, &buf, pointcloud.PCDBinary)
 			if err != nil {
-				return nil, fmt.Errorf("failed to convert returned point cloud to PCD: %v", err)
+				return nil, fmt.Errorf("failed to convert returned point cloud to PCD: %w", err)
 			}
 		}
 		return buf.Bytes(), nil

--- a/components/camera/collectors.go
+++ b/components/camera/collectors.go
@@ -3,8 +3,10 @@ package camera
 import (
 	"bytes"
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	"go.opencensus.io/trace"
 	pb "go.viam.com/api/component/camera/v1"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -66,7 +68,7 @@ func newNextPointCloudCollector(resource interface{}, params data.CollectorParam
 			buf.Grow(headerSize + v.Size()*4*4) // 4 numbers per point, each 4 bytes
 			err = pointcloud.ToPCD(v, &buf, pointcloud.PCDBinary)
 			if err != nil {
-				return nil, errors.Errorf("failed to convert returned point cloud to PCD: %v", err)
+				return nil, fmt.Errorf("failed to convert returned point cloud to PCD: %v", err)
 			}
 		}
 		return buf.Bytes(), nil

--- a/components/camera/config.go
+++ b/components/camera/config.go
@@ -1,8 +1,6 @@
 package camera
 
-import (
-	"github.com/pkg/errors"
-)
+import "fmt"
 
 // ImageType specifies what kind of image stream is coming from the camera.
 type ImageType string
@@ -16,5 +14,5 @@ const (
 
 // NewUnsupportedImageTypeError is when the stream type is unknown.
 func NewUnsupportedImageTypeError(s ImageType) error {
-	return errors.Errorf("image type %q not supported", s)
+	return fmt.Errorf("image type %q not supported", s)
 }

--- a/components/camera/fake/camera.go
+++ b/components/camera/fake/camera.go
@@ -3,13 +3,12 @@ package fake
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"image"
 	"image/color"
 	"math"
 	"time"
-
-	"errors"
 
 	"github.com/golang/geo/r3"
 

--- a/components/camera/fake/camera.go
+++ b/components/camera/fake/camera.go
@@ -3,13 +3,15 @@ package fake
 
 import (
 	"context"
+	"fmt"
 	"image"
 	"image/color"
 	"math"
 	"time"
 
+	"errors"
+
 	"github.com/golang/geo/r3"
-	"github.com/pkg/errors"
 
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/logging"
@@ -83,11 +85,11 @@ func (conf *Config) Validate(path string) ([]string, error) {
 	}
 
 	if conf.Height%2 != 0 {
-		return nil, errors.Errorf("odd-number resolutions cannot be rendered, cannot use a height of %d", conf.Height)
+		return nil, fmt.Errorf("odd-number resolutions cannot be rendered, cannot use a height of %d", conf.Height)
 	}
 
 	if conf.Width%2 != 0 {
-		return nil, errors.Errorf("odd-number resolutions cannot be rendered, cannot use a width of %d", conf.Width)
+		return nil, fmt.Errorf("odd-number resolutions cannot be rendered, cannot use a width of %d", conf.Width)
 	}
 
 	return nil, nil

--- a/components/camera/replaypcd/replaypcd.go
+++ b/components/camera/replaypcd/replaypcd.go
@@ -4,12 +4,11 @@ package replaypcd
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"sync"
 	"time"
-
-	"errors"
 
 	"go.uber.org/multierr"
 	datapb "go.viam.com/api/app/data/v1"

--- a/components/camera/replaypcd/replaypcd_test.go
+++ b/components/camera/replaypcd/replaypcd_test.go
@@ -2,11 +2,10 @@ package replaypcd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"testing"
-
-	"errors"
 
 	"go.viam.com/test"
 	"google.golang.org/grpc"

--- a/components/camera/replaypcd/replaypcd_test.go
+++ b/components/camera/replaypcd/replaypcd_test.go
@@ -6,7 +6,8 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	"go.viam.com/test"
 	"google.golang.org/grpc"
 

--- a/components/camera/replaypcd/replaypcd_utils_test.go
+++ b/components/camera/replaypcd/replaypcd_utils_test.go
@@ -2,6 +2,7 @@ package replaypcd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"net"
@@ -12,8 +13,6 @@ import (
 	"strconv"
 	"testing"
 	"time"
-
-	"errors"
 
 	datapb "go.viam.com/api/app/data/v1"
 	"go.viam.com/test"

--- a/components/camera/replaypcd/replaypcd_utils_test.go
+++ b/components/camera/replaypcd/replaypcd_utils_test.go
@@ -13,7 +13,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	datapb "go.viam.com/api/app/data/v1"
 	"go.viam.com/test"
 	"go.viam.com/utils"
@@ -123,7 +124,7 @@ func (mDServer *mockDataServiceServer) BinaryDataByFilter(ctx context.Context, r
 func timestampsFromFileNum(fileNum int) (*timestamppb.Timestamp, *timestamppb.Timestamp, error) {
 	timeReq, err := time.Parse(time.RFC3339, fmt.Sprintf(testTime, fileNum))
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed parsing time")
+		return nil, nil, errors.Join(err, errors.New("failed parsing time"))
 	}
 	timeRec := timeReq.Add(time.Second)
 	return timestamppb.New(timeReq), timestamppb.New(timeRec), nil

--- a/components/camera/rtppassthrough/stream_subscription.go
+++ b/components/camera/rtppassthrough/stream_subscription.go
@@ -20,9 +20,10 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"errors"
+
 	"github.com/bluenviron/gortsplib/v4/pkg/ringbuffer"
 	"github.com/google/uuid"
-	"github.com/pkg/errors"
 	"go.viam.com/utils"
 )
 

--- a/components/camera/rtppassthrough/stream_subscription.go
+++ b/components/camera/rtppassthrough/stream_subscription.go
@@ -17,10 +17,9 @@ package rtppassthrough
 // As a result, at time of writing StreamSubscriptions only ever have a single publisher and a single subscriber.
 
 import (
+	"errors"
 	"sync"
 	"sync/atomic"
-
-	"errors"
 
 	"github.com/bluenviron/gortsplib/v4/pkg/ringbuffer"
 	"github.com/google/uuid"

--- a/components/camera/rtppassthrough/stream_subscription_test.go
+++ b/components/camera/rtppassthrough/stream_subscription_test.go
@@ -1,9 +1,8 @@
 package rtppassthrough
 
 import (
-	"testing"
-
 	"errors"
+	"testing"
 
 	"go.viam.com/test"
 )

--- a/components/camera/rtppassthrough/stream_subscription_test.go
+++ b/components/camera/rtppassthrough/stream_subscription_test.go
@@ -3,7 +3,8 @@ package rtppassthrough
 import (
 	"testing"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	"go.viam.com/test"
 )
 

--- a/components/camera/server.go
+++ b/components/camera/server.go
@@ -3,9 +3,8 @@ package camera
 import (
 	"bytes"
 	"context"
-	"image"
-
 	"errors"
+	"image"
 
 	"go.opencensus.io/trace"
 	commonpb "go.viam.com/api/common/v1"

--- a/components/camera/transformpipeline/classifier.go
+++ b/components/camera/transformpipeline/classifier.go
@@ -2,10 +2,9 @@ package transformpipeline
 
 import (
 	"context"
+	"errors"
 	"image"
 	"strings"
-
-	"errors"
 
 	"go.opencensus.io/trace"
 

--- a/components/camera/transformpipeline/composed.go
+++ b/components/camera/transformpipeline/composed.go
@@ -2,10 +2,9 @@ package transformpipeline
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"image"
-
-	"errors"
 
 	"go.opencensus.io/trace"
 

--- a/components/camera/transformpipeline/depth_edges.go
+++ b/components/camera/transformpipeline/depth_edges.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"image"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	"go.opencensus.io/trace"
 
 	"go.viam.com/rdk/components/camera"
@@ -63,7 +64,7 @@ func (os *depthEdgesSource) Read(ctx context.Context) (image.Image, func(), erro
 	}
 	dm, err := rimage.ConvertImageToDepthMap(ctx, i)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "cannot transform for depth edges")
+		return nil, nil, errors.Join(err, errors.New("cannot transform for depth edges"))
 	}
 	edges, err := os.detector.DetectDepthEdges(dm, os.blurRadius)
 	if err != nil {

--- a/components/camera/transformpipeline/depth_edges.go
+++ b/components/camera/transformpipeline/depth_edges.go
@@ -2,9 +2,8 @@ package transformpipeline
 
 import (
 	"context"
-	"image"
-
 	"errors"
+	"image"
 
 	"go.opencensus.io/trace"
 

--- a/components/camera/transformpipeline/mods.go
+++ b/components/camera/transformpipeline/mods.go
@@ -2,10 +2,9 @@ package transformpipeline
 
 import (
 	"context"
+	"errors"
 	"image"
 	"image/color"
-
-	"errors"
 
 	"github.com/disintegration/imaging"
 	"go.opencensus.io/trace"

--- a/components/camera/transformpipeline/mods.go
+++ b/components/camera/transformpipeline/mods.go
@@ -5,8 +5,9 @@ import (
 	"image"
 	"image/color"
 
+	"errors"
+
 	"github.com/disintegration/imaging"
-	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 	"golang.org/x/image/draw"
 
@@ -35,7 +36,7 @@ func newRotateTransform(ctx context.Context, source gostream.VideoSource, stream
 ) (gostream.VideoSource, camera.ImageType, error) {
 	conf, err := resource.TransformAttributeMap[*rotateConfig](am)
 	if err != nil {
-		return nil, camera.UnspecifiedStream, errors.Wrap(err, "cannot parse rotate attribute map")
+		return nil, camera.UnspecifiedStream, errors.Join(err, errors.New("cannot parse rotate attribute map"))
 	}
 
 	if !am.Has("angle_degs") {

--- a/components/camera/transformpipeline/pipeline.go
+++ b/components/camera/transformpipeline/pipeline.go
@@ -5,10 +5,9 @@ package transformpipeline
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"image"
-
-	"errors"
 
 	"go.opencensus.io/trace"
 	"go.uber.org/multierr"

--- a/components/camera/transformpipeline/preprocessing.go
+++ b/components/camera/transformpipeline/preprocessing.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"image"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	"go.opencensus.io/trace"
 
 	"go.viam.com/rdk/components/camera"
@@ -49,7 +50,7 @@ func (os *preprocessDepthTransform) Read(ctx context.Context) (image.Image, func
 	}
 	dm, err := rimage.ConvertImageToDepthMap(ctx, i)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "transform source does not provide depth image")
+		return nil, nil, errors.Join(err, errors.New("transform source does not provide depth image"))
 	}
 	dm, err = rimage.PreprocessDepthMap(dm, nil)
 	if err != nil {

--- a/components/camera/transformpipeline/preprocessing.go
+++ b/components/camera/transformpipeline/preprocessing.go
@@ -2,9 +2,8 @@ package transformpipeline
 
 import (
 	"context"
-	"image"
-
 	"errors"
+	"image"
 
 	"go.opencensus.io/trace"
 

--- a/components/camera/transformpipeline/transform.go
+++ b/components/camera/transformpipeline/transform.go
@@ -2,9 +2,9 @@ package transformpipeline
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/invopop/jsonschema"
-	"github.com/pkg/errors"
 
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/gostream"
@@ -168,6 +168,6 @@ func buildTransform(
 	case transformTypeDepthPreprocess:
 		return newDepthPreprocessTransform(ctx, source)
 	default:
-		return nil, camera.UnspecifiedStream, errors.Errorf("do not know camera transform of type %q", tr.Type)
+		return nil, camera.UnspecifiedStream, fmt.Errorf("do not know camera transform of type %q", tr.Type)
 	}
 }

--- a/components/camera/transformpipeline/undistort.go
+++ b/components/camera/transformpipeline/undistort.go
@@ -2,10 +2,9 @@ package transformpipeline
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"image"
-
-	"errors"
 
 	"go.opencensus.io/trace"
 

--- a/components/camera/transformpipeline/undistort.go
+++ b/components/camera/transformpipeline/undistort.go
@@ -2,9 +2,11 @@ package transformpipeline
 
 import (
 	"context"
+	"fmt"
 	"image"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	"go.opencensus.io/trace"
 
 	"go.viam.com/rdk/components/camera"
@@ -36,7 +38,7 @@ func newUndistortTransform(
 		return nil, camera.UnspecifiedStream, err
 	}
 	if conf.CameraParams == nil {
-		return nil, camera.UnspecifiedStream, errors.Wrapf(transform.ErrNoIntrinsics, "cannot create undistort transform")
+		return nil, camera.UnspecifiedStream, errors.Join(transform.ErrNoIntrinsics, errors.New("cannot create undistort transform"))
 	}
 	cameraModel := camera.NewPinholeModelWithBrownConradyDistortion(conf.CameraParams, conf.DistortionParams)
 	reader := &undistortSource{
@@ -78,7 +80,7 @@ func (us *undistortSource) Read(ctx context.Context) (image.Image, func(), error
 		}
 		return depth, release, nil
 	default:
-		return nil, nil, errors.Errorf("do not know how to decode stream type %q", string(us.stream))
+		return nil, nil, fmt.Errorf("do not know how to decode stream type %q", string(us.stream))
 	}
 }
 

--- a/components/camera/velodyne/velodyne.go
+++ b/components/camera/velodyne/velodyne.go
@@ -3,13 +3,12 @@ package velodyne
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"image"
 	"image/color"
 	"sync"
 	"time"
-
-	"errors"
 
 	"github.com/golang/geo/r3"
 	"go.einride.tech/vlp16"

--- a/components/camera/velodyne/velodyne.go
+++ b/components/camera/velodyne/velodyne.go
@@ -9,8 +9,9 @@ import (
 	"sync"
 	"time"
 
+	"errors"
+
 	"github.com/golang/geo/r3"
-	"github.com/pkg/errors"
 	"go.einride.tech/vlp16"
 	gutils "go.viam.com/utils"
 

--- a/components/camera/videosource/helpers.go
+++ b/components/camera/videosource/helpers.go
@@ -3,13 +3,12 @@ package videosource
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"image"
 	"io"
 	"net/http"
 	"strings"
-
-	"errors"
 
 	viamutils "go.viam.com/utils"
 

--- a/components/camera/videosource/join_pointcloud.go
+++ b/components/camera/videosource/join_pointcloud.go
@@ -2,11 +2,10 @@ package videosource
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"image"
 	"math"
-
-	"errors"
 
 	"github.com/golang/geo/r3"
 	"go.opencensus.io/trace"

--- a/components/camera/videosource/join_pointcloud.go
+++ b/components/camera/videosource/join_pointcloud.go
@@ -6,8 +6,9 @@ import (
 	"image"
 	"math"
 
+	"errors"
+
 	"github.com/golang/geo/r3"
-	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 
 	"go.viam.com/rdk/components/camera"
@@ -85,7 +86,7 @@ const (
 )
 
 func newMergeMethodUnsupportedError(method string) MergeMethodUnsupportedError {
-	return errors.Errorf("merge method %s not supported", method)
+	return fmt.Errorf("merge method %s not supported", method)
 }
 
 // joinPointCloudSource takes image sources that can produce point clouds and merges them together from
@@ -222,7 +223,7 @@ func (jpcc *joinPointCloudCamera) NextPointCloudNaive(ctx context.Context) (poin
 				return nil, nil, err
 			}
 			if pc == nil {
-				return nil, nil, errors.Errorf("camera %q returned a nil point cloud", jpcc.sourceNames[iCopy])
+				return nil, nil, fmt.Errorf("camera %q returned a nil point cloud", jpcc.sourceNames[iCopy])
 			}
 			return pc, framePose, nil
 		}

--- a/components/camera/videosource/logging/logger.go
+++ b/components/camera/videosource/logging/logger.go
@@ -5,6 +5,7 @@ package logging
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -15,8 +16,6 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
-
-	"errors"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 	"go.viam.com/utils"
@@ -73,19 +72,19 @@ func NewLogger() (*Logger, error) {
 
 	dir := filepath.Dir(filePath)
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
-		return nil, errors.Join(err, fmt.Errorf("camera logger: cannot mkdir "+dir))
+		return nil, errors.Join(err, fmt.Errorf("camera logger: cannot mkdir %s", dir))
 	}
 
 	// remove enough entries to keep the number of files <= maxFiles
 	for entries, err := os.ReadDir(dir); len(entries) >= maxFiles; entries, err = os.ReadDir(dir) {
 		if err != nil {
-			utils.UncheckedError(errors.Join(err, fmt.Errorf("camera logger: cannot read directory "+dir)))
+			utils.UncheckedError(errors.Join(err, fmt.Errorf("camera logger: cannot read directory %s", dir)))
 			break
 		}
 
 		// because entries are sorted by name (timestamp), earlier entries are removed first
 		if err = os.Remove(filepath.Join(dir, entries[0].Name())); err != nil {
-			utils.UncheckedError(errors.Join(err, fmt.Errorf("camera logger: cannot remove file "+filepath.Join(dir, entries[0].Name()))))
+			utils.UncheckedError(errors.Join(err, fmt.Errorf("camera logger: cannot remove file %s", filepath.Join(dir, entries[0].Name()))))
 			break
 		}
 	}

--- a/components/camera/videosource/server.go
+++ b/components/camera/videosource/server.go
@@ -5,16 +5,16 @@ package videosource
 
 import (
 	"context"
-	"fmt"
 	// for embedding camera parameters.
 	_ "embed"
+	// register ppm.
+	"errors"
+	"fmt"
 	"image"
 	"net/http"
 	"sync"
 
-	// register ppm.
-	"errors"
-
+	// imported for ppm.
 	_ "github.com/lmittmann/ppm"
 	"go.opencensus.io/trace"
 	viamutils "go.viam.com/utils"

--- a/components/camera/videosource/server.go
+++ b/components/camera/videosource/server.go
@@ -5,6 +5,7 @@ package videosource
 
 import (
 	"context"
+	"fmt"
 	// for embedding camera parameters.
 	_ "embed"
 	"image"
@@ -12,8 +13,9 @@ import (
 	"sync"
 
 	// register ppm.
+	"errors"
+
 	_ "github.com/lmittmann/ppm"
-	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 	viamutils "go.viam.com/utils"
 
@@ -228,7 +230,7 @@ func (s *serverSource) NextPointCloud(ctx context.Context) (pointcloud.PointClou
 		return depthadapter.ToPointCloud(depth.(*rimage.DepthMap), s.Intrinsics), nil
 	}
 	return nil,
-		errors.Errorf("no depth information in stream %q, cannot project to point cloud", s.stream)
+		fmt.Errorf("no depth information in stream %q, cannot project to point cloud", s.stream)
 }
 
 // NewServerSource creates the VideoSource that streams color/depth data from an external server at a given URL.

--- a/components/camera/videosource/static.go
+++ b/components/camera/videosource/static.go
@@ -8,7 +8,7 @@ import (
 	"image"
 	"time"
 
-	"github.com/pkg/errors"
+	"errors"
 
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/logging"

--- a/components/camera/videosource/static.go
+++ b/components/camera/videosource/static.go
@@ -4,11 +4,10 @@ package videosource
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"image"
 	"time"
-
-	"errors"
 
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/logging"

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"image"
 	"path/filepath"
 	"strings"
 	"sync"
 	"time"
-
-	"errors"
 
 	"github.com/pion/mediadevices"
 	"github.com/pion/mediadevices/pkg/driver"

--- a/components/encoder/ams/ams_as5048.go
+++ b/components/encoder/ams/ams_as5048.go
@@ -5,12 +5,11 @@ package ams
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"sync"
 	"time"
-
-	"errors"
 
 	"go.viam.com/utils"
 

--- a/components/encoder/ams/ams_as5048.go
+++ b/components/encoder/ams/ams_as5048.go
@@ -10,7 +10,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/board/genericlinux/buses"
@@ -66,7 +67,7 @@ func (conf *Config) Validate(path string) ([]string, error) {
 	}
 	_, isSupported := supportedConnections[connType]
 	if !isSupported {
-		return nil, errors.Errorf("%s is not a supported connection type", connType)
+		return nil, fmt.Errorf("%s is not a supported connection type", connType)
 	}
 	if connType == i2cConn {
 		if conf.I2CConfig == nil {
@@ -176,8 +177,8 @@ func (enc *Encoder) Reconfigure(
 	if enc.i2cBusName != newConf.I2CBus || enc.i2cBus == nil {
 		bus, err := buses.NewI2cBus(newConf.I2CBus)
 		if err != nil {
-			msg := fmt.Sprintf("can't find I2C bus '%q' for AMS encoder", newConf.I2CBus)
-			return errors.Wrap(err, msg)
+			msg := fmt.Errorf("can't find I2C bus '%q' for AMS encoder", newConf.I2CBus)
+			return errors.Join(err, msg)
 		}
 		enc.i2cBusName = newConf.I2CBus
 		enc.i2cBus = bus

--- a/components/encoder/errors.go
+++ b/components/encoder/errors.go
@@ -1,11 +1,14 @@
 package encoder
 
-import "github.com/pkg/errors"
+import (
+	"errors"
+	"fmt"
+)
 
 // NewPositionTypeUnsupportedError returns a standard error for when
 // an encoder does not support the given PositionType.
 func NewPositionTypeUnsupportedError(positionType PositionType) error {
-	return errors.Errorf("encoder does not support %q; use a different PositionType", positionType)
+	return fmt.Errorf("encoder does not support %q; use a different PositionType", positionType)
 }
 
 // NewEncodedMotorPositionTypeUnsupportedError returns a standard error for when

--- a/components/encoder/incremental/incremental_encoder.go
+++ b/components/encoder/incremental/incremental_encoder.go
@@ -3,11 +3,13 @@ package incremental
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"sync"
 	"sync/atomic"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/board"
@@ -136,12 +138,12 @@ func (e *Encoder) Reconfigure(
 
 	encA, ok := board.DigitalInterruptByName(newConf.Pins.A)
 	if !ok {
-		err := errors.Errorf("cannot find pin (%s) for incremental Encoder", newConf.Pins.A)
+		err := fmt.Errorf("cannot find pin (%s) for incremental Encoder", newConf.Pins.A)
 		return err
 	}
 	encB, ok := board.DigitalInterruptByName(newConf.Pins.B)
 	if !ok {
-		err := errors.Errorf("cannot find pin (%s) for incremental Encoder", newConf.Pins.B)
+		err := fmt.Errorf("cannot find pin (%s) for incremental Encoder", newConf.Pins.B)
 		return err
 	}
 

--- a/components/encoder/incremental/incremental_encoder.go
+++ b/components/encoder/incremental/incremental_encoder.go
@@ -3,12 +3,11 @@ package incremental
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"sync"
 	"sync/atomic"
-
-	"errors"
 
 	"go.viam.com/utils"
 

--- a/components/encoder/server.go
+++ b/components/encoder/server.go
@@ -2,8 +2,8 @@ package encoder
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	commonpb "go.viam.com/api/common/v1"
 	pb "go.viam.com/api/component/encoder/v1"
 
@@ -50,7 +50,7 @@ func (s *serviceServer) ResetPosition(
 	encName := req.GetName()
 	enc, err := s.coll.Resource(encName)
 	if err != nil {
-		return nil, errors.Errorf("no encoder (%s) found", encName)
+		return nil, fmt.Errorf("no encoder (%s) found", encName)
 	}
 
 	return &pb.ResetPositionResponse{}, enc.ResetPosition(ctx, req.Extra.AsMap())
@@ -64,7 +64,7 @@ func (s *serviceServer) GetProperties(
 	encoderName := req.GetName()
 	enc, err := s.coll.Resource(encoderName)
 	if err != nil {
-		return nil, errors.Errorf("no encoder (%s) found", encoderName)
+		return nil, fmt.Errorf("no encoder (%s) found", encoderName)
 	}
 	features, err := enc.Properties(ctx, req.Extra.AsMap())
 	if err != nil {

--- a/components/encoder/single/single_encoder.go
+++ b/components/encoder/single/single_encoder.go
@@ -23,11 +23,11 @@ package single
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"sync"
 	"sync/atomic"
 
-	"github.com/pkg/errors"
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/board"
@@ -155,7 +155,7 @@ func (e *Encoder) Reconfigure(
 
 	di, ok := board.DigitalInterruptByName(newConf.Pins.I)
 	if !ok {
-		return errors.Errorf("cannot find pin (%s) for Encoder", newConf.Pins.I)
+		return fmt.Errorf("cannot find pin (%s) for Encoder", newConf.Pins.I)
 	}
 
 	if !needRestart {

--- a/components/gantry/gantry_test.go
+++ b/components/gantry/gantry_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"testing"
 
+	"errors"
+
 	"github.com/go-viper/mapstructure/v2"
-	"github.com/pkg/errors"
 	pb "go.viam.com/api/component/gantry/v1"
 	"go.viam.com/test"
 	"go.viam.com/utils/protoutils"

--- a/components/gantry/gantry_test.go
+++ b/components/gantry/gantry_test.go
@@ -2,9 +2,8 @@ package gantry_test
 
 import (
 	"context"
-	"testing"
-
 	"errors"
+	"testing"
 
 	"github.com/go-viper/mapstructure/v2"
 	pb "go.viam.com/api/component/gantry/v1"

--- a/components/gantry/multiaxis/multiaxis.go
+++ b/components/gantry/multiaxis/multiaxis.go
@@ -3,9 +3,11 @@ package multiaxis
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	"go.uber.org/multierr"
 	"go.viam.com/utils"
 
@@ -76,7 +78,7 @@ func newMultiAxis(
 	for _, s := range newConf.SubAxes {
 		subAx, err := gantry.FromDependencies(deps, s)
 		if err != nil {
-			return nil, errors.Wrapf(err, "no axes named [%s]", s)
+			return nil, errors.Join(err, fmt.Errorf("no axes named [%s]", s))
 		}
 		mAx.subAxes = append(mAx.subAxes, subAx)
 	}
@@ -114,11 +116,11 @@ func (g *multiAxis) MoveToPosition(ctx context.Context, positions, speeds []floa
 	defer done()
 
 	if len(positions) == 0 {
-		return errors.Errorf("need position inputs for %v-axis gantry, have %v positions", len(g.subAxes), len(positions))
+		return fmt.Errorf("need position inputs for %v-axis gantry, have %v positions", len(g.subAxes), len(positions))
 	}
 
 	if len(positions) != len(g.lengthsMm) {
-		return errors.Errorf(
+		return fmt.Errorf(
 			"number of input positions %v does not match total gantry axes count %v",
 			len(positions), len(g.lengthsMm),
 		)

--- a/components/gantry/multiaxis/multiaxis.go
+++ b/components/gantry/multiaxis/multiaxis.go
@@ -3,10 +3,9 @@ package multiaxis
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
-
-	"errors"
 
 	"go.uber.org/multierr"
 	"go.viam.com/utils"

--- a/components/gantry/server_test.go
+++ b/components/gantry/server_test.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	pb "go.viam.com/api/component/gantry/v1"
 	"go.viam.com/test"
 	"go.viam.com/utils/protoutils"

--- a/components/gantry/server_test.go
+++ b/components/gantry/server_test.go
@@ -2,9 +2,8 @@ package gantry_test
 
 import (
 	"context"
-	"testing"
-
 	"errors"
+	"testing"
 
 	pb "go.viam.com/api/component/gantry/v1"
 	"go.viam.com/test"

--- a/components/gantry/singleaxis/singleaxis.go
+++ b/components/gantry/singleaxis/singleaxis.go
@@ -3,12 +3,11 @@ package singleaxis
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"sync"
 	"time"
-
-	"errors"
 
 	"github.com/golang/geo/r3"
 	"go.uber.org/multierr"

--- a/components/gantry/singleaxis/singleaxis_test.go
+++ b/components/gantry/singleaxis/singleaxis_test.go
@@ -5,8 +5,9 @@ import (
 	"math"
 	"testing"
 
+	"errors"
+
 	"github.com/golang/geo/r3"
-	"github.com/pkg/errors"
 	"go.viam.com/test"
 
 	"go.viam.com/rdk/components/board"

--- a/components/gantry/singleaxis/singleaxis_test.go
+++ b/components/gantry/singleaxis/singleaxis_test.go
@@ -2,10 +2,9 @@ package singleaxis
 
 import (
 	"context"
+	"errors"
 	"math"
 	"testing"
-
-	"errors"
 
 	"github.com/golang/geo/r3"
 	"go.viam.com/test"

--- a/components/gripper/robotiq/gripper.go
+++ b/components/gripper/robotiq/gripper.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/gripper"
@@ -153,7 +152,7 @@ func (g *robotiqGripper) Set(what, to string) error {
 		return err
 	}
 	if res != "ack" {
-		return errors.Errorf("didn't get ack back, got [%s]", res)
+		return fmt.Errorf("didn't get ack back, got [%s]", res)
 	}
 	return nil
 }
@@ -170,7 +169,7 @@ func (g *robotiqGripper) read() (string, error) {
 		return "", err
 	}
 	if x > 100 {
-		return "", errors.Errorf("read too much: %d", x)
+		return "", fmt.Errorf("read too much: %d", x)
 	}
 	if x == 0 {
 		return "", nil

--- a/components/gripper/softrobotics/gripper.go
+++ b/components/gripper/softrobotics/gripper.go
@@ -3,10 +3,9 @@ package softrobotics
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
-
-	"errors"
 
 	"go.uber.org/multierr"
 	"go.viam.com/utils"

--- a/components/gripper/softrobotics/gripper.go
+++ b/components/gripper/softrobotics/gripper.go
@@ -3,9 +3,11 @@ package softrobotics
 
 import (
 	"context"
+	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	"go.uber.org/multierr"
 	"go.viam.com/utils"
 
@@ -47,7 +49,7 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 
 	if cfg.AnalogReader != "psi" {
 		return nil, resource.NewConfigValidationError(path,
-			errors.Errorf("analog_reader %s on board must be created and called 'psi'", cfg.AnalogReader))
+			fmt.Errorf("analog_reader %s on board must be created and called 'psi'", cfg.AnalogReader))
 	}
 	deps = append(deps, cfg.Board)
 	return deps, nil

--- a/components/input/fake/input.go
+++ b/components/input/fake/input.go
@@ -7,7 +7,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/input"

--- a/components/input/fake/input.go
+++ b/components/input/fake/input.go
@@ -3,11 +3,10 @@ package fake
 
 import (
 	"context"
+	"errors"
 	"math/rand"
 	"sync"
 	"time"
-
-	"errors"
 
 	"go.viam.com/utils"
 

--- a/components/input/fake/input_test.go
+++ b/components/input/fake/input_test.go
@@ -5,7 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	"go.viam.com/test"
 
 	"go.viam.com/rdk/components/input"

--- a/components/input/fake/input_test.go
+++ b/components/input/fake/input_test.go
@@ -2,10 +2,9 @@ package fake
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
-
-	"errors"
 
 	"go.viam.com/test"
 

--- a/components/input/gamepad/gamepad.go
+++ b/components/input/gamepad/gamepad.go
@@ -6,7 +6,6 @@ package gamepad
 
 import (
 	"context"
-
 	"errors"
 
 	"go.viam.com/rdk/components/input"

--- a/components/input/gamepad/gamepad.go
+++ b/components/input/gamepad/gamepad.go
@@ -7,7 +7,7 @@ package gamepad
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"errors"
 
 	"go.viam.com/rdk/components/input"
 	"go.viam.com/rdk/logging"

--- a/components/input/gamepad/gamepad_linux.go
+++ b/components/input/gamepad/gamepad_linux.go
@@ -6,14 +6,13 @@ package gamepad
 
 import (
 	"context"
+	"errors"
 	"math"
 	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
 	"time"
-
-	"errors"
 
 	"github.com/viamrobotics/evdev"
 	"go.viam.com/utils"

--- a/components/input/gamepad/gamepad_linux.go
+++ b/components/input/gamepad/gamepad_linux.go
@@ -13,7 +13,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	"github.com/viamrobotics/evdev"
 	"go.viam.com/utils"
 

--- a/components/input/gpio/gpio.go
+++ b/components/input/gpio/gpio.go
@@ -7,8 +7,9 @@ import (
 	"sync"
 	"time"
 
+	"errors"
+
 	"github.com/bep/debounce"
-	"github.com/pkg/errors"
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/board"
@@ -258,7 +259,7 @@ func (c *Controller) newButton(ctx context.Context, brd board.Board, intName str
 	tickChan := make(chan board.Tick)
 	err := brd.StreamTicks(ctx, []string{intName}, tickChan, nil)
 	if err != nil {
-		return errors.Wrap(err, "error getting digital interrupt ticks")
+		return errors.Join(err, errors.New("error getting digital interrupt ticks"))
 	}
 
 	c.activeBackgroundWorkers.Add(1)

--- a/components/input/gpio/gpio.go
+++ b/components/input/gpio/gpio.go
@@ -3,11 +3,10 @@ package gpio
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
-
-	"errors"
 
 	"github.com/bep/debounce"
 	"go.viam.com/utils"

--- a/components/input/input_test.go
+++ b/components/input/input_test.go
@@ -2,10 +2,9 @@ package input_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
-
-	"errors"
 
 	pb "go.viam.com/api/component/inputcontroller/v1"
 	"go.viam.com/test"

--- a/components/input/input_test.go
+++ b/components/input/input_test.go
@@ -5,7 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	pb "go.viam.com/api/component/inputcontroller/v1"
 	"go.viam.com/test"
 	"google.golang.org/protobuf/types/known/timestamppb"

--- a/components/input/server.go
+++ b/components/input/server.go
@@ -3,8 +3,8 @@ package input
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	commonpb "go.viam.com/api/common/v1"
 	pb "go.viam.com/api/component/inputcontroller/v1"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -88,7 +88,7 @@ func (s *serviceServer) TriggerEvent(
 	}
 	injectController, ok := controller.(Triggerable)
 	if !ok {
-		return nil, errors.Errorf("input controller is not of type Triggerable (%s)", req.Controller)
+		return nil, fmt.Errorf("input controller is not of type Triggerable (%s)", req.Controller)
 	}
 
 	err = injectController.TriggerEvent(

--- a/components/input/server_test.go
+++ b/components/input/server_test.go
@@ -2,10 +2,9 @@ package input_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
-
-	"errors"
 
 	pb "go.viam.com/api/component/inputcontroller/v1"
 	"go.viam.com/test"

--- a/components/input/server_test.go
+++ b/components/input/server_test.go
@@ -5,7 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	pb "go.viam.com/api/component/inputcontroller/v1"
 	"go.viam.com/test"
 	"go.viam.com/utils/protoutils"

--- a/components/motor/dimensionengineering/sabertooth.go
+++ b/components/motor/dimensionengineering/sabertooth.go
@@ -3,14 +3,13 @@ package dimensionengineering
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math"
 	"strings"
 	"sync"
 	"time"
-
-	"errors"
 
 	"github.com/jacobsa/go-serial/serial"
 

--- a/components/motor/dimensionengineering/sabertooth.go
+++ b/components/motor/dimensionengineering/sabertooth.go
@@ -10,8 +10,9 @@ import (
 	"sync"
 	"time"
 
+	"errors"
+
 	"github.com/jacobsa/go-serial/serial"
-	"github.com/pkg/errors"
 
 	"go.viam.com/rdk/components/motor"
 	"go.viam.com/rdk/logging"
@@ -383,7 +384,7 @@ func (m *Motor) SetPower(ctx context.Context, powerPct float64, extra map[string
 	}
 	c, err := newCommand(m.c.address, cmd, m.Channel, byte(int(rawSpeed)))
 	if err != nil {
-		return errors.Wrap(err, "error in SetPower")
+		return errors.Join(err, errors.New("error in SetPower"))
 	}
 	err = m.c.sendCmd(c)
 	return err
@@ -400,7 +401,7 @@ func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[s
 	powerPct, waitDur := goForMath(m.maxRPM, rpm, revolutions)
 	err := m.SetPower(ctx, powerPct, extra)
 	if err != nil {
-		return errors.Wrap(err, "error in GoFor")
+		return errors.Join(err, errors.New("error in GoFor"))
 	}
 
 	if revolutions == 0 {

--- a/components/motor/dmc4000/dmc.go
+++ b/components/motor/dmc4000/dmc.go
@@ -12,8 +12,9 @@ import (
 	"sync"
 	"time"
 
+	"errors"
+
 	"github.com/jacobsa/go-serial/serial"
-	"github.com/pkg/errors"
 	"go.viam.com/utils"
 	"go.viam.com/utils/usb"
 
@@ -561,7 +562,7 @@ func (m *Motor) ResetZeroPosition(ctx context.Context, offset float64, extra map
 	defer m.c.mu.Unlock()
 	_, err := m.c.sendCmd(fmt.Sprintf("DP%s=%d", m.Axis, int(-1*offset*float64(m.TicksPerRotation))))
 	if err != nil {
-		return errors.Wrap(err, "error in ResetZeroPosition")
+		return errors.Join(err, errors.New("error in ResetZeroPosition"))
 	}
 	return err
 }
@@ -584,7 +585,7 @@ func (m *Motor) Stop(ctx context.Context, extra map[string]interface{}) error {
 	m.jogging = false
 	_, err := m.c.sendCmd(fmt.Sprintf("ST%s", m.Axis))
 	if err != nil {
-		return errors.Wrap(err, "error in Stop function")
+		return errors.Join(err, errors.New("error in Stop function"))
 	}
 
 	return m.opMgr.WaitForSuccess(
@@ -609,7 +610,7 @@ func (m *Motor) IsMoving(ctx context.Context) (bool, error) {
 func (m *Motor) IsPowered(ctx context.Context, extra map[string]interface{}) (bool, float64, error) {
 	on, err := m.IsMoving(ctx)
 	if err != nil {
-		return on, m.powerPct, errors.Wrap(err, "error in IsPowered")
+		return on, m.powerPct, errors.Join(err, errors.New("error in IsPowered"))
 	}
 	return on, m.powerPct, err
 }

--- a/components/motor/dmc4000/dmc.go
+++ b/components/motor/dmc4000/dmc.go
@@ -4,6 +4,7 @@ package dmc4000
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -11,8 +12,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"errors"
 
 	"github.com/jacobsa/go-serial/serial"
 	"go.viam.com/utils"

--- a/components/motor/errors.go
+++ b/components/motor/errors.go
@@ -20,7 +20,7 @@ func NewPropertyUnsupportedError(prop Properties, motorName string) error {
 // NewZeroRPMError returns an error representing a request to move a motor at
 // zero speed (i.e., moving the motor without moving the motor).
 func NewZeroRPMError() error {
-	return errors.New("Cannot move motor at an RPM that is nearly 0")
+	return errors.New("cannot move motor at an RPM that is nearly 0")
 }
 
 // NewGoToUnsupportedError returns error when a motor is required to support GoTo feature.

--- a/components/motor/errors.go
+++ b/components/motor/errors.go
@@ -1,17 +1,20 @@
 package motor
 
-import "github.com/pkg/errors"
+import (
+	"errors"
+	"fmt"
+)
 
 // NewResetZeroPositionUnsupportedError returns a standard error for when a motor
 // is required to support reseting the zero position.
 func NewResetZeroPositionUnsupportedError(motorName string) error {
-	return errors.Errorf("motor with name %s does not support ResetZeroPosition", motorName)
+	return fmt.Errorf("motor with name %s does not support ResetZeroPosition", motorName)
 }
 
 // NewPropertyUnsupportedError returns an error representing the need
 // for a motor to support a particular property.
 func NewPropertyUnsupportedError(prop Properties, motorName string) error {
-	return errors.Errorf("motor named %s has wrong support for property %#v", motorName, prop)
+	return fmt.Errorf("motor named %s has wrong support for property %#v", motorName, prop)
 }
 
 // NewZeroRPMError returns an error representing a request to move a motor at
@@ -22,7 +25,7 @@ func NewZeroRPMError() error {
 
 // NewGoToUnsupportedError returns error when a motor is required to support GoTo feature.
 func NewGoToUnsupportedError(motorName string) error {
-	return errors.Errorf("motor with name %s does not support GoTo", motorName)
+	return fmt.Errorf("motor with name %s does not support GoTo", motorName)
 }
 
 // NewControlParametersUnimplementedError returns an error when a control parameters are

--- a/components/motor/fake/motor.go
+++ b/components/motor/fake/motor.go
@@ -3,11 +3,12 @@ package fake
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
+	"errors"
 
 	"go.viam.com/rdk/components/board"
 	fakeboard "go.viam.com/rdk/components/board/fake"
@@ -376,7 +377,7 @@ func (m *Motor) Stop(ctx context.Context, extra map[string]interface{}) error {
 	if m.Encoder != nil {
 		err := m.Encoder.SetSpeed(ctx, 0.0)
 		if err != nil {
-			return errors.Wrapf(err, "error in Stop from motor (%s)", m.Name())
+			return errors.Join(err, fmt.Errorf("error in Stop from motor (%s)", m.Name()))
 		}
 	}
 	return nil
@@ -394,7 +395,7 @@ func (m *Motor) ResetZeroPosition(ctx context.Context, offset float64, extra map
 
 	err := m.Encoder.SetPosition(ctx, int64(-1*offset))
 	if err != nil {
-		return errors.Wrapf(err, "error in ResetZeroPosition from motor (%s)", m.Name())
+		return errors.Join(err, fmt.Errorf("error in ResetZeroPosition from motor (%s)", m.Name()))
 	}
 
 	return nil

--- a/components/motor/fake/motor.go
+++ b/components/motor/fake/motor.go
@@ -3,12 +3,11 @@ package fake
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"sync"
 	"time"
-
-	"errors"
 
 	"go.viam.com/rdk/components/board"
 	fakeboard "go.viam.com/rdk/components/board/fake"

--- a/components/motor/gpio/basic.go
+++ b/components/motor/gpio/basic.go
@@ -2,11 +2,9 @@ package gpio
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"math"
 	"sync"
-
-	"errors"
 
 	"go.uber.org/multierr"
 
@@ -160,13 +158,13 @@ func (m *Motor) turnOff(ctx context.Context, extra map[string]interface{}) error
 	}
 
 	if m.A != nil && m.B != nil {
-		aErr := errors.Join(m.A.Set(ctx, false, extra), fmt.Errorf("could not set A pin to low"))
-		bErr := errors.Join(m.B.Set(ctx, false, extra), fmt.Errorf("could not set B pin to low"))
+		aErr := errors.Join(m.A.Set(ctx, false, extra), errors.New("could not set A pin to low"))
+		bErr := errors.Join(m.B.Set(ctx, false, extra), errors.New("could not set B pin to low"))
 		errs = multierr.Combine(errs, aErr, bErr)
 	}
 
 	if m.PWM != nil {
-		pwmErr := errors.Join(m.PWM.Set(ctx, false, extra), fmt.Errorf("could not set PWM pin to low"))
+		pwmErr := errors.Join(m.PWM.Set(ctx, false, extra), errors.New("could not set PWM pin to low"))
 		errs = multierr.Combine(errs, pwmErr)
 	}
 	return errs

--- a/components/motor/gpio/basic_test.go
+++ b/components/motor/gpio/basic_test.go
@@ -6,7 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	"go.viam.com/test"
 	"go.viam.com/utils/testutils"
 

--- a/components/motor/gpio/basic_test.go
+++ b/components/motor/gpio/basic_test.go
@@ -2,11 +2,10 @@ package gpio
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
-
-	"errors"
 
 	"go.viam.com/test"
 	"go.viam.com/utils/testutils"

--- a/components/motor/gpio/loop.go
+++ b/components/motor/gpio/loop.go
@@ -6,7 +6,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	"go.uber.org/multierr"
 
 	"go.viam.com/rdk/components/encoder"

--- a/components/motor/gpio/loop.go
+++ b/components/motor/gpio/loop.go
@@ -2,11 +2,10 @@ package gpio
 
 import (
 	"context"
+	"errors"
 	"math"
 	"sync"
 	"time"
-
-	"errors"
 
 	"go.uber.org/multierr"
 

--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -3,12 +3,11 @@ package gpio
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"sync"
 	"time"
-
-	"errors"
 
 	"go.uber.org/multierr"
 	"go.viam.com/utils"

--- a/components/motor/gpio/motor_encoder.go
+++ b/components/motor/gpio/motor_encoder.go
@@ -8,7 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	"go.uber.org/multierr"
 	"go.viam.com/utils"
 

--- a/components/motor/gpio/setup.go
+++ b/components/motor/gpio/setup.go
@@ -3,7 +3,7 @@ package gpio
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"errors"
 
 	"go.viam.com/rdk/components/board"
 	"go.viam.com/rdk/components/encoder"

--- a/components/motor/gpio/setup.go
+++ b/components/motor/gpio/setup.go
@@ -2,7 +2,6 @@ package gpio
 
 import (
 	"context"
-
 	"errors"
 
 	"go.viam.com/rdk/components/board"

--- a/components/motor/gpiostepper/gpiostepper.go
+++ b/components/motor/gpiostepper/gpiostepper.go
@@ -29,12 +29,11 @@ package gpiostepper
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"sync"
 	"time"
-
-	"errors"
 
 	"go.uber.org/multierr"
 	"go.viam.com/utils"

--- a/components/motor/gpiostepper/gpiostepper.go
+++ b/components/motor/gpiostepper/gpiostepper.go
@@ -34,7 +34,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	"go.uber.org/multierr"
 	"go.viam.com/utils"
 
@@ -213,7 +214,7 @@ func (m *gpioStepper) SetPower(ctx context.Context, powerPct float64, extra map[
 	}
 
 	if m.minDelay == 0 {
-		return errors.Errorf(
+		return fmt.Errorf(
 			"if you want to set the power, set 'stepper_delay_usec' in the motor config at "+
 				"the minimum time delay between pulses for your stepper motor (%s)",
 			m.Name().Name)
@@ -321,14 +322,14 @@ func (m *gpioStepper) GoFor(ctx context.Context, rpm, revolutions float64, extra
 
 	err := m.enable(ctx, true)
 	if err != nil {
-		return errors.Wrapf(err, "error enabling motor in GoFor from motor (%s)", m.Name().Name)
+		return errors.Join(err, fmt.Errorf("error enabling motor in GoFor from motor (%s)", m.Name().Name))
 	}
 
 	err = m.goForInternal(ctx, rpm, revolutions)
 	if err != nil {
 		return multierr.Combine(
 			m.enable(ctx, false),
-			errors.Wrapf(err, "error in GoFor from motor (%s)", m.Name().Name))
+			errors.Join(err, fmt.Errorf("error in GoFor from motor (%s)", m.Name().Name)))
 	}
 
 	// this is a long-running operation, do not wait for Stop, do not disable enable pins
@@ -385,7 +386,7 @@ func (m *gpioStepper) goForInternal(ctx context.Context, rpm, revolutions float6
 func (m *gpioStepper) GoTo(ctx context.Context, rpm, positionRevolutions float64, extra map[string]interface{}) error {
 	curPos, err := m.Position(ctx, extra)
 	if err != nil {
-		return errors.Wrapf(err, "error in GoTo from motor (%s)", m.Name().Name)
+		return errors.Join(err, fmt.Errorf("error in GoTo from motor (%s)", m.Name().Name))
 	}
 	moveDistance := positionRevolutions - curPos
 
@@ -452,7 +453,7 @@ func (m *gpioStepper) stop() {
 func (m *gpioStepper) IsPowered(ctx context.Context, extra map[string]interface{}) (bool, float64, error) {
 	on, err := m.IsMoving(ctx)
 	if err != nil {
-		return on, 0.0, errors.Wrapf(err, "error in IsPowered from motor (%s)", m.Name().Name)
+		return on, 0.0, errors.Join(err, fmt.Errorf("error in IsPowered from motor (%s)", m.Name().Name))
 	}
 	percent := 0.0
 	if on {

--- a/components/motor/i2cmotors/ezopmp.go
+++ b/components/motor/i2cmotors/ezopmp.go
@@ -6,13 +6,12 @@ package ezopmp
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
 	"strings"
 	"time"
-
-	"errors"
 
 	"go.viam.com/rdk/components/board/genericlinux/buses"
 	"go.viam.com/rdk/components/motor"
@@ -112,7 +111,7 @@ func NewMotor(ctx context.Context, deps resource.Dependencies, c *Config, name r
 
 	flowRate, err := m.findMaxFlowRate(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("can't find max flow rate: %v", err)
+		return nil, fmt.Errorf("can't find max flow rate: %w", err)
 	}
 	m.maxFlowRate = flowRate
 

--- a/components/motor/motor_test.go
+++ b/components/motor/motor_test.go
@@ -2,9 +2,8 @@ package motor_test
 
 import (
 	"context"
-	"testing"
-
 	"errors"
+	"testing"
 
 	"github.com/go-viper/mapstructure/v2"
 	pb "go.viam.com/api/component/motor/v1"

--- a/components/motor/motor_test.go
+++ b/components/motor/motor_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"testing"
 
+	"errors"
+
 	"github.com/go-viper/mapstructure/v2"
-	"github.com/pkg/errors"
 	pb "go.viam.com/api/component/motor/v1"
 	"go.viam.com/test"
 	"go.viam.com/utils/protoutils"

--- a/components/motor/roboclaw/roboclaw.go
+++ b/components/motor/roboclaw/roboclaw.go
@@ -27,8 +27,9 @@ import (
 	"math"
 	"time"
 
+	"errors"
+
 	"github.com/CPRT/roboclaw"
-	"github.com/pkg/errors"
 
 	"go.viam.com/rdk/components/motor"
 	"go.viam.com/rdk/logging"
@@ -77,7 +78,7 @@ func (conf *Config) Validate(path string) ([]string, error) {
 	}
 
 	if !rutils.ValidateBaudRate(validBaudRates, conf.SerialBaud) {
-		return nil, resource.NewConfigValidationError(path, errors.Errorf("Baud rate invalid, must be one of these values: %v", validBaudRates))
+		return nil, resource.NewConfigValidationError(path, fmt.Errorf("Baud rate invalid, must be one of these values: %v", validBaudRates))
 	}
 	return nil, nil
 }
@@ -270,7 +271,7 @@ func (m *roboclawMotor) GoFor(ctx context.Context, rpm, revolutions float64, ext
 		m.logger.CInfo(ctx, "distance traveled is a time based estimation with max RPM 250. For increased accuracy, connect encoders")
 		err := m.SetPower(ctx, powerPct, extra)
 		if err != nil {
-			return errors.Wrap(err, "error in GoFor")
+			return errors.Join(err, errors.New("error in GoFor"))
 		}
 		if revolutions == 0 {
 			return nil

--- a/components/motor/roboclaw/roboclaw.go
+++ b/components/motor/roboclaw/roboclaw.go
@@ -23,11 +23,10 @@ Serial path: path to serial file
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"time"
-
-	"errors"
 
 	"github.com/CPRT/roboclaw"
 
@@ -74,11 +73,13 @@ func (conf *Config) Validate(path string) ([]string, error) {
 	}
 
 	if conf.TicksPerRotation < 0 {
-		return nil, resource.NewConfigValidationError(path, errors.New("Ticks Per Rotation must be a positive number"))
+		return nil, resource.NewConfigValidationError(path, errors.New("ticks_per_rotation must be a positive number"))
 	}
 
 	if !rutils.ValidateBaudRate(validBaudRates, conf.SerialBaud) {
-		return nil, resource.NewConfigValidationError(path, fmt.Errorf("Baud rate invalid, must be one of these values: %v", validBaudRates))
+		return nil, resource.NewConfigValidationError(
+			path,
+			fmt.Errorf("serial_baud_rate invalid, must be one of these values: %d", validBaudRates))
 	}
 	return nil, nil
 }

--- a/components/motor/tmcstepper/stepper_motor_tmc.go
+++ b/components/motor/tmcstepper/stepper_motor_tmc.go
@@ -5,11 +5,10 @@ package tmcstepper
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"time"
-
-	"errors"
 
 	"go.uber.org/multierr"
 	"go.viam.com/utils"

--- a/components/motor/ulnstepper/28byj-48.go
+++ b/components/motor/ulnstepper/28byj-48.go
@@ -19,12 +19,11 @@ package uln28byj
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"sync"
 	"time"
-
-	"errors"
 
 	"go.uber.org/multierr"
 
@@ -199,7 +198,7 @@ func (m *uln28byj) doRun(ctx context.Context) error {
 		err := m.doStep(ctx, m.stepPosition < m.targetStepPosition)
 		m.lock.Unlock()
 		if err != nil {
-			return fmt.Errorf("error stepping %v", err)
+			return fmt.Errorf("error stepping %w", err)
 		}
 	}
 	return nil
@@ -268,7 +267,7 @@ func (m *uln28byj) GoFor(ctx context.Context, rpm, revolutions float64, extra ma
 
 	err := m.doRun(ctx)
 	if err != nil {
-		return fmt.Errorf(" error while running motor %v", err)
+		return fmt.Errorf(" error while running motor %w", err)
 	}
 	return nil
 }

--- a/components/movementsensor/adxl345/adxl345.go
+++ b/components/movementsensor/adxl345/adxl345.go
@@ -25,9 +25,10 @@ import (
 	"sync"
 	"time"
 
+	"errors"
+
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
-	"github.com/pkg/errors"
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/board"
@@ -192,8 +193,8 @@ func newAdxl345(
 
 	bus, err := buses.NewI2cBus(newConf.I2cBus)
 	if err != nil {
-		msg := fmt.Sprintf("can't find I2C bus '%q' for ADXL345 sensor", newConf.I2cBus)
-		return nil, errors.Wrap(err, msg)
+		msg := fmt.Errorf("can't find I2C bus '%q' for ADXL345 sensor", newConf.I2cBus)
+		return nil, errors.Join(err, msg)
 	}
 
 	// The rest of the constructor is separated out so that you can pass in a mock I2C bus during
@@ -261,7 +262,7 @@ func makeAdxl345(
 	// The chip starts out in standby mode. Set it to measurement mode so we can get data from it.
 	// To do this, we set the Power Control register (0x2D) to turn on the 8's bit.
 	if err = sensor.writeByte(ctx, powerControlRegister, 0x08); err != nil {
-		return nil, errors.Wrap(err, "unable to put ADXL345 into measurement mode")
+		return nil, errors.Join(err, errors.New("unable to put ADXL345 into measurement mode"))
 	}
 
 	// Now, turn on the background goroutine that constantly reads from the chip and stores data in

--- a/components/movementsensor/adxl345/adxl345.go
+++ b/components/movementsensor/adxl345/adxl345.go
@@ -21,11 +21,10 @@ package adxl345
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
-
-	"errors"
 
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
@@ -81,16 +80,16 @@ type FreeFallConfig struct {
 // validateTapConfigs validates the tap piece of the config.
 func (tapCfg *TapConfig) validateTapConfigs() error {
 	if tapCfg.AccelerometerPin != 1 && tapCfg.AccelerometerPin != 2 {
-		return errors.New("Accelerometer pin on the ADXL345 must be 1 or 2")
+		return errors.New("accelerometer pin on the ADXL345 must be 1 or 2")
 	}
 	if tapCfg.Threshold != 0 {
 		if tapCfg.Threshold < 0 || tapCfg.Threshold > (255*threshTapScaleFactor) {
-			return errors.New("Tap threshold on the ADXL345 must be 0 between and 15,937mg")
+			return errors.New("tap threshold on the ADXL345 must be 0 between and 15,937mg")
 		}
 	}
 	if tapCfg.Dur != 0 {
 		if tapCfg.Dur < 0 || tapCfg.Dur > (255*durScaleFactor) {
-			return errors.New("Tap dur on the ADXL345 must be between 0 and 160,000µs")
+			return errors.New("tap dur on the ADXL345 must be between 0 and 160,000µs")
 		}
 	}
 	return nil
@@ -99,16 +98,16 @@ func (tapCfg *TapConfig) validateTapConfigs() error {
 // validateFreeFallConfigs validates the freefall piece of the config.
 func (freefallCfg *FreeFallConfig) validateFreeFallConfigs() error {
 	if freefallCfg.AccelerometerPin != 1 && freefallCfg.AccelerometerPin != 2 {
-		return errors.New("Accelerometer pin on the ADXL345 must be 1 or 2")
+		return errors.New("accelerometer pin on the ADXL345 must be 1 or 2")
 	}
 	if freefallCfg.Threshold != 0 {
 		if freefallCfg.Threshold < 0 || freefallCfg.Threshold > (255*threshFfScaleFactor) {
-			return errors.New("Accelerometer tap threshold on the ADXL345 must be 0 between and 15,937mg")
+			return errors.New("accelerometer tap threshold on the ADXL345 must be 0 between and 15,937mg")
 		}
 	}
 	if freefallCfg.Time != 0 {
 		if freefallCfg.Time < 0 || freefallCfg.Time > (255*timeFfScaleFactor) {
-			return errors.New("Accelerometer tap time on the ADXL345 must be between 0 and 1,275ms")
+			return errors.New("accelerometer tap time on the ADXL345 must be between 0 and 1,275ms")
 		}
 	}
 	return nil

--- a/components/movementsensor/adxl345/adxl345_test.go
+++ b/components/movementsensor/adxl345/adxl345_test.go
@@ -4,10 +4,9 @@ package adxl345
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
-
-	"errors"
 
 	"go.viam.com/test"
 	"go.viam.com/utils/testutils"

--- a/components/movementsensor/adxl345/adxl345_test.go
+++ b/components/movementsensor/adxl345/adxl345_test.go
@@ -7,7 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	"go.viam.com/test"
 	"go.viam.com/utils/testutils"
 

--- a/components/movementsensor/errors.go
+++ b/components/movementsensor/errors.go
@@ -1,9 +1,8 @@
 package movementsensor
 
 import (
-	"fmt"
-
 	"errors"
+	"fmt"
 )
 
 // AddressReadError returns a standard error for when we cannot read from an I2C bus.

--- a/components/movementsensor/errors.go
+++ b/components/movementsensor/errors.go
@@ -3,18 +3,18 @@ package movementsensor
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
+	"errors"
 )
 
 // AddressReadError returns a standard error for when we cannot read from an I2C bus.
 func AddressReadError(err error, address byte, bus string) error {
-	msg := fmt.Sprintf("can't read from I2C address %d on bus %s", address, bus)
-	return errors.Wrap(err, msg)
+	msg := fmt.Errorf("can't read from I2C address %d on bus %s", address, bus)
+	return errors.Join(err, msg)
 }
 
 // UnexpectedDeviceError returns a standard error for we cannot find the expected device
 // at the given address.
 func UnexpectedDeviceError(address, response byte, deviceName string) error {
-	return errors.Errorf("unexpected non-%s device at address %d: response '%d'",
+	return fmt.Errorf("unexpected non-%s device at address %d: response '%d'",
 		deviceName, address, response)
 }

--- a/components/movementsensor/gpsnmea/gpsnmea.go
+++ b/components/movementsensor/gpsnmea/gpsnmea.go
@@ -14,9 +14,8 @@ package gpsnmea
 
 import (
 	"context"
+	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"go.viam.com/rdk/components/movementsensor"
 	"go.viam.com/rdk/components/movementsensor/gpsutils"
@@ -25,7 +24,7 @@ import (
 )
 
 func connectionTypeError(connType, serialConn, i2cConn string) error {
-	return errors.Errorf("%s is not a valid connection_type of %s, %s",
+	return fmt.Errorf("%s is not a valid connection_type of %s, %s",
 		connType,
 		serialConn,
 		i2cConn)

--- a/components/movementsensor/gpsutils/cachedData.go
+++ b/components/movementsensor/gpsutils/cachedData.go
@@ -2,10 +2,9 @@ package gpsutils
 
 import (
 	"context"
+	"errors"
 	"math"
 	"sync"
-
-	"errors"
 
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"

--- a/components/movementsensor/gpsutils/cachedData.go
+++ b/components/movementsensor/gpsutils/cachedData.go
@@ -5,9 +5,10 @@ import (
 	"math"
 	"sync"
 
+	"errors"
+
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
-	"github.com/pkg/errors"
 	goutils "go.viam.com/utils"
 
 	"go.viam.com/rdk/components/movementsensor"

--- a/components/movementsensor/gpsutils/nmeaParser.go
+++ b/components/movementsensor/gpsutils/nmeaParser.go
@@ -6,9 +6,10 @@ import (
 	"strconv"
 	"strings"
 
+	"errors"
+
 	"github.com/adrianmo/go-nmea"
 	geo "github.com/kellydunn/golang-geo"
-	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 )
 
@@ -34,7 +35,7 @@ type NmeaParser struct {
 }
 
 func errInvalidFix(sentenceType, badFix, goodFix string) error {
-	return errors.Errorf("type %q sentence fix is not valid have: %q  want %q", sentenceType, badFix, goodFix)
+	return fmt.Errorf("type %q sentence fix is not valid have: %q  want %q", sentenceType, badFix, goodFix)
 }
 
 // ParseAndUpdate will attempt to parse a line to an NMEA sentence, and if valid, will try to update the given struct

--- a/components/movementsensor/gpsutils/nmeaParser.go
+++ b/components/movementsensor/gpsutils/nmeaParser.go
@@ -1,12 +1,11 @@
 package gpsutils
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
 	"strings"
-
-	"errors"
 
 	"github.com/adrianmo/go-nmea"
 	geo "github.com/kellydunn/golang-geo"

--- a/components/movementsensor/imuvectornav/imu.go
+++ b/components/movementsensor/imuvectornav/imu.go
@@ -6,11 +6,10 @@ package imuvectornav
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
-
-	"errors"
 
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
@@ -348,7 +347,7 @@ func (vn *vectornav) readRegisterSPI(ctx context.Context, reg vectornavRegister,
 	vn.spiMu.Lock()
 	defer vn.spiMu.Unlock()
 	if vn.busClosed {
-		return nil, errors.New("C=cannot read spi register the bus is closed")
+		return nil, errors.New("cannot read spi register the bus is closed")
 	}
 	hnd, err := vn.bus.OpenHandle()
 	if err != nil {
@@ -380,7 +379,7 @@ func (vn *vectornav) writeRegisterSPI(ctx context.Context, reg vectornavRegister
 	vn.spiMu.Lock()
 	defer vn.spiMu.Unlock()
 	if vn.busClosed {
-		return errors.New("Cannot write spi register the bus is closed")
+		return errors.New("cannot write spi register the bus is closed")
 	}
 	hnd, err := vn.bus.OpenHandle()
 	if err != nil {
@@ -413,7 +412,7 @@ func (vn *vectornav) vectornavTareSPI(ctx context.Context) error {
 	vn.spiMu.Lock()
 	defer vn.spiMu.Unlock()
 	if vn.busClosed {
-		return errors.New("Cannot write spi register the bus is closed")
+		return errors.New("cannot write spi register the bus is closed")
 	}
 	hnd, err := vn.bus.OpenHandle()
 	if err != nil {

--- a/components/movementsensor/imuwit/imu.go
+++ b/components/movementsensor/imuwit/imu.go
@@ -72,7 +72,7 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 
 	// Validating baud rate
 	if !rutils.ValidateBaudRate(baudRateList, int(cfg.BaudRate)) {
-		return nil, resource.NewConfigValidationError(path, fmt.Errorf("Baud rate is not in %v", baudRateList))
+		return nil, resource.NewConfigValidationError(path, fmt.Errorf("serial_baud_rate is not in %v", baudRateList))
 	}
 
 	return nil, nil

--- a/components/movementsensor/imuwit/imu.go
+++ b/components/movementsensor/imuwit/imu.go
@@ -35,7 +35,6 @@ import (
 	"github.com/golang/geo/r3"
 	slib "github.com/jacobsa/go-serial/serial"
 	geo "github.com/kellydunn/golang-geo"
-	"github.com/pkg/errors"
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/movementsensor"
@@ -73,7 +72,7 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 
 	// Validating baud rate
 	if !rutils.ValidateBaudRate(baudRateList, int(cfg.BaudRate)) {
-		return nil, resource.NewConfigValidationError(path, errors.Errorf("Baud rate is not in %v", baudRateList))
+		return nil, resource.NewConfigValidationError(path, fmt.Errorf("Baud rate is not in %v", baudRateList))
 	}
 
 	return nil, nil

--- a/components/movementsensor/mpu6050/mpu6050.go
+++ b/components/movementsensor/mpu6050/mpu6050.go
@@ -26,9 +26,10 @@ import (
 	"sync"
 	"time"
 
+	"errors"
+
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
-	"github.com/pkg/errors"
 
 	"go.viam.com/rdk/components/board/genericlinux/buses"
 	"go.viam.com/rdk/components/movementsensor"
@@ -88,12 +89,12 @@ type mpu6050 struct {
 }
 
 func addressReadError(err error, address byte, bus string) error {
-	msg := fmt.Sprintf("can't read from I2C address %d on bus %s", address, bus)
-	return errors.Wrap(err, msg)
+	msg := fmt.Errorf("can't read from I2C address %d on bus %s", address, bus)
+	return errors.Join(err, msg)
 }
 
 func unexpectedDeviceError(address, defaultAddress byte) error {
-	return errors.Errorf("unexpected non-MPU6050 device at address %d: response '%d'",
+	return fmt.Errorf("unexpected non-MPU6050 device at address %d: response '%d'",
 		address, defaultAddress)
 }
 
@@ -162,7 +163,7 @@ func makeMpu6050(
 	// To do this, we set register 107 to 0.
 	err = sensor.writeByte(ctx, 107, 0)
 	if err != nil {
-		return nil, errors.Errorf("Unable to wake up MPU6050: '%s'", err.Error())
+		return nil, fmt.Errorf("Unable to wake up MPU6050: '%s'", err.Error())
 	}
 
 	// Now, turn on the background goroutine that constantly reads from the chip and stores data in

--- a/components/movementsensor/mpu6050/mpu6050.go
+++ b/components/movementsensor/mpu6050/mpu6050.go
@@ -22,11 +22,10 @@ package mpu6050
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
-
-	"errors"
 
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
@@ -163,7 +162,7 @@ func makeMpu6050(
 	// To do this, we set register 107 to 0.
 	err = sensor.writeByte(ctx, 107, 0)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to wake up MPU6050: '%s'", err.Error())
+		return nil, fmt.Errorf("unable to wake up MPU6050: '%s'", err.Error())
 	}
 
 	// Now, turn on the background goroutine that constantly reads from the chip and stores data in

--- a/components/movementsensor/mpu6050/mpu6050_test.go
+++ b/components/movementsensor/mpu6050/mpu6050_test.go
@@ -6,7 +6,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	"go.viam.com/test"
 	"go.viam.com/utils/testutils"
 

--- a/components/movementsensor/mpu6050/mpu6050_test.go
+++ b/components/movementsensor/mpu6050/mpu6050_test.go
@@ -4,9 +4,8 @@ package mpu6050
 
 import (
 	"context"
-	"testing"
-
 	"errors"
+	"testing"
 
 	"go.viam.com/test"
 	"go.viam.com/utils/testutils"

--- a/components/movementsensor/replay/replay.go
+++ b/components/movementsensor/replay/replay.go
@@ -3,13 +3,12 @@ package replay
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
 	"sync"
 	"time"
-
-	"errors"
 
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"

--- a/components/movementsensor/replay/replay_test.go
+++ b/components/movementsensor/replay/replay_test.go
@@ -2,11 +2,10 @@ package replay
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
-
-	"errors"
 
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"

--- a/components/movementsensor/replay/replay_test.go
+++ b/components/movementsensor/replay/replay_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 	"time"
 
+	"errors"
+
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
-	"github.com/pkg/errors"
 	"go.viam.com/test"
 	"google.golang.org/grpc"
 
@@ -109,8 +110,9 @@ var (
 		OrientationSupported:        true,
 	}
 
-	errPropertiesFailedToInitializeTest = errors.Wrap(
-		errors.Wrap(context.DeadlineExceeded, errPropertiesFailedToInitialize.Error()),
+	errPropertiesFailedToInitializeTest = errors.Join(
+		context.DeadlineExceeded,
+		errPropertiesFailedToInitialize,
 		errMessageNoDataAvailable)
 )
 
@@ -149,7 +151,7 @@ func TestNewReplayMovementSensor(t *testing.T) {
 				APIKeyID:       validAPIKeyID,
 			},
 			validCloudConnection: false,
-			expectedErr:          errors.Wrap(errTestCloudConnection, errCloudConnectionFailure.Error()),
+			expectedErr:          errors.Join(errTestCloudConnection, errCloudConnectionFailure),
 		},
 		{
 			description: "Bad start timestamp",

--- a/components/movementsensor/replay/replay_utils_test.go
+++ b/components/movementsensor/replay/replay_utils_test.go
@@ -2,14 +2,13 @@ package replay
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"net"
 	"strconv"
 	"testing"
 	"time"
-
-	"errors"
 
 	"github.com/golang/geo/r3"
 	datapb "go.viam.com/api/app/data/v1"

--- a/components/movementsensor/replay/replay_utils_test.go
+++ b/components/movementsensor/replay/replay_utils_test.go
@@ -9,8 +9,9 @@ import (
 	"testing"
 	"time"
 
+	"errors"
+
 	"github.com/golang/geo/r3"
-	"github.com/pkg/errors"
 	datapb "go.viam.com/api/app/data/v1"
 	"go.viam.com/test"
 	"go.viam.com/utils/rpc"
@@ -96,7 +97,7 @@ func (mDServer *mockDataServiceServer) TabularDataByFilter(ctx context.Context, 
 func timestampsFromIndex(index int) (*timestamppb.Timestamp, *timestamppb.Timestamp, error) {
 	timeReq, err := time.Parse(time.RFC3339, fmt.Sprintf(testTime, index))
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed parsing time")
+		return nil, nil, errors.Join(err, errors.New("failed parsing time"))
 	}
 	timeRec := timeReq.Add(time.Second)
 	return timestamppb.New(timeReq), timestamppb.New(timeRec), nil

--- a/components/sensor/ultrasonic/ultrasonic.go
+++ b/components/sensor/ultrasonic/ultrasonic.go
@@ -3,12 +3,11 @@ package ultrasonic
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"sync"
 	"time"
-
-	"errors"
 
 	rdkutils "go.viam.com/utils"
 
@@ -103,7 +102,7 @@ func NewSensor(ctx context.Context, deps resource.Dependencies,
 		return nil, errors.Join(err, fmt.Errorf("ultrasonic: cannot grab gpio %q", config.TriggerPin))
 	}
 	if err := triggerPin.Set(ctx, false, nil); err != nil {
-		return nil, errors.Join(err, fmt.Errorf("ultrasonic: cannot set trigger pin to low"))
+		return nil, errors.Join(err, errors.New("ultrasonic: cannot set trigger pin to low"))
 	}
 
 	return s, nil
@@ -125,7 +124,7 @@ type Sensor struct {
 
 func (s *Sensor) namedError(err error) error {
 	return errors.Join(
-		err, fmt.Errorf("Error in ultrasonic sensor with name %s: ", s.Name()),
+		err, fmt.Errorf("error in ultrasonic sensor with name %s: ", s.Name()),
 	)
 }
 
@@ -147,7 +146,7 @@ func (s *Sensor) Readings(ctx context.Context, extra map[string]interface{}) (ma
 
 	err = s.board.StreamTicks(ctx, []string{s.config.EchoInterrupt}, s.ticksChan, nil)
 	if err != nil {
-		return nil, errors.Join(err, fmt.Errorf("ultrasonic: error getting digital interrupt ticks"))
+		return nil, errors.Join(err, errors.New("ultrasonic: error getting digital interrupt ticks"))
 	}
 
 	// Remove the callbacks added by the interrupt stream once we are done reading.

--- a/components/servo/gpio/servo.go
+++ b/components/servo/gpio/servo.go
@@ -3,11 +3,13 @@ package gpio
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	viamutils "go.viam.com/utils"
 
 	"go.viam.com/rdk/components/board"
@@ -71,7 +73,7 @@ func (config *servoConfig) Validate(path string) ([]string, error) {
 		}
 		if *config.StartPos < minDeg || *config.StartPos > maxDeg {
 			return nil, resource.NewConfigValidationError(path,
-				errors.Errorf("starting_position_deg should be between minimum (%.1f) and maximum (%.1f) positions", minDeg, maxDeg))
+				fmt.Errorf("starting_position_deg should be between minimum (%.1f) and maximum (%.1f) positions", minDeg, maxDeg))
 		}
 	}
 
@@ -79,10 +81,10 @@ func (config *servoConfig) Validate(path string) ([]string, error) {
 		return nil, resource.NewConfigValidationError(path, errors.New("min_angle_deg cannot be lower than 0"))
 	}
 	if config.MinWidthUs != nil && *config.MinWidthUs < minWidthUs {
-		return nil, resource.NewConfigValidationError(path, errors.Errorf("min_width_us cannot be lower than %d", minWidthUs))
+		return nil, resource.NewConfigValidationError(path, fmt.Errorf("min_width_us cannot be lower than %d", minWidthUs))
 	}
 	if config.MaxWidthUs != nil && *config.MaxWidthUs > maxWidthUs {
-		return nil, resource.NewConfigValidationError(path, errors.Errorf("max_width_us cannot be higher than %d", maxWidthUs))
+		return nil, resource.NewConfigValidationError(path, fmt.Errorf("max_width_us cannot be higher than %d", maxWidthUs))
 	}
 	return deps, nil
 }
@@ -143,12 +145,12 @@ func (s *servoGPIO) Reconfigure(ctx context.Context, deps resource.Dependencies,
 
 	b, err := board.FromDependencies(deps, boardName)
 	if err != nil {
-		return errors.Wrap(err, "board doesn't exist")
+		return errors.Join(err, fmt.Errorf("board doesn't exist"))
 	}
 
 	s.pin, err = b.GPIOPinByName(newConf.Pin)
 	if err != nil {
-		return errors.Wrap(err, "couldn't get servo pin")
+		return errors.Join(err, fmt.Errorf("couldn't get servo pin"))
 	}
 
 	s.minDeg = defaultMinDeg
@@ -179,7 +181,7 @@ func (s *servoGPIO) Reconfigure(ctx context.Context, deps resource.Dependencies,
 	// instead. If it's currently set to 0, we'll default to using 300 Hz.
 	s.frequency, err = s.pin.PWMFreq(ctx, nil)
 	if err != nil {
-		return errors.Wrap(err, "couldn't get servo pin pwm frequency")
+		return errors.Join(err, fmt.Errorf("couldn't get servo pin pwm frequency"))
 	}
 
 	if s.frequency == 0 {
@@ -188,7 +190,7 @@ func (s *servoGPIO) Reconfigure(ctx context.Context, deps resource.Dependencies,
 
 	if newConf.Frequency != nil {
 		if *newConf.Frequency > 450 || *newConf.Frequency < 50 {
-			return errors.Errorf(
+			return fmt.Errorf(
 				"PWM frequencies should not be above 450Hz or below 50, have %d", newConf.Frequency)
 		}
 
@@ -206,20 +208,20 @@ func (s *servoGPIO) Reconfigure(ctx context.Context, deps resource.Dependencies,
 	}
 
 	if err := s.pin.SetPWMFreq(ctx, s.frequency, nil); err != nil {
-		return errors.Wrap(err, "error setting servo pin frequency")
+		return errors.Join(err, fmt.Errorf("error setting servo pin frequency"))
 	}
 
 	// Try to detect the PWM resolution.
 	if err := s.Move(ctx, uint32(startPos), nil); err != nil {
-		return errors.Wrap(err, "couldn't move servo to start position")
+		return errors.Join(err, fmt.Errorf("couldn't move servo to start position"))
 	}
 
 	if err := s.findPWMResolution(ctx); err != nil {
-		return errors.Wrap(err, "failed to guess the pwm resolution")
+		return errors.Join(err, fmt.Errorf("failed to guess the pwm resolution"))
 	}
 
 	if err := s.Move(ctx, uint32(startPos), nil); err != nil {
-		return errors.Wrap(err, "couldn't move servo back to start position")
+		return errors.Join(err, fmt.Errorf("couldn't move servo back to start position"))
 	}
 
 	return nil
@@ -266,7 +268,7 @@ func (s *servoGPIO) findPWMResolution(ctx context.Context) error {
 	currPct := s.currPct
 	realPct, err := s.pin.PWM(ctx, nil)
 	if err != nil {
-		return errors.Wrap(err, "cannot find PWM resolution")
+		return errors.Join(err, fmt.Errorf("cannot find PWM resolution"))
 	}
 
 	// The direction will be towards whichever extreme duration (minUs or maxUs) is farther away.
@@ -279,16 +281,16 @@ func (s *servoGPIO) findPWMResolution(ctx context.Context) error {
 
 	if realPct != currPct {
 		if err := s.pin.SetPWM(ctx, realPct, nil); err != nil {
-			return errors.Wrap(err, "couldn't set PWM to realPct")
+			return errors.Join(err, fmt.Errorf("couldn't set PWM to realPct"))
 		}
 		r2, err := s.pin.PWM(ctx, nil)
 		if err != nil {
-			return errors.Wrap(err, "couldn't find PWM resolution")
+			return errors.Join(err, fmt.Errorf("couldn't find PWM resolution"))
 		}
 		if r2 == realPct {
 			currPct = r2
 		} else {
-			return errors.Errorf("giving up searching for the resolution tried to match %.7f but got %.7f", realPct, r2)
+			return fmt.Errorf("giving up searching for the resolution tried to match %.7f but got %.7f", realPct, r2)
 		}
 	}
 
@@ -298,7 +300,7 @@ func (s *servoGPIO) findPWMResolution(ctx context.Context) error {
 		pct := currPct + dir/float64(val)
 		err := s.pin.SetPWM(ctx, pct, nil)
 		if err != nil {
-			return errors.Wrap(err, "couldn't search for PWM resolution")
+			return errors.Join(err, fmt.Errorf("couldn't search for PWM resolution"))
 		}
 		if !viamutils.SelectContextOrWait(ctx, 3*time.Millisecond) {
 			return errors.New("context canceled while looking for servo's PWM resolution")
@@ -306,7 +308,7 @@ func (s *servoGPIO) findPWMResolution(ctx context.Context) error {
 		realPct, err := s.pin.PWM(ctx, nil)
 		s.logger.CDebugf(ctx, "starting step %d currPct %.7f target Pct %.14f realPct %.14f", val, currPct, pct, realPct)
 		if err != nil {
-			return errors.Wrap(err, "couldn't find servo PWM resolution")
+			return errors.Join(err, fmt.Errorf("couldn't find servo PWM resolution"))
 		}
 		if realPct != currPct {
 			if realPct == pct {
@@ -345,7 +347,7 @@ func (s *servoGPIO) Move(ctx context.Context, ang uint32, extra map[string]inter
 	}
 
 	if err := s.pin.SetPWM(ctx, pct, nil); err != nil {
-		return errors.Wrap(err, "couldn't move the servo")
+		return errors.Join(err, fmt.Errorf("couldn't move the servo"))
 	}
 
 	s.currPct = pct
@@ -356,7 +358,7 @@ func (s *servoGPIO) Move(ctx context.Context, ang uint32, extra map[string]inter
 func (s *servoGPIO) Position(ctx context.Context, extra map[string]interface{}) (uint32, error) {
 	pct, err := s.pin.PWM(ctx, nil)
 	if err != nil {
-		return 0, errors.Wrap(err, "couldn't get servo pin duty cycle")
+		return 0, errors.Join(err, fmt.Errorf("couldn't get servo pin duty cycle"))
 	}
 	// Since Stop() sets the dutyCycle to 0.0 in order to maintain the position of the servo,
 	// we are setting the dutyCycle back to the last known dutyCycle to prevent the servo
@@ -365,7 +367,7 @@ func (s *servoGPIO) Position(ctx context.Context, extra map[string]interface{}) 
 		pct = s.currPct
 		err := s.pin.SetPWM(ctx, pct, extra)
 		if err != nil {
-			return 0, errors.Wrap(err, "couldn't get servo pin duty cycle")
+			return 0, errors.Join(err, fmt.Errorf("couldn't get servo pin duty cycle"))
 		}
 	}
 
@@ -379,7 +381,7 @@ func (s *servoGPIO) Stop(ctx context.Context, extra map[string]interface{}) erro
 	// Turning the pin all the way off (i.e., setting the duty cycle to 0%) will cut power to the
 	// motor. If you wanted to send it to position 0, you should set it to `minUs` instead.
 	if err := s.pin.SetPWM(ctx, 0.0, nil); err != nil {
-		return errors.Wrap(err, "couldn't stop servo")
+		return errors.Join(err, fmt.Errorf("couldn't stop servo"))
 	}
 	return nil
 }
@@ -388,7 +390,7 @@ func (s *servoGPIO) Stop(ctx context.Context, extra map[string]interface{}) erro
 func (s *servoGPIO) IsMoving(ctx context.Context) (bool, error) {
 	res, err := s.pin.PWM(ctx, nil)
 	if err != nil {
-		return false, errors.Wrap(err, "servo error while checking if moving")
+		return false, errors.Join(err, fmt.Errorf("servo error while checking if moving"))
 	}
 	if int(res) == 0 {
 		return false, nil

--- a/components/servo/gpio/servo_test.go
+++ b/components/servo/gpio/servo_test.go
@@ -5,7 +5,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	"go.viam.com/test"
 
 	"go.viam.com/rdk/components/board"

--- a/components/servo/gpio/servo_test.go
+++ b/components/servo/gpio/servo_test.go
@@ -3,9 +3,8 @@ package gpio
 
 import (
 	"context"
-	"testing"
-
 	"errors"
+	"testing"
 
 	"go.viam.com/test"
 

--- a/components/servo/server_test.go
+++ b/components/servo/server_test.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	pb "go.viam.com/api/component/servo/v1"
 	"go.viam.com/test"
 	"go.viam.com/utils/protoutils"

--- a/components/servo/server_test.go
+++ b/components/servo/server_test.go
@@ -2,9 +2,8 @@ package servo_test
 
 import (
 	"context"
-	"testing"
-
 	"errors"
+	"testing"
 
 	pb "go.viam.com/api/component/servo/v1"
 	"go.viam.com/test"

--- a/components/servo/servo_test.go
+++ b/components/servo/servo_test.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	pb "go.viam.com/api/component/servo/v1"
 	"go.viam.com/test"
 

--- a/components/servo/servo_test.go
+++ b/components/servo/servo_test.go
@@ -2,9 +2,8 @@ package servo_test
 
 import (
 	"context"
-	"testing"
-
 	"errors"
+	"testing"
 
 	pb "go.viam.com/api/component/servo/v1"
 	"go.viam.com/test"


### PR DESCRIPTION
Starting a bit of a cleanup effort for our error package usage in rdk. Starting with the components. The package "github/com/pkg/errors" is an archived package; the standard "errors" library has different methods.

This also uncovered some linting errors, because the standard "errors" package seems to be the only one checked against with our linter. "github.com/pkg/errors" seems to be ignored.