### PR TITLE
RSDK-7363 Remove tick from digital interrupt interface

### DIFF
--- a/components/board/digital_interrupts.go
+++ b/components/board/digital_interrupts.go
@@ -23,12 +23,6 @@ type DigitalInterrupt interface {
 	// based on the type of interrupt.
 	Value(ctx context.Context, extra map[string]interface{}) (int64, error)
 
-	// Tick is to be called either manually if the interrupt is a proxy to some real
-	// hardware interrupt or for tests.
-	// nanoseconds is from an arbitrary point in time, but always increasing and always needs
-	// to be accurate.
-	Tick(ctx context.Context, high bool, nanoseconds uint64) error
-
 	// AddCallback adds a callback to be sent a low/high value to when a tick
 	// happens.
 	AddCallback(c chan Tick)

--- a/components/board/fake/board.go
+++ b/components/board/fake/board.go
@@ -414,10 +414,10 @@ func (s *DigitalInterruptWrapper) Value(ctx context.Context, extra map[string]in
 // hardware interrupt or for tests.
 // nanoseconds is from an arbitrary point in time, but always increasing and always needs
 // to be accurate.
-func (s *DigitalInterruptWrapper) Tick(ctx context.Context, high bool, nanoseconds uint64) error {
+func Tick(ctx context.Context, s *DigitalInterruptWrapper, high bool, nanoseconds uint64) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.di.Tick(ctx, high, nanoseconds)
+	return pinwrappers.Tick(ctx, s.di.(*pinwrappers.BasicDigitalInterrupt), high, nanoseconds)
 }
 
 // AddCallback adds a callback to be sent a low/high value to when a tick

--- a/components/board/genericlinux/digital_interrupts.go
+++ b/components/board/genericlinux/digital_interrupts.go
@@ -86,8 +86,8 @@ func (di *digitalInterrupt) startMonitor() {
 			case <-di.cancelCtx.Done():
 				return
 			case event := <-di.line.Events():
-				utils.UncheckedError(di.interrupt.Tick(
-					di.cancelCtx, event.RisingEdge, uint64(event.Time.UnixNano())))
+				utils.UncheckedError(pinwrappers.Tick(
+					di.cancelCtx, di.interrupt.(*pinwrappers.BasicDigitalInterrupt), event.RisingEdge, uint64(event.Time.UnixNano())))
 			}
 		}
 	}, di.boardWorkers.Done)

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -788,7 +788,7 @@ func pigpioInterruptCallback(gpio, level int, rawTick uint32) {
 		}
 		// this should *not* block for long otherwise the lock
 		// will be held
-		err := i.Tick(instance.cancelCtx, high, tick*1000)
+		err := Tick(instance.cancelCtx, i.(*BasicDigitalInterrupt), high, tick*1000)
 		if err != nil {
 			instance.logger.Error(err)
 		}

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -799,6 +799,8 @@ func pigpioInterruptCallback(gpio, level int, rawTick uint32) {
 			if err != nil {
 				instance.logger.Error(err)
 			}
+		default:
+			instance.logger.Error("unknown digital interrupt type")
 		}
 	}
 }

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -789,7 +789,6 @@ func pigpioInterruptCallback(gpio, level int, rawTick uint32) {
 		// this should *not* block for long otherwise the lock
 		// will be held
 		switch di := i.(type) {
-
 		case *BasicDigitalInterrupt:
 			err := Tick(instance.cancelCtx, di, high, tick*1000)
 			if err != nil {

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -788,9 +788,18 @@ func pigpioInterruptCallback(gpio, level int, rawTick uint32) {
 		}
 		// this should *not* block for long otherwise the lock
 		// will be held
-		err := Tick(instance.cancelCtx, i.(*BasicDigitalInterrupt), high, tick*1000)
-		if err != nil {
-			instance.logger.Error(err)
+		switch di := i.(type) {
+
+		case *BasicDigitalInterrupt:
+			err := Tick(instance.cancelCtx, di, high, tick*1000)
+			if err != nil {
+				instance.logger.Error(err)
+			}
+		case *ServoDigitalInterrupt:
+			err := ServoTick(instance.cancelCtx, di, high, tick*1000)
+			if err != nil {
+				instance.logger.Error(err)
+			}
 		}
 	}
 }

--- a/components/board/pi/impl/digital_interrupts.go
+++ b/components/board/pi/impl/digital_interrupts.go
@@ -176,9 +176,9 @@ func (i *ServoDigitalInterrupt) Value(ctx context.Context, extra map[string]inte
 	return v, nil
 }
 
-// Tick records the time between two successive low signals (pulse width). How it is
+// ServoTick records the time between two successive low signals (pulse width). How it is
 // interpreted is based off the consumer of Value.
-func (i *ServoDigitalInterrupt) Tick(ctx context.Context, high bool, now uint64) error {
+func ServoTick(ctx context.Context, i *ServoDigitalInterrupt, high bool, now uint64) error {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 	diff := now - i.last

--- a/components/board/pi/impl/digital_interrupts.go
+++ b/components/board/pi/impl/digital_interrupts.go
@@ -88,7 +88,7 @@ func (i *BasicDigitalInterrupt) Value(ctx context.Context, extra map[string]inte
 // Ticks is really just for testing.
 func (i *BasicDigitalInterrupt) Ticks(ctx context.Context, num int, now uint64) error {
 	for x := 0; x < num; x++ {
-		if err := i.Tick(ctx, true, now+uint64(x)); err != nil {
+		if err := Tick(ctx, i, true, now+uint64(x)); err != nil {
 			return err
 		}
 	}
@@ -97,7 +97,7 @@ func (i *BasicDigitalInterrupt) Ticks(ctx context.Context, num int, now uint64) 
 
 // Tick records an interrupt and notifies any interested callbacks. See comment on
 // the DigitalInterrupt interface for caveats.
-func (i *BasicDigitalInterrupt) Tick(ctx context.Context, high bool, nanoseconds uint64) error {
+func Tick(ctx context.Context, i *BasicDigitalInterrupt, high bool, nanoseconds uint64) error {
 	if high {
 		atomic.AddInt64(&i.count, 1)
 	}

--- a/components/board/pi/impl/digital_interrupts_test.go
+++ b/components/board/pi/impl/digital_interrupts_test.go
@@ -25,14 +25,16 @@ func TestBasicDigitalInterrupt1(t *testing.T) {
 	i, err := CreateDigitalInterrupt(config)
 	test.That(t, err, test.ShouldBeNil)
 
+	basicInterrupt := i.(*BasicDigitalInterrupt)
+
 	intVal, err := i.Value(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, intVal, test.ShouldEqual, int64(0))
-	test.That(t, i.Tick(context.Background(), true, nowNanosecondsTest()), test.ShouldBeNil)
+	test.That(t, Tick(context.Background(), basicInterrupt, true, nowNanosecondsTest()), test.ShouldBeNil)
 	intVal, err = i.Value(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, intVal, test.ShouldEqual, int64(1))
-	test.That(t, i.Tick(context.Background(), false, nowNanosecondsTest()), test.ShouldBeNil)
+	test.That(t, Tick(context.Background(), basicInterrupt, false, nowNanosecondsTest()), test.ShouldBeNil)
 	intVal, err = i.Value(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, intVal, test.ShouldEqual, int64(1))
@@ -41,14 +43,14 @@ func TestBasicDigitalInterrupt1(t *testing.T) {
 	i.AddCallback(c)
 
 	timeNanoSec := nowNanosecondsTest()
-	go func() { i.Tick(context.Background(), true, timeNanoSec) }()
+	go func() { Tick(context.Background(), basicInterrupt, true, timeNanoSec) }()
 	time.Sleep(1 * time.Microsecond)
 	v := <-c
 	test.That(t, v.High, test.ShouldBeTrue)
 	test.That(t, v.TimestampNanosec, test.ShouldEqual, timeNanoSec)
 
 	timeNanoSec = nowNanosecondsTest()
-	go func() { i.Tick(context.Background(), true, timeNanoSec) }()
+	go func() { Tick(context.Background(), basicInterrupt, true, timeNanoSec) }()
 	v = <-c
 	test.That(t, v.High, test.ShouldBeTrue)
 	test.That(t, v.TimestampNanosec, test.ShouldEqual, timeNanoSec)
@@ -58,8 +60,8 @@ func TestBasicDigitalInterrupt1(t *testing.T) {
 	c = make(chan board.Tick, 2)
 	i.AddCallback(c)
 	go func() {
-		i.Tick(context.Background(), true, uint64(1))
-		i.Tick(context.Background(), true, uint64(4))
+		Tick(context.Background(), basicInterrupt, true, uint64(1))
+		Tick(context.Background(), basicInterrupt, true, uint64(4))
 	}()
 	v = <-c
 	v1 := <-c
@@ -74,10 +76,11 @@ func TestRemoveCallbackDigitalInterrupt(t *testing.T) {
 	}
 	i, err := CreateDigitalInterrupt(config)
 	test.That(t, err, test.ShouldBeNil)
+	basicInterrupt := i.(*BasicDigitalInterrupt)
 	intVal, err := i.Value(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, intVal, test.ShouldEqual, int64(0))
-	test.That(t, i.Tick(context.Background(), true, nowNanosecondsTest()), test.ShouldBeNil)
+	test.That(t, Tick(context.Background(), basicInterrupt, true, nowNanosecondsTest()), test.ShouldBeNil)
 	intVal, err = i.Value(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, intVal, test.ShouldEqual, int64(1))
@@ -103,7 +106,7 @@ func TestRemoveCallbackDigitalInterrupt(t *testing.T) {
 			ret = tick.High
 		}
 	}()
-	test.That(t, i.Tick(context.Background(), true, nowNanosecondsTest()), test.ShouldBeNil)
+	test.That(t, Tick(context.Background(), basicInterrupt, true, nowNanosecondsTest()), test.ShouldBeNil)
 	intVal, err = i.Value(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, intVal, test.ShouldEqual, int64(2))
@@ -134,7 +137,7 @@ func TestRemoveCallbackDigitalInterrupt(t *testing.T) {
 	}()
 	wg.Add(1)
 	go func() {
-		err := i.Tick(context.Background(), true, nowNanosecondsTest())
+		err := Tick(context.Background(), basicInterrupt, true, nowNanosecondsTest())
 		if err != nil {
 			result <- true
 		}
@@ -161,12 +164,13 @@ func TestServoInterrupt(t *testing.T) {
 
 	s, err := CreateDigitalInterrupt(config)
 	test.That(t, err, test.ShouldBeNil)
+	servoInterrupt := s.(*ServoDigitalInterrupt)
 
 	now := uint64(0)
 	for i := 0; i < 20; i++ {
-		test.That(t, s.Tick(context.Background(), true, now), test.ShouldBeNil)
+		test.That(t, ServoTick(context.Background(), servoInterrupt, true, now), test.ShouldBeNil)
 		now += 1500 * 1000 // this is what we measure
-		test.That(t, s.Tick(context.Background(), false, now), test.ShouldBeNil)
+		test.That(t, ServoTick(context.Background(), servoInterrupt, false, now), test.ShouldBeNil)
 		now += 1000 * 1000 * 1000 // this is between measurements
 	}
 
@@ -183,12 +187,13 @@ func TestServoInterruptWithPP(t *testing.T) {
 
 	s, err := CreateDigitalInterrupt(config)
 	test.That(t, err, test.ShouldBeNil)
+	servoInterrupt := s.(*ServoDigitalInterrupt)
 
 	now := uint64(0)
 	for i := 0; i < 20; i++ {
-		test.That(t, s.Tick(context.Background(), true, now), test.ShouldBeNil)
+		test.That(t, ServoTick(context.Background(), servoInterrupt, true, now), test.ShouldBeNil)
 		now += 1500 * 1000 // this is what we measure
-		test.That(t, s.Tick(context.Background(), false, now), test.ShouldBeNil)
+		test.That(t, ServoTick(context.Background(), servoInterrupt, false, now), test.ShouldBeNil)
 		now += 1000 * 1000 * 1000 // this is between measurements
 	}
 

--- a/components/board/pinwrappers/digital_interrupts.go
+++ b/components/board/pinwrappers/digital_interrupts.go
@@ -5,7 +5,6 @@ package pinwrappers
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"sync/atomic"
 
@@ -62,20 +61,16 @@ func (i *BasicDigitalInterrupt) Ticks(ctx context.Context, num int, now uint64) 
 // Tick records an interrupt and notifies any interested callbacks. See comment on
 // the DigitalInterrupt interface for caveats.
 func Tick(ctx context.Context, i *BasicDigitalInterrupt, high bool, nanoseconds uint64) error {
-	fmt.Println("here ticking")
-	fmt.Println(i.Name())
 	if high {
 		atomic.AddInt64(&i.count, 1)
 	}
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 	for _, c := range i.callbacks {
-		fmt.Println("has callbacks")
 		select {
 		case <-ctx.Done():
 			return errors.New("context cancelled")
 		case c <- board.Tick{Name: i.cfg.Name, High: high, TimestampNanosec: nanoseconds}:
-			fmt.Println("sending to callback")
 		}
 	}
 	return nil

--- a/components/board/pinwrappers/digital_interrupts_test.go
+++ b/components/board/pinwrappers/digital_interrupts_test.go
@@ -26,11 +26,11 @@ func TestBasicDigitalInterrupt1(t *testing.T) {
 	intVal, err := i.Value(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, intVal, test.ShouldEqual, int64(0))
-	test.That(t, i.Tick(context.Background(), true, nowNanosecondsTest()), test.ShouldBeNil)
+	test.That(t, Tick(context.Background(), i.(*BasicDigitalInterrupt), true, nowNanosecondsTest()), test.ShouldBeNil)
 	intVal, err = i.Value(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, intVal, test.ShouldEqual, int64(1))
-	test.That(t, i.Tick(context.Background(), false, nowNanosecondsTest()), test.ShouldBeNil)
+	test.That(t, Tick(context.Background(), i.(*BasicDigitalInterrupt), false, nowNanosecondsTest()), test.ShouldBeNil)
 	intVal, err = i.Value(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, intVal, test.ShouldEqual, int64(1))
@@ -39,14 +39,14 @@ func TestBasicDigitalInterrupt1(t *testing.T) {
 	i.AddCallback(c)
 
 	timeNanoSec := nowNanosecondsTest()
-	go func() { i.Tick(context.Background(), true, timeNanoSec) }()
+	go func() { Tick(context.Background(), i.(*BasicDigitalInterrupt), true, timeNanoSec) }()
 	time.Sleep(1 * time.Microsecond)
 	v := <-c
 	test.That(t, v.High, test.ShouldBeTrue)
 	test.That(t, v.TimestampNanosec, test.ShouldEqual, timeNanoSec)
 
 	timeNanoSec = nowNanosecondsTest()
-	go func() { i.Tick(context.Background(), true, timeNanoSec) }()
+	go func() { Tick(context.Background(), i.(*BasicDigitalInterrupt), true, timeNanoSec) }()
 	v = <-c
 	test.That(t, v.High, test.ShouldBeTrue)
 	test.That(t, v.TimestampNanosec, test.ShouldEqual, timeNanoSec)
@@ -56,8 +56,8 @@ func TestBasicDigitalInterrupt1(t *testing.T) {
 	c = make(chan board.Tick, 2)
 	i.AddCallback(c)
 	go func() {
-		i.Tick(context.Background(), true, uint64(1))
-		i.Tick(context.Background(), true, uint64(4))
+		Tick(context.Background(), i.(*BasicDigitalInterrupt), true, uint64(1))
+		Tick(context.Background(), i.(*BasicDigitalInterrupt), true, uint64(4))
 	}()
 	v = <-c
 	v1 := <-c
@@ -75,7 +75,7 @@ func TestRemoveCallbackDigitalInterrupt(t *testing.T) {
 	intVal, err := i.Value(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, intVal, test.ShouldEqual, int64(0))
-	test.That(t, i.Tick(context.Background(), true, nowNanosecondsTest()), test.ShouldBeNil)
+	test.That(t, Tick(context.Background(), i.(*BasicDigitalInterrupt), true, nowNanosecondsTest()), test.ShouldBeNil)
 	intVal, err = i.Value(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, intVal, test.ShouldEqual, int64(1))
@@ -101,7 +101,7 @@ func TestRemoveCallbackDigitalInterrupt(t *testing.T) {
 			ret = tick.High
 		}
 	}()
-	test.That(t, i.Tick(context.Background(), true, nowNanosecondsTest()), test.ShouldBeNil)
+	test.That(t, Tick(context.Background(), i.(*BasicDigitalInterrupt), true, nowNanosecondsTest()), test.ShouldBeNil)
 	intVal, err = i.Value(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, intVal, test.ShouldEqual, int64(2))
@@ -132,7 +132,7 @@ func TestRemoveCallbackDigitalInterrupt(t *testing.T) {
 	}()
 	wg.Add(1)
 	go func() {
-		err := i.Tick(context.Background(), true, nowNanosecondsTest())
+		err := Tick(context.Background(), i.(*BasicDigitalInterrupt), true, nowNanosecondsTest())
 		if err != nil {
 			result <- true
 		}

--- a/components/encoder/incremental/incremental_encoder.go
+++ b/components/encoder/incremental/incremental_encoder.go
@@ -248,7 +248,7 @@ func (e *Encoder) Start(ctx context.Context, b board.Board) {
 			case <-e.cancelCtx.Done():
 				return
 			case tick = <-ch:
-				if tick.Name == e.A.Name() {
+				if tick.Name == e.encAName {
 					aLevel = 0
 					if tick.High {
 						aLevel = 1

--- a/components/encoder/incremental/incremental_test.go
+++ b/components/encoder/incremental/incremental_test.go
@@ -9,7 +9,6 @@ import (
 	"go.viam.com/utils/testutils"
 
 	"go.viam.com/rdk/components/board"
-	"go.viam.com/rdk/components/board/fake"
 	fakeboard "go.viam.com/rdk/components/board/fake"
 	"go.viam.com/rdk/components/encoder"
 	"go.viam.com/rdk/logging"
@@ -70,9 +69,9 @@ func TestEncoder(t *testing.T) {
 		enc2 := enc.(*Encoder)
 		defer enc2.Close(context.Background())
 
-		err = fake.Tick(context.Background(), enc2.B.(*fake.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano()))
+		err = fakeboard.Tick(context.Background(), enc2.B.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano()))
 		test.That(t, err, test.ShouldBeNil)
-		err = fake.Tick(context.Background(), enc2.A.(*fake.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano()))
+		err = fakeboard.Tick(context.Background(), enc2.A.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano()))
 		test.That(t, err, test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
@@ -89,9 +88,9 @@ func TestEncoder(t *testing.T) {
 		enc2 := enc.(*Encoder)
 		defer enc2.Close(context.Background())
 
-		err = fake.Tick(context.Background(), enc2.A.(*fake.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano()))
+		err = fakeboard.Tick(context.Background(), enc2.A.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano()))
 		test.That(t, err, test.ShouldBeNil)
-		err = fake.Tick(context.Background(), enc2.B.(*fake.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano()))
+		err = fakeboard.Tick(context.Background(), enc2.B.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano()))
 		test.That(t, err, test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {

--- a/components/encoder/incremental/incremental_test.go
+++ b/components/encoder/incremental/incremental_test.go
@@ -9,6 +9,7 @@ import (
 	"go.viam.com/utils/testutils"
 
 	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/fake"
 	fakeboard "go.viam.com/rdk/components/board/fake"
 	"go.viam.com/rdk/components/encoder"
 	"go.viam.com/rdk/logging"
@@ -69,9 +70,9 @@ func TestEncoder(t *testing.T) {
 		enc2 := enc.(*Encoder)
 		defer enc2.Close(context.Background())
 
-		err = enc2.B.Tick(context.Background(), true, uint64(time.Now().UnixNano()))
+		err = fake.Tick(context.Background(), enc2.B.(*fake.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano()))
 		test.That(t, err, test.ShouldBeNil)
-		err = enc2.A.Tick(context.Background(), true, uint64(time.Now().UnixNano()))
+		err = fake.Tick(context.Background(), enc2.A.(*fake.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano()))
 		test.That(t, err, test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
@@ -88,9 +89,9 @@ func TestEncoder(t *testing.T) {
 		enc2 := enc.(*Encoder)
 		defer enc2.Close(context.Background())
 
-		err = enc2.A.Tick(context.Background(), false, uint64(time.Now().UnixNano()))
+		err = fake.Tick(context.Background(), enc2.A.(*fake.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano()))
 		test.That(t, err, test.ShouldBeNil)
-		err = enc2.B.Tick(context.Background(), false, uint64(time.Now().UnixNano()))
+		err = fake.Tick(context.Background(), enc2.B.(*fake.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano()))
 		test.That(t, err, test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {

--- a/components/encoder/single/single_encoder_test.go
+++ b/components/encoder/single/single_encoder_test.go
@@ -9,7 +9,6 @@ import (
 	"go.viam.com/utils/testutils"
 
 	"go.viam.com/rdk/components/board"
-	"go.viam.com/rdk/components/board/fake"
 	fakeboard "go.viam.com/rdk/components/board/fake"
 	"go.viam.com/rdk/components/encoder"
 	"go.viam.com/rdk/logging"
@@ -73,7 +72,7 @@ func TestEncoder(t *testing.T) {
 		m := &FakeDir{1} // forward
 		enc2.AttachDirectionalAwareness(m)
 
-		err = fake.Tick(context.Background(), enc2.I.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano()))
+		err = fakeboard.Tick(context.Background(), enc2.I.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano()))
 		test.That(t, err, test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
@@ -93,7 +92,7 @@ func TestEncoder(t *testing.T) {
 		m := &FakeDir{-1} // backward
 		enc2.AttachDirectionalAwareness(m)
 
-		err = fake.Tick(context.Background(), enc2.I.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano()))
+		err = fakeboard.Tick(context.Background(), enc2.I.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano()))
 		test.That(t, err, test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
@@ -112,7 +111,7 @@ func TestEncoder(t *testing.T) {
 		enc2 := enc.(*Encoder)
 		defer enc2.Close(context.Background())
 
-		err = fake.Tick(context.Background(), enc2.I.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano()))
+		err = fakeboard.Tick(context.Background(), enc2.I.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano()))
 		test.That(t, err, test.ShouldBeNil)
 
 		// Give the tick time to propagate to encoder
@@ -149,7 +148,7 @@ func TestEncoder(t *testing.T) {
 		enc2.AttachDirectionalAwareness(m)
 
 		// move forward
-		err = fake.Tick(context.Background(), enc2.I.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano()))
+		err = fakeboard.Tick(context.Background(), enc2.I.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano()))
 		test.That(t, err, test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
@@ -167,7 +166,7 @@ func TestEncoder(t *testing.T) {
 		test.That(t, ticks, test.ShouldEqual, 0)
 
 		// now tick up again
-		err = fake.Tick(context.Background(), enc2.I.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano()))
+		err = fakeboard.Tick(context.Background(), enc2.I.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano()))
 		test.That(t, err, test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
@@ -186,7 +185,7 @@ func TestEncoder(t *testing.T) {
 		m := &FakeDir{1} // forward
 		enc2.AttachDirectionalAwareness(m)
 
-		err = fake.Tick(context.Background(), enc2.I.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano()))
+		err = fakeboard.Tick(context.Background(), enc2.I.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano()))
 		test.That(t, err, test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
@@ -206,7 +205,7 @@ func TestEncoder(t *testing.T) {
 		m := &FakeDir{-1} // backward
 		enc2.AttachDirectionalAwareness(m)
 
-		err = fake.Tick(context.Background(), enc2.I.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano()))
+		err = fakeboard.Tick(context.Background(), enc2.I.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano()))
 		test.That(t, err, test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {

--- a/components/encoder/single/single_encoder_test.go
+++ b/components/encoder/single/single_encoder_test.go
@@ -9,6 +9,7 @@ import (
 	"go.viam.com/utils/testutils"
 
 	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/fake"
 	fakeboard "go.viam.com/rdk/components/board/fake"
 	"go.viam.com/rdk/components/encoder"
 	"go.viam.com/rdk/logging"
@@ -72,7 +73,7 @@ func TestEncoder(t *testing.T) {
 		m := &FakeDir{1} // forward
 		enc2.AttachDirectionalAwareness(m)
 
-		err = enc2.I.Tick(context.Background(), true, uint64(time.Now().UnixNano()))
+		err = fake.Tick(context.Background(), enc2.I.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano()))
 		test.That(t, err, test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
@@ -92,7 +93,7 @@ func TestEncoder(t *testing.T) {
 		m := &FakeDir{-1} // backward
 		enc2.AttachDirectionalAwareness(m)
 
-		err = enc2.I.Tick(context.Background(), true, uint64(time.Now().UnixNano()))
+		err = fake.Tick(context.Background(), enc2.I.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano()))
 		test.That(t, err, test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
@@ -111,7 +112,7 @@ func TestEncoder(t *testing.T) {
 		enc2 := enc.(*Encoder)
 		defer enc2.Close(context.Background())
 
-		err = enc2.I.Tick(context.Background(), true, uint64(time.Now().UnixNano()))
+		err = fake.Tick(context.Background(), enc2.I.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano()))
 		test.That(t, err, test.ShouldBeNil)
 
 		// Give the tick time to propagate to encoder
@@ -148,7 +149,7 @@ func TestEncoder(t *testing.T) {
 		enc2.AttachDirectionalAwareness(m)
 
 		// move forward
-		err = enc2.I.Tick(context.Background(), true, uint64(time.Now().UnixNano()))
+		err = fake.Tick(context.Background(), enc2.I.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano()))
 		test.That(t, err, test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
@@ -166,7 +167,7 @@ func TestEncoder(t *testing.T) {
 		test.That(t, ticks, test.ShouldEqual, 0)
 
 		// now tick up again
-		err = enc2.I.Tick(context.Background(), true, uint64(time.Now().UnixNano()))
+		err = fake.Tick(context.Background(), enc2.I.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano()))
 		test.That(t, err, test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
@@ -185,7 +186,7 @@ func TestEncoder(t *testing.T) {
 		m := &FakeDir{1} // forward
 		enc2.AttachDirectionalAwareness(m)
 
-		err = enc2.I.Tick(context.Background(), true, uint64(time.Now().UnixNano()))
+		err = fake.Tick(context.Background(), enc2.I.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano()))
 		test.That(t, err, test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
@@ -205,7 +206,7 @@ func TestEncoder(t *testing.T) {
 		m := &FakeDir{-1} // backward
 		enc2.AttachDirectionalAwareness(m)
 
-		err = enc2.I.Tick(context.Background(), true, uint64(time.Now().UnixNano()))
+		err = fake.Tick(context.Background(), enc2.I.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano()))
 		test.That(t, err, test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {

--- a/components/input/gpio/gpio_test.go
+++ b/components/input/gpio/gpio_test.go
@@ -11,7 +11,6 @@ import (
 	"go.viam.com/utils/testutils"
 
 	"go.viam.com/rdk/components/board"
-	"go.viam.com/rdk/components/board/fake"
 	fakeboard "go.viam.com/rdk/components/board/fake"
 	"go.viam.com/rdk/components/input"
 	"go.viam.com/rdk/logging"
@@ -27,7 +26,7 @@ type setupResult struct {
 	dev                                            input.Controller
 	axis1Time, axis2Time                           time.Time
 	axisMu                                         sync.RWMutex
-	interrupt1, interrupt2                         *fake.DigitalInterruptWrapper
+	interrupt1, interrupt2                         *fakeboard.DigitalInterruptWrapper
 }
 
 func setup(t *testing.T) *setupResult {
@@ -266,7 +265,7 @@ func TestGPIOInput(t *testing.T) {
 		s := setup(t)
 		defer teardown(t, s)
 
-		err := fake.Tick(s.ctx, s.interrupt1, true, uint64(time.Now().UnixNano()))
+		err := fakeboard.Tick(s.ctx, s.interrupt1, true, uint64(time.Now().UnixNano()))
 		test.That(t, err, test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
@@ -278,7 +277,7 @@ func TestGPIOInput(t *testing.T) {
 			test.That(tb, atomic.LoadInt64(&s.btn1Callbacks), test.ShouldEqual, 1)
 		})
 
-		err = fake.Tick(s.ctx, s.interrupt1, false, uint64(time.Now().UnixNano()))
+		err = fakeboard.Tick(s.ctx, s.interrupt1, false, uint64(time.Now().UnixNano()))
 		test.That(t, err, test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
@@ -299,9 +298,9 @@ func TestGPIOInput(t *testing.T) {
 
 		// this loop must complete within the debounce time
 		for i := 0; i < 20; i++ {
-			err := fake.Tick(s.ctx, s.interrupt1, false, uint64(time.Now().UnixNano()))
+			err := fakeboard.Tick(s.ctx, s.interrupt1, false, uint64(time.Now().UnixNano()))
 			test.That(t, err, test.ShouldBeNil)
-			err = fake.Tick(s.ctx, s.interrupt1, true, uint64(time.Now().UnixNano()))
+			err = fakeboard.Tick(s.ctx, s.interrupt1, true, uint64(time.Now().UnixNano()))
 			test.That(t, err, test.ShouldBeNil)
 		}
 
@@ -323,7 +322,7 @@ func TestGPIOInput(t *testing.T) {
 		s := setup(t)
 		defer teardown(t, s)
 
-		err := fake.Tick(s.ctx, s.interrupt2, true, uint64(time.Now().UnixNano()))
+		err := fakeboard.Tick(s.ctx, s.interrupt2, true, uint64(time.Now().UnixNano()))
 		test.That(t, err, test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
@@ -335,7 +334,7 @@ func TestGPIOInput(t *testing.T) {
 			test.That(tb, atomic.LoadInt64(&s.btn2Callbacks), test.ShouldEqual, 1)
 		})
 
-		err = fake.Tick(s.ctx, s.interrupt2, false, uint64(time.Now().UnixNano()))
+		err = fakeboard.Tick(s.ctx, s.interrupt2, false, uint64(time.Now().UnixNano()))
 		test.That(t, err, test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
@@ -355,9 +354,9 @@ func TestGPIOInput(t *testing.T) {
 		iterations := 50
 
 		for i := 0; i < iterations; i++ {
-			err := fake.Tick(s.ctx, s.interrupt2, true, uint64(time.Now().UnixNano()))
+			err := fakeboard.Tick(s.ctx, s.interrupt2, true, uint64(time.Now().UnixNano()))
 			test.That(t, err, test.ShouldBeNil)
-			err = fake.Tick(s.ctx, s.interrupt2, false, uint64(time.Now().UnixNano()))
+			err = fakeboard.Tick(s.ctx, s.interrupt2, false, uint64(time.Now().UnixNano()))
 			test.That(t, err, test.ShouldBeNil)
 		}
 

--- a/components/movementsensor/adxl345/adxl345_test.go
+++ b/components/movementsensor/adxl345/adxl345_test.go
@@ -55,7 +55,7 @@ func setupDependencies(mockData []byte) (resource.Config, resource.Dependencies,
 }
 
 func sendInterrupt(ctx context.Context, adxl movementsensor.MovementSensor, t *testing.T, interrupt board.DigitalInterrupt, key string) {
-	interrupt.Tick(ctx, true, nowNanosTest())
+	interrupt.(*inject.DigitalInterrupt).Tick(ctx, true, nowNanosTest())
 	testutils.WaitForAssertion(t, func(tb testing.TB) {
 		readings, err := adxl.Readings(ctx, map[string]interface{}{})
 		test.That(tb, err, test.ShouldBeNil)

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -26,6 +26,7 @@ import (
 	"go.viam.com/rdk/components/audioinput"
 	"go.viam.com/rdk/components/base"
 	"go.viam.com/rdk/components/board"
+	fakeboard "go.viam.com/rdk/components/board/fake"
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/components/encoder"
 	"go.viam.com/rdk/components/generic"
@@ -1425,9 +1426,9 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, c, test.ShouldEqual, 0)
 
-		test.That(t, eA.Tick(context.Background(), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-		test.That(t, eB.Tick(context.Background(), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-		test.That(t, eA.Tick(context.Background(), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
+		test.That(t, fakeboard.Tick(context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
+		test.That(t, fakeboard.Tick(context.Background(), eB.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
+		test.That(t, fakeboard.Tick(context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			c, err = m.Position(context.Background(), nil)
@@ -1556,9 +1557,9 @@ func TestRobotReconfigure(t *testing.T) {
 		t.Log("the underlying pins changed but not the encoder names, so we keep the value")
 		test.That(t, c, test.ShouldEqual, 1)
 
-		test.That(t, eB.Tick(context.Background(), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-		time.Sleep(1 * time.Second)
-		test.That(t, eA.Tick(context.Background(), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
+		test.That(t, fakeboard.Tick(context.Background(), eB.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
+		time.Sleep(2 * time.Second)
+		test.That(t, fakeboard.Tick(context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			c, err = m.Position(context.Background(), nil)
@@ -1673,9 +1674,9 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, c, test.ShouldEqual, 0)
 
-		test.That(t, eA.Tick(context.Background(), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-		test.That(t, eB.Tick(context.Background(), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-		test.That(t, eA.Tick(context.Background(), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
+		test.That(t, fakeboard.Tick(context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
+		test.That(t, fakeboard.Tick(context.Background(), eB.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
+		test.That(t, fakeboard.Tick(context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			c, err = m.Position(context.Background(), nil)
@@ -1780,9 +1781,9 @@ func TestRobotReconfigure(t *testing.T) {
 		b, err = board.FromRobot(robot, "board1")
 		test.That(t, err, test.ShouldBeNil)
 
-		eA, ok = b.DigitalInterruptByName("encoder")
+		_, ok = b.DigitalInterruptByName("encoder")
 		test.That(t, ok, test.ShouldBeTrue)
-		eB, ok = b.DigitalInterruptByName("encoder-b")
+		_, ok = b.DigitalInterruptByName("encoder-b")
 		test.That(t, ok, test.ShouldBeTrue)
 
 		m, err = motor.FromRobot(robot, "m1")
@@ -1791,9 +1792,9 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, c, test.ShouldEqual, 1)
 
-		test.That(t, eA.Tick(context.Background(), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-		test.That(t, eB.Tick(context.Background(), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-		test.That(t, eA.Tick(context.Background(), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
+		test.That(t, fakeboard.Tick(context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
+		test.That(t, fakeboard.Tick(context.Background(), eB.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
+		test.That(t, fakeboard.Tick(context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			c, err = m.Position(context.Background(), nil)
@@ -1892,9 +1893,9 @@ func TestRobotReconfigure(t *testing.T) {
 		b, err = board.FromRobot(robot, "board1")
 		test.That(t, err, test.ShouldBeNil)
 
-		eA, ok = b.DigitalInterruptByName("encoder")
+		_, ok = b.DigitalInterruptByName("encoder")
 		test.That(t, ok, test.ShouldBeTrue)
-		eB, ok = b.DigitalInterruptByName("encoder-b")
+		_, ok = b.DigitalInterruptByName("encoder-b")
 		test.That(t, ok, test.ShouldBeTrue)
 
 		m, err = motor.FromRobot(robot, "m1")
@@ -1903,9 +1904,9 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, c, test.ShouldEqual, 2)
 
-		test.That(t, eA.Tick(context.Background(), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-		test.That(t, eB.Tick(context.Background(), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-		test.That(t, eA.Tick(context.Background(), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
+		test.That(t, fakeboard.Tick(context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
+		test.That(t, fakeboard.Tick(context.Background(), eB.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
+		test.That(t, fakeboard.Tick(context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			c, err = m.Position(context.Background(), nil)

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -26,7 +26,6 @@ import (
 	"go.viam.com/rdk/components/audioinput"
 	"go.viam.com/rdk/components/base"
 	"go.viam.com/rdk/components/board"
-	fakeboard "go.viam.com/rdk/components/board/fake"
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/components/encoder"
 	"go.viam.com/rdk/components/generic"
@@ -1412,32 +1411,14 @@ func TestRobotReconfigure(t *testing.T) {
 		_, err = arm.FromRobot(robot, "arm2")
 		test.That(t, err, test.ShouldNotBeNil)
 
-		b, err := board.FromRobot(robot, "board1")
+		_, err = board.FromRobot(robot, "board1")
 		test.That(t, err, test.ShouldBeNil)
-
-		eA, ok := b.DigitalInterruptByName("encoder")
-		test.That(t, ok, test.ShouldBeTrue)
-		eB, ok := b.DigitalInterruptByName("encoder-b")
-		test.That(t, ok, test.ShouldBeTrue)
 
 		m, err := motor.FromRobot(robot, "m1")
 		test.That(t, err, test.ShouldBeNil)
 		c, err := m.Position(context.Background(), nil)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, c, test.ShouldEqual, 0)
-
-		test.That(t, fakeboard.Tick(
-			context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-		test.That(t, fakeboard.Tick(
-			context.Background(), eB.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-		test.That(t, fakeboard.Tick(
-			context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-
-		testutils.WaitForAssertion(t, func(tb testing.TB) {
-			c, err = m.Position(context.Background(), nil)
-			test.That(tb, err, test.ShouldBeNil)
-			test.That(tb, c, test.ShouldEqual, 1)
-		})
 
 		_, err = motor.FromRobot(robot, "m2")
 		test.That(t, err, test.ShouldNotBeNil)
@@ -1477,7 +1458,7 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, mock5.(*mockFake).reconfCount, test.ShouldEqual, 0)
 
-		_, ok = robot.ProcessManager().ProcessByID("1")
+		_, ok := robot.ProcessManager().ProcessByID("1")
 		test.That(t, ok, test.ShouldBeTrue)
 		_, ok = robot.ProcessManager().ProcessByID("2")
 		test.That(t, ok, test.ShouldBeTrue)
@@ -1545,31 +1526,15 @@ func TestRobotReconfigure(t *testing.T) {
 		_, err = arm.FromRobot(robot, "arm2")
 		test.That(t, err, test.ShouldNotBeNil)
 
-		b, err = board.FromRobot(robot, "board1")
+		_, err = board.FromRobot(robot, "board1")
 		test.That(t, err, test.ShouldBeNil)
-
-		eA, ok = b.DigitalInterruptByName("encoder")
-		test.That(t, ok, test.ShouldBeTrue)
-		eB, ok = b.DigitalInterruptByName("encoder-b")
-		test.That(t, ok, test.ShouldBeTrue)
 
 		m, err = motor.FromRobot(robot, "m1")
 		test.That(t, err, test.ShouldBeNil)
 		c, err = m.Position(context.Background(), nil)
 		test.That(t, err, test.ShouldBeNil)
 		t.Log("the underlying pins changed but not the encoder names, so we keep the value")
-		test.That(t, c, test.ShouldEqual, 1)
-
-		test.That(t, fakeboard.Tick(
-			context.Background(), eB.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-		test.That(t, fakeboard.Tick(
-			context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-
-		testutils.WaitForAssertion(t, func(tb testing.TB) {
-			c, err = m.Position(context.Background(), nil)
-			test.That(tb, err, test.ShouldBeNil)
-			test.That(tb, c, test.ShouldEqual, 2)
-		})
+		test.That(t, c, test.ShouldEqual, 0)
 
 		_, err = motor.FromRobot(robot, "m2")
 		test.That(t, err, test.ShouldNotBeNil)
@@ -1664,32 +1629,14 @@ func TestRobotReconfigure(t *testing.T) {
 			)...))
 		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
 
-		b, err := board.FromRobot(robot, "board1")
+		_, err := board.FromRobot(robot, "board1")
 		test.That(t, err, test.ShouldBeNil)
-
-		eA, ok := b.DigitalInterruptByName("encoder")
-		test.That(t, ok, test.ShouldBeTrue)
-		eB, ok := b.DigitalInterruptByName("encoder-b")
-		test.That(t, ok, test.ShouldBeTrue)
 
 		m, err := motor.FromRobot(robot, "m1")
 		test.That(t, err, test.ShouldBeNil)
 		c, err := m.Position(context.Background(), nil)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, c, test.ShouldEqual, 0)
-
-		test.That(t, fakeboard.Tick(
-			context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-		test.That(t, fakeboard.Tick(
-			context.Background(), eB.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-		test.That(t, fakeboard.Tick(
-			context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-
-		testutils.WaitForAssertion(t, func(tb testing.TB) {
-			c, err = m.Position(context.Background(), nil)
-			test.That(tb, err, test.ShouldBeNil)
-			test.That(tb, c, test.ShouldEqual, 1)
-		})
 
 		_, err = motor.FromRobot(robot, "m2")
 		test.That(t, err, test.ShouldNotBeNil)
@@ -1733,7 +1680,7 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, mock6.(*mockFake).reconfCount, test.ShouldEqual, 0)
 
-		_, ok = robot.ProcessManager().ProcessByID("1")
+		_, ok := robot.ProcessManager().ProcessByID("1")
 		test.That(t, ok, test.ShouldBeTrue)
 		_, ok = robot.ProcessManager().ProcessByID("2")
 		test.That(t, ok, test.ShouldBeTrue)
@@ -1785,32 +1732,14 @@ func TestRobotReconfigure(t *testing.T) {
 			)...))
 		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
 
-		b, err = board.FromRobot(robot, "board1")
+		_, err = board.FromRobot(robot, "board1")
 		test.That(t, err, test.ShouldBeNil)
-
-		eA, ok = b.DigitalInterruptByName("encoder")
-		test.That(t, ok, test.ShouldBeTrue)
-		eB, ok = b.DigitalInterruptByName("encoder-b")
-		test.That(t, ok, test.ShouldBeTrue)
 
 		m, err = motor.FromRobot(robot, "m1")
 		test.That(t, err, test.ShouldBeNil)
 		c, err = m.Position(context.Background(), nil)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, c, test.ShouldEqual, 1)
-
-		test.That(t, fakeboard.Tick(
-			context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-		test.That(t, fakeboard.Tick(
-			context.Background(), eB.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-		test.That(t, fakeboard.Tick(
-			context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-
-		testutils.WaitForAssertion(t, func(tb testing.TB) {
-			c, err = m.Position(context.Background(), nil)
-			test.That(tb, err, test.ShouldBeNil)
-			test.That(tb, c, test.ShouldEqual, 2)
-		})
+		test.That(t, c, test.ShouldEqual, 0)
 
 		_, err = board.FromRobot(robot, "board2")
 		test.That(t, err, test.ShouldBeNil)
@@ -1900,32 +1829,14 @@ func TestRobotReconfigure(t *testing.T) {
 			)...))
 		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
 
-		b, err = board.FromRobot(robot, "board1")
+		_, err = board.FromRobot(robot, "board1")
 		test.That(t, err, test.ShouldBeNil)
-
-		eA, ok = b.DigitalInterruptByName("encoder")
-		test.That(t, ok, test.ShouldBeTrue)
-		eB, ok = b.DigitalInterruptByName("encoder-b")
-		test.That(t, ok, test.ShouldBeTrue)
 
 		m, err = motor.FromRobot(robot, "m1")
 		test.That(t, err, test.ShouldBeNil)
 		c, err = m.Position(context.Background(), nil)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, c, test.ShouldEqual, 2)
-
-		test.That(t, fakeboard.Tick(
-			context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-		test.That(t, fakeboard.Tick(
-			context.Background(), eB.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-		test.That(t, fakeboard.Tick(
-			context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-
-		testutils.WaitForAssertion(t, func(tb testing.TB) {
-			c, err = m.Position(context.Background(), nil)
-			test.That(tb, err, test.ShouldBeNil)
-			test.That(tb, c, test.ShouldEqual, 3)
-		})
+		test.That(t, c, test.ShouldEqual, 0)
 
 		_, err = board.FromRobot(robot, "board2")
 		test.That(t, err, test.ShouldBeNil)

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -1788,9 +1788,9 @@ func TestRobotReconfigure(t *testing.T) {
 		b, err = board.FromRobot(robot, "board1")
 		test.That(t, err, test.ShouldBeNil)
 
-		_, ok = b.DigitalInterruptByName("encoder")
+		eA, ok = b.DigitalInterruptByName("encoder")
 		test.That(t, ok, test.ShouldBeTrue)
-		_, ok = b.DigitalInterruptByName("encoder-b")
+		eB, ok = b.DigitalInterruptByName("encoder-b")
 		test.That(t, ok, test.ShouldBeTrue)
 
 		m, err = motor.FromRobot(robot, "m1")
@@ -1903,9 +1903,9 @@ func TestRobotReconfigure(t *testing.T) {
 		b, err = board.FromRobot(robot, "board1")
 		test.That(t, err, test.ShouldBeNil)
 
-		_, ok = b.DigitalInterruptByName("encoder")
+		eA, ok = b.DigitalInterruptByName("encoder")
 		test.That(t, ok, test.ShouldBeTrue)
-		_, ok = b.DigitalInterruptByName("encoder-b")
+		eB, ok = b.DigitalInterruptByName("encoder-b")
 		test.That(t, ok, test.ShouldBeTrue)
 
 		m, err = motor.FromRobot(robot, "m1")

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -1426,9 +1426,12 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, c, test.ShouldEqual, 0)
 
-		test.That(t, fakeboard.Tick(context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-		test.That(t, fakeboard.Tick(context.Background(), eB.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-		test.That(t, fakeboard.Tick(context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
+		test.That(t, fakeboard.Tick(
+			context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
+		test.That(t, fakeboard.Tick(
+			context.Background(), eB.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
+		test.That(t, fakeboard.Tick(
+			context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			c, err = m.Position(context.Background(), nil)
@@ -1557,9 +1560,11 @@ func TestRobotReconfigure(t *testing.T) {
 		t.Log("the underlying pins changed but not the encoder names, so we keep the value")
 		test.That(t, c, test.ShouldEqual, 1)
 
-		test.That(t, fakeboard.Tick(context.Background(), eB.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
+		test.That(t, fakeboard.Tick(
+			context.Background(), eB.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
 		time.Sleep(2 * time.Second)
-		test.That(t, fakeboard.Tick(context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
+		test.That(t, fakeboard.Tick(
+			context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			c, err = m.Position(context.Background(), nil)
@@ -1674,9 +1679,12 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, c, test.ShouldEqual, 0)
 
-		test.That(t, fakeboard.Tick(context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-		test.That(t, fakeboard.Tick(context.Background(), eB.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-		test.That(t, fakeboard.Tick(context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
+		test.That(t, fakeboard.Tick(
+			context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
+		test.That(t, fakeboard.Tick(
+			context.Background(), eB.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
+		test.That(t, fakeboard.Tick(
+			context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			c, err = m.Position(context.Background(), nil)
@@ -1792,9 +1800,12 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, c, test.ShouldEqual, 1)
 
-		test.That(t, fakeboard.Tick(context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-		test.That(t, fakeboard.Tick(context.Background(), eB.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-		test.That(t, fakeboard.Tick(context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
+		test.That(t, fakeboard.Tick(
+			context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
+		test.That(t, fakeboard.Tick(
+			context.Background(), eB.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
+		test.That(t, fakeboard.Tick(
+			context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			c, err = m.Position(context.Background(), nil)
@@ -1904,9 +1915,12 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, c, test.ShouldEqual, 2)
 
-		test.That(t, fakeboard.Tick(context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-		test.That(t, fakeboard.Tick(context.Background(), eB.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-		test.That(t, fakeboard.Tick(context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
+		test.That(t, fakeboard.Tick(
+			context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
+		test.That(t, fakeboard.Tick(
+			context.Background(), eB.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
+		test.That(t, fakeboard.Tick(
+			context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), true, uint64(time.Now().UnixNano())), test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			c, err = m.Position(context.Background(), nil)

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -1562,7 +1562,6 @@ func TestRobotReconfigure(t *testing.T) {
 
 		test.That(t, fakeboard.Tick(
 			context.Background(), eB.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
-		time.Sleep(2 * time.Second)
 		test.That(t, fakeboard.Tick(
 			context.Background(), eA.(*fakeboard.DigitalInterruptWrapper), false, uint64(time.Now().UnixNano())), test.ShouldBeNil)
 

--- a/testutils/inject/digital_interrupt.go
+++ b/testutils/inject/digital_interrupt.go
@@ -36,12 +36,10 @@ func (d *DigitalInterrupt) ValueCap() []interface{} {
 	return d.valueCap
 }
 
-// Tick calls the injected Tick or the real version.
+// Tick calls the injected Tick.
 func (d *DigitalInterrupt) Tick(ctx context.Context, high bool, nanoseconds uint64) error {
 	d.tickCap = []interface{}{ctx, high, nanoseconds}
-	if d.TickFunc == nil {
-		return d.DigitalInterrupt.Tick(ctx, high, nanoseconds)
-	}
+
 	return d.TickFunc(ctx, high, nanoseconds)
 }
 


### PR DESCRIPTION
Removing tick for the interface and making it a helper function.