### PR TITLE
RSDK-6947 - Test Datarace: go.viam.com/rdk/components/input.TestClient

### DIFF
--- a/components/input/client.go
+++ b/components/input/client.go
@@ -31,8 +31,12 @@ type client struct {
 	streamHUP     bool
 	streamRunning bool
 	streamReady   bool
-	streamMu      sync.Mutex
-	mu            sync.RWMutex
+
+	// streamMu ensures that only one stream at most is active at any given time
+	streamMu sync.Mutex
+
+	// mu guards access to other members of the struct
+	mu sync.RWMutex
 
 	closeContext            context.Context
 	activeBackgroundWorkers sync.WaitGroup

--- a/components/input/client_test.go
+++ b/components/input/client_test.go
@@ -83,13 +83,13 @@ func TestClient(t *testing.T) {
 	go rpcServer.Serve(listener1)
 	defer rpcServer.Stop()
 
-	// t.Run("Failing client", func(t *testing.T) {
-	// 	cancelCtx, cancel := context.WithCancel(context.Background())
-	// 	cancel()
-	// 	_, err := viamgrpc.Dial(cancelCtx, listener1.Addr().String(), logger)
-	// 	test.That(t, err, test.ShouldNotBeNil)
-	// 	test.That(t, err, test.ShouldBeError, context.Canceled)
-	// })
+	t.Run("Failing client", func(t *testing.T) {
+		cancelCtx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := viamgrpc.Dial(cancelCtx, listener1.Addr().String(), logger)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err, test.ShouldBeError, context.Canceled)
+	})
 
 	t.Run("input controller client 1", func(t *testing.T) {
 		conn, err := viamgrpc.Dial(context.Background(), listener1.Addr().String(), logger)
@@ -138,11 +138,11 @@ func TestClient(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		ev := <-evStream
 		test.That(t, ev.Event, test.ShouldEqual, input.ButtonRelease)
-		// test.That(t, ev.Control, test.ShouldEqual, input.ButtonStart)
-		// test.That(t, ev.Value, test.ShouldEqual, 0.0)
-		// test.That(t, ev.Time.After(startTime), test.ShouldBeTrue)
-		// test.That(t, ev.Time.Before(time.Now()), test.ShouldBeTrue)
-		// test.That(t, extraOptions, test.ShouldResemble, extra)
+		test.That(t, ev.Control, test.ShouldEqual, input.ButtonStart)
+		test.That(t, ev.Value, test.ShouldEqual, 0.0)
+		test.That(t, ev.Time.After(startTime), test.ShouldBeTrue)
+		test.That(t, ev.Time.Before(time.Now()), test.ShouldBeTrue)
+		test.That(t, extraOptions, test.ShouldResemble, extra)
 
 		err = inputController1Client.RegisterControlCallback(
 			context.Background(),
@@ -186,86 +186,86 @@ func TestClient(t *testing.T) {
 		)
 		test.That(t, err, test.ShouldBeNil)
 
-		// ev1 = <-evStream
-		// ev2 = <-evStream
+		ev1 = <-evStream
+		ev2 = <-evStream
 
-		// if ev1.Control == input.ButtonStart {
-		// 	btnEv = ev1
-		// 	posEv = ev2
-		// } else {
-		// 	btnEv = ev2
-		// 	posEv = ev1
-		// }
+		if ev1.Control == input.ButtonStart {
+			btnEv = ev1
+			posEv = ev2
+		} else {
+			btnEv = ev2
+			posEv = ev1
+		}
 
-		// test.That(t, posEv, test.ShouldResemble, input.Event{})
+		test.That(t, posEv, test.ShouldResemble, input.Event{})
 
-		// test.That(t, btnEv.Event, test.ShouldEqual, input.ButtonRelease)
-		// test.That(t, btnEv.Control, test.ShouldEqual, input.ButtonStart)
-		// test.That(t, btnEv.Value, test.ShouldEqual, 0.0)
-		// test.That(t, btnEv.Time.After(startTime), test.ShouldBeTrue)
-		// test.That(t, btnEv.Time.Before(time.Now()), test.ShouldBeTrue)
+		test.That(t, btnEv.Event, test.ShouldEqual, input.ButtonRelease)
+		test.That(t, btnEv.Control, test.ShouldEqual, input.ButtonStart)
+		test.That(t, btnEv.Value, test.ShouldEqual, 0.0)
+		test.That(t, btnEv.Time.After(startTime), test.ShouldBeTrue)
+		test.That(t, btnEv.Time.Before(time.Now()), test.ShouldBeTrue)
 
-		// injectInputController.TriggerEventFunc = func(ctx context.Context, event input.Event, extra map[string]interface{}) error {
-		// 	return errTriggerEvent
-		// }
-		// event1 := input.Event{
-		// 	Time:    time.Now().UTC(),
-		// 	Event:   input.PositionChangeAbs,
-		// 	Control: input.AbsoluteX,
-		// 	Value:   0.7,
-		// }
-		// injectable, ok := inputController1Client.(input.Triggerable)
-		// test.That(t, ok, test.ShouldBeTrue)
-		// err = injectable.TriggerEvent(context.Background(), event1, map[string]interface{}{})
-		// test.That(t, err, test.ShouldNotBeNil)
-		// test.That(t, err.Error(), test.ShouldContainSubstring, errTriggerEvent.Error())
+		injectInputController.TriggerEventFunc = func(ctx context.Context, event input.Event, extra map[string]interface{}) error {
+			return errTriggerEvent
+		}
+		event1 := input.Event{
+			Time:    time.Now().UTC(),
+			Event:   input.PositionChangeAbs,
+			Control: input.AbsoluteX,
+			Value:   0.7,
+		}
+		injectable, ok := inputController1Client.(input.Triggerable)
+		test.That(t, ok, test.ShouldBeTrue)
+		err = injectable.TriggerEvent(context.Background(), event1, map[string]interface{}{})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, errTriggerEvent.Error())
 
-		// var injectedEvent input.Event
-		// extra = map[string]interface{}{"foo": "TriggerEvent"}
-		// injectInputController.TriggerEventFunc = func(ctx context.Context, event input.Event, extra map[string]interface{}) error {
-		// 	injectedEvent = event
-		// 	extraOptions = extra
-		// 	return nil
-		// }
-		// err = injectable.TriggerEvent(context.Background(), event1, extra)
-		// test.That(t, err, test.ShouldBeNil)
-		// test.That(t, injectedEvent, test.ShouldResemble, event1)
-		// test.That(t, extraOptions, test.ShouldResemble, extra)
-		// injectInputController.TriggerEventFunc = nil
+		var injectedEvent input.Event
+		extra = map[string]interface{}{"foo": "TriggerEvent"}
+		injectInputController.TriggerEventFunc = func(ctx context.Context, event input.Event, extra map[string]interface{}) error {
+			injectedEvent = event
+			extraOptions = extra
+			return nil
+		}
+		err = injectable.TriggerEvent(context.Background(), event1, extra)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, injectedEvent, test.ShouldResemble, event1)
+		test.That(t, extraOptions, test.ShouldResemble, extra)
+		injectInputController.TriggerEventFunc = nil
 
 		test.That(t, inputController1Client.Close(context.Background()), test.ShouldBeNil)
 		test.That(t, conn.Close(), test.ShouldBeNil)
 	})
 
-	// t.Run("input controller client 2", func(t *testing.T) {
-	// 	conn, err := viamgrpc.Dial(context.Background(), listener1.Addr().String(), logger)
-	// 	test.That(t, err, test.ShouldBeNil)
-	// 	client2, err := resourceAPI.RPCClient(context.Background(), conn, "", input.Named(failInputControllerName), logger)
-	// 	test.That(t, err, test.ShouldBeNil)
+	t.Run("input controller client 2", func(t *testing.T) {
+		conn, err := viamgrpc.Dial(context.Background(), listener1.Addr().String(), logger)
+		test.That(t, err, test.ShouldBeNil)
+		client2, err := resourceAPI.RPCClient(context.Background(), conn, "", input.Named(failInputControllerName), logger)
+		test.That(t, err, test.ShouldBeNil)
 
-	// 	_, err = client2.Controls(context.Background(), map[string]interface{}{})
-	// 	test.That(t, err, test.ShouldNotBeNil)
-	// 	test.That(t, err.Error(), test.ShouldContainSubstring, errControlsFailed.Error())
+		_, err = client2.Controls(context.Background(), map[string]interface{}{})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, errControlsFailed.Error())
 
-	// 	_, err = client2.Events(context.Background(), map[string]interface{}{})
-	// 	test.That(t, err, test.ShouldNotBeNil)
-	// 	test.That(t, err.Error(), test.ShouldContainSubstring, errEventsFailed.Error())
+		_, err = client2.Events(context.Background(), map[string]interface{}{})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, errEventsFailed.Error())
 
-	// 	event1 := input.Event{
-	// 		Time:    time.Now().UTC(),
-	// 		Event:   input.PositionChangeAbs,
-	// 		Control: input.AbsoluteX,
-	// 		Value:   0.7,
-	// 	}
-	// 	injectable, ok := client2.(input.Triggerable)
-	// 	test.That(t, ok, test.ShouldBeTrue)
-	// 	err = injectable.TriggerEvent(context.Background(), event1, map[string]interface{}{})
-	// 	test.That(t, err, test.ShouldNotBeNil)
-	// 	test.That(t, err.Error(), test.ShouldContainSubstring, "not of type Triggerable")
+		event1 := input.Event{
+			Time:    time.Now().UTC(),
+			Event:   input.PositionChangeAbs,
+			Control: input.AbsoluteX,
+			Value:   0.7,
+		}
+		injectable, ok := client2.(input.Triggerable)
+		test.That(t, ok, test.ShouldBeTrue)
+		err = injectable.TriggerEvent(context.Background(), event1, map[string]interface{}{})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "not of type Triggerable")
 
-	// 	test.That(t, client2.Close(context.Background()), test.ShouldBeNil)
-	// 	test.That(t, conn.Close(), test.ShouldBeNil)
-	// })
+		test.That(t, client2.Close(context.Background()), test.ShouldBeNil)
+		test.That(t, conn.Close(), test.ShouldBeNil)
+	})
 }
 
 func TestClientRace(t *testing.T) {

--- a/components/input/client_test.go
+++ b/components/input/client_test.go
@@ -97,6 +97,11 @@ func TestClient(t *testing.T) {
 		inputController1Client, err := input.NewClientFromConn(context.Background(), conn, "", input.Named(testInputControllerName), logger)
 		test.That(t, err, test.ShouldBeNil)
 
+		defer func() {
+			test.That(t, inputController1Client.Close(context.Background()), test.ShouldBeNil)
+			test.That(t, conn.Close(), test.ShouldBeNil)
+		}()
+
 		// DoCommand
 		resp, err := inputController1Client.DoCommand(context.Background(), testutils.TestCommand)
 		test.That(t, err, test.ShouldBeNil)
@@ -232,9 +237,6 @@ func TestClient(t *testing.T) {
 		test.That(t, injectedEvent, test.ShouldResemble, event1)
 		test.That(t, extraOptions, test.ShouldResemble, extra)
 		injectInputController.TriggerEventFunc = nil
-
-		test.That(t, inputController1Client.Close(context.Background()), test.ShouldBeNil)
-		test.That(t, conn.Close(), test.ShouldBeNil)
 	})
 
 	t.Run("input controller client 2", func(t *testing.T) {
@@ -242,6 +244,11 @@ func TestClient(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		client2, err := resourceAPI.RPCClient(context.Background(), conn, "", input.Named(failInputControllerName), logger)
 		test.That(t, err, test.ShouldBeNil)
+
+		defer func() {
+			test.That(t, client2.Close(context.Background()), test.ShouldBeNil)
+			test.That(t, conn.Close(), test.ShouldBeNil)
+		}()
 
 		_, err = client2.Controls(context.Background(), map[string]interface{}{})
 		test.That(t, err, test.ShouldNotBeNil)
@@ -262,9 +269,6 @@ func TestClient(t *testing.T) {
 		err = injectable.TriggerEvent(context.Background(), event1, map[string]interface{}{})
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "not of type Triggerable")
-
-		test.That(t, client2.Close(context.Background()), test.ShouldBeNil)
-		test.That(t, conn.Close(), test.ShouldBeNil)
 	})
 }
 
@@ -304,6 +308,11 @@ func TestClientRace(t *testing.T) {
 	inputController1Client, err := input.NewClientFromConn(context.Background(), conn, "", input.Named(testInputControllerName), logger)
 	test.That(t, err, test.ShouldBeNil)
 
+	defer func() {
+		test.That(t, inputController1Client.Close(context.Background()), test.ShouldBeNil)
+		test.That(t, conn.Close(), test.ShouldBeNil)
+	}()
+
 	extra := map[string]interface{}{"foo": "RegisterControlCallback"}
 	ctrlFuncIn := func(ctx context.Context, event input.Event) {}
 	err = inputController1Client.RegisterControlCallback(
@@ -332,7 +341,4 @@ func TestClientRace(t *testing.T) {
 		extra,
 	)
 	test.That(t, err, test.ShouldBeNil)
-
-	test.That(t, inputController1Client.Close(context.Background()), test.ShouldBeNil)
-	test.That(t, conn.Close(), test.ShouldBeNil)
 }

--- a/components/input/client_test.go
+++ b/components/input/client_test.go
@@ -83,13 +83,13 @@ func TestClient(t *testing.T) {
 	go rpcServer.Serve(listener1)
 	defer rpcServer.Stop()
 
-	t.Run("Failing client", func(t *testing.T) {
-		cancelCtx, cancel := context.WithCancel(context.Background())
-		cancel()
-		_, err := viamgrpc.Dial(cancelCtx, listener1.Addr().String(), logger)
-		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err, test.ShouldBeError, context.Canceled)
-	})
+	// t.Run("Failing client", func(t *testing.T) {
+	// 	cancelCtx, cancel := context.WithCancel(context.Background())
+	// 	cancel()
+	// 	_, err := viamgrpc.Dial(cancelCtx, listener1.Addr().String(), logger)
+	// 	test.That(t, err, test.ShouldNotBeNil)
+	// 	test.That(t, err, test.ShouldBeError, context.Canceled)
+	// })
 
 	t.Run("input controller client 1", func(t *testing.T) {
 		conn, err := viamgrpc.Dial(context.Background(), listener1.Addr().String(), logger)
@@ -138,11 +138,11 @@ func TestClient(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		ev := <-evStream
 		test.That(t, ev.Event, test.ShouldEqual, input.ButtonRelease)
-		test.That(t, ev.Control, test.ShouldEqual, input.ButtonStart)
-		test.That(t, ev.Value, test.ShouldEqual, 0.0)
-		test.That(t, ev.Time.After(startTime), test.ShouldBeTrue)
-		test.That(t, ev.Time.Before(time.Now()), test.ShouldBeTrue)
-		test.That(t, extraOptions, test.ShouldResemble, extra)
+		// test.That(t, ev.Control, test.ShouldEqual, input.ButtonStart)
+		// test.That(t, ev.Value, test.ShouldEqual, 0.0)
+		// test.That(t, ev.Time.After(startTime), test.ShouldBeTrue)
+		// test.That(t, ev.Time.Before(time.Now()), test.ShouldBeTrue)
+		// test.That(t, extraOptions, test.ShouldResemble, extra)
 
 		err = inputController1Client.RegisterControlCallback(
 			context.Background(),
@@ -186,84 +186,153 @@ func TestClient(t *testing.T) {
 		)
 		test.That(t, err, test.ShouldBeNil)
 
-		ev1 = <-evStream
-		ev2 = <-evStream
+		// ev1 = <-evStream
+		// ev2 = <-evStream
 
-		if ev1.Control == input.ButtonStart {
-			btnEv = ev1
-			posEv = ev2
-		} else {
-			btnEv = ev2
-			posEv = ev1
-		}
+		// if ev1.Control == input.ButtonStart {
+		// 	btnEv = ev1
+		// 	posEv = ev2
+		// } else {
+		// 	btnEv = ev2
+		// 	posEv = ev1
+		// }
 
-		test.That(t, posEv, test.ShouldResemble, input.Event{})
+		// test.That(t, posEv, test.ShouldResemble, input.Event{})
 
-		test.That(t, btnEv.Event, test.ShouldEqual, input.ButtonRelease)
-		test.That(t, btnEv.Control, test.ShouldEqual, input.ButtonStart)
-		test.That(t, btnEv.Value, test.ShouldEqual, 0.0)
-		test.That(t, btnEv.Time.After(startTime), test.ShouldBeTrue)
-		test.That(t, btnEv.Time.Before(time.Now()), test.ShouldBeTrue)
+		// test.That(t, btnEv.Event, test.ShouldEqual, input.ButtonRelease)
+		// test.That(t, btnEv.Control, test.ShouldEqual, input.ButtonStart)
+		// test.That(t, btnEv.Value, test.ShouldEqual, 0.0)
+		// test.That(t, btnEv.Time.After(startTime), test.ShouldBeTrue)
+		// test.That(t, btnEv.Time.Before(time.Now()), test.ShouldBeTrue)
 
-		injectInputController.TriggerEventFunc = func(ctx context.Context, event input.Event, extra map[string]interface{}) error {
-			return errTriggerEvent
-		}
-		event1 := input.Event{
-			Time:    time.Now().UTC(),
-			Event:   input.PositionChangeAbs,
-			Control: input.AbsoluteX,
-			Value:   0.7,
-		}
-		injectable, ok := inputController1Client.(input.Triggerable)
-		test.That(t, ok, test.ShouldBeTrue)
-		err = injectable.TriggerEvent(context.Background(), event1, map[string]interface{}{})
-		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, errTriggerEvent.Error())
+		// injectInputController.TriggerEventFunc = func(ctx context.Context, event input.Event, extra map[string]interface{}) error {
+		// 	return errTriggerEvent
+		// }
+		// event1 := input.Event{
+		// 	Time:    time.Now().UTC(),
+		// 	Event:   input.PositionChangeAbs,
+		// 	Control: input.AbsoluteX,
+		// 	Value:   0.7,
+		// }
+		// injectable, ok := inputController1Client.(input.Triggerable)
+		// test.That(t, ok, test.ShouldBeTrue)
+		// err = injectable.TriggerEvent(context.Background(), event1, map[string]interface{}{})
+		// test.That(t, err, test.ShouldNotBeNil)
+		// test.That(t, err.Error(), test.ShouldContainSubstring, errTriggerEvent.Error())
 
-		var injectedEvent input.Event
-		extra = map[string]interface{}{"foo": "TriggerEvent"}
-		injectInputController.TriggerEventFunc = func(ctx context.Context, event input.Event, extra map[string]interface{}) error {
-			injectedEvent = event
-			extraOptions = extra
-			return nil
-		}
-		err = injectable.TriggerEvent(context.Background(), event1, extra)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, injectedEvent, test.ShouldResemble, event1)
-		test.That(t, extraOptions, test.ShouldResemble, extra)
-		injectInputController.TriggerEventFunc = nil
+		// var injectedEvent input.Event
+		// extra = map[string]interface{}{"foo": "TriggerEvent"}
+		// injectInputController.TriggerEventFunc = func(ctx context.Context, event input.Event, extra map[string]interface{}) error {
+		// 	injectedEvent = event
+		// 	extraOptions = extra
+		// 	return nil
+		// }
+		// err = injectable.TriggerEvent(context.Background(), event1, extra)
+		// test.That(t, err, test.ShouldBeNil)
+		// test.That(t, injectedEvent, test.ShouldResemble, event1)
+		// test.That(t, extraOptions, test.ShouldResemble, extra)
+		// injectInputController.TriggerEventFunc = nil
 
 		test.That(t, inputController1Client.Close(context.Background()), test.ShouldBeNil)
 		test.That(t, conn.Close(), test.ShouldBeNil)
 	})
 
-	t.Run("input controller client 2", func(t *testing.T) {
-		conn, err := viamgrpc.Dial(context.Background(), listener1.Addr().String(), logger)
-		test.That(t, err, test.ShouldBeNil)
-		client2, err := resourceAPI.RPCClient(context.Background(), conn, "", input.Named(failInputControllerName), logger)
-		test.That(t, err, test.ShouldBeNil)
+	// t.Run("input controller client 2", func(t *testing.T) {
+	// 	conn, err := viamgrpc.Dial(context.Background(), listener1.Addr().String(), logger)
+	// 	test.That(t, err, test.ShouldBeNil)
+	// 	client2, err := resourceAPI.RPCClient(context.Background(), conn, "", input.Named(failInputControllerName), logger)
+	// 	test.That(t, err, test.ShouldBeNil)
 
-		_, err = client2.Controls(context.Background(), map[string]interface{}{})
-		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, errControlsFailed.Error())
+	// 	_, err = client2.Controls(context.Background(), map[string]interface{}{})
+	// 	test.That(t, err, test.ShouldNotBeNil)
+	// 	test.That(t, err.Error(), test.ShouldContainSubstring, errControlsFailed.Error())
 
-		_, err = client2.Events(context.Background(), map[string]interface{}{})
-		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, errEventsFailed.Error())
+	// 	_, err = client2.Events(context.Background(), map[string]interface{}{})
+	// 	test.That(t, err, test.ShouldNotBeNil)
+	// 	test.That(t, err.Error(), test.ShouldContainSubstring, errEventsFailed.Error())
 
-		event1 := input.Event{
-			Time:    time.Now().UTC(),
-			Event:   input.PositionChangeAbs,
-			Control: input.AbsoluteX,
-			Value:   0.7,
-		}
-		injectable, ok := client2.(input.Triggerable)
-		test.That(t, ok, test.ShouldBeTrue)
-		err = injectable.TriggerEvent(context.Background(), event1, map[string]interface{}{})
-		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "not of type Triggerable")
+	// 	event1 := input.Event{
+	// 		Time:    time.Now().UTC(),
+	// 		Event:   input.PositionChangeAbs,
+	// 		Control: input.AbsoluteX,
+	// 		Value:   0.7,
+	// 	}
+	// 	injectable, ok := client2.(input.Triggerable)
+	// 	test.That(t, ok, test.ShouldBeTrue)
+	// 	err = injectable.TriggerEvent(context.Background(), event1, map[string]interface{}{})
+	// 	test.That(t, err, test.ShouldNotBeNil)
+	// 	test.That(t, err.Error(), test.ShouldContainSubstring, "not of type Triggerable")
 
-		test.That(t, client2.Close(context.Background()), test.ShouldBeNil)
-		test.That(t, conn.Close(), test.ShouldBeNil)
-	})
+	// 	test.That(t, client2.Close(context.Background()), test.ShouldBeNil)
+	// 	test.That(t, conn.Close(), test.ShouldBeNil)
+	// })
+}
+
+func TestClientRace(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	listener1, err := net.Listen("tcp", "localhost:0")
+	test.That(t, err, test.ShouldBeNil)
+	rpcServer, err := rpc.NewServer(logger.AsZap(), rpc.WithUnauthenticated())
+	test.That(t, err, test.ShouldBeNil)
+
+	injectInputController := &inject.TriggerableInputController{}
+	injectInputController.RegisterControlCallbackFunc = func(
+		ctx context.Context,
+		control input.Control,
+		triggers []input.EventType,
+		ctrlFunc input.ControlFunction,
+		extra map[string]interface{},
+	) error {
+		return nil
+	}
+
+	resources := map[resource.Name]input.Controller{
+		input.Named(testInputControllerName): injectInputController,
+	}
+	inputControllerSvc, err := resource.NewAPIResourceCollection(input.API, resources)
+	test.That(t, err, test.ShouldBeNil)
+	resourceAPI, ok, err := resource.LookupAPIRegistration[input.Controller](input.API)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, resourceAPI.RegisterRPCService(context.Background(), rpcServer, inputControllerSvc), test.ShouldBeNil)
+
+	go rpcServer.Serve(listener1)
+	defer rpcServer.Stop()
+
+	conn, err := viamgrpc.Dial(context.Background(), listener1.Addr().String(), logger)
+	test.That(t, err, test.ShouldBeNil)
+	inputController1Client, err := input.NewClientFromConn(context.Background(), conn, "", input.Named(testInputControllerName), logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	extra := map[string]interface{}{"foo": "RegisterControlCallback"}
+	ctrlFuncIn := func(ctx context.Context, event input.Event) {}
+	err = inputController1Client.RegisterControlCallback(
+		context.Background(),
+		input.ButtonStart,
+		[]input.EventType{input.ButtonRelease},
+		ctrlFuncIn,
+		extra,
+	)
+	test.That(t, err, test.ShouldBeNil)
+
+	err = inputController1Client.RegisterControlCallback(
+		context.Background(),
+		input.AbsoluteX,
+		[]input.EventType{input.PositionChangeAbs},
+		ctrlFuncIn,
+		extra,
+	)
+	test.That(t, err, test.ShouldBeNil)
+
+	err = inputController1Client.RegisterControlCallback(
+		context.Background(),
+		input.AbsoluteX,
+		[]input.EventType{input.PositionChangeAbs},
+		ctrlFuncIn,
+		extra,
+	)
+	test.That(t, err, test.ShouldBeNil)
+
+	test.That(t, inputController1Client.Close(context.Background()), test.ShouldBeNil)
+	test.That(t, conn.Close(), test.ShouldBeNil)
 }


### PR DESCRIPTION
added a bunch more locking, but I think the new lock points make sense

added a new test that definitely races if the changes were not in