### PR TITLE
RSDK-7210 Fix kinematic base ErrorState

### DIFF
--- a/components/base/kinematicbase/ptgKinematics.go
+++ b/components/base/kinematicbase/ptgKinematics.go
@@ -183,8 +183,17 @@ func (ptgk *ptgBaseKinematics) ErrorState(ctx context.Context) (spatialmath.Pose
 	if err != nil {
 		return nil, err
 	}
+	// The inputs representing the arc we have already executed can be computed as below.
+	// The return of CurrentInputs() represents the amount left on the arc, as an external caller will be more interested in where a base
+	// is going than where it has been.
+	executedInputs := []referenceframe.Input{
+		currentInputs[ptgIndex],
+		currentInputs[trajectoryAlphaWithinPTG],
+		currentExecutingSteps[currentIdx].arcSegment.StartConfiguration[startDistanceAlongTrajectoryIndex],
+		currentInputs[startDistanceAlongTrajectoryIndex],
+	}
 
-	currPoseInArc, err := ptgk.frame.Transform(currentInputs)
+	currPoseInArc, err := ptgk.frame.Transform(executedInputs)
 	if err != nil {
 		return nil, err
 	}

--- a/components/base/kinematicbase/ptgKinematics_test.go
+++ b/components/base/kinematicbase/ptgKinematics_test.go
@@ -246,7 +246,13 @@ func TestPTGKinematicsWithGeom(t *testing.T) {
 			test.That(t, err, test.ShouldBeNil)
 
 			arcStartPosition := arcSteps[arcIdx].arcSegment.StartPosition
-			onArcPosition, err := kb.Kinematics().Transform(ptgBase.currentInputs)
+			executedInputs := []referenceframe.Input{
+				ptgBase.currentInputs[ptgIndex],
+				ptgBase.currentInputs[trajectoryAlphaWithinPTG],
+				arcSteps[arcIdx].arcSegment.StartConfiguration[startDistanceAlongTrajectoryIndex],
+				ptgBase.currentInputs[startDistanceAlongTrajectoryIndex],
+			}
+			onArcPosition, err := kb.Kinematics().Transform(executedInputs)
 			test.That(t, err, test.ShouldBeNil)
 			arcPose := spatialmath.Compose(arcStartPosition, onArcPosition)
 


### PR DESCRIPTION
Prior PR missed updating the way ErrorState is calculated.

Tests did not catch because the test was also calculating the old way.