### PR TITLE
add back internal ports of cmp structures for compatibility

### DIFF
--- a/utils/value.go
+++ b/utils/value.go
@@ -65,10 +65,12 @@ func FindInSlice[T any](items []T, predicate func(T) bool) *T {
 	return nil
 }
 
+// Ordered wraps cmp.Ordered. Please use cmp.Ordered directly if possible. This is here to avoid breaking downstream code.
 type Ordered interface {
 	cmp.Ordered
 }
 
+// Compare wraps cmp.Compare. Please use cmp.Compare directly if possible. This is here to avoid breaking downstream code.
 func Compare[T Ordered](a, b T) int {
 	return cmp.Compare(a, b)
 }

--- a/utils/value.go
+++ b/utils/value.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"cmp"
 	"flag"
 	"math/rand"
 )
@@ -62,4 +63,12 @@ func FindInSlice[T any](items []T, predicate func(T) bool) *T {
 		}
 	}
 	return nil
+}
+
+type Ordered interface {
+	cmp.Ordered
+}
+
+func Compare[T Ordered](a, b T) int {
+	return cmp.Compare(a, b)
 }


### PR DESCRIPTION
## What changed
- add Ordered interface and Compare function in utils
## Why
We had these for a while and removed them when we could get them from go 1.21. This broke downstream projects.
> [!NOTE]
> Close this if not needed -- it's a temporary fix