### PR TITLE
add timeout for e2e job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -202,7 +202,7 @@ jobs:
     name: Test End-to-End and Web
     runs-on: [buildjet-4vcpu-ubuntu-2204]
     container: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
-    timeout-minutes: 30
+    timeout-minutes: 15
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -202,6 +202,7 @@ jobs:
     name: Test End-to-End and Web
     runs-on: [buildjet-4vcpu-ubuntu-2204]
     container: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
## What changed
15-minute timeout for e2e job
## Why
Good runs for this are quick, but bad runs take hours

Quick runs:
- https://github.com/viamrobotics/rdk/actions/runs/8807475062/job/24174617621 3m
- https://github.com/viamrobotics/rdk/actions/runs/8805676593/job/24168779288 7:30
- https://github.com/viamrobotics/rdk/actions/runs/8759676217/job/24043586383 9:30

Slow runs (canceled after 1+ hours):
- https://github.com/viamrobotics/rdk/actions/runs/8817911494/job/24205474457 56m
- https://github.com/viamrobotics/rdk/actions/runs/8756235104/job/24032213572 5h

Even the good runs are fairly variable -- we should look into this. For now adding a 15 minute timeout so the endless ones get canceled and unblock the next run on main.