### PR TITLE
RSDK-7284 - Fix TestModularResourceReconfigurationCount flake

### DIFF
--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -3154,7 +3154,7 @@ func TestModularResourceReconfigurationCount(t *testing.T) {
 
 	testutils.WaitForAssertion(t, func(tb testing.TB) {
 		tb.Helper()
-		test.That(tb, logs.FilterMessageSnippet("Module successfully restarted").Len(), test.ShouldEqual, 1)
+		test.That(tb, logs.FilterMessageSnippet("Module resources successfully re-added after module restart").Len(), test.ShouldEqual, 1)
 	})
 
 	resp, err = h.DoCommand(ctx, map[string]any{"command": "get_num_reconfigurations"})


### PR DESCRIPTION
DISCLAIMER: I don't fully understand this code -- I just saw a lot of notifs in team-devops and this flaked for me. If you would rather fix this your own way, we can close this or I can change this to just skip the test. [The ticket](https://viam.atlassian.net/browse/RSDK-7284) is assigned to maxim, but he is on vacation for another week 

The test was only checking that "Module successfully restarted" occured, but not that the manager had all of the resources updated.  I think DoCommand will fail until then

See modmanager/ newOnUnexpectedExitHandler:
```go
func (mgr *Manager) newOnUnexpectedExitHandler(mod *module) func(exitCode int) bool {
	return func(exitCode int) bool {
		mod.inRecoveryLock.Lock()
		defer mod.inRecoveryLock.Unlock()
		if mod.inStartup.Load() {
			return false
		}

		mod.inStartup.Store(true)
		defer mod.inStartup.Store(false)

		// Log error immediately, as this is unexpected behavior.
		mgr.logger.Errorw(
			"Module has unexpectedly exited.", "module", mod.cfg.Name, "exit_code", exitCode,
		)

		if err := mod.sharedConn.Close(); err != nil {
			mod.logger.Warnw("Error closing connection to crashed module. Continuing restart attempt",
				"error", err)
		}

		// If attemptRestart returns any orphaned resource names, restart failed,
		// and we should remove orphaned resources. Since we handle process
		// restarting ourselves, return false here so goutils knows not to attempt
		// a process restart.
		if orphanedResourceNames := mgr.attemptRestart(mgr.restartCtx, mod); orphanedResourceNames != nil {
			if mgr.removeOrphanedResources != nil {
				mgr.removeOrphanedResources(mgr.restartCtx, orphanedResourceNames)
			}
			return false
		}
		mgr.logger.Infow("Module successfully restarted, re-adding resources", "module", mod.cfg.Name)

		// Otherwise, add old module process' resources to new module; warn if new
		// module cannot handle old resource and remove it from mod.resources.
		// Finally, handle orphaned resources.
		var orphanedResourceNames []resource.Name
		for name, res := range mod.resources {
			if _, err := mgr.AddResource(mgr.restartCtx, res.conf, res.deps); err != nil {
				mgr.logger.Warnw("Error while re-adding resource to module",
					"resource", name, "module", mod.cfg.Name, "error", err)
				mgr.rMap.Delete(name)
				delete(mod.resources, name)
				orphanedResourceNames = append(orphanedResourceNames, name)
			}
		}
		if mgr.removeOrphanedResources != nil {
			mgr.removeOrphanedResources(mgr.restartCtx, orphanedResourceNames)
		}

		mgr.logger.Infow("Module resources successfully re-added after module restart", "module", mod.cfg.Name)
		return false
	}

```