### PR TITLE
APP-3954 - Respect SignalingInsecure when reading TLS info

### DIFF
--- a/config/reader.go
+++ b/config/reader.go
@@ -149,6 +149,12 @@ func readCertificateDataFromCloudGRPC(ctx context.Context,
 		// Check cache?
 		return tlsConfig{}, err
 	}
+	if res.TlsCertificate == "" {
+		return tlsConfig{}, errors.New("no TLS certificate yet from cloud; try again later")
+	}
+	if res.TlsPrivateKey == "" {
+		return tlsConfig{}, errors.New("no TLS private key yet from cloud; try again later")
+	}
 
 	return tlsConfig{
 		certificate: res.TlsCertificate,
@@ -270,12 +276,6 @@ func readFromCloud(
 			}
 			logger.Warnw("failed to refresh certificate data; using cached for now", "error", err)
 		} else {
-			if certData.certificate == "" {
-				return nil, errors.New("no TLS certificate yet from cloud; try again later")
-			}
-			if certData.privateKey == "" {
-				return nil, errors.New("no TLS private key yet from cloud; try again later")
-			}
 			tls = certData
 			cancel()
 		}


### PR DESCRIPTION
## Why
In https://github.com/viamrobotics/rdk/pull/3620 @maximpertsov shrunk the requirement for parsing the cached config to just care about the tls cert and private key. This allows us to safely add fields to the cloud config without creating incompatibility with previous cached configs (a big & dangerous footgun)

However, this PR was only targeting a  `SignalingInsecure == false` environment (where TLS is required). When we have a local app and local rdk, we have `SignalingInsecure==true` and should not block on an empty tls object.

## Change

Add a check against the cached `SignalingInsecure` before failing validation in `tls.readCache`

## Related
```golang
func readCertificateDataFromCloudGRPC(ctx context.Context,
	signalingInsecure bool,
	cloudConfigFromDisk *Cloud,
	logger logging.Logger,
) (tlsConfig, error) {
	conn, err := CreateNewGRPCClient(ctx, cloudConfigFromDisk, logger)
	if err != nil {
		return tlsConfig{}, err
	}
	defer utils.UncheckedErrorFunc(conn.Close)

	service := apppb.NewRobotServiceClient(conn)
	res, err := service.Certificate(ctx, &apppb.CertificateRequest{Id: cloudConfigFromDisk.ID})
	if err != nil {
		// Check cache?
		return tlsConfig{}, err
	}

	if !signalingInsecure {
		if res.TlsCertificate == "" {
			return tlsConfig{}, errNoTLSCertificate
		}
		if res.TlsPrivateKey == "" {
			return tlsConfig{}, errNoTLSPrivateKey
		}
	}

	return tlsConfig{
		certificate: res.TlsCertificate,
		privateKey:  res.TlsPrivateKey,
	}, nil
}
```