### PR TITLE
[DATA-2591] Fix URL returned by CLI command to upload ML training script

### DIFF
--- a/cli/packages.go
+++ b/cli/packages.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -219,5 +220,5 @@ func getNextPackageUploadRequest(file *os.File) (*packagespb.CreatePackageReques
 }
 
 func (m *moduleID) ToDetailURL(baseURL string, packageType PackageType) string {
-	return fmt.Sprintf("https://%s/%s/%s/%s", baseURL, packageType, m.prefix, m.name)
+	return fmt.Sprintf("https://%s/%s/%s/%s", baseURL, strings.ReplaceAll(string(packageType), "_", "-"), m.prefix, m.name)
 }


### PR DESCRIPTION
ToDetailURL is [only used by ML training](https://github.com/search?q=repo%3Aviamrobotics%2Frdk%20todetailurl&type=code), so updated the code there. 

The [other package upload receives the URL from the server](https://github.com/viamrobotics/rdk/blob/1c27a46539b7598ed891c0063d2a9f2e98a2c3fc/cli/module_registry.go#L360-L403), which converts the input package type into the one used by the URL.

**Testing**
`go run cli/viam/main.go training-script upload --org-id=f87b919c-63b2-4d32-b676-0b55393938d7 --path=/Users/alexa.greenberg@viam.com/Downloads/trainingscript-0.1.tar.gz --name=alexas-example-script`
yields:
`Version successfully uploaded! you can view your changes online here: https://app.viam.dev/ml-training/f87b919c-63b2-4d32-b676-0b55393938d7/alexas-example-script`
Which can be viewed in @katiepeters's deployment for the 'Data/ML Dev' staging org: https://pr-4514-appmain-bplesliplq-uc.a.run.app/ml-training/f87b919c-63b2-4d32-b676-0b55393938d7/alexas-example-script

Previously, this returned `Version successfully uploaded! you can view your changes online here: https://app.viam.dev/ml_training/f87b919c-63b2-4d32-b676-0b55393938d7/alexas-example-script` which was a nonfunctional URL.
