### PR TITLE
shell service: add bidi file copy support

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -1150,30 +1150,31 @@ var app = &cli.App{
 						{
 							Name:  "cp",
 							Usage: "copy files to and from a machine part",
-							//nolint:lll
+
 							Description: `
 In order to use the cp command, the machine must have a valid shell type service.
 Specifying ~ or a blank destination for the machine will use the home directory of the user
-that is running the process (this may sometimes be root).
-Note: There is no progress meter while copying is progress.
+that is running the process (this may sometimes be root). Organization and location are
+required flags if the machine/part name are not unique across your account.
+Note: There is no progress meter while copying is in progress.
 
 Copy a single file to the machine with a new name:
 'viam machine part cp --organization "org" --location "location" --machine "m1" --part "m1-main" my_file machine:/home/user/'
 
 Recursively copy a directory to the machine with the same name:
-'viam machine part cp --organization "org" --location "location" --machine "m1" --part "m1-main" -r my_dir machine:/home/user/'
+'viam machine part cp --machine "m1" --part "m1-main" -r my_dir machine:/home/user/'
 
 Copy multiple files to the machine with recursion and keep original permissions and metadata:
-'viam machine part cp --organization "org" --location "location" --machine "m1" --part "m1-main" -r -p my_dir my_file machine:/home/user/some/existing/dir/'
+'viam machine part cp --machine "m1" --part "m1-main" -r -p my_dir my_file machine:/home/user/some/existing/dir/'
 
 Copy a single file from the machine to a local destination:
-'viam machine part cp --organization "org" --location "location" --machine "m1" --part "m1-main" machine:my_file ~/Downloads/'
+'viam machine part cp --machine "m1" --part "m1-main" machine:my_file ~/Downloads/'
 
 Recursively copy a directory from the machine to a local destination with the same name:
-'viam machine part cp --organization "org" --location "location" --machine "m1" --part "m1-main" -r machine:my_dir ~/Downloads/'
+'viam machine part cp --machine "m1" --part "m1-main" -r machine:my_dir ~/Downloads/'
 
 Copy multiple files from the machine to a local destination with recursion and keep original permissions and metadata:
-'viam machine part cp --organization "org" --location "location" --machine "m1" --part "m1-main" -r -p machine:my_dir machine:my_file ~/some/existing/dir/'
+'viam machine part cp --machine "m1" --part "m1-main" -r -p machine:my_dir machine:my_file ~/some/existing/dir/'
 `,
 							UsageText: createUsageText(
 								"machines part cp",

--- a/cli/app.go
+++ b/cli/app.go
@@ -1148,9 +1148,33 @@ var app = &cli.App{
 							Action: RobotsPartShellAction,
 						},
 						{
-							Name:        "cp",
-							Usage:       "copy files to and from a machine part",
-							Description: `In order to use the cp command, the machine must have a valid shell type service.`,
+							Name:  "cp",
+							Usage: "copy files to and from a machine part",
+							//nolint:lll
+							Description: `
+In order to use the cp command, the machine must have a valid shell type service.
+Specifying ~ or a blank destination for the machine will use the home directory of the user
+that is running the process (this may sometimes be root).
+Note: There is no progress meter while copying is progress.
+
+Copy a single file to the machine with a new name:
+'viam machine part cp --organization "org" --location "location" --machine "m1" --part "m1-main" my_file machine:/home/user/'
+
+Recursively copy a directory to the machine with the same name:
+'viam machine part cp --organization "org" --location "location" --machine "m1" --part "m1-main" -r my_dir machine:/home/user/'
+
+Copy multiple files to the machine with recursion and keep original permissions and metadata:
+'viam machine part cp --organization "org" --location "location" --machine "m1" --part "m1-main" -r -p my_dir my_file machine:/home/user/some/existing/dir/'
+
+Copy a single file from the machine to a local destination:
+'viam machine part cp --organization "org" --location "location" --machine "m1" --part "m1-main" machine:my_file ~/Downloads/'
+
+Recursively copy a directory from the machine to a local destination with the same name:
+'viam machine part cp --organization "org" --location "location" --machine "m1" --part "m1-main" -r machine:my_dir ~/Downloads/'
+
+Copy multiple files from the machine to a local destination with recursion and keep original permissions and metadata:
+'viam machine part cp --organization "org" --location "location" --machine "m1" --part "m1-main" -r -p machine:my_dir machine:my_file ~/some/existing/dir/'
+`,
 							UsageText: createUsageText(
 								"machines part cp",
 								[]string{organizationFlag, locationFlag, machineFlag, partFlag},
@@ -1165,12 +1189,14 @@ var app = &cli.App{
 								},
 								&AliasStringFlag{
 									cli.StringFlag{
-										Name:    machineFlag,
-										Aliases: []string{aliasRobotFlag},
+										Name:     machineFlag,
+										Aliases:  []string{aliasRobotFlag},
+										Required: true,
 									},
 								},
 								&cli.StringFlag{
-									Name: partFlag,
+									Name:     partFlag,
+									Required: true,
 								},
 								&cli.BoolFlag{
 									Name:    cpFlagRecursive,

--- a/cli/app.go
+++ b/cli/app.go
@@ -92,6 +92,9 @@ const (
 	packageFlagVersion     = "version"
 	packageFlagType        = "type"
 	packageFlagDestination = "destination"
+
+	cpFlagRecursive = "recursive"
+	cpFlagPreserve  = "preserve"
 )
 
 var commonFilterFlags = []cli.Flag{
@@ -1143,6 +1146,45 @@ var app = &cli.App{
 								},
 							},
 							Action: RobotsPartShellAction,
+						},
+						{
+							Name:        "cp",
+							Usage:       "copy files to and from a machine part",
+							Description: `In order to use the cp command, the machine must have a valid shell type service.`,
+							UsageText: createUsageText(
+								"machines part cp",
+								[]string{organizationFlag, locationFlag, machineFlag, partFlag},
+								true,
+								"[-p] [-r] source ([machine:]files) ... target ([machine:]files"),
+							Flags: []cli.Flag{
+								&cli.StringFlag{
+									Name: organizationFlag,
+								},
+								&cli.StringFlag{
+									Name: locationFlag,
+								},
+								&AliasStringFlag{
+									cli.StringFlag{
+										Name:    machineFlag,
+										Aliases: []string{aliasRobotFlag},
+									},
+								},
+								&cli.StringFlag{
+									Name: partFlag,
+								},
+								&cli.BoolFlag{
+									Name:    cpFlagRecursive,
+									Aliases: []string{"r"},
+									Usage:   "recursively copy files",
+								},
+								&cli.BoolFlag{
+									Name:    cpFlagPreserve,
+									Aliases: []string{"p"},
+									// Note(erd): maybe support access time in the future if needed
+									Usage: "preserve modification times and file mode bits from the source files",
+								},
+							},
+							Action: MachinesPartCopyFilesAction,
 						},
 					},
 				},

--- a/cli/client.go
+++ b/cli/client.go
@@ -427,9 +427,10 @@ func RobotsPartShellAction(c *cli.Context) error {
 }
 
 var (
-	errNoFiles              = errors.New("must provide files to copy")
-	errLastArgOfFromMissing = errors.New("expected last argument to be <copy to path>")
-	errLastArgOfToMissing   = errors.New("expected last argument to be machine:<copy to path>")
+	errNoFiles                         = errors.New("must provide files to copy")
+	errLastArgOfFromMissing            = errors.New("expected last argument to be <copy to path>")
+	errLastArgOfToMissing              = errors.New("expected last argument to be machine:<copy to path>")
+	errDirectoryCopyRequestNoRecursion = errors.New("file is a directory but copy recursion not used (you can use -r to enable this)")
 )
 
 type copyFromPathInvalidError struct {
@@ -532,7 +533,7 @@ func MachinesPartCopyFilesAction(c *cli.Context) error {
 		if statusErr := status.Convert(err); statusErr != nil &&
 			statusErr.Code() == codes.InvalidArgument &&
 			statusErr.Message() == shell.ErrMsgDirectoryCopyRequestNoRecursion {
-			return errors.New("file is a directory but copy recursion not used (you can use -r to enable this)")
+			return errDirectoryCopyRequestNoRecursion
 		}
 		return err
 	}

--- a/cli/client.go
+++ b/cli/client.go
@@ -443,14 +443,18 @@ func (err copyFromPathInvalidError) Error() string {
 
 // MachinesPartCopyFilesAction is the corresponding Action for 'machines part cp'.
 func MachinesPartCopyFilesAction(c *cli.Context) error {
-	args := c.Args().Slice()
-	if len(args) == 0 {
-		return errNoFiles
-	}
-
 	client, err := newViamClient(c)
 	if err != nil {
 		return err
+	}
+
+	return machinesPartCopyFilesAction(c, client)
+}
+
+func machinesPartCopyFilesAction(c *cli.Context, client *viamClient) error {
+	args := c.Args().Slice()
+	if len(args) == 0 {
+		return errNoFiles
 	}
 
 	// Create logger based on presence of debugFlag.
@@ -754,17 +758,7 @@ func isProdBaseURL(baseURL *url.URL) bool {
 	return strings.HasSuffix(baseURL.Hostname(), "viam.com")
 }
 
-type ctxKey int
-
-const ctxKeyViamClientForTesting ctxKey = iota
-
 func newViamClient(c *cli.Context) (*viamClient, error) {
-	// quick hack to avoid dealing with any of the logic below. some testing
-	// may want to use this for integration testing.
-	if val := c.Context.Value(ctxKeyViamClientForTesting); val != nil {
-		return val.(*viamClient), nil
-	}
-
 	conf, err := configFromCache()
 	if err != nil {
 		if !os.IsNotExist(err) {

--- a/cli/client.go
+++ b/cli/client.go
@@ -425,6 +425,108 @@ func RobotsPartShellAction(c *cli.Context) error {
 	)
 }
 
+var (
+	errNoFiles              = errors.New("must provide files to copy")
+	errLastArgOfFromMissing = errors.New("expected last argument to be <copy to path>")
+	errLastArgOfToMissing   = errors.New("expected last argument to be machine:<copy to path>")
+)
+
+type copyFromPathInvalidError struct {
+	path string
+}
+
+func (err copyFromPathInvalidError) Error() string {
+	return fmt.Sprintf("expected argument %q to be machine:<copy from path>", err.path)
+}
+
+// MachinesPartCopyFilesAction is the corresponding Action for 'machines part cp'.
+func MachinesPartCopyFilesAction(c *cli.Context) error {
+	args := c.Args().Slice()
+	if len(args) == 0 {
+		return errNoFiles
+	}
+
+	client, err := newViamClient(c)
+	if err != nil {
+		return err
+	}
+
+	// Create logger based on presence of debugFlag.
+	logger := logging.FromZapCompatible(zap.NewNop().Sugar())
+	if c.Bool(debugFlag) {
+		logger = logging.NewDebugLogger("cli")
+	}
+
+	// the general format is
+	// from:
+	//		cp machine:path1 machine:path2 ... local_destination
+	// to:
+	//		cp path1 path2 ... remote_destination
+	// we just need to look for machine: to determine what the user's intent is
+	determineDirection := func(args []string) (isFrom bool, destination string, paths []string, err error) {
+		const machinePrefix = "machine:"
+		isFrom = strings.HasPrefix(args[0], machinePrefix)
+
+		if strings.HasPrefix(args[len(args)-1], machinePrefix) {
+			if isFrom {
+				return false, "", nil, errLastArgOfFromMissing
+			}
+		} else if !isFrom {
+			return false, "", nil, errLastArgOfToMissing
+		}
+
+		destination = args[len(args)-1]
+		if !isFrom {
+			destination = strings.TrimPrefix(destination, machinePrefix)
+		}
+
+		// all but the last arg are what we are copying to/from
+		for _, arg := range args[:len(args)-1] {
+			if isFrom && !strings.HasPrefix(arg, machinePrefix) {
+				return false, "", nil, copyFromPathInvalidError{arg}
+			}
+			if isFrom {
+				arg = strings.TrimPrefix(arg, machinePrefix)
+			}
+			paths = append(paths, arg)
+		}
+		return
+	}
+
+	isFrom, destination, paths, err := determineDirection(args)
+	if err != nil {
+		return err
+	}
+
+	if isFrom {
+		return client.copyFilesFromMachine(
+			c.String(organizationFlag),
+			c.String(locationFlag),
+			c.String(machineFlag),
+			c.String(partFlag),
+			c.Bool(debugFlag),
+			c.Bool(cpFlagRecursive),
+			c.Bool(cpFlagPreserve),
+			paths,
+			destination,
+			logger,
+		)
+	}
+
+	return client.copyFilesToMachine(
+		c.String(organizationFlag),
+		c.String(locationFlag),
+		c.String(machineFlag),
+		c.String(partFlag),
+		c.Bool(debugFlag),
+		c.Bool(cpFlagRecursive),
+		c.Bool(cpFlagPreserve),
+		paths,
+		destination,
+		logger,
+	)
+}
+
 // checkUpdateResponse holds the values used to hold release information.
 type getLatestReleaseResponse struct {
 	Name       string `json:"name"`
@@ -639,7 +741,17 @@ func isProdBaseURL(baseURL *url.URL) bool {
 	return strings.HasSuffix(baseURL.Hostname(), "viam.com")
 }
 
+type ctxKey int
+
+const ctxKeyViamClientForTesting ctxKey = iota
+
 func newViamClient(c *cli.Context) (*viamClient, error) {
+	// quick hack to avoid dealing with any of the logic below. some testing
+	// may want to use this for integration testing.
+	if val := c.Context.Value(ctxKeyViamClientForTesting); val != nil {
+		return val.(*viamClient), nil
+	}
+
 	conf, err := configFromCache()
 	if err != nil {
 		if !os.IsNotExist(err) {
@@ -1199,14 +1311,13 @@ func (c *viamClient) runRobotPartCommand(
 	}
 }
 
-func (c *viamClient) startRobotPartShell(
-	orgStr, locStr, robotStr, partStr string,
+func (c *viamClient) connectToShellService(orgStr, locStr, robotStr, partStr string,
 	debug bool,
 	logger logging.Logger,
-) error {
+) (shell.Service, func(ctx context.Context) error, error) {
 	dialCtx, fqdn, rpcOpts, err := c.prepareDial(orgStr, locStr, robotStr, partStr, debug)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	if debug {
@@ -1214,11 +1325,14 @@ func (c *viamClient) startRobotPartShell(
 	}
 	robotClient, err := client.New(dialCtx, fqdn, logger, client.WithDialOptions(rpcOpts...))
 	if err != nil {
-		return errors.Wrap(err, "could not connect to machine part")
+		return nil, nil, errors.Wrap(err, "could not connect to machine part")
 	}
 
+	var successful bool
 	defer func() {
-		utils.UncheckedError(robotClient.Close(c.c.Context))
+		if !successful {
+			utils.UncheckedError(robotClient.Close(c.c.Context))
+		}
 	}()
 
 	// Returns the first shell service found in the robot resources
@@ -1231,18 +1345,34 @@ func (c *viamClient) startRobotPartShell(
 		}
 	}
 	if found == nil {
-		return errors.New("shell service is not enabled on this machine part")
+		return nil, nil, errors.New("shell service is not enabled on this machine part")
 	}
 
 	shellRes, err := robotClient.ResourceByName(*found)
 	if err != nil {
-		return errors.Wrap(err, "could not get shell service from machine part")
+		return nil, nil, errors.Wrap(err, "could not get shell service from machine part")
 	}
 
 	shellSvc, ok := shellRes.(shell.Service)
 	if !ok {
-		return errors.New("could not get shell service from machine part")
+		return nil, nil, errors.New("could not get shell service from machine part")
 	}
+	successful = true
+	return shellSvc, robotClient.Close, nil
+}
+
+func (c *viamClient) startRobotPartShell(
+	orgStr, locStr, robotStr, partStr string,
+	debug bool,
+	logger logging.Logger,
+) error {
+	shellSvc, closeClient, err := c.connectToShellService(orgStr, locStr, robotStr, partStr, debug, logger)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		utils.UncheckedError(closeClient(c.c.Context))
+	}()
 
 	getWinChMsg := func() map[string]interface{} {
 		cols, rows := consolesize.GetConsoleSize()
@@ -1347,6 +1477,68 @@ func (c *viamClient) startRobotPartShell(
 
 	outputLoop()
 	return nil
+}
+
+func (c *viamClient) copyFilesToMachine(
+	orgStr, locStr, robotStr, partStr string,
+	debug bool,
+	allowRecursion bool,
+	preserve bool,
+	paths []string,
+	destination string,
+	logger logging.Logger,
+) error {
+	shellSvc, closeClient, err := c.connectToShellService(orgStr, locStr, robotStr, partStr, debug, logger)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		utils.UncheckedError(closeClient(c.c.Context))
+	}()
+
+	// prepare a factory that understands the file copying service (RPC or not).
+	copyFactory := shell.NewCopyFileToMachineFactory(destination, preserve, shellSvc)
+	// make a reader copier that just does the traversal and copy work for us. Think of
+	// this as a tee reader.
+	readCopier, err := shell.NewLocalFileReadCopier(paths, allowRecursion, false, copyFactory)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := readCopier.Close(c.c.Context); err != nil {
+			utils.UncheckedError(err)
+		}
+	}()
+
+	// ReadAl the files into the copier.
+	return readCopier.ReadAll(c.c.Context)
+}
+
+func (c *viamClient) copyFilesFromMachine(
+	orgStr, locStr, robotStr, partStr string,
+	debug bool,
+	allowRecursion bool,
+	preserve bool,
+	paths []string,
+	destination string,
+	logger logging.Logger,
+) error {
+	shellSvc, closeClient, err := c.connectToShellService(orgStr, locStr, robotStr, partStr, debug, logger)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		utils.UncheckedError(closeClient(c.c.Context))
+	}()
+
+	// prepare a factory that understands how to work with our local filesystem.
+	factory, err := shell.NewLocalFileCopyFactory(destination, preserve, false)
+	if err != nil {
+		return err
+	}
+
+	// let the shell service figure out how to grab the files for and pass them to our copier.
+	return shellSvc.CopyFilesFromMachine(c.c.Context, paths, allowRecursion, preserve, factory, nil)
 }
 
 func logEntryFieldsToString(fields []*structpb.Struct) (string, error) {

--- a/cli/client.go
+++ b/cli/client.go
@@ -532,16 +532,12 @@ func MachinesPartCopyFilesAction(c *cli.Context) error {
 		if statusErr := status.Convert(err); statusErr != nil &&
 			statusErr.Code() == codes.InvalidArgument &&
 			statusErr.Message() == shell.ErrMsgDirectoryCopyRequestNoRecursion {
-			return errors.New(errMsgDirectoryCopyRequestNoRecursionForCLI)
+			return errors.New("file is a directory but copy recursion not used (you can use -r to enable this)")
 		}
 		return err
 	}
 	return nil
 }
-
-// errMsgDirectoryCopyRequestNoRecursionForCLI should be returned when a file is included in a path for a copy request
-// where recursion is not enabled.
-var errMsgDirectoryCopyRequestNoRecursionForCLI = "file is a directory but copy recursion not used (you can use -r to enable this)"
 
 // checkUpdateResponse holds the values used to hold release information.
 type getLatestReleaseResponse struct {

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -24,8 +24,6 @@ import (
 	"go.viam.com/test"
 	"go.viam.com/utils/protoutils"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	robotconfig "go.viam.com/rdk/config"
@@ -612,11 +610,7 @@ func TestShellFileCopy(t *testing.T) {
 				t, asc, nil, nil, partFlags, "token", partFqdn, args...)
 			defer teardown1()
 			err := MachinesPartCopyFilesAction(cCtx)
-			test.That(t, err, test.ShouldNotBeNil)
-			s, ok := status.FromError(err)
-			test.That(t, ok, test.ShouldBeTrue)
-			test.That(t, s.Code(), test.ShouldEqual, codes.InvalidArgument)
-			test.That(t, s.Message(), test.ShouldContainSubstring, "recursion")
+			test.That(t, errors.Is(err, errDirectoryCopyRequestNoRecursion), test.ShouldBeTrue)
 			_, err = os.ReadFile(filepath.Join(tempDir, filepath.Base(tfs.SingleFileNested)))
 			test.That(t, errors.Is(err, fs.ErrNotExist), test.ShouldBeTrue)
 
@@ -741,11 +735,7 @@ func TestShellFileCopy(t *testing.T) {
 				t, asc, nil, nil, partFlags, "token", partFqdn, args...)
 			defer teardown1()
 			err := MachinesPartCopyFilesAction(cCtx)
-			test.That(t, err, test.ShouldNotBeNil)
-			s, ok := status.FromError(err)
-			test.That(t, ok, test.ShouldBeTrue)
-			test.That(t, s.Code(), test.ShouldEqual, codes.InvalidArgument)
-			test.That(t, s.Message(), test.ShouldContainSubstring, "recursion")
+			test.That(t, errors.Is(err, errDirectoryCopyRequestNoRecursion), test.ShouldBeTrue)
 			_, err = os.ReadFile(filepath.Join(tempDir, filepath.Base(tfs.SingleFileNested)))
 			test.That(t, errors.Is(err, fs.ErrNotExist), test.ShouldBeTrue)
 

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -5,11 +5,16 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io/fs"
+	"maps"
 	"os"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/urfave/cli/v2"
 	"go.uber.org/zap/zapcore"
 	buildpb "go.viam.com/api/app/build/v1"
@@ -19,10 +24,19 @@ import (
 	"go.viam.com/test"
 	"go.viam.com/utils/protoutils"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 
+	robotconfig "go.viam.com/rdk/config"
 	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+	robotimpl "go.viam.com/rdk/robot/impl"
+	"go.viam.com/rdk/services/shell"
+	_ "go.viam.com/rdk/services/shell/register"
+	shelltestutils "go.viam.com/rdk/services/shell/testutils"
 	"go.viam.com/rdk/testutils/inject"
+	"go.viam.com/rdk/testutils/robottestutils"
 	"go.viam.com/rdk/utils"
 )
 
@@ -44,7 +58,7 @@ func (tw *testWriter) Write(b []byte) (int, error) {
 }
 
 // populateFlags populates a FlagSet from a map.
-func populateFlags(m map[string]any) *flag.FlagSet {
+func populateFlags(m map[string]any, args ...string) *flag.FlagSet {
 	flags := &flag.FlagSet{}
 	// init all the default flags from the input
 	for name, val := range m {
@@ -59,6 +73,9 @@ func populateFlags(m map[string]any) *flag.FlagSet {
 			// non-int and non-string flags not yet supported
 			continue
 		}
+	}
+	if err := flags.Parse(args); err != nil {
+		panic(err)
 	}
 	return flags
 }
@@ -79,10 +96,11 @@ func setup(
 	buildClient buildpb.BuildServiceClient,
 	defaultFlags map[string]any,
 	authMethod string,
+	cliArgs ...string,
 ) (*cli.Context, *viamClient, *testWriter, *testWriter) {
 	out := &testWriter{}
 	errOut := &testWriter{}
-	flags := populateFlags(defaultFlags)
+	flags := populateFlags(defaultFlags, cliArgs...)
 
 	if dataClient != nil {
 		// these flags are only relevant when testing a dataClient
@@ -106,14 +124,62 @@ func setup(
 			KeyCrypto: testKeyCrypto,
 		}
 	}
+
 	ac := &viamClient{
 		client:      asc,
 		conf:        conf,
 		c:           cCtx,
 		dataClient:  dataClient,
 		buildClient: buildClient,
+		selectedOrg: &apppb.Organization{},
+		selectedLoc: &apppb.Location{},
 	}
+	cCtx.Context = context.WithValue(cCtx.Context, ctxKeyViamClientForTesting, ac)
 	return cCtx, ac, out, errOut
+}
+
+//nolint:unparam
+func setupWithRunningPart(
+	t *testing.T,
+	asc apppb.AppServiceClient,
+	dataClient datapb.DataServiceClient,
+	buildClient buildpb.BuildServiceClient,
+	defaultFlags map[string]any,
+	authMethod string,
+	partFQDN string,
+	cliArgs ...string,
+) (*cli.Context, *viamClient, *testWriter, *testWriter, func()) {
+	t.Helper()
+
+	cCtx, ac, out, errOut := setup(asc, dataClient, buildClient, defaultFlags, authMethod, cliArgs...)
+
+	// this config could later become a parameter
+	r, err := robotimpl.New(cCtx.Context, &robotconfig.Config{
+		Services: []resource.Config{
+			{
+				Name:  "shell1",
+				API:   shell.API,
+				Model: resource.DefaultServiceModel,
+			},
+		},
+	}, logging.NewTestLogger(t))
+	test.That(t, err, test.ShouldBeNil)
+
+	options, _, addr := robottestutils.CreateBaseOptionsAndListener(t)
+	options.FQDN = partFQDN
+	err = r.StartWeb(cCtx.Context, options)
+	test.That(t, err, test.ShouldBeNil)
+
+	baseURL, rpcOpts, err := parseBaseURL(fmt.Sprintf("http://%s", addr), false)
+	test.That(t, err, test.ShouldBeNil)
+	// this will be the URL we use to make new clients. In a backwards way, this
+	// lets the robot be the one with external auth handling (if auth were being used)
+	ac.baseURL = baseURL
+	ac.rpcOpts = rpcOpts
+
+	return cCtx, ac, out, errOut, func() {
+		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
+	}
 }
 
 func TestListOrganizationsAction(t *testing.T) {
@@ -435,5 +501,330 @@ func TestGetRobotPartLogs(t *testing.T) {
 		err := ac.robotsPartLogsAction(cCtx)
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err, test.ShouldBeError, errors.New(`provided too high of a "count" value. Maximum is 10000`))
+	})
+}
+
+func TestShellFileCopy(t *testing.T) {
+	listOrganizationsFunc := func(ctx context.Context, in *apppb.ListOrganizationsRequest,
+		opts ...grpc.CallOption,
+	) (*apppb.ListOrganizationsResponse, error) {
+		orgs := []*apppb.Organization{{Name: "jedi", Id: uuid.NewString(), PublicNamespace: "anakin"}, {Name: "mandalorians"}}
+		return &apppb.ListOrganizationsResponse{Organizations: orgs}, nil
+	}
+	listLocationsFunc := func(ctx context.Context, in *apppb.ListLocationsRequest,
+		opts ...grpc.CallOption,
+	) (*apppb.ListLocationsResponse, error) {
+		locs := []*apppb.Location{{Name: "naboo"}}
+		return &apppb.ListLocationsResponse{Locations: locs}, nil
+	}
+	listRobotsFunc := func(ctx context.Context, in *apppb.ListRobotsRequest,
+		opts ...grpc.CallOption,
+	) (*apppb.ListRobotsResponse, error) {
+		robots := []*apppb.Robot{{Name: "r2d2"}}
+		return &apppb.ListRobotsResponse{Robots: robots}, nil
+	}
+
+	partFqdn := uuid.NewString()
+	getRobotPartsFunc := func(ctx context.Context, in *apppb.GetRobotPartsRequest,
+		opts ...grpc.CallOption,
+	) (*apppb.GetRobotPartsResponse, error) {
+		parts := []*apppb.RobotPart{{Name: "main", Fqdn: partFqdn}}
+		return &apppb.GetRobotPartsResponse{Parts: parts}, nil
+	}
+
+	asc := &inject.AppServiceClient{
+		ListOrganizationsFunc: listOrganizationsFunc,
+		ListLocationsFunc:     listLocationsFunc,
+		ListRobotsFunc:        listRobotsFunc,
+		GetRobotPartsFunc:     getRobotPartsFunc,
+	}
+
+	partFlags := map[string]any{
+		"organization": "jedi",
+		"location":     "naboo",
+		"robot":        "r2d2",
+		"part":         "main",
+	}
+
+	t.Run("no arguments or files", func(t *testing.T) {
+		cCtx, _, _, _ := setup(asc, nil, nil, partFlags, "token")
+		test.That(t, MachinesPartCopyFilesAction(cCtx), test.ShouldEqual, errNoFiles)
+	})
+
+	t.Run("one file path is insufficient", func(t *testing.T) {
+		args := []string{"machine:path"}
+		cCtx, _, _, _ := setup(asc, nil, nil, partFlags, "token", args...)
+		test.That(t, MachinesPartCopyFilesAction(cCtx), test.ShouldEqual, errLastArgOfFromMissing)
+
+		args = []string{"path"}
+		cCtx, _, _, _ = setup(asc, nil, nil, partFlags, "token", args...)
+		test.That(t, MachinesPartCopyFilesAction(cCtx), test.ShouldEqual, errLastArgOfToMissing)
+	})
+
+	t.Run("from has wrong path prefixes", func(t *testing.T) {
+		args := []string{"machine:path", "path2", "machine:path3", "destination"}
+		cCtx, _, _, _ := setup(asc, nil, nil, partFlags, "token", args...)
+		test.That(t, MachinesPartCopyFilesAction(cCtx), test.ShouldHaveSameTypeAs, copyFromPathInvalidError{})
+	})
+
+	tfs := shelltestutils.SetupTestFileSystem(t)
+
+	t.Run("from", func(t *testing.T) {
+		t.Run("single file", func(t *testing.T) {
+			tempDir := t.TempDir()
+
+			args := []string{fmt.Sprintf("machine:%s", tfs.SingleFileNested), tempDir}
+			cCtx, _, _, _, teardown := setupWithRunningPart(
+				t, asc, nil, nil, partFlags, "token", partFqdn, args...)
+			defer teardown()
+			test.That(t, MachinesPartCopyFilesAction(cCtx), test.ShouldBeNil)
+
+			rd, err := os.ReadFile(filepath.Join(tempDir, filepath.Base(tfs.SingleFileNested)))
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, rd, test.ShouldResemble, tfs.SingleFileNestedData)
+		})
+
+		t.Run("single file relative", func(t *testing.T) {
+			tempDir := t.TempDir()
+			cwd, err := os.Getwd()
+			test.That(t, err, test.ShouldBeNil)
+			t.Cleanup(func() { os.Chdir(cwd) })
+			test.That(t, os.Chdir(tempDir), test.ShouldBeNil)
+
+			args := []string{fmt.Sprintf("machine:%s", tfs.SingleFileNested), "foo"}
+			cCtx, _, _, _, teardown := setupWithRunningPart(
+				t, asc, nil, nil, partFlags, "token", partFqdn, args...)
+			defer teardown()
+			test.That(t, MachinesPartCopyFilesAction(cCtx), test.ShouldBeNil)
+
+			rd, err := os.ReadFile(filepath.Join(tempDir, "foo"))
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, rd, test.ShouldResemble, tfs.SingleFileNestedData)
+		})
+
+		t.Run("single directory", func(t *testing.T) {
+			tempDir := t.TempDir()
+
+			args := []string{fmt.Sprintf("machine:%s", tfs.Root), tempDir}
+
+			t.Log("without recursion set")
+			cCtx, _, _, _, teardown1 := setupWithRunningPart(
+				t, asc, nil, nil, partFlags, "token", partFqdn, args...)
+			defer teardown1()
+			err := MachinesPartCopyFilesAction(cCtx)
+			test.That(t, err, test.ShouldNotBeNil)
+			s, ok := status.FromError(err)
+			test.That(t, ok, test.ShouldBeTrue)
+			test.That(t, s.Code(), test.ShouldEqual, codes.InvalidArgument)
+			test.That(t, s.Message(), test.ShouldContainSubstring, "recursion")
+			_, err = os.ReadFile(filepath.Join(tempDir, filepath.Base(tfs.SingleFileNested)))
+			test.That(t, errors.Is(err, fs.ErrNotExist), test.ShouldBeTrue)
+
+			t.Log("with recursion set")
+			partFlagsCopy := make(map[string]any, len(partFlags))
+			maps.Copy(partFlagsCopy, partFlags)
+			partFlagsCopy["recursive"] = true
+			cCtx, _, _, _, teardown2 := setupWithRunningPart(
+				t, asc, nil, nil, partFlagsCopy, "token", partFqdn, args...)
+			defer teardown2()
+			test.That(t, MachinesPartCopyFilesAction(cCtx), test.ShouldBeNil)
+			test.That(t, shelltestutils.DirectoryContentsEqual(tfs.Root, filepath.Join(tempDir, filepath.Base(tfs.Root))), test.ShouldBeNil)
+		})
+
+		t.Run("multiple files", func(t *testing.T) {
+			tempDir := t.TempDir()
+
+			args := []string{
+				fmt.Sprintf("machine:%s", tfs.SingleFileNested),
+				fmt.Sprintf("machine:%s", tfs.InnerDir),
+				tempDir,
+			}
+			partFlagsCopy := make(map[string]any, len(partFlags))
+			maps.Copy(partFlagsCopy, partFlags)
+			partFlagsCopy["recursive"] = true
+			cCtx, _, _, _, teardown := setupWithRunningPart(
+				t, asc, nil, nil, partFlagsCopy, "token", partFqdn, args...)
+			defer teardown()
+			test.That(t, MachinesPartCopyFilesAction(cCtx), test.ShouldBeNil)
+
+			rd, err := os.ReadFile(filepath.Join(tempDir, filepath.Base(tfs.SingleFileNested)))
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, rd, test.ShouldResemble, tfs.SingleFileNestedData)
+
+			test.That(t, shelltestutils.DirectoryContentsEqual(tfs.InnerDir, filepath.Join(tempDir, filepath.Base(tfs.InnerDir))), test.ShouldBeNil)
+		})
+
+		t.Run("preserve permissions on a nested file", func(t *testing.T) {
+			tfs := shelltestutils.SetupTestFileSystem(t)
+
+			beforeInfo, err := os.Stat(tfs.SingleFileNested)
+			test.That(t, err, test.ShouldBeNil)
+			t.Log("start with mode", beforeInfo.Mode())
+			newMode := os.FileMode(0o444)
+			test.That(t, beforeInfo.Mode(), test.ShouldNotEqual, newMode)
+			test.That(t, os.Chmod(tfs.SingleFileNested, newMode), test.ShouldBeNil)
+			modTime := time.Date(1988, 1, 2, 3, 0, 0, 0, time.UTC)
+			test.That(t, os.Chtimes(tfs.SingleFileNested, time.Time{}, modTime), test.ShouldBeNil)
+			relNestedPath := strings.TrimPrefix(tfs.SingleFileNested, tfs.Root)
+
+			for _, preserve := range []bool{false, true} {
+				t.Run(fmt.Sprintf("preserve=%t", preserve), func(t *testing.T) {
+					tempDir := t.TempDir()
+
+					args := []string{fmt.Sprintf("machine:%s", tfs.Root), tempDir}
+
+					partFlagsCopy := make(map[string]any, len(partFlags))
+					maps.Copy(partFlagsCopy, partFlags)
+					partFlagsCopy["recursive"] = true
+					partFlagsCopy["preserve"] = preserve
+					cCtx, _, _, _, teardown := setupWithRunningPart(
+						t, asc, nil, nil, partFlagsCopy, "token", partFqdn, args...)
+					defer teardown()
+					test.That(t, MachinesPartCopyFilesAction(cCtx), test.ShouldBeNil)
+					test.That(t, shelltestutils.DirectoryContentsEqual(tfs.Root, filepath.Join(tempDir, filepath.Base(tfs.Root))), test.ShouldBeNil)
+
+					nestedCopy := filepath.Join(tempDir, filepath.Base(tfs.Root), relNestedPath)
+					test.That(t, shelltestutils.DirectoryContentsEqual(tfs.Root, filepath.Join(tempDir, filepath.Base(tfs.Root))), test.ShouldBeNil)
+					afterInfo, err := os.Stat(nestedCopy)
+					test.That(t, err, test.ShouldBeNil)
+					if preserve {
+						test.That(t, afterInfo.ModTime().UTC().String(), test.ShouldEqual, modTime.String())
+						test.That(t, afterInfo.Mode(), test.ShouldEqual, newMode)
+					} else {
+						test.That(t, afterInfo.ModTime().UTC().String(), test.ShouldNotEqual, modTime.String())
+						test.That(t, afterInfo.Mode(), test.ShouldNotEqual, newMode)
+					}
+				})
+			}
+		})
+	})
+
+	t.Run("to", func(t *testing.T) {
+		t.Run("single file", func(t *testing.T) {
+			tempDir := t.TempDir()
+
+			args := []string{tfs.SingleFileNested, fmt.Sprintf("machine:%s", tempDir)}
+			cCtx, _, _, _, teardown := setupWithRunningPart(
+				t, asc, nil, nil, partFlags, "token", partFqdn, args...)
+			defer teardown()
+			test.That(t, MachinesPartCopyFilesAction(cCtx), test.ShouldBeNil)
+
+			rd, err := os.ReadFile(filepath.Join(tempDir, filepath.Base(tfs.SingleFileNested)))
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, rd, test.ShouldResemble, tfs.SingleFileNestedData)
+		})
+
+		t.Run("single file relative", func(t *testing.T) {
+			homeDir, err := os.UserHomeDir()
+			test.That(t, err, test.ShouldBeNil)
+			randomName := uuid.NewString()
+			randomPath := filepath.Join(homeDir, randomName)
+			defer os.Remove(randomPath)
+			args := []string{tfs.SingleFileNested, fmt.Sprintf("machine:%s", randomName)}
+			cCtx, _, _, _, teardown := setupWithRunningPart(
+				t, asc, nil, nil, partFlags, "token", partFqdn, args...)
+			defer teardown()
+			test.That(t, MachinesPartCopyFilesAction(cCtx), test.ShouldBeNil)
+
+			rd, err := os.ReadFile(randomPath)
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, rd, test.ShouldResemble, tfs.SingleFileNestedData)
+		})
+
+		t.Run("single directory", func(t *testing.T) {
+			tempDir := t.TempDir()
+
+			args := []string{tfs.Root, fmt.Sprintf("machine:%s", tempDir)}
+
+			t.Log("without recursion set")
+			cCtx, _, _, _, teardown1 := setupWithRunningPart(
+				t, asc, nil, nil, partFlags, "token", partFqdn, args...)
+			defer teardown1()
+			err := MachinesPartCopyFilesAction(cCtx)
+			test.That(t, err, test.ShouldNotBeNil)
+			s, ok := status.FromError(err)
+			test.That(t, ok, test.ShouldBeTrue)
+			test.That(t, s.Code(), test.ShouldEqual, codes.InvalidArgument)
+			test.That(t, s.Message(), test.ShouldContainSubstring, "recursion")
+			_, err = os.ReadFile(filepath.Join(tempDir, filepath.Base(tfs.SingleFileNested)))
+			test.That(t, errors.Is(err, fs.ErrNotExist), test.ShouldBeTrue)
+
+			t.Log("with recursion set")
+			partFlagsCopy := make(map[string]any, len(partFlags))
+			maps.Copy(partFlagsCopy, partFlags)
+			partFlagsCopy["recursive"] = true
+			cCtx, _, _, _, teardown2 := setupWithRunningPart(
+				t, asc, nil, nil, partFlagsCopy, "token", partFqdn, args...)
+			defer teardown2()
+			test.That(t, MachinesPartCopyFilesAction(cCtx), test.ShouldBeNil)
+			test.That(t, shelltestutils.DirectoryContentsEqual(tfs.Root, filepath.Join(tempDir, filepath.Base(tfs.Root))), test.ShouldBeNil)
+		})
+
+		t.Run("multiple files", func(t *testing.T) {
+			tempDir := t.TempDir()
+
+			args := []string{
+				tfs.SingleFileNested,
+				tfs.InnerDir,
+				fmt.Sprintf("machine:%s", tempDir),
+			}
+			partFlagsCopy := make(map[string]any, len(partFlags))
+			maps.Copy(partFlagsCopy, partFlags)
+			partFlagsCopy["recursive"] = true
+			cCtx, _, _, _, teardown := setupWithRunningPart(
+				t, asc, nil, nil, partFlagsCopy, "token", partFqdn, args...)
+			defer teardown()
+			test.That(t, MachinesPartCopyFilesAction(cCtx), test.ShouldBeNil)
+
+			rd, err := os.ReadFile(filepath.Join(tempDir, filepath.Base(tfs.SingleFileNested)))
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, rd, test.ShouldResemble, tfs.SingleFileNestedData)
+
+			test.That(t, shelltestutils.DirectoryContentsEqual(tfs.InnerDir, filepath.Join(tempDir, filepath.Base(tfs.InnerDir))), test.ShouldBeNil)
+		})
+
+		t.Run("preserve permissions on a nested file", func(t *testing.T) {
+			tfs := shelltestutils.SetupTestFileSystem(t)
+
+			beforeInfo, err := os.Stat(tfs.SingleFileNested)
+			test.That(t, err, test.ShouldBeNil)
+			t.Log("start with mode", beforeInfo.Mode())
+			newMode := os.FileMode(0o444)
+			test.That(t, beforeInfo.Mode(), test.ShouldNotEqual, newMode)
+			test.That(t, os.Chmod(tfs.SingleFileNested, newMode), test.ShouldBeNil)
+			modTime := time.Date(1988, 1, 2, 3, 0, 0, 0, time.UTC)
+			test.That(t, os.Chtimes(tfs.SingleFileNested, time.Time{}, modTime), test.ShouldBeNil)
+			relNestedPath := strings.TrimPrefix(tfs.SingleFileNested, tfs.Root)
+
+			for _, preserve := range []bool{false, true} {
+				t.Run(fmt.Sprintf("preserve=%t", preserve), func(t *testing.T) {
+					tempDir := t.TempDir()
+
+					args := []string{tfs.Root, fmt.Sprintf("machine:%s", tempDir)}
+
+					partFlagsCopy := make(map[string]any, len(partFlags))
+					maps.Copy(partFlagsCopy, partFlags)
+					partFlagsCopy["recursive"] = true
+					partFlagsCopy["preserve"] = preserve
+					cCtx, _, _, _, teardown := setupWithRunningPart(
+						t, asc, nil, nil, partFlagsCopy, "token", partFqdn, args...)
+					defer teardown()
+					test.That(t, MachinesPartCopyFilesAction(cCtx), test.ShouldBeNil)
+					test.That(t, shelltestutils.DirectoryContentsEqual(tfs.Root, filepath.Join(tempDir, filepath.Base(tfs.Root))), test.ShouldBeNil)
+
+					nestedCopy := filepath.Join(tempDir, filepath.Base(tfs.Root), relNestedPath)
+					test.That(t, shelltestutils.DirectoryContentsEqual(tfs.Root, filepath.Join(tempDir, filepath.Base(tfs.Root))), test.ShouldBeNil)
+					afterInfo, err := os.Stat(nestedCopy)
+					test.That(t, err, test.ShouldBeNil)
+					if preserve {
+						test.That(t, afterInfo.ModTime().UTC().String(), test.ShouldEqual, modTime.String())
+						test.That(t, afterInfo.Mode(), test.ShouldEqual, newMode)
+					} else {
+						test.That(t, afterInfo.ModTime().UTC().String(), test.ShouldNotEqual, modTime.String())
+						test.That(t, afterInfo.Mode(), test.ShouldNotEqual, newMode)
+					}
+				})
+			}
+		})
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -96,6 +96,7 @@ require (
 	gonum.org/v1/gonum v0.12.0
 	gonum.org/v1/plot v0.12.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20230711160842-782d3b101e98
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98
 	google.golang.org/grpc v1.58.3
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.2.0
 	google.golang.org/protobuf v1.31.0
@@ -375,7 +376,6 @@ require (
 	google.golang.org/api v0.126.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230711160842-782d3b101e98 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/robot/server/server_test.go
+++ b/robot/server/server_test.go
@@ -88,7 +88,6 @@ func TestServer(t *testing.T) {
 		}
 		resp, err := server.GetCloudMetadata(context.Background(), &req)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, resp.GetMachinePartId(), test.ShouldEqual, "the-robot-part")
 		test.That(t, resp.GetLocationId(), test.ShouldEqual, "the-location")
 		test.That(t, resp.GetPrimaryOrgId(), test.ShouldEqual, "the-primary-org")
 		test.That(t, resp.GetMachineId(), test.ShouldEqual, "the-machine")

--- a/services/shell/builtin/builtin.go
+++ b/services/shell/builtin/builtin.go
@@ -207,6 +207,47 @@ func (svc *builtIn) Shell(ctx context.Context, extra map[string]interface{}) (
 	return input, oobInput, output, nil
 }
 
+// CopyFilesToMachine places files from the returned FileCopier
+// into the given local destination.
+func (svc *builtIn) CopyFilesToMachine(
+	ctx context.Context,
+	sourceType shell.CopyFilesSourceType,
+	destination string,
+	preserve bool,
+	extra map[string]interface{},
+) (shell.FileCopier, error) {
+	// we make a temporary factory here just because its reusing some code used
+	// elsewhere (like the CLI) that keeps the factory around longer.
+	factory, err := shell.NewLocalFileCopyFactory(destination, preserve, true)
+	if err != nil {
+		return nil, err
+	}
+	return factory.MakeFileCopier(ctx, sourceType)
+}
+
+// CopyFilesFromMachine searches for files locally from the given paths and then
+// copies them into a FileCopier created by the given FileCopyFactory.
+// Note(erd): a future version of this API may prefer to be more iterator based where
+// a shell.CopyFilesSourceType and a new reader type is returned. Right now, it's a tad
+// more tightly coupled for the sake of reducing the number of exposed abstractions.
+func (svc *builtIn) CopyFilesFromMachine(
+	ctx context.Context,
+	paths []string,
+	allowRecursion bool,
+	preserve bool,
+	copyFactory shell.FileCopyFactory,
+	extra map[string]interface{},
+) error {
+	reader, err := shell.NewLocalFileReadCopier(paths, allowRecursion, false, copyFactory)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		utils.UncheckedError(reader.Close(ctx))
+	}()
+	return reader.ReadAll(ctx)
+}
+
 func (svc *builtIn) Close(ctx context.Context) error {
 	svc.activeBackgroundWorkers.Wait()
 	return nil

--- a/services/shell/copy.go
+++ b/services/shell/copy.go
@@ -1,0 +1,112 @@
+package shell
+
+import (
+	"context"
+	"io/fs"
+
+	servicepb "go.viam.com/api/service/shell/v1"
+)
+
+// A File is a complete File to be sent/received.
+type File struct {
+	// RelativeName is the filesystem agnostic name.
+	// For example, ~/my/file would appear as my/file.
+	RelativeName string
+	// The underlying data for the File and it must have
+	// a non-nil fs.FileInfo.
+	Data fs.File
+}
+
+// A FileCopier receives files to copy into some implementation specific
+// location. It is only safe to call for one file at a time.
+type FileCopier interface {
+	Copy(ctx context.Context, file File) error
+	Close(ctx context.Context) error
+}
+
+// A FileCopyFactory is used to create FileCopiers when the CopyFilesSourceType is not
+// known until a later time. For example, asking to copy files from a machine results in
+// an RPC that is likely to be handled by a method that knows how to make FileCopiers, but
+// not what kind yet. This is a consequence of the current flow of operations and in the future
+// the factory may become obviated.
+type FileCopyFactory interface {
+	MakeFileCopier(ctx context.Context, sourceType CopyFilesSourceType) (FileCopier, error)
+}
+
+// A FileReadCopier is mostly a tee-like utility to read all files from somewhere and
+// pass them through to some bound-to, underlying FileCopier. Similar to the FileCopyFactory,
+// this abstraction exists so as to promote re-use across client/server interactions while
+// reducing some extra abstractions like a FileReader/FileIterator.
+type FileReadCopier interface {
+	ReadAll(ctx context.Context) error
+	Close(ctx context.Context) error
+}
+
+// CopyFilesSourceType indicates the types of files being transmitted.
+type CopyFilesSourceType int
+
+const (
+	// CopyFilesSourceTypeSingleFile is just one normal file being copied.
+	CopyFilesSourceTypeSingleFile CopyFilesSourceType = iota
+	// CopyFilesSourceTypeSingleDirectory is one top-level directory being
+	// copied but the transmission may contain many files. This disambiguates
+	// where to place the directory versus multiple files. Multiple files always
+	// go within the target destination, but a single directory may be renamed
+	// at the top depending on if the target destination exists or not. Either
+	// way, the receiving side needs to know what is being worked with. This
+	// is a consequence of mimicking SCP and is admittedly a bit involved as well
+	// as probably annoying to implement correctly.
+	CopyFilesSourceTypeSingleDirectory
+	// CopyFilesSourceTypeMultipleFiles indicates multiple files will be transmitted.
+	CopyFilesSourceTypeMultipleFiles
+	// CopyFilesSourceTypeMultipleUnknown should never be used.
+	CopyFilesSourceTypeMultipleUnknown
+)
+
+// String returns a human-readable string of the type.
+func (t CopyFilesSourceType) String() string {
+	switch t {
+	case CopyFilesSourceTypeSingleFile:
+		return "SingleFile"
+	case CopyFilesSourceTypeSingleDirectory:
+		return "SingleDirectory"
+	case CopyFilesSourceTypeMultipleFiles:
+		return "MultipleFiles"
+	case CopyFilesSourceTypeMultipleUnknown:
+		fallthrough
+	default:
+		return "Unknown"
+	}
+}
+
+// CopyFilesSourceTypeFromProto converts from proto to native.
+func CopyFilesSourceTypeFromProto(p servicepb.CopyFilesSourceType) CopyFilesSourceType {
+	switch p {
+	case servicepb.CopyFilesSourceType_COPY_FILES_SOURCE_TYPE_SINGLE_FILE:
+		return CopyFilesSourceTypeSingleFile
+	case servicepb.CopyFilesSourceType_COPY_FILES_SOURCE_TYPE_SINGLE_DIRECTORY:
+		return CopyFilesSourceTypeSingleDirectory
+	case servicepb.CopyFilesSourceType_COPY_FILES_SOURCE_TYPE_MULTIPLE_FILES:
+		return CopyFilesSourceTypeMultipleFiles
+	case servicepb.CopyFilesSourceType_COPY_FILES_SOURCE_TYPE_UNSPECIFIED:
+		fallthrough
+	default:
+		return CopyFilesSourceTypeMultipleUnknown
+	}
+}
+
+// ToProto converts from native to proto.
+func (t CopyFilesSourceType) ToProto() servicepb.CopyFilesSourceType {
+	switch t {
+	case CopyFilesSourceTypeSingleFile:
+		return servicepb.CopyFilesSourceType_COPY_FILES_SOURCE_TYPE_SINGLE_FILE
+	case CopyFilesSourceTypeSingleDirectory:
+		return servicepb.CopyFilesSourceType_COPY_FILES_SOURCE_TYPE_SINGLE_DIRECTORY
+	case CopyFilesSourceTypeMultipleFiles:
+		return servicepb.CopyFilesSourceType_COPY_FILES_SOURCE_TYPE_MULTIPLE_FILES
+	case CopyFilesSourceTypeMultipleUnknown:
+		fallthrough
+	default:
+		return servicepb.CopyFilesSourceType_COPY_FILES_SOURCE_TYPE_UNSPECIFIED
+	}
+}

--- a/services/shell/copy_local.go
+++ b/services/shell/copy_local.go
@@ -1,0 +1,443 @@
+package shell
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"go.uber.org/multierr"
+	"go.viam.com/utils"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// copy_local supports local filesystem copy operations and is agnostic to which
+// side of the RPC copying is happening from.
+
+// NewLocalFileCopyFactory returns a FileCopyFactory that is responsible for making
+// FileCopiers that copy from the local filesystem. The destination is used later on
+// in tandem with a the CopyFilesSourceType passed into MakeFileCopier.
+func NewLocalFileCopyFactory(
+	destination string,
+	preserve bool,
+	relativeToHome bool,
+) (FileCopyFactory, error) {
+	// fixup destination to something we can work with
+	destination, err := fixPeerPath(destination, true, relativeToHome)
+	if err != nil {
+		return nil, err
+	}
+	return &localFileCopyFactory{destination: destination, preserve: preserve}, nil
+}
+
+type localFileCopyFactory struct {
+	destination string
+	preserve    bool
+}
+
+// MakeFileCopier makes a new FileCopier that is ready for to copy files into the factory's
+// file destination.
+func (f *localFileCopyFactory) MakeFileCopier(ctx context.Context, sourceType CopyFilesSourceType) (FileCopier, error) {
+	finalDestination := f.destination
+	var overrideName string
+	switch sourceType {
+	case CopyFilesSourceTypeMultipleFiles:
+		// for multiple files (a b c machine:~/some/dir), ~/some/dir neds to already exist
+		// as a directory
+		dstInfo, err := os.Stat(f.destination)
+		if err != nil || dstInfo == nil || !dstInfo.IsDir() {
+			return nil, fmt.Errorf("%q does not exist or is not a directory", f.destination)
+		}
+		if err := os.MkdirAll(filepath.Dir(f.destination), 0o750); err != nil {
+			return nil, err
+		}
+	case CopyFilesSourceTypeSingleFile, CopyFilesSourceTypeSingleDirectory:
+		// for single files (a machine:~/some/dir_or_file):
+		// if destination exists and
+		// 		it is a directory, then put the source file/directory in it.
+		//		it is a file and the source is a file, overwrrite.
+		//      it is a file and the source is a directory, error.
+		// or if destination does not exist and
+		//		if the parent exists and
+		//			it is a directory, then put the source/file directory in it.
+		//			it is a file, then error.
+		//		the parent does not exist, then error.
+
+		var rename bool
+		dstInfo, err := os.Stat(f.destination)
+		// if destination exists and
+		if err == nil {
+			if dstInfo == nil {
+				return nil, fmt.Errorf("expected file info for %q", f.destination)
+			}
+			switch {
+			case dstInfo.IsDir():
+				// it is a directory, then put the source file/directory in it
+				// destination stays the same
+			case sourceType == CopyFilesSourceTypeSingleFile:
+				// it is a file and the source is a file, overwrrite
+				// destination becomes parent
+				rename = true
+			default:
+				// it is a file and the source is a directory, error
+				return nil, fmt.Errorf("destination %q is an existing file", f.destination)
+			}
+		} else { // or if destination does not exist and
+			parent := filepath.Dir(f.destination)
+			parentInfo, err := os.Stat(parent)
+			if err != nil {
+				// the parent does not exist, then error
+				return nil, err
+			}
+			if parentInfo == nil {
+				return nil, fmt.Errorf("expected file info for %q", parent)
+			}
+			// if the parent exists and
+			if parentInfo.IsDir() {
+				// it is a directory, then put the source/file directory in it
+				// destination becomes parent
+				rename = true
+			} else {
+				// it is a file, then error
+				return nil, fmt.Errorf("parent of destination %q is an existing file, not a directory", f.destination)
+			}
+		}
+
+		if rename {
+			overrideName = filepath.Base(f.destination)
+			finalDestination = filepath.Dir(f.destination)
+		}
+	case CopyFilesSourceTypeMultipleUnknown:
+		fallthrough
+	default:
+		return nil, fmt.Errorf("do not know how to process source copy type %q", sourceType)
+	}
+	return &localFileCopier{
+		sourceType:   sourceType,
+		dst:          finalDestination,
+		overrideName: overrideName,
+		preserve:     f.preserve,
+	}, nil
+}
+
+func (f *localFileCopyFactory) Close(ctx context.Context) error {
+	return nil
+}
+
+// A localFileCopier takes in files and copies them to a set destination. It should be created
+// with a localFileCopyFactory.
+type localFileCopier struct {
+	sourceType   CopyFilesSourceType
+	dst          string
+	overrideName string
+	preserve     bool
+}
+
+func (copier *localFileCopier) Copy(ctx context.Context, file File) error {
+	defer func() {
+		utils.UncheckedError(file.Data.Close())
+	}()
+
+	fileName := file.RelativeName
+	if copier.overrideName != "" {
+		// only change the first part of the file name for directory
+		// renaming purposes. This is based on SCP logic.
+		fileSplit := splitPath(file.RelativeName)
+		if len(fileSplit) == 0 {
+			fileSplit = []string{copier.overrideName}
+		} else {
+			fileSplit[0] = copier.overrideName
+		}
+		fileName = filepath.Join(fileSplit...)
+	}
+	fullPath := filepath.Join(copier.dst, fileName)
+
+	fileInfo, err := file.Data.Stat()
+	if err != nil {
+		return err
+	}
+	if fileInfo == nil {
+		return fmt.Errorf("expected file info for %q to be non-nil", fileName)
+	}
+
+	parentPath := filepath.Dir(fullPath)
+	if parentPath == "" {
+		return fmt.Errorf("expected non-empty parent path to destination %q", copier.dst)
+	}
+	if fileInfo, err := os.Stat(parentPath); err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return err
+		}
+		// this will later be updated with chmod for a specific directory. It's safe to make
+		// directories here because we assume whoever constructed us has validated the top-level
+		// directory as existing or created.
+		//nolint:gosec // this is from an authenticated/authorized connection
+		if err := os.MkdirAll(parentPath, 0o755); err != nil {
+			return err
+		}
+	} else if fileInfo == nil {
+		return fmt.Errorf("expected file info for %q to be non-nil", parentPath)
+	} else if !fileInfo.IsDir() {
+		return fmt.Errorf("invariant: parent path %q should have been a directory", parentPath)
+	}
+
+	var fileMode fs.FileMode
+	modTime := time.Now()
+	switch {
+	case copier.preserve:
+		modTime = fileInfo.ModTime()
+		fileMode = fileInfo.Mode()
+	case fileInfo.IsDir():
+		fileMode = 0o755
+	default:
+		fileMode = 0o644
+	}
+
+	if fileInfo.IsDir() {
+		if err := os.Mkdir(fullPath, fileMode); err != nil {
+			if !errors.Is(err, fs.ErrExist) {
+				return err
+			}
+			if copier.preserve {
+				// Update the mode since it maye have been created via mkdirall above
+				if err := os.Chmod(fullPath, fileMode); err != nil {
+					return err
+				}
+			}
+		}
+	} else {
+		//nolint:gosec // this is from an authenticated/authorized connection
+		localFile, err := os.OpenFile(fullPath, os.O_CREATE|os.O_WRONLY, fileMode)
+		if err != nil {
+			return err
+		}
+		if _, err := io.Copy(localFile, file.Data); err != nil {
+			return multierr.Combine(err, localFile.Close())
+		}
+	}
+	if copier.preserve {
+		// Update the mode since it maye have been created via mkdirall above
+		// or modified by umask
+		if err := os.Chmod(fullPath, fileMode); err != nil {
+			return err
+		}
+		// Note(erd): maybe support access time in the future if needed
+		if err := os.Chtimes(fullPath, time.Now(), modTime); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Close does nothing.
+func (copier *localFileCopier) Close(ctx context.Context) error {
+	return nil
+}
+
+type localFileReadCopier struct {
+	filesToCopy []*os.File
+	copyFactory FileCopyFactory
+}
+
+// NewLocalFileReadCopier returns a FileReadCopier that will have its ReadAll
+// method iteratively copy each file found indicated by paths into a FileCopier
+// created by the FileCopyFactory. The Factory is used since we don't yet know
+// what type of files we are going to copy until ReadAll is called.
+func NewLocalFileReadCopier(
+	paths []string,
+	allowRecursive bool,
+	relativeToHome bool,
+	copyFactory FileCopyFactory,
+) (FileReadCopier, error) {
+	var filesToCopy []*os.File
+
+	for _, p := range paths {
+		p, err := fixPeerPath(p, false, relativeToHome)
+		if err != nil {
+			return nil, err
+		}
+
+		//nolint:gosec // this is from an authenticated/authorized connection
+		fileToCopy, err := os.Open(p)
+		if err != nil {
+			return nil, err
+		}
+		if !allowRecursive {
+			fileInfo, err := fileToCopy.Stat()
+			if err != nil {
+				return nil, err
+			}
+			if fileInfo.IsDir() {
+				return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("local %q is a directory but copy recursion not used", p))
+			}
+		}
+		filesToCopy = append(filesToCopy, fileToCopy)
+	}
+	if len(filesToCopy) == 0 {
+		return nil, errors.New("no files provided to copy")
+	}
+	return &localFileReadCopier{filesToCopy: filesToCopy, copyFactory: copyFactory}, nil
+}
+
+// ReadAll processes and copies each file one by one into a newly constructed FileCopier until
+// complete.
+func (reader *localFileReadCopier) ReadAll(ctx context.Context) error {
+	if len(reader.filesToCopy) == 0 {
+		return nil
+	}
+
+	var sourceType CopyFilesSourceType
+	if len(reader.filesToCopy) == 1 {
+		fileInfo, err := reader.filesToCopy[0].Stat()
+		if err != nil {
+			return err
+		}
+		if fileInfo.IsDir() {
+			sourceType = CopyFilesSourceTypeSingleDirectory
+		} else {
+			sourceType = CopyFilesSourceTypeSingleFile
+		}
+	} else {
+		sourceType = CopyFilesSourceTypeMultipleFiles
+	}
+
+	copier, err := reader.copyFactory.MakeFileCopier(ctx, sourceType)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		utils.UncheckedError(copier.Close(ctx))
+	}()
+
+	// Note: okay with recursion for now. may want to check depth later...
+
+	makeRelName := func(relDir string, file *os.File) string {
+		return filepath.Join(relDir, filepath.Base(file.Name()))
+	}
+	var copyFiles func(relDir string, files []*os.File) error
+	copyFiles = func(relDir string, files []*os.File) error {
+		for _, f := range files {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+
+			fileInfo, err := f.Stat()
+			if err != nil {
+				return err
+			}
+			if fileInfo.IsDir() {
+				filesEntriesInDir, err := f.ReadDir(0)
+				if err != nil {
+					return err
+				}
+				filesInDir := make([]*os.File, 0, len(filesEntriesInDir))
+				for _, dirEntry := range filesEntriesInDir {
+					entryPath := filepath.Join(f.Name(), dirEntry.Name())
+					//nolint:gosec // this is from an authenticated/authorized connection
+					entryFile, err := os.Open(entryPath)
+					if err != nil {
+						for _, f := range filesInDir {
+							utils.UncheckedError(f.Close())
+						}
+						return err
+					}
+					filesInDir = append(filesInDir, entryFile)
+				}
+
+				if err := copyFiles(makeRelName(relDir, f), filesInDir); err != nil {
+					return err
+				}
+			}
+
+			if err := copier.Copy(ctx, File{
+				RelativeName: makeRelName(relDir, f),
+				Data:         f,
+			}); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+	if err := copyFiles("", reader.filesToCopy); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Close closes all files that were used for copying at the top-level. They have
+// likely already been closed deeper down the stack.
+func (reader *localFileReadCopier) Close(ctx context.Context) error {
+	var errs error
+	for _, f := range reader.filesToCopy {
+		if err := f.Close(); err != nil && !errors.Is(err, fs.ErrClosed) {
+			errs = multierr.Combine(errs, err)
+		}
+	}
+	return errs
+}
+
+var errUnexpectedEmptyPath = errors.New("unexpected empty path")
+
+// fixPeerPath works with the usage of ~ or empty paths and turns
+// them into the proper HOME pathings.
+// Security Note: this is the only time we end up interpreting a user's path
+// string before it's passed to a file related syscall.
+func fixPeerPath(path string, allowEmpty, relativeToHome bool) (string, error) {
+	if !filepath.IsAbs(path) {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+
+		switch {
+		case strings.HasPrefix(path, "~/"):
+			path = strings.Replace(path, "~", homeDir, 1)
+		case path == "":
+			if !allowEmpty {
+				return "", errUnexpectedEmptyPath
+			}
+			if relativeToHome {
+				path = homeDir
+			} else {
+				path, err = filepath.Abs("")
+				if err != nil {
+					return "", err
+				}
+			}
+		case relativeToHome:
+			// From path has us use HOME paths
+			path = filepath.Join(homeDir, path)
+		default:
+			// To path has us use CWD paths
+			path, err = filepath.Abs(path)
+			if err != nil {
+				return "", err
+			}
+		}
+	}
+	return path, nil
+}
+
+// this seems to mostly work as a cross-platform splitter.
+func splitPath(path string) []string {
+	var split []string
+	vol := filepath.VolumeName(path)
+	start := len(vol)
+	for i := start; i < len(path); i++ {
+		if os.IsPathSeparator(path[i]) {
+			split = append(split, path[start:i])
+			start = i + 1
+		} else if i+1 == len(path) {
+			split = append(split, path[start:])
+		}
+	}
+	return split
+}

--- a/services/shell/copy_local_test.go
+++ b/services/shell/copy_local_test.go
@@ -1,0 +1,282 @@
+package shell
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"go.viam.com/test"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	shelltestutils "go.viam.com/rdk/services/shell/testutils"
+)
+
+func TestFixPeerPath(t *testing.T) {
+	tempDir := t.TempDir()
+	cwd, err := os.Getwd()
+	test.That(t, err, test.ShouldBeNil)
+	t.Cleanup(func() { os.Chdir(cwd) })
+	test.That(t, os.Chdir(tempDir), test.ShouldBeNil)
+	// macos uses /private for /var temp dirs, getwd will give us that path
+	realTempDir, err := os.Getwd()
+	test.That(t, err, test.ShouldBeNil)
+
+	fixed, err := fixPeerPath("/one/two/three", false, true)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, fixed, test.ShouldEqual, "/one/two/three")
+
+	homeDir, err := os.UserHomeDir()
+	test.That(t, err, test.ShouldBeNil)
+
+	fixed, err = fixPeerPath("one/two/three", false, true)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, fixed, test.ShouldEqual, filepath.Join(homeDir, "one/two/three"))
+
+	fixed, err = fixPeerPath("~/one/two/three", false, true)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, fixed, test.ShouldEqual, filepath.Join(homeDir, "one/two/three"))
+
+	fixed, err = fixPeerPath("~/one/two/~/three", false, true)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, fixed, test.ShouldEqual, filepath.Join(homeDir, "one/two/~/three"))
+
+	fixed, err = fixPeerPath("one/two/three", false, false)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, fixed, test.ShouldEqual, filepath.Join(realTempDir, "one/two/three"))
+
+	_, err = fixPeerPath("", false, true)
+	test.That(t, err, test.ShouldEqual, errUnexpectedEmptyPath)
+
+	fixed, err = fixPeerPath("", true, true)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, fixed, test.ShouldEqual, homeDir)
+
+	fixed, err = fixPeerPath("", true, false)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, fixed, test.ShouldEqual, realTempDir)
+}
+
+// TestLocalFileCopy contains tests are very similar to cli.TestShellFileCopy but
+// it includes some more detailed testing at the unit level that is more annoying to
+// test in the CLI. The RPC side of this is covered by the CLI.
+func TestLocalFileCopy(t *testing.T) {
+	ctx := context.Background()
+	tfs := shelltestutils.SetupTestFileSystem(t)
+
+	t.Run("single file", func(t *testing.T) {
+		tempDir := t.TempDir()
+
+		factory, err := NewLocalFileCopyFactory(tempDir, false, false)
+		test.That(t, err, test.ShouldBeNil)
+
+		readCopier, err := NewLocalFileReadCopier([]string{tfs.SingleFileNested}, false, false, factory)
+		test.That(t, err, test.ShouldBeNil)
+
+		test.That(t, readCopier.ReadAll(ctx), test.ShouldBeNil)
+		test.That(t, readCopier.Close(ctx), test.ShouldBeNil)
+
+		rd, err := os.ReadFile(filepath.Join(tempDir, filepath.Base(tfs.SingleFileNested)))
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, rd, test.ShouldResemble, tfs.SingleFileNestedData)
+	})
+
+	t.Run("single file but destination does not exist", func(t *testing.T) {
+		tempDir := t.TempDir()
+		tempDirInner := filepath.Join(tempDir, "inner")
+		test.That(t, os.Mkdir(tempDirInner, 0o750), test.ShouldBeNil)
+		test.That(t, os.RemoveAll(tempDirInner), test.ShouldBeNil)
+
+		factory, err := NewLocalFileCopyFactory(tempDirInner, false, false)
+		test.That(t, err, test.ShouldBeNil)
+
+		readCopier, err := NewLocalFileReadCopier([]string{tfs.SingleFileNested}, false, false, factory)
+		test.That(t, err, test.ShouldBeNil)
+
+		test.That(t, readCopier.ReadAll(ctx), test.ShouldBeNil)
+		test.That(t, readCopier.Close(ctx), test.ShouldBeNil)
+
+		rd, err := os.ReadFile(tempDirInner)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, rd, test.ShouldResemble, tfs.SingleFileNestedData)
+
+		t.Log("parent exists but it is a file not a directory")
+		factory, err = NewLocalFileCopyFactory(filepath.Join(tempDirInner, "notthere"), false, false)
+		test.That(t, err, test.ShouldBeNil)
+
+		readCopier, err = NewLocalFileReadCopier([]string{tfs.SingleFileNested}, false, false, factory)
+		test.That(t, err, test.ShouldBeNil)
+
+		err = readCopier.ReadAll(ctx)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, readCopier.Close(ctx), test.ShouldBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "is an existing file")
+	})
+
+	t.Run("single file relative", func(t *testing.T) {
+		tempDir := t.TempDir()
+		cwd, err := os.Getwd()
+		test.That(t, err, test.ShouldBeNil)
+		t.Cleanup(func() { os.Chdir(cwd) })
+		test.That(t, os.Chdir(tempDir), test.ShouldBeNil)
+
+		factory, err := NewLocalFileCopyFactory("foo", false, false)
+		test.That(t, err, test.ShouldBeNil)
+
+		readCopier, err := NewLocalFileReadCopier([]string{tfs.SingleFileNested}, false, false, factory)
+		test.That(t, err, test.ShouldBeNil)
+
+		test.That(t, readCopier.ReadAll(ctx), test.ShouldBeNil)
+		test.That(t, readCopier.Close(ctx), test.ShouldBeNil)
+
+		rd, err := os.ReadFile(filepath.Join(tempDir, "foo"))
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, rd, test.ShouldResemble, tfs.SingleFileNestedData)
+	})
+
+	t.Run("single directory", func(t *testing.T) {
+		tempDir := t.TempDir()
+
+		t.Log("without recursion set")
+		factory, err := NewLocalFileCopyFactory(tempDir, false, false)
+		test.That(t, err, test.ShouldBeNil)
+
+		_, err = NewLocalFileReadCopier([]string{tfs.Root}, false, false, factory)
+		test.That(t, err, test.ShouldNotBeNil)
+		s, ok := status.FromError(err)
+		test.That(t, ok, test.ShouldBeTrue)
+		test.That(t, s.Code(), test.ShouldEqual, codes.InvalidArgument)
+		test.That(t, s.Message(), test.ShouldContainSubstring, "recursion")
+		_, err = os.ReadFile(filepath.Join(tempDir, "example"))
+		test.That(t, errors.Is(err, fs.ErrNotExist), test.ShouldBeTrue)
+
+		t.Log("with recursion set")
+		readCopier, err := NewLocalFileReadCopier([]string{tfs.Root}, true, false, factory)
+		test.That(t, err, test.ShouldBeNil)
+
+		test.That(t, readCopier.ReadAll(ctx), test.ShouldBeNil)
+		test.That(t, readCopier.Close(ctx), test.ShouldBeNil)
+
+		test.That(t, shelltestutils.DirectoryContentsEqual(tfs.Root, filepath.Join(tempDir, filepath.Base(tfs.Root))), test.ShouldBeNil)
+	})
+
+	t.Run("single directory but destination does not exist", func(t *testing.T) {
+		tempDir := t.TempDir()
+		tempDirInner := filepath.Join(tempDir, "inner")
+		test.That(t, os.Mkdir(tempDirInner, 0o750), test.ShouldBeNil)
+		test.That(t, os.RemoveAll(tempDirInner), test.ShouldBeNil)
+
+		factory, err := NewLocalFileCopyFactory(tempDirInner, false, false)
+		test.That(t, err, test.ShouldBeNil)
+
+		readCopier, err := NewLocalFileReadCopier([]string{tfs.Root}, true, false, factory)
+		test.That(t, err, test.ShouldBeNil)
+
+		test.That(t, readCopier.ReadAll(ctx), test.ShouldBeNil)
+		test.That(t, readCopier.Close(ctx), test.ShouldBeNil)
+
+		test.That(t, shelltestutils.DirectoryContentsEqual(tfs.Root, tempDirInner), test.ShouldBeNil)
+
+		t.Log("parent exists but it is a file not a directory")
+		fileNotDirectory := filepath.Join(tempDir, "file")
+		test.That(t, os.WriteFile(fileNotDirectory, nil, 0o640), test.ShouldBeNil)
+		factory, err = NewLocalFileCopyFactory(filepath.Join(fileNotDirectory, "notthere"), false, false)
+		test.That(t, err, test.ShouldBeNil)
+
+		readCopier, err = NewLocalFileReadCopier([]string{tfs.Root}, true, false, factory)
+		test.That(t, err, test.ShouldBeNil)
+
+		err = readCopier.ReadAll(ctx)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, readCopier.Close(ctx), test.ShouldBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "is an existing file")
+	})
+
+	t.Run("multiple files", func(t *testing.T) {
+		tempDir := t.TempDir()
+
+		factory, err := NewLocalFileCopyFactory(tempDir, false, false)
+		test.That(t, err, test.ShouldBeNil)
+
+		readCopier, err := NewLocalFileReadCopier([]string{
+			tfs.SingleFileNested,
+			tfs.InnerDir,
+		}, true, false, factory)
+		test.That(t, err, test.ShouldBeNil)
+
+		test.That(t, readCopier.ReadAll(ctx), test.ShouldBeNil)
+		test.That(t, readCopier.Close(ctx), test.ShouldBeNil)
+
+		rd, err := os.ReadFile(filepath.Join(tempDir, filepath.Base(tfs.SingleFileNested)))
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, rd, test.ShouldResemble, tfs.SingleFileNestedData)
+
+		test.That(t, shelltestutils.DirectoryContentsEqual(tfs.InnerDir, filepath.Join(tempDir, filepath.Base(tfs.InnerDir))), test.ShouldBeNil)
+	})
+
+	t.Run("multiple files but destination does not exist", func(t *testing.T) {
+		tempDir := t.TempDir()
+		test.That(t, os.RemoveAll(tempDir), test.ShouldBeNil)
+
+		factory, err := NewLocalFileCopyFactory(tempDir, false, false)
+		test.That(t, err, test.ShouldBeNil)
+
+		readCopier, err := NewLocalFileReadCopier([]string{
+			tfs.SingleFileNested,
+			tfs.InnerDir,
+		}, true, false, factory)
+		test.That(t, err, test.ShouldBeNil)
+
+		err = readCopier.ReadAll(ctx)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, readCopier.Close(ctx), test.ShouldBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "does not exist or is not a directory")
+	})
+
+	t.Run("preserve permissions on a nested file", func(t *testing.T) {
+		tfs := shelltestutils.SetupTestFileSystem(t)
+
+		beforeInfo, err := os.Stat(tfs.SingleFileNested)
+		test.That(t, err, test.ShouldBeNil)
+		t.Log("start with mode", beforeInfo.Mode())
+		newMode := os.FileMode(0o444)
+		test.That(t, beforeInfo.Mode(), test.ShouldNotEqual, newMode)
+		test.That(t, os.Chmod(tfs.SingleFileNested, newMode), test.ShouldBeNil)
+		modTime := time.Date(1988, 1, 2, 3, 0, 0, 0, time.UTC)
+		test.That(t, os.Chtimes(tfs.SingleFileNested, time.Time{}, modTime), test.ShouldBeNil)
+		relNestedPath := strings.TrimPrefix(tfs.SingleFileNested, tfs.Root)
+
+		for _, preserve := range []bool{false, true} {
+			t.Run(fmt.Sprintf("preserve=%t", preserve), func(t *testing.T) {
+				tempDir := t.TempDir()
+
+				factory, err := NewLocalFileCopyFactory(tempDir, preserve, false)
+				test.That(t, err, test.ShouldBeNil)
+
+				readCopier, err := NewLocalFileReadCopier([]string{tfs.Root}, true, false, factory)
+				test.That(t, err, test.ShouldBeNil)
+
+				test.That(t, readCopier.ReadAll(ctx), test.ShouldBeNil)
+				test.That(t, readCopier.Close(ctx), test.ShouldBeNil)
+
+				nestedCopy := filepath.Join(tempDir, filepath.Base(tfs.Root), relNestedPath)
+				test.That(t, shelltestutils.DirectoryContentsEqual(tfs.Root, filepath.Join(tempDir, filepath.Base(tfs.Root))), test.ShouldBeNil)
+				afterInfo, err := os.Stat(nestedCopy)
+				test.That(t, err, test.ShouldBeNil)
+				if preserve {
+					test.That(t, afterInfo.ModTime().UTC().String(), test.ShouldEqual, modTime.String())
+					test.That(t, afterInfo.Mode(), test.ShouldEqual, newMode)
+				} else {
+					test.That(t, afterInfo.ModTime().UTC().String(), test.ShouldNotEqual, modTime.String())
+					test.That(t, afterInfo.Mode(), test.ShouldNotEqual, newMode)
+				}
+			})
+		}
+	})
+}

--- a/services/shell/copy_rpc.go
+++ b/services/shell/copy_rpc.go
@@ -1,0 +1,478 @@
+package shell
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"path/filepath"
+	"sync"
+	"time"
+
+	pb "go.viam.com/api/service/shell/v1"
+	"go.viam.com/utils"
+	"go.viam.com/utils/rpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// copy_rpc supports RPC based copy operations and is agnostic to where files
+// originated from beyond the RPC boundary. The main testing for this is done
+// in the CLI package since it's just easier to coordinate over there.
+
+// newCopyFileFromMachineFactory returns a factory that can make FileCopiers for
+// the Writer/Server side of a CopyFrom.
+func newCopyFileFromMachineFactory(
+	srv pb.ShellService_CopyFilesFromMachineServer, preserve bool,
+) FileCopyFactory {
+	return &copyFileFromMachineFactory{srv: srv, preserve: preserve}
+}
+
+type copyFileFromMachineFactory struct {
+	once     bool
+	onceMu   sync.Mutex
+	srv      pb.ShellService_CopyFilesFromMachineServer
+	preserve bool
+}
+
+func (f *copyFileFromMachineFactory) MakeFileCopier(ctx context.Context, sourceType CopyFilesSourceType) (FileCopier, error) {
+	f.onceMu.Lock()
+	if f.once {
+		f.onceMu.Unlock()
+		return nil, errors.New("can only support making one file copier right now")
+	}
+	f.onceMu.Unlock()
+	if err := f.srv.Send(&pb.CopyFilesFromMachineResponse{
+		Response: &pb.CopyFilesFromMachineResponse_Metadata{
+			Metadata: &pb.CopyFilesFromMachineResponseMetadata{
+				SourceType: sourceType.ToProto(),
+			},
+		},
+	}); err != nil {
+		return nil, err
+	}
+
+	return newShellRPCFileCopier(shellRPCCopyWriterFrom{f.srv}, f.preserve), nil
+}
+
+// NewCopyFileToMachineFactory returns a simple FileCopyFactory that calls a service's
+// CopyFilesToMachine method once the CopyFilesSourceType is discovered by the initiating
+// process.
+func NewCopyFileToMachineFactory(
+	destination string,
+	preserve bool,
+	shellSvc Service,
+) FileCopyFactory {
+	return &copyFileToMachineFactory{
+		destination: destination,
+		preserve:    preserve,
+		svc:         shellSvc,
+	}
+}
+
+type copyFileToMachineFactory struct {
+	destination string
+	preserve    bool
+	svc         Service
+}
+
+func (f *copyFileToMachineFactory) MakeFileCopier(ctx context.Context, sourceType CopyFilesSourceType) (FileCopier, error) {
+	return f.svc.CopyFilesToMachine(ctx, sourceType, f.destination, f.preserve, nil)
+}
+
+// A shellRPCCopyReader is a light abstraction around the different directions of
+// copying (reading) in order to get a little bit of code re-use in addition to making it
+// more clear how to use the protocol. Implementations are inverses of each other.
+type shellRPCCopyReader interface {
+	NextFileData() (*pb.FileData, error)
+	AckLastFile() error
+	Close() error
+}
+
+// A shellRPCCopyReaderTo is the To, Reader/Server side of a CopyTo.
+type shellRPCCopyReaderTo struct {
+	rpcServer pb.ShellService_CopyFilesToMachineServer
+}
+
+func (srv shellRPCCopyReaderTo) AckLastFile() error {
+	return srv.rpcServer.Send(&pb.CopyFilesToMachineResponse{
+		AckLastFile: true,
+	})
+}
+
+func (srv shellRPCCopyReaderTo) NextFileData() (*pb.FileData, error) {
+	req, err := srv.rpcServer.Recv()
+	if err != nil {
+		return nil, err
+	}
+	reqFileData, ok := req.Request.(*pb.CopyFilesToMachineRequest_FileData)
+	if !ok {
+		return nil, errors.New("expected copy request file data")
+	}
+	return reqFileData.FileData, nil
+}
+
+func (srv shellRPCCopyReaderTo) Close() error {
+	return nil
+}
+
+// A shellRPCCopyReaderFrom is the From, Reader/Client side of a CopyFrom.
+type shellRPCCopyReaderFrom struct {
+	rpcClient pb.ShellService_CopyFilesFromMachineClient
+}
+
+func (client shellRPCCopyReaderFrom) AckLastFile() error {
+	return client.rpcClient.Send(&pb.CopyFilesFromMachineRequest{
+		Request: &pb.CopyFilesFromMachineRequest_AckLastFile{
+			AckLastFile: true,
+		},
+	})
+}
+
+func (client shellRPCCopyReaderFrom) NextFileData() (*pb.FileData, error) {
+	resp, err := client.rpcClient.Recv()
+	if err != nil {
+		return nil, err
+	}
+	reqFileData, ok := resp.Response.(*pb.CopyFilesFromMachineResponse_FileData)
+	if !ok {
+		return nil, errors.New("expected copy response file data")
+	}
+	return reqFileData.FileData, nil
+}
+
+func (client shellRPCCopyReaderFrom) Close() error {
+	return client.rpcClient.CloseSend()
+}
+
+// A shellRPCFileReadCopier is a lightly utility struct that implements FileReadCopier
+// and uses a shellRPCCopyReader to copy all files into some FileCopier (RPC based or not).
+type shellRPCFileReadCopier struct {
+	rpc    shellRPCCopyReader
+	copier FileCopier
+}
+
+func newShellRPCFileReadCopier(rpc shellRPCCopyReader, copier FileCopier) FileReadCopier {
+	return &shellRPCFileReadCopier{
+		rpc:    rpc,
+		copier: copier,
+	}
+}
+
+// ReadAll is only safe to call once.
+func (reader *shellRPCFileReadCopier) ReadAll(ctx context.Context) error {
+	for {
+		file, err := reader.rpc.NextFileData()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return err
+		}
+		if err := reader.copyFile(ctx, file); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return err
+		}
+		if err := reader.rpc.AckLastFile(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (reader *shellRPCFileReadCopier) copyFile(
+	ctx context.Context,
+	initialFile *pb.FileData,
+) error {
+	fileName := initialFile.Name
+	if fileName == "" {
+		return errors.New("file name blank")
+	}
+	copyErr := make(chan error, 1)
+	cancelCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// we create a streaming based file using FIFO logic so that we
+	// don't keep too much data in memory.
+	streamingCopy := &streamingRPCFileCopy{
+		info: fileInfoData{
+			name:  filepath.Base(initialFile.Name),
+			size:  initialFile.Size,
+			isDir: initialFile.IsDir,
+		},
+		dataCh: make(chan []byte),
+	}
+
+	// this data is present pending the preserve option being used.
+	if initialFile.Mode != nil {
+		streamingCopy.info.mode = *initialFile.Mode
+	}
+	if initialFile.ModTime != nil {
+		streamingCopy.info.modTime = initialFile.ModTime.AsTime()
+	}
+	defer utils.UncheckedErrorFunc(streamingCopy.Close)
+	utils.PanicCapturingGo(func() {
+		copyErr <- reader.copier.Copy(cancelCtx, File{
+			RelativeName: fileName,
+			Data:         streamingCopy,
+		})
+	})
+
+	file := initialFile
+	for {
+		if file.Eof {
+			streamingCopy.close(io.EOF)
+			break
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		select {
+		case <-ctx.Done():
+		case streamingCopy.dataCh <- file.Data:
+		}
+		var err error
+		file, err = reader.rpc.NextFileData()
+		if err != nil {
+			return err
+		}
+		if file.Name != "" {
+			// Note(erd): this is a forwards compatibility defense against multiple files being
+			// at the same time. Without this, we may clobber data together.
+			return fmt.Errorf("unexpected file name %q while reading current file %q", file.Name, initialFile.Name)
+		}
+	}
+
+	return <-copyErr
+}
+
+func (reader *shellRPCFileReadCopier) Close(ctx context.Context) error {
+	return reader.rpc.Close()
+}
+
+// A streamingRPCFileCopy is an efficient, low-memory usage representation
+// of an fs.File being populated via RPC.
+type streamingRPCFileCopy struct {
+	info     fileInfoData
+	lastData []byte
+	dataCh   chan []byte
+	closeMu  sync.Mutex
+	closed   bool
+	closeErr error
+}
+
+type fileInfoData struct {
+	name    string
+	size    int64
+	isDir   bool
+	modTime time.Time
+	mode    uint32
+}
+
+func (info fileInfoData) Name() string {
+	return info.name
+}
+
+func (info fileInfoData) Size() int64 {
+	return info.size
+}
+
+func (info fileInfoData) Mode() fs.FileMode {
+	// may be 0 -- must check preserve flag elsewhere
+	return fs.FileMode(info.mode)
+}
+
+func (info fileInfoData) ModTime() time.Time {
+	// may be zero value -- must check preserve flag elsewhere
+	return info.modTime
+}
+
+func (info fileInfoData) IsDir() bool {
+	return info.isDir
+}
+
+func (info fileInfoData) Sys() any {
+	return nil
+}
+
+func (file *streamingRPCFileCopy) Stat() (fs.FileInfo, error) {
+	return file.info, nil
+}
+
+// Read is not safe to call concurrently.
+func (file *streamingRPCFileCopy) Read(buf []byte) (int, error) {
+	if file.lastData == nil {
+		data, ok := <-file.dataCh
+		if !ok {
+			return 0, file.closeErr
+		}
+		file.lastData = data
+	}
+	nToCopy := len(file.lastData)
+	if nToCopy > len(buf) {
+		nToCopy = len(buf)
+	}
+	copy(buf, file.lastData[:nToCopy])
+	file.lastData = file.lastData[nToCopy:]
+	if len(file.lastData) == 0 {
+		file.lastData = nil
+	}
+	return nToCopy, nil
+}
+
+func (file *streamingRPCFileCopy) close(reason error) {
+	file.closeMu.Lock()
+	if file.closed {
+		file.closeMu.Unlock()
+		return
+	}
+	file.closed = true
+	file.closeErr = reason
+	close(file.dataCh)
+	file.closeMu.Unlock()
+}
+
+func (file *streamingRPCFileCopy) Close() error {
+	file.close(fs.ErrClosed)
+	return nil
+}
+
+// A shellRPCCopyWriter is a light abstraction around the different directions of
+// copying (writing) in order to get a little bit of code re-use in addition to making it
+// more clear how to use the protocol. Implementations are inverses of each other.
+type shellRPCCopyWriter interface {
+	SendFile(fileDataProto *pb.FileData) error
+	WaitLastACK() error
+	Close() error
+}
+
+// A shellRPCCopyWriterTo is the To, Writer/Client side of a CopyTo.
+type shellRPCCopyWriterTo struct {
+	rpcClient pb.ShellService_CopyFilesToMachineClient
+}
+
+func (client shellRPCCopyWriterTo) SendFile(fileDataProto *pb.FileData) error {
+	return client.rpcClient.Send(&pb.CopyFilesToMachineRequest{
+		Request: &pb.CopyFilesToMachineRequest_FileData{
+			FileData: fileDataProto,
+		},
+	})
+}
+
+func (client shellRPCCopyWriterTo) WaitLastACK() error {
+	_, err := client.rpcClient.Recv()
+	return err
+}
+
+func (client shellRPCCopyWriterTo) Close() error {
+	return client.rpcClient.CloseSend()
+}
+
+// A shellRPCCopyWriterFrom is the From, Writer/Server side of a CopyFrom.
+type shellRPCCopyWriterFrom struct {
+	rpcServer pb.ShellService_CopyFilesFromMachineServer
+}
+
+func (srv shellRPCCopyWriterFrom) SendFile(fileDataProto *pb.FileData) error {
+	return srv.rpcServer.Send(&pb.CopyFilesFromMachineResponse{
+		Response: &pb.CopyFilesFromMachineResponse_FileData{
+			FileData: fileDataProto,
+		},
+	})
+}
+
+func (srv shellRPCCopyWriterFrom) WaitLastACK() error {
+	_, err := srv.rpcServer.Recv()
+	return err
+}
+
+func (srv shellRPCCopyWriterFrom) Close() error {
+	return nil
+}
+
+// A shellFileCopyWriter wraps a shellRPCCopyWriter and handles streaming a file over
+// RPC to the other side. It tries to send as large packets as possible but under the
+// limits imposed by RPC.
+type shellFileCopyWriter struct {
+	singleWriterMu sync.Mutex
+	rpc            shellRPCCopyWriter
+	buf            []byte
+	preserve       bool
+}
+
+func newShellRPCFileCopier(rpcWriter shellRPCCopyWriter, preserve bool) FileCopier {
+	return &shellFileCopyWriter{
+		rpc:      rpcWriter,
+		buf:      make([]byte, rpc.MaxMessageSize>>1),
+		preserve: preserve,
+	}
+}
+
+var _ = FileCopier(&shellFileCopyWriter{})
+
+func (writer *shellFileCopyWriter) Copy(ctx context.Context, file File) error {
+	writer.singleWriterMu.Lock()
+	defer writer.singleWriterMu.Unlock()
+
+	defer func() {
+		utils.UncheckedError(file.Data.Close())
+	}()
+	fileInfo, err := file.Data.Stat()
+	if err != nil {
+		return err
+	}
+
+	firstFileDataProto := true
+	var isEOF bool
+	for !isEOF {
+		var fileDataProto pb.FileData
+
+		if fileInfo.IsDir() {
+			isEOF = true
+		} else {
+			n, readErr := file.Data.Read(writer.buf)
+			if readErr != nil {
+				if !errors.Is(readErr, io.EOF) {
+					return readErr
+				}
+				isEOF = true
+			}
+			isEOF = isEOF || n == 0
+			fileDataProto.Data = writer.buf[:n]
+		}
+		fileDataProto.Eof = isEOF
+
+		if firstFileDataProto {
+			firstFileDataProto = false
+			// no reason to keep sending after this it with current protocol
+			fileDataProto.Name = file.RelativeName
+			fileDataProto.IsDir = fileInfo.IsDir()
+			fileDataProto.Size = fileInfo.Size()
+			if writer.preserve {
+				// Note(erd): maybe support access time in the future if needed
+				mode := uint32(fileInfo.Mode())
+				fileDataProto.Mode = &mode
+				fileDataProto.ModTime = timestamppb.New(fileInfo.ModTime())
+			}
+		}
+		if err := writer.rpc.SendFile(&fileDataProto); err != nil {
+			return err
+		}
+		if !isEOF {
+			continue
+		}
+		if err := writer.rpc.WaitLastACK(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (writer *shellFileCopyWriter) Close(ctx context.Context) error {
+	writer.singleWriterMu.Lock()
+	defer writer.singleWriterMu.Unlock()
+
+	return writer.rpc.Close()
+}

--- a/services/shell/copy_rpc_test.go
+++ b/services/shell/copy_rpc_test.go
@@ -1,0 +1,330 @@
+package shell
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	pb "go.viam.com/api/service/shell/v1"
+	"go.viam.com/test"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	shelltestutils "go.viam.com/rdk/services/shell/testutils"
+)
+
+func TestShellRPCFileReadCopier(t *testing.T) {
+	t.Run("no files", func(t *testing.T) {
+		memCopier := inMemoryFileCopier{
+			files: map[string]copiedFile{},
+		}
+		memReader := inMemoryRPCCopyReader{}
+		readCopier := newShellRPCFileReadCopier(&memReader, &memCopier)
+		test.That(t, readCopier.ReadAll(context.Background()), test.ShouldBeNil)
+		test.That(t, readCopier.Close(context.Background()), test.ShouldBeNil)
+		test.That(t, memReader.closeCalled, test.ShouldEqual, 1)
+	})
+
+	modTime := time.Unix(time.Now().Unix(), 0).UTC()
+	mode := uint32(0o222)
+	smallFile := []*pb.FileData{
+		{
+			Name:    "small_file",
+			Size:    25,
+			Data:    bytes.Repeat([]byte{'a'}, 20),
+			ModTime: timestamppb.New(modTime),
+			Mode:    &mode,
+		},
+		{
+			Data: bytes.Repeat([]byte{'b'}, 5),
+		},
+		{
+			Eof: true,
+		},
+	}
+
+	t.Run("single small file", func(t *testing.T) {
+		memCopier := inMemoryFileCopier{
+			files: map[string]copiedFile{},
+		}
+		memReader := inMemoryRPCCopyReader{
+			fileDatas: smallFile,
+		}
+		readCopier := newShellRPCFileReadCopier(&memReader, &memCopier)
+		test.That(t, readCopier.ReadAll(context.Background()), test.ShouldBeNil)
+		test.That(t, readCopier.Close(context.Background()), test.ShouldBeNil)
+		test.That(t, memReader.ackCalled, test.ShouldEqual, 1)
+		test.That(t, memReader.closeCalled, test.ShouldEqual, 1)
+		test.That(t, memCopier.files, test.ShouldResemble, map[string]copiedFile{
+			"small_file": {
+				name:  "small_file",
+				data:  bytes.Join([][]byte{smallFile[0].Data, smallFile[1].Data}, nil),
+				mtime: modTime,
+				mode:  mode,
+			},
+		})
+	})
+
+	t.Run("single small file incomplete", func(t *testing.T) {
+		memCopier := inMemoryFileCopier{
+			files: map[string]copiedFile{},
+		}
+		memReader := inMemoryRPCCopyReader{
+			fileDatas: smallFile[:1],
+		}
+		readCopier := newShellRPCFileReadCopier(&memReader, &memCopier)
+		test.That(t, readCopier.ReadAll(context.Background()), test.ShouldBeNil)
+		test.That(t, readCopier.Close(context.Background()), test.ShouldBeNil)
+		test.That(t, memReader.ackCalled, test.ShouldEqual, 0)
+		test.That(t, memReader.closeCalled, test.ShouldEqual, 1)
+		test.That(t, memCopier.files, test.ShouldBeEmpty)
+	})
+
+	t.Run("single small file duplicate info", func(t *testing.T) {
+		memCopier := inMemoryFileCopier{
+			files: map[string]copiedFile{},
+		}
+		memReader := inMemoryRPCCopyReader{
+			fileDatas: []*pb.FileData{smallFile[0], smallFile[0]},
+		}
+		readCopier := newShellRPCFileReadCopier(&memReader, &memCopier)
+		err := readCopier.ReadAll(context.Background())
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "unexpected file name")
+	})
+
+	otherModTime := time.Unix(time.Now().Unix(), 0).UTC()
+	otherMode := uint32(0o333)
+	otherSmallFile := []*pb.FileData{
+		{
+			Name:    "other_file",
+			Size:    250,
+			Data:    bytes.Repeat([]byte{'c'}, 200),
+			ModTime: timestamppb.New(otherModTime),
+			Mode:    &otherMode,
+		},
+		{
+			Data: bytes.Repeat([]byte{'d'}, 50),
+		},
+		{
+			Eof: true,
+		},
+	}
+
+	t.Run("multiple files", func(t *testing.T) {
+		memCopier := inMemoryFileCopier{
+			files: map[string]copiedFile{},
+		}
+		var datas []*pb.FileData
+		datas = append(datas, smallFile...)
+		datas = append(datas, otherSmallFile...)
+		memReader := inMemoryRPCCopyReader{
+			fileDatas: datas,
+		}
+		readCopier := newShellRPCFileReadCopier(&memReader, &memCopier)
+		test.That(t, readCopier.ReadAll(context.Background()), test.ShouldBeNil)
+		test.That(t, readCopier.Close(context.Background()), test.ShouldBeNil)
+		test.That(t, memReader.ackCalled, test.ShouldEqual, 2)
+		test.That(t, memReader.closeCalled, test.ShouldEqual, 1)
+		test.That(t, memCopier.files, test.ShouldResemble, map[string]copiedFile{
+			"small_file": {
+				name:  "small_file",
+				data:  bytes.Join([][]byte{smallFile[0].Data, smallFile[1].Data}, nil),
+				mtime: modTime,
+				mode:  mode,
+			},
+			"other_file": {
+				name:  "other_file",
+				data:  bytes.Join([][]byte{otherSmallFile[0].Data, otherSmallFile[1].Data}, nil),
+				mtime: otherModTime,
+				mode:  otherMode,
+			},
+		})
+	})
+}
+
+func TestShellRPCFileCopier(t *testing.T) {
+	t.Run("no files", func(t *testing.T) {
+		memWriter := inMemoryRPCCopyWriter{}
+
+		copier := newShellRPCFileCopier(&memWriter, false)
+		test.That(t, copier.Close(context.Background()), test.ShouldBeNil)
+		test.That(t, memWriter.ackCalled, test.ShouldEqual, 0)
+		test.That(t, memWriter.closeCalled, test.ShouldEqual, 1)
+	})
+
+	tfs := shelltestutils.SetupTestFileSystem(t, strings.Repeat("a", 1<<8))
+	beforeInfo, err := os.Stat(tfs.SingleFileNested)
+	test.That(t, err, test.ShouldBeNil)
+	newMode := os.FileMode(0o444)
+	test.That(t, beforeInfo.Mode(), test.ShouldNotEqual, newMode)
+	test.That(t, os.Chmod(tfs.SingleFileNested, newMode), test.ShouldBeNil)
+	modTime := time.Date(1988, 1, 2, 3, 0, 0, 0, time.UTC)
+	test.That(t, os.Chtimes(tfs.SingleFileNested, time.Time{}, modTime), test.ShouldBeNil)
+
+	t.Run("single file", func(t *testing.T) {
+		for _, preserve := range []bool{false, true} {
+			t.Run(fmt.Sprintf("preserve=%t", preserve), func(t *testing.T) {
+				file, err := os.Open(tfs.SingleFileNested)
+				test.That(t, err, test.ShouldBeNil)
+
+				shellFile := File{
+					RelativeName: "this/is_a_file",
+					Data:         file,
+				}
+
+				memWriter := inMemoryRPCCopyWriter{}
+				copier := newShellRPCFileCopier(&memWriter, preserve)
+				test.That(t, copier.Copy(context.Background(), shellFile), test.ShouldBeNil)
+				test.That(t, copier.Close(context.Background()), test.ShouldBeNil)
+				test.That(t, memWriter.ackCalled, test.ShouldEqual, 1)
+				test.That(t, memWriter.closeCalled, test.ShouldEqual, 1)
+				test.That(t, memWriter.fileDatas[0].Name, test.ShouldEqual, shellFile.RelativeName)
+				test.That(t, memWriter.fileDatas[0].Eof, test.ShouldBeFalse)
+
+				if preserve {
+					test.That(t, memWriter.fileDatas[0].ModTime, test.ShouldNotBeNil)
+					test.That(t, memWriter.fileDatas[0].Mode, test.ShouldNotBeNil)
+					test.That(t, memWriter.fileDatas[0].ModTime.AsTime().String(), test.ShouldEqual, modTime.String())
+					test.That(t, fs.FileMode(*memWriter.fileDatas[0].Mode), test.ShouldEqual, newMode)
+				} else {
+					test.That(t, memWriter.fileDatas[0].ModTime, test.ShouldBeNil)
+					test.That(t, memWriter.fileDatas[0].Mode, test.ShouldBeNil)
+				}
+
+				test.That(t, len(memWriter.fileDatas), test.ShouldEqual, 6)
+				test.That(t, memWriter.fileDatas[1].Name, test.ShouldBeEmpty)
+				test.That(t, memWriter.fileDatas[1].Eof, test.ShouldBeFalse)
+				test.That(t, memWriter.fileDatas[len(memWriter.fileDatas)-1].Data, test.ShouldHaveLength, 0)
+				test.That(t, memWriter.fileDatas[len(memWriter.fileDatas)-1].Eof, test.ShouldBeTrue)
+			})
+		}
+	})
+
+	t.Run("multiple files", func(t *testing.T) {
+		file1, err := os.Open(tfs.SingleFileNested)
+		test.That(t, err, test.ShouldBeNil)
+		file2, err := os.Open(tfs.InnerDir)
+		test.That(t, err, test.ShouldBeNil)
+		shellFile1 := File{
+			RelativeName: "this/is_a_file",
+			Data:         file1,
+		}
+		shellFile2 := File{
+			RelativeName: "another/file",
+			Data:         file2,
+		}
+
+		memWriter := inMemoryRPCCopyWriter{}
+		copier := newShellRPCFileCopier(&memWriter, false)
+		test.That(t, copier.Copy(context.Background(), shellFile1), test.ShouldBeNil)
+		test.That(t, memWriter.ackCalled, test.ShouldEqual, 1)
+		test.That(t, copier.Copy(context.Background(), shellFile2), test.ShouldBeNil)
+		test.That(t, memWriter.ackCalled, test.ShouldEqual, 2)
+		test.That(t, copier.Close(context.Background()), test.ShouldBeNil)
+		test.That(t, memWriter.ackCalled, test.ShouldEqual, 2)
+		test.That(t, memWriter.closeCalled, test.ShouldEqual, 1)
+
+		test.That(t, memWriter.fileDatas[0].Name, test.ShouldEqual, shellFile1.RelativeName)
+		test.That(t, memWriter.fileDatas[0].Eof, test.ShouldBeFalse)
+		test.That(t, memWriter.fileDatas[0].IsDir, test.ShouldBeFalse)
+		test.That(t, len(memWriter.fileDatas), test.ShouldEqual, 7)
+		test.That(t, memWriter.fileDatas[1].Name, test.ShouldBeEmpty)
+		test.That(t, memWriter.fileDatas[1].Eof, test.ShouldBeFalse)
+		test.That(t, memWriter.fileDatas[5].Data, test.ShouldHaveLength, 0)
+		test.That(t, memWriter.fileDatas[5].Eof, test.ShouldBeTrue)
+
+		// directory is 0 bytes so EOF
+		test.That(t, memWriter.fileDatas[6].Name, test.ShouldEqual, shellFile2.RelativeName)
+		test.That(t, memWriter.fileDatas[6].Eof, test.ShouldBeTrue)
+		test.That(t, memWriter.fileDatas[6].IsDir, test.ShouldBeTrue)
+	})
+}
+
+type inMemoryRPCCopyWriter struct {
+	fileDatas   []*pb.FileData
+	ackCalled   int
+	closeCalled int
+}
+
+func (mem *inMemoryRPCCopyWriter) SendFile(fileDataProto *pb.FileData) error {
+	mem.fileDatas = append(mem.fileDatas, fileDataProto)
+	return nil
+}
+
+func (mem *inMemoryRPCCopyWriter) WaitLastACK() error {
+	mem.ackCalled++
+	return nil
+}
+
+func (mem *inMemoryRPCCopyWriter) Close() error {
+	mem.closeCalled++
+	return nil
+}
+
+type inMemoryRPCCopyReader struct {
+	fileDatas   []*pb.FileData
+	ackCalled   int
+	closeCalled int
+}
+
+func (mem *inMemoryRPCCopyReader) NextFileData() (*pb.FileData, error) {
+	if len(mem.fileDatas) == 0 {
+		return nil, io.EOF
+	}
+	next := mem.fileDatas[0]
+	mem.fileDatas = mem.fileDatas[1:]
+	return next, nil
+}
+
+func (mem *inMemoryRPCCopyReader) AckLastFile() error {
+	mem.ackCalled++
+	return nil
+}
+
+func (mem *inMemoryRPCCopyReader) Close() error {
+	mem.closeCalled++
+	return nil
+}
+
+type copiedFile struct {
+	name  string
+	data  []byte
+	mode  uint32
+	mtime time.Time
+}
+
+type inMemoryFileCopier struct {
+	files map[string]copiedFile
+}
+
+func (mem *inMemoryFileCopier) Copy(ctx context.Context, file File) error {
+	var buf bytes.Buffer
+	n, err := io.Copy(&buf, file.Data)
+	if err != nil {
+		return err
+	}
+	info, err := file.Data.Stat()
+	if err != nil {
+		return err
+	}
+	if info.Size() != n {
+		return fmt.Errorf("size mismatch %d!=%d (read)", info.Size(), n)
+	}
+	mem.files[file.RelativeName] = copiedFile{
+		name:  file.RelativeName,
+		data:  buf.Bytes(),
+		mode:  uint32(info.Mode()),
+		mtime: info.ModTime(),
+	}
+	return nil
+}
+
+func (mem *inMemoryFileCopier) Close(ctx context.Context) error {
+	return nil
+}

--- a/services/shell/copy_test.go
+++ b/services/shell/copy_test.go
@@ -1,0 +1,20 @@
+package shell
+
+import (
+	"testing"
+
+	"go.viam.com/test"
+)
+
+func TestCopyFilesSourceTypeProtoRoundTrip(t *testing.T) {
+	for _, tc := range []CopyFilesSourceType{
+		CopyFilesSourceTypeSingleFile,
+		CopyFilesSourceTypeSingleDirectory,
+		CopyFilesSourceTypeMultipleFiles,
+		CopyFilesSourceTypeMultipleUnknown,
+	} {
+		t.Run(tc.String(), func(t *testing.T) {
+			test.That(t, CopyFilesSourceTypeFromProto(tc.ToProto()), test.ShouldEqual, tc)
+		})
+	}
+}

--- a/services/shell/server.go
+++ b/services/shell/server.go
@@ -8,7 +8,7 @@ import (
 	"go.uber.org/multierr"
 	commonpb "go.viam.com/api/common/v1"
 	pb "go.viam.com/api/service/shell/v1"
-	goutils "go.viam.com/utils"
+	"go.viam.com/utils"
 
 	"go.viam.com/rdk/protoutils"
 	"go.viam.com/rdk/resource"
@@ -45,7 +45,7 @@ func (server *serviceServer) Shell(srv pb.ShellService_ShellServer) (retErr erro
 		retErr = multierr.Combine(retErr, <-inDone)
 	}()
 
-	goutils.PanicCapturingGo(func() {
+	utils.PanicCapturingGo(func() {
 		defer close(inDone)
 
 		for {
@@ -119,6 +119,72 @@ func (server *serviceServer) Shell(srv pb.ShellService_ShellServer) (retErr erro
 			return srv.Context().Err()
 		}
 	}
+}
+
+// CopyFilesToMachine is the server side RPC implementation of copying files to a machine.
+// It'll receive the initial metadata of the request, call the underlying service's CopyFilesToMachine
+// method, and forward files to its FileCopier via an RPC based FileReadCopier.
+func (server *serviceServer) CopyFilesToMachine(srv pb.ShellService_CopyFilesToMachineServer) error {
+	mdReq, err := srv.Recv()
+	if err != nil {
+		return err
+	}
+	md, ok := mdReq.Request.(*pb.CopyFilesToMachineRequest_Metadata)
+	if !ok {
+		return errors.New("expected copy request metadata")
+	}
+	svc, err := server.coll.Resource(md.Metadata.Name)
+	if err != nil {
+		return err
+	}
+	fileCopier, err := svc.CopyFilesToMachine(
+		srv.Context(),
+		CopyFilesSourceTypeFromProto(md.Metadata.SourceType),
+		md.Metadata.Destination,
+		md.Metadata.Preserve,
+		md.Metadata.Extra.AsMap())
+	if err != nil {
+		return err
+	}
+	defer func() {
+		utils.UncheckedError(fileCopier.Close(srv.Context()))
+	}()
+
+	// create a FileCopyReader that has a Read/Copy pipeline of:
+	// CopyFilesToMachineClient->ShellRPCFileReadCopier->copier
+	// ShellRPCFileReadCopier does the heavy lifting for us by handling fragmentation
+	// and ordering of files coming in.
+	reader := newShellRPCFileReadCopier(shellRPCCopyReaderTo{srv}, fileCopier)
+	defer func() {
+		utils.UncheckedError(reader.Close(srv.Context()))
+	}()
+	return reader.ReadAll(srv.Context())
+}
+
+// CopyFilesFromMachine is the server side RPC implementation of copying files from a machine.
+// It'll receive the initial metadata of the request, call the underlying service's CopyFilesFromMachine
+// and allow it to copy files into the RPC based FileCopier connected to the calling client.
+func (server *serviceServer) CopyFilesFromMachine(srv pb.ShellService_CopyFilesFromMachineServer) error {
+	mdReq, err := srv.Recv()
+	if err != nil {
+		return err
+	}
+	md, ok := mdReq.Request.(*pb.CopyFilesFromMachineRequest_Metadata)
+	if !ok {
+		return errors.New("expected copy request metadata")
+	}
+	svc, err := server.coll.Resource(md.Metadata.Name)
+	if err != nil {
+		return err
+	}
+
+	return svc.CopyFilesFromMachine(
+		srv.Context(),
+		md.Metadata.Paths,
+		md.Metadata.AllowRecursion,
+		md.Metadata.Preserve,
+		newCopyFileFromMachineFactory(srv, md.Metadata.Preserve),
+		md.Metadata.Extra.AsMap())
 }
 
 // DoCommand receives arbitrary commands.

--- a/services/shell/shell.go
+++ b/services/shell/shell.go
@@ -23,6 +23,34 @@ type Service interface {
 	resource.Resource
 	Shell(ctx context.Context, extra map[string]interface{}) (
 		input chan<- string, oobInput chan<- map[string]interface{}, output <-chan Output, retErr error)
+
+	// CopyFilesToMachines copies a stream of files from a client to the connected-to machine.
+	// Initially, metadata is sent to describe the destination in the filesystem in addition
+	// to what kind of file(s) are being sent. A FileCopier is returned that can be used
+	// to copy files one by one-by-one. When files are done being copied, the returned FileCopier
+	// MUST be closed. Returning a FileCopier over passing in the files was chosen so as to promote
+	// the streaming of files, less copies of memory, and less open files.
+	CopyFilesToMachine(
+		ctx context.Context,
+		sourceType CopyFilesSourceType,
+		destination string,
+		preserve bool,
+		extra map[string]interface{},
+	) (FileCopier, error)
+
+	// CopyFilesFromMachine copies a stream of files from a connected-to machine to the calling client.
+	// Essentially, it is the inverse of CopyFilesToMachine. The FileCopyFactory passed in will be
+	// called once the service knows what kinds of files are being transmitted and that FileCopier
+	// will be passed all the files to be copied one-by-one. The method will return once all files
+	// are copied or an error happens in between.
+	CopyFilesFromMachine(
+		ctx context.Context,
+		paths []string,
+		allowRecursion bool,
+		preserve bool,
+		copyFactory FileCopyFactory,
+		extra map[string]interface{},
+	) error
 }
 
 // Output reflects an instance of shell output on either stdout or stderr.

--- a/services/shell/testutils/utils.go
+++ b/services/shell/testutils/utils.go
@@ -1,0 +1,166 @@
+// Package shelltestutils contains test utilities for working with the shell service
+// like test file system directories and comparison tools.
+package shelltestutils
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.viam.com/test"
+	"go.viam.com/utils"
+)
+
+// DirectoryContentsEqual checks if the directory contents on the left and right are equal,
+// excluding metadata (atime, mtime, mode, etc.)
+//
+//nolint:gosec // for testing
+func DirectoryContentsEqual(leftRoot, rightRoot string) error {
+	traverseAndGather := func(root string) (map[string]*os.File, error) {
+		files := map[string]*os.File{}
+
+		var traverseAndGatherInner func(relDir, currentDir string) error
+		traverseAndGatherInner = func(relDir, currentDir string) error {
+			entries, err := os.ReadDir(currentDir)
+			if err != nil {
+				return err
+			}
+
+			for _, entry := range entries {
+				entryPath := filepath.Join(currentDir, entry.Name())
+				relPath := filepath.Join(relDir, entry.Name())
+				file, err := os.Open(entryPath)
+				if err != nil {
+					return err
+				}
+				info, err := file.Stat()
+				if err != nil {
+					return err
+				}
+				if info.IsDir() {
+					if err := traverseAndGatherInner(relPath, entryPath); err != nil {
+						return err
+					}
+				}
+				files[relPath] = file
+			}
+			return nil
+		}
+		if err := traverseAndGatherInner("", root); err != nil {
+			return nil, err
+		}
+		return files, nil
+	}
+	closeFiles := func(files map[string]*os.File) {
+		for _, file := range files {
+			utils.UncheckedError(file.Close())
+		}
+	}
+
+	leftFiles, err := traverseAndGather(leftRoot)
+	if err != nil {
+		return err
+	}
+	defer closeFiles(leftFiles)
+
+	rightFiles, err := traverseAndGather(rightRoot)
+	if err != nil {
+		return err
+	}
+	defer closeFiles(rightFiles)
+
+	if len(leftFiles) != len(rightFiles) {
+		return fmt.Errorf(
+			"%q has %d files while %q has %d files",
+			leftRoot, len(leftFiles),
+			rightRoot, len(rightFiles),
+		)
+	}
+	for leftFilePath, leftFile := range leftFiles {
+		rightFile, ok := rightFiles[leftFilePath]
+		if !ok {
+			return fmt.Errorf("right does not have %q", leftFilePath)
+		}
+		delete(rightFiles, leftFilePath)
+
+		if filepath.Base(leftFile.Name()) != filepath.Base(rightFile.Name()) {
+			panic(fmt.Errorf("unexpected mismatched name %q, %q", leftFile.Name(), rightFile.Name()))
+		}
+		leftInfo, err := leftFile.Stat()
+		if err != nil {
+			return err
+		}
+		rightInfo, err := rightFile.Stat()
+		if err != nil {
+			return err
+		}
+		if leftInfo.IsDir() != rightInfo.IsDir() {
+			return fmt.Errorf("%q directory/file mismatch", leftFilePath)
+		}
+		if leftInfo.IsDir() {
+			continue
+		}
+		leftRd, err := io.ReadAll(leftFile)
+		if err != nil {
+			return err
+		}
+		rightRd, err := io.ReadAll(rightFile)
+		if err != nil {
+			return err
+		}
+		if !bytes.Equal(leftRd, rightRd) {
+			return fmt.Errorf("%q contents not equal", leftFilePath)
+		}
+	}
+	if len(rightFiles) != 0 {
+		return fmt.Errorf("left does not have the following files %v", rightFiles)
+	}
+	return nil
+}
+
+// TestFileSystemInfo contains information about where the file system is and
+// some various file paths/details.
+type TestFileSystemInfo struct {
+	Root                 string
+	SingleFileNested     string
+	SingleFileNestedData []byte
+	InnerDir             string
+}
+
+// SetupTestFileSystem sets up and returns a test file system for playing around with files. It
+// contains a nested symlinked directory.
+//
+//nolint:gosec
+func SetupTestFileSystem(t *testing.T, prefixData ...string) TestFileSystemInfo {
+	tempStaticDir := t.TempDir()
+	helloFile := filepath.Join(tempStaticDir, "hello")
+	worldFile := filepath.Join(tempStaticDir, "world")
+	emptyDir := filepath.Join(tempStaticDir, "emptydir")
+	innerDir := filepath.Join(tempStaticDir, "inner")
+	innerDirEmptyFile := filepath.Join(innerDir, "file")
+	innerDirExampleFile := filepath.Join(innerDir, "example")
+	tempStaticDirForLinking := t.TempDir()
+	symlinkFile := filepath.Join(tempStaticDirForLinking, "kibby")
+
+	helloFileData := []byte(strings.Repeat(strings.Join(prefixData, "")+"world", 32))
+	test.That(t, os.WriteFile(helloFile, helloFileData, 0o666), test.ShouldBeNil)
+	test.That(t, os.WriteFile(worldFile, nil, 0o644), test.ShouldBeNil)
+	test.That(t, os.Mkdir(emptyDir, 0o750), test.ShouldBeNil)
+	test.That(t, os.Mkdir(innerDir, 0o750), test.ShouldBeNil)
+	test.That(t, os.WriteFile(innerDirEmptyFile, nil, 0o644), test.ShouldBeNil)
+	innerDirExampleFileData := []byte(strings.Repeat(strings.Join(prefixData, "")+"a", 1<<18))
+	test.That(t, os.WriteFile(innerDirExampleFile, innerDirExampleFileData, 0o644), test.ShouldBeNil)
+	test.That(t, os.Symlink(tempStaticDirForLinking, filepath.Join(innerDir, "elsewhere")), test.ShouldBeNil)
+	test.That(t, os.WriteFile(symlinkFile, []byte(strings.Repeat(strings.Join(prefixData, "")+"a", 1<<10)), 0o644), test.ShouldBeNil)
+
+	return TestFileSystemInfo{
+		Root:                 tempStaticDir,
+		SingleFileNested:     innerDirExampleFile,
+		SingleFileNestedData: innerDirExampleFileData,
+		InnerDir:             innerDir,
+	}
+}

--- a/services/shell/testutils/utils_test.go
+++ b/services/shell/testutils/utils_test.go
@@ -1,0 +1,27 @@
+package shelltestutils
+
+import (
+	"testing"
+
+	"go.viam.com/test"
+)
+
+func TestDirectoryContentsEqual(t *testing.T) {
+	tfs := SetupTestFileSystem(t)
+
+	err := DirectoryContentsEqual(tfs.Root, tfs.SingleFileNested)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "not a directory")
+
+	err = DirectoryContentsEqual(tfs.Root, tfs.InnerDir)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "has 8 files")
+	test.That(t, err.Error(), test.ShouldContainSubstring, "has 4 files")
+
+	test.That(t, DirectoryContentsEqual(tfs.Root, tfs.Root), test.ShouldBeNil)
+
+	tfs2 := SetupTestFileSystem(t, "diff")
+	err = DirectoryContentsEqual(tfs.Root, tfs2.Root)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "contents not equal")
+}


### PR DESCRIPTION
This adds bidirectional file copy support (think SCP) for the shell service. Tested this across machines far away for a 100MB transfer. This doesn't have visual file progress support like scp does.

Usage:
Copying to: `viam robot part cp --organization "First's Org" --location "First Location" --robot "r1" --part "r1-main" -r -p ~/Downloads/bar2 machine:~/foo`
Copying from `viam robot part cp --organization "First's Org" --location "First Location" --robot "r1" --part "r1-main" -r -p machine:~/Downloads/bar2 ~/foo`

n.b.: I went through the efforts of playing with `scp -S` under the hood where you can pass your own ssh compliant program to it and it handles all the protocol for you. It would be way less code to write (no proto additions) if we did it that way but it's convoluted in that the cli needs to first parse that we do scp, make a dummy shell script to pipe stdin/out back and forth between the local `scp` <-> go <-> shell rpc <-> viam-server <-> `scp/sftp` (with undocumented flags). It also would print out nice progress messages for free. I got a mostly working prototype with that but it's pretty hard to reasonably catch errors and of course it requires `scp`/`sftp` to be installed (which is likely but still). And a further subnote, it's really easy to have the shell service accept alternate commands to execute other than the shell. I PoC'd a few line change to allow a different command like `htop` and it just works; might be worth adding in the future.