### PR TITLE
[RSDK-7437] check if a pin is already in the names list

### DIFF
--- a/components/board/client.go
+++ b/components/board/client.go
@@ -4,6 +4,7 @@ package board
 import (
 	"context"
 	"math"
+	"slices"
 	"sync"
 	"time"
 
@@ -67,13 +68,7 @@ func NewClientFromConn(
 }
 
 func (c *client) AnalogByName(name string) (Analog, error) {
-	inList := false
-	for _, analog := range c.info.analogNames {
-		if analog == name {
-			inList = true
-		}
-	}
-	if !inList {
+	if !slices.Contains(c.info.analogNames, name) {
 		c.info.analogNames = append(c.info.analogNames, name)
 	}
 	return &analogClient{
@@ -84,13 +79,7 @@ func (c *client) AnalogByName(name string) (Analog, error) {
 }
 
 func (c *client) DigitalInterruptByName(name string) (DigitalInterrupt, error) {
-	inList := false
-	for _, interrupt := range c.info.digitalInterruptNames {
-		if interrupt == name {
-			inList = true
-		}
-	}
-	if !inList {
+	if !slices.Contains(c.info.digitalInterruptNames, name) {
 		c.info.digitalInterruptNames = append(c.info.digitalInterruptNames, name)
 	}
 	return &digitalInterruptClient{

--- a/components/board/client.go
+++ b/components/board/client.go
@@ -67,7 +67,15 @@ func NewClientFromConn(
 }
 
 func (c *client) AnalogByName(name string) (Analog, error) {
-	c.info.analogNames = append(c.info.analogNames, name)
+	inList := false
+	for _, analog := range c.info.analogNames {
+		if analog == name {
+			inList = true
+		}
+	}
+	if !inList {
+		c.info.analogNames = append(c.info.analogNames, name)
+	}
 	return &analogClient{
 		client:     c,
 		boardName:  c.info.name,
@@ -76,7 +84,15 @@ func (c *client) AnalogByName(name string) (Analog, error) {
 }
 
 func (c *client) DigitalInterruptByName(name string) (DigitalInterrupt, error) {
-	c.info.digitalInterruptNames = append(c.info.digitalInterruptNames, name)
+	inList := false
+	for _, interrupt := range c.info.digitalInterruptNames {
+		if interrupt == name {
+			inList = true
+		}
+	}
+	if !inList {
+		c.info.digitalInterruptNames = append(c.info.digitalInterruptNames, name)
+	}
 	return &digitalInterruptClient{
 		client:               c,
 		boardName:            c.info.name,

--- a/components/board/client_test.go
+++ b/components/board/client_test.go
@@ -236,28 +236,11 @@ func TestClientNames(t *testing.T) {
 		client, err := board.NewClientFromConn(ctx, conn, "", board.Named(testBoardName), logger)
 		test.That(t, err, test.ShouldBeNil)
 
-		// AnalogNames Client Tests
-		names := client.AnalogNames()
-		test.That(t, len(names), test.ShouldEqual, 0)
-
-		_, err = client.AnalogByName("analog1client")
-		test.That(t, err, test.ShouldBeNil)
-		names = client.AnalogNames()
-		test.That(t, len(names), test.ShouldEqual, 1)
-		test.That(t, slices.Contains(names, "analog1client"), test.ShouldBeTrue)
-
-		_, err = client.AnalogByName("analog2client")
-		test.That(t, err, test.ShouldBeNil)
-
-		names = client.AnalogNames()
-		test.That(t, len(names), test.ShouldEqual, 2)
-		test.That(t, slices.Contains(names, "analog2client"), test.ShouldBeTrue)
-
-		_, err = client.AnalogByName("analog1client")
-		test.That(t, err, test.ShouldBeNil)
-		names = client.AnalogNames()
-		test.That(t, len(names), test.ShouldEqual, 2)
-		test.That(t, slices.Contains(names, "analog1client"), test.ShouldBeTrue)
+		nameFunc := func(name string) error {
+			_, err = client.AnalogByName(name)
+			return err
+		}
+		testNamesAPI(t, client.AnalogNames, nameFunc, "Analog")
 
 		test.That(t, conn.Close(), test.ShouldBeNil)
 	})
@@ -268,29 +251,38 @@ func TestClientNames(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		client, err := board.NewClientFromConn(ctx, conn, "", board.Named(testBoardName), logger)
 		test.That(t, err, test.ShouldBeNil)
-		// DigitalInterruptNames Client Tests
-		names := client.DigitalInterruptNames()
-		test.That(t, len(names), test.ShouldEqual, 0)
 
-		_, err = client.DigitalInterruptByName("DigitalInterrupt1client")
-		test.That(t, err, test.ShouldBeNil)
-		names = client.DigitalInterruptNames()
-		test.That(t, len(names), test.ShouldEqual, 1)
-		test.That(t, slices.Contains(names, "DigitalInterrupt1client"), test.ShouldBeTrue)
-
-		_, err = client.DigitalInterruptByName("DigitalInterrupt2client")
-		test.That(t, err, test.ShouldBeNil)
-
-		names = client.DigitalInterruptNames()
-		test.That(t, len(names), test.ShouldEqual, 2)
-		test.That(t, slices.Contains(names, "DigitalInterrupt2client"), test.ShouldBeTrue)
-
-		_, err = client.DigitalInterruptByName("DigitalInterrupt1client")
-		test.That(t, err, test.ShouldBeNil)
-		names = client.DigitalInterruptNames()
-		test.That(t, len(names), test.ShouldEqual, 2)
-		test.That(t, slices.Contains(names, "DigitalInterrupt1client"), test.ShouldBeTrue)
-
+		nameFunc := func(name string) error {
+			_, err = client.DigitalInterruptByName(name)
+			return err
+		}
+		testNamesAPI(t, client.DigitalInterruptNames, nameFunc, "DigitalInterrupt")
 		test.That(t, conn.Close(), test.ShouldBeNil)
 	})
+}
+
+func testNamesAPI(t *testing.T, namesFunc func() []string, nameFunc func(string) error, name string) {
+	t.Helper()
+	names := namesFunc()
+	test.That(t, len(names), test.ShouldEqual, 0)
+	name1 := name + "1"
+	err := nameFunc(name1)
+	test.That(t, err, test.ShouldBeNil)
+	names = namesFunc()
+	test.That(t, len(names), test.ShouldEqual, 1)
+	test.That(t, slices.Contains(names, name1), test.ShouldBeTrue)
+
+	name2 := name + "2"
+	err = nameFunc(name2)
+	test.That(t, err, test.ShouldBeNil)
+
+	names = namesFunc()
+	test.That(t, len(names), test.ShouldEqual, 2)
+	test.That(t, slices.Contains(names, name2), test.ShouldBeTrue)
+
+	err = nameFunc(name1)
+	test.That(t, err, test.ShouldBeNil)
+	names = namesFunc()
+	test.That(t, len(names), test.ShouldEqual, 2)
+	test.That(t, slices.Contains(names, name1), test.ShouldBeTrue)
 }

--- a/components/board/client_test.go
+++ b/components/board/client_test.go
@@ -3,6 +3,7 @@ package board_test
 import (
 	"context"
 	"net"
+	"slices"
 	"testing"
 	"time"
 
@@ -216,6 +217,80 @@ func TestWorkingClient(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		testWorkingClient(t, client)
+		test.That(t, conn.Close(), test.ShouldBeNil)
+	})
+}
+
+// these tests validate that for modular boards(which rely on client.go's board interface)
+// we will only add new pins to the cached name lists.
+func TestClientNames(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	injectBoard := &inject.Board{}
+
+	listener, cleanup := setupService(t, injectBoard)
+	defer cleanup()
+	t.Run("test analog names are cached correctly in the client", func(t *testing.T) {
+		ctx := context.Background()
+		conn, err := viamgrpc.Dial(ctx, listener.Addr().String(), logger)
+		test.That(t, err, test.ShouldBeNil)
+		client, err := board.NewClientFromConn(ctx, conn, "", board.Named(testBoardName), logger)
+		test.That(t, err, test.ShouldBeNil)
+
+		// AnalogNames Client Tests
+		names := client.AnalogNames()
+		test.That(t, len(names), test.ShouldEqual, 0)
+
+		_, err = client.AnalogByName("analog1client")
+		test.That(t, err, test.ShouldBeNil)
+		names = client.AnalogNames()
+		test.That(t, len(names), test.ShouldEqual, 1)
+		test.That(t, slices.Contains(names, "analog1client"), test.ShouldBeTrue)
+
+		_, err = client.AnalogByName("analog2client")
+		test.That(t, err, test.ShouldBeNil)
+
+		names = client.AnalogNames()
+		test.That(t, len(names), test.ShouldEqual, 2)
+		test.That(t, slices.Contains(names, "analog2client"), test.ShouldBeTrue)
+
+		_, err = client.AnalogByName("analog1client")
+		test.That(t, err, test.ShouldBeNil)
+		names = client.AnalogNames()
+		test.That(t, len(names), test.ShouldEqual, 2)
+		test.That(t, slices.Contains(names, "analog1client"), test.ShouldBeTrue)
+
+		test.That(t, conn.Close(), test.ShouldBeNil)
+	})
+
+	t.Run("test interrupt names are cached correctly in the client", func(t *testing.T) {
+		ctx := context.Background()
+		conn, err := viamgrpc.Dial(ctx, listener.Addr().String(), logger)
+		test.That(t, err, test.ShouldBeNil)
+		client, err := board.NewClientFromConn(ctx, conn, "", board.Named(testBoardName), logger)
+		test.That(t, err, test.ShouldBeNil)
+		// DigitalInterruptNames Client Tests
+		names := client.DigitalInterruptNames()
+		test.That(t, len(names), test.ShouldEqual, 0)
+
+		_, err = client.DigitalInterruptByName("DigitalInterrupt1client")
+		test.That(t, err, test.ShouldBeNil)
+		names = client.DigitalInterruptNames()
+		test.That(t, len(names), test.ShouldEqual, 1)
+		test.That(t, slices.Contains(names, "DigitalInterrupt1client"), test.ShouldBeTrue)
+
+		_, err = client.DigitalInterruptByName("DigitalInterrupt2client")
+		test.That(t, err, test.ShouldBeNil)
+
+		names = client.DigitalInterruptNames()
+		test.That(t, len(names), test.ShouldEqual, 2)
+		test.That(t, slices.Contains(names, "DigitalInterrupt2client"), test.ShouldBeTrue)
+
+		_, err = client.DigitalInterruptByName("DigitalInterrupt1client")
+		test.That(t, err, test.ShouldBeNil)
+		names = client.DigitalInterruptNames()
+		test.That(t, len(names), test.ShouldEqual, 2)
+		test.That(t, slices.Contains(names, "DigitalInterrupt1client"), test.ShouldBeTrue)
+
 		test.That(t, conn.Close(), test.ShouldBeNil)
 	})
 }


### PR DESCRIPTION
fixes an issue for modular boards where interrupt and analog names would be readed to the client names list, causing the status stream to grow exponentially.

Intended to be a quick fix as other work is scheduled for modifying the names list. 

Other board implementations appear to already solve this issue, such as [genericlinux](https://github.com/viamrobotics/rdk/blob/6ab84fbccd6cc2e99a781c02b50bb71739035f21/components/board/genericlinux/board.go#L413-L416) looking to see if the interrupt already exists

ticket: https://viam.atlassian.net/browse/RSDK-7437