### PR TITLE
Use StoppableWorkers in some of the robot/ directory

### DIFF
--- a/robot/server/server.go
+++ b/robot/server/server.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -42,26 +41,18 @@ const logTSKey = "log_ts"
 // a robot.Robot as a gRPC server.
 type Server struct {
 	pb.UnimplementedRobotServiceServer
-	robot                   robot.Robot
-	activeBackgroundWorkers sync.WaitGroup
-	cancelCtx               context.Context
-	cancel                  func()
+	robot robot.Robot
 }
 
 // New constructs a gRPC service server for a Robot.
 func New(robot robot.Robot) pb.RobotServiceServer {
-	cancelCtx, cancel := context.WithCancel(context.Background())
 	return &Server{
-		robot:     robot,
-		cancelCtx: cancelCtx,
-		cancel:    cancel,
+		robot: robot,
 	}
 }
 
 // Close cleanly shuts down the server.
 func (s *Server) Close() {
-	s.cancel()
-	s.activeBackgroundWorkers.Wait()
 }
 
 // GetOperations lists all running operations.


### PR DESCRIPTION
I was hoping to do more during the 20% Happy Hour, but this is as far as I got this time.
- In `server.go`, I was surprised that `activeBackgroundWorkers` was never used, and by extension `cancel` and `cancelCtx` weren't either! So, I removed them.
- In `session_manager.go`, I added a `StoppableWorker`  for the pattern it's intended to replace.

No changes to behavior are intended. Everything compiles and the linter is happy, but I haven't tried things more thoroughly than that.