### PR TITLE
RSDK-7326 fix flaky test in builtin navigation service

### DIFF
--- a/services/navigation/builtin/builtin_test.go
+++ b/services/navigation/builtin/builtin_test.go
@@ -1384,11 +1384,11 @@ func TestStartWaypoint(t *testing.T) {
 
 		err := s.ns.AddWaypoint(cancelCtx, geo.NewPoint(1, 2), nil)
 		test.That(t, err, test.ShouldBeNil)
-		err = s.ns.SetMode(cancelCtx, navigation.ModeWaypoint, nil)
-		test.That(t, err, test.ShouldBeNil)
 		wps, err := s.ns.Waypoints(cancelCtx, nil)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, len(wps), test.ShouldEqual, 1)
+		err = s.ns.SetMode(cancelCtx, navigation.ModeWaypoint, nil)
+		test.That(t, err, test.ShouldBeNil)
 
 		for {
 			if cancelCtx.Err() != nil {


### PR DESCRIPTION
This flake was caused by this test checking the length of the waypoints in the nav service after it was set to `waypoint_mode`.  This has been a latent race condition that has existed as long as the test has, but only recently flaked due to a speedup introduced in surfacing the relevant error in motion/builtin.  Checking the length of the waypoint list before starting the motion removes the race and deflakes the test 