### PR TITLE
retry offline errors every thirty seconds

### DIFF
--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -28,8 +28,8 @@ var (
 	InitialWaitTimeMillis = atomic.NewInt32(1000)
 	// RetryExponentialFactor defines the factor by which the retry wait time increases.
 	RetryExponentialFactor = atomic.NewInt32(2)
-	// OfflineWaitTimeSeconds defines the amount of time to wait to retry if the machine is offline
-	OfflineWaitTimeSeconds = atomic.NewInt32(30)
+	// OfflineWaitTimeSeconds defines the amount of time to wait to retry if the machine is offline.
+	OfflineWaitTimeSeconds = atomic.NewInt32(60)
 	maxRetryInterval       = 24 * time.Hour
 )
 
@@ -291,7 +291,7 @@ func exponentialRetry(cancelCtx context.Context, fn func(cancelCtx context.Conte
 
 func isOfflineGRPCError(err error) bool {
 	errStatus := status.Convert(err)
-	return strings.Contains(errStatus.Message(), "connection error")
+	return errStatus.Code() == codes.Unavailable
 }
 
 // isRetryableGRPCError returns true if we should retry syncing and otherwise

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -266,10 +266,10 @@ func (s *syncer) logSyncErrs() {
 func exponentialRetry(cancelCtx context.Context, fn func(cancelCtx context.Context) error) error {
 	// Only create a ticker and enter the retry loop if we actually need to retry.
 	var err error
-	// if err = fn(cancelCtx); err == nil {
-	// 	return nil
-	// }
-	err = errors.New("new error, not offline")
+	if err = fn(cancelCtx); err == nil {
+		return nil
+	}
+
 	// Don't retry non-retryable errors.
 	if !isRetryableGRPCError(err) {
 		return err
@@ -294,7 +294,6 @@ func exponentialRetry(cancelCtx context.Context, fn func(cancelCtx context.Conte
 				// If error, retry with a new nextWait.
 				ticker.Stop()
 				nextWait = getNextWait(nextWait, isOfflineGRPCError(err))
-				fmt.Printf("\n----------isOffline: %s, waiting for %s seconds\n", isOfflineGRPCError(err), nextWait)
 				ticker = time.NewTicker(nextWait)
 				continue
 			}


### PR DESCRIPTION
We have a bug where certain threads can get stuck in an extremely long wait for exponential backoff. This is mostly a problem we encounter with machines that go offline for long periods of time. This fixes that.

~Also, I changed the sleep logic to use `sleep()` instead of `ticker` as, based on reading [docs](https://gobyexample.com/tickers) it seems like this was a funny way of doing a changing sleep. But I'm a fool and should not be trusted on anything related to Go.~

**EDIT: Not changing anything about the ticker! Lessons learned: Always listen to @tahiyasalam!**

**Testing**

I set the number of threads to be 1 and the time interval to be 10 seconds (and added a print statement when it tries to upload).  I then, let it run and in the middle, turned off my wifi. Here are the logs

<img width="1195" alt="Screenshot 2024-05-02 at 5 13 45 PM" src="https://github.com/viamrobotics/rdk/assets/4420609/0fe18c35-4c4b-4814-9064-8dd8d6618514">

Notice that it uploads about every five seconds successfully until the WIFI shuts off, after which it logs only every 10 seconds.

Tested to ensure that exponential still works as expected when it's not an offline bug. 

<img width="1135" alt="Screenshot 2024-05-07 at 3 16 30 PM" src="https://github.com/viamrobotics/rdk/assets/4420609/84d2100a-a477-4007-a163-257c88104953">
