### PR TITLE
RSDK-7370 upload full-static from main and stable

### DIFF
--- a/.github/workflows/full-static.yml
+++ b/.github/workflows/full-static.yml
@@ -14,15 +14,21 @@ on:
         description: a vX.X.X version string to use for file naming
         required: false
         type: string
-  # workflow_call: # todo: add this back when attaching latest/stable
-  #   inputs:
-  #     version:
-  #       description: a channel or version tag for upload
-  #       required: false
-  #       type: string
-  #   secrets:
-  #     GCP_CREDENTIALS:
-  #       required: true
+  workflow_call:
+    inputs:
+      channel:
+        description: a channel for file naming
+        required: false
+        type: choice
+        # test channel is for manual runs
+        options: [latest, stable, test]
+      version:
+        description: a vX.X.X version string to use for file naming
+        required: false
+        type: string
+    secrets:
+      GCP_CREDENTIALS:
+        required: true
 
 jobs:
   full-static:

--- a/.github/workflows/full-static.yml
+++ b/.github/workflows/full-static.yml
@@ -41,7 +41,9 @@ jobs:
       with:
         go-version: '1.21'
 
-    - name: build
+    - name: build js
+      run: make build-web
+    - name: build go
       shell: bash
       run: |
         for goarch in ${{ env.GOARCHES }}; do

--- a/.github/workflows/full-static.yml
+++ b/.github/workflows/full-static.yml
@@ -111,4 +111,7 @@ jobs:
       run: |
         for arch in ${{ env.GOARCHES }}; do
           echo "- $arch https://storage.googleapis.com/${{ env.BUCKET }}/viam-server-${{ inputs.channel }}-static-$arch" >> $GITHUB_STEP_SUMMARY
+          if [ ${{ inputs.version }} ]; then
+            echo "- $arch https://storage.googleapis.com/${{ env.BUCKET }}/viam-server-${{ inputs.channel }}-${{ inputs.version }}-static-$arch" >> $GITHUB_STEP_SUMMARY
+          fi
         done

--- a/.github/workflows/full-static.yml
+++ b/.github/workflows/full-static.yml
@@ -73,7 +73,7 @@ jobs:
       working-directory: ${{ env.BINS_DIR }}
       run: |
         for arch in ${{ env.GOARCHES }}; do
-          mv viam*.$arch viam-server-${{ inputs.channel }}-static-$arch
+          mv viam*-$arch viam-server-${{ inputs.channel }}-static-$arch
         done
 
     - name: copy for channel+version
@@ -82,7 +82,7 @@ jobs:
       working-directory: ${{ env.BINS_DIR }}
       run: |
         for arch in ${{ env.GOARCHES }}; do
-          cp viam*.$arch viam-server-${{ inputs.channel }}-${{ inputs.version }}-static-$arch
+          cp viam*-$arch viam-server-${{ inputs.channel }}-${{ inputs.version }}-static-$arch
         done
 
     - uses: google-github-actions/auth@v2
@@ -103,6 +103,6 @@ jobs:
       if: inputs.channel
       shell: bash
       run: |
-        for arch in arm64 amd64 arm; do
+        for arch in ${{ env.GOARCHES }}; do
           echo "- $arch https://storage.googleapis.com/${{ env.BUCKET }}/viam-server-${{ inputs.channel }}-static-$arch" >> $GITHUB_STEP_SUMMARY
         done

--- a/.github/workflows/full-static.yml
+++ b/.github/workflows/full-static.yml
@@ -19,9 +19,7 @@ on:
       channel:
         description: a channel for file naming
         required: false
-        type: choice
-        # test channel is for manual runs
-        options: [latest, stable, test]
+        type: string # 'choice' not supported in workflow_call
       version:
         description: a vX.X.X version string to use for file naming
         required: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,14 @@ jobs:
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
+  full-static:
+    needs: test
+    uses: viamrobotics/rdk/.github/workflows/full-static.yml@main
+    with:
+      channel: latest
+    secrets:
+      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+
   droid:
     needs: test
     uses: viamrobotics/rdk/.github/workflows/droid.yml@main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,75 +15,75 @@ on:
 # Don't forget to tag back to @main before merge.
 
 jobs:
-  # test:
-  #   uses: viamrobotics/rdk/.github/workflows/test.yml@main
-  #   secrets:
-  #     MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
-  #     DOCKER_PUBLIC_READONLY_PAT: ${{ secrets.DOCKER_PUBLIC_READONLY_PAT }}
+  test:
+    uses: viamrobotics/rdk/.github/workflows/test.yml@main
+    secrets:
+      MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
+      DOCKER_PUBLIC_READONLY_PAT: ${{ secrets.DOCKER_PUBLIC_READONLY_PAT }}
 
-  # appimage:
-  #   needs: test
-  #   uses: viamrobotics/rdk/.github/workflows/appimage.yml@main
-  #   with:
-  #     release_type: 'latest'
-  #   secrets:
-  #     GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+  appimage:
+    needs: test
+    uses: viamrobotics/rdk/.github/workflows/appimage.yml@main
+    with:
+      release_type: 'latest'
+    secrets:
+      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
-  # staticbuild:
-  #   needs: test
-  #   uses: viamrobotics/rdk/.github/workflows/staticbuild.yml@main
-  #   with:
-  #     release_type: 'latest'
-  #   secrets:
-  #     GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+  staticbuild:
+    needs: test
+    uses: viamrobotics/rdk/.github/workflows/staticbuild.yml@main
+    with:
+      release_type: 'latest'
+    secrets:
+      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
   full-static:
-    # needs: test
-    uses: ./.github/workflows/full-static.yml
+    needs: test
+    uses: viamrobotics/rdk/.github/workflows/full-static.yml@main
     with:
       channel: latest
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
-  # droid:
-  #   needs: test
-  #   uses: viamrobotics/rdk/.github/workflows/droid.yml@main
-  #   with:
-  #     release_type: 'latest'
-  #   secrets:
-  #     GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+  droid:
+    needs: test
+    uses: viamrobotics/rdk/.github/workflows/droid.yml@main
+    with:
+      release_type: 'latest'
+    secrets:
+      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
-  # cli:
-  #   uses: viamrobotics/rdk/.github/workflows/cli.yml@main
-  #   with:
-  #     release_type: 'latest'
-  #   secrets:
-  #     GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+  cli:
+    uses: viamrobotics/rdk/.github/workflows/cli.yml@main
+    with:
+      release_type: 'latest'
+    secrets:
+      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
-  # npm_publish:
-  #   uses: viamrobotics/rdk/.github/workflows/npm-publish.yml@main
-  #   needs: test
-  #   secrets:
-  #     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  npm_publish:
+    uses: viamrobotics/rdk/.github/workflows/npm-publish.yml@main
+    needs: test
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  # license_finder:
-  #   uses: viamrobotics/rdk/.github/workflows/license_finder.yml@main
+  license_finder:
+    uses: viamrobotics/rdk/.github/workflows/license_finder.yml@main
 
-  # slack-workflow-status:
-  #   if: ${{ failure() }}
-  #   name: Post Workflow Status To Slack
-  #   needs:
-  #     - test
-  #     - appimage
-  #     - staticbuild
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     actions: 'read'
-  #   steps:
-  #     - name: Slack Workflow Notification
-  #       uses: Gamesight/slack-workflow-status@master
-  #       with:
-  #         repo_token: ${{secrets.GITHUB_TOKEN}}
-  #         slack_webhook_url: ${{secrets.SLACK_WEBHOOK_URL}}
-  #         channel: '#team-devops'
-  #         name: 'Workflow Status'
+  slack-workflow-status:
+    if: ${{ failure() }}
+    name: Post Workflow Status To Slack
+    needs:
+      - test
+      - appimage
+      - staticbuild
+    runs-on: ubuntu-latest
+    permissions:
+      actions: 'read'
+    steps:
+      - name: Slack Workflow Notification
+        uses: Gamesight/slack-workflow-status@master
+        with:
+          repo_token: ${{secrets.GITHUB_TOKEN}}
+          slack_webhook_url: ${{secrets.SLACK_WEBHOOK_URL}}
+          channel: '#team-devops'
+          name: 'Workflow Status'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,75 +15,75 @@ on:
 # Don't forget to tag back to @main before merge.
 
 jobs:
-  test:
-    uses: viamrobotics/rdk/.github/workflows/test.yml@main
-    secrets:
-      MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
-      DOCKER_PUBLIC_READONLY_PAT: ${{ secrets.DOCKER_PUBLIC_READONLY_PAT }}
+  # test:
+  #   uses: viamrobotics/rdk/.github/workflows/test.yml@main
+  #   secrets:
+  #     MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
+  #     DOCKER_PUBLIC_READONLY_PAT: ${{ secrets.DOCKER_PUBLIC_READONLY_PAT }}
 
-  appimage:
-    needs: test
-    uses: viamrobotics/rdk/.github/workflows/appimage.yml@main
-    with:
-      release_type: 'latest'
-    secrets:
-      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+  # appimage:
+  #   needs: test
+  #   uses: viamrobotics/rdk/.github/workflows/appimage.yml@main
+  #   with:
+  #     release_type: 'latest'
+  #   secrets:
+  #     GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
-  staticbuild:
-    needs: test
-    uses: viamrobotics/rdk/.github/workflows/staticbuild.yml@main
-    with:
-      release_type: 'latest'
-    secrets:
-      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+  # staticbuild:
+  #   needs: test
+  #   uses: viamrobotics/rdk/.github/workflows/staticbuild.yml@main
+  #   with:
+  #     release_type: 'latest'
+  #   secrets:
+  #     GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
   full-static:
-    needs: test
-    uses: viamrobotics/rdk/.github/workflows/full-static.yml@main
+    # needs: test
+    uses: ./.github/workflows/full-static.yml
     with:
       channel: latest
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
-  droid:
-    needs: test
-    uses: viamrobotics/rdk/.github/workflows/droid.yml@main
-    with:
-      release_type: 'latest'
-    secrets:
-      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+  # droid:
+  #   needs: test
+  #   uses: viamrobotics/rdk/.github/workflows/droid.yml@main
+  #   with:
+  #     release_type: 'latest'
+  #   secrets:
+  #     GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
-  cli:
-    uses: viamrobotics/rdk/.github/workflows/cli.yml@main
-    with:
-      release_type: 'latest'
-    secrets:
-      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+  # cli:
+  #   uses: viamrobotics/rdk/.github/workflows/cli.yml@main
+  #   with:
+  #     release_type: 'latest'
+  #   secrets:
+  #     GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
-  npm_publish:
-    uses: viamrobotics/rdk/.github/workflows/npm-publish.yml@main
-    needs: test
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  # npm_publish:
+  #   uses: viamrobotics/rdk/.github/workflows/npm-publish.yml@main
+  #   needs: test
+  #   secrets:
+  #     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  license_finder:
-    uses: viamrobotics/rdk/.github/workflows/license_finder.yml@main
+  # license_finder:
+  #   uses: viamrobotics/rdk/.github/workflows/license_finder.yml@main
 
-  slack-workflow-status:
-    if: ${{ failure() }}
-    name: Post Workflow Status To Slack
-    needs:
-      - test
-      - appimage
-      - staticbuild
-    runs-on: ubuntu-latest
-    permissions:
-      actions: 'read'
-    steps:
-      - name: Slack Workflow Notification
-        uses: Gamesight/slack-workflow-status@master
-        with:
-          repo_token: ${{secrets.GITHUB_TOKEN}}
-          slack_webhook_url: ${{secrets.SLACK_WEBHOOK_URL}}
-          channel: '#team-devops'
-          name: 'Workflow Status'
+  # slack-workflow-status:
+  #   if: ${{ failure() }}
+  #   name: Post Workflow Status To Slack
+  #   needs:
+  #     - test
+  #     - appimage
+  #     - staticbuild
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     actions: 'read'
+  #   steps:
+  #     - name: Slack Workflow Notification
+  #       uses: Gamesight/slack-workflow-status@master
+  #       with:
+  #         repo_token: ${{secrets.GITHUB_TOKEN}}
+  #         slack_webhook_url: ${{secrets.SLACK_WEBHOOK_URL}}
+  #         channel: '#team-devops'
+  #         name: 'Workflow Status'

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -35,6 +35,15 @@ jobs:
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
+  full-static:
+    needs: test
+    uses: viamrobotics/rdk/.github/workflows/full-static.yml@main
+    with:
+      channel: stable
+      version: ${{ github.ref_name }}
+    secrets:
+      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+
   droid:
     needs: test
     uses: viamrobotics/rdk/.github/workflows/droid.yml@main


### PR DESCRIPTION
## What changed
- call the new full-static.yml from 'main' and 'stable' workflows
## Why
These full-static binaries are more portable than our existing static build, at the cost of fewer features.
## Runs
- inside main.yml https://github.com/viamrobotics/rdk/actions/runs/8930990933
- example with channel and version https://github.com/viamrobotics/rdk/actions/runs/8930977917
## Checklist
- [x] make sure this doesn't overwrite existing filenames in GCP bucket