### PR TITLE
Remove triggerConfig from remote robot tests and add documentation

### DIFF
--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -493,7 +493,9 @@ func newWithResources(
 			case <-closeCtx.Done():
 				return
 			case <-r.configTicker.C:
+				r.logger.CDebugw(ctx, "configuration attempt triggered by ticker")
 			case <-r.triggerConfig:
+				r.logger.CDebugw(ctx, "configuration attempt triggered by remote")
 			}
 			anyChanges := r.manager.updateRemotesResourceNames(closeCtx)
 			if r.manager.anyResourcesNotConfigured() {
@@ -502,6 +504,9 @@ func newWithResources(
 			}
 			if anyChanges {
 				r.updateWeakDependents(ctx)
+				r.logger.CDebugw(ctx, "configuration attempt completed with changes")
+			} else {
+				r.logger.CDebugw(ctx, "configuration attempt completed without changes")
 			}
 		}
 	}, r.activeBackgroundWorkers.Done)

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -228,6 +228,11 @@ func (manager *resourceManager) updateRemoteResourceNames(
 		} else {
 			anythingChanged = true
 		}
+		if anythingChanged {
+			manager.logger.CDebugw(ctx, "remote resource names update completed with changes to resource graph", "remote", remoteName)
+		} else {
+			manager.logger.CDebugw(ctx, "remote resource names update completed with no changes to resource graph", "remote", remoteName)
+		}
 	}
 
 	for resName, isActive := range activeResourceNames {

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -23,7 +23,6 @@ import (
 
 	"go.viam.com/rdk/components/arm"
 	"go.viam.com/rdk/components/arm/fake"
-	"go.viam.com/rdk/components/audioinput"
 	"go.viam.com/rdk/components/base"
 	"go.viam.com/rdk/components/board"
 	"go.viam.com/rdk/components/camera"
@@ -2579,20 +2578,47 @@ func TestStatusServiceUpdate(t *testing.T) {
 }
 
 func TestRemoteRobotsGold(t *testing.T) {
+	// The test tests that the robot is able to start up with an offline robot,
+	// connect to it and depend on its resources when it comes online,
+	// and react appropriately when it goes offline again. If a separate robot
+	// then comes online again at the same address, the robot should be able to
+	// use their resources as well.
+
+	// To do so, the test initially sets up two remote robots, Remote 1 and 2, and then a third remote, Remote 3,
+	// in the following scenario:
+	// 1) Remote 1's server is started.
+	// 2) The local robot is then set up with resources that depend on resources on both Remote 1 and 2. Since
+	//    Remote 2 is not up, it is expected that some resources will not be built or be available.
+	// 3) After initial configuration, Remote 2's server starts up and the local robot should then connect
+	//	  and pick up the new available resources.
+	// 4) Remote 2 goes down, and the local robot should remove any resources or resources that depend on
+	//    resources from Remote 2.
+	// 5) Remote 3 comes online at the same address as Remote 2, and the local robot should treat it the same as
+	//    if Remote 2 came online again and readd all the removed resources.
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(context.Background(), "data/fake.json", logger)
-	test.That(t, err, test.ShouldBeNil)
+	remoteConfig := &config.Config{
+		Components: []resource.Config{
+			{
+				Name:  "remoteArm",
+				Model: resource.DefaultModelFamily.WithModel("fake"),
+				ConvertedAttributes: &fake.Config{
+					ModelFilePath: "../../components/arm/fake/fake_model.json",
+				},
+				API: arm.API,
+			},
+		},
+	}
 
 	ctx := context.Background()
 
-	remote1 := setupLocalRobot(t, ctx, cfg, logger.Sublogger("remote1"))
-
+	// set up and start remote1's web service
+	remote1 := setupLocalRobot(t, ctx, remoteConfig, logger.Sublogger("remote1"))
 	options, _, addr1 := robottestutils.CreateBaseOptionsAndListener(t)
-	err = remote1.StartWeb(ctx, options)
+	err := remote1.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
-	remote2 := setupLocalRobot(t, ctx, cfg, logger.Sublogger("remote2"))
-
+	// set up but do not start remote2's web service
+	remote2 := setupLocalRobot(t, ctx, remoteConfig, logger.Sublogger("remote2"))
 	options, listener2, addr2 := robottestutils.CreateBaseOptionsAndListener(t)
 
 	localConfig := &config.Config{
@@ -2604,7 +2630,7 @@ func TestRemoteRobotsGold(t *testing.T) {
 					ModelFilePath: "../../components/arm/fake/fake_model.json",
 				},
 				API:       arm.API,
-				DependsOn: []string{"foo:pieceGripper"},
+				DependsOn: []string{"foo:remoteArm"},
 			},
 			{
 				Name:  "arm2",
@@ -2613,7 +2639,7 @@ func TestRemoteRobotsGold(t *testing.T) {
 					ModelFilePath: "../../components/arm/fake/fake_model.json",
 				},
 				API:       arm.API,
-				DependsOn: []string{"bar:pieceArm"},
+				DependsOn: []string{"bar:remoteArm"},
 			},
 		},
 		Services: []resource.Config{},
@@ -2638,24 +2664,16 @@ func TestRemoteRobotsGold(t *testing.T) {
 			sensors.Named(resource.DefaultServiceName),
 			datamanager.Named(resource.DefaultServiceName),
 			arm.Named("arm1"),
-			arm.Named("foo:pieceArm"),
-			audioinput.Named("foo:mic1"),
-			camera.Named("foo:cameraOver"),
-			movementsensor.Named("foo:movement_sensor1"),
-			movementsensor.Named("foo:movement_sensor2"),
-			gripper.Named("foo:pieceGripper"),
+			arm.Named("foo:remoteArm"),
 			motion.Named("foo:builtin"),
 			sensors.Named("foo:builtin"),
 			datamanager.Named("foo:builtin"),
 		),
 	)
+
+	// start remote2's web service
 	err = remote2.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
-
-	rr, ok := r.(*localRobot)
-	test.That(t, ok, test.ShouldBeTrue)
-
-	rr.triggerConfig <- struct{}{}
 
 	expectedSet := rdktestutils.NewResourceNameSet(
 		motion.Named(resource.DefaultServiceName),
@@ -2663,21 +2681,11 @@ func TestRemoteRobotsGold(t *testing.T) {
 		datamanager.Named(resource.DefaultServiceName),
 		arm.Named("arm1"),
 		arm.Named("arm2"),
-		arm.Named("foo:pieceArm"),
-		audioinput.Named("foo:mic1"),
-		camera.Named("foo:cameraOver"),
-		movementsensor.Named("foo:movement_sensor1"),
-		movementsensor.Named("foo:movement_sensor2"),
-		gripper.Named("foo:pieceGripper"),
+		arm.Named("foo:remoteArm"),
 		motion.Named("foo:builtin"),
 		sensors.Named("foo:builtin"),
 		datamanager.Named("foo:builtin"),
-		arm.Named("bar:pieceArm"),
-		audioinput.Named("bar:mic1"),
-		camera.Named("bar:cameraOver"),
-		movementsensor.Named("bar:movement_sensor1"),
-		movementsensor.Named("bar:movement_sensor2"),
-		gripper.Named("bar:pieceGripper"),
+		arm.Named("bar:remoteArm"),
 		motion.Named("bar:builtin"),
 		sensors.Named("bar:builtin"),
 		datamanager.Named("bar:builtin"),
@@ -2688,7 +2696,7 @@ func TestRemoteRobotsGold(t *testing.T) {
 	test.That(t, remote2.Close(context.Background()), test.ShouldBeNil)
 
 	// wait for local_robot to detect that the remote is now offline
-	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 600, func(tb testing.TB) {
+	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
 		test.That(
 			tb,
 			rdktestutils.NewResourceNameSet(r.ResourceNames()...),
@@ -2698,12 +2706,7 @@ func TestRemoteRobotsGold(t *testing.T) {
 				sensors.Named(resource.DefaultServiceName),
 				datamanager.Named(resource.DefaultServiceName),
 				arm.Named("arm1"),
-				arm.Named("foo:pieceArm"),
-				audioinput.Named("foo:mic1"),
-				camera.Named("foo:cameraOver"),
-				movementsensor.Named("foo:movement_sensor1"),
-				movementsensor.Named("foo:movement_sensor2"),
-				gripper.Named("foo:pieceGripper"),
+				arm.Named("foo:remoteArm"),
 				motion.Named("foo:builtin"),
 				sensors.Named("foo:builtin"),
 				datamanager.Named("foo:builtin"),
@@ -2711,7 +2714,7 @@ func TestRemoteRobotsGold(t *testing.T) {
 		)
 	})
 
-	remote3 := setupLocalRobot(t, ctx, cfg, logger.Sublogger("remote3"))
+	remote3 := setupLocalRobot(t, ctx, remoteConfig, logger.Sublogger("remote3"))
 
 	// Note: There's a slight chance this test can fail if someone else
 	// claims the port we just released by closing the server.
@@ -2721,19 +2724,15 @@ func TestRemoteRobotsGold(t *testing.T) {
 	err = remote3.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
-	rr, ok = r.(*localRobot)
-	test.That(t, ok, test.ShouldBeTrue)
-
-	rr.triggerConfig <- struct{}{}
-
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
 		test.That(tb, rdktestutils.NewResourceNameSet(r.ResourceNames()...), test.ShouldResemble, expectedSet)
 	})
 }
 
 func TestRemoteRobotsUpdate(t *testing.T) {
+	// The test tests that the robot is able to update when multiple remote robot
+	// updates happen at the same time.
 	logger := logging.NewTestLogger(t)
-	ctx := context.Background()
 	remoteConfig := &config.Config{
 		Components: []resource.Config{
 			{
@@ -2746,7 +2745,7 @@ func TestRemoteRobotsUpdate(t *testing.T) {
 			},
 		},
 	}
-
+	ctx := context.Background()
 	remote := setupLocalRobot(t, ctx, remoteConfig, logger.Sublogger("remote"))
 
 	options, _, addr1 := robottestutils.CreateBaseOptionsAndListener(t)
@@ -2801,11 +2800,6 @@ func TestRemoteRobotsUpdate(t *testing.T) {
 	})
 	test.That(t, remote.Close(context.Background()), test.ShouldBeNil)
 
-	rr, ok := r.(*localRobot)
-	test.That(t, ok, test.ShouldBeTrue)
-
-	rr.triggerConfig <- struct{}{}
-
 	// wait for local_robot to detect that the remote is now offline
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
 		test.That(
@@ -2822,6 +2816,9 @@ func TestRemoteRobotsUpdate(t *testing.T) {
 }
 
 func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
+	// The test tests that the robot is able to infer remote dependencies
+	// if remote name is not part of the specified dependency
+	// and the remote is online at start up.
 	logger := logging.NewTestLogger(t)
 
 	fooCfg := &config.Config{
@@ -2836,9 +2833,7 @@ func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
 			},
 		},
 	}
-
 	ctx := context.Background()
-
 	foo := setupLocalRobot(t, ctx, fooCfg, logger.Sublogger("foo"))
 
 	options, listener1, addr1 := robottestutils.CreateBaseOptionsAndListener(t)
@@ -2865,27 +2860,6 @@ func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
 		},
 	}
 	r := setupLocalRobot(t, ctx, localConfig, logger.Sublogger("local"))
-	test.That(
-		t,
-		rdktestutils.NewResourceNameSet(r.ResourceNames()...),
-		test.ShouldResemble,
-		rdktestutils.NewResourceNameSet(
-			motion.Named(resource.DefaultServiceName),
-			sensors.Named(resource.DefaultServiceName),
-			datamanager.Named(resource.DefaultServiceName),
-			arm.Named("arm1"),
-			arm.Named("foo:pieceArm"),
-			motion.Named("foo:builtin"),
-			sensors.Named("foo:builtin"),
-			datamanager.Named("foo:builtin"),
-		),
-	)
-
-	rr, ok := r.(*localRobot)
-	test.That(t, ok, test.ShouldBeTrue)
-
-	rr.triggerConfig <- struct{}{}
-
 	expectedSet := rdktestutils.NewResourceNameSet(
 		motion.Named(resource.DefaultServiceName),
 		sensors.Named(resource.DefaultServiceName),
@@ -2896,12 +2870,13 @@ func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
 		sensors.Named("foo:builtin"),
 		datamanager.Named("foo:builtin"),
 	)
-
-	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		test.That(tb, rdktestutils.NewResourceNameSet(r.ResourceNames()...), test.ShouldResemble, expectedSet)
-	})
+	test.That(
+		t,
+		rdktestutils.NewResourceNameSet(r.ResourceNames()...),
+		test.ShouldResemble,
+		expectedSet,
+	)
 	test.That(t, foo.Close(context.Background()), test.ShouldBeNil)
-	rr.triggerConfig <- struct{}{}
 
 	// wait for local_robot to detect that the remote is now offline
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
@@ -2927,17 +2902,15 @@ func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
 	err = foo2.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
-	rr, ok = r.(*localRobot)
-	test.That(t, ok, test.ShouldBeTrue)
-
-	rr.triggerConfig <- struct{}{}
-
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
 		test.That(tb, rdktestutils.NewResourceNameSet(r.ResourceNames()...), test.ShouldResemble, expectedSet)
 	})
 }
 
 func TestInferRemoteRobotDependencyConnectAfterStartup(t *testing.T) {
+	// The test tests that the robot is able to infer remote dependencies
+	// if remote name is not part of the specified dependency
+	// and the remote is offline at start up.
 	logger := logging.NewTestLogger(t)
 
 	fooCfg := &config.Config{
@@ -2992,11 +2965,6 @@ func TestInferRemoteRobotDependencyConnectAfterStartup(t *testing.T) {
 	err := foo.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
-	rr, ok := r.(*localRobot)
-	test.That(t, ok, test.ShouldBeTrue)
-
-	rr.triggerConfig <- struct{}{}
-
 	expectedSet := rdktestutils.NewResourceNameSet(
 		motion.Named(resource.DefaultServiceName),
 		sensors.Named(resource.DefaultServiceName),
@@ -3011,7 +2979,6 @@ func TestInferRemoteRobotDependencyConnectAfterStartup(t *testing.T) {
 		test.That(tb, rdktestutils.NewResourceNameSet(r.ResourceNames()...), test.ShouldResemble, expectedSet)
 	})
 	test.That(t, foo.Close(context.Background()), test.ShouldBeNil)
-	rr.triggerConfig <- struct{}{}
 
 	// wait for local_robot to detect that the remote is now offline
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
@@ -3029,6 +2996,9 @@ func TestInferRemoteRobotDependencyConnectAfterStartup(t *testing.T) {
 }
 
 func TestInferRemoteRobotDependencyAmbiguous(t *testing.T) {
+	// The test tests that the robot will not build a resource if the dependency
+	// is ambiguous. In this case, "pieceArm" can refer to both "foo:pieceArm"
+	// and "bar:pieceArm".
 	logger := logging.NewTestLogger(t)
 
 	remoteCfg := &config.Config{
@@ -3098,13 +3068,10 @@ func TestInferRemoteRobotDependencyAmbiguous(t *testing.T) {
 
 	test.That(t, rdktestutils.NewResourceNameSet(r.ResourceNames()...), test.ShouldResemble, expectedSet)
 
-	rr, ok := r.(*localRobot)
-	test.That(t, ok, test.ShouldBeTrue)
-
-	rr.triggerConfig <- struct{}{}
-	time.Sleep(2 * time.Second)
 	// we expect the robot to correctly detect the ambiguous dependency and not build the resource
-	test.That(t, rdktestutils.NewResourceNameSet(r.ResourceNames()...), test.ShouldResemble, expectedSet)
+	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 150, func(tb testing.TB) {
+		test.That(tb, rdktestutils.NewResourceNameSet(r.ResourceNames()...), test.ShouldResemble, expectedSet)
+	})
 
 	// now reconfig with a fully qualified name
 	reConfig := &config.Config{
@@ -3131,7 +3098,6 @@ func TestInferRemoteRobotDependencyAmbiguous(t *testing.T) {
 		},
 	}
 	r.Reconfigure(ctx, reConfig)
-	rr.triggerConfig <- struct{}{}
 
 	finalSet := rdktestutils.NewResourceNameSet(
 		motion.Named(resource.DefaultServiceName),


### PR DESCRIPTION
* Simplifies TestRemoteRobotsGold by creating a smaller config instead of using a file
* Adds clarifying comments around TestRemoteRobotsGold and some other updated tests
* Remove triggerConfig calls from tests (ran it a few times, doesn't seem to change failure rate/time). triggerConfig can make reconfiguration go faster, but only if the remote robot has already re/connected by that point. Calling it immediately does not speed up reconnection and would not improve speed.