### PR TITLE
unbreak no_cgo build

### DIFF
--- a/robot/web/web_notc.go
+++ b/robot/web/web_notc.go
@@ -4,7 +4,6 @@ package web
 
 import (
 	"context"
-	"net/http"
 	"sync"
 
 	"go.viam.com/rdk/logging"


### PR DESCRIPTION
## What changed
- remove unused import
## Why
This broke in a recent commit, but the `no_cgo` tagged build isn't exercised in PRs so it didn't show up until the PR was merged.

To-do later: add a (fast) version of the full-static build in PRs to protect against this.