### PR TITLE
RSDK-7487: Guarantee context cancel errors are not logged after a data collector is `Close`d.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,6 @@ metadata
 # act
 .secrets
 
-/data/
 out/
 .idea/*
 bin/

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ metadata
 # act
 .secrets
 
+/data/
 out/
 .idea/*
 bin/

--- a/data/collector.go
+++ b/data/collector.go
@@ -328,8 +328,9 @@ func (c *collector) logCaptureErrs() {
 	for err := range c.captureErrors {
 		now := c.clock.Now().Unix()
 		if c.closeStarted.Load() {
-			// Don't log context cancellation errors if the collector has already been closed. This means the collector
-			// cancelled the context, and the context cancellation error is expected.
+			// Don't log context cancellation errors if the collector has already been closed. This
+			// means the collector canceled the context, and the context cancellation error is
+			// expected.
 			if errors.Is(err, context.Canceled) {
 				continue
 			}

--- a/data/collector.go
+++ b/data/collector.go
@@ -171,12 +171,6 @@ func (c *collector) sleepBasedCapture(started chan struct{}) {
 
 		select {
 		case <-c.cancelCtx.Done():
-			// Dan: It's unclear to me why this handling differs from the above error handling with
-			// `c.cancelCtx.Err()`. When this case returns, it's guaranteed that `c.cancelCtx.Err()`
-			// is non-nil. The reason why the test passes most of the time is because the above
-			// `c.clock.Sleep` is long enough such that the test's `collector.Close` happens during
-			// the sleep. Reducing the sleep interval to a small value makes it much easier for the
-			// `Context.Err` check to be observed first.
 			captureWorkers.Wait()
 			close(c.captureResults)
 			return

--- a/data/collector.go
+++ b/data/collector.go
@@ -171,6 +171,12 @@ func (c *collector) sleepBasedCapture(started chan struct{}) {
 
 		select {
 		case <-c.cancelCtx.Done():
+			// Dan: It's unclear to me why this handling differs from the above error handling with
+			// `c.cancelCtx.Err()`. When this case returns, it's guaranteed that `c.cancelCtx.Err()`
+			// is non-nil. The reason why the test passes most of the time is because the above
+			// `c.clock.Sleep` is long enough such that the test's `collector.Close` happens during
+			// the sleep. Reducing the sleep interval to a small value makes it much easier for the
+			// `Context.Err` check to be observed first.
 			captureWorkers.Wait()
 			close(c.captureResults)
 			return

--- a/data/collector_test.go
+++ b/data/collector_test.go
@@ -339,7 +339,7 @@ func validateReadings(t *testing.T, act []*v1.SensorData, n int) {
 	}
 }
 
-// nolint
+//nolint
 func getAllFiles(dir string) []os.FileInfo {
 	var files []os.FileInfo
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/data/collector_test.go
+++ b/data/collector_test.go
@@ -264,11 +264,11 @@ func TestCtxCancelledNotLoggedAfterClose(t *testing.T) {
 
 	params := CollectorParams{
 		ComponentName: "testComponent",
-		Interval:      time.Millisecond * 1,
+		Interval:      time.Nanosecond,
 		MethodParams:  map[string]*anypb.Any{"name": fakeVal},
 		Target:        target,
-		QueueSize:     queueSize,
-		BufferSize:    bufferSize,
+		QueueSize:     250,  //queueSize,
+		BufferSize:    4096, //bufferSize,
 		Logger:        logger,
 	}
 	c, _ := NewCollector(errorCapturer, params)
@@ -277,7 +277,11 @@ func TestCtxCancelledNotLoggedAfterClose(t *testing.T) {
 	c.Close()
 	close(captured)
 
-	test.That(t, logs.FilterLevelExact(zapcore.ErrorLevel).Len(), test.ShouldEqual, 0)
+	failedLogs := logs.FilterLevelExact(zapcore.ErrorLevel)
+	if failedLogs.Len() != 0 {
+		fmt.Println("FailedLogs:", failedLogs)
+	}
+	test.That(t, failedLogs.Len(), test.ShouldEqual, 0)
 }
 
 func TestLogErrorsOnlyOnce(t *testing.T) {
@@ -334,7 +338,7 @@ func validateReadings(t *testing.T, act []*v1.SensorData, n int) {
 	}
 }
 
-//nolint
+// nolint
 func getAllFiles(dir string) []os.FileInfo {
 	var files []os.FileInfo
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/data/collector_test.go
+++ b/data/collector_test.go
@@ -264,11 +264,11 @@ func TestCtxCancelledNotLoggedAfterClose(t *testing.T) {
 
 	params := CollectorParams{
 		ComponentName: "testComponent",
-		Interval:      time.Nanosecond,
+		Interval:      time.Millisecond,
 		MethodParams:  map[string]*anypb.Any{"name": fakeVal},
 		Target:        target,
-		QueueSize:     250,  //queueSize,
-		BufferSize:    4096, //bufferSize,
+		QueueSize:     queueSize,
+		BufferSize:    bufferSize,
 		Logger:        logger,
 	}
 	c, _ := NewCollector(errorCapturer, params)
@@ -279,7 +279,8 @@ func TestCtxCancelledNotLoggedAfterClose(t *testing.T) {
 
 	failedLogs := logs.FilterLevelExact(zapcore.ErrorLevel)
 	if failedLogs.Len() != 0 {
-		fmt.Println("FailedLogs:", failedLogs)
+		// The test is going to fail. Output the logs for diagnostics.
+		logger.Error("FailedLogs:", failedLogs)
 	}
 	test.That(t, failedLogs.Len(), test.ShouldEqual, 0)
 }

--- a/data/collector_test.go
+++ b/data/collector_test.go
@@ -245,10 +245,10 @@ func TestClose(t *testing.T) {
 	}
 }
 
-// TestCtxCancelledNotLoggedInTickerBasedCaptureAfterClose verifies that context cancelled errors are not logged if they
-// occur after Close has been called. The collector context is cancelled as part of Close, so we expect to see context
-// cancelled errors for any running capture routines.
-func TestCtxCancelledNotLoggedInTickerBasedCaptureAfterClose(t *testing.T) {
+// TestCtxCancelledNotLoggedAfterClose verifies that context cancelled errors are not logged if they occur after Close
+// has been called. The collector context is cancelled as part of Close, so we expect to see context cancelled errors
+// for any running capture routines.
+func TestCtxCancelledNotLoggedAfterClose(t *testing.T) {
 	logger, logs := logging.NewObservedTestLogger(t)
 	tmpDir := t.TempDir()
 	target := datacapture.NewBuffer(tmpDir, &v1.DataCaptureMetadata{})
@@ -264,15 +264,12 @@ func TestCtxCancelledNotLoggedInTickerBasedCaptureAfterClose(t *testing.T) {
 
 	params := CollectorParams{
 		ComponentName: "testComponent",
-		// Ensure that we use ticker-based capture since capturing at 1000+ Hz
-		// uses a sleep-based capture that may let a context cancelation error
-		// occasionally be logged.
-		Interval:     sleepCaptureCutoff + time.Microsecond,
-		MethodParams: map[string]*anypb.Any{"name": fakeVal},
-		Target:       target,
-		QueueSize:    queueSize,
-		BufferSize:   bufferSize,
-		Logger:       logger,
+		Interval:      time.Millisecond * 1,
+		MethodParams:  map[string]*anypb.Any{"name": fakeVal},
+		Target:        target,
+		QueueSize:     queueSize,
+		BufferSize:    bufferSize,
+		Logger:        logger,
 	}
 	c, _ := NewCollector(errorCapturer, params)
 	c.Collect()


### PR DESCRIPTION
https://github.com/viamrobotics/rdk/commit/2845abe484258d45b20879a755fb9039d764ae72 is a strawman proposal for fixing the `TestCtxCancelledNotLogged...AfterClose` test. The PR here is more to communicate than be exactly what I think we should merge. The other commit in this PR that reverts the prior commit was just from the state my branch happened to be in when I was investigating. It's inclusion here is not a preference one way or the other.

My "fix" being proposed here is the smallest code change I know of that preserves existing behaviors[1] at the cost of introducing more state tracking. This state tracking is an intrinsic consequence of the number of goroutines data collection spins up.

[1] The existing behaviors I am intentionally preserving. I don't think all are particularly valuable, and I think we should consider removing some behaviors such that we can fix this by reducing code rather than adding code.
* Close can continue to be double-called without error.
  * Additionally, if two goroutines race to call close, the "loser" will continue to wait until the winner is finished before returning.
* Logging errors continues to be de-coupled and in its own go-routine from creating errors
* We continue to log "context canceled" errors if the collector was not closed.
  * I'm not convinced this is possible. But if it were to happen, the context canceled error would be logged.