### PR TITLE
RSDK-7512: arm and gripper geometries always returns unimplemented error

### DIFF
--- a/components/arm/server.go
+++ b/components/arm/server.go
@@ -111,7 +111,7 @@ func (s *serviceServer) IsMoving(ctx context.Context, req *pb.IsMovingRequest) (
 	return &pb.IsMovingResponse{IsMoving: moving}, nil
 }
 
-func (s *serviceServer) Geometries(ctx context.Context, req *commonpb.GetGeometriesRequest) (*commonpb.GetGeometriesResponse, error) {
+func (s *serviceServer) GetGeometries(ctx context.Context, req *commonpb.GetGeometriesRequest) (*commonpb.GetGeometriesResponse, error) {
 	res, err := s.coll.Resource(req.GetName())
 	if err != nil {
 		return nil, err

--- a/components/gripper/server.go
+++ b/components/gripper/server.go
@@ -81,7 +81,7 @@ func (s *serviceServer) DoCommand(ctx context.Context,
 	return protoutils.DoFromResourceServer(ctx, gripper, req)
 }
 
-func (s *serviceServer) Geometries(ctx context.Context, req *commonpb.GetGeometriesRequest) (*commonpb.GetGeometriesResponse, error) {
+func (s *serviceServer) GetGeometries(ctx context.Context, req *commonpb.GetGeometriesRequest) (*commonpb.GetGeometriesResponse, error) {
 	res, err := s.coll.Resource(req.GetName())
 	if err != nil {
 		return nil, err

--- a/testutils/inject/arm.go
+++ b/testutils/inject/arm.go
@@ -26,6 +26,7 @@ type Arm struct {
 	ModelFrameFunc           func() referenceframe.Model
 	CurrentInputsFunc        func(ctx context.Context) ([]referenceframe.Input, error)
 	GoToInputsFunc           func(ctx context.Context, inputSteps ...[]referenceframe.Input) error
+	GeometriesFunc           func(ctx context.Context) ([]spatialmath.Geometry, error)
 }
 
 // NewArm returns a new injected arm.
@@ -131,4 +132,12 @@ func (a *Arm) GoToInputs(ctx context.Context, inputSteps ...[]referenceframe.Inp
 		return a.Arm.GoToInputs(ctx, inputSteps...)
 	}
 	return a.GoToInputsFunc(ctx, inputSteps...)
+}
+
+// Geometries returns the gripper's geometries.
+func (a *Arm) Geometries(ctx context.Context, extra map[string]interface{}) ([]spatialmath.Geometry, error) {
+	if a.GeometriesFunc == nil {
+		return a.Arm.Geometries(ctx, extra)
+	}
+	return a.GeometriesFunc(ctx)
 }

--- a/testutils/inject/gripper.go
+++ b/testutils/inject/gripper.go
@@ -5,18 +5,20 @@ import (
 
 	"go.viam.com/rdk/components/gripper"
 	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/spatialmath"
 )
 
 // Gripper is an injected gripper.
 type Gripper struct {
 	gripper.Gripper
-	name         resource.Name
-	DoFunc       func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
-	OpenFunc     func(ctx context.Context, extra map[string]interface{}) error
-	GrabFunc     func(ctx context.Context, extra map[string]interface{}) (bool, error)
-	StopFunc     func(ctx context.Context, extra map[string]interface{}) error
-	IsMovingFunc func(context.Context) (bool, error)
-	CloseFunc    func(ctx context.Context) error
+	name           resource.Name
+	DoFunc         func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
+	OpenFunc       func(ctx context.Context, extra map[string]interface{}) error
+	GrabFunc       func(ctx context.Context, extra map[string]interface{}) (bool, error)
+	StopFunc       func(ctx context.Context, extra map[string]interface{}) error
+	IsMovingFunc   func(context.Context) (bool, error)
+	CloseFunc      func(ctx context.Context) error
+	GeometriesFunc func(ctx context.Context) ([]spatialmath.Geometry, error)
 }
 
 // NewGripper returns a new injected gripper.
@@ -78,4 +80,12 @@ func (g *Gripper) DoCommand(ctx context.Context, cmd map[string]interface{}) (ma
 		return g.Gripper.DoCommand(ctx, cmd)
 	}
 	return g.DoFunc(ctx, cmd)
+}
+
+// Geometries returns the gripper's geometries.
+func (g *Gripper) Geometries(ctx context.Context, extra map[string]interface{}) ([]spatialmath.Geometry, error) {
+	if g.GeometriesFunc == nil {
+		return g.Gripper.Geometries(ctx, extra)
+	}
+	return g.GeometriesFunc(ctx)
 }


### PR DESCRIPTION
not sure if there's a reason these were different, but arm and gripper were always returning unimplemented error when calling `Geometries` from the sdk, but this fixed it