### PR TITLE
RSDK-6804 - Test Datarace: go.viam.com/rdk/module/modmanager.TestDebugModule

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -781,7 +781,6 @@ func (mgr *Manager) newOnUnexpectedExitHandler(mod *module) func(exitCode int) b
 	return func(exitCode int) bool {
 		mod.inRecoveryLock.Lock()
 		defer mod.inRecoveryLock.Unlock()
-
 		if mod.inStartup.Load() {
 			return false
 		}

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -1095,8 +1095,11 @@ func (m *module) stopProcess() error {
 
 	// TODO(RSDK-2551): stop ignoring exit status 143 once Python modules handle
 	// SIGTERM correctly.
-	if err := m.process.Stop(); err != nil &&
-		!strings.Contains(err.Error(), errMessageExitStatus143) {
+	// Also ignore if error is that the process no longer exists.
+	if err := m.process.Stop(); err != nil {
+		if strings.Contains(err.Error(), errMessageExitStatus143) || strings.Contains(err.Error(), "no such process") {
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -37,8 +37,8 @@ func setupModManager(
 	t.Helper()
 	mgr := NewManager(ctx, parentAddr, logger, options)
 	t.Cleanup(func() {
-		// Wait for inRecoveryWorker here because modmanager.Close does not.
-		// Do so by grabbing a copy of the modules and then waiting after
+		// Wait for module recovery processes here because modmanager.Close does not.
+		// Do so by grabbing a copy of the modules and then waiting for the lock after
 		// mgr.Close() completes, so that all contexts relating to module
 		// restarting are cancelled.
 		mMgr, ok := mgr.(*Manager)
@@ -53,7 +53,7 @@ func setupModManager(
 			if mod != nil {
 				func() {
 					// Wait for module recovery processes to complete.
-					mod.inRecoverLock.Lock()
+					mod.inRecoveryLock.Lock()
 					defer mod.inRecoveryLock.Unlock()
 				}()
 			}

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -51,7 +51,11 @@ func setupModManager(
 		test.That(t, mgr.Close(ctx), test.ShouldBeNil)
 		for _, mod := range modules {
 			if mod != nil {
-				mod.inRecoveryWorker.Wait()
+				func() {
+					// Wait for module recovery processes to complete.
+					mod.inRecoverLock.Lock()
+					defer mod.inRecoveryLock.Unlock()
+				}()
 			}
 		}
 	})

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -484,7 +484,6 @@ func TestModuleReloading(t *testing.T) {
 		// Assert that RemoveOrphanedResources was called once.
 		test.That(t, dummyRemoveOrphanedResourcesCallCount.Load(), test.ShouldEqual, 1)
 	})
-
 	t.Run("unsuccessful restart", func(t *testing.T) {
 		logger, logs := logging.NewObservedTestLogger(t)
 

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -38,9 +38,9 @@ func setupModManager(
 	mgr := NewManager(ctx, parentAddr, logger, options)
 	t.Cleanup(func() {
 		// Wait for module recovery processes here because modmanager.Close does not.
-		// Do so by grabbing a copy of the modules and then waiting for the lock after
-		// mgr.Close() completes, so that all contexts relating to module
-		// restarting are cancelled.
+		// Do so by grabbing a copy of the modules and then waiting after
+		// mgr.Close() completes, which cancels all contexts relating to module
+		// recovery.
 		mMgr, ok := mgr.(*Manager)
 		test.That(t, ok, test.ShouldBeTrue)
 		modules := []*module{}


### PR DESCRIPTION
We were logging after the test cleaned up, in this case in the OnUnexpectedHandler

* Added a setup/clean up function for mod manager in tests - made a copy of the mod map before modmanager.Close() because otherwise we wouldn't know which modules were in existence. Waited for the module in recovery lock after Close() instead of before so that modmanager could cancel any contexts related to module recovery which should speed up the Lock() and also prevent deadlocks
* Exit earlier in the attemptRestart loop, just an optimization