### PR TITLE
revert macos homebrew cache

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,11 +11,12 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
-    - uses: actions/setup-go@v4
+    - uses: actions/setup-go@v5
       with:
         go-version: '1.21.x'
     - name: brew
       run: |
+        brew config
         brew tap viamrobotics/brews
         brew install pkg-config
         brew install nlopt-static

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,24 +11,9 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@v4
       with:
         go-version: '1.21.x'
-
-    - name: config + tap
-      run: |
-        brew config
-        # note: this must come before caching because we use it to invalidate
-        brew tap viamrobotics/brews
-    # note: this caching is brittle but we are okay with periodic build failures in exchange for speed
-    # TODO(RSDK-5474): replace with bottling
-    - id: cache-brew
-      uses: actions/cache@v4
-      with:
-        path: |
-          /usr/local/**/tensorflow*
-          /usr/local/**/nlopt*
-        key: ${{ hashFiles('/usr/local/Homebrew/Library/Taps/viamrobotics/homebrew-brews/**/*', '.github/workflows/macos.yml') }}
     - name: brew
       run: |
         brew tap viamrobotics/brews


### PR DESCRIPTION
## What changed
- Don't cache homebrew folders for slow builds
## Why
This caching never in fact worked, but a flag change broke our tflite import, masking this failure. (Fix for the flag change is here https://github.com/viamrobotics/rdk/pull/3903).
## Test runs
- :heavy_check_mark: https://github.com/viamrobotics/rdk/actions/runs/8972984931/job/24642172488