### PR TITLE
RSDK-7541: Have TestTwoModuleRestart wait for log message that implies its follow-up assertions have been met.

### DIFF
--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -992,7 +992,7 @@ func TestTwoModulesRestart(t *testing.T) {
 
 	testutils.WaitForAssertion(t, func(tb testing.TB) {
 		tb.Helper()
-		test.That(tb, logs.FilterMessageSnippet("Module successfully restarted").Len(),
+		test.That(tb, logs.FilterMessageSnippet("Module resources successfully re-added after module restart").Len(),
 			test.ShouldEqual, 2)
 	})
 


### PR DESCRIPTION
This [commit](https://github.com/viamrobotics/rdk/commit/2609b3d91d) changed log message content. `TestTwoModulesRestart` depended on those log lines to know when an assertion was valid.