### PR TITLE
DATA-2484 Make N configurable via JSON

### DIFF
--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -658,7 +658,7 @@ func (svc *builtIn) sync() {
 	}
 }
 
-// nolint
+//nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"sync"
 	"time"
 
@@ -728,6 +729,10 @@ func generateMetadataKey(component, method string) string {
 func pollFilesystem(ctx context.Context, wg *sync.WaitGroup, captureDir string,
 	deleteEveryNth int, syncer datasync.Manager, logger logging.Logger,
 ) {
+	if runtime.GOOS == "android" {
+		logger.Debug("file deletion if disk is full is not currently supported on Android")
+		return
+	}
 	t := deletionTicker.Ticker(filesystemPollInterval)
 	defer t.Stop()
 	defer wg.Done()

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -67,15 +67,15 @@ var errCaptureDirectoryConfigurationDisabled = errors.New("changing the capture 
 
 // Config describes how to configure the service.
 type Config struct {
-	CaptureDir             string   `json:"capture_dir"`
-	AdditionalSyncPaths    []string `json:"additional_sync_paths"`
-	SyncIntervalMins       float64  `json:"sync_interval_mins"`
-	CaptureDisabled        bool     `json:"capture_disabled"`
-	ScheduledSyncDisabled  bool     `json:"sync_disabled"`
-	Tags                   []string `json:"tags"`
-	FileLastModifiedMillis int      `json:"file_last_modified_millis"`
-	SelectiveSyncerName    string   `json:"selective_syncer_name"`
-	DeleteEveryNth         int      `json:"delete_every_nth"`
+	CaptureDir                 string   `json:"capture_dir"`
+	AdditionalSyncPaths        []string `json:"additional_sync_paths"`
+	SyncIntervalMins           float64  `json:"sync_interval_mins"`
+	CaptureDisabled            bool     `json:"capture_disabled"`
+	ScheduledSyncDisabled      bool     `json:"sync_disabled"`
+	Tags                       []string `json:"tags"`
+	FileLastModifiedMillis     int      `json:"file_last_modified_millis"`
+	SelectiveSyncerName        string   `json:"selective_syncer_name"`
+	DeleteEveryNthWhenDiskFull int      `json:"delete_every_nth_when_disk_full"`
 }
 
 // Validate returns components which will be depended upon weakly due to the above matcher.
@@ -450,8 +450,8 @@ func (svc *builtIn) Reconfigure(
 	if svc.fileDeletionBackgroundWorkers != nil {
 		svc.fileDeletionBackgroundWorkers.Wait()
 	}
-	if svcConfig.DeleteEveryNth != 0 {
-		svc.deleteEveryNth = svcConfig.DeleteEveryNth
+	if svcConfig.DeleteEveryNthWhenDiskFull != 0 {
+		svc.deleteEveryNth = svcConfig.DeleteEveryNthWhenDiskFull
 	} else {
 		svc.deleteEveryNth = defaultDeleteEveryNth
 	}
@@ -573,7 +573,6 @@ func (svc *builtIn) Reconfigure(
 		svc.fileDeletionRoutineCancelFn = cancelFunc
 		svc.fileDeletionBackgroundWorkers = &sync.WaitGroup{}
 		svc.fileDeletionBackgroundWorkers.Add(1)
-		svc.logger.Infof("Deleting every nth %d", svc.deleteEveryNth)
 		go pollFilesystem(fileDeletionCtx, svc.fileDeletionBackgroundWorkers,
 			svc.captureDir, svc.deleteEveryNth, svc.syncer, svc.logger)
 	}

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -656,7 +656,7 @@ func (svc *builtIn) sync() {
 	}
 }
 
-// nolint
+//nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/services/datamanager/builtin/file_deletion.go
+++ b/services/datamanager/builtin/file_deletion.go
@@ -85,7 +85,8 @@ func exceedsDeletionThreshold(ctx context.Context, captureDirPath string, fsSize
 }
 
 func deleteFiles(ctx context.Context, syncer datasync.Manager, deleteEveryNth int,
-	captureDirPath string, logger logging.Logger) (int, error) {
+	captureDirPath string, logger logging.Logger,
+) (int, error) {
 	index := 0
 	deletedFileCount := 0
 	logger.Infof("Deleting every %dth file", deleteEveryNth)

--- a/services/datamanager/builtin/file_deletion.go
+++ b/services/datamanager/builtin/file_deletion.go
@@ -18,7 +18,7 @@ import (
 var (
 	fsThresholdToTriggerDeletion = .90
 	captureDirToFSUsageRatio     = .5
-	deleteEveryNth               = 5
+	defaultDeleteEveryNth        = 5
 )
 
 var errAtSizeThreshold = errors.New("capture directory has reached or exceeded disk usage threshold for deletion")
@@ -84,9 +84,11 @@ func exceedsDeletionThreshold(ctx context.Context, captureDirPath string, fsSize
 	return false, nil
 }
 
-func deleteFiles(ctx context.Context, syncer datasync.Manager, captureDirPath string, logger logging.Logger) (int, error) {
+func deleteFiles(ctx context.Context, syncer datasync.Manager, deleteEveryNth int,
+	captureDirPath string, logger logging.Logger) (int, error) {
 	index := 0
 	deletedFileCount := 0
+	logger.Infof("Deleting every nth %d", deleteEveryNth)
 	fileDeletion := func(path string, d fs.DirEntry, err error) error {
 		if ctx.Err() != nil {
 			return ctx.Err()

--- a/services/datamanager/builtin/file_deletion.go
+++ b/services/datamanager/builtin/file_deletion.go
@@ -88,7 +88,7 @@ func deleteFiles(ctx context.Context, syncer datasync.Manager, deleteEveryNth in
 	captureDirPath string, logger logging.Logger) (int, error) {
 	index := 0
 	deletedFileCount := 0
-	logger.Infof("Deleting every nth %d", deleteEveryNth)
+	logger.Infof("Deleting every %d file", deleteEveryNth)
 	fileDeletion := func(path string, d fs.DirEntry, err error) error {
 		if ctx.Err() != nil {
 			return ctx.Err()

--- a/services/datamanager/builtin/file_deletion.go
+++ b/services/datamanager/builtin/file_deletion.go
@@ -88,7 +88,7 @@ func deleteFiles(ctx context.Context, syncer datasync.Manager, deleteEveryNth in
 	captureDirPath string, logger logging.Logger) (int, error) {
 	index := 0
 	deletedFileCount := 0
-	logger.Infof("Deleting every %d file", deleteEveryNth)
+	logger.Infof("Deleting every %dth file", deleteEveryNth)
 	fileDeletion := func(path string, d fs.DirEntry, err error) error {
 		if ctx.Err() != nil {
 			return ctx.Err()

--- a/services/datamanager/builtin/file_deletion_test.go
+++ b/services/datamanager/builtin/file_deletion_test.go
@@ -158,7 +158,7 @@ func TestFileDeletion(t *testing.T) {
 			if tc.shouldCancelContext {
 				cancelFunc()
 			}
-			deletedFileCount, err := deleteFiles(ctx, syncer, tempCaptureDir, logger)
+			deletedFileCount, err := deleteFiles(ctx, syncer, defaultDeleteEveryNth, tempCaptureDir, logger)
 			if tc.shouldCancelContext {
 				test.That(t, err, test.ShouldBeError, context.Canceled)
 			} else {


### PR DESCRIPTION
Hey yall, this PR is to make the value of N for file deletion configurable via raw JSON. If no value is set, N is the default value of 5, otherwise it's what in the config.
Example service config:
```json
{
      "name": "data_manager-1",
      "namespace": "rdk",
      "type": "data_manager",
      "attributes": {
        "sync_disabled": false,
        "delete_every_nth": 5,
        "sync_interval_mins": 60,
        "capture_dir": "",
        "tags": [],
        "additional_sync_paths": []
      }
}
```
I've tested this works on a pi 
<img width="1110" alt="Screenshot 2024-05-08 at 11 40 01 AM" src="https://github.com/vijayvuyyuru/rdk/assets/13922806/0bace64f-1285-44c0-b15b-8dcdca0e932c">
I can see logs matching when I change the value for N. I also checked there are not random reconfigures happening as a result of this addition. 