### PR TITLE
use StoppableWorkers in wheeledodometry

### DIFF
--- a/components/movementsensor/wheeledodometry/wheeledodometry.go
+++ b/components/movementsensor/wheeledodometry/wheeledodometry.go
@@ -212,7 +212,7 @@ func (o *odometry) Reconfigure(ctx context.Context, deps resource.Dependencies, 
 
 	o.orientation.Yaw = 0
 	o.originCoord = geo.NewPoint(0, 0)
-	o.workers = utils.NewStoppableWorkers(o.trackPosition)
+	o.trackPosition() // (re-)initializes o.workers
 
 	return nil
 }
@@ -352,93 +352,96 @@ func (o *odometry) checkBaseProps(ctx context.Context) {
 // linear velocity, and angular velocity of the wheeled base.
 // The estimations in this function are based on the math outlined in this article:
 // https://stuff.mit.edu/afs/athena/course/6/6.186/OldFiles/2005/doc/odomtutorial/odomtutorial.pdf
-func (o *odometry) trackPosition(ctx context.Context) {
-	ticker := time.NewTicker(time.Duration(o.timeIntervalMSecs) * time.Millisecond)
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		default:
+func (o *odometry) trackPosition() {
+	// Spawn a new goroutine to do all the work in the background.
+	o.workers = utils.NewStoppableWorkers(func(ctx context.Context) {
+		ticker := time.NewTicker(time.Duration(o.timeIntervalMSecs) * time.Millisecond)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			// Sleep until it's time to update the position again.
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+
+			// Use GetInParallel to ensure the left and right motors are polled at the same time.
+			positionFuncs := func() []utils.FloatFunc {
+				fs := []utils.FloatFunc{}
+
+				// Always use the first pair until more than one pair of motors is supported in this model.
+				fs = append(fs, func(ctx context.Context) (float64, error) { return o.motors[0].left.Position(ctx, nil) })
+				fs = append(fs, func(ctx context.Context) (float64, error) { return o.motors[0].right.Position(ctx, nil) })
+
+				return fs
+			}
+
+			_, positions, err := utils.GetInParallel(ctx, positionFuncs())
+			if err != nil {
+				o.logger.CError(ctx, err)
+				continue
+			}
+
+			// Current position of the left and right motors in revolutions.
+			if len(positions) != len(o.motors)*2 {
+				o.logger.CError(ctx, "error getting both motor positions, trying again")
+				continue
+			}
+			left := positions[0]
+			right := positions[1]
+
+			// Base properties need to be checked every time because dependent components reconfiguring does not trigger
+			// the parent component to reconfigure. In this case, that means if the base properties change, the wheeled
+			// odometry movement sensor will not be aware of these changes and will continue to use the old values
+			o.checkBaseProps(ctx)
+
+			// Difference in the left and right motors since the last iteration, in mm.
+			leftDist := (left - o.lastLeftPos) * o.wheelCircumference
+			rightDist := (right - o.lastRightPos) * o.wheelCircumference
+
+			// Update lastLeftPos and lastRightPos to be the current position in mm.
+			o.lastLeftPos = left
+			o.lastRightPos = right
+
+			// Linear and angular distance the center point has traveled. This works based on
+			// the assumption that the time interval between calulations is small enough that
+			// the inner angle of the rotation will be small enough that it can be accurately
+			// estimated using the below equations.
+			centerDist := (leftDist + rightDist) / 2
+			centerAngle := (rightDist - leftDist) / o.baseWidth
+
+			// Update the position and orientation values accordingly.
+			o.mu.Lock()
+			o.orientation.Yaw += centerAngle
+
+			// Limit the yaw to a range of positive 0 to 360 degrees.
+			o.orientation.Yaw = math.Mod(o.orientation.Yaw, oneTurn)
+			o.orientation.Yaw = math.Mod(o.orientation.Yaw+oneTurn, oneTurn)
+			angle := o.orientation.Yaw
+			xFlip := -1.0
+			if o.useCompass {
+				angle = utils.DegToRad(yawToCompassHeading(o.orientation.Yaw))
+				xFlip = 1.0
+			}
+			o.position.X += xFlip * (centerDist * math.Sin(angle))
+			o.position.Y += (centerDist * math.Cos(angle))
+
+			distance := math.Hypot(o.position.X, o.position.Y)
+			heading := utils.RadToDeg(math.Atan2(o.position.X, o.position.Y))
+			o.coord = o.originCoord.PointAtDistanceAndBearing(distance*mToKm, heading)
+
+			// Update the linear and angular velocity values using the provided time interval.
+			o.linearVelocity.Y = centerDist / (o.timeIntervalMSecs / 1000)
+			o.angularVelocity.Z = centerAngle * (180 / math.Pi) / (o.timeIntervalMSecs / 1000)
+
+			o.mu.Unlock()
 		}
-
-		// Sleep until it's time to update the position again.
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-		}
-
-		// Use GetInParallel to ensure the left and right motors are polled at the same time.
-		positionFuncs := func() []utils.FloatFunc {
-			fs := []utils.FloatFunc{}
-
-			// Always use the first pair until more than one pair of motors is supported in this model.
-			fs = append(fs, func(ctx context.Context) (float64, error) { return o.motors[0].left.Position(ctx, nil) })
-			fs = append(fs, func(ctx context.Context) (float64, error) { return o.motors[0].right.Position(ctx, nil) })
-
-			return fs
-		}
-
-		_, positions, err := utils.GetInParallel(ctx, positionFuncs())
-		if err != nil {
-			o.logger.CError(ctx, err)
-			continue
-		}
-
-		// Current position of the left and right motors in revolutions.
-		if len(positions) != len(o.motors)*2 {
-			o.logger.CError(ctx, "error getting both motor positions, trying again")
-			continue
-		}
-		left := positions[0]
-		right := positions[1]
-
-		// Base properties need to be checked every time because dependent components reconfiguring does not trigger
-		// the parent component to reconfigure. In this case, that means if the base properties change, the wheeled
-		// odometry movement sensor will not be aware of these changes and will continue to use the old values
-		o.checkBaseProps(ctx)
-
-		// Difference in the left and right motors since the last iteration, in mm.
-		leftDist := (left - o.lastLeftPos) * o.wheelCircumference
-		rightDist := (right - o.lastRightPos) * o.wheelCircumference
-
-		// Update lastLeftPos and lastRightPos to be the current position in mm.
-		o.lastLeftPos = left
-		o.lastRightPos = right
-
-		// Linear and angular distance the center point has traveled. This works based on
-		// the assumption that the time interval between calulations is small enough that
-		// the inner angle of the rotation will be small enough that it can be accurately
-		// estimated using the below equations.
-		centerDist := (leftDist + rightDist) / 2
-		centerAngle := (rightDist - leftDist) / o.baseWidth
-
-		// Update the position and orientation values accordingly.
-		o.mu.Lock()
-		o.orientation.Yaw += centerAngle
-
-		// Limit the yaw to a range of positive 0 to 360 degrees.
-		o.orientation.Yaw = math.Mod(o.orientation.Yaw, oneTurn)
-		o.orientation.Yaw = math.Mod(o.orientation.Yaw+oneTurn, oneTurn)
-		angle := o.orientation.Yaw
-		xFlip := -1.0
-		if o.useCompass {
-			angle = utils.DegToRad(yawToCompassHeading(o.orientation.Yaw))
-			xFlip = 1.0
-		}
-		o.position.X += xFlip * (centerDist * math.Sin(angle))
-		o.position.Y += (centerDist * math.Cos(angle))
-
-		distance := math.Hypot(o.position.X, o.position.Y)
-		heading := utils.RadToDeg(math.Atan2(o.position.X, o.position.Y))
-		o.coord = o.originCoord.PointAtDistanceAndBearing(distance*mToKm, heading)
-
-		// Update the linear and angular velocity values using the provided time interval.
-		o.linearVelocity.Y = centerDist / (o.timeIntervalMSecs / 1000)
-		o.angularVelocity.Z = centerAngle * (180 / math.Pi) / (o.timeIntervalMSecs / 1000)
-
-		o.mu.Unlock()
-	}
+	})
 }
 
 func (o *odometry) DoCommand(ctx context.Context,

--- a/components/movementsensor/wheeledodometry/wheeledodometry.go
+++ b/components/movementsensor/wheeledodometry/wheeledodometry.go
@@ -359,10 +359,6 @@ func (o *odometry) checkBaseProps(ctx context.Context) {
 // The estimations in this function are based on the math outlined in this article:
 // https://stuff.mit.edu/afs/athena/course/6/6.186/OldFiles/2005/doc/odomtutorial/odomtutorial.pdf
 func (o *odometry) trackPosition(ctx context.Context) {
-	if o.originCoord == nil {
-		o.originCoord = geo.NewPoint(0, 0)
-	}
-
 	o.activeBackgroundWorkers.Add(1)
 	utils.PanicCapturingGo(func() {
 		defer o.activeBackgroundWorkers.Done()

--- a/components/movementsensor/wheeledodometry/wheeledodometry_test.go
+++ b/components/movementsensor/wheeledodometry/wheeledodometry_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	geo "github.com/kellydunn/golang-geo"
 	"go.viam.com/test"
 
 	"go.viam.com/rdk/components/base"
@@ -264,6 +265,7 @@ func TestSpin(t *testing.T) {
 		baseWidth:          0.2,
 		base:               base,
 		timeIntervalMSecs:  500,
+		originCoord:        geo.NewPoint(0, 0)
 	}
 	od.motors = append(od.motors, motorPair{left, right})
 	od.trackPosition(context.Background())
@@ -318,6 +320,7 @@ func TestMoveStraight(t *testing.T) {
 		baseWidth:          1,
 		base:               base,
 		timeIntervalMSecs:  500,
+		originCoord:        geo.NewPoint(0, 0)
 	}
 	od.motors = append(od.motors, motorPair{left, right})
 	od.trackPosition(context.Background())
@@ -360,6 +363,7 @@ func TestComplicatedPath(t *testing.T) {
 		baseWidth:          1,
 		base:               base,
 		timeIntervalMSecs:  500,
+		originCoord:        geo.NewPoint(0, 0)
 	}
 	od.motors = append(od.motors, motorPair{left, right})
 	od.trackPosition(context.Background())
@@ -451,6 +455,7 @@ func TestVelocities(t *testing.T) {
 		baseWidth:         1,
 		base:              base,
 		timeIntervalMSecs: 500,
+		originCoord:        geo.NewPoint(0, 0)
 	}
 	od.motors = append(od.motors, motorPair{left, right})
 	od.trackPosition(context.Background())

--- a/components/movementsensor/wheeledodometry/wheeledodometry_test.go
+++ b/components/movementsensor/wheeledodometry/wheeledodometry_test.go
@@ -268,7 +268,7 @@ func TestSpin(t *testing.T) {
 		originCoord:        geo.NewPoint(0, 0),
 	}
 	od.motors = append(od.motors, motorPair{left, right})
-	od.trackPosition(context.Background())
+	od.trackPosition()
 
 	// turn 90 degrees
 	setPositions(-1*(math.Pi/4), 1*(math.Pi/4))
@@ -303,6 +303,7 @@ func TestSpin(t *testing.T) {
 	test.That(t, or.OrientationVectorDegrees().Theta, test.ShouldAlmostEqual, 270, 0.1)
 	test.That(t, pos.Lat(), test.ShouldAlmostEqual, 0, 0.1)
 	test.That(t, pos.Lng(), test.ShouldAlmostEqual, 0, 0.1)
+	test.That(t, od.Close(context.Background()), test.ShouldBeNil)
 }
 
 func TestMoveStraight(t *testing.T) {
@@ -323,7 +324,7 @@ func TestMoveStraight(t *testing.T) {
 		originCoord:        geo.NewPoint(0, 0),
 	}
 	od.motors = append(od.motors, motorPair{left, right})
-	od.trackPosition(context.Background())
+	od.trackPosition()
 
 	// move straight 5 m
 	setPositions(5, 5)
@@ -346,6 +347,7 @@ func TestMoveStraight(t *testing.T) {
 	test.That(t, or.OrientationVectorDegrees().Theta, test.ShouldAlmostEqual, 0, 0.1)
 	test.That(t, pos.Lat(), test.ShouldAlmostEqual, -5, 0.1)
 	test.That(t, pos.Lng(), test.ShouldAlmostEqual, 0, 0.1)
+	test.That(t, od.Close(context.Background()), test.ShouldBeNil)
 }
 
 func TestComplicatedPath(t *testing.T) {
@@ -366,7 +368,7 @@ func TestComplicatedPath(t *testing.T) {
 		originCoord:        geo.NewPoint(0, 0),
 	}
 	od.motors = append(od.motors, motorPair{left, right})
-	od.trackPosition(context.Background())
+	od.trackPosition()
 
 	// move straight 5 m
 	setPositions(5, 5)
@@ -439,6 +441,7 @@ func TestComplicatedPath(t *testing.T) {
 	test.That(t, or.OrientationVectorDegrees().Theta, test.ShouldAlmostEqual, 0, 0.1)
 	test.That(t, pos.Lat(), test.ShouldAlmostEqual, 7.6, 0.1)
 	test.That(t, pos.Lng(), test.ShouldAlmostEqual, 6.4, 0.1)
+	test.That(t, od.Close(context.Background()), test.ShouldBeNil)
 }
 
 func TestVelocities(t *testing.T) {
@@ -458,7 +461,7 @@ func TestVelocities(t *testing.T) {
 		originCoord:       geo.NewPoint(0, 0),
 	}
 	od.motors = append(od.motors, motorPair{left, right})
-	od.trackPosition(context.Background())
+	od.trackPosition()
 
 	// move forward 10 m
 	setPositions(10, 10)
@@ -503,4 +506,5 @@ func TestVelocities(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, linVel.Y, test.ShouldAlmostEqual, -10, 0.1)
 	test.That(t, angVel.Z, test.ShouldAlmostEqual, 0, 0.1)
+	test.That(t, od.Close(context.Background()), test.ShouldBeNil)
 }

--- a/components/movementsensor/wheeledodometry/wheeledodometry_test.go
+++ b/components/movementsensor/wheeledodometry/wheeledodometry_test.go
@@ -265,7 +265,7 @@ func TestSpin(t *testing.T) {
 		baseWidth:          0.2,
 		base:               base,
 		timeIntervalMSecs:  500,
-		originCoord:        geo.NewPoint(0, 0)
+		originCoord:        geo.NewPoint(0, 0),
 	}
 	od.motors = append(od.motors, motorPair{left, right})
 	od.trackPosition(context.Background())
@@ -320,7 +320,7 @@ func TestMoveStraight(t *testing.T) {
 		baseWidth:          1,
 		base:               base,
 		timeIntervalMSecs:  500,
-		originCoord:        geo.NewPoint(0, 0)
+		originCoord:        geo.NewPoint(0, 0),
 	}
 	od.motors = append(od.motors, motorPair{left, right})
 	od.trackPosition(context.Background())
@@ -363,7 +363,7 @@ func TestComplicatedPath(t *testing.T) {
 		baseWidth:          1,
 		base:               base,
 		timeIntervalMSecs:  500,
-		originCoord:        geo.NewPoint(0, 0)
+		originCoord:        geo.NewPoint(0, 0),
 	}
 	od.motors = append(od.motors, motorPair{left, right})
 	od.trackPosition(context.Background())
@@ -455,7 +455,7 @@ func TestVelocities(t *testing.T) {
 		baseWidth:         1,
 		base:              base,
 		timeIntervalMSecs: 500,
-		originCoord:        geo.NewPoint(0, 0)
+		originCoord:        geo.NewPoint(0, 0),
 	}
 	od.motors = append(od.motors, motorPair{left, right})
 	od.trackPosition(context.Background())

--- a/components/movementsensor/wheeledodometry/wheeledodometry_test.go
+++ b/components/movementsensor/wheeledodometry/wheeledodometry_test.go
@@ -455,7 +455,7 @@ func TestVelocities(t *testing.T) {
 		baseWidth:         1,
 		base:              base,
 		timeIntervalMSecs: 500,
-		originCoord:        geo.NewPoint(0, 0),
+		originCoord:       geo.NewPoint(0, 0),
 	}
 	od.motors = append(od.motors, motorPair{left, right})
 	od.trackPosition(context.Background())


### PR DESCRIPTION
Not tried on real hardware yet; need to do that soon.

- At the top of `trackPosition` we'd check if `o.originCoord` was nil. However, `trackPosition` was only ever called immediately after setting `o.originCoord` to a non-nil value. So, I took that out. 
- Then, `trackPosition` did nothing but spawn a goroutine. I refactored so the call to `trackPosition` spawned the goroutine and `trackPosition` itself is just the code that runs in the routine. This meant unindenting the entirety of `trackPosition` a level, leading to a much bigger diff than it should really be. *I'd review this while ignoring whitespace changes.*
- Once we've replaced the `activeBackgroundWorkers` pattern with a `StoppableWorkers` struct, we no longer import go.viam.com/utils, so don't need to use a nonstandard name when importing go.viam.com/rdk/utils.