### PR TITLE
 APP-4066: Remove legacy .data dir cleanup logic

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1085,13 +1085,6 @@ func (p *PackageConfig) LocalDataParentDirectory(packagesDir string) string {
 	return filepath.Join(packagesDir, "data", string(p.Type))
 }
 
-// LocalLegacyDataRootDirectory returns the old private directory.
-// This can be cleaned up after a few RDK releases (APP-4066)
-// Ex: /home/user/.viam/packages/.data/.
-func (p *PackageConfig) LocalLegacyDataRootDirectory(packagesDir string) string {
-	return filepath.Join(packagesDir, ".data")
-}
-
 // SanitizedName returns the package name for the symlink/filepath of the package on the system.
 func (p *PackageConfig) SanitizedName() string {
 	return fmt.Sprintf("%s-%s", strings.ReplaceAll(p.Package, string(os.PathSeparator), "-"), p.sanitizedVersion())

--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -422,12 +422,6 @@ func (m *cloudManager) downloadPackage(ctx context.Context, url string, p config
 		return err
 	}
 
-	// Delete legacy directory, silently fail if the cleanup fails
-	// This can be cleaned up after a few RDK releases (APP-4066)
-	if err := os.RemoveAll(p.LocalLegacyDataRootDirectory(m.packagesDir)); err != nil {
-		utils.UncheckedError(err)
-	}
-
 	// Force redownload of package archive.
 	if err := m.cleanup(p); err != nil {
 		m.logger.Debug(err)


### PR DESCRIPTION
Removes the cleanup logic for previously renaming .data -> data in https://github.com/viamrobotics/rdk/pull/3608