### PR TITLE
RSDK-7583 Fix test race condition

### DIFF
--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -423,7 +423,7 @@ func TestObstacleReplanningGlobe(t *testing.T) {
 
 	testFn := func(t *testing.T, tc testCase) {
 		t.Helper()
-		
+
 		calledPC := false
 		pcFunc := func(ctx context.Context, cameraName string, extra map[string]interface{}) ([]*viz.Object, error) {
 			if !calledPC {
@@ -432,7 +432,7 @@ func TestObstacleReplanningGlobe(t *testing.T) {
 			}
 			return tc.getPCfunc(ctx, cameraName, extra)
 		}
-		
+
 		injectedMovementSensor, _, kb, ms := createMoveOnGlobeEnvironment(
 			ctx,
 			t,

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"sync"
 	"testing"
 	"time"
 
@@ -338,29 +337,11 @@ func TestObstacleReplanningGlobe(t *testing.T) {
 	extraNoReplan := map[string]interface{}{"max_replans": 0, "max_ik_solutions": 1, "smooth_iter": 1}
 
 	// We set a flag here per test case so that detections are not returned the first time each vision service is called
-	firstRunMap := map[string]bool{}
-	var mapMutex sync.RWMutex
-	setCase := func(caseName string) bool {
-		mapMutex.RLock()
-		if _, ok := firstRunMap[caseName]; !ok {
-			mapMutex.RUnlock()
-			mapMutex.Lock()
-			defer mapMutex.Unlock()
-			firstRunMap[caseName] = true
-			return false
-		}
-		return true
-	}
-
 	testCases := []testCase{
 		{
 			name: "ensure no replan from discovered obstacles",
 			getPCfunc: func(ctx context.Context, cameraName string, extra map[string]interface{}) ([]*viz.Object, error) {
 				caseName := "test-case-1"
-				alreadyRun := setCase(caseName)
-				if !alreadyRun {
-					return []*viz.Object{}, nil
-				}
 				obstaclePosition := spatialmath.NewPoseFromPoint(r3.Vector{X: -1000, Y: -1000, Z: 0})
 				box, err := spatialmath.NewBox(obstaclePosition, r3.Vector{X: 10, Y: 10, Z: 10}, caseName)
 				test.That(t, err, test.ShouldBeNil)
@@ -377,10 +358,6 @@ func TestObstacleReplanningGlobe(t *testing.T) {
 			name: "ensure replan due to obstacle collision",
 			getPCfunc: func(ctx context.Context, cameraName string, extra map[string]interface{}) ([]*viz.Object, error) {
 				caseName := "test-case-2"
-				alreadyRun := setCase(caseName)
-				if !alreadyRun {
-					return []*viz.Object{}, nil
-				}
 				// The camera is parented to the base. Thus, this will always see an obstacle 300mm in front of where the base is.
 				// Note: for createMoveOnGlobeEnvironment, the camera is given an orientation such that it is pointing left, not
 				// forwards. Thus, an obstacle in front of the base will be seen as being in +X.
@@ -401,10 +378,6 @@ func TestObstacleReplanningGlobe(t *testing.T) {
 			name: "ensure replan reaching goal",
 			getPCfunc: func(ctx context.Context, cameraName string, extra map[string]interface{}) ([]*viz.Object, error) {
 				caseName := "test-case-3"
-				alreadyRun := setCase(caseName)
-				if !alreadyRun {
-					return []*viz.Object{}, nil
-				}
 				// This base will always see an obstacle 800mm in front of it, triggering several replans.
 				// However, enough replans should eventually get it to its goal.
 				obstaclePosition := spatialmath.NewPoseFromPoint(r3.Vector{X: 800, Y: 0, Z: 0})

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -423,6 +423,16 @@ func TestObstacleReplanningGlobe(t *testing.T) {
 
 	testFn := func(t *testing.T, tc testCase) {
 		t.Helper()
+		
+		calledPC := false
+		pcFunc := func(ctx context.Context, cameraName string, extra map[string]interface{}) ([]*viz.Object, error) {
+			if !calledPC {
+				calledPC = true
+				return []*viz.Object{}, nil
+			}
+			return tc.getPCfunc(ctx, cameraName, extra)
+		}
+		
 		injectedMovementSensor, _, kb, ms := createMoveOnGlobeEnvironment(
 			ctx,
 			t,
@@ -434,7 +444,7 @@ func TestObstacleReplanningGlobe(t *testing.T) {
 
 		srvc, ok := ms.(*builtIn).visionServices[cfg.ObstacleDetectors[0].VisionServiceName].(*inject.VisionService)
 		test.That(t, ok, test.ShouldBeTrue)
-		srvc.GetObjectPointCloudsFunc = tc.getPCfunc
+		srvc.GetObjectPointCloudsFunc = pcFunc
 
 		req := motion.MoveOnGlobeReq{
 			ComponentName:      kb.Name(),


### PR DESCRIPTION
For some tests, we are mocking up transient obstacle avoidance and so wish to return a different value from an injected function the first time it is called.

As we are doing this several times over for multiple tests, we track the values in a map, where each tests can flip a bool corresponding to its own name to determine whether it has already run.

However, the map was unprotected, so we have multiple tests reading/writing to the same map simultaneously, even if it was guaranteed there would be no collision as each test only queried its own key.

This PR adds a mutex to the map.