### PR TITLE
RSDK-7598 - Fix logger tests

### DIFF
--- a/logging/net_appender.go
+++ b/logging/net_appender.go
@@ -84,6 +84,13 @@ func (nl *NetAppender) queueSize() int {
 	return len(nl.toLog)
 }
 
+// cancelBackgroundWorkers is an internal function meant to be used only in testing and in Close(). NetAppender will
+// not function correctly if cancelBackgroundWorkers() is called outside of those contexts.
+func (nl *NetAppender) cancelBackgroundWorkers() {
+	nl.cancel()
+	nl.activeBackgroundWorkers.Wait()
+}
+
 // Close the NetAppender. This makes a best effort at sending all logs before returning.
 func (nl *NetAppender) Close() {
 	// try for up to 10 seconds for log queue to clear before cancelling it
@@ -97,8 +104,7 @@ func (nl *NetAppender) Close() {
 
 		time.Sleep(10 * time.Millisecond)
 	}
-	nl.cancel()
-	nl.activeBackgroundWorkers.Wait()
+	nl.cancelBackgroundWorkers()
 	nl.remoteWriter.close()
 }
 

--- a/logging/net_appender.go
+++ b/logging/net_appender.go
@@ -87,22 +87,27 @@ func (nl *NetAppender) queueSize() int {
 // cancelBackgroundWorkers is an internal function meant to be used only in testing and in Close(). NetAppender will
 // not function correctly if cancelBackgroundWorkers() is called outside of those contexts.
 func (nl *NetAppender) cancelBackgroundWorkers() {
-	nl.cancel()
+	if nl.cancel != nil {
+		nl.cancel()
+		nl.cancel = nil
+	}
 	nl.activeBackgroundWorkers.Wait()
 }
 
 // Close the NetAppender. This makes a best effort at sending all logs before returning.
 func (nl *NetAppender) Close() {
-	// try for up to 10 seconds for log queue to clear before cancelling it
-	for i := 0; i < 1000; i++ {
-		// A batch can be popped from the queue for a sync by the background worker, and re-enqueued
-		// due to an error. This check does not account for this case. It will cancel the background
-		// worker once the last batch is in flight. Successful or not.
-		if nl.queueSize() == 0 {
-			break
-		}
+	if nl.cancel != nil {
+		// try for up to 10 seconds for log queue to clear before cancelling it
+		for i := 0; i < 1000; i++ {
+			// A batch can be popped from the queue for a sync by the background worker, and re-enqueued
+			// due to an error. This check does not account for this case. It will cancel the background
+			// worker once the last batch is in flight. Successful or not.
+			if nl.queueSize() == 0 {
+				break
+			}
 
-		time.Sleep(10 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
+		}
 	}
 	nl.cancelBackgroundWorkers()
 	nl.remoteWriter.close()

--- a/logging/net_appender_test.go
+++ b/logging/net_appender_test.go
@@ -166,8 +166,6 @@ func TestNetLoggerSyncFailureAndRetry(t *testing.T) {
 	// server. Once the log queue is full of size ten batches, the first sync will decrement
 	// `logFailForSizeCount` to 1 and return an error. The second will decrement it to a negative
 	// value and return an error. The third sync will succeed.
-	//
-	// This test depends on the `Close` method performing a `Sync`.
 	test.That(t, netAppender.sync(), test.ShouldNotBeNil)
 
 	logger.Info("New info")

--- a/logging/net_appender_test.go
+++ b/logging/net_appender_test.go
@@ -2,7 +2,6 @@ package logging
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"sync"
@@ -66,8 +65,9 @@ func (ms *mockRobotService) Log(ctx context.Context, req *apppb.LogRequest) (*ap
 	ms.logsMu.Lock()
 	defer ms.logsMu.Unlock()
 	if ms.logFailForSizeCount > 0 {
+		logsLeft := ms.logFailForSizeCount
 		ms.logFailForSizeCount -= len(req.Logs)
-		return &apppb.LogResponse{}, errors.New("not right now")
+		return &apppb.LogResponse{}, fmt.Errorf("not right now, %d log(s) left", logsLeft)
 	}
 	ms.logs = append(ms.logs, req.Logs...)
 	ms.logBatches = append(ms.logBatches, req.Logs)


### PR DESCRIPTION
* The main cause seems to be that the background worker and us calling sync at the same time. So cancelled the background worker.
* I've been getting failures on 10k runs sometimes even after this fix, but less reliably and also seems like a network blip mostly (usually fails in `TestNetLoggerSyncFailureAndRetry` and the error is deadline exceeded), so opting to just push this in and see if the other failure will actually show up and may be easier to debug within CI. It was hard to debug the new issue because of the overwhelming amount of logs 