### PR TITLE
APP-4577: incorrect error message about gpio motor pins

### DIFF
--- a/components/motor/gpio/basic.go
+++ b/components/motor/gpio/basic.go
@@ -30,7 +30,7 @@ func NewMotor(b board.Board, mc Config, name resource.Name, logger logging.Logge
 		return nil, err
 	} else if motorType == AB {
 		logger.Warnf(
-			"motor %s has been configured with A and B pins, but no PWM. Make sure this is intentional",
+			"Motor %s has been configured with A and B pins, but no PWM. Make sure your motor driver doesn't also require a PWM pin.",
 			name.Name,
 		)
 	}

--- a/components/motor/gpio/setup.go
+++ b/components/motor/gpio/setup.go
@@ -56,10 +56,10 @@ func getPinConfigErrorMessage(errorEnum pinConfigError) error {
 
 // PinConfig defines the mapping of where motor are wired.
 type PinConfig struct {
-	A             string `json:"a"`
-	B             string `json:"b"`
-	Direction     string `json:"dir"`
-	PWM           string `json:"pwm"`
+	A             string `json:"a,omitempty"`
+	B             string `json:"b,omitempty"`
+	Direction     string `json:"dir,omitempty"`
+	PWM           string `json:"pwm,omitempty"`
 	EnablePinHigh string `json:"en_high,omitempty"`
 	EnablePinLow  string `json:"en_low,omitempty"`
 }


### PR DESCRIPTION
- make all pins omitempty to silence config errors on app
- change A/B/PWM warning message to make it clear that some A/B motor drivers also require PWM