### PR TITLE
RSDK-6700 Bugfix for course correction

### DIFF
--- a/components/base/kinematicbase/execution.go
+++ b/components/base/kinematicbase/execution.go
@@ -130,6 +130,16 @@ func (ptgk *ptgBaseKinematics) GoToInputs(ctx context.Context, inputSteps ...[]r
 		// - move until we think we have finished the arc, then move on to the next step
 		// - update our CurrentInputs tracking where we are through the arc
 		// - Check where we are relative to where we think we are, and tweak velocities accordingly
+
+		// Check if this arc is shorter than our typical check time; if so just run that and do not course correct.
+		if step.durationSeconds < updateStepSeconds {
+			utils.SelectContextOrWait(ctx, (time.Duration(step.durationSeconds*1000) * time.Millisecond))
+			if ctx.Err() != nil {
+				return tryStop(ctx.Err())
+			}
+			continue
+		}
+
 		for timeElapsedSeconds := updateStepSeconds; timeElapsedSeconds <= step.durationSeconds; timeElapsedSeconds += updateStepSeconds {
 			if ctx.Err() != nil {
 				return ctx.Err()
@@ -493,6 +503,7 @@ func (ptgk *ptgBaseKinematics) makeCourseCorrectionGoals(
 
 	startingTrajPt := 0
 	for i := 0; i < len(steps[currStep].subTraj); i++ {
+		// Determine the index of the current subtraj point
 		if steps[currStep].subTraj[i].Dist >= currDist {
 			startingTrajPt = i
 			break
@@ -513,9 +524,23 @@ func (ptgk *ptgBaseKinematics) makeCourseCorrectionGoals(
 	for i := currStep; i < len(steps); i++ {
 		for len(steps[i].subTraj)-startingTrajPt > stepsRemainingThisGoal {
 			goalTrajPtIdx := startingTrajPt + stepsRemainingThisGoal
+
+			// Since the arc may not be starting at 0, we must compute the transform for this particular traj pt.
+			// The pose in trajPt.Pose is from the zero position.
+			arcTrajInputs := []referenceframe.Input{
+				steps[i].arcSegment.StartConfiguration[ptgIndex],
+				steps[i].arcSegment.StartConfiguration[trajectoryAlphaWithinPTG],
+				steps[i].arcSegment.StartConfiguration[startDistanceAlongTrajectoryIndex],
+				{steps[i].subTraj[goalTrajPtIdx].Dist},
+			}
+			arcPose, err := ptgk.Kinematics().Transform(arcTrajInputs)
+			if err != nil {
+				return []courseCorrectionGoal{}
+			}
+
 			goalPose := spatialmath.PoseBetween(
 				currPose,
-				spatialmath.Compose(steps[i].arcSegment.StartPosition, steps[i].subTraj[goalTrajPtIdx].Pose),
+				spatialmath.Compose(steps[i].arcSegment.StartPosition, arcPose),
 			)
 			goals = append(goals, courseCorrectionGoal{Goal: goalPose, stepIdx: i, trajIdx: goalTrajPtIdx})
 			if len(goals) == nGoals {

--- a/components/base/kinematicbase/ptgKinematics_test.go
+++ b/components/base/kinematicbase/ptgKinematics_test.go
@@ -315,8 +315,10 @@ func TestPTGKinematicsWithGeom(t *testing.T) {
 		// To mock this up correctly, we need to alter the inputs here to simulate the base moving without a localizer
 		ms.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
 			ptgBase.inputLock.RLock()
-			newPose, err := kb.Kinematics().Transform(ptgBase.currentState.currentInputs)
+			currInputs := ptgBase.currentState.currentInputs
 			ptgBase.inputLock.RUnlock()
+			currInputs[2].Value = 0
+			newPose, err := kb.Kinematics().Transform(currInputs)
 
 			test.That(t, err, test.ShouldBeNil)
 			newGeoPose := spatialmath.PoseToGeoPose(spatialmath.NewGeoPose(gpOrigin, 0), newPose)
@@ -324,8 +326,10 @@ func TestPTGKinematicsWithGeom(t *testing.T) {
 		}
 		ms.CompassHeadingFunc = func(ctx context.Context, extra map[string]interface{}) (float64, error) {
 			ptgBase.inputLock.RLock()
-			newPose, err := kb.Kinematics().Transform(ptgBase.currentState.currentInputs)
+			currInputs := ptgBase.currentState.currentInputs
 			ptgBase.inputLock.RUnlock()
+			currInputs[2].Value = 0
+			newPose, err := kb.Kinematics().Transform(currInputs)
 			test.That(t, err, test.ShouldBeNil)
 			headingRightHanded := newPose.Orientation().OrientationVectorDegrees().Theta
 			return math.Abs(headingRightHanded) - 360, nil


### PR DESCRIPTION
It was noted that course-correcting bases could sometimes veer wildly off the path.

It was determined that the goal poses being course corrected for could be incorrect in the case where their parent arc was one which had already been course-corrected.