### PR TITLE
cleaner error in CLI when part not found

### DIFF
--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -418,6 +418,9 @@ func reloadModuleAction(c *cli.Context, vc *viamClient) error {
 	if err != nil {
 		return err
 	}
+	if part.Part == nil {
+		return fmt.Errorf("part with id=%s not found", partID)
+	}
 	// note: configureModule and restartModule signal the robot via different channels.
 	// Running this command in rapid succession can cause an extra restart because the
 	// CLI will see configuration changes before the robot, and skip to the needsRestart


### PR DESCRIPTION
## What changed
- in CLI, check for nil part + return clean error instead of segfaulting
