### PR TITLE
DOCS-2317: Add motion service code snippets

### DIFF
--- a/services/motion/motion.go
+++ b/services/motion/motion.go
@@ -195,7 +195,7 @@ type PlanWithStatus struct {
 //	// Assumes a gripper configured with name "my_gripper" on the machine
 //	gripperName := gripper.Named("my_gripper")
 //
-//	// Define destination
+//	// Define a destination Pose
 //	destination := referenceframe.NewPoseInFrame("world", spatialmath.NewPoseFromPoint(r3.Vector{X: 0.1, Y: 0.0, Z: 0.0}))
 //
 //	// Create obstacles


### PR DESCRIPTION
These code snippets were tested on a machine configured with real hardware Monday, 5/20. The purpose was to validate the functionality of these samples with the motion and SLAM services.

This error was thrown every time we tested the script. This error came up regardless of the method being called or the success of the method.

<img width="1269" alt="Screenshot 2024-05-21 at 12 12 29 PM" src="https://github.com/viamrobotics/rdk/assets/45158875/b095c068-23ad-4341-9098-c1e7697101d5">

