### PR TITLE
Move some of the genericlinux code around

### DIFF
--- a/components/board/genericlinux/analogs.go
+++ b/components/board/genericlinux/analogs.go
@@ -1,0 +1,54 @@
+//go:build linux
+
+package genericlinux
+
+import (
+	"context"
+	"sync"
+
+	"github.com/pkg/errors"
+	"go.viam.com/utils"
+
+	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/board/pinwrappers"
+	"go.viam.com/rdk/grpc"
+)
+
+type wrappedAnalogReader struct {
+	mu         sync.RWMutex
+	chipSelect string
+	reader     *pinwrappers.AnalogSmoother
+}
+
+func newWrappedAnalogReader(ctx context.Context, chipSelect string, reader *pinwrappers.AnalogSmoother) *wrappedAnalogReader {
+	var wrapped wrappedAnalogReader
+	wrapped.reset(ctx, chipSelect, reader)
+	return &wrapped
+}
+
+func (a *wrappedAnalogReader) Read(ctx context.Context, extra map[string]interface{}) (board.AnalogValue, error) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if a.reader == nil {
+		return board.AnalogValue{}, errors.New("closed")
+	}
+	return a.reader.Read(ctx, extra)
+}
+
+func (a *wrappedAnalogReader) Close(ctx context.Context) error {
+	return a.reader.Close(ctx)
+}
+
+func (a *wrappedAnalogReader) reset(ctx context.Context, chipSelect string, reader *pinwrappers.AnalogSmoother) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.reader != nil {
+		utils.UncheckedError(a.reader.Close(ctx))
+	}
+	a.reader = reader
+	a.chipSelect = chipSelect
+}
+
+func (a *wrappedAnalogReader) Write(ctx context.Context, value int, extra map[string]interface{}) error {
+	return grpc.UnimplementedError
+}

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -353,45 +353,6 @@ func (b *Board) createGpioPin(mapping GPIOBoardMapping) *gpioPin {
 	return &pin
 }
 
-type wrappedAnalogReader struct {
-	mu         sync.RWMutex
-	chipSelect string
-	reader     *pinwrappers.AnalogSmoother
-}
-
-func newWrappedAnalogReader(ctx context.Context, chipSelect string, reader *pinwrappers.AnalogSmoother) *wrappedAnalogReader {
-	var wrapped wrappedAnalogReader
-	wrapped.reset(ctx, chipSelect, reader)
-	return &wrapped
-}
-
-func (a *wrappedAnalogReader) Read(ctx context.Context, extra map[string]interface{}) (board.AnalogValue, error) {
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-	if a.reader == nil {
-		return board.AnalogValue{}, errors.New("closed")
-	}
-	return a.reader.Read(ctx, extra)
-}
-
-func (a *wrappedAnalogReader) Close(ctx context.Context) error {
-	return a.reader.Close(ctx)
-}
-
-func (a *wrappedAnalogReader) reset(ctx context.Context, chipSelect string, reader *pinwrappers.AnalogSmoother) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	if a.reader != nil {
-		utils.UncheckedError(a.reader.Close(ctx))
-	}
-	a.reader = reader
-	a.chipSelect = chipSelect
-}
-
-func (a *wrappedAnalogReader) Write(ctx context.Context, value int, extra map[string]interface{}) error {
-	return grpc.UnimplementedError
-}
-
 // Board implements a component for a Linux machine.
 type Board struct {
 	resource.Named

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -339,6 +339,20 @@ func (b *Board) reconfigureInterrupts(newConf *LinuxBoardConfig) error {
 	return nil
 }
 
+func (b *Board) createGpioPin(mapping GPIOBoardMapping) *gpioPin {
+	pin := gpioPin{
+		boardWorkers: &b.activeBackgroundWorkers,
+		devicePath:   mapping.GPIOChipDev,
+		offset:       uint32(mapping.GPIO),
+		cancelCtx:    b.cancelCtx,
+		logger:       b.logger,
+	}
+	if mapping.HWPWMSupported {
+		pin.hwPwm = newPwmDevice(mapping.PWMSysFsDir, mapping.PWMID, b.logger)
+	}
+	return &pin
+}
+
 type wrappedAnalogReader struct {
 	mu         sync.RWMutex
 	chipSelect string

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -370,17 +370,3 @@ func (pin *gpioPin) Close() error {
 
 	return nil
 }
-
-func (b *Board) createGpioPin(mapping GPIOBoardMapping) *gpioPin {
-	pin := gpioPin{
-		boardWorkers: &b.activeBackgroundWorkers,
-		devicePath:   mapping.GPIOChipDev,
-		offset:       uint32(mapping.GPIO),
-		cancelCtx:    b.cancelCtx,
-		logger:       b.logger,
-	}
-	if mapping.HWPWMSupported {
-		pin.hwPwm = newPwmDevice(mapping.PWMSysFsDir, mapping.PWMID, b.logger)
-	}
-	return &pin
-}


### PR DESCRIPTION
- `createGpioPin` is a method on the `Board` struct: put it in the file that defines `Board`. I was trying to do a different refactoring, and totally missed that this function existed!
- `wrappedAnalogReader` is a nontrivial struct: put it in its own file.

No changes to behavior are intended. 