### PR TITLE
RSDK-7677 Update Analog reader RC card

### DIFF
--- a/web/frontend/src/components/board/index.svelte
+++ b/web/frontend/src/components/board/index.svelte
@@ -95,8 +95,8 @@ const writeAnalog = async () => {
 
 const readAnalog = async () => {
   try {
-    const reading = await boardClient.readAnalogReader(analogPinName);
-    readAnalogMessage = `${analogPinName}: value is ${reading.value}`;
+    const {value} = await boardClient.readAnalogReader(analogPinName);
+    readAnalogMessage = `${analogPinName}: value is ${value}`;
   } catch (error) {
     notify.danger((error as ServiceError).message);
   }

--- a/web/frontend/src/components/board/index.svelte
+++ b/web/frontend/src/components/board/index.svelte
@@ -94,8 +94,9 @@ const writeAnalog = async () => {
 };
 
 const readAnalog = async () => {
+
   try {
-    const {value} = await boardClient.readAnalogReader(analogPinName);
+    const { value } = await boardClient.readAnalogReader(analogPinName);
     readAnalogMessage = `${analogPinName}: value is ${value}`;
   } catch (error) {
     notify.danger((error as ServiceError).message);

--- a/web/frontend/src/components/board/index.svelte
+++ b/web/frontend/src/components/board/index.svelte
@@ -95,8 +95,8 @@ const writeAnalog = async () => {
 
 const readAnalog = async () => {
   try {
-    const value = await boardClient.readAnalogReader(analogPinName);
-    readAnalogMessage = `${analogPinName}: value is ${value}`;
+    const reading = await boardClient.readAnalogReader(analogPinName);
+    readAnalogMessage = `${analogPinName}: value is ${reading.value}`;
   } catch (error) {
     notify.danger((error as ServiceError).message);
   }


### PR DESCRIPTION
board` readAnalogReader` response type was changed to a struct so we need to call `value` to get the bit value for the RC card. 
This relies on the [typescipt change ](https://github.com/viamrobotics/viam-typescript-sdk/pull/298) so will be waiting to merge this until the updated typescript sdk version is being used by RDK. 
Tested locally with a fake board.