### PR TITLE
APP-4940 - Update fake encoder config to have `ticks_per_sec` parameter

### DIFF
--- a/components/encoder/fake/encoder.go
+++ b/components/encoder/fake/encoder.go
@@ -60,8 +60,13 @@ func (e *fakeEncoder) Reconfigure(
 		return err
 	}
 	e.mu.Lock()
-	e.updateRate = newConf.UpdateRate
+
 	e.ticksPerSec = newConf.TicksPerSec
+	if e.ticksPerSec == 0 {
+		e.logger.Warnf("Fake encoder %s was reconfigued with 0 ticks_per_sec."+
+			" Set this to a positive or negative value to have the fake encoder count up or down", e.Name().ShortName())
+	}
+	e.updateRate = newConf.UpdateRate
 	if e.updateRate == 0 {
 		e.updateRate = 100
 	}

--- a/components/encoder/fake/encoder.go
+++ b/components/encoder/fake/encoder.go
@@ -89,7 +89,6 @@ type fakeEncoder struct {
 	mu          sync.RWMutex
 	workers     rdkutils.StoppableWorkers
 	position    int64
-	ticksPerSec float64 // increment to position every sec
 	updateRate  int64   // update position in start every updateRate ms
 }
 
@@ -125,7 +124,6 @@ func (e *fakeEncoder) start(cancelCtx context.Context) {
 		}
 
 		e.mu.Lock()
-		// e.position += e.ticksPerSec / float64(1000/updateRate)
 		e.position ++
 		e.mu.Unlock()
 	}

--- a/components/encoder/fake/encoder.go
+++ b/components/encoder/fake/encoder.go
@@ -83,7 +83,6 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 // fakeEncoder keeps track of a fake motor position.
 type fakeEncoder struct {
 	resource.Named
-	resource.TriviallyCloseable
 
 	positionType encoder.PositionType
 	logger       logging.Logger

--- a/components/encoder/fake/encoder.go
+++ b/components/encoder/fake/encoder.go
@@ -71,7 +71,7 @@ func (e *fakeEncoder) Reconfigure(
 
 // Config describes the configuration of a fake encoder.
 type Config struct {
-	UpdateRate  int64   `json:"update_rate_msec,omitempty"`
+	UpdateRate int64 `json:"update_rate_msec,omitempty"`
 }
 
 // Validate ensures all parts of a config is valid.
@@ -86,10 +86,10 @@ type fakeEncoder struct {
 	positionType encoder.PositionType
 	logger       logging.Logger
 
-	mu          sync.RWMutex
-	workers     rdkutils.StoppableWorkers
-	position    int64
-	updateRate  int64   // update position in start every updateRate ms
+	mu         sync.RWMutex
+	workers    rdkutils.StoppableWorkers
+	position   int64
+	updateRate int64 // update position in start every updateRate ms
 }
 
 // Position returns the current position in terms of ticks or
@@ -124,7 +124,7 @@ func (e *fakeEncoder) start(cancelCtx context.Context) {
 		}
 
 		e.mu.Lock()
-		e.position ++
+		e.position++
 		e.mu.Unlock()
 	}
 }

--- a/components/encoder/fake/encoder_test.go
+++ b/components/encoder/fake/encoder_test.go
@@ -98,29 +98,4 @@ func TestEncoder(t *testing.T) {
 			test.That(tb, err, test.ShouldBeNil)
 		})
 	})
-
-	t.Run("reconfigure with different update ticks per second", func(t *testing.T) {
-		e1 := e.(*fakeEncoder)
-		err := e1.SetSpeed(ctx, 0)
-		test.That(t, err, test.ShouldBeNil)
-		err = e1.SetPosition(ctx, 0)
-		test.That(t, err, test.ShouldBeNil)
-
-		ic := Config{
-			UpdateRate:  100,
-			TicksPerSec: 700,
-		}
-		cfg := resource.Config{Name: "enc1", ConvertedAttributes: &ic}
-		e.Reconfigure(ctx, nil, cfg)
-
-		test.That(t, e1.updateRate, test.ShouldEqual, 100)
-		test.That(t, e1.ticksPerSec, test.ShouldEqual, 700)
-
-		testutils.WaitForAssertion(t, func(tb testing.TB) {
-			tb.Helper()
-			pos, _, err := e.Position(ctx, encoder.PositionTypeUnspecified, nil)
-			test.That(tb, pos, test.ShouldBeGreaterThan, 0)
-			test.That(tb, err, test.ShouldBeNil)
-		})
-	})
 }

--- a/components/encoder/fake/encoder_test.go
+++ b/components/encoder/fake/encoder_test.go
@@ -69,27 +69,14 @@ func TestEncoder(t *testing.T) {
 		})
 	})
 
-	// Set ticks per sec
-	t.Run("set ticks per second", func(t *testing.T) {
-		e1 := e.(*fakeEncoder)
-		err := e1.SetSpeed(ctx, 1)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, e1.ticksPerSec, test.ShouldEqual, 1)
-	})
-
 	// Start with default update rate
 	t.Run("start default update rate", func(t *testing.T) {
 		e1 := e.(*fakeEncoder)
-		err := e1.SetSpeed(ctx, 0)
-		test.That(t, err, test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
 			test.That(t, e1.updateRate, test.ShouldEqual, 100)
 		})
-
-		err = e1.SetSpeed(ctx, 600)
-		test.That(t, err, test.ShouldBeNil)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()

--- a/components/encoder/fake/encoder_test.go
+++ b/components/encoder/fake/encoder_test.go
@@ -69,12 +69,12 @@ func TestEncoder(t *testing.T) {
 		})
 	})
 
-	// Set Speed
-	t.Run("set speed", func(t *testing.T) {
+	// Set ticks per sec
+	t.Run("set ticks per second", func(t *testing.T) {
 		e1 := e.(*fakeEncoder)
 		err := e1.SetSpeed(ctx, 1)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, e1.speed, test.ShouldEqual, 1)
+		test.That(t, e1.ticksPerSec, test.ShouldEqual, 1)
 	})
 
 	// Start with default update rate
@@ -99,7 +99,7 @@ func TestEncoder(t *testing.T) {
 		})
 	})
 
-	t.Run("reconfigure with speed", func(t *testing.T) {
+	t.Run("reconfigure with different update ticks per second", func(t *testing.T) {
 		e1 := e.(*fakeEncoder)
 		err := e1.SetSpeed(ctx, 0)
 		test.That(t, err, test.ShouldBeNil)
@@ -107,14 +107,14 @@ func TestEncoder(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		ic := Config{
-			UpdateRate: 100,
-			Speed:      700,
+			UpdateRate:  100,
+			TicksPerSec: 700,
 		}
 		cfg := resource.Config{Name: "enc1", ConvertedAttributes: &ic}
 		e.Reconfigure(ctx, nil, cfg)
 
 		test.That(t, e1.updateRate, test.ShouldEqual, 100)
-		test.That(t, e1.speed, test.ShouldEqual, 700)
+		test.That(t, e1.ticksPerSec, test.ShouldEqual, 700)
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()

--- a/components/motor/fake/motor.go
+++ b/components/motor/fake/motor.go
@@ -209,17 +209,6 @@ func (m *Motor) SetPower(ctx context.Context, powerPct float64, extra map[string
 	m.Logger.CDebugf(ctx, "Motor SetPower %f", powerPct)
 	m.setPowerPct(powerPct)
 
-	if m.Encoder != nil {
-		if m.TicksPerRotation <= 0 {
-			return errors.New("need positive nonzero TicksPerRotation")
-		}
-
-		newSpeed := (m.MaxRPM * m.powerPct) * float64(m.TicksPerRotation)
-		err := m.Encoder.SetSpeed(ctx, newSpeed)
-		if err != nil {
-			return err
-		}
-	}
 	return nil
 }
 
@@ -373,12 +362,6 @@ func (m *Motor) Stop(ctx context.Context, extra map[string]interface{}) error {
 
 	m.Logger.CDebug(ctx, "Motor Stopped")
 	m.setPowerPct(0.0)
-	if m.Encoder != nil {
-		err := m.Encoder.SetSpeed(ctx, 0.0)
-		if err != nil {
-			return errors.Wrapf(err, "error in Stop from motor (%s)", m.Name())
-		}
-	}
 	return nil
 }
 

--- a/components/motor/fake/motor_test.go
+++ b/components/motor/fake/motor_test.go
@@ -60,14 +60,15 @@ func TestGoFor(t *testing.T) {
 
 	err = m.GoFor(ctx, 0, 1, nil)
 	allObs := obs.All()
-	test.That(t, fmt.Sprint(allObs), test.ShouldContainSubstring, "nearly 0")
-	// test.That(t, fmt.Sprint(latestLoggedEntry), test.ShouldContainSubstring, "nearly 0")
+	latestLoggedEntry := allObs[len(allObs)-1]
+	test.That(t, fmt.Sprint(latestLoggedEntry), test.ShouldContainSubstring, "nearly 0")
 	test.That(t, err, test.ShouldBeError, motor.NewZeroRPMError())
 
 	err = m.GoFor(ctx, 60, 1, nil)
 	test.That(t, err, test.ShouldBeNil)
 	allObs = obs.All()
-	test.That(t, fmt.Sprint(allObs), test.ShouldContainSubstring, "nearly the max")
+	latestLoggedEntry = allObs[1]
+	test.That(t, fmt.Sprint(latestLoggedEntry), test.ShouldContainSubstring, "nearly the max")
 
 	testutils.WaitForAssertion(t, func(tb testing.TB) {
 		tb.Helper()

--- a/components/motor/fake/motor_test.go
+++ b/components/motor/fake/motor_test.go
@@ -60,15 +60,14 @@ func TestGoFor(t *testing.T) {
 
 	err = m.GoFor(ctx, 0, 1, nil)
 	allObs := obs.All()
-	latestLoggedEntry := allObs[len(allObs)-1]
-	test.That(t, fmt.Sprint(latestLoggedEntry), test.ShouldContainSubstring, "nearly 0")
+    test.That(t, fmt.Sprint(allObs), test.ShouldContainSubstring, "nearly 0")
+	// test.That(t, fmt.Sprint(latestLoggedEntry), test.ShouldContainSubstring, "nearly 0")
 	test.That(t, err, test.ShouldBeError, motor.NewZeroRPMError())
 
 	err = m.GoFor(ctx, 60, 1, nil)
 	test.That(t, err, test.ShouldBeNil)
 	allObs = obs.All()
-	latestLoggedEntry = allObs[1]
-	test.That(t, fmt.Sprint(latestLoggedEntry), test.ShouldContainSubstring, "nearly the max")
+	test.That(t, fmt.Sprint(allObs), test.ShouldContainSubstring, "nearly the max")
 
 	testutils.WaitForAssertion(t, func(tb testing.TB) {
 		tb.Helper()

--- a/components/motor/fake/motor_test.go
+++ b/components/motor/fake/motor_test.go
@@ -60,7 +60,7 @@ func TestGoFor(t *testing.T) {
 
 	err = m.GoFor(ctx, 0, 1, nil)
 	allObs := obs.All()
-    test.That(t, fmt.Sprint(allObs), test.ShouldContainSubstring, "nearly 0")
+	test.That(t, fmt.Sprint(allObs), test.ShouldContainSubstring, "nearly 0")
 	// test.That(t, fmt.Sprint(latestLoggedEntry), test.ShouldContainSubstring, "nearly 0")
 	test.That(t, err, test.ShouldBeError, motor.NewZeroRPMError())
 


### PR DESCRIPTION
Useful for viz team config testing: https://viam.atlassian.net/browse/APP-4940


New proposed config for a fake encoder:
```json
    {
      "name": "encoder-1",
      "namespace": "rdk",
      "type": "encoder",
      "model": "fake",
      "attributes": {
        "update_rate_msec": 100,
        "ticks_per_sec": 610
      }
    },
```

I also changed this to use a StoppableWorkers group because there was a subtle bug with the context being canceled too early