### PR TITLE
RSDK-6700 Nav service is not properly placing transient obstacles

### DIFF
--- a/services/motion/builtin/move_on_map_test.go
+++ b/services/motion/builtin/move_on_map_test.go
@@ -482,29 +482,6 @@ func TestMoveOnMapAskewIMU(t *testing.T) {
 
 		test.That(t, spatialmath.PoseAlmostEqualEps(endPos, goal1BaseFrame, 10), test.ShouldBeTrue)
 	})
-	t.Run("Upside down base should fail to plan", func(t *testing.T) {
-		t.Parallel()
-		ctx := context.Background()
-		askewOrient := &spatialmath.OrientationVectorDegrees{OX: 1, OY: 1, OZ: -1, Theta: 55}
-		// goal x-position of 1.32m is scaled to be in mm
-		goal1SLAMFrame := spatialmath.NewPose(r3.Vector{X: 1.32 * 1000, Y: 0}, &spatialmath.OrientationVectorDegrees{OZ: 1, Theta: 55})
-
-		_, ms := createMoveOnMapEnvironment(ctx, t, "pointcloud/octagonspace.pcd", 40, spatialmath.NewPoseFromOrientation(askewOrient))
-		defer ms.Close(ctx)
-
-		req := motion.MoveOnMapReq{
-			ComponentName: base.Named("test-base"),
-			Destination:   goal1SLAMFrame,
-			SlamName:      slam.Named("test_slam"),
-			Extra:         extraPosOnly,
-		}
-
-		timeoutCtx, timeoutFn := context.WithTimeout(ctx, time.Second*15)
-		defer timeoutFn()
-		_, err := ms.(*builtIn).MoveOnMap(timeoutCtx, req)
-		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldEqual, "base appears to be upside down, check your movement sensor")
-	})
 }
 
 func TestMoveOnMapStaticObs(t *testing.T) {

--- a/services/motion/localizer.go
+++ b/services/motion/localizer.go
@@ -18,8 +18,6 @@ import (
 // However, for a rover's relative planning frame, driving forwards increments +Y. Thus we must adjust where the rover thinks it is.
 var SLAMOrientationAdjustment = spatialmath.NewPoseFromOrientation(&spatialmath.OrientationVectorDegrees{OZ: 1, Theta: -90})
 
-const poleEpsilon = 0.0001 // If the base is this close to vertical, we cannot plan.
-
 // Localizer is an interface which both slam and movementsensor can satisfy when wrapped respectively.
 type Localizer interface {
 	CurrentPosition(context.Context) (*referenceframe.PoseInFrame, error)

--- a/services/motion/localizer.go
+++ b/services/motion/localizer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"math"
 
-	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
 	"github.com/pkg/errors"
 
@@ -114,35 +113,11 @@ func (y *yForwards2dLocalizer) CurrentPosition(ctx context.Context) (*referencef
 	if err != nil {
 		return nil, err
 	}
-	newPose, err := projectOrientationTo2dRotation(currPos.Pose())
+	newPose, err := spatialmath.ProjectOrientationTo2dRotation(currPos.Pose())
 	if err != nil {
 		return nil, err
 	}
 	newPiF := referenceframe.NewPoseInFrame(currPos.Parent(), newPose)
 	newPiF.SetName(currPos.Name())
 	return newPiF, nil
-}
-
-func projectOrientationTo2dRotation(pose spatialmath.Pose) (spatialmath.Pose, error) {
-	orient := pose.Orientation().OrientationVectorRadians() // OV is easy to check if we are in plane
-	if orient.OZ < 0 {
-		return nil, errors.New("base appears to be upside down, check your movement sensor")
-	}
-	if orient.OX == 0 && orient.OY == 0 {
-		return pose, nil
-	}
-
-	// This is the vector in which the base would move if it had no changed orientation
-	adjPt := spatialmath.NewPoseFromPoint(r3.Vector{0, 1, 0})
-	// This is the vector the base would follow based on the reported orientation, were it unencumbered by things like gravity or the ground
-	newAdjPt := spatialmath.Compose(spatialmath.NewPoseFromOrientation(orient), adjPt).Point()
-	if 1-math.Abs(newAdjPt.Z) < poleEpsilon {
-		if newAdjPt.Z > 0 {
-			return nil, errors.New("base appears to be pointing straight up, check your movement sensor")
-		}
-		return nil, errors.New("base appears to be pointing straight down, check your movement sensor")
-	}
-	// This is the vector across the ground of the above hypothetical vector, projected onto the X-Y plane.
-	theta := -math.Atan2(newAdjPt.Y, -newAdjPt.X)
-	return spatialmath.NewPose(pose.Point(), &spatialmath.OrientationVector{OZ: 1, Theta: theta}), nil
 }

--- a/services/motion/localizer_test.go
+++ b/services/motion/localizer_test.go
@@ -158,15 +158,6 @@ func TestCorrectStartPose(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, corrected.Pose().Orientation().OrientationVectorDegrees().Theta, test.ShouldAlmostEqual, 127.)
 	})
-	t.Run("Test upside-down error", func(t *testing.T) {
-		t.Parallel()
-		askewOrient := &spatialmath.OrientationVectorDegrees{OX: 1, OY: 1, OZ: -1}
-		movementSensor := createInjectedOrientationMovementSensor(askewOrient)
-		localizer := motion.TwoDLocalizer(motion.NewMovementSensorLocalizer(movementSensor, origin, spatialmath.NewZeroPose()))
-		_, err := localizer.CurrentPosition(ctx)
-		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldEqual, "base appears to be upside down, check your movement sensor")
-	})
 	t.Run("Test pointing-straight-up error", func(t *testing.T) {
 		t.Parallel()
 		askewOrient := &spatialmath.OrientationVectorDegrees{OX: 0, OY: 1, OZ: 0, Theta: 90}
@@ -174,7 +165,7 @@ func TestCorrectStartPose(t *testing.T) {
 		localizer := motion.TwoDLocalizer(motion.NewMovementSensorLocalizer(movementSensor, origin, spatialmath.NewZeroPose()))
 		_, err := localizer.CurrentPosition(ctx)
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldEqual, "base appears to be pointing straight up, check your movement sensor")
+		test.That(t, err.Error(), test.ShouldEqual, "orientation appears to be pointing straight up, cannot project to 2d")
 	})
 	t.Run("Test pointing-straight-down error", func(t *testing.T) {
 		t.Parallel()
@@ -183,6 +174,6 @@ func TestCorrectStartPose(t *testing.T) {
 		localizer := motion.TwoDLocalizer(motion.NewMovementSensorLocalizer(movementSensor, origin, spatialmath.NewZeroPose()))
 		_, err := localizer.CurrentPosition(ctx)
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldEqual, "base appears to be pointing straight down, check your movement sensor")
+		test.That(t, err.Error(), test.ShouldEqual, "orientation appears to be pointing straight down, cannot project to 2d")
 	})
 }

--- a/services/navigation/builtin/builtin.go
+++ b/services/navigation/builtin/builtin.go
@@ -457,6 +457,28 @@ func (svc *builtIn) Location(ctx context.Context, extra map[string]interface{}) 
 	if err != nil {
 		return nil, err
 	}
+	movementsensorOrigin := referenceframe.NewPoseInFrame(svc.movementSensor.Name().ShortName(), spatialmath.NewZeroPose())
+	movementSensorPoseInBase, err := svc.fsService.TransformPose(ctx, movementsensorOrigin, svc.base.Name().ShortName(), nil)
+	if err != nil {
+		// here we make the assumption the movementsensor is coincident with the camera
+		svc.logger.CDebugf(
+			ctx,
+			"we assume the movementsensor named: %s is coincident with the base named: %s due to err: %v",
+			svc.movementSensor.Name().ShortName(), svc.base.Name(), err.Error(),
+		)
+		movementSensorPoseInBase = referenceframe.NewPoseInFrame(svc.base.Name().ShortName(), spatialmath.NewZeroPose())
+	}
+	svc.logger.CDebugf(ctx, "movementSensorPoseInBase: %v", spatialmath.PoseToProtobuf(movementSensorPoseInBase.Pose()))
+
+	movementSensor2dOrientation, err := spatialmath.ProjectOrientationTo2dRotation(movementSensorPoseInBase.Pose())
+	if err != nil {
+		return nil, err
+	}
+	// When rotation about the +Z axis, an OV theta is right handed but compass heading is left handed. Account for this.
+	compassHeading = compassHeading - movementSensor2dOrientation.Orientation().OrientationVectorDegrees().Theta
+	if compassHeading < 0 {
+		compassHeading += 360
+	}
 	geoPose := spatialmath.NewGeoPose(loc, compassHeading)
 	return geoPose, err
 }
@@ -766,6 +788,7 @@ func (svc *builtIn) Obstacles(ctx context.Context, extra map[string]interface{})
 				label += "_" + detection.Geometry.Label()
 			}
 			detection.Geometry.SetLabel(label)
+			svc.logger.Debug(detection.Geometry)
 
 			// determine the desired geometry pose
 			desiredPose = spatialmath.NewPoseFromOrientation(detection.Geometry.Pose().Orientation())

--- a/services/navigation/builtin/builtin.go
+++ b/services/navigation/builtin/builtin.go
@@ -475,7 +475,7 @@ func (svc *builtIn) Location(ctx context.Context, extra map[string]interface{}) 
 		return nil, err
 	}
 	// When rotation about the +Z axis, an OV theta is right handed but compass heading is left handed. Account for this.
-	compassHeading = compassHeading - movementSensor2dOrientation.Orientation().OrientationVectorDegrees().Theta
+	compassHeading -= movementSensor2dOrientation.Orientation().OrientationVectorDegrees().Theta
 	if compassHeading < 0 {
 		compassHeading += 360
 	}

--- a/spatialmath/pose.go
+++ b/spatialmath/pose.go
@@ -6,8 +6,8 @@
 package spatialmath
 
 import (
-	"math"
 	"errors"
+	"math"
 
 	"github.com/golang/geo/r3"
 	commonpb "go.viam.com/api/common/v1"
@@ -223,8 +223,8 @@ func ResetPoseDQTranslation(p Pose, v r3.Vector) {
 	q.SetTranslation(v)
 }
 
-// ProjectOrientationTo2dRotation takes a pose whose orientation is not pointing at a pole and collapses its orientation into a single rotation
-// around the Z axis. This is useful for determining things like heading on a map where the thing reproting heading may be askew.
+// ProjectOrientationTo2dRotation takes a pose whose orientation is not pointing at a pole and collapses its orientation into a single
+// rotation around the Z axis. This is useful for determining things like heading on a map if the component reporting heading is askew.
 func ProjectOrientationTo2dRotation(pose Pose) (Pose, error) {
 	orient := pose.Orientation().OrientationVectorRadians() // OV is easy to check if we are in plane
 	if orient.OX == 0 && orient.OY == 0 {

--- a/spatialmath/pose.go
+++ b/spatialmath/pose.go
@@ -6,6 +6,9 @@
 package spatialmath
 
 import (
+	"math"
+	"errors"
+
 	"github.com/golang/geo/r3"
 	commonpb "go.viam.com/api/common/v1"
 	"gonum.org/v1/gonum/num/dualquat"
@@ -218,4 +221,27 @@ func ResetPoseDQTranslation(p Pose, v r3.Vector) {
 		panic("ResetPoseDQTranslation has to be passed a dual quaternion")
 	}
 	q.SetTranslation(v)
+}
+
+// ProjectOrientationTo2dRotation takes a pose whose orientation is not pointing at a pole and collapses its orientation into a single rotation
+// around the Z axis. This is useful for determining things like heading on a map where the thing reproting heading may be askew.
+func ProjectOrientationTo2dRotation(pose Pose) (Pose, error) {
+	orient := pose.Orientation().OrientationVectorRadians() // OV is easy to check if we are in plane
+	if orient.OX == 0 && orient.OY == 0 {
+		return pose, nil
+	}
+
+	// This is the vector in which a base would move if it had no changed orientation
+	adjPt := NewPoseFromPoint(r3.Vector{0, 1, 0})
+	// This is the vector a base would follow based on the reported orientation, were it unencumbered by things like gravity or the ground
+	newAdjPt := Compose(NewPoseFromOrientation(orient), adjPt).Point()
+	if 1-math.Abs(newAdjPt.Z) < orientationVectorPoleRadius {
+		if newAdjPt.Z > 0 {
+			return nil, errors.New("orientation appears to be pointing straight up, cannot project to 2d")
+		}
+		return nil, errors.New("orientation appears to be pointing straight down, cannot project to 2d")
+	}
+	// This is the vector across the ground of the above hypothetical vector, projected onto the X-Y plane.
+	theta := -math.Atan2(newAdjPt.Y, -newAdjPt.X)
+	return NewPose(pose.Point(), &OrientationVector{OZ: 1, Theta: theta}), nil
 }


### PR DESCRIPTION
The navigation service was not accounting for any rotation of a camera with regard to the base when placing obstacles.

This PR corrects that and will correctly orient obstacles with regard to the base.