### PR TITLE
RSDK-7670 Fix flaking test

### DIFF
--- a/components/base/kinematicbase/execution.go
+++ b/components/base/kinematicbase/execution.go
@@ -76,7 +76,7 @@ func (ptgk *ptgBaseKinematics) GoToInputs(ctx context.Context, inputSteps ...[]r
 
 	defer func() {
 		ptgk.inputLock.Lock()
-		ptgk.currentState.currentInputs = zeroInput
+		ptgk.currentState = baseState{currentInputs: zeroInput}
 		ptgk.inputLock.Unlock()
 	}()
 

--- a/components/base/kinematicbase/fake_kinematics.go
+++ b/components/base/kinematicbase/fake_kinematics.go
@@ -268,9 +268,11 @@ func (fk *fakePTGKinematics) GoToInputs(ctx context.Context, inputSteps ...[]ref
 
 		fk.inputLock.Lock()
 		fk.currentIndex = i
-		fk.currentInput = []referenceframe.Input{inputs[0], inputs[1], inputs[2], inputs[2]}
+		fk.currentInput, err = fk.frame.Interpolate(zeroInput, inputs, 0)
 		fk.inputLock.Unlock()
-
+		if err != nil {
+			return err
+		}
 		finalPose, err := fk.frame.Transform(inputs)
 		if err != nil {
 			return err


### PR DESCRIPTION
Fake PTG kinematics was briefly reporting an incorrect starting currentInputs each time it went to a negative input.

If CheckFrame is called on the fake base between that call and the first time it gets updated across an arc (a window of ~50ms) then it will error out.

This PR corrects the starting currentInputs to be correct, and thus not error.