### PR TITLE
RSDK-7703: Grab more diagnostics in TestFilePolling files on disk.

### DIFF
--- a/services/datamanager/builtin/capture_test.go
+++ b/services/datamanager/builtin/capture_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 	v1 "go.viam.com/api/app/datasync/v1"
 	"go.viam.com/test"
 
+	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/services/datamanager/datacapture"
@@ -366,7 +368,9 @@ func waitForCaptureFilesToExceedNFiles(captureDir string, n int) {
 
 // waitForCaptureFilesToEqualNFiles returns once `captureDir` has exactly `n` files of at least
 // `emptyFileBytesSize` bytes.
-func waitForCaptureFilesToEqualNFiles(captureDir string, n int) {
+func waitForCaptureFilesToEqualNFiles(captureDir string, n int, logger logging.Logger) {
+	var diagnostics sync.Once
+	start := time.Now()
 	for {
 		files := getAllFileInfos(captureDir)
 		nonEmptyFiles := 0
@@ -383,6 +387,14 @@ func waitForCaptureFilesToEqualNFiles(captureDir string, n int) {
 		}
 
 		time.Sleep(10 * time.Millisecond)
+		if time.Since(start) > 10*time.Second {
+			diagnostics.Do(func() {
+				logger.Infow("waitForCaptureFilesToEqualNFiles diagnostics after 10 seconds of waiting", "numFiles", len(files), "expectedFiles", n)
+				for idx, file := range files {
+					logger.Infow("File information", "idx", idx, "name", file.Name(), "size", file.Size())
+				}
+			})
+		}
 	}
 }
 

--- a/services/datamanager/builtin/capture_test.go
+++ b/services/datamanager/builtin/capture_test.go
@@ -391,7 +391,7 @@ func waitForCaptureFilesToEqualNFiles(captureDir string, n int, logger logging.L
 			diagnostics.Do(func() {
 				logger.Infow("waitForCaptureFilesToEqualNFiles diagnostics after 10 seconds of waiting", "numFiles", len(files), "expectedFiles", n)
 				for idx, file := range files {
-					logger.Infow("File information", "idx", idx, "name", file.Name(), "size", file.Size())
+					logger.Infow("File information", "idx", idx, "dir", captureDir, "name", file.Name(), "size", file.Size())
 				}
 			})
 		}

--- a/services/datamanager/builtin/file_deletion_test.go
+++ b/services/datamanager/builtin/file_deletion_test.go
@@ -207,6 +207,7 @@ func getFiles(t *testing.T, path string) []string {
 }
 
 func TestFilePolling(t *testing.T) {
+	logger := logging.NewTestLogger(t)
 	mockClock := clk.NewMock()
 	// Make mockClock the package level clock used by the dmsvc so that we can simulate time's passage
 	clock = mockClock
@@ -230,7 +231,7 @@ func TestFilePolling(t *testing.T) {
 	flusher.closeCollectors()
 	// number of capture files is based on the number of unique
 	// collectors in the robot config used in this test
-	waitForCaptureFilesToEqualNFiles(tempDir, 4)
+	waitForCaptureFilesToEqualNFiles(tempDir, 4, logger)
 
 	files := getAllFileInfos(tempDir)
 	test.That(t, len(files), test.ShouldEqual, 4)
@@ -240,7 +241,7 @@ func TestFilePolling(t *testing.T) {
 
 	// run forward 20ms to delete any files
 	mockClock.Add(filesystemPollInterval)
-	waitForCaptureFilesToEqualNFiles(tempDir, 3)
+	waitForCaptureFilesToEqualNFiles(tempDir, 3, logger)
 	newFiles := getAllFileInfos(tempDir)
 	test.That(t, len(newFiles), test.ShouldEqual, 3)
 	test.That(t, newFiles, test.ShouldNotContain, expectedDeletedFile)


### PR DESCRIPTION
I hand tested this by changing the number of files we needed to see before moving on. This is the sample output:
```
    capture_test.go:392: 2024-05-21T16:29:45.356-0400	INFO		builtin/capture_test.go:392	waitForCaptureFilesToEqualNFiles diagnostics after 10 seconds of waiting	{"numFiles":4,"expectedFiles":5}
    capture_test.go:394: 2024-05-21T16:29:45.357-0400	INFO		builtin/capture_test.go:394	File information	{"idx":0,"name":"2024-05-21T16_29_35.343210622-04_00.capture","size":203}
    capture_test.go:394: 2024-05-21T16:29:45.357-0400	INFO		builtin/capture_test.go:394	File information	{"idx":1,"name":"2024-05-21T16_29_35.34433745-04_00.capture","size":111}
    capture_test.go:394: 2024-05-21T16:29:45.357-0400	INFO		builtin/capture_test.go:394	File information	{"idx":2,"name":"2024-05-21T16_29_35.346710614-04_00.capture","size":97}
    capture_test.go:394: 2024-05-21T16:29:45.357-0400	INFO		builtin/capture_test.go:394	File information	{"idx":3,"name":"2024-05-21T16_29_35.345554441-04_00.capture","size":100}
```