### PR TITLE
RSDK-7670 Fix errorstate when plan is complete

### DIFF
--- a/components/base/kinematicbase/ptgKinematics.go
+++ b/components/base/kinematicbase/ptgKinematics.go
@@ -212,6 +212,11 @@ func (ptgk *ptgBaseKinematics) ErrorState(ctx context.Context) (spatialmath.Pose
 	currentInputs := ptgk.currentState.currentInputs
 	ptgk.inputLock.RUnlock()
 
+	if currentExecutingSteps == nil {
+		// We are not currently executing a plan
+		return spatialmath.NewZeroPose(), nil
+	}
+
 	currPoseInArc, err := ptgk.frame.Transform(currentInputs)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Previous PR to fix a flaky test missed an update to `ErrorState()` which caused panics when completing plans.