### PR TITLE
RSDK-6925 Add parity test for sync/async reconfigure flows

### DIFF
--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -1109,12 +1109,6 @@ func (r *localRobot) Reconfigure(ctx context.Context, newConfig *config.Config) 
 	r.reconfigure(ctx, newConfig, false)
 }
 
-// ReconfigureSync is like Reconfigure, but prevents any resources from being processed
-// concurrently.
-func (r *localRobot) ReconfigureSync(ctx context.Context, newConfig *config.Config) {
-	r.reconfigure(ctx, newConfig, true)
-}
-
 func (r *localRobot) reconfigure(ctx context.Context, newConfig *config.Config, forceSync bool) {
 	var allErrs error
 

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -510,7 +510,7 @@ func newWithResources(
 			anyChanges := r.manager.updateRemotesResourceNames(closeCtx)
 			if r.manager.anyResourcesNotConfigured() {
 				anyChanges = true
-				r.manager.completeConfig(closeCtx, r)
+				r.manager.completeConfig(closeCtx, r, false)
 			}
 			if anyChanges {
 				r.updateWeakDependents(ctx)
@@ -1106,6 +1106,16 @@ func dialRobotClient(
 // a best effort to remove no longer in use parts, but if it fails to do so, they could
 // possibly leak resources. The given config may be modified by Reconfigure.
 func (r *localRobot) Reconfigure(ctx context.Context, newConfig *config.Config) {
+	r.reconfigure(ctx, newConfig, false)
+}
+
+// ReconfigureSync is like Reconfigure, but prevents any resources from being processed
+// concurrently.
+func (r *localRobot) ReconfigureSync(ctx context.Context, newConfig *config.Config) {
+	r.reconfigure(ctx, newConfig, true)
+}
+
+func (r *localRobot) reconfigure(ctx context.Context, newConfig *config.Config, forceSync bool) {
 	var allErrs error
 
 	// Sync Packages before reconfiguring rest of robot and resolving references to any packages
@@ -1202,7 +1212,7 @@ func (r *localRobot) Reconfigure(ctx context.Context, newConfig *config.Config) 
 
 	// Fourth we attempt to complete the config (see function for details) and
 	// update weak dependents.
-	r.manager.completeConfig(ctx, r)
+	r.manager.completeConfig(ctx, r, forceSync)
 	r.updateWeakDependents(ctx)
 
 	// Finally we actually remove marked resources and Close any that are

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -519,8 +519,13 @@ func (manager *resourceManager) Close(ctx context.Context) error {
 
 // completeConfig process the tree in reverse order and attempts to build or reconfigure
 // resources that are wrapped in a placeholderResource. this function will attempt to
-// process resources concurrently when they do not depend on each other.
-func (manager *resourceManager) completeConfig(ctx context.Context, lr *localRobot) {
+// process resources concurrently when they do not depend on each other unless
+// `forceSynce` is set to true.
+func (manager *resourceManager) completeConfig(
+	ctx context.Context,
+	lr *localRobot,
+	forceSync bool,
+) {
 	manager.configLock.Lock()
 	defer func() {
 		if err := manager.viz.SaveSnapshot(manager.resources); err != nil {
@@ -672,16 +677,19 @@ func (manager *resourceManager) completeConfig(ctx context.Context, lr *localRob
 				return nil
 			}
 
-			var processSync bool
-			// TODO(RSDK-6925): support concurrent processing of resources of APIs with a
-			// maximum instance limit. Currently this limit is validated later in the
-			// resource creation flow and assumes that each resource is created
-			// synchronously to have an accurate creation count.
-			if c, ok := resource.LookupGenericAPIRegistration(resName.API); ok && c.MaxInstance != 0 {
-				processSync = true
+			syncRes := forceSync
+			if !syncRes {
+				// TODO(RSDK-6925): support concurrent processing of resources of
+				// APIs with a maximum instance limit. Currently this limit is
+				// validated later in the resource creation flow and assumes that
+				// each resource is created synchronously to have an accurate
+				// creation count.
+				if c, ok := resource.LookupGenericAPIRegistration(resName.API); ok && c.MaxInstance != 0 {
+					syncRes = true
+				}
 			}
 
-			if processSync {
+			if syncRes {
 				if err := processResource(); err != nil {
 					return
 				}

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -696,7 +696,7 @@ func (manager *resourceManager) completeConfig(
 			} else {
 				lr.reconfigureWorkers.Add(1)
 				levelErrG.Go(func() error {
-					lr.reconfigureWorkers.Done()
+					defer lr.reconfigureWorkers.Done()
 					return processResource()
 				})
 			}

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -1857,6 +1857,7 @@ func managerForDummyRobot(t *testing.T, robot robot.Robot) *resourceManager {
 // of `Reconfigure` results in the same resource state on a local robot for all
 // combinations of an initial and updated configuration.
 func TestReconfigureParity(t *testing.T) {
+	// TODO(RSDK-7716): add some configurations with modules.
 	files := []string{
 		"data/diff_config_deps1.json",
 		"data/diff_config_deps2.json",

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"fmt"
 	"os"
 	"sync"
 	"testing"
@@ -24,6 +25,7 @@ import (
 	"go.viam.com/utils/pexec"
 	"go.viam.com/utils/rpc"
 	"go.viam.com/utils/testutils"
+	"gonum.org/v1/gonum/stat/combin"
 	"google.golang.org/protobuf/testing/protocmp"
 
 	"go.viam.com/rdk/cloud"
@@ -1849,4 +1851,73 @@ func managerForDummyRobot(t *testing.T, robot robot.Robot) *resourceManager {
 		test.That(t, manager.resources.AddNode(name, gNode), test.ShouldBeNil)
 	}
 	return manager
+}
+
+// TestReconfigureParity validates that calling the synchronous and asynchronous version
+// of `Reconfigure` results in the same resource state on a local robot for all
+// combinations of an initial and updated configuration.
+func TestReconfigureParity(t *testing.T) {
+	files := []string{
+		"data/diff_config_deps1.json",
+		"data/diff_config_deps2.json",
+		"data/diff_config_deps3.json",
+		"data/diff_config_deps4.json",
+		"data/diff_config_deps5.json",
+		"data/diff_config_deps6.json",
+		"data/diff_config_deps7.json",
+		"data/diff_config_deps8.json",
+		"data/diff_config_deps9_good.json",
+		"data/diff_config_deps9_bad.json",
+		"data/diff_config_deps10.json",
+		"data/diff_config_deps11.json",
+		"data/diff_config_deps12.json",
+	}
+	logger := logging.NewTestLogger(t)
+	ctx := context.Background()
+
+	testReconfigureParity := func(t *testing.T, initCfg, updateCfg string) {
+		name := fmt.Sprintf("%s -> %s", initCfg, updateCfg)
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// Configuration may mutate `*config.Config`, so we read it from
+			// file each time.
+			cfg := ConfigFromFile(t, initCfg)
+			r1 := setupLocalRobot(t, ctx, cfg, logger).(*localRobot)
+			cfg = ConfigFromFile(t, initCfg)
+			r2 := setupLocalRobot(t, ctx, cfg, logger).(*localRobot)
+
+			test.That(
+				t,
+				rdktestutils.NewResourceNameSet(r1.ResourceNames()...),
+				test.ShouldResemble,
+				rdktestutils.NewResourceNameSet(r2.ResourceNames()...),
+			)
+
+			cfg = ConfigFromFile(t, updateCfg)
+			r1.Reconfigure(ctx, cfg)
+			cfg = ConfigFromFile(t, updateCfg)
+			r2.ReconfigureSync(ctx, cfg)
+
+			test.That(
+				t,
+				rdktestutils.NewResourceNameSet(r1.ResourceNames()...),
+				test.ShouldResemble,
+				rdktestutils.NewResourceNameSet(r2.ResourceNames()...),
+			)
+		})
+	}
+
+	gen := combin.NewCombinationGenerator(len(files), 2)
+
+	pair := []int{0, 0}
+	for gen.Next() {
+		gen.Combination(pair)
+
+		i, j := pair[0], pair[1]
+		testReconfigureParity(t, files[i], files[j])
+
+		i, j = pair[1], pair[0]
+		testReconfigureParity(t, files[i], files[j])
+	}
 }

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -1897,7 +1897,8 @@ func TestReconfigureParity(t *testing.T) {
 			cfg = ConfigFromFile(t, updateCfg)
 			r1.Reconfigure(ctx, cfg)
 			cfg = ConfigFromFile(t, updateCfg)
-			r2.ReconfigureSync(ctx, cfg)
+			// force robot to reconfigure resources serially
+			r2.reconfigure(ctx, cfg, true)
 
 			test.That(
 				t,

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -53,17 +53,18 @@ var (
 	testReconfiguringMismatch = false
 )
 
+func ConfigFromFile(tb testing.TB, filePath string) *config.Config {
+	tb.Helper()
+	logger := logging.NewTestLogger(tb)
+	buf, err := envsubst.ReadFile(filePath)
+	test.That(tb, err, test.ShouldBeNil)
+	conf, err := config.FromReader(context.Background(), filePath, bytes.NewReader(buf), logger)
+	test.That(tb, err, test.ShouldBeNil)
+	return conf
+}
+
 func TestRobotReconfigure(t *testing.T) {
 	test.That(t, len(resource.DefaultServices()), test.ShouldEqual, 2)
-	ConfigFromFile := func(t *testing.T, filePath string) *config.Config {
-		t.Helper()
-		logger := logging.NewTestLogger(t)
-		buf, err := envsubst.ReadFile(filePath)
-		test.That(t, err, test.ShouldBeNil)
-		conf, err := config.FromReader(context.Background(), filePath, bytes.NewReader(buf), logger)
-		test.That(t, err, test.ShouldBeNil)
-		return conf
-	}
 	mockAPI := resource.APINamespaceRDK.WithComponentType("mock")
 	mockNamed := func(name string) resource.Name {
 		return resource.NewName(mockAPI, name)


### PR DESCRIPTION
Add a parity test that asserts sync and async reconfigure flows produce the same resource state. 

We [previously discussed](https://github.com/viamrobotics/rdk/pull/3707#discussion_r1600236702) making this part of [the PR that introduced async reconfiguration](https://github.com/viamrobotics/rdk/pull/3707) but were concerned that this test might be a pain to maintain due to it's fuzzy nature and opted to use it as a one-time smoke test. However, after further discussion IRL, we think it's important to have as a long-term fixture.