### PR TITLE
RSDK-7674 - Fix flake: TestValidationFailureDuringReconfiguration

### DIFF
--- a/module/version_reconfigure_test.go
+++ b/module/version_reconfigure_test.go
@@ -65,7 +65,7 @@ func TestValidationFailureDuringReconfiguration(t *testing.T) {
 
 	// Assert that there were no validation or component building errors
 	test.That(t, logs.FilterMessageSnippet(
-		"modular config validation error found in resource: generic1").Len(), test.ShouldEqual, 0)
+		"Modular config validation error found in resource: generic1").Len(), test.ShouldEqual, 0)
 	test.That(t, logs.FilterMessageSnippet("error building component").Len(), test.ShouldEqual, 0)
 
 	// Read the config, swap to `run_version2.sh`, and overwrite the config, triggering a
@@ -86,7 +86,7 @@ func TestValidationFailureDuringReconfiguration(t *testing.T) {
 	// Race condition safety: Resource removal should occur after modular resource validation (during completeConfig), so if
 	// ResourceByName is failing, these errors should already be present
 	test.That(t, logs.FilterMessageSnippet(
-		"modular config validation error found in resource: generic1").Len(), test.ShouldEqual, 1)
+		"Modular config validation error found in resource: generic1").Len(), test.ShouldEqual, 1)
 	test.That(t, logs.FilterMessageSnippet("error building component").Len(), test.ShouldEqual, 0)
 }
 
@@ -137,7 +137,7 @@ func TestVersionBumpWithNewImplicitDeps(t *testing.T) {
 
 	// Assert that there were no validation or component building errors
 	test.That(t, logs.FilterMessageSnippet(
-		"modular config validation error found in resource: generic1").Len(), test.ShouldEqual, 0)
+		"Modular config validation error found in resource: generic1").Len(), test.ShouldEqual, 0)
 	test.That(t, logs.FilterMessageSnippet("error building component").Len(), test.ShouldEqual, 0)
 
 	// Swap in `run_version3.sh`. Version 3 requires `generic1` to have a `motor` in its
@@ -155,7 +155,7 @@ func TestVersionBumpWithNewImplicitDeps(t *testing.T) {
 	// Race condition safety: Resource removal should occur after modular resource validation (during completeConfig), so if
 	// ResourceByName is failing, these errors should already be present
 	test.That(t, logs.FilterMessageSnippet(
-		"modular config validation error found in resource: generic1").Len(), test.ShouldEqual, 1)
+		"Modular config validation error found in resource: generic1").Len(), test.ShouldEqual, 1)
 	test.That(t, logs.FilterMessageSnippet("error building component").Len(), test.ShouldEqual, 0)
 
 	// Update the generic1 configuration to have a `motor` attribute. The following reconfiguration

--- a/module/version_reconfigure_test.go
+++ b/module/version_reconfigure_test.go
@@ -65,7 +65,7 @@ func TestValidationFailureDuringReconfiguration(t *testing.T) {
 
 	// Assert that there were no validation or component building errors
 	test.That(t, logs.FilterMessageSnippet(
-		"modular resource config validation error").Len(), test.ShouldEqual, 0)
+		"modular config validation error found in resource: generic1").Len(), test.ShouldEqual, 0)
 	test.That(t, logs.FilterMessageSnippet("error building component").Len(), test.ShouldEqual, 0)
 
 	// Read the config, swap to `run_version2.sh`, and overwrite the config, triggering a
@@ -86,7 +86,7 @@ func TestValidationFailureDuringReconfiguration(t *testing.T) {
 	// Race condition safety: Resource removal should occur after modular resource validation (during completeConfig), so if
 	// ResourceByName is failing, these errors should already be present
 	test.That(t, logs.FilterMessageSnippet(
-		"modular resource config validation error").Len(), test.ShouldEqual, 1)
+		"modular config validation error found in resource: generic1").Len(), test.ShouldEqual, 1)
 	test.That(t, logs.FilterMessageSnippet("error building component").Len(), test.ShouldEqual, 0)
 }
 
@@ -137,7 +137,7 @@ func TestVersionBumpWithNewImplicitDeps(t *testing.T) {
 
 	// Assert that there were no validation or component building errors
 	test.That(t, logs.FilterMessageSnippet(
-		"modular resource config validation error").Len(), test.ShouldEqual, 0)
+		"modular config validation error found in resource: generic1").Len(), test.ShouldEqual, 0)
 	test.That(t, logs.FilterMessageSnippet("error building component").Len(), test.ShouldEqual, 0)
 
 	// Swap in `run_version3.sh`. Version 3 requires `generic1` to have a `motor` in its
@@ -155,7 +155,7 @@ func TestVersionBumpWithNewImplicitDeps(t *testing.T) {
 	// Race condition safety: Resource removal should occur after modular resource validation (during completeConfig), so if
 	// ResourceByName is failing, these errors should already be present
 	test.That(t, logs.FilterMessageSnippet(
-		"modular resource config validation error").Len(), test.ShouldEqual, 1)
+		"modular config validation error found in resource: generic1").Len(), test.ShouldEqual, 1)
 	test.That(t, logs.FilterMessageSnippet("error building component").Len(), test.ShouldEqual, 0)
 
 	// Update the generic1 configuration to have a `motor` attribute. The following reconfiguration


### PR DESCRIPTION
## Summary 
Change test to filter+count a different error log - the current one can appear more than once occasionally.

## Details
We changed the log line we filter for (941aebecf294df655d3c086e8e2e8f51b6ef291c) since the tests were originally introduced (2bd2860d2722a8fe80aa0db27d8df07540328866).

The current error log is in the resource manager (in `completeConfig`): https://github.com/viamrobotics/rdk/blob/4be931a11870a197c13b5844027551ccaec00809/robot/impl/resource_manager.go#L613-L616, and the original is in the mod manager: https://github.com/viamrobotics/rdk/blob/4be931a11870a197c13b5844027551ccaec00809/module/modmanager/manager.go#L699

While rare, the current log line can conceivably appear more than once in this test if the `completeConfig` ticker goes off and triggers another reconfiguration. However, the original log line can only appear once in this test, so reverting to it should eliminate the flake.