### PR TITLE
DATA-2651 Change error to warning log

### DIFF
--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -755,7 +755,7 @@ func pollFilesystem(ctx context.Context, wg *sync.WaitGroup, captureDir string,
 			logger.Debug("checking disk usage")
 			shouldDelete, err := shouldDeleteBasedOnDiskUsage(ctx, captureDir, logger)
 			if err != nil {
-				logger.Errorw("error checking file system stats", "error", err)
+				logger.Warnw("error checking file system stats", "error", err)
 			}
 			if shouldDelete {
 				start := time.Now()

--- a/services/datamanager/builtin/file_deletion.go
+++ b/services/datamanager/builtin/file_deletion.go
@@ -62,6 +62,9 @@ func exceedsDeletionThreshold(ctx context.Context, captureDirPath string, fsSize
 		if !d.IsDir() {
 			fileInfo, err := d.Info()
 			if err != nil {
+				if errors.Is(err, fs.ErrNotExist) {
+					return nil
+				}
 				return err
 			}
 			dirSize += fileInfo.Size()


### PR DESCRIPTION
hey yall, this PR is to change the error log for file system stats to a warning log. While making this change, I added another check to swallow a file not existing from getting renamed as otherwise, we can exit out of the file system checking thread unnecessarily, leading to files not being deleted when they should be. 