### PR TITLE
Test debugging QoL: compare sorted resource names instead of unordered sets

### DIFF
--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -770,8 +770,7 @@ func TestClientRefresh(t *testing.T) {
 			utils.NewStringSet(testutils.ExtractNames(baseNames...)...),
 		)
 
-		test.That(t, testutils.NewSortedResourceNames(client.ResourceNames()...), test.ShouldResemble, testutils.NewSortedResourceNames(
-			finalResources...))
+		testutils.VerifySameResourceNames(t, client.ResourceNames(), finalResources)
 
 		test.That(t, client.Close(context.Background()), test.ShouldBeNil)
 
@@ -801,8 +800,7 @@ func TestClientRefresh(t *testing.T) {
 			utils.NewStringSet(testutils.ExtractNames(baseNames...)...),
 		)
 
-		test.That(t, testutils.NewSortedResourceNames(client.ResourceNames()...), test.ShouldResemble, testutils.NewSortedResourceNames(
-			emptyResources...))
+		testutils.VerifySameResourceNames(t, client.ResourceNames(), emptyResources)
 
 		mu.Lock()
 		injectRobot.ResourceRPCAPIsFunc = func() []resource.RPCAPI { return nil }
@@ -825,8 +823,7 @@ func TestClientRefresh(t *testing.T) {
 			utils.NewStringSet(testutils.ExtractNames(baseNames...)...),
 		)
 
-		test.That(t, testutils.NewSortedResourceNames(client.ResourceNames()...), test.ShouldResemble, testutils.NewSortedResourceNames(
-			finalResources...))
+		testutils.VerifySameResourceNames(t, client.ResourceNames(), finalResources)
 
 		test.That(t, client.Close(context.Background()), test.ShouldBeNil)
 	})

--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -770,7 +770,7 @@ func TestClientRefresh(t *testing.T) {
 			utils.NewStringSet(testutils.ExtractNames(baseNames...)...),
 		)
 
-		test.That(t, testutils.NewResourceNameSet(client.ResourceNames()...), test.ShouldResemble, testutils.NewResourceNameSet(
+		test.That(t, testutils.NewSortedResourceNames(client.ResourceNames()...), test.ShouldResemble, testutils.NewSortedResourceNames(
 			finalResources...))
 
 		test.That(t, client.Close(context.Background()), test.ShouldBeNil)
@@ -801,7 +801,7 @@ func TestClientRefresh(t *testing.T) {
 			utils.NewStringSet(testutils.ExtractNames(baseNames...)...),
 		)
 
-		test.That(t, testutils.NewResourceNameSet(client.ResourceNames()...), test.ShouldResemble, testutils.NewResourceNameSet(
+		test.That(t, testutils.NewSortedResourceNames(client.ResourceNames()...), test.ShouldResemble, testutils.NewSortedResourceNames(
 			emptyResources...))
 
 		mu.Lock()
@@ -825,7 +825,7 @@ func TestClientRefresh(t *testing.T) {
 			utils.NewStringSet(testutils.ExtractNames(baseNames...)...),
 		)
 
-		test.That(t, testutils.NewResourceNameSet(client.ResourceNames()...), test.ShouldResemble, testutils.NewResourceNameSet(
+		test.That(t, testutils.NewSortedResourceNames(client.ResourceNames()...), test.ShouldResemble, testutils.NewSortedResourceNames(
 			finalResources...))
 
 		test.That(t, client.Close(context.Background()), test.ShouldBeNil)

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -208,9 +208,9 @@ func TestConfigRemote(t *testing.T) {
 
 	test.That(
 		t,
-		rtestutils.NewResourceNameSet(resources2...),
+		rtestutils.NewSortedResourceNames(resources2...),
 		test.ShouldResemble,
-		rtestutils.NewResourceNameSet(expected...),
+		rtestutils.NewSortedResourceNames(expected...),
 	)
 
 	expectedRemotes := []string{"squee", "foo", "bar"}
@@ -445,9 +445,9 @@ func TestConfigRemoteWithAuth(t *testing.T) {
 
 			test.That(
 				t,
-				rtestutils.NewResourceNameSet(resources2...),
+				rtestutils.NewSortedResourceNames(resources2...),
 				test.ShouldResemble,
-				rtestutils.NewResourceNameSet(expected...),
+				rtestutils.NewSortedResourceNames(expected...),
 			)
 
 			remotes2 := r2.RemoteNames()
@@ -617,9 +617,9 @@ func TestConfigRemoteWithTLSAuth(t *testing.T) {
 
 	test.That(
 		t,
-		rtestutils.NewResourceNameSet(resources2...),
+		rtestutils.NewSortedResourceNames(resources2...),
 		test.ShouldResemble,
-		rtestutils.NewResourceNameSet(expected...),
+		rtestutils.NewSortedResourceNames(expected...),
 	)
 
 	remotes2 := r2.RemoteNames()
@@ -897,7 +897,7 @@ func TestMetadataUpdate(t *testing.T) {
 
 	resources = r.ResourceNames()
 	test.That(t, len(resources), test.ShouldEqual, len(resourceNames))
-	test.That(t, rtestutils.NewResourceNameSet(resources...), test.ShouldResemble, rtestutils.NewResourceNameSet(resourceNames...))
+	test.That(t, rtestutils.NewSortedResourceNames(resources...), test.ShouldResemble, rtestutils.NewSortedResourceNames(resourceNames...))
 
 	test.That(t, r.Close(context.Background()), test.ShouldBeNil)
 	resources = r.ResourceNames()
@@ -917,7 +917,7 @@ func TestSensorsService(t *testing.T) {
 	sensorNames := []resource.Name{movementsensor.Named("movement_sensor1"), movementsensor.Named("movement_sensor2")}
 	foundSensors, err := svc.Sensors(context.Background(), map[string]interface{}{})
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, rtestutils.NewResourceNameSet(foundSensors...), test.ShouldResemble, rtestutils.NewResourceNameSet(sensorNames...))
+	test.That(t, rtestutils.NewSortedResourceNames(foundSensors...), test.ShouldResemble, rtestutils.NewSortedResourceNames(sensorNames...))
 
 	readings, err := svc.Readings(context.Background(), []resource.Name{movementsensor.Named("movement_sensor1")}, map[string]interface{}{})
 	test.That(t, err, test.ShouldBeNil)
@@ -1214,9 +1214,9 @@ func TestStatusRemote(t *testing.T) {
 
 	test.That(
 		t,
-		rtestutils.NewResourceNameSet(r.ResourceNames()...),
+		rtestutils.NewSortedResourceNames(r.ResourceNames()...),
 		test.ShouldResemble,
-		rtestutils.NewResourceNameSet(
+		rtestutils.NewSortedResourceNames(
 			motion.Named(resource.DefaultServiceName),
 			sensors.Named(resource.DefaultServiceName),
 			arm.Named("foo:arm1"),
@@ -1323,9 +1323,9 @@ func TestGetRemoteResourceAndGrandFather(t *testing.T) {
 
 	test.That(
 		t,
-		rtestutils.NewResourceNameSet(r.ResourceNames()...),
+		rtestutils.NewSortedResourceNames(r.ResourceNames()...),
 		test.ShouldResemble,
-		rtestutils.NewResourceNameSet(
+		rtestutils.NewSortedResourceNames(
 			motion.Named(resource.DefaultServiceName),
 			sensors.Named(resource.DefaultServiceName),
 			arm.Named("remote:foo:arm1"), arm.Named("remote:foo:arm2"),

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -206,12 +206,7 @@ func TestConfigRemote(t *testing.T) {
 
 	resources2 := r2.ResourceNames()
 
-	test.That(
-		t,
-		rtestutils.NewSortedResourceNames(resources2...),
-		test.ShouldResemble,
-		rtestutils.NewSortedResourceNames(expected...),
-	)
+	rtestutils.VerifySameResourceNames(t, resources2, expected)
 
 	expectedRemotes := []string{"squee", "foo", "bar"}
 	remotes2 := r2.RemoteNames()
@@ -443,12 +438,7 @@ func TestConfigRemoteWithAuth(t *testing.T) {
 
 			resources2 := r2.ResourceNames()
 
-			test.That(
-				t,
-				rtestutils.NewSortedResourceNames(resources2...),
-				test.ShouldResemble,
-				rtestutils.NewSortedResourceNames(expected...),
-			)
+			rtestutils.VerifySameResourceNames(t, resources2, expected)
 
 			remotes2 := r2.RemoteNames()
 			expectedRemotes := []string{"bar", "foo"}
@@ -615,12 +605,7 @@ func TestConfigRemoteWithTLSAuth(t *testing.T) {
 
 	resources2 := r2.ResourceNames()
 
-	test.That(
-		t,
-		rtestutils.NewSortedResourceNames(resources2...),
-		test.ShouldResemble,
-		rtestutils.NewSortedResourceNames(expected...),
-	)
+	rtestutils.VerifySameResourceNames(t, resources2, expected)
 
 	remotes2 := r2.RemoteNames()
 	expectedRemotes := []string{"foo"}
@@ -897,7 +882,7 @@ func TestMetadataUpdate(t *testing.T) {
 
 	resources = r.ResourceNames()
 	test.That(t, len(resources), test.ShouldEqual, len(resourceNames))
-	test.That(t, rtestutils.NewSortedResourceNames(resources...), test.ShouldResemble, rtestutils.NewSortedResourceNames(resourceNames...))
+	rtestutils.VerifySameResourceNames(t, resources, resourceNames)
 
 	test.That(t, r.Close(context.Background()), test.ShouldBeNil)
 	resources = r.ResourceNames()
@@ -917,7 +902,7 @@ func TestSensorsService(t *testing.T) {
 	sensorNames := []resource.Name{movementsensor.Named("movement_sensor1"), movementsensor.Named("movement_sensor2")}
 	foundSensors, err := svc.Sensors(context.Background(), map[string]interface{}{})
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, rtestutils.NewSortedResourceNames(foundSensors...), test.ShouldResemble, rtestutils.NewSortedResourceNames(sensorNames...))
+	rtestutils.VerifySameResourceNames(t, foundSensors, sensorNames)
 
 	readings, err := svc.Readings(context.Background(), []resource.Name{movementsensor.Named("movement_sensor1")}, map[string]interface{}{})
 	test.That(t, err, test.ShouldBeNil)
@@ -1212,18 +1197,17 @@ func TestStatusRemote(t *testing.T) {
 	ctx := context.Background()
 	r := setupLocalRobot(t, ctx, remoteConfig, logger)
 
-	test.That(
+	rtestutils.VerifySameResourceNames(
 		t,
-		rtestutils.NewSortedResourceNames(r.ResourceNames()...),
-		test.ShouldResemble,
-		rtestutils.NewSortedResourceNames(
+		r.ResourceNames(),
+		[]resource.Name{
 			motion.Named(resource.DefaultServiceName),
 			sensors.Named(resource.DefaultServiceName),
 			arm.Named("foo:arm1"),
 			arm.Named("foo:arm2"),
 			arm.Named("bar:arm1"),
 			arm.Named("bar:arm2"),
-		),
+		},
 	)
 	statuses, err := r.Status(
 		ctx, []resource.Name{arm.Named("foo:arm1"), arm.Named("foo:arm2"), arm.Named("bar:arm1"), arm.Named("bar:arm2")},
@@ -1321,11 +1305,10 @@ func TestGetRemoteResourceAndGrandFather(t *testing.T) {
 
 	r := setupLocalRobot(t, ctx, remoteConfig, logger)
 
-	test.That(
+	rtestutils.VerifySameResourceNames(
 		t,
-		rtestutils.NewSortedResourceNames(r.ResourceNames()...),
-		test.ShouldResemble,
-		rtestutils.NewSortedResourceNames(
+		r.ResourceNames(),
+		[]resource.Name{
 			motion.Named(resource.DefaultServiceName),
 			sensors.Named(resource.DefaultServiceName),
 			arm.Named("remote:foo:arm1"), arm.Named("remote:foo:arm2"),
@@ -1340,7 +1323,7 @@ func TestGetRemoteResourceAndGrandFather(t *testing.T) {
 			sensors.Named("remote:builtin"),
 			motion.Named("remote:foo:builtin"),
 			sensors.Named("remote:foo:builtin"),
-		),
+		},
 	)
 	arm1, err := r.ResourceByName(arm.Named("remote:foo:arm1"))
 	test.That(t, err, test.ShouldBeNil)

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -199,11 +199,10 @@ func TestManagerForRemoteRobot(t *testing.T) {
 	servoNames := []resource.Name{servo.Named("servo1"), servo.Named("servo2")}
 
 	test.That(t, manager.RemoteNames(), test.ShouldBeEmpty)
-	test.That(
+	rdktestutils.VerifySameResourceNames(
 		t,
-		rdktestutils.NewSortedResourceNames(manager.ResourceNames()...),
-		test.ShouldResemble,
-		rdktestutils.NewSortedResourceNames(rdktestutils.ConcatResourceNames(
+		manager.ResourceNames(),
+		rdktestutils.ConcatResourceNames(
 			armNames,
 			baseNames,
 			boardNames,
@@ -212,7 +211,7 @@ func TestManagerForRemoteRobot(t *testing.T) {
 			inputNames,
 			motorNames,
 			servoNames,
-		)...),
+		),
 	)
 
 	_, err := manager.ResourceByName(arm.Named("arm1"))
@@ -286,11 +285,10 @@ func TestManagerMergeNamesWithRemotes(t *testing.T) {
 		test.ShouldResemble,
 		utils.NewStringSet("remote1", "remote2"),
 	)
-	test.That(
+	rdktestutils.VerifySameResourceNames(
 		t,
-		rdktestutils.NewSortedResourceNames(manager.ResourceNames()...),
-		test.ShouldResemble,
-		rdktestutils.NewSortedResourceNames(rdktestutils.ConcatResourceNames(
+		manager.ResourceNames(),
+		rdktestutils.ConcatResourceNames(
 			armNames,
 			baseNames,
 			boardNames,
@@ -299,7 +297,7 @@ func TestManagerMergeNamesWithRemotes(t *testing.T) {
 			inputNames,
 			motorNames,
 			servoNames,
-		)...),
+		),
 	)
 	_, err := manager.ResourceByName(arm.Named("arm1"))
 	test.That(t, err, test.ShouldBeNil)
@@ -394,13 +392,10 @@ func TestManagerResourceRemoteName(t *testing.T) {
 
 	manager.updateRemotesResourceNames(context.Background())
 
-	res := manager.remoteResourceNames(fromRemoteNameToRemoteNodeName("remote1"))
-
-	test.That(
+	rdktestutils.VerifySameResourceNames(
 		t,
-		rdktestutils.NewSortedResourceNames(res...),
-		test.ShouldResemble,
-		rdktestutils.NewSortedResourceNames([]resource.Name{arm.Named("remote1:arm1"), arm.Named("remote1:arm2")}...),
+		manager.remoteResourceNames(fromRemoteNameToRemoteNodeName("remote1")),
+		[]resource.Name{arm.Named("remote1:arm1"), arm.Named("remote1:arm2")},
 	)
 }
 
@@ -1888,12 +1883,7 @@ func TestReconfigureParity(t *testing.T) {
 			cfg = ConfigFromFile(t, initCfg)
 			r2 := setupLocalRobot(t, ctx, cfg, logger).(*localRobot)
 
-			test.That(
-				t,
-				rdktestutils.NewSortedResourceNames(r1.ResourceNames()...),
-				test.ShouldResemble,
-				rdktestutils.NewSortedResourceNames(r2.ResourceNames()...),
-			)
+			rdktestutils.VerifySameResourceNames(t, r1.ResourceNames(), r2.ResourceNames())
 
 			cfg = ConfigFromFile(t, updateCfg)
 			r1.Reconfigure(ctx, cfg)
@@ -1901,12 +1891,7 @@ func TestReconfigureParity(t *testing.T) {
 			// force robot to reconfigure resources serially
 			r2.reconfigure(ctx, cfg, true)
 
-			test.That(
-				t,
-				rdktestutils.NewSortedResourceNames(r1.ResourceNames()...),
-				test.ShouldResemble,
-				rdktestutils.NewSortedResourceNames(r2.ResourceNames()...),
-			)
+			rdktestutils.VerifySameResourceNames(t, r1.ResourceNames(), r2.ResourceNames())
 		})
 	}
 

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -201,9 +201,9 @@ func TestManagerForRemoteRobot(t *testing.T) {
 	test.That(t, manager.RemoteNames(), test.ShouldBeEmpty)
 	test.That(
 		t,
-		rdktestutils.NewResourceNameSet(manager.ResourceNames()...),
+		rdktestutils.NewSortedResourceNames(manager.ResourceNames()...),
 		test.ShouldResemble,
-		rdktestutils.NewResourceNameSet(rdktestutils.ConcatResourceNames(
+		rdktestutils.NewSortedResourceNames(rdktestutils.ConcatResourceNames(
 			armNames,
 			baseNames,
 			boardNames,
@@ -288,9 +288,9 @@ func TestManagerMergeNamesWithRemotes(t *testing.T) {
 	)
 	test.That(
 		t,
-		rdktestutils.NewResourceNameSet(manager.ResourceNames()...),
+		rdktestutils.NewSortedResourceNames(manager.ResourceNames()...),
 		test.ShouldResemble,
-		rdktestutils.NewResourceNameSet(rdktestutils.ConcatResourceNames(
+		rdktestutils.NewSortedResourceNames(rdktestutils.ConcatResourceNames(
 			armNames,
 			baseNames,
 			boardNames,
@@ -398,9 +398,9 @@ func TestManagerResourceRemoteName(t *testing.T) {
 
 	test.That(
 		t,
-		rdktestutils.NewResourceNameSet(res...),
+		rdktestutils.NewSortedResourceNames(res...),
 		test.ShouldResemble,
-		rdktestutils.NewResourceNameSet([]resource.Name{arm.Named("remote1:arm1"), arm.Named("remote1:arm2")}...),
+		rdktestutils.NewSortedResourceNames([]resource.Name{arm.Named("remote1:arm1"), arm.Named("remote1:arm2")}...),
 	)
 }
 
@@ -896,7 +896,7 @@ func TestManagerMarkRemoved(t *testing.T) {
 		t,
 		markedResourceNames,
 		test.ShouldResemble,
-		rdktestutils.NewResourceNameSet(rdktestutils.ConcatResourceNames(
+		rdktestutils.NewSortedResourceNames(rdktestutils.ConcatResourceNames(
 			armNames,
 			baseNames,
 			boardNames,
@@ -1014,7 +1014,7 @@ func TestManagerMarkRemoved(t *testing.T) {
 		t,
 		markedResourceNames,
 		test.ShouldResemble,
-		rdktestutils.NewResourceNameSet(rdktestutils.ConcatResourceNames(
+		rdktestutils.NewSortedResourceNames(rdktestutils.ConcatResourceNames(
 			armNames,
 			baseNames,
 			boardNames,
@@ -1199,7 +1199,7 @@ func TestManagerMarkRemoved(t *testing.T) {
 		t,
 		markedResourceNames,
 		test.ShouldResemble,
-		rdktestutils.NewResourceNameSet(rdktestutils.ConcatResourceNames(
+		rdktestutils.NewSortedResourceNames(rdktestutils.ConcatResourceNames(
 			armNames,
 			baseNames,
 			boardNames,
@@ -1890,9 +1890,9 @@ func TestReconfigureParity(t *testing.T) {
 
 			test.That(
 				t,
-				rdktestutils.NewResourceNameSet(r1.ResourceNames()...),
+				rdktestutils.NewSortedResourceNames(r1.ResourceNames()...),
 				test.ShouldResemble,
-				rdktestutils.NewResourceNameSet(r2.ResourceNames()...),
+				rdktestutils.NewSortedResourceNames(r2.ResourceNames()...),
 			)
 
 			cfg = ConfigFromFile(t, updateCfg)
@@ -1903,9 +1903,9 @@ func TestReconfigureParity(t *testing.T) {
 
 			test.That(
 				t,
-				rdktestutils.NewResourceNameSet(r1.ResourceNames()...),
+				rdktestutils.NewSortedResourceNames(r1.ResourceNames()...),
 				test.ShouldResemble,
-				rdktestutils.NewResourceNameSet(r2.ResourceNames()...),
+				rdktestutils.NewSortedResourceNames(r2.ResourceNames()...),
 			)
 		})
 	}

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -896,7 +896,7 @@ func TestManagerMarkRemoved(t *testing.T) {
 		t,
 		markedResourceNames,
 		test.ShouldResemble,
-		rdktestutils.NewSortedResourceNames(rdktestutils.ConcatResourceNames(
+		rdktestutils.NewResourceNameSet(rdktestutils.ConcatResourceNames(
 			armNames,
 			baseNames,
 			boardNames,
@@ -1014,7 +1014,7 @@ func TestManagerMarkRemoved(t *testing.T) {
 		t,
 		markedResourceNames,
 		test.ShouldResemble,
-		rdktestutils.NewSortedResourceNames(rdktestutils.ConcatResourceNames(
+		rdktestutils.NewResourceNameSet(rdktestutils.ConcatResourceNames(
 			armNames,
 			baseNames,
 			boardNames,
@@ -1199,7 +1199,7 @@ func TestManagerMarkRemoved(t *testing.T) {
 		t,
 		markedResourceNames,
 		test.ShouldResemble,
-		rdktestutils.NewSortedResourceNames(rdktestutils.ConcatResourceNames(
+		rdktestutils.NewResourceNameSet(rdktestutils.ConcatResourceNames(
 			armNames,
 			baseNames,
 			boardNames,

--- a/robot/impl/robot_framesystem_test.go
+++ b/robot/impl/robot_framesystem_test.go
@@ -128,14 +128,14 @@ func TestFrameSystemConfigWithRemote(t *testing.T) {
 
 	rr.triggerConfig <- struct{}{}
 
-	finalSet := rdktestutils.NewSortedResourceNames(
+	finalSet := []resource.Name{
 		motion.Named(resource.DefaultServiceName),
 		sensors.Named(resource.DefaultServiceName),
 		base.Named("foo"),
 		gripper.Named("myParentIsRemote"),
-	)
+	}
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		test.That(tb, rdktestutils.NewSortedResourceNames(r2.ResourceNames()...), test.ShouldResemble, finalSet)
+		rdktestutils.VerifySameResourceNames(tb, r2.ResourceNames(), finalSet)
 	})
 
 	fsCfg, err = r2.FrameSystemConfig(context.Background())

--- a/robot/impl/robot_framesystem_test.go
+++ b/robot/impl/robot_framesystem_test.go
@@ -128,14 +128,14 @@ func TestFrameSystemConfigWithRemote(t *testing.T) {
 
 	rr.triggerConfig <- struct{}{}
 
-	finalSet := rdktestutils.NewResourceNameSet(
+	finalSet := rdktestutils.NewSortedResourceNames(
 		motion.Named(resource.DefaultServiceName),
 		sensors.Named(resource.DefaultServiceName),
 		base.Named("foo"),
 		gripper.Named("myParentIsRemote"),
 	)
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		test.That(tb, rdktestutils.NewResourceNameSet(r2.ResourceNames()...), test.ShouldResemble, finalSet)
+		test.That(tb, rdktestutils.NewSortedResourceNames(r2.ResourceNames()...), test.ShouldResemble, finalSet)
 	})
 
 	fsCfg, err = r2.FrameSystemConfig(context.Background())

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -169,14 +169,13 @@ func TestRobotReconfigure(t *testing.T) {
 		)
 		_ = names2
 		_ = names
-		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
-			rdktestutils.ConcatResourceNames(
-				armNames,
-				baseNames,
-				boardNames,
-				mockNames,
-				resource.DefaultServices(),
-			)...))
+		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
+			armNames,
+			baseNames,
+			boardNames,
+			mockNames,
+			resource.DefaultServices(),
+		))
 		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
 
 		robot.Reconfigure(ctx, conf1)
@@ -203,14 +202,13 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
-			rdktestutils.ConcatResourceNames(
-				armNames,
-				baseNames,
-				boardNames,
-				mockNames,
-				resource.DefaultServices(),
-			)...))
+		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
+			armNames,
+			baseNames,
+			boardNames,
+			mockNames,
+			resource.DefaultServices(),
+		))
 		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
 
 		_, err := arm.FromRobot(robot, "arm1")
@@ -278,14 +276,13 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
-			rdktestutils.ConcatResourceNames(
-				armNames,
-				baseNames,
-				boardNames,
-				mockNames,
-				resource.DefaultServices(),
-			)...))
+		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
+			armNames,
+			baseNames,
+			boardNames,
+			mockNames,
+			resource.DefaultServices(),
+		))
 		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
 
 		arm1, err := arm.FromRobot(robot, "arm1")
@@ -344,14 +341,13 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
-			rdktestutils.ConcatResourceNames(
-				armNames,
-				baseNames,
-				boardNames,
-				mockNames,
-				resource.DefaultServices(),
-			)...))
+		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
+			armNames,
+			baseNames,
+			boardNames,
+			mockNames,
+			resource.DefaultServices(),
+		))
 		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
 
 		test.That(t, mock1.(*mockFake).reconfCount, test.ShouldEqual, 0)
@@ -424,14 +420,13 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
-			rdktestutils.ConcatResourceNames(
-				armNames,
-				baseNames,
-				boardNames,
-				resource.DefaultServices(),
-				mockNames,
-			)...))
+		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
+			armNames,
+			baseNames,
+			boardNames,
+			resource.DefaultServices(),
+			mockNames,
+		))
 		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
 
 		armNames = []resource.Name{arm.Named("arm1"), arm.Named("arm2")}
@@ -467,15 +462,14 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
-			rdktestutils.ConcatResourceNames(
-				armNames,
-				baseNames,
-				boardNames,
-				motorNames,
-				mockNames,
-				resource.DefaultServices(),
-			)...))
+		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
+			armNames,
+			baseNames,
+			boardNames,
+			motorNames,
+			mockNames,
+			resource.DefaultServices(),
+		))
 		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
 
 		_, err := arm.FromRobot(robot, "arm1")
@@ -574,14 +568,13 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
-			rdktestutils.ConcatResourceNames(
-				armNames,
-				baseNames,
-				boardNames,
-				motorNames,
-				resource.DefaultServices(),
-			)...))
+		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
+			armNames,
+			baseNames,
+			boardNames,
+			motorNames,
+			resource.DefaultServices(),
+		))
 		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
 
 		b, err := board.FromRobot(robot, "board1")
@@ -624,14 +617,13 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
-			rdktestutils.ConcatResourceNames(
-				armNames,
-				baseNames,
-				boardNames,
-				motorNames,
-				resource.DefaultServices(),
-			)...))
+		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
+			armNames,
+			baseNames,
+			boardNames,
+			motorNames,
+			resource.DefaultServices(),
+		))
 		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
 
 		_, err = arm.FromRobot(robot, "arm1")
@@ -734,14 +726,13 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
-			rdktestutils.ConcatResourceNames(
-				armNames,
-				baseNames,
-				boardNames,
-				motorNames,
-				resource.DefaultServices(),
-			)...))
+		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
+			armNames,
+			baseNames,
+			boardNames,
+			motorNames,
+			resource.DefaultServices(),
+		))
 		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
 
 		arm2, err := arm.FromRobot(robot, "arm2")
@@ -778,11 +769,10 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
-			rdktestutils.ConcatResourceNames(
-				boardNames,
-				resource.DefaultServices(),
-			)...))
+		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
+			boardNames,
+			resource.DefaultServices(),
+		))
 		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
 
 		_, err = arm.FromRobot(robot, "arm1")
@@ -821,14 +811,13 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, ok, test.ShouldBeTrue)
 		sorted := robot.(*localRobot).manager.resources.TopologicalSort()
 		sorted = rdktestutils.SubtractNames(sorted, robot.(*localRobot).manager.internalResourceNames()...)
-		test.That(t, rdktestutils.NewSortedResourceNames(sorted...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
-			rdktestutils.ConcatResourceNames(
-				boardNames,
-				resource.DefaultServices(),
-				[]resource.Name{
-					mockNamed("mock6"),
-				},
-			)...))
+		rdktestutils.VerifySameResourceNames(t, sorted, rdktestutils.ConcatResourceNames(
+			boardNames,
+			resource.DefaultServices(),
+			[]resource.Name{
+				mockNamed("mock6"),
+			},
+		))
 	})
 
 	t.Run("mixed deps diff", func(t *testing.T) {
@@ -872,14 +861,13 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
-			rdktestutils.ConcatResourceNames(
-				armNames,
-				baseNames,
-				boardNames,
-				motorNames,
-				resource.DefaultServices(),
-			)...))
+		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
+			armNames,
+			baseNames,
+			boardNames,
+			motorNames,
+			resource.DefaultServices(),
+		))
 		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
 		b, err := board.FromRobot(robot, "board1")
 		test.That(t, err, test.ShouldBeNil)
@@ -931,14 +919,13 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
-			rdktestutils.ConcatResourceNames(
-				armNames,
-				baseNames,
-				boardNames,
-				motorNames,
-				resource.DefaultServices(),
-			)...))
+		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
+			armNames,
+			baseNames,
+			boardNames,
+			motorNames,
+			resource.DefaultServices(),
+		))
 		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
 
 		_, err = arm.FromRobot(robot, "arm1")
@@ -1031,12 +1018,7 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(
-			t,
-			rdktestutils.NewSortedResourceNames(robot.ResourceNames()...),
-			test.ShouldResemble,
-			rdktestutils.NewSortedResourceNames(resource.DefaultServices()...),
-		)
+		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), resource.DefaultServices())
 		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldBeEmpty)
 
 		armNames := []resource.Name{arm.Named("arm1"), arm.Named("arm3")}
@@ -1075,14 +1057,13 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
-			rdktestutils.ConcatResourceNames(
-				armNames,
-				baseNames,
-				boardNames,
-				motorNames,
-				resource.DefaultServices(),
-			)...))
+		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
+			armNames,
+			baseNames,
+			boardNames,
+			motorNames,
+			resource.DefaultServices(),
+		))
 		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
 
 		_, err := arm.FromRobot(robot, "arm1")
@@ -1184,11 +1165,10 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
-			rdktestutils.ConcatResourceNames(
-				boardNames,
-				resource.DefaultServices(),
-			)...))
+		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
+			boardNames,
+			resource.DefaultServices(),
+		))
 		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
 
 		_, err := arm.FromRobot(robot, "arm1")
@@ -1267,14 +1247,13 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
-			rdktestutils.ConcatResourceNames(
-				boardNames,
-				resource.DefaultServices(),
-				motorNames,
-				mockNames,
-				encoderNames,
-			)...))
+		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
+			boardNames,
+			resource.DefaultServices(),
+			motorNames,
+			mockNames,
+			encoderNames,
+		))
 		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
 
 		_, err = arm.FromRobot(robot, "arm1")
@@ -1337,14 +1316,13 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, ok, test.ShouldBeTrue)
 		sorted := robot.(*localRobot).manager.resources.TopologicalSort()
 		sorted = rdktestutils.SubtractNames(sorted, robot.(*localRobot).manager.internalResourceNames()...)
-		test.That(t, rdktestutils.NewSortedResourceNames(sorted...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
-			rdktestutils.ConcatResourceNames(
-				motorNames,
-				resource.DefaultServices(),
-				boardNames,
-				mockNames,
-				encoderNames,
-			)...))
+		rdktestutils.VerifySameResourceNames(t, sorted, rdktestutils.ConcatResourceNames(
+			motorNames,
+			resource.DefaultServices(),
+			boardNames,
+			mockNames,
+			encoderNames,
+		))
 	})
 
 	t.Run("parent attribute change deps config", func(t *testing.T) {
@@ -1394,14 +1372,13 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
-			rdktestutils.ConcatResourceNames(
-				boardNames,
-				encoderNames,
-				resource.DefaultServices(),
-				motorNames,
-				mockNames,
-			)...))
+		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
+			boardNames,
+			encoderNames,
+			resource.DefaultServices(),
+			motorNames,
+			mockNames,
+		))
 		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
 
 		_, err := arm.FromRobot(robot, "arm1")
@@ -1463,14 +1440,13 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, ok, test.ShouldBeTrue)
 		sorted := robot.(*localRobot).manager.resources.TopologicalSort()
 		sorted = rdktestutils.SubtractNames(sorted, robot.(*localRobot).manager.internalResourceNames()...)
-		test.That(t, rdktestutils.NewSortedResourceNames(sorted...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
-			rdktestutils.ConcatResourceNames(
-				motorNames,
-				resource.DefaultServices(),
-				boardNames,
-				mockNames,
-				encoderNames,
-			)...))
+		rdktestutils.VerifySameResourceNames(t, sorted, rdktestutils.ConcatResourceNames(
+			motorNames,
+			resource.DefaultServices(),
+			boardNames,
+			mockNames,
+			encoderNames,
+		))
 		robot.Reconfigure(context.Background(), conf8)
 		mockNames = []resource.Name{
 			mockNamed("mock1"), mockNamed("mock2"),
@@ -1509,14 +1485,13 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
-			rdktestutils.ConcatResourceNames(
-				boardNames,
-				resource.DefaultServices(),
-				motorNames,
-				mockNames,
-				encoderNames,
-			)...))
+		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
+			boardNames,
+			resource.DefaultServices(),
+			motorNames,
+			mockNames,
+			encoderNames,
+		))
 		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
 
 		_, err = arm.FromRobot(robot, "arm1")
@@ -1618,14 +1593,13 @@ func TestRobotReconfigure(t *testing.T) {
 			utils.NewStringSet(rdktestutils.ExtractNames(encoderNames...)...),
 		)
 
-		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
-			rdktestutils.ConcatResourceNames(
-				boardNames,
-				resource.DefaultServices(),
-				motorNames,
-				mockNames,
-				encoderNames,
-			)...))
+		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
+			boardNames,
+			resource.DefaultServices(),
+			motorNames,
+			mockNames,
+			encoderNames,
+		))
 		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
 
 		_, err := board.FromRobot(robot, "board1")
@@ -1685,14 +1659,13 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, ok, test.ShouldBeTrue)
 		sorted := robot.(*localRobot).manager.resources.TopologicalSort()
 		sorted = rdktestutils.SubtractNames(sorted, robot.(*localRobot).manager.internalResourceNames()...)
-		test.That(t, rdktestutils.NewSortedResourceNames(sorted...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
-			rdktestutils.ConcatResourceNames(
-				motorNames,
-				resource.DefaultServices(),
-				boardNames,
-				mockNames,
-				encoderNames,
-			)...))
+		rdktestutils.VerifySameResourceNames(t, sorted, rdktestutils.ConcatResourceNames(
+			motorNames,
+			resource.DefaultServices(),
+			boardNames,
+			mockNames,
+			encoderNames,
+		))
 
 		reconfigurableTrue = false
 		robot.Reconfigure(context.Background(), conf9)
@@ -1721,14 +1694,13 @@ func TestRobotReconfigure(t *testing.T) {
 			utils.NewStringSet(rdktestutils.ExtractNames(boardNames...)...),
 		)
 
-		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
-			rdktestutils.ConcatResourceNames(
-				boardNames,
-				resource.DefaultServices(),
-				motorNames,
-				mockNames,
-				encoderNames,
-			)...))
+		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
+			boardNames,
+			resource.DefaultServices(),
+			motorNames,
+			mockNames,
+			encoderNames,
+		))
 		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
 
 		_, err = board.FromRobot(robot, "board1")
@@ -1774,21 +1746,20 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, ok, test.ShouldBeTrue)
 		sorted = robot.(*localRobot).manager.resources.TopologicalSort()
 		sorted = rdktestutils.SubtractNames(sorted, robot.(*localRobot).manager.internalResourceNames()...)
-		test.That(t, rdktestutils.NewSortedResourceNames(sorted...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
-			rdktestutils.ConcatResourceNames(
-				motorNames,
-				resource.DefaultServices(),
-				boardNames,
-				mockNames,
-				encoderNames,
-				[]resource.Name{
-					arm.Named("armFake"),
-					mockNamed("mock1"),
-					mockNamed("mock4"),
-					mockNamed("mock5"),
-					mockNamed("mock6"),
-				},
-			)...))
+		rdktestutils.VerifySameResourceNames(t, sorted, rdktestutils.ConcatResourceNames(
+			motorNames,
+			resource.DefaultServices(),
+			boardNames,
+			mockNames,
+			encoderNames,
+			[]resource.Name{
+				arm.Named("armFake"),
+				mockNamed("mock1"),
+				mockNamed("mock4"),
+				mockNamed("mock5"),
+				mockNamed("mock6"),
+			},
+		))
 
 		// This configuration will put `mock6` into a good state after two calls to "reconfigure".
 		conf9good := ConfigFromFile(t, "data/diff_config_deps9_good.json")
@@ -1818,14 +1789,13 @@ func TestRobotReconfigure(t *testing.T) {
 			utils.NewStringSet(rdktestutils.ExtractNames(encoderNames...)...),
 		)
 
-		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
-			rdktestutils.ConcatResourceNames(
-				boardNames,
-				resource.DefaultServices(),
-				motorNames,
-				mockNames,
-				encoderNames,
-			)...))
+		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
+			boardNames,
+			resource.DefaultServices(),
+			motorNames,
+			mockNames,
+			encoderNames,
+		))
 		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
 
 		_, err = board.FromRobot(robot, "board1")
@@ -1900,18 +1870,17 @@ func TestRobotReconfigure(t *testing.T) {
 
 		sorted = robot.(*localRobot).manager.resources.TopologicalSort()
 		sorted = rdktestutils.SubtractNames(sorted, robot.(*localRobot).manager.internalResourceNames()...)
-		test.That(t, rdktestutils.NewSortedResourceNames(sorted...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
-			rdktestutils.ConcatResourceNames(
-				motorNames,
-				resource.DefaultServices(),
-				boardNames,
-				mockNames,
-				encoderNames,
-				[]resource.Name{
-					arm.Named("armFake"),
-					mockNamed("mock6"),
-				},
-			)...))
+		rdktestutils.VerifySameResourceNames(t, sorted, rdktestutils.ConcatResourceNames(
+			motorNames,
+			resource.DefaultServices(),
+			boardNames,
+			mockNames,
+			encoderNames,
+			[]resource.Name{
+				arm.Named("armFake"),
+				mockNamed("mock6"),
+			},
+		))
 	})
 	t.Run("complex diff", func(t *testing.T) {
 		resetComponentFailureState()
@@ -1933,12 +1902,11 @@ func TestRobotReconfigure(t *testing.T) {
 			test.ShouldResemble,
 			utils.NewStringSet(rdktestutils.ExtractNames(armNames...)...),
 		)
-		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
-			rdktestutils.ConcatResourceNames(
-				armNames,
-				resource.DefaultServices(),
-				mockNames,
-			)...))
+		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
+			armNames,
+			resource.DefaultServices(),
+			mockNames,
+		))
 		_, err := robot.ResourceByName(mockNamed("mock1"))
 		test.That(t, err, test.ShouldNotBeNil)
 		_, err = arm.FromRobot(robot, "mock7")
@@ -1952,11 +1920,10 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(robot.RemoteNames()...), test.ShouldBeEmpty)
 
 		test.That(t, utils.NewStringSet(arm.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
-			rdktestutils.ConcatResourceNames(
-				mockNames,
-				resource.DefaultServices(),
-			)...))
+		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
+			mockNames,
+			resource.DefaultServices(),
+		))
 
 		_, err = arm.FromRobot(robot, "arm1")
 		test.That(t, err, test.ShouldNotBeNil)
@@ -2159,12 +2126,7 @@ func TestSensorsServiceReconfigure(t *testing.T) {
 
 		foundSensors, err = svc.Sensors(context.Background(), map[string]interface{}{})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(
-			t,
-			rdktestutils.NewSortedResourceNames(foundSensors...),
-			test.ShouldResemble,
-			rdktestutils.NewSortedResourceNames(sensorNames...),
-		)
+		rdktestutils.VerifySameResourceNames(t, foundSensors, sensorNames)
 	})
 
 	t.Run("two sensors to empty", func(t *testing.T) {
@@ -2175,12 +2137,7 @@ func TestSensorsServiceReconfigure(t *testing.T) {
 
 		foundSensors, err := svc.Sensors(context.Background(), map[string]interface{}{})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(
-			t,
-			rdktestutils.NewSortedResourceNames(foundSensors...),
-			test.ShouldResemble,
-			rdktestutils.NewSortedResourceNames(sensorNames...),
-		)
+		rdktestutils.VerifySameResourceNames(t, foundSensors, sensorNames)
 
 		robot.Reconfigure(context.Background(), emptyCfg)
 
@@ -2197,23 +2154,13 @@ func TestSensorsServiceReconfigure(t *testing.T) {
 
 		foundSensors, err := svc.Sensors(context.Background(), map[string]interface{}{})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(
-			t,
-			rdktestutils.NewSortedResourceNames(foundSensors...),
-			test.ShouldResemble,
-			rdktestutils.NewSortedResourceNames(sensorNames...),
-		)
+		rdktestutils.VerifySameResourceNames(t, foundSensors, sensorNames)
 
 		robot.Reconfigure(context.Background(), cfg)
 
 		foundSensors, err = svc.Sensors(context.Background(), map[string]interface{}{})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(
-			t,
-			rdktestutils.NewSortedResourceNames(foundSensors...),
-			test.ShouldResemble,
-			rdktestutils.NewSortedResourceNames(sensorNames...),
-		)
+		rdktestutils.VerifySameResourceNames(t, foundSensors, sensorNames)
 	})
 }
 
@@ -2498,14 +2445,11 @@ func TestDefaultServiceReconfigure(t *testing.T) {
 	}
 	robot := setupLocalRobot(t, context.Background(), cfg1, logger)
 
-	test.That(
-		t,
-		rdktestutils.NewSortedResourceNames(robot.ResourceNames()...),
-		test.ShouldResemble,
-		rdktestutils.NewSortedResourceNames(
+	rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(),
+		[]resource.Name{
 			motion.Named(motionName),
 			sensors.Named(resource.DefaultServiceName),
-		),
+		},
 	)
 	sName := "sensors"
 	cfg2 := &config.Config{
@@ -2518,14 +2462,13 @@ func TestDefaultServiceReconfigure(t *testing.T) {
 		},
 	}
 	robot.Reconfigure(context.Background(), cfg2)
-	test.That(
+	rdktestutils.VerifySameResourceNames(
 		t,
-		rdktestutils.NewSortedResourceNames(robot.ResourceNames()...),
-		test.ShouldResemble,
-		rdktestutils.NewSortedResourceNames(
+		robot.ResourceNames(),
+		[]resource.Name{
 			motion.Named(resource.DefaultServiceName),
 			sensors.Named(sName),
-		),
+		},
 	)
 }
 
@@ -2675,25 +2618,24 @@ func TestRemoteRobotsGold(t *testing.T) {
 	r := setupLocalRobot(t, ctx, localConfig, logger.Sublogger("main"))
 
 	// assert all of remote1's resources exist on main but none of remote2's
-	test.That(
+	rdktestutils.VerifySameResourceNames(
 		t,
-		rdktestutils.NewSortedResourceNames(r.ResourceNames()...),
-		test.ShouldResemble,
-		rdktestutils.NewSortedResourceNames(
+		r.ResourceNames(),
+		[]resource.Name{
 			motion.Named(resource.DefaultServiceName),
 			sensors.Named(resource.DefaultServiceName),
 			arm.Named("arm1"),
 			arm.Named("foo:remoteArm"),
 			motion.Named("foo:builtin"),
 			sensors.Named("foo:builtin"),
-		),
+		},
 	)
 
 	// start remote2's web service
 	err = remote2.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
-	mainPartAndFooAndBarResources := rdktestutils.NewSortedResourceNames(
+	mainPartAndFooAndBarResources := []resource.Name{
 		motion.Named(resource.DefaultServiceName),
 		sensors.Named(resource.DefaultServiceName),
 		arm.Named("arm1"),
@@ -2704,26 +2646,23 @@ func TestRemoteRobotsGold(t *testing.T) {
 		arm.Named("bar:remoteArm"),
 		motion.Named("bar:builtin"),
 		sensors.Named("bar:builtin"),
-	)
+	}
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		test.That(tb, rdktestutils.NewSortedResourceNames(r.ResourceNames()...), test.ShouldResemble, mainPartAndFooAndBarResources)
+		rdktestutils.VerifySameResourceNames(tb, r.ResourceNames(), mainPartAndFooAndBarResources)
 	})
 	test.That(t, remote2.Close(context.Background()), test.ShouldBeNil)
 
 	// wait for local_robot to detect that the remote is now offline
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		test.That(
-			tb,
-			rdktestutils.NewSortedResourceNames(r.ResourceNames()...),
-			test.ShouldResemble,
-			rdktestutils.NewSortedResourceNames(
+		rdktestutils.VerifySameResourceNames(tb, r.ResourceNames(),
+			[]resource.Name{
 				motion.Named(resource.DefaultServiceName),
 				sensors.Named(resource.DefaultServiceName),
 				arm.Named("arm1"),
 				arm.Named("foo:remoteArm"),
 				motion.Named("foo:builtin"),
 				sensors.Named("foo:builtin"),
-			),
+			},
 		)
 	})
 
@@ -2738,7 +2677,7 @@ func TestRemoteRobotsGold(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		test.That(tb, rdktestutils.NewSortedResourceNames(r.ResourceNames()...), test.ShouldResemble, mainPartAndFooAndBarResources)
+		rdktestutils.VerifySameResourceNames(tb, r.ResourceNames(), mainPartAndFooAndBarResources)
 	})
 }
 
@@ -2787,7 +2726,7 @@ func TestRemoteRobotsUpdate(t *testing.T) {
 	}
 	r := setupLocalRobot(t, ctx, localConfig, logger.Sublogger("local"))
 
-	expectedSet := rdktestutils.NewSortedResourceNames(
+	expectedSet := []resource.Name{
 		motion.Named(resource.DefaultServiceName),
 		sensors.Named(resource.DefaultServiceName),
 		arm.Named("foo:arm1"),
@@ -2802,22 +2741,19 @@ func TestRemoteRobotsUpdate(t *testing.T) {
 		arm.Named("world:arm1"),
 		motion.Named("world:builtin"),
 		sensors.Named("world:builtin"),
-	)
+	}
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		test.That(tb, rdktestutils.NewSortedResourceNames(r.ResourceNames()...), test.ShouldResemble, expectedSet)
+		rdktestutils.VerifySameResourceNames(tb, r.ResourceNames(), expectedSet)
 	})
 	test.That(t, remote.Close(context.Background()), test.ShouldBeNil)
 
 	// wait for local_robot to detect that the remote is now offline
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		test.That(
-			tb,
-			rdktestutils.NewSortedResourceNames(r.ResourceNames()...),
-			test.ShouldResemble,
-			rdktestutils.NewSortedResourceNames(
+		rdktestutils.VerifySameResourceNames(tb, r.ResourceNames(),
+			[]resource.Name{
 				motion.Named(resource.DefaultServiceName),
 				sensors.Named(resource.DefaultServiceName),
-			),
+			},
 		)
 	})
 }
@@ -2867,32 +2803,25 @@ func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
 		},
 	}
 	r := setupLocalRobot(t, ctx, localConfig, logger.Sublogger("local"))
-	expectedSet := rdktestutils.NewSortedResourceNames(
+	expectedSet := []resource.Name{
 		motion.Named(resource.DefaultServiceName),
 		sensors.Named(resource.DefaultServiceName),
 		arm.Named("arm1"),
 		arm.Named("foo:pieceArm"),
 		motion.Named("foo:builtin"),
 		sensors.Named("foo:builtin"),
-	)
-	test.That(
-		t,
-		rdktestutils.NewSortedResourceNames(r.ResourceNames()...),
-		test.ShouldResemble,
-		expectedSet,
-	)
+	}
+
+	rdktestutils.VerifySameResourceNames(t, r.ResourceNames(), expectedSet)
 	test.That(t, foo.Close(context.Background()), test.ShouldBeNil)
 
 	// wait for local_robot to detect that the remote is now offline
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		test.That(
-			tb,
-			rdktestutils.NewSortedResourceNames(r.ResourceNames()...),
-			test.ShouldResemble,
-			rdktestutils.NewSortedResourceNames(
+		rdktestutils.VerifySameResourceNames(tb, r.ResourceNames(),
+			[]resource.Name{
 				motion.Named(resource.DefaultServiceName),
 				sensors.Named(resource.DefaultServiceName),
-			),
+			},
 		)
 	})
 
@@ -2907,7 +2836,7 @@ func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		test.That(tb, rdktestutils.NewSortedResourceNames(r.ResourceNames()...), test.ShouldResemble, expectedSet)
+		rdktestutils.VerifySameResourceNames(tb, r.ResourceNames(), expectedSet)
 	})
 }
 
@@ -2956,41 +2885,35 @@ func TestInferRemoteRobotDependencyConnectAfterStartup(t *testing.T) {
 		},
 	}
 	r := setupLocalRobot(t, ctx, localConfig, logger.Sublogger("local"))
-	test.That(
-		t,
-		rdktestutils.NewSortedResourceNames(r.ResourceNames()...),
-		test.ShouldResemble,
-		rdktestutils.NewSortedResourceNames(
+	rdktestutils.VerifySameResourceNames(t, r.ResourceNames(),
+		[]resource.Name{
 			motion.Named(resource.DefaultServiceName),
 			sensors.Named(resource.DefaultServiceName),
-		),
+		},
 	)
 	err := foo.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
-	expectedSet := rdktestutils.NewSortedResourceNames(
+	expectedSet := []resource.Name{
 		motion.Named(resource.DefaultServiceName),
 		sensors.Named(resource.DefaultServiceName),
 		arm.Named("arm1"),
 		arm.Named("foo:pieceArm"),
 		motion.Named("foo:builtin"),
 		sensors.Named("foo:builtin"),
-	)
+	}
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		test.That(tb, rdktestutils.NewSortedResourceNames(r.ResourceNames()...), test.ShouldResemble, expectedSet)
+		rdktestutils.VerifySameResourceNames(tb, r.ResourceNames(), expectedSet)
 	})
 	test.That(t, foo.Close(context.Background()), test.ShouldBeNil)
 
 	// wait for local_robot to detect that the remote is now offline
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		test.That(
-			tb,
-			rdktestutils.NewSortedResourceNames(r.ResourceNames()...),
-			test.ShouldResemble,
-			rdktestutils.NewSortedResourceNames(
+		rdktestutils.VerifySameResourceNames(tb, r.ResourceNames(),
+			[]resource.Name{
 				motion.Named(resource.DefaultServiceName),
 				sensors.Named(resource.DefaultServiceName),
-			),
+			},
 		)
 	})
 }
@@ -3052,7 +2975,7 @@ func TestInferRemoteRobotDependencyAmbiguous(t *testing.T) {
 	}
 	r := setupLocalRobot(t, ctx, localConfig, logger.Sublogger("local"))
 
-	expectedSet := rdktestutils.NewSortedResourceNames(
+	expectedSet := []resource.Name{
 		motion.Named(resource.DefaultServiceName),
 		sensors.Named(resource.DefaultServiceName),
 		arm.Named("foo:pieceArm"),
@@ -3061,13 +2984,13 @@ func TestInferRemoteRobotDependencyAmbiguous(t *testing.T) {
 		arm.Named("bar:pieceArm"),
 		motion.Named("bar:builtin"),
 		sensors.Named("bar:builtin"),
-	)
+	}
 
-	test.That(t, rdktestutils.NewSortedResourceNames(r.ResourceNames()...), test.ShouldResemble, expectedSet)
+	rdktestutils.VerifySameResourceNames(t, r.ResourceNames(), expectedSet)
 
 	// we expect the robot to correctly detect the ambiguous dependency and not build the resource
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 150, func(tb testing.TB) {
-		test.That(tb, rdktestutils.NewSortedResourceNames(r.ResourceNames()...), test.ShouldResemble, expectedSet)
+		rdktestutils.VerifySameResourceNames(tb, r.ResourceNames(), expectedSet)
 	})
 
 	// now reconfig with a fully qualified name
@@ -3096,7 +3019,7 @@ func TestInferRemoteRobotDependencyAmbiguous(t *testing.T) {
 	}
 	r.Reconfigure(ctx, reConfig)
 
-	finalSet := rdktestutils.NewSortedResourceNames(
+	finalSet := []resource.Name{
 		motion.Named(resource.DefaultServiceName),
 		sensors.Named(resource.DefaultServiceName),
 		arm.Named("foo:pieceArm"),
@@ -3106,10 +3029,10 @@ func TestInferRemoteRobotDependencyAmbiguous(t *testing.T) {
 		motion.Named("bar:builtin"),
 		sensors.Named("bar:builtin"),
 		arm.Named("arm1"),
-	)
+	}
 
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		test.That(tb, rdktestutils.NewSortedResourceNames(r.ResourceNames()...), test.ShouldResemble, finalSet)
+		rdktestutils.VerifySameResourceNames(tb, r.ResourceNames(), finalSet)
 	})
 }
 

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -2159,7 +2159,12 @@ func TestSensorsServiceReconfigure(t *testing.T) {
 
 		foundSensors, err = svc.Sensors(context.Background(), map[string]interface{}{})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, rdktestutils.NewSortedResourceNames(foundSensors...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(sensorNames...))
+		test.That(
+			t,
+			rdktestutils.NewSortedResourceNames(foundSensors...),
+			test.ShouldResemble,
+			rdktestutils.NewSortedResourceNames(sensorNames...),
+		)
 	})
 
 	t.Run("two sensors to empty", func(t *testing.T) {
@@ -2170,7 +2175,12 @@ func TestSensorsServiceReconfigure(t *testing.T) {
 
 		foundSensors, err := svc.Sensors(context.Background(), map[string]interface{}{})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, rdktestutils.NewSortedResourceNames(foundSensors...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(sensorNames...))
+		test.That(
+			t,
+			rdktestutils.NewSortedResourceNames(foundSensors...),
+			test.ShouldResemble,
+			rdktestutils.NewSortedResourceNames(sensorNames...),
+		)
 
 		robot.Reconfigure(context.Background(), emptyCfg)
 
@@ -2187,13 +2197,23 @@ func TestSensorsServiceReconfigure(t *testing.T) {
 
 		foundSensors, err := svc.Sensors(context.Background(), map[string]interface{}{})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, rdktestutils.NewSortedResourceNames(foundSensors...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(sensorNames...))
+		test.That(
+			t,
+			rdktestutils.NewSortedResourceNames(foundSensors...),
+			test.ShouldResemble,
+			rdktestutils.NewSortedResourceNames(sensorNames...),
+		)
 
 		robot.Reconfigure(context.Background(), cfg)
 
 		foundSensors, err = svc.Sensors(context.Background(), map[string]interface{}{})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, rdktestutils.NewSortedResourceNames(foundSensors...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(sensorNames...))
+		test.That(
+			t,
+			rdktestutils.NewSortedResourceNames(foundSensors...),
+			test.ShouldResemble,
+			rdktestutils.NewSortedResourceNames(sensorNames...),
+		)
 	})
 }
 

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -159,7 +159,7 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		names := rdktestutils.NewResourceNameSet(robot.ResourceNames()...)
+		names := rdktestutils.NewSortedResourceNames(robot.ResourceNames()...)
 		names2 := rdktestutils.ConcatResourceNames(
 			armNames,
 			baseNames,
@@ -169,7 +169,7 @@ func TestRobotReconfigure(t *testing.T) {
 		)
 		_ = names2
 		_ = names
-		test.That(t, rdktestutils.NewResourceNameSet(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewResourceNameSet(
+		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
 			rdktestutils.ConcatResourceNames(
 				armNames,
 				baseNames,
@@ -203,7 +203,7 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewResourceNameSet(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewResourceNameSet(
+		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
 			rdktestutils.ConcatResourceNames(
 				armNames,
 				baseNames,
@@ -278,7 +278,7 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewResourceNameSet(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewResourceNameSet(
+		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
 			rdktestutils.ConcatResourceNames(
 				armNames,
 				baseNames,
@@ -344,7 +344,7 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewResourceNameSet(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewResourceNameSet(
+		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
 			rdktestutils.ConcatResourceNames(
 				armNames,
 				baseNames,
@@ -424,7 +424,7 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewResourceNameSet(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewResourceNameSet(
+		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
 			rdktestutils.ConcatResourceNames(
 				armNames,
 				baseNames,
@@ -467,7 +467,7 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewResourceNameSet(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewResourceNameSet(
+		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
 			rdktestutils.ConcatResourceNames(
 				armNames,
 				baseNames,
@@ -574,7 +574,7 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewResourceNameSet(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewResourceNameSet(
+		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
 			rdktestutils.ConcatResourceNames(
 				armNames,
 				baseNames,
@@ -624,7 +624,7 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewResourceNameSet(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewResourceNameSet(
+		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
 			rdktestutils.ConcatResourceNames(
 				armNames,
 				baseNames,
@@ -734,7 +734,7 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewResourceNameSet(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewResourceNameSet(
+		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
 			rdktestutils.ConcatResourceNames(
 				armNames,
 				baseNames,
@@ -778,7 +778,7 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewResourceNameSet(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewResourceNameSet(
+		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
 			rdktestutils.ConcatResourceNames(
 				boardNames,
 				resource.DefaultServices(),
@@ -821,7 +821,7 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, ok, test.ShouldBeTrue)
 		sorted := robot.(*localRobot).manager.resources.TopologicalSort()
 		sorted = rdktestutils.SubtractNames(sorted, robot.(*localRobot).manager.internalResourceNames()...)
-		test.That(t, rdktestutils.NewResourceNameSet(sorted...), test.ShouldResemble, rdktestutils.NewResourceNameSet(
+		test.That(t, rdktestutils.NewSortedResourceNames(sorted...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
 			rdktestutils.ConcatResourceNames(
 				boardNames,
 				resource.DefaultServices(),
@@ -872,7 +872,7 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewResourceNameSet(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewResourceNameSet(
+		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
 			rdktestutils.ConcatResourceNames(
 				armNames,
 				baseNames,
@@ -931,7 +931,7 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewResourceNameSet(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewResourceNameSet(
+		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
 			rdktestutils.ConcatResourceNames(
 				armNames,
 				baseNames,
@@ -1033,9 +1033,9 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(
 			t,
-			rdktestutils.NewResourceNameSet(robot.ResourceNames()...),
+			rdktestutils.NewSortedResourceNames(robot.ResourceNames()...),
 			test.ShouldResemble,
-			rdktestutils.NewResourceNameSet(resource.DefaultServices()...),
+			rdktestutils.NewSortedResourceNames(resource.DefaultServices()...),
 		)
 		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldBeEmpty)
 
@@ -1075,7 +1075,7 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewResourceNameSet(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewResourceNameSet(
+		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
 			rdktestutils.ConcatResourceNames(
 				armNames,
 				baseNames,
@@ -1184,7 +1184,7 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewResourceNameSet(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewResourceNameSet(
+		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
 			rdktestutils.ConcatResourceNames(
 				boardNames,
 				resource.DefaultServices(),
@@ -1267,7 +1267,7 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewResourceNameSet(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewResourceNameSet(
+		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
 			rdktestutils.ConcatResourceNames(
 				boardNames,
 				resource.DefaultServices(),
@@ -1337,7 +1337,7 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, ok, test.ShouldBeTrue)
 		sorted := robot.(*localRobot).manager.resources.TopologicalSort()
 		sorted = rdktestutils.SubtractNames(sorted, robot.(*localRobot).manager.internalResourceNames()...)
-		test.That(t, rdktestutils.NewResourceNameSet(sorted...), test.ShouldResemble, rdktestutils.NewResourceNameSet(
+		test.That(t, rdktestutils.NewSortedResourceNames(sorted...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
 			rdktestutils.ConcatResourceNames(
 				motorNames,
 				resource.DefaultServices(),
@@ -1394,7 +1394,7 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewResourceNameSet(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewResourceNameSet(
+		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
 			rdktestutils.ConcatResourceNames(
 				boardNames,
 				encoderNames,
@@ -1463,7 +1463,7 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, ok, test.ShouldBeTrue)
 		sorted := robot.(*localRobot).manager.resources.TopologicalSort()
 		sorted = rdktestutils.SubtractNames(sorted, robot.(*localRobot).manager.internalResourceNames()...)
-		test.That(t, rdktestutils.NewResourceNameSet(sorted...), test.ShouldResemble, rdktestutils.NewResourceNameSet(
+		test.That(t, rdktestutils.NewSortedResourceNames(sorted...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
 			rdktestutils.ConcatResourceNames(
 				motorNames,
 				resource.DefaultServices(),
@@ -1509,7 +1509,7 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewResourceNameSet(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewResourceNameSet(
+		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
 			rdktestutils.ConcatResourceNames(
 				boardNames,
 				resource.DefaultServices(),
@@ -1618,7 +1618,7 @@ func TestRobotReconfigure(t *testing.T) {
 			utils.NewStringSet(rdktestutils.ExtractNames(encoderNames...)...),
 		)
 
-		test.That(t, rdktestutils.NewResourceNameSet(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewResourceNameSet(
+		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
 			rdktestutils.ConcatResourceNames(
 				boardNames,
 				resource.DefaultServices(),
@@ -1685,7 +1685,7 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, ok, test.ShouldBeTrue)
 		sorted := robot.(*localRobot).manager.resources.TopologicalSort()
 		sorted = rdktestutils.SubtractNames(sorted, robot.(*localRobot).manager.internalResourceNames()...)
-		test.That(t, rdktestutils.NewResourceNameSet(sorted...), test.ShouldResemble, rdktestutils.NewResourceNameSet(
+		test.That(t, rdktestutils.NewSortedResourceNames(sorted...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
 			rdktestutils.ConcatResourceNames(
 				motorNames,
 				resource.DefaultServices(),
@@ -1721,7 +1721,7 @@ func TestRobotReconfigure(t *testing.T) {
 			utils.NewStringSet(rdktestutils.ExtractNames(boardNames...)...),
 		)
 
-		test.That(t, rdktestutils.NewResourceNameSet(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewResourceNameSet(
+		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
 			rdktestutils.ConcatResourceNames(
 				boardNames,
 				resource.DefaultServices(),
@@ -1774,7 +1774,7 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, ok, test.ShouldBeTrue)
 		sorted = robot.(*localRobot).manager.resources.TopologicalSort()
 		sorted = rdktestutils.SubtractNames(sorted, robot.(*localRobot).manager.internalResourceNames()...)
-		test.That(t, rdktestutils.NewResourceNameSet(sorted...), test.ShouldResemble, rdktestutils.NewResourceNameSet(
+		test.That(t, rdktestutils.NewSortedResourceNames(sorted...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
 			rdktestutils.ConcatResourceNames(
 				motorNames,
 				resource.DefaultServices(),
@@ -1818,7 +1818,7 @@ func TestRobotReconfigure(t *testing.T) {
 			utils.NewStringSet(rdktestutils.ExtractNames(encoderNames...)...),
 		)
 
-		test.That(t, rdktestutils.NewResourceNameSet(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewResourceNameSet(
+		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
 			rdktestutils.ConcatResourceNames(
 				boardNames,
 				resource.DefaultServices(),
@@ -1900,7 +1900,7 @@ func TestRobotReconfigure(t *testing.T) {
 
 		sorted = robot.(*localRobot).manager.resources.TopologicalSort()
 		sorted = rdktestutils.SubtractNames(sorted, robot.(*localRobot).manager.internalResourceNames()...)
-		test.That(t, rdktestutils.NewResourceNameSet(sorted...), test.ShouldResemble, rdktestutils.NewResourceNameSet(
+		test.That(t, rdktestutils.NewSortedResourceNames(sorted...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
 			rdktestutils.ConcatResourceNames(
 				motorNames,
 				resource.DefaultServices(),
@@ -1933,7 +1933,7 @@ func TestRobotReconfigure(t *testing.T) {
 			test.ShouldResemble,
 			utils.NewStringSet(rdktestutils.ExtractNames(armNames...)...),
 		)
-		test.That(t, rdktestutils.NewResourceNameSet(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewResourceNameSet(
+		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
 			rdktestutils.ConcatResourceNames(
 				armNames,
 				resource.DefaultServices(),
@@ -1952,7 +1952,7 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(robot.RemoteNames()...), test.ShouldBeEmpty)
 
 		test.That(t, utils.NewStringSet(arm.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, rdktestutils.NewResourceNameSet(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewResourceNameSet(
+		test.That(t, rdktestutils.NewSortedResourceNames(robot.ResourceNames()...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(
 			rdktestutils.ConcatResourceNames(
 				mockNames,
 				resource.DefaultServices(),
@@ -2159,7 +2159,7 @@ func TestSensorsServiceReconfigure(t *testing.T) {
 
 		foundSensors, err = svc.Sensors(context.Background(), map[string]interface{}{})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, rdktestutils.NewResourceNameSet(foundSensors...), test.ShouldResemble, rdktestutils.NewResourceNameSet(sensorNames...))
+		test.That(t, rdktestutils.NewSortedResourceNames(foundSensors...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(sensorNames...))
 	})
 
 	t.Run("two sensors to empty", func(t *testing.T) {
@@ -2170,7 +2170,7 @@ func TestSensorsServiceReconfigure(t *testing.T) {
 
 		foundSensors, err := svc.Sensors(context.Background(), map[string]interface{}{})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, rdktestutils.NewResourceNameSet(foundSensors...), test.ShouldResemble, rdktestutils.NewResourceNameSet(sensorNames...))
+		test.That(t, rdktestutils.NewSortedResourceNames(foundSensors...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(sensorNames...))
 
 		robot.Reconfigure(context.Background(), emptyCfg)
 
@@ -2187,13 +2187,13 @@ func TestSensorsServiceReconfigure(t *testing.T) {
 
 		foundSensors, err := svc.Sensors(context.Background(), map[string]interface{}{})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, rdktestutils.NewResourceNameSet(foundSensors...), test.ShouldResemble, rdktestutils.NewResourceNameSet(sensorNames...))
+		test.That(t, rdktestutils.NewSortedResourceNames(foundSensors...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(sensorNames...))
 
 		robot.Reconfigure(context.Background(), cfg)
 
 		foundSensors, err = svc.Sensors(context.Background(), map[string]interface{}{})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, rdktestutils.NewResourceNameSet(foundSensors...), test.ShouldResemble, rdktestutils.NewResourceNameSet(sensorNames...))
+		test.That(t, rdktestutils.NewSortedResourceNames(foundSensors...), test.ShouldResemble, rdktestutils.NewSortedResourceNames(sensorNames...))
 	})
 }
 
@@ -2480,9 +2480,9 @@ func TestDefaultServiceReconfigure(t *testing.T) {
 
 	test.That(
 		t,
-		rdktestutils.NewResourceNameSet(robot.ResourceNames()...),
+		rdktestutils.NewSortedResourceNames(robot.ResourceNames()...),
 		test.ShouldResemble,
-		rdktestutils.NewResourceNameSet(
+		rdktestutils.NewSortedResourceNames(
 			motion.Named(motionName),
 			sensors.Named(resource.DefaultServiceName),
 		),
@@ -2500,9 +2500,9 @@ func TestDefaultServiceReconfigure(t *testing.T) {
 	robot.Reconfigure(context.Background(), cfg2)
 	test.That(
 		t,
-		rdktestutils.NewResourceNameSet(robot.ResourceNames()...),
+		rdktestutils.NewSortedResourceNames(robot.ResourceNames()...),
 		test.ShouldResemble,
-		rdktestutils.NewResourceNameSet(
+		rdktestutils.NewSortedResourceNames(
 			motion.Named(resource.DefaultServiceName),
 			sensors.Named(sName),
 		),
@@ -2657,9 +2657,9 @@ func TestRemoteRobotsGold(t *testing.T) {
 	// assert all of remote1's resources exist on main but none of remote2's
 	test.That(
 		t,
-		rdktestutils.NewResourceNameSet(r.ResourceNames()...),
+		rdktestutils.NewSortedResourceNames(r.ResourceNames()...),
 		test.ShouldResemble,
-		rdktestutils.NewResourceNameSet(
+		rdktestutils.NewSortedResourceNames(
 			motion.Named(resource.DefaultServiceName),
 			sensors.Named(resource.DefaultServiceName),
 			arm.Named("arm1"),
@@ -2673,7 +2673,7 @@ func TestRemoteRobotsGold(t *testing.T) {
 	err = remote2.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
-	mainPartAndFooAndBarResources := rdktestutils.NewResourceNameSet(
+	mainPartAndFooAndBarResources := rdktestutils.NewSortedResourceNames(
 		motion.Named(resource.DefaultServiceName),
 		sensors.Named(resource.DefaultServiceName),
 		arm.Named("arm1"),
@@ -2686,7 +2686,7 @@ func TestRemoteRobotsGold(t *testing.T) {
 		sensors.Named("bar:builtin"),
 	)
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		test.That(tb, rdktestutils.NewResourceNameSet(r.ResourceNames()...), test.ShouldResemble, mainPartAndFooAndBarResources)
+		test.That(tb, rdktestutils.NewSortedResourceNames(r.ResourceNames()...), test.ShouldResemble, mainPartAndFooAndBarResources)
 	})
 	test.That(t, remote2.Close(context.Background()), test.ShouldBeNil)
 
@@ -2694,9 +2694,9 @@ func TestRemoteRobotsGold(t *testing.T) {
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
 		test.That(
 			tb,
-			rdktestutils.NewResourceNameSet(r.ResourceNames()...),
+			rdktestutils.NewSortedResourceNames(r.ResourceNames()...),
 			test.ShouldResemble,
-			rdktestutils.NewResourceNameSet(
+			rdktestutils.NewSortedResourceNames(
 				motion.Named(resource.DefaultServiceName),
 				sensors.Named(resource.DefaultServiceName),
 				arm.Named("arm1"),
@@ -2718,7 +2718,7 @@ func TestRemoteRobotsGold(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		test.That(tb, rdktestutils.NewResourceNameSet(r.ResourceNames()...), test.ShouldResemble, mainPartAndFooAndBarResources)
+		test.That(tb, rdktestutils.NewSortedResourceNames(r.ResourceNames()...), test.ShouldResemble, mainPartAndFooAndBarResources)
 	})
 }
 
@@ -2767,7 +2767,7 @@ func TestRemoteRobotsUpdate(t *testing.T) {
 	}
 	r := setupLocalRobot(t, ctx, localConfig, logger.Sublogger("local"))
 
-	expectedSet := rdktestutils.NewResourceNameSet(
+	expectedSet := rdktestutils.NewSortedResourceNames(
 		motion.Named(resource.DefaultServiceName),
 		sensors.Named(resource.DefaultServiceName),
 		arm.Named("foo:arm1"),
@@ -2784,7 +2784,7 @@ func TestRemoteRobotsUpdate(t *testing.T) {
 		sensors.Named("world:builtin"),
 	)
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		test.That(tb, rdktestutils.NewResourceNameSet(r.ResourceNames()...), test.ShouldResemble, expectedSet)
+		test.That(tb, rdktestutils.NewSortedResourceNames(r.ResourceNames()...), test.ShouldResemble, expectedSet)
 	})
 	test.That(t, remote.Close(context.Background()), test.ShouldBeNil)
 
@@ -2792,9 +2792,9 @@ func TestRemoteRobotsUpdate(t *testing.T) {
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
 		test.That(
 			tb,
-			rdktestutils.NewResourceNameSet(r.ResourceNames()...),
+			rdktestutils.NewSortedResourceNames(r.ResourceNames()...),
 			test.ShouldResemble,
-			rdktestutils.NewResourceNameSet(
+			rdktestutils.NewSortedResourceNames(
 				motion.Named(resource.DefaultServiceName),
 				sensors.Named(resource.DefaultServiceName),
 			),
@@ -2847,7 +2847,7 @@ func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
 		},
 	}
 	r := setupLocalRobot(t, ctx, localConfig, logger.Sublogger("local"))
-	expectedSet := rdktestutils.NewResourceNameSet(
+	expectedSet := rdktestutils.NewSortedResourceNames(
 		motion.Named(resource.DefaultServiceName),
 		sensors.Named(resource.DefaultServiceName),
 		arm.Named("arm1"),
@@ -2857,7 +2857,7 @@ func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
 	)
 	test.That(
 		t,
-		rdktestutils.NewResourceNameSet(r.ResourceNames()...),
+		rdktestutils.NewSortedResourceNames(r.ResourceNames()...),
 		test.ShouldResemble,
 		expectedSet,
 	)
@@ -2867,9 +2867,9 @@ func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
 		test.That(
 			tb,
-			rdktestutils.NewResourceNameSet(r.ResourceNames()...),
+			rdktestutils.NewSortedResourceNames(r.ResourceNames()...),
 			test.ShouldResemble,
-			rdktestutils.NewResourceNameSet(
+			rdktestutils.NewSortedResourceNames(
 				motion.Named(resource.DefaultServiceName),
 				sensors.Named(resource.DefaultServiceName),
 			),
@@ -2887,7 +2887,7 @@ func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		test.That(tb, rdktestutils.NewResourceNameSet(r.ResourceNames()...), test.ShouldResemble, expectedSet)
+		test.That(tb, rdktestutils.NewSortedResourceNames(r.ResourceNames()...), test.ShouldResemble, expectedSet)
 	})
 }
 
@@ -2938,9 +2938,9 @@ func TestInferRemoteRobotDependencyConnectAfterStartup(t *testing.T) {
 	r := setupLocalRobot(t, ctx, localConfig, logger.Sublogger("local"))
 	test.That(
 		t,
-		rdktestutils.NewResourceNameSet(r.ResourceNames()...),
+		rdktestutils.NewSortedResourceNames(r.ResourceNames()...),
 		test.ShouldResemble,
-		rdktestutils.NewResourceNameSet(
+		rdktestutils.NewSortedResourceNames(
 			motion.Named(resource.DefaultServiceName),
 			sensors.Named(resource.DefaultServiceName),
 		),
@@ -2948,7 +2948,7 @@ func TestInferRemoteRobotDependencyConnectAfterStartup(t *testing.T) {
 	err := foo.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
-	expectedSet := rdktestutils.NewResourceNameSet(
+	expectedSet := rdktestutils.NewSortedResourceNames(
 		motion.Named(resource.DefaultServiceName),
 		sensors.Named(resource.DefaultServiceName),
 		arm.Named("arm1"),
@@ -2957,7 +2957,7 @@ func TestInferRemoteRobotDependencyConnectAfterStartup(t *testing.T) {
 		sensors.Named("foo:builtin"),
 	)
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		test.That(tb, rdktestutils.NewResourceNameSet(r.ResourceNames()...), test.ShouldResemble, expectedSet)
+		test.That(tb, rdktestutils.NewSortedResourceNames(r.ResourceNames()...), test.ShouldResemble, expectedSet)
 	})
 	test.That(t, foo.Close(context.Background()), test.ShouldBeNil)
 
@@ -2965,9 +2965,9 @@ func TestInferRemoteRobotDependencyConnectAfterStartup(t *testing.T) {
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
 		test.That(
 			tb,
-			rdktestutils.NewResourceNameSet(r.ResourceNames()...),
+			rdktestutils.NewSortedResourceNames(r.ResourceNames()...),
 			test.ShouldResemble,
-			rdktestutils.NewResourceNameSet(
+			rdktestutils.NewSortedResourceNames(
 				motion.Named(resource.DefaultServiceName),
 				sensors.Named(resource.DefaultServiceName),
 			),
@@ -3032,7 +3032,7 @@ func TestInferRemoteRobotDependencyAmbiguous(t *testing.T) {
 	}
 	r := setupLocalRobot(t, ctx, localConfig, logger.Sublogger("local"))
 
-	expectedSet := rdktestutils.NewResourceNameSet(
+	expectedSet := rdktestutils.NewSortedResourceNames(
 		motion.Named(resource.DefaultServiceName),
 		sensors.Named(resource.DefaultServiceName),
 		arm.Named("foo:pieceArm"),
@@ -3043,11 +3043,11 @@ func TestInferRemoteRobotDependencyAmbiguous(t *testing.T) {
 		sensors.Named("bar:builtin"),
 	)
 
-	test.That(t, rdktestutils.NewResourceNameSet(r.ResourceNames()...), test.ShouldResemble, expectedSet)
+	test.That(t, rdktestutils.NewSortedResourceNames(r.ResourceNames()...), test.ShouldResemble, expectedSet)
 
 	// we expect the robot to correctly detect the ambiguous dependency and not build the resource
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 150, func(tb testing.TB) {
-		test.That(tb, rdktestutils.NewResourceNameSet(r.ResourceNames()...), test.ShouldResemble, expectedSet)
+		test.That(tb, rdktestutils.NewSortedResourceNames(r.ResourceNames()...), test.ShouldResemble, expectedSet)
 	})
 
 	// now reconfig with a fully qualified name
@@ -3076,7 +3076,7 @@ func TestInferRemoteRobotDependencyAmbiguous(t *testing.T) {
 	}
 	r.Reconfigure(ctx, reConfig)
 
-	finalSet := rdktestutils.NewResourceNameSet(
+	finalSet := rdktestutils.NewSortedResourceNames(
 		motion.Named(resource.DefaultServiceName),
 		sensors.Named(resource.DefaultServiceName),
 		arm.Named("foo:pieceArm"),
@@ -3089,7 +3089,7 @@ func TestInferRemoteRobotDependencyAmbiguous(t *testing.T) {
 	)
 
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		test.That(tb, rdktestutils.NewResourceNameSet(r.ResourceNames()...), test.ShouldResemble, finalSet)
+		test.That(tb, rdktestutils.NewSortedResourceNames(r.ResourceNames()...), test.ShouldResemble, finalSet)
 	})
 }
 

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -159,16 +159,6 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
 		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		names := rdktestutils.NewSortedResourceNames(robot.ResourceNames()...)
-		names2 := rdktestutils.ConcatResourceNames(
-			armNames,
-			baseNames,
-			boardNames,
-			mockNames,
-			resource.DefaultServices(),
-		)
-		_ = names2
-		_ = names
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
 			armNames,
 			baseNames,

--- a/robot/server/server_test.go
+++ b/robot/server/server_test.go
@@ -473,12 +473,7 @@ func TestServerGetStatus(t *testing.T) {
 			aStatus.Name: lastReconfigured,
 		}
 		injectRobot.StatusFunc = func(ctx context.Context, resourceNames []resource.Name) ([]robot.Status, error) {
-			test.That(
-				t,
-				testutils.NewSortedResourceNames(resourceNames...),
-				test.ShouldResemble,
-				testutils.NewSortedResourceNames(aStatus.Name),
-			)
+			testutils.VerifySameResourceNames(t, resourceNames, []resource.Name{aStatus.Name})
 			return readings, nil
 		}
 		req := &pb.GetStatusRequest{
@@ -523,12 +518,7 @@ func TestServerGetStatus(t *testing.T) {
 			aStatus.Name: lastReconfigured2,
 		}
 		injectRobot.StatusFunc = func(ctx context.Context, resourceNames []resource.Name) ([]robot.Status, error) {
-			test.That(
-				t,
-				testutils.NewSortedResourceNames(resourceNames...),
-				test.ShouldResemble,
-				testutils.NewSortedResourceNames(gStatus.Name, aStatus.Name),
-			)
+			testutils.VerifySameResourceNames(t, resourceNames, []resource.Name{gStatus.Name, aStatus.Name})
 			return statuses, nil
 		}
 		req := &pb.GetStatusRequest{

--- a/robot/server/server_test.go
+++ b/robot/server/server_test.go
@@ -475,9 +475,9 @@ func TestServerGetStatus(t *testing.T) {
 		injectRobot.StatusFunc = func(ctx context.Context, resourceNames []resource.Name) ([]robot.Status, error) {
 			test.That(
 				t,
-				testutils.NewResourceNameSet(resourceNames...),
+				testutils.NewSortedResourceNames(resourceNames...),
 				test.ShouldResemble,
-				testutils.NewResourceNameSet(aStatus.Name),
+				testutils.NewSortedResourceNames(aStatus.Name),
 			)
 			return readings, nil
 		}
@@ -525,9 +525,9 @@ func TestServerGetStatus(t *testing.T) {
 		injectRobot.StatusFunc = func(ctx context.Context, resourceNames []resource.Name) ([]robot.Status, error) {
 			test.That(
 				t,
-				testutils.NewResourceNameSet(resourceNames...),
+				testutils.NewSortedResourceNames(resourceNames...),
 				test.ShouldResemble,
-				testutils.NewResourceNameSet(gStatus.Name, aStatus.Name),
+				testutils.NewSortedResourceNames(gStatus.Name, aStatus.Name),
 			)
 			return statuses, nil
 		}

--- a/services/sensors/builtin/builtin_test.go
+++ b/services/sensors/builtin/builtin_test.go
@@ -60,9 +60,9 @@ func TestGetSensors(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(
 			t,
-			testutils.NewResourceNameSet(sNames1...),
+			testutils.NewSortedResourceNames(sNames1...),
 			test.ShouldResemble,
-			testutils.NewResourceNameSet(movementsensor.Named("imu")),
+			testutils.NewSortedResourceNames(movementsensor.Named("imu")),
 		)
 	})
 
@@ -78,7 +78,7 @@ func TestGetSensors(t *testing.T) {
 
 		sNames1, err := svc.Sensors(context.Background(), map[string]interface{}{})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, testutils.NewResourceNameSet(sNames1...), test.ShouldResemble, testutils.NewResourceNameSet(sensorNames...))
+		test.That(t, testutils.NewSortedResourceNames(sNames1...), test.ShouldResemble, testutils.NewSortedResourceNames(sensorNames...))
 	})
 }
 
@@ -204,7 +204,7 @@ func TestReconfigure(t *testing.T) {
 
 		sNames1, err := svc.Sensors(context.Background(), map[string]interface{}{})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, testutils.NewResourceNameSet(sNames1...), test.ShouldResemble, testutils.NewResourceNameSet(sensorNames...))
+		test.That(t, testutils.NewSortedResourceNames(sNames1...), test.ShouldResemble, testutils.NewSortedResourceNames(sensorNames...))
 
 		err = svc.Reconfigure(
 			context.Background(),
@@ -228,7 +228,7 @@ func TestReconfigure(t *testing.T) {
 
 		sNames1, err := svc.Sensors(context.Background(), map[string]interface{}{})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, testutils.NewResourceNameSet(sNames1...), test.ShouldResemble, testutils.NewResourceNameSet(sensorNames...))
+		test.That(t, testutils.NewSortedResourceNames(sNames1...), test.ShouldResemble, testutils.NewSortedResourceNames(sensorNames...))
 
 		err = svc.Reconfigure(
 			context.Background(),
@@ -241,9 +241,9 @@ func TestReconfigure(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(
 			t,
-			testutils.NewResourceNameSet(sNames1...),
+			testutils.NewSortedResourceNames(sNames1...),
 			test.ShouldResemble,
-			testutils.NewResourceNameSet(movementsensor.Named("imu")),
+			testutils.NewSortedResourceNames(movementsensor.Named("imu")),
 		)
 	})
 
@@ -255,7 +255,7 @@ func TestReconfigure(t *testing.T) {
 
 		sNames1, err := svc.Sensors(context.Background(), map[string]interface{}{})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, testutils.NewResourceNameSet(sNames1...), test.ShouldResemble, testutils.NewResourceNameSet(sensorNames...))
+		test.That(t, testutils.NewSortedResourceNames(sNames1...), test.ShouldResemble, testutils.NewSortedResourceNames(sensorNames...))
 
 		err = svc.Reconfigure(
 			context.Background(),
@@ -266,6 +266,6 @@ func TestReconfigure(t *testing.T) {
 
 		sNames1, err = svc.Sensors(context.Background(), map[string]interface{}{})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, testutils.NewResourceNameSet(sNames1...), test.ShouldResemble, testutils.NewResourceNameSet(sensorNames...))
+		test.That(t, testutils.NewSortedResourceNames(sNames1...), test.ShouldResemble, testutils.NewSortedResourceNames(sensorNames...))
 	})
 }

--- a/services/sensors/builtin/builtin_test.go
+++ b/services/sensors/builtin/builtin_test.go
@@ -58,12 +58,7 @@ func TestGetSensors(t *testing.T) {
 
 		sNames1, err := svc.Sensors(context.Background(), map[string]interface{}{})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(
-			t,
-			testutils.NewSortedResourceNames(sNames1...),
-			test.ShouldResemble,
-			testutils.NewSortedResourceNames(movementsensor.Named("imu")),
-		)
+		testutils.VerifySameResourceNames(t, sNames1, []resource.Name{movementsensor.Named("imu")})
 	})
 
 	t.Run("many sensors", func(t *testing.T) {
@@ -78,7 +73,7 @@ func TestGetSensors(t *testing.T) {
 
 		sNames1, err := svc.Sensors(context.Background(), map[string]interface{}{})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, testutils.NewSortedResourceNames(sNames1...), test.ShouldResemble, testutils.NewSortedResourceNames(sensorNames...))
+		testutils.VerifySameResourceNames(t, sNames1, sensorNames)
 	})
 }
 
@@ -204,7 +199,7 @@ func TestReconfigure(t *testing.T) {
 
 		sNames1, err := svc.Sensors(context.Background(), map[string]interface{}{})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, testutils.NewSortedResourceNames(sNames1...), test.ShouldResemble, testutils.NewSortedResourceNames(sensorNames...))
+		testutils.VerifySameResourceNames(t, sNames1, sensorNames)
 
 		err = svc.Reconfigure(
 			context.Background(),
@@ -228,7 +223,7 @@ func TestReconfigure(t *testing.T) {
 
 		sNames1, err := svc.Sensors(context.Background(), map[string]interface{}{})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, testutils.NewSortedResourceNames(sNames1...), test.ShouldResemble, testutils.NewSortedResourceNames(sensorNames...))
+		testutils.VerifySameResourceNames(t, sNames1, sensorNames)
 
 		err = svc.Reconfigure(
 			context.Background(),
@@ -239,12 +234,7 @@ func TestReconfigure(t *testing.T) {
 
 		sNames1, err = svc.Sensors(context.Background(), map[string]interface{}{})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(
-			t,
-			testutils.NewSortedResourceNames(sNames1...),
-			test.ShouldResemble,
-			testutils.NewSortedResourceNames(movementsensor.Named("imu")),
-		)
+		testutils.VerifySameResourceNames(t, sNames1, []resource.Name{movementsensor.Named("imu")})
 	})
 
 	t.Run("update with same sensors", func(t *testing.T) {
@@ -255,7 +245,7 @@ func TestReconfigure(t *testing.T) {
 
 		sNames1, err := svc.Sensors(context.Background(), map[string]interface{}{})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, testutils.NewSortedResourceNames(sNames1...), test.ShouldResemble, testutils.NewSortedResourceNames(sensorNames...))
+		testutils.VerifySameResourceNames(t, sNames1, sensorNames)
 
 		err = svc.Reconfigure(
 			context.Background(),
@@ -266,6 +256,6 @@ func TestReconfigure(t *testing.T) {
 
 		sNames1, err = svc.Sensors(context.Background(), map[string]interface{}{})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, testutils.NewSortedResourceNames(sNames1...), test.ShouldResemble, testutils.NewSortedResourceNames(sensorNames...))
+		testutils.VerifySameResourceNames(t, sNames1, sensorNames)
 	})
 }

--- a/services/sensors/server_test.go
+++ b/services/sensors/server_test.go
@@ -82,7 +82,7 @@ func TestServerGetSensors(t *testing.T) {
 		for _, rn := range resp.SensorNames {
 			convertedNames = append(convertedNames, rprotoutils.ResourceNameFromProto(rn))
 		}
-		test.That(t, testutils.NewResourceNameSet(convertedNames...), test.ShouldResemble, testutils.NewResourceNameSet(names...))
+		test.That(t, testutils.NewSortedResourceNames(convertedNames...), test.ShouldResemble, testutils.NewSortedResourceNames(names...))
 	})
 }
 

--- a/services/sensors/server_test.go
+++ b/services/sensors/server_test.go
@@ -82,7 +82,7 @@ func TestServerGetSensors(t *testing.T) {
 		for _, rn := range resp.SensorNames {
 			convertedNames = append(convertedNames, rprotoutils.ResourceNameFromProto(rn))
 		}
-		test.That(t, testutils.NewSortedResourceNames(convertedNames...), test.ShouldResemble, testutils.NewSortedResourceNames(names...))
+		testutils.VerifySameResourceNames(t, convertedNames, names)
 	})
 }
 

--- a/testutils/resource_utils.go
+++ b/testutils/resource_utils.go
@@ -44,15 +44,21 @@ func NewResourceNameSet(resourceNames ...resource.Name) map[resource.Name]struct
 	return set
 }
 
-// NewSortedResourceNames returns a new slice of resources names sorted by each
+// newSortedResourceNames returns a new slice of resources names sorted by each
 // resource's fully-qualified names for the purposes of comparison in automated tests.
-func NewSortedResourceNames(resourceNames ...resource.Name) []resource.Name {
+func newSortedResourceNames(resourceNames []resource.Name) []resource.Name {
 	sorted := make([]resource.Name, len(resourceNames))
 	copy(sorted, resourceNames)
 	slices.SortStableFunc(sorted, func(r1, r2 resource.Name) int {
 		return cmp.Compare(r1.String(), r2.String())
 	})
 	return sorted
+}
+
+// VerifySameResourceNames asserts that two slices of resource.Names contain the same
+// resources.Names without considering order.
+func VerifySameResourceNames(tb testing.TB, actual, expected []resource.Name) {
+	test.That(tb, newSortedResourceNames(actual), test.ShouldResemble, newSortedResourceNames(expected))
 }
 
 // ExtractNames takes a slice of resource.Name objects

--- a/testutils/resource_utils.go
+++ b/testutils/resource_utils.go
@@ -1,7 +1,9 @@
 package testutils
 
 import (
+	"cmp"
 	"context"
+	"slices"
 	"testing"
 
 	"go.viam.com/test"
@@ -40,6 +42,17 @@ func NewResourceNameSet(resourceNames ...resource.Name) map[resource.Name]struct
 		set[val] = struct{}{}
 	}
 	return set
+}
+
+// NewSortedResourceNames returns a new slice of resources names sorted by each
+// resource's fully-qualified names for the purposes of comparison in automated tests.
+func NewSortedResourceNames(resourceNames ...resource.Name) []resource.Name {
+	sorted := make([]resource.Name, len(resourceNames))
+	copy(sorted, resourceNames)
+	slices.SortStableFunc(sorted, func(r1, r2 resource.Name) int {
+		return cmp.Compare(r1.String(), r2.String())
+	})
+	return sorted
 }
 
 // ExtractNames takes a slice of resource.Name objects


### PR DESCRIPTION
QoL testing improvements identified while investigating [this flaky test](https://viam.atlassian.net/browse/RSDK-7706).

* Add a `VerifySameResourceNames` test utility function and use it in places where we verbosely convert to set + assert resembles.
  * Note for reviewers - I tried my best to do this change programmatically via regex-replace, but the format of some sections varied too much and needed to be changed "by hand", so please double-check if I made a silly mistake.
* Under the hood, assert same resources by comparing sorted slices instead of converting to sets - this makes failure diffs a bit more a little more human readable.