### PR TITLE
[RSDK-6777][RSDK-7256][RSDK-7255] Make tests for goForMath and GoFor pass.

### DIFF
--- a/components/motor/gpio/controlled_test.go
+++ b/components/motor/gpio/controlled_test.go
@@ -27,8 +27,10 @@ func TestEncodedMotorControls(t *testing.T) {
 		motorType: DirectionPwm,
 	}
 
+	vals := newState()
+
 	// create an inject encoder
-	enc := injectEncoder()
+	enc := injectEncoder(vals)
 
 	// create an encoded motor
 	conf := resource.Config{
@@ -85,7 +87,8 @@ func TestControlledMotorCreation(t *testing.T) {
 
 	deps := make(resource.Dependencies)
 
-	deps[encoder.Named(encoderName)] = injectEncoder()
+	vals := newState()
+	deps[encoder.Named(encoderName)] = injectEncoder(vals)
 	deps[board.Named(boardName)] = injectBoard()
 
 	m, err := createNewMotor(context.Background(), deps, conf, logger)

--- a/components/motor/gpio/encoded.go
+++ b/components/motor/gpio/encoded.go
@@ -300,7 +300,7 @@ func (m *EncodedMotor) GoFor(ctx context.Context, rpm, revolutions float64, extr
 	)
 	// Ignore the context canceled error - this occurs when the rpmCtx is canceled
 	// with m.rpmMonitorDone in goForInternal and in Stop
-	if !errors.Is(err, context.Canceled) && err != nil {
+	if !errors.Is(err, context.Canceled) {
 		return err
 	}
 	return nil

--- a/components/motor/gpio/encoded.go
+++ b/components/motor/gpio/encoded.go
@@ -300,7 +300,7 @@ func (m *EncodedMotor) GoFor(ctx context.Context, rpm, revolutions float64, extr
 	)
 	// Ignore the context canceled error - this occurs when the rpmCtx is canceled
 	// with m.rpmMonitorDone in goForInternal and in Stop
-	if !errors.Is(err, context.Canceled) {
+	if !errors.Is(err, context.Canceled) && err != nil {
 		return err
 	}
 	return nil

--- a/components/motor/gpio/encoded_test.go
+++ b/components/motor/gpio/encoded_test.go
@@ -243,6 +243,7 @@ func TestEncodedMotor(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		err = m.SetPower(context.Background(), -0.5, nil)
+		test.That(t, err, test.ShouldBeNil)
 		on, powerPct, err := m.IsPowered(context.Background(), nil)
 		test.That(t, on, test.ShouldBeTrue)
 		test.That(t, powerPct, test.ShouldBeLessThan, 0)

--- a/components/motor/gpio/encoded_test.go
+++ b/components/motor/gpio/encoded_test.go
@@ -76,7 +76,7 @@ func injectMotor() motor.Motor {
 		vals.mu.Lock()
 		defer vals.mu.Unlock()
 		vals.powerPct = powerPct
-		vals.position++
+		vals.position += sign(powerPct)
 		return nil
 	}
 	m.GoForFunc = func(ctx context.Context, rpm, rotations float64, extra map[string]interface{}) error {
@@ -186,8 +186,7 @@ func TestEncodedMotor(t *testing.T) {
 	})
 
 	t.Run("encoded motor test GoFor forward", func(t *testing.T) {
-		t.Skip("temporary skip for flake")
-		test.That(t, m.goForInternal(10, 1, 1), test.ShouldBeNil)
+		test.That(t, m.GoFor(context.Background(), 10, 1, nil), test.ShouldBeNil)
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
 			on, powerPct, err := m.IsPowered(context.Background(), nil)
@@ -198,8 +197,7 @@ func TestEncodedMotor(t *testing.T) {
 	})
 
 	t.Run("encoded motor test GoFor backwards", func(t *testing.T) {
-		t.Skip("temporary skip for flake")
-		test.That(t, m.goForInternal(-10, -1, -1), test.ShouldBeNil)
+		test.That(t, m.GoFor(context.Background(), -10, 1, nil), test.ShouldBeNil)
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
 			on, powerPct, err := m.IsPowered(context.Background(), nil)
@@ -210,7 +208,6 @@ func TestEncodedMotor(t *testing.T) {
 	})
 
 	t.Run("encoded motor test goForMath", func(t *testing.T) {
-		t.Skip("temporary skip for flake")
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
 			test.That(tb, m.ResetZeroPosition(context.Background(), 0, nil), test.ShouldBeNil)
@@ -238,9 +235,8 @@ func TestEncodedMotor(t *testing.T) {
 	})
 
 	t.Run("encoded motor test SetPower interrupts GoFor", func(t *testing.T) {
-		t.Skip("temporary skip for flake")
 		go func() {
-			test.That(t, m.goForInternal(10, 1, 1), test.ShouldBeNil)
+			test.That(t, m.GoFor(context.Background(), 10, 1, nil), test.ShouldBeNil)
 		}()
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {

--- a/components/motor/gpio/encoded_test.go
+++ b/components/motor/gpio/encoded_test.go
@@ -236,14 +236,14 @@ func TestEncodedMotor(t *testing.T) {
 			test.That(t, err, test.ShouldBeNil)
 		})
 
-		on, powerPct, err := m.IsPowered(context.Background(), nil)
+		_, _, err := m.IsPowered(context.Background(), nil)
 		// TODO make these tests pass
 		// test.That(t, on, test.ShouldBeTrue)
 		// test.That(t, powerPct, test.ShouldBeGreaterThan, 0)
 		test.That(t, err, test.ShouldBeNil)
 
 		err = m.SetPower(context.Background(), -0.5, nil)
-		on, powerPct, err = m.IsPowered(context.Background(), nil)
+		on, powerPct, err := m.IsPowered(context.Background(), nil)
 		test.That(t, on, test.ShouldBeTrue)
 		test.That(t, powerPct, test.ShouldBeLessThan, 0)
 		test.That(t, err, test.ShouldBeNil)

--- a/components/motor/gpio/encoded_test.go
+++ b/components/motor/gpio/encoded_test.go
@@ -107,7 +107,6 @@ func injectMotor(vals *injectedState) motor.Motor {
 	m.IsPoweredFunc = func(ctx context.Context, extra map[string]interface{}) (bool, float64, error) {
 		vals.mu.Lock()
 		defer vals.mu.Unlock()
-		// fmt.Println(vals)
 		return vals.powerPct != 0, vals.powerPct, nil
 	}
 	m.IsMovingFunc = func(ctx context.Context) (bool, error) {


### PR DESCRIPTION
I found a race between `WaitForSuccess`'s `position` and `goForInternals` `position` that I'd like to address. But this makes the tests pass (they were failing - not racing - before).

I'll need to restructure some of the motor logic more to have less helpers and call the encoder position directly - we will be able to get rid of `direction` and possibly `m.TicksPerRotation` in the control logic. In a separate pr. 
