### PR TITLE
[DATA-2652] Do not attempt sync if offline

### DIFF
--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -4,6 +4,7 @@ package builtin
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -637,7 +638,7 @@ func (svc *builtIn) uploadData(cancelCtx context.Context, intervalMins float64) 
 					}
 					svc.lock.Unlock()
 
-					if shouldSync {
+					if !isOffline() && shouldSync {
 						svc.sync()
 					}
 				} else {
@@ -646,6 +647,13 @@ func (svc *builtIn) uploadData(cancelCtx context.Context, intervalMins float64) 
 			}
 		}
 	})
+}
+
+func isOffline() bool {
+	timeout := 5 * time.Second
+	_, err := net.DialTimeout("tcp", "viam.com:443", timeout)
+	// If there's an error, the system is likely offline.
+	return err != nil
 }
 
 func (svc *builtIn) sync() {
@@ -663,7 +671,7 @@ func (svc *builtIn) sync() {
 	}
 }
 
-//nolint
+// nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {


### PR DESCRIPTION
Even if we're offline, we attempt sync every sync_interval_min, and [close any files](https://github.com/viamrobotics/rdk/blob/46fd67569bc7288408bd34135d06c28326e66da1/services/datamanager/datasync/sync.go#L160-L170) first before attempting to sync them. If [app.viam.com](http://app.viam.com/) Sync API returns with an "offline" error, we keep retrying more frequently so that when we get back online, it syncs within 30 seconds.

The issue is that the capture rate is less frequent than the sync rate and the machine is constantly offline, this will create small files.

Instead, check if system is offline from RDK and thus not attempt sync in the first place, keeping the files constantly appended to until the system is back online and actually ready to sync.