### PR TITLE
[DATA-2652] Do not error log renaming corrupted files if already moved

### DIFF
--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -353,7 +353,9 @@ func moveFailedData(path, parentDir string) error {
 	// Move the file from parentDir/pathToFile/file.ext to parentDir/corrupted/pathToFile/file.ext
 	newPath := filepath.Join(newDir, filepath.Base(path))
 	if err := os.Rename(path, newPath); err != nil {
-		return errors.Wrapf(err, fmt.Sprintf("error moving corrupted data: %s", path))
+		if !errors.Is(err, os.ErrNotExist) {
+			return errors.Wrapf(err, fmt.Sprintf("error moving corrupted data: %s", path))
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
If a file no longer exists, it indicates it's already been moved. Do not error log the rename.