### PR TITLE
DOCS-2347: Standardize code samples

### DIFF
--- a/components/arm/arm.go
+++ b/components/arm/arm.go
@@ -64,6 +64,42 @@ func Named(name string) resource.Name {
 }
 
 // An Arm represents a physical robotic arm that exists in three-dimensional space.
+//
+// EndPosition example:
+//
+//	// Get the end position of the arm as a Pose.
+//	pos, err := myArm.EndPosition(context.Background(), nil)
+//
+// MoveToPosition example:
+//
+//	// This will block until done or a new operation cancels this one
+//
+//	// Create a Pose for the arm.
+//	examplePose := spatialmath.NewPose(
+//			r3.Vector{X: 5, Y: 5, Z: 5},
+//			&spatialmath.OrientationVectorDegrees{0X: 5, 0Y: 5, Theta: 20}
+//	)
+//
+//	// Move your arm to the Pose.
+//	err = myArm.MoveToPosition(context.Background(), examplePose, nil)
+//
+// MoveToJointPositions example:
+//
+//    // Assumes you have imported "go.viam.com/api/component/arm/v1" as `componentpb`
+//
+//    // Declare an array of values with your desired rotational value for each joint on the arm.
+//    degrees := []float64{4.0, 5.0, 6.0}
+//
+//    // Declare a new JointPositions with these values.
+//    jointPos := &componentpb.JointPositions{Values: degrees}
+//
+//    // Move each joint of the arm to the position these values specify.
+//    err = myArm.MoveToJointPositions(context.Background(), jointPos, nil)
+//
+// JointPositions example:
+//
+//	// Get the current position of each joint on the arm as JointPositions.
+//	pos, err := myArm.JointPositions(context.Background(), nil)
 type Arm interface {
 	resource.Resource
 	referenceframe.ModelFramer
@@ -72,47 +108,15 @@ type Arm interface {
 	referenceframe.InputEnabled
 
 	// EndPosition returns the current position of the arm.
-	//
-	//    myArm, err := arm.FromRobot(machine, "my_arm")
-	//    // Get the end position of the arm as a Pose.
-	//    pos, err := myArm.EndPosition(context.Background(), nil)
 	EndPosition(ctx context.Context, extra map[string]interface{}) (spatialmath.Pose, error)
 
 	// MoveToPosition moves the arm to the given absolute position.
-	// This will block until done or a new operation cancels this one
-	//
-	//    myArm, err := arm.FromRobot(machine, "my_arm")
-	//    // Create a Pose for the arm.
-	//    examplePose := spatialmath.NewPose(
-	//            r3.Vector{X: 5, Y: 5, Z: 5},
-	//            &spatialmath.OrientationVectorDegrees{0X: 5, 0Y: 5, Theta: 20}
-	//    )
-	//
-	//    // Move your arm to the Pose.
-	//    err = myArm.MoveToPosition(context.Background(), examplePose, nil)
 	MoveToPosition(ctx context.Context, pose spatialmath.Pose, extra map[string]interface{}) error
 
 	// MoveToJointPositions moves the arm's joints to the given positions.
-	// This will block until done or a new operation cancels this one
-	//
-	//    // Assumes you have imported "go.viam.com/api/component/arm/v1" as `componentpb`
-	//    myArm, err := arm.FromRobot(machine, "my_arm")
-	//
-	//    // Declare an array of values with your desired rotational value for each joint on the arm.
-	//    degrees := []float64{4.0, 5.0, 6.0}
-	//
-	//    // Declare a new JointPositions with these values.
-	//    jointPos := &componentpb.JointPositions{Values: degrees}
-	//
-	//    // Move each joint of the arm to the position these values specify.
-	//    err = myArm.MoveToJointPositions(context.Background(), jointPos, nil)
 	MoveToJointPositions(ctx context.Context, positionDegs *pb.JointPositions, extra map[string]interface{}) error
 
 	// JointPositions returns the current joint positions of the arm.
-	//    myArm , err := arm.FromRobot(machine, "my_arm")
-	//
-	//    // Get the current position of each joint on the arm as JointPositions.
-	//    pos, err := myArm.JointPositions(context.Background(), nil)
 	JointPositions(ctx context.Context, extra map[string]interface{}) (*pb.JointPositions, error)
 }
 

--- a/components/arm/arm.go
+++ b/components/arm/arm.go
@@ -67,38 +67,35 @@ func Named(name string) resource.Name {
 //
 // EndPosition example:
 //
-//	// Get the end position of the arm as a Pose.
+//	// Get the end position of the arm as a Pose
 //	pos, err := myArm.EndPosition(context.Background(), nil)
 //
 // MoveToPosition example:
 //
-//	// This will block until done or a new operation cancels this one
-//
-//	// Create a Pose for the arm.
+//	// Create a Pose for the arm
 //	examplePose := spatialmath.NewPose(
 //			r3.Vector{X: 5, Y: 5, Z: 5},
 //			&spatialmath.OrientationVectorDegrees{0X: 5, 0Y: 5, Theta: 20}
 //	)
 //
-//	// Move your arm to the Pose.
+//	// Move your arm to the Pose
 //	err = myArm.MoveToPosition(context.Background(), examplePose, nil)
 //
 // MoveToJointPositions example:
 //
 //    // Assumes you have imported "go.viam.com/api/component/arm/v1" as `componentpb`
-//
 //    // Declare an array of values with your desired rotational value for each joint on the arm.
 //    degrees := []float64{4.0, 5.0, 6.0}
 //
-//    // Declare a new JointPositions with these values.
+//    // Declare a new JointPositions with these values
 //    jointPos := &componentpb.JointPositions{Values: degrees}
 //
-//    // Move each joint of the arm to the position these values specify.
+//    // Move each joint of the arm to the position these values specify
 //    err = myArm.MoveToJointPositions(context.Background(), jointPos, nil)
 //
 // JointPositions example:
 //
-//	// Get the current position of each joint on the arm as JointPositions.
+//	// Get the current position of each joint on the arm as JointPositions
 //	pos, err := myArm.JointPositions(context.Background(), nil)
 type Arm interface {
 	resource.Resource
@@ -111,6 +108,7 @@ type Arm interface {
 	EndPosition(ctx context.Context, extra map[string]interface{}) (spatialmath.Pose, error)
 
 	// MoveToPosition moves the arm to the given absolute position.
+	// This method blocks until completed or cancelled.
 	MoveToPosition(ctx context.Context, pose spatialmath.Pose, extra map[string]interface{}) error
 
 	// MoveToJointPositions moves the arm's joints to the given positions.

--- a/components/base/base.go
+++ b/components/base/base.go
@@ -34,6 +34,56 @@ func Named(name string) resource.Name {
 }
 
 // A Base represents a physical base of a robot.
+//
+// MoveStraight example:
+//
+//	// Move the base forward 40 mm at a velocity of 90 mm/s
+//	myBase.MoveStraight(context.Background(), 40, 90, nil)
+//
+//	// Move the base backward 40 mm at a velocity of -90 mm/s
+//	myBase.MoveStraight(context.Background(), 40, -90, nil)
+//
+// Spin example:
+//
+//	// Spin the base 10 degrees at an angular velocity of 15 deg/sec
+//	myBase.Spin(context.Background(), 10, 15, nil)
+//
+// SetPower example:
+//
+//	// Make your wheeled base move forward. Set linear power to 75%
+//	logger.Info("move forward")
+//	err := myBase.SetPower(context.Background(), r3.Vector{Y: .75}, r3.Vector{}, nil)
+//
+//	// Make your wheeled base move backward. Set linear power to -100%
+//	logger.Info("move backward")
+//	err = myBase.SetPower(context.Background(), r3.Vector{Y: -1}, r3.Vector{}, nil)
+//
+//	// Make your wheeled base spin left. Set angular power to 100%
+//	logger.Info("spin left")
+//	err = myBase.SetPower(context.Background(), r3.Vector{}, r3.Vector{Z: 1}, nil)
+//
+//	// Make your wheeled base spin right. Set angular power to -75%
+//	logger.Info("spin right")
+//	err = mybase.SetPower(context.Background(), r3.Vector{}, r3.Vector{Z: -.75}, nil)
+//
+// SetVelocity example:
+//
+//	// Set the linear velocity to 50 mm/sec and the angular velocity to 15 deg/sec
+//	myBase.SetVelocity(context.Background(), r3.Vector{Y: 50}, r3.Vector{Z: 15}, nil)
+//
+// Properties example:
+//
+//	// Get the width and turning radius of the base
+//	properties, err := myBase.Properties(context.Background(), nil)
+//
+//	// Get the width
+//	myBaseWidth := properties.WidthMeters
+//
+//	// Get the turning radius
+//	myBaseTurningRadius := properties.TurningRadiusMeters
+//
+//	// Get the wheel circumference
+//	myBaseWheelCircumference := properties.WheelCircumferenceMeters
 type Base interface {
 	resource.Resource
 	resource.Actuator
@@ -41,72 +91,27 @@ type Base interface {
 
 	// MoveStraight moves the robot straight a given distance at a given speed.
 	// If a distance or speed of zero is given, the base will stop.
-	// This method blocks until completed or cancelled
-	//
-	//    myBase, err := base.FromRobot(machine, "my_base")
-	//    // Move the base forward 40 mm at a velocity of 90 mm/s.
-	//    myBase.MoveStraight(context.Background(), 40, 90, nil)
-	//
-	//    // Move the base backward 40 mm at a velocity of -90 mm/s.
-	//    myBase.MoveStraight(context.Background(), 40, -90, nil)
+	// This method blocks until completed or cancelled.
 	MoveStraight(ctx context.Context, distanceMm int, mmPerSec float64, extra map[string]interface{}) error
 
 	// Spin spins the robot by a given angle in degrees at a given speed.
-	// If a speed of 0 the base will stop.
-	// Given a positive speed and a positive angle, the base turns to the left (for built-in RDK drivers)
-	// This method blocks until completed or cancelled
-	//
-	//    myBase, err := base.FromRobot(machine, "my_base")
-	//
-	//    // Spin the base 10 degrees at an angular velocity of 15 deg/sec.
-	//    myBase.Spin(context.Background(), 10, 15, nil)
+	// Given a speed of 0, the base will stop.
+	// Given a positive speed and a positive angle, the base turns to the left (for built-in RDK drivers).
+	// This method blocks until completed or cancelled.
 	Spin(ctx context.Context, angleDeg, degsPerSec float64, extra map[string]interface{}) error
 
-	// For linear power, positive Y moves forwards for built-in RDK drivers
-	// For angular power, positive Z turns to the left for built-in RDK drivers
-	//    myBase, err := base.FromRobot(machine, "my_base")
-	//
-	//    // Make your wheeled base move forward. Set linear power to 75%.
-	//    logger.Info("move forward")
-	//    err = myBase.SetPower(context.Background(), r3.Vector{Y: .75}, r3.Vector{}, nil)
-	//
-	//    // Make your wheeled base move backward. Set linear power to -100%.
-	//    logger.Info("move backward")
-	//    err = myBase.SetPower(context.Background(), r3.Vector{Y: -1}, r3.Vector{}, nil)
-	//
-	//    // Make your wheeled base spin left. Set angular power to 100%.
-	//    logger.Info("spin left")
-	//    err = myBase.SetPower(context.Background(), r3.Vector{}, r3.Vector{Z: 1}, nil)
-	//
-	//    // Make your wheeled base spin right. Set angular power to -75%.
-	//    logger.Info("spin right")
-	//    err = mybase.SetPower(context.Background(), r3.Vector{}, r3.Vector{Z: -.75}, nil)
+	// SetPower sets the linear and angular power of the base, represented as a percentage of max power for each direction.
+	// The power values are in the range of [-1.0 to 1.0].
+	// For linear power, positive Y moves forwards for built-in RDK drivers.
+	// For angular power, positive Z turns to the left for built-in RDK drivers.
 	SetPower(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error
 
-	// linear is in mmPerSec (positive Y moves forwards for built-in RDK drivers)
-	// angular is in degsPerSec (positive Z turns to the left for built-in RDK drivers)
-	//
-	//    myBase, err := base.FromRobot(machine, "my_base")
-	//
-	//    // Set the linear velocity to 50 mm/sec and the angular velocity to 15 deg/sec.
-	//    myBase.SetVelocity(context.Background(), r3.Vector{Y: 50}, r3.Vector{Z: 15}, nil)
+	// SetVelocity sets the linear velocity (mm/sec) and angular velocity (degrees/sec) of the base.
+	// linear is in mmPerSec (positive Y moves forwards for built-in RDK drivers).
+	// angular is in degsPerSec (positive Z turns to the left for built-in RDK drivers).
 	SetVelocity(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error
 
 	// Properties returns the width, turning radius, and wheel circumference of the physical base in meters.
-	//
-	//    myBase, err := base.FromRobot(machine, "my_base")
-	//
-	//    // Get the width and turning radius of the base
-	//    properties, err := myBase.Properties(context.Background(), nil)
-	//
-	//    // Get the width
-	//    myBaseWidth := properties.WidthMeters
-	//
-	//    // Get the turning radius
-	//    myBaseTurningRadius := properties.TurningRadiusMeters
-	//
-	//    // Get the wheel circumference
-	//    myBaseWheelCircumference := properties.WheelCircumferenceMeters
 	Properties(ctx context.Context, extra map[string]interface{}) (Properties, error)
 }
 

--- a/components/camera/camera.go
+++ b/components/camera/camera.go
@@ -83,49 +83,51 @@ type Camera interface {
 }
 
 // A VideoSource represents anything that can capture frames.
+//
+// Images example:
+//
+//	images, metadata, err := myCamera.Images(context.Background())
+//
+// Stream example:
+//
+//	// Gets the stream from a camera
+//	stream, err := myCamera.Stream(context.Background())
+//
+//	// Gets an image from the camera stream
+//	img, release, err := stream.Next(context.Background())
+//	defer release()
+//
+// NextPointCloud example:
+//
+//	// Gets the next available point cloud
+//	pointCloud, err := myCamera.NextPointCloud(context.Background())
+//
+// Properties example:
+//
+//	// Gets the properties from a camera
+//	properties, err := myCamera.Properties(context.Background())
+//
+// Close example:
+//
+//	err := myCamera.Close(context.Background())
 type VideoSource interface {
 	projectorProvider
-	// Images is used for getting simultaneous images from different imagers,
-	// along with associated metadata (just timestamp for now). It's not for getting a time series of images from the same imager.
-	//
-	//    myCamera, err := camera.FromRobot(machine, "my_camera")
-	//
-	//    images, metadata, err := myCamera.Images(context.Background())
+
+	// Images returns simultaneous images from different imagers, along with associated metadata (just timestamp for now).
+	// This method is not for getting a time series of images from the same imager.
 	Images(ctx context.Context) ([]NamedImage, resource.ResponseMetadata, error)
-	// Stream returns a stream that makes a best effort to return consecutive images
-	// that may have a MIME type hint dictated in the context via gostream.WithMIMETypeHint.
-	//
-	//    myCamera, err := camera.FromRobot(machine, "my_camera")
-	//
-	//    // gets the stream from a camera
-	//    stream, err := myCamera.Stream(context.Background())
-	//
-	//    // gets an image from the camera stream
-	//    img, release, err := stream.Next(context.Background())
-	//    defer release()
+
+	// Stream returns a stream of consecutive images, with an optional MIME type hint set using gostream.WithMIMETypeHint.
 	Stream(ctx context.Context, errHandlers ...gostream.ErrorHandler) (gostream.VideoStream, error)
 
-	// NextPointCloud returns the next immediately available point cloud, not necessarily one
-	// a part of a sequence. In the future, there could be streaming of point clouds.
-	//
-	//    myCamera, err := camera.FromRobot(machine, "my_camera")
-	//
-	//    pointCloud, err := myCamera.NextPointCloud(context.Background())
+	// NextPointCloud returns the next immediately available point cloud, which may not be part of a sequence.
+	// Future versions may support streaming of point clouds.
 	NextPointCloud(ctx context.Context) (pointcloud.PointCloud, error)
-	// Properties returns properties that are intrinsic to the particular
-	// implementation of a camera
-	//
-	//    myCamera, err := camera.FromRobot(machine, "my_camera")
-	//
-	//    // gets the properties from a camera
-	//    properties, err := myCamera.Properties(context.Background())
+
+	// Properties returns properties that are intrinsic to the particular implementation of a camera.
 	Properties(ctx context.Context) (Properties, error)
 
-	// Close shuts down the resource and prevents further use
-	//
-	//    myCamera, err := camera.FromRobot(machine, "my_camera")
-	//
-	//    err = myCamera.Close(ctx)
+	// Close shuts down the resource and prevents further use.
 	Close(ctx context.Context) error
 }
 

--- a/components/encoder/encoder.go
+++ b/components/encoder/encoder.go
@@ -58,36 +58,30 @@ func (t PositionType) String() string {
 }
 
 // A Encoder turns a position into a signal.
+//
+// Position example:
+//
+//	// Get the position of the encoder in ticks
+//	position, posType, err := myEncoder.Position(context.Background(), encoder.PositionTypeTicks, nil)
+//
+// ResetPosition example:
+//
+//	err := myEncoder.ResetPosition(context.Background(), nil)
+//
+// Properties example:
+//
+//	// Get whether the encoder returns position in ticks or degrees.
+//	properties, err := myEncoder.Properties(context.Background(), nil)
 type Encoder interface {
 	resource.Resource
 
 	// Position returns the current position in terms of ticks or degrees, and whether it is a relative or absolute position.
-	//
-	//    myEncoder, err := encoder.FromRobot(machine, "my_encoder")
-	//    if err != nil {
-	//      logger.Fatalf("cannot get encoder: %v", err)
-	//    }
-	//
-	//    // Get the position of the encoder in ticks
-	//    position, posType, err := myEncoder.Position(context.Background(), encoder.PositionTypeTicks, nil)
 	Position(ctx context.Context, positionType PositionType, extra map[string]interface{}) (float64, PositionType, error)
 
 	// ResetPosition sets the current position of the motor to be its new zero position.
-	//
-	//    myEncoder, err := encoder.FromRobot(machine, "my_encoder")
-	//    if err != nil {
-	//      logger.Fatalf("cannot get encoder: %v", err)
-	//    }
-	//
-	//    err = myEncoder.ResetPosition(context.Background(), nil)
 	ResetPosition(ctx context.Context, extra map[string]interface{}) error
 
-	// Properties returns a list of all the position types that are supported by a given encoder
-	//
-	//    myEncoder, err := encoder.FromRobot(machine, "my_encoder")
-	//
-	//    // Get whether the encoder returns position in ticks or degrees.
-	//    properties, err := myEncoder.Properties(context.Background(), nil)
+	// Properties returns a list of all the position types that are supported by a given encoder.
 	Properties(ctx context.Context, extra map[string]interface{}) (Properties, error)
 }
 

--- a/components/gantry/gantry.go
+++ b/components/gantry/gantry.go
@@ -41,48 +41,48 @@ func Named(name string) resource.Name {
 }
 
 // Gantry is used for controlling gantries of N axis.
+//
+// Position example:
+//
+//	// Get the current positions of the axes of the gantry in millimeters
+//	position, err := myGantry.Position(context.Background(), nil)
+//
+// MoveToPosition example:
+//
+//	// Assume in this example that the gantry is multi-axis, with 3 axes
+//	// Create a list of positions for the axes of the gantry to move to
+//	examplePositions := []float64{1, 2, 3}
+//
+//	exampleSpeeds := []float64{3, 9, 12}
+//
+//	// Move the axes of the gantry to the positions specified
+//	myGantry.MoveToPosition(context.Background(), examplePositions, exampleSpeeds, nil)
+//
+// Lengths example:
+//
+//	// Get the lengths of the axes of the gantry in millimeters
+//	lengths_mm, err := myGantry.Lengths(context.Background(), nil)
+//
+// Home example:
+//
+//    myGantry.Home(context.Background(), nil)
 type Gantry interface {
 	resource.Resource
 	resource.Actuator
 	referenceframe.ModelFramer
 	referenceframe.InputEnabled
 
-	// Position returns the position in meters
-	//
-	//    myGantry, err := gantry.FromRobot(machine, "my_gantry")
-	//
-	//    // Get the current positions of the axes of the gantry in millimeters.
-	//    position, err := myGantry.Position(context.Background(), nil)
+	// Position returns the position in meters.
 	Position(ctx context.Context, extra map[string]interface{}) ([]float64, error)
 
-	// MoveToPosition is in meters
-	// This will block until done or a new operation cancels this one
-	//
-	//    myGantry, err := gantry.FromRobot(machine, "my_gantry")
-	//
-	//    // Create a list of positions for the axes of the gantry to move to.
-	//    // Assume in this example that the gantry is multi-axis, with 3 axes.
-	//    examplePositions := []float64{1, 2, 3}
-	//
-	//    exampleSpeeds := []float64{3, 9, 12}
-	//
-	//    // Move the axes of the gantry to the positions specified.
-	//    myGantry.MoveToPosition(context.Background(), examplePositions, exampleSpeeds, nil)
+	// MoveToPosition moves the arm's end to the desired Pose, relative to the arm's base, using meters.
+	// This method blocks until completed or cancelled.
 	MoveToPosition(ctx context.Context, positionsMm, speedsMmPerSec []float64, extra map[string]interface{}) error
 
-	// Lengths is the length of gantries in meters
-	//
-	//    myGantry, err := gantry.FromRobot(machine, "my_gantry")
-	//
-	//    // Get the lengths of the axes of the gantry in millimeters.
-	//    lengths_mm, err := myGantry.Lengths(context.Background(), nil)
+	// Lengths is the length of gantries in meters.
 	Lengths(ctx context.Context, extra map[string]interface{}) ([]float64, error)
 
-	// Home runs the homing sequence of the gantry and returns true once completed
-	//
-	//    myGantry, err := gantry.FromRobot(machine, "my_gantry")
-	//
-	//    myGantry.Home(context.Background(), nil)
+	// Home runs the homing sequence of the gantry and returns true once completed.
 	Home(ctx context.Context, extra map[string]interface{}) (bool, error)
 }
 

--- a/components/gripper/gripper.go
+++ b/components/gripper/gripper.go
@@ -54,9 +54,8 @@ type Gripper interface {
 	// This will block until done or a new operation cancels this one
 	Open(ctx context.Context, extra map[string]interface{}) error
 
-	// Grab makes the gripper grab.
-	// returns true if we grabbed something.
-	// This will block until done or a new operation cancels this one
+	// Grab makes the gripper grab and returns true if it grabbed something.
+	// This method blocks until completed or cancelled.
 	Grab(ctx context.Context, extra map[string]interface{}) (bool, error)
 }
 

--- a/components/input/input.go
+++ b/components/input/input.go
@@ -38,12 +38,12 @@ func Named(name string) resource.Name {
 //
 // Controls example:
 //
-//	// Get the list of Controls provided by the controller.
+//	// Get the list of Controls provided by the controller
 //	controls, err := myController.Controls(context.Background(), nil)
 //
 // Events example:
 //
-//	// Get the most recent Event for each Control.
+//	// Get the most recent Event for each Control
 //	recent_events, err := myController.Events(context.Background(), nil)
 //
 // RegisterControlCallback example:
@@ -53,24 +53,24 @@ func Named(name string) resource.Name {
 //	    logger.Info("Start Menu Button was pressed at this time: %v", event.Time)
 //	}
 //
-//	// Define the EventType "ButtonPress" to serve as the trigger for printStartTime.
+//	// Define the EventType "ButtonPress" to serve as the trigger for printStartTime
 //	triggers := []input.EventType{input.ButtonPress}
 //
 //	// Get the controller's Controls.
 //	controls, err := controller.Controls(ctx, nil)
 //
-//	// If the "ButtonStart" Control is found, trigger printStartTime when "ButtonStart" the event "ButtonPress" occurs.
+//	// If the "ButtonStart" Control is found, trigger printStartTime when "ButtonStart" the event "ButtonPress" occurs
 //	if !slices.Contains(controls, input.ButtonStart) {
 //	    return errors.New("button `ButtonStart` not found; controller may be disconnected")
 //	}
-//	Mycontroller.RegisterControlCallback(context.Background(), input.ButtonStart, triggers, printStartTime, nil)
+//	myController.RegisterControlCallback(context.Background(), input.ButtonStart, triggers, printStartTime, nil)
 type Controller interface {
 	resource.Resource
 
-	// Controls returns a list of Controls provided by the Controller
+	// Controls returns a list of Controls provided by the Controller.
 	Controls(ctx context.Context, extra map[string]interface{}) ([]Control, error)
 
-	// Events returns most recent Event for each input (which should be the current state)
+	// Events returns most recent Event for each input (which should be the current state).
 	Events(ctx context.Context, extra map[string]interface{}) (map[Control]Event, error)
 
 	// RegisterCallback registers a callback that will fire on given EventTypes for a given Control.

--- a/components/movementsensor/movementsensor.go
+++ b/components/movementsensor/movementsensor.go
@@ -73,36 +73,36 @@ func Named(name string) resource.Name {
 //
 // LinearVelocity example:
 //
-//	// Get the current linear velocity of the movement sensor.
+//	// Get the current linear velocity of the movement sensor
 //	linVel, err := myMovementSensor.LinearVelocity(context.Background(), nil)
 //
 // AngularVelocity example:
 //
-//	// Get the current angular velocity of the movement sensor.
+//	// Get the current angular velocity of the movement sensor
 //	angVel, err := myMovementSensor.AngularVelocity(context.Background(), nil)
 //
-//	// Get the y component of angular velocity.
+//	// Get the y component of angular velocity
 //	yAngVel := angVel.Y
 //
 // LinearAcceleration example:
 //
-//	// Get the current linear acceleration of the movement sensor.
+//	// Get the current linear acceleration of the movement sensor
 //	linVel, err := myMovementSensor.LinearVelocity(context.Background(), nil)
 //
 // CompassHeading example:
 //
-//	// Get the current compass heading of the movement sensor.
+//	// Get the current compass heading of the movement sensor
 //	heading, err := myMovementSensor.CompassHeading(context.Background(), nil)
 //
 // Orientation example:
 //
-//	// Get the current orientation of the movement sensor.
+//	// Get the current orientation of the movement sensor
 //	sensorOrientation, err := myMovementSensor.Orientation(context.Background(), nil)
 //
-//	// Get the orientation vector.
+//	// Get the orientation vector
 //	orientation := sensorOrientation.OrientationVectorDegrees()
 //
-//	// Print out the orientation vector.
+//	// Print out the orientation vector
 //	logger.Info("The x component of the orientation vector: ", orientation.0X)
 //	logger.Info("The y component of the orientation vector: ", orientation.0Y)
 //	logger.Info("The z component of the orientation vector: ", orientation.0Z)
@@ -110,12 +110,12 @@ func Named(name string) resource.Name {
 //
 // Properties example:
 //
-//	// Get the supported properties of the movement sensor.
+//	// Get the supported properties of the movement sensor
 //	properties, err := myMovementSensor.Properties(context.Background(), nil)
 //
 // Accuracy example:
 //
-//	// Get the accuracy of the movement sensor.
+//	// Get the accuracy of the movement sensor
 //	accuracy, err := myMovementSensor.Accuracy(context.Background(), nil)
 type MovementSensor interface {
 	resource.Sensor

--- a/components/powersensor/powersensor.go
+++ b/components/powersensor/powersensor.go
@@ -66,6 +66,7 @@ func Named(name string) resource.Name {
 type PowerSensor interface {
 	resource.Sensor
 	resource.Resource
+
 	// Voltage returns the voltage reading in volts and a bool returning true if the voltage is AC.
 	Voltage(ctx context.Context, extra map[string]interface{}) (float64, bool, error)
 

--- a/components/servo/servo.go
+++ b/components/servo/servo.go
@@ -34,19 +34,19 @@ var API = resource.APINamespaceRDK.WithComponentType(SubtypeName)
 //
 // Move example:
 //
-//	// Move the servo from its origin to the desired angle of 30 degrees.
-//	myServoComponent.Move(context.Background(), 30, nil)
+//	// Move the servo from its origin to the desired angle of 30 degrees
+//	myServo.Move(context.Background(), 30, nil)
 //
 // Position example:
 //
-//	// Get the current set angle of the servo.
-//	pos1, err := myServoComponent.Position(context.Background(), nil)
+//	// Get the current set angle of the servo
+//	pos1, err := myServo.Position(context.Background(), nil)
 //
-//	// Move the servo from its origin to the desired angle of 20 degrees.
-//	myServoComponent.Move(context.Background(), 20, nil)
+//	// Move the servo from its origin to the desired angle of 20 degrees
+//	myServo.Move(context.Background(), 20, nil)
 //
-//	// Get the current set angle of the servo.
-//	pos2, err := myServoComponent.Position(context.Background(), nil)
+//	// Get the current set angle of the servo
+//	pos2, err := myServo.Position(context.Background(), nil)
 //
 //	logger.Info("Position 1: ", pos1)
 //	logger.Info("Position 2: ", pos2)
@@ -54,8 +54,8 @@ type Servo interface {
 	resource.Resource
 	resource.Actuator
 
-	// Move moves the servo to the given angle (0-180 degrees)
-	// This will block until done or a new operation cancels this one
+	// Move moves the servo to the given angle (0-180 degrees).
+	// This method blocks until completed or cancelled.
 	Move(ctx context.Context, angleDeg uint32, extra map[string]interface{}) error
 
 	// Position returns the current set angle (degrees) of the servo.

--- a/services/baseremotecontrol/base_remote_control.go
+++ b/services/baseremotecontrol/base_remote_control.go
@@ -33,17 +33,19 @@ func init() {
 //
 // Close example:
 //
-//	// Close out of all remote control-related systems.
+//	// Close out of all remote control-related systems
 //	err := baseRCService.Close(context.Background())
 //
 // ControllerInputs example:
 //
-//	// Get the list of inputs from the controller that are being monitored for that control mode.
+//	// Get the list of inputs from the controller that are being monitored for that control mode
 //	inputs := baseRCService.ControllerInputs()
 type Service interface {
 	resource.Resource
-	// Close out of all remote control related systems.
+
+	// Close closes out of all remote control related systems.
 	Close(ctx context.Context) error
-	// controllerInputs returns the list of inputs from the controller that are being monitored for that control mode.
+
+	// ControllerInputs returns the list of inputs from the controller that are being monitored for that control mode.
 	ControllerInputs() []input.Control
 }

--- a/services/datamanager/data_manager.go
+++ b/services/datamanager/data_manager.go
@@ -38,7 +38,8 @@ func init() {
 //	err := data.Sync(context.Background(), nil)
 type Service interface {
 	resource.Resource
-	// Sync will sync data stored on the machine to the cloud.
+
+	// Sync will sync data stored on the machine to the cloud
 	Sync(ctx context.Context, extra map[string]interface{}) error
 }
 

--- a/services/mlmodel/mlmodel.go
+++ b/services/mlmodel/mlmodel.go
@@ -40,6 +40,7 @@ func init() {
 //	metadata, err := myMLModel.Metadata(context.Background())
 type Service interface {
 	resource.Resource
+
 	// Infer returns an output tensor map after running an input tensor map through an interface model.
 	Infer(ctx context.Context, tensors ml.Tensors) (ml.Tensors, error)
 

--- a/services/sensors/sensors.go
+++ b/services/sensors/sensors.go
@@ -21,15 +21,17 @@ func init() {
 }
 
 // A Readings ties both the sensor name and its reading together.
-//
-//	// Get the readings provided by the sensor.
-//	readings, err := mySensor.Readings(context.Background(), nil)
 type Readings struct {
 	Name     resource.Name
 	Readings map[string]interface{}
 }
 
 // A Service centralizes all sensors into one place.
+//
+// Readings example:
+//
+// 	// Get the readings provided by the sensor.
+//	readings, err := mySensor.Readings(context.Background(), nil)
 type Service interface {
 	resource.Resource
 	Sensors(ctx context.Context, extra map[string]interface{}) ([]resource.Name, error)


### PR DESCRIPTION
Changed the format of the code samples (whitespace, comments, punctuation) and deleted any resource initializations for uniformity across samples.

Method descriptions have been lightly modified.
The meaning has been retained (in my opinion, this is probably subjective!). 

