### PR TITLE
DATA-2507 - Update training script using CLI

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -1674,11 +1674,6 @@ Example:
 							Usage:    "task type of the ML training script to upload, can be: " + strings.Join(modelTypes, ", "),
 							Required: false,
 						},
-						&cli.StringFlag{
-							Name:     mlTrainingFlagDescription,
-							Usage:    "description of the ML training script",
-							Required: false,
-						},
 						&cli.BoolFlag{
 							Name:     mlTrainingFlagDraft,
 							Usage:    "indicate draft mode, drafts will not be viewable in the registry",

--- a/cli/app.go
+++ b/cli/app.go
@@ -60,12 +60,14 @@ const (
 	moduleBuildRestartOnly   = "restart-only"
 	moduleBuildFlagNoBuild   = "no-build"
 
-	mlTrainingFlagPath      = "path"
-	mlTrainingFlagName      = "script-name"
-	mlTrainingFlagVersion   = "version"
-	mlTrainingFlagFramework = "framework"
-	mlTrainingFlagType      = "type"
-	mlTrainingFlagDraft     = "draft"
+	mlTrainingFlagPath        = "path"
+	mlTrainingFlagName        = "script-name"
+	mlTrainingFlagVersion     = "version"
+	mlTrainingFlagFramework   = "framework"
+	mlTrainingFlagType        = "type"
+	mlTrainingFlagDraft       = "draft"
+	mlTrainingFlagVisibility  = "visibility"
+	mlTrainingFlagDescription = "description"
 
 	dataFlagDestination                    = "destination"
 	dataFlagDataType                       = "data-type"
@@ -1672,6 +1674,11 @@ Example:
 							Usage:    "task type of the ML training script to upload, can be: " + strings.Join(modelTypes, ", "),
 							Required: false,
 						},
+						&cli.StringFlag{
+							Name:     mlTrainingFlagDescription,
+							Usage:    "description of the ML training script",
+							Required: false,
+						},
 						&cli.BoolFlag{
 							Name:     mlTrainingFlagDraft,
 							Usage:    "indicate draft mode, drafts will not be viewable in the registry",
@@ -1680,6 +1687,34 @@ Example:
 					},
 					// Upload action
 					Action: MLTrainingUploadAction,
+				},
+				{
+					Name:      "update",
+					Usage:     "update visibility of ML training scripts for custom ML training",
+					UsageText: createUsageText("training-script update", []string{generalFlagOrgID, mlTrainingFlagName, mlTrainingFlagVisibility}, true),
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:     generalFlagOrgID,
+							Required: true,
+							Usage:    "organization ID that will host the scripts",
+						},
+						&cli.StringFlag{
+							Name:     mlTrainingFlagName,
+							Usage:    "name of the ML training script to upload",
+							Required: true,
+						},
+						&cli.StringFlag{
+							Name:     mlTrainingFlagVisibility,
+							Usage:    "visibility of the registry item, can be: `public` or `private`",
+							Required: true,
+						},
+						&cli.StringFlag{
+							Name:     mlTrainingFlagDescription,
+							Usage:    "description of the ML training script",
+							Required: false,
+						},
+					},
+					Action: MLTrainingUpdateAction,
 				},
 			},
 		},

--- a/cli/app.go
+++ b/cli/app.go
@@ -1691,11 +1691,11 @@ Example:
 						&cli.StringFlag{
 							Name:     generalFlagOrgID,
 							Required: true,
-							Usage:    "organization ID that will host the scripts",
+							Usage:    "organization ID that hosts the scripts",
 						},
 						&cli.StringFlag{
 							Name:     mlTrainingFlagName,
-							Usage:    "name of the ML training script to upload",
+							Usage:    "name of the ML training script to update",
 							Required: true,
 						},
 						&cli.StringFlag{

--- a/cli/ml_training.go
+++ b/cli/ml_training.go
@@ -11,6 +11,7 @@ import (
 	"github.com/urfave/cli/v2"
 	"go.uber.org/multierr"
 	mltrainingpb "go.viam.com/api/app/mltraining/v1"
+	v1 "go.viam.com/api/app/v1"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -270,7 +271,62 @@ func (c *viamClient) uploadTrainingScript(draft bool, modelType, framework, orgI
 	); err != nil {
 		return err
 	}
+	return nil
+}
 
+// MLTrainingUpdateAction updates the visibility of training scripts.
+func MLTrainingUpdateAction(c *cli.Context) error {
+	client, err := newViamClient(c)
+	if err != nil {
+		return err
+	}
+
+	err = client.updateTrainingScript(c.String(generalFlagOrgID), c.String(mlTrainingFlagName),
+		c.String(mlTrainingFlagVisibility), c.String(mlTrainingFlagDescription),
+	)
+	if err != nil {
+		return err
+	}
+
+	moduleID := moduleID{
+		prefix: c.String(generalFlagOrgID),
+		name:   c.String(mlTrainingFlagName),
+	}
+	url := moduleID.ToDetailURL(client.baseURL.Hostname(), PackageTypeMLTraining)
+	printf(c.App.Writer, "Training script successfully updated! you can view your changes online here: %s", url)
+	return nil
+}
+
+func (c *viamClient) updateTrainingScript(orgID, name, visibility, description string) error {
+	// Get registry item
+	itemID := fmt.Sprintf("%s:%s", orgID, name)
+	resp, err := c.client.GetRegistryItem(c.c.Context, &v1.GetRegistryItemRequest{
+		ItemId: itemID,
+	})
+	if err != nil {
+		return err
+	}
+	// Get and validate description and visibility
+	updatedDescription := resp.GetItem().GetDescription()
+	if description == "" {
+		updatedDescription = description
+	}
+	if updatedDescription == "" {
+		return errors.New("no existing description for registry item, description must be provided")
+	}
+	visibilityProto, err := convertVisibilityToProto(visibility)
+	if err != nil {
+		return err
+	}
+	// Update registry item
+	if _, err = c.client.UpdateRegistryItem(c.c.Context, &v1.UpdateRegistryItemRequest{
+		ItemId:      itemID,
+		Type:        resp.GetItem().GetType(),
+		Description: updatedDescription,
+		Visibility:  *visibilityProto,
+	}); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -359,4 +415,18 @@ func convertMetadataToStruct(metadata MLMetadata) (*structpb.Struct, error) {
 		return nil, err
 	}
 	return metadataStruct, nil
+}
+
+func convertVisibilityToProto(visibility string) (*v1.Visibility, error) {
+	var visibilityProto v1.Visibility
+	switch visibility {
+	case "public":
+		visibilityProto = v1.Visibility_VISIBILITY_PUBLIC
+	case "private":
+		visibilityProto = v1.Visibility_VISIBILITY_PRIVATE
+	default:
+		return nil, errors.New("invalid visibility provided, must be either public or private")
+	}
+
+	return &visibilityProto, nil
 }

--- a/cli/ml_training.go
+++ b/cli/ml_training.go
@@ -298,6 +298,10 @@ func MLTrainingUpdateAction(c *cli.Context) error {
 }
 
 func (c *viamClient) updateTrainingScript(orgID, name, visibility, description string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+
 	// Get registry item
 	itemID := fmt.Sprintf("%s:%s", orgID, name)
 	resp, err := c.client.GetRegistryItem(c.c.Context, &v1.GetRegistryItemRequest{
@@ -308,7 +312,7 @@ func (c *viamClient) updateTrainingScript(orgID, name, visibility, description s
 	}
 	// Get and validate description and visibility
 	updatedDescription := resp.GetItem().GetDescription()
-	if description == "" {
+	if description != "" {
 		updatedDescription = description
 	}
 	if updatedDescription == "" {


### PR DESCRIPTION
Manually testing by uploading a training script and changing the visibility and description

```
go run cli/viam/main.go training-script upload  --path=training-0.1.tar.gz --org-id=32b2d69a-17be-43a5-83b2-3858cf9c1a74 --script-name=read-pkg-other-org --version=1

go run cli/viam/main.go training-script update --visibility=public --org-id=32b2d69a-17be-43a5-83b2-3858cf9c1a74 --script-name=read-pkg-other-org --description="try changing visiblity"

go run cli/viam/main.go training-script update --visibility=private --org-id=32b2d69a-17be-43a5-83b2-3858cf9c1a74 --script-name=read-pkg-other-org 
```