### PR TITLE
RSDK-7733 Benchmark flaky concurrent reconfigure test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,7 +177,7 @@ jobs:
           --platform linux/arm/v7 \
           -v `pwd`:/rdk \
           ghcr.io/viamrobotics/rdk-devenv:armhf-cache \
-          sudo -Hu testbot bash -lc 'cd /rdk && go test -v -tags=no_tflite ./... -bench=.'
+          sudo -Hu testbot bash -lc 'cd /rdk && go test -v -tags=no_tflite ./... -bench=BenchmarkConcurrentReconfiguration' # TODO: better filter?
 
   test_pi:
     name: Test Raspberry Pi Code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,7 +177,7 @@ jobs:
           --platform linux/arm/v7 \
           -v `pwd`:/rdk \
           ghcr.io/viamrobotics/rdk-devenv:armhf-cache \
-          sudo -Hu testbot bash -lc 'cd /rdk && go test -v -tags=no_tflite ./...'
+          sudo -Hu testbot bash -lc 'cd /rdk && go test -v -tags=no_tflite ./... -bench=.'
 
   test_pi:
     name: Test Raspberry Pi Code

--- a/etc/test.sh
+++ b/etc/test.sh
@@ -19,7 +19,7 @@ if [[ "$1" == "race" ]]; then
 fi
 
 # We run analyzetests on every run, pass or fail. We only run analyzecoverage when all tests passed.
-PION_LOG_WARN=webrtc,datachannel,sctp gotestsum --format standard-verbose $LOGFILE -- -tags=no_skip $RACE $COVER $TEST_TARGET
+PION_LOG_WARN=webrtc,datachannel,sctp gotestsum --format standard-verbose $LOGFILE -- -tags=no_skip -bench=. $RACE $COVER $TEST_TARGET
 SUCCESS=$?
 
 if [[ $RACE != "" ]]; then

--- a/etc/test.sh
+++ b/etc/test.sh
@@ -18,8 +18,11 @@ if [[ "$1" == "race" ]]; then
 	LOGFILE="--jsonfile json.log"
 fi
 
+# TODO: better filter?
+BENCH="-bench=BenchmarkConcurrentReconfiguration"
+
 # We run analyzetests on every run, pass or fail. We only run analyzecoverage when all tests passed.
-PION_LOG_WARN=webrtc,datachannel,sctp gotestsum --format standard-verbose $LOGFILE -- -tags=no_skip -bench=. $RACE $COVER $TEST_TARGET
+PION_LOG_WARN=webrtc,datachannel,sctp gotestsum --format standard-verbose $LOGFILE -- -tags=no_skip $BENCH $RACE $COVER $TEST_TARGET
 SUCCESS=$?
 
 if [[ $RACE != "" ]]; then

--- a/module/concurrent_reconfigure_test.go
+++ b/module/concurrent_reconfigure_test.go
@@ -37,8 +37,10 @@ func setupTestRobotWithModules(
 	return cfg, rob
 }
 
-const resCount = 10
-const configDuration = "1ms"
+const (
+	resCount       = 10
+	configDuration = "1ms"
+)
 
 func BenchmarkConcurrentReconfiguration(b *testing.B) {
 	ctx := context.Background()

--- a/module/concurrent_reconfigure_test.go
+++ b/module/concurrent_reconfigure_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"go.viam.com/test"
 
@@ -14,10 +13,11 @@ import (
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot"
 	robotimpl "go.viam.com/rdk/robot/impl"
+	"go.viam.com/rdk/utils"
 )
 
 func setupTestRobotWithModules(
-	t *testing.T,
+	t testing.TB,
 	ctx context.Context,
 	logger logging.Logger,
 ) (*config.Config, robot.LocalRobot) {
@@ -37,122 +37,107 @@ func setupTestRobotWithModules(
 	return cfg, rob
 }
 
-func TestConcurrentReconfiguration(t *testing.T) {
+const resCount = 10
+const configDuration = "1ms"
+
+func BenchmarkConcurrentReconfiguration(t *testing.B) {
 	ctx := context.Background()
 	logger := logging.NewTestLogger(t)
 
-	t.Run("no dependencies", func(t *testing.T) {
-		cfg, rob := setupTestRobotWithModules(t, ctx, logger)
+	reportMetrics := func(t *testing.B) {
+		// How many resources are reconfigured per millisecond. Since the number of
+		// resources and configuration for each resource is constant, this metric should
+		// generally as there are fewer dependencies between resources.
+		t.ReportMetric(float64(t.Elapsed().Milliseconds())/float64(t.N)/float64(resCount), "ms/resource")
+	}
 
-		// Add resources to the config
-		const resCount = 10
-		for i := 1; i <= resCount; i++ {
-			cfg.Components = append(cfg.Components,
-				resource.Config{
-					Name:  fmt.Sprintf("slow%d", i),
-					Model: resource.NewModel("rdk", "test", "slow"),
-					API:   generic.API,
-				},
-			)
-		}
-		// We configure the robot with 10 resources where each resource takes 1s to
-		// construct. Since we construct resources concurrently, it should take much less
-		// than 10s.
-		start := time.Now()
-		rob.Reconfigure(ctx, cfg)
-		duration := time.Since(start)
-
-		// This threshold is somewhat arbitrary and can be adjusted upward if this test
-		// starts to flake.
-		const threshold = 3 * time.Second
-		test.That(t, duration, test.ShouldBeLessThan, threshold)
-
-		// This threshold is absolute and should not be adjusted.
-		const absThreshold = 10 * time.Second
-		test.That(t, duration, test.ShouldBeLessThan, absThreshold)
-
-		// Assert that all resources were added.
-		var err error
-		for i := 1; i <= resCount; i++ {
-			_, err = rob.ResourceByName(generic.Named(fmt.Sprintf("slow%d", i)))
-			test.That(t, err, test.ShouldBeNil)
-		}
-
-		// Rename resources in config
-		cfg.Components = nil
-		for i := 1; i <= resCount; i++ {
-			// rename components
-			cfg.Components = append(cfg.Components,
-				resource.Config{
-					Name:  fmt.Sprintf("slow-%d", i),
-					Model: resource.NewModel("rdk", "test", "slow"),
-					API:   generic.API,
-				},
-			)
-		}
-
-		// We renamed each resource to trigger a reconfiguration - this should happen
-		// concurrently and take much less than 10s.
-		start = time.Now()
-		rob.Reconfigure(context.Background(), cfg)
-		duration = time.Since(start)
-
-		test.That(t, duration, test.ShouldBeLessThan, threshold)
-		test.That(t, duration, test.ShouldBeLessThan, absThreshold)
-
-		// Assert that all resources were reconfigured.
-		for i := 1; i <= resCount; i++ {
-			_, err = rob.ResourceByName(generic.Named(fmt.Sprintf("slow%d", i)))
-			test.That(t, err, test.ShouldNotBeNil)
-			_, err = rob.ResourceByName(generic.Named(fmt.Sprintf("slow-%d", i)))
-			test.That(t, err, test.ShouldBeNil)
-		}
-	})
-
-	t.Run("with dependencies", func(t *testing.T) {
-		cfg, rob := setupTestRobotWithModules(t, ctx, logger)
-		const resCount = 10
-		for i := 1; i <= resCount; i++ {
-			if i%2 == 1 {
-				cfg.Components = append(cfg.Components,
-					resource.Config{
-						Name:  fmt.Sprintf("slow%d", i),
-						Model: resource.NewModel("rdk", "test", "slow"),
-						API:   generic.API,
-					},
-				)
-			} else {
-				cfg.Components = append(cfg.Components,
-					resource.Config{
-						Name:      fmt.Sprintf("slow%d", i),
-						Model:     resource.NewModel("rdk", "test", "slow"),
-						API:       generic.API,
-						DependsOn: []string{fmt.Sprintf("slow%d", i-1)},
-					},
-				)
+	type testcase struct {
+		name         string
+		dependencies [][]string
+	}
+	for _, tc := range []testcase{
+		{"serial dependencies", func() (deps [][]string) {
+			// Update config to include N resources such that:
+			//
+			// * resource 0 has no dependencies
+			// * for all resources N>0, resource N depends on resource N-1
+			//
+			// This dependency structure should force each resource to be constructed
+			// serially. If each resource takes duration T to configure, then
+			// total configuration time per resource be approximately T.
+			for i := 0; i < resCount; i++ {
+				var dependsOn []string
+				if i > 0 {
+					dependsOn = append(dependsOn, fmt.Sprintf("slow%d", i-1))
+				}
+				deps = append(deps, dependsOn)
 			}
-		}
+			return
+		}()},
+		{"no dependencies", func() (deps [][]string) {
+			// Update config to include N resources that do no have any dependencies.
+			//
+			// This dependency structure should allow each resource to be constructed
+			// concurrently. If each resource takes duration T to configure, then
+			// total configuration time per resource be approximately T/N.
+			for i := 0; i < resCount; i++ {
+				deps = append(deps, nil)
+			}
+			return
+		}()},
+		{"some dependencies", func() (deps [][]string) {
+			// Update config to include N resources such that for approximately 1/3 of
+			// the resources, resource N depends on resource N-1.
+			//
+			// This dependency structure should allow some resources to be constructed
+			// concurrently. If each resource takes duration T to configure, then
+			// total configuration time per resource be between T/N and T, approximately.
+			for i := 0; i < resCount; i++ {
+				var dependsOn []string
+				if i%3 == 1 {
+					dependsOn = append(dependsOn, fmt.Sprintf("slow%d", i-1))
+				}
+				deps = append(deps, dependsOn)
+			}
+			return
+		}()},
+	} {
+		t.Run(tc.name, func(t *testing.B) {
+			cfg, rob := setupTestRobotWithModules(t, ctx, logger)
 
-		// We configure the robot with 10 resources where each resource takes 1s to
-		// construct. This resource config has 2 levels of dependencies and resources are
-		// constructed concurrently within each level. Therefore it should take more than
-		// 2s to reconfigure but much less than 10s.
-		start := time.Now()
-		rob.Reconfigure(context.Background(), cfg)
-		duration := time.Since(start)
+			t.StopTimer()
+			t.ResetTimer()
+			for n := 0; n < t.N; n++ {
+				// Create config with parametrized dependencies.
+				for i := 0; i < resCount; i++ {
+					cfg.Components = append(cfg.Components,
+						resource.Config{
+							Name:       fmt.Sprintf("slow%d", i),
+							Model:      resource.NewModel("rdk", "test", "slow"),
+							API:        generic.API,
+							Attributes: utils.AttributeMap{"config_duration": configDuration},
+							DependsOn:  tc.dependencies[i],
+						},
+					)
+				}
 
-		test.That(t, duration, test.ShouldBeGreaterThanOrEqualTo, 2*time.Second)
-		// This threshold is somewhat arbitrary and can be adjusted upward if this test
-		// starts to flake.
-		test.That(t, duration, test.ShouldBeLessThan, 5*time.Second)
-		// This threshold is absolute and should not be adjusted.
-		test.That(t, duration, test.ShouldBeLessThan, 10*time.Second)
+				// Reconfigure robot and benchmark.
+				t.StartTimer()
+				rob.Reconfigure(ctx, cfg)
+				t.StopTimer()
 
-		// Assert that all resources were added.
-		var err error
-		for i := 1; i <= resCount; i++ {
-			_, err = rob.ResourceByName(generic.Named(fmt.Sprintf("slow%d", i)))
-			test.That(t, err, test.ShouldBeNil)
-		}
-	})
+				// Assert that all resources were added.
+				var err error
+				for i := 0; i < resCount; i++ {
+					_, err = rob.ResourceByName(generic.Named(fmt.Sprintf("slow%d", i)))
+					test.That(t, err, test.ShouldBeNil)
+				}
+				// Remove all resources.
+				cfg.Components = nil
+				rob.Reconfigure(ctx, cfg)
+				test.That(t, rob.ResourceNames(), test.ShouldBeEmpty)
+			}
+			reportMetrics(t)
+		})
+	}
 }

--- a/module/concurrent_reconfigure_test.go
+++ b/module/concurrent_reconfigure_test.go
@@ -46,13 +46,6 @@ func BenchmarkConcurrentReconfiguration(b *testing.B) {
 	ctx := context.Background()
 	logger := logging.NewTestLogger(b)
 
-	reportMetrics := func(b *testing.B) {
-		// How many resources are reconfigured per millisecond. Since the number of
-		// resources and configuration for each resource is constant, this metric should
-		// generally as there are fewer dependencies between resources.
-		b.ReportMetric(float64(b.Elapsed().Milliseconds())/float64(b.N)/float64(resCount), "ms/resource")
-	}
-
 	type testcase struct {
 		name         string
 		dependencies [][]string
@@ -139,7 +132,13 @@ func BenchmarkConcurrentReconfiguration(b *testing.B) {
 				rob.Reconfigure(ctx, cfg)
 				test.That(b, rob.ResourceNames(), test.ShouldBeEmpty)
 			}
-			reportMetrics(b)
+
+			// --- Report metrics ---
+			//
+			// Reconfiguration time per resource. Since the number of resources and
+			// configuration time for each resource is constant, this metric should
+			// generally be lower as there are fewer dependencies between resources.
+			b.ReportMetric(float64(b.Elapsed().Milliseconds())/float64(b.N)/float64(resCount), "ms/resource")
 		})
 	}
 }

--- a/module/concurrent_reconfigure_test.go
+++ b/module/concurrent_reconfigure_test.go
@@ -103,6 +103,11 @@ func BenchmarkConcurrentReconfiguration(b *testing.B) {
 			b.StopTimer()
 			b.ResetTimer()
 			for n := 0; n < b.N; n++ {
+				// Ensure all resources are removed before benchmark iteration.
+				cfg.Components = nil
+				rob.Reconfigure(ctx, cfg)
+				test.That(b, rob.ResourceNames(), test.ShouldBeEmpty)
+
 				// Create config with parametrized dependencies.
 				for i := 0; i < resCount; i++ {
 					cfg.Components = append(cfg.Components,
@@ -127,10 +132,6 @@ func BenchmarkConcurrentReconfiguration(b *testing.B) {
 					_, err = rob.ResourceByName(generic.Named(fmt.Sprintf("slow%d", i)))
 					test.That(b, err, test.ShouldBeNil)
 				}
-				// Remove all resources.
-				cfg.Components = nil
-				rob.Reconfigure(ctx, cfg)
-				test.That(b, rob.ResourceNames(), test.ShouldBeEmpty)
 			}
 
 			// --- Report metrics ---

--- a/module/testmodule/main.go
+++ b/module/testmodule/main.go
@@ -289,19 +289,25 @@ func (tm *testMotor) IsMoving(context.Context) (bool, error) {
 func newSlow(
 	ctx context.Context, deps resource.Dependencies, conf resource.Config, logger logging.Logger,
 ) (resource.Resource, error) {
-	time.Sleep(1 * time.Second)
+	configDuration, err := time.ParseDuration(conf.Attributes.String("config_duration"))
+	if err != nil {
+		return nil, err
+	}
+	time.Sleep(configDuration)
 	return &slow{
-		Named: conf.ResourceName().AsNamed(),
+		Named:          conf.ResourceName().AsNamed(),
+		configDuration: configDuration,
 	}, nil
 }
 
 type slow struct {
 	resource.Named
 	resource.TriviallyCloseable
+	configDuration time.Duration
 }
 
 // Reconfigure does nothing but is slow.
 func (s *slow) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
-	time.Sleep(1 * time.Second)
+	time.Sleep(s.configDuration)
 	return nil
 }


### PR DESCRIPTION
### Summary

Convert flaky time-based reconfiguration tests into a benchmarks. The benchmarks will still assert that the resulting resource graph is as expected, so CI will fail if we have any regressions in correctness.

### Details

Benchmarks will produce the following logs (example pulled from [this run](https://productionresultssa8.blob.core.windows.net/actions-results/e16e5bb9-33b7-4f6c-958a-5524a897152c/workflow-job-run-da1430bc-6c64-5736-200c-429dbb21b994/logs/job/job-logs.txt?rsct=text%2Fplain&se=2024-05-29T16%3A37%3A24Z&sig=IpEG8ArcnjHdDEKq62Zqk4ZfmjGzCic34BfSMUJodZ4%3D&sp=r&spr=https&sr=b&st=2024-05-29T16%3A27%3A19Z&sv=2021-12-02)):

```
2024-05-29T15:52:36.4220491Z BenchmarkConcurrentReconfiguration/serial_dependencies-8         	       7	 144138506 ns/op	        14.40 ms/resource
...
2024-05-29T15:52:36.6733896Z BenchmarkConcurrentReconfiguration/no_dependencies-8             	      51	  21863042 ns/op	         2.186 ms/resource
...
2024-05-29T15:52:36.7406737Z BenchmarkConcurrentReconfiguration/some_dependencies-8           	      19	  59896041 ns/op	         5.989 ms/resource
```

If you scroll all the way to right, you will see the custom metric "ms/resource" (i.e. total reconfig time / total resources), which is a bit more human-readable than the standard "ns/op".

### Questions
* [ ] Should benchmarks be run in a separate workflow? 
* [ ] Should they be segregates from existing motioning planning benchmarks?
* [ ] Should we fail or report if benchmarks significantly degrade? Or should this be logged as is?