### PR TITLE
RSDK-7743 Add checks for nil in movementsensor position and orientation

### DIFF
--- a/components/board/client.go
+++ b/components/board/client.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
 	pb "go.viam.com/api/component/board/v1"
 	"go.viam.com/utils/protoutils"
 	"go.viam.com/utils/rpc"
@@ -18,10 +17,6 @@ import (
 	rprotoutils "go.viam.com/rdk/protoutils"
 	"go.viam.com/rdk/resource"
 )
-
-// errUnimplemented is used for any unimplemented methods that should
-// eventually be implemented server side or faked client side.
-var errUnimplemented = errors.New("unimplemented")
 
 // client implements BoardServiceClient.
 type client struct {
@@ -191,10 +186,6 @@ func (dic *digitalInterruptClient) Value(ctx context.Context, extra map[string]i
 		return 0, err
 	}
 	return resp.Value, nil
-}
-
-func (dic *digitalInterruptClient) Tick(ctx context.Context, high bool, nanoseconds uint64) error {
-	panic(errUnimplemented)
 }
 
 func (dic *digitalInterruptClient) Name() string {

--- a/components/movementsensor/server.go
+++ b/components/movementsensor/server.go
@@ -55,10 +55,10 @@ func (s *serviceServer) GetPosition(
 		return nil, err
 	}
 
-	var coordinate *commonpb.GeoPoint
-	if loc == nil {
-		coordinate = &commonpb.GeoPoint{Latitude: math.NaN(), Longitude: math.NaN()}
-	} else {
+	// defensively initialize a invalid, non-nil default
+	coordinate := &commonpb.GeoPoint{Latitude: math.NaN(), Longitude: math.NaN()}
+	// populate the coordinate response with the location if it is non nil
+	if loc != nil {
 		coordinate = &commonpb.GeoPoint{Latitude: loc.Lat(), Longitude: loc.Lng()}
 	}
 

--- a/components/movementsensor/server.go
+++ b/components/movementsensor/server.go
@@ -2,6 +2,7 @@ package movementsensor
 
 import (
 	"context"
+	"math"
 
 	"github.com/golang/geo/r3"
 	commonpb "go.viam.com/api/common/v1"
@@ -53,8 +54,16 @@ func (s *serviceServer) GetPosition(
 	if err != nil {
 		return nil, err
 	}
+
+	var coordinate *commonpb.GeoPoint
+	if loc == nil {
+		coordinate = &commonpb.GeoPoint{Latitude: math.NaN(), Longitude: math.NaN()}
+	} else {
+		coordinate = &commonpb.GeoPoint{Latitude: loc.Lat(), Longitude: loc.Lng()}
+	}
+
 	return &pb.GetPositionResponse{
-		Coordinate: &commonpb.GeoPoint{Latitude: loc.Lat(), Longitude: loc.Lng()},
+		Coordinate: coordinate,
 		AltitudeM:  float32(altitide),
 	}, nil
 }

--- a/components/movementsensor/server_test.go
+++ b/components/movementsensor/server_test.go
@@ -102,7 +102,7 @@ func TestServer(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, resource.IsNotFoundError(err), test.ShouldBeTrue)
 
-		// Redefine the
+		// Redefine the positionFunc to test nil return
 		injectMovementSensor.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
 			return nil, alt, nil
 		}
@@ -188,6 +188,7 @@ func TestServer(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, resource.IsNotFoundError(err), test.ShouldBeTrue)
 
+		// Redefine the orientationFunc to test nil return
 		injectMovementSensor.OrientationFunc = func(ctx context.Context, extra map[string]interface{}) (spatialmath.Orientation, error) {
 			return nil, nil
 		}

--- a/components/movementsensor/server_test.go
+++ b/components/movementsensor/server_test.go
@@ -194,7 +194,6 @@ func TestServer(t *testing.T) {
 		resp, err = gpsServer.GetOrientation(context.Background(), &pb.GetOrientationRequest{Name: testMovementSensorName, Extra: ext})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, resp.Orientation.OZ, test.ShouldEqual, 0)
-
 	})
 
 	t.Run("GetCompassHeading", func(t *testing.T) {

--- a/components/movementsensor/server_test.go
+++ b/components/movementsensor/server_test.go
@@ -101,6 +101,15 @@ func TestServer(t *testing.T) {
 		_, err = gpsServer.GetPosition(context.Background(), &pb.GetPositionRequest{Name: missingMovementSensorName})
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, resource.IsNotFoundError(err), test.ShouldBeTrue)
+
+		// Redefine the
+		injectMovementSensor.PositionFunc = func(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+			return nil, alt, nil
+		}
+		resp, err = gpsServer.GetPosition(context.Background(), &pb.GetPositionRequest{Name: testMovementSensorName})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, math.IsNaN(resp.Coordinate.Latitude), test.ShouldBeTrue)
+		test.That(t, math.IsNaN(resp.Coordinate.Longitude), test.ShouldBeTrue)
 	})
 
 	t.Run("GetLinearVelocity", func(t *testing.T) {
@@ -178,6 +187,14 @@ func TestServer(t *testing.T) {
 		_, err = gpsServer.GetOrientation(context.Background(), &pb.GetOrientationRequest{Name: missingMovementSensorName})
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, resource.IsNotFoundError(err), test.ShouldBeTrue)
+
+		injectMovementSensor.OrientationFunc = func(ctx context.Context, extra map[string]interface{}) (spatialmath.Orientation, error) {
+			return nil, nil
+		}
+		resp, err = gpsServer.GetOrientation(context.Background(), &pb.GetOrientationRequest{Name: testMovementSensorName, Extra: ext})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, resp.Orientation.OZ, test.ShouldEqual, 0)
+
 	})
 
 	t.Run("GetCompassHeading", func(t *testing.T) {

--- a/protoutils/messages.go
+++ b/protoutils/messages.go
@@ -54,6 +54,8 @@ func ConvertVectorR3ToProto(v r3.Vector) *commonpb.Vector3 {
 // ConvertOrientationToProto TODO.
 func ConvertOrientationToProto(o spatialmath.Orientation) *commonpb.Orientation {
 	oo := &commonpb.Orientation{}
+	// the orientation structure returned in the response can be nil as well,
+	// so we check again before populating the message.
 	if o != nil {
 		ov := o.OrientationVectorDegrees()
 		if ov != nil {

--- a/protoutils/messages.go
+++ b/protoutils/messages.go
@@ -56,10 +56,12 @@ func ConvertOrientationToProto(o spatialmath.Orientation) *commonpb.Orientation 
 	oo := &commonpb.Orientation{}
 	if o != nil {
 		ov := o.OrientationVectorDegrees()
-		oo.OX = ov.OX
-		oo.OY = ov.OY
-		oo.OZ = ov.OZ
-		oo.Theta = ov.Theta
+		if ov != nil {
+			oo.OX = ov.OX
+			oo.OY = ov.OY
+			oo.OZ = ov.OZ
+			oo.Theta = ov.Theta
+		}
 	}
 	return oo
 }


### PR DESCRIPTION
Adding a check for a nil to avoid a panic if a modular movementsensor returns nil for position or orientation. 