### PR TITLE
[RSDK-6986] add velocity only sensorcontrolled MoveStraight

### DIFF
--- a/components/base/sensorcontrolled/movestraight.go
+++ b/components/base/sensorcontrolled/movestraight.go
@@ -34,7 +34,7 @@ func (sb *sensorBase) MoveStraight(
 	// If a position movement sensor or controls are not configured, we cannot use this MoveStraight method.
 	// Instead we need to use the MoveStraight method of the base that the sensorcontrolled base wraps.
 	// If there is no valid velocity sensor, there won't be a controlLoopConfig.
-	if sb.position == nil || len(sb.controlLoopConfig.Blocks) == 0 {
+	if len(sb.controlLoopConfig.Blocks) == 0 {
 		sb.logger.CWarnf(ctx,
 			"Position reporting sensor not available, or control loop not configured, using base %s's MoveStraight",
 			sb.controlledBase.Name().ShortName())
@@ -43,6 +43,16 @@ func (sb *sensorBase) MoveStraight(
 		}
 		return sb.controlledBase.MoveStraight(ctx, distanceMm, mmPerSec, extra)
 	}
+	if sb.position == nil {
+		sb.logger.CWarn(ctx,
+			"Position reporting sensor not available, controlling using linear velocity only")
+
+		// adjust inputs to ensure errDist is always positive to match the position based implementation
+		if distanceMm < 0 {
+			distanceMm = -distanceMm
+			mmPerSec = -mmPerSec
+		}
+	}
 
 	// make sure the control loop is enabled
 	if sb.loop == nil {
@@ -50,6 +60,9 @@ func (sb *sensorBase) MoveStraight(
 			return err
 		}
 	}
+
+	// pause and resume the loop to reset the control blocks
+	sb.loop.Pause()
 	sb.loop.Resume()
 
 	straightTimeEst := time.Duration(int(time.Second) * int(math.Abs(float64(distanceMm)/mmPerSec)))
@@ -77,6 +90,10 @@ func (sb *sensorBase) MoveStraight(
 		}
 	}
 
+	// this state is only used when no position sensor is configured
+	prevTime := startTime
+	currDistMm := 0.
+
 	ticker := time.NewTicker(time.Duration(1000./sb.controlLoopConfig.Frequency) * time.Millisecond)
 	defer ticker.Stop()
 	for {
@@ -101,6 +118,18 @@ func (sb *sensorBase) MoveStraight(
 				if err != nil {
 					return err
 				}
+			} else {
+				currTime := time.Now()
+				vels, err := sb.velocities.LinearVelocity(ctx, nil)
+				if err != nil {
+					return err
+				}
+				deltaTime := currTime.Sub(prevTime).Seconds()
+				// calculate the estimated change in position based on the latest velocity
+				deltaPosMm := sign(mmPerSec) * vels.Y * deltaTime * 1000
+				currDistMm = currDistMm + deltaPosMm
+				errDist = float64(distanceMm) - currDistMm
+				prevTime = currTime
 			}
 
 			if errDist < moveStraightErrTarget {

--- a/components/base/sensorcontrolled/movestraight.go
+++ b/components/base/sensorcontrolled/movestraight.go
@@ -127,7 +127,7 @@ func (sb *sensorBase) MoveStraight(
 				deltaTime := currTime.Sub(prevTime).Seconds()
 				// calculate the estimated change in position based on the latest velocity
 				deltaPosMm := sign(mmPerSec) * vels.Y * deltaTime * 1000
-				currDistMm = currDistMm + deltaPosMm
+				currDistMm += deltaPosMm
 				errDist = float64(distanceMm) - currDistMm
 				prevTime = currTime
 			}

--- a/components/base/sensorcontrolled/movestraight.go
+++ b/components/base/sensorcontrolled/movestraight.go
@@ -45,7 +45,7 @@ func (sb *sensorBase) MoveStraight(
 	}
 	if sb.position == nil {
 		sb.logger.CWarn(ctx,
-			"Position reporting sensor not available, controlling using linear velocity only")
+			"controlling using linear velocity only, for increased accuracy add a position reporting sensor")
 
 		// adjust inputs to ensure errDist is always positive to match the position based implementation
 		if distanceMm < 0 {

--- a/components/base/sensorcontrolled/movestraight.go
+++ b/components/base/sensorcontrolled/movestraight.go
@@ -36,7 +36,7 @@ func (sb *sensorBase) MoveStraight(
 	// If there is no valid velocity sensor, there won't be a controlLoopConfig.
 	if len(sb.controlLoopConfig.Blocks) == 0 {
 		sb.logger.CWarnf(ctx,
-			"Position reporting sensor not available, or control loop not configured, using base %s's MoveStraight",
+			"control loop not configured, using base %s's MoveStraight",
 			sb.controlledBase.Name().ShortName())
 		if sb.loop != nil {
 			sb.loop.Pause()
@@ -61,7 +61,8 @@ func (sb *sensorBase) MoveStraight(
 		}
 	}
 
-	// pause and resume the loop to reset the control blocks
+	// pause and resume the loop to reset the control blocks.
+	// This prevents any residual signals in the control loop from "kicking" the robot
 	sb.loop.Pause()
 	sb.loop.Resume()
 

--- a/components/base/sensorcontrolled/sensorcontrolled_test.go
+++ b/components/base/sensorcontrolled/sensorcontrolled_test.go
@@ -471,7 +471,6 @@ func TestSensorBaseMoveStraight(t *testing.T) {
 	t.Run("Test not including a position ms will use the controlled MoveStraight", func(t *testing.T) {
 		// flaky test, will see behavior after RSDK-6164
 		t.Skip()
-		// the injected base will return nil instead of blocking
 		err := sbNoPos.MoveStraight(ctx, 100, 100, nil)
 		test.That(t, err, test.ShouldBeNil)
 	})

--- a/components/base/sensorcontrolled/sensorcontrolled_test.go
+++ b/components/base/sensorcontrolled/sensorcontrolled_test.go
@@ -468,7 +468,9 @@ func TestSensorBaseMoveStraight(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		wg.Wait()
 	})
-	t.Run("Test not including a position ms will use the non controlled MoveStraight", func(t *testing.T) {
+	t.Run("Test not including a position ms will use the controlled MoveStraight", func(t *testing.T) {
+		// flaky test, will see behavior after RSDK-6164
+		t.Skip()
 		// the injected base will return nil instead of blocking
 		err := sbNoPos.MoveStraight(ctx, 100, 100, nil)
 		test.That(t, err, test.ShouldBeNil)

--- a/components/base/sensorcontrolled/spin.go
+++ b/components/base/sensorcontrolled/spin.go
@@ -53,6 +53,7 @@ func (sb *sensorBase) Spin(ctx context.Context, angleDeg, degsPerSec float64, ex
 	}
 
 	// pause and resume the loop to reset the control blocks
+	// This prevents any residual signals in the control loop from "kicking" the robot
 	sb.loop.Pause()
 	sb.loop.Resume()
 	var angErr float64

--- a/components/base/sensorcontrolled/spin.go
+++ b/components/base/sensorcontrolled/spin.go
@@ -51,6 +51,9 @@ func (sb *sensorBase) Spin(ctx context.Context, angleDeg, degsPerSec float64, ex
 			return err
 		}
 	}
+
+	// pause and resume the loop to reset the control blocks
+	sb.loop.Pause()
 	sb.loop.Resume()
 	var angErr float64
 	prevMovedAng := 0.


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-6986

tested on a benchtop and in the grid area using a viam rover both with and without a position endpoint. Both cases used odometry for the velocity movement sensor, and odometry was used for the position endpoint for those tests. 