### PR TITLE
RSDK-7785 Do not call removeOrphanedResources with no orphans

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -849,7 +849,7 @@ func (mgr *Manager) newOnUnexpectedExitHandler(mod *module) func(exitCode int) b
 				orphanedResourceNames = append(orphanedResourceNames, name)
 			}
 		}
-		if mgr.removeOrphanedResources != nil {
+		if len(orphanedResourceNames) > 0 && mgr.removeOrphanedResources != nil {
 			mgr.removeOrphanedResources(mgr.restartCtx, orphanedResourceNames)
 		}
 

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -480,8 +480,9 @@ func TestModuleReloading(t *testing.T) {
 		test.That(t, logs.FilterMessageSnippet("Error while restarting crashed module").Len(),
 			test.ShouldEqual, 0)
 
-		// Assert that RemoveOrphanedResources was called once.
-		test.That(t, dummyRemoveOrphanedResourcesCallCount.Load(), test.ShouldEqual, 1)
+		// Assert that RemoveOrphanedResources was not called (successful restart and re-addition of
+		// modular resources should not require removal of any orphans).
+		test.That(t, dummyRemoveOrphanedResourcesCallCount.Load(), test.ShouldEqual, 0)
 	})
 	t.Run("unsuccessful restart", func(t *testing.T) {
 		logger, logs := logging.NewObservedTestLogger(t)
@@ -982,8 +983,10 @@ func TestTwoModulesRestart(t *testing.T) {
 	test.That(t, logs.FilterMessageSnippet("Error while restarting crashed module").Len(),
 		test.ShouldEqual, 0)
 
-	// Assert that RemoveOrphanedResources was called once for each module.
-	test.That(t, dummyRemoveOrphanedResourcesCallCount.Load(), test.ShouldEqual, 2)
+	// Assert that RemoveOrphanedResources was not called for either module
+	// (successful restart and re-addition of modular resources should not
+	// require removal of any orphans).
+	test.That(t, dummyRemoveOrphanedResourcesCallCount.Load(), test.ShouldEqual, 0)
 }
 
 var (


### PR DESCRIPTION
[RSDK-7785](https://viam.atlassian.net/browse/RSDK-7785)

Only calls `removeOrphanedResources` for a crashed module if there were actually orphaned resources (`len(orphanedResourceNames) > 0`). Modifies tests accordingly. 

Calling `removeOrphanedResources` when no resources have actually been orphaned is not _terrible_, but it does cause an extra weak dependents update [here](https://github.com/viamrobotics/rdk/blob/main/robot/impl/local_robot.go#L561). Extra weak dependents update means extra, unnecessary `Reconfigure`s of resources like the data manager service, making us more prone to bugs like [DATA-2664](https://viam.atlassian.net/browse/DATA-2664).

cc @vijayvuyyuru 

[RSDK-7785]: https://viam.atlassian.net/browse/RSDK-7785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DATA-2664]: https://viam.atlassian.net/browse/DATA-2664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ