### PR TITLE
DATA-2665 Change max thread check to handle empty value from config

### DIFF
--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -568,7 +568,6 @@ func (svc *builtIn) Reconfigure(
 		svc.syncIntervalMins = svcConfig.SyncIntervalMins
 		svc.tags = svcConfig.Tags
 		svc.fileLastModifiedMillis = fileLastModifiedMillis
-
 		svc.maxSyncThreads = newMaxSyncThreadValue
 
 		svc.cancelSyncScheduler()

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -416,14 +416,6 @@ func (svc *builtIn) Reconfigure(
 	deps resource.Dependencies,
 	conf resource.Config,
 ) error {
-	svc.logger.Info("In data manager reconfigure")
-	// svc.logger.Infow("count", svc.count.Load())
-	// svc.count.Add(1)
-	// if svc.count.Load() > 4 {
-	// 	svc.logger.Warn("slepeing, forcing hang")
-	// 	time.Sleep(61 * time.Second)
-	// }
-	defer svc.logger.Info("exiting data manager reconfigure")
 	svc.lock.Lock()
 	defer svc.lock.Unlock()
 	svcConfig, err := resource.NativeConfig[*Config](conf)
@@ -572,7 +564,6 @@ func (svc *builtIn) Reconfigure(
 		svc.maxSyncThreads != newMaxSyncThreadValue
 
 	if syncConfigUpdated {
-		svc.logger.Info("updating syncer config")
 		svc.syncDisabled = svcConfig.ScheduledSyncDisabled
 		svc.syncIntervalMins = svcConfig.SyncIntervalMins
 		svc.tags = svcConfig.Tags
@@ -601,8 +592,6 @@ func (svc *builtIn) Reconfigure(
 			}
 			svc.closeSyncer()
 		}
-	} else {
-		svc.logger.Info("skipping sync reconfig")
 	}
 	// if datacapture is enabled, kick off a go routine to check if disk space is filling due to
 	// cached datacapture files

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -691,7 +691,7 @@ func (svc *builtIn) sync() {
 	}
 }
 
-// nolint
+//nolint
 func getAllFilesToSync(dir string, lastModifiedMillis int) []string {
 	var filePaths []string
 	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {


### PR DESCRIPTION
Hey yall, inside of datamanager's reconfigure, there is a check designed to only cancel the syncer if a relevant value has changed. There was a small bug where it would naively compare the service value to the value from the config struct(introduced by me sorry). However if this value was unset (which it is the majority of the time), it would be comparing the service threads to 0 (the default value if the field is unset). As a result, we would cancel and reconfigure the syncer unncessarily. This was discovered as part of @benjirewis's investigation into a customer issue where sync would not occur until a service level restart. 

**Testing**
This was tested by adding logging to reconfigure and verifying the log line was only printed when the actual number of sync threads was changed, not just from empty config values.  