### PR TITLE
Dont remove disconnected remote resources from resource graph

### DIFF
--- a/components/camera/client.go
+++ b/components/camera/client.go
@@ -363,6 +363,8 @@ func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map
 func (c *client) Close(ctx context.Context) error {
 	_, span := trace.StartSpan(ctx, "camera::client::Close")
 	defer span.End()
+	c.logger.Info("Close() START")
+	defer c.logger.Info("Close() END")
 
 	c.cancelFn()
 	c.mu.Lock()

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -2016,9 +2016,9 @@ func TestReconnectRemote(t *testing.T) {
 	test.That(t, len(remoteRobotClient.ResourceNames()), test.ShouldEqual, 0)
 	testutils.WaitForAssertion(t, func(tb testing.TB) {
 		tb.Helper()
-		test.That(tb, len(robotClient.ResourceNames()), test.ShouldEqual, 2)
+		test.That(tb, len(robotClient.ResourceNames()), test.ShouldEqual, 5)
 	})
-	test.That(t, len(robot1.ResourceNames()), test.ShouldEqual, 2)
+	test.That(t, len(robot1.ResourceNames()), test.ShouldEqual, 5)
 	_, err = anArm.EndPosition(context.Background(), map[string]interface{}{})
 	test.That(t, err, test.ShouldBeError)
 
@@ -2117,11 +2117,28 @@ func TestReconnectRemoteChangeConfig(t *testing.T) {
 	test.That(t, robot.Close(context.Background()), test.ShouldBeNil)
 	test.That(t, <-remoteRobotClient.Changed(), test.ShouldBeTrue)
 	test.That(t, len(remoteRobotClient.ResourceNames()), test.ShouldEqual, 0)
+
+	expectedFirstResources := []resource.Name{
+		motion.Named(resource.DefaultServiceName),
+		sensors.Named(resource.DefaultServiceName),
+		arm.Named("remote:arm1"),
+		motion.Named("remote:builtin"),
+		sensors.Named("remote:builtin"),
+	}
+
 	testutils.WaitForAssertion(t, func(tb testing.TB) {
 		tb.Helper()
-		test.That(tb, len(robotClient.ResourceNames()), test.ShouldEqual, 2)
+		test.That(tb,
+			rtestutils.NewSortedResourceNames(robotClient.ResourceNames()),
+			test.ShouldResemble,
+			rtestutils.NewSortedResourceNames(expectedFirstResources),
+		)
 	})
-	test.That(t, len(robot1.ResourceNames()), test.ShouldEqual, 2)
+	test.That(t,
+		rtestutils.NewSortedResourceNames(robotClient.ResourceNames()),
+		test.ShouldResemble,
+		rtestutils.NewSortedResourceNames(expectedFirstResources),
+	)
 	_, err = anArm.EndPosition(context.Background(), map[string]interface{}{})
 	test.That(t, err, test.ShouldBeError)
 
@@ -2148,10 +2165,20 @@ func TestReconnectRemoteChangeConfig(t *testing.T) {
 	// check if the original arm can't be called anymore
 	test.That(t, <-remoteRobotClient.Changed(), test.ShouldBeTrue)
 	test.That(t, remoteRobotClient.Connected(), test.ShouldBeTrue)
-	test.That(t, len(remoteRobotClient.ResourceNames()), test.ShouldEqual, 3)
+	expectedSecondRobotResources := []resource.Name{
+		motion.Named(resource.DefaultServiceName),
+		sensors.Named(resource.DefaultServiceName),
+		base.Named("remote:base1"),
+		motion.Named("remote:builtin"),
+		sensors.Named("remote:builtin"),
+	}
 	testutils.WaitForAssertion(t, func(tb testing.TB) {
 		tb.Helper()
-		test.That(tb, len(robotClient.ResourceNames()), test.ShouldEqual, 5)
+		test.That(tb,
+			rtestutils.NewSortedResourceNames(robotClient.ResourceNames()),
+			test.ShouldResemble,
+			rtestutils.NewSortedResourceNames(expectedSecondRobotResources),
+		)
 	})
 	test.That(t, len(robot1.ResourceNames()), test.ShouldEqual, 5)
 	_, err = anArm.EndPosition(context.Background(), map[string]interface{}{})

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"log"
 	"os"
 	"reflect"
 	"strings"
@@ -179,6 +180,16 @@ func (manager *resourceManager) updateRemoteResourceNames(
 ) bool {
 	manager.logger.CDebugw(ctx, "updating remote resource names", "remote", remoteName)
 	activeResourceNames := map[resource.Name]bool{}
+	rc, ok := rr.(*client.RobotClient)
+	if !ok {
+		log.Fatal("client is not a robot client")
+	}
+	if !rc.Connected() {
+		manager.logger.CWarnw(ctx, "remote is disconnected, not updating clients of resources in that remote",
+			"name", rr.Name())
+		return false
+	}
+
 	newResources := rr.ResourceNames()
 	oldResources := manager.remoteResourceNames(remoteName)
 	for _, res := range oldResources {

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"log"
 	"os"
 	"reflect"
 	"strings"
@@ -180,11 +179,11 @@ func (manager *resourceManager) updateRemoteResourceNames(
 ) bool {
 	manager.logger.CDebugw(ctx, "updating remote resource names", "remote", remoteName)
 	activeResourceNames := map[resource.Name]bool{}
-	rc, ok := rr.(*client.RobotClient)
-	if !ok {
-		log.Fatal("client is not a robot client")
-	}
-	if !rc.Connected() {
+	// if the robot supports the Connected method then we know that it is for a resource
+	// that might be disconnected. If it is disconnected then we won't update our
+	// resources for that robot as they are in an indeterminant state
+	connectable, ok := rr.(interface{ Connected() bool })
+	if ok && !connectable.Connected() {
 		manager.logger.CWarnw(ctx, "remote is disconnected, not updating clients of resources in that remote",
 			"name", rr.Name())
 		return false

--- a/robot/impl/robot_framesystem_test.go
+++ b/robot/impl/robot_framesystem_test.go
@@ -17,9 +17,7 @@ import (
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/resource"
 	_ "go.viam.com/rdk/services/datamanager/builtin"
-	"go.viam.com/rdk/services/motion"
 	_ "go.viam.com/rdk/services/motion/builtin"
-	"go.viam.com/rdk/services/sensors"
 	_ "go.viam.com/rdk/services/sensors/builtin"
 	"go.viam.com/rdk/spatialmath"
 	rdktestutils "go.viam.com/rdk/testutils"
@@ -129,15 +127,39 @@ func TestFrameSystemConfigWithRemote(t *testing.T) {
 	rr.triggerConfig <- struct{}{}
 
 	finalSet := []resource.Name{
-		motion.Named(resource.DefaultServiceName),
-		sensors.Named(resource.DefaultServiceName),
-		base.Named("foo"),
-		gripper.Named("myParentIsRemote"),
-	}
+		resource.Name{API: resource.API{Type: resource.APIType{Namespace: resource.APINamespace("rdk"), Name: "component"}, SubtypeName: "arm"}, Remote: "bar", Name: "pieceArm"},
+		resource.Name{API: resource.API{Type: resource.APIType{Namespace: resource.APINamespace("rdk"), Name: "component"}, SubtypeName: "arm"}, Remote: "dontAddMe", Name: "pieceArm"},
+		resource.Name{API: resource.API{Type: resource.APIType{Namespace: resource.APINamespace("rdk"), Name: "component"}, SubtypeName: "arm"}, Remote: "squee", Name: "pieceArm"},
+		resource.Name{API: resource.API{Type: resource.APIType{Namespace: resource.APINamespace("rdk"), Name: "component"}, SubtypeName: "audio_input"}, Remote: "bar", Name: "mic1"},
+		resource.Name{API: resource.API{Type: resource.APIType{Namespace: resource.APINamespace("rdk"), Name: "component"}, SubtypeName: "audio_input"}, Remote: "dontAddMe", Name: "mic1"},
+		resource.Name{API: resource.API{Type: resource.APIType{Namespace: resource.APINamespace("rdk"), Name: "component"}, SubtypeName: "audio_input"}, Remote: "squee", Name: "mic1"},
+		resource.Name{API: resource.API{Type: resource.APIType{Namespace: resource.APINamespace("rdk"), Name: "component"}, SubtypeName: "base"}, Remote: "", Name: "foo"},
+		resource.Name{API: resource.API{Type: resource.APIType{Namespace: resource.APINamespace("rdk"), Name: "component"}, SubtypeName: "camera"}, Remote: "bar", Name: "cameraOver"},
+		resource.Name{API: resource.API{Type: resource.APIType{Namespace: resource.APINamespace("rdk"), Name: "component"}, SubtypeName: "camera"}, Remote: "dontAddMe", Name: "cameraOver"},
+		resource.Name{API: resource.API{Type: resource.APIType{Namespace: resource.APINamespace("rdk"), Name: "component"}, SubtypeName: "camera"}, Remote: "squee", Name: "cameraOver"},
+		resource.Name{API: resource.API{Type: resource.APIType{Namespace: resource.APINamespace("rdk"), Name: "component"}, SubtypeName: "gripper"}, Remote: "bar", Name: "pieceGripper"},
+		resource.Name{API: resource.API{Type: resource.APIType{Namespace: resource.APINamespace("rdk"), Name: "component"}, SubtypeName: "gripper"}, Remote: "dontAddMe", Name: "pieceGripper"},
+		resource.Name{API: resource.API{Type: resource.APIType{Namespace: resource.APINamespace("rdk"), Name: "component"}, SubtypeName: "gripper"}, Remote: "", Name: "myParentIsRemote"},
+		resource.Name{API: resource.API{Type: resource.APIType{Namespace: resource.APINamespace("rdk"), Name: "component"}, SubtypeName: "gripper"}, Remote: "squee", Name: "pieceGripper"},
+		resource.Name{API: resource.API{Type: resource.APIType{Namespace: resource.APINamespace("rdk"), Name: "component"}, SubtypeName: "movement_sensor"}, Remote: "bar", Name: "movement_sensor1"},
+		resource.Name{API: resource.API{Type: resource.APIType{Namespace: resource.APINamespace("rdk"), Name: "component"}, SubtypeName: "movement_sensor"}, Remote: "bar", Name: "movement_sensor2"},
+		resource.Name{API: resource.API{Type: resource.APIType{Namespace: resource.APINamespace("rdk"), Name: "component"}, SubtypeName: "movement_sensor"}, Remote: "dontAddMe", Name: "movement_sensor1"},
+		resource.Name{API: resource.API{Type: resource.APIType{Namespace: resource.APINamespace("rdk"), Name: "component"}, SubtypeName: "movement_sensor"}, Remote: "dontAddMe", Name: "movement_sensor2"},
+		resource.Name{API: resource.API{Type: resource.APIType{Namespace: resource.APINamespace("rdk"), Name: "component"}, SubtypeName: "movement_sensor"}, Remote: "squee", Name: "movement_sensor1"},
+		resource.Name{API: resource.API{Type: resource.APIType{Namespace: resource.APINamespace("rdk"), Name: "component"}, SubtypeName: "movement_sensor"}, Remote: "squee", Name: "movement_sensor2"},
+		resource.Name{API: resource.API{Type: resource.APIType{Namespace: resource.APINamespace("rdk"), Name: "service"}, SubtypeName: "motion"}, Remote: "bar", Name: "builtin"},
+		resource.Name{API: resource.API{Type: resource.APIType{Namespace: resource.APINamespace("rdk"), Name: "service"}, SubtypeName: "motion"}, Remote: "", Name: "builtin"},
+		resource.Name{API: resource.API{Type: resource.APIType{Namespace: resource.APINamespace("rdk"), Name: "service"}, SubtypeName: "motion"}, Remote: "dontAddMe", Name: "builtin"},
+		resource.Name{API: resource.API{Type: resource.APIType{Namespace: resource.APINamespace("rdk"), Name: "service"}, SubtypeName: "motion"}, Remote: "squee", Name: "builtin"},
+		resource.Name{API: resource.API{Type: resource.APIType{Namespace: resource.APINamespace("rdk"), Name: "service"}, SubtypeName: "sensors"}, Remote: "bar", Name: "builtin"},
+		resource.Name{API: resource.API{Type: resource.APIType{Namespace: resource.APINamespace("rdk"), Name: "service"}, SubtypeName: "sensors"}, Remote: "", Name: "builtin"},
+		resource.Name{API: resource.API{Type: resource.APIType{Namespace: resource.APINamespace("rdk"), Name: "service"}, SubtypeName: "sensors"}, Remote: "dontAddMe", Name: "builtin"},
+		resource.Name{API: resource.API{Type: resource.APIType{Namespace: resource.APINamespace("rdk"), Name: "service"}, SubtypeName: "sensors"}, Remote: "squee", Name: "builtin"}}
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
 		rdktestutils.VerifySameResourceNames(tb, r2.ResourceNames(), finalSet)
 	})
 
+	//NOTE: Currently this always errors
 	fsCfg, err = r2.FrameSystemConfig(context.Background())
 	test.That(t, err, test.ShouldBeNil)
 

--- a/testutils/resource_utils.go
+++ b/testutils/resource_utils.go
@@ -44,9 +44,9 @@ func NewResourceNameSet(resourceNames ...resource.Name) map[resource.Name]struct
 	return set
 }
 
-// newSortedResourceNames returns a new slice of resources names sorted by each
+// NewSortedResourceNames returns a new slice of resources names sorted by each
 // resource's fully-qualified names for the purposes of comparison in automated tests.
-func newSortedResourceNames(resourceNames []resource.Name) []resource.Name {
+func NewSortedResourceNames(resourceNames []resource.Name) []resource.Name {
 	sorted := make([]resource.Name, len(resourceNames))
 	copy(sorted, resourceNames)
 	slices.SortStableFunc(sorted, func(r1, r2 resource.Name) int {
@@ -58,7 +58,8 @@ func newSortedResourceNames(resourceNames []resource.Name) []resource.Name {
 // VerifySameResourceNames asserts that two slices of resource.Names contain the same
 // resources.Names without considering order.
 func VerifySameResourceNames(tb testing.TB, actual, expected []resource.Name) {
-	test.That(tb, newSortedResourceNames(actual), test.ShouldResemble, newSortedResourceNames(expected))
+	tb.Helper()
+	test.That(tb, NewSortedResourceNames(actual), test.ShouldResemble, NewSortedResourceNames(expected))
 }
 
 // ExtractNames takes a slice of resource.Name objects


### PR DESCRIPTION
Change resource_manager to detect if the Robot has a `Connected` method during `updateRemoteResourceNames` and if if does, don't update the resource graph if the `Connected` method returned false.

This results in the resources in the remote staying in the resource graph & as a side effect GRPC clients for resources in the remote to not have their `Close()` methods called on them if the remotes they are connected to are disconnected.