### PR TITLE
APP-5114 export CLI config parsing + dialing

### DIFF
--- a/cli/auth.go
+++ b/cli/auth.go
@@ -485,7 +485,10 @@ func (c *viamClient) ensureLoggedIn() error {
 		}
 	}
 
-	rpcOpts := append(c.copyRPCOpts(), c.conf.Auth.dialOpts())
+	rpcOpts, err := c.conf.DialOptions()
+	if err != nil {
+		return err
+	}
 
 	conn, err := rpc.DialDirectGRPC(
 		c.c.Context,
@@ -542,10 +545,11 @@ func (c *viamClient) prepareDial(
 	}()
 	dialCtx := rpc.ContextWithDialer(c.c.Context, rpcDialer)
 
-	rpcOpts := append(c.copyRPCOpts(),
-		rpc.WithExternalAuth(c.baseURL.Host, part.Fqdn),
-		c.conf.Auth.dialOpts(),
-	)
+	rpcOpts, err := c.conf.DialOptions()
+	if err != nil {
+		return nil, "", nil, err
+	}
+	rpcOpts = append(rpcOpts, rpc.WithExternalAuth(c.baseURL.Host, part.Fqdn))
 
 	if debug {
 		rpcOpts = append(rpcOpts, rpc.WithDialDebug())

--- a/cli/auth.go
+++ b/cli/auth.go
@@ -227,7 +227,7 @@ func (c *viamClient) printAccessTokenAction(cCtx *cli.Context) error {
 // LogoutAction is the corresponding Action for 'logout'.
 func LogoutAction(cCtx *cli.Context) error {
 	// Create basic viam client; no need to check base URL.
-	conf, err := configFromCache()
+	conf, err := ConfigFromCache()
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return err

--- a/cli/auth.go
+++ b/cli/auth.go
@@ -232,7 +232,7 @@ func LogoutAction(cCtx *cli.Context) error {
 		if !os.IsNotExist(err) {
 			return err
 		}
-		conf = &config{}
+		conf = &Config{}
 	}
 
 	vc := &viamClient{
@@ -513,7 +513,7 @@ func (c *viamClient) logout() error {
 	if err := removeConfigFromCache(); err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	c.conf = &config{}
+	c.conf = &Config{}
 	return nil
 }
 

--- a/cli/auth_test.go
+++ b/cli/auth_test.go
@@ -232,7 +232,7 @@ func TestWhoAmIAction(t *testing.T) {
 
 func TestConfigMarshalling(t *testing.T) {
 	t.Run("token config", func(t *testing.T) {
-		conf := config{
+		conf := Config{
 			BaseURL: "https://guthib.com:443",
 			Auth: &token{
 				AccessToken: "secret-token",
@@ -245,7 +245,7 @@ func TestConfigMarshalling(t *testing.T) {
 
 		bytes, err := json.Marshal(conf)
 		test.That(t, err, test.ShouldBeNil)
-		var newConf config
+		var newConf Config
 		test.That(t, newConf.tryUnmarshallWithAPIKey(bytes), test.ShouldBeError)
 		test.That(t, newConf.tryUnmarshallWithToken(bytes), test.ShouldBeNil)
 		test.That(t, newConf.BaseURL, test.ShouldEqual, "https://guthib.com:443")
@@ -257,7 +257,7 @@ func TestConfigMarshalling(t *testing.T) {
 	})
 
 	t.Run("api-key config", func(t *testing.T) {
-		conf := config{
+		conf := Config{
 			BaseURL: "https://docs.viam.com:443",
 			Auth: &apiKey{
 				KeyID:     "42",
@@ -267,7 +267,7 @@ func TestConfigMarshalling(t *testing.T) {
 
 		bytes, err := json.Marshal(conf)
 		test.That(t, err, test.ShouldBeNil)
-		var newConf config
+		var newConf Config
 		test.That(t, newConf.tryUnmarshallWithToken(bytes), test.ShouldBeError)
 		test.That(t, newConf.tryUnmarshallWithAPIKey(bytes), test.ShouldBeNil)
 		test.That(t, newConf.BaseURL, test.ShouldEqual, "https://docs.viam.com:443")

--- a/cli/client.go
+++ b/cli/client.go
@@ -70,7 +70,6 @@ type viamClient struct {
 	mlTrainingClient mltrainingpb.MLTrainingServiceClient
 	buildClient      buildpb.BuildServiceClient
 	baseURL          *url.URL
-	rpcOpts          []rpc.DialOption
 	authFlow         *authFlow
 
 	selectedOrg *apppb.Organization
@@ -784,7 +783,7 @@ func newViamClient(c *cli.Context) (*viamClient, error) {
 	if conf.BaseURL != defaultBaseURL {
 		infof(c.App.ErrWriter, "Using %q as base URL value", conf.BaseURL)
 	}
-	baseURL, rpcOpts, err := parseBaseURL(conf.BaseURL, true)
+	baseURL, _, err := parseBaseURL(conf.BaseURL, true)
 	if err != nil {
 		return nil, err
 	}
@@ -801,17 +800,10 @@ func newViamClient(c *cli.Context) (*viamClient, error) {
 		c:           c,
 		conf:        conf,
 		baseURL:     baseURL,
-		rpcOpts:     rpcOpts,
 		selectedOrg: &apppb.Organization{},
 		selectedLoc: &apppb.Location{},
 		authFlow:    authFlow,
 	}, nil
-}
-
-func (c *viamClient) copyRPCOpts() []rpc.DialOption {
-	rpcOpts := make([]rpc.DialOption, len(c.rpcOpts))
-	copy(rpcOpts, c.rpcOpts)
-	return rpcOpts
 }
 
 func (c *viamClient) loadOrganizations() error {

--- a/cli/client.go
+++ b/cli/client.go
@@ -601,7 +601,7 @@ func CheckUpdateAction(c *cli.Context) error {
 		return nil
 	}
 
-	conf, err := configFromCache()
+	conf, err := ConfigFromCache()
 	if err != nil {
 		if !os.IsNotExist(err) {
 			utils.UncheckedError(err)
@@ -759,7 +759,7 @@ func isProdBaseURL(baseURL *url.URL) bool {
 }
 
 func newViamClient(c *cli.Context) (*viamClient, error) {
-	conf, err := configFromCache()
+	conf, err := ConfigFromCache()
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return nil, err

--- a/cli/client.go
+++ b/cli/client.go
@@ -61,7 +61,7 @@ const (
 // needed to talk to the app and data services but not directly to robot parts.
 type viamClient struct {
 	c                *cli.Context
-	conf             *config
+	conf             *Config
 	client           apppb.AppServiceClient
 	dataClient       datapb.DataServiceClient
 	packageClient    packagepb.PackageServiceClient
@@ -608,7 +608,7 @@ func CheckUpdateAction(c *cli.Context) error {
 			utils.UncheckedError(err)
 			return nil
 		}
-		conf = &config{}
+		conf = &Config{}
 	}
 
 	var lastCheck time.Time
@@ -765,7 +765,7 @@ func newViamClient(c *cli.Context) (*viamClient, error) {
 		if !os.IsNotExist(err) {
 			return nil, err
 		}
-		conf = &config{}
+		conf = &Config{}
 	}
 
 	// If base URL was not specified, assume cached base URL. If no base URL is

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -108,7 +108,7 @@ func setup(
 	}
 
 	cCtx := cli.NewContext(NewApp(out, errOut), flags, nil)
-	conf := &config{}
+	conf := &Config{}
 	if authMethod == "token" {
 		conf.Auth = &token{
 			AccessToken: testToken,

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -169,12 +169,11 @@ func setupWithRunningPart(
 	err = r.StartWeb(cCtx.Context, options)
 	test.That(t, err, test.ShouldBeNil)
 
-	baseURL, rpcOpts, err := parseBaseURL(fmt.Sprintf("http://%s", addr), false)
-	test.That(t, err, test.ShouldBeNil)
 	// this will be the URL we use to make new clients. In a backwards way, this
 	// lets the robot be the one with external auth handling (if auth were being used)
-	ac.baseURL = baseURL
-	ac.rpcOpts = rpcOpts
+	ac.conf.BaseURL = fmt.Sprintf("http://%s", addr)
+	ac.baseURL, _, err = parseBaseURL(ac.conf.BaseURL, false)
+	test.That(t, err, test.ShouldBeNil)
 
 	return cCtx, ac, out, errOut, func() {
 		test.That(t, r.Close(context.Background()), test.ShouldBeNil)

--- a/cli/config.go
+++ b/cli/config.go
@@ -17,6 +17,7 @@ func getCLICachePath() string {
 }
 
 // ConfigFromCache parses the cached json into a Config.
+// TODO(RSDK-7812): maybe move shared code to common location.
 func ConfigFromCache() (*Config, error) {
 	rd, err := os.ReadFile(getCLICachePath())
 	if err != nil {

--- a/cli/config.go
+++ b/cli/config.go
@@ -15,12 +15,12 @@ func getCLICachePath() string {
 	return filepath.Join(viamDotDir, "cached_cli_config.json")
 }
 
-func configFromCache() (*config, error) {
+func configFromCache() (*Config, error) {
 	rd, err := os.ReadFile(getCLICachePath())
 	if err != nil {
 		return nil, err
 	}
-	var conf config
+	var conf Config
 
 	tokenErr := conf.tryUnmarshallWithToken(rd)
 	if tokenErr == nil {
@@ -38,7 +38,7 @@ func removeConfigFromCache() error {
 	return os.Remove(getCLICachePath())
 }
 
-func storeConfigToCache(cfg *config) error {
+func storeConfigToCache(cfg *Config) error {
 	if err := os.MkdirAll(viamDotDir, 0o700); err != nil {
 		return err
 	}
@@ -50,14 +50,14 @@ func storeConfigToCache(cfg *config) error {
 	return os.WriteFile(getCLICachePath(), md, 0o640)
 }
 
-type config struct {
+type Config struct {
 	BaseURL         string     `json:"base_url"`
 	Auth            authMethod `json:"auth"`
 	LastUpdateCheck string     `json:"last_update_check"`
 	LatestVersion   string     `json:"latest_version"`
 }
 
-func (conf *config) tryUnmarshallWithToken(configBytes []byte) error {
+func (conf *Config) tryUnmarshallWithToken(configBytes []byte) error {
 	conf.Auth = &token{}
 	if err := json.Unmarshal(configBytes, &conf); err != nil {
 		return err
@@ -68,7 +68,7 @@ func (conf *config) tryUnmarshallWithToken(configBytes []byte) error {
 	return errors.New("config did not contain a user token")
 }
 
-func (conf *config) tryUnmarshallWithAPIKey(configBytes []byte) error {
+func (conf *Config) tryUnmarshallWithAPIKey(configBytes []byte) error {
 	conf.Auth = &apiKey{}
 	if err := json.Unmarshal(configBytes, &conf); err != nil {
 		return err

--- a/cli/config.go
+++ b/cli/config.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
+	"go.viam.com/utils/rpc"
 )
 
 var viamDotDir = filepath.Join(os.Getenv("HOME"), ".viam")
@@ -77,4 +78,12 @@ func (conf *Config) tryUnmarshallWithAPIKey(configBytes []byte) error {
 		return nil
 	}
 	return errors.New("config did not contain an api key")
+}
+
+func (conf *Config) DialOptions() ([]rpc.DialOption, error) {
+	_, opts, err := parseBaseURL(conf.BaseURL, true)
+	if err != nil {
+		return nil, err
+	}
+	return append(opts, conf.Auth.dialOpts()), nil
 }

--- a/cli/config.go
+++ b/cli/config.go
@@ -16,7 +16,8 @@ func getCLICachePath() string {
 	return filepath.Join(viamDotDir, "cached_cli_config.json")
 }
 
-func configFromCache() (*Config, error) {
+// ConfigFromCache parses the cached json into a Config.
+func ConfigFromCache() (*Config, error) {
 	rd, err := os.ReadFile(getCLICachePath())
 	if err != nil {
 		return nil, err
@@ -32,7 +33,7 @@ func configFromCache() (*Config, error) {
 		return &conf, nil
 	}
 
-	return nil, errors.Wrap(multierr.Combine(tokenErr, apiKeyErr), "failed to read config from cache")
+	return nil, errors.Wrap(multierr.Combine(tokenErr, apiKeyErr), "failed to parse cached config")
 }
 
 func removeConfigFromCache() error {

--- a/cli/config.go
+++ b/cli/config.go
@@ -52,6 +52,7 @@ func storeConfigToCache(cfg *Config) error {
 	return os.WriteFile(getCLICachePath(), md, 0o640)
 }
 
+// Config is the schema for saved CLI credentials.
 type Config struct {
 	BaseURL         string     `json:"base_url"`
 	Auth            authMethod `json:"auth"`
@@ -81,6 +82,7 @@ func (conf *Config) tryUnmarshallWithAPIKey(configBytes []byte) error {
 	return errors.New("config did not contain an api key")
 }
 
+// DialOptions constructs an rpc.DialOption slice from config.
 func (conf *Config) DialOptions() ([]rpc.DialOption, error) {
 	_, opts, err := parseBaseURL(conf.BaseURL, true)
 	if err != nil {


### PR DESCRIPTION
## What changed
- export `Config` struct and `ConfigFromCache` loader
- add `Config.DialOptions()` method in place of old piecewise dial opts creation
## Why
Make logged-in token usable by additional tools
## Extra testing
This works:
```sh
go run ./cli/viam/ org list
```