### PR TITLE
RSDK-7797 Guard against nils in arm client and server 

### DIFF
--- a/components/arm/client.go
+++ b/components/arm/client.go
@@ -79,7 +79,7 @@ func (c *client) MoveToPosition(ctx context.Context, pose spatialmath.Pose, extr
 		return err
 	}
 	if pose == nil {
-		c.logger.Warnf("%s MoveToPosition: pose parameter is nil")
+		c.logger.Warnf("%s MoveToPosition: pose parameter is nil", c.name)
 	}
 	_, err = c.client.MoveToPosition(ctx, &pb.MoveToPositionRequest{
 		Name:  c.name,
@@ -95,7 +95,7 @@ func (c *client) MoveToJointPositions(ctx context.Context, positions *pb.JointPo
 		return err
 	}
 	if positions == nil {
-		c.logger.Warnf("%s MoveToJointPositions: position parameter is nil")
+		c.logger.Warnf("%s MoveToJointPositions: position parameter is nil", c.name)
 	}
 	_, err = c.client.MoveToJointPositions(ctx, &pb.MoveToJointPositionsRequest{
 		Name:      c.name,

--- a/components/arm/client.go
+++ b/components/arm/client.go
@@ -78,6 +78,9 @@ func (c *client) MoveToPosition(ctx context.Context, pose spatialmath.Pose, extr
 	if err != nil {
 		return err
 	}
+	if pose == nil {
+		c.logger.Warnf("%s MoveToPosition: pose parameter is nil")
+	}
 	_, err = c.client.MoveToPosition(ctx, &pb.MoveToPositionRequest{
 		Name:  c.name,
 		To:    spatialmath.PoseToProtobuf(pose),
@@ -90,6 +93,9 @@ func (c *client) MoveToJointPositions(ctx context.Context, positions *pb.JointPo
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return err
+	}
+	if positions == nil {
+		c.logger.Warnf("%s MoveToJointPositions: position parameter is nil")
 	}
 	_, err = c.client.MoveToJointPositions(ctx, &pb.MoveToJointPositionsRequest{
 		Name:      c.name,

--- a/components/arm/server.go
+++ b/components/arm/server.go
@@ -41,6 +41,12 @@ func (s *serviceServer) GetEndPosition(
 	if err != nil {
 		return nil, err
 	}
+	// Return default value if the position returned is nil.
+	if pos == nil {
+		pose := &commonpb.Pose{}
+		return &pb.GetEndPositionResponse{Pose: pose}, nil
+	}
+
 	return &pb.GetEndPositionResponse{Pose: spatialmath.PoseToProtobuf(pos)}, nil
 }
 
@@ -57,7 +63,11 @@ func (s *serviceServer) GetJointPositions(
 	if err != nil {
 		return nil, err
 	}
-	convertedPos := &pb.JointPositions{Values: pos.Values}
+	// Have a default empty joint postions in case the position returned is nil.
+	convertedPos := &pb.JointPositions{Values: []float64{}}
+	if pos != nil {
+		convertedPos.Values = pos.Values
+	}
 	return &pb.GetJointPositionsResponse{Positions: convertedPos}, nil
 }
 

--- a/components/arm/server.go
+++ b/components/arm/server.go
@@ -41,7 +41,8 @@ func (s *serviceServer) GetEndPosition(
 	if err != nil {
 		return nil, err
 	}
-	// Return default value if the position returned is nil.
+	// Return a default empty value if the position returned is nil,
+	// this guards against nil objects being transferred over the wire.
 	if pos == nil {
 		pose := &commonpb.Pose{}
 		return &pb.GetEndPositionResponse{Pose: pose}, nil
@@ -63,7 +64,8 @@ func (s *serviceServer) GetJointPositions(
 	if err != nil {
 		return nil, err
 	}
-	// Have a default empty joint postions in case the position returned is nil.
+	// Have a default empty joint position object in case the position returned is nil,
+	// this guards against nil objects being transferred over the wire.
 	convertedPos := &pb.JointPositions{Values: []float64{}}
 	if pos != nil {
 		convertedPos.Values = pos.Values

--- a/components/arm/server_test.go
+++ b/components/arm/server_test.go
@@ -126,6 +126,14 @@ func TestServer(t *testing.T) {
 		_, err = armServer.GetEndPosition(context.Background(), &pb.GetEndPositionRequest{Name: failArmName})
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errGetPoseFailed.Error())
+
+		// Redefine EndPositionFunc to test nil return.
+		injectArm.EndPositionFunc = func(ctx context.Context, extra map[string]interface{}) (spatialmath.Pose, error) {
+			return nil, nil
+		}
+		resp, err = armServer.GetEndPosition(context.Background(), &pb.GetEndPositionRequest{Name: testArmName})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, resp.Pose, test.ShouldResemble, &commonpb.Pose{})
 	})
 
 	t.Run("move to position", func(t *testing.T) {
@@ -164,6 +172,14 @@ func TestServer(t *testing.T) {
 		_, err = armServer.GetJointPositions(context.Background(), &pb.GetJointPositionsRequest{Name: failArmName})
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errGetJointsFailed.Error())
+
+		// Redefine JointPositionsFunc to test nil return.
+		injectArm.JointPositionsFunc = func(ctx context.Context, extra map[string]interface{}) (*pb.JointPositions, error) {
+			return nil, nil
+		}
+		resp, err = armServer.GetJointPositions(context.Background(), &pb.GetJointPositionsRequest{Name: testArmName})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, resp.Positions.Values, test.ShouldResemble, []float64{})
 	})
 
 	t.Run("move to joint position", func(t *testing.T) {

--- a/components/arm/server_test.go
+++ b/components/arm/server_test.go
@@ -174,6 +174,7 @@ func TestServer(t *testing.T) {
 		test.That(t, err.Error(), test.ShouldContainSubstring, errGetJointsFailed.Error())
 
 		// Redefine JointPositionsFunc to test nil return.
+		//nolint: nilnil
 		injectArm.JointPositionsFunc = func(ctx context.Context, extra map[string]interface{}) (*pb.JointPositions, error) {
 			return nil, nil
 		}


### PR DESCRIPTION
`empty-arm` in fake components module now shows up correctly on the RC card 