### PR TITLE
RSDK-7786 optional shared ClientConn param in NetAppender

### DIFF
--- a/logging/net_appender.go
+++ b/logging/net_appender.go
@@ -33,14 +33,19 @@ type CloudConfig struct {
 
 // NewNetAppender creates a NetAppender to send log events to the app backend. NetAppenders ought to
 // be `Close`d prior to shutdown to flush remaining logs.
-func NewNetAppender(config *CloudConfig) (*NetAppender, error) {
+// Pass `nil` for `conn` if you want this to create its own connection.
+func NewNetAppender(config *CloudConfig, conn rpc.ClientConn) (*NetAppender, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return nil, err
 	}
 
 	logWriter := &remoteLogWriterGRPC{
-		cfg: config,
+		cfg:       config,
+		rpcClient: conn,
+	}
+	if conn != nil {
+		logWriter.service = apppb.NewRobotServiceClient(conn)
 	}
 
 	cancelCtx, cancel := context.WithCancel(context.Background())

--- a/logging/net_appender_test.go
+++ b/logging/net_appender_test.go
@@ -107,7 +107,7 @@ func TestNetLoggerSync(t *testing.T) {
 	server := makeServerForRobotLogger(t)
 	defer server.stop()
 
-	netAppender, err := NewNetAppender(server.cloudConfig)
+	netAppender, err := NewNetAppender(server.cloudConfig, nil)
 	test.That(t, err, test.ShouldBeNil)
 
 	// This test is testing the behavior of sync(), so the background worker shouldn't be running at the same time.
@@ -139,7 +139,7 @@ func TestNetLoggerSyncFailureAndRetry(t *testing.T) {
 	server := makeServerForRobotLogger(t)
 	defer server.stop()
 
-	netAppender, err := NewNetAppender(server.cloudConfig)
+	netAppender, err := NewNetAppender(server.cloudConfig, nil)
 	test.That(t, err, test.ShouldBeNil)
 
 	// This test is testing the behavior of sync(), so the background worker shouldn't be running at the same time.
@@ -193,7 +193,7 @@ func TestNetLoggerOverflowDuringWrite(t *testing.T) {
 	server := makeServerForRobotLogger(t)
 	defer server.stop()
 
-	netAppender, err := NewNetAppender(server.cloudConfig)
+	netAppender, err := NewNetAppender(server.cloudConfig, nil)
 	test.That(t, err, test.ShouldBeNil)
 	logger := NewDebugLogger("test logger")
 	logger.AddAppender(netAppender)

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -147,6 +147,7 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 				ID:         cfgFromDisk.Cloud.ID,
 				Secret:     cfgFromDisk.Cloud.Secret,
 			},
+			nil,
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
## What changed
- the `NewNetAppender` constructor now has an optional `conn` param which allows it to share a ClientConn
## Why
Conserve and share resources used at runtime, esp as we duplicate this for viam-agent. Agent's Manager object already keeps a long-lived connection [here](https://github.com/viamrobotics/agent/blob/8848c83f11c02655ccb1ec8ac5f7fad0b406df29/manager.go#L383), no need to add another.