### PR TITLE
Change fake encoder's position calculations to use floats

### DIFF
--- a/components/encoder/fake/encoder.go
+++ b/components/encoder/fake/encoder.go
@@ -104,7 +104,7 @@ func (e *fakeEncoder) Position(
 	}
 	e.mu.RLock()
 	defer e.mu.RUnlock()
-	return float64(e.position), e.positionType, nil
+	return e.position, e.positionType, nil
 }
 
 // Start starts a background thread to run the encoder.

--- a/components/encoder/fake/encoder.go
+++ b/components/encoder/fake/encoder.go
@@ -104,7 +104,6 @@ func (e *fakeEncoder) Position(
 	}
 	e.mu.RLock()
 	defer e.mu.RUnlock()
-	e.logger.Infof("position %v", e.position)
 	return float64(e.position), e.positionType, nil
 }
 
@@ -128,7 +127,6 @@ func (e *fakeEncoder) start(cancelCtx context.Context) {
 
 			e.mu.Lock()
 			e.position += e.speed / float64(60*1000/updateRate)
-			e.logger.Infof("speed %v, update rate %v, position %v", e.speed, updateRate, e.position)
 			e.mu.Unlock()
 		}
 	}, e.activeBackgroundWorkers.Done)

--- a/components/encoder/fake/encoder.go
+++ b/components/encoder/fake/encoder.go
@@ -87,7 +87,7 @@ type fakeEncoder struct {
 	logger                  logging.Logger
 
 	mu         sync.RWMutex
-	position   int64
+	position   float64
 	speed      float64 // ticks per minute
 	updateRate int64   // update position in start every updateRate ms
 }
@@ -104,6 +104,7 @@ func (e *fakeEncoder) Position(
 	}
 	e.mu.RLock()
 	defer e.mu.RUnlock()
+	e.logger.Infof("position %v", e.position)
 	return float64(e.position), e.positionType, nil
 }
 
@@ -126,7 +127,8 @@ func (e *fakeEncoder) start(cancelCtx context.Context) {
 			}
 
 			e.mu.Lock()
-			e.position += int64(e.speed / float64(60*1000/updateRate))
+			e.position += e.speed / float64(60*1000/updateRate)
+			e.logger.Infof("speed %v, update rate %v, position %v", e.speed, updateRate, e.position)
 			e.mu.Unlock()
 		}
 	}, e.activeBackgroundWorkers.Done)
@@ -137,7 +139,7 @@ func (e *fakeEncoder) start(cancelCtx context.Context) {
 func (e *fakeEncoder) ResetPosition(ctx context.Context, extra map[string]interface{}) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	e.position = int64(0)
+	e.position = 0
 	return nil
 }
 
@@ -153,7 +155,7 @@ func (e *fakeEncoder) Properties(ctx context.Context, extra map[string]interface
 type Encoder interface {
 	encoder.Encoder
 	SetSpeed(ctx context.Context, speed float64) error
-	SetPosition(ctx context.Context, position int64) error
+	SetPosition(ctx context.Context, position float64) error
 }
 
 // SetSpeed sets the speed of the fake motor the encoder is measuring.
@@ -165,7 +167,7 @@ func (e *fakeEncoder) SetSpeed(ctx context.Context, speed float64) error {
 }
 
 // SetPosition sets the position of the encoder.
-func (e *fakeEncoder) SetPosition(ctx context.Context, position int64) error {
+func (e *fakeEncoder) SetPosition(ctx context.Context, position float64) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.position = position

--- a/components/motor/fake/motor.go
+++ b/components/motor/fake/motor.go
@@ -313,7 +313,7 @@ func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[s
 		}
 
 		if m.Encoder != nil {
-			return m.Encoder.SetPosition(ctx, int64(finalPos*float64(m.TicksPerRotation)))
+			return m.Encoder.SetPosition(ctx, finalPos*float64(m.TicksPerRotation))
 		}
 	}
 	return nil
@@ -360,7 +360,7 @@ func (m *Motor) GoTo(ctx context.Context, rpm, pos float64, extra map[string]int
 			return err
 		}
 
-		return m.Encoder.SetPosition(ctx, int64(pos*float64(m.TicksPerRotation)))
+		return m.Encoder.SetPosition(ctx, pos*float64(m.TicksPerRotation))
 	}
 
 	return nil
@@ -397,7 +397,7 @@ func (m *Motor) ResetZeroPosition(ctx context.Context, offset float64, extra map
 		return errors.New("need nonzero TicksPerRotation for motor")
 	}
 
-	err := m.Encoder.SetPosition(ctx, int64(-1*offset))
+	err := m.Encoder.SetPosition(ctx, -1*offset)
 	if err != nil {
 		return errors.Wrapf(err, "error in ResetZeroPosition from motor (%s)", m.Name())
 	}

--- a/components/motor/fake/motor_test.go
+++ b/components/motor/fake/motor_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"go.viam.com/test"
 	"go.viam.com/utils/testutils"
@@ -180,4 +181,27 @@ func TestPower(t *testing.T) {
 
 	powerPct = m.PowerPct()
 	test.That(t, powerPct, test.ShouldEqual, 0.0)
+}
+
+func TestGoFor2(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	ctx := context.Background()
+
+	enc, err := fake.NewEncoder(context.Background(), resource.Config{
+		ConvertedAttributes: &fake.Config{},
+	}, logger)
+	test.That(t, err, test.ShouldBeNil)
+	m := &Motor{
+		Encoder:           enc.(fake.Encoder),
+		Logger:            logger,
+		PositionReporting: true,
+		MaxRPM:            1000,
+		TicksPerRotation:  10,
+		OpMgr:             operation.NewSingleOperationManager(),
+	}
+
+	for i := 0; i <= 20; i++ {
+		err = m.GoFor(ctx, 102.53338, 0, nil)
+		time.Sleep(500 * time.Millisecond)
+	}
 }

--- a/components/motor/fake/motor_test.go
+++ b/components/motor/fake/motor_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"go.viam.com/test"
 	"go.viam.com/utils/testutils"
@@ -181,27 +180,4 @@ func TestPower(t *testing.T) {
 
 	powerPct = m.PowerPct()
 	test.That(t, powerPct, test.ShouldEqual, 0.0)
-}
-
-func TestGoFor2(t *testing.T) {
-	logger := logging.NewTestLogger(t)
-	ctx := context.Background()
-
-	enc, err := fake.NewEncoder(context.Background(), resource.Config{
-		ConvertedAttributes: &fake.Config{},
-	}, logger)
-	test.That(t, err, test.ShouldBeNil)
-	m := &Motor{
-		Encoder:           enc.(fake.Encoder),
-		Logger:            logger,
-		PositionReporting: true,
-		MaxRPM:            1000,
-		TicksPerRotation:  10,
-		OpMgr:             operation.NewSingleOperationManager(),
-	}
-
-	for i := 0; i <= 20; i++ {
-		err = m.GoFor(ctx, 102.53338, 0, nil)
-		time.Sleep(500 * time.Millisecond)
-	}
 }


### PR DESCRIPTION
@biotinker was trying to use the fake motor and fake encoder to set up a wheeled odometer for testing in the nav stack. Casting the position in the encoder struct to an integer and Setting the Position in the fake encoder to an integer was accruing massive errors. This pr does away with unnecessary conversions.

Example output before change
```
    encoder.go:107: 2024-06-05T15:22:11.679-0400	INFO		fake/encoder.go:107	position 0
    motor.go:209: 2024-06-05T15:22:11.680-0400	DEBUG		fake/motor.go:209	Motor SetPower 0.102533
    encoder.go:131: 2024-06-05T15:22:11.780-0400	INFO		fake/encoder.go:131	speed 1025.3337999999999, update rate 100, position 1
    encoder.go:131: 2024-06-05T15:22:11.881-0400	INFO		fake/encoder.go:131	speed 1025.3337999999999, update rate 100, position 2
    encoder.go:131: 2024-06-05T15:22:11.982-0400	INFO		fake/encoder.go:131	speed 1025.3337999999999, update rate 100, position 3
    encoder.go:131: 2024-06-05T15:22:12.084-0400	INFO		fake/encoder.go:131	speed 1025.3337999999999, update rate 100, position 4
    encoder.go:107: 2024-06-05T15:22:12.180-0400	INFO		fake/encoder.go:107	position 4
```

Example output after change
```
    encoder.go:107: 2024-06-05T15:34:32.988-0400	INFO		fake/encoder.go:107	position 0
    motor.go:209: 2024-06-05T15:34:32.989-0400	DEBUG		fake/motor.go:209	Motor SetPower 0.102533
    encoder.go:131: 2024-06-05T15:34:33.089-0400	INFO		fake/encoder.go:131	speed 1025.3337999999999, update rate 100, position 1.7088896666666664
    encoder.go:131: 2024-06-05T15:34:33.190-0400	INFO		fake/encoder.go:131	speed 1025.3337999999999, update rate 100, position 3.417779333333333
    encoder.go:131: 2024-06-05T15:34:33.292-0400	INFO		fake/encoder.go:131	speed 1025.3337999999999, update rate 100, position 5.126669
    encoder.go:131: 2024-06-05T15:34:33.392-0400	INFO		fake/encoder.go:131	speed 1025.3337999999999, update rate 100, position 6.835558666666666
    encoder.go:107: 2024-06-05T15:34:33.490-0400	INFO		fake/encoder.go:107	position 6.835558666666666
    motor.go:209: 2024-06-05T15:34:33.490-0400	DEBUG		fake/motor.go:209	Motor SetPower 0.102533
```
 