### PR TITLE
RSDK-7829: Make shutdown error handling more robust

### DIFF
--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -991,8 +991,7 @@ func (rc *RobotClient) RestartModule(ctx context.Context, req robot.RestartModul
 	return nil
 }
 
-// Shutdown shuts down the robot. Will return "shutdown function not defined" error if
-// shutdown callback is not specified in robot options.
+// Shutdown shuts down the robot.
 func (rc *RobotClient) Shutdown(ctx context.Context) error {
 	reqPb := &pb.ShutdownRequest{}
 	_, err := rc.client.Shutdown(ctx, reqPb)

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -999,7 +999,7 @@ func (rc *RobotClient) Shutdown(ctx context.Context) error {
 	_, err := rc.client.Shutdown(ctx, reqPb)
 	if err != nil {
 		if status, ok := status.FromError(err); ok {
-			switch status.Code() {
+			switch status.Code() { //nolint:exhaustive
 			case codes.Internal, codes.Unknown:
 				rc.Logger().CInfow(ctx, "robot shutdown successful")
 				return nil
@@ -1009,10 +1009,6 @@ func (rc *RobotClient) Shutdown(ctx context.Context) error {
 			case codes.DeadlineExceeded:
 				rc.Logger().CWarnw(ctx, "request timeout, robot shutdown may still be successful")
 				return err
-			case codes.OK, codes.Aborted, codes.AlreadyExists, codes.Canceled, codes.DataLoss,
-				codes.FailedPrecondition, codes.InvalidArgument, codes.NotFound, codes.PermissionDenied,
-				codes.ResourceExhausted, codes.OutOfRange, codes.Unimplemented, codes.Unauthenticated:
-				return err
 			default:
 				return err
 			}
@@ -1020,5 +1016,6 @@ func (rc *RobotClient) Shutdown(ctx context.Context) error {
 			return err
 		}
 	}
+	rc.Logger().CInfow(ctx, "robot shutdown successful")
 	return nil
 }

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -997,18 +997,21 @@ func (rc *RobotClient) Shutdown(ctx context.Context) error {
 	reqPb := &pb.ShutdownRequest{}
 	_, err := rc.client.Shutdown(ctx, reqPb)
 	if err != nil {
-		status, _ := status.FromError(err)
-		switch status.Code().String() {
-		case "Unavailable", "Internal", "Unknown":
-			rc.Logger().CInfow(ctx, "robot shutdown successful")
-			return nil
-		case "DeadlineExceeded":
-			rc.Logger().CWarnw(ctx, "request timeout, robot shutdown may still be successful")
-			return err
-		default:
+		status, ok := status.FromError(err)
+		if ok {
+			switch status.Code().String() {
+			case "Unavailable", "Internal", "Unknown":
+				rc.Logger().CInfow(ctx, "robot shutdown successful")
+				return nil
+			case "DeadlineExceeded":
+				rc.Logger().CWarnw(ctx, "request timeout, robot shutdown may still be successful")
+				return err
+			default:
+				return err
+			}
+		} else {
 			return err
 		}
 	}
-
 	return nil
 }

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -1305,10 +1305,10 @@ func (r *localRobot) RestartModule(ctx context.Context, req robot.RestartModuleR
 }
 
 func (r *localRobot) Shutdown(ctx context.Context) error {
-	shutdownFunc := r.shutdownCallback
-	if shutdownFunc != nil {
+	if shutdownFunc := r.shutdownCallback; shutdownFunc != nil {
 		shutdownFunc()
-		return nil
+	} else {
+		r.Logger().CErrorw(ctx, "shutdown function not defined")
 	}
-	return errors.New("shutdown function not defined")
+	return nil
 }

--- a/web/server/entrypoint_test.go
+++ b/web/server/entrypoint_test.go
@@ -10,12 +10,14 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/invopop/jsonschema"
 	"go.uber.org/zap/zapcore"
 	robotpb "go.viam.com/api/robot/v1"
 	"go.viam.com/test"
 	goutils "go.viam.com/utils"
+	"go.viam.com/utils/pexec"
 
 	_ "go.viam.com/rdk/components/register"
 	"go.viam.com/rdk/config"
@@ -25,6 +27,7 @@ import (
 	"go.viam.com/rdk/testutils"
 	"go.viam.com/rdk/testutils/robottestutils"
 	"go.viam.com/rdk/utils"
+	gtestutils "go.viam.com/utils/testutils"
 )
 
 // numResources is the # of resources in /etc/configs/fake.json + the 2
@@ -122,6 +125,7 @@ func TestShutdown(t *testing.T) {
 
 		var port int
 		var success bool
+		var server pexec.ManagedProcess
 		for portTryNum := 0; portTryNum < 10; portTryNum++ {
 			p, err := goutils.TryReserveRandomPort()
 			port = p
@@ -131,7 +135,7 @@ func TestShutdown(t *testing.T) {
 			cfgFilename, err = robottestutils.MakeTempConfig(t, cfg, logger)
 			test.That(t, err, test.ShouldBeNil)
 
-			server := robottestutils.ServerAsSeparateProcess(t, cfgFilename, logger)
+			server = robottestutils.ServerAsSeparateProcess(t, cfgFilename, logger)
 
 			err = server.Start(context.Background())
 			test.That(t, err, test.ShouldBeNil)
@@ -156,7 +160,13 @@ func TestShutdown(t *testing.T) {
 		rc := robotpb.NewRobotServiceClient(conn)
 
 		_, err = rc.Shutdown(context.Background(), &robotpb.ShutdownRequest{})
-		test.That(t, err, test.ShouldBeNil)
+
+		gtestutils.WaitForAssertionWithSleep(t, 50*time.Millisecond, 50, func(tb testing.TB) {
+			tb.Helper()
+			rdkStatus := server.Status()
+			test.That(tb, rdkStatus, test.ShouldNotBeNil)
+		})
+		test.That(t, (err == nil || err.Error() == "rpc error: code = Internal desc = server closed the stream without sending trailers"), test.ShouldBeTrue)
 		test.That(t, logObserver.FilterLevelExact(zapcore.ErrorLevel).Len(), test.ShouldEqual, 0)
 	})
 }

--- a/web/server/entrypoint_test.go
+++ b/web/server/entrypoint_test.go
@@ -166,8 +166,8 @@ func TestShutdown(t *testing.T) {
 			rdkStatus := server.Status()
 			test.That(tb, rdkStatus, test.ShouldNotBeNil)
 		})
-		test.That(t, (err == nil || err.Error() == `rpc error: code = Internal desc = server 
-			closed the stream without sending trailers`), test.ShouldBeTrue)
+		test.That(t, (err == nil || err.Error() == `rpc error: code = DeadlineExceeded 
+			desc = context deadline exceeded`), test.ShouldBeTrue)
 		test.That(t, logObserver.FilterLevelExact(zapcore.ErrorLevel).Len(), test.ShouldEqual, 0)
 	})
 }

--- a/web/server/entrypoint_test.go
+++ b/web/server/entrypoint_test.go
@@ -18,6 +18,7 @@ import (
 	"go.viam.com/test"
 	goutils "go.viam.com/utils"
 	"go.viam.com/utils/pexec"
+	gtestutils "go.viam.com/utils/testutils"
 
 	_ "go.viam.com/rdk/components/register"
 	"go.viam.com/rdk/config"
@@ -27,7 +28,6 @@ import (
 	"go.viam.com/rdk/testutils"
 	"go.viam.com/rdk/testutils/robottestutils"
 	"go.viam.com/rdk/utils"
-	gtestutils "go.viam.com/utils/testutils"
 )
 
 // numResources is the # of resources in /etc/configs/fake.json + the 2
@@ -166,7 +166,8 @@ func TestShutdown(t *testing.T) {
 			rdkStatus := server.Status()
 			test.That(tb, rdkStatus, test.ShouldNotBeNil)
 		})
-		test.That(t, (err == nil || err.Error() == "rpc error: code = Internal desc = server closed the stream without sending trailers"), test.ShouldBeTrue)
+		test.That(t, (err == nil || err.Error() == `rpc error: code = Internal desc = server 
+			closed the stream without sending trailers`), test.ShouldBeTrue)
 		test.That(t, logObserver.FilterLevelExact(zapcore.ErrorLevel).Len(), test.ShouldEqual, 0)
 	})
 }

--- a/web/server/entrypoint_test.go
+++ b/web/server/entrypoint_test.go
@@ -164,6 +164,7 @@ func TestShutdown(t *testing.T) {
 		gtestutils.WaitForAssertionWithSleep(t, 50*time.Millisecond, 50, func(tb testing.TB) {
 			tb.Helper()
 			rdkStatus := server.Status()
+			// Asserting not nil here to ensure process is dead
 			test.That(tb, rdkStatus, test.ShouldNotBeNil)
 		})
 		test.That(t, (err == nil || err.Error() == `rpc error: code = DeadlineExceeded 


### PR DESCRIPTION
### Description
[RSDK-7829](https://viam.atlassian.net/browse/RSDK-7829): `TestShutdown()` failure in `entrypoint_test.go`
* This test was previously flaky because the client would send a `ShutdownRequest` and the `ShutdownResponse` was not guaranteed to make it back as the robot and server shutdown, potentially throwing a variety grpc errors.
  * To fix this, `Shutdown()` returns `nil` if it recieves `nil` or a grpc error with one of the following codes: `Unavailable`, `Internal`, or `Unknown`. 
    * These were decided based on the potential circumstances that may occur at shutdown described by the [grpc error code docs](https://grpc.github.io/grpc/core/md_doc_statuscodes.html)
  * This is unavoidable; we cannot guarantee a non-error response will be returned, and depending on shutdown timing and the state of the server when `Shutdown()` returns, it may send a full response or error due to an incomplete response or no response at all.
 * Test is made more robust by ensuring the the RDK server process is killed after calling `Shutdown()` and checking that either no error or a `DeadlineExceeded` error is returned. 
   * It seems impossible to differentiate between a real request timeout and a timeout because the server shutdown before sending a response, so this is an acceptable error to recieve. In the case of an actual timeout, we would want to return this error to the user. 
 * Also refactors `local_robot.go` `Shutdown()` to show an error log when the shutdown function is not defined instead of returning an error since we can't guarantee the error will actually end up being returned.

[RSDK-7829]: https://viam.atlassian.net/browse/RSDK-7829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ