### PR TITLE
move overnight + test32 jobs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,12 +25,12 @@ jobs:
           platform: linux/amd64
           image: rdk-devenv
           file: etc/Dockerfile.cache
-        - arch: buildjet-4vcpu-ubuntu-2204-arm
+        - arch: github-linux-arm64-4core
           tag: arm64
           platform: linux/arm64
           image: rdk-devenv
           file: etc/Dockerfile.cache
-        - arch: buildjet-2vcpu-ubuntu-2204-arm
+        - arch: github-linux-arm64-2core
           tag: armhf
           platform: linux/arm/v7
           image: rdk-devenv
@@ -41,12 +41,12 @@ jobs:
           image: antique2
           file: etc/Dockerfile.antique-cache
           tag: amd64
-        - arch: buildjet-2vcpu-ubuntu-2204-arm
+        - arch: github-linux-arm64-2core
           platform: linux/arm64
           image: antique2
           file: etc/Dockerfile.antique-cache
           tag: arm64
-        - arch: buildjet-2vcpu-ubuntu-2204-arm
+        - arch: github-linux-arm64-2core
           platform: linux/arm/v7
           image: antique2
           file: etc/Dockerfile.antique-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,7 +156,7 @@ jobs:
 
   test32:
     name: Go 32-bit Unit Tests
-    runs-on: [buildjet-8vcpu-ubuntu-2204-arm]
+    runs-on: github-linux-arm64-8core
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
## What changed
- test new runners with docker.yml arm jobs + `test32` job
## Why
Test new infra
## Runs
- successful docker.yml run [here](https://github.com/viamrobotics/rdk/actions/runs/9405587339)