### PR TITLE
RSDK-7831 support meta.json inside tarball

### DIFF
--- a/config/module.go
+++ b/config/module.go
@@ -141,8 +141,8 @@ func (m Module) exeDir(packagesDir string) (string, error) {
 	return pkg.LocalDataDirectory(packagesDir), nil
 }
 
-// parseJSONPath returns a *T by parsing the json file at `path`.
-func parseJSONPath[T any](path string) (*T, error) {
+// parseJSONFile returns a *T by parsing the json file at `path`.
+func parseJSONFile[T any](path string) (*T, error) {
 	f, err := os.Open(path) //nolint:gosec
 	if err != nil {
 		return nil, errors.Wrap(err, "reading json file")
@@ -179,7 +179,7 @@ func (m Module) EvaluateExePath(packagesDir string) (string, error) {
 		_, err = os.Stat(metaPath)
 		if err == nil {
 			// this is case 1, meta.json in exe dir
-			meta, err := parseJSONPath[JSONManifest](metaPath)
+			meta, err := parseJSONFile[JSONManifest](metaPath)
 			if err != nil {
 				return "", err
 			}
@@ -197,7 +197,7 @@ func (m Module) EvaluateExePath(packagesDir string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		meta, err := parseJSONPath[JSONManifest](metaPath)
+		meta, err := parseJSONFile[JSONManifest](metaPath)
 		if err != nil {
 			return "", errors.Wrap(err, "loading side-by-side meta.json")
 		}

--- a/config/module.go
+++ b/config/module.go
@@ -168,15 +168,15 @@ func (m Module) EvaluateExePath(packagesDir string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	metaPath, err := utils.SafeJoinDir(exeDir, "meta.json")
-	if err != nil {
-		return "", err
-	}
 	// note: we don't look at internal meta.json in local non-tarball case because user has explicitly requested a binary.
 	localNonTarball := m.Type == ModuleTypeLocal && !m.NeedsSyntheticPackage()
 	if !localNonTarball {
 		// this is case 1, meta.json in exe folder.
-		_, err := os.Stat(metaPath)
+		metaPath, err := utils.SafeJoinDir(exeDir, "meta.json")
+		if err != nil {
+			return "", err
+		}
+		_, err = os.Stat(metaPath)
 		if err == nil {
 			// this is case 1, meta.json in exe dir
 			meta, err := parseJSONPath[JSONManifest](metaPath)
@@ -193,13 +193,13 @@ func (m Module) EvaluateExePath(packagesDir string) (string, error) {
 	if m.NeedsSyntheticPackage() {
 		// this is case 2, side-by-side
 		// TODO(RSDK-7848): remove this case once java sdk supports internal meta.json.
+		metaPath, err := utils.SafeJoinDir(filepath.Dir(m.ExePath), "meta.json")
+		if err != nil {
+			return "", err
+		}
 		meta, err := parseJSONPath[JSONManifest](metaPath)
 		if err != nil {
 			return "", errors.Wrap(err, "loading side-by-side meta.json")
-		}
-		exeDir, err := m.exeDir(packagesDir)
-		if err != nil {
-			return "", err
 		}
 		entrypoint, err := utils.SafeJoinDir(exeDir, meta.Entrypoint)
 		if err != nil {

--- a/config/module_test.go
+++ b/config/module_test.go
@@ -74,7 +74,7 @@ func TestSyntheticModule(t *testing.T) {
 	})
 
 	t.Run("syntheticPackageExeDir", func(t *testing.T) {
-		dir, err := modNeedsSynthetic.syntheticPackageExeDir(tmp)
+		dir, err := modNeedsSynthetic.exeDir(tmp)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, dir, test.ShouldEqual, filepath.Join(tmp, "data/module/synthetic--"))
 	})
@@ -88,7 +88,7 @@ func TestSyntheticModule(t *testing.T) {
 		// local tarball case
 		syntheticPath, err := modNeedsSynthetic.EvaluateExePath(tmp)
 		test.That(t, err, test.ShouldBeNil)
-		exeDir, err := modNeedsSynthetic.syntheticPackageExeDir(tmp)
+		exeDir, err := modNeedsSynthetic.exeDir(tmp)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, syntheticPath, test.ShouldEqual, filepath.Join(exeDir, meta.Entrypoint))
 

--- a/config/module_test.go
+++ b/config/module_test.go
@@ -23,15 +23,18 @@ func TestInternalMeta(t *testing.T) {
 	tmp := t.TempDir()
 	testChdir(t, tmp)
 	testWriteJSON(t, "meta.json", JSONManifest{Entrypoint: "entry"})
+	packagesDir := filepath.Join(tmp, "packages")
 	t.Run("local-tarball", func(t *testing.T) {
 		mod := Module{
 			Type:    ModuleTypeLocal,
 			ExePath: filepath.Join(tmp, "whatever.tar.gz"),
 		}
-		exePath, err := mod.EvaluateExePath("doesnt-matter")
+		exePath, err := mod.EvaluateExePath(packagesDir)
+		test.That(t, err, test.ShouldBeNil)
+		exeDir, err := mod.exeDir(packagesDir)
 		test.That(t, err, test.ShouldBeNil)
 		// "entry" is from meta.json.
-		test.That(t, exePath, test.ShouldEqual, filepath.Join(tmp, "entry"))
+		test.That(t, exePath, test.ShouldEqual, filepath.Join(exeDir, "entry"))
 	})
 
 	t.Run("non-tarball", func(t *testing.T) {
@@ -39,7 +42,7 @@ func TestInternalMeta(t *testing.T) {
 			Type:    ModuleTypeLocal,
 			ExePath: filepath.Join(tmp, "whatever"),
 		}
-		exePath, err := mod.EvaluateExePath("doesnt-matter")
+		exePath, err := mod.EvaluateExePath(packagesDir)
 		test.That(t, err, test.ShouldBeNil)
 		// "whatever" is from config.Module object.
 		test.That(t, exePath, test.ShouldEqual, filepath.Join(tmp, "whatever"))

--- a/config/module_test.go
+++ b/config/module_test.go
@@ -23,14 +23,27 @@ func TestInternalMeta(t *testing.T) {
 	tmp := t.TempDir()
 	testChdir(t, tmp)
 	testWriteJSON(t, "meta.json", JSONManifest{Entrypoint: "entry"})
-	mod := Module{
-		Type:    ModuleTypeLocal,
-		ExePath: filepath.Join(tmp, "whatever"),
-	}
-	exePath, err := mod.EvaluateExePath("doesnt-matter")
-	test.That(t, err, test.ShouldBeNil)
-	// note: this is testing that meta.json gets used *and* that it takes precedence.
-	test.That(t, exePath, test.ShouldEqual, filepath.Join(tmp, "entry"))
+	t.Run("local-tarball", func(t *testing.T) {
+		mod := Module{
+			Type:    ModuleTypeLocal,
+			ExePath: filepath.Join(tmp, "whatever.tar.gz"),
+		}
+		exePath, err := mod.EvaluateExePath("doesnt-matter")
+		test.That(t, err, test.ShouldBeNil)
+		// "entry" is from meta.json.
+		test.That(t, exePath, test.ShouldEqual, filepath.Join(tmp, "entry"))
+	})
+
+	t.Run("non-tarball", func(t *testing.T) {
+		mod := Module{
+			Type:    ModuleTypeLocal,
+			ExePath: filepath.Join(tmp, "whatever"),
+		}
+		exePath, err := mod.EvaluateExePath("doesnt-matter")
+		test.That(t, err, test.ShouldBeNil)
+		// "whatever" is from config.Module object.
+		test.That(t, exePath, test.ShouldEqual, filepath.Join(tmp, "whatever"))
+	})
 }
 
 func TestSyntheticModule(t *testing.T) {

--- a/module/concurrent_reconfigure_test.go
+++ b/module/concurrent_reconfigure_test.go
@@ -3,6 +3,7 @@ package module_test
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -22,11 +23,13 @@ func setupTestRobotWithModules(
 	ctx context.Context,
 	logger logging.Logger,
 ) (*config.Config, robot.LocalRobot) {
+	absPath, err := filepath.Abs("testmodule/run.sh")
+	test.That(t, err, test.ShouldBeNil)
 	cfg := &config.Config{
 		Modules: []config.Module{
 			{
 				Name:    "TestModule",
-				ExePath: "testmodule/run.sh",
+				ExePath: absPath,
 			},
 		},
 	}

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -266,11 +266,10 @@ func (mgr *Manager) add(ctx context.Context, conf config.Module) error {
 	var moduleDataDir string
 	// only set the module data directory if the parent dir is present (which it might not be during tests)
 	if mgr.moduleDataParentDir != "" {
-		moduleDataDir = filepath.Join(mgr.moduleDataParentDir, conf.Name)
-		// safety check to prevent exiting the moduleDataDirectory in case conf.Name ends up including characters like ".."
-		if !strings.HasPrefix(filepath.Clean(moduleDataDir), filepath.Clean(mgr.moduleDataParentDir)) {
-			return errors.Errorf("module %q would have a data directory %q outside of the module data directory %q",
-				conf.Name, moduleDataDir, mgr.moduleDataParentDir)
+		var err error
+		moduleDataDir, err = rutils.SafeJoinDir(mgr.moduleDataParentDir, conf.Name)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -267,6 +267,7 @@ func (mgr *Manager) add(ctx context.Context, conf config.Module) error {
 	// only set the module data directory if the parent dir is present (which it might not be during tests)
 	if mgr.moduleDataParentDir != "" {
 		var err error
+		// todo: why isn't conf.Name being sanitized like PackageConfig.SanitizedName?
 		moduleDataDir, err = rutils.SafeJoinDir(mgr.moduleDataParentDir, conf.Name)
 		if err != nil {
 			return err

--- a/module/version_reconfigure_test.go
+++ b/module/version_reconfigure_test.go
@@ -2,6 +2,7 @@ package module_test
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"go.viam.com/test"
@@ -22,11 +23,13 @@ func TestValidationFailureDuringReconfiguration(t *testing.T) {
 	ctx := context.Background()
 	logger, logs := logging.NewObservedTestLogger(t)
 
+	absPath, err := filepath.Abs("multiversionmodule/run_version1.sh")
+	test.That(t, err, test.ShouldBeNil)
 	cfg := &config.Config{
 		Modules: []config.Module{
 			{
 				Name:     "AcmeModule",
-				ExePath:  "multiversionmodule/run_version1.sh",
+				ExePath:  absPath,
 				LogLevel: "debug",
 			},
 		},
@@ -94,11 +97,13 @@ func TestVersionBumpWithNewImplicitDeps(t *testing.T) {
 	ctx := context.Background()
 	logger, logs := logging.NewObservedTestLogger(t)
 
+	absPath, err := filepath.Abs("multiversionmodule/run_version1.sh")
+	test.That(t, err, test.ShouldBeNil)
 	cfg := &config.Config{
 		Modules: []config.Module{
 			{
 				Name:     "AcmeModule",
-				ExePath:  "multiversionmodule/run_version1.sh",
+				ExePath:  absPath,
 				LogLevel: "debug",
 			},
 		},

--- a/robot/packages/cloud_package_manager_test.go
+++ b/robot/packages/cloud_package_manager_test.go
@@ -450,27 +450,6 @@ func isSymLink(t *testing.T, file string) bool {
 	return fileInfo.Mode()&os.ModeSymlink != 0
 }
 
-func TestSafeJoin(t *testing.T) {
-	parentDir := "/some/parent"
-
-	validate := func(in, expectedOut string, expectedErr error) {
-		t.Helper()
-
-		out, err := safeJoin(parentDir, in)
-		if expectedErr == nil {
-			test.That(t, err, test.ShouldBeNil)
-			test.That(t, out, test.ShouldEqual, expectedOut)
-		} else {
-			test.That(t, err, test.ShouldNotBeNil)
-			test.That(t, err.Error(), test.ShouldContainSubstring, expectedErr.Error())
-		}
-	}
-
-	validate("sub/dir", "/some/parent/sub/dir", nil)
-	validate("/other/parent", "/some/parent/other/parent", nil)
-	validate("../../../root", "", errors.New("unsafe path join"))
-}
-
 func TestSafeLink(t *testing.T) {
 	parentDir := "/some/parent"
 

--- a/robot/packages/utils.go
+++ b/robot/packages/utils.go
@@ -16,6 +16,7 @@ import (
 
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/logging"
+	rutils "go.viam.com/rdk/utils"
 )
 
 // installCallback is the function signature that gets passed to installPackage.
@@ -42,7 +43,7 @@ func installPackage(ctx context.Context, logger logging.Logger, packagesDir, url
 	}
 
 	if p.Type == config.PackageTypeMlModel {
-		symlinkPath, err := safeJoin(packagesDir, p.Name)
+		symlinkPath, err := rutils.SafeJoinDir(packagesDir, p.Name)
 		if err == nil {
 			if err := os.Remove(symlinkPath); err != nil {
 				utils.UncheckedError(err)
@@ -148,7 +149,7 @@ func unpackFile(ctx context.Context, fromFile, toDir string) error {
 			continue
 		}
 
-		if path, err = safeJoin(toDir, path); err != nil {
+		if path, err = rutils.SafeJoinDir(toDir, path); err != nil {
 			return err
 		}
 
@@ -168,7 +169,7 @@ func unpackFile(ctx context.Context, fromFile, toDir string) error {
 			if err := os.MkdirAll(parent, 0o700); err != nil {
 				return errors.Wrapf(err, "failed to create directory %q", parent)
 			}
-			//nolint:gosec // path sanitized with safeJoin
+			//nolint:gosec // path sanitized with rutils.SafeJoin
 			outFile, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600|info.Mode().Perm())
 			if err != nil {
 				return errors.Wrapf(err, "failed to create file %s", path)
@@ -183,7 +184,7 @@ func unpackFile(ctx context.Context, fromFile, toDir string) error {
 		case tar.TypeLink:
 			name := header.Linkname
 
-			if name, err = safeJoin(toDir, name); err != nil {
+			if name, err = rutils.SafeJoinDir(toDir, name); err != nil {
 				return err
 			}
 			links = append(links, link{Path: path, Name: name})
@@ -261,7 +262,7 @@ func commonCleanup(logger logging.Logger, expectedPackageDirectories map[string]
 
 	// A packageTypeDir is a directory that contains all of the packages for the specified type. ex: data/ml_model
 	for _, packageTypeDir := range topLevelFiles {
-		packageTypeDirName, err := safeJoin(packagesDataDir, packageTypeDir.Name())
+		packageTypeDirName, err := rutils.SafeJoinDir(packagesDataDir, packageTypeDir.Name())
 		if err != nil {
 			allErrors = multierr.Append(allErrors, err)
 			continue
@@ -279,7 +280,7 @@ func commonCleanup(logger logging.Logger, expectedPackageDirectories map[string]
 			continue
 		}
 		for _, packageDir := range packageDirs {
-			packageDirName, err := safeJoin(packageTypeDirName, packageDir.Name())
+			packageDirName, err := rutils.SafeJoinDir(packageTypeDirName, packageDir.Name())
 			if err != nil {
 				allErrors = multierr.Append(allErrors, err)
 				continue

--- a/utils/file.go
+++ b/utils/file.go
@@ -4,7 +4,9 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
+	"github.com/pkg/errors"
 	"go.viam.com/utils"
 )
 
@@ -33,4 +35,15 @@ func RemoveFileNoError(path string) {
 		}
 		return nil
 	})
+}
+
+// SafeJoinDir performs a filepath.Join of 'parent' and 'subdir' but returns an error
+// if the resulting path points outside of 'parent'.
+// See also https://github.com/cyphar/filepath-securejoin.
+func SafeJoinDir(parent, subdir string) (string, error) {
+	res := filepath.Join(parent, subdir)
+	if !strings.HasPrefix(filepath.Clean(res), filepath.Clean(parent)+string(os.PathSeparator)) {
+		return res, errors.Errorf("unsafe path join: '%s' with '%s'", parent, subdir)
+	}
+	return res, nil
 }

--- a/utils/file_test.go
+++ b/utils/file_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/pkg/errors"
 	"go.viam.com/test"
 )
 
@@ -15,4 +16,25 @@ func TestResolveFile(t *testing.T) {
 	rd, err := os.ReadFile(resolved)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, bytes.Contains(rd, []byte(`sentinel := "great"`)), test.ShouldBeTrue)
+}
+
+func TestSafeJoinDir(t *testing.T) {
+	parentDir := "/some/parent"
+
+	validate := func(in, expectedOut string, expectedErr error) {
+		t.Helper()
+
+		out, err := SafeJoinDir(parentDir, in)
+		if expectedErr == nil {
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, out, test.ShouldEqual, expectedOut)
+		} else {
+			test.That(t, err, test.ShouldNotBeNil)
+			test.That(t, err.Error(), test.ShouldContainSubstring, expectedErr.Error())
+		}
+	}
+
+	validate("sub/dir", "/some/parent/sub/dir", nil)
+	validate("/other/parent", "/some/parent/other/parent", nil)
+	validate("../../../root", "", errors.New("unsafe path join"))
 }


### PR DESCRIPTION
## What changed
- EvaluateExePath changes:
    - **main change**: support meta.json inside tarball
    - error when ExePath isn't an abs path. Currently relative paths are undefined behavior (they will be relative to working directory), this turns them into an error. ( :warning: reviewers, check me on this)
- move SafeJoinDir to common utils + use it in a few places
- (incidental) parseJSONPath helper
## Why
- Currently local tarballs require a meta.json file *next to* the tarball. This is 1) awkward and hard to explain to people, and 2) makes it hard to use these. For example, what if you want two local tarballs in the same directory? They end up sharing a meta.json, which may be a non-starter.
- Embedded meta.json makes it easier to copy local tarballs around, which benefits android + remote reloading
## Follow up work
[RSDK-7848](https://viam.atlassian.net/browse/RSDK-7848) to potentially remove the old side-by-side meta.json behavior.
## Testing
Ran test with meta-in-tarball module, registry module, and local binary:
![image](https://github.com/viamrobotics/rdk/assets/7256523/33e694a7-70cc-40c2-9c9c-efaa1f711280)
![image](https://github.com/viamrobotics/rdk/assets/7256523/e87b3405-b90a-4c20-9819-6f9e62c9406b)

[RSDK-7848]: https://viam.atlassian.net/browse/RSDK-7848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ