### PR TITLE
RSDK-2670 Testing QOL: add generic unordered list comparison

### DIFF
--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -759,16 +759,8 @@ func TestClientRefresh(t *testing.T) {
 		baseNames := []resource.Name{base.Named("base2"), base.Named("base3")}
 
 		test.That(t, client.RemoteNames(), test.ShouldBeEmpty)
-		test.That(t,
-			utils.NewStringSet(arm.NamesFromRobot(client)...),
-			test.ShouldResemble,
-			utils.NewStringSet(testutils.ExtractNames(armNames...)...),
-		)
-		test.That(t,
-			utils.NewStringSet(base.NamesFromRobot(client)...),
-			test.ShouldResemble,
-			utils.NewStringSet(testutils.ExtractNames(baseNames...)...),
-		)
+		testutils.VerifySameMembers(t, arm.NamesFromRobot(client), testutils.ExtractNames(armNames...))
+		testutils.VerifySameMembers(t, base.NamesFromRobot(client), testutils.ExtractNames(baseNames...))
 
 		testutils.VerifySameResourceNames(t, client.ResourceNames(), finalResources)
 
@@ -789,16 +781,8 @@ func TestClientRefresh(t *testing.T) {
 		baseNames = []resource.Name{base.Named("base1")}
 
 		test.That(t, client.RemoteNames(), test.ShouldBeEmpty)
-		test.That(t,
-			utils.NewStringSet(arm.NamesFromRobot(client)...),
-			test.ShouldResemble,
-			utils.NewStringSet(testutils.ExtractNames(armNames...)...),
-		)
-		test.That(t,
-			utils.NewStringSet(base.NamesFromRobot(client)...),
-			test.ShouldResemble,
-			utils.NewStringSet(testutils.ExtractNames(baseNames...)...),
-		)
+		testutils.VerifySameMembers(t, arm.NamesFromRobot(client), testutils.ExtractNames(armNames...))
+		testutils.VerifySameMembers(t, base.NamesFromRobot(client), testutils.ExtractNames(baseNames...))
 
 		testutils.VerifySameResourceNames(t, client.ResourceNames(), emptyResources)
 
@@ -812,16 +796,8 @@ func TestClientRefresh(t *testing.T) {
 		baseNames = []resource.Name{base.Named("base2"), base.Named("base3")}
 
 		test.That(t, client.RemoteNames(), test.ShouldBeEmpty)
-		test.That(t,
-			utils.NewStringSet(arm.NamesFromRobot(client)...),
-			test.ShouldResemble,
-			utils.NewStringSet(testutils.ExtractNames(armNames...)...),
-		)
-		test.That(t,
-			utils.NewStringSet(base.NamesFromRobot(client)...),
-			test.ShouldResemble,
-			utils.NewStringSet(testutils.ExtractNames(baseNames...)...),
-		)
+		testutils.VerifySameMembers(t, arm.NamesFromRobot(client), testutils.ExtractNames(armNames...))
+		testutils.VerifySameMembers(t, base.NamesFromRobot(client), testutils.ExtractNames(baseNames...))
 
 		testutils.VerifySameResourceNames(t, client.ResourceNames(), finalResources)
 

--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -759,8 +759,8 @@ func TestClientRefresh(t *testing.T) {
 		baseNames := []resource.Name{base.Named("base2"), base.Named("base3")}
 
 		test.That(t, client.RemoteNames(), test.ShouldBeEmpty)
-		testutils.VerifySameMembers(t, arm.NamesFromRobot(client), testutils.ExtractNames(armNames...))
-		testutils.VerifySameMembers(t, base.NamesFromRobot(client), testutils.ExtractNames(baseNames...))
+		testutils.VerifySameElements(t, arm.NamesFromRobot(client), testutils.ExtractNames(armNames...))
+		testutils.VerifySameElements(t, base.NamesFromRobot(client), testutils.ExtractNames(baseNames...))
 
 		testutils.VerifySameResourceNames(t, client.ResourceNames(), finalResources)
 
@@ -781,8 +781,8 @@ func TestClientRefresh(t *testing.T) {
 		baseNames = []resource.Name{base.Named("base1")}
 
 		test.That(t, client.RemoteNames(), test.ShouldBeEmpty)
-		testutils.VerifySameMembers(t, arm.NamesFromRobot(client), testutils.ExtractNames(armNames...))
-		testutils.VerifySameMembers(t, base.NamesFromRobot(client), testutils.ExtractNames(baseNames...))
+		testutils.VerifySameElements(t, arm.NamesFromRobot(client), testutils.ExtractNames(armNames...))
+		testutils.VerifySameElements(t, base.NamesFromRobot(client), testutils.ExtractNames(baseNames...))
 
 		testutils.VerifySameResourceNames(t, client.ResourceNames(), emptyResources)
 
@@ -796,8 +796,8 @@ func TestClientRefresh(t *testing.T) {
 		baseNames = []resource.Name{base.Named("base2"), base.Named("base3")}
 
 		test.That(t, client.RemoteNames(), test.ShouldBeEmpty)
-		testutils.VerifySameMembers(t, arm.NamesFromRobot(client), testutils.ExtractNames(armNames...))
-		testutils.VerifySameMembers(t, base.NamesFromRobot(client), testutils.ExtractNames(baseNames...))
+		testutils.VerifySameElements(t, arm.NamesFromRobot(client), testutils.ExtractNames(armNames...))
+		testutils.VerifySameElements(t, base.NamesFromRobot(client), testutils.ExtractNames(baseNames...))
 
 		testutils.VerifySameResourceNames(t, client.ResourceNames(), finalResources)
 

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
-
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	armpb "go.viam.com/api/component/arm/v1"

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
+
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	armpb "go.viam.com/api/component/arm/v1"
@@ -211,11 +212,7 @@ func TestConfigRemote(t *testing.T) {
 	expectedRemotes := []string{"squee", "foo", "bar"}
 	remotes2 := r2.RemoteNames()
 
-	test.That(
-		t, utils.NewStringSet(remotes2...),
-		test.ShouldResemble,
-		utils.NewStringSet(expectedRemotes...),
-	)
+	rtestutils.VerifySameMembers(t, remotes2, expectedRemotes)
 
 	arm1Name := arm.Named("bar:pieceArm")
 	arm1, err := r2.ResourceByName(arm1Name)
@@ -443,11 +440,7 @@ func TestConfigRemoteWithAuth(t *testing.T) {
 			remotes2 := r2.RemoteNames()
 			expectedRemotes := []string{"bar", "foo"}
 
-			test.That(
-				t, utils.NewStringSet(remotes2...),
-				test.ShouldResemble,
-				utils.NewStringSet(expectedRemotes...),
-			)
+			rtestutils.VerifySameMembers(t, remotes2, expectedRemotes)
 
 			statuses, err := r2.Status(
 				context.Background(), []resource.Name{movementsensor.Named("bar:movement_sensor1"), movementsensor.Named("foo:movement_sensor1")},
@@ -610,11 +603,7 @@ func TestConfigRemoteWithTLSAuth(t *testing.T) {
 	remotes2 := r2.RemoteNames()
 	expectedRemotes := []string{"foo"}
 
-	test.That(
-		t, utils.NewStringSet(remotes2...),
-		test.ShouldResemble,
-		utils.NewStringSet(expectedRemotes...),
-	)
+	rtestutils.VerifySameMembers(t, remotes2, expectedRemotes)
 
 	statuses, err := r2.Status(context.Background(), []resource.Name{movementsensor.Named("foo:movement_sensor1")})
 	test.That(t, err, test.ShouldBeNil)

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -212,7 +212,7 @@ func TestConfigRemote(t *testing.T) {
 	expectedRemotes := []string{"squee", "foo", "bar"}
 	remotes2 := r2.RemoteNames()
 
-	rtestutils.VerifySameMembers(t, remotes2, expectedRemotes)
+	rtestutils.VerifySameElements(t, remotes2, expectedRemotes)
 
 	arm1Name := arm.Named("bar:pieceArm")
 	arm1, err := r2.ResourceByName(arm1Name)
@@ -440,7 +440,7 @@ func TestConfigRemoteWithAuth(t *testing.T) {
 			remotes2 := r2.RemoteNames()
 			expectedRemotes := []string{"bar", "foo"}
 
-			rtestutils.VerifySameMembers(t, remotes2, expectedRemotes)
+			rtestutils.VerifySameElements(t, remotes2, expectedRemotes)
 
 			statuses, err := r2.Status(
 				context.Background(), []resource.Name{movementsensor.Named("bar:movement_sensor1"), movementsensor.Named("foo:movement_sensor1")},
@@ -603,7 +603,7 @@ func TestConfigRemoteWithTLSAuth(t *testing.T) {
 	remotes2 := r2.RemoteNames()
 	expectedRemotes := []string{"foo"}
 
-	rtestutils.VerifySameMembers(t, remotes2, expectedRemotes)
+	rtestutils.VerifySameElements(t, remotes2, expectedRemotes)
 
 	statuses, err := r2.Status(context.Background(), []resource.Name{movementsensor.Named("foo:movement_sensor1")})
 	test.That(t, err, test.ShouldBeNil)

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -279,12 +279,7 @@ func TestManagerMergeNamesWithRemotes(t *testing.T) {
 	servoNames := []resource.Name{servo.Named("servo1"), servo.Named("servo2")}
 	servoNames = append(servoNames, rdktestutils.AddRemotes(servoNames, "remote1", "remote2")...)
 
-	test.That(
-		t,
-		utils.NewStringSet(manager.RemoteNames()...),
-		test.ShouldResemble,
-		utils.NewStringSet("remote1", "remote2"),
-	)
+	rdktestutils.VerifySameMembers(t, manager.RemoteNames(), []string{"remote1", "remote2"})
 	rdktestutils.VerifySameResourceNames(
 		t,
 		manager.ResourceNames(),
@@ -759,7 +754,7 @@ func TestManagerMarkRemoved(t *testing.T) {
 		t.Helper()
 		test.That(t, names, test.ShouldBeEmpty)
 		test.That(t, resourcesToCloseBeforeComplete, test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(procMan.ProcessIDs()...), test.ShouldBeEmpty)
+		test.That(t, procMan.ProcessIDs(), test.ShouldBeEmpty)
 	}
 
 	processesToRemove, resourcesToCloseBeforeComplete, markedResourceNames := manager.markRemoved(ctx, &config.Config{}, logger)
@@ -902,12 +897,7 @@ func TestManagerMarkRemoved(t *testing.T) {
 			servoNames,
 		)...),
 	)
-	test.That(
-		t,
-		utils.NewStringSet(processesToRemove.ProcessIDs()...),
-		test.ShouldResemble,
-		utils.NewStringSet("2"),
-	)
+	rdktestutils.VerifySameMembers(t, processesToRemove.ProcessIDs(), []string{"2"})
 
 	test.That(t, manager.Close(ctx), test.ShouldBeNil)
 	cancel()
@@ -1021,12 +1011,7 @@ func TestManagerMarkRemoved(t *testing.T) {
 			[]resource.Name{fromRemoteNameToRemoteNodeName("remote2")},
 		)...),
 	)
-	test.That(
-		t,
-		utils.NewStringSet(processesToRemove.ProcessIDs()...),
-		test.ShouldResemble,
-		utils.NewStringSet("2"),
-	)
+	rdktestutils.VerifySameMembers(t, processesToRemove.ProcessIDs(), []string{"2"})
 
 	test.That(t, manager.Close(ctx), test.ShouldBeNil)
 	cancel()
@@ -1209,12 +1194,7 @@ func TestManagerMarkRemoved(t *testing.T) {
 			},
 		)...),
 	)
-	test.That(
-		t,
-		utils.NewStringSet(processesToRemove.ProcessIDs()...),
-		test.ShouldResemble,
-		utils.NewStringSet("1", "2"),
-	)
+	rdktestutils.VerifySameMembers(t, processesToRemove.ProcessIDs(), []string{"1", "2"})
 	test.That(t, manager.Close(ctx), test.ShouldBeNil)
 	cancel()
 }

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -279,7 +279,7 @@ func TestManagerMergeNamesWithRemotes(t *testing.T) {
 	servoNames := []resource.Name{servo.Named("servo1"), servo.Named("servo2")}
 	servoNames = append(servoNames, rdktestutils.AddRemotes(servoNames, "remote1", "remote2")...)
 
-	rdktestutils.VerifySameMembers(t, manager.RemoteNames(), []string{"remote1", "remote2"})
+	rdktestutils.VerifySameElements(t, manager.RemoteNames(), []string{"remote1", "remote2"})
 	rdktestutils.VerifySameResourceNames(
 		t,
 		manager.ResourceNames(),
@@ -897,7 +897,7 @@ func TestManagerMarkRemoved(t *testing.T) {
 			servoNames,
 		)...),
 	)
-	rdktestutils.VerifySameMembers(t, processesToRemove.ProcessIDs(), []string{"2"})
+	rdktestutils.VerifySameElements(t, processesToRemove.ProcessIDs(), []string{"2"})
 
 	test.That(t, manager.Close(ctx), test.ShouldBeNil)
 	cancel()
@@ -1011,7 +1011,7 @@ func TestManagerMarkRemoved(t *testing.T) {
 			[]resource.Name{fromRemoteNameToRemoteNodeName("remote2")},
 		)...),
 	)
-	rdktestutils.VerifySameMembers(t, processesToRemove.ProcessIDs(), []string{"2"})
+	rdktestutils.VerifySameElements(t, processesToRemove.ProcessIDs(), []string{"2"})
 
 	test.That(t, manager.Close(ctx), test.ShouldBeNil)
 	cancel()
@@ -1194,7 +1194,7 @@ func TestManagerMarkRemoved(t *testing.T) {
 			},
 		)...),
 	)
-	rdktestutils.VerifySameMembers(t, processesToRemove.ProcessIDs(), []string{"1", "2"})
+	rdktestutils.VerifySameElements(t, processesToRemove.ProcessIDs(), []string{"1", "2"})
 	test.That(t, manager.Close(ctx), test.ShouldBeNil)
 	cancel()
 }

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -582,9 +582,9 @@ func TestRobotReconfigure(t *testing.T) {
 
 		boardNames = []resource.Name{board.Named("board1"), board.Named("board2")}
 		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
-		rdktestutils.VerifySameElements(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
-		rdktestutils.VerifySameElements(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
-		rdktestutils.VerifySameElements(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
+		test.That(t, arm.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, motor.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, base.NamesFromRobot(robot), test.ShouldBeEmpty)
 		rdktestutils.VerifySameElements(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
 		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -138,9 +138,9 @@ func TestRobotReconfigure(t *testing.T) {
 
 		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
 
-		rdktestutils.VerifySameMembers(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
-		rdktestutils.VerifySameMembers(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
-		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		rdktestutils.VerifySameElements(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
+		rdktestutils.VerifySameElements(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
+		rdktestutils.VerifySameElements(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
 		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
@@ -152,13 +152,13 @@ func TestRobotReconfigure(t *testing.T) {
 			mockNames,
 			resource.DefaultServices(),
 		))
-		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
+		rdktestutils.VerifySameElements(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		robot.Reconfigure(ctx, conf1)
 		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
-		rdktestutils.VerifySameMembers(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
-		rdktestutils.VerifySameMembers(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
-		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		rdktestutils.VerifySameElements(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
+		rdktestutils.VerifySameElements(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
+		rdktestutils.VerifySameElements(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
 		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
@@ -170,7 +170,7 @@ func TestRobotReconfigure(t *testing.T) {
 			mockNames,
 			resource.DefaultServices(),
 		))
-		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
+		rdktestutils.VerifySameElements(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		_, err := arm.FromRobot(robot, "arm1")
 		test.That(t, err, test.ShouldBeNil)
@@ -215,9 +215,9 @@ func TestRobotReconfigure(t *testing.T) {
 		boardNames := []resource.Name{board.Named("board1")}
 		mockNames := []resource.Name{mockNamed("mock1"), mockNamed("mock2")}
 		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
-		rdktestutils.VerifySameMembers(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
-		rdktestutils.VerifySameMembers(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
-		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		rdktestutils.VerifySameElements(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
+		rdktestutils.VerifySameElements(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
+		rdktestutils.VerifySameElements(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
 		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
@@ -229,7 +229,7 @@ func TestRobotReconfigure(t *testing.T) {
 			mockNames,
 			resource.DefaultServices(),
 		))
-		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
+		rdktestutils.VerifySameElements(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		arm1, err := arm.FromRobot(robot, "arm1")
 		test.That(t, err, test.ShouldBeNil)
@@ -265,9 +265,9 @@ func TestRobotReconfigure(t *testing.T) {
 			test.That(tb, err, test.ShouldBeNil)
 		})
 		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
-		rdktestutils.VerifySameMembers(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
-		rdktestutils.VerifySameMembers(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
-		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		rdktestutils.VerifySameElements(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
+		rdktestutils.VerifySameElements(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
+		rdktestutils.VerifySameElements(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
 		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
@@ -279,7 +279,7 @@ func TestRobotReconfigure(t *testing.T) {
 			mockNames,
 			resource.DefaultServices(),
 		))
-		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
+		rdktestutils.VerifySameElements(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		test.That(t, mock1.(*mockFake).reconfCount, test.ShouldEqual, 0)
 
@@ -329,9 +329,9 @@ func TestRobotReconfigure(t *testing.T) {
 		robot.Reconfigure(context.Background(), conf1)
 		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
 		test.That(t, motor.NamesFromRobot(robot), test.ShouldBeEmpty)
-		rdktestutils.VerifySameMembers(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
-		rdktestutils.VerifySameMembers(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
-		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		rdktestutils.VerifySameElements(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
+		rdktestutils.VerifySameElements(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
+		rdktestutils.VerifySameElements(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
 		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
@@ -343,17 +343,17 @@ func TestRobotReconfigure(t *testing.T) {
 			resource.DefaultServices(),
 			mockNames,
 		))
-		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
+		rdktestutils.VerifySameElements(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		armNames = []resource.Name{arm.Named("arm1"), arm.Named("arm2")}
 		baseNames = []resource.Name{base.Named("base1"), base.Named("base2")}
 		motorNames := []resource.Name{motor.Named("m1"), motor.Named("m2"), motor.Named("m3"), motor.Named("m4")}
 		robot.Reconfigure(context.Background(), conf2)
 		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
-		rdktestutils.VerifySameMembers(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
-		rdktestutils.VerifySameMembers(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
-		rdktestutils.VerifySameMembers(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
-		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		rdktestutils.VerifySameElements(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
+		rdktestutils.VerifySameElements(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
+		rdktestutils.VerifySameElements(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
+		rdktestutils.VerifySameElements(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
 		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
@@ -366,7 +366,7 @@ func TestRobotReconfigure(t *testing.T) {
 			mockNames,
 			resource.DefaultServices(),
 		))
-		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
+		rdktestutils.VerifySameElements(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		_, err := arm.FromRobot(robot, "arm1")
 		test.That(t, err, test.ShouldBeNil)
@@ -437,10 +437,10 @@ func TestRobotReconfigure(t *testing.T) {
 
 		robot.Reconfigure(context.Background(), conf3)
 		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
-		rdktestutils.VerifySameMembers(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
-		rdktestutils.VerifySameMembers(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
-		rdktestutils.VerifySameMembers(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
-		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		rdktestutils.VerifySameElements(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
+		rdktestutils.VerifySameElements(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
+		rdktestutils.VerifySameElements(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
+		rdktestutils.VerifySameElements(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
 		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
@@ -452,7 +452,7 @@ func TestRobotReconfigure(t *testing.T) {
 			motorNames,
 			resource.DefaultServices(),
 		))
-		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
+		rdktestutils.VerifySameElements(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		b, err := board.FromRobot(robot, "board1")
 		test.That(t, err, test.ShouldBeNil)
@@ -466,10 +466,10 @@ func TestRobotReconfigure(t *testing.T) {
 
 		robot.Reconfigure(context.Background(), conf2)
 		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
-		rdktestutils.VerifySameMembers(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
-		rdktestutils.VerifySameMembers(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
-		rdktestutils.VerifySameMembers(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
-		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		rdktestutils.VerifySameElements(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
+		rdktestutils.VerifySameElements(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
+		rdktestutils.VerifySameElements(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
+		rdktestutils.VerifySameElements(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
 		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
@@ -481,7 +481,7 @@ func TestRobotReconfigure(t *testing.T) {
 			motorNames,
 			resource.DefaultServices(),
 		))
-		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
+		rdktestutils.VerifySameElements(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		_, err = arm.FromRobot(robot, "arm1")
 		test.That(t, err, test.ShouldBeNil)
@@ -556,10 +556,10 @@ func TestRobotReconfigure(t *testing.T) {
 
 		robot.Reconfigure(context.Background(), conf2)
 		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
-		rdktestutils.VerifySameMembers(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
-		rdktestutils.VerifySameMembers(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
-		rdktestutils.VerifySameMembers(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
-		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		rdktestutils.VerifySameElements(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
+		rdktestutils.VerifySameElements(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
+		rdktestutils.VerifySameElements(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
+		rdktestutils.VerifySameElements(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
 		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
@@ -571,7 +571,7 @@ func TestRobotReconfigure(t *testing.T) {
 			motorNames,
 			resource.DefaultServices(),
 		))
-		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
+		rdktestutils.VerifySameElements(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		arm2, err := arm.FromRobot(robot, "arm2")
 		test.That(t, err, test.ShouldBeNil)
@@ -582,10 +582,10 @@ func TestRobotReconfigure(t *testing.T) {
 
 		boardNames = []resource.Name{board.Named("board1"), board.Named("board2")}
 		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
-		rdktestutils.VerifySameMembers(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
-		rdktestutils.VerifySameMembers(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
-		rdktestutils.VerifySameMembers(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
-		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		rdktestutils.VerifySameElements(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
+		rdktestutils.VerifySameElements(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
+		rdktestutils.VerifySameElements(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
+		rdktestutils.VerifySameElements(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
 		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
@@ -594,7 +594,7 @@ func TestRobotReconfigure(t *testing.T) {
 			boardNames,
 			resource.DefaultServices(),
 		))
-		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
+		rdktestutils.VerifySameElements(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		_, err = arm.FromRobot(robot, "arm1")
 		test.That(t, err, test.ShouldNotBeNil)
@@ -655,10 +655,10 @@ func TestRobotReconfigure(t *testing.T) {
 
 		robot.Reconfigure(context.Background(), conf2)
 		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
-		rdktestutils.VerifySameMembers(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
-		rdktestutils.VerifySameMembers(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
-		rdktestutils.VerifySameMembers(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
-		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		rdktestutils.VerifySameElements(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
+		rdktestutils.VerifySameElements(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
+		rdktestutils.VerifySameElements(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
+		rdktestutils.VerifySameElements(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
 		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
@@ -670,7 +670,7 @@ func TestRobotReconfigure(t *testing.T) {
 			motorNames,
 			resource.DefaultServices(),
 		))
-		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
+		rdktestutils.VerifySameElements(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 		b, err := board.FromRobot(robot, "board1")
 		test.That(t, err, test.ShouldBeNil)
 		pin, err := b.GPIOPinByName("1")
@@ -694,10 +694,10 @@ func TestRobotReconfigure(t *testing.T) {
 
 		robot.Reconfigure(context.Background(), conf6)
 		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
-		rdktestutils.VerifySameMembers(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
-		rdktestutils.VerifySameMembers(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
-		rdktestutils.VerifySameMembers(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
-		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		rdktestutils.VerifySameElements(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
+		rdktestutils.VerifySameElements(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
+		rdktestutils.VerifySameElements(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
+		rdktestutils.VerifySameElements(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
 		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
@@ -709,7 +709,7 @@ func TestRobotReconfigure(t *testing.T) {
 			motorNames,
 			resource.DefaultServices(),
 		))
-		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
+		rdktestutils.VerifySameElements(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		_, err = arm.FromRobot(robot, "arm1")
 		test.That(t, err, test.ShouldBeNil)
@@ -813,10 +813,10 @@ func TestRobotReconfigure(t *testing.T) {
 		}
 		robot.Reconfigure(context.Background(), conf6)
 		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
-		rdktestutils.VerifySameMembers(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
-		rdktestutils.VerifySameMembers(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
-		rdktestutils.VerifySameMembers(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
-		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		rdktestutils.VerifySameElements(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
+		rdktestutils.VerifySameElements(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
+		rdktestutils.VerifySameElements(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
+		rdktestutils.VerifySameElements(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
 		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
@@ -828,7 +828,7 @@ func TestRobotReconfigure(t *testing.T) {
 			motorNames,
 			resource.DefaultServices(),
 		))
-		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
+		rdktestutils.VerifySameElements(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		_, err := arm.FromRobot(robot, "arm1")
 		test.That(t, err, test.ShouldBeNil)
@@ -907,7 +907,7 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, arm.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, motor.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, base.NamesFromRobot(robot), test.ShouldBeEmpty)
-		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		rdktestutils.VerifySameElements(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
 		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
@@ -916,7 +916,7 @@ func TestRobotReconfigure(t *testing.T) {
 			boardNames,
 			resource.DefaultServices(),
 		))
-		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
+		rdktestutils.VerifySameElements(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		_, err := arm.FromRobot(robot, "arm1")
 		test.That(t, err, test.ShouldNotBeNil)
@@ -963,10 +963,10 @@ func TestRobotReconfigure(t *testing.T) {
 		robot.Reconfigure(context.Background(), conf7)
 		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
 		test.That(t, arm.NamesFromRobot(robot), test.ShouldBeEmpty)
-		rdktestutils.VerifySameMembers(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
+		rdktestutils.VerifySameElements(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
 		test.That(t, base.NamesFromRobot(robot), test.ShouldBeEmpty)
-		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
-		rdktestutils.VerifySameMembers(t, encoder.NamesFromRobot(robot), rdktestutils.ExtractNames(encoderNames...))
+		rdktestutils.VerifySameElements(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		rdktestutils.VerifySameElements(t, encoder.NamesFromRobot(robot), rdktestutils.ExtractNames(encoderNames...))
 		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
@@ -978,7 +978,7 @@ func TestRobotReconfigure(t *testing.T) {
 			mockNames,
 			encoderNames,
 		))
-		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
+		rdktestutils.VerifySameElements(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		_, err = arm.FromRobot(robot, "arm1")
 		test.That(t, err, test.ShouldNotBeNil)
@@ -1065,10 +1065,10 @@ func TestRobotReconfigure(t *testing.T) {
 		}
 		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
 		test.That(t, arm.NamesFromRobot(robot), test.ShouldBeEmpty)
-		rdktestutils.VerifySameMembers(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
+		rdktestutils.VerifySameElements(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
 		test.That(t, base.NamesFromRobot(robot), test.ShouldBeEmpty)
-		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
-		rdktestutils.VerifySameMembers(t, encoder.NamesFromRobot(robot), rdktestutils.ExtractNames(encoderNames...))
+		rdktestutils.VerifySameElements(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		rdktestutils.VerifySameElements(t, encoder.NamesFromRobot(robot), rdktestutils.ExtractNames(encoderNames...))
 		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
@@ -1080,7 +1080,7 @@ func TestRobotReconfigure(t *testing.T) {
 			motorNames,
 			mockNames,
 		))
-		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
+		rdktestutils.VerifySameElements(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		_, err := arm.FromRobot(robot, "arm1")
 		test.That(t, err, test.ShouldNotBeNil)
@@ -1155,10 +1155,10 @@ func TestRobotReconfigure(t *testing.T) {
 		}
 		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
 		test.That(t, arm.NamesFromRobot(robot), test.ShouldBeEmpty)
-		rdktestutils.VerifySameMembers(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
+		rdktestutils.VerifySameElements(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
 		test.That(t, base.NamesFromRobot(robot), test.ShouldBeEmpty)
-		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
-		rdktestutils.VerifySameMembers(t, encoder.NamesFromRobot(robot), rdktestutils.ExtractNames(encoderNames...))
+		rdktestutils.VerifySameElements(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		rdktestutils.VerifySameElements(t, encoder.NamesFromRobot(robot), rdktestutils.ExtractNames(encoderNames...))
 		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
 		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
@@ -1170,7 +1170,7 @@ func TestRobotReconfigure(t *testing.T) {
 			mockNames,
 			encoderNames,
 		))
-		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
+		rdktestutils.VerifySameElements(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		_, err = arm.FromRobot(robot, "arm1")
 		test.That(t, err, test.ShouldNotBeNil)
@@ -1252,9 +1252,9 @@ func TestRobotReconfigure(t *testing.T) {
 			mockNamed("mock6"),
 		}
 		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
-		rdktestutils.VerifySameMembers(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
-		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
-		rdktestutils.VerifySameMembers(t, encoder.NamesFromRobot(robot), rdktestutils.ExtractNames(encoderNames...))
+		rdktestutils.VerifySameElements(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
+		rdktestutils.VerifySameElements(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		rdktestutils.VerifySameElements(t, encoder.NamesFromRobot(robot), rdktestutils.ExtractNames(encoderNames...))
 
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
 			boardNames,
@@ -1263,7 +1263,7 @@ func TestRobotReconfigure(t *testing.T) {
 			mockNames,
 			encoderNames,
 		))
-		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
+		rdktestutils.VerifySameElements(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		_, err := board.FromRobot(robot, "board1")
 		test.That(t, err, test.ShouldBeNil)
@@ -1338,9 +1338,9 @@ func TestRobotReconfigure(t *testing.T) {
 			mockNamed("mock3"),
 		}
 		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
-		rdktestutils.VerifySameMembers(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
-		rdktestutils.VerifySameMembers(t, encoder.NamesFromRobot(robot), rdktestutils.ExtractNames(encoderNames...))
-		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		rdktestutils.VerifySameElements(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
+		rdktestutils.VerifySameElements(t, encoder.NamesFromRobot(robot), rdktestutils.ExtractNames(encoderNames...))
+		rdktestutils.VerifySameElements(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
 
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
 			boardNames,
@@ -1349,7 +1349,7 @@ func TestRobotReconfigure(t *testing.T) {
 			mockNames,
 			encoderNames,
 		))
-		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
+		rdktestutils.VerifySameElements(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		_, err = board.FromRobot(robot, "board1")
 		test.That(t, err, test.ShouldBeNil)
@@ -1418,9 +1418,9 @@ func TestRobotReconfigure(t *testing.T) {
 			mockNamed("mock4"), mockNamed("mock5"),
 		}
 		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
-		rdktestutils.VerifySameMembers(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
-		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
-		rdktestutils.VerifySameMembers(t, encoder.NamesFromRobot(robot), rdktestutils.ExtractNames(encoderNames...))
+		rdktestutils.VerifySameElements(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
+		rdktestutils.VerifySameElements(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		rdktestutils.VerifySameElements(t, encoder.NamesFromRobot(robot), rdktestutils.ExtractNames(encoderNames...))
 
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
 			boardNames,
@@ -1429,7 +1429,7 @@ func TestRobotReconfigure(t *testing.T) {
 			mockNames,
 			encoderNames,
 		))
-		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
+		rdktestutils.VerifySameElements(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		_, err = board.FromRobot(robot, "board1")
 		test.That(t, err, test.ShouldBeNil)
@@ -1529,7 +1529,7 @@ func TestRobotReconfigure(t *testing.T) {
 		}
 
 		robot.Reconfigure(context.Background(), conf1)
-		rdktestutils.VerifySameMembers(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
+		rdktestutils.VerifySameElements(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
 			armNames,
 			resource.DefaultServices(),

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -136,29 +136,15 @@ func TestRobotReconfigure(t *testing.T) {
 		boardNames := []resource.Name{board.Named("board1")}
 		mockNames := []resource.Name{mockNamed("mock1"), mockNamed("mock2")}
 
-		test.That(t, utils.NewStringSet(robot.RemoteNames()...), test.ShouldBeEmpty)
-		test.That(
-			t,
-			utils.NewStringSet(arm.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(armNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(base.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(baseNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(board.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(boardNames...)...),
-		)
-		test.That(t, utils.NewStringSet(camera.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
+		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
+
+		rdktestutils.VerifySameMembers(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
+		rdktestutils.VerifySameMembers(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
+		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, servo.NamesFromRobot(robot), test.ShouldBeEmpty)
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
 			armNames,
 			baseNames,
@@ -166,32 +152,17 @@ func TestRobotReconfigure(t *testing.T) {
 			mockNames,
 			resource.DefaultServices(),
 		))
-		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
+		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		robot.Reconfigure(ctx, conf1)
-		test.That(t, utils.NewStringSet(robot.RemoteNames()...), test.ShouldBeEmpty)
-		test.That(
-			t,
-			utils.NewStringSet(arm.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(armNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(base.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(baseNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(board.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(boardNames...)...),
-		)
-		test.That(t, utils.NewStringSet(camera.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
+		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
+		rdktestutils.VerifySameMembers(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
+		rdktestutils.VerifySameMembers(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
+		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, servo.NamesFromRobot(robot), test.ShouldBeEmpty)
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
 			armNames,
 			baseNames,
@@ -199,7 +170,7 @@ func TestRobotReconfigure(t *testing.T) {
 			mockNames,
 			resource.DefaultServices(),
 		))
-		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
+		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		_, err := arm.FromRobot(robot, "arm1")
 		test.That(t, err, test.ShouldBeNil)
@@ -243,29 +214,14 @@ func TestRobotReconfigure(t *testing.T) {
 		baseNames := []resource.Name{base.Named("base1")}
 		boardNames := []resource.Name{board.Named("board1")}
 		mockNames := []resource.Name{mockNamed("mock1"), mockNamed("mock2")}
-		test.That(t, utils.NewStringSet(robot.RemoteNames()...), test.ShouldBeEmpty)
-		test.That(
-			t,
-			utils.NewStringSet(arm.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(armNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(base.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(baseNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(board.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(boardNames...)...),
-		)
-		test.That(t, utils.NewStringSet(camera.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
+		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
+		rdktestutils.VerifySameMembers(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
+		rdktestutils.VerifySameMembers(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
+		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, servo.NamesFromRobot(robot), test.ShouldBeEmpty)
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
 			armNames,
 			baseNames,
@@ -273,7 +229,7 @@ func TestRobotReconfigure(t *testing.T) {
 			mockNames,
 			resource.DefaultServices(),
 		))
-		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
+		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		arm1, err := arm.FromRobot(robot, "arm1")
 		test.That(t, err, test.ShouldBeNil)
@@ -308,29 +264,14 @@ func TestRobotReconfigure(t *testing.T) {
 			_, err = robot.ResourceByName(mockNamed("mock2"))
 			test.That(tb, err, test.ShouldBeNil)
 		})
-		test.That(t, utils.NewStringSet(robot.RemoteNames()...), test.ShouldBeEmpty)
-		test.That(
-			t,
-			utils.NewStringSet(arm.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(armNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(base.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(baseNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(board.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(boardNames...)...),
-		)
-		test.That(t, utils.NewStringSet(camera.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
+		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
+		rdktestutils.VerifySameMembers(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
+		rdktestutils.VerifySameMembers(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
+		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, servo.NamesFromRobot(robot), test.ShouldBeEmpty)
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
 			armNames,
 			baseNames,
@@ -338,7 +279,7 @@ func TestRobotReconfigure(t *testing.T) {
 			mockNames,
 			resource.DefaultServices(),
 		))
-		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
+		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		test.That(t, mock1.(*mockFake).reconfCount, test.ShouldEqual, 0)
 
@@ -386,30 +327,15 @@ func TestRobotReconfigure(t *testing.T) {
 		}
 
 		robot.Reconfigure(context.Background(), conf1)
-		test.That(t, utils.NewStringSet(robot.RemoteNames()...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(motor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(
-			t,
-			utils.NewStringSet(arm.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(armNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(base.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(baseNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(board.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(boardNames...)...),
-		)
-		test.That(t, utils.NewStringSet(camera.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
+		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
+		test.That(t, motor.NamesFromRobot(robot), test.ShouldBeEmpty)
+		rdktestutils.VerifySameMembers(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
+		rdktestutils.VerifySameMembers(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
+		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, servo.NamesFromRobot(robot), test.ShouldBeEmpty)
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
 			armNames,
 			baseNames,
@@ -417,41 +343,21 @@ func TestRobotReconfigure(t *testing.T) {
 			resource.DefaultServices(),
 			mockNames,
 		))
-		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
+		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		armNames = []resource.Name{arm.Named("arm1"), arm.Named("arm2")}
 		baseNames = []resource.Name{base.Named("base1"), base.Named("base2")}
 		motorNames := []resource.Name{motor.Named("m1"), motor.Named("m2"), motor.Named("m3"), motor.Named("m4")}
 		robot.Reconfigure(context.Background(), conf2)
-		test.That(t, utils.NewStringSet(robot.RemoteNames()...), test.ShouldBeEmpty)
-		test.That(
-			t,
-			utils.NewStringSet(arm.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(armNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(motor.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(motorNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(base.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(baseNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(board.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(boardNames...)...),
-		)
-		test.That(t, utils.NewStringSet(camera.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
+		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
+		rdktestutils.VerifySameMembers(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
+		rdktestutils.VerifySameMembers(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
+		rdktestutils.VerifySameMembers(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
+		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, servo.NamesFromRobot(robot), test.ShouldBeEmpty)
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
 			armNames,
 			baseNames,
@@ -460,7 +366,7 @@ func TestRobotReconfigure(t *testing.T) {
 			mockNames,
 			resource.DefaultServices(),
 		))
-		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
+		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		_, err := arm.FromRobot(robot, "arm1")
 		test.That(t, err, test.ShouldBeNil)
@@ -530,34 +436,15 @@ func TestRobotReconfigure(t *testing.T) {
 		boardNames := []resource.Name{board.Named("board1")}
 
 		robot.Reconfigure(context.Background(), conf3)
-		test.That(t, utils.NewStringSet(robot.RemoteNames()...), test.ShouldBeEmpty)
-		test.That(t,
-			utils.NewStringSet(motor.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(motorNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(arm.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(armNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(base.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(baseNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(board.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(boardNames...)...),
-		)
-		test.That(t, utils.NewStringSet(camera.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
+		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
+		rdktestutils.VerifySameMembers(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
+		rdktestutils.VerifySameMembers(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
+		rdktestutils.VerifySameMembers(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
+		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, servo.NamesFromRobot(robot), test.ShouldBeEmpty)
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
 			armNames,
 			baseNames,
@@ -565,7 +452,7 @@ func TestRobotReconfigure(t *testing.T) {
 			motorNames,
 			resource.DefaultServices(),
 		))
-		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
+		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		b, err := board.FromRobot(robot, "board1")
 		test.That(t, err, test.ShouldBeNil)
@@ -578,35 +465,15 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 
 		robot.Reconfigure(context.Background(), conf2)
-		test.That(t, utils.NewStringSet(robot.RemoteNames()...), test.ShouldBeEmpty)
-		test.That(
-			t,
-			utils.NewStringSet(arm.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(armNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(motor.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(motorNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(base.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(baseNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(board.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(boardNames...)...),
-		)
-		test.That(t, utils.NewStringSet(camera.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
+		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
+		rdktestutils.VerifySameMembers(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
+		rdktestutils.VerifySameMembers(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
+		rdktestutils.VerifySameMembers(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
+		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, servo.NamesFromRobot(robot), test.ShouldBeEmpty)
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
 			armNames,
 			baseNames,
@@ -614,7 +481,7 @@ func TestRobotReconfigure(t *testing.T) {
 			motorNames,
 			resource.DefaultServices(),
 		))
-		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
+		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		_, err = arm.FromRobot(robot, "arm1")
 		test.That(t, err, test.ShouldBeNil)
@@ -688,34 +555,15 @@ func TestRobotReconfigure(t *testing.T) {
 		boardNames := []resource.Name{board.Named("board1")}
 
 		robot.Reconfigure(context.Background(), conf2)
-		test.That(t, utils.NewStringSet(robot.RemoteNames()...), test.ShouldBeEmpty)
-		test.That(t,
-			utils.NewStringSet(motor.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(motorNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(arm.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(armNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(base.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(baseNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(board.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(boardNames...)...),
-		)
-		test.That(t, utils.NewStringSet(camera.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
+		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
+		rdktestutils.VerifySameMembers(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
+		rdktestutils.VerifySameMembers(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
+		rdktestutils.VerifySameMembers(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
+		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, servo.NamesFromRobot(robot), test.ShouldBeEmpty)
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
 			armNames,
 			baseNames,
@@ -723,7 +571,7 @@ func TestRobotReconfigure(t *testing.T) {
 			motorNames,
 			resource.DefaultServices(),
 		))
-		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
+		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		arm2, err := arm.FromRobot(robot, "arm2")
 		test.That(t, err, test.ShouldBeNil)
@@ -733,37 +581,20 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, arm2.(*fake.Arm).CloseCount, test.ShouldEqual, 1)
 
 		boardNames = []resource.Name{board.Named("board1"), board.Named("board2")}
-		test.That(t, utils.NewStringSet(robot.RemoteNames()...), test.ShouldBeEmpty)
-		test.That(
-			t,
-			utils.NewStringSet(arm.NamesFromRobot(robot)...),
-			test.ShouldBeEmpty,
-		)
-		test.That(
-			t,
-			utils.NewStringSet(motor.NamesFromRobot(robot)...),
-			test.ShouldBeEmpty,
-		)
-		test.That(
-			t,
-			utils.NewStringSet(base.NamesFromRobot(robot)...),
-			test.ShouldBeEmpty,
-		)
-		test.That(
-			t,
-			utils.NewStringSet(board.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(boardNames...)...),
-		)
-		test.That(t, utils.NewStringSet(camera.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
+		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
+		rdktestutils.VerifySameMembers(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
+		rdktestutils.VerifySameMembers(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
+		rdktestutils.VerifySameMembers(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
+		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, servo.NamesFromRobot(robot), test.ShouldBeEmpty)
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
 			boardNames,
 			resource.DefaultServices(),
 		))
-		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
+		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		_, err = arm.FromRobot(robot, "arm1")
 		test.That(t, err, test.ShouldNotBeNil)
@@ -823,34 +654,15 @@ func TestRobotReconfigure(t *testing.T) {
 		boardNames := []resource.Name{board.Named("board1")}
 
 		robot.Reconfigure(context.Background(), conf2)
-		test.That(t, utils.NewStringSet(robot.RemoteNames()...), test.ShouldBeEmpty)
-		test.That(t,
-			utils.NewStringSet(motor.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(motorNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(arm.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(armNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(base.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(baseNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(board.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(boardNames...)...),
-		)
-		test.That(t, utils.NewStringSet(camera.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
+		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
+		rdktestutils.VerifySameMembers(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
+		rdktestutils.VerifySameMembers(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
+		rdktestutils.VerifySameMembers(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
+		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, servo.NamesFromRobot(robot), test.ShouldBeEmpty)
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
 			armNames,
 			baseNames,
@@ -858,7 +670,7 @@ func TestRobotReconfigure(t *testing.T) {
 			motorNames,
 			resource.DefaultServices(),
 		))
-		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
+		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 		b, err := board.FromRobot(robot, "board1")
 		test.That(t, err, test.ShouldBeNil)
 		pin, err := b.GPIOPinByName("1")
@@ -881,34 +693,15 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		robot.Reconfigure(context.Background(), conf6)
-		test.That(t, utils.NewStringSet(robot.RemoteNames()...), test.ShouldBeEmpty)
-		test.That(t,
-			utils.NewStringSet(motor.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(motorNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(arm.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(armNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(base.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(baseNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(board.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(boardNames...)...),
-		)
-		test.That(t, utils.NewStringSet(camera.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
+		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
+		rdktestutils.VerifySameMembers(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
+		rdktestutils.VerifySameMembers(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
+		rdktestutils.VerifySameMembers(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
+		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, servo.NamesFromRobot(robot), test.ShouldBeEmpty)
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
 			armNames,
 			baseNames,
@@ -916,7 +709,7 @@ func TestRobotReconfigure(t *testing.T) {
 			motorNames,
 			resource.DefaultServices(),
 		))
-		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
+		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		_, err = arm.FromRobot(robot, "arm1")
 		test.That(t, err, test.ShouldBeNil)
@@ -1000,16 +793,16 @@ func TestRobotReconfigure(t *testing.T) {
 
 		resources := robot.ResourceNames()
 		test.That(t, len(resources), test.ShouldEqual, 2)
-		test.That(t, utils.NewStringSet(robot.RemoteNames()...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(arm.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(base.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(board.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(camera.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
+		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
+		test.That(t, arm.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, base.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, board.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, servo.NamesFromRobot(robot), test.ShouldBeEmpty)
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), resource.DefaultServices())
-		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldBeEmpty)
+		test.That(t, robot.ProcessManager().ProcessIDs(), test.ShouldBeEmpty)
 
 		armNames := []resource.Name{arm.Named("arm1"), arm.Named("arm3")}
 		baseNames := []resource.Name{base.Named("base1"), base.Named("base2")}
@@ -1019,34 +812,15 @@ func TestRobotReconfigure(t *testing.T) {
 			board.Named("board2"), board.Named("board3"),
 		}
 		robot.Reconfigure(context.Background(), conf6)
-		test.That(t, utils.NewStringSet(robot.RemoteNames()...), test.ShouldBeEmpty)
-		test.That(t,
-			utils.NewStringSet(motor.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(motorNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(arm.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(armNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(base.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(baseNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(board.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(boardNames...)...),
-		)
-		test.That(t, utils.NewStringSet(camera.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
+		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
+		rdktestutils.VerifySameMembers(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
+		rdktestutils.VerifySameMembers(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
+		rdktestutils.VerifySameMembers(t, base.NamesFromRobot(robot), rdktestutils.ExtractNames(baseNames...))
+		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, servo.NamesFromRobot(robot), test.ShouldBeEmpty)
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
 			armNames,
 			baseNames,
@@ -1054,7 +828,7 @@ func TestRobotReconfigure(t *testing.T) {
 			motorNames,
 			resource.DefaultServices(),
 		))
-		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
+		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		_, err := arm.FromRobot(robot, "arm1")
 		test.That(t, err, test.ShouldBeNil)
@@ -1129,37 +903,20 @@ func TestRobotReconfigure(t *testing.T) {
 		robot := setupLocalRobot(t, context.Background(), conf4, logger)
 
 		boardNames := []resource.Name{board.Named("board1"), board.Named("board2")}
-		test.That(t, utils.NewStringSet(robot.RemoteNames()...), test.ShouldBeEmpty)
-		test.That(
-			t,
-			utils.NewStringSet(arm.NamesFromRobot(robot)...),
-			test.ShouldBeEmpty,
-		)
-		test.That(
-			t,
-			utils.NewStringSet(motor.NamesFromRobot(robot)...),
-			test.ShouldBeEmpty,
-		)
-		test.That(
-			t,
-			utils.NewStringSet(base.NamesFromRobot(robot)...),
-			test.ShouldBeEmpty,
-		)
-		test.That(
-			t,
-			utils.NewStringSet(board.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(boardNames...)...),
-		)
-		test.That(t, utils.NewStringSet(camera.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
+		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
+		test.That(t, arm.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, motor.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, base.NamesFromRobot(robot), test.ShouldBeEmpty)
+		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, servo.NamesFromRobot(robot), test.ShouldBeEmpty)
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
 			boardNames,
 			resource.DefaultServices(),
 		))
-		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
+		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		_, err := arm.FromRobot(robot, "arm1")
 		test.That(t, err, test.ShouldNotBeNil)
@@ -1204,39 +961,16 @@ func TestRobotReconfigure(t *testing.T) {
 		encoderNames := []resource.Name{encoder.Named("e1")}
 
 		robot.Reconfigure(context.Background(), conf7)
-		test.That(t, utils.NewStringSet(robot.RemoteNames()...), test.ShouldBeEmpty)
-		test.That(
-			t,
-			utils.NewStringSet(arm.NamesFromRobot(robot)...),
-			test.ShouldBeEmpty,
-		)
-		test.That(
-			t,
-			utils.NewStringSet(motor.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(motorNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(base.NamesFromRobot(robot)...),
-			test.ShouldBeEmpty,
-		)
-		test.That(
-			t,
-			utils.NewStringSet(board.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(boardNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(encoder.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(encoderNames...)...),
-		)
-		test.That(t, utils.NewStringSet(camera.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
+		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
+		test.That(t, arm.NamesFromRobot(robot), test.ShouldBeEmpty)
+		rdktestutils.VerifySameMembers(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
+		test.That(t, base.NamesFromRobot(robot), test.ShouldBeEmpty)
+		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		rdktestutils.VerifySameMembers(t, encoder.NamesFromRobot(robot), rdktestutils.ExtractNames(encoderNames...))
+		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, servo.NamesFromRobot(robot), test.ShouldBeEmpty)
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
 			boardNames,
 			resource.DefaultServices(),
@@ -1244,7 +978,7 @@ func TestRobotReconfigure(t *testing.T) {
 			mockNames,
 			encoderNames,
 		))
-		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
+		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		_, err = arm.FromRobot(robot, "arm1")
 		test.That(t, err, test.ShouldNotBeNil)
@@ -1329,39 +1063,16 @@ func TestRobotReconfigure(t *testing.T) {
 			mockNamed("mock1"), mockNamed("mock2"), mockNamed("mock6"),
 			mockNamed("mock3"), mockNamed("mock4"), mockNamed("mock5"),
 		}
-		test.That(t, utils.NewStringSet(robot.RemoteNames()...), test.ShouldBeEmpty)
-		test.That(
-			t,
-			utils.NewStringSet(arm.NamesFromRobot(robot)...),
-			test.ShouldBeEmpty,
-		)
-		test.That(
-			t,
-			utils.NewStringSet(motor.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(motorNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(base.NamesFromRobot(robot)...),
-			test.ShouldBeEmpty,
-		)
-		test.That(
-			t,
-			utils.NewStringSet(board.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(boardNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(encoder.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(encoderNames...)...),
-		)
-		test.That(t, utils.NewStringSet(camera.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
+		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
+		test.That(t, arm.NamesFromRobot(robot), test.ShouldBeEmpty)
+		rdktestutils.VerifySameMembers(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
+		test.That(t, base.NamesFromRobot(robot), test.ShouldBeEmpty)
+		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		rdktestutils.VerifySameMembers(t, encoder.NamesFromRobot(robot), rdktestutils.ExtractNames(encoderNames...))
+		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, servo.NamesFromRobot(robot), test.ShouldBeEmpty)
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
 			boardNames,
 			encoderNames,
@@ -1369,7 +1080,7 @@ func TestRobotReconfigure(t *testing.T) {
 			motorNames,
 			mockNames,
 		))
-		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
+		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		_, err := arm.FromRobot(robot, "arm1")
 		test.That(t, err, test.ShouldNotBeNil)
@@ -1442,39 +1153,16 @@ func TestRobotReconfigure(t *testing.T) {
 			mockNamed("mock1"), mockNamed("mock2"),
 			mockNamed("mock3"), mockNamed("mock4"), mockNamed("mock5"),
 		}
-		test.That(t, utils.NewStringSet(robot.RemoteNames()...), test.ShouldBeEmpty)
-		test.That(
-			t,
-			utils.NewStringSet(arm.NamesFromRobot(robot)...),
-			test.ShouldBeEmpty,
-		)
-		test.That(
-			t,
-			utils.NewStringSet(motor.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(motorNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(base.NamesFromRobot(robot)...),
-			test.ShouldBeEmpty,
-		)
-		test.That(
-			t,
-			utils.NewStringSet(board.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(boardNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(encoder.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(encoderNames...)...),
-		)
-		test.That(t, utils.NewStringSet(camera.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(gripper.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(sensor.NamesFromRobot(robot)...), test.ShouldBeEmpty)
-		test.That(t, utils.NewStringSet(servo.NamesFromRobot(robot)...), test.ShouldBeEmpty)
+		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
+		test.That(t, arm.NamesFromRobot(robot), test.ShouldBeEmpty)
+		rdktestutils.VerifySameMembers(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
+		test.That(t, base.NamesFromRobot(robot), test.ShouldBeEmpty)
+		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		rdktestutils.VerifySameMembers(t, encoder.NamesFromRobot(robot), rdktestutils.ExtractNames(encoderNames...))
+		test.That(t, camera.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, gripper.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, sensor.NamesFromRobot(robot), test.ShouldBeEmpty)
+		test.That(t, servo.NamesFromRobot(robot), test.ShouldBeEmpty)
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
 			boardNames,
 			resource.DefaultServices(),
@@ -1482,7 +1170,7 @@ func TestRobotReconfigure(t *testing.T) {
 			mockNames,
 			encoderNames,
 		))
-		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
+		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		_, err = arm.FromRobot(robot, "arm1")
 		test.That(t, err, test.ShouldNotBeNil)
@@ -1563,25 +1251,10 @@ func TestRobotReconfigure(t *testing.T) {
 			mockNamed("mock3"), mockNamed("mock4"), mockNamed("mock5"),
 			mockNamed("mock6"),
 		}
-		test.That(t, utils.NewStringSet(robot.RemoteNames()...), test.ShouldBeEmpty)
-		test.That(
-			t,
-			utils.NewStringSet(motor.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(motorNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(board.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(boardNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(encoder.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(encoderNames...)...),
-		)
+		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
+		rdktestutils.VerifySameMembers(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
+		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		rdktestutils.VerifySameMembers(t, encoder.NamesFromRobot(robot), rdktestutils.ExtractNames(encoderNames...))
 
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
 			boardNames,
@@ -1590,7 +1263,7 @@ func TestRobotReconfigure(t *testing.T) {
 			mockNames,
 			encoderNames,
 		))
-		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
+		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		_, err := board.FromRobot(robot, "board1")
 		test.That(t, err, test.ShouldBeNil)
@@ -1664,25 +1337,10 @@ func TestRobotReconfigure(t *testing.T) {
 			mockNamed("mock2"),
 			mockNamed("mock3"),
 		}
-		test.That(t, utils.NewStringSet(robot.RemoteNames()...), test.ShouldBeEmpty)
-		test.That(
-			t,
-			utils.NewStringSet(motor.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(motorNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(encoder.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(encoderNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(board.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(boardNames...)...),
-		)
+		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
+		rdktestutils.VerifySameMembers(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
+		rdktestutils.VerifySameMembers(t, encoder.NamesFromRobot(robot), rdktestutils.ExtractNames(encoderNames...))
+		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
 
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
 			boardNames,
@@ -1691,7 +1349,7 @@ func TestRobotReconfigure(t *testing.T) {
 			mockNames,
 			encoderNames,
 		))
-		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
+		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		_, err = board.FromRobot(robot, "board1")
 		test.That(t, err, test.ShouldBeNil)
@@ -1759,25 +1417,10 @@ func TestRobotReconfigure(t *testing.T) {
 			mockNamed("mock2"), mockNamed("mock1"), mockNamed("mock3"),
 			mockNamed("mock4"), mockNamed("mock5"),
 		}
-		test.That(t, utils.NewStringSet(robot.RemoteNames()...), test.ShouldBeEmpty)
-		test.That(
-			t,
-			utils.NewStringSet(motor.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(motorNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(board.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(boardNames...)...),
-		)
-		test.That(
-			t,
-			utils.NewStringSet(encoder.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(encoderNames...)...),
-		)
+		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
+		rdktestutils.VerifySameMembers(t, motor.NamesFromRobot(robot), rdktestutils.ExtractNames(motorNames...))
+		rdktestutils.VerifySameMembers(t, board.NamesFromRobot(robot), rdktestutils.ExtractNames(boardNames...))
+		rdktestutils.VerifySameMembers(t, encoder.NamesFromRobot(robot), rdktestutils.ExtractNames(encoderNames...))
 
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
 			boardNames,
@@ -1786,7 +1429,7 @@ func TestRobotReconfigure(t *testing.T) {
 			mockNames,
 			encoderNames,
 		))
-		test.That(t, utils.NewStringSet(robot.ProcessManager().ProcessIDs()...), test.ShouldResemble, utils.NewStringSet("1", "2"))
+		rdktestutils.VerifySameMembers(t, robot.ProcessManager().ProcessIDs(), []string{"1", "2"})
 
 		_, err = board.FromRobot(robot, "board1")
 		test.That(t, err, test.ShouldBeNil)
@@ -1886,12 +1529,7 @@ func TestRobotReconfigure(t *testing.T) {
 		}
 
 		robot.Reconfigure(context.Background(), conf1)
-		test.That(
-			t,
-			utils.NewStringSet(arm.NamesFromRobot(robot)...),
-			test.ShouldResemble,
-			utils.NewStringSet(rdktestutils.ExtractNames(armNames...)...),
-		)
+		rdktestutils.VerifySameMembers(t, arm.NamesFromRobot(robot), rdktestutils.ExtractNames(armNames...))
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
 			armNames,
 			resource.DefaultServices(),
@@ -1907,9 +1545,9 @@ func TestRobotReconfigure(t *testing.T) {
 			mockNamed("mock1"),
 			mockNamed("mock3"), mockNamed("mock2"), mockNamed("mock5"),
 		}
-		test.That(t, utils.NewStringSet(robot.RemoteNames()...), test.ShouldBeEmpty)
+		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
 
-		test.That(t, utils.NewStringSet(arm.NamesFromRobot(robot)...), test.ShouldBeEmpty)
+		test.That(t, arm.NamesFromRobot(robot), test.ShouldBeEmpty)
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
 			mockNames,
 			resource.DefaultServices(),

--- a/robot/robot_test.go
+++ b/robot/robot_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"go.viam.com/test"
-	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/arm"
 	"go.viam.com/rdk/components/gantry"
@@ -76,10 +75,10 @@ func TestNamesFromRobot(t *testing.T) {
 	test.That(t, names, test.ShouldBeEmpty)
 
 	names = robot.NamesByAPI(r, sensor.API)
-	test.That(t, utils.NewStringSet(names...), test.ShouldResemble, utils.NewStringSet(testutils.ExtractNames(sensorNames...)...))
+	testutils.VerifySameMembers(t, names, testutils.ExtractNames(sensorNames...))
 
 	names = robot.NamesByAPI(r, arm.API)
-	test.That(t, utils.NewStringSet(names...), test.ShouldResemble, utils.NewStringSet(testutils.ExtractNames(armNames...)...))
+	testutils.VerifySameMembers(t, names, testutils.ExtractNames(armNames...))
 }
 
 func TestResourceFromRobot(t *testing.T) {

--- a/robot/robot_test.go
+++ b/robot/robot_test.go
@@ -75,10 +75,10 @@ func TestNamesFromRobot(t *testing.T) {
 	test.That(t, names, test.ShouldBeEmpty)
 
 	names = robot.NamesByAPI(r, sensor.API)
-	testutils.VerifySameMembers(t, names, testutils.ExtractNames(sensorNames...))
+	testutils.VerifySameElements(t, names, testutils.ExtractNames(sensorNames...))
 
 	names = robot.NamesByAPI(r, arm.API)
-	testutils.VerifySameMembers(t, names, testutils.ExtractNames(armNames...))
+	testutils.VerifySameElements(t, names, testutils.ExtractNames(armNames...))
 }
 
 func TestResourceFromRobot(t *testing.T) {

--- a/services/baseremotecontrol/builtin/builtin_test.go
+++ b/services/baseremotecontrol/builtin/builtin_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/golang/geo/r3"
 	"github.com/pkg/errors"
 	"go.viam.com/test"
-	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/base"
 	fakebase "go.viam.com/rdk/components/base/fake"
@@ -15,6 +14,7 @@ import (
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/services/baseremotecontrol"
+	"go.viam.com/rdk/testutils"
 	"go.viam.com/rdk/testutils/inject"
 )
 
@@ -30,7 +30,7 @@ func TestBaseRemoteControl(t *testing.T) {
 
 	depNames, err := cfg.Validate("")
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, utils.NewStringSet(depNames...), test.ShouldResemble, utils.NewStringSet("baseTest", "inputTest"))
+	testutils.VerifySameMembers(t, depNames, []string{"baseTest", "inputTest"})
 
 	fakeController := &inject.InputController{}
 	fakeBase := &fakebase.Base{}

--- a/services/baseremotecontrol/builtin/builtin_test.go
+++ b/services/baseremotecontrol/builtin/builtin_test.go
@@ -30,7 +30,7 @@ func TestBaseRemoteControl(t *testing.T) {
 
 	depNames, err := cfg.Validate("")
 	test.That(t, err, test.ShouldBeNil)
-	testutils.VerifySameMembers(t, depNames, []string{"baseTest", "inputTest"})
+	testutils.VerifySameElements(t, depNames, []string{"baseTest", "inputTest"})
 
 	fakeController := &inject.InputController{}
 	fakeBase := &fakebase.Base{}

--- a/testutils/resource_utils.go
+++ b/testutils/resource_utils.go
@@ -63,22 +63,6 @@ func VerifySameResourceNames(tb testing.TB, actual, expected []resource.Name) {
 	test.That(tb, newSortedResourceNames(actual), test.ShouldResemble, newSortedResourceNames(expected))
 }
 
-// VerifySameElements asserts that two slices contain the same elements without
-// considering order.
-func VerifySameElements[E cmp.Ordered](tb testing.TB, actual, expected []E) {
-	tb.Helper()
-
-	actualSorted := make([]E, len(actual))
-	copy(actualSorted, actual)
-	expectedSorted := make([]E, len(expected))
-	copy(expectedSorted, expected)
-
-	slices.Sort(actualSorted)
-	slices.Sort(expectedSorted)
-
-	test.That(tb, actualSorted, test.ShouldResemble, expectedSorted)
-}
-
 // ExtractNames takes a slice of resource.Name objects
 // and returns a slice of name strings for the purposes of comparison
 // in automated tests.

--- a/testutils/resource_utils.go
+++ b/testutils/resource_utils.go
@@ -61,9 +61,9 @@ func VerifySameResourceNames(tb testing.TB, actual, expected []resource.Name) {
 	test.That(tb, newSortedResourceNames(actual), test.ShouldResemble, newSortedResourceNames(expected))
 }
 
-// VerifySameMembers asserts that two slices contain the same elements without
+// VerifySameElements asserts that two slices contain the same elements without
 // considering order.
-func VerifySameMembers[E cmp.Ordered](tb testing.TB, actual, expected []E) {
+func VerifySameElements[E cmp.Ordered](tb testing.TB, actual, expected []E) {
 	actualSorted := make([]E, len(actual))
 	copy(actualSorted, actual)
 	expectedSorted := make([]E, len(expected))

--- a/testutils/resource_utils.go
+++ b/testutils/resource_utils.go
@@ -58,12 +58,16 @@ func newSortedResourceNames(resourceNames []resource.Name) []resource.Name {
 // VerifySameResourceNames asserts that two slices of resource.Names contain the same
 // resources.Names without considering order.
 func VerifySameResourceNames(tb testing.TB, actual, expected []resource.Name) {
+	tb.Helper()
+
 	test.That(tb, newSortedResourceNames(actual), test.ShouldResemble, newSortedResourceNames(expected))
 }
 
 // VerifySameElements asserts that two slices contain the same elements without
 // considering order.
 func VerifySameElements[E cmp.Ordered](tb testing.TB, actual, expected []E) {
+	tb.Helper()
+
 	actualSorted := make([]E, len(actual))
 	copy(actualSorted, actual)
 	expectedSorted := make([]E, len(expected))

--- a/testutils/resource_utils.go
+++ b/testutils/resource_utils.go
@@ -61,6 +61,20 @@ func VerifySameResourceNames(tb testing.TB, actual, expected []resource.Name) {
 	test.That(tb, newSortedResourceNames(actual), test.ShouldResemble, newSortedResourceNames(expected))
 }
 
+// VerifySameMembers asserts that two slices contain the same elements without
+// considering order.
+func VerifySameMembers[E cmp.Ordered](tb testing.TB, actual, expected []E) {
+	actualSorted := make([]E, len(actual))
+	copy(actualSorted, actual)
+	expectedSorted := make([]E, len(expected))
+	copy(expectedSorted, expected)
+
+	slices.Sort(actualSorted)
+	slices.Sort(expectedSorted)
+
+	test.That(tb, actualSorted, test.ShouldResemble, expectedSorted)
+}
+
 // ExtractNames takes a slice of resource.Name objects
 // and returns a slice of name strings for the purposes of comparison
 // in automated tests.

--- a/testutils/slices.go
+++ b/testutils/slices.go
@@ -1,0 +1,25 @@
+package testutils
+
+import (
+	"cmp"
+	"slices"
+	"testing"
+
+	"go.viam.com/test"
+)
+
+// VerifySameElements asserts that two slices contain the same elements without
+// considering order.
+func VerifySameElements[E cmp.Ordered](tb testing.TB, actual, expected []E) {
+	tb.Helper()
+
+	actualSorted := make([]E, len(actual))
+	copy(actualSorted, actual)
+	expectedSorted := make([]E, len(expected))
+	copy(expectedSorted, expected)
+
+	slices.Sort(actualSorted)
+	slices.Sort(expectedSorted)
+
+	test.That(tb, actualSorted, test.ShouldResemble, expectedSorted)
+}


### PR DESCRIPTION
Follow-up to https://github.com/viamrobotics/rdk/pull/3996 - add a generic testing functionality that verifies is two slices of comparable elements have the same elements without considering order. This ends up removing a lot of boilerplate from resource tests.