### PR TITLE
RSDK-7106: Ignore blank lines in label files

### DIFF
--- a/.artifact/tree.json
+++ b/.artifact/tree.json
@@ -52249,9 +52249,17 @@
         "hash": "359468bee2538de4c5950190cc1eb002",
         "size": 699
       },
+      "effdetlabels_with_spaces.txt": {
+        "hash": "03baf0c24095635ab80bf1c7ba13d71e",
+        "size": 728
+      },
       "effnet0.tflite": {
         "hash": "301b893e4701ec6f490c21a2435befbc",
         "size": 7165437
+      },
+      "empty_labels.txt": {
+        "hash": "f263703128b264cd3bdc41684338b44f",
+        "size": 21
       },
       "fakelabels.txt": {
         "hash": "9b9d5e11ece4e6fe52246a2851636145",
@@ -52313,6 +52321,10 @@
     "white2.png": {
       "hash": "ae363a34e2a707cfbc2b6b20a2879210",
       "size": 4179
+    },
+    "yolov4_1_3_416_416_static.onnx": {
+      "hash": "fd96b603a89e8c0bc928a925498cf879",
+      "size": 24324690
     }
   }
 }

--- a/services/vision/mlvision/ml_model.go
+++ b/services/vision/mlvision/ml_model.go
@@ -234,7 +234,14 @@ func getLabelsFromMetadata(md mlmodel.MLMetadata) []string {
 		}()
 		scanner := bufio.NewScanner(f)
 		for scanner.Scan() {
+			label := strings.TrimSpace(scanner.Text())
+			if label == "" {
+				continue
+			}
 			labels = append(labels, scanner.Text())
+		}
+		if len(labels) == 0 {
+			return nil
 		}
 		// if the labels come out as one line, try splitting that line by spaces or commas to extract labels
 		// Check if the labels should be comma split first and then space split.

--- a/services/vision/mlvision/ml_model_test.go
+++ b/services/vision/mlvision/ml_model_test.go
@@ -501,11 +501,51 @@ func TestLabelReader(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, outMD, test.ShouldNotBeNil)
 	outLabels := getLabelsFromMetadata(outMD)
-	test.That(t, err, test.ShouldBeNil)
+	test.That(t, len(outLabels), test.ShouldEqual, 12)
 	test.That(t, outLabels[0], test.ShouldResemble, "this")
 	test.That(t, outLabels[1], test.ShouldResemble, "could")
 	test.That(t, outLabels[2], test.ShouldResemble, "be")
-	test.That(t, len(outLabels), test.ShouldEqual, 12)
+}
+
+func TestBlankLabelLines(t *testing.T) {
+	ctx := context.Background()
+	modelLoc := artifact.MustPath("vision/tflite/effdet0.tflite")
+	labelLoc := artifact.MustPath("vision/tflite/effdetlabels_with_spaces.txt")
+	cfg := tflitecpu.TFLiteConfig{ // detector config
+		ModelPath:  modelLoc,
+		NumThreads: 2,
+		LabelPath:  labelLoc,
+	}
+	out, err := tflitecpu.NewTFLiteCPUModel(ctx, &cfg, mlmodel.Named("spacedLabels"))
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, out, test.ShouldNotBeNil)
+	outMD, err := out.Metadata(ctx)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, outMD, test.ShouldNotBeNil)
+	outLabels := getLabelsFromMetadata(outMD)
+	test.That(t, len(outLabels), test.ShouldEqual, 91)
+	test.That(t, outLabels[0], test.ShouldResemble, "Person")
+	test.That(t, outLabels[1], test.ShouldResemble, "Bicycle")
+	test.That(t, outLabels[2], test.ShouldResemble, "Car")
+}
+
+func TestNoLabelsInFile(t *testing.T) {
+	ctx := context.Background()
+	modelLoc := artifact.MustPath("vision/tflite/effdet0.tflite")
+	labelLoc := artifact.MustPath("vision/tflite/empty_labels.txt")
+	cfg := tflitecpu.TFLiteConfig{ // detector config
+		ModelPath:  modelLoc,
+		NumThreads: 2,
+		LabelPath:  labelLoc,
+	}
+	out, err := tflitecpu.NewTFLiteCPUModel(ctx, &cfg, mlmodel.Named("emptyLabels"))
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, out, test.ShouldNotBeNil)
+	outMD, err := out.Metadata(ctx)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, outMD, test.ShouldNotBeNil)
+	outLabels := getLabelsFromMetadata(outMD)
+	test.That(t, outLabels, test.ShouldBeNil)
 }
 
 func TestSpaceDelineatedLabels(t *testing.T) {

--- a/services/vision/mlvision/ml_model_test.go
+++ b/services/vision/mlvision/ml_model_test.go
@@ -527,24 +527,15 @@ func TestBlankLabelLines(t *testing.T) {
 	test.That(t, outLabels[0], test.ShouldResemble, "Person")
 	test.That(t, outLabels[1], test.ShouldResemble, "Bicycle")
 	test.That(t, outLabels[2], test.ShouldResemble, "Car")
-}
 
-func TestNoLabelsInFile(t *testing.T) {
-	ctx := context.Background()
-	modelLoc := artifact.MustPath("vision/tflite/effdet0.tflite")
-	labelLoc := artifact.MustPath("vision/tflite/empty_labels.txt")
-	cfg := tflitecpu.TFLiteConfig{ // detector config
-		ModelPath:  modelLoc,
-		NumThreads: 2,
-		LabelPath:  labelLoc,
-	}
-	out, err := tflitecpu.NewTFLiteCPUModel(ctx, &cfg, mlmodel.Named("emptyLabels"))
+	labelLoc2 := artifact.MustPath("vision/tflite/empty_labels.txt")
+	cfg.LabelPath = labelLoc2
+	out, err = tflitecpu.NewTFLiteCPUModel(ctx, &cfg, mlmodel.Named("emptyLabels"))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, out, test.ShouldNotBeNil)
-	outMD, err := out.Metadata(ctx)
+	outMD, err = out.Metadata(ctx)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, outMD, test.ShouldNotBeNil)
-	outLabels := getLabelsFromMetadata(outMD)
+	outLabels = getLabelsFromMetadata(outMD)
 	test.That(t, outLabels, test.ShouldBeNil)
 }
 


### PR DESCRIPTION
This will skip over blank lines in label files so that label strings do not accidentally get assigned the empty string