### PR TITLE
revert CI runner change

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,12 +25,12 @@ jobs:
           platform: linux/amd64
           image: rdk-devenv
           file: etc/Dockerfile.cache
-        - arch: github-linux-arm64-4core
+        - arch: buildjet-4vcpu-ubuntu-2204-arm
           tag: arm64
           platform: linux/arm64
           image: rdk-devenv
           file: etc/Dockerfile.cache
-        - arch: github-linux-arm64-2core
+        - arch: buildjet-2vcpu-ubuntu-2204-arm
           tag: armhf
           platform: linux/arm/v7
           image: rdk-devenv
@@ -41,12 +41,12 @@ jobs:
           image: antique2
           file: etc/Dockerfile.antique-cache
           tag: amd64
-        - arch: github-linux-arm64-2core
+        - arch: buildjet-2vcpu-ubuntu-2204-arm
           platform: linux/arm64
           image: antique2
           file: etc/Dockerfile.antique-cache
           tag: arm64
-        - arch: github-linux-arm64-2core
+        - arch: buildjet-2vcpu-ubuntu-2204-arm
           platform: linux/arm/v7
           image: antique2
           file: etc/Dockerfile.antique-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,7 +156,7 @@ jobs:
 
   test32:
     name: Go 32-bit Unit Tests
-    runs-on: github-linux-arm64-8core
+    runs-on: [buildjet-8vcpu-ubuntu-2204-arm]
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
Revert 6a16992c -- mkdir denied.

Error was:
```
FAIL	go.viam.com/rdk/vision/objectdetection	0.287s
2024-06-07T23:32:10.678Z	FATAL	ext/verify.go:49	error opening artifact	{"error": "mkdir /rdk/.artifact/cache: permission denied"}
FAIL	go.viam.com/rdk/vision/segmentation	0.405s
2024-06-07T23:32:15.148Z	FATAL	ext/verify.go:49	error opening artifact	{"error": "mkdir /rdk/.artifact/cache: permission denied"}
FAIL	go.viam.com/rdk/web/server	0.391s
```