### PR TITLE
don't double-close when NetAppender uses shared connection

### DIFF
--- a/logging/net_appender_test.go
+++ b/logging/net_appender_test.go
@@ -238,6 +238,7 @@ func TestProvidedClientConn(t *testing.T) {
 	defer server.stop()
 	conn, err := CreateNewGRPCClient(context.Background(), server.cloudConfig)
 	test.That(t, err, test.ShouldBeNil)
+	defer conn.Close()
 	netAppender, err := NewNetAppender(server.cloudConfig, conn)
 	test.That(t, err, test.ShouldBeNil)
 	// make sure these are the same object, i.e. that the constructor set it properly.


### PR DESCRIPTION
## What changed
- when NetAppender is given a shared connection, don't try to close it
- add `remoteLogWriterGRPC.clientIsShared` field to support this behavior
## Why
In #4039 we added the ability to give NetAppender a shared connection. That (predictably, in retrospect) breaks cleanup because it's essentially a weak ref.

Specifically, this prevents 'unchecked error' / 'the client connection is closing' errors on shutdown when NetAppender is used in viam-agent.
## Alternate approach
Could add a `newRemoteLogWriterGRPC` constructor to encapsulate this logic, rather than doing it in NewNetAppender? But remoteLogWriterGRPC is internal so I'm fine leaving it as-is for now