### PR TITLE
RSDK-7034: Fix Panic when Renaming Modules

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -634,8 +634,11 @@ func (mgr *Manager) ResolveImplicitDependenciesInConfig(ctx context.Context, con
 			continue
 		}
 
-		//nolint:gocritic
-		deltaModules := append(conf.Modified.Modules, conf.Added.Modules...)
+		lenModified, lenAdded := len(conf.Modified.Modules), len(conf.Added.Modules)
+		deltaModules := make([]config.Module, lenModified, lenModified+lenAdded)
+		copy(deltaModules, conf.Modified.Modules)
+		deltaModules = append(deltaModules, conf.Added.Modules...)
+
 		if !slices.ContainsFunc(deltaModules, func(elem config.Module) bool {
 			return elem.Name == mod.cfg.Name
 		}) {

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -620,8 +620,8 @@ func (mgr *Manager) ValidateConfig(ctx context.Context, conf resource.Config) ([
 }
 
 // ResolveImplicitDependenciesInConfig mutates the passed in diff to add modular implicit dependencies to added
-// and modified resources. It also puts modular resources whose module has been modified in conf.Added if they
-// are not already there.
+// and modified resources. It also puts modular resources whose module has been modified or added in conf.Added if
+// they are not already there since the resources themselves are not necessarily new.
 func (mgr *Manager) ResolveImplicitDependenciesInConfig(ctx context.Context, conf *config.Diff) error {
 	mgr.mu.RLock()
 	defer mgr.mu.RUnlock()
@@ -640,7 +640,7 @@ func (mgr *Manager) ResolveImplicitDependenciesInConfig(ctx context.Context, con
 			return elem.Name == mod.cfg.Name
 		}) {
 			// continue if this modular component is not being handled by a modified
-			// module.
+			// or added module.
 			continue
 		}
 		if slices.ContainsFunc(conf.Added.Components, func(elem resource.Config) bool {

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -633,7 +633,10 @@ func (mgr *Manager) ResolveImplicitDependenciesInConfig(ctx context.Context, con
 			// continue if this component is not being provided by a module.
 			continue
 		}
-		if !slices.ContainsFunc(conf.Modified.Modules, func(elem config.Module) bool {
+
+		//nolint:gocritic
+		deltaModules := append(conf.Modified.Modules, conf.Added.Modules...)
+		if !slices.ContainsFunc(deltaModules, func(elem config.Module) bool {
 			return elem.Name == mod.cfg.Name
 		}) {
 			// continue if this modular component is not being handled by a modified

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -1194,17 +1194,17 @@ func (r *localRobot) reconfigure(ctx context.Context, newConfig *config.Config, 
 	// First we mark diff.Removed resources and their children for removal.
 	processesToClose, resourcesToCloseBeforeComplete, _ := r.manager.markRemoved(ctx, diff.Removed, r.logger)
 
-	// Second we update the resource graph and stop any removed processes.
-	allErrs = multierr.Combine(allErrs, r.manager.updateResources(ctx, diff))
-	allErrs = multierr.Combine(allErrs, processesToClose.Stop())
-
-	// Third we attempt to Close resources.
+	// Second we attempt to Close resources.
 	alreadyClosed := make(map[resource.Name]struct{}, len(resourcesToCloseBeforeComplete))
 	for _, res := range resourcesToCloseBeforeComplete {
 		allErrs = multierr.Combine(allErrs, r.manager.closeResource(ctx, res))
 		// avoid a double close later
 		alreadyClosed[res.Name()] = struct{}{}
 	}
+
+	// Third we update the resource graph and stop any removed processes.
+	allErrs = multierr.Combine(allErrs, r.manager.updateResources(ctx, diff))
+	allErrs = multierr.Combine(allErrs, processesToClose.Stop())
 
 	// Fourth we attempt to complete the config (see function for details) and
 	// update weak dependents.

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
-
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	armpb "go.viam.com/api/component/arm/v1"

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
+
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	armpb "go.viam.com/api/component/arm/v1"
@@ -3483,7 +3484,7 @@ func TestCustomResourceBuildsOnModuleAddition(t *testing.T) {
 		return slices.Contains(defaultSvcs, resource)
 	})
 
-	// Manually inspect resources to ensure modular resource does not build without module
+	// Manually inspect resources to ensure myGizmo does not build without module
 	// Assert that there are 2 resources (the motors) minus the default ones
 	test.That(t, len(robotResources), test.ShouldEqual, 2)
 	for _, resource := range robotResources {
@@ -3492,7 +3493,7 @@ func TestCustomResourceBuildsOnModuleAddition(t *testing.T) {
 		test.That(t, isMyMotor1 || isMyMotor2, test.ShouldBeTrue)
 	}
 
-	// Modify config so that it now has module that supports the myGizmo
+	// Modify config so that it now has a module that supports myGizmo
 	mod := []config.Module{
 		{
 			Name:     "mod",

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -3404,23 +3404,23 @@ func TestReconfigureOnModuleRename(t *testing.T) {
 		},
 	}
 
+	// Create copy of cfg since Reconfigure (called when setting up a robot) modifies cfg.
 	cfgCopy := *cfg
 	r := setupLocalRobot(t, ctx, cfg, logger)
 
-	// Modify config copy by renaming module
-
+	// Use copy to modify config by renaming module
 	cfgCopy.Modules[0].Name = "mod-renamed"
 
+	// Create copy of cfgCopy to test against
 	expectedCfg := cfgCopy
-
 	r.Reconfigure(ctx, &cfgCopy)
 
 	actualCfg := r.Config()
 
-	// Verify correct attributes of config
+	// Verify attributes of config
+
 	// Manually inspect components
 	test.That(t, len(actualCfg.Components), test.ShouldEqual, 3)
-
 	for _, comp := range actualCfg.Components {
 		isMyBase := comp.Equals(cfg.Components[0])
 		isMotor1 := comp.Equals(cfg.Components[1])

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -3489,7 +3489,7 @@ func TestCustomResourceBuildsOnModuleAddition(t *testing.T) {
 
 	// Verify resources to ensure myGizmo does build
 	expectedResources = rtestutils.ConcatResourceNames(
-		[]resource.Name{gizmoapi.Named("myGizmo")},
+		[]resource.Name{cfg.Components[0].ResourceName()},
 		expectedResources,
 	)
 	rtestutils.VerifySameResourceNames(t, r.ResourceNames(), expectedResources)


### PR DESCRIPTION
### Description
RSDK-7034: RDK panics when renaming a local module
* This bug occurs because when a module is renamed, it is a part of `conf.Added.Modules`, so when calling `updateResources()` during reconfiguration, components with the same API end up being registered twice (since it is not truly a newly added module) causing a panic. 
* In order to fix this, we remove resources marked for removal first before attempting to update resources.
  * Before, we attempted to update resources then remove resources marked for removal.
* Log output on module rename now: 
<img width="1111" alt="Screenshot 2024-06-10 at 2 59 25 PM" 
src="https://github.com/viamrobotics/rdk/assets/93689852/5fece4b7-5b5c-4c69-9c34-8dd44b0a0935">
