### PR TITLE
Change shutdown success line to Debug

### DIFF
--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -1001,8 +1001,7 @@ func (rc *RobotClient) Shutdown(ctx context.Context) error {
 		if status, ok := status.FromError(err); ok {
 			switch status.Code() { //nolint:exhaustive
 			case codes.Internal, codes.Unknown:
-				rc.Logger().CInfow(ctx, "robot shutdown successful")
-				return nil
+				break
 			case codes.Unavailable:
 				rc.Logger().CWarnw(ctx, "server unavailable, likely due to successful robot shutdown")
 				return err
@@ -1016,6 +1015,6 @@ func (rc *RobotClient) Shutdown(ctx context.Context) error {
 			return err
 		}
 	}
-	rc.Logger().CInfow(ctx, "robot shutdown successful")
+	rc.Logger().CDebug(ctx, "robot shutdown successful")
 	return nil
 }


### PR DESCRIPTION
slight change to behavior, but I think logs for successes should be fairly silent, especially if this is a library users will be interacting with. 

If shutting down successfully is something they want to log, they can, but we shouldn't force it on them in the Info level.

also changed one of the logs to break out of the switch so we're not repeating the log, happy to change back though