### PR TITLE
RSDK-7805: Adding tests for GPSRTKSERIAL

### DIFF
--- a/components/movementsensor/gpsrtkserial/gpsrtkserial_test.go
+++ b/components/movementsensor/gpsrtkserial/gpsrtkserial_test.go
@@ -2,10 +2,14 @@ package gpsrtkserial
 
 import (
 	"context"
+	"errors"
+	"math"
 	"testing"
 
 	"go.viam.com/test"
 
+	geo "github.com/kellydunn/golang-geo"
+	"go.viam.com/rdk/components/movementsensor"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 )
@@ -84,4 +88,35 @@ func TestReconfigure(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, g.writePath, test.ShouldResemble, "/dev/ttyUSB1")
 	test.That(t, g.wbaud, test.ShouldEqual, 115200)
+}
+
+func TestPosition(t *testing.T) {
+
+	t.Run("position test with last error and no last position", func(t *testing.T) {
+		g := &rtkSerial{
+			err: movementsensor.NewLastError(1, 1),
+		}
+		g.err.Set(errors.New("last error test"))
+
+		point, flt, err := g.Position(context.Background(), nil)
+		test.That(t, movementsensor.IsPositionNaN(point), test.ShouldBeTrue)
+		test.That(t, math.IsNaN(flt), test.ShouldBeTrue)
+		test.That(t, err, test.ShouldBeError, "last error test")
+	})
+
+	t.Run("position test with last error and last position", func(t *testing.T) {
+		g := &rtkSerial{
+			err:          movementsensor.NewLastError(1, 1),
+			lastposition: movementsensor.NewLastPosition(),
+		}
+		g.lastposition.SetLastPosition(geo.NewPoint(42.1, 123))
+		g.err.Set(errors.New("last position"))
+		expectedPoint := geo.NewPoint(42.1, 123.)
+
+		point, flt, err := g.Position(context.Background(), nil)
+		test.That(t, movementsensor.ArePointsEqual(point, expectedPoint), test.ShouldBeTrue)
+		test.That(t, flt, test.ShouldEqual, 0.0)
+		test.That(t, err, test.ShouldBeNil)
+	})
+
 }

--- a/components/movementsensor/gpsutils/cachedData_test.go
+++ b/components/movementsensor/gpsutils/cachedData_test.go
@@ -2,6 +2,7 @@ package gpsutils
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	geo "github.com/kellydunn/golang-geo"
@@ -59,4 +60,50 @@ func TestReadingsSerial(t *testing.T) {
 	fix1, err := g.ReadFix(ctx)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, fix1, test.ShouldEqual, fix)
+}
+
+func TestLinearVelocity(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewTestLogger(t)
+	g := NewCachedData(&mockDataReader{}, logger)
+
+	t.Run("no compass heading", func(t *testing.T) {
+		g.nmeaData = NmeaParser{
+			CompassHeading: math.NaN(),
+		}
+
+		speed, err := g.LinearVelocity(ctx, make(map[string]interface{}))
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, speed.X, test.ShouldEqual, 0.0)
+		test.That(t, speed.Y, test.ShouldEqual, 0.0)
+	})
+
+	t.Run("test sample velocity", func(t *testing.T) {
+		// Two quandrants of the compass
+		// Enough to verify quadrant signs are correct
+
+		g.nmeaData = NmeaParser{
+			Speed:          speed,
+			CompassHeading: 60.,
+		}
+
+		expectedX := speed * math.Sqrt(3) / 2
+		expectedY := speed / 2
+
+		speed1, err := g.LinearVelocity(ctx, make(map[string]interface{}))
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, speed1.X, test.ShouldAlmostEqual, expectedX)
+		test.That(t, speed1.Y, test.ShouldAlmostEqual, expectedY)
+
+		g.nmeaData.CompassHeading = 150.
+
+		expectedX = speed / 2.
+		expectedY = speed * -math.Sqrt(3) / 2.
+
+		speed2, err := g.LinearVelocity(ctx, make(map[string]interface{}))
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, speed2.X, test.ShouldAlmostEqual, expectedX)
+		test.That(t, speed2.Y, test.ShouldAlmostEqual, expectedY)
+	})
+
 }

--- a/components/movementsensor/gpsutils/cachedData_test.go
+++ b/components/movementsensor/gpsutils/cachedData_test.go
@@ -9,6 +9,7 @@ import (
 	geo "github.com/kellydunn/golang-geo"
 	"go.viam.com/test"
 
+	"go.viam.com/rdk/components/movementsensor"
 	"go.viam.com/rdk/logging"
 )
 
@@ -74,10 +75,11 @@ func TestPosition(t *testing.T) {
 			Location: nil,
 		}
 
+		expectedPoint := geo.NewPoint(32.4, 54.2)
+
 		pos, alt, err := g.Position(ctx, make(map[string]interface{}))
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, pos.Lat(), test.ShouldEqual, 32.4)
-		test.That(t, pos.Lng(), test.ShouldEqual, 54.2)
+		test.That(t, movementsensor.ArePointsEqual(pos, expectedPoint), test.ShouldBeTrue)
 		test.That(t, alt, test.ShouldEqual, 0.0)
 	})
 
@@ -88,15 +90,15 @@ func TestPosition(t *testing.T) {
 			Alt:      12.1,
 		}
 
+		expectedPoint := geo.NewPoint(32.4, 54.2)
+
 		pos, alt, err := g.Position(ctx, make(map[string]interface{}))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, pos.Lat(), test.ShouldEqual, 32.4)
-		test.That(t, pos.Lng(), test.ShouldEqual, 54.2)
+		test.That(t, movementsensor.ArePointsEqual(pos, expectedPoint), test.ShouldBeTrue)
 		test.That(t, alt, test.ShouldEqual, 12.1)
 
 		// Check that the last known position was not updated
-		test.That(t, g.lastPosition.GetLastPosition().Lat(), test.ShouldEqual, 32.4)
-		test.That(t, g.lastPosition.GetLastPosition().Lng(), test.ShouldEqual, 54.2)
+		test.That(t, movementsensor.ArePointsEqual(g.lastPosition.GetLastPosition(), expectedPoint), test.ShouldBeTrue)
 	})
 
 	t.Run("Valid current location", func(t *testing.T) {
@@ -106,15 +108,15 @@ func TestPosition(t *testing.T) {
 			Alt:      1.3,
 		}
 
+		expectedPoint := geo.NewPoint(1.1, 1.2)
+
 		pos, alt, err := g.Position(ctx, make(map[string]interface{}))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, pos.Lat(), test.ShouldEqual, 1.1)
-		test.That(t, pos.Lng(), test.ShouldEqual, 1.2)
+		test.That(t, movementsensor.ArePointsEqual(pos, expectedPoint), test.ShouldBeTrue)
 		test.That(t, alt, test.ShouldEqual, 1.3)
 
 		// Check that the last known position was updated
-		test.That(t, g.lastPosition.GetLastPosition().Lat(), test.ShouldEqual, 1.1)
-		test.That(t, g.lastPosition.GetLastPosition().Lng(), test.ShouldEqual, 1.2)
+		test.That(t, movementsensor.ArePointsEqual(g.lastPosition.GetLastPosition(), expectedPoint), test.ShouldBeTrue)
 	})
 }
 

--- a/components/movementsensor/gpsutils/cachedData_test.go
+++ b/components/movementsensor/gpsutils/cachedData_test.go
@@ -221,3 +221,12 @@ func TestCompassHeading(t *testing.T) {
 		test.That(t, g.lastCompassHeading.GetLastCompassHeading(), test.ShouldEqual, 180.)
 	})
 }
+
+func TestCompassDegreeError(t *testing.T) {
+	var p1 *geo.Point = nil
+	p2 := geo.NewPoint(1, 1)
+
+	g := NewCachedData(&mockDataReader{}, logging.NewTestLogger(t))
+	cde := g.calculateCompassDegreeError(p1, p2)
+	test.That(t, math.IsNaN(cde), test.ShouldBeTrue)
+}

--- a/components/movementsensor/gpsutils/cachedData_test.go
+++ b/components/movementsensor/gpsutils/cachedData_test.go
@@ -92,6 +92,10 @@ func TestPosition(t *testing.T) {
 		test.That(t, pos.Lat(), test.ShouldEqual, 32.4)
 		test.That(t, pos.Lng(), test.ShouldEqual, 54.2)
 		test.That(t, alt, test.ShouldEqual, 12.1)
+
+		// Check that the last known position was not updated
+		test.That(t, g.lastPosition.GetLastPosition().Lat(), test.ShouldEqual, 32.4)
+		test.That(t, g.lastPosition.GetLastPosition().Lng(), test.ShouldEqual, 54.2)
 	})
 
 	t.Run("Valid current location", func(t *testing.T) {


### PR DESCRIPTION
Adding Go tests for GPS testing. These tests are passing and valid, but do not cover the entire testing regimen for `gpsrtkserial` + `cacheddata`. 

## CachedData Tests
- Tests the functionality of `cachedData.go`. 
- Tested calculated values for linear velocity, position, accuracy, compass direction, etc.
- Tested validation cases, for example: position returns last position if current position is invalid, last position updates to current position if current position is valid, etc.
- Did initial testing on position for gpsrtkserial conditional behavior

## To be Done
- Mimicking serial connection, NTRIP connection, etc., which is most of the behavior in `gpsrtkserial`. Otherwise any serial connection or stream connection cannot be tested (which is most of the methods). 
