### PR TITLE
[RSDK-7739] remove unexported position function from encoded motor

### DIFF
--- a/components/motor/gpio/mathutils.go
+++ b/components/motor/gpio/mathutils.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"time"
 
+	"go.viam.com/rdk/components/encoder"
 	"go.viam.com/rdk/components/motor"
 )
 
@@ -73,4 +74,11 @@ func checkSpeed(rpm, max float64) (string, error) {
 	default:
 		return "", nil
 	}
+}
+
+func checkEncPosType(posType encoder.PositionType) error {
+	if posType != encoder.PositionTypeTicks {
+		return fmt.Errorf("expected %v got %v", encoder.PositionTypeTicks.String(), posType.String())
+	}
+	return nil
 }

--- a/components/motor/gpio/mathutils.go
+++ b/components/motor/gpio/mathutils.go
@@ -76,6 +76,7 @@ func checkSpeed(rpm, max float64) (string, error) {
 	}
 }
 
+// checkEncPosType checks that the position type of an encoder is in ticks.
 func checkEncPosType(posType encoder.PositionType) error {
 	if posType != encoder.PositionTypeTicks {
 		return fmt.Errorf("expected %v got %v", encoder.PositionTypeTicks.String(), posType.String())


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-7739

small pr to help clean up encoded motor. This one changes encoded motor to read from the encoder directly, along with a few other smaller changes