### PR TITLE
Make NativeConfig TypeCasting Error more expressive

### DIFF
--- a/resource/config.go
+++ b/resource/config.go
@@ -122,7 +122,14 @@ func (conf Config) MarshalJSON() ([]byte, error) {
 // this should be a method on the type and hide away both Attributes and
 // ConvertedAttributes.
 func NativeConfig[T any](conf Config) (T, error) {
-	return utils.AssertType[T](conf.ConvertedAttributes)
+	var zero T
+	assertedConfig, err := utils.AssertType[T](conf.ConvertedAttributes)
+	if err != nil {
+		// error will be of the format expected x, but got y from AsssertType
+		return zero, fmt.Errorf(
+			"NativeConfig %w, make sure the type passed to Assert to matches the type passed into NativeConfig", err)
+	}
+	return assertedConfig, nil
 }
 
 // NewEmptyConfig returns a new, empty config for the given name and model.


### PR DESCRIPTION
The error given to the user looks like:
```
2024-05-26T19:50:17.399Z	ERROR	robot_server.rdk:component:motor/motor-1	resource/graph_node.go:230resource build error: rpc error: code = Unknown desc = expected fakemotor.Config but got *fakemotor.Config	{"resource":"rdk:component:motor/motor-1","model":"rand:fake-modules-go:fake-motor"}
```

Since we can pass a resource.Config structure when coding a Go module in three places: `RegisterComponent/Service`, `NativeConfig`, and `Reconfigure`, this isn't enough information to tell me what was complaining. 