### PR TITLE
RSDK-7881: Refactor Shutdown to use actual robot client

### DIFF
--- a/testutils/robottestutils/robot_utils.go
+++ b/testutils/robottestutils/robot_utils.go
@@ -41,8 +41,9 @@ func CreateBaseOptionsAndListener(tb testing.TB) (weboptions.Options, net.Listen
 func NewRobotClient(tb testing.TB, logger logging.Logger, addr string, dur time.Duration) *client.RobotClient {
 	tb.Helper()
 	// start robot client
+	ctx := context.Background()
 	robotClient, err := client.New(
-		context.Background(),
+		ctx,
 		addr,
 		logger,
 		client.WithRefreshEvery(dur),
@@ -50,6 +51,9 @@ func NewRobotClient(tb testing.TB, logger logging.Logger, addr string, dur time.
 		client.WithReconnectEvery(dur),
 	)
 	test.That(tb, err, test.ShouldBeNil)
+	tb.Cleanup(func() {
+		test.That(tb, robotClient.Close(ctx), test.ShouldBeNil)
+	})
 	return robotClient
 }
 
@@ -115,7 +119,7 @@ func ServerAsSeparateProcess(t *testing.T, cfgFileName string, logger logging.Lo
 //
 // WaitForServing will return true if the server has started successfully in the allotted time, and
 // false otherwise.
-//nolint
+// nolint
 func WaitForServing(observer *observer.ObservedLogs, port int) bool {
 	// Message:"\n\\_ 2024-02-07T20:47:03.576Z\tINFO\trobot_server\tweb/web.go:598\tserving\t{\"url\":\"http://127.0.0.1:20000\"}"
 	successRegex := regexp.MustCompile(fmt.Sprintf("\tserving\t.*:%d\"", port))

--- a/testutils/robottestutils/robot_utils.go
+++ b/testutils/robottestutils/robot_utils.go
@@ -119,7 +119,7 @@ func ServerAsSeparateProcess(t *testing.T, cfgFileName string, logger logging.Lo
 //
 // WaitForServing will return true if the server has started successfully in the allotted time, and
 // false otherwise.
-// nolint
+//nolint
 func WaitForServing(observer *observer.ObservedLogs, port int) bool {
 	// Message:"\n\\_ 2024-02-07T20:47:03.576Z\tINFO\trobot_server\tweb/web.go:598\tserving\t{\"url\":\"http://127.0.0.1:20000\"}"
 	successRegex := regexp.MustCompile(fmt.Sprintf("\tserving\t.*:%d\"", port))

--- a/web/server/entrypoint_test.go
+++ b/web/server/entrypoint_test.go
@@ -161,9 +161,6 @@ func TestShutdown(t *testing.T) {
 
 		addr := "localhost:" + strconv.Itoa(port)
 		rc := robottestutils.NewRobotClient(t, testLogger, addr, time.Second)
-		defer func() {
-			test.That(t, rc.Close(context.Background()), test.ShouldBeNil)
-		}()
 
 		testLogger.Info("Issuing shutdown.")
 		err = rc.Shutdown(context.Background())

--- a/web/server/entrypoint_test.go
+++ b/web/server/entrypoint_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"testing"
 	"time"
 
@@ -158,15 +159,14 @@ func TestShutdown(t *testing.T) {
 		}
 		test.That(t, success, test.ShouldBeTrue)
 
-		conn, err := robottestutils.Connect(port)
-		test.That(t, err, test.ShouldBeNil)
+		addr := "localhost:" + strconv.Itoa(port)
+		rc := robottestutils.NewRobotClient(t, testLogger, addr, time.Second)
 		defer func() {
-			test.That(t, conn.Close(), test.ShouldBeNil)
+			test.That(t, rc.Close(context.Background()), test.ShouldBeNil)
 		}()
-		rc := robotpb.NewRobotServiceClient(conn)
 
 		testLogger.Info("Issuing shutdown.")
-		_, err = rc.Shutdown(context.Background(), &robotpb.ShutdownRequest{})
+		err = rc.Shutdown(context.Background())
 
 		gtestutils.WaitForAssertionWithSleep(t, 50*time.Millisecond, 50, func(tb testing.TB) {
 			tb.Helper()


### PR DESCRIPTION
### Description
RSDK-7881: Refactor Shutdown to use actual robot client
* This PR refactors the `Shutdown()` integration test to use the actual robot client so that we don't have to maintain two different sets of expected errors between the test and the actual client. 