### PR TITLE
DATA-2664: Unlock the datamanagement lock prior to waiting for background sync workers to drain.

### DIFF
--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -638,8 +638,10 @@ func (svc *builtIn) startSyncScheduler(intervalMins float64) {
 func (svc *builtIn) cancelSyncScheduler() {
 	if svc.syncRoutineCancelFn != nil {
 		svc.syncRoutineCancelFn()
-		svc.backgroundWorkers.Wait()
 		svc.syncRoutineCancelFn = nil
+		svc.lock.Unlock()
+		svc.backgroundWorkers.Wait()
+		svc.lock.Lock()
 	}
 }
 

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -639,6 +639,10 @@ func (svc *builtIn) cancelSyncScheduler() {
 	if svc.syncRoutineCancelFn != nil {
 		svc.syncRoutineCancelFn()
 		svc.syncRoutineCancelFn = nil
+		// DATA-2664: A goroutine calling this method must currently be holding the data manager
+		// lock. The `uploadData` background goroutine can also acquire the data manager lock prior
+		// to learning to exit. Thus we release the lock such that the `uploadData` goroutine can
+		// make progress and exit.
 		svc.lock.Unlock()
 		svc.backgroundWorkers.Wait()
 		svc.lock.Lock()


### PR DESCRIPTION
I was able to reproduce the hang with a unittest that is attached in patch form to [DATA-2664](https://viam.atlassian.net/browse/DATA-2664). Unfortunately that leverages a [timely sleep](https://github.com/viamrobotics/rdk/blob/538896b370593c3b24071be5a7a88665d762c033/services/datamanager/builtin/builtin.go#L651-L652) to open a hole for the deadlock to form.

[DATA-2664]: https://viam.atlassian.net/browse/DATA-2664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ