### PR TITLE
DATA-2703 Fix oom

### DIFF
--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -703,8 +703,13 @@ func (svc *builtIn) sync() {
 	captureDir := svc.captureDir
 	fileLastModifiedMillis := svc.fileLastModifiedMillis
 	additionalSyncPaths := svc.additionalSyncPaths
+	if svc.syncer == nil {
+		svc.lock.Unlock()
+		return
+	}
 	syncer := svc.syncer
 	svc.lock.Unlock()
+
 	// Kick off a goroutine to retrieve all the names of the files to sync, then another 1000 to
 	// sync the files to Viam app.
 

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -734,7 +734,6 @@ func (svc *builtIn) sync(ctx context.Context) {
 //nolint:errcheck,nilerr
 func getAllFilesToSync(ctx context.Context, dirs []string, lastModifiedMillis int, syncer datasync.Manager, logger logging.Logger) {
 	numFiles := 0
-	fmt.Println("syncing")
 	for _, dir := range dirs {
 		_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 			if ctx.Err() != nil {
@@ -769,7 +768,6 @@ func getAllFilesToSync(ctx context.Context, dirs []string, lastModifiedMillis in
 			isCompletedCaptureFile := filepath.Ext(path) == datacapture.FileExt
 			if isCompletedCaptureFile || isStuckInProgressCaptureFile || isNonCaptureFileThatIsNotBeingWrittenTo {
 				syncer.SendFileToSync(path)
-				fmt.Println(numFiles)
 				numFiles++
 			}
 			return nil

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -734,7 +734,6 @@ func (svc *builtIn) sync() {
 	// 		}
 	// 	}()
 	// }
-
 }
 
 //nolint:errcheck,nilerr

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -753,8 +753,6 @@ func getAllFilesToSync(ctx context.Context, dirs []string, lastModifiedMillis in
 			if ctx.Err() != nil {
 				return filepath.SkipAll
 			}
-
-			// TODO: check for context cancellation and stopAfter time passed
 			if err != nil {
 				return nil
 			}
@@ -905,8 +903,8 @@ func countCaptureDirFiles(ctx context.Context, captureDir string) int {
 		if info.IsDir() {
 			return nil
 		}
-		// this is intentionally not doing as many checks as this is intended
-		// for debugging and does not need to be 100% accurate.
+		// this is intentionally not doing as many checkas as getAllFilesToSync because
+		// this is intended for debugging and does not need to be 100% accurate.
 		isCompletedCaptureFile := filepath.Ext(path) == datacapture.FileExt
 		if isCompletedCaptureFile {
 			numFiles++

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -712,16 +712,11 @@ func (svc *builtIn) sync() {
 
 	// Kick off a goroutine to retrieve all the names of the files to sync, then another 1000 to
 	// sync the files to Viam app.
-
-	svc.backgroundWorkers.Add(1)
-	go func() {
-		defer svc.backgroundWorkers.Done()
-		getAllFilesToSync(append([]string{captureDir}, additionalSyncPaths...),
-			fileLastModifiedMillis,
-			syncer,
-			svc.logger,
-		)
-	}()
+	getAllFilesToSync(append([]string{captureDir}, additionalSyncPaths...),
+		fileLastModifiedMillis,
+		syncer,
+		svc.logger,
+	)
 
 	// for i := 0; i < numWorkers; i++ {
 	// 	wg.Add(1)

--- a/services/datamanager/builtin/file_deletion_test.go
+++ b/services/datamanager/builtin/file_deletion_test.go
@@ -147,7 +147,9 @@ func TestFileDeletion(t *testing.T) {
 
 			var syncer datasync.Manager
 			if tc.syncEnabled {
-				s, err := datasync.NewManager("rick astley", mockClient, logger, tempCaptureDir, datasync.MaxParallelSyncRoutines)
+				filesToSync := make(chan string)
+				defer close(filesToSync)
+				s, err := datasync.NewManager("rick astley", mockClient, logger, tempCaptureDir, datasync.MaxParallelSyncRoutines, filesToSync)
 				test.That(t, err, test.ShouldBeNil)
 				syncer = s
 				defer syncer.Close()

--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -474,6 +474,14 @@ func TestArbitraryFileUpload(t *testing.T) {
 }
 
 func TestStreamingDCUpload(t *testing.T) {
+	// Set max unary file size to 1 byte, so it uses the streaming rpc. Reset the original
+	// value such that other tests take the correct code paths.
+	origSize := datasync.MaxUnaryFileSize
+	datasync.MaxUnaryFileSize = 1
+	defer func() {
+		datasync.MaxUnaryFileSize = origSize
+	}()
+
 	tests := []struct {
 		name        string
 		serviceFail bool
@@ -537,13 +545,6 @@ func TestStreamingDCUpload(t *testing.T) {
 				streamingDCUploads: make(chan *mockStreamingDCClient, 10),
 				fail:               &f,
 			}
-			// Set max unary file size to 1 byte, so it uses the streaming rpc. Reset the original
-			// value such that other tests take the correct code paths.
-			origSize := datasync.MaxUnaryFileSize
-			datasync.MaxUnaryFileSize = 1
-			defer func() {
-				datasync.MaxUnaryFileSize = origSize
-			}()
 			newDMSvc.SetSyncerConstructor(getTestSyncerConstructorMock(mockClient))
 			cfg.CaptureDisabled = true
 			cfg.ScheduledSyncDisabled = true

--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -924,9 +924,9 @@ func (m *mockStreamingDCClient) CloseSend() error {
 
 func getTestSyncerConstructorMock(client mockDataSyncServiceClient) datasync.ManagerConstructor {
 	return func(identity string, _ v1.DataSyncServiceClient, logger logging.Logger,
-		viamCaptureDotDir string, maxSyncThreads int,
+		viamCaptureDotDir string, maxSyncThreads int, filesToSync chan string,
 	) (datasync.Manager, error) {
-		return datasync.NewManager(identity, client, logger, viamCaptureDotDir, maxSyncThreads)
+		return datasync.NewManager(identity, client, logger, viamCaptureDotDir, maxSyncThreads, make(chan string))
 	}
 }
 

--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -537,8 +537,13 @@ func TestStreamingDCUpload(t *testing.T) {
 				streamingDCUploads: make(chan *mockStreamingDCClient, 10),
 				fail:               &f,
 			}
-			// Set max unary file size to 1 byte, so it uses the streaming rpc.
+			// Set max unary file size to 1 byte, so it uses the streaming rpc. Reset the original
+			// value such that other tests take the correct code paths.
+			origSize := datasync.MaxUnaryFileSize
 			datasync.MaxUnaryFileSize = 1
+			defer func() {
+				datasync.MaxUnaryFileSize = origSize
+			}()
 			newDMSvc.SetSyncerConstructor(getTestSyncerConstructorMock(mockClient))
 			cfg.CaptureDisabled = true
 			cfg.ScheduledSyncDisabled = true

--- a/services/datamanager/datasync/noop_sync.go
+++ b/services/datamanager/datasync/noop_sync.go
@@ -1,7 +1,5 @@
 package datasync
 
-import "time"
-
 type noopManager struct{}
 
 var _ Manager = (*noopManager)(nil)
@@ -11,7 +9,7 @@ func NewNoopManager() Manager {
 	return &noopManager{}
 }
 
-func (m *noopManager) SyncFile(path string, stopAfter time.Time) {}
+func (m *noopManager) SyncFile(path string) {}
 
 func (m *noopManager) SetArbitraryFileTags(tags []string) {}
 
@@ -20,5 +18,7 @@ func (m *noopManager) Close() {}
 func (m *noopManager) MarkInProgress(path string) bool {
 	return true
 }
+
+func (m *noopManager) SendFileToSync(path string) {}
 
 func (m *noopManager) UnmarkInProgress(path string) {}

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -142,7 +142,12 @@ func (s *syncer) SetArbitraryFileTags(tags []string) {
 }
 
 func (s *syncer) SendFileToSync(path string) {
-	s.filesToSync <- path
+	select {
+	case s.filesToSync <- path:
+		return
+	case <-s.cancelCtx.Done():
+		return
+	}
 }
 
 func (s *syncer) SyncFile(path string) {

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -90,8 +90,8 @@ func NewManager(identity string, client v1.DataSyncServiceClient, logger logging
 		arbitraryFileTags: []string{},
 		inProgress:        make(map[string]bool),
 		syncErrs:          make(chan error, 10),
-		//shold this be buffered?
-		filesToSync: make(chan string, 1000),
+
+		filesToSync: make(chan string, maxSyncThreads),
 
 		// syncRoutineTracker: make(chan struct{}, maxSyncThreads),
 		captureDir: captureDir,
@@ -106,7 +106,7 @@ func NewManager(identity string, client v1.DataSyncServiceClient, logger logging
 		ret.backgroundWorkers.Add(1)
 		go func() {
 			defer ret.backgroundWorkers.Done()
-			defer fmt.Print("exiting from sync thread, should not see") //REMOVE BEFORE MERGE
+			// defer fmt.Print("exiting from sync thread, should not see") //REMOVE BEFORE MERGE
 			for {
 				if cancelCtx.Err() != nil {
 					return

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -247,7 +247,7 @@ func (s *syncer) MarkInProgress(path string) bool {
 	s.progressLock.Lock()
 	defer s.progressLock.Unlock()
 	if s.inProgress[path] {
-		s.logger.Warnw("File already in progress, trying to mark it again", "file", path)
+		s.logger.Debugw("File already in progress, trying to mark it again", "file", path)
 		return false
 	}
 	s.inProgress[path] = true

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -91,8 +91,7 @@ func NewManager(identity string, client v1.DataSyncServiceClient, logger logging
 		inProgress:        make(map[string]bool),
 		syncErrs:          make(chan error, 10),
 		filesToSync:       filesToSync,
-		// syncRoutineTracker: make(chan struct{}, maxSyncThreads),
-		captureDir: captureDir,
+		captureDir:        captureDir,
 	}
 	ret.logRoutine.Add(1)
 	goutils.PanicCapturingGo(func() {
@@ -104,7 +103,6 @@ func NewManager(identity string, client v1.DataSyncServiceClient, logger logging
 		ret.backgroundWorkers.Add(1)
 		go func() {
 			defer ret.backgroundWorkers.Done()
-			// defer fmt.Print("exiting from sync thread, should not see") //REMOVE BEFORE MERGE
 			for {
 				if cancelCtx.Err() != nil {
 					return

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -90,7 +90,7 @@ func NewManager(identity string, client v1.DataSyncServiceClient, logger logging
 		arbitraryFileTags: []string{},
 		inProgress:        make(map[string]bool),
 		syncErrs:          make(chan error, 10),
-		filesToSync:       make(chan string), //shold this be buffered?
+
 		// syncRoutineTracker: make(chan struct{}, maxSyncThreads),
 		captureDir: captureDir,
 	}
@@ -104,7 +104,7 @@ func NewManager(identity string, client v1.DataSyncServiceClient, logger logging
 		ret.backgroundWorkers.Add(1)
 		go func() {
 			defer ret.backgroundWorkers.Done()
-			defer fmt.Print("exiting from sync thread, should not see")
+			// defer fmt.Print("exiting from sync thread, should not see") REMOVE BEFORE MERGE
 			for {
 				if cancelCtx.Err() != nil {
 					return


### PR DESCRIPTION
hey yall, this PR is to change how go funcs are handled by sync and datamangement. 
**Implementation**
The big change here is now when we call .sync from builtin, it ONLY sends a filepath on a channel. It does nothing else. Sync has a global channel that all paths are sent to. On sync initialization it makes go funcs that pull from that channel. The number of go funcs is equal to the configured max sync threads. 

The big change is that we've decoupled sync from the datamanger loosely speaking. On reconfigure or close, the context in sync is cancelled, the threads exit after syncing their current file, and are recreated correctly. 

**Testing**
this is where I will need yalls help @n0nick @tahiyasalam . I have not tested how the changes in builtin.go affect scheduled sync or on large dirs. I have a test set on a raspberry pi that I will use but so far, I have ONLY tested it on my laptop with a normal capture dir, not with hundreds of thousands of files. 

This pr will need cleanup but I'm hoping by putting it in review sooner, I can get more eyes to catch anything I might have missed. THanks for the help yall!

**Updating testing**:
This capture dir had 1.5 million files. With main viam-server, I saw memory peak at 9.7% usage with 125% cpu usage but with this patch it peaked at 5.0 w/ max cpu usage of 37% so this validates the testing on my mac yesterday in that we are more memory and cpu resource efficient with this change and we have a bound on resources vs letting grow as files count does. 
 would like yalls opinion if this is fine) is that because of the changes we introduced if there is a massive amount of data that needs to be synced at a time and a sync interval goes off, another ticket will not go off until it finishes syncing ALL files and the thread that would respond to the ticker going off would be blocked on channel sends as the work is being processed. I personally think this is fine as this thread will still exit if we close viam server/reconfigure. I tested this by enabling a capture while sync was happening and ensuring the robot responded appropriately. I also tested that sync reconfigured correctly even in the middle of syncing currently happening.
There are a couple small tests I think need to be done but I can handle at least one of them and would like yall to point out any I missed:
Timing how long it takes to sync a capture dir of ~100k files (will use my mac for this test and can do on pi but im not sure its 100% needed)
Any other reconfigure/close/deadlocky things that people can think of testing? 
Syncing 147k datapoints took 5 minutes total. Sycing 14k took 34 seconds. These files are small compared to normal datacapture files (200 bytes compared to 256kb but I didnt think that details mattered as much here) but either way its fast
