### PR TITLE
[RSDK-7847] only allow motion to use slam in localization mode

### DIFF
--- a/services/motion/builtin/builtin_utils_test.go
+++ b/services/motion/builtin/builtin_utils_test.go
@@ -23,6 +23,7 @@ import (
 	"go.viam.com/rdk/robot/framesystem"
 	robotimpl "go.viam.com/rdk/robot/impl"
 	"go.viam.com/rdk/services/motion"
+	"go.viam.com/rdk/services/slam"
 	"go.viam.com/rdk/spatialmath"
 	"go.viam.com/rdk/testutils/inject"
 )
@@ -85,6 +86,17 @@ func createInjectedSlam(name, pcdPath string, origin spatialmath.Pose) *inject.S
 			return origin, nil
 		}
 		return spatialmath.NewZeroPose(), nil
+	}
+	injectSlam.PropertiesFunc = func(ctx context.Context) (slam.Properties, error) {
+		return slam.Properties{
+			CloudSlam:             false,
+			MappingMode:           slam.MappingModeLocalizationOnly,
+			InternalStateFileType: ".pbstream",
+			SensorInfo: []slam.SensorInfo{
+				{Name: "my-camera", Type: slam.SensorTypeCamera},
+				{Name: "my-movement-sensor", Type: slam.SensorTypeMovementSensor},
+			},
+		}, nil
 	}
 	return injectSlam
 }

--- a/services/motion/builtin/move_request.go
+++ b/services/motion/builtin/move_request.go
@@ -578,6 +578,15 @@ func (ms *builtIn) newMoveOnMapRequest(
 		return nil, resource.DependencyNotFoundError(req.SlamName)
 	}
 
+	// verify slam is in localization mode
+	slamProps, err := slamSvc.Properties(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if slamProps.MappingMode != slam.MappingModeLocalizationOnly {
+		return nil, fmt.Errorf("expected SLAM to be in localization only mode, got %v", slamProps.MappingMode)
+	}
+
 	// gets the extents of the SLAM map
 	limits, err := slam.Limits(ctx, slamSvc, true)
 	if err != nil {

--- a/services/slam/fake/slam.go
+++ b/services/slam/fake/slam.go
@@ -97,7 +97,7 @@ func (slamSvc *SLAM) Properties(ctx context.Context) (slam.Properties, error) {
 
 	prop := slam.Properties{
 		CloudSlam:             false,
-		MappingMode:           slam.MappingModeNewMap,
+		MappingMode:           slam.MappingModeLocalizationOnly,
 		InternalStateFileType: ".pbstream",
 		SensorInfo: []slam.SensorInfo{
 			{Name: "my-camera", Type: slam.SensorTypeCamera},

--- a/services/slam/fake/slam.go
+++ b/services/slam/fake/slam.go
@@ -95,6 +95,8 @@ func (slamSvc *SLAM) Properties(ctx context.Context) (slam.Properties, error) {
 	_, span := trace.StartSpan(ctx, "slam::fake::Properties")
 	defer span.End()
 
+	// MappingModeLocalizationOnly may cause the frontend to not refresh, but it allows motion to work with
+	// fakeslam. Can make changes in motion to only restrict for cartographer if this becomes a problem.
 	prop := slam.Properties{
 		CloudSlam:             false,
 		MappingMode:           slam.MappingModeLocalizationOnly,

--- a/services/slam/fake/slam_test.go
+++ b/services/slam/fake/slam_test.go
@@ -45,7 +45,7 @@ func TestFakeProperties(t *testing.T) {
 	prop, err := slamSvc.Properties(context.Background())
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, prop.CloudSlam, test.ShouldBeFalse)
-	test.That(t, prop.MappingMode, test.ShouldEqual, slam.MappingModeNewMap)
+	test.That(t, prop.MappingMode, test.ShouldEqual, slam.MappingModeLocalizationOnly)
 	test.That(t, prop.InternalStateFileType, test.ShouldEqual, ".pbstream")
 	test.That(t, prop.SensorInfo, test.ShouldResemble,
 		[]slam.SensorInfo{

--- a/services/slam/slam.go
+++ b/services/slam/slam.go
@@ -64,6 +64,17 @@ const (
 	SensorTypeMovementSensor
 )
 
+func (t SensorType) String() string {
+	switch t {
+	case SensorTypeCamera:
+		return "camera"
+	case SensorTypeMovementSensor:
+		return "movement sensor"
+	default:
+		return "unsupported sensor type"
+	}
+}
+
 // API is a variable that identifies the slam resource API.
 var API = resource.APINamespaceRDK.WithServiceType(SubtypeName)
 

--- a/services/slam/slam.go
+++ b/services/slam/slam.go
@@ -45,6 +45,19 @@ const (
 	MappingModeUpdateExistingMap
 )
 
+func (t MappingMode) String() string {
+	switch t {
+	case MappingModeNewMap:
+		return "mapping mode"
+	case MappingModeLocalizationOnly:
+		return "localizing only mode"
+	case MappingModeUpdateExistingMap:
+		return "updating mode"
+	default:
+		return "unspecified mode"
+	}
+}
+
 // SensorTypeCamera is a camera sensor.
 const (
 	SensorTypeCamera = SensorType(iota)


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-7847

had a user that ran into some issues when trying to use SLAM, and one of them was that they were trying to use motion while in mapping mode. 

While normally that shouldn't be a huge issue, since cartographer can take a pretty long time to send maps while in mapping mode it ends up being a poor user experience when using motion on mid/large sized maps. 

this pr adds a check for motion to only use localization mode, but I want to make sure I'm not breaking anything else by doing this change. I could also special case this check to only validate the mode with cartographer by looking at the internal state file if that makes things easier. 