### PR TITLE
[RSDK-7890] ensure all motor drivers ignore rpm sign in GoTo

### DIFF
--- a/components/motor/gpio/controlled.go
+++ b/components/motor/gpio/controlled.go
@@ -245,6 +245,10 @@ func (cm *controlledMotor) GoTo(ctx context.Context, rpm, targetPosition float64
 		return err
 	}
 	rotations := targetPosition - pos
+
+	// ignore the direction of rpm
+	rpm = math.Abs(rpm)
+
 	// if you call GoFor with 0 revolutions, the motor will spin forever. If we are at the target,
 	// we must avoid this by not calling GoFor.
 	if rdkutils.Float64AlmostEqual(rotations, 0, 0.1) {

--- a/components/motor/gpio/encoded.go
+++ b/components/motor/gpio/encoded.go
@@ -319,6 +319,10 @@ func (m *EncodedMotor) GoTo(ctx context.Context, rpm, targetPosition float64, ex
 		return err
 	}
 	rotations := targetPosition - currRotations
+
+	// ignore the direction of rpm
+	rpm = math.Abs(rpm)
+
 	// if you call GoFor with 0 revolutions, the motor will spin forever. If we are at the target,
 	// we must avoid this by not calling GoFor.
 	if rdkutils.Float64AlmostEqual(rotations, 0, 0.1) {

--- a/components/motor/roboclaw/roboclaw.go
+++ b/components/motor/roboclaw/roboclaw.go
@@ -306,6 +306,10 @@ func (m *roboclawMotor) GoTo(ctx context.Context, rpm, positionRevolutions float
 	if m.conf.TicksPerRotation == 0 {
 		return errors.New("roboclaw needs an encoder connected to use GoTo")
 	}
+
+	// ignore the direction of rpm
+	rpm = math.Abs(rpm)
+
 	pos, err := m.Position(ctx, extra)
 	if err != nil {
 		return err


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-7890

turns out only 3 drivers were missing this logic, so thats nice