### PR TITLE
Remove unused fields

### DIFF
--- a/components/movementsensor/gpsrtkserial/gpsrtkserial.go
+++ b/components/movementsensor/gpsrtkserial/gpsrtkserial.go
@@ -106,7 +106,6 @@ type rtkSerial struct {
 	activeBackgroundWorkers sync.WaitGroup
 
 	err                movementsensor.LastError
-	lastposition       movementsensor.LastPosition
 	InputProtocol      string
 	isClosed           bool
 
@@ -191,7 +190,6 @@ func newRTKSerial(
 		cancelFunc:         cancelFunc,
 		logger:             logger,
 		err:                movementsensor.NewLastError(1, 1),
-		lastposition:       movementsensor.NewLastPosition(),
 	}
 
 	if err := g.Reconfigure(ctx, deps, conf); err != nil {
@@ -460,29 +458,20 @@ func (g *rtkSerial) receiveAndWriteSerial() {
 
 // Position returns the current geographic location of the MOVEMENTSENSOR.
 func (g *rtkSerial) Position(ctx context.Context, extra map[string]interface{}) (*geo.Point, float64, error) {
+	nanPoint := geo.NewPoint(math.NaN(), math.NaN())
+
 	lastError := g.err.Get()
 	if lastError != nil {
-		lastPosition := g.lastposition.GetLastPosition()
-		if lastPosition != nil {
-			return lastPosition, 0, nil
-		}
-		return geo.NewPoint(math.NaN(), math.NaN()), math.NaN(), lastError
+		return nanPoint, math.NaN(), lastError
 	}
 
 	position, alt, err := g.cachedData.Position(ctx, extra)
 	if err != nil {
-		// Use the last known valid position if current position is (0,0)/ NaN.
-		if position != nil && (movementsensor.IsZeroPosition(position) || movementsensor.IsPositionNaN(position)) {
-			lastPosition := g.lastposition.GetLastPosition()
-			if lastPosition != nil {
-				return lastPosition, alt, nil
-			}
-		}
-		return geo.NewPoint(math.NaN(), math.NaN()), math.NaN(), err
+		return nanPoint, math.NaN(), err
 	}
 
 	if movementsensor.IsPositionNaN(position) {
-		position = g.lastposition.GetLastPosition()
+		position = nanPoint
 	}
 	return position, alt, nil
 }

--- a/components/movementsensor/gpsrtkserial/gpsrtkserial.go
+++ b/components/movementsensor/gpsrtkserial/gpsrtkserial.go
@@ -105,9 +105,9 @@ type rtkSerial struct {
 
 	activeBackgroundWorkers sync.WaitGroup
 
-	err                movementsensor.LastError
-	InputProtocol      string
-	isClosed           bool
+	err           movementsensor.LastError
+	InputProtocol string
+	isClosed      bool
 
 	mu sync.Mutex
 
@@ -185,11 +185,11 @@ func newRTKSerial(
 
 	cancelCtx, cancelFunc := context.WithCancel(context.Background())
 	g := &rtkSerial{
-		Named:              conf.ResourceName().AsNamed(),
-		cancelCtx:          cancelCtx,
-		cancelFunc:         cancelFunc,
-		logger:             logger,
-		err:                movementsensor.NewLastError(1, 1),
+		Named:      conf.ResourceName().AsNamed(),
+		cancelCtx:  cancelCtx,
+		cancelFunc: cancelFunc,
+		logger:     logger,
+		err:        movementsensor.NewLastError(1, 1),
 	}
 
 	if err := g.Reconfigure(ctx, deps, conf); err != nil {

--- a/components/movementsensor/gpsrtkserial/gpsrtkserial.go
+++ b/components/movementsensor/gpsrtkserial/gpsrtkserial.go
@@ -107,7 +107,6 @@ type rtkSerial struct {
 
 	err                movementsensor.LastError
 	lastposition       movementsensor.LastPosition
-	lastcompassheading movementsensor.LastCompassHeading
 	InputProtocol      string
 	isClosed           bool
 
@@ -193,7 +192,6 @@ func newRTKSerial(
 		logger:             logger,
 		err:                movementsensor.NewLastError(1, 1),
 		lastposition:       movementsensor.NewLastPosition(),
-		lastcompassheading: movementsensor.NewLastCompassHeading(),
 	}
 
 	if err := g.Reconfigure(ctx, deps, conf); err != nil {

--- a/components/movementsensor/gpsrtkserial/gpsrtkserial_test.go
+++ b/components/movementsensor/gpsrtkserial/gpsrtkserial_test.go
@@ -101,7 +101,7 @@ func TestReconfigure(t *testing.T) {
 	test.That(t, g.wbaud, test.ShouldEqual, 115200)
 }
 
-// This sets the position to 12°34.5678' N, 123°45.6789' W, at time 12:34:56.78 UTC
+// This sets the position to 12°34.5678' N, 123°45.6789' W, at time 12:34:56.78 UTC.
 const setPositionSentence = "$GPGLL,1234.5678,N,12345.6789,W,123456.78,A,D*7F"
 
 // initializePosition sets the position in the cached data and returns the point it is set to.

--- a/components/movementsensor/gpsrtkserial/gpsrtkserial_test.go
+++ b/components/movementsensor/gpsrtkserial/gpsrtkserial_test.go
@@ -103,7 +103,7 @@ func TestReconfigure(t *testing.T) {
 
 // initializePosition sets the position in the cached data and returns the point it is set to.
 func initializePosition(cachedData *gpsutils.CachedData) *geo.Point {
-	// This sets the position to 12d34.5678m N, 123d45.6789m W, at time 12:34:56.78 UTC
+	// This sets the position to 12°34.5678' N, 123°45.6789' W, at time 12:34:56.78 UTC
 	setPositionSentence := "$GPGLL,1234.5678,N,12345.6789,W,123456.78,A,D*7F"
 	cachedData.ParseAndUpdate(setPositionSentence)
 	return geo.NewPoint(12.576130000000001, -123.76131500000001)

--- a/components/movementsensor/gpsrtkserial/gpsrtkserial_test.go
+++ b/components/movementsensor/gpsrtkserial/gpsrtkserial_test.go
@@ -120,7 +120,7 @@ func TestPosition(t *testing.T) {
 	// If there is last error and last position, return last position
 	t.Run("position with last error and last position", func(t *testing.T) {
 		g := &rtkSerial{
-			err:          movementsensor.NewLastError(1, 1),
+			err: movementsensor.NewLastError(1, 1),
 		}
 
 		g.err.Set(errors.New("last position"))
@@ -150,8 +150,8 @@ func TestPosition(t *testing.T) {
 	// If there is no last error, invalid current position and valid last position, return last position
 	t.Run("invalid position with valid last position, with position error", func(t *testing.T) {
 		g := &rtkSerial{
-			err:          movementsensor.NewLastError(1, 1),
-			cachedData:   gpsutils.NewCachedData(&mockDataReader{}, logging.NewTestLogger(t)),
+			err:        movementsensor.NewLastError(1, 1),
+			cachedData: gpsutils.NewCachedData(&mockDataReader{}, logging.NewTestLogger(t)),
 		}
 
 		expectedPos := geo.NewPoint(math.NaN(), math.NaN())
@@ -166,8 +166,8 @@ func TestPosition(t *testing.T) {
 	// Invalid current position from NMEA message, return last known position
 	t.Run("invalid position with valid last position, no error", func(t *testing.T) {
 		g := &rtkSerial{
-			err:          movementsensor.NewLastError(1, 1),
-			cachedData:   gpsutils.NewCachedData(&mockDataReader{}, logging.NewTestLogger(t)),
+			err:        movementsensor.NewLastError(1, 1),
+			cachedData: gpsutils.NewCachedData(&mockDataReader{}, logging.NewTestLogger(t)),
 		}
 
 		// NMEA sentence with invalid position, Fix quality is 0
@@ -183,8 +183,8 @@ func TestPosition(t *testing.T) {
 	// Valid current position, should return current position
 	t.Run("valid position, no error", func(t *testing.T) {
 		g := &rtkSerial{
-			err:          movementsensor.NewLastError(1, 1),
-			cachedData:   gpsutils.NewCachedData(&mockDataReader{}, logging.NewTestLogger(t)),
+			err:        movementsensor.NewLastError(1, 1),
+			cachedData: gpsutils.NewCachedData(&mockDataReader{}, logging.NewTestLogger(t)),
 		}
 
 		// Valid NMEA sentence

--- a/components/movementsensor/gpsrtkserial/gpsrtkserial_test.go
+++ b/components/movementsensor/gpsrtkserial/gpsrtkserial_test.go
@@ -101,10 +101,11 @@ func TestReconfigure(t *testing.T) {
 	test.That(t, g.wbaud, test.ShouldEqual, 115200)
 }
 
+// This sets the position to 12°34.5678' N, 123°45.6789' W, at time 12:34:56.78 UTC
+const setPositionSentence = "$GPGLL,1234.5678,N,12345.6789,W,123456.78,A,D*7F"
+
 // initializePosition sets the position in the cached data and returns the point it is set to.
 func initializePosition(cachedData *gpsutils.CachedData) *geo.Point {
-	// This sets the position to 12°34.5678' N, 123°45.6789' W, at time 12:34:56.78 UTC
-	setPositionSentence := "$GPGLL,1234.5678,N,12345.6789,W,123456.78,A,D*7F"
 	cachedData.ParseAndUpdate(setPositionSentence)
 	return geo.NewPoint(12.576130000000001, -123.76131500000001)
 }


### PR DESCRIPTION
This is hopefully super easy to review commit-by-commit. 

It turns out that the `rtkSerial` struct had `lastposition` and `lastcompassheading` fields in it that were never set in production, while the `cachedData` struct had similarly named fields that were set instead. The fields _were_ set only during tests, and although I think I've got the tests working correctly, that part could use extra scrutiny.

No behavioral changes are intended; I'm just removing dead code. 