### PR TITLE
RSDK-7917: Only output `TestReconfigureParity` logs on failure.

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -8,7 +8,6 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
-
 	"go.viam.com/utils"
 )
 

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -8,6 +8,8 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
+
+	"go.viam.com/utils"
 )
 
 var (
@@ -123,7 +125,7 @@ type MemLogger struct {
 func (memLogger *MemLogger) OutputLogs() {
 	appender := NewTestAppender(memLogger.tb)
 	for _, loggedEntry := range memLogger.observer.All() {
-		appender.Write(loggedEntry.Entry, loggedEntry.Context)
+		utils.UncheckedError(appender.Write(loggedEntry.Entry, loggedEntry.Context))
 	}
 }
 

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -111,6 +111,7 @@ func NewObservedTestLogger(tb testing.TB) (Logger, *observer.ObservedLogs) {
 	return logger, observedLogs
 }
 
+// MemLogger stores test logs in memory. And can write them on request with `OutputLogs`.
 type MemLogger struct {
 	Logger
 
@@ -118,6 +119,7 @@ type MemLogger struct {
 	observer *observer.ObservedLogs
 }
 
+// OutputLogs writes in-memory logs to the test object MemLogger was constructed with.
 func (memLogger *MemLogger) OutputLogs() {
 	appender := NewTestAppender(memLogger.tb)
 	for _, loggedEntry := range memLogger.observer.All() {
@@ -125,6 +127,8 @@ func (memLogger *MemLogger) OutputLogs() {
 	}
 }
 
+// NewInMemoryLogger creates a MemLogger that can be used to buffer test logs and output them on
+// command. This is handy if a test is noisy, but the output is useful when the test fails.
 func NewInMemoryLogger(tb testing.TB) *MemLogger {
 	observerCore, observedLogs := observer.New(zap.LevelEnablerFunc(zapcore.DebugLevel.Enabled))
 	logger := &impl{

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -1838,13 +1838,18 @@ func TestReconfigureParity(t *testing.T) {
 		"data/diff_config_deps11.json",
 		"data/diff_config_deps12.json",
 	}
-	logger := logging.NewTestLogger(t)
 	ctx := context.Background()
 
 	testReconfigureParity := func(t *testing.T, initCfg, updateCfg string) {
 		name := fmt.Sprintf("%s -> %s", initCfg, updateCfg)
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
+			// Capture logs for this sub-test run. Only output the logs if the test fails.
+			logger := logging.NewInMemoryLogger(t)
+			logOnFailure := rutils.NewGuard(func() {
+				logger.OutputLogs()
+			})
+			defer logOnFailure.OnFail()
 
 			// Configuration may mutate `*config.Config`, so we read it from
 			// file each time.
@@ -1862,6 +1867,7 @@ func TestReconfigureParity(t *testing.T) {
 			r2.reconfigure(ctx, cfg, true)
 
 			rdktestutils.VerifySameResourceNames(t, r1.ResourceNames(), r2.ResourceNames())
+			logOnFailure.Success()
 		})
 	}
 

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -1846,10 +1846,11 @@ func TestReconfigureParity(t *testing.T) {
 			t.Parallel()
 			// Capture logs for this sub-test run. Only output the logs if the test fails.
 			logger := logging.NewInMemoryLogger(t)
-			logOnFailure := rutils.NewGuard(func() {
-				logger.OutputLogs()
-			})
-			defer logOnFailure.OnFail()
+			defer func() {
+				if t.Failed() {
+					logger.OutputLogs()
+				}
+			}()
 
 			// Configuration may mutate `*config.Config`, so we read it from
 			// file each time.
@@ -1867,7 +1868,6 @@ func TestReconfigureParity(t *testing.T) {
 			r2.reconfigure(ctx, cfg, true)
 
 			rdktestutils.VerifySameResourceNames(t, r1.ResourceNames(), r2.ResourceNames())
-			logOnFailure.Success()
 		})
 	}
 


### PR DESCRIPTION
Output: https://gist.github.com/dgottlieb/9586d819b17313e6af00b78af79d2834

with an accidental debug line of:
```
Outputting logs. All: 52
```