### PR TITLE
RSDK-7923 - fix WebRTC connections between a viam-server and a module can involve non loopback interfaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,8 @@ require (
 	github.com/muesli/kmeans v0.3.1
 	github.com/nathan-fiscaletti/consolesize-go v0.0.0-20220204101620-317176b6684d
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
+	github.com/pion/interceptor v0.1.25
+	github.com/pion/logging v0.2.2
 	github.com/pion/mediadevices v0.6.4
 	github.com/pion/rtp v1.8.5
 	github.com/pion/webrtc/v3 v3.2.36
@@ -289,8 +291,6 @@ require (
 	github.com/pion/datachannel v1.5.5 // indirect
 	github.com/pion/dtls/v2 v2.2.7 // indirect
 	github.com/pion/ice/v2 v2.3.13 // indirect
-	github.com/pion/interceptor v0.1.25 // indirect
-	github.com/pion/logging v0.2.2 // indirect
 	github.com/pion/mdns v0.0.12 // indirect
 	github.com/pion/randutil v0.1.0 // indirect
 	github.com/pion/rtcp v1.2.14 // indirect

--- a/grpc/shared_conn.go
+++ b/grpc/shared_conn.go
@@ -186,7 +186,7 @@ func (sc *SharedConn) ResetConn(conn rpc.ClientConn, moduleLogger logging.Logger
 		sc.peerConn = nil
 	}
 
-	peerConn, err := NewLocalPeerConnection()
+	peerConn, err := NewLocalPeerConnection(sc.logger.AsZap())
 	if err != nil {
 		sc.logger.Warnw("Unable to create optional peer connection for module. Ignoring.", "err", err)
 		return
@@ -328,8 +328,7 @@ func (sc *SharedConn) Close() error {
 
 // NewLocalPeerConnection creates a peer connection that only accepts loopback
 // address candidates
-func NewLocalPeerConnection() (*webrtc.PeerConnection, error) {
-	logger := golog.Global()
+func NewLocalPeerConnection(logger golog.Logger) (*webrtc.PeerConnection, error) {
 	m := webrtc.MediaEngine{}
 	if err := m.RegisterDefaultCodecs(); err != nil {
 		return nil, err
@@ -349,7 +348,7 @@ func NewLocalPeerConnection() (*webrtc.PeerConnection, error) {
 		// Stolen from net/ip.go, `IP.String` method.
 		// Disallow non loopback addresses as this is a local peer connection
 		if p4 := ip.To4(); len(p4) == net.IPv4len && p4.IsLoopback() {
-			logger.Debugf("SetIPFilter is ip v4: %s", ip.String())
+			logger.Debugf("SetIPFilter allowing loppback ip: %s", ip.String())
 			return true
 		}
 		logger.Debugf("SetIPFilter disallowing ip: %s", ip.String())

--- a/grpc/shared_conn.go
+++ b/grpc/shared_conn.go
@@ -327,7 +327,7 @@ func (sc *SharedConn) Close() error {
 }
 
 // NewLocalPeerConnection creates a peer connection that only accepts loopback
-// address candidates
+// address candidates.
 func NewLocalPeerConnection(logger golog.Logger) (*webrtc.PeerConnection, error) {
 	m := webrtc.MediaEngine{}
 	if err := m.RegisterDefaultCodecs(); err != nil {

--- a/grpc/shared_conn.go
+++ b/grpc/shared_conn.go
@@ -4,14 +4,20 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"sync"
+	"time"
 
+	"github.com/edaniels/golog"
+	"github.com/pion/interceptor"
 	"github.com/pion/webrtc/v3"
 	"go.uber.org/multierr"
+	"go.uber.org/zap"
 	"go.viam.com/utils"
 	"go.viam.com/utils/rpc"
 	googlegrpc "google.golang.org/grpc"
 
+	pionLogging "github.com/pion/logging"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	rutils "go.viam.com/rdk/utils"
@@ -180,7 +186,7 @@ func (sc *SharedConn) ResetConn(conn rpc.ClientConn, moduleLogger logging.Logger
 		sc.peerConn = nil
 	}
 
-	peerConn, err := webrtc.NewPeerConnection(webrtc.Configuration{})
+	peerConn, err := NewLocalPeerConnection()
 	if err != nil {
 		sc.logger.Warnw("Unable to create optional peer connection for module. Ignoring.", "err", err)
 		return
@@ -318,4 +324,106 @@ func (sc *SharedConn) Close() error {
 	sc.peerConnMu.Unlock()
 
 	return multierr.Combine(err, sc.grpcConn.Close())
+}
+func NewLocalPeerConnection() (*webrtc.PeerConnection, error) {
+	logger := golog.Global()
+	m := webrtc.MediaEngine{}
+	if err := m.RegisterDefaultCodecs(); err != nil {
+		return nil, err
+	}
+	i := interceptor.Registry{}
+	if err := webrtc.RegisterDefaultInterceptors(&m, &i); err != nil {
+		return nil, err
+	}
+
+	var settingEngine webrtc.SettingEngine
+	settingEngine.SetIncludeLoopbackCandidate(true)
+	settingEngine.SetRelayAcceptanceMinWait(3 * time.Second)
+	settingEngine.SetIPFilter(func(ip net.IP) bool {
+		// Disallow ipv6 addresses since grpc-go does not currently support IPv6 scoped literals.
+		// See related grpc-go issue: https://github.com/grpc/grpc-go/issues/3272.
+		//
+		// Stolen from net/ip.go, `IP.String` method.
+		// Disallow non loopback addresses as this is a local peer connection
+		if p4 := ip.To4(); len(p4) == net.IPv4len && p4.IsLoopback() {
+			logger.Debugf("SetIPFilter is ip v4: %s", ip.String())
+			return true
+		}
+		logger.Debugf("SetIPFilter disallowing ip: %s", ip.String())
+
+		return false
+	})
+
+	options := []func(a *webrtc.API){webrtc.WithMediaEngine(&m), webrtc.WithInterceptorRegistry(&i)}
+	if utils.Debug {
+		settingEngine.LoggerFactory = WebRTCLoggerFactory{logger}
+	}
+	options = append(options, webrtc.WithSettingEngine(settingEngine))
+	webAPI := webrtc.NewAPI(options...)
+
+	// attempt to construct a PeerConnection
+	pc, err := webAPI.NewPeerConnection(webrtc.Configuration{})
+	if err != nil {
+		logger.Debugw("Unable to create optional peer connection for module. Skipping WebRTC for module...", "err", err)
+		return nil, err
+	}
+	return pc, nil
+}
+
+// WebRTCLoggerFactory wraps a golog.Logger for use with pion's webrtc logging system.
+type WebRTCLoggerFactory struct {
+	Logger golog.Logger
+}
+
+type webrtcLogger struct {
+	logger golog.Logger
+}
+
+func (l webrtcLogger) loggerWithSkip() golog.Logger {
+	return l.logger.Desugar().WithOptions(zap.AddCallerSkip(1)).Sugar()
+}
+
+func (l webrtcLogger) Trace(msg string) {
+	l.loggerWithSkip().Debug(msg)
+}
+
+func (l webrtcLogger) Tracef(format string, args ...interface{}) {
+	l.loggerWithSkip().Debugf(format, args...)
+}
+
+func (l webrtcLogger) Debug(msg string) {
+	l.loggerWithSkip().Debug(msg)
+}
+
+func (l webrtcLogger) Debugf(format string, args ...interface{}) {
+	l.loggerWithSkip().Debugf(format, args...)
+}
+
+func (l webrtcLogger) Info(msg string) {
+	l.loggerWithSkip().Info(msg)
+}
+
+func (l webrtcLogger) Infof(format string, args ...interface{}) {
+	l.loggerWithSkip().Infof(format, args...)
+}
+
+func (l webrtcLogger) Warn(msg string) {
+	l.loggerWithSkip().Warn(msg)
+}
+
+func (l webrtcLogger) Warnf(format string, args ...interface{}) {
+	l.loggerWithSkip().Warnf(format, args...)
+}
+
+func (l webrtcLogger) Error(msg string) {
+	l.loggerWithSkip().Error(msg)
+}
+
+func (l webrtcLogger) Errorf(format string, args ...interface{}) {
+	l.loggerWithSkip().Errorf(format, args...)
+}
+
+// NewLogger returns a new webrtc logger under the given scope.
+func (lf WebRTCLoggerFactory) NewLogger(scope string) pionLogging.LeveledLogger {
+	return webrtcLogger{lf.Logger.Named(scope)}
 }

--- a/grpc/shared_conn.go
+++ b/grpc/shared_conn.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/edaniels/golog"
 	"github.com/pion/interceptor"
+	pionLogging "github.com/pion/logging"
 	"github.com/pion/webrtc/v3"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
@@ -17,7 +18,6 @@ import (
 	"go.viam.com/utils/rpc"
 	googlegrpc "google.golang.org/grpc"
 
-	pionLogging "github.com/pion/logging"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	rutils "go.viam.com/rdk/utils"
@@ -325,6 +325,9 @@ func (sc *SharedConn) Close() error {
 
 	return multierr.Combine(err, sc.grpcConn.Close())
 }
+
+// NewLocalPeerConnection creates a peer connection that only accepts loopback
+// address candidates
 func NewLocalPeerConnection() (*webrtc.PeerConnection, error) {
 	logger := golog.Global()
 	m := webrtc.MediaEngine{}

--- a/grpc/shared_conn_test.go
+++ b/grpc/shared_conn_test.go
@@ -7,9 +7,10 @@ import (
 	"time"
 
 	"github.com/pion/webrtc/v3"
-	"go.viam.com/rdk/logging"
 	"go.viam.com/test"
 	"go.viam.com/utils/rpc"
+
+	"go.viam.com/rdk/logging"
 )
 
 func TestNewLocalPeerConnection(t *testing.T) {

--- a/grpc/shared_conn_test.go
+++ b/grpc/shared_conn_test.go
@@ -1,0 +1,183 @@
+package grpc
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pion/webrtc/v3"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/test"
+	"go.viam.com/utils/rpc"
+)
+
+func TestNewLocalPeerConnection(t *testing.T) {
+	t.Run("both NewLocalPeerConnections", func(t *testing.T) {
+		logger := logging.NewTestLogger(t)
+		client, err := NewLocalPeerConnection(logger.AsZap())
+		test.That(t, err, test.ShouldBeNil)
+		server, err := NewLocalPeerConnection(logger.AsZap())
+		test.That(t, err, test.ShouldBeNil)
+		var cMu sync.Mutex
+		clientCandates := []*webrtc.ICECandidate{}
+		client.OnICECandidate(func(i *webrtc.ICECandidate) {
+			cMu.Lock()
+			defer cMu.Unlock()
+			clientCandates = append(clientCandates, i)
+		})
+		clientPeerConnReady, clientPeerConnClosed, err := rpc.ConfigureForRenegotiation(client, logger.AsZap())
+		test.That(t, err, test.ShouldBeNil)
+
+		var sMu sync.Mutex
+		serverCandidates := []*webrtc.ICECandidate{}
+		server.OnICECandidate(func(i *webrtc.ICECandidate) {
+			sMu.Lock()
+			defer sMu.Unlock()
+			serverCandidates = append(serverCandidates, i)
+		})
+
+		defer func() {
+			test.That(t, client.Close(), test.ShouldBeNil)
+			<-clientPeerConnClosed
+		}()
+		serverPeerConnReady, serverPeerConnClosed, err := rpc.ConfigureForRenegotiation(server, logger.AsZap())
+		test.That(t, err, test.ShouldBeNil)
+		defer func() {
+			server.Close()
+			<-serverPeerConnClosed
+		}()
+		timeoutCtx, timeoutFn := context.WithTimeout(context.Background(), time.Second*10)
+		defer timeoutFn()
+
+		signalPair(t, client, server)
+
+		select {
+		case <-timeoutCtx.Done():
+			t.Log("timeout")
+			t.FailNow()
+		case <-clientPeerConnReady:
+		}
+
+		select {
+		case <-timeoutCtx.Done():
+			t.Log("timeout")
+			t.FailNow()
+		case <-serverPeerConnReady:
+		}
+
+		// proves that only the loopback address is considered an ice candidate for both
+		// client and server
+		cMu.Lock()
+		test.That(t, len(clientCandates), test.ShouldEqual, 2)
+		test.That(t, len(clientCandates), test.ShouldEqual, 2)
+		test.That(t, clientCandates[1], test.ShouldBeNil)
+		test.That(t, clientCandates[0], test.ShouldNotBeNil)
+		test.That(t, clientCandates[0].Address, test.ShouldResemble, "127.0.0.1")
+		cMu.Unlock()
+
+		sMu.Lock()
+		test.That(t, len(serverCandidates), test.ShouldEqual, 2)
+		test.That(t, serverCandidates[1], test.ShouldBeNil)
+		test.That(t, serverCandidates[0], test.ShouldNotBeNil)
+		test.That(t, serverCandidates[0].Address, test.ShouldResemble, "127.0.0.1")
+		sMu.Unlock()
+	})
+
+	t.Run("one NewLocalPeerConnection non local server", func(t *testing.T) {
+		logger := logging.NewTestLogger(t)
+		client, err := NewLocalPeerConnection(logger.AsZap())
+		test.That(t, err, test.ShouldBeNil)
+		server, err := webrtc.NewPeerConnection(webrtc.Configuration{})
+		test.That(t, err, test.ShouldBeNil)
+		clientPeerConnReady, clientPeerConnClosed, err := rpc.ConfigureForRenegotiation(client, logger.AsZap())
+		test.That(t, err, test.ShouldBeNil)
+
+		defer func() {
+			test.That(t, client.Close(), test.ShouldBeNil)
+			<-clientPeerConnClosed
+		}()
+		serverPeerConnReady, serverPeerConnClosed, err := rpc.ConfigureForRenegotiation(server, logger.AsZap())
+		test.That(t, err, test.ShouldBeNil)
+		defer func() {
+			server.Close()
+			<-serverPeerConnClosed
+		}()
+		timeoutCtx, timeoutFn := context.WithTimeout(context.Background(), time.Second*10)
+		defer timeoutFn()
+
+		signalPair(t, client, server)
+
+		select {
+		case <-timeoutCtx.Done():
+			t.Log("timeout")
+			t.FailNow()
+		case <-clientPeerConnReady:
+		}
+
+		select {
+		case <-timeoutCtx.Done():
+			t.Log("timeout")
+			t.FailNow()
+		case <-serverPeerConnReady:
+		}
+	})
+
+	t.Run("one NewLocalPeerConnection non local client", func(t *testing.T) {
+		logger := logging.NewTestLogger(t)
+		server, err := NewLocalPeerConnection(logger.AsZap())
+		test.That(t, err, test.ShouldBeNil)
+		client, err := webrtc.NewPeerConnection(webrtc.Configuration{})
+		test.That(t, err, test.ShouldBeNil)
+		clientPeerConnReady, clientPeerConnClosed, err := rpc.ConfigureForRenegotiation(client, logger.AsZap())
+		test.That(t, err, test.ShouldBeNil)
+
+		defer func() {
+			test.That(t, client.Close(), test.ShouldBeNil)
+			<-clientPeerConnClosed
+		}()
+		serverPeerConnReady, serverPeerConnClosed, err := rpc.ConfigureForRenegotiation(server, logger.AsZap())
+		test.That(t, err, test.ShouldBeNil)
+		defer func() {
+			server.Close()
+			<-serverPeerConnClosed
+		}()
+		timeoutCtx, timeoutFn := context.WithTimeout(context.Background(), time.Second*10)
+		defer timeoutFn()
+
+		signalPair(t, client, server)
+
+		select {
+		case <-timeoutCtx.Done():
+			t.Log("timeout")
+			t.FailNow()
+		case <-clientPeerConnReady:
+		}
+
+		select {
+		case <-timeoutCtx.Done():
+			t.Log("timeout")
+			t.FailNow()
+		case <-serverPeerConnReady:
+		}
+	})
+}
+
+func signalPair(t *testing.T, left, right *webrtc.PeerConnection) {
+	t.Helper()
+
+	leftOffer, err := left.CreateOffer(nil)
+	test.That(t, err, test.ShouldBeNil)
+	err = left.SetLocalDescription(leftOffer)
+	test.That(t, err, test.ShouldBeNil)
+	<-webrtc.GatheringCompletePromise(left)
+
+	leftOffer.SDP = left.LocalDescription().SDP
+	test.That(t, right.SetRemoteDescription(leftOffer), test.ShouldBeNil)
+
+	rightAnswer, err := right.CreateAnswer(nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, right.SetLocalDescription(rightAnswer), test.ShouldBeNil)
+	<-webrtc.GatheringCompletePromise(right)
+	test.That(t, left.SetRemoteDescription(rightAnswer), test.ShouldBeNil)
+}

--- a/module/module.go
+++ b/module/module.go
@@ -229,7 +229,7 @@ func NewModule(ctx context.Context, address string, logger logging.Logger) (*Mod
 	}
 
 	// attempt to construct a PeerConnection
-	pc, err := webrtc.NewPeerConnection(webrtc.Configuration{})
+	pc, err := rgrpc.NewLocalPeerConnection()
 	if err != nil {
 		logger.Debugw("Unable to create optional peer connection for module. Skipping WebRTC for module...", "err", err)
 		return m, nil

--- a/module/module.go
+++ b/module/module.go
@@ -229,7 +229,7 @@ func NewModule(ctx context.Context, address string, logger logging.Logger) (*Mod
 	}
 
 	// attempt to construct a PeerConnection
-	pc, err := rgrpc.NewLocalPeerConnection()
+	pc, err := rgrpc.NewLocalPeerConnection(logger.AsZap())
 	if err != nil {
 		logger.Debugw("Unable to create optional peer connection for module. Skipping WebRTC for module...", "err", err)
 		return m, nil

--- a/services/sensors/client.go
+++ b/services/sensors/client.go
@@ -1,7 +1,4 @@
 // Package sensors contains a gRPC based sensors service client
-//
-//nolint:staticcheck
-
 package sensors
 
 import (
@@ -50,11 +47,14 @@ func (c *client) Sensors(ctx context.Context, extra map[string]interface{}) ([]r
 	if err != nil {
 		return nil, err
 	}
+	//nolint:staticcheck
 	resp, err := c.client.GetSensors(ctx, &pb.GetSensorsRequest{Name: c.name, Extra: ext})
 	if err != nil {
 		return nil, err
 	}
+	//nolint:staticcheck
 	sensorNames := make([]resource.Name, 0, len(resp.SensorNames))
+	//nolint:staticcheck
 	for _, name := range resp.SensorNames {
 		sensorNames = append(sensorNames, rprotoutils.ResourceNameFromProto(name))
 	}
@@ -70,19 +70,24 @@ func (c *client) Readings(ctx context.Context, sensorNames []resource.Name, extr
 	if err != nil {
 		return nil, err
 	}
+	//nolint:staticcheck
 	resp, err := c.client.GetReadings(ctx, &pb.GetReadingsRequest{Name: c.name, SensorNames: names, Extra: ext})
 	if err != nil {
 		return nil, err
 	}
 
+	//nolint:staticcheck
 	readings := make([]Readings, 0, len(resp.Readings))
+	//nolint:staticcheck
 	for _, reading := range resp.Readings {
+		//nolint:staticcheck
 		sReading, err := rprotoutils.ReadingProtoToGo(reading.Readings)
 		if err != nil {
 			return nil, err
 		}
 		readings = append(
 			readings, Readings{
+				//nolint:staticcheck
 				Name:     rprotoutils.ResourceNameFromProto(reading.Name),
 				Readings: sReading,
 			})

--- a/services/sensors/client.go
+++ b/services/sensors/client.go
@@ -1,5 +1,6 @@
 // Package sensors contains a gRPC based sensors service client
 //
+//nolint:staticcheck
 
 package sensors
 

--- a/services/sensors/client.go
+++ b/services/sensors/client.go
@@ -1,6 +1,6 @@
 // Package sensors contains a gRPC based sensors service client
 //
-//nolint:staticcheck
+
 package sensors
 
 import (

--- a/services/sensors/server.go
+++ b/services/sensors/server.go
@@ -1,5 +1,4 @@
 // Package sensors contains a gRPC based sensors service server
-
 package sensors
 
 import (

--- a/services/sensors/server.go
+++ b/services/sensors/server.go
@@ -1,5 +1,6 @@
 // Package sensors contains a gRPC based sensors service server
 //
+//nolint:staticcheck
 
 package sensors
 

--- a/services/sensors/server.go
+++ b/services/sensors/server.go
@@ -1,6 +1,6 @@
 // Package sensors contains a gRPC based sensors service server
 //
-//nolint:staticcheck
+
 package sensors
 
 import (

--- a/services/sensors/server.go
+++ b/services/sensors/server.go
@@ -1,6 +1,4 @@
 // Package sensors contains a gRPC based sensors service server
-//
-//nolint:staticcheck
 
 package sensors
 
@@ -26,14 +24,17 @@ func NewRPCServiceServer(coll resource.APIResourceCollection[Service]) interface
 	return &serviceServer{coll: coll}
 }
 
+//nolint:staticcheck
 func (server *serviceServer) GetSensors(
 	ctx context.Context,
 	req *pb.GetSensorsRequest,
 ) (*pb.GetSensorsResponse, error) {
+	//nolint:staticcheck
 	svc, err := server.coll.Resource(req.Name)
 	if err != nil {
 		return nil, err
 	}
+	//nolint:staticcheck
 	names, err := svc.Sensors(ctx, req.Extra.AsMap())
 	if err != nil {
 		return nil, err
@@ -43,33 +44,41 @@ func (server *serviceServer) GetSensors(
 		sensorNames = append(sensorNames, protoutils.ResourceNameToProto(name))
 	}
 
+	//nolint:staticcheck
 	return &pb.GetSensorsResponse{SensorNames: sensorNames}, nil
 }
 
+//nolint:staticcheck
 func (server *serviceServer) GetReadings(
 	ctx context.Context,
 	req *pb.GetReadingsRequest,
 ) (*pb.GetReadingsResponse, error) {
+	//nolint:staticcheck
 	svc, err := server.coll.Resource(req.Name)
 	if err != nil {
 		return nil, err
 	}
+	//nolint:staticcheck
 	sensorNames := make([]resource.Name, 0, len(req.SensorNames))
+	//nolint:staticcheck
 	for _, name := range req.SensorNames {
 		sensorNames = append(sensorNames, protoutils.ResourceNameFromProto(name))
 	}
 
+	//nolint:staticcheck
 	readings, err := svc.Readings(ctx, sensorNames, req.Extra.AsMap())
 	if err != nil {
 		return nil, err
 	}
 
+	//nolint:staticcheck
 	readingsP := make([]*pb.Readings, 0, len(readings))
 	for _, reading := range readings {
 		rReading, err := protoutils.ReadingGoToProto(reading.Readings)
 		if err != nil {
 			return nil, err
 		}
+		//nolint:staticcheck
 		readingP := &pb.Readings{
 			Name:     protoutils.ResourceNameToProto(reading.Name),
 			Readings: rReading,
@@ -77,6 +86,7 @@ func (server *serviceServer) GetReadings(
 		readingsP = append(readingsP, readingP)
 	}
 
+	//nolint:staticcheck
 	return &pb.GetReadingsResponse{Readings: readingsP}, nil
 }
 

--- a/services/sensors/server_test.go
+++ b/services/sensors/server_test.go
@@ -149,6 +149,7 @@ func TestServerGetReadings(t *testing.T) {
 		ext, err := protoutils.StructToStructPb(extra)
 		test.That(t, err, test.ShouldBeNil)
 
+		//nolint:staticcheck
 		req := &pb.GetReadingsRequest{
 			Name:        testSvcName1.ShortName(),
 			SensorNames: []*commonpb.ResourceName{},
@@ -159,6 +160,7 @@ func TestServerGetReadings(t *testing.T) {
 		resp, err := server.GetReadings(context.Background(), req)
 		test.That(t, err, test.ShouldBeNil)
 
+		//nolint:staticcheck
 		test.That(t, len(resp.Readings), test.ShouldEqual, 2)
 		test.That(t, extraOptions, test.ShouldResemble, extra)
 
@@ -171,9 +173,10 @@ func TestServerGetReadings(t *testing.T) {
 		}
 
 		observed := map[resource.Name]interface{}{
-
+			//nolint:staticcheck
 			rprotoutils.ResourceNameFromProto(resp.Readings[0].Name): conv(resp.Readings[0].Readings),
 
+			//nolint:staticcheck
 			rprotoutils.ResourceNameFromProto(resp.Readings[1].Name): conv(resp.Readings[1].Readings),
 		}
 		test.That(t, observed, test.ShouldResemble, expected)

--- a/services/sensors/server_test.go
+++ b/services/sensors/server_test.go
@@ -32,7 +32,7 @@ func TestServerGetSensors(t *testing.T) {
 		sMap := map[resource.Name]sensors.Service{}
 		server, err := newServer(sMap)
 		test.That(t, err, test.ShouldBeNil)
-		
+		//nolint:staticcheck
 		_, err = server.GetSensors(context.Background(), &pb.GetSensorsRequest{})
 		test.That(t, err, test.ShouldBeError, errors.New("resource \"rdk:service:sensors/\" not found"))
 	})
@@ -48,7 +48,8 @@ func TestServerGetSensors(t *testing.T) {
 		injectSensors.SensorsFunc = func(ctx context.Context, extra map[string]interface{}) ([]resource.Name, error) {
 			return nil, passedErr
 		}
-		
+
+		//nolint:staticcheck
 		_, err = server.GetSensors(context.Background(), &pb.GetSensorsRequest{Name: testSvcName1.ShortName()})
 		test.That(t, err, test.ShouldBeError, passedErr)
 	})
@@ -71,14 +72,15 @@ func TestServerGetSensors(t *testing.T) {
 		ext, err := protoutils.StructToStructPb(extra)
 		test.That(t, err, test.ShouldBeNil)
 
-		
+		//nolint:staticcheck
 		resp, err := server.GetSensors(context.Background(), &pb.GetSensorsRequest{Name: testSvcName1.ShortName(), Extra: ext})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, extraOptions, test.ShouldResemble, extra)
 
-		
+		//nolint:staticcheck
 		convertedNames := make([]resource.Name, 0, len(resp.SensorNames))
-		
+
+		//nolint:staticcheck
 		for _, rn := range resp.SensorNames {
 			convertedNames = append(convertedNames, rprotoutils.ResourceNameFromProto(rn))
 		}
@@ -91,7 +93,8 @@ func TestServerGetReadings(t *testing.T) {
 		sMap := map[resource.Name]sensors.Service{}
 		server, err := newServer(sMap)
 		test.That(t, err, test.ShouldBeNil)
-		
+
+		//nolint:staticcheck
 		_, err = server.GetReadings(context.Background(), &pb.GetReadingsRequest{})
 		test.That(t, err, test.ShouldBeError, errors.New("resource \"rdk:service:sensors/\" not found"))
 	})
@@ -109,12 +112,14 @@ func TestServerGetReadings(t *testing.T) {
 		) ([]sensors.Readings, error) {
 			return nil, passedErr
 		}
-		
+
+		//nolint:staticcheck
 		req := &pb.GetReadingsRequest{
 			Name:        testSvcName1.ShortName(),
 			SensorNames: []*commonpb.ResourceName{},
 		}
-		
+
+		//nolint:staticcheck
 		_, err = server.GetReadings(context.Background(), req)
 		test.That(t, err, test.ShouldBeError, passedErr)
 	})
@@ -144,16 +149,16 @@ func TestServerGetReadings(t *testing.T) {
 		ext, err := protoutils.StructToStructPb(extra)
 		test.That(t, err, test.ShouldBeNil)
 
-		
 		req := &pb.GetReadingsRequest{
 			Name:        testSvcName1.ShortName(),
 			SensorNames: []*commonpb.ResourceName{},
 			Extra:       ext,
 		}
-		
+
+		//nolint:staticcheck
 		resp, err := server.GetReadings(context.Background(), req)
 		test.That(t, err, test.ShouldBeNil)
-		
+
 		test.That(t, len(resp.Readings), test.ShouldEqual, 2)
 		test.That(t, extraOptions, test.ShouldResemble, extra)
 
@@ -166,9 +171,9 @@ func TestServerGetReadings(t *testing.T) {
 		}
 
 		observed := map[resource.Name]interface{}{
-			
+
 			rprotoutils.ResourceNameFromProto(resp.Readings[0].Name): conv(resp.Readings[0].Readings),
-			
+
 			rprotoutils.ResourceNameFromProto(resp.Readings[1].Name): conv(resp.Readings[1].Readings),
 		}
 		test.That(t, observed, test.ShouldResemble, expected)
@@ -190,7 +195,8 @@ func TestServerDoCommand(t *testing.T) {
 		Name:    testSvcName1.ShortName(),
 		Command: cmd,
 	}
-	
+
+	//nolint:staticcheck
 	doCommandResponse, err := server.DoCommand(context.Background(), doCommandRequest)
 	test.That(t, err, test.ShouldBeNil)
 

--- a/services/sensors/server_test.go
+++ b/services/sensors/server_test.go
@@ -32,7 +32,7 @@ func TestServerGetSensors(t *testing.T) {
 		sMap := map[resource.Name]sensors.Service{}
 		server, err := newServer(sMap)
 		test.That(t, err, test.ShouldBeNil)
-		//nolint:staticcheck
+		
 		_, err = server.GetSensors(context.Background(), &pb.GetSensorsRequest{})
 		test.That(t, err, test.ShouldBeError, errors.New("resource \"rdk:service:sensors/\" not found"))
 	})
@@ -48,7 +48,7 @@ func TestServerGetSensors(t *testing.T) {
 		injectSensors.SensorsFunc = func(ctx context.Context, extra map[string]interface{}) ([]resource.Name, error) {
 			return nil, passedErr
 		}
-		//nolint:staticcheck
+		
 		_, err = server.GetSensors(context.Background(), &pb.GetSensorsRequest{Name: testSvcName1.ShortName()})
 		test.That(t, err, test.ShouldBeError, passedErr)
 	})
@@ -71,14 +71,14 @@ func TestServerGetSensors(t *testing.T) {
 		ext, err := protoutils.StructToStructPb(extra)
 		test.That(t, err, test.ShouldBeNil)
 
-		//nolint:staticcheck
+		
 		resp, err := server.GetSensors(context.Background(), &pb.GetSensorsRequest{Name: testSvcName1.ShortName(), Extra: ext})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, extraOptions, test.ShouldResemble, extra)
 
-		//nolint:staticcheck
+		
 		convertedNames := make([]resource.Name, 0, len(resp.SensorNames))
-		//nolint:staticcheck
+		
 		for _, rn := range resp.SensorNames {
 			convertedNames = append(convertedNames, rprotoutils.ResourceNameFromProto(rn))
 		}
@@ -91,7 +91,7 @@ func TestServerGetReadings(t *testing.T) {
 		sMap := map[resource.Name]sensors.Service{}
 		server, err := newServer(sMap)
 		test.That(t, err, test.ShouldBeNil)
-		//nolint:staticcheck
+		
 		_, err = server.GetReadings(context.Background(), &pb.GetReadingsRequest{})
 		test.That(t, err, test.ShouldBeError, errors.New("resource \"rdk:service:sensors/\" not found"))
 	})
@@ -109,12 +109,12 @@ func TestServerGetReadings(t *testing.T) {
 		) ([]sensors.Readings, error) {
 			return nil, passedErr
 		}
-		//nolint:staticcheck
+		
 		req := &pb.GetReadingsRequest{
 			Name:        testSvcName1.ShortName(),
 			SensorNames: []*commonpb.ResourceName{},
 		}
-		//nolint:staticcheck
+		
 		_, err = server.GetReadings(context.Background(), req)
 		test.That(t, err, test.ShouldBeError, passedErr)
 	})
@@ -144,16 +144,16 @@ func TestServerGetReadings(t *testing.T) {
 		ext, err := protoutils.StructToStructPb(extra)
 		test.That(t, err, test.ShouldBeNil)
 
-		//nolint:staticcheck
+		
 		req := &pb.GetReadingsRequest{
 			Name:        testSvcName1.ShortName(),
 			SensorNames: []*commonpb.ResourceName{},
 			Extra:       ext,
 		}
-		//nolint:staticcheck
+		
 		resp, err := server.GetReadings(context.Background(), req)
 		test.That(t, err, test.ShouldBeNil)
-		//nolint:staticcheck
+		
 		test.That(t, len(resp.Readings), test.ShouldEqual, 2)
 		test.That(t, extraOptions, test.ShouldResemble, extra)
 
@@ -166,9 +166,9 @@ func TestServerGetReadings(t *testing.T) {
 		}
 
 		observed := map[resource.Name]interface{}{
-			//nolint:staticcheck
+			
 			rprotoutils.ResourceNameFromProto(resp.Readings[0].Name): conv(resp.Readings[0].Readings),
-			//nolint:staticcheck
+			
 			rprotoutils.ResourceNameFromProto(resp.Readings[1].Name): conv(resp.Readings[1].Readings),
 		}
 		test.That(t, observed, test.ShouldResemble, expected)
@@ -190,7 +190,7 @@ func TestServerDoCommand(t *testing.T) {
 		Name:    testSvcName1.ShortName(),
 		Command: cmd,
 	}
-	//nolint:staticcheck
+	
 	doCommandResponse, err := server.DoCommand(context.Background(), doCommandRequest)
 	test.That(t, err, test.ShouldBeNil)
 


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-7923)

Original intent when we added WebRTC connection support between a module & a viam-server is to support sending webrtc track data from the module to the viam-server. We assumed the loopback address would always be used. Testing found that frequently one or the other peer bind to a non loopback interface. This change makes it so that the viam-server & module will both only allow candidates from the other which are on the loopback interface.

Manual Testing:
- [x] new go module, new viam-server: both peers always connect on 127.0.0.1 ports
- [x] old go module (erh/viamrtsp 0.0.3 using rdk version v0.26.0-rc0.0.20240503203304-30f601249ccf), new viam-server: go module might connect on non 127.0.0.1 port, aka no behavior change
- [x] new go module, old viam-server  (v0.28.1): go module might connect on non 127.0.0.1 port, aka no behavior change