### PR TITLE
RSDK-7885: Send Event to Run Networking Tests on Release Candidate

### DIFF
--- a/.github/workflows/releasecandidate.yml
+++ b/.github/workflows/releasecandidate.yml
@@ -80,4 +80,4 @@ jobs:
           -H "Authorization: token ${{secrets.GITHUB_TOKEN}}" \
           -H "Accept: application/vnd.github.everest-preview+json" \
           https://api.github.com/repos/viamrobotics/sdk-integration-tests/dispatches \
-          -d '{"event_type":"new-rc-branch"}'
+          -d '{"event_type":"new_rc_branch"}'

--- a/.github/workflows/releasecandidate.yml
+++ b/.github/workflows/releasecandidate.yml
@@ -67,8 +67,3 @@ jobs:
           slack_webhook_url: ${{secrets.SLACK_WEBHOOK_URL}}
           channel: '#team-devops'
           name: 'Workflow Status'
-    
-  run-sdk-integration-networking-tests:
-    needs: [staticbuild, appimage]
-    if: ${{ success() }}
-    uses: ./trigger-networking-tests.yml

--- a/.github/workflows/releasecandidate.yml
+++ b/.github/workflows/releasecandidate.yml
@@ -67,3 +67,17 @@ jobs:
           slack_webhook_url: ${{secrets.SLACK_WEBHOOK_URL}}
           channel: '#team-devops'
           name: 'Workflow Status'
+    
+  run-sdk-networking-tests:
+    needs: [test, staticbuild, appimage]
+    if: ${{ success() }}
+    name: Trigger Networking Tests Workflow
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Workflow
+        run: |
+          curl -X POST \
+          -H "Authorization: token ${{secrets.GITHUB_TOKEN}}" \
+          -H "Accept: application/vnd.github.everest-preview+json" \
+          https://api.github.com/repos/viamrobotics/sdk-integration-tests/dispatches \
+          -d '{"event_type":"new-rc-branch"}'

--- a/.github/workflows/releasecandidate.yml
+++ b/.github/workflows/releasecandidate.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Trigger Workflow
         run: |
           curl -X POST \
-          -H "Authorization: token ${{secrets.GITHUB_TOKEN}}" \
+          -H "Authorization: token ${{ secrets.REPO_READ_TOKEN }}" \
           -H "Accept: application/vnd.github+json" \
           https://api.github.com/repos/viamrobotics/sdk-integration-tests/dispatches \
           -d '{"event_type":"new_rc_branch"}'

--- a/.github/workflows/releasecandidate.yml
+++ b/.github/workflows/releasecandidate.yml
@@ -81,4 +81,3 @@ jobs:
           -H "Accept: application/vnd.github+json" \
           https://api.github.com/repos/viamrobotics/sdk-integration-tests/dispatches \
           -d '{"event_type":"new_rc_branch"}'
-          

--- a/.github/workflows/releasecandidate.yml
+++ b/.github/workflows/releasecandidate.yml
@@ -81,3 +81,4 @@ jobs:
           -H "Accept: application/vnd.github+json" \
           https://api.github.com/repos/viamrobotics/sdk-integration-tests/dispatches \
           -d '{"event_type":"new_rc_branch"}'
+          

--- a/.github/workflows/releasecandidate.yml
+++ b/.github/workflows/releasecandidate.yml
@@ -68,16 +68,7 @@ jobs:
           channel: '#team-devops'
           name: 'Workflow Status'
     
-  run-sdk-networking-tests:
+  run-sdk-integration-networking-tests:
     needs: [staticbuild, appimage]
     if: ${{ success() }}
-    name: Trigger Networking Tests Workflow
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger Workflow
-        run: |
-          curl -X POST \
-          -H "Authorization: token ${{ secrets.REPO_READ_TOKEN }}" \
-          -H "Accept: application/vnd.github+json" \
-          https://api.github.com/repos/viamrobotics/sdk-integration-tests/dispatches \
-          -d '{"event_type":"new_rc_branch"}'
+    uses: ./trigger-networking-tests.yml

--- a/.github/workflows/releasecandidate.yml
+++ b/.github/workflows/releasecandidate.yml
@@ -69,7 +69,7 @@ jobs:
           name: 'Workflow Status'
     
   run-sdk-networking-tests:
-    needs: [test, staticbuild, appimage]
+    needs: [staticbuild, appimage]
     if: ${{ success() }}
     name: Trigger Networking Tests Workflow
     runs-on: ubuntu-latest
@@ -78,6 +78,6 @@ jobs:
         run: |
           curl -X POST \
           -H "Authorization: token ${{secrets.GITHUB_TOKEN}}" \
-          -H "Accept: application/vnd.github.everest-preview+json" \
+          -H "Accept: application/vnd.github+json" \
           https://api.github.com/repos/viamrobotics/sdk-integration-tests/dispatches \
           -d '{"event_type":"new_rc_branch"}'

--- a/.github/workflows/trigger-networking-tests.yml
+++ b/.github/workflows/trigger-networking-tests.yml
@@ -1,0 +1,18 @@
+name: Trigger Networking Tests in sdk-integration-tests
+
+on:
+    workflow_call:
+    workflow_dispatch:
+
+jobs:
+    run-networking-tests:
+        name: Trigger Networking Tests Workflow
+        runs-on: ubuntu-latest
+        steps:
+        - name: Trigger Workflow
+          run: |
+            curl -X POST \
+            -H "Authorization: token ${{ secrets.REPO_READ_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/viamrobotics/sdk-integration-tests/dispatches \
+            -d '{"event_type":"new_rc_branch"}'


### PR DESCRIPTION
### Description
* **RSDK-7885:** Run Networking Tests on release Candidate
* See [this pr](https://github.com/viamrobotics/sdk-integration-tests/pull/35)
  * On RC build and upload success, sends an event to sdk-integration-test repo which triggers Networking Tests workflow for rc builds
### Testing
* Running this command will trigger Networking Tests in the `sdk-integration-tests` repo:
```shell
gh api \       
  -X POST \
  -H "Accept: application/vnd.github+json" \
  /repos/viamrobotics/sdk-integration-tests/dispatches \
  -f event_type=new_rc_branch
``` 