### PR TITLE
RSDK-7666 - fix log after test termination flake

### DIFF
--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -1002,6 +1002,11 @@ func greenLog(t *testing.T, msg string) {
 func TestRTPPassthrough(t *testing.T) {
 	ctx := context.Background()
 	logger := logging.NewInMemoryLogger(t)
+	defer func() {
+		if t.Failed() {
+			logger.OutputLogs()
+		}
+	}()
 
 	// Precompile module copies to avoid timeout issues when building takes too long.
 	modPath := rtestutils.BuildTempModule(t, "examples/customresources/demos/rtppassthrough")
@@ -1230,6 +1235,11 @@ func TestRTPPassthrough(t *testing.T) {
 func TestAddStreamMaxTrackErr(t *testing.T) {
 	ctx := context.Background()
 	logger := logging.NewInMemoryLogger(t)
+	defer func() {
+		if t.Failed() {
+			logger.OutputLogs()
+		}
+	}()
 
 	// Precompile module copies to avoid timeout issues when building takes too long.
 	modPath := rtestutils.BuildTempModule(t, "examples/customresources/demos/rtppassthrough")

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -1001,7 +1001,7 @@ func greenLog(t *testing.T, msg string) {
 
 func TestRTPPassthrough(t *testing.T) {
 	ctx := context.Background()
-	logger := logging.NewTestLogger(t)
+	logger := logging.NewInMemoryLogger(t)
 
 	// Precompile module copies to avoid timeout issues when building takes too long.
 	modPath := rtestutils.BuildTempModule(t, "examples/customresources/demos/rtppassthrough")
@@ -1229,7 +1229,7 @@ func TestRTPPassthrough(t *testing.T) {
 
 func TestAddStreamMaxTrackErr(t *testing.T) {
 	ctx := context.Background()
-	logger := logging.NewTestLogger(t)
+	logger := logging.NewInMemoryLogger(t)
 
 	// Precompile module copies to avoid timeout issues when building takes too long.
 	modPath := rtestutils.BuildTempModule(t, "examples/customresources/demos/rtppassthrough")


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-7666)

Using the in memory logger doesn't trigger go test to panic if it logs after the test terminates due to pion bugs.