### PR TITLE
RSDK-7403 - add sdp methods to resource

### DIFF
--- a/resource/name.go
+++ b/resource/name.go
@@ -140,3 +140,14 @@ func (n Name) String() string {
 	}
 	return name
 }
+
+// SDPTrackName returns a valid SDP video/audio track name as defined in RFC 4566 (https://www.rfc-editor.org/rfc/rfc4566)
+// where track names should not include colons.
+func (n Name) SDPTrackName() string {
+	return strings.ReplaceAll(n.ShortName(), ":", "+")
+}
+
+// SDPTrackNameToShortName takes the output of SDPTrackName() and returns the resource ShortName.
+func SDPTrackNameToShortName(name string) string {
+	return strings.ReplaceAll(name, "+", ":")
+}

--- a/resource/name_test.go
+++ b/resource/name_test.go
@@ -1,0 +1,165 @@
+package resource
+
+import (
+	"testing"
+
+	"go.viam.com/test"
+)
+
+func TestNewName(t *testing.T) {
+	type testCase struct {
+		api          API
+		nameString   string
+		expectedName Name
+	}
+
+	camAPI := API{Type: APIType{Namespace: APINamespace("rdk"), Name: "component"}, SubtypeName: "camera"}
+	test.That(t, camAPI, test.ShouldResemble, APINamespaceRDK.WithComponentType("camera"))
+
+	motionAPI := API{Type: APIType{Namespace: APINamespace("rdk"), Name: "service"}, SubtypeName: "motion"}
+	test.That(t, motionAPI, test.ShouldResemble, APINamespaceRDK.WithServiceType("motion"))
+
+	tcs := []testCase{
+		{
+			api:          camAPI,
+			nameString:   "cam-1",
+			expectedName: Name{API: camAPI, Remote: "", Name: "cam-1"},
+		},
+		{
+			api:        camAPI,
+			nameString: "remote:cam-1",
+
+			expectedName: Name{API: camAPI, Remote: "remote", Name: "cam-1"},
+		},
+		{
+			api:        camAPI,
+			nameString: "remoteA:remoteB:cam-1",
+
+			expectedName: Name{API: camAPI, Remote: "remoteA:remoteB", Name: "cam-1"},
+		},
+		{
+			api:        motionAPI,
+			nameString: "builtin",
+
+			expectedName: Name{API: motionAPI, Remote: "", Name: "builtin"},
+		},
+		{
+			api:        motionAPI,
+			nameString: "remote:builtin",
+
+			expectedName: Name{API: motionAPI, Remote: "remote", Name: "builtin"},
+		},
+		{
+			api:        motionAPI,
+			nameString: "remoteA:remoteB:builtin",
+
+			expectedName: Name{API: motionAPI, Remote: "remoteA:remoteB", Name: "builtin"},
+		},
+	}
+	for _, tc := range tcs {
+		test.That(t, NewName(tc.api, tc.nameString), test.ShouldResemble, tc.expectedName)
+	}
+}
+
+func TestNewFromString(t *testing.T) {
+	type testCase struct {
+		string       string
+		expectedErr  error
+		expectedName Name
+	}
+
+	camAPI := API{Type: APIType{Namespace: APINamespace("rdk"), Name: "component"}, SubtypeName: "camera"}
+	test.That(t, camAPI, test.ShouldResemble, APINamespaceRDK.WithComponentType("camera"))
+
+	motionAPI := API{Type: APIType{Namespace: APINamespace("rdk"), Name: "service"}, SubtypeName: "motion"}
+	test.That(t, motionAPI, test.ShouldResemble, APINamespaceRDK.WithServiceType("motion"))
+
+	tcs := []testCase{
+		{
+			string:       "rdk:component:camera/cam-1",
+			expectedName: Name{API: camAPI, Remote: "", Name: "cam-1"},
+		},
+		{
+			string:       "rdk:component:camera/remote:cam-1",
+			expectedName: Name{API: camAPI, Remote: "remote", Name: "cam-1"},
+		},
+		{
+			string:       "rdk:component:camera/remoteA:remoteB:cam-1",
+			expectedName: Name{API: camAPI, Remote: "remoteA:remoteB", Name: "cam-1"},
+		},
+		{
+			string:       "rdk:service:motion/builtin",
+			expectedName: Name{API: motionAPI, Remote: "", Name: "builtin"},
+		},
+		{
+			string:       "rdk:service:motion/remote:builtin",
+			expectedName: Name{API: motionAPI, Remote: "remote", Name: "builtin"},
+		},
+		{
+			string:       "rdk:service:motion/remoteA:remoteB:builtin",
+			expectedName: Name{API: motionAPI, Remote: "remoteA:remoteB", Name: "builtin"},
+		},
+	}
+	for _, tc := range tcs {
+		name, err := NewFromString(tc.string)
+		if tc.expectedErr != nil {
+			test.That(t, err, test.ShouldBeError, tc.expectedErr)
+		} else {
+			test.That(t, err, test.ShouldBeNil)
+		}
+		test.That(t, name, test.ShouldResemble, tc.expectedName)
+	}
+}
+
+func TestSDPTrackName(t *testing.T) {
+	type testCase struct {
+		name   Name
+		output string
+	}
+
+	camAPI := API{Type: APIType{Namespace: APINamespace("rdk"), Name: "component"}, SubtypeName: "camera"}
+	test.That(t, camAPI, test.ShouldResemble, APINamespaceRDK.WithComponentType("camera"))
+
+	tcs := []testCase{
+		{
+			name:   Name{API: camAPI, Remote: "", Name: "cam-1"},
+			output: "cam-1",
+		},
+		{
+			name:   Name{API: camAPI, Remote: "remote", Name: "cam-1"},
+			output: "remote+cam-1",
+		},
+		{
+			name:   Name{API: camAPI, Remote: "remoteA:remoteB", Name: "cam-1"},
+			output: "remoteA+remoteB+cam-1",
+		},
+	}
+	for _, tc := range tcs {
+		test.That(t, tc.name.SDPTrackName(), test.ShouldResemble, tc.output)
+	}
+}
+
+func TestSDPTrackNameToShortName(t *testing.T) {
+	type testCase struct {
+		input  string
+		output string
+	}
+
+	tcs := []testCase{
+		{
+			input:  "cam-1",
+			output: "cam-1",
+		},
+		{
+			input:  "remote+cam-1",
+			output: "remote:cam-1",
+		},
+		{
+			input:  "remoteA+remoteB+cam-1",
+			output: "remoteA:remoteB:cam-1",
+		},
+	}
+	for _, tc := range tcs {
+		test.That(t, SDPTrackNameToShortName(tc.input), test.ShouldResemble, tc.output)
+	}
+}

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -169,12 +169,6 @@ func hasManagedAuthHandlers(handlers []config.AuthHandlerConfig) bool {
 	return false
 }
 
-// validSDPTrackName returns a valid SDP video/audio track name as defined in RFC 4566 (https://www.rfc-editor.org/rfc/rfc4566)
-// where track names should not include colons.
-func validSDPTrackName(name string) string {
-	return strings.ReplaceAll(name, ":", "+")
-}
-
 // A Service controls the web server for a robot.
 type Service interface {
 	resource.Resource

--- a/robot/web/web_c.go
+++ b/robot/web/web_c.go
@@ -292,13 +292,13 @@ func (svc *webService) refreshVideoSources() {
 		if err != nil {
 			continue
 		}
-		existing, ok := svc.videoSources[validSDPTrackName(name)]
+		existing, ok := svc.videoSources[cam.Name().SDPTrackName()]
 		if ok {
 			existing.Swap(cam)
 			continue
 		}
 		newSwapper := gostream.NewHotSwappableVideoSource(cam)
-		svc.videoSources[validSDPTrackName(name)] = newSwapper
+		svc.videoSources[cam.Name().SDPTrackName()] = newSwapper
 	}
 }
 
@@ -309,13 +309,13 @@ func (svc *webService) refreshAudioSources() {
 		if err != nil {
 			continue
 		}
-		existing, ok := svc.audioSources[validSDPTrackName(name)]
+		existing, ok := svc.audioSources[input.Name().SDPTrackName()]
 		if ok {
 			existing.Swap(input)
 			continue
 		}
 		newSwapper := gostream.NewHotSwappableAudioSource(input)
-		svc.audioSources[validSDPTrackName(name)] = newSwapper
+		svc.audioSources[input.Name().SDPTrackName()] = newSwapper
 	}
 }
 

--- a/robot/web/web_test.go
+++ b/robot/web/web_test.go
@@ -859,12 +859,11 @@ func TestWebWithStreams(t *testing.T) {
 
 	// Start a robot with a camera
 	robot := &inject.Robot{}
-	cam1 := &inject.Camera{
-		PropertiesFunc: func(ctx context.Context) (camera.Properties, error) {
-			return camera.Properties{}, nil
-		},
+	cam1 := inject.NewCamera(camera1Key)
+	cam1.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
+		return camera.Properties{}, nil
 	}
-	rs := map[resource.Name]resource.Resource{camera.Named(camera1Key): cam1}
+	rs := map[resource.Name]resource.Resource{cam1.Name(): cam1}
 	robot.MockResourcesFromMap(rs)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -892,13 +891,12 @@ func TestWebWithStreams(t *testing.T) {
 	test.That(t, resp.Names, test.ShouldHaveLength, 1)
 
 	// Add another camera and update
-	cam2 := &inject.Camera{
-		PropertiesFunc: func(ctx context.Context) (camera.Properties, error) {
-			return camera.Properties{}, nil
-		},
+	cam2 := inject.NewCamera(camera2Key)
+	cam2.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
+		return camera.Properties{}, nil
 	}
 	robot.Mu.Lock()
-	rs[camera.Named(camera2Key)] = cam2
+	rs[cam2.Name()] = cam2
 	robot.Mu.Unlock()
 	robot.MockResourcesFromMap(rs)
 	err = svc.Reconfigure(context.Background(), rs, resource.Config{})
@@ -958,13 +956,12 @@ func TestWebAddFirstStream(t *testing.T) {
 	test.That(t, resp.Names, test.ShouldHaveLength, 0)
 
 	// Add first camera and update
-	cam1 := &inject.Camera{
-		PropertiesFunc: func(ctx context.Context) (camera.Properties, error) {
-			return camera.Properties{}, nil
-		},
+	cam1 := inject.NewCamera(camera1Key)
+	cam1.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
+		return camera.Properties{}, nil
 	}
 	robot.Mu.Lock()
-	rs[camera.Named(camera1Key)] = cam1
+	rs[cam1.Name()] = cam1
 	robot.Mu.Unlock()
 	robot.MockResourcesFromMap(rs)
 	err = svc.Reconfigure(ctx, rs, resource.Config{})


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-7403)

This splits out the additions of some resource functions / methods for handling SDP names (which are self contained) from https://github.com/viamrobotics/rdk/pull/3957

Needed to DRY up the linked PR