### PR TITLE
RSDK-7721: Fix bad module startup hang

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -1106,6 +1106,9 @@ func (m *module) startProcess(
 			}
 			return ctxTimeout.Err()
 		case <-checkTicker.C:
+			if errors.Is(m.process.Status(), os.ErrProcessDone) {
+				return fmt.Errorf("module %s cannot start", m.cfg.Name)
+			}
 		}
 		err = modlib.CheckSocketOwner(m.addr)
 		if errors.Is(err, fs.ErrNotExist) {

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -1107,7 +1107,10 @@ func (m *module) startProcess(
 			return ctxTimeout.Err()
 		case <-checkTicker.C:
 			if errors.Is(m.process.Status(), os.ErrProcessDone) {
-				return fmt.Errorf("module %s cannot start", m.cfg.Name)
+				return fmt.Errorf(
+					"module %s exited too quickly after attempted startup; it might have a fatal runtime issue",
+					m.cfg.Name,
+				)
 			}
 		}
 		err = modlib.CheckSocketOwner(m.addr)

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -1327,5 +1327,6 @@ func TestBadModuleFailsFast(t *testing.T) {
 	mgr := setupModManager(t, ctx, parentAddr, logger, opts)
 
 	err := mgr.Add(ctx, modCfgs...)
-	test.That(t, err.Error(), test.ShouldContainSubstring, "module test-module cannot start")
+
+	test.That(t, err.Error(), test.ShouldContainSubstring, "module test-module exited too quickly after attempted startup")
 }

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -1310,7 +1310,7 @@ func TestAddStreamMaxTrackErr(t *testing.T) {
 
 func TestBadModuleFailsFast(t *testing.T) {
 	t.Setenv("TESTMODULE_PANIC", "1")
-	logger, observer := logging.NewObservedTestLogger(t)
+	logger, _ := logging.NewObservedTestLogger(t)
 
 	modCfgs := []config.Module{
 		{
@@ -1328,6 +1328,4 @@ func TestBadModuleFailsFast(t *testing.T) {
 
 	err := mgr.Add(ctx, modCfgs...)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "module test-module cannot start")
-	waitingLogLine := "Waiting for module to complete startup and registration"
-	test.That(t, observer.FilterMessageSnippet(waitingLogLine), test.ShouldNotBeEmpty)
 }

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -1327,7 +1327,7 @@ func TestBadModuleFailsFast(t *testing.T) {
 	mgr := setupModManager(t, ctx, parentAddr, logger, opts)
 
 	err := mgr.Add(ctx, modCfgs...)
-	test.That(t, err.Error(), test.ShouldContainSubstring, "module test-module timed out")
+	test.That(t, err.Error(), test.ShouldContainSubstring, "module test-module cannot start")
 	waitingLogLine := "Waiting for module to complete startup and registration"
 	test.That(t, observer.FilterMessageSnippet(waitingLogLine), test.ShouldNotBeEmpty)
 }

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -1309,7 +1309,7 @@ func TestAddStreamMaxTrackErr(t *testing.T) {
 }
 
 func TestBadModuleFailsFast(t *testing.T) {
-	t.Setenv("TESTMODULE_PANIC", "1")
+	t.Setenv("VIAM_TESTMODULE_PANIC", "1")
 	logger := logging.NewTestLogger(t)
 
 	modCfgs := []config.Module{

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -1310,7 +1310,7 @@ func TestAddStreamMaxTrackErr(t *testing.T) {
 
 func TestBadModuleFailsFast(t *testing.T) {
 	t.Setenv("TESTMODULE_PANIC", "1")
-	logger, _ := logging.NewObservedTestLogger(t)
+	logger := logging.NewTestLogger(t)
 
 	modCfgs := []config.Module{
 		{

--- a/module/testmodule/main.go
+++ b/module/testmodule/main.go
@@ -32,6 +32,9 @@ func main() {
 }
 
 func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) error {
+	if os.Getenv("TESTMODULE_PANIC") != "" {
+		panic("there is no flavor town")
+	}
 	logger.Debug("debug mode enabled")
 
 	var err error

--- a/module/testmodule/main.go
+++ b/module/testmodule/main.go
@@ -32,7 +32,7 @@ func main() {
 }
 
 func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) error {
-	if os.Getenv("TESTMODULE_PANIC") != "" {
+	if os.Getenv("VIAM_TESTMODULE_PANIC") != "" {
 		panic("there is no flavor town")
 	}
 	logger.Debug("debug mode enabled")


### PR DESCRIPTION
The RDK server hangs and cannot process requests while it tries to load a module with a fatal bug (e.g. syntax error, immediate panic). This PR tries to detect if a module cannot start due to such an error and aborts loading to unblock the RDK.

### Testing
* See https://github.com/viamrobotics/rdk/pull/4090#issuecomment-2180710730