### PR TITLE
fix update-models command to ignore parent connection

### DIFF
--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -699,6 +699,8 @@ func readModels(path string, logger logging.Logger) ([]ModuleComponent, error) {
 	defer vutils.UncheckedErrorFunc(func() error { return os.RemoveAll(parentAddr) })
 	parentAddr += "/parent.sock"
 
+	os.Setenv("VALID_PARENT_SOCK", "false")
+
 	cfg := modconfig.Module{
 		Name:    "xxxx",
 		ExePath: path,

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -699,10 +699,10 @@ func readModels(path string, logger logging.Logger) ([]ModuleComponent, error) {
 	defer vutils.UncheckedErrorFunc(func() error { return os.RemoveAll(parentAddr) })
 	parentAddr += "/parent.sock"
 
-    // in some scenarios, we want to run module code without having a "real"
-    // parent available. This environment variable illustrates this.
-	os.Setenv("VALID_PARENT_SOCK", "false")
-    defer os.Unsetenv("VALID_PARENT_SOCK")
+	// in some scenarios, we want to run module code without having a "real"
+	// parent available. This environment variable illustrates this.
+	os.Setenv("VIAM_NO_MODULE_PARENT", "true")
+	defer os.Unsetenv("VIAM_NO_MODULE_PARENT")
 
 	cfg := modconfig.Module{
 		Name:    "xxxx",

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -699,7 +699,10 @@ func readModels(path string, logger logging.Logger) ([]ModuleComponent, error) {
 	defer vutils.UncheckedErrorFunc(func() error { return os.RemoveAll(parentAddr) })
 	parentAddr += "/parent.sock"
 
+    // in some scenarios, we want to run module code without having a "real"
+    // parent available. This environment variable illustrates this.
 	os.Setenv("VALID_PARENT_SOCK", "false")
+    defer os.Unsetenv("VALID_PARENT_SOCK")
 
 	cfg := modconfig.Module{
 		Name:    "xxxx",

--- a/cli/module_registry_test.go
+++ b/cli/module_registry_test.go
@@ -1,0 +1,38 @@
+package cli
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"go.viam.com/rdk/testutils"
+	"go.viam.com/rdk/testutils/inject"
+	"go.viam.com/test"
+)
+
+func TestUpdateModelsAction(t *testing.T) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.FailNow()
+	}
+	dir := filepath.Dir(filename)
+	binaryPath := testutils.BuildTempModule(t, "./module/testmodule")
+	modulePath := dir + "/../module/testmodule/module.json"
+	metaPath := dir + "/../module/testmodule/meta.json"
+
+	asc := &inject.AppServiceClient{}
+	flags := map[string]any{"binary": binaryPath, "module": metaPath}
+	cCtx, _, _, _ := setup(asc, nil, nil, nil, flags, "")
+	err := UpdateModelsAction(cCtx)
+	if err != nil {
+		t.FailNow()
+	}
+
+	// verify that the models added to meta.json are equivalent to those in module.json
+	moduleModels, err1 := loadManifest(modulePath)
+	metaModels, err2 := loadManifest(metaPath)
+	if err1 != nil || err2 != nil {
+		t.FailNow()
+	}
+	test.That(t, sameModels(moduleModels.Models, metaModels.Models), test.ShouldBeTrue)
+}

--- a/components/arm/arm.go
+++ b/components/arm/arm.go
@@ -64,6 +64,45 @@ func Named(name string) resource.Name {
 }
 
 // An Arm represents a physical robotic arm that exists in three-dimensional space.
+//
+// EndPosition example:
+//
+//	myArm, err := arm.FromRobot(machine, "my_arm")
+//	// Get the end position of the arm as a Pose.
+//	pos, err := myArm.EndPosition(context.Background(), nil)
+//
+// MoveToPosition example:
+//
+//	myArm, err := arm.FromRobot(machine, "my_arm")
+//	// Create a Pose for the arm.
+//	examplePose := spatialmath.NewPose(
+//	        r3.Vector{X: 5, Y: 5, Z: 5},
+//	        &spatialmath.OrientationVectorDegrees{0X: 5, 0Y: 5, Theta: 20}
+//	)
+//
+//	// Move your arm to the Pose.
+//	err = myArm.MoveToPosition(context.Background(), examplePose, nil)
+//
+// MoveToJointPositions example:
+//
+//	// Assumes you have imported "go.viam.com/api/component/arm/v1" as `componentpb`
+//	myArm, err := arm.FromRobot(machine, "my_arm")
+//
+//	// Declare an array of values with your desired rotational value for each joint on the arm.
+//	degrees := []float64{4.0, 5.0, 6.0}
+//
+//	// Declare a new JointPositions with these values.
+//	jointPos := &componentpb.JointPositions{Values: degrees}
+//
+//	// Move each joint of the arm to the position these values specify.
+//	err = myArm.MoveToJointPositions(context.Background(), jointPos, nil)
+//
+// JointPositions example:
+//
+//	myArm , err := arm.FromRobot(machine, "my_arm")
+//
+//	// Get the current position of each joint on the arm as JointPositions.
+//	pos, err := myArm.JointPositions(context.Background(), nil)
 type Arm interface {
 	resource.Resource
 	referenceframe.ModelFramer
@@ -72,47 +111,17 @@ type Arm interface {
 	referenceframe.InputEnabled
 
 	// EndPosition returns the current position of the arm.
-	//
-	//    myArm, err := arm.FromRobot(machine, "my_arm")
-	//    // Get the end position of the arm as a Pose.
-	//    pos, err := myArm.EndPosition(context.Background(), nil)
 	EndPosition(ctx context.Context, extra map[string]interface{}) (spatialmath.Pose, error)
 
 	// MoveToPosition moves the arm to the given absolute position.
-	// This will block until done or a new operation cancels this one
-	//
-	//    myArm, err := arm.FromRobot(machine, "my_arm")
-	//    // Create a Pose for the arm.
-	//    examplePose := spatialmath.NewPose(
-	//            r3.Vector{X: 5, Y: 5, Z: 5},
-	//            &spatialmath.OrientationVectorDegrees{0X: 5, 0Y: 5, Theta: 20}
-	//    )
-	//
-	//    // Move your arm to the Pose.
-	//    err = myArm.MoveToPosition(context.Background(), examplePose, nil)
+	// This will block until done or a new operation cancels this one.
 	MoveToPosition(ctx context.Context, pose spatialmath.Pose, extra map[string]interface{}) error
 
 	// MoveToJointPositions moves the arm's joints to the given positions.
-	// This will block until done or a new operation cancels this one
-	//
-	//    // Assumes you have imported "go.viam.com/api/component/arm/v1" as `componentpb`
-	//    myArm, err := arm.FromRobot(machine, "my_arm")
-	//
-	//    // Declare an array of values with your desired rotational value for each joint on the arm.
-	//    degrees := []float64{4.0, 5.0, 6.0}
-	//
-	//    // Declare a new JointPositions with these values.
-	//    jointPos := &componentpb.JointPositions{Values: degrees}
-	//
-	//    // Move each joint of the arm to the position these values specify.
-	//    err = myArm.MoveToJointPositions(context.Background(), jointPos, nil)
+	// This will block until done or a new operation cancels this one.
 	MoveToJointPositions(ctx context.Context, positionDegs *pb.JointPositions, extra map[string]interface{}) error
 
 	// JointPositions returns the current joint positions of the arm.
-	//    myArm , err := arm.FromRobot(machine, "my_arm")
-	//
-	//    // Get the current position of each joint on the arm as JointPositions.
-	//    pos, err := myArm.JointPositions(context.Background(), nil)
 	JointPositions(ctx context.Context, extra map[string]interface{}) (*pb.JointPositions, error)
 }
 

--- a/components/base/base.go
+++ b/components/base/base.go
@@ -34,6 +34,65 @@ func Named(name string) resource.Name {
 }
 
 // A Base represents a physical base of a robot.
+//
+// MoveStraight example:
+//
+//	myBase, err := base.FromRobot(machine, "my_base")
+//	// Move the base forward 40 mm at a velocity of 90 mm/s.
+//	myBase.MoveStraight(context.Background(), 40, 90, nil)
+//
+//	// Move the base backward 40 mm at a velocity of -90 mm/s.
+//	myBase.MoveStraight(context.Background(), 40, -90, nil)
+//
+// Spin example:
+//
+//	myBase, err := base.FromRobot(machine, "my_base")
+//
+//	// Spin the base 10 degrees at an angular velocity of 15 deg/sec.
+//	myBase.Spin(context.Background(), 10, 15, nil)
+//
+// SetPower example:
+//
+//	myBase, err := base.FromRobot(machine, "my_base")
+//
+//	// Make your wheeled base move forward. Set linear power to 75%.
+//	logger.Info("move forward")
+//	err = myBase.SetPower(context.Background(), r3.Vector{Y: .75}, r3.Vector{}, nil)
+//
+//	// Make your wheeled base move backward. Set linear power to -100%.
+//	logger.Info("move backward")
+//	err = myBase.SetPower(context.Background(), r3.Vector{Y: -1}, r3.Vector{}, nil)
+//
+//	// Make your wheeled base spin left. Set angular power to 100%.
+//	logger.Info("spin left")
+//	err = myBase.SetPower(context.Background(), r3.Vector{}, r3.Vector{Z: 1}, nil)
+//
+//	// Make your wheeled base spin right. Set angular power to -75%.
+//	logger.Info("spin right")
+//	err = mybase.SetPower(context.Background(), r3.Vector{}, r3.Vector{Z: -.75}, nil)
+//
+// SetVelocity example:
+//
+//	myBase, err := base.FromRobot(machine, "my_base")
+//
+//	// Set the linear velocity to 50 mm/sec and the angular velocity to 15 deg/sec.
+//	myBase.SetVelocity(context.Background(), r3.Vector{Y: 50}, r3.Vector{Z: 15}, nil)
+//
+// Properties example:
+//
+//	myBase, err := base.FromRobot(machine, "my_base")
+//
+//	// Get the width and turning radius of the base
+//	properties, err := myBase.Properties(context.Background(), nil)
+//
+//	// Get the width
+//	myBaseWidth := properties.WidthMeters
+//
+//	// Get the turning radius
+//	myBaseTurningRadius := properties.TurningRadiusMeters
+//
+//	// Get the wheel circumference
+//	myBaseWheelCircumference := properties.WheelCircumferenceMeters
 type Base interface {
 	resource.Resource
 	resource.Actuator
@@ -41,72 +100,26 @@ type Base interface {
 
 	// MoveStraight moves the robot straight a given distance at a given speed.
 	// If a distance or speed of zero is given, the base will stop.
-	// This method blocks until completed or cancelled
-	//
-	//    myBase, err := base.FromRobot(machine, "my_base")
-	//    // Move the base forward 40 mm at a velocity of 90 mm/s.
-	//    myBase.MoveStraight(context.Background(), 40, 90, nil)
-	//
-	//    // Move the base backward 40 mm at a velocity of -90 mm/s.
-	//    myBase.MoveStraight(context.Background(), 40, -90, nil)
+	// This method blocks until completed or cancelled.
 	MoveStraight(ctx context.Context, distanceMm int, mmPerSec float64, extra map[string]interface{}) error
 
 	// Spin spins the robot by a given angle in degrees at a given speed.
 	// If a speed of 0 the base will stop.
-	// Given a positive speed and a positive angle, the base turns to the left (for built-in RDK drivers)
-	// This method blocks until completed or cancelled
-	//
-	//    myBase, err := base.FromRobot(machine, "my_base")
-	//
-	//    // Spin the base 10 degrees at an angular velocity of 15 deg/sec.
-	//    myBase.Spin(context.Background(), 10, 15, nil)
+	// Given a positive speed and a positive angle, the base turns to the left (for built-in RDK drivers).
+	// This method blocks until completed or cancelled.
 	Spin(ctx context.Context, angleDeg, degsPerSec float64, extra map[string]interface{}) error
 
-	// For linear power, positive Y moves forwards for built-in RDK drivers
-	// For angular power, positive Z turns to the left for built-in RDK drivers
-	//    myBase, err := base.FromRobot(machine, "my_base")
-	//
-	//    // Make your wheeled base move forward. Set linear power to 75%.
-	//    logger.Info("move forward")
-	//    err = myBase.SetPower(context.Background(), r3.Vector{Y: .75}, r3.Vector{}, nil)
-	//
-	//    // Make your wheeled base move backward. Set linear power to -100%.
-	//    logger.Info("move backward")
-	//    err = myBase.SetPower(context.Background(), r3.Vector{Y: -1}, r3.Vector{}, nil)
-	//
-	//    // Make your wheeled base spin left. Set angular power to 100%.
-	//    logger.Info("spin left")
-	//    err = myBase.SetPower(context.Background(), r3.Vector{}, r3.Vector{Z: 1}, nil)
-	//
-	//    // Make your wheeled base spin right. Set angular power to -75%.
-	//    logger.Info("spin right")
-	//    err = mybase.SetPower(context.Background(), r3.Vector{}, r3.Vector{Z: -.75}, nil)
+	// Set the power of the base.
+	// For linear power, positive Y moves forwards for built-in RDK drivers.
+	// For angular power, positive Z turns to the left for built-in RDK drivers.
 	SetPower(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error
 
-	// linear is in mmPerSec (positive Y moves forwards for built-in RDK drivers)
-	// angular is in degsPerSec (positive Z turns to the left for built-in RDK drivers)
-	//
-	//    myBase, err := base.FromRobot(machine, "my_base")
-	//
-	//    // Set the linear velocity to 50 mm/sec and the angular velocity to 15 deg/sec.
-	//    myBase.SetVelocity(context.Background(), r3.Vector{Y: 50}, r3.Vector{Z: 15}, nil)
+	// Set the velocity of the base.
+	// linear is in mmPerSec (positive Y moves forwards for built-in RDK drivers).
+	// angular is in degsPerSec (positive Z turns to the left for built-in RDK drivers).
 	SetVelocity(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error
 
 	// Properties returns the width, turning radius, and wheel circumference of the physical base in meters.
-	//
-	//    myBase, err := base.FromRobot(machine, "my_base")
-	//
-	//    // Get the width and turning radius of the base
-	//    properties, err := myBase.Properties(context.Background(), nil)
-	//
-	//    // Get the width
-	//    myBaseWidth := properties.WidthMeters
-	//
-	//    // Get the turning radius
-	//    myBaseTurningRadius := properties.TurningRadiusMeters
-	//
-	//    // Get the wheel circumference
-	//    myBaseWheelCircumference := properties.WheelCircumferenceMeters
 	Properties(ctx context.Context, extra map[string]interface{}) (Properties, error)
 }
 

--- a/components/base/kinematicbase/execution.go
+++ b/components/base/kinematicbase/execution.go
@@ -157,15 +157,14 @@ func (ptgk *ptgBaseKinematics) GoToInputs(ctx context.Context, inputSteps ...[]r
 					return tryStop(ctx.Err())
 				}
 			}
-			distIncVel := step.linVelMMps.Y
-			if distIncVel == 0 {
-				distIncVel = step.angVelDegps.Z
-			}
+			inputValDiff := step.arcSegment.EndConfiguration[endDistanceAlongTrajectoryIndex].Value -
+				step.arcSegment.EndConfiguration[startDistanceAlongTrajectoryIndex].Value
+			elapsedPct := math.Min(1.0, timeElapsedSeconds/step.durationSeconds)
 			currentInputs := []referenceframe.Input{
 				step.arcSegment.StartConfiguration[ptgIndex],
 				step.arcSegment.StartConfiguration[trajectoryAlphaWithinPTG],
 				step.arcSegment.StartConfiguration[startDistanceAlongTrajectoryIndex],
-				{step.arcSegment.StartConfiguration[startDistanceAlongTrajectoryIndex].Value + math.Abs(distIncVel)*timeElapsedSeconds},
+				{step.arcSegment.StartConfiguration[startDistanceAlongTrajectoryIndex].Value + inputValDiff*elapsedPct},
 			}
 			ptgk.inputLock.Lock()
 			ptgk.currentState.currentInputs = currentInputs
@@ -298,7 +297,7 @@ func (ptgk *ptgBaseKinematics) trajectoryArcSteps(
 			timeStep = 0.
 		}
 		distIncrement := trajPt.Dist - curDist
-		curDist += distIncrement
+		curDist = trajPt.Dist
 		if nextStep.linVelMMps.Y != 0 {
 			timeStep += distIncrement / (math.Abs(nextStep.linVelMMps.Y))
 		} else if nextStep.angVelDegps.Z != 0 {

--- a/components/base/wheeled/wheeled_base_test.go
+++ b/components/base/wheeled/wheeled_base_test.go
@@ -82,8 +82,6 @@ func TestWheelBaseMath(t *testing.T) {
 	test.That(t, ok, test.ShouldBeTrue)
 
 	t.Run("basics", func(t *testing.T) {
-		// temporarily skipping this test until SetRPM (RSDK-7754) is implemented in fake motors
-		t.Skip()
 		props, err := wb.Properties(ctx, nil)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, props.WidthMeters, test.ShouldEqual, 100*0.001)
@@ -92,8 +90,8 @@ func TestWheelBaseMath(t *testing.T) {
 		test.That(t, len(geometries), test.ShouldBeZeroValue)
 		test.That(t, err, test.ShouldBeNil)
 
-		err = wb.SetVelocity(ctx, r3.Vector{X: 0, Y: 10, Z: 0}, r3.Vector{X: 0, Y: 0, Z: 10}, nil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "RPM that is nearly 0")
+		err = wb.SetVelocity(ctx, r3.Vector{X: 0, Y: 0, Z: 0}, r3.Vector{X: 0, Y: 0, Z: 0}, nil)
+		test.That(t, err, test.ShouldBeNil)
 
 		err = wb.SetVelocity(ctx, r3.Vector{X: 0, Y: 100, Z: 0}, r3.Vector{X: 0, Y: 0, Z: 100}, nil)
 		test.That(t, err, test.ShouldBeNil)

--- a/components/camera/camera.go
+++ b/components/camera/camera.go
@@ -83,49 +83,55 @@ type Camera interface {
 }
 
 // A VideoSource represents anything that can capture frames.
+//
+// Images example:
+//
+//	myCamera, err := camera.FromRobot(machine, "my_camera")
+//
+//	images, metadata, err := myCamera.Images(context.Background())
+//
+// Stream example:
+//
+//	myCamera, err := camera.FromRobot(machine, "my_camera")
+//
+//	// gets the stream from a camera
+//	stream, err := myCamera.Stream(context.Background())
+//
+//	// gets an image from the camera stream
+//	img, release, err := stream.Next(context.Background())
+//	defer release()
+//
+// NextPointCloud example:
+//
+//	myCamera, err := camera.FromRobot(machine, "my_camera")
+//
+//	// gets the properties from a camera
+//	properties, err := myCamera.Properties(context.Background())
+//
+// Close example:
+//
+//	myCamera, err := camera.FromRobot(machine, "my_camera")
+//
+//	err = myCamera.Close(ctx)
 type VideoSource interface {
 	projectorProvider
 	// Images is used for getting simultaneous images from different imagers,
 	// along with associated metadata (just timestamp for now). It's not for getting a time series of images from the same imager.
-	//
-	//    myCamera, err := camera.FromRobot(machine, "my_camera")
-	//
-	//    images, metadata, err := myCamera.Images(context.Background())
 	Images(ctx context.Context) ([]NamedImage, resource.ResponseMetadata, error)
+
 	// Stream returns a stream that makes a best effort to return consecutive images
 	// that may have a MIME type hint dictated in the context via gostream.WithMIMETypeHint.
-	//
-	//    myCamera, err := camera.FromRobot(machine, "my_camera")
-	//
-	//    // gets the stream from a camera
-	//    stream, err := myCamera.Stream(context.Background())
-	//
-	//    // gets an image from the camera stream
-	//    img, release, err := stream.Next(context.Background())
-	//    defer release()
 	Stream(ctx context.Context, errHandlers ...gostream.ErrorHandler) (gostream.VideoStream, error)
 
 	// NextPointCloud returns the next immediately available point cloud, not necessarily one
 	// a part of a sequence. In the future, there could be streaming of point clouds.
-	//
-	//    myCamera, err := camera.FromRobot(machine, "my_camera")
-	//
-	//    pointCloud, err := myCamera.NextPointCloud(context.Background())
 	NextPointCloud(ctx context.Context) (pointcloud.PointCloud, error)
+
 	// Properties returns properties that are intrinsic to the particular
-	// implementation of a camera
-	//
-	//    myCamera, err := camera.FromRobot(machine, "my_camera")
-	//
-	//    // gets the properties from a camera
-	//    properties, err := myCamera.Properties(context.Background())
+	// implementation of a camera.
 	Properties(ctx context.Context) (Properties, error)
 
-	// Close shuts down the resource and prevents further use
-	//
-	//    myCamera, err := camera.FromRobot(machine, "my_camera")
-	//
-	//    err = myCamera.Close(ctx)
+	// Close shuts down the resource and prevents further use.
 	Close(ctx context.Context) error
 }
 

--- a/components/encoder/encoder.go
+++ b/components/encoder/encoder.go
@@ -58,36 +58,42 @@ func (t PositionType) String() string {
 }
 
 // A Encoder turns a position into a signal.
+//
+// Position example:
+//
+//	myEncoder, err := encoder.FromRobot(machine, "my_encoder")
+//	if err != nil {
+//	  logger.Fatalf("cannot get encoder: %v", err)
+//	}
+//
+//	// Get the position of the encoder in ticks
+//	position, posType, err := myEncoder.Position(context.Background(), encoder.PositionTypeTicks, nil)
+//
+// ResetPosition example:
+//
+//	myEncoder, err := encoder.FromRobot(machine, "my_encoder")
+//	if err != nil {
+//	  logger.Fatalf("cannot get encoder: %v", err)
+//	}
+//
+//	err = myEncoder.ResetPosition(context.Background(), nil)
+//
+// Properties example:
+//
+//	myEncoder, err := encoder.FromRobot(machine, "my_encoder")
+//
+//	// Get whether the encoder returns position in ticks or degrees.
+//	properties, err := myEncoder.Properties(context.Background(), nil)
 type Encoder interface {
 	resource.Resource
 
 	// Position returns the current position in terms of ticks or degrees, and whether it is a relative or absolute position.
-	//
-	//    myEncoder, err := encoder.FromRobot(machine, "my_encoder")
-	//    if err != nil {
-	//      logger.Fatalf("cannot get encoder: %v", err)
-	//    }
-	//
-	//    // Get the position of the encoder in ticks
-	//    position, posType, err := myEncoder.Position(context.Background(), encoder.PositionTypeTicks, nil)
 	Position(ctx context.Context, positionType PositionType, extra map[string]interface{}) (float64, PositionType, error)
 
 	// ResetPosition sets the current position of the motor to be its new zero position.
-	//
-	//    myEncoder, err := encoder.FromRobot(machine, "my_encoder")
-	//    if err != nil {
-	//      logger.Fatalf("cannot get encoder: %v", err)
-	//    }
-	//
-	//    err = myEncoder.ResetPosition(context.Background(), nil)
 	ResetPosition(ctx context.Context, extra map[string]interface{}) error
 
-	// Properties returns a list of all the position types that are supported by a given encoder
-	//
-	//    myEncoder, err := encoder.FromRobot(machine, "my_encoder")
-	//
-	//    // Get whether the encoder returns position in ticks or degrees.
-	//    properties, err := myEncoder.Properties(context.Background(), nil)
+	// Properties returns a list of all the position types that are supported by a given encoder.
 	Properties(ctx context.Context, extra map[string]interface{}) (Properties, error)
 }
 

--- a/components/gantry/gantry.go
+++ b/components/gantry/gantry.go
@@ -41,48 +41,56 @@ func Named(name string) resource.Name {
 }
 
 // Gantry is used for controlling gantries of N axis.
+//
+// Position example:
+//
+//	myGantry, err := gantry.FromRobot(machine, "my_gantry")
+//
+//	// Get the current positions of the axes of the gantry in millimeters.
+//	position, err := myGantry.Position(context.Background(), nil)
+//
+// MoveToPosition example:
+//
+//	myGantry, err := gantry.FromRobot(machine, "my_gantry")
+//
+//	// Create a list of positions for the axes of the gantry to move to.
+//	// Assume in this example that the gantry is multi-axis, with 3 axes.
+//	examplePositions := []float64{1, 2, 3}
+//
+//	exampleSpeeds := []float64{3, 9, 12}
+//
+//	// Move the axes of the gantry to the positions specified.
+//	myGantry.MoveToPosition(context.Background(), examplePositions, exampleSpeeds, nil)
+//
+// Lengths example:
+//
+//	myGantry, err := gantry.FromRobot(machine, "my_gantry")
+//
+//	// Get the lengths of the axes of the gantry in millimeters.
+//	lengths_mm, err := myGantry.Lengths(context.Background(), nil)
+//
+// Home example:
+//
+//	myGantry, err := gantry.FromRobot(machine, "my_gantry")
+//
+//	myGantry.Home(context.Background(), nil)
 type Gantry interface {
 	resource.Resource
 	resource.Actuator
 	referenceframe.ModelFramer
 	referenceframe.InputEnabled
 
-	// Position returns the position in meters
-	//
-	//    myGantry, err := gantry.FromRobot(machine, "my_gantry")
-	//
-	//    // Get the current positions of the axes of the gantry in millimeters.
-	//    position, err := myGantry.Position(context.Background(), nil)
+	// Position returns the position in meters.
 	Position(ctx context.Context, extra map[string]interface{}) ([]float64, error)
 
-	// MoveToPosition is in meters
-	// This will block until done or a new operation cancels this one
-	//
-	//    myGantry, err := gantry.FromRobot(machine, "my_gantry")
-	//
-	//    // Create a list of positions for the axes of the gantry to move to.
-	//    // Assume in this example that the gantry is multi-axis, with 3 axes.
-	//    examplePositions := []float64{1, 2, 3}
-	//
-	//    exampleSpeeds := []float64{3, 9, 12}
-	//
-	//    // Move the axes of the gantry to the positions specified.
-	//    myGantry.MoveToPosition(context.Background(), examplePositions, exampleSpeeds, nil)
+	// MoveToPosition is in meters.
+	// This will block until done or a new operation cancels this one.
 	MoveToPosition(ctx context.Context, positionsMm, speedsMmPerSec []float64, extra map[string]interface{}) error
 
-	// Lengths is the length of gantries in meters
-	//
-	//    myGantry, err := gantry.FromRobot(machine, "my_gantry")
-	//
-	//    // Get the lengths of the axes of the gantry in millimeters.
-	//    lengths_mm, err := myGantry.Lengths(context.Background(), nil)
+	// Lengths is the length of gantries in meters.
 	Lengths(ctx context.Context, extra map[string]interface{}) ([]float64, error)
 
-	// Home runs the homing sequence of the gantry and returns true once completed
-	//
-	//    myGantry, err := gantry.FromRobot(machine, "my_gantry")
-	//
-	//    myGantry.Home(context.Background(), nil)
+	// Home runs the homing sequence of the gantry and returns true once completed.
 	Home(ctx context.Context, extra map[string]interface{}) (bool, error)
 }
 

--- a/components/gripper/gripper.go
+++ b/components/gripper/gripper.go
@@ -51,12 +51,12 @@ type Gripper interface {
 	referenceframe.ModelFramer
 
 	// Open opens the gripper.
-	// This will block until done or a new operation cancels this one
+	// This will block until done or a new operation cancels this one.
 	Open(ctx context.Context, extra map[string]interface{}) error
 
 	// Grab makes the gripper grab.
 	// returns true if we grabbed something.
-	// This will block until done or a new operation cancels this one
+	// This will block until done or a new operation cancels this one.
 	Grab(ctx context.Context, extra map[string]interface{}) (bool, error)
 }
 

--- a/components/motor/dimensionengineering/sabertooth.go
+++ b/components/motor/dimensionengineering/sabertooth.go
@@ -404,6 +404,7 @@ func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[s
 	}
 
 	if revolutions == 0 {
+		m.logger.Warn("Deprecated: setting revolutions == 0 will spin the motor indefinitely at the specified RPM")
 		return nil
 	}
 
@@ -422,7 +423,12 @@ func (m *Motor) GoTo(ctx context.Context, rpm, position float64, extra map[strin
 
 // SetRPM instructs the motor to move at the specified RPM indefinitely.
 func (m *Motor) SetRPM(ctx context.Context, rpm float64, extra map[string]interface{}) error {
-	return motor.NewSetRPMUnsupportedError(m.Name().ShortName())
+	if m.maxRPM == 0 {
+		return motor.NewZeroRPMError()
+	}
+
+	powerPct := rpm / m.maxRPM
+	return m.SetPower(ctx, powerPct, extra)
 }
 
 // ResetZeroPosition defines the current position to be zero (+/- offset).

--- a/components/motor/dimensionengineering/sabertooth_test.go
+++ b/components/motor/dimensionengineering/sabertooth_test.go
@@ -95,6 +95,37 @@ func TestSabertoothMotor(t *testing.T) {
 		test.That(t, fmt.Sprint(latestLoggedEntry), test.ShouldContainSubstring, "nearly 0")
 	})
 
+	t.Run("motor SetRPM testing", func(t *testing.T) {
+		// Test 0 (aka "stop")
+		test.That(t, motor1.SetRPM(ctx, 0, nil), test.ShouldBeNil)
+		checkTx(t, resChan, c, []byte{0x80, 0x00, 0x00, 0x00})
+		allObs := obs.All()
+		latestLoggedEntry := allObs[len(allObs)-1]
+		test.That(t, fmt.Sprint(latestLoggedEntry), test.ShouldContainSubstring, "nearly 0")
+
+		// Test 0.5 of max power
+		test.That(t, motor1.SetRPM(ctx, 0.5, nil), test.ShouldBeNil)
+		checkTx(t, resChan, c, []byte{0x80, 0x00, 0x3f, 0x3f})
+
+		// Test -0.5 of max power
+		test.That(t, motor1.SetRPM(ctx, -0.5, nil), test.ShouldBeNil)
+		checkTx(t, resChan, c, []byte{0x80, 0x01, 0x3f, 0x40})
+
+		// Test max power
+		test.That(t, motor1.SetRPM(ctx, 1, nil), test.ShouldBeNil)
+		checkTx(t, resChan, c, []byte{0x80, 0x00, 0x7f, 0x7f})
+		allObs = obs.All()
+		latestLoggedEntry = allObs[len(allObs)-1]
+		test.That(t, fmt.Sprint(latestLoggedEntry), test.ShouldContainSubstring, "nearly the max")
+
+		// Test 0 (aka "stop")
+		test.That(t, motor1.SetRPM(ctx, 0, nil), test.ShouldBeNil)
+		checkTx(t, resChan, c, []byte{0x80, 0x00, 0x00, 0x00})
+		allObs = obs.All()
+		latestLoggedEntry = allObs[len(allObs)-1]
+		test.That(t, fmt.Sprint(latestLoggedEntry), test.ShouldContainSubstring, "nearly 0")
+	})
+
 	mc2 := dimensionengineering.Config{
 		SerialPath:    "testchan",
 		MotorChannel:  2,

--- a/components/motor/fake/motor_test.go
+++ b/components/motor/fake/motor_test.go
@@ -61,7 +61,7 @@ func TestGoFor(t *testing.T) {
 	err = m.GoFor(ctx, 0, 1, nil)
 	allObs := obs.All()
 	latestLoggedEntry := allObs[len(allObs)-1]
-	test.That(t, fmt.Sprint(latestLoggedEntry), test.ShouldContainSubstring, "nearly 0")
+	test.That(t, fmt.Sprint(latestLoggedEntry), test.ShouldContainSubstring, "motor speed is 0 rev_per_min")
 	test.That(t, err, test.ShouldBeError, motor.NewZeroRPMError())
 
 	err = m.GoFor(ctx, 60, 1, nil)
@@ -102,16 +102,53 @@ func TestGoTo(t *testing.T) {
 	test.That(t, fmt.Sprint(latestLoggedEntry), test.ShouldContainSubstring, "nearly the max")
 
 	err = m.GoTo(ctx, 0, 1, nil)
-	test.That(t, err, test.ShouldBeNil)
+	test.That(t, err, test.ShouldNotBeNil)
 	allObs = obs.All()
 	latestLoggedEntry = allObs[3]
-	test.That(t, fmt.Sprint(latestLoggedEntry), test.ShouldContainSubstring, "nearly 0")
+	test.That(t, fmt.Sprint(latestLoggedEntry), test.ShouldContainSubstring, "motor speed is 0 rev_per_min")
 
 	testutils.WaitForAssertion(t, func(tb testing.TB) {
 		tb.Helper()
 		pos, err := m.Position(ctx, nil)
 		test.That(tb, err, test.ShouldBeNil)
 		test.That(tb, pos, test.ShouldEqual, 1)
+	})
+}
+
+func TestSetRPM(t *testing.T) {
+	logger, obs := logging.NewObservedTestLogger(t)
+	ctx := context.Background()
+
+	enc, err := fake.NewEncoder(context.Background(), resource.Config{
+		ConvertedAttributes: &fake.Config{},
+	}, logger)
+	test.That(t, err, test.ShouldBeNil)
+	m := &Motor{
+		Encoder:           enc.(fake.Encoder),
+		Logger:            logger,
+		PositionReporting: true,
+		MaxRPM:            60,
+		TicksPerRotation:  1,
+		OpMgr:             operation.NewSingleOperationManager(),
+	}
+
+	err = m.SetRPM(ctx, 0, nil)
+	allObs := obs.All()
+	latestLoggedEntry := allObs[len(allObs)-1]
+	test.That(t, fmt.Sprint(latestLoggedEntry), test.ShouldContainSubstring, "motor speed is 0 rev_per_min")
+	test.That(t, err, test.ShouldBeError, motor.NewZeroRPMError())
+
+	err = m.SetRPM(ctx, 60, nil)
+	test.That(t, err, test.ShouldBeNil)
+	allObs = obs.All()
+	latestLoggedEntry = allObs[1]
+	test.That(t, fmt.Sprint(latestLoggedEntry), test.ShouldContainSubstring, "nearly the max")
+
+	testutils.WaitForAssertion(t, func(tb testing.TB) {
+		tb.Helper()
+		pos, err := m.Position(ctx, nil)
+		test.That(tb, err, test.ShouldBeNil)
+		test.That(tb, pos, test.ShouldBeGreaterThan, 0)
 	})
 }
 

--- a/components/motor/motor.go
+++ b/components/motor/motor.go
@@ -90,7 +90,7 @@ type Motor interface {
 	resource.Actuator
 
 	// SetPower sets the percentage of power the motor should employ between -1 and 1.
-	// Negative power corresponds to a backward direction of rotation
+	// Negative power corresponds to a backward direction of rotation.
 	SetPower(ctx context.Context, powerPct float64, extra map[string]interface{}) error
 
 	// GoFor instructs the motor to go in a specific direction for a specific amount of
@@ -103,8 +103,8 @@ type Motor interface {
 
 	// GoTo instructs the motor to go to a specific position (provided in revolutions from home/zero),
 	// at a specific speed. Regardless of the directionality of the RPM this function will move the motor
-	// towards the specified target/position
-	// This will block until the position has been reached
+	// towards the specified target/position.
+	// This will block until the position has been reached.
 	GoTo(ctx context.Context, rpm, positionRevolutions float64, extra map[string]interface{}) error
 
 	// SetRPM instructs the motor to move at the specified RPM indefinitely.

--- a/components/movementsensor/gpsutils/ntrip.go
+++ b/components/movementsensor/gpsutils/ntrip.go
@@ -147,9 +147,7 @@ Loop:
 		}
 		fields := strings.Split(ln, ";")
 		switch fields[0] {
-		case "CAS":
-			continue
-		case "NET":
+		case "CAS", "NET":
 			continue
 		case "STR":
 			if fields[mp] == n.MountPoint {
@@ -159,9 +157,11 @@ Loop:
 				}
 				st.Streams = append(st.Streams, str)
 			}
-		case "ENDSOURCETABLE":
-			break Loop
 		default:
+			if strings.HasPrefix(fields[0], "END") {
+				logger.Debug("Reached the end of SourceTable")
+				break Loop
+			}
 			return nil, fmt.Errorf("%s: illegal sourcetable line: '%s'", n.URL, ln)
 		}
 	}

--- a/components/movementsensor/gpsutils/vrs.go
+++ b/components/movementsensor/gpsutils/vrs.go
@@ -15,10 +15,8 @@ import (
 )
 
 // ConnectToVirtualBase is responsible for establishing a connection to
-// a virtual base station using the NTRIP protocol.
-func ConnectToVirtualBase(ntripInfo *NtripInfo,
-	logger logging.Logger,
-) (*bufio.ReadWriter, error) {
+// a virtual base station using the NTRIP protocol with enhanced error handling and retries.
+func ConnectToVirtualBase(ntripInfo *NtripInfo, logger logging.Logger) (*bufio.ReadWriter, error) {
 	mp := "/" + ntripInfo.MountPoint
 	credentials := ntripInfo.username + ":" + ntripInfo.password
 	credentialsBase64 := base64.StdEncoding.EncodeToString([]byte(credentials))
@@ -31,6 +29,7 @@ func ConnectToVirtualBase(ntripInfo *NtripInfo,
 
 	conn, err := net.Dial("tcp", serverAddr.Host)
 	if err != nil {
+		logger.Errorf("Failed to connect to server %s: %v", serverAddr, err)
 		return nil, err
 	}
 

--- a/components/movementsensor/movementsensor.go
+++ b/components/movementsensor/movementsensor.go
@@ -68,7 +68,7 @@ func Named(name string) resource.Name {
 //
 // Position example:
 //
-//	// Get the current position of the movement sensor above sea level in meters
+//	// Get the current position of the movement sensor above sea level in meters.
 //	position, altitude, err := myMovementSensor.Position(context.Background(), nil)
 //
 // LinearVelocity example:

--- a/components/powersensor/powersensor.go
+++ b/components/powersensor/powersensor.go
@@ -51,17 +51,17 @@ func Named(name string) resource.Name {
 //
 // Voltage example:
 //
-//	// Get the voltage from device in volts
+//	// Get the voltage from device in volts.
 //	voltage, isAC, err := myPowerSensor.Voltage(context.Background(), nil)
 //
 // Current example:
 //
-//	// Get the current reading from device in amps
+//	// Get the current reading from device in amps.
 //	current, isAC, err := myPowerSensor.Current(context.Background(), nil)
 //
 // Power example:
 //
-//	// Get the power measurement from device in watts
+//	// Get the power measurement from device in watts.
 //	power, err := myPowerSensor.Power(context.Background(), nil)
 type PowerSensor interface {
 	resource.Sensor

--- a/components/servo/servo.go
+++ b/components/servo/servo.go
@@ -54,8 +54,8 @@ type Servo interface {
 	resource.Resource
 	resource.Actuator
 
-	// Move moves the servo to the given angle (0-180 degrees)
-	// This will block until done or a new operation cancels this one
+	// Move moves the servo to the given angle (0-180 degrees).
+	// This will block until done or a new operation cancels this one.
 	Move(ctx context.Context, angleDeg uint32, extra map[string]interface{}) error
 
 	// Position returns the current set angle (degrees) of the servo.

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -1000,6 +1000,8 @@ func greenLog(t *testing.T, msg string) {
 }
 
 func TestRTPPassthrough(t *testing.T) {
+	// RSDK-7958
+	t.Skip()
 	ctx := context.Background()
 	logger := logging.NewInMemoryLogger(t)
 	defer func() {

--- a/module/module.go
+++ b/module/module.go
@@ -427,10 +427,6 @@ func (m *Module) Ready(ctx context.Context, req *pb.ReadyRequest) (*pb.ReadyResp
 		}
 	}
 
-	// We no longer attempt to interact with the "fake" parent socket,
-	// so we can safely discard the associated environment variable.
-	os.Unsetenv("VALID_PARENT_SOCK")
-
 	resp.Ready = m.ready
 	resp.Handlermap = m.handlers.ToProto()
 	return resp, nil

--- a/module/module.go
+++ b/module/module.go
@@ -413,7 +413,7 @@ func (m *Module) Ready(ctx context.Context, req *pb.ReadyRequest) (*pb.ReadyResp
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.parentAddr = req.GetParentAddress()
-	if os.Getenv("VALID_PARENT_SOCK") != "false" {
+	if os.Getenv("VIAM_NO_MODULE_PARENT") != "true" {
 		if err := m.connectParent(ctx); err != nil {
 			// Return error back to parent if we cannot make a connection from module
 			// -> parent. Something is wrong in that case and the module should not be

--- a/module/testmodule/meta.json
+++ b/module/testmodule/meta.json
@@ -1,0 +1,8 @@
+{
+  "module_id": "acme:testmodule",
+  "visibility": "public",
+  "url": "",
+  "description": "Viam Test Module",
+  "models": [],
+  "entrypoint": "./testmodule"
+}

--- a/module/testmodule/module.json
+++ b/module/testmodule/module.json
@@ -13,6 +13,24 @@
 			"model": "rdk:test:helper"
 		}
 	],
+	"models": [
+		{
+			"api": "rdk:service:generic",
+			"model": "rdk:test:other"
+		},
+		{
+			"api": "rdk:component:motor",
+			"model": "rdk:test:motor"
+		},
+		{
+			"api": "rdk:component:generic",
+			"model": "rdk:test:helper"
+		},
+		{
+			"api": "rdk:component:generic",
+			"model": "rdk:test:slow"
+		}
+	],
 	"network": {
 		"bind_address": ":8080"
 	}

--- a/motionplan/tpSpaceRRT_test.go
+++ b/motionplan/tpSpaceRRT_test.go
@@ -170,6 +170,20 @@ func TestPtgWithObstacle(t *testing.T) {
 
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, len(plan), test.ShouldBeGreaterThan, 2)
+
+	tp.planOpts.SmoothIter = 80
+
+	newplan := tp.smoothPath(ctx, plan)
+	test.That(t, newplan, test.ShouldNotBeNil)
+	oldcost := 0.
+	smoothcost := 0.
+	for _, planNode := range plan {
+		oldcost += planNode.Cost()
+	}
+	for _, planNode := range newplan {
+		smoothcost += planNode.Cost()
+	}
+	test.That(t, smoothcost, test.ShouldBeLessThan, oldcost)
 }
 
 func TestTPsmoothing(t *testing.T) {
@@ -450,7 +464,7 @@ func planToTpspaceRec(plan Plan, f referenceframe.Frame) ([]node, error) {
 	for _, inp := range plan.Trajectory() {
 		thisNode := &basicNode{
 			q:    inp[f.Name()],
-			cost: inp[f.Name()][3].Value,
+			cost: math.Abs(inp[f.Name()][3].Value - inp[f.Name()][2].Value),
 		}
 		nodes = append(nodes, thisNode)
 	}

--- a/motionplan/tpspace/ptg.go
+++ b/motionplan/tpspace/ptg.go
@@ -154,11 +154,11 @@ func invertComputedPTG(forwardsPTG []*TrajNode) []*TrajNode {
 		)
 		flippedTraj = append(flippedTraj,
 			&TrajNode{
-				flippedPose,
-				startNode.Dist - fwdNode.Dist,
-				startNode.Alpha,
-				fwdNode.LinVel,
-				fwdNode.AngVel * -1,
+				Pose:   flippedPose,
+				Dist:   fwdNode.Dist,
+				Alpha:  startNode.Alpha,
+				LinVel: fwdNode.LinVel,
+				AngVel: fwdNode.AngVel * -1,
 			})
 	}
 	return flippedTraj

--- a/motionplan/tpspace/ptgGridSim.go
+++ b/motionplan/tpspace/ptgGridSim.go
@@ -110,9 +110,6 @@ func (ptg *ptgGridSim) MaxDistance() float64 {
 }
 
 func (ptg *ptgGridSim) Trajectory(alpha, start, end, resolution float64) ([]*TrajNode, error) {
-	if math.Abs(start) > math.Abs(end) {
-		return nil, fmt.Errorf("cannot calculate trajectory, start %f cannot be greater than end %f", start, end)
-	}
 	if end == 0 {
 		return computePTG(ptg, alpha, end, resolution)
 	}
@@ -140,7 +137,7 @@ func (ptg *ptgGridSim) Trajectory(alpha, start, end, resolution float64) ([]*Tra
 		}
 		return append([]*TrajNode{firstNode}, traj[first:len(traj)-1]...), nil
 	}
-	if end < 0 {
+	if end < start {
 		return invertComputedPTG(traj), nil
 	}
 	return traj, nil

--- a/motionplan/tpspace/ptgGroupFrame_test.go
+++ b/motionplan/tpspace/ptgGroupFrame_test.go
@@ -26,9 +26,9 @@ func TestPtgNegativePartialTransform(t *testing.T) {
 	pf, ok := pFrame.(*ptgGroupFrame)
 	test.That(t, ok, test.ShouldBeTrue)
 
-	partialPose1, err := pf.Transform([]referenceframe.Input{{0}, {math.Pi / 2}, {-30}, {-200}})
+	partialPose1, err := pf.Transform([]referenceframe.Input{{0}, {math.Pi / 2}, {200}, {30}})
 	test.That(t, err, test.ShouldBeNil)
-	partialPose2, err := pf.Transform([]referenceframe.Input{{0}, {math.Pi / 2}, {-40}, {-200}})
+	partialPose2, err := pf.Transform([]referenceframe.Input{{0}, {math.Pi / 2}, {200}, {40}})
 	test.That(t, err, test.ShouldBeNil)
 
 	test.That(
@@ -115,26 +115,25 @@ func TestInterpolate(t *testing.T) {
 			expected:  []referenceframe.Input{{0}, {math.Pi / 2}, {100}, {100}},
 			amount:    0,
 		},
-		// TODO (pl): All of these will change with RSDK-7515
 		{
-			name:      "Negative interpolation 1",
+			name:      "Reverse interpolation 1",
 			inputFrom: zeroInput,
-			inputTo:   []referenceframe.Input{{0}, {math.Pi / 2}, {0}, {-200}},
-			expected:  []referenceframe.Input{{0}, {math.Pi / 2}, {-120}, {-200}},
+			inputTo:   []referenceframe.Input{{0}, {math.Pi / 2}, {200}, {0}},
+			expected:  []referenceframe.Input{{0}, {math.Pi / 2}, {200}, {120}},
 			amount:    0.4,
 		},
 		{
-			name:      "Negative interpolation 2",
-			inputFrom: []referenceframe.Input{{0}, {math.Pi / 2}, {-200}, {-200}},
-			inputTo:   []referenceframe.Input{{0}, {math.Pi / 2}, {0}, {-200}},
-			expected:  []referenceframe.Input{{0}, {math.Pi / 2}, {-120}, {-200}},
+			name:      "Reverse interpolation 2",
+			inputFrom: []referenceframe.Input{{0}, {math.Pi / 2}, {200}, {200}},
+			inputTo:   []referenceframe.Input{{0}, {math.Pi / 2}, {200}, {0}},
+			expected:  []referenceframe.Input{{0}, {math.Pi / 2}, {200}, {120}},
 			amount:    0.4,
 		},
 		{
-			name:      "Negative interpolation nonzero starting point",
-			inputFrom: []referenceframe.Input{{0}, {math.Pi / 2}, {-100}, {-200}},
-			inputTo:   []referenceframe.Input{{0}, {math.Pi / 2}, {0}, {-200}},
-			expected:  []referenceframe.Input{{0}, {math.Pi / 2}, {-60}, {-100}},
+			name:      "Reverse interpolation nonzero starting point",
+			inputFrom: []referenceframe.Input{{0}, {math.Pi / 2}, {200}, {100}},
+			inputTo:   []referenceframe.Input{{0}, {math.Pi / 2}, {200}, {0}},
+			expected:  []referenceframe.Input{{0}, {math.Pi / 2}, {100}, {60}},
 			amount:    0.4,
 		},
 	}

--- a/motionplan/tpspace/ptgIK.go
+++ b/motionplan/tpspace/ptgIK.go
@@ -5,7 +5,6 @@ package tpspace
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math"
 	"sync"
 
@@ -157,16 +156,17 @@ func (ptg *ptgIK) cachedTraj(alpha, end, resolution float64) ([]*TrajNode, error
 }
 
 func (ptg *ptgIK) Trajectory(alpha, start, end, resolution float64) ([]*TrajNode, error) {
-	// TODO: For inverted trajectories, it would probably make more sense to allow this, replacing the current convention of negative dists.
-	if math.Abs(start) > math.Abs(end) {
-		return nil, fmt.Errorf("cannot calculate trajectory, start %f cannot be greater than end %f", start, end)
-	}
-	if end == 0 {
+	if end == start {
 		return computePTG(ptg, alpha, end, resolution)
 	}
 
-	startPos := math.Abs(start)
-	endPos := math.Abs(end)
+	startPos := start
+	endPos := end
+
+	if end < start {
+		startPos, endPos = endPos, startPos
+	}
+
 	trajPrecompute, err := ptg.cachedTraj(alpha, endPos, resolution)
 	if err != nil {
 		return nil, err
@@ -209,7 +209,7 @@ func (ptg *ptgIK) Trajectory(alpha, start, end, resolution float64) ([]*TrajNode
 		}
 		traj = append(traj, lastNode)
 	}
-	if end < 0 {
+	if end < start {
 		return invertComputedPTG(traj), nil
 	}
 

--- a/motionplan/tpspace/ptgIKFrame.go
+++ b/motionplan/tpspace/ptgIKFrame.go
@@ -66,9 +66,6 @@ func (pf *ptgIKFrame) Transform(inputs []referenceframe.Input) (spatialmath.Pose
 		if err != nil {
 			return nil, err
 		}
-		if inputs[i+1].Value < 0 {
-			p2 = spatialmath.PoseBetween(spatialmath.Compose(p2, flipPose), flipPose)
-		}
 		p1 = spatialmath.Compose(p1, p2)
 	}
 	return p1, nil

--- a/motionplan/tpspace/ptg_test.go
+++ b/motionplan/tpspace/ptg_test.go
@@ -52,9 +52,9 @@ func TestPtgTransform(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, spatialmath.PoseAlmostEqual(pose, traj[len(traj)-1].Pose), test.ShouldBeTrue)
 
-	poseInv, err := p.Transform([]referenceframe.Input{{0}, {math.Pi / 2}, {0}, {-200}})
+	poseInv, err := p.Transform([]referenceframe.Input{{0}, {math.Pi / 2}, {200}, {0}})
 	test.That(t, err, test.ShouldBeNil)
-	trajInv, err := p.PTGSolvers()[0].Trajectory(math.Pi/2, 0, -200, defaultResolution)
+	trajInv, err := p.PTGSolvers()[0].Trajectory(math.Pi/2, 200, 0, defaultResolution)
 	test.That(t, err, test.ShouldBeNil)
 
 	test.That(t, spatialmath.PoseAlmostEqual(poseInv, trajInv[len(trajInv)-1].Pose), test.ShouldBeTrue)

--- a/referenceframe/errors.go
+++ b/referenceframe/errors.go
@@ -2,8 +2,8 @@ package referenceframe
 
 import "github.com/pkg/errors"
 
-// ErrAtLeastOneEndEffector is an error indicating that at least one end effector is required.
-var ErrAtLeastOneEndEffector = errors.New("need at least one end effector")
+// ErrNeedOneEndEffector is an error indicating that exactly one end effector is required.
+var ErrNeedOneEndEffector = errors.New("need exactly one end effector")
 
 // ErrCircularReference is an error indicating that a circular path exists somewhere between the end effector and the world.
 var ErrCircularReference = errors.New("infinite loop finding path from end effector to world")

--- a/referenceframe/model.go
+++ b/referenceframe/model.go
@@ -249,44 +249,6 @@ func floatsToString(inputs []Input) string {
 	return string(b)
 }
 
-// Create an ordered list of transforms given a parent mapping, keeping an eye out for a sentinel string (World).
-func sortTransforms(unsorted map[string]Frame, parentMap map[string]string, start, finish string) ([]Frame, error) {
-	seen := map[string]bool{}
-
-	nextTransform, ok := unsorted[start]
-	if !ok {
-		return nil, NewFrameNotInListOfTransformsError(start)
-	}
-	orderedTransforms := []Frame{nextTransform}
-	seen[start] = true
-	for {
-		parent, ok := parentMap[nextTransform.Name()]
-		if !ok {
-			return nil, NewParentFrameNotInMapOfParentsError(nextTransform.Name())
-		}
-		if seen[parent] {
-			return nil, ErrCircularReference
-		}
-		// Reserved word, we reached the end of the chain
-		if parent == finish {
-			break
-		}
-		seen[parent] = true
-		nextTransform, ok = unsorted[parent]
-		if !ok {
-			return nil, NewFrameNotInListOfTransformsError(parent)
-		}
-		orderedTransforms = append(orderedTransforms, nextTransform)
-	}
-
-	// After the above loop, the transforms are in reverse order, so we reverse the list.
-	for i, j := 0, len(orderedTransforms)-1; i < j; i, j = i+1, j-1 {
-		orderedTransforms[i], orderedTransforms[j] = orderedTransforms[j], orderedTransforms[i]
-	}
-
-	return orderedTransforms, nil
-}
-
 // New2DMobileModelFrame builds the kinematic model associated with the kinematicWheeledBase
 // This model is intended to be used with a mobile base and has either 2DOF corresponding to  a state of x, y
 // or has 3DOF corresponding to a state of x, y, and theta, where x and y are the positional coordinates

--- a/referenceframe/model_json_test.go
+++ b/referenceframe/model_json_test.go
@@ -34,8 +34,8 @@ func TestParseJSONFile(t *testing.T) {
 		ErrCircularReference,
 		NewReservedWordError("link", "world"),
 		NewReservedWordError("joint", "world"),
-		ErrAtLeastOneEndEffector,
-		NewFrameNotInListOfTransformsError("base"),
+		ErrNeedOneEndEffector, // 0 end effectors
+		ErrNeedOneEndEffector, // 2 end effectors
 	}
 
 	for _, f := range goodFiles {

--- a/referenceframe/testjson/missinglink.json
+++ b/referenceframe/testjson/missinglink.json
@@ -2,24 +2,6 @@
     "name": "missinglink",
     "links": [
         {
-            "id": "base_top",
-            "parent": "waist",
-            "translation": {
-                "x": 0,
-                "y": 0,
-                "z": 267
-            },
-            "geometry": {
-                "r": 50,
-                "l": 320,
-                "translation": {
-                    "x": 0,
-                    "y": 0,
-                    "z": 160
-                }
-            }
-        },
-        {
             "id": "upper_arm",
             "parent": "shoulder",
             "translation": {

--- a/resource/graph_node.go
+++ b/resource/graph_node.go
@@ -327,13 +327,16 @@ func (w *GraphNode) UnresolvedDependencies() []string {
 // Close closes the underlying resource of this node.
 func (w *GraphNode) Close(ctx context.Context) error {
 	w.mu.Lock()
-	defer w.mu.Unlock()
-
 	if w.current == nil {
+		w.mu.Unlock()
 		return nil
 	}
 	current := w.current
 	w.current = nil
+
+	// Unlock before calling Close() on underlying resource, since Close() behavior can be unpredictable
+	// and usage of the graph node should not block on the underlying resource being closed.
+	w.mu.Unlock()
 	return current.Close(ctx)
 }
 

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -46,9 +46,28 @@ var (
 // to reconfigure themselves (or signal that they must be rebuilt).
 // Resources that fail to reconfigure or rebuild may be closed and must return
 // errors when in a closed state for all non Close methods.
+//
+// Name example:
+//
+//	// Get the Name of an arm component.
+//	myArmName := myArm.Name()
+//
+// DoCommand example:
+//
+//	// This example shows using DoCommand with an arm component.
+//	myArm, err := arm.FromRobot(machine, "my_arm")
+//
+//	command := map[string]interface{}{"cmd": "test", "data1": 500}
+//	result, err := myArm.DoCommand(context.Background(), command)
+//
+// Close example:
+//
+//	// This example shows using Close with an arm component.
+//	myArm, err := arm.FromRobot(machine, "my_arm")
+//
+//	err = myArm.Close(ctx)
 type Resource interface {
 	// Get the Name of the resource.
-	//    // myArmName := myArm.Name()
 	Name() Name
 
 	// Reconfigure must reconfigure the resource atomically and in place. If this
@@ -57,15 +76,11 @@ type Resource interface {
 	Reconfigure(ctx context.Context, deps Dependencies, conf Config) error
 
 	// DoCommand sends/receives arbitrary data
-	//    // myBoard, err := board.FromRobot(machine, "my_board")
-	//    // resp, err := myBoard.DoCommand(ctx, map[string]interface{}{"command": "dosomething", "someparameter": 52})
 	DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
 
 	// Close must safely shut down the resource and prevent further use.
 	// Close must be idempotent.
 	// Later reconfiguration may allow a resource to be "open" again.
-	//    // myBoard, err := board.FromRobot(machine, "my_board")
-	//    // err := myBoard.Close(ctx)
 	Close(ctx context.Context) error
 }
 
@@ -135,21 +150,59 @@ func ContainsReservedCharacter(val string) error {
 
 // A Sensor represents a general purpose sensor that can give arbitrary readings
 // of all readings that it is sensing.
+//
+// Readings example:
+//
+//	// Get the readings provided by the sensor.
+//	readings, err := mySensor.Readings(context.Background(), nil)
 type Sensor interface {
 	// Readings return data specific to the type of sensor and can be of any type.
 	Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error)
 }
 
 // Actuator is any resource that can move.
+//
+// IsMoving example:
+//
+//	// This example shows using IsMoving with an arm component.
+//	myArm, err := arm.FromRobot(machine, "my_arm")
+//
+//	// Stop all motion of the arm. It is assumed that the arm stops immediately.
+//	myArm.Stop(context.Background(), nil)
+//
+//	// Log if the arm is currently moving.
+//	is_moving, err := myArm.IsMoving(context.Background())
+//	logger.Info(is_moving)
+//
+// Stop example:
+//
+//	// This example shows using Stop with an arm component.
+//	myArm, err := arm.FromRobot(machine, "my_arm")
+//
+//	// Stop all motion of the arm. It is assumed that the arm stops immediately.
+//	err = myArm.Stop(context.Background(), nil)
 type Actuator interface {
-	// IsMoving returns whether the resource is moving or not
+	// IsMoving returns whether the resource is moving or not.
 	IsMoving(context.Context) (bool, error)
 
-	// Stop stops all movement for the resource
+	// Stop stops all movement for the resource.
 	Stop(context.Context, map[string]interface{}) error
 }
 
 // Shaped is any resource that can have geometries.
+//
+// Geometries example:
+//
+//	// This example shows using Geometries with an arm component.
+//	myArm, err := arm.FromRobot(machine, "my_arm")
+//
+//	geometries, err := myArm.Geometries(context.Background(), nil)
+//
+//	if len(geometries) > 0 {
+//	   // Get the center of the first geometry
+//	   elem := geometries[0]
+//	   fmt.Println("Pose of the first geometry's center point:", elem.center)
+//	}
 type Shaped interface {
 	// Geometries returns the list of geometries associated with the resource, in any order. The poses of the geometries reflect their
 	// current location relative to the frame of the resource.

--- a/resource/visualizer.go
+++ b/resource/visualizer.go
@@ -254,6 +254,8 @@ func exportEdge(bw *blockWriter, left, right Name) {
 // ExportDot exports the resource graph as a DOT representation for visualization.
 // DOT reference: https://graphviz.org/doc/info/lang.html.
 // This function will output the exact same string given the same input resource graph.
+// If not called inside a resourceGraphLock, there is a chance
+// of the graph changing as the snapshot is being taken.
 func (g *Graph) ExportDot() (string, error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
@@ -268,6 +270,9 @@ func (g *Graph) ExportDot() (string, error) {
 	// the same text output is produced. We desire this such that a diff in the output implies the
 	// resource graph has logically changed. To achieve this, we sort all of the inputs (nodes and
 	// edges) for a predictable iteration order.
+	//
+	// As graph nodes are not all locked during the duration of this function, nodes could change
+	// before it gets exported. This is known and expected as the graph output is "best-effort".
 	nodesSortedByName := nodesSortedByName(g.nodes)
 
 	writer := &blockWriter{}

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -330,9 +330,10 @@ func (rc *RobotClient) connect(ctx context.Context) error {
 	if err := rc.connectWithLock(ctx); err != nil {
 		return err
 	}
-
+	rc.Logger().CInfow(ctx, "successfully (re)connected to remote at address", "address", rc.address)
 	if rc.notifyParent != nil {
 		rc.notifyParent()
+		rc.Logger().CDebugw(ctx, "successfully notified parent after (re)connection", "address", rc.address)
 	}
 	return nil
 }
@@ -413,7 +414,6 @@ func (rc *RobotClient) checkConnection(ctx context.Context, checkEvery, reconnec
 				rc.Logger().CErrorw(ctx, "failed to reconnect remote", "error", err, "address", rc.address)
 				continue
 			}
-			rc.Logger().CInfow(ctx, "successfully reconnected remote at address", "address", rc.address)
 		} else {
 			check := func() error {
 				if refresh {
@@ -716,7 +716,7 @@ func (rc *RobotClient) PackageManager() packages.Manager {
 //	resource_names := machine.ResourceNames()
 func (rc *RobotClient) ResourceNames() []resource.Name {
 	if err := rc.checkConnected(); err != nil {
-		rc.Logger().Errorw("failed to get remote resource names", "error", err)
+		rc.Logger().Errorw("failed to get remote resource names", "error", err.Error())
 		return nil
 	}
 	rc.mu.RLock()

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -3482,3 +3482,38 @@ func TestCustomResourceBuildsOnModuleAddition(t *testing.T) {
 	)
 	rtestutils.VerifySameResourceNames(t, r.ResourceNames(), expectedResources)
 }
+
+func TestSendTriggerConfig(t *testing.T) {
+	// Tests that the triggerConfig channel buffers exactly 1 message and that
+	// sendTriggerConfig does not block whether or not the channel has
+	// capacity.
+	ctx := context.Background()
+	logger := logging.NewTestLogger(t)
+
+	// Set up local robot normally so that the triggerConfig channel is set up normally
+	r := setupLocalRobot(t, ctx, &config.Config{}, logger)
+
+	// Close the robot to stop the background workers from processing any messages to triggerConfig
+	// but also reinitialize the closeContext so that sendTriggerConfig will attempt to send messages
+	// through.
+	test.That(t, r.Close(ctx), test.ShouldBeNil)
+	actualR := r.(*localRobot)
+	actualR.closeContext = context.Background()
+
+	// This pattern fails the test faster on deadlocks instead of having to wait for the full
+	// test timeout.
+	sentCh := make(chan bool)
+	go func() {
+		for i := 0; i < 5; i++ {
+			actualR.sendTriggerConfig("remote1")
+		}
+		sentCh <- true
+	}()
+	select {
+	case sent := <-sentCh:
+		test.That(t, sent, test.ShouldBeTrue)
+	case <-time.After(time.Second * 20):
+		t.Fatal("took too long to send messages to triggerConfig channel, might be a deadlock")
+	}
+	test.That(t, len(actualR.triggerConfig), test.ShouldEqual, 1)
+}

--- a/robot/robot.go
+++ b/robot/robot.go
@@ -28,6 +28,58 @@ import (
 
 // A Robot encompasses all functionality of some robot comprised
 // of parts, local and remote.
+//
+// DiscoverComponents example:
+//
+//	// Define a new discovery query.
+//	q := resource.NewDiscoveryQuery(acme.API, resource.Model{Name: "some model"})
+//
+//	// Define a list of discovery queries.
+//	qs := []resource.DiscoverQuery{q}
+//
+//	// Get component configurations with these queries.
+//	component_configs, err := machine.DiscoverComponents(ctx.Background(), qs)
+//
+// ResourceNames example:
+//
+//	resource_names := machine.ResourceNames()
+//
+// FrameSystemConfig example:
+//
+//	// Print the frame system configuration
+//	frameSystem, err := machine.FrameSystemConfig(context.Background(), nil)
+//	fmt.Println(frameSystem)
+//
+// TransformPose example:
+//
+//	import (
+//	  "go.viam.com/rdk/referenceframe"
+//	  "go.viam.com/rdk/spatialmath"
+//	)
+//
+//	baseOrigin := referenceframe.NewPoseInFrame("test-base", spatialmath.NewZeroPose())
+//	movementSensorToBase, err := machine.TransformPose(ctx, baseOrigin, "my-movement-sensor", nil)
+//
+// Status example:
+//
+//	status, err := machine.Status(ctx)
+//
+// GetCloudMetadata example:
+//
+//	metadata := machine.GetCloudMetadata()
+//	machine_part_id = metadata.MachinePartID
+//	primary_org_id = metadata.PrimaryOrgID
+//	location_id = metadata.LocationID
+//
+// Close example:
+//
+//	// Cleanly close the underlying connections and stop any periodic tasks,
+//	err := machine.Close(ctx)
+//
+// StopAll example:
+//
+//	// Cancel all current and outstanding operations for the machine and stop all actuators and movement.
+//	err := machine.StopAll(ctx)
 type Robot interface {
 	// DiscoverComponents returns discovered component configurations.
 	DiscoverComponents(ctx context.Context, qs []resource.DiscoveryQuery) ([]resource.Discovery, error)

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -68,9 +68,6 @@ type inputEnabledActuator interface {
 	referenceframe.InputEnabled
 }
 
-// ErrNotImplemented is thrown when an unreleased function is called.
-var ErrNotImplemented = errors.New("function coming soon but not yet implemented")
-
 // Config describes how to configure the service; currently only used for specifying dependency on framesystem service.
 type Config struct {
 	LogFilePath string `json:"log_file_path"`

--- a/services/motion/motion.go
+++ b/services/motion/motion.go
@@ -187,6 +187,112 @@ type PlanWithStatus struct {
 }
 
 // A Service controls the flow of moving components.
+//
+// Move example:
+//
+//	motionService, err := motion.FromRobot(robot, "builtin")
+//
+//	// Assumes a gripper configured with name "my_gripper" on the machine
+//	gripperName := gripper.Named("my_gripper")
+//	myFrame := "my_gripper_offset"
+//
+//	goalPose := referenceframe.PoseInFrame(0, 0, 300, 0, 0, 1, 0)
+//
+//	// Move the gripper
+//	moved, err := motionService.Move(context.Background(), gripperName, goalPose, worldState, nil, nil)
+//
+// GetPose example:
+//
+//	// Insert code to connect to your machine.
+//	// (see CONNECT tab of your machine's page in the Viam app)
+//
+//	// Assumes a gripper configured with name "my_gripper" on the machine
+//	gripperName := gripper.Named("my_gripper")
+//	myFrame := "my_gripper_offset"
+//
+//	// Access the motion service
+//	motionService, err := motion.FromRobot(robot, "builtin")
+//	if err != nil {
+//	  logger.Fatal(err)
+//	}
+//
+//	myArmMotionPose, err := motionService.GetPose(context.Background(), my_gripper, referenceframe.World, nil, nil)
+//	if err != nil {
+//	  logger.Fatal(err)
+//	}
+//	logger.Info("Position of myArm from the motion service:", myArmMotionPose.Pose().Point())
+//	logger.Info("Orientation of myArm from the motion service:", myArmMotionPose.Pose().Orientation())
+//
+// MoveOnMap example:
+//
+//	motionService, err := motion.FromRobot(robot, "builtin")
+//
+//	// Get the resource.Names of the base and of the SLAM service
+//	myBaseResourceName := base.Named("myBase")
+//	mySLAMServiceResourceName := slam.Named("my_slam_service")
+//	// Define a destination Pose with respect to the origin of the map from the SLAM service "my_slam_service"
+//	myPose := spatialmath.NewPoseFromPoint(r3.Vector{Y: 10})
+//
+//	// Move the base component to the destination pose of Y=10, a location of (0, 10, 0) in respect to the origin of the map
+//	executionID, err := motionService.MoveOnMap(context.Background(), motion.MoveOnMapReq{
+//	    ComponentName: myBaseResourceName,
+//	    Destination:   myPose,
+//	    SlamName:      mySLAMServiceResourceName,
+//	})
+//
+// MoveOnGlobe example:
+//
+//	motionService, err := motion.FromRobot(robot, "builtin")
+//
+//	// Get the resource.Names of the base and movement sensor
+//	myBaseResourceName := base.Named("myBase")
+//	myMvmntSensorResourceName := movement_sensor.Named("my_movement_sensor")
+//	// Define a destination Point at the GPS coordinates [0, 0]
+//	myDestination := geo.NewPoint(0, 0)
+//
+//	// Move the base component to the designated geographic location, as reported by the movement sensor
+//	ctx := context.Background()
+//	executionID, err := motionService.MoveOnGlobe(ctx, motion.MoveOnGlobeReq{
+//	    ComponentName:      myBaseResourceName,
+//	    Destination:        myDestination,
+//	    MovementSensorName: myMvmntSensorResourceName,
+//	})
+//
+// StopPlan example:
+//
+//	motionService, err := motion.FromRobot(robot, "builtin")
+//	myBaseResourceName := base.Named("myBase")
+//	ctx := context.Background()
+//
+//	// Assuming a move_on_globe started the execution
+//	// myMvmntSensorResourceName := movement_sensor.Named("my_movement_sensor")
+//	// myDestination := geo.NewPoint(0, 0)
+//	// executionID, err := motionService.MoveOnGlobe(ctx, motion.MoveOnGlobeReq{
+//	//     ComponentName:      myBaseResourceName,
+//	//     Destination:        myDestination,
+//	//     MovementSensorName: myMvmntSensorResourceName,
+//	// })
+//
+//	// Stop the base component which was instructed to move by `MoveOnGlobe()` or `MoveOnMap()`
+//	err := motionService.StopPlan(context.Background(), motion.StopPlanReq{
+//	    ComponentName: s.req.ComponentName,
+//	})
+//
+// GetPlan example:
+//
+//	motionService, err := motion.FromRobot(robot, "builtin")
+//	// Get the plan(s) of the base component's most recent execution i.e. `MoveOnGlobe()` or `MoveOnMap()` call.
+//	ctx := context.Background()
+//	planHistory, err := motionService.PlanHistory(ctx, motion.PlanHistoryReq{
+//	    ComponentName: s.req.ComponentName,
+//	})
+//
+// ListPlanStatus example:
+//
+//	motionService, err := motion.FromRobot(robot, "builtin")
+//	// Get the plan(s) of the base component's most recent execution i.e. `MoveOnGlobe()` or `MoveOnMap()` call.
+//	ctx := context.Background()
+//	planStatuses, err := motionService.ListPlanStatuses(ctx, motion.ListPlanStatusesReq{})
 type Service interface {
 	resource.Resource
 	Move(

--- a/services/navigation/navigation.go
+++ b/services/navigation/navigation.go
@@ -83,17 +83,17 @@ type Properties struct {
 //
 // Mode example:
 //
-//	// Get the Mode the service is operating in
+//	// Get the Mode the service is operating in.
 //	mode, err := myNav.Mode(context.Background(), nil)
 //
 // SetMode example:
 //
-//	// Set the Mode the service is operating in to ModeWaypoint and begin navigation
+//	// Set the Mode the service is operating in to ModeWaypoint and begin navigation.
 //	err := myNav.SetMode(context.Background(), navigation.ModeWaypoint, nil)
 //
 // Location example:
 //
-//	// Get the current location of the robot in the navigation service
+//	// Get the current location of the robot in the navigation service.
 //	location, err := myNav.Location(context.Background(), nil)
 //
 // Waypoints example:
@@ -102,37 +102,37 @@ type Properties struct {
 //
 // AddWaypoint example:
 //
-//	// Create a new waypoint with latitude and longitude values of 0 degrees
-//	// Assumes you have imported "github.com/kellydunn/golang-geo" as `geo`
+//	// Create a new waypoint with latitude and longitude values of 0 degrees.
+//	// Assumes you have imported "github.com/kellydunn/golang-geo" as `geo`.
 //	location := geo.NewPoint(0, 0)
 //
-//	// Add your waypoint to the service's data storage
+//	// Add your waypoint to the service's data storage.
 //	err := myNav.AddWaypoint(context.Background(), location, nil)
 //
 // RemoveWaypoint example:
 //
-//	// Assumes you have already called AddWaypoint once and the waypoint has not yet been reached
+//	// Assumes you have already called AddWaypoint once and the waypoint has not yet been reached.
 //	waypoints, err := myNav.Waypoints(context.Background(), nil)
 //	if (err != nil || len(waypoints) == 0) {
 //	    return
 //	}
 //
-//	// Remove the first waypoint from the service's data storage
+//	// Remove the first waypoint from the service's data storage.
 //	err = myNav.RemoveWaypoint(context.Background(), waypoints[0].ID, nil)
 //
 // Obstacles example:
 //
-//	// Get an array containing each obstacle stored by the navigation service
+//	// Get an array containing each obstacle stored by the navigation service.
 //	obstacles, err := myNav.Obstacles(context.Background(), nil)
 //
 // Paths example:
 //
-//	// Get an array containing each path stored by the navigation service
+//	// Get an array containing each path stored by the navigation service.
 //	paths, err := myNav.Paths(context.Background(), nil)
 //
 // Properties example:
 //
-//	// Get the properties of the current navigation service
+//	// Get the properties of the current navigation service.
 //	navProperties, err := myNav.Properties(context.Background())
 type Service interface {
 	resource.Resource

--- a/services/slam/slam.go
+++ b/services/slam/slam.go
@@ -120,7 +120,7 @@ func FromDependencies(deps resource.Dependencies, name string) (Service, error) 
 // Service describes the functions that are available to the service.
 //
 // The Go SDK implements helper functions that concatenate streaming
-// responses. Some of the following examples use correstponding
+// responses. Some of the following examples use corresponding
 // helper methods instead of interface methods.
 //
 // Position example:

--- a/vision/classification/classifier.go
+++ b/vision/classification/classifier.go
@@ -19,11 +19,11 @@ type Classifications []Classification
 
 // TopN finds the N Classifications with the highest confidence scores.
 func (cc Classifications) TopN(n int) (Classifications, error) {
-	m := max(n, len(cc))
-	sort.Slice(cc, func(i, j int) bool { return cc[i].Score() > cc[j].Score() })
-	if n == 0 {
+	if n <= 0 {
 		return cc, nil
 	}
+	m := min(n, len(cc))
+	sort.Slice(cc, func(i, j int) bool { return cc[i].Score() > cc[j].Score() })
 	return cc[0:m], nil
 }
 

--- a/vision/classification/classifier_test.go
+++ b/vision/classification/classifier_test.go
@@ -1,0 +1,38 @@
+package classification
+
+import (
+	"testing"
+
+	"go.viam.com/test"
+)
+
+func TestTopNClassifications(t *testing.T) {
+	cls := Classifications{
+		NewClassification(0.2, "a"),
+		NewClassification(0.4, "b"),
+		NewClassification(0.1, "c"),
+	}
+	top1, err := cls.TopN(1)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, len(top1), test.ShouldEqual, 1)
+	test.That(t, top1[0].Score(), test.ShouldAlmostEqual, 0.4)
+
+	top3, err := cls.TopN(3)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, len(top3), test.ShouldEqual, 3)
+	test.That(t, top3[0].Score(), test.ShouldAlmostEqual, 0.4)
+	test.That(t, top3[1].Score(), test.ShouldAlmostEqual, 0.2)
+	test.That(t, top3[2].Score(), test.ShouldAlmostEqual, 0.1)
+
+	topN, err := cls.TopN(10000000)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, len(topN), test.ShouldEqual, 3)
+
+	top0, err := cls.TopN(0)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, len(top0), test.ShouldEqual, 3)
+
+	topNeg, err := cls.TopN(-5)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, len(topNeg), test.ShouldEqual, 3)
+}

--- a/web/frontend/src/components/vision/index.svelte
+++ b/web/frontend/src/components/vision/index.svelte
@@ -137,7 +137,7 @@ const run = async () => {
           img.width,
           img.height,
           mime,
-          2_147_483_647
+          100
         );
         let y = 0;
         for (const cls of classifications) {


### PR DESCRIPTION
[RSDK-7306](https://viam.atlassian.net/browse/RSDK-7306): fix update-models command to ignore parent connection

- In this PR, we add a new environment variable that denotes whether a valid parent exists. If not, then we can forgo some of the module code that assumes a parent to exist.

[RSDK-7306]: https://viam.atlassian.net/browse/RSDK-7306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ