### PR TITLE
RSDK-7942: Propagate log level config changes to custom modular resources

### DIFF
--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -930,10 +930,10 @@ func (manager *resourceManager) processResource(
 	isModular := manager.moduleManager.Provides(conf)
 	if gNode.ResourceModel() == conf.Model {
 		if isModular {
+			gNode.SetLogLevel(conf.LogConfiguration.Level)
 			if err := manager.moduleManager.ReconfigureResource(ctx, conf, modmanager.DepsToNames(deps)); err != nil {
 				return nil, false, err
 			}
-			gNode.Logger().SetLevel(conf.LogConfiguration.Level)
 			return currentRes, false, nil
 		}
 

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -933,6 +933,7 @@ func (manager *resourceManager) processResource(
 			if err := manager.moduleManager.ReconfigureResource(ctx, conf, modmanager.DepsToNames(deps)); err != nil {
 				return nil, false, err
 			}
+			gNode.Logger().SetLevel(conf.LogConfiguration.Level)
 			return currentRes, false, nil
 		}
 


### PR DESCRIPTION
### Description
RSDK-7942: Reconfiguring custom modular resources log level does not propagate
* In `processResource()` there is two different paths; one for builtin resources and another for modular resources. For builtin resources, the log level is set and then reconfigure is called. For modular resources, the log level is never set before reconfiguration for that resource is called.
* This PR just sets the log level before reconfiguring a modular resource, propagating the config change.
### Testing