### PR TITLE
Rsdk-7530: vrs ntrip bug fix

### DIFF
--- a/components/movementsensor/gpsutils/ntrip.go
+++ b/components/movementsensor/gpsutils/ntrip.go
@@ -147,22 +147,24 @@ Loop:
 		}
 		fields := strings.Split(ln, ";")
 		switch fields[0] {
-		case "CAS":
-			continue
-		case "NET":
+		case "CAS", "NET":
 			continue
 		case "STR":
 			if fields[mp] == n.MountPoint {
 				str, err := parseStream(ln)
+
 				if err != nil {
 					return nil, fmt.Errorf("error while parsing stream: %w", err)
 				}
 				st.Streams = append(st.Streams, str)
 			}
-		case "ENDSOURCETABLE":
-			break Loop
 		default:
-			return nil, fmt.Errorf("%s: illegal sourcetable line: '%s'", n.URL, ln)
+			if strings.Contains(fields[0], "END") {
+				logger.Debug("Reached the end of SourceTable")
+				break Loop
+			} else {
+				return nil, fmt.Errorf("%s: illegal sourcetable line: '%s'", n.URL, ln)
+			}
 		}
 	}
 

--- a/components/movementsensor/gpsutils/vrs.go
+++ b/components/movementsensor/gpsutils/vrs.go
@@ -15,10 +15,8 @@ import (
 )
 
 // ConnectToVirtualBase is responsible for establishing a connection to
-// a virtual base station using the NTRIP protocol.
-func ConnectToVirtualBase(ntripInfo *NtripInfo,
-	logger logging.Logger,
-) (*bufio.ReadWriter, error) {
+// a virtual base station using the NTRIP protocol with enhanced error handling and retries.
+func ConnectToVirtualBase(ntripInfo *NtripInfo, logger logging.Logger) (*bufio.ReadWriter, error) {
 	mp := "/" + ntripInfo.MountPoint
 	credentials := ntripInfo.username + ":" + ntripInfo.password
 	credentialsBase64 := base64.StdEncoding.EncodeToString([]byte(credentials))
@@ -31,6 +29,7 @@ func ConnectToVirtualBase(ntripInfo *NtripInfo,
 
 	conn, err := net.Dial("tcp", serverAddr.Host)
 	if err != nil {
+		logger.Errorf("Failed to connect to server %s: %v", serverAddr, err)
 		return nil, err
 	}
 


### PR DESCRIPTION
we used to look for "ENDSOURCETABLE" as a stopping point for source table. In the case of an extremely large sourcetable,  ParseSourcetable function occasionally received "ENDSOURCETABL" which didn't match the exit case and and would keep requesting sourcetable from the caster until caster banns the NTRIP username. This PR address this issue along with a few cleanups and debugging logs. 