### PR TITLE
Vision RC card: reduce max requested classifications to 100

### DIFF
--- a/web/frontend/src/components/vision/index.svelte
+++ b/web/frontend/src/components/vision/index.svelte
@@ -137,7 +137,7 @@ const run = async () => {
           img.width,
           img.height,
           mime,
-          2_147_483_647
+          100
         );
         let y = 0;
         for (const cls of classifications) {


### PR DESCRIPTION
Instead of requesting as many classifications as possible, just request the top 100. We decided on this change offline.