### PR TITLE
Fix typo

### DIFF
--- a/components/motor/gpiostepper/gpiostepper_test.go
+++ b/components/motor/gpiostepper/gpiostepper_test.go
@@ -403,7 +403,7 @@ func TestRunning(t *testing.T) {
 		p, err := m.Position(context.Background(), nil)
 		test.That(t, err, test.ShouldBeNil)
 
-		// stop() sets targetStepPosition to the stepPostion value
+		// stop() sets targetStepPosition to the stepPosition value
 		test.That(t, s.targetStepPosition, test.ShouldEqual, s.stepPosition)
 		test.That(t, s.targetStepPosition, test.ShouldBeBetweenOrEqual, 1, 100*200)
 		test.That(t, p, test.ShouldBeBetween, 0, 100)

--- a/components/motor/motor.go
+++ b/components/motor/motor.go
@@ -53,7 +53,7 @@ var API = resource.APINamespaceRDK.WithComponentType(SubtypeName)
 //	// Turn the motor to 8.3 revolutions from home at 75 RPM.
 //	myMotorComponent.GoTo(context.Background(), 75, 8.3, nil)
 //
-// ResetZeroPostion example:
+// ResetZeroPosition example:
 //
 //	// Set the current position as the new home position with no offset.
 //	myMotorComponent.ResetZeroPosition(context.Background(), 0.0, nil)


### PR DESCRIPTION
Fix typo I made to `components/motor/motor.go` in previous PR, apologies!
- Fix other occurrence of same typo in test file.