### PR TITLE
Fix generate-go command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ lint: lint-go lint-web
 	PATH=$(PATH_WITH_TOOLS) actionlint
 
 generate-go: tool-install
-	go generate ./...
+	PATH=$(PATH_WITH_TOOLS) go generate ./...
 
 lint-go: tool-install
 	go mod tidy

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	_ "github.com/rhysd/actionlint"
 	_ "golang.org/x/mobile/cmd/gomobile"
+	_ "golang.org/x/tools/cmd/stringer"
 	_ "gotest.tools/gotestsum"
 
 	// only needed for proto building in examples/customresources/apis/proto


### PR DESCRIPTION
Forgot to import the `stringer` package and set `PATH` correctly.

Follow-up to https://github.com/viamrobotics/rdk/pull/4075, which introduced a code generation step to stringify enums via the [stringer tool](https://pkg.go.dev/golang.org/x/tools/cmd/stringer).

### Testing
* Ran `make generate-go` in canon shell on amd64 and arm64 containers.