### PR TITLE
[RSDK-7937] update injected motor to check for context canceled

### DIFF
--- a/components/motor/gpio/encoded_test.go
+++ b/components/motor/gpio/encoded_test.go
@@ -78,6 +78,9 @@ func injectBoard() board.Board {
 func injectMotor(vals *injectedState) motor.Motor {
 	m := inject.NewMotor(motorName)
 	m.SetPowerFunc = func(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		vals.mu.Lock()
 		defer vals.mu.Unlock()
 		vals.powerPct = powerPct
@@ -269,17 +272,20 @@ func TestEncodedMotor(t *testing.T) {
 		wg.Add(1)
 		utils.PanicCapturingGo(func() {
 			defer wg.Done()
-			err := m.GoFor(ctxTimeout, 1000, 1, nil) // arbitrarily long blocking call
+			err := m.GoFor(ctxTimeout, 10, 100, nil) // arbitrarily long blocking call
 			test.That(t, err, test.ShouldBeNil)
 		})
 
-		_, _, err := m.IsPowered(context.Background(), nil)
-		// TODO make these tests pass
-		// test.That(t, on, test.ShouldBeTrue)
-		// test.That(t, powerPct, test.ShouldBeGreaterThan, 0)
-		test.That(t, err, test.ShouldBeNil)
+		testutils.WaitForAssertion(t, func(tb testing.TB) {
+			tb.Helper()
+			on, powerPct, err := m.IsPowered(context.Background(), nil)
+			test.That(tb, on, test.ShouldBeTrue)
+			test.That(tb, powerPct, test.ShouldBeGreaterThan, 0)
+			test.That(tb, err, test.ShouldBeNil)
+		})
 
-		err = m.SetPower(context.Background(), -0.5, nil)
+		ctxInterrupt, cancelInterrupt := context.WithTimeout(context.Background(), 10*time.Second)
+		err = m.SetPower(ctxInterrupt, -0.5, nil)
 		test.That(t, err, test.ShouldBeNil)
 		on, powerPct, err := m.IsPowered(context.Background(), nil)
 		test.That(t, on, test.ShouldBeTrue)
@@ -288,5 +294,6 @@ func TestEncodedMotor(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		wg.Wait()
 		cancel()
+		cancelInterrupt()
 	})
 }

--- a/components/motor/gpio/encoded_test.go
+++ b/components/motor/gpio/encoded_test.go
@@ -284,8 +284,7 @@ func TestEncodedMotor(t *testing.T) {
 			test.That(tb, err, test.ShouldBeNil)
 		})
 
-		ctxInterrupt, cancelInterrupt := context.WithTimeout(context.Background(), 10*time.Second)
-		err = m.SetPower(ctxInterrupt, -0.5, nil)
+		err = m.SetPower(context.Background(), -0.5, nil)
 		test.That(t, err, test.ShouldBeNil)
 		on, powerPct, err := m.IsPowered(context.Background(), nil)
 		test.That(t, on, test.ShouldBeTrue)
@@ -294,6 +293,5 @@ func TestEncodedMotor(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		wg.Wait()
 		cancel()
-		cancelInterrupt()
 	})
 }


### PR DESCRIPTION
ticket: https://viam.atlassian.net/browse/RSDK-7937

before the fix, the `"encoded motor test SetPower interrupts GoFor"` would fail ~1 in 1000 runs due to a motor power being set by GoFor after the context was canceled (via `Cancelrunning` and` makeAdjustmentsDone()`). 
when I got the context to be canceled, the injected motor was still handling the setpower call. Adding a check to the injected motor to see if the context was canceled fixed this. 

after the fix, I could not repro in 40k runs

testing command `/opt/homebrew/bin/go test -timeout 100s -count 1000 -run ^TestEncodedMotor$/^encoded_motor_test_SetPower_interrupts_GoFor$ go.viam.com/rdk/components/motor/gpio`

