### PR TITLE
RSDK-7885: Call networking tests trigger workflow in rc workflow

### DIFF
--- a/.github/workflows/releasecandidate.yml
+++ b/.github/workflows/releasecandidate.yml
@@ -72,3 +72,5 @@ jobs:
     needs: [staticbuild, appimage]
     if: ${{ success() }}
     uses: ./trigger-networking-tests.yml
+    secrets:
+      REPO_READ_TOKEN: ${{ secrets.REPO_READ_TOKEN }}

--- a/.github/workflows/releasecandidate.yml
+++ b/.github/workflows/releasecandidate.yml
@@ -67,3 +67,8 @@ jobs:
           slack_webhook_url: ${{secrets.SLACK_WEBHOOK_URL}}
           channel: '#team-devops'
           name: 'Workflow Status'
+
+  run-sdk-integration-networking-tests:
+    needs: [staticbuild, appimage]
+    if: ${{ success() }}
+    uses: ./trigger-networking-tests.yml

--- a/.github/workflows/trigger-networking-tests.yml
+++ b/.github/workflows/trigger-networking-tests.yml
@@ -2,6 +2,9 @@ name: Trigger Networking Tests in sdk-integration-tests
 
 on:
     workflow_call:
+        secrets:
+            REPO_READ_TOKEN:
+              required: true
     workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
### Description
* **RSDK-7885:** Run Networking Tests on release Candidate
* See these PRs:
  *  [This PR](https://github.com/viamrobotics/sdk-integration-tests/pull/35)  modifies `Networking Tests` workflow to be able to be triggered by `new-rc-branch` events sent by remote repositories
  * [This PR](https://github.com/viamrobotics/rdk/pull/4083) creates a new workflow in the RDK which sends a `new-rc-branch` event to the `sdk-integration-tests` repo which triggers the `Networking Tests`
* This final PR makes a workflow-call from the RC workflow to the `trigger-network-tests` workflow triggering `Networking Tests` in the  `sdk-integration-tests` repo
### Testing
You can manually run the "Trigger Networking Tests in sdk-integration-tests" workflow from the Actions tab and see that `Networking Tests` will be triggered in the  `sdk-integration-tests` repo