### PR TITLE
RSDK 7885: Fix Job path Syntax

### DIFF
--- a/.github/workflows/releasecandidate.yml
+++ b/.github/workflows/releasecandidate.yml
@@ -72,3 +72,5 @@ jobs:
     needs: [staticbuild, appimage]
     if: ${{ success() }}
     uses: ./trigger-networking-tests.yml
+    secrets:
+      REPO_READ_TOKEN: ${{ secrets.REPO_READ_TOKEN }}

--- a/.github/workflows/releasecandidate.yml
+++ b/.github/workflows/releasecandidate.yml
@@ -71,6 +71,6 @@ jobs:
   run-sdk-integration-networking-tests:
     needs: [staticbuild, appimage]
     if: ${{ success() }}
-    uses: ./trigger-networking-tests.yml
+    uses: ./.github/workflows/trigger-networking-tests.yml
     secrets:
       REPO_READ_TOKEN: ${{ secrets.REPO_READ_TOKEN }}

--- a/.github/workflows/releasecandidate.yml
+++ b/.github/workflows/releasecandidate.yml
@@ -67,3 +67,8 @@ jobs:
           slack_webhook_url: ${{secrets.SLACK_WEBHOOK_URL}}
           channel: '#team-devops'
           name: 'Workflow Status'
+
+  run-sdk-integration-networking-tests:
+    needs: [staticbuild, appimage]
+    if: ${{ success() }}
+    uses: ./trigger-networking-tests.yml

--- a/.github/workflows/releasecandidate.yml
+++ b/.github/workflows/releasecandidate.yml
@@ -71,6 +71,6 @@ jobs:
   run-sdk-integration-networking-tests:
     needs: [staticbuild, appimage]
     if: ${{ success() }}
-    uses: ./.github/workflows/trigger-networking-tests.yml
+    uses: viamrobotics/rdk/.github/workflows/trigger-networking-tests.yml@main
     secrets:
       REPO_READ_TOKEN: ${{ secrets.REPO_READ_TOKEN }}

--- a/.github/workflows/trigger-networking-tests.yml
+++ b/.github/workflows/trigger-networking-tests.yml
@@ -2,6 +2,9 @@ name: Trigger Networking Tests in sdk-integration-tests
 
 on:
     workflow_call:
+        secrets:
+            REPO_READ_TOKEN:
+              required: true
     workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
### Description
[This PR](https://github.com/viamrobotics/rdk/pull/4115) added a job to trigger networking tests after building a new rc version. Somehow missed this Actions error:
```
[Invalid workflow file: .github/workflows/releasecandidate.yml#L74](https://github.com/viamrobotics/rdk/actions/runs/9617360229/workflow)
invalid value workflow reference: no version specified
``` 
which is due to using `./trigger-networking-tests.yml` as the job path instead of `./.github/workflows/trigger-networking-tests.yml`