### PR TITLE
RSDK-7942: Include LogConfiguration field to ServiceConfig proto conversions

### DIFF
--- a/config/proto_conversions_test.go
+++ b/config/proto_conversions_test.go
@@ -68,7 +68,8 @@ var testComponent = resource.Config{
 			},
 		},
 	},
-	Frame: testFrame,
+	Frame:            testFrame,
+	LogConfiguration: resource.LogConfig{Level: logging.DEBUG},
 }
 
 var testRemote = Remote{
@@ -118,6 +119,7 @@ var testService = resource.Config{
 			},
 		},
 	},
+	LogConfiguration: resource.LogConfig{Level: logging.DEBUG},
 }
 
 var testProcessConfig = pexec.ProcessConfig{
@@ -338,6 +340,7 @@ func TestComponentConfigToProto(t *testing.T) {
 	out, err := ComponentConfigFromProto(proto)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, out, test.ShouldNotBeNil)
+	test.That(t, out.LogConfiguration.Level, test.ShouldEqual, logging.DEBUG)
 
 	validateComponent(t, *out, testComponent)
 
@@ -572,6 +575,7 @@ func TestServiceConfigToProto(t *testing.T) {
 
 	out, err := ServiceConfigFromProto(proto)
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, out.LogConfiguration.Level, test.ShouldEqual, logging.DEBUG)
 
 	validateService(t, *out, testService)
 

--- a/module/testmodule/main.go
+++ b/module/testmodule/main.go
@@ -191,13 +191,15 @@ func newOther(
 	ctx context.Context, deps resource.Dependencies, conf resource.Config, logger logging.Logger,
 ) (resource.Resource, error) {
 	return &other{
-		Named: conf.ResourceName().AsNamed(),
+		Named:  conf.ResourceName().AsNamed(),
+		logger: logger,
 	}, nil
 }
 
 type other struct {
 	resource.Named
 	resource.TriviallyCloseable
+	logger              logging.Logger
 	numReconfigurations int
 }
 
@@ -209,6 +211,24 @@ func (o *other) DoCommand(ctx context.Context, req map[string]interface{}) (map[
 	}
 
 	switch req["command"] {
+	case "log":
+		level, err := logging.LevelFromString(req["level"].(string))
+		if err != nil {
+			return nil, err
+		}
+
+		msg := req["msg"].(string)
+		switch level {
+		case logging.DEBUG:
+			o.logger.CDebugw(ctx, msg, "foo", "bar")
+		case logging.INFO:
+			o.logger.CInfow(ctx, msg, "foo", "bar")
+		case logging.WARN:
+			o.logger.CWarnw(ctx, msg, "foo", "bar")
+		case logging.ERROR:
+			o.logger.CErrorw(ctx, msg, "foo", "bar")
+		}
+		return map[string]any{}, nil
 	case "get_num_reconfigurations":
 		return map[string]any{"num_reconfigurations": o.numReconfigurations}, nil
 	default:

--- a/robot/impl/resource_manager_modular_test.go
+++ b/robot/impl/resource_manager_modular_test.go
@@ -19,10 +19,12 @@ import (
 	"go.viam.com/rdk/module/modmaninterface"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot/framesystem"
+	genericservice "go.viam.com/rdk/services/generic"
 	"go.viam.com/rdk/services/motion"
 	motionBuiltin "go.viam.com/rdk/services/motion/builtin"
 	rtestutils "go.viam.com/rdk/testutils"
 	"go.viam.com/rdk/utils"
+	rutils "go.viam.com/rdk/utils"
 )
 
 func TestModularResources(t *testing.T) {
@@ -478,7 +480,7 @@ func (m *dummyModMan) Close(ctx context.Context) error {
 	return nil
 }
 
-func TestDynamicModuleLogging(t *testing.T) {
+func TestDynamicModularComponentLogging(t *testing.T) {
 	modPath := rtestutils.BuildTempModule(t, "module/testmodule")
 
 	ctx := context.Background()
@@ -510,13 +512,13 @@ func TestDynamicModuleLogging(t *testing.T) {
 
 	//nolint:lll
 	// Have the module log a line at info. It should appear as:
-	// 2024-01-08T19:28:11.415-0800	INFO	TestModule.rdk:component:generic/helper	testmodule/main.go:147	info level log line	{"module_log_ts": "2024-01-09T03:28:11.412Z", "foo": "bar"}
+	// 2024-01-08T19:28:11.415-0800	INFO	TestModule.rdk:component:generic/helper testmodule/main.go:169  info level log line{"foo": "bar", "log_ts": "2024-06-24T19:18:33.426Z"}
 	infoLogLine := "info level log line"
 	testCmd := map[string]interface{}{"command": "log", "msg": infoLogLine, "level": "info"}
 	_, err = client.DoCommand(ctx, testCmd)
 	test.That(t, err, test.ShouldBeNil)
 
-	// Our log observer should find one occurrence of the log line with `module_log_ts` and `foo`
+	// Our log observer should find one occurrence of the log line with `log_ts` and `foo`
 	// arguments.
 	testutils.WaitForAssertion(t, func(tb testing.TB) {
 		tb.Helper()
@@ -537,6 +539,82 @@ func TestDynamicModuleLogging(t *testing.T) {
 
 	// Change the modular component to log at DEBUG instead of INFO.
 	cfg.Components[0].LogConfiguration.Level = logging.DEBUG
+	myRobot.Reconfigure(ctx, cfg)
+
+	// Trying to log again at DEBUG should see our log line pattern show up a second time. Now with
+	// DEBUG in the output string.
+	testCmd = map[string]interface{}{"command": "log", "msg": debugLogLine, "level": "debug"}
+	_, err = client.DoCommand(ctx, testCmd)
+	test.That(t, err, test.ShouldBeNil)
+
+	testutils.WaitForAssertion(t, func(tb testing.TB) {
+		tb.Helper()
+		test.That(tb, observer.FilterMessageSnippet(infoLogLine).Len(), test.ShouldEqual, 1)
+		test.That(tb, observer.FilterMessageSnippet(debugLogLine).Len(), test.ShouldEqual, 1)
+	})
+}
+
+func TestDynamicModularServiceLogging(t *testing.T) {
+	modPath := rtestutils.BuildTempModule(t, "module/testmodule")
+
+	ctx := context.Background()
+	logger, observer := logging.NewObservedTestLogger(t)
+
+	otherConf := resource.Config{
+		Name:  "other",
+		Model: resource.NewModel("rdk", "test", "other"),
+		API:   genericservice.API,
+		Attributes: rutils.AttributeMap{
+			"bar": "baz",
+		},
+		LogConfiguration: resource.LogConfig{Level: logging.INFO},
+	}
+
+	cfg := &config.Config{
+		Services: []resource.Config{otherConf},
+		Modules: []config.Module{{
+			Name:     "helperModule",
+			ExePath:  modPath,
+			LogLevel: "info",
+			Type:     "local",
+		}},
+	}
+
+	myRobot := setupLocalRobot(t, ctx, cfg, logger)
+
+	client, err := genericservice.FromRobot(myRobot, "other")
+	test.That(t, err, test.ShouldBeNil)
+	defer client.Close(ctx)
+
+	//nolint:lll
+	// Have the module log a line at info. It should appear as:
+	// 2024-01-08T19:28:11.415-0800	INFO	TestModule.rdk:service:generic/other    testmodule/main.go:225  info level log line{"foo": "bar", "log_ts": "2024-06-24T19:14:16.921Z"}
+	infoLogLine := "info level log line"
+	testCmd := map[string]interface{}{"command": "log", "msg": infoLogLine, "level": "info"}
+	_, err = client.DoCommand(ctx, testCmd)
+	test.That(t, err, test.ShouldBeNil)
+
+	// Our log observer should find one occurrence of the log line with `log_ts` and `foo`
+	// arguments.
+	testutils.WaitForAssertion(t, func(tb testing.TB) {
+		tb.Helper()
+		test.That(tb, observer.FilterMessageSnippet(infoLogLine).Len(), test.ShouldEqual, 1)
+		test.That(tb, observer.FilterMessageSnippet(infoLogLine).FilterFieldKey("log_ts").Len(), test.ShouldEqual, 1)
+		test.That(tb, observer.FilterMessageSnippet(infoLogLine).FilterFieldKey("foo").Len(), test.ShouldEqual, 1)
+	})
+
+	// The module is currently configured to log at info. If the module tries to log at debug,
+	// nothing new should be observed.
+	debugLogLine := "debug level log line"
+	testCmd = map[string]interface{}{"command": "log", "msg": debugLogLine, "level": "debug"}
+	_, err = client.DoCommand(ctx, testCmd)
+	test.That(t, err, test.ShouldBeNil)
+
+	test.That(t, observer.FilterMessageSnippet(infoLogLine).Len(), test.ShouldEqual, 1)
+	test.That(t, observer.FilterMessageSnippet(debugLogLine).Len(), test.ShouldEqual, 0)
+
+	// Change the modular service to log at DEBUG instead of INFO.
+	cfg.Services[0].LogConfiguration.Level = logging.DEBUG
 	myRobot.Reconfigure(ctx, cfg)
 
 	// Trying to log again at DEBUG should see our log line pattern show up a second time. Now with

--- a/robot/impl/resource_manager_modular_test.go
+++ b/robot/impl/resource_manager_modular_test.go
@@ -24,7 +24,6 @@ import (
 	motionBuiltin "go.viam.com/rdk/services/motion/builtin"
 	rtestutils "go.viam.com/rdk/testutils"
 	"go.viam.com/rdk/utils"
-	rutils "go.viam.com/rdk/utils"
 )
 
 func TestModularResources(t *testing.T) {
@@ -564,7 +563,7 @@ func TestDynamicModularServiceLogging(t *testing.T) {
 		Name:  "other",
 		Model: resource.NewModel("rdk", "test", "other"),
 		API:   genericservice.API,
-		Attributes: rutils.AttributeMap{
+		Attributes: utils.AttributeMap{
 			"bar": "baz",
 		},
 		LogConfiguration: resource.LogConfig{Level: logging.INFO},


### PR DESCRIPTION
### Description
**[RSDK-7942:](https://viam.atlassian.net/browse/RSDK-7942)** Reconfiguring cloud robot's services' log levels does not propagate
* This bug occurs because the `ServiceConfig` message does not have a `LogConfiguration` field, so when converting proto objects to an actual config, the logging configuration is never properly set on a reconfiguration. [This PR](https://github.com/viamrobotics/api/pull/519) adds adds a `LogConfiguration` field to the `ServiceConfig` message so that data is actually captured and can be used to propagate log level changes. 
* This PR modifies `ServiceConfigFromProto` such that it attempts to read the log configuration level for the service from the proto configuration object and sets it in the service's actual config (just like`ComponentConfigFromProto`).
* Also modifies `ServiceConfigToProto` by taking the service's log level from it's config and sets it as the `LogConfiguration` for the config proto object (just like`ComponentConfigToProto`).
### Testing 
* This bug is cloud-only (due to missing API field) and was tested by running my RDK branch against app locally.
* Added a test (which would have passed without any of these PRs) that ensures log level propagation for modular services as well (before, testing was only for component behavior) 