### PR TITLE
Use StoppableWorkers in genericlinux

### DIFF
--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -337,10 +337,8 @@ func (b *Board) reconfigureInterrupts(newConf *LinuxBoardConfig) error {
 
 func (b *Board) createGpioPin(mapping GPIOBoardMapping) *gpioPin {
 	pin := gpioPin{
-		boardWorkers: b.workers,
 		devicePath:   mapping.GPIOChipDev,
 		offset:       uint32(mapping.GPIO),
-		cancelCtx:    b.workers.Context(),
 		logger:       b.logger,
 	}
 	if mapping.HWPWMSupported {

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -15,7 +15,6 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 	pb "go.viam.com/api/component/board/v1"
-	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/board"
 	"go.viam.com/rdk/components/board/genericlinux/buses"
@@ -24,6 +23,7 @@ import (
 	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/utils"
 )
 
 // RegisterBoard registers a sysfs based board of the given model.
@@ -50,15 +50,12 @@ func NewBoard(
 	convertConfig ConfigConverter,
 	logger logging.Logger,
 ) (board.Board, error) {
-	cancelCtx, cancelFunc := context.WithCancel(context.Background())
-
 	b := &Board{
 		Named:         conf.ResourceName().AsNamed(),
 		convertConfig: convertConfig,
 
-		logger:     logger,
-		cancelCtx:  cancelCtx,
-		cancelFunc: cancelFunc,
+		logger:  logger,
+		workers: utils.NewStoppableWorkers(),
 
 		analogReaders: map[string]*wrappedAnalogReader{},
 		gpios:         map[string]*gpioPin{},
@@ -340,10 +337,10 @@ func (b *Board) reconfigureInterrupts(newConf *LinuxBoardConfig) error {
 
 func (b *Board) createGpioPin(mapping GPIOBoardMapping) *gpioPin {
 	pin := gpioPin{
-		boardWorkers: &b.activeBackgroundWorkers,
+		boardWorkers: b.workers,
 		devicePath:   mapping.GPIOChipDev,
 		offset:       uint32(mapping.GPIO),
-		cancelCtx:    b.cancelCtx,
+		cancelCtx:    b.workers.Context(),
 		logger:       b.logger,
 	}
 	if mapping.HWPWMSupported {
@@ -365,9 +362,7 @@ type Board struct {
 	gpios      map[string]*gpioPin
 	interrupts map[string]*digitalInterrupt
 
-	cancelCtx               context.Context
-	cancelFunc              func()
-	activeBackgroundWorkers sync.WaitGroup
+	workers utils.StoppableWorkers
 }
 
 // AnalogByName returns the analog pin by the given name if it exists.
@@ -481,17 +476,16 @@ func (b *Board) StreamTicks(ctx context.Context, interrupts []board.DigitalInter
 		i.AddChannel(ch)
 	}
 
-	b.activeBackgroundWorkers.Add(1)
-	utils.ManagedGo(func() {
+	b.workers.AddWorkers(func(cancelCtx context.Context) {
 		// Wait until it's time to shut down then remove callbacks.
 		select {
 		case <-ctx.Done():
-		case <-b.cancelCtx.Done():
+		case <-cancelCtx.Done():
 		}
 		for _, i := range rawInterrupts {
 			i.RemoveChannel(ch)
 		}
-	}, b.activeBackgroundWorkers.Done)
+	})
 
 	return nil
 }
@@ -499,9 +493,8 @@ func (b *Board) StreamTicks(ctx context.Context, interrupts []board.DigitalInter
 // Close attempts to cleanly close each part of the board.
 func (b *Board) Close(ctx context.Context) error {
 	b.mu.Lock()
-	b.cancelFunc()
-	b.mu.Unlock()
-	b.activeBackgroundWorkers.Wait()
+	defer b.mu.Unlock()
+	b.workers.Stop()
 
 	var err error
 	for _, pin := range b.gpios {

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -337,9 +337,9 @@ func (b *Board) reconfigureInterrupts(newConf *LinuxBoardConfig) error {
 
 func (b *Board) createGpioPin(mapping GPIOBoardMapping) *gpioPin {
 	pin := gpioPin{
-		devicePath:   mapping.GPIOChipDev,
-		offset:       uint32(mapping.GPIO),
-		logger:       b.logger,
+		devicePath: mapping.GPIOChipDev,
+		offset:     uint32(mapping.GPIO),
+		logger:     b.logger,
 	}
 	if mapping.HWPWMSupported {
 		pin.hwPwm = newPwmDevice(mapping.PWMSysFsDir, mapping.PWMID, b.logger)

--- a/components/board/genericlinux/board_test.go
+++ b/components/board/genericlinux/board_test.go
@@ -19,8 +19,6 @@ import (
 )
 
 func TestGenericLinux(t *testing.T) {
-	ctx := context.Background()
-
 	b := &Board{
 		logger: logging.NewTestLogger(t),
 	}
@@ -35,9 +33,6 @@ func TestGenericLinux(t *testing.T) {
 		gpioMappings:  nil,
 		analogReaders: map[string]*wrappedAnalogReader{"an": {}},
 		logger:        logging.NewTestLogger(t),
-		cancelCtx:     ctx,
-		cancelFunc: func() {
-		},
 	}
 
 	t.Run("test analog-readers digital-interrupts and gpio names", func(t *testing.T) {

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -14,13 +14,12 @@ import (
 	"go.viam.com/utils"
 
 	"go.viam.com/rdk/logging"
+	rdkutils "go.viam.com/rdk/utils"
 )
 
 const noPin = 0xFFFFFFFF // noPin is the uint32 version of -1. A pin with this offset has no GPIO
 
 type gpioPin struct {
-	boardWorkers *sync.WaitGroup
-
 	// These values should both be considered immutable.
 	devicePath string
 	offset     uint32
@@ -31,12 +30,10 @@ type gpioPin struct {
 	hwPwm           *pwmDevice // Defined in hw_pwm.go, will be nil for pins that don't support it.
 	pwmFreqHz       uint
 	pwmDutyCyclePct float64
+	softwarePwm     rdkutils.StoppableWorkers
 
 	mu        sync.Mutex
-	cancelCtx context.Context
 	logger    logging.Logger
-
-	swPwmCancel func()
 }
 
 func (pin *gpioPin) wrapError(err error) error {
@@ -114,9 +111,9 @@ func (pin *gpioPin) Set(ctx context.Context, isHigh bool,
 	defer pin.mu.Unlock()
 
 	// Shut down any software PWM loop that might be running.
-	if pin.swPwmCancel != nil {
-		pin.swPwmCancel()
-		pin.swPwmCancel = nil
+	if pin.softwarePwm != nil {
+		pin.softwarePwm.Stop()
+		pin.softwarePwm = nil
 	}
 
 	return pin.setInternal(isHigh)
@@ -176,9 +173,9 @@ func (pin *gpioPin) Get(
 func (pin *gpioPin) startSoftwarePWM() error {
 	if pin.pwmDutyCyclePct == 0 || pin.pwmFreqHz == 0 {
 		// We don't have both parameters set up. Stop any PWM loop we might have started previously.
-		if pin.swPwmCancel != nil {
-			pin.swPwmCancel()
-			pin.swPwmCancel = nil
+		if pin.softwarePwm != nil {
+			pin.softwarePwm.Stop()
+			pin.softwarePwm = nil
 		}
 		if pin.hwPwm != nil {
 			return pin.hwPwm.Close()
@@ -195,9 +192,9 @@ func (pin *gpioPin) startSoftwarePWM() error {
 				return err
 			}
 			// Shut down any software PWM loop that might be running.
-			if pin.swPwmCancel != nil {
-				pin.swPwmCancel()
-				pin.swPwmCancel = nil
+			if pin.softwarePwm != nil {
+				pin.softwarePwm.Stop()
+				pin.softwarePwm = nil
 			}
 			return pin.hwPwm.SetPwm(pin.pwmFreqHz, pin.pwmDutyCyclePct)
 		}
@@ -212,15 +209,12 @@ func (pin *gpioPin) startSoftwarePWM() error {
 	// If we get here, we need a software loop to drive the PWM signal, either because this pin
 	// doesn't have hardware support or because we want to drive it at such a low frequency that
 	// the hardware chip can't do it.
-	if pin.swPwmCancel != nil {
+	if pin.softwarePwm != nil {
 		// We already have a software PWM loop running. It will pick up the changes on its own.
 		return nil
 	}
 
-	ctx, cancel := context.WithCancel(pin.cancelCtx)
-	pin.swPwmCancel = cancel
-	pin.boardWorkers.Add(1)
-	utils.ManagedGo(func() { pin.softwarePwmLoop(ctx) }, pin.boardWorkers.Done)
+	pin.softwarePwm = rdkutils.NewStoppableWorkers(pin.softwarePwmLoop)
 	return nil
 }
 
@@ -345,6 +339,11 @@ func (pin *gpioPin) Close() error {
 	// we don't leak file descriptors.
 	pin.mu.Lock()
 	defer pin.mu.Unlock()
+
+	if pin.softwarePwm != nil {
+		pin.softwarePwm.Stop()
+		pin.softwarePwm = nil
+	}
 
 	if pin.hwPwm != nil {
 		if err := pin.hwPwm.Close(); err != nil {

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -32,8 +32,8 @@ type gpioPin struct {
 	pwmDutyCyclePct float64
 	softwarePwm     rdkutils.StoppableWorkers
 
-	mu        sync.Mutex
-	logger    logging.Logger
+	mu     sync.Mutex
+	logger logging.Logger
 }
 
 func (pin *gpioPin) wrapError(err error) error {


### PR DESCRIPTION
Not tested on hardware yet, will do that Monday.

The biggest change is that each GPIO pin has its own way to track goroutines, rather than reusing the board's one. I think this is a good move: it helps each struct be more self-contained and easier to reason about.

The second-biggest change is that every time we stop a software PWM loop, we call `StoppableWorkers.Stop()`, which means that next time we want to start it up again, we need to create a new one. Again, I think this is a good move, but that's why this isn't a 10-line PR.