### PR TITLE
RSDK-7999: Parameterize RC Build & Networking Tests trigger job on RC version and number

### DIFF
--- a/.github/workflows/releasecandidate.yml
+++ b/.github/workflows/releasecandidate.yml
@@ -70,6 +70,7 @@ jobs:
 
   extract-rc-version:
     runs-on: ubuntu-latest
+    continue-on-error: true
     outputs:
       version: ${{ steps.extract-rc-version.outputs.version }}
       rc_number: ${{ steps.extract-rc-version.outputs.rc_number }}

--- a/.github/workflows/releasecandidate.yml
+++ b/.github/workflows/releasecandidate.yml
@@ -68,9 +68,31 @@ jobs:
           channel: '#team-devops'
           name: 'Workflow Status'
 
+  extract-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Extract version and RC number
+        id: extract_version
+        run: |
+          TAG_NAME=${GITHUB_REF#refs/tags/}
+          if [[ $TAG_NAME =~ ^v([0-9]+\.[0-9]+\.[0-9]+)-rc([0-9]+)$ ]]; then
+            VERSION="${BASH_REMATCH[1]}"
+            RC_NUMBER="${BASH_REMATCH[2]}"
+            echo "::set-output name=version::$VERSION"
+            echo "::set-output name=rc_number::$RC_NUMBER"
+          else
+            echo "The tag does not match the expected pattern"
+            exit 1
+          fi
+
   run-sdk-integration-networking-tests:
-    needs: [staticbuild, appimage]
+    needs: [staticbuild, appimage, extract-version]
     if: ${{ success() }}
     uses: viamrobotics/rdk/.github/workflows/trigger-networking-tests.yml@main
+    with:
+      version: ${{ needs.extract_version.outputs.version }}
+      rc_number: ${{ needs.extract_version.outputs.rc_number }}
     secrets:
       REPO_READ_TOKEN: ${{ secrets.REPO_READ_TOKEN }}

--- a/.github/workflows/releasecandidate.yml
+++ b/.github/workflows/releasecandidate.yml
@@ -80,7 +80,7 @@ jobs:
         id: extract-rc-version
         run: |
           TAG_NAME=${GITHUB_REF#refs/tags/}
-          if [[ $TAG_NAME =~ ^v([0-9]+\.[0-9]+\.[0-9]+)-rc([0-9]+)$ ]]; then
+          if [[ $TAG_NAME =~ v([0-9]+\.[0-9]+\.[0-9]+)-rc([0-9]+) ]]; then
             VERSION="${BASH_REMATCH[1]}"
             RC_NUMBER="${BASH_REMATCH[2]}"
             echo "version=$VERSION" >> $GITUHB_OUTPUT

--- a/.github/workflows/releasecandidate.yml
+++ b/.github/workflows/releasecandidate.yml
@@ -68,31 +68,34 @@ jobs:
           channel: '#team-devops'
           name: 'Workflow Status'
 
-  extract-version:
+  extract-rc-version:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.extract-rc-version.outputs.version }}
+      rc_number: ${{ steps.extract-rc-version.outputs.rc_number }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Extract version and RC number
-        id: extract_version
+        id: extract-rc-version
         run: |
           TAG_NAME=${GITHUB_REF#refs/tags/}
           if [[ $TAG_NAME =~ ^v([0-9]+\.[0-9]+\.[0-9]+)-rc([0-9]+)$ ]]; then
             VERSION="${BASH_REMATCH[1]}"
             RC_NUMBER="${BASH_REMATCH[2]}"
-            echo "::set-output name=version::$VERSION"
-            echo "::set-output name=rc_number::$RC_NUMBER"
+            echo "version=$VERSION" >> $GITUHB_OUTPUT
+            echo "rc_number=$RC_NUMBER" >> $GITUHB_OUTPUT
           else
             echo "The tag does not match the expected pattern"
             exit 1
           fi
 
   run-sdk-integration-networking-tests:
-    needs: [staticbuild, appimage, extract-version]
+    needs: [staticbuild, appimage, extract-rc-version]
     if: ${{ success() }}
     uses: viamrobotics/rdk/.github/workflows/trigger-networking-tests.yml@main
     with:
-      version: ${{ needs.extract_version.outputs.version }}
-      rc_number: ${{ needs.extract_version.outputs.rc_number }}
+      version: ${{ needs.extract-rc-version.outputs.version }}
+      rc_number: ${{ needs.extract-rc-version.outputs.rc_number }}
     secrets:
       REPO_READ_TOKEN: ${{ secrets.REPO_READ_TOKEN }}

--- a/.github/workflows/releasecandidate.yml
+++ b/.github/workflows/releasecandidate.yml
@@ -87,7 +87,6 @@ jobs:
             echo "rc_number=$RC_NUMBER" >> $GITUHB_OUTPUT
           else
             echo "The tag does not match the expected pattern"
-            exit 1
           fi
 
   run-sdk-integration-networking-tests:

--- a/.github/workflows/trigger-networking-tests.yml
+++ b/.github/workflows/trigger-networking-tests.yml
@@ -2,10 +2,28 @@ name: Trigger Networking Tests in sdk-integration-tests
 
 on:
     workflow_call:
-        secrets:
-            REPO_READ_TOKEN:
-              required: true
+      inputs:
+        version:
+          type: string
+          description: 'Version number'
+          required: true
+        rc_number:
+          type: string
+          description: 'RC number'
+          required: true
+      secrets:
+          REPO_READ_TOKEN:
+            required: true     
     workflow_dispatch:
+      inputs:
+        version:
+          description: 'Version number'
+          required: true
+          type: string
+        rc_number:
+          description: 'RC number'
+          required: true
+          type: string
 
 jobs:
     run-networking-tests:
@@ -14,8 +32,14 @@ jobs:
         steps:
         - name: Trigger Workflow
           run: |
-            curl -X POST \
+            curl -f -X POST \
             -H "Authorization: token ${{ secrets.REPO_READ_TOKEN }}" \
             -H "Accept: application/vnd.github+json" \
             https://api.github.com/repos/viamrobotics/sdk-integration-tests/dispatches \
-            -d '{"event_type":"new_rc_branch"}'
+            -d '{
+              "event_type": "new_rc_branch",
+              "client_payload": {
+                "version": "${{ github.event.inputs.version }}",
+                "rc_number": "${{ github.event.inputs.rc_number }}"
+              }
+            }'


### PR DESCRIPTION
### Description
RSDK-7999: Fix RC Integration Tests download url
* Networking Tests triggered by new RC will currently always fail because it is not downloading a valid URL for an RC build, since their build names also include a version and rc number. 
* This PR adds in parameters for `version` and `rc_number` to `trigger-networking-tests.yml` which are passed within the curl to trigger Networking Tests.
  * [This PR](https://github.com/viamrobotics/sdk-integration-tests/pull/38) modifies the Networking Tests workflow to handle these inputs and download the RC building with the correct URL
* On RC Build workflow, a new job is added to extract versioning from the branch tag and passes those parameters into the `run-sdk-integration-networking-tests` job, completing the automation flow. 

### Testing
* Tested regex to ensure proper capture groups are matched
* Simulated test for `trigger-networking-tests.yml` with this command and:
```
gh api \
  --method POST \
  -H "Accept: application/vnd.github+json" \
  /repos/viamrobotics/sdk-integration-tests/dispatches \
  -f "event_type=new_rc_branch" \
  -F "client_payload[version]=0.30.0" \
  -F "client_payload[rc_number]=0"
``` 
which triggered Networking Tests on the expected RC build. 
* Only thing left untested is whether in `releasecandidate.yml` the tag gets correctly parsed and passed into the `trigger-networking-tests.yml` workflow correctly. However, if there is some issue with this the `continue-on-error: true` line should stop this job from failing the entire workflow, and the `run-sdk-integration-networking-tests` shouldn't be run since the `if: ${{ success() }}` requires job dependencies to succeed without error. 