### PR TITLE
APP-5330 NetAppender.SetConn and sharedConn

### DIFF
--- a/logging/net_appender.go
+++ b/logging/net_appender.go
@@ -89,10 +89,8 @@ func (w *remoteLogWriterGRPC) setConn(ctx context.Context, logger Logger, conn r
 	defer w.clientMutex.Unlock()
 	if w.rpcClient != nil && !w.sharedConn {
 		oldClient := w.rpcClient
-		go func() {
-			err := oldClient.Close()
-			logger.CErrorf(ctx, "error closing oldClient: %s", err)
-		}()
+		err := oldClient.Close()
+		logger.CErrorf(ctx, "error closing oldClient: %s", err)
 	}
 	w.rpcClient = conn
 	w.service = nil

--- a/logging/net_appender.go
+++ b/logging/net_appender.go
@@ -20,10 +20,10 @@ import (
 )
 
 var (
-	defaultMaxQueueSize          = 20000
-	defaultShutdownIters         = 1000
-	writeBatchSize               = 100
-	uninitializedConnectionError = errors.New("sharedConn is true and connection is not initialized")
+	defaultMaxQueueSize        = 20000
+	defaultShutdownIters       = 1000
+	writeBatchSize             = 100
+	errUninitializedConnection = errors.New("sharedConn is true and connection is not initialized")
 )
 
 // CloudConfig contains the necessary inputs to send logs to the app backend over grpc.
@@ -267,7 +267,7 @@ func (nl *NetAppender) backgroundWorker() {
 		err := nl.sync()
 		if err != nil && !errors.Is(err, context.Canceled) {
 			interval = abnormalInterval
-			if !errors.Is(err, uninitializedConnectionError) {
+			if !errors.Is(err, errUninitializedConnection) {
 				nl.loggerWithoutNet.Infof("error logging to network: %s", err)
 			}
 		} else {
@@ -379,7 +379,7 @@ func (w *remoteLogWriterGRPC) getOrCreateClient(ctx context.Context) (apppb.Robo
 	}
 
 	if w.sharedConn {
-		return nil, uninitializedConnectionError
+		return nil, errUninitializedConnection
 	}
 
 	client, err := CreateNewGRPCClient(ctx, w.cfg)

--- a/logging/net_appender.go
+++ b/logging/net_appender.go
@@ -35,7 +35,6 @@ type CloudConfig struct {
 // NewNetAppender creates a NetAppender to send log events to the app backend. NetAppenders ought to
 // be `Close`d prior to shutdown to flush remaining logs.
 // Pass `nil` for `conn` if you want this to create its own connection.
-// Pass `shutdownIters`=-1 for the default value.
 func NewNetAppender(config *CloudConfig, conn rpc.ClientConn, sharedConn bool) (*NetAppender, error) {
 	hostname, err := os.Hostname()
 	if err != nil {

--- a/logging/net_appender_test.go
+++ b/logging/net_appender_test.go
@@ -264,7 +264,7 @@ func TestSetConn(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	client, err := netAppender.remoteWriter.getOrCreateClient(context.Background())
 	test.That(t, client, test.ShouldBeNil)
-	test.That(t, errors.Is(err, uninitializedConnectionError), test.ShouldBeTrue)
+	test.That(t, errors.Is(err, errUninitializedConnection), test.ShouldBeTrue)
 
 	// write a line before the connection is up
 	logger := NewDebugLogger("provided-client-conn")

--- a/logging/net_appender_test.go
+++ b/logging/net_appender_test.go
@@ -108,7 +108,7 @@ func TestNetLoggerSync(t *testing.T) {
 	server := makeServerForRobotLogger(t)
 	defer server.stop()
 
-	netAppender, err := NewNetAppender(server.cloudConfig, nil, false, -1)
+	netAppender, err := NewNetAppender(server.cloudConfig, nil, false)
 	test.That(t, err, test.ShouldBeNil)
 
 	// This test is testing the behavior of sync(), so the background worker shouldn't be running at the same time.
@@ -140,7 +140,7 @@ func TestNetLoggerSyncFailureAndRetry(t *testing.T) {
 	server := makeServerForRobotLogger(t)
 	defer server.stop()
 
-	netAppender, err := NewNetAppender(server.cloudConfig, nil, false, -1)
+	netAppender, err := NewNetAppender(server.cloudConfig, nil, false)
 	test.That(t, err, test.ShouldBeNil)
 
 	// This test is testing the behavior of sync(), so the background worker shouldn't be running at the same time.
@@ -194,7 +194,7 @@ func TestNetLoggerOverflowDuringWrite(t *testing.T) {
 	server := makeServerForRobotLogger(t)
 	defer server.stop()
 
-	netAppender, err := NewNetAppender(server.cloudConfig, nil, false, -1)
+	netAppender, err := NewNetAppender(server.cloudConfig, nil, false)
 	test.That(t, err, test.ShouldBeNil)
 	logger := NewDebugLogger("test logger")
 	logger.AddAppender(netAppender)
@@ -240,7 +240,7 @@ func TestProvidedClientConn(t *testing.T) {
 	conn, err := CreateNewGRPCClient(context.Background(), server.cloudConfig)
 	test.That(t, err, test.ShouldBeNil)
 	defer conn.Close()
-	netAppender, err := NewNetAppender(server.cloudConfig, conn, true, -1)
+	netAppender, err := NewNetAppender(server.cloudConfig, conn, true)
 	test.That(t, err, test.ShouldBeNil)
 	// make sure these are the same object, i.e. that the constructor set it properly.
 	test.That(t, netAppender.remoteWriter.rpcClient == conn, test.ShouldBeTrue)
@@ -260,7 +260,7 @@ func TestSetConn(t *testing.T) {
 	defer server.stop()
 
 	// when inheritConn=true, getOrCreateClient should return uninitializedConnectionError
-	netAppender, err := NewNetAppender(server.cloudConfig, nil, true, -1)
+	netAppender, err := NewNetAppender(server.cloudConfig, nil, true)
 	test.That(t, err, test.ShouldBeNil)
 	client, err := netAppender.remoteWriter.getOrCreateClient(context.Background())
 	test.That(t, client, test.ShouldBeNil)

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -147,7 +147,7 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 				ID:         cfgFromDisk.Cloud.ID,
 				Secret:     cfgFromDisk.Cloud.Secret,
 			},
-			nil, false, -1,
+			nil, false,
 		)
 		if err != nil {
 			return err

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -147,7 +147,7 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 				ID:         cfgFromDisk.Cloud.ID,
 				Secret:     cfgFromDisk.Cloud.Secret,
 			},
-			nil,
+			nil, false, -1,
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
## What changed
- add `NetAppender.SetConn` method which can replace the underlying connection after the NetAppender has been instantiated
- add `sharedConn` bool which prevents NetAppender from creating its own connection
- ~add shutdownIters param so agent can shut down more quickly when offline~
## Why
This is a follow-up to adding NetAppender to viam-agent.

We want to:
- share viam-agent's existing grpc connection with the logger (this already happens)
- wait for that connection, but instantiate the NetAppender at the top of `main()` so it is copied to subloggers
- capture log messages from before the connection is available

`SetConn` lets us do the 2nd + 3rd bullet.
## Reviewer questions
1. I've changed the NetAppender constructor. will this break compatibility with anything outside RDK? should I create a second constructor instead?
2. is the goroutine-based close method safe? (note: this will not be called in tests, with the exception of TestSetConn)
3. in Close, the stopping condition is currently 'number of sleeps'. would it make sense to also have a 'no progress' condition so that when the device is offline, it doesn't wait to close?