### PR TITLE
[RSDK-7081] Fewer checksum errors in I2C NMEA parsing

### DIFF
--- a/components/movementsensor/gpsutils/cachedData.go
+++ b/components/movementsensor/gpsutils/cachedData.go
@@ -72,7 +72,7 @@ func (g *CachedData) start(cancelCtx context.Context) {
 			// Update our struct's gps data in-place
 			err := g.ParseAndUpdate(message)
 			if err != nil {
-				g.logger.CWarnf(cancelCtx, "can't parse nmea sentence: %#v", err)
+				g.logger.CWarnf(cancelCtx, "can't parse nmea sentence '%s': %#v", message, err)
 				g.logger.Debug("Check: GPS requires clear sky view." +
 					"Ensure the antenna is outdoors if signal is weak or unavailable indoors.")
 			}

--- a/components/movementsensor/gpsutils/i2c_data_reader.go
+++ b/components/movementsensor/gpsutils/i2c_data_reader.go
@@ -152,9 +152,9 @@ func (dr *PmtkI2cDataReader) start() {
 				}
 
 				// Otherwise, the chip is trying to communicate with us. However, sometimes the
-				// NMEA data has the most significant bit of the byte set, even though it should
-				// only send ASCII (which never sets the most significant bit). So, to reduce
-				// checksum errors, we mask out that bit.
+				// data has the most significant bit of the byte set, even though it should only
+				// send ASCII (which never sets the most significant bit). So, to reduce checksum
+				// errors, we mask out that bit.
 				b = b & 0x7F
 
 				// PMTK uses CRLF line endings to terminate sentences, but just LF to blank data.

--- a/components/movementsensor/gpsutils/i2c_data_reader.go
+++ b/components/movementsensor/gpsutils/i2c_data_reader.go
@@ -155,7 +155,7 @@ func (dr *PmtkI2cDataReader) start() {
 				// data has the most significant bit of the byte set, even though it should only
 				// send ASCII (which never sets the most significant bit). So, to reduce checksum
 				// errors, we mask out that bit.
-				b = b & 0x7F
+				b &= 0x7F
 
 				// PMTK uses CRLF line endings to terminate sentences, but just LF to blank data.
 				// Since CR should never appear except at the end of our sentence, we use that to

--- a/components/movementsensor/gpsutils/i2c_data_reader.go
+++ b/components/movementsensor/gpsutils/i2c_data_reader.go
@@ -147,6 +147,16 @@ func (dr *PmtkI2cDataReader) start() {
 			}
 
 			for _, b := range buffer {
+				if b == 0xFF {
+					continue // This byte indicates that the chip did not have data to send us.
+				}
+
+				// Otherwise, the chip is trying to communicate with us. However, sometimes the
+				// NMEA data has the most significant bit of the byte set, even though it should
+				// only send ASCII (which never sets the most significant bit). So, to reduce
+				// checksum errors, we mask out that bit.
+				b = b & 0x7F
+
 				// PMTK uses CRLF line endings to terminate sentences, but just LF to blank data.
 				// Since CR should never appear except at the end of our sentence, we use that to
 				// determine sentence end. LF is merely ignored.
@@ -170,7 +180,7 @@ func (dr *PmtkI2cDataReader) start() {
 						default:
 						}
 					}
-				} else if b != 0x0A && b < 0x7F { // only append valid (printable) bytes
+				} else if b != 0x0A { // skip the newlines; we focused on the carriage returns
 					strBuf += string(b)
 				}
 			}

--- a/components/movementsensor/gpsutils/i2c_data_reader.go
+++ b/components/movementsensor/gpsutils/i2c_data_reader.go
@@ -180,7 +180,7 @@ func (dr *PmtkI2cDataReader) start() {
 						default:
 						}
 					}
-				} else if b != 0x0A { // skip the newlines; we focused on the carriage returns
+				} else if b != 0x0A { // Skip the newlines, as described earlier
 					strBuf += string(b)
 				}
 			}


### PR DESCRIPTION
Without this change, between a third and half of the NMEA sentences received over I2C had checksum errors. With this change, I haven't seen any! 

It turns out that sometimes, the chip will set the most significant bit of a byte it sends us. However, we expect all the data to be ASCII (which never sets the most significant bit), so we'd ignore those characters, and then we'd get NMEA sentences that are 1 character too short, and whose checksum doesn't match. Every example I looked at, if you just ignore the most significant bit of the problem byte (but keep the other 7 bits!), everything else lines up perfectly. So, that's the change I made.

Tried on piworld with a gps-nmea component. 