### PR TITLE
DOCS-2089: Add board API code samples

### DIFF
--- a/components/board/board.go
+++ b/components/board/board.go
@@ -92,7 +92,6 @@ func Named(name string) resource.Name {
 //	  interrupts = append(interrupts, di11)
 //	}
 //
-//	// Show how a ticksChan can be made from the listed digital interrupts on pins 8 and 11.
 //	err = myBoard.StreamTicks(context.Background(), interrupts, ticksChan, nil)
 type Board interface {
 	resource.Resource

--- a/components/board/board.go
+++ b/components/board/board.go
@@ -68,20 +68,6 @@ func Named(name string) resource.Name {
 //	// Get the GPIOPin with pin number 15.
 //	pin, err := myBoard.GPIOPinByName("15")
 //
-// AnalogNames example:
-//
-//	myBoard, err := board.FromRobot(robot, "my_board")
-//
-//	// Get the name of every Analog pin configured on the board.
-//	names := myBoard.AnalogNames()
-//
-// DigitalInterruptNames example:
-//
-//	myBoard, err := board.FromRobot(robot, "my_board")
-//
-//	// Get the name of every DigitalInterrupt configured on the board.
-//	names := myBoard.DigitalInterruptNames()
-//
 // SetPowerMode example:
 //
 //	myBoard, err := board.FromRobot(robot, "my_board")
@@ -106,7 +92,7 @@ func Named(name string) resource.Name {
 //	  interrupts = append(interrupts, di11)
 //	}
 //
-//	// Stream ticks on ticksChan from the listed digital interrupts on pins 8 and 11.
+//	// Show how a ticksChan can be made from the listed digital interrupts on pins 8 and 11.
 //	err = myBoard.StreamTicks(context.Background(), interrupts, ticksChan, nil)
 type Board interface {
 	resource.Resource
@@ -145,7 +131,7 @@ type Board interface {
 //	// Get the analog pin "my_example_analog".
 //	analog, err := myBoard.AnalogByName("my_example_analog")
 //
-//	// Get the value of the digital signal "my_example_analog" has most recently measured.
+//	// Get the value of the analog signal "my_example_analog" has most recently measured.
 //	reading, err := analog.Read(context.Background(), nil)
 //	readingValue := reading.Value
 //	stepSize := reading.StepSize

--- a/components/board/board.go
+++ b/components/board/board.go
@@ -46,6 +46,68 @@ func Named(name string) resource.Name {
 
 // A Board represents a physical general purpose board that contains various
 // components such as analogs, and digital interrupts.
+//
+// AnalogByName example:
+//
+//	myBoard, err := board.FromRobot(robot, "my_board")
+//
+//	// Get the Analog pin "my_example_analog".
+//	analog, err := myBoard.AnalogByName("my_example_analog")
+//
+// DigitalInterruptByName example:
+//
+//	myBoard, err := board.FromRobot(robot, "my_board")
+//
+//	// Get the DigitalInterrupt "my_example_digital_interrupt".
+//	interrupt, err := myBoard.DigitalInterruptByName("my_example_digital_interrupt")
+//
+// GPIOPinByName example:
+//
+//	myBoard, err := board.FromRobot(robot, "my_board")
+//
+//	// Get the GPIOPin with pin number 15.
+//	pin, err := myBoard.GPIOPinByName("15")
+//
+// AnalogNames example:
+//
+//	myBoard, err := board.FromRobot(robot, "my_board")
+//
+//	// Get the name of every Analog pin configured on the board.
+//	names := myBoard.AnalogNames()
+//
+// DigitalInterruptNames example:
+//
+//	myBoard, err := board.FromRobot(robot, "my_board")
+//
+//	// Get the name of every DigitalInterrupt configured on the board.
+//	names := myBoard.DigitalInterruptNames()
+//
+// SetPowerMode example:
+//
+//	myBoard, err := board.FromRobot(robot, "my_board")
+//
+//	Set the power mode of the board to OFFLINE_DEEP.
+//	myBoard.SetPowerMode(context.Background(), boardpb.PowerMode_POWER_MODE_OFFLINE_DEEP, nil)
+//
+// StreamTicks example:
+//
+//	myBoard, err := board.FromRobot(robot, "my_board")
+//
+//	// Make a channel to stream ticks
+//	ticksChan := make(chan board.Tick)
+//
+//	interrupts := []*DigitalInterrupt{}
+//
+//	if di8, err := myBoard.DigitalInterruptByName("8"); err == nil {
+//	  interrupts = append(interrupts, di8)
+//	}
+//
+//	if di11, err := myBoard.DigitalInterruptByName("11"); err == nil {
+//	  interrupts = append(interrupts, di11)
+//	}
+//
+//	// Stream ticks on ticksChan from the listed digital interrupts on pins 8 and 11.
+//	err = myBoard.StreamTicks(context.Background(), interrupts, ticksChan, nil)
 type Board interface {
 	resource.Resource
 
@@ -75,6 +137,28 @@ type Board interface {
 }
 
 // An Analog represents an analog pin that resides on a board.
+//
+// Read example:
+//
+//	myBoard, err := board.FromRobot(robot, "my_board")
+//
+//	// Get the analog pin "my_example_analog".
+//	analog, err := myBoard.AnalogByName("my_example_analog")
+//
+//	// Get the value of the digital signal "my_example_analog" has most recently measured.
+//	reading, err := analog.Read(context.Background(), nil)
+//	readingValue := reading.Value
+//	stepSize := reading.StepSize
+//
+// Write example:
+//
+//	myBoard, err := board.FromRobot(robot, "my_board")
+//
+//	// Get the Analog pin "my_example_analog".
+//	analog, err := myBoard.AnalogByName("my_example_analog")
+//
+//	// Set the pin to value 48.
+//	err := analog.Write(context.Background(), 48, nil)
 type Analog interface {
 	// Read reads off the current value.
 	Read(ctx context.Context, extra map[string]interface{}) (AnalogValue, error)

--- a/components/board/digital_interrupts.go
+++ b/components/board/digital_interrupts.go
@@ -26,11 +26,8 @@ type Tick struct {
 //	// Get the DigitalInterrupt "my_example_digital_interrupt".
 //	interrupt, err := myBoard.DigitalInterruptByName("my_example_digital_interrupt")
 //
-//	// If using type basic: Get the amount of times this DigitalInterrupt has been interrupted with a tick.
+//	// Get the amount of times this DigitalInterrupt has ticked.
 //	count, err := interrupt.Value(context.Background(), nil)
-//
-//	// If using type servo: Get the rolling average of the pulse width across each time the DigitalInterrupt is interrupted with a tick.
-//	rolling_avg, err := interrupt.Value(context.Background(), nil)
 type DigitalInterrupt interface {
 	// Name returns the name of the interrupt.
 	Name() string

--- a/components/board/digital_interrupts.go
+++ b/components/board/digital_interrupts.go
@@ -18,6 +18,19 @@ type Tick struct {
 
 // A DigitalInterrupt represents a configured interrupt on the board that
 // when interrupted, calls the added callbacks.
+//
+// Value example:
+//
+//	myBoard, err := board.FromRobot(robot, "my_board")
+//
+//	// Get the DigitalInterrupt "my_example_digital_interrupt".
+//	interrupt, err := myBoard.DigitalInterruptByName("my_example_digital_interrupt")
+//
+//	// If using type basic: Get the amount of times this DigitalInterrupt has been interrupted with a tick.
+//	count, err := interrupt.Value(context.Background(), nil)
+//
+//	// If using type servo: Get the rolling average of the pulse width across each time the DigitalInterrupt is interrupted with a tick.
+//	rolling_avg, err := interrupt.Value(context.Background(), nil)
 type DigitalInterrupt interface {
 	// Name returns the name of the interrupt.
 	Name() string

--- a/components/board/gpio_pin.go
+++ b/components/board/gpio_pin.go
@@ -31,7 +31,7 @@ import "context"
 //	// Get the GPIOPin with pin number 15.
 //	pin, err := myBoard.GPIOPinByName("15")
 //
-//	// Get if it is true or false that the state of the pin is high.
+//	// Returns the duty cycle.
 //	duty_cycle := pin.PWM(context.Background(), nil)
 //
 // SetPWM example:

--- a/components/board/gpio_pin.go
+++ b/components/board/gpio_pin.go
@@ -3,6 +3,66 @@ package board
 import "context"
 
 // A GPIOPin represents an individual GPIO pin on a board.
+//
+// Set example:
+//
+//	myBoard, err := board.FromRobot(robot, "my_board")
+//
+//	// Get the GPIOPin with pin number 15.
+//	pin, err := myBoard.GPIOPinByName("15")
+//
+//	// Set the pin to high.
+//	err := pin.Set(context.Background(), "true", nil)
+//
+// Get example:
+//
+//	myBoard, err := board.FromRobot(robot, "my_board")
+//
+//	// Get the GPIOPin with pin number 15.
+//	pin, err := myBoard.GPIOPinByName("15")
+//
+//	// Get if it is true or false that the state of the pin is high.
+//	high := pin.Get(context.Background(), nil)
+//
+// PWM example:
+//
+//	myBoard, err := board.FromRobot(robot, "my_board")
+//
+//	// Get the GPIOPin with pin number 15.
+//	pin, err := myBoard.GPIOPinByName("15")
+//
+//	// Get if it is true or false that the state of the pin is high.
+//	duty_cycle := pin.PWM(context.Background(), nil)
+//
+// SetPWM example:
+//
+//	myBoard, err := board.FromRobot(robot, "my_board")
+//
+//	// Get the GPIOPin with pin number 15.
+//	pin, err := myBoard.GPIOPinByName("15")
+//
+//	// Set the duty cycle to .6, meaning that this pin will be in the high state for 60% of the duration of the PWM interval period.
+//	err := pin.SetPWM(context.Background(), .6, nil)
+//
+// PWMFreq example:
+//
+//	myBoard, err := board.FromRobot(robot, "my_board")
+//
+//	// Get the GPIOPin with pin number 15.
+//	pin, err := myBoard.GPIOPinByName("15")
+//
+//	// Get the PWM frequency of this pin.
+//	freqHz, err := pin.PWMFreq(context.Background(), nil)
+//
+// SetPWMFreq example:
+//
+//	myBoard, err := board.FromRobot(robot, "my_board")
+//
+//	// Get the GPIOPin with pin number 15.
+//	pin, err := myBoard.GPIOPinByName("15")
+//
+//	// Set the PWM frequency of this pin to 1600 Hz.
+//	high := pin.SetPWMFreq(context.Background(), 1600, nil)
 type GPIOPin interface {
 	// Set sets the pin to either low or high.
 	Set(ctx context.Context, high bool, extra map[string]interface{}) error


### PR DESCRIPTION
Add code samples to Board API GO methods, for:
- `Board` API itself
- `Analog` API
- `GPIOPin` API
- `DigitalInterrupt` API

Code samples sourced from live docs.viam.com reference page: https://docs.viam.com/components/board/#api