### PR TITLE
Add disclaimer about classifications in the vision service card

### DIFF
--- a/web/frontend/src/components/vision/index.svelte
+++ b/web/frontend/src/components/vision/index.svelte
@@ -178,6 +178,12 @@ const onRefreshKeyPress = async (event: KeyboardEvent) => {
         options={cameras.map((cam) => cam.name).join(',')}
         on:input={selectCamera}
       />
+      <v-notify
+        class="max-w-sm"
+        variant="info"
+        title="Classifications won't show here"
+        message="Right now this card only supports detections. Soon your classifications will show here too."
+      />
     </div>
 
     <div class="flex min-w-fit flex-col gap-4 p-4">


### PR DESCRIPTION
The vision service card doesn't support classifications. This adds a banner saying that it's not supported while we are working on the new vision service card.

<img width="1229" alt="Screenshot 2024-06-25 at 5 06 44 PM" src="https://github.com/viamrobotics/rdk/assets/5910938/6d0e3b9a-3ac3-4aee-b930-ae2aac04fc53">