### PR TITLE
Reduce config ticker logs

### DIFF
--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -529,13 +529,14 @@ func newWithResources(
 				return
 			}
 
+			var trigger string
 			select {
 			case <-closeCtx.Done():
 				return
 			case <-r.configTicker.C:
-				r.logger.CDebugw(ctx, "configuration attempt triggered by ticker")
+				trigger = "ticker"
 			case <-r.triggerConfig:
-				r.logger.CDebugw(ctx, "configuration attempt triggered by remote")
+				trigger = "remote"
 			}
 			anyChanges := r.manager.updateRemotesResourceNames(closeCtx)
 			if r.manager.anyResourcesNotConfigured() {
@@ -544,9 +545,7 @@ func newWithResources(
 			}
 			if anyChanges {
 				r.updateWeakDependents(ctx)
-				r.logger.CDebugw(ctx, "configuration attempt completed with changes")
-			} else {
-				r.logger.CDebugw(ctx, "configuration attempt completed without changes")
+				r.logger.CDebugw(ctx, "configuration attempt completed with changes", "trigger", trigger)
 			}
 		}
 	}, r.activeBackgroundWorkers.Done)

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -537,6 +537,7 @@ func newWithResources(
 				trigger = "ticker"
 			case <-r.triggerConfig:
 				trigger = "remote"
+				r.logger.CDebugw(ctx, "configuration attempt triggered by remote")
 			}
 			anyChanges := r.manager.updateRemotesResourceNames(closeCtx)
 			if r.manager.anyResourcesNotConfigured() {


### PR DESCRIPTION
there are too many, reducing to only log if changes detected or if it was triggered by a remote