### PR TITLE
RSDK-7933: fix logging bugs

### DIFF
--- a/logging/level.go
+++ b/logging/level.go
@@ -93,9 +93,7 @@ func LevelFromString(inp string) (Level, error) {
 		return DEBUG, nil
 	case "info":
 		return INFO, nil
-	case "warn":
-		return WARN, nil
-	case "warning":
+	case "warn", "warning":
 		return WARN, nil
 	case "error":
 		return ERROR, nil

--- a/logging/level.go
+++ b/logging/level.go
@@ -95,6 +95,8 @@ func LevelFromString(inp string) (Level, error) {
 		return INFO, nil
 	case "warn":
 		return WARN, nil
+	case "warning":
+		return WARN, nil
 	case "error":
 		return ERROR, nil
 	}

--- a/logging/level.go
+++ b/logging/level.go
@@ -85,7 +85,7 @@ func (level Level) AsZap() zapcore.Level {
 }
 
 // LevelFromString parses an input string to a log level. The string must be one of `debug`, `info`,
-// `warn`, `warning`, or `error`. The parsing is case-insensitive. An error is returned if the input 
+// `warn`, `warning`, or `error`. The parsing is case-insensitive. An error is returned if the input
 // does not match one of labeled cases.
 func LevelFromString(inp string) (Level, error) {
 	switch strings.ToLower(inp) {

--- a/logging/level.go
+++ b/logging/level.go
@@ -85,8 +85,8 @@ func (level Level) AsZap() zapcore.Level {
 }
 
 // LevelFromString parses an input string to a log level. The string must be one of `debug`, `info`,
-// `warn` or `error`. The parsing is case-insensitive. An error is returned if the input does not
-// match one of labeled cases.
+// `warn`, `warning`, or `error`. The parsing is case-insensitive. An error is returned if the input 
+// does not match one of labeled cases.
 func LevelFromString(inp string) (Level, error) {
 	switch strings.ToLower(inp) {
 	case "debug":

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -14,6 +14,10 @@ func TestRoundTrip(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, parsed, test.ShouldEqual, level)
 	}
+
+	parsed, err := LevelFromString("warning")
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, parsed, test.ShouldEqual, WARN)
 }
 
 func TestJSONRoundTrip(t *testing.T) {

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -7,7 +7,7 @@ import (
 	"go.viam.com/test"
 )
 
-func TestRoundTrip(t *testing.T) {
+func TestLevelStrings(t *testing.T) {
 	for _, level := range []Level{DEBUG, INFO, WARN, ERROR} {
 		serialzied := level.String()
 		parsed, err := LevelFromString(serialzied)


### PR DESCRIPTION
[Jira Ticket](https://viam.atlassian.net/browse/RSDK-7933)

fixed an issue where the string input might be `warning` instead of `warn`.