### PR TITLE
RSDK-7803 fix pion log after test "data race" (log goleak)

### DIFF
--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -147,7 +147,7 @@ func setupWithRunningPart(
 	authMethod string,
 	partFQDN string,
 	cliArgs ...string,
-) (*cli.Context, *viamClient, *testWriter, *testWriter, func()) {
+) (*cli.Context, *viamClient, *testWriter, *testWriter) {
 	t.Helper()
 
 	cCtx, ac, out, errOut := setup(asc, dataClient, buildClient, nil, defaultFlags, authMethod, cliArgs...)
@@ -175,9 +175,10 @@ func setupWithRunningPart(
 	ac.baseURL, _, err = parseBaseURL(ac.conf.BaseURL, false)
 	test.That(t, err, test.ShouldBeNil)
 
-	return cCtx, ac, out, errOut, func() {
+	t.Cleanup(func() {
 		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-	}
+	})
+	return cCtx, ac, out, errOut
 }
 
 func TestListOrganizationsAction(t *testing.T) {
@@ -572,9 +573,8 @@ func TestShellFileCopy(t *testing.T) {
 			tempDir := t.TempDir()
 
 			args := []string{fmt.Sprintf("machine:%s", tfs.SingleFileNested), tempDir}
-			cCtx, viamClient, _, _, teardown := setupWithRunningPart(
+			cCtx, viamClient, _, _ := setupWithRunningPart(
 				t, asc, nil, nil, partFlags, "token", partFqdn, args...)
-			defer teardown()
 			test.That(t, machinesPartCopyFilesAction(cCtx, viamClient), test.ShouldBeNil)
 
 			rd, err := os.ReadFile(filepath.Join(tempDir, filepath.Base(tfs.SingleFileNested)))
@@ -590,9 +590,8 @@ func TestShellFileCopy(t *testing.T) {
 			test.That(t, os.Chdir(tempDir), test.ShouldBeNil)
 
 			args := []string{fmt.Sprintf("machine:%s", tfs.SingleFileNested), "foo"}
-			cCtx, viamClient, _, _, teardown := setupWithRunningPart(
+			cCtx, viamClient, _, _ := setupWithRunningPart(
 				t, asc, nil, nil, partFlags, "token", partFqdn, args...)
-			defer teardown()
 			test.That(t, machinesPartCopyFilesAction(cCtx, viamClient), test.ShouldBeNil)
 
 			rd, err := os.ReadFile(filepath.Join(tempDir, "foo"))
@@ -606,9 +605,8 @@ func TestShellFileCopy(t *testing.T) {
 			args := []string{fmt.Sprintf("machine:%s", tfs.Root), tempDir}
 
 			t.Log("without recursion set")
-			cCtx, viamClient, _, _, teardown1 := setupWithRunningPart(
+			cCtx, viamClient, _, _ := setupWithRunningPart(
 				t, asc, nil, nil, partFlags, "token", partFqdn, args...)
-			defer teardown1()
 			err := machinesPartCopyFilesAction(cCtx, viamClient)
 			test.That(t, errors.Is(err, errDirectoryCopyRequestNoRecursion), test.ShouldBeTrue)
 			_, err = os.ReadFile(filepath.Join(tempDir, filepath.Base(tfs.SingleFileNested)))
@@ -618,9 +616,8 @@ func TestShellFileCopy(t *testing.T) {
 			partFlagsCopy := make(map[string]any, len(partFlags))
 			maps.Copy(partFlagsCopy, partFlags)
 			partFlagsCopy["recursive"] = true
-			cCtx, viamClient, _, _, teardown2 := setupWithRunningPart(
+			cCtx, viamClient, _, _ = setupWithRunningPart(
 				t, asc, nil, nil, partFlagsCopy, "token", partFqdn, args...)
-			defer teardown2()
 			test.That(t, machinesPartCopyFilesAction(cCtx, viamClient), test.ShouldBeNil)
 			test.That(t, shelltestutils.DirectoryContentsEqual(tfs.Root, filepath.Join(tempDir, filepath.Base(tfs.Root))), test.ShouldBeNil)
 		})
@@ -636,9 +633,8 @@ func TestShellFileCopy(t *testing.T) {
 			partFlagsCopy := make(map[string]any, len(partFlags))
 			maps.Copy(partFlagsCopy, partFlags)
 			partFlagsCopy["recursive"] = true
-			cCtx, viamClient, _, _, teardown := setupWithRunningPart(
+			cCtx, viamClient, _, _ := setupWithRunningPart(
 				t, asc, nil, nil, partFlagsCopy, "token", partFqdn, args...)
-			defer teardown()
 			test.That(t, machinesPartCopyFilesAction(cCtx, viamClient), test.ShouldBeNil)
 
 			rd, err := os.ReadFile(filepath.Join(tempDir, filepath.Base(tfs.SingleFileNested)))
@@ -671,9 +667,8 @@ func TestShellFileCopy(t *testing.T) {
 					maps.Copy(partFlagsCopy, partFlags)
 					partFlagsCopy["recursive"] = true
 					partFlagsCopy["preserve"] = preserve
-					cCtx, viamClient, _, _, teardown := setupWithRunningPart(
+					cCtx, viamClient, _, _ := setupWithRunningPart(
 						t, asc, nil, nil, partFlagsCopy, "token", partFqdn, args...)
-					defer teardown()
 					test.That(t, machinesPartCopyFilesAction(cCtx, viamClient), test.ShouldBeNil)
 					test.That(t, shelltestutils.DirectoryContentsEqual(tfs.Root, filepath.Join(tempDir, filepath.Base(tfs.Root))), test.ShouldBeNil)
 
@@ -698,9 +693,8 @@ func TestShellFileCopy(t *testing.T) {
 			tempDir := t.TempDir()
 
 			args := []string{tfs.SingleFileNested, fmt.Sprintf("machine:%s", tempDir)}
-			cCtx, viamClient, _, _, teardown := setupWithRunningPart(
+			cCtx, viamClient, _, _ := setupWithRunningPart(
 				t, asc, nil, nil, partFlags, "token", partFqdn, args...)
-			defer teardown()
 			test.That(t, machinesPartCopyFilesAction(cCtx, viamClient), test.ShouldBeNil)
 
 			rd, err := os.ReadFile(filepath.Join(tempDir, filepath.Base(tfs.SingleFileNested)))
@@ -715,9 +709,8 @@ func TestShellFileCopy(t *testing.T) {
 			randomPath := filepath.Join(homeDir, randomName)
 			defer os.Remove(randomPath)
 			args := []string{tfs.SingleFileNested, fmt.Sprintf("machine:%s", randomName)}
-			cCtx, viamClient, _, _, teardown := setupWithRunningPart(
+			cCtx, viamClient, _, _ := setupWithRunningPart(
 				t, asc, nil, nil, partFlags, "token", partFqdn, args...)
-			defer teardown()
 			test.That(t, machinesPartCopyFilesAction(cCtx, viamClient), test.ShouldBeNil)
 
 			rd, err := os.ReadFile(randomPath)
@@ -731,9 +724,8 @@ func TestShellFileCopy(t *testing.T) {
 			args := []string{tfs.Root, fmt.Sprintf("machine:%s", tempDir)}
 
 			t.Log("without recursion set")
-			cCtx, viamClient, _, _, teardown1 := setupWithRunningPart(
+			cCtx, viamClient, _, _ := setupWithRunningPart(
 				t, asc, nil, nil, partFlags, "token", partFqdn, args...)
-			defer teardown1()
 			err := machinesPartCopyFilesAction(cCtx, viamClient)
 			test.That(t, errors.Is(err, errDirectoryCopyRequestNoRecursion), test.ShouldBeTrue)
 			_, err = os.ReadFile(filepath.Join(tempDir, filepath.Base(tfs.SingleFileNested)))
@@ -743,9 +735,8 @@ func TestShellFileCopy(t *testing.T) {
 			partFlagsCopy := make(map[string]any, len(partFlags))
 			maps.Copy(partFlagsCopy, partFlags)
 			partFlagsCopy["recursive"] = true
-			cCtx, viamClient, _, _, teardown2 := setupWithRunningPart(
+			cCtx, viamClient, _, _ = setupWithRunningPart(
 				t, asc, nil, nil, partFlagsCopy, "token", partFqdn, args...)
-			defer teardown2()
 			test.That(t, machinesPartCopyFilesAction(cCtx, viamClient), test.ShouldBeNil)
 			test.That(t, shelltestutils.DirectoryContentsEqual(tfs.Root, filepath.Join(tempDir, filepath.Base(tfs.Root))), test.ShouldBeNil)
 		})
@@ -761,9 +752,8 @@ func TestShellFileCopy(t *testing.T) {
 			partFlagsCopy := make(map[string]any, len(partFlags))
 			maps.Copy(partFlagsCopy, partFlags)
 			partFlagsCopy["recursive"] = true
-			cCtx, viamClient, _, _, teardown := setupWithRunningPart(
+			cCtx, viamClient, _, _ := setupWithRunningPart(
 				t, asc, nil, nil, partFlagsCopy, "token", partFqdn, args...)
-			defer teardown()
 			test.That(t, machinesPartCopyFilesAction(cCtx, viamClient), test.ShouldBeNil)
 
 			rd, err := os.ReadFile(filepath.Join(tempDir, filepath.Base(tfs.SingleFileNested)))
@@ -796,9 +786,8 @@ func TestShellFileCopy(t *testing.T) {
 					maps.Copy(partFlagsCopy, partFlags)
 					partFlagsCopy["recursive"] = true
 					partFlagsCopy["preserve"] = preserve
-					cCtx, viamClient, _, _, teardown := setupWithRunningPart(
+					cCtx, viamClient, _, _ := setupWithRunningPart(
 						t, asc, nil, nil, partFlagsCopy, "token", partFqdn, args...)
-					defer teardown()
 					test.That(t, machinesPartCopyFilesAction(cCtx, viamClient), test.ShouldBeNil)
 					test.That(t, shelltestutils.DirectoryContentsEqual(tfs.Root, filepath.Join(tempDir, filepath.Base(tfs.Root))), test.ShouldBeNil)
 

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -151,7 +151,6 @@ func setupWithRunningPart(
 	t.Helper()
 
 	cCtx, ac, out, errOut := setup(asc, dataClient, buildClient, nil, defaultFlags, authMethod, cliArgs...)
-	logger := logging.NewInMemoryLogger(t)
 
 	// this config could later become a parameter
 	r, err := robotimpl.New(cCtx.Context, &robotconfig.Config{
@@ -162,7 +161,7 @@ func setupWithRunningPart(
 				Model: resource.DefaultServiceModel,
 			},
 		},
-	}, logger)
+	}, logging.NewInMemoryLogger(t))
 	test.That(t, err, test.ShouldBeNil)
 
 	options, _, addr := robottestutils.CreateBaseOptionsAndListener(t)
@@ -177,11 +176,6 @@ func setupWithRunningPart(
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Cleanup(func() {
-		defer func() {
-			if t.Failed() {
-				logger.OutputLogs()
-			}
-		}()
 		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
 	})
 	return cCtx, ac, out, errOut

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -151,6 +151,7 @@ func setupWithRunningPart(
 	t.Helper()
 
 	cCtx, ac, out, errOut := setup(asc, dataClient, buildClient, nil, defaultFlags, authMethod, cliArgs...)
+	logger := logging.NewInMemoryLogger(t)
 
 	// this config could later become a parameter
 	r, err := robotimpl.New(cCtx.Context, &robotconfig.Config{
@@ -161,7 +162,7 @@ func setupWithRunningPart(
 				Model: resource.DefaultServiceModel,
 			},
 		},
-	}, logging.NewTestLogger(t))
+	}, logger)
 	test.That(t, err, test.ShouldBeNil)
 
 	options, _, addr := robottestutils.CreateBaseOptionsAndListener(t)
@@ -177,6 +178,9 @@ func setupWithRunningPart(
 
 	t.Cleanup(func() {
 		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
+		if t.Failed() {
+			logger.OutputLogs()
+		}
 	})
 	return cCtx, ac, out, errOut
 }

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -177,10 +177,12 @@ func setupWithRunningPart(
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Cleanup(func() {
+		defer func() {
+			if t.Failed() {
+				logger.OutputLogs()
+			}
+		}()
 		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
-		if t.Failed() {
-			logger.OutputLogs()
-		}
 	})
 	return cCtx, ac, out, errOut
 }

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -141,5 +141,12 @@ func NewInMemoryLogger(tb testing.TB) *MemLogger {
 		testHelper: tb.Helper,
 	}
 
-	return &MemLogger{logger, tb, observedLogs}
+	memLogger := &MemLogger{logger, tb, observedLogs}
+	// Ensure that logs are always output on failure.
+	tb.Cleanup(func() {
+		if tb.Failed() {
+			memLogger.OutputLogs()
+		}
+	})
+	return memLogger
 }

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -128,8 +128,9 @@ func (memLogger *MemLogger) OutputLogs() {
 	}
 }
 
-// NewInMemoryLogger creates a MemLogger that can be used to buffer test logs and output them on
-// command. This is handy if a test is noisy, but the output is useful when the test fails.
+// NewInMemoryLogger creates a MemLogger that buffers test logs and only outputs them if
+// requested or if the test fails. This is handy if a test is noisy, but the output is
+// useful when the test fails.
 func NewInMemoryLogger(tb testing.TB) *MemLogger {
 	observerCore, observedLogs := observer.New(zap.LevelEnablerFunc(zapcore.DebugLevel.Enabled))
 	logger := &impl{

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -1004,11 +1004,6 @@ func TestRTPPassthrough(t *testing.T) {
 	t.Skip()
 	ctx := context.Background()
 	logger := logging.NewInMemoryLogger(t)
-	defer func() {
-		if t.Failed() {
-			logger.OutputLogs()
-		}
-	}()
 
 	// Precompile module copies to avoid timeout issues when building takes too long.
 	modPath := rtestutils.BuildTempModule(t, "examples/customresources/demos/rtppassthrough")
@@ -1219,11 +1214,6 @@ func TestRTPPassthrough(t *testing.T) {
 func TestAddStreamMaxTrackErr(t *testing.T) {
 	ctx := context.Background()
 	logger := logging.NewInMemoryLogger(t)
-	defer func() {
-		if t.Failed() {
-			logger.OutputLogs()
-		}
-	}()
 
 	// Precompile module copies to avoid timeout issues when building takes too long.
 	modPath := rtestutils.BuildTempModule(t, "examples/customresources/demos/rtppassthrough")

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -1846,11 +1846,6 @@ func TestReconfigureParity(t *testing.T) {
 			t.Parallel()
 			// Capture logs for this sub-test run. Only output the logs if the test fails.
 			logger := logging.NewInMemoryLogger(t)
-			defer func() {
-				if t.Failed() {
-					logger.OutputLogs()
-				}
-			}()
 
 			// Configuration may mutate `*config.Config`, so we read it from
 			// file each time.


### PR DESCRIPTION
## Summary

Fix a flaky test failure related to [logging after a test completes](https://cs.opensource.google/go/go/+/refs/tags/go1.22.4:src/testing/testing.go;l=1674-1679) by using a `MemLogger`, which suppresses logs unless a test fails for other reasons. This particular log is written [by a goroutine in the pion webrtc library that we cannot wait on](https://github.com/pion/webrtc/blob/a868a14ec8196a58bf064e33ba00dd3e259c36e8/datachannel.go#L330).

## Fly-by changes
* Change `NewInMemoryLogger` to return a `MemLogger` that automatically outputs on test failures.
* Update CLI test helpers to automatically close robots created for testing.

## Testing

Reproduce the data race with the following patch to https://github.com/viamrobotics/goutils and ensure that the change this PR resolves the data race.

```diff
diff --git a/rpc/wrtc_server_stream.go b/rpc/wrtc_server_stream.go
index 070a07a..1c8d601 100644
--- a/rpc/wrtc_server_stream.go
+++ b/rpc/wrtc_server_stream.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"math"
 	"sync/atomic"
+	"time"
 
 	"github.com/edaniels/golog"
 	protov1 "github.com/golang/protobuf/proto" //nolint:staticcheck
@@ -240,9 +241,11 @@ func (s *webrtcServerStream) onRequest(request *webrtcpb.Request) {
 		}
 		s.processMessage(r.Message)
 	case *webrtcpb.Request_RstStream:
-		if err := s.closeWithSendError(status.Error(codes.Canceled, "request cancelled")); err != nil {
-			s.logger.Errorw("error closing", "error", err)
-		}
+		// if err := s.closeWithSendError(status.Error(codes.Canceled, "request cancelled")); err != nil {
+		err := s.closeWithSendError(status.Error(codes.Canceled, "request cancelled"))
+		time.Sleep(1 * time.Second)
+		s.logger.Errorw("error closing", "error", err)
+		// }
 		return
 	default:
 		if err := s.closeWithSendError(status.Error(codes.InvalidArgument, fmt.Sprintf("unknown request type %T", r))); err != nil {
```