### PR TITLE
RSDK-6256: Robot Leaks Connection to Remotes

### DIFF
--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -836,11 +836,13 @@ func (manager *resourceManager) processRemote(
 	config config.Remote,
 	gNode *resource.GraphNode,
 ) (*client.RobotClient, error) {
-
 	// if there was an existing client (i.e. remote was modified), close old client before making a new one
 	res, err := gNode.Resource()
 	if err == nil {
-		res.Close(ctx)
+		err = res.Close(ctx)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	dialOpts := remoteDialOptions(config, manager.opts)

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -169,8 +169,9 @@ type internalRemoteRobot interface {
 }
 
 // updateRemoteResourceNames is called when the Remote robot has changed (either connection or disconnection).
-// It will pull the current remote resources and update the resource tree adding or removing nodes accordingly
-// If any local resources are dependent on a remote resource two things can happen
+// It will pull the current remote resources and update the resource tree adding or removing nodes accordingly.
+// The recreateAllClients flag will re-add all remote resource nodes if true and only new / uninitalized
+// resource names if false. If any local resources are dependent on a remote resource two things can happen
 //  1. The remote resource already is in the tree and nothing will happen.
 //  2. A remote resource is being deleted but a local resource depends on it; it will be removed
 //     and its local children will be destroyed.

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -221,6 +221,7 @@ func (manager *resourceManager) updateRemoteResourceNames(
 					continue
 				}
 				// reconfiguration attempt, remote could have changed, so close all duplicate name remote resource clients and readd new ones later
+				manager.logger.CDebugw(ctx, "attempting to remove remote resource", "name", resName)
 				if err := manager.markChildrenForUpdate(resName); err != nil {
 					manager.logger.CErrorw(ctx,
 						"failed to mark children of remote resource for update",
@@ -276,14 +277,14 @@ func (manager *resourceManager) updateRemoteResourceNames(
 		}
 		if err := manager.markChildrenForUpdate(resName); err != nil {
 			manager.logger.CErrorw(ctx,
-				"failed to mark children of remote for update",
+				"failed to mark children of remote resource for update",
 				"resource", resName,
 				"reason", err)
 			continue
 		}
 		if err := gNode.Close(ctx); err != nil {
 			manager.logger.CErrorw(ctx,
-				"failed to close remote node",
+				"failed to close remote resource node",
 				"resource", resName,
 				"reason", err)
 		}

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -836,6 +836,13 @@ func (manager *resourceManager) processRemote(
 	config config.Remote,
 	gNode *resource.GraphNode,
 ) (*client.RobotClient, error) {
+
+	// if there was an existing client (i.e. remote was modified), close old client before making a new one
+	res, err := gNode.Resource()
+	if err == nil {
+		res.Close(ctx)
+	}
+
 	dialOpts := remoteDialOptions(config, manager.opts)
 	manager.logger.CInfow(ctx, "Connecting now to remote", "remote", config.Name)
 	robotClient, err := dialRobotClient(ctx, config, gNode.Logger(), dialOpts...)

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -1698,7 +1698,7 @@ func TestRemoteConnClosedOnReconfigure(t *testing.T) {
 		mainCfgCopy2.Remotes[0].Address = addr1
 		mainRobot.Reconfigure(context.Background(), &mainCfgCopy2)
 
-		// Check that we were able to grab the arm from remote1 through the main robot and successfully call IsPowered()
+		// Check that we were able to grab the arm from remote1 through the main robot and successfully call IsMoving()
 		remoteFromMain, ok := mainRobot.RemoteByName("remote")
 		test.That(t, ok, test.ShouldBeTrue)
 

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -1668,7 +1668,7 @@ func TestRemoteConnClosedOnReconfigure(t *testing.T) {
 		mainCfgCopy2.Remotes[0].Address = addr1
 		mainRobot.Reconfigure(ctx, &mainCfgCopy2)
 
-		// Close second remote connection
+		// Close second remote robot
 		remote2.Close(ctx)
 
 		// Verify that motor of remote2 no longer works

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -30,7 +30,6 @@ import (
 
 	"go.viam.com/rdk/cloud"
 	"go.viam.com/rdk/components/arm"
-	"go.viam.com/rdk/components/arm/fake"
 	fakearm "go.viam.com/rdk/components/arm/fake"
 	"go.viam.com/rdk/components/base"
 	fakebase "go.viam.com/rdk/components/base/fake"
@@ -1601,7 +1600,7 @@ func TestRemoteConnClosedOnReconfigure(t *testing.T) {
 		Name:                "arm",
 		Model:               resource.DefaultModelFamily.WithModel("fake"),
 		API:                 arm.API,
-		ConvertedAttributes: &fake.Config{},
+		ConvertedAttributes: &fakearm.Config{},
 	}
 
 	remoteCfg1 := &config.Config{

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -1604,11 +1604,11 @@ func TestRemoteConnClosedOnReconfigure(t *testing.T) {
 	}
 
 	remoteCfg1 := &config.Config{
-		Components: []resource.Config{fakeArm},
+		Components: []resource.Config{fakeMotor},
 	}
 
 	remoteCfg2 := &config.Config{
-		Components: []resource.Config{fakeMotor},
+		Components: []resource.Config{fakeArm},
 	}
 
 	t.Run("remotes with same exact resources", func(t *testing.T) {
@@ -1664,8 +1664,8 @@ func TestRemoteConnClosedOnReconfigure(t *testing.T) {
 	})
 
 	t.Run("remotes with different resources", func(t *testing.T) {
-		remote1 := setupLocalRobot(t, ctx, remoteCfg1, logger.Sublogger("remote1"))
-		remote2 := setupLocalRobot(t, ctx, remoteCfg2, logger.Sublogger("remote2"))
+		remote1 := setupLocalRobot(t, ctx, remoteCfg2, logger.Sublogger("remote1"))
+		remote2 := setupLocalRobot(t, ctx, remoteCfg1, logger.Sublogger("remote2"))
 
 		options1, _, addr1 := robottestutils.CreateBaseOptionsAndListener(t)
 		err := remote1.StartWeb(ctx, options1)

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -1745,7 +1745,7 @@ func TestRemoteConnClosedOnReconfigure(t *testing.T) {
 		mainCfgCopy2.Remotes[0].Address = addr1
 		mainRobot.Reconfigure(ctx, &mainCfgCopy2)
 
-		// Close second remote connection
+		// Close second remote robot
 		remote2.Close(ctx)
 
 		// Verify that motor of remote2 no longer works

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/grpcreflect"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.uber.org/zap/zapcore"
 	armpb "go.viam.com/api/component/arm/v1"
 	basepb "go.viam.com/api/component/base/v1"
 	boardpb "go.viam.com/api/component/board/v1"
@@ -29,6 +30,7 @@ import (
 
 	"go.viam.com/rdk/cloud"
 	"go.viam.com/rdk/components/arm"
+	"go.viam.com/rdk/components/arm/fake"
 	fakearm "go.viam.com/rdk/components/arm/fake"
 	"go.viam.com/rdk/components/base"
 	fakebase "go.viam.com/rdk/components/base/fake"
@@ -1581,6 +1583,137 @@ func TestReconfigure(t *testing.T) {
 	defer func() {
 		test.That(t, local.Close(ctx), test.ShouldBeNil)
 	}()
+}
+
+func TestRemoteConnClosedOnReconfigure(t *testing.T) {
+	logger, observer := logging.NewObservedTestLogger(t)
+
+	ctx := context.Background()
+
+	fakeMotor := resource.Config{
+		Name:                "motor",
+		Model:               resource.DefaultModelFamily.WithModel("fake"),
+		API:                 motor.API,
+		ConvertedAttributes: &fakemotor.Config{},
+	}
+
+	fakeArm := resource.Config{
+		Name:                "arm",
+		Model:               resource.DefaultModelFamily.WithModel("fake"),
+		API:                 arm.API,
+		ConvertedAttributes: &fake.Config{},
+	}
+
+	remoteCfg1 := &config.Config{
+		Components: []resource.Config{fakeArm},
+	}
+
+	remoteCfg2 := &config.Config{
+		Components: []resource.Config{fakeMotor},
+	}
+
+	t.Run("remotes with same exact resources", func(t *testing.T) {
+		remote1 := setupLocalRobot(t, ctx, remoteCfg1, logger.Sublogger("remote1"))
+		remote2 := setupLocalRobot(t, ctx, remoteCfg1, logger.Sublogger("remote2"))
+
+		options1, _, addr1 := robottestutils.CreateBaseOptionsAndListener(t)
+		err := remote1.StartWeb(ctx, options1)
+		test.That(t, err, test.ShouldBeNil)
+
+		options2, _, addr2 := robottestutils.CreateBaseOptionsAndListener(t)
+		err = remote2.StartWeb(ctx, options2)
+		test.That(t, err, test.ShouldBeNil)
+
+		// Set up a local main robot which is connected to remote1
+		remoteConf := config.Remote{
+			Name:    "remote",
+			Address: addr1,
+		}
+
+		mainRobotCfg := &config.Config{
+			Remotes: []config.Remote{remoteConf},
+		}
+
+		// Make a copy of the main robot config as reconfigure will directly modify it
+		mainCfgCopy := *mainRobotCfg
+		mainRobot := setupLocalRobot(t, context.Background(), mainRobotCfg, logger.Sublogger("main"))
+
+		// Change address in config copy to reference address of the remote2, make a copy of the config, and reconfigure
+		mainCfgCopy.Remotes[0].Address = addr2
+		mainCfgCopy2 := mainCfgCopy
+		mainRobot.Reconfigure(context.Background(), &mainCfgCopy)
+
+		// Change address back to original remote, and reconfigure
+		mainCfgCopy2.Remotes[0].Address = addr1
+		mainRobot.Reconfigure(context.Background(), &mainCfgCopy2)
+
+		// Check that we were able to grab the motor from remote1 through the main robot and successfully call IsPowered()
+		remoteFromMain, ok := mainRobot.RemoteByName("remote")
+		test.That(t, ok, test.ShouldBeTrue)
+
+		res, err := motor.FromRobot(remoteFromMain, "motor")
+		test.That(t, err, test.ShouldBeNil)
+
+		moving, speed, err := res.IsPowered(context.Background(), nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, moving, test.ShouldBeFalse)
+		test.That(t, speed, test.ShouldEqual, 0.0)
+
+		// Also check that there are no error logs associated with the main robot trying to reconnect to remote2
+		// Leaked remote connections will cause the test to fail due to goroutine leaks
+		test.That(t, observer.FilterLevelExact(zapcore.ErrorLevel).Len(), test.ShouldEqual, 0)
+	})
+
+	t.Run("remotes with different resources", func(t *testing.T) {
+		remote1 := setupLocalRobot(t, ctx, remoteCfg1, logger.Sublogger("remote1"))
+		remote2 := setupLocalRobot(t, ctx, remoteCfg2, logger.Sublogger("remote2"))
+
+		options1, _, addr1 := robottestutils.CreateBaseOptionsAndListener(t)
+		err := remote1.StartWeb(ctx, options1)
+		test.That(t, err, test.ShouldBeNil)
+
+		options2, _, addr2 := robottestutils.CreateBaseOptionsAndListener(t)
+		err = remote2.StartWeb(ctx, options2)
+		test.That(t, err, test.ShouldBeNil)
+
+		// Set up a local main robot which is connected to remote1
+		remoteConf := config.Remote{
+			Name:    "remote",
+			Address: addr1,
+		}
+
+		mainRobotCfg := &config.Config{
+			Remotes: []config.Remote{remoteConf},
+		}
+
+		// Make a copy of the main robot config as reconfigure will directly modify it
+		mainCfgCopy := *mainRobotCfg
+		mainRobot := setupLocalRobot(t, context.Background(), mainRobotCfg, logger.Sublogger("main"))
+
+		// Change address in config copy to reference address of the remote2, make a copy of the config, and reconfigure
+		mainCfgCopy.Remotes[0].Address = addr2
+		mainCfgCopy2 := mainCfgCopy
+		mainRobot.Reconfigure(context.Background(), &mainCfgCopy)
+
+		// Change address back to original remote, and reconfigure
+		mainCfgCopy2.Remotes[0].Address = addr1
+		mainRobot.Reconfigure(context.Background(), &mainCfgCopy2)
+
+		// Check that we were able to grab the arm from remote1 through the main robot and successfully call IsPowered()
+		remoteFromMain, ok := mainRobot.RemoteByName("remote")
+		test.That(t, ok, test.ShouldBeTrue)
+
+		res, err := arm.FromRobot(remoteFromMain, "arm")
+		test.That(t, err, test.ShouldBeNil)
+
+		moving, err := res.IsMoving(ctx)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, moving, test.ShouldBeFalse)
+
+		// Also check that there are no error logs associated with the main robot trying to reconnect to remote2
+		// Leaked remote connections will cause the test to fail due to goroutine leaks
+		test.That(t, observer.FilterLevelExact(zapcore.ErrorLevel).Len(), test.ShouldEqual, 0)
+	})
 }
 
 func TestResourceCreationPanic(t *testing.T) {


### PR DESCRIPTION
### Description
RSDK-6256: Robot Leaks Connection to Remote
* Certain robot configurations can cause remote connections to leak due to the same remote being added twice causing two clients to be created despite one resource, thus one connection gets leaked.
* Also having a single remote robot configured and switching the remote between two robots up at different addresses will cause a connection to leak each time the address is changed.
* This leak is due to the fact that new robot clients are allocated every time a remote is configured, without checking if the old client exists and closing it.
* This PR checks the remote resource node for a client, and if it exists, closing it before creating a new one so the connection does not leak.
### Testing
* A test `TestRemoteConnClosedOnReconfigure` for checking that remote resources are properly closed before a new one is created on reconfiguration, if necessary. 
  * The test will fail due to a goroutine leak is there is a connection leak, and logs are checked for no reconnection failures to leaked connections.
* Also tested cloud reproduction against this PR which was leaking connections due to the same issue, is also now fixed.
### Notes
* This PR will break [this method of capturing data from remotes ](https://docs.google.com/document/d/1Fu-y2fyI2bY4fdDQ4M-u6B3y9BVtmjoGfVPhydZ7KFM/edit#heading=h.h0jiaq7nwb7t).
* The same functionality can be achieved by having a separate remote robot rather than relying on using a subpart.
  * A subpart can still be used, but the name of the data capturing configuration in the main robot JSON must be different from the subparts name. This effectively creates two resource nodes that have 2 clients for the same remote robot.   