### PR TITLE
RSDK-6811: return foreign resource when client registration doesnt exist

### DIFF
--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -559,10 +559,7 @@ func (rc *RobotClient) ResourceByName(name resource.Name) (resource.Resource, er
 func (rc *RobotClient) createClient(name resource.Name) (resource.Resource, error) {
 	apiInfo, ok := resource.LookupGenericAPIRegistration(name.API)
 	if !ok || apiInfo.RPCClient == nil {
-		if name.API.Type.Namespace != resource.APINamespaceRDK {
-			return grpc.NewForeignResource(name, &rc.conn), nil
-		}
-		return nil, ErrMissingClientRegistration
+		return grpc.NewForeignResource(name, &rc.conn), nil
 	}
 	return apiInfo.RPCClient(rc.backgroundCtx, &rc.conn, rc.remoteName, name, rc.Logger())
 }

--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -2055,7 +2055,7 @@ func TestShutDown(t *testing.T) {
 	test.That(t, shutdownCalled, test.ShouldBeTrue)
 }
 
-func TestSomething(t *testing.T) {
+func TestUnregisteredResourceByName(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	listener, err := net.Listen("tcp", "localhost:0")
 	test.That(t, err, test.ShouldBeNil)

--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -2054,3 +2054,43 @@ func TestShutDown(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, shutdownCalled, test.ShouldBeTrue)
 }
+
+func TestSomething(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	listener, err := net.Listen("tcp", "localhost:0")
+	test.That(t, err, test.ShouldBeNil)
+
+	testAPI := resource.APINamespace("testNamespace").WithComponentType("encoder")
+	testName := resource.NewName(testAPI, "encoder1")
+
+	testAPI2 := resource.APINamespaceRDK.WithComponentType("fake")
+	testName2 := resource.NewName(testAPI2, "fake")
+
+	resourceList := []resource.Name{
+		testName,
+		testName2,
+	}
+	injectRobot := &inject.Robot{
+		ResourceNamesFunc:   func() []resource.Name { return resourceList },
+		ResourceRPCAPIsFunc: func() []resource.RPCAPI { return nil },
+	}
+
+	gServer := grpc.NewServer()
+	pb.RegisterRobotServiceServer(gServer, server.New(injectRobot))
+
+	go gServer.Serve(listener)
+	defer gServer.Stop()
+
+	client, err := New(context.Background(), listener.Addr().String(), logger)
+	test.That(t, err, test.ShouldBeNil)
+	defer func() {
+		test.That(t, client.Close(context.Background()), test.ShouldBeNil)
+	}()
+
+	// We should not error when trying to create a client for an unregistered
+	// resource, regardless of whether or not it is in RDK namespace.
+	for _, name := range resourceList {
+		_, err = client.ResourceByName(name)
+		test.That(t, err, test.ShouldBeNil)
+	}
+}


### PR DESCRIPTION
[RSDK-6811](https://viam.atlassian.net/browse/RSDK-6811): return foreign resource when client registration doesnt exist
- we now return foreign resources as resource clients for unregistered API's, so that modular resources may have arbitrary dependencies and still configure.

[RSDK-6811]: https://viam.atlassian.net/browse/RSDK-6811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ