### PR TITLE
[APP-5401]: Change viam prod auth domain to vanity domain (auth.viam.com).

### DIFF
--- a/cli/auth.go
+++ b/cli/auth.go
@@ -48,7 +48,7 @@ type authFlow struct {
 const (
 	defaultOpenIDDiscoveryPath = "/.well-known/openid-configuration"
 
-	prodAuthDomain = "https://viam-prod.fusionauth.io"
+	prodAuthDomain = "https://auth.viam.com"
 	prodAudience   = "c1e41724-9b29-479f-abcc-7bfbe2e3309a"
 	prodClientID   = "c1e41724-9b29-479f-abcc-7bfbe2e3309a" // native client ID
 


### PR DESCRIPTION
https://viam.atlassian.net/browse/APP-5401
Made same change in device authorization grant flow in the prod auth dashboard.