### PR TITLE
[RSDK-7081] get higher fix numbers on the RTK I2C component

### DIFF
--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
@@ -33,7 +33,6 @@ package gpsrtkpmtk
 */
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -394,7 +393,7 @@ func (g *rtkI2C) receiveAndWriteI2C(ctx context.Context) {
 
 		msg, err := scanner.NextMessage()
 		if err == nil {
-			err = handle.Write(ctx, msg)
+			err = handle.Write(ctx, msg.Serialize())
 			if err != nil {
 				g.logger.CErrorf(ctx, "i2c handle write failed %s", err)
 				g.err.Set(err)

--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
@@ -399,7 +399,7 @@ func (g *rtkI2C) receiveAndWriteI2C(ctx context.Context) {
 				g.err.Set(err)
 				return
 			}
-			continue // No errors: we're still connected to the caster, and forwarded data over I2C.
+			continue // No errors: we're still connected to the caster and the I2C bus.
 		}
 
 		// If we get here, the scanner encountered an error but is supposed to continue going. Try

--- a/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
+++ b/components/movementsensor/gpsrtkpmtk/gpsrtkpmtk.go
@@ -365,9 +365,6 @@ func (g *rtkI2C) receiveAndWriteI2C(ctx context.Context) {
 	}
 
 	// create a buffer
-	w := &bytes.Buffer{}
-	r := io.TeeReader(g.ntripClient.Stream, w)
-
 	buf := make([]byte, 1100)
 	n, err := g.ntripClient.Stream.Read(buf)
 	if err != nil {
@@ -385,7 +382,7 @@ func (g *rtkI2C) receiveAndWriteI2C(ctx context.Context) {
 		return
 	}
 
-	scanner := rtcm3.NewScanner(r)
+	scanner := rtcm3.NewScanner(g.ntripClient.Stream)
 
 	for {
 		select {
@@ -415,9 +412,6 @@ func (g *rtkI2C) receiveAndWriteI2C(ctx context.Context) {
 			return
 		}
 
-		w = &bytes.Buffer{}
-		r = io.TeeReader(g.ntripClient.Stream, w)
-
 		buf = make([]byte, 1100)
 		n, err := g.ntripClient.Stream.Read(buf)
 		if err != nil {
@@ -434,7 +428,7 @@ func (g *rtkI2C) receiveAndWriteI2C(ctx context.Context) {
 			return
 		}
 
-		scanner = rtcm3.NewScanner(r)
+		scanner = rtcm3.NewScanner(g.ntripClient.Stream)
 	}
 }
 


### PR DESCRIPTION
It turns out we weren't forwarding any data from the caster to the chip! I've removed the "unused" TeeReader and the buffer it wrote into (mildly surprised we never had out-of-memory issues, since I think the TeeReader might have been writing into a buffer forever without doing anything else with the data), and added in a part about writing the messages into the I2C bus instead.

Tried on piworld: I can get a fix of 2 and then later 5 with the I2C component, same as the serial component!