### PR TITLE
RSDK-8063 Disable motion position-based replanning on obstacle-based replan test

### DIFF
--- a/services/motion/builtin/move_on_globe_test.go
+++ b/services/motion/builtin/move_on_globe_test.go
@@ -275,7 +275,7 @@ func TestObstacleReplanningGlobe(t *testing.T) {
 	}
 
 	cfg := &motion.MotionConfiguration{
-		PositionPollingFreqHz: 1,
+		PositionPollingFreqHz: 0.000001,
 		ObstaclePollingFreqHz: 5,
 		PlanDeviationMM:       epsilonMM,
 		ObstacleDetectors:     obstacleDetectorSlice,


### PR DESCRIPTION
Fix a flaky test.

A test was failing due to the simulated base being off-course (something expected to happen mildly in these tests) and triggering a replan, causing the test to fail as it was checking a replan did not occur for any reason.