### PR TITLE
Avoid race conditions in single-line encoder

### DIFF
--- a/components/encoder/single/single_encoder.go
+++ b/components/encoder/single/single_encoder.go
@@ -166,7 +166,7 @@ func (e *Encoder) Reconfigure(
 	// state is not really valid anymore
 	atomic.StoreInt64(&e.position, 0)
 
-	if e.workers == nil {
+	if e.workers != nil {
 		e.workers.Stop() // Shut down the old interrupt stream
 	}
 	e.start(ctx, board) // Start up the new interrupt stream

--- a/components/encoder/single/single_encoder.go
+++ b/components/encoder/single/single_encoder.go
@@ -221,6 +221,9 @@ func (e *Encoder) Position(
 	positionType encoder.PositionType,
 	extra map[string]interface{},
 ) (float64, encoder.PositionType, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
 	if positionType == encoder.PositionTypeDegrees {
 		return math.NaN(), encoder.PositionTypeUnspecified, encoder.NewPositionTypeUnsupportedError(positionType)
 	}

--- a/components/encoder/single/single_encoder.go
+++ b/components/encoder/single/single_encoder.go
@@ -173,7 +173,8 @@ func (e *Encoder) Reconfigure(
 	return nil
 }
 
-// start starts the Encoder background thread.
+// start starts the Encoder background thread. It should only be called when the encoder's
+// background workers have been stopped (or never started).
 func (e *Encoder) start(ctx context.Context, b board.Board) {
 	e.workers = rdkutils.NewStoppableWorkers()
 


### PR DESCRIPTION
Thanks to @seanavery for noticing the problem! This is a follow-up to https://github.com/viamrobotics/rdk/pull/4147 Changes include:
- Every time we lock the mutex, do so at the very top of the function and then defer unlocking it immediately, instead of manually unlocking it later. This ensures that the functions that lock the mutex are atomic. 
- Lock the mutex on all public functions. This ensures that we can't get bogus readings by calling some public function at the same time that we're, say, reconfiguring the component.
- Don't call `Close()` from within `Reconfigure()`, to avoid deadlocks now that both are locking the mutex no matter what. All we really needed from `Close()` was stopping the `StoppableWorkers`, and that's easy enough to copy over.
- We were calling `e.workers.Stop()` twice within 10 lines of each other, and the second one should never fire (see my dithering in the comments of https://github.com/viamrobotics/rdk/pull/4147). It's now much more obvious that it should never need to be stopped again: get rid of the second `Stop()`, and just put in a comment at the top of the function saying it needs to have already been stopped (compare old line 183 to new line 170).
- Now that `Close()` is not called during `Reconfigure()`, remove the part that was only there to make `Reconfigure()` work right.

Tried on the `grievance` rover: seems to work fine, but the old version seemed to work fine, too. but this time it looks like it has fewer potential bugs!