### PR TITLE
Delete temp directory after running CLI command

### DIFF
--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -698,7 +698,7 @@ func readModels(path string, logger logging.Logger) ([]ModuleComponent, error) {
 	}
 	defer func() {
 		if err := os.RemoveAll(tmpdir); err != nil {
-			logger.Warnw("failed to delete temp directory", "error", err)
+			logger.Warnw("failed to delete temp directory", "path", tmpdir, "error", err)
 		}
 	}()
 	parentAddr := tmpdir + "/parent.sock"

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -692,12 +692,16 @@ func createTarballForUpload(moduleUploadPath string, stdout io.Writer) (string, 
 }
 
 func readModels(path string, logger logging.Logger) ([]ModuleComponent, error) {
-	parentAddr, err := os.MkdirTemp("", "viam-cli-test-*")
+	tmpdir, err := os.MkdirTemp("", "viam-cli-test-*")
 	if err != nil {
 		return nil, err
 	}
-	defer vutils.UncheckedErrorFunc(func() error { return os.RemoveAll(parentAddr) })
-	parentAddr += "/parent.sock"
+	defer func() {
+		if err := os.RemoveAll(tmpdir); err != nil {
+			logger.Warnw("failed to delete temp directory", "error", err)
+		}
+	}()
+	parentAddr := tmpdir + "/parent.sock"
 
 	// allows a module to start without connecting to a parent
 	if err := os.Setenv("VIAM_NO_MODULE_PARENT", "true"); err != nil {


### PR DESCRIPTION
Remove temp directory (not just contents) after starting a fake module manager as part of the `viam module update-models` command.