### PR TITLE
APP-5082 - Better errors when token expires

### DIFF
--- a/cli/auth.go
+++ b/cli/auth.go
@@ -468,14 +468,14 @@ func (c *viamClient) ensureLoggedIn() error {
 	if ok && authToken.isExpired() {
 		if !authToken.canRefresh() {
 			utils.UncheckedError(c.logout())
-			return errors.New("token expired and cannot refresh")
+			return errors.New("token expired and cannot refresh, logging out. Please log in again.")
 		}
 
 		// expired.
 		newToken, err := c.authFlow.refreshToken(c.c.Context, authToken)
 		if err != nil {
 			utils.UncheckedError(c.logout()) // clear cache if failed to refresh
-			return errors.Wrapf(err, "error while refreshing token")
+			return errors.New("error while refreshing token, logging out. Please log in again.")
 		}
 
 		// write token to config.

--- a/cli/auth.go
+++ b/cli/auth.go
@@ -158,14 +158,14 @@ func (c *viamClient) loginAction(cCtx *cli.Context) error {
 		if err != nil {
 			debugf(c.c.App.Writer, c.c.Bool(debugFlag), "Token refresh error: %v", err)
 			utils.UncheckedError(c.logout()) // clear cache if failed to refresh
-			return errors.New("error while refreshing token, logging out. Please log in again.")
+			return errors.New("error while refreshing token, logging out. Please log in again")
 		}
 	} else {
 		t, err = c.authFlow.loginAsUser(c.c.Context)
 		if err != nil {
 			debugf(c.c.App.Writer, c.c.Bool(debugFlag), "Login error: %v", err)
-			utils.UncheckedError(c.logout()) //clear cache on any error
-			return errors.New("error while logging in. Please try again.")
+
+			return errors.New("error while logging in. Please try again")
 		}
 	}
 
@@ -471,7 +471,7 @@ func (c *viamClient) ensureLoggedIn() error {
 	if ok && authToken.isExpired() {
 		if !authToken.canRefresh() {
 			utils.UncheckedError(c.logout())
-			return errors.New("token expired and cannot refresh, logging out. Please log in again.")
+			return errors.New("token expired and cannot refresh, logging out. Please log in again")
 		}
 
 		// expired.
@@ -479,7 +479,7 @@ func (c *viamClient) ensureLoggedIn() error {
 		if err != nil {
 			debugf(c.c.App.Writer, c.c.Bool(debugFlag), "Token refresh error: %v", err)
 			utils.UncheckedError(c.logout()) // clear cache if failed to refresh
-			return errors.New("error while refreshing token, logging out. Please log in again.")
+			return errors.New("error while refreshing token, logging out. Please log in again")
 		}
 
 		// write token to config.

--- a/cli/auth.go
+++ b/cli/auth.go
@@ -156,12 +156,13 @@ func (c *viamClient) loginAction(cCtx *cli.Context) error {
 	if currentToken != nil && currentToken.canRefresh() {
 		t, err = c.authFlow.refreshToken(c.c.Context, currentToken)
 		if err != nil {
-			utils.UncheckedError(c.logout())
-			return err
+			utils.UncheckedError(c.logout()) // clear cache if failed to refresh
+			return errors.New("error while refreshing token, logging out. Please log in again.")
 		}
 	} else {
 		t, err = c.authFlow.loginAsUser(c.c.Context)
 		if err != nil {
+			utils.UncheckedError(c.logout()) //clear cache on any error
 			return err
 		}
 	}

--- a/cli/auth.go
+++ b/cli/auth.go
@@ -156,14 +156,16 @@ func (c *viamClient) loginAction(cCtx *cli.Context) error {
 	if currentToken != nil && currentToken.canRefresh() {
 		t, err = c.authFlow.refreshToken(c.c.Context, currentToken)
 		if err != nil {
+			debugf(c.c.App.Writer, c.c.Bool(debugFlag), "Token refresh error: %v", err)
 			utils.UncheckedError(c.logout()) // clear cache if failed to refresh
 			return errors.New("error while refreshing token, logging out. Please log in again.")
 		}
 	} else {
 		t, err = c.authFlow.loginAsUser(c.c.Context)
 		if err != nil {
+			debugf(c.c.App.Writer, c.c.Bool(debugFlag), "Login error: %v", err)
 			utils.UncheckedError(c.logout()) //clear cache on any error
-			return err
+			return errors.New("error while logging in. Please try again.")
 		}
 	}
 
@@ -475,6 +477,7 @@ func (c *viamClient) ensureLoggedIn() error {
 		// expired.
 		newToken, err := c.authFlow.refreshToken(c.c.Context, authToken)
 		if err != nil {
+			debugf(c.c.App.Writer, c.c.Bool(debugFlag), "Token refresh error: %v", err)
 			utils.UncheckedError(c.logout()) // clear cache if failed to refresh
 			return errors.New("error while refreshing token, logging out. Please log in again.")
 		}

--- a/cli/client.go
+++ b/cli/client.go
@@ -765,7 +765,7 @@ func newViamClient(c *cli.Context) (*viamClient, error) {
 	conf, err := ConfigFromCache()
 	if err != nil {
 		if !os.IsNotExist(err) {
-			return nil, err
+			return nil, errors.New("Failed to parse cached config. Please log in again.")
 		}
 		conf = &Config{}
 	}

--- a/cli/client.go
+++ b/cli/client.go
@@ -765,6 +765,7 @@ func newViamClient(c *cli.Context) (*viamClient, error) {
 	conf, err := ConfigFromCache()
 	if err != nil {
 		if !os.IsNotExist(err) {
+			debugf(c.App.Writer, c.Bool(debugFlag), "Cached config parse error: %v", err)
 			return nil, errors.New("failed to parse cached config. Please log in again.")
 		}
 		conf = &Config{}

--- a/cli/client.go
+++ b/cli/client.go
@@ -766,7 +766,7 @@ func newViamClient(c *cli.Context) (*viamClient, error) {
 	if err != nil {
 		if !os.IsNotExist(err) {
 			debugf(c.App.Writer, c.Bool(debugFlag), "Cached config parse error: %v", err)
-			return nil, errors.New("failed to parse cached config. Please log in again.")
+			return nil, errors.New("failed to parse cached config. Please log in again")
 		}
 		conf = &Config{}
 	}

--- a/cli/client.go
+++ b/cli/client.go
@@ -765,7 +765,7 @@ func newViamClient(c *cli.Context) (*viamClient, error) {
 	conf, err := ConfigFromCache()
 	if err != nil {
 		if !os.IsNotExist(err) {
-			return nil, errors.New("Failed to parse cached config. Please log in again.")
+			return nil, errors.New("failed to parse cached config. Please log in again.")
 		}
 		conf = &Config{}
 	}


### PR DESCRIPTION
errors are now more like
`Error: Failed to parse cached config. Please log in again.`

If cached config fails to parse for any reason, cache gets removed.
The current logic already logs users out if their token is expired, just made the message clearer

These changes do hide the actual error in a few cases, but I think it'll make the experience more smooth since it's clearer what the next action should be