### PR TITLE
RSDK-8095: rename robot_server loggers to rdk

### DIFF
--- a/config/logging_level.go
+++ b/config/logging_level.go
@@ -27,7 +27,7 @@ var globalLogger struct {
 func InitLoggingSettings(logger logging.Logger, cmdLineDebugFlag bool) {
 	globalLogger.logger = logger
 	globalLogger.cmdLineDebugFlag = cmdLineDebugFlag
-	gologLogger := golog.NewDebugLogger("robot_server.golog")
+	gologLogger := golog.NewDebugLogger("rdk.golog")
 
 	if cmdLineDebugFlag {
 		logging.GlobalLogLevel.SetLevel(zapcore.DebugLevel)
@@ -35,7 +35,7 @@ func InitLoggingSettings(logger logging.Logger, cmdLineDebugFlag bool) {
 	} else {
 		logging.GlobalLogLevel.SetLevel(zapcore.InfoLevel)
 		logger.SetLevel(logging.INFO)
-		gologLogger = golog.NewLogger("robot_server.golog")
+		gologLogger = golog.NewLogger("rdk.golog")
 	}
 
 	golog.ReplaceGloabl(gologLogger)

--- a/web/cmd/directremotecontrol/main.go
+++ b/web/cmd/directremotecontrol/main.go
@@ -53,7 +53,7 @@ type Arguments struct {
 	Port   utils.NetPortFlag `flag:"port,default=8080"`
 }
 
-var logger = logging.NewDebugLogger("robot_server")
+var logger = logging.NewDebugLogger("rdk")
 
 func main() {
 	utils.ContextualMain(mainWithArgs, logger)

--- a/web/cmd/droid/droid.go
+++ b/web/cmd/droid/droid.go
@@ -10,7 +10,6 @@ import (
 	// registers all components.
 	_ "go.viam.com/rdk/components/register"
 	"go.viam.com/rdk/logging"
-
 	// registers all services.
 	_ "go.viam.com/rdk/services/register"
 	"go.viam.com/rdk/web/server"

--- a/web/cmd/droid/droid.go
+++ b/web/cmd/droid/droid.go
@@ -10,12 +10,13 @@ import (
 	// registers all components.
 	_ "go.viam.com/rdk/components/register"
 	"go.viam.com/rdk/logging"
+
 	// registers all services.
 	_ "go.viam.com/rdk/services/register"
 	"go.viam.com/rdk/web/server"
 )
 
-var logger = logging.NewDebugLogger("robot_server")
+var logger = logging.NewDebugLogger("rdk")
 
 // DroidStopHook used by android harness to stop the RDK.
 func DroidStopHook() { //nolint:revive

--- a/web/cmd/server/main.go
+++ b/web/cmd/server/main.go
@@ -8,7 +8,6 @@ import (
 	// registers all components.
 	_ "go.viam.com/rdk/components/register"
 	"go.viam.com/rdk/logging"
-
 	// registers all services.
 	_ "go.viam.com/rdk/services/register"
 	"go.viam.com/rdk/web/server"

--- a/web/cmd/server/main.go
+++ b/web/cmd/server/main.go
@@ -8,12 +8,13 @@ import (
 	// registers all components.
 	_ "go.viam.com/rdk/components/register"
 	"go.viam.com/rdk/logging"
+
 	// registers all services.
 	_ "go.viam.com/rdk/services/register"
 	"go.viam.com/rdk/web/server"
 )
 
-var logger = logging.NewDebugLogger("robot_server")
+var logger = logging.NewDebugLogger("rdk")
 
 func main() {
 	utils.ContextualMain(server.RunServer, logger)

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -77,7 +77,7 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 	// Replace logger with logger based on flags.
 	logger := logging.NewLogger("")
 	logging.ReplaceGlobal(logger)
-	logger = logger.Sublogger("robot_server")
+	logger = logger.Sublogger("rdk")
 	config.InitLoggingSettings(logger, argsParsed.Debug)
 
 	// Always log the version, return early if the '-version' flag was provided


### PR DESCRIPTION
[RSDK-8095](https://viam.atlassian.net/browse/RSDK-8095): rename robot_server loggers to rdk
- Renamed all instances of loggers with name `robot_server` to `rdk`

[RSDK-8095]: https://viam.atlassian.net/browse/RSDK-8095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ