### PR TITLE
[DATA-2728] close datamanger if reconfigure fails and tolerate booting offline

### DIFF
--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -460,7 +460,7 @@ func (svc *builtIn) Reconfigure(
 	deps resource.Dependencies,
 	conf resource.Config,
 ) error {
-	g := utils.NewGuard(func() { svc.internalClose() })
+	g := utils.NewGuard(svc.internalClose)
 	defer g.OnFail()
 	svc.lock.Lock()
 	defer svc.lock.Unlock()

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -402,14 +402,12 @@ func (svc *builtIn) closeSyncer() {
 	}
 }
 
-var grpcConnectionTimeout = 10 * time.Second
+var grpcConnectionTimeout = time.Second
 
 func (svc *builtIn) initSyncer(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, grpcConnectionTimeout)
 	defer cancel()
-	timeoutCtx, timeoutFn := context.WithTimeout(ctx, time.Second)
-	defer timeoutFn()
-	identity, conn, err := svc.cloudConnSvc.AcquireConnection(timeoutCtx)
+	identity, conn, err := svc.cloudConnSvc.AcquireConnection(ctx)
 	if errors.Is(err, cloud.ErrNotCloudManaged) {
 		svc.logger.CDebug(ctx, "Using no-op sync manager when not cloud managed")
 		svc.syncer = datasync.NewNoopManager()

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -627,7 +627,7 @@ func (svc *builtIn) Reconfigure(
 		svc.maxSyncThreads = newMaxSyncThreadValue
 	}
 
-	// if datacapture is enabled, kick off a go routine to check if disk space is filling due to
+	// if datacapture is enabled, kick off a go routine to handle disk space filling due to
 	// cached datacapture files
 	if !svc.captureDisabled {
 		fileDeletionCtx, cancelFunc := context.WithCancel(context.Background())

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -664,10 +664,9 @@ func (svc *builtIn) Reconfigure(
 }
 
 func (svc *builtIn) startSync() {
-	svc.lock.Lock()
-	defer svc.lock.Lock()
 
 	for goutils.SelectContextOrWait(svc.closedCtx, time.Second) {
+		svc.lock.Lock()
 		if svc.syncConfigUpdated {
 			svc.cancelSyncScheduler()
 			if !svc.syncDisabled && svc.syncIntervalMins != 0.0 {
@@ -694,6 +693,7 @@ func (svc *builtIn) startSync() {
 			}
 			svc.syncConfigUpdated = false
 		}
+		svc.lock.Unlock()
 	}
 }
 

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -198,7 +198,7 @@ func NewBuiltIn(
 		return nil, err
 	}
 	svc.backgroundWorkers.Add(1)
-	goutils.ManagedGo(svc.startSync, svc.backgroundWorkers.Done)
+	goutils.ManagedGo(svc.asyncInitDataSync, svc.backgroundWorkers.Done)
 
 	return svc, nil
 }
@@ -643,7 +643,7 @@ func (svc *builtIn) Reconfigure(
 	return nil
 }
 
-func (svc *builtIn) startSync() {
+func (svc *builtIn) asyncInitDataSync() {
 	for goutils.SelectContextOrWait(svc.closedCtx, time.Second) {
 		svc.lock.Lock()
 		if svc.syncConfigUpdated {

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -409,7 +409,6 @@ func (svc *builtIn) closeSyncer() {
 	}
 	if svc.cloudConn != nil {
 		goutils.UncheckedError(svc.cloudConn.Close())
-		svc.cloudConn = nil
 	}
 }
 

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -402,7 +402,7 @@ func (svc *builtIn) closeSyncer() {
 	}
 }
 
-var grpcConnectionTimeout = time.Second
+var grpcConnectionTimeout = 10 * time.Second
 
 func (svc *builtIn) initSyncer(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, grpcConnectionTimeout)
@@ -730,7 +730,7 @@ func (svc *builtIn) uploadData(cancelCtx context.Context, intervalMins float64) 
 }
 
 func isOffline() bool {
-	timeout := time.Second
+	timeout := 5 * time.Second
 	_, err := net.DialTimeout("tcp", "app.viam.com:443", timeout)
 	// If there's an error, the system is likely offline.
 	return err != nil

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -206,6 +206,11 @@ func NewBuiltIn(
 // Close releases all resources managed by data_manager.
 func (svc *builtIn) Close(_ context.Context) error {
 	svc.closedCancelFn()
+	svc.internalClose()
+	return nil
+}
+
+func (svc *builtIn) internalClose() {
 	svc.lock.Lock()
 	svc.closeCollectors()
 	svc.closeSyncer()
@@ -230,8 +235,6 @@ func (svc *builtIn) Close(_ context.Context) error {
 	if capturePollingWorker != nil {
 		capturePollingWorker.Wait()
 	}
-
-	return nil
 }
 
 func (svc *builtIn) closeCollectors() {
@@ -457,7 +460,7 @@ func (svc *builtIn) Reconfigure(
 	deps resource.Dependencies,
 	conf resource.Config,
 ) error {
-	g := utils.NewGuard(func() { goutils.UncheckedError(svc.Close(ctx)) })
+	g := utils.NewGuard(func() { svc.internalClose() })
 	defer g.OnFail()
 	svc.lock.Lock()
 	defer svc.lock.Unlock()

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -753,7 +753,6 @@ func (svc *builtIn) uploadData(cancelCtx context.Context, intervalMins float64) 
 	})
 }
 
-// NOTE: Caller must be holding svc.lock.
 func isOffline() bool {
 	timeout := 5 * time.Second
 	_, err := net.DialTimeout("tcp", "app.viam.com:443", timeout)

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -418,11 +418,7 @@ func (svc *builtIn) initSyncer(ctx context.Context) error {
 
 	client := v1.NewDataSyncServiceClient(conn)
 	svc.filesToSync = make(chan string, svc.maxSyncThreads)
-	syncer, err := svc.syncerConstructor(identity, client, svc.logger, svc.captureDir, svc.maxSyncThreads, svc.filesToSync)
-	if err != nil {
-		return errors.Wrap(err, "failed to initialize new syncer")
-	}
-	svc.syncer = syncer
+	svc.syncer = svc.syncerConstructor(identity, client, svc.logger, svc.captureDir, svc.maxSyncThreads, svc.filesToSync)
 	svc.cloudConn = conn
 	return nil
 }

--- a/services/datamanager/builtin/capture_test.go
+++ b/services/datamanager/builtin/capture_test.go
@@ -139,6 +139,8 @@ func TestDataCaptureEnabled(t *testing.T) {
 				AssociatedAttributes: associations,
 			})
 			test.That(t, err, test.ShouldBeNil)
+			b := dmsvc.(*builtIn)
+			test.That(t, b.propagateDataSyncConfig(), test.ShouldBeNil)
 			passTimeCtx1, cancelPassTime1 := context.WithCancel(context.Background())
 			donePassingTime1 := passTime(passTimeCtx1, mockClock, captureInterval)
 
@@ -172,6 +174,7 @@ func TestDataCaptureEnabled(t *testing.T) {
 				AssociatedAttributes: associations,
 			})
 			test.That(t, err, test.ShouldBeNil)
+			test.That(t, b.propagateDataSyncConfig(), test.ShouldBeNil)
 			oldCaptureDirFiles := getAllFileInfos(initCaptureDir)
 			passTimeCtx2, cancelPassTime2 := context.WithCancel(context.Background())
 			donePassingTime2 := passTime(passTimeCtx2, mockClock, captureInterval)
@@ -218,6 +221,8 @@ func TestSwitchResource(t *testing.T) {
 		AssociatedAttributes: associations,
 	})
 	test.That(t, err, test.ShouldBeNil)
+	b := dmsvc.(*builtIn)
+	test.That(t, b.propagateDataSyncConfig(), test.ShouldBeNil)
 	passTimeCtx1, cancelPassTime1 := context.WithCancel(context.Background())
 	donePassingTime1 := passTime(passTimeCtx1, mockClock, captureInterval)
 
@@ -244,6 +249,7 @@ func TestSwitchResource(t *testing.T) {
 		AssociatedAttributes: associations,
 	})
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, b.propagateDataSyncConfig(), test.ShouldBeNil)
 
 	dataBeforeSwitch, err := getSensorData(captureDir)
 	test.That(t, err, test.ShouldBeNil)

--- a/services/datamanager/builtin/file_deletion_test.go
+++ b/services/datamanager/builtin/file_deletion_test.go
@@ -326,5 +326,7 @@ func newDMSvc(t *testing.T, tempDir string) (internal.DMService, mockDataSyncSer
 		AssociatedAttributes: associations,
 	})
 	test.That(t, err, test.ShouldBeNil)
+	b := dmsvc.(*builtIn)
+	test.That(t, b.propagateDataSyncConfig(), test.ShouldBeNil)
 	return dmsvc, mockClient
 }

--- a/services/datamanager/builtin/file_deletion_test.go
+++ b/services/datamanager/builtin/file_deletion_test.go
@@ -149,9 +149,7 @@ func TestFileDeletion(t *testing.T) {
 			if tc.syncEnabled {
 				filesToSync := make(chan string)
 				defer close(filesToSync)
-				s, err := datasync.NewManager("rick astley", mockClient, logger, tempCaptureDir, datasync.MaxParallelSyncRoutines, filesToSync)
-				test.That(t, err, test.ShouldBeNil)
-				syncer = s
+				syncer = datasync.NewManager("rick astley", mockClient, logger, tempCaptureDir, datasync.MaxParallelSyncRoutines, filesToSync)
 				defer syncer.Close()
 			}
 

--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -926,7 +926,7 @@ func (m *mockStreamingDCClient) CloseSend() error {
 func getTestSyncerConstructorMock(client mockDataSyncServiceClient) datasync.ManagerConstructor {
 	return func(identity string, _ v1.DataSyncServiceClient, logger logging.Logger,
 		viamCaptureDotDir string, maxSyncThreads int, filesToSync chan string,
-	) (datasync.Manager, error) {
+	) datasync.Manager {
 		return datasync.NewManager(identity, client, logger, viamCaptureDotDir, maxSyncThreads, make(chan string))
 	}
 }

--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -565,7 +565,7 @@ func TestStreamingDCUpload(t *testing.T) {
 				AssociatedAttributes: associations,
 			})
 			test.That(t, err, test.ShouldBeNil)
-			b2 := dmsvc.(*builtIn)
+			b2 := newDMSvc.(*builtIn)
 			test.That(t, b2.propagateDataSyncConfig(), test.ShouldBeNil)
 
 			// Call sync.

--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -88,6 +88,8 @@ func TestSyncEnabled(t *testing.T) {
 				AssociatedAttributes: associations,
 			})
 			test.That(t, err, test.ShouldBeNil)
+			b := dmsvc.(*builtIn)
+			test.That(t, b.propagateDataSyncConfig(), test.ShouldBeNil)
 			mockClock.Add(captureInterval)
 			waitForCaptureFilesToExceedNFiles(tmpDir, 0)
 			mockClock.Add(syncInterval)
@@ -117,6 +119,7 @@ func TestSyncEnabled(t *testing.T) {
 				AssociatedAttributes: associations,
 			})
 			test.That(t, err, test.ShouldBeNil)
+			test.That(t, b.propagateDataSyncConfig(), test.ShouldBeNil)
 
 			// Drain any requests that were already sent before Update returned.
 			for len(mockClient.succesfulDCRequests) > 0 {
@@ -235,6 +238,8 @@ func TestDataCaptureUploadIntegration(t *testing.T) {
 				AssociatedAttributes: associations,
 			})
 			test.That(t, err, test.ShouldBeNil)
+			b := dmsvc.(*builtIn)
+			test.That(t, b.propagateDataSyncConfig(), test.ShouldBeNil)
 
 			// Let it capture a bit, then close.
 			for i := 0; i < 20; i++ {
@@ -270,6 +275,8 @@ func TestDataCaptureUploadIntegration(t *testing.T) {
 				AssociatedAttributes: associations,
 			})
 			test.That(t, err, test.ShouldBeNil)
+			b2 := newDMSvc.(*builtIn)
+			test.That(t, b2.propagateDataSyncConfig(), test.ShouldBeNil)
 
 			if tc.failTransiently {
 				// Simulate the backend returning errors some number of times, and validate that the dmsvc is continuing
@@ -397,6 +404,8 @@ func TestArbitraryFileUpload(t *testing.T) {
 				AssociatedAttributes: associations,
 			})
 			test.That(t, err, test.ShouldBeNil)
+			b := dmsvc.(*builtIn)
+			test.That(t, b.propagateDataSyncConfig(), test.ShouldBeNil)
 			// Ensure that we don't wait to sync files.
 			dmsvc.SetFileLastModifiedMillis(0)
 
@@ -525,6 +534,8 @@ func TestStreamingDCUpload(t *testing.T) {
 				AssociatedAttributes: associations,
 			})
 			test.That(t, err, test.ShouldBeNil)
+			b := dmsvc.(*builtIn)
+			test.That(t, b.propagateDataSyncConfig(), test.ShouldBeNil)
 
 			// Capture an image, then close.
 			mockClock.Add(captureInterval)
@@ -554,6 +565,8 @@ func TestStreamingDCUpload(t *testing.T) {
 				AssociatedAttributes: associations,
 			})
 			test.That(t, err, test.ShouldBeNil)
+			b2 := dmsvc.(*builtIn)
+			test.That(t, b2.propagateDataSyncConfig(), test.ShouldBeNil)
 
 			// Call sync.
 			err = newDMSvc.Sync(context.Background(), nil)
@@ -687,8 +700,10 @@ func TestSyncConfigUpdateBehavior(t *testing.T) {
 			})
 			test.That(t, err, test.ShouldBeNil)
 
-			builtInSvc := dmsvc.(*builtIn)
-			initTicker := builtInSvc.syncTicker
+			b := dmsvc.(*builtIn)
+			test.That(t, b.propagateDataSyncConfig(), test.ShouldBeNil)
+
+			initTicker := b.syncTicker
 
 			// Reconfigure the dmsvc with new sync configs
 			cfg.ScheduledSyncDisabled = tc.newSyncDisabled
@@ -701,10 +716,10 @@ func TestSyncConfigUpdateBehavior(t *testing.T) {
 			})
 			test.That(t, err, test.ShouldBeNil)
 
-			newBuildInSvc := dmsvc.(*builtIn)
-			newTicker := newBuildInSvc.syncTicker
-			newSyncer := newBuildInSvc.syncer
-			newFileDeletionBackgroundWorker := newBuildInSvc.fileDeletionBackgroundWorkers
+			test.That(t, b.propagateDataSyncConfig(), test.ShouldBeNil)
+			newTicker := b.syncTicker
+			newSyncer := b.syncer
+			newFileDeletionBackgroundWorker := b.fileDeletionBackgroundWorkers
 
 			if tc.newSyncDisabled {
 				test.That(t, newSyncer, test.ShouldBeNil)
@@ -715,7 +730,7 @@ func TestSyncConfigUpdateBehavior(t *testing.T) {
 				test.That(t, initTicker, test.ShouldNotEqual, newTicker)
 			}
 			if tc.newMaxSyncThreads != 0 {
-				test.That(t, newBuildInSvc.maxSyncThreads, test.ShouldEqual, tc.newMaxSyncThreads)
+				test.That(t, b.maxSyncThreads, test.ShouldEqual, tc.newMaxSyncThreads)
 			}
 		})
 	}

--- a/services/datamanager/datasync/sync.go
+++ b/services/datamanager/datasync/sync.go
@@ -73,12 +73,12 @@ type syncer struct {
 
 // ManagerConstructor is a function for building a Manager.
 type ManagerConstructor func(identity string, client v1.DataSyncServiceClient, logger logging.Logger,
-	captureDir string, maxSyncThreadsConfig int, filesToSync chan string) (Manager, error)
+	captureDir string, maxSyncThreadsConfig int, filesToSync chan string) Manager
 
 // NewManager returns a new syncer.
 func NewManager(identity string, client v1.DataSyncServiceClient, logger logging.Logger,
 	captureDir string, maxSyncThreads int, filesToSync chan string,
-) (Manager, error) {
+) Manager {
 	cancelCtx, cancelFunc := context.WithCancel(context.Background())
 	logger.Infof("Making new syncer with %d max threads", maxSyncThreads)
 	ret := syncer{
@@ -120,7 +120,7 @@ func NewManager(identity string, client v1.DataSyncServiceClient, logger logging
 		}()
 	}
 
-	return &ret, nil
+	return &ret
 }
 
 // Close closes all resources (goroutines) associated with s.


### PR DESCRIPTION
Bandaid fix for: https://viam.atlassian.net/browse/DATA-2728?focusedCommentId=31943

1. Change datamanager to call Close() on itself if Reconfigure returns an error
2. Change datasync to config changes to be processed after Reconfigure so that datamanger can boot successfully if viam-server starts while offline

### Manual Testing:

I tested this with a custom sensor I wrote that records the number of times Readings has been called & the current time when the Readings method was called. This allowed me to confirm that data capture captured data at the configured interval (once a second) and that no sensor readings were dropped.

#### Test Cases

1. Booted a Pi with a viam-server built from this PR with an internet connection & the config below. Collected data for a few minutes. Unplugged pi from internet. Let run for a few minutes. Re connected pi To internet. Let viam-server run for a few more minutes. Stopped viam-server. Ran export command to collect data from when viam-server was running. Confirmed that no readings were missed & data capture captured data every second.
2. Booted a Pi with a viam-server built from this PR WITHOUT an internet connection & the config below. Collected data for a few minutes.  Re connected pi from internet. Let viam-server run for a few more minutes. Unplugged Pi from internet. Let run for a few minutes. Reconnected pi to the internet. Let data flush to teh cloud. Stopped viam-server. Ran export command to collect data from when viam-server was running. Confirmed that no readings were missed & data capture captured data every second.
3. Changed config values while robot is online & confirm config changes propagate


#### manual testing config
```json
{
  "components": [
    {
      "name": "boom",
      "namespace": "rdk",
      "type": "sensor",
      "model": "ncs:sensor:boom",
      "attributes": {},
      "service_configs": [
        {
          "type": "data_manager",
          "attributes": {
            "capture_methods": [
              {
                "method": "Readings",
                "capture_frequency_hz": 1,
                "additional_params": {}
              }
            ]
          }
        }
      ]
    }
  ],
  "services": [
    {
      "name": "data_manager-1",
      "namespace": "rdk",
      "type": "data_manager",
      "attributes": {
        "additional_sync_paths": [],
        "sync_disabled": false,
        "maximum_num_sync_threads": 10,
        "sync_interval_mins": 0.01,
        "capture_dir": "",
        "tags": [
          "nick"
        ]
      }
    }
  ],
  "modules": [
    {
      "type": "local",
      "name": "boomsensor",
      "executable_path": "/home/user/boomsensor"
    }
  ]
}
```
where `boomsensor` is a module produced from: https://github.com/nicksanford/boomsensor 
