### PR TITLE
DATA-2677 - Allow user to create dataset file from exported data for local testing of custom training scripts

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -844,6 +844,12 @@ var app = &cli.App{
 							Usage:    "option to include JSON Lines files for local testing",
 							Value:    false,
 						},
+						&cli.UintFlag{
+							Name:     dataFlagParallelDownloads,
+							Required: false,
+							Usage:    "number of download requests to make in parallel",
+							Value:    100,
+						},
 					},
 					Action: DatasetDownloadAction,
 				},

--- a/cli/app.go
+++ b/cli/app.go
@@ -822,6 +822,31 @@ var app = &cli.App{
 					},
 					Action: DatasetCreateAction,
 				},
+				{
+					Name:  "download",
+					Usage: "download data from a dataset",
+					UsageText: createUsageText("dataset download",
+						[]string{datasetFlagDatasetID, datasetFlagName}, false),
+					Flags: []cli.Flag{
+						&cli.PathFlag{
+							Name:     dataFlagDestination,
+							Required: true,
+							Usage:    "output directory for downloaded data",
+						},
+						&cli.StringFlag{
+							Name:     datasetFlagDatasetID,
+							Required: true,
+							Usage:    "dataset ID of the dataset to be downloaded",
+						},
+						&cli.BoolFlag{
+							Name:     datasetFlagIncludeJSONLines,
+							Required: false,
+							Usage:    "option to include JSON Lines files for local testing",
+							Value:    false,
+						},
+					},
+					Action: DatasetDownloadAction,
+				},
 			},
 		},
 		{

--- a/cli/data.go
+++ b/cli/data.go
@@ -68,7 +68,7 @@ func (c *viamClient) dataExportAction(cCtx *cli.Context) error {
 
 	switch cCtx.String(dataFlagDataType) {
 	case dataTypeBinary:
-		if err := c.binaryData(cCtx.Path(dataFlagDestination), filter, cCtx.Uint(dataFlagParallelDownloads), false); err != nil {
+		if err := c.binaryData(cCtx.Path(dataFlagDestination), filter, cCtx.Uint(dataFlagParallelDownloads)); err != nil {
 			return err
 		}
 	case dataTypeTabular:
@@ -264,7 +264,7 @@ func createDataFilter(c *cli.Context) (*datapb.Filter, error) {
 }
 
 // BinaryData downloads binary data matching filter to dst.
-func (c *viamClient) binaryData(dst string, filter *datapb.Filter, parallelDownloads uint, includeJSONL bool) error {
+func (c *viamClient) binaryData(dst string, filter *datapb.Filter, parallelDownloads uint) error {
 	if err := c.ensureLoggedIn(); err != nil {
 		return err
 	}

--- a/cli/data.go
+++ b/cli/data.go
@@ -68,7 +68,7 @@ func (c *viamClient) dataExportAction(cCtx *cli.Context) error {
 
 	switch cCtx.String(dataFlagDataType) {
 	case dataTypeBinary:
-		if err := c.binaryData(cCtx.Path(dataFlagDestination), filter, cCtx.Uint(dataFlagParallelDownloads)); err != nil {
+		if err := c.binaryData(cCtx.Path(dataFlagDestination), filter, cCtx.Uint(dataFlagParallelDownloads), false); err != nil {
 			return err
 		}
 	case dataTypeTabular:
@@ -264,7 +264,7 @@ func createDataFilter(c *cli.Context) (*datapb.Filter, error) {
 }
 
 // BinaryData downloads binary data matching filter to dst.
-func (c *viamClient) binaryData(dst string, filter *datapb.Filter, parallelDownloads uint) error {
+func (c *viamClient) binaryData(dst string, filter *datapb.Filter, parallelDownloads uint, includeJSONL bool) error {
 	if err := c.ensureLoggedIn(); err != nil {
 		return err
 	}

--- a/cli/dataset.go
+++ b/cli/dataset.go
@@ -19,7 +19,7 @@ const (
 	datasetFlagDatasetIDs       = "dataset-ids"
 	dataFlagLocationID          = "location-id"
 	dataFlagFileIDs             = "file-ids"
-	datasetFlagIncludeJSONLines = "jsonl"
+	datasetFlagIncludeJSONLines = "include-jsonl"
 )
 
 // DatasetCreateAction is the corresponding action for 'dataset create'.


### PR DESCRIPTION
This new CLI commands allows a user to create a dataset file, where the file is formatted in the same way that's expected by the custom training script interface. This will allow a user to locally test parsing a dataset file and ensuring that their model compiles when writing training scripts. 

I manually tested a variety of scenarios and then used the dataset file as input to a training script. I tested with base command
`go run cli/viam/main.go dataset download --destination=test-download --dataset-id=6515b637a420eb685e988e84`
- with include-jsonl set to true, false, and unspecified which downloads the data as well the dataset, just the data, and just the data, respectively
- with parallel downloads set to 50, 100, and unspecified which works as implied 
