### PR TITLE
RSDK-8116 allow node16 in antique

### DIFF
--- a/.github/workflows/staticbuild.yml
+++ b/.github/workflows/staticbuild.yml
@@ -47,6 +47,8 @@ jobs:
     timeout-minutes: 15
     outputs:
       date: ${{ steps.build_date.outputs.date }}
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: 'true'
 
     steps:
     - name: Check out code


### PR DESCRIPTION
## What changed
- set flag to use node16 in antique builds
## Why
actions/checkout suddenly started using node20 which added a GLIBC 2.28 dependency (see https://github.com/actions/checkout/issues/1809).

This is fine for us in most places, but our compatibility build is intentionally on an old linux that has old GLIBC.
## Test run
Here, works:
https://github.com/viamrobotics/rdk/actions/runs/9845816473/job/27182189699
## Follow-ups
At some point node16 will be removed and we'll need to find a new option, probably overwriting the runner's node20 dist on start.