### PR TITLE
RSDK-8087: add utils for updating logger registry

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	Auth            AuthConfig
 	Debug           bool
 	GlobalLogConfig []GlobalLogConfig
+	LogConfig       []LogPatternConfig
 
 	ConfigFilePath string
 
@@ -82,6 +83,7 @@ type configData struct {
 	DisablePartialStart bool                  `json:"disable_partial_start"`
 	EnableWebProfile    bool                  `json:"enable_web_profile"`
 	GlobalLogConfig     []GlobalLogConfig     `json:"global_log_configuration"`
+	LogConfig           []LogPatternConfig    `json:"log"`
 }
 
 // AppValidationStatus refers to the.
@@ -270,6 +272,7 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 	c.DisablePartialStart = conf.DisablePartialStart
 	c.EnableWebProfile = conf.EnableWebProfile
 	c.GlobalLogConfig = conf.GlobalLogConfig
+	c.LogConfig = conf.LogConfig
 
 	return nil
 }
@@ -300,6 +303,7 @@ func (c Config) MarshalJSON() ([]byte, error) {
 		DisablePartialStart: c.DisablePartialStart,
 		EnableWebProfile:    c.EnableWebProfile,
 		GlobalLogConfig:     c.GlobalLogConfig,
+		LogConfig:           c.LogConfig,
 	})
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -38,7 +38,7 @@ type Config struct {
 	Auth            AuthConfig
 	Debug           bool
 	GlobalLogConfig []GlobalLogConfig
-	LogConfig       []LogPatternConfig
+	LogConfig       []LoggerPatternConfig
 
 	ConfigFilePath string
 
@@ -83,7 +83,7 @@ type configData struct {
 	DisablePartialStart bool                  `json:"disable_partial_start"`
 	EnableWebProfile    bool                  `json:"enable_web_profile"`
 	GlobalLogConfig     []GlobalLogConfig     `json:"global_log_configuration"`
-	LogConfig           []LogPatternConfig    `json:"log"`
+	LogConfig           []LoggerPatternConfig `json:"log"`
 }
 
 // AppValidationStatus refers to the.

--- a/config/log_config.go
+++ b/config/log_config.go
@@ -59,16 +59,11 @@ func UpdateLoggerRegistry(logConfig []LoggerPatternConfig, loggerRegistry map[st
 				newLogRegistry[name] = logger
 			}
 			if r.MatchString(name) {
-				switch strings.ToLower(lpc.Level) {
-				case "debug":
-					newLogRegistry[name].SetLevel(logging.DEBUG)
-				case "info":
-					newLogRegistry[name].SetLevel(logging.INFO)
-				case "warn":
-					newLogRegistry[name].SetLevel(logging.WARN)
-				case "error":
-					newLogRegistry[name].SetLevel(logging.ERROR)
+				level, err := logging.LevelFromString(lpc.Level)
+				if err != nil {
+					return nil, err
 				}
+				newLogRegistry[name].SetLevel(level)
 			}
 		}
 	}

--- a/config/log_config.go
+++ b/config/log_config.go
@@ -15,18 +15,17 @@ type LoggerPatternConfig struct {
 	Level   string `json:"level"`
 }
 
-var (
-	validLoggerNameCharPattern = `[a-zA-Z0-9_-]`
-	loggerPatternRegexp        = regexp.MustCompile(`^` + validLoggerNameCharPattern + `+$|^\*$`)
+const (
+	validLoggerSectionName             = `[a-zA-Z0-9]+([_-]*[a-zA-Z0-9]+)*`
+	validLoggerSectionNameWithWildcard = `(` + validLoggerSectionName + `|\*)`
+	validLoggerSections                = validLoggerSectionNameWithWildcard + `(\.` + validLoggerSectionNameWithWildcard + `)*`
+	validLoggerName                    = `^` + validLoggerSections + `$`
 )
 
+var loggerPatternRegexp = regexp.MustCompile(validLoggerName)
+
 func validatePattern(pattern string) bool {
-	for _, sep := range strings.Split(pattern, ".") {
-		if !loggerPatternRegexp.MatchString(sep) {
-			return false
-		}
-	}
-	return true
+	return loggerPatternRegexp.MatchString(pattern)
 }
 
 // UpdateLoggerRegistry updates the logger registry if necessary  with the specified logConfig.
@@ -43,9 +42,9 @@ func UpdateLoggerRegistry(logConfig []LoggerPatternConfig, loggerRegistry map[st
 			switch ch {
 			case '*':
 				if idx == len(lpc.Pattern)-1 {
-					matcher.WriteString(validLoggerNameCharPattern + `+(\.` + validLoggerNameCharPattern + `+)*`)
+					matcher.WriteString(validLoggerSections)
 				} else {
-					matcher.WriteString(validLoggerNameCharPattern + `+`)
+					matcher.WriteString(validLoggerSectionNameWithWildcard)
 				}
 			case '.':
 				matcher.WriteString(`\.`)

--- a/config/log_config.go
+++ b/config/log_config.go
@@ -1,0 +1,77 @@
+package config
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"go.viam.com/rdk/logging"
+)
+
+// LogPatternConfig is an instance of a level specification for a given logger.
+type LogPatternConfig struct {
+	Pattern string `json:"pattern"`
+	Level   string `json:"level"`
+}
+
+func validatePattern(pattern string) bool {
+	size := len(pattern)
+	if size == 0 || pattern[0] == '.' || pattern[size-1] == '.' {
+		return false
+	}
+	for i := 1; i < size; i++ {
+		if pattern[i] == '.' && pattern[i-1] == '.' {
+			return false
+		}
+	}
+	r := regexp.MustCompile(`^[a-z_-]+$|^\*$`)
+	for _, sep := range strings.Split(pattern, ".") {
+		if !r.MatchString(sep) {
+			return false
+		}
+	}
+	return true
+}
+
+// UpdateLoggerRegistry updates the logger registry if necessary  with the specified logConfig.
+func UpdateLoggerRegistry(logConfig []LogPatternConfig, loggerRegistry map[string]logging.Logger) (map[string]logging.Logger, error) {
+	newLogRegistry := make(map[string]logging.Logger)
+
+	for _, lpc := range logConfig {
+		if !validatePattern(lpc.Pattern) {
+			return nil, errors.New("Failed to Validate a Pattern")
+		}
+
+		matcher := "^"
+		for _, ch := range lpc.Pattern {
+			if ch == '*' {
+				matcher += `(\w|\.)+`
+			} else {
+				matcher += string(ch)
+			}
+		}
+		matcher += "$"
+		r := regexp.MustCompile(matcher)
+
+		for name, logger := range loggerRegistry {
+			if _, ok := newLogRegistry[name]; !ok {
+				newLogRegistry[name] = logger
+			}
+			if r.MatchString(name) {
+				switch lowercaseLevel := strings.ToLower(lpc.Level); lowercaseLevel {
+				case "debug":
+					newLogRegistry[name].SetLevel(logging.DEBUG)
+				case "info":
+					newLogRegistry[name].SetLevel(logging.INFO)
+				case "warn":
+					newLogRegistry[name].SetLevel(logging.WARN)
+				case "error":
+					newLogRegistry[name].SetLevel(logging.ERROR)
+				}
+			}
+		}
+	}
+
+	return newLogRegistry, nil
+}

--- a/config/log_config.go
+++ b/config/log_config.go
@@ -15,7 +15,10 @@ type LoggerPatternConfig struct {
 	Level   string `json:"level"`
 }
 
-var loggerPatternRegexp = regexp.MustCompile(`^[a-z_-]+$|^\*$`)
+var (
+	validLoggerNameCharPattern = `[a-zA-Z0-9_-]`
+	loggerPatternRegexp        = regexp.MustCompile(`^` + validLoggerNameCharPattern + `+$|^\*$`)
+)
 
 func validatePattern(pattern string) bool {
 	for _, sep := range strings.Split(pattern, ".") {
@@ -40,9 +43,9 @@ func UpdateLoggerRegistry(logConfig []LoggerPatternConfig, loggerRegistry map[st
 			switch ch {
 			case '*':
 				if idx == len(lpc.Pattern)-1 {
-					matcher.WriteString(`\w+(\.\w+)*`)
+					matcher.WriteString(validLoggerNameCharPattern + `+(\.` + validLoggerNameCharPattern + `+)*`)
 				} else {
-					matcher.WriteString(`\w+`)
+					matcher.WriteString(validLoggerNameCharPattern + `+`)
 				}
 			case '.':
 				matcher.WriteString(`\.`)

--- a/config/log_config.go
+++ b/config/log_config.go
@@ -40,7 +40,7 @@ func UpdateLoggerRegistry(logConfig []LoggerPatternConfig, loggerRegistry map[st
 			switch ch {
 			case '*':
 				if idx == len(lpc.Pattern)-1 {
-					matcher.WriteString(`(\w|\.)+`)
+					matcher.WriteString(`\w+(\.\w+)*`)
 				} else {
 					matcher.WriteString(`\w+`)
 				}

--- a/config/log_config_test.go
+++ b/config/log_config_test.go
@@ -89,7 +89,6 @@ func TestUpdateLoggerRegistry(t *testing.T) {
 		test.That(t, ok, test.ShouldBeTrue)
 		test.That(t, logger.GetLevel(), test.ShouldEqual, logging.ERROR)
 		logger.SetLevel(logging.INFO)
-
 	})
 
 	t.Run("overwrite existing registry entries", func(t *testing.T) {

--- a/config/log_config_test.go
+++ b/config/log_config_test.go
@@ -1,0 +1,82 @@
+package config
+
+import (
+	"testing"
+
+	"go.viam.com/rdk/logging"
+	"go.viam.com/test"
+)
+
+func TestValidatePattern(t *testing.T) {
+	test.That(t, validatePattern("robot_server.resource_manager"), test.ShouldBeTrue)
+	test.That(t, validatePattern("robot_server.resource_manager.*"), test.ShouldBeTrue)
+	test.That(t, validatePattern("robot_server.*.resource_manager"), test.ShouldBeTrue)
+	test.That(t, validatePattern("robot_server.*.*"), test.ShouldBeTrue)
+	test.That(t, validatePattern("*.resource_manager"), test.ShouldBeTrue)
+	test.That(t, validatePattern("*"), test.ShouldBeTrue)
+
+	test.That(t, validatePattern("robot_server..resource_manager"), test.ShouldBeFalse)
+	test.That(t, validatePattern("robot_server.resource_manager."), test.ShouldBeFalse)
+	test.That(t, validatePattern(".robot_server.resource_manager"), test.ShouldBeFalse)
+	test.That(t, validatePattern("robot_server.resource_manager.**"), test.ShouldBeFalse)
+	test.That(t, validatePattern("robot_server.**.resource_manager"), test.ShouldBeFalse)
+}
+
+func TestUpdateLoggerRegistry(t *testing.T) {
+	testRegistry := map[string]logging.Logger{
+		"rdk.resource_manager":            logging.NewLogger("rdk.resource_manager"),
+		"rdk.resource_manager.modmanager": logging.NewLogger("rdk.resource_manager.modmanager"),
+		"rdk.network_traffic":             logging.NewLogger("rdk.network_traffic"),
+	}
+	t.Run("basic case", func(t *testing.T) {
+		logCfg := []LogPatternConfig{
+			{
+				Pattern: "rdk.resource_manager",
+				Level:   "WARN",
+			},
+		}
+		newRegistry, err := UpdateLoggerRegistry(logCfg, testRegistry)
+		test.That(t, err, test.ShouldBeNil)
+
+		logger, ok := newRegistry["rdk.resource_manager"]
+		test.That(t, ok, test.ShouldBeTrue)
+		test.That(t, logger.GetLevel(), test.ShouldEqual, logging.WARN)
+
+		testRegistry["rdk.resource_manager"].SetLevel(logging.INFO)
+	})
+
+	t.Run("wildcard case", func(t *testing.T) {
+		logCfg := []LogPatternConfig{
+			{
+				Pattern: "rdk.*",
+				Level:   "DEBUG",
+			},
+		}
+		newRegistry, err := UpdateLoggerRegistry(logCfg, testRegistry)
+		test.That(t, err, test.ShouldBeNil)
+
+		for name, logger := range newRegistry {
+			test.That(t, logger.GetLevel(), test.ShouldEqual, logging.DEBUG)
+			newRegistry[name].SetLevel(logging.INFO)
+		}
+	})
+
+	t.Run("overwrite existing registry entries", func(t *testing.T) {
+		logCfg := []LogPatternConfig{
+			{
+				Pattern: "rdk.*",
+				Level:   "DEBUG",
+			},
+			{
+				Pattern: "rdk.resource_manager",
+				Level:   "WARN",
+			},
+		}
+		newRegistry, err := UpdateLoggerRegistry(logCfg, testRegistry)
+		test.That(t, err, test.ShouldBeNil)
+
+		logger, ok := newRegistry["rdk.resource_manager"]
+		test.That(t, ok, test.ShouldBeTrue)
+		test.That(t, logger.GetLevel(), test.ShouldEqual, logging.WARN)
+	})
+}

--- a/config/log_config_test.go
+++ b/config/log_config_test.go
@@ -15,9 +15,17 @@ func verifySetLevels(registry map[string]logging.Logger, expectedMatches map[str
 		if !ok || !strings.EqualFold(level, logger.GetLevel().String()) {
 			return false
 		}
-		registry[name].SetLevel(logging.INFO)
 	}
 	return true
+}
+
+func createTestRegistry(loggerNames ...string) map[string]logging.Logger {
+	registry := make(map[string]logging.Logger)
+	for _, name := range loggerNames {
+		registry[name] = logging.NewLogger(name)
+
+	}
+	return registry
 }
 
 func TestValidatePattern(t *testing.T) {
@@ -43,14 +51,8 @@ func TestValidatePattern(t *testing.T) {
 }
 
 func TestUpdateLoggerRegistry(t *testing.T) {
-	testRegistry := map[string]logging.Logger{
-		"rdk.resource_manager":                            logging.NewLogger("rdk.resource_manager"),
-		"rdk.resource_manager.modmanager":                 logging.NewLogger("rdk.resource_manager.modmanager"),
-		"rdk.network_traffic":                             logging.NewLogger("rdk.network_traffic"),
-		"rdk.test_manager.modmanager":                     logging.NewLogger("rdk.test_manager.modmanager"),
-		"rdk.resource_manager.package_manager.modmanager": logging.NewLogger("rdk.resource_manager.package_manager.modmanager"),
-	}
 	t.Run("basic case", func(t *testing.T) {
+		testRegistry := createTestRegistry("rdk.resource_manager", "rdk.resource_manager.modmanager", "rdk.network_traffic")
 		logCfg := []LoggerPatternConfig{
 			{
 				Pattern: "rdk.resource_manager",
@@ -67,6 +69,7 @@ func TestUpdateLoggerRegistry(t *testing.T) {
 	})
 
 	t.Run("ending wildcard case", func(t *testing.T) {
+		testRegistry := createTestRegistry("rdk.resource_manager", "rdk.test_manager.modmanager", "rdk.resource_manager.package_manager.modmanager")
 		logCfg := []LoggerPatternConfig{
 			{
 				Pattern: "rdk.*",
@@ -75,8 +78,6 @@ func TestUpdateLoggerRegistry(t *testing.T) {
 		}
 		expectedMatches := map[string]string{
 			"rdk.resource_manager":                            "DEBUG",
-			"rdk.resource_manager.modmanager":                 "DEBUG",
-			"rdk.network_traffic":                             "DEBUG",
 			"rdk.test_manager.modmanager":                     "DEBUG",
 			"rdk.resource_manager.package_manager.modmanager": "DEBUG",
 		}
@@ -87,6 +88,7 @@ func TestUpdateLoggerRegistry(t *testing.T) {
 	})
 
 	t.Run("middle wildcard case", func(t *testing.T) {
+		testRegistry := createTestRegistry("rdk.resource_manager.modmanager", "rdk.test_manager.modmanager", "rdk.resource_manager.test_manager")
 		logCfg := []LoggerPatternConfig{
 			{
 				Pattern: "rdk.*.modmanager",
@@ -104,6 +106,7 @@ func TestUpdateLoggerRegistry(t *testing.T) {
 	})
 
 	t.Run("overwrite existing registry entries", func(t *testing.T) {
+		testRegistry := createTestRegistry("rdk.resource_manager")
 		logCfg := []LoggerPatternConfig{
 			{
 				Pattern: "rdk.*",
@@ -124,6 +127,7 @@ func TestUpdateLoggerRegistry(t *testing.T) {
 	})
 
 	t.Run("greedy wildcard matching case", func(t *testing.T) {
+		testRegistry := createTestRegistry("rdk.resource_manager.modmanager", "rdk.resource_manager.package_manager.modmanager")
 		logCfg := []LoggerPatternConfig{
 			{
 				Pattern: "rdk.*.modmanager",
@@ -141,6 +145,7 @@ func TestUpdateLoggerRegistry(t *testing.T) {
 	})
 
 	t.Run("error case", func(t *testing.T) {
+		testRegistry := createTestRegistry("rdk.resource_manager")
 		logCfg := []LoggerPatternConfig{
 			{
 				Pattern: "_.*.modmanager",

--- a/config/log_config_test.go
+++ b/config/log_config_test.go
@@ -21,6 +21,13 @@ func TestValidatePattern(t *testing.T) {
 	test.That(t, validatePattern(".robot_server.resource_manager"), test.ShouldBeFalse)
 	test.That(t, validatePattern("robot_server.resource_manager.**"), test.ShouldBeFalse)
 	test.That(t, validatePattern("robot_server.**.resource_manager"), test.ShouldBeFalse)
+
+	test.That(t, validatePattern("_.robot_server.resource_manager"), test.ShouldBeFalse)
+	test.That(t, validatePattern("-.robot_server"), test.ShouldBeFalse)
+	test.That(t, validatePattern("robot_server.-"), test.ShouldBeFalse)
+	test.That(t, validatePattern("robot_server.-"), test.ShouldBeFalse)
+	test.That(t, validatePattern("robot_server.-.resource_manager"), test.ShouldBeFalse)
+	test.That(t, validatePattern("robot_server._.resource_manager"), test.ShouldBeFalse)
 }
 
 func TestUpdateLoggerRegistry(t *testing.T) {

--- a/config/log_config_test.go
+++ b/config/log_config_test.go
@@ -30,7 +30,7 @@ func TestUpdateLoggerRegistry(t *testing.T) {
 		"rdk.network_traffic":             logging.NewLogger("rdk.network_traffic"),
 	}
 	t.Run("basic case", func(t *testing.T) {
-		logCfg := []LogPatternConfig{
+		logCfg := []LoggerPatternConfig{
 			{
 				Pattern: "rdk.resource_manager",
 				Level:   "WARN",
@@ -47,7 +47,7 @@ func TestUpdateLoggerRegistry(t *testing.T) {
 	})
 
 	t.Run("wildcard case", func(t *testing.T) {
-		logCfg := []LogPatternConfig{
+		logCfg := []LoggerPatternConfig{
 			{
 				Pattern: "rdk.*",
 				Level:   "DEBUG",
@@ -63,7 +63,7 @@ func TestUpdateLoggerRegistry(t *testing.T) {
 	})
 
 	t.Run("overwrite existing registry entries", func(t *testing.T) {
-		logCfg := []LogPatternConfig{
+		logCfg := []LoggerPatternConfig{
 			{
 				Pattern: "rdk.*",
 				Level:   "DEBUG",

--- a/config/log_config_test.go
+++ b/config/log_config_test.go
@@ -23,7 +23,6 @@ func createTestRegistry(loggerNames ...string) map[string]logging.Logger {
 	registry := make(map[string]logging.Logger)
 	for _, name := range loggerNames {
 		registry[name] = logging.NewLogger(name)
-
 	}
 	return registry
 }
@@ -69,7 +68,7 @@ func TestUpdateLoggerRegistry(t *testing.T) {
 	})
 
 	t.Run("ending wildcard case", func(t *testing.T) {
-		testRegistry := createTestRegistry("rdk.resource_manager", "rdk.test_manager.modmanager", "rdk.resource_manager.package_manager.modmanager")
+		testRegistry := createTestRegistry("rdk.resource_manager", "rdk.test_manager.modmanager", "rdk.resource_manager.package.modmanager")
 		logCfg := []LoggerPatternConfig{
 			{
 				Pattern: "rdk.*",
@@ -77,9 +76,9 @@ func TestUpdateLoggerRegistry(t *testing.T) {
 			},
 		}
 		expectedMatches := map[string]string{
-			"rdk.resource_manager":                            "DEBUG",
-			"rdk.test_manager.modmanager":                     "DEBUG",
-			"rdk.resource_manager.package_manager.modmanager": "DEBUG",
+			"rdk.resource_manager":                    "DEBUG",
+			"rdk.test_manager.modmanager":             "DEBUG",
+			"rdk.resource_manager.package.modmanager": "DEBUG",
 		}
 		newRegistry, err := UpdateLoggerRegistry(logCfg, testRegistry)
 		test.That(t, err, test.ShouldBeNil)

--- a/config/log_config_test.go
+++ b/config/log_config_test.go
@@ -1,12 +1,24 @@
 package config
 
 import (
+	"strings"
 	"testing"
 
 	"go.viam.com/test"
 
 	"go.viam.com/rdk/logging"
 )
+
+func verifySetLevels(registry map[string]logging.Logger, expectedMatches map[string]string) bool {
+	for name, level := range expectedMatches {
+		logger, ok := registry[name]
+		if !ok || !strings.EqualFold(level, logger.GetLevel().String()) {
+			return false
+		}
+		registry[name].SetLevel(logging.INFO)
+	}
+	return true
+}
 
 func TestValidatePattern(t *testing.T) {
 	test.That(t, validatePattern("robot_server.resource_manager"), test.ShouldBeTrue)
@@ -32,10 +44,11 @@ func TestValidatePattern(t *testing.T) {
 
 func TestUpdateLoggerRegistry(t *testing.T) {
 	testRegistry := map[string]logging.Logger{
-		"rdk.resource_manager":            logging.NewLogger("rdk.resource_manager"),
-		"rdk.resource_manager.modmanager": logging.NewLogger("rdk.resource_manager.modmanager"),
-		"rdk.network_traffic":             logging.NewLogger("rdk.network_traffic"),
-		"rdk.test_manager.modmanager":     logging.NewLogger("rdk.test_manager.modmanager"),
+		"rdk.resource_manager":                            logging.NewLogger("rdk.resource_manager"),
+		"rdk.resource_manager.modmanager":                 logging.NewLogger("rdk.resource_manager.modmanager"),
+		"rdk.network_traffic":                             logging.NewLogger("rdk.network_traffic"),
+		"rdk.test_manager.modmanager":                     logging.NewLogger("rdk.test_manager.modmanager"),
+		"rdk.resource_manager.package_manager.modmanager": logging.NewLogger("rdk.resource_manager.package_manager.modmanager"),
 	}
 	t.Run("basic case", func(t *testing.T) {
 		logCfg := []LoggerPatternConfig{
@@ -44,14 +57,13 @@ func TestUpdateLoggerRegistry(t *testing.T) {
 				Level:   "WARN",
 			},
 		}
+		expectedMatches := map[string]string{
+			"rdk.resource_manager": "WARN",
+		}
 		newRegistry, err := UpdateLoggerRegistry(logCfg, testRegistry)
 		test.That(t, err, test.ShouldBeNil)
 
-		logger, ok := newRegistry["rdk.resource_manager"]
-		test.That(t, ok, test.ShouldBeTrue)
-		test.That(t, logger.GetLevel(), test.ShouldEqual, logging.WARN)
-
-		testRegistry["rdk.resource_manager"].SetLevel(logging.INFO)
+		test.That(t, verifySetLevels(newRegistry, expectedMatches), test.ShouldBeTrue)
 	})
 
 	t.Run("ending wildcard case", func(t *testing.T) {
@@ -61,13 +73,17 @@ func TestUpdateLoggerRegistry(t *testing.T) {
 				Level:   "DEBUG",
 			},
 		}
+		expectedMatches := map[string]string{
+			"rdk.resource_manager":                            "DEBUG",
+			"rdk.resource_manager.modmanager":                 "DEBUG",
+			"rdk.network_traffic":                             "DEBUG",
+			"rdk.test_manager.modmanager":                     "DEBUG",
+			"rdk.resource_manager.package_manager.modmanager": "DEBUG",
+		}
 		newRegistry, err := UpdateLoggerRegistry(logCfg, testRegistry)
 		test.That(t, err, test.ShouldBeNil)
 
-		for name, logger := range newRegistry {
-			test.That(t, logger.GetLevel(), test.ShouldEqual, logging.DEBUG)
-			newRegistry[name].SetLevel(logging.INFO)
-		}
+		test.That(t, verifySetLevels(newRegistry, expectedMatches), test.ShouldBeTrue)
 	})
 
 	t.Run("middle wildcard case", func(t *testing.T) {
@@ -77,18 +93,14 @@ func TestUpdateLoggerRegistry(t *testing.T) {
 				Level:   "ERROR",
 			},
 		}
+		expectedMatches := map[string]string{
+			"rdk.resource_manager.modmanager": "ERROR",
+			"rdk.test_manager.modmanager":     "ERROR",
+		}
 		newRegistry, err := UpdateLoggerRegistry(logCfg, testRegistry)
 		test.That(t, err, test.ShouldBeNil)
 
-		logger, ok := newRegistry["rdk.resource_manager.modmanager"]
-		test.That(t, ok, test.ShouldBeTrue)
-		test.That(t, logger.GetLevel(), test.ShouldEqual, logging.ERROR)
-		logger.SetLevel(logging.INFO)
-
-		logger, ok = newRegistry["rdk.test_manager.modmanager"]
-		test.That(t, ok, test.ShouldBeTrue)
-		test.That(t, logger.GetLevel(), test.ShouldEqual, logging.ERROR)
-		logger.SetLevel(logging.INFO)
+		test.That(t, verifySetLevels(newRegistry, expectedMatches), test.ShouldBeTrue)
 	})
 
 	t.Run("overwrite existing registry entries", func(t *testing.T) {
@@ -102,12 +114,30 @@ func TestUpdateLoggerRegistry(t *testing.T) {
 				Level:   "WARN",
 			},
 		}
+		expectedMatches := map[string]string{
+			"rdk.resource_manager": "WARN",
+		}
 		newRegistry, err := UpdateLoggerRegistry(logCfg, testRegistry)
 		test.That(t, err, test.ShouldBeNil)
 
-		logger, ok := newRegistry["rdk.resource_manager"]
-		test.That(t, ok, test.ShouldBeTrue)
-		test.That(t, logger.GetLevel(), test.ShouldEqual, logging.WARN)
+		test.That(t, verifySetLevels(newRegistry, expectedMatches), test.ShouldBeTrue)
+	})
+
+	t.Run("greedy wildcard matching case", func(t *testing.T) {
+		logCfg := []LoggerPatternConfig{
+			{
+				Pattern: "rdk.*.modmanager",
+				Level:   "WARN",
+			},
+		}
+		expectedMatches := map[string]string{
+			"rdk.resource_manager.modmanager":                 "WARN",
+			"rdk.resource_manager.package_manager.modmanager": "WARN",
+		}
+		newRegistry, err := UpdateLoggerRegistry(logCfg, testRegistry)
+		test.That(t, err, test.ShouldBeNil)
+
+		test.That(t, verifySetLevels(newRegistry, expectedMatches), test.ShouldBeTrue)
 	})
 
 	t.Run("error case", func(t *testing.T) {

--- a/config/log_config_test.go
+++ b/config/log_config_test.go
@@ -3,8 +3,9 @@ package config
 import (
 	"testing"
 
-	"go.viam.com/rdk/logging"
 	"go.viam.com/test"
+
+	"go.viam.com/rdk/logging"
 )
 
 func TestValidatePattern(t *testing.T) {


### PR DESCRIPTION
[RSDK-8087](https://viam.atlassian.net/browse/RSDK-8087): add utils for updating logger registry

### Changes

`log_config.go`: 

- Stores the type for LogPatternConfig
- UpdateLoggerRegistry function, that returns a new registry map with any updates after reading in the new log config.

`log_config_test.go`:

- test valid pattern match strings
- test registry updates are as we expect

`config.go`:
- added LogPatternConfig as a field to each config struct

Note: Did not take into account the log configuration for resources, and did not use these utils meaningfully yet. Will do so in a subsequent PR.

[RSDK-8087]: https://viam.atlassian.net/browse/RSDK-8087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ