### PR TITLE
Use correct GH Actions Input Syntax for Networking Tests Trigger Job

### DIFF
--- a/.github/workflows/trigger-networking-tests.yml
+++ b/.github/workflows/trigger-networking-tests.yml
@@ -39,7 +39,7 @@ jobs:
             -d '{
               "event_type": "new_rc_branch",
               "client_payload": {
-                "version": "${{ github.event.inputs.version }}",
-                "rc_number": "${{ github.event.inputs.rc_number }}"
+                "version": "${{ inputs.version }}",
+                "rc_number": "${{ inputs.rc_number }}"
               }
             }'


### PR DESCRIPTION
### Description
* In the job run, you can observe that the RC version parameters were accepted just fine, but the variables `github.event.inputs.version` and `github.event.inputs.rc_number` did not populate correctly. 
* Since inputs were explicitly defined at the header of the workflow, they should be accessed using `inputs.<variable-name>` to be interpolated properly. https://github.blog/changelog/2022-06-10-github-actions-inputs-unified-across-manual-and-reusable-workflows/