### PR TITLE
RDSK-8056

### DIFF
--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -409,10 +409,8 @@ func TestArbitraryFileUpload(t *testing.T) {
 
 			// Write file to the path.
 			var fileContents []byte
-			for i := 0; i < 1000; i++ {
-				if tc.name != emptyFileTestName {
-					fileContents = append(fileContents, []byte("happy cows come from california\n")...)
-				}
+			if tc.name != emptyFileTestName {
+				fileContents = populateFileContents(fileContents)
 			}
 			tmpFile, err := os.Create(filepath.Join(additionalPathsDir, fileName))
 			test.That(t, err, test.ShouldBeNil)
@@ -952,4 +950,12 @@ func waitUntilNoFiles(dir string) {
 		time.Sleep(waitPerCheck)
 		files = getAllFileInfos(dir)
 	}
+}
+
+func populateFileContents(fileContents []byte) []byte {
+	for i := 0; i < 1000; i++ {
+		fileContents = append(fileContents, []byte("happy cows come from california\n")...)
+	}
+
+	return fileContents
 }

--- a/services/datamanager/builtin/sync_test.go
+++ b/services/datamanager/builtin/sync_test.go
@@ -332,6 +332,7 @@ func TestArbitraryFileUpload(t *testing.T) {
 	datasync.RetryExponentialFactor.Store(int32(1))
 	fileName := "some_file_name.txt"
 	fileExt := ".txt"
+	emptyFileTestName := "error due to empty file, local files should not be deleted"
 	// Disable the check to see if the file was modified recently,
 	// since we are testing instanteous arbitrary file uploads.
 	datasync.SetFileLastModifiedMillis(0)
@@ -358,6 +359,12 @@ func TestArbitraryFileUpload(t *testing.T) {
 		},
 		{
 			name:                 "if an error response is received from the backend, local files should not be deleted",
+			manualSync:           false,
+			scheduleSyncDisabled: false,
+			serviceFail:          true,
+		},
+		{
+			name:                 emptyFileTestName,
 			manualSync:           false,
 			scheduleSyncDisabled: false,
 			serviceFail:          true,
@@ -403,7 +410,9 @@ func TestArbitraryFileUpload(t *testing.T) {
 			// Write file to the path.
 			var fileContents []byte
 			for i := 0; i < 1000; i++ {
-				fileContents = append(fileContents, []byte("happy cows come from california\n")...)
+				if tc.name != emptyFileTestName {
+					fileContents = append(fileContents, []byte("happy cows come from california\n")...)
+				}
 			}
 			tmpFile, err := os.Create(filepath.Join(additionalPathsDir, fileName))
 			test.That(t, err, test.ShouldBeNil)

--- a/services/datamanager/datasync/upload_arbitrary_file.go
+++ b/services/datamanager/datasync/upload_arbitrary_file.go
@@ -44,6 +44,9 @@ func uploadArbitraryFile(ctx context.Context, client v1.DataSyncServiceClient, f
 	if err != nil {
 		return err
 	}
+	if info.Size() == 0 {
+		return errors.New("file is empty (0 bytes)")
+	}
 	timeSinceMod := clock.Since(info.ModTime())
 	if timeSinceMod < time.Duration(fileLastModifiedMillis)*time.Millisecond {
 		return errors.New("file modified too recently")


### PR DESCRIPTION
**_Jira_**: [https://viam.atlassian.net/browse/RSDK-8056](https://viam.atlassian.net/browse/RSDK-8056)

**_Changes Made_**: The purpose of this change is to ensure that no files of size 0 bytes are uploaded. Instead, an error is thrown. Binary and tabular data are uploaded via `upload_data_capture_file.go` in which there is a pre-existing check ensuring that only files with `len(sensorData) > 0` are uploaded and synced. However, this check did not exist within `upload_arbitrary_file.go`, allowing users to upload empty files. Thus, this change covers that edge case. 

**_Testing_**:  I have conducted manual testing by attempting to sync a file of 0 bytes and ensuring the proper error messages are logged and that the file is not synced or deleted from the local disk. I have also added a unit test to ensure an empty file returns an error. 