### PR TITLE
[RSDK-5768][RSDK-8035] enable gpsrtk with pmtk to use vrs and write correction data to the gps when using vrs

### DIFF
--- a/components/movementsensor/gpsrtk/gpsrtk.go
+++ b/components/movementsensor/gpsrtk/gpsrtk.go
@@ -56,7 +56,7 @@ type gpsrtk struct {
 	// everything below this comment is protected by mu
 	ntripClient      *gpsutils.NtripInfo
 	cachedData       *gpsutils.CachedData
-	correctionWriter io.ReadWriteCloser
+	correctionWriter io.WriteCloser
 	writePath        string
 	wbaud            int
 	isVirtualBase    bool

--- a/components/movementsensor/gpsrtk/gpsrtk.go
+++ b/components/movementsensor/gpsrtk/gpsrtk.go
@@ -63,7 +63,7 @@ type gpsrtk struct {
 	vrsReaderWriter  *bufio.ReadWriter // readerWriter that is connected to the VRS corrections stream
 	writer           io.Writer         // writer that takes correction data and sends it to the gps
 	// reader is the TeeReader to write the corrections stream to the gps chip.
-	// We also use it to scan RTCM messages to ensure there are no errors from the streams
+	// Additionally used to scan RTCM messages to ensure there are no errors from the streams
 	reader io.Reader
 }
 

--- a/components/movementsensor/gpsrtk/gpsrtk.go
+++ b/components/movementsensor/gpsrtk/gpsrtk.go
@@ -83,6 +83,13 @@ func (g *gpsrtk) getStreamFromMountPoint(mountPoint string, maxAttempts int) err
 	success := false
 	attempts := 0
 
+	// setting the Timeout to 0 on the http client to prevent the ntrip stream from canceling itself.
+	// ntrip.NewClient() defaults sets this value to 15 seconds, which causes us to disconnect
+	// the ntrip stream and require a reconnection.
+	// Setting the Timeout on the http client to be 0 removes the timeout. It's possible we want to have different
+	// Additionally, this should be tested with other CORS.
+	g.ntripClient.Client.Timeout = 0
+
 	var rc io.ReadCloser
 	var err error
 

--- a/components/movementsensor/gpsrtk/gpsrtk.go
+++ b/components/movementsensor/gpsrtk/gpsrtk.go
@@ -238,7 +238,7 @@ func (g *gpsrtk) receiveAndWriteCorrectionData() {
 		}
 
 		// added a log so we do not always swallow the error
-		g.logger.Debug(err)
+		g.logger.Debugf("no longer connected to NTRIP scanner: %s", err)
 
 		if g.isClosed {
 			return
@@ -479,9 +479,9 @@ func (g *gpsrtk) getNtripFromVRS() error {
 		return err
 	}
 
-	g.logger.Debugf("Writing GGA message: %v\n", (ggaMessage))
+	g.logger.Debugf("Writing GGA message: %v\n", ggaMessage)
 
-	_, err = g.readerWriter.WriteString((ggaMessage))
+	_, err = g.readerWriter.WriteString(ggaMessage)
 	if err != nil {
 		g.logger.Error("Failed to send NMEA data:", err)
 		return err

--- a/components/movementsensor/gpsrtk/gpsrtk.go
+++ b/components/movementsensor/gpsrtk/gpsrtk.go
@@ -480,15 +480,16 @@ func (g *gpsrtk) getNtripFromVRS() error {
 		}
 	}
 
-	ggaMessage, err := gpsutils.GetGGAMessage(g.correctionWriter, g.logger)
+	// get the GGA message from cached data
+	ggaMessage, err := g.cachedData.GGA()
 	if err != nil {
 		g.logger.Error("Failed to get GGA message")
 		return err
 	}
 
-	g.logger.Debugf("Writing GGA message: %v\n", string(ggaMessage))
+	g.logger.Debugf("Writing GGA message: %v\n", (ggaMessage))
 
-	_, err = g.readerWriter.WriteString(string(ggaMessage))
+	_, err = g.readerWriter.WriteString((ggaMessage))
 	if err != nil {
 		g.logger.Error("Failed to send NMEA data:", err)
 		return err

--- a/components/movementsensor/gpsrtk/gpsrtk.go
+++ b/components/movementsensor/gpsrtk/gpsrtk.go
@@ -211,7 +211,6 @@ func (g *gpsrtk) getStream() (io.Reader, error) {
 		return nil, err
 	}
 	return io.TeeReader(g.ntripClient.Stream, g.writer), nil
-
 }
 
 // receiveAndWriteCorrectionData connects to the NTRIP receiver and sends the correction stream to
@@ -442,7 +441,6 @@ func (g *gpsrtk) getNtripFromVRS() error {
 	defer g.mu.Unlock()
 	var err error
 	g.readerWriter, err = gpsutils.ConnectToVirtualBase(g.ntripClient, g.logger)
-
 	if err != nil {
 		return err
 	}

--- a/components/movementsensor/gpsrtk/gpsrtk.go
+++ b/components/movementsensor/gpsrtk/gpsrtk.go
@@ -249,7 +249,7 @@ func (g *gpsrtk) receiveAndWriteCorrectionData() {
 		// added a log so we do not always swallow the error
 		g.logger.Debugf("no longer connected to NTRIP scanner: %s", err)
 
-		if g.isClosed {
+		if g.isClosed || g.cancelCtx.Err() != nil {
 			return
 		}
 

--- a/components/movementsensor/gpsrtk/gpsrtk.go
+++ b/components/movementsensor/gpsrtk/gpsrtk.go
@@ -422,7 +422,6 @@ func (g *gpsrtk) Close(ctx context.Context) error {
 			g.mu.Unlock()
 			return err
 		}
-
 	}
 
 	if g.ntripClient.Stream != nil {

--- a/components/movementsensor/gpsrtk/pmtk.go
+++ b/components/movementsensor/gpsrtk/pmtk.go
@@ -9,6 +9,7 @@ import (
 	"io"
 
 	"go.uber.org/multierr"
+
 	"go.viam.com/rdk/components/board/genericlinux/buses"
 	"go.viam.com/rdk/components/movementsensor"
 	"go.viam.com/rdk/components/movementsensor/gpsutils"

--- a/components/movementsensor/gpsrtk/pmtk.go
+++ b/components/movementsensor/gpsrtk/pmtk.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 
+	"go.uber.org/multierr"
 	"go.viam.com/rdk/components/board/genericlinux/buses"
 	"go.viam.com/rdk/components/movementsensor"
 	"go.viam.com/rdk/components/movementsensor/gpsutils"
@@ -138,11 +139,11 @@ func makeRTKI2C(
 
 	g.correctionWriter, err = newI2CCorrectionWriter(newConf.I2CBus, byte(newConf.I2CAddr))
 	if err != nil {
-		return nil, err
+		return nil, multierr.Combine(err, g.Close(ctx))
 	}
 
 	if err := g.start(); err != nil {
-		return nil, err
+		return nil, multierr.Combine(err, g.Close(ctx))
 	}
 
 	// It's possible that we've taken so long to start up that the resource manager has given up on

--- a/components/movementsensor/gpsrtk/pmtk.go
+++ b/components/movementsensor/gpsrtk/pmtk.go
@@ -173,7 +173,7 @@ func newI2CCorrectionWriter(busname string, address byte) (io.WriteCloser, error
 	return &correctionWriter, nil
 }
 
-// This implements the io.ReadWriteCloser interface.
+// This implements the io.WriteCloser interface.
 type i2cCorrectionWriter struct {
 	bus    buses.I2C
 	handle buses.I2CHandle

--- a/components/movementsensor/gpsrtk/pmtk.go
+++ b/components/movementsensor/gpsrtk/pmtk.go
@@ -5,7 +5,6 @@ package gpsrtk
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 
@@ -158,7 +157,7 @@ func makeRTKI2C(
 	return g, nil
 }
 
-func newI2CCorrectionWriter(busname string, address byte) (io.ReadWriteCloser, error) {
+func newI2CCorrectionWriter(busname string, address byte) (io.WriteCloser, error) {
 	bus, err := buses.NewI2cBus(busname)
 	if err != nil {
 		return nil, err
@@ -178,13 +177,6 @@ func newI2CCorrectionWriter(busname string, address byte) (io.ReadWriteCloser, e
 type i2cCorrectionWriter struct {
 	bus    buses.I2C
 	handle buses.I2CHandle
-}
-
-// Read (vacuously) implements the io.ReadWriteCloser interface for this struct. We need that
-// interface for the moment because `gpsutils.GetGGAMessage()` requires it. However, that code will
-// be changed in summer of 2024 to no longer read via this struct, and then we can remove this.
-func (i *i2cCorrectionWriter) Read(p []byte) (int, error) {
-	return 0, errors.New("unimplemented")
 }
 
 func (i *i2cCorrectionWriter) Write(p []byte) (int, error) {

--- a/components/movementsensor/gpsrtk/serial.go
+++ b/components/movementsensor/gpsrtk/serial.go
@@ -38,6 +38,7 @@ import (
 	"io"
 
 	slib "github.com/jacobsa/go-serial/serial"
+	"go.uber.org/multierr"
 
 	"go.viam.com/rdk/components/movementsensor"
 	"go.viam.com/rdk/components/movementsensor/gpsutils"
@@ -141,11 +142,11 @@ func newRTKSerial(
 	g.correctionWriter, err = newSerialCorrectionWriter(
 		newConf.SerialPath, uint(newConf.SerialBaudRate))
 	if err != nil {
-		return nil, err
+		return nil, multierr.Combine(err, g.Close(ctx))
 	}
 
 	if err := g.start(); err != nil {
-		return nil, err
+		return nil, multierr.Combine(err, g.Close(ctx))
 	}
 
 	// It's possible that we've taken so long to start up that the resource manager has given up on

--- a/components/movementsensor/gpsutils/cachedData.go
+++ b/components/movementsensor/gpsutils/cachedData.go
@@ -93,10 +93,10 @@ func (g *CachedData) GGA() (string, error) {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
 
-	if g.nmeaData.GGAMessage == "" {
+	if g.nmeaData.LastGGAMessage == "" {
 		return "", errors.New("empty gga message, check nmea message parsing")
 	}
-	return g.nmeaData.GGAMessage, g.err.Get()
+	return g.nmeaData.LastGGAMessage, g.err.Get()
 }
 
 // Position returns the position and altitide of the sensor, or an error.

--- a/components/movementsensor/gpsutils/cachedData.go
+++ b/components/movementsensor/gpsutils/cachedData.go
@@ -88,6 +88,17 @@ func (g *CachedData) ParseAndUpdate(line string) error {
 	return g.nmeaData.ParseAndUpdate(line)
 }
 
+// GGA returns the GGA message of the sensor, or an error.
+func (g *CachedData) GGA() (string, error) {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+
+	if g.nmeaData.GGAMessage == "" {
+		return "", errors.New("empty gga message, check nmea message parsing")
+	}
+	return g.nmeaData.GGAMessage, g.err.Get()
+}
+
 // Position returns the position and altitide of the sensor, or an error.
 func (g *CachedData) Position(
 	ctx context.Context, extra map[string]interface{},

--- a/components/movementsensor/gpsutils/nmeaParser.go
+++ b/components/movementsensor/gpsutils/nmeaParser.go
@@ -31,6 +31,7 @@ type NmeaParser struct {
 	CompassHeading      float64 // true compass heading in degree
 	isEast              bool    // direction for magnetic variation which outputs East or West.
 	validCompassHeading bool    // true if we get course of direction instead of empty strings.
+	GGAMessage          string
 }
 
 func errInvalidFix(sentenceType, badFix, goodFix string) error {
@@ -187,6 +188,7 @@ func (g *NmeaParser) updateGGA(gga nmea.GGA) error {
 	g.SatsInUse = int(gga.NumSatellites)
 	g.HDOP = gga.HDOP
 	g.Alt = gga.Altitude
+	g.GGAMessage = gga.String()
 	return nil
 }
 

--- a/components/movementsensor/gpsutils/nmeaParser.go
+++ b/components/movementsensor/gpsutils/nmeaParser.go
@@ -31,7 +31,7 @@ type NmeaParser struct {
 	CompassHeading      float64 // true compass heading in degree
 	isEast              bool    // direction for magnetic variation which outputs East or West.
 	validCompassHeading bool    // true if we get course of direction instead of empty strings.
-	GGAMessage          string
+	LastGGAMessage      string
 }
 
 func errInvalidFix(sentenceType, badFix, goodFix string) error {
@@ -188,7 +188,7 @@ func (g *NmeaParser) updateGGA(gga nmea.GGA) error {
 	g.SatsInUse = int(gga.NumSatellites)
 	g.HDOP = gga.HDOP
 	g.Alt = gga.Altitude
-	g.GGAMessage = gga.String()
+	g.LastGGAMessage = gga.String()
 	return nil
 }
 

--- a/components/movementsensor/gpsutils/ntrip.go
+++ b/components/movementsensor/gpsutils/ntrip.go
@@ -179,8 +179,12 @@ func parseStream(line string) (Stream, error) {
 		return Stream{}, fmt.Errorf("missing fields at stream line: %s", line)
 	}
 
+	if fields[carrierField] == "" {
+		fields[carrierField] = "0"
+	}
 	carrier, err := strconv.Atoi(fields[carrierField])
 	if err != nil {
+
 		return Stream{}, fmt.Errorf("cannot parse the streams carrier in line: %s", line)
 	}
 

--- a/components/movementsensor/gpsutils/ntrip.go
+++ b/components/movementsensor/gpsutils/ntrip.go
@@ -247,13 +247,6 @@ func (n *NtripInfo) Connect(ctx context.Context, logger logging.Logger) error {
 		c, err = ntrip.NewClient(n.URL, ntrip.Options{Username: n.username, Password: n.password})
 		if err == nil { // Success!
 			logger.Info("Connected to NTRIP caster")
-			// setting the Timeout to 0 on the http client to prevent the ntrip stream from canceling itself.
-			// ntrip.NewClient() defaults sets this value to 15 seconds, which causes us to disconnect
-			// the ntrip stream and require a reconnection.
-			// Setting the Timeout on the http client to be 0 removes the timeout. It's possible we want to have different
-			// timeouts configured when reading from the source table vs receiving RCTM corrections.
-			// Additionally, this should be tested with other CORS.
-			c.Client.Timeout = 0
 			n.Client = c
 			return nil
 		}

--- a/components/movementsensor/gpsutils/ntrip.go
+++ b/components/movementsensor/gpsutils/ntrip.go
@@ -184,7 +184,6 @@ func parseStream(line string) (Stream, error) {
 	}
 	carrier, err := strconv.Atoi(fields[carrierField])
 	if err != nil {
-
 		return Stream{}, fmt.Errorf("cannot parse the streams carrier in line: %s", line)
 	}
 

--- a/components/movementsensor/gpsutils/vrs.go
+++ b/components/movementsensor/gpsutils/vrs.go
@@ -4,12 +4,9 @@ package gpsutils
 import (
 	"bufio"
 	"encoding/base64"
-	"errors"
 	"fmt"
-	"io"
 	"net"
 	"net/url"
-	"strings"
 
 	"go.viam.com/rdk/logging"
 )
@@ -56,39 +53,6 @@ func ConnectToVirtualBase(ntripInfo *NtripInfo, logger logging.Logger) (*bufio.R
 	logger.Debugf("request header: %v\n", httpHeaders)
 	logger.Debug("HTTP headers sent successfully.")
 	return rw, nil
-}
-
-// GetGGAMessage checks if a GGA message exists in the buffer and returns it.
-func GetGGAMessage(correctionWriter io.ReadWriteCloser, logger logging.Logger) ([]byte, error) {
-	buffer := make([]byte, 1024)
-	var totalBytesRead int
-
-	for {
-		n, err := correctionWriter.Read(buffer[totalBytesRead:])
-		if err != nil {
-			logger.Errorf("Error reading from Ntrip stream: %v", err)
-			return nil, err
-		}
-
-		totalBytesRead += n
-
-		// Check if the received data contains "GGA"
-		if ContainsGGAMessage(buffer[:totalBytesRead]) {
-			return buffer[:totalBytesRead], nil
-		}
-
-		// If we haven't found the "GGA" message, and we've reached the end of
-		// the buffer, return error.
-		if totalBytesRead >= len(buffer) {
-			return nil, errors.New("GGA message not found in the received data")
-		}
-	}
-}
-
-// ContainsGGAMessage returns true if data contains GGA message.
-func ContainsGGAMessage(data []byte) bool {
-	dataStr := string(data)
-	return strings.Contains(dataStr, "GGA")
 }
 
 // HasVRSStream returns the NMEA field associated with the given mountpoint

--- a/components/movementsensor/gpsutils/vrs.go
+++ b/components/movementsensor/gpsutils/vrs.go
@@ -43,7 +43,6 @@ func ConnectToVirtualBase(ntripInfo *NtripInfo, logger logging.Logger) (*bufio.R
 	// Send HTTP headers over the TCP connection
 	_, err = rw.Write([]byte(httpHeaders))
 	if err != nil {
-
 		return nil, nil, fmt.Errorf("failed to send HTTP headers: %w %w", err, conn.Close())
 	}
 	err = rw.Flush()


### PR DESCRIPTION
was quicker to make a new branch instead of fixing merge conflicts. previous pr was [here](https://github.com/viamrobotics/rdk/pull/4105) 

this PR  adds support for VRS for a gps rtk that is configured for i2c. This was done by adding the GGA message to cached data. In addition, this pr adds a `io.TeeReader` when connecting to a VRS, which allows the gps to get a rtk fix. 

other parts of the code include some small amounts of cleanup and making a function for a chunk of code that was used in multiple spots(`g.getStream`)

tickets: 
vrs with i2c https://viam.atlassian.net/browse/RSDK-5768
low fix with vrs https://viam.atlassian.net/browse/RSDK-8035