### PR TITLE
Update default rotational velocity in motion

### DIFF
--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -51,7 +51,7 @@ const (
 	maxTravelDistanceMM                = 5e6 // this is equivalent to 5km
 	lookAheadDistanceMM        float64 = 5e6
 	defaultSmoothIter                  = 30
-	defaultAngularDegsPerSec           = 20.
+	defaultAngularDegsPerSec           = 60.
 	defaultLinearMPerSec               = 0.3
 	defaultSlamPlanDeviationM          = 1.
 	defaultGlobePlanDeviationM         = 2.6


### PR DESCRIPTION
The initial low angular velocity meant that turning radii were too large to easily course correct