### PR TITLE
Add info log instruction to add pid gains manually after completing a control loop tuning

### DIFF
--- a/control/pid.go
+++ b/control/pid.go
@@ -55,8 +55,9 @@ func (p *basicPID) Next(ctx context.Context, x []*Signal, dt time.Duration) ([]*
 			p.kD = p.tuner.kD
 			p.kI = p.tuner.kI
 			p.kP = p.tuner.kP
+			p.logger.Info("\n\n-------- ***** PID GAINS CALCULATED **** --------")
 			p.logger.CInfof(ctx, "Calculated gains are p: %1.6f, i: %1.6f, d: %1.6f", p.kP, p.kI, p.kD)
-			p.logger.CInfof(ctx, "You must MANUALLY ADD p, i and d gains to the robot config to use the values after tuning")
+			p.logger.CInfof(ctx, "You must MANUALLY ADD p, i and d gains to the robot config to use the values after tuning\n\n")
 			p.tuning = false
 		}
 		p.y[0].SetSignalValueAt(0, out)

--- a/control/pid.go
+++ b/control/pid.go
@@ -56,6 +56,7 @@ func (p *basicPID) Next(ctx context.Context, x []*Signal, dt time.Duration) ([]*
 			p.kI = p.tuner.kI
 			p.kP = p.tuner.kP
 			p.logger.CInfof(ctx, "Calculated gains are p: %1.6f, i: %1.6f, d: %1.6f", p.kP, p.kI, p.kD)
+			p.logger.CInfof(ctx, "You must MANUALLY ADD p, i and d gains to the robot config to use the values after tuning")
 			p.tuning = false
 		}
 		p.y[0].SetSignalValueAt(0, out)

--- a/control/pid.go
+++ b/control/pid.go
@@ -57,7 +57,7 @@ func (p *basicPID) Next(ctx context.Context, x []*Signal, dt time.Duration) ([]*
 			p.kP = p.tuner.kP
 			p.logger.Info("\n\n-------- ***** PID GAINS CALCULATED **** --------")
 			p.logger.CInfof(ctx, "Calculated gains are p: %1.6f, i: %1.6f, d: %1.6f", p.kP, p.kI, p.kD)
-			p.logger.CInfof(ctx, "You must MANUALLY ADD p, i and d gains to the robot config to use the values after tuning")
+			p.logger.CInfof(ctx, "You must MANUALLY ADD p, i and d gains to the robot config to use the values after tuning\n\n")
 			p.tuning = false
 		}
 		p.y[0].SetSignalValueAt(0, out)


### PR DESCRIPTION
I think there's probably a better place for this in the motor/sensor-controlled base setup code, but I can't immediately find it. We're relying on this log to surface the calculated gains. It's an okay stop-gap for the immediate future that we can remove when we store the gains in the controlled components' states.