### PR TITLE
Rsdk-8155: adding sats in use to sensor reading

### DIFF
--- a/components/movementsensor/gpsnmea/component.go
+++ b/components/movementsensor/gpsnmea/component.go
@@ -96,6 +96,11 @@ func (g *NMEAMovementSensor) ReadSatsInView(ctx context.Context) (int, error) {
 	return g.cachedData.ReadSatsInView(ctx)
 }
 
+// ReadSatsInUse returns the number of satellites in use.
+func (g *NMEAMovementSensor) ReadSatsInUse(ctx context.Context) (int, error) {
+	return g.cachedData.ReadSatsInUse(ctx)
+}
+
 // Readings will use return all of the MovementSensor Readings.
 func (g *NMEAMovementSensor) Readings(
 	ctx context.Context, extra map[string]interface{},
@@ -113,8 +118,13 @@ func (g *NMEAMovementSensor) Readings(
 	if err != nil {
 		return nil, err
 	}
+	satsInUse, err := g.ReadSatsInUse(ctx)
+	if err != nil {
+		return nil, err
+	}
 	readings["fix"] = fix
 	readings["satellites_in_view"] = satsInView
+	readings["satellites_in_use"] = satsInUse
 
 	return readings, nil
 }

--- a/components/movementsensor/gpsrtk/gpsrtk.go
+++ b/components/movementsensor/gpsrtk/gpsrtk.go
@@ -355,6 +355,16 @@ func (g *gpsrtk) readSatsInView(ctx context.Context) (int, error) {
 	return g.cachedData.ReadSatsInView(ctx)
 }
 
+// readSatsInUse returns the number of satellites in use.
+func (g *gpsrtk) readSatsInUse(ctx context.Context) (int, error) {
+	lastError := g.err.Get()
+	if lastError != nil {
+		return 0, lastError
+	}
+
+	return g.cachedData.ReadSatsInUse(ctx)
+}
+
 // Properties passthrough.
 func (g *gpsrtk) Properties(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
 	lastError := g.err.Get()
@@ -393,8 +403,14 @@ func (g *gpsrtk) Readings(ctx context.Context, extra map[string]interface{}) (ma
 		return nil, err
 	}
 
+	satsInUse, err := g.readSatsInUse(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	readings["fix"] = fix
 	readings["satellites_in_view"] = satsInView
+	readings["satellites_in_use"] = satsInUse
 
 	return readings, nil
 }

--- a/components/movementsensor/gpsutils/cachedData.go
+++ b/components/movementsensor/gpsutils/cachedData.go
@@ -213,6 +213,13 @@ func (g *CachedData) ReadSatsInView(ctx context.Context) (int, error) {
 	return g.nmeaData.SatsInView, nil
 }
 
+// ReadSatsInUse returns the number of satellites in use to calculate fix type.
+func (g *CachedData) ReadSatsInUse(ctx context.Context) (int, error) {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	return g.nmeaData.SatsInUse, nil
+}
+
 // Properties returns what movement sensor capabilities we have.
 func (g *CachedData) Properties(
 	ctx context.Context, extra map[string]interface{},

--- a/components/movementsensor/gpsutils/nmeaParser.go
+++ b/components/movementsensor/gpsutils/nmeaParser.go
@@ -230,7 +230,7 @@ func (g *NmeaParser) updateGNS(gns nmea.GNS) error {
 	}
 
 	g.Location = geo.NewPoint(gns.Latitude, gns.Longitude)
-	g.SatsInUse = int(gns.SVs) //gns.SVs can range from 0 to 99
+
 	g.HDOP = gns.HDOP
 	g.Alt = gns.Altitude
 	return nil

--- a/components/movementsensor/gpsutils/nmeaParser.go
+++ b/components/movementsensor/gpsutils/nmeaParser.go
@@ -24,8 +24,8 @@ type NmeaParser struct {
 	Speed               float64 // ground speed in m per sec
 	VDOP                float64 // vertical accuracy
 	HDOP                float64 // horizontal accuracy
-	SatsInView          int     // quantity satellites in view
-	SatsInUse           int     // quantity satellites in view
+	SatsInView          int     // all satellites visible to the receiver, whether or not they are used for positioning.
+	SatsInUse           int     // satellites actively used for positioning and measuring fix type
 	valid               bool
 	FixQuality          int
 	CompassHeading      float64 // true compass heading in degree
@@ -184,7 +184,7 @@ func (g *NmeaParser) updateGGA(gga nmea.GGA) error {
 
 	g.valid = true
 	g.Location = geo.NewPoint(gga.Latitude, gga.Longitude)
-	g.SatsInUse = int(gga.NumSatellites)
+	g.SatsInUse = int(gga.NumSatellites) // gga.NumSatellites can range from 0 through to 24+
 	g.HDOP = gga.HDOP
 	g.Alt = gga.Altitude
 	return nil
@@ -230,7 +230,7 @@ func (g *NmeaParser) updateGNS(gns nmea.GNS) error {
 	}
 
 	g.Location = geo.NewPoint(gns.Latitude, gns.Longitude)
-	g.SatsInUse = int(gns.SVs)
+	g.SatsInUse = int(gns.SVs) //gns.SVs can range from 0 to 99
 	g.HDOP = gns.HDOP
 	g.Alt = gns.Altitude
 	return nil

--- a/components/movementsensor/gpsutils/nmeaParser.go
+++ b/components/movementsensor/gpsutils/nmeaParser.go
@@ -230,7 +230,7 @@ func (g *NmeaParser) updateGNS(gns nmea.GNS) error {
 	}
 
 	g.Location = geo.NewPoint(gns.Latitude, gns.Longitude)
-
+	g.SatsInUse = int(gns.SVs)
 	g.HDOP = gns.HDOP
 	g.Alt = gns.Altitude
 	return nil


### PR DESCRIPTION
Turns out we were using `sats_in_view `wrong. `sats_in_use` is used to calculate position and measure fix type. `sats_in_view` is the number of satellites visible to the receiver and it may or may not use it for positioning. 
I added some comments in the code to clarify the difference between the two and surfacing `sats_in_use` in sensor reading which is what we need to determine the fix type