### PR TITLE
RSDK-8088: Create Logger Registry

### DIFF
--- a/grpc/shared_conn_test.go
+++ b/grpc/shared_conn_test.go
@@ -16,9 +16,9 @@ import (
 func TestNewLocalPeerConnection(t *testing.T) {
 	t.Run("both NewLocalPeerConnections", func(t *testing.T) {
 		logger := logging.NewTestLogger(t)
-		client, err := NewLocalPeerConnection(logger.AsZap())
+		client, err := NewLocalPeerConnection(logger)
 		test.That(t, err, test.ShouldBeNil)
-		server, err := NewLocalPeerConnection(logger.AsZap())
+		server, err := NewLocalPeerConnection(logger)
 		test.That(t, err, test.ShouldBeNil)
 		var cMu sync.Mutex
 		clientCandates := []*webrtc.ICECandidate{}
@@ -87,7 +87,7 @@ func TestNewLocalPeerConnection(t *testing.T) {
 
 	t.Run("one NewLocalPeerConnection non local server", func(t *testing.T) {
 		logger := logging.NewTestLogger(t)
-		client, err := NewLocalPeerConnection(logger.AsZap())
+		client, err := NewLocalPeerConnection(logger)
 		test.That(t, err, test.ShouldBeNil)
 		server, err := webrtc.NewPeerConnection(webrtc.Configuration{})
 		test.That(t, err, test.ShouldBeNil)
@@ -97,7 +97,7 @@ func TestNewLocalPeerConnection(t *testing.T) {
 
 	t.Run("one NewLocalPeerConnection non local client", func(t *testing.T) {
 		logger := logging.NewTestLogger(t)
-		server, err := NewLocalPeerConnection(logger.AsZap())
+		server, err := NewLocalPeerConnection(logger)
 		test.That(t, err, test.ShouldBeNil)
 		client, err := webrtc.NewPeerConnection(webrtc.Configuration{})
 		test.That(t, err, test.ShouldBeNil)

--- a/logging/impl.go
+++ b/logging/impl.go
@@ -71,12 +71,16 @@ func (imp *impl) Sublogger(subname string) Logger {
 
 	// Force all parameters to be passed. Avoid bugs where adding members to `impl` silently
 	// succeeds without a change here.
-	return &impl{
+	sublogger := &impl{
 		newName,
 		NewAtomicLevelAt(imp.level.Get()),
 		imp.appenders,
 		imp.testHelper,
 	}
+
+	loggerManager.RegisterLogger(newName, sublogger)
+
+	return sublogger
 }
 
 func (imp *impl) Named(name string) *zap.SugaredLogger {

--- a/logging/impl.go
+++ b/logging/impl.go
@@ -78,7 +78,7 @@ func (imp *impl) Sublogger(subname string) Logger {
 		imp.testHelper,
 	}
 
-	loggerManager.RegisterLogger(newName, sublogger)
+	loggerManager.registerLogger(newName, sublogger)
 
 	return sublogger
 }

--- a/logging/logger_manager.go
+++ b/logging/logger_manager.go
@@ -6,7 +6,7 @@ import (
 )
 
 type loggerRegistry struct {
-	mu      sync.Mutex
+	mu      sync.RWMutex
 	loggers map[string]Logger
 	names   map[Logger]string
 }
@@ -28,22 +28,22 @@ func (lr *loggerRegistry) registerLogger(name string, logger Logger) {
 }
 
 func (lr *loggerRegistry) nameOf(logger Logger) (name string, ok bool) {
-	lr.mu.Lock()
-	defer lr.mu.Unlock()
+	lr.mu.RLock()
+	defer lr.mu.RUnlock()
 	name, ok = lr.names[logger]
 	return name, ok
 }
 
 func (lr *loggerRegistry) loggerNamed(name string) (logger Logger, ok bool) {
-	lr.mu.Lock()
-	defer lr.mu.Unlock()
+	lr.mu.RLock()
+	defer lr.mu.RUnlock()
 	logger, ok = lr.loggers[name]
 	return logger, ok
 }
 
 func (lr *loggerRegistry) updateLoggerLevel(name string, level Level) error {
-	lr.mu.Lock()
-	defer lr.mu.Unlock()
+	lr.mu.RLock()
+	defer lr.mu.RUnlock()
 	logger, ok := lr.loggers[name]
 	if !ok {
 		return fmt.Errorf("logger named %s not recognized", name)

--- a/logging/logger_manager.go
+++ b/logging/logger_manager.go
@@ -42,6 +42,8 @@ func (lr *loggerRegistry) loggerNamed(name string) (logger Logger, ok bool) {
 }
 
 func (lr *loggerRegistry) updateLoggerLevel(name string, level Level) error {
+	lr.mu.Lock()
+	defer lr.mu.Unlock()
 	logger, ok := lr.loggers[name]
 	if !ok {
 		return fmt.Errorf("logger named %s not recognized", name)

--- a/logging/logger_manager.go
+++ b/logging/logger_manager.go
@@ -1,0 +1,38 @@
+package logging
+
+import (
+	"sync"
+)
+
+type LoggerRegistry struct {
+	mu      sync.Mutex
+	loggers map[string]Logger
+	names   map[Logger]string
+}
+
+var loggerManager = NewLoggerManager()
+
+func NewLoggerManager() *LoggerRegistry {
+	return &LoggerRegistry{
+		loggers: make(map[string]Logger),
+		names:   make(map[Logger]string),
+	}
+}
+
+func (lr *LoggerRegistry) RegisterLogger(name string, logger Logger) {
+	lr.mu.Lock()
+	defer lr.mu.Unlock()
+	lr.loggers[name] = logger
+	lr.names[logger] = name
+}
+
+func (lr *LoggerRegistry) NameOf(logger Logger) (name string, ok bool) {
+	lr.mu.Lock()
+	defer lr.mu.Unlock()
+	name, ok = lr.names[logger]
+	return name, ok
+}
+
+func (lr *LoggerRegistry) UpdateLoggerLevel(name string, level Level) {
+	lr.loggers[name].SetLevel(level)
+}

--- a/logging/logger_manager.go
+++ b/logging/logger_manager.go
@@ -8,7 +8,6 @@ import (
 type loggerRegistry struct {
 	mu      sync.RWMutex
 	loggers map[string]Logger
-	names   map[Logger]string
 }
 
 var loggerManager = newLoggerManager()
@@ -16,7 +15,6 @@ var loggerManager = newLoggerManager()
 func newLoggerManager() *loggerRegistry {
 	return &loggerRegistry{
 		loggers: make(map[string]Logger),
-		names:   make(map[Logger]string),
 	}
 }
 
@@ -24,14 +22,6 @@ func (lr *loggerRegistry) registerLogger(name string, logger Logger) {
 	lr.mu.Lock()
 	defer lr.mu.Unlock()
 	lr.loggers[name] = logger
-	lr.names[logger] = name
-}
-
-func (lr *loggerRegistry) nameOf(logger Logger) (name string, ok bool) {
-	lr.mu.RLock()
-	defer lr.mu.RUnlock()
-	name, ok = lr.names[logger]
-	return name, ok
 }
 
 func (lr *loggerRegistry) loggerNamed(name string) (logger Logger, ok bool) {

--- a/logging/logger_manager.go
+++ b/logging/logger_manager.go
@@ -1,38 +1,51 @@
 package logging
 
 import (
+	"fmt"
 	"sync"
 )
 
-type LoggerRegistry struct {
+type loggerRegistry struct {
 	mu      sync.Mutex
 	loggers map[string]Logger
 	names   map[Logger]string
 }
 
-var loggerManager = NewLoggerManager()
+var loggerManager = newLoggerManager()
 
-func NewLoggerManager() *LoggerRegistry {
-	return &LoggerRegistry{
+func newLoggerManager() *loggerRegistry {
+	return &loggerRegistry{
 		loggers: make(map[string]Logger),
 		names:   make(map[Logger]string),
 	}
 }
 
-func (lr *LoggerRegistry) RegisterLogger(name string, logger Logger) {
+func (lr *loggerRegistry) registerLogger(name string, logger Logger) {
 	lr.mu.Lock()
 	defer lr.mu.Unlock()
 	lr.loggers[name] = logger
 	lr.names[logger] = name
 }
 
-func (lr *LoggerRegistry) NameOf(logger Logger) (name string, ok bool) {
+func (lr *loggerRegistry) nameOf(logger Logger) (name string, ok bool) {
 	lr.mu.Lock()
 	defer lr.mu.Unlock()
 	name, ok = lr.names[logger]
 	return name, ok
 }
 
-func (lr *LoggerRegistry) UpdateLoggerLevel(name string, level Level) {
-	lr.loggers[name].SetLevel(level)
+func (lr *loggerRegistry) loggerNamed(name string) (logger Logger, ok bool) {
+	lr.mu.Lock()
+	defer lr.mu.Unlock()
+	logger, ok = lr.loggers[name]
+	return logger, ok
+}
+
+func (lr *loggerRegistry) updateLoggerLevel(name string, level Level) error {
+	logger, ok := lr.loggers[name]
+	if !ok {
+		return fmt.Errorf("logger named %s not recognized", name)
+	}
+	logger.SetLevel(level)
+	return nil
 }

--- a/logging/logger_manager_test.go
+++ b/logging/logger_manager_test.go
@@ -39,11 +39,6 @@ func TestLoggerRegistration(t *testing.T) {
 
 	test.That(t, actualLogger, test.ShouldEqual, expectedLogger)
 	test.That(t, ok, test.ShouldBeTrue)
-
-	actualName, ok := manager.nameOf(actualLogger)
-
-	test.That(t, actualName, test.ShouldEqual, expectedName)
-	test.That(t, ok, test.ShouldBeTrue)
 }
 
 func TestLoggerRetrieval(t *testing.T) {
@@ -56,14 +51,6 @@ func TestLoggerRetrieval(t *testing.T) {
 	sublogger2, ok := manager.loggerNamed("sublogger-2")
 	test.That(t, ok, test.ShouldBeFalse)
 	test.That(t, sublogger2, test.ShouldBeNil)
-
-	name2, ok := manager.nameOf(l2)
-	test.That(t, ok, test.ShouldBeTrue)
-	test.That(t, name2, test.ShouldEqual, "logger-2")
-
-	name3, ok := manager.nameOf(l3)
-	test.That(t, ok, test.ShouldBeFalse)
-	test.That(t, name3, test.ShouldEqual, "")
 }
 
 func TestLoggersRegisteredOnCreation(t *testing.T) {
@@ -76,18 +63,10 @@ func TestLoggersRegisteredOnCreation(t *testing.T) {
 	test.That(t, logger, test.ShouldEqual, newLogger)
 	test.That(t, ok, test.ShouldBeTrue)
 
-	loggerName, ok := manager.nameOf(newLogger)
-	test.That(t, loggerName, test.ShouldEqual, "new")
-	test.That(t, ok, test.ShouldBeTrue)
-
 	debugLogger := NewDebugLogger("debug")
 
 	logger, ok = manager.loggerNamed("debug")
 	test.That(t, logger, test.ShouldEqual, debugLogger)
-	test.That(t, ok, test.ShouldBeTrue)
-
-	loggerName, ok = manager.nameOf(debugLogger)
-	test.That(t, loggerName, test.ShouldEqual, "debug")
 	test.That(t, ok, test.ShouldBeTrue)
 
 	blankLogger := NewBlankLogger("blank")
@@ -96,19 +75,11 @@ func TestLoggersRegisteredOnCreation(t *testing.T) {
 	test.That(t, logger, test.ShouldEqual, blankLogger)
 	test.That(t, ok, test.ShouldBeTrue)
 
-	loggerName, ok = manager.nameOf(blankLogger)
-	test.That(t, loggerName, test.ShouldEqual, "blank")
-	test.That(t, ok, test.ShouldBeTrue)
-
 	sublogger := l1.Sublogger("sublogger-1")
 	subloggerName := fmt.Sprintf("%s.%s", "logger-1", "sublogger-1")
 
 	logger, ok = manager.loggerNamed(subloggerName)
 	test.That(t, logger, test.ShouldEqual, sublogger)
-	test.That(t, ok, test.ShouldBeTrue)
-
-	loggerName, ok = manager.nameOf(sublogger)
-	test.That(t, loggerName, test.ShouldEqual, subloggerName)
 	test.That(t, ok, test.ShouldBeTrue)
 }
 

--- a/logging/logger_manager_test.go
+++ b/logging/logger_manager_test.go
@@ -1,0 +1,128 @@
+package logging
+
+import (
+	"fmt"
+	"testing"
+
+	"go.viam.com/test"
+)
+
+var (
+	l1 = NewLogger("logger-1")
+	l2 = NewLogger("logger-2")
+	l3 = NewLogger("logger-3")
+)
+
+func mockRegistry() *loggerRegistry {
+	manager := newLoggerManager()
+	manager.registerLogger("logger-1", l1)
+	manager.registerLogger("logger-2", l2)
+	l3.Sublogger("sublogger-1")
+	loggerManager = manager
+	return manager
+}
+
+func TestLoggerRegistration(t *testing.T) {
+	manager := mockRegistry()
+
+	expectedName := "test"
+	expectedLogger := &impl{
+		name:       expectedName,
+		level:      NewAtomicLevelAt(INFO),
+		appenders:  []Appender{NewStdoutAppender()},
+		testHelper: func() {},
+	}
+
+	manager.registerLogger(expectedName, expectedLogger)
+
+	actualLogger, ok := manager.loggerNamed("test")
+
+	test.That(t, actualLogger, test.ShouldEqual, expectedLogger)
+	test.That(t, ok, test.ShouldBeTrue)
+
+	actualName, ok := manager.nameOf(actualLogger)
+
+	test.That(t, actualName, test.ShouldEqual, expectedName)
+	test.That(t, ok, test.ShouldBeTrue)
+}
+
+func TestLoggerRetrieval(t *testing.T) {
+	manager := mockRegistry()
+
+	logger1, ok := manager.loggerNamed("logger-1")
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, logger1, test.ShouldEqual, l1)
+
+	sublogger2, ok := manager.loggerNamed("sublogger-2")
+	test.That(t, ok, test.ShouldBeFalse)
+	test.That(t, sublogger2, test.ShouldBeNil)
+
+	name2, ok := manager.nameOf(l2)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, name2, test.ShouldEqual, "logger-2")
+
+	name3, ok := manager.nameOf(l3)
+	test.That(t, ok, test.ShouldBeFalse)
+	test.That(t, name3, test.ShouldEqual, "")
+}
+
+func TestLoggersRegisteredOnCreation(t *testing.T) {
+	manager := mockRegistry()
+
+	newLogger := NewLogger("new")
+
+	logger, ok := manager.loggerNamed("new")
+
+	test.That(t, logger, test.ShouldEqual, newLogger)
+	test.That(t, ok, test.ShouldBeTrue)
+
+	loggerName, ok := manager.nameOf(newLogger)
+	test.That(t, loggerName, test.ShouldEqual, "new")
+	test.That(t, ok, test.ShouldBeTrue)
+
+	debugLogger := NewDebugLogger("debug")
+
+	logger, ok = manager.loggerNamed("debug")
+	test.That(t, logger, test.ShouldEqual, debugLogger)
+	test.That(t, ok, test.ShouldBeTrue)
+
+	loggerName, ok = manager.nameOf(debugLogger)
+	test.That(t, loggerName, test.ShouldEqual, "debug")
+	test.That(t, ok, test.ShouldBeTrue)
+
+	blankLogger := NewBlankLogger("blank")
+
+	logger, ok = manager.loggerNamed("blank")
+	test.That(t, logger, test.ShouldEqual, blankLogger)
+	test.That(t, ok, test.ShouldBeTrue)
+
+	loggerName, ok = manager.nameOf(blankLogger)
+	test.That(t, loggerName, test.ShouldEqual, "blank")
+	test.That(t, ok, test.ShouldBeTrue)
+
+	sublogger := l1.Sublogger("sublogger-1")
+	subloggerName := fmt.Sprintf("%s.%s", "logger-1", "sublogger-1")
+
+	logger, ok = manager.loggerNamed(subloggerName)
+	test.That(t, logger, test.ShouldEqual, sublogger)
+	test.That(t, ok, test.ShouldBeTrue)
+
+	loggerName, ok = manager.nameOf(sublogger)
+	test.That(t, loggerName, test.ShouldEqual, subloggerName)
+	test.That(t, ok, test.ShouldBeTrue)
+}
+
+func TestUpdateLogLevel(t *testing.T) {
+	manager := mockRegistry()
+
+	err := manager.updateLoggerLevel("logger-1", DEBUG)
+	test.That(t, err, test.ShouldBeNil)
+
+	logger1, ok := manager.loggerNamed("logger-1")
+	test.That(t, ok, test.ShouldBeTrue)
+	level := logger1.GetLevel()
+	test.That(t, level, test.ShouldEqual, DEBUG)
+
+	err = manager.updateLoggerLevel("slogger-1", DEBUG)
+	test.That(t, err, test.ShouldNotBeNil)
+}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -69,7 +69,6 @@ func NewLogger(name string) Logger {
 	}
 
 	loggerManager.registerLogger(name, logger)
-	globalLogger.Warn("now registering", name, logger)
 	return logger
 }
 

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -14,6 +14,7 @@ import (
 var (
 	globalMu     sync.RWMutex
 	globalLogger = NewDebugLogger("startup")
+
 	// GlobalLogLevel should be used whenever a zap logger is created that wants to obey the debug
 	// flag from the CLI or robot config.
 	GlobalLogLevel = zap.NewAtomicLevelAt(zap.InfoLevel)
@@ -67,7 +68,8 @@ func NewLogger(name string) Logger {
 		testHelper: func() {},
 	}
 
-	loggerManager.RegisterLogger(name, logger)
+	loggerManager.registerLogger(name, logger)
+	globalLogger.Warn("now registering", name, logger)
 	return logger
 }
 
@@ -80,7 +82,7 @@ func NewDebugLogger(name string) Logger {
 		testHelper: func() {},
 	}
 
-	loggerManager.RegisterLogger(name, logger)
+	loggerManager.registerLogger(name, logger)
 	return logger
 }
 
@@ -94,7 +96,7 @@ func NewBlankLogger(name string) Logger {
 		testHelper: func() {},
 	}
 
-	loggerManager.RegisterLogger(name, logger)
+	loggerManager.registerLogger(name, logger)
 	return logger
 }
 

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -14,7 +14,6 @@ import (
 var (
 	globalMu     sync.RWMutex
 	globalLogger = NewDebugLogger("startup")
-
 	// GlobalLogLevel should be used whenever a zap logger is created that wants to obey the debug
 	// flag from the CLI or robot config.
 	GlobalLogLevel = zap.NewAtomicLevelAt(zap.InfoLevel)
@@ -61,33 +60,42 @@ func NewZapLoggerConfig() zap.Config {
 
 // NewLogger returns a new logger that outputs Info+ logs to stdout in UTC.
 func NewLogger(name string) Logger {
-	return &impl{
+	logger := &impl{
 		name:       name,
 		level:      NewAtomicLevelAt(INFO),
 		appenders:  []Appender{NewStdoutAppender()},
 		testHelper: func() {},
 	}
+
+	loggerManager.RegisterLogger(name, logger)
+	return logger
 }
 
 // NewDebugLogger returns a new logger that outputs Debug+ logs to stdout in UTC.
 func NewDebugLogger(name string) Logger {
-	return &impl{
+	logger := &impl{
 		name:       name,
 		level:      NewAtomicLevelAt(DEBUG),
 		appenders:  []Appender{NewStdoutAppender()},
 		testHelper: func() {},
 	}
+
+	loggerManager.RegisterLogger(name, logger)
+	return logger
 }
 
 // NewBlankLogger returns a new logger that outputs Debug+ logs in UTC, but without any
 // pre-existing appenders/outputs.
 func NewBlankLogger(name string) Logger {
-	return &impl{
+	logger := &impl{
 		name:       name,
 		level:      NewAtomicLevelAt(DEBUG),
 		appenders:  []Appender{},
 		testHelper: func() {},
 	}
+
+	loggerManager.RegisterLogger(name, logger)
+	return logger
 }
 
 // NewTestLogger returns a new logger that outputs Debug+ logs to stdout in local time.

--- a/module/module.go
+++ b/module/module.go
@@ -229,7 +229,7 @@ func NewModule(ctx context.Context, address string, logger logging.Logger) (*Mod
 	}
 
 	// attempt to construct a PeerConnection
-	pc, err := rgrpc.NewLocalPeerConnection(logger.AsZap())
+	pc, err := rgrpc.NewLocalPeerConnection(logger)
 	if err != nil {
 		logger.Debugw("Unable to create optional peer connection for module. Skipping WebRTC for module...", "err", err)
 		return m, nil

--- a/web/cmd/directremotecontrol/main.go
+++ b/web/cmd/directremotecontrol/main.go
@@ -53,7 +53,7 @@ type Arguments struct {
 	Port   utils.NetPortFlag `flag:"port,default=8080"`
 }
 
-var logger = logging.NewDebugLogger("rdk")
+var logger = logging.NewDebugLogger("entrypoint")
 
 func main() {
 	utils.ContextualMain(mainWithArgs, logger)

--- a/web/cmd/directremotecontrol/main.go
+++ b/web/cmd/directremotecontrol/main.go
@@ -53,7 +53,7 @@ type Arguments struct {
 	Port   utils.NetPortFlag `flag:"port,default=8080"`
 }
 
-var logger = logging.NewDebugLogger("entrypoint")
+var logger = logging.NewDebugLogger("direct-remote-control")
 
 func main() {
 	utils.ContextualMain(mainWithArgs, logger)

--- a/web/cmd/droid/droid.go
+++ b/web/cmd/droid/droid.go
@@ -10,7 +10,6 @@ import (
 	// registers all components.
 	_ "go.viam.com/rdk/components/register"
 	"go.viam.com/rdk/logging"
-
 	// registers all services.
 	_ "go.viam.com/rdk/services/register"
 	"go.viam.com/rdk/web/server"

--- a/web/cmd/droid/droid.go
+++ b/web/cmd/droid/droid.go
@@ -10,12 +10,13 @@ import (
 	// registers all components.
 	_ "go.viam.com/rdk/components/register"
 	"go.viam.com/rdk/logging"
+
 	// registers all services.
 	_ "go.viam.com/rdk/services/register"
 	"go.viam.com/rdk/web/server"
 )
 
-var logger = logging.NewDebugLogger("rdk")
+var logger = logging.NewDebugLogger("entrypoint")
 
 // DroidStopHook used by android harness to stop the RDK.
 func DroidStopHook() { //nolint:revive

--- a/web/cmd/droid/droid.go
+++ b/web/cmd/droid/droid.go
@@ -10,12 +10,13 @@ import (
 	// registers all components.
 	_ "go.viam.com/rdk/components/register"
 	"go.viam.com/rdk/logging"
+
 	// registers all services.
 	_ "go.viam.com/rdk/services/register"
 	"go.viam.com/rdk/web/server"
 )
 
-var logger = logging.NewDebugLogger("entrypoint")
+var logger = logging.NewDebugLogger("droid-entrypoint")
 
 // DroidStopHook used by android harness to stop the RDK.
 func DroidStopHook() { //nolint:revive

--- a/web/cmd/server/main.go
+++ b/web/cmd/server/main.go
@@ -8,7 +8,6 @@ import (
 	// registers all components.
 	_ "go.viam.com/rdk/components/register"
 	"go.viam.com/rdk/logging"
-
 	// registers all services.
 	_ "go.viam.com/rdk/services/register"
 	"go.viam.com/rdk/web/server"

--- a/web/cmd/server/main.go
+++ b/web/cmd/server/main.go
@@ -8,12 +8,13 @@ import (
 	// registers all components.
 	_ "go.viam.com/rdk/components/register"
 	"go.viam.com/rdk/logging"
+
 	// registers all services.
 	_ "go.viam.com/rdk/services/register"
 	"go.viam.com/rdk/web/server"
 )
 
-var logger = logging.NewDebugLogger("rdk")
+var logger = logging.NewDebugLogger("entrypoint")
 
 func main() {
 	utils.ContextualMain(server.RunServer, logger)


### PR DESCRIPTION
### Description
RSDK-8088: Build registry of loggers in RDK
* This PR creates a `loggerRegistry` type and global variable which maintains a bidirectional map between logger names and loggers, as well as functions to register logger, retrieve them (either by the log object itself or name), and update their log levels. 
  * All RDK loggers that get created now get registered into this data structure.
* Also converts loggers in `shared_conn.go` that don't need to be zap loggers into RDK loggers, and renames loggers created on robot start up to `entrypoint` so as to not have a name collision with the `rdk` logger actually responsible for robot processes. 
### Testing
* A simple test suite for various `loggerRegistry` methods and functionality. 