### PR TITLE
[RSDK-8145] Speed up RTK construction

### DIFF
--- a/components/movementsensor/gpsrtk/gpsrtk.go
+++ b/components/movementsensor/gpsrtk/gpsrtk.go
@@ -449,6 +449,10 @@ func (g *gpsrtk) Close(ctx context.Context) error {
 		}
 	}
 
+	// WARNING: if the background goroutine is calling `getStream()` and is waiting on the mutex
+	// before initializing `g.ntripClient.Stream`, we might finish closing and then initialize a new
+	// stream. This could be fixed by putting the background goroutine in a StoppableWorkers which
+	// we shut down at the top of this function, which can happen in the near future.
 	if g.ntripClient.Stream != nil {
 		if err := g.ntripClient.Stream.Close(); err != nil {
 			g.mu.Unlock()

--- a/components/movementsensor/gpsrtk/gpsrtk.go
+++ b/components/movementsensor/gpsrtk/gpsrtk.go
@@ -120,8 +120,8 @@ func (g *gpsrtk) getStreamFromMountPoint(mountPoint string, maxAttempts int) err
 	return g.err.Get()
 }
 
-// closePort closes the correctionWriter.
-func (g *gpsrtk) closePort() {
+// closeCorrectionWriter closes the correctionWriter.
+func (g *gpsrtk) closeCorrectionWriter() {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
@@ -222,7 +222,7 @@ func (g *gpsrtk) getStream() (io.Reader, error) {
 // the MovementSensor.
 func (g *gpsrtk) receiveAndWriteCorrectionData() {
 	defer g.activeBackgroundWorkers.Done()
-	defer g.closePort()
+	defer g.closeCorrectionWriter()
 
 	err := g.connectToNTRIP()
 	if err != nil {

--- a/components/movementsensor/gpsrtk/pmtk.go
+++ b/components/movementsensor/gpsrtk/pmtk.go
@@ -147,15 +147,6 @@ func makeRTKI2C(
 		return nil, multierr.Combine(err, g.Close(ctx))
 	}
 
-	// It's possible that we've taken so long to start up that the resource manager has given up on
-	// us and tried constructing a new component instead. If that happens, we don't want 2
-	// components talking to the same chip. So, if our context is canceled, close our component
-	// instead of returning it.
-	if ctx.Err() != nil {
-		logger.Warn("context canceled by the end of the constructor! Closing the new component...")
-		return nil, fmt.Errorf("timed out constructing I2C RTK reader. Closing: %w", g.Close(ctx))
-	}
-
 	return g, nil
 }
 

--- a/components/movementsensor/gpsrtk/pmtk.go
+++ b/components/movementsensor/gpsrtk/pmtk.go
@@ -5,7 +5,6 @@ package gpsrtk
 
 import (
 	"context"
-	"fmt"
 	"io"
 
 	"go.uber.org/multierr"

--- a/components/movementsensor/gpsrtk/serial.go
+++ b/components/movementsensor/gpsrtk/serial.go
@@ -149,15 +149,6 @@ func newRTKSerial(
 		return nil, multierr.Combine(err, g.Close(ctx))
 	}
 
-	// It's possible that we've taken so long to start up that the resource manager has given up on
-	// us and tried constructing a new component instead. If that happens, we don't want 2
-	// components talking to the same chip. So, if our context is canceled, close our component
-	// instead of returning it.
-	if ctx.Err() != nil {
-		logger.Warn("context canceled by the end of the constructor! Closing the new component...")
-		return nil, fmt.Errorf("timed out constructing serial RTK reader. Closing: %w", g.Close(ctx))
-	}
-
 	return g, nil
 }
 


### PR DESCRIPTION
The slow part of constructing a component was connecting to the NTRIP caster. So, I moved that to the start of the background goroutine, rather than the constructor. Now, the constructer is nice and fast again.

Tried on john-pi: both the serial and I2C components start up in less than a second! 

While I was at it, I renamed `closePort()` to `closeCorrectionWriter()`, which I thought was a clearer name. That part is unrelated to the rest, and I can undo that again if you prefer.

Justification for why it's okay to move `connectToNTRIP()` to the goroutine:
- `connectToNTRIP()` initializes `g.reader`. That field is only used in `receiveAndWriteCorrectionData()`, which comes later in the goroutine. It is not used elsewhere, so initializing it after we're done constructing the component is okay.
- `connectToNTRIP()` calls `connectAndParseSourceTable()`, which sets `isVirtualBase`. That is only used in `connectToNTRIP()` itself and `receiveAndWriteCorrectionData()` (only called from later in the goroutine), so nothing outside of this goroutine depends on it and won't get messed up if it is initialized after the constructor has finished.
- `connectToNTRIP()` calls `getNtripFromVRS()`, which initializes `g.readerWriter`. That field is only used by `receiveAndWriteCorrectionData()`, which is only called from later in the goroutine. So, initializing it after the constructor has finished won't cause trouble.
- `connectToNTRIP()` calls `getStream()`, which initializes `g.ntripClient.Stream`. Admittedly, I haven't been able to reason about this very well because it violates the [Law of Demeter](https://en.wikipedia.org/wiki/Law_of_Demeter) (do other parts of `ntripClient` depend on the `Stream` being initialized early? How can you find them all?). However, `g.ntripClient` as a whole is only used in the following:
  - `receiveAndWriteCorrectionData()`, which is only called later in the goroutine
  - `connectToNTRIP()`, which is only called from `receiveAndWriteCorrectionData()`
  - `connectAndParseSourceTable()`, which is only called from `connectToNTRIP()`
  - `Close()`, which only does stuff if `g.ntripClient.Client` or `g.ntripClient.Stream` is not nil (and locks the mutex, so nothing else should be modifying that field at the same time)
  - `getNtripFromVRS()`, which is only called from `connectToNTRIP()` and `receiveAndWriteCorrectionData()`, both mentioned earlier.
  - There is a small race condition where we call `Close()` and then immediately afterwards the background goroutine calls `getStream()` and initializes the stream. but we already have that problem, and it sounds unlikely to occur in practice. I've put in a comment about it, and will aim to fix this with a `StoppableWorkers` during 20% happy hour tomorrow.
- `connectToNTRIP()` doesn't have any other obvious side effects: I suspect I've examined them all.