### PR TITLE
ensure an exact pattern match for loggers

### DIFF
--- a/config/log_config.go
+++ b/config/log_config.go
@@ -39,6 +39,7 @@ func UpdateLoggerRegistry(logConfig []LoggerPatternConfig, loggerRegistry map[st
 		}
 
 		var matcher strings.Builder
+		matcher.WriteRune('^')
 		for _, ch := range lpc.Pattern {
 			switch ch {
 			case '*':
@@ -49,6 +50,7 @@ func UpdateLoggerRegistry(logConfig []LoggerPatternConfig, loggerRegistry map[st
 				matcher.WriteRune(ch)
 			}
 		}
+		matcher.WriteRune('$')
 		r, err := regexp.Compile(matcher.String())
 		if err != nil {
 			return nil, err

--- a/config/log_config_test.go
+++ b/config/log_config_test.go
@@ -161,6 +161,21 @@ func TestUpdateLoggerRegistry(t *testing.T) {
 			expectedMatches: map[string]string{},
 			doesError:       true,
 		},
+		{
+			loggerConfig: []LoggerPatternConfig{
+				{
+					Pattern: "a.b",
+					Level:   "DEBUG",
+				},
+			},
+			loggerNames: []string{
+				"a.b.c",
+			},
+			expectedMatches: map[string]string{
+				"a.b.c": "INFO",
+			},
+			doesError: false,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
When matching a dynamic regex to a logger name, we want to make sure that the full logger name matches the pattern, not just a subsection of it.