### PR TITLE
Fix debug arm panic

### DIFF
--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
-
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	armpb "go.viam.com/api/component/arm/v1"

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -626,60 +626,43 @@ func TestConfigRemoteWithTLSAuth(t *testing.T) {
 	test.That(t, convMap, test.ShouldResemble, armStatus)
 }
 
-type dummyArm struct {
-	arm.Arm
-	stopCount int
-	extra     map[string]interface{}
-	channel   chan struct{}
-}
-
-func (da *dummyArm) Name() resource.Name {
-	return arm.Named("bad")
-}
-
-func (da *dummyArm) MoveToPosition(
-	ctx context.Context,
-	pose spatialmath.Pose,
-	extra map[string]interface{},
-) error {
-	return nil
-}
-
-func (da *dummyArm) MoveToJointPositions(ctx context.Context, positionDegs *armpb.JointPositions, extra map[string]interface{}) error {
-	return nil
-}
-
-func (da *dummyArm) JointPositions(ctx context.Context, extra map[string]interface{}) (*armpb.JointPositions, error) {
-	return nil, errors.New("fake error")
-}
-
-func (da *dummyArm) ModelFrame() referenceframe.Model {
-	return nil
-}
-
-func (da *dummyArm) Stop(ctx context.Context, extra map[string]interface{}) error {
-	da.stopCount++
-	da.extra = extra
-	return nil
-}
-
-func (da *dummyArm) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
-	close(da.channel)
-	<-ctx.Done()
-	return nil, ctx.Err()
-}
-
-func (da *dummyArm) Close(ctx context.Context) error {
-	return nil
-}
-
 func TestStopAll(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	channel := make(chan struct{})
 
 	model := resource.DefaultModelFamily.WithModel(utils.RandomAlphaString(8))
-	dummyArm1 := dummyArm{channel: channel}
-	dummyArm2 := dummyArm{channel: channel}
+
+	var (
+		stopCount1 int
+		stopCount2 int
+
+		extraOptions1 map[string]interface{}
+		extraOptions2 map[string]interface{}
+	)
+	dummyArm1 := &inject.Arm{
+		StopFunc: func(ctx context.Context, extra map[string]interface{}) error {
+			stopCount1++
+			extraOptions1 = extra
+			return nil
+		},
+		DoFunc: func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+			close(channel)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	dummyArm2 := &inject.Arm{
+		StopFunc: func(ctx context.Context, extra map[string]interface{}) error {
+			stopCount2++
+			extraOptions2 = extra
+			return nil
+		},
+		DoFunc: func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+			close(channel)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
 	resource.RegisterComponent(
 		arm.API,
 		model,
@@ -690,9 +673,9 @@ func TestStopAll(t *testing.T) {
 			logger logging.Logger,
 		) (arm.Arm, error) {
 			if conf.Name == "arm1" {
-				return &dummyArm1, nil
+				return dummyArm1, nil
 			}
-			return &dummyArm2, nil
+			return dummyArm2, nil
 		}})
 
 	armConfig := fmt.Sprintf(`{
@@ -720,20 +703,20 @@ func TestStopAll(t *testing.T) {
 	ctx := context.Background()
 	r := setupLocalRobot(t, ctx, cfg, logger)
 
-	test.That(t, dummyArm1.stopCount, test.ShouldEqual, 0)
-	test.That(t, dummyArm2.stopCount, test.ShouldEqual, 0)
+	test.That(t, stopCount1, test.ShouldEqual, 0)
+	test.That(t, stopCount2, test.ShouldEqual, 0)
 
-	test.That(t, dummyArm1.extra, test.ShouldBeNil)
-	test.That(t, dummyArm2.extra, test.ShouldBeNil)
+	test.That(t, extraOptions1, test.ShouldBeNil)
+	test.That(t, extraOptions2, test.ShouldBeNil)
 
 	err = r.StopAll(ctx, map[resource.Name]map[string]interface{}{arm.Named("arm2"): {"foo": "bar"}})
 	test.That(t, err, test.ShouldBeNil)
 
-	test.That(t, dummyArm1.stopCount, test.ShouldEqual, 1)
-	test.That(t, dummyArm2.stopCount, test.ShouldEqual, 1)
+	test.That(t, stopCount1, test.ShouldEqual, 1)
+	test.That(t, stopCount2, test.ShouldEqual, 1)
 
-	test.That(t, dummyArm1.extra, test.ShouldBeNil)
-	test.That(t, dummyArm2.extra, test.ShouldResemble, map[string]interface{}{"foo": "bar"})
+	test.That(t, extraOptions1, test.ShouldBeNil)
+	test.That(t, extraOptions2, test.ShouldResemble, map[string]interface{}{"foo": "bar"})
 
 	// Test OPID cancellation
 	options, _, addr := robottestutils.CreateBaseOptionsAndListener(t)

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
+
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	armpb "go.viam.com/api/component/arm/v1"
@@ -651,6 +652,10 @@ func (da *dummyArm) MoveToJointPositions(ctx context.Context, positionDegs *armp
 
 func (da *dummyArm) JointPositions(ctx context.Context, extra map[string]interface{}) (*armpb.JointPositions, error) {
 	return nil, errors.New("fake error")
+}
+
+func (da *dummyArm) ModelFrame() referenceframe.Model {
+	return nil
 }
 
 func (da *dummyArm) Stop(ctx context.Context, extra map[string]interface{}) error {


### PR DESCRIPTION
otherwise we were getting
```
    logger.go:130: 2024-07-15T12:18:51.959-0400 ERROR   rpc/server.go:320       panicked while calling unary server method      {"error": "rpc error: code = Internal desc = runtime error: invalid memory address or nil pointer dereference", "errorVerbose": "rpc error: code = Internal desc = runtime error: invalid memory address or nil pointer dereference\ngo.viam.com/utils/rpc.NewServer.func1\n\t/Users/cheukt/go/pkg/mod/go.viam.com/utils@v0.1.84/rpc/server.go:320\ngo.viam.com/utils/rpc.NewServer.WithRecoveryHandler.func10.1\n\t/Users/cheukt/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/recovery/options.go:33\ngithub.com/grpc-ecosystem/go-grpc-middleware/recovery.recoverFrom\n\t/Users/cheukt/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/recovery/interceptors.go:61\ngithub.com/grpc-ecosystem/go-grpc-middleware/recovery.UnaryServerInterceptor.func1.1\n\t/Users/cheukt/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/recovery/interceptors.go:29\nruntime.gopanic\n\t/opt/homebrew/Cellar/go/1.22.4/libexec/src/runtime/panic.go:770\nruntime.panicmem\n\t/opt/homebrew/Cellar/go/1.22.4/libexec/src/runtime/panic.go:261\nruntime.sigpanic\n\t/opt/homebrew/Cellar/go/1.22.4/libexec/src/runtime/signal_unix.go:881\ngo.viam.com/rdk/robot/impl.(*dummyArm).ModelFrame\n\t<autogenerated>:1\ngo.viam.com/rdk/components/arm.(*serviceServer).GetKinematics\n\t/Users/cheukt/repos/rdk-cheuk/components/arm/server.go:144\ngo.viam.com/api/component/arm/v1._ArmService_GetKinematics_Handler.func1\n\t/Users/cheukt/go/pkg/mod/go.viam.com/api@v0.1.322/component/arm/v1/arm_grpc.pb.go:347\ngo.viam.com/rdk/logging.UnaryServerInterceptor\n\t/Users/cheukt/repos/rdk-cheuk/logging/context.go:88\ngo.viam.com/rdk/robot/web.(*webService).initRPCOptions.ChainUnaryServer.func11.1\n\t/Users/cheukt/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48\ngo.viam.com/rdk/operation.(*Manager).UnaryServerInterceptor\n\t/Users/cheukt/repos/rdk-cheuk/operation/web.go:61\ngo.viam.com/rdk/robot/web.(*webService).initRPCOptions.ChainUnaryServer.func11.1\n\t/Users/cheukt/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48\ngo.viam.com/rdk/robot.(*SessionManager).UnaryServerInterceptor\n\t/Users/cheukt/repos/rdk-cheuk/robot/session_web.go:150\ngo.viam.com/rdk/robot/web.(*webService).initRPCOptions.ChainUnaryServer.func11.1\n\t/Users/cheukt/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48\ngo.viam.com/rdk/grpc.EnsureTimeoutUnaryServerInterceptor\n\t/Users/cheukt/repos/rdk-cheuk/grpc/interceptors.go:26\ngo.viam.com/rdk/robot/web.(*webService).initRPCOptions.ChainUnaryServer.func11\n\t/Users/cheukt/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:53\ngo.viam.com/utils/rpc.NewServer.func2\n\t/Users/cheukt/go/pkg/mod/go.viam.com/utils@v0.1.84/rpc/server.go:342\ngo.viam.com/utils/rpc.NewServer.ChainUnaryServer.func26.1\n\t/Users/cheukt/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48\ngo.viam.com/utils/rpc.NewServer.UnaryServerTracingInterceptor.func12\n\t/Users/cheukt/go/pkg/mod/go.viam.com/utils@v0.1.84/rpc/server_interceptors.go:26\ngo.viam.com/utils/rpc.NewServer.ChainUnaryServer.func26.1\n\t/Users/cheukt/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48\ngo.viam.com/utils/rpc.NewServer.unaryServerCodeInterceptor.func11\n\t/Users/cheukt/go/pkg/mod/go.viam.com/utils@v0.1.84/rpc/server.go:900\ngo.viam.com/utils/rpc.NewServer.ChainUnaryServer.func26.1\n\t/Users/cheukt/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48\ngithub.com/grpc-ecosystem/go-grpc-middleware/logging/zap.UnaryServerInterceptor.func1\n\t/Users/cheukt/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/logging/zap/server_interceptors.go:31\ngo.viam.com/utils/rpc.NewServer.ChainUnaryServer.func26.1\n\t/Users/cheukt/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48\ngithub.com/grpc-ecosystem/go-grpc-middleware/recovery.UnaryServerInterceptor.func1\n\t/Users/cheukt/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/recovery/interceptors.go:33\ngo.viam.com/utils/rpc.NewServer.ChainUnaryServer.func26\n\t/Users/cheukt/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:53\ngo.viam.com/api/component/arm/v1._ArmService_GetKinematics_Handler\n\t/Users/cheukt/go/pkg/mod/go.viam.com/api@v0.1.322/component/arm/v1/arm_grpc.pb.go:349\ngo.viam.com/utils/rpc.(*webrtcServer).RegisterService.(*webrtcServer).unaryHandler.func1\n\t/Users/cheukt/go/pkg/mod/go.viam.com/utils@v0.1.84/rpc/wrtc_server.go:220\ngo.viam.com/utils/rpc.(*webrtcServerStream).processHeaders.func1\n\t/Users/cheukt/go/pkg/mod/go.viam.com/utils@v0.1.84/rpc/wrtc_server_stream.go:307\ngo.viam.com/utils.PanicCapturingGoWithCallback.func1\n\t/Users/cheukt/go/pkg/mod/go.viam.com/utils@v0.1.84/runtime.go:164"}
    logger.go:130: 2024-07-15T12:18:51.960-0400 ERROR   webrtc  zap/options.go:212      finished client unary call      {"ch": 0, "system": "grpc", "span.kind": "client", "grpc.service": "viam.component.arm.v1.ArmService", "grpc.method": "GetKinematics", "error": "rpc error: code = Internal desc = runtime error: invalid memory address or nil pointer dereference", "grpc.code": "Internal", "grpc.time_ms": 1.53}
    client.go:54: 2024-07-15T12:18:51.960-0400  ERROR           arm/client.go:54        error getting model for arm; will not allow certain methods     {"err":"rpc error: code = Internal desc = runtime error: invalid memory address or nil pointer dereference"}
```