### PR TITLE
Rsdk-8170: Create commonReading for GPS 

### DIFF
--- a/components/movementsensor/fake/movementsensor.go
+++ b/components/movementsensor/fake/movementsensor.go
@@ -115,9 +115,3 @@ func (f *MovementSensor) Start(ctx context.Context) error { return nil }
 func (f *MovementSensor) Close(ctx context.Context) error {
 	return nil
 }
-
-// ReadFix returns the fix of a fake gps movementsensor.
-func (f *MovementSensor) ReadFix(ctx context.Context) (int, error) { return 1, nil }
-
-// ReadSatsInView returns the number of satellites in view.
-func (f *MovementSensor) ReadSatsInView(ctx context.Context) (int, error) { return 2, nil }

--- a/components/movementsensor/gpsnmea/component.go
+++ b/components/movementsensor/gpsnmea/component.go
@@ -105,14 +105,11 @@ func (g *NMEAMovementSensor) Readings(
 		return nil, err
 	}
 
-	commonReadings, err := g.cachedData.GetCommonReadings(ctx)
-	if err != nil {
-		return nil, err
-	}
+	commonReadings := g.cachedData.GetCommonReadings(ctx)
 
-	readings["fix"] = commonReadings[gpsutils.FixValueKey]
-	readings["satellites_in_view"] = commonReadings[gpsutils.SatsInViewKey]
-	readings["satellites_in_use"] = commonReadings[gpsutils.SatsInUseKey]
+	readings["fix"] = commonReadings.FixValue
+	readings["satellites_in_view"] = commonReadings.SatsInView
+	readings["satellites_in_use"] = commonReadings.SatsInUse
 
 	return readings, nil
 }

--- a/components/movementsensor/gpsnmea/component.go
+++ b/components/movementsensor/gpsnmea/component.go
@@ -86,16 +86,6 @@ func (g *NMEAMovementSensor) CompassHeading(
 	return g.cachedData.CompassHeading(ctx, extra)
 }
 
-// ReadFix returns Fix quality of MovementSensor measurements.
-func (g *NMEAMovementSensor) ReadFix(ctx context.Context) (int, error) {
-	return g.cachedData.ReadFix(ctx)
-}
-
-// ReadSatsInView returns the number of satellites in view.
-func (g *NMEAMovementSensor) ReadSatsInView(ctx context.Context) (int, error) {
-	return g.cachedData.ReadSatsInView(ctx)
-}
-
 // Readings will use return all of the MovementSensor Readings.
 func (g *NMEAMovementSensor) Readings(
 	ctx context.Context, extra map[string]interface{},

--- a/components/movementsensor/gpsnmea/component.go
+++ b/components/movementsensor/gpsnmea/component.go
@@ -96,11 +96,6 @@ func (g *NMEAMovementSensor) ReadSatsInView(ctx context.Context) (int, error) {
 	return g.cachedData.ReadSatsInView(ctx)
 }
 
-// ReadSatsInUse returns the number of satellites in use.
-func (g *NMEAMovementSensor) ReadSatsInUse(ctx context.Context) (int, error) {
-	return g.cachedData.ReadSatsInUse(ctx)
-}
-
 // Readings will use return all of the MovementSensor Readings.
 func (g *NMEAMovementSensor) Readings(
 	ctx context.Context, extra map[string]interface{},

--- a/components/movementsensor/gpsnmea/component.go
+++ b/components/movementsensor/gpsnmea/component.go
@@ -14,13 +14,6 @@ import (
 	"go.viam.com/rdk/spatialmath"
 )
 
-// Constants for map keys
-const (
-	FixValueKey   = 1
-	SatsInViewKey = 2
-	SatsInUseKey  = 3
-)
-
 // NMEAMovementSensor allows the use of any MovementSensor chip via a DataReader.
 type NMEAMovementSensor struct {
 	resource.Named
@@ -108,32 +101,6 @@ func (g *NMEAMovementSensor) ReadSatsInUse(ctx context.Context) (int, error) {
 	return g.cachedData.ReadSatsInUse(ctx)
 }
 
-// GetCommonReadings returns a map including fix value, sats in view and sats in use.
-func (g *NMEAMovementSensor) GetCommonReadings(ctx context.Context) (map[int]interface{}, error) {
-	commonReadings := make(map[int]interface{})
-
-	fixValue, err := g.cachedData.ReadFix(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	satsInView, err := g.cachedData.ReadSatsInView(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	satsInUse, err := g.cachedData.ReadSatsInUse(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	commonReadings[FixValueKey] = fixValue
-	commonReadings[SatsInViewKey] = satsInView
-	commonReadings[SatsInUseKey] = satsInUse
-
-	return commonReadings, nil
-}
-
 // Readings will use return all of the MovementSensor Readings.
 func (g *NMEAMovementSensor) Readings(
 	ctx context.Context, extra map[string]interface{},
@@ -143,14 +110,14 @@ func (g *NMEAMovementSensor) Readings(
 		return nil, err
 	}
 
-	commonReadings, err := g.GetCommonReadings(ctx)
+	commonReadings, err := g.cachedData.GetCommonReadings(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	readings["fix"] = commonReadings[FixValueKey]
-	readings["satellites_in_view"] = commonReadings[SatsInViewKey]
-	readings["satellites_in_use"] = commonReadings[SatsInUseKey]
+	readings["fix"] = commonReadings[gpsutils.FixValueKey]
+	readings["satellites_in_view"] = commonReadings[gpsutils.SatsInViewKey]
+	readings["satellites_in_use"] = commonReadings[gpsutils.SatsInUseKey]
 
 	return readings, nil
 }

--- a/components/movementsensor/gpsnmea/gpsnmea.go
+++ b/components/movementsensor/gpsnmea/gpsnmea.go
@@ -60,9 +60,7 @@ var model = resource.DefaultModelFamily.WithModel("gps-nmea")
 // NmeaMovementSensor implements a gps that sends nmea messages for movement data.
 type NmeaMovementSensor interface {
 	movementsensor.MovementSensor
-	Close(ctx context.Context) error                 // Close MovementSensor
-	ReadFix(ctx context.Context) (int, error)        // Returns the fix quality of the current MovementSensor measurements
-	ReadSatsInView(ctx context.Context) (int, error) // Returns the number of satellites in view
+	Close(ctx context.Context) error // Close MovementSensor
 }
 
 func init() {

--- a/components/movementsensor/gpsrtk/gpsrtk.go
+++ b/components/movementsensor/gpsrtk/gpsrtk.go
@@ -336,35 +336,6 @@ func (g *gpsrtk) Orientation(ctx context.Context, extra map[string]interface{}) 
 	return g.cachedData.Orientation(ctx, extra)
 }
 
-// readFix passthrough.
-func (g *gpsrtk) readFix(ctx context.Context) (int, error) {
-	lastError := g.err.Get()
-	if lastError != nil {
-		return 0, lastError
-	}
-	return g.cachedData.ReadFix(ctx)
-}
-
-// readSatsInView returns the number of satellites in view.
-func (g *gpsrtk) readSatsInView(ctx context.Context) (int, error) {
-	lastError := g.err.Get()
-	if lastError != nil {
-		return 0, lastError
-	}
-
-	return g.cachedData.ReadSatsInView(ctx)
-}
-
-// readSatsInUse returns the number of satellites in use.
-func (g *gpsrtk) readSatsInUse(ctx context.Context) (int, error) {
-	lastError := g.err.Get()
-	if lastError != nil {
-		return 0, lastError
-	}
-
-	return g.cachedData.ReadSatsInUse(ctx)
-}
-
 // Properties passthrough.
 func (g *gpsrtk) Properties(ctx context.Context, extra map[string]interface{}) (*movementsensor.Properties, error) {
 	lastError := g.err.Get()
@@ -393,24 +364,14 @@ func (g *gpsrtk) Readings(ctx context.Context, extra map[string]interface{}) (ma
 		return nil, err
 	}
 
-	fix, err := g.readFix(ctx)
+	commonReadings, err := g.cachedData.GetCommonReadings(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	satsInView, err := g.readSatsInView(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	satsInUse, err := g.readSatsInUse(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	readings["fix"] = fix
-	readings["satellites_in_view"] = satsInView
-	readings["satellites_in_use"] = satsInUse
+	readings["fix"] = commonReadings[gpsutils.FixValueKey]
+	readings["satellites_in_view"] = commonReadings[gpsutils.SatsInViewKey]
+	readings["satellites_in_use"] = commonReadings[gpsutils.SatsInUseKey]
 
 	return readings, nil
 }

--- a/components/movementsensor/gpsrtk/gpsrtk.go
+++ b/components/movementsensor/gpsrtk/gpsrtk.go
@@ -364,14 +364,11 @@ func (g *gpsrtk) Readings(ctx context.Context, extra map[string]interface{}) (ma
 		return nil, err
 	}
 
-	commonReadings, err := g.cachedData.GetCommonReadings(ctx)
-	if err != nil {
-		return nil, err
-	}
+	commonReadings := g.cachedData.GetCommonReadings(ctx)
 
-	readings["fix"] = commonReadings[gpsutils.FixValueKey]
-	readings["satellites_in_view"] = commonReadings[gpsutils.SatsInViewKey]
-	readings["satellites_in_use"] = commonReadings[gpsutils.SatsInUseKey]
+	readings["fix"] = commonReadings.FixValue
+	readings["satellites_in_view"] = commonReadings.SatsInView
+	readings["satellites_in_use"] = commonReadings.SatsInUse
 
 	return readings, nil
 }

--- a/components/movementsensor/gpsutils/cachedData.go
+++ b/components/movementsensor/gpsutils/cachedData.go
@@ -217,20 +217,6 @@ func (g *CachedData) CompassHeading(
 	return currentHeading, nil
 }
 
-// ReadFix returns Fix quality of MovementSensor measurements.
-func (g *CachedData) ReadFix(ctx context.Context) (int, error) {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
-	return g.nmeaData.FixQuality, nil
-}
-
-// ReadSatsInView returns the number of satellites in view.
-func (g *CachedData) ReadSatsInView(ctx context.Context) (int, error) {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
-	return g.nmeaData.SatsInView, nil
-}
-
 // GetCommonReadings returns a map including fix value, sats in view and sats in use.
 func (g *CachedData) GetCommonReadings(ctx context.Context) *CommonReadings {
 	g.mu.Lock()

--- a/components/movementsensor/gpsutils/cachedData.go
+++ b/components/movementsensor/gpsutils/cachedData.go
@@ -15,6 +15,13 @@ import (
 	"go.viam.com/rdk/utils"
 )
 
+// Constants for map keys
+const (
+	FixValueKey   = 1
+	SatsInViewKey = 2
+	SatsInUseKey  = 3
+)
+
 var errNilLocation = errors.New("nil gps location, check nmea message parsing")
 
 // DataReader represents a way to get data from a GPS NMEA device. We can read data from it using
@@ -229,6 +236,32 @@ func (g *CachedData) ReadSatsInUse(ctx context.Context) (int, error) {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
 	return g.nmeaData.SatsInUse, nil
+}
+
+// GetCommonReadings returns a map including fix value, sats in view and sats in use.
+func (g *CachedData) GetCommonReadings(ctx context.Context) (map[int]interface{}, error) {
+	commonReadings := make(map[int]interface{})
+
+	fixValue, err := g.ReadFix(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	satsInView, err := g.ReadSatsInView(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	satsInUse, err := g.ReadSatsInUse(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	commonReadings[FixValueKey] = fixValue
+	commonReadings[SatsInViewKey] = satsInView
+	commonReadings[SatsInUseKey] = satsInUse
+
+	return commonReadings, nil
 }
 
 // Properties returns what movement sensor capabilities we have.

--- a/components/movementsensor/gpsutils/cachedData.go
+++ b/components/movementsensor/gpsutils/cachedData.go
@@ -15,7 +15,7 @@ import (
 	"go.viam.com/rdk/utils"
 )
 
-// Constants for map keys
+// Constants for map keys.
 const (
 	FixValueKey   = 1
 	SatsInViewKey = 2

--- a/components/movementsensor/gpsutils/cachedData.go
+++ b/components/movementsensor/gpsutils/cachedData.go
@@ -231,35 +231,13 @@ func (g *CachedData) ReadSatsInView(ctx context.Context) (int, error) {
 	return g.nmeaData.SatsInView, nil
 }
 
-// ReadSatsInUse returns the number of satellites in use to calculate fix type.
-func (g *CachedData) ReadSatsInUse(ctx context.Context) (int, error) {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
-	return g.nmeaData.SatsInUse, nil
-}
-
 // GetCommonReadings returns a map including fix value, sats in view and sats in use.
 func (g *CachedData) GetCommonReadings(ctx context.Context) (map[int]interface{}, error) {
 	commonReadings := make(map[int]interface{})
 
-	fixValue, err := g.ReadFix(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	satsInView, err := g.ReadSatsInView(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	satsInUse, err := g.ReadSatsInUse(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	commonReadings[FixValueKey] = fixValue
-	commonReadings[SatsInViewKey] = satsInView
-	commonReadings[SatsInUseKey] = satsInUse
+	commonReadings[FixValueKey] = g.nmeaData.FixQuality
+	commonReadings[SatsInViewKey] = g.nmeaData.SatsInView
+	commonReadings[SatsInUseKey] = g.nmeaData.SatsInUse
 
 	return commonReadings, nil
 }

--- a/components/movementsensor/gpsutils/cachedData_test.go
+++ b/components/movementsensor/gpsutils/cachedData_test.go
@@ -59,9 +59,10 @@ func TestReadingsSerial(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, speed1.Y, test.ShouldEqual, speed)
 
-	fix1, err := g.ReadFix(ctx)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, fix1, test.ShouldEqual, fix)
+	readings := g.GetCommonReadings(ctx)
+	test.That(t, readings.FixValue, test.ShouldEqual, fix)
+	test.That(t, readings.SatsInUse, test.ShouldEqual, activeSats)
+	test.That(t, readings.SatsInView, test.ShouldEqual, totalSats)
 }
 
 func TestPosition(t *testing.T) {


### PR DESCRIPTION
1. Added a const values for the `commonReadings` map in `gpsutils`
2. Created `GetCommonReadings` function. This includes `satsInView,` `fixQuality` and `satsInUse.` 
3. Removed `ReadSatsInUse` function