### PR TITLE
DATA-2790: CLI Data export limit config

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -86,6 +86,7 @@ const (
 	dataFlagMimeTypes                      = "mime-types"
 	dataFlagStart                          = "start"
 	dataFlagEnd                            = "end"
+	dataFlagChunkLimit                     = "chunk-limit"
 	dataFlagParallelDownloads              = "parallel"
 	dataFlagTags                           = "tags"
 	dataFlagBboxLabels                     = "bbox-labels"
@@ -393,6 +394,11 @@ var app = &cli.App{
 							Name:     dataFlagDestination,
 							Required: true,
 							Usage:    "output directory for downloaded data",
+						},
+						&cli.UintFlag{
+							Name:  dataFlagChunkLimit,
+							Usage: "maximum number of results per download chunk (tabular data only)",
+							Value: 100000,
 						},
 						&cli.UintFlag{
 							Name:  dataFlagParallelDownloads,

--- a/cli/app.go
+++ b/cli/app.go
@@ -397,7 +397,7 @@ var app = &cli.App{
 						},
 						&cli.UintFlag{
 							Name:  dataFlagChunkLimit,
-							Usage: "maximum number of results per download chunk (tabular data only)",
+							Usage: "maximum number of results per download request (tabular data only)",
 							Value: 100000,
 						},
 						&cli.UintFlag{

--- a/cli/app.go
+++ b/cli/app.go
@@ -396,7 +396,7 @@ var app = &cli.App{
 						},
 						&cli.UintFlag{
 							Name:  dataFlagParallelDownloads,
-							Usage: "number of download requests to make in parallel",
+							Usage: "number of download requests to make in parallel (binary data only)",
 							Value: 100,
 						},
 						&cli.StringSliceFlag{

--- a/cli/data.go
+++ b/cli/data.go
@@ -35,7 +35,7 @@ const (
 	metadataDir   = "metadata"
 	maxRetryCount = 5
 	logEveryN     = 100
-	maxLimit      = 100000
+	maxLimit      = 100
 
 	dataTypeBinary  = "binary"
 	dataTypeTabular = "tabular"
@@ -72,7 +72,7 @@ func (c *viamClient) dataExportAction(cCtx *cli.Context) error {
 			return err
 		}
 	case dataTypeTabular:
-		if err := c.tabularData(cCtx.Path(dataFlagDestination), filter); err != nil {
+		if err := c.tabularData(cCtx.Path(dataFlagDestination), filter, cCtx.Uint(dataFlagChunkLimit)); err != nil {
 			return err
 		}
 	default:
@@ -584,7 +584,7 @@ func filenameForDownload(meta *datapb.BinaryMetadata) string {
 }
 
 // tabularData downloads binary data matching filter to dst.
-func (c *viamClient) tabularData(dst string, filter *datapb.Filter) error {
+func (c *viamClient) tabularData(dst string, filter *datapb.Filter, limit uint) error {
 	if err := c.ensureLoggedIn(); err != nil {
 		return err
 	}
@@ -612,7 +612,7 @@ func (c *viamClient) tabularData(dst string, filter *datapb.Filter) error {
 			resp, err = c.dataClient.TabularDataByFilter(context.Background(), &datapb.TabularDataByFilterRequest{
 				DataRequest: &datapb.DataRequest{
 					Filter: filter,
-					Limit:  maxLimit,
+					Limit:  uint64(limit),
 					Last:   last,
 				},
 				CountOnly: false,

--- a/cli/data.go
+++ b/cli/data.go
@@ -35,7 +35,7 @@ const (
 	metadataDir   = "metadata"
 	maxRetryCount = 5
 	logEveryN     = 100
-	maxLimit      = 100
+	maxLimit      = 100000
 
 	dataTypeBinary  = "binary"
 	dataTypeTabular = "tabular"


### PR DESCRIPTION
Users (ex. SolEng) were limited to downloads of 100 results/per request, leading to painfully slow data export times. Bumped the default way up + made configurable via flag