### PR TITLE
RSDK-8087: add wrappers over registry methods + resolve cyclic dependencies 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -37,7 +37,7 @@ type Config struct {
 	Network    NetworkConfig
 	Auth       AuthConfig
 	Debug      bool
-	LogConfig  []LoggerPatternConfig
+	LogConfig  []logging.LoggerPatternConfig
 
 	ConfigFilePath string
 
@@ -69,19 +69,19 @@ type Config struct {
 
 // NOTE: This data must be maintained with what is in Config.
 type configData struct {
-	Cloud               *Cloud                `json:"cloud,omitempty"`
-	Modules             []Module              `json:"modules,omitempty"`
-	Remotes             []Remote              `json:"remotes,omitempty"`
-	Components          []resource.Config     `json:"components,omitempty"`
-	Processes           []pexec.ProcessConfig `json:"processes,omitempty"`
-	Services            []resource.Config     `json:"services,omitempty"`
-	Packages            []PackageConfig       `json:"packages,omitempty"`
-	Network             NetworkConfig         `json:"network"`
-	Auth                AuthConfig            `json:"auth"`
-	Debug               bool                  `json:"debug,omitempty"`
-	DisablePartialStart bool                  `json:"disable_partial_start"`
-	EnableWebProfile    bool                  `json:"enable_web_profile"`
-	LogConfig           []LoggerPatternConfig `json:"log,omitempty"`
+	Cloud               *Cloud                        `json:"cloud,omitempty"`
+	Modules             []Module                      `json:"modules,omitempty"`
+	Remotes             []Remote                      `json:"remotes,omitempty"`
+	Components          []resource.Config             `json:"components,omitempty"`
+	Processes           []pexec.ProcessConfig         `json:"processes,omitempty"`
+	Services            []resource.Config             `json:"services,omitempty"`
+	Packages            []PackageConfig               `json:"packages,omitempty"`
+	Network             NetworkConfig                 `json:"network"`
+	Auth                AuthConfig                    `json:"auth"`
+	Debug               bool                          `json:"debug,omitempty"`
+	DisablePartialStart bool                          `json:"disable_partial_start"`
+	EnableWebProfile    bool                          `json:"enable_web_profile"`
+	LogConfig           []logging.LoggerPatternConfig `json:"log,omitempty"`
 }
 
 // AppValidationStatus refers to the.

--- a/config/proto_conversions.go
+++ b/config/proto_conversions.go
@@ -936,7 +936,7 @@ func logAnyFragmentOverwriteErrors(logger logging.Logger, overwriteFragmentStatu
 }
 
 // LogConfigToProto converts a LoggerPatternConfig type to its proto equivalent.
-func LogConfigToProto(logConfig *LoggerPatternConfig) (*pb.LogPatternConfig, error) {
+func LogConfigToProto(logConfig *logging.LoggerPatternConfig) (*pb.LogPatternConfig, error) {
 	return &pb.LogPatternConfig{
 		Pattern: logConfig.Pattern,
 		Level:   logConfig.Level,
@@ -944,8 +944,8 @@ func LogConfigToProto(logConfig *LoggerPatternConfig) (*pb.LogPatternConfig, err
 }
 
 // LogConfigFromProto converts a proto LoggerPatternConfig to the rdk version.
-func LogConfigFromProto(proto *pb.LogPatternConfig) (*LoggerPatternConfig, error) {
-	return &LoggerPatternConfig{
+func LogConfigFromProto(proto *pb.LogPatternConfig) (*logging.LoggerPatternConfig, error) {
+	return &logging.LoggerPatternConfig{
 		Pattern: proto.Pattern,
 		Level:   proto.Level,
 	}, nil

--- a/config/proto_conversions_test.go
+++ b/config/proto_conversions_test.go
@@ -207,7 +207,7 @@ var testPackageConfig = PackageConfig{
 	Type:    PackageTypeModule,
 }
 
-var testLogConfig = LoggerPatternConfig{
+var testLogConfig = logging.LoggerPatternConfig{
 	Pattern: "rdk.resource_manager.modmanager",
 	Level:   "WARN",
 }

--- a/config/reader.go
+++ b/config/reader.go
@@ -610,7 +610,9 @@ func processConfig(unprocessedConfig *Config, fromCloud bool, logger logging.Log
 		}
 	}
 
-	logging.UpdateLoggerRegistry(cfg.LogConfig)
+	if err := logging.UpdateLoggerRegistry(cfg.LogConfig); err != nil {
+		return nil, err
+	}
 
 	// now that the attribute maps are converted, validate configs and get implicit dependencies for builtin resource models
 	if err := cfg.Ensure(fromCloud, logger); err != nil {

--- a/config/reader.go
+++ b/config/reader.go
@@ -610,6 +610,8 @@ func processConfig(unprocessedConfig *Config, fromCloud bool, logger logging.Log
 		}
 	}
 
+	logging.UpdateLoggerRegistry(cfg.LogConfig)
+
 	// now that the attribute maps are converted, validate configs and get implicit dependencies for builtin resource models
 	if err := cfg.Ensure(fromCloud, logger); err != nil {
 		return nil, err

--- a/config/reader_test.go
+++ b/config/reader_test.go
@@ -235,6 +235,33 @@ func TestCacheInvalidation(t *testing.T) {
 	test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
 }
 
+func TestProcessLoggerUpdate(t *testing.T) {
+	testLogger := logging.NewTestLogger(t)
+
+	// register a fake logger in the global registry
+	fakeLogger := logging.NewLogger("fakelogger")
+	fakeLogger.SetLevel(logging.INFO)
+	logging.RegisterLogger("fakelogger", fakeLogger)
+
+	logCfg := []logging.LoggerPatternConfig{
+		{
+			Pattern: "fakelogger",
+			Level:   "ERROR",
+		},
+	}
+	unprocessedCfg := Config{
+		LogConfig: logCfg,
+	}
+
+	// process the logger config, should set fake logger to new level
+	_, err := processConfig(&unprocessedCfg, false, testLogger)
+	test.That(t, err, test.ShouldBeNil)
+
+	// verify that the logger config was parsed, and the new level was set
+	test.That(t, fakeLogger.GetLevel().String(), test.ShouldEqual, "Error")
+	test.That(t, logging.DeRegisterLogger("fakelogger"), test.ShouldBeTrue)
+}
+
 func TestShouldCheckForCert(t *testing.T) {
 	cloud1 := Cloud{
 		ManagedBy:        "acme",

--- a/config/reader_test.go
+++ b/config/reader_test.go
@@ -259,7 +259,7 @@ func TestProcessLoggerUpdate(t *testing.T) {
 
 	// verify that the logger config was parsed, and the new level was set
 	test.That(t, fakeLogger.GetLevel().String(), test.ShouldEqual, "Error")
-	test.That(t, logging.DeRegisterLogger("fakelogger"), test.ShouldBeTrue)
+	test.That(t, logging.DeregisterLogger("fakelogger"), test.ShouldBeTrue)
 }
 
 func TestShouldCheckForCert(t *testing.T) {

--- a/logging/impl.go
+++ b/logging/impl.go
@@ -78,7 +78,7 @@ func (imp *impl) Sublogger(subname string) Logger {
 		imp.testHelper,
 	}
 
-	loggerManager.registerLogger(newName, sublogger)
+	RegisterLogger(newName, sublogger)
 
 	return sublogger
 }

--- a/logging/log_config.go
+++ b/logging/log_config.go
@@ -1,12 +1,9 @@
-package config
+package logging
 
 import (
+	"errors"
 	"regexp"
 	"strings"
-
-	"github.com/pkg/errors"
-
-	"go.viam.com/rdk/logging"
 )
 
 // LoggerPatternConfig is an instance of a level specification for a given logger.
@@ -29,13 +26,10 @@ func validatePattern(pattern string) bool {
 	return loggerPatternRegexp.MatchString(pattern)
 }
 
-// UpdateLoggerRegistry updates the logger registry if necessary  with the specified logConfig.
-func UpdateLoggerRegistry(logConfig []LoggerPatternConfig, loggerRegistry map[string]logging.Logger) (map[string]logging.Logger, error) {
-	newLogRegistry := make(map[string]logging.Logger)
-
+func (lr *loggerRegistry) updateLoggerRegistry(logConfig []LoggerPatternConfig) error {
 	for _, lpc := range logConfig {
 		if !validatePattern(lpc.Pattern) {
-			return nil, errors.New("failed to validate a pattern")
+			return errors.New("failed to validate a pattern")
 		}
 
 		var matcher strings.Builder
@@ -53,22 +47,24 @@ func UpdateLoggerRegistry(logConfig []LoggerPatternConfig, loggerRegistry map[st
 		matcher.WriteRune('$')
 		r, err := regexp.Compile(matcher.String())
 		if err != nil {
-			return nil, err
+			return err
 		}
 
-		for name, logger := range loggerRegistry {
-			if _, ok := newLogRegistry[name]; !ok {
-				newLogRegistry[name] = logger
-			}
+		for _, name := range lr.getRegisteredLoggerNames() {
 			if r.MatchString(name) {
-				level, err := logging.LevelFromString(lpc.Level)
+				level, err := LevelFromString(lpc.Level)
 				if err != nil {
-					return nil, err
+					return err
 				}
-				newLogRegistry[name].SetLevel(level)
+				lr.updateLoggerLevel(name, level)
 			}
 		}
 	}
 
-	return newLogRegistry, nil
+	return nil
+}
+
+// UpdateLoggerRegistry updates the logger registry if necessary  with the specified logConfig.
+func UpdateLoggerRegistry(logConfig []LoggerPatternConfig) {
+	loggerManager.updateLoggerRegistry(logConfig)
 }

--- a/logging/log_config.go
+++ b/logging/log_config.go
@@ -56,7 +56,10 @@ func (lr *loggerRegistry) updateLoggerRegistry(logConfig []LoggerPatternConfig) 
 				if err != nil {
 					return err
 				}
-				lr.updateLoggerLevel(name, level)
+				err = lr.updateLoggerLevel(name, level)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -65,6 +68,6 @@ func (lr *loggerRegistry) updateLoggerRegistry(logConfig []LoggerPatternConfig) 
 }
 
 // UpdateLoggerRegistry updates the logger registry if necessary  with the specified logConfig.
-func UpdateLoggerRegistry(logConfig []LoggerPatternConfig) {
-	loggerManager.updateLoggerRegistry(logConfig)
+func UpdateLoggerRegistry(logConfig []LoggerPatternConfig) error {
+	return loggerManager.updateLoggerRegistry(logConfig)
 }

--- a/logging/logger_manager.go
+++ b/logging/logger_manager.go
@@ -25,6 +25,16 @@ func (lr *loggerRegistry) registerLogger(name string, logger Logger) {
 	lr.loggers[name] = logger
 }
 
+func (lr *loggerRegistry) deregisterLogger(name string) bool {
+	lr.mu.Lock()
+	defer lr.mu.Unlock()
+	_, ok := lr.loggers[name]
+	if ok {
+		delete(lr.loggers, name)
+	}
+	return ok
+}
+
 func (lr *loggerRegistry) loggerNamed(name string) (logger Logger, ok bool) {
 	lr.mu.RLock()
 	defer lr.mu.RUnlock()
@@ -58,6 +68,11 @@ func (lr *loggerRegistry) getRegisteredLoggerNames() []string {
 // RegisterLogger registers a new logger with a given name.
 func RegisterLogger(name string, logger Logger) {
 	loggerManager.registerLogger(name, logger)
+}
+
+// DeRegisterLogger attempts to remove a logger from the registry and returns a boolean denoting whether it succeeded.
+func DeRegisterLogger(name string) bool {
+	return loggerManager.deregisterLogger(name)
 }
 
 // LoggerNamed returns logger with specified name if exists.

--- a/logging/logger_manager.go
+++ b/logging/logger_manager.go
@@ -42,15 +42,19 @@ func (lr *loggerRegistry) updateLoggerLevel(name string, level Level) error {
 	return nil
 }
 
-// Exported Functions specifically for use on global logger manager
+// Exported Functions specifically for use on global logger manager.
+
+// RegisterLogger registers a new logger with a given name
 func RegisterLogger(name string, logger Logger) {
 	loggerManager.registerLogger(name, logger)
 }
 
+// LoggerNamed returns logger with specified name if exists
 func LoggerNamed(name string) (logger Logger, ok bool) {
 	return loggerManager.loggerNamed(name)
 }
 
+// UpdateLoggerLevel assigns level to appropriate logger in the registry
 func UpdateLoggerLevel(name string, level Level) error {
 	return loggerManager.updateLoggerLevel(name, level)
 }

--- a/logging/logger_manager.go
+++ b/logging/logger_manager.go
@@ -43,6 +43,16 @@ func (lr *loggerRegistry) updateLoggerLevel(name string, level Level) error {
 	return nil
 }
 
+func (lr *loggerRegistry) GetRegisteredLoggerNames() []string {
+	lr.mu.RLock()
+	defer lr.mu.RUnlock()
+	registeredNames := make([]string, 0, len(loggerManager.loggers))
+	for name := range lr.loggers {
+		registeredNames = append(registeredNames, name)
+	}
+	return registeredNames
+}
+
 // Exported Functions specifically for use on global logger manager.
 
 // RegisterLogger registers a new logger with a given name.
@@ -58,4 +68,9 @@ func LoggerNamed(name string) (logger Logger, ok bool) {
 // UpdateLoggerLevel assigns level to appropriate logger in the registry.
 func UpdateLoggerLevel(name string, level Level) error {
 	return loggerManager.updateLoggerLevel(name, level)
+}
+
+// GetRegisteredLoggerNames returns the names of all loggers in the registry.
+func GetRegisteredLoggerNames() []string {
+	return GetRegisteredLoggerNames()
 }

--- a/logging/logger_manager.go
+++ b/logging/logger_manager.go
@@ -10,7 +10,7 @@ type loggerRegistry struct {
 	loggers map[string]Logger
 }
 
-// TODO(RSDK-8250): convert loggerManager from global variable to variable on local robot
+// TODO(RSDK-8250): convert loggerManager from global variable to variable on local robot.
 var loggerManager = newLoggerManager()
 
 func newLoggerManager() *loggerRegistry {

--- a/logging/logger_manager.go
+++ b/logging/logger_manager.go
@@ -70,8 +70,8 @@ func RegisterLogger(name string, logger Logger) {
 	loggerManager.registerLogger(name, logger)
 }
 
-// DeRegisterLogger attempts to remove a logger from the registry and returns a boolean denoting whether it succeeded.
-func DeRegisterLogger(name string) bool {
+// DeregisterLogger attempts to remove a logger from the registry and returns a boolean denoting whether it succeeded.
+func DeregisterLogger(name string) bool {
 	return loggerManager.deregisterLogger(name)
 }
 

--- a/logging/logger_manager.go
+++ b/logging/logger_manager.go
@@ -10,6 +10,7 @@ type loggerRegistry struct {
 	loggers map[string]Logger
 }
 
+// TODO(RSDK-8250): convert loggerManager from global variable to variable on local robot
 var loggerManager = newLoggerManager()
 
 func newLoggerManager() *loggerRegistry {

--- a/logging/logger_manager.go
+++ b/logging/logger_manager.go
@@ -41,3 +41,28 @@ func (lr *loggerRegistry) updateLoggerLevel(name string, level Level) error {
 	logger.SetLevel(level)
 	return nil
 }
+
+// Exported Functions specifically for use on global logger manager
+func RegisterLogger(name string, logger Logger) {
+	loggerManager.mu.Lock()
+	defer loggerManager.mu.Unlock()
+	loggerManager.loggers[name] = logger
+}
+
+func LoggerNamed(name string) (logger Logger, ok bool) {
+	loggerManager.mu.RLock()
+	defer loggerManager.mu.RUnlock()
+	logger, ok = loggerManager.loggers[name]
+	return logger, ok
+}
+
+func UpdateLoggerLevel(name string, level Level) error {
+	loggerManager.mu.RLock()
+	defer loggerManager.mu.RUnlock()
+	logger, ok := loggerManager.loggers[name]
+	if !ok {
+		return fmt.Errorf("logger named %s not recognized", name)
+	}
+	logger.SetLevel(level)
+	return nil
+}

--- a/logging/logger_manager.go
+++ b/logging/logger_manager.go
@@ -28,7 +28,7 @@ func (lr *loggerRegistry) loggerNamed(name string) (logger Logger, ok bool) {
 	lr.mu.RLock()
 	defer lr.mu.RUnlock()
 	logger, ok = lr.loggers[name]
-	return logger, ok
+	return
 }
 
 func (lr *loggerRegistry) updateLoggerLevel(name string, level Level) error {
@@ -44,25 +44,13 @@ func (lr *loggerRegistry) updateLoggerLevel(name string, level Level) error {
 
 // Exported Functions specifically for use on global logger manager
 func RegisterLogger(name string, logger Logger) {
-	loggerManager.mu.Lock()
-	defer loggerManager.mu.Unlock()
-	loggerManager.loggers[name] = logger
+	loggerManager.registerLogger(name, logger)
 }
 
 func LoggerNamed(name string) (logger Logger, ok bool) {
-	loggerManager.mu.RLock()
-	defer loggerManager.mu.RUnlock()
-	logger, ok = loggerManager.loggers[name]
-	return logger, ok
+	return loggerManager.loggerNamed(name)
 }
 
 func UpdateLoggerLevel(name string, level Level) error {
-	loggerManager.mu.RLock()
-	defer loggerManager.mu.RUnlock()
-	logger, ok := loggerManager.loggers[name]
-	if !ok {
-		return fmt.Errorf("logger named %s not recognized", name)
-	}
-	logger.SetLevel(level)
-	return nil
+	return loggerManager.updateLoggerLevel(name, level)
 }

--- a/logging/logger_manager.go
+++ b/logging/logger_manager.go
@@ -44,17 +44,17 @@ func (lr *loggerRegistry) updateLoggerLevel(name string, level Level) error {
 
 // Exported Functions specifically for use on global logger manager.
 
-// RegisterLogger registers a new logger with a given name
+// RegisterLogger registers a new logger with a given name.
 func RegisterLogger(name string, logger Logger) {
 	loggerManager.registerLogger(name, logger)
 }
 
-// LoggerNamed returns logger with specified name if exists
+// LoggerNamed returns logger with specified name if exists.
 func LoggerNamed(name string) (logger Logger, ok bool) {
 	return loggerManager.loggerNamed(name)
 }
 
-// UpdateLoggerLevel assigns level to appropriate logger in the registry
+// UpdateLoggerLevel assigns level to appropriate logger in the registry.
 func UpdateLoggerLevel(name string, level Level) error {
 	return loggerManager.updateLoggerLevel(name, level)
 }

--- a/logging/logger_manager.go
+++ b/logging/logger_manager.go
@@ -43,7 +43,7 @@ func (lr *loggerRegistry) updateLoggerLevel(name string, level Level) error {
 	return nil
 }
 
-func (lr *loggerRegistry) GetRegisteredLoggerNames() []string {
+func (lr *loggerRegistry) getRegisteredLoggerNames() []string {
 	lr.mu.RLock()
 	defer lr.mu.RUnlock()
 	registeredNames := make([]string, 0, len(loggerManager.loggers))
@@ -72,5 +72,5 @@ func UpdateLoggerLevel(name string, level Level) error {
 
 // GetRegisteredLoggerNames returns the names of all loggers in the registry.
 func GetRegisteredLoggerNames() []string {
-	return GetRegisteredLoggerNames()
+	return loggerManager.getRegisteredLoggerNames()
 }

--- a/logging/logger_manager_test.go
+++ b/logging/logger_manager_test.go
@@ -100,7 +100,7 @@ func TestUpdateLogLevel(t *testing.T) {
 
 func TestGetRegisteredNames(t *testing.T) {
 	manager := mockRegistry()
-	for _, name := range manager.GetRegisteredLoggerNames() {
+	for _, name := range manager.getRegisteredLoggerNames() {
 		_, ok := manager.loggerNamed(name)
 		test.That(t, ok, test.ShouldBeTrue)
 	}

--- a/logging/logger_manager_test.go
+++ b/logging/logger_manager_test.go
@@ -97,3 +97,11 @@ func TestUpdateLogLevel(t *testing.T) {
 	err = manager.updateLoggerLevel("slogger-1", DEBUG)
 	test.That(t, err, test.ShouldNotBeNil)
 }
+
+func TestGetRegisteredNames(t *testing.T) {
+	manager := mockRegistry()
+	for _, name := range manager.GetRegisteredLoggerNames() {
+		_, ok := manager.loggerNamed(name)
+		test.That(t, ok, test.ShouldBeTrue)
+	}
+}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -68,7 +68,7 @@ func NewLogger(name string) Logger {
 		testHelper: func() {},
 	}
 
-	loggerManager.registerLogger(name, logger)
+	RegisterLogger(name, logger)
 	return logger
 }
 
@@ -81,7 +81,7 @@ func NewDebugLogger(name string) Logger {
 		testHelper: func() {},
 	}
 
-	loggerManager.registerLogger(name, logger)
+	RegisterLogger(name, logger)
 	return logger
 }
 
@@ -95,7 +95,7 @@ func NewBlankLogger(name string) Logger {
 		testHelper: func() {},
 	}
 
-	loggerManager.registerLogger(name, logger)
+	RegisterLogger(name, logger)
 	return logger
 }
 


### PR DESCRIPTION
This change creates exported wrapper functions on the logger manager instance methods. This allows us to utilize these instance methods outside the logging package. After talking offline, it was decided that keeping the logger manager private but having publicly exposed functions that operate on the manager is the best approach. As a side note, I left the instance methods as is since they are used for testing.

**UPDATE**:
Now closes [this](https://viam.atlassian.net/browse/RSDK-8087) ticket. 

### Changes

- Moved `log_config.go` and corresponding tests into the logging package. This reduces the likelihood of cyclic dependencies arising between the `logging` and `config` packages and localized the `UpdateRegistry` function near the registry code.
- `LoggerPatternConfig` now lives inside the `logging` package. This is necessary to prevent cyclic dependencies.
- Call UpdateLoggerRegistry inside `reader.go`
- new test in `reader_test.go` ensuring that logger config is read and utilized correctly.
- `DeRegisterLogger` and `GetRegisteredLoggerNames` methods in the logger manager