### PR TITLE
RSDK-8247 Implement gpio output as PWM in generic linux

### DIFF
--- a/components/board/beaglebone/data.go
+++ b/components/board/beaglebone/data.go
@@ -15,7 +15,7 @@ var boardInfoMappings = map[string]genericlinux.BoardInformation{
 			// NOTE: each hardware PWM device can only drive 1 line at a time, even though 2 lines
 			// are hooked up to each. For example, you can't have PWM signals running on lines 914
 			// and 916 at the same time, even though both of them work on their own.
-			// NOTE: pins with hardware PWM support don't work as GPIO by default
+			// NOTE: pins with hardware PWM support don't work as GPIO input.
 
 			// GPIO only pins
 			// beaglebone gpio mapping uses directory sys/devices/platform/bus@100000/*.gpio
@@ -32,14 +32,14 @@ var boardInfoMappings = map[string]genericlinux.BoardInformation{
 			{Name: "810", DeviceName: "gpiochip1", LineNumber: 16, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "811", DeviceName: "gpiochip1", LineNumber: 60, PwmChipSysfsDir: "", PwmID: -1}, // BOOTMODE7
 			{Name: "812", DeviceName: "gpiochip1", LineNumber: 59, PwmChipSysfsDir: "", PwmID: -1},
-			// We're unable to get GPIO to work on pin 813 despite Beaglebone's docs. PWM works.
+			// Note that gpio input cannot be used on this pin.
 			{Name: "813", DeviceName: "gpiochip1", LineNumber: 89, PwmChipSysfsDir: "3000000.pwm", PwmID: 1}, // pwmchip0 V27 EHRPWM0_A
 			{Name: "814", DeviceName: "gpiochip1", LineNumber: 75, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "815", DeviceName: "gpiochip1", LineNumber: 61, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "816", DeviceName: "gpiochip1", LineNumber: 62, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "817", DeviceName: "gpiochip1", LineNumber: 3, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "818", DeviceName: "gpiochip1", LineNumber: 4, PwmChipSysfsDir: "", PwmID: -1},
-			// We're unable to get GPIO to work on pin 819 despite Beaglebone's docs. PWM works.
+			// Note that gpio input cannot be used on this pin.
 			{Name: "819", DeviceName: "gpiochip1", LineNumber: 88, PwmChipSysfsDir: "3000000.pwm", PwmID: 0}, // pwmchip0 V29 EHRPWM0_B
 			{Name: "820", DeviceName: "gpiochip1", LineNumber: 76, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "821", DeviceName: "gpiochip1", LineNumber: 30, PwmChipSysfsDir: "", PwmID: -1},
@@ -71,10 +71,10 @@ var boardInfoMappings = map[string]genericlinux.BoardInformation{
 			{Name: "911", DeviceName: "gpiochip1", LineNumber: 1, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "912", DeviceName: "gpiochip1", LineNumber: 45, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "913", DeviceName: "gpiochip1", LineNumber: 2, PwmChipSysfsDir: "", PwmID: -1},
-			// We're unable to get GPIO to work on pin 914 despite Beaglebone's docs. PWM works.
+			// Note that gpio input cannot be used on this pin.
 			{Name: "914", DeviceName: "gpiochip1", LineNumber: 93, PwmChipSysfsDir: "3020000.pwm", PwmID: 0},
 			{Name: "915", DeviceName: "gpiochip1", LineNumber: 47, PwmChipSysfsDir: "", PwmID: -1},
-			// We're unable to get GPIO to work on pin 916 despite Beaglebone's docs. PWM works.
+			// Note that gpio input cannot be used on this pin.
 			{Name: "916", DeviceName: "gpiochip1", LineNumber: 94, PwmChipSysfsDir: "3020000.pwm", PwmID: 1},
 			{Name: "917", DeviceName: "gpiochip1", LineNumber: 28, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "918", DeviceName: "gpiochip1", LineNumber: 40, PwmChipSysfsDir: "", PwmID: -1},

--- a/components/board/customlinux/board.go
+++ b/components/board/customlinux/board.go
@@ -86,14 +86,6 @@ func parseRawPinData(pinData []byte, filePath string, logger logging.Logger) ([]
 	var err error
 	for name, pin := range parsedPinData.Pins {
 		err = multierr.Combine(err, pin.Validate(filePath))
-
-		// Until we can reliably switch between gpio and pwm on lots of boards, pins that have
-		// hardware pwm enabled will be hardware pwm only. Disabling gpio functionality on these
-		// pins.
-		if parsedPinData.Pins[name].PwmChipSysfsDir != "" && parsedPinData.Pins[name].LineNumber >= 0 {
-			logger.Warnf("pin %s can be used for PWM only", parsedPinData.Pins[name].Name)
-			parsedPinData.Pins[name].LineNumber = -1
-		}
 	}
 	if err != nil {
 		return nil, err

--- a/components/board/customlinux/board.go
+++ b/components/board/customlinux/board.go
@@ -77,7 +77,7 @@ func parsePinConfig(filePath string, logger logging.Logger) ([]genericlinux.PinD
 
 // This function is separate from parsePinConfig to make it testable without interacting with the
 // file system. The filePath is passed in just for logging purposes.
-func parseRawPinData(pinData []byte, filePath string, logger logging.Logger) ([]genericlinux.PinDefinition, error) {
+func parseRawPinData(pinData []byte, filePath string, _ logging.Logger) ([]genericlinux.PinDefinition, error) {
 	var parsedPinData genericlinux.PinDefinitions
 	if err := json.Unmarshal(pinData, &parsedPinData); err != nil {
 		return nil, err

--- a/components/board/customlinux/board.go
+++ b/components/board/customlinux/board.go
@@ -84,7 +84,7 @@ func parseRawPinData(pinData []byte, filePath string, logger logging.Logger) ([]
 	}
 
 	var err error
-	for name, pin := range parsedPinData.Pins {
+	for _, pin := range parsedPinData.Pins {
 		err = multierr.Combine(err, pin.Validate(filePath))
 	}
 	if err != nil {

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -131,7 +131,7 @@ func (pin *gpioPin) setInternal(isHigh bool) (err error) {
 		}
 		err := pin.hwPwm.SetPwm(10, value)
 		if err != nil {
-			return fmt.Errorf("could not set pin: %w")
+			return fmt.Errorf("could not set pin: %w", err)
 		}
 		return nil
 	}

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -132,7 +132,7 @@ func (pin *gpioPin) setInternal(isHigh bool) (err error) {
 
 		// Set pwm with a frequency of 10 Hz. Any frequency value would work.
 		// Note that pin.pwmFreqHz is not modified, so a previously used frequency
-		// is still avaliable to use later.
+		// is still available to use later.
 		err := pin.hwPwm.SetPwm(10, value)
 		if err != nil {
 			return fmt.Errorf("could not set pin: %w", err)

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -127,8 +127,12 @@ func (pin *gpioPin) setInternal(isHigh bool) (err error) {
 	if pin.hwPwm != nil {
 		var value float64
 		if isHigh {
-			value = 1
+			value = 1.0
 		}
+
+		// Set pwm with a frequency of 10 Hz. Any frequency value would work.
+		// Note that pin.pwmFreqHz is not modified, so a previously used frequency
+		// is still avaliable to use later.
 		err := pin.hwPwm.SetPwm(10, value)
 		if err != nil {
 			return fmt.Errorf("could not set pin: %w", err)
@@ -273,7 +277,6 @@ func (pin *gpioPin) halfPwmCycle(ctx context.Context, shouldBeOn bool) bool {
 	// Make local copies of these, then release the mutex
 	var dutyCycle float64
 	var freqHz uint
-
 	// We encapsulate some of this code into its own function, to ensure that the mutex is unlocked
 	// at the appropriate time even if we return early.
 	shouldContinue := func() bool {

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -277,6 +277,7 @@ func (pin *gpioPin) halfPwmCycle(ctx context.Context, shouldBeOn bool) bool {
 	// Make local copies of these, then release the mutex
 	var dutyCycle float64
 	var freqHz uint
+
 	// We encapsulate some of this code into its own function, to ensure that the mutex is unlocked
 	// at the appropriate time even if we return early.
 	shouldContinue := func() bool {

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -6,6 +6,7 @@ package genericlinux
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -122,6 +123,19 @@ func (pin *gpioPin) Set(ctx context.Context, isHigh bool,
 // This function assumes you've already locked the mutex. It sets the value of a pin without
 // changing whether the pin is part of a software PWM loop.
 func (pin *gpioPin) setInternal(isHigh bool) (err error) {
+	// if pin is a hw pwm pin, set to either 0% or 100% duty cycle
+	if pin.hwPwm != nil {
+		var value float64
+		if isHigh {
+			value = 1
+		}
+		err := pin.hwPwm.SetPwm(10, value)
+		if err != nil {
+			return fmt.Errorf("could not set pin: %w")
+		}
+		return nil
+	}
+
 	var value byte
 	if isHigh {
 		value = 1
@@ -150,6 +164,10 @@ func (pin *gpioPin) Get(
 ) (result bool, err error) {
 	pin.mu.Lock()
 	defer pin.mu.Unlock()
+
+	if pin.hwPwm != nil {
+		return false, errors.New("cannot read from a HW pwm pin")
+	}
 
 	if pin.offset == noPin {
 		return false, errors.New("cannot read from non-GPIO pin")

--- a/components/board/orangepi/data.go
+++ b/components/board/orangepi/data.go
@@ -15,10 +15,10 @@ var boardInfoMappings = map[string]genericlinux.BoardInformation{
 			{Name: "3", DeviceName: "gpiochip0", LineNumber: 229, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "5", DeviceName: "gpiochip0", LineNumber: 228, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "7", DeviceName: "gpiochip0", LineNumber: 73, PwmChipSysfsDir: "", PwmID: -1},
-			// When we can switch between gpio and pwm, this would have line number 226.
-			{Name: "8", DeviceName: "gpiochip0", LineNumber: -1, PwmChipSysfsDir: "300a000.pwm", PwmID: 2},
-			// When we can switch between gpio and pwm, this would have line number 227.
-			{Name: "10", DeviceName: "gpiochip0", LineNumber: -1, PwmChipSysfsDir: "300a000.pwm", PwmID: 1},
+			// Note that gpio input cannot be used on this pin.
+			{Name: "8", DeviceName: "gpiochip0", LineNumber: 226, PwmChipSysfsDir: "300a000.pwm", PwmID: 2},
+			// Note that gpio input cannot be used on this pin.
+			{Name: "10", DeviceName: "gpiochip0", LineNumber: 227, PwmChipSysfsDir: "300a000.pwm", PwmID: 1},
 			{Name: "11", DeviceName: "gpiochip0", LineNumber: 70, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "12", DeviceName: "gpiochip0", LineNumber: 75, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "13", DeviceName: "gpiochip0", LineNumber: 69, PwmChipSysfsDir: "", PwmID: -1},
@@ -39,8 +39,8 @@ var boardInfoMappings = map[string]genericlinux.BoardInformation{
 		PinDefinitions: []genericlinux.PinDefinition{
 			{Name: "3", DeviceName: "gpiochip1", LineNumber: 122, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "5", DeviceName: "gpiochip1", LineNumber: 121, PwmChipSysfsDir: "", PwmID: -1},
-			// When we can switch between gpio and pwm, the line number would be 118.
-			{Name: "7", DeviceName: "gpiochip1", LineNumber: -1, PwmChipSysfsDir: "300a000.pwm", PwmID: 0},
+			// Note that gpio input cannot be used on this pin.
+			{Name: "7", DeviceName: "gpiochip1", LineNumber: 118, PwmChipSysfsDir: "300a000.pwm", PwmID: 0},
 			{Name: "8", DeviceName: "gpiochip0", LineNumber: 2, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "10", DeviceName: "gpiochip0", LineNumber: 3, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "11", DeviceName: "gpiochip1", LineNumber: 120, PwmChipSysfsDir: "", PwmID: -1},

--- a/components/board/pi5/data.go
+++ b/components/board/pi5/data.go
@@ -13,7 +13,7 @@ var boardInfoMappings = map[string]genericlinux.BoardInformation{
 			{Name: "8", DeviceName: "gpiochip4", LineNumber: 14, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "10", DeviceName: "gpiochip4", LineNumber: 15, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "11", DeviceName: "gpiochip4", LineNumber: 17, PwmChipSysfsDir: "", PwmID: -1},
-			// You might run into issues if trying to switch between using this as GPIO and PWM.
+			// Note that this pin cannot be used for GPIO input.
 			{Name: "12", DeviceName: "gpiochip4", LineNumber: 18, PwmChipSysfsDir: "1f00098000.pwm", PwmID: 2},
 			{Name: "13", DeviceName: "gpiochip4", LineNumber: 27, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "15", DeviceName: "gpiochip4", LineNumber: 22, PwmChipSysfsDir: "", PwmID: -1},
@@ -34,7 +34,7 @@ var boardInfoMappings = map[string]genericlinux.BoardInformation{
 			// that to work yet.
 			{Name: "32", DeviceName: "gpiochip4", LineNumber: 12, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "33", DeviceName: "gpiochip4", LineNumber: 13, PwmChipSysfsDir: "", PwmID: -1},
-			// You might run into issues if trying to switch between using this as GPIO and PWM.
+			// Note that this pin cannot be used for GPIO input.
 			{Name: "35", DeviceName: "gpiochip4", LineNumber: 19, PwmChipSysfsDir: "1f00098000.pwm", PwmID: 3},
 			{Name: "36", DeviceName: "gpiochip4", LineNumber: 16, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "37", DeviceName: "gpiochip4", LineNumber: 26, PwmChipSysfsDir: "", PwmID: -1},


### PR DESCRIPTION
Setting 0 or 100% duty cycle as gpio output on pwm pins. Adds an error if calling getGPIO on one of these pins. Tested on the pi5 and beaglebone, works great!