### PR TITLE
[RSDK_8225] remove redundant interface NmeaMovementSensor

### DIFF
--- a/components/movementsensor/gpsnmea/component.go
+++ b/components/movementsensor/gpsnmea/component.go
@@ -25,7 +25,7 @@ type NMEAMovementSensor struct {
 // newNMEAMovementSensor creates a new movement sensor.
 func newNMEAMovementSensor(
 	_ context.Context, name resource.Name, dev gpsutils.DataReader, logger logging.Logger,
-) (NmeaMovementSensor, error) {
+) (movementsensor.MovementSensor, error) {
 	g := &NMEAMovementSensor{
 		Named:      name.AsNamed(),
 		logger:     logger,

--- a/components/movementsensor/gpsnmea/gpsnmea.go
+++ b/components/movementsensor/gpsnmea/gpsnmea.go
@@ -57,12 +57,6 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 
 var model = resource.DefaultModelFamily.WithModel("gps-nmea")
 
-// NmeaMovementSensor implements a gps that sends nmea messages for movement data.
-type NmeaMovementSensor interface {
-	movementsensor.MovementSensor
-	Close(ctx context.Context) error // Close MovementSensor
-}
-
 func init() {
 	resource.RegisterComponent(
 		movementsensor.API,

--- a/components/movementsensor/gpsnmea/pmtkI2C.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"go.viam.com/rdk/components/board/genericlinux/buses"
+	"go.viam.com/rdk/components/movementsensor"
 	"go.viam.com/rdk/components/movementsensor/gpsutils"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -19,7 +20,7 @@ func NewPmtkI2CGPSNMEA(
 	name resource.Name,
 	conf *Config,
 	logger logging.Logger,
-) (NmeaMovementSensor, error) {
+) (movementsensor.MovementSensor, error) {
 	// The nil on this next line means "use a real I2C bus, because we're not going to pass in a
 	// mock one."
 	return MakePmtkI2cGpsNmea(ctx, deps, name, conf, logger, nil)
@@ -35,7 +36,7 @@ func MakePmtkI2cGpsNmea(
 	conf *Config,
 	logger logging.Logger,
 	i2cBus buses.I2C,
-) (NmeaMovementSensor, error) {
+) (movementsensor.MovementSensor, error) {
 	dev, err := gpsutils.NewI2cDataReader(*conf.I2CConfig, i2cBus, logger)
 	if err != nil {
 		return nil, err

--- a/components/movementsensor/gpsnmea/pmtkI2C_nonlinux.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C_nonlinux.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 
+	"go.viam.com/rdk/components/movementsensor"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 )
@@ -19,7 +20,7 @@ func NewPmtkI2CGPSNMEA(
 	name resource.Name,
 	conf *Config,
 	logger logging.Logger,
-) (NmeaMovementSensor, error) {
+) (movementsensor.MovementSensor, error) {
 	// The nil on this next line means "use a real I2C bus, because we're not going to pass in a
 	// mock one."
 	return nil, errors.New("all I2C components are only available on Linux")

--- a/components/movementsensor/gpsnmea/serial.go
+++ b/components/movementsensor/gpsnmea/serial.go
@@ -4,13 +4,14 @@ package gpsnmea
 import (
 	"context"
 
+	"go.viam.com/rdk/components/movementsensor"
 	"go.viam.com/rdk/components/movementsensor/gpsutils"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 )
 
 // NewSerialGPSNMEA creates a component that communicates over a serial port.
-func NewSerialGPSNMEA(ctx context.Context, name resource.Name, conf *Config, logger logging.Logger) (NmeaMovementSensor, error) {
+func NewSerialGPSNMEA(ctx context.Context, name resource.Name, conf *Config, logger logging.Logger) (movementsensor.MovementSensor, error) {
 	dev, err := gpsutils.NewSerialDataReader(conf.SerialConfig, logger)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This is a follow-up from https://github.com/viamrobotics/rdk/pull/4201. The `NmeaMovementSensor` interface was a closeable `MovementSensor`, except that `MovementSensor` is already closeable. So, remove the redundant interface.

Tried on piworld: works like normal.