### PR TITLE
RSDK-8270: Add orangepi 2w pin mappings

### DIFF
--- a/components/board/orangepi/data.go
+++ b/components/board/orangepi/data.go
@@ -44,7 +44,7 @@ var boardInfoMappings = map[string]genericlinux.BoardInformation{
 			{Name: "38", DeviceName: "gpiochip0", LineNumber: 260, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "40", DeviceName: "gpiochip0", LineNumber: 259, PwmChipSysfsDir: "", PwmID: -1},
 		},
-		Compats: []string{"xunlong,orangepi-zero2w", "allwinner,sun50i-h616"},
+		Compats: []string{"xunlong,orangepi-zero2w"},
 	},
 	opzero2: {
 		// OP zero 2 user manual: https://drive.google.com/drive/folders/1ToDjWZQptABxfiRwaeYW1WzQILM5iwpb
@@ -69,7 +69,7 @@ var boardInfoMappings = map[string]genericlinux.BoardInformation{
 			{Name: "24", DeviceName: "gpiochip0", LineNumber: 233, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "26", DeviceName: "gpiochip0", LineNumber: 74, PwmChipSysfsDir: "", PwmID: -1},
 		},
-		Compats: []string{"xunlong,orangepi-zero2", "allwinner,sun50i-h616"},
+		Compats: []string{"xunlong,orangepi-zero2"},
 	},
 	op3lts: {
 		// OP 3 LTS user manual: https://drive.google.com/file/d/1jka7avWnzNeTIQFkk78LoJdygWaGH2iu/view
@@ -94,6 +94,6 @@ var boardInfoMappings = map[string]genericlinux.BoardInformation{
 			{Name: "24", DeviceName: "gpiochip1", LineNumber: 227, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "26", DeviceName: "gpiochip0", LineNumber: 8, PwmChipSysfsDir: "", PwmID: -1},
 		},
-		Compats: []string{"xunlong,orangepi-3-lts", "allwinner,sun50i-h6"},
+		Compats: []string{"xunlong,orangepi-3-lts"},
 	},
 }

--- a/components/board/orangepi/data.go
+++ b/components/board/orangepi/data.go
@@ -3,8 +3,8 @@ package orangepi
 import "go.viam.com/rdk/components/board/genericlinux"
 
 const (
-	opzero2 = "OrangePi Zero2"
-	op3lts  = "OrangePi 3 LTS"
+	opzero2  = "OrangePi Zero2"
+	op3lts   = "OrangePi 3 LTS"
 	opzero2w = "OrangePi Zero 2W"
 )
 
@@ -21,6 +21,7 @@ var boardInfoMappings = map[string]genericlinux.BoardInformation{
 			{Name: "13", DeviceName: "gpiochip0", LineNumber: 227, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "15", DeviceName: "gpiochip0", LineNumber: 261, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "16", DeviceName: "gpiochip0", LineNumber: 270, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "18", DeviceName: "gpiochip0", LineNumber: 228, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "19", DeviceName: "gpiochip0", LineNumber: 231, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "21", DeviceName: "gpiochip0", LineNumber: 232, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "22", DeviceName: "gpiochip0", LineNumber: 262, PwmChipSysfsDir: "", PwmID: -1},
@@ -38,10 +39,10 @@ var boardInfoMappings = map[string]genericlinux.BoardInformation{
 			{Name: "35", DeviceName: "gpiochip0", LineNumber: 258, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "36", DeviceName: "gpiochip0", LineNumber: 76, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "37", DeviceName: "gpiochip0", LineNumber: 272, PwmChipSysfsDir: "", PwmID: -1},
-			{Name: "38", DeviceName: "gpiochip0", LineNumber: 260 , PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "38", DeviceName: "gpiochip0", LineNumber: 260, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "40", DeviceName: "gpiochip0", LineNumber: 259, PwmChipSysfsDir: "", PwmID: -1},
 		},
-		Compats: []string{"xunlong,orangepi-zero2w","allwinner,sun50i-h616"},
+		Compats: []string{"xunlong,orangepi-zero2w", "allwinner,sun50i-h616"},
 	},
 	opzero2: {
 		// OP zero 2 user manual: https://drive.google.com/drive/folders/1ToDjWZQptABxfiRwaeYW1WzQILM5iwpb

--- a/components/board/orangepi/data.go
+++ b/components/board/orangepi/data.go
@@ -5,9 +5,44 @@ import "go.viam.com/rdk/components/board/genericlinux"
 const (
 	opzero2 = "OrangePi Zero2"
 	op3lts  = "OrangePi 3 LTS"
+	opzero2w = "OrangePi Zero 2W"
 )
 
 var boardInfoMappings = map[string]genericlinux.BoardInformation{
+	opzero2w: {
+		PinDefinitions: []genericlinux.PinDefinition{
+			{Name: "3", DeviceName: "gpiochip0", LineNumber: 264, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "5", DeviceName: "gpiochip0", LineNumber: 263, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "7", DeviceName: "gpiochip0", LineNumber: 269, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "8", DeviceName: "gpiochip0", LineNumber: 224, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "10", DeviceName: "gpiochip0", LineNumber: 225, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "11", DeviceName: "gpiochip0", LineNumber: 226, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "12", DeviceName: "gpiochip0", LineNumber: 257, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "13", DeviceName: "gpiochip0", LineNumber: 227, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "15", DeviceName: "gpiochip0", LineNumber: 261, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "16", DeviceName: "gpiochip0", LineNumber: 270, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "19", DeviceName: "gpiochip0", LineNumber: 231, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "21", DeviceName: "gpiochip0", LineNumber: 232, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "22", DeviceName: "gpiochip0", LineNumber: 262, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "23", DeviceName: "gpiochip0", LineNumber: 230, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "24", DeviceName: "gpiochip0", LineNumber: 229, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "26", DeviceName: "gpiochip0", LineNumber: 233, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "27", DeviceName: "gpiochip0", LineNumber: 266, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "28", DeviceName: "gpiochip0", LineNumber: 265, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "29", DeviceName: "gpiochip0", LineNumber: 256, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "31", DeviceName: "gpiochip0", LineNumber: 271, PwmChipSysfsDir: "", PwmID: -1},
+			// When we can switch between gpio and pwm, this would have line number 267.
+			{Name: "32", DeviceName: "gpiochip0", LineNumber: -1, PwmChipSysfsDir: "300a000.pwm", PwmID: 1},
+			// When we can switch between gpio and pwm, this would have line number 268.
+			{Name: "33", DeviceName: "gpiochip0", LineNumber: -1, PwmChipSysfsDir: "300a000.pwm", PwmID: 2},
+			{Name: "35", DeviceName: "gpiochip0", LineNumber: 258, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "36", DeviceName: "gpiochip0", LineNumber: 76, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "37", DeviceName: "gpiochip0", LineNumber: 272, PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "38", DeviceName: "gpiochip0", LineNumber: 260 , PwmChipSysfsDir: "", PwmID: -1},
+			{Name: "40", DeviceName: "gpiochip0", LineNumber: 259, PwmChipSysfsDir: "", PwmID: -1},
+		},
+		Compats: []string{"xunlong,orangepi-zero2w","allwinner,sun50i-h616"},
+	},
 	opzero2: {
 		// OP zero 2 user manual: https://drive.google.com/drive/folders/1ToDjWZQptABxfiRwaeYW1WzQILM5iwpb
 		// Gpio pins can be found on page 147.

--- a/components/board/orangepi/data.go
+++ b/components/board/orangepi/data.go
@@ -34,10 +34,10 @@ var boardInfoMappings = map[string]genericlinux.BoardInformation{
 			{Name: "28", DeviceName: "gpiochip0", LineNumber: 265, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "29", DeviceName: "gpiochip0", LineNumber: 256, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "31", DeviceName: "gpiochip0", LineNumber: 271, PwmChipSysfsDir: "", PwmID: -1},
-			// When we can switch between gpio and pwm, this would have line number 267.
-			{Name: "32", DeviceName: "gpiochip0", LineNumber: -1, PwmChipSysfsDir: "300a000.pwm", PwmID: 1},
-			// When we can switch between gpio and pwm, this would have line number 268.
-			{Name: "33", DeviceName: "gpiochip0", LineNumber: -1, PwmChipSysfsDir: "300a000.pwm", PwmID: 2},
+			// Note that gpio input cannot be used on this pin.
+			{Name: "32", DeviceName: "gpiochip0", LineNumber: 267, PwmChipSysfsDir: "300a000.pwm", PwmID: 1},
+			// Note that gpio input cannot be used on this pin.
+			{Name: "33", DeviceName: "gpiochip0", LineNumber: 268, PwmChipSysfsDir: "300a000.pwm", PwmID: 2},
 			{Name: "35", DeviceName: "gpiochip0", LineNumber: 258, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "36", DeviceName: "gpiochip0", LineNumber: 76, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "37", DeviceName: "gpiochip0", LineNumber: 272, PwmChipSysfsDir: "", PwmID: -1},

--- a/components/board/orangepi/data.go
+++ b/components/board/orangepi/data.go
@@ -10,6 +10,8 @@ const (
 
 var boardInfoMappings = map[string]genericlinux.BoardInformation{
 	opzero2w: {
+		// OP zero 2w user manual: https://drive.google.com/drive/folders/1KIZMMDBlqf1rKmOEhGH7_7A-COAgYoGZ
+		// Gpio pins can be found on page 131.
 		PinDefinitions: []genericlinux.PinDefinition{
 			{Name: "3", DeviceName: "gpiochip0", LineNumber: 264, PwmChipSysfsDir: "", PwmID: -1},
 			{Name: "5", DeviceName: "gpiochip0", LineNumber: 263, PwmChipSysfsDir: "", PwmID: -1},


### PR DESCRIPTION
Tested a handful of gpio pins on a local build with success.

<img width="590" alt="Screenshot 2024-07-18 at 10 43 22 AM" src="https://github.com/user-attachments/assets/a6b6089c-26c5-46a0-ab0a-47265f4c2ce2">
