### PR TITLE
[RSDK-8260] Be more explicit if we permanently give up on the NTRIP caster

### DIFF
--- a/components/movementsensor/gpsrtk/gpsrtk.go
+++ b/components/movementsensor/gpsrtk/gpsrtk.go
@@ -174,8 +174,6 @@ func (g *gpsrtk) receiveAndWriteCorrectionData() {
 			// need to reconnect to the mount point), and not the message itself.
 			_, err = scanner.NextMessage()
 		}
-
-		// added a log so we do not always swallow the error
 		g.logger.Debugf("no longer connected to NTRIP scanner: %s", err)
 
 		if g.isClosed || g.cancelCtx.Err() != nil {

--- a/components/movementsensor/gpsrtk/gpsrtk.go
+++ b/components/movementsensor/gpsrtk/gpsrtk.go
@@ -140,12 +140,6 @@ func (g *gpsrtk) receiveAndWriteCorrectionData() {
 	defer g.activeBackgroundWorkers.Done()
 	defer g.closeCorrectionWriter()
 
-	select {
-	case <-g.cancelCtx.Done():
-		return
-	default:
-	}
-
 	err := g.connectAndParseSourceTable()
 	if err != nil {
 		g.err.Set(err)

--- a/components/movementsensor/gpsrtk/gpsrtk.go
+++ b/components/movementsensor/gpsrtk/gpsrtk.go
@@ -188,7 +188,7 @@ func (g *gpsrtk) receiveAndWriteCorrectionData() {
 		scanner, err = g.getStream()
 		if err != nil {
 			g.err.Set(err)
-			g.logger.Error("unable to get reconnect to NTRIP stream! Giving up on RTK messages")
+			g.logger.Error("unable to reconnect to NTRIP stream! Giving up on RTK messages")
 			return
 		}
 	}

--- a/components/movementsensor/gpsrtk/gpsrtk.go
+++ b/components/movementsensor/gpsrtk/gpsrtk.go
@@ -168,10 +168,10 @@ func (g *gpsrtk) receiveAndWriteCorrectionData() {
 			default:
 			}
 
-			// Calling NextMessage() reads from the scanner until a valid message is found, and returns
-			// that. We don't care about the message: we care that the scanner is able to read messages
-			// at all! So, focus on whether the scanner had errors (which indicate we need to reconnect
-			// to the mount point), and not the message itself.
+			// Calling NextMessage() reads from the scanner until a valid message is found, and
+			// returns that. We don't care about the message: we care that the scanner is able to
+			// read messages at all! So, focus on whether the scanner had errors (which indicate we
+			// need to reconnect to the mount point), and not the message itself.
 			_, err = scanner.NextMessage()
 		}
 

--- a/components/movementsensor/gpsrtk/gpsrtk.go
+++ b/components/movementsensor/gpsrtk/gpsrtk.go
@@ -142,7 +142,6 @@ func (g *gpsrtk) receiveAndWriteCorrectionData() {
 
 	select {
 	case <-g.cancelCtx.Done():
-		g.err.Set(errors.New("context canceled"))
 		return
 	default:
 	}
@@ -189,6 +188,7 @@ func (g *gpsrtk) receiveAndWriteCorrectionData() {
 		scanner, err = g.getStream()
 		if err != nil {
 			g.err.Set(err)
+			g.logger.Error("unable to get reconnect to NTRIP stream! Giving up on RTK messages")
 			return
 		}
 	}

--- a/components/movementsensor/gpsutils/ntrip.go
+++ b/components/movementsensor/gpsutils/ntrip.go
@@ -212,18 +212,15 @@ func (n *NtripInfo) GetStreamFromMountPoint(
 		rc, err = n.client.GetStream(n.MountPoint)
 		if err == nil {
 			success = true
+			logger.Debug("Connected to stream")
+			n.stream = rc
+			return rc, nil
 		}
 		attempts++
 	}
 
-	if err != nil {
-		logger.Errorf("Can't connect to NTRIP stream: %s", err)
-		return nil, err
-	}
-	logger.Debug("Connected to stream")
-
-	n.stream = rc
-	return rc, nil
+	logger.Errorf("Can't connect to NTRIP stream: %s", err)
+	return nil, err
 }
 
 // Close shuts down all connections to the NTRIP caster.

--- a/components/movementsensor/gpsutils/ntrip.go
+++ b/components/movementsensor/gpsutils/ntrip.go
@@ -202,6 +202,7 @@ func (n *NtripInfo) GetStreamFromMountPoint(
 	logger.Debug("Getting NTRIP stream")
 
 	for !success && attempts < n.maxConnectAttempts {
+		logger.Debugf("unable to get stream after %d attempts, trying again...", attempts)
 		select {
 		case <-cancelCtx.Done():
 			return nil, errors.New("Canceled")

--- a/components/movementsensor/gpsutils/ntrip.go
+++ b/components/movementsensor/gpsutils/ntrip.go
@@ -207,13 +207,14 @@ func (n *NtripInfo) GetStreamFromMountPoint(
 		}
 
 		rc, err = n.client.GetStream(n.MountPoint)
-		if err == nil {
+		if err == nil { // Success!
 			logger.Debug("Connected to stream")
 			n.stream = rc
 			return rc, nil
 		}
 	}
 
+	// If we get here, none of our attempts to connect succeeded.
 	logger.Errorf("Can't connect to NTRIP stream: %s", err)
 	return nil, err
 }

--- a/components/movementsensor/gpsutils/ntrip.go
+++ b/components/movementsensor/gpsutils/ntrip.go
@@ -187,8 +187,6 @@ func (n *NtripInfo) GetStreamFromMountPoint(
 	n.mu.Lock()
 	defer n.mu.Unlock()
 
-	attempts := 0
-
 	// Set the Timeout to 0 on the http client to prevent the ntrip stream from canceling itself.
 	// ntrip.NewClient() defaults sets this value to 15 seconds, which causes us to disconnect
 	// the ntrip stream and require a reconnection. Additionally, this should be tested with other
@@ -200,7 +198,7 @@ func (n *NtripInfo) GetStreamFromMountPoint(
 
 	logger.Debug("Getting NTRIP stream")
 
-	for attempts < n.maxConnectAttempts {
+	for attempts := 0; attempts < n.maxConnectAttempts; attempts++ {
 		logger.Debugf("unable to get stream after %d attempts, trying again...", attempts)
 		select {
 		case <-cancelCtx.Done():
@@ -214,7 +212,6 @@ func (n *NtripInfo) GetStreamFromMountPoint(
 			n.stream = rc
 			return rc, nil
 		}
-		attempts++
 	}
 
 	logger.Errorf("Can't connect to NTRIP stream: %s", err)

--- a/components/movementsensor/gpsutils/ntrip.go
+++ b/components/movementsensor/gpsutils/ntrip.go
@@ -187,7 +187,6 @@ func (n *NtripInfo) GetStreamFromMountPoint(
 	n.mu.Lock()
 	defer n.mu.Unlock()
 
-	success := false
 	attempts := 0
 
 	// Set the Timeout to 0 on the http client to prevent the ntrip stream from canceling itself.
@@ -201,7 +200,7 @@ func (n *NtripInfo) GetStreamFromMountPoint(
 
 	logger.Debug("Getting NTRIP stream")
 
-	for !success && attempts < n.maxConnectAttempts {
+	for attempts < n.maxConnectAttempts {
 		logger.Debugf("unable to get stream after %d attempts, trying again...", attempts)
 		select {
 		case <-cancelCtx.Done():
@@ -211,7 +210,6 @@ func (n *NtripInfo) GetStreamFromMountPoint(
 
 		rc, err = n.client.GetStream(n.MountPoint)
 		if err == nil {
-			success = true
 			logger.Debug("Connected to stream")
 			n.stream = rc
 			return rc, nil


### PR DESCRIPTION
I strongly recommend reviewing this commit-by-commit! A lot of this is refactoring, and only a small amount is actually changing behavior. 

The original plan for this ticket was that, once we get into the for loop in the background goroutine, we can reconnect to the caster, so before we get to the for loop, we should also reconnect to the caster if something goes wrong, rather than just logging that we're giving up on the caster entirely and exiting the goroutine. 

However, after the refactorings, it became very clear that, if reconnecting to the caster fails within the for loop, we do the exact same thing of giving up entirely and exiting, but we've been doing so _silently,_ which is why no one thought this was a thing! John, Susmita, and I have discussed, and decided that this is actually probably the right behavior: we go through 10 reconnection attempts before giving up, but if they all fail, we don't want to spam the caster and get banned from their network, so exiting the goroutine _with a giant error message_ is the right choice.

@susmitaSanyal is going to change the VRS code so that it attempts to get a GGA message from the chip multiple times before giving up on that, see https://github.com/viamrobotics/rdk/pull/4216

Changes include:
- `gpsrtk.reader` is now a local variable instead of a field on the struct
- `gpsrtk.getStream()` now returns an `rtcm3.Scanner` instead of an `io.Reader`.
- We log more error messages on failures! :upside_down_face: 
- `gpsrtk.connectToNTRIP()` has been inlined within `gpsrtk.receiveAndWriteCorrectionData()`.
- The control flow in `NtripInfo.GetStreamFromMountPoint()` has been simplified

Tried on John-Pi: works like normal, though I was unable to get the failure condition to happen. Both the serial and I2C components, when connected to both the NJ caster and the VRS, can get a fix of 5.