### PR TITLE
Use StoppableWorkers in the GPS RTK component

### DIFF
--- a/components/movementsensor/gpsrtk/gpsrtk.go
+++ b/components/movementsensor/gpsrtk/gpsrtk.go
@@ -60,7 +60,7 @@ type gpsrtk struct {
 
 func (g *gpsrtk) start() error {
 	if g.workers != nil {
-		return errors.New("do not double-start background goroutines")
+		return errors.New("do not call start() twice on the same object")
 	}
 	g.workers = utils.NewStoppableWorkers(g.receiveAndWriteCorrectionData)
 	return nil

--- a/components/movementsensor/gpsrtk/gpsrtk.go
+++ b/components/movementsensor/gpsrtk/gpsrtk.go
@@ -26,13 +26,13 @@ import (
 	"github.com/go-gnss/rtcm/rtcm3"
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
-	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/movementsensor"
 	"go.viam.com/rdk/components/movementsensor/gpsutils"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/spatialmath"
+	"go.viam.com/rdk/utils"
 )
 
 // gpsrtk is an nmea movementsensor model that can intake RTK correction data.
@@ -40,10 +40,8 @@ type gpsrtk struct {
 	resource.Named
 	resource.AlwaysRebuild
 	logger     logging.Logger
-	cancelCtx  context.Context
-	cancelFunc func()
 
-	activeBackgroundWorkers sync.WaitGroup
+	workers utils.StoppableWorkers
 
 	err      movementsensor.LastError
 	isClosed bool
@@ -61,9 +59,11 @@ type gpsrtk struct {
 }
 
 func (g *gpsrtk) start() error {
-	g.activeBackgroundWorkers.Add(1)
-	utils.PanicCapturingGo(g.receiveAndWriteCorrectionData)
-	return g.err.Get()
+	if g.workers != nil {
+		return errors.New("do not double-start background goroutines")
+	}
+	g.workers = utils.NewStoppableWorkers(g.receiveAndWriteCorrectionData)
+	return nil
 }
 
 // closeCorrectionWriter closes the correctionWriter.
@@ -81,12 +81,12 @@ func (g *gpsrtk) closeCorrectionWriter() {
 
 // connectAndParseSourceTable connects to the NTRIP caster, gets and parses source table
 // from the caster.
-func (g *gpsrtk) connectAndParseSourceTable() error {
-	if err := g.cancelCtx.Err(); err != nil {
+func (g *gpsrtk) connectAndParseSourceTable(cancelCtx context.Context) error {
+	if err := cancelCtx.Err(); err != nil {
 		return g.err.Get()
 	}
 
-	err := g.ntripClient.Connect(g.cancelCtx, g.logger)
+	err := g.ntripClient.Connect(cancelCtx, g.logger)
 	if err != nil {
 		g.err.Set(err)
 		return g.err.Get()
@@ -111,12 +111,12 @@ func (g *gpsrtk) connectAndParseSourceTable() error {
 	return nil
 }
 
-func (g *gpsrtk) getStream() (*rtcm3.Scanner, error) {
+func (g *gpsrtk) getStream(cancelCtx context.Context) (*rtcm3.Scanner, error) {
 	var streamSource io.Reader
 
 	if g.isVirtualBase {
 		g.logger.Debug("connecting to Virtual Reference Station")
-		err := g.getNtripFromVRS()
+		err := g.getNtripFromVRS(cancelCtx)
 		if err != nil {
 			return nil, err
 		}
@@ -124,7 +124,7 @@ func (g *gpsrtk) getStream() (*rtcm3.Scanner, error) {
 	} else {
 		g.logger.Debug("connecting to NTRIP stream from static mount point...")
 		var err error
-		streamSource, err = g.ntripClient.GetStreamFromMountPoint(g.cancelCtx, g.logger)
+		streamSource, err = g.ntripClient.GetStreamFromMountPoint(cancelCtx, g.logger)
 		if err != nil {
 			return nil, err
 		}
@@ -136,26 +136,25 @@ func (g *gpsrtk) getStream() (*rtcm3.Scanner, error) {
 
 // receiveAndWriteCorrectionData connects to the NTRIP receiver and sends the correction stream to
 // the MovementSensor.
-func (g *gpsrtk) receiveAndWriteCorrectionData() {
-	defer g.activeBackgroundWorkers.Done()
+func (g *gpsrtk) receiveAndWriteCorrectionData(cancelCtx context.Context) {
 	defer g.closeCorrectionWriter()
 
-	err := g.connectAndParseSourceTable()
+	err := g.connectAndParseSourceTable(cancelCtx)
 	if err != nil {
 		g.logger.Errorf("unable to parse source table! Aborting: %w", err)
 		return
 	}
 
 	// While we're supposed to keep running, (re)connect to the caster.
-	for !g.isClosed && g.cancelCtx.Err() == nil {
-		scanner, err := g.getStream()
+	for !g.isClosed && cancelCtx.Err() == nil {
+		scanner, err := g.getStream(cancelCtx)
 		if err != nil {
 			g.logger.Errorf("unable to get NTRIP stream! Aborting: %w", err)
 			return
 		}
 
 		for err == nil { // Keep checking our connection until it fails and needs to reconnect
-			if g.isClosed || g.cancelCtx.Err() != nil {
+			if g.isClosed || cancelCtx.Err() != nil {
 				return
 			}
 
@@ -278,8 +277,8 @@ func (g *gpsrtk) Readings(ctx context.Context, extra map[string]interface{}) (ma
 
 // Close shuts down the gpsrtk.
 func (g *gpsrtk) Close(ctx context.Context) error {
+	g.workers.Stop()
 	g.mu.Lock()
-	g.cancelFunc()
 
 	g.logger.Debug("Closing GPS RTK")
 	if err := g.cachedData.Close(ctx); err != nil {
@@ -314,7 +313,6 @@ func (g *gpsrtk) Close(ctx context.Context) error {
 	}
 
 	g.mu.Unlock()
-	g.activeBackgroundWorkers.Wait()
 
 	if err := g.err.Get(); err != nil && !errors.Is(err, context.Canceled) {
 		return err
@@ -326,17 +324,17 @@ func (g *gpsrtk) Close(ctx context.Context) error {
 
 // getNtripFromVRS sends GGA messages to the NTRIP Caster over a TCP connection
 // to get the NTRIP steam when the mount point is a Virtual Reference Station.
-func (g *gpsrtk) getNtripFromVRS() error {
+func (g *gpsrtk) getNtripFromVRS(cancelCtx context.Context) error {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	var err error
 	if g.vrs != nil {
-		if err := g.vrs.Close(g.cancelCtx); err != nil {
+		if err := g.vrs.Close(cancelCtx); err != nil {
 			return err
 		}
 		g.vrs = nil
 	}
-	g.vrs, err = gpsutils.ConnectToVirtualBase(g.cancelCtx, g.ntripClient, g.cachedData.GGA, g.logger)
+	g.vrs, err = gpsutils.ConnectToVirtualBase(cancelCtx, g.ntripClient, g.cachedData.GGA, g.logger)
 	if err != nil {
 		return err
 	}

--- a/components/movementsensor/gpsrtk/gpsrtk.go
+++ b/components/movementsensor/gpsrtk/gpsrtk.go
@@ -76,6 +76,7 @@ func (g *gpsrtk) closeCorrectionWriter() {
 		if err != nil {
 			g.logger.Errorf("Error closing port: %v", err)
 		}
+		g.correctionWriter = nil
 	}
 }
 

--- a/components/movementsensor/gpsrtk/gpsrtk.go
+++ b/components/movementsensor/gpsrtk/gpsrtk.go
@@ -39,7 +39,7 @@ import (
 type gpsrtk struct {
 	resource.Named
 	resource.AlwaysRebuild
-	logger     logging.Logger
+	logger logging.Logger
 
 	workers utils.StoppableWorkers
 

--- a/components/movementsensor/gpsrtk/pmtk.go
+++ b/components/movementsensor/gpsrtk/pmtk.go
@@ -98,9 +98,9 @@ func makeRTKI2C(
 	}
 
 	g := &gpsrtk{
-		Named:      conf.ResourceName().AsNamed(),
-		logger:     logger,
-		err:        movementsensor.NewLastError(1, 1),
+		Named:  conf.ResourceName().AsNamed(),
+		logger: logger,
+		err:    movementsensor.NewLastError(1, 1),
 	}
 
 	ntripConfig := &gpsutils.NtripConfig{

--- a/components/movementsensor/gpsrtk/pmtk.go
+++ b/components/movementsensor/gpsrtk/pmtk.go
@@ -97,11 +97,8 @@ func makeRTKI2C(
 		return nil, err
 	}
 
-	cancelCtx, cancelFunc := context.WithCancel(context.Background())
 	g := &gpsrtk{
 		Named:      conf.ResourceName().AsNamed(),
-		cancelCtx:  cancelCtx,
-		cancelFunc: cancelFunc,
 		logger:     logger,
 		err:        movementsensor.NewLastError(1, 1),
 	}

--- a/components/movementsensor/gpsrtk/serial.go
+++ b/components/movementsensor/gpsrtk/serial.go
@@ -93,11 +93,8 @@ func newRTKSerial(
 		return nil, err
 	}
 
-	cancelCtx, cancelFunc := context.WithCancel(context.Background())
 	g := &gpsrtk{
 		Named:      conf.ResourceName().AsNamed(),
-		cancelCtx:  cancelCtx,
-		cancelFunc: cancelFunc,
 		logger:     logger,
 		err:        movementsensor.NewLastError(1, 1),
 	}

--- a/components/movementsensor/gpsrtk/serial.go
+++ b/components/movementsensor/gpsrtk/serial.go
@@ -94,9 +94,9 @@ func newRTKSerial(
 	}
 
 	g := &gpsrtk{
-		Named:      conf.ResourceName().AsNamed(),
-		logger:     logger,
-		err:        movementsensor.NewLastError(1, 1),
+		Named:  conf.ResourceName().AsNamed(),
+		logger: logger,
+		err:    movementsensor.NewLastError(1, 1),
 	}
 
 	if newConf.SerialPath != "" {


### PR DESCRIPTION
This gets rid of the race condition discussed in `Close()`. Everything still compiles and the linter is happy, but I haven't tried this out on actual hardware yet. Will do that Monday...

The biggest change in here is that `cancelCtx` is now a local variable only available within the background goroutine, so I've passed it as an argument to several helper functions that didn't need an argument before.