### PR TITLE
[RSDK-8345] prevent deadlock in software PWM loop

### DIFF
--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -336,11 +336,12 @@ func (b *Board) reconfigureInterrupts(newConf *LinuxBoardConfig) error {
 }
 
 func (b *Board) createGpioPin(mapping GPIOBoardMapping) *gpioPin {
+	startSoftwarePWMChan := make(chan any)
 	pin := gpioPin{
 		devicePath:           mapping.GPIOChipDev,
 		offset:               uint32(mapping.GPIO),
 		logger:               b.logger,
-		startSoftwarePWMChan: make(chan any),
+		startSoftwarePWMChan: &startSoftwarePWMChan,
 	}
 	pin.softwarePwm = utils.NewStoppableWorkers(pin.softwarePwmLoop)
 	if mapping.HWPWMSupported {

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -337,10 +337,12 @@ func (b *Board) reconfigureInterrupts(newConf *LinuxBoardConfig) error {
 
 func (b *Board) createGpioPin(mapping GPIOBoardMapping) *gpioPin {
 	pin := gpioPin{
-		devicePath: mapping.GPIOChipDev,
-		offset:     uint32(mapping.GPIO),
-		logger:     b.logger,
+		devicePath:           mapping.GPIOChipDev,
+		offset:               uint32(mapping.GPIO),
+		logger:               b.logger,
+		startSoftwarePWMChan: make(chan any),
 	}
+	pin.softwarePwm = utils.NewStoppableWorkers(pin.softwarePwmLoop)
 	if mapping.HWPWMSupported {
 		pin.hwPwm = newPwmDevice(mapping.PWMSysFsDir, mapping.PWMID, b.logger)
 	}

--- a/components/board/genericlinux/board_test.go
+++ b/components/board/genericlinux/board_test.go
@@ -138,13 +138,13 @@ func TestNewBoard(t *testing.T) {
 	// was constructed at the beginning of the test. That was so recent that the Go runtime
 	// environment will think there is a race condition when the test framework walks that part of
 	// the struct. To avoid that, we don't use the test framework directly here.
-	if (gn1 == nil ) {
+	if gn1 == nil {
 		t.FailNow()
 	}
 
 	gn2, err := b.GPIOPinByName("2")
 	test.That(t, err, test.ShouldBeNil)
-	if (gn2 == nil ) {
+	if gn2 == nil {
 		t.FailNow()
 	}
 }

--- a/components/board/genericlinux/board_test.go
+++ b/components/board/genericlinux/board_test.go
@@ -133,9 +133,18 @@ func TestNewBoard(t *testing.T) {
 
 	gn1, err := b.GPIOPinByName("1")
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, gn1, test.ShouldNotBeNil)
+	// Our test framework uses reflection to walk the structs it asserts on. However, gn1 (and
+	// later gn2) contains a mutex that was locked and unlocked by a background goroutine when it
+	// was constructed at the beginning of the test. That was so recent that the Go runtime
+	// environment will think there is a race condition when the test framework walks that part of
+	// the struct. To avoid that, we don't use the test framework directly here.
+	if (gn1 == nil ) {
+		t.FailNow()
+	}
 
 	gn2, err := b.GPIOPinByName("2")
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, gn2, test.ShouldNotBeNil)
+	if (gn2 == nil ) {
+		t.FailNow()
+	}
 }

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -278,7 +278,7 @@ func (pin *gpioPin) halfPwmCycle(ctx context.Context, shouldBeOn bool) bool {
 		pin.mu.Lock()
 		defer pin.mu.Unlock()
 		// Before we modify the pin, check if we should stop running
-		if ctx.Err() != nil {
+		if ctx.Err() != nil || !pin.enableSoftwarePWM.Load() {
 			return false
 		}
 
@@ -312,10 +312,10 @@ func (pin *gpioPin) softwarePwmLoop(ctx context.Context) {
 		case <-pin.startSoftwarePWMChan:
 		}
 		for {
-			if !pin.halfPwmCycle(ctx, true) || !pin.enableSoftwarePWM.Load() {
+			if !pin.halfPwmCycle(ctx, true) {
 				break
 			}
-			if !pin.halfPwmCycle(ctx, false) || !pin.enableSoftwarePWM.Load() {
+			if !pin.halfPwmCycle(ctx, false) {
 				break
 			}
 		}

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -31,7 +31,7 @@ type gpioPin struct {
 	hwPwm                *pwmDevice // Defined in hw_pwm.go, will be nil for pins that don't support it.
 	pwmFreqHz            uint
 	pwmDutyCyclePct      float64
-	enableSoftwarePWM    bool // Indicates whether a software PWM loop should continue running
+	enableSoftwarePWM    bool     // Indicates whether a software PWM loop should continue running
 	startSoftwarePWMChan chan any // Close and reinitialize this to (re)start the SW PWM loop
 
 	softwarePwm rdkutils.StoppableWorkers
@@ -233,7 +233,7 @@ func (pin *gpioPin) startSoftwarePWM() error {
 	// Sneaky trick alert! We use startSoftwarePWMChan to tell the background worker to start up.
 	// However, we have acquired the mutex, and if the background worker was already started
 	// (because it had been started, another goroutine told it to stop, and we are running so
-	// soon after that that it hasn't yet noticed it should stop), it's possible the background
+	// soon afterwards that it hasn't yet noticed it should stop), it's possible the background
 	// worker is still running and is about to acquire the mutex. If we tried sending a message on
 	// the channel in that situation, we would deadlock (we would wait until something can read
 	// from the channel, and the only goroutine that can read from it would wait until the mutex is

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -31,7 +31,7 @@ type gpioPin struct {
 	hwPwm                *pwmDevice // Defined in hw_pwm.go, will be nil for pins that don't support it.
 	pwmFreqHz            uint
 	pwmDutyCyclePct      float64
-	enableSoftwarePWM    bool     // Indicates whether a software PWM loop should continue running
+	enableSoftwarePWM    bool      // Indicates whether a software PWM loop should continue running
 	startSoftwarePWMChan *chan any // Close and reinitialize this to (re)start the SW PWM loop
 
 	softwarePwm rdkutils.StoppableWorkers

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -32,7 +32,7 @@ type gpioPin struct {
 	pwmFreqHz            uint
 	pwmDutyCyclePct      float64
 	enableSoftwarePWM    bool // Indicates whether a software PWM loop should continue running
-	startSoftwarePWMChan chan any // Write to this to tell the software PWM loop to start up (again)
+	startSoftwarePWMChan chan any // Close and reinitialize this to (re)start the SW PWM loop
 
 	softwarePwm rdkutils.StoppableWorkers
 
@@ -230,7 +230,18 @@ func (pin *gpioPin) startSoftwarePWM() error {
 	}
 
 	pin.enableSoftwarePWM = true
-	pin.startSoftwarePWMChan <- true
+	// Sneaky trick alert! We use startSoftwarePWMChan to tell the background worker to start up.
+	// However, we have acquired the mutex, and if the background worker was already started
+	// (because it had been started, another goroutine told it to stop, and we are running so
+	// soon after that that it hasn't yet noticed it should stop), it's possible the background
+	// worker is still running and is about to acquire the mutex. If we tried sending a message on
+	// the channel in that situation, we would deadlock (we would wait until something can read
+	// from the channel, and the only goroutine that can read from it would wait until the mutex is
+	// unlocked). So, instead, we send the message by closing the old channel and creating a new
+	// one: if the background worker was waiting on the channel, it will wake up when it closes,
+	// and if it was not waiting on the channel, we don't block waiting for it to start waiting.
+	close(pin.startSoftwarePWMChan)
+	pin.startSoftwarePWMChan = make(chan any)
 	return nil
 }
 

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -31,9 +31,10 @@ type gpioPin struct {
 	hwPwm                *pwmDevice // Defined in hw_pwm.go, will be nil for pins that don't support it.
 	pwmFreqHz            uint
 	pwmDutyCyclePct      float64
-	enableSoftwarePWM    bool
-	softwarePwm          rdkutils.StoppableWorkers
+	enableSoftwarePWM    bool // Indicates whether a software PWM loop should continue running
 	startSoftwarePWMChan chan any // Write to this to tell the software PWM loop to start up (again)
+
+	softwarePwm rdkutils.StoppableWorkers
 
 	mu     sync.Mutex
 	logger logging.Logger

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -322,9 +322,11 @@ func (pin *gpioPin) softwarePwmLoop(ctx context.Context) {
 		// it, and we might be running on a board with a small enough CPU that pointer assignment
 		// is not atomic. Lock the mutex when getting a copy of the channel, so we don't
 		// accidentally get half a pointer to an old one and half a pointer to a new one.
-		pin.mu.Lock()
-		startSoftwarePWMChan := pin.startSoftwarePWMChan
-		pin.mu.Unlock()
+		startSoftwarePWMChan := func() chan any {
+			pin.mu.Lock()
+			defer pin.mu.Unlock()
+			return pin.startSoftwarePWMChan
+		}()
 
 		select {
 		case <-ctx.Done():

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -322,11 +322,9 @@ func (pin *gpioPin) softwarePwmLoop(ctx context.Context) {
 		// it, and we might be running on a board with a small enough CPU that pointer assignment
 		// is not atomic. Lock the mutex when getting a copy of the channel, so we don't
 		// accidentally get half a pointer to an old one and half a pointer to a new one.
-		startSoftwarePWMChan := func() chan any {
-			pin.mu.Lock()
-			defer pin.mu.Unlock()
-			return pin.startSoftwarePWMChan
-		}()
+		pin.mu.Lock()
+		startSoftwarePWMChan := pin.startSoftwarePWMChan
+		pin.mu.Unlock()
 
 		select {
 		case <-ctx.Done():

--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -322,16 +322,16 @@ func (pin *gpioPin) softwarePwmLoop(ctx context.Context) {
 		// it, and we might be running on a board with a small enough CPU that pointer assignment
 		// is not atomic. Lock the mutex when getting a copy of the channel, so we don't
 		// accidentally get half a pointer to an old one and half a pointer to a new one.
-		startSoftwarePWMChan := func() chan any {
+		startSoftwarePWMChan := func() *chan any {
 			pin.mu.Lock()
 			defer pin.mu.Unlock()
-			return pin.startSoftwarePWMChan
+			return &pin.startSoftwarePWMChan
 		}()
 
 		select {
 		case <-ctx.Done():
 			return
-		case <-startSoftwarePWMChan:
+		case <-*startSoftwarePWMChan:
 		}
 		for {
 			if !pin.halfPwmCycle(ctx, true) {


### PR DESCRIPTION
Thanks to @oliviamiller for helping debug this with me! 

Tried on an Orin Nano: I'm no longer able to deadlock the pins! (though admittedly it's possible I just haven't tried hard enough, and I should continue trying to deadlock them. but it used to be way easier to deadlock!)

The idea here is that we only start up the background goroutine to do software PWM once per pin at the very beginning, and that background goroutine mostly sits around waiting to be told to start doing things. It gets stopped only once, when the pin is `Close`d.

There are 2 new fields in the struct:
- `enableSoftwarePWM` is a bool, that should only be read or written when the mutex is locked. Set it to false to tell the software PWM goroutine to go back to waiting, and set it to true to tell that goroutine to continue running if it's already started a loop.
- `startSoftwarePWMChan` is a channel. You should _close_ it (and immediately reinitialize it so it's ready for next time) to tell the background goroutine to start. Because you need to reinitialize it, this should only be done when you've locked the mutex.