### PR TITLE
reset logger level when config isnt present

### DIFF
--- a/config/reader_test.go
+++ b/config/reader_test.go
@@ -435,10 +435,38 @@ func TestProcessConfigRegistersLogConfig(t *testing.T) {
 	logger, ok := logging.LoggerNamed(serviceLoggerName)
 	test.That(t, ok, test.ShouldBeTrue)
 	test.That(t, logger.GetLevel().String(), test.ShouldEqual, "Warn")
-	test.That(t, logging.DeregisterLogger(serviceLoggerName), test.ShouldBeTrue)
 
 	logger, ok = logging.LoggerNamed(componentLoggerName)
 	test.That(t, ok, test.ShouldBeTrue)
 	test.That(t, logger.GetLevel().String(), test.ShouldEqual, "Debug")
+
+	// remove resource patterns
+	unprocessedConfig.Components = nil
+	unprocessedConfig.Services = nil
+	_, err = processConfig(&unprocessedConfig, true, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	logger, ok = logging.LoggerNamed(serviceLoggerName)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, logger.GetLevel().String(), test.ShouldEqual, "Error")
+
+	logger, ok = logging.LoggerNamed(componentLoggerName)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, logger.GetLevel().String(), test.ShouldEqual, "Error")
+
+	// remove log patterns
+	unprocessedConfig.LogConfig = nil
+	_, err = processConfig(&unprocessedConfig, true, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	logger, ok = logging.LoggerNamed(serviceLoggerName)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, logger.GetLevel().String(), test.ShouldEqual, "Info")
+
+	logger, ok = logging.LoggerNamed(componentLoggerName)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, logger.GetLevel().String(), test.ShouldEqual, "Info")
+
+	test.That(t, logging.DeregisterLogger(serviceLoggerName), test.ShouldBeTrue)
 	test.That(t, logging.DeregisterLogger(componentLoggerName), test.ShouldBeTrue)
 }

--- a/logging/log_config_test.go
+++ b/logging/log_config_test.go
@@ -88,7 +88,6 @@ func TestUpdateLoggerRegistry(t *testing.T) {
 		loggerConfig    []LoggerPatternConfig
 		loggerNames     []string
 		expectedMatches map[string]string
-		doesError       bool
 	}
 
 	tests := []testCfg{
@@ -107,7 +106,6 @@ func TestUpdateLoggerRegistry(t *testing.T) {
 			expectedMatches: map[string]string{
 				"rdk.resource_manager": "WARN",
 			},
-			doesError: false,
 		},
 		{
 			loggerConfig: []LoggerPatternConfig{
@@ -126,7 +124,6 @@ func TestUpdateLoggerRegistry(t *testing.T) {
 				"rdk.test_manager.modmanager":             "DEBUG",
 				"rdk.resource_manager.package.modmanager": "DEBUG",
 			},
-			doesError: false,
 		},
 		{
 			loggerConfig: []LoggerPatternConfig{
@@ -144,7 +141,6 @@ func TestUpdateLoggerRegistry(t *testing.T) {
 				"rdk.resource_manager.modmanager": "ERROR",
 				"rdk.test_manager.modmanager":     "ERROR",
 			},
-			doesError: false,
 		},
 		{
 			loggerConfig: []LoggerPatternConfig{
@@ -163,7 +159,6 @@ func TestUpdateLoggerRegistry(t *testing.T) {
 			expectedMatches: map[string]string{
 				"rdk.resource_manager": "WARN",
 			},
-			doesError: false,
 		},
 		{
 			loggerConfig: []LoggerPatternConfig{
@@ -180,7 +175,6 @@ func TestUpdateLoggerRegistry(t *testing.T) {
 				"rdk.resource_manager.modmanager":                 "WARN",
 				"rdk.resource_manager.package_manager.modmanager": "WARN",
 			},
-			doesError: false,
 		},
 		{
 			loggerConfig: []LoggerPatternConfig{
@@ -193,7 +187,6 @@ func TestUpdateLoggerRegistry(t *testing.T) {
 				"rdk.resource_manager",
 			},
 			expectedMatches: map[string]string{},
-			doesError:       true,
 		},
 		{
 			loggerConfig: []LoggerPatternConfig{
@@ -208,7 +201,6 @@ func TestUpdateLoggerRegistry(t *testing.T) {
 			expectedMatches: map[string]string{
 				"a.b.c": "INFO",
 			},
-			doesError: false,
 		},
 	}
 
@@ -216,12 +208,7 @@ func TestUpdateLoggerRegistry(t *testing.T) {
 		testRegistry := createTestRegistry(tc.loggerNames)
 
 		err := testRegistry.updateLoggerRegistry(tc.loggerConfig)
-		if tc.doesError {
-			test.That(t, err, test.ShouldNotBeNil)
-			continue
-		}
 		test.That(t, err, test.ShouldBeNil)
-
 		test.That(t, verifySetLevels(testRegistry, tc.expectedMatches), test.ShouldBeTrue)
 	}
 }

--- a/logging/logger_registry.go
+++ b/logging/logger_registry.go
@@ -82,6 +82,9 @@ func (lr *loggerRegistry) updateLoggerLevel(name string, level Level) error {
 }
 
 func (lr *loggerRegistry) updateLoggerRegistry(logConfig []LoggerPatternConfig) error {
+	for _, name := range lr.getRegisteredLoggerNames() {
+		lr.updateLoggerLevel(name, INFO)
+	}
 	for _, lpc := range logConfig {
 		if !validatePattern(lpc.Pattern) {
 			return errors.New("failed to validate a pattern")

--- a/logging/logger_registry.go
+++ b/logging/logger_registry.go
@@ -83,7 +83,10 @@ func (lr *loggerRegistry) updateLoggerLevel(name string, level Level) error {
 
 func (lr *loggerRegistry) updateLoggerRegistry(logConfig []LoggerPatternConfig) error {
 	for _, name := range lr.getRegisteredLoggerNames() {
-		lr.updateLoggerLevel(name, INFO)
+		err := lr.updateLoggerLevel(name, INFO)
+		if err != nil {
+			return nil
+		}
 	}
 	for _, lpc := range logConfig {
 		if !validatePattern(lpc.Pattern) {

--- a/logging/logger_registry.go
+++ b/logging/logger_registry.go
@@ -85,7 +85,7 @@ func (lr *loggerRegistry) updateLoggerRegistry(logConfig []LoggerPatternConfig) 
 	for _, name := range lr.getRegisteredLoggerNames() {
 		err := lr.updateLoggerLevel(name, INFO)
 		if err != nil {
-			return nil
+			return err
 		}
 	}
 	for _, lpc := range logConfig {

--- a/logging/logger_registry.go
+++ b/logging/logger_registry.go
@@ -189,11 +189,17 @@ func GetCurrentConfig() []LoggerPatternConfig {
 // Consider removing this as a part of or after RSDK-8291 (https://viam.atlassian.net/browse/RSDK-8291)
 // which may consolidate various calls to the rdk.networking logger into one.
 func GetOrNewLogger(name string) (logger Logger) {
+	logger, ok := globalLoggerRegistry.loggerNamed(name)
 	globalLoggerRegistry.mu.Lock()
 	defer globalLoggerRegistry.mu.Unlock()
-	logger, ok := globalLoggerRegistry.loggers[name]
 	if !ok {
-		return NewLogger(name)
+		logger = &impl{
+			name:       name,
+			level:      NewAtomicLevelAt(INFO),
+			appenders:  []Appender{NewStdoutAppender()},
+			testHelper: func() {},
+		}
+		globalLoggerRegistry.loggers[name] = logger
 	}
 	return logger
 }

--- a/logging/logger_registry.go
+++ b/logging/logger_registry.go
@@ -189,9 +189,9 @@ func GetCurrentConfig() []LoggerPatternConfig {
 // Consider removing this as a part of or after RSDK-8291 (https://viam.atlassian.net/browse/RSDK-8291)
 // which may consolidate various calls to the rdk.networking logger into one.
 func GetOrNewLogger(name string) (logger Logger) {
-	logger, ok := globalLoggerRegistry.loggerNamed(name)
 	globalLoggerRegistry.mu.Lock()
 	defer globalLoggerRegistry.mu.Unlock()
+	logger, ok := globalLoggerRegistry.loggers[name]
 	if !ok {
 		logger = &impl{
 			name:       name,

--- a/logging/logger_registry.go
+++ b/logging/logger_registry.go
@@ -184,6 +184,8 @@ func GetCurrentConfig() []LoggerPatternConfig {
 	return globalLoggerRegistry.getCurrentConfig()
 }
 
+// GetOrNewLogger returns a logger with the specified name if it exists, otherwise it
+// creates and registers one with the same name.
 // Consider removing this as a part of or after RSDK-8291 (https://viam.atlassian.net/browse/RSDK-8291)
 // which may consolidate various calls to the rdk.networking logger into one.
 func GetOrNewLogger(name string) (logger Logger) {

--- a/logging/logger_registry_test.go
+++ b/logging/logger_registry_test.go
@@ -166,3 +166,30 @@ func TestGetCurrentConfig(t *testing.T) {
 	manager.registerConfig(logCfg)
 	test.That(t, manager.getCurrentConfig(), test.ShouldResemble, logCfg)
 }
+
+func TestLoggerLevelReset(t *testing.T) {
+	manager := mockRegistry()
+	manager.registerLogger("a", NewLogger("a"))
+	logCfg := []LoggerPatternConfig{
+		{
+			Pattern: "a",
+			Level:   "WARN",
+		},
+	}
+
+	err := manager.registerConfig(logCfg)
+	test.That(t, err, test.ShouldBeNil)
+
+	logger, ok := manager.loggerNamed("a")
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, logger.GetLevel().String(), test.ShouldEqual, "Warn")
+
+	logCfg = []LoggerPatternConfig{}
+
+	err = manager.registerConfig(logCfg)
+	test.That(t, err, test.ShouldBeNil)
+
+	logger, ok = manager.loggerNamed("a")
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, logger.GetLevel().String(), test.ShouldEqual, "Info")
+}

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -78,6 +78,10 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 	logger := logging.NewLogger("")
 	logging.ReplaceGlobal(logger)
 	logger = logger.Sublogger("rdk")
+
+	//nolint:UnusedVar
+	registryLogger := logger.Sublogger("logging")
+
 	config.InitLoggingSettings(logger, argsParsed.Debug)
 
 	// Always log the version, return early if the '-version' flag was provided

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -78,9 +78,7 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 	logger := logging.NewLogger("")
 	logging.ReplaceGlobal(logger)
 	logger = logger.Sublogger("rdk")
-
-	//nolint:UnusedVar
-	registryLogger := logger.Sublogger("logging")
+	logger.Sublogger("logging")
 
 	config.InitLoggingSettings(logger, argsParsed.Debug)
 


### PR DESCRIPTION
Issue: Suppose we had a registered logger named `a.b.c` that we configured to have the level `WARN`. Then, we removed this configuration option and reconfigured. The `a.b.c` logger will still be set to `WARN` despite not specifying this.

Solution: Any loggers that no longer have a configuration are reset back to `INFO`. Also, logger changes are applied only once, so there is no undefined behavior of logs during reconfiguration.
