### PR TITLE
RSDK-8367 Fix bug preventing use of cbirrt when topological constraints are enabled

### DIFF
--- a/motionplan/planManager.go
+++ b/motionplan/planManager.go
@@ -25,6 +25,9 @@ const (
 	defaultOptimalityMultiple      = 2.0
 	defaultFallbackTimeout         = 1.5
 	defaultTPspaceOrientationScale = 500.
+
+	cbirrtName  = "cbirrt"
+	rrtstarName = "rrtstar"
 )
 
 // planManager is intended to be the single entry point to motion planners, wrapping all others, dealing with fallbacks, etc.
@@ -560,9 +563,6 @@ func (pm *planManager) plannerSetupFromMoveRequest(
 	}
 
 	hasTopoConstraint := opt.addPbTopoConstraints(from, to, constraints)
-	if hasTopoConstraint {
-		planAlg = "cbirrt"
-	}
 
 	// error handling around extracting motion_profile information from map[string]interface{}
 	var motionProfile string
@@ -590,21 +590,26 @@ func (pm *planManager) plannerSetupFromMoveRequest(
 		if !ok {
 			return nil, errors.New("could not interpret planning_alg field as string")
 		}
-		if pm.useTPspace && planAlg != "" {
-			return nil, fmt.Errorf("cannot specify a planning_alg when planning for a TP-space frame. alg specified was %s", planAlg)
+	}
+	if pm.useTPspace && planAlg != "" {
+		return nil, fmt.Errorf("cannot specify a planning_alg when planning for a TP-space frame. alg specified was %s", planAlg)
+	}
+	if hasTopoConstraint {
+		if planAlg != "" && planAlg != cbirrtName {
+			return nil, fmt.Errorf("cannot specify a planning alg other than cbirrt with topo constraints. alg specified was %s", planAlg)
 		}
-		switch planAlg {
-		// TODO(pl): make these consts
-		case "cbirrt":
-			opt.PlannerConstructor = newCBiRRTMotionPlanner
-		case "rrtstar":
-			// no motion profiles for RRT*
-			opt.PlannerConstructor = newRRTStarConnectMotionPlanner
-			// TODO(pl): more logic for RRT*?
-			return opt, nil
-		default:
-			// use default, already set
-		}
+		planAlg = cbirrtName
+	}
+	switch planAlg {
+	case cbirrtName:
+		opt.PlannerConstructor = newCBiRRTMotionPlanner
+	case rrtstarName:
+		// no motion profiles for RRT*
+		opt.PlannerConstructor = newRRTStarConnectMotionPlanner
+		// TODO(pl): more logic for RRT*?
+		return opt, nil
+	default:
+		// use default, already set
 	}
 	if pm.useTPspace {
 		// overwrite default with TP space

--- a/motionplan/rrt.go
+++ b/motionplan/rrt.go
@@ -268,7 +268,12 @@ type rrtPlan struct {
 
 func newRRTPlan(solution []node, sf *solverFrame, relative bool) (Plan, error) {
 	if len(solution) < 2 {
-		return nil, errors.New("cannot construct a Plan using fewer than two nodes")
+		if len(solution) == 1 {
+			// Started at the goal, nothing to do
+			solution = append(solution, solution[0])
+		} else {
+			return nil, errors.New("cannot construct a Plan using fewer than two nodes")
+		}
 	}
 	traj := sf.nodesToTrajectory(solution)
 	path, err := newPath(solution, sf)


### PR DESCRIPTION
This managed to go unnoticed until now because we still broke the path up into small sub-waypoints, allowing rrt star to mostly approximate a linear path...except when it didn't.

This also fixes RSDK-8352 as a drive-by