### PR TITLE
Switch runners to github.

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,6 +1,11 @@
 self-hosted-runner:
   labels:
+    - macos-13
     - pi4
+    - pi5
+    - ubuntu-large
+    - ubuntu-large-arm
+    - ubuntu-small-arm
     - buildjet-2vcpu-ubuntu-2204
     - buildjet-4vcpu-ubuntu-2204
     - buildjet-8vcpu-ubuntu-2204

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -22,11 +22,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - arch: [ubuntu-latest]
+          - arch: ubuntu-latest
             image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
             platform: linux/amd64
             label: amd64
-          - arch: [github-linux-arm64-2core]
+          - arch: ubuntu-small-arm
             image: ghcr.io/viamrobotics/rdk-devenv:arm64-cache
             platform: linux/arm64
             label: arm64
@@ -103,7 +103,7 @@ jobs:
   # this job builds the 32-bit RDK binary
   appimage-static-32bit:
     name: static 32-bit for appimage
-    runs-on: github-linux-arm64-2core
+    runs-on: ubuntu-small-arm
     steps:
     - uses: actions/checkout@v4
       with:
@@ -182,7 +182,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [[ubuntu-latest], [github-linux-arm64-2core], [arm64, pi4]]
+        arch: [[ubuntu-latest], [ubuntu-small-arm], [pi4], [pi5]]
     needs: appimage
     runs-on: ${{ matrix.arch }}
     timeout-minutes: 15
@@ -198,7 +198,7 @@ jobs:
 
     - name: Test AppImage
       run: |
-        if echo "${{ matrix.arch[0] }}" | grep -q -E 'ubuntu|github-linux'; then
+        if echo "${{ matrix.arch[0] }}" | grep -q 'ubuntu'; then
           sudo apt-get install -y libfuse2
         fi
         channel="${{ github.ref_name }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,33 +20,33 @@ jobs:
       matrix:
         include:
         # rdk-devenv
-        - arch: buildjet-2vcpu-ubuntu-2204
+        - arch: ubuntu-latest
           tag: amd64
           platform: linux/amd64
           image: rdk-devenv
           file: etc/Dockerfile.cache
-        - arch: buildjet-4vcpu-ubuntu-2204-arm
+        - arch: ubuntu-small-arm
           tag: arm64
           platform: linux/arm64
           image: rdk-devenv
           file: etc/Dockerfile.cache
-        - arch: buildjet-2vcpu-ubuntu-2204-arm
+        - arch: ubuntu-small-arm
           tag: armhf
           platform: linux/arm/v7
           image: rdk-devenv
           file: etc/Dockerfile.cache
         # antique2
-        - arch: buildjet-2vcpu-ubuntu-2204
+        - arch: ubuntu-latest
           platform: linux/amd64
           image: antique2
           file: etc/Dockerfile.antique-cache
           tag: amd64
-        - arch: buildjet-2vcpu-ubuntu-2204-arm
+        - arch: ubuntu-small-arm
           platform: linux/arm64
           image: antique2
           file: etc/Dockerfile.antique-cache
           tag: arm64
-        - arch: buildjet-2vcpu-ubuntu-2204-arm
+        - arch: ubuntu-small-arm
           platform: linux/arm/v7
           image: antique2
           file: etc/Dockerfile.antique-cache

--- a/.github/workflows/motion-benchmarks.yml
+++ b/.github/workflows/motion-benchmarks.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   motion_benchmarks:
     name:  Motion Benchmarks
-    runs-on: [buildjet-8vcpu-ubuntu-2204]
+    runs-on: ubuntu-large
     container: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
     timeout-minutes: 30
     env:

--- a/.github/workflows/motion-tests.yml
+++ b/.github/workflows/motion-tests.yml
@@ -32,7 +32,7 @@ jobs:
   motion-tests-extended:
     name:  Motion Extended Tests
     needs: check-files
-    runs-on: [buildjet-8vcpu-ubuntu-2204]
+    runs-on: ubuntu-large
     container: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
     if: ${{ needs.check-files.outputs.EXTENDED_MOTION_TEST == 'true' }}
     timeout-minutes: 30

--- a/.github/workflows/staticbuild.yml
+++ b/.github/workflows/staticbuild.yml
@@ -37,7 +37,7 @@ jobs:
           - arch: ubuntu-latest
             image: ghcr.io/viamrobotics/antique2:amd64-cache
             platform: linux/amd64
-          - arch: github-linux-arm64-2core
+          - arch: ubuntu-small-arm
             image: ghcr.io/viamrobotics/antique2:arm64-cache
             platform: linux/arm64
     runs-on: ${{ matrix.arch }}
@@ -143,7 +143,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [[ubuntu-latest], [github-linux-arm64-2core], [arm64, pi4]]
+        arch: [[ubuntu-latest], [ubuntu-small-arm], [pi4], [pi5]]
     needs: static
     runs-on: ${{ matrix.arch }}
     timeout-minutes: 15

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,11 +20,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - arch: [buildjet-8vcpu-ubuntu-2204]
+          - arch: ubuntu-large
             image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
             platform: linux/amd64
             platform_name: linux-amd64
-          - arch: github-linux-arm64-8core
+          - arch: ubuntu-large-arm
             image: ghcr.io/viamrobotics/rdk-devenv:arm64-cache
             platform: linux/arm64
             platform_name: linux-arm64
@@ -92,11 +92,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - arch: [buildjet-8vcpu-ubuntu-2204]
+          - arch: ubuntu-large
             image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
             platform: linux/amd64
             platform_name: linux-amd64
-          - arch: github-linux-arm64-8core
+          - arch: ubuntu-large-arm
             image: ghcr.io/viamrobotics/rdk-devenv:arm64-cache
             platform: linux/arm64
             platform_name: linux-arm64
@@ -157,7 +157,7 @@ jobs:
 
   test32:
     name: Go 32-bit Unit Tests
-    runs-on: github-linux-arm64-8core
+    runs-on: ubuntu-large-arm
     timeout-minutes: 30
 
     steps:
@@ -206,7 +206,7 @@ jobs:
 
   test_web_e2e:
     name: Test End-to-End and Web
-    runs-on: [buildjet-4vcpu-ubuntu-2204]
+    runs-on: ubuntu-latest
     container: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
Switching runners to avoid long queues

Also, simplify our large-runner names to just "small" and "large" varients, rather than individual cpu counts.