### PR TITLE
Use StoppableWorkers in the GPS DataReaders

### DIFF
--- a/components/movementsensor/gpsnmea/pmtkI2C.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C.go
@@ -37,7 +37,7 @@ func MakePmtkI2cGpsNmea(
 	logger logging.Logger,
 	i2cBus buses.I2C,
 ) (movementsensor.MovementSensor, error) {
-	dev, err := gpsutils.NewI2cDataReader(*conf.I2CConfig, i2cBus, logger)
+	dev, err := gpsutils.NewI2cDataReader(ctx, *conf.I2CConfig, i2cBus, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/components/movementsensor/gpsnmea/serial.go
+++ b/components/movementsensor/gpsnmea/serial.go
@@ -12,7 +12,7 @@ import (
 
 // NewSerialGPSNMEA creates a component that communicates over a serial port.
 func NewSerialGPSNMEA(ctx context.Context, name resource.Name, conf *Config, logger logging.Logger) (movementsensor.MovementSensor, error) {
-	dev, err := gpsutils.NewSerialDataReader(conf.SerialConfig, logger)
+	dev, err := gpsutils.NewSerialDataReader(ctx, conf.SerialConfig, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/components/movementsensor/gpsrtk/pmtk.go
+++ b/components/movementsensor/gpsrtk/pmtk.go
@@ -131,7 +131,7 @@ func makeRTKI2C(
 
 	// If we have a mock I2C bus, pass that in, too. If we don't, it'll be nil and constructing the
 	// reader will create a real I2C bus instead.
-	dev, err := gpsutils.NewI2cDataReader(i2cConfig, mockI2c, logger)
+	dev, err := gpsutils.NewI2cDataReader(ctx, i2cConfig, mockI2c, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/components/movementsensor/gpsrtk/serial.go
+++ b/components/movementsensor/gpsrtk/serial.go
@@ -132,7 +132,7 @@ func newRTKSerial(
 		SerialPath:     newConf.SerialPath,
 		SerialBaudRate: newConf.SerialBaudRate,
 	}
-	dev, err := gpsutils.NewSerialDataReader(serialConfig, logger)
+	dev, err := gpsutils.NewSerialDataReader(ctx, serialConfig, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/components/movementsensor/gpsutils/i2c_data_reader.go
+++ b/components/movementsensor/gpsutils/i2c_data_reader.go
@@ -56,11 +56,11 @@ func NewI2cDataReader(
 
 	data := make(chan string)
 	reader := PmtkI2cDataReader{
-		data:       data,
-		logger:     logger,
-		bus:        bus,
-		addr:       byte(addr),
-		baud:       baud,
+		data:   data,
+		logger: logger,
+		bus:    bus,
+		addr:   byte(addr),
+		baud:   baud,
 	}
 
 	if err := reader.initialize(ctx); err != nil {

--- a/components/movementsensor/gpsutils/i2c_data_reader.go
+++ b/components/movementsensor/gpsutils/i2c_data_reader.go
@@ -68,7 +68,7 @@ func NewI2cDataReader(config I2CConfig, bus buses.I2C, logger logging.Logger) (D
 		return nil, err
 	}
 
-	reader.start()
+	reader.backgroundWorker()
 	return &reader, nil
 }
 
@@ -124,9 +124,9 @@ func (dr *PmtkI2cDataReader) readData() ([]byte, error) {
 	return buffer, nil
 }
 
-// start spins up a background coroutine to read data from the I2C bus and put it into the channel
-// of complete messages.
-func (dr *PmtkI2cDataReader) start() {
+// backgroundWorker should be run in a background coroutine. It reads data from the I2C bus and
+// puts it into the channel of complete messages.
+func (dr *PmtkI2cDataReader) backgroundWorker() {
 	dr.activeBackgroundWorkers.Add(1)
 	utils.PanicCapturingGo(func() {
 		defer dr.activeBackgroundWorkers.Done()

--- a/components/movementsensor/gpsutils/i2c_data_reader.go
+++ b/components/movementsensor/gpsutils/i2c_data_reader.go
@@ -123,7 +123,7 @@ func (dr *PmtkI2cDataReader) readData(cancelCtx context.Context) ([]byte, error)
 	return buffer, nil
 }
 
-// backgroundWorker should be run in a background coroutine. It reads data from the I2C bus and
+// backgroundWorker should be run in a background goroutine. It reads data from the I2C bus and
 // puts it into the channel of complete messages.
 func (dr *PmtkI2cDataReader) backgroundWorker(cancelCtx context.Context) {
 	defer close(dr.data)

--- a/components/movementsensor/gpsutils/serial_data_reader.go
+++ b/components/movementsensor/gpsutils/serial_data_reader.go
@@ -11,20 +11,18 @@ import (
 	"sync"
 
 	"github.com/jacobsa/go-serial/serial"
-	"go.viam.com/utils"
 
 	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/utils"
 )
 
 // SerialDataReader implements the DataReader interface (defined in component.go) by interacting
 // with the device over a serial port.
 type SerialDataReader struct {
-	dev                     io.ReadWriteCloser
-	data                    chan string
-	cancelCtx               context.Context
-	cancelFunc              func()
-	activeBackgroundWorkers sync.WaitGroup
-	logger                  logging.Logger
+	dev     io.ReadWriteCloser
+	data    chan string
+	workers utils.StoppableWorkers
+	logger  logging.Logger
 }
 
 // NewSerialDataReader constructs a new DataReader that gets its NMEA messages over a serial port.
@@ -54,41 +52,40 @@ func NewSerialDataReader(config *SerialConfig, logger logging.Logger) (DataReade
 	}
 
 	data := make(chan string)
-	cancelCtx, cancelFunc := context.WithCancel(context.Background())
 
 	reader := SerialDataReader{
 		dev:        dev,
 		data:       data,
-		cancelCtx:  cancelCtx,
-		cancelFunc: cancelFunc,
 		logger:     logger,
 	}
-	reader.backgroundWorker()
+	reader.workers = utils.NewStoppableWorkers(reader.backgroundWorker)
 
 	return &reader, nil
 }
 
-func (dr *SerialDataReader) backgroundWorker() {
-	dr.activeBackgroundWorkers.Add(1)
-	utils.PanicCapturingGo(func() {
-		defer dr.activeBackgroundWorkers.Done()
-		defer close(dr.data)
+func (dr *SerialDataReader) backgroundWorker(cancelCtx context.Context) {
+	defer close(dr.data)
 
-		r := bufio.NewReader(dr.dev)
-		for {
-			line, err := r.ReadString('\n')
-			if err != nil {
-				dr.logger.CErrorf(dr.cancelCtx, "can't read gps serial %s", err)
-				continue // The line has bogus data; don't put it in the channel.
-			}
-
-			select {
-			case <-dr.cancelCtx.Done():
-				return
-			case dr.data <- line:
-			}
+	r := bufio.NewReader(dr.dev)
+	for {
+		select {
+		case <-cancelCtx.Done():
+			return
+		default:
 		}
-	})
+
+		line, err := r.ReadString('\n')
+		if err != nil {
+			dr.logger.CErrorf(cancelCtx, "can't read gps serial %s", err)
+			continue // The line has bogus data; don't put it in the channel.
+		}
+
+		select {
+		case <-cancelCtx.Done():
+			return
+		case dr.data <- line:
+		}
+	}
 }
 
 // Messages returns the channel of complete NMEA sentences we have read off of the device. It's part
@@ -100,13 +97,6 @@ func (dr *SerialDataReader) Messages() chan string {
 // Close is part of the DataReader interface. It shuts everything down, including our connection to
 // the serial port.
 func (dr *SerialDataReader) Close() error {
-	dr.cancelFunc()
-	// If the background coroutine is trying to put a new line of data into the channel, it won't
-	// notice that we've canceled it until something tries taking the line out of the channel. So,
-	// let's try to read that out so the coroutine isn't stuck. If the background coroutine shut
-	// itself down already, the channel will be closed and reading something out of it will just
-	// return the empty string.
-	<-dr.data
-	dr.activeBackgroundWorkers.Wait()
+	dr.workers.Stop()
 	return dr.dev.Close()
 }

--- a/components/movementsensor/gpsutils/serial_data_reader.go
+++ b/components/movementsensor/gpsutils/serial_data_reader.go
@@ -76,17 +76,12 @@ func (dr *SerialDataReader) start() {
 
 		r := bufio.NewReader(dr.dev)
 		for {
-			select {
-			case <-dr.cancelCtx.Done():
-				return
-			default:
-			}
-
 			line, err := r.ReadString('\n')
 			if err != nil {
 				dr.logger.CErrorf(dr.cancelCtx, "can't read gps serial %s", err)
 				continue // The line has bogus data; don't put it in the channel.
 			}
+
 			select {
 			case <-dr.cancelCtx.Done():
 				return

--- a/components/movementsensor/gpsutils/serial_data_reader.go
+++ b/components/movementsensor/gpsutils/serial_data_reader.go
@@ -25,7 +25,11 @@ type SerialDataReader struct {
 }
 
 // NewSerialDataReader constructs a new DataReader that gets its NMEA messages over a serial port.
-func NewSerialDataReader(config *SerialConfig, logger logging.Logger) (DataReader, error) {
+func NewSerialDataReader(
+	ctx context.Context,
+	config *SerialConfig,
+	logger logging.Logger,
+) (DataReader, error) {
 	serialPath := config.SerialPath
 	if serialPath == "" {
 		return nil, fmt.Errorf("SerialNMEAMovementSensor expected non-empty string for %q", config.SerialPath)

--- a/components/movementsensor/gpsutils/serial_data_reader.go
+++ b/components/movementsensor/gpsutils/serial_data_reader.go
@@ -53,9 +53,9 @@ func NewSerialDataReader(config *SerialConfig, logger logging.Logger) (DataReade
 	data := make(chan string)
 
 	reader := SerialDataReader{
-		dev:        dev,
-		data:       data,
-		logger:     logger,
+		dev:    dev,
+		data:   data,
+		logger: logger,
 	}
 	reader.workers = utils.NewStoppableWorkers(reader.backgroundWorker)
 

--- a/components/movementsensor/gpsutils/serial_data_reader.go
+++ b/components/movementsensor/gpsutils/serial_data_reader.go
@@ -87,7 +87,11 @@ func (dr *SerialDataReader) start() {
 				dr.logger.CErrorf(dr.cancelCtx, "can't read gps serial %s", err)
 				continue // The line has bogus data; don't put it in the channel.
 			}
-			dr.data <- line
+			select {
+			case <-dr.cancelCtx.Done():
+				return
+			case dr.data <- line:
+			}
 		}
 	})
 }

--- a/components/movementsensor/gpsutils/serial_data_reader.go
+++ b/components/movementsensor/gpsutils/serial_data_reader.go
@@ -63,12 +63,12 @@ func NewSerialDataReader(config *SerialConfig, logger logging.Logger) (DataReade
 		cancelFunc: cancelFunc,
 		logger:     logger,
 	}
-	reader.start()
+	reader.backgroundWorker()
 
 	return &reader, nil
 }
 
-func (dr *SerialDataReader) start() {
+func (dr *SerialDataReader) backgroundWorker() {
 	dr.activeBackgroundWorkers.Add(1)
 	utils.PanicCapturingGo(func() {
 		defer dr.activeBackgroundWorkers.Done()

--- a/components/movementsensor/gpsutils/serial_data_reader.go
+++ b/components/movementsensor/gpsutils/serial_data_reader.go
@@ -68,6 +68,8 @@ func (dr *SerialDataReader) backgroundWorker(cancelCtx context.Context) {
 
 	r := bufio.NewReader(dr.dev)
 	for {
+		// Even if r.ReadString(), below, always returns errors and we never get to the bottom of
+		// the loop, make sure we can still exit when we're supposed to.
 		select {
 		case <-cancelCtx.Done():
 			return

--- a/components/movementsensor/gpsutils/serial_data_reader.go
+++ b/components/movementsensor/gpsutils/serial_data_reader.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"sync"
 
 	"github.com/jacobsa/go-serial/serial"
 


### PR DESCRIPTION
I recommend reviewing this while suppressing whitespace changes; otherwise the diff is way bigger than it should be (60ish lines of code merely became less indented).

Changes include:
- `start()` in both the `PmtkI2cDataReader` and `SerialDataReader` classes has been renamed `backgroundWorker`, and no longer spawns a background goroutine (it's just the implementation of the code that should run in the background). 
- `gpsutils.NewI2cDataReader` takes in a context. Should `gpsutils.NewSerialDataReader` take in a context it doesn't use, just to keep consistency? I'm unsure.
- The background goroutines in both data readers check their context while trying to put data into the output channel. This greatly simplifies the implementation of `Close()`, because you don't need to read from the output channel to trigger the background worker shutting down.

Tried on John-Pi: the NMEA component seems to work fine with both serial and I2C connections, and the RTK component seems to work fine with both VRS and non-VRS casters, with both serial and I2C connections.