### PR TITLE
RSDK-6712 APP-3548 meta.json overrides section

### DIFF
--- a/cli/archive.go
+++ b/cli/archive.go
@@ -80,6 +80,7 @@ func createArchive(files []string, buf, stdout io.Writer) error {
 }
 
 func addToArchive(tw *tar.Writer, filename string) error {
+	// TODO(go1.22): use Writer.AddFS.
 	// Open the file which will be written into the archive
 	//nolint:gosec
 	file, err := os.Open(filename)

--- a/cli/module.schema.json
+++ b/cli/module.schema.json
@@ -37,6 +37,20 @@
         },
         "build": {
             "$ref": "#/$defs/build_section"
+        },
+        "overrides": {
+            "type": "object",
+            "description": "Platform overrides that override other fields in meta.json. Keys here take the form 'linux/arm64;dev'; see examples.",
+            "examples": [
+                {";dev": {"entrypoint": "run.sh"}},
+                {"darwin": {"build.setup": "brew install"}},
+                {"linux/arm64": {}}
+            ],
+            "additionalProperties": {
+                "type": "object",
+                "description": "A map like {\"build.setup\": \"brew install\"}. The keys are dotted paths similar to jsonpath, the values are any replacement value.",
+                "examples": [{"entrypoint": "run.sh"}, {"build.setup": "brew install"}, {"build.setup": "brew install"}]
+            }
         }
     },
     "required": [

--- a/cli/module.schema.json
+++ b/cli/module.schema.json
@@ -40,7 +40,7 @@
         },
         "overrides": {
             "type": "object",
-            "description": "Platform overrides that override other fields in meta.json. Keys here take the form 'linux/arm64;dev'; see examples.",
+            "description": "Platform overrides that override other fields in meta.json. Keys here take the form 'linux/arm64;dev'; see examples. The ';dev' suffix applies only in the `module reload` command.",
             "examples": [
                 {";dev": {"entrypoint": "run.sh"}},
                 {"darwin": {"build.setup": "brew install"}},

--- a/cli/module.schema.json
+++ b/cli/module.schema.json
@@ -40,16 +40,17 @@
         },
         "overrides": {
             "type": "object",
-            "description": "Platform overrides that override other fields in meta.json. Keys here take the form 'linux/arm64;dev'; see examples. The ';dev' suffix applies only in the `module reload` command.",
+            "description": "Platform overrides that override other fields in meta.json. Keys here take the form 'linux/arm64', see examples. The special 'dev' key applies only in the `module reload` command.",
             "examples": [
-                {";dev": {"entrypoint": "run.sh"}},
+                {"dev": {"entrypoint": "run.sh"}},
                 {"darwin": {"build.setup": "brew install"}},
-                {"linux/arm64": {}}
+                {"linux/arm64": {"entrypoint": "run-arm.sh"}},
+                {"linux/any": {"entrypoint": "run-linux.sh"}}
             ],
             "additionalProperties": {
                 "type": "object",
                 "description": "A map like {\"build.setup\": \"brew install\"}. The keys are dotted paths similar to jsonpath, the values are any replacement value.",
-                "examples": [{"entrypoint": "run.sh"}, {"build.setup": "brew install"}, {"build.setup": "brew install"}]
+                "examples": [{"entrypoint": "run.sh"}, {"build.setup": "brew install"}]
             }
         }
     },

--- a/cli/module.schema.json
+++ b/cli/module.schema.json
@@ -40,7 +40,7 @@
         },
         "overrides": {
             "type": "object",
-            "description": "Platform overrides that override other fields in meta.json. Keys here take the form 'linux/arm64', see examples. The special 'dev' key applies only in the `module reload` command.",
+            "description": "Platform overrides that override other fields in meta.json. Keys here take the form 'linux/arm64', see examples. The special 'dev' key applies only in the `module reload` command. When platforms and dev are both active, platforms will apply in alphabetical order and then dev. For example: [linux/any, linux/arm64, dev].",
             "examples": [
                 {"dev": {"entrypoint": "run.sh"}},
                 {"darwin": {"build.setup": "brew install"}},

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -499,12 +499,12 @@ func validateReloadableArchive(c *cli.Context, build *manifestBuildInfo) error {
 	if err != nil {
 		return err
 	}
-	defer reader.Close()
+	defer reader.Close() //nolint:errcheck
 	decompressed, err := gzip.NewReader(reader)
 	if err != nil {
 		return err
 	}
-	defer decompressed.Close()
+	defer decompressed.Close() //nolint:errcheck
 	archive := tar.NewReader(decompressed)
 	metaFound := false
 	for {

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -55,7 +55,7 @@ func ModuleBuildStartAction(cCtx *cli.Context) error {
 }
 
 func (c *viamClient) moduleBuildStartAction(cCtx *cli.Context) error {
-	manifest, err := loadManifest(cCtx.String(moduleFlagPath))
+	manifest, err := loadManifest(cCtx.String(moduleFlagPath), false)
 	if err != nil {
 		return err
 	}
@@ -86,7 +86,7 @@ func (c *viamClient) moduleBuildStartAction(cCtx *cli.Context) error {
 // ModuleBuildLocalAction runs the module's build commands locally.
 func ModuleBuildLocalAction(cCtx *cli.Context) error {
 	manifestPath := cCtx.String(moduleFlagPath)
-	manifest, err := loadManifest(manifestPath)
+	manifest, err := loadManifest(manifestPath, false)
 	if err != nil {
 		return err
 	}
@@ -142,7 +142,7 @@ func (c *viamClient) moduleBuildListAction(cCtx *cli.Context) error {
 		buildIDFilter = &filter
 	} else {
 		manifestPath := cCtx.String(moduleBuildFlagPath)
-		manifest, err := loadManifest(manifestPath)
+		manifest, err := loadManifest(manifestPath, false)
 		if err != nil {
 			return err
 		}
@@ -408,7 +408,7 @@ func reloadModuleAction(c *cli.Context, vc *viamClient) error {
 	if err != nil {
 		return err
 	}
-	manifest, err := loadManifestOrNil(c.String(moduleFlagPath))
+	manifest, err := loadManifestOrNil(c.String(moduleFlagPath), true)
 	if err != nil {
 		return err
 	}

--- a/cli/module_build_test.go
+++ b/cli/module_build_test.go
@@ -13,7 +13,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/testutils/inject"
 )
 
@@ -287,14 +286,12 @@ func TestOverrides(t *testing.T) {
 	})
 
 	t.Run("applyOverrides", func(t *testing.T) {
-		logger := logging.NewTestLogger(t)
-
 		// shallow example
 		manifest := moduleManifest{
 			Build:     &manifestBuildInfo{},
 			Overrides: map[string]any{";dev": map[string]any{"entrypoint": "./run.sh"}},
 		}
-		copied, err := manifest.applyOverrides(logger, true)
+		copied, err := manifest.applyOverrides(true)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, manifest.Entrypoint, test.ShouldBeEmpty)
 		test.That(t, copied.Entrypoint, test.ShouldResemble, "./run.sh")
@@ -304,14 +301,14 @@ func TestOverrides(t *testing.T) {
 			Build:     &manifestBuildInfo{},
 			Overrides: map[string]any{";dev": map[string]any{"build.setup": "brew install"}},
 		}
-		copied, err = manifest.applyOverrides(logger, true)
+		copied, err = manifest.applyOverrides(true)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, manifest.Build.Setup, test.ShouldBeEmpty)
 		test.That(t, copied.Build.Setup, test.ShouldResemble, "brew install")
 
 		// make sure empty doesn't crash
 		manifest = moduleManifest{}
-		_, err = manifest.applyOverrides(logger, true)
+		_, err = manifest.applyOverrides(true)
 		test.That(t, err, test.ShouldBeNil)
 	})
 }

--- a/cli/module_build_test.go
+++ b/cli/module_build_test.go
@@ -212,33 +212,13 @@ func TestOverrides(t *testing.T) {
 		_, err := parseOverridePlatform("")
 		test.That(t, err, test.ShouldNotBeNil)
 
-		op, err := parseOverridePlatform("linux")
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, op.os, test.ShouldResemble, "linux")
-		test.That(t, op.arch, test.ShouldBeEmpty)
-		test.That(t, op.dev, test.ShouldBeFalse)
-
-		op, err = parseOverridePlatform("linux/arm64")
+		op, err := parseOverridePlatform("linux/arm64")
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, op.os, test.ShouldResemble, "linux")
 		test.That(t, op.arch, test.ShouldResemble, "arm64")
 
-		op, err = parseOverridePlatform("linux/arm64;dev")
+		op, err = parseOverridePlatform("dev")
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, op.os, test.ShouldResemble, "linux")
-		test.That(t, op.arch, test.ShouldResemble, "arm64")
-		test.That(t, op.dev, test.ShouldBeTrue)
-
-		op, err = parseOverridePlatform("linux;dev")
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, op.os, test.ShouldResemble, "linux")
-		test.That(t, op.arch, test.ShouldBeEmpty)
-		test.That(t, op.dev, test.ShouldBeTrue)
-
-		op, err = parseOverridePlatform(";dev")
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, op.os, test.ShouldBeEmpty)
-		test.That(t, op.arch, test.ShouldBeEmpty)
 		test.That(t, op.dev, test.ShouldBeTrue)
 	})
 
@@ -250,19 +230,13 @@ func TestOverrides(t *testing.T) {
 		test.That(t, op.check("darwin", "arm64", false), test.ShouldBeFalse)
 		test.That(t, op.check("linux", "amd64", false), test.ShouldBeFalse)
 
-		op, err = parseOverridePlatform("linux")
+		op, err = parseOverridePlatform("linux/any")
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, op.check("linux", "arm64", false), test.ShouldBeTrue)
 		test.That(t, op.check("linux", "amd64", false), test.ShouldBeTrue)
 		test.That(t, op.check("darwin", "arm64", false), test.ShouldBeFalse)
 
-		op, err = parseOverridePlatform("linux;dev")
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, op.check("linux", "arm64", true), test.ShouldBeTrue)
-		test.That(t, op.check("linux", "arm64", false), test.ShouldBeFalse)
-		test.That(t, op.check("darwin", "arm64", true), test.ShouldBeFalse)
-
-		op, err = parseOverridePlatform(";dev")
+		op, err = parseOverridePlatform("dev")
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, op.check("linux", "arm64", true), test.ShouldBeTrue)
 		test.That(t, op.check("linux", "arm64", false), test.ShouldBeFalse)
@@ -289,7 +263,7 @@ func TestOverrides(t *testing.T) {
 		// shallow example
 		manifest := moduleManifest{
 			Build:     &manifestBuildInfo{},
-			Overrides: map[string]any{";dev": map[string]any{"entrypoint": "./run.sh"}},
+			Overrides: map[string]any{"dev": map[string]any{"entrypoint": "./run.sh"}},
 		}
 		copied, err := manifest.applyOverrides(true)
 		test.That(t, err, test.ShouldBeNil)
@@ -299,7 +273,7 @@ func TestOverrides(t *testing.T) {
 		// deep example
 		manifest = moduleManifest{
 			Build:     &manifestBuildInfo{},
-			Overrides: map[string]any{";dev": map[string]any{"build.setup": "brew install"}},
+			Overrides: map[string]any{"dev": map[string]any{"build.setup": "brew install"}},
 		}
 		copied, err = manifest.applyOverrides(true)
 		test.That(t, err, test.ShouldBeNil)

--- a/cli/module_build_test.go
+++ b/cli/module_build_test.go
@@ -294,19 +294,24 @@ func TestOverrides(t *testing.T) {
 			Build:     &manifestBuildInfo{},
 			Overrides: map[string]any{";dev": map[string]any{"entrypoint": "./run.sh"}},
 		}
-		copy, err := manifest.applyOverrides(logger, true)
+		copied, err := manifest.applyOverrides(logger, true)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, manifest.Entrypoint, test.ShouldBeEmpty)
-		test.That(t, copy.Entrypoint, test.ShouldResemble, "./run.sh")
+		test.That(t, copied.Entrypoint, test.ShouldResemble, "./run.sh")
 
 		// deep example
 		manifest = moduleManifest{
 			Build:     &manifestBuildInfo{},
 			Overrides: map[string]any{";dev": map[string]any{"build.setup": "brew install"}},
 		}
-		copy, err = manifest.applyOverrides(logger, true)
+		copied, err = manifest.applyOverrides(logger, true)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, manifest.Build.Setup, test.ShouldBeEmpty)
-		test.That(t, copy.Build.Setup, test.ShouldResemble, "brew install")
+		test.That(t, copied.Build.Setup, test.ShouldResemble, "brew install")
+
+		// make sure empty doesn't crash
+		manifest = moduleManifest{}
+		_, err = manifest.applyOverrides(logger, true)
+		test.That(t, err, test.ShouldBeNil)
 	})
 }

--- a/cli/module_build_test.go
+++ b/cli/module_build_test.go
@@ -197,7 +197,7 @@ func TestLocalBuild(t *testing.T) {
 	// run the build local action
 	cCtx, _, out, errOut := setup(&inject.AppServiceClient{}, nil, &inject.BuildServiceClient{},
 		nil, map[string]any{moduleBuildFlagPath: manifestPath, moduleBuildFlagVersion: "1.2.3"}, "token")
-	manifest, err := loadManifest(manifestPath)
+	manifest, err := loadManifest(manifestPath, false)
 	test.That(t, err, test.ShouldBeNil)
 	err = moduleBuildLocalAction(cCtx, &manifest)
 	test.That(t, err, test.ShouldBeNil)

--- a/cli/module_build_test.go
+++ b/cli/module_build_test.go
@@ -241,6 +241,33 @@ func TestOverrides(t *testing.T) {
 		test.That(t, op.arch, test.ShouldBeEmpty)
 		test.That(t, op.dev, test.ShouldBeTrue)
 	})
+
+	t.Run("check", func(t *testing.T) {
+		op, err := parseOverridePlatform("linux/arm64")
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, op.check("linux", "arm64", false), test.ShouldBeTrue)
+		test.That(t, op.check("linux", "arm64", true), test.ShouldBeTrue)
+		test.That(t, op.check("darwin", "arm64", false), test.ShouldBeFalse)
+		test.That(t, op.check("linux", "amd64", false), test.ShouldBeFalse)
+
+		op, err = parseOverridePlatform("linux")
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, op.check("linux", "arm64", false), test.ShouldBeTrue)
+		test.That(t, op.check("linux", "amd64", false), test.ShouldBeTrue)
+		test.That(t, op.check("darwin", "arm64", false), test.ShouldBeFalse)
+
+		op, err = parseOverridePlatform("linux;dev")
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, op.check("linux", "arm64", true), test.ShouldBeTrue)
+		test.That(t, op.check("linux", "arm64", false), test.ShouldBeFalse)
+		test.That(t, op.check("darwin", "arm64", true), test.ShouldBeFalse)
+
+		op, err = parseOverridePlatform(";dev")
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, op.check("linux", "arm64", true), test.ShouldBeTrue)
+		test.That(t, op.check("linux", "arm64", false), test.ShouldBeFalse)
+		test.That(t, op.check("darwin", "arm64", true), test.ShouldBeTrue)
+	})
 }
 
 // override cases for json

--- a/cli/module_build_test.go
+++ b/cli/module_build_test.go
@@ -206,3 +206,46 @@ func TestLocalBuild(t *testing.T) {
 	test.That(t, outMsg, test.ShouldContainSubstring, "setup step msg")
 	test.That(t, outMsg, test.ShouldContainSubstring, "build step msg")
 }
+
+func TestOverrides(t *testing.T) {
+	t.Run("parse", func(t *testing.T) {
+		_, err := parseOverridePlatform("")
+		test.That(t, err, test.ShouldNotBeNil)
+
+		op, err := parseOverridePlatform("linux")
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, op.os, test.ShouldResemble, "linux")
+		test.That(t, op.arch, test.ShouldBeEmpty)
+		test.That(t, op.dev, test.ShouldBeFalse)
+
+		op, err = parseOverridePlatform("linux/arm64")
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, op.os, test.ShouldResemble, "linux")
+		test.That(t, op.arch, test.ShouldResemble, "arm64")
+
+		op, err = parseOverridePlatform("linux/arm64;dev")
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, op.os, test.ShouldResemble, "linux")
+		test.That(t, op.arch, test.ShouldResemble, "arm64")
+		test.That(t, op.dev, test.ShouldBeTrue)
+
+		op, err = parseOverridePlatform("linux;dev")
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, op.os, test.ShouldResemble, "linux")
+		test.That(t, op.arch, test.ShouldBeEmpty)
+		test.That(t, op.dev, test.ShouldBeTrue)
+
+		op, err = parseOverridePlatform(";dev")
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, op.os, test.ShouldBeEmpty)
+		test.That(t, op.arch, test.ShouldBeEmpty)
+		test.That(t, op.dev, test.ShouldBeTrue)
+	})
+}
+
+// override cases for json
+var overrideDot = map[string]any{"darwin": map[string]any{"build.setup": "brew install"}}
+var overrideSlash = map[string]any{"darwin/arm64": map[string]any{"build.setup": "brew install"}}
+var overrideMap = map[string]any{"darwin": map[string]any{"build": map[string]any{"setup": "brew install"}}}
+var overrideDev = map[string]any{"dev": map[string]any{"entrypoint": "run.sh"}}
+var overrideDevPlatform = map[string]any{"linux;dev": map[string]any{"entrypoint": "run.sh"}}

--- a/cli/module_build_test.go
+++ b/cli/module_build_test.go
@@ -268,6 +268,22 @@ func TestOverrides(t *testing.T) {
 		test.That(t, op.check("linux", "arm64", false), test.ShouldBeFalse)
 		test.That(t, op.check("darwin", "arm64", true), test.ShouldBeTrue)
 	})
+
+	t.Run("apply", func(t *testing.T) {
+		conf := map[string]any{"x": 1}
+		err := applyOverrideField(conf, 2, "x", "x")
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, conf["x"], test.ShouldEqual, 2)
+
+		conf = map[string]any{"x": map[string]any{"y": 1}}
+		err = applyOverrideField(conf, 2, "x.y", strings.Split("x.y", ".")...)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, conf["x"].(map[string]any)["y"], test.ShouldEqual, 2)
+
+		conf = map[string]any{}
+		err = applyOverrideField(conf, 2, "x.y", strings.Split("x.y", ".")...)
+		test.That(t, err, test.ShouldNotBeNil)
+	})
 }
 
 // override cases for json

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -644,7 +644,7 @@ func parseOverridePlatform(raw string) (overridePlatform, error) {
 		return ret, fmt.Errorf("cannot parse platform key '%s' in overrides", raw)
 	}
 	for _, tok := range tokens {
-		if tok == "" {
+		if tok == "" { //nolint:gocritic
 			continue
 		} else if tok == ";dev" {
 			ret.dev = true
@@ -692,23 +692,23 @@ func applyOverrideField(configAsMap map[string]any, val any, origKey string, key
 
 // applies the `overrides` section to a copy of this manifest, return copy.
 func (manifest moduleManifest) applyOverrides(logger logging.Logger, dev bool) (moduleManifest, error) {
-	var copy moduleManifest
+	var copied moduleManifest
 	asBytes, err := json.Marshal(manifest)
 	if err != nil {
-		return copy, err
+		return copied, err
 	}
 	var asMap map[string]any
 	if err := json.Unmarshal(asBytes, &asMap); err != nil {
-		return copy, err
+		return copied, err
 	}
 	for key, val := range manifest.Overrides {
 		op, err := parseOverridePlatform(key)
 		if err != nil {
-			return copy, err
+			return copied, err
 		}
 		overrides, ok := val.(map[string]any)
 		if !ok {
-			return copy, fmt.Errorf("override section %s is not a map", key)
+			return copied, fmt.Errorf("override section %s is not a map", key)
 		}
 		if !op.checkCurrent(dev) {
 			logger.Debugf("skipping override section %s", key)
@@ -717,16 +717,16 @@ func (manifest moduleManifest) applyOverrides(logger logging.Logger, dev bool) (
 		logger.Debugf("applying override section %s", key)
 		for okey, oval := range overrides {
 			if err := applyOverrideField(asMap, oval, okey, strings.Split(okey, ".")...); err != nil {
-				return copy, err
+				return copied, err
 			}
 		}
 	}
 	asBytes, err = json.Marshal(asMap)
 	if err != nil {
-		return copy, err
+		return copied, err
 	}
-	err = json.Unmarshal(asBytes, &copy)
-	return copy, err
+	err = json.Unmarshal(asBytes, &copied)
+	return copied, err
 }
 
 func loadManifest(manifestPath string, devMode bool) (moduleManifest, error) {

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -691,7 +691,7 @@ func applyOverrideField(configAsMap map[string]any, val any, origKey string, key
 }
 
 // applies the `overrides` section to a copy of this manifest, return copy.
-func (manifest moduleManifest) applyOverrides(logger logging.Logger, dev bool) (moduleManifest, error) {
+func (manifest moduleManifest) applyOverrides(dev bool) (moduleManifest, error) {
 	var copied moduleManifest
 	asBytes, err := json.Marshal(manifest)
 	if err != nil {
@@ -711,10 +711,8 @@ func (manifest moduleManifest) applyOverrides(logger logging.Logger, dev bool) (
 			return copied, fmt.Errorf("override section %s is not a map", key)
 		}
 		if !op.checkCurrent(dev) {
-			logger.Debugf("skipping override section %s", key)
 			continue
 		}
-		logger.Debugf("applying override section %s", key)
 		for okey, oval := range overrides {
 			if err := applyOverrideField(asMap, oval, okey, strings.Split(okey, ".")...); err != nil {
 				return copied, err
@@ -742,7 +740,7 @@ func loadManifest(manifestPath string, devMode bool) (moduleManifest, error) {
 	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
 		return moduleManifest{}, err
 	}
-	return manifest.applyOverrides(logging.Global(), devMode)
+	return manifest.applyOverrides(devMode)
 }
 
 // loadManifestOrNil doesn't throw error on missing.

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -119,7 +119,7 @@ func CreateModuleAction(c *cli.Context) error {
 	// in order to minimize user frustration. We will continue the creation if the args passed to create
 	// match the values in the meta.json
 	if _, err := os.Stat(defaultManifestFilename); err == nil {
-		modManifest, err := loadManifest(defaultManifestFilename)
+		modManifest, err := loadManifest(defaultManifestFilename, false)
 		if err != nil {
 			return errors.New("another meta.json already exists in the current directory. Delete it and try again")
 		}
@@ -187,7 +187,7 @@ func UpdateModuleAction(c *cli.Context) error {
 		return err
 	}
 
-	manifest, err := loadManifest(manifestPath)
+	manifest, err := loadManifest(manifestPath, false)
 	if err != nil {
 		return err
 	}
@@ -262,7 +262,7 @@ func UploadModuleAction(c *cli.Context) error {
 		}
 	} else {
 		// if we can find a manifest, use that
-		manifest, err := loadManifest(manifestPath)
+		manifest, err := loadManifest(manifestPath, false)
 		if err != nil {
 			return err
 		}
@@ -322,7 +322,7 @@ func UpdateModelsAction(c *cli.Context) error {
 		return err
 	}
 
-	manifest, err := loadManifest(c.String(moduleFlagPath))
+	manifest, err := loadManifest(c.String(moduleFlagPath), false)
 	if err != nil {
 		return err
 	}
@@ -729,7 +729,7 @@ func (manifest moduleManifest) applyOverrides(logger logging.Logger, dev bool) (
 	return copy, err
 }
 
-func loadManifest(manifestPath string) (moduleManifest, error) {
+func loadManifest(manifestPath string, devMode bool) (moduleManifest, error) {
 	//nolint:gosec
 	manifestBytes, err := os.ReadFile(manifestPath)
 	if err != nil {
@@ -742,12 +742,12 @@ func loadManifest(manifestPath string) (moduleManifest, error) {
 	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
 		return moduleManifest{}, err
 	}
-	return manifest, nil
+	return manifest.applyOverrides(logging.Global(), devMode)
 }
 
 // loadManifestOrNil doesn't throw error on missing.
-func loadManifestOrNil(path string) (*moduleManifest, error) {
-	manifest, err := loadManifest(path)
+func loadManifestOrNil(path string, devMode bool) (*moduleManifest, error) {
+	manifest, err := loadManifest(path, devMode)
 	if err == nil {
 		return &manifest, nil
 	}

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -80,7 +80,7 @@ type moduleManifest struct {
 	// JsonManifest provides fields shared with RDK proper.
 	modconfig.JSONManifest
 	Build     *manifestBuildInfo `json:"build,omitempty"`
-	Overrides map[string]any     `json:"overrides"`
+	Overrides map[string]any     `json:"overrides,omitempty"`
 }
 
 const (

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -659,6 +659,19 @@ func (op overridePlatform) checkCurrent(dev bool) bool {
 	return op.check(runtime.GOOS, runtime.GOARCH, dev)
 }
 
+// looks up key, which is a decomposed jsonpath, sets configAsMap[key] to val.
+func applyOverrideField(configAsMap map[string]any, val any, origKey string, key ...string) error {
+	if len(key) == 1 {
+		configAsMap[key[0]] = val
+		return nil
+	}
+	subtree, ok := configAsMap[key[0]].(map[string]any)
+	if !ok {
+		return fmt.Errorf("non-map subtree in override key %s at .%s", origKey, strings.Join(key, "."))
+	}
+	return applyOverrideField(subtree, val, origKey, key[1:]...)
+}
+
 // applies the `overrides` section to the manifest.
 // func applyManifestOverrides(manifest moduleManifest) error {
 // 	for key, val := range manifest.Overrides {

--- a/cli/module_registry_test.go
+++ b/cli/module_registry_test.go
@@ -39,10 +39,10 @@ func TestUpdateModelsAction(t *testing.T) {
 	test.That(t, len(errOut.messages), test.ShouldEqual, 0)
 
 	// verify that models added to meta.json are equivalent to those defined in expected_meta.json
-	metaModels, err := loadManifest(metaPath)
+	metaModels, err := loadManifest(metaPath, false)
 	test.That(t, err, test.ShouldBeNil)
 
-	expectedMetaModels, err := loadManifest(expectedMetaPath)
+	expectedMetaModels, err := loadManifest(expectedMetaPath, false)
 	test.That(t, err, test.ShouldBeNil)
 
 	test.That(t, sameModels(metaModels.Models, expectedMetaModels.Models), test.ShouldBeTrue)

--- a/cli/module_registry_test.go
+++ b/cli/module_registry_test.go
@@ -47,3 +47,12 @@ func TestUpdateModelsAction(t *testing.T) {
 
 	test.That(t, sameModels(metaModels.Models, expectedMetaModels.Models), test.ShouldBeTrue)
 }
+
+func TestSortOverrides(t *testing.T) {
+	sorted := sortOverrides(map[string]any{"linux": true, "dev": true, "darwin": true})
+	keys := make([]string, 0, len(sorted))
+	for _, pair := range sorted {
+		keys = append(keys, pair.a)
+	}
+	test.That(t, keys, test.ShouldResemble, []string{"darwin", "linux", "dev"})
+}

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -45,28 +45,26 @@ func replaceInTarGz(path string, newEntries map[string][]byte) error {
 	// nested function so the Close() calls finish before we rename.
 	err := func() error {
 		// open reader
-		sourceFile, err := os.Open(path)
+		sourceFile, err := os.Open(path) //nolint:gosec
 		if err != nil {
 			return err
 		}
-		defer sourceFile.Close()
+		defer sourceFile.Close() //nolint:errcheck
 		gzRead, err := gzip.NewReader(sourceFile)
 		if err != nil {
 			return err
 		}
-		defer gzRead.Close()
+		defer gzRead.Close() //nolint:errcheck
 		tarRead := tar.NewReader(gzRead)
 
 		// open writer
-		destFile, err := os.Create(tmpPath)
+		destFile, err := os.Create(tmpPath) //nolint:gosec
 		if err != nil {
 			return err
 		}
-		defer destFile.Close()
+		defer destFile.Close() //nolint:errcheck
 		gzw := gzip.NewWriter(destFile)
-		defer gzw.Close()
 		tarWrite := tar.NewWriter(gzw)
-		defer tarWrite.Close()
 
 		// copy
 		consumed := make(map[string]bool)
@@ -92,7 +90,7 @@ func replaceInTarGz(path string, newEntries map[string][]byte) error {
 				if err := tarWrite.WriteHeader(head); err != nil {
 					return err
 				}
-				if _, err := io.Copy(tarWrite, tarRead); err != nil {
+				if _, err := io.Copy(tarWrite, tarRead); err != nil { //nolint:gosec
 					return err
 				}
 			}
@@ -112,6 +110,12 @@ func replaceInTarGz(path string, newEntries map[string][]byte) error {
 			if _, err := tarWrite.Write(entry); err != nil {
 				return err
 			}
+		}
+		if err := gzw.Close(); err != nil {
+			return err
+		}
+		if err := tarWrite.Close(); err != nil {
+			return err
 		}
 		return nil
 	}()

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -66,8 +66,8 @@ func replaceInTarGz(path string, newEntries map[string][]byte) error {
 		gzw := gzip.NewWriter(destFile)
 		tarWrite := tar.NewWriter(gzw)
 
-		// copy
 		consumed := make(map[string]bool)
+		// copy existing files, using newEntries where necessary
 		for {
 			head, err := tarRead.Next()
 			if errors.Is(err, io.EOF) {
@@ -95,6 +95,8 @@ func replaceInTarGz(path string, newEntries map[string][]byte) error {
 				}
 			}
 		}
+
+		// copy any remaining newEntries
 		for name, entry := range newEntries {
 			if consumed[name] {
 				continue
@@ -111,10 +113,12 @@ func replaceInTarGz(path string, newEntries map[string][]byte) error {
 				return err
 			}
 		}
-		if err := gzw.Close(); err != nil {
+
+		// cleanup
+		if err := tarWrite.Close(); err != nil {
 			return err
 		}
-		if err := tarWrite.Close(); err != nil {
+		if err := gzw.Close(); err != nil {
 			return err
 		}
 		return nil

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -1,6 +1,14 @@
 package cli
 
-import "path/filepath"
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
 
 // samePath returns true if abs(path1) and abs(path2) are the same.
 func samePath(path1, path2 string) (bool, error) {
@@ -28,4 +36,87 @@ func getMapString(m map[string]any, key string) string {
 		}
 	}
 	return ""
+}
+
+// replaceInTarGz adds entries to a .tar.gz file by the awkward method of copying
+// its contents to a new file.
+func replaceInTarGz(path string, newEntries map[string][]byte) error {
+	tmpPath := path + ".tmp"
+	// nested function so the Close() calls finish before we rename.
+	err := func() error {
+		// open reader
+		sourceFile, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer sourceFile.Close()
+		gzRead, err := gzip.NewReader(sourceFile)
+		if err != nil {
+			return err
+		}
+		defer gzRead.Close()
+		tarRead := tar.NewReader(gzRead)
+
+		// open writer
+		destFile, err := os.Create(tmpPath)
+		if err != nil {
+			return err
+		}
+		defer destFile.Close()
+		gzw := gzip.NewWriter(destFile)
+		defer gzw.Close()
+		tarWrite := tar.NewWriter(gzw)
+		defer tarWrite.Close()
+
+		// copy
+		consumed := make(map[string]bool)
+		for {
+			head, err := tarRead.Next()
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			if err != nil {
+				return err
+			}
+
+			if entry, ok := newEntries[head.Name]; ok {
+				head.Size = int64(len(entry))
+				if err := tarWrite.WriteHeader(head); err != nil {
+					return err
+				}
+				if _, err := tarWrite.Write(entry); err != nil {
+					return err
+				}
+				consumed[head.Name] = true
+			} else {
+				if err := tarWrite.WriteHeader(head); err != nil {
+					return err
+				}
+				if _, err := io.Copy(tarWrite, tarRead); err != nil {
+					return err
+				}
+			}
+		}
+		for name, entry := range newEntries {
+			if consumed[name] {
+				continue
+			}
+			if err := tarWrite.WriteHeader(&tar.Header{
+				Typeflag: tar.TypeReg,
+				Name:     name,
+				Size:     int64(len(entry)),
+				ModTime:  time.Now(),
+			}); err != nil {
+				return err
+			}
+			if _, err := tarWrite.Write(entry); err != nil {
+				return err
+			}
+		}
+		return nil
+	}()
+	if err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
 }

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -126,5 +126,7 @@ func replaceInTarGz(path string, newEntries map[string][]byte) error {
 	if err != nil {
 		return err
 	}
+	// note: body of function is closure-scoped so the `defer close` actions finish
+	// before the Rename below.
 	return os.Rename(tmpPath, path)
 }

--- a/cli/utils_test.go
+++ b/cli/utils_test.go
@@ -1,6 +1,12 @@
 package cli
 
 import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
 	"testing"
 
 	"go.viam.com/test"
@@ -21,4 +27,66 @@ func TestGetMapString(t *testing.T) {
 	test.That(t, getMapString(m, "x"), test.ShouldEqual, "x")
 	test.That(t, getMapString(m, "y"), test.ShouldEqual, "")
 	test.That(t, getMapString(m, "z"), test.ShouldEqual, "")
+}
+
+func chdir(t *testing.T, path string) {
+	wd, err := os.Getwd()
+	test.That(t, err, test.ShouldBeNil)
+	err = os.Chdir(path)
+	test.That(t, err, test.ShouldBeNil)
+	t.Cleanup(func() { os.Chdir(wd) })
+}
+
+// helper; starts and waits for an exec.Cmd.
+func runCommand(t *testing.T, cmd *exec.Cmd) {
+	t.Helper()
+	err := errors.Join(cmd.Start(), cmd.Wait())
+	test.That(t, err, test.ShouldBeNil)
+}
+
+// helper; returns map of {name: length} for tarball contents.
+func tarContents(t *testing.T, path string) map[string]int64 {
+	r, err := os.Open(path)
+	test.That(t, err, test.ShouldBeNil)
+	gz, err := gzip.NewReader(r)
+	test.That(t, err, test.ShouldBeNil)
+	tr := tar.NewReader(gz)
+	ret := make(map[string]int64)
+	for {
+		head, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		test.That(t, err, test.ShouldBeNil)
+		ret[head.Name] = head.Size
+	}
+	return ret
+}
+
+func TestReplaceInTarGz(t *testing.T) {
+	tmp := t.TempDir()
+	chdir(t, tmp)
+
+	// setup
+	runCommand(t, exec.Command("touch", "hello.txt"))
+	runCommand(t, exec.Command("touch", "replaceme.txt"))
+	// add a symlink to make sure this doesn't choke on symlinks
+	runCommand(t, exec.Command("ln", "-s", "hello.txt", "linkhello"))
+	runCommand(t, exec.Command("tar", "czf", "archive.tar.gz", "hello.txt", "replaceme.txt", "linkhello"))
+
+	err := replaceInTarGz("archive.tar.gz", map[string][]byte{
+		// replace an entry
+		"replaceme.txt": []byte("hi"),
+		// add an entry
+		"new.txt": []byte("hey"),
+	})
+	test.That(t, err, test.ShouldBeNil)
+
+	// verify
+	test.That(t, tarContents(t, "archive.tar.gz"), test.ShouldResemble, map[string]int64{
+		"hello.txt":     0,
+		"linkhello":     0,
+		"replaceme.txt": 2,
+		"new.txt":       3,
+	})
 }


### PR DESCRIPTION
## What changed
- add `overrides` section to meta.json; this edits some meta.json fields based on platform constraints. look at module.schema.json for examples
    - note: meta.json without overrides will work as before
- a 'dev' tag lets users choose overrides when using local + remote reloading
- document overrides in module.schema.json
- important and subtle: for remote reloading, I'm saving the post-override meta.json into the tarball
- new tarball helper in utils
## Why
- the ability to do platform overrides is a frequent user request
- for python reloading users, this lets people automatically toggle between virtualenv (local + remote reloading) and pyinstaller (publishing)
## Design questions
- ~are people happy with the `linux/arm64;dev` format for the override keys? as we evolve our platform tagging this may eventually have a v2, but is this good for now?~ -> going with simpler approach that doesn't combine tags; can add it later if needed
## Testing / sample
Local and remote reloading work as expected with this config:

commands:
```sh
$ ./viam module reload --local --no-build
$ ./viam module reload --home $HOME
```

meta.json:
```json
{
	"$schema": "https://dl.viam.dev/module.schema.json",
	"module_id": "test:test",
	"entrypoint": "dist/main",
	"build": {
		"build": "make dist/main",
		"path": "dist/main"
	},
	"overrides": {
		";dev": {
			"entrypoint": "run.sh",
			"build": {"build": "make module.tar.gz", "path": "module.tar.gz"}
		}
	}
}
```
run.sh:
```bash
#!/usr/bin/env bash

set -e

uv v
uv pip install -r requirements.txt

.venv/bin/python main.py $@
```