### PR TITLE
[RSDK-8261] initialize new interrupts using the correct name

### DIFF
--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -321,9 +321,9 @@ func (b *Board) reconfigureInterrupts(newConf *LinuxBoardConfig) error {
 			oldInterrupt = nil
 		}
 
-		gpioMapping, ok := b.gpioMappings[config.Name]
+		gpioMapping, ok := b.gpioMappings[config.Pin]
 		if !ok {
-			return fmt.Errorf("cannot create digital interrupt on unknown pin %s", config.Name)
+			return fmt.Errorf("cannot create digital interrupt on unknown pin %s", config.Pin)
 		}
 		interrupt, err := newDigitalInterrupt(config, gpioMapping, oldInterrupt)
 		if err != nil {


### PR DESCRIPTION
Oof, this was a silly mistake! Thanks to @susmitaSanyal for sticking to her guns and pushing on this. We missed it before because _renaming_ a pre-existing interrupt to a different name worked totally fine: it was only creating a _brand new_ interrupt named something other than its pin name that was a problem.

Tried on the Harun (rpi5) rover: without this PR, the board cannot configure itself because it `cannot create digital interrupt on unknown pin re`, and with this PR, the board configures and the board/motors/encoders/base work properly.