### PR TITLE
RSDK-8390 pose interpolation between orientations can take the long way around

### DIFF
--- a/motionplan/ik/metrics.go
+++ b/motionplan/ik/metrics.go
@@ -75,7 +75,7 @@ func CombineMetrics(metrics ...StateMetric) StateMetric {
 
 // OrientDist returns the arclength between two orientations in degrees.
 func OrientDist(o1, o2 spatial.Orientation) float64 {
-	return utils.RadToDeg(spatial.QuatToR4AA(spatial.OrientationBetween(o1, o2).Quaternion()).Theta)
+	return math.Abs(utils.RadToDeg(spatial.QuatToR4AA(spatial.OrientationBetween(o1, o2).Quaternion()).Theta))
 }
 
 // OrientDistToRegion will return a function which will tell you how far the unit sphere component of an orientation

--- a/spatialmath/pose.go
+++ b/spatialmath/pose.go
@@ -165,8 +165,12 @@ func PoseInverse(p Pose) Pose {
 // p1 and p2 are the two poses to interpolate between, by is a float representing the amount to interpolate between them.
 // by == 0 will return p1, by == 1 will return p2, and by == 0.5 will return the pose halfway between them.
 func Interpolate(p1, p2 Pose, by float64) Pose {
+	p2Orient := p2.Orientation().Quaternion()
+	if OrientationBetween(p1.Orientation(), p2.Orientation()).Quaternion().Real < 0 {
+		p2Orient = quat.Scale(-1, p2Orient)
+	}
 	intQ := newDualQuaternion()
-	intQ.Real = slerp(p1.Orientation().Quaternion(), p2.Orientation().Quaternion(), by)
+	intQ.Real = slerp(p1.Orientation().Quaternion(), p2Orient, by)
 
 	intQ.SetTranslation(r3.Vector{
 		(p1.Point().X + (p2.Point().X-p1.Point().X)*by),

--- a/spatialmath/pose_test.go
+++ b/spatialmath/pose_test.go
@@ -104,7 +104,7 @@ func TestPoseInterpolation(t *testing.T) {
 	p2 = NewPose(r3.Vector{100, 200, 200}, ov)
 	intP = Interpolate(p1, p2, 0.1)
 	ptCompare(t, intP.Point(), r3.Vector{100, 110, 200})
-	
+
 	// Set up from/to dual quats with the same real orientation but flipped signs
 	// p1 and p2 have a OV of OX: -1
 	// And so should all intermediate poses
@@ -116,7 +116,7 @@ func TestPoseInterpolation(t *testing.T) {
 		Real: quat.Number{0, -0.7071, 0, 0.7071},
 		Dual: quat.Number{-253.144227664784, 5.303300858899092, 165.46298679765218, 5.303300858899096},
 	}}
-	
+
 	intP = Interpolate(p1, p3, 0.4)
 	test.That(t, OrientationAlmostEqual(p1.Orientation(), intP.Orientation()), test.ShouldBeTrue)
 	intP = Interpolate(p1, p3, 0.5)

--- a/spatialmath/pose_test.go
+++ b/spatialmath/pose_test.go
@@ -104,6 +104,25 @@ func TestPoseInterpolation(t *testing.T) {
 	p2 = NewPose(r3.Vector{100, 200, 200}, ov)
 	intP = Interpolate(p1, p2, 0.1)
 	ptCompare(t, intP.Point(), r3.Vector{100, 110, 200})
+	
+	// Set up from/to dual quats with the same real orientation but flipped signs
+	// p1 and p2 have a OV of OX: -1
+	// And so should all intermediate poses
+	p1 = &dualQuaternion{dualquat.Number{
+		Real: quat.Number{0, 0.7071, 0, -0.7071},
+		Dual: quat.Number{352.1382097850126, -5.310529463390053, -66.47154194130341, -5.30562208840844},
+	}}
+	p3 := &dualQuaternion{dualquat.Number{
+		Real: quat.Number{0, -0.7071, 0, 0.7071},
+		Dual: quat.Number{-253.144227664784, 5.303300858899092, 165.46298679765218, 5.303300858899096},
+	}}
+	
+	intP = Interpolate(p1, p3, 0.4)
+	test.That(t, OrientationAlmostEqual(p1.Orientation(), intP.Orientation()), test.ShouldBeTrue)
+	intP = Interpolate(p1, p3, 0.5)
+	test.That(t, OrientationAlmostEqual(p1.Orientation(), intP.Orientation()), test.ShouldBeTrue)
+	intP = Interpolate(p1, p3, 0.6)
+	test.That(t, OrientationAlmostEqual(p1.Orientation(), intP.Orientation()), test.ShouldBeTrue)
 }
 
 func TestLidarPose(t *testing.T) {


### PR DESCRIPTION
This fixes two issues with linear constraints. One, `ik.OrientDist` should have been an absolute value. Two, pose interpolation needed to ensure both orientations were in the same hemisphere.