### PR TITLE
APP-5488: add IDs to rc cards

### DIFF
--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "2.19.0",
+  "version": "2.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/remote-control",
-      "version": "2.19.0",
+      "version": "2.19.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@improbable-eng/grpc-web": "0.15.0",

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/remote-control",
-  "version": "2.19.0",
+  "version": "2.19.1",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/web/frontend/src/lib/components/collapse.svelte
+++ b/web/frontend/src/lib/components/collapse.svelte
@@ -36,7 +36,10 @@ onMount(() => {
 });
 </script>
 
-<div class="relative w-full" id={title}>
+<div
+  class="relative w-full"
+  id={encodeURIComponent(title)}
+>
   <div
     class="
       flex-reverse flex w-full cursor-pointer items-center justify-between

--- a/web/frontend/src/lib/components/collapse.svelte
+++ b/web/frontend/src/lib/components/collapse.svelte
@@ -36,7 +36,7 @@ onMount(() => {
 });
 </script>
 
-<div class="relative w-full">
+<div class="relative w-full" id={title}>
   <div
     class="
       flex-reverse flex w-full cursor-pointer items-center justify-between


### PR DESCRIPTION
This adds IDs to each RC card. By doing this, all cards (new and old) will have fragments we can link to, so we can show all resources in the sidebar in App.