### PR TITLE
[RSDK-7209] fix deadlock in analog reader initialization

### DIFF
--- a/components/board/mcp3008helper/mcp3008.go
+++ b/components/board/mcp3008helper/mcp3008.go
@@ -38,6 +38,8 @@ func (config *MCP3008AnalogConfig) Validate(path string) error {
 	return nil
 }
 
+// Read returns a board.AnalogValue, but the Min, Max, and StepSize within it are never initialized
+// and will always be 0!
 func (mar *MCP3008AnalogReader) Read(ctx context.Context, extra map[string]interface{}) (
 	analogVal board.AnalogValue, err error,
 ) {

--- a/components/board/pinwrappers/analog_smoother.go
+++ b/components/board/pinwrappers/analog_smoother.go
@@ -63,22 +63,22 @@ func (as *AnalogSmoother) Close(ctx context.Context) error {
 // Read returns the smoothed out reading.
 func (as *AnalogSmoother) Read(ctx context.Context, extra map[string]interface{}) (board.AnalogValue, error) {
 	lastDataPointer := as.lastData.Load()
+	if lastDataPointer == nil {
+		return board.AnalogValue{}, errors.New("have not yet read any analog data")
+	}
+
 	if as.data == nil { // We're using raw data, and not averaging
-		if lastDataPointer == nil {
-			return board.AnalogValue{}, errors.New("have not yet read any analog data")
-		}
 		return *lastDataPointer, nil
 	}
-	avg := as.data.Average()
-	lastErr := as.lastError.Load()
 
 	analogVal := board.AnalogValue{
 		Min:      lastDataPointer.Min,
 		Max:      lastDataPointer.Max,
 		StepSize: lastDataPointer.StepSize,
+		Value:    as.data.Average(),
 	}
-	analogVal.Value = avg
 
+	lastErr := as.lastError.Load()
 	if lastErr == nil {
 		return analogVal, nil
 	}

--- a/components/board/pinwrappers/analog_smoother.go
+++ b/components/board/pinwrappers/analog_smoother.go
@@ -76,7 +76,7 @@ func (as *AnalogSmoother) Read(ctx context.Context, extra map[string]interface{}
 
 	if as.data == nil { // We're using raw data, and not averaging
 		analogVal.Value = as.lastData
-		return as.analogVal, nil
+		return analogVal, nil
 	}
 	avg := as.data.Average()
 	lastErr := as.lastError.Load()

--- a/components/board/pinwrappers/analog_smoother.go
+++ b/components/board/pinwrappers/analog_smoother.go
@@ -62,11 +62,6 @@ func (as *AnalogSmoother) Close(ctx context.Context) error {
 
 // Read returns the smoothed out reading.
 func (as *AnalogSmoother) Read(ctx context.Context, extra map[string]interface{}) (board.AnalogValue, error) {
-	// If as.lastData is all 0's, we haven't read anything yet, and should return an error saying so.
-	if as.lastData.Min == 0 && as.lastData.Max == 0 && as.lastData.StepSize == 0 && as.lastData.Value == 0 {
-		return 0, errors.New("no data received from analog reader yet")
-	}
-
 	if as.data == nil { // We're using raw data, and not averaging
 		return as.lastData, nil
 	}


### PR DESCRIPTION
Thanks to @mariapatni for her patience while we figured this out! The problem wasn't actually to do with reconfiguring a digital interrupt: on the raspberry pi, if you initialize a new analog reader while using arbitrary GPIO pins as the Chip Select for the SPI device, it deadlocked during reconfiguration!

Changes include:
- when initializing a `SmoothAnalogReader`, don't read from the device immediately (see below for why that's a problem). Instead, just start the background goroutine that will read from it when yo're supposed to. If you ask for values out of it before the goroutine has read anything, you get an error saying that we haven't read anything yet.
- the `lastData` field was not thread safe, so it's now an `atomic.Pointer` instead of a raw value.

Tried on a raspberry pi (with the component built into the RDK, not the new modular version), with an MCP3008 attached: it works fine. If I then add an ultrasonic sensor (which uses a digital interrupt), both the ultrasonic and the analogs continue to work fine. I have not tried the modular component yet, but because it imports the mcp3008helper and pinwrappers packages from the RDK, and because I didn't change any code outside of those packages, it should work, too.

Why this was a problem: during rpi4 reconfiguration, we throw out all old analog readers and create new ones. Before this change, creating a new analog smoother required reading an initial value from the ADC. and on the raspberry pi 4, reading a value required getting the GPIO pin for the chip select and manually toggling it, then using pigpio to talk to the SPI bus, and then us manually toggling a GPIO pin for the chip select again. However, manually toggling a GPIO pin involves locking the mutex for the board, and reconfiguring the board also locks the mutex (so, the deadlock was that a single goroutine would lock the mutex, then sleep until the mutex was unlocked and it could lock it again). To avoid this, creating a new analog smoother no longer requires reading the initial value: it will be read from its background goroutine when it is able to (which will happen after reconfiguration is complete).