### PR TITLE
DATA-2505 Implement default mimetype (change to JPEG)

### DIFF
--- a/components/camera/collectors.go
+++ b/components/camera/collectors.go
@@ -83,7 +83,7 @@ func newReadImageCollector(resource interface{}, params data.CollectorParams) (d
 	mimeType := params.MethodParams["mime_type"]
 	if mimeType == nil {
 		// TODO: Potentially log the actual mime type at collector instantiation or include in response.
-		strWrapper := wrapperspb.String(utils.MimeTypeRawRGBA)
+		strWrapper := wrapperspb.String(utils.MimeTypeJPEG)
 		mimeType, err = anypb.New(strWrapper)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Hey yall, this PR is to change the default mime type from `image/vnd.viam.rgba` to `image/jpeg`. Based on queries in the binaryDB, JPEG is the most popular format for binary data and should be the default. 