### PR TITLE
RSDK-8437 - Viam robot part restart cli command

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -1248,6 +1248,34 @@ var app = &cli.App{
 							Action: RobotsPartLogsAction,
 						},
 						{
+							Name:      "restart",
+							Aliases:   []string{},
+							Usage:     "request part restart",
+							UsageText: createUsageText("machines part restart", []string{machineFlag, partFlag}, true),
+							Flags: []cli.Flag{
+								&cli.StringFlag{
+									Name:        organizationFlag,
+									DefaultText: "first organization alphabetically",
+								},
+								&cli.StringFlag{
+									Name:        locationFlag,
+									DefaultText: "first location alphabetically",
+								},
+								&AliasStringFlag{
+									cli.StringFlag{
+										Name:     machineFlag,
+										Aliases:  []string{aliasRobotFlag},
+										Required: true,
+									},
+								},
+								&cli.StringFlag{
+									Name:     partFlag,
+									Required: true,
+								},
+							},
+							Action: RobotsPartRestartAction,
+						},
+						{
 							Name:  "run",
 							Usage: "run a command on a machine part",
 							UsageText: createUsageText("machines part run", []string{

--- a/cli/client.go
+++ b/cli/client.go
@@ -372,6 +372,34 @@ func (c *viamClient) robotsPartLogsAction(cCtx *cli.Context) error {
 	)
 }
 
+// RobotsPartRestartAction is the corresponding Action for 'machines part restart'.
+func RobotsPartRestartAction(c *cli.Context) error {
+	client, err := newViamClient(c)
+	if err != nil {
+		return err
+	}
+
+	return client.robotPartRestart(c)
+}
+
+func (c *viamClient) robotPartRestart(cCtx *cli.Context) error {
+	orgStr := cCtx.String(organizationFlag)
+	locStr := cCtx.String(locationFlag)
+	robotStr := cCtx.String(machineFlag)
+	partStr := cCtx.String(partFlag)
+
+	part, err := c.robotPart(orgStr, locStr, robotStr, partStr)
+	if err != nil {
+		return err
+	}
+	_, err = c.client.MarkPartForRestart(cCtx.Context, &apppb.MarkPartForRestartRequest{PartId: part.Id})
+	if err != nil {
+		return err
+	}
+	infof(c.c.App.Writer, "Request to restart part sent successfully")
+	return nil
+}
+
 // RobotsPartRunAction is the corresponding Action for 'machines part run'.
 func RobotsPartRunAction(c *cli.Context) error {
 	svcMethod := c.Args().First()


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-8437

Needed because the SolEng team needed to restart a part that was offline but the app ui doesn’t want to show a restart button for offline robots. See: https://viam.atlassian.net/browse/RSDK-8436 



Assigning to me because I did the initial impl to unblock the SolEng team.



However, if you don’t like this idea or this ticket (or think it needs scoping), feel free to say so and I will close the PR and the ticket.


Output:
```
➜  cli git:(main) ✗ viam robot part restart --machine e4713ae5-013a-43fe-800e-ff7959a8e3a0 --part 804a4a26-3b28-4f1b-9a7c-5cccc949aa32
Info: Request to restart part sent successfully
```