### PR TITLE
make a standardized Main function for writing modules

### DIFF
--- a/module/runtime.go
+++ b/module/runtime.go
@@ -15,7 +15,7 @@ type APIModel = resource.APIModel
 
 // ModularMain can be called as the main function from a module. It will start up a module with all
 // the provided APIModels added to it.
-func ModularMain(loggerName string, models ...resource.APIModel) {
+func ModularMain(moduleName string, models ...resource.APIModel) {
 	mainWithArgs := func(ctx context.Context, args []string, logger logging.Logger) error {
 		mod, err := NewModuleFromArgs(ctx, logger)
 		if err != nil {
@@ -38,5 +38,5 @@ func ModularMain(loggerName string, models ...resource.APIModel) {
 		return nil
 	}
 
-	utils.ContextualMain(mainWithArgs, NewLoggerFromArgs(loggerName))
+	utils.ContextualMain(mainWithArgs, NewLoggerFromArgs(moduleName))
 }

--- a/module/runtime.go
+++ b/module/runtime.go
@@ -9,10 +9,6 @@ import (
 	"go.viam.com/rdk/resource"
 )
 
-// APIModel is a glorified (resource.API, resource.Model) pair. Pass as many of these as you want
-// to ModularMain, to have this module support those models.
-type APIModel = resource.APIModel
-
 // ModularMain can be called as the main function from a module. It will start up a module with all
 // the provided APIModels added to it.
 func ModularMain(moduleName string, models ...resource.APIModel) {

--- a/module/runtime.go
+++ b/module/runtime.go
@@ -1,0 +1,42 @@
+package module
+
+import (
+	"context"
+
+	"go.viam.com/utils"
+
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+)
+
+// APIModel is a glorified (resource.API, resource.Model) pair. Pass as many of these as you want
+// to ModularMain, to have this module support those models.
+type APIModel = resource.APIModel
+
+// ModularMain can be called as the main function from a module. It will start up a module with all
+// the provided APIModels added to it.
+func ModularMain(loggerName string, models ...resource.APIModel) {
+	mainWithArgs := func(ctx context.Context, args []string, logger logging.Logger) error {
+		mod, err := NewModuleFromArgs(ctx, logger)
+		if err != nil {
+			return err
+		}
+
+		for _, apiModel := range models {
+			if err = mod.AddModelFromRegistry(ctx, apiModel.API, apiModel.Model); err != nil {
+				return err
+			}
+		}
+
+		err = mod.Start(ctx)
+		defer mod.Close(ctx)
+		if err != nil {
+			return err
+		}
+
+		<-ctx.Done()
+		return nil
+	}
+
+	utils.ContextualMain(mainWithArgs, NewLoggerFromArgs(loggerName))
+}


### PR DESCRIPTION
I've seen this pattern copied and pasted in module after module. Let's just make it a helper function, and then when you write a new module, your main function is a one-liner (or two-liner, if you have lots of models). 

Everything compiles and I'm fairly confident I've copied and pasted this correctly, but I haven't tried it out in detail yet. I want a second opinion before I go to the effort: is this worthwhile? Should I put it somewhere else instead? Should I get a third opinion?

If you think this is useful, I'll try it out and make sure it works as expected.

Examples of modules whose `main()` could be replaced by a call to this function: [1](https://github.com/mariapatni/pinctrl/blob/main/main.go) [2](https://github.com/viam-modules/viam-ultrasonic/blob/main/main.go) [3](https://github.com/viam-modules/failover/blob/main/main.go) literally every Go module I've looked at