### PR TITLE
RSDK-8307: get and send go sdk versions

### DIFF
--- a/grpc/dial.go
+++ b/grpc/dial.go
@@ -10,6 +10,7 @@ import (
 	"go.viam.com/utils/rpc"
 	"google.golang.org/grpc"
 
+	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/utils/contextutils"
 )
@@ -65,15 +66,16 @@ func InferSignalingServerAddress(address string) (string, bool, bool) {
 }
 
 func addVersionMetadataToContext(ctx context.Context) context.Context {
+	version := config.Version
+	if version == "" {
+		version = "dev-"
+		if config.GitRevision != "" {
+			version = config.GitRevision
+		} else {
+			version = "unknown"
+		}
+	}
 	info, _ := debug.ReadBuildInfo()
-	settings := make(map[string]string, len(info.Settings))
-	for _, setting := range info.Settings {
-			settings[setting.Key] = setting.Value
-	}
-	version := "?"
-	if rev, ok := settings["vcs.revision"]; ok {
-			version = rev[:8]
-	}
 	deps := make(map[string]*debug.Module, len(info.Deps))
 	for _, dep := range info.Deps {
 			deps[dep.Path] = dep

--- a/grpc/dial.go
+++ b/grpc/dial.go
@@ -54,4 +54,3 @@ func InferSignalingServerAddress(address string) (string, bool, bool) {
 	}
 	return "", false, false
 }
-

--- a/grpc/dial.go
+++ b/grpc/dial.go
@@ -2,15 +2,11 @@ package grpc
 
 import (
 	"context"
-	"fmt"
-	"runtime/debug"
 	"strings"
 	"time"
 
 	"go.viam.com/utils/rpc"
-	"google.golang.org/grpc"
 
-	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/utils/contextutils"
 )
@@ -30,12 +26,6 @@ func Dial(ctx context.Context, address string, logger logging.Logger, opts ...rp
 		webrtcOpts.SignalingInsecure = !secure
 		webrtcOpts.SignalingServerAddress = signalingServerAddress
 	}
-
-	opts = append(
-		opts, 
-		rpc.WithUnaryClientInterceptor(unaryClientInterceptor()), 
-		rpc.WithStreamClientInterceptor(streamClientInterceptor()),
-	)
 
 	optsCopy := make([]rpc.DialOption, len(opts)+2)
 	optsCopy[0] = rpc.WithWebRTCOptions(webrtcOpts)
@@ -65,53 +55,3 @@ func InferSignalingServerAddress(address string) (string, bool, bool) {
 	return "", false, false
 }
 
-func addVersionMetadataToContext(ctx context.Context) context.Context {
-	version := config.Version
-	if version == "" {
-		version = "dev-"
-		if config.GitRevision != "" {
-			version = config.GitRevision
-		} else {
-			version = "unknown"
-		}
-	}
-	info, _ := debug.ReadBuildInfo()
-	deps := make(map[string]*debug.Module, len(info.Deps))
-	for _, dep := range info.Deps {
-			deps[dep.Path] = dep
-	}
-	apiVersion := "?"
-	if dep, ok := deps["go.viam.com/api"]; ok {
-			apiVersion = dep.Version
-	}
-	versionMetadata := fmt.Sprintf("go;v%s;v%s", version, apiVersion)
-	return context.WithValue(ctx, "viam_client", versionMetadata)
-}
-
-func unaryClientInterceptor() grpc.UnaryClientInterceptor{
-	return func(
-			ctx context.Context,
-			method string,
-			req, reply interface{},
-			cc *grpc.ClientConn,
-			invoker grpc.UnaryInvoker,
-			opts ...grpc.CallOption,
-	) error {
-		ctx = addVersionMetadataToContext(ctx)
-		return invoker(ctx, method, req, reply, cc, opts...)
-	}
-}
-
-func streamClientInterceptor() grpc.StreamClientInterceptor {
-	return func(
-		ctx context.Context, 
-		desc *grpc.StreamDesc, 
-		cc *grpc.ClientConn, 
-		method string, 
-		streamer grpc.Streamer, 
-		opts ...grpc.CallOption,
-	) (cs grpc.ClientStream, err error) {
-		ctx = addVersionMetadataToContext(ctx)
-		return streamer(ctx, desc, cc, method, opts...)
-	}
-}

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -253,7 +253,7 @@ func New(ctx context.Context, address string, clientLogger logging.ZapCompatible
 		rpc.WithStreamClientInterceptor(operation.StreamClientInterceptor),
 		rpc.WithUnaryClientInterceptor(logging.UnaryClientInterceptor),
 		// sending version metadata
-		rpc.WithUnaryClientInterceptor(unaryClientInterceptor()), 
+		rpc.WithUnaryClientInterceptor(unaryClientInterceptor()),
 		rpc.WithStreamClientInterceptor(streamClientInterceptor()),
 	)
 
@@ -1088,32 +1088,32 @@ func addVersionMetadataToContext(ctx context.Context) context.Context {
 	info, _ := debug.ReadBuildInfo()
 	settings := make(map[string]string, len(info.Settings))
 	for _, setting := range info.Settings {
-			settings[setting.Key] = setting.Value
+		settings[setting.Key] = setting.Value
 	}
 	version := "?"
 	if rev, ok := settings["vcs.revision"]; ok {
-			version = rev[:8]
+		version = rev[:8]
 	}
 	deps := make(map[string]*debug.Module, len(info.Deps))
 	for _, dep := range info.Deps {
-			deps[dep.Path] = dep
+		deps[dep.Path] = dep
 	}
 	apiVersion := "?"
 	if dep, ok := deps["go.viam.com/api"]; ok {
-			apiVersion = dep.Version
+		apiVersion = dep.Version
 	}
 	versionMetadata := fmt.Sprintf("go;v%s;%s", version, apiVersion)
 	return metadata.AppendToOutgoingContext(ctx, "viam_client", versionMetadata)
 }
 
-func unaryClientInterceptor() googlegrpc.UnaryClientInterceptor{
+func unaryClientInterceptor() googlegrpc.UnaryClientInterceptor {
 	return func(
-			ctx context.Context,
-			method string,
-			req, reply interface{},
-			cc *googlegrpc.ClientConn,
-			invoker googlegrpc.UnaryInvoker,
-			opts ...googlegrpc.CallOption,
+		ctx context.Context,
+		method string,
+		req, reply interface{},
+		cc *googlegrpc.ClientConn,
+		invoker googlegrpc.UnaryInvoker,
+		opts ...googlegrpc.CallOption,
 	) error {
 		ctx = addVersionMetadataToContext(ctx)
 		return invoker(ctx, method, req, reply, cc, opts...)
@@ -1122,11 +1122,11 @@ func unaryClientInterceptor() googlegrpc.UnaryClientInterceptor{
 
 func streamClientInterceptor() googlegrpc.StreamClientInterceptor {
 	return func(
-		ctx context.Context, 
-		desc *googlegrpc.StreamDesc, 
-		cc *googlegrpc.ClientConn, 
-		method string, 
-		streamer googlegrpc.Streamer, 
+		ctx context.Context,
+		desc *googlegrpc.StreamDesc,
+		cc *googlegrpc.ClientConn,
+		method string,
+		streamer googlegrpc.Streamer,
 		opts ...googlegrpc.CallOption,
 	) (cs googlegrpc.ClientStream, err error) {
 		ctx = addVersionMetadataToContext(ctx)

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -1094,6 +1094,7 @@ func unaryClientInterceptor() googlegrpc.UnaryClientInterceptor {
 	) error {
 		md, err := robot.Version()
 		if err != nil {
+			ctx = metadata.AppendToOutgoingContext(ctx, "viam_client", "go;unknown;unknown")
 			return invoker(ctx, method, req, reply, cc, opts...)
 		}
 		stringMd := fmt.Sprintf("go;%s;%s", md.Version, md.APIVersion)
@@ -1113,6 +1114,7 @@ func streamClientInterceptor() googlegrpc.StreamClientInterceptor {
 	) (cs googlegrpc.ClientStream, err error) {
 		md, err := robot.Version()
 		if err != nil {
+			ctx = metadata.AppendToOutgoingContext(ctx, "viam_client", "go;unknown;unknown")
 			return streamer(ctx, desc, cc, method, opts...)
 		}
 		stringMd := fmt.Sprintf("go;%s;%s", md.Version, md.APIVersion)

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -1090,15 +1090,20 @@ func addVersionMetadataToContext(ctx context.Context) context.Context {
 	for _, dep := range info.Deps {
 		deps[dep.Path] = dep
 	}
-	apiVersion := "?"
+	var apiVersion string
 	if dep, ok := deps["go.viam.com/api"]; ok {
 		apiVersion = dep.Version
 	}
-	version := "?"
-	if dep, ok := deps["go.viam.com/rdk"]; ok {
-			version = dep.Version
+	version := config.Version
+	if version == "" && config.GitRevision != ""{
+		version = "git-" + config.GitRevision
 	}
-	versionMetadata := fmt.Sprintf("go;v%s;%s", version, apiVersion)
+	if version == "" {
+		if dep, ok := deps["go.viam.com/rdk"]; ok {
+			version = dep.Version
+		}
+	}
+	versionMetadata := fmt.Sprintf("go;%s;%s", version, apiVersion)
 	return metadata.AppendToOutgoingContext(ctx, "viam_client", versionMetadata)
 }
 

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -1092,7 +1092,10 @@ func unaryClientInterceptor() googlegrpc.UnaryClientInterceptor {
 		invoker googlegrpc.UnaryInvoker,
 		opts ...googlegrpc.CallOption,
 	) error {
-		md, _ := robot.Version()
+		md, err := robot.Version()
+		if err != nil {
+			return invoker(ctx, method, req, reply, cc, opts...)
+		}
 		stringMd := fmt.Sprintf("go;%s;%s", md.Version, md.APIVersion)
 		ctx = metadata.AppendToOutgoingContext(ctx, "viam_client", stringMd)
 		return invoker(ctx, method, req, reply, cc, opts...)
@@ -1108,7 +1111,10 @@ func streamClientInterceptor() googlegrpc.StreamClientInterceptor {
 		streamer googlegrpc.Streamer,
 		opts ...googlegrpc.CallOption,
 	) (cs googlegrpc.ClientStream, err error) {
-		md, _ := robot.Version()
+		md, err := robot.Version()
+		if err != nil {
+			return streamer(ctx, desc, cc, method, opts...)
+		}
 		stringMd := fmt.Sprintf("go;%s;%s", md.Version, md.APIVersion)
 		ctx = metadata.AppendToOutgoingContext(ctx, "viam_client", stringMd)
 		return streamer(ctx, desc, cc, method, opts...)

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -1095,9 +1095,6 @@ func addVersionMetadataToContext(ctx context.Context) context.Context {
 		apiVersion = dep.Version
 	}
 	version := config.Version
-	if version == "" && config.GitRevision != "" {
-		version = "git-" + config.GitRevision
-	}
 	if version == "" {
 		if dep, ok := deps["go.viam.com/rdk"]; ok {
 			version = dep.Version

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -1086,14 +1086,6 @@ func (rc *RobotClient) Version(ctx context.Context) (robot.VersionResponse, erro
 
 func addVersionMetadataToContext(ctx context.Context) context.Context {
 	info, _ := debug.ReadBuildInfo()
-	settings := make(map[string]string, len(info.Settings))
-	for _, setting := range info.Settings {
-		settings[setting.Key] = setting.Value
-	}
-	version := "?"
-	if rev, ok := settings["vcs.revision"]; ok {
-		version = rev[:8]
-	}
 	deps := make(map[string]*debug.Module, len(info.Deps))
 	for _, dep := range info.Deps {
 		deps[dep.Path] = dep
@@ -1101,6 +1093,10 @@ func addVersionMetadataToContext(ctx context.Context) context.Context {
 	apiVersion := "?"
 	if dep, ok := deps["go.viam.com/api"]; ok {
 		apiVersion = dep.Version
+	}
+	version := "?"
+	if dep, ok := deps["go.viam.com/rdk"]; ok {
+			version = dep.Version
 	}
 	versionMetadata := fmt.Sprintf("go;v%s;%s", version, apiVersion)
 	return metadata.AppendToOutgoingContext(ctx, "viam_client", versionMetadata)

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -1095,7 +1095,7 @@ func addVersionMetadataToContext(ctx context.Context) context.Context {
 		apiVersion = dep.Version
 	}
 	version := config.Version
-	if version == "" && config.GitRevision != ""{
+	if version == "" && config.GitRevision != "" {
 		version = "git-" + config.GitRevision
 	}
 	if version == "" {


### PR DESCRIPTION
Get the version from `robot.Version`: `viam_client:[go;dev-unknown;v0.1.330]` (`dev-unknown` is because there's local changes and will be the default.)
Tested by manually changing the `TAG_VERSION` in Makefile: `viam_client:[go;v1.2.3;v0.1.330]`