### PR TITLE
Tweaks to the interruptStream

### DIFF
--- a/components/board/client.go
+++ b/components/board/client.go
@@ -204,14 +204,14 @@ func (c *client) StreamTicks(ctx context.Context, interrupts []DigitalInterrupt,
 		client: c,
 	}
 
-	c.mu.Lock()
-	c.interruptStreams = append(c.interruptStreams, stream)
-	c.mu.Unlock()
-
 	err = stream.startStream(ctx, interrupts, ch)
 	if err != nil {
 		return err
 	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.interruptStreams = append(c.interruptStreams, stream)
 	return nil
 }
 

--- a/components/board/interrupt_stream.go
+++ b/components/board/interrupt_stream.go
@@ -12,7 +12,6 @@ import (
 type interruptStream struct {
 	*client
 	streamCancel  context.CancelFunc
-	streamRunning bool
 	streamReady   chan bool
 	streamMu      sync.Mutex
 
@@ -28,7 +27,6 @@ func (s *interruptStream) startStream(ctx context.Context, interrupts []DigitalI
 		return ctx.Err()
 	}
 
-	s.streamRunning = true
 	s.streamReady = make(chan bool)
 	s.activeBackgroundWorkers.Add(1)
 	ctx, cancel := context.WithCancel(ctx)
@@ -76,11 +74,6 @@ func (s *interruptStream) startStream(ctx context.Context, interrupts []DigitalI
 }
 
 func (s *interruptStream) recieveFromStream(ctx context.Context, stream pb.BoardService_StreamTicksClient, ch chan Tick) {
-	defer func() {
-		s.streamMu.Lock()
-		defer s.streamMu.Unlock()
-		s.streamRunning = false
-	}()
 	// Close the stream ready channel so the above function returns.
 	if s.streamReady != nil {
 		close(s.streamReady)

--- a/components/board/interrupt_stream.go
+++ b/components/board/interrupt_stream.go
@@ -12,7 +12,7 @@ import (
 type interruptStream struct {
 	*client
 	streamCancel  context.CancelFunc
-	streamReady   chan bool
+	streamReady   chan bool // Close this channel to indicate the stream is initialized
 	streamMu      sync.Mutex
 
 	activeBackgroundWorkers sync.WaitGroup

--- a/components/board/interrupt_stream.go
+++ b/components/board/interrupt_stream.go
@@ -11,9 +11,9 @@ import (
 
 type interruptStream struct {
 	*client
-	streamCancel  context.CancelFunc
-	streamReady   chan bool // Close this channel to indicate the stream is initialized
-	streamMu      sync.Mutex
+	streamCancel context.CancelFunc
+	streamReady  chan bool // Close this channel to indicate the stream is initialized
+	streamMu     sync.Mutex
 
 	activeBackgroundWorkers sync.WaitGroup
 	extra                   *structpb.Struct

--- a/components/board/interrupt_stream.go
+++ b/components/board/interrupt_stream.go
@@ -74,7 +74,7 @@ func (s *interruptStream) startStream(ctx context.Context, interrupts []DigitalI
 }
 
 func (s *interruptStream) recieveFromStream(ctx context.Context, stream pb.BoardService_StreamTicksClient, ch chan Tick) {
-	// Close the stream ready channel so the above function returns.
+	// Close the stream ready channel so startStream returns.
 	if s.streamReady != nil {
 		close(s.streamReady)
 	}

--- a/components/board/interrupt_stream.go
+++ b/components/board/interrupt_stream.go
@@ -61,7 +61,7 @@ func (s *interruptStream) startStream(ctx context.Context, interrupts []DigitalI
 	// since managed go calls that function when the routine exits.
 	s.activeBackgroundWorkers.Add(1)
 	utils.ManagedGo(func() {
-		s.recieveFromStream(ctx, stream, ch)
+		s.receiveFromStream(ctx, stream, ch)
 	},
 		s.activeBackgroundWorkers.Done)
 
@@ -73,7 +73,7 @@ func (s *interruptStream) startStream(ctx context.Context, interrupts []DigitalI
 	}
 }
 
-func (s *interruptStream) recieveFromStream(ctx context.Context, stream pb.BoardService_StreamTicksClient, ch chan Tick) {
+func (s *interruptStream) receiveFromStream(ctx context.Context, stream pb.BoardService_StreamTicksClient, ch chan Tick) {
 	// Close the stream ready channel so startStream returns.
 	if s.streamReady != nil {
 		close(s.streamReady)

--- a/components/board/interrupt_stream.go
+++ b/components/board/interrupt_stream.go
@@ -59,10 +59,10 @@ func (s *interruptStream) startStream(ctx context.Context, interrupts []DigitalI
 	// since managed go calls that function when the routine exits.
 	s.activeBackgroundWorkers.Add(1)
 	utils.ManagedGo(func() {
-			s.receiveFromStream(ctx, stream, ch)
-		},
-		s.activeBackgroundWorkers.Done
-	)
+		s.receiveFromStream(ctx, stream, ch)
+	},
+		s.activeBackgroundWorkers.Done)
+	return nil
 }
 
 func (s *interruptStream) receiveFromStream(ctx context.Context, stream pb.BoardService_StreamTicksClient, ch chan Tick) {

--- a/components/board/interrupt_stream.go
+++ b/components/board/interrupt_stream.go
@@ -28,7 +28,6 @@ func (s *interruptStream) startStream(ctx context.Context, interrupts []DigitalI
 	}
 
 	s.streamReady = make(chan bool)
-	s.activeBackgroundWorkers.Add(1)
 	ctx, cancel := context.WithCancel(ctx)
 	s.streamCancel = cancel
 
@@ -60,6 +59,7 @@ func (s *interruptStream) startStream(ctx context.Context, interrupts []DigitalI
 	// Create a background go routine to receive from the server stream.
 	// We rely on calling the Done function here rather than in close stream
 	// since managed go calls that function when the routine exits.
+	s.activeBackgroundWorkers.Add(1)
 	utils.ManagedGo(func() {
 		s.recieveFromStream(ctx, stream, ch)
 	},


### PR DESCRIPTION
I recommend reviewing this commit-by-commit. 

My original plan was to move this to using a `StoppableWorkers`, so that we definitely shut down the background goroutine when we call `closeStream()` (right now, it cancels the context and returns without waiting for the goroutine to actually stop). However, this is trickier than I realized: the context that is canceled is _not_ descended from the background context: it's passed in as an argument and might be canceled by something else! So, this PR is some preliminary cleanup without using a `StoppableWorkers` yet.

No changes to behavior are intended. I haven't tried this out yet; will do that Mondayish.