### PR TITLE
Remove unused field in adxl struct

### DIFF
--- a/components/movementsensor/adxl345/adxl345.go
+++ b/components/movementsensor/adxl345/adxl345.go
@@ -164,9 +164,6 @@ type adxl345 struct {
 	interruptsFound          map[InterruptID]int
 	configuredRegisterValues map[byte]byte
 
-	// Used only to remove the callbacks from the interrupts upon closing component.
-	interruptChannels map[board.DigitalInterrupt]chan board.Tick
-
 	// Lock the mutex when you want to read or write either the acceleration or the last error.
 	mu                 sync.Mutex
 	linearAcceleration r3.Vector
@@ -235,7 +232,6 @@ func makeAdxl345(
 		logger:                   logger,
 		configuredRegisterValues: configuredRegisterValues,
 		interruptsFound:          make(map[InterruptID]int),
-		interruptChannels:        make(map[board.DigitalInterrupt]chan board.Tick),
 
 		// On overloaded boards, sometimes the I2C bus can be flaky. Only report errors if at least
 		// 5 of the last 10 times we've tried interacting with the device have had problems.


### PR DESCRIPTION
We don't actually use interruptChannels anywhere, so removing