### PR TITLE
[RSDK-7589] Update remote control version bump workflow

### DIFF
--- a/.github/workflows/npm-bump-version.yml
+++ b/.github/workflows/npm-bump-version.yml
@@ -11,13 +11,13 @@ on:
         type: string
         description: |
           Typescript SDK Version.
-          If specified, may be `rc`, `latest`, or a specific version.
+          If specified, may be `latest`, `next`, or a specific version.
           Defaults to unspecified, which will not update the TypeScript SDK.
 
       bump:
         required: false
         type: string
-        default: 'patch'
+        default: "patch"
         description: |
           RC version to bump to.
           May be `patch`, `minor`, `major`, or a specific version.
@@ -30,12 +30,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
-      - name: Bump SDK Version
-        if: ${{ inputs.sdk_version}}
-        working-directory: web/frontend
-        run: npm install --save --save-exact @viamrobotics/sdk@${{ inputs.sdk_version }}
-
-      - name: Bump RC Version
+      - name: Bump SDK + RC Version
         run: |
           cd web/frontend
           npm install --save --save-exact @viamrobotics/sdk@${{ inputs.sdk_version }}
@@ -44,8 +39,8 @@ jobs:
       - name: Add + Commit + Open PR
         uses: peter-evans/create-pull-request@v3
         with:
-          commit-message: '[WORKFLOW] Updating remote-control'
-          branch: 'workflow/bump-remote-control/${{ github.ref_name }}'
+          commit-message: "[WORKFLOW] Updating remote-control"
+          branch: "workflow/bump-remote-control/${{ github.ref_name }}"
           delete-branch: true
           base: ${{ github.ref_name }}
           title: Automated remote-control Version Update


### PR DESCRIPTION
With a new weekly release cadence, the TypeScript SDK is moving away from publishing release candidates. Instead, the TS SDK gets a draft release on Monday, goes through automated integration testing, and then is released. 

This PR updates the remote control RC workflow to grab the latest release for the TS SDK, which should be released earlier in the day. (Basically it just changes the comment to say "grab the latest or next version" instead of "RC version")