### PR TITLE
APP-5844 clear version in `module reload` when type=registry

### DIFF
--- a/cli/module_reload.go
+++ b/cli/module_reload.go
@@ -174,7 +174,9 @@ func mutateModuleConfig(c *cli.Context, modules []ModuleMap, manifest moduleMani
 				warningf(c.App.Writer, "you're replacing a registry module. we're converting it to a local module")
 				foundMod["type"] = string(rdkConfig.ModuleTypeLocal)
 				foundMod["name"] = localName
-				foundMod["module_id"] = ""
+				delete(foundMod, "module_id")
+				// TODO(APP-5844): stop clearing this once backend no longer rejects; we will use it for revert
+				delete(foundMod, "version")
 			}
 			foundMod["executable_path"] = absEntrypoint
 		}

--- a/cli/module_reload.go
+++ b/cli/module_reload.go
@@ -171,7 +171,7 @@ func mutateModuleConfig(c *cli.Context, modules []ModuleMap, manifest moduleMani
 			debugf(c.App.Writer, c.Bool(debugFlag), "replacing entrypoint")
 			if getMapString(foundMod, "type") == string(rdkConfig.ModuleTypeRegistry) {
 				// warning: there's a chance of inserting a dupe name here in odd cases
-				warningf(c.App.Writer, "You're replacing a registry module. we're converting it to a local module. "+
+				warningf(c.App.Writer, "You're replacing a registry module. We're converting it to a local module. "+
 					"To revert this change, use your machine's history page on app.viam.com.")
 				foundMod["type"] = string(rdkConfig.ModuleTypeLocal)
 				foundMod["name"] = localName

--- a/cli/module_reload.go
+++ b/cli/module_reload.go
@@ -171,7 +171,8 @@ func mutateModuleConfig(c *cli.Context, modules []ModuleMap, manifest moduleMani
 			debugf(c.App.Writer, c.Bool(debugFlag), "replacing entrypoint")
 			if getMapString(foundMod, "type") == string(rdkConfig.ModuleTypeRegistry) {
 				// warning: there's a chance of inserting a dupe name here in odd cases
-				warningf(c.App.Writer, "you're replacing a registry module. we're converting it to a local module")
+				warningf(c.App.Writer, "You're replacing a registry module. we're converting it to a local module. "+
+					"To revert this change, use your machine's history page on app.viam.com.")
 				foundMod["type"] = string(rdkConfig.ModuleTypeLocal)
 				foundMod["name"] = localName
 				delete(foundMod, "module_id")


### PR DESCRIPTION
## What changed
- clear `version` field when you run `viam module reload` and the module is already installed on the robot from registry
## Why
The backend refuses to serve type=local modules with a `version` field, causing this error in RDK:

```log
2024-08-06T18:20:13.260Z	ERROR	rdk	config/config.go:135	module config error; starting robot without module	{"name":"viam_python-example-module_from_reload","error":"Error validating. Path: \"modules.0\" Error: the version field is not permitted on local modules"}
```

## Manual testing
Tested cases:
1. empty config, `viam module reload` creates a new module
2. config has module installed from registry, `viam module reload` overrides it successfully