### PR TITLE
show instructions in `viam module reload` when the user hits the non-root destination issue

### DIFF
--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -21,6 +21,8 @@ import (
 	"go.viam.com/utils/pexec"
 	"go.viam.com/utils/rpc"
 	"golang.org/x/exp/maps"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/logging"
@@ -453,6 +455,11 @@ func reloadModuleAction(c *cli.Context, vc *viamClient) error {
 				part.Part.Fqdn, c.Bool(debugFlag), false, false, []string{manifest.Build.Path},
 				reloadingDestination(c, manifest), logging.NewLogger("reload"))
 			if err != nil {
+				if s, ok := status.FromError(err); ok && s.Code() == codes.PermissionDenied {
+					warningf(c.App.ErrWriter, "RDK couldn't write to the default file copy destination. "+
+						"If you're running as non-root, try adding --home $HOME or --home /user/username to your CLI command. "+
+						"Alternatively, run the RDK as root.")
+				}
 				return err
 			}
 		}

--- a/services/shell/server.go
+++ b/services/shell/server.go
@@ -148,11 +148,11 @@ func (server *serviceServer) CopyFilesToMachine(srv pb.ShellService_CopyFilesToM
 		md.Metadata.Preserve,
 		md.Metadata.Extra.AsMap())
 	if err != nil {
-		if pathErr, ok := err.(*fs.PathError); ok {
-			if errno, ok := pathErr.Err.(syscall.Errno); ok && errno == syscall.EACCES {
-				// we use an error code here so CLI can detect this case and give instructions
-				return status.New(codes.PermissionDenied, err.Error()).Err()
-			}
+		var pathErr *fs.PathError
+		var errno syscall.Errno
+		if errors.As(err, &pathErr) && errors.As(pathErr.Err, &errno) {
+			// we use an error code here so CLI can detect this case and give instructions
+			return status.New(codes.PermissionDenied, err.Error()).Err()
 		}
 		return err
 	}

--- a/services/shell/server.go
+++ b/services/shell/server.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"errors"
 	"io"
+	"io/fs"
+	"syscall"
 
 	"go.uber.org/multierr"
 	commonpb "go.viam.com/api/common/v1"
 	pb "go.viam.com/api/service/shell/v1"
 	"go.viam.com/utils"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"go.viam.com/rdk/protoutils"
 	"go.viam.com/rdk/resource"
@@ -144,6 +148,12 @@ func (server *serviceServer) CopyFilesToMachine(srv pb.ShellService_CopyFilesToM
 		md.Metadata.Preserve,
 		md.Metadata.Extra.AsMap())
 	if err != nil {
+		if pathErr, ok := err.(*fs.PathError); ok {
+			if errno, ok := pathErr.Err.(syscall.Errno); ok && errno == syscall.EACCES {
+				// we use an error code here so CLI can detect this case and give instructions
+				return status.New(codes.PermissionDenied, err.Error()).Err()
+			}
+		}
 		return err
 	}
 	defer func() {

--- a/services/shell/server.go
+++ b/services/shell/server.go
@@ -150,7 +150,7 @@ func (server *serviceServer) CopyFilesToMachine(srv pb.ShellService_CopyFilesToM
 	if err != nil {
 		var pathErr *fs.PathError
 		var errno syscall.Errno
-		if errors.As(err, &pathErr) && errors.As(pathErr.Err, &errno) {
+		if errors.As(err, &pathErr) && errors.As(pathErr.Err, &errno) && errno == syscall.EACCES {
 			// we use an error code here so CLI can detect this case and give instructions
 			return status.New(codes.PermissionDenied, err.Error()).Err()
 		}


### PR DESCRIPTION
## What changed
- wrap EACCES with PermissionDenied in CopyFilesToMachine
- in CLI `viam module reload` command, show an instructional warning when the copy command returns PermissionDenied
## Why
In remote reloading, when we upload a tarball to the destination RDK, the shell copy files endpoint takes an absolute path. That's fine, except when RDK is not running as root; in that case we need to know the remote user. This manifests as a permission denied error (see red error line in screenshot).

In #4139, the remote reloading PR, we added a `--home` flag so the user can override this. Today's PR prints instructions to use the home flag when you hit the permission denied error.

The ideal solve here is to support `$VIAM_HOME`, `~`, or relative paths in the file copy service. (There's a chance relative paths already work, but would need to think through what is the working directory and will it always be the same. Always interpreting relative paths as relative to the `viamDotDir` would be a good solve).
## Screenshot
(The yellow warning line is the new piece).
![Screenshot from 2024-08-07 14-51-56](https://github.com/user-attachments/assets/6235d9bb-250b-4e04-89f0-a6122ccd63c7)
