### PR TITLE
check OS + architecture of binary in `validateModuleFile`

### DIFF
--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -525,17 +525,9 @@ func getExecutableArch(reader *tar.Reader) string {
 	if _, err := exec.LookPath("file"); err != nil {
 		return ""
 	}
-	f, err := os.CreateTemp("", "")
-	if err != nil {
-		return ""
-	}
-	// note: we limit this to prefix because binaries can get huge and `file` only needs the beginning.
-	if _, err := io.CopyN(f, reader, 1024); err != nil && !errors.Is(err, io.EOF) {
-		return ""
-	}
-	f.Close()                                              //nolint:errcheck,gosec
-	output, err := exec.Command("file", f.Name()).Output() //nolint:gosec
-	os.Remove(f.Name())                                    //nolint:errcheck,gosec
+	cmd := exec.Command("file", "-")
+	cmd.Stdin = reader
+	output, err := cmd.Output()
 	if err != nil {
 		return ""
 	}

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -11,6 +11,7 @@ import (
 	"io/fs"
 	"math"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -294,7 +295,7 @@ func UploadModuleAction(c *cli.Context) error {
 	}
 
 	if !forceUploadArg {
-		if err := validateModuleFile(client, moduleID, tarballPath, versionArg); err != nil {
+		if err := validateModuleFile(client, c, moduleID, tarballPath, versionArg, platformArg); err != nil {
 			return fmt.Errorf(
 				"error validating module: %w. For more details, please visit: https://docs.viam.com/cli/#module ",
 				err)
@@ -421,7 +422,7 @@ func (c *viamClient) uploadModuleFile(
 	return resp, errs
 }
 
-func validateModuleFile(client *viamClient, moduleID moduleID, tarballPath, version string) error {
+func validateModuleFile(client *viamClient, c *cli.Context, moduleID moduleID, tarballPath, version, platform string) error {
 	getModuleResp, err := client.getModule(moduleID)
 	if err != nil {
 		return err
@@ -484,6 +485,11 @@ func validateModuleFile(client *viamClient, moduleID moduleID, tarballPath, vers
 			// executable file at entrypoint. validation succeeded.
 			// continue looping to find symlinks
 			foundEntrypoint = true
+			if parsed := getExecutableArch(tarReader); parsed != "" && parsed != platform {
+				warningf(c.App.ErrWriter,
+					"You've tagged %s but your binary has platform %s. (This warning is experimental, ignore if it doesn't make sense).",
+					platform, parsed)
+			}
 		}
 		if filepath.Base(path) == filepath.Base(entrypoint) {
 			filesWithSameNameAsEntrypoint = append(filesWithSameNameAsEntrypoint, path)
@@ -512,6 +518,28 @@ func validateModuleFile(client *viamClient, moduleID moduleID, tarballPath, vers
 	}
 	// success
 	return nil
+}
+
+// runs ParseFileType on the output of running `file` on whatever is in the tarball. Returns empty string if anything went wrong.
+func getExecutableArch(reader *tar.Reader) string {
+	if _, err := exec.LookPath("file"); err != nil {
+		return ""
+	}
+	f, err := os.CreateTemp("", "")
+	if err != nil {
+		return ""
+	}
+	// note: we limit this to prefix because binaries can get huge and `file` only needs the beginning.
+	if _, err := io.CopyN(f, reader, 1024); err != nil && !errors.Is(err, io.EOF) {
+		return ""
+	}
+	f.Close()
+	output, err := exec.Command("file", f.Name()).Output()
+	os.Remove(f.Name())
+	if err != nil {
+		return ""
+	}
+	return ParseFileType(string(output))
 }
 
 func visibilityToProto(visibility moduleVisibility) (apppb.Visibility, error) {

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -533,9 +533,9 @@ func getExecutableArch(reader *tar.Reader) string {
 	if _, err := io.CopyN(f, reader, 1024); err != nil && !errors.Is(err, io.EOF) {
 		return ""
 	}
-	f.Close()
-	output, err := exec.Command("file", f.Name()).Output()
-	os.Remove(f.Name())
+	f.Close()                                              //nolint:errcheck,gosec
+	output, err := exec.Command("file", f.Name()).Output() //nolint:gosec
+	os.Remove(f.Name())                                    //nolint:errcheck,gosec
 	if err != nil {
 		return ""
 	}

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -1,6 +1,10 @@
 package cli
 
-import "path/filepath"
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+)
 
 // samePath returns true if abs(path1) and abs(path2) are the same.
 func samePath(path1, path2 string) (bool, error) {
@@ -28,4 +32,27 @@ func getMapString(m map[string]any, key string) string {
 		}
 	}
 	return ""
+}
+
+var fileTypeRegex = regexp.MustCompile(`^((ELF) [^,]+, ([^,]+),|(Mach-O) [^\ ]+ ([^\ ]+) executable)`)
+
+// ParseFileType parses output from the `file` command. Returns a platform string like "linux/amd64".
+// Empty string means failed to parse.
+func ParseFileType(raw string) string {
+	groups := fileTypeRegex.FindStringSubmatch(raw)
+	if len(groups) == 0 {
+		return ""
+	}
+	var rawOs, rawArch string
+	if groups[2] != "" {
+		rawOs = groups[2]
+		rawArch = groups[3]
+	} else {
+		rawOs = groups[4]
+		rawArch = groups[5]
+	}
+	osLookup := map[string]string{"ELF": "linux", "Mach-O": "darwin"}
+	// todo: double-check 'arm' is right for arm32
+	archLookup := map[string]string{"x86-64": "amd64", "ARM aarch64": "arm64", "ARM": "arm", "x86_64": "amd64", "arm64": "arm64"}
+	return fmt.Sprintf("%s/%s", osLookup[rawOs], archLookup[rawArch])
 }

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -52,7 +52,10 @@ func ParseFileType(raw string) string {
 		rawArch = groups[5]
 	}
 	osLookup := map[string]string{"ELF": "linux", "Mach-O": "darwin"}
-	// todo: double-check 'arm' is right for arm32
-	archLookup := map[string]string{"x86-64": "amd64", "ARM aarch64": "arm64", "ARM": "arm", "x86_64": "amd64", "arm64": "arm64"}
+	archLookup := map[string]string{"x86-64": "amd64", "ARM aarch64": "arm64", "ARM": "arm32", "x86_64": "amd64", "arm64": "arm64"}
+	if archLookup[rawArch] == "arm32" {
+		// if we ever parse the different arm versions, give arm32v6 etc. for now, return "" to prevent checking this case.
+		return ""
+	}
 	return fmt.Sprintf("%s/%s", osLookup[rawOs], archLookup[rawArch])
 }

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -34,7 +34,7 @@ func getMapString(m map[string]any, key string) string {
 	return ""
 }
 
-var fileTypeRegex = regexp.MustCompile(`^((ELF) [^,]+, ([^,]+),|(Mach-O) [^\ ]+ ([^\ ]+) executable)`)
+var fileTypeRegex = regexp.MustCompile(`^[^:]+: ((ELF) [^,]+, ([^,]+),|(Mach-O) [^\ ]+ ([^\ ]+) executable)`)
 
 // ParseFileType parses output from the `file` command. Returns a platform string like "linux/amd64".
 // Empty string means failed to parse.

--- a/cli/utils_test.go
+++ b/cli/utils_test.go
@@ -28,7 +28,7 @@ func TestParseFileType(t *testing.T) {
 	pairs := [][]string{
 		{"linux/amd64", `filename: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=2VnfLaDNwi7mhCjdDkAr/lpOa21AkXD_n1ZOzOBaE/WQvWVRjuvto6MgjwqbQ3/hja5tmvEfcE09ZLPl819, with debug_info, not stripped`},
 		{"linux/arm64", `/path/to: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=xswztQyDYn9C34kIHH1c/al0YUQI7PfmFrMDS910o/BRt84DHJJKOoz3JFShfc/gCDP6LgcLRWk5l2TpxbR, with debug_info, not stripped`},
-		{"linux/arm", `file: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, Go BuildID=1TRJ7vRfAd6gwe6x0c6d/m6JcXHPRiWLykXbmUtO5/vMbl6w2O72ILWCBSPVF3/l3HWqdJgAaP46rzUna4Y, with debug_info, not stripped`},
+		{"", `file: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, Go BuildID=1TRJ7vRfAd6gwe6x0c6d/m6JcXHPRiWLykXbmUtO5/vMbl6w2O72ILWCBSPVF3/l3HWqdJgAaP46rzUna4Y, with debug_info, not stripped`},
 		{"darwin/amd64", `/bin/whatever: Mach-O 64-bit x86_64 executable`},
 		{"darwin/arm64", `x/y/z: Mach-O 64-bit arm64 executable, flags:<|DYLDLINK|PIE>`},
 	}

--- a/cli/utils_test.go
+++ b/cli/utils_test.go
@@ -26,11 +26,11 @@ func TestGetMapString(t *testing.T) {
 
 func TestParseFileType(t *testing.T) {
 	pairs := [][]string{
-		{"linux/amd64", `ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=2VnfLaDNwi7mhCjdDkAr/lpOa21AkXD_n1ZOzOBaE/WQvWVRjuvto6MgjwqbQ3/hja5tmvEfcE09ZLPl819, with debug_info, not stripped`},
-		{"linux/arm64", `ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=xswztQyDYn9C34kIHH1c/al0YUQI7PfmFrMDS910o/BRt84DHJJKOoz3JFShfc/gCDP6LgcLRWk5l2TpxbR, with debug_info, not stripped`},
-		{"linux/arm", `ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, Go BuildID=1TRJ7vRfAd6gwe6x0c6d/m6JcXHPRiWLykXbmUtO5/vMbl6w2O72ILWCBSPVF3/l3HWqdJgAaP46rzUna4Y, with debug_info, not stripped`},
-		{"darwin/amd64", `Mach-O 64-bit x86_64 executable`},
-		{"darwin/arm64", `Mach-O 64-bit arm64 executable, flags:<|DYLDLINK|PIE>`},
+		{"linux/amd64", `filename: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=2VnfLaDNwi7mhCjdDkAr/lpOa21AkXD_n1ZOzOBaE/WQvWVRjuvto6MgjwqbQ3/hja5tmvEfcE09ZLPl819, with debug_info, not stripped`},
+		{"linux/arm64", `/path/to: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=xswztQyDYn9C34kIHH1c/al0YUQI7PfmFrMDS910o/BRt84DHJJKOoz3JFShfc/gCDP6LgcLRWk5l2TpxbR, with debug_info, not stripped`},
+		{"linux/arm", `file: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, Go BuildID=1TRJ7vRfAd6gwe6x0c6d/m6JcXHPRiWLykXbmUtO5/vMbl6w2O72ILWCBSPVF3/l3HWqdJgAaP46rzUna4Y, with debug_info, not stripped`},
+		{"darwin/amd64", `/bin/whatever: Mach-O 64-bit x86_64 executable`},
+		{"darwin/arm64", `x/y/z: Mach-O 64-bit arm64 executable, flags:<|DYLDLINK|PIE>`},
 	}
 	for _, pair := range pairs {
 		test.That(t, ParseFileType(pair[1]), test.ShouldResemble, pair[0])

--- a/cli/utils_test.go
+++ b/cli/utils_test.go
@@ -1,3 +1,4 @@
+//nolint:lll
 package cli
 
 import (
@@ -21,4 +22,17 @@ func TestGetMapString(t *testing.T) {
 	test.That(t, getMapString(m, "x"), test.ShouldEqual, "x")
 	test.That(t, getMapString(m, "y"), test.ShouldEqual, "")
 	test.That(t, getMapString(m, "z"), test.ShouldEqual, "")
+}
+
+func TestParseFileType(t *testing.T) {
+	pairs := [][]string{
+		{"linux/amd64", `ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=2VnfLaDNwi7mhCjdDkAr/lpOa21AkXD_n1ZOzOBaE/WQvWVRjuvto6MgjwqbQ3/hja5tmvEfcE09ZLPl819, with debug_info, not stripped`},
+		{"linux/arm64", `ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=xswztQyDYn9C34kIHH1c/al0YUQI7PfmFrMDS910o/BRt84DHJJKOoz3JFShfc/gCDP6LgcLRWk5l2TpxbR, with debug_info, not stripped`},
+		{"linux/arm", `ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, Go BuildID=1TRJ7vRfAd6gwe6x0c6d/m6JcXHPRiWLykXbmUtO5/vMbl6w2O72ILWCBSPVF3/l3HWqdJgAaP46rzUna4Y, with debug_info, not stripped`},
+		{"darwin/amd64", `Mach-O 64-bit x86_64 executable`},
+		{"darwin/arm64", `Mach-O 64-bit arm64 executable, flags:<|DYLDLINK|PIE>`},
+	}
+	for _, pair := range pairs {
+		test.That(t, ParseFileType(pair[1]), test.ShouldResemble, pair[0])
+	}
 }


### PR DESCRIPTION
## What changed
- when validating a tarball, make sure the binary matches the desired platform (e.g. linux/arm64 vs linux/amd64). Warn if not
## Why
We've seen people upload binaries of the wrong architecture when first doing cross-platform work; this makes that situation slightly louder, to save debugging time
## Notes
- I made it a warning rather than an error because I'm not sure how complete / correct the parser is. It's designed to fail silently unless the system is reasonably sure something is wrong.
- This is silent if someone is using a run.sh
- This is silent for 32-bit arm
## Screenshot
(The yellow warning line is new).
![Screenshot from 2024-08-07 16-50-38](https://github.com/user-attachments/assets/7f5798c7-54bb-4c13-8af8-42c276c8f34d)
