### PR TITLE
⚠️ RSDK-7903 Include unhealthy remotes in resource list with status

### DIFF
--- a/resource/graph_node.go
+++ b/resource/graph_node.go
@@ -36,7 +36,7 @@ const (
 
 	// NodeStateUnhealthy denotes a resource is unhealthy.
 	NodeStateUnhealthy
-	
+
 	// NodeStateDisconnected denotes a resource is disconnected.
 	NodeStateDisconnected
 )

--- a/resource/graph_node.go
+++ b/resource/graph_node.go
@@ -467,6 +467,7 @@ func (w *GraphNode) replace(other *GraphNode) error {
 }
 
 func (w *GraphNode) canTransitionTo(state NodeState) bool {
+	//nolint // TODO add NodeStateDisconnected if agreed to
 	switch w.state {
 	case NodeStateUnknown:
 	case NodeStateUnconfigured:

--- a/resource/nodestate_string.go
+++ b/resource/nodestate_string.go
@@ -14,11 +14,12 @@ func _() {
 	_ = x[NodeStateReady-3]
 	_ = x[NodeStateRemoving-4]
 	_ = x[NodeStateUnhealthy-5]
+	_ = x[NodeStateDisconnected-6]
 }
 
-const _NodeState_name = "UnknownUnconfiguredConfiguringReadyRemovingUnhealthy"
+const _NodeState_name = "UnknownUnconfiguredConfiguringReadyRemovingUnhealthyDisconnected"
 
-var _NodeState_index = [...]uint8{0, 7, 19, 30, 35, 43, 52}
+var _NodeState_index = [...]uint8{0, 7, 19, 30, 35, 43, 52, 64}
 
 func (i NodeState) String() string {
 	if i >= NodeState(len(_NodeState_index)-1) {

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -1085,7 +1085,7 @@ func (rc *RobotClient) MachineStatus(ctx context.Context) (robot.MachineStatus, 
 	ms := rc.cachedMachineStatus
 	if errors.Is(err, ErrDisconnected) {
 		for i := range rc.cachedMachineStatus.Resources {
-			ms.Resources[i].State = resource.NodeStateUnhealthy
+			ms.Resources[i].State = resource.NodeStateDisconnected
 		}
 	}
 	return ms, err

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -629,11 +629,28 @@ func (rc *RobotClient) resources(ctx context.Context) ([]resource.Status, []reso
 
 	resources := make([]resource.Status, 0, len(resp.Resources))
 	for _, rs := range resp.Resources {
-		if rs.Name.API == RemoteAPI ||
-			rs.Name.API.Type.Namespace == resource.APINamespaceRDKInternal {
+		if rs.Name.API == RemoteAPI {
 			continue
 		}
+		if rs.Name.API.Type.Namespace == resource.APINamespaceRDKInternal {
+			continue
+		}
+		if rs.State == resource.NodeStateUnhealthy {
+			continue
+		}
+		fmt.Println(">>> client -> status resource", "name", rs.Name)
 		resources = append(resources, rs)
+	}
+
+	resp2, err := rc.client.ResourceNames(ctx, &pb.ResourceNamesRequest{})
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, name := range resp2.Resources {
+		newName := rprotoutils.ResourceNameFromProto(name)
+		fmt.Println(">>> client -> legacy resource", "name", newName)
+		// s := resource.Status{Name: newName}
+		// resources = append(resources, s)
 	}
 
 	// resource has previously returned an unimplemented response, skip rpc call

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -635,22 +635,7 @@ func (rc *RobotClient) resources(ctx context.Context) ([]resource.Status, []reso
 		if rs.Name.API.Type.Namespace == resource.APINamespaceRDKInternal {
 			continue
 		}
-		if rs.State == resource.NodeStateUnhealthy {
-			continue
-		}
-		fmt.Println(">>> client -> status resource", "name", rs.Name)
 		resources = append(resources, rs)
-	}
-
-	resp2, err := rc.client.ResourceNames(ctx, &pb.ResourceNamesRequest{})
-	if err != nil {
-		return nil, nil, err
-	}
-	for _, name := range resp2.Resources {
-		newName := rprotoutils.ResourceNameFromProto(name)
-		fmt.Println(">>> client -> legacy resource", "name", newName)
-		// s := resource.Status{Name: newName}
-		// resources = append(resources, s)
 	}
 
 	// resource has previously returned an unimplemented response, skip rpc call

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -629,6 +629,10 @@ func (rc *RobotClient) resources(ctx context.Context) ([]resource.Name, []resour
 
 	resources := make([]resource.Name, 0, len(resp.Resources))
 	for _, status := range resp.Resources {
+		if status.Name.API == RemoteAPI ||
+			status.Name.API.Type.Namespace == resource.APINamespaceRDKInternal {
+			continue
+		}
 		resources = append(resources, status.Name)
 	}
 

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -1066,11 +1066,19 @@ func (rc *RobotClient) Shutdown(ctx context.Context) error {
 	return nil
 }
 
+// ErrDisconnected that a robot is disconnected.
+var ErrDisconnected = errors.New("disconnected")
+
 // MachineStatus returns the current status of the robot.
 func (rc *RobotClient) MachineStatus(ctx context.Context) (robot.MachineStatus, error) {
+	var err error
+	if rc.checkConnected() != nil {
+		err = ErrDisconnected
+	}
+
 	rc.mu.Lock()
 	defer rc.mu.Unlock()
-	return rc.cachedMachineStatus, nil
+	return rc.cachedMachineStatus, err
 }
 
 func (rc *RobotClient) machineStatus(ctx context.Context) (robot.MachineStatus, error) {

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -620,7 +620,7 @@ func (rc *RobotClient) resources(ctx context.Context) ([]resource.Name, []resour
 		defer cancel()
 	}
 
-	resp, err := rc.client.ResourceNames(ctx, &pb.ResourceNamesRequest{})
+	resp, err := rc.MachineStatus(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -628,9 +628,8 @@ func (rc *RobotClient) resources(ctx context.Context) ([]resource.Name, []resour
 	var resTypes []resource.RPCAPI
 
 	resources := make([]resource.Name, 0, len(resp.Resources))
-	for _, name := range resp.Resources {
-		newName := rprotoutils.ResourceNameFromProto(name)
-		resources = append(resources, newName)
+	for _, status := range resp.Resources {
+		resources = append(resources, status.Name)
 	}
 
 	// resource has previously returned an unimplemented response, skip rpc call

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -1070,25 +1070,18 @@ func (rc *RobotClient) Shutdown(ctx context.Context) error {
 // ErrDisconnected that a robot is disconnected.
 var ErrDisconnected = errors.New("disconnected")
 
-// MachineStatus returns the current status of the robot. If the robot is
-// disconnected return it's cached resource statuses with state
-// [NodeStateDisconnected].
+// MachineStatus returns the current status of the robot.
 func (rc *RobotClient) MachineStatus(ctx context.Context) (robot.MachineStatus, error) {
-	var err error
 	if rc.checkConnected() != nil {
-		err = ErrDisconnected
+		return robot.MachineStatus{}, ErrDisconnected
 	}
 
 	rc.mu.Lock()
 	defer rc.mu.Unlock()
 
-	ms := rc.cachedMachineStatus
-	if errors.Is(err, ErrDisconnected) {
-		for i := range rc.cachedMachineStatus.Resources {
-			ms.Resources[i].State = resource.NodeStateDisconnected
-		}
-	}
-	return ms, err
+	// TODO: cache errors related to fetching cached machine status and
+	// return here?
+	return rc.cachedMachineStatus, nil
 }
 
 func (rc *RobotClient) machineStatus(ctx context.Context) (robot.MachineStatus, error) {

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -1078,9 +1078,6 @@ func (rc *RobotClient) MachineStatus(ctx context.Context) (robot.MachineStatus, 
 
 	rc.mu.Lock()
 	defer rc.mu.Unlock()
-
-	// TODO: cache errors related to fetching cached machine status and
-	// return here?
 	return rc.cachedMachineStatus, nil
 }
 

--- a/robot/client/client_session.go
+++ b/robot/client/client_session.go
@@ -28,6 +28,7 @@ var exemptFromSession = map[string]bool{
 	"/proto.rpc.webrtc.v1.SignalingService/OptionalWebRTCConfig":     true,
 	"/proto.rpc.v1.AuthService/Authenticate":                         true,
 	"/proto.rpc.v1.ExternalAuthService/AuthenticateTo":               true,
+	"/viam.robot.v1.RobotService/GetMachineStatus":                   true,
 	"/viam.robot.v1.RobotService/ResourceNames":                      true,
 	"/viam.robot.v1.RobotService/ResourceRPCSubtypes":                true,
 	"/viam.robot.v1.RobotService/StartSession":                       true,

--- a/robot/client/client_session_test.go
+++ b/robot/client/client_session_test.go
@@ -81,191 +81,205 @@ func init() {
 func TestClientSessionOptions(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
+
+	type testcase struct {
+		webrtcDisabled   bool
+		withRemoteName   bool
+		sessionsDisabled bool
+	}
+
+	var testcases []testcase
 	for _, webrtcDisabled := range []bool{false, true} {
 		for _, sessionsDisabled := range []bool{false, true} {
 			for _, withRemoteName := range []bool{false, true} {
-				webrtcDisabledCopy := webrtcDisabled
-				withRemoteNameCopy := withRemoteName
-				sessionsDisabledCopy := sessionsDisabled
-
-				t.Run(
-					fmt.Sprintf(
-						"webrtc disabled=%t,with remote name=%t,sessions disabled=%t",
-						webrtcDisabledCopy,
-						withRemoteNameCopy,
-						sessionsDisabledCopy,
-					),
-					func(t *testing.T) {
-						t.Parallel()
-
-						logger := logging.NewTestLogger(t)
-
-						sessMgr := &sessionManager{}
-						arbName := resource.NewName(echoAPI, "woo")
-						injectResources := []resource.Name{arbName}
-						injectRobot := &inject.Robot{
-							ResourceNamesFunc: func() []resource.Name { return injectResources },
-							MachineStatusFunc: func(ctx context.Context) (robot.MachineStatus, error) {
-								return rdktestutils.ResourcesToMachineStatus(injectResources), nil
-							},
-							ResourceByNameFunc: func(name resource.Name) (resource.Resource, error) {
-								return &dummyEcho{Named: arbName.AsNamed()}, nil
-							},
-							ResourceRPCAPIsFunc: func() []resource.RPCAPI { return nil },
-							LoggerFunc:          func() logging.Logger { return logger },
-							SessMgr:             sessMgr,
-						}
-
-						svc := web.New(injectRobot, logger)
-
-						options, _, addr := robottestutils.CreateBaseOptionsAndListener(t)
-						err := svc.Start(ctx, options)
-						test.That(t, err, test.ShouldBeNil)
-
-						var opts []client.RobotClientOption
-						if sessionsDisabledCopy {
-							opts = append(opts, client.WithDisableSessions())
-						}
-						if withRemoteNameCopy {
-							opts = append(opts, client.WithRemoteName("rem1"))
-						}
-						if webrtcDisabledCopy {
-							opts = append(opts, client.WithDialOptions(rpc.WithWebRTCOptions(rpc.DialWebRTCOptions{
-								Disable: true,
-							})))
-						}
-						roboClient, err := client.New(ctx, addr, logger, opts...)
-						test.That(t, err, test.ShouldBeNil)
-
-						injectRobot.Mu.Lock()
-						injectRobot.StatusFunc = func(ctx context.Context, resourceNames []resource.Name) ([]robot.Status, error) {
-							session.SafetyMonitorResourceName(ctx, someTargetName1)
-							return []robot.Status{}, nil
-						}
-						injectRobot.Mu.Unlock()
-
-						var capMu sync.Mutex
-						var startCalled int
-						var findCalled int
-						var capOwnerID string
-						var capID uuid.UUID
-						var associateCount int
-						var storedID uuid.UUID
-						var storedResourceName resource.Name
-
-						sess1 := session.New(context.Background(), "ownerID", 5*time.Second, func(id uuid.UUID, resourceName resource.Name) {
-							capMu.Lock()
-							associateCount++
-							storedID = id
-							storedResourceName = resourceName
-							capMu.Unlock()
-						})
-						nextCtx := session.ToContext(ctx, sess1)
-
-						sessMgr.mu.Lock()
-						sessMgr.StartFunc = func(ctx context.Context, ownerID string) (*session.Session, error) {
-							capMu.Lock()
-							startCalled++
-							capOwnerID = ownerID
-							capMu.Unlock()
-							return sess1, nil
-						}
-						sessMgr.FindByIDFunc = func(ctx context.Context, id uuid.UUID, ownerID string) (*session.Session, error) {
-							if id != sess1.ID() {
-								return nil, errors.New("session id mismatch")
-							}
-							capMu.Lock()
-							findCalled++
-							capID = id
-							capOwnerID = ownerID
-							capMu.Unlock()
-							sess1.Heartbeat(ctx) // gotta keep session alive
-							return sess1, nil
-						}
-						sessMgr.mu.Unlock()
-
-						resp, err := roboClient.Status(nextCtx, []resource.Name{})
-						test.That(t, err, test.ShouldBeNil)
-						test.That(t, len(resp), test.ShouldEqual, 0)
-
-						if sessionsDisabledCopy {
-							// wait for any kind of heartbeat
-							time.Sleep(2 * time.Second)
-
-							capMu.Lock()
-							test.That(t, startCalled, test.ShouldEqual, 0)
-							test.That(t, findCalled, test.ShouldEqual, 0)
-							capMu.Unlock()
-						} else {
-							capMu.Lock()
-							test.That(t, startCalled, test.ShouldEqual, 1)
-							test.That(t, findCalled, test.ShouldEqual, 0)
-
-							if webrtcDisabledCopy {
-								test.That(t, capOwnerID, test.ShouldEqual, "")
-							} else {
-								test.That(t, capOwnerID, test.ShouldNotEqual, "")
-							}
-							capMu.Unlock()
-
-							startAt := time.Now()
-							testutils.WaitForAssertionWithSleep(t, time.Second, 10, func(tb testing.TB) {
-								tb.Helper()
-
-								capMu.Lock()
-								defer capMu.Unlock()
-								test.That(tb, findCalled, test.ShouldBeGreaterThanOrEqualTo, 5)
-								test.That(tb, capID, test.ShouldEqual, sess1.ID())
-
-								if webrtcDisabledCopy {
-									test.That(tb, capOwnerID, test.ShouldEqual, "")
-								} else {
-									test.That(tb, capOwnerID, test.ShouldNotEqual, "")
-								}
-							})
-							// testing against time but fairly generous range
-							test.That(t, time.Since(startAt), test.ShouldBeBetween, 4*time.Second, 7*time.Second)
-						}
-
-						capMu.Lock()
-						if withRemoteNameCopy {
-							test.That(t, associateCount, test.ShouldEqual, 1)
-							test.That(t, storedID, test.ShouldEqual, sess1.ID())
-							test.That(t, storedResourceName, test.ShouldResemble, someTargetName1.PrependRemote("rem1"))
-						} else {
-							test.That(t, associateCount, test.ShouldEqual, 0)
-						}
-						capMu.Unlock()
-
-						echoRes, err := roboClient.ResourceByName(arbName)
-						test.That(t, err, test.ShouldBeNil)
-						echoClient := echoRes.(*dummyClient).client
-
-						echoMultiClient, err := echoClient.EchoResourceMultiple(nextCtx, &echopb.EchoResourceMultipleRequest{
-							Name:    arbName.Name,
-							Message: "doesnotmatter",
-						})
-						test.That(t, err, test.ShouldBeNil)
-						_, err = echoMultiClient.Recv() // EOF; okay
-						test.That(t, err, test.ShouldBeError, io.EOF)
-
-						err = roboClient.Close(context.Background())
-						test.That(t, err, test.ShouldBeNil)
-
-						capMu.Lock()
-						if withRemoteNameCopy {
-							test.That(t, associateCount, test.ShouldEqual, 2)
-							test.That(t, storedID, test.ShouldEqual, sess1.ID())
-							test.That(t, storedResourceName, test.ShouldResemble, someTargetName2.PrependRemote("rem1"))
-						} else {
-							test.That(t, associateCount, test.ShouldEqual, 0)
-						}
-						capMu.Unlock()
-
-						test.That(t, svc.Close(ctx), test.ShouldBeNil)
-					})
+				tc := testcase{
+					webrtcDisabled:   webrtcDisabled,
+					withRemoteName:   withRemoteName,
+					sessionsDisabled: sessionsDisabled,
+				}
+				testcases = append(testcases, tc)
 			}
 		}
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(
+			fmt.Sprintf(
+				"webrtc disabled=%t,with remote name=%t,sessions disabled=%t",
+				tc.webrtcDisabled,
+				tc.withRemoteName,
+				tc.sessionsDisabled,
+			),
+			func(t *testing.T) {
+				t.Parallel()
+
+				logger := logging.NewTestLogger(t)
+
+				sessMgr := &sessionManager{}
+				arbName := resource.NewName(echoAPI, "woo")
+				injectResources := []resource.Name{arbName}
+				injectRobot := &inject.Robot{
+					ResourceNamesFunc: func() []resource.Name { return injectResources },
+					MachineStatusFunc: func(ctx context.Context) (robot.MachineStatus, error) {
+						return rdktestutils.ResourcesToMachineStatus(injectResources), nil
+					},
+					ResourceByNameFunc: func(name resource.Name) (resource.Resource, error) {
+						return &dummyEcho{Named: arbName.AsNamed()}, nil
+					},
+					ResourceRPCAPIsFunc: func() []resource.RPCAPI { return nil },
+					LoggerFunc:          func() logging.Logger { return logger },
+					SessMgr:             sessMgr,
+				}
+
+				svc := web.New(injectRobot, logger)
+
+				options, _, addr := robottestutils.CreateBaseOptionsAndListener(t)
+				err := svc.Start(ctx, options)
+				test.That(t, err, test.ShouldBeNil)
+
+				var opts []client.RobotClientOption
+				if tc.sessionsDisabled {
+					opts = append(opts, client.WithDisableSessions())
+				}
+				if tc.withRemoteName {
+					opts = append(opts, client.WithRemoteName("rem1"))
+				}
+				if tc.webrtcDisabled {
+					opts = append(opts, client.WithDialOptions(rpc.WithWebRTCOptions(rpc.DialWebRTCOptions{
+						Disable: true,
+					})))
+				}
+				roboClient, err := client.New(ctx, addr, logger, opts...)
+				test.That(t, err, test.ShouldBeNil)
+
+				injectRobot.Mu.Lock()
+				injectRobot.StatusFunc = func(ctx context.Context, resourceNames []resource.Name) ([]robot.Status, error) {
+					session.SafetyMonitorResourceName(ctx, someTargetName1)
+					return []robot.Status{}, nil
+				}
+				injectRobot.Mu.Unlock()
+
+				var capMu sync.Mutex
+				var startCalled int
+				var findCalled int
+				var capOwnerID string
+				var capID uuid.UUID
+				var associateCount int
+				var storedID uuid.UUID
+				var storedResourceName resource.Name
+
+				sess1 := session.New(context.Background(), "ownerID", 5*time.Second, func(id uuid.UUID, resourceName resource.Name) {
+					capMu.Lock()
+					associateCount++
+					storedID = id
+					storedResourceName = resourceName
+					capMu.Unlock()
+				})
+				nextCtx := session.ToContext(ctx, sess1)
+
+				sessMgr.mu.Lock()
+				sessMgr.StartFunc = func(ctx context.Context, ownerID string) (*session.Session, error) {
+					capMu.Lock()
+					startCalled++
+					capOwnerID = ownerID
+					capMu.Unlock()
+					return sess1, nil
+				}
+				sessMgr.FindByIDFunc = func(ctx context.Context, id uuid.UUID, ownerID string) (*session.Session, error) {
+					if id != sess1.ID() {
+						return nil, errors.New("session id mismatch")
+					}
+					capMu.Lock()
+					findCalled++
+					capID = id
+					capOwnerID = ownerID
+					capMu.Unlock()
+					sess1.Heartbeat(ctx) // gotta keep session alive
+					return sess1, nil
+				}
+				sessMgr.mu.Unlock()
+
+				resp, err := roboClient.Status(nextCtx, []resource.Name{})
+				test.That(t, err, test.ShouldBeNil)
+				test.That(t, len(resp), test.ShouldEqual, 0)
+
+				if tc.sessionsDisabled {
+					// wait for any kind of heartbeat
+					time.Sleep(2 * time.Second)
+
+					capMu.Lock()
+					test.That(t, startCalled, test.ShouldEqual, 0)
+					test.That(t, findCalled, test.ShouldEqual, 0)
+					capMu.Unlock()
+				} else {
+					capMu.Lock()
+					test.That(t, startCalled, test.ShouldEqual, 1)
+					test.That(t, findCalled, test.ShouldEqual, 0)
+
+					if tc.webrtcDisabled {
+						test.That(t, capOwnerID, test.ShouldEqual, "")
+					} else {
+						test.That(t, capOwnerID, test.ShouldNotEqual, "")
+					}
+					capMu.Unlock()
+
+					startAt := time.Now()
+					testutils.WaitForAssertionWithSleep(t, time.Second, 10, func(tb testing.TB) {
+						tb.Helper()
+
+						capMu.Lock()
+						defer capMu.Unlock()
+						test.That(tb, findCalled, test.ShouldBeGreaterThanOrEqualTo, 5)
+						test.That(tb, capID, test.ShouldEqual, sess1.ID())
+
+						if tc.webrtcDisabled {
+							test.That(tb, capOwnerID, test.ShouldEqual, "")
+						} else {
+							test.That(tb, capOwnerID, test.ShouldNotEqual, "")
+						}
+					})
+					// testing against time but fairly generous range
+					test.That(t, time.Since(startAt), test.ShouldBeBetween, 4*time.Second, 7*time.Second)
+				}
+
+				capMu.Lock()
+				if tc.withRemoteName {
+					test.That(t, associateCount, test.ShouldEqual, 1)
+					test.That(t, storedID, test.ShouldEqual, sess1.ID())
+					test.That(t, storedResourceName, test.ShouldResemble, someTargetName1.PrependRemote("rem1"))
+				} else {
+					test.That(t, associateCount, test.ShouldEqual, 0)
+				}
+				capMu.Unlock()
+
+				echoRes, err := roboClient.ResourceByName(arbName)
+				test.That(t, err, test.ShouldBeNil)
+				echoClient := echoRes.(*dummyClient).client
+
+				echoMultiClient, err := echoClient.EchoResourceMultiple(nextCtx, &echopb.EchoResourceMultipleRequest{
+					Name:    arbName.Name,
+					Message: "doesnotmatter",
+				})
+				test.That(t, err, test.ShouldBeNil)
+				_, err = echoMultiClient.Recv() // EOF; okay
+				test.That(t, err, test.ShouldBeError, io.EOF)
+
+				err = roboClient.Close(context.Background())
+				test.That(t, err, test.ShouldBeNil)
+
+				capMu.Lock()
+				if tc.withRemoteName {
+					test.That(t, associateCount, test.ShouldEqual, 2)
+					test.That(t, storedID, test.ShouldEqual, sess1.ID())
+					test.That(t, storedResourceName, test.ShouldResemble, someTargetName2.PrependRemote("rem1"))
+				} else {
+					test.That(t, associateCount, test.ShouldEqual, 0)
+				}
+				capMu.Unlock()
+
+				test.That(t, svc.Close(ctx), test.ShouldBeNil)
+			})
 	}
 }
 

--- a/robot/client/client_session_test.go
+++ b/robot/client/client_session_test.go
@@ -25,6 +25,7 @@ import (
 	"go.viam.com/rdk/robot/client"
 	"go.viam.com/rdk/robot/web"
 	"go.viam.com/rdk/session"
+	rdktestutils "go.viam.com/rdk/testutils"
 	"go.viam.com/rdk/testutils/inject"
 	"go.viam.com/rdk/testutils/robottestutils"
 )
@@ -101,8 +102,12 @@ func TestClientSessionOptions(t *testing.T) {
 
 						sessMgr := &sessionManager{}
 						arbName := resource.NewName(echoAPI, "woo")
+						injectResources := []resource.Name{arbName}
 						injectRobot := &inject.Robot{
-							ResourceNamesFunc: func() []resource.Name { return []resource.Name{arbName} },
+							ResourceNamesFunc: func() []resource.Name { return injectResources },
+							MachineStatusFunc: func(ctx context.Context) (robot.MachineStatus, error) {
+								return rdktestutils.ResourcesToMachineStatus(injectResources), nil
+							},
 							ResourceByNameFunc: func(name resource.Name) (resource.Resource, error) {
 								return &dummyEcho{Named: arbName.AsNamed()}, nil
 							},
@@ -284,8 +289,12 @@ func TestClientSessionExpiration(t *testing.T) {
 				arbName := resource.NewName(echoAPI, "woo")
 
 				var dummyEcho1 dummyEcho
+				injectResources := []resource.Name{arbName}
 				injectRobot := &inject.Robot{
-					ResourceNamesFunc: func() []resource.Name { return []resource.Name{arbName} },
+					ResourceNamesFunc: func() []resource.Name { return injectResources },
+					MachineStatusFunc: func(ctx context.Context) (robot.MachineStatus, error) {
+						return rdktestutils.ResourcesToMachineStatus(injectResources), nil
+					},
 					ResourceByNameFunc: func(name resource.Name) (resource.Resource, error) {
 						return &dummyEcho1, nil
 					},
@@ -478,7 +487,10 @@ func TestClientSessionResume(t *testing.T) {
 
 				sessMgr := &sessionManager{}
 				injectRobot := &inject.Robot{
-					ResourceNamesFunc:   func() []resource.Name { return []resource.Name{} },
+					ResourceNamesFunc: func() []resource.Name { return []resource.Name{} },
+					MachineStatusFunc: func(ctx context.Context) (robot.MachineStatus, error) {
+						return robot.MachineStatus{}, nil
+					},
 					ResourceRPCAPIsFunc: func() []resource.RPCAPI { return nil },
 					LoggerFunc:          func() logging.Logger { return logger },
 					SessMgr:             sessMgr,

--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -171,19 +171,6 @@ func toMachineStatusFunc(
 	}
 }
 
-// func machineStatusFunc1(*pb.GetMachineStatusRequest) (*pb.GetMachineStatusResponse, error) {
-// 	resp, err := resourceFunc1(&pb.ResourceNamesRequest{})
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	statuses := make([]*pb.ResourceStatus, 0, len(resp.Resources))
-// 	for _, name := range resp.Resources {
-// 		s := &pb.ResourceStatus{Name: name, State: pb.ResourceStatus_STATE_READY}
-// 		statuses = append(statuses, s)
-// 	}
-// 	return &pb.GetMachineStatusResponse{Resources: statuses}, nil
-// }
-
 var resourceFunc2 = func(*pb.ResourceNamesRequest) (*pb.ResourceNamesResponse, error) {
 	board1 := board.Named("board1")
 	board2 := board.Named("board2")
@@ -2397,4 +2384,3 @@ func TestVersion(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, md, test.ShouldResemble, version)
 }
-

--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -2356,7 +2356,9 @@ func TestMachineStatus(t *testing.T) {
 
 			const badStateMsg = "received resource in an unspecified state"
 			badStateCount := logs.FilterLevelExact(zapcore.ErrorLevel).FilterMessageSnippet(badStateMsg).Len()
-			test.That(t, badStateCount, test.ShouldEqual, tc.expBadStateCount)
+			// MachineStatus is also used for loading resources in a robot client, so every resource-specific error log will appear twice.
+			dedupedBadStateCount := badStateCount / 2
+			test.That(t, dedupedBadStateCount, test.ShouldEqual, tc.expBadStateCount)
 		})
 	}
 }
@@ -2395,3 +2397,4 @@ func TestVersion(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, md, test.ShouldResemble, version)
 }
+

--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -1335,9 +1335,9 @@ func TestClientResources(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	// no reflection
-	resources, rpcAPIs, err := client.resources(context.Background())
+	mStatus, rpcAPIs, err := client.machineStatusAndRPCAPIs(context.Background())
 	test.That(t, err, test.ShouldBeNil)
-	names := testutils.ResourceStatusesToNames(resources)
+	names := testutils.ResourceStatusesToNames(mStatus.Resources)
 	test.That(t, names, test.ShouldResemble, finalResources)
 	test.That(t, rpcAPIs, test.ShouldBeEmpty)
 
@@ -1358,9 +1358,9 @@ func TestClientResources(t *testing.T) {
 	client, err = New(context.Background(), listener.Addr().String(), logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	resources, rpcAPIs, err = client.resources(context.Background())
+	mStatus, rpcAPIs, err = client.machineStatusAndRPCAPIs(context.Background())
 	test.That(t, err, test.ShouldBeNil)
-	names = testutils.ResourceStatusesToNames(resources)
+	names = testutils.ResourceStatusesToNames(mStatus.Resources)
 	test.That(t, names, test.ShouldResemble, finalResources)
 
 	test.That(t, rpcAPIs, test.ShouldHaveLength, len(respWith))

--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -101,7 +101,8 @@ var pose1 = spatialmath.NewZeroPose()
 
 type mockRPCSubtypesUnimplemented struct {
 	pb.UnimplementedRobotServiceServer
-	ResourceNamesFunc func(*pb.ResourceNamesRequest) (*pb.ResourceNamesResponse, error)
+	ResourceNamesFunc    func(*pb.ResourceNamesRequest) (*pb.ResourceNamesResponse, error)
+	GetMachineStatusFunc func(*pb.GetMachineStatusRequest) (*pb.GetMachineStatusResponse, error)
 }
 
 func (ms *mockRPCSubtypesUnimplemented) ResourceNames(
@@ -110,9 +111,16 @@ func (ms *mockRPCSubtypesUnimplemented) ResourceNames(
 	return ms.ResourceNamesFunc(req)
 }
 
+func (ms *mockRPCSubtypesUnimplemented) GetMachineStatus(
+	ctx context.Context, req *pb.GetMachineStatusRequest,
+) (*pb.GetMachineStatusResponse, error) {
+	return ms.GetMachineStatusFunc(req)
+}
+
 type mockRPCSubtypesImplemented struct {
 	mockRPCSubtypesUnimplemented
-	ResourceNamesFunc func(*pb.ResourceNamesRequest) (*pb.ResourceNamesResponse, error)
+	ResourceNamesFunc    func(*pb.ResourceNamesRequest) (*pb.ResourceNamesResponse, error)
+	GetMachineStatusFunc func(*pb.GetMachineStatusRequest) (*pb.GetMachineStatusResponse, error)
 }
 
 func (ms *mockRPCSubtypesImplemented) ResourceRPCSubtypes(
@@ -127,6 +135,12 @@ func (ms *mockRPCSubtypesImplemented) ResourceNames(
 	return ms.ResourceNamesFunc(req)
 }
 
+func (ms *mockRPCSubtypesImplemented) GetMachineStatus(
+	ctx context.Context, req *pb.GetMachineStatusRequest,
+) (*pb.GetMachineStatusResponse, error) {
+	return ms.GetMachineStatusFunc(req)
+}
+
 var resourceFunc1 = func(*pb.ResourceNamesRequest) (*pb.ResourceNamesResponse, error) {
 	board1 := board.Named("board1")
 	rNames := []*commonpb.ResourceName{
@@ -139,6 +153,36 @@ var resourceFunc1 = func(*pb.ResourceNamesRequest) (*pb.ResourceNamesResponse, e
 	}
 	return &pb.ResourceNamesResponse{Resources: rNames}, nil
 }
+
+func toMachineStatusFunc(
+	f func(*pb.ResourceNamesRequest) (*pb.ResourceNamesResponse, error),
+) func(*pb.GetMachineStatusRequest) (*pb.GetMachineStatusResponse, error) {
+	return func(*pb.GetMachineStatusRequest) (*pb.GetMachineStatusResponse, error) {
+		resp, err := f(&pb.ResourceNamesRequest{})
+		if err != nil {
+			return nil, err
+		}
+		statuses := make([]*pb.ResourceStatus, 0, len(resp.Resources))
+		for _, name := range resp.Resources {
+			s := &pb.ResourceStatus{Name: name, State: pb.ResourceStatus_STATE_READY}
+			statuses = append(statuses, s)
+		}
+		return &pb.GetMachineStatusResponse{Resources: statuses}, nil
+	}
+}
+
+// func machineStatusFunc1(*pb.GetMachineStatusRequest) (*pb.GetMachineStatusResponse, error) {
+// 	resp, err := resourceFunc1(&pb.ResourceNamesRequest{})
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	statuses := make([]*pb.ResourceStatus, 0, len(resp.Resources))
+// 	for _, name := range resp.Resources {
+// 		s := &pb.ResourceStatus{Name: name, State: pb.ResourceStatus_STATE_READY}
+// 		statuses = append(statuses, s)
+// 	}
+// 	return &pb.GetMachineStatusResponse{Resources: statuses}, nil
+// }
 
 var resourceFunc2 = func(*pb.ResourceNamesRequest) (*pb.ResourceNamesResponse, error) {
 	board1 := board.Named("board1")
@@ -211,11 +255,13 @@ func TestUnimplementedRPCSubtypes(t *testing.T) {
 	}()
 
 	implementedService := mockRPCSubtypesImplemented{
-		ResourceNamesFunc: resourceFunc1,
+		ResourceNamesFunc:    resourceFunc1,
+		GetMachineStatusFunc: toMachineStatusFunc(resourceFunc1),
 	}
 
 	unimplementedService := mockRPCSubtypesUnimplemented{
-		ResourceNamesFunc: resourceFunc1,
+		ResourceNamesFunc:    resourceFunc1,
+		GetMachineStatusFunc: toMachineStatusFunc(resourceFunc1),
 	}
 
 	err = rpcServer1.RegisterServiceServer(
@@ -271,6 +317,7 @@ func TestUnimplementedRPCSubtypes(t *testing.T) {
 
 	// still unimplemented, but with two resources
 	unimplementedService.ResourceNamesFunc = resourceFunc2
+	unimplementedService.GetMachineStatusFunc = toMachineStatusFunc(resourceFunc2)
 	err = client2.Refresh(ctx2)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -301,6 +348,9 @@ func TestStatusClient(t *testing.T) {
 			servo.Named("servo1"),
 		}
 	}
+	machineStatusFunc := func(ctx context.Context) (robot.MachineStatus, error) {
+		return testutils.ResourcesToMachineStatus(resourcesFunc()), nil
+	}
 
 	// TODO(RSDK-882): will update this so that this is not necessary
 	frameSystemConfigFunc := func(ctx context.Context) (*framesystem.Config, error) {
@@ -311,11 +361,13 @@ func TestStatusClient(t *testing.T) {
 		FrameSystemConfigFunc: frameSystemConfigFunc,
 		ResourceNamesFunc:     resourcesFunc,
 		ResourceRPCAPIsFunc:   func() []resource.RPCAPI { return nil },
+		MachineStatusFunc:     machineStatusFunc,
 	}
 	injectRobot2 := &inject.Robot{
 		FrameSystemConfigFunc: frameSystemConfigFunc,
 		ResourceNamesFunc:     resourcesFunc,
 		ResourceRPCAPIsFunc:   func() []resource.RPCAPI { return nil },
+		MachineStatusFunc:     machineStatusFunc,
 	}
 	pb.RegisterRobotServiceServer(gServer1, server.New(injectRobot1))
 	pb.RegisterRobotServiceServer(gServer2, server.New(injectRobot2))
@@ -679,6 +731,12 @@ func TestClientRefresh(t *testing.T) {
 			callCountNames++
 			return emptyResources
 		}
+		injectRobot.MachineStatusFunc = func(ctx context.Context) (robot.MachineStatus, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			callCountNames++
+			return testutils.ResourcesToMachineStatus(emptyResources), nil
+		}
 		mu.Unlock()
 
 		start := time.Now()
@@ -722,6 +780,12 @@ func TestClientRefresh(t *testing.T) {
 			callCountNames++
 			return emptyResources
 		}
+		injectRobot.MachineStatusFunc = func(ctx context.Context) (robot.MachineStatus, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			callCountNames++
+			return testutils.ResourcesToMachineStatus(emptyResources), nil
+		}
 		mu.Unlock()
 
 		start := time.Now()
@@ -748,6 +812,9 @@ func TestClientRefresh(t *testing.T) {
 		mu.Lock()
 		injectRobot.ResourceRPCAPIsFunc = func() []resource.RPCAPI { return nil }
 		injectRobot.ResourceNamesFunc = func() []resource.Name { return finalResources }
+		injectRobot.MachineStatusFunc = func(ctx context.Context) (robot.MachineStatus, error) {
+			return testutils.ResourcesToMachineStatus(finalResources), nil
+		}
 		mu.Unlock()
 		client, _ := New(
 			context.Background(),
@@ -769,6 +836,9 @@ func TestClientRefresh(t *testing.T) {
 		mu.Lock()
 		injectRobot.ResourceRPCAPIsFunc = func() []resource.RPCAPI { return nil }
 		injectRobot.ResourceNamesFunc = func() []resource.Name { return emptyResources }
+		injectRobot.MachineStatusFunc = func(ctx context.Context) (robot.MachineStatus, error) {
+			return testutils.ResourcesToMachineStatus(emptyResources), nil
+		}
 		mu.Unlock()
 		client, err := New(
 			context.Background(),
@@ -789,6 +859,9 @@ func TestClientRefresh(t *testing.T) {
 		mu.Lock()
 		injectRobot.ResourceRPCAPIsFunc = func() []resource.RPCAPI { return nil }
 		injectRobot.ResourceNamesFunc = func() []resource.Name { return finalResources }
+		injectRobot.MachineStatusFunc = func(ctx context.Context) (robot.MachineStatus, error) {
+			return testutils.ResourcesToMachineStatus(finalResources), nil
+		}
 		mu.Unlock()
 		test.That(t, client.Refresh(context.Background()), test.ShouldBeNil)
 
@@ -813,10 +886,13 @@ func TestClientDisconnect(t *testing.T) {
 	injectRobot := &inject.Robot{}
 	pb.RegisterRobotServiceServer(gServer, server.New(injectRobot))
 	injectRobot.ResourceRPCAPIsFunc = func() []resource.RPCAPI { return nil }
+
 	injectRobot.ResourceNamesFunc = func() []resource.Name {
 		return []resource.Name{arm.Named("arm1")}
 	}
-
+	injectRobot.MachineStatusFunc = func(ctx context.Context) (robot.MachineStatus, error) {
+		return testutils.ResourcesToMachineStatus([]resource.Name{arm.Named("arm1")}), nil
+	}
 	// TODO(RSDK-882): will update this so that this is not necessary
 	injectRobot.FrameSystemConfigFunc = func(ctx context.Context) (*framesystem.Config, error) {
 		return &framesystem.Config{}, nil
@@ -956,6 +1032,9 @@ func TestClientStreamDisconnectHandler(t *testing.T) {
 	injectRobot := &inject.Robot{}
 	injectRobot.ResourceRPCAPIsFunc = func() []resource.RPCAPI { return nil }
 	injectRobot.ResourceNamesFunc = func() []resource.Name { return nil }
+	injectRobot.MachineStatusFunc = func(ctx context.Context) (robot.MachineStatus, error) {
+		return robot.MachineStatus{}, nil
+	}
 	injectRobot.StatusFunc = func(ctx context.Context, rs []resource.Name) ([]robot.Status, error) {
 		return []robot.Status{}, nil
 	}
@@ -1050,6 +1129,11 @@ func TestClientReconnect(t *testing.T) {
 	thing1Name := resource.NewName(someAPI, "thing1")
 	injectRobot.ResourceNamesFunc = func() []resource.Name {
 		return []resource.Name{arm.Named("arm1"), thing1Name}
+	}
+	injectRobot.MachineStatusFunc = func(ctx context.Context) (robot.MachineStatus, error) {
+		return testutils.ResourcesToMachineStatus(
+			[]resource.Name{arm.Named("arm1"), thing1Name},
+		), nil
 	}
 
 	// TODO(RSDK-882): will update this so that this is not necessary
@@ -1163,6 +1247,17 @@ func TestClientRefreshNoReconfigure(t *testing.T) {
 
 		return []resource.Name{arm.Named("arm1"), thing1Name}
 	}
+	injectRobot.MachineStatusFunc = func(ctx context.Context) (robot.MachineStatus, error) {
+		if callCount == 1 {
+			<-allow
+		}
+		if callCount == 5 {
+			close(calledEnough)
+		}
+		callCount++
+
+		return testutils.ResourcesToMachineStatus([]resource.Name{arm.Named("arm1"), thing1Name}), nil
+	}
 
 	go gServer.Serve(listener)
 	defer gServer.Stop()
@@ -1237,6 +1332,9 @@ func TestClientResources(t *testing.T) {
 
 	injectRobot.ResourceRPCAPIsFunc = func() []resource.RPCAPI { return respWith }
 	injectRobot.ResourceNamesFunc = func() []resource.Name { return finalResources }
+	injectRobot.MachineStatusFunc = func(ctx context.Context) (robot.MachineStatus, error) {
+		return testutils.ResourcesToMachineStatus(finalResources), nil
+	}
 
 	gServer := grpc.NewServer()
 	pb.RegisterRobotServiceServer(gServer, server.New(injectRobot))
@@ -1292,6 +1390,9 @@ func TestClientDiscovery(t *testing.T) {
 	injectRobot.ResourceRPCAPIsFunc = func() []resource.RPCAPI { return nil }
 	injectRobot.ResourceNamesFunc = func() []resource.Name {
 		return finalResources
+	}
+	injectRobot.MachineStatusFunc = func(ctx context.Context) (robot.MachineStatus, error) {
+		return testutils.ResourcesToMachineStatus(finalResources), nil
 	}
 	q := resource.DiscoveryQuery{movementsensor.Named("foo").API, resource.DefaultModelFamily.WithModel("something")}
 	injectRobot.DiscoverComponentsFunc = func(ctx context.Context, keys []resource.DiscoveryQuery) ([]resource.Discovery, error) {
@@ -1362,12 +1463,17 @@ func TestClientConfig(t *testing.T) {
 	failingServer := grpc.NewServer()
 
 	resourcesFunc := func() []resource.Name { return []resource.Name{} }
+	machineStatusFunc := func(ctx context.Context) (robot.MachineStatus, error) {
+		return testutils.ResourcesToMachineStatus([]resource.Name{}), nil
+	}
 	workingRobot := &inject.Robot{
 		ResourceNamesFunc:   resourcesFunc,
+		MachineStatusFunc:   machineStatusFunc,
 		ResourceRPCAPIsFunc: func() []resource.RPCAPI { return nil },
 	}
 	failingRobot := &inject.Robot{
 		ResourceNamesFunc:   resourcesFunc,
+		MachineStatusFunc:   machineStatusFunc,
 		ResourceRPCAPIsFunc: func() []resource.RPCAPI { return nil },
 	}
 
@@ -1492,11 +1598,17 @@ func TestClientStatus(t *testing.T) {
 	gServer2 := grpc.NewServer()
 
 	injectRobot := &inject.Robot{
-		ResourceNamesFunc:   func() []resource.Name { return []resource.Name{} },
+		ResourceNamesFunc: func() []resource.Name { return []resource.Name{} },
+		MachineStatusFunc: func(ctx context.Context) (robot.MachineStatus, error) {
+			return robot.MachineStatus{}, nil
+		},
 		ResourceRPCAPIsFunc: func() []resource.RPCAPI { return nil },
 	}
 	injectRobot2 := &inject.Robot{
-		ResourceNamesFunc:   func() []resource.Name { return []resource.Name{} },
+		ResourceNamesFunc: func() []resource.Name { return []resource.Name{} },
+		MachineStatusFunc: func(ctx context.Context) (robot.MachineStatus, error) {
+			return robot.MachineStatus{}, nil
+		},
 		ResourceRPCAPIsFunc: func() []resource.RPCAPI { return nil },
 	}
 	pb.RegisterRobotServiceServer(gServer, server.New(injectRobot))
@@ -1630,6 +1742,9 @@ func TestForeignResource(t *testing.T) {
 
 	injectRobot.ResourceRPCAPIsFunc = func() []resource.RPCAPI { return respWith }
 	injectRobot.ResourceNamesFunc = func() []resource.Name { return respWithResources }
+	injectRobot.MachineStatusFunc = func(ctx context.Context) (robot.MachineStatus, error) {
+		return testutils.ResourcesToMachineStatus(respWithResources), nil
+	}
 	// TODO(RSDK-882): will update this so that this is not necessary
 	injectRobot.FrameSystemConfigFunc = func(ctx context.Context) (*framesystem.Config, error) {
 		return &framesystem.Config{}, nil
@@ -1679,7 +1794,10 @@ func TestNewRobotClientRefresh(t *testing.T) {
 		callCount++
 		return emptyResources
 	}
-
+	injectRobot.MachineStatusFunc = func(ctx context.Context) (robot.MachineStatus, error) {
+		callCount++
+		return testutils.ResourcesToMachineStatus(emptyResources), nil
+	}
 	pb.RegisterRobotServiceServer(gServer, server.New(injectRobot))
 
 	go gServer.Serve(listener)
@@ -1730,7 +1848,10 @@ func TestClientStopAll(t *testing.T) {
 	resourcesFunc := func() []resource.Name { return []resource.Name{} }
 	stopAllCalled := false
 	injectRobot1 := &inject.Robot{
-		ResourceNamesFunc:   resourcesFunc,
+		ResourceNamesFunc: resourcesFunc,
+		MachineStatusFunc: func(ctx context.Context) (robot.MachineStatus, error) {
+			return testutils.ResourcesToMachineStatus(resourcesFunc()), nil
+		},
 		ResourceRPCAPIsFunc: func() []resource.RPCAPI { return nil },
 		StopAllFunc: func(ctx context.Context, extra map[resource.Name]map[string]interface{}) error {
 			stopAllCalled = true
@@ -1760,7 +1881,10 @@ func TestRemoteClientMatch(t *testing.T) {
 	gServer1 := grpc.NewServer()
 	validResources := []resource.Name{arm.Named("remote:arm1")}
 	injectRobot1 := &inject.Robot{
-		ResourceNamesFunc:   func() []resource.Name { return validResources },
+		ResourceNamesFunc: func() []resource.Name { return validResources },
+		MachineStatusFunc: func(ctx context.Context) (robot.MachineStatus, error) {
+			return testutils.ResourcesToMachineStatus(validResources), nil
+		},
 		ResourceRPCAPIsFunc: func() []resource.RPCAPI { return nil },
 	}
 
@@ -1810,7 +1934,10 @@ func TestRemoteClientDuplicate(t *testing.T) {
 	gServer1 := grpc.NewServer()
 	validResources := []resource.Name{arm.Named("remote1:arm1"), arm.Named("remote2:arm1")}
 	injectRobot1 := &inject.Robot{
-		ResourceNamesFunc:   func() []resource.Name { return validResources },
+		ResourceNamesFunc: func() []resource.Name { return validResources },
+		MachineStatusFunc: func(ctx context.Context) (robot.MachineStatus, error) {
+			return testutils.ResourcesToMachineStatus(validResources), nil
+		},
 		ResourceRPCAPIsFunc: func() []resource.RPCAPI { return nil },
 	}
 	pb.RegisterRobotServiceServer(gServer1, server.New(injectRobot1))
@@ -1853,7 +1980,10 @@ func TestClientOperationIntercept(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	injectRobot := &inject.Robot{
-		ResourceNamesFunc:   func() []resource.Name { return []resource.Name{} },
+		ResourceNamesFunc: func() []resource.Name { return []resource.Name{} },
+		MachineStatusFunc: func(ctx context.Context) (robot.MachineStatus, error) {
+			return testutils.ResourcesToMachineStatus([]resource.Name{}), nil
+		},
 		ResourceRPCAPIsFunc: func() []resource.RPCAPI { return nil },
 	}
 
@@ -1896,8 +2026,12 @@ func TestGetUnknownResource(t *testing.T) {
 	listener1, err := net.Listen("tcp", "localhost:0")
 	test.That(t, err, test.ShouldBeNil)
 
+	injectResources := []resource.Name{arm.Named("myArm")}
 	injectRobot := &inject.Robot{
-		ResourceNamesFunc:   func() []resource.Name { return []resource.Name{arm.Named("myArm")} },
+		ResourceNamesFunc: func() []resource.Name { return injectResources },
+		MachineStatusFunc: func(ctx context.Context) (robot.MachineStatus, error) {
+			return testutils.ResourcesToMachineStatus(injectResources), nil
+		},
 		ResourceRPCAPIsFunc: func() []resource.RPCAPI { return nil },
 	}
 
@@ -1935,9 +2069,13 @@ func TestLoggingInterceptor(t *testing.T) {
 	// A server with the logging interceptor looks for some values in the grpc request metadata and
 	// will call unary functions with a modified context.
 	gServer := grpc.NewServer(grpc.ChainUnaryInterceptor(logging.UnaryServerInterceptor))
+	injectResources := []resource.Name{arm.Named("myArm")}
 	injectRobot := &inject.Robot{
 		// Needed for client connect. Not important to the test.
-		ResourceNamesFunc:   func() []resource.Name { return []resource.Name{arm.Named("myArm")} },
+		ResourceNamesFunc: func() []resource.Name { return injectResources },
+		MachineStatusFunc: func(ctx context.Context) (robot.MachineStatus, error) {
+			return testutils.ResourcesToMachineStatus(injectResources), nil
+		},
 		ResourceRPCAPIsFunc: func() []resource.RPCAPI { return nil },
 
 		// Hijack the `StatusFunc` for testing the reception of debug metadata via the
@@ -1998,7 +2136,10 @@ func TestCloudMetadata(t *testing.T) {
 		MachinePartID: "the-robot-part",
 	}
 	injectRobot := &inject.Robot{
-		ResourceNamesFunc:   func() []resource.Name { return nil },
+		ResourceNamesFunc: func() []resource.Name { return nil },
+		MachineStatusFunc: func(ctx context.Context) (robot.MachineStatus, error) {
+			return robot.MachineStatus{}, nil
+		},
 		ResourceRPCAPIsFunc: func() []resource.RPCAPI { return nil },
 		CloudMetadataFunc: func(ctx context.Context) (cloud.Metadata, error) {
 			return injectCloudMD, nil
@@ -2031,7 +2172,10 @@ func TestShutDown(t *testing.T) {
 
 	shutdownCalled := false
 	injectRobot := &inject.Robot{
-		ResourceNamesFunc:   func() []resource.Name { return nil },
+		ResourceNamesFunc: func() []resource.Name { return nil },
+		MachineStatusFunc: func(ctx context.Context) (robot.MachineStatus, error) {
+			return robot.MachineStatus{}, nil
+		},
 		ResourceRPCAPIsFunc: func() []resource.RPCAPI { return nil },
 		ShutdownFunc: func(ctx context.Context) error {
 			shutdownCalled = true
@@ -2071,7 +2215,10 @@ func TestUnregisteredResourceByName(t *testing.T) {
 		testName2,
 	}
 	injectRobot := &inject.Robot{
-		ResourceNamesFunc:   func() []resource.Name { return resourceList },
+		ResourceNamesFunc: func() []resource.Name { return resourceList },
+		MachineStatusFunc: func(ctx context.Context) (robot.MachineStatus, error) {
+			return testutils.ResourcesToMachineStatus(resourceList), nil
+		},
 		ResourceRPCAPIsFunc: func() []resource.RPCAPI { return nil },
 	}
 
@@ -2221,7 +2368,10 @@ func TestVersion(t *testing.T) {
 	gServer := grpc.NewServer()
 
 	injectRobot := &inject.Robot{
-		ResourceNamesFunc:   func() []resource.Name { return nil },
+		ResourceNamesFunc: func() []resource.Name { return nil },
+		MachineStatusFunc: func(ctx context.Context) (robot.MachineStatus, error) {
+			return robot.MachineStatus{}, nil
+		},
 		ResourceRPCAPIsFunc: func() []resource.RPCAPI { return nil },
 	}
 

--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -1337,7 +1337,8 @@ func TestClientResources(t *testing.T) {
 	// no reflection
 	resources, rpcAPIs, err := client.resources(context.Background())
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, resources, test.ShouldResemble, finalResources)
+	names := testutils.ResourceStatusesToNames(resources)
+	test.That(t, names, test.ShouldResemble, finalResources)
 	test.That(t, rpcAPIs, test.ShouldBeEmpty)
 
 	err = client.Close(context.Background())
@@ -1359,7 +1360,8 @@ func TestClientResources(t *testing.T) {
 
 	resources, rpcAPIs, err = client.resources(context.Background())
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, resources, test.ShouldResemble, finalResources)
+	names = testutils.ResourceStatusesToNames(resources)
+	test.That(t, names, test.ShouldResemble, finalResources)
 
 	test.That(t, rpcAPIs, test.ShouldHaveLength, len(respWith))
 	for idx, rpcType := range rpcAPIs {

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -708,14 +708,26 @@ func (r *localRobot) newResource(
 			}
 		}
 	}
-
-	if resInfo.Constructor != nil {
-		return resInfo.Constructor(ctx, deps, conf, gNode.Logger())
-	}
-	if resInfo.DeprecatedRobotConstructor == nil {
+	switch {
+	case resInfo.Constructor != nil:
+		res, err = resInfo.Constructor(ctx, deps, conf, gNode.Logger())
+	case resInfo.DeprecatedRobotConstructor != nil:
+		res, err = resInfo.DeprecatedRobotConstructor(ctx, r, conf, gNode.Logger())
+	default:
 		return nil, errors.Errorf("invariant: no constructor for %q", conf.API)
 	}
-	return resInfo.DeprecatedRobotConstructor(ctx, r, conf, gNode.Logger())
+	if err != nil {
+		return nil, err
+	}
+
+	// If context has errored, even if construction succeeded we should close the resource and return the context error.
+	// Use closeContext because otherwise any Close operations that rely on the context will immediately fail.
+	// The deadline associated with the context passed in to this function is utils.GetResourceConfigurationTimeout.
+	if ctx.Err() != nil {
+		r.logger.CDebugw(ctx, "resource successfully constructed but context is done, closing constructed resource")
+		return nil, multierr.Combine(ctx.Err(), res.Close(r.closeContext))
+	}
+	return res, nil
 }
 
 func (r *localRobot) updateWeakDependents(ctx context.Context) {
@@ -1178,14 +1190,26 @@ func (r *localRobot) reconfigure(ctx context.Context, newConfig *config.Config, 
 	// if anything has changed.
 	err := r.packageManager.Sync(ctx, newConfig.Packages, newConfig.Modules)
 	if err != nil {
-		allErrs = multierr.Combine(allErrs, err)
+		r.Logger().CErrorw(ctx, "reconfiguration aborted because cloud modules or packages download failed", "error", err)
+		return
 	}
 	// For local tarball modules, we create synthetic versions for package management. The `localRobot` keeps track of these because
 	// config reader would overwrite if we just stored it in config. Here, we copy the synthetic version from the `localRobot` into the
 	// appropriate `config.Module` object inside the `cfg.Modules` slice. Thus, when a local tarball module is reloaded, the viam-server
 	// can unpack it into a fresh directory rather than reusing the previous one.
 	r.applyLocalModuleVersions(newConfig)
-	allErrs = multierr.Combine(allErrs, r.localPackages.Sync(ctx, newConfig.Packages, newConfig.Modules))
+	err = r.localPackages.Sync(ctx, newConfig.Packages, newConfig.Modules)
+	if err != nil {
+		r.Logger().CErrorw(ctx, "reconfiguration aborted because local modules or packages sync failed", "error", err)
+		return
+	}
+
+	if newConfig.Cloud != nil {
+		r.Logger().CDebug(ctx, "updating cached config")
+		if err := newConfig.StoreToCache(); err != nil {
+			r.logger.CErrorw(ctx, "error storing the config", "error", err)
+		}
+	}
 
 	// Add default services and process their dependencies. Dependencies may
 	// already come from config validation so we check that here.

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/golang/geo/r3"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
-
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	armpb "go.viam.com/api/component/arm/v1"

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/golang/geo/r3"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
+
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	armpb "go.viam.com/api/component/arm/v1"

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -1095,11 +1095,11 @@ func TestStatusRemote(t *testing.T) {
 		return robot.MachineStatus{
 			Resources: []resource.Status{
 				{
-					Name: arm.Named("arm1"),
+					Name:  arm.Named("arm1"),
 					State: resource.NodeStateReady,
 				},
 				{
-					Name: arm.Named("arm2"),
+					Name:  arm.Named("arm2"),
 					State: resource.NodeStateReady,
 				},
 			},

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -3427,34 +3427,6 @@ func getExpectedDefaultStatuses(revision string) []resource.Status {
 	return []resource.Status{
 		{
 			Name: resource.Name{
-				API:  resource.APINamespaceRDKInternal.WithServiceType("frame_system"),
-				Name: "builtin",
-			},
-			State: resource.NodeStateReady,
-		},
-		{
-			Name: resource.Name{
-				API:  resource.APINamespaceRDKInternal.WithServiceType("cloud_connection"),
-				Name: "builtin",
-			},
-			State: resource.NodeStateReady,
-		},
-		{
-			Name: resource.Name{
-				API:  resource.APINamespaceRDKInternal.WithServiceType("packagemanager"),
-				Name: "builtin",
-			},
-			State: resource.NodeStateReady,
-		},
-		{
-			Name: resource.Name{
-				API:  resource.APINamespaceRDKInternal.WithServiceType("web"),
-				Name: "builtin",
-			},
-			State: resource.NodeStateReady,
-		},
-		{
-			Name: resource.Name{
 				API:  resource.APINamespaceRDK.WithServiceType("motion"),
 				Name: "builtin",
 			},

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/golang/geo/r3"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
+
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	armpb "go.viam.com/api/component/arm/v1"
@@ -3427,7 +3428,7 @@ func getExpectedDefaultStatuses(revision string) []resource.Status {
 	return []resource.Status{
 		{
 			Name: resource.Name{
-				API:  resource.APINamespaceRDKInternal.WithServiceType("framesystem"),
+				API:  resource.APINamespaceRDKInternal.WithServiceType("frame_system"),
 				Name: "builtin",
 			},
 			State: resource.NodeStateReady,

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -1091,6 +1091,20 @@ func TestStatusRemote(t *testing.T) {
 	gServer1 := grpc.NewServer()
 	gServer2 := grpc.NewServer()
 	resourcesFunc := func() []resource.Name { return []resource.Name{arm.Named("arm1"), arm.Named("arm2")} }
+	machineStatusFunc := func(ctx context.Context) (robot.MachineStatus, error) {
+		return robot.MachineStatus{
+			Resources: []resource.Status{
+				{
+					Name: arm.Named("arm1"),
+					State: resource.NodeStateReady,
+				},
+				{
+					Name: arm.Named("arm2"),
+					State: resource.NodeStateReady,
+				},
+			},
+		}, nil
+	}
 	statusCallCount := 0
 
 	// TODO: RSDK-882 will update this so that this is not necessary
@@ -1110,6 +1124,7 @@ func TestStatusRemote(t *testing.T) {
 	injectRobot1 := &inject.Robot{
 		FrameSystemConfigFunc: frameSystemConfigFunc,
 		ResourceNamesFunc:     resourcesFunc,
+		MachineStatusFunc:     machineStatusFunc,
 		ResourceRPCAPIsFunc:   func() []resource.RPCAPI { return nil },
 	}
 	armStatus := &armpb.Status{
@@ -1135,6 +1150,7 @@ func TestStatusRemote(t *testing.T) {
 	injectRobot2 := &inject.Robot{
 		FrameSystemConfigFunc: frameSystemConfigFunc,
 		ResourceNamesFunc:     resourcesFunc,
+		MachineStatusFunc:     machineStatusFunc,
 		ResourceRPCAPIsFunc:   func() []resource.RPCAPI { return nil },
 	}
 	injectRobot2.StatusFunc = func(ctx context.Context, resourceNames []resource.Name) ([]robot.Status, error) {

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -72,6 +72,7 @@ func newResourceManager(
 	logger logging.Logger,
 ) *resourceManager {
 	resLogger := logger.Sublogger("resource_manager")
+	resLogger.SetLevel(logging.ERROR) // TODO: remove
 	return &resourceManager{
 		resources:      resource.NewGraph(),
 		processManager: newProcessManager(opts, logger),

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -371,13 +371,9 @@ func (manager *resourceManager) ResourceNames() []resource.Name {
 // ResourceStatuses returns the names of all resources in the manager.
 func (manager *resourceManager) ResourceStatuses() []resource.Status {
 	result := []resource.Status{}
-	for _, k := range manager.resources.Names() {
-		if k.API == client.RemoteAPI ||
-			k.API.Type.Namespace == resource.APINamespaceRDKInternal {
-			continue
-		}
-		gNode, ok := manager.resources.Node(k)
-		if !ok || !gNode.HasResource() {
+	for _, name := range manager.resources.Names() {
+		gNode, ok := manager.resources.Node(name)
+		if !ok || gNode.IsUninitialized() {
 			continue
 		}
 		result = append(result, gNode.ResourceStatus())

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -186,8 +186,8 @@ func (manager *resourceManager) updateRemoteResourceNames(
 	activeResourceNames := map[resource.Name]bool{}
 	mStatus, err := rr.MachineStatus(ctx)
 	if errors.Is(err, client.ErrDisconnected) {
-		// nil implies our connection to the remote is currently broken. Return without changing any
-		// state for this remote.
+		// Our connection to the remote is broken, but the remote itself might be working
+		// fine. Return without changing any state in this case.
 		return false
 	}
 	// TODO: handle other kinds of errors?

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -364,7 +364,6 @@ func (manager *resourceManager) ResourceNames() []resource.Name {
 		if !ok || !gNode.HasResource() {
 			continue
 		}
-		fmt.Println(">>> local -> legacy resource", k)
 		names = append(names, k)
 	}
 	return names
@@ -379,7 +378,6 @@ func (manager *resourceManager) ResourceStatuses() []resource.Status {
 			continue
 		}
 		s := gNode.ResourceStatus()
-		fmt.Println(">>> local -> status resource", name, "vs", s.Name)
 		// replace with fully-qualified remote name
 		s.Name = name
 		result = append(result, s)

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -1,4 +1,5 @@
 package robotimpl
+
 import (
 	"context"
 	"crypto/tls"

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -364,6 +364,7 @@ func (manager *resourceManager) ResourceNames() []resource.Name {
 		if !ok || !gNode.HasResource() {
 			continue
 		}
+		fmt.Println(">>> local -> legacy resource", k)
 		names = append(names, k)
 	}
 	return names
@@ -377,7 +378,11 @@ func (manager *resourceManager) ResourceStatuses() []resource.Status {
 		if !ok || gNode.IsUninitialized() {
 			continue
 		}
-		result = append(result, gNode.ResourceStatus())
+		s := gNode.ResourceStatus()
+		fmt.Println(">>> local -> status resource", name, "vs", s.Name)
+		// replace with fully-qualified remote name
+		s.Name = name
+		result = append(result, s)
 	}
 	return result
 }

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -187,10 +187,16 @@ func (manager *resourceManager) updateRemoteResourceNames(
 	activeResourceNames := map[resource.Name]bool{}
 	ms, err := rr.MachineStatus(ctx)
 	if errors.Is(err, client.ErrDisconnected) {
-		// Our connection to the remote is broken, but the remote itself might be working
-		// fine. We mark each node as disconnected but report no changes.
-		for _, rs := range ms.Resources {
-			gNode, ok := manager.resources.Node(rs.Name)
+		// The connection to the remote is broken, but the remote itself might be working
+		// fine. Mark each node as disconnected but report no changes.
+		remoteGraph, err := manager.resources.SubGraphFrom(remoteName)
+		if err != nil {
+			// TODO: handle error?
+			manager.logger.Error(err)
+			return false
+		}
+		for _, name := range remoteGraph.Names() {
+			gNode, ok := manager.resources.Node(name)
 			if !ok {
 				continue
 			}

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -1,5 +1,4 @@
 package robotimpl
-
 import (
 	"context"
 	"crypto/tls"
@@ -367,6 +366,23 @@ func (manager *resourceManager) ResourceNames() []resource.Name {
 		names = append(names, k)
 	}
 	return names
+}
+
+// ResourceStatuses returns the names of all resources in the manager.
+func (manager *resourceManager) ResourceStatuses() []resource.Status {
+	result := []resource.Status{}
+	for _, k := range manager.resources.Names() {
+		if k.API == client.RemoteAPI ||
+			k.API.Type.Namespace == resource.APINamespaceRDKInternal {
+			continue
+		}
+		gNode, ok := manager.resources.Node(k)
+		if !ok || !gNode.HasResource() {
+			continue
+		}
+		result = append(result, gNode.ResourceStatus())
+	}
+	return result
 }
 
 // ResourceRPCAPIs returns the types of all resource RPC APIs in use by the manager.

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -72,7 +72,6 @@ func newResourceManager(
 	logger logging.Logger,
 ) *resourceManager {
 	resLogger := logger.Sublogger("resource_manager")
-	resLogger.SetLevel(logging.ERROR) // TODO: remove
 	return &resourceManager{
 		resources:      resource.NewGraph(),
 		processManager: newProcessManager(opts, logger),

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -398,13 +398,18 @@ func (manager *resourceManager) ResourceNames() []resource.Name {
 func (manager *resourceManager) ResourceStatuses() []resource.Status {
 	result := []resource.Status{}
 	for _, name := range manager.resources.Names() {
-		gNode, ok := manager.resources.Node(name)
-		if !ok || gNode.IsUninitialized() {
+		if name.API == client.RemoteAPI {
 			continue
 		}
 		if name.API.Type.Namespace == resource.APINamespaceRDKInternal {
 			continue
 		}
+
+		gNode, ok := manager.resources.Node(name)
+		if !ok || gNode.IsUninitialized() {
+			continue
+		}
+
 		s := gNode.ResourceStatus()
 		// replace with fully-qualified remote name
 		s.Name = name

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -1967,7 +1967,12 @@ func (rr *dummyRobot) Shutdown(ctx context.Context) error {
 }
 
 func (rr *dummyRobot) MachineStatus(ctx context.Context) (robot.MachineStatus, error) {
-	return rr.robot.MachineStatus(ctx)
+	var ms robot.MachineStatus
+	for _, name := range rr.ResourceNames() {
+		s := resource.Status{Name: name}
+		ms.Resources = append(ms.Resources, s)
+	}
+	return ms, nil
 }
 
 func (rr *dummyRobot) Version(ctx context.Context) (robot.VersionResponse, error) {

--- a/robot/impl/robot_framesystem_test.go
+++ b/robot/impl/robot_framesystem_test.go
@@ -22,7 +22,6 @@ import (
 	"go.viam.com/rdk/services/sensors"
 	_ "go.viam.com/rdk/services/sensors/builtin"
 	"go.viam.com/rdk/spatialmath"
-	rdktestutils "go.viam.com/rdk/testutils"
 	"go.viam.com/rdk/testutils/robottestutils"
 	rutils "go.viam.com/rdk/utils"
 )
@@ -135,15 +134,7 @@ func TestFrameSystemConfigWithRemote(t *testing.T) {
 		gripper.Named("myParentIsRemote"),
 	}
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		ms, err := r2.MachineStatus(ctx)
-		test.That(t, err, test.ShouldBeNil)
-		var ready []resource.Name
-		for _, rs := range ms.Resources {
-			logger.Infow(">>> ms resource",
-				"name", rs.Name, "state", rs.State)
-			ready = append(ready, rs.Name)
-		}
-		rdktestutils.VerifySameResourceNames(tb, ready, finalSet)
+		verifyReadyResourceNames(tb, r2, finalSet)
 	})
 
 	fsCfg, err = r2.FrameSystemConfig(context.Background())

--- a/robot/impl/robot_framesystem_test.go
+++ b/robot/impl/robot_framesystem_test.go
@@ -135,7 +135,15 @@ func TestFrameSystemConfigWithRemote(t *testing.T) {
 		gripper.Named("myParentIsRemote"),
 	}
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		rdktestutils.VerifySameResourceNames(tb, r2.ResourceNames(), finalSet)
+		ms, err := r2.MachineStatus(ctx)
+		test.That(t, err, test.ShouldBeNil)
+		var ready []resource.Name
+		for _, rs := range ms.Resources {
+			logger.Infow(">>> ms resource",
+				"name", rs.Name, "state", rs.State)
+			ready = append(ready, rs.Name)
+		}
+		rdktestutils.VerifySameResourceNames(tb, ready, finalSet)
 	})
 
 	fsCfg, err = r2.FrameSystemConfig(context.Background())

--- a/robot/impl/robot_reconfigure_remote_test.go
+++ b/robot/impl/robot_reconfigure_remote_test.go
@@ -16,7 +16,6 @@ import (
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
-
 	// TODO(RSDK-7884): change everything that depends on this import to a mock.
 	"go.viam.com/rdk/services/motion"
 	// TODO(RSDK-7884): change all referenced resources to mocks.

--- a/robot/impl/robot_reconfigure_remote_test.go
+++ b/robot/impl/robot_reconfigure_remote_test.go
@@ -141,7 +141,7 @@ func TestRemoteRobotsGold(t *testing.T) {
 
 	// wait for local_robot to detect that the remote is now offline
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		rdktestutils.VerifySameResourceNames(tb, r.ResourceNames(),
+		verifyReadyResourceNames(tb, r,
 			[]resource.Name{
 				motion.Named(resource.DefaultServiceName),
 				sensors.Named(resource.DefaultServiceName),
@@ -236,17 +236,12 @@ func TestRemoteRobotsUpdate(t *testing.T) {
 
 	// wait for local_robot to detect that the remote is now offline
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		ms, err := r.MachineStatus(context.Background())
-		test.That(t, err, test.ShouldBeNil)
-		var ready []resource.Name
-		for _, rs := range rdktestutils.FilterByStatus(t, ms.Resources, resource.NodeStateReady) {
-			ready = append(ready, rs.Name)
-		}
-		expected := []resource.Name{
-			motion.Named(resource.DefaultServiceName),
-			sensors.Named(resource.DefaultServiceName),
-		}
-		rdktestutils.VerifySameResourceNames(tb, ready, expected)
+		verifyReadyResourceNames(tb, r,
+			[]resource.Name{
+				motion.Named(resource.DefaultServiceName),
+				sensors.Named(resource.DefaultServiceName),
+			},
+		)
 	})
 }
 
@@ -309,7 +304,7 @@ func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
 
 	// wait for local_robot to detect that the remote is now offline
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		rdktestutils.VerifySameResourceNames(tb, r.ResourceNames(),
+		verifyReadyResourceNames(tb, r,
 			[]resource.Name{
 				motion.Named(resource.DefaultServiceName),
 				sensors.Named(resource.DefaultServiceName),

--- a/robot/impl/robot_reconfigure_remote_test.go
+++ b/robot/impl/robot_reconfigure_remote_test.go
@@ -395,7 +395,7 @@ func TestInferRemoteRobotDependencyConnectAfterStartup(t *testing.T) {
 
 	// wait for local_robot to detect that the remote is now offline
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		rdktestutils.VerifySameResourceNames(tb, r.ResourceNames(),
+		verifyReadyResourceNames(tb, r,
 			[]resource.Name{
 				motion.Named(resource.DefaultServiceName),
 				sensors.Named(resource.DefaultServiceName),

--- a/robot/impl/utils.go
+++ b/robot/impl/utils.go
@@ -8,7 +8,9 @@ import (
 
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot"
+	"go.viam.com/rdk/testutils"
 )
 
 func setupLocalRobot(
@@ -31,4 +33,19 @@ func setupLocalRobot(
 		lRobot.reconfigureWorkers.Wait()
 	})
 	return r
+}
+
+func verifyReadyResourceNames(tb testing.TB, r robot.LocalRobot, expected []resource.Name) {
+	tb.Helper()
+
+	ms, err := r.MachineStatus(context.Background())
+	test.That(tb, err, test.ShouldBeNil)
+
+	var ready []resource.Name
+	for _, rs := range ms.Resources {
+		if rs.State == resource.NodeStateReady {
+			ready = append(ready, rs.Name)
+		}
+	}
+	testutils.VerifySameResourceNames(tb, ready, expected)
 }

--- a/robot/server/server.go
+++ b/robot/server/server.go
@@ -512,6 +512,7 @@ func (s *Server) GetMachineStatus(ctx context.Context, _ *pb.GetMachineStatusReq
 			Revision:    resStatus.Revision,
 		}
 
+		//nolint // TODO add NodeStateDisconnected if agreed to
 		switch resStatus.State {
 		case resource.NodeStateUnknown:
 			s.robot.Logger().CErrorw(ctx, "resource in an unknown state", "resource", resStatus.Name.String())

--- a/testutils/resource_utils.go
+++ b/testutils/resource_utils.go
@@ -12,6 +12,7 @@ import (
 	"go.viam.com/test"
 
 	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/robot"
 )
 
 // NewUnimplementedResource returns a resource that has all methods
@@ -233,4 +234,15 @@ func AddRemotes(values []resource.Name, remotes ...string) []resource.Name {
 		}
 	}
 	return rNames
+}
+
+// ResourcesToMachineStatus converts a slice of [resource.Name] to a [robot.MachineStatus] with the
+// `Resources` field populated with that same resources, all in the [NodeStateReady] state.
+func ResourcesToMachineStatus(names []resource.Name) robot.MachineStatus {
+	ms := robot.MachineStatus{}
+	for _, name := range names {
+		s := resource.Status{Name: name, State: resource.NodeStateReady}
+		ms.Resources = append(ms.Resources, s)
+	}
+	return ms
 }

--- a/testutils/resource_utils.go
+++ b/testutils/resource_utils.go
@@ -246,3 +246,12 @@ func ResourcesToMachineStatus(names []resource.Name) robot.MachineStatus {
 	}
 	return ms
 }
+
+// ResourceStatusesToNames converts a slice of [resource.Status] to a slice of [resource.Name].
+func ResourceStatusesToNames(statuses []resource.Status) []resource.Name {
+	names := make([]resource.Name, 0, len(statuses))
+	for _, rs := range statuses {
+		names = append(names, rs.Name)
+	}
+	return names
+}


### PR DESCRIPTION
:warning: hold off on reviewing for now - the following issue needs to be addressed first 

* [ ] https://github.com/viamrobotics/rdk/pull/4399/files#r1783017466

----

### Summary

Keep remote resources in the `ResourceNames` and `MachineStatus` APIs when their remote gets disconnected. In the latter API, mark such resources with a state indicate that they are disconnected.

### Prerequisites

To make reviews a bit easier, this PR is going to broken out into smaller chunks:

* [ ] https://github.com/viamrobotics/rdk/pull/4399

### Details

Robot clients now fetch and cache resource statuses via the `GetMachineStatus` API instead of resource names via `ResourceNames` API.

### Open questions

* [ ] Should we add a new state for disconnected nodes? (e.g. `NodeStateDisconnected`), or is it sufficient to reuse the unhealthy state with a corresponding error (e.g. `NodeStateUnhealthy[reason:disconnected]`)? 
  * FWIW, I slightly prefer a new state given the proposed implementation, since a healthy but disconnected remote resource can appear as "disconnected" or "ready" depending on whether a client calls `MachineStatus` on the local or remote machine, respectively. Having a specialized state that can only appear for remote resources feels like the less confusing option in this case.
* [ ] Shall we bubble up remote update errors? (see [this comment](https://github.com/viamrobotics/rdk/pull/4273/files#r1773984731) and [this comment](https://github.com/viamrobotics/rdk/pull/4273/files#r1773985885)) - this will make the PR much noisier but might be the correct thing to do.

### Depends on

* [x] Expose unhealthy state + error: https://github.com/viamrobotics/rdk/pull/4257
  * Note that those changes are included in this PR as well - see [this diff](https://github.com/maximpertsov/rdk/compare/RSDK-7903-unhealthy-state...maximpertsov:rdk:RSDK-7903-unhealthy-remotes-replace-names?expand=1) for changes excluding the dependent PR.
* [x] https://github.com/viamrobotics/rdk/pull/4268 - specifically include the unit test from the PR since we want to satisfy the same invariant here.