### PR TITLE
DATA-2989: Fix export command for dataset file excluding extension 

### DIFF
--- a/cli/dataset.go
+++ b/cli/dataset.go
@@ -266,8 +266,18 @@ func binaryDataToJSONLines(ctx context.Context, client datapb.DataServiceClient,
 		annotations = append(annotations, Annotation{AnnotationLabel: tag})
 	}
 	bboxAnnotations := convertBoundingBoxes(datum.GetMetadata().GetAnnotations().GetBboxes())
+
+	fileName := filepath.Join(dst, dataDir, filenameForDownload(datum.GetMetadata()))
+	ext := datum.GetMetadata().GetFileExt()
+	// If the file is gzipped, unzip.
+	if ext != gzFileExt && filepath.Ext(fileName) != ext {
+		// If the file name did not already include the extension (e.g. for data capture files), add it.
+		// Don't do this for files that we're unzipping.
+		fileName += ext
+	}
+
 	jsonl = ImageMetadata{
-		ImagePath:                 filepath.Join(dst, dataDir, filenameForDownload(datum.GetMetadata())),
+		ImagePath:                 fileName,
 		ClassificationAnnotations: annotations,
 		BBoxAnnotations:           bboxAnnotations,
 	}


### PR DESCRIPTION
We were ignoring a file extension for data capture files. Now, it should be included. I tested with various datasets & it seems to be working, but let me know if you run into any issues.

On the app side, we're actually grabbing the blob path, so nothing to change there. That means when you run a custom training script in Viam, you shouldn't need to do anything special. You should just grab the file path as json_lines["image_file_path"] or something similar. 

You can manually test this yourself by checking out the code in this repo and then running `go run cli/viam/main.go dataset export --destination=../khari/ --dataset-id=66a90ecd6231af8ac2965fb2 --include-jsonl=true`