### PR TITLE
RSDK-8536 Fix PTG frame check, and add a minimum step check count

### DIFF
--- a/motionplan/constraint.go
+++ b/motionplan/constraint.go
@@ -16,6 +16,8 @@ import (
 	spatial "go.viam.com/rdk/spatialmath"
 )
 
+var defaultMinStepCount = 3
+
 // Given a constraint input with only frames and input positions, calculates the corresponding poses as needed.
 func resolveSegmentsToPositions(segment *ik.Segment) error {
 	if segment.StartPosition == nil {
@@ -155,6 +157,10 @@ func interpolateSegment(ci *ik.Segment, resolution float64) ([][]referenceframe.
 	}
 
 	steps := PathStepCount(ci.StartPosition, ci.EndPosition, resolution)
+	if steps < defaultMinStepCount {
+		// Minimum step count ensures we are not missing anything
+		steps = defaultMinStepCount
+	}
 
 	var interpolatedConfigurations [][]referenceframe.Input
 	for i := 0; i <= steps; i++ {

--- a/motionplan/plannerOptions.go
+++ b/motionplan/plannerOptions.go
@@ -98,7 +98,7 @@ func newBasicPlannerOptions(frame referenceframe.Frame) *plannerOptions {
 	opt.MaxSolutions = defaultSolutionsToSeed
 	opt.MinScore = defaultMinIkScore
 	opt.Resolution = defaultResolution
-	if _, isPTGframe := frame.(tpspace.PTGProvider); isPTGframe {
+	if ptgFrame, isPTGframe := frame.(tpspace.PTGProvider); isPTGframe && len(ptgFrame.PTGSolvers()) > 0 {
 		opt.Resolution = defaultPTGCollisionResolution
 	}
 	opt.Timeout = defaultTimeout


### PR DESCRIPTION
Because arms, like bases, are wrapped in solverFrames, the solverFrame fills the interface in the type check for planner options, giving arms the wrong resolution.

Here we add a length check to confirm that PTG options are appropriate.

Additionally, we add a minimum number of steps to check between configurations, as having this acts as an additional safeguard against issues where large joint swings over small physical distances (+/- 360) were not being properly checked.