### PR TITLE
APP-5909

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"bufio"
-	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -532,6 +530,7 @@ var app = &cli.App{
 									Required: true,
 								},
 							},
+							Before: DataConfigureDatabaseUserConfirmation,
 							Action: DataConfigureDatabaseUser,
 						},
 						{
@@ -546,53 +545,6 @@ var app = &cli.App{
 								},
 							},
 							Action: DataGetDatabaseConnection,
-						},
-					},
-				},
-				{
-					Name:      "nick",
-					Usage:     "do nick stuff",
-					UsageText: createUsageText("data database", nil, true),
-					Subcommands: []*cli.Command{
-						{
-							Name:      "configure",
-							Usage:     "configures a nick",
-							UsageText: createUsageText("data nick configure", []string{generalFlagOrgID, dataFlagDatabasePassword}, false),
-							Flags: []cli.Flag{
-								&cli.StringFlag{
-									Name:     generalFlagOrgID,
-									Usage:    "org ID for the database user being configured",
-									Required: true,
-								},
-								&cli.StringFlag{
-									Name:     dataFlagDatabasePassword,
-									Usage:    "password for the database user being configured",
-									Required: true,
-								},
-							},
-							Before: func(ctx *cli.Context) error {
-								printf(ctx.App.Writer, "WARNING!!!")
-								printf(ctx.App.Writer, "Proceed? y/n")
-								reader := bufio.NewReader(ctx.App.Reader)
-								if err := ctx.Err(); err != nil {
-									return err
-								}
-
-								s, err := reader.ReadString('\n')
-								if err != nil {
-									return err
-								}
-
-								input := strings.ToUpper(strings.TrimSpace(s))
-								if input != "Y" {
-									return errors.New("not confirmed")
-								}
-								return nil
-							},
-							Action: func(ctx *cli.Context) error {
-								printf(ctx.App.Writer, "DO THE THING")
-								return nil
-							},
 						},
 					},
 				},

--- a/cli/app.go
+++ b/cli/app.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -544,6 +546,53 @@ var app = &cli.App{
 								},
 							},
 							Action: DataGetDatabaseConnection,
+						},
+					},
+				},
+				{
+					Name:      "nick",
+					Usage:     "do nick stuff",
+					UsageText: createUsageText("data database", nil, true),
+					Subcommands: []*cli.Command{
+						{
+							Name:      "configure",
+							Usage:     "configures a nick",
+							UsageText: createUsageText("data nick configure", []string{generalFlagOrgID, dataFlagDatabasePassword}, false),
+							Flags: []cli.Flag{
+								&cli.StringFlag{
+									Name:     generalFlagOrgID,
+									Usage:    "org ID for the database user being configured",
+									Required: true,
+								},
+								&cli.StringFlag{
+									Name:     dataFlagDatabasePassword,
+									Usage:    "password for the database user being configured",
+									Required: true,
+								},
+							},
+							Before: func(ctx *cli.Context) error {
+								printf(ctx.App.Writer, "WARNING!!!")
+								printf(ctx.App.Writer, "Proceed? y/n")
+								reader := bufio.NewReader(ctx.App.Reader)
+								if err := ctx.Err(); err != nil {
+									return err
+								}
+
+								s, err := reader.ReadString('\n')
+								if err != nil {
+									return err
+								}
+
+								input := strings.ToUpper(strings.TrimSpace(s))
+								if input != "Y" {
+									return errors.New("not confirmed")
+								}
+								return nil
+							},
+							Action: func(ctx *cli.Context) error {
+								printf(ctx.App.Writer, "DO THE THING")
+								return nil
+							},
 						},
 					},
 				},

--- a/cli/data.go
+++ b/cli/data.go
@@ -905,26 +905,41 @@ func (c *viamClient) dataRemoveFromDataset(datasetID, orgID, locationID string, 
 
 // DataConfigureDatabaseUserConfirmation is the Before action for 'data database configure'.
 // it asks for the user to confirm that they are aware that they are changing the authentication
-// credentials of their database
+// credentials of their database.
 func DataConfigureDatabaseUserConfirmation(c *cli.Context) error {
-	yellow := "\033[1;33m%s\033[0m"
-	printf(c.App.Writer, yellow, "WARNING!!!")
-	printf(c.App.Writer, yellow, "If you or someone else in your organization have already created this user, the following steps update the password for that user instead. Dashboards or other integrations relying on this password will then need to be updated.")
-	printf(c.App.Writer, yellow, "Do you want to continue?")
-	printf(c.App.Writer, "Continue: y/n")
-	if err := c.Err(); err != nil {
-		return err
-	}
-
-	rawInput, err := bufio.NewReader(c.App.Reader).ReadString('\n')
+	client, err := newViamClient(c)
 	if err != nil {
 		return err
 	}
 
-	input := strings.ToUpper(strings.TrimSpace(rawInput))
-	if input != "Y" {
-		return errors.New("aborted")
+	res, err := client.dataGetDatabaseConnection(c.String(generalFlagOrgID))
+	if err != nil {
+		return err
 	}
+
+	if res.HasDatabaseUser {
+		yellow := "\033[1;33m%s\033[0m"
+		printf(c.App.Writer, yellow, "WARNING!!!")
+		printf(c.App.Writer, yellow, "You or someone else in your organization have already created a user. "+
+			"The following steps update the password for that user. Once you have updated the password, you "+
+			"will need to update all dashboards or other integrations relying on this password.")
+		printf(c.App.Writer, yellow, "Do you want to continue?")
+		printf(c.App.Writer, "Continue: y/n")
+		if err := c.Err(); err != nil {
+			return err
+		}
+
+		rawInput, err := bufio.NewReader(c.App.Reader).ReadString('\n')
+		if err != nil {
+			return err
+		}
+
+		input := strings.ToUpper(strings.TrimSpace(rawInput))
+		if input != "Y" {
+			return errors.New("aborted")
+		}
+	}
+
 	return nil
 }
 
@@ -962,23 +977,24 @@ func DataGetDatabaseConnection(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	if err := client.dataGetDatabaseConnection(c.String(generalFlagOrgID)); err != nil {
+	res, err := client.dataGetDatabaseConnection(c.String(generalFlagOrgID))
+	if err != nil {
 		return err
 	}
+	printf(client.c.App.Writer, "MongoDB Atlas Data Federation instance hostname: %s", res.GetHostname())
+	printf(client.c.App.Writer, "MongoDB Atlas Data Federation instance connection URI: %s", res.GetMongodbUri())
 	return nil
 }
 
 // dataGetDatabaseConnection gets the hostname of the MongoDB Atlas Data Federation instance
 // for the given organization ID.
-func (c *viamClient) dataGetDatabaseConnection(orgID string) error {
+func (c *viamClient) dataGetDatabaseConnection(orgID string) (*datapb.GetDatabaseConnectionResponse, error) {
 	if err := c.ensureLoggedIn(); err != nil {
-		return err
+		return nil, err
 	}
 	res, err := c.dataClient.GetDatabaseConnection(context.Background(), &datapb.GetDatabaseConnectionRequest{OrganizationId: orgID})
 	if err != nil {
-		return errors.Wrapf(err, serverErrorMessage)
+		return nil, errors.Wrapf(err, serverErrorMessage)
 	}
-	printf(c.c.App.Writer, "MongoDB Atlas Data Federation instance hostname: %s", res.GetHostname())
-	printf(c.c.App.Writer, "MongoDB Atlas Data Federation instance connection URI: %s", res.GetMongodbUri())
-	return nil
+	return res, nil
 }

--- a/cli/data.go
+++ b/cli/data.go
@@ -910,7 +910,7 @@ func DataConfigureDatabaseUserConfirmation(c *cli.Context) error {
 	yellow := "\033[1;33m%s\033[0m"
 	printf(c.App.Writer, yellow, "WARNING!!!")
 	printf(c.App.Writer, yellow, "If you or someone else in your organization have already created this user, the following steps update the password for that user instead. Dashboards or other integrations relying on this password will then need to be updated.")
-	printf(c.App.Writer, yellow, "do you want to continue?")
+	printf(c.App.Writer, yellow, "Do you want to continue?")
 	printf(c.App.Writer, "Continue: y/n")
 	if err := c.Err(); err != nil {
 		return err

--- a/cli/data.go
+++ b/cli/data.go
@@ -907,8 +907,11 @@ func (c *viamClient) dataRemoveFromDataset(datasetID, orgID, locationID string, 
 // it asks for the user to confirm that they are aware that they are changing the authentication
 // credentials of their database
 func DataConfigureDatabaseUserConfirmation(c *cli.Context) error {
-	printf(c.App.Writer, "WARNING!!!")
-	printf(c.App.Writer, "Proceed? y/n")
+	yellow := "\033[1;33m%s\033[0m"
+	printf(c.App.Writer, yellow, "WARNING!!!")
+	printf(c.App.Writer, yellow, "this will change the password of the database")
+	printf(c.App.Writer, yellow, "do you want to continue?")
+	printf(c.App.Writer, "Continue: y/n")
 	if err := c.Err(); err != nil {
 		return err
 	}
@@ -920,7 +923,7 @@ func DataConfigureDatabaseUserConfirmation(c *cli.Context) error {
 
 	input := strings.ToUpper(strings.TrimSpace(rawInput))
 	if input != "Y" {
-		return errors.New("not confirmed")
+		return errors.New("aborted")
 	}
 	return nil
 }

--- a/cli/data.go
+++ b/cli/data.go
@@ -909,7 +909,7 @@ func (c *viamClient) dataRemoveFromDataset(datasetID, orgID, locationID string, 
 func DataConfigureDatabaseUserConfirmation(c *cli.Context) error {
 	yellow := "\033[1;33m%s\033[0m"
 	printf(c.App.Writer, yellow, "WARNING!!!")
-	printf(c.App.Writer, yellow, "this will change the password of the database")
+	printf(c.App.Writer, yellow, "If you or someone else in your organization have already created this user, the following steps update the password for that user instead. Dashboards or other integrations relying on this password will then need to be updated.")
 	printf(c.App.Writer, yellow, "do you want to continue?")
 	printf(c.App.Writer, "Continue: y/n")
 	if err := c.Err(); err != nil {

--- a/cli/data.go
+++ b/cli/data.go
@@ -919,10 +919,11 @@ func DataConfigureDatabaseUserConfirmation(c *cli.Context) error {
 
 	if res.HasDatabaseUser {
 		yellow := "\033[1;33m%s\033[0m"
-		printf(c.App.Writer, yellow, "WARNING!!!")
-		printf(c.App.Writer, yellow, "You or someone else in your organization have already created a user. "+
-			"The following steps update the password for that user. Once you have updated the password, you "+
-			"will need to update all dashboards or other integrations relying on this password.")
+		printf(c.App.Writer, yellow, "WARNING!!\n")
+		printf(c.App.Writer, yellow, "You or someone else in your organization have already created a user.\n")
+		printf(c.App.Writer, yellow, "The following steps update the password for that user.\n")
+		printf(c.App.Writer, yellow, "Once you have updated the password, you will need to update all dashboards or")
+		printf(c.App.Writer, yellow, "other integrations relying on this password.\n")
 		printf(c.App.Writer, yellow, "Do you want to continue?")
 		printf(c.App.Writer, "Continue: y/n")
 		if err := c.Err(); err != nil {

--- a/cli/data.go
+++ b/cli/data.go
@@ -903,6 +903,28 @@ func (c *viamClient) dataRemoveFromDataset(datasetID, orgID, locationID string, 
 	return nil
 }
 
+// DataConfigureDatabaseUserConfirmation is the Before action for 'data database configure'.
+// it asks for the user to confirm that they are aware that they are changing the authentication
+// credentials of their database
+func DataConfigureDatabaseUserConfirmation(c *cli.Context) error {
+	printf(c.App.Writer, "WARNING!!!")
+	printf(c.App.Writer, "Proceed? y/n")
+	if err := c.Err(); err != nil {
+		return err
+	}
+
+	rawInput, err := bufio.NewReader(c.App.Reader).ReadString('\n')
+	if err != nil {
+		return err
+	}
+
+	input := strings.ToUpper(strings.TrimSpace(rawInput))
+	if input != "Y" {
+		return errors.New("not confirmed")
+	}
+	return nil
+}
+
 // DataConfigureDatabaseUser is the corresponding action for 'data database configure'.
 func DataConfigureDatabaseUser(c *cli.Context) error {
 	client, err := newViamClient(c)


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/APP-5909)

Change viam cli's `viam data database configure` command to require user confirmation before executing change to database auth credentials if a user already exists.

```bash
# first time configuring
$ viam data database configure --org-id <REDACTED> --password <REDACTED>

# second time configuring, with the user aborting
Configured database user for org <REDACTED>
$ viam data database configure --org-id <REDACTED> --password <REDACTED>
WARNING!!

You or someone else in your organization have already created a user.

The following steps update the password for that user.

Once you have updated the password, you will need to update all dashboards or
other integrations relying on this password.

Do you want to continue?

Continue: y/n
n
Error: Aborted
exit status 1

# third time attempting to 
$ viam data database configure --org-id <REDACTED> --password <REDACTED>
WARNING!!

You or someone else in your organization have already created a user.

The following steps update the password for that user.

Once you have updated the password, you will need to update all dashboards or
other integrations relying on this password.

Do you want to continue?

Continue: y/n
y
Configured database user for org <REDACTED>
```

