### PR TITLE
[RSDK-8526] Make communicating with the TMC5072 atomic

### DIFF
--- a/components/motor/tmcstepper/stepper_motor_tmc.go
+++ b/components/motor/tmcstepper/stepper_motor_tmc.go
@@ -325,7 +325,7 @@ func (m *Motor) writeReg(ctx context.Context, addr uint8, value int32) error {
 		}
 	}()
 
-	// m.logger.Debug("Write: ", buf)
+	m.logger.Debug("Write: ", buf)
 
 	_, err = handle.Xfer(ctx, 1000000, m.csPin, 3, buf[:]) // SPI Mode 3, 1mhz
 	if err != nil {
@@ -373,8 +373,8 @@ func (m *Motor) readReg(ctx context.Context, addr uint8) (int32, error) {
 	value <<= 8
 	value |= int32(rbuf[4])
 
-	// m.logger.Debug("ReadR: ", rbuf)
-	// m.logger.Debug("Read: ", value)
+	m.logger.Debug("ReadR: ", rbuf)
+	m.logger.Debug("Read: ", value)
 
 	return value, nil
 }

--- a/components/motor/tmcstepper/stepper_motor_tmc_test.go
+++ b/components/motor/tmcstepper/stepper_motor_tmc_test.go
@@ -88,7 +88,7 @@ func TestRPMBounds(t *testing.T) {
 		// Filter out the debug logs that just indicate what we sent/received on the SPI bus.
 		for _, lineVal := range obs.All() {
 			line := fmt.Sprint(lineVal)
-			if strings.HasPrefix(line, "Read from ") || strings.HasPrefix(line, "Write to ") {
+			if strings.Contains(line, "Read from ") || strings.Contains(line, "Write to ") {
 				continue
 			}
 			lastLine = line


### PR DESCRIPTION
Surprise: although sending a packet on an SPI bus is already atomic (as enforced by the Linux kernel), reading a value from a TMC5072 stepper motor is _not_ atomic, because it requires sending multiple packets on the bus! and that means that we need an _extra_ mutex across all TMC5072 components, making sure that only one of them communicates with the chip at a time.

Specifically, you can only read the value you interacted with in the previous command. So, to read a value you send a read command and get back arbitrary data, and then you send the read command a second time, and get back the value you care about. but if, in between those two, another component sent some other command, your second read has something else in it! So, we add in a global mutex that all the TMC5072's can use, to ensure that you don't send commands in the middle of another component reading.

Tried on an rpi5 at my desk: without this change, the positions from the encoder keep doing weird things (sometimes it's right, sometimes it shows the position of the other motor, sometimes it shows garbage because it's giving, like, a status message that we mistakenly think is an encoder position). With this change, everything works the way you'd expect!