### PR TITLE
use ModularMain in the example modules

### DIFF
--- a/examples/customresources/demos/complexmodule/module.go
+++ b/examples/customresources/demos/complexmodule/module.go
@@ -17,10 +17,11 @@ import (
 func main() {
 	// We will use a logging.Logger named "complexmodule," and our module will support 4 different
 	// resource models.
-	module.ModularMain("complexmodule",
-	                   resource.APIModel{gizmoapi.API, mygizmo.Model},
-	                   resource.APIModel{summationapi.API, mysum.Model},
-	                   resource.APIModel{base.API, mybase.Model},
-	                   resource.APIModel{navigation.API, mynavigation.Model},
-	                   )
+	module.ModularMain(
+		"complexmodule",
+		resource.APIModel{gizmoapi.API, mygizmo.Model},
+		resource.APIModel{summationapi.API, mysum.Model},
+		resource.APIModel{base.API, mybase.Model},
+		resource.APIModel{navigation.API, mynavigation.Model},
+	)
 }

--- a/examples/customresources/demos/complexmodule/module.go
+++ b/examples/customresources/demos/complexmodule/module.go
@@ -2,10 +2,6 @@
 package main
 
 import (
-	"context"
-
-	"go.viam.com/utils"
-
 	"go.viam.com/rdk/components/base"
 	"go.viam.com/rdk/examples/customresources/apis/gizmoapi"
 	"go.viam.com/rdk/examples/customresources/apis/summationapi"
@@ -13,48 +9,18 @@ import (
 	"go.viam.com/rdk/examples/customresources/models/mygizmo"
 	"go.viam.com/rdk/examples/customresources/models/mynavigation"
 	"go.viam.com/rdk/examples/customresources/models/mysum"
-	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/module"
+	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/services/navigation"
 )
 
 func main() {
-	// NewLoggerFromArgs will create a logging.Logger at "DebugLevel" if
-	// "--log-level=debug" is the third argument in os.Args and at "InfoLevel"
-	// otherwise.
-	utils.ContextualMain(mainWithArgs, module.NewLoggerFromArgs("complexmodule"))
-}
-
-func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) (err error) {
-	myMod, err := module.NewModuleFromArgs(ctx, logger)
-	if err != nil {
-		return err
-	}
-
-	// Models and APIs add helpers to the registry during their init().
-	// They can then be added to the module here.
-	err = myMod.AddModelFromRegistry(ctx, gizmoapi.API, mygizmo.Model)
-	if err != nil {
-		return err
-	}
-	err = myMod.AddModelFromRegistry(ctx, summationapi.API, mysum.Model)
-	if err != nil {
-		return err
-	}
-	err = myMod.AddModelFromRegistry(ctx, base.API, mybase.Model)
-	if err != nil {
-		return err
-	}
-	err = myMod.AddModelFromRegistry(ctx, navigation.API, mynavigation.Model)
-	if err != nil {
-		return err
-	}
-
-	err = myMod.Start(ctx)
-	defer myMod.Close(ctx)
-	if err != nil {
-		return err
-	}
-	<-ctx.Done()
-	return nil
+	// We will use a logging.Logger named "complexmodule," and our module will support 4 different
+	// resource models.
+	module.ModularMain("complexmodule",
+	                   resource.APIModel{gizmoapi.API, mygizmo.Model},
+	                   resource.APIModel{summationapi.API, mysum.Model},
+	                   resource.APIModel{base.API, mybase.Model},
+	                   resource.APIModel{navigation.API, mynavigation.Model},
+	                   )
 }

--- a/examples/customresources/demos/multiplemodules/gizmomodule/gizmomodule.go
+++ b/examples/customresources/demos/multiplemodules/gizmomodule/gizmomodule.go
@@ -2,41 +2,14 @@
 package main
 
 import (
-	"context"
-
-	"go.viam.com/utils"
-
 	"go.viam.com/rdk/examples/customresources/apis/gizmoapi"
 	"go.viam.com/rdk/examples/customresources/models/mygizmosummer"
-	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/module"
+	"go.viam.com/rdk/resource"
 )
 
 func main() {
-	// NewLoggerFromArgs will create a logging.Logger at "DebugLevel" if
-	// "--log-level=debug" is the third argument in os.Args and at "InfoLevel"
-	// otherwise.
-	utils.ContextualMain(mainWithArgs, module.NewLoggerFromArgs("gizmomodule"))
-}
-
-func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) (err error) {
-	myMod, err := module.NewModuleFromArgs(ctx, logger)
-	if err != nil {
-		return err
-	}
-
-	// Models and APIs add helpers to the registry during their init().
-	// They can then be added to the module here.
-	err = myMod.AddModelFromRegistry(ctx, gizmoapi.API, mygizmosummer.Model)
-	if err != nil {
-		return err
-	}
-
-	err = myMod.Start(ctx)
-	defer myMod.Close(ctx)
-	if err != nil {
-		return err
-	}
-	<-ctx.Done()
-	return nil
+	// ModularMain will create a logger named "gizmomodule", and will stand up a module which will
+	// host our gizmo.
+	module.ModularMain("gizmomodule", resource.APIModel{gizmoapi.API, mygizmosummer.Model})
 }

--- a/examples/customresources/demos/multiplemodules/summationmodule/summationmodule.go
+++ b/examples/customresources/demos/multiplemodules/summationmodule/summationmodule.go
@@ -2,41 +2,14 @@
 package main
 
 import (
-	"context"
-
-	"go.viam.com/utils"
-
 	"go.viam.com/rdk/examples/customresources/apis/summationapi"
 	"go.viam.com/rdk/examples/customresources/models/mysum"
-	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/module"
+	"go.viam.com/rdk/resource"
 )
 
 func main() {
-	// NewLoggerFromArgs will create a logging.Logger at "DebugLevel" if
-	// "--log-level=debug" is the third argument in os.Args and at "InfoLevel"
-	// otherwise.
-	utils.ContextualMain(mainWithArgs, module.NewLoggerFromArgs("summationmodule"))
-}
-
-func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) (err error) {
-	myMod, err := module.NewModuleFromArgs(ctx, logger)
-	if err != nil {
-		return err
-	}
-
-	// Models and APIs add helpers to the registry during their init().
-	// They can then be added to the module here.
-	err = myMod.AddModelFromRegistry(ctx, summationapi.API, mysum.Model)
-	if err != nil {
-		return err
-	}
-
-	err = myMod.Start(ctx)
-	defer myMod.Close(ctx)
-	if err != nil {
-		return err
-	}
-	<-ctx.Done()
-	return nil
+	// ModularMain will create a logger named "summationmodule" and will then host a module with
+	// our mysum model in it.
+	module.ModularMain("summationmodule", resource.APIModel{summationapi.API, mysum.Model})
 }

--- a/examples/customresources/demos/rtppassthrough/myrtppassthrough.go
+++ b/examples/customresources/demos/rtppassthrough/myrtppassthrough.go
@@ -4,8 +4,6 @@ package main
 import (
 	"context"
 
-	goutils "go.viam.com/utils"
-
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/components/camera/fake"
 	"go.viam.com/rdk/logging"
@@ -16,31 +14,12 @@ import (
 var model = resource.NewModel("acme", "camera", "fake")
 
 func main() {
-	goutils.ContextualMain(mainWithArgs, logging.NewDebugLogger("rtp-passthrough-camera"))
-}
-
-func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) (err error) {
 	resource.RegisterComponent(
 		camera.API,
 		model,
 		resource.Registration[camera.Camera, *fake.Config]{Constructor: newFakeCamera})
 
-	module, err := module.NewModuleFromArgs(ctx, logger)
-	if err != nil {
-		return err
-	}
-	if err := module.AddModelFromRegistry(ctx, camera.API, model); err != nil {
-		return err
-	}
-
-	err = module.Start(ctx)
-	defer module.Close(ctx)
-	if err != nil {
-		return err
-	}
-
-	<-ctx.Done()
-	return nil
+	module.ModularMain("rtp-passthrough-camera", resource.APIModel{camera.API, model})
 }
 
 func newFakeCamera(


### PR DESCRIPTION
All examples compile and the ones with makefiles run, but I haven't tried things out further than that (I haven't figured out how to send requests and get responses back). The intention here is that I've made a `ModularMain()` function (see https://github.com/viamrobotics/rdk/pull/4256) to avoid copying and pasting so much boilerplate when running modules, and we should encourage users to use it instead of copying and pasting boilerplate, too. 

Have I tagged the right people for this PR? Feel free to untag yourself if I've got this wrong.

How thoroughly would you like me to test this? Given that the code compiles and all the ones with a makefile run, I suspect I've done this right (if I have a bug, I'd expect it not to compile in the first place), but I'm willing to try it out more thoroughly if you want.