### PR TITLE
DATA-2823 - Add logic in CaptureAllFromCamera to exclude readings from being captured

### DIFF
--- a/services/vision/collector.go
+++ b/services/vision/collector.go
@@ -63,9 +63,14 @@ func newCaptureAllFromCameraCollector(resource interface{}, params data.Collecto
 			ReturnClassifications: true,
 			ReturnObject:          true,
 		}
-		visCapture, err := vision.CaptureAllFromCamera(ctx, cameraName, visCaptureOptions, nil)
+		visCapture, err := vision.CaptureAllFromCamera(ctx, cameraName, visCaptureOptions, data.FromDMExtraMap)
 		if err != nil {
-			return nil, data.FailedToReadErr(cameraName, captureAllFromCamera.String(), err)
+			// A modular filter component can be created to filter the readings from a component. The error ErrNoCaptureToStore
+			// is used in the datamanager to exclude readings from being captured and stored.
+			if errors.Is(err, data.ErrNoCaptureToStore) {
+				return nil, err
+			}
+			return nil, data.FailedToReadErr(params.ComponentName, captureAllFromCamera.String(), err)
 		}
 
 		protoImage, err := imageToProto(ctx, visCapture.Image, cameraName)

--- a/services/vision/collector.go
+++ b/services/vision/collector.go
@@ -65,7 +65,7 @@ func newCaptureAllFromCameraCollector(resource interface{}, params data.Collecto
 		}
 		visCapture, err := vision.CaptureAllFromCamera(ctx, cameraName, visCaptureOptions, data.FromDMExtraMap)
 		if err != nil {
-			// A modular filter component can be created to filter the readings from a component. The error ErrNoCaptureToStore
+			// A modular filter component can be created to filter the readings from a service. The error ErrNoCaptureToStore
 			// is used in the datamanager to exclude readings from being captured and stored.
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return nil, err


### PR DESCRIPTION
Arush added a collector the vision service (info [here](https://docs.google.com/document/d/1HvqAnnIjKNyLn0y0DnskJQ4tF-PgaI7ywJAq6V356ig/edit)) to allow one to simultaneously capture images and annotations (labels, bounding boxes).

This is adding in the logic for the filter readings.

https://viam.atlassian.net/browse/DATA-2823 