### PR TITLE
DATA-3009

### DIFF
--- a/grpc/conn.go
+++ b/grpc/conn.go
@@ -62,6 +62,16 @@ func (c *ReconfigurableClientConn) ReplaceConn(conn rpc.ClientConn) {
 	c.connMu.Unlock()
 }
 
+// GRPCConn returns the backing rpc.GRPCClientConnInterface object, if applicable. Nil otherwise.
+func (c *ReconfigurableClientConn) GRPCConn() rpc.GRPCClientConnInterface {
+	c.connMu.Lock()
+	defer c.connMu.Unlock()
+	if c.conn == nil {
+		return nil
+	}
+	return c.conn.GRPCConn()
+}
+
 // PeerConn returns the backing PeerConnection object, if applicable. Nil otherwise.
 func (c *ReconfigurableClientConn) PeerConn() *webrtc.PeerConnection {
 	c.connMu.Lock()

--- a/grpc/shared_conn.go
+++ b/grpc/shared_conn.go
@@ -120,6 +120,15 @@ func (sc *SharedConn) RemoveOnTrackSub(name resource.Name) {
 	delete(sc.resOnTrackCBs, name)
 }
 
+// GRPCConn returns a gRPC capable client connection.
+func (sc *SharedConn) GRPCConn() rpc.GRPCClientConnInterface {
+	g := sc.GrpcConn()
+	if g == nil {
+		return nil
+	}
+	return g.GRPCConn()
+}
+
 // GrpcConn returns a gRPC capable client connection.
 func (sc *SharedConn) GrpcConn() *ReconfigurableClientConn {
 	return &sc.grpcConn


### PR DESCRIPTION
Depends on https://github.com/viamrobotics/goutils/pull/332

1. Adds `GRPCConn()` on *ReconfigurableClientConn and *SharedConn to conform to the new `rpc.ClientConn` interface.
2. In future PRs this will allow data manager to detect if the connection with app.vaim.com is healthy or not without needing to create a new tcp connection as we do today: https://github.com/viamrobotics/rdk/blob/1077e8390ad7b620ad796bfbac3deaac344f2900/services/datamanager/builtin/builtin.go#L779