### PR TITLE
[DATA-2672] simplify diskusage

### DIFF
--- a/services/datamanager/builtin/file_deletion.go
+++ b/services/datamanager/builtin/file_deletion.go
@@ -26,7 +26,7 @@ var errAtSizeThreshold = errors.New("capture directory has reached or exceeded d
 func shouldDeleteBasedOnDiskUsage(ctx context.Context, captureDirPath string, logger logging.Logger) (bool, error) {
 	statfs, err := diskusage.Statfs(captureDirPath)
 	if err != nil {
-		//nolint:nilerr
+		logger.Debugf("diskusage.Statfs returned error: %s", err.Error())
 		return false, nil
 	}
 	// we get usage this way to ensure we get the amount of remaining space in the partition.

--- a/utils/diskusage/disk_usage.go
+++ b/utils/diskusage/disk_usage.go
@@ -7,39 +7,27 @@ import "syscall"
 
 // DiskUsage contains usage data and provides user-friendly access methods.
 type DiskUsage struct {
-	stat *syscall.Statfs_t
+	// AvailableBytes is the total available bytes on file system to an unprivileged user.
+	AvailableBytes uint64
+	// SizeBytes is the total size of the file system in bytes.
+	SizeBytes uint64
 }
 
-// NewDiskUsage returns an object holding the disk usage of volumePath
-// or nil in case of error (invalid path, etc).
-func NewDiskUsage(volumePath string) *DiskUsage {
+// Statfs returns file system statistics.
+func Statfs(volumePath string) (DiskUsage, error) {
 	var stat syscall.Statfs_t
-	//nolint:errcheck,gosec
-	syscall.Statfs(volumePath, &stat)
-	return &DiskUsage{&stat}
+	if err := syscall.Statfs(volumePath, &stat); err != nil {
+		return DiskUsage{}, err
+	}
+	return DiskUsage{
+		AvailableBytes: stat.Bavail * uint64(stat.Bsize),
+		SizeBytes:      stat.Blocks * uint64(stat.Bsize),
+	}, nil
 }
 
-// Free returns total free bytes on file system.
-func (du *DiskUsage) Free() uint64 {
-	return du.stat.Bfree * uint64(du.stat.Bsize)
-}
-
-// Available return total available bytes on file system to an unprivileged user.
-func (du *DiskUsage) Available() uint64 {
-	return du.stat.Bavail * uint64(du.stat.Bsize)
-}
-
-// Size returns total size of the file system.
-func (du *DiskUsage) Size() uint64 {
-	return du.stat.Blocks * uint64(du.stat.Bsize)
-}
-
-// Used returns total bytes used in file system.
-func (du *DiskUsage) Used() uint64 {
-	return du.Size() - du.Free()
-}
-
-// Usage returns percentage of use on the file system.
-func (du *DiskUsage) Usage() float32 {
-	return float32(du.Used()) / float32(du.Size())
+// AvailablePercent returns the percentage (0.0-1.0) of the disk available
+// to an unprivileged user
+// see `man statfs` for how the underlying values are derived on your platform.
+func (du DiskUsage) AvailablePercent() float64 {
+	return float64(du.AvailableBytes) / float64(du.SizeBytes)
 }


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/DATA-2672)

This PR applies self-contained changes needed to refactor builtin data manage to be easier to unit test.

Here is the PR which is the final state:
https://github.com/viamrobotics/rdk/pull/4161

1. Changes diskusage.NewDiskUsage to be named diskusage.Statfs (the actual syscall used) and return an error if the sys call fails rather than swallowing it (as the current implementation does)
2. Change it to return a struct rather than a pointer to a struct with methods that need to be called to get the underlying values. This will make it easier to test how data manager behaves under different file system conditions without needing to set up those conditions in tests.
3. Delete all unused portions of the diskusage package 
4. Update callers and maintain exact same behavior as before