### PR TITLE
[DATA-2672] refactor data registry

### DIFF
--- a/data/registry.go
+++ b/data/registry.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/benbjohnson/clock"
-	"github.com/mitchellh/copystructure"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/types/known/anypb"
 
@@ -53,6 +52,8 @@ func (m MethodMetadata) String() string {
 	return fmt.Sprintf("Api: %v, Method Name: %s", m.API, m.MethodName)
 }
 
+// collectorRegistry is accessed without locks. This is safe because all collectors are registered
+// in package initialization functions. Those functions are executed in series.
 var collectorRegistry = map[MethodMetadata]CollectorConstructor{}
 
 // RegisterCollector registers a Collector to its corresponding MethodMetadata.
@@ -67,18 +68,6 @@ func RegisterCollector(method MethodMetadata, c CollectorConstructor) {
 
 // CollectorLookup looks up a Collector by the given MethodMetadata. nil is returned if
 // there is None.
-func CollectorLookup(method MethodMetadata) *CollectorConstructor {
-	if registration, ok := RegisteredCollectors()[method]; ok {
-		return &registration
-	}
-	return nil
-}
-
-// RegisteredCollectors returns a copy of the registry.
-func RegisteredCollectors() map[MethodMetadata]CollectorConstructor {
-	copied, err := copystructure.Copy(collectorRegistry)
-	if err != nil {
-		panic(err)
-	}
-	return copied.(map[MethodMetadata]CollectorConstructor)
+func CollectorLookup(method MethodMetadata) CollectorConstructor {
+	return collectorRegistry[method]
 }

--- a/data/registry_test.go
+++ b/data/registry_test.go
@@ -28,7 +28,7 @@ func TestRegister(t *testing.T) {
 
 	// Return registered collector if one exists.
 	RegisterCollector(md, dummyCollectorConstructor)
-	ret := *CollectorLookup(md)
+	ret := CollectorLookup(md)
 	test.That(t, ret, test.ShouldEqual, dummyCollectorConstructor)
 
 	// Return nothing if exact match has not been registered.

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,6 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.2.0
 	github.com/mattn/go-tflite v1.0.4
 	github.com/matttproud/golang_protobuf_extensions v1.0.4
-	github.com/mitchellh/copystructure v1.2.0
 	github.com/mkch/gpio v0.0.0-20190919032813-8327cd97d95e
 	github.com/montanaflynn/stats v0.7.0
 	github.com/muesli/clusters v0.0.0-20200529215643-2700303c1762
@@ -274,6 +273,7 @@ require (
 	github.com/mbilski/exhaustivestruct v1.2.0 // indirect
 	github.com/mgechev/revive v1.3.2 // indirect
 	github.com/miekg/dns v1.1.53 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -390,7 +390,7 @@ func (svc *builtIn) initializeOrUpdateCollector(
 		Logger:        svc.logger,
 		Clock:         clock,
 	}
-	collector, err := (*collectorConstructor)(res, params)
+	collector, err := (collectorConstructor)(res, params)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/DATA-2672)

This PR refactors the data.registry.go 


Here is the PR which is the final state:
https://github.com/viamrobotics/rdk/pull/4161


1. Change data.CollectorLookup to return a `CollectorConstructor` rather than pointer to one (everywhere we used it we had to de-reference the pointer which defeats the point)
2. Remove the unused data.RegisteredCollectors