### PR TITLE
[RSDK-8562] make control freq configurable

### DIFF
--- a/components/base/sensorcontrolled/sensorcontrolled.go
+++ b/components/base/sensorcontrolled/sensorcontrolled.go
@@ -25,6 +25,7 @@ const (
 	sensorDebug        = false
 	typeLinVel         = "linear_velocity"
 	typeAngVel         = "angular_velocity"
+	defaultControlFreq = 10 // Hz
 )
 
 var (
@@ -38,6 +39,7 @@ type Config struct {
 	MovementSensor    []string            `json:"movement_sensor"`
 	Base              string              `json:"base"`
 	ControlParameters []control.PIDConfig `json:"control_parameters,omitempty"`
+	ControlFreq       float64             `json:"control_frequency_hz,omitempty"`
 }
 
 // Validate validates all parts of the sensor controlled base config.
@@ -76,6 +78,7 @@ type sensorBase struct {
 	controlLoopConfig control.Config
 	blockNames        map[string][]string
 	loop              *control.Loop
+	controlFreq       float64
 }
 
 func init() {
@@ -118,6 +121,11 @@ func (sb *sensorBase) Reconfigure(ctx context.Context, deps resource.Dependencie
 
 	sb.mu.Lock()
 	defer sb.mu.Unlock()
+
+	sb.controlFreq = defaultControlFreq
+	if newConf.ControlFreq != 0 {
+		sb.controlFreq = newConf.ControlFreq
+	}
 
 	// reset all sensors
 	sb.allSensors = nil

--- a/components/base/sensorcontrolled/velocities.go
+++ b/components/base/sensorcontrolled/velocities.go
@@ -59,7 +59,7 @@ func (sb *sensorBase) setupControlLoop(linear, angular control.PIDConfig) error 
 	// set the necessary options for a sensorcontrolled base
 	options := control.Options{
 		SensorFeedback2DVelocityControl: true,
-		LoopFrequency:                   10,
+		LoopFrequency:                   sb.controlFreq,
 		ControllableType:                "base_name",
 	}
 


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-8562

last week we realized that some controllers we use have poor performance at low velocities. Adjusting the control loop frequency is another way we can improve controller behavior. 

default frequency, set velocity 50 mm/s
![image](https://github.com/user-attachments/assets/21e701b8-cdca-4e9f-a1c5-bb80db047fdd)

high frequency, same PID
![run582-uhigh-freq-performance](https://github.com/user-attachments/assets/396c0d9f-b39e-4a58-8fc7-62edc22b8a9a)
