### PR TITLE
[RSDK-7731] more verbose error message when NativeConfig has an unexpected type passed in

### DIFF
--- a/components/movementsensor/gpsnmea/pmtkI2C_test.go
+++ b/components/movementsensor/gpsnmea/pmtkI2C_test.go
@@ -14,7 +14,6 @@ import (
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/testutils/inject"
-	"go.viam.com/rdk/utils"
 )
 
 const (
@@ -55,8 +54,7 @@ func TestNewI2CMovementSensor(t *testing.T) {
 	// validation step.
 	g1, err := newNMEAGPS(ctx, deps, conf, logger)
 	test.That(t, g1, test.ShouldBeNil)
-	test.That(t, err, test.ShouldBeError,
-		utils.NewUnexpectedTypeError[*Config](conf.ConvertedAttributes))
+	test.That(t, err, test.ShouldNotBeNil)
 
 	conf = resource.Config{
 		Name:  "movementsensor2",

--- a/resource/config.go
+++ b/resource/config.go
@@ -122,7 +122,14 @@ func (conf Config) MarshalJSON() ([]byte, error) {
 // this should be a method on the type and hide away both Attributes and
 // ConvertedAttributes.
 func NativeConfig[T any](conf Config) (T, error) {
-	return utils.AssertType[T](conf.ConvertedAttributes)
+	val, err := utils.AssertType[T](conf.ConvertedAttributes)
+	if err != nil {
+		err = fmt.Errorf(
+			"unexpected config type passed to NativeConfig: %w. Make sure the "+
+			"config type registered to the resource matches the one passed into "+
+			"NativeConfig", err)
+	}
+	return val, err
 }
 
 // NewEmptyConfig returns a new, empty config for the given name and model.

--- a/resource/config.go
+++ b/resource/config.go
@@ -125,9 +125,8 @@ func NativeConfig[T any](conf Config) (T, error) {
 	val, err := utils.AssertType[T](conf.ConvertedAttributes)
 	if err != nil {
 		err = fmt.Errorf(
-			"unexpected config type passed to NativeConfig: %w. Make sure the "+
-			"config type registered to the resource matches the one passed into "+
-			"NativeConfig", err)
+			"incorrect config type: NativeConfig %w. Make sure the config type registered to the "+
+			"resource matches the one passed into NativeConfig", err)
 	}
 	return val, err
 }

--- a/resource/config.go
+++ b/resource/config.go
@@ -126,7 +126,7 @@ func NativeConfig[T any](conf Config) (T, error) {
 	if err != nil {
 		err = fmt.Errorf(
 			"incorrect config type: NativeConfig %w. Make sure the config type registered to the "+
-			"resource matches the one passed into NativeConfig", err)
+				"resource matches the one passed into NativeConfig", err)
 	}
 	return val, err
 }


### PR DESCRIPTION
Here's an example of the new error message:
```
2024-08-20T22:11:20.668Z	ERROR	rdk.resource_manager.rdk:component:board/b	resource/graph_node.go:288	resource build error: incorrect config type: NativeConfig expected genericlinux.Config but got *genericlinux.Config. Make sure the config type registered to the resource matches the one passed into NativeConfig	{"resource":"rdk:component:board/b","model":"rdk:builtin:pi5"}
```