### PR TITLE
[RSDK-8494] Validate PWM-setting requests

### DIFF
--- a/components/board/genericlinux/gpio.go
+++ b/components/board/genericlinux/gpio.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"go.viam.com/utils"
 
+	"go.viam.com/rdk/components/board"
 	"go.viam.com/rdk/logging"
 	rdkutils "go.viam.com/rdk/utils"
 )
@@ -358,17 +359,9 @@ func (pin *gpioPin) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[
 	pin.mu.Lock()
 	defer pin.mu.Unlock()
 
-	// Make sure the duty cycle we receive is believable.
-	if dutyCyclePct < 0.0 {
-		return errors.New("cannot set negative duty cycle")
-	}
-	if dutyCyclePct > 1.0 {
-		if dutyCyclePct < 1.01 {
-			// Someone was probably setting it to 1 and had a roundoff error.
-			dutyCyclePct = 1.0
-		} else {
-			return fmt.Errorf("cannot set duty cycle to %f: range is 0.0 to 1.0", dutyCyclePct)
-		}
+	dutyCyclePct, err := board.ValidatePWMDutyCycle(dutyCyclePct)
+	if err != nil {
+		return err
 	}
 
 	pin.pwmDutyCyclePct = dutyCyclePct

--- a/components/board/gpio_pin_test.go
+++ b/components/board/gpio_pin_test.go
@@ -1,0 +1,29 @@
+package board_test
+
+import (
+	"testing"
+
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/components/board"
+)
+
+func TestValidatePWMDutyCycle(t *testing.T) {
+	// Normal values are unchanged
+	val, err := board.ValidatePWMDutyCycle(0.5)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, val, test.ShouldEqual, 0.5)
+
+	// No negative values
+	val, err = board.ValidatePWMDutyCycle(-1.0)
+	test.That(t, err, test.ShouldNotBeNil)
+
+	// Values slightly over 100% get rounded down
+	val, err = board.ValidatePWMDutyCycle(1.005)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, val, test.ShouldEqual, 1.0)
+
+	// No values well over 100%
+	val, err = board.ValidatePWMDutyCycle(2.0)
+	test.That(t, err, test.ShouldNotBeNil)
+}

--- a/components/board/gpio_pin_test.go
+++ b/components/board/gpio_pin_test.go
@@ -15,7 +15,7 @@ func TestValidatePWMDutyCycle(t *testing.T) {
 	test.That(t, val, test.ShouldEqual, 0.5)
 
 	// No negative values
-	val, err = board.ValidatePWMDutyCycle(-1.0)
+	_, err = board.ValidatePWMDutyCycle(-1.0)
 	test.That(t, err, test.ShouldNotBeNil)
 
 	// Values slightly over 100% get rounded down
@@ -24,6 +24,6 @@ func TestValidatePWMDutyCycle(t *testing.T) {
 	test.That(t, val, test.ShouldEqual, 1.0)
 
 	// No values well over 100%
-	val, err = board.ValidatePWMDutyCycle(2.0)
+	_, err = board.ValidatePWMDutyCycle(2.0)
 	test.That(t, err, test.ShouldNotBeNil)
 }

--- a/components/board/hat/pca9685/pca9685.go
+++ b/components/board/hat/pca9685/pca9685.go
@@ -6,7 +6,6 @@ package pca9685
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"sync"
 	"time"
@@ -340,17 +339,9 @@ func (gp *gpioPin) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[s
 	gp.pca.mu.RLock()
 	defer gp.pca.mu.RUnlock()
 
-	// Make sure the duty cycle we receive is believable.
-	if dutyCyclePct < 0.0 {
-		return errors.New("cannot set negative duty cycle")
-	}
-	if dutyCyclePct > 1.0 {
-		if dutyCyclePct < 1.01 {
-			// Someone was probably setting it to 1 and had a roundoff error.
-			dutyCyclePct = 1.0
-		} else {
-			return fmt.Errorf("cannot set duty cycle to %f: range is 0.0 to 1.0", dutyCyclePct)
-		}
+	dutyCyclePct, err := board.ValidatePWMDutyCycle(dutyCyclePct)
+	if err != nil {
+		return err
 	}
 
 	dutyCycle := uint16(dutyCyclePct * float64(0xffff))

--- a/components/board/pi/impl/board.go
+++ b/components/board/pi/impl/board.go
@@ -503,17 +503,9 @@ func (pi *piPigpio) SetPWMBcom(bcom int, dutyCyclePct float64) error {
 	pi.mu.Lock()
 	defer pi.mu.Unlock()
 
-	// Make sure the duty cycle we receive is believable.
-	if dutyCyclePct < 0.0 {
-		return errors.New("cannot set negative duty cycle")
-	}
-	if dutyCyclePct > 1.0 {
-		if dutyCyclePct < 1.01 {
-			// Someone was probably setting it to 1 and had a roundoff error.
-			dutyCyclePct = 1.0
-		} else {
-			return fmt.Errorf("cannot set duty cycle to %f: range is 0.0 to 1.0", dutyCyclePct)
-		}
+	dutyCyclePct, err := board.ValidatePWMDutyCycle(dutyCyclePct)
+	if err != nil {
+		return err
 	}
 
 	dutyCycle := rdkutils.ScaleByPct(255, dutyCyclePct)


### PR DESCRIPTION
The Jira ticket was specifically for the pinctrl module, but I think it should be generalized to all boards. So, here we go.

Thanks to @JohnN193 for the suggestion of calling "slightly over 1.0" a non-error value! If you want a different threshold for "slightly over," I'm happy to change it.

The rpi4 doesn't validate that the frequency is positive because apparently setting it to 0 already sets it to the default of 800 Hz, and it's a uint so can't be negative.

I haven't tested on actual hardware, but the new unit tests pass. I'm willing to test on hardware if you think it's important.