### PR TITLE
parallel projection is OK to include in static builds

### DIFF
--- a/rimage/transform/parallel_projection.go
+++ b/rimage/transform/parallel_projection.go
@@ -1,5 +1,3 @@
-//go:build !no_cgo
-
 package transform
 
 import (


### PR DESCRIPTION
`make full-static` passes on canon rdk-arm64