### PR TITLE
RSDK-4575: Add optional label path to vision service

### DIFF
--- a/.artifact/tree.json
+++ b/.artifact/tree.json
@@ -52265,6 +52265,10 @@
         "hash": "9b9d5e11ece4e6fe52246a2851636145",
         "size": 50
       },
+      "fakelabels_alt.txt": {
+        "hash": "810175e2c610f153320652b6132c1c95",
+        "size": 98
+      },
       "imagenetlabels.txt": {
         "hash": "93b03dc453206b6ce0cd083f96066544",
         "size": 23685

--- a/services/vision/mlvision/classifier.go
+++ b/services/vision/mlvision/classifier.go
@@ -37,7 +37,7 @@ func attemptToBuildClassifier(mlm mlmodel.Service,
 		return nil, errors.New("no input tensors received")
 	}
 	inType := md.Inputs[0].DataType
-	labels := getLabelsFromMetadata(md)
+	labels := getLabelsFromMetadata(md, params.LabelPath)
 	if shapeLen := len(md.Inputs[0].Shape); shapeLen < 4 {
 		return nil, errors.Errorf("invalid length of shape array (expected 4, got %d)", shapeLen)
 	}

--- a/services/vision/mlvision/detector.go
+++ b/services/vision/mlvision/detector.go
@@ -41,7 +41,7 @@ func attemptToBuildDetector(mlm mlmodel.Service,
 		return nil, errors.New("no input tensors received")
 	}
 	inType := md.Inputs[0].DataType
-	labels := getLabelsFromMetadata(md)
+	labels := getLabelsFromMetadata(md, params.LabelPath)
 	var boxOrder []int
 	if len(params.BoxOrder) == 4 {
 		boxOrder = params.BoxOrder

--- a/services/vision/mlvision/ml_model_test.go
+++ b/services/vision/mlvision/ml_model_test.go
@@ -500,7 +500,7 @@ func TestLabelReader(t *testing.T) {
 	outMD, err := out.Metadata(ctx)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, outMD, test.ShouldNotBeNil)
-	outLabels := getLabelsFromMetadata(outMD)
+	outLabels := getLabelsFromMetadata(outMD, "")
 	test.That(t, len(outLabels), test.ShouldEqual, 12)
 	test.That(t, outLabels[0], test.ShouldResemble, "this")
 	test.That(t, outLabels[1], test.ShouldResemble, "could")
@@ -522,7 +522,7 @@ func TestBlankLabelLines(t *testing.T) {
 	outMD, err := out.Metadata(ctx)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, outMD, test.ShouldNotBeNil)
-	outLabels := getLabelsFromMetadata(outMD)
+	outLabels := getLabelsFromMetadata(outMD, "")
 	test.That(t, len(outLabels), test.ShouldEqual, 91)
 	test.That(t, outLabels[0], test.ShouldResemble, "Person")
 	test.That(t, outLabels[1], test.ShouldResemble, "Bicycle")
@@ -535,7 +535,7 @@ func TestBlankLabelLines(t *testing.T) {
 	test.That(t, out, test.ShouldNotBeNil)
 	outMD, err = out.Metadata(ctx)
 	test.That(t, err, test.ShouldBeNil)
-	outLabels = getLabelsFromMetadata(outMD)
+	outLabels = getLabelsFromMetadata(outMD, "")
 	test.That(t, outLabels, test.ShouldBeNil)
 }
 
@@ -554,7 +554,7 @@ func TestSpaceDelineatedLabels(t *testing.T) {
 	outMD, err := out.Metadata(ctx)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, outMD, test.ShouldNotBeNil)
-	outLabels := getLabelsFromMetadata(outMD)
+	outLabels := getLabelsFromMetadata(outMD, "")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, len(outLabels), test.ShouldEqual, 10)
 }


### PR DESCRIPTION
This allows a non-breaking alternative for loading label files. 
The vision service now has an optional field called "label_path" which will over-write the labels from the meta data from the ml model (if they were present).

@acmorrow FYI 