### PR TITLE
use StoppableWorkers in vectornav/imu

### DIFF
--- a/components/movementsensor/imuvectornav/imu.go
+++ b/components/movementsensor/imuvectornav/imu.go
@@ -74,13 +74,12 @@ type vectornav struct {
 	spiMu   sync.Mutex
 	polling int
 
-	cancelFunc              func()
-	activeBackgroundWorkers sync.WaitGroup
-	bus                     buses.SPI
-	cs                      string
-	speed                   int
-	logger                  logging.Logger
-	busClosed               bool
+	workers   utils.StoppableWorkers
+	bus       buses.SPI
+	cs        string
+	speed     int
+	logger    logging.Logger
+	busClosed bool
 
 	bdVX float64
 	bdVY float64
@@ -212,16 +211,13 @@ func newVectorNav(
 	if err != nil {
 		return nil, err
 	}
-	var cancelCtx context.Context
-	cancelCtx, v.cancelFunc = context.WithCancel(context.Background())
+
 	// optionally start a polling goroutine
 	if pfreq > 0 {
 		logger.CDebugf(ctx, "vecnav: will pool at %d Hz", pfreq)
 		waitCh := make(chan struct{})
 		s := 1.0 / float64(pfreq)
-		v.activeBackgroundWorkers.Add(1)
-		goutils.PanicCapturingGo(func() {
-			defer v.activeBackgroundWorkers.Done()
+		v.workers = utils.NewStoppableWorkers(func(cancelCtx context.Context) {
 			timer := time.NewTicker(time.Duration(s * float64(time.Second)))
 			defer timer.Stop()
 			close(waitCh)
@@ -539,9 +535,8 @@ func (vn *vectornav) compensateDVBias(ctx context.Context, smpSize uint) error {
 
 func (vn *vectornav) Close(ctx context.Context) error {
 	vn.logger.CDebug(ctx, "closing vecnav imu")
-	vn.cancelFunc()
 	vn.busClosed = true
-	vn.activeBackgroundWorkers.Wait()
+	vn.workers.Stop()
 	vn.logger.CDebug(ctx, "closed vecnav imu")
 	return nil
 }


### PR DESCRIPTION
This all compiles, but I don't know how to test it out on real hardware. I'm willing to do that if you think it's important, but my hope is the change is simple enough that we can skip it.

I don't think this PR actually fixes any bugs or race conditions: the old code looked right to me. but I also think the new version is simpler to reason about.

Github suggests that @dgottlieb should review this; if you disagree, feel free to remove yourself and add someone else.