### PR TITLE
Data-2818: Get training logs

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -1034,6 +1034,19 @@ var app = &cli.App{
 					Action: DataGetTrainingJob,
 				},
 				{
+					Name:      "logs",
+					Usage:     "gets training job logs from Viam cloud based on training job ID",
+					UsageText: createUsageText("train logs", []string{trainFlagJobID}, false),
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:     trainFlagJobID,
+							Usage:    "training job ID",
+							Required: true,
+						},
+					},
+					Action: DataGetTrainingJobLogs,
+				},
+				{
 					Name:      "cancel",
 					Usage:     "cancels training job in Viam cloud based on training job ID",
 					UsageText: createUsageText("train cancel", []string{trainFlagJobID}, false),

--- a/cli/app.go
+++ b/cli/app.go
@@ -1044,7 +1044,7 @@ var app = &cli.App{
 							Required: true,
 						},
 					},
-					Action: DataGetTrainingJobLogs,
+					Action: MLGetTrainingJobLogs,
 				},
 				{
 					Name:      "cancel",

--- a/cli/ml_training.go
+++ b/cli/ml_training.go
@@ -11,6 +11,7 @@ import (
 	"github.com/urfave/cli/v2"
 	"go.uber.org/multierr"
 	mltrainingpb "go.viam.com/api/app/mltraining/v1"
+	packagespb "go.viam.com/api/app/packages/v1"
 	v1 "go.viam.com/api/app/v1"
 	"google.golang.org/protobuf/types/known/structpb"
 )
@@ -51,16 +52,24 @@ func MLSubmitCustomTrainingJobWithUpload(c *cli.Context) error {
 		return err
 	}
 
-	err = client.uploadTrainingScript(true, c.String(trainFlagModelType), c.String(mlTrainingFlagFramework),
-		c.String(trainFlagModelOrgID), c.String(mlTrainingFlagName), c.String(mlTrainingFlagVersion),
-		c.Path(mlTrainingFlagPath))
+	resp, err := client.uploadTrainingScript(true, c.String(trainFlagModelType), c.String(mlTrainingFlagFramework),
+		c.String(mlTrainingFlagURL), c.String(trainFlagModelOrgID), c.String(mlTrainingFlagName),
+		c.String(mlTrainingFlagVersion), c.Path(mlTrainingFlagPath))
 	if err != nil {
 		return err
 	}
 	registryItemID := fmt.Sprintf("%s:%s", c.String(trainFlagModelOrgID), c.String(mlTrainingFlagName))
-	printf(c.App.Writer, "successfully uploaded training script to %s", registryItemID)
+
+	moduleID := moduleID{
+		prefix: c.String(generalFlagOrgID),
+		name:   c.String(mlTrainingFlagName),
+	}
+	url := moduleID.ToDetailURL(client.baseURL.Hostname(), PackageTypeMLTraining)
+	printf(c.App.Writer, "Version successfully uploaded! you can view your changes online here: %s. \n"+
+		"To use your training script in the from-registry command, use %s as the script name", url,
+		registryItemID)
 	trainingJobID, err := client.mlSubmitCustomTrainingJob(
-		c.String(datasetFlagDatasetID), registryItemID, c.String(mlTrainingFlagVersion), c.String(trainFlagModelOrgID),
+		c.String(datasetFlagDatasetID), registryItemID, resp.Version, c.String(trainFlagModelOrgID),
 		c.String(trainFlagModelName), c.String(trainFlagModelVersion))
 	if err != nil {
 		return err
@@ -120,6 +129,12 @@ func (c *viamClient) mlSubmitCustomTrainingJob(datasetID, registryItemID, regist
 ) (string, error) {
 	if err := c.ensureLoggedIn(); err != nil {
 		return "", err
+	}
+	splitName := strings.Split(registryItemID, ":")
+	if len(splitName) != 2 {
+		return "", errors.Errorf("invalid training script name '%s'."+
+			" Training script name must be in the form 'public-namespace:registry-name' for public training scripts"+
+			" or 'org-id:registry-name' for private training scripts in organizations without a public namespace", registryItemID)
 	}
 	if modelVersion == "" {
 		modelVersion = time.Now().Format("2006-01-02T15-04-05")
@@ -196,7 +211,8 @@ func (c *viamClient) dataGetTrainingJobLogs(trainingJobID string) ([]*mltraining
 
 	// Loop to fetch and accumulate results
 	for {
-		resp, err := c.mlTrainingClient.GetTrainingJobLogs(context.Background(), &mltrainingpb.GetTrainingJobLogsRequest{Id: trainingJobID, PageToken: &page})
+		resp, err := c.mlTrainingClient.GetTrainingJobLogs(context.Background(),
+			&mltrainingpb.GetTrainingJobLogsRequest{Id: trainingJobID, PageToken: &page})
 		if err != nil {
 			return nil, err
 		}
@@ -296,8 +312,8 @@ func MLTrainingUploadAction(c *cli.Context) error {
 		return err
 	}
 
-	err = client.uploadTrainingScript(c.Bool(mlTrainingFlagDraft), c.String(mlTrainingFlagType),
-		c.String(mlTrainingFlagFramework), c.String(generalFlagOrgID), c.String(mlTrainingFlagName),
+	_, err = client.uploadTrainingScript(c.Bool(mlTrainingFlagDraft), c.String(mlTrainingFlagType),
+		c.String(mlTrainingFlagFramework), c.String(mlTrainingFlagURL), c.String(generalFlagOrgID), c.String(mlTrainingFlagName),
 		c.String(mlTrainingFlagVersion), c.Path(mlTrainingFlagPath),
 	)
 	if err != nil {
@@ -309,30 +325,35 @@ func MLTrainingUploadAction(c *cli.Context) error {
 		name:   c.String(mlTrainingFlagName),
 	}
 	url := moduleID.ToDetailURL(client.baseURL.Hostname(), PackageTypeMLTraining)
-	printf(c.App.Writer, "Version successfully uploaded! you can view your changes online here: %s", url)
+	printf(c.App.Writer, "Version successfully uploaded! you can view your changes online here: %s. \n"+
+		"To use your training script in the from-registry command, use %s:%s as the script name", url,
+		moduleID.prefix, moduleID.name)
 	return nil
 }
 
-func (c *viamClient) uploadTrainingScript(draft bool, modelType, framework, orgID, name, version, path string) error {
-	metadata, err := createMetadata(draft, modelType, framework)
+func (c *viamClient) uploadTrainingScript(draft bool, modelType, framework, url, orgID, name, version, path string) (
+	*packagespb.CreatePackageResponse, error,
+) {
+	metadata, err := createMetadata(draft, modelType, framework, url)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	metadataStruct, err := convertMetadataToStruct(*metadata)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	if _, err := c.uploadPackage(orgID,
+	resp, err := c.uploadPackage(orgID,
 		name,
 		version,
 		string(PackageTypeMLTraining),
 		path,
 		metadataStruct,
-	); err != nil {
-		return err
+	)
+	if err != nil {
+		return nil, err
 	}
-	return nil
+	return resp, nil
 }
 
 // MLTrainingUpdateAction updates the visibility of training scripts.
@@ -343,7 +364,7 @@ func MLTrainingUpdateAction(c *cli.Context) error {
 	}
 
 	err = client.updateTrainingScript(c.String(generalFlagOrgID), c.String(mlTrainingFlagName),
-		c.String(mlTrainingFlagVisibility), c.String(mlTrainingFlagDescription),
+		c.String(mlTrainingFlagVisibility), c.String(mlTrainingFlagDescription), c.String(mlTrainingFlagURL),
 	)
 	if err != nil {
 		return err
@@ -358,7 +379,7 @@ func MLTrainingUpdateAction(c *cli.Context) error {
 	return nil
 }
 
-func (c *viamClient) updateTrainingScript(orgID, name, visibility, description string) error {
+func (c *viamClient) updateTrainingScript(orgID, name, visibility, description, url string) error {
 	if err := c.ensureLoggedIn(); err != nil {
 		return err
 	}
@@ -371,17 +392,23 @@ func (c *viamClient) updateTrainingScript(orgID, name, visibility, description s
 	if err != nil {
 		return err
 	}
+	visibilityProto, err := convertVisibilityToProto(visibility)
+	if err != nil {
+		return err
+	}
 	// Get and validate description and visibility
 	updatedDescription := resp.GetItem().GetDescription()
 	if description != "" {
 		updatedDescription = description
 	}
-	if updatedDescription == "" {
+	if updatedDescription == "" && *visibilityProto == v1.Visibility_VISIBILITY_PUBLIC {
 		return errors.New("no existing description for registry item, description must be provided")
 	}
-	visibilityProto, err := convertVisibilityToProto(visibility)
-	if err != nil {
-		return err
+	var stringURL *string
+	if url != "" {
+		stringURL = &url
+	} else {
+		stringURL = nil
 	}
 	// Update registry item
 	if _, err = c.client.UpdateRegistryItem(c.c.Context, &v1.UpdateRegistryItemRequest{
@@ -389,6 +416,7 @@ func (c *viamClient) updateTrainingScript(orgID, name, visibility, description s
 		Type:        resp.GetItem().GetType(),
 		Description: updatedDescription,
 		Visibility:  *visibilityProto,
+		Url:         stringURL,
 	}); err != nil {
 		return err
 	}
@@ -433,9 +461,10 @@ type MLMetadata struct {
 	Draft     bool
 	ModelType string
 	Framework string
+	URL       string
 }
 
-func createMetadata(draft bool, modelType, framework string) (*MLMetadata, error) {
+func createMetadata(draft bool, modelType, framework, url string) (*MLMetadata, error) {
 	t, typeErr := findValueOrSetDefault(modelTypes, modelType, string(ModelTypeUnspecified))
 	f, frameWorkErr := findValueOrSetDefault(modelFrameworks, framework, string(ModelFrameworkUnspecified))
 
@@ -447,6 +476,7 @@ func createMetadata(draft bool, modelType, framework string) (*MLMetadata, error
 		Draft:     draft,
 		ModelType: t,
 		Framework: f,
+		URL:       url,
 	}, nil
 }
 
@@ -468,6 +498,7 @@ var (
 	modelTypeKey      = "model_type"
 	modelFrameworkKey = "model_framework"
 	draftKey          = "draft"
+	urlKey            = "url"
 )
 
 func convertMetadataToStruct(metadata MLMetadata) (*structpb.Struct, error) {
@@ -475,6 +506,7 @@ func convertMetadataToStruct(metadata MLMetadata) (*structpb.Struct, error) {
 	metadataMap[modelTypeKey] = metadata.ModelType
 	metadataMap[modelFrameworkKey] = metadata.Framework
 	metadataMap[draftKey] = metadata.Draft
+	metadataMap[urlKey] = metadata.URL
 	metadataStruct, err := structpb.NewStruct(metadataMap)
 	if err != nil {
 		return nil, err

--- a/cli/ml_training.go
+++ b/cli/ml_training.go
@@ -181,7 +181,7 @@ func (c *viamClient) dataGetTrainingJob(trainingJobID string) (*mltrainingpb.Tra
 	return resp.Metadata, nil
 }
 
-// DataGetTrainingJob is the corresponding action for 'data train logs'.
+// MLGetTrainingJobLogs is the corresponding action for 'data train logs'.
 func MLGetTrainingJobLogs(c *cli.Context) error {
 	client, err := newViamClient(c)
 	if err != nil {
@@ -201,7 +201,7 @@ func MLGetTrainingJobLogs(c *cli.Context) error {
 	return nil
 }
 
-// dataGetTrainingJob gets the training job logs with the given ID.
+// mlGetTrainingJobLogs gets the training job logs with the given ID.
 func (c *viamClient) mlGetTrainingJobLogs(trainingJobID string) ([]*mltrainingpb.TrainingJobLogEntry, error) {
 	if err := c.ensureLoggedIn(); err != nil {
 		return nil, err

--- a/cli/ml_training.go
+++ b/cli/ml_training.go
@@ -182,12 +182,12 @@ func (c *viamClient) dataGetTrainingJob(trainingJobID string) (*mltrainingpb.Tra
 }
 
 // DataGetTrainingJob is the corresponding action for 'data train logs'.
-func DataGetTrainingJobLogs(c *cli.Context) error {
+func MLGetTrainingJobLogs(c *cli.Context) error {
 	client, err := newViamClient(c)
 	if err != nil {
 		return err
 	}
-	logs, err := client.dataGetTrainingJobLogs(c.String(trainFlagJobID))
+	logs, err := client.mlGetTrainingJobLogs(c.String(trainFlagJobID))
 	if err != nil {
 		return err
 	}
@@ -202,7 +202,7 @@ func DataGetTrainingJobLogs(c *cli.Context) error {
 }
 
 // dataGetTrainingJob gets the training job logs with the given ID.
-func (c *viamClient) dataGetTrainingJobLogs(trainingJobID string) ([]*mltrainingpb.TrainingJobLogEntry, error) {
+func (c *viamClient) mlGetTrainingJobLogs(trainingJobID string) ([]*mltrainingpb.TrainingJobLogEntry, error) {
 	if err := c.ensureLoggedIn(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This returns all the logs for a given training job id.

Tested with: `go run cli/viam/main.go train logs --job-id=66cce7012df448bf1e4b6b5d` 

<img width="1568" alt="Screenshot 2024-08-26 at 5 08 12 PM" src="https://github.com/user-attachments/assets/ccb368e5-9e98-4ac1-9a2c-91e07927346c">
