### PR TITLE
Making sense of the error

### DIFF
--- a/components/base/sensorcontrolled/movestraight.go
+++ b/components/base/sensorcontrolled/movestraight.go
@@ -100,9 +100,10 @@ func (sb *sensorBase) MoveStraight(
 	for {
 		select {
 		case <-ctx.Done():
-			// do not return context canceled errors, just log them
+			// context.cancelled can happen due to UI being closed during MoveStraight.
+			// Do not return context canceled errors, just log them
 			if errors.Is(ctx.Err(), context.Canceled) {
-				sb.logger.Error(ctx.Err())
+				sb.logger.Warn(ctx.Err())
 				return nil
 			}
 			return ctx.Err()

--- a/components/base/sensorcontrolled/movestraight.go
+++ b/components/base/sensorcontrolled/movestraight.go
@@ -103,7 +103,7 @@ func (sb *sensorBase) MoveStraight(
 			// context.cancelled can happen due to UI being closed during MoveStraight.
 			// Do not return context canceled errors, just log them
 			if errors.Is(ctx.Err(), context.Canceled) {
-				sb.logger.Warn(ctx.Err())
+				sb.logger.Warnf("Context cancelled during MoveStraight ", ctx.Err())
 				return nil
 			}
 			return ctx.Err()

--- a/components/base/sensorcontrolled/spin.go
+++ b/components/base/sensorcontrolled/spin.go
@@ -82,9 +82,10 @@ func (sb *sensorBase) Spin(ctx context.Context, angleDeg, degsPerSec float64, ex
 
 		select {
 		case <-ctx.Done():
-			// do not return context canceled errors, just log them
+			// context.cancelled can happen due to UI being closed during Spin.
+			// Do not return context canceled errors, just log them
 			if errors.Is(ctx.Err(), context.Canceled) {
-				sb.logger.Error(ctx.Err())
+				sb.logger.Warn(ctx.Err())
 				return nil
 			}
 			return err

--- a/components/base/sensorcontrolled/spin.go
+++ b/components/base/sensorcontrolled/spin.go
@@ -85,7 +85,7 @@ func (sb *sensorBase) Spin(ctx context.Context, angleDeg, degsPerSec float64, ex
 			// context.cancelled can happen due to UI being closed during Spin.
 			// Do not return context canceled errors, just log them
 			if errors.Is(ctx.Err(), context.Canceled) {
-				sb.logger.Warn(ctx.Err())
+				sb.logger.Warn("Context cancelled during Spin ", ctx.Err())
 				return nil
 			}
 			return err

--- a/components/base/wheeled/wheeled_base.go
+++ b/components/base/wheeled/wheeled_base.go
@@ -315,7 +315,7 @@ func (wb *wheeledBase) runAllGoFor(ctx context.Context, leftRPM, leftRotations, 
 		}
 		// Log the context canceled error as a warning.
 		// This can happen when the UI is closed or something went wrong during the operation.
-		wb.logger.Warn(err)
+		wb.logger.Warnf("Context cancelled during GoFor ", err)
 	}
 	return nil
 }
@@ -361,7 +361,7 @@ func (wb *wheeledBase) runAllSetRPM(ctx context.Context, leftRPM, rightRPM float
 		}
 		// Log the context canceled error as a warning.
 		// This can happen when the UI is closed or something went wrong during the operation.
-		wb.logger.Warn(err)
+		wb.logger.Warn("Context cancelled during SetRPM ", err)
 	}
 	return nil
 }

--- a/components/base/wheeled/wheeled_base.go
+++ b/components/base/wheeled/wheeled_base.go
@@ -313,6 +313,9 @@ func (wb *wheeledBase) runAllGoFor(ctx context.Context, leftRPM, leftRotations, 
 		if !errors.Is(err, context.Canceled) {
 			return err
 		}
+		// Log the context canceled error as a warning.
+		// This can happen when the UI is closed or something went wrong during the operation.
+		wb.logger.Warn(err)
 	}
 	return nil
 }
@@ -356,6 +359,9 @@ func (wb *wheeledBase) runAllSetRPM(ctx context.Context, leftRPM, rightRPM float
 		if !errors.Is(err, context.Canceled) {
 			return err
 		}
+		// Log the context canceled error as a warning.
+		// This can happen when the UI is closed or something went wrong during the operation.
+		wb.logger.Warn(err)
 	}
 	return nil
 }


### PR DESCRIPTION
When running sensor_controlled base, I ran into the following error 
```
8/28/2024, 3:19:00 PM error rdk.resource_manager.rdk:component:base/sensor-controlled sensorcontrolled/movestraight.go:105 context canceled 
``` 
I didn't have any idea to why this error was occurring. After talking with @JohnN193 I understand that when we switch away from the UI this error is surfaced. There are also possibility of some other reason why the context was cancelled, which is why it is surfaced. 

### Changes
- changed the error to a warning
- Added comments around the why we may wanna ignore it. 
- resurfaced the  warning in wheeled base. 