### PR TITLE
RSDK-8372 - Test RuntimeError: go.viam.com/rdk/services/navigation/builtin.TestStartWaypoint/Reach_waypoints_successfully

### DIFF
--- a/services/navigation/builtin/builtin.go
+++ b/services/navigation/builtin/builtin.go
@@ -591,6 +591,8 @@ func (svc *builtIn) moveToWaypoint(ctx context.Context, wp navigation.Waypoint, 
 	// call StopPlan upon exiting moveOnGlobeSync
 	// is a NoOp if execution has already terminted
 	defer func() {
+		svc.mu.Lock()
+		defer svc.mu.Unlock()
 		timeoutCtx, timeoutCancelFn := context.WithTimeout(context.Background(), time.Second*5)
 		defer timeoutCancelFn()
 		err := svc.motionService.StopPlan(timeoutCtx, motion.StopPlanReq{ComponentName: req.ComponentName})


### PR DESCRIPTION
Explanation of the runtime error:
the nil pointer dereference happens when we called `paths, err := s.ns.Paths(ctx, nil)` (https://github.com/viamrobotics/rdk/blob/main/services/navigation/builtin/builtin_test.go#L1029)
Specifically, we query the `rawExecutionWaypoint` with `rawExecutionWaypoint := svc.activeExecutionWaypoint.Load()`  (https://github.com/viamrobotics/rdk/blob/main/services/navigation/builtin/builtin.go#L841).
The test expects the `rawExecutionWaypoint` to be nil or the `emptyExecutionWayPoint`, but it is not.
We then proceed further in the function and encounter the nil pointer dereference.

------------------------------------------------------------------------------------------

What **should** be happening:
Within `moveToWaypoint` we swap the `activeExecutionWaypoint` here for the first time (https://github.com/viamrobotics/rdk/blob/main/services/navigation/builtin/builtin.go#L586)
We then _declare a deferred function_ that swaps again (https://github.com/viamrobotics/rdk/blob/main/services/navigation/builtin/builtin.go#L601)
This deferred function is only called after `svc.waypointReached(cancelCtx)`, i.e. once we are done returning from `moveToWaypoint`
We then enter `Paths` and query the `rawExecutionWaypoint`

------------------------------------------------------------------------------------------

What **was** happening:
Within `moveToWaypoint` we swap the `activeExecutionWaypoint` here for the first time (https://github.com/viamrobotics/rdk/blob/main/services/navigation/builtin/builtin.go#L586)
We then _declare a deferred function_ that swaps again (https://github.com/viamrobotics/rdk/blob/main/services/navigation/builtin/builtin.go#L601)
This deferred function is only called after `svc.waypointReached(cancelCtx)`, i.e. once we are done returning from `moveToWaypoint`
We entered `Paths` and queried for the `rawExecutionWaypoint` **_before_** the deferred function was done executing, i.e. before it was done swapping.


Hence the fix is to add a mutex on the deferred function.