### PR TITLE
RSDK-8592 Make single encoder tick even without motor 

### DIFF
--- a/components/encoder/single/single_encoder.go
+++ b/components/encoder/single/single_encoder.go
@@ -208,7 +208,8 @@ func (e *Encoder) start(ctx context.Context, b board.Board) {
 					atomic.AddInt64(&e.position, dir)
 				}
 			} else {
-				e.logger.CDebug(ctx, "received tick for encoder that isn't connected to a motor; ignoring")
+				// no motor is attached to the encoder - increase in positive direction.
+				atomic.AddInt64(&e.position, 1)
 			}
 		}
 	})


### PR DESCRIPTION
Previously, we ignored all ticks from the single encoder if it wasn't attached to a motor. This has caused confusion for users, so making the encoder tick in the positive direction even without a motor. 