### PR TITLE
Ignore direnv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ web/cmd/server/*.core
 # gomobile / android
 *.aar
 *.jar
+
+# direnv (optional dev tool)
+.envrc


### PR DESCRIPTION
I use [this tool](https://direnv.net) sometimes to load per-project environment variables. Add to `.gitignore` for convenience.