### PR TITLE
bump min golang

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.viam.com/rdk
 
-go 1.21
+go 1.21.13
 
 require (
 	github.com/AlekSi/gocov-xml v1.0.0


### PR DESCRIPTION
## What changed
- bump go.mod min to 1.21.13
## Why
- netip vuln https://pkg.go.dev/vuln/GO-2024-2887