### PR TITLE
DOCS-2498: Link to main component documentation on RDK docs site

### DIFF
--- a/components/arm/arm.go
+++ b/components/arm/arm.go
@@ -51,6 +51,7 @@ func Named(name string) resource.Name {
 }
 
 // An Arm represents a physical robotic arm that exists in three-dimensional space.
+// For more information, see the [arm component docs].
 //
 // EndPosition example:
 //
@@ -90,6 +91,8 @@ func Named(name string) resource.Name {
 //
 //	// Get the current position of each joint on the arm as JointPositions.
 //	pos, err := myArm.JointPositions(context.Background(), nil)
+//
+// [arm component docs]: https://docs.viam.com/components/arm/
 type Arm interface {
 	resource.Resource
 	referenceframe.ModelFramer

--- a/components/arm/arm.go
+++ b/components/arm/arm.go
@@ -1,6 +1,9 @@
 //go:build !no_cgo
 
 // Package arm defines the arm that a robot uses to manipulate objects.
+// For more information, see the [Arm Component].
+//
+// [Arm Component]: https://docs.viam.com/components/arm/
 package arm
 
 import (

--- a/components/arm/arm.go
+++ b/components/arm/arm.go
@@ -1,9 +1,9 @@
 //go:build !no_cgo
 
 // Package arm defines the arm that a robot uses to manipulate objects.
-// For more information, see the [Arm Component].
+// For more information, see the [arm component docs].
 //
-// [Arm Component]: https://docs.viam.com/components/arm/
+// [arm component docs]: https://docs.viam.com/components/arm/
 package arm
 
 import (

--- a/components/base/base.go
+++ b/components/base/base.go
@@ -37,6 +37,7 @@ func Named(name string) resource.Name {
 }
 
 // A Base represents a physical base of a robot.
+// For more information, see the [base component docs].
 //
 // MoveStraight example:
 //
@@ -96,6 +97,8 @@ func Named(name string) resource.Name {
 //
 //	// Get the wheel circumference
 //	myBaseWheelCircumference := properties.WheelCircumferenceMeters
+//
+// [base component docs]: https://docs.viam.com/components/base/
 type Base interface {
 	resource.Resource
 	resource.Actuator

--- a/components/base/base.go
+++ b/components/base/base.go
@@ -1,4 +1,7 @@
 // Package base defines the base that a robot uses to move around.
+// For more information, see the [Base Component].
+//
+// [Base Component]: https://docs.viam.com/components/base/
 package base
 
 import (

--- a/components/base/base.go
+++ b/components/base/base.go
@@ -1,7 +1,7 @@
 // Package base defines the base that a robot uses to move around.
-// For more information, see the [Base Component].
+// For more information, see the [base component docs].
 //
-// [Base Component]: https://docs.viam.com/components/base/
+// [base component docs]: https://docs.viam.com/components/base/
 package base
 
 import (

--- a/components/board/board.go
+++ b/components/board/board.go
@@ -49,6 +49,7 @@ func Named(name string) resource.Name {
 
 // A Board represents a physical general purpose board that contains various
 // components such as analogs, and digital interrupts.
+// For more information, see the [board component docs].
 //
 // AnalogByName example:
 //
@@ -96,6 +97,8 @@ func Named(name string) resource.Name {
 //	}
 //
 //	err = myBoard.StreamTicks(context.Background(), interrupts, ticksChan, nil)
+//
+// [board component docs]: https://docs.viam.com/components/board/
 type Board interface {
 	resource.Resource
 

--- a/components/board/board.go
+++ b/components/board/board.go
@@ -2,9 +2,9 @@
 // such as a Raspberry Pi.
 //
 // Besides the board itself, some other interfaces it defines are analog pins and digital interrupts.
-// For more information, see the [Board Component].
+// For more information, see the [board component docs].
 //
-// [Board Component]: https://docs.viam.com/components/board/
+// [board component docs]: https://docs.viam.com/components/board/
 package board
 
 import (

--- a/components/board/board.go
+++ b/components/board/board.go
@@ -2,6 +2,9 @@
 // such as a Raspberry Pi.
 //
 // Besides the board itself, some other interfaces it defines are analog pins and digital interrupts.
+// For more information, see the [Board Component].
+//
+// [Board Component]: https://docs.viam.com/components/board/
 package board
 
 import (

--- a/components/camera/camera.go
+++ b/components/camera/camera.go
@@ -1,4 +1,7 @@
 // Package camera defines an image capturing device.
+// For more information, see the [Camera Component].
+//
+// [Camera Component]: https://docs.viam.com/components/camera/
 package camera
 
 import (

--- a/components/camera/camera.go
+++ b/components/camera/camera.go
@@ -78,6 +78,7 @@ type Camera interface {
 }
 
 // A VideoSource represents anything that can capture frames.
+// For more information, see the [camera component docs].
 //
 // Images example:
 //
@@ -108,6 +109,8 @@ type Camera interface {
 //	myCamera, err := camera.FromRobot(machine, "my_camera")
 //
 //	err = myCamera.Close(ctx)
+//
+// [camera component docs]: https://docs.viam.com/components/camera/
 type VideoSource interface {
 	// Images is used for getting simultaneous images from different imagers,
 	// along with associated metadata (just timestamp for now). It's not for getting a time series of images from the same imager.

--- a/components/camera/camera.go
+++ b/components/camera/camera.go
@@ -1,7 +1,7 @@
 // Package camera defines an image capturing device.
-// For more information, see the [Camera Component].
+// For more information, see the [camera component docs].
 //
-// [Camera Component]: https://docs.viam.com/components/camera/
+// [camera component docs]: https://docs.viam.com/components/camera/
 package camera
 
 import (

--- a/components/encoder/encoder.go
+++ b/components/encoder/encoder.go
@@ -1,7 +1,7 @@
 // Package encoder implements the encoder component.
-// For more information, see the [Encoder Component].
+// For more information, see the [encoder component docs].
 //
-// [Encoder Component]: https://docs.viam.com/components/encoder/
+// [encoder component docs]: https://docs.viam.com/components/encoder/
 package encoder
 
 import (

--- a/components/encoder/encoder.go
+++ b/components/encoder/encoder.go
@@ -1,4 +1,7 @@
-// Package encoder implements the encoder component
+// Package encoder implements the encoder component.
+// For more information, see the [Encoder Component].
+//
+// [Encoder Component]: https://docs.viam.com/components/encoder/
 package encoder
 
 import (

--- a/components/encoder/encoder.go
+++ b/components/encoder/encoder.go
@@ -61,6 +61,7 @@ func (t PositionType) String() string {
 }
 
 // A Encoder turns a position into a signal.
+// For more information, see the [encoder component docs].
 //
 // Position example:
 //
@@ -87,6 +88,8 @@ func (t PositionType) String() string {
 //
 //	// Get whether the encoder returns position in ticks or degrees.
 //	properties, err := myEncoder.Properties(context.Background(), nil)
+//
+// [encoder component docs]: https://docs.viam.com/components/encoder/
 type Encoder interface {
 	resource.Resource
 

--- a/components/gantry/gantry.go
+++ b/components/gantry/gantry.go
@@ -1,4 +1,4 @@
-// Gantry defines a robotic gantry with one or multiple axes.
+// Package gantry defines a robotic gantry with one or multiple axes.
 // For more information, see the [Gantry Component].
 //
 // [Gantry Component]: https://docs.viam.com/components/gantry/

--- a/components/gantry/gantry.go
+++ b/components/gantry/gantry.go
@@ -45,6 +45,7 @@ func Named(name string) resource.Name {
 }
 
 // Gantry is used for controlling gantries of N axis.
+// For more information, see the [gantry component docs].
 //
 // Position example:
 //
@@ -78,6 +79,8 @@ func Named(name string) resource.Name {
 //	myGantry, err := gantry.FromRobot(machine, "my_gantry")
 //
 //	myGantry.Home(context.Background(), nil)
+//
+// [gantry component docs]: https://docs.viam.com/components/gantry/
 type Gantry interface {
 	resource.Resource
 	resource.Actuator

--- a/components/gantry/gantry.go
+++ b/components/gantry/gantry.go
@@ -1,3 +1,7 @@
+// Gantry defines a robotic gantry with one or multiple axes.
+// For more information, see the [Gantry Component].
+//
+// [Gantry Component]: https://docs.viam.com/components/gantry/
 package gantry
 
 import (

--- a/components/gantry/gantry.go
+++ b/components/gantry/gantry.go
@@ -1,7 +1,7 @@
 // Package gantry defines a robotic gantry with one or multiple axes.
-// For more information, see the [Gantry Component].
+// For more information, see the [gantry component docs].
 //
-// [Gantry Component]: https://docs.viam.com/components/gantry/
+// [gantry component docs]: https://docs.viam.com/components/gantry/
 package gantry
 
 import (

--- a/components/generic/generic.go
+++ b/components/generic/generic.go
@@ -1,7 +1,7 @@
 // Package generic defines an abstract generic device and DoCommand() method.
-// For more information, see the [Generic Component].
+// For more information, see the [generic component docs].
 //
-// [Generic Component]: https://docs.viam.com/components/generic/
+// [generic component docs]: https://docs.viam.com/components/generic/
 package generic
 
 import (

--- a/components/generic/generic.go
+++ b/components/generic/generic.go
@@ -1,4 +1,7 @@
-// Package generic defines an abstract generic device and DoCommand() method
+// Package generic defines an abstract generic device and DoCommand() method.
+// For more information, see the [Generic Component].
+//
+// [Generic Component]: https://docs.viam.com/components/generic/
 package generic
 
 import (

--- a/components/gripper/gripper.go
+++ b/components/gripper/gripper.go
@@ -1,7 +1,7 @@
 // Package gripper defines a robotic gripper.
-// For more information, see the [Gripper Component].
+// For more information, see the [gripper component docs].
 //
-// [Gripper Component]: https://docs.viam.com/components/gripper/
+// [gripper component docs]: https://docs.viam.com/components/gripper/
 package gripper
 
 import (

--- a/components/gripper/gripper.go
+++ b/components/gripper/gripper.go
@@ -37,6 +37,7 @@ func Named(name string) resource.Name {
 }
 
 // A Gripper represents a physical robotic gripper.
+// For more information, see the [gripper component docs].
 //
 // Open example:
 //
@@ -47,6 +48,8 @@ func Named(name string) resource.Name {
 //
 //	// Grab with the gripper.
 //	grabbed, err := myGripper.Grab(context.Background(), nil)
+//
+// [gripper component docs]: https://docs.viam.com/components/gripper/
 type Gripper interface {
 	resource.Resource
 	resource.Shaped

--- a/components/gripper/gripper.go
+++ b/components/gripper/gripper.go
@@ -1,4 +1,7 @@
 // Package gripper defines a robotic gripper.
+// For more information, see the [Gripper Component].
+//
+// [Gripper Component]: https://docs.viam.com/components/gripper/
 package gripper
 
 import (


### PR DESCRIPTION
* Links to main component docs from arm --> gripper
* Does the same in examples section everywhere except for generic bc no examples