### PR TITLE
RSDK-8699: Cannot go to gantry position 0.0, only 0.2+.

### DIFF
--- a/components/gantry/singleaxis/singleaxis.go
+++ b/components/gantry/singleaxis/singleaxis.go
@@ -546,13 +546,13 @@ func (g *singleAxis) MoveToPosition(ctx context.Context, positions, speeds []flo
 	if len(g.limitSwitchPins) > 0 {
 		// Stops if position x is past the 0 limit switch
 		if x < g.positionLimits[0] {
-			err := errors.New("cannot move past limit switch!")
+			err := errors.New("cannot move past limit switch")
 			return multierr.Combine(err, g.motor.Stop(ctx, extra))
 		}
 
 		// Stops if position x is past the at-length limit switch
 		if x > g.positionLimits[1] {
-			err := errors.New("cannot move past limit switch!")
+			err := errors.New("cannot move past limit switch")
 			return multierr.Combine(err, g.motor.Stop(ctx, extra))
 		}
 	}

--- a/components/gantry/singleaxis/singleaxis.go
+++ b/components/gantry/singleaxis/singleaxis.go
@@ -546,13 +546,13 @@ func (g *singleAxis) MoveToPosition(ctx context.Context, positions, speeds []flo
 	if len(g.limitSwitchPins) > 0 {
 		// Stops if position x is past the 0 limit switch
 		if x < g.positionLimits[0] {
-			err := errors.New("Cannot move past limit switch!")
+			err := errors.New("cannot move past limit switch!")
 			return multierr.Combine(err, g.motor.Stop(ctx, extra))
 		}
 
 		// Stops if position x is past the at-length limit switch
 		if x > g.positionLimits[1] {
-			err := errors.New("Cannot move past limit switch!")
+			err := errors.New("cannot move past limit switch!")
 			return multierr.Combine(err, g.motor.Stop(ctx, extra))
 		}
 	}

--- a/components/gantry/singleaxis/singleaxis.go
+++ b/components/gantry/singleaxis/singleaxis.go
@@ -31,7 +31,7 @@ var (
 )
 
 // limitErrorMargin is added or subtracted from the location of the limit switch to ensure the switch is not passed.
-const limitErrorMargin = 0.25
+const limitErrorMargin = 0.0
 
 // Config is used for converting singleAxis config attributes.
 type Config struct {
@@ -372,7 +372,7 @@ func (g *singleAxis) homeLimSwitch(ctx context.Context) error {
 	if g.positionRange == 0 {
 		g.logger.CError(ctx, "positionRange is 0 or not a valid number")
 	} else {
-		g.logger.CDebugf(ctx, "positionA: %0.2f positionB: %0.2f range: %0.2f", positionA, positionB, g.positionRange)
+		g.logger.CInfof(ctx, "positionA: %0.2f positionB: %0.2f range: %0.2f", positionA, positionB, g.positionRange)
 	}
 
 	// Go to start position at the middle of the axis.
@@ -548,15 +548,15 @@ func (g *singleAxis) MoveToPosition(ctx context.Context, positions, speeds []flo
 	// Currently needs to be moved by underlying gantry motor.
 	if len(g.limitSwitchPins) > 0 {
 		// Stops if position x is past the 0 limit switch
-		if x <= (g.positionLimits[0] + limitErrorMargin) {
-			g.logger.CError(ctx, "Cannot move past limit switch!")
-			return g.motor.Stop(ctx, extra)
+		if x < (g.positionLimits[0] + limitErrorMargin) {
+			err := errors.New("Cannot move past limit switch!")
+			return multierr.Combine(err, g.motor.Stop(ctx, extra))
 		}
 
 		// Stops if position x is past the at-length limit switch
-		if x >= (g.positionLimits[1] - limitErrorMargin) {
-			g.logger.CError(ctx, "Cannot move past limit switch!")
-			return g.motor.Stop(ctx, extra)
+		if x > (g.positionLimits[1] - limitErrorMargin) {
+			err := errors.New("Cannot move past limit switch!")
+			return multierr.Combine(err, g.motor.Stop(ctx, extra))
 		}
 	}
 

--- a/components/gantry/singleaxis/singleaxis.go
+++ b/components/gantry/singleaxis/singleaxis.go
@@ -30,9 +30,6 @@ var (
 	homingTimeout = time.Duration(15e9)
 )
 
-// limitErrorMargin is added or subtracted from the location of the limit switch to ensure the switch is not passed.
-const limitErrorMargin = 0.0
-
 // Config is used for converting singleAxis config attributes.
 type Config struct {
 	Board           string   `json:"board,omitempty"` // used to read limit switch pins and control motor with gpio pins
@@ -548,13 +545,13 @@ func (g *singleAxis) MoveToPosition(ctx context.Context, positions, speeds []flo
 	// Currently needs to be moved by underlying gantry motor.
 	if len(g.limitSwitchPins) > 0 {
 		// Stops if position x is past the 0 limit switch
-		if x < (g.positionLimits[0] + limitErrorMargin) {
+		if x < g.positionLimits[0] {
 			err := errors.New("Cannot move past limit switch!")
 			return multierr.Combine(err, g.motor.Stop(ctx, extra))
 		}
 
 		// Stops if position x is past the at-length limit switch
-		if x > (g.positionLimits[1] - limitErrorMargin) {
+		if x > g.positionLimits[1] {
 			err := errors.New("Cannot move past limit switch!")
 			return multierr.Combine(err, g.motor.Stop(ctx, extra))
 		}

--- a/components/gantry/singleaxis/singleaxis_test.go
+++ b/components/gantry/singleaxis/singleaxis_test.go
@@ -868,10 +868,10 @@ func TestGoToInputs(t *testing.T) {
 
 	inputs = []referenceframe.Input{{Value: 1.0}}
 	err = fakegantry.GoToInputs(ctx, inputs)
-	test.That(t, err, test.ShouldBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "cannot move past limit switch")
 
 	err = fakegantry.GoToInputs(ctx, inputs, inputs)
-	test.That(t, err, test.ShouldBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "cannot move past limit switch")
 
 	err = fakegantry.GoToInputs(ctx)
 	test.That(t, err, test.ShouldBeNil)

--- a/components/gantry/singleaxis/singleaxis_test.go
+++ b/components/gantry/singleaxis/singleaxis_test.go
@@ -673,6 +673,13 @@ func TestMoveToPosition(t *testing.T) {
 	err = fakegantry.MoveToPosition(ctx, pos, speed, nil)
 	test.That(t, err, test.ShouldBeNil)
 
+	pos = []float64{4}
+	fakegantry.lengthMm = float64(4)
+	fakegantry.positionLimits = []float64{0, 10}
+	fakegantry.limitSwitchPins = []string{"1", "2"}
+	err = fakegantry.MoveToPosition(ctx, pos, speed, nil)
+	test.That(t, err, test.ShouldBeNil)
+
 	pos = []float64{1}
 	fakegantry.lengthMm = float64(4)
 	fakegantry.positionLimits = []float64{0.01, .01}

--- a/components/gantry/singleaxis/singleaxis_test.go
+++ b/components/gantry/singleaxis/singleaxis_test.go
@@ -666,12 +666,14 @@ func TestMoveToPosition(t *testing.T) {
 	err = fakegantry.MoveToPosition(ctx, pos, speed, nil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "out of range")
 
+	pos = []float64{0}
 	fakegantry.lengthMm = float64(4)
 	fakegantry.positionLimits = []float64{0, 4}
 	fakegantry.limitSwitchPins = []string{"1", "2"}
 	err = fakegantry.MoveToPosition(ctx, pos, speed, nil)
 	test.That(t, err, test.ShouldBeNil)
 
+	pos = []float64{1}
 	fakegantry.lengthMm = float64(4)
 	fakegantry.positionLimits = []float64{0.01, .01}
 	fakegantry.limitSwitchPins = []string{"1", "2"}


### PR DESCRIPTION
- remove error margin to allow gantry to move to 0
- return more logs and errors for frontend 