### PR TITLE
DOCS-2498: Add links back to main docs for services

### DIFF
--- a/services/baseremotecontrol/base_remote_control.go
+++ b/services/baseremotecontrol/base_remote_control.go
@@ -1,4 +1,7 @@
 // Package baseremotecontrol implements a remote control for a base.
+// For more information, see the [base remote control service docs].
+//
+// [base remote control service docs]: https://docs.viam.com/services/base-rc/
 package baseremotecontrol
 
 import (
@@ -30,6 +33,7 @@ func init() {
 }
 
 // A Service is the basis for the base remote control.
+// For more information, see the [base remote control service docs].
 //
 // Close example:
 //
@@ -40,6 +44,8 @@ func init() {
 //
 //	// Get the list of inputs from the controller that are being monitored for that control mode.
 //	inputs := baseRCService.ControllerInputs()
+//
+// [base remote control service docs]: https://docs.viam.com/services/base-rc/
 type Service interface {
 	resource.Resource
 	// Close out of all remote control related systems.

--- a/services/datamanager/data_manager.go
+++ b/services/datamanager/data_manager.go
@@ -1,4 +1,7 @@
 // Package datamanager contains a service type that can be used to capture data from a robot's components.
+// For more information, see the [data management service docs].
+//
+// [data management service docs]: https://docs.viam.com/services/data/
 package datamanager
 
 import (
@@ -31,11 +34,14 @@ func init() {
 }
 
 // Service defines what a Data Manager Service should expose to the users.
+// For more information, see the [data management service docs].
 //
 // Sync example:
 //
 //	// Sync data stored on the machine to the cloud.
 //	err := data.Sync(context.Background(), nil)
+//
+// [data management service docs]: https://docs.viam.com/services/data/
 type Service interface {
 	resource.Resource
 	// Sync will sync data stored on the machine to the cloud.

--- a/services/generic/generic.go
+++ b/services/generic/generic.go
@@ -1,4 +1,7 @@
-// Package generic defines an abstract generic service and DoCommand() method
+// Package generic defines an abstract generic service and DoCommand() method.
+// For more information, see the [generic service docs].
+//
+// [generic service docs]: https://docs.viam.com/services/generic/
 package generic
 
 import (

--- a/services/mlmodel/mlmodel.go
+++ b/services/mlmodel/mlmodel.go
@@ -1,5 +1,8 @@
 // Package mlmodel defines the client and server for a service that can take in a map of
 // input tensors/arrays, pass them through an inference engine, and then return a map output tensors/arrays.
+// For more information, see the [ML model service docs].
+//
+// [ML model service docs]: https://docs.viam.com/services/ml/deploy/
 package mlmodel
 
 import (
@@ -28,6 +31,7 @@ func init() {
 // Service defines the ML Model interface, which takes a map of inputs, runs it through
 // an inference engine, and creates a map of outputs. Metadata is necessary in order to build
 // the struct that will decode that map[string]interface{} correctly.
+// For more information, see the [ML model service docs].
 //
 // Infer example:
 //
@@ -38,6 +42,8 @@ func init() {
 // Metadata example:
 //
 //	metadata, err := myMLModel.Metadata(context.Background())
+//
+// [ML model service docs]: https://docs.viam.com/services/ml/deploy/
 type Service interface {
 	resource.Resource
 	// Infer returns an output tensor map after running an input tensor map through an interface model.

--- a/services/motion/motion.go
+++ b/services/motion/motion.go
@@ -1,4 +1,7 @@
 // Package motion is the service that allows you to plan and execute movements.
+// For more information, see the [motion service docs].
+//
+// [motion service docs]: https://docs.viam.com/services/motion/
 package motion
 
 import (
@@ -186,6 +189,7 @@ type PlanWithStatus struct {
 }
 
 // A Service controls the flow of moving components.
+// For more information, see the [motion service docs].
 //
 // Move example:
 //
@@ -324,6 +328,8 @@ type PlanWithStatus struct {
 //	planHistory, err := motionService.PlanHistory(context.Background(), motion.PlanHistoryReq{
 //		ComponentName: myBaseResourceName,
 //	})
+//
+// [motion service docs]: https://docs.viam.com/services/motion/
 type Service interface {
 	resource.Resource
 

--- a/services/navigation/navigation.go
+++ b/services/navigation/navigation.go
@@ -1,4 +1,7 @@
 // Package navigation is the service that allows you to navigate along waypoints.
+// For more information, see the [navigation service docs].
+//
+// [navigation service docs]: https://docs.viam.com/services/navigation/
 package navigation
 
 import (
@@ -80,6 +83,7 @@ type Properties struct {
 }
 
 // A Service controls the navigation for a robot.
+// For more information, see the [navigation service docs].
 //
 // Mode example:
 //
@@ -134,6 +138,8 @@ type Properties struct {
 //
 //	// Get the properties of the current navigation service.
 //	navProperties, err := myNav.Properties(context.Background())
+//
+// [navigation service docs]: https://docs.viam.com/services/navigation/
 type Service interface {
 	resource.Resource
 

--- a/services/slam/slam.go
+++ b/services/slam/slam.go
@@ -1,5 +1,8 @@
 // Package slam implements simultaneous localization and mapping.
 // This is an Experimental package.
+// For more information, see the [SLAM service docs].
+//
+// [SLAM service docs]: https://docs.viam.com/services/slam/
 package slam
 
 import (
@@ -122,6 +125,7 @@ func FromDependencies(deps resource.Dependencies, name string) (Service, error) 
 // The Go SDK implements helper functions that concatenate streaming
 // responses. Some of the following examples use corresponding
 // helper methods instead of interface methods.
+// For more information, see the [SLAM service docs].
 //
 // Position example:
 //
@@ -146,6 +150,8 @@ func FromDependencies(deps resource.Dependencies, name string) (Service, error) 
 //
 //	// Get the properties of your current SLAM session
 //	properties, err := mySLAMService.Properties(context.Background())
+//
+// [SLAM service docs]: https://docs.viam.com/services/slam/
 type Service interface {
 	resource.Resource
 	Position(ctx context.Context) (spatialmath.Pose, error)

--- a/services/vision/vision.go
+++ b/services/vision/vision.go
@@ -1,5 +1,8 @@
 // Package vision is the service that allows you to access various computer vision algorithms
 // (like detection, segmentation, tracking, etc) that usually only require a camera or image input.
+// For more information, see the [vision service docs].
+//
+// [vision service docs]: https://docs.viam.com/services/vision/
 package vision
 
 import (
@@ -34,7 +37,8 @@ func init() {
 	}, newCaptureAllFromCameraCollector)
 }
 
-// A Service that implements various computer vision algorithms like detection and segmentation.
+// A Service implements various computer vision algorithms like detection and segmentation.
+// For more information, see the [vision service docs].
 //
 // DetectionsFromCamera example:
 //
@@ -122,6 +126,8 @@ func init() {
 //	detections := capture.Detections
 //	classifications := capture.Classifications
 //	objects := capture.Objects
+//
+// [vision service docs]: https://docs.viam.com/services/vision/
 type Service interface {
 	resource.Resource
 	// DetectionsFromCamera returns a list of detections from the next image from a specified camera using a configured detector.


### PR DESCRIPTION
* adds links back for all documented services besides frame system which afaik doesn't have API user could access
* adds at beginning and around method examples