### PR TITLE
RSDK-8701 Show configuring state through MachineStatus endpoint

### DIFF
--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -1422,13 +1422,13 @@ func (r *localRobot) Shutdown(ctx context.Context) error {
 func (r *localRobot) MachineStatus(ctx context.Context) (robot.MachineStatus, error) {
 	var result robot.MachineStatus
 
-	r.manager.resourceGraphLock.Lock()
+	// r.manager.resourceGraphLock.Lock()
 	result.Resources = append(result.Resources, r.manager.resources.Status()...)
-	r.manager.resourceGraphLock.Unlock()
+	// r.manager.resourceGraphLock.Unlock()
 
-	r.configRevisionMu.RLock()
+	// r.configRevisionMu.RLock()
 	result.Config = r.configRevision
-	r.configRevisionMu.RUnlock()
+	// r.configRevisionMu.RUnlock()
 
 	return result, nil
 }

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -1422,13 +1422,13 @@ func (r *localRobot) Shutdown(ctx context.Context) error {
 func (r *localRobot) MachineStatus(ctx context.Context) (robot.MachineStatus, error) {
 	var result robot.MachineStatus
 
-	// r.manager.resourceGraphLock.Lock()
+	r.manager.resourceGraphLock.Lock()
 	result.Resources = append(result.Resources, r.manager.resources.Status()...)
-	// r.manager.resourceGraphLock.Unlock()
+	r.manager.resourceGraphLock.Unlock()
 
-	// r.configRevisionMu.RLock()
+	r.configRevisionMu.RLock()
 	result.Config = r.configRevision
-	// r.configRevisionMu.RUnlock()
+	r.configRevisionMu.RUnlock()
 
 	return result, nil
 }

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -1422,9 +1422,7 @@ func (r *localRobot) Shutdown(ctx context.Context) error {
 func (r *localRobot) MachineStatus(ctx context.Context) (robot.MachineStatus, error) {
 	var result robot.MachineStatus
 
-	r.manager.resourceGraphLock.Lock()
 	result.Resources = append(result.Resources, r.manager.resources.Status()...)
-	r.manager.resourceGraphLock.Unlock()
 
 	r.configRevisionMu.RLock()
 	result.Config = r.configRevision

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -3541,7 +3541,6 @@ func TestMachineStatus(t *testing.T) {
 	})
 
 	t.Run("poll during reconfiguration", func(t *testing.T) {
-		t.Skip()
 		rev4 := "rev4"
 		lr := setupLocalRobot(t, ctx, &config.Config{
 			Revision:   rev4,
@@ -3556,13 +3555,14 @@ func TestMachineStatus(t *testing.T) {
 			defer wg.Done()
 			lr.Reconfigure(ctx, &config.Config{
 				Revision:   rev5,
-				Components: []resource.Config{newMockConfig("m", 300, false, "1s")},
+				Components: []resource.Config{newMockConfig("m", 300, false, "5s")},
 			})
 		}()
+		time.Sleep(time.Millisecond * 100)
 		// while reconfiguring
 		mStatus, err := lr.MachineStatus(ctx)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, mStatus.Config.Revision, test.ShouldEqual, rev4)
+		test.That(t, mStatus.Config.Revision, test.ShouldEqual, rev5)
 		expectedStatuses := rtestutils.ConcatResourceStatuses(
 			getExpectedDefaultStatuses(rev4),
 			[]resource.Status{

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -3470,7 +3470,7 @@ func TestMachineStatus(t *testing.T) {
 		rtestutils.VerifySameResourceStatuses(t, mStatus.Resources, expectedStatuses)
 	})
 
-	t.Run("reconfigure", func(t *testing.T) {
+	t.Run("poll after working and failing reconfigures", func(t *testing.T) {
 		lr := setupLocalRobot(t, ctx, &config.Config{Revision: rev1}, logger)
 
 		// Add a fake resource to the robot.
@@ -3538,6 +3538,15 @@ func TestMachineStatus(t *testing.T) {
 			},
 		)
 		rtestutils.VerifySameResourceStatuses(t, mStatus.Resources, expectedStatuses)
+	})
+
+	t.Run("poll during reconfiguration", func(t *testing.T) {
+		t.Skip()
+		rev4 := "rev4"
+		lr := setupLocalRobot(t, ctx, &config.Config{
+			Revision:   rev4,
+			Components: []resource.Config{newMockConfig("m", 200, false, "")},
+		}, logger)
 
 		// Update resource with a working config that is slow to reconfigure.
 		rev5 := "rev5"
@@ -3551,10 +3560,10 @@ func TestMachineStatus(t *testing.T) {
 			})
 		}()
 		// while reconfiguring
-		mStatus, err = lr.MachineStatus(ctx)
+		mStatus, err := lr.MachineStatus(ctx)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, mStatus.Config.Revision, test.ShouldEqual, rev4)
-		expectedStatuses = rtestutils.ConcatResourceStatuses(
+		expectedStatuses := rtestutils.ConcatResourceStatuses(
 			getExpectedDefaultStatuses(rev4),
 			[]resource.Status{
 				{

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/golang/geo/r3"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
-
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	armpb "go.viam.com/api/component/arm/v1"
@@ -3337,7 +3336,7 @@ type mockConfig struct {
 	Sleep string `json:"sleep"`
 }
 
-//nolint:unparam - the resource name is currently always "m" but this could easily change
+//nolint:unparam // the resource name is currently always "m" but this could easily change
 func newMockConfig(name string, val int, fail bool, sleep string) resource.Config {
 	return resource.Config{
 		Name:  name,

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -3337,6 +3337,7 @@ type mockConfig struct {
 	Sleep string `json:"sleep"`
 }
 
+//nolint:unparam - the resource name is currently always "m" but this could easily change
 func newMockConfig(name string, val int, fail bool, sleep string) resource.Config {
 	return resource.Config{
 		Name:  name,

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/golang/geo/r3"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
-
 	// registers all components.
 	commonpb "go.viam.com/api/common/v1"
 	armpb "go.viam.com/api/component/arm/v1"
@@ -3558,45 +3557,38 @@ func TestMachineStatus(t *testing.T) {
 				Components: []resource.Config{newMockConfig("m", 300, false, "1s")},
 			})
 		}()
+		// sleep for a short amount of time to allow the machine to receive a new
+		// revision. this sleep should be shorter than the resource update duration
+		// defined above so that updated resource is still in a "configuring" state.
+		time.Sleep(time.Millisecond * 100)
 
-		// poll machine status during reconfiguration until the following state is
-		// detected:
-		//
-		// - config revision is updated to rev2
-		// - mock component "m" has state "configuring" and still has revision rev1
-		// - all other components are ready and have revisions updated to rev2
-		testutils.WaitForAssertion(
-			t,
-			func(tb testing.TB) {
-				// get status while reconfiguring
-				mStatus, err := lr.MachineStatus(ctx)
-				test.That(t, err, test.ShouldBeNil)
-				test.That(t, mStatus.Config.Revision, test.ShouldEqual, rev2)
+		// get status while reconfiguring
+		mStatus, err := lr.MachineStatus(ctx)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, mStatus.Config.Revision, test.ShouldEqual, rev2)
 
-				// the component whose config changed should be the only component in a
-				// "configuring" state and associated with the original revision.
-				filterConfiguring := rtestutils.FilterByStatus(t, mStatus.Resources, resource.NodeStateConfiguring)
-				expectedConfiguring := []resource.Status{
-					{
-						Name:     mockNamed("m"),
-						State:    resource.NodeStateConfiguring,
-						Revision: rev1,
-					},
-				}
-				rtestutils.VerifySameResourceStatuses(t, filterConfiguring, expectedConfiguring)
-
-				// all other components should be in the "ready" state and associated with the
-				// new revision.
-				filterReady := rtestutils.FilterByStatus(t, mStatus.Resources, resource.NodeStateReady)
-				expectedReady := getExpectedDefaultStatuses(rev2)
-				rtestutils.VerifySameResourceStatuses(t, filterReady, expectedReady)
+		// the component whose config changed should be the only component in a
+		// "configuring" state and associated with the original revision.
+		filterConfiguring := rtestutils.FilterByStatus(t, mStatus.Resources, resource.NodeStateConfiguring)
+		expectedConfiguring := []resource.Status{
+			{
+				Name:     mockNamed("m"),
+				State:    resource.NodeStateConfiguring,
+				Revision: rev1,
 			},
-		)
+		}
+		rtestutils.VerifySameResourceStatuses(t, filterConfiguring, expectedConfiguring)
+
+		// all other components should be in the "ready" state and associated with the
+		// new revision.
+		filterReady := rtestutils.FilterByStatus(t, mStatus.Resources, resource.NodeStateReady)
+		expectedReady := getExpectedDefaultStatuses(rev2)
+		rtestutils.VerifySameResourceStatuses(t, filterReady, expectedReady)
 
 		wg.Wait()
 
 		// get status after reconfigure finishes
-		mStatus, err := lr.MachineStatus(ctx)
+		mStatus, err = lr.MachineStatus(ctx)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, mStatus.Config.Revision, test.ShouldEqual, rev2)
 

--- a/testutils/resource_utils.go
+++ b/testutils/resource_utils.go
@@ -83,6 +83,20 @@ func VerifySameResourceStatuses(tb testing.TB, actual, expected []resource.Statu
 	test.That(tb, sortedActual, test.ShouldResemble, sortedExpected)
 }
 
+// FilterByStatus takes a slice of [resource.Status] and a [resource.NodeState] and
+// returns a slice of [resource.Status] that are in the given [resource.NodeState].
+func FilterByStatus(tb testing.TB, resourceStatuses []resource.Status, state resource.NodeState) []resource.Status {
+	tb.Helper()
+
+	var result []resource.Status
+	for _, rs := range resourceStatuses {
+		if rs.State == state {
+			result = append(result, rs)
+		}
+	}
+	return result
+}
+
 func newSortedResourceStatuses(resourceStatuses []resource.Status) []resource.Status {
 	sorted := make([]resource.Status, len(resourceStatuses))
 	copy(sorted, resourceStatuses)


### PR DESCRIPTION
Stop holding `resourceGraphLock` while fetching machine status from local robot, since this prevents users from seeing resources statuses while a robot is (re)configuring.