### PR TITLE
[APP 2911] Allow Robots with Multiple Legacy API Keys to Connect

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -886,21 +886,27 @@ type AuthHandlerConfig struct {
 // Validate ensures all parts of the config are valid. If it exists, updates ExternalAuthConfig's ValidatedKeySet once validated.
 // A sample AuthConfig in JSON form is shown below, where "handlers" contains a list of auth handlers. The only accepted credential
 // type for the RDK in the config is "api-key" currently. An auth handler for utils.CredentialsTypeRobotLocationSecret may be added
-// later by the RDK during processing.
+// later by the RDK during processing. Note that the "config" field inside of the "api-key" auth handler should be structured to contain
+// key ID/key pairings of NON-legacy keys, as well as a list of all non-legacy key ID's and legacy keys associated with a "keys" field.
 //
-//	"auth": {
-//			"handlers": [
-//				{
-//					"type": "api-key",
-//					"config": {
-//						"API_KEY_ID": "API_KEY",
-//						"API_KEY_ID_2": "API_KEY_2",
-//						"keys": ["API_KEY_ID", "API_KEY_ID_2"]
+//		"auth": {
+//				"handlers": [
+//					{
+//						"type": "api-key",
+//						"config": {
+//							"NON_LEGACY_API_KEY_ID": "NON_LEGACY_API_KEY",
+//							"NON_LEGACY_API_KEY_ID_2": "NON_LEGACY_API_KEY_2",
+//							"keys": [
+//	                         "NON_LEGACY_API_KEY_ID",
+//	                         "NON_LEGACY_API_KEY_ID_2",
+//	                         "LEGACY_API_KEY",
+//	                         "LEGACY_API_KEY_2"
+//	                     ]
+//						}
 //					}
-//				}
-//			],
-//		"external_auth_config": {}
-//	}
+//				],
+//			"external_auth_config": {}
+//		}
 func (config *AuthConfig) Validate(path string) error {
 	seenTypes := make(map[string]struct{}, len(config.Handlers))
 	for idx, handler := range config.Handlers {

--- a/config/config.go
+++ b/config/config.go
@@ -888,22 +888,18 @@ type AuthHandlerConfig struct {
 // type for the RDK in the config is "api-key" currently. An auth handler for utils.CredentialsTypeRobotLocationSecret may be added
 // later by the RDK during processing.
 //
-//		"auth": {
-//				"handlers": [
-//					{
-//						"type": "api-key",
-//						"config": {
-//							"API_KEY_ID": "API_KEY",
-//							"API_KEY_ID_2": "API_KEY_2",
-//							"keys": [
-//	                         "API_KEY_ID",
-//	                         "API_KEY_ID_2",
-//	                     ]
-//						}
+//	"auth": {
+//			"handlers": [
+//				{
+//					"type": "api-key",
+//					"config": {
+//						"API_KEY_ID": "API_KEY",
+//						"API_KEY_ID_2": "API_KEY_2",
 //					}
-//				],
-//			"external_auth_config": {}
-//		}
+//				}
+//			],
+//		"external_auth_config": {}
+//	}
 func (config *AuthConfig) Validate(path string) error {
 	seenTypes := make(map[string]struct{}, len(config.Handlers))
 	for idx, handler := range config.Handlers {

--- a/config/config.go
+++ b/config/config.go
@@ -928,7 +928,7 @@ func (config *AuthHandlerConfig) Validate(path string) error {
 	switch config.Type {
 	case rpc.CredentialsTypeAPIKey:
 		if len(config.Config) == 0 || config.Config == nil {
-			return errors.New("API key handler must contain at least 1 key")
+			return resource.NewConfigValidationError(fmt.Sprintf("%s.config", path), errors.New("At least 1 key required for API key handler"))
 		}
 	case rpc.CredentialsTypeExternal:
 		return errors.New("robot cannot issue external auth tokens")

--- a/config/config.go
+++ b/config/config.go
@@ -888,19 +888,19 @@ type AuthHandlerConfig struct {
 // type for the RDK in the config is "api-key" currently. An auth handler for utils.CredentialsTypeRobotLocationSecret may be added
 // later by the RDK during processing.
 //
-//		"auth": {
-//				"handlers": [
-//					{
-//						"type": "api-key",
-//						"config": {
-//							"API_KEY_ID": "API_KEY",
-//							"API_KEY_ID_2": "API_KEY_2",
-//	                        "keys": ["API_KEY_ID", "API_KEY_ID_2"],
-//						}
+//	"auth": {
+//			"handlers": [
+//				{
+//					"type": "api-key",
+//					"config": {
+//						"API_KEY_ID": "API_KEY",
+//						"API_KEY_ID_2": "API_KEY_2",
+//						"keys": ["API_KEY_ID", "API_KEY_ID_2"]
 //					}
-//				],
-//			"external_auth_config": {}
-//		}
+//				}
+//			],
+//		    "external_auth_config": {},
+//	}
 func (config *AuthConfig) Validate(path string) error {
 	seenTypes := make(map[string]struct{}, len(config.Handlers))
 	for idx, handler := range config.Handlers {

--- a/config/config.go
+++ b/config/config.go
@@ -886,21 +886,18 @@ type AuthHandlerConfig struct {
 // Validate ensures all parts of the config are valid. If it exists, updates ExternalAuthConfig's ValidatedKeySet once validated.
 // A sample AuthConfig in JSON form is shown below, where "handlers" contains a list of auth handlers. The only accepted credential
 // type for the RDK in the config is "api-key" currently. An auth handler for utils.CredentialsTypeRobotLocationSecret may be added
-// later by the RDK during processing. Note that the "config" field inside of the "api-key" auth handler should be structured to contain
-// key ID/key pairings of NON-legacy keys, as well as a list of all non-legacy key ID's and legacy keys associated with a "keys" field.
+// later by the RDK during processing.
 //
 //		"auth": {
 //				"handlers": [
 //					{
 //						"type": "api-key",
 //						"config": {
-//							"NON_LEGACY_API_KEY_ID": "NON_LEGACY_API_KEY",
-//							"NON_LEGACY_API_KEY_ID_2": "NON_LEGACY_API_KEY_2",
+//							"API_KEY_ID": "API_KEY",
+//							"API_KEY_ID_2": "API_KEY_2",
 //							"keys": [
-//	                         "NON_LEGACY_API_KEY_ID",
-//	                         "NON_LEGACY_API_KEY_ID_2",
-//	                         "LEGACY_API_KEY",
-//	                         "LEGACY_API_KEY_2"
+//	                         "API_KEY_ID",
+//	                         "API_KEY_ID_2",
 //	                     ]
 //						}
 //					}

--- a/config/config.go
+++ b/config/config.go
@@ -927,15 +927,12 @@ func (config *AuthHandlerConfig) Validate(path string) error {
 	}
 	switch config.Type {
 	case rpc.CredentialsTypeAPIKey:
-		if config.Config.String("key") == "" && len(config.Config.StringSlice("keys")) == 0 {
-			return resource.NewConfigValidationError(fmt.Sprintf("%s.config", path), errors.New("key or keys is required"))
-		}
+		return nil
 	case rpc.CredentialsTypeExternal:
 		return errors.New("robot cannot issue external auth tokens")
 	default:
 		return resource.NewConfigValidationError(path, errors.Errorf("do not know how to handle auth for %q", config.Type))
 	}
-	return nil
 }
 
 // TLSConfig stores the TLS config for the robot.

--- a/config/config.go
+++ b/config/config.go
@@ -895,7 +895,7 @@ type AuthHandlerConfig struct {
 //						"config": {
 //							"API_KEY_ID": "API_KEY",
 //							"API_KEY_ID_2": "API_KEY_2",
-//	                     "keys": ["API_KEY_ID", "API_KEY_ID_2"]
+//	                        "keys": ["API_KEY_ID", "API_KEY_ID_2"],
 //						}
 //					}
 //				],

--- a/config/config.go
+++ b/config/config.go
@@ -927,12 +927,15 @@ func (config *AuthHandlerConfig) Validate(path string) error {
 	}
 	switch config.Type {
 	case rpc.CredentialsTypeAPIKey:
-		return nil
+		if len(config.Config) == 0 || config.Config == nil {
+			return errors.New("API key handler must contain at least 1 key")
+		}
 	case rpc.CredentialsTypeExternal:
 		return errors.New("robot cannot issue external auth tokens")
 	default:
 		return resource.NewConfigValidationError(path, errors.Errorf("do not know how to handle auth for %q", config.Type))
 	}
+	return nil
 }
 
 // TLSConfig stores the TLS config for the robot.

--- a/config/config.go
+++ b/config/config.go
@@ -888,18 +888,19 @@ type AuthHandlerConfig struct {
 // type for the RDK in the config is "api-key" currently. An auth handler for utils.CredentialsTypeRobotLocationSecret may be added
 // later by the RDK during processing.
 //
-//	"auth": {
-//			"handlers": [
-//				{
-//					"type": "api-key",
-//					"config": {
-//						"API_KEY_ID": "API_KEY",
-//						"API_KEY_ID_2": "API_KEY_2",
+//		"auth": {
+//				"handlers": [
+//					{
+//						"type": "api-key",
+//						"config": {
+//							"API_KEY_ID": "API_KEY",
+//							"API_KEY_ID_2": "API_KEY_2",
+//	                     "keys": ["API_KEY_ID", "API_KEY_ID_2"]
+//						}
 //					}
-//				}
-//			],
-//		"external_auth_config": {}
-//	}
+//				],
+//			"external_auth_config": {}
+//		}
 func (config *AuthConfig) Validate(path string) error {
 	seenTypes := make(map[string]struct{}, len(config.Handlers))
 	for idx, handler := range config.Handlers {
@@ -927,8 +928,8 @@ func (config *AuthHandlerConfig) Validate(path string) error {
 	}
 	switch config.Type {
 	case rpc.CredentialsTypeAPIKey:
-		if len(config.Config) == 0 || config.Config == nil {
-			return resource.NewConfigValidationError(fmt.Sprintf("%s.config", path), errors.New("At least 1 key required for API key handler"))
+		if len(config.Config.StringSlice("keys")) == 0 {
+			return resource.NewConfigValidationError(fmt.Sprintf("%s.config", path), errors.New("keys is required"))
 		}
 	case rpc.CredentialsTypeExternal:
 		return errors.New("robot cannot issue external auth tokens")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -420,18 +420,6 @@ func TestConfigEnsure(t *testing.T) {
 	test.That(t, invalidAuthConfig.Ensure(false, logger), test.ShouldBeNil)
 
 	validAPIKeyHandler.Config = rutils.AttributeMap{
-		"keys": []string{},
-	}
-	invalidAuthConfig.Auth.Handlers = []config.AuthHandlerConfig{
-		validAPIKeyHandler,
-	}
-	err = invalidAuthConfig.Ensure(false, logger)
-	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `auth.handlers.0`)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `required`)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `key`)
-
-	validAPIKeyHandler.Config = rutils.AttributeMap{
 		"keys": []string{"one", "two"},
 	}
 	invalidAuthConfig.Auth.Handlers = []config.AuthHandlerConfig{
@@ -637,18 +625,6 @@ func TestConfigEnsurePartialStart(t *testing.T) {
 		validAPIKeyHandler,
 	}
 	test.That(t, invalidAuthConfig.Ensure(false, logger), test.ShouldBeNil)
-
-	validAPIKeyHandler.Config = rutils.AttributeMap{
-		"keys": []string{},
-	}
-	invalidAuthConfig.Auth.Handlers = []config.AuthHandlerConfig{
-		validAPIKeyHandler,
-	}
-	err = invalidAuthConfig.Ensure(false, logger)
-	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `auth.handlers.0`)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `required`)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `key`)
 
 	validAPIKeyHandler.Config = rutils.AttributeMap{
 		"keys": []string{"one", "two"},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -420,6 +420,18 @@ func TestConfigEnsure(t *testing.T) {
 	test.That(t, invalidAuthConfig.Ensure(false, logger), test.ShouldBeNil)
 
 	validAPIKeyHandler.Config = rutils.AttributeMap{
+		"keys": []string{},
+	}
+	invalidAuthConfig.Auth.Handlers = []config.AuthHandlerConfig{
+		validAPIKeyHandler,
+	}
+	err = invalidAuthConfig.Ensure(false, logger)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, `auth.handlers.0`)
+	test.That(t, err.Error(), test.ShouldContainSubstring, `required`)
+	test.That(t, err.Error(), test.ShouldContainSubstring, `keys`)
+
+	validAPIKeyHandler.Config = rutils.AttributeMap{
 		"keys": []string{"one", "two"},
 	}
 	invalidAuthConfig.Auth.Handlers = []config.AuthHandlerConfig{
@@ -625,6 +637,18 @@ func TestConfigEnsurePartialStart(t *testing.T) {
 		validAPIKeyHandler,
 	}
 	test.That(t, invalidAuthConfig.Ensure(false, logger), test.ShouldBeNil)
+
+	validAPIKeyHandler.Config = rutils.AttributeMap{
+		"keys": []string{},
+	}
+	invalidAuthConfig.Auth.Handlers = []config.AuthHandlerConfig{
+		validAPIKeyHandler,
+	}
+	err = invalidAuthConfig.Ensure(false, logger)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, `auth.handlers.0`)
+	test.That(t, err.Error(), test.ShouldContainSubstring, `required`)
+	test.That(t, err.Error(), test.ShouldContainSubstring, `keys`)
 
 	validAPIKeyHandler.Config = rutils.AttributeMap{
 		"keys": []string{"one", "two"},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -381,11 +381,6 @@ func TestConfigEnsure(t *testing.T) {
 	invalidAuthConfig.Auth.Handlers = []config.AuthHandlerConfig{
 		{Type: rpc.CredentialsTypeAPIKey},
 	}
-	err = invalidAuthConfig.Ensure(false, logger)
-	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `auth.handlers.0`)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `required`)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `key`)
 
 	validAPIKeyHandler := config.AuthHandlerConfig{
 		Type: rpc.CredentialsTypeAPIKey,
@@ -600,11 +595,6 @@ func TestConfigEnsurePartialStart(t *testing.T) {
 	invalidAuthConfig.Auth.Handlers = []config.AuthHandlerConfig{
 		{Type: rpc.CredentialsTypeAPIKey},
 	}
-	err = invalidAuthConfig.Ensure(false, logger)
-	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `auth.handlers.0`)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `required`)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `key`)
 
 	validAPIKeyHandler := config.AuthHandlerConfig{
 		Type: rpc.CredentialsTypeAPIKey,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -381,6 +381,11 @@ func TestConfigEnsure(t *testing.T) {
 	invalidAuthConfig.Auth.Handlers = []config.AuthHandlerConfig{
 		{Type: rpc.CredentialsTypeAPIKey},
 	}
+	err = invalidAuthConfig.Ensure(false, logger)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, `auth.handlers.0`)
+	test.That(t, err.Error(), test.ShouldContainSubstring, `required`)
+	test.That(t, err.Error(), test.ShouldContainSubstring, `key`)
 
 	validAPIKeyHandler := config.AuthHandlerConfig{
 		Type: rpc.CredentialsTypeAPIKey,
@@ -595,6 +600,11 @@ func TestConfigEnsurePartialStart(t *testing.T) {
 	invalidAuthConfig.Auth.Handlers = []config.AuthHandlerConfig{
 		{Type: rpc.CredentialsTypeAPIKey},
 	}
+	err = invalidAuthConfig.Ensure(false, logger)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, `auth.handlers.0`)
+	test.That(t, err.Error(), test.ShouldContainSubstring, `required`)
+	test.That(t, err.Error(), test.ShouldContainSubstring, `key`)
 
 	validAPIKeyHandler := config.AuthHandlerConfig{
 		Type: rpc.CredentialsTypeAPIKey,

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -742,12 +742,23 @@ func (svc *webService) initAuthHandlers(listenerTCPAddr *net.TCPAddr, options we
 			switch handler.Type {
 			case rpc.CredentialsTypeAPIKey:
 				apiKeys := parseAPIKeys(handler)
+				legacyAPIKeys := parseLegacyAPIKeys(handler, apiKeys)
+				hasAPIKeys := len(apiKeys) != 0
+				hasLegacyAPIKeys := len(legacyAPIKeys) != 0
 
-				if len(apiKeys) == 0 {
+				switch {
+				case !hasLegacyAPIKeys && !hasAPIKeys:
 					return nil, errors.Errorf("%q handler requires non-empty API key or keys", handler.Type)
+				case hasLegacyAPIKeys && !hasAPIKeys:
+					rpcOpts = append(rpcOpts, rpc.WithAuthHandler(
+						handler.Type,
+						rpc.MakeSimpleMultiAuthHandler(authEntities, legacyAPIKeys),
+					))
+				case !hasLegacyAPIKeys && hasAPIKeys:
+					rpcOpts = append(rpcOpts, rpc.WithAuthHandler(handler.Type, rpc.MakeSimpleMultiAuthPairHandler(apiKeys)))
+				default:
+					rpcOpts = append(rpcOpts, rpc.WithAuthHandler(handler.Type, makeMultiStepAPIKeyAuthHandler(authEntities, legacyAPIKeys, apiKeys)))
 				}
-
-				rpcOpts = append(rpcOpts, rpc.WithAuthHandler(handler.Type, rpc.MakeSimpleMultiAuthPairHandler(apiKeys)))
 			case rutils.CredentialsTypeRobotLocationSecret:
 				locationSecrets := handler.Config.StringSlice("secrets")
 				if len(locationSecrets) == 0 {
@@ -778,12 +789,53 @@ func (svc *webService) initAuthHandlers(listenerTCPAddr *net.TCPAddr, options we
 	return rpcOpts, nil
 }
 
+func parseLegacyAPIKeys(handler config.AuthHandlerConfig, nonLegacyAPIKeys map[string]string) []string {
+	apiKeys := handler.Config.StringSlice("keys")
+	var filteredAPIKeys []string
+
+	// filter out new api keys from keys array to ensure we're left with only legacy keys
+	for _, apiKey := range apiKeys {
+		if _, ok := nonLegacyAPIKeys[apiKey]; !ok {
+			filteredAPIKeys = append(filteredAPIKeys, apiKey)
+		}
+	}
+
+	if len(filteredAPIKeys) == 0 {
+		apiKey := handler.Config.String("key")
+		if apiKey == "" {
+			return []string{}
+		}
+		filteredAPIKeys = []string{apiKey}
+	}
+
+	return filteredAPIKeys
+}
+
 func parseAPIKeys(handler config.AuthHandlerConfig) map[string]string {
 	apiKeys := map[string]string{}
 	for k := range handler.Config {
-		apiKeys[k] = handler.Config.String(k)
+		// if it is not a legacy api key indicated by "key(s)" key
+		// current api keys will follow format { [keyId]: [key] }
+		if k != "keys" && k != "key" {
+			apiKeys[k] = handler.Config.String(k)
+		}
 	}
 	return apiKeys
+}
+
+// makeMultiStepAPIKeyAuthHandler supports auth handlers for both legacy and non-legacy api keys for backwards compatibility.
+func makeMultiStepAPIKeyAuthHandler(legacyEntities, legacyExpectedAPIKeys []string, apiKeys map[string]string) rpc.AuthHandler {
+	legacyAuthHandler := rpc.MakeSimpleMultiAuthHandler(legacyEntities, legacyExpectedAPIKeys)
+	currentAuthHandler := rpc.MakeSimpleMultiAuthPairHandler(apiKeys)
+	return rpc.AuthHandlerFunc(func(ctx context.Context, entity, payload string) (map[string]string, error) {
+		result, err := legacyAuthHandler.Authenticate(ctx, entity, payload)
+		if err == nil {
+			return result, nil
+		}
+
+		// if legacy API key authentication fails, try a new API key authentication
+		return currentAuthHandler.Authenticate(ctx, entity, payload)
+	})
 }
 
 // Register every API resource grpc service here.

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -745,9 +745,9 @@ func (svc *webService) initAuthHandlers(listenerTCPAddr *net.TCPAddr, options we
 
 				if len(apiKeys) == 0 {
 					return nil, errors.Errorf("%q handler requires non-empty API key or keys", handler.Type)
-				} else {
-					rpcOpts = append(rpcOpts, rpc.WithAuthHandler(handler.Type, rpc.MakeSimpleMultiAuthPairHandler(apiKeys)))
 				}
+
+				rpcOpts = append(rpcOpts, rpc.WithAuthHandler(handler.Type, rpc.MakeSimpleMultiAuthPairHandler(apiKeys)))
 			case rutils.CredentialsTypeRobotLocationSecret:
 				locationSecrets := handler.Config.StringSlice("secrets")
 				if len(locationSecrets) == 0 {

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -742,22 +742,11 @@ func (svc *webService) initAuthHandlers(listenerTCPAddr *net.TCPAddr, options we
 			switch handler.Type {
 			case rpc.CredentialsTypeAPIKey:
 				apiKeys := parseAPIKeys(handler)
-				legacyAPIKeys := parseLegacyAPIKeys(handler, apiKeys)
-				hasAPIKeys := len(apiKeys) != 0
-				hasLegacyAPIKeys := len(legacyAPIKeys) != 0
 
-				switch {
-				case !hasLegacyAPIKeys && !hasAPIKeys:
+				if len(apiKeys) == 0 {
 					return nil, errors.Errorf("%q handler requires non-empty API key or keys", handler.Type)
-				case hasLegacyAPIKeys && !hasAPIKeys:
-					rpcOpts = append(rpcOpts, rpc.WithAuthHandler(
-						handler.Type,
-						rpc.MakeSimpleMultiAuthHandler(authEntities, legacyAPIKeys),
-					))
-				case !hasLegacyAPIKeys && hasAPIKeys:
+				} else {
 					rpcOpts = append(rpcOpts, rpc.WithAuthHandler(handler.Type, rpc.MakeSimpleMultiAuthPairHandler(apiKeys)))
-				default:
-					rpcOpts = append(rpcOpts, rpc.WithAuthHandler(handler.Type, makeMultiStepAPIKeyAuthHandler(authEntities, legacyAPIKeys, apiKeys)))
 				}
 			case rutils.CredentialsTypeRobotLocationSecret:
 				locationSecrets := handler.Config.StringSlice("secrets")
@@ -789,53 +778,12 @@ func (svc *webService) initAuthHandlers(listenerTCPAddr *net.TCPAddr, options we
 	return rpcOpts, nil
 }
 
-func parseLegacyAPIKeys(handler config.AuthHandlerConfig, nonLegacyAPIKeys map[string]string) []string {
-	apiKeys := handler.Config.StringSlice("keys")
-	var filteredAPIKeys []string
-
-	// filter out new api keys from keys array to ensure we're left with only legacy keys
-	for _, apiKey := range apiKeys {
-		if _, ok := nonLegacyAPIKeys[apiKey]; !ok {
-			filteredAPIKeys = append(filteredAPIKeys, apiKey)
-		}
-	}
-
-	if len(filteredAPIKeys) == 0 {
-		apiKey := handler.Config.String("key")
-		if apiKey == "" {
-			return []string{}
-		}
-		filteredAPIKeys = []string{apiKey}
-	}
-
-	return filteredAPIKeys
-}
-
 func parseAPIKeys(handler config.AuthHandlerConfig) map[string]string {
 	apiKeys := map[string]string{}
 	for k := range handler.Config {
-		// if it is not a legacy api key indicated by "key(s)" key
-		// current api keys will follow format { [keyId]: [key] }
-		if k != "keys" && k != "key" {
-			apiKeys[k] = handler.Config.String(k)
-		}
+		apiKeys[k] = handler.Config.String(k)
 	}
 	return apiKeys
-}
-
-// makeMultiStepAPIKeyAuthHandler supports auth handlers for both legacy and non-legacy api keys for backwards compatibility.
-func makeMultiStepAPIKeyAuthHandler(legacyEntities, legacyExpectedAPIKeys []string, apiKeys map[string]string) rpc.AuthHandler {
-	legacyAuthHandler := rpc.MakeSimpleMultiAuthHandler(legacyEntities, legacyExpectedAPIKeys)
-	currentAuthHandler := rpc.MakeSimpleMultiAuthPairHandler(apiKeys)
-	return rpc.AuthHandlerFunc(func(ctx context.Context, entity, payload string) (map[string]string, error) {
-		result, err := legacyAuthHandler.Authenticate(ctx, entity, payload)
-		if err == nil {
-			return result, nil
-		}
-
-		// if legacy API key authentication fails, try a new API key authentication
-		return currentAuthHandler.Authenticate(ctx, entity, payload)
-	})
 }
 
 // Register every API resource grpc service here.

--- a/robot/web/web_test.go
+++ b/robot/web/web_test.go
@@ -202,7 +202,6 @@ func TestWebWithAuth(t *testing.T) {
 			options.Managed = tc.Managed
 			options.FQDN = tc.EntityName
 			options.LocalFQDN = primitive.NewObjectID().Hex()
-			legacyAPIKey := "sosecret"
 			apiKeyID1 := uuid.New().String()
 			apiKey1 := utils.RandomAlphaString(32)
 			apiKeyID2 := uuid.New().String()
@@ -212,10 +211,8 @@ func TestWebWithAuth(t *testing.T) {
 				{
 					Type: rpc.CredentialsTypeAPIKey,
 					Config: rutils.AttributeMap{
-						"key":     legacyAPIKey,
 						apiKeyID1: apiKey1,
 						apiKeyID2: apiKey2,
-						"keys":    []string{apiKeyID1, apiKeyID2},
 					},
 				},
 				{
@@ -244,7 +241,7 @@ func TestWebWithAuth(t *testing.T) {
 				_, err = rgrpc.Dial(context.Background(), addr, logger, rpc.WithAllowInsecureWithCredentialsDowngrade(),
 					rutils.WithEntityCredentials("wrong", rpc.Credentials{
 						Type:    rpc.CredentialsTypeAPIKey,
-						Payload: legacyAPIKey,
+						Payload: apiKey1,
 					}))
 				test.That(t, err, test.ShouldNotBeNil)
 				test.That(t, err.Error(), test.ShouldContainSubstring, "invalid credentials")
@@ -268,9 +265,9 @@ func TestWebWithAuth(t *testing.T) {
 				// WebRTC connections across unix sockets can create deadlock in CI.
 				conn, err := rgrpc.Dial(context.Background(), addr, logger,
 					rpc.WithAllowInsecureWithCredentialsDowngrade(),
-					rpc.WithEntityCredentials(entityName, rpc.Credentials{
+					rpc.WithEntityCredentials(apiKeyID1, rpc.Credentials{
 						Type:    rpc.CredentialsTypeAPIKey,
-						Payload: legacyAPIKey,
+						Payload: apiKey1,
 					}),
 					rpc.WithForceDirectGRPC(),
 				)
@@ -407,9 +404,9 @@ func TestWebWithAuth(t *testing.T) {
 				// WebRTC connections across unix sockets can create deadlock in CI.
 				conn, err := rgrpc.Dial(context.Background(), addr, logger,
 					rpc.WithAllowInsecureWithCredentialsDowngrade(),
-					rpc.WithCredentials(rpc.Credentials{
+					rpc.WithEntityCredentials(apiKeyID1, rpc.Credentials{
 						Type:    rpc.CredentialsTypeAPIKey,
-						Payload: legacyAPIKey,
+						Payload: apiKey1,
 					}),
 					rpc.WithForceDirectGRPC(),
 				)
@@ -670,7 +667,6 @@ func TestWebWithOnlyNewAPIKeyAuthHandlers(t *testing.T) {
 			Config: rutils.AttributeMap{
 				apiKeyID1: apiKey1,
 				apiKeyID2: apiKey2,
-				"keys":    []string{apiKeyID1, apiKeyID2},
 			},
 		},
 	}

--- a/robot/web/web_test.go
+++ b/robot/web/web_test.go
@@ -213,6 +213,7 @@ func TestWebWithAuth(t *testing.T) {
 					Config: rutils.AttributeMap{
 						apiKeyID1: apiKey1,
 						apiKeyID2: apiKey2,
+						"keys":    []string{apiKeyID1, apiKeyID2},
 					},
 				},
 				{
@@ -667,6 +668,7 @@ func TestWebWithOnlyNewAPIKeyAuthHandlers(t *testing.T) {
 			Config: rutils.AttributeMap{
 				apiKeyID1: apiKey1,
 				apiKeyID2: apiKey2,
+				"keys":    []string{apiKeyID1, apiKeyID2},
 			},
 		},
 	}


### PR DESCRIPTION
This is the second PR in what started out as a fix to the bug forbidding robots with multiple legacy api keys from connecting to App but has become the removal of support for legacy API keys. On the RDK side, this means no longer parsing for legacy keys and no longer expecting them in config validation.