### PR TITLE
Do not scale gantry collector returns from `Lengths` and `Positions` 

### DIFF
--- a/components/gantry/collectors.go
+++ b/components/gantry/collectors.go
@@ -46,7 +46,7 @@ func newPositionCollector(resource interface{}, params data.CollectorParams) (da
 			return nil, data.FailedToReadErr(params.ComponentName, position.String(), err)
 		}
 		return pb.GetPositionResponse{
-			PositionsMm: scaleMetersToMm(v),
+			PositionsMm: v,
 		}, nil
 	})
 	return data.NewCollector(cFunc, params)
@@ -71,18 +71,10 @@ func newLengthsCollector(resource interface{}, params data.CollectorParams) (dat
 			return nil, data.FailedToReadErr(params.ComponentName, lengths.String(), err)
 		}
 		return pb.GetLengthsResponse{
-			LengthsMm: scaleMetersToMm(v),
+			LengthsMm: v,
 		}, nil
 	})
 	return data.NewCollector(cFunc, params)
-}
-
-func scaleMetersToMm(meters []float64) []float64 {
-	ret := make([]float64, len(meters))
-	for i := range ret {
-		ret[i] = meters[i] * 1000
-	}
-	return ret
 }
 
 func assertGantry(resource interface{}) (Gantry, error) {

--- a/components/gantry/collectors_test.go
+++ b/components/gantry/collectors_test.go
@@ -22,7 +22,8 @@ const (
 	numRetries      = 5
 )
 
-var floatList = []float64{1.0, 2.0, 3.0}
+// floatList is a lit of floats in units of millimeters.
+var floatList = []float64{1000, 2000, 3000}
 
 func TestGantryCollectors(t *testing.T) {
 	tests := []struct {
@@ -34,14 +35,14 @@ func TestGantryCollectors(t *testing.T) {
 			name:      "Length collector should write a lengths response",
 			collector: gantry.NewLengthsCollector,
 			expected: tu.ToProtoMapIgnoreOmitEmpty(pb.GetLengthsResponse{
-				LengthsMm: scaleMetersToMm(floatList),
+				LengthsMm: floatList,
 			}),
 		},
 		{
 			name:      "Position collector should write a list of positions",
 			collector: gantry.NewPositionCollector,
 			expected: tu.ToProtoMapIgnoreOmitEmpty(pb.GetPositionResponse{
-				PositionsMm: scaleMetersToMm(floatList),
+				PositionsMm: floatList,
 			}),
 		},
 	}
@@ -84,12 +85,4 @@ func newGantry() gantry.Gantry {
 		return floatList, nil
 	}
 	return g
-}
-
-func scaleMetersToMm(meters []float64) []float64 {
-	ret := make([]float64, len(meters))
-	for i := range ret {
-		ret[i] = meters[i] * 1000
-	}
-	return ret
 }


### PR DESCRIPTION
Our API contract specifies mm units for [Positions](https://github.com/viamrobotics/api/blob/cba5f1e67aad798b42134a1a748199a2faef6bc7/proto/viam/component/gantry/v1/gantry.proto#L79) and [Lengths](https://github.com/viamrobotics/api/blob/cba5f1e67aad798b42134a1a748199a2faef6bc7/proto/viam/component/gantry/v1/gantry.proto#L112), so I was getting my data collected in units of micrometres:
![Screenshot 2024-09-13 at 13 53 06](https://github.com/user-attachments/assets/dd1bb574-c374-4c06-b416-a4fc56625634)

In general, I try not to transform any data being returned in our responses above the driver level. We are the only ones who have to adhere to our behavioural contract for the components/service rpc returns and ensure they adhere to the correct units; if someone wants to implement their gantry model driver in inches, for example, have at it.

Caveats:
- [ ] I did not look at other collectors to see how they transform their units.
- [ ] I do not know if this affects any tests you have in app.