### PR TITLE
RSDK-8831 - Add log for failing module restart

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -830,6 +830,7 @@ func (mgr *Manager) newOnUnexpectedExitHandler(mod *module) func(exitCode int) b
 		if orphanedResourceNames := mgr.attemptRestart(mgr.restartCtx, mod); orphanedResourceNames != nil {
 			if mgr.removeOrphanedResources != nil {
 				mgr.removeOrphanedResources(mgr.restartCtx, orphanedResourceNames)
+				mgr.logger.Debugw("Removed resources after failed module restart", "module", mod.cfg.Name, "resources", orphanedResourceNames)
 			}
 			return false
 		}

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -530,8 +530,8 @@ func TestModuleReloading(t *testing.T) {
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			test.That(tb, logs.FilterMessageSnippet("Error while restarting crashed module").Len(),
-				test.ShouldEqual, 3)
+			test.That(tb, logs.FilterMessageSnippet("Removed resources after failed module restart").Len(),
+				test.ShouldEqual, 1)
 		})
 
 		ok = mgr.IsModularResource(rNameMyHelper)
@@ -546,6 +546,8 @@ func TestModuleReloading(t *testing.T) {
 			test.ShouldEqual, 1)
 		test.That(t, logs.FilterMessageSnippet("Module successfully restarted").Len(),
 			test.ShouldEqual, 0)
+		test.That(t, logs.FilterMessageSnippet("Error while restarting crashed module").Len(),
+			test.ShouldEqual, 3)
 
 		// Assert that RemoveOrphanedResources was called once.
 		test.That(t, dummyRemoveOrphanedResourcesCallCount.Load(), test.ShouldEqual, 1)
@@ -587,7 +589,7 @@ func TestModuleReloading(t *testing.T) {
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			test.That(tb, logs.FilterMessageSnippet("Will not attempt to restart crashed module").Len(),
+			test.That(tb, logs.FilterMessageSnippet("Removed resources after failed module restart").Len(),
 				test.ShouldEqual, 1)
 		})
 
@@ -598,11 +600,13 @@ func TestModuleReloading(t *testing.T) {
 		test.That(t, err.Error(), test.ShouldContainSubstring, "not connected")
 
 		// Assert that logs reflect that test-module crashed and was not
-		// successfully restarted.
+		// restarted.
 		test.That(t, logs.FilterMessageSnippet("Module has unexpectedly exited").Len(),
 			test.ShouldEqual, 1)
 		test.That(t, logs.FilterMessageSnippet("Module successfully restarted").Len(),
 			test.ShouldEqual, 0)
+		test.That(t, logs.FilterMessageSnippet("Will not attempt to restart crashed module").Len(),
+			test.ShouldEqual, 1)
 
 		// Assert that RemoveOrphanedResources was called once.
 		test.That(t, dummyRemoveOrphanedResourcesCallCount.Load(), test.ShouldEqual, 1)


### PR DESCRIPTION
log looks like

```
manager.go:834: 2024-09-20T12:18:41.701-0400        DEBUG   modmanager      modmanager/manager.go:834       Removed resources after failed module restart    {"module":"test-module","resources":[{"API":"rdk:component:generic","Remote":"","Name":"myhelper"}]}
```

could perhaps make the list a little prettier, but this will do for now.

Since we weren't waiting for OnUnexpectedHandler to actually exit, there's a chance that the log assertion we were waiting for to pass but the remove orphaned resources method to not have run yet. Could repro the failure with a sleep right before the mgr.removeOrphanedResources call. So added an extra log and wait for that log instead