### PR TITLE
RSDK-8840 - Add set speed and acceleration function to xArm doCommand

### DIFF
--- a/components/arm/xarm/xarm.go
+++ b/components/arm/xarm/xarm.go
@@ -257,7 +257,14 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[s
 		return x.getLoad(ctx)
 	}
 	if val, ok := cmd["set_speed"]; ok {
-		speed, err := utils.AssertType[float64](val)
+		interfaceList, err := utils.AssertType[[]interface{}](val)
+		if err != nil {
+			return nil, err
+		}
+		if len(interfaceList) != 1 {
+			return nil, errors.New("set_speed is incorrectly formatted, expected a slice of length 1")
+		}
+		speed, err := utils.AssertType[float64](interfaceList[0])
 		if err != nil {
 			return nil, err
 		}
@@ -268,7 +275,14 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[s
 		return map[string]interface{}{}, nil
 	}
 	if val, ok := cmd["set_acceleration"]; ok {
-		acceleration, err := utils.AssertType[float64](val)
+		interfaceList, err := utils.AssertType[[]interface{}](val)
+		if err != nil {
+			return nil, err
+		}
+		if len(interfaceList) != 1 {
+			return nil, errors.New("set_speed is incorrectly formatted, expected a slice of length 1")
+		}
+		acceleration, err := utils.AssertType[float64](interfaceList[0])
 		if err != nil {
 			return nil, err
 		}

--- a/components/arm/xarm/xarm.go
+++ b/components/arm/xarm/xarm.go
@@ -235,24 +235,24 @@ func (x *xArm) ModelFrame() referenceframe.Model {
 }
 
 func (x *xArm) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
-	err := x.enableGripper(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if err = x.setGripperMode(ctx, false); err != nil {
-		return nil, err
-	}
-
 	resp := map[string]interface{}{}
 	validCommand := false
 
+	if _, ok := cmd["setup_gripper"]; ok {
+		if err := x.enableGripper(ctx); err != nil {
+			return nil, err
+		}
+		if err := x.setGripperMode(ctx, false); err != nil {
+			return nil, err
+		}
+		validCommand = true
+	}
 	if val, ok := cmd["move_gripper"]; ok {
 		position, ok := val.(float64)
 		if !ok || position < -10 || position > 850 {
 			return nil, fmt.Errorf("must move gripper to an int between 0 and 840 %v", val)
 		}
-		err = x.setGripperPosition(ctx, uint32(position))
-		if err != nil {
+		if err := x.setGripperPosition(ctx, uint32(position)); err != nil {
 			return nil, err
 		}
 		validCommand = true

--- a/components/arm/xarm/xarm.go
+++ b/components/arm/xarm/xarm.go
@@ -255,5 +255,25 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[s
 	if _, ok := cmd["load"]; ok {
 		return x.getLoad(ctx)
 	}
+	if val, ok := cmd["set"]; ok {
+		// The command expects a float64 slice of length 2, describing the desired speed and acceleration.
+		// We specify our values in degrees and here they are converted into radians.
+		interfaceList, err := utils.AssertType[[]interface{}](val)
+		if err != nil {
+			return nil, err
+		}
+		speed, ok := interfaceList[0].(float64)
+		if !ok {
+			return nil, errors.New("could not get float64 from interfaceList[0]")
+		}
+		acceleration, ok := interfaceList[1].(float64)
+		if !ok {
+			return nil, errors.New("could not get float64 from interfaceList[1]")
+		}
+		x.speed = utils.DegToRad(speed)
+		x.acceleration = utils.DegToRad(acceleration)
+		return map[string]interface{}{}, nil
+	}
+
 	return nil, errors.New("command not found")
 }

--- a/components/arm/xarm/xarm.go
+++ b/components/arm/xarm/xarm.go
@@ -264,19 +264,7 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[s
 		if !ok {
 			return nil, errors.New("could not read loadInformation")
 		}
-		loadInterfaceList, err := utils.AssertType[[]interface{}](loadInformationInterface)
-		if err != nil {
-			return nil, err
-		}
-		loads := make([]float64, len(loadInterfaceList))
-		for i, l := range loadInterfaceList {
-			loadValue, err := utils.AssertType[float64](l)
-			if err != nil {
-				return nil, err
-			}
-			loads[i] = loadValue
-		}
-		resp["load"] = loads
+		resp["load"] = loadInformationInterface
 	}
 	if val, ok := cmd["set_speed"]; ok {
 		speed, err := utils.AssertType[float64](val)

--- a/components/arm/xarm/xarm.go
+++ b/components/arm/xarm/xarm.go
@@ -244,6 +244,7 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[s
 	}
 
 	resp := map[string]interface{}{}
+	validCommand := false
 
 	if val, ok := cmd["move_gripper"]; ok {
 		position, ok := val.(float64)
@@ -254,6 +255,7 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[s
 		if err != nil {
 			return nil, err
 		}
+		validCommand = true
 	}
 	if _, ok := cmd["load"]; ok {
 		loadInformation, err := x.getLoad(ctx)
@@ -265,6 +267,7 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[s
 			return nil, errors.New("could not read loadInformation")
 		}
 		resp["load"] = loadInformationInterface
+		validCommand = true
 	}
 	if val, ok := cmd["set_speed"]; ok {
 		speed, err := utils.AssertType[float64](val)
@@ -275,6 +278,7 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[s
 			return nil, errors.New("speed cannot be less than or equal to zero")
 		}
 		x.speed = utils.DegToRad(speed)
+		validCommand = true
 	}
 	if val, ok := cmd["set_acceleration"]; ok {
 		acceleration, err := utils.AssertType[float64](val)
@@ -285,7 +289,11 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[s
 			return nil, errors.New("acceleration cannot be less than or equal to zero")
 		}
 		x.acceleration = utils.DegToRad(acceleration)
+		validCommand = true
 	}
 
+	if !validCommand {
+		return nil, errors.New("command not found")
+	}
 	return resp, nil
 }

--- a/components/arm/xarm/xarm.go
+++ b/components/arm/xarm/xarm.go
@@ -257,14 +257,7 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[s
 		return x.getLoad(ctx)
 	}
 	if val, ok := cmd["set_speed"]; ok {
-		interfaceList, err := utils.AssertType[[]interface{}](val)
-		if err != nil {
-			return nil, err
-		}
-		if len(interfaceList) != 1 {
-			return nil, errors.New("set_speed is incorrectly formatted, expected a slice of length 1")
-		}
-		speed, err := utils.AssertType[float64](interfaceList[0])
+		speed, err := utils.AssertType[float64](val)
 		if err != nil {
 			return nil, err
 		}
@@ -275,14 +268,7 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[s
 		return map[string]interface{}{}, nil
 	}
 	if val, ok := cmd["set_acceleration"]; ok {
-		interfaceList, err := utils.AssertType[[]interface{}](val)
-		if err != nil {
-			return nil, err
-		}
-		if len(interfaceList) != 1 {
-			return nil, errors.New("set_speed is incorrectly formatted, expected a slice of length 1")
-		}
-		acceleration, err := utils.AssertType[float64](interfaceList[0])
+		acceleration, err := utils.AssertType[float64](val)
 		if err != nil {
 			return nil, err
 		}

--- a/components/arm/xarm/xarm.go
+++ b/components/arm/xarm/xarm.go
@@ -251,26 +251,30 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[s
 		if err != nil {
 			return nil, err
 		}
+		return map[string]interface{}{}, nil
 	}
 	if _, ok := cmd["load"]; ok {
 		return x.getLoad(ctx)
 	}
-	if val, ok := cmd["set"]; ok {
-		// The command expects a float64 slice of length 2, describing the desired speed and acceleration.
-		// We specify our values in degrees and here they are converted into radians.
-		interfaceList, err := utils.AssertType[[]interface{}](val)
+	if val, ok := cmd["set_speed"]; ok {
+		speed, err := utils.AssertType[float64](val)
 		if err != nil {
 			return nil, err
 		}
-		speed, ok := interfaceList[0].(float64)
-		if !ok {
-			return nil, errors.New("could not get float64 from interfaceList[0]")
-		}
-		acceleration, ok := interfaceList[1].(float64)
-		if !ok {
-			return nil, errors.New("could not get float64 from interfaceList[1]")
+		if speed <= 0 {
+			return nil, errors.New("speed cannot be less than or equal to zero")
 		}
 		x.speed = utils.DegToRad(speed)
+		return map[string]interface{}{}, nil
+	}
+	if val, ok := cmd["set_acceleration"]; ok {
+		acceleration, err := utils.AssertType[float64](val)
+		if err != nil {
+			return nil, err
+		}
+		if acceleration <= 0 {
+			return nil, errors.New("acceleration cannot be less than or equal to zero")
+		}
 		x.acceleration = utils.DegToRad(acceleration)
 		return map[string]interface{}{}, nil
 	}


### PR DESCRIPTION
Add to the xArm's DoCommand. 
This DoCommand is used within the wine pouring demo.
This allows us to set a higher acceleration and speed for when we want to de-pour.
A higher speed and acceleration prevents the wine from dribbling out of the bottle on the de-pour.
This is being added so that people other than me can run the demo here in nyc.