### PR TITLE
RSDK-8836: Gantry Can't Home with Limit Switches

### DIFF
--- a/components/gantry/singleaxis/singleaxis.go
+++ b/components/gantry/singleaxis/singleaxis.go
@@ -442,20 +442,22 @@ func (g *singleAxis) testLimit(ctx context.Context, pin int) (float64, error) {
 			break
 		}
 
-		// check if the wrong limit switch was hit
-		wrongHit, err := g.limitHit(ctx, wrongPin)
-		if err != nil {
-			return 0, err
-		}
-		if wrongHit {
-			err = g.motor.Stop(ctx, nil)
+		if len(g.limitSwitchPins) > 1 {
+			// check if the wrong limit switch was hit
+			wrongHit, err := g.limitHit(ctx, wrongPin)
 			if err != nil {
 				return 0, err
 			}
-			return 0, errors.Errorf(
-				"expected limit switch %v but hit limit switch %v, try switching the order in the config",
-				pin,
-				wrongPin)
+			if wrongHit {
+				err = g.motor.Stop(ctx, nil)
+				if err != nil {
+					return 0, err
+				}
+				return 0, errors.Errorf(
+					"expected limit switch %v but hit limit switch %v, try switching the order in the config",
+					pin,
+					wrongPin)
+			}
 		}
 
 		elapsed := time.Since(start)


### PR DESCRIPTION
when checking if the gantry hit a limit switch during homing, we were also checking if it hit the other limit switch that we didn't expect, and returned an error so the user knows their limit switches aren't configured correctly. this caused an out of range error when there was only 1 limit switch since there isn't a second limit switch to check but we were assuming there was.

I thought there'd be a software test to check this but all the functions, specifically `GPIOPinByName` are injected so it failed when we told it to and passed when we told it to. looking for suggestions of a good way to add a test for this even now that it's fixed