### PR TITLE
add a wrapper around motion/builtin DoCommand utilities

### DIFF
--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -1303,7 +1303,7 @@ func TestDoCommand(t *testing.T) {
 		test.That(t, len(trajectory), test.ShouldEqual, 2)
 	})
 
-	t.Run("DoExectute", func(t *testing.T) {
+	t.Run("DoExecute", func(t *testing.T) {
 		ms, teardown := setupMotionServiceFromConfig(t, "../data/moving_arm.json")
 		defer teardown()
 

--- a/services/motion/builtin/experimental/do_wrappers.go
+++ b/services/motion/builtin/experimental/do_wrappers.go
@@ -1,3 +1,5 @@
+// Package experimental contains functions which extend the motion/builtin resource with additional functionality
+// the code contained within it comes with no stability guarantees and is likely to change often
 package experimental
 
 import (
@@ -5,13 +7,14 @@ import (
 	"errors"
 
 	"github.com/go-viper/mapstructure/v2"
+	"google.golang.org/protobuf/encoding/protojson"
+
 	"go.viam.com/rdk/motionplan"
 	"go.viam.com/rdk/services/motion"
 	"go.viam.com/rdk/services/motion/builtin"
-	"go.viam.com/utils/web/protojson"
 )
 
-// DoPlan is a helper function to wrap doPlan (a utility inside DoCommand) with types that are easier to work with.
+// DoPlan is a helper function to wrap DoPlan (a utility inside builtin/DoCommand) with types that are easier to work with.
 func DoPlan(ctx context.Context, ms motion.Service, req motion.MoveReq) (motionplan.Trajectory, error) {
 	proto, err := req.ToProto(ms.Name().Name)
 	if err != nil {
@@ -34,7 +37,7 @@ func DoPlan(ctx context.Context, ms motion.Service, req motion.MoveReq) (motionp
 	return trajectory, err
 }
 
-// DoExecute is a helper function to wrap doExecute (a utility inside DoCommand) with types that are easier to work with.
+// DoExecute is a helper function to wrap DoExecute (a utility inside builtin/DoCommand) with types that are easier to work with.
 func DoExecute(ctx context.Context, ms motion.Service, traj motionplan.Trajectory) error {
 	_, err := ms.DoCommand(ctx, map[string]interface{}{builtin.DoExecute: traj})
 	return err

--- a/services/motion/builtin/experimental/do_wrappers.go
+++ b/services/motion/builtin/experimental/do_wrappers.go
@@ -1,0 +1,41 @@
+package experimental
+
+import (
+	"context"
+	"errors"
+
+	"github.com/go-viper/mapstructure/v2"
+	"go.viam.com/rdk/motionplan"
+	"go.viam.com/rdk/services/motion"
+	"go.viam.com/rdk/services/motion/builtin"
+	"go.viam.com/utils/web/protojson"
+)
+
+// DoPlan is a helper function to wrap doPlan (a utility inside DoCommand) with types that are easier to work with.
+func DoPlan(ctx context.Context, ms motion.Service, req motion.MoveReq) (motionplan.Trajectory, error) {
+	proto, err := req.ToProto(ms.Name().Name)
+	if err != nil {
+		return nil, err
+	}
+	bytes, err := protojson.Marshal(proto)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := ms.DoCommand(ctx, map[string]interface{}{builtin.DoPlan: string(bytes)})
+	if err != nil {
+		return nil, err
+	}
+	respMap, ok := resp[builtin.DoPlan]
+	if !ok {
+		return nil, errors.New("could not find Trajectory in DoCommand response")
+	}
+	var trajectory motionplan.Trajectory
+	err = mapstructure.Decode(respMap, &trajectory)
+	return trajectory, err
+}
+
+// DoExecute is a helper function to wrap doExecute (a utility inside DoCommand) with types that are easier to work with.
+func DoExecute(ctx context.Context, ms motion.Service, traj motionplan.Trajectory) error {
+	_, err := ms.DoCommand(ctx, map[string]interface{}{builtin.DoExecute: traj})
+	return err
+}


### PR DESCRIPTION
This PR builds on https://github.com/viamrobotics/rdk/pull/4287 by adding wrapper functions to the builtin package to make using DoCommand more ergonomic.  

I tested these locally by duplicating the `TestDoCommand` function but decided against committing it since its entirely duplicative of that function