### PR TITLE
[RSDK-8849] Change low rpm error to warning and limit zeroRpm tracker to make logs less noisy

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -76,7 +76,7 @@ jobs:
 
   test:
     needs: docker-cache
-    uses: viamrobotics/rdk/.github/workflows/test.yml@main
+    uses: ./.github/workflows/test.yml
     secrets:
       MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
       DOCKER_PUBLIC_READONLY_PAT: ${{ secrets.DOCKER_PUBLIC_READONLY_PAT }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -76,7 +76,7 @@ jobs:
 
   test:
     needs: docker-cache
-    uses: ./.github/workflows/test.yml
+    uses: viamrobotics/rdk/.github/workflows/test.yml@main
     secrets:
       MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
       DOCKER_PUBLIC_READONLY_PAT: ${{ secrets.DOCKER_PUBLIC_READONLY_PAT }}

--- a/components/motor/gpio/encoded.go
+++ b/components/motor/gpio/encoded.go
@@ -174,7 +174,7 @@ func (m *EncodedMotor) makeAdjustments(ctx context.Context, goalRPM, goalPos, di
 		if deltaTime == 0.0 {
 			currentRPM = 0
 			zeroRPMTracker++
-			m.logger.Debug("zero time delta calculated between motor powe adjustments")
+			m.logger.Debug("zero time delta calculated between motor power adjustments")
 		} else {
 			currentRPM = deltaPos / deltaTime
 			if currentRPM == 0 {

--- a/components/motor/gpio/encoded.go
+++ b/components/motor/gpio/encoded.go
@@ -182,7 +182,8 @@ func (m *EncodedMotor) makeAdjustments(ctx context.Context, goalRPM, goalPos, di
 			}
 		}
 		if zeroRPMTracker > 20 {
-			m.logger.Warnf("motor running at too low an rpm %v for stable motion: %v, trying to run at %v rpm, check if stalled or try increasing the motor's rpm",
+			m.logger.Warnf(
+			"motor running at too low an rpm %v for stable motion: %v, trying to run at %v rpm, check if stalled or try increasing the motor's rpm",
 				m.Name().Name, currentRPM, goalRPM)
 			zeroRPMTracker = 0
 		}

--- a/components/motor/gpio/encoded.go
+++ b/components/motor/gpio/encoded.go
@@ -183,7 +183,7 @@ func (m *EncodedMotor) makeAdjustments(ctx context.Context, goalRPM, goalPos, di
 		}
 		if zeroRPMTracker > 20 {
 			m.logger.Warnf(
-			"motor running at too low an rpm %v for stable motion: %v, trying to run at %v rpm, check if stalled or try increasing the motor's rpm",
+				"motor running at too low an rpm %v for stable motion: %v, trying to run at %v rpm, check if stalled or try increasing the motor's rpm",
 				m.Name().Name, currentRPM, goalRPM)
 			zeroRPMTracker = 0
 		}

--- a/components/motor/gpio/encoded.go
+++ b/components/motor/gpio/encoded.go
@@ -183,7 +183,8 @@ func (m *EncodedMotor) makeAdjustments(ctx context.Context, goalRPM, goalPos, di
 		}
 		if zeroRPMTracker > 20 {
 			m.logger.Warnf(
-				"%v motor running at too low an rpm [%v] for stable motion: trying to run at %v rpm, check if stalled or try increasing the motor's rpm",
+				"%v motor running at too low an rpm [%v] for stable motion:"+
+					"trying to run at %v rpm, check if stalled or try increasing the motor's rpm",
 				m.Name().Name, currentRPM, goalRPM)
 			zeroRPMTracker = 0
 		}

--- a/components/motor/gpio/encoded.go
+++ b/components/motor/gpio/encoded.go
@@ -182,7 +182,7 @@ func (m *EncodedMotor) makeAdjustments(ctx context.Context, goalRPM, goalPos, di
 			}
 		}
 		if zeroRPMTracker > 20 {
-			m.logger.Warnf("error running motor %v, current rpm is too low for stable motion: %v, asked to go at %v rpm",
+			m.logger.Warnf("motor running at too low an rpm %v for stable motion: %v, trying to run at %v rpm, check if stalled",
 				m.Name().Name, currentRPM, goalRPM)
 			zeroRPMTracker = 0
 		}

--- a/components/motor/gpio/encoded.go
+++ b/components/motor/gpio/encoded.go
@@ -183,7 +183,7 @@ func (m *EncodedMotor) makeAdjustments(ctx context.Context, goalRPM, goalPos, di
 		}
 		if zeroRPMTracker > 20 {
 			m.logger.Warnf(
-				"motor running at too low an rpm %v for stable motion: %v, trying to run at %v rpm, check if stalled or try increasing the motor's rpm",
+				"%v motor running at too low an rpm [%v] for stable motion: trying to run at %v rpm, check if stalled or try increasing the motor's rpm",
 				m.Name().Name, currentRPM, goalRPM)
 			zeroRPMTracker = 0
 		}

--- a/components/motor/gpio/encoded.go
+++ b/components/motor/gpio/encoded.go
@@ -173,14 +173,18 @@ func (m *EncodedMotor) makeAdjustments(ctx context.Context, goalRPM, goalPos, di
 		var currentRPM float64
 		if deltaTime == 0.0 {
 			currentRPM = 0
+			zeroRPMTracker++
+			m.logger.Debug("zero time delta calculated between motor powe adjustments")
 		} else {
 			currentRPM = deltaPos / deltaTime
 			if currentRPM == 0 {
 				zeroRPMTracker++
 			}
 		}
-		if zeroRPMTracker > 10 {
-			m.logger.Errorf("error running motor %v, desired rpm is too low for stable motion: %v", m.Name().Name, goalRPM)
+		if zeroRPMTracker > 20 {
+			m.logger.Warnf("error running motor %v, current rpm is too low for stable motion: %v, asked to go at %v rpm",
+				m.Name().Name, currentRPM, goalRPM)
+			zeroRPMTracker = 0
 		}
 
 		newPower, err := m.calcNewPowerPct(ctx, currentRPM, goalRPM, lastPowerPct, direction)

--- a/components/motor/gpio/encoded.go
+++ b/components/motor/gpio/encoded.go
@@ -182,7 +182,7 @@ func (m *EncodedMotor) makeAdjustments(ctx context.Context, goalRPM, goalPos, di
 			}
 		}
 		if zeroRPMTracker > 20 {
-			m.logger.Warnf("motor running at too low an rpm %v for stable motion: %v, trying to run at %v rpm, check if stalled",
+			m.logger.Warnf("motor running at too low an rpm %v for stable motion: %v, trying to run at %v rpm, check if stalled or try increasing the motor's rpm",
 				m.Name().Name, currentRPM, goalRPM)
 			zeroRPMTracker = 0
 		}


### PR DESCRIPTION
Make it a bit less alarming and opt to warn users that we're going a slow motor speeds.

Tell users them what rpm the motor is going at compared to what they requested. 

Reset the zerorpm tracker so it doesn't continuously spam after the first time this condition is hit. cc @npentrel.