### PR TITLE
hotfix/credentials

### DIFF
--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -1550,6 +1550,7 @@
       "resolved": "https://registry.npmjs.org/@viamrobotics/sdk/-/sdk-0.24.0.tgz",
       "integrity": "sha512-yrcgu2w3++KltlgwrUro6Bt+2Ywc2NEStVGB4sNsGZfno68ZhMv+1nkTsLgP1ccFUBnjXkpZJ0OLJ7cS/tSVWw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@viamrobotics/rpc": "^0.2.6",
         "exponential-backoff": "^3.1.1"

--- a/web/frontend/src/lib/components/robot-client.svelte
+++ b/web/frontend/src/lib/components/robot-client.svelte
@@ -8,8 +8,8 @@ import {
   Client,
   robotApi,
   commonApi,
-  Credentials as SDKCredentials,
   type ServiceError,
+  type CredentialType,
 } from '@viamrobotics/sdk';
 import { notify } from '@viamrobotics/prime';
 import { StreamManager } from '@/lib/stream-manager';
@@ -442,9 +442,20 @@ const start = () => {
 const connect = async (creds?: Credentials, authEntity?: string) => {
   $connectionStatus = 'connecting';
 
+  let sdkCreds = undefined;
+  const c = creds ?? bakedAuth.creds;
+  const ae = authEntity ?? bakedAuth.authEntity;
+  if (c && ae) {
+    sdkCreds = {
+      type: c.type as CredentialType,
+      payload: c.payload,
+      authEntity: ae,
+    };
+  }
+
   await $robotClient.connect({
     authEntity: authEntity ?? bakedAuth.authEntity,
-    creds: { authEntity: authEntity ?? bakedAuth.authEntity, ...creds },
+    creds: sdkCreds,
     priority: 1,
   });
 

--- a/web/frontend/src/lib/components/robot-client.svelte
+++ b/web/frontend/src/lib/components/robot-client.svelte
@@ -8,6 +8,7 @@ import {
   Client,
   robotApi,
   commonApi,
+  Credentials as SDKCredentials,
   type ServiceError,
 } from '@viamrobotics/sdk';
 import { notify } from '@viamrobotics/prime';
@@ -443,7 +444,7 @@ const connect = async (creds?: Credentials, authEntity?: string) => {
 
   await $robotClient.connect({
     authEntity: authEntity ?? bakedAuth.authEntity,
-    creds: creds ?? bakedAuth.creds,
+    creds: { authEntity: authEntity ?? bakedAuth.authEntity, ...creds },
     priority: 1,
   });
 


### PR DESCRIPTION
The TS SDK introduced a new `Credentials` type to manage both access tokens and normal credentials.

The `RobotClient.connect` function previously took a different `Credentials` type. That type was change at import time to a differently named import, so I didn't catch that the type had actually changed since the signature was the same.

Here I changed the connect function to provide the appropriate `Credentials` type.