### PR TITLE
Clearer resource diff in tests for VerifySameResources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.4.6
 	github.com/jhump/protoreflect v1.15.1
 	github.com/kellydunn/golang-geo v0.7.0
+	github.com/kylelemons/godebug v1.1.0
 	github.com/lestrrat-go/jwx v1.2.29
 	github.com/lmittmann/ppm v1.0.2
 	github.com/lucasb-eyer/go-colorful v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -877,6 +877,7 @@ github.com/kunwardeep/paralleltest v1.0.8 h1:Ul2KsqtzFxTlSU7IP0JusWlLiNqQaloB9vg
 github.com/kunwardeep/paralleltest v1.0.8/go.mod h1:2C7s65hONVqY7Q5Efj5aLzRCNLjw2h4eMc9EcypGjcY=
 github.com/kylelemons/go-gypsy v1.0.0 h1:7/wQ7A3UL1bnqRMnZ6T8cwCOArfZCxFmb1iTxaOOo1s=
 github.com/kylelemons/go-gypsy v1.0.0/go.mod h1:chkXM0zjdpXOiqkCW1XcCHDfjfk14PH2KKkQWxfJUcU=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/kyoh86/exportloopref v0.1.8/go.mod h1:1tUcJeiioIs7VWe5gcOObrux3lb66+sBqGZrRkMwPgg=
 github.com/kyoh86/exportloopref v0.1.11 h1:1Z0bcmTypkL3Q4k+IDHMWTcnCliEZcaPiIe0/ymEyhQ=

--- a/testutils/resource_utils.go
+++ b/testutils/resource_utils.go
@@ -4,9 +4,11 @@ import (
 	"cmp"
 	"context"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/kylelemons/godebug/pretty"
 	"go.viam.com/test"
 
 	"go.viam.com/rdk/resource"
@@ -57,11 +59,35 @@ func newSortedResourceNames(resourceNames []resource.Name) []resource.Name {
 }
 
 // VerifySameResourceNames asserts that two slices of resource.Names contain the same
-// resources.Names without considering order.
+// resources.Names without considering order. To make debugging failures easier, this
+// function prints out differing [resource.Name] elements both as structs and
+// strings.
 func VerifySameResourceNames(tb testing.TB, actual, expected []resource.Name) {
 	tb.Helper()
 
-	test.That(tb, newSortedResourceNames(actual), test.ShouldResemble, newSortedResourceNames(expected))
+	actualSorted := newSortedResourceNames(actual)
+	expectedSorted := newSortedResourceNames(expected)
+
+	// This deferred function provides more concise output for debugging on failure
+	defer func() {
+		if !tb.Failed() {
+			return
+		}
+		var sb strings.Builder
+		expectedNames := make([]string, len(expectedSorted))
+		actualNames := make([]string, len(actualSorted))
+		for i, exp := range expectedSorted {
+			expectedNames[i] = exp.String()
+		}
+		for i, act := range actualSorted {
+			actualNames[i] = act.String()
+		}
+		sb.WriteString("Resource names do not match - see diff below: (-expected +actual)\n")
+		sb.WriteString(pretty.Compare(expectedNames, actualNames))
+		tb.Log(sb.String())
+	}()
+
+	test.That(tb, actualSorted, test.ShouldResemble, expectedSorted)
 }
 
 // VerifySameResourceStatuses asserts that two slices of [resource.Status] contain the


### PR DESCRIPTION
Pulled out of https://github.com/viamrobotics/rdk/pull/4273 - provides a more concise diff of resources when the test utility `VerifySameResources` fails. The current (verbose) diff is still included in the failure output.


#### Example output

```
# current (verbose)
robot_reconfigure_remote_test.go:143: Expected: '[]resource.Name{resource.Name{API:resource.API{Type:resource.APIType{Namespace:resource.APINamespace("rdk"), Name:"component"}, SubtypeName:"arm"}, Remote:"", Name:"arm1"}, resource.Name{API:resource.API{Type:resource.APIType{Namespace:resource.APINamespace("rdk"), Name:"component"}, SubtypeName:"arm"}, Remote:"foo", Name:"remoteArm"}, resource.Name{API:resource.API{Type:resource.APIType{Namespace:resource.APINamespace("rdk"), Name:"service"}, SubtypeName:"motion"}, Remote:"", Name:"builtin"}, resource.Name{API:resource.API{Type:resource.APIType{Namespace:resource.APINamespace("rdk"), Name:"service"}, SubtypeName:"motion"}, Remote:"foo", Name:"builtin"}, resource.Name{API:resource.API{Type:resource.APIType{Namespace:resource.APINamespace("rdk"), Name:"service"}, SubtypeName:"sensors"}, Remote:"", Name:"builtin"}, resource.Name{API:resource.API{Type:resource.APIType{Namespace:resource.APINamespace("rdk"), Name:"service"}, SubtypeName:"sensors"}, Remote:"foo", Name:"builtin"}}'
        Actual:   '[]resource.Name{resource.Name{API:resource.API{Type:resource.APIType{Namespace:resource.APINamespace("rdk"), Name:"component"}, SubtypeName:"arm"}, Remote:"", Name:"arm1"}, resource.Name{API:resource.API{Type:resource.APIType{Namespace:resource.APINamespace("rdk"), Name:"component"}, SubtypeName:"arm"}, Remote:"foo", Name:"remoteArm"}, resource.Name{API:resource.API{Type:resource.APIType{Namespace:resource.APINamespace("rdk"), Name:"remote"}, SubtypeName:""}, Remote:"", Name:"foo"}, resource.Name{API:resource.API{Type:resource.APIType{Namespace:resource.APINamespace("rdk"), Name:"service"}, SubtypeName:"motion"}, Remote:"", Name:"builtin"}, resource.Name{API:resource.API{Type:resource.APIType{Namespace:resource.APINamespace("rdk"), Name:"service"}, SubtypeName:"motion"}, Remote:"foo", Name:"builtin"}, resource.Name{API:resource.API{Type:resource.APIType{Namespace:resource.APINamespace("rdk"), Name:"service"}, SubtypeName:"sensors"}, Remote:"", Name:"builtin"}, resource.Name{API:resource.API{Type:resource.APIType{Namespace:resource.APINamespace("rdk"), Name:"service"}, SubtypeName:"sensors"}, Remote:"foo", Name:"builtin"}}'
        (Should resemble)!
        Diff:     '[]resource.Name{resource.Name{API:resource.API{Type:resource.APIType{Namespace:resource.APINamespace("rdk"), Name:"component"}, SubtypeName:"arm"}, Remote:"", Name:"arm1"}, resource.Name{API:resource.API{Type:resource.APIType{Namespace:resource.APINamespace("rdk"), Name:"component"}, SubtypeName:"arm"}, Remote:"foo", Name:"remoteArm"}, resource.Name{API:resource.API{Type:resource.APIType{Namespace:resource.APINamespace("rdk"), Name:"remote"}, SubtypeName:""}, Remote:"", Name:"foo"}, resource.Name{API:resource.API{Type:resource.APIType{Namespace:resource.APINamespace("rdk"), Name:"service"}, SubtypeName:"motion"}, Remote:"", Name:"builtin"}, resource.Name{API:resource.API{Type:resource.APIType{Namespace:resource.APINamespace("rdk"), Name:"service"}, SubtypeName:"motion"}, Remote:"foo", Name:"builtin"}, resource.Name{API:resource.API{Type:resource.APIType{Namespace:resource.APINamespace("rdk"), Name:"service"}, SubtypeName:"sensors"}, Remote:"", Name:"builtin"}, resource.Name{API:resource.API{Type:resource.APIType{Namespace:resource.APINamespace("rdk"), Name:"service"}, SubtypeName:"sensors"}, Remote:"foo", Name:"builtin"}}'
      
# added (concise)
    resource_utils.go:92: Resource names do not match - see diff below: (-expected +actual)
         [
          "rdk:component:arm/arm1",
          "rdk:component:arm/foo:remoteArm",
        + "rdk:remote:/foo",
          "rdk:service:motion/builtin",
          "rdk:service:motion/foo:builtin",
          "rdk:service:sensors/builtin",
          "rdk:service:sensors/foo:builtin",
         ]
```