### PR TITLE
RSDK-8736: Only keep last error instead of joining

### DIFF
--- a/resource/graph_node.go
+++ b/resource/graph_node.go
@@ -270,7 +270,7 @@ func (w *GraphNode) MarkedForRemoval() bool {
 // The additional `args` should come in key/value pairs for structured logging.
 func (w *GraphNode) LogAndSetLastError(err error, args ...any) {
 	w.mu.Lock()
-	w.lastErr = errors.Join(w.lastErr, err)
+	w.lastErr = err
 	w.transitionTo(NodeStateUnhealthy)
 	w.mu.Unlock()
 

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -3517,7 +3517,7 @@ func TestMachineStatus(t *testing.T) {
 					Name:     mockNamed("m"),
 					State:    resource.NodeStateUnhealthy,
 					Revision: rev2,
-					Error:    errors.Join(expectedConfigError),
+					Error:    expectedConfigError,
 				},
 			},
 		)


### PR DESCRIPTION
viam-server can have multiple successive config failures very quickly, which leads to some very long error messages