### PR TITLE
RSDK-8858 Add frame_rate to webcam driver

### DIFF
--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -157,7 +157,7 @@ func (c WebcamConfig) Validate(path string) ([]string, error) {
 			"got illegal negative dimensions for width_px and height_px (%d, %d) fields set for webcam camera",
 			c.Height, c.Width)
 	}
-	if c.FrameRate <= 0 {
+	if c.FrameRate < 0 {
 		return nil, fmt.Errorf(
 			"got illegal non-positive dimension for frame rate (%.2f) field set for webcam camera",
 			c.FrameRate)

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -157,6 +157,11 @@ func (c WebcamConfig) Validate(path string) ([]string, error) {
 			"got illegal negative dimensions for width_px and height_px (%d, %d) fields set for webcam camera",
 			c.Height, c.Width)
 	}
+	if c.FrameRate <= 0 {
+		return nil, fmt.Errorf(
+			"got illegal non-positive dimension for frame rate (%.2f) field set for webcam camera",
+			c.FrameRate)
+	}
 
 	return []string{}, nil
 }
@@ -640,7 +645,7 @@ func (c *monitoredWebcam) Properties(ctx context.Context) (camera.Properties, er
 		}
 		props.IntrinsicParams = &cameraIntrinsics
 
-		if c.conf.FrameRate != 0 {
+		if c.conf.FrameRate > 0 {
 			props.FrameRate = c.conf.FrameRate
 		}
 	}

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -639,6 +639,10 @@ func (c *monitoredWebcam) Properties(ctx context.Context) (camera.Properties, er
 			c.hasLoggedIntrinsicsInfo = true
 		}
 		props.IntrinsicParams = &cameraIntrinsics
+
+		if c.conf.FrameRate != 0 {
+			props.FrameRate = c.conf.FrameRate
+		}
 	}
 	return props, nil
 }

--- a/components/camera/videosource/webcam_e2e_test.go
+++ b/components/camera/videosource/webcam_e2e_test.go
@@ -119,4 +119,19 @@ func TestWebcamGetImage(t *testing.T) {
 
 	test.That(t, img.Bounds().Dx(), test.ShouldEqual, 1280)
 	test.That(t, img.Bounds().Dy(), test.ShouldEqual, 720)
+
+	// new camera for frame rate test
+	// fakeFrameRate = 10.0
+	var props camera.Properties
+	conf = newWebcamConfig("cam3", "video64")
+	cam3, err := videosource.NewWebcam(cancelCtx, nil, conf, logger)
+	props, err = cam3.Properties(cancelCtx)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, props.FrameRate, test.ShouldEqual, 0.0) //without setting frame rate
+	// test.That(t, props.FrameRate, test.ShouldBeNil) //without setting frame rate ?? not sure about this one
+	// props.FrameRate = fakeFrameRate
+	// test.That(t, props.FrameRate, test.ShouldNotBeNil)
+	// test.That(t, props.FrameRate, test.ShouldEqual, fakeFrameRate)
+	defer cam3.Close(cancelCtx)
+
 }

--- a/components/camera/videosource/webcam_e2e_test.go
+++ b/components/camera/videosource/webcam_e2e_test.go
@@ -119,19 +119,4 @@ func TestWebcamGetImage(t *testing.T) {
 
 	test.That(t, img.Bounds().Dx(), test.ShouldEqual, 1280)
 	test.That(t, img.Bounds().Dy(), test.ShouldEqual, 720)
-
-	// new camera for frame rate test
-	// fakeFrameRate = 10.0
-	var props camera.Properties
-	conf = newWebcamConfig("cam3", "video64")
-	cam3, err := videosource.NewWebcam(cancelCtx, nil, conf, logger)
-	props, err = cam3.Properties(cancelCtx)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, props.FrameRate, test.ShouldEqual, 0.0) //without setting frame rate
-	// test.That(t, props.FrameRate, test.ShouldBeNil) //without setting frame rate ?? not sure about this one
-	// props.FrameRate = fakeFrameRate
-	// test.That(t, props.FrameRate, test.ShouldNotBeNil)
-	// test.That(t, props.FrameRate, test.ShouldEqual, fakeFrameRate)
-	defer cam3.Close(cancelCtx)
-
 }

--- a/components/camera/videosource/webcam_test.go
+++ b/components/camera/videosource/webcam_test.go
@@ -67,9 +67,10 @@ func TestWebcamValidation(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, deps, test.ShouldResemble, []string{})
 
-	// no error with 0 width and 0 height
+	// no error with 0 width, 0 height and frame rate
 	webCfg.Width = 0
 	webCfg.Height = 0
+	webCfg.FrameRate = 0
 	deps, err = webCfg.Validate("path")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, deps, test.ShouldResemble, []string{})
@@ -95,12 +96,5 @@ func TestWebcamValidation(t *testing.T) {
 	deps, err = webCfg.Validate("path")
 	test.That(t, err.Error(), test.ShouldEqual,
 		"got illegal non-positive dimension for frame rate (-100.00) field set for webcam camera")
-	test.That(t, deps, test.ShouldBeNil)
-
-	// error with a 0 frame rate
-	webCfg.FrameRate = 0
-	deps, err = webCfg.Validate("path")
-	test.That(t, err.Error(), test.ShouldEqual,
-		"got illegal non-positive dimension for frame rate (0.00) field set for webcam camera")
 	test.That(t, deps, test.ShouldBeNil)
 }

--- a/components/camera/videosource/webcam_test.go
+++ b/components/camera/videosource/webcam_test.go
@@ -84,7 +84,7 @@ func TestWebcamValidation(t *testing.T) {
 	webCfg.Width = -200
 	deps, err = webCfg.Validate("path")
 	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, deps, test.ShouldBeNil) //nil when there is an error?
+	test.That(t, deps, test.ShouldBeNil)
 
 	// error with a pos width and negative height
 	webCfg.Width = 200
@@ -92,12 +92,5 @@ func TestWebcamValidation(t *testing.T) {
 	deps, err = webCfg.Validate("path")
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, deps, test.ShouldBeNil)
-
-	// logger := logging.NewTestLogger(t)
-	// camera, err := videosource.NewWebcam(context.Background(), nil, cfg, logger)
-	// test.That(t, err, test.ShouldBeNil) //failed to find camera!!!! failed!!! NOT NILL!!!!!!
-	// test.That(t, camera, test.ShouldNotBeNil)
-	// // test.That(t, camera.Close(context.Background()), test.ShouldBeNil)
-	// defer camera.Close(context.Background())
 
 }

--- a/components/camera/videosource/webcam_test.go
+++ b/components/camera/videosource/webcam_test.go
@@ -57,33 +57,50 @@ func TestDiscoveryWebcam(t *testing.T) {
 
 func TestWebcamValidation(t *testing.T) {
 	webCfg := &videosource.WebcamConfig{
-		Width:  1280,
-		Height: 640,
+		Width:     1280,
+		Height:    640,
+		FrameRate: 100,
 	}
 
-	// no error with positive width and height
+	// no error with positive width, height, and frame rate
 	deps, err := webCfg.Validate("path")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, deps, test.ShouldResemble, []string{})
 
+	// no error with 0 width and 0 height
 	webCfg.Width = 0
 	webCfg.Height = 0
 	deps, err = webCfg.Validate("path")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, deps, test.ShouldResemble, []string{})
 
-	// error with a negative width and positive height
+	// error with a negative width
 	webCfg.Width = -200
 	deps, err = webCfg.Validate("path")
 	test.That(t, err.Error(), test.ShouldEqual,
 		"got illegal negative dimensions for width_px and height_px (0, -200) fields set for webcam camera")
 	test.That(t, deps, test.ShouldBeNil)
 
-	// error with a positive width and negative height
+	// error with a negative height
 	webCfg.Width = 200
 	webCfg.Height = -200
 	deps, err = webCfg.Validate("path")
 	test.That(t, err.Error(), test.ShouldEqual,
 		"got illegal negative dimensions for width_px and height_px (-200, 200) fields set for webcam camera")
+	test.That(t, deps, test.ShouldBeNil)
+
+	// error with a negative frame rate
+	webCfg.Height = 200
+	webCfg.FrameRate = -100
+	deps, err = webCfg.Validate("path")
+	test.That(t, err.Error(), test.ShouldEqual,
+		"got illegal non-positive dimension for frame rate (-100.00) field set for webcam camera")
+	test.That(t, deps, test.ShouldBeNil)
+
+	// error with a 0 frame rate
+	webCfg.FrameRate = 0
+	deps, err = webCfg.Validate("path")
+	test.That(t, err.Error(), test.ShouldEqual,
+		"got illegal non-positive dimension for frame rate (0.00) field set for webcam camera")
 	test.That(t, deps, test.ShouldBeNil)
 }

--- a/components/camera/videosource/webcam_test.go
+++ b/components/camera/videosource/webcam_test.go
@@ -2,19 +2,16 @@ package videosource_test
 
 import (
 	"context"
-	"image"
+
 	"testing"
 
 	"github.com/pion/mediadevices/pkg/driver"
 	"github.com/pion/mediadevices/pkg/prop"
 	"go.viam.com/test"
 
-	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/components/camera/videosource"
-	"go.viam.com/rdk/gostream"
+
 	"go.viam.com/rdk/logging"
-	"go.viam.com/rdk/pointcloud"
-	"go.viam.com/rdk/resource"
 )
 
 // fakeDriver is a driver has a label and media properties.
@@ -60,50 +57,47 @@ func TestDiscoveryWebcam(t *testing.T) {
 	test.That(t, respProps[0].FrameRate, test.ShouldResemble, float32(30))
 }
 
-// Testing FrameRate camera property
+func TestWebcamValidation(t *testing.T) {
 
-type mockVideoSource struct {
-	frameRate float32
-}
-
-func (m *mockVideoSource) Properties(context.Context) (camera.Properties, error) {
-	return camera.Properties{FrameRate: m.frameRate}, nil
-}
-func (m *mockVideoSource) Close(ctx context.Context) error {
-	return nil
-}
-func (m *mockVideoSource) Images(context.Context) ([]camera.NamedImage, resource.ResponseMetadata, error) {
-	return nil, resource.ResponseMetadata{}, nil
-}
-func (m *mockVideoSource) NextPointCloud(context.Context) (pointcloud.PointCloud, error) {
-	return nil, nil
-}
-func (m *mockVideoSource) Stream(context.Context, ...gostream.ErrorHandler) (gostream.MediaStream[image.Image], error) {
-	return nil, nil
-}
-
-type fakeMonitoredWebcam struct {
-	resource.Named
-	exposedProjector camera.VideoSource
-}
-
-func TestFrameRate(t *testing.T) {
-	mockCam := &mockVideoSource{frameRate: 0.0}
-
-	fakeCam := &fakeMonitoredWebcam{
-		exposedProjector: mockCam,
+	webCfg := &videosource.WebcamConfig{
+		Debug:     true,
+		Format:    "fakeFormat",
+		Path:      "fakePath",
+		Width:     1280,
+		Height:    640,
+		FrameRate: 10.0,
 	}
-	// Test without setting frame rate
-	props, err := fakeCam.exposedProjector.Properties(context.Background())
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, props.FrameRate, test.ShouldEqual, 0.0)
 
-	// Test with setting frame rate
-	fakeFrameRate := float32(30.0)
-	mockCam.frameRate = fakeFrameRate
-	props, err = fakeCam.exposedProjector.Properties(context.Background())
+	// no error with positive width and height and no other params
+	deps, err := webCfg.Validate("path")
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, props.FrameRate, test.ShouldEqual, fakeFrameRate)
+	test.That(t, deps, test.ShouldNotBeNil)
 
-	defer mockCam.Close(context.Background())
+	//no error with a 0 width and 0 height
+	webCfg.Width = 0
+	webCfg.Height = 0
+	deps, err = webCfg.Validate("path")
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, deps, test.ShouldNotBeNil)
+
+	// error with a negative width and pos height
+	webCfg.Width = -200
+	deps, err = webCfg.Validate("path")
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, deps, test.ShouldBeNil) //nil when there is an error?
+
+	// error with a pos width and negative height
+	webCfg.Width = 200
+	webCfg.Height = -200
+	deps, err = webCfg.Validate("path")
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, deps, test.ShouldBeNil)
+
+	// logger := logging.NewTestLogger(t)
+	// camera, err := videosource.NewWebcam(context.Background(), nil, cfg, logger)
+	// test.That(t, err, test.ShouldBeNil) //failed to find camera!!!! failed!!! NOT NILL!!!!!!
+	// test.That(t, camera, test.ShouldNotBeNil)
+	// // test.That(t, camera.Close(context.Background()), test.ShouldBeNil)
+	// defer camera.Close(context.Background())
+
 }

--- a/components/camera/videosource/webcam_test.go
+++ b/components/camera/videosource/webcam_test.go
@@ -2,7 +2,6 @@ package videosource_test
 
 import (
 	"context"
-
 	"testing"
 
 	"github.com/pion/mediadevices/pkg/driver"
@@ -10,7 +9,6 @@ import (
 	"go.viam.com/test"
 
 	"go.viam.com/rdk/components/camera/videosource"
-
 	"go.viam.com/rdk/logging"
 )
 
@@ -58,39 +56,34 @@ func TestDiscoveryWebcam(t *testing.T) {
 }
 
 func TestWebcamValidation(t *testing.T) {
-
 	webCfg := &videosource.WebcamConfig{
-		Debug:     true,
-		Format:    "fakeFormat",
-		Path:      "fakePath",
-		Width:     1280,
-		Height:    640,
-		FrameRate: 10.0,
+		Width:  1280,
+		Height: 640,
 	}
 
-	// no error with positive width and height and no other params
+	// no error with positive width and height
 	deps, err := webCfg.Validate("path")
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, deps, test.ShouldNotBeNil)
+	test.That(t, deps, test.ShouldResemble, []string{})
 
-	//no error with a 0 width and 0 height
 	webCfg.Width = 0
 	webCfg.Height = 0
 	deps, err = webCfg.Validate("path")
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, deps, test.ShouldNotBeNil)
+	test.That(t, deps, test.ShouldResemble, []string{})
 
-	// error with a negative width and pos height
+	// error with a negative width and positive height
 	webCfg.Width = -200
 	deps, err = webCfg.Validate("path")
-	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldEqual,
+		"got illegal negative dimensions for width_px and height_px (0, -200) fields set for webcam camera")
 	test.That(t, deps, test.ShouldBeNil)
 
-	// error with a pos width and negative height
+	// error with a positive width and negative height
 	webCfg.Width = 200
 	webCfg.Height = -200
 	deps, err = webCfg.Validate("path")
-	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldEqual,
+		"got illegal negative dimensions for width_px and height_px (-200, 200) fields set for webcam camera")
 	test.That(t, deps, test.ShouldBeNil)
-
 }


### PR DESCRIPTION
- Added `frame_rate` to monitoredWebCam properties 
- Added a test in webcam_test.go to check that `frame_rate` was assigned properly 