### PR TITLE
Bump dependencies in /web/frontend

### DIFF
--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -51,7 +51,7 @@
         "trzy": "0.3.11",
         "type-fest": "^4.14.0",
         "typescript": "5.2.2",
-        "vite": "4.4.9",
+        "vite": "4.5.5",
         "vite-plugin-css-injected-by-js": "3.3.0",
         "vitest": "0.34.1"
       },
@@ -6981,9 +6981,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.9.tgz",
-      "integrity": "sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.5.tgz",
+      "integrity": "sha512-ifW3Lb2sMdX+WU91s3R0FyQlAyLxOzCSCP37ujw0+r5POeHPwe6udWVIElKQq8gk3t7b8rkmvqC6IHBpCff4GQ==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",

--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -5661,9 +5661,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.28.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.28.0.tgz",
-      "integrity": "sha512-d7zhvo1OUY2SXSM6pfNjgD5+d0Nz87CUp4mt8l/GgVP3oBsPwzNvSzyu1me6BSG9JIgWNTVcafIXBIyM8yQ3yw==",
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
+      "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -86,7 +86,7 @@
     "trzy": "0.3.11",
     "type-fest": "^4.14.0",
     "typescript": "5.2.2",
-    "vite": "4.4.9",
+    "vite": "4.5.5",
     "vite-plugin-css-injected-by-js": "3.3.0",
     "vitest": "0.34.1"
   }


### PR DESCRIPTION
I finally got tired of seeing the dependabot PRs in my inbox. I took matters into my own hands.

```
git cherry-pick 32d5bb1bd381ab148e0fa41bd4bfaaf7b4406342
git commit --amend --author="Ethan Look-Potts <ethan.look@viam.com>" --no-edit 
git cherry-pick ab0d41b03d76cdb386971f2090d8a5db4f167bbc
git commit --amend --author="Ethan Look-Potts <ethan.look@viam.com>" --no-edit 
```

CLA was being finicky - might not have been necessary to amend the author.

Closing these:
- #4373 
- #4385