### PR TITLE
⚠️ RSDK-7903 Cache machine status in robot client

### DIFF
--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -71,7 +71,7 @@ type RobotClient struct {
 	dialOptions []rpc.DialOption
 
 	mu                       sync.RWMutex
-	resourceNames            []resource.Name
+	cachedMachineStatus      robot.MachineStatus
 	resourceRPCAPIs          []resource.RPCAPI
 	resourceClients          map[resource.Name]resource.Resource
 	remoteNameMap            map[resource.Name]resource.Name
@@ -415,8 +415,8 @@ func (rc *RobotClient) connectWithLock(ctx context.Context) error {
 func (rc *RobotClient) updateResourceClients(ctx context.Context) error {
 	activeResources := make(map[resource.Name]bool)
 
-	for _, name := range rc.resourceNames {
-		activeResources[name] = true
+	for _, rs := range rc.cachedMachineStatus.Resources {
+		activeResources[rs.Name] = true
 	}
 
 	for resourceName, client := range rc.resourceClients {
@@ -464,7 +464,7 @@ func (rc *RobotClient) checkConnection(ctx context.Context, checkEvery, reconnec
 						return err
 					}
 				} else {
-					if _, _, err := rc.resources(ctx); err != nil {
+					if _, _, err := rc.machineStatusAndRPCAPIs(ctx); err != nil {
 						return err
 					}
 				}
@@ -586,8 +586,8 @@ func (rc *RobotClient) ResourceByName(name resource.Name) (resource.Resource, er
 	}
 
 	// finally, before adding a new resource, make sure this name exists and is known
-	for _, knownName := range rc.resourceNames {
-		if name == knownName {
+	for _, rs := range rc.cachedMachineStatus.Resources {
+		if name == rs.Name {
 			resourceClient, err := rc.createClient(name)
 			if err != nil {
 				return nil, err
@@ -608,7 +608,7 @@ func (rc *RobotClient) createClient(name resource.Name) (resource.Resource, erro
 	return apiInfo.RPCClient(rc.backgroundCtx, &rc.conn, rc.remoteName, name, logger)
 }
 
-func (rc *RobotClient) resources(ctx context.Context) ([]resource.Name, []resource.RPCAPI, error) {
+func (rc *RobotClient) machineStatusAndRPCAPIs(ctx context.Context) (robot.MachineStatus, []resource.RPCAPI, error) {
 	// RSDK-5356 If we are in a testing environment, never apply
 	// defaultResourcesTimeout. Tests run in parallel, and if execution of a test
 	// pauses for longer than 5s, below calls to ResourceNames or
@@ -620,22 +620,29 @@ func (rc *RobotClient) resources(ctx context.Context) ([]resource.Name, []resour
 		defer cancel()
 	}
 
-	resp, err := rc.client.ResourceNames(ctx, &pb.ResourceNamesRequest{})
+	resp, err := rc.machineStatus(ctx)
 	if err != nil {
-		return nil, nil, err
+		return robot.MachineStatus{}, nil, err
 	}
 
 	var resTypes []resource.RPCAPI
 
-	resources := make([]resource.Name, 0, len(resp.Resources))
-	for _, name := range resp.Resources {
-		newName := rprotoutils.ResourceNameFromProto(name)
-		resources = append(resources, newName)
+	mStatus := resp
+	resources := make([]resource.Status, 0, len(resp.Resources))
+	for _, rs := range resp.Resources {
+		if rs.Name.API == RemoteAPI {
+			continue
+		}
+		if rs.Name.API.Type.Namespace == resource.APINamespaceRDKInternal {
+			continue
+		}
+		resources = append(resources, rs)
 	}
+	mStatus.Resources = resources
 
 	// resource has previously returned an unimplemented response, skip rpc call
 	if rc.rpcSubtypesUnimplemented {
-		return resources, resTypes, nil
+		return mStatus, resTypes, nil
 	}
 
 	typesResp, err := rc.client.ResourceRPCSubtypes(ctx, &pb.ResourceRPCSubtypesRequest{})
@@ -656,7 +663,7 @@ func (rc *RobotClient) resources(ctx context.Context) ([]resource.Name, []resour
 			}
 			svcDesc, ok := symDesc.(*desc.ServiceDescriptor)
 			if !ok {
-				return nil, nil, fmt.Errorf("expected descriptor to be service descriptor but got %T", symDesc)
+				return robot.MachineStatus{}, nil, fmt.Errorf("expected descriptor to be service descriptor but got %T", symDesc)
 			}
 			resTypes = append(resTypes, resource.RPCAPI{
 				API:  rprotoutils.ResourceNameFromProto(resAPI.Subtype).API,
@@ -665,13 +672,13 @@ func (rc *RobotClient) resources(ctx context.Context) ([]resource.Name, []resour
 		}
 	} else {
 		if s, ok := status.FromError(err); !(ok && (s.Code() == codes.Unimplemented)) {
-			return nil, nil, err
+			return robot.MachineStatus{}, nil, err
 		}
 		// prevent future calls to ResourceRPCSubtypes
 		rc.rpcSubtypesUnimplemented = true
 	}
 
-	return resources, resTypes, nil
+	return mStatus, resTypes, nil
 }
 
 // Refresh manually updates the underlying parts of this machine.
@@ -686,13 +693,12 @@ func (rc *RobotClient) Refresh(ctx context.Context) (err error) {
 func (rc *RobotClient) updateResources(ctx context.Context) error {
 	// call metadata service.
 
-	names, rpcAPIs, err := rc.resources(ctx)
+	mStatus, rpcAPIs, err := rc.machineStatusAndRPCAPIs(ctx)
 	if err != nil && status.Code(err) != codes.Unimplemented {
 		return fmt.Errorf("error updating resources: %w", err)
 	}
 
-	rc.resourceNames = make([]resource.Name, 0, len(names))
-	rc.resourceNames = append(rc.resourceNames, names...)
+	rc.cachedMachineStatus = mStatus
 	rc.resourceRPCAPIs = rpcAPIs
 
 	rc.updateRemoteNameMap()
@@ -703,17 +709,17 @@ func (rc *RobotClient) updateResources(ctx context.Context) error {
 func (rc *RobotClient) updateRemoteNameMap() {
 	tempMap := make(map[resource.Name]resource.Name)
 	dupMap := make(map[resource.Name]bool)
-	for _, n := range rc.resourceNames {
-		if err := n.Validate(); err != nil {
+	for _, rs := range rc.cachedMachineStatus.Resources {
+		if err := rs.Name.Validate(); err != nil {
 			rc.Logger().Error(err)
 			continue
 		}
-		tempName := resource.RemoveRemoteName(n)
+		tempName := resource.RemoveRemoteName(rs.Name)
 		// If the short name already exists in the map then there is a collision and we make the long name empty.
 		if _, ok := tempMap[tempName]; ok {
 			dupMap[tempName] = true
 		} else {
-			tempMap[tempName] = n
+			tempMap[tempName] = rs.Name
 		}
 	}
 	for key := range dupMap {
@@ -759,8 +765,10 @@ func (rc *RobotClient) ResourceNames() []resource.Name {
 	}
 	rc.mu.RLock()
 	defer rc.mu.RUnlock()
-	names := make([]resource.Name, 0, len(rc.resourceNames))
-	names = append(names, rc.resourceNames...)
+	names := make([]resource.Name, 0, len(rc.cachedMachineStatus.Resources))
+	for _, rs := range rc.cachedMachineStatus.Resources {
+		names = append(names, rs.Name)
+	}
 	return names
 }
 
@@ -1058,8 +1066,21 @@ func (rc *RobotClient) Shutdown(ctx context.Context) error {
 	return nil
 }
 
+// ErrDisconnected that a robot is disconnected.
+var ErrDisconnected = errors.New("disconnected")
+
 // MachineStatus returns the current status of the robot.
 func (rc *RobotClient) MachineStatus(ctx context.Context) (robot.MachineStatus, error) {
+	if rc.checkConnected() != nil {
+		return robot.MachineStatus{}, ErrDisconnected
+	}
+
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	return rc.cachedMachineStatus, nil
+}
+
+func (rc *RobotClient) machineStatus(ctx context.Context) (robot.MachineStatus, error) {
 	mStatus := robot.MachineStatus{}
 
 	req := &pb.GetMachineStatusRequest{}

--- a/robot/client/client_session.go
+++ b/robot/client/client_session.go
@@ -28,6 +28,7 @@ var exemptFromSession = map[string]bool{
 	"/proto.rpc.webrtc.v1.SignalingService/OptionalWebRTCConfig":     true,
 	"/proto.rpc.v1.AuthService/Authenticate":                         true,
 	"/proto.rpc.v1.ExternalAuthService/AuthenticateTo":               true,
+	"/viam.robot.v1.RobotService/GetMachineStatus":                   true,
 	"/viam.robot.v1.RobotService/ResourceNames":                      true,
 	"/viam.robot.v1.RobotService/ResourceRPCSubtypes":                true,
 	"/viam.robot.v1.RobotService/StartSession":                       true,

--- a/robot/client/client_session_test.go
+++ b/robot/client/client_session_test.go
@@ -25,6 +25,7 @@ import (
 	"go.viam.com/rdk/robot/client"
 	"go.viam.com/rdk/robot/web"
 	"go.viam.com/rdk/session"
+	rdktestutils "go.viam.com/rdk/testutils"
 	"go.viam.com/rdk/testutils/inject"
 	"go.viam.com/rdk/testutils/robottestutils"
 )
@@ -101,8 +102,12 @@ func TestClientSessionOptions(t *testing.T) {
 
 						sessMgr := &sessionManager{}
 						arbName := resource.NewName(echoAPI, "woo")
+						injectResources := []resource.Name{arbName}
 						injectRobot := &inject.Robot{
-							ResourceNamesFunc: func() []resource.Name { return []resource.Name{arbName} },
+							ResourceNamesFunc: func() []resource.Name { return injectResources },
+							MachineStatusFunc: func(ctx context.Context) (robot.MachineStatus, error) {
+								return rdktestutils.ResourcesToMachineStatus(injectResources), nil
+							},
 							ResourceByNameFunc: func(name resource.Name) (resource.Resource, error) {
 								return &dummyEcho{Named: arbName.AsNamed()}, nil
 							},
@@ -284,8 +289,12 @@ func TestClientSessionExpiration(t *testing.T) {
 				arbName := resource.NewName(echoAPI, "woo")
 
 				var dummyEcho1 dummyEcho
+				injectResources := []resource.Name{arbName}
 				injectRobot := &inject.Robot{
-					ResourceNamesFunc: func() []resource.Name { return []resource.Name{arbName} },
+					ResourceNamesFunc: func() []resource.Name { return injectResources },
+					MachineStatusFunc: func(ctx context.Context) (robot.MachineStatus, error) {
+						return rdktestutils.ResourcesToMachineStatus(injectResources), nil
+					},
 					ResourceByNameFunc: func(name resource.Name) (resource.Resource, error) {
 						return &dummyEcho1, nil
 					},
@@ -478,7 +487,10 @@ func TestClientSessionResume(t *testing.T) {
 
 				sessMgr := &sessionManager{}
 				injectRobot := &inject.Robot{
-					ResourceNamesFunc:   func() []resource.Name { return []resource.Name{} },
+					ResourceNamesFunc: func() []resource.Name { return []resource.Name{} },
+					MachineStatusFunc: func(ctx context.Context) (robot.MachineStatus, error) {
+						return robot.MachineStatus{}, nil
+					},
 					ResourceRPCAPIsFunc: func() []resource.RPCAPI { return nil },
 					LoggerFunc:          func() logging.Logger { return logger },
 					SessMgr:             sessMgr,

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -1422,7 +1422,7 @@ func (r *localRobot) Shutdown(ctx context.Context) error {
 func (r *localRobot) MachineStatus(ctx context.Context) (robot.MachineStatus, error) {
 	var result robot.MachineStatus
 
-	result.Resources = append(result.Resources, r.manager.resources.Status()...)
+	result.Resources = r.manager.ResourceStatuses()
 
 	r.configRevisionMu.RLock()
 	result.Config = r.configRevision

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -1090,7 +1090,6 @@ func TestStatusRemote(t *testing.T) {
 
 	gServer1 := grpc.NewServer()
 	gServer2 := grpc.NewServer()
-	resourcesFunc := func() []resource.Name { return []resource.Name{arm.Named("arm1"), arm.Named("arm2")} }
 	machineStatusFunc := func(ctx context.Context) (robot.MachineStatus, error) {
 		return robot.MachineStatus{
 			Resources: []resource.Status{
@@ -1123,7 +1122,6 @@ func TestStatusRemote(t *testing.T) {
 
 	injectRobot1 := &inject.Robot{
 		FrameSystemConfigFunc: frameSystemConfigFunc,
-		ResourceNamesFunc:     resourcesFunc,
 		MachineStatusFunc:     machineStatusFunc,
 		ResourceRPCAPIsFunc:   func() []resource.RPCAPI { return nil },
 	}
@@ -1149,7 +1147,6 @@ func TestStatusRemote(t *testing.T) {
 	}
 	injectRobot2 := &inject.Robot{
 		FrameSystemConfigFunc: frameSystemConfigFunc,
-		ResourceNamesFunc:     resourcesFunc,
 		MachineStatusFunc:     machineStatusFunc,
 		ResourceRPCAPIsFunc:   func() []resource.RPCAPI { return nil },
 	}

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -1091,6 +1091,20 @@ func TestStatusRemote(t *testing.T) {
 	gServer1 := grpc.NewServer()
 	gServer2 := grpc.NewServer()
 	resourcesFunc := func() []resource.Name { return []resource.Name{arm.Named("arm1"), arm.Named("arm2")} }
+	machineStatusFunc := func(ctx context.Context) (robot.MachineStatus, error) {
+		return robot.MachineStatus{
+			Resources: []resource.Status{
+				{
+					Name:  arm.Named("arm1"),
+					State: resource.NodeStateReady,
+				},
+				{
+					Name:  arm.Named("arm2"),
+					State: resource.NodeStateReady,
+				},
+			},
+		}, nil
+	}
 	statusCallCount := 0
 
 	// TODO: RSDK-882 will update this so that this is not necessary
@@ -1110,6 +1124,7 @@ func TestStatusRemote(t *testing.T) {
 	injectRobot1 := &inject.Robot{
 		FrameSystemConfigFunc: frameSystemConfigFunc,
 		ResourceNamesFunc:     resourcesFunc,
+		MachineStatusFunc:     machineStatusFunc,
 		ResourceRPCAPIsFunc:   func() []resource.RPCAPI { return nil },
 	}
 	armStatus := &armpb.Status{
@@ -1135,6 +1150,7 @@ func TestStatusRemote(t *testing.T) {
 	injectRobot2 := &inject.Robot{
 		FrameSystemConfigFunc: frameSystemConfigFunc,
 		ResourceNamesFunc:     resourcesFunc,
+		MachineStatusFunc:     machineStatusFunc,
 		ResourceRPCAPIsFunc:   func() []resource.RPCAPI { return nil },
 	}
 	injectRobot2.StatusFunc = func(ctx context.Context, resourceNames []resource.Name) ([]robot.Status, error) {

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -3427,34 +3427,6 @@ func getExpectedDefaultStatuses(revision string) []resource.Status {
 	return []resource.Status{
 		{
 			Name: resource.Name{
-				API:  resource.APINamespaceRDKInternal.WithServiceType("framesystem"),
-				Name: "builtin",
-			},
-			State: resource.NodeStateReady,
-		},
-		{
-			Name: resource.Name{
-				API:  resource.APINamespaceRDKInternal.WithServiceType("cloud_connection"),
-				Name: "builtin",
-			},
-			State: resource.NodeStateReady,
-		},
-		{
-			Name: resource.Name{
-				API:  resource.APINamespaceRDKInternal.WithServiceType("packagemanager"),
-				Name: "builtin",
-			},
-			State: resource.NodeStateReady,
-		},
-		{
-			Name: resource.Name{
-				API:  resource.APINamespaceRDKInternal.WithServiceType("web"),
-				Name: "builtin",
-			},
-			State: resource.NodeStateReady,
-		},
-		{
-			Name: resource.Name{
 				API:  resource.APINamespaceRDK.WithServiceType("motion"),
 				Name: "builtin",
 			},

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -369,7 +369,9 @@ func (manager *resourceManager) ResourceNames() []resource.Name {
 	return names
 }
 
-// ResourceStatuses returns the names of all resources in the manager.
+// ResourceStatuses returns the names of all resources in the manager, excluding the following types of resources:
+// - Resources that represent entire remote machines.
+// - Resources that are considered internal to viam-server that cannot be removed via configuration.
 func (manager *resourceManager) ResourceStatuses() []resource.Status {
 	result := []resource.Status{}
 	for _, name := range manager.resources.Names() {

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -369,6 +369,30 @@ func (manager *resourceManager) ResourceNames() []resource.Name {
 	return names
 }
 
+// ResourceStatuses returns the names of all resources in the manager.
+func (manager *resourceManager) ResourceStatuses() []resource.Status {
+	result := []resource.Status{}
+	for _, name := range manager.resources.Names() {
+		if name.API == client.RemoteAPI {
+			continue
+		}
+		if name.API.Type.Namespace == resource.APINamespaceRDKInternal {
+			continue
+		}
+
+		gNode, ok := manager.resources.Node(name)
+		if !ok || gNode.IsUninitialized() {
+			continue
+		}
+
+		s := gNode.ResourceStatus()
+		// replace with fully-qualified remote name
+		s.Name = name
+		result = append(result, s)
+	}
+	return result
+}
+
 // ResourceRPCAPIs returns the types of all resource RPC APIs in use by the manager.
 func (manager *resourceManager) ResourceRPCAPIs() []resource.RPCAPI {
 	resourceAPIs := resource.RegisteredAPIs()

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -1965,7 +1965,12 @@ func (rr *dummyRobot) Shutdown(ctx context.Context) error {
 }
 
 func (rr *dummyRobot) MachineStatus(ctx context.Context) (robot.MachineStatus, error) {
-	return rr.robot.MachineStatus(ctx)
+	var ms robot.MachineStatus
+	for _, name := range rr.ResourceNames() {
+		s := resource.Status{Name: name}
+		ms.Resources = append(ms.Resources, s)
+	}
+	return ms, nil
 }
 
 func (rr *dummyRobot) Version(ctx context.Context) (robot.VersionResponse, error) {

--- a/testutils/resource_utils.go
+++ b/testutils/resource_utils.go
@@ -12,6 +12,7 @@ import (
 	"go.viam.com/test"
 
 	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/robot"
 )
 
 // NewUnimplementedResource returns a resource that has all methods
@@ -233,4 +234,24 @@ func AddRemotes(values []resource.Name, remotes ...string) []resource.Name {
 		}
 	}
 	return rNames
+}
+
+// ResourcesToMachineStatus converts a slice of [resource.Name] to a [robot.MachineStatus] with the
+// `Resources` field populated with that same resources, all in the [NodeStateReady] state.
+func ResourcesToMachineStatus(names []resource.Name) robot.MachineStatus {
+	ms := robot.MachineStatus{}
+	for _, name := range names {
+		s := resource.Status{Name: name, State: resource.NodeStateReady}
+		ms.Resources = append(ms.Resources, s)
+	}
+	return ms
+}
+
+// ResourceStatusesToNames converts a slice of [resource.Status] to a slice of [resource.Name].
+func ResourceStatusesToNames(statuses []resource.Status) []resource.Name {
+	names := make([]resource.Name, 0, len(statuses))
+	for _, rs := range statuses {
+		names = append(names, rs.Name)
+	}
+	return names
 }


### PR DESCRIPTION
:warning: hold off on reviewing for now - the following issue needs to be addressed first 

* [ ] https://github.com/viamrobotics/rdk/pull/4399/files#r1783017466

----

Update robot client to source and cache resources from the `MachineStatus` API instead of the `ResourceNames` API. 

This change is _mostly_ a no-op for public APIs: 
* `ResourceNames` does not change - it will return the exact same resources.
* `MachineStatus` changes slightly - it will no longer include RDK internal resources and RemoteAPIs (e.g. the resource that represents the remote itself). This mirrors the behavior of `ResourceNames`.

This change is a prerequisite for [keeping remote resources in `ResourceNames` when they get disconnected](https://github.com/viamrobotics/rdk/pull/4273) - after making that change, we will want `MachineStatus` to show that those disconnected resources are in a non-`Ready` state, which is why the robot client needs to cache more information than just `ResourceNames`. 

See [this thread](https://github.com/viamrobotics/rdk/pull/4273#issuecomment-2374016473) for details on our strategy break this change up.