### PR TITLE
RSDK-8878: gantry shouldn't look for the second limit switch until it has cleared the first limit switch

### DIFF
--- a/components/gantry/singleaxis/singleaxis.go
+++ b/components/gantry/singleaxis/singleaxis.go
@@ -476,8 +476,14 @@ func (g *singleAxis) testLimit(ctx context.Context, pin int) (float64, error) {
 	}
 	// Short pause after stopping to increase the precision of the position of each limit switch
 	position, err := g.motor.Position(ctx, nil)
+	if err != nil {
+		return position, err
+	}
 	time.Sleep(250 * time.Millisecond)
-	return position, err
+	if err := g.moveAway(ctx, pin); err != nil {
+		return position, err
+	}
+	return position, nil
 }
 
 // this function may need to be run in the background upon initialisation of the ganty,

--- a/components/gantry/singleaxis/singleaxis_test.go
+++ b/components/gantry/singleaxis/singleaxis_test.go
@@ -30,11 +30,8 @@ var fakeFrame = &referenceframe.LinkConfig{
 
 var badFrame = &referenceframe.LinkConfig{}
 
-var (
-	count            = 0
-	defaultPinValues = []int{1, 1, 0}
-	limitPinValues   = []int{1, 0, 1, 0, 1, 1, 0}
-)
+// alternate high and low to replicate the behavior of a gantry hitting and moving away from a limit switch
+var defaultPinValues = []int{1, 0, 1, 0, 1, 1, 0}
 
 func createFakeMotor() motor.Motor {
 	return &inject.Motor{
@@ -42,7 +39,7 @@ func createFakeMotor() motor.Motor {
 			return motor.Properties{PositionReporting: true}, nil
 		},
 		PositionFunc: func(ctx context.Context, extra map[string]interface{}) (float64, error) {
-			return float64(count + 1), nil
+			return 1.0, nil
 		},
 		ResetZeroPositionFunc: func(ctx context.Context, offset float64, extra map[string]interface{}) error { return nil },
 		GoToFunc:              func(ctx context.Context, rpm, position float64, extra map[string]interface{}) error { return nil },
@@ -270,7 +267,7 @@ func TestHome(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	fakegantry := &singleAxis{
 		motor:           createFakeMotor(),
-		board:           createFakeBoard(limitPinValues),
+		board:           createFakeBoard(defaultPinValues),
 		limitHigh:       true,
 		logger:          logger,
 		rpm:             float64(300),
@@ -310,7 +307,7 @@ func TestHome(t *testing.T) {
 
 	fakegantry = &singleAxis{
 		motor:           createFakeMotor(),
-		board:           createFakeBoard(limitPinValues),
+		board:           createFakeBoard(defaultPinValues),
 		limitHigh:       true,
 		logger:          logger,
 		rpm:             float64(300),
@@ -331,7 +328,7 @@ func TestHome(t *testing.T) {
 
 	fakegantry = &singleAxis{
 		motor:           createFakeMotor(),
-		board:           createFakeBoard(limitPinValues),
+		board:           createFakeBoard(defaultPinValues),
 		limitHigh:       true,
 		logger:          logger,
 		rpm:             float64(300),
@@ -348,7 +345,7 @@ func TestHomeLimitSwitch(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	fakegantry := &singleAxis{
 		motor:           createFakeMotor(),
-		board:           createFakeBoard(limitPinValues),
+		board:           createFakeBoard(defaultPinValues),
 		limitHigh:       true,
 		logger:          logger,
 		rpm:             float64(300),
@@ -445,7 +442,7 @@ func TestHomeLimitSwitch2(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	fakegantry := &singleAxis{
 		motor:           createFakeMotor(),
-		board:           createFakeBoard(limitPinValues),
+		board:           createFakeBoard(defaultPinValues),
 		limitHigh:       true,
 		logger:          logger,
 		rpm:             float64(300),
@@ -530,7 +527,7 @@ func TestTestLimit(t *testing.T) {
 	fakegantry := &singleAxis{
 		limitSwitchPins: []string{"1", "2"},
 		motor:           createFakeMotor(),
-		board:           createFakeBoard(limitPinValues),
+		board:           createFakeBoard(defaultPinValues),
 		rpm:             float64(300),
 		limitHigh:       true,
 		opMgr:           operation.NewSingleOperationManager(),

--- a/components/gantry/singleaxis/singleaxis_test.go
+++ b/components/gantry/singleaxis/singleaxis_test.go
@@ -30,7 +30,7 @@ var fakeFrame = &referenceframe.LinkConfig{
 
 var badFrame = &referenceframe.LinkConfig{}
 
-// alternate high and low to replicate the behavior of a gantry hitting and moving away from a limit switch.
+// alternate high and low to replicate the behavior of a gantry hitting and moving away from a limit switch during homing.
 var defaultPinValues = []int{1, 0, 1, 0, 1, 0, 1, 0}
 
 func createFakeMotor() motor.Motor {

--- a/components/gantry/singleaxis/singleaxis_test.go
+++ b/components/gantry/singleaxis/singleaxis_test.go
@@ -30,8 +30,8 @@ var fakeFrame = &referenceframe.LinkConfig{
 
 var badFrame = &referenceframe.LinkConfig{}
 
-// alternate high and low to replicate the behavior of a gantry hitting and moving away from a limit switch
-var defaultPinValues = []int{1, 0, 1, 0, 1, 1, 0}
+// alternate high and low to replicate the behavior of a gantry hitting and moving away from a limit switch.
+var defaultPinValues = []int{1, 0, 1, 0, 1, 0, 1, 0}
 
 func createFakeMotor() motor.Motor {
 	return &inject.Motor{

--- a/components/gantry/singleaxis/singleaxis_test.go
+++ b/components/gantry/singleaxis/singleaxis_test.go
@@ -31,8 +31,9 @@ var fakeFrame = &referenceframe.LinkConfig{
 var badFrame = &referenceframe.LinkConfig{}
 
 var (
-	count     = 0
-	pinValues = []int{1, 1, 0}
+	count            = 0
+	defaultPinValues = []int{1, 1, 0}
+	limitPinValues   = []int{1, 0, 1, 0, 1, 1, 0}
 )
 
 func createFakeMotor() motor.Motor {
@@ -51,26 +52,19 @@ func createFakeMotor() motor.Motor {
 	}
 }
 
-func createLimitBoard() board.Board {
-	injectGPIOPin := &inject.GPIOPin{
-		GetFunc: func(ctx context.Context, extra map[string]interface{}) (bool, error) { return true, nil },
-		SetFunc: func(ctx context.Context, high bool, extra map[string]interface{}) error { return nil },
-	}
-	return &inject.Board{GPIOPinByNameFunc: func(pin string) (board.GPIOPin, error) { return injectGPIOPin, nil }}
-}
-
-func createFakeBoard() board.Board {
+func createFakeBoard(pinValues []int) board.Board {
 	pinCount := 0
 	injectGPIOPin := &inject.GPIOPin{
 		GetFunc: func(ctx context.Context, extra map[string]interface{}) (bool, error) {
+			pinVal := false
 			if pinValues[pinCount] == 1 {
-				return true, nil
+				pinVal = true
 			}
 			pinCount++
 			if pinCount == len(pinValues) {
 				pinCount = 0
 			}
-			return false, nil
+			return pinVal, nil
 		},
 		SetFunc: func(ctx context.Context, high bool, extra map[string]interface{}) error { return nil },
 	}
@@ -80,7 +74,7 @@ func createFakeBoard() board.Board {
 func createFakeDepsForTestNewSingleAxis(t *testing.T) resource.Dependencies {
 	t.Helper()
 	deps := make(resource.Dependencies)
-	deps[board.Named(boardName)] = createFakeBoard()
+	deps[board.Named(boardName)] = createFakeBoard(defaultPinValues)
 	deps[motor.Named(motorName)] = createFakeMotor()
 	return deps
 }
@@ -206,7 +200,7 @@ func TestNewSingleAxis(t *testing.T) {
 	}
 	deps = make(resource.Dependencies)
 	deps[motor.Named(motorName)] = injectMotor
-	deps[board.Named(boardName)] = createFakeBoard()
+	deps[board.Named(boardName)] = createFakeBoard(defaultPinValues)
 
 	_, err = newSingleAxis(ctx, deps, fakecfg, logger)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "invalid gantry type")
@@ -221,7 +215,7 @@ func TestNewSingleAxis(t *testing.T) {
 
 	deps = make(resource.Dependencies)
 	deps[motor.Named(motorName)] = injectMotor
-	deps[board.Named(boardName)] = createFakeBoard()
+	deps[board.Named(boardName)] = createFakeBoard(defaultPinValues)
 	properties, _ := injectMotor.Properties(ctx, nil)
 	_, err = newSingleAxis(ctx, deps, fakecfg, logger)
 	expectedErr := motor.NewPropertyUnsupportedError(properties, motorName)
@@ -276,7 +270,7 @@ func TestHome(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	fakegantry := &singleAxis{
 		motor:           createFakeMotor(),
-		board:           createFakeBoard(),
+		board:           createFakeBoard(limitPinValues),
 		limitHigh:       true,
 		logger:          logger,
 		rpm:             float64(300),
@@ -316,7 +310,7 @@ func TestHome(t *testing.T) {
 
 	fakegantry = &singleAxis{
 		motor:           createFakeMotor(),
-		board:           createFakeBoard(),
+		board:           createFakeBoard(limitPinValues),
 		limitHigh:       true,
 		logger:          logger,
 		rpm:             float64(300),
@@ -337,7 +331,7 @@ func TestHome(t *testing.T) {
 
 	fakegantry = &singleAxis{
 		motor:           createFakeMotor(),
-		board:           createFakeBoard(),
+		board:           createFakeBoard(limitPinValues),
 		limitHigh:       true,
 		logger:          logger,
 		rpm:             float64(300),
@@ -354,7 +348,7 @@ func TestHomeLimitSwitch(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	fakegantry := &singleAxis{
 		motor:           createFakeMotor(),
-		board:           createFakeBoard(),
+		board:           createFakeBoard(limitPinValues),
 		limitHigh:       true,
 		logger:          logger,
 		rpm:             float64(300),
@@ -451,7 +445,7 @@ func TestHomeLimitSwitch2(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	fakegantry := &singleAxis{
 		motor:           createFakeMotor(),
-		board:           createFakeBoard(),
+		board:           createFakeBoard(limitPinValues),
 		limitHigh:       true,
 		logger:          logger,
 		rpm:             float64(300),
@@ -536,7 +530,7 @@ func TestTestLimit(t *testing.T) {
 	fakegantry := &singleAxis{
 		limitSwitchPins: []string{"1", "2"},
 		motor:           createFakeMotor(),
-		board:           createLimitBoard(),
+		board:           createFakeBoard(limitPinValues),
 		rpm:             float64(300),
 		limitHigh:       true,
 		opMgr:           operation.NewSingleOperationManager(),
@@ -551,7 +545,7 @@ func TestTestLimitTimeout(t *testing.T) {
 	fakegantry := &singleAxis{
 		limitSwitchPins: []string{"1", "2"},
 		motor:           createFakeMotor(),
-		board:           createLimitBoard(),
+		board:           createFakeBoard(defaultPinValues),
 		rpm:             float64(3000),
 		limitHigh:       true,
 		opMgr:           operation.NewSingleOperationManager(),
@@ -579,7 +573,7 @@ func TestLimitHit(t *testing.T) {
 	ctx := context.Background()
 	fakegantry := &singleAxis{
 		limitSwitchPins: []string{"1", "2", "3"},
-		board:           createLimitBoard(),
+		board:           createFakeBoard(defaultPinValues),
 		limitHigh:       true,
 		opMgr:           operation.NewSingleOperationManager(),
 	}
@@ -601,7 +595,7 @@ func TestPosition(t *testing.T) {
 			},
 			PositionFunc: func(ctx context.Context, extra map[string]interface{}) (float64, error) { return 1, nil },
 		},
-		board:           createFakeBoard(),
+		board:           createFakeBoard(defaultPinValues),
 		positionLimits:  []float64{0, 1},
 		positionRange:   1.0,
 		limitHigh:       true,
@@ -622,7 +616,7 @@ func TestPosition(t *testing.T) {
 				return 1, errors.New("not supported")
 			},
 		},
-		board:           createFakeBoard(),
+		board:           createFakeBoard(defaultPinValues),
 		limitHigh:       true,
 		limitSwitchPins: []string{"1", "2"},
 		positionLimits:  []float64{0, 1},
@@ -650,7 +644,7 @@ func TestMoveToPosition(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	fakegantry := &singleAxis{
 		logger:        logger,
-		board:         createFakeBoard(),
+		board:         createFakeBoard(defaultPinValues),
 		motor:         createFakeMotor(),
 		limitHigh:     true,
 		positionRange: 10,
@@ -752,7 +746,7 @@ func TestStop(t *testing.T) {
 
 	fakegantry := &singleAxis{
 		motor:           createFakeMotor(),
-		board:           createFakeBoard(),
+		board:           createFakeBoard(defaultPinValues),
 		limitHigh:       true,
 		logger:          logger,
 		rpm:             float64(300),
@@ -771,7 +765,7 @@ func TestCurrentInputs(t *testing.T) {
 
 	fakegantry := &singleAxis{
 		motor:           createFakeMotor(),
-		board:           createFakeBoard(),
+		board:           createFakeBoard(defaultPinValues),
 		limitHigh:       true,
 		logger:          logger,
 		rpm:             float64(300),
@@ -788,7 +782,7 @@ func TestCurrentInputs(t *testing.T) {
 
 	fakegantry = &singleAxis{
 		motor:           createFakeMotor(),
-		board:           createFakeBoard(),
+		board:           createFakeBoard(defaultPinValues),
 		limitHigh:       true,
 		logger:          logger,
 		rpm:             float64(300),
@@ -810,7 +804,7 @@ func TestCurrentInputs(t *testing.T) {
 				return 5, errors.New("nope")
 			},
 		},
-		board:          createFakeBoard(),
+		board:          createFakeBoard(defaultPinValues),
 		limitHigh:      false,
 		logger:         logger,
 		rpm:            float64(300),
@@ -846,7 +840,7 @@ func TestGoToInputs(t *testing.T) {
 	test.That(t, err.Error(), test.ShouldContainSubstring, "is homed")
 
 	fakegantry := &singleAxis{
-		board:           createFakeBoard(),
+		board:           createFakeBoard(defaultPinValues),
 		limitSwitchPins: []string{"1", "2"},
 		limitHigh:       true,
 		motor:           createFakeMotor(),


### PR DESCRIPTION
use move away to make sure limit switch it cleared before homing to the next limit switch

more info from ticket description:
Currently during the gantry homing process, the gantry will move to limit switch 0, and then limit switch 1. During this process, it is constantly checking if it has hit the limit switch it is looking for, but it is also constantly checking if it has hit the wrong limit switch, meaning if it was expecting to hit limit switch 0 next and it hits limit switch 1, or if it expects to hit limit switch 1 next and hits limit switch 0. If this happens, the homing sequence errors and stops. 

This causes a problem with slower gantries because there’s a case in which the first limit switch could be hit, and then the gantry starts moving in the opposite direction trying to find the second limit switch, but it has not moved out of the range of the first limit switch yet. In this scenario, the homing sequence is interrupted because the gantry is looking for limit switch 1, but it is still hitting limit switch 0, so it returns an error.

This can be fixed by moving in the opposite direction to set the limit switch back to false before continuing to home in the opposite direction. 