### PR TITLE
RSDK-8883: Have package downloading better interpret file does not exist errors.

### DIFF
--- a/robot/packages/utils.go
+++ b/robot/packages/utils.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -13,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 	"go.viam.com/utils"
 
@@ -66,7 +66,7 @@ func installPackage(
 	// unpack to temp directory to ensure we do an atomic rename once finished.
 	tmpDataPath, err := os.MkdirTemp(p.LocalDataParentDirectory(packagesDir), "*.tmp")
 	if err != nil {
-		return errors.Wrap(err, "failed to create temp data dir path")
+		return fmt.Errorf("failed to create temp data dir path %w", err)
 	}
 
 	defer func() {
@@ -155,7 +155,7 @@ func unpackFile(ctx context.Context, fromFile, toDir string) error {
 		}
 
 		if err != nil {
-			return errors.Wrap(err, "read tar")
+			return fmt.Errorf("read tar %w", err)
 		}
 
 		path := header.Name
@@ -173,7 +173,7 @@ func unpackFile(ctx context.Context, fromFile, toDir string) error {
 		switch header.Typeflag {
 		case tar.TypeDir:
 			if err := os.Mkdir(path, info.Mode()); err != nil {
-				return errors.Wrapf(err, "failed to create directory %s", path)
+				return fmt.Errorf("failed to create directory %q %w", path, err)
 			}
 
 		case tar.TypeReg:
@@ -182,18 +182,18 @@ func unpackFile(ctx context.Context, fromFile, toDir string) error {
 			// Ex: tar -czf package.tar.gz ./bin/module.exe
 			parent := filepath.Dir(path)
 			if err := os.MkdirAll(parent, 0o700); err != nil {
-				return errors.Wrapf(err, "failed to create directory %q", parent)
+				return fmt.Errorf("failed to create directory %q %w", parent, err)
 			}
 			//nolint:gosec // path sanitized with rutils.SafeJoin
 			outFile, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600|info.Mode().Perm())
 			if err != nil {
-				return errors.Wrapf(err, "failed to create file %s", path)
+				return fmt.Errorf("failed to create file %q %w", path, err)
 			}
 			if _, err := io.CopyN(outFile, tarReader, maxPackageSize); err != nil && !errors.Is(err, io.EOF) {
-				return errors.Wrapf(err, "failed to copy file %s", path)
+				return fmt.Errorf("failed to copy file %q %w", path, err)
 			}
 			if err := outFile.Sync(); err != nil {
-				return errors.Wrapf(err, "failed to sync %s", path)
+				return fmt.Errorf("failed to sync %q %w", path, err)
 			}
 			utils.UncheckedError(outFile.Close())
 
@@ -219,7 +219,7 @@ func unpackFile(ctx context.Context, fromFile, toDir string) error {
 			return err
 		}
 		if err := linkFile(links[i].Name, links[i].Path); err != nil {
-			return errors.Wrapf(err, "failed to create link %s", links[i].Path)
+			return fmt.Errorf("failed to create link %q %w", links[i].Path, err)
 		}
 	}
 
@@ -228,7 +228,7 @@ func unpackFile(ctx context.Context, fromFile, toDir string) error {
 			return err
 		}
 		if err := linkFile(symlinks[i].Name, symlinks[i].Path); err != nil {
-			return errors.Wrapf(err, "failed to create link %s", links[i].Path)
+			return fmt.Errorf("failed to create link %q %w", links[i].Path, err)
 		}
 	}
 
@@ -347,7 +347,7 @@ func readStatusFile(pkg config.PackageConfig, packagesDir string) (packageSyncFi
 	syncFileBytes, err := os.ReadFile(syncFileName)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return packageSyncFile{}, errors.Wrapf(err, "cannot find %s", syncFileName)
+			return packageSyncFile{}, fmt.Errorf("cannot find %q %w", syncFileName, err)
 		}
 		return packageSyncFile{}, err
 	}
@@ -368,13 +368,13 @@ func writeStatusFile(pkg config.PackageConfig, statusFile packageSyncFile, packa
 	//nolint:gosec
 	syncFile, err := os.Create(syncFileName)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create %s", syncFileName)
+		return fmt.Errorf("failed to create %q %w", syncFileName, err)
 	}
 	if _, err := syncFile.Write(statusFileBytes); err != nil {
-		return errors.Wrapf(err, "failed to write syncfile to %s", syncFileName)
+		return fmt.Errorf("failed to write syncfile to %q %w", syncFileName, err)
 	}
 	if err := syncFile.Sync(); err != nil {
-		return errors.Wrapf(err, "failed to sync %s", syncFileName)
+		return fmt.Errorf("failed to sync %q %w", syncFileName, err)
 	}
 
 	return nil


### PR DESCRIPTION
I split this into two commits:
* The [logging logic](https://github.com/viamrobotics/rdk/pull/4402/commits/46ce76f4431a636dfa60de2fd28fdb9dc32c8deb) `packageIsSynced`
* [Migrating from](https://github.com/viamrobotics/rdk/pull/4402/commits/ee69673c954ab4f4e74f3dd5b2b4c0b7e91614b8) `pkg/errors.Wrapf` to stdlib `fmt.Errorf("...%w", err)`

Old log:
```
2024-09-24T13:16:10.175-0400	DEBUG	packages/utils.go:312	unchecked error	{"error": "cannot find /home/dgottlieb/.viam/packages/data/module/4593c406-dda4-40ff-9ea2-e5eb2fbe4ac4-nicksensor-0_0_1-linux-amd64.status.json: open /home/dgottlieb/.viam/packages/data/module/4593c406-dda4-40ff-9ea2-e5eb2fbe4ac4-nicksensor-0_0_1-linux-amd64.status.json: no such file or directory", "errorVerbose": "open /home/dgottlieb/.viam/packages/data/module/4593c406-dda4-40ff-9ea2-e5eb2fbe4ac4-nicksensor-0_0_1-linux-amd64.status.json: no such file or directory\ncannot find /home/dgottlieb/.viam/packages/data/module/4593c406-dda4-40ff-9ea2-e5eb2fbe4ac4-nicksensor-0_0_1-linux-amd64.status.json\ngo.viam.com/rdk/robot/packages.readStatusFile\n\t/home/dgottlieb/viam/rdk/robot/packages/utils.go:342\ngo.viam.com/rdk/robot/packages.packageIsSynced\n\t/home/dgottlieb/viam/rdk/robot/packages/utils.go:310\ngo.viam.com/rdk/robot/packages.packagesAreSynced\n\t/home/dgottlieb/viam/rdk/robot/packages/utils.go:325\ngo.viam.com/rdk/robot/packages.(*deferredPackageManager).getManagerForSync\n\t/home/dgottlieb/viam/rdk/robot/packages/deferred_package_manager.go:123\ngo.viam.com/rdk/robot/packages.(*deferredPackageManager).Sync\n\t/home/dgottlieb/viam/rdk/robot/packages/deferred_package_manager.go:81\ngo.viam.com/rdk/robot/impl.(*localRobot).reconfigure\n\t/home/dgottlieb/viam/rdk/robot/impl/local_robot.go:1200\ngo.viam.com/rdk/robot/impl.(*localRobot).Reconfigure\n\t/home/dgottlieb/viam/rdk/robot/impl/local_robot.go:1168\ngo.viam.com/rdk/robot/impl.newWithResources\n\t/home/dgottlieb/viam/rdk/robot/impl/local_robot.go:571\ngo.viam.com/rdk/robot/impl.New\n\t/home/dgottlieb/viam/rdk/robot/impl/local_robot.go:595\ngo.viam.com/rdk/web/server.(*robotServer).serveWeb\n\t/home/dgottlieb/viam/rdk/web/server/entrypoint.go:373\ngo.viam.com/rdk/web/server.(*robotServer).runServer\n\t/home/dgottlieb/viam/rdk/web/server/entrypoint.go:193\ngo.viam.com/rdk/web/server.RunServer\n\t/home/dgottlieb/viam/rdk/web/server/entrypoint.go:173\ngo.viam.com/utils.contextualMain[...]\n\t/home/dgottlieb/viam/rdk/vendor/go.viam.com/utils/runtime.go:72\ngo.viam.com/utils.ContextualMain[...]\n\t/home/dgottlieb/viam/rdk/vendor/go.viam.com/utils/runtime.go:29\nmain.main\n\t/home/dgottlieb/viam/rdk/web/cmd/server/main.go:19\nruntime.main\n\t/home/dgottlieb/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.21.13.linux-amd64/src/runtime/proc.go:267\nruntime.goexit\n\t/home/dgottlieb/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.21.13.linux-amd64/src/runtime/asm_amd64.s:1650"}
```

New Log (for fs.NotExists):
```
2024-09-30T14:24:05.621Z	INFO	rdk.package_manager	packages/utils.go:313	New package to download detected	{"name":"m_ncs_nicksensor","version":"0.0.1-linux-amd64","id":"4593c406-dda4-40ff-9ea2-e5eb2fbe4ac4/nicksensor"}
```

New Log (if an unknown error):
```
2024-09-30T14:05:34.905Z	WARN	rdk.package_manager	packages/utils.go:316	Error reading status file for package	{"packageName":"m_ncs_nicksensor","packageVersion":"0.0.1-linux-amd64","packageId":"4593c406-dda4-40ff-9ea2-e5eb2fbe4ac4/nicksensor","packagesDir":"/home/dgottlieb/.viam/packages","err":"cannot find \"/home/dgottlieb/.viam/packages/data/module/4593c406-dda4-40ff-9ea2-e5eb2fbe4ac4-nicksensor-0_0_1-linux-amd64.status.json\" open /home/dgottlieb/.viam/packages/data/module/4593c406-dda4-40ff-9ea2-e5eb2fbe4ac4-nicksensor-0_0_1-linux-amd64.status.json: no such file or directory"}
```