### PR TITLE
RSDK-8773: Return error if invalid dataset ID during export

### DIFF
--- a/cli/dataset.go
+++ b/cli/dataset.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -193,6 +194,14 @@ func (c *viamClient) downloadDataset(dst, datasetID string, includeJSONLines boo
 				Errorf(c.c.App.ErrWriter, "failed to close dataset file %q", datasetFile.Name())
 			}
 		}()
+	}
+	resp, err := c.datasetClient.ListDatasetsByIDs(context.Background(),
+		&datasetpb.ListDatasetsByIDsRequest{Ids: []string{datasetID}})
+	if err != nil {
+		return errors.Wrapf(err, "error getting dataset ID")
+	}
+	if len(resp.GetDatasets()) == 0 {
+		return errors.New(fmt.Sprintf("%s does not match any dataset IDs", datasetID))
 	}
 
 	return c.performActionOnBinaryDataFromFilter(

--- a/cli/dataset.go
+++ b/cli/dataset.go
@@ -201,7 +201,7 @@ func (c *viamClient) downloadDataset(dst, datasetID string, includeJSONLines boo
 		return errors.Wrapf(err, "error getting dataset ID")
 	}
 	if len(resp.GetDatasets()) == 0 {
-		return errors.New(fmt.Sprintf("%s does not match any dataset IDs", datasetID))
+		return fmt.Errorf("%s does not match any dataset IDs", datasetID)
 	}
 
 	return c.performActionOnBinaryDataFromFilter(


### PR DESCRIPTION
If a user tries to export a dataset that doesn't exist, we now return an error.

Manually tested:

![image](https://github.com/user-attachments/assets/1822bc8b-3e33-41a3-ba0c-50768cf9d266)

`go run cli/viam/main.go dataset export --destination mydataset1 --dataset-id bccf8f8f-e3c4-4f72-ab9a-fc547757f352`