### PR TITLE
APP-6543 configurable dependencies for faster mac build

### DIFF
--- a/cli/module.schema.json
+++ b/cli/module.schema.json
@@ -104,6 +104,16 @@
                         "linux/amd64",
                         "linux/arm64"
                     ]
+                },
+                "darwin_deps": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Homebrew dependencies for darwin builds. The first example has the default list; explicitly pass `[]` for empty.",
+                    "examples": [
+                        ["go", "pkg-config", "nlopt-static", "x264", "jpeg-turbo", "ffmpeg"]
+                    ]
                 }
             }
         }

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -73,10 +73,11 @@ type moduleID struct {
 
 // manifestBuildInfo is the "build" section of meta.json.
 type manifestBuildInfo struct {
-	Build string   `json:"build"`
-	Setup string   `json:"setup"`
-	Path  string   `json:"path"`
-	Arch  []string `json:"arch"`
+	Build      string   `json:"build"`
+	Setup      string   `json:"setup"`
+	Path       string   `json:"path"`
+	Arch       []string `json:"arch"`
+	DarwinDeps []string `json:"darwin_deps,omitempty"`
 }
 
 // defaultBuildInfo has defaults for unset fields in "build".
@@ -87,6 +88,7 @@ var defaultBuildInfo = manifestBuildInfo{
 }
 
 // moduleManifest is used to create & parse manifest.json.
+// Detailed user-facing docs for this are in module.schema.json.
 type moduleManifest struct {
 	Schema      string            `json:"$schema"`
 	ModuleID    string            `json:"module_id"`


### PR DESCRIPTION
## What changed
- Add `build.darwin_deps` field to meta.json
## Why
Cloud build currently has a 20 minute homebrew step. Most modules don't need most of these libraries though. This change lets people iterate more quickly around hosted mac builds.