### PR TITLE
RSDK-7903 Keep unhealthy remotes in ResourceNames

### DIFF
--- a/resource/graph_node.go
+++ b/resource/graph_node.go
@@ -372,13 +372,6 @@ func (w *GraphNode) SetUnreachable() {
 	w.unreachable = true
 }
 
-// Unreachable indicates if a remote resource node is disconnected.
-func (w *GraphNode) Unreachable() bool {
-	w.mu.RLock()
-	defer w.mu.RLock()
-	return w.unreachable
-}
-
 // setUnresolvedDependencies sets names that are yet to be resolved as
 // dependencies for the node. Note that even an empty list will still
 // set needsDependencyResolution to true. If no resolution is needed,

--- a/resource/graph_node.go
+++ b/resource/graph_node.go
@@ -365,13 +365,6 @@ func (w *GraphNode) SetNeedsUpdate() {
 	w.setNeedsReconfigure(w.Config(), false, w.UnresolvedDependencies())
 }
 
-// SetUnreachable marks a remote resource node as disconnected.
-func (w *GraphNode) SetUnreachable() {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	w.unreachable = true
-}
-
 // setUnresolvedDependencies sets names that are yet to be resolved as
 // dependencies for the node. Note that even an empty list will still
 // set needsDependencyResolution to true. If no resolution is needed,

--- a/resource/graph_node.go
+++ b/resource/graph_node.go
@@ -349,6 +349,13 @@ func (w *GraphNode) UpdateRevision(revision string) {
 	}
 }
 
+func (w *GraphNode) markReachability(reachable bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.unreachable = !reachable
+}
+
 // SetNewConfig is used to inform the node that it has been modified
 // and requires a reconfiguration. If the node was previously marked for removal,
 // this unmarks it.

--- a/resource/graph_node.go
+++ b/resource/graph_node.go
@@ -79,6 +79,10 @@ type GraphNode struct {
 	// stored the on the revision field.
 	pendingRevision string
 	revision        string
+
+	// unreachable is an informational field that indicates if a resource on a remote
+	// machine is disconnected.
+	unreachable bool
 }
 
 var (
@@ -359,6 +363,20 @@ func (w *GraphNode) SetNewConfig(newConfig Config, dependencies []string) {
 func (w *GraphNode) SetNeedsUpdate() {
 	// doing two mutex ops here but we assume there's only one caller.
 	w.setNeedsReconfigure(w.Config(), false, w.UnresolvedDependencies())
+}
+
+// SetUnreachable marks a remote resource node as disconnected.
+func (w *GraphNode) SetUnreachable() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.unreachable = true
+}
+
+// Unreachable indicates if a remote resource node is disconnected.
+func (w *GraphNode) Unreachable() bool {
+	w.mu.RLock()
+	defer w.mu.RLock()
+	return w.unreachable
 }
 
 // setUnresolvedDependencies sets names that are yet to be resolved as

--- a/resource/resource_graph.go
+++ b/resource/resource_graph.go
@@ -640,15 +640,17 @@ func (g *Graph) isNodeDependingOn(node, child Name) bool {
 	return g.transitiveClosureMatrix[child][node] != 0
 }
 
-// SubGraphFrom returns a Sub-Graph containing all linked dependencies starting with node Name.
+// SubGraphFrom returns a Sub-Graph containing all linked dependencies starting with node [Name].
 func (g *Graph) SubGraphFrom(node Name) (*Graph, error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
-	return g.subGraphFrom(node)
+	return g.subGraphFromWithMutex(node)
 }
 
-func (g *Graph) subGraphFrom(node Name) (*Graph, error) {
+// subGraphFrom returns a Sub-Graph containing all linked dependencies starting with node [Name].
+// This method is NOT threadsafe: A client must hold [Graph.mu] while calling this method.
+func (g *Graph) subGraphFromWithMutex(node Name) (*Graph, error) {
 	if _, ok := g.nodes[node]; !ok {
 		return nil, errors.Errorf("cannot create sub-graph from non existing node %q ", node.Name)
 	}
@@ -667,7 +669,7 @@ func (g *Graph) MarkReachability(node Name, reachable bool) error {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
-	subGraph, err := g.subGraphFrom(node)
+	subGraph, err := g.subGraphFromWithMutex(node)
 	if err != nil {
 		return err
 	}

--- a/resource/resource_graph.go
+++ b/resource/resource_graph.go
@@ -183,6 +183,22 @@ func (g *Graph) Names() []Name {
 	return names
 }
 
+// ReachableNames returns the all resource graph names, excluding remote resources that are unreached.
+func (g *Graph) ReachableNames() []Name {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	names := make([]Name, len(g.nodes))
+	i := 0
+	for k, node := range g.nodes {
+		if node.unreachable {
+			continue
+		}
+		names[i] = k
+		i++
+	}
+	return names
+}
+
 // FindNodesByShortNameAndAPI will look for resources matching both the API and the name.
 func (g *Graph) FindNodesByShortNameAndAPI(name Name) []Name {
 	g.mu.Lock()

--- a/resource/resource_graph.go
+++ b/resource/resource_graph.go
@@ -644,6 +644,11 @@ func (g *Graph) isNodeDependingOn(node, child Name) bool {
 func (g *Graph) SubGraphFrom(node Name) (*Graph, error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
+
+	return g.subGraphFrom(node)
+}
+
+func (g *Graph) subGraphFrom(node Name) (*Graph, error) {
 	if _, ok := g.nodes[node]; !ok {
 		return nil, errors.Errorf("cannot create sub-graph from non existing node %q ", node.Name)
 	}
@@ -655,6 +660,21 @@ func (g *Graph) SubGraphFrom(node Name) (*Graph, error) {
 		}
 	}
 	return subGraph, nil
+}
+
+// MarkReachability marks all nodes in the subgraph from the given [Name] node as either reachable [true] or unreachable [false].
+func (g *Graph) MarkReachability(node Name, reachable bool) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	subGraph, err := g.subGraphFrom(node)
+	if err != nil {
+		return err
+	}
+	for _, node := range subGraph.nodes {
+		node.unreachable = !reachable
+	}
+	return nil
 }
 
 // Status returns a slice of all graph node statuses.

--- a/resource/resource_graph.go
+++ b/resource/resource_graph.go
@@ -672,7 +672,7 @@ func (g *Graph) MarkReachability(node Name, reachable bool) error {
 		return err
 	}
 	for _, node := range subGraph.nodes {
-		node.unreachable = !reachable
+		node.markReachability(reachable)
 	}
 	return nil
 }

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -1422,7 +1422,7 @@ func (r *localRobot) Shutdown(ctx context.Context) error {
 func (r *localRobot) MachineStatus(ctx context.Context) (robot.MachineStatus, error) {
 	var result robot.MachineStatus
 
-	result.Resources = r.manager.ResourceStatuses()
+	result.Resources = append(result.Resources, r.manager.resources.Status()...)
 
 	r.configRevisionMu.RLock()
 	result.Config = r.configRevision

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -1422,7 +1422,7 @@ func (r *localRobot) Shutdown(ctx context.Context) error {
 func (r *localRobot) MachineStatus(ctx context.Context) (robot.MachineStatus, error) {
 	var result robot.MachineStatus
 
-	result.Resources = append(result.Resources, r.manager.resources.Status()...)
+	result.Resources = r.manager.ResourceStatuses()
 
 	r.configRevisionMu.RLock()
 	result.Config = r.configRevision

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -209,6 +209,7 @@ func (manager *resourceManager) updateRemoteResourceNames(
 	}
 
 	oldResources := manager.remoteResourceNames(remoteName)
+	// TODO: mark reachable
 	for _, res := range oldResources {
 		activeResourceNames[res] = false
 	}

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -189,27 +189,26 @@ func (manager *resourceManager) updateRemoteResourceNames(
 	// The connection to the remote is broken. In this case, we mark each resource node
 	// on this remote as disconnected but do not report any other changes.
 	if newResources == nil {
-		remoteGraph, err := manager.resources.SubGraphFrom(remoteName)
+		err := manager.resources.MarkReachability(remoteName, false)
 		if err != nil {
 			manager.logger.Error(
-				"unable to lookup remote resources internally",
+				"unable to mark remote resources as unreachable",
 				"remote", remoteName,
 				"error", err,
 			)
-			return false
-		}
-		for _, name := range remoteGraph.Names() {
-			gNode, ok := manager.resources.Node(name)
-			if !ok {
-				continue
-			}
-			gNode.SetUnreachable()
 		}
 		return false
 	}
 
+	err := manager.resources.MarkReachability(remoteName, true)
+	if err != nil {
+		manager.logger.Error(
+			"unable to mark remote resources as reachable",
+			"remote", remoteName,
+			"error", err,
+		)
+	}
 	oldResources := manager.remoteResourceNames(remoteName)
-	// TODO: mark reachable
 	for _, res := range oldResources {
 		activeResourceNames[res] = false
 	}

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -367,29 +367,39 @@ func (manager *resourceManager) internalResourceNames() []resource.Name {
 	return names
 }
 
-// ResourceNames returns the names of all resources in the manager.
+// ResourceNames returns the names of all resources in the manager, excluding the following types of resources:
+// - Resources that represent entire remote machines.
+// - Resources that are considered internal to viam-server that cannot be removed via configuration.
 func (manager *resourceManager) ResourceNames() []resource.Name {
 	names := []resource.Name{}
 	for _, k := range manager.resources.Names() {
-		if manager.includeResourceName(k) {
+		if manager.resourceName(k) {
 			names = append(names, k)
 		}
 	}
 	return names
 }
 
-// reachableResourceNames returns the names of all reachable resources in the manager.
+// reachableResourceNames returns the names of all resources in the manager, excluding the following types of resources:
+// - Resources that represent entire remote machines.
+// - Resources that are considered internal to viam-server that cannot be removed via configuration.
+// - Remote resources that are currently unreachable.
 func (manager *resourceManager) reachableResourceNames() []resource.Name {
 	names := []resource.Name{}
 	for _, k := range manager.resources.ReachableNames() {
-		if manager.includeResourceName(k) {
+		if manager.resourceName(k) {
 			names = append(names, k)
 		}
 	}
 	return names
 }
 
-func (manager *resourceManager) includeResourceName(k resource.Name) bool {
+// resourceName is a validation function that dictates if a given [resource.Name] should be returned by [ResourceNames].
+// A resource should NOT be returned by [ResourceNames] if any of the following conditions are true:
+// - The resource is not stored in the resource manager.
+// - The resource represents an entire remote machine.
+// - The resource is considered internal to viam-server, meaning it cannot be removed via configuration.
+func (manager *resourceManager) resourceName(k resource.Name) bool {
 	if k.API == client.RemoteAPI ||
 		k.API.Type.Namespace == resource.APINamespaceRDKInternal {
 		return false

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -408,32 +408,6 @@ func (manager *resourceManager) reachableResourceNames() []resource.Name {
 	return names
 }
 
-// ResourceStatuses returns the names of all resources in the manager, excluding the following types of resources:
-// - Resources that represent entire remote machines.
-// - Resources that are considered internal to viam-server that cannot be removed via configuration.
-func (manager *resourceManager) ResourceStatuses() []resource.Status {
-	result := []resource.Status{}
-	for _, name := range manager.resources.Names() {
-		if name.API == client.RemoteAPI {
-			continue
-		}
-		if name.API.Type.Namespace == resource.APINamespaceRDKInternal {
-			continue
-		}
-
-		gNode, ok := manager.resources.Node(name)
-		if !ok || gNode.IsUninitialized() {
-			continue
-		}
-
-		s := gNode.ResourceStatus()
-		// replace with fully-qualified remote name
-		s.Name = name
-		result = append(result, s)
-	}
-	return result
-}
-
 // ResourceRPCAPIs returns the types of all resource RPC APIs in use by the manager.
 func (manager *resourceManager) ResourceRPCAPIs() []resource.RPCAPI {
 	resourceAPIs := resource.RegisteredAPIs()

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -216,15 +216,14 @@ func (manager *resourceManager) updateRemoteResourceNames(
 
 	for _, resName := range newResources {
 		remoteResName := resName
+		resLogger := logger.WithFields("resource", remoteResName)
 		res, err := rr.ResourceByName(remoteResName) // this returns a remote known OR foreign resource client
 		if err != nil {
 			if errors.Is(err, client.ErrMissingClientRegistration) {
-				logger.CDebugw(ctx, "couldn't obtain remote resource interface",
-					"resource", remoteResName,
+				resLogger.CDebugw(ctx, "couldn't obtain remote resource interface",
 					"reason", err)
 			} else {
-				logger.CErrorw(ctx, "couldn't obtain remote resource interface",
-					"resource", remoteResName,
+				resLogger.CErrorw(ctx, "couldn't obtain remote resource interface",
 					"reason", err)
 			}
 			continue
@@ -242,18 +241,16 @@ func (manager *resourceManager) updateRemoteResourceNames(
 					continue
 				}
 				// reconfiguration attempt, remote could have changed, so close all duplicate name remote resource clients and readd new ones later
-				logger.CDebugw(ctx, "attempting to remove remote resource", "name", resName)
+				resLogger.CDebugw(ctx, "attempting to remove remote resource")
 				if err := manager.markChildrenForUpdate(resName); err != nil {
-					logger.CErrorw(ctx,
+					resLogger.CErrorw(ctx,
 						"failed to mark children of remote resource for update",
-						"resource", resName,
 						"reason", err)
 					continue
 				}
 				if err := gNode.Close(ctx); err != nil {
-					logger.CErrorw(ctx,
+					resLogger.CErrorw(ctx,
 						"failed to close remote resource node",
-						"resource", resName,
 						"reason", err)
 				}
 			}
@@ -264,48 +261,45 @@ func (manager *resourceManager) updateRemoteResourceNames(
 		} else {
 			gNode = resource.NewConfiguredGraphNode(resource.Config{}, res, unknownModel)
 			if err := manager.resources.AddNode(resName, gNode); err != nil {
-				logger.CErrorw(ctx, "failed to add remote resource node", "resource", resName, "error", err)
+				resLogger.CErrorw(ctx, "failed to add remote resource node", "error", err)
 			}
 		}
 
 		err = manager.resources.AddChild(resName, remoteName)
 		if err != nil {
-			logger.CErrorw(ctx,
-				"error while trying add node as a dependency of remote",
-				"resource", resName)
+			resLogger.CErrorw(ctx,
+				"error while trying add node as a dependency of remote")
 		} else {
 			anythingChanged = true
 		}
-		if anythingChanged {
-			logger.CDebugw(ctx, "remote resource names update completed with changes to resource graph")
-		} else {
-			logger.CDebugw(ctx, "remote resource names update completed with no changes to resource graph")
-		}
+	}
+
+	if anythingChanged {
+		logger.CDebugw(ctx, "remote resource names update completed with changes to resource graph")
+	} else {
+		logger.CDebugw(ctx, "remote resource names update completed with no changes to resource graph")
 	}
 
 	for resName, isActive := range activeResourceNames {
 		if isActive {
 			continue
 		}
-		logger.CDebugw(ctx, "attempting to remove remote resource", "name", resName)
+		resLogger := logger.WithFields("resource", resName)
+		resLogger.CDebugw(ctx, "attempting to remove remote resource")
 		gNode, ok := manager.resources.Node(resName)
 		if !ok || gNode.IsUninitialized() {
-			logger.CDebugw(ctx,
-				"remote resource already removed",
-				"resource", resName)
+			resLogger.CDebugw(ctx, "remote resource already removed")
 			continue
 		}
 		if err := manager.markChildrenForUpdate(resName); err != nil {
-			logger.CErrorw(ctx,
+			resLogger.CErrorw(ctx,
 				"failed to mark children of remote resource for update",
-				"resource", resName,
 				"reason", err)
 			continue
 		}
 		if err := gNode.Close(ctx); err != nil {
-			logger.CErrorw(ctx,
+			resLogger.CErrorw(ctx,
 				"failed to close remote resource node",
-				"resource", resName,
 				"reason", err)
 		}
 		anythingChanged = true

--- a/robot/impl/robot_framesystem_test.go
+++ b/robot/impl/robot_framesystem_test.go
@@ -22,7 +22,6 @@ import (
 	"go.viam.com/rdk/services/sensors"
 	_ "go.viam.com/rdk/services/sensors/builtin"
 	"go.viam.com/rdk/spatialmath"
-	rdktestutils "go.viam.com/rdk/testutils"
 	"go.viam.com/rdk/testutils/robottestutils"
 	rutils "go.viam.com/rdk/utils"
 )
@@ -135,7 +134,7 @@ func TestFrameSystemConfigWithRemote(t *testing.T) {
 		gripper.Named("myParentIsRemote"),
 	}
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		rdktestutils.VerifySameResourceNames(tb, r2.ResourceNames(), finalSet)
+		verifyReachableResourceNames(tb, r2, finalSet)
 	})
 
 	fsCfg, err = r2.FrameSystemConfig(context.Background())

--- a/robot/impl/robot_reconfigure_remote_test.go
+++ b/robot/impl/robot_reconfigure_remote_test.go
@@ -16,7 +16,6 @@ import (
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
-
 	// TODO(RSDK-7884): change everything that depends on this import to a mock.
 	"go.viam.com/rdk/services/motion"
 	// TODO(RSDK-7884): change all referenced resources to mocks.

--- a/robot/impl/robot_reconfigure_remote_test.go
+++ b/robot/impl/robot_reconfigure_remote_test.go
@@ -16,6 +16,7 @@ import (
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
+
 	// TODO(RSDK-7884): change everything that depends on this import to a mock.
 	"go.viam.com/rdk/services/motion"
 	// TODO(RSDK-7884): change all referenced resources to mocks.
@@ -140,7 +141,7 @@ func TestRemoteRobotsGold(t *testing.T) {
 
 	// wait for local_robot to detect that the remote is now offline
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		rdktestutils.VerifySameResourceNames(tb, r.ResourceNames(),
+		verifyReachableResourceNames(tb, r,
 			[]resource.Name{
 				motion.Named(resource.DefaultServiceName),
 				sensors.Named(resource.DefaultServiceName),
@@ -235,7 +236,7 @@ func TestRemoteRobotsUpdate(t *testing.T) {
 
 	// wait for local_robot to detect that the remote is now offline
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		rdktestutils.VerifySameResourceNames(tb, r.ResourceNames(),
+		verifyReachableResourceNames(tb, r,
 			[]resource.Name{
 				motion.Named(resource.DefaultServiceName),
 				sensors.Named(resource.DefaultServiceName),
@@ -303,7 +304,7 @@ func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
 
 	// wait for local_robot to detect that the remote is now offline
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		rdktestutils.VerifySameResourceNames(tb, r.ResourceNames(),
+		verifyReachableResourceNames(tb, r,
 			[]resource.Name{
 				motion.Named(resource.DefaultServiceName),
 				sensors.Named(resource.DefaultServiceName),
@@ -395,7 +396,7 @@ func TestInferRemoteRobotDependencyConnectAfterStartup(t *testing.T) {
 
 	// wait for local_robot to detect that the remote is now offline
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
-		rdktestutils.VerifySameResourceNames(tb, r.ResourceNames(),
+		verifyReachableResourceNames(tb, r,
 			[]resource.Name{
 				motion.Named(resource.DefaultServiceName),
 				sensors.Named(resource.DefaultServiceName),

--- a/robot/impl/utils.go
+++ b/robot/impl/utils.go
@@ -8,7 +8,9 @@ import (
 
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot"
+	"go.viam.com/rdk/testutils"
 )
 
 func setupLocalRobot(
@@ -31,4 +33,14 @@ func setupLocalRobot(
 		lRobot.reconfigureWorkers.Wait()
 	})
 	return r
+}
+
+func verifyReachableResourceNames(tb testing.TB, r robot.LocalRobot, expected []resource.Name) {
+	tb.Helper()
+
+	lRobot, ok := r.(*localRobot)
+	test.That(tb, ok, test.ShouldBeTrue)
+
+	reachable := lRobot.manager.reachableResourceNames()
+	testutils.VerifySameResourceNames(tb, reachable, expected)
 }


### PR DESCRIPTION
## Changes

* Keep offline remote resources in `ResourceNames`
* Add an internal `unreachable` field to graph_nodes, so that existing tests have a way to assert on the subset of resources are still online