### PR TITLE
RSDK-8683 - Checking if start is within planDevMM of goal should be handled by motionplan/ik package

### DIFF
--- a/motionplan/motionPlanner.go
+++ b/motionplan/motionPlanner.go
@@ -108,6 +108,16 @@ func (req *PlanRequest) validatePlanRequest() error {
 		}
 	}
 
+	_, ok := req.Options["planDeviationMM"].(float64)
+	if !ok {
+		req.Logger.Info("no planDeviationMM value was provided so we will use the default value of 1e-4")
+		if req.Options == nil {
+			req.Options = map[string]interface{}{"planDeviationMM": 1e-4}
+		} else {
+			req.Options["planDeviationMM"] = 1e-4
+		}
+	}
+
 	frameDOF := len(req.Frame.DoF())
 	seedMap, ok := req.StartConfiguration[req.Frame.Name()]
 	if frameDOF > 0 {

--- a/motionplan/motionPlanner.go
+++ b/motionplan/motionPlanner.go
@@ -51,6 +51,7 @@ type PlanRequest struct {
 	WorldState         *frame.WorldState
 	BoundingRegions    []spatialmath.Geometry
 	Constraints        *Constraints
+	GoalThreshold      float64
 	Options            map[string]interface{}
 }
 
@@ -108,14 +109,8 @@ func (req *PlanRequest) validatePlanRequest() error {
 		}
 	}
 
-	_, ok := req.Options["planDeviationMM"].(float64)
-	if !ok {
-		req.Logger.Info("no planDeviationMM value was provided so we will use the default value of 1e-4")
-		if req.Options == nil {
-			req.Options = map[string]interface{}{"planDeviationMM": 1e-4}
-		} else {
-			req.Options["planDeviationMM"] = 1e-4
-		}
+	if req.GoalThreshold == 0 {
+		req.GoalThreshold = 0.1
 	}
 
 	frameDOF := len(req.Frame.DoF())

--- a/motionplan/planManager.go
+++ b/motionplan/planManager.go
@@ -912,14 +912,6 @@ func (pm *planManager) planRelativeWaypoint(ctx context.Context, request *PlanRe
 	}
 	opt.planDeviationMM = planDevMM
 
-	opt.AtGoalMetric = func(startPose, goalPose spatialmath.Pose) bool {
-		if opt.profile == PositionOnlyMotionProfile {
-			return spatialmath.PoseAlmostCoincidentEps(startPose, goalPose, opt.planDeviationMM)
-		}
-		return spatialmath.OrientationAlmostEqual(goalPose.Orientation(), startPose.Orientation()) &&
-			spatialmath.PoseAlmostCoincidentEps(goalPose, startPose, opt.planDeviationMM)
-	}
-
 	// re-root the frame system on the relative frame
 	relativeOnlyFS, err := pm.frame.fss.FrameSystemSubset(request.Frame)
 	if err != nil {

--- a/motionplan/planManager.go
+++ b/motionplan/planManager.go
@@ -19,7 +19,6 @@ import (
 	"go.viam.com/rdk/motionplan/tpspace"
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/spatialmath"
-	rutils "go.viam.com/rdk/utils"
 )
 
 const (
@@ -906,11 +905,16 @@ func (pm *planManager) planRelativeWaypoint(ctx context.Context, request *PlanRe
 		return nil, err
 	}
 
-	planDevMM, err := rutils.AssertType[float64](request.Options["planDeviationMM"])
-	if err != nil {
-		return nil, err
+	if opt.profile == PositionOnlyMotionProfile {
+		opt.AtGoalMetric = func(startPose, goalPose spatialmath.Pose) bool {
+			return spatialmath.PoseAlmostCoincidentEps(startPose, goalPose, request.GoalThreshold)
+		}
+	} else {
+		opt.AtGoalMetric = func(startPose, goalPose spatialmath.Pose) bool {
+			return spatialmath.OrientationAlmostEqual(goalPose.Orientation(), startPose.Orientation()) &&
+				spatialmath.PoseAlmostCoincidentEps(goalPose, startPose, request.GoalThreshold)
+		}
 	}
-	opt.planDeviationMM = planDevMM
 
 	// re-root the frame system on the relative frame
 	relativeOnlyFS, err := pm.frame.fss.FrameSystemSubset(request.Frame)

--- a/motionplan/plannerOptions.go
+++ b/motionplan/plannerOptions.go
@@ -180,11 +180,17 @@ type plannerOptions struct {
 	// DistanceFunc is the function that the planner will use to measure the degree of "closeness" between two states of the robot
 	DistanceFunc ik.SegmentMetric
 
+	// AtGoalMetric
+	AtGoalMetric func(startPose, goalPose spatialmath.Pose) bool
+
 	// ScoreFunc is the function that the planner will use to evaluate a plan for final cost comparisons.
 	ScoreFunc ik.SegmentMetric
 
 	// profile is the string representing the motion profile
 	profile string
+
+	// profile is the string representing the motion profile
+	planDeviationMM float64
 
 	PlannerConstructor plannerConstructor
 

--- a/motionplan/plannerOptions.go
+++ b/motionplan/plannerOptions.go
@@ -180,14 +180,14 @@ type plannerOptions struct {
 	// DistanceFunc is the function that the planner will use to measure the degree of "closeness" between two states of the robot
 	DistanceFunc ik.SegmentMetric
 
+	// AtGoalMetric is a function that only the tpspace planner will use on the first iteration to determine if we are already at the goal
+	AtGoalMetric func(startPose, goalPose spatialmath.Pose) bool
+
 	// ScoreFunc is the function that the planner will use to evaluate a plan for final cost comparisons.
 	ScoreFunc ik.SegmentMetric
 
 	// profile is the string representing the motion profile
 	profile string
-
-	// planDeviationMM is a float representing how close we must be to the goal in order for planning to finish
-	planDeviationMM float64
 
 	PlannerConstructor plannerConstructor
 

--- a/motionplan/plannerOptions.go
+++ b/motionplan/plannerOptions.go
@@ -186,7 +186,7 @@ type plannerOptions struct {
 	// profile is the string representing the motion profile
 	profile string
 
-	// profile is the string representing the motion profile
+	// planDeviationMM is a float representing how close we must be to the goal in order for planning to finish
 	planDeviationMM float64
 
 	PlannerConstructor plannerConstructor

--- a/motionplan/plannerOptions.go
+++ b/motionplan/plannerOptions.go
@@ -180,9 +180,6 @@ type plannerOptions struct {
 	// DistanceFunc is the function that the planner will use to measure the degree of "closeness" between two states of the robot
 	DistanceFunc ik.SegmentMetric
 
-	// AtGoalMetric
-	AtGoalMetric func(startPose, goalPose spatialmath.Pose) bool
-
 	// ScoreFunc is the function that the planner will use to evaluate a plan for final cost comparisons.
 	ScoreFunc ik.SegmentMetric
 

--- a/motionplan/tpSpaceRRT.go
+++ b/motionplan/tpSpaceRRT.go
@@ -309,7 +309,14 @@ func (mp *tpSpaceRRTMotionPlanner) rrtBackgroundRunner(
 
 		// Check to see if the startPose is already within some predefined delta of the goalPose
 		if iter == 0 {
-			if mp.planOpts.AtGoalMetric(startPose, goalPose) {
+			atGoal := func(startPose, goalPose spatialmath.Pose) bool {
+				if mp.planOpts.profile == PositionOnlyMotionProfile {
+					return spatialmath.PoseAlmostCoincidentEps(startPose, goalPose, mp.planOpts.planDeviationMM)
+				}
+				return spatialmath.OrientationAlmostEqual(goalPose.Orientation(), startPose.Orientation()) &&
+					spatialmath.PoseAlmostCoincidentEps(goalPose, startPose, mp.planOpts.planDeviationMM)
+			}
+			if atGoal(startPose, goalPose) {
 				path := extractTPspacePath(rrt.maps.startMap, rrt.maps.goalMap,
 					&nodePair{
 						a: &basicNode{

--- a/motionplan/tpSpaceRRT_test.go
+++ b/motionplan/tpSpaceRRT_test.go
@@ -45,6 +45,9 @@ func TestPtgRrtBidirectional(t *testing.T) {
 	opt := newBasicPlannerOptions(ackermanFrame)
 	opt.DistanceFunc = ik.NewSquaredNormSegmentMetric(30.)
 	opt.StartPose = spatialmath.NewZeroPose()
+	opt.AtGoalMetric = func(startPose, goalPose spatialmath.Pose) bool {
+		return spatialmath.PoseAlmostCoincidentEps(startPose, goalPose, opt.GoalThreshold)
+	}
 	mp, err := newTPSpaceMotionPlanner(ackermanFrame, rand.New(rand.NewSource(42)), logger, opt)
 	test.That(t, err, test.ShouldBeNil)
 	tp, ok := mp.(*tpSpaceRRTMotionPlanner)

--- a/motionplan/tpSpaceRRT_test.go
+++ b/motionplan/tpSpaceRRT_test.go
@@ -149,6 +149,9 @@ func TestPtgWithObstacle(t *testing.T) {
 	for name, constraint := range collisionConstraints {
 		opt.AddStateConstraint(name, constraint)
 	}
+	opt.AtGoalMetric = func(startPose, goalPose spatialmath.Pose) bool {
+		return spatialmath.PoseAlmostCoincidentEps(startPose, goalPose, opt.GoalThreshold)
+	}
 
 	mp, err := newTPSpaceMotionPlanner(ackermanFrame, rand.New(rand.NewSource(42)), logger, opt)
 	test.That(t, err, test.ShouldBeNil)
@@ -167,7 +170,6 @@ func TestPtgWithObstacle(t *testing.T) {
 		tp.logger.Debugf("$SG,%f,%f", goalPos.Point().X, goalPos.Point().Y)
 	}
 	plan, err := tp.plan(ctx, goalPos, nil)
-
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, len(plan), test.ShouldBeGreaterThan, 2)
 

--- a/services/motion/builtin/move_on_globe_test.go
+++ b/services/motion/builtin/move_on_globe_test.go
@@ -17,6 +17,7 @@ import (
 	"go.viam.com/rdk/components/movementsensor"
 	_ "go.viam.com/rdk/components/register"
 	"go.viam.com/rdk/pointcloud"
+	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/services/motion"
 	"go.viam.com/rdk/services/vision"
@@ -145,6 +146,11 @@ func TestMoveOnGlobe(t *testing.T) {
 		planResp, err := moveRequest.Plan(ctx)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, planResp, test.ShouldNotBeNil)
+		test.That(t, len(planResp.Trajectory()), test.ShouldEqual, 2)
+		expectedMap := map[string][]referenceframe.Input{"test-base": referenceframe.FloatsToInputs([]float64{0, 0, 0, 0})}
+		test.That(t, planResp.Trajectory()[0], test.ShouldResemble, expectedMap)
+		test.That(t, planResp.Trajectory()[1], test.ShouldResemble, expectedMap)
+		test.That(t, len(planResp.Path()), test.ShouldEqual, 2)
 
 		// test that nothing breaks in state when we return an empty plan
 		executionID, err := ms.MoveOnGlobe(ctx, req)

--- a/services/motion/builtin/move_request.go
+++ b/services/motion/builtin/move_request.go
@@ -164,10 +164,6 @@ func (mr *moveRequest) execute(ctx context.Context, plan motionplan.Plan) (state
 	if !ok {
 		return state.ExecuteResponse{}, errors.New("exeuctionState.CurrentPoses() does not contain an entry for the LocalizationFrame")
 	}
-	planDevMM, err := utils.AssertType[float64](mr.planRequest.Options["planDeviationMM"])
-	if err != nil {
-		return state.ExecuteResponse{}, err
-	}
 	profile, err := utils.AssertType[string](mr.planRequest.Options["motion_profile"])
 	if err != nil {
 		profile = ""
@@ -175,10 +171,10 @@ func (mr *moveRequest) execute(ctx context.Context, plan motionplan.Plan) (state
 	atGoalCheck := func(basePose spatialmath.Pose) bool {
 		goal := mr.planRequest.Goal.Pose()
 		if profile == motionplan.PositionOnlyMotionProfile {
-			return spatialmath.PoseAlmostCoincidentEps(goal, basePose, planDevMM)
+			return spatialmath.PoseAlmostCoincidentEps(goal, basePose, mr.planRequest.GoalThreshold)
 		}
 		return spatialmath.OrientationAlmostEqualEps(goal.Orientation(), basePose.Orientation(), 5) &&
-			spatialmath.PoseAlmostCoincidentEps(goal, basePose, planDevMM)
+			spatialmath.PoseAlmostCoincidentEps(goal, basePose, mr.planRequest.GoalThreshold)
 	}
 	if resp := atGoalCheck(currentPosition.Pose()); !resp {
 		return state.ExecuteResponse{Replan: true, ReplanReason: "issuing a replan since we are not within planDeviationMM of the goal"}, nil
@@ -910,9 +906,6 @@ func (ms *builtIn) createBaseMoveRequest(
 
 	var backgroundWorkers sync.WaitGroup
 
-	// assign a planDeviationMM to our PlanRequest options so we know if we are already at the goal at plan time
-	valExtra.extra["planDeviationMM"] = motionCfg.planDeviationMM
-
 	mr := &moveRequest{
 		config: motionCfg,
 		logger: ms.logger,
@@ -924,6 +917,7 @@ func (ms *builtIn) createBaseMoveRequest(
 			StartConfiguration: currentInputs,
 			StartPose:          startPose,
 			WorldState:         worldState,
+			GoalThreshold:      motionCfg.planDeviationMM,
 			Options:            valExtra.extra,
 		},
 		kinematicBase:     kb,


### PR DESCRIPTION
This is an improvement for this ticket [RSDK-8481](https://github.com/viamrobotics/rdk/pull/4327)

The planner still runs, but on the first iteration of RRT we check if we are within PlanDevMM of the startPosition.
If we are, our returned plan is:
```
[0, 0, 0, 0],
[0, 0, 0, 0]
```


In this PR, we remove `atGoalCheck` from the `moveRequest` struct.
Since it is removed we redefine how we check for success once a plan has been completed. 

[RSDK-8481]: https://viam.atlassian.net/browse/RSDK-8481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ