### PR TITLE
Make sensors service not configured on default

### DIFF
--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -182,7 +182,6 @@ func TestConfigRemote(t *testing.T) {
 
 	expected := []resource.Name{
 		motion.Named(resource.DefaultServiceName),
-		sensors.Named(resource.DefaultServiceName),
 		arm.Named("squee:pieceArm"),
 		arm.Named("foo:pieceArm"),
 		arm.Named("bar:pieceArm"),
@@ -204,11 +203,8 @@ func TestConfigRemote(t *testing.T) {
 		gripper.Named("foo:pieceGripper"),
 		gripper.Named("bar:pieceGripper"),
 		motion.Named("squee:builtin"),
-		sensors.Named("squee:builtin"),
 		motion.Named("foo:builtin"),
-		sensors.Named("foo:builtin"),
 		motion.Named("bar:builtin"),
-		sensors.Named("bar:builtin"),
 	}
 
 	resources2 := r2.ResourceNames()
@@ -424,7 +420,6 @@ func TestConfigRemoteWithAuth(t *testing.T) {
 
 			expected := []resource.Name{
 				motion.Named(resource.DefaultServiceName),
-				sensors.Named(resource.DefaultServiceName),
 				arm.Named("bar:pieceArm"),
 				arm.Named("foo:pieceArm"),
 				audioinput.Named("bar:mic1"),
@@ -438,9 +433,7 @@ func TestConfigRemoteWithAuth(t *testing.T) {
 				gripper.Named("bar:pieceGripper"),
 				gripper.Named("foo:pieceGripper"),
 				motion.Named("foo:builtin"),
-				sensors.Named("foo:builtin"),
 				motion.Named("bar:builtin"),
-				sensors.Named("bar:builtin"),
 			}
 
 			resources2 := r2.ResourceNames()
@@ -595,7 +588,6 @@ func TestConfigRemoteWithTLSAuth(t *testing.T) {
 
 	expected := []resource.Name{
 		motion.Named(resource.DefaultServiceName),
-		sensors.Named(resource.DefaultServiceName),
 		arm.Named("foo:pieceArm"),
 		audioinput.Named("foo:mic1"),
 		camera.Named("foo:cameraOver"),
@@ -603,7 +595,6 @@ func TestConfigRemoteWithTLSAuth(t *testing.T) {
 		movementsensor.Named("foo:movement_sensor2"),
 		gripper.Named("foo:pieceGripper"),
 		motion.Named("foo:builtin"),
-		sensors.Named("foo:builtin"),
 	}
 
 	resources2 := r2.ResourceNames()
@@ -847,7 +838,6 @@ func TestMetadataUpdate(t *testing.T) {
 		movementsensor.Named("movement_sensor1"),
 		movementsensor.Named("movement_sensor2"),
 		motion.Named(resource.DefaultServiceName),
-		sensors.Named(resource.DefaultServiceName),
 	}
 
 	resources = r.ResourceNames()
@@ -1178,7 +1168,6 @@ func TestStatusRemote(t *testing.T) {
 		r.ResourceNames(),
 		[]resource.Name{
 			motion.Named(resource.DefaultServiceName),
-			sensors.Named(resource.DefaultServiceName),
 			arm.Named("foo:arm1"),
 			arm.Named("foo:arm2"),
 			arm.Named("bar:arm1"),
@@ -1286,7 +1275,6 @@ func TestGetRemoteResourceAndGrandFather(t *testing.T) {
 		r.ResourceNames(),
 		[]resource.Name{
 			motion.Named(resource.DefaultServiceName),
-			sensors.Named(resource.DefaultServiceName),
 			arm.Named("remote:foo:arm1"), arm.Named("remote:foo:arm2"),
 			arm.Named("remote:pieceArm"),
 			arm.Named("remote:foo:pieceArm"),
@@ -1296,9 +1284,7 @@ func TestGetRemoteResourceAndGrandFather(t *testing.T) {
 			movementsensor.Named("remote:movement_sensor2"),
 			gripper.Named("remote:pieceGripper"),
 			motion.Named("remote:builtin"),
-			sensors.Named("remote:builtin"),
 			motion.Named("remote:foo:builtin"),
-			sensors.Named("remote:foo:builtin"),
 		},
 	)
 	arm1, err := r.ResourceByName(arm.Named("remote:foo:arm1"))

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -826,7 +826,7 @@ func TestMetadataUpdate(t *testing.T) {
 	resources := r.ResourceNames()
 	test.That(t, err, test.ShouldBeNil)
 
-	test.That(t, len(resources), test.ShouldEqual, 8)
+	test.That(t, len(resources), test.ShouldEqual, 7)
 	test.That(t, err, test.ShouldBeNil)
 
 	// 5 declared resources + default sensors

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -849,32 +849,6 @@ func TestMetadataUpdate(t *testing.T) {
 	test.That(t, resources, test.ShouldBeEmpty)
 }
 
-func TestSensorsService(t *testing.T) {
-	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(context.Background(), "data/fake.json", logger)
-	test.That(t, err, test.ShouldBeNil)
-
-	r := setupLocalRobot(t, context.Background(), cfg, logger)
-
-	svc, err := sensors.FromRobot(r, resource.DefaultServiceName)
-	test.That(t, err, test.ShouldBeNil)
-
-	sensorNames := []resource.Name{movementsensor.Named("movement_sensor1"), movementsensor.Named("movement_sensor2")}
-	foundSensors, err := svc.Sensors(context.Background(), map[string]interface{}{})
-	test.That(t, err, test.ShouldBeNil)
-	rtestutils.VerifySameResourceNames(t, foundSensors, sensorNames)
-
-	readings, err := svc.Readings(context.Background(), []resource.Name{movementsensor.Named("movement_sensor1")}, map[string]interface{}{})
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, len(readings), test.ShouldEqual, 1)
-	test.That(t, readings[0].Name, test.ShouldResemble, movementsensor.Named("movement_sensor1"))
-	test.That(t, len(readings[0].Readings), test.ShouldBeGreaterThan, 3)
-
-	readings, err = svc.Readings(context.Background(), sensorNames, map[string]interface{}{})
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, len(readings), test.ShouldEqual, 2)
-}
-
 func TestStatusService(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	cfg, err := config.Read(context.Background(), "data/fake.json", logger)
@@ -1052,7 +1026,7 @@ func TestStatus(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		// 5 because the 3 default services are always added to a local_robot. We only care
 		// about the first two (working1 and button1) however.
-		test.That(t, len(resp), test.ShouldEqual, 4)
+		test.That(t, len(resp), test.ShouldEqual, 3)
 
 		// although the response is length 5, the only thing we actually care about for testing
 		// is consistency with the expected values in the workingResourceMap. So we eliminate
@@ -1756,7 +1730,7 @@ func TestConfigMethod(t *testing.T) {
 	// Assert that Config method returns the two default services: motion and sensors.
 	actualCfg := r.Config()
 	defaultSvcs := removeDefaultServices(actualCfg)
-	test.That(t, len(defaultSvcs), test.ShouldEqual, 2)
+	test.That(t, len(defaultSvcs), test.ShouldEqual, 1)
 	for _, svc := range defaultSvcs {
 		test.That(t, svc.API.SubtypeName, test.ShouldBeIn,
 			motion.API.SubtypeName, sensors.API.SubtypeName)
@@ -1861,7 +1835,7 @@ func TestConfigMethod(t *testing.T) {
 	// Assert that default motion and sensor services are still present, but data
 	// manager default service has been replaced by the "fake1" data manager service.
 	defaultSvcs = removeDefaultServices(actualCfg)
-	test.That(t, len(defaultSvcs), test.ShouldEqual, 2)
+	test.That(t, len(defaultSvcs), test.ShouldEqual, 1)
 	for _, svc := range defaultSvcs {
 		test.That(t, svc.API.SubtypeName, test.ShouldBeIn, motion.API.SubtypeName,
 			sensors.API.SubtypeName)
@@ -3426,14 +3400,6 @@ func getExpectedDefaultStatuses(revision string) []resource.Status {
 		{
 			Name: resource.Name{
 				API:  resource.APINamespaceRDK.WithServiceType("motion"),
-				Name: "builtin",
-			},
-			State:    resource.NodeStateReady,
-			Revision: revision,
-		},
-		{
-			Name: resource.Name{
-				API:  resource.APINamespaceRDK.WithServiceType("sensors"),
 				Name: "builtin",
 			},
 			State:    resource.NodeStateReady,

--- a/robot/impl/robot_framesystem_test.go
+++ b/robot/impl/robot_framesystem_test.go
@@ -19,7 +19,6 @@ import (
 	_ "go.viam.com/rdk/services/datamanager/builtin"
 	"go.viam.com/rdk/services/motion"
 	_ "go.viam.com/rdk/services/motion/builtin"
-	"go.viam.com/rdk/services/sensors"
 	_ "go.viam.com/rdk/services/sensors/builtin"
 	"go.viam.com/rdk/spatialmath"
 	rdktestutils "go.viam.com/rdk/testutils"
@@ -130,7 +129,6 @@ func TestFrameSystemConfigWithRemote(t *testing.T) {
 
 	finalSet := []resource.Name{
 		motion.Named(resource.DefaultServiceName),
-		sensors.Named(resource.DefaultServiceName),
 		base.Named("foo"),
 		gripper.Named("myParentIsRemote"),
 	}

--- a/robot/impl/robot_framesystem_test.go
+++ b/robot/impl/robot_framesystem_test.go
@@ -19,7 +19,6 @@ import (
 	_ "go.viam.com/rdk/services/datamanager/builtin"
 	"go.viam.com/rdk/services/motion"
 	_ "go.viam.com/rdk/services/motion/builtin"
-	_ "go.viam.com/rdk/services/sensors/builtin"
 	"go.viam.com/rdk/spatialmath"
 	rdktestutils "go.viam.com/rdk/testutils"
 	"go.viam.com/rdk/testutils/robottestutils"

--- a/robot/impl/robot_reconfigure_remote_test.go
+++ b/robot/impl/robot_reconfigure_remote_test.go
@@ -19,7 +19,6 @@ import (
 	// TODO(RSDK-7884): change everything that depends on this import to a mock.
 	"go.viam.com/rdk/services/motion"
 	// TODO(RSDK-7884): change all referenced resources to mocks.
-	"go.viam.com/rdk/services/sensors"
 	rdktestutils "go.viam.com/rdk/testutils"
 	"go.viam.com/rdk/testutils/robottestutils"
 )
@@ -109,11 +108,9 @@ func TestRemoteRobotsGold(t *testing.T) {
 		r.ResourceNames(),
 		[]resource.Name{
 			motion.Named(resource.DefaultServiceName),
-			sensors.Named(resource.DefaultServiceName),
 			arm.Named("arm1"),
 			arm.Named("foo:remoteArm"),
 			motion.Named("foo:builtin"),
-			sensors.Named("foo:builtin"),
 		},
 	)
 
@@ -123,15 +120,12 @@ func TestRemoteRobotsGold(t *testing.T) {
 
 	mainPartAndFooAndBarResources := []resource.Name{
 		motion.Named(resource.DefaultServiceName),
-		sensors.Named(resource.DefaultServiceName),
 		arm.Named("arm1"),
 		arm.Named("arm2"),
 		arm.Named("foo:remoteArm"),
 		motion.Named("foo:builtin"),
-		sensors.Named("foo:builtin"),
 		arm.Named("bar:remoteArm"),
 		motion.Named("bar:builtin"),
-		sensors.Named("bar:builtin"),
 	}
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
 		rdktestutils.VerifySameResourceNames(tb, r.ResourceNames(), mainPartAndFooAndBarResources)
@@ -143,11 +137,9 @@ func TestRemoteRobotsGold(t *testing.T) {
 		rdktestutils.VerifySameResourceNames(tb, r.ResourceNames(),
 			[]resource.Name{
 				motion.Named(resource.DefaultServiceName),
-				sensors.Named(resource.DefaultServiceName),
 				arm.Named("arm1"),
 				arm.Named("foo:remoteArm"),
 				motion.Named("foo:builtin"),
-				sensors.Named("foo:builtin"),
 			},
 		)
 	})
@@ -214,19 +206,14 @@ func TestRemoteRobotsUpdate(t *testing.T) {
 
 	expectedSet := []resource.Name{
 		motion.Named(resource.DefaultServiceName),
-		sensors.Named(resource.DefaultServiceName),
 		arm.Named("foo:arm1"),
 		motion.Named("foo:builtin"),
-		sensors.Named("foo:builtin"),
 		arm.Named("bar:arm1"),
 		motion.Named("bar:builtin"),
-		sensors.Named("bar:builtin"),
 		arm.Named("hello:arm1"),
 		motion.Named("hello:builtin"),
-		sensors.Named("hello:builtin"),
 		arm.Named("world:arm1"),
 		motion.Named("world:builtin"),
-		sensors.Named("world:builtin"),
 	}
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
 		rdktestutils.VerifySameResourceNames(tb, r.ResourceNames(), expectedSet)
@@ -238,7 +225,6 @@ func TestRemoteRobotsUpdate(t *testing.T) {
 		rdktestutils.VerifySameResourceNames(tb, r.ResourceNames(),
 			[]resource.Name{
 				motion.Named(resource.DefaultServiceName),
-				sensors.Named(resource.DefaultServiceName),
 			},
 		)
 	})
@@ -291,11 +277,9 @@ func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
 	r := setupLocalRobot(t, ctx, localConfig, logger.Sublogger("local"))
 	expectedSet := []resource.Name{
 		motion.Named(resource.DefaultServiceName),
-		sensors.Named(resource.DefaultServiceName),
 		arm.Named("arm1"),
 		arm.Named("foo:pieceArm"),
 		motion.Named("foo:builtin"),
-		sensors.Named("foo:builtin"),
 	}
 
 	rdktestutils.VerifySameResourceNames(t, r.ResourceNames(), expectedSet)
@@ -306,7 +290,6 @@ func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
 		rdktestutils.VerifySameResourceNames(tb, r.ResourceNames(),
 			[]resource.Name{
 				motion.Named(resource.DefaultServiceName),
-				sensors.Named(resource.DefaultServiceName),
 			},
 		)
 	})
@@ -374,7 +357,6 @@ func TestInferRemoteRobotDependencyConnectAfterStartup(t *testing.T) {
 	rdktestutils.VerifySameResourceNames(t, r.ResourceNames(),
 		[]resource.Name{
 			motion.Named(resource.DefaultServiceName),
-			sensors.Named(resource.DefaultServiceName),
 		},
 	)
 	err := foo.StartWeb(ctx, options)
@@ -382,11 +364,9 @@ func TestInferRemoteRobotDependencyConnectAfterStartup(t *testing.T) {
 
 	expectedSet := []resource.Name{
 		motion.Named(resource.DefaultServiceName),
-		sensors.Named(resource.DefaultServiceName),
 		arm.Named("arm1"),
 		arm.Named("foo:pieceArm"),
 		motion.Named("foo:builtin"),
-		sensors.Named("foo:builtin"),
 	}
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
 		rdktestutils.VerifySameResourceNames(tb, r.ResourceNames(), expectedSet)
@@ -398,7 +378,6 @@ func TestInferRemoteRobotDependencyConnectAfterStartup(t *testing.T) {
 		rdktestutils.VerifySameResourceNames(tb, r.ResourceNames(),
 			[]resource.Name{
 				motion.Named(resource.DefaultServiceName),
-				sensors.Named(resource.DefaultServiceName),
 			},
 		)
 	})
@@ -463,13 +442,10 @@ func TestInferRemoteRobotDependencyAmbiguous(t *testing.T) {
 
 	expectedSet := []resource.Name{
 		motion.Named(resource.DefaultServiceName),
-		sensors.Named(resource.DefaultServiceName),
 		arm.Named("foo:pieceArm"),
 		motion.Named("foo:builtin"),
-		sensors.Named("foo:builtin"),
 		arm.Named("bar:pieceArm"),
 		motion.Named("bar:builtin"),
-		sensors.Named("bar:builtin"),
 	}
 
 	rdktestutils.VerifySameResourceNames(t, r.ResourceNames(), expectedSet)
@@ -507,13 +483,10 @@ func TestInferRemoteRobotDependencyAmbiguous(t *testing.T) {
 
 	finalSet := []resource.Name{
 		motion.Named(resource.DefaultServiceName),
-		sensors.Named(resource.DefaultServiceName),
 		arm.Named("foo:pieceArm"),
 		motion.Named("foo:builtin"),
-		sensors.Named("foo:builtin"),
 		arm.Named("bar:pieceArm"),
 		motion.Named("bar:builtin"),
-		sensors.Named("bar:builtin"),
 		arm.Named("arm1"),
 	}
 

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -83,7 +83,7 @@ func registerMockComponent[R resource.Resource, CV resource.ConfigValidator](
 	return model
 }
 
-func TestRobotReconfigure(t *testing.T) {
+func (t *testing.T) {
 	test.That(t, len(resource.DefaultServices()), test.ShouldEqual, 2)
 
 	model1 := registerMockComponent(

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -3303,7 +3303,6 @@ func TestDefaultServiceReconfigure(t *testing.T) {
 	rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(),
 		[]resource.Name{
 			motion.Named(motionName),
-			sensors.Named(resource.DefaultServiceName),
 		},
 	)
 	sName := "sensors"
@@ -3322,7 +3321,6 @@ func TestDefaultServiceReconfigure(t *testing.T) {
 		robot.ResourceNames(),
 		[]resource.Name{
 			motion.Named(resource.DefaultServiceName),
-			sensors.Named(sName),
 		},
 	)
 }

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -23,16 +23,14 @@ import (
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
+
 	// TODO(RSDK-7884): change everything that depends on this import to a mock.
 	_ "go.viam.com/rdk/services/datamanager/builtin"
 	// TODO(RSDK-7884): change everything that depends on this import to a mock.
 	"go.viam.com/rdk/services/motion"
 	// TODO(RSDK-7884): change everything that depends on this import to a mock.
 	_ "go.viam.com/rdk/services/motion/builtin"
-	// TODO(RSDK-7884): change everything that depends on this import to a mock.
-	"go.viam.com/rdk/services/sensors"
-	// TODO(RSDK-7884): change everything that depends on this import to a mock.
-	_ "go.viam.com/rdk/services/sensors/builtin"
+
 	rdktestutils "go.viam.com/rdk/testutils"
 	rutils "go.viam.com/rdk/utils"
 )
@@ -83,8 +81,8 @@ func registerMockComponent[R resource.Resource, CV resource.ConfigValidator](
 	return model
 }
 
-func (t *testing.T) {
-	test.That(t, len(resource.DefaultServices()), test.ShouldEqual, 2)
+func TestRobotReconfigure(t *testing.T) {
+	test.That(t, len(resource.DefaultServices()), test.ShouldEqual, 1)
 
 	model1 := registerMockComponent(
 		t,
@@ -227,7 +225,7 @@ func (t *testing.T) {
 		robot := setupLocalRobot(t, ctx, conf1, logger)
 
 		resources := robot.ResourceNames()
-		test.That(t, len(resources), test.ShouldEqual, 7)
+		test.That(t, len(resources), test.ShouldEqual, 6)
 
 		armNames := []resource.Name{mockNamed("arm1")}
 		baseNames := []resource.Name{mockNamed("base1")}
@@ -1658,7 +1656,7 @@ func (t *testing.T) {
 		robot := setupLocalRobot(t, ctx, cempty, logger)
 
 		resources := robot.ResourceNames()
-		test.That(t, len(resources), test.ShouldEqual, 2)
+		test.That(t, len(resources), test.ShouldEqual, 1)
 		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), resource.DefaultServices())
 		test.That(t, robot.ProcessManager().ProcessIDs(), test.ShouldBeEmpty)
@@ -3305,16 +3303,8 @@ func TestDefaultServiceReconfigure(t *testing.T) {
 			motion.Named(motionName),
 		},
 	)
-	sName := "sensors"
-	cfg2 := &config.Config{
-		Services: []resource.Config{
-			{
-				Name:  sName,
-				API:   sensors.API,
-				Model: resource.DefaultServiceModel,
-			},
-		},
-	}
+
+	cfg2 := &config.Config{}
 	robot.Reconfigure(context.Background(), cfg2)
 	rdktestutils.VerifySameResourceNames(
 		t,

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -23,14 +23,12 @@ import (
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
-
 	// TODO(RSDK-7884): change everything that depends on this import to a mock.
 	_ "go.viam.com/rdk/services/datamanager/builtin"
 	// TODO(RSDK-7884): change everything that depends on this import to a mock.
 	"go.viam.com/rdk/services/motion"
 	// TODO(RSDK-7884): change everything that depends on this import to a mock.
 	_ "go.viam.com/rdk/services/motion/builtin"
-
 	rdktestutils "go.viam.com/rdk/testutils"
 	rutils "go.viam.com/rdk/utils"
 )

--- a/robot/impl/robot_reconfigure_weak_dependencies_test.go
+++ b/robot/impl/robot_reconfigure_weak_dependencies_test.go
@@ -12,126 +12,14 @@ import (
 	// TODO(RSDK-7884): change everything that depends on this import to a mock.
 	"go.viam.com/rdk/components/arm/fake"
 	// TODO(RSDK-7884): change everything that depends on this import to a mock.
-	"go.viam.com/rdk/components/audioinput"
-	// TODO(RSDK-7884): change everything that depends on this import to a mock.
 	"go.viam.com/rdk/components/base"
 	// TODO(RSDK-7884): change everything that depends on this import to a mock.
-	"go.viam.com/rdk/components/camera"
-	// TODO(RSDK-7884): change everything that depends on this import to a mock.
 	"go.viam.com/rdk/components/generic"
-	// TODO(RSDK-7884): change everything that depends on this import to a mock.
-	"go.viam.com/rdk/components/gripper"
-	// TODO(RSDK-7884): change everything that depends on this import to a mock.
-	"go.viam.com/rdk/components/movementsensor"
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
-	// TODO(RSDK-7884): change everything that depends on this import to a mock.
-	"go.viam.com/rdk/services/sensors"
-	rdktestutils "go.viam.com/rdk/testutils"
 	rutils "go.viam.com/rdk/utils"
 )
-
-// this serves as a test for updateWeakDependents as the sensors service defines a weak
-// dependency.
-func TestSensorsServiceReconfigure(t *testing.T) {
-	logger := logging.NewTestLogger(t)
-
-	// emptyCfg, err := config.Read(context.Background(), "data/diff_config_empty.json", logger)
-	emptyCfg := &config.Config{}
-	// cfg, err := config.Read(context.Background(), "data/fake.json", logger)
-	// test.That(t, err, test.ShouldBeNil)
-	cfg := processConfig(t, &config.Config{
-		Components: []resource.Config{
-			{
-				Name:  "pieceGripper",
-				API:   gripper.API,
-				Model: resource.DefaultModelFamily.WithModel("fake"),
-			},
-			{
-				Name:  "mic1",
-				API:   audioinput.API,
-				Model: resource.DefaultModelFamily.WithModel("fake"),
-			},
-			{
-				Name:  "camera",
-				API:   camera.API,
-				Model: resource.DefaultModelFamily.WithModel("fake"),
-			},
-			{
-				Name:  "pieceArm",
-				API:   mockAPI,
-				Model: resource.DefaultModelFamily.WithModel("fake"),
-				Attributes: rutils.AttributeMap{
-					"model-path": "../../components/arm/fake/fake_model.json",
-				},
-			},
-			{
-				Name:  "movement_sensor1",
-				API:   movementsensor.API,
-				Model: resource.DefaultModelFamily.WithModel("fake"),
-			},
-			{
-				Name:  "movement_sensor2",
-				API:   movementsensor.API,
-				Model: resource.DefaultModelFamily.WithModel("fake"),
-			},
-		},
-	})
-
-	sensorNames := []resource.Name{movementsensor.Named("movement_sensor1"), movementsensor.Named("movement_sensor2")}
-
-	t.Run("empty to two sensors", func(t *testing.T) {
-		robot := setupLocalRobot(t, context.Background(), emptyCfg, logger)
-
-		svc, err := sensors.FromRobot(robot, resource.DefaultServiceName)
-		test.That(t, err, test.ShouldBeNil)
-
-		foundSensors, err := svc.Sensors(context.Background(), map[string]interface{}{})
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, foundSensors, test.ShouldBeEmpty)
-
-		robot.Reconfigure(context.Background(), cfg)
-
-		foundSensors, err = svc.Sensors(context.Background(), map[string]interface{}{})
-		test.That(t, err, test.ShouldBeNil)
-		rdktestutils.VerifySameResourceNames(t, foundSensors, sensorNames)
-	})
-
-	t.Run("two sensors to empty", func(t *testing.T) {
-		robot := setupLocalRobot(t, context.Background(), cfg, logger)
-
-		svc, err := sensors.FromRobot(robot, resource.DefaultServiceName)
-		test.That(t, err, test.ShouldBeNil)
-
-		foundSensors, err := svc.Sensors(context.Background(), map[string]interface{}{})
-		test.That(t, err, test.ShouldBeNil)
-		rdktestutils.VerifySameResourceNames(t, foundSensors, sensorNames)
-
-		robot.Reconfigure(context.Background(), emptyCfg)
-
-		foundSensors, err = svc.Sensors(context.Background(), map[string]interface{}{})
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, foundSensors, test.ShouldBeEmpty)
-	})
-
-	t.Run("two sensors to two sensors", func(t *testing.T) {
-		robot := setupLocalRobot(t, context.Background(), cfg, logger)
-
-		svc, err := sensors.FromRobot(robot, resource.DefaultServiceName)
-		test.That(t, err, test.ShouldBeNil)
-
-		foundSensors, err := svc.Sensors(context.Background(), map[string]interface{}{})
-		test.That(t, err, test.ShouldBeNil)
-		rdktestutils.VerifySameResourceNames(t, foundSensors, sensorNames)
-
-		robot.Reconfigure(context.Background(), cfg)
-
-		foundSensors, err = svc.Sensors(context.Background(), map[string]interface{}{})
-		test.That(t, err, test.ShouldBeNil)
-		rdktestutils.VerifySameResourceNames(t, foundSensors, sensorNames)
-	})
-}
 
 type someTypeWithWeakAndStrongDeps struct {
 	resource.Named

--- a/services/sensors/builtin/builtin.go
+++ b/services/sensors/builtin/builtin.go
@@ -14,7 +14,7 @@ import (
 )
 
 func init() {
-	resource.RegisterDefaultService(
+	resource.RegisterService(
 		sensors.API,
 		resource.DefaultServiceModel,
 		resource.Registration[sensors.Service, resource.NoNativeConfig]{
@@ -36,6 +36,8 @@ func NewBuiltIn(
 	if err := s.Reconfigure(ctx, deps, conf); err != nil {
 		return nil, err
 	}
+
+	s.logger.Warn("sensors service is deprecated")
 	return s, nil
 }
 

--- a/web/server/entrypoint_test.go
+++ b/web/server/entrypoint_test.go
@@ -35,7 +35,7 @@ import (
 
 // numResources is the # of resources in /etc/configs/fake.json + the 2
 // expected builtin resources.
-const numResources = 21
+const numResources = 20
 
 func TestEntrypoint(t *testing.T) {
 	if runtime.GOARCH == "arm" {


### PR DESCRIPTION
The sensors service API is [deprecated](https://github.com/viamrobotics/api/blob/main/proto/viam/service/sensors/v1/sensors.proto). We still, however, add a default sensors service resource to every viam-server out there. This pr removes it as a default service.