### PR TITLE
downgrade-sync-path-log-to-debug

### DIFF
--- a/services/datamanager/builtin/sync/sync.go
+++ b/services/datamanager/builtin/sync/sync.go
@@ -552,7 +552,7 @@ func (s *Sync) walkDirsAndSendFilesToSync(ctx context.Context, config Config) er
 	s.flushCollectors()
 	var errs []error
 	for _, dir := range config.SyncPaths() {
-		s.logger.Infof("syncing from: %s", dir)
+		s.logger.Debugf("syncing from: %s", dir)
 		loggedDirPaths := map[string]bool{}
 		// Retrieve all files in capture dir and send them to the syncer
 		err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {


### PR DESCRIPTION
Turns out this log is a bit too noisy when your robot is not syncing data 