### PR TITLE
Create capture directory in data manager builtin

### DIFF
--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -197,6 +197,9 @@ func (b *builtIn) Reconfigure(ctx context.Context, deps resource.Dependencies, c
 		// If this error occurs it's a resource graph error
 		return err
 	}
+	if err := os.MkdirAll(captureConfig.CaptureDir, 0o700); err != nil {
+		b.logger.Warnf("failed to create capture directory: %s", captureConfig.CaptureDir)
+	}
 
 	syncSensor, syncSensorEnabled := syncSensorFromDeps(c.SelectiveSyncerName, deps, b.logger)
 	syncConfig := c.syncConfig(syncSensor, syncSensorEnabled, b.logger)


### PR DESCRIPTION
If you configure data sync without any collectors, you get logs in data sync that complain about the capture directory not existing.

This is b/c data manager currently only creates the capture directory if you have a collector, but data sync expects the capture directory to always exist. 

This mitigates the problem my having data manager builtin attempt to create the top-level capture director if it doesn't already exist.