### PR TITLE
[RSDK-8950] Allow Try Viam to use specific viam modules

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -203,13 +203,13 @@ func (mgr *Manager) Handles() map[string]modlib.HandlerMap {
 	return res
 }
 
-// an
+// an allowed list of specific viam namespace modules 
 var allowedModules = map[string]bool{
 	"viam:raspberry-pi": true,
 }
 
 // this function checks if the modules added in an intrusted environment are
-// viam modules
+// viam modules and alloweds them to be run within an untrusted envionment if so
 func checkIfAllowed(confs ...config.Module) (
 	allowed bool, newConfs []config.Module,
 ) {

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -203,7 +203,8 @@ func (mgr *Manager) Handles() map[string]modlib.HandlerMap {
 	return res
 }
 
-// an allowed list of specific viam namespace modules.
+// An allowed list of specific viam namespace modules. We want to allow running some of our official
+// modules even in an untrusted environment.
 var allowedModules = map[string]bool{
 	"viam:raspberry-pi": true,
 }

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -209,8 +209,8 @@ var allowedModules = map[string]bool{
 	"viam:raspberry-pi": true,
 }
 
-// this function checks if the modules added in an intrusted environment are
-// viam modules and allowes them to be run within an untrusted envionment if so.
+// Checks if the modules added in an untrusted environment are Viam modules
+// and returns `true` and a list of their configs if any exist in the passed-in slice.
 func checkIfAllowed(confs ...config.Module) (
 	allowed bool /*false*/, newConfs []config.Module,
 ) {

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -203,22 +203,21 @@ func (mgr *Manager) Handles() map[string]modlib.HandlerMap {
 	return res
 }
 
-// an allowed list of specific viam namespace modules 
+// an allowed list of specific viam namespace modules.
 var allowedModules = map[string]bool{
 	"viam:raspberry-pi": true,
 }
 
 // this function checks if the modules added in an intrusted environment are
-// viam modules and alloweds them to be run within an untrusted envionment if so
+// viam modules and alloweds them to be run within an untrusted envionment if so.
 func checkIfAllowed(confs ...config.Module) (
-	allowed bool, newConfs []config.Module,
+	allowed bool /*false*/, newConfs []config.Module,
 ) {
 	for _, conf := range confs {
 		if ok := allowedModules[conf.ModuleID]; ok {
 			allowed = true
 			newConfs = append(newConfs, conf)
 		}
-		return allowed, newConfs
 	}
 	return allowed, newConfs
 }

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -238,8 +238,8 @@ func (mgr *Manager) Add(ctx context.Context, confs ...config.Module) error {
 		}
 		// overwrite with just the modules we've allowed
 		confs = newConfs
-		mgr.logger.Warnf(
-			"viam server is running in an untrusted environment and will only add the following modules: %v",
+		mgr.logger.CWarnw(
+			ctx, "Running in an untrusted environment; will only add some modules", "modules",
 			confs)
 	}
 

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -209,7 +209,7 @@ var allowedModules = map[string]bool{
 }
 
 // this function checks if the modules added in an intrusted environment are
-// viam modules and alloweds them to be run within an untrusted envionment if so.
+// viam modules and allowes them to be run within an untrusted envionment if so.
 func checkIfAllowed(confs ...config.Module) (
 	allowed bool /*false*/, newConfs []config.Module,
 ) {
@@ -238,7 +238,7 @@ func (mgr *Manager) Add(ctx context.Context, confs ...config.Module) error {
 		// overwrite with just the modules we've allowed
 		confs = newConfs
 		mgr.logger.Warnf(
-			"in an untrusted environrment only specific modules can be used, running machine with only the following modules %v",
+			"viam server is running in an untrusted environment and will only add the following modules: %v",
 			confs)
 	}
 

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -918,6 +918,33 @@ func TestModuleMisc(t *testing.T) {
 		// i.e.  '/private/var/folders/p1/nl3sq7jn5nx8tfkdwpz2_g7r0000gn/T/TestModuleMisc1764175663/002'
 		test.That(t, modWorkingDirectory, test.ShouldEndWith, filepath.Dir(modPath))
 	})
+
+	t.Run("allowed viam modules only in untrusted environment", func(t *testing.T) {
+		logger := logging.NewTestLogger(t)
+		mgr := setupModManager(t, ctx, parentAddr, logger, modmanageroptions.Options{
+			UntrustedEnv: true,
+			ViamHomeDir:  testViamHomeDir,
+		})
+		// confirm that nothing is added when all modules are not in the allowedList
+		err := mgr.Add(ctx, modCfg)
+		test.That(t, err, test.ShouldBeError, errModularResourcesDisabled)
+
+		allowedCfg := config.Module{
+			Name:     "test-module",
+			ExePath:  modPath,
+			Type:     config.ModuleTypeLocal,
+			ModuleID: "viam:raspberry-pi",
+		}
+
+		// this currently logs and does not return an error
+		err = mgr.Add(ctx, allowedCfg, modCfg)
+		test.That(t, err, test.ShouldBeNil)
+
+		// confirm only the raspberry-pi module was added
+		for _, conf := range mgr.Configs() {
+			test.That(t, conf.ModuleID, test.ShouldContainSubstring, "viam")
+		}
+	})
 }
 
 func TestTwoModulesRestart(t *testing.T) {
@@ -1386,5 +1413,3 @@ func TestModularDiscovery(t *testing.T) {
 	test.That(t, discovery.Query.Model, test.ShouldEqual, "rdk:test:helper")
 	test.That(t, discovery.Results["foo"], test.ShouldEqual, "bar")
 }
-
-

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -1386,3 +1386,5 @@ func TestModularDiscovery(t *testing.T) {
 	test.That(t, discovery.Query.Model, test.ShouldEqual, "rdk:test:helper")
 	test.That(t, discovery.Results["foo"], test.ShouldEqual, "bar")
 }
+
+

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -941,6 +941,7 @@ func TestModuleMisc(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		// confirm only the raspberry-pi module was added
+		test.That(t, len(mgr.Configs()), test.ShouldEqual, 1)
 		for _, conf := range mgr.Configs() {
 			test.That(t, conf.ModuleID, test.ShouldContainSubstring, "viam")
 		}


### PR DESCRIPTION
Try viam is run with an untrusted environment, which means no modules. However, we are modularizing all the builtin components. We need a way to run specific modules only in untrusted environments.

Right now, I'm only whitelisting the raspberry pi, but I'm welcome to suggesting to make this not as brittle.

Tested with a `viam:odrive` module and a `viam:raspberry-pi` module, this only allows the pi resource to be built, though I do think the logging on what is going on could be clearer.

I have not added more whitelisted modules because we have a scope doc discussing their names right now.

Robot logs showing the pi being added in an untrusted environment, but not the drive:
```sh
archytas@archytas:~ $ sudo ./viam-server -untrusted-env -config /etc/viam.json 
2024-10-08T22:35:43.535Z	INFO	rdk	config/logging_level.go:38	Log level initialized: info
2024-10-08T22:35:43.536Z	INFO	rdk	server/entrypoint.go:70	Viam RDK built from source; version unknown
2024-10-08T22:35:44.124Z	INFO	rdk.package_manager	packages/local_package_manager.go:158	Local package changes have been detected, starting sync...
2024-10-08T22:35:44.175Z	INFO	rdk.package_manager	packages/deferred_package_manager.go:143	cloud package manager created asyncronously
2024-10-08T22:35:45.539Z	INFO	rdk.package_manager	packages/local_package_manager.go:190	Local package sync complete after 1.414697776s
2024-10-08T22:35:45.540Z	INFO	rdk	impl/local_robot.go:1277	(Re)configuring robot
2024-10-08T22:35:45.541Z	INFO	rdk.modmanager	modmanager/manager.go:261	Now adding module	{"module":"viam_raspberry-pi"}
2024-10-08T22:35:45.541Z	INFO	rdk.modmanager	modmanager/manager.go:342	Creating data directory "/root/.viam/module-data/d7919dff-0751-4f44-a914-4a6fdb196c97/viam_raspberry-pi" for module "viam_raspberry-pi"
2024-10-08T22:35:45.542Z	INFO	rdk.modmanager	modmanager/manager.go:1099	Starting module in working directory	{"module":"viam_raspberry-pi","dir":"/root/.viam/packages/data/module/e76d1b3b-0468-4efd-bb7f-fb1d2b352fcb-raspberry-pi-1_0_6-linux-arm64"}
2024-10-08T22:35:45.543Z	INFO	rdk.modmanager	modmanager/manager.go:1128	Starting up module	{"module":"viam_raspberry-pi"}
2024-10-08T22:35:45.565Z	INFO	rdk.modmanager.process.viam_raspberry-pi_/root/.viam/packages/data/module/e76d1b3b-0468-4efd-bb7f-fb1d2b352fcb-raspberry-pi-1_0_6-linux-arm64/run.sh.StdOut	pexec/managed_process.go:277	
\_ libpigpiod-if2-1 is already installed.
2024-10-08T22:35:45.587Z	INFO	rdk.modmanager.process.viam_raspberry-pi_/root/.viam/packages/data/module/e76d1b3b-0468-4efd-bb7f-fb1d2b352fcb-raspberry-pi-1_0_6-linux-arm64/run.sh.StdOut	pexec/managed_process.go:277	
\_ pigpio is already installed.
2024-10-08T22:35:45.588Z	INFO	rdk.modmanager.process.viam_raspberry-pi_/root/.viam/packages/data/module/e76d1b3b-0468-4efd-bb7f-fb1d2b352fcb-raspberry-pi-1_0_6-linux-arm64/run.sh.StdOut	pexec/managed_process.go:277	
\_ Starting pigpiod service...
2024-10-08T22:35:47.076Z	INFO	rdk.modmanager.process.viam_raspberry-pi_/root/.viam/packages/data/module/e76d1b3b-0468-4efd-bb7f-fb1d2b352fcb-raspberry-pi-1_0_6-linux-arm64/run.sh.StdOut	pexec/managed_process.go:277	
\_ pigpiod is running successfully.
2024-10-08T22:35:47.077Z	INFO	rdk.modmanager.process.viam_raspberry-pi_/root/.viam/packages/data/module/e76d1b3b-0468-4efd-bb7f-fb1d2b352fcb-raspberry-pi-1_0_6-linux-arm64/run.sh.StdOut	pexec/managed_process.go:277	
\_ Installation and verification completed successfully!
2024-10-08T22:35:47.129Z	INFO	rdk.modmanager.process.viam_raspberry-pi_/root/.viam/packages/data/module/e76d1b3b-0468-4efd-bb7f-fb1d2b352fcb-raspberry-pi-1_0_6-linux-arm64/run.sh.StdOut	pexec/managed_process.go:277	
\_ 2024-10-08T22:35:47.129Z	INFO	raspberry-pi	module/module.go:287	server listening at /tmp/viam-module-2987130088/viam_raspberry-pi-RIjVi.sock
2024-10-08T22:35:47.146Z	INFO	rdk.modmanager	modmanager/manager.go:1028	Waiting for module to respond to ready request	{"module":"viam_raspberry-pi"}
2024-10-08T22:35:47.158Z	INFO	rdk.modmanager.process.viam_raspberry-pi_/root/.viam/packages/data/module/e76d1b3b-0468-4efd-bb7f-fb1d2b352fcb-raspberry-pi-1_0_6-linux-arm64/run.sh.StdOut	pexec/managed_process.go:277	
\_ 2024-10-08T22:35:47.158Z	INFO	networking.module-connection	client/client.go:338	successfully (re)connected to remote at address	{"address":"unix:///tmp/viam-module-2987130088/parent.sock"}
2024-10-08T22:35:47.181Z	INFO	rdk.modmanager	modmanager/manager.go:1190	Registering component API and model from module	{"module":"viam_raspberry-pi","API":"rdk:component:board","model":"viam:raspberry-pi:rpi"}
2024-10-08T22:35:47.182Z	INFO	rdk.modmanager	modmanager/manager.go:1190	Registering component API and model from module	{"module":"viam_raspberry-pi","API":"rdk:component:servo","model":"viam:raspberry-pi:rpi-servo"}
2024-10-08T22:35:47.182Z	INFO	rdk.modmanager	modmanager/manager.go:366	Module successfully added	{"module":"viam_raspberry-pi"}
2024-10-08T22:35:47.183Z	INFO	rdk.modmanager	modmanager/manager.go:278	Modules successfully added	{"modules":["viam_raspberry-pi"]}
2024-10-08T22:35:47.186Z	INFO	rdk.resource_manager	impl/resource_manager.go:674	Now configuring resource	{"resource":"rdk:service:sensors/builtin"}
2024-10-08T22:35:47.186Z	INFO	rdk.resource_manager	impl/resource_manager.go:674	Now configuring resource	{"resource":"rdk:service:motion/builtin"}
2024-10-08T22:35:47.187Z	INFO	rdk.resource_manager	impl/resource_manager.go:674	Now configuring resource	{"resource":"rdk:component:motor/motor-1"}
2024-10-08T22:35:47.187Z	INFO	rdk.resource_manager	impl/resource_manager.go:674	Now configuring resource	{"resource":"rdk:component:board/board-1"}
2024-10-08T22:35:47.187Z	ERROR	rdk.resource_manager.rdk:component:motor/motor-1	resource/graph_node.go:282	resource build error: unknown resource type: API "rdk:component:motor" with model "viam:odrive:serial" not registered	{"resource":"rdk:component:motor/motor-1","model":"viam:odrive:serial"}
2024-10-08T22:35:47.189Z	INFO	rdk.modmanager	modmanager/manager.go:506	Adding resource to module	{"resource":"board-1","module":"viam_raspberry-pi"}
2024-10-08T23:35:47.200+0100	INFO	rdk.raspberry-pi.rdk:component:board/board-1	rpi/daemon.go:51	pigpiod is already running	{"log_ts": "2024-10-08T22:35:47.199Z"}
2024-10-08T23:35:47.255+0100	INFO	rdk.raspberry-pi.rdk:component:board/board-1	rpi/board.go:129	successfully started pigpiod	{"log_ts": "2024-10-08T22:35:47.254Z"}
2024-10-08T22:35:47.259Z	INFO	rdk	impl/local_robot.go:1322	Robot (re)configured
2024-10-08T22:35:47.276Z	INFO	rdk.networking	rpc/server.go:599	will run external signaling answerer	{"signaling_address":"app.viam.com:443","for_hosts":["archytas-main.ikzfbcf5i3.viam.cloud"]}
2024-10-08T22:35:47.337Z	INFO	rdk	web/web.go:599	serving	{"url":"https://archytas-main.ikzfbcf5i3.local.viam.cloud:8080","alt_url":"https://0.0.0.0:8080"}
2024-10-08T22:35:49.125Z	INFO	rdk.resource_manager	impl/resource_manager.go:674	Now configuring resource	{"resource":"rdk:component:motor/motor-1"}
2024-10-08T22:35:49.127Z	ERROR	rdk.resource_manager.rdk:component:motor/motor-1	resource/graph_node.go:282	resource build error: unknown resource type: API "rdk:component:motor" with model "viam:odrive:serial" not registered	{"resource":"rdk:component:motor/motor-1","model":"viam:odrive:serial"}
2024-10-08T22:35:49.453Z	INFO	rdk	impl/local_robot.go:1277	(Re)configuring robot
2024-10-08T22:35:49.453Z	ERROR	rdk.resource_manager	impl/resource_manager.go:1087	error adding modules	{"error":"modular resources disabled in untrusted environment","errorVerbose":"modular resources disabled in untrusted environment\ngo.viam.com/rdk/module/modmanager.init\n\t<autogenerated>:1\nruntime.doInit1\n\t/usr/local/go/src/runtime/proc.go:7290\nruntime.doInit\n\t/usr/local/go/src/runtime/proc.go:7257\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:254\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_arm64.s:1223"}
2024-10-08T22:35:49.454Z	INFO	rdk.resource_manager	impl/resource_manager.go:674	Now configuring resource	{"resource":"rdk:component:motor/motor-1"}
2024-10-08T22:35:49.455Z	ERROR	rdk.resource_manager.rdk:component:motor/motor-1	resource/graph_node.go:282	resource build error: unknown resource type: API "rdk:component:motor" with model "viam:odrive:serial" not registered	{"resource":"rdk:component:motor/motor-1","model":"viam:odrive:serial"}
2024-10-08T22:35:49.459Z	INFO	rdk	impl/local_robot.go:1322	Robot (re)configured
2024-10-08T22:35:54.125Z	INFO	rdk.resource_manager	impl/resource_manager.go:674	Now configuring resource	{"resource":"rdk:component:motor/motor-1"}
2024-10-08T22:35:54.126Z	ERROR	rdk.resource_manager.rdk:component:motor/motor-1	resource/graph_node.go:282	resource build error: unknown resource type: API "rdk:component:motor" with model "viam:odrive:serial" not registered	{"resource":"rdk:component:motor/motor-1","model":"viam:odrive:serial"}
2024-10-08T22:35:59.127Z	INFO	rdk.resource_manager	impl/resource_manager.go:674	Now configuring resource	{"resource":"rdk:component:motor/motor-1"}
2024-10-08T22:35:59.128Z	ERROR	rdk.resource_manager.rdk:component:motor/motor-1	resource/graph_node.go:282	resource build error: unknown resource type: API "rdk:component:motor" with model "viam:odrive:serial" not registered	{"resource":"rdk:component:motor/motor-1","model":"viam:odrive:serial"}
2024-10-08T22:35:59.693Z	INFO	rdk	impl/local_robot.go:1277	(Re)configuring robot
2024-10-08T22:35:59.693Z	ERROR	rdk.resource_manager	impl/resource_manager.go:1087	error adding modules	{"error":"modular resources disabled in untrusted environment","errorVerbose":"modular resources disabled in untrusted environment\ngo.viam.com/rdk/module/modmanager.init\n\t<autogenerated>:1\nruntime.doInit1\n\t/usr/local/go/src/runtime/proc.go:7290\nruntime.doInit\n\t/usr/local/go/src/runtime/proc.go:7257\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:254\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_arm64.s:1223"}
2024-10-08T22:35:59.695Z	INFO	rdk.resource_manager	impl/resource_manager.go:674	Now configuring resource	{"resource":"rdk:component:motor/motor-1"}
2024-10-08T22:35:59.696Z	ERROR	rdk.resource_manager.rdk:component:motor/motor-1	resource/graph_node.go:282	resource build error: unknown resource type: API "rdk:component:motor" with model "viam:odrive:serial" not registered	{"resource":"rdk:component:motor/motor-1","model":"viam:odrive:serial"}
2024-10-08T22:35:59.702Z	INFO	rdk	impl/local_robot.go:1322	Robot (re)configured
^C2024-10-08T22:36:03.879Z	INFO	rdk.networking	rpc/server.go:829	stopping
2024-10-08T22:36:03.881Z	INFO	rdk.networking	rpc/wrtc_server.go:97	waiting for handlers to complete
2024-10-08T22:36:03.883Z	INFO	rdk.networking	rpc/wrtc_server.go:100	handlers complete
2024-10-08T22:36:03.883Z	INFO	rdk.networking	rpc/wrtc_server.go:101	closing lingering peer connections
2024-10-08T22:36:03.884Z	INFO	rdk.networking	rpc/wrtc_server.go:119	lingering peer connections closed
2024-10-08T22:36:03.899Z	INFO	rdk.networking	rpc/server.go:860	stopped cleanly
2024-10-08T22:36:03.901Z	INFO	rdk.resource_manager	impl/resource_manager.go:498	Now removing resource	{"resource":"rdk-internal:service:packagemanager/deferred-manager"}
2024-10-08T22:36:03.902Z	INFO	rdk.resource_manager	impl/resource_manager.go:498	Now removing resource	{"resource":"rdk-internal:service:cloud_connection/builtin"}
2024-10-08T22:36:03.903Z	INFO	rdk.resource_manager	impl/resource_manager.go:498	Now removing resource	{"resource":"rdk:service:motion/builtin"}
2024-10-08T22:36:03.904Z	INFO	rdk.resource_manager	impl/resource_manager.go:498	Now removing resource	{"resource":"rdk:service:sensors/builtin"}
2024-10-08T22:36:03.904Z	INFO	rdk.resource_manager	impl/resource_manager.go:498	Now removing resource	{"resource":"rdk:component:board/board-1"}
2024-10-08T22:36:03.905Z	INFO	rdk.modmanager	modmanager/manager.go:596	Removing resource for module	{"resource":"rdk:component:board/board-1","module":"viam_raspberry-pi"}
2024-10-08T22:36:03.910Z	INFO	rdk.resource_manager	impl/resource_manager.go:498	Now removing resource	{"resource":"rdk:component:motor/motor-1"}
2024-10-08T22:36:03.912Z	INFO	rdk.resource_manager	impl/resource_manager.go:498	Now removing resource	{"resource":"rdk-internal:service:frame_system/builtin"}
2024-10-08T22:36:03.915Z	INFO	rdk.modmanager.process.viam_raspberry-pi_/root/.viam/packages/data/module/e76d1b3b-0468-4efd-bb7f-fb1d2b352fcb-raspberry-pi-1_0_6-linux-arm64/run.sh	pexec/managed_process_unix.go:91	stopping process 78615 with signal terminated
2024-10-08T23:36:03.919+0100	INFO	rdk.raspberry-pi	module/module.go:307	Shutting down gracefully.	{"log_ts": "2024-10-08T22:36:03.917Z"}
2024-10-08T22:36:03.935Z	INFO	rdk.modmanager	modmanager/manager.go:483	Module successfully closed	{"module":"viam_raspberry-pi"}
archytas@archytas:~ $ 

```