### PR TITLE
RSDK-1848: Don’t use video constraints for microphone

### DIFF
--- a/components/audioinput/microphone/microphone.go
+++ b/components/audioinput/microphone/microphone.go
@@ -62,7 +62,6 @@ func newMicrophoneSource(conf *Config, logger logging.Logger) (audioinput.AudioS
 
 	constraints := mediadevices.MediaTrackConstraints{}
 	audioConstraints := constraints.MediaConstraints.AudioConstraints
-
 	audioOption := func(trackConstraints *mediadevices.MediaTrackConstraints) {
 		trackConstraints.AudioConstraints = audioConstraints
 	}

--- a/components/audioinput/microphone/microphone.go
+++ b/components/audioinput/microphone/microphone.go
@@ -60,9 +60,22 @@ func newMicrophoneSource(conf *Config, logger logging.Logger) (audioinput.AudioS
 
 	debug := conf.Debug
 
-	if conf.Path != "" {
-		return tryMicrophoneOpen(conf.Path, gostream.DefaultConstraints, logger)
+	var constraints mediadevices.MediaTrackConstraints
+	audioConstraints := constraints.MediaConstraints.AudioConstraints
+
+	audioOption := func(trackConstraints *mediadevices.MediaTrackConstraints) {
+		trackConstraints.AudioConstraints = audioConstraints
 	}
+	audioStreamConstraints := mediadevices.MediaStreamConstraints{
+		Audio: audioOption,
+	}
+	if conf.Path != "" {
+		return tryMicrophoneOpen(conf.Path, audioStreamConstraints, logger)
+	}
+
+	// if conf.Path != "" {
+	// 	return tryMicrophoneOpen(conf.Path, gostream.DefaultConstraints, logger)
+	// }
 
 	var pattern *regexp.Regexp
 	if conf.PathPattern != "" {
@@ -91,7 +104,8 @@ func newMicrophoneSource(conf *Config, logger logging.Logger) (audioinput.AudioS
 					}
 					continue
 				}
-				s, err := tryMicrophoneOpen(label, gostream.DefaultConstraints, logger)
+				// s, err := tryMicrophoneOpen(label, gostream.DefaultConstraints, logger)
+				s, err := tryMicrophoneOpen(label, audioStreamConstraints, logger)
 				if err == nil {
 					if debug {
 						logger.Debug("\t USING")

--- a/components/audioinput/microphone/microphone.go
+++ b/components/audioinput/microphone/microphone.go
@@ -60,8 +60,14 @@ func newMicrophoneSource(conf *Config, logger logging.Logger) (audioinput.AudioS
 
 	debug := conf.Debug
 
-	var audioStreamConstraints = mediadevices.MediaStreamConstraints{
-		Audio: func(constraint *mediadevices.MediaTrackConstraints) {},
+	constraints := mediadevices.MediaTrackConstraints{}
+	audioConstraints := constraints.MediaConstraints.AudioConstraints
+
+	audioOption := func(trackConstraints *mediadevices.MediaTrackConstraints) {
+		trackConstraints.AudioConstraints = audioConstraints
+	}
+	audioStreamConstraints := mediadevices.MediaStreamConstraints{
+		Audio: audioOption,
 	}
 
 	if conf.Path != "" {

--- a/components/audioinput/microphone/microphone.go
+++ b/components/audioinput/microphone/microphone.go
@@ -60,15 +60,10 @@ func newMicrophoneSource(conf *Config, logger logging.Logger) (audioinput.AudioS
 
 	debug := conf.Debug
 
-	var constraints mediadevices.MediaTrackConstraints
-	audioConstraints := constraints.MediaConstraints.AudioConstraints
+	var audioStreamConstraints = mediadevices.MediaStreamConstraints{
+		Audio: func(constraint *mediadevices.MediaTrackConstraints) {},
+	}
 
-	audioOption := func(trackConstraints *mediadevices.MediaTrackConstraints) {
-		trackConstraints.AudioConstraints = audioConstraints
-	}
-	audioStreamConstraints := mediadevices.MediaStreamConstraints{
-		Audio: audioOption,
-	}
 	if conf.Path != "" {
 		return tryMicrophoneOpen(conf.Path, audioStreamConstraints, logger)
 	}

--- a/components/audioinput/microphone/microphone.go
+++ b/components/audioinput/microphone/microphone.go
@@ -73,10 +73,6 @@ func newMicrophoneSource(conf *Config, logger logging.Logger) (audioinput.AudioS
 		return tryMicrophoneOpen(conf.Path, audioStreamConstraints, logger)
 	}
 
-	// if conf.Path != "" {
-	// 	return tryMicrophoneOpen(conf.Path, gostream.DefaultConstraints, logger)
-	// }
-
 	var pattern *regexp.Regexp
 	if conf.PathPattern != "" {
 		pattern, err = regexp.Compile(conf.PathPattern)
@@ -104,7 +100,6 @@ func newMicrophoneSource(conf *Config, logger logging.Logger) (audioinput.AudioS
 					}
 					continue
 				}
-				// s, err := tryMicrophoneOpen(label, gostream.DefaultConstraints, logger)
 				s, err := tryMicrophoneOpen(label, audioStreamConstraints, logger)
 				if err == nil {
 					if debug {


### PR DESCRIPTION
Instead of using the default constraints (which were for video), microphone now uses audioConstraints. I was finally able to figure out how to test this by printing out the `malgo.DeviceInfo device.ID` and using that ID as the audio_path in app. 

-I tested the audio_input locally on darwin/arm64 (mac) by creating a microphone component and using the Macbook Air microphone as the audio stream. 

-I tested the audio_input locally on canon (for linux/arm64 and linux/amd64) by creating a microphone component and using the "Built-in Audio Analog Stereo Air" on the framework (aka framework microphone) microphone as the audio stream. 