### PR TITLE
Clearer error for dependency conflicts

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -834,11 +834,11 @@ func (mgr *Manager) newOnUnexpectedExitHandler(mod *module) func(exitCode int) b
 		if orphanedResourceNames := mgr.attemptRestart(mgr.restartCtx, mod); orphanedResourceNames != nil {
 			if mgr.removeOrphanedResources != nil {
 				mgr.removeOrphanedResources(mgr.restartCtx, orphanedResourceNames)
-				rNames := make([]string, 0, len(orphanedResourceNames))
-				for _, rName := range orphanedResourceNames {
-					rNames = append(rNames, rName.String())
-				}
-				mgr.logger.Debugw("Removed resources after failed module restart", "module", mod.cfg.Name, "resources", rNames)
+				mgr.logger.Debugw(
+					"Removed resources after failed module restart",
+					"module", mod.cfg.Name,
+					"resources", resource.NamesToStrings(orphanedResourceNames),
+				)
 			}
 			return false
 		}

--- a/resource/name.go
+++ b/resource/name.go
@@ -151,3 +151,12 @@ func (n Name) SDPTrackName() string {
 func SDPTrackNameToShortName(name string) string {
 	return strings.ReplaceAll(name, "+", ":")
 }
+
+// NamesToStrings is a utility that takes a list of resource names and returns a list of fully qualified names.
+func NamesToStrings(lst []Name) []string {
+	rNames := make([]string, 0, len(lst))
+	for _, rName := range lst {
+		rNames = append(rNames, rName.String())
+	}
+	return rNames
+}

--- a/resource/name_test.go
+++ b/resource/name_test.go
@@ -163,3 +163,31 @@ func TestSDPTrackNameToShortName(t *testing.T) {
 		test.That(t, SDPTrackNameToShortName(tc.input), test.ShouldResemble, tc.output)
 	}
 }
+
+func TestNamesToStrings(t *testing.T) {
+	type testCase struct {
+		input  []Name
+		output []string
+	}
+
+	camAPI := API{Type: APIType{Namespace: APINamespace("rdk"), Name: "component"}, SubtypeName: "camera"}
+	test.That(t, camAPI, test.ShouldResemble, APINamespaceRDK.WithComponentType("camera"))
+
+	tcs := []testCase{
+		{
+			input:  []Name{},
+			output: []string{},
+		},
+		{
+			input:  []Name{{API: camAPI, Remote: "", Name: "cam1"}},
+			output: []string{"rdk:component:camera/cam1"},
+		},
+		{
+			input:  []Name{{API: camAPI, Remote: "", Name: "cam1"}, {API: camAPI, Remote: "abc", Name: "cam1"}},
+			output: []string{"rdk:component:camera/cam1", "rdk:component:camera/abc:cam1"},
+		},
+	}
+	for _, tc := range tcs {
+		test.That(t, NamesToStrings(tc.input), test.ShouldResemble, tc.output)
+	}
+}

--- a/resource/resource_graph.go
+++ b/resource/resource_graph.go
@@ -595,11 +595,11 @@ func (g *Graph) ResolveDependencies(logger logging.Logger) error {
 				default:
 					allErrs = multierr.Combine(
 						allErrs,
-						errors.Errorf("conflicting names for resource %q: %v", nodeName, nodeNames))
+						errors.Errorf("conflicting names for resource %q: %v", nodeName, NamesToStrings(nodeNames)))
 					logger.Errorw(
 						"cannot resolve dependency for resource due to multiple matching names",
 						"name", nodeName,
-						"conflicts", nodeNames,
+						"conflicts", NamesToStrings(nodeNames),
 					)
 				}
 				return Name{}, false


### PR DESCRIPTION
goes from 

```
2024-10-09T21:11:08.342Z        ERROR   rdk.resource_manager    resource/resource_graph.go:599     cannot resolve dependency for resource due to multiple matching names      {"name":"rdk:component:power_sensor/power_sensor1","conflicts":[{"API":"rdk:component:movement_sensor","Remote":"","Name":"movement_sensor1"},{"API":"rdk:component:movement_sensor","Remote":"robot1","Name":"movement_sensor1"}]}
```

to
```
2024-10-09T21:39:10.399Z        ERROR   rdk.resource_manager    resource/resource_graph.go:599     cannot resolve dependency for resource due to multiple matching names      {"name":"rdk:component:power_sensor/power_sensor1","conflicts":["rdk:component:movement_sensor/robot1:movement_sensor1","rdk:component:movement_sensor/movement_sensor1"]}
```