### PR TITLE
APP-6588 private repo support in generated modules

### DIFF
--- a/cli/module_generate/templates/.github/workflows/deploy.yml
+++ b/cli/module_generate/templates/.github/workflows/deploy.yml
@@ -17,3 +17,4 @@ jobs:
           ref: ${{ github.sha }}
           key-id: ${{ secrets.viam_key_id }}
           key-value: ${{ secrets.viam_key_value }}
+          token: ${{ github.token }} # only required for private git repos


### PR DESCRIPTION
## What changed
- add `token` field to deploy.yml to match build-action README
## Why
So this uses the new private repo support.