### PR TITLE
[RSDK-8486] Fix 28byj-48 control issues

### DIFF
--- a/components/motor/motor.go
+++ b/components/motor/motor.go
@@ -218,3 +218,22 @@ func GetRequestedDirection(rpm, revolutions float64) float64 {
 	}
 	return dir
 }
+
+// GetSign returns the sign of the float as a helper for getting
+// the intended direction of travel of a motor.
+func GetSign(x float64) float64 {
+	if x == 0 {
+		return 0
+	}
+	if math.Signbit(x) {
+		return -1.0
+	}
+	return 1.0
+}
+
+// ClampPower clamps a percentage power to 1.0 or -1.0.
+func ClampPower(pwr float64) float64 {
+	pwr = math.Min(pwr, 1.0)
+	pwr = math.Max(pwr, -1.0)
+	return pwr
+}

--- a/components/motor/ulnstepper/28byj-48.go
+++ b/components/motor/ulnstepper/28byj-48.go
@@ -378,6 +378,7 @@ func (m *uln28byj) SetRPM(ctx context.Context, rpm float64, extra map[string]int
 // Set the current position (+/- offset) to be the new zero (home) position.
 func (m *uln28byj) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]interface{}) error {
 	newPosition := int64(-1 * offset * float64(m.ticksPerRotation))
+	// use Stop to set the target position to the current position again
 	if err := m.Stop(ctx, extra); err != nil {
 		return err
 	}
@@ -385,7 +386,6 @@ func (m *uln28byj) ResetZeroPosition(ctx context.Context, offset float64, extra 
 	defer m.lock.Unlock()
 	m.stepPosition = newPosition
 	m.targetStepPosition = newPosition
-	// use Stop to set the target position to the current position again
 	return nil
 }
 

--- a/components/motor/ulnstepper/28byj-48.go
+++ b/components/motor/ulnstepper/28byj-48.go
@@ -293,8 +293,13 @@ func (m *uln28byj) GoFor(ctx context.Context, rpm, revolutions float64, extra ma
 		m.logger.CWarn(ctx, warning)
 		if err != nil {
 			m.logger.CError(ctx, err)
+			// only stop if we receive a zero RPM error
+			return m.Stop(ctx, extra)
 		}
-		return m.Stop(ctx, extra)
+		// we do not get the zeroRPM error, but still want
+		// the motor to move at the maximum rpm
+		m.logger.CWarnf(ctx, "can only move at maxRPM of %v", maxRPM)
+		rpm = maxRPM * motor.GetSign(rpm)
 	}
 
 	targetStepPosition, stepperDelay := m.goMath(rpm, revolutions)
@@ -372,12 +377,15 @@ func (m *uln28byj) SetRPM(ctx context.Context, rpm float64, extra map[string]int
 
 // Set the current position (+/- offset) to be the new zero (home) position.
 func (m *uln28byj) ResetZeroPosition(ctx context.Context, offset float64, extra map[string]interface{}) error {
+	newPosition := int64(-1 * offset * float64(m.ticksPerRotation))
 	if err := m.Stop(ctx, extra); err != nil {
 		return err
 	}
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	m.stepPosition = int64(-1 * offset * float64(m.ticksPerRotation))
+	m.stepPosition = newPosition
+	m.targetStepPosition = newPosition
+	// use Stop to set the target position to the current position again
 	return nil
 }
 
@@ -391,13 +399,16 @@ func (m *uln28byj) SetPower(ctx context.Context, powerPct float64, extra map[str
 		m.logger.CWarn(ctx, warning)
 		if err != nil {
 			m.logger.CError(ctx, err)
+			// only stop if we receive a zero RPM error
+			return m.Stop(ctx, extra)
 		}
-		return m.Stop(ctx, extra)
 	}
 
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	m.targetStepPosition = int64(math.Inf(int(powerPct)))
+	direction := motor.GetSign(powerPct) // get the direction to set target to -ve/+ve Inf
+	m.targetStepPosition = int64(math.Inf(int(direction)))
+	powerPct = motor.ClampPower(powerPct) // ensure 1.0 max and -1.0 min
 	m.stepperDelay = m.calcStepperDelay(powerPct * maxRPM)
 
 	m.doRun()
@@ -432,6 +443,9 @@ func (m *uln28byj) Stop(ctx context.Context, extra map[string]interface{}) error
 	if m.doRunDone != nil {
 		m.doRunDone()
 	}
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.targetStepPosition = m.stepPosition
 	return nil
 }
 

--- a/components/motor/ulnstepper/28byj-48_test.go
+++ b/components/motor/ulnstepper/28byj-48_test.go
@@ -268,7 +268,7 @@ func TestFunctions(t *testing.T) {
 		err = m.GoFor(ctx, 146, 1, nil)
 		test.That(t, err, test.ShouldBeNil)
 		allObs = obs.All()
-		latestLoggedEntry = allObs[len(allObs)-1]
+		latestLoggedEntry = allObs[len(allObs)-2]
 		test.That(t, fmt.Sprint(latestLoggedEntry), test.ShouldContainSubstring, "nearly the max")
 	})
 


### PR DESCRIPTION
Addressed in this PR:
- allow SetPower Calls to move backwards.
- allow SetRPM calls with rpms above the max rpm to move with the maxrpm, and add a warning saying we're moving at the maxrpm
- isMoving returns a correct state of the motor false when stopped, true when moving
- ResetZero position does not falsely report that the motor is moving after resetting the position.

Manual testing:
- control page execution of SetPower +ve/-ve, observed motor going forwards when expected and backwards when expected. 0 power did not move the motor.
- control page execution of SetRPM +ve/-ve, observed motor going forward when expected. 0 rpm did not move the motor, magnitudes of rpm > maxrpm did move the motor with the added warning. 
- control page GoFor with combo of -ve/+ve rpm and -ve and +ve revolutions. Observed motor motion going forwards when expected and backwards when expected.
- control page execution of GoTo moved the motor to the desired position, with -ve or +ve rpm.
- SDK code run, GoFor, GoTo blocks, SetPower does not.
- SDK code ResetZeroPosition stops a SetPower call and resets the position as well as setting is moving to false and returns 0 power, false on  from IsPowered.
- No hangs in server shutdown from SetPower interrupting GoFor or IsPowered run from a client script while a SetPower call is running. 