### PR TITLE
DATA-3237: Command to transfer data across datasets

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -96,6 +96,7 @@ const (
 	dataFlagParallelDownloads              = "parallel"
 	dataFlagTags                           = "tags"
 	dataFlagBboxLabels                     = "bbox-labels"
+	dataFlagDatasetIDFilter                = "dataset-filter-id"
 	dataFlagDeleteTabularDataOlderThanDays = "delete-older-than-days"
 	dataFlagDatabasePassword               = "password"
 	dataFlagFilterTags                     = "filter-tags"
@@ -830,6 +831,10 @@ var app = &cli.App{
 											Name: dataFlagBboxLabels,
 											Usage: "bbox labels filter. " +
 												"accepts string labels corresponding to bounding boxes within images",
+										},
+										&cli.StringFlag{
+											Name:  dataFlagDatasetIDFilter,
+											Usage: "dataset ID filter. filter for all images in a dataset",
 										},
 									},
 									Action: DataAddToDatasetByFilter,

--- a/cli/data.go
+++ b/cli/data.go
@@ -203,6 +203,9 @@ func createDataFilter(c *cli.Context) (*datapb.Filter, error) {
 	if len(c.StringSlice(dataFlagMimeTypes)) != 0 {
 		filter.MimeType = c.StringSlice(dataFlagMimeTypes)
 	}
+	if c.String(dataFlagDatasetIDFilter) != "" {
+		filter.DatasetId = c.String(dataFlagDatasetIDFilter)
+	}
 	// We have some weirdness because the --tags flag can mean two completely different things.
 	// It could be either tags to filter by, or, if running 'viam data tag' it will mean the
 	// tags to add to the data. To account for this, we have to check if we're running the tag


### PR DESCRIPTION
Adds a new criteria to filter by and copy data from the CLI interface. This filter by dataset already existed, but we add a flag to make it usable in this context.
Tested manually:
Copies all items from dataset 6515b637a420eb685e988e84 to dataset 659d9f8e4aecd23bc99e693e.
`go run cli/viam/main.go dataset data add filter --dataset-id=659d9f8e4aecd23bc99e693e --dataset-filter-id=6515b637a420eb685e988e84`