### PR TITLE
Change logger name to ensure logs are picked up by the net appender

### DIFF
--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -126,7 +126,7 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 
 	// Read the config from disk and use it to initialize the remote logger.
 	initialReadCtx, cancel := context.WithTimeout(ctx, time.Second*5)
-	cfgFromDisk, err := config.ReadLocalConfig(initialReadCtx, argsParsed.ConfigFile, logger.Sublogger("config"))
+	cfgFromDisk, err := config.ReadLocalConfig(initialReadCtx, argsParsed.ConfigFile, logger.Sublogger("initial_config_read"))
 	if err != nil {
 		cancel()
 		return err


### PR DESCRIPTION
## Bug

- Logs were not propogating to App when they occurred in the config retreiver


## Fix

- Changing the logger name allows logs to be picked up by the net appender