### PR TITLE
DATA-3040: Allow specifying timeout for large file downloads

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -102,6 +102,7 @@ const (
 	dataFlagDeleteTabularDataOlderThanDays = "delete-older-than-days"
 	dataFlagDatabasePassword               = "password"
 	dataFlagFilterTags                     = "filter-tags"
+	dataFlagTimeout                        = "timeout"
 
 	packageFlagName        = "name"
 	packageFlagVersion     = "version"
@@ -423,6 +424,11 @@ var app = &cli.App{
 							Name:  dataFlagDataType,
 							Usage: "type of data to download. can be binary or tabular",
 						},
+						&cli.UintFlag{
+							Name:  dataFlagTimeout,
+							Usage: "number of seconds to wait for large file downloads",
+							Value: 30,
+						},
 					},
 						commonFilterFlags...),
 					Action: DataExportAction,
@@ -716,6 +722,11 @@ var app = &cli.App{
 							Required: false,
 							Usage:    "number of download requests to make in parallel",
 							Value:    100,
+						},
+						&cli.UintFlag{
+							Name:  dataFlagTimeout,
+							Usage: "number of seconds to wait for large file downloads",
+							Value: 30,
 						},
 					},
 					Action: DatasetDownloadAction,

--- a/cli/dataset.go
+++ b/cli/dataset.go
@@ -165,14 +165,15 @@ func DatasetDownloadAction(c *cli.Context) error {
 		return err
 	}
 	if err := client.downloadDataset(c.Path(dataFlagDestination), c.String(datasetFlagDatasetID),
-		c.Bool(datasetFlagIncludeJSONLines), c.Uint(dataFlagParallelDownloads)); err != nil {
+		c.Bool(datasetFlagIncludeJSONLines), c.Uint(dataFlagParallelDownloads),
+		c.Uint(dataFlagTimeout)); err != nil {
 		return err
 	}
 	return nil
 }
 
 // downloadDataset downloads a dataset with the specified ID.
-func (c *viamClient) downloadDataset(dst, datasetID string, includeJSONLines bool, parallelDownloads uint) error {
+func (c *viamClient) downloadDataset(dst, datasetID string, includeJSONLines bool, parallelDownloads, timeout uint) error {
 	if err := c.ensureLoggedIn(); err != nil {
 		return err
 	}
@@ -206,7 +207,7 @@ func (c *viamClient) downloadDataset(dst, datasetID string, includeJSONLines boo
 
 	return c.performActionOnBinaryDataFromFilter(
 		func(id *datapb.BinaryID) error {
-			downloadErr := c.downloadBinary(dst, id)
+			downloadErr := c.downloadBinary(dst, id, timeout)
 			var datasetErr error
 			if includeJSONLines {
 				datasetErr = binaryDataToJSONLines(c.c.Context, c.dataClient, dst, datasetFile, id)


### PR DESCRIPTION
The previous implementation used authFlow.httpClient, which sets a 30
seconds timeout - not enough for large binary file downloads.

Also, simplify export CLI code slightly by passing the response body
reader as-is instead of an unnecessary ReadAll step.
