### PR TITLE
Bump timeout for CLI base URL validity check

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -768,7 +768,7 @@ func parseBaseURL(baseURL string, verifyConnection bool) (*url.URL, []rpc.DialOp
 
 	if verifyConnection {
 		// Check if URL is even valid with a TCP dial.
-		conn, err := net.DialTimeout("tcp", baseURLParsed.Host, 3*time.Second)
+		conn, err := net.DialTimeout("tcp", baseURLParsed.Host, 10*time.Second)
 		if err != nil {
 			return nil, nil, fmt.Errorf("base URL %q (needed for auth) is currently unreachable. "+
 				"Ensure URL is valid and you are connected to internet", baseURLParsed.Host)

--- a/cli/client.go
+++ b/cli/client.go
@@ -770,8 +770,8 @@ func parseBaseURL(baseURL string, verifyConnection bool) (*url.URL, []rpc.DialOp
 		// Check if URL is even valid with a TCP dial.
 		conn, err := net.DialTimeout("tcp", baseURLParsed.Host, 10*time.Second)
 		if err != nil {
-			return nil, nil, fmt.Errorf("base URL %q (needed for auth) is currently unreachable. "+
-				"Ensure URL is valid and you are connected to internet", baseURLParsed.Host)
+			return nil, nil, fmt.Errorf("base URL %q (needed for auth) is currently unreachable (%v). "+
+				"Ensure URL is valid and you are connected to internet", err.Error(), baseURLParsed.Host)
 		}
 		utils.UncheckedError(conn.Close())
 	}


### PR DESCRIPTION
See offline discussion: I'm guessing CLI users are timing out with 3 seconds.