### PR TITLE
fix(services/baseremotecontrol): validate control_mode config attribute

### DIFF
--- a/services/baseremotecontrol/builtin/builtin.go
+++ b/services/baseremotecontrol/builtin/builtin.go
@@ -63,6 +63,22 @@ func (conf *Config) Validate(path string) ([]string, error) {
 	}
 	deps = append(deps, conf.BaseName)
 
+	if conf.ControlModeName != "" {
+		modes := []string{"joystickControl", "triggerSpeedControl", "buttonControl", "arrowControl", "droneControl"}
+
+		configModeExists := false
+		for _, mode := range modes {
+			if mode == conf.ControlModeName {
+				configModeExists = true
+				break
+			}
+		}
+
+		if !configModeExists {
+			return nil, resource.NewConfigValidationError(path, errors.Errorf("Control mode '%s' is not in %v", conf.ControlModeName, modes))
+		}
+	}
+
 	return deps, nil
 }
 

--- a/services/baseremotecontrol/builtin/builtin.go
+++ b/services/baseremotecontrol/builtin/builtin.go
@@ -32,6 +32,8 @@ const (
 	droneControl
 )
 
+var modes = []string{"joystickControl", "triggerSpeedControl", "buttonControl", "arrowControl", "droneControl"}
+
 func init() {
 	resource.RegisterService(baseremotecontrol.API, resource.DefaultServiceModel, resource.Registration[baseremotecontrol.Service, *Config]{
 		Constructor: NewBuiltIn,
@@ -64,8 +66,6 @@ func (conf *Config) Validate(path string) ([]string, error) {
 	deps = append(deps, conf.BaseName)
 
 	if conf.ControlModeName != "" {
-		modes := []string{"joystickControl", "triggerSpeedControl", "buttonControl", "arrowControl", "droneControl"}
-
 		configModeExists := false
 		for _, mode := range modes {
 			if mode == conf.ControlModeName {

--- a/services/baseremotecontrol/builtin/builtin_test.go
+++ b/services/baseremotecontrol/builtin/builtin_test.go
@@ -32,6 +32,13 @@ func TestBaseRemoteControl(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	testutils.VerifySameElements(t, depNames, []string{"baseTest", "inputTest"})
 
+	cfg.ControlModeName = "fail"
+	_, err = cfg.Validate("")
+	test.That(t, err, test.ShouldBeError,
+		errors.New(
+			//nolint: lll
+			`Error validating. Path: "" Error: Control mode 'fail' is not in [joystickControl triggerSpeedControl buttonControl arrowControl droneControl]`))
+
 	fakeController := &inject.InputController{}
 	fakeBase := &fakebase.Base{}
 

--- a/services/baseremotecontrol/builtin/builtin_test.go
+++ b/services/baseremotecontrol/builtin/builtin_test.go
@@ -35,9 +35,10 @@ func TestBaseRemoteControl(t *testing.T) {
 	cfg.ControlModeName = "fail"
 	_, err = cfg.Validate("")
 	test.That(t, err, test.ShouldBeError,
-		errors.New(
-			//nolint: lll
-			`Error validating. Path: "" Error: Control mode 'fail' is not in [joystickControl triggerSpeedControl buttonControl arrowControl droneControl]`))
+		errors.Errorf(
+			`Error validating. Path: "" Error: Control mode '%s' is not in %v`,
+			cfg.ControlModeName,
+			modes))
 
 	fakeController := &inject.InputController{}
 	fakeBase := &fakebase.Base{}

--- a/services/baseremotecontrol/builtin/builtin_test.go
+++ b/services/baseremotecontrol/builtin/builtin_test.go
@@ -35,10 +35,7 @@ func TestBaseRemoteControl(t *testing.T) {
 	cfg.ControlModeName = "fail"
 	_, err = cfg.Validate("")
 	test.That(t, err, test.ShouldBeError,
-		errors.Errorf(
-			`Error validating. Path: "" Error: Control mode '%s' is not in %v`,
-			cfg.ControlModeName,
-			modes))
+		resource.NewConfigValidationError("", errors.Errorf("Control mode '%s' is not in %v", cfg.ControlModeName, modes)))
 
 	fakeController := &inject.InputController{}
 	fakeBase := &fakebase.Base{}


### PR DESCRIPTION
While working with a Discord community member to configure the base remote control service to use joystick controls instead of the default D-pad (arrows) controls, I noticed a spelling discrepancy between the RDK code and the documentation. The latter specifies "joyStickControl" as the expected value for that control mode, however the RDK checks for "joystickControl" (even though the const variable is `joyStickControl`). This small spelling difference is confusing to debug, especially when there is no validation for that configuration attribute. 

I've submitted a PR to the docs (https://github.com/viamrobotics/docs/pull/3596) to update the spelling to match the RDK as the more immediate fix. This PR adds helpful validation of the control_mode attribute to ensure it matches one of the expected modes. 