### PR TITLE
[RSDK-9072] - Simplify stream inits

### DIFF
--- a/robot/web/stream/server.go
+++ b/robot/web/stream/server.go
@@ -52,7 +52,7 @@ type Server struct {
 func NewServer(
 	robot robot.Robot,
 	logger logging.Logger,
-) (*Server, error) {
+) *Server {
 	closedCtx, closedFn := context.WithCancel(context.Background())
 	server := &Server{
 		closedCtx:         closedCtx,
@@ -63,10 +63,8 @@ func NewServer(
 		activePeerStreams: map[*webrtc.PeerConnection]map[string]*peerState{},
 		isAlive:           true,
 	}
-
 	server.startMonitorCameraAvailable()
-
-	return server, nil
+	return server
 }
 
 // StreamAlreadyRegisteredError indicates that a stream has a name that is already registered on

--- a/robot/web/stream/server.go
+++ b/robot/web/stream/server.go
@@ -50,7 +50,6 @@ type Server struct {
 // NewServer returns a server that will run on the given port and initially starts with the given
 // stream.
 func NewServer(
-	streams []gostream.Stream,
 	robot robot.Robot,
 	logger logging.Logger,
 ) (*Server, error) {
@@ -65,11 +64,6 @@ func NewServer(
 		isAlive:           true,
 	}
 
-	for _, stream := range streams {
-		if err := server.add(stream); err != nil {
-			return nil, err
-		}
-	}
 	server.startMonitorCameraAvailable()
 
 	return server, nil

--- a/robot/web/web_c.go
+++ b/robot/web/web_c.go
@@ -264,14 +264,9 @@ func (svc *webService) closeStreamServer() {
 }
 
 func (svc *webService) initStreamServer(ctx context.Context, options *weboptions.Options) error {
-	var err error
-	server, err := webstream.NewServer(svc.r, svc.logger)
-	if err != nil {
-		return err
-	}
+	server := webstream.NewServer(svc.r, svc.logger)
 	svc.streamServer = &StreamServer{server, false}
-	err = svc.addNewStreams(ctx)
-	if err != nil {
+	if err := svc.addNewStreams(ctx); err != nil {
 		return err
 	}
 	if err := svc.rpcServer.RegisterServiceServer(

--- a/robot/web/web_c.go
+++ b/robot/web/web_c.go
@@ -91,7 +91,7 @@ func (svc *webService) addNewStreams(ctx context.Context) error {
 			Name: name,
 		}
 		config.VideoEncoderFactory = svc.opts.streamConfig.VideoEncoderFactory
-		// TODO(RSDK): Add handler for target framerate
+		// TODO(RSDK-9079) Add reliable framerate fetcher for stream videosources
 		stream, err := svc.createStream(config, name)
 		if err != nil {
 			return err

--- a/robot/web/web_c.go
+++ b/robot/web/web_c.go
@@ -94,8 +94,15 @@ func (svc *webService) addNewStreams(ctx context.Context) error {
 		}
 		config.VideoEncoderFactory = svc.opts.streamConfig.VideoEncoderFactory
 		stream, err := svc.streamServer.Server.NewStream(config)
-		if err != nil {
+		// Skip if stream is already registered, otherwise raise any other errors
+		var registeredError *webstream.StreamAlreadyRegisteredError
+		if errors.As(err, &registeredError) {
+			continue
+		} else if err != nil {
 			return err
+		}
+		if !svc.streamServer.HasStreams {
+			svc.streamServer.HasStreams = true
 		}
 		svc.startVideoStream(ctx, svc.videoSources[name], stream)
 	}
@@ -107,10 +114,13 @@ func (svc *webService) addNewStreams(ctx context.Context) error {
 		}
 		config.AudioEncoderFactory = svc.opts.streamConfig.AudioEncoderFactory
 		stream, err := svc.streamServer.Server.NewStream(config)
-		if err != nil {
+		// Skip if stream is already registered, otherwise raise any other errors
+		var registeredError *webstream.StreamAlreadyRegisteredError
+		if errors.As(err, &registeredError) {
+			continue
+		} else if err != nil {
 			return err
 		}
-		// start audio stream
 		svc.startAudioStream(ctx, svc.audioSources[name], stream)
 	}
 

--- a/robot/web/web_c.go
+++ b/robot/web/web_c.go
@@ -248,7 +248,6 @@ func (svc *webService) refreshAudioSources() {
 
 // Update updates the web service when the robot has changed.
 func (svc *webService) Reconfigure(ctx context.Context, deps resource.Dependencies, _ resource.Config) error {
-	svc.logger.Info("Hit Reconfigure")
 	svc.mu.Lock()
 	defer svc.mu.Unlock()
 	if err := svc.updateResources(deps); err != nil {
@@ -269,7 +268,6 @@ func (svc *webService) closeStreamServer() {
 }
 
 func (svc *webService) initStreamServer(ctx context.Context, options *weboptions.Options) error {
-	svc.logger.Info("Hit initStreamServer")
 	var err error
 	svc.streamServer, err = svc.makeStreamServer()
 	if err != nil {

--- a/robot/web/web_c.go
+++ b/robot/web/web_c.go
@@ -86,6 +86,12 @@ func (svc *webService) addNewStreams(ctx context.Context) error {
 	}
 	svc.refreshVideoSources()
 	svc.refreshAudioSources()
+	if svc.opts.streamConfig == nil {
+		if len(svc.videoSources) != 0 || len(svc.audioSources) != 0 {
+			svc.logger.Debug("not starting streams due to no stream config being set")
+		}
+		return nil
+	}
 	for name := range svc.videoSources {
 		config := gostream.StreamConfig{
 			Name: name,

--- a/robot/web/web_c.go
+++ b/robot/web/web_c.go
@@ -108,7 +108,7 @@ func (svc *webService) addNewStreams(ctx context.Context) error {
 		}
 
 		// Call `createStream`. `createStream` is responsible for first checking if the stream
-		// already exists.
+		// already exists. If it does, it skips creating a new stream and we continue to the next source.
 		//
 		// TODO(RSDK-9079) Add reliable framerate fetcher for stream videosources
 		stream, alreadyRegistered, err := svc.createStream(config, name)
@@ -118,8 +118,6 @@ func (svc *webService) addNewStreams(ctx context.Context) error {
 			continue
 		}
 
-		// If the stream already exists, `createStream` will return a `nil` stream and `nil`
-		// error. `startVideoStream` copes with this input.
 		svc.startVideoStream(ctx, svc.videoSources[name], stream)
 	}
 	for name := range svc.audioSources {

--- a/robot/web/web_c.go
+++ b/robot/web/web_c.go
@@ -82,7 +82,7 @@ func (svc *webService) streamInitialized() bool {
 
 func (svc *webService) addNewStreams(ctx context.Context) error {
 	if !svc.streamInitialized() {
-		errors.New("stream server not initialized")
+		return errors.New("stream server not initialized")
 	}
 	svc.refreshVideoSources()
 	svc.refreshAudioSources()
@@ -91,6 +91,7 @@ func (svc *webService) addNewStreams(ctx context.Context) error {
 			Name: name,
 		}
 		config.VideoEncoderFactory = svc.opts.streamConfig.VideoEncoderFactory
+		// TODO(RSDK): Add handler for target framerate
 		stream, err := svc.createStream(config, name)
 		if err != nil {
 			return err

--- a/robot/web/web_c.go
+++ b/robot/web/web_c.go
@@ -5,7 +5,6 @@ package web
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"net/http"
 	"slices"
 	"sync"
@@ -83,7 +82,7 @@ func (svc *webService) streamInitialized() bool {
 
 func (svc *webService) addNewStreams(ctx context.Context) error {
 	if !svc.streamInitialized() {
-		return fmt.Errorf("stream server not initialized")
+		errors.New("stream server not initialized")
 	}
 	svc.refreshVideoSources()
 	svc.refreshAudioSources()

--- a/robot/web/web_c.go
+++ b/robot/web/web_c.go
@@ -83,7 +83,8 @@ func (svc *webService) streamInitialized() bool {
 
 func (svc *webService) addNewStreams(ctx context.Context) error {
 	if !svc.streamInitialized() {
-		return errors.New("stream server not initialized")
+		svc.logger.Warn("not starting streams because the stream server is not initialized")
+		return nil
 	}
 
 	// Refreshing sources will walk the robot resources for anything implementing the camera and

--- a/robot/web/web_c.go
+++ b/robot/web/web_c.go
@@ -161,14 +161,6 @@ func (svc *webService) createStream(config gostream.StreamConfig, name string) (
 	return stream, false, err
 }
 
-func (svc *webService) makeStreamServer() (*StreamServer, error) {
-	server, err := webstream.NewServer(svc.r, svc.logger)
-	if err != nil {
-		return nil, err
-	}
-	return &StreamServer{server, false}, nil
-}
-
 func (svc *webService) startStream(streamFunc func(opts *webstream.BackoffTuningOptions) error) {
 	waitCh := make(chan struct{})
 	svc.webWorkers.Add(1)
@@ -273,10 +265,11 @@ func (svc *webService) closeStreamServer() {
 
 func (svc *webService) initStreamServer(ctx context.Context, options *weboptions.Options) error {
 	var err error
-	svc.streamServer, err = svc.makeStreamServer()
+	server, err := webstream.NewServer(svc.r, svc.logger)
 	if err != nil {
 		return err
 	}
+	svc.streamServer = &StreamServer{server, false}
 	err = svc.addNewStreams(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description
Getting started on dynamic resolution epic. This is just a first-step PR to make sure I have a good handle on the relevant code & tests.

- Simplifies stream server initialization.
  - No longer special case for noop stream server.
  - Removes passing in streams to stream server constructor `webstream.NewServer`.
- Unifies logic for adding new streams between reconfigures and initialization.
  - No longer have separate stream flows for `initStreamServer` vs `Reconfigure`.
  - Simplified `addNewStreams` helper.
  - Added `createStream` helper for commonalities between audio & video stream initialization.

## Testing
- webcam live stream ✅ 
  - linux ✅ 
  - darwin ✅ 
  - reconfigure ✅ 
- fake cam live stream ✅ 
  - GetImage ✅ 
  - passthrough ✅ 
    - reconfigure ✅ 
- audio stream ✅
  - reconfigure ✅ 
 - viamrtsp ✅ 
   - passthrough ✅ 
   - GetImage ✅ 
   - reconfigure ✅ 
  