### PR TITLE
RSDK-8881, RSDK-9074 - add first_run to CLI update module action, proto conversions for first_run_timeout

### DIFF
--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -421,6 +421,9 @@ func (c *viamClient) updateModule(moduleID moduleID, manifest moduleManifest) (*
 		Models:      models,
 		Entrypoint:  manifest.Entrypoint,
 	}
+	if manifest.FirstRun != "" {
+		req.FirstRun = &manifest.FirstRun
+	}
 	return c.client.UpdateModule(c.c.Context, &req)
 }
 

--- a/config/module.go
+++ b/config/module.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -38,6 +39,9 @@ type Module struct {
 	// Environment contains additional variables that are passed to the module process when it is started.
 	// They overwrite existing environment variables.
 	Environment map[string]string `json:"env,omitempty"`
+
+	// FirstRunTimeout is the timeout duration for the first run script.
+	FirstRunTimeout time.Duration `json:"first_run_timeout,omitempty"`
 
 	// Status refers to the validations done in the APP to make sure a module is configured correctly
 	Status           *AppValidationStatus `json:"status"`

--- a/config/proto_conversions.go
+++ b/config/proto_conversions.go
@@ -302,13 +302,14 @@ func ModuleConfigToProto(module *Module) (*pb.ModuleConfig, error) {
 	}
 
 	proto := pb.ModuleConfig{
-		Name:     module.Name,
-		Path:     module.ExePath,
-		LogLevel: module.LogLevel,
-		Type:     string(module.Type),
-		ModuleId: module.ModuleID,
-		Env:      module.Environment,
-		Status:   status,
+		Name:            module.Name,
+		Path:            module.ExePath,
+		LogLevel:        module.LogLevel,
+		Type:            string(module.Type),
+		ModuleId:        module.ModuleID,
+		Env:             module.Environment,
+		Status:          status,
+		FirstRunTimeout: durationpb.New(module.FirstRunTimeout),
 	}
 
 	return &proto, nil
@@ -322,13 +323,14 @@ func ModuleConfigFromProto(proto *pb.ModuleConfig) (*Module, error) {
 	}
 
 	module := Module{
-		Name:        proto.GetName(),
-		ExePath:     proto.GetPath(),
-		LogLevel:    proto.GetLogLevel(),
-		Type:        ModuleType(proto.GetType()),
-		ModuleID:    proto.GetModuleId(),
-		Environment: proto.GetEnv(),
-		Status:      status,
+		Name:            proto.GetName(),
+		ExePath:         proto.GetPath(),
+		LogLevel:        proto.GetLogLevel(),
+		Type:            ModuleType(proto.GetType()),
+		ModuleID:        proto.GetModuleId(),
+		Environment:     proto.GetEnv(),
+		Status:          status,
+		FirstRunTimeout: proto.GetFirstRunTimeout().AsDuration(),
 	}
 	return &module, nil
 }

--- a/config/proto_conversions_test.go
+++ b/config/proto_conversions_test.go
@@ -199,6 +199,7 @@ var testModuleWithError = Module{
 		Error: "i have a bad error ah!",
 	},
 }
+
 var testModuleWithTimeout = Module{
 	Name:            "testmod",
 	ExePath:         "/tmp/test.mod",

--- a/config/proto_conversions_test.go
+++ b/config/proto_conversions_test.go
@@ -199,6 +199,15 @@ var testModuleWithError = Module{
 		Error: "i have a bad error ah!",
 	},
 }
+var testModuleWithTimeout = Module{
+	Name:            "testmod",
+	ExePath:         "/tmp/test.mod",
+	LogLevel:        "debug",
+	Type:            ModuleTypeLocal,
+	ModuleID:        "a:b",
+	Environment:     map[string]string{"SOME_VAR": "value"},
+	FirstRunTimeout: time.Minute,
+}
 
 var testPackageConfig = PackageConfig{
 	Name:    "package-name",
@@ -239,6 +248,7 @@ func validateModule(t *testing.T, actual, expected Module) {
 	test.That(t, actual.Name, test.ShouldEqual, expected.Name)
 	test.That(t, actual.ExePath, test.ShouldEqual, expected.ExePath)
 	test.That(t, actual.LogLevel, test.ShouldEqual, expected.LogLevel)
+	test.That(t, actual.FirstRunTimeout, test.ShouldEqual, expected.FirstRunTimeout)
 	test.That(t, actual, test.ShouldResemble, expected)
 }
 
@@ -296,11 +306,21 @@ func TestModuleConfigToProto(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, protoWithErr.Status, test.ShouldNotBeNil)
 
-	out, err = ModuleConfigFromProto(proto)
+	out, err = ModuleConfigFromProto(protoWithErr)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, out, test.ShouldNotBeNil)
 
-	validateModule(t, *out, testModule)
+	validateModule(t, *out, testModuleWithError)
+
+	protoWithTimeout, err := ModuleConfigToProto(&testModuleWithTimeout)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, protoWithTimeout.Status, test.ShouldBeNil)
+
+	out, err = ModuleConfigFromProto(protoWithTimeout)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, out, test.ShouldNotBeNil)
+
+	validateModule(t, *out, testModuleWithTimeout)
 }
 
 //nolint:thelper


### PR DESCRIPTION
this does not handle reading the JSON config from disk, might have to shadow the data structure like some other configData structs.

With this PR, app will be able to pass through the first_run_timeout correctly

