### PR TITLE
RSDK-9091,RSDK-9088 Emit logs as they come from setup phase command

### DIFF
--- a/logging/logger.go
+++ b/logging/logger.go
@@ -111,9 +111,8 @@ func (logger *zLogger) AddAppender(appender Appender) {
 	// Not supported
 }
 
-func (logger zLogger) WithFields(args ...interface{}) Logger {
-	// Not supported. Use With() instead.
-	return nil
+func (logger *zLogger) WithFields(args ...interface{}) Logger {
+	return &zLogger{logger.AsZap().With(args...)}
 }
 
 // AsZap converts the logger to a zap logger.

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -1159,7 +1159,7 @@ func (mgr *Manager) FirstRun(ctx context.Context, conf config.Module) error {
 		return err
 	}
 	if err := cmd.Wait(); err != nil {
-		logger.Errorw("command failed", "error", err)
+		logger.Errorw("command failed", "error", err, "combined output", combined)
 		return err
 	}
 	logger.Infow("command succeeded", "combined output", combined)

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -1083,7 +1083,7 @@ func (m *module) checkReady(ctx context.Context, parentAddr string, logger loggi
 
 // FirstRun is runs a module-specific setup script.
 func (mgr *Manager) FirstRun(ctx context.Context, conf config.Module) error {
-	logger := mgr.logger.AsZap().With("name", conf.Name)
+	logger := mgr.logger.Sublogger("first_run").AsZap().With("name", conf.Name)
 
 	// Evaluate the Module's FirstRun path. If there is an error we assume
 	// that the first run script does not exist and we debug log and exit quietly.

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -1095,7 +1095,7 @@ func (mgr *Manager) FirstRun(ctx context.Context, conf config.Module) error {
 	}
 
 	logger = logger.WithFields("module", conf.Name, "path", firstRunPath)
-	logger.Infow("executing script")
+	logger.Infow("executing first run script")
 
 	// This value is normally set on a field on the [module] struct but it seems like we can safely get it on demand.
 	var dataDir string

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -1095,7 +1095,7 @@ func (mgr *Manager) FirstRun(ctx context.Context, conf config.Module) error {
 	}
 
 	logger = logger.WithFields("module", conf.Name, "path", firstRunPath)
-	logger.Infow("executing first run script")
+	logger.Infow("executing script")
 
 	// This value is normally set on a field on the [module] struct but it seems like we can safely get it on demand.
 	var dataDir string
@@ -1134,30 +1134,30 @@ func (mgr *Manager) FirstRun(ctx context.Context, conf config.Module) error {
 	scanOut := bufio.NewScanner(stdOut)
 	go func() {
 		for scanOut.Scan() {
-			logger.Infow("first run stdio", "output", scanOut.Text())
+			logger.Infow("got stdio", "output", scanOut.Text())
 		}
 		if err := scanOut.Err(); err != nil {
-			logger.Errorw("error scanning first run stdio", "error", err)
+			logger.Errorw("error scanning stdio", "error", err)
 		}
 	}()
 	scanErr := bufio.NewScanner(stdErr)
 	go func() {
 		for scanErr.Scan() {
-			logger.Warnw("first run stderr", "output", scanErr.Text())
+			logger.Warnw("got stderr", "output", scanErr.Text())
 		}
 		if err := scanErr.Err(); err != nil {
-			logger.Errorw("error scanning first run stderr", "error", err)
+			logger.Errorw("error scanning stderr", "error", err)
 		}
 	}()
 	if err := cmd.Start(); err != nil {
-		logger.Errorw("first run failed to start", "error", err)
+		logger.Errorw("failed to start", "error", err)
 		return err
 	}
 	if err := cmd.Wait(); err != nil {
-		logger.Errorw("first run failed", "error", err)
+		logger.Errorw("failed", "error", err)
 		return err
 	}
-	logger.Infow("first run succeeded")
+	logger.Infow("succeeded")
 
 	// Mark success by writing a marker file to disk. This is a best
 	// effort; if writing to disk fails the setup phase will run again

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -1131,17 +1131,11 @@ func (mgr *Manager) FirstRun(ctx context.Context, conf config.Module) error {
 		return err
 	}
 
-	var combined []string
-	var mu sync.Mutex
-
 	scanOut := bufio.NewScanner(stdOut)
 	go func() {
 		for scanOut.Scan() {
 			out := scanOut.Text()
 			logger.Infow("first run stdio", "output", out)
-			mu.Lock()
-			combined = append(combined, out)
-			mu.Unlock()
 		}
 	}()
 	scanErr := bufio.NewScanner(stdErr)
@@ -1149,9 +1143,6 @@ func (mgr *Manager) FirstRun(ctx context.Context, conf config.Module) error {
 		for scanErr.Scan() {
 			out := scanErr.Text()
 			logger.Warnw("first run stderr", "output", out)
-			mu.Lock()
-			combined = append(combined, out)
-			mu.Unlock()
 		}
 	}()
 	if err := cmd.Start(); err != nil {
@@ -1159,10 +1150,10 @@ func (mgr *Manager) FirstRun(ctx context.Context, conf config.Module) error {
 		return err
 	}
 	if err := cmd.Wait(); err != nil {
-		logger.Errorw("first run failed", "error", err, "combined output", combined)
+		logger.Errorw("first run failed", "error", err)
 		return err
 	}
-	logger.Infow("first run succeeded", "combined output", combined)
+	logger.Infow("first run succeeded")
 
 	if err := scanOut.Err(); err != nil {
 		logger.Warnw("error scanning first run stdio", "error", err)

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -1156,14 +1156,14 @@ func (mgr *Manager) FirstRun(ctx context.Context, conf config.Module) error {
 		}
 	}()
 	if err := cmd.Start(); err != nil {
-		logger.Errorw("failed to start", "error", err)
+		logger.Errorw("failed to start first run script", "error", err)
 		return err
 	}
 	if err := cmd.Wait(); err != nil {
-		logger.Errorw("failed", "error", err)
+		logger.Errorw("first run script failed", "error", err)
 		return err
 	}
-	logger.Infow("succeeded")
+	logger.Info("first run script succeeded")
 
 	// Mark success by writing a marker file to disk. This is a best
 	// effort; if writing to disk fails the setup phase will run again

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -1083,7 +1083,7 @@ func (m *module) checkReady(ctx context.Context, parentAddr string, logger loggi
 
 // FirstRun is runs a module-specific setup script.
 func (mgr *Manager) FirstRun(ctx context.Context, conf config.Module) error {
-	logger := mgr.logger.Sublogger("first_run").AsZap().With("name", conf.Name)
+	logger := mgr.logger.Sublogger("first_run").WithFields("module", conf.Name)
 
 	// Evaluate the Module's FirstRun path. If there is an error we assume
 	// that the first run script does not exist and we debug log and exit quietly.
@@ -1094,7 +1094,7 @@ func (mgr *Manager) FirstRun(ctx context.Context, conf config.Module) error {
 		return nil
 	}
 
-	logger = logger.With("path", firstRunPath)
+	logger = logger.WithFields("module", conf.Name, "path", firstRunPath)
 	logger.Infow("executing first run script")
 
 	// This value is normally set on a field on the [module] struct but it seems like we can safely get it on demand.

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -1134,15 +1134,19 @@ func (mgr *Manager) FirstRun(ctx context.Context, conf config.Module) error {
 	scanOut := bufio.NewScanner(stdOut)
 	go func() {
 		for scanOut.Scan() {
-			out := scanOut.Text()
-			logger.Infow("first run stdio", "output", out)
+			logger.Infow("first run stdio", "output", scanOut.Text())
+		}
+		if err := scanOut.Err(); err != nil {
+			logger.Errorw("error scanning first run stdio", "error", err)
 		}
 	}()
 	scanErr := bufio.NewScanner(stdErr)
 	go func() {
 		for scanErr.Scan() {
-			out := scanErr.Text()
-			logger.Warnw("first run stderr", "output", out)
+			logger.Warnw("first run stderr", "output", scanErr.Text())
+		}
+		if err := scanErr.Err(); err != nil {
+			logger.Errorw("error scanning first run stderr", "error", err)
 		}
 	}()
 	if err := cmd.Start(); err != nil {
@@ -1154,13 +1158,6 @@ func (mgr *Manager) FirstRun(ctx context.Context, conf config.Module) error {
 		return err
 	}
 	logger.Infow("first run succeeded")
-
-	if err := scanOut.Err(); err != nil {
-		logger.Warnw("error scanning first run stdio", "error", err)
-	}
-	if err := scanErr.Err(); err != nil {
-		logger.Warnw("error scanning first run stderr", "error", err)
-	}
 
 	// Mark success by writing a marker file to disk. This is a best
 	// effort; if writing to disk fails the setup phase will run again


### PR DESCRIPTION
### Changes

Emit logs of stdio/stderr messages from setup phase command as they come instead of only at the end. ~Combined output is re-logged after the command completes.~ EDIT: [not anymore](https://github.com/viamrobotics/rdk/pull/4475#discussion_r1809701738)

Also fix bug where script logs were not being posted to app.viam

### Demo

Example run with a setup phase that contains a mongo pull command:

```
2024-10-23T17:17:15.667Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1098      executing first run script        {"module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:16.165Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"6: Pulling from library/mongo","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:16.276Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"6414378b6477: Pulling fs layer","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:16.276Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"d759adb89a6b: Pulling fs layer","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:16.276Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"ba36503b8fbe: Pulling fs layer","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:16.276Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"ce3aea978520: Pulling fs layer","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:16.276Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"4afd0f756edf: Pulling fs layer","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:16.276Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"3f39e6c4bb86: Pulling fs layer","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:16.276Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"575208bc5436: Pulling fs layer","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:16.276Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"1588a03ab798: Pulling fs layer","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:16.276Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"ce3aea978520: Waiting","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:16.276Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"1588a03ab798: Waiting","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:16.276Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"575208bc5436: Waiting","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:16.276Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"4afd0f756edf: Waiting","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:16.276Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"3f39e6c4bb86: Waiting","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:16.467Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"d759adb89a6b: Verifying Checksum","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:16.467Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"d759adb89a6b: Download complete","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:17.012Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"ce3aea978520: Verifying Checksum","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:17.012Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"ce3aea978520: Download complete","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:17.179Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"ba36503b8fbe: Download complete","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:17.407Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"4afd0f756edf: Verifying Checksum","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:17.407Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"4afd0f756edf: Download complete","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:17.536Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"3f39e6c4bb86: Verifying Checksum","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:17.536Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"3f39e6c4bb86: Download complete","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:17.960Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"1588a03ab798: Verifying Checksum","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:17.960Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"1588a03ab798: Download complete","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:25.195Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"6414378b6477: Verifying Checksum","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:25.195Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"6414378b6477: Download complete","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:25.956Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"6414378b6477: Pull complete","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:26.040Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"d759adb89a6b: Pull complete","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:26.158Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"ba36503b8fbe: Pull complete","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:26.205Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"ce3aea978520: Pull complete","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:26.228Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"4afd0f756edf: Pull complete","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:26.254Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"3f39e6c4bb86: Pull complete","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:44.897Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"575208bc5436: Verifying Checksum","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:44.897Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"575208bc5436: Download complete","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:48.885Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"575208bc5436: Pull complete","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:48.909Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"1588a03ab798: Pull complete","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:48.920Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"Digest: sha256:8192e949e2d5d02be195f96afef1cf30adc87a4d5e631895497e11f4acc7a429","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:48.924Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"Status: Downloaded newer image for mongo:6","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:48.926Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"docker.io/library/mongo:6","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:48.930Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"-------------------------------------","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:48.930Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"Congratulations!","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:48.930Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:48.930Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"The setup script ran successfully!","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:48.930Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:48.930Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"This message is obnoxiously large for","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:48.930Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"testing purposes.","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:48.930Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:48.930Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"Sincerely,","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:48.930Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"First Run Script","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:48.930Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1137      got stdio       {"output":"-------------------------------------","module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
2024-10-23T17:17:48.930Z        INFO    rdk.modmanager.first_run        modmanager/manager.go:1166      first run script succeeded      {"module":"5784b2a8-d84f-473b-9be5-9a2abe7e8752_my_setup_phase","path":"/home/mp/.viam/packages/data/module/5784b2a8-d84f-473b-9be5-9a2abe7e8752-my_setup_phase-0_0_13-linux-amd64/first_run.sh"}
```