### PR TITLE
RSDK-9097 Accept malformed gRPC error log fields

### DIFF
--- a/logging/proto_conversions.go
+++ b/logging/proto_conversions.go
@@ -52,6 +52,16 @@ func FieldFromProto(field *structpb.Struct) (zap.Field, error) {
 		return zap.Field{}, err
 	}
 
+	// Handle poorly serialized error fields (force them into a string type with
+	// an empty value). Newer Golang modules should serialize correctly (turn
+	// errors into strings client-side) per RSDK-9097.
+	if zf.Type == zapcore.ErrorType {
+		if _, ok := zf.Interface.(error); !ok {
+			zf.Type = zapcore.StringType
+			zf.String = ""
+		}
+	}
+
 	return zf, err
 }
 

--- a/robot/server/server.go
+++ b/robot/server/server.go
@@ -445,17 +445,6 @@ func (s *Server) Log(ctx context.Context, req *pb.LogRequest) (*pb.LogResponse, 
 	fields := make([]zapcore.Field, 0, len(log.Fields)*2)
 	for _, fieldP := range log.Fields {
 		field, err := logging.FieldFromProto(fieldP)
-
-		// Handle poorly serialized error fields (force them into a string type
-		// with an empty value). Newer Golang modules should serialize correctly
-		// (turn errors into strings client-side) per RSDK-9097.
-		if field.Type == zapcore.ErrorType {
-			if _, ok := field.Interface.(error); !ok {
-				field.Type = zapcore.StringType
-				field.String = ""
-			}
-		}
-
 		if err != nil {
 			return nil, errors.Wrap(err, "error converting LogRequest log field from proto")
 		}


### PR DESCRIPTION
Manually handles log fields in `robot/server/server.go#Log` that are encoded as error types and contain an error object (or nil) in their `Interface` field. #4478 added a fix for Golang modules that ensures error fields are encoded as string types during proto conversion. Old Golang modules without that fix will still encode errors as error types, so we should have a similar change server-side to remain backward compatible. 

Tested with a version of `simplemodule` built before #4478 that tries to log an error field. RDK panics without the change in this PR:
```
panic: interface conversion: map[string]interface {} is not error: missing method Error

go.uber.org/zap/zapcore.Field.AddTo({{0x140009035b0, 0x3}, 0x1a, 0x0, {0x0, 0x0}, {0x10531b5e0, 0x14000b41980}}, {0x105815840, 0x14000b0e500})
	/Users/benji.rewis/go/pkg/mod/go.uber.org/zap@v1.27.0/zapcore/field.go:176 +0x838
go.uber.org/zap/zapcore.addFields(...)
	/Users/benji.rewis/go/pkg/mod/go.uber.org/zap@v1.27.0/zapcore/field.go:210
go.uber.org/zap/zapcore.(*jsonEncoder).EncodeEntry(0x14000b0ed40, {0x0, {0x0, 0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, {0x0, ...}, ...}, ...)
	/Users/benji.rewis/go/pkg/mod/go.uber.org/zap@v1.27.0/zapcore/json_encoder.go:420 +0x5b4
go.viam.com/rdk/logging.ConsoleAppender.Write({{0x1057c5858?, 0x140001c4020?}}, {0x0, {0xc1be654c820e1f80, 0x3b821987, 0x107116520}, {0x14000177e60, 0x2c}, {0x14000177e90, 0x29}, ...}, ...)
...
```

With the change, the field appears as `"err":""`, and the RDK continues to function.