### PR TITLE
add-support-for-capturing-to-mongo

### DIFF
--- a/data/registry.go
+++ b/data/registry.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/benbjohnson/clock"
 	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/mongo"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"go.viam.com/rdk/logging"
@@ -18,14 +19,17 @@ type CollectorConstructor func(resource interface{}, params CollectorParams) (Co
 
 // CollectorParams contain the parameters needed to construct a Collector.
 type CollectorParams struct {
-	ComponentName string
-	Interval      time.Duration
-	MethodParams  map[string]*anypb.Any
-	Target        CaptureBufferedWriter
-	QueueSize     int
-	BufferSize    int
-	Logger        logging.Logger
-	Clock         clock.Clock
+	MongoCollection *mongo.Collection
+	ComponentName   string
+	ComponentType   string
+	MethodName      string
+	Interval        time.Duration
+	MethodParams    map[string]*anypb.Any
+	Target          CaptureBufferedWriter
+	QueueSize       int
+	BufferSize      int
+	Logger          logging.Logger
+	Clock           clock.Clock
 }
 
 // Validate validates that p contains all required parameters.

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -129,13 +129,13 @@ func New(
 }
 
 // Close releases all resources managed by data_manager.
-func (b *builtIn) Close(_ context.Context) error {
+func (b *builtIn) Close(ctx context.Context) error {
 	b.logger.Info("Close START")
 	defer b.logger.Info("Close END")
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.diskSummaryLogger.close()
-	b.capture.Close()
+	b.capture.Close(ctx)
 	b.sync.Close()
 	return nil
 }

--- a/services/datamanager/builtin/builtin_test.go
+++ b/services/datamanager/builtin/builtin_test.go
@@ -321,7 +321,7 @@ func TestFileDeletion(t *testing.T) {
 
 	// flush and close collectors to ensure we have exactly 4 files
 	// close capture to stop it from writing more files
-	b.capture.Close()
+	b.capture.Close(ctx)
 
 	// number of capture files is based on the number of unique
 	// collectors in the robot config used in this test

--- a/services/datamanager/builtin/capture/config.go
+++ b/services/datamanager/builtin/capture/config.go
@@ -1,5 +1,35 @@
 package capture
 
+import "errors"
+
+// MongoConfig is the optional data capture mongo config.
+type MongoConfig struct {
+	URI        string `json:"uri"`
+	Database   string `json:"database"`
+	Collection string `json:"collection"`
+}
+
+// Equal returns true when both MongoConfigs are equal.
+func (mc MongoConfig) Equal(o MongoConfig) bool {
+	return mc.URI == o.URI && mc.Database == o.Database && mc.Collection == o.Collection
+}
+
+func (mc MongoConfig) validate() error {
+	if mc.URI == "" {
+		return errors.New("mongo config URI can't be empty string")
+	}
+
+	if mc.Database == "" {
+		return errors.New("mongo config Database can't be empty string")
+	}
+
+	if mc.Collection == "" {
+		return errors.New("mongo config Collection can't be empty string")
+	}
+
+	return nil
+}
+
 // Config is the capture config.
 type Config struct {
 	// CaptureDisabled if set to true disables all data capture collectors
@@ -12,4 +42,6 @@ type Config struct {
 	// (.prog) files should be allowed to grow to before they are convered into .capture
 	// files
 	MaximumCaptureFileSizeBytes int64
+
+	MongoConfig *MongoConfig
 }

--- a/services/datamanager/builtin/config.go
+++ b/services/datamanager/builtin/config.go
@@ -43,12 +43,13 @@ type Config struct {
 	DeleteEveryNthWhenDiskFull  int   `json:"delete_every_nth_when_disk_full"`
 	MaximumCaptureFileSizeBytes int64 `json:"maximum_capture_file_size_bytes"`
 	// Sync
-	AdditionalSyncPaths    []string `json:"additional_sync_paths"`
-	FileLastModifiedMillis int      `json:"file_last_modified_millis"`
-	MaximumNumSyncThreads  int      `json:"maximum_num_sync_threads"`
-	ScheduledSyncDisabled  bool     `json:"sync_disabled"`
-	SelectiveSyncerName    string   `json:"selective_syncer_name"`
-	SyncIntervalMins       float64  `json:"sync_interval_mins"`
+	AdditionalSyncPaths    []string             `json:"additional_sync_paths"`
+	FileLastModifiedMillis int                  `json:"file_last_modified_millis"`
+	MaximumNumSyncThreads  int                  `json:"maximum_num_sync_threads"`
+	ScheduledSyncDisabled  bool                 `json:"sync_disabled"`
+	SelectiveSyncerName    string               `json:"selective_syncer_name"`
+	SyncIntervalMins       float64              `json:"sync_interval_mins"`
+	MongoConfig            *capture.MongoConfig `json:"mongo_config"`
 }
 
 // Validate returns components which will be depended upon weakly due to the above matcher.
@@ -89,6 +90,7 @@ func (c *Config) captureConfig() capture.Config {
 		CaptureDir:                  c.getCaptureDir(),
 		Tags:                        c.Tags,
 		MaximumCaptureFileSizeBytes: maximumCaptureFileSizeBytes,
+		MongoConfig:                 c.MongoConfig,
 	}
 }
 


### PR DESCRIPTION
Adds basic support for capturing tabular data into a mongo database, even when offline:

Documents written to mongo look like the following:
```
{
  "_id": {
    "$oid": "671a83869cfd73855ef1db7d"
  },
  "time_requested": {
    "$date": "2024-10-24T17:27:34.489Z"
  },
  "time_received": {
    "$date": "2024-10-24T17:27:34.491Z"
  },
  "component_name": "sensor-1",
  "component_type": "rdk:component:sensor",
  "method_name": "Readings",
  "data": {
    "readings": {
      "now_unix_micro": 1729790854490768,
      "call_count": 782,
      "now_unix": 1729790854,
      "boot_time_unix": 1729790072
    }
  }
}
```

Given this is a first implementation, in the interest of expediency, I've omitted metadata such as:
1. additional_params 
2. part_id, robot_id, location_id, org_id
3. tags

Otherwise it should be a subset of the cloud mongo tabular_data documents 

app.viam.com MAY change the structure/content of some tabular data data so there may be some discrepancies between sensor data synced directly to a mongo database from viam-server & the tabular data available from a viam hosted cloud mongo database.