### PR TITLE
RSDK-9117 - Remove logger from NewModuleFromArgs, and moduleName from ModularMain

### DIFF
--- a/examples/customresources/demos/complexmodule/module.go
+++ b/examples/customresources/demos/complexmodule/module.go
@@ -15,10 +15,8 @@ import (
 )
 
 func main() {
-	// We will use a logging.Logger named "complexmodule," and our module will support 4 different
-	// resource models.
+	// ModularMain will stand up a module which will host 4 different models.
 	module.ModularMain(
-		"complexmodule",
 		resource.APIModel{gizmoapi.API, mygizmo.Model},
 		resource.APIModel{summationapi.API, mysum.Model},
 		resource.APIModel{base.API, mybase.Model},

--- a/examples/customresources/demos/multiplemodules/gizmomodule/gizmomodule.go
+++ b/examples/customresources/demos/multiplemodules/gizmomodule/gizmomodule.go
@@ -9,7 +9,6 @@ import (
 )
 
 func main() {
-	// ModularMain will create a logger named "gizmomodule", and will stand up a module which will
-	// host our gizmo.
-	module.ModularMain("gizmomodule", resource.APIModel{gizmoapi.API, mygizmosummer.Model})
+	// ModularMain will stand up a module which will host our gizmo.
+	module.ModularMain(resource.APIModel{gizmoapi.API, mygizmosummer.Model})
 }

--- a/examples/customresources/demos/multiplemodules/summationmodule/summationmodule.go
+++ b/examples/customresources/demos/multiplemodules/summationmodule/summationmodule.go
@@ -9,7 +9,6 @@ import (
 )
 
 func main() {
-	// ModularMain will create a logger named "summationmodule" and will then host a module with
-	// our mysum model in it.
-	module.ModularMain("summationmodule", resource.APIModel{summationapi.API, mysum.Model})
+	// ModularMain will host a module with our mysum model in it.
+	module.ModularMain(resource.APIModel{summationapi.API, mysum.Model})
 }

--- a/examples/customresources/demos/rtppassthrough/myrtppassthrough.go
+++ b/examples/customresources/demos/rtppassthrough/myrtppassthrough.go
@@ -18,8 +18,7 @@ func main() {
 		camera.API,
 		model,
 		resource.Registration[camera.Camera, *fake.Config]{Constructor: newFakeCamera})
-
-	module.ModularMain("rtp-passthrough-camera", resource.APIModel{camera.API, model})
+	module.ModularMain(resource.APIModel{camera.API, model})
 }
 
 func newFakeCamera(

--- a/examples/customresources/demos/simplemodule/module.go
+++ b/examples/customresources/demos/simplemodule/module.go
@@ -24,9 +24,8 @@ func main() {
 		Constructor: newCounter,
 	})
 
-	// Next, we run a module, which will log things as "simple-module." This module has a single
-	// model in it, the one we have created.
-	module.ModularMain("simple-module", resource.APIModel{generic.API, myModel})
+	// Next, we run a module which will have a singl model.
+	module.ModularMain(resource.APIModel{generic.API, myModel})
 }
 
 // newCounter is used to create a new instance of our specific model. It is called for each component in the robot's config with this model.

--- a/examples/customresources/models/mygizmo/mygizmo.go
+++ b/examples/customresources/models/mygizmo/mygizmo.go
@@ -3,7 +3,6 @@ package mygizmo
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 
@@ -58,7 +57,6 @@ func NewMyGizmo(
 	conf resource.Config,
 	logger logging.Logger,
 ) (gizmoapi.Gizmo, error) {
-	logger.Errorw("hello", "err", errors.New("from the other side"))
 	g := &myActualGizmo{
 		Named: conf.ResourceName().AsNamed(),
 	}

--- a/examples/customresources/models/mygizmo/mygizmo.go
+++ b/examples/customresources/models/mygizmo/mygizmo.go
@@ -3,6 +3,7 @@ package mygizmo
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -57,6 +58,7 @@ func NewMyGizmo(
 	conf resource.Config,
 	logger logging.Logger,
 ) (gizmoapi.Gizmo, error) {
+	logger.Errorw("hello", "err", errors.New("from the other side"))
 	g := &myActualGizmo{
 		Named: conf.ResourceName().AsNamed(),
 	}

--- a/module/module.go
+++ b/module/module.go
@@ -196,7 +196,8 @@ type Module struct {
 	robotpb.UnimplementedRobotServiceServer
 }
 
-// NewModule returns the basic module framework/structure.
+// NewModule returns the basic module framework/structure. Use ModularMain and NewModuleFromArgs unless
+// you really know what you're doing.
 func NewModule(ctx context.Context, address string, logger logging.Logger) (*Module, error) {
 	// TODO(PRODUCT-343): session support likely means interceptors here
 	opMgr := operation.NewManager(logger)
@@ -263,11 +264,11 @@ func NewModule(ctx context.Context, address string, logger logging.Logger) (*Mod
 }
 
 // NewModuleFromArgs directly parses the command line argument to get its address.
-func NewModuleFromArgs(ctx context.Context, logger logging.Logger) (*Module, error) {
+func NewModuleFromArgs(ctx context.Context) (*Module, error) {
 	if len(os.Args) < 2 {
 		return nil, errors.New("need socket path as command line argument")
 	}
-	return NewModule(ctx, os.Args[1], logger)
+	return NewModule(ctx, os.Args[1], NewLoggerFromArgs(""))
 }
 
 // Start starts the module service and grpc server.

--- a/module/multiversionmodule/module.go
+++ b/module/multiversionmodule/module.go
@@ -57,7 +57,7 @@ func main() {
 }
 
 func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) error {
-	myMod, err := module.NewModuleFromArgs(ctx, logger)
+	myMod, err := module.NewModuleFromArgs(ctx)
 	if err != nil {
 		return err
 	}

--- a/module/runtime.go
+++ b/module/runtime.go
@@ -11,9 +11,9 @@ import (
 
 // ModularMain can be called as the main function from a module. It will start up a module with all
 // the provided APIModels added to it.
-func ModularMain(moduleName string, models ...resource.APIModel) {
+func ModularMain(models ...resource.APIModel) {
 	mainWithArgs := func(ctx context.Context, args []string, logger logging.Logger) error {
-		mod, err := NewModuleFromArgs(ctx, logger)
+		mod, err := NewModuleFromArgs(ctx)
 		if err != nil {
 			return err
 		}
@@ -34,5 +34,5 @@ func ModularMain(moduleName string, models ...resource.APIModel) {
 		return nil
 	}
 
-	utils.ContextualMain(mainWithArgs, NewLoggerFromArgs(moduleName))
+	utils.ContextualMain(mainWithArgs, NewLoggerFromArgs(""))
 }

--- a/module/testmodule/main.go
+++ b/module/testmodule/main.go
@@ -38,7 +38,7 @@ func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) err
 	logger.Debug("debug mode enabled")
 
 	var err error
-	myMod, err = module.NewModuleFromArgs(ctx, logger)
+	myMod, err = module.NewModuleFromArgs(ctx)
 	if err != nil {
 		return err
 	}

--- a/module/testmodule2/main.go
+++ b/module/testmodule2/main.go
@@ -35,7 +35,7 @@ func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) err
 	logger.Debug("debug mode enabled")
 
 	var err error
-	myMod, err = module.NewModuleFromArgs(ctx, logger)
+	myMod, err = module.NewModuleFromArgs(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
we want to force a breakage so that users will not use the wrong logger when making a Go module.

logs now look like
```
10/23/2024, 3:23:27 PM error acme:component:gizmo/gizmo1 mygizmo/mygizmo.go:61 hello err from the other side log_ts 2024-10-23T19:23:27.697Z
```
on app

when it used to be

```
10/23/2024, 3:23:27 PM error {moduleName}.acme:component:gizmo/gizmo1 mygizmo/mygizmo.go:61 hello err from the other side log_ts 2024-10-23T19:23:27.697Z
```

I think it's generally fine to no longer have the moduleName tacked on to the beginning of the logger name.

this is a breaking change but all the user needs to do is to get rid of the logger/module name from their function calls

cc: @benjirewis 