### PR TITLE
RSDK-9115 - Hotfix - Remove options arg from web_notc init stream server stub

### DIFF
--- a/robot/web/web_notc.go
+++ b/robot/web/web_notc.go
@@ -9,7 +9,6 @@ import (
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot"
-	weboptions "go.viam.com/rdk/robot/web/options"
 	"go.viam.com/utils/rpc"
 )
 
@@ -63,7 +62,7 @@ func (svc *webService) Reconfigure(ctx context.Context, deps resource.Dependenci
 func (svc *webService) closeStreamServer() {}
 
 // stub implementation when gostream not available
-func (svc *webService) initStreamServer(ctx context.Context, options *weboptions.Options) error {
+func (svc *webService) initStreamServer(ctx context.Context) error {
 	return nil
 }
 


### PR DESCRIPTION
## Description

I did not remove options from the `web_notc` path in the previous [PR](https://github.com/viamrobotics/rdk/pull/4488). This is causing CI to fail, see [here](https://github.com/viamrobotics/rdk/actions/runs/11557035823/job/32167240371).