### PR TITLE
RSDK-9164 Modules cannot depend on builtin motion service

### DIFF
--- a/resource/resource_graph.go
+++ b/resource/resource_graph.go
@@ -236,16 +236,18 @@ func (g *Graph) FindNodesByAPI(api API) []Name {
 
 // findNodesByShortName returns all resources matching the given short name.
 func (g *Graph) findNodesByShortName(name string) []Name {
-	hasRemote := strings.Contains(name, ":")
+	hasRemoteOrTriplet := strings.Contains(name, ":")
 	var matches []Name
 	for nodeName := range g.nodes {
 		if !(nodeName.API.IsComponent() || nodeName.API.IsService()) {
 			continue
 		}
-		if hasRemote {
+		if hasRemoteOrTriplet {
 			// check the whole remote. we could technically check
 			// a prefix of the remote but thats excluded for now.
 			if nodeName.ShortName() == name {
+				matches = append(matches, nodeName)
+			} else if nodeName.String() == name {
 				matches = append(matches, nodeName)
 			}
 			continue

--- a/resource/resource_graph_test.go
+++ b/resource/resource_graph_test.go
@@ -686,6 +686,10 @@ func TestResourceGraphFindNodeByName(t *testing.T) {
 	test.That(t, names, test.ShouldHaveLength, 1)
 	names = gA.findNodesByShortName("D")
 	test.That(t, names, test.ShouldHaveLength, 0)
+	names = gA.findNodesByShortName("rdk:component:aapi/C")
+	test.That(t, names, test.ShouldHaveLength, 1)
+	names = gA.findNodesByShortName("rdk:component:aapi/D")
+	test.That(t, names, test.ShouldHaveLength, 0)
 }
 
 var cfgA = []fakeComponent{


### PR DESCRIPTION
This PR adds support for specifying dependencies using the entire triplet + name, allowing components, services, and modules to depend on builtin services.