### PR TITLE
RSDK-9188 - Add fake cam attr to toggle intrinsic & distortion props

### DIFF
--- a/components/camera/fake/camera.go
+++ b/components/camera/fake/camera.go
@@ -38,9 +38,9 @@ var (
 )
 
 const (
-	initialWidth      = 1280
-	initialHeight     = 720
-	defaultIntrinsics = true
+	initialWidth  = 1280
+	initialHeight = 720
+	defaultModel  = true
 )
 
 func init() {
@@ -74,12 +74,12 @@ func NewCamera(
 	if height > 0 {
 		height = newConf.Height
 	}
-	intrinsics := defaultIntrinsics
-	if newConf.Intrinsics != nil {
-		intrinsics = *newConf.Intrinsics
+	model := defaultModel
+	if newConf.Model != nil {
+		model = *newConf.Model
 	}
 	var resModel *transform.PinholeCameraModel
-	if intrinsics {
+	if model {
 		resModel = fakeModel(width, height)
 	} else {
 		resModel = nil
@@ -125,7 +125,7 @@ type Config struct {
 	Height         int   `json:"height,omitempty"`
 	Animated       bool  `json:"animated,omitempty"`
 	RTPPassthrough bool  `json:"rtp_passthrough,omitempty"`
-	Intrinsics     *bool `json:"intrinsics,omitempty"`
+	Model          *bool `json:"model,omitempty"`
 }
 
 // Validate checks that the config attributes are valid for a fake camera.
@@ -168,12 +168,8 @@ var fakeDistortion = &transform.BrownConrady{
 
 func fakeModel(width, height int) *transform.PinholeCameraModel {
 	intrinsics := *fakeIntrinsics
-	if width > 0 {
-		intrinsics.Width = width
-	}
-	if height > 0 {
-		intrinsics.Height = height
-	}
+	intrinsics.Width = width
+	intrinsics.Height = height
 	return &transform.PinholeCameraModel{
 		PinholeCameraIntrinsics: &intrinsics,
 		Distortion:              fakeDistortion,

--- a/components/camera/fake/camera.go
+++ b/components/camera/fake/camera.go
@@ -40,7 +40,6 @@ var (
 const (
 	initialWidth  = 1280
 	initialHeight = 720
-	defaultModel  = true
 )
 
 func init() {
@@ -71,15 +70,11 @@ func NewCamera(
 		width = newConf.Width
 	}
 	height := initialHeight
-	if height > 0 {
+	if newConf.Height > 0 {
 		height = newConf.Height
 	}
-	model := defaultModel
-	if newConf.Model != nil {
-		model = *newConf.Model
-	}
 	var resModel *transform.PinholeCameraModel
-	if model {
+	if newConf.Model {
 		resModel = fakeModel(width, height)
 	} else {
 		resModel = nil
@@ -121,11 +116,11 @@ func NewCamera(
 
 // Config are the attributes of the fake camera config.
 type Config struct {
-	Width          int   `json:"width,omitempty"`
-	Height         int   `json:"height,omitempty"`
-	Animated       bool  `json:"animated,omitempty"`
-	RTPPassthrough bool  `json:"rtp_passthrough,omitempty"`
-	Model          *bool `json:"model,omitempty"`
+	Width          int  `json:"width,omitempty"`
+	Height         int  `json:"height,omitempty"`
+	Animated       bool `json:"animated,omitempty"`
+	RTPPassthrough bool `json:"rtp_passthrough,omitempty"`
+	Model          bool `json:"model,omitempty"`
 }
 
 // Validate checks that the config attributes are valid for a fake camera.

--- a/components/camera/fake/camera.go
+++ b/components/camera/fake/camera.go
@@ -65,7 +65,20 @@ func NewCamera(
 	if paramErr != nil {
 		return nil, paramErr
 	}
-	resModel, width, height := fakeModel(newConf.Width, newConf.Height)
+	width := initialWidth
+	if newConf.Width > 0 {
+		width = newConf.Width
+	}
+	height := initialHeight
+	if height > 0 {
+		height = newConf.Height
+	}
+	var resModel *transform.PinholeCameraModel
+	if newConf.Intrinsics {
+		resModel = fakeModel(newConf.Width, newConf.Height)
+	} else {
+		resModel = nil
+	}
 	cancelCtx, cancelFn := context.WithCancel(context.Background())
 	cam := &Camera{
 		ctx:            cancelCtx,
@@ -107,6 +120,7 @@ type Config struct {
 	Height         int  `json:"height,omitempty"`
 	Animated       bool `json:"animated,omitempty"`
 	RTPPassthrough bool `json:"rtp_passthrough,omitempty"`
+	Intrinsics     bool `json:"intrinsics,omitempty"`
 }
 
 // Validate checks that the config attributes are valid for a fake camera.
@@ -147,59 +161,17 @@ var fakeDistortion = &transform.BrownConrady{
 	TangentialP2: 0.19969297,
 }
 
-func fakeModel(width, height int) (*transform.PinholeCameraModel, int, int) {
-	fakeModelReshaped := &transform.PinholeCameraModel{
-		PinholeCameraIntrinsics: fakeIntrinsics,
-		Distortion:              fakeDistortion,
+func fakeModel(width, height int) *transform.PinholeCameraModel {
+	intrinsics := *fakeIntrinsics
+	if width > 0 {
+		intrinsics.Width = width
 	}
-	switch {
-	case width > 0 && height > 0:
-		widthRatio := float64(width) / float64(initialWidth)
-		heightRatio := float64(height) / float64(initialHeight)
-		intrinsics := &transform.PinholeCameraIntrinsics{
-			Width:  int(float64(fakeIntrinsics.Width) * widthRatio),
-			Height: int(float64(fakeIntrinsics.Height) * heightRatio),
-			Fx:     fakeIntrinsics.Fx * widthRatio,
-			Fy:     fakeIntrinsics.Fy * heightRatio,
-			Ppx:    fakeIntrinsics.Ppx * widthRatio,
-			Ppy:    fakeIntrinsics.Ppy * heightRatio,
-		}
-		fakeModelReshaped.PinholeCameraIntrinsics = intrinsics
-		return fakeModelReshaped, width, height
-	case width > 0 && height <= 0:
-		ratio := float64(width) / float64(initialWidth)
-		intrinsics := &transform.PinholeCameraIntrinsics{
-			Width:  int(float64(fakeIntrinsics.Width) * ratio),
-			Height: int(float64(fakeIntrinsics.Height) * ratio),
-			Fx:     fakeIntrinsics.Fx * ratio,
-			Fy:     fakeIntrinsics.Fy * ratio,
-			Ppx:    fakeIntrinsics.Ppx * ratio,
-			Ppy:    fakeIntrinsics.Ppy * ratio,
-		}
-		fakeModelReshaped.PinholeCameraIntrinsics = intrinsics
-		newHeight := int(float64(initialHeight) * ratio)
-		if newHeight%2 != 0 {
-			newHeight++
-		}
-		return fakeModelReshaped, width, newHeight
-	case width <= 0 && height > 0:
-		ratio := float64(height) / float64(initialHeight)
-		intrinsics := &transform.PinholeCameraIntrinsics{
-			Width:  int(float64(fakeIntrinsics.Width) * ratio),
-			Height: int(float64(fakeIntrinsics.Height) * ratio),
-			Fx:     fakeIntrinsics.Fx * ratio,
-			Fy:     fakeIntrinsics.Fy * ratio,
-			Ppx:    fakeIntrinsics.Ppx * ratio,
-			Ppy:    fakeIntrinsics.Ppy * ratio,
-		}
-		fakeModelReshaped.PinholeCameraIntrinsics = intrinsics
-		newWidth := int(float64(initialWidth) * ratio)
-		if newWidth%2 != 0 {
-			newWidth++
-		}
-		return fakeModelReshaped, newWidth, height
-	default:
-		return fakeModelReshaped, initialWidth, initialHeight
+	if height > 0 {
+		intrinsics.Height = height
+	}
+	return &transform.PinholeCameraModel{
+		PinholeCameraIntrinsics: &intrinsics,
+		Distortion:              fakeDistortion,
 	}
 }
 

--- a/components/camera/fake/camera.go
+++ b/components/camera/fake/camera.go
@@ -38,8 +38,9 @@ var (
 )
 
 const (
-	initialWidth  = 1280
-	initialHeight = 720
+	initialWidth      = 1280
+	initialHeight     = 720
+	defaultIntrinsics = true
 )
 
 func init() {
@@ -73,9 +74,13 @@ func NewCamera(
 	if height > 0 {
 		height = newConf.Height
 	}
+	intrinsics := defaultIntrinsics
+	if newConf.Intrinsics != nil {
+		intrinsics = *newConf.Intrinsics
+	}
 	var resModel *transform.PinholeCameraModel
-	if newConf.Intrinsics {
-		resModel = fakeModel(newConf.Width, newConf.Height)
+	if intrinsics {
+		resModel = fakeModel(width, height)
 	} else {
 		resModel = nil
 	}
@@ -116,11 +121,11 @@ func NewCamera(
 
 // Config are the attributes of the fake camera config.
 type Config struct {
-	Width          int  `json:"width,omitempty"`
-	Height         int  `json:"height,omitempty"`
-	Animated       bool `json:"animated,omitempty"`
-	RTPPassthrough bool `json:"rtp_passthrough,omitempty"`
-	Intrinsics     bool `json:"intrinsics,omitempty"`
+	Width          int   `json:"width,omitempty"`
+	Height         int   `json:"height,omitempty"`
+	Animated       bool  `json:"animated,omitempty"`
+	RTPPassthrough bool  `json:"rtp_passthrough,omitempty"`
+	Intrinsics     *bool `json:"intrinsics,omitempty"`
 }
 
 // Validate checks that the config attributes are valid for a fake camera.

--- a/components/camera/fake/camera_test.go
+++ b/components/camera/fake/camera_test.go
@@ -162,7 +162,7 @@ func TestRTPPassthrough(t *testing.T) {
 
 func TestPropertiesToggle(t *testing.T) {
 	// Test fake camera without setting model
-	// IntrinsicParams and DistortionParams should be nil from Properties
+	// IntrinsicParams and DistortionParams Properties should be nil
 	ctx := context.Background()
 	cfg1 := resource.Config{
 		Name:                "test1",
@@ -181,7 +181,7 @@ func TestPropertiesToggle(t *testing.T) {
 	test.That(t, cam1.Close(ctx), test.ShouldBeNil)
 
 	// Test fake camera with model set to true
-	// IntrinsicParams and DistortionParams should be set from Properties
+	// IntrinsicParams and DistortionParams Properties should be set
 	cfg2 := resource.Config{
 		Name:  "test2",
 		API:   camera.API,
@@ -199,6 +199,4 @@ func TestPropertiesToggle(t *testing.T) {
 	test.That(t, propsRes2.IntrinsicParams, test.ShouldNotBeNil)
 	test.That(t, propsRes2.DistortionParams, test.ShouldNotBeNil)
 	test.That(t, cam2.Close(ctx), test.ShouldBeNil)
-
-	// Test fake camera with model set to nil
 }

--- a/components/camera/fake/camera_test.go
+++ b/components/camera/fake/camera_test.go
@@ -161,46 +161,44 @@ func TestRTPPassthrough(t *testing.T) {
 }
 
 func TestPropertiesToggle(t *testing.T) {
-	// Test fake camera with model set to false
+	// Test fake camera without setting model
 	// IntrinsicParams and DistortionParams should be nil from Properties
 	ctx := context.Background()
-	modleFalse := false
 	cfg1 := resource.Config{
-		Name:  "test1",
-		API:   camera.API,
-		Model: Model,
-		ConvertedAttributes: &Config{
-			Model: &modleFalse,
-		},
+		Name:                "test1",
+		API:                 camera.API,
+		Model:               Model,
+		ConvertedAttributes: &Config{},
 	}
 	cam1, err := NewCamera(ctx, nil, cfg1, logging.NewTestLogger(t))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, cam1, test.ShouldNotBeNil)
-	propsRes, err := cam1.Properties(ctx)
+	propsRes1, err := cam1.Properties(ctx)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, propsRes, test.ShouldNotBeNil)
-	test.That(t, propsRes.IntrinsicParams, test.ShouldBeNil)
-	test.That(t, propsRes.DistortionParams, test.ShouldBeNil)
+	test.That(t, propsRes1, test.ShouldNotBeNil)
+	test.That(t, propsRes1.IntrinsicParams, test.ShouldBeNil)
+	test.That(t, propsRes1.DistortionParams, test.ShouldBeNil)
 	test.That(t, cam1.Close(ctx), test.ShouldBeNil)
 
 	// Test fake camera with model set to true
-	// IntrinsicParams and DistortionParams should not be nil from Properties
-	modelTrue := true
+	// IntrinsicParams and DistortionParams should be set from Properties
 	cfg2 := resource.Config{
 		Name:  "test2",
 		API:   camera.API,
 		Model: Model,
 		ConvertedAttributes: &Config{
-			Model: &modelTrue,
+			Model: true,
 		},
 	}
 	cam2, err := NewCamera(ctx, nil, cfg2, logging.NewTestLogger(t))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, cam2, test.ShouldNotBeNil)
-	propsRes, err = cam2.Properties(ctx)
+	propsRes2, err := cam2.Properties(ctx)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, propsRes, test.ShouldNotBeNil)
-	test.That(t, propsRes.IntrinsicParams, test.ShouldNotBeNil)
-	test.That(t, propsRes.DistortionParams, test.ShouldNotBeNil)
+	test.That(t, propsRes2, test.ShouldNotBeNil)
+	test.That(t, propsRes2.IntrinsicParams, test.ShouldNotBeNil)
+	test.That(t, propsRes2.DistortionParams, test.ShouldNotBeNil)
 	test.That(t, cam2.Close(ctx), test.ShouldBeNil)
+
+	// Test fake camera with model set to nil
 }

--- a/components/camera/fake/camera_test.go
+++ b/components/camera/fake/camera_test.go
@@ -160,5 +160,47 @@ func TestRTPPassthrough(t *testing.T) {
 	})
 }
 
-// func TestIntricsicParams(t *testing.T) {
-// }
+func TestPropertiesToggle(t *testing.T) {
+	// Test fake camera with model set to false
+	// IntrinsicParams and DistortionParams should be nil from Properties
+	ctx := context.Background()
+	modleFalse := false
+	cfg1 := resource.Config{
+		Name:  "test1",
+		API:   camera.API,
+		Model: Model,
+		ConvertedAttributes: &Config{
+			Model: &modleFalse,
+		},
+	}
+	cam1, err := NewCamera(ctx, nil, cfg1, logging.NewTestLogger(t))
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, cam1, test.ShouldNotBeNil)
+	propsRes, err := cam1.Properties(ctx)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, propsRes, test.ShouldNotBeNil)
+	test.That(t, propsRes.IntrinsicParams, test.ShouldBeNil)
+	test.That(t, propsRes.DistortionParams, test.ShouldBeNil)
+	test.That(t, cam1.Close(ctx), test.ShouldBeNil)
+
+	// Test fake camera with model set to true
+	// IntrinsicParams and DistortionParams should not be nil from Properties
+	modelTrue := true
+	cfg2 := resource.Config{
+		Name:  "test2",
+		API:   camera.API,
+		Model: Model,
+		ConvertedAttributes: &Config{
+			Model: &modelTrue,
+		},
+	}
+	cam2, err := NewCamera(ctx, nil, cfg2, logging.NewTestLogger(t))
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, cam2, test.ShouldNotBeNil)
+	propsRes, err = cam2.Properties(ctx)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, propsRes, test.ShouldNotBeNil)
+	test.That(t, propsRes.IntrinsicParams, test.ShouldNotBeNil)
+	test.That(t, propsRes.DistortionParams, test.ShouldNotBeNil)
+	test.That(t, cam2.Close(ctx), test.ShouldBeNil)
+}


### PR DESCRIPTION
## Description
In order to test dynamic resolution endpoints, it is helpful to configure fake cameras with and without intrinsic parameters.  In the process of adding this I noticed some seemingly outdated code blocks and tests we can remove.

- Adds `Model` attribute to fake camera.
  - Toggles `IntrinsicParams` and `DistortionParams` for the camera.
  - Defaults to false.
- Removes seemingly stale width & height handling for params in `fakeModel` helper.
  - No longer need to handle 16:9 aspect ratio adjustments.
  - We now validate and set default sizes in the constructor.
- Removes tests that are not using the fake cam methods.

```
type Config struct {
	Width          int   `json:"width,omitempty"`
	Height         int   `json:"height,omitempty"`
	Animated       bool  `json:"animated,omitempty"`
	RTPPassthrough bool  `json:"rtp_passthrough,omitempty"`
	Model          bool  `json:"model,omitempty"`
}
```

## Tests

- test cases for properties toggle ✅ 
- test default size ✅ 
- animated ✅ 
- rtp_passthrough ✅

___

TODO:
- [x] Make sure that this will not affect any transform cam tests
- [x] Write tests to validate Properties response based on Model attr.
- [x] Manually test from frontend.
- [x] Figure out why CI test are cancelling now. See [here](https://github.com/viamrobotics/rdk/actions/runs/11634903549/job/32403661351).