### PR TITLE
RSDK-9067 Refactor first run

### DIFF
--- a/config/module.go
+++ b/config/module.go
@@ -233,7 +233,7 @@ func (m Module) EvaluateExePath(packagesDir string) (string, error) {
 }
 
 // FirstRunSuccessSuffix is the suffix of the file whose existence
-// denotes that the setup phase for a module ran successfully.
+// denotes that the first run script for a module ran successfully.
 //
 // Note that we create a new file instead of writing to `.status.json`,
 // which contains various package/module state tracking information.
@@ -270,29 +270,29 @@ func (m *Module) FirstRun(
 	var pathErr *os.PathError
 	switch {
 	case errors.As(err, &pathErr):
-		logger.Debugw("meta.json not found, skipping setup phase", "error", err)
+		logger.Debugw("meta.json not found, skipping first run", "error", err)
 		return nil
 	case err != nil:
-		logger.Warn("failed to parse meta.json, skipping setup phase", "error", err)
+		logger.Warn("failed to parse meta.json, skipping first run", "error", err)
 		return nil
 	}
 	if err != nil {
-		logger.Debugw("failed to load meta.json, skipping setup phase", "error", err)
+		logger.Debugw("failed to load meta.json, skipping first run", "error", err)
 		return nil
 	}
 
 	if meta.FirstRun == "" {
-		logger.Debug("no first run script specified, skipping setup phase")
+		logger.Debug("no first run script specified, skipping first run")
 		return nil
 	}
 	relFirstRunPath, err := utils.SafeJoinDir(unpackedModDir, meta.FirstRun)
 	if err != nil {
-		logger.Errorw("failed to build path to first run script, skipping setup phase", "error", err)
+		logger.Errorw("failed to build path to first run script, skipping first run", "error", err)
 		return nil
 	}
 	firstRunPath, err := filepath.Abs(relFirstRunPath)
 	if err != nil {
-		logger.Errorw("failed to build absolute path to first run script, skipping setup phase", "path", relFirstRunPath, "error", err)
+		logger.Errorw("failed to build absolute path to first run script, skipping first run", "path", relFirstRunPath, "error", err)
 		return nil
 	}
 
@@ -365,7 +365,7 @@ func (m *Module) FirstRun(
 	logger.Info("first run script succeeded")
 
 	// Mark success by writing a marker file to disk. This is a best
-	// effort; if writing to disk fails the setup phase will run again
+	// effort; if writing to disk fails the first run script will run again
 	// for this module and version and we are okay with that.
 	//nolint:gosec // safe
 	markerFile, err := os.Create(firstRunSuccessPath)

--- a/config/module.go
+++ b/config/module.go
@@ -1,13 +1,18 @@
 package config
 
 import (
+	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"regexp"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 	goutils "go.viam.com/utils"
@@ -17,7 +22,10 @@ import (
 	"go.viam.com/rdk/utils"
 )
 
-const reservedModuleName = "parent"
+const (
+	reservedModuleName     = "parent"
+	defaultFirstRunTimeout = 1 * time.Hour
+)
 
 // Module represents an external resource module, with a path to the binary module file.
 type Module struct {
@@ -305,4 +313,100 @@ func (m Module) EvaluateFirstRunPath(packagesDir string, logger logging.Logger) 
 		return firstRunPath, markFirstRunSuccess, err
 	}
 	return "", noop, errors.New("no first run script")
+}
+
+// FirstRun executes a module-specific setup script.
+func (m *Module) FirstRun(
+	ctx context.Context,
+	localPackagesDir,
+	dataDir string,
+	env map[string]string,
+	logger logging.Logger,
+) error {
+	logger = logger.Sublogger("first_run").WithFields("module", m.Name)
+
+	// Evaluate the Module's FirstRun path. If there is an error we assume
+	// that the first run script does not exist and we debug log and exit quietly.
+	firstRunPath, markSuccess, err := m.EvaluateFirstRunPath(localPackagesDir, logger)
+	if err != nil {
+		// TODO(RSDK-9067): some first run path evaluation errors should be promoted to WARN logs.
+		logger.Debugw("no first run script detected, skipping setup phase", "error", err)
+		return nil
+	}
+
+	logger = logger.WithFields("module", m.Name, "path", firstRunPath)
+	logger.Infow("executing first run script")
+
+	timeout := defaultFirstRunTimeout
+	if m.FirstRunTimeout > 0 {
+		timeout = m.FirstRunTimeout.Unwrap()
+	}
+	cmdCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	//nolint:gosec // Yes, we are deliberating executing arbitrary user code here.
+	cmd := exec.CommandContext(cmdCtx, firstRunPath)
+
+	cmd.Env = os.Environ()
+	for key, val := range env {
+		cmd.Env = append(cmd.Env, key+"="+val)
+	}
+
+	stdOut, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	stdErr, err := cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+
+	scanOut := bufio.NewScanner(stdOut)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+
+		for scanOut.Scan() {
+			logger.Infow("got stdio", "output", scanOut.Text())
+		}
+		// This scanner keeps trying to read stdio until the command terminates,
+		// at which point the stdio pipe handle is no longer available. This sometimes
+		// results in an `os.ErrClosed`, which we discard.
+		if err := scanOut.Err(); err != nil && !errors.Is(err, os.ErrClosed) {
+			logger.Errorw("error scanning stdio", "error", err)
+		}
+	}()
+	scanErr := bufio.NewScanner(stdErr)
+	go func() {
+		defer wg.Done()
+
+		for scanErr.Scan() {
+			logger.Warnw("got stderr", "output", scanErr.Text())
+		}
+		// This scanner keeps trying to read stderr until the command terminates,
+		// at which point the stderr pipe handle is no longer available. This sometimes
+		// results in an `os.ErrClosed`, which we discard.
+		if err := scanErr.Err(); err != nil && !errors.Is(err, os.ErrClosed) {
+			logger.Errorw("error scanning stderr", "error", err)
+		}
+	}()
+	if err := cmd.Start(); err != nil {
+		logger.Errorw("failed to start first run script", "error", err)
+		return err
+	}
+	if err := cmd.Wait(); err != nil {
+		logger.Errorw("first run script failed", "error", err)
+		return err
+	}
+	wg.Wait()
+	logger.Info("first run script succeeded")
+
+	// Mark success by writing a marker file to disk. This is a best
+	// effort; if writing to disk fails the setup phase will run again
+	// for this module and version and we are okay with that.
+	if err := markSuccess(); err != nil {
+		logger.Errorw("failed to mark success", "error", err)
+	}
+	return nil
 }

--- a/config/module.go
+++ b/config/module.go
@@ -320,6 +320,10 @@ func (m *Module) FirstRun(
 		logger.Debugw("failed to load meta.json, skipping setup phase", "error", err)
 		return nil
 	}
+	if meta.FirstRun == "" {
+		logger.Debug("no first run script specified, skipping setup phase")
+		return nil
+	}
 	relFirstRunPath, err := utils.SafeJoinDir(unpackedModDir, meta.FirstRun)
 	if err != nil {
 		logger.Errorw("failed to build path to first run script, skipping setup phase", "error", err)

--- a/config/module.go
+++ b/config/module.go
@@ -276,10 +276,6 @@ func (m *Module) FirstRun(
 		logger.Warn("failed to parse meta.json, skipping first run", "error", err)
 		return nil
 	}
-	if err != nil {
-		logger.Debugw("failed to load meta.json, skipping first run", "error", err)
-		return nil
-	}
 
 	if meta.FirstRun == "" {
 		logger.Debug("no first run script specified, skipping first run")

--- a/config/module.go
+++ b/config/module.go
@@ -142,8 +142,8 @@ func (m Module) SyntheticPackage() (PackageConfig, error) {
 	return PackageConfig{Name: name, Package: name, Type: PackageTypeModule, Version: m.LocalVersion}, nil
 }
 
-// exeDir returns the parent directory for the unpacked module.
-func (m Module) exeDir(packagesDir string) (string, error) {
+// UnpackedModuleDirectory returns the parent directory for the unpacked module.
+func (m Module) UnpackedModuleDirectory(packagesDir string) (string, error) {
 	if !m.NeedsSyntheticPackage() {
 		return filepath.Dir(m.ExePath), nil
 	}
@@ -177,7 +177,7 @@ func (m Module) EvaluateExePath(packagesDir string) (string, error) {
 	if !filepath.IsAbs(m.ExePath) {
 		return "", fmt.Errorf("expected ExePath to be absolute path, got %s", m.ExePath)
 	}
-	exeDir, err := m.exeDir(packagesDir)
+	exeDir, err := m.UnpackedModuleDirectory(packagesDir)
 	if err != nil {
 		return "", err
 	}
@@ -237,52 +237,28 @@ const FirstRunSuccessSuffix = ".first_run_succeeded"
 // 1. if there is a meta.json in the exe dir, use that, except in local non-tarball case.
 // 2. if this is a local tarball and there's a meta.json next to the tarball, use that.
 // Note: the working directory must be the unpacked tarball directory or local exec directory.
-//
-// On success (i.e. if the returned error is nil), this function also returns a function that creates
-// a marker file indicating that the setup phase has run successfully.
-func (m Module) EvaluateFirstRunPath(packagesDir string, logger logging.Logger) (
-	string,
-	func() error,
-	error,
-) {
-	noop := func() error { return nil }
-	unpackedModDir, err := m.exeDir(packagesDir)
-	if err != nil {
-		return "", noop, err
-	}
-
-	firstRunSuccessPath := unpackedModDir + FirstRunSuccessSuffix
-	if _, err := os.Stat(firstRunSuccessPath); !errors.Is(err, os.ErrNotExist) {
-		logger.Info("first run already ran")
-		return "", noop, errors.New("first run already ran")
-	}
-	markFirstRunSuccess := func() error {
-		//nolint:gosec // safe
-		_, err := os.Create(firstRunSuccessPath)
-		return err
-	}
-
+func (m Module) EvaluateFirstRunPath(unpackedModDir string, logger logging.Logger) (string, error) {
 	// note: we don't look at internal meta.json in local non-tarball case because user has explicitly requested a binary.
 	localNonTarball := m.Type == ModuleTypeLocal && !m.NeedsSyntheticPackage()
 	if !localNonTarball {
 		// this is case 1, meta.json in exe folder.
 		metaPath, err := utils.SafeJoinDir(unpackedModDir, "meta.json")
 		if err != nil {
-			return "", noop, err
+			return "", err
 		}
 		_, err = os.Stat(metaPath)
 		if err == nil {
 			// this is case 1, meta.json in exe dir
 			meta, err := parseJSONFile[JSONManifest](metaPath)
 			if err != nil {
-				return "", noop, err
+				return "", err
 			}
 			firstRun, err := utils.SafeJoinDir(unpackedModDir, meta.FirstRun)
 			if err != nil {
-				return "", noop, err
+				return "", err
 			}
 			firstRunPath, err := filepath.Abs(firstRun)
-			return firstRunPath, markFirstRunSuccess, err
+			return firstRunPath, err
 		}
 	}
 	if m.NeedsSyntheticPackage() {
@@ -290,19 +266,19 @@ func (m Module) EvaluateFirstRunPath(packagesDir string, logger logging.Logger) 
 		// TODO(RSDK-7848): remove this case once java sdk supports internal meta.json.
 		metaPath, err := utils.SafeJoinDir(filepath.Dir(m.ExePath), "meta.json")
 		if err != nil {
-			return "", noop, err
+			return "", err
 		}
 		meta, err := parseJSONFile[JSONManifest](metaPath)
 		if err != nil {
 			// note: this error deprecates the side-by-side case because the side-by-side case is deprecated.
-			return "", noop, errors.Wrapf(err, "couldn't find meta.json inside tarball %s (or next to it)", m.ExePath)
+			return "", errors.Wrapf(err, "couldn't find meta.json inside tarball %s (or next to it)", m.ExePath)
 		}
 		firstRun, err := utils.SafeJoinDir(unpackedModDir, meta.FirstRun)
 		if err != nil {
-			return "", noop, err
+			return "", err
 		}
 		firstRunPath, err := filepath.Abs(firstRun)
-		return firstRunPath, markFirstRunSuccess, err
+		return firstRunPath, err
 	}
-	return "", noop, errors.New("no first run script")
+	return "", errors.New("no first run script")
 }

--- a/config/module_test.go
+++ b/config/module_test.go
@@ -31,7 +31,7 @@ func TestInternalMeta(t *testing.T) {
 		}
 		exePath, err := mod.EvaluateExePath(packagesDir)
 		test.That(t, err, test.ShouldBeNil)
-		exeDir, err := mod.exeDir(packagesDir)
+		exeDir, err := mod.UnpackedModuleDirectory(packagesDir)
 		test.That(t, err, test.ShouldBeNil)
 		// "entry" is from meta.json.
 		test.That(t, exePath, test.ShouldEqual, filepath.Join(exeDir, "entry"))
@@ -77,7 +77,7 @@ func TestSyntheticModule(t *testing.T) {
 	})
 
 	t.Run("syntheticPackageExeDir", func(t *testing.T) {
-		dir, err := modNeedsSynthetic.exeDir(tmp)
+		dir, err := modNeedsSynthetic.UnpackedModuleDirectory(tmp)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, dir, test.ShouldEqual, filepath.Join(tmp, "data/module/synthetic--"))
 	})
@@ -91,7 +91,7 @@ func TestSyntheticModule(t *testing.T) {
 		// local tarball case
 		syntheticPath, err := modNeedsSynthetic.EvaluateExePath(tmp)
 		test.That(t, err, test.ShouldBeNil)
-		exeDir, err := modNeedsSynthetic.exeDir(tmp)
+		exeDir, err := modNeedsSynthetic.UnpackedModuleDirectory(tmp)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, syntheticPath, test.ShouldEqual, filepath.Join(exeDir, meta.Entrypoint))
 

--- a/config/module_test.go
+++ b/config/module_test.go
@@ -31,7 +31,7 @@ func TestInternalMeta(t *testing.T) {
 		}
 		exePath, err := mod.EvaluateExePath(packagesDir)
 		test.That(t, err, test.ShouldBeNil)
-		exeDir, err := mod.UnpackedModuleDirectory(packagesDir)
+		exeDir, err := mod.exeDir(packagesDir)
 		test.That(t, err, test.ShouldBeNil)
 		// "entry" is from meta.json.
 		test.That(t, exePath, test.ShouldEqual, filepath.Join(exeDir, "entry"))
@@ -77,7 +77,7 @@ func TestSyntheticModule(t *testing.T) {
 	})
 
 	t.Run("syntheticPackageExeDir", func(t *testing.T) {
-		dir, err := modNeedsSynthetic.UnpackedModuleDirectory(tmp)
+		dir, err := modNeedsSynthetic.exeDir(tmp)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, dir, test.ShouldEqual, filepath.Join(tmp, "data/module/synthetic--"))
 	})
@@ -91,7 +91,7 @@ func TestSyntheticModule(t *testing.T) {
 		// local tarball case
 		syntheticPath, err := modNeedsSynthetic.EvaluateExePath(tmp)
 		test.That(t, err, test.ShouldBeNil)
-		exeDir, err := modNeedsSynthetic.UnpackedModuleDirectory(tmp)
+		exeDir, err := modNeedsSynthetic.exeDir(tmp)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, syntheticPath, test.ShouldEqual, filepath.Join(exeDir, meta.Entrypoint))
 

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -40,10 +40,6 @@ import (
 	rutils "go.viam.com/rdk/utils"
 )
 
-const (
-	defaultFirstRunTimeout = 1 * time.Hour
-)
-
 var (
 	validateConfigTimeout       = 5 * time.Second
 	errMessageExitStatus143     = "exit status 143"

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -1088,23 +1088,7 @@ func (mgr *Manager) FirstRun(ctx context.Context, conf config.Module) error {
 	// Evaluate the Module's FirstRun path. If there is an error we assume
 	// that the first run script does not exist and we debug log and exit quietly.
 	localPackagesDir := packages.LocalPackagesDir(mgr.packagesDir)
-	unpackedModDir, err := conf.UnpackedModuleDirectory(localPackagesDir)
-	if err != nil {
-		logger.Errorw("error finding unpacked module directory", "error", err)
-		return nil
-	}
-
-	// Check if FirstRun already ran succesfully for this module version by
-	// checking for the existence of a marker file.
-	// TODO: add a module method for this?
-	firstRunSuccessPath := unpackedModDir + config.FirstRunSuccessSuffix
-	if _, err := os.Stat(firstRunSuccessPath); !errors.Is(err, os.ErrNotExist) {
-		logger.Info("first run already ran")
-		return nil
-	}
-
-	// TODO: create a "GetMeta" method.
-	firstRunPath, err := conf.EvaluateFirstRunPath(unpackedModDir, logger)
+	firstRunPath, markSuccess, err := conf.EvaluateFirstRunPath(localPackagesDir, logger)
 	if err != nil {
 		// TODO(RSDK-9067): some first run path evaluation errors should be promoted to WARN logs.
 		logger.Debugw("no first run script detected, skipping setup phase", "error", err)
@@ -1195,14 +1179,8 @@ func (mgr *Manager) FirstRun(ctx context.Context, conf config.Module) error {
 	// Mark success by writing a marker file to disk. This is a best
 	// effort; if writing to disk fails the setup phase will run again
 	// for this module and version and we are okay with that.
-	//nolint:gosec // safe
-	markerFile, err := os.Create(firstRunSuccessPath)
-	if err != nil {
+	if err := markSuccess(); err != nil {
 		logger.Errorw("failed to mark success", "error", err)
-	}
-	if err = markerFile.Close(); err != nil {
-		logger.Errorw("failed to close marker file", "error", err)
-
 	}
 	return nil
 }

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -2,12 +2,10 @@
 package modmanager
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"io/fs"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -1083,20 +1081,7 @@ func (m *module) checkReady(ctx context.Context, parentAddr string, logger loggi
 
 // FirstRun is runs a module-specific setup script.
 func (mgr *Manager) FirstRun(ctx context.Context, conf config.Module) error {
-	logger := mgr.logger.Sublogger("first_run").WithFields("module", conf.Name)
-
-	// Evaluate the Module's FirstRun path. If there is an error we assume
-	// that the first run script does not exist and we debug log and exit quietly.
-	localPackagesDir := packages.LocalPackagesDir(mgr.packagesDir)
-	firstRunPath, markSuccess, err := conf.EvaluateFirstRunPath(localPackagesDir, logger)
-	if err != nil {
-		// TODO(RSDK-9067): some first run path evaluation errors should be promoted to WARN logs.
-		logger.Debugw("no first run script detected, skipping setup phase", "error", err)
-		return nil
-	}
-
-	logger = logger.WithFields("module", conf.Name, "path", firstRunPath)
-	logger.Infow("executing first run script")
+	pkgsDir := packages.LocalPackagesDir(mgr.packagesDir)
 
 	// This value is normally set on a field on the [module] struct but it seems like we can safely get it on demand.
 	var dataDir string
@@ -1108,81 +1093,9 @@ func (mgr *Manager) FirstRun(ctx context.Context, conf config.Module) error {
 			return err
 		}
 	}
+	env := getFullEnvironment(conf, dataDir, mgr.viamHomeDir)
 
-	moduleEnvironment := getFullEnvironment(conf, dataDir, mgr.viamHomeDir)
-
-	timeout := defaultFirstRunTimeout
-	if conf.FirstRunTimeout > 0 {
-		timeout = conf.FirstRunTimeout.Unwrap()
-	}
-	cmdCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
-	//nolint:gosec // Yes, we are deliberating executing arbitrary user code here.
-	cmd := exec.CommandContext(cmdCtx, firstRunPath)
-
-	cmd.Env = os.Environ()
-	for key, val := range moduleEnvironment {
-		cmd.Env = append(cmd.Env, key+"="+val)
-	}
-
-	stdOut, err := cmd.StdoutPipe()
-	if err != nil {
-		return err
-	}
-	stdErr, err := cmd.StderrPipe()
-	if err != nil {
-		return err
-	}
-
-	scanOut := bufio.NewScanner(stdOut)
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-
-		for scanOut.Scan() {
-			logger.Infow("got stdio", "output", scanOut.Text())
-		}
-		// This scanner keeps trying to read stdio until the command terminates,
-		// at which point the stdio pipe handle is no longer available. This sometimes
-		// results in an `os.ErrClosed`, which we discard.
-		if err := scanOut.Err(); err != nil && !errors.Is(err, os.ErrClosed) {
-			logger.Errorw("error scanning stdio", "error", err)
-		}
-	}()
-	scanErr := bufio.NewScanner(stdErr)
-	go func() {
-		defer wg.Done()
-
-		for scanErr.Scan() {
-			logger.Warnw("got stderr", "output", scanErr.Text())
-		}
-		// This scanner keeps trying to read stderr until the command terminates,
-		// at which point the stderr pipe handle is no longer available. This sometimes
-		// results in an `os.ErrClosed`, which we discard.
-		if err := scanErr.Err(); err != nil && !errors.Is(err, os.ErrClosed) {
-			logger.Errorw("error scanning stderr", "error", err)
-		}
-	}()
-	if err := cmd.Start(); err != nil {
-		logger.Errorw("failed to start first run script", "error", err)
-		return err
-	}
-	if err := cmd.Wait(); err != nil {
-		logger.Errorw("first run script failed", "error", err)
-		return err
-	}
-	wg.Wait()
-	logger.Info("first run script succeeded")
-
-	// Mark success by writing a marker file to disk. This is a best
-	// effort; if writing to disk fails the setup phase will run again
-	// for this module and version and we are okay with that.
-	if err := markSuccess(); err != nil {
-		logger.Errorw("failed to mark success", "error", err)
-	}
-	return nil
+	return conf.FirstRun(ctx, pkgsDir, dataDir, env, mgr.logger)
 }
 
 func (m *module) startProcess(


### PR DESCRIPTION
### Description

Move the majority of first run logic to `config/module`. Address some issues from the initial implementation of [the setup phase](https://github.com/viamrobotics/rdk/pull/4457).

### Dependencies

* [x] Based on https://github.com/viamrobotics/rdk/pull/4511, merge that PR first

### TODO
* [x] ~Update `EvaluateExePath` to use `getJSONManifest`~ Will leave as a follow-up, just because I'm not sure how well tested this is.