### PR TITLE
RSDK-9181 Log "first run already ran" once

### DIFF
--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -1261,7 +1261,7 @@ func (r *localRobot) reconfigure(ctx context.Context, newConfig *config.Config, 
 	// Run the setup phase for new and modified modules in new config modules before proceeding with reconfiguration.
 	diffMods, err := config.DiffConfigs(*r.Config(), *newConfig, r.revealSensitiveConfigDiffs)
 	if err != nil {
-		r.logger.CErrorw(ctx, "error diffing module configs before before first run", "error", err)
+		r.logger.CErrorw(ctx, "error diffing module configs before first run", "error", err)
 		return
 	}
 	mods := slices.Concat[[]config.Module](diffMods.Added.Modules, diffMods.Modified.Modules)

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -1260,6 +1260,10 @@ func (r *localRobot) reconfigure(ctx context.Context, newConfig *config.Config, 
 
 	// Run the setup phase for new and modified modules in new config modules before proceeding with reconfiguration.
 	diffMods, err := config.DiffConfigs(*r.Config(), *newConfig, r.revealSensitiveConfigDiffs)
+	if err != nil {
+		r.logger.CErrorw(ctx, "error diffing module configs before before first run", "error", err)
+		return
+	}
 	mods := slices.Concat[[]config.Module](diffMods.Added.Modules, diffMods.Modified.Modules)
 	for _, mod := range mods {
 		if err := r.manager.moduleManager.FirstRun(ctx, mod); err != nil {

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -1267,7 +1267,7 @@ func (r *localRobot) reconfigure(ctx context.Context, newConfig *config.Config, 
 	mods := slices.Concat[[]config.Module](diffMods.Added.Modules, diffMods.Modified.Modules)
 	for _, mod := range mods {
 		if err := r.manager.moduleManager.FirstRun(ctx, mod); err != nil {
-			r.logger.CErrorw(ctx, "error executing setup phase", "module", mod.Name, "error", err)
+			r.logger.CErrorw(ctx, "error executing first run", "module", mod.Name, "error", err)
 			return
 		}
 	}


### PR DESCRIPTION
### Description

Update reconfiguration loop to only run first_run script for new and modified modules, instead of all modules in received config. This caused the noop "first run already ran log" to be logged each time we receive a new config if any modules have an associated first run script.

### TODO

* [x] ~Fix `TestStreamState` tests~ Appears to be a flake unrelated to this change per local testing