### PR TITLE
[RSDK-8982, RSDK-9167, RSDK-8979] - Add SetStreamOptions to stream server

### DIFF
--- a/robot/web/stream/server.go
+++ b/robot/web/stream/server.go
@@ -393,6 +393,13 @@ func (server *Server) SetStreamOptions(
 	if err != nil {
 		return nil, fmt.Errorf("failed to resize video source: %w", err)
 	}
+	server.mu.RLock()
+	streamState, ok := server.nameToStreamState[req.Name]
+	server.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("stream %q not found", req.Name)
+	}
+	streamState.Resize()
 	return &streampb.SetStreamOptionsResponse{}, nil
 }
 

--- a/robot/web/stream/server.go
+++ b/robot/web/stream/server.go
@@ -336,6 +336,8 @@ func (server *Server) GetStreamOptions(
 	ctx context.Context,
 	req *streampb.GetStreamOptionsRequest,
 ) (*streampb.GetStreamOptionsResponse, error) {
+	server.mu.RLock()
+	defer server.mu.RUnlock()
 	if req.Name == "" {
 		return nil, errors.New("stream name is required")
 	}

--- a/robot/web/stream/server.go
+++ b/robot/web/stream/server.go
@@ -423,7 +423,10 @@ func (server *Server) resizeVideoSource(name string, width, height int) error {
 		return fmt.Errorf("stream state not found with name %q", name)
 	}
 	resizer := gostream.NewResizeVideoSource(cam, width, height)
-	server.logger.Debug("resizing video source with a hot swap")
+	server.logger.Debugf(
+		"resizing video source to width %d and height %d",
+		width, height,
+	)
 	existing.Swap(resizer)
 	err = streamState.Resize()
 	if err != nil {
@@ -446,9 +449,8 @@ func (server *Server) resetVideoSource(name string) error {
 	if !ok {
 		return fmt.Errorf("stream state not found with name %q", name)
 	}
-	newSwapper := gostream.NewHotSwappableVideoSource(cam)
 	server.logger.Debug("resetting video source")
-	existing.Swap(newSwapper)
+	existing.Swap(cam)
 	err = streamState.Reset()
 	if err != nil {
 		return fmt.Errorf("failed to reset stream %q: %w", name, err)

--- a/robot/web/stream/server.go
+++ b/robot/web/stream/server.go
@@ -381,20 +381,13 @@ func (server *Server) SetStreamOptions(
 	if req.Name == "" {
 		return nil, errors.New("stream name is required")
 	}
-	if _, ok := server.videoSources[req.Name]; !ok {
-		return nil, errors.New("stream name not found")
-	}
 	if req.Resolution == nil {
 		return nil, errors.New("resolution is required")
 	}
 	if req.Resolution.Width <= 0 || req.Resolution.Height <= 0 {
 		return nil, errors.New("invalid resolution, width and height must be greater than 0")
 	}
-	_, err := camera.FromRobot(server.robot, req.Name)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get camera from robot: %w", err)
-	}
-	err = server.resizeVideoSource(req.Name, int(req.Resolution.Width), int(req.Resolution.Height))
+	err := server.resizeVideoSource(req.Name, int(req.Resolution.Width), int(req.Resolution.Height))
 	if err != nil {
 		return nil, fmt.Errorf("failed to resize video source: %w", err)
 	}

--- a/robot/web/stream/server.go
+++ b/robot/web/stream/server.go
@@ -406,11 +406,11 @@ func (server *Server) resizeVideoSource(name string, width, height int) error {
 	}
 	cam, err := camera.FromRobot(server.robot, name)
 	if err != nil {
-		server.logger.Errorw("error getting camera from robot", "error", err)
+		server.logger.Errorf("error getting camera %q from robot", name)
 		return err
 	}
 	resizer := gostream.NewResizeVideoSource(cam, width, height)
-	server.logger.Debug("Resizing video source with swap")
+	server.logger.Debug("resizing video source with swap")
 	existing.Swap(resizer)
 	return nil
 }

--- a/robot/web/stream/server.go
+++ b/robot/web/stream/server.go
@@ -336,8 +336,6 @@ func (server *Server) GetStreamOptions(
 	ctx context.Context,
 	req *streampb.GetStreamOptionsRequest,
 ) (*streampb.GetStreamOptionsResponse, error) {
-	server.mu.RLock()
-	defer server.mu.RUnlock()
 	if req.Name == "" {
 		return nil, errors.New("stream name is required")
 	}

--- a/robot/web/stream/server.go
+++ b/robot/web/stream/server.go
@@ -389,13 +389,13 @@ func (server *Server) SetStreamOptions(
 	if req.Resolution.Width <= 0 || req.Resolution.Height <= 0 {
 		return nil, errors.New("invalid resolution, width and height must be greater than 0")
 	}
+	server.mu.Lock()
+	defer server.mu.Unlock()
 	err := server.resizeVideoSource(req.Name, int(req.Resolution.Width), int(req.Resolution.Height))
 	if err != nil {
 		return nil, fmt.Errorf("failed to resize video source: %w", err)
 	}
-	server.mu.RLock()
 	streamState, ok := server.nameToStreamState[req.Name]
-	server.mu.RUnlock()
 	if !ok {
 		return nil, fmt.Errorf("stream %q not found", req.Name)
 	}
@@ -408,8 +408,6 @@ func (server *Server) SetStreamOptions(
 
 // ResizeVideoSource resizes the video source with the given name.
 func (server *Server) resizeVideoSource(name string, width, height int) error {
-	server.mu.Lock()
-	defer server.mu.Unlock()
 	existing, ok := server.videoSources[name]
 	if !ok {
 		return fmt.Errorf("video source %q not found", name)

--- a/robot/web/stream/server.go
+++ b/robot/web/stream/server.go
@@ -399,7 +399,10 @@ func (server *Server) SetStreamOptions(
 	if !ok {
 		return nil, fmt.Errorf("stream %q not found", req.Name)
 	}
-	streamState.Resize()
+	err = streamState.Resize()
+	if err != nil {
+		return nil, fmt.Errorf("failed to resize stream: %w", err)
+	}
 	return &streampb.SetStreamOptionsResponse{}, nil
 }
 

--- a/robot/web/stream/server.go
+++ b/robot/web/stream/server.go
@@ -378,17 +378,8 @@ func (server *Server) SetStreamOptions(
 	ctx context.Context,
 	req *streampb.SetStreamOptionsRequest,
 ) (*streampb.SetStreamOptionsResponse, error) {
-	if req.Name == "" {
-		return nil, errors.New("stream name is required in request")
-	}
-	if req.Resolution == nil {
-		return nil, fmt.Errorf("resolution is required to resize stream %q", req.Name)
-	}
-	if req.Resolution.Width <= 0 || req.Resolution.Height <= 0 {
-		return nil, fmt.Errorf(
-			"invalid resolution to resize stream %q: width (%d) and height (%d) must be greater than 0",
-			req.Name, req.Resolution.Width, req.Resolution.Height,
-		)
+	if err := validateSetStreamOptionsRequest(req); err != nil {
+		return nil, err
 	}
 	server.mu.Lock()
 	defer server.mu.Unlock()
@@ -728,4 +719,20 @@ retryLoop:
 		return 0, 0, fmt.Errorf("failed to get frame after 5 attempts: %w", err)
 	}
 	return frame.Bounds().Dx(), frame.Bounds().Dy(), nil
+}
+
+func validateSetStreamOptionsRequest(req *streampb.SetStreamOptionsRequest) error {
+	if req.Name == "" {
+		return errors.New("stream name is required in request")
+	}
+	if req.Resolution == nil {
+		return fmt.Errorf("resolution is required to resize stream %q", req.Name)
+	}
+	if req.Resolution.Width <= 0 || req.Resolution.Height <= 0 {
+		return fmt.Errorf(
+			"invalid resolution to resize stream %q: width (%d) and height (%d) must be greater than 0",
+			req.Name, req.Resolution.Width, req.Resolution.Height,
+		)
+	}
+	return nil
 }

--- a/robot/web/stream/state/state.go
+++ b/robot/web/stream/state/state.go
@@ -285,7 +285,7 @@ func (state *StreamState) tick() {
 		state.stopInputStream()
 	// If streamSource is unknown and resized is true, we do not want to attempt passthrough.
 	case state.streamSource == streamSourceUnknown && state.isResized:
-		state.logger.Debug("in a resized state, using gostream")
+		state.logger.Debug("in a resized state and stream source is unknown, defaulting to GoStream")
 		state.Stream.Start()
 		state.streamSource = streamSourceGoStream
 	case state.streamSource == streamSourceUnknown: // && state.activeClients > 0

--- a/robot/web/stream/state/state.go
+++ b/robot/web/stream/state/state.go
@@ -148,6 +148,8 @@ func (mt msgType) String() string {
 		return "Increment"
 	case msgTypeDecrement:
 		return "Decrement"
+	case msgTypeResize:
+		return "Resize"
 	case msgTypeUnknown:
 		fallthrough
 	default:

--- a/robot/web/stream/state/state_test.go
+++ b/robot/web/stream/state/state_test.go
@@ -843,52 +843,52 @@ func TestStreamState(t *testing.T) {
 		test.That(t, unsubscribeCount.Load(), test.ShouldEqual, 0)
 		test.That(t, writeRTPCalledCtx.Err(), test.ShouldBeNil)
 
-		logger.Info("the first Increment() eventually call calls SubscribeRTP()")
-		test.That(t, s.Increment(), test.ShouldBeNil)
-		testutils.WaitForAssertion(t, func(tb testing.TB) {
-			test.That(tb, subscribeRTPCount.Load(), test.ShouldEqual, 1)
-			test.That(tb, unsubscribeCount.Load(), test.ShouldEqual, 0)
-		})
-		// WriteRTP is called
-		<-writeRTPCalledCtx.Done()
-
-		// Call Resize to simulate a resize event. This should stop rtp_passthrough and start gostream.
-		logger.Info("calling Resize() should stop rtp_passthrough and start gostream")
-		test.That(t, s.Resize(), test.ShouldBeNil)
-		testutils.WaitForAssertion(t, func(tb testing.TB) {
-			test.That(tb, unsubscribeCount.Load(), test.ShouldEqual, 1)
-			test.That(tb, startCount.Load(), test.ShouldEqual, 1)
-			test.That(tb, stopCount.Load(), test.ShouldEqual, 0)
+		t.Run("Increment should call SubscribeRTP", func(t *testing.T) {
+			test.That(t, s.Increment(), test.ShouldBeNil)
+			testutils.WaitForAssertion(t, func(tb testing.TB) {
+				test.That(tb, subscribeRTPCount.Load(), test.ShouldEqual, 1)
+				test.That(tb, unsubscribeCount.Load(), test.ShouldEqual, 0)
+			})
+			// WriteRTP is called
+			<-writeRTPCalledCtx.Done()
 		})
 
-		// Make sure that Decrement() calls Stop() as gostream is the data source
-		logger.Info("calling Decrement() should call Stop() as gostream is the data source")
-		test.That(t, s.Decrement(), test.ShouldBeNil)
-		testutils.WaitForAssertion(t, func(tb testing.TB) {
-			test.That(tb, unsubscribeCount.Load(), test.ShouldEqual, 1)
-			test.That(tb, startCount.Load(), test.ShouldEqual, 1)
-			test.That(tb, stopCount.Load(), test.ShouldEqual, 1)
+		t.Run("Resize should stop rtp_passthrough and start gostream", func(t *testing.T) {
+			test.That(t, s.Resize(), test.ShouldBeNil)
+			testutils.WaitForAssertion(t, func(tb testing.TB) {
+				test.That(tb, unsubscribeCount.Load(), test.ShouldEqual, 1)
+				test.That(tb, startCount.Load(), test.ShouldEqual, 1)
+				test.That(tb, stopCount.Load(), test.ShouldEqual, 0)
+			})
 		})
 
-		// Call increment again and make sure that gostream is started
-		// and rtppassthrough is not called
-		logger.Info("calling Increment() should call Start() as gostream is the data source")
-		test.That(t, s.Increment(), test.ShouldBeNil)
-		testutils.WaitForAssertion(t, func(tb testing.TB) {
-			test.That(tb, subscribeRTPCount.Load(), test.ShouldEqual, 1)
-			test.That(tb, unsubscribeCount.Load(), test.ShouldEqual, 1)
-			test.That(tb, startCount.Load(), test.ShouldEqual, 2)
-			test.That(tb, stopCount.Load(), test.ShouldEqual, 1)
+		t.Run("Decrement should call Stop as gostream is the data source", func(t *testing.T) {
+			test.That(t, s.Decrement(), test.ShouldBeNil)
+			testutils.WaitForAssertion(t, func(tb testing.TB) {
+				test.That(tb, unsubscribeCount.Load(), test.ShouldEqual, 1)
+				test.That(tb, startCount.Load(), test.ShouldEqual, 1)
+				test.That(tb, stopCount.Load(), test.ShouldEqual, 1)
+			})
 		})
 
-		// Call decrement again and make sure that gostream is stopped.
-		logger.Info("calling Decrement() should call Stop() as gostream is the data source")
-		test.That(t, s.Decrement(), test.ShouldBeNil)
-		testutils.WaitForAssertion(t, func(tb testing.TB) {
-			test.That(tb, subscribeRTPCount.Load(), test.ShouldEqual, 1)
-			test.That(tb, unsubscribeCount.Load(), test.ShouldEqual, 1)
-			test.That(tb, startCount.Load(), test.ShouldEqual, 2)
-			test.That(tb, stopCount.Load(), test.ShouldEqual, 2)
+		t.Run("Increment should call Start as gostream is the data source", func(t *testing.T) {
+			test.That(t, s.Increment(), test.ShouldBeNil)
+			testutils.WaitForAssertion(t, func(tb testing.TB) {
+				test.That(tb, subscribeRTPCount.Load(), test.ShouldEqual, 1)
+				test.That(tb, unsubscribeCount.Load(), test.ShouldEqual, 1)
+				test.That(tb, startCount.Load(), test.ShouldEqual, 2)
+				test.That(tb, stopCount.Load(), test.ShouldEqual, 1)
+			})
+		})
+
+		t.Run("Decrement should call Stop as gostream is the data source", func(t *testing.T) {
+			test.That(t, s.Decrement(), test.ShouldBeNil)
+			testutils.WaitForAssertion(t, func(tb testing.TB) {
+				test.That(tb, subscribeRTPCount.Load(), test.ShouldEqual, 1)
+				test.That(tb, unsubscribeCount.Load(), test.ShouldEqual, 1)
+				test.That(tb, startCount.Load(), test.ShouldEqual, 2)
+				test.That(tb, stopCount.Load(), test.ShouldEqual, 2)
+			})
 		})
 	})
 }

--- a/robot/web/stream/state/state_test.go
+++ b/robot/web/stream/state/state_test.go
@@ -890,5 +890,36 @@ func TestStreamState(t *testing.T) {
 				test.That(tb, stopCount.Load(), test.ShouldEqual, 2)
 			})
 		})
+
+		t.Run("Increment should call Start as gostream is the data source", func(t *testing.T) {
+			test.That(t, s.Increment(), test.ShouldBeNil)
+			testutils.WaitForAssertion(t, func(tb testing.TB) {
+				test.That(tb, subscribeRTPCount.Load(), test.ShouldEqual, 1)
+				test.That(tb, unsubscribeCount.Load(), test.ShouldEqual, 1)
+				test.That(tb, startCount.Load(), test.ShouldEqual, 3)
+				test.That(tb, stopCount.Load(), test.ShouldEqual, 2)
+			})
+		})
+
+		t.Run("Reset should call Stop as gostream is the current data source and then "+
+			"Subscribe as rtp_passthrough is the new data source", func(t *testing.T) {
+			test.That(t, s.Reset(), test.ShouldBeNil)
+			testutils.WaitForAssertion(t, func(tb testing.TB) {
+				test.That(tb, subscribeRTPCount.Load(), test.ShouldEqual, 2)
+				test.That(tb, unsubscribeCount.Load(), test.ShouldEqual, 1)
+				test.That(tb, startCount.Load(), test.ShouldEqual, 3)
+				test.That(tb, stopCount.Load(), test.ShouldEqual, 3)
+			})
+		})
+
+		t.Run("Decrement should call unsubscribe as rtp_passthrough is the data source", func(t *testing.T) {
+			test.That(t, s.Decrement(), test.ShouldBeNil)
+			testutils.WaitForAssertion(t, func(tb testing.TB) {
+				test.That(tb, subscribeRTPCount.Load(), test.ShouldEqual, 2)
+				test.That(tb, unsubscribeCount.Load(), test.ShouldEqual, 2)
+				test.That(tb, startCount.Load(), test.ShouldEqual, 3)
+				test.That(tb, stopCount.Load(), test.ShouldEqual, 3)
+			})
+		})
 	})
 }

--- a/robot/web/stream/stream_test.go
+++ b/robot/web/stream/stream_test.go
@@ -452,8 +452,17 @@ func TestSetStreamOptions(t *testing.T) {
 		})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, setStreamOptionsResp, test.ShouldNotBeNil)
-
 		// Make sure that video strack is still alive through the peer connection
+		videoCnt := strings.Count(conn.PeerConn().CurrentLocalDescription().SDP, "m=video")
+		test.That(t, videoCnt, test.ShouldEqual, 1)
+	})
+
+	t.Run("SetStreamOptions without resolution field to reset to the original resolution", func(t *testing.T) {
+		setStreamOptionsResp, err := livestreamClient.SetStreamOptions(ctx, &streampb.SetStreamOptionsRequest{
+			Name: "fake-cam-0-0",
+		})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, setStreamOptionsResp, test.ShouldNotBeNil)
 		videoCnt := strings.Count(conn.PeerConn().CurrentLocalDescription().SDP, "m=video")
 		test.That(t, videoCnt, test.ShouldEqual, 1)
 	})
@@ -478,8 +487,16 @@ func TestSetStreamOptions(t *testing.T) {
 		})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, setStreamOptionsResp, test.ShouldNotBeNil)
+		videoCnt := strings.Count(conn.PeerConn().CurrentLocalDescription().SDP, "m=video")
+		test.That(t, videoCnt, test.ShouldEqual, 2)
+	})
 
-		// Make sure that video strack is still alive through the peer connection
+	t.Run("SetStreamOptions reset to original resolution when RTPPassthrough is enabled", func(t *testing.T) {
+		setStreamOptionsResp, err := livestreamClient.SetStreamOptions(ctx, &streampb.SetStreamOptionsRequest{
+			Name: "fake-cam-0-1",
+		})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, setStreamOptionsResp, test.ShouldNotBeNil)
 		videoCnt := strings.Count(conn.PeerConn().CurrentLocalDescription().SDP, "m=video")
 		test.That(t, videoCnt, test.ShouldEqual, 2)
 	})

--- a/robot/web/stream/stream_test.go
+++ b/robot/web/stream/stream_test.go
@@ -403,7 +403,8 @@ func TestSetStreamOptions(t *testing.T) {
 
 	// Test setting stream options with invalid name
 	setStreamOptionsResp, err := livestreamClient.SetStreamOptions(ctx, &streampb.SetStreamOptionsRequest{
-		Name: "invalid-name",
+		Name:       "invalid-name",
+		Resolution: &streampb.Resolution{Width: 320, Height: 240},
 	})
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, setStreamOptionsResp, test.ShouldBeNil)

--- a/robot/web/stream/stream_test.go
+++ b/robot/web/stream/stream_test.go
@@ -414,6 +414,17 @@ func TestSetStreamOptions(t *testing.T) {
 	test.That(t, setStreamOptionsResp, test.ShouldBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "invalid resolution")
 
+	// Try adding stream
+	res, err := livestreamClient.AddStream(ctx, &streampb.AddStreamRequest{
+		Name: "fake-cam-0-0",
+	})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, res, test.ShouldNotBeNil)
+	testutils.WaitForAssertion(t, func(tb testing.TB) {
+		videoCnt := strings.Count(conn.PeerConn().CurrentLocalDescription().SDP, "m=video")
+		test.That(tb, videoCnt, test.ShouldEqual, 1)
+	})
+
 	// Test setting the stream optoins with a valid resolution
 	setStreamOptionsResp, err = livestreamClient.SetStreamOptions(ctx, &streampb.SetStreamOptionsRequest{
 		Name:       "fake-cam-0-0",
@@ -421,4 +432,36 @@ func TestSetStreamOptions(t *testing.T) {
 	})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, setStreamOptionsResp, test.ShouldNotBeNil)
+
+	// Make sure that video strack is still alive through the peer connection
+	videoCnt := strings.Count(conn.PeerConn().CurrentLocalDescription().SDP, "m=video")
+	test.That(t, videoCnt, test.ShouldEqual, 1)
+
+	// try RemoveStream
+	removeRes, err := livestreamClient.RemoveStream(ctx, &streampb.RemoveStreamRequest{
+		Name: "fake-cam-0-0",
+	})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, removeRes, test.ShouldNotBeNil)
+	// testutils.WaitForAssertion(t, func(tb testing.TB) {
+	// 	videoCnt = strings.Count(conn.PeerConn().CurrentLocalDescription().SDP, "m=video")
+	// 	test.That(t, videoCnt, test.ShouldEqual, 0)
+	// })
+
+	// // Get image from camera and verify the resolution
+	// !!! this will not work need to go through webrtc path
+	// cam, err := camera.FromRobot(robot, "fake-cam-0-0")
+	// cam
+	// test.That(t, err, test.ShouldBeNil)
+	// defer cam.Close(ctx)
+	// var errHandlers []gostream.ErrorHandler
+	// stream, err := cam.Stream(ctx, errHandlers...)
+	// test.That(t, err, test.ShouldBeNil)
+	// defer stream.Close(ctx)
+	// img, release, err := stream.Next(ctx)
+	// release()
+	// test.That(t, err, test.ShouldBeNil)
+	// test.That(t, img.Bounds().Dx(), test.ShouldEqual, 320)
+	// test.That(t, img.Bounds().Dy(), test.ShouldEqual, 240)
+
 }


### PR DESCRIPTION
## Description

[RSDK-8982](https://viam.atlassian.net/browse/RSDK-8982), [RSDK-9167](https://viam.atlassian.net/browse/RSDK-9167) [RSDK-8979](https://viam.atlassian.net/browse/RSDK-8979)

This PR adds the `SetStreamOptions` endpoint to the stream server. 
- Validates the requests and performs a hot swap on the video source with a `NewResizeVideoSource`.
- If Resolution is provided, we dispatch a `Resize` msg to the `streamState` handler.
  - If in Passthrough mode, the state transitions to gostream.
  - Prevents attempting to use passthrough during `Increment` and `Decrement` calls.
- If Resolution is not provided, we dispatch a `Reset` msg to the `streamState` handler.
  - Attempts to restart passthrough if available.
- In order to unify RTP `Sequence Number` handling between GoStream and Passthrough paths we now override the Sequence Number header field in the `WriteRTP` method.

## Tests
- CI Tests:
  - Request Validation ✅ 
  - GetImage Fake camera resize swap ✅ 
  - RTPPassthrough fake camera downgrade state transition ✅
  - Video tracks stay alive through resize transition ✅ 
  - Verifies prevention of RTPPassthrough when resized and peers Increment/Decrement ✅ 
  - Gostream back Passthrough reset state transition ✅ 
 - Manual tests (using `NewStreamServiceClient` script as seen below):
   - GetImage livestreams still work ✅ 
     - webcam ✅ 
     - fake cam ✅ 
     - viamrtsp ✅ 
   - Passthrough livestreams still work ✅
     - fake cam ✅ 
     - viamrtsp ✅ 
   - GetImage resize livestreams ✅ 
     - webcam ✅ 
     - fake cam ✅
     - viamrtsp ✅ 
   - Passthrough->GetImage resize livestream ✅
     - fake cam ✅ 
     - viamrtsp ✅ 
   - GetImage->Passthrough reset livestream ✅ 
     - fake cam ✅ 
     - viamrtsp ✅ 
     
___
### Demos
- viamrtsp passthrough -> resize getimage stream via SetStreamOptions

https://github.com/user-attachments/assets/0137c2b2-2b17-49cb-a7c6-637e9e8c3813

- passthrough <-> gostream getimage loop using resize and reset

https://github.com/user-attachments/assets/f6104227-0376-4a26-bfce-c9fdf0e180e4

___
### TODO:
- [x] Test that video tracks survive SetSteamOptions swap.
- [x] Make sure we are safe wrt locking strategy.
- [x] Resize state transition from passthrough -> get_image.
- [x] Figure out how to test stream state transition for passthrough -> get_image.
- [x] Figure out how to prevent passthrough attempts when in resized mode.
- [x] Make sure resizes are working with viamrtsp camera source.
- [x] Fix flaky handoff between Gostream and Passthrough RTP sources.

[RSDK-8982]: https://viam.atlassian.net/browse/RSDK-8982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RSDK-9167]: https://viam.atlassian.net/browse/RSDK-9167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RSDK-8979]: https://viam.atlassian.net/browse/RSDK-8979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

___
### Test Script

```golang
package main

import (
	"context"
	"time"

	streampb "go.viam.com/api/stream/v1"
	rgrpc "go.viam.com/rdk/grpc"
	rdklogger "go.viam.com/rdk/logging"
	"go.viam.com/utils/rpc"
)

func main() {
	logger := rdklogger.NewLogger("main")
	addr := "..."
	keyID := "..."
	apiKey := "..."
	camName := "..."
	ctx := context.Background()
	conn, err := rgrpc.Dial(ctx, addr, logger, rpc.WithEntityCredentials(
		keyID,
		rpc.Credentials{
			Type:    rpc.CredentialsTypeAPIKey,
			Payload: apiKey,
		}))
	if err != nil {
		logger.Error("Failed to dial: %v", err)
		return
	}
	livestreamClient := streampb.NewStreamServiceClient(conn)
	if livestreamClient == nil {
		logger.Error("Failed to create stream service client")
		return
	}
	opts, err := livestreamClient.GetStreamOptions(ctx, &streampb.GetStreamOptionsRequest{
		Name: camName,
	})
	if err != nil {
		logger.Error("Failed to get stream options: %v", err)
		return
	}
	logger.Info("Stream options: %v", opts)
	for {
		for _, resolution := range opts.Resolutions {
			logger.Info("Resizing to %v", resolution)
			_, err = livestreamClient.SetStreamOptions(ctx, &streampb.SetStreamOptionsRequest{
				Name:       camName,
				Resolution: resolution,
			})
			if err != nil {
				logger.Error("Failed to set stream options: %v", err)
				return
			}
			time.Sleep(5 * time.Second)
			logger.Info("Resetting to default")
			_, err = livestreamClient.SetStreamOptions(ctx, &streampb.SetStreamOptionsRequest{
				Name: camName,
			})
			if err != nil {
				logger.Error("Failed to set stream options: %v", err)
				return
			}
			time.Sleep(5 * time.Second)
		}
	}
}

```