### PR TITLE
RSDK-9218: Move upload-artifacts to v4.

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -124,7 +124,7 @@ jobs:
     # note: we do this because uname sees the arm64 kernel underneath the armhf container
     - name: fix platform detection
       run: mv bin/`uname -s`-`uname -m` bin/`uname -s`-armv7l
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: appimage-static-32bit
         path: |
@@ -157,7 +157,7 @@ jobs:
         DPKG_ARCH: armhf
         APPIMAGE_ARCH: armhf
       run: make appimage-arch
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: appimage-armhf
         path: etc/packaging/appimages/deploy

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -53,7 +53,7 @@ jobs:
         BUILD_CHANNEL: ${{ inputs.release_type }}
       run: make server-android
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: viam-server-android
         path: ${{ env.TARGET }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,7 +25,7 @@ jobs:
         brew install ffmpeg
     - name: build
       run: go build ./web/cmd/server
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: viam-server-macos
         path: server

--- a/.github/workflows/motion-benchmarks.yml
+++ b/.github/workflows/motion-benchmarks.yml
@@ -35,30 +35,30 @@ jobs:
 
     - name: Run motion quality tests on main branch
       shell: bash
-      env: 
+      env:
         URL: ${{ github.event.pull_request.base.repo.html_url }}
         SHA: ${{ github.event.pull_request.base.sha }}
       run: |
         cd motion-testing
         go mod edit -replace go.viam.com/rdk=${URL#"https://"}@$SHA
         sudo -Hu testbot bash -lc "go mod tidy && go test ./... -v -run TestDefault --name=$BASELINE"
-        
+
     - name: Run motion quality tests on PR branch
       shell: bash
-      env: 
+      env:
         URL: ${{ github.event.pull_request.head.repo.html_url }}
         SHA: ${{ github.event.pull_request.head.sha }}
       run: |
         cd motion-testing
         go mod edit -replace go.viam.com/rdk=${URL#"https://"}@$SHA
         sudo -Hu testbot bash -lc "go mod tidy && go test ./... -v -run TestDefault --name=$MODIFIED"
-        
+
     - name: Print results
       run: |
         cd motion-testing
         sudo -Hu testbot bash -lc "go test ./... -v -run TestScores --baselineDir=$BASELINE --modifiedDir=$MODIFIED"
         cat results/motion-benchmarks.md
- 
+
     # Now that RDK is public, can't directly comment without token having full read/write access
     # motion-benchmarks-comment.yml will trigger seperately and post the actual comments
 
@@ -67,7 +67,7 @@ jobs:
         echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> pr.env
 
     - name: Upload results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pr-motion-benchmark
         path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Upload test.json
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-${{ matrix.platform_name }}.json
           path: json.log
@@ -147,7 +147,7 @@ jobs:
           sudo --preserve-env=MONGODB_TEST_OUTPUT_URI,GITHUB_SHA,GITHUB_RUN_ID,GITHUB_RUN_NUMBER,GITHUB_RUN_ATTEMPT,GITHUB_X_PR_BASE_SHA,GITHUB_X_PR_BASE_REF,GITHUB_X_HEAD_REF,GITHUB_X_HEAD_SHA,GITHUB_REPOSITORY -Hu testbot bash -lc 'make cover-only'
 
       - name: Upload code coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pr-code-coverage
           path: |


### PR DESCRIPTION
The [breaking changes](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes) documentation is poorly written:
> (1) On self hosted runners, additional [firewall rules](https://github.com/actions/toolkit/tree/main/packages/artifact#breaking-changes) may be required.
>
> (2) Uploading to the same named Artifact multiple times.
>
> Due to how Artifacts are created in this new version, it is no longer possible to upload to the same named Artifact multiple times. You must either split the uploads into multiple Artifacts with different names, or only upload once. Otherwise you will encounter an error.
>
> (3) Limit of Artifacts for an individual job. Each job in a workflow run now has a limit of 500 artifacts.
>
> (4) With v4.4 and later, hidden files are excluded by default.

I don't know if (1) applies to us. For (2), I'm unsure if that applies to:
* The entirety of github?
* The entirety of a repo?
* The entirety of a workflow run?
* Or only within a given "retry" of a workflow run?

For (4), I don't know what v4.4 is? Is that v4.4 of upload-artifacts? I'm certain that hidden files don't apply to us so not a problem.