### PR TITLE
RSDK-9060: Fix docstring for FirstRunTimeout

### DIFF
--- a/config/module.go
+++ b/config/module.go
@@ -42,10 +42,11 @@ type Module struct {
 	Environment map[string]string `json:"env,omitempty"`
 
 	// FirstRunTimeout is the timeout duration for the first run script.
-	// Setting this field to a zero value (e.g. 0 * [time.Second]) will
-	// set the first run timeout to the default value of 1 hour, which
-	// is equivalent to leaving this field unset. If you wish to set an
-	// immediate timeout you can set this field to a negative value.
+	// This field will only be applied if it is a positive value. Supplying a
+	// non-positive will set the first run timeout to the default value of 1 hour,
+	// which is equivalent to leaving this field unset. If you wish to set an
+	// immediate timeout you should set this field to a very small positive value
+	// such as "1ns".
 	FirstRunTimeout goutils.Duration `json:"first_run_timeout,omitempty"`
 
 	// Status refers to the validations done in the APP to make sure a module is configured correctly


### PR DESCRIPTION
Fix-up for https://github.com/viamrobotics/rdk/pull/4511 - the doc string for `FirstRunTimeout` is incorrect. The value _must_ be a positive value or it will not be used.