### PR TITLE
APP-6720 in cli `module download` cmd, show options when platform not found

### DIFF
--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -977,17 +977,22 @@ func DownloadModuleAction(c *cli.Context) error {
 			return fmt.Errorf("version %s not found in versions for module", requestedVersion)
 		}
 	}
-	infof(c.App.ErrWriter, "found version %s", ver.Version)
+	infof(c.App.ErrWriter, "Found version %s", ver.Version)
 	if len(ver.Files) == 0 {
 		return fmt.Errorf("version %s has 0 files uploaded", ver.Version)
 	}
 	platform := c.String(moduleFlagPlatform)
 	if platform == "" {
 		platform = fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
-		infof(c.App.ErrWriter, "using default platform %s", platform)
+		infof(c.App.ErrWriter, "Using current system platform %s", platform)
 	}
 	if !slices.ContainsFunc(ver.Files, func(file *apppb.Uploads) bool { return file.Platform == platform }) {
-		return fmt.Errorf("platform %s not present for version %s", platform, ver.Version)
+		availablePlatforms := make([]string, 0, len(ver.Files))
+		for _, upload := range ver.Files {
+			availablePlatforms = append(availablePlatforms, upload.Platform)
+		}
+		return fmt.Errorf("Platform %s not present for version %s. Available platforms: %s",
+			platform, ver.Version, strings.Join(availablePlatforms, ", "))
 	}
 	include := true
 	packageType := packagespb.PackageType_PACKAGE_TYPE_MODULE

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -991,7 +991,7 @@ func DownloadModuleAction(c *cli.Context) error {
 		for _, upload := range ver.Files {
 			availablePlatforms = append(availablePlatforms, upload.Platform)
 		}
-		return fmt.Errorf("Platform %s not present for version %s. Available platforms: %s",
+		return fmt.Errorf("platform %s not present for version %s. available platforms: %s",
 			platform, ver.Version, strings.Join(availablePlatforms, ", "))
 	}
 	include := true


### PR DESCRIPTION
## What changed
...
## Why
...
## Example output
Error output ('available platforms' on last line is new):
```log
$ viam module download 
Info: Using "http://localhost:8080" as base URL value
Info: found version 0.0.4
Info: using current system platform linux/amd64
Error: Platform linux/amd64 not present for version 0.0.4. available platforms: linux/arm64-distro-debian
```
Success output:
```log
$ viam module download --platform linux/arm64-distro-debian
Info: Using "http://localhost:8080" as base URL value
Info: found version 0.0.4
Info: saving to 0.0.4-linux-arm64-distro-debian/awinter-package-delete-test.tar.gz
```