### PR TITLE
APP-6850 update android build for go 1.23

### DIFF
--- a/android.make
+++ b/android.make
@@ -32,8 +32,10 @@ droid-rdk.%.aar: etc/android/prefix/aarch64 etc/android/prefix/x86_64
 	# we clear CGO_LDFLAGS so this doesn't try (and fail) to link to linuxbrew where present
 	$(eval JNI_ARCH := $(if $(filter arm64,$*),arm64-v8a,x86_64))
 	$(eval CPU_ARCH := $(if $(filter arm64,$*),aarch64,x86_64))
+        # checklinkname here is from https://github.com/wlynxg/anet#how-to-build-with-go-1230-or-later
 	CGO_LDFLAGS= PKG_CONFIG_PATH=$(DROID_PREFIX)/$(CPU_ARCH)/lib/pkgconfig \
 		gomobile bind -v -target android/$* -androidapi 28 -tags no_cgo \
+                -ldflags="-checklinkname=0" \
 		-o $@ ./web/cmd/droid
 	rm -rf droidtmp/jni/$(JNI_ARCH)
 	mkdir -p droidtmp/jni/$(JNI_ARCH)


### PR DESCRIPTION
## What changed
Add linker flag in `droid-rdk.aar` makefile target
## Why
See https://github.com/wlynxg/anet#how-to-build-with-go-1230-or-later -- this is required to work around go:linkname being deprecated.