### PR TITLE
RSDK-8926: Rover canary motor test fail because failure to set pins

### DIFF
--- a/components/motor/gpio/basic.go
+++ b/components/motor/gpio/basic.go
@@ -189,7 +189,7 @@ func (m *Motor) setPWM(ctx context.Context, powerPct float64, extra map[string]i
 	switch m.motorType {
 	case ABPwm, DirectionPwm:
 		if math.Abs(powerPct) <= 0.001 {
-			return m.turnOff(ctx, extra)
+			return m.turnOff(context.Background(), extra)
 		}
 		pwmPin = m.PWM
 	case AB:
@@ -306,7 +306,7 @@ func (m *Motor) Stop(ctx context.Context, extra map[string]interface{}) error {
 	m.opMgr.CancelRunning(ctx)
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.setPWM(ctx, 0, extra)
+	return m.setPWM(context.Background(), 0, extra)
 }
 
 // IsMoving returns if the motor is currently on or off.

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -208,10 +208,11 @@ func (r *localRobot) StopAll(ctx context.Context, extra map[resource.Name]map[st
 		}
 	}
 
+	var errs error
 	for k, v := range resourceErrs {
-		return errors.Errorf("failed to stop component named %s with error %v", k, v)
+		multierr.Combine(errs, errors.Errorf("failed to stop component named %s with error %v", k, v))
 	}
-	return nil
+	return errs
 }
 
 // Config returns a config representing the current state of the robot.

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -210,7 +210,7 @@ func (r *localRobot) StopAll(ctx context.Context, extra map[resource.Name]map[st
 
 	var errs error
 	for k, v := range resourceErrs {
-		multierr.Combine(errs, errors.Errorf("failed to stop component named %s with error %v", k, v))
+		errs = multierr.Combine(errs, errors.Errorf("failed to stop component named %s with error %v", k, v))
 	}
 	return errs
 }

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -193,23 +193,23 @@ func (r *localRobot) StopAll(ctx context.Context, extra map[resource.Name]map[st
 	}
 
 	// Stop all stoppable resources
-	resourceErrs := []string{}
+	resourceErrs := make(map[string]error)
 	for _, name := range r.ResourceNames() {
 		res, err := r.ResourceByName(name)
 		if err != nil {
-			resourceErrs = append(resourceErrs, name.Name)
+			resourceErrs[name.Name] = err
 			continue
 		}
 
 		if actuator, ok := res.(resource.Actuator); ok {
 			if err := actuator.Stop(ctx, extra[name]); err != nil {
-				resourceErrs = append(resourceErrs, name.Name)
+				resourceErrs[name.Name] = err
 			}
 		}
 	}
 
-	if len(resourceErrs) > 0 {
-		return errors.Errorf("failed to stop components named %s", strings.Join(resourceErrs, ","))
+	for k, v := range resourceErrs {
+		return errors.Errorf("failed to stop component named %s with error %v", k, v)
 	}
 	return nil
 }


### PR DESCRIPTION
The context was getting canceled before the pins could be set correctly in order to stop the motor. by using a background context, `Stop()` and `setPWM()` can return while `turnOff` is still setting the pins. Could this also be done with `SelectContextOrWait`? 

I also updated the error return from local_robot.go because it buried the error from `StopAll` in order to see what was actually happening. 