### PR TITLE
RSDK-9136: issues when stopping motor with controls

### DIFF
--- a/components/motor/gpio/basic.go
+++ b/components/motor/gpio/basic.go
@@ -58,10 +58,6 @@ func NewMotor(b board.Board, mc Config, name resource.Name, logger logging.Logge
 		motorType:   motorType,
 	}
 
-	if m.maxRPM == 0 {
-		m.maxRPM = 100
-	}
-
 	switch motorType {
 	case ABPwm, AB:
 		a, err := b.GPIOPinByName(mc.Pins.A)
@@ -104,6 +100,10 @@ func NewMotor(b board.Board, mc Config, name resource.Name, logger logging.Logge
 			return nil, err
 		}
 		m.EnablePinLow = enablePinLow
+	}
+
+	if m.maxRPM == 0 {
+		m.maxRPM = 100
 	}
 
 	return m, nil

--- a/components/motor/gpio/basic.go
+++ b/components/motor/gpio/basic.go
@@ -58,6 +58,10 @@ func NewMotor(b board.Board, mc Config, name resource.Name, logger logging.Logge
 		motorType:   motorType,
 	}
 
+	if m.maxRPM == 0 {
+		m.maxRPM = 100
+	}
+
 	switch motorType {
 	case ABPwm, AB:
 		a, err := b.GPIOPinByName(mc.Pins.A)

--- a/components/motor/gpio/basic_test.go
+++ b/components/motor/gpio/basic_test.go
@@ -168,7 +168,7 @@ func TestMotorDirPWM(t *testing.T) {
 			mc.ResourceName(), logger)
 
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, m.GoFor(ctx, 50, 10, nil), test.ShouldBeError, errors.New("not supported, define max_rpm attribute != 0"))
+		test.That(t, m.GoFor(ctx, 50, 10, nil), test.ShouldBeNil)
 
 		m, err = NewMotor(b, Config{Pins: PinConfig{Direction: "1", EnablePinLow: "2"}, PWMFreq: 4000},
 			mc.ResourceName(), logger)
@@ -191,7 +191,7 @@ func TestMotorDirPWM(t *testing.T) {
 
 	t.Run("motor (DIR/PWM) Off testing", func(t *testing.T) {
 		test.That(t, m.Stop(ctx, nil), test.ShouldBeNil)
-		test.That(t, mustGetGPIOPinByName(b, "1").Get(context.Background()), test.ShouldEqual, false)
+		test.That(t, mustGetGPIOPinByName(b, "1").Get(context.Background()), test.ShouldEqual, true)
 		test.That(t, mustGetGPIOPinByName(b, "2").Get(context.Background()), test.ShouldEqual, true)
 		test.That(t, mustGetGPIOPinByName(b, "1").PWM(context.Background()), test.ShouldEqual, 0)
 		test.That(t, mustGetGPIOPinByName(b, "2").PWM(context.Background()), test.ShouldEqual, 0)
@@ -204,11 +204,11 @@ func TestMotorDirPWM(t *testing.T) {
 
 	t.Run("motor (DIR/PWM) GoFor testing", func(t *testing.T) {
 		test.That(t, m.GoFor(ctx, 50, 0, nil), test.ShouldBeError, motor.NewZeroRevsError())
-		test.That(t, mustGetGPIOPinByName(b, "1").Get(context.Background()), test.ShouldEqual, false)
+		test.That(t, mustGetGPIOPinByName(b, "1").Get(context.Background()), test.ShouldEqual, true)
 		test.That(t, mustGetGPIOPinByName(b, "3").PWM(context.Background()), test.ShouldEqual, 0)
 
 		test.That(t, m.GoFor(ctx, -50, 0, nil), test.ShouldBeError, motor.NewZeroRevsError())
-		test.That(t, mustGetGPIOPinByName(b, "1").Get(context.Background()), test.ShouldEqual, false)
+		test.That(t, mustGetGPIOPinByName(b, "1").Get(context.Background()), test.ShouldEqual, true)
 		test.That(t, mustGetGPIOPinByName(b, "3").PWM(context.Background()), test.ShouldEqual, 0)
 
 		test.That(t, m.Stop(context.Background(), nil), test.ShouldBeNil)
@@ -341,7 +341,7 @@ func TestMotorABNoEncoder(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Run("motor no encoder GoFor testing", func(t *testing.T) {
-		test.That(t, m.GoFor(ctx, 50, 10, nil), test.ShouldBeError, errors.New("not supported, define max_rpm attribute != 0"))
+		test.That(t, m.GoFor(ctx, 50, 10, nil), test.ShouldBeNil)
 	})
 
 	t.Run("motor no encoder GoTo testing", func(t *testing.T) {


### PR DESCRIPTION
in controlled motor, when stop is called, `updateControlBlock` is called, with the maxVel parameter being `cm.real.maxRPM*cm.ticksPerRotation/60`. maxVel cannot be 0 in this function, but `cm.real.maxRPM` didn't have a default value so sometimes it was causing maxVel to be 0 and error when stop was called on the controlled motor