### PR TITLE
RSDK-9037: Add AttachDirectionalAwareness to DoCommand

### DIFF
--- a/components/encoder/single/single_encoder.go
+++ b/components/encoder/single/single_encoder.go
@@ -33,8 +33,14 @@ import (
 
 	"go.viam.com/rdk/components/board"
 	"go.viam.com/rdk/components/encoder"
+	"go.viam.com/rdk/components/motor"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
+)
+
+const (
+	isSingle          = "single"
+	directionAttached = "direction"
 )
 
 var singleModel = resource.DefaultModelFamily.WithModel("single")
@@ -259,4 +265,16 @@ func (e *Encoder) Close(ctx context.Context) error {
 		e.workers.Stop() // This also shuts down the interrupt stream.
 	}
 	return nil
+}
+
+// DoCommand uses a map string to run custom functionality of a single encoder.
+func (e *Encoder) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+	resp := make(map[string]interface{})
+
+	if m, ok := cmd[isSingle].(motor.Motor); ok {
+		e.AttachDirectionalAwareness(m.(DirectionAware))
+		resp[directionAttached] = true
+	}
+
+	return resp, nil
 }

--- a/components/motor/gpio/encoded.go
+++ b/components/motor/gpio/encoded.go
@@ -88,8 +88,8 @@ func newEncodedMotor(
 	}
 
 	if em.rampRate == 0 || em.rampRate > 0.5 {
-		em.rampRate = 0.05 // Use a conservative value by default.
 		em.logger.Warnf("setting ramp rate to default value of 0.05 instead of %v", em.rampRate)
+		em.rampRate = 0.05 // Use a conservative value by default.
 	}
 
 	if em.maxPowerPct < 0 || em.maxPowerPct > 1 {

--- a/components/motor/gpio/encoded_test.go
+++ b/components/motor/gpio/encoded_test.go
@@ -56,6 +56,9 @@ func injectEncoder(vals *injectedState) encoder.Encoder {
 	enc.PropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (encoder.Properties, error) {
 		return encoder.Properties{TicksCountSupported: true}, nil
 	}
+	enc.DoFunc = func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+		return nil, nil
+	}
 	return enc
 }
 

--- a/components/motor/gpio/setup.go
+++ b/components/motor/gpio/setup.go
@@ -209,7 +209,7 @@ func createNewMotor(
 		if err != nil {
 			return nil, err
 		}
-		if resp[directionAttached].(bool) {
+		if resp != nil && resp[directionAttached].(bool) {
 			logger.CInfo(ctx, "direction attached to single encoder from encoded motor")
 		}
 


### PR DESCRIPTION
I'm not sure I think this is any better than the way it was before. I considered the method Olivia suggested by converting the `DoCommand` interface into a motor object, but it couldn't be `motor.Motor`, it would have to be specifically `gpio.Motor` because the interface doesn't implement all the API functions. And imo `gpio.Motor` in `DoCommand` is no better than `single.Encoder` in `setup.go` as it was before. Open to ideas tho, because I don't love this implementation. 

Basically, my goal here was to avoid casting to any specific model types of either motor or encoder. I did have to cast to the `DirectionAware` type, but that seemed better since it's specific to single encoder.