### PR TITLE
RSDK-9222 Serve `restart_status` HTTP endpoint

### DIFF
--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -89,6 +89,9 @@ type localRobot struct {
 	// when a local tarball is updated.
 	localModuleVersions map[string]semver.Version
 	ftdc                *ftdc.FTDC
+
+	// whether the robot is actively reconfiguring
+	reconfiguring atomic.Bool
 }
 
 // ExportResourcesAsDot exports the resource graph as a DOT representation for
@@ -1190,42 +1193,13 @@ func (r *localRobot) applyLocalModuleVersions(cfg *config.Config) {
 }
 
 func (r *localRobot) reconfigure(ctx context.Context, newConfig *config.Config, forceSync bool) {
-	// Maintenance config can be configured to block reconfigure based off of a sensor reading
-	// These sensors can be configured on the main robot, or a remote
-	// In situations where there are conflicting sensor names the following behavior happens
-	// Main robot and remote share sensor name -> main robot sensor is chosen
-	// Only remote has the sensor name -> remote sensor is read
-	// Multiple remotes share a senor name -> conflict error is returned and reconfigure happens
-	// To specify a specific remote sensor use the name format remoteName:sensorName to specify a remote sensor
-	if newConfig.MaintenanceConfig != nil {
-		name, err := resource.NewFromString(newConfig.MaintenanceConfig.SensorName)
-		if err != nil {
-			r.logger.Warnf("sensor_name %s in maintenance config is not in a supported format", newConfig.MaintenanceConfig.SensorName)
-		} else {
-			sensorComponent, err := robot.ResourceFromRobot[sensor.Sensor](r, name)
-			if err != nil {
-				r.logger.Warnf("%s, Starting reconfiguration", err.Error())
-			} else {
-				canReconfigure, err := r.checkMaintenanceSensorReadings(ctx, newConfig.MaintenanceConfig.MaintenanceAllowedKey, sensorComponent)
-				if !canReconfigure {
-					if err != nil {
-						r.logger.CErrorw(ctx, "error reading maintenance sensor", "error", err)
-					} else {
-						r.logger.Info("maintenance_allowed_key found from readings on maintenance sensor. Skipping reconfiguration.")
-					}
-					diff, err := config.DiffConfigs(*r.Config(), *newConfig, false)
-					if err != nil {
-						r.logger.CErrorw(ctx, "error diffing the configs", "error", err)
-					}
-					// NetworkEqual checks if Cloud/Auth/Network are equal between configs
-					if diff != nil && !diff.NetworkEqual {
-						r.logger.Info("Machine reconfiguration skipped but Cloud/Auth/Network config section contain changes and will be applied.")
-					}
-					return
-				}
-				r.logger.Info("maintenance_allowed_key found from readings on maintenance sensor. Starting reconfiguration")
-			}
-		}
+	r.reconfiguring.Store(true)
+	defer func() {
+		r.reconfiguring.Store(false)
+	}()
+
+	if !r.reconfigureAllowed(ctx, newConfig, true) {
+		return
 	}
 
 	r.configRevisionMu.Lock()
@@ -1519,6 +1493,58 @@ func (r *localRobot) Version(ctx context.Context) (robot.VersionResponse, error)
 	return robot.Version()
 }
 
+// reconfigureAllowed returns whether the local robot can reconfigure.
+func (r *localRobot) reconfigureAllowed(ctx context.Context, cfg *config.Config, log bool) bool {
+	// Hack: if we should not log (allowance of reconfiguration is being checked
+	// from the `/restart_status` endpoint), then use a no-op logger. Otherwise
+	// use robot's logger.
+	logger := r.logger
+	if !log {
+		logger = logging.NewBlankLogger("")
+	}
+
+	// Maintenance config can be configured to block reconfigure based off of a sensor reading
+	// These sensors can be configured on the main robot, or a remote
+	// In situations where there are conflicting sensor names the following behavior happens
+	// Main robot and remote share sensor name -> main robot sensor is chosen
+	// Only remote has the sensor name -> remote sensor is read
+	// Multiple remotes share a senor name -> conflict error is returned and reconfigure happens
+	// To specify a specific remote sensor use the name format remoteName:sensorName to specify a remote sensor
+	if cfg.MaintenanceConfig != nil {
+		name, err := resource.NewFromString(cfg.MaintenanceConfig.SensorName)
+		if err != nil {
+			logger.Warnf("sensor_name %s in maintenance config is not in a supported format", cfg.MaintenanceConfig.SensorName)
+		} else {
+			sensorComponent, err := robot.ResourceFromRobot[sensor.Sensor](r, name)
+			if err != nil {
+				logger.Warnf("%s, Starting reconfiguration", err.Error())
+			} else {
+				canReconfigure, err := r.checkMaintenanceSensorReadings(ctx, cfg.MaintenanceConfig.MaintenanceAllowedKey, sensorComponent)
+				if !canReconfigure {
+					if err != nil {
+						logger.CErrorw(ctx, "error reading maintenance sensor", "error", err)
+					} else {
+						logger.Info("maintenance_allowed_key found from readings on maintenance sensor. Skipping reconfiguration.")
+					}
+					diff, err := config.DiffConfigs(*r.Config(), *cfg, false)
+					if err != nil {
+						logger.CErrorw(ctx, "error diffing the configs", "error", err)
+					}
+					// NetworkEqual checks if Cloud/Auth/Network are equal between configs
+					if diff != nil && !diff.NetworkEqual {
+						logger.Info("Machine reconfiguration skipped but Cloud/Auth/Network config section contain changes and will be applied.")
+					}
+					return false
+				}
+				logger.Info("maintenance_allowed_key found from readings on maintenance sensor. Starting reconfiguration")
+			}
+		}
+	}
+
+	// Reconfigure is always allowed in the absence of a MaintenanceConfig.
+	return true
+}
+
 // checkMaintenanceSensorReadings ensures that errors from reading a sensor are handled properly.
 func (r *localRobot) checkMaintenanceSensorReadings(ctx context.Context,
 	maintenanceAllowedKey string, sensor resource.Sensor,
@@ -1542,4 +1568,18 @@ func (r *localRobot) checkMaintenanceSensorReadings(ctx context.Context,
 		return false, errors.Errorf("maintenance_allowed_key %s is not a bool value", maintenanceAllowedKey)
 	}
 	return canReconfigure, nil
+}
+
+// RestartAllowed returns whether the robot can safely be restarted. The robot
+// can be safely restarted if a reconfigure would be allowed, and the robot is
+// not in the middle of a reconfigure.
+func (r *localRobot) RestartAllowed() bool {
+	ctx := context.Background()
+
+	var restartAllowed bool
+	if r.reconfigureAllowed(ctx, r.Config(), false) && !r.reconfiguring.Load() {
+		restartAllowed = true
+	}
+
+	return restartAllowed
 }

--- a/robot/robot.go
+++ b/robot/robot.go
@@ -191,6 +191,9 @@ type LocalRobot interface {
 	// visualization.
 	// DOT reference: https://graphviz.org/doc/info/lang.html
 	ExportResourcesAsDot(index int) (resource.GetSnapshotInfo, error)
+
+	// RestartAllowed returns whether the robot can safely be restarted.
+	RestartAllowed() bool
 }
 
 // A RemoteRobot is a Robot that was created through a connection.


### PR DESCRIPTION
RSDK-9222

Serves a new `restart_status` HTTP endpoint (visible at `localhost:8080/restart_status` for a local robot, for example.) `restart_status` returns JSON in response to a GET request of the form
```
{
    "restart_status": [restart_allowed]
}
```
Where `[restart_allowed]` is one of `true` or `false` depending on whether this `viam-server` instance can be externally restarted by `viam-agent`. 

A `viam-server` instance can be restarted if
1. Reconfigure is allowed per existing maintenance sensor rules
2. The robot handled by `viam-server` is not currently reconfiguring