### PR TITLE
DATA-3385 Fix ConfigureDatabaseUser flow

### DIFF
--- a/cli/data.go
+++ b/cli/data.go
@@ -48,6 +48,8 @@ const (
 	serverErrorMessage = "received error from server"
 
 	viamCaptureDotSubdir = "/.viam/capture/"
+
+	noExistingADFErrCode = "NotFound"
 )
 
 // DataExportAction is the corresponding action for 'data export'.
@@ -929,11 +931,13 @@ func DataConfigureDatabaseUserConfirmation(c *cli.Context) error {
 	}
 
 	res, err := client.dataGetDatabaseConnection(c.String(generalFlagOrgID))
-	if err != nil {
+	// if the error is adf doesn't exist for org yet, continue and skip HasDatabaseUser check
+	if err != nil && !strings.Contains(err.Error(), noExistingADFErrCode) {
 		return err
 	}
 
-	if res.HasDatabaseUser {
+	// skip this check if we don't have an existing ADF instance
+	if err == nil && res.HasDatabaseUser {
 		yellow := "\033[1;33m%s\033[0m"
 		printf(c.App.Writer, yellow, "WARNING!!\n")
 		printf(c.App.Writer, yellow, "You or someone else in your organization have already created a user.\n")


### PR DESCRIPTION
This PR fixes a bug in our ConfigureDatabaseUser flow in the CLI itself. We try to fetch the existing DB user from mongo and if we error, we return and exit. This is done as part of the confirmation of a password change code. However, this causes an edge case to fail. If we do not have an ADF instance and want to trigger creation of one via `viam data database configure --org-id 94380e5a-0df2-4ae8-9b5f-53eaaf507f02 --password *******`, we attempt to look up the existing DB user which doesn't exist. We then return an error to the user saying we can't find their instance. This PR changes this so that if the ADF instance doesn't exist, we skip the confirmation routine. 