### PR TITLE
[RSDK-9315]   Fix modular discovery response

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -1245,8 +1245,13 @@ func (m *module) registerResources(mgr modmaninterface.ModuleManager, logger log
 							m.logger.Errorf("error in modular DiscoverComponents: %s", err)
 							return nil, err
 						}
-
-						return res, nil
+						if len(res.Discovery) > 1 {
+							return nil, errors.New("modular DiscoverComponents response contains more than one discovery")
+						}
+						if len(res.Discovery) == 0 {
+							return nil, errors.New("modular DiscoverComponents response did not contain any discoveries")
+						}
+						return res.Discovery[0].Results.AsMap(), nil
 					},
 				})
 			}

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -1245,13 +1245,14 @@ func (m *module) registerResources(mgr modmaninterface.ModuleManager, logger log
 							m.logger.Errorf("error in modular DiscoverComponents: %s", err)
 							return nil, err
 						}
-						if len(res.Discovery) > 1 {
+						switch len(res.Discovery) {
+						case 0:
+							return nil, errors.New("modular DiscoverComponents response did not contain any discoveries")
+						case 1:
+							return res.Discovery[0].Results.AsMap(), nil
+						default:
 							return nil, errors.New("modular DiscoverComponents response contains more than one discovery")
 						}
-						if len(res.Discovery) == 0 {
-							return nil, errors.New("modular DiscoverComponents response did not contain any discoveries")
-						}
-						return res.Discovery[0].Results.AsMap(), nil
 					},
 				})
 			}

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -36,19 +36,7 @@ import (
 	rutils "go.viam.com/rdk/utils"
 )
 
-type testDiscoveryResult struct {
-	Discovery []testDiscoveryItem `json:"discovery"`
-}
-
-type testDiscoveryItem struct {
-	Query   testDiscoveryQuery `json:"query"`
-	Results map[string]string  `json:"results"`
-}
-
-type testDiscoveryQuery struct {
-	Subtype string `json:"subtype"`
-	Model   string `json:"model"`
-}
+type testDiscoveryResult map[string]interface{}
 
 func setupSocketWithRobot(t *testing.T) string {
 	t.Helper()
@@ -1369,7 +1357,7 @@ func TestBadModuleFailsFast(t *testing.T) {
 	test.That(t, err.Error(), test.ShouldContainSubstring, "module test-module exited too quickly after attempted startup")
 }
 
-func TestModularDiscovery(t *testing.T) {
+func TestModularDiscoverFunc(t *testing.T) {
 	ctx := context.Background()
 	logger := logging.NewTestLogger(t)
 
@@ -1425,11 +1413,10 @@ func TestModularDiscovery(t *testing.T) {
 			test.That(t, err, test.ShouldBeNil)
 			t.Logf("Casted struct: %+v", discoveryResult)
 
-			test.That(t, len(discoveryResult.Discovery), test.ShouldEqual, 1)
-			discovery := discoveryResult.Discovery[0]
-			test.That(t, discovery.Query.Subtype, test.ShouldEqual, "rdk:component:generic")
-			test.That(t, discovery.Query.Model, test.ShouldEqual, "rdk:test:helper")
-			test.That(t, discovery.Results["extra"], test.ShouldEqual, tc.expectedExtra)
+			test.That(t, len(discoveryResult), test.ShouldEqual, 1)
+			extraStr, ok := discoveryResult["extra"].(string)
+			test.That(t, ok, test.ShouldBeTrue)
+			test.That(t, extraStr, test.ShouldEqual, tc.expectedExtra)
 		})
 	}
 }

--- a/module/testmodule/main.go
+++ b/module/testmodule/main.go
@@ -57,7 +57,7 @@ func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) err
 				if !ok {
 					return nil, errors.New("'extra' value must be a string")
 				}
-				return map[string]string{
+				return map[string]interface{}{
 					"extra": extraValStr,
 				}, nil
 			},


### PR DESCRIPTION
[RSDK-9315](https://viam.atlassian.net/browse/RSDK-9315)

Let it be known that in the current janky discovery world, `DiscoveryFunc` and `DiscoverComponents` are not 1:1. "Modular discovery," which is basically a `DiscoveryFunc` served via the `DiscoverComponents` method, should _not_ contain any crap like subtype, api etc. because it is serving one model only, even though it uses the `DiscoverComponents` method to go over the wire. This is partially what went wrong with the serialization in the first place.

The other part of went wrong was that we should not be returning raw pb. Let's use `asMap` to get rid of the proto wrappings.
 
[RSDK-9315]: https://viam.atlassian.net/browse/RSDK-9315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ