### PR TITLE
add relative crop to transform camera and overlay crop box

### DIFF
--- a/components/camera/transformpipeline/mods.go
+++ b/components/camera/transformpipeline/mods.go
@@ -194,7 +194,9 @@ func newCropTransform(
 		if conf.XMin <= 1. && conf.YMin <= 1. && conf.XMax <= 1. && conf.YMax <= 1. {
 			cropRel = []float64{conf.XMin, conf.YMin, conf.XMax, conf.YMax}
 		} else {
-			return nil, camera.UnspecifiedStream, errors.New("if using relative bounds between 0 and 1 for cropping, all parameter attributes must be between 0 and 1")
+			return nil,
+				camera.UnspecifiedStream,
+				errors.New("if using relative bounds between 0 and 1 for cropping, all parameter attributes must be between 0 and 1")
 		}
 	} else {
 		cropRect = image.Rect(int(conf.XMin), int(conf.YMin), int(conf.XMax), int(conf.YMax))
@@ -208,7 +210,7 @@ func newCropTransform(
 	return src, stream, err
 }
 
-func (cs *cropSource) relToAbsCrop(ctx context.Context, img image.Image) image.Rectangle {
+func (cs *cropSource) relToAbsCrop(img image.Image) image.Rectangle {
 	xMin, yMin, xMax, yMax := cs.cropRel[0], cs.cropRel[1], cs.cropRel[2], cs.cropRel[3]
 	// Get image bounds
 	bounds := img.Bounds()
@@ -235,7 +237,7 @@ func (cs *cropSource) Read(ctx context.Context) (image.Image, func(), error) {
 		return nil, nil, err
 	}
 	if cs.cropWindow.Empty() && len(cs.cropRel) != 0 {
-		cs.cropWindow = cs.relToAbsCrop(ctx, orig)
+		cs.cropWindow = cs.relToAbsCrop(orig)
 	}
 	switch cs.imgType {
 	case camera.ColorStream, camera.UnspecifiedStream:

--- a/components/camera/transformpipeline/mods_test.go
+++ b/components/camera/transformpipeline/mods_test.go
@@ -94,6 +94,24 @@ func TestCrop(t *testing.T) {
 	test.That(t, out, test.ShouldHaveSameTypeAs, &image.NRGBA{})
 	test.That(t, rs.Close(context.Background()), test.ShouldBeNil)
 
+	// relative crop but you just overlay the box
+	am = utils.AttributeMap{
+		"x_min_px":         0.2,
+		"x_max_px":         0.4,
+		"y_min_px":         0.3,
+		"y_max_px":         0.99,
+		"overlay_crop_box": true,
+	}
+	rs, stream, err = newCropTransform(context.Background(), source, camera.ColorStream, am)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, stream, test.ShouldEqual, camera.ColorStream)
+	out, _, err = camera.ReadImage(context.Background(), rs)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, out.Bounds().Dx(), test.ShouldEqual, 100)
+	test.That(t, out.Bounds().Dy(), test.ShouldEqual, 100)
+	test.That(t, out, test.ShouldHaveSameTypeAs, &image.NRGBA{})
+	test.That(t, rs.Close(context.Background()), test.ShouldBeNil)
+
 	//  error - crop limits are outside of original image
 	am = utils.AttributeMap{"x_min_px": 1000, "x_max_px": 2000, "y_min_px": 300, "y_max_px": 400}
 	rs, stream, err = newCropTransform(context.Background(), source, camera.ColorStream, am)

--- a/components/camera/transformpipeline/mods_test.go
+++ b/components/camera/transformpipeline/mods_test.go
@@ -94,6 +94,40 @@ func TestCrop(t *testing.T) {
 	test.That(t, out, test.ShouldHaveSameTypeAs, &image.NRGBA{})
 	test.That(t, rs.Close(context.Background()), test.ShouldBeNil)
 
+	// the edge case of cropping to one pixel
+	am = utils.AttributeMap{
+		"x_min_px": 0.0,
+		"x_max_px": 1.0,
+		"y_min_px": 0.0,
+		"y_max_px": 1.0,
+	}
+	rs, stream, err = newCropTransform(context.Background(), source, camera.ColorStream, am)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, stream, test.ShouldEqual, camera.ColorStream)
+	out, _, err = camera.ReadImage(context.Background(), rs)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, out.Bounds().Dx(), test.ShouldEqual, 1)
+	test.That(t, out.Bounds().Dy(), test.ShouldEqual, 1)
+	test.That(t, out, test.ShouldHaveSameTypeAs, &image.NRGBA{})
+	test.That(t, rs.Close(context.Background()), test.ShouldBeNil)
+
+	// quadrant cropping
+	am = utils.AttributeMap{
+		"x_min_px": 0.5,
+		"x_max_px": 1.0,
+		"y_min_px": 0.5,
+		"y_max_px": 1.0,
+	}
+	rs, stream, err = newCropTransform(context.Background(), source, camera.ColorStream, am)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, stream, test.ShouldEqual, camera.ColorStream)
+	out, _, err = camera.ReadImage(context.Background(), rs)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, out.Bounds().Dx(), test.ShouldEqual, 50)
+	test.That(t, out.Bounds().Dy(), test.ShouldEqual, 50)
+	test.That(t, out, test.ShouldHaveSameTypeAs, &image.NRGBA{})
+	test.That(t, rs.Close(context.Background()), test.ShouldBeNil)
+
 	// relative crop but you just overlay the box
 	am = utils.AttributeMap{
 		"x_min_px":         0.2,

--- a/components/camera/transformpipeline/mods_test.go
+++ b/components/camera/transformpipeline/mods_test.go
@@ -64,6 +64,7 @@ func TestCrop(t *testing.T) {
 	test.That(t, out.Bounds().Dy(), test.ShouldEqual, 10)
 	test.That(t, out, test.ShouldHaveSameTypeAs, &image.NRGBA{})
 	test.That(t, rs.Close(context.Background()), test.ShouldBeNil)
+
 	// crop has limits bigger than the image dimensions, but just takes the window
 	am = utils.AttributeMap{"x_min_px": 127, "x_max_px": 150, "y_min_px": 71, "y_max_px": 110}
 	rs, stream, err = newCropTransform(context.Background(), source, camera.ColorStream, am)
@@ -73,6 +74,24 @@ func TestCrop(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, out.Bounds().Dx(), test.ShouldEqual, 1)
 	test.That(t, out.Bounds().Dy(), test.ShouldEqual, 1)
+	test.That(t, rs.Close(context.Background()), test.ShouldBeNil)
+
+	// relative crop
+	dummyImg := image.NewRGBA(image.Rect(0, 0, 100, 100))
+	source = gostream.NewVideoSource(&fake.StaticSource{ColorImg: dummyImg}, prop.Video{})
+	out, _, err = camera.ReadImage(context.Background(), source)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, out.Bounds().Dx(), test.ShouldEqual, 100)
+	test.That(t, out.Bounds().Dy(), test.ShouldEqual, 100)
+	am = utils.AttributeMap{"x_min_px": 0.2, "x_max_px": 0.4, "y_min_px": 0.3, "y_max_px": 0.99}
+	rs, stream, err = newCropTransform(context.Background(), source, camera.ColorStream, am)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, stream, test.ShouldEqual, camera.ColorStream)
+	out, _, err = camera.ReadImage(context.Background(), rs)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, out.Bounds().Dx(), test.ShouldEqual, 20)
+	test.That(t, out.Bounds().Dy(), test.ShouldEqual, 69)
+	test.That(t, out, test.ShouldHaveSameTypeAs, &image.NRGBA{})
 	test.That(t, rs.Close(context.Background()), test.ShouldBeNil)
 
 	//  error - crop limits are outside of original image


### PR DESCRIPTION
Right now, you have to give absolute pixel values to do a crop with the transform camera.

This update allows you to do both -- if you put in values between 0 and 1 for the crop, then it will interpret the crop as using relative proportions of the image

Also, a new attribute called `overlay_crop_box` allows you to not actually carry out the crop, but just overlay the cropping box on the original image. This is a way to visualize where the crop would be applied.

@randhid just FYI since it's touching cameras