### PR TITLE
override nodejs to unbreak antique builds

### DIFF
--- a/.github/workflows/staticbuild.yml
+++ b/.github/workflows/staticbuild.yml
@@ -57,7 +57,10 @@ jobs:
     - name: override nodejs
       # note: the antique image intentionally has an old ubuntu with old GLIBC; github's node requires a newer one.
       # we do this hack so actions can run.
-      run: ln --force --symbolic $(which node) /__e/node20/node
+      run: |
+        mount
+        df -h
+        sudo ln --force --symbolic $(which node) /__e/node20/node
 
     - name: Check out code
       if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'

--- a/.github/workflows/staticbuild.yml
+++ b/.github/workflows/staticbuild.yml
@@ -8,7 +8,7 @@ on:
         type: string
       no-upload:
         type: boolean
-        description: if present, don't upload
+        description: "no-upload: if checked, don't upload"
   workflow_call:
     inputs:
       release_type:

--- a/.github/workflows/staticbuild.yml
+++ b/.github/workflows/staticbuild.yml
@@ -60,11 +60,11 @@ jobs:
     steps:
     - name: override nodejs
       # note: the antique image intentionally has an old ubuntu with old GLIBC; github's node requires a newer one.
-      # we do this hack so actions can run.
+      # actions require this /__e/node20/bin/node file, so we override it.
       run: |
-        mount
-        df -h
-        sudo ln --force --symbolic $(which node) /__e/node20/node
+        mkdir -p __e/node20/bin/
+        ln --force --symbolic $(which node) /__e/node20/bin/node
+        /__e/node20/bin/node --version
 
     - name: Check out code
       if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'

--- a/.github/workflows/staticbuild.yml
+++ b/.github/workflows/staticbuild.yml
@@ -113,7 +113,7 @@ jobs:
       run: echo "date=`date +%F`" >> $GITHUB_OUTPUT
 
     - name: Upload Files (Testing)
-      if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' && !inputs.no-upload }}
+      if: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'push') && !inputs.no-upload }}
       uses: google-github-actions/upload-cloud-storage@v0.10.4
       with:
         headers: "cache-control: no-cache"
@@ -124,7 +124,7 @@ jobs:
         gzip: false
 
     - name: Upload Manifest (Testing)
-      if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' && !inputs.no-upload }}
+      if: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'push') && !inputs.no-upload }}
       uses: google-github-actions/upload-cloud-storage@v0.10.4
       with:
         headers: "cache-control: no-cache"
@@ -150,7 +150,7 @@ jobs:
 
   static_test:
     name: Static Test
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' && !inputs.no-upload }}
+    if: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'push') && !inputs.no-upload }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/staticbuild.yml
+++ b/.github/workflows/staticbuild.yml
@@ -48,6 +48,9 @@ jobs:
     container:
       image: ${{ matrix.image }}
       options: --platform ${{ matrix.platform }}
+      volumes:
+      # otherwise we get a 'read-only filesystem' error when symlinking over this
+      - /tmp/node20:/__e/node20
     timeout-minutes: 15
     outputs:
       date: ${{ steps.build_date.outputs.date }}

--- a/.github/workflows/staticbuild.yml
+++ b/.github/workflows/staticbuild.yml
@@ -54,13 +54,10 @@ jobs:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: 'true'
 
     steps:
-    - name: nodejs overrides
-      run: |
-        which node
-        ls -ls /usr/bin/node
-        /usr/bin/node --version
-        ls -ls /__e/node20/bin
-        /__e/node20/bin/node -version
+    - name: override nodejs
+      # note: the antique image intentionally has an old ubuntu with old GLIBC; github's node requires a newer one.
+      # we do this hack so actions can run.
+      run: ln --force --symbolic $(which node) /__e/node20/node
 
     - name: Check out code
       if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'

--- a/.github/workflows/staticbuild.yml
+++ b/.github/workflows/staticbuild.yml
@@ -62,7 +62,7 @@ jobs:
       # note: the antique image intentionally has an old ubuntu with old GLIBC; github's node requires a newer one.
       # actions require this /__e/node20/bin/node file, so we override it.
       run: |
-        mkdir -p __e/node20/bin/
+        mkdir -p /__e/node20/bin/
         ln --force --symbolic $(which node) /__e/node20/bin/node
         /__e/node20/bin/node --version
 

--- a/.github/workflows/staticbuild.yml
+++ b/.github/workflows/staticbuild.yml
@@ -5,6 +5,7 @@ on:
     inputs:
       release_type:
         required: true
+        default: latest
         type: string
       no-upload:
         type: boolean

--- a/.github/workflows/staticbuild.yml
+++ b/.github/workflows/staticbuild.yml
@@ -113,7 +113,7 @@ jobs:
       run: echo "date=`date +%F`" >> $GITHUB_OUTPUT
 
     - name: Upload Files (Testing)
-      if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' && !inputs.no-upload
+      if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' && !inputs.no-upload }}
       uses: google-github-actions/upload-cloud-storage@v0.10.4
       with:
         headers: "cache-control: no-cache"
@@ -124,7 +124,7 @@ jobs:
         gzip: false
 
     - name: Upload Manifest (Testing)
-      if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' && !inputs.no-upload
+      if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' && !inputs.no-upload }}
       uses: google-github-actions/upload-cloud-storage@v0.10.4
       with:
         headers: "cache-control: no-cache"
@@ -150,7 +150,7 @@ jobs:
 
   static_test:
     name: Static Test
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' && !inputs.no-upload
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' && !inputs.no-upload }}
     strategy:
       fail-fast: false
       matrix:
@@ -197,7 +197,7 @@ jobs:
   static_deploy:
     name: Static Deploy
     needs: static_test
-    if: !inputs.no-upload
+    if: ${{ !inputs.no-upload }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/staticbuild.yml
+++ b/.github/workflows/staticbuild.yml
@@ -51,6 +51,14 @@ jobs:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: 'true'
 
     steps:
+    - name: nodejs overrides
+      run: |
+        which node
+        ls -ls /usr/bin/node
+        /usr/bin/node --version
+        ls -ls /__e/node20/bin
+        /__e/node20/bin/node -version
+
     - name: Check out code
       if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
       uses: actions/checkout@v3

--- a/.github/workflows/staticbuild.yml
+++ b/.github/workflows/staticbuild.yml
@@ -6,6 +6,9 @@ on:
       release_type:
         required: true
         type: string
+      no-upload:
+        type: boolean
+        description: if present, don't upload
   workflow_call:
     inputs:
       release_type:
@@ -110,7 +113,7 @@ jobs:
       run: echo "date=`date +%F`" >> $GITHUB_OUTPUT
 
     - name: Upload Files (Testing)
-      if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
+      if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' && !inputs.no-upload
       uses: google-github-actions/upload-cloud-storage@v0.10.4
       with:
         headers: "cache-control: no-cache"
@@ -121,7 +124,7 @@ jobs:
         gzip: false
 
     - name: Upload Manifest (Testing)
-      if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
+      if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' && !inputs.no-upload
       uses: google-github-actions/upload-cloud-storage@v0.10.4
       with:
         headers: "cache-control: no-cache"
@@ -147,7 +150,7 @@ jobs:
 
   static_test:
     name: Static Test
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' && !inputs.no-upload
     strategy:
       fail-fast: false
       matrix:
@@ -194,6 +197,7 @@ jobs:
   static_deploy:
     name: Static Deploy
     needs: static_test
+    if: !inputs.no-upload
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## What changed
- in antique build, symlink `/__e/node20/node` to the container's node 16 intallation
- incidental: add `no-upload` bool to workflow_dispatch for the static build workflow (to support my testing today)
## Why
The actions nodejs install (`/__e/node20/node`) now requires GLIBC 2_28 and we have 2_27; antique builds are failing as a result, example [here](https://github.com/viamrobotics/rdk/actions/runs/12038915350/job/33566401901#step:3:18). Context: the antique container intentionally links against old GLIBC for broad compatibility.
## Successful run
https://github.com/viamrobotics/rdk/actions/runs/12039219859