### PR TITLE
[RSDK-9364] - Move to debug log for rtp subcribe err

### DIFF
--- a/components/camera/client.go
+++ b/components/camera/client.go
@@ -422,7 +422,7 @@ func (c *client) SubscribeRTP(
 		return sub, err
 	}
 	g := utils.NewGuard(func() {
-		c.logger.CInfo(ctx, "Error subscribing to RTP. Closing passthrough buffer.")
+		c.logger.CDebug(ctx, "Error subscribing to RTP. Closing passthrough buffer.")
 		rtpPacketBuffer.Close()
 	})
 	defer g.OnFail()


### PR DESCRIPTION
## Description
This is to avoid spamming logs when using gostream livestream feed from a camera with `Subscribe` defined but erroring out. Ex: viamrtsp listening to an h265 feed.