### PR TITLE
RSDK-9368 - Remove log arg in module generation code

### DIFF
--- a/cli/module_generate/_templates/go/tmpl-main.go
+++ b/cli/module_generate/_templates/go/tmpl-main.go
@@ -15,7 +15,7 @@ func main() {
 }
 
 func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) error {
-	{{.ModuleCamel}}, err := module.NewModuleFromArgs(ctx, logger)
+	{{.ModuleCamel}}, err := module.NewModuleFromArgs(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
It got out of sync as a result of https://github.com/viamrobotics/rdk/commit/517e861b2bc11b01f184067935f73c1e238bd8d2
tested locally

cc: @michaellee1019 