### PR TITLE
APP-6819: Adding the CLI command to get/set support-email

### DIFF
--- a/app/app_client_test.go
+++ b/app/app_client_test.go
@@ -730,6 +730,30 @@ func TestAppClient(t *testing.T) {
 		test.That(t, resp, test.ShouldResemble, expectedOrganizations)
 	})
 
+	t.Run("SetSupportEmail", func(t *testing.T) {
+		grpcClient.OrganizationSetSupportEmailFunc = func(
+			ctx context.Context, in *pb.OrganizationSetSupportEmailRequest, opts ...grpc.CallOption,
+		) (*pb.OrganizationSetSupportEmailResponse, error) {
+			test.That(t, in.OrgId, test.ShouldEqual, organizationID)
+			return &pb.OrganizationSetSupportEmailResponse{}, nil
+		}
+
+		err := client.OrganizationSetSupportEmail(context.Background(), organizationID, "test-email")
+		test.That(t, err, test.ShouldBeNil)
+	})
+
+	t.Run("GetSupportEmail", func(t *testing.T) {
+		grpcClient.OrganizationGetSupportEmailFunc = func(
+			ctx context.Context, in *pb.OrganizationGetSupportEmailRequest, opts ...grpc.CallOption,
+		) (*pb.OrganizationGetSupportEmailResponse, error) {
+			test.That(t, in.OrgId, test.ShouldEqual, organizationID)
+			return &pb.OrganizationGetSupportEmailResponse{Email: "test-email"}, nil
+		}
+		resp, err := client.OrganizationGetSupportEmail(context.Background(), organizationID)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, resp, test.ShouldEqual, "test-email")
+	})
+
 	t.Run("GetOrganizationsWithAccessToLocation", func(t *testing.T) {
 		expectedOrganizationIdentities := []*OrganizationIdentity{&organizationIdentity}
 		grpcClient.GetOrganizationsWithAccessToLocationFunc = func(

--- a/cli/app.go
+++ b/cli/app.go
@@ -123,6 +123,8 @@ const (
 
 	cpFlagRecursive = "recursive"
 	cpFlagPreserve  = "preserve"
+
+	organizationFlagSupportEmail = "support-email"
 )
 
 var commonFilterFlags = []cli.Flag{
@@ -327,6 +329,42 @@ var app = &cli.App{
 					Name:   "list",
 					Usage:  "list organizations for the current user",
 					Action: ListOrganizationsAction,
+				},
+				{
+					Name:      "support-email",
+					Usage:     "manage the support email for an organization",
+					UsageText: createUsageText("organizations support-email", []string{generalFlagOrgID}, true),
+					Subcommands: []*cli.Command{
+						{
+							Name:  "set",
+							Usage: "set the support email for an organization",
+							Flags: []cli.Flag{
+								&cli.StringFlag{
+									Name:     generalFlagOrgID,
+									Required: true,
+									Usage:    "the org to set the support email for",
+								},
+								&cli.StringFlag{
+									Name:     organizationFlagSupportEmail,
+									Required: true,
+									Usage:    "the org to set the support email for",
+								},
+							},
+							Action: OrganizationsSupportEmailSetAction,
+						},
+						{
+							Name:  "get",
+							Usage: "get the support email for an organization",
+							Flags: []cli.Flag{
+								&cli.StringFlag{
+									Name:     generalFlagOrgID,
+									Required: true,
+									Usage:    "the org to get the support email for",
+								},
+							},
+							Action: OrganizationsSupportEmailGetAction,
+						},
+					},
 				},
 				{
 					Name:      "api-key",

--- a/cli/app.go
+++ b/cli/app.go
@@ -347,7 +347,7 @@ var app = &cli.App{
 								&cli.StringFlag{
 									Name:     organizationFlagSupportEmail,
 									Required: true,
-									Usage:    "the org to set the support email for",
+									Usage:    "the support email to set for the organization",
 								},
 							},
 							Action: OrganizationsSupportEmailSetAction,

--- a/cli/client.go
+++ b/cli/client.go
@@ -110,6 +110,73 @@ func (c *viamClient) listOrganizationsAction(cCtx *cli.Context) error {
 	return nil
 }
 
+// OrganizationsSupportEmailSetAction corresponds to `organizations support-email set`.
+func OrganizationsSupportEmailSetAction(cCtx *cli.Context) error {
+	c, err := newViamClient(cCtx)
+	if err != nil {
+		return err
+	}
+
+	orgID := cCtx.String(generalFlagOrgID)
+	if orgID == "" {
+		return errors.New("cannot set support email without an organization ID")
+	}
+
+	supportEmail := cCtx.String(organizationFlagSupportEmail)
+	if supportEmail == "" {
+		return errors.New("cannot set support email to an empty string")
+	}
+
+	return c.organizationsSupportEmailSetAction(cCtx, orgID, supportEmail)
+}
+
+func (c *viamClient) organizationsSupportEmailSetAction(cCtx *cli.Context, orgID, supportEmail string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+
+	_, err := c.client.OrganizationSetSupportEmail(c.c.Context, &apppb.OrganizationSetSupportEmailRequest{
+		OrgId: orgID,
+		Email: supportEmail,
+	})
+	if err != nil {
+		return err
+	}
+	printf(cCtx.App.Writer, "Successfully set support email for organization %q to %q", orgID, supportEmail)
+	return nil
+}
+
+// OrganizationsSupportEmailGetAction corresponds to `organizations support-email get`.
+func OrganizationsSupportEmailGetAction(cCtx *cli.Context) error {
+	c, err := newViamClient(cCtx)
+	if err != nil {
+		return err
+	}
+
+	orgID := cCtx.String(generalFlagOrgID)
+	if orgID == "" {
+		return errors.New("cannot get support email without an organization ID")
+	}
+
+	return c.organizationsSupportEmailGetAction(cCtx, orgID)
+}
+
+func (c *viamClient) organizationsSupportEmailGetAction(cCtx *cli.Context, orgID string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+
+	resp, err := c.client.OrganizationGetSupportEmail(c.c.Context, &apppb.OrganizationGetSupportEmailRequest{
+		OrgId: orgID,
+	})
+	if err != nil {
+		return err
+	}
+
+	printf(cCtx.App.Writer, "Support email for organization %q: %q", orgID, resp.GetEmail())
+	return nil
+}
+
 // ListLocationsAction is the corresponding Action for 'locations list'.
 func ListLocationsAction(c *cli.Context) error {
 	client, err := newViamClient(c)

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -202,6 +202,41 @@ func TestListOrganizationsAction(t *testing.T) {
 	test.That(t, out.messages[2], test.ShouldContainSubstring, "mandalorians")
 }
 
+func TestSetSupportEmailAction(t *testing.T) {
+	setSupportEmailFunc := func(ctx context.Context, in *apppb.OrganizationSetSupportEmailRequest,
+		opts ...grpc.CallOption,
+	) (*apppb.OrganizationSetSupportEmailResponse, error) {
+		return &apppb.OrganizationSetSupportEmailResponse{}, nil
+	}
+	asc := &inject.AppServiceClient{
+		OrganizationSetSupportEmailFunc: setSupportEmailFunc,
+	}
+
+	cCtx, ac, out, errOut := setup(asc, nil, nil, nil, nil, "token")
+
+	test.That(t, ac.organizationsSupportEmailSetAction(cCtx, "test-org", "test-email"), test.ShouldBeNil)
+	test.That(t, len(errOut.messages), test.ShouldEqual, 0)
+	test.That(t, len(out.messages), test.ShouldEqual, 1)
+}
+
+func TestGetSupportEmailAction(t *testing.T) {
+	getSupportEmailFunc := func(ctx context.Context, in *apppb.OrganizationGetSupportEmailRequest,
+		opts ...grpc.CallOption,
+	) (*apppb.OrganizationGetSupportEmailResponse, error) {
+		return &apppb.OrganizationGetSupportEmailResponse{Email: "test-email"}, nil
+	}
+	asc := &inject.AppServiceClient{
+		OrganizationGetSupportEmailFunc: getSupportEmailFunc,
+	}
+
+	cCtx, ac, out, errOut := setup(asc, nil, nil, nil, nil, "token")
+
+	test.That(t, ac.organizationsSupportEmailGetAction(cCtx, "test-org"), test.ShouldBeNil)
+	test.That(t, len(errOut.messages), test.ShouldEqual, 0)
+	test.That(t, len(out.messages), test.ShouldEqual, 1)
+	test.That(t, out.messages[0], test.ShouldContainSubstring, "test-email")
+}
+
 func TestTabularDataByFilterAction(t *testing.T) {
 	pbStruct, err := protoutils.StructToStructPb(map[string]interface{}{"bool": true, "string": "true", "float": float64(1)})
 	test.That(t, err, test.ShouldBeNil)


### PR DESCRIPTION
This PR adds functionality to get / set a support email at the org level from the CLI. This is used for white-labelled billing. 

@benjirewis @stuqdog I just want to make sure there is nothing I am missing here with test coverage + CLI additions. Thank you for the 👀 on this PR! 

Manual Testing Against Staging:
<img width="731" alt="Screenshot 2024-12-04 at 10 39 17 AM" src="https://github.com/user-attachments/assets/0bd30ab9-e815-4c8f-b5ef-7c08a195156a">
