### PR TITLE
RSDK-9266: improve comments in golang module templates

### DIFF
--- a/cli/module_generate/_templates/go/models/tmpl-module.go
+++ b/cli/module_generate/_templates/go/models/tmpl-module.go
@@ -40,8 +40,8 @@ type Config struct {
 
 // Validate ensures all parts of the config are valid and important fields exist. 
 // Returns implicit dependencies based on the config.
-// The path is the JSON path in your robot's config, not the config struct, to the
-// resource being validated; e.g. "components.0"
+// The path is the JSON path in your robot's config (not the `Config` struct) to the
+// resource being validated; e.g. "components.0".
 func (cfg *Config) Validate(path string) ([]string, error) {
 	// Add config validation code here
 	 return nil, nil

--- a/cli/module_generate/_templates/go/models/tmpl-module.go
+++ b/cli/module_generate/_templates/go/models/tmpl-module.go
@@ -18,17 +18,30 @@ func init() {
 }
 
 type Config struct {
-	// Put config attributes here
+	/*
+	Put config attributes here. There should be public/exported fields
+	with a `json` parameter at the end of each attribute.
 
-	/* if your model  does not need a config,
-	   replace *Config in the init function with resource.NoNativeConfig */
+	If your model does not need a config, replace *Config in the init 
+	function with resource.NoNativeConfig
+
+	Example config struct:
+		type Config struct {
+			Pin   string `json:"pin"`
+			Board string `json:"board"`
+			MinDeg *float64 `json:"min_angle_deg,omitempty"`
+		}
+	*/
 
 	/* Uncomment this if your model does not need to be validated
 	    and has no implicit dependecies. */
 	// resource.TriviallyValidateConfig
-
 }
 
+// Validate ensures all parts of the config are valid and important fields exist. 
+// Returns implicit dependencies based on the config.
+// The path is the JSON path in your robot's config, not the config struct, to the
+// resource being validated; e.g. "components.0"
 func (cfg *Config) Validate(path string) ([]string, error) {
 	// Add config validation code here
 	 return nil, nil

--- a/cli/module_generate/_templates/go/models/tmpl-module.go
+++ b/cli/module_generate/_templates/go/models/tmpl-module.go
@@ -21,16 +21,16 @@ type Config struct {
 	/*
 	Put config attributes here. There should be public/exported fields
 	with a `json` parameter at the end of each attribute.
-
-	If your model does not need a config, replace *Config in the init 
-	function with resource.NoNativeConfig
-
+	
 	Example config struct:
 		type Config struct {
 			Pin   string `json:"pin"`
 			Board string `json:"board"`
 			MinDeg *float64 `json:"min_angle_deg,omitempty"`
 		}
+
+	If your model does not need a config, replace *Config in the init 
+	function with resource.NoNativeConfig
 	*/
 
 	/* Uncomment this if your model does not need to be validated

--- a/cli/module_generate/scripts/tmpl-module
+++ b/cli/module_generate/scripts/tmpl-module
@@ -19,17 +19,30 @@ func init() {
 }
 
 type Config struct {
-	// Put config attributes here
+	/*
+	Put config attributes here. There should be public/exported fields
+	with a `json` parameter at the end of each attribute.
 
-	/* if your model  does not need a config,
-	   replace *Config in the init function with resource.NoNativeConfig */
+	If your model does not need a config, replace *Config in the init 
+	function with resource.NoNativeConfig
+
+	Example config struct:
+		type Config struct {
+			Pin   string `json:"pin"`
+			Board string `json:"board"`
+			MinDeg *float64 `json:"min_angle_deg,omitempty"`
+		}
+	*/
 
 	/* Uncomment this if your model does not need to be validated
 	    and has no implicit dependecies. */
 	// resource.TriviallyValidateConfig
-
 }
 
+// Validate ensures all parts of the config are valid and important fields exist. 
+// Returns implicit dependencies based on the config.
+// The path is the JSON path in your robot's config, not the config struct, to the
+// resource being validated; e.g. "components.0"
 func (cfg *Config) Validate(path string) ([]string, error) {
 	// Add config validation code here
 	 return nil, nil

--- a/cli/module_generate/scripts/tmpl-module
+++ b/cli/module_generate/scripts/tmpl-module
@@ -41,8 +41,8 @@ type Config struct {
 
 // Validate ensures all parts of the config are valid and important fields exist. 
 // Returns implicit dependencies based on the config.
-// The path is the JSON path in your robot's config, not the config struct, to the
-// resource being validated; e.g. "components.0"
+// The path is the JSON path in your robot's config (not the `Config` struct) to the
+// resource being validated; e.g. "components.0".
 func (cfg *Config) Validate(path string) ([]string, error) {
 	// Add config validation code here
 	 return nil, nil

--- a/cli/module_generate/scripts/tmpl-module
+++ b/cli/module_generate/scripts/tmpl-module
@@ -22,16 +22,16 @@ type Config struct {
 	/*
 	Put config attributes here. There should be public/exported fields
 	with a `json` parameter at the end of each attribute.
-
-	If your model does not need a config, replace *Config in the init 
-	function with resource.NoNativeConfig
-
+	
 	Example config struct:
 		type Config struct {
 			Pin   string `json:"pin"`
 			Board string `json:"board"`
 			MinDeg *float64 `json:"min_angle_deg,omitempty"`
 		}
+
+	If your model does not need a config, replace *Config in the init 
+	function with resource.NoNativeConfig
 	*/
 
 	/* Uncomment this if your model does not need to be validated


### PR DESCRIPTION
[Jira ticket](https://viam.atlassian.net/browse/RSDK-9266)

Changes:
- add more clarifying details of what to put in config struct
- add example config struct
- describe what `Validate()` does
- explain what `path` parameter is

Tested by running the module generator locally