### PR TITLE
[RSDK-9314]   Fully deprecate data.GetExtraFromContext

### DIFF
--- a/components/camera/client.go
+++ b/components/camera/client.go
@@ -248,7 +248,7 @@ func (c *client) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, err
 	if ctx.Value(data.FromDMContextKey{}) == true {
 		extra[data.FromDMString] = true
 	}
-	extraStruct, err := goprotoutils.StructToStructPb(extra)
+	extraStructPb, err := goprotoutils.StructToStructPb(extra)
 	if err != nil {
 		return nil, err
 	}
@@ -256,7 +256,7 @@ func (c *client) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, err
 	resp, err := c.client.GetPointCloud(ctx, &pb.GetPointCloudRequest{
 		Name:     c.name,
 		MimeType: utils.MimeTypePCD,
-		Extra:    extraStruct,
+		Extra:    extraStructPb,
 	})
 	getPcdSpan.End()
 	if err != nil {

--- a/components/camera/client.go
+++ b/components/camera/client.go
@@ -244,7 +244,11 @@ func (c *client) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, err
 
 	ctx, getPcdSpan := trace.StartSpan(ctx, "camera::client::NextPointCloud::GetPointCloud")
 
-	ext, err := data.GetExtraFromContext(ctx)
+	extra := make(map[string]interface{})
+	if ctx.Value(data.FromDMContextKey{}) == true {
+		extra[data.FromDMString] = true
+	}
+	extraStruct, err := goprotoutils.StructToStructPb(extra)
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +256,7 @@ func (c *client) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, err
 	resp, err := c.client.GetPointCloud(ctx, &pb.GetPointCloudRequest{
 		Name:     c.name,
 		MimeType: utils.MimeTypePCD,
-		Extra:    ext,
+		Extra:    extraStruct,
 	})
 	getPcdSpan.End()
 	if err != nil {

--- a/data/collector.go
+++ b/data/collector.go
@@ -383,13 +383,3 @@ func InvalidInterfaceErr(api resource.API) error {
 func FailedToReadErr(component, method string, err error) error {
 	return errors.Errorf("failed to get reading of method %s of component %s: %v", method, component, err)
 }
-
-// GetExtraFromContext sets the extra struct with "fromDataManagement": true if the flag is true in the context.
-// Deprecated: Use camera.FromContext instead.
-func GetExtraFromContext(ctx context.Context) (*structpb.Struct, error) {
-	extra := make(map[string]interface{})
-	if ctx.Value(FromDMContextKey{}) == true {
-		extra[FromDMString] = true
-	}
-	return protoutils.StructToStructPb(extra)
-}

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -1223,13 +1223,13 @@ func (m *module) registerResources(mgr modmaninterface.ModuleManager, logger log
 						return mgr.AddResource(ctx, conf, DepsToNames(deps))
 					},
 					Discover: func(ctx context.Context, logger logging.Logger, extra map[string]interface{}) (interface{}, error) {
-						extraStruct, err := structpb.NewStruct(extra)
+						extraStructPb, err := structpb.NewStruct(extra)
 						if err != nil {
 							return nil, err
 						}
 						req := &robotpb.DiscoverComponentsRequest{
 							Queries: []*robotpb.DiscoveryQuery{
-								{Subtype: apiCopy.API.String(), Model: modelCopy.String(), Extra: extraStruct},
+								{Subtype: apiCopy.API.String(), Model: modelCopy.String(), Extra: extraStructPb},
 							},
 						}
 


### PR DESCRIPTION
[RSDK-9314](https://viam.atlassian.net/browse/RSDK-9314)

[RSDK-9314]: https://viam.atlassian.net/browse/RSDK-9314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

That point cloud method is the only usage of the helper. 