### PR TITLE
APP-7128 windows build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,10 @@ full-static:
 	mkdir -p bin/static
 	go build -tags no_cgo,osusergo,netgo -ldflags="-extldflags=-static $(COMMON_LDFLAGS)" -o bin/static/viam-server-$(shell go env GOARCH) ./web/cmd/server
 
+windows:
+	mkdir -p bin/windows
+	GOOS=windows go build -tags no_cgo -ldflags="-extldflags=-static $(COMMON_LDFLAGS)" -o bin/windows/viam-server-$(shell go env GOARCH) ./web/cmd/server
+
 server-static-compressed: server-static
 	upx --best --lzma $(BIN_OUTPUT_PATH)/viam-server
 

--- a/services/datamanager/builtin/disk_summary_logger.go
+++ b/services/datamanager/builtin/disk_summary_logger.go
@@ -8,7 +8,6 @@ import (
 
 	"go.viam.com/rdk/data"
 	"go.viam.com/rdk/logging"
-	"go.viam.com/rdk/utils/diskusage"
 )
 
 // diskSummaryLogger logs a summary of the capture directory and additional
@@ -51,7 +50,7 @@ func (poller *diskSummaryLogger) reconfigure(dirs []string, interval time.Durati
 				for i, s := range summary {
 					if i == 0 {
 						poller.logger.Info("datamanager disk state summary:")
-						poller.logger.Info(diskusage.Statfs(dirs[i]))
+						poller.logDiskUsage(dirs[i])
 					}
 					var (
 						dataTimeRange string

--- a/services/datamanager/builtin/disk_summary_logger_posix.go
+++ b/services/datamanager/builtin/disk_summary_logger_posix.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin
+//go:build !windows
 
 package builtin
 

--- a/services/datamanager/builtin/disk_summary_logger_posix.go
+++ b/services/datamanager/builtin/disk_summary_logger_posix.go
@@ -1,0 +1,9 @@
+//go:build linux || darwin
+
+package builtin
+
+import "go.viam.com/rdk/utils/diskusage"
+
+func (poller *diskSummaryLogger) logDiskUsage(dir string) {
+	poller.logger.Info(diskusage.Statfs(dir))
+}

--- a/services/datamanager/builtin/disk_summary_logger_windows.go
+++ b/services/datamanager/builtin/disk_summary_logger_windows.go
@@ -1,0 +1,5 @@
+package builtin
+
+func (poller *diskSummaryLogger) logDiskUsage(dir string) {
+	poller.logger.Warn("can't log disk usage yet on windows")
+}

--- a/services/datamanager/builtin/sync/file_deletion.go
+++ b/services/datamanager/builtin/sync/file_deletion.go
@@ -2,7 +2,6 @@ package sync
 
 import (
 	"context"
-	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -11,7 +10,6 @@ import (
 
 	"github.com/benbjohnson/clock"
 	"github.com/pkg/errors"
-
 	"go.viam.com/rdk/data"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/utils/diskusage"
@@ -54,47 +52,6 @@ func deleteExcessFilesOnSchedule(
 	}
 }
 
-func maybeDeleteExcessFiles(
-	ctx context.Context,
-	fileTracker *fileTracker,
-	captureDir string,
-	deleteEveryNth int,
-	clock clock.Clock,
-	logger logging.Logger,
-) {
-	start := clock.Now()
-	logger.Debug("checking disk usage")
-	usage, err := diskusage.Statfs(captureDir)
-	logger.Infof("disk usage: %s", usage)
-	if err != nil {
-		logger.Error(errors.Wrap(err, "error checking file system stats"))
-		return
-	}
-
-	if usage.SizeBytes == 0 {
-		logger.Error("captureDir partition has size zero")
-		return
-	}
-	deletedFileCount, err := deleteExcessFiles(
-		ctx,
-		fileTracker,
-		usage,
-		captureDir,
-		deleteEveryNth,
-		logger)
-
-	duration := clock.Since(start)
-
-	switch {
-	case err != nil:
-		logger.Errorw("error deleting cached datacapture files", "error", err, "execution time", duration.String())
-	case deletedFileCount > 0:
-		logger.Infof("%d files have been deleted to avoid the disk filling up, execution time: %s", deletedFileCount, duration.String())
-	default:
-		logger.Infof("no files deleted, execution time: %s", duration)
-	}
-}
-
 func deleteExcessFiles(
 	ctx context.Context,
 	fileTracker *fileTracker,
@@ -118,34 +75,6 @@ func deleteExcessFiles(
 
 	logger.Warnf("current disk usage of the data capture directory exceeds threshold (%f)", CaptureDirToFSUsageRatio)
 	return deleteFiles(ctx, fileTracker, deleteEveryNth, captureDir, logger)
-}
-
-func shouldDeleteBasedOnDiskUsage(
-	ctx context.Context,
-	usage diskusage.DiskUsage,
-	captureDirPath string,
-	logger logging.Logger,
-) (bool, error) {
-	usedSpace := 1.0 - usage.AvailablePercent()
-	if usedSpace < FSThresholdToTriggerDeletion {
-		logger.Debugf("disk not full enough. Threshold: %s, Used space: %s, %s",
-			fmt.Sprintf("%.2f", FSThresholdToTriggerDeletion*100)+"%",
-			fmt.Sprintf("%.2f", usedSpace*100)+"%",
-			usage)
-		return false, nil
-	}
-	// Walk the dir to get capture stats
-	shouldDelete, err := exceedsDeletionThreshold(
-		ctx,
-		captureDirPath,
-		float64(usage.SizeBytes),
-		CaptureDirToFSUsageRatio,
-	)
-	if err != nil && !shouldDelete {
-		logger.Warnf("Disk nearing capacity but data capture directory is below %f of that size, file deletion will not run",
-			CaptureDirToFSUsageRatio)
-	}
-	return shouldDelete, err
 }
 
 // returns false, nil if the threshold is not exceeded

--- a/services/datamanager/builtin/sync/file_deletion.go
+++ b/services/datamanager/builtin/sync/file_deletion.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/benbjohnson/clock"
 	"github.com/pkg/errors"
+
 	"go.viam.com/rdk/data"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/utils/diskusage"

--- a/services/datamanager/builtin/sync/file_deletion_posix.go
+++ b/services/datamanager/builtin/sync/file_deletion_posix.go
@@ -1,0 +1,82 @@
+//go:build !windows
+
+package sync
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/benbjohnson/clock"
+	"github.com/pkg/errors"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/utils/diskusage"
+)
+
+func maybeDeleteExcessFiles(
+	ctx context.Context,
+	fileTracker *fileTracker,
+	captureDir string,
+	deleteEveryNth int,
+	clock clock.Clock,
+	logger logging.Logger,
+) {
+	start := clock.Now()
+	logger.Debug("checking disk usage")
+	usage, err := diskusage.Statfs(captureDir)
+	logger.Infof("disk usage: %s", usage)
+	if err != nil {
+		logger.Error(errors.Wrap(err, "error checking file system stats"))
+		return
+	}
+
+	if usage.SizeBytes == 0 {
+		logger.Error("captureDir partition has size zero")
+		return
+	}
+	deletedFileCount, err := deleteExcessFiles(
+		ctx,
+		fileTracker,
+		usage,
+		captureDir,
+		deleteEveryNth,
+		logger)
+
+	duration := clock.Since(start)
+
+	switch {
+	case err != nil:
+		logger.Errorw("error deleting cached datacapture files", "error", err, "execution time", duration.String())
+	case deletedFileCount > 0:
+		logger.Infof("%d files have been deleted to avoid the disk filling up, execution time: %s", deletedFileCount, duration.String())
+	default:
+		logger.Infof("no files deleted, execution time: %s", duration)
+	}
+}
+
+func shouldDeleteBasedOnDiskUsage(
+	ctx context.Context,
+	usage diskusage.DiskUsage,
+	captureDirPath string,
+	logger logging.Logger,
+) (bool, error) {
+	usedSpace := 1.0 - usage.AvailablePercent()
+	if usedSpace < FSThresholdToTriggerDeletion {
+		logger.Debugf("disk not full enough. Threshold: %s, Used space: %s, %s",
+			fmt.Sprintf("%.2f", FSThresholdToTriggerDeletion*100)+"%",
+			fmt.Sprintf("%.2f", usedSpace*100)+"%",
+			usage)
+		return false, nil
+	}
+	// Walk the dir to get capture stats
+	shouldDelete, err := exceedsDeletionThreshold(
+		ctx,
+		captureDirPath,
+		float64(usage.SizeBytes),
+		CaptureDirToFSUsageRatio,
+	)
+	if err != nil && !shouldDelete {
+		logger.Warnf("Disk nearing capacity but data capture directory is below %f of that size, file deletion will not run",
+			CaptureDirToFSUsageRatio)
+	}
+	return shouldDelete, err
+}

--- a/services/datamanager/builtin/sync/file_deletion_posix.go
+++ b/services/datamanager/builtin/sync/file_deletion_posix.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/benbjohnson/clock"
 	"github.com/pkg/errors"
+
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/utils/diskusage"
 )

--- a/services/datamanager/builtin/sync/file_deletion_windows.go
+++ b/services/datamanager/builtin/sync/file_deletion_windows.go
@@ -1,0 +1,47 @@
+package sync
+
+import (
+	"context"
+
+	"github.com/benbjohnson/clock"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/utils/diskusage"
+)
+
+func maybeDeleteExcessFiles(
+	ctx context.Context,
+	fileTracker *fileTracker,
+	captureDir string,
+	deleteEveryNth int,
+	clock clock.Clock,
+	logger logging.Logger,
+) {
+	start := clock.Now()
+	deletedFileCount, err := deleteExcessFiles(
+		ctx,
+		fileTracker,
+		diskusage.DiskUsage{},
+		captureDir,
+		deleteEveryNth,
+		logger)
+
+	duration := clock.Since(start)
+
+	switch {
+	case err != nil:
+		logger.Errorw("error deleting cached datacapture files", "error", err, "execution time", duration.String())
+	case deletedFileCount > 0:
+		logger.Infof("%d files have been deleted to avoid the disk filling up, execution time: %s", deletedFileCount, duration.String())
+	default:
+		logger.Infof("no files deleted, execution time: %s", duration)
+	}
+}
+
+func shouldDeleteBasedOnDiskUsage(
+	ctx context.Context,
+	usage diskusage.DiskUsage,
+	captureDirPath string,
+	logger logging.Logger,
+) (bool, error) {
+	return false, nil
+}

--- a/web/server/entrypoint_windows.go
+++ b/web/server/entrypoint_windows.go
@@ -4,12 +4,9 @@ package server
 
 import (
 	"go.viam.com/rdk/gostream"
-	"go.viam.com/rdk/gostream/codec/opus"
 )
 
 func makeStreamConfig() gostream.StreamConfig {
-	var streamConfig gostream.StreamConfig
 	// TODO(RSDK-1771): support video on windows
-	streamConfig.AudioEncoderFactory = opus.NewEncoderFactory()
-	return streamConfig
+	return gostream.StreamConfig{}
 }


### PR DESCRIPTION
## What changed
- datamanager + entrypoint build tag changes to allow RDK to build with GOOS=windows
- `make windows` target in makefile
## Why
Keeping our options open for windows support. WSL is a better route for us for now (because of systemd support), but there are potential benefits to running un-sandboxed so I rehabbed this. Note that [unix sockets dropped in 2017](https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/).
## Manual testing
- the process starts on windows without WSL
- the device turns green in webapp
- still figuring out module connectivity. Status: Working on updates. 29% complete. Don't turn off your computer.