### PR TITLE
RSDK-9441 clean up app wrappers

### DIFF
--- a/app/app_client.go
+++ b/app/app_client.go
@@ -116,9 +116,9 @@ type RobotPart struct {
 	Secret           string
 	Robot            string
 	LocationID       string
-	RobotConfig      *map[string]interface{}
+	RobotConfig      map[string]interface{}
 	LastAccess       *time.Time
-	UserSuppliedInfo *map[string]interface{}
+	UserSuppliedInfo map[string]interface{}
 	MainPart         bool
 	FQDN             string
 	LocalFQDN        string
@@ -143,16 +143,16 @@ type LogEntry struct {
 	Time       *time.Time
 	LoggerName string
 	Message    string
-	Caller     *map[string]interface{}
+	Caller     map[string]interface{}
 	Stack      string
-	Fields     []*map[string]interface{}
+	Fields     []map[string]interface{}
 }
 
 // Fragment stores the information of a fragment.
 type Fragment struct {
 	ID                string
 	Name              string
-	Fragment          *map[string]interface{}
+	Fragment          map[string]interface{}
 	OrganizationOwner string
 	Public            bool
 	CreatedOn         *time.Time
@@ -1955,14 +1955,12 @@ func robotPartFromProto(part *pb.RobotPart) *RobotPart {
 	for _, secret := range part.Secrets {
 		secrets = append(secrets, sharedSecretFromProto(secret))
 	}
-	var cfg, info *map[string]interface{}
+	var cfg, info map[string]interface{}
 	if part.RobotConfig != nil {
-		m := part.RobotConfig.AsMap()
-		cfg = &m
+		cfg = part.RobotConfig.AsMap()
 	}
 	if part.UserSuppliedInfo != nil {
-		m := part.UserSuppliedInfo.AsMap()
-		info = &m
+		info = part.UserSuppliedInfo.AsMap()
 	}
 	lastUpdated := part.LastUpdated.AsTime()
 	return &RobotPart{
@@ -2011,18 +2009,16 @@ func logEntryFromProto(log *common.LogEntry) *LogEntry {
 		t := log.Time.AsTime()
 		entryTime = &t
 	}
-	var caller *map[string]interface{}
+	var caller map[string]interface{}
 	if log.Caller != nil {
-		m := log.Caller.AsMap()
-		caller = &m
+		caller = log.Caller.AsMap()
 	}
-	var fields []*map[string]interface{}
+	var fields []map[string]interface{}
 	for _, field := range log.Fields {
 		if field == nil {
 			continue
 		}
-		f := field.AsMap()
-		fields = append(fields, &f)
+		fields = append(fields, field.AsMap())
 	}
 	return &LogEntry{
 		Host:       log.Host,
@@ -2040,10 +2036,9 @@ func fragmentFromProto(fragment *pb.Fragment) *Fragment {
 	if fragment == nil {
 		return nil
 	}
-	var frag *map[string]interface{}
+	var frag map[string]interface{}
 	if fragment.Fragment != nil {
-		f := fragment.Fragment.AsMap()
-		frag = &f
+		frag = fragment.Fragment.AsMap()
 	}
 	var createdOn, lastUpdated *time.Time
 	if fragment.CreatedOn != nil {

--- a/app/app_client_test.go
+++ b/app/app_client_test.go
@@ -246,8 +246,8 @@ var (
 		RobotMainPartID: partID,
 	}
 	robotConfig           = map[string]interface{}{"name": name, "ID": robotID}
-	pbRobotConfig, _      = protoutils.StructToStructPb(*robotPart.RobotConfig)
-	pbUserSuppliedInfo, _ = protoutils.StructToStructPb(*robotPart.UserSuppliedInfo)
+	pbRobotConfig, _      = protoutils.StructToStructPb(robotPart.RobotConfig)
+	pbUserSuppliedInfo, _ = protoutils.StructToStructPb(robotPart.UserSuppliedInfo)
 	userSuppliedInfo      = map[string]interface{}{"userID": userID}
 	robotPart             = RobotPart{
 		ID:               partID,
@@ -256,9 +256,9 @@ var (
 		Secret:           secret,
 		Robot:            robotID,
 		LocationID:       locationID,
-		RobotConfig:      &robotConfig,
+		RobotConfig:      robotConfig,
 		LastAccess:       &lastAccess,
-		UserSuppliedInfo: &userSuppliedInfo,
+		UserSuppliedInfo: userSuppliedInfo,
 		MainPart:         mainPart,
 		FQDN:             fqdn,
 		LocalFQDN:        localFQDN,
@@ -294,11 +294,11 @@ var (
 		Time:       &timestamp,
 		LoggerName: loggerName,
 		Message:    message,
-		Caller:     &caller,
+		Caller:     caller,
 		Stack:      stack,
-		Fields:     []*map[string]interface{}{&field},
+		Fields:     []map[string]interface{}{field},
 	}
-	pbCaller, _ = protoutils.StructToStructPb(*logEntry.Caller)
+	pbCaller, _ = protoutils.StructToStructPb(logEntry.Caller)
 	pbField, _  = protoutils.StructToStructPb(field)
 	pbLogEntry  = common.LogEntry{
 		Host:       logEntry.Host,
@@ -373,7 +373,7 @@ var (
 	fragment                    = Fragment{
 		ID:                fragmentID,
 		Name:              name,
-		Fragment:          &f,
+		Fragment:          f,
 		OrganizationOwner: organizationOwner,
 		Public:            public,
 		CreatedOn:         &createdOn,

--- a/app/billing_client_test.go
+++ b/app/billing_client_test.go
@@ -28,7 +28,7 @@ const (
 	digits                       = "1234"
 	invoiceID                    = "invoice_id"
 	invoiceAmount        float64 = 100.12
-	status                       = "status"
+	statusString                 = "status"
 	balance              float64 = 73.21
 	billingOwnerOrgID            = "billing_owner_organization_id"
 )
@@ -73,7 +73,7 @@ var (
 		ID:            invoiceID,
 		InvoiceDate:   &invoiceDate,
 		InvoiceAmount: invoiceAmount,
-		Status:        status,
+		Status:        statusString,
 		DueDate:       &dueDate,
 		PaidDate:      &paidDate,
 	}

--- a/app/common.go
+++ b/app/common.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	mltrainingpb "go.viam.com/api/app/mltraining/v1"
-	"google.golang.org/protobuf/types/known/anypb"
 )
 
 // Constants used throughout app.
@@ -41,13 +40,6 @@ const (
 	// ModelFrameworkONNX specifies a ONNX model framework.
 	ModelFrameworkONNX
 )
-
-// GenericProtoMessage contains an arbitrary serialized protocol buffer message
-// along with a URL that describes the type of serialized message.
-type GenericProtoMessage struct {
-	TypeURL string
-	Value   []byte
-}
 
 func modelTypeFromProto(modelType mltrainingpb.ModelType) ModelType {
 	switch modelType {
@@ -93,12 +85,3 @@ func modelFrameworkFromProto(framework mltrainingpb.ModelFramework) ModelFramewo
 	return ModelFrameworkUnspecified
 }
 
-func genericProtoMessageFromProto(message *anypb.Any) *GenericProtoMessage {
-	if message == nil {
-		return nil
-	}
-	return &GenericProtoMessage{
-		TypeURL: message.TypeUrl,
-		Value:   message.Value,
-	}
-}

--- a/app/data_client.go
+++ b/app/data_client.go
@@ -397,7 +397,7 @@ func (d *DataClient) TabularDataByFilter(ctx context.Context, opts *DataByFilter
 }
 
 // TabularDataBySQL queries tabular data with a SQL query.
-func (d *DataClient) TabularDataBySQL(ctx context.Context, organizationID, sqlQuery string) (*[]map[string]interface{}, error) {
+func (d *DataClient) TabularDataBySQL(ctx context.Context, organizationID, sqlQuery string) ([]map[string]interface{}, error) {
 	resp, err := d.dataClient.TabularDataBySQL(ctx, &pb.TabularDataBySQLRequest{
 		OrganizationId: organizationID,
 		SqlQuery:       sqlQuery,
@@ -409,13 +409,13 @@ func (d *DataClient) TabularDataBySQL(ctx context.Context, organizationID, sqlQu
 	if err != nil {
 		return nil, err
 	}
-	return &dataObjects, nil
+	return dataObjects, nil
 }
 
 // TabularDataByMQL queries tabular data with MQL (MongoDB Query Language) queries.
 func (d *DataClient) TabularDataByMQL(
 	ctx context.Context, organizationID string, mqlQueries []map[string]interface{},
-) (*[]map[string]interface{}, error) {
+) ([]map[string]interface{}, error) {
 	mqlBinary := [][]byte{}
 	for _, query := range mqlQueries {
 		binary, err := bson.Marshal(query)
@@ -437,7 +437,7 @@ func (d *DataClient) TabularDataByMQL(
 	if err != nil {
 		return nil, err
 	}
-	return &result, nil
+	return result, nil
 }
 
 // GetLatestTabularData gets the most recent tabular data captured from the specified data source, as well as the time that it was captured

--- a/app/data_client.go
+++ b/app/data_client.go
@@ -1422,6 +1422,9 @@ func uploadMetadataToProto(metadata UploadMetadata) *syncPb.UploadMetadata {
 }
 
 func annotationsToProto(annotations *Annotations) *pb.Annotations {
+	if annotations == nil {
+		return nil
+	}
 	var protoBboxes []*pb.BoundingBox
 	for _, bbox := range annotations.Bboxes {
 		protoBboxes = append(protoBboxes, &pb.BoundingBox{

--- a/app/data_client.go
+++ b/app/data_client.go
@@ -412,11 +412,22 @@ func (d *DataClient) TabularDataBySQL(ctx context.Context, organizationID, sqlQu
 	return dataObjects, nil
 }
 
-// TabularDataByMQL queries tabular data with an MQL (MongoDB Query Language) query.
-func (d *DataClient) TabularDataByMQL(ctx context.Context, organizationID string, mqlbinary [][]byte) ([]map[string]interface{}, error) {
+// TabularDataByMQL queries tabular data with MQL (MongoDB Query Language) queries.
+func (d *DataClient) TabularDataByMQL(
+	ctx context.Context, organizationID string, mqlQueries []map[string]interface{},
+) ([]map[string]interface{}, error) {
+	mqlBinary := [][]byte{}
+	for _, query := range mqlQueries {
+		binary, err := bson.Marshal(query)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal BSON query: %w", err)
+		}
+		mqlBinary = append(mqlBinary, binary)
+	}
+
 	resp, err := d.dataClient.TabularDataByMQL(ctx, &pb.TabularDataByMQLRequest{
 		OrganizationId: organizationID,
-		MqlBinary:      mqlbinary,
+		MqlBinary:      mqlBinary,
 	})
 	if err != nil {
 		return nil, err

--- a/app/data_client_test.go
+++ b/app/data_client_test.go
@@ -282,7 +282,7 @@ func TestDataClient(t *testing.T) {
 		resp, _ := client.TabularDataByFilter(context.Background(), &DataByFilterOptions{
 			&filter, limit, last, dataRequest.SortOrder, countOnly, includeInternalData,
 		})
-		test.That(t, resp.TabularData[0], test.ShouldResemble, tabularData)
+		test.That(t, resp.TabularData[0], test.ShouldResemble, &tabularData)
 		test.That(t, resp.Count, test.ShouldEqual, count)
 		test.That(t, resp.Last, test.ShouldEqual, last)
 	})
@@ -343,7 +343,7 @@ func TestDataClient(t *testing.T) {
 
 	t.Run("GetLatestTabularData", func(t *testing.T) {
 		dataStruct, _ := utils.StructToStructPb(data)
-		latestTabularData := LatestTabularDataReturn{
+		latestTabularData := GetLatestTabularDataResponse{
 			TimeCaptured: start,
 			TimeSynced:   end,
 			Payload:      dataStruct.AsMap(),

--- a/app/data_client_test.go
+++ b/app/data_client_test.go
@@ -166,7 +166,7 @@ func captureMetadataToProto(metadata CaptureMetadata) *pb.CaptureMetadata {
 	}
 }
 
-func binaryMetadataToProto(binaryMetadata BinaryMetadata) *pb.BinaryMetadata {
+func binaryMetadataToProto(binaryMetadata *BinaryMetadata) *pb.BinaryMetadata {
 	return &pb.BinaryMetadata{
 		Id:              binaryMetadata.ID,
 		CaptureMetadata: captureMetadataToProto(binaryMetadata.CaptureMetadata),
@@ -255,7 +255,7 @@ func TestDataClient(t *testing.T) {
 
 	binaryData := BinaryData{
 		Binary:   binaryDataByte,
-		Metadata: binaryMetadata,
+		Metadata: &binaryMetadata,
 	}
 
 	t.Run("TabularDataByFilter", func(t *testing.T) {

--- a/app/data_client_test.go
+++ b/app/data_client_test.go
@@ -279,9 +279,10 @@ func TestDataClient(t *testing.T) {
 				Metadata: []*pb.CaptureMetadata{captureMetadataToProto(tabularMetadata)},
 			}, nil
 		}
-		resp, _ := client.TabularDataByFilter(context.Background(), &DataByFilterOptions{
+		resp, err := client.TabularDataByFilter(context.Background(), &DataByFilterOptions{
 			&filter, limit, last, dataRequest.SortOrder, countOnly, includeInternalData,
 		})
+		test.That(t, err, test.ShouldBeNil)
 		test.That(t, resp.TabularData[0], test.ShouldResemble, &tabularData)
 		test.That(t, resp.Count, test.ShouldEqual, count)
 		test.That(t, resp.Last, test.ShouldEqual, last)
@@ -306,7 +307,8 @@ func TestDataClient(t *testing.T) {
 				RawData: expectedRawDataPb,
 			}, nil
 		}
-		response, _ := client.TabularDataBySQL(context.Background(), organizationID, sqlQuery)
+		response, err := client.TabularDataBySQL(context.Background(), organizationID, sqlQuery)
+		test.That(t, err, test.ShouldBeNil)
 		test.That(t, response, test.ShouldResemble, rawData)
 	})
 
@@ -337,7 +339,8 @@ func TestDataClient(t *testing.T) {
 				RawData: expectedRawDataPb,
 			}, nil
 		}
-		response, _ := client.TabularDataByMQL(context.Background(), organizationID, mqlQueries)
+		response, err := client.TabularDataByMQL(context.Background(), organizationID, mqlQueries)
+		test.That(t, err, test.ShouldBeNil)
 		test.That(t, response, test.ShouldResemble, rawData)
 	})
 
@@ -363,7 +366,8 @@ func TestDataClient(t *testing.T) {
 			}, nil
 		}
 
-		resp, _ := client.GetLatestTabularData(context.Background(), partID, componentName, componentType, method)
+		resp, err := client.GetLatestTabularData(context.Background(), partID, componentName, componentType, method)
+		test.That(t, err, test.ShouldBeNil)
 		test.That(t, resp, test.ShouldResemble, &latestTabularData)
 	})
 
@@ -383,14 +387,16 @@ func TestDataClient(t *testing.T) {
 				Last:  last,
 			}, nil
 		}
-		resp, _ := client.BinaryDataByFilter(
+		resp, err := client.BinaryDataByFilter(
 			context.Background(), includeBinary, &DataByFilterOptions{
 				&filter, limit, last, dataRequest.SortOrder, countOnly, includeInternalData,
 			})
+		test.That(t, err, test.ShouldBeNil)
 		test.That(t, resp.BinaryData[0], test.ShouldResemble, &binaryData)
 		test.That(t, resp.Count, test.ShouldEqual, count)
 		test.That(t, resp.Last, test.ShouldEqual, last)
 	})
+
 	t.Run("BinaryDataByIDs", func(t *testing.T) {
 		grpcClient.BinaryDataByIDsFunc = func(ctx context.Context, in *pb.BinaryDataByIDsRequest,
 			opts ...grpc.CallOption,
@@ -401,7 +407,8 @@ func TestDataClient(t *testing.T) {
 
 			return &pb.BinaryDataByIDsResponse{Data: expectedBinaryDataList, Count: uint64(len(expectedBinaryDataList))}, nil
 		}
-		respBinaryData, _ := client.BinaryDataByIDs(context.Background(), binaryIDs)
+		respBinaryData, err := client.BinaryDataByIDs(context.Background(), binaryIDs)
+		test.That(t, err, test.ShouldBeNil)
 		test.That(t, respBinaryData[0], test.ShouldResemble, &binaryData)
 	})
 
@@ -418,7 +425,8 @@ func TestDataClient(t *testing.T) {
 				DeletedCount: pbCount,
 			}, nil
 		}
-		resp, _ := client.DeleteTabularData(context.Background(), organizationID, deleteOlderThanDays)
+		resp, err := client.DeleteTabularData(context.Background(), organizationID, deleteOlderThanDays)
+		test.That(t, err, test.ShouldBeNil)
 		test.That(t, resp, test.ShouldEqual, count)
 	})
 
@@ -432,7 +440,8 @@ func TestDataClient(t *testing.T) {
 				DeletedCount: pbCount,
 			}, nil
 		}
-		resp, _ := client.DeleteBinaryDataByFilter(context.Background(), &filter)
+		resp, err := client.DeleteBinaryDataByFilter(context.Background(), &filter)
+		test.That(t, err, test.ShouldBeNil)
 		test.That(t, resp, test.ShouldEqual, count)
 	})
 
@@ -445,7 +454,8 @@ func TestDataClient(t *testing.T) {
 				DeletedCount: pbCount,
 			}, nil
 		}
-		resp, _ := client.DeleteBinaryDataByIDs(context.Background(), binaryIDs)
+		resp, err := client.DeleteBinaryDataByIDs(context.Background(), binaryIDs)
+		test.That(t, err, test.ShouldBeNil)
 		test.That(t, resp, test.ShouldEqual, count)
 	})
 
@@ -457,7 +467,8 @@ func TestDataClient(t *testing.T) {
 			test.That(t, in.Tags, test.ShouldResemble, tags)
 			return &pb.AddTagsToBinaryDataByIDsResponse{}, nil
 		}
-		client.AddTagsToBinaryDataByIDs(context.Background(), tags, binaryIDs)
+		err := client.AddTagsToBinaryDataByIDs(context.Background(), tags, binaryIDs)
+		test.That(t, err, test.ShouldBeNil)
 	})
 
 	t.Run("AddTagsToBinaryDataByFilter", func(t *testing.T) {
@@ -468,7 +479,8 @@ func TestDataClient(t *testing.T) {
 			test.That(t, in.Tags, test.ShouldResemble, tags)
 			return &pb.AddTagsToBinaryDataByFilterResponse{}, nil
 		}
-		client.AddTagsToBinaryDataByFilter(context.Background(), tags, &filter)
+		err := client.AddTagsToBinaryDataByFilter(context.Background(), tags, &filter)
+		test.That(t, err, test.ShouldBeNil)
 	})
 
 	t.Run("RemoveTagsFromBinaryDataByIDs", func(t *testing.T) {
@@ -481,7 +493,8 @@ func TestDataClient(t *testing.T) {
 				DeletedCount: pbCount,
 			}, nil
 		}
-		resp, _ := client.RemoveTagsFromBinaryDataByIDs(context.Background(), tags, binaryIDs)
+		resp, err := client.RemoveTagsFromBinaryDataByIDs(context.Background(), tags, binaryIDs)
+		test.That(t, err, test.ShouldBeNil)
 		test.That(t, resp, test.ShouldEqual, count)
 	})
 
@@ -495,7 +508,8 @@ func TestDataClient(t *testing.T) {
 				DeletedCount: pbCount,
 			}, nil
 		}
-		resp, _ := client.RemoveTagsFromBinaryDataByFilter(context.Background(), tags, &filter)
+		resp, err := client.RemoveTagsFromBinaryDataByFilter(context.Background(), tags, &filter)
+		test.That(t, err, test.ShouldBeNil)
 		test.That(t, resp, test.ShouldEqual, count)
 	})
 
@@ -508,7 +522,8 @@ func TestDataClient(t *testing.T) {
 				Tags: tags,
 			}, nil
 		}
-		resp, _ := client.TagsByFilter(context.Background(), &filter)
+		resp, err := client.TagsByFilter(context.Background(), &filter)
+		test.That(t, err, test.ShouldBeNil)
 		test.That(t, resp, test.ShouldResemble, tags)
 	})
 
@@ -528,9 +543,10 @@ func TestDataClient(t *testing.T) {
 				BboxId: annotations.Bboxes[0].ID,
 			}, nil
 		}
-		resp, _ := client.AddBoundingBoxToImageByID(
+		resp, err := client.AddBoundingBoxToImageByID(
 			context.Background(), &binaryID, bboxLabel, annotations.Bboxes[0].XMinNormalized,
 			annotations.Bboxes[0].YMinNormalized, annotations.Bboxes[0].XMaxNormalized, annotations.Bboxes[0].YMaxNormalized)
+		test.That(t, err, test.ShouldBeNil)
 		test.That(t, resp, test.ShouldResemble, annotations.Bboxes[0].ID)
 	})
 
@@ -543,7 +559,8 @@ func TestDataClient(t *testing.T) {
 
 			return &pb.RemoveBoundingBoxFromImageByIDResponse{}, nil
 		}
-		client.RemoveBoundingBoxFromImageByID(context.Background(), annotations.Bboxes[0].ID, &binaryID)
+		err := client.RemoveBoundingBoxFromImageByID(context.Background(), annotations.Bboxes[0].ID, &binaryID)
+		test.That(t, err, test.ShouldBeNil)
 	})
 
 	t.Run("BoundingBoxLabelsByFilter", func(t *testing.T) {
@@ -563,7 +580,8 @@ func TestDataClient(t *testing.T) {
 				Labels: expectedBBoxLabelsPb,
 			}, nil
 		}
-		resp, _ := client.BoundingBoxLabelsByFilter(context.Background(), &filter)
+		resp, err := client.BoundingBoxLabelsByFilter(context.Background(), &filter)
+		test.That(t, err, test.ShouldBeNil)
 		test.That(t, resp, test.ShouldResemble, expectedBBoxLabels)
 	})
 	t.Run("UpdateBoundingBox", func(t *testing.T) {
@@ -580,13 +598,14 @@ func TestDataClient(t *testing.T) {
 			test.That(t, *in.YMaxNormalized, test.ShouldEqual, annotationsPb.Bboxes[0].YMaxNormalized)
 			return &pb.UpdateBoundingBoxResponse{}, nil
 		}
-		client.UpdateBoundingBox(context.Background(), &binaryID, annotations.Bboxes[0].ID, &UpdateBoundingBoxOptions{
+		err := client.UpdateBoundingBox(context.Background(), &binaryID, annotations.Bboxes[0].ID, &UpdateBoundingBoxOptions{
 			&annotationsPb.Bboxes[0].Label,
 			&annotationsPb.Bboxes[0].XMinNormalized,
 			&annotationsPb.Bboxes[0].YMinNormalized,
 			&annotationsPb.Bboxes[0].XMaxNormalized,
 			&annotationsPb.Bboxes[0].YMaxNormalized,
 		})
+		test.That(t, err, test.ShouldBeNil)
 	})
 
 	t.Run("GetDatabaseConnection", func(t *testing.T) {
@@ -600,7 +619,8 @@ func TestDataClient(t *testing.T) {
 				HasDatabaseUser: true,
 			}, nil
 		}
-		resp, _ := client.GetDatabaseConnection(context.Background(), organizationID)
+		resp, err := client.GetDatabaseConnection(context.Background(), organizationID)
+		test.That(t, err, test.ShouldBeNil)
 		test.That(t, resp.Hostname, test.ShouldResemble, host)
 		test.That(t, resp.MongodbURI, test.ShouldResemble, mongodbURI)
 		test.That(t, resp.HasDatabaseUser, test.ShouldBeTrue)
@@ -614,7 +634,8 @@ func TestDataClient(t *testing.T) {
 			test.That(t, in.Password, test.ShouldResemble, password)
 			return &pb.ConfigureDatabaseUserResponse{}, nil
 		}
-		client.ConfigureDatabaseUser(context.Background(), organizationID, password)
+		err := client.ConfigureDatabaseUser(context.Background(), organizationID, password)
+		test.That(t, err, test.ShouldBeNil)
 	})
 
 	t.Run("AddBinaryDataToDatasetByIDs", func(t *testing.T) {
@@ -625,7 +646,8 @@ func TestDataClient(t *testing.T) {
 			test.That(t, in.DatasetId, test.ShouldResemble, datasetID)
 			return &pb.AddBinaryDataToDatasetByIDsResponse{}, nil
 		}
-		client.AddBinaryDataToDatasetByIDs(context.Background(), binaryIDs, datasetID)
+		err := client.AddBinaryDataToDatasetByIDs(context.Background(), binaryIDs, datasetID)
+		test.That(t, err, test.ShouldBeNil)
 	})
 
 	t.Run("RemoveBinaryDataFromDatasetByIDs", func(t *testing.T) {
@@ -636,7 +658,8 @@ func TestDataClient(t *testing.T) {
 			test.That(t, in.DatasetId, test.ShouldResemble, datasetID)
 			return &pb.RemoveBinaryDataFromDatasetByIDsResponse{}, nil
 		}
-		client.RemoveBinaryDataFromDatasetByIDs(context.Background(), binaryIDs, datasetID)
+		err := client.RemoveBinaryDataFromDatasetByIDs(context.Background(), binaryIDs, datasetID)
+		test.That(t, err, test.ShouldBeNil)
 	})
 }
 
@@ -689,9 +712,10 @@ func TestDataSyncClient(t *testing.T) {
 				FileId: fileID,
 			}, nil
 		}
-		resp, _ := client.BinaryDataCaptureUpload(context.Background(),
+		resp, err := client.BinaryDataCaptureUpload(context.Background(),
 			binaryDataByte, partID, componentType, componentName,
 			method, fileExt, &options)
+		test.That(t, err, test.ShouldBeNil)
 		test.That(t, resp, test.ShouldResemble, fileID)
 	})
 
@@ -739,9 +763,10 @@ func TestDataSyncClient(t *testing.T) {
 		dataRequestTimes := [][2]time.Time{
 			{start, end},
 		}
-		resp, _ := client.TabularDataCaptureUpload(context.Background(),
+		resp, err := client.TabularDataCaptureUpload(context.Background(),
 			tabularData, partID, componentType, componentName, method,
 			dataRequestTimes, &options)
+		test.That(t, err, test.ShouldBeNil)
 		test.That(t, resp, test.ShouldResemble, fileID)
 	})
 

--- a/app/data_client_test.go
+++ b/app/data_client_test.go
@@ -67,7 +67,7 @@ var (
 	tabularData = TabularData{
 		Data:          data,
 		MetadataIndex: 0,
-		Metadata:      tabularMetadata,
+		Metadata:      &tabularMetadata,
 		TimeRequested: start,
 		TimeReceived:  end,
 	}
@@ -117,7 +117,7 @@ var (
 		},
 	}
 	annotations = Annotations{
-		Bboxes: []BoundingBox{
+		Bboxes: []*BoundingBox{
 			{
 				ID:             "bbox1",
 				Label:          "label1",
@@ -240,7 +240,7 @@ func TestDataClient(t *testing.T) {
 		FileName:        fileName,
 		FileExt:         fileExt,
 		URI:             uri,
-		Annotations:     annotations,
+		Annotations:     &annotations,
 		DatasetIDs:      datasetIDs,
 	}
 
@@ -552,8 +552,8 @@ func TestDataClient(t *testing.T) {
 			annotations.Bboxes[1].Label,
 		}
 		expectedBBoxLabelsPb := []string{
-			annotationsToProto(annotations).Bboxes[0].Label,
-			annotationsToProto(annotations).Bboxes[1].Label,
+			annotationsToProto(&annotations).Bboxes[0].Label,
+			annotationsToProto(&annotations).Bboxes[1].Label,
 		}
 		grpcClient.BoundingBoxLabelsByFilterFunc = func(ctx context.Context, in *pb.BoundingBoxLabelsByFilterRequest,
 			opts ...grpc.CallOption,
@@ -567,7 +567,7 @@ func TestDataClient(t *testing.T) {
 		test.That(t, resp, test.ShouldResemble, expectedBBoxLabels)
 	})
 	t.Run("UpdateBoundingBox", func(t *testing.T) {
-		annotationsPb := annotationsToProto(annotations)
+		annotationsPb := annotationsToProto(&annotations)
 		grpcClient.UpdateBoundingBoxFunc = func(ctx context.Context, in *pb.UpdateBoundingBoxRequest,
 			opts ...grpc.CallOption,
 		) (*pb.UpdateBoundingBoxResponse, error) {

--- a/app/data_client_test.go
+++ b/app/data_client_test.go
@@ -364,7 +364,7 @@ func TestDataClient(t *testing.T) {
 		}
 
 		resp, _ := client.GetLatestTabularData(context.Background(), partID, componentName, componentType, method)
-		test.That(t, resp, test.ShouldResemble, latestTabularData)
+		test.That(t, resp, test.ShouldResemble, &latestTabularData)
 	})
 
 	t.Run("BinaryDataByFilter", func(t *testing.T) {
@@ -387,7 +387,7 @@ func TestDataClient(t *testing.T) {
 			context.Background(), includeBinary, &DataByFilterOptions{
 				&filter, limit, last, dataRequest.SortOrder, countOnly, includeInternalData,
 			})
-		test.That(t, resp.BinaryData[0], test.ShouldResemble, binaryData)
+		test.That(t, resp.BinaryData[0], test.ShouldResemble, &binaryData)
 		test.That(t, resp.Count, test.ShouldEqual, count)
 		test.That(t, resp.Last, test.ShouldEqual, last)
 	})
@@ -402,7 +402,7 @@ func TestDataClient(t *testing.T) {
 			return &pb.BinaryDataByIDsResponse{Data: expectedBinaryDataList, Count: uint64(len(expectedBinaryDataList))}, nil
 		}
 		respBinaryData, _ := client.BinaryDataByIDs(context.Background(), binaryIDs)
-		test.That(t, respBinaryData[0], test.ShouldResemble, binaryData)
+		test.That(t, respBinaryData[0], test.ShouldResemble, &binaryData)
 	})
 
 	t.Run("DeleteTabularData", func(t *testing.T) {

--- a/app/data_client_test.go
+++ b/app/data_client_test.go
@@ -312,9 +312,12 @@ func TestDataClient(t *testing.T) {
 
 	t.Run("TabularDataByMQL", func(t *testing.T) {
 		// convert to BSON byte arrays
-		matchBytes, _ := bson.Marshal(bson.M{"$match": bson.M{"organization_id": "e76d1b3b-0468-4efd-bb7f-fb1d2b352fcb"}})
-		limitBytes, _ := bson.Marshal(bson.M{"$limit": 1})
-		mqlbinary := [][]byte{matchBytes, limitBytes}
+		matchQuery := bson.M{"$match": bson.M{"organization_id": "e76d1b3b-0468-4efd-bb7f-fb1d2b352fcb"}}
+		matchBytes, _ := bson.Marshal(matchQuery)
+		limitQuery := bson.M{"$limit": 1}
+		limitBytes, _ := bson.Marshal(limitQuery)
+		mqlQueries := []map[string]interface{}{matchQuery, limitQuery}
+		mqlBinary := [][]byte{matchBytes, limitBytes}
 
 		// convert rawData to BSON
 		var expectedRawDataPb [][]byte
@@ -329,12 +332,12 @@ func TestDataClient(t *testing.T) {
 			opts ...grpc.CallOption,
 		) (*pb.TabularDataByMQLResponse, error) {
 			test.That(t, in.OrganizationId, test.ShouldEqual, organizationID)
-			test.That(t, in.MqlBinary, test.ShouldResemble, mqlbinary)
+			test.That(t, in.MqlBinary, test.ShouldResemble, mqlBinary)
 			return &pb.TabularDataByMQLResponse{
 				RawData: expectedRawDataPb,
 			}, nil
 		}
-		response, _ := client.TabularDataByMQL(context.Background(), organizationID, mqlbinary)
+		response, _ := client.TabularDataByMQL(context.Background(), organizationID, mqlQueries)
 		test.That(t, response, test.ShouldResemble, rawData)
 	})
 

--- a/app/mltraining_client.go
+++ b/app/mltraining_client.go
@@ -35,7 +35,7 @@ const (
 type ErrorStatus struct {
 	Code    int
 	Message string
-	Details []*interface{}
+	Details []interface{}
 }
 
 // TrainingJobMetadata contains the metadata for a training job.
@@ -246,7 +246,7 @@ func errorStatusFromProto(status *errorstatus.Status) (*ErrorStatus, error) {
 	if status == nil {
 		return nil, nil
 	}
-	var details []*interface{}
+	var details []interface{}
 	for _, pbDetail := range status.Details {
 		structValue := &structpb.Value{}
 		if err := pbDetail.UnmarshalTo(structValue); err != nil {

--- a/app/mltraining_client.go
+++ b/app/mltraining_client.go
@@ -143,7 +143,7 @@ func (c *MLTrainingClient) GetTrainingJob(ctx context.Context, id string) (*Trai
 		return nil, err
 	}
 	metadata, err := trainingJobMetadataFromProto(resp.Metadata)
-	if err != nil{
+	if err != nil {
 		return nil, err
 	}
 	return metadata, nil
@@ -254,7 +254,7 @@ func errorStatusFromProto(status *errorstatus.Status) (*ErrorStatus, error) {
 		}
 		detail := structValue.AsInterface()
 		details = append(details, &detail)
-	}	
+	}
 	return &ErrorStatus{
 		Code:    int(status.Code),
 		Message: status.Message,

--- a/app/mltraining_client_test.go
+++ b/app/mltraining_client_test.go
@@ -39,12 +39,7 @@ var (
 		ErrorStatus: &ErrorStatus{
 			Code:    code,
 			Message: message,
-			Details: []*GenericProtoMessage{
-				{
-					TypeURL: siteURL,
-					Value:   byteData,
-				},
-			},
+			Details: []*interface{}(nil),
 		},
 		CreatedOn:       &createdOn,
 		LastModified:    &lastUpdated,
@@ -68,12 +63,7 @@ var (
 		ErrorStatus: &statuspb.Status{
 			Code:    int32(jobMetadata.ErrorStatus.Code),
 			Message: jobMetadata.ErrorStatus.Message,
-			Details: []*anypb.Any{
-				{
-					TypeUrl: jobMetadata.ErrorStatus.Details[0].TypeURL,
-					Value:   jobMetadata.ErrorStatus.Details[0].Value,
-				},
-			},
+			Details: []*anypb.Any{},
 		},
 		CreatedOn:       pbCreatedOn,
 		LastModified:    timestamppb.New(lastUpdated),

--- a/app/mltraining_client_test.go
+++ b/app/mltraining_client_test.go
@@ -39,7 +39,7 @@ var (
 		ErrorStatus: &ErrorStatus{
 			Code:    code,
 			Message: message,
-			Details: []*interface{}(nil),
+			Details: []interface{}(nil),
 		},
 		CreatedOn:       &createdOn,
 		LastModified:    &lastUpdated,

--- a/app/viam_client.go
+++ b/app/viam_client.go
@@ -24,29 +24,29 @@ type ViamClient struct {
 
 // Options has the options necessary to connect through gRPC.
 type Options struct {
-	baseURL     string
-	entity      string
-	credentials rpc.Credentials
+	BaseURL     string
+	Entity      string
+	Credentials rpc.Credentials
 }
 
 var dialDirectGRPC = rpc.DialDirectGRPC
 
 // CreateViamClientWithOptions creates a ViamClient with an Options struct.
 func CreateViamClientWithOptions(ctx context.Context, options Options, logger logging.Logger) (*ViamClient, error) {
-	if options.baseURL == "" {
-		options.baseURL = "https://app.viam.com"
-	} else if !strings.HasPrefix(options.baseURL, "http://") && !strings.HasPrefix(options.baseURL, "https://") {
+	if options.BaseURL == "" {
+		options.BaseURL = "https://app.viam.com"
+	} else if !strings.HasPrefix(options.BaseURL, "http://") && !strings.HasPrefix(options.BaseURL, "https://") {
 		return nil, errors.New("use valid URL")
 	}
-	serviceHost, err := url.Parse(options.baseURL + ":443")
+	serviceHost, err := url.Parse(options.BaseURL + ":443")
 	if err != nil {
 		return nil, err
 	}
 
-	if options.credentials.Payload == "" || options.entity == "" {
+	if options.Credentials.Payload == "" || options.Entity == "" {
 		return nil, errors.New("entity and payload cannot be empty")
 	}
-	opts := rpc.WithEntityCredentials(options.entity, options.credentials)
+	opts := rpc.WithEntityCredentials(options.Entity, options.Credentials)
 
 	conn, err := dialDirectGRPC(ctx, serviceHost.Host, logger, opts)
 	if err != nil {
@@ -59,8 +59,8 @@ func CreateViamClientWithOptions(ctx context.Context, options Options, logger lo
 func CreateViamClientWithAPIKey(
 	ctx context.Context, options Options, apiKey, apiKeyID string, logger logging.Logger,
 ) (*ViamClient, error) {
-	options.entity = apiKeyID
-	options.credentials = rpc.Credentials{
+	options.Entity = apiKeyID
+	options.Credentials = rpc.Credentials{
 		Type:    rpc.CredentialsTypeAPIKey,
 		Payload: apiKey,
 	}

--- a/app/viam_client_test.go
+++ b/app/viam_client_test.go
@@ -74,9 +74,9 @@ func TestCreateViamClientWithOptions(t *testing.T) {
 	for _, tt := range urlTests {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := Options{
-				baseURL: tt.baseURL,
-				entity:  tt.entity,
-				credentials: rpc.Credentials{
+				BaseURL: tt.baseURL,
+				Entity:  tt.entity,
+				Credentials: rpc.Credentials{
 					Type:    rpc.CredentialsTypeAPIKey,
 					Payload: tt.payload,
 				},
@@ -129,9 +129,9 @@ func TestNewAppClients(t *testing.T) {
 	dialDirectGRPC = mockDialDirectGRPC
 	defer func() { dialDirectGRPC = originalDialDirectGRPC }()
 	opts := Options{
-		baseURL: defaultURL,
-		entity:  testAPIKey,
-		credentials: rpc.Credentials{
+		BaseURL: defaultURL,
+		Entity:  testAPIKey,
+		Credentials: rpc.Credentials{
 			Type:    rpc.CredentialsTypeAPIKey,
 			Payload: testAPIKeyID,
 		},


### PR DESCRIPTION
This PR mainly focuses on basic cleanup for app wrappers. Naming and return types were standardized to follow the rest of the app wrappers. Note that these changes do not necessarily mean that something was done wrong previously.

Changes:
- return pointers where pointers are returned from proto
- name response shadow types `<Method>Response`
- convert `anypb.Any` types to Go standard types
- call `MQL` function with queries
- remove pointers from types that are already references
- return errors where applicable
- check for errors in tests
- return proto type for Google Status object