### PR TITLE
APP-6846: Adding the GetBillingConfig CLI endpoint

### DIFF
--- a/app/app_client.go
+++ b/app/app_client.go
@@ -825,6 +825,17 @@ func (c *AppClient) OrganizationGetSupportEmail(ctx context.Context, orgID strin
 	return resp.Email, nil
 }
 
+// GetBillingServiceConfig gets the billing service configuration for an organization.
+func (c *AppClient) GetBillingServiceConfig(ctx context.Context, orgID string) (*pb.GetBillingServiceConfigResponse, error) {
+	resp, err := c.client.GetBillingServiceConfig(ctx, &pb.GetBillingServiceConfigRequest{
+		OrgId: orgID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
 // CreateLocation creates a location with the given name under the given organization.
 func (c *AppClient) CreateLocation(ctx context.Context, orgID, name string, opts *CreateLocationOptions) (*Location, error) {
 	var parentID *string

--- a/app/app_client_test.go
+++ b/app/app_client_test.go
@@ -700,6 +700,19 @@ func TestAppClient(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 	})
 
+	t.Run("GetBillingConfig", func(t *testing.T) {
+		grpcClient.GetBillingServiceConfigFunc = func(
+			ctx context.Context, in *pb.GetBillingServiceConfigRequest, opts ...grpc.CallOption,
+		) (*pb.GetBillingServiceConfigResponse, error) {
+			test.That(t, in.OrgId, test.ShouldEqual, organizationID)
+			return &pb.GetBillingServiceConfigResponse{}, nil
+		}
+
+		resp, err := client.GetBillingServiceConfig(context.Background(), organizationID)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, resp, test.ShouldResemble, &pb.GetBillingServiceConfigResponse{})
+	})
+
 	t.Run("GetSupportEmail", func(t *testing.T) {
 		grpcClient.OrganizationGetSupportEmailFunc = func(
 			ctx context.Context, in *pb.OrganizationGetSupportEmailRequest, opts ...grpc.CallOption,

--- a/cli/app.go
+++ b/cli/app.go
@@ -367,6 +367,18 @@ var app = &cli.App{
 					},
 				},
 				{
+					Name:      "billing-service",
+					Usage:     "manage the organizations billing service",
+					UsageText: createUsageText("organizations billing-service", []string{generalFlagOrgID}, false),
+					Subcommands: []*cli.Command{
+						{
+							Name:   "get-config",
+							Usage:  "get the billing service config for an organization",
+							Action: GetBillingConfigAction,
+						},
+					},
+				},
+				{
 					Name:      "api-key",
 					Usage:     "work with an organization's api keys",
 					UsageText: createUsageText("organizations api-key", []string{generalFlagOrgID}, true),

--- a/cli/client.go
+++ b/cli/client.go
@@ -177,6 +177,44 @@ func (c *viamClient) organizationsSupportEmailGetAction(cCtx *cli.Context, orgID
 	return nil
 }
 
+// GetBillingConfigAction corresponds to `organizations billing get`.
+func GetBillingConfigAction(cCtx *cli.Context) error {
+	c, err := newViamClient(cCtx)
+	if err != nil {
+		return err
+	}
+	return c.getBillingConfig(cCtx, cCtx.String(generalFlagOrgID))
+}
+
+func (c *viamClient) getBillingConfig(cCtx *cli.Context, orgID string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+
+	resp, err := c.client.GetBillingServiceConfig(cCtx.Context, &apppb.GetBillingServiceConfigRequest{
+		OrgId: orgID,
+	})
+	if err != nil {
+		return err
+	}
+
+	printf(cCtx.App.Writer, "Billing config for organization: %s", orgID)
+	printf(cCtx.App.Writer, "Support Email: %s", resp.GetSupportEmail())
+	printf(cCtx.App.Writer, "Billing Dashboard URL: %s", resp.GetBillingDashboardUrl())
+	printf(cCtx.App.Writer, "Logo URL: %s", resp.GetLogoUrl())
+
+	printf(cCtx.App.Writer, " --- Billing Address --- ")
+	printf(cCtx.App.Writer, "Address Line 1: %s", resp.BillingAddress.GetAddressLine_1())
+	if resp.BillingAddress.GetAddressLine_2() != "" {
+		printf(cCtx.App.Writer, "Address Line 2: %s", resp.BillingAddress.GetAddressLine_2())
+	}
+	printf(cCtx.App.Writer, "City: %s", resp.BillingAddress.GetCity())
+	printf(cCtx.App.Writer, "State: %s", resp.BillingAddress.GetState())
+	printf(cCtx.App.Writer, "Postal Code: %s", resp.BillingAddress.GetZipcode())
+	printf(cCtx.App.Writer, "Country: %s", "USA")
+	return nil
+}
+
 // ListLocationsAction is the corresponding Action for 'locations list'.
 func ListLocationsAction(c *cli.Context) error {
 	client, err := newViamClient(c)

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -237,6 +237,47 @@ func TestGetSupportEmailAction(t *testing.T) {
 	test.That(t, out.messages[0], test.ShouldContainSubstring, "test-email")
 }
 
+func TestGetBillingConfigAction(t *testing.T) {
+	getConfigEmailFunc := func(ctx context.Context, in *apppb.GetBillingServiceConfigRequest, opts ...grpc.CallOption) (
+		*apppb.GetBillingServiceConfigResponse, error,
+	) {
+		address2 := "Apt 123"
+		return &apppb.GetBillingServiceConfigResponse{
+			SupportEmail: "test-email@mail.com",
+			BillingAddress: &apppb.BillingAddress{
+				AddressLine_1: "1234 Main St",
+				AddressLine_2: &address2,
+				City:          "San Francisco",
+				State:         "CA",
+				Zipcode:       "94105",
+			},
+			LogoUrl:             "https://logo.com",
+			BillingDashboardUrl: "https://app.viam.dev/my-dashboard",
+		}, nil
+	}
+
+	asc := &inject.AppServiceClient{
+		GetBillingServiceConfigFunc: getConfigEmailFunc,
+	}
+
+	cCtx, ac, out, errOut := setup(asc, nil, nil, nil, nil, "token")
+	test.That(t, ac.getBillingConfig(cCtx, "test-org"), test.ShouldBeNil)
+	test.That(t, len(errOut.messages), test.ShouldEqual, 0)
+	test.That(t, len(out.messages), test.ShouldEqual, 11)
+
+	test.That(t, out.messages[0], test.ShouldContainSubstring, "Billing config for organization")
+	test.That(t, out.messages[1], test.ShouldContainSubstring, "Support Email: test-email@mail.com")
+	test.That(t, out.messages[2], test.ShouldContainSubstring, "Billing Dashboard URL: https://app.viam.dev/my-dashboard")
+	test.That(t, out.messages[3], test.ShouldContainSubstring, "Logo URL: https://logo.com")
+	test.That(t, out.messages[4], test.ShouldContainSubstring, "--- Billing Address --- ")
+	test.That(t, out.messages[5], test.ShouldContainSubstring, "1234 Main St")
+	test.That(t, out.messages[6], test.ShouldContainSubstring, "Apt 123")
+	test.That(t, out.messages[7], test.ShouldContainSubstring, "San Francisco")
+	test.That(t, out.messages[8], test.ShouldContainSubstring, "CA")
+	test.That(t, out.messages[9], test.ShouldContainSubstring, "94105")
+	test.That(t, out.messages[10], test.ShouldContainSubstring, "USA")
+}
+
 func TestTabularDataByFilterAction(t *testing.T) {
 	pbStruct, err := protoutils.StructToStructPb(map[string]interface{}{"bool": true, "string": "true", "float": float64(1)})
 	test.That(t, err, test.ShouldBeNil)

--- a/testutils/inject/app_service_client.go
+++ b/testutils/inject/app_service_client.go
@@ -42,6 +42,8 @@ type AppServiceClient struct {
 		opts ...grpc.CallOption) (*apppb.ResendOrganizationInviteResponse, error)
 	EnableBillingServiceFunc func(ctx context.Context, in *apppb.EnableBillingServiceRequest,
 		opts ...grpc.CallOption) (*apppb.EnableBillingServiceResponse, error)
+	GetBillingServiceConfigFunc func(ctx context.Context, in *apppb.GetBillingServiceConfigRequest,
+		opts ...grpc.CallOption) (*apppb.GetBillingServiceConfigResponse, error)
 	DisableBillingServiceFunc func(ctx context.Context, in *apppb.DisableBillingServiceRequest,
 		opts ...grpc.CallOption) (*apppb.DisableBillingServiceResponse, error)
 	UpdateBillingServiceFunc func(ctx context.Context, in *apppb.UpdateBillingServiceRequest,
@@ -325,6 +327,16 @@ func (asc *AppServiceClient) EnableBillingService(
 		return asc.AppServiceClient.EnableBillingService(ctx, in, opts...)
 	}
 	return asc.EnableBillingServiceFunc(ctx, in, opts...)
+}
+
+// GetBillingServiceConfig calls the injected GetBillingServiceConfigFunc or the real version.
+func (asc *AppServiceClient) GetBillingServiceConfig(
+	ctx context.Context, in *apppb.GetBillingServiceConfigRequest, opts ...grpc.CallOption,
+) (*apppb.GetBillingServiceConfigResponse, error) {
+	if asc.GetBillingServiceConfigFunc == nil {
+		return asc.AppServiceClient.GetBillingServiceConfig(ctx, in, opts...)
+	}
+	return asc.GetBillingServiceConfigFunc(ctx, in, opts...)
 }
 
 // DisableBillingService calls the injected DisableBillingServiceFunc or the real version.


### PR DESCRIPTION
The new command from the scope:
```
viam organization billing-service get-config --org-id=<org-id>
```

Manual Testing:
![Screenshot 2024-12-06 at 2 16 01 PM](https://github.com/user-attachments/assets/b2bee408-b692-448a-83ad-befc749c21ee)
