### PR TITLE
Add method which converts a pointcloud into an octree.

### DIFF
--- a/pointcloud/basic_octree_test.go
+++ b/pointcloud/basic_octree_test.go
@@ -638,7 +638,7 @@ func createPopulatedOctree(sign int) (*BasicOctree, error) {
 	side := 2.0
 	octree, err := createNewOctree(center, side)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 	pointsAndData := []PointAndData{
 		{P: r3.Vector{X: 0, Y: 0, Z: 0}, D: NewValueData(2 * sign)},
@@ -652,7 +652,7 @@ func createPopulatedOctree(sign int) (*BasicOctree, error) {
 
 	err = addPoints(octree, pointsAndData)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 	return octree, nil
 }

--- a/pointcloud/basic_octree_test.go
+++ b/pointcloud/basic_octree_test.go
@@ -633,24 +633,33 @@ func testPCDToBasicOctree(t *testing.T, artifactPath string) {
 	validateBasicOctree(t, basicOct, basicOct.center, basicOct.sideLength)
 }
 
-func TestCachedMaxProbability(t *testing.T) {
+func createPopulatedOctree(sign int) (*BasicOctree, error) {
 	center := r3.Vector{X: 0, Y: 0, Z: 0}
 	side := 2.0
+	octree, err := createNewOctree(center, side)
+	if err != nil {
+		return nil, nil
+	}
+	pointsAndData := []PointAndData{
+		{P: r3.Vector{X: 0, Y: 0, Z: 0}, D: NewValueData(2 * sign)},
+		{P: r3.Vector{X: .5, Y: 0, Z: 0}, D: NewValueData(3 * sign)},
+		{P: r3.Vector{X: .5, Y: 0, Z: .5}, D: NewValueData(10 * sign)},
+		{P: r3.Vector{X: .5, Y: .5, Z: 0}, D: NewValueData(1 * sign)},
+		{P: r3.Vector{X: .55, Y: .55, Z: 0}, D: NewValueData(4 * sign)},
+		{P: r3.Vector{X: -.55, Y: -.55, Z: 0}, D: NewValueData(5 * sign)},
+		{P: r3.Vector{X: .755, Y: .755, Z: 0}, D: NewValueData(6 * sign)},
+	}
 
+	err = addPoints(octree, pointsAndData)
+	if err != nil {
+		return nil, nil
+	}
+	return octree, nil
+}
+
+func TestCachedMaxProbability(t *testing.T) {
 	t.Run("get the max val from an octree", func(t *testing.T) {
-		octree, err := createNewOctree(center, side)
-		test.That(t, err, test.ShouldBeNil)
-		pointsAndData := []PointAndData{
-			{P: r3.Vector{X: 0, Y: 0, Z: 0}, D: NewValueData(2)},
-			{P: r3.Vector{X: .5, Y: 0, Z: 0}, D: NewValueData(3)},
-			{P: r3.Vector{X: .5, Y: 0, Z: .5}, D: NewValueData(10)},
-			{P: r3.Vector{X: .5, Y: .5, Z: 0}, D: NewValueData(1)},
-			{P: r3.Vector{X: .55, Y: .55, Z: 0}, D: NewValueData(4)},
-			{P: r3.Vector{X: -.55, Y: -.55, Z: 0}, D: NewValueData(5)},
-			{P: r3.Vector{X: .755, Y: .755, Z: 0}, D: NewValueData(6)},
-		}
-
-		err = addPoints(octree, pointsAndData)
+		octree, err := createPopulatedOctree(1)
 		test.That(t, err, test.ShouldBeNil)
 
 		validateBasicOctree(t, octree, octree.center, octree.sideLength)
@@ -675,19 +684,7 @@ func TestCachedMaxProbability(t *testing.T) {
 	})
 
 	t.Run("setting negative values", func(t *testing.T) {
-		octree, err := createNewOctree(center, side)
-		test.That(t, err, test.ShouldBeNil)
-		pointsAndData := []PointAndData{
-			{P: r3.Vector{X: 0, Y: 0, Z: 0}, D: NewValueData(-2)},
-			{P: r3.Vector{X: .5, Y: 0, Z: 0}, D: NewValueData(-3)},
-			{P: r3.Vector{X: .5, Y: 0, Z: .5}, D: NewValueData(-10)},
-			{P: r3.Vector{X: .5, Y: .5, Z: 0}, D: NewValueData(-1)},
-			{P: r3.Vector{X: .55, Y: .55, Z: 0}, D: NewValueData(-4)},
-			{P: r3.Vector{X: -.55, Y: -.55, Z: 0}, D: NewValueData(-5)},
-			{P: r3.Vector{X: .755, Y: .755, Z: 0}, D: NewValueData(-6)},
-		}
-
-		err = addPoints(octree, pointsAndData)
+		octree, err := createPopulatedOctree(-1)
 		test.That(t, err, test.ShouldBeNil)
 
 		validateBasicOctree(t, octree, octree.center, octree.sideLength)

--- a/pointcloud/pointcloud_utils.go
+++ b/pointcloud/pointcloud_utils.go
@@ -104,16 +104,16 @@ func ToBasicOctree(cloud PointCloud) (*BasicOctree, error) {
 	if err != nil {
 		return &BasicOctree{}, err
 	}
-	// var iterateError error
+	var iterateError error
 	cloud.Iterate(0, 0, func(p r3.Vector, d Data) bool {
 		if err = basicOctree.Set(p, d); err != nil {
-			// iterateError = err
+			iterateError = err
 			return false
 		}
 		return true
 	})
-	// if iterateError != nil {
-	// 	return &BasicOctree{}, iterateError
-	// }
+	if iterateError != nil {
+		return &BasicOctree{}, iterateError
+	}
 	return basicOctree, nil
 }

--- a/pointcloud/pointcloud_utils.go
+++ b/pointcloud/pointcloud_utils.go
@@ -102,7 +102,7 @@ func ToBasicOctree(cloud PointCloud) (*BasicOctree, error) {
 	maxSideLength := getMaxSideLengthFromPcMetaData(cloud.MetaData())
 	basicOctree, err := NewBasicOctree(center, maxSideLength)
 	if err != nil {
-		return &BasicOctree{}, err
+		return nil, err
 	}
 	var iterateError error
 	cloud.Iterate(0, 0, func(p r3.Vector, d Data) bool {
@@ -113,7 +113,7 @@ func ToBasicOctree(cloud PointCloud) (*BasicOctree, error) {
 		return true
 	})
 	if iterateError != nil {
-		return &BasicOctree{}, iterateError
+		return nil, err
 	}
 	return basicOctree, nil
 }

--- a/pointcloud/pointcloud_utils.go
+++ b/pointcloud/pointcloud_utils.go
@@ -104,16 +104,16 @@ func ToBasicOctree(cloud PointCloud) (*BasicOctree, error) {
 	if err != nil {
 		return &BasicOctree{}, err
 	}
-	var iterateError error
+	// var iterateError error
 	cloud.Iterate(0, 0, func(p r3.Vector, d Data) bool {
 		if err = basicOctree.Set(p, d); err != nil {
-			iterateError = err
+			// iterateError = err
 			return false
 		}
 		return true
 	})
-	if iterateError != nil {
-		return &BasicOctree{}, iterateError
-	}
+	// if iterateError != nil {
+	// 	return &BasicOctree{}, iterateError
+	// }
 	return basicOctree, nil
 }

--- a/pointcloud/pointcloud_utils.go
+++ b/pointcloud/pointcloud_utils.go
@@ -91,3 +91,22 @@ func StatisticalOutlierFilter(meanK int, stdDevThresh float64) (func(PointCloud)
 	}
 	return filterFunc, nil
 }
+
+// PointCloudToBasicOctree takes a pointcloud object and converts it into an octree.
+func PointCloudToBasicOctree(cloud PointCloud) (*BasicOctree, error) {
+	center := getCenterFromPcMetaData(cloud.MetaData())
+	maxSideLength := getMaxSideLengthFromPcMetaData(cloud.MetaData())
+
+	basicOct, err := NewBasicOctree(center, maxSideLength)
+	if err != nil {
+		return &BasicOctree{}, err
+	}
+
+	cloud.Iterate(0, 0, func(p r3.Vector, d Data) bool {
+		if err = basicOct.Set(p, d); err != nil {
+			return false
+		}
+		return true
+	})
+	return basicOct, nil
+}

--- a/pointcloud/pointcloud_utils.go
+++ b/pointcloud/pointcloud_utils.go
@@ -8,7 +8,6 @@ import (
 	"gonum.org/v1/gonum/stat"
 
 	"go.viam.com/rdk/spatialmath"
-	"go.viam.com/rdk/utils"
 )
 
 // BoundingBoxFromPointCloud returns a Geometry object that encompasses all the points in the given point cloud.
@@ -95,14 +94,13 @@ func StatisticalOutlierFilter(meanK int, stdDevThresh float64) (func(PointCloud)
 
 // ToBasicOctree takes a pointcloud object and converts it into a basic octree.
 func ToBasicOctree(cloud PointCloud) (*BasicOctree, error) {
-	basicOctree, err := utils.AssertType[*BasicOctree](cloud)
-	if err != nil && basicOctree != nil {
+	if basicOctree, ok := cloud.(*BasicOctree); ok {
 		return basicOctree, nil
 	}
 
 	center := getCenterFromPcMetaData(cloud.MetaData())
 	maxSideLength := getMaxSideLengthFromPcMetaData(cloud.MetaData())
-	basicOctree, err = NewBasicOctree(center, maxSideLength)
+	basicOctree, err := NewBasicOctree(center, maxSideLength)
 	if err != nil {
 		return &BasicOctree{}, err
 	}

--- a/pointcloud/pointcloud_utils_test.go
+++ b/pointcloud/pointcloud_utils_test.go
@@ -82,19 +82,7 @@ func TestToOctree(t *testing.T) {
 		return true
 	})
 
-	basicTree, err := createNewOctree(r3.Vector{0, 0, 0}, 2)
-	test.That(t, err, test.ShouldBeNil)
-	pointsAndData := []PointAndData{
-		{P: r3.Vector{X: 0, Y: 0, Z: 0}, D: NewValueData(2)},
-		{P: r3.Vector{X: .5, Y: 0, Z: 0}, D: NewValueData(3)},
-		{P: r3.Vector{X: .5, Y: 0, Z: .5}, D: NewValueData(10)},
-		{P: r3.Vector{X: .5, Y: .5, Z: 0}, D: NewValueData(1)},
-		{P: r3.Vector{X: .55, Y: .55, Z: 0}, D: NewValueData(4)},
-		{P: r3.Vector{X: -.55, Y: -.55, Z: 0}, D: NewValueData(5)},
-		{P: r3.Vector{X: .755, Y: .755, Z: 0}, D: NewValueData(6)},
-	}
-
-	err = addPoints(basicTree, pointsAndData)
+	basicTree, err := createPopulatedOctree(1)
 	test.That(t, err, test.ShouldBeNil)
 	tree, err = ToBasicOctree(basicTree)
 	test.That(t, err, test.ShouldBeNil)

--- a/pointcloud/pointcloud_utils_test.go
+++ b/pointcloud/pointcloud_utils_test.go
@@ -70,3 +70,38 @@ func TestPrune(t *testing.T) {
 	test.That(t, len(clouds), test.ShouldEqual, 1)
 	test.That(t, clouds[0].Size(), test.ShouldEqual, 5)
 }
+
+func TestToOctree(t *testing.T) {
+	pc := newBigPC()
+	tree, err := ToBasicOctree(pc)
+	test.That(t, err, test.ShouldBeNil)
+	pc.Iterate(0, 0, func(p r3.Vector, d Data) bool {
+		treeData, b := tree.At(p.X, p.Y, p.Z)
+		test.That(t, b, test.ShouldBeTrue)
+		test.ShouldResemble(t, treeData, d)
+		return true
+	})
+
+	basicTree, err := createNewOctree(r3.Vector{0, 0, 0}, 2)
+	test.That(t, err, test.ShouldBeNil)
+	pointsAndData := []PointAndData{
+		{P: r3.Vector{X: 0, Y: 0, Z: 0}, D: NewValueData(2)},
+		{P: r3.Vector{X: .5, Y: 0, Z: 0}, D: NewValueData(3)},
+		{P: r3.Vector{X: .5, Y: 0, Z: .5}, D: NewValueData(10)},
+		{P: r3.Vector{X: .5, Y: .5, Z: 0}, D: NewValueData(1)},
+		{P: r3.Vector{X: .55, Y: .55, Z: 0}, D: NewValueData(4)},
+		{P: r3.Vector{X: -.55, Y: -.55, Z: 0}, D: NewValueData(5)},
+		{P: r3.Vector{X: .755, Y: .755, Z: 0}, D: NewValueData(6)},
+	}
+
+	err = addPoints(basicTree, pointsAndData)
+	test.That(t, err, test.ShouldBeNil)
+	tree, err = ToBasicOctree(basicTree)
+	test.That(t, err, test.ShouldBeNil)
+	basicTree.Iterate(0, 0, func(p r3.Vector, d Data) bool {
+		treeData, b := tree.At(p.X, p.Y, p.Z)
+		test.That(t, b, test.ShouldBeTrue)
+		test.ShouldResemble(t, treeData, d)
+		return true
+	})
+}


### PR DESCRIPTION
We already have the [ReadPCDToBasicOctree](https://github.com/viamrobotics/rdk/blob/main/pointcloud/pointcloud_file.go#L536) method. However in order to use it on a pointcloud.PointCloud object, a user first needs to convert it into a PCD file and only then are they able to use the mentioned method. This is not an optimal route.

The goal of this PR is to add a function which removes the step of converting a pointcloud into a file.