### PR TITLE
RSDK-9292 - change module specific logs to use the module logger

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -270,11 +270,12 @@ func (mgr *Manager) Add(ctx context.Context, confs ...config.Module) error {
 		wg.Add(1)
 		go func(i int, conf config.Module) {
 			defer wg.Done()
+			moduleLogger := mgr.logger.Sublogger(conf.Name)
 
-			mgr.logger.CInfow(ctx, "Now adding module", "module", conf.Name)
-			err := mgr.add(ctx, conf)
+			moduleLogger.CInfow(ctx, "Now adding module", "module", conf.Name)
+			err := mgr.add(ctx, conf, moduleLogger)
 			if err != nil {
-				mgr.logger.CErrorw(ctx, "Error adding module", "module", conf.Name, "error", err)
+				moduleLogger.CErrorw(ctx, "Error adding module", "module", conf.Name, "error", err)
 				errs[i] = err
 				return
 			}
@@ -293,9 +294,10 @@ func (mgr *Manager) Add(ctx context.Context, confs ...config.Module) error {
 	return combinedErr
 }
 
-func (mgr *Manager) add(ctx context.Context, conf config.Module) error {
+func (mgr *Manager) add(ctx context.Context, conf config.Module, moduleLogger logging.Logger) error {
 	_, exists := mgr.modules.Load(conf.Name)
 	if exists {
+		// Keeping this as a manager logger since it is dealing with manager behavior
 		mgr.logger.CWarnw(ctx, "Not adding module that already exists", "module", conf.Name)
 		return nil
 	}
@@ -315,7 +317,7 @@ func (mgr *Manager) add(ctx context.Context, conf config.Module) error {
 		cfg:       conf,
 		dataDir:   moduleDataDir,
 		resources: map[resource.Name]*addedResource{},
-		logger:    mgr.logger.Sublogger(conf.Name),
+		logger:    moduleLogger,
 	}
 
 	if err := mgr.startModule(ctx, mod); err != nil {
@@ -329,7 +331,6 @@ func (mgr *Manager) startModuleProcess(mod *module) error {
 		mgr.restartCtx,
 		mgr.parentAddr,
 		mgr.newOnUnexpectedExitHandler(mod),
-		mgr.logger,
 		mgr.viamHomeDir,
 		mgr.packagesDir,
 	)
@@ -346,20 +347,20 @@ func (mgr *Manager) startModule(ctx context.Context, mod *module) error {
 	var success bool
 	defer func() {
 		if !success {
-			mod.cleanupAfterStartupFailure(mgr.logger)
+			mod.cleanupAfterStartupFailure()
 		}
 	}()
 
 	// create the module's data directory
 	if mod.dataDir != "" {
-		mgr.logger.Debugf("Creating data directory %q for module %q", mod.dataDir, mod.cfg.Name)
+		mod.logger.Debugf("Creating data directory %q for module %q", mod.dataDir, mod.cfg.Name)
 		if err := os.MkdirAll(mod.dataDir, 0o750); err != nil {
 			return errors.WithMessage(err, "error while creating data directory for module "+mod.cfg.Name)
 		}
 	}
 
 	cleanup := rutils.SlowStartupLogger(
-		ctx, "Waiting for module to complete startup and registration", "module", mod.cfg.Name, mgr.logger)
+		ctx, "Waiting for module to complete startup and registration", "module", mod.cfg.Name, mod.logger)
 	defer cleanup()
 
 	if err := mgr.startModuleProcess(mod); err != nil {
@@ -370,13 +371,13 @@ func (mgr *Manager) startModule(ctx context.Context, mod *module) error {
 		return errors.WithMessage(err, "error while dialing module "+mod.cfg.Name)
 	}
 
-	if err := mod.checkReady(ctx, mgr.parentAddr, mgr.logger); err != nil {
+	if err := mod.checkReady(ctx, mgr.parentAddr); err != nil {
 		return errors.WithMessage(err, "error while waiting for module to be ready "+mod.cfg.Name)
 	}
 
-	mod.registerResources(mgr, mgr.logger)
+	mod.registerResources(mgr)
 	mgr.modules.Store(mod.cfg.Name, mod)
-	mgr.logger.Infow("Module successfully added", "module", mod.cfg.Name)
+	mod.logger.Infow("Module successfully added", "module", mod.cfg.Name)
 	success = true
 	return nil
 }
@@ -399,7 +400,7 @@ func (mgr *Manager) Reconfigure(ctx context.Context, conf config.Module) ([]reso
 		handledResourceNameStrings = append(handledResourceNameStrings, name.String())
 	}
 
-	mgr.logger.CInfow(ctx, "Module configuration changed. Stopping the existing module process", "module", conf.Name)
+	mod.logger.CInfow(ctx, "Module configuration changed. Stopping the existing module process", "module", conf.Name)
 
 	if err := mgr.closeModule(mod, true); err != nil {
 		// If removal fails, assume all handled resources are orphaned.
@@ -409,17 +410,17 @@ func (mgr *Manager) Reconfigure(ctx context.Context, conf config.Module) ([]reso
 	mod.cfg = conf
 	mod.resources = map[resource.Name]*addedResource{}
 
-	mgr.logger.CInfow(ctx, "Existing module process stopped. Starting new module process", "module", conf.Name)
+	mod.logger.CInfow(ctx, "Existing module process stopped. Starting new module process", "module", conf.Name)
 
 	if err := mgr.startModule(ctx, mod); err != nil {
 		// If re-addition fails, assume all handled resources are orphaned.
 		return handledResourceNames, err
 	}
 
-	mgr.logger.CInfow(ctx, "New module process is running and responding to gRPC requests", "module",
+	mod.logger.CInfow(ctx, "New module process is running and responding to gRPC requests", "module",
 		mod.cfg.Name, "module address", mod.addr)
 
-	mgr.logger.CInfow(ctx, "Resources handled by reconfigured module will be re-added to new module process",
+	mod.logger.CInfow(ctx, "Resources handled by reconfigured module will be re-added to new module process",
 		"module", mod.cfg.Name, "resources", handledResourceNameStrings)
 	return handledResourceNames, nil
 }
@@ -462,16 +463,16 @@ func (mgr *Manager) Remove(modName string) ([]resource.Name, error) {
 func (mgr *Manager) closeModule(mod *module, reconfigure bool) error {
 	// resource manager should've removed these cleanly if this isn't a reconfigure
 	if !reconfigure && len(mod.resources) != 0 {
-		mgr.logger.Warnw("Forcing removal of module with active resources", "module", mod.cfg.Name)
+		mod.logger.Warnw("Forcing removal of module with active resources", "module", mod.cfg.Name)
 	}
 
 	// need to actually close the resources within the module itself before stopping
 	for res := range mod.resources {
 		_, err := mod.client.RemoveResource(context.Background(), &pb.RemoveResourceRequest{Name: res.String()})
 		if err != nil {
-			mgr.logger.Errorw("Error removing resource", "module", mod.cfg.Name, "resource", res.Name, "error", err)
+			mod.logger.Errorw("Error removing resource", "module", mod.cfg.Name, "resource", res.Name, "error", err)
 		} else {
-			mgr.logger.Infow("Successfully removed resource from module", "module", mod.cfg.Name, "resource", res.Name)
+			mod.logger.Infow("Successfully removed resource from module", "module", mod.cfg.Name, "resource", res.Name)
 		}
 	}
 
@@ -480,7 +481,7 @@ func (mgr *Manager) closeModule(mod *module, reconfigure bool) error {
 	}
 
 	if err := mod.sharedConn.Close(); err != nil {
-		mgr.logger.Warnw("Error closing connection to module", "error", err)
+		mod.logger.Warnw("Error closing connection to module", "error", err)
 	}
 
 	mod.deregisterResources()
@@ -493,7 +494,7 @@ func (mgr *Manager) closeModule(mod *module, reconfigure bool) error {
 	})
 	mgr.modules.Delete(mod.cfg.Name)
 
-	mgr.logger.Infow("Module successfully closed", "module", mod.cfg.Name)
+	mod.logger.Infow("Module successfully closed", "module", mod.cfg.Name)
 	return nil
 }
 
@@ -516,7 +517,7 @@ func (mgr *Manager) addResource(ctx context.Context, conf resource.Config, deps 
 		return nil, errors.Errorf("no active module registered to serve resource api %s and model %s", conf.API, conf.Model)
 	}
 
-	mgr.logger.CInfow(ctx, "Adding resource to module", "resource", conf.Name, "module", mod.cfg.Name)
+	mod.logger.CInfow(ctx, "Adding resource to module", "resource", conf.Name, "module", mod.cfg.Name)
 
 	confProto, err := config.ComponentConfigToProto(&conf)
 	if err != nil {
@@ -535,7 +536,7 @@ func (mgr *Manager) addResource(ctx context.Context, conf resource.Config, deps 
 
 	apiInfo, ok := resource.LookupGenericAPIRegistration(conf.API)
 	if !ok || apiInfo.RPCClient == nil {
-		mgr.logger.CWarnw(ctx, "No built-in grpc client for modular resource", "resource", conf.ResourceName())
+		mod.logger.CWarnw(ctx, "No built-in grpc client for modular resource", "resource", conf.ResourceName())
 		return rdkgrpc.NewForeignResource(conf.ResourceName(), &mod.sharedConn), nil
 	}
 
@@ -549,7 +550,7 @@ func (mgr *Manager) ReconfigureResource(ctx context.Context, conf resource.Confi
 		return errors.Errorf("no module registered to serve resource api %s and model %s", conf.API, conf.Model)
 	}
 
-	mgr.logger.CInfow(ctx, "Reconfiguring resource for module", "resource", conf.Name, "module", mod.cfg.Name)
+	mod.logger.CInfow(ctx, "Reconfiguring resource for module", "resource", conf.Name, "module", mod.cfg.Name)
 
 	confProto, err := config.ComponentConfigToProto(&conf)
 	if err != nil {
@@ -599,7 +600,7 @@ func (mgr *Manager) RemoveResource(ctx context.Context, name resource.Name) erro
 		return errors.Errorf("resource %+v not found in module", name)
 	}
 
-	mgr.logger.CInfow(ctx, "Removing resource for module", "resource", name.String(), "module", mod.cfg.Name)
+	mod.logger.CInfow(ctx, "Removing resource for module", "resource", name.String(), "module", mod.cfg.Name)
 
 	mgr.rMap.Delete(name)
 	delete(mod.resources, name)
@@ -840,7 +841,7 @@ func (mgr *Manager) newOnUnexpectedExitHandler(mod *module) func(exitCode int) b
 		defer mod.inStartup.Store(false)
 
 		// Log error immediately, as this is unexpected behavior.
-		mgr.logger.Errorw(
+		mod.logger.Errorw(
 			"Module has unexpectedly exited.", "module", mod.cfg.Name, "exit_code", exitCode,
 		)
 
@@ -856,7 +857,7 @@ func (mgr *Manager) newOnUnexpectedExitHandler(mod *module) func(exitCode int) b
 		if orphanedResourceNames := mgr.attemptRestart(mgr.restartCtx, mod); orphanedResourceNames != nil {
 			if mgr.removeOrphanedResources != nil {
 				mgr.removeOrphanedResources(mgr.restartCtx, orphanedResourceNames)
-				mgr.logger.Debugw(
+				mod.logger.Debugw(
 					"Removed resources after failed module restart",
 					"module", mod.cfg.Name,
 					"resources", resource.NamesToStrings(orphanedResourceNames),
@@ -864,7 +865,7 @@ func (mgr *Manager) newOnUnexpectedExitHandler(mod *module) func(exitCode int) b
 			}
 			return false
 		}
-		mgr.logger.Infow("Module successfully restarted, re-adding resources", "module", mod.cfg.Name)
+		mod.logger.Infow("Module successfully restarted, re-adding resources", "module", mod.cfg.Name)
 
 		// Otherwise, add old module process' resources to new module; warn if new
 		// module cannot handle old resource and remove it from mod.resources.
@@ -875,7 +876,7 @@ func (mgr *Manager) newOnUnexpectedExitHandler(mod *module) func(exitCode int) b
 			// read lock, so we execute it here with a write lock to make sure it doesn't
 			// run concurrently.
 			if _, err := mgr.addResourceWithWriteLock(mgr.restartCtx, res.conf, res.deps); err != nil {
-				mgr.logger.Warnw("Error while re-adding resource to module",
+				mod.logger.Warnw("Error while re-adding resource to module",
 					"resource", name, "module", mod.cfg.Name, "error", err)
 				mgr.rMap.Delete(name)
 
@@ -890,7 +891,7 @@ func (mgr *Manager) newOnUnexpectedExitHandler(mod *module) func(exitCode int) b
 			mgr.removeOrphanedResources(mgr.restartCtx, orphanedResourceNames)
 		}
 
-		mgr.logger.Infow("Module resources successfully re-added after module restart", "module", mod.cfg.Name)
+		mod.logger.Infow("Module resources successfully re-added after module restart", "module", mod.cfg.Name)
 		return false
 	}
 }
@@ -939,7 +940,7 @@ func (mgr *Manager) attemptRestart(ctx context.Context, mod *module) []resource.
 	// executable we were given for initial module addition.
 
 	cleanup := rutils.SlowStartupLogger(
-		ctx, "Waiting for module to complete restart and re-registration", "module", mod.cfg.Name, mgr.logger)
+		ctx, "Waiting for module to complete restart and re-registration", "module", mod.cfg.Name, mod.logger)
 	defer cleanup()
 
 	// Attempt to restart module process 3 times.
@@ -971,13 +972,13 @@ func (mgr *Manager) attemptRestart(ctx context.Context, mod *module) []resource.
 		return orphanedResourceNames
 	}
 
-	if err := mod.checkReady(ctx, mgr.parentAddr, mgr.logger); err != nil {
+	if err := mod.checkReady(ctx, mgr.parentAddr); err != nil {
 		mgr.logger.CErrorw(ctx, "Error while waiting for restarted module to be ready",
 			"module", mod.cfg.Name, "error", err)
 		return orphanedResourceNames
 	}
 
-	mod.registerResources(mgr, mgr.logger)
+	mod.registerResources(mgr)
 
 	success = true
 	return nil
@@ -1023,11 +1024,11 @@ func (m *module) dial() error {
 
 // checkReady sends a `ReadyRequest` and waits for either a `ReadyResponse`, or a context
 // cancelation.
-func (m *module) checkReady(ctx context.Context, parentAddr string, logger logging.Logger) error {
-	ctxTimeout, cancelFunc := context.WithTimeout(ctx, rutils.GetModuleStartupTimeout(logger))
+func (m *module) checkReady(ctx context.Context, parentAddr string) error {
+	ctxTimeout, cancelFunc := context.WithTimeout(ctx, rutils.GetModuleStartupTimeout(m.logger))
 	defer cancelFunc()
 
-	logger.CInfow(ctx, "Waiting for module to respond to ready request", "module", m.cfg.Name)
+	m.logger.CInfow(ctx, "Waiting for module to respond to ready request", "module", m.cfg.Name)
 
 	req := &pb.ReadyRequest{ParentAddress: parentAddr}
 
@@ -1035,7 +1036,7 @@ func (m *module) checkReady(ctx context.Context, parentAddr string, logger loggi
 	var err error
 	req.WebrtcOffer, err = m.sharedConn.GenerateEncodedOffer()
 	if err != nil {
-		logger.CWarnw(ctx, "Unable to generate offer for module PeerConnection. Ignoring.", "err", err)
+		m.logger.CWarnw(ctx, "Unable to generate offer for module PeerConnection. Ignoring.", "err", err)
 	}
 
 	for {
@@ -1057,7 +1058,7 @@ func (m *module) checkReady(ctx context.Context, parentAddr string, logger loggi
 
 		err = m.sharedConn.ProcessEncodedAnswer(resp.WebrtcAnswer)
 		if err != nil {
-			logger.CWarnw(ctx, "Unable to create PeerConnection with module. Ignoring.", "err", err)
+			m.logger.CWarnw(ctx, "Unable to create PeerConnection with module. Ignoring.", "err", err)
 		}
 
 		// The `ReadyRespones` also includes the Viam `API`s and `Model`s the module provides. This
@@ -1091,7 +1092,6 @@ func (m *module) startProcess(
 	ctx context.Context,
 	parentAddr string,
 	oue func(int) bool,
-	logger logging.Logger,
 	viamHomeDir string,
 	packagesDir string,
 ) error {
@@ -1114,10 +1114,10 @@ func (m *module) startProcess(
 	moduleWorkingDirectory, ok := moduleEnvironment["VIAM_MODULE_ROOT"]
 	if !ok {
 		moduleWorkingDirectory = filepath.Dir(absoluteExePath)
-		logger.CDebugw(ctx, "VIAM_MODULE_ROOT was not passed to module. Defaulting to module's working directory",
+		m.logger.CDebugw(ctx, "VIAM_MODULE_ROOT was not passed to module. Defaulting to module's working directory",
 			"module", m.cfg.Name, "dir", moduleWorkingDirectory)
 	} else {
-		logger.CInfow(ctx, "Starting module in working directory", "module", m.cfg.Name, "dir", moduleWorkingDirectory)
+		m.logger.CInfow(ctx, "Starting module in working directory", "module", m.cfg.Name, "dir", moduleWorkingDirectory)
 	}
 
 	pconf := pexec.ProcessConfig{
@@ -1133,11 +1133,11 @@ func (m *module) startProcess(
 	// supplied and module manager has a DebugLevel logger.
 	if m.cfg.LogLevel != "" {
 		pconf.Args = append(pconf.Args, fmt.Sprintf(logLevelArgumentTemplate, m.cfg.LogLevel))
-	} else if logger.Level().Enabled(zapcore.DebugLevel) {
+	} else if m.logger.Level().Enabled(zapcore.DebugLevel) {
 		pconf.Args = append(pconf.Args, fmt.Sprintf(logLevelArgumentTemplate, "debug"))
 	}
 
-	m.process = pexec.NewManagedProcess(pconf, logger)
+	m.process = pexec.NewManagedProcess(pconf, m.logger)
 
 	if err := m.process.Start(context.Background()); err != nil {
 		return errors.WithMessage(err, "module startup failed")
@@ -1146,8 +1146,8 @@ func (m *module) startProcess(
 	checkTicker := time.NewTicker(100 * time.Millisecond)
 	defer checkTicker.Stop()
 
-	logger.CInfow(ctx, "Starting up module", "module", m.cfg.Name)
-	ctxTimeout, cancel := context.WithTimeout(ctx, rutils.GetModuleStartupTimeout(logger))
+	m.logger.CInfow(ctx, "Starting up module", "module", m.cfg.Name)
+	ctxTimeout, cancel := context.WithTimeout(ctx, rutils.GetModuleStartupTimeout(m.logger))
 	defer cancel()
 	for {
 		select {
@@ -1193,10 +1193,11 @@ func (m *module) stopProcess() error {
 		}
 		return err
 	}
+	m.logger.Infof("Stopping module: %s process", m.cfg.Name)
 	return nil
 }
 
-func (m *module) registerResources(mgr modmaninterface.ModuleManager, logger logging.Logger) {
+func (m *module) registerResources(mgr modmaninterface.ModuleManager) {
 	for api, models := range m.handles {
 		if _, ok := resource.LookupGenericAPIRegistration(api.API); !ok {
 			resource.RegisterAPI(
@@ -1208,7 +1209,7 @@ func (m *module) registerResources(mgr modmaninterface.ModuleManager, logger log
 		switch {
 		case api.API.IsComponent():
 			for _, model := range models {
-				logger.Infow("Registering component API and model from module", "module", m.cfg.Name, "API", api.API, "model", model)
+				m.logger.Infow("Registering component API and model from module", "module", m.cfg.Name, "API", api.API, "model", model)
 				// We must copy because the Discover closure func relies on api and model, but they are iterators and mutate.
 				// Copying prevents mutation.
 				modelCopy := model
@@ -1251,7 +1252,7 @@ func (m *module) registerResources(mgr modmaninterface.ModuleManager, logger log
 			}
 		case api.API.IsService():
 			for _, model := range models {
-				logger.Infow("Registering service API and model from module", "module", m.cfg.Name, "API", api.API, "model", model)
+				m.logger.Infow("Registering service API and model from module", "module", m.cfg.Name, "API", api.API, "model", model)
 				resource.RegisterService(api.API, model, resource.Registration[resource.Resource, resource.NoNativeConfig]{
 					Constructor: func(
 						ctx context.Context,
@@ -1264,7 +1265,7 @@ func (m *module) registerResources(mgr modmaninterface.ModuleManager, logger log
 				})
 			}
 		default:
-			logger.Errorw("Invalid module type", "API type", api.API.Type)
+			m.logger.Errorw("Invalid module type", "API type", api.API.Type)
 		}
 	}
 }
@@ -1278,10 +1279,10 @@ func (m *module) deregisterResources() {
 	m.handles = nil
 }
 
-func (m *module) cleanupAfterStartupFailure(logger logging.Logger) {
+func (m *module) cleanupAfterStartupFailure() {
 	if err := m.stopProcess(); err != nil {
 		msg := "Error while stopping process of module that failed to start"
-		logger.Errorw(msg, "module", m.cfg.Name, "error", err)
+		m.logger.Errorw(msg, "module", m.cfg.Name, "error", err)
 	}
 	utils.UncheckedError(m.sharedConn.Close())
 }

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -118,16 +118,16 @@ func TestModManagerFunctions(t *testing.T) {
 		logger:  logger,
 	}
 
-	err = mod.startProcess(ctx, parentAddr, nil, logger, viamHomeTemp, filepath.Join(viamHomeTemp, "packages"))
+	err = mod.startProcess(ctx, parentAddr, nil, viamHomeTemp, filepath.Join(viamHomeTemp, "packages"))
 	test.That(t, err, test.ShouldBeNil)
 
 	err = mod.dial()
 	test.That(t, err, test.ShouldBeNil)
 
-	err = mod.checkReady(ctx, parentAddr, logger)
+	err = mod.checkReady(ctx, parentAddr)
 	test.That(t, err, test.ShouldBeNil)
 
-	mod.registerResources(mgr, logger)
+	mod.registerResources(mgr)
 	reg, ok := resource.LookupRegistration(generic.API, myCounterModel)
 	test.That(t, ok, test.ShouldBeTrue)
 	test.That(t, reg, test.ShouldNotBeNil)
@@ -155,7 +155,7 @@ func TestModManagerFunctions(t *testing.T) {
 	oldAddr := mod.addr
 	oldClient := mod.client
 
-	utils.UncheckedError(mod.startProcess(ctx, parentAddr, nil, logger, viamHomeTemp, filepath.Join(viamHomeTemp, "packages")))
+	utils.UncheckedError(mod.startProcess(ctx, parentAddr, nil, viamHomeTemp, filepath.Join(viamHomeTemp, "packages")))
 	err = mod.dial()
 	test.That(t, err, test.ShouldBeNil)
 


### PR DESCRIPTION
## Feature
- Module specific logs will now use the module logger instead of the mod manager logger