### PR TITLE
RDSK-9311: (gripper/input-controller) Guard against nil responses in rdk client/servers

### DIFF
--- a/components/gripper/client_test.go
+++ b/components/gripper/client_test.go
@@ -59,6 +59,9 @@ func TestClient(t *testing.T) {
 	injectGripper2.StopFunc = func(ctx context.Context, extra map[string]interface{}) error {
 		return errStopUnimplemented
 	}
+	injectGripper2.GeometriesFunc = func(ctx context.Context) ([]spatialmath.Geometry, error) {
+		return nil, nil
+	}
 
 	gripperSvc, err := resource.NewAPIResourceCollection(
 		gripper.API,
@@ -144,6 +147,9 @@ func TestClient(t *testing.T) {
 		err = client2.Stop(context.Background(), extra)
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errStopUnimplemented.Error())
+
+		_, err = client2.Geometries(context.Background(), extra)
+		test.That(t, err.Error(), test.ShouldContainSubstring, gripper.ErrGeometriesNil(failGripperName).Error())
 
 		test.That(t, client2.Close(context.Background()), test.ShouldBeNil)
 		test.That(t, conn.Close(), test.ShouldBeNil)

--- a/components/gripper/server.go
+++ b/components/gripper/server.go
@@ -3,6 +3,7 @@ package gripper
 
 import (
 	"context"
+	"fmt"
 
 	commonpb "go.viam.com/api/common/v1"
 	pb "go.viam.com/api/component/gripper/v1"
@@ -12,6 +13,11 @@ import (
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/spatialmath"
 )
+
+// ErrGeometriesNil is the returned error if gripper geometries are nil.
+var ErrGeometriesNil = func(gripperName string) error {
+	return fmt.Errorf("gripper component %v Geometries should not return nil geometries", gripperName)
+}
 
 // serviceServer implements the GripperService from gripper.proto.
 type serviceServer struct {
@@ -89,6 +95,9 @@ func (s *serviceServer) GetGeometries(ctx context.Context, req *commonpb.GetGeom
 	geometries, err := res.Geometries(ctx, req.Extra.AsMap())
 	if err != nil {
 		return nil, err
+	}
+	if geometries == nil {
+		return nil, ErrGeometriesNil(req.GetName())
 	}
 	return &commonpb.GetGeometriesResponse{Geometries: spatialmath.NewGeometriesToProto(geometries)}, nil
 }

--- a/components/input/client.go
+++ b/components/input/client.go
@@ -76,6 +76,9 @@ func (c *client) Controls(ctx context.Context, extra map[string]interface{}) ([]
 	if err != nil {
 		return nil, err
 	}
+	if resp.Controls == nil {
+		return nil, nil
+	}
 	var controls []Control
 	for _, control := range resp.Controls {
 		controls = append(controls, Control(control))
@@ -94,6 +97,9 @@ func (c *client) Events(ctx context.Context, extra map[string]interface{}) (map[
 	})
 	if err != nil {
 		return nil, err
+	}
+	if resp.Events == nil {
+		return nil, nil
 	}
 
 	eventsOut := make(map[Control]Event)

--- a/components/input/client_test.go
+++ b/components/input/client_test.go
@@ -67,14 +67,6 @@ func TestClient(t *testing.T) {
 		return nil, nil
 	}
 
-	injectInputController3 := &inject.InputController{}
-	injectInputController3.ControlsFunc = func(ctx context.Context, extra map[string]interface{}) ([]input.Control, error) {
-		return nil, nil
-	}
-	injectInputController3.EventsFunc = func(ctx context.Context, extra map[string]interface{}) (map[input.Control]input.Event, error) {
-		return nil, nil
-	}
-
 	resources := map[resource.Name]input.Controller{
 		input.Named(testInputControllerName): injectInputController,
 		input.Named(failInputControllerName): injectInputController2,

--- a/components/input/client_test.go
+++ b/components/input/client_test.go
@@ -67,9 +67,18 @@ func TestClient(t *testing.T) {
 		return nil, errEventsFailed
 	}
 
+	injectInputController3 := &inject.InputController{}
+	injectInputController3.ControlsFunc = func(ctx context.Context, extra map[string]interface{}) ([]input.Control, error) {
+		return nil, nil
+	}
+	injectInputController3.EventsFunc = func(ctx context.Context, extra map[string]interface{}) (map[input.Control]input.Event, error) {
+		return nil, nil
+	}
+
 	resources := map[resource.Name]input.Controller{
-		input.Named(testInputControllerName): injectInputController,
-		input.Named(failInputControllerName): injectInputController2,
+		input.Named(testInputControllerName):  injectInputController,
+		input.Named(failInputControllerName):  injectInputController2,
+		input.Named(testInputControllerName4): injectInputController3,
 	}
 	inputControllerSvc, err := resource.NewAPIResourceCollection(input.API, resources)
 	test.That(t, err, test.ShouldBeNil)
@@ -269,6 +278,26 @@ func TestClient(t *testing.T) {
 		err = injectable.TriggerEvent(context.Background(), event1, map[string]interface{}{})
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "not of type Triggerable")
+	})
+
+	t.Run("input controller client 3", func(t *testing.T) {
+		conn, err := viamgrpc.Dial(context.Background(), listener1.Addr().String(), logger)
+		test.That(t, err, test.ShouldBeNil)
+		client3, err := resourceAPI.RPCClient(context.Background(), conn, "", input.Named(failInputControllerName), logger)
+		test.That(t, err, test.ShouldBeNil)
+
+		defer func() {
+			test.That(t, client3.Close(context.Background()), test.ShouldBeNil)
+			test.That(t, conn.Close(), test.ShouldBeNil)
+		}()
+
+		_, err = client3.Controls(context.Background(), map[string]interface{}{})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, input.ErrControlsNil(testInputControllerName4).Error())
+
+		_, err = client3.Events(context.Background(), map[string]interface{}{})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, input.ErrEventsNil(testInputControllerName4).Error())
 	})
 }
 

--- a/components/input/server.go
+++ b/components/input/server.go
@@ -3,6 +3,7 @@ package input
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	commonpb "go.viam.com/api/common/v1"
@@ -11,6 +12,17 @@ import (
 
 	"go.viam.com/rdk/protoutils"
 	"go.viam.com/rdk/resource"
+)
+
+var (
+	// ErrControlsNil is the returned error if input controller controls are nil.
+	ErrControlsNil = func(inputName string) error {
+		return fmt.Errorf("input controller component %v Controls should not return nil controls", inputName)
+	}
+	// ErrEventsNil is the returned error if input controller events are nil.
+	ErrEventsNil = func(inputName string) error {
+		return fmt.Errorf("input controller component %v Events should not return nil events", inputName)
+	}
 )
 
 // serviceServer implements the InputControllerService from proto.
@@ -39,6 +51,9 @@ func (s *serviceServer) GetControls(
 	if err != nil {
 		return nil, err
 	}
+	if controlList == nil {
+		return nil, ErrControlsNil(req.Controller)
+	}
 
 	resp := &pb.GetControlsResponse{}
 
@@ -61,6 +76,9 @@ func (s *serviceServer) GetEvents(
 	eventsIn, err := controller.Events(ctx, req.Extra.AsMap())
 	if err != nil {
 		return nil, err
+	}
+	if eventsIn == nil {
+		return nil, ErrEventsNil(req.Controller)
 	}
 
 	resp := &pb.GetEventsResponse{}

--- a/components/input/server_test.go
+++ b/components/input/server_test.go
@@ -55,7 +55,13 @@ func (x *streamServer) Send(m *pb.StreamEventsResponse) error {
 	return nil
 }
 
-func newServer() (pb.InputControllerServiceServer, *inject.TriggerableInputController, *inject.InputController, *inject.InputController, error) {
+func newServer() (
+	pb.InputControllerServiceServer,
+	*inject.TriggerableInputController,
+	*inject.InputController,
+	*inject.InputController,
+	error,
+) {
 	injectInputController := &inject.TriggerableInputController{}
 	injectInputController2 := &inject.InputController{}
 	injectInputController3 := &inject.InputController{}
@@ -68,7 +74,11 @@ func newServer() (pb.InputControllerServiceServer, *inject.TriggerableInputContr
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
-	return input.NewRPCServiceServer(inputControllerSvc).(pb.InputControllerServiceServer), injectInputController, injectInputController2, injectInputController3, nil
+	return input.NewRPCServiceServer(inputControllerSvc).(pb.InputControllerServiceServer),
+		injectInputController,
+		injectInputController2,
+		injectInputController3,
+		nil
 }
 
 func TestServer(t *testing.T) {


### PR DESCRIPTION
went through encoder, gripper, input controller, motor, and posetracker server code to see what had the possibility to be returned as nil, and added checks to return errors in that case. also added tests for each nil failure. there were no changes for encoder, motor, or pose tracker.

added necessary tests to client test file to ensure that the server changes resulted in the same returned error, so the checks didn't need to be added in the client files as well.

still need to do this for the other components, but want to break up the work into smaller PRs (https://github.com/viamrobotics/rdk/pull/4618 & https://github.com/viamrobotics/rdk/pull/4621)