### PR TITLE
(powersensor/sensor) Guard against nil responses in rdk client/servers

### DIFF
--- a/components/powersensor/server.go
+++ b/components/powersensor/server.go
@@ -6,6 +6,7 @@ import (
 	commonpb "go.viam.com/api/common/v1"
 	pb "go.viam.com/api/component/powersensor/v1"
 
+	"go.viam.com/rdk/components/sensor"
 	"go.viam.com/rdk/protoutils"
 	"go.viam.com/rdk/resource"
 )
@@ -32,6 +33,9 @@ func (s *serviceServer) GetReadings(
 	readings, err := sensorDevice.Readings(ctx, req.Extra.AsMap())
 	if err != nil {
 		return nil, err
+	}
+	if readings == nil {
+		return nil, sensor.ErrReadingsNil("power-sensor", req.Name)
 	}
 	m, err := protoutils.ReadingGoToProto(readings)
 	if err != nil {

--- a/components/powersensor/server_test.go
+++ b/components/powersensor/server_test.go
@@ -179,6 +179,14 @@ func TestServerGetReadings(t *testing.T) {
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, errReadingsFailed.Error())
 
+	failingPowerSensor.ReadingsFunc = func(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+		return nil, nil
+	}
+
+	_, err = powerSensorServer.GetReadings(context.Background(), &commonpb.GetReadingsRequest{Name: failingPowerSensorName})
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, sensor.ErrReadingsNil("power-sensor", failingPowerSensorName).Error())
+
 	_, err = powerSensorServer.GetReadings(context.Background(), &commonpb.GetReadingsRequest{Name: missingPowerSensorName})
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "not found")

--- a/components/sensor/client_test.go
+++ b/components/sensor/client_test.go
@@ -106,6 +106,13 @@ func TestClient(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errReadingsFailed.Error())
 
+		injectSensor2.ReadingsFunc = func(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+			return nil, nil
+		}
+		_, err = client2.Readings(context.Background(), make(map[string]interface{}))
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, sensor.ErrReadingsNil("sensor", failSensorName).Error())
+
 		test.That(t, client2.Close(context.Background()), test.ShouldBeNil)
 		test.That(t, conn.Close(), test.ShouldBeNil)
 	})

--- a/components/sensor/server.go
+++ b/components/sensor/server.go
@@ -13,7 +13,7 @@ import (
 )
 
 // ErrReadingsNil is the returned error if sensor readings are nil.
-var ErrReadingsNil = func(sensorName, sensorType string) error {
+var ErrReadingsNil = func(sensorType, sensorName string) error {
 	return fmt.Errorf("%v component %v Readings should not return nil readings", sensorType, sensorName)
 }
 

--- a/components/sensor/server.go
+++ b/components/sensor/server.go
@@ -3,6 +3,7 @@ package sensor
 
 import (
 	"context"
+	"fmt"
 
 	commonpb "go.viam.com/api/common/v1"
 	pb "go.viam.com/api/component/sensor/v1"
@@ -10,6 +11,11 @@ import (
 	"go.viam.com/rdk/protoutils"
 	"go.viam.com/rdk/resource"
 )
+
+// ErrReadingsNil is the returned error if sensor readings are nil.
+var ErrReadingsNil = func(sensorName, sensorType string) error {
+	return fmt.Errorf("%v component %v Readings should not return nil readings", sensorType, sensorName)
+}
 
 // serviceServer implements the SensorService from sensor.proto.
 type serviceServer struct {
@@ -34,6 +40,9 @@ func (s *serviceServer) GetReadings(
 	readings, err := sensorDevice.Readings(ctx, req.Extra.AsMap())
 	if err != nil {
 		return nil, err
+	}
+	if readings == nil {
+		return nil, ErrReadingsNil("sensor", req.Name)
 	}
 	m, err := protoutils.ReadingGoToProto(readings)
 	if err != nil {

--- a/components/sensor/server_test.go
+++ b/components/sensor/server_test.go
@@ -67,6 +67,13 @@ func TestServer(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errReadingsFailed.Error())
 
+		injectSensor2.ReadingsFunc = func(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+			return nil, nil
+		}
+		_, err = sensorServer.GetReadings(context.Background(), &commonpb.GetReadingsRequest{Name: failSensorName})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, sensor.ErrReadingsNil("sensor", failSensorName).Error())
+
 		_, err = sensorServer.GetReadings(context.Background(), &commonpb.GetReadingsRequest{Name: missingSensorName})
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "not found")

--- a/protoutils/sensor.go
+++ b/protoutils/sensor.go
@@ -125,6 +125,9 @@ func ReadingGoToProto(readings map[string]interface{}) (map[string]*structpb.Val
 
 // ReadingProtoToGo converts proto readings to go readings.
 func ReadingProtoToGo(readings map[string]*structpb.Value) (map[string]interface{}, error) {
+	if readings == nil {
+		return nil, nil
+	}
 	m := map[string]interface{}{}
 	for k, v := range readings {
 		m[k] = cleanSensorType(v.AsInterface())


### PR DESCRIPTION
went through power sensor, sensor, and servo server code to see what had the possibility to be returned as nil, and added checks to return errors in that case. also added tests for each nil failure. there were no changes for servo.

added necessary tests to client test file to ensure that the server changes resulted in the same returned error, so the checks didn't need to be added in the client files as well.

work for other components are in other PRs (https://github.com/viamrobotics/rdk/pull/4618 & https://github.com/viamrobotics/rdk/pull/4620)