### PR TITLE
help users better understand who really owns the socks

### DIFF
--- a/module/module_unix.go
+++ b/module/module_unix.go
@@ -5,8 +5,8 @@ package module
 import (
 	"os"
 	"os/user"
-	"syscall"
 	"strconv"
+	"syscall"
 
 	"github.com/pkg/errors"
 )
@@ -26,17 +26,17 @@ func CheckSocketOwner(address string) error {
 	if err != nil {
 		return err
 	}
-	sockUid := int(info.Sys().(*syscall.Stat_t).Uid)
-	if osUid := os.Getuid(); osUid != sockUid {
-		sockUser, err := user.LookupId(strconv.Itoa(sockUid))
+	sockUID := int(info.Sys().(*syscall.Stat_t).Uid)
+	if serverUID := os.Getuid(); serverUID != sockUID {
+		sockUser, err := user.LookupId(strconv.Itoa(sockUID))
 		if err != nil {
 			return errors.Wrap(err, "error looking up user")
 		}
-		osUser, err := user.LookupId(strconv.Itoa(osUid))
+		serverUser, err := user.LookupId(strconv.Itoa(serverUID))
 		if err != nil {
 			return errors.Wrap(err, "error looking up user")
 		}
-		return errors.Errorf("socket owned by %s while process is owned by %s", sockUser.Name, osUser.Name)
+		return errors.Errorf("socket owned by %s while process is owned by %s", sockUser.Name, serverUser.Name)
 	}
 	return nil
 }


### PR DESCRIPTION
I'm doing something funny with this module I'm writing where I need to execute the binary as the root user.  If I then run viam-server as a non-root user I got a vague message talking about sock ownership.  This seems like a less than ideal user experience, that we can make better by more explicitly answering the burning questions that must be on their mind relating to who owns the socks. 

The new error can be seen below
<img width="1132" alt="Screenshot 2024-12-11 at 5 44 58 PM" src="https://github.com/user-attachments/assets/40dff432-2f88-4279-8c58-7b1544c8d435" />
