### PR TITLE
[RSDK-9512]   Remove Stream and ReadImage tests

### DIFF
--- a/components/camera/camera_test.go
+++ b/components/camera/camera_test.go
@@ -10,7 +10,6 @@ import (
 	"go.viam.com/utils/artifact"
 
 	"go.viam.com/rdk/components/camera"
-	"go.viam.com/rdk/gostream"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/resource"
@@ -186,18 +185,6 @@ func TestCameraWithNoProjector(t *testing.T) {
 	_, got := pc.At(0, 0, 0)
 	test.That(t, got, test.ShouldBeTrue)
 
-	// TODO(hexbabe): remove below test when Stream is refactored
-	t.Run("ReadImage depth map without projector", func(t *testing.T) {
-		img, _, err := camera.ReadImage(
-			gostream.WithMIMETypeHint(context.Background(), rutils.WithLazyMIMEType(rutils.MimeTypePNG)),
-			noProj2)
-		test.That(t, err, test.ShouldBeNil)
-		depthImg := img.(*rimage.DepthMap)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, depthImg.Bounds().Dx(), test.ShouldEqual, 1280)
-		test.That(t, depthImg.Bounds().Dy(), test.ShouldEqual, 720)
-	})
-
 	img, err := camera.DecodeImageFromCamera(context.Background(), rutils.WithLazyMIMEType(rutils.MimeTypePNG), nil, noProj2)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -246,26 +233,6 @@ func TestCameraWithProjector(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	_, got := pc.At(0, 0, 0)
 	test.That(t, got, test.ShouldBeTrue)
-
-	// TODO(hexbabe): remove below test when Stream/ReadImage pattern is refactored
-	t.Run("ReadImage depth map with projector", func(t *testing.T) {
-		img, _, err := camera.ReadImage(
-			gostream.WithMIMETypeHint(context.Background(), rutils.MimeTypePNG),
-			cam2)
-		test.That(t, err, test.ShouldBeNil)
-
-		depthImg := img.(*rimage.DepthMap)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, depthImg.Bounds().Dx(), test.ShouldEqual, 1280)
-		test.That(t, depthImg.Bounds().Dy(), test.ShouldEqual, 720)
-		// cam2 should implement a default GetImages, that just returns the one image
-		images, _, err := cam2.Images(context.Background())
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, len(images), test.ShouldEqual, 1)
-		test.That(t, images[0].Image, test.ShouldHaveSameTypeAs, &rimage.DepthMap{})
-		test.That(t, images[0].Image.Bounds().Dx(), test.ShouldEqual, 1280)
-		test.That(t, images[0].Image.Bounds().Dy(), test.ShouldEqual, 720)
-	})
 
 	img, err := camera.DecodeImageFromCamera(context.Background(), rutils.MimeTypePNG, nil, cam2)
 	test.That(t, err, test.ShouldBeNil)

--- a/components/camera/client_test.go
+++ b/components/camera/client_test.go
@@ -275,7 +275,6 @@ func TestClient(t *testing.T) {
 			return nil, camera.ImageMetadata{}, errGetImageFailed
 		}
 
-		// one kvp created with map[string]interface{}
 		ctx := context.Background()
 		_, _, err = camClient.Image(ctx, "", nil)
 		test.That(t, err, test.ShouldNotBeNil)

--- a/components/camera/client_test.go
+++ b/components/camera/client_test.go
@@ -178,25 +178,7 @@ func TestClient(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		camera1Client, err := camera.NewClientFromConn(context.Background(), conn, "", camera.Named(testCameraName), logger)
 		test.That(t, err, test.ShouldBeNil)
-		// TODO(hexbabe): remove below test when Stream/ReadImage pattern is refactored
-		t.Run("ReadImage from camera client 1", func(t *testing.T) {
-			// Test Stream and Next
-			ctx := gostream.WithMIMETypeHint(context.Background(), rutils.MimeTypeRawRGBA)
-			stream, err := camera1Client.Stream(ctx)
-			test.That(t, err, test.ShouldBeNil)
-			frame, _, err := stream.Next(ctx)
-			test.That(t, err, test.ShouldBeNil)
-			compVal, _, err := rimage.CompareImages(img, frame)
-			test.That(t, err, test.ShouldBeNil)
-			test.That(t, compVal, test.ShouldEqual, 0) // exact copy, no color conversion
 
-			// Test ReadImage
-			frame, _, err = camera.ReadImage(ctx, camera1Client)
-			test.That(t, err, test.ShouldBeNil)
-			compVal, _, err = rimage.CompareImages(img, frame)
-			test.That(t, err, test.ShouldBeNil)
-			test.That(t, compVal, test.ShouldEqual, 0)
-		})
 		frame, err := camera.DecodeImageFromCamera(context.Background(), rutils.MimeTypeRawRGBA, nil, camera1Client)
 		test.That(t, err, test.ShouldBeNil)
 		compVal, _, err := rimage.CompareImages(img, frame)
@@ -246,17 +228,6 @@ func TestClient(t *testing.T) {
 		client, err := resourceAPI.RPCClient(context.Background(), conn, "", camera.Named(depthCameraName), logger)
 		test.That(t, err, test.ShouldBeNil)
 
-		// TODO(hexbabe): remove below test when Stream/ReadImage pattern is refactored
-		t.Run("ReadImage from camera depth", func(t *testing.T) {
-			ctx := gostream.WithMIMETypeHint(
-				context.Background(), rutils.WithLazyMIMEType(rutils.MimeTypePNG))
-			frame, _, err := camera.ReadImage(ctx, client)
-			test.That(t, err, test.ShouldBeNil)
-			dm, err := rimage.ConvertImageToDepthMap(context.Background(), frame)
-			test.That(t, err, test.ShouldBeNil)
-			test.That(t, dm, test.ShouldResemble, depthImg)
-		})
-
 		ctx := context.Background()
 		frame, err := camera.DecodeImageFromCamera(ctx, rutils.WithLazyMIMEType(rutils.MimeTypePNG), nil, client)
 		test.That(t, err, test.ShouldBeNil)
@@ -304,25 +275,9 @@ func TestClient(t *testing.T) {
 			return nil, camera.ImageMetadata{}, errGetImageFailed
 		}
 
-		ctx := context.Background()
-		// TODO(hexbabe): remove below test when Stream/ReadImage pattern is refactored
-		t.Run("ReadImage test failure", func(t *testing.T) {
-			_, _, err = camera.ReadImage(ctx, camClient)
-			test.That(t, err, test.ShouldNotBeNil)
-			test.That(t, err.Error(), test.ShouldContainSubstring, errGetImageFailed.Error())
-		})
-		_, _, err = camClient.Image(ctx, "", nil)
-		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, errGetImageFailed.Error())
-
-		injectCamera.ImageFunc = func(ctx context.Context, mimeType string, extra map[string]interface{}) ([]byte, camera.ImageMetadata, error) {
-			test.That(t, len(extra), test.ShouldEqual, 1)
-			test.That(t, extra["hello"], test.ShouldEqual, "world")
-			return nil, camera.ImageMetadata{}, errGetImageFailed
-		}
-
 		// one kvp created with map[string]interface{}
 		ext := map[string]interface{}{"hello": "world"}
+		ctx := context.Background()
 		_, _, err = camClient.Image(ctx, "", ext)
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errGetImageFailed.Error())
@@ -509,17 +464,6 @@ func TestClientLazyImage(t *testing.T) {
 	camera1Client, err := camera.NewClientFromConn(context.Background(), conn, "", camera.Named(testCameraName), logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	// TODO(hexbabe): remove below test when Stream/ReadImage pattern is refactored
-	t.Run("lazily decode from ReadImage without lazy suffix", func(t *testing.T) {
-		ctx := gostream.WithMIMETypeHint(context.Background(), rutils.MimeTypePNG)
-		frame, _, err := camera.ReadImage(ctx, camera1Client)
-		test.That(t, err, test.ShouldBeNil)
-		// Should always lazily decode
-		test.That(t, frame, test.ShouldHaveSameTypeAs, &rimage.LazyEncodedImage{})
-		frameLazy := frame.(*rimage.LazyEncodedImage)
-		test.That(t, frameLazy.RawData(), test.ShouldResemble, imgBuf.Bytes())
-	})
-
 	ctx := context.Background()
 	frame, err := camera.DecodeImageFromCamera(ctx, rutils.MimeTypePNG, nil, camera1Client)
 	test.That(t, err, test.ShouldBeNil)
@@ -527,20 +471,6 @@ func TestClientLazyImage(t *testing.T) {
 	test.That(t, frame, test.ShouldHaveSameTypeAs, &rimage.LazyEncodedImage{})
 	frameLazy := frame.(*rimage.LazyEncodedImage)
 	test.That(t, frameLazy.RawData(), test.ShouldResemble, imgBuf.Bytes())
-
-	// TODO(hexbabe): remove below test when Stream/ReadImage pattern is refactored
-	t.Run("lazily decode from ReadImage", func(t *testing.T) {
-		ctx = gostream.WithMIMETypeHint(context.Background(), rutils.WithLazyMIMEType(rutils.MimeTypePNG))
-		frame, _, err = camera.ReadImage(ctx, camera1Client)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, frame, test.ShouldHaveSameTypeAs, &rimage.LazyEncodedImage{})
-		frameLazy = frame.(*rimage.LazyEncodedImage)
-		test.That(t, frameLazy.RawData(), test.ShouldResemble, imgBuf.Bytes())
-		test.That(t, frameLazy.MIMEType(), test.ShouldEqual, rutils.MimeTypePNG)
-		compVal, _, err := rimage.CompareImages(img, frame)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, compVal, test.ShouldEqual, 0) // exact copy, no color conversion
-	})
 
 	ctx = context.Background()
 	frame, err = camera.DecodeImageFromCamera(ctx, rutils.WithLazyMIMEType(rutils.MimeTypePNG), nil, camera1Client)

--- a/components/camera/client_test.go
+++ b/components/camera/client_test.go
@@ -276,9 +276,8 @@ func TestClient(t *testing.T) {
 		}
 
 		// one kvp created with map[string]interface{}
-		ext := map[string]interface{}{"hello": "world"}
 		ctx := context.Background()
-		_, _, err = camClient.Image(ctx, "", ext)
+		_, _, err = camClient.Image(ctx, "", nil)
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errGetImageFailed.Error())
 
@@ -301,7 +300,7 @@ func TestClient(t *testing.T) {
 		}
 
 		// merge values from data and camera
-		ext = data.FromDMExtraMap
+		ext := data.FromDMExtraMap
 		ext["hello"] = "world"
 		ctx = context.Background()
 		_, _, err = camClient.Image(ctx, "", ext)

--- a/components/camera/fake/camera_test.go
+++ b/components/camera/fake/camera_test.go
@@ -94,20 +94,6 @@ func TestRTPPassthrough(t *testing.T) {
 		cam, err := NewCamera(context.Background(), nil, cfg, logger)
 		test.That(t, err, test.ShouldBeNil)
 
-		// TODO(hexbabe): remove below test when Stream/ReadImage pattern is refactored
-		t.Run("test Stream and Next", func(t *testing.T) {
-			camera, err := NewCamera(context.Background(), nil, cfg, logger)
-			test.That(t, err, test.ShouldBeNil)
-
-			stream, err := camera.Stream(context.Background())
-			test.That(t, err, test.ShouldBeNil)
-			img, _, err := stream.Next(context.Background())
-			test.That(t, err, test.ShouldBeNil)
-			// GetImage returns the world jpeg
-			test.That(t, img.Bounds(), test.ShouldResemble, image.Rectangle{Max: image.Point{X: 480, Y: 270}})
-			test.That(t, camera, test.ShouldNotBeNil)
-		})
-
 		img, err := camera.DecodeImageFromCamera(context.Background(), utils.MimeTypeRawRGBA, nil, cam)
 		test.That(t, err, test.ShouldBeNil)
 		// GetImage returns the world jpeg

--- a/components/camera/fake/image_file_test.go
+++ b/components/camera/fake/image_file_test.go
@@ -27,10 +27,6 @@ func TestPCD(t *testing.T) {
 	cam, err := newCamera(ctx, resource.Name{API: camera.API}, cfg, logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	// TODO(hexbabe): remove below test when Stream/ReadImage pattern is refactored
-	_, err = cam.Stream(ctx)
-	test.That(t, err, test.ShouldBeNil)
-
 	pc, err := cam.NextPointCloud(ctx)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, pc.Size(), test.ShouldEqual, 628)
@@ -49,16 +45,6 @@ func TestPCD(t *testing.T) {
 
 	readInImage, err := rimage.NewImageFromFile(artifact.MustPath("vision/objectdetection/detection_test.jpg"))
 	test.That(t, err, test.ShouldBeNil)
-
-	// TODO(hexbabe): remove below test when Stream/ReadImage pattern is refactored
-	t.Run("test Stream and Next", func(t *testing.T) {
-		stream, err := cam.Stream(ctx)
-		test.That(t, err, test.ShouldBeNil)
-		strmImg, _, err := stream.Next(ctx)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, strmImg, test.ShouldResemble, readInImage)
-		test.That(t, strmImg.Bounds(), test.ShouldResemble, readInImage.Bounds())
-	})
 
 	imgBytes, _, err := cam.Image(ctx, utils.MimeTypeJPEG, nil)
 	test.That(t, err, test.ShouldBeNil)
@@ -83,16 +69,6 @@ func TestColor(t *testing.T) {
 
 	readInImage, err := rimage.NewImageFromFile(artifact.MustPath("vision/objectdetection/detection_test.jpg"))
 	test.That(t, err, test.ShouldBeNil)
-
-	// TODO(hexbabe): remove below test when Stream/ReadImage pattern is refactored
-	t.Run("test Stream and Next", func(t *testing.T) {
-		stream, err := cam.Stream(ctx)
-		test.That(t, err, test.ShouldBeNil)
-		strmImg, _, err := stream.Next(ctx)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, strmImg, test.ShouldResemble, readInImage)
-		test.That(t, strmImg.Bounds(), test.ShouldResemble, readInImage.Bounds())
-	})
 
 	imgBytes, _, err := cam.Image(ctx, utils.MimeTypeJPEG, nil)
 	test.That(t, err, test.ShouldBeNil)
@@ -125,21 +101,6 @@ func TestColorOddResolution(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	cam, err := newCamera(ctx, resource.Name{API: camera.API}, cfg, logger)
 	test.That(t, err, test.ShouldBeNil)
-
-	// TODO(hexbabe): remove below test when Stream/ReadImage pattern is refactored
-	t.Run("test Stream and Next", func(t *testing.T) {
-		stream, err := cam.Stream(ctx)
-		test.That(t, err, test.ShouldBeNil)
-
-		readInImage, err := rimage.NewImageFromFile(imgFilePath)
-		test.That(t, err, test.ShouldBeNil)
-
-		strmImg, _, err := stream.Next(ctx)
-		test.That(t, err, test.ShouldBeNil)
-
-		expectedBounds := image.Rect(0, 0, readInImage.Bounds().Dx()-1, readInImage.Bounds().Dy()-1)
-		test.That(t, strmImg, test.ShouldResemble, readInImage.SubImage(expectedBounds))
-	})
 
 	strmImg, err := camera.DecodeImageFromCamera(ctx, utils.MimeTypeRawRGBA, nil, cam)
 	test.That(t, err, test.ShouldBeNil)

--- a/components/camera/ffmpeg/ffmpeg_test.go
+++ b/components/camera/ffmpeg/ffmpeg_test.go
@@ -18,16 +18,11 @@ func TestFFMPEGCamera(t *testing.T) {
 	path := artifact.MustPath("components/camera/ffmpeg/testsrc.mpg")
 	cam, err := NewFFMPEGCamera(ctx, &Config{VideoPath: path}, logger)
 	test.That(t, err, test.ShouldBeNil)
-	// TODO(hexbabe): remove below test when Stream/ReadImage pattern is refactored
-	stream, err := cam.Stream(ctx)
 	test.That(t, err, test.ShouldBeNil)
 	for i := 0; i < 5; i++ {
-		_, _, err := stream.Next(ctx)
-		test.That(t, err, test.ShouldBeNil)
 		_, _, err = cam.Image(ctx, utils.MimeTypeJPEG, nil)
 		test.That(t, err, test.ShouldBeNil)
 	}
-	test.That(t, stream.Close(context.Background()), test.ShouldBeNil)
 	test.That(t, cam.Close(context.Background()), test.ShouldBeNil)
 }
 

--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -54,7 +54,6 @@ import (
 	"go.viam.com/rdk/components/sensor"
 	"go.viam.com/rdk/components/servo"
 	"go.viam.com/rdk/config"
-	"go.viam.com/rdk/gostream"
 	rgrpc "go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/operation"
@@ -504,12 +503,6 @@ func TestStatusClient(t *testing.T) {
 
 	camera1, err := camera.FromRobot(client, "camera1")
 	test.That(t, err, test.ShouldBeNil)
-	// TODO(hexbabe): remove below test when Stream/ReadImage pattern is refactored
-	t.Run("ReadImage on missing camera", func(t *testing.T) {
-		_, _, err = camera.ReadImage(context.Background(), camera1)
-		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "not found")
-	})
 	imgBytes, metadata, err := camera1.Image(context.Background(), rutils.MimeTypeJPEG, nil)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "not found")
@@ -590,16 +583,6 @@ func TestStatusClient(t *testing.T) {
 
 	camera1, err = camera.FromRobot(client, "camera1")
 	test.That(t, err, test.ShouldBeNil)
-
-	// TODO(hexbabe): remove below test when Stream/ReadImage pattern is refactored
-	t.Run("ReadImage on camera with valid response", func(t *testing.T) {
-		ctx := gostream.WithMIMETypeHint(context.Background(), rutils.MimeTypeRawRGBA)
-		frame, _, err := camera.ReadImage(ctx, camera1)
-		test.That(t, err, test.ShouldBeNil)
-		compVal, _, err := rimage.CompareImages(img, frame)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, compVal, test.ShouldEqual, 0) // exact copy, no color conversion
-	})
 
 	frame, err := camera.DecodeImageFromCamera(context.Background(), rutils.MimeTypeRawRGBA, nil, camera1)
 	test.That(t, err, test.ShouldBeNil)

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -86,14 +86,6 @@ func TestConfig1(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, c1.Name(), test.ShouldResemble, camera.Named("c1"))
 
-	// TODO(hexbabe): remove below test when Stream/ReadImage pattern is refactored
-	t.Run("ReadImage from camera", func(t *testing.T) {
-		pic, _, err := camera.ReadImage(context.Background(), c1)
-		test.That(t, err, test.ShouldBeNil)
-		bounds := pic.Bounds()
-		test.That(t, bounds.Max.X, test.ShouldBeGreaterThanOrEqualTo, 32)
-	})
-
 	pic, err := camera.DecodeImageFromCamera(context.Background(), rutils.MimeTypeJPEG, nil, c1)
 	test.That(t, err, test.ShouldBeNil)
 

--- a/testutils/inject/camera.go
+++ b/testutils/inject/camera.go
@@ -52,20 +52,6 @@ func (c *Camera) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, err
 	return nil, errors.New("NextPointCloud unimplemented")
 }
 
-// Stream calls the injected Stream or the real version.
-func (c *Camera) Stream(
-	ctx context.Context,
-	errHandlers ...gostream.ErrorHandler,
-) (gostream.VideoStream, error) {
-	if c.StreamFunc != nil {
-		return c.StreamFunc(ctx, errHandlers...)
-	}
-	if c.Camera != nil {
-		return c.Camera.Stream(ctx, errHandlers...)
-	}
-	return nil, errors.Wrap(ctx.Err(), "no stream function available")
-}
-
 // Image calls the injected Image or the real version.
 func (c *Camera) Image(ctx context.Context, mimeType string, extra map[string]interface{}) ([]byte, camera.ImageMetadata, error) {
 	if c.ImageFunc != nil {

--- a/testutils/inject/camera.go
+++ b/testutils/inject/camera.go
@@ -52,6 +52,20 @@ func (c *Camera) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, err
 	return nil, errors.New("NextPointCloud unimplemented")
 }
 
+// Stream calls the injected Stream or the real version.
+func (c *Camera) Stream(
+	ctx context.Context,
+	errHandlers ...gostream.ErrorHandler,
+) (gostream.VideoStream, error) {
+	if c.StreamFunc != nil {
+		return c.StreamFunc(ctx, errHandlers...)
+	}
+	if c.Camera != nil {
+		return c.Camera.Stream(ctx, errHandlers...)
+	}
+	return nil, errors.Wrap(ctx.Err(), "no stream function available")
+}
+
 // Image calls the injected Image or the real version.
 func (c *Camera) Image(ctx context.Context, mimeType string, extra map[string]interface{}) ([]byte, camera.ImageMetadata, error) {
 	if c.ImageFunc != nil {


### PR DESCRIPTION
[RSDK-9512](https://viam.atlassian.net/browse/RSDK-9512)


[RSDK-9512]: https://viam.atlassian.net/browse/RSDK-9512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Non-breaking change we can do before removing Stream 

Can't remove injected StreamFunc since we use it for transform pipeline tests