### PR TITLE
[RSDK-9513]   Add VideoSourceFromCamera helper in stream camera utils

### DIFF
--- a/robot/web/stream/camera/camera.go
+++ b/robot/web/stream/camera/camera.go
@@ -35,12 +35,11 @@ func VideoSourceFromCamera(ctx context.Context, cam camera.Camera) gostream.Vide
 		}
 		return img, func() {}, nil
 	})
-	camProps, err := cam.Properties(ctx)
-	if err != nil {
-		camProps = camera.Properties{}
+
+	img, errImage := camera.DecodeImageFromCamera(ctx, "", nil, cam)
+	if errImage == nil {
+		return gostream.NewVideoSource(reader, prop.Video{Width: img.Bounds().Dx(), Height: img.Bounds().Dy()})
 	}
-	if camProps.IntrinsicParams == nil {
-		return gostream.NewVideoSource(reader, prop.Video{Width: 0, Height: 0})
-	}
-	return gostream.NewVideoSource(reader, prop.Video{Width: camProps.IntrinsicParams.Width, Height: camProps.IntrinsicParams.Height})
+	// Okay to return empty prop because processInputFrames will tick and set them
+	return gostream.NewVideoSource(reader, prop.Video{})
 }

--- a/robot/web/stream/camera/camera.go
+++ b/robot/web/stream/camera/camera.go
@@ -1,7 +1,12 @@
-// Package camera provides functions for looking up a camera from a robot using a stream
+// Package camera provides utilities for working with camera resources in the context of streaming.
 package camera
 
 import (
+	"context"
+	"image"
+
+	"github.com/pion/mediadevices/pkg/prop"
+
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/gostream"
 	"go.viam.com/rdk/resource"
@@ -18,4 +23,24 @@ func Camera(robot robot.Robot, stream gostream.Stream) (camera.Camera, error) {
 		return nil, err
 	}
 	return cam, nil
+}
+
+// VideoSourceFromCamera converts a camera resource into a gostream VideoSource.
+// This is useful for streaming video from a camera resource.
+func VideoSourceFromCamera(ctx context.Context, cam camera.Camera) gostream.VideoSource {
+	reader := gostream.VideoReaderFunc(func(ctx context.Context) (image.Image, func(), error) {
+		img, err := camera.DecodeImageFromCamera(ctx, "", nil, cam)
+		if err != nil {
+			return nil, func() {}, err
+		}
+		return img, func() {}, nil
+	})
+	camProps, err := cam.Properties(ctx)
+	if err != nil {
+		camProps = camera.Properties{}
+	}
+	if camProps.IntrinsicParams == nil {
+		return gostream.NewVideoSource(reader, prop.Video{Width: 0, Height: 0})
+	}
+	return gostream.NewVideoSource(reader, prop.Video{Width: camProps.IntrinsicParams.Width, Height: camProps.IntrinsicParams.Height})
 }

--- a/robot/web/stream/camera/camera.go
+++ b/robot/web/stream/camera/camera.go
@@ -36,8 +36,8 @@ func VideoSourceFromCamera(ctx context.Context, cam camera.Camera) gostream.Vide
 		return img, func() {}, nil
 	})
 
-	img, errImage := camera.DecodeImageFromCamera(ctx, "", nil, cam)
-	if errImage == nil {
+	img, err := camera.DecodeImageFromCamera(ctx, "", nil, cam)
+	if err == nil {
 		return gostream.NewVideoSource(reader, prop.Video{Width: img.Bounds().Dx(), Height: img.Bounds().Dy()})
 	}
 	// Okay to return empty prop because processInputFrames will tick and set them

--- a/robot/web/stream/camera/camera_test.go
+++ b/robot/web/stream/camera/camera_test.go
@@ -9,7 +9,7 @@ import (
 
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/rimage"
-	cameraStreamUtils "go.viam.com/rdk/robot/web/stream/camera"
+	camerautils "go.viam.com/rdk/robot/web/stream/camera"
 	"go.viam.com/rdk/testutils/inject"
 	"go.viam.com/rdk/utils"
 )
@@ -23,7 +23,7 @@ func TestVideoSourceFromCamera(t *testing.T) {
 			return imgBytes, camera.ImageMetadata{MimeType: utils.MimeTypePNG}, nil
 		},
 	}
-	vs := cameraStreamUtils.VideoSourceFromCamera(context.Background(), cam)
+	vs := camerautils.VideoSourceFromCamera(context.Background(), cam)
 
 	stream, err := vs.Stream(context.Background())
 	test.That(t, err, test.ShouldBeNil)

--- a/robot/web/stream/camera/camera_test.go
+++ b/robot/web/stream/camera/camera_test.go
@@ -1,0 +1,37 @@
+package camera_test
+
+import (
+	"context"
+	"image"
+	"testing"
+
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/components/camera"
+	"go.viam.com/rdk/rimage"
+	cameraStreamUtils "go.viam.com/rdk/robot/web/stream/camera"
+	"go.viam.com/rdk/testutils/inject"
+	"go.viam.com/rdk/utils"
+)
+
+func TestVideoSourceFromCamera(t *testing.T) {
+	sourceImg := image.NewRGBA(image.Rect(0, 0, 3, 3))
+	cam := &inject.Camera{
+		ImageFunc: func(ctx context.Context, mimeType string, extra map[string]interface{}) ([]byte, camera.ImageMetadata, error) {
+			imgBytes, err := rimage.EncodeImage(ctx, sourceImg, utils.MimeTypePNG)
+			test.That(t, err, test.ShouldBeNil)
+			return imgBytes, camera.ImageMetadata{MimeType: utils.MimeTypePNG}, nil
+		},
+	}
+	vs := cameraStreamUtils.VideoSourceFromCamera(context.Background(), cam)
+
+	stream, err := vs.Stream(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+
+	img, _, err := stream.Next(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+
+	diffVal, _, err := rimage.CompareImages(img, sourceImg)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, diffVal, test.ShouldEqual, 0)
+}


### PR DESCRIPTION
[RSDK-9513](https://viam.atlassian.net/browse/RSDK-9513)

[RSDK-9513]: https://viam.atlassian.net/browse/RSDK-9513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Add helper necessary to convert a `camera.Camera` into a `Stream`-having struct for streaming in the server.