### PR TITLE
Remove non rpc interface methods `AnalogNames` and `DigitalInterruptNames` from board

### DIFF
--- a/components/board/board.go
+++ b/components/board/board.go
@@ -110,12 +110,6 @@ type Board interface {
 	// GPIOPinByName returns a GPIOPin by name.
 	GPIOPinByName(name string) (GPIOPin, error)
 
-	// AnalogNames returns the names of all known analog pins.
-	AnalogNames() []string
-
-	// DigitalInterruptNames returns the names of all known digital interrupts.
-	DigitalInterruptNames() []string
-
 	// SetPowerMode sets the board to the given power mode. If
 	// provided, the board will exit the given power mode after
 	// the specified duration.

--- a/components/board/client.go
+++ b/components/board/client.go
@@ -92,22 +92,6 @@ func (c *client) GPIOPinByName(name string) (GPIOPin, error) {
 	}, nil
 }
 
-func (c *client) AnalogNames() []string {
-	if len(c.info.analogNames) == 0 {
-		c.logger.Debugw("no cached analog readers")
-		return []string{}
-	}
-	return copyStringSlice(c.info.analogNames)
-}
-
-func (c *client) DigitalInterruptNames() []string {
-	if len(c.info.digitalInterruptNames) == 0 {
-		c.logger.Debugw("no cached digital interrupts")
-		return []string{}
-	}
-	return copyStringSlice(c.info.digitalInterruptNames)
-}
-
 func (c *client) SetPowerMode(ctx context.Context, mode pb.PowerMode, duration *time.Duration) error {
 	var dur *durationpb.Duration
 	if duration != nil {
@@ -325,12 +309,4 @@ func (gpc *gpioPinClient) SetPWMFreq(ctx context.Context, freqHz uint, extra map
 		Extra:       ext,
 	})
 	return err
-}
-
-// copyStringSlice is a helper to simply copy a string slice
-// so that no one mutates it.
-func copyStringSlice(src []string) []string {
-	out := make([]string, len(src))
-	copy(out, src)
-	return out
 }

--- a/components/board/client.go
+++ b/components/board/client.go
@@ -4,7 +4,6 @@ package board
 import (
 	"context"
 	"math"
-	"slices"
 	"sync"
 	"time"
 
@@ -26,17 +25,14 @@ type client struct {
 	client pb.BoardServiceClient
 	logger logging.Logger
 
-	info boardInfo
+	// boardName is used to attach the name of the board resource to the different
+	// pin clients (gpioclient, analogclient and digitalinterrupt client)
+	// the rpc services are fulfilled by methods on each pin type.
+	boardName string
 
 	interruptStreams []*interruptStream
 
 	mu sync.Mutex
-}
-
-type boardInfo struct {
-	name                  string
-	analogNames           []string
-	digitalInterruptNames []string
 }
 
 // NewClientFromConn constructs a new Client from connection passed in.
@@ -47,39 +43,28 @@ func NewClientFromConn(
 	name resource.Name,
 	logger logging.Logger,
 ) (Board, error) {
-	info := boardInfo{
-		name:                  name.ShortName(),
-		analogNames:           []string{},
-		digitalInterruptNames: []string{},
-	}
 	bClient := pb.NewBoardServiceClient(conn)
 	c := &client{
-		Named:  name.PrependRemote(remoteName).AsNamed(),
-		client: bClient,
-		logger: logger,
-		info:   info,
+		Named:     name.PrependRemote(remoteName).AsNamed(),
+		client:    bClient,
+		logger:    logger,
+		boardName: name.ShortName(),
 	}
 	return c, nil
 }
 
 func (c *client) AnalogByName(name string) (Analog, error) {
-	if !slices.Contains(c.info.analogNames, name) {
-		c.info.analogNames = append(c.info.analogNames, name)
-	}
 	return &analogClient{
 		client:     c,
-		boardName:  c.info.name,
+		boardName:  c.boardName,
 		analogName: name,
 	}, nil
 }
 
 func (c *client) DigitalInterruptByName(name string) (DigitalInterrupt, error) {
-	if !slices.Contains(c.info.digitalInterruptNames, name) {
-		c.info.digitalInterruptNames = append(c.info.digitalInterruptNames, name)
-	}
 	return &digitalInterruptClient{
 		client:               c,
-		boardName:            c.info.name,
+		boardName:            c.boardName,
 		digitalInterruptName: name,
 	}, nil
 }
@@ -87,7 +72,7 @@ func (c *client) DigitalInterruptByName(name string) (DigitalInterrupt, error) {
 func (c *client) GPIOPinByName(name string) (GPIOPin, error) {
 	return &gpioPinClient{
 		client:    c,
-		boardName: c.info.name,
+		boardName: c.boardName,
 		pinName:   name,
 	}, nil
 }
@@ -97,12 +82,12 @@ func (c *client) SetPowerMode(ctx context.Context, mode pb.PowerMode, duration *
 	if duration != nil {
 		dur = durationpb.New(*duration)
 	}
-	_, err := c.client.SetPowerMode(ctx, &pb.SetPowerModeRequest{Name: c.info.name, PowerMode: mode, Duration: dur})
+	_, err := c.client.SetPowerMode(ctx, &pb.SetPowerModeRequest{Name: c.boardName, PowerMode: mode, Duration: dur})
 	return err
 }
 
 func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
-	return rprotoutils.DoFromResourceClient(ctx, c.client, c.info.name, cmd)
+	return rprotoutils.DoFromResourceClient(ctx, c.client, c.boardName, cmd)
 }
 
 // analogClient satisfies a gRPC based board.AnalogReader. Refer to the interface

--- a/components/board/fake/board.go
+++ b/components/board/fake/board.go
@@ -204,28 +204,6 @@ func (b *Board) GPIOPinByName(name string) (board.GPIOPin, error) {
 	return p, nil
 }
 
-// AnalogNames returns the names of all known analog pins.
-func (b *Board) AnalogNames() []string {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
-	names := []string{}
-	for k := range b.Analogs {
-		names = append(names, k)
-	}
-	return names
-}
-
-// DigitalInterruptNames returns the names of all known digital interrupts.
-func (b *Board) DigitalInterruptNames() []string {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
-	names := []string{}
-	for k := range b.Digitals {
-		names = append(names, k)
-	}
-	return names
-}
-
 // SetPowerMode sets the board to the given power mode. If provided,
 // the board will exit the given power mode after the specified
 // duration.

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -413,28 +413,6 @@ func (b *Board) DigitalInterruptByName(name string) (board.DigitalInterrupt, err
 	return interrupt, nil
 }
 
-// AnalogNames returns the names of all known analog pins.
-func (b *Board) AnalogNames() []string {
-	names := []string{}
-	for k := range b.analogReaders {
-		names = append(names, k)
-	}
-	return names
-}
-
-// DigitalInterruptNames returns the names of all known digital interrupts.
-func (b *Board) DigitalInterruptNames() []string {
-	if b.interrupts == nil {
-		return nil
-	}
-
-	names := []string{}
-	for name := range b.interrupts {
-		names = append(names, name)
-	}
-	return names
-}
-
 // GPIOPinByName returns a GPIOPin by name.
 func (b *Board) GPIOPinByName(pinName string) (board.GPIOPin, error) {
 	if pin, ok := b.gpios[pinName]; ok {

--- a/components/board/genericlinux/board_test.go
+++ b/components/board/genericlinux/board_test.go
@@ -36,9 +36,6 @@ func TestGenericLinux(t *testing.T) {
 	}
 
 	t.Run("test analog-readers digital-interrupts and gpio names", func(t *testing.T) {
-		ans := b.AnalogNames()
-		test.That(t, ans, test.ShouldResemble, []string{"an"})
-
 		an1, err := b.AnalogByName("an")
 		test.That(t, an1, test.ShouldHaveSameTypeAs, &wrappedAnalogReader{})
 		test.That(t, err, test.ShouldBeNil)
@@ -46,9 +43,6 @@ func TestGenericLinux(t *testing.T) {
 		an2, err := b.AnalogByName("missing")
 		test.That(t, an2, test.ShouldBeNil)
 		test.That(t, err, test.ShouldNotBeNil)
-
-		dns := b.DigitalInterruptNames()
-		test.That(t, dns, test.ShouldBeNil)
 
 		dn1, err := b.DigitalInterruptByName("dn")
 		test.That(t, dn1, test.ShouldBeNil)
@@ -124,12 +118,6 @@ func TestNewBoard(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, b, test.ShouldNotBeNil)
 	defer b.Close(ctx)
-
-	ans := b.AnalogNames()
-	test.That(t, ans, test.ShouldResemble, []string{"an1"})
-
-	dis := b.DigitalInterruptNames()
-	test.That(t, dis, test.ShouldResemble, []string{})
 
 	gn1, err := b.GPIOPinByName("1")
 	test.That(t, err, test.ShouldBeNil)

--- a/components/board/interrupt_stream.go
+++ b/components/board/interrupt_stream.go
@@ -40,7 +40,7 @@ func (s *interruptStream) startStream(ctx context.Context, interrupts []DigitalI
 	}
 
 	req := &pb.StreamTicksRequest{
-		Name:     s.client.info.name,
+		Name:     s.client.boardName,
 		PinNames: names,
 		Extra:    s.extra,
 	}

--- a/testutils/inject/board.go
+++ b/testutils/inject/board.go
@@ -21,8 +21,6 @@ type Board struct {
 	digitalInterruptByNameCap  []interface{}
 	GPIOPinByNameFunc          func(name string) (board.GPIOPin, error)
 	gpioPinByNameCap           []interface{}
-	AnalogNamesFunc            func() []string
-	DigitalInterruptNamesFunc  func() []string
 	CloseFunc                  func(ctx context.Context) error
 	SetPowerModeFunc           func(ctx context.Context, mode boardpb.PowerMode, duration *time.Duration) error
 	StreamTicksFunc            func(ctx context.Context,
@@ -91,22 +89,6 @@ func (b *Board) GPIOPinByNameCap() []interface{} {
 	}
 	defer func() { b.gpioPinByNameCap = nil }()
 	return b.gpioPinByNameCap
-}
-
-// AnalogNames calls the injected AnalogNames or the real version.
-func (b *Board) AnalogNames() []string {
-	if b.AnalogNamesFunc == nil {
-		return b.Board.AnalogNames()
-	}
-	return b.AnalogNamesFunc()
-}
-
-// DigitalInterruptNames calls the injected DigitalInterruptNames or the real version.
-func (b *Board) DigitalInterruptNames() []string {
-	if b.DigitalInterruptNamesFunc == nil {
-		return b.Board.DigitalInterruptNames()
-	}
-	return b.DigitalInterruptNamesFunc()
 }
 
 // Close calls the injected Close or the real version.


### PR DESCRIPTION
We can now do this cleanup chore since `Status` and `StatusStream` are completely unused and the reason for these rpcs to exist is now gone.

Tested with Viam server running on a mac with a few fake modular boards.

Will probably wait to merge until SDK work is complete. 
