### PR TITLE
APP-6996: Implement OrganizationGetLogo

### DIFF
--- a/app/app_client.go
+++ b/app/app_client.go
@@ -846,6 +846,17 @@ func (c *AppClient) OrganizationSetLogo(ctx context.Context, orgID string, logo 
 	return err
 }
 
+// OrganizationGetLogo gets an organization's logo.
+func (c *AppClient) OrganizationGetLogo(ctx context.Context, orgID string) (string, error) {
+	resp, err := c.client.OrganizationGetLogo(ctx, &pb.OrganizationGetLogoRequest{
+		OrgId: orgID,
+	})
+	if err != nil {
+		return "", err
+	}
+	return resp.Url, nil
+}
+
 // CreateLocation creates a location with the given name under the given organization.
 func (c *AppClient) CreateLocation(ctx context.Context, orgID, name string, opts *CreateLocationOptions) (*Location, error) {
 	var parentID *string

--- a/app/app_client_test.go
+++ b/app/app_client_test.go
@@ -725,6 +725,21 @@ func TestAppClient(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 	})
 
+	t.Run("OrganizationGetLogo", func(t *testing.T) {
+		grpcClient.OrganizationGetLogoFunc = func(
+			ctx context.Context, in *pb.OrganizationGetLogoRequest, opts ...grpc.CallOption,
+		) (*pb.OrganizationGetLogoResponse, error) {
+			test.That(t, in.OrgId, test.ShouldEqual, organizationID)
+			return &pb.OrganizationGetLogoResponse{
+				Url: "https://logo.com",
+			}, nil
+		}
+
+		resp, err := client.OrganizationGetLogo(context.Background(), organizationID)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, resp, test.ShouldEqual, "https://logo.com")
+	})
+
 	t.Run("GetSupportEmail", func(t *testing.T) {
 		grpcClient.OrganizationGetSupportEmailFunc = func(
 			ctx context.Context, in *pb.OrganizationGetSupportEmailRequest, opts ...grpc.CallOption,

--- a/cli/app.go
+++ b/cli/app.go
@@ -426,7 +426,7 @@ var app = &cli.App{
 				},
 				{
 					Name:      "logo",
-					Usage:     "manage logos for an organization",
+					Usage:     "manage the logo for an organization",
 					UsageText: createUsageText("organizations logo", []string{generalFlagOrgID}, true),
 					Subcommands: []*cli.Command{
 						{
@@ -445,6 +445,18 @@ var app = &cli.App{
 								},
 							},
 							Action: createCommandWithT[organizationsLogoSetArgs](OrganizationLogoSetAction),
+						},
+						{
+							Name:  "get",
+							Usage: "get the logo for an organization",
+							Flags: []cli.Flag{
+								&cli.StringFlag{
+									Name:     generalFlagOrgID,
+									Required: true,
+									Usage:    "the org to get the logo for",
+								},
+							},
+							Action: createCommandWithT[organizationsLogoGetArgs](OrganizationsLogoGetAction),
 						},
 					},
 				},

--- a/cli/client.go
+++ b/cli/client.go
@@ -410,6 +410,11 @@ func (c *viamClient) organizationsLogoGetAction(cCtx *cli.Context, orgID string)
 		return err
 	}
 
+	if resp.GetUrl() == "" {
+		printf(cCtx.App.Writer, "No logo set for organization %q", orgID)
+		return nil
+	}
+
 	printf(cCtx.App.Writer, "Logo URL for organization %q: %q", orgID, resp.GetUrl())
 	return nil
 }

--- a/cli/client.go
+++ b/cli/client.go
@@ -395,6 +395,12 @@ func OrganizationsLogoGetAction(cCtx *cli.Context, args organizationsLogoGetArgs
 	if err != nil {
 		return err
 	}
+
+	orgID := args.OrgID
+	if orgID == "" {
+		return errors.New("cannot get logo without an organization ID")
+	}
+
 	return c.organizationsLogoGetAction(cCtx, args.OrgID)
 }
 

--- a/cli/client.go
+++ b/cli/client.go
@@ -385,6 +385,35 @@ func (c *viamClient) organizationLogoSetAction(cCtx *cli.Context, orgID, logoFil
 	return nil
 }
 
+type organizationsLogoGetArgs struct {
+	OrgID string
+}
+
+// OrganizationsLogoGetAction corresponds to `organizations logo get`.
+func OrganizationsLogoGetAction(cCtx *cli.Context, args organizationsLogoGetArgs) error {
+	c, err := newViamClient(cCtx)
+	if err != nil {
+		return err
+	}
+	return c.organizationsLogoGetAction(cCtx, args.OrgID)
+}
+
+func (c *viamClient) organizationsLogoGetAction(cCtx *cli.Context, orgID string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+
+	resp, err := c.client.OrganizationGetLogo(cCtx.Context, &apppb.OrganizationGetLogoRequest{
+		OrgId: orgID,
+	})
+	if err != nil {
+		return err
+	}
+
+	printf(cCtx.App.Writer, "Logo URL for organization %q: %q", orgID, resp.GetUrl())
+	return nil
+}
+
 // ListLocationsAction is the corresponding Action for 'locations list'.
 func ListLocationsAction(c *cli.Context, args emptyArgs) error {
 	client, err := newViamClient(c)

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -339,6 +339,25 @@ func TestOrganizationSetLogoAction(t *testing.T) {
 	test.That(t, len(out.messages), test.ShouldEqual, 0)
 }
 
+func TestGetLogoAction(t *testing.T) {
+	getLogoFunc := func(ctx context.Context, in *apppb.OrganizationGetLogoRequest, opts ...grpc.CallOption) (
+		*apppb.OrganizationGetLogoResponse, error,
+	) {
+		return &apppb.OrganizationGetLogoResponse{Url: "https://logo.com"}, nil
+	}
+
+	asc := &inject.AppServiceClient{
+		OrganizationGetLogoFunc: getLogoFunc,
+	}
+
+	cCtx, ac, out, errOut := setup(asc, nil, nil, nil, nil, "token")
+
+	test.That(t, ac.organizationsLogoGetAction(cCtx, "test-org"), test.ShouldBeNil)
+	test.That(t, len(errOut.messages), test.ShouldEqual, 0)
+	test.That(t, len(out.messages), test.ShouldEqual, 1)
+	test.That(t, out.messages[0], test.ShouldContainSubstring, "https://logo.com")
+}
+
 func TestUpdateBillingServiceAction(t *testing.T) {
 	updateConfigFunc := func(ctx context.Context, in *apppb.UpdateBillingServiceRequest, opts ...grpc.CallOption) (
 		*apppb.UpdateBillingServiceResponse, error,

--- a/testutils/inject/app_service_client.go
+++ b/testutils/inject/app_service_client.go
@@ -54,6 +54,8 @@ type AppServiceClient struct {
 		opts ...grpc.CallOption) (*apppb.OrganizationGetSupportEmailResponse, error)
 	OrganizationSetLogoFunc func(ctx context.Context, in *apppb.OrganizationSetLogoRequest,
 		opts ...grpc.CallOption) (*apppb.OrganizationSetLogoResponse, error)
+	OrganizationGetLogoFunc func(ctx context.Context, in *apppb.OrganizationGetLogoRequest,
+		opts ...grpc.CallOption) (*apppb.OrganizationGetLogoResponse, error)
 	CreateLocationFunc func(ctx context.Context, in *apppb.CreateLocationRequest,
 		opts ...grpc.CallOption) (*apppb.CreateLocationResponse, error)
 	GetLocationFunc func(ctx context.Context, in *apppb.GetLocationRequest,
@@ -389,6 +391,16 @@ func (asc *AppServiceClient) OrganizationSetLogo(
 		return asc.AppServiceClient.OrganizationSetLogo(ctx, in, opts...)
 	}
 	return asc.OrganizationSetLogoFunc(ctx, in, opts...)
+}
+
+// OrganizationGetLogo calls the injected OrganizationGetLogoFunc or the real version.
+func (asc *AppServiceClient) OrganizationGetLogo(
+	ctx context.Context, in *apppb.OrganizationGetLogoRequest, opts ...grpc.CallOption,
+) (*apppb.OrganizationGetLogoResponse, error) {
+	if asc.OrganizationGetLogoFunc == nil {
+		return asc.AppServiceClient.OrganizationGetLogo(ctx, in, opts...)
+	}
+	return asc.OrganizationGetLogoFunc(ctx, in, opts...)
 }
 
 // CreateLocation calls the injected CreateLocationFunc or the real version.


### PR DESCRIPTION
APP-6996: Implement OrganizationGetLogo 

dont have org with logo set but heres an example of it without:
```
go run cli/viam/main.go organization logo get  --org-id  a757fe30-5648-4c5b-ab74-4ecd6bf06e4c
Info: Using "https://app.viam.dev" as base URL value
No logo set for organization "a757fe30-5648-4c5b-ab74-4ecd6bf06e4c"
```