### PR TITLE
[RSDK-9520] Refactor NextPointCloud -> PointCloud and add `extra` param

### DIFF
--- a/components/camera/camera.go
+++ b/components/camera/camera.go
@@ -57,7 +57,7 @@ func Named(name string) resource.Name {
 // Properties is a lookup for a camera's features and settings.
 type Properties struct {
 	// SupportsPCD indicates that the Camera supports a valid
-	// implementation of NextPointCloud
+	// implementation of PointCloud
 	SupportsPCD      bool
 	ImageType        ImageType
 	IntrinsicParams  *transform.PinholeCameraIntrinsics
@@ -113,12 +113,12 @@ type Camera interface {
 //	img, release, err := stream.Next(context.Background())
 //	defer release()
 //
-// NextPointCloud example:
+// PointCloud example:
 //
 //	myCamera, err := camera.FromRobot(machine, "my_camera")
 //
 //	// gets the next point cloud from a camera
-//	pointCloud, err := myCamera.NextPointCloud(context.Background())
+//	pointCloud, err := myCamera.PointCloud(context.Background(), nil)
 //
 // Close example:
 //
@@ -175,7 +175,7 @@ func DecodeImageFromCamera(ctx context.Context, mimeType string, extra map[strin
 
 // A PointCloudSource is a source that can generate pointclouds.
 type PointCloudSource interface {
-	NextPointCloud(ctx context.Context) (pointcloud.PointCloud, error)
+	PointCloud(ctx context.Context, extra map[string]interface{}) (pointcloud.PointCloud, error)
 }
 
 // A ImagesSource is a source that can return a list of images with timestamp.

--- a/components/camera/camera.go
+++ b/components/camera/camera.go
@@ -140,9 +140,9 @@ type VideoSource interface {
 	// that may have a MIME type hint dictated in the context via gostream.WithMIMETypeHint.
 	Stream(ctx context.Context, errHandlers ...gostream.ErrorHandler) (gostream.VideoStream, error)
 
-	// NextPointCloud returns the next immediately available point cloud, not necessarily one
+	// PointCloud returns the next immediately available point cloud, not necessarily one
 	// a part of a sequence. In the future, there could be streaming of point clouds.
-	NextPointCloud(ctx context.Context) (pointcloud.PointCloud, error)
+	PointCloud(ctx context.Context, extra map[string]interface{}) (pointcloud.PointCloud, error)
 
 	// Properties returns properties that are intrinsic to the particular
 	// implementation of a camera.

--- a/components/camera/camera_test.go
+++ b/components/camera/camera_test.go
@@ -49,7 +49,7 @@ func (s *simpleSourceWithPCD) Read(ctx context.Context) (image.Image, func(), er
 	return img, func() {}, err
 }
 
-func (s *simpleSourceWithPCD) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, error) {
+func (s *simpleSourceWithPCD) PointCloud(ctx context.Context, _ map[string]interface{}) (pointcloud.PointCloud, error) {
 	return nil, nil
 }
 
@@ -162,7 +162,7 @@ type cloudSource struct {
 	*simpleSource
 }
 
-func (cs *cloudSource) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, error) {
+func (cs *cloudSource) PointCloud(ctx context.Context, _ map[string]interface{}) (pointcloud.PointCloud, error) {
 	p := pointcloud.New()
 	return p, p.Set(pointcloud.NewVector(0, 0, 0), nil)
 }
@@ -175,7 +175,7 @@ func TestCameraWithNoProjector(t *testing.T) {
 	_, err = noProj.PointCloud(context.Background(), nil)
 	test.That(t, errors.Is(err, transform.ErrNoIntrinsics), test.ShouldBeTrue)
 
-	// make a camera with a NextPointCloudFunction
+	// make a camera with a PointCloudFunction
 	cloudSrc2 := &cloudSource{Named: camera.Named("foo").AsNamed(), simpleSource: videoSrc}
 	videoSrc2, err := camera.NewVideoSourceFromReader(context.Background(), cloudSrc2, nil, camera.DepthStream)
 	noProj2 := camera.FromVideoSource(resource.NewName(camera.API, "bar"), videoSrc2, logger)

--- a/components/camera/camera_test.go
+++ b/components/camera/camera_test.go
@@ -173,7 +173,7 @@ func TestCameraWithNoProjector(t *testing.T) {
 	videoSrc := &simpleSource{"rimage/board1"}
 	noProj, err := camera.NewVideoSourceFromReader(context.Background(), videoSrc, nil, camera.DepthStream)
 	test.That(t, err, test.ShouldBeNil)
-	_, err = noProj.NextPointCloud(context.Background())
+	_, err = noProj.PointCloud(context.Background(), nil)
 	test.That(t, errors.Is(err, transform.ErrNoIntrinsics), test.ShouldBeTrue)
 
 	// make a camera with a NextPointCloudFunction
@@ -181,7 +181,7 @@ func TestCameraWithNoProjector(t *testing.T) {
 	videoSrc2, err := camera.NewVideoSourceFromReader(context.Background(), cloudSrc2, nil, camera.DepthStream)
 	noProj2 := camera.FromVideoSource(resource.NewName(camera.API, "bar"), videoSrc2, logger)
 	test.That(t, err, test.ShouldBeNil)
-	pc, err := noProj2.NextPointCloud(context.Background())
+	pc, err := noProj2.PointCloud(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
 	_, got := pc.At(0, 0, 0)
 	test.That(t, got, test.ShouldBeTrue)
@@ -225,7 +225,7 @@ func TestCameraWithProjector(t *testing.T) {
 		camera.DepthStream,
 	)
 	test.That(t, err, test.ShouldBeNil)
-	pc, err := src.NextPointCloud(context.Background())
+	pc, err := src.PointCloud(context.Background(), nil)
 	test.That(t, pc.Size(), test.ShouldEqual, 921600)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, src.Close(context.Background()), test.ShouldBeNil)
@@ -242,7 +242,7 @@ func TestCameraWithProjector(t *testing.T) {
 	)
 	cam2 := camera.FromVideoSource(resource.NewName(camera.API, "bar"), videoSrc2, logger)
 	test.That(t, err, test.ShouldBeNil)
-	pc, err = videoSrc2.NextPointCloud(context.Background())
+	pc, err = videoSrc2.PointCloud(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
 	_, got := pc.At(0, 0, 0)
 	test.That(t, got, test.ShouldBeTrue)

--- a/components/camera/client.go
+++ b/components/camera/client.go
@@ -23,7 +23,6 @@ import (
 	"golang.org/x/exp/slices"
 
 	"go.viam.com/rdk/components/camera/rtppassthrough"
-	"go.viam.com/rdk/data"
 	"go.viam.com/rdk/gostream"
 	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
@@ -238,16 +237,12 @@ func (c *client) Images(ctx context.Context) ([]NamedImage, resource.ResponseMet
 	return images, resource.ResponseMetadataFromProto(resp.ResponseMetadata), nil
 }
 
-func (c *client) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, error) {
+func (c *client) PointCloud(ctx context.Context, extra map[string]interface{}) (pointcloud.PointCloud, error) {
 	ctx, span := trace.StartSpan(ctx, "camera::client::NextPointCloud")
 	defer span.End()
 
 	ctx, getPcdSpan := trace.StartSpan(ctx, "camera::client::NextPointCloud::GetPointCloud")
 
-	extra := make(map[string]interface{})
-	if ctx.Value(data.FromDMContextKey{}) == true {
-		extra[data.FromDMString] = true
-	}
 	extraStructPb, err := goprotoutils.StructToStructPb(extra)
 	if err != nil {
 		return nil, err

--- a/components/camera/client.go
+++ b/components/camera/client.go
@@ -238,10 +238,10 @@ func (c *client) Images(ctx context.Context) ([]NamedImage, resource.ResponseMet
 }
 
 func (c *client) PointCloud(ctx context.Context, extra map[string]interface{}) (pointcloud.PointCloud, error) {
-	ctx, span := trace.StartSpan(ctx, "camera::client::NextPointCloud")
+	ctx, span := trace.StartSpan(ctx, "camera::client::PointCloud")
 	defer span.End()
 
-	ctx, getPcdSpan := trace.StartSpan(ctx, "camera::client::NextPointCloud::GetPointCloud")
+	ctx, getPcdSpan := trace.StartSpan(ctx, "camera::client::PointCloud::GetPointCloud")
 
 	extraStructPb, err := goprotoutils.StructToStructPb(extra)
 	if err != nil {
@@ -263,7 +263,7 @@ func (c *client) PointCloud(ctx context.Context, extra map[string]interface{}) (
 	}
 
 	return func() (pointcloud.PointCloud, error) {
-		_, span := trace.StartSpan(ctx, "camera::client::NextPointCloud::ReadPCD")
+		_, span := trace.StartSpan(ctx, "camera::client::PointCloud::ReadPCD")
 		defer span.End()
 
 		return pointcloud.ReadPCD(bytes.NewReader(resp.PointCloud))

--- a/components/camera/client_test.go
+++ b/components/camera/client_test.go
@@ -534,7 +534,7 @@ func TestClientWithInterceptor(t *testing.T) {
 	camera1Client, err := camera.NewClientFromConn(context.Background(), conn, "", camera.Named(testCameraName), logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	// Construct a ContextWithMetadata to pass into NextPointCloud and check that the
+	// Construct a ContextWithMetadata to pass into PointCloud and check that the
 	// interceptor correctly injected the metadata from the gRPC response header into the
 	// context.
 	ctx, md := contextutils.ContextWithMetadata(context.Background())

--- a/components/camera/client_test.go
+++ b/components/camera/client_test.go
@@ -72,7 +72,7 @@ func TestClient(t *testing.T) {
 	projA = intrinsics
 
 	// color camera
-	injectCamera.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
+	injectCamera.PointCloudFunc = func(ctx context.Context, _ map[string]interface{}) (pointcloud.PointCloud, error) {
 		return pcA, nil
 	}
 	injectCamera.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
@@ -112,7 +112,7 @@ func TestClient(t *testing.T) {
 	depthImg.Set(5, 6, rimage.Depth(190))
 	depthImg.Set(9, 12, rimage.Depth(3000))
 	depthImg.Set(5, 9, rimage.MaxDepth-rimage.Depth(1))
-	injectCameraDepth.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
+	injectCameraDepth.PointCloudFunc = func(ctx context.Context, _ map[string]interface{}) (pointcloud.PointCloud, error) {
 		return pcA, nil
 	}
 	injectCameraDepth.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
@@ -135,7 +135,7 @@ func TestClient(t *testing.T) {
 	}
 	// bad camera
 	injectCamera2 := &inject.Camera{}
-	injectCamera2.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
+	injectCamera2.PointCloudFunc = func(ctx context.Context, _ map[string]interface{}) (pointcloud.PointCloud, error) {
 		return nil, errGeneratePointCloudFailed
 	}
 	injectCamera2.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
@@ -206,7 +206,7 @@ func TestClient(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "received empty bytes from Image method")
 
-		pcB, err := camera1Client.NextPointCloud(context.Background())
+		pcB, err := camera1Client.PointCloud(context.Background(), nil)
 		test.That(t, err, test.ShouldBeNil)
 		_, got := pcB.At(5, 5, 5)
 		test.That(t, got, test.ShouldBeTrue)
@@ -282,7 +282,7 @@ func TestClient(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errGetImageFailed.Error())
 
-		_, err = client2.NextPointCloud(context.Background())
+		_, err = client2.PointCloud(context.Background(), nil)
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errGeneratePointCloudFailed.Error())
 
@@ -573,7 +573,7 @@ func TestClientWithInterceptor(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	k, v := "hello", "world"
-	injectCamera.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
+	injectCamera.PointCloudFunc = func(ctx context.Context, _ map[string]interface{}) (pointcloud.PointCloud, error) {
 		var grpcMetadata metadata.MD = make(map[string][]string)
 		grpcMetadata.Set(k, v)
 		grpc.SendHeader(ctx, grpcMetadata)
@@ -610,7 +610,7 @@ func TestClientWithInterceptor(t *testing.T) {
 	// interceptor correctly injected the metadata from the gRPC response header into the
 	// context.
 	ctx, md := contextutils.ContextWithMetadata(context.Background())
-	pcB, err := camera1Client.NextPointCloud(ctx)
+	pcB, err := camera1Client.PointCloud(ctx, nil)
 	test.That(t, err, test.ShouldBeNil)
 	_, got := pcB.At(5, 5, 5)
 	test.That(t, got, test.ShouldBeTrue)

--- a/components/camera/collectors.go
+++ b/components/camera/collectors.go
@@ -45,9 +45,7 @@ func newNextPointCloudCollector(resource interface{}, params data.CollectorParam
 		_, span := trace.StartSpan(ctx, "camera::data::collector::CaptureFunc::NextPointCloud")
 		defer span.End()
 
-		ctx = context.WithValue(ctx, data.FromDMContextKey{}, true)
-
-		v, err := camera.NextPointCloud(ctx)
+		v, err := camera.PointCloud(ctx, data.FromDMExtraMap)
 		if err != nil {
 			// A modular filter component can be created to filter the readings from a component. The error ErrNoCaptureToStore
 			// is used in the datamanager to exclude readings from being captured and stored.

--- a/components/camera/collectors_test.go
+++ b/components/camera/collectors_test.go
@@ -108,7 +108,7 @@ func TestCollectors(t *testing.T) {
 			camera: cam,
 		},
 		{
-			name:      "NextPointCloud returns a non nil binary response",
+			name:      "PointCloud returns a non nil binary response",
 			collector: camera.NewNextPointCloudCollector,
 			expected: []*datasyncpb.SensorData{{
 				Metadata: &datasyncpb.SensorMetadata{

--- a/components/camera/collectors_test.go
+++ b/components/camera/collectors_test.go
@@ -192,7 +192,7 @@ func newCamera(
 		return viamLogoJpegBytes, camera.ImageMetadata{MimeType: mimeType}, nil
 	}
 
-	v.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
+	v.PointCloudFunc = func(ctx context.Context, _ map[string]interface{}) (pointcloud.PointCloud, error) {
 		return pcd, nil
 	}
 

--- a/components/camera/fake/camera.go
+++ b/components/camera/fake/camera.go
@@ -225,8 +225,8 @@ func (c *Camera) Read(ctx context.Context) (image.Image, func(), error) {
 	return rimage.ConvertImage(img), func() {}, nil
 }
 
-// NextPointCloud always returns a pointcloud of a yellow to blue gradient, with the depth determined by the intensity of blue.
-func (c *Camera) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, error) {
+// PointCloud always returns a pointcloud of a yellow to blue gradient, with the depth determined by the intensity of blue.
+func (c *Camera) PointCloud(ctx context.Context, extra map[string]interface{}) (pointcloud.PointCloud, error) {
 	if c.cachePointCloud != nil {
 		return c.cachePointCloud, nil
 	}

--- a/components/camera/fake/camera.go
+++ b/components/camera/fake/camera.go
@@ -226,7 +226,7 @@ func (c *Camera) Read(ctx context.Context) (image.Image, func(), error) {
 }
 
 // PointCloud always returns a pointcloud of a yellow to blue gradient, with the depth determined by the intensity of blue.
-func (c *Camera) PointCloud(ctx context.Context, extra map[string]interface{}) (pointcloud.PointCloud, error) {
+func (c *Camera) PointCloud(ctx context.Context, _ map[string]interface{}) (pointcloud.PointCloud, error) {
 	if c.cachePointCloud != nil {
 		return c.cachePointCloud, nil
 	}

--- a/components/camera/fake/image_file.go
+++ b/components/camera/fake/image_file.go
@@ -145,9 +145,9 @@ func (fs *fileSource) Images(ctx context.Context) ([]camera.NamedImage, resource
 	return imgs, resource.ResponseMetadata{CapturedAt: ts}, nil
 }
 
-// NextPointCloud returns the point cloud from projecting the rgb and depth image using the intrinsic parameters,
+// PointCloud returns the point cloud from projecting the rgb and depth image using the intrinsic parameters,
 // or the pointcloud from file if set.
-func (fs *fileSource) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, error) {
+func (fs *fileSource) PointCloud(ctx context.Context, extra map[string]interface{}) (pointcloud.PointCloud, error) {
 	if fs.PointCloudFN != "" {
 		return pointcloud.NewFromFile(fs.PointCloudFN, nil)
 	}
@@ -207,8 +207,8 @@ func (ss *StaticSource) Images(ctx context.Context) ([]camera.NamedImage, resour
 	return imgs, resource.ResponseMetadata{CapturedAt: ts}, nil
 }
 
-// NextPointCloud returns the point cloud from projecting the rgb and depth image using the intrinsic parameters.
-func (ss *StaticSource) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, error) {
+// PointCloud returns the point cloud from projecting the rgb and depth image using the intrinsic parameters.
+func (ss *StaticSource) PointCloud(ctx context.Context, extra map[string]interface{}) (pointcloud.PointCloud, error) {
 	if ss.Proj == nil {
 		return nil, transform.NewNoIntrinsicsError("camera intrinsics not found in config")
 	}

--- a/components/camera/fake/image_file.go
+++ b/components/camera/fake/image_file.go
@@ -147,7 +147,7 @@ func (fs *fileSource) Images(ctx context.Context) ([]camera.NamedImage, resource
 
 // PointCloud returns the point cloud from projecting the rgb and depth image using the intrinsic parameters,
 // or the pointcloud from file if set.
-func (fs *fileSource) PointCloud(ctx context.Context, extra map[string]interface{}) (pointcloud.PointCloud, error) {
+func (fs *fileSource) PointCloud(ctx context.Context, _ map[string]interface{}) (pointcloud.PointCloud, error) {
 	if fs.PointCloudFN != "" {
 		return pointcloud.NewFromFile(fs.PointCloudFN, nil)
 	}
@@ -208,7 +208,7 @@ func (ss *StaticSource) Images(ctx context.Context) ([]camera.NamedImage, resour
 }
 
 // PointCloud returns the point cloud from projecting the rgb and depth image using the intrinsic parameters.
-func (ss *StaticSource) PointCloud(ctx context.Context, extra map[string]interface{}) (pointcloud.PointCloud, error) {
+func (ss *StaticSource) PointCloud(ctx context.Context, _ map[string]interface{}) (pointcloud.PointCloud, error) {
 	if ss.Proj == nil {
 		return nil, transform.NewNoIntrinsicsError("camera intrinsics not found in config")
 	}

--- a/components/camera/fake/image_file_test.go
+++ b/components/camera/fake/image_file_test.go
@@ -31,11 +31,11 @@ func TestPCD(t *testing.T) {
 	_, err = cam.Stream(ctx)
 	test.That(t, err, test.ShouldBeNil)
 
-	pc, err := cam.NextPointCloud(ctx)
+	pc, err := cam.PointCloud(ctx, nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, pc.Size(), test.ShouldEqual, 628)
 
-	pc, err = cam.NextPointCloud(ctx)
+	pc, err = cam.PointCloud(ctx, nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, pc.Size(), test.ShouldEqual, 628)
 
@@ -78,7 +78,7 @@ func TestColor(t *testing.T) {
 	cam, err := newCamera(ctx, resource.Name{API: camera.API}, cfg, logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	_, err = cam.NextPointCloud(ctx)
+	_, err = cam.PointCloud(ctx, nil)
 	test.That(t, err, test.ShouldNotBeNil)
 
 	readInImage, err := rimage.NewImageFromFile(artifact.MustPath("vision/objectdetection/detection_test.jpg"))

--- a/components/camera/replaypcd/replaypcd.go
+++ b/components/camera/replaypcd/replaypcd.go
@@ -169,7 +169,7 @@ func newPCDCamera(
 func (replay *pcdCamera) PointCloud(ctx context.Context, extra map[string]interface{}) (pointcloud.PointCloud, error) {
 	// First acquire the lock, so that it's safe to populate the cache and/or retrieve and
 	// remove the next data point from the cache. Note that if multiple threads call
-	// NextPointCloud concurrently, they may get data out-of-order, since there's no guarantee
+	// PointCloud concurrently, they may get data out-of-order, since there's no guarantee
 	// about who acquires the lock first.
 	replay.mu.Lock()
 	defer replay.mu.Unlock()

--- a/components/camera/replaypcd/replaypcd.go
+++ b/components/camera/replaypcd/replaypcd.go
@@ -166,7 +166,7 @@ func newPCDCamera(
 }
 
 // PointCloud returns the next point cloud retrieved from cloud storage based on the applied filter.
-func (replay *pcdCamera) PointCloud(ctx context.Context, extra map[string]interface{}) (pointcloud.PointCloud, error) {
+func (replay *pcdCamera) PointCloud(ctx context.Context, _ map[string]interface{}) (pointcloud.PointCloud, error) {
 	// First acquire the lock, so that it's safe to populate the cache and/or retrieve and
 	// remove the next data point from the cache. Note that if multiple threads call
 	// PointCloud concurrently, they may get data out-of-order, since there's no guarantee

--- a/components/camera/replaypcd/replaypcd.go
+++ b/components/camera/replaypcd/replaypcd.go
@@ -165,8 +165,8 @@ func newPCDCamera(
 	return cam, nil
 }
 
-// NextPointCloud returns the next point cloud retrieved from cloud storage based on the applied filter.
-func (replay *pcdCamera) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, error) {
+// PointCloud returns the next point cloud retrieved from cloud storage based on the applied filter.
+func (replay *pcdCamera) PointCloud(ctx context.Context, extra map[string]interface{}) (pointcloud.PointCloud, error) {
 	// First acquire the lock, so that it's safe to populate the cache and/or retrieve and
 	// remove the next data point from the cache. Note that if multiple threads call
 	// NextPointCloud concurrently, they may get data out-of-order, since there's no guarantee

--- a/components/camera/replaypcd/replaypcd_test.go
+++ b/components/camera/replaypcd/replaypcd_test.go
@@ -127,7 +127,7 @@ func TestReplayPCDNew(t *testing.T) {
 	}
 }
 
-func TestReplayPCDNextPointCloud(t *testing.T) {
+func TestReplayPCDPointCloud(t *testing.T) {
 	ctx := context.Background()
 
 	cases := []struct {
@@ -137,7 +137,7 @@ func TestReplayPCDNextPointCloud(t *testing.T) {
 		endFileNum   int
 	}{
 		{
-			description: "Calling NextPointCloud no filter",
+			description: "Calling PointCloud no filter",
 			cfg: &Config{
 				Source:         validSource,
 				RobotID:        validRobotID,
@@ -150,7 +150,7 @@ func TestReplayPCDNextPointCloud(t *testing.T) {
 			endFileNum:   numPCDFiles,
 		},
 		{
-			description: "Calling NextPointCloud with bad source",
+			description: "Calling PointCloud with bad source",
 			cfg: &Config{
 				Source:         "bad_source",
 				RobotID:        validRobotID,
@@ -163,7 +163,7 @@ func TestReplayPCDNextPointCloud(t *testing.T) {
 			endFileNum:   -1,
 		},
 		{
-			description: "Calling NextPointCloud with bad robot_id",
+			description: "Calling PointCloud with bad robot_id",
 			cfg: &Config{
 				Source:         validSource,
 				RobotID:        "bad_robot_id",
@@ -176,7 +176,7 @@ func TestReplayPCDNextPointCloud(t *testing.T) {
 			endFileNum:   -1,
 		},
 		{
-			description: "Calling NextPointCloud with bad location_id",
+			description: "Calling PointCloud with bad location_id",
 			cfg: &Config{
 				Source:         validSource,
 				RobotID:        validRobotID,
@@ -189,7 +189,7 @@ func TestReplayPCDNextPointCloud(t *testing.T) {
 			endFileNum:   -1,
 		},
 		{
-			description: "Calling NextPointCloud with bad organization_id",
+			description: "Calling PointCloud with bad organization_id",
 			cfg: &Config{
 				Source:         validSource,
 				RobotID:        validRobotID,
@@ -202,7 +202,7 @@ func TestReplayPCDNextPointCloud(t *testing.T) {
 			endFileNum:   -1,
 		},
 		{
-			description: "Calling NextPointCloud with filter no data",
+			description: "Calling PointCloud with filter no data",
 			cfg: &Config{
 				Source:         validSource,
 				RobotID:        validRobotID,
@@ -220,7 +220,7 @@ func TestReplayPCDNextPointCloud(t *testing.T) {
 			endFileNum:   -1,
 		},
 		{
-			description: "Calling NextPointCloud with end filter",
+			description: "Calling PointCloud with end filter",
 			cfg: &Config{
 				Source:         validSource,
 				RobotID:        validRobotID,
@@ -237,7 +237,7 @@ func TestReplayPCDNextPointCloud(t *testing.T) {
 			endFileNum:   10,
 		},
 		{
-			description: "Calling NextPointCloud with start filter",
+			description: "Calling PointCloud with start filter",
 			cfg: &Config{
 				Source:         validSource,
 				RobotID:        validRobotID,
@@ -254,7 +254,7 @@ func TestReplayPCDNextPointCloud(t *testing.T) {
 			endFileNum:   numPCDFiles,
 		},
 		{
-			description: "Calling NextPointCloud with start and end filter",
+			description: "Calling PointCloud with start and end filter",
 			cfg: &Config{
 				Source:         validSource,
 				RobotID:        validRobotID,
@@ -272,7 +272,7 @@ func TestReplayPCDNextPointCloud(t *testing.T) {
 			endFileNum:   10,
 		},
 		{
-			description: "Calling NextPointCloud with non-divisible batch size, last batch size 1",
+			description: "Calling PointCloud with non-divisible batch size, last batch size 1",
 			cfg: &Config{
 				Source:         validSource,
 				RobotID:        validRobotID,
@@ -286,7 +286,7 @@ func TestReplayPCDNextPointCloud(t *testing.T) {
 			endFileNum:   numPCDFiles,
 		},
 		{
-			description: "Calling NextPointCloud with non-divisible batch size, last batch > 1",
+			description: "Calling PointCloud with non-divisible batch size, last batch > 1",
 			cfg: &Config{
 				Source:         validSource,
 				RobotID:        validRobotID,
@@ -300,7 +300,7 @@ func TestReplayPCDNextPointCloud(t *testing.T) {
 			endFileNum:   numPCDFiles,
 		},
 		{
-			description: "Calling NextPointCloud with divisible batch size",
+			description: "Calling PointCloud with divisible batch size",
 			cfg: &Config{
 				Source:         validSource,
 				RobotID:        validRobotID,
@@ -314,7 +314,7 @@ func TestReplayPCDNextPointCloud(t *testing.T) {
 			endFileNum:   numPCDFiles,
 		},
 		{
-			description: "Calling NextPointCloud with batching and a start and end filter",
+			description: "Calling PointCloud with batching and a start and end filter",
 			cfg: &Config{
 				Source:         validSource,
 				RobotID:        validRobotID,
@@ -332,7 +332,7 @@ func TestReplayPCDNextPointCloud(t *testing.T) {
 			endFileNum:   11,
 		},
 		{
-			description: "Calling NextPointCloud with a large batch size",
+			description: "Calling PointCloud with a large batch size",
 			cfg: &Config{
 				Source:         validSource,
 				RobotID:        validRobotID,
@@ -383,10 +383,10 @@ func TestReplayPCDNextPointCloud(t *testing.T) {
 	}
 }
 
-// TestLiveNextPointCloud checks the replay pcd camera's ability to handle new data being added to the
-// database the pool during a session, proving that NextPointCloud can return new data even after
+// TestLivePointCloud checks the replay pcd camera's ability to handle new data being added to the
+// database the pool during a session, proving that PointCloud can return new data even after
 // returning errEndOfDataset.
-func TestReplayPCDLiveNextPointCloud(t *testing.T) {
+func TestReplayPCDLivePointCloud(t *testing.T) {
 	ctx := context.Background()
 
 	numPCDFiles = 10
@@ -679,7 +679,7 @@ func TestReplayPCDTimestamps(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, replayCamera, test.ShouldNotBeNil)
 
-		// Repeatedly call NextPointCloud, checking for timestamps in the gRPC header.
+		// Repeatedly call PointCloud, checking for timestamps in the gRPC header.
 		for i := 0; i < numPCDFiles; i++ {
 			serverStream := testutils.NewServerTransportStream()
 			ctx = grpc.NewContextWithServerTransportStream(ctx, serverStream)
@@ -769,7 +769,7 @@ func TestReplayPCDReconfigure(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, replayCamera, test.ShouldNotBeNil)
 
-	// Call NextPointCloud to iterate through a few files
+	// Call PointCloud to iterate through a few files
 	for i := 0; i < 3; i++ {
 		pc, err := replayCamera.PointCloud(ctx, nil)
 		test.That(t, err, test.ShouldBeNil)
@@ -782,7 +782,7 @@ func TestReplayPCDReconfigure(t *testing.T) {
 	cfg = &Config{Source: validSource, BatchSize: &batchSize4}
 	replayCamera.Reconfigure(ctx, deps, resource.Config{ConvertedAttributes: cfg})
 
-	// Call NextPointCloud a couple more times, ensuring that we start over from the beginning
+	// Call PointCloud a couple more times, ensuring that we start over from the beginning
 	// of the dataset after calling Reconfigure
 	for i := 0; i < 5; i++ {
 		pc, err := replayCamera.PointCloud(ctx, nil)

--- a/components/camera/replaypcd/replaypcd_test.go
+++ b/components/camera/replaypcd/replaypcd_test.go
@@ -356,7 +356,7 @@ func TestReplayPCDNextPointCloud(t *testing.T) {
 			// Iterate through all files that meet the provided filter
 			if tt.startFileNum != -1 {
 				for i := tt.startFileNum; i < tt.endFileNum; i++ {
-					pc, err := replayCamera.NextPointCloud(ctx)
+					pc, err := replayCamera.PointCloud(ctx, nil)
 					test.That(t, err, test.ShouldBeNil)
 					pcExpected, err := getPointCloudFromArtifact(i)
 					if err != nil {
@@ -370,7 +370,7 @@ func TestReplayPCDNextPointCloud(t *testing.T) {
 			}
 
 			// Confirm the end of the dataset was reached when expected
-			pc, err := replayCamera.NextPointCloud(ctx)
+			pc, err := replayCamera.PointCloud(ctx, nil)
 			test.That(t, err, test.ShouldNotBeNil)
 			test.That(t, err.Error(), test.ShouldContainSubstring, ErrEndOfDataset.Error())
 			test.That(t, pc, test.ShouldBeNil)
@@ -408,7 +408,7 @@ func TestReplayPCDLiveNextPointCloud(t *testing.T) {
 	// Iterate through all files that meet the provided filter
 	i := 0
 	for {
-		pc, err := replayCamera.NextPointCloud(ctx)
+		pc, err := replayCamera.PointCloud(ctx, nil)
 		if i == numPCDFiles {
 			test.That(t, err, test.ShouldNotBeNil)
 			test.That(t, err.Error(), test.ShouldContainSubstring, ErrEndOfDataset.Error())
@@ -683,7 +683,7 @@ func TestReplayPCDTimestamps(t *testing.T) {
 		for i := 0; i < numPCDFiles; i++ {
 			serverStream := testutils.NewServerTransportStream()
 			ctx = grpc.NewContextWithServerTransportStream(ctx, serverStream)
-			pc, err := replayCamera.NextPointCloud(ctx)
+			pc, err := replayCamera.PointCloud(ctx, nil)
 			test.That(t, err, test.ShouldBeNil)
 			pcExpected, err := getPointCloudFromArtifact(i)
 			test.That(t, err, test.ShouldBeNil)
@@ -700,7 +700,7 @@ func TestReplayPCDTimestamps(t *testing.T) {
 		}
 
 		// Confirm the end of the dataset was reached when expected
-		pc, err := replayCamera.NextPointCloud(ctx)
+		pc, err := replayCamera.PointCloud(ctx, nil)
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, ErrEndOfDataset.Error())
 		test.That(t, pc, test.ShouldBeNil)
@@ -771,7 +771,7 @@ func TestReplayPCDReconfigure(t *testing.T) {
 
 	// Call NextPointCloud to iterate through a few files
 	for i := 0; i < 3; i++ {
-		pc, err := replayCamera.NextPointCloud(ctx)
+		pc, err := replayCamera.PointCloud(ctx, nil)
 		test.That(t, err, test.ShouldBeNil)
 		pcExpected, err := getPointCloudFromArtifact(i)
 		test.That(t, err, test.ShouldBeNil)
@@ -785,7 +785,7 @@ func TestReplayPCDReconfigure(t *testing.T) {
 	// Call NextPointCloud a couple more times, ensuring that we start over from the beginning
 	// of the dataset after calling Reconfigure
 	for i := 0; i < 5; i++ {
-		pc, err := replayCamera.NextPointCloud(ctx)
+		pc, err := replayCamera.PointCloud(ctx, nil)
 		test.That(t, err, test.ShouldBeNil)
 		pcExpected, err := getPointCloudFromArtifact(i)
 		test.That(t, err, test.ShouldBeNil)
@@ -798,7 +798,7 @@ func TestReplayPCDReconfigure(t *testing.T) {
 
 	// Again verify dataset starts from beginning
 	for i := 0; i < numPCDFiles; i++ {
-		pc, err := replayCamera.NextPointCloud(ctx)
+		pc, err := replayCamera.PointCloud(ctx, nil)
 		test.That(t, err, test.ShouldBeNil)
 		pcExpected, err := getPointCloudFromArtifact(i)
 		test.That(t, err, test.ShouldBeNil)
@@ -806,7 +806,7 @@ func TestReplayPCDReconfigure(t *testing.T) {
 	}
 
 	// Confirm the end of the dataset was reached when expected
-	pc, err := replayCamera.NextPointCloud(ctx)
+	pc, err := replayCamera.PointCloud(ctx, nil)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, ErrEndOfDataset.Error())
 	test.That(t, pc, test.ShouldBeNil)

--- a/components/camera/server.go
+++ b/components/camera/server.go
@@ -196,7 +196,7 @@ func (s *serviceServer) GetPointCloud(
 		return nil, err
 	}
 
-	pc, err := camera.NextPointCloud(ctx)
+	pc, err := camera.PointCloud(ctx, req.Extra.AsMap())
 	if err != nil {
 		return nil, err
 	}

--- a/components/camera/server.go
+++ b/components/camera/server.go
@@ -203,7 +203,7 @@ func (s *serviceServer) GetPointCloud(
 
 	var buf bytes.Buffer
 	buf.Grow(200 + (pc.Size() * 4 * 4)) // 4 numbers per point, each 4 bytes
-	_, pcdSpan := trace.StartSpan(ctx, "camera::server::NextPointCloud::ToPCD")
+	_, pcdSpan := trace.StartSpan(ctx, "camera::server::PointCloud::ToPCD")
 	err = pointcloud.ToPCD(pc, &buf, pointcloud.PCDBinary)
 	pcdSpan.End()
 	if err != nil {

--- a/components/camera/server_test.go
+++ b/components/camera/server_test.go
@@ -81,7 +81,7 @@ func TestServer(t *testing.T) {
 	err = pcA.Set(pointcloud.NewVector(5, 5, 5), nil)
 	test.That(t, err, test.ShouldBeNil)
 
-	injectCamera.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
+	injectCamera.PointCloudFunc = func(ctx context.Context, _ map[string]interface{}) (pointcloud.PointCloud, error) {
 		return pcA, nil
 	}
 	injectCamera.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
@@ -145,7 +145,7 @@ func TestServer(t *testing.T) {
 	depthImage.Set(5, 9, rimage.MaxDepth-rimage.Depth(1))
 	var depthBuf bytes.Buffer
 	test.That(t, png.Encode(&depthBuf, depthImage), test.ShouldBeNil)
-	injectCameraDepth.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
+	injectCameraDepth.PointCloudFunc = func(ctx context.Context, _ map[string]interface{}) (pointcloud.PointCloud, error) {
 		return pcA, nil
 	}
 	// no frame rate camera
@@ -171,7 +171,7 @@ func TestServer(t *testing.T) {
 		return resBytes, camera.ImageMetadata{MimeType: mimeType}, nil
 	}
 	// bad camera
-	injectCamera2.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
+	injectCamera2.PointCloudFunc = func(ctx context.Context, _ map[string]interface{}) (pointcloud.PointCloud, error) {
 		return nil, errGeneratePointCloudFailed
 	}
 	injectCamera2.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
@@ -349,7 +349,7 @@ func TestServer(t *testing.T) {
 		err = pcA.Set(pointcloud.NewVector(5, 5, 5), nil)
 		test.That(t, err, test.ShouldBeNil)
 
-		injectCamera.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
+		injectCamera.PointCloudFunc = func(ctx context.Context, _ map[string]interface{}) (pointcloud.PointCloud, error) {
 			return pcA, nil
 		}
 		_, err = cameraServer.GetPointCloud(context.Background(), &pb.GetPointCloudRequest{

--- a/components/camera/transformpipeline/composed.go
+++ b/components/camera/transformpipeline/composed.go
@@ -83,7 +83,7 @@ func (dtp *depthToPretty) Close(ctx context.Context) error {
 	return dtp.src.Close(ctx)
 }
 
-func (dtp *depthToPretty) PointCloud(ctx context.Context) (pointcloud.PointCloud, error) {
+func (dtp *depthToPretty) PointCloud(ctx context.Context, _ map[string]interface{}) (pointcloud.PointCloud, error) {
 	ctx, span := trace.StartSpan(ctx, "camera::transformpipeline::depthToPretty::PointCloud")
 	defer span.End()
 	if dtp.cameraModel == nil || dtp.cameraModel.PinholeCameraIntrinsics == nil {

--- a/components/camera/transformpipeline/composed.go
+++ b/components/camera/transformpipeline/composed.go
@@ -159,7 +159,7 @@ func (os *overlaySource) Read(ctx context.Context) (image.Image, func(), error) 
 	if !ok {
 		return nil, nil, errors.New("source of overlay transform does not have PointCloud method")
 	}
-	pc, err := srcPointCloud.NextPointCloud(ctx)
+	pc, err := srcPointCloud.PointCloud(ctx, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/components/camera/transformpipeline/composed_test.go
+++ b/components/camera/transformpipeline/composed_test.go
@@ -31,7 +31,7 @@ func TestComposed(t *testing.T) {
 	robot := &inject.Robot{}
 	logger := logging.NewTestLogger(t)
 	cloudSource := &inject.Camera{}
-	cloudSource.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
+	cloudSource.PointCloudFunc = func(ctx context.Context, _ map[string]interface{}) (pointcloud.PointCloud, error) {
 		p := pointcloud.New()
 		return p, p.Set(pointcloud.NewVector(0, 0, 0), pointcloud.NewColoredData(color.NRGBA{255, 1, 2, 255}))
 	}
@@ -59,7 +59,7 @@ func TestComposed(t *testing.T) {
 			},
 		},
 	}
-	pc, err := cloudSource.NextPointCloud(context.Background())
+	pc, err := cloudSource.PointCloud(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, pc.Size(), test.ShouldEqual, 1)
 

--- a/components/camera/transformpipeline/pipeline.go
+++ b/components/camera/transformpipeline/pipeline.go
@@ -148,17 +148,17 @@ func (tp transformPipeline) Read(ctx context.Context) (image.Image, func(), erro
 	return camera.ReadImage(ctx, tp.src)
 }
 
-func (tp transformPipeline) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, error) {
-	ctx, span := trace.StartSpan(ctx, "camera::transformpipeline::NextPointCloud")
+func (tp transformPipeline) PointCloud(ctx context.Context, extra map[string]interface{}) (pointcloud.PointCloud, error) {
+	ctx, span := trace.StartSpan(ctx, "camera::transformpipeline::PointCloud")
 	defer span.End()
 	if lastElem, ok := tp.pipeline[len(tp.pipeline)-1].(camera.PointCloudSource); ok {
-		pc, err := lastElem.NextPointCloud(ctx)
+		pc, err := lastElem.PointCloud(ctx, extra)
 		if err != nil {
-			return nil, errors.Wrap(err, "function NextPointCloud not defined for last videosource in transform pipeline")
+			return nil, errors.Wrap(err, "function PointCloud not defined for last videosource in transform pipeline")
 		}
 		return pc, nil
 	}
-	return nil, errors.New("function NextPointCloud not defined for last videosource in transform pipeline")
+	return nil, errors.New("function PointCloud not defined for last videosource in transform pipeline")
 }
 
 func (tp transformPipeline) Close(ctx context.Context) error {

--- a/components/camera/transformpipeline/pipeline_test.go
+++ b/components/camera/transformpipeline/pipeline_test.go
@@ -47,7 +47,7 @@ func TestTransformPipelineColor(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, outImg.Bounds().Dx(), test.ShouldEqual, 10)
 	test.That(t, outImg.Bounds().Dy(), test.ShouldEqual, 20)
-	_, err = color.NextPointCloud(context.Background())
+	_, err = color.PointCloud(context.Background(), nil)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldWrap, transform.ErrNoIntrinsics)
 
@@ -96,7 +96,7 @@ func TestTransformPipelineDepth(t *testing.T) {
 	prop, err := depth.Properties(context.Background())
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, prop.IntrinsicParams, test.ShouldResemble, intrinsics)
-	outPc, err := depth.NextPointCloud(context.Background())
+	outPc, err := depth.PointCloud(context.Background(), nil)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "not defined for last videosource")
 	test.That(t, outPc, test.ShouldBeNil)

--- a/components/camera/transformpipeline/segmenter.go
+++ b/components/camera/transformpipeline/segmenter.go
@@ -70,7 +70,7 @@ func (cfg *segmenterConfig) Validate(path string) ([]string, error) {
 }
 
 // PointCloud function calls a segmenter service on the underlying camera and returns a pointcloud.
-func (ss *segmenterSource) PointCloud(ctx context.Context, extra map[string]interface{}) (pointcloud.PointCloud, error) {
+func (ss *segmenterSource) PointCloud(ctx context.Context, _ map[string]interface{}) (pointcloud.PointCloud, error) {
 	ctx, span := trace.StartSpan(ctx, "camera::transformpipeline::segmenter::PointCloud")
 	defer span.End()
 

--- a/components/camera/transformpipeline/segmenter.go
+++ b/components/camera/transformpipeline/segmenter.go
@@ -69,9 +69,9 @@ func (cfg *segmenterConfig) Validate(path string) ([]string, error) {
 	return deps, nil
 }
 
-// NextPointCloud function calls a segmenter service on the underlying camera and returns a pointcloud.
-func (ss *segmenterSource) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, error) {
-	ctx, span := trace.StartSpan(ctx, "camera::transformpipeline::segmenter::NextPointCloud")
+// PointCloud function calls a segmenter service on the underlying camera and returns a pointcloud.
+func (ss *segmenterSource) PointCloud(ctx context.Context, extra map[string]interface{}) (pointcloud.PointCloud, error) {
+	ctx, span := trace.StartSpan(ctx, "camera::transformpipeline::segmenter::PointCloud")
 	defer span.End()
 
 	// get the service

--- a/components/camera/transformpipeline/segmenter_test.go
+++ b/components/camera/transformpipeline/segmenter_test.go
@@ -154,7 +154,7 @@ func TestTransformSegmenterFunctionality(t *testing.T) {
 	pipeline, err := newTransformPipeline(context.Background(), cam, transformConf, r, logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	pc, err := pipeline.NextPointCloud(context.Background())
+	pc, err := pipeline.PointCloud(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, pc, test.ShouldNotBeNil)
 	_, isValid := pc.At(0, 0, 1)

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -572,13 +572,13 @@ func (c *webcam) Image(ctx context.Context, mimeType string, extra map[string]in
 	return camera.ReadImageBytes(ctx, c.underlyingSource, mimeType)
 }
 
-func (c *webcam) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, error) {
+func (c *webcam) PointCloud(ctx context.Context, extra map[string]interface{}) (pointcloud.PointCloud, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	if err := c.ensureActive(); err != nil {
 		return nil, err
 	}
-	return c.exposedProjector.NextPointCloud(ctx)
+	return c.exposedProjector.PointCloud(ctx, extra)
 }
 
 // driverInfo gets the mediadevices Info struct containing info such as name and device type of the given driver.

--- a/components/camera/videosourcewrappers.go
+++ b/components/camera/videosourcewrappers.go
@@ -239,8 +239,8 @@ func (vs *videoSource) Images(ctx context.Context) ([]NamedImage, resource.Respo
 	return []NamedImage{{img, ""}}, resource.ResponseMetadata{CapturedAt: ts}, nil
 }
 
-// NextPointCloud returns the next PointCloud from the camera, or will error if not supported.
-func (vs *videoSource) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, error) {
+// PointCloud returns the next PointCloud from the camera, or will error if not supported.
+func (vs *videoSource) PointCloud(ctx context.Context, _ map[string]interface{}) (pointcloud.PointCloud, error) {
 	ctx, span := trace.StartSpan(ctx, "camera::videoSource::NextPointCloud")
 	defer span.End()
 	if c, ok := vs.actualSource.(PointCloudSource); ok {

--- a/components/camera/videosourcewrappers.go
+++ b/components/camera/videosourcewrappers.go
@@ -98,7 +98,7 @@ func NewPinholeModelWithBrownConradyDistortion(pinholeCameraIntrinsics *transfor
 
 // NewVideoSourceFromReader creates a VideoSource either with or without a projector. The stream type
 // argument is for detecting whether or not the resulting camera supports return
-// of pointcloud data in the absence of an implemented NextPointCloud function.
+// of pointcloud data in the absence of an implemented PointCloud function.
 // If this is unknown or not applicable, a value of camera.Unspecified stream can be supplied.
 func NewVideoSourceFromReader(
 	ctx context.Context,
@@ -144,7 +144,7 @@ func NewVideoSourceFromReader(
 
 // WrapVideoSourceWithProjector creates a Camera either with or without a projector. The stream type
 // argument is for detecting whether or not the resulting camera supports return
-// of pointcloud data in the absence of an implemented NextPointCloud function.
+// of pointcloud data in the absence of an implemented PointCloud function.
 // If this is unknown or not applicable, a value of camera.Unspecified stream can be supplied.
 func WrapVideoSourceWithProjector(
 	ctx context.Context,
@@ -240,11 +240,11 @@ func (vs *videoSource) Images(ctx context.Context) ([]NamedImage, resource.Respo
 }
 
 // PointCloud returns the next PointCloud from the camera, or will error if not supported.
-func (vs *videoSource) PointCloud(ctx context.Context, _ map[string]interface{}) (pointcloud.PointCloud, error) {
-	ctx, span := trace.StartSpan(ctx, "camera::videoSource::NextPointCloud")
+func (vs *videoSource) PointCloud(ctx context.Context, extra map[string]interface{}) (pointcloud.PointCloud, error) {
+	ctx, span := trace.StartSpan(ctx, "camera::videoSource::PointCloud")
 	defer span.End()
 	if c, ok := vs.actualSource.(PointCloudSource); ok {
-		return c.NextPointCloud(ctx)
+		return c.PointCloud(ctx, extra)
 	}
 	if vs.system == nil || vs.system.PinholeCameraIntrinsics == nil {
 		return nil, transform.NewNoIntrinsicsError("cannot do a projection to a point cloud")

--- a/services/vision/detectionstosegments/detections_to_3dsegments_test.go
+++ b/services/vision/detectionstosegments/detections_to_3dsegments_test.go
@@ -34,7 +34,7 @@ func Test3DSegmentsFromDetector(t *testing.T) {
 	svc, err := vision.NewService(name, r, nil, nil, m.Detect, nil)
 	test.That(t, err, test.ShouldBeNil)
 	cam := &inject.Camera{}
-	cam.NextPointCloudFunc = func(ctx context.Context) (pc.PointCloud, error) {
+	cam.PointCloudFunc = func(ctx context.Context, _ map[string]interface{}) (pc.PointCloud, error) {
 		return nil, errors.New("no pointcloud")
 	}
 	cam.ImagesFunc = func(ctx context.Context) ([]camera.NamedImage, resource.ResponseMetadata, error) {
@@ -100,7 +100,7 @@ func Test3DSegmentsFromDetector(t *testing.T) {
 		imgs := []camera.NamedImage{{img, "color"}, {dm, "depth"}}
 		return imgs, resource.ResponseMetadata{CapturedAt: time.Now()}, nil
 	}
-	cam.NextPointCloudFunc = func(ctx context.Context) (pc.PointCloud, error) {
+	cam.PointCloudFunc = func(ctx context.Context, _ map[string]interface{}) (pc.PointCloud, error) {
 		cloud := pc.New()
 		err = cloud.Set(pc.NewVector(0, 0, 5), pc.NewColoredData(color.NRGBA{255, 0, 0, 255}))
 		test.That(t, err, test.ShouldBeNil)

--- a/services/vision/obstaclesdistance/obstacles_distance.go
+++ b/services/vision/obstaclesdistance/obstacles_distance.go
@@ -79,7 +79,7 @@ func registerObstacleDistanceDetector(
 		clouds := make([]pointcloud.PointCloud, 0, conf.NumQueries)
 
 		for i := 0; i < conf.NumQueries; i++ {
-			nxtPC, err := src.NextPointCloud(ctx)
+			nxtPC, err := src.PointCloud(ctx, nil)
 			if err != nil {
 				return nil, err
 			}

--- a/services/vision/obstaclesdistance/obstacles_distance.go
+++ b/services/vision/obstaclesdistance/obstacles_distance.go
@@ -1,5 +1,5 @@
 // Package obstaclesdistance uses an underlying camera to fulfill vision service methods, specifically
-// GetObjectPointClouds, which performs several queries of NextPointCloud and returns a median point.
+// GetObjectPointClouds, which performs several queries of PointCloud and returns a median point.
 package obstaclesdistance
 
 import (

--- a/services/vision/obstaclesdistance/obstacles_distance_test.go
+++ b/services/vision/obstaclesdistance/obstacles_distance_test.go
@@ -34,7 +34,7 @@ func TestObstacleDist(t *testing.T) {
 	r := &inject.Robot{}
 	cam := &inject.Camera{}
 
-	cam.NextPointCloudFunc = func(ctx context.Context) (pc.PointCloud, error) {
+	cam.PointCloudFunc = func(ctx context.Context, _ map[string]interface{}) (pc.PointCloud, error) {
 		return nil, errors.New("no pointcloud")
 	}
 	r.ResourceNamesFunc = func() []resource.Name {
@@ -72,7 +72,7 @@ func TestObstacleDist(t *testing.T) {
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "does not implement")
 
-	cam.NextPointCloudFunc = func(ctx context.Context) (pc.PointCloud, error) {
+	cam.PointCloudFunc = func(ctx context.Context, _ map[string]interface{}) (pc.PointCloud, error) {
 		cloud := pc.New()
 		err = cloud.Set(pc.NewVector(0, 0, 1), pc.NewColoredData(color.NRGBA{255, 0, 0, 255}))
 		test.That(t, err, test.ShouldBeNil)
@@ -92,7 +92,7 @@ func TestObstacleDist(t *testing.T) {
 
 	count := 0
 	nums := []float64{10, 9, 4, 5, 3, 1, 2, 6, 7, 8}
-	cam.NextPointCloudFunc = func(ctx context.Context) (pc.PointCloud, error) {
+	cam.PointCloudFunc = func(ctx context.Context, _ map[string]interface{}) (pc.PointCloud, error) {
 		cloud := pc.New()
 		err = cloud.Set(pc.NewVector(0, 0, nums[count]), pc.NewColoredData(color.NRGBA{255, 0, 0, 255}))
 		test.That(t, err, test.ShouldBeNil)
@@ -109,7 +109,7 @@ func TestObstacleDist(t *testing.T) {
 
 	// more than one point in cloud
 	count = 0
-	cam.NextPointCloudFunc = func(ctx context.Context) (pc.PointCloud, error) {
+	cam.PointCloudFunc = func(ctx context.Context, _ map[string]interface{}) (pc.PointCloud, error) {
 		cloud := pc.New()
 		err = cloud.Set(pc.NewVector(0, 0, nums[count]), pc.NewColoredData(color.NRGBA{255, 0, 0, 255}))
 		test.That(t, err, test.ShouldBeNil)

--- a/services/vision/obstaclespointcloud/obstacles_pointcloud_test.go
+++ b/services/vision/obstaclespointcloud/obstacles_pointcloud_test.go
@@ -20,7 +20,7 @@ import (
 func TestRadiusClusteringSegmentation(t *testing.T) {
 	r := &inject.Robot{}
 	cam := &inject.Camera{}
-	cam.NextPointCloudFunc = func(ctx context.Context) (pc.PointCloud, error) {
+	cam.PointCloudFunc = func(ctx context.Context, _ map[string]interface{}) (pc.PointCloud, error) {
 		return nil, errors.New("no pointcloud")
 	}
 	r.ResourceNamesFunc = func() []resource.Name {
@@ -77,7 +77,7 @@ func TestRadiusClusteringSegmentation(t *testing.T) {
 	test.That(t, err.Error(), test.ShouldContainSubstring, "no pointcloud")
 
 	// successful, creates two clusters of points
-	cam.NextPointCloudFunc = func(ctx context.Context) (pc.PointCloud, error) {
+	cam.PointCloudFunc = func(ctx context.Context, _ map[string]interface{}) (pc.PointCloud, error) {
 		cloud := pc.New()
 		// cluster 1
 		err = cloud.Set(pc.NewVector(1, 1, 1), pc.NewColoredData(color.NRGBA{255, 0, 0, 255}))

--- a/testutils/inject/camera.go
+++ b/testutils/inject/camera.go
@@ -49,7 +49,7 @@ func (c *Camera) PointCloud(ctx context.Context, extra map[string]interface{}) (
 	if c.Camera != nil {
 		return c.Camera.PointCloud(ctx, extra)
 	}
-	return nil, errors.New("NextPointCloud unimplemented")
+	return nil, errors.New("PointCloud unimplemented")
 }
 
 // Stream calls the injected Stream or the real version.

--- a/testutils/inject/camera.go
+++ b/testutils/inject/camera.go
@@ -25,10 +25,10 @@ type Camera struct {
 		ctx context.Context,
 		errHandlers ...gostream.ErrorHandler,
 	) (gostream.VideoStream, error)
-	NextPointCloudFunc func(ctx context.Context) (pointcloud.PointCloud, error)
-	ProjectorFunc      func(ctx context.Context) (transform.Projector, error)
-	PropertiesFunc     func(ctx context.Context) (camera.Properties, error)
-	CloseFunc          func(ctx context.Context) error
+	PointCloudFunc func(ctx context.Context, extra map[string]interface{}) (pointcloud.PointCloud, error)
+	ProjectorFunc  func(ctx context.Context) (transform.Projector, error)
+	PropertiesFunc func(ctx context.Context) (camera.Properties, error)
+	CloseFunc      func(ctx context.Context) error
 }
 
 // NewCamera returns a new injected camera.
@@ -41,13 +41,13 @@ func (c *Camera) Name() resource.Name {
 	return c.name
 }
 
-// NextPointCloud calls the injected NextPointCloud or the real version.
-func (c *Camera) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, error) {
-	if c.NextPointCloudFunc != nil {
-		return c.NextPointCloudFunc(ctx)
+// PointCloud calls the injected PointCloud or the real version.
+func (c *Camera) PointCloud(ctx context.Context, extra map[string]interface{}) (pointcloud.PointCloud, error) {
+	if c.PointCloudFunc != nil {
+		return c.PointCloudFunc(ctx, extra)
 	}
 	if c.Camera != nil {
-		return c.Camera.NextPointCloud(ctx)
+		return c.Camera.PointCloud(ctx, extra)
 	}
 	return nil, errors.New("NextPointCloud unimplemented")
 }

--- a/vision/segmentation/debug_object_segmentation_test.go
+++ b/vision/segmentation/debug_object_segmentation_test.go
@@ -49,7 +49,7 @@ func (h *segmentObjectTestHelper) Process(
 	test.That(t, err, test.ShouldBeNil)
 	pCtx.GotDebugPointCloud(cloud, "intel-full-pointcloud")
 	injectCamera := &inject.Camera{}
-	injectCamera.NextPointCloudFunc = func(ctx context.Context) (pc.PointCloud, error) {
+	injectCamera.PointCloudFunc = func(ctx context.Context, _ map[string]interface{}) (pc.PointCloud, error) {
 		return cloud, nil
 	}
 
@@ -121,7 +121,7 @@ func (h *gripperSegmentTestHelper) Process(
 	test.That(t, err, test.ShouldBeNil)
 	pCtx.GotDebugPointCloud(cloud, "gripper-pointcloud")
 	injectCamera := &inject.Camera{}
-	injectCamera.NextPointCloudFunc = func(ctx context.Context) (pc.PointCloud, error) {
+	injectCamera.PointCloudFunc = func(ctx context.Context, _ map[string]interface{}) (pc.PointCloud, error) {
 		return cloud, nil
 	}
 

--- a/vision/segmentation/debug_object_segmentation_voxel_test.go
+++ b/vision/segmentation/debug_object_segmentation_voxel_test.go
@@ -48,7 +48,7 @@ func (h *gripperVoxelSegmentTestHelper) Process(
 	test.That(t, err, test.ShouldBeNil)
 	pCtx.GotDebugPointCloud(cloud, "gripper-pointcloud")
 	cam := &inject.Camera{}
-	cam.NextPointCloudFunc = func(ctx context.Context) (pc.PointCloud, error) {
+	cam.PointCloudFunc = func(ctx context.Context, _ map[string]interface{}) (pc.PointCloud, error) {
 		return cloud, nil
 	}
 

--- a/vision/segmentation/er_ccl_clustering.go
+++ b/vision/segmentation/er_ccl_clustering.go
@@ -131,7 +131,7 @@ func NewERCCLClustering(params utils.AttributeMap) (Segmenter, error) {
 // ErCCLAlgorithm applies the connected components clustering algorithm to a VideoSource.
 func (erCCL *ErCCLConfig) ErCCLAlgorithm(ctx context.Context, src camera.VideoSource) ([]*vision.Object, error) {
 	// get next point cloud
-	cloud, err := src.NextPointCloud(ctx)
+	cloud, err := src.PointCloud(ctx, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vision/segmentation/er_ccl_clustering_test.go
+++ b/vision/segmentation/er_ccl_clustering_test.go
@@ -28,7 +28,7 @@ func TestERCCL(t *testing.T) {
 	}()
 	logger := logging.NewTestLogger(t)
 	injectCamera := &inject.Camera{}
-	injectCamera.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
+	injectCamera.PointCloudFunc = func(ctx context.Context, _ map[string]interface{}) (pointcloud.PointCloud, error) {
 		return pointcloud.NewFromFile(artifact.MustPath("pointcloud/intel_d435_pointcloud_424.pcd"), logger)
 	}
 
@@ -82,7 +82,7 @@ func BenchmarkERCCL(b *testing.B) {
 	}
 	// create the fake camera
 	injectCamera := &inject.Camera{}
-	injectCamera.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
+	injectCamera.PointCloudFunc = func(ctx context.Context, _ map[string]interface{}) (pointcloud.PointCloud, error) {
 		img, err := rimage.NewImageFromFile(artifact.MustPath("pointcloud/the_color_image_intel_424.jpg"))
 		test.That(b, err, test.ShouldBeNil)
 		dm, err := rimage.NewDepthMapFromFile(context.Background(), artifact.MustPath("pointcloud/the_depth_image_intel_424.png"))

--- a/vision/segmentation/radius_clustering.go
+++ b/vision/segmentation/radius_clustering.go
@@ -89,7 +89,7 @@ func NewRadiusClustering(params utils.AttributeMap) (Segmenter, error) {
 // RadiusClustering applies the radius clustering algorithm directly on a given point cloud.
 func (rcc *RadiusClusteringConfig) RadiusClustering(ctx context.Context, src camera.VideoSource) ([]*vision.Object, error) {
 	// get next point cloud
-	cloud, err := src.NextPointCloud(ctx)
+	cloud, err := src.PointCloud(ctx, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vision/segmentation/radius_clustering_test.go
+++ b/vision/segmentation/radius_clustering_test.go
@@ -57,7 +57,7 @@ func TestPixelSegmentation(t *testing.T) {
 	t.Parallel()
 	logger := logging.NewTestLogger(t)
 	injectCamera := &inject.Camera{}
-	injectCamera.NextPointCloudFunc = func(ctx context.Context) (pc.PointCloud, error) {
+	injectCamera.PointCloudFunc = func(ctx context.Context, _ map[string]interface{}) (pc.PointCloud, error) {
 		return pc.NewFromLASFile(artifact.MustPath("pointcloud/test.las"), logger)
 	}
 	// do segmentation
@@ -83,7 +83,7 @@ func TestPixelSegmentationNoFiltering(t *testing.T) {
 	t.Parallel()
 	logger := logging.NewTestLogger(t)
 	injectCamera := &inject.Camera{}
-	injectCamera.NextPointCloudFunc = func(ctx context.Context) (pc.PointCloud, error) {
+	injectCamera.PointCloudFunc = func(ctx context.Context, _ map[string]interface{}) (pc.PointCloud, error) {
 		return pc.NewFromLASFile(artifact.MustPath("pointcloud/test.las"), logger)
 	}
 	// do segmentation with no mean k filtering
@@ -125,7 +125,7 @@ func testSegmentation(t *testing.T, segments []*vision.Object, expectedLabel str
 
 func BenchmarkRadiusClustering(b *testing.B) {
 	injectCamera := &inject.Camera{}
-	injectCamera.NextPointCloudFunc = func(ctx context.Context) (pc.PointCloud, error) {
+	injectCamera.PointCloudFunc = func(ctx context.Context, _ map[string]interface{}) (pc.PointCloud, error) {
 		return pc.NewFromLASFile(artifact.MustPath("pointcloud/test.las"), nil)
 	}
 	var pts []*vision.Object

--- a/vision/segmentation/radius_clustering_voxel.go
+++ b/vision/segmentation/radius_clustering_voxel.go
@@ -88,7 +88,7 @@ func NewRadiusClusteringFromVoxels(params utils.AttributeMap) (Segmenter, error)
 func (rcc *RadiusClusteringVoxelConfig) RadiusClusteringVoxels(ctx context.Context, src camera.VideoSource) ([]*vision.Object, error) {
 	// get next point cloud and convert it to a  VoxelGrid
 	// NOTE(bh): Maybe one day cameras will return voxel grids directly.
-	cloud, err := src.NextPointCloud(ctx)
+	cloud, err := src.PointCloud(ctx, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vision/segmentation/radius_clustering_voxel_test.go
+++ b/vision/segmentation/radius_clustering_voxel_test.go
@@ -47,7 +47,7 @@ func TestClusteringVoxelConfig(t *testing.T) {
 func TestVoxelSegmentMeans(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	cam := &inject.Camera{}
-	cam.NextPointCloudFunc = func(ctx context.Context) (pc.PointCloud, error) {
+	cam.PointCloudFunc = func(ctx context.Context, _ map[string]interface{}) (pc.PointCloud, error) {
 		return pc.NewFromLASFile(artifact.MustPath("pointcloud/test.las"), logger)
 	}
 


### PR DESCRIPTION
Refactor camera interface: rename NextPointCloud to PointCloud and update related tests

This PR updates the camera interface by renaming the method `NextPointCloud` to `PointCloud`, reflecting a more consistent naming convention. All instances of the method across various files, including tests and implementations, have been modified accordingly. The new method signature includes the `extra` parameter to match the proto API, enhancing flexibility and aligning the interfaces.

Changes include:
- Updated method definitions and calls in `camera.go`, `client.go`, `videosourcewrappers.go`, and other related files.
- Adjusted test cases to use the new method name and signature.

This refactor improves code clarity and prepares the codebase for further updates to point cloud processing.