### PR TITLE
improve DoCommand in motion/builtin to properly support WorldStates

### DIFF
--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -4,16 +4,15 @@ package builtin
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/golang/geo/r3"
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	pb "go.viam.com/api/service/motion/v1"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	"go.viam.com/rdk/components/movementsensor"
 	"go.viam.com/rdk/logging"
@@ -357,7 +356,7 @@ func (ms *builtIn) DoCommand(ctx context.Context, cmd map[string]interface{}) (m
 			return nil, err
 		}
 		var moveReqProto pb.MoveRequest
-		err = jsonpb.Unmarshal(strings.NewReader(s), &moveReqProto)
+		err = protojson.Unmarshal([]byte(s), &moveReqProto)
 		if err != nil {
 			return nil, err
 		}

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -3,13 +3,14 @@ package builtin
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/golang/geo/r3"
+	"github.com/golang/protobuf/jsonpb"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	pb "go.viam.com/api/service/motion/v1"
@@ -351,12 +352,12 @@ func (ms *builtIn) DoCommand(ctx context.Context, cmd map[string]interface{}) (m
 
 	resp := make(map[string]interface{}, 0)
 	if req, ok := cmd[DoPlan]; ok {
-		bytes, err := json.Marshal(req)
+		s, err := utils.AssertType[string](req)
 		if err != nil {
 			return nil, err
 		}
 		var moveReqProto pb.MoveRequest
-		err = json.Unmarshal(bytes, &moveReqProto)
+		err = jsonpb.Unmarshal(strings.NewReader(s), &moveReqProto)
 		if err != nil {
 			return nil, err
 		}

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -10,12 +10,12 @@ import (
 
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/golang/geo/r3"
-	"github.com/golang/protobuf/jsonpb"
 	geo "github.com/kellydunn/golang-geo"
 	"github.com/pkg/errors"
 	commonpb "go.viam.com/api/common/v1"
 	"go.viam.com/test"
 	"go.viam.com/utils/protoutils"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	"go.viam.com/rdk/components/arm"
 	armFake "go.viam.com/rdk/components/arm/fake"
@@ -1276,10 +1276,9 @@ func TestDoCommand(t *testing.T) {
 		// format the command to send DoCommand
 		proto, err := moveReq.ToProto(ms.Name().Name)
 		test.That(t, err, test.ShouldBeNil)
-		m := jsonpb.Marshaler{}
-		s, err := m.MarshalToString(proto)
+		bytes, err := protojson.Marshal(proto)
 		test.That(t, err, test.ShouldBeNil)
-		cmd := map[string]interface{}{DoPlan: s}
+		cmd := map[string]interface{}{DoPlan: string(bytes)}
 
 		// simulate going over the wire
 		resp, ok := doOverWire(ms, cmd)[DoPlan]

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/golang/geo/r3"
+	"github.com/golang/protobuf/jsonpb"
 	geo "github.com/kellydunn/golang-geo"
 	"github.com/pkg/errors"
 	commonpb "go.viam.com/api/common/v1"
@@ -1246,8 +1247,14 @@ func TestCheckPlan(t *testing.T) {
 
 func TestDoCommand(t *testing.T) {
 	ctx := context.Background()
+	box, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{1000, 1000, 1000}), r3.Vector{1, 1, 1}, "box")
+	test.That(t, err, test.ShouldBeNil)
+	geometries := []*referenceframe.GeometriesInFrame{referenceframe.NewGeometriesInFrame("world", []spatialmath.Geometry{box})}
+	worldState, err := referenceframe.NewWorldState(geometries, nil)
+	test.That(t, err, test.ShouldBeNil)
 	moveReq := motion.MoveReq{
 		ComponentName: gripper.Named("pieceGripper"),
+		WorldState:    worldState,
 		Destination:   referenceframe.NewPoseInFrame("c", spatialmath.NewPoseFromPoint(r3.Vector{X: 0, Y: -30, Z: -50})),
 	}
 
@@ -1269,7 +1276,10 @@ func TestDoCommand(t *testing.T) {
 		// format the command to send DoCommand
 		proto, err := moveReq.ToProto(ms.Name().Name)
 		test.That(t, err, test.ShouldBeNil)
-		cmd := map[string]interface{}{DoPlan: proto}
+		m := jsonpb.Marshaler{}
+		s, err := m.MarshalToString(proto)
+		test.That(t, err, test.ShouldBeNil)
+		cmd := map[string]interface{}{DoPlan: s}
 
 		// simulate going over the wire
 		resp, ok := doOverWire(ms, cmd)[DoPlan]


### PR DESCRIPTION
There currently exists a bug in the DoPlan option in motion/builtin's DoCommand function where when you pass a WorldState it is not properly deserialized.  This is due to the protobuf struct making use of oneofs.  This PR switches the library used for serialization and deserializing of the MoveReq to the [the protojson package](https://pkg.go.dev/google.golang.org/protobuf@v1.35.1/encoding/protojson) which solves this problem by properly using the struct tags in the protobuf