### PR TITLE
allow passing MoveReq options in motion/builtin.Do

### DIFF
--- a/components/camera/server.go
+++ b/components/camera/server.go
@@ -200,9 +200,7 @@ func (s *serviceServer) GetPointCloud(
 		return nil, err
 	}
 
-	_, pcdSpan := trace.StartSpan(ctx, "camera::server::NextPointCloud::ToPCD")
 	bytes, err := pointcloud.ToBytes(pc)
-	pcdSpan.End()
 	if err != nil {
 		return nil, err
 	}

--- a/components/camera/server.go
+++ b/components/camera/server.go
@@ -1,7 +1,6 @@
 package camera
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"image"
@@ -201,10 +200,8 @@ func (s *serviceServer) GetPointCloud(
 		return nil, err
 	}
 
-	var buf bytes.Buffer
-	buf.Grow(200 + (pc.Size() * 4 * 4)) // 4 numbers per point, each 4 bytes
 	_, pcdSpan := trace.StartSpan(ctx, "camera::server::NextPointCloud::ToPCD")
-	err = pointcloud.ToPCD(pc, &buf, pointcloud.PCDBinary)
+	bytes, err := pointcloud.ToBytes(pc)
 	pcdSpan.End()
 	if err != nil {
 		return nil, err
@@ -212,7 +209,7 @@ func (s *serviceServer) GetPointCloud(
 
 	return &pb.GetPointCloudResponse{
 		MimeType:   utils.MimeTypePCD,
-		PointCloud: buf.Bytes(),
+		PointCloud: bytes,
 	}, nil
 }
 

--- a/motionplan/errors.go
+++ b/motionplan/errors.go
@@ -28,7 +28,12 @@ var (
 	errMixedFrameTypes = errors.New("unable to plan for PTG and non-PTG frames simultaneously")
 )
 
-func genIKConstraintErr(failures map[string]int, constraintFailCnt int) error {
+// NewAlgAndConstraintMismatchErr is returned when an incompatible planning_alg is specified and there are contraints.
+func NewAlgAndConstraintMismatchErr(planAlg string) error {
+	return fmt.Errorf("cannot specify a planning alg other than cbirrt with topo constraints. alg specified was %s", planAlg)
+}
+
+func newIKConstraintErr(failures map[string]int, constraintFailCnt int) error {
 	ikConstraintFailures := errIKConstraint
 	for failName, count := range failures {
 		ikConstraintFailures += fmt.Sprintf("{ %s: %.2f%% }, ", failName, 100*float64(count)/float64(constraintFailCnt))

--- a/motionplan/motionPlanner.go
+++ b/motionplan/motionPlanner.go
@@ -469,7 +469,7 @@ IK:
 			return nil, errIKSolve
 		}
 
-		return nil, genIKConstraintErr(failures, constraintFailCnt)
+		return nil, newIKConstraintErr(failures, constraintFailCnt)
 	}
 
 	keys := make([]float64, 0, len(solutions))

--- a/motionplan/motionPlanner_test.go
+++ b/motionplan/motionPlanner_test.go
@@ -792,6 +792,9 @@ func TestArmConstraintSpecificationSolve(t *testing.T) {
 }
 
 func TestMovementWithGripper(t *testing.T) {
+	// TODO(rb): move these tests to a separate repo eventually, as they take up too much time for general CI pipeline
+	t.Skip()
+
 	// setup frame system and planning query
 	fs := makeTestFS(t)
 	fs.RemoveFrame(fs.Frame("urOffset"))

--- a/motionplan/motionPlanner_test.go
+++ b/motionplan/motionPlanner_test.go
@@ -792,9 +792,6 @@ func TestArmConstraintSpecificationSolve(t *testing.T) {
 }
 
 func TestMovementWithGripper(t *testing.T) {
-	// TODO(rb): move these tests to a separate repo eventually, as they take up too much time for general CI pipeline
-	t.Skip()
-
 	// setup frame system and planning query
 	fs := makeTestFS(t)
 	fs.RemoveFrame(fs.Frame("urOffset"))

--- a/pointcloud/pointcloud_utils.go
+++ b/pointcloud/pointcloud_utils.go
@@ -1,6 +1,7 @@
 package pointcloud
 
 import (
+	"bytes"
 	"math"
 
 	"github.com/golang/geo/r3"
@@ -116,4 +117,16 @@ func ToBasicOctree(cloud PointCloud) (*BasicOctree, error) {
 		return nil, err
 	}
 	return basicOctree, nil
+}
+
+func ToBytes(cloud PointCloud) ([]byte, error) {
+	if cloud == nil {
+		return nil, errors.New("pointcloud cannot be nil")
+	}
+	var buf bytes.Buffer
+	buf.Grow(200 + (cloud.Size() * 4 * 4)) // 4 numbers per point, each 4 bytes, 200 is header size
+	if err := ToPCD(cloud, &buf, PCDBinary); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }

--- a/pointcloud/pointcloud_utils.go
+++ b/pointcloud/pointcloud_utils.go
@@ -119,6 +119,7 @@ func ToBasicOctree(cloud PointCloud) (*BasicOctree, error) {
 	return basicOctree, nil
 }
 
+// ToBytes takes a pointcloud object and converts it to bytes.
 func ToBytes(cloud PointCloud) ([]byte, error) {
 	if cloud == nil {
 		return nil, errors.New("pointcloud cannot be nil")

--- a/robot/server/server.go
+++ b/robot/server/server.go
@@ -276,13 +276,11 @@ func (s *Server) TransformPCD(ctx context.Context, req *pb.TransformPCDRequest) 
 		return nil, err
 	}
 	// transform pointcloud back to PCD bytes
-	var buf bytes.Buffer
-	buf.Grow(200 + (final.Size() * 4 * 4)) // 4 numbers per point, each 4 bytes
-	err = pointcloud.ToPCD(final, &buf, pointcloud.PCDBinary)
+	bytes, err := pointcloud.ToBytes(final)
 	if err != nil {
 		return nil, err
 	}
-	return &pb.TransformPCDResponse{PointCloudPcd: buf.Bytes()}, err
+	return &pb.TransformPCDResponse{PointCloudPcd: bytes}, err
 }
 
 // StopAll will stop all current and outstanding operations for the robot and stops all actuators and movement.

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -12,8 +12,9 @@ import (
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	pb "go.viam.com/api/service/motion/v1"
-	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"go.viam.com/rdk/components/movementsensor"
 	"go.viam.com/rdk/logging"

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	pb "go.viam.com/api/service/motion/v1"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"go.viam.com/rdk/components/movementsensor"
 	"go.viam.com/rdk/logging"
@@ -359,6 +360,14 @@ func (ms *builtIn) DoCommand(ctx context.Context, cmd map[string]interface{}) (m
 		err = json.Unmarshal(bytes, &moveReqProto)
 		if err != nil {
 			return nil, err
+		}
+		fields := moveReqProto.Extra.AsMap()
+		if extra, err := utils.AssertType[map[string]interface{}](fields["fields"]); err == nil {
+			v, err := structpb.NewStruct(extra)
+			if err != nil {
+				return nil, err
+			}
+			moveReqProto.Extra = v
 		}
 		moveReq, err := motion.MoveReqFromProto(&moveReqProto)
 		if err != nil {

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 	pb "go.viam.com/api/service/motion/v1"
 	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"go.viam.com/rdk/components/movementsensor"

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -1302,7 +1302,7 @@ func TestDoCommand(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, len(trajectory), test.ShouldEqual, 2)
 
-		// test that it breaks if a bad motion profile is provided, meaning it is being parsed correctly
+		// test that it correctly breaks if bad inputs are provided, meaning it is being parsed correctly
 		moveReq.Extra = map[string]interface{}{
 			"motion_profile": motionplan.LinearMotionProfile,
 			"planning_alg":   "rrtstar",

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 	commonpb "go.viam.com/api/common/v1"
 	"go.viam.com/test"
+	"go.viam.com/utils/artifact"
 	"go.viam.com/utils/protoutils"
 
 	"go.viam.com/rdk/components/arm"
@@ -1245,10 +1246,18 @@ func TestCheckPlan(t *testing.T) {
 }
 
 func TestDoCommand(t *testing.T) {
+	logger := logging.NewTestLogger(t)
 	ctx := context.Background()
+	cloud, err := pointcloud.NewFromFile(artifact.MustPath("pointcloud/test.las"), logger)
+	test.That(t, err, test.ShouldBeNil)
+	pcBytes, err := pointcloud.ToBytes(cloud)
+	test.That(t, err, test.ShouldBeNil)
 	moveReq := motion.MoveReq{
 		ComponentName: gripper.Named("pieceGripper"),
 		Destination:   referenceframe.NewPoseInFrame("c", spatialmath.NewPoseFromPoint(r3.Vector{X: 0, Y: -30, Z: -50})),
+		Extra: map[string]interface{}{
+			"pcd": pcBytes,
+		},
 	}
 
 	// need to simulate what happens when the DoCommand message is serialized/deserialized into proto

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/pkg/errors"
 	commonpb "go.viam.com/api/common/v1"
 	"go.viam.com/test"
-	"go.viam.com/utils/artifact"
 	"go.viam.com/utils/protoutils"
 	"google.golang.org/protobuf/encoding/protojson"
 
@@ -1247,7 +1246,6 @@ func TestCheckPlan(t *testing.T) {
 }
 
 func TestDoCommand(t *testing.T) {
-	logger := logging.NewTestLogger(t)
 	ctx := context.Background()
 	box, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{1000, 1000, 1000}), r3.Vector{1, 1, 1}, "box")
 	test.That(t, err, test.ShouldBeNil)
@@ -1262,17 +1260,19 @@ func TestDoCommand(t *testing.T) {
 	}
 
 	// need to simulate what happens when the DoCommand message is serialized/deserialized into proto
-	doOverWire := func(ms motion.Service, cmd map[string]interface{}) map[string]interface{} {
+	doOverWire := func(ms motion.Service, cmd map[string]interface{}) (map[string]interface{}, error) {
 		command, err := protoutils.StructToStructPb(cmd)
 		test.That(t, err, test.ShouldBeNil)
 		resp, err := ms.DoCommand(ctx, command.AsMap())
-		test.That(t, err, test.ShouldBeNil)
+		if err != nil {
+			return map[string]interface{}{}, err
+		}
 		respProto, err := protoutils.StructToStructPb(resp)
 		test.That(t, err, test.ShouldBeNil)
-		return respProto.AsMap()
+		return respProto.AsMap(), nil
 	}
 
-	testDoPlan := func(t *testing.T, moveReq motion.MoveReq) {
+	testDoPlan := func(t *testing.T, moveReq motion.MoveReq) (motionplan.Trajectory, error) {
 		ms, teardown := setupMotionServiceFromConfig(t, "../data/moving_arm.json")
 		defer teardown()
 
@@ -1284,26 +1284,32 @@ func TestDoCommand(t *testing.T) {
 		cmd := map[string]interface{}{DoPlan: string(bytes)}
 
 		// simulate going over the wire
-		resp, ok := doOverWire(ms, cmd)[DoPlan]
+		respMap, err := doOverWire(ms, cmd)
+		if err != nil {
+			return nil, err
+		}
+		resp, ok := respMap[DoPlan]
 		test.That(t, ok, test.ShouldBeTrue)
 
 		// the client will need to decode the response still
 		var trajectory motionplan.Trajectory
 		err = mapstructure.Decode(resp, &trajectory)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, len(trajectory), test.ShouldEqual, 2)
+		return trajectory, err
 	}
 
 	t.Run("DoPlan", func(t *testing.T) {
-		testDoPlan(t, moveReq)
+		trajectory, err := testDoPlan(t, moveReq)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(trajectory), test.ShouldEqual, 2)
 
-		// test that it still works when extras are added to moveReq
-		cloud, err := pointcloud.NewFromFile(artifact.MustPath("pointcloud/test.las"), logger)
-		test.That(t, err, test.ShouldBeNil)
-		pcBytes, err := pointcloud.ToBytes(cloud)
-		test.That(t, err, test.ShouldBeNil)
-		moveReq.Extra = map[string]interface{}{"pcd": pcBytes}
-		testDoPlan(t, moveReq)
+		// test that it breaks if a bad motion profile is provided, meaning it is being parsed correctly
+		moveReq.Extra = map[string]interface{}{
+			"motion_profile": motionplan.LinearMotionProfile,
+			"planning_alg":   "rrtstar",
+		}
+		_, err = testDoPlan(t, moveReq)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err, test.ShouldResemble, motionplan.NewAlgAndConstraintMismatchErr("rrtstar"))
 	})
 
 	t.Run("DoExectute", func(t *testing.T) {
@@ -1317,7 +1323,9 @@ func TestDoCommand(t *testing.T) {
 		cmd := map[string]interface{}{DoExecute: plan.Trajectory()}
 
 		// simulate going over the wire
-		resp, ok := doOverWire(ms, cmd)[DoExecute]
+		respMap, err := doOverWire(ms, cmd)
+		test.That(t, err, test.ShouldBeNil)
+		resp, ok := respMap[DoExecute]
 		test.That(t, ok, test.ShouldBeTrue)
 
 		// the client will need to decode the response still


### PR DESCRIPTION
Currently, passing motion options in the MoveRequest does not work.  This PR fixes this so they are correctly transmitted.  

In addition, I did a little bit of refactoring to make it easier to convert a pointcloud into bytes.  This is related to the above objective because we are interested in passing in pointclouds through the MoveReq Options field.  