### PR TITLE
DATA-3445 Implement Go SDK for ExportTabularData API

### DIFF
--- a/app/data_client.go
+++ b/app/data_client.go
@@ -186,6 +186,38 @@ type GetLatestTabularDataResponse struct {
 	Payload      map[string]interface{}
 }
 
+// ExportTabularDataResponse represents the result of an ExportTabularData API call.
+type ExportTabularDataResponse struct {
+	OrganizationID   string
+	LocationID       string
+	RobotID          string
+	RobotName        string
+	PartID           string
+	PartName         string
+	ResourceName     string
+	ResourceSubtype  string
+	MethodName       string
+	TimeCaptured     time.Time
+	MethodParameters map[string]interface{}
+	Tags             []string
+	Payload          map[string]interface{}
+}
+
+// ExportTabularDataStream is a stream that returns ExportTabularDataResponses.
+type ExportTabularDataStream struct {
+	Stream pb.DataService_ExportTabularDataClient
+}
+
+// Next gets the next ExportTabularDataResponse.
+func (e *ExportTabularDataStream) Next() (*ExportTabularDataResponse, error) {
+	streamResp, err := e.Stream.Recv()
+	if err != nil {
+		return nil, err
+	}
+
+	return exportTabularDataResponseFromProto(streamResp), nil
+}
+
 // DataSyncClient structs
 
 // SensorMetadata contains the time the sensor data was requested and was received.
@@ -465,6 +497,25 @@ func (d *DataClient) GetLatestTabularData(ctx context.Context, partID, resourceN
 		TimeCaptured: resp.TimeCaptured.AsTime(),
 		TimeSynced:   resp.TimeSynced.AsTime(),
 		Payload:      resp.Payload.AsMap(),
+	}, nil
+}
+
+// ExportTabularData returns a stream of ExportTabularDataResponses.
+func (d *DataClient) ExportTabularData(
+	ctx context.Context, partID, resourceName, resourceSubtype, method string, interval CaptureInterval,
+) (*ExportTabularDataStream, error) {
+	stream, err := d.dataClient.ExportTabularData(ctx, &pb.ExportTabularDataRequest{
+		PartId:          partID,
+		ResourceName:    resourceName,
+		ResourceSubtype: resourceSubtype,
+		MethodName:      method,
+		Interval:        captureIntervalToProto(interval),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &ExportTabularDataStream{
+		Stream: stream,
 	}, nil
 }
 
@@ -1178,6 +1229,24 @@ func boundingBoxFromProto(proto *pb.BoundingBox) *BoundingBox {
 		YMinNormalized: proto.YMinNormalized,
 		XMaxNormalized: proto.XMaxNormalized,
 		YMaxNormalized: proto.YMaxNormalized,
+	}
+}
+
+func exportTabularDataResponseFromProto(proto *pb.ExportTabularDataResponse) *ExportTabularDataResponse {
+	return &ExportTabularDataResponse{
+		OrganizationID:   proto.OrganizationId,
+		LocationID:       proto.LocationId,
+		RobotID:          proto.RobotId,
+		RobotName:        proto.RobotName,
+		PartID:           proto.PartId,
+		PartName:         proto.PartName,
+		ResourceName:     proto.ResourceName,
+		ResourceSubtype:  proto.ResourceSubtype,
+		MethodName:       proto.MethodName,
+		TimeCaptured:     proto.TimeCaptured.AsTime(),
+		MethodParameters: proto.MethodParameters.AsMap(),
+		Tags:             proto.Tags,
+		Payload:          proto.Payload.AsMap(),
 	}
 }
 

--- a/app/data_client_test.go
+++ b/app/data_client_test.go
@@ -13,6 +13,7 @@ import (
 	"go.viam.com/test"
 	utils "go.viam.com/utils/protoutils"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"go.viam.com/rdk/protoutils"
@@ -70,6 +71,21 @@ var (
 		Metadata:      &tabularMetadata,
 		TimeRequested: start,
 		TimeReceived:  end,
+	}
+	exportTabularResponse = &pb.ExportTabularDataResponse{
+		PartId:           partID,
+		ResourceName:     componentName,
+		ResourceSubtype:  componentType,
+		MethodName:       method,
+		TimeCaptured:     timestamppb.Now(),
+		OrganizationId:   organizationID,
+		LocationId:       parentLocationID,
+		RobotName:        robotName,
+		RobotId:          robotID,
+		PartName:         partName,
+		MethodParameters: &structpb.Struct{},
+		Tags:             tags,
+		Payload:          &structpb.Struct{},
 	}
 	binaryID = BinaryID{
 		FileID:         "file1",
@@ -373,6 +389,31 @@ func TestDataClient(t *testing.T) {
 		resp, err := client.GetLatestTabularData(context.Background(), partID, componentName, componentType, method)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, resp, test.ShouldResemble, &latestTabularData)
+	})
+
+	t.Run("ExportTabularData", func(t *testing.T) {
+		mockStream := &inject.DataServiceExportTabularDataClient{
+			RecvFunc: func() (*pb.ExportTabularDataResponse, error) {
+				return exportTabularResponse, nil
+			},
+		}
+
+		grpcClient.ExportTabularDataFunc = func(ctx context.Context, in *pb.ExportTabularDataRequest,
+			opts ...grpc.CallOption,
+		) (pb.DataService_ExportTabularDataClient, error) {
+			test.That(t, in.PartId, test.ShouldEqual, partID)
+			test.That(t, in.ResourceName, test.ShouldEqual, componentName)
+			test.That(t, in.ResourceSubtype, test.ShouldEqual, componentType)
+			test.That(t, in.MethodName, test.ShouldEqual, method)
+			test.That(t, in.Interval, test.ShouldResemble, captureIntervalToProto(captureInterval))
+			return mockStream, nil
+		}
+
+		stream, err := client.ExportTabularData(context.Background(), partID, componentName, componentType, method, captureInterval)
+		test.That(t, err, test.ShouldBeNil)
+		resp, err := stream.Next()
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, resp, test.ShouldResemble, exportTabularDataResponseFromProto(exportTabularResponse))
 	})
 
 	t.Run("BinaryDataByFilter", func(t *testing.T) {

--- a/testutils/inject/data_service_client.go
+++ b/testutils/inject/data_service_client.go
@@ -20,6 +20,8 @@ type DataServiceClient struct {
 		opts ...grpc.CallOption) (*datapb.TabularDataByMQLResponse, error)
 	GetLatestTabularDataFunc func(ctx context.Context, in *datapb.GetLatestTabularDataRequest,
 		opts ...grpc.CallOption) (*datapb.GetLatestTabularDataResponse, error)
+	ExportTabularDataFunc func(ctx context.Context, in *datapb.ExportTabularDataRequest,
+		opts ...grpc.CallOption) (datapb.DataService_ExportTabularDataClient, error)
 	BinaryDataByFilterFunc func(ctx context.Context, in *datapb.BinaryDataByFilterRequest,
 		opts ...grpc.CallOption) (*datapb.BinaryDataByFilterResponse, error)
 	BinaryDataByIDsFunc func(ctx context.Context, in *datapb.BinaryDataByIDsRequest,
@@ -100,6 +102,30 @@ func (client *DataServiceClient) GetLatestTabularData(ctx context.Context, in *d
 		return client.DataServiceClient.GetLatestTabularData(ctx, in, opts...)
 	}
 	return client.GetLatestTabularDataFunc(ctx, in, opts...)
+}
+
+// DataServiceExportTabularDataClient represents a fake instance of a proto DataService_ExportTabularDataClient.
+type DataServiceExportTabularDataClient struct {
+	datapb.DataService_ExportTabularDataClient
+	RecvFunc func() (*datapb.ExportTabularDataResponse, error)
+}
+
+// Recv calls the injected RecvFunc or the real version.
+func (c *DataServiceExportTabularDataClient) Recv() (*datapb.ExportTabularDataResponse, error) {
+	if c.RecvFunc == nil {
+		return c.DataService_ExportTabularDataClient.Recv()
+	}
+	return c.RecvFunc()
+}
+
+// ExportTabularData calls the injected ExportTabularData or the real version.
+func (client *DataServiceClient) ExportTabularData(ctx context.Context, in *datapb.ExportTabularDataRequest,
+	opts ...grpc.CallOption,
+) (datapb.DataService_ExportTabularDataClient, error) {
+	if client.ExportTabularDataFunc == nil {
+		return client.DataServiceClient.ExportTabularData(ctx, in, opts...)
+	}
+	return client.ExportTabularDataFunc(ctx, in, opts...)
 }
 
 // BinaryDataByFilter calls the injected BinaryDataByFilter or the real version.


### PR DESCRIPTION
This PR fixes the git mess that happened here:
https://github.com/viamrobotics/rdk/pull/4597
