### PR TITLE
RSDK 9552: Transforms shouldn't have to close anything

### DIFF
--- a/components/camera/transformpipeline/classifier.go
+++ b/components/camera/transformpipeline/classifier.go
@@ -110,5 +110,5 @@ func (cs *classifierSource) Read(ctx context.Context) (image.Image, func(), erro
 }
 
 func (cs *classifierSource) Close(ctx context.Context) error {
-	return cs.src.Close(ctx)
+	return nil
 }

--- a/components/camera/transformpipeline/composed.go
+++ b/components/camera/transformpipeline/composed.go
@@ -80,7 +80,7 @@ func (dtp *depthToPretty) Read(ctx context.Context) (image.Image, func(), error)
 }
 
 func (dtp *depthToPretty) Close(ctx context.Context) error {
-	return dtp.src.Close(ctx)
+	return nil
 }
 
 func (dtp *depthToPretty) PointCloud(ctx context.Context) (pointcloud.PointCloud, error) {

--- a/components/camera/transformpipeline/depth_edges.go
+++ b/components/camera/transformpipeline/depth_edges.go
@@ -72,5 +72,5 @@ func (os *depthEdgesSource) Read(ctx context.Context) (image.Image, func(), erro
 }
 
 func (os *depthEdgesSource) Close(ctx context.Context) error {
-	return os.src.Close(ctx)
+	return nil
 }

--- a/components/camera/transformpipeline/detector.go
+++ b/components/camera/transformpipeline/detector.go
@@ -104,5 +104,5 @@ func (ds *detectorSource) Read(ctx context.Context) (image.Image, func(), error)
 }
 
 func (ds *detectorSource) Close(ctx context.Context) error {
-	return ds.src.Close(ctx)
+	return nil
 }

--- a/components/camera/transformpipeline/mods.go
+++ b/components/camera/transformpipeline/mods.go
@@ -85,9 +85,8 @@ func (rs *rotateSource) Read(ctx context.Context) (image.Image, func(), error) {
 	}
 }
 
-// Close closes the original stream.
 func (rs *rotateSource) Close(ctx context.Context) error {
-	return rs.src.Close(ctx)
+	return nil
 }
 
 // resizeConfig are the attributes for a resize transform.
@@ -152,9 +151,8 @@ func (rs *resizeSource) Read(ctx context.Context) (image.Image, func(), error) {
 	}
 }
 
-// Close closes the original stream.
 func (rs *resizeSource) Close(ctx context.Context) error {
-	return rs.src.Close(ctx)
+	return nil
 }
 
 // cropConfig are the attributes for a crop transform.
@@ -296,7 +294,6 @@ func (cs *cropSource) Read(ctx context.Context) (image.Image, func(), error) {
 	}
 }
 
-// Close closes the original stream.
 func (cs *cropSource) Close(ctx context.Context) error {
-	return cs.src.Close(ctx)
+	return nil
 }

--- a/components/camera/transformpipeline/pipeline.go
+++ b/components/camera/transformpipeline/pipeline.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
-	"go.uber.org/multierr"
 
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/logging"
@@ -162,16 +161,5 @@ func (tp transformPipeline) NextPointCloud(ctx context.Context) (pointcloud.Poin
 }
 
 func (tp transformPipeline) Close(ctx context.Context) error {
-	var errs error
-	for _, src := range tp.pipeline {
-		errs = multierr.Combine(errs, func() (err error) {
-			defer func() {
-				if panicErr := recover(); panicErr != nil {
-					err = multierr.Combine(err, errors.Errorf("panic: %v", panicErr))
-				}
-			}()
-			return src.Close(ctx)
-		}())
-	}
-	return multierr.Combine(tp.src.Close(ctx), errs)
+	return nil
 }

--- a/components/camera/transformpipeline/preprocessing.go
+++ b/components/camera/transformpipeline/preprocessing.go
@@ -58,5 +58,5 @@ func (os *preprocessDepthTransform) Read(ctx context.Context) (image.Image, func
 }
 
 func (os *preprocessDepthTransform) Close(ctx context.Context) error {
-	return os.src.Close(ctx)
+	return nil
 }

--- a/components/camera/transformpipeline/segmenter.go
+++ b/components/camera/transformpipeline/segmenter.go
@@ -114,7 +114,6 @@ func (ss *segmenterSource) Read(ctx context.Context) (image.Image, func(), error
 	return img, release, nil
 }
 
-// Close closes the underlying stream.
 func (ss *segmenterSource) Close(ctx context.Context) error {
-	return ss.src.Close(ctx)
+	return nil
 }

--- a/components/camera/transformpipeline/undistort.go
+++ b/components/camera/transformpipeline/undistort.go
@@ -81,7 +81,6 @@ func (us *undistortSource) Read(ctx context.Context) (image.Image, func(), error
 	}
 }
 
-// Close closes the original stream.
 func (us *undistortSource) Close(ctx context.Context) error {
-	return us.originalSource.Close(ctx)
+	return nil
 }

--- a/components/camera/videosourcewrappers.go
+++ b/components/camera/videosourcewrappers.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pion/mediadevices/pkg/prop"
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
-	"go.uber.org/multierr"
 
 	"go.viam.com/rdk/components/camera/rtppassthrough"
 	"go.viam.com/rdk/gostream"
@@ -136,7 +135,6 @@ func NewVideoSourceFromReader(
 		rtpPassthroughSource: rtpPassthroughSource,
 		system:               actualSystem,
 		videoSource:          vs,
-		videoStream:          gostream.NewEmbeddedVideoStream(vs),
 		actualSource:         reader,
 		imageType:            imageType,
 	}, nil
@@ -177,7 +175,6 @@ func WrapVideoSourceWithProjector(
 	return &videoSource{
 		system:       actualSystem,
 		videoSource:  source,
-		videoStream:  gostream.NewEmbeddedVideoStream(source),
 		actualSource: source,
 		imageType:    imageType,
 	}, nil
@@ -187,7 +184,6 @@ func WrapVideoSourceWithProjector(
 type videoSource struct {
 	rtpPassthroughSource rtppassthrough.Source
 	videoSource          gostream.VideoSource
-	videoStream          gostream.VideoStream
 	actualSource         interface{}
 	system               *transform.PinholeCameraModel
 	imageType            ImageType
@@ -249,7 +245,7 @@ func (vs *videoSource) NextPointCloud(ctx context.Context) (pointcloud.PointClou
 	if vs.system == nil || vs.system.PinholeCameraIntrinsics == nil {
 		return nil, transform.NewNoIntrinsicsError("cannot do a projection to a point cloud")
 	}
-	img, release, err := vs.videoStream.Next(ctx)
+	img, release, err := ReadImage(ctx, vs.videoSource)
 	defer release()
 	if err != nil {
 		return nil, err
@@ -290,5 +286,8 @@ func (vs *videoSource) Properties(ctx context.Context) (Properties, error) {
 }
 
 func (vs *videoSource) Close(ctx context.Context) error {
-	return multierr.Combine(vs.videoStream.Close(ctx), vs.videoSource.Close(ctx))
+	if res, ok := vs.actualSource.(resource.Resource); ok {
+		return res.Close(ctx)
+	}
+	return vs.videoSource.Close(ctx)
 }


### PR DESCRIPTION
This fixes a bug where transform cameras cannot reconfigure hitting the below error

This was caused by the transform pipeline refactor in https://github.com/viamrobotics/rdk/pull/4487/files#diff-7901d35a5a488937d314d3f6be687673f43b08fbf5b904b74caf8f6a55713abc

```
12/16/2024, 3:40:31 PM error rdk server/entrypoint.go:200 Fatal error running server, exiting now: webcam already closed; webcam already closed; webcam already closed; webcam already closed

12/16/2024, 3:40:31 PM error rdk server/entrypoint.go:220 error serving web error webcam already closed; webcam already closed; webcam already closed; webcam already closed
```