### PR TITLE
RSDK-8471 Add three-dot diff to git diff

### DIFF
--- a/.github/workflows/motion-tests.yml
+++ b/.github/workflows/motion-tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: check modified files
         id: file_checker
         run: |
-          ( git diff --name-only origin/${{github.base_ref}} | grep -e "motionplan" \
+          ( git diff --name-only origin/${{github.base_ref}}... | grep -e "motionplan" \
             -e "referenceframe" \
             -e "spatialmath" \
             -e "components/base/wheeled" \


### PR DESCRIPTION
See documentation here: https://www.baeldung.com/ops/git-double-vs-triple-dot

Basically, this prevents the diff from being applied bidirectionally, only triggering the extended tests on the actual PR that changes motion, rather than any PRs coming in after a motion PR has been merged that did not rebase on main