### PR TITLE
DATA-3445 Update ExportTabularData to return a slice

### DIFF
--- a/app/data_client.go
+++ b/app/data_client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -201,21 +202,6 @@ type ExportTabularDataResponse struct {
 	MethodParameters map[string]interface{}
 	Tags             []string
 	Payload          map[string]interface{}
-}
-
-// ExportTabularDataStream is a stream that returns ExportTabularDataResponses.
-type ExportTabularDataStream struct {
-	Stream pb.DataService_ExportTabularDataClient
-}
-
-// Next gets the next ExportTabularDataResponse.
-func (e *ExportTabularDataStream) Next() (*ExportTabularDataResponse, error) {
-	streamResp, err := e.Stream.Recv()
-	if err != nil {
-		return nil, err
-	}
-
-	return exportTabularDataResponseFromProto(streamResp), nil
 }
 
 // DataSyncClient structs
@@ -503,7 +489,7 @@ func (d *DataClient) GetLatestTabularData(ctx context.Context, partID, resourceN
 // ExportTabularData returns a stream of ExportTabularDataResponses.
 func (d *DataClient) ExportTabularData(
 	ctx context.Context, partID, resourceName, resourceSubtype, method string, interval CaptureInterval,
-) (*ExportTabularDataStream, error) {
+) ([]*ExportTabularDataResponse, error) {
 	stream, err := d.dataClient.ExportTabularData(ctx, &pb.ExportTabularDataRequest{
 		PartId:          partID,
 		ResourceName:    resourceName,
@@ -514,9 +500,22 @@ func (d *DataClient) ExportTabularData(
 	if err != nil {
 		return nil, err
 	}
-	return &ExportTabularDataStream{
-		Stream: stream,
-	}, nil
+
+	var responses []*ExportTabularDataResponse
+
+	for {
+		response, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		responses = append(responses, exportTabularDataResponseFromProto(response))
+	}
+
+	return responses, nil
 }
 
 // BinaryDataByFilter queries binary data and metadata based on given filters.


### PR DESCRIPTION
After discussing with SDK team, changing `ExportTabularData` to return the full response as a slice instead of streaming the responses. This will better align with the other SDKs and will also be more user-friendly.