### PR TITLE
[RSDK-9574] - Do not bump sequence number for each track

### DIFF
--- a/gostream/webrtc_track.go
+++ b/gostream/webrtc_track.go
@@ -124,14 +124,14 @@ func (s *trackLocalStaticRTP) WriteRTP(p *rtp.Packet) error {
 
 	writeErrs := []error{}
 	outboundPacket := *p
-
+	sequenceNum := s.sequencer.NextSequenceNumber()
 	for _, b := range s.bindings {
 		outboundPacket.Header.SSRC = uint32(b.ssrc)
 		outboundPacket.Header.PayloadType = uint8(b.payloadType)
 		// We overwrite the sequence number to ensure continuity between packets
 		// coming from Passthrough sources and those that are packetized by the
 		// Pion RTP Packetizer in the WriteData method.
-		outboundPacket.Header.SequenceNumber = s.sequencer.NextSequenceNumber()
+		outboundPacket.Header.SequenceNumber = sequenceNum
 		if _, err := b.writeStream.WriteRTP(&outboundPacket.Header, outboundPacket.Payload); err != nil {
 			writeErrs = append(writeErrs, err)
 		}


### PR DESCRIPTION
## Description

This fixes a livestream bug that was causing two concurrent webrtc streams to fail.

## Testing
- Test two concurrent gostream livestream feeds ✅ 
- Test passthrough ✅ 
- Test dynamic resolution resize ✅ 

https://github.com/user-attachments/assets/99f9df41-7b98-48cf-bd74-8e3cb1e86484

https://github.com/user-attachments/assets/5ffd7f87-4eaf-47b6-acd8-95e03db737a3

https://github.com/user-attachments/assets/25445f52-f6a9-4e34-a2f1-06898bbdca9d


