### PR TITLE
RSDK-9602: Prevent lazyEncodedImage.Bounds from getting gostream into a panic loop.

### DIFF
--- a/gostream/stream.go
+++ b/gostream/stream.go
@@ -4,6 +4,7 @@ package gostream
 import (
 	"context"
 	"errors"
+	"fmt"
 	"image"
 	"sync"
 	"time"
@@ -269,7 +270,31 @@ func (bs *basicStream) processInputFrames() {
 			if frame, ok := framePair.Media.(*rimage.LazyEncodedImage); ok && frame.MIMEType() == utils2.MimeTypeH264 {
 				encodedFrame = frame.RawData() // nothing to do; already encoded
 			} else {
-				bounds := framePair.Media.Bounds()
+				var bounds image.Rectangle
+				var boundsError any
+				func() {
+					defer func() {
+						if paniced := recover(); paniced != nil {
+							boundsError = paniced
+						}
+					}()
+
+					bounds = framePair.Media.Bounds()
+				}()
+
+				if boundsError != nil {
+					bs.logger.Errorw("Getting frame bounds failed", "err", fmt.Sprintf("%s", boundsError))
+					// Dan: It's unclear why we get this error. There's reason to believe this pops
+					// up when a camera is reconfigured/removed. In which case I'd expect the
+					// `basicStream` to soon be closed. Making this `initErr = true` assignment to
+					// exit the `processInputFrames` goroutine unnecessary. But I'm choosing to be
+					// conservative for the worst case. Where we may be in a permanent bad state and
+					// (until we understand the problem better) we would spew logs until the user
+					// stops the stream.
+					initErr = true
+					return
+				}
+
 				newDx, newDy := bounds.Dx(), bounds.Dy()
 				if bs.videoEncoder == nil || dx != newDx || dy != newDy {
 					dx, dy = newDx, newDy


### PR DESCRIPTION
I hand tested this with some "panic once" code:
```
+                               var bounds image.Rectangle
+                               var boundsError any = nil
+                               func() {
+                                       defer func() {
+                                               if paniced := recover(); paniced != nil {
+                                                       boundsError = paniced
+                                               }
+                                       }()
+
+                                       bounds = framePair.Media.Bounds()
+                                       global.Do(func() {
+                                               panic("dan paniced")
+                                       })
+                               }()
```

I confirmed that the first time I go to "Live", the stream fails. As a user I had to switch back to try adding the stream a second time. Everything worked after that first error.

And I saw the expected log in the viam-server output:
```
2024-12-20T17:04:54.964Z	ERROR	rdk	gostream/stream.go:291	Getting frame bounds failed	{"err":"dan paniced"}
```