### PR TITLE
RSDK-9295 - refactor disable-web-browser name and behavior

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -371,8 +371,9 @@ var app = &cli.App{
 			HideHelpCommand: true,
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
-					Name:  loginFlagDisableBrowser,
-					Usage: "prevent opening the default browser during login",
+					Name:    loginFlagDisableBrowser,
+					Aliases: []string{"no-browser"}, // ease of use alias, not related to backwards compatibility
+					Usage:   "prevent opening the default browser during login",
 				},
 			},
 			Action: createCommandWithT[loginActionArgs](LoginAction),

--- a/cli/auth.go
+++ b/cli/auth.go
@@ -745,9 +745,9 @@ func (a *authFlow) makeDeviceCodeRequest(ctx context.Context, discovery *openIDD
 func (a *authFlow) directUser(code *deviceCodeResponse) error {
 	suggestedLoginMethods := ""
 	if !a.disableBrowserOpen {
-		suggestedLoginMethods = "through the opened browser window or"
+		suggestedLoginMethods = " through the opened browser window or"
 	}
-	infof(a.console, `You can log into Viam %s by following the URL below.
+	infof(a.console, `You can log into Viam%s by following the URL below.
 Ensure the code in the URL matches the one shown in your browser.
   %s`, suggestedLoginMethods, code.VerificationURIComplete)
 


### PR DESCRIPTION
Adds a slightly less verbose `no-browser` alias to the `disable-web-browser` flag, and changes default behavior such that a command won't fail when a browser can't be opened, but rather inform the user that the browser failed to open and that they can still visit the provided URL to log in.

Tested manually.
Without flag, artificially injected error at browser open attempt:
<img width="1440" alt="Screenshot 2024-12-23 at 14 08 17" src="https://github.com/user-attachments/assets/332036a1-e577-4f1d-9c4e-75c65257a720" />

With flag:
<img width="914" alt="Screenshot 2024-12-23 at 14 20 36" src="https://github.com/user-attachments/assets/5ca37fef-a370-43f4-b4cd-e25444824287" />
