### PR TITLE
RSDK-9370: change param prefix check in module generation

### DIFF
--- a/cli/module_generate/scripts/generate_stubs.go
+++ b/cli/module_generate/scripts/generate_stubs.go
@@ -135,7 +135,7 @@ func formatType(typeExpr ast.Expr, resourceSubtype string) string {
 		}
 		return str
 	}
-	for _, prefix := range(prefixes) {
+	for _, prefix := range prefixes {
 		if strings.HasPrefix(typeString, prefix) {
 			return checkUpper(typeString, prefix)
 		}

--- a/cli/module_generate/scripts/generate_stubs.go
+++ b/cli/module_generate/scripts/generate_stubs.go
@@ -195,7 +195,9 @@ func parseFunctionSignature(
 			switch {
 			case unicode.IsUpper(rune(paramType[0])):
 				paramType = fmt.Sprintf("%s.%s", resourceSubtype, paramType)
-			// IF `paramType` has a prefix, check if type is capitalized after prefix.
+			// If `paramType` has a prefix, check if type is capitalized after prefix.
+			case strings.HasPrefix(paramType, "*") && unicode.IsUpper(rune(paramType[1])):
+				paramType = fmt.Sprintf("*%s.%s", resourceSubtype, paramType[1:])
 			case strings.HasPrefix(paramType, "[]") && unicode.IsUpper(rune(paramType[2])):
 				paramType = fmt.Sprintf("[]%s.%s", resourceSubtype, paramType[2:])
 			case strings.HasPrefix(paramType, "chan ") && unicode.IsUpper(rune(paramType[5])):

--- a/cli/module_generate/scripts/generate_stubs.go
+++ b/cli/module_generate/scripts/generate_stubs.go
@@ -25,7 +25,7 @@ import (
 //go:embed tmpl-module
 var goTmpl string
 
-// possible prefixes before function parameter and return types
+// typePrefixes lists possible prefixes before function parameter and return types.
 var typePrefixes = []string{"*", "[]*", "[]", "chan "}
 
 // getClientCode grabs client.go code of component type.

--- a/cli/module_generate/scripts/generate_stubs.go
+++ b/cli/module_generate/scripts/generate_stubs.go
@@ -25,6 +25,9 @@ import (
 //go:embed tmpl-module
 var goTmpl string
 
+// possible prefixes before function parameter and return types
+var typePrefixes = []string{"*", "[]*", "[]", "chan "}
+
 // getClientCode grabs client.go code of component type.
 func getClientCode(module modulegen.ModuleInputs) (string, error) {
 	url := fmt.Sprintf("https://raw.githubusercontent.com/viamrobotics/rdk/refs/tags/v%s/%ss/%s/client.go",
@@ -126,8 +129,7 @@ func formatType(typeExpr ast.Expr, resourceSubtype string) string {
 	}
 	typeString := buf.String()
 
-	prefixes := []string{"*", "[]*", "[]", "chan "}
-	// checkUpper attributes to <resourceSubtype> if type is capitalized after prefix.
+	// checkUpper adds "<resourceSubtype>." to the type if type is capitalized after prefix.
 	checkUpper := func(str, prefix string) string {
 		prefixLen := len(prefix)
 		if unicode.IsUpper(rune(str[prefixLen])) {
@@ -135,7 +137,7 @@ func formatType(typeExpr ast.Expr, resourceSubtype string) string {
 		}
 		return str
 	}
-	for _, prefix := range prefixes {
+	for _, prefix := range typePrefixes {
 		if strings.HasPrefix(typeString, prefix) {
 			return checkUpper(typeString, prefix)
 		}

--- a/cli/module_generate/scripts/generate_stubs.go
+++ b/cli/module_generate/scripts/generate_stubs.go
@@ -126,6 +126,7 @@ func formatType(typeExpr ast.Expr, resourceSubtype string) string {
 	}
 	typeString := buf.String()
 
+	prefixes := []string{"*", "[]*", "[]", "chan "}
 	// checkUpper attributes to <resourceSubtype> if type is capitalized after prefix.
 	checkUpper := func(str, prefix string) string {
 		prefixLen := len(prefix)
@@ -134,20 +135,12 @@ func formatType(typeExpr ast.Expr, resourceSubtype string) string {
 		}
 		return str
 	}
-
-	// Attribute type to <resourceSubtype> if type if applicable.
-	switch {
-	default:
-		return checkUpper(typeString, "")
-	case strings.HasPrefix(typeString, "*"):
-		return checkUpper(typeString, "*")
-	case strings.HasPrefix(typeString, "[]*"):
-		return checkUpper(typeString, "[]*")
-	case strings.HasPrefix(typeString, "[]"):
-		return checkUpper(typeString, "[]")
-	case strings.HasPrefix(typeString, "chan "):
-		return checkUpper(typeString, "chan ")
-	case strings.HasPrefix(typeString, "map["):
+	for _, prefix := range(prefixes) {
+		if strings.HasPrefix(typeString, prefix) {
+			return checkUpper(typeString, prefix)
+		}
+	}
+	if strings.HasPrefix(typeString, "map[") {
 		endStr := strings.Index(typeString, "]")
 		keyType := strings.TrimSpace(typeString[4:endStr])
 		valueType := strings.TrimSpace(typeString[endStr+1:])
@@ -159,6 +152,7 @@ func formatType(typeExpr ast.Expr, resourceSubtype string) string {
 		}
 		return fmt.Sprintf("map[%s]%s", keyType, valueType)
 	}
+	return checkUpper(typeString, "")
 }
 
 func formatStruct(typeSpec *ast.TypeSpec, modelType string) string {

--- a/cli/module_generate/scripts/generate_stubs.go
+++ b/cli/module_generate/scripts/generate_stubs.go
@@ -90,7 +90,6 @@ func setGoModuleTemplate(clientCode string, module modulegen.ModuleInputs) (*mod
 		if funcDecl, ok := n.(*ast.FuncDecl); ok {
 			name, receiver, args, returns := parseFunctionSignature(
 				module.ResourceSubtype,
-				module.ResourceSubtypePascal,
 				module.ModuleCamel+module.ModelPascal,
 				funcDecl,
 			)
@@ -118,28 +117,48 @@ func setGoModuleTemplate(clientCode string, module modulegen.ModuleInputs) (*mod
 	return &goTmplInputs, nil
 }
 
-// formatType outputs typeExpr as readable string.
-func formatType(typeExpr ast.Expr) string {
+// formatType formats typeExpr as readable string with correct attribution if applicable.
+func formatType(typeExpr ast.Expr, resourceSubtype string) string {
 	var buf bytes.Buffer
 	err := printer.Fprint(&buf, token.NewFileSet(), typeExpr)
 	if err != nil {
 		return fmt.Sprintf("Error formatting type: %v", err)
 	}
-	return buf.String()
-}
+	typeString := buf.String()
 
-func handleMapType(str, resourceSubtype string) string {
-	endStr := strings.Index(str, "]")
-	keyType := strings.TrimSpace(str[4:endStr])
-	valueType := strings.TrimSpace(str[endStr+1:])
-	if unicode.IsUpper(rune(keyType[0])) {
-		keyType = fmt.Sprintf("%s.%s", resourceSubtype, keyType)
-	}
-	if unicode.IsUpper(rune(valueType[0])) {
-		valueType = fmt.Sprintf("%s.%s", resourceSubtype, valueType)
+	// checkUpper attributes to <resourceSubtype> if type is capitalized after prefix.
+	checkUpper := func(str, prefix string) string {
+		prefixLen := len(prefix)
+		if unicode.IsUpper(rune(str[prefixLen])) {
+			return fmt.Sprintf("%s%s.%s", prefix, resourceSubtype, str[prefixLen:])
+		}
+		return str
 	}
 
-	return fmt.Sprintf("map[%s]%s", keyType, valueType)
+	// Attribute type to <resourceSubtype> if type if applicable.
+	switch {
+	default:
+		return checkUpper(typeString, "")
+	case strings.HasPrefix(typeString, "*"):
+		return checkUpper(typeString, "*")
+	case strings.HasPrefix(typeString, "[]*"):
+		return checkUpper(typeString, "[]*")
+	case strings.HasPrefix(typeString, "[]"):
+		return checkUpper(typeString, "[]")
+	case strings.HasPrefix(typeString, "chan "):
+		return checkUpper(typeString, "chan ")
+	case strings.HasPrefix(typeString, "map["):
+		endStr := strings.Index(typeString, "]")
+		keyType := strings.TrimSpace(typeString[4:endStr])
+		valueType := strings.TrimSpace(typeString[endStr+1:])
+		if unicode.IsUpper(rune(keyType[0])) {
+			keyType = checkUpper(keyType, "")
+		}
+		if unicode.IsUpper(rune(valueType[0])) {
+			valueType = checkUpper(valueType, "")
+		}
+		return fmt.Sprintf("map[%s]%s", keyType, valueType)
+	}
 }
 
 func formatStruct(typeSpec *ast.TypeSpec, modelType string) string {
@@ -153,8 +172,7 @@ func formatStruct(typeSpec *ast.TypeSpec, modelType string) string {
 
 // parseFunctionSignature parses function declarations into the function name, the arguments, and the return types.
 func parseFunctionSignature(
-	resourceSubtype,
-	resourceSubtypePascal string,
+	resourceSubtype string,
 	modelType string,
 	funcDecl *ast.FuncDecl,
 ) (name, receiver, args string, returns []string) {
@@ -188,22 +206,7 @@ func parseFunctionSignature(
 	var params []string
 	if funcDecl.Type.Params != nil {
 		for _, param := range funcDecl.Type.Params.List {
-			paramType := formatType(param.Type)
-
-			// Check if `paramType` is a type that is capitalized.
-			// If so, attribute the type to <resourceSubtype>.
-			switch {
-			case unicode.IsUpper(rune(paramType[0])):
-				paramType = fmt.Sprintf("%s.%s", resourceSubtype, paramType)
-			// If `paramType` has a prefix, check if type is capitalized after prefix.
-			case strings.HasPrefix(paramType, "*") && unicode.IsUpper(rune(paramType[1])):
-				paramType = fmt.Sprintf("*%s.%s", resourceSubtype, paramType[1:])
-			case strings.HasPrefix(paramType, "[]") && unicode.IsUpper(rune(paramType[2])):
-				paramType = fmt.Sprintf("[]%s.%s", resourceSubtype, paramType[2:])
-			case strings.HasPrefix(paramType, "chan ") && unicode.IsUpper(rune(paramType[5])):
-				paramType = fmt.Sprintf("chan %s.%s", resourceSubtype, paramType[5:])
-			}
-
+			paramType := formatType(param.Type, resourceSubtype)
 			for _, name := range param.Names {
 				params = append(params, name.Name+" "+paramType)
 			}
@@ -213,32 +216,7 @@ func parseFunctionSignature(
 	// Return types
 	if funcDecl.Type.Results != nil {
 		for _, result := range funcDecl.Type.Results.List {
-			str := formatType(result.Type)
-			isPointer := false
-			isMapPointer := false
-			if str[0] == '*' {
-				str = str[1:]
-				isPointer = true
-			} else if str[2] == '*' {
-				str = str[3:]
-				isMapPointer = true
-			}
-
-			switch {
-			case strings.HasPrefix(str, "map["):
-				str = handleMapType(str, resourceSubtype)
-			case unicode.IsUpper(rune(str[0])):
-				str = fmt.Sprintf("%s.%s", resourceSubtype, str)
-			case strings.HasPrefix(str, "[]") && unicode.IsUpper(rune(str[2])):
-				str = fmt.Sprintf("[]%s.%s", resourceSubtype, str[2:])
-			case str == resourceSubtypePascal:
-				str = fmt.Sprintf("%s.%s", resourceSubtype, resourceSubtypePascal)
-			}
-			if isPointer {
-				str = fmt.Sprintf("*%s", str)
-			} else if isMapPointer {
-				str = fmt.Sprintf("[]*%s", str)
-			}
+			str := formatType(result.Type, resourceSubtype)
 			// fixing vision service package imports
 			if strings.Contains(str, "vision.Object") {
 				str = strings.ReplaceAll(str, "vision.Object", "vis.Object")

--- a/cli/module_generate/scripts/generate_stubs_test.go
+++ b/cli/module_generate/scripts/generate_stubs_test.go
@@ -1,0 +1,23 @@
+package scripts
+
+import (
+	"fmt"
+	"go/ast"
+	"testing"
+
+	"go.viam.com/test"
+)
+
+func TestGenerateStubs(t *testing.T) {
+	t.Run("test type formatting", func(t *testing.T) {
+		subtype := "resource"
+		testType := "Test"
+
+		paramType := formatType(ast.NewIdent(testType), subtype)
+		test.That(t, paramType, test.ShouldEqual, fmt.Sprintf("%s.%s", subtype, testType))
+		for _, prefix := range typePrefixes {
+			paramType := formatType(ast.NewIdent(prefix + testType), subtype)
+			test.That(t, paramType, test.ShouldEqual, fmt.Sprintf("%s%s.%s", prefix, subtype, testType))
+		}
+	})
+}

--- a/cli/module_generate/scripts/generate_stubs_test.go
+++ b/cli/module_generate/scripts/generate_stubs_test.go
@@ -16,7 +16,7 @@ func TestGenerateStubs(t *testing.T) {
 		paramType := formatType(ast.NewIdent(testType), subtype)
 		test.That(t, paramType, test.ShouldEqual, fmt.Sprintf("%s.%s", subtype, testType))
 		for _, prefix := range typePrefixes {
-			paramType := formatType(ast.NewIdent(prefix + testType), subtype)
+			paramType := formatType(ast.NewIdent(prefix+testType), subtype)
 			test.That(t, paramType, test.ShouldEqual, fmt.Sprintf("%s%s.%s", prefix, subtype, testType))
 		}
 	})

--- a/cli/module_generate/scripts/generate_stubs_test.go
+++ b/cli/module_generate/scripts/generate_stubs_test.go
@@ -11,13 +11,18 @@ import (
 func TestGenerateStubs(t *testing.T) {
 	t.Run("test type formatting", func(t *testing.T) {
 		subtype := "resource"
-		testType := "Test"
+		testType := "test"
+		testTypeUpper := "Test"
 
-		paramType := formatType(ast.NewIdent(testType), subtype)
-		test.That(t, paramType, test.ShouldEqual, fmt.Sprintf("%s.%s", subtype, testType))
+		test.That(t, formatType(ast.NewIdent(testType), subtype), test.ShouldEqual, testType)
+
+		paramType := formatType(ast.NewIdent(testTypeUpper), subtype)
+		test.That(t, paramType, test.ShouldEqual, fmt.Sprintf("%s.%s", subtype, testTypeUpper))
 		for _, prefix := range typePrefixes {
-			paramType := formatType(ast.NewIdent(prefix+testType), subtype)
-			test.That(t, paramType, test.ShouldEqual, fmt.Sprintf("%s%s.%s", prefix, subtype, testType))
+			paramType = formatType(ast.NewIdent(prefix+testType), subtype)
+			test.That(t, paramType, test.ShouldEqual, fmt.Sprintf("%s%s", prefix, testType))
+			paramType := formatType(ast.NewIdent(prefix+testTypeUpper), subtype)
+			test.That(t, paramType, test.ShouldEqual, fmt.Sprintf("%s%s.%s", prefix, subtype, testTypeUpper))
 		}
 	})
 }


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-9370) found a bug where pointer param types weren't attributing to the resource subtype.
Return and param types were treated differently and separately, so even though return types were attributing pointer types correctly, params were not. Now, types are being formatted the same in both returns and types. Instead of a switch statement, a for loop that contains prefix types (`"*", "[]*", "[]", "chan "`) was introduced for scalability and readability.

Testing:
- unit test for `formatType`
- locally with `arm`, `board`, and `camera` components and `vision service`. Not sure if there's other resources with more kinds of types that should be tested.

arm component:
<img width="1232" alt="image" src="https://github.com/user-attachments/assets/9976042f-2a89-4b85-9abb-6b0b33cf0f61" />

board component:
<img width="710" alt="image" src="https://github.com/user-attachments/assets/be8e81fe-2ef2-4448-95a2-b31aa8bcaa2f" />
<img width="1120" alt="image" src="https://github.com/user-attachments/assets/788b7c3c-816f-4eff-bd56-7376a6f652f1" />

vision service:
<img width="1025" alt="image" src="https://github.com/user-attachments/assets/29de94b9-b949-40e7-89ed-5327601cfe0e" />