### PR TITLE
fix(services/vision/ml_model): add err to errList when build attempt fails

### DIFF
--- a/services/vision/mlvision/ml_model.go
+++ b/services/vision/mlvision/ml_model.go
@@ -151,6 +151,7 @@ func registerMLModelVisionService(
 	var errList []error
 	classifierFunc, err := attemptToBuildClassifier(mlm, inNameMap, outNameMap, params)
 	if err != nil {
+		errList = append(errList, err)
 		logger.CDebugw(ctx, "unable to use ml model as a classifier, will attempt to evaluate as"+
 			"detector and segmenter", "model", params.ModelName, "error", err)
 	} else {
@@ -167,6 +168,7 @@ func registerMLModelVisionService(
 
 	detectorFunc, err := attemptToBuildDetector(mlm, inNameMap, outNameMap, params)
 	if err != nil {
+		errList = append(errList, err)
 		logger.CDebugw(ctx, "unable to use ml model as a detector, will attempt to evaluate as 3D segmenter",
 			"model", params.ModelName, "error", err)
 	} else {


### PR DESCRIPTION
While working on a new MLModel service module, I ran into an issue testing it with vision/mlmodel module where the vision module would panic due to indexing a list out of bounds:

```
12/31/2024, 10:18:01 AM error rdk.resource_manager.rdk:service:vision/vision-1 resource/graph_node.go:296 resource build error: panic creating resource: runtime error: index out of range [1] with length 1 resource rdk:service:vision/vision-1 model rdk:builtin:mlmodel
```

I traced the source of the error to the vision's Reconfigure method, which expects an `errList` variable to have at least 3 values for each attempt at building a different type of vision service (classifier, detector, 3D segmenter). This logic only works if the first checks of `attemptToBuildClassifier` and `attemptToBuildDetector` don't error, which was happening with my in-progress module. I've resolved this by appending the result errors from those checks to the `errList` to maintain the expected length. 