### PR TITLE
APP-7335 add --platforms to `viam module build start`

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -79,6 +79,7 @@ const (
 	moduleBuildFlagWait      = "wait"
 	moduleBuildFlagToken     = "token"
 	moduleBuildFlagWorkdir   = "workdir"
+	moduleBuildFlagPlatforms = "platforms"
 	moduleBuildFlagGroupLogs = "group-logs"
 	moduleBuildRestartOnly   = "restart-only"
 	moduleBuildFlagNoBuild   = "no-build"
@@ -2047,6 +2048,10 @@ Example:
 									Name:  moduleBuildFlagWorkdir,
 									Usage: "use this to indicate that your meta.json is in a subdirectory of your repo." + " --module flag should be relative to this",
 									Value: ".",
+								},
+								&cli.StringFlag{
+									Name:  moduleBuildFlagPlatforms,
+									Usage: "comma-separated list of platforms to build, e.g. linux/amd64,linux/arm64. Defaults to build.arch in meta.json.",
 								},
 							},
 							Action: createCommandWithT[moduleBuildStartArgs](ModuleBuildStartAction),

--- a/cli/app.go
+++ b/cli/app.go
@@ -2049,9 +2049,9 @@ Example:
 									Usage: "use this to indicate that your meta.json is in a subdirectory of your repo." + " --module flag should be relative to this",
 									Value: ".",
 								},
-								&cli.StringFlag{
+								&cli.StringSliceFlag{
 									Name:  moduleBuildFlagPlatforms,
-									Usage: "comma-separated list of platforms to build, e.g. linux/amd64,linux/arm64. Defaults to build.arch in meta.json.",
+									Usage: "list of platforms to build, e.g. linux/amd64,linux/arm64. Defaults to build.arch in meta.json.",
 								},
 							},
 							Action: createCommandWithT[moduleBuildStartArgs](ModuleBuildStartAction),

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -50,11 +50,12 @@ const (
 var moduleBuildPollingInterval = 2 * time.Second
 
 type moduleBuildStartArgs struct {
-	Module  string
-	Version string
-	Ref     string
-	Token   string
-	Workdir string
+	Module    string
+	Version   string
+	Ref       string
+	Token     string
+	Workdir   string
+	Platforms string
 }
 
 // ModuleBuildStartAction starts a cloud build.
@@ -79,8 +80,12 @@ func (c *viamClient) moduleBuildStartAction(cCtx *cli.Context, args moduleBuildS
 	// Clean the version argument to ensure compatibility with github tag standards
 	version = strings.TrimPrefix(version, "v")
 
-	platforms := manifest.Build.Arch
-	if len(platforms) == 0 {
+	var platforms []string
+	if args.Platforms != "" {
+		platforms = strings.Split(args.Platforms, ",")
+	} else if len(manifest.Build.Arch) > 0 {
+		platforms = manifest.Build.Arch
+	} else {
 		platforms = defaultBuildInfo.Arch
 	}
 

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -55,7 +55,7 @@ type moduleBuildStartArgs struct {
 	Ref       string
 	Token     string
 	Workdir   string
-	Platforms string
+	Platforms []string
 }
 
 // ModuleBuildStartAction starts a cloud build.
@@ -81,8 +81,8 @@ func (c *viamClient) moduleBuildStartAction(cCtx *cli.Context, args moduleBuildS
 	version = strings.TrimPrefix(version, "v")
 
 	var platforms []string
-	if args.Platforms != "" { //nolint:gocritic
-		platforms = strings.Split(args.Platforms, ",")
+	if len(args.Platforms) > 0 { //nolint:gocritic
+		platforms = args.Platforms
 	} else if len(manifest.Build.Arch) > 0 {
 		platforms = manifest.Build.Arch
 	} else {

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -81,7 +81,7 @@ func (c *viamClient) moduleBuildStartAction(cCtx *cli.Context, args moduleBuildS
 	version = strings.TrimPrefix(version, "v")
 
 	var platforms []string
-	if args.Platforms != "" {
+	if args.Platforms != "" { //nolint:gocritic
 		platforms = strings.Split(args.Platforms, ",")
 	} else if len(manifest.Build.Arch) > 0 {
 		platforms = manifest.Build.Arch


### PR DESCRIPTION
## What changed
- Add the `--platforms` field to the `module build start` CLI command (it was already in the API)
## Why
User request, simpler iteration when someone is debugging a build.
## Notes
1. If someone passes a version field, i.e. tries to do a release, this allows them to release for only one platform, or for a platform not mentioned in meta.json. I think that's okay; user is boss in this case
2. this doesn't support granular tagging yet