### PR TITLE
Generate less boilerplate code when making a new Go module

### DIFF
--- a/cli/module_generate/_templates/go/tmpl-main.go
+++ b/cli/module_generate/_templates/go/tmpl-main.go
@@ -2,35 +2,14 @@ package main
 
 import (
 	"{{.ModuleName}}/models"
-	"context"
-	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/module"
-	"go.viam.com/utils"
+	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/{{.ResourceType}}s/{{.ResourceSubtype}}"
 
 )
 
 func main() {
-	utils.ContextualMain(mainWithArgs, module.NewLoggerFromArgs("{{.ModuleName}}"))
-}
-
-func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) error {
-	{{.ModuleCamel}}, err := module.NewModuleFromArgs(ctx)
-	if err != nil {
-		return err
-	}
-
-	if err = {{.ModuleCamel}}.AddModelFromRegistry(ctx, {{.ResourceSubtype}}.API, models.{{.ModelPascal}}); err != nil {
-		return err
-	}
-
-
-	err = {{.ModuleCamel}}.Start(ctx)
-	defer {{.ModuleCamel}}.Close(ctx)
-	if err != nil {
-		return err
-	}
-
-	<-ctx.Done()
-	return nil
+	module.ModularMain(resource.APIModel{ {{.ResourceSubtype}}.API, models.{{.ModelPascal}} },
+	                   // If your module implements multiple models, add the rest here
+				       )
 }

--- a/cli/module_generate/_templates/go/tmpl-main.go
+++ b/cli/module_generate/_templates/go/tmpl-main.go
@@ -8,6 +8,6 @@ import (
 )
 
 func main() {
-	// ModularMain can take multiple arguments, if your module implements multiple models.
+	// ModularMain can take multiple APIModel arguments, if your module implements multiple models.
 	module.ModularMain(resource.APIModel{ {{.ResourceSubtype}}.API, models.{{.ModelPascal}}})
 }

--- a/cli/module_generate/_templates/go/tmpl-main.go
+++ b/cli/module_generate/_templates/go/tmpl-main.go
@@ -5,11 +5,9 @@ import (
 	"go.viam.com/rdk/module"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/{{.ResourceType}}s/{{.ResourceSubtype}}"
-
 )
 
 func main() {
-	module.ModularMain(resource.APIModel{ {{.ResourceSubtype}}.API, models.{{.ModelPascal}} },
-	                   // If your module implements multiple models, add the rest here
-				       )
+	// ModularMain can take multiple arguments, if your module implements multiple models.
+	module.ModularMain(resource.APIModel{ {{.ResourceSubtype}}.API, models.{{.ModelPascal}}})
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/viamrobotics/rdk/pull/4455.

Nearly all modules can really have a 1-line `main` function, rather than all the boilerplate that gets generated in the current version.

Tried locally: running `./main module generate` can make a new codebase whose `main.go` looks like this:
```go
package main

import (
	"branch-module-one-space/models"
	"go.viam.com/rdk/module"
	"go.viam.com/rdk/resource"
	"go.viam.com/rdk/components/audioinput"
)

func main() {
	// ModularMain can take multiple APIModel arguments, if your module implements multiple models.
	module.ModularMain(resource.APIModel{ audioinput.API, models.BranchModelOnespace})
}
```

Running `make` not only successfully compiles everything, but `main.go` gets cleaned up like this (note the reordering of the imports, and the space removed from the `APIModel` constructor):
```go
package main

import (
	"branch-module-one-space/models"
	"go.viam.com/rdk/components/audioinput"
	"go.viam.com/rdk/module"
	"go.viam.com/rdk/resource"
)

func main() {
	// ModularMain can take multiple APIModel arguments, if your module implements multiple models.
	module.ModularMain(resource.APIModel{audioinput.API, models.BranchModelOnespace})
}
```