### PR TITLE
[RSDK-9660] - fix-camera-image-returning-no-mime-type

### DIFF
--- a/components/camera/camera.go
+++ b/components/camera/camera.go
@@ -19,6 +19,7 @@ import (
 	"go.viam.com/rdk/rimage"
 	"go.viam.com/rdk/rimage/transform"
 	"go.viam.com/rdk/robot"
+	"go.viam.com/rdk/utils"
 )
 
 func init() {
@@ -166,7 +167,7 @@ func DecodeImageFromCamera(ctx context.Context, mimeType string, extra map[strin
 	if len(resBytes) == 0 {
 		return nil, errors.New("received empty bytes from camera")
 	}
-	img, err := rimage.DecodeImage(ctx, resBytes, resMetadata.MimeType)
+	img, err := rimage.DecodeImage(ctx, resBytes, utils.WithLazyMIMEType(resMetadata.MimeType))
 	if err != nil {
 		return nil, fmt.Errorf("could not decode into image.Image: %w", err)
 	}

--- a/components/camera/client.go
+++ b/components/camera/client.go
@@ -196,11 +196,14 @@ func (c *client) Image(ctx context.Context, mimeType string, extra map[string]in
 
 	if expectedType != "" && resp.MimeType != expectedType {
 		c.logger.CDebugw(ctx, "got different MIME type than what was asked for", "sent", expectedType, "received", resp.MimeType)
-	} else {
-		resp.MimeType = mimeType
+		if resp.MimeType == "" {
+			// if the user expected a mime_type and the successful response didn't have a mime type, assume the
+			// response's mime_type was what the user requested
+			resp.MimeType = mimeType
+		}
 	}
 
-	return resp.Image, ImageMetadata{MimeType: utils.WithLazyMIMEType(resp.MimeType)}, nil
+	return resp.Image, ImageMetadata{MimeType: resp.MimeType}, nil
 }
 
 func (c *client) Images(ctx context.Context) ([]NamedImage, resource.ResponseMetadata, error) {

--- a/rimage/lazy_encoded.go
+++ b/rimage/lazy_encoded.go
@@ -6,6 +6,7 @@ import (
 	"image"
 	"image/color"
 	"net/http"
+	"strings"
 	"sync"
 
 	"go.viam.com/rdk/logging"
@@ -37,6 +38,11 @@ func NewLazyEncodedImage(imgBytes []byte, mimeType string) image.Image {
 			"Sniffing bytes to detect mime_type. Specify mime_type to reduce CPU utilization")
 		mimeType = http.DetectContentType(imgBytes)
 	}
+
+	if !strings.HasPrefix(mimeType, "image/") {
+		logging.Global().Warnf("NewLazyEncodedImage resolving to non image mime_type: %s", mimeType)
+	}
+
 	return &LazyEncodedImage{
 		imgBytes: imgBytes,
 		mimeType: mimeType,

--- a/rimage/lazy_encoded.go
+++ b/rimage/lazy_encoded.go
@@ -33,7 +33,8 @@ type LazyEncodedImage struct {
 // NOTE: Usage of an image that would fail to decode causes a lazy panic.
 func NewLazyEncodedImage(imgBytes []byte, mimeType string) image.Image {
 	if mimeType == "" {
-		logging.Global().Warn("NewLazyEncodedImage called without a mime_type. Sniffing bytes to detect mime_type. Specify mime_type to reduce CPU utilization")
+		logging.Global().Warn("NewLazyEncodedImage called without a mime_type. " +
+			"Sniffing bytes to detect mime_type. Specify mime_type to reduce CPU utilization")
 		mimeType = http.DetectContentType(imgBytes)
 	}
 	return &LazyEncodedImage{

--- a/rimage/lazy_encoded.go
+++ b/rimage/lazy_encoded.go
@@ -5,7 +5,10 @@ import (
 	"context"
 	"image"
 	"image/color"
+	"net/http"
 	"sync"
+
+	"go.viam.com/rdk/logging"
 )
 
 // LazyEncodedImage defers the decoding of an image until necessary.
@@ -29,6 +32,10 @@ type LazyEncodedImage struct {
 // away with reading all metadata from the header of the image bytes.
 // NOTE: Usage of an image that would fail to decode causes a lazy panic.
 func NewLazyEncodedImage(imgBytes []byte, mimeType string) image.Image {
+	if mimeType == "" {
+		logging.Global().Warn("NewLazyEncodedImage called without a mime_type. Sniffing bytes to detect mime_type. Specify mime_type to reduce CPU utilization")
+		mimeType = http.DetectContentType(imgBytes)
+	}
 	return &LazyEncodedImage{
 		imgBytes: imgBytes,
 		mimeType: mimeType,

--- a/rimage/lazy_encoded_test.go
+++ b/rimage/lazy_encoded_test.go
@@ -3,6 +3,7 @@ package rimage
 import (
 	"bytes"
 	"image"
+	"image/jpeg"
 	"image/png"
 	"testing"
 
@@ -15,10 +16,14 @@ func TestLazyEncodedImage(t *testing.T) {
 	img := image.NewNRGBA(image.Rect(0, 0, 4, 8))
 	img.Set(3, 3, Red)
 
-	var buf bytes.Buffer
-	test.That(t, png.Encode(&buf, img), test.ShouldBeNil)
+	var pngBuf bytes.Buffer
+	test.That(t, png.Encode(&pngBuf, img), test.ShouldBeNil)
+	var jpegBuf bytes.Buffer
+	test.That(t, jpeg.Encode(&jpegBuf, img, &jpeg.Options{Quality: 100}), test.ShouldBeNil)
+	jpegImg, err := jpeg.Decode(bytes.NewBuffer(jpegBuf.Bytes()))
+	test.That(t, err, test.ShouldBeNil)
 
-	imgLazy := NewLazyEncodedImage(buf.Bytes(), utils.MimeTypePNG)
+	imgLazy := NewLazyEncodedImage(pngBuf.Bytes(), utils.MimeTypePNG)
 
 	test.That(t, imgLazy.(*LazyEncodedImage).MIMEType(), test.ShouldEqual, utils.MimeTypePNG)
 	test.That(t, NewColorFromColor(imgLazy.At(0, 0)), test.ShouldEqual, Black)
@@ -46,4 +51,26 @@ func TestLazyEncodedImage(t *testing.T) {
 	test.That(t, func() { imgLazy.ColorModel() }, test.ShouldPanic)
 	test.That(t, func() { NewColorFromColor(imgLazy.At(0, 0)) }, test.ShouldPanic)
 	test.That(t, func() { NewColorFromColor(imgLazy.At(4, 4)) }, test.ShouldPanic)
+
+	// png without a mime type
+	imgLazy = NewLazyEncodedImage(pngBuf.Bytes(), "")
+	test.That(t, imgLazy.(*LazyEncodedImage).MIMEType(), test.ShouldEqual, utils.MimeTypePNG)
+	test.That(t, NewColorFromColor(imgLazy.At(0, 0)), test.ShouldEqual, Black)
+	test.That(t, NewColorFromColor(imgLazy.At(3, 3)), test.ShouldEqual, Red)
+	test.That(t, imgLazy.Bounds(), test.ShouldResemble, img.Bounds())
+	test.That(t, imgLazy.ColorModel(), test.ShouldResemble, img.ColorModel())
+
+	img2, err = png.Decode(bytes.NewBuffer(imgLazy.(*LazyEncodedImage).RawData()))
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, img2, test.ShouldResemble, img)
+
+	// jpeg without a mime type
+	imgLazy = NewLazyEncodedImage(jpegBuf.Bytes(), "")
+	test.That(t, imgLazy.(*LazyEncodedImage).MIMEType(), test.ShouldEqual, utils.MimeTypeJPEG)
+	test.That(t, imgLazy.Bounds(), test.ShouldResemble, jpegImg.Bounds())
+	test.That(t, imgLazy.ColorModel(), test.ShouldResemble, jpegImg.ColorModel())
+
+	img2, err = jpeg.Decode(bytes.NewBuffer(imgLazy.(*LazyEncodedImage).RawData()))
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, img2, test.ShouldResemble, jpegImg)
 }


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-9660

This fixes a bug in which the `vision.CaptureAllFromCamera` data collector receives an `*rimage.LazyEncodedImage` with a mime_type of empty string. This condition happens when a builtin vision service uses a remote or modular camera to get it's image. This causes those images to show up under the `files` tab in app.viam.com rather than the data tab when they are synced to the cloud.

1. Change camera.DecodeImageFromCamera to always return a lazy image (for lower resource usage)
2. Change camera.client.Image to return the mime_type of the camera.GetImageResponse when the camera.Image caller doesn't specify a mime_type. This is needed so that vision services (which frequently don't specify a mime_type in their call to camera.client.Image) to still be able to detect the mime_type of the image.
3. Change camera.client.Image to no longer wrap the mime_type in the `+lazy` suffix, as the lazy suffix is a directive to the rimage package to wrap the image bytes in a lazy image, which is something which camera.client.Image  should be deciding for all callers, especially given that the `+lazy` suffix will not be understood by mime_type libraries outside of viam. Point 1 makes it so that this isn't a breaking change for all RDK code. 
4. Change rimage.NewLazyEncodedImage to log a warning when the caller doesn't specify a mime_type and detect the mime type by sniffing the image's bytes. 