### PR TITLE
RSDK-9666 - Increase module resource client max receive message size limit

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -1011,6 +1011,7 @@ func (m *module) dial() error {
 	}
 	conn, err := grpc.Dial( //nolint:staticcheck
 		addrToDial,
+		// grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(rpc.MaxMessageSize)),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithChainUnaryInterceptor(
 			rdkgrpc.EnsureTimeoutUnaryClientInterceptor,

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -1011,7 +1011,7 @@ func (m *module) dial() error {
 	}
 	conn, err := grpc.Dial( //nolint:staticcheck
 		addrToDial,
-		// grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(rpc.MaxMessageSize)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(rpc.MaxMessageSize)),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithChainUnaryInterceptor(
 			rdkgrpc.EnsureTimeoutUnaryClientInterceptor,


### PR DESCRIPTION
the connection from the viam-server to the module still has the 4mb limit. this raises the limit to 32mb

tested on an example module by returning a very large response