### PR TITLE
APP-7128 close-before-move fix for windows

### DIFF
--- a/data/capture_file.go
+++ b/data/capture_file.go
@@ -194,10 +194,7 @@ func (f *CaptureFile) Close() error {
 	if err := f.file.Close(); err != nil {
 		return err
 	}
-	if err := os.Rename(f.file.Name(), newName); err != nil {
-		return err
-	}
-	return nil
+	return os.Rename(f.file.Name(), newName)
 }
 
 // Delete deletes the file.

--- a/data/capture_file.go
+++ b/data/capture_file.go
@@ -191,10 +191,13 @@ func (f *CaptureFile) Close() error {
 	// Rename file to indicate that it is done being written.
 	withoutExt := strings.TrimSuffix(f.file.Name(), filepath.Ext(f.file.Name()))
 	newName := withoutExt + CompletedCaptureFileExt
+	if err := f.file.Close(); err != nil {
+		return err
+	}
 	if err := os.Rename(f.file.Name(), newName); err != nil {
 		return err
 	}
-	return f.file.Close()
+	return nil
 }
 
 // Delete deletes the file.


### PR DESCRIPTION
## What changed
- reverse order of file.Close and os.Rename
## Why
On windows, which has stricter file sharing restrictions, the old way produced:
> 1/6/2025, 7:41:15 PM error rdk.resource_manager.rdk:service:data_manager/data_manager-1.capture data/collector.go:106 failed to flush collector error rename .viam\capture\rdk_component_sensor\***.prog .viam\capture\rdk_component_sensor\***.capture: The process cannot access the file because it is being used by another process.
## Design questions
Is flush called concurrently with writes? i.e. have I introduced a write-after-close error? (assign me reading if reviewers don't know the answer)
## Manual testing
- [x] sensor capture on linux
- [x] sensor capture on windows