### PR TITLE
[RSDK-9498] Search for meta.json File in Top Level of Online Module

### DIFF
--- a/config/module.go
+++ b/config/module.go
@@ -420,7 +420,7 @@ func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*
 	localNonTarball := m.Type == ModuleTypeLocal && !m.NeedsSyntheticPackage()
 
 	// case 2: registry OR tarball
-	if !localNonTarball {
+	if !localNonTarball && unpackedModDir != moduleWorkingDirectory {
 		var meta *JSONManifest
 		meta, registryTarballErr = findMetaJSONFile(unpackedModDir)
 		if registryTarballErr != nil {

--- a/config/module.go
+++ b/config/module.go
@@ -402,70 +402,70 @@ func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*
 			if err != nil {
 				// return from getJSONManifest() if the error returned does NOT indicate that the file wasn't found
 				if !os.IsNotExist(err) {
-					return nil, "", errors.Wrap(err, "registry module")
+					return nil, "", errors.Wrap(err, "registry module") // TODO
 				}
 			}
 
 			if meta != nil {
-				return meta, moduleWorkingDirectory, nil
+				return meta, moduleWorkingDirectory, nil // TODO
 			}
 		}
 	}
 
 	localNonTarball := m.Type == ModuleTypeLocal && !m.NeedsSyntheticPackage()
 
-	// case 2: online OR non-tarball
+	// case 2: online OR tarball
 	if !localNonTarball {
 		meta, err := findMetaJSONFile(unpackedModDir)
 		if err != nil {
 			if !os.IsNotExist(err) {
 				if online {
-					return nil, "", errors.Wrap(err, "registry module")
+					return nil, "", errors.Wrap(err, "registry module") // TODO
 				}
 
-				return nil, "", errors.Wrap(err, "local non-tarball")
+				return nil, "", errors.Wrap(err, "local tarball") // DONE
 			}
 		}
 
 		if meta != nil {
-			return meta, unpackedModDir, nil
+			return meta, unpackedModDir, nil // TODO
 		}
 	}
 
 	var exeDir string
 
 	// TODO(RSDK-7848): remove this case once java sdk supports internal meta.json.
-	// case 3: local AND tarball
+	// case 3: local AND non-tarball
 	if m.NeedsSyntheticPackage() {
 		exeDir = filepath.Dir(m.ExePath)
 
 		meta, err := findMetaJSONFile(exeDir)
 		if err != nil {
 			if !os.IsNotExist(err) {
-				return nil, "", errors.Wrap(err, "local tarball")
+				return nil, "", errors.Wrap(err, "local non-tarball") // TODO
 			}
 		}
 
 		if meta != nil {
-			return meta, unpackedModDir, nil
+			return meta, unpackedModDir, nil // TODO
 		}
 	}
 
 	if online {
 		if !ok {
 			return nil, "", errors.Errorf("registry module: VIAM_MODULE_ROOT not set. Searched instead in executable directory %s but failed to find meta.json",
-				unpackedModDir)
+				unpackedModDir) // TODO
 		}
 
 		return nil, "", errors.Errorf("registry module: failed to find meta.json. Searched in executable directory %s and path set by VIAM_MODULE_ROOT %s",
-			moduleWorkingDirectory, unpackedModDir)
+			moduleWorkingDirectory, unpackedModDir) // TODO
 	}
 
 	if !localNonTarball {
-		return nil, "", errors.Errorf("local non-tarball: failed to find meta.json. Searched in %s and executable directory %s", unpackedModDir, exeDir)
+		return nil, "", errors.Errorf("local tarball: failed to find meta.json. Searched in %s and executable directory %s", unpackedModDir, exeDir) // TODO
 	}
 
-	return nil, "", errors.Errorf("local tarball: failed to find meta.json. Searched only in %s", exeDir)
+	return nil, "", errors.Errorf("local non-tarball: failed to find meta.json. Searched only in %s", exeDir) // TODO
 }
 
 func findMetaJSONFile(dir string) (*JSONManifest, error) {

--- a/config/module.go
+++ b/config/module.go
@@ -282,13 +282,7 @@ func (m *Module) FirstRun(
 		logger.Debug("no first run script specified, skipping first run")
 		return nil
 	}
-	var firstRunTopLevelDir string
-	if moduleWorkingDirectory == "" {
-		firstRunTopLevelDir = unpackedModDir
-	} else {
-		firstRunTopLevelDir = moduleWorkingDirectory
-	}
-	relFirstRunPath, err := utils.SafeJoinDir(firstRunTopLevelDir, meta.FirstRun)
+	relFirstRunPath, err := utils.SafeJoinDir(moduleWorkingDirectory, meta.FirstRun)
 	if err != nil {
 		logger.Errorw("failed to build path to first run script, skipping first run", "error", err)
 		return nil
@@ -397,7 +391,7 @@ func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*
 			return nil, "", err
 		}
 		if meta != nil {
-			return meta, "", nil
+			return meta, unpackedModDir, nil
 		}
 	}
 	if m.NeedsSyntheticPackage() {
@@ -405,14 +399,14 @@ func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*
 		// TODO(RSDK-7848): remove this case once java sdk supports internal meta.json.
 		metaPath, err := utils.SafeJoinDir(filepath.Dir(m.ExePath), "meta.json")
 		if err != nil {
-			return nil, "", err
+			return nil, unpackedModDir, err
 		}
 		meta, err := parseJSONFile[JSONManifest](metaPath)
 		if err != nil {
 			// note: this error deprecates the side-by-side case because the side-by-side case is deprecated.
-			return nil, "", errors.Wrapf(err, "couldn't find meta.json inside tarball %s (or next to it)", m.ExePath)
+			return nil, unpackedModDir, errors.Wrapf(err, "couldn't find meta.json inside tarball %s (or next to it)", m.ExePath)
 		}
-		return meta, "", err
+		return meta, unpackedModDir, err
 	}
 
 	if m.Type == ModuleTypeRegistry {
@@ -432,7 +426,7 @@ func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*
 			return nil, "", err
 		}
 		if meta != nil {
-			return meta, "", nil
+			return meta, unpackedModDir, nil
 		}
 
 		if !ok {

--- a/config/module.go
+++ b/config/module.go
@@ -442,13 +442,16 @@ func findMetaJSONFile(dir string) (*JSONManifest, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	_, err = os.Stat(metaPath)
-	if err == nil {
-		meta, err := parseJSONFile[JSONManifest](metaPath)
-		if err != nil {
-			return nil, err
-		}
-		return meta, nil
+	if err != nil {
+		return nil, nil
 	}
-	return nil, nil
+
+	meta, err := parseJSONFile[JSONManifest](metaPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return meta, nil
 }

--- a/config/module.go
+++ b/config/module.go
@@ -377,6 +377,8 @@ func (m *Module) FirstRun(
 	return nil
 }
 
+// TODO(bashar): update comment with current state of things
+// TODO(bashar): write test(s)
 // getJSONManifest returns a loaded meta.json from one of two sources (in order of precedence):
 // 1. if there is a meta.json in the exe dir, use that, except in local non-tarball case.
 // 2. if this is a local tarball and there's a meta.json next to the tarball, use that.
@@ -427,9 +429,9 @@ func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*
 		}
 
 		if !ok {
-			return nil, "", errors.Errorf("VIAM_MODULE_ROOT not set. Failed to find meta.json in executable directory %s", unpackedModDir)
+			return nil, "", errors.Errorf("VIAM_MODULE_ROOT not set. Searched instead in executable directory %s but failed to find meta.json", unpackedModDir)
 		}
-		return nil, "", errors.Errorf("failed to find meta.json. Searched in  executable directory %s and path set by VIAM_MODULE_ROOT %s",
+		return nil, "", errors.Errorf("failed to find meta.json. Searched in executable directory %s and path set by VIAM_MODULE_ROOT %s",
 			moduleWorkingDirectory, unpackedModDir)
 	}
 	return nil, "", errors.New("failed to find meta.json")

--- a/config/module.go
+++ b/config/module.go
@@ -397,16 +397,13 @@ func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*
 	if m.NeedsSyntheticPackage() {
 		// this is case 2, side-by-side
 		// TODO(RSDK-7848): remove this case once java sdk supports internal meta.json.
-		metaPath, err := utils.SafeJoinDir(filepath.Dir(m.ExePath), "meta.json")
+		meta, err := findMetaJSONFile(filepath.Dir(m.ExePath))
 		if err != nil {
-			return nil, unpackedModDir, err
+			return nil, "", err
 		}
-		meta, err := parseJSONFile[JSONManifest](metaPath)
-		if err != nil {
-			// note: this error deprecates the side-by-side case because the side-by-side case is deprecated.
-			return nil, unpackedModDir, errors.Wrapf(err, "couldn't find meta.json inside tarball %s (or next to it)", m.ExePath)
+		if meta != nil {
+			return meta, unpackedModDir, nil
 		}
-		return meta, unpackedModDir, err
 	}
 
 	if m.Type == ModuleTypeRegistry {

--- a/config/module.go
+++ b/config/module.go
@@ -267,7 +267,7 @@ func (m *Module) FirstRun(
 
 	// Load the module's meta.json. If it doesn't exist DEBUG log and exit quietly.
 	// For all other errors WARN log and exit.
-	meta, err, moduleWorkingDirectory := m.getJSONManifest(unpackedModDir, env)
+	meta, moduleWorkingDirectory, err := m.getJSONManifest(unpackedModDir, env)
 	var pathErr *os.PathError
 	switch {
 	case errors.As(err, &pathErr):
@@ -387,17 +387,17 @@ func (m *Module) FirstRun(
 // 1. if there is a meta.json in the exe dir, use that, except in local non-tarball case.
 // 2. if this is a local tarball and there's a meta.json next to the tarball, use that.
 // Note: the working directory must be the unpacked tarball directory or local exec directory.
-func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*JSONManifest, error, string) {
+func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*JSONManifest, string, error) {
 	// note: we don't look at internal meta.json in local non-tarball case because user has explicitly requested a binary.
 	localNonTarball := m.Type == ModuleTypeLocal && !m.NeedsSyntheticPackage()
 	if !localNonTarball {
 		// this is case 1, meta.json in exe folder.
 		meta, err := findMetaJSONFile(unpackedModDir)
 		if err != nil {
-			return nil, err, ""
+			return nil, "", err
 		}
 		if meta != nil {
-			return meta, nil, ""
+			return meta, "", nil
 		}
 	}
 	if m.NeedsSyntheticPackage() {
@@ -405,14 +405,14 @@ func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*
 		// TODO(RSDK-7848): remove this case once java sdk supports internal meta.json.
 		metaPath, err := utils.SafeJoinDir(filepath.Dir(m.ExePath), "meta.json")
 		if err != nil {
-			return nil, err, ""
+			return nil, "", err
 		}
 		meta, err := parseJSONFile[JSONManifest](metaPath)
 		if err != nil {
 			// note: this error deprecates the side-by-side case because the side-by-side case is deprecated.
-			return nil, errors.Wrapf(err, "couldn't find meta.json inside tarball %s (or next to it)", m.ExePath), ""
+			return nil, "", errors.Wrapf(err, "couldn't find meta.json inside tarball %s (or next to it)", m.ExePath)
 		}
-		return meta, err, ""
+		return meta, "", err
 	}
 
 	if m.Type == ModuleTypeRegistry {
@@ -420,27 +420,28 @@ func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*
 		if ok {
 			meta, err := findMetaJSONFile(moduleWorkingDirectory)
 			if err != nil {
-				return nil, err, ""
+				return nil, "", err
 			}
 			if meta != nil {
-				return meta, nil, moduleWorkingDirectory
+				return meta, moduleWorkingDirectory, nil
 			}
 		}
 
 		meta, err := findMetaJSONFile(unpackedModDir)
 		if err != nil {
-			return nil, err, ""
+			return nil, "", err
 		}
 		if meta != nil {
-			return meta, nil, ""
+			return meta, "", nil
 		}
 
 		if !ok {
-			return nil, errors.Errorf("VIAM_MODULE_ROOT not set. Failed to find meta.json in executable directory %s", unpackedModDir), ""
+			return nil, "", errors.Errorf("VIAM_MODULE_ROOT not set. Failed to find meta.json in executable directory %s", unpackedModDir)
 		}
-		return nil, errors.Errorf("failed to find meta.json. Searched in  executable directory %s and path set by VIAM_MODULE_ROOT %s", moduleWorkingDirectory, unpackedModDir), ""
+		return nil, "", errors.Errorf("failed to find meta.json. Searched in  executable directory %s and path set by VIAM_MODULE_ROOT %s",
+			moduleWorkingDirectory, unpackedModDir)
 	}
-	return nil, errors.New("failed to find meta.json"), ""
+	return nil, "", errors.New("failed to find meta.json")
 }
 
 func findMetaJSONFile(dir string) (*JSONManifest, error) {

--- a/config/module.go
+++ b/config/module.go
@@ -380,7 +380,7 @@ func (m *Module) FirstRun(
 // TODO(RSDK-9498): write test(s)
 // getJSONManifest returns a loaded meta.json from one of three sources (in order of precedence):
 // 1. if this is an online module and there is a meta.json in its top level directory, use that.
-// 2. if there is a meta.json in the exe dir, use that, exept in local non-tarball case.
+// 2. if there is a meta.json in the exe dir, use that, except in local non-tarball case.
 // 3. if this is a local tarball and there's a meta.json next to the tarball, use that.
 // Note: the working directory must be the unpacked tarball directory or local exec directory.
 func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*JSONManifest, string, error) {

--- a/config/module.go
+++ b/config/module.go
@@ -449,7 +449,8 @@ func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*
 
 	if online {
 		if !ok {
-			return nil, "", errors.Errorf("VIAM_MODULE_ROOT not set. Searched instead in executable directory %s but failed to find meta.json", unpackedModDir)
+			return nil, "", errors.Errorf("VIAM_MODULE_ROOT not set. Searched instead in executable directory %s but failed to find meta.json",
+				unpackedModDir)
 		}
 
 		return nil, "", errors.Errorf("failed to find meta.json. Searched in executable directory %s and path set by VIAM_MODULE_ROOT %s",

--- a/config/module.go
+++ b/config/module.go
@@ -445,7 +445,6 @@ func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*
 
 func findMetaJSONFile(dir string) (*JSONManifest, error) {
 	metaPath, err := utils.SafeJoinDir(dir, "meta.json")
-	fmt.Println("META PATH: ", metaPath)
 	if err != nil {
 		return nil, err
 	}

--- a/config/module.go
+++ b/config/module.go
@@ -377,11 +377,11 @@ func (m *Module) FirstRun(
 	return nil
 }
 
-// TODO(bashar): update comment with current state of things
 // TODO(bashar): write test(s)
-// getJSONManifest returns a loaded meta.json from one of two sources (in order of precedence):
-// 1. if there is a meta.json in the exe dir, use that, except in local non-tarball case.
-// 2. if this is a local tarball and there's a meta.json next to the tarball, use that.
+// getJSONManifest returns a loaded meta.json from one of three sources (in order of precedence):
+// 1. if this is an online module and there is a meta.json in its top level directory, use that.
+// 3. if there is a meta.json in the exe dir, use that, exept in local non-tarball case.
+// 4. if this is a local tarball and there's a meta.json next to the tarball, use that.
 // Note: the working directory must be the unpacked tarball directory or local exec directory.
 func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*JSONManifest, string, error) {
 	// note: all online modules qualify for cases 1 & 2; local tarballs for cases 2 & 3; and local non-tarballs for none. We don't look at

--- a/config/module.go
+++ b/config/module.go
@@ -382,10 +382,10 @@ func (m *Module) FirstRun(
 // getJSONManifest returns a loaded meta.json from one of three sources (in order of precedence):
 // 1. if this is a registry module and there is a meta.json in its top level directory, use that.
 // 2. if there is a meta.json in the exe dir, use that, except in local non-tarball case.
-// 3. if this is a local tarball and there's a meta.json next to the tarball, use that.
+// 3. if this is a local tarball, use the meta.json in unpackedModDir.
 // Note: the working directory must be the unpacked tarball directory or local exec directory.
 func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*JSONManifest, string, error) {
-	// note: all registry modules qualify for cases 1 & 2; local tarballs for cases 2 & 3; and local non-tarballs for case 3. We don't look at
+	// note: all registry modules qualify for cases 1 & 2; local tarballs for cases 2 & 3; and local non-tarballs for none. We don't look at
 	// internal meta.json in local non-tarball case because user has explicitly requested a binary.
 
 	// note: each case is exited iff no errors occur but the meta.json file is not found

--- a/config/module.go
+++ b/config/module.go
@@ -405,12 +405,12 @@ func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*
 			if registryErr != nil {
 				// return from getJSONManifest() if the error returned does NOT indicate that the file wasn't found
 				if !os.IsNotExist(registryErr) {
-					return nil, "", errors.Wrap(registryErr, "registry module")
+					return nil, "", errors.Wrap(registryErr, "registry module") // DONE
 				}
 			}
 
 			if meta != nil {
-				return meta, moduleWorkingDirectory, nil
+				return meta, moduleWorkingDirectory, nil // DONE
 			}
 		}
 	}
@@ -450,7 +450,7 @@ func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*
 		meta, localTarballErr = findMetaJSONFile(exeDir)
 		if localTarballErr != nil {
 			if !os.IsNotExist(localTarballErr) {
-				return nil, "", errors.Wrap(localTarballErr, "local non-tarball")
+				return nil, "", errors.Wrap(localTarballErr, "local tarball")
 			}
 		}
 

--- a/config/module.go
+++ b/config/module.go
@@ -406,9 +406,7 @@ func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*
 				}
 			}
 
-			if meta != nil {
-				return meta, moduleWorkingDirectory, nil // TODO
-			}
+			return meta, moduleWorkingDirectory, nil // TODO
 		}
 	}
 
@@ -427,9 +425,7 @@ func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*
 			}
 		}
 
-		if meta != nil {
-			return meta, unpackedModDir, nil // TODO
-		}
+		return meta, unpackedModDir, nil // TODO
 	}
 
 	var exeDir string
@@ -446,9 +442,7 @@ func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*
 			}
 		}
 
-		if meta != nil {
-			return meta, unpackedModDir, nil // TODO
-		}
+		return meta, unpackedModDir, nil // TODO
 	}
 
 	if online {

--- a/config/module.go
+++ b/config/module.go
@@ -400,7 +400,10 @@ func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*
 		if ok {
 			meta, err := findMetaJSONFile(moduleWorkingDirectory)
 			if err != nil {
-				return nil, "", err
+				// return from getJSONManifest() if the error returned does NOT indicate that the file wasn't found
+				if !os.IsNotExist(err) {
+					return nil, "", err
+				}
 			}
 
 			if meta != nil {
@@ -415,7 +418,9 @@ func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*
 	if !localNonTarball {
 		meta, err := findMetaJSONFile(unpackedModDir)
 		if err != nil {
-			return nil, "", err
+			if !os.IsNotExist(err) {
+				return nil, "", err
+			}
 		}
 
 		if meta != nil {
@@ -432,7 +437,9 @@ func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*
 
 		meta, err := findMetaJSONFile(exeDir)
 		if err != nil {
-			return nil, "", err
+			if !os.IsNotExist(err) {
+				return nil, "", err
+			}
 		}
 
 		if meta != nil {
@@ -464,7 +471,7 @@ func findMetaJSONFile(dir string) (*JSONManifest, error) {
 
 	_, err = os.Stat(metaPath)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 
 	meta, err := parseJSONFile[JSONManifest](metaPath)

--- a/config/module.go
+++ b/config/module.go
@@ -471,7 +471,7 @@ func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*
 		return nil, "", errors.Wrap(stderrors.Join(registryTarballErr, localTarballErr), "local tarball: failed to find meta.json")
 	}
 
-	return nil, "", errors.Errorf("local non-tarball: did not search for meta.json") // DONE
+	return nil, "", errors.New("local non-tarball: did not search for meta.json") // DONE
 }
 
 func findMetaJSONFile(dir string) (*JSONManifest, error) {

--- a/config/module.go
+++ b/config/module.go
@@ -380,8 +380,8 @@ func (m *Module) FirstRun(
 // TODO(RSDK-9498): write test(s)
 // getJSONManifest returns a loaded meta.json from one of three sources (in order of precedence):
 // 1. if this is an online module and there is a meta.json in its top level directory, use that.
-// 3. if there is a meta.json in the exe dir, use that, exept in local non-tarball case.
-// 4. if this is a local tarball and there's a meta.json next to the tarball, use that.
+// 2. if there is a meta.json in the exe dir, use that, exept in local non-tarball case.
+// 3. if this is a local tarball and there's a meta.json next to the tarball, use that.
 // Note: the working directory must be the unpacked tarball directory or local exec directory.
 func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*JSONManifest, string, error) {
 	// note: all online modules qualify for cases 1 & 2; local tarballs for cases 2 & 3; and local non-tarballs for none. We don't look at

--- a/config/module.go
+++ b/config/module.go
@@ -249,7 +249,11 @@ func (m *Module) FirstRun(
 	dataDir string,
 	env map[string]string,
 	logger logging.Logger,
+	packagesDir,
+	viamHomeDir string,
 ) error {
+	fmt.Println("PACKAGES DIRECTORY: ", packagesDir)
+	fmt.Println("VIAM HOME DIRECTORY: ", viamHomeDir)
 	logger = logger.Sublogger("first_run").WithFields("module", m.Name)
 
 	unpackedModDir, err := m.exeDir(localPackagesDir)

--- a/config/module.go
+++ b/config/module.go
@@ -458,10 +458,10 @@ func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*
 	}
 
 	if !localNonTarball {
-		return nil, "", errors.Errorf("failed to find meta.json. Searched in %s and %s", unpackedModDir, exeDir)
+		return nil, "", errors.Errorf("failed to find meta.json. Searched in %s and executable directory %s", unpackedModDir, exeDir)
 	}
 
-	return nil, "", errors.Errorf("failed to find meta.json. Searched only in %s", exeDir)
+	return nil, "", errors.Errorf("local tarball: failed to find meta.json. Searched only in %s", exeDir)
 }
 
 func findMetaJSONFile(dir string) (*JSONManifest, error) {

--- a/config/module.go
+++ b/config/module.go
@@ -380,7 +380,7 @@ func (m *Module) FirstRun(
 
 // TODO(RSDK-9498): write test(s)
 // getJSONManifest returns a loaded meta.json from one of three sources (in order of precedence):
-// 1. if this is an registry module and there is a meta.json in its top level directory, use that.
+// 1. if this is a registry module and there is a meta.json in its top level directory, use that.
 // 2. if there is a meta.json in the exe dir, use that, except in local non-tarball case.
 // 3. if this is a local tarball and there's a meta.json next to the tarball, use that.
 // Note: the working directory must be the unpacked tarball directory or local exec directory.
@@ -405,12 +405,12 @@ func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*
 			if registryErr != nil {
 				// return from getJSONManifest() if the error returned does NOT indicate that the file wasn't found
 				if !os.IsNotExist(registryErr) {
-					return nil, "", errors.Wrap(registryErr, "registry module") // DONE
+					return nil, "", errors.Wrap(registryErr, "registry module")
 				}
 			}
 
 			if meta != nil {
-				return meta, moduleWorkingDirectory, nil // DONE
+				return meta, moduleWorkingDirectory, nil
 			}
 		}
 	}
@@ -426,7 +426,7 @@ func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*
 		if registryTarballErr != nil {
 			if !os.IsNotExist(registryTarballErr) {
 				if online {
-					return nil, "", errors.Wrap(registryTarballErr, "registry module") // DONE
+					return nil, "", errors.Wrap(registryTarballErr, "registry module")
 				}
 
 				return nil, "", errors.Wrap(registryTarballErr, "local tarball")
@@ -434,7 +434,7 @@ func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*
 		}
 
 		if meta != nil {
-			return meta, unpackedModDir, nil // DONE
+			return meta, unpackedModDir, nil
 		}
 	}
 
@@ -461,17 +461,17 @@ func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*
 
 	if online {
 		if !ok {
-			return nil, "", errors.Wrap(registryTarballErr, "registry module: failed to find meta.json. VIAM_MODULE_ROOT not set") // DONE
+			return nil, "", errors.Wrap(registryTarballErr, "registry module: failed to find meta.json. VIAM_MODULE_ROOT not set")
 		}
 
-		return nil, "", errors.Wrap(stderrors.Join(registryErr, registryTarballErr), "registry module: failed to find meta.json") // DONE
+		return nil, "", errors.Wrap(stderrors.Join(registryErr, registryTarballErr), "registry module: failed to find meta.json")
 	}
 
 	if !localNonTarball {
 		return nil, "", errors.Wrap(stderrors.Join(registryTarballErr, localTarballErr), "local tarball: failed to find meta.json")
 	}
 
-	return nil, "", errors.New("local non-tarball: did not search for meta.json") // DONE
+	return nil, "", errors.New("local non-tarball: did not search for meta.json")
 }
 
 func findMetaJSONFile(dir string) (*JSONManifest, error) {

--- a/config/module.go
+++ b/config/module.go
@@ -377,7 +377,7 @@ func (m *Module) FirstRun(
 	return nil
 }
 
-// TODO(bashar): write test(s)
+// TODO(RSDK-9498): write test(s)
 // getJSONManifest returns a loaded meta.json from one of three sources (in order of precedence):
 // 1. if this is an online module and there is a meta.json in its top level directory, use that.
 // 3. if there is a meta.json in the exe dir, use that, exept in local non-tarball case.

--- a/config/module.go
+++ b/config/module.go
@@ -471,7 +471,7 @@ func (m Module) getJSONManifest(unpackedModDir string, env map[string]string) (*
 		return nil, "", errors.Wrap(stderrors.Join(registryTarballErr, localTarballErr), "local tarball: failed to find meta.json")
 	}
 
-	return nil, "", errors.Errorf("local non-tarball: did not search for meta.json")
+	return nil, "", errors.Errorf("local non-tarball: did not search for meta.json") // DONE
 }
 
 func findMetaJSONFile(dir string) (*JSONManifest, error) {

--- a/config/module.go
+++ b/config/module.go
@@ -378,7 +378,6 @@ func (m *Module) FirstRun(
 	return nil
 }
 
-// TODO(RSDK-9498): write test(s)
 // getJSONManifest returns a loaded meta.json from one of three sources (in order of precedence):
 // 1. if this is a registry module and there is a meta.json in its top level directory, use that.
 // 2. if there is a meta.json in the exe dir, use that, except in local non-tarball case.

--- a/config/module_test.go
+++ b/config/module_test.go
@@ -106,7 +106,7 @@ func TestSyntheticModule(t *testing.T) {
 	})
 }
 
-func TestFirstRun(t *testing.T) {
+func TestRegistryModuleFirstRun(t *testing.T) {
 	m := Module{Type: ModuleTypeRegistry}
 
 	tmp := t.TempDir()

--- a/config/module_test.go
+++ b/config/module_test.go
@@ -118,13 +118,12 @@ func TestFirstRun(t *testing.T) {
 	localPackagesDir := ""
 	dataDir := ""
 	env := map[string]string{"VIAM_MODULE_ROOT": tmp}
-	logger := logging.NewTestLogger(t)
+	logger, observedLogs := logging.NewObservedTestLogger(t)
 
 	t.Run("MetaFileNotFound", func(t *testing.T) {
 		err := m.FirstRun(ctx, localPackagesDir, dataDir, env, logger)
-		// TODO: test logger output
-		// "meta.json not found, skipping first run"
 		test.That(t, err, test.ShouldBeNil)
+		test.That(t, observedLogs.FilterMessage("meta.json not found, skipping first run").Len(), test.ShouldEqual, 1)
 	})
 
 	t.Run("MetaFileInvalid", func(t *testing.T) {
@@ -133,9 +132,8 @@ func TestFirstRun(t *testing.T) {
 		defer metaJSONFile.Close()
 
 		err = m.FirstRun(ctx, localPackagesDir, dataDir, env, logger)
-		// TODO: test logger output
-		// "failed to parse meta.json, skipping first run"
 		test.That(t, err, test.ShouldBeNil)
+		test.That(t, observedLogs.FilterMessage("failed to parse meta.json, skipping first run").Len(), test.ShouldEqual, 1)
 	})
 
 	t.Run("NoFirstRunScript", func(t *testing.T) {
@@ -143,9 +141,8 @@ func TestFirstRun(t *testing.T) {
 
 		err := m.FirstRun(ctx, localPackagesDir, dataDir, env, logger)
 		t.Log(err)
-		// TODO: test logger output
-		// "no first run script specified, skipping first run"
 		test.That(t, err, test.ShouldBeNil)
+		test.That(t, observedLogs.FilterMessage("no first run script specified, skipping first run").Len(), test.ShouldEqual, 1)
 	})
 
 	t.Run("InvalidFirstRunPath", func(t *testing.T) {
@@ -153,9 +150,8 @@ func TestFirstRun(t *testing.T) {
 
 		err := m.FirstRun(ctx, localPackagesDir, dataDir, env, logger)
 		t.Log(err)
-		// TODO: test logger output
-		// "failed to build path to first run script, skipping first run"
 		test.That(t, err, test.ShouldBeNil)
+		test.That(t, observedLogs.FilterMessage("failed to build path to first run script, skipping first run").Len(), test.ShouldEqual, 1)
 	})
 }
 

--- a/config/module_test.go
+++ b/config/module_test.go
@@ -8,8 +8,9 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
-	"go.viam.com/rdk/logging"
 	"go.viam.com/test"
+
+	"go.viam.com/rdk/logging"
 )
 
 // testChdir is a helper that cleans up an os.Chdir.
@@ -155,7 +156,6 @@ func TestFirstRun(t *testing.T) {
 		// TODO: test logger output
 		// "failed to build path to first run script, skipping first run"
 		test.That(t, err, test.ShouldBeNil)
-
 	})
 }
 

--- a/config/module_test.go
+++ b/config/module_test.go
@@ -102,7 +102,7 @@ func TestSyntheticModule(t *testing.T) {
 	})
 }
 
-func testFindMetaJSONFile(t *testing.T) {
+func TestFindMetaJSONFile(t *testing.T) {
 	tmp := t.TempDir()
 	metaJSONFilePath := filepath.Join(tmp, "meta.json")
 

--- a/config/module_test.go
+++ b/config/module_test.go
@@ -116,7 +116,7 @@ func TestGetJSONManifest(t *testing.T) {
 		env := make(map[string]string, 1)
 		modRegistry := Module{Type: ModuleTypeRegistry}
 
-		err := os.Mkdir(unpackedModDir, 0700)
+		err := os.Mkdir(unpackedModDir, 0o700)
 		test.That(t, err, test.ShouldBeNil)
 
 		// meta.json not found; only unpacked module directory searched
@@ -189,7 +189,7 @@ func TestGetJSONManifest(t *testing.T) {
 		env := map[string]string{}
 		modLocalNontar := Module{Type: ModuleTypeLocal}
 
-		err := os.Mkdir(unpackedModDir, 0700)
+		err := os.Mkdir(unpackedModDir, 0o700)
 		test.That(t, err, test.ShouldBeNil)
 
 		meta, moduleWorkingDirectory, err := modLocalNontar.getJSONManifest(unpackedModDir, env)

--- a/config/module_test.go
+++ b/config/module_test.go
@@ -102,6 +102,35 @@ func TestSyntheticModule(t *testing.T) {
 	})
 }
 
+func testFindMetaJSONFile(t *testing.T) {
+	tmp := t.TempDir()
+	metaJSONFilePath := filepath.Join(tmp, "meta.json")
+
+	t.Run("MissingMetaFile", func(t *testing.T) {
+		meta, err := findMetaJSONFile(tmp)
+		test.That(t, meta, test.ShouldBeNil)
+		test.That(t, err, test.ShouldEqual, os.IsNotExist)
+	})
+
+	file, err := os.Create(metaJSONFilePath)
+	test.That(t, err, test.ShouldBeNil)
+	defer file.Close()
+	t.Run("InvalidMetaFile", func(t *testing.T) {
+		meta, err := findMetaJSONFile(tmp)
+		test.That(t, meta, test.ShouldBeNil)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err, test.ShouldNotEqual, os.IsNotExist)
+	})
+
+	validMeta := JSONManifest{Entrypoint: "entry"}
+	testWriteJSON(t, metaJSONFilePath, &validMeta)
+	t.Run("ValidMetaFileFound", func(t *testing.T) {
+		meta, err := findMetaJSONFile(tmp)
+		test.That(t, meta, test.ShouldEqual, validMeta)
+		test.That(t, err, test.ShouldBeNil)
+	})
+}
+
 // testWriteJSON is a t.Helper that serializes `value` to `path` as json.
 func testWriteJSON(t *testing.T, path string, value any) {
 	t.Helper()

--- a/config/module_test.go
+++ b/config/module_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"os"

--- a/config/module_test.go
+++ b/config/module_test.go
@@ -386,15 +386,19 @@ func testWriteJSON(t *testing.T, path string, value any) {
 }
 
 // testSetUpRegistryModule is a t.Helper that creates a registry module with a meta.json file and an executable file in its top level
-// directory. It also returns a logger and its observed logs for testing
-func testSetUpRegistryModule(t *testing.T) (module Module, metaJSONFilepath string, env map[string]string, logger logging.Logger, observedLogs *observer.ObservedLogs) {
+// directory. It also returns a logger and its observed logs for testing.
+func testSetUpRegistryModule(t *testing.T) (module Module, metaJSONFilepath string, env map[string]string, logger logging.Logger,
+	observedLogs *observer.ObservedLogs) {
 	t.Helper()
 	module = Module{Type: ModuleTypeRegistry}
 	tmp := t.TempDir()
 	exePath := filepath.Join(tmp, "whatever.sh")
 	module.ExePath = exePath
 	metaJSONFilepath = filepath.Join(tmp, "meta.json")
+
+	env = make(map[string]string, 1)
 	env["VIAM_MODULE_ROOT"] = tmp
+
 	logger, observedLogs = logging.NewObservedTestLogger(t)
 	return
 }

--- a/config/module_test.go
+++ b/config/module_test.go
@@ -109,7 +109,7 @@ func TestFindMetaJSONFile(t *testing.T) {
 	t.Run("MissingMetaFile", func(t *testing.T) {
 		meta, err := findMetaJSONFile(tmp)
 		test.That(t, meta, test.ShouldBeNil)
-		test.That(t, err, test.ShouldEqual, os.IsNotExist)
+		test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
 	})
 
 	file, err := os.Create(metaJSONFilePath)
@@ -126,7 +126,7 @@ func TestFindMetaJSONFile(t *testing.T) {
 	testWriteJSON(t, metaJSONFilePath, &validMeta)
 	t.Run("ValidMetaFileFound", func(t *testing.T) {
 		meta, err := findMetaJSONFile(tmp)
-		test.That(t, meta, test.ShouldEqual, validMeta)
+		test.That(t, *meta, test.ShouldResemble, validMeta)
 		test.That(t, err, test.ShouldBeNil)
 	})
 }

--- a/config/module_test.go
+++ b/config/module_test.go
@@ -362,7 +362,3 @@ func testWriteJSON(t *testing.T, path string, value any) {
 	err = encoder.Encode(value)
 	test.That(t, err, test.ShouldBeNil)
 }
-
-func testCheckLogOutput(t *testing.T, buf bytes.Buffer, expected string) {
-	t.Helper()
-}

--- a/config/module_test.go
+++ b/config/module_test.go
@@ -117,7 +117,10 @@ func TestFirstRun(t *testing.T) {
 	ctx := context.Background()
 	localPackagesDir := ""
 	dataDir := ""
+
+	// getJSONManifest() uses the "VIAM_MODUE_ROOT" environment variable to find the top level directory of a registry module
 	env := map[string]string{"VIAM_MODULE_ROOT": tmp}
+
 	logger, observedLogs := logging.NewObservedTestLogger(t)
 
 	t.Run("MetaFileNotFound", func(t *testing.T) {
@@ -182,6 +185,9 @@ func TestGetJSONManifest(t *testing.T) {
 		test.That(t, err.Error(), test.ShouldNotContainSubstring, topLevelMetaJSONFilepath)
 
 		// meta.json not found; top level module directory and unpacked module directories searched
+
+		// setting the "VIAM_MODULE_ROOT" environment variable allows getJSONManifest() to search in a registry module's top level directory
+		// for the meta.json file. The variable is accessed through the 'env' function parameter
 		env["VIAM_MODULE_ROOT"] = topLevelDir
 
 		meta, moduleWorkingDirectory, err = modRegistry.getJSONManifest(unpackedModDir, env)

--- a/config/module_test.go
+++ b/config/module_test.go
@@ -117,6 +117,7 @@ func TestGetJSONManifest(t *testing.T) {
 		modRegistry := Module{Type: ModuleTypeRegistry}
 
 		err := os.Mkdir(unpackedModDir, 0700)
+		test.That(t, err, test.ShouldBeNil)
 
 		// meta.json not found; only unpacked module directory searched
 		meta, moduleWorkingDirectory, err := modRegistry.getJSONManifest(unpackedModDir, env)
@@ -179,6 +180,24 @@ func TestGetJSONManifest(t *testing.T) {
 		test.That(t, *meta, test.ShouldResemble, validJSONManifest)
 		test.That(t, moduleWorkingDirectory, test.ShouldEqual, topLevelDir)
 		test.That(t, err, test.ShouldBeNil)
+	})
+
+	t.Run("LocalNontarball", func(t *testing.T) {
+		tmp := t.TempDir()
+
+		unpackedModDir := filepath.Join(tmp, "unpacked-mod-dir")
+		env := map[string]string{}
+		modLocalNontar := Module{Type: ModuleTypeLocal}
+
+		err := os.Mkdir(unpackedModDir, 0700)
+		test.That(t, err, test.ShouldBeNil)
+
+		meta, moduleWorkingDirectory, err := modLocalNontar.getJSONManifest(unpackedModDir, env)
+		test.That(t, meta, test.ShouldBeNil)
+		test.That(t, moduleWorkingDirectory, test.ShouldBeEmpty)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "local non-tarball")
+		test.That(t, errors.Is(err, os.ErrNotExist), test.ShouldBeFalse)
 	})
 }
 

--- a/config/module_test.go
+++ b/config/module_test.go
@@ -411,7 +411,8 @@ func testWriteJSON(t *testing.T, path string, value any) {
 // testSetUpRegistryModule is a t.Helper that creates a registry module with a meta.json file and an executable file in its top level
 // directory. It also returns a logger and its observed logs for testing.
 func testSetUpRegistryModule(t *testing.T) (module Module, metaJSONFilepath string, env map[string]string, logger logging.Logger,
-	observedLogs *observer.ObservedLogs) {
+	observedLogs *observer.ObservedLogs,
+) {
 	t.Helper()
 	module = Module{Type: ModuleTypeRegistry}
 	tmp := t.TempDir()

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -1098,6 +1098,7 @@ func (mgr *Manager) FirstRun(ctx context.Context, conf config.Module) error {
 	// This value is normally set on a field on the [module] struct but it seems like we can safely get it on demand.
 	var dataDir string
 	if mgr.moduleDataParentDir != "" {
+		fmt.Println("MODULE DATA PARENT DIRECTORY: ", mgr.moduleDataParentDir)
 		var err error
 		// TODO: why isn't conf.Name being sanitized like PackageConfig.SanitizedName?
 		dataDir, err = rutils.SafeJoinDir(mgr.moduleDataParentDir, conf.Name)
@@ -1106,8 +1107,9 @@ func (mgr *Manager) FirstRun(ctx context.Context, conf config.Module) error {
 		}
 	}
 	env := getFullEnvironment(conf, dataDir, mgr.viamHomeDir)
+	fmt.Println("ENV: ", env)
 
-	return conf.FirstRun(ctx, pkgsDir, dataDir, env, mgr.logger, mgr.packagesDir, mgr.viamHomeDir)
+	return conf.FirstRun(ctx, pkgsDir, dataDir, env, mgr.logger)
 }
 
 func (m *module) startProcess(
@@ -1139,6 +1141,7 @@ func (m *module) startProcess(
 	moduleEnvironment := m.getFullEnvironment(viamHomeDir)
 	// Prefer VIAM_MODULE_ROOT as the current working directory if present but fallback to the directory of the exepath
 	moduleWorkingDirectory, ok := moduleEnvironment["VIAM_MODULE_ROOT"]
+	fmt.Println("MODULE WORKING DIRECTORY: ", moduleWorkingDirectory)
 	if !ok {
 		moduleWorkingDirectory = filepath.Dir(absoluteExePath)
 		m.logger.CDebugw(ctx, "VIAM_MODULE_ROOT was not passed to module. Defaulting to module's working directory",

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -334,7 +334,7 @@ func (mgr *Manager) add(ctx context.Context, conf config.Module, moduleLogger lo
 		resources: map[resource.Name]*addedResource{},
 		logger:    moduleLogger,
 		ftdc:      mgr.ftdc,
-		port:      mgr.nextPort,
+		port:      int(mgr.nextPort.Add(1)),
 	}
 
 	if err := mgr.startModule(ctx, mod); err != nil {
@@ -1365,7 +1365,7 @@ func (m *module) registerProcessWithFTDC() {
 		return
 	}
 
-	m.ftdc.Add(fmt.Sprintf("modules.%s", m.process.ID()), statser)
+	m.ftdc.Add(fmt.Sprintf("proc.modules.%s", m.process.ID()), statser)
 }
 
 func getFullEnvironment(

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -30,6 +30,8 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/ftdc"
+	"go.viam.com/rdk/ftdc/sys"
 	rdkgrpc "go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	modlib "go.viam.com/rdk/module"
@@ -163,7 +165,14 @@ func (rmap *resourceModuleMap) Range(f func(name resource.Name, mod *module) boo
 
 // Manager is the root structure for the module system.
 type Manager struct {
-	mu           sync.RWMutex
+	// mu (mostly) coordinates API methods that modify the `modules` map. Specifically,
+	// `AddResource` can be called concurrently during a reconfigure. But `RemoveResource` or
+	// resources being restarted after a module crash are given exclusive access.
+	//
+	// mu additionally is used for exclusive access when `Add`ing modules (as opposed to resources),
+	// `Reconfigure`ing modules, `Remove`ing modules and `Close`ing the `Manager`.
+	mu sync.RWMutex
+
 	logger       logging.Logger
 	modules      moduleMap
 	parentAddr   string
@@ -204,9 +213,6 @@ func (mgr *Manager) Close(ctx context.Context) error {
 
 // Handles returns all the models for each module registered.
 func (mgr *Manager) Handles() map[string]modlib.HandlerMap {
-	mgr.mu.Lock()
-	defer mgr.mu.Unlock()
-
 	res := map[string]modlib.HandlerMap{}
 
 	mgr.modules.Range(func(n string, m *module) bool {
@@ -279,11 +285,12 @@ func (mgr *Manager) Add(ctx context.Context, confs ...config.Module) error {
 		wg.Add(1)
 		go func(i int, conf config.Module) {
 			defer wg.Done()
+			moduleLogger := mgr.logger.Sublogger(conf.Name)
 
-			mgr.logger.CInfow(ctx, "Now adding module", "module", conf.Name)
-			err := mgr.add(ctx, conf)
+			moduleLogger.CInfow(ctx, "Now adding module", "module", conf.Name)
+			err := mgr.add(ctx, conf, moduleLogger)
 			if err != nil {
-				mgr.logger.CErrorw(ctx, "Error adding module", "module", conf.Name, "error", err)
+				moduleLogger.CErrorw(ctx, "Error adding module", "module", conf.Name, "error", err)
 				errs[i] = err
 				return
 			}
@@ -302,9 +309,10 @@ func (mgr *Manager) Add(ctx context.Context, confs ...config.Module) error {
 	return combinedErr
 }
 
-func (mgr *Manager) add(ctx context.Context, conf config.Module) error {
+func (mgr *Manager) add(ctx context.Context, conf config.Module, moduleLogger logging.Logger) error {
 	_, exists := mgr.modules.Load(conf.Name)
 	if exists {
+		// Keeping this as a manager logger since it is dealing with manager behavior
 		mgr.logger.CWarnw(ctx, "Not adding module that already exists", "module", conf.Name)
 		return nil
 	}
@@ -326,7 +334,7 @@ func (mgr *Manager) add(ctx context.Context, conf config.Module) error {
 		resources: map[resource.Name]*addedResource{},
 		ftdc:      mgr.ftdc,
 		port:      mgr.nextPort,
-		logger:    mgr.logger.Sublogger(conf.Name),
+		logger:    moduleLogger,
 	}
 
 	if err := mgr.startModule(ctx, mod); err != nil {
@@ -340,7 +348,6 @@ func (mgr *Manager) startModuleProcess(mod *module) error {
 		mgr.restartCtx,
 		mgr.parentAddr,
 		mgr.newOnUnexpectedExitHandler(mod),
-		mgr.logger,
 		mgr.viamHomeDir,
 		mgr.packagesDir,
 	)
@@ -357,20 +364,20 @@ func (mgr *Manager) startModule(ctx context.Context, mod *module) error {
 	var success bool
 	defer func() {
 		if !success {
-			mod.cleanupAfterStartupFailure(mgr.logger)
+			mod.cleanupAfterStartupFailure()
 		}
 	}()
 
 	// create the module's data directory
 	if mod.dataDir != "" {
-		mgr.logger.Infof("Creating data directory %q for module %q", mod.dataDir, mod.cfg.Name)
+		mod.logger.Debugf("Creating data directory %q for module %q", mod.dataDir, mod.cfg.Name)
 		if err := os.MkdirAll(mod.dataDir, 0o750); err != nil {
 			return errors.WithMessage(err, "error while creating data directory for module "+mod.cfg.Name)
 		}
 	}
 
 	cleanup := rutils.SlowStartupLogger(
-		ctx, "Waiting for module to complete startup and registration", "module", mod.cfg.Name, mgr.logger)
+		ctx, "Waiting for module to complete startup and registration", "module", mod.cfg.Name, mod.logger)
 	defer cleanup()
 
 	if err := mgr.startModuleProcess(mod); err != nil {
@@ -381,13 +388,13 @@ func (mgr *Manager) startModule(ctx context.Context, mod *module) error {
 		return errors.WithMessage(err, "error while dialing module "+mod.cfg.Name)
 	}
 
-	if err := mod.checkReady(ctx, mgr.parentAddr, mgr.logger); err != nil {
+	if err := mod.checkReady(ctx, mgr.parentAddr); err != nil {
 		return errors.WithMessage(err, "error while waiting for module to be ready "+mod.cfg.Name)
 	}
 
-	mod.registerResources(mgr, mgr.logger)
+	mod.registerResources(mgr)
 	mgr.modules.Store(mod.cfg.Name, mod)
-	mgr.logger.Infow("Module successfully added", "module", mod.cfg.Name)
+	mod.logger.Infow("Module successfully added", "module", mod.cfg.Name)
 	success = true
 	return nil
 }
@@ -410,7 +417,7 @@ func (mgr *Manager) Reconfigure(ctx context.Context, conf config.Module) ([]reso
 		handledResourceNameStrings = append(handledResourceNameStrings, name.String())
 	}
 
-	mgr.logger.CInfow(ctx, "Module configuration changed. Stopping the existing module process", "module", conf.Name)
+	mod.logger.CInfow(ctx, "Module configuration changed. Stopping the existing module process", "module", conf.Name)
 
 	if err := mgr.closeModule(mod, true); err != nil {
 		// If removal fails, assume all handled resources are orphaned.
@@ -420,17 +427,17 @@ func (mgr *Manager) Reconfigure(ctx context.Context, conf config.Module) ([]reso
 	mod.cfg = conf
 	mod.resources = map[resource.Name]*addedResource{}
 
-	mgr.logger.CInfow(ctx, "Existing module process stopped. Starting new module process", "module", conf.Name)
+	mod.logger.CInfow(ctx, "Existing module process stopped. Starting new module process", "module", conf.Name)
 
 	if err := mgr.startModule(ctx, mod); err != nil {
 		// If re-addition fails, assume all handled resources are orphaned.
 		return handledResourceNames, err
 	}
 
-	mgr.logger.CInfow(ctx, "New module process is running and responding to gRPC requests", "module",
+	mod.logger.CInfow(ctx, "New module process is running and responding to gRPC requests", "module",
 		mod.cfg.Name, "module address", mod.addr)
 
-	mgr.logger.CInfow(ctx, "Resources handled by reconfigured module will be re-added to new module process",
+	mod.logger.CInfow(ctx, "Resources handled by reconfigured module will be re-added to new module process",
 		"module", mod.cfg.Name, "resources", handledResourceNameStrings)
 	return handledResourceNames, nil
 }
@@ -473,16 +480,16 @@ func (mgr *Manager) Remove(modName string) ([]resource.Name, error) {
 func (mgr *Manager) closeModule(mod *module, reconfigure bool) error {
 	// resource manager should've removed these cleanly if this isn't a reconfigure
 	if !reconfigure && len(mod.resources) != 0 {
-		mgr.logger.Warnw("Forcing removal of module with active resources", "module", mod.cfg.Name)
+		mod.logger.Warnw("Forcing removal of module with active resources", "module", mod.cfg.Name)
 	}
 
 	// need to actually close the resources within the module itself before stopping
 	for res := range mod.resources {
 		_, err := mod.client.RemoveResource(context.Background(), &pb.RemoveResourceRequest{Name: res.String()})
 		if err != nil {
-			mgr.logger.Errorw("Error removing resource", "module", mod.cfg.Name, "resource", res.Name, "error", err)
+			mod.logger.Errorw("Error removing resource", "module", mod.cfg.Name, "resource", res.Name, "error", err)
 		} else {
-			mgr.logger.Infow("Successfully removed resource from module", "module", mod.cfg.Name, "resource", res.Name)
+			mod.logger.Infow("Successfully removed resource from module", "module", mod.cfg.Name, "resource", res.Name)
 		}
 	}
 
@@ -491,7 +498,7 @@ func (mgr *Manager) closeModule(mod *module, reconfigure bool) error {
 	}
 
 	if err := mod.sharedConn.Close(); err != nil {
-		mgr.logger.Warnw("Error closing connection to module", "error", err)
+		mod.logger.Warnw("Error closing connection to module", "error", err)
 	}
 
 	mod.deregisterResources()
@@ -504,7 +511,7 @@ func (mgr *Manager) closeModule(mod *module, reconfigure bool) error {
 	})
 	mgr.modules.Delete(mod.cfg.Name)
 
-	mgr.logger.Infow("Module successfully closed", "module", mod.cfg.Name)
+	mod.logger.Infow("Module successfully closed", "module", mod.cfg.Name)
 	return nil
 }
 
@@ -527,7 +534,7 @@ func (mgr *Manager) addResource(ctx context.Context, conf resource.Config, deps 
 		return nil, errors.Errorf("no active module registered to serve resource api %s and model %s", conf.API, conf.Model)
 	}
 
-	mgr.logger.CInfow(ctx, "Adding resource to module", "resource", conf.Name, "module", mod.cfg.Name)
+	mod.logger.CInfow(ctx, "Adding resource to module", "resource", conf.Name, "module", mod.cfg.Name)
 
 	confProto, err := config.ComponentConfigToProto(&conf)
 	if err != nil {
@@ -546,7 +553,7 @@ func (mgr *Manager) addResource(ctx context.Context, conf resource.Config, deps 
 
 	apiInfo, ok := resource.LookupGenericAPIRegistration(conf.API)
 	if !ok || apiInfo.RPCClient == nil {
-		mgr.logger.CWarnw(ctx, "No built-in grpc client for modular resource", "resource", conf.ResourceName())
+		mod.logger.CWarnw(ctx, "No built-in grpc client for modular resource", "resource", conf.ResourceName())
 		return rdkgrpc.NewForeignResource(conf.ResourceName(), &mod.sharedConn), nil
 	}
 
@@ -555,14 +562,12 @@ func (mgr *Manager) addResource(ctx context.Context, conf resource.Config, deps 
 
 // ReconfigureResource updates/reconfigures a modular component with a new configuration.
 func (mgr *Manager) ReconfigureResource(ctx context.Context, conf resource.Config, deps []string) error {
-	mgr.mu.RLock()
-	defer mgr.mu.RUnlock()
 	mod, ok := mgr.getModule(conf)
 	if !ok {
 		return errors.Errorf("no module registered to serve resource api %s and model %s", conf.API, conf.Model)
 	}
 
-	mgr.logger.CInfow(ctx, "Reconfiguring resource for module", "resource", conf.Name, "module", mod.cfg.Name)
+	mod.logger.CInfow(ctx, "Reconfiguring resource for module", "resource", conf.Name, "module", mod.cfg.Name)
 
 	confProto, err := config.ComponentConfigToProto(&conf)
 	if err != nil {
@@ -572,6 +577,7 @@ func (mgr *Manager) ReconfigureResource(ctx context.Context, conf resource.Confi
 	if err != nil {
 		return err
 	}
+
 	mod.resourcesMu.Lock()
 	defer mod.resourcesMu.Unlock()
 	mod.resources[conf.ResourceName()] = &addedResource{conf, deps}
@@ -582,8 +588,6 @@ func (mgr *Manager) ReconfigureResource(ctx context.Context, conf resource.Confi
 // Configs returns a slice of config.Module representing the currently managed
 // modules.
 func (mgr *Manager) Configs() []config.Module {
-	mgr.mu.RLock()
-	defer mgr.mu.RUnlock()
 	var configs []config.Module
 	mgr.modules.Range(func(_ string, mod *module) bool {
 		configs = append(configs, mod.cfg)
@@ -594,16 +598,12 @@ func (mgr *Manager) Configs() []config.Module {
 
 // Provides returns true if a component/service config WOULD be handled by a module.
 func (mgr *Manager) Provides(conf resource.Config) bool {
-	mgr.mu.RLock()
-	defer mgr.mu.RUnlock()
 	_, ok := mgr.getModule(conf)
 	return ok
 }
 
 // IsModularResource returns true if an existing resource IS handled by a module.
 func (mgr *Manager) IsModularResource(name resource.Name) bool {
-	mgr.mu.RLock()
-	defer mgr.mu.RUnlock()
 	_, ok := mgr.rMap.Load(name)
 	return ok
 }
@@ -617,7 +617,7 @@ func (mgr *Manager) RemoveResource(ctx context.Context, name resource.Name) erro
 		return errors.Errorf("resource %+v not found in module", name)
 	}
 
-	mgr.logger.CInfow(ctx, "Removing resource for module", "resource", name.String(), "module", mod.cfg.Name)
+	mod.logger.CInfow(ctx, "Removing resource for module", "resource", name.String(), "module", mod.cfg.Name)
 
 	mgr.rMap.Delete(name)
 	delete(mod.resources, name)
@@ -636,8 +636,6 @@ func (mgr *Manager) RemoveResource(ctx context.Context, name resource.Name) erro
 // ValidateConfig determines whether the given config is valid and returns its implicit
 // dependencies.
 func (mgr *Manager) ValidateConfig(ctx context.Context, conf resource.Config) ([]string, error) {
-	mgr.mu.RLock()
-	defer mgr.mu.RUnlock()
 	mod, ok := mgr.getModule(conf)
 	if !ok {
 		return nil,
@@ -671,8 +669,6 @@ func (mgr *Manager) ValidateConfig(ctx context.Context, conf resource.Config) ([
 // and modified resources. It also puts modular resources whose module has been modified or added in conf.Added if
 // they are not already there since the resources themselves are not necessarily new.
 func (mgr *Manager) ResolveImplicitDependenciesInConfig(ctx context.Context, conf *config.Diff) error {
-	mgr.mu.RLock()
-	defer mgr.mu.RUnlock()
 	// NOTE(benji): We could simplify some of the following `continue`
 	// conditional clauses to a single clause, but we split them for readability.
 	for _, c := range conf.Right.Components {
@@ -862,7 +858,7 @@ func (mgr *Manager) newOnUnexpectedExitHandler(mod *module) func(exitCode int) b
 		defer mod.inStartup.Store(false)
 
 		// Log error immediately, as this is unexpected behavior.
-		mgr.logger.Errorw(
+		mod.logger.Errorw(
 			"Module has unexpectedly exited.", "module", mod.cfg.Name, "exit_code", exitCode,
 		)
 
@@ -878,7 +874,7 @@ func (mgr *Manager) newOnUnexpectedExitHandler(mod *module) func(exitCode int) b
 		if orphanedResourceNames := mgr.attemptRestart(mgr.restartCtx, mod); orphanedResourceNames != nil {
 			if mgr.removeOrphanedResources != nil {
 				mgr.removeOrphanedResources(mgr.restartCtx, orphanedResourceNames)
-				mgr.logger.Debugw(
+				mod.logger.Debugw(
 					"Removed resources after failed module restart",
 					"module", mod.cfg.Name,
 					"resources", resource.NamesToStrings(orphanedResourceNames),
@@ -886,7 +882,7 @@ func (mgr *Manager) newOnUnexpectedExitHandler(mod *module) func(exitCode int) b
 			}
 			return false
 		}
-		mgr.logger.Infow("Module successfully restarted, re-adding resources", "module", mod.cfg.Name)
+		mod.logger.Infow("Module successfully restarted, re-adding resources", "module", mod.cfg.Name)
 
 		// Otherwise, add old module process' resources to new module; warn if new
 		// module cannot handle old resource and remove it from mod.resources.
@@ -897,7 +893,7 @@ func (mgr *Manager) newOnUnexpectedExitHandler(mod *module) func(exitCode int) b
 			// read lock, so we execute it here with a write lock to make sure it doesn't
 			// run concurrently.
 			if _, err := mgr.addResourceWithWriteLock(mgr.restartCtx, res.conf, res.deps); err != nil {
-				mgr.logger.Warnw("Error while re-adding resource to module",
+				mod.logger.Warnw("Error while re-adding resource to module",
 					"resource", name, "module", mod.cfg.Name, "error", err)
 				mgr.rMap.Delete(name)
 
@@ -912,7 +908,7 @@ func (mgr *Manager) newOnUnexpectedExitHandler(mod *module) func(exitCode int) b
 			mgr.removeOrphanedResources(mgr.restartCtx, orphanedResourceNames)
 		}
 
-		mgr.logger.Infow("Module resources successfully re-added after module restart", "module", mod.cfg.Name)
+		mod.logger.Infow("Module resources successfully re-added after module restart", "module", mod.cfg.Name)
 		return false
 	}
 }
@@ -961,7 +957,7 @@ func (mgr *Manager) attemptRestart(ctx context.Context, mod *module) []resource.
 	// executable we were given for initial module addition.
 
 	cleanup := rutils.SlowStartupLogger(
-		ctx, "Waiting for module to complete restart and re-registration", "module", mod.cfg.Name, mgr.logger)
+		ctx, "Waiting for module to complete restart and re-registration", "module", mod.cfg.Name, mod.logger)
 	defer cleanup()
 
 	// Attempt to restart module process 3 times.
@@ -993,13 +989,13 @@ func (mgr *Manager) attemptRestart(ctx context.Context, mod *module) []resource.
 		return orphanedResourceNames
 	}
 
-	if err := mod.checkReady(ctx, mgr.parentAddr, mgr.logger); err != nil {
+	if err := mod.checkReady(ctx, mgr.parentAddr); err != nil {
 		mgr.logger.CErrorw(ctx, "Error while waiting for restarted module to be ready",
 			"module", mod.cfg.Name, "error", err)
 		return orphanedResourceNames
 	}
 
-	mod.registerResources(mgr, mgr.logger)
+	mod.registerResources(mgr)
 
 	success = true
 	return nil
@@ -1050,11 +1046,11 @@ func (m *module) dial() error {
 
 // checkReady sends a `ReadyRequest` and waits for either a `ReadyResponse`, or a context
 // cancelation.
-func (m *module) checkReady(ctx context.Context, parentAddr string, logger logging.Logger) error {
-	ctxTimeout, cancelFunc := context.WithTimeout(ctx, rutils.GetModuleStartupTimeout(logger))
+func (m *module) checkReady(ctx context.Context, parentAddr string) error {
+	ctxTimeout, cancelFunc := context.WithTimeout(ctx, rutils.GetModuleStartupTimeout(m.logger))
 	defer cancelFunc()
 
-	logger.CInfow(ctx, "Waiting for module to respond to ready request", "module", m.cfg.Name)
+	m.logger.CInfow(ctx, "Waiting for module to respond to ready request", "module", m.cfg.Name)
 
 	req := &pb.ReadyRequest{ParentAddress: parentAddr}
 
@@ -1062,7 +1058,7 @@ func (m *module) checkReady(ctx context.Context, parentAddr string, logger loggi
 	var err error
 	req.WebrtcOffer, err = m.sharedConn.GenerateEncodedOffer()
 	if err != nil {
-		logger.CWarnw(ctx, "Unable to generate offer for module PeerConnection. Ignoring.", "err", err)
+		m.logger.CWarnw(ctx, "Unable to generate offer for module PeerConnection. Ignoring.", "err", err)
 	}
 
 	for {
@@ -1084,7 +1080,7 @@ func (m *module) checkReady(ctx context.Context, parentAddr string, logger loggi
 
 		err = m.sharedConn.ProcessEncodedAnswer(resp.WebrtcAnswer)
 		if err != nil {
-			logger.CWarnw(ctx, "Unable to create PeerConnection with module. Ignoring.", "err", err)
+			m.logger.CWarnw(ctx, "Unable to create PeerConnection with module. Ignoring.", "err", err)
 		}
 
 		// The `ReadyRespones` also includes the Viam `API`s and `Model`s the module provides. This
@@ -1118,7 +1114,6 @@ func (m *module) startProcess(
 	ctx context.Context,
 	parentAddr string,
 	oue func(int) bool,
-	logger logging.Logger,
 	viamHomeDir string,
 	packagesDir string,
 ) error {
@@ -1146,10 +1141,10 @@ func (m *module) startProcess(
 	moduleWorkingDirectory, ok := moduleEnvironment["VIAM_MODULE_ROOT"]
 	if !ok {
 		moduleWorkingDirectory = filepath.Dir(absoluteExePath)
-		logger.CWarnw(ctx, "VIAM_MODULE_ROOT was not passed to module. Defaulting to module's working directory",
+		m.logger.CDebugw(ctx, "VIAM_MODULE_ROOT was not passed to module. Defaulting to module's working directory",
 			"module", m.cfg.Name, "dir", moduleWorkingDirectory)
 	} else {
-		logger.CInfow(ctx, "Starting module in working directory", "module", m.cfg.Name, "dir", moduleWorkingDirectory)
+		m.logger.CInfow(ctx, "Starting module in working directory", "module", m.cfg.Name, "dir", moduleWorkingDirectory)
 	}
 
 	pconf := pexec.ProcessConfig{
@@ -1165,21 +1160,25 @@ func (m *module) startProcess(
 	// supplied and module manager has a DebugLevel logger.
 	if m.cfg.LogLevel != "" {
 		pconf.Args = append(pconf.Args, fmt.Sprintf(logLevelArgumentTemplate, m.cfg.LogLevel))
-	} else if logger.Level().Enabled(zapcore.DebugLevel) {
+	} else if m.logger.Level().Enabled(zapcore.DebugLevel) {
 		pconf.Args = append(pconf.Args, fmt.Sprintf(logLevelArgumentTemplate, "debug"))
 	}
 
-	m.process = pexec.NewManagedProcess(pconf, logger)
+	m.process = pexec.NewManagedProcess(pconf, m.logger)
 
 	if err := m.process.Start(context.Background()); err != nil {
 		return errors.WithMessage(err, "module startup failed")
 	}
 
+	// Turn on process cpu/memory diagnostics for the module process. If there's an error, we
+	// continue normally, just without FTDC.
+	m.registerProcessWithFTDC()
+
 	checkTicker := time.NewTicker(100 * time.Millisecond)
 	defer checkTicker.Stop()
 
-	logger.CInfow(ctx, "Starting up module", "module", m.cfg.Name)
-	ctxTimeout, cancel := context.WithTimeout(ctx, rutils.GetModuleStartupTimeout(logger))
+	m.logger.CInfow(ctx, "Starting up module", "module", m.cfg.Name)
+	ctxTimeout, cancel := context.WithTimeout(ctx, rutils.GetModuleStartupTimeout(m.logger))
 	defer cancel()
 	for {
 		select {
@@ -1215,9 +1214,21 @@ func (m *module) stopProcess() error {
 	if m.process == nil {
 		return nil
 	}
+
+	m.logger.Infof("Stopping module: %s process", m.cfg.Name)
+
 	// Attempt to remove module's .sock file if module did not remove it
 	// already.
-	defer rutils.RemoveFileNoError(m.addr)
+	defer func() {
+		rutils.RemoveFileNoError(m.addr)
+
+		// The system metrics "statser" is resilient to the process dying under the hood. An empty set
+		// of metrics will be reported. Therefore it is safe to continue monitoring the module process
+		// while it's in shutdown.
+		if m.ftdc != nil {
+			m.ftdc.Remove(m.process.ID())
+		}
+	}()
 
 	// TODO(RSDK-2551): stop ignoring exit status 143 once Python modules handle
 	// SIGTERM correctly.
@@ -1228,10 +1239,11 @@ func (m *module) stopProcess() error {
 		}
 		return err
 	}
+
 	return nil
 }
 
-func (m *module) registerResources(mgr modmaninterface.ModuleManager, logger logging.Logger) {
+func (m *module) registerResources(mgr modmaninterface.ModuleManager) {
 	for api, models := range m.handles {
 		if _, ok := resource.LookupGenericAPIRegistration(api.API); !ok {
 			resource.RegisterAPI(
@@ -1243,7 +1255,7 @@ func (m *module) registerResources(mgr modmaninterface.ModuleManager, logger log
 		switch {
 		case api.API.IsComponent():
 			for _, model := range models {
-				logger.Infow("Registering component API and model from module", "module", m.cfg.Name, "API", api.API, "model", model)
+				m.logger.Infow("Registering component API and model from module", "module", m.cfg.Name, "API", api.API, "model", model)
 				// We must copy because the Discover closure func relies on api and model, but they are iterators and mutate.
 				// Copying prevents mutation.
 				modelCopy := model
@@ -1258,13 +1270,13 @@ func (m *module) registerResources(mgr modmaninterface.ModuleManager, logger log
 						return mgr.AddResource(ctx, conf, DepsToNames(deps))
 					},
 					Discover: func(ctx context.Context, logger logging.Logger, extra map[string]interface{}) (interface{}, error) {
-						extraStruct, err := structpb.NewStruct(extra)
+						extraStructPb, err := structpb.NewStruct(extra)
 						if err != nil {
 							return nil, err
 						}
 						req := &robotpb.DiscoverComponentsRequest{
 							Queries: []*robotpb.DiscoveryQuery{
-								{Subtype: apiCopy.API.String(), Model: modelCopy.String(), Extra: extraStruct},
+								{Subtype: apiCopy.API.String(), Model: modelCopy.String(), Extra: extraStructPb},
 							},
 						}
 
@@ -1286,7 +1298,7 @@ func (m *module) registerResources(mgr modmaninterface.ModuleManager, logger log
 			}
 		case api.API.IsService():
 			for _, model := range models {
-				logger.Infow("Registering service API and model from module", "module", m.cfg.Name, "API", api.API, "model", model)
+				m.logger.Infow("Registering service API and model from module", "module", m.cfg.Name, "API", api.API, "model", model)
 				resource.RegisterService(api.API, model, resource.Registration[resource.Resource, resource.NoNativeConfig]{
 					Constructor: func(
 						ctx context.Context,
@@ -1299,7 +1311,7 @@ func (m *module) registerResources(mgr modmaninterface.ModuleManager, logger log
 				})
 			}
 		default:
-			logger.Errorw("Invalid module type", "API type", api.API.Type)
+			m.logger.Errorw("Invalid module type", "API type", api.API.Type)
 		}
 	}
 }
@@ -1313,10 +1325,10 @@ func (m *module) deregisterResources() {
 	m.handles = nil
 }
 
-func (m *module) cleanupAfterStartupFailure(logger logging.Logger) {
+func (m *module) cleanupAfterStartupFailure() {
 	if err := m.stopProcess(); err != nil {
 		msg := "Error while stopping process of module that failed to start"
-		logger.Errorw(msg, "module", m.cfg.Name, "error", err)
+		m.logger.Errorw(msg, "module", m.cfg.Name, "error", err)
 	}
 	utils.UncheckedError(m.sharedConn.Close())
 }
@@ -1334,6 +1346,26 @@ func (m *module) cleanupAfterCrash(mgr *Manager) {
 
 func (m *module) getFullEnvironment(viamHomeDir string) map[string]string {
 	return getFullEnvironment(m.cfg, m.dataDir, viamHomeDir)
+}
+
+func (m *module) registerProcessWithFTDC() {
+	if m.ftdc == nil {
+		return
+	}
+
+	pid, err := m.process.UnixPid()
+	if err != nil {
+		m.logger.Warnw("Module process has no pid. Cannot start ftdc.", "err", err)
+		return
+	}
+
+	statser, err := sys.NewPidSysUsageStatser(pid)
+	if err != nil {
+		m.logger.Warnw("Cannot find /proc files", "err", err)
+		return
+	}
+
+	m.ftdc.Add(fmt.Sprintf("modules.%s", m.process.ID()), statser)
 }
 
 func getFullEnvironment(

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -332,9 +332,9 @@ func (mgr *Manager) add(ctx context.Context, conf config.Module, moduleLogger lo
 		cfg:       conf,
 		dataDir:   moduleDataDir,
 		resources: map[resource.Name]*addedResource{},
+		logger:    moduleLogger,
 		ftdc:      mgr.ftdc,
 		port:      mgr.nextPort,
-		logger:    moduleLogger,
 	}
 
 	if err := mgr.startModule(ctx, mod); err != nil {

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -1107,7 +1107,7 @@ func (mgr *Manager) FirstRun(ctx context.Context, conf config.Module) error {
 	}
 	env := getFullEnvironment(conf, dataDir, mgr.viamHomeDir)
 
-	return conf.FirstRun(ctx, pkgsDir, dataDir, env, mgr.logger)
+	return conf.FirstRun(ctx, pkgsDir, dataDir, env, mgr.logger, mgr.packagesDir, mgr.viamHomeDir)
 }
 
 func (m *module) startProcess(


### PR DESCRIPTION
Search for a registry module's meta.json file in the top level of the module _and_ in the parent directory of its executable entry point.
### Testing
Running the robot linked in the [Jira ticket](https://viam.atlassian.net/browse/RSDK-9498) no longer outputs the WARN log listed. `first_run.sh` is successfully sourced and executed, and a `dist.first_run_succeeded` file is created.
**Note:** This has only been tested with a registry module, _not_ a local module.