### PR TITLE
Move lock down in gpiostepper SetPower

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,5 @@ web/cmd/server/*.core
 
 # codegpt
 .codegpt/*
+
+.codegpt

--- a/.gitignore
+++ b/.gitignore
@@ -95,5 +95,3 @@ web/cmd/server/*.core
 
 # codegpt
 .codegpt/*
-
-.codegpt


### PR DESCRIPTION
In trying to clean up this code, I discovered the following:

- We don't need separate stop functions.
- There's a possible deadlock with SetPower if we call it before close.

I'm going to go ahead and refactor the stepper motor code next - it's not great as is.
