### PR TITLE
[RSDK-9702] - Do not return odd resolutions from GetStreamOptions Response

### DIFF
--- a/robot/web/stream/server.go
+++ b/robot/web/stream/server.go
@@ -422,6 +422,13 @@ func validateSetStreamOptionsRequest(req *streampb.SetStreamOptionsRequest) (int
 				req.Name, req.Resolution.Width, req.Resolution.Height,
 			)
 	}
+	if req.Resolution.Width%2 != 0 || req.Resolution.Height%2 != 0 {
+		return optionsCommandUnknown,
+			fmt.Errorf(
+				"invalid resolution to resize stream %q: width (%d) and height (%d) must be even",
+				req.Name, req.Resolution.Width, req.Resolution.Height,
+			)
+	}
 	return optionsCommandResize, nil
 }
 

--- a/robot/web/stream/server.go
+++ b/robot/web/stream/server.go
@@ -731,11 +731,18 @@ func GenerateResolutions(width, height int32, logger logging.Logger) []Resolutio
 	// original aspect ratio exactly if source dimensions are odd.
 	for i := 0; i < 4; i++ {
 		// Break if the next scaled resolution would be too small.
-		if width <= 1 || height <= 1 {
+		if width <= 2 || height <= 2 {
 			break
 		}
 		width /= 2
 		height /= 2
+		// Ensure width and height are even
+		if width%2 != 0 {
+			width--
+		}
+		if height%2 != 0 {
+			height--
+		}
 		resolutions = append(resolutions, Resolution{Width: width, Height: height})
 		logger.Debugf("scaled resolution %d: %dx%d", i, width, height)
 	}


### PR DESCRIPTION
## Description

Although we can resize to odd resolutions this breaks our h264 encoder pipeline. Prevent odd resolutions by rounding down to nearest even.

## Testing

Manually tested we no longer return odd resolutions and resize streams are working.