### PR TITLE
RSDK-9668 - Mitigate mDNS race

### DIFF
--- a/robot/impl/robot_framesystem_test.go
+++ b/robot/impl/robot_framesystem_test.go
@@ -227,7 +227,7 @@ func TestServiceWithUnavailableRemote(t *testing.T) {
 		},
 	}
 
-	r := setupLocalRobot(t, context.Background(), localConfig, logger)
+	r := setupLocalRobot(t, context.Background(), localConfig, logger, withDisableCompleteConfigWorker())
 
 	// make sure calling into remotes don't error
 	fsCfg, err := r.FrameSystemConfig(context.Background())


### PR DESCRIPTION
can't repro locally, but what I'm theorizing is that the cancel happening at the same time the mDNS lookup is happening on the background reconfig routine is what is causing the issue. maybe one of the recent changes made this more likely? In any case, want to merge this in first so that dev is not blocked while we fix it properly