### PR TITLE
[RSDK-9655] skip reflection for discovery service and add fake discovery

### DIFF
--- a/examples/customresources/models/mydiscovery/mydiscovery.go
+++ b/examples/customresources/models/mydiscovery/mydiscovery.go
@@ -11,10 +11,8 @@ import (
 	"go.viam.com/rdk/services/discovery"
 )
 
-var (
-	// Model is the full model definition.
-	Model = resource.NewModel("acme", "demo", "mydiscovery")
-)
+// Model is the full model definition.
+var Model = resource.NewModel("acme", "demo", "mydiscovery")
 
 func init() {
 	resource.RegisterService(

--- a/examples/customresources/models/mydiscovery/mydiscovery.go
+++ b/examples/customresources/models/mydiscovery/mydiscovery.go
@@ -1,0 +1,61 @@
+// Package mydiscovery implements a discovery that returns some fake components.
+package mydiscovery
+
+import (
+	"context"
+
+	"go.viam.com/rdk/components/camera"
+	"go.viam.com/rdk/components/movementsensor"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/services/discovery"
+)
+
+var (
+	// Model is the full model definition.
+	Model = resource.NewModel("acme", "demo", "mydiscovery")
+)
+
+func init() {
+	resource.RegisterService(
+		discovery.API,
+		Model,
+		resource.Registration[discovery.Service, resource.NoNativeConfig]{Constructor: func(
+			ctx context.Context,
+			deps resource.Dependencies,
+			conf resource.Config,
+			logger logging.Logger,
+		) (discovery.Service, error) {
+			return newDiscovery(conf.ResourceName(), logger), nil
+		}})
+}
+
+func newDiscovery(name resource.Name, logger logging.Logger) discovery.Service {
+	cfg1 := createFakeConfig("fake1", movementsensor.API)
+	cfg2 := createFakeConfig("fake2", camera.API)
+	return &Discovery{Named: name.AsNamed(), logger: logger, cfgs: []resource.Config{cfg1, cfg2}}
+}
+
+// DiscoverResources returns the discovered resources.
+func (dis *Discovery) DiscoverResources(context.Context, map[string]any) ([]resource.Config, error) {
+	return dis.cfgs, nil
+}
+
+// Discovery is a fake Discovery service that returns.
+type Discovery struct {
+	resource.Named
+	resource.TriviallyReconfigurable
+	resource.TriviallyCloseable
+	logger logging.Logger
+	cfgs   []resource.Config
+}
+
+// DoCommand echos input back to the caller.
+func (dis *Discovery) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+	return cmd, nil
+}
+
+// createFakeConfig creates a fake component with the defined name, api, and attributes.
+func createFakeConfig(name string, api resource.API) resource.Config {
+	return resource.Config{Name: name, API: api, Model: resource.DefaultModelFamily.WithModel("fake")}
+}

--- a/examples/customresources/models/mydiscovery/mydiscovery.go
+++ b/examples/customresources/models/mydiscovery/mydiscovery.go
@@ -39,7 +39,7 @@ func (dis *Discovery) DiscoverResources(context.Context, map[string]any) ([]reso
 	return dis.cfgs, nil
 }
 
-// Discovery is a fake Discovery service that returns.
+// Discovery is a fake Discovery service.
 type Discovery struct {
 	resource.Named
 	resource.TriviallyReconfigurable

--- a/module/module.go
+++ b/module/module.go
@@ -135,8 +135,10 @@ func NewHandlerMapFromProto(ctx context.Context, pMap *pb.HandlerMap, conn rpc.C
 	var errs error
 	for _, h := range pMap.GetHandlers() {
 		api := protoutils.ResourceNameFromProto(h.Subtype.Subtype).API
+		// due to how tagger is setup in the proto we cannot use reflection on the discovery service currently
+		// for now we will add any registered models without a description,
+		// and rely on the builtin registered discovery service instead.
 		if api == discovery.API {
-			fmt.Println("yos skip")
 			rpcAPI := &resource.RPCAPI{
 				API: api,
 			}
@@ -151,9 +153,6 @@ func NewHandlerMapFromProto(ctx context.Context, pMap *pb.HandlerMap, conn rpc.C
 		}
 		symDesc, err := reflSource.FindSymbol(h.Subtype.ProtoService)
 		if err != nil {
-			if api == discovery.API {
-				fmt.Println("yos error")
-			}
 			errs = multierr.Combine(errs, err)
 			if errors.Is(err, grpcurl.ErrReflectionNotSupported) {
 				return nil, errs

--- a/module/module.go
+++ b/module/module.go
@@ -140,6 +140,7 @@ func NewHandlerMapFromProto(ctx context.Context, pMap *pb.HandlerMap, conn rpc.C
 		}
 		// due to how tagger is setup in the api we cannot use reflection on the discovery service currently
 		// for now we will skip the reflection step for discovery until the issue is resolved.
+		// TODO(RSDK-9718) - remove the skip.
 		if api != discovery.API {
 			symDesc, err := reflSource.FindSymbol(h.Subtype.ProtoService)
 			if err != nil {

--- a/module/module_test.go
+++ b/module/module_test.go
@@ -212,16 +212,26 @@ func TestModuleFunctions(t *testing.T) {
 	t.Run("HandlerMap", func(t *testing.T) {
 		// test the raw return
 		handlers := resp.GetHandlermap().GetHandlers()
-		test.That(t, "acme", test.ShouldBeIn, handlers[0].Subtype.Subtype.Namespace, handlers[1].Subtype.Subtype.Namespace, handlers[2].Subtype.Subtype.Namespace)
-		test.That(t, "rdk", test.ShouldBeIn, handlers[0].Subtype.Subtype.Namespace, handlers[1].Subtype.Subtype.Namespace, handlers[2].Subtype.Subtype.Namespace)
-		test.That(t, "component", test.ShouldBeIn, handlers[0].Subtype.Subtype.Type, handlers[1].Subtype.Subtype.Type, handlers[2].Subtype.Subtype.Type)
-		test.That(t, "service", test.ShouldBeIn, handlers[0].Subtype.Subtype.Type, handlers[1].Subtype.Subtype.Type, handlers[2].Subtype.Subtype.Type)
-		test.That(t, "gizmo", test.ShouldBeIn, handlers[0].Subtype.Subtype.Subtype, handlers[1].Subtype.Subtype.Subtype, handlers[2].Subtype.Subtype.Subtype)
-		test.That(t, "base", test.ShouldBeIn, handlers[0].Subtype.Subtype.Subtype, handlers[1].Subtype.Subtype.Subtype, handlers[2].Subtype.Subtype.Subtype)
-		test.That(t, "discovery", test.ShouldBeIn, handlers[0].Subtype.Subtype.Subtype, handlers[1].Subtype.Subtype.Subtype, handlers[2].Subtype.Subtype.Subtype)
-		test.That(t, "acme:demo:mygizmo", test.ShouldBeIn, handlers[0].GetModels()[0], handlers[1].GetModels()[0], handlers[2].GetModels()[0])
-		test.That(t, "acme:demo:mybase", test.ShouldBeIn, handlers[0].GetModels()[0], handlers[1].GetModels()[0], handlers[2].GetModels()[0])
-		test.That(t, "acme:demo:mydiscovery", test.ShouldBeIn, handlers[0].GetModels()[0], handlers[1].GetModels()[0], handlers[2].GetModels()[0])
+		test.That(t, "acme", test.ShouldBeIn,
+			handlers[0].Subtype.Subtype.Namespace, handlers[1].Subtype.Subtype.Namespace, handlers[2].Subtype.Subtype.Namespace)
+		test.That(t, "rdk", test.ShouldBeIn,
+			handlers[0].Subtype.Subtype.Namespace, handlers[1].Subtype.Subtype.Namespace, handlers[2].Subtype.Subtype.Namespace)
+		test.That(t, "component", test.ShouldBeIn,
+			handlers[0].Subtype.Subtype.Type, handlers[1].Subtype.Subtype.Type, handlers[2].Subtype.Subtype.Type)
+		test.That(t, "service", test.ShouldBeIn,
+			handlers[0].Subtype.Subtype.Type, handlers[1].Subtype.Subtype.Type, handlers[2].Subtype.Subtype.Type)
+		test.That(t, "gizmo", test.ShouldBeIn,
+			handlers[0].Subtype.Subtype.Subtype, handlers[1].Subtype.Subtype.Subtype, handlers[2].Subtype.Subtype.Subtype)
+		test.That(t, "base", test.ShouldBeIn,
+			handlers[0].Subtype.Subtype.Subtype, handlers[1].Subtype.Subtype.Subtype, handlers[2].Subtype.Subtype.Subtype)
+		test.That(t, "discovery", test.ShouldBeIn,
+			handlers[0].Subtype.Subtype.Subtype, handlers[1].Subtype.Subtype.Subtype, handlers[2].Subtype.Subtype.Subtype)
+		test.That(t, "acme:demo:mygizmo", test.ShouldBeIn,
+			handlers[0].GetModels()[0], handlers[1].GetModels()[0], handlers[2].GetModels()[0])
+		test.That(t, "acme:demo:mybase", test.ShouldBeIn,
+			handlers[0].GetModels()[0], handlers[1].GetModels()[0], handlers[2].GetModels()[0])
+		test.That(t, "acme:demo:mydiscovery", test.ShouldBeIn,
+			handlers[0].GetModels()[0], handlers[1].GetModels()[0], handlers[2].GetModels()[0])
 
 		// convert from proto
 		hmap, err := module.NewHandlerMapFromProto(ctx, resp.GetHandlermap(), rpc.GrpcOverHTTPClientConn{ClientConn: conn})
@@ -230,27 +240,38 @@ func TestModuleFunctions(t *testing.T) {
 
 		for k, v := range hmap {
 			test.That(t, k.API, test.ShouldBeIn, gizmoapi.API, base.API, discovery.API)
-			if k.API == gizmoapi.API {
+			switch k.API {
+			case gizmoapi.API:
 				test.That(t, mygizmo.Model, test.ShouldResemble, v[0])
-			} else if k.API == discovery.API {
+			case discovery.API:
 				test.That(t, mydiscovery.Model, test.ShouldResemble, v[0])
-			} else {
+			default:
 				test.That(t, mybase.Model, test.ShouldResemble, v[0])
 			}
 		}
 
 		// convert back to proto
 		handlers2 := hmap.ToProto().GetHandlers()
-		test.That(t, "acme", test.ShouldBeIn, handlers2[0].Subtype.Subtype.Namespace, handlers2[1].Subtype.Subtype.Namespace, handlers2[2].Subtype.Subtype.Namespace)
-		test.That(t, "rdk", test.ShouldBeIn, handlers2[0].Subtype.Subtype.Namespace, handlers2[1].Subtype.Subtype.Namespace, handlers2[2].Subtype.Subtype.Namespace)
-		test.That(t, "component", test.ShouldBeIn, handlers2[0].Subtype.Subtype.Type, handlers2[1].Subtype.Subtype.Type, handlers2[2].Subtype.Subtype.Type)
-		test.That(t, "service", test.ShouldBeIn, handlers2[0].Subtype.Subtype.Type, handlers2[1].Subtype.Subtype.Type, handlers2[2].Subtype.Subtype.Type)
-		test.That(t, "gizmo", test.ShouldBeIn, handlers2[0].Subtype.Subtype.Subtype, handlers2[1].Subtype.Subtype.Subtype, handlers2[2].Subtype.Subtype.Subtype)
-		test.That(t, "base", test.ShouldBeIn, handlers2[0].Subtype.Subtype.Subtype, handlers2[1].Subtype.Subtype.Subtype, handlers2[2].Subtype.Subtype.Subtype)
-		test.That(t, "discovery", test.ShouldBeIn, handlers2[0].Subtype.Subtype.Subtype, handlers2[1].Subtype.Subtype.Subtype, handlers2[2].Subtype.Subtype.Subtype)
-		test.That(t, "acme:demo:mygizmo", test.ShouldBeIn, handlers2[0].GetModels()[0], handlers2[1].GetModels()[0], handlers[2].GetModels()[0])
-		test.That(t, "acme:demo:mybase", test.ShouldBeIn, handlers2[0].GetModels()[0], handlers2[1].GetModels()[0], handlers[2].GetModels()[0])
-		test.That(t, "acme:demo:mydiscovery", test.ShouldBeIn, handlers2[0].GetModels()[0], handlers2[1].GetModels()[0], handlers[2].GetModels()[0])
+		test.That(t, "acme", test.ShouldBeIn,
+			handlers2[0].Subtype.Subtype.Namespace, handlers2[1].Subtype.Subtype.Namespace, handlers2[2].Subtype.Subtype.Namespace)
+		test.That(t, "rdk", test.ShouldBeIn,
+			handlers2[0].Subtype.Subtype.Namespace, handlers2[1].Subtype.Subtype.Namespace, handlers2[2].Subtype.Subtype.Namespace)
+		test.That(t, "component", test.ShouldBeIn,
+			handlers2[0].Subtype.Subtype.Type, handlers2[1].Subtype.Subtype.Type, handlers2[2].Subtype.Subtype.Type)
+		test.That(t, "service", test.ShouldBeIn,
+			handlers2[0].Subtype.Subtype.Type, handlers2[1].Subtype.Subtype.Type, handlers2[2].Subtype.Subtype.Type)
+		test.That(t, "gizmo", test.ShouldBeIn,
+			handlers2[0].Subtype.Subtype.Subtype, handlers2[1].Subtype.Subtype.Subtype, handlers2[2].Subtype.Subtype.Subtype)
+		test.That(t, "base", test.ShouldBeIn,
+			handlers2[0].Subtype.Subtype.Subtype, handlers2[1].Subtype.Subtype.Subtype, handlers2[2].Subtype.Subtype.Subtype)
+		test.That(t, "discovery", test.ShouldBeIn,
+			handlers2[0].Subtype.Subtype.Subtype, handlers2[1].Subtype.Subtype.Subtype, handlers2[2].Subtype.Subtype.Subtype)
+		test.That(t, "acme:demo:mygizmo", test.ShouldBeIn,
+			handlers2[0].GetModels()[0], handlers2[1].GetModels()[0], handlers[2].GetModels()[0])
+		test.That(t, "acme:demo:mybase", test.ShouldBeIn,
+			handlers2[0].GetModels()[0], handlers2[1].GetModels()[0], handlers[2].GetModels()[0])
+		test.That(t, "acme:demo:mydiscovery", test.ShouldBeIn,
+			handlers2[0].GetModels()[0], handlers2[1].GetModels()[0], handlers[2].GetModels()[0])
 	})
 
 	t.Run("GetParentResource", func(t *testing.T) {

--- a/module/module_test.go
+++ b/module/module_test.go
@@ -150,11 +150,6 @@ func TestModuleFunctions(t *testing.T) {
 		Api:   "rdk:component:base",
 		Model: "acme:demo:mybase",
 	}
-	// discoveryConf := &v1.ComponentConfig{
-	// 	Name: "mydis1",
-	// 	Api: "rdk:service:discovery",
-	// 	Model: "acme:demo:mydiscovery",
-	// }
 
 	cfg := &config.Config{Components: []resource.Config{
 		{

--- a/module/module_test.go
+++ b/module/module_test.go
@@ -262,11 +262,11 @@ func TestModuleFunctions(t *testing.T) {
 		test.That(t, "discovery", test.ShouldBeIn,
 			handlers2[0].Subtype.Subtype.Subtype, handlers2[1].Subtype.Subtype.Subtype, handlers2[2].Subtype.Subtype.Subtype)
 		test.That(t, "acme:demo:mygizmo", test.ShouldBeIn,
-			handlers2[0].GetModels()[0], handlers2[1].GetModels()[0], handlers[2].GetModels()[0])
+			handlers2[0].GetModels()[0], handlers2[1].GetModels()[0], handlers2[2].GetModels()[0])
 		test.That(t, "acme:demo:mybase", test.ShouldBeIn,
-			handlers2[0].GetModels()[0], handlers2[1].GetModels()[0], handlers[2].GetModels()[0])
+			handlers2[0].GetModels()[0], handlers2[1].GetModels()[0], handlers2[2].GetModels()[0])
 		test.That(t, "acme:demo:mydiscovery", test.ShouldBeIn,
-			handlers2[0].GetModels()[0], handlers2[1].GetModels()[0], handlers[2].GetModels()[0])
+			handlers2[0].GetModels()[0], handlers2[1].GetModels()[0], handlers2[2].GetModels()[0])
 	})
 
 	t.Run("GetParentResource", func(t *testing.T) {

--- a/services/discovery/fake/fake.go
+++ b/services/discovery/fake/fake.go
@@ -1,0 +1,69 @@
+// Package fake implements a fake discovery service.
+package fake
+
+import (
+	"context"
+
+	"go.viam.com/rdk/components/movementsensor"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/services/discovery"
+)
+
+func init() {
+	resource.RegisterService(
+		discovery.API,
+		resource.DefaultModelFamily.WithModel("fake"),
+		resource.Registration[discovery.Service, resource.NoNativeConfig]{Constructor: func(
+			ctx context.Context,
+			deps resource.Dependencies,
+			conf resource.Config,
+			logger logging.Logger,
+		) (discovery.Service, error) {
+			return newDiscovery(conf.ResourceName(), logger), nil
+		}})
+}
+
+func newDiscovery(name resource.Name, logger logging.Logger) discovery.Service {
+	cfg1 := createFakeConfig("fake1")
+	cfg2 := createFakeConfig("fake2")
+	return &Discovery{Named: name.AsNamed(), logger: logger, cfgs: []resource.Config{cfg1, cfg2}}
+}
+
+func (dis *Discovery) DiscoverResources(context.Context, map[string]any) ([]resource.Config, error) {
+
+	return nil, nil
+}
+
+// Discovery is a fake Discovery service that returns
+type Discovery struct {
+	resource.Named
+	resource.TriviallyReconfigurable
+	resource.TriviallyCloseable
+	logger logging.Logger
+	cfgs   []resource.Config
+}
+
+// DoCommand echos input back to the caller.
+func (fg *Discovery) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+	return cmd, nil
+}
+
+func createFakeConfig(name string) resource.Config {
+	// // using the camera's Config struct in case a breaking change occurs
+	// attributes := viamrtsp.Config{Address: address}
+	// var result map[string]interface{}
+
+	// // marshal to bytes
+	// jsonBytes, err := json.Marshal(attributes)
+	// if err != nil {
+	// 	return resource.Config{}, err
+	// }
+
+	// // convert to map to be used as attributes in resource.Config
+	// err = json.Unmarshal(jsonBytes, &result)
+	// if err != nil {
+	// 	return resource.Config{}, err
+	// }
+	return resource.Config{Name: name, API: movementsensor.API, Model: resource.DefaultModelFamily.WithModel("fake"), Attributes: nil}
+}

--- a/services/discovery/fake/fake.go
+++ b/services/discovery/fake/fake.go
@@ -16,13 +16,20 @@ func init() {
 	resource.RegisterService(
 		discovery.API,
 		resource.DefaultModelFamily.WithModel("fake"),
-		resource.Registration[discovery.Service, resource.NoNativeConfig]{Constructor:  newDiscovery})
+		resource.Registration[discovery.Service, resource.NoNativeConfig]{Constructor: func(
+			ctx context.Context,
+			deps resource.Dependencies,
+			conf resource.Config,
+			logger logging.Logger,
+		) (discovery.Service, error) {
+			return newDiscovery(conf.ResourceName(), logger), nil
+		}})
 }
 
-func newDiscovery(_ context.Context, _ resource.Dependencies, conf resource.Config, logger logging.Logger ) discovery.Service {
+func newDiscovery(name resource.Name, logger logging.Logger) discovery.Service {
 	cfg1 := createFakeConfig("fake1", movementsensor.API, nil)
 	cfg2 := createFakeConfig("fake2", camera.API, nil)
-	return &Discovery{Named: conf.ResourceName().AsNamed(), logger: logger, cfgs: []resource.Config{cfg1, cfg2}}
+	return &Discovery{Named: name.AsNamed(), logger: logger, cfgs: []resource.Config{cfg1, cfg2}}
 }
 
 // DiscoverResources returns the discovered resources.
@@ -30,7 +37,7 @@ func (dis *Discovery) DiscoverResources(context.Context, map[string]any) ([]reso
 	return dis.cfgs, nil
 }
 
-// Discovery is a fake Discovery service.
+// Discovery is a fake Discovery service that returns.
 type Discovery struct {
 	resource.Named
 	resource.TriviallyReconfigurable

--- a/services/discovery/fake/fake.go
+++ b/services/discovery/fake/fake.go
@@ -4,10 +4,12 @@ package fake
 import (
 	"context"
 
+	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/components/movementsensor"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/services/discovery"
+	"go.viam.com/rdk/utils"
 )
 
 func init() {
@@ -25,8 +27,8 @@ func init() {
 }
 
 func newDiscovery(name resource.Name, logger logging.Logger) discovery.Service {
-	cfg1 := createFakeConfig("fake1")
-	cfg2 := createFakeConfig("fake2")
+	cfg1 := createFakeConfig("fake1", movementsensor.API, nil)
+	cfg2 := createFakeConfig("fake2", camera.API, nil)
 	return &Discovery{Named: name.AsNamed(), logger: logger, cfgs: []resource.Config{cfg1, cfg2}}
 }
 
@@ -48,7 +50,9 @@ func (fg *Discovery) DoCommand(ctx context.Context, cmd map[string]interface{}) 
 	return cmd, nil
 }
 
-func createFakeConfig(name string) resource.Config {
+// createFakeConfig creates a fake component with the defined name, api, and attributes.
+// additionally the commented code is an example of how to take a model's Config and convert it into Attributes for the api.
+func createFakeConfig(name string, api resource.API, attributes utils.AttributeMap) resource.Config {
 	// // using the camera's Config struct in case a breaking change occurs
 	// attributes := viamrtsp.Config{Address: address}
 	// var result map[string]interface{}
@@ -64,5 +68,5 @@ func createFakeConfig(name string) resource.Config {
 	// if err != nil {
 	// 	return resource.Config{}, err
 	// }
-	return resource.Config{Name: name, API: movementsensor.API, Model: resource.DefaultModelFamily.WithModel("fake"), Attributes: nil}
+	return resource.Config{Name: name, API: api, Model: resource.DefaultModelFamily.WithModel("fake"), Attributes: attributes}
 }

--- a/services/discovery/fake/fake.go
+++ b/services/discovery/fake/fake.go
@@ -32,11 +32,12 @@ func newDiscovery(name resource.Name, logger logging.Logger) discovery.Service {
 	return &Discovery{Named: name.AsNamed(), logger: logger, cfgs: []resource.Config{cfg1, cfg2}}
 }
 
+// DiscoverResources returns the discovered resources.
 func (dis *Discovery) DiscoverResources(context.Context, map[string]any) ([]resource.Config, error) {
 	return dis.cfgs, nil
 }
 
-// Discovery is a fake Discovery service that returns
+// Discovery is a fake Discovery service that returns.
 type Discovery struct {
 	resource.Named
 	resource.TriviallyReconfigurable
@@ -46,12 +47,14 @@ type Discovery struct {
 }
 
 // DoCommand echos input back to the caller.
-func (fg *Discovery) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+func (dis *Discovery) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
 	return cmd, nil
 }
 
 // createFakeConfig creates a fake component with the defined name, api, and attributes.
 // additionally the commented code is an example of how to take a model's Config and convert it into Attributes for the api.
+//
+//nolint:unparam
 func createFakeConfig(name string, api resource.API, attributes utils.AttributeMap) resource.Config {
 	// // using the camera's Config struct in case a breaking change occurs
 	// attributes := viamrtsp.Config{Address: address}

--- a/services/discovery/fake/fake.go
+++ b/services/discovery/fake/fake.go
@@ -16,20 +16,13 @@ func init() {
 	resource.RegisterService(
 		discovery.API,
 		resource.DefaultModelFamily.WithModel("fake"),
-		resource.Registration[discovery.Service, resource.NoNativeConfig]{Constructor: func(
-			ctx context.Context,
-			deps resource.Dependencies,
-			conf resource.Config,
-			logger logging.Logger,
-		) (discovery.Service, error) {
-			return newDiscovery(conf.ResourceName(), logger), nil
-		}})
+		resource.Registration[discovery.Service, resource.NoNativeConfig]{Constructor:  newDiscovery})
 }
 
-func newDiscovery(name resource.Name, logger logging.Logger) discovery.Service {
+func newDiscovery(_ context.Context, _ resource.Dependencies, conf resource.Config, logger logging.Logger ) discovery.Service {
 	cfg1 := createFakeConfig("fake1", movementsensor.API, nil)
 	cfg2 := createFakeConfig("fake2", camera.API, nil)
-	return &Discovery{Named: name.AsNamed(), logger: logger, cfgs: []resource.Config{cfg1, cfg2}}
+	return &Discovery{Named: conf.ResourceName().AsNamed(), logger: logger, cfgs: []resource.Config{cfg1, cfg2}}
 }
 
 // DiscoverResources returns the discovered resources.
@@ -37,7 +30,7 @@ func (dis *Discovery) DiscoverResources(context.Context, map[string]any) ([]reso
 	return dis.cfgs, nil
 }
 
-// Discovery is a fake Discovery service that returns.
+// Discovery is a fake Discovery service.
 type Discovery struct {
 	resource.Named
 	resource.TriviallyReconfigurable

--- a/services/discovery/fake/fake.go
+++ b/services/discovery/fake/fake.go
@@ -31,8 +31,7 @@ func newDiscovery(name resource.Name, logger logging.Logger) discovery.Service {
 }
 
 func (dis *Discovery) DiscoverResources(context.Context, map[string]any) ([]resource.Config, error) {
-
-	return nil, nil
+	return dis.cfgs, nil
 }
 
 // Discovery is a fake Discovery service that returns

--- a/services/discovery/fake/fake_test.go
+++ b/services/discovery/fake/fake_test.go
@@ -1,0 +1,34 @@
+package fake
+
+import (
+	"context"
+	"testing"
+
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/components/camera"
+	"go.viam.com/rdk/components/movementsensor"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/services/discovery"
+)
+
+func TestDiscoverResources(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewTestLogger(t)
+
+	dis := newDiscovery(discovery.Named("foo"), logger)
+
+	expectedCfgs := []resource.Config{
+		createFakeConfig("fake1", movementsensor.API, nil),
+		createFakeConfig("fake2", camera.API, nil),
+	}
+	cfgs, err := dis.DiscoverResources(ctx, nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, len(cfgs), test.ShouldEqual, len(expectedCfgs))
+	for index, cfg := range cfgs {
+		test.That(t, cfg.Name, test.ShouldEqual, expectedCfgs[index].Name)
+		test.That(t, cfg.API, test.ShouldEqual, expectedCfgs[index].API)
+		test.That(t, cfg.Model, test.ShouldEqual, expectedCfgs[index].Model)
+	}
+}

--- a/services/discovery/fake/fake_test.go
+++ b/services/discovery/fake/fake_test.go
@@ -28,7 +28,7 @@ func TestDiscoverResources(t *testing.T) {
 	test.That(t, len(cfgs), test.ShouldEqual, len(expectedCfgs))
 	for index, cfg := range cfgs {
 		test.That(t, cfg.Name, test.ShouldEqual, expectedCfgs[index].Name)
-		test.That(t, cfg.API, test.ShouldEqual, expectedCfgs[index].API)
-		test.That(t, cfg.Model, test.ShouldEqual, expectedCfgs[index].Model)
+		test.That(t, cfg.API, test.ShouldResemble, expectedCfgs[index].API)
+		test.That(t, cfg.Model, test.ShouldResemble, expectedCfgs[index].Model)
 	}
 }

--- a/services/discovery/register/register.go
+++ b/services/discovery/register/register.go
@@ -1,0 +1,7 @@
+// Package register registers all relevant discovery models and also API specific functions
+package register
+
+import (
+	// for discovery models.
+	_ "go.viam.com/rdk/services/discovery/fake"
+)

--- a/services/register/all.go
+++ b/services/register/all.go
@@ -5,6 +5,7 @@ import (
 	// register services.
 	_ "go.viam.com/rdk/services/baseremotecontrol/register"
 	_ "go.viam.com/rdk/services/datamanager/register"
+	_ "go.viam.com/rdk/services/discovery/register"
 	_ "go.viam.com/rdk/services/generic/register"
 	_ "go.viam.com/rdk/services/shell/register"
 	_ "go.viam.com/rdk/services/slam/register"


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-9655

in order to get around the tagger/proto reflection issue we saw when using the discovery service with modules, we are now skipping the reflection step for discovery apis, and relying on the builtin fake discovery service to register the proto definition. 

tested with a module that implements a discover service and some client code