### PR TITLE
RSDK-9440 Store initializing value at end of reconfigure not Reconfigure

### DIFF
--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -1105,9 +1105,6 @@ func (r *localRobot) Reconfigure(ctx context.Context, newConfig *config.Config) 
 	r.reconfigurationLock.Lock()
 	defer r.reconfigurationLock.Unlock()
 	r.reconfigure(ctx, newConfig, false)
-
-	// Set initializing value based on `newConfig.Initial`.
-	r.initializing.Store(newConfig.Initial)
 }
 
 // set Module.LocalVersion on Type=local modules. Call this before localPackages.Sync and in RestartModule.
@@ -1320,6 +1317,9 @@ func (r *localRobot) reconfigure(ctx context.Context, newConfig *config.Config, 
 	} else {
 		r.logger.CInfow(ctx, "Robot (re)configured")
 	}
+
+	// Set initializing value based on `newConfig.Initial`.
+	r.initializing.Store(newConfig.Initial)
 }
 
 // checkMaxInstance checks to see if the local robot has reached the maximum number of a specific resource type that are local.


### PR DESCRIPTION
My changes collided with @cheukt's a bit: `newWithResources` now calls `reconfigure` instead of `Reconfigure`, so the `r.initializing.Store(true)` does not happen, and the robot does not actually start in an initializing state when `config.Initial == true`.

To some extent, this proves how fragile the code I added is... But, at least the test I wrote will break if anyone moves things around.

(cc @dgottlieb but small so just got Cheuk as RLGTM)