### PR TITLE
APP-7377 registry modules on windows

### DIFF
--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -11,7 +11,9 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -68,6 +70,13 @@ func NewCloudManager(
 	packagesDir string,
 	logger logging.Logger,
 ) (ManagerSyncer, error) {
+	if runtime.GOOS == "windows" {
+		var err error
+		packagesDir, err = filepath.Abs(packagesDir)
+		if err != nil {
+			return nil, err
+		}
+	}
 	packagesDataDir := filepath.Join(packagesDir, "data")
 
 	if err := os.MkdirAll(packagesDir, 0o700); err != nil {

--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -238,6 +239,9 @@ func (m *cloudManager) validateAndGetChangedPackages(
 
 // Cleanup removes all unknown packages from the working directory.
 func (m *cloudManager) Cleanup(ctx context.Context) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
 	// Only allow one rdk process to operate on the manager at once. This is generally safe to keep locked for an extended period of time
 	// since the config reconfiguration process is handled by a single thread.
 	m.mu.Lock()

--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -70,13 +69,6 @@ func NewCloudManager(
 	packagesDir string,
 	logger logging.Logger,
 ) (ManagerSyncer, error) {
-	if runtime.GOOS == "windows" {
-		var err error
-		packagesDir, err = filepath.Abs(packagesDir)
-		if err != nil {
-			return nil, err
-		}
-	}
 	packagesDataDir := filepath.Join(packagesDir, "data")
 
 	if err := os.MkdirAll(packagesDir, 0o700); err != nil {

--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -239,7 +239,7 @@ func (m *cloudManager) validateAndGetChangedPackages(
 
 // Cleanup removes all unknown packages from the working directory.
 func (m *cloudManager) Cleanup(ctx context.Context) error {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == "windows" { //nolint:goconst
 		return nil
 	}
 	// Only allow one rdk process to operate on the manager at once. This is generally safe to keep locked for an extended period of time

--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"sync"

--- a/robot/packages/utils.go
+++ b/robot/packages/utils.go
@@ -391,6 +391,11 @@ func readStatusFile(pkg config.PackageConfig, packagesDir string) (packageSyncFi
 
 func writeStatusFile(pkg config.PackageConfig, statusFile packageSyncFile, packagesDir string) error {
 	syncFileName := getSyncFileName(pkg.LocalDataDirectory(packagesDir))
+	if runtime.GOOS == "windows" {
+		if err := os.MkdirAll(pkg.LocalDataDirectory(packagesDir), os.ModeDir); err != nil {
+			return err
+		}
+	}
 
 	statusFileBytes, err := json.MarshalIndent(statusFile, "", "  ")
 	if err != nil {

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -45,13 +45,12 @@ import (
 // SubtypeName is a constant that identifies the internal web resource subtype string.
 const (
 	SubtypeName = "web"
+	// TCPParentPort is the port of the parent socket when VIAM_TCP_MODE is set.
+	TCPParentPort = 14998
 	// TestTCPParentPort is the test suite version of TCPParentPort. It's different to avoid
 	// collisions; it's listed here for documentation.
 	TestTCPParentPort = 14999
 )
-
-// TCPParentPort is the auto-assigned port of the parent socket when VIAM_TCP_MODE is set.
-var TCPParentPort int
 
 // API is the fully qualified API for the internal web service.
 var API = resource.APINamespaceRDKInternal.WithServiceType(SubtypeName)
@@ -171,15 +170,8 @@ func (svc *webService) StartModule(ctx context.Context) error {
 		}
 
 		if rutils.ViamTCPSockets() {
-			addr = "127.0.0.1:0"
+			addr = "127.0.0.1:" + strconv.Itoa(TCPParentPort)
 			lis, err = net.Listen("tcp", addr)
-			tokens := strings.Split(lis.Addr().String(), ":")
-			port, err := strconv.Atoi(tokens[len(tokens)-1])
-			if err != nil {
-				return errors.WithMessage(err, "couldn't parse auto-assigned port")
-			}
-			TCPParentPort = port
-			svc.logger.Infof("listening on auto-assigned port %d", TCPParentPort)
 		} else {
 			addr, err = module.CreateSocketAddress(dir, "parent")
 			if err != nil {

--- a/utils/env.go
+++ b/utils/env.go
@@ -70,7 +70,7 @@ func PlatformHomeDir() string {
 		return AndroidFilesDir
 	}
 	if runtime.GOOS == "windows" {
-		homedir, _ := os.UserHomeDir()
+		homedir, _ := os.UserHomeDir() //nolint:errcheck
 		if homedir != "" {
 			return homedir
 		}

--- a/utils/env.go
+++ b/utils/env.go
@@ -69,6 +69,12 @@ func PlatformHomeDir() string {
 	if runtime.GOOS == "android" {
 		return AndroidFilesDir
 	}
+	if runtime.GOOS == "windows" {
+		homedir, _ := os.UserHomeDir()
+		if homedir != "" {
+			return homedir
+		}
+	}
 	return os.Getenv("HOME")
 }
 


### PR DESCRIPTION
## What changed
note all of these are behind goos==windows guards:
- in `installPackage`, delete rename destination before renaming (to prevent permission error)
- homedir hack to satisfy abs path checks
- temporarily flag off cloudManager.Cleanup
## Why
Initial support for registry modules on windows. Some of these require follow-ups (in particularly `cloudManager.Cleanup`).