### PR TITLE
RSDK-9286 - simplify org-location-machine-part hierarchy

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -1327,7 +1327,7 @@ var app = &cli.App{
 							Usage: "removes binary data with file IDs in a single org and location from dataset",
 							UsageText: createUsageText("dataset data remove",
 								[]string{datasetFlagDatasetID, generalFlagOrgID, dataFlagLocationID, dataFlagFileIDs}, false),
-							// TODO(RSDK-9286) do we need to ask for og and location here?
+							// CR erodkin: we need these because currently the way the Data APIs work, if you don't pass the primary org ID then it won't work correctly and I don't think we can properly infer which one is the "correct" one. We could do something hacky! but probably better to leave this to data to fix, and flag this to reviewers in the meantime.
 							Flags: []cli.Flag{
 								&cli.StringFlag{
 									Name:     datasetFlagDatasetID,
@@ -1652,8 +1652,14 @@ var app = &cli.App{
 					Name:      "status",
 					Usage:     "display machine status",
 					UsageText: createUsageText("machines status", []string{generalFlagMachine}, true),
-					// TODO(RSDK-9286) - do we need to ask for all three of these?
 					Flags: []cli.Flag{
+						&AliasStringFlag{
+							cli.StringFlag{
+								Name:     generalFlagMachine,
+								Aliases:  []string{generalFlagAliasRobot, generalFlagMachineID, generalFlagAliasMachineName},
+								Required: true,
+							},
+						},
 						&cli.StringFlag{
 							Name:        generalFlagOrganization,
 							Aliases:     []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
@@ -1663,13 +1669,6 @@ var app = &cli.App{
 							Name:        generalFlagLocation,
 							Aliases:     []string{generalFlagLocationID, generalFlagAliasLocationName},
 							DefaultText: "first location alphabetically",
-						},
-						&AliasStringFlag{
-							cli.StringFlag{
-								Name:     generalFlagMachine,
-								Aliases:  []string{generalFlagAliasRobot, generalFlagMachineID, generalFlagAliasMachineName},
-								Required: true,
-							},
 						},
 					},
 					Action: createCommandWithT[robotsStatusArgs](RobotsStatusAction),
@@ -1679,8 +1678,14 @@ var app = &cli.App{
 					Aliases:   []string{"log"},
 					Usage:     "display machine logs",
 					UsageText: createUsageText("machines logs", []string{generalFlagMachine}, true),
-					// TODO(RSDK-9286) do we need to ask for og and location and machine here?
 					Flags: []cli.Flag{
+						&AliasStringFlag{
+							cli.StringFlag{
+								Name:     generalFlagMachine,
+								Aliases:  []string{generalFlagAliasRobot, generalFlagMachineID, generalFlagAliasMachineName},
+								Required: true,
+							},
+						},
 						&cli.StringFlag{
 							Name:        generalFlagOrganization,
 							Aliases:     []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
@@ -1690,13 +1695,6 @@ var app = &cli.App{
 							Name:        generalFlagLocation,
 							Aliases:     []string{generalFlagLocationID, generalFlagAliasLocationName},
 							DefaultText: "first location alphabetically",
-						},
-						&AliasStringFlag{
-							cli.StringFlag{
-								Name:     generalFlagMachine,
-								Aliases:  []string{generalFlagAliasRobot, generalFlagMachineID, generalFlagAliasMachineName},
-								Required: true,
-							},
 						},
 						&cli.StringFlag{
 							Name:  logsFlagOutputFile,
@@ -1727,8 +1725,14 @@ var app = &cli.App{
 							Name:      "status",
 							Usage:     "display part status",
 							UsageText: createUsageText("machines part status", []string{generalFlagMachine, generalFlagPart}, true),
-							// TODO(RSDK-9286) do we need to ask for og and location and machine and part here?
 							Flags: []cli.Flag{
+								&AliasStringFlag{
+									cli.StringFlag{
+										Name:     generalFlagPart,
+										Aliases:  []string{generalFlagPartID, generalFlagAliasPartName},
+										Required: true,
+									},
+								},
 								&cli.StringFlag{
 									Name:        generalFlagOrganization,
 									Aliases:     []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
@@ -1741,16 +1745,8 @@ var app = &cli.App{
 								},
 								&AliasStringFlag{
 									cli.StringFlag{
-										Name:     generalFlagMachine,
-										Aliases:  []string{generalFlagAliasRobot, generalFlagMachineID, generalFlagAliasMachineName},
-										Required: true,
-									},
-								},
-								&AliasStringFlag{
-									cli.StringFlag{
-										Name:     generalFlagPart,
-										Aliases:  []string{generalFlagPartID, generalFlagAliasPartName},
-										Required: true,
+										Name:    generalFlagMachine,
+										Aliases: []string{generalFlagAliasRobot, generalFlagMachineID, generalFlagAliasMachineName},
 									},
 								},
 							},
@@ -1762,6 +1758,13 @@ var app = &cli.App{
 							Usage:     "display part logs",
 							UsageText: createUsageText("machines part logs", []string{generalFlagMachine, generalFlagPart}, true),
 							Flags: []cli.Flag{
+								&AliasStringFlag{
+									cli.StringFlag{
+										Name:     generalFlagPart,
+										Aliases:  []string{generalFlagPartID, generalFlagAliasPartName},
+										Required: true,
+									},
+								},
 								&cli.StringFlag{
 									Name:        generalFlagOrganization,
 									Aliases:     []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
@@ -1774,16 +1777,8 @@ var app = &cli.App{
 								},
 								&AliasStringFlag{
 									cli.StringFlag{
-										Name:     generalFlagMachine,
-										Aliases:  []string{generalFlagAliasRobot, generalFlagMachineID, generalFlagAliasMachineName},
-										Required: true,
-									},
-								},
-								&AliasStringFlag{
-									cli.StringFlag{
-										Name:     generalFlagPart,
-										Aliases:  []string{generalFlagPartID, generalFlagAliasPartName},
-										Required: true,
+										Name:    generalFlagMachine,
+										Aliases: []string{generalFlagAliasRobot, generalFlagMachineID, generalFlagAliasMachineName},
 									},
 								},
 								&cli.BoolFlag{
@@ -1808,8 +1803,14 @@ var app = &cli.App{
 							Aliases:   []string{},
 							Usage:     "request part restart",
 							UsageText: createUsageText("machines part restart", []string{generalFlagMachine, generalFlagPart}, true),
-							// TODO(RSDK-9286) revisit flags
 							Flags: []cli.Flag{
+								&AliasStringFlag{
+									cli.StringFlag{
+										Name:     generalFlagPart,
+										Aliases:  []string{generalFlagPartID, generalFlagAliasPartName},
+										Required: true,
+									},
+								},
 								&cli.StringFlag{
 									Name:        generalFlagOrganization,
 									Aliases:     []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
@@ -1822,16 +1823,8 @@ var app = &cli.App{
 								},
 								&AliasStringFlag{
 									cli.StringFlag{
-										Name:     generalFlagMachine,
-										Aliases:  []string{generalFlagAliasRobot, generalFlagMachineID, generalFlagAliasMachineName},
-										Required: true,
-									},
-								},
-								&AliasStringFlag{
-									cli.StringFlag{
-										Name:     generalFlagPart,
-										Aliases:  []string{generalFlagPartID, generalFlagAliasPartName},
-										Required: true,
+										Name:    generalFlagMachine,
+										Aliases: []string{generalFlagAliasRobot, generalFlagMachineID, generalFlagAliasMachineName},
 									},
 								},
 							},
@@ -1846,30 +1839,27 @@ var app = &cli.App{
 							Flags: []cli.Flag{
 								&AliasStringFlag{
 									cli.StringFlag{
-										Name:     generalFlagOrganization,
-										Aliases:  []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
-										Required: true,
-									},
-								},
-								&AliasStringFlag{
-									cli.StringFlag{
-										Name:     generalFlagLocation,
-										Aliases:  []string{generalFlagLocationID, generalFlagAliasLocationName},
-										Required: true,
-									},
-								},
-								&AliasStringFlag{
-									cli.StringFlag{
-										Name:     generalFlagMachine,
-										Aliases:  []string{generalFlagAliasRobot, generalFlagMachineID, generalFlagAliasMachineName},
-										Required: true,
-									},
-								},
-								&AliasStringFlag{
-									cli.StringFlag{
 										Name:     generalFlagPart,
 										Aliases:  []string{generalFlagPartID, generalFlagAliasPartName},
 										Required: true,
+									},
+								},
+								&AliasStringFlag{
+									cli.StringFlag{
+										Name:    generalFlagOrganization,
+										Aliases: []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
+									},
+								},
+								&AliasStringFlag{
+									cli.StringFlag{
+										Name:    generalFlagLocation,
+										Aliases: []string{generalFlagLocationID, generalFlagAliasLocationName},
+									},
+								},
+								&AliasStringFlag{
+									cli.StringFlag{
+										Name:    generalFlagMachine,
+										Aliases: []string{generalFlagAliasRobot, generalFlagMachineID, generalFlagAliasMachineName},
 									},
 								},
 								&cli.StringFlag{
@@ -1888,10 +1878,14 @@ var app = &cli.App{
 							Usage:       "start a shell on a machine part",
 							Description: `In order to use the shell command, the machine must have a valid shell type service.`,
 							UsageText: createUsageText(
-								"machines part shell", []string{generalFlagOrganization, generalFlagLocation, generalFlagMachine, generalFlagPart}, false,
+								"machines part shell", []string{generalFlagMachine, generalFlagPart}, false,
 							),
-							// TODO(RSDK-9286) do we need to ask for og and location and machine and part here?
 							Flags: []cli.Flag{
+								&cli.StringFlag{
+									Name:     generalFlagPart,
+									Aliases:  []string{generalFlagPartID, generalFlagAliasPartName},
+									Required: true,
+								},
 								&cli.StringFlag{
 									Name:    generalFlagOrganization,
 									Aliases: []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
@@ -1905,10 +1899,6 @@ var app = &cli.App{
 										Name:    generalFlagMachine,
 										Aliases: []string{generalFlagAliasRobot, generalFlagMachineID, generalFlagAliasMachineName},
 									},
-								},
-								&cli.StringFlag{
-									Name:    generalFlagPart,
-									Aliases: []string{generalFlagPartID, generalFlagAliasPartName},
 								},
 							},
 							Action: createCommandWithT[robotsPartShellArgs](RobotsPartShellAction),
@@ -1948,6 +1938,13 @@ Copy multiple files from the machine to a local destination with recursion and k
 								true,
 								"[-p] [-r] source ([machine:]files) ... target ([machine:]files"),
 							Flags: []cli.Flag{
+								&AliasStringFlag{
+									cli.StringFlag{
+										Name:     generalFlagPart,
+										Aliases:  []string{generalFlagPartID, generalFlagAliasPartName},
+										Required: true,
+									},
+								},
 								&cli.StringFlag{
 									Name:    generalFlagOrganization,
 									Aliases: []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
@@ -1958,16 +1955,8 @@ Copy multiple files from the machine to a local destination with recursion and k
 								},
 								&AliasStringFlag{
 									cli.StringFlag{
-										Name:     generalFlagMachine,
-										Aliases:  []string{generalFlagAliasRobot, generalFlagMachineID, generalFlagAliasMachineName},
-										Required: true,
-									},
-								},
-								&AliasStringFlag{
-									cli.StringFlag{
-										Name:     generalFlagPart,
-										Aliases:  []string{generalFlagPartID, generalFlagAliasPartName},
-										Required: true,
+										Name:    generalFlagMachine,
+										Aliases: []string{generalFlagAliasRobot, generalFlagMachineID, generalFlagAliasMachineName},
 									},
 								},
 								&cli.BoolFlag{


### PR DESCRIPTION
Minimizes the information needed when working with the org/location/machine/part hierarchy. We continue to allow for all information to be passed and indicate as such because the way information is passed alters what's necessary, i.e. passing just part is okay if we pass the part ID, but _not_ if we pass the part name.

As a flyby, updates the way the hierarchy is shared to ensure accuracy. Previously, if we passed just a machine ID and a part ID, we'd list the org and location as the alphabetically first ones even when that wasn't correct.

Tested locally by running commands with minimized information, ensured no change in behavior.