### PR TITLE
RSDK-9356 Bump timeout slightly for TestFirstRun/with_timeout

### DIFF
--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -1717,7 +1717,7 @@ func TestFirstRun(t *testing.T) {
 		modCfg := config.Module{
 			Name:            "test-module",
 			ExePath:         exePath,
-			FirstRunTimeout: utils.Duration(1 * time.Millisecond),
+			FirstRunTimeout: utils.Duration(100 * time.Millisecond),
 		}
 		err := mgr.FirstRun(ctx, modCfg)
 		test.That(t, err, test.ShouldNotBeNil)


### PR DESCRIPTION
RDSK-9356

1ms timeout, as @dgottlieb diagnosed, was sometimes not enough time to actually let the first run script start, so we got did not get the expected error. Bumping to 100ms should definitely be enough time for the script to start while still not being a high enough value to allow `module/testmodule/first_run.sh` to complete (as it calls `sleep 1` internally.)