### PR TITLE
RSDK-8217 Add client logs to CLI tests

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -1152,17 +1152,6 @@ func MachinesPartCopyFilesAction(c *cli.Context, args machinesPartCopyFilesArgs)
 		return err
 	}
 
-	return machinesPartCopyFilesAction(c, client, args)
-}
-
-func machinesPartCopyFilesAction(c *cli.Context, client *viamClient, flagArgs machinesPartCopyFilesArgs) error {
-	// TODO(RSDK-9288) - this is brittle and inconsistent with how most data is passed.
-	// Move this to being a flag (but make sure existing workflows still work!)
-	args := c.Args().Slice()
-	if len(args) == 0 {
-		return errNoFiles
-	}
-
 	// Create logger based on presence of debugFlag.
 	logger := logging.FromZapCompatible(zap.NewNop().Sugar())
 	globalArgs, err := getGlobalArgs(c)
@@ -1171,6 +1160,22 @@ func machinesPartCopyFilesAction(c *cli.Context, client *viamClient, flagArgs ma
 	}
 	if globalArgs.Debug {
 		logger = logging.NewDebugLogger("cli")
+	}
+
+	return machinesPartCopyFilesAction(c, client, args, logger)
+}
+
+func machinesPartCopyFilesAction(
+	c *cli.Context,
+	client *viamClient,
+	flagArgs machinesPartCopyFilesArgs,
+	logger logging.Logger,
+) error {
+	// TODO(RSDK-9288) - this is brittle and inconsistent with how most data is passed.
+	// Move this to being a flag (but make sure existing workflows still work!)
+	args := c.Args().Slice()
+	if len(args) == 0 {
+		return errNoFiles
 	}
 
 	// the general format is
@@ -1210,6 +1215,11 @@ func machinesPartCopyFilesAction(c *cli.Context, client *viamClient, flagArgs ma
 	}
 
 	isFrom, destination, paths, err := determineDirection(args)
+	if err != nil {
+		return err
+	}
+
+	globalArgs, err := getGlobalArgs(c)
 	if err != nil {
 		return err
 	}

--- a/cli/module_reload_test.go
+++ b/cli/module_reload_test.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	rdkConfig "go.viam.com/rdk/config"
+	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/testutils/inject"
 )
 
@@ -31,6 +32,8 @@ func TestConfigureModule(t *testing.T) {
 }
 
 func TestFullReloadFlow(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+
 	manifestPath := createTestManifest(t, "")
 	confStruct, err := structpb.NewStruct(map[string]any{
 		"modules": []any{},
@@ -67,7 +70,7 @@ func TestFullReloadFlow(t *testing.T) {
 		"token",
 	)
 	test.That(t, vc.loginAction(cCtx), test.ShouldBeNil)
-	err = reloadModuleAction(cCtx, vc, parseStructFromCtx[reloadModuleArgs](cCtx))
+	err = reloadModuleAction(cCtx, vc, parseStructFromCtx[reloadModuleArgs](cCtx), logger)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, updateCount, test.ShouldEqual, 1)
 


### PR DESCRIPTION
RSDK-8217

Allows passing in loggers to CLI actions that establish connections to machines with `client.New`. Passes in test loggers to those actions during testing.

This will not necessarily _ensure_ we're outputting debug client logs from future tests that end up calling `client.New`, but, from what I can tell, that's not super trivial to ensure, and my guess is this ticket was mostly to make sure we can see debug logs from the shell service tests.