### PR TITLE
RSDK-9726 - improve modulegen help text and deprecate resource-type flag

### DIFF
--- a/.github/workflows/test-module-generation.yml
+++ b/.github/workflows/test-module-generation.yml
@@ -13,29 +13,29 @@ jobs:
         language: ["python", "go"]
         resource:
           [
-            { subtype: "arm", type: "component" },
-            { subtype: "audio_input", type: "component" },
-            { subtype: "base", type: "component" },
-            { subtype: "board", type: "component" },
-            { subtype: "camera", type: "component" },
-            { subtype: "encoder", type: "component" },
-            { subtype: "gantry", type: "component" },
-            { subtype: "generic", type: "component" },
-            { subtype: "gripper", type: "component" },
-            { subtype: "input", type: "component" },
-            { subtype: "motor", type: "component" },
-            { subtype: "movement_sensor", type: "component" },
-            { subtype: "pose_tracker", type: "component" },
-            { subtype: "power_sensor", type: "component" },
-            { subtype: "sensor", type: "component" },
-            { subtype: "servo", type: "component" },
+            { subtype: "arm" },
+            { subtype: "audio_input" },
+            { subtype: "base" },
+            { subtype: "board" },
+            { subtype: "camera" },
+            { subtype: "encoder" },
+            { subtype: "gantry" },
+            { subtype: "generic_component" },
+            { subtype: "gripper" },
+            { subtype: "input" },
+            { subtype: "motor" },
+            { subtype: "movement_sensor" },
+            { subtype: "pose_tracker" },
+            { subtype: "power_sensor" },
+            { subtype: "sensor" },
+            { subtype: "servo" },
 
-            { subtype: "generic", type: "service" },
-            { subtype: "mlmodel", type: "service" },
-            { subtype: "motion", type: "service" },
-            { subtype: "navigation", type: "service" },
-            { subtype: "slam", type: "service" },
-            { subtype: "vision", type: "service" },
+            { subtype: "generic-service" },
+            { subtype: "mlmodel" },
+            { subtype: "motion" },
+            { subtype: "navigation" },
+            { subtype: "slam" },
+            { subtype: "vision" },
           ]
     steps:
       - name: Checkout Code
@@ -53,7 +53,6 @@ jobs:
           --language "${{ matrix.language }}" \
           --public-namespace "my-org" \
           --resource-subtype "${{ matrix.resource.subtype }}" \
-          --resource-type "${{ matrix.resource.type }}" \
           --model-name "model-name" \
           --dry-run
 

--- a/cli/app.go
+++ b/cli/app.go
@@ -2242,13 +2242,6 @@ After creation, use 'viam module update' to push your new module to app.viam.com
 						},
 					},
 					Action: createCommandWithT[generateModuleArgs](GenerateModuleAction),
-					UsageText: createUsageText("module generate", []string{
-						generalFlagName,
-						moduleFlagLanguage,
-						generalFlagResourceSubtype,
-						moduleFlagModelName,
-						moduleFlagPublicNamespace,
-					}, true, false),
 				},
 				{
 					Name:      "update",

--- a/cli/app.go
+++ b/cli/app.go
@@ -2195,31 +2195,37 @@ After creation, use 'viam module update' to push your new module to app.viam.com
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:  generalFlagName,
-							Usage: "name to use for module",
+							Usage: "name to use for module. for example, a module that contains sensor implementations might be named 'sensors'",
 						},
 						&cli.StringFlag{
 							Name:  moduleFlagLanguage,
-							Usage: "language to use for module",
+							Usage: formatAcceptedValues("language to use for module", supportedModuleGenLanguages...),
 						},
 						&cli.BoolFlag{
 							Name:  moduleFlagIsPublic,
 							Usage: "set module to public",
 						},
 						&cli.StringFlag{
-							Name:  moduleFlagPublicNamespace,
-							Usage: "namespace or organization ID of module",
+							Name: moduleFlagPublicNamespace,
+							Usage: "namespace or organization ID of module. " +
+								"must be either a valid organization ID, or a namespace that exists within a user organization",
 						},
 						&cli.StringFlag{
-							Name:  generalFlagResourceSubtype,
-							Usage: "resource subtype to use in module",
+							Name: generalFlagResourceSubtype,
+							Usage: "resource subtype to use in module, for example arm, camera, or motion. see " +
+								"https://docs.viam.com/dev/reference/glossary/#term-subtype for more details",
+						},
+						// This is unnecessary and creates a gotcha for users. Kept here
+						// because it's technically breaking to remove it, but it's hidden
+						// and serves no purpose.
+						&cli.StringFlag{
+							Name:   moduleFlagResourceType,
+							Hidden: true,
 						},
 						&cli.StringFlag{
-							Name:  moduleFlagResourceType,
-							Usage: "resource type to use in module",
-						},
-						&cli.StringFlag{
-							Name:  moduleFlagModelName,
-							Usage: "resource model name to use in module",
+							Name: moduleFlagModelName,
+							Usage: "name for the particular resource subtype implementation." +
+								" for example, a sensor model that detects moisture might be named 'moisture'",
 						},
 						&cli.BoolFlag{
 							Name:  moduleFlagEnableCloud,
@@ -2236,6 +2242,13 @@ After creation, use 'viam module update' to push your new module to app.viam.com
 						},
 					},
 					Action: createCommandWithT[generateModuleArgs](GenerateModuleAction),
+					UsageText: createUsageText("module generate", []string{
+						generalFlagName,
+						moduleFlagLanguage,
+						generalFlagResourceSubtype,
+						moduleFlagModelName,
+						moduleFlagPublicNamespace,
+					}, true, false),
 				},
 				{
 					Name:      "update",

--- a/cli/module_generate.go
+++ b/cli/module_generate.go
@@ -205,7 +205,16 @@ func promptUser(module *modulegen.ModuleInputs) error {
 				words[i] = titleCaser.String(word)
 			}
 		}
-		resourceOptions = append(resourceOptions, huh.NewOption(strings.Join(words, " "), resource))
+		// we differentiate generic-service and generic-component in `modulegen.Resources`
+		// but they still have the type listed. This carveout prevents the user prompt from
+		// suggesting `Generic Component Component` or `Generic Service Service` as an option
+		var resType string
+		if words[0] == "Generic" {
+			resType = strings.Join(words[:2], " ")
+		} else {
+			resType = strings.Join(words, " ")
+		}
+		resourceOptions = append(resourceOptions, huh.NewOption(resType, resource))
 	}
 	form := huh.NewForm(
 		huh.NewGroup(

--- a/cli/module_generate.go
+++ b/cli/module_generate.go
@@ -336,13 +336,10 @@ func populateAdditionalInfo(newModule *modulegen.ModuleInputs) {
 	newModule.GeneratedOn = time.Now().UTC()
 	newModule.GeneratorVersion = version
 	// TODO(RSDK-9727) - this is a bit inefficient because `newModule.Resource` is set above in
-	// `generateModuleAction` based on `ResourceType` and `ResourceSubtype`! Since this is always
-	// called and this setting is unqualified, we end up just repeating work here.
-	//
-	// update: actually not sure that's true, at least in cases where the user doesn't provide
-	// info and so it's being set in the `promptUser` call. I wonder if we can avoid the duplicate
-	// work in the "user passed info" case while still functioning properly in the "user didn't pass info"
-	// case?
+	// `generateModuleAction` based on `ResourceType` and `ResourceSubtype`, which are then
+	// overwritten based on `newModule.Resource`! Unfortunately fixing this is slightly complicated
+	// due to cases where a user didn't pass a `ResourceSubtype`, and so it was set in the `promptUser`
+	// call. We should look into simplifying though, such that all these values are only ever set once.
 	newModule.ResourceSubtype = strings.Split(newModule.Resource, " ")[0]
 	newModule.ResourceType = strings.Split(newModule.Resource, " ")[1]
 

--- a/cli/module_generate/modulegen/inputs.go
+++ b/cli/module_generate/modulegen/inputs.go
@@ -87,7 +87,7 @@ func (inputs *ModuleInputs) HasEmptyInput() bool {
 	return false
 }
 
-// SpaceReplacer removes spaces, dashes, and underscores from a string
+// SpaceReplacer removes spaces, dashes, and underscores from a string.
 var SpaceReplacer = strings.NewReplacer(" ", "", "_", "", "-", "")
 
 // CheckResourceAndSetType checks if the given resource subtype is valid, and sets the corresponding resource type if so.

--- a/cli/module_generate/modulegen/inputs.go
+++ b/cli/module_generate/modulegen/inputs.go
@@ -96,7 +96,7 @@ func (inputs *ModuleInputs) CheckResourceAndSetType() error {
 		return nil
 	}
 	if inputs.ResourceSubtype == "generic" {
-		return fmt.Errorf(
+		return errors.New(
 			"resource subtype 'generic' cannot be differentiated; please specify either 'generic-service' or 'generic-component'")
 	}
 	for _, resource := range Resources {


### PR DESCRIPTION
Provides improved help text in terms of the `usage` invocation, as well as clarifying the role/usage of the `language`, `model-name`, `name`, `public-namespace`, and `resource-subtype` flags.

Additionally, removes `resource-type` as a flag we pay attention to/care about. While still supported for backwards compatibility, it is invisible and ignored. This flag is a gotcha since each subtype only has one valid type (except generic, but we can carve out a specific case for that), and a user shouldn't reasonably be expected to understand the component/service distinction that is primarily internal.

Tested by creating modules using both old and new code and diffing them to ensure no changes in behavior.

Old help text:
```
NAME:
   viam module generate - generate a new modular resource via prompts

USAGE:
   viam module generate [command options] [arguments...]

OPTIONS:
   --enable-cloud            generate Github workflows to build module (default: false)
   --language value          language to use for module
   --model-name value        resource model name to use in module
   --name value              name to use for module
   --public                  set module to public (default: false)
   --public-namespace value  namespace or organization ID of module
   --register                register module with Viam to associate with your organization (default: false)
   --resource-subtype value  resource subtype to use in module
   --resource-type value     resource type to use
```

New help text:
```
NAME:
   viam module generate - generate a new modular resource via prompts

USAGE:
   viam module generate --name=<name> --language=<language> --resource-subtype=<resource-subtype> --model-name=<model-name> --public-namespace=<public-namespace> [other options]

OPTIONS:
   --enable-cloud            generate Github workflows to build module (default: false)
   --language value          language to use for module, can be one of [python, go]
   --model-name value        name for the particular resource subtype implementation. for example, a sensor model that detects moisture might be named 'moisture'
   --name value              name to use for module. for example, a module that contains sensor implementations might be named 'sensors'
   --public                  set module to public (default: false)
   --public-namespace value  namespace or organization ID of module. must be either a valid organization ID, or a namespace that exists within a user organization
   --register                register module with Viam to associate with your organization (default: false)
   --resource-subtype value  resource subtype to use in module, for example arm, camera, or motion. see https://docs.viam.com/dev/reference/glossary/#term-subtype for more details
```