### PR TITLE
[RSDK-9754] Remove webcam discovery logic

### DIFF
--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"image"
 	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
@@ -20,7 +19,6 @@ import (
 	"github.com/pion/mediadevices/pkg/prop"
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
-	pb "go.viam.com/api/component/camera/v1"
 	goutils "go.viam.com/utils"
 
 	"go.viam.com/rdk/components/camera"
@@ -39,99 +37,16 @@ var intrinsics []byte
 
 var data map[string]transform.PinholeCameraIntrinsics
 
-// getVideoDrivers is a helper callback passed to the registered Discover func to get all video drivers.
-func getVideoDrivers() []driver.Driver {
-	return driver.GetManager().Query(driver.FilterVideoRecorder())
-}
-
 func init() {
 	resource.RegisterComponent(
 		camera.API,
 		ModelWebcam,
 		resource.Registration[camera.Camera, *WebcamConfig]{
 			Constructor: NewWebcam,
-			Discover: func(ctx context.Context, logger logging.Logger, extra map[string]interface{}) (interface{}, error) {
-				return Discover(ctx, getVideoDrivers, logger)
-			},
 		})
 	if err := json.Unmarshal(intrinsics, &data); err != nil {
 		logging.Global().Errorw("cannot parse intrinsics json", "error", err)
 	}
-}
-
-// getProperties is a helper func for webcam discovery that returns the Media properties of a specific driver.
-// It is NOT related to the GetProperties camera proto API.
-func getProperties(d driver.Driver) (_ []prop.Media, err error) {
-	// Need to open driver to get properties
-	if d.Status() == driver.StateClosed {
-		errOpen := d.Open()
-		if errOpen != nil {
-			return nil, errOpen
-		}
-		defer func() {
-			if errClose := d.Close(); errClose != nil {
-				err = errClose
-			}
-		}()
-	}
-	return d.Properties(), err
-}
-
-// Discover webcam attributes.
-func Discover(ctx context.Context, getDrivers func() []driver.Driver, logger logging.Logger) (*pb.Webcams, error) {
-	mediadevicescamera.Initialize()
-	var webcams []*pb.Webcam
-	drivers := getDrivers()
-	for _, d := range drivers {
-		driverInfo := d.Info()
-
-		props, err := getProperties(d)
-		if len(props) == 0 {
-			logger.CDebugw(ctx, "no properties detected for driver, skipping discovery...", "driver", driverInfo.Label)
-			continue
-		} else if err != nil {
-			logger.CDebugw(ctx, "cannot access driver properties, skipping discovery...", "driver", driverInfo.Label, "error", err)
-			continue
-		}
-
-		if d.Status() == driver.StateRunning {
-			logger.CDebugw(ctx, "driver is in use, skipping discovery...", "driver", driverInfo.Label)
-			continue
-		}
-
-		labelParts := strings.Split(driverInfo.Label, mediadevicescamera.LabelSeparator)
-		label := labelParts[0]
-
-		name, id := func() (string, string) {
-			nameParts := strings.Split(driverInfo.Name, mediadevicescamera.LabelSeparator)
-			if len(nameParts) > 1 {
-				return nameParts[0], nameParts[1]
-			}
-			// fallback to the label if the name does not have an any additional parts to use.
-			return nameParts[0], label
-		}()
-
-		wc := &pb.Webcam{
-			Name:       name,
-			Id:         id,
-			Label:      label,
-			Status:     string(d.Status()),
-			Properties: make([]*pb.Property, 0, len(d.Properties())),
-		}
-
-		for _, prop := range props {
-			pbProp := &pb.Property{
-				WidthPx:     int32(prop.Video.Width),
-				HeightPx:    int32(prop.Video.Height),
-				FrameRate:   prop.Video.FrameRate,
-				FrameFormat: string(prop.Video.FrameFormat),
-			}
-			wc.Properties = append(wc.Properties, pbProp)
-		}
-		webcams = append(webcams, wc)
-	}
-
-	return &pb.Webcams{Webcams: webcams}, nil
 }
 
 // WebcamConfig is the native config attribute struct for webcams.

--- a/components/camera/videosource/webcam_test.go
+++ b/components/camera/videosource/webcam_test.go
@@ -1,59 +1,12 @@
 package videosource_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/pion/mediadevices/pkg/driver"
-	"github.com/pion/mediadevices/pkg/prop"
 	"go.viam.com/test"
 
 	"go.viam.com/rdk/components/camera/videosource"
-	"go.viam.com/rdk/logging"
 )
-
-// fakeDriver is a driver has a label and media properties.
-type fakeDriver struct {
-	label string
-	props []prop.Media
-}
-
-func (d *fakeDriver) Open() error              { return nil }
-func (d *fakeDriver) Properties() []prop.Media { return d.props }
-func (d *fakeDriver) ID() string               { return d.label }
-func (d *fakeDriver) Info() driver.Info        { return driver.Info{Label: d.label} }
-func (d *fakeDriver) Status() driver.State     { return "some state" }
-func (d *fakeDriver) Close() error             { return nil }
-
-func newFakeDriver(label string, props []prop.Media) driver.Driver {
-	return &fakeDriver{label: label, props: props}
-}
-
-func testGetDrivers() []driver.Driver {
-	props := prop.Media{
-		Video: prop.Video{Width: 320, Height: 240, FrameFormat: "some format", FrameRate: 30.0},
-	}
-	withProps := newFakeDriver("some label", []prop.Media{props})
-	withoutProps := newFakeDriver("another label", []prop.Media{})
-	return []driver.Driver{withProps, withoutProps}
-}
-
-func TestDiscoveryWebcam(t *testing.T) {
-	logger := logging.NewTestLogger(t)
-	resp, err := videosource.Discover(context.Background(), testGetDrivers, logger)
-
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, resp.Webcams, test.ShouldHaveLength, 1)
-	test.That(t, resp.Webcams[0].Label, test.ShouldResemble, "some label")
-	test.That(t, resp.Webcams[0].Status, test.ShouldResemble, "some state")
-
-	respProps := resp.Webcams[0].Properties
-	test.That(t, respProps, test.ShouldHaveLength, 1)
-	test.That(t, respProps[0].WidthPx, test.ShouldResemble, int32(320))
-	test.That(t, respProps[0].HeightPx, test.ShouldResemble, int32(240))
-	test.That(t, respProps[0].FrameFormat, test.ShouldResemble, "some format")
-	test.That(t, respProps[0].FrameRate, test.ShouldResemble, float32(30))
-}
 
 func TestWebcamValidation(t *testing.T) {
 	webCfg := &videosource.WebcamConfig{


### PR DESCRIPTION
In an effort to make [RSDK-9630](https://viam.atlassian.net/browse/RSDK-9630?atlOrigin=eyJpIjoiZjVmNzcyM2Y5YTA3NDZkZmJkMDI4YmJmZTllOTVlOWYiLCJwIjoiaiJ9) slightly smaller - I broke out the webcam Discovery removal into its own work since it is isolated.

I tested the app on my Mac - nothing broke. We get no response in the video_path field and it connects to the first camera it finds.

I will wait until we have a discovery card to merge this in.

The replacement [find-cameras module](https://github.com/randhid/find-webcams)

TODO:
- Test on a pi.