### PR TITLE
APP-7459 Fix Enabled grants parsing issue in CreateOAuthApplication CLI

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -2781,7 +2781,7 @@ func enabledGrantsToProto(enabledGrants []string) ([]apppb.EnabledGrant, error) 
 	if enabledGrants == nil {
 		return nil, nil
 	}
-	enabledGrantsProto := make([]apppb.EnabledGrant, len(enabledGrants))
+	var enabledGrantsProto []apppb.EnabledGrant
 	for _, eg := range enabledGrants {
 		enabledGrant, err := enabledGrantToProto(eg)
 		if err != nil {


### PR DESCRIPTION
[ticket](https://viam.atlassian.net/browse/APP-7459)
This PR fixes the bug of appending to an empty array when converting enabled grants to the proto values