### PR TITLE
RSDK-9452 - require logged in status for module generation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,7 @@ jobs:
       - name: Run go unit tests
         run: |
           chmod -R a+rwx . # temporary fix for arm runners
+          sudo apt-get update
           sudo apt-get install -y python3-venv
           sudo --preserve-env=MONGODB_TEST_OUTPUT_URI,GITHUB_SHA,GITHUB_RUN_ID,GITHUB_RUN_NUMBER,GITHUB_RUN_ATTEMPT,GITHUB_X_PR_BASE_SHA,GITHUB_X_PR_BASE_REF,GITHUB_X_HEAD_REF,GITHUB_X_HEAD_SHA,GITHUB_REPOSITORY -Hu testbot bash -lc 'make test-go'
 
@@ -108,6 +109,7 @@ jobs:
             --platform linux/arm/v7 \
             -v `pwd`:/rdk \
             ghcr.io/viamrobotics/rdk-devenv:armhf-cache \
+            sudo apt-get update
             sudo -Hu testbot bash -lc 'sudo apt-get install -y python3-venv && cd /rdk && go test -v ./...'
 
   motion_tests:

--- a/cli/app.go
+++ b/cli/app.go
@@ -1893,7 +1893,6 @@ var app = &cli.App{
 							Name:      "status",
 							Usage:     "display part status",
 							UsageText: createUsageText("machines part status", []string{generalFlagPart}, true, false),
-							// TODO(RSDK-9286) do we need to ask for og and location and machine and part here?
 							Flags: []cli.Flag{
 								&AliasStringFlag{
 									cli.StringFlag{

--- a/cli/module_generate.go
+++ b/cli/module_generate.go
@@ -70,6 +70,9 @@ func GenerateModuleAction(cCtx *cli.Context, args generateModuleArgs) error {
 }
 
 func (c *viamClient) generateModuleAction(cCtx *cli.Context, args generateModuleArgs) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
 	var newModule *modulegen.ModuleInputs
 	var err error
 

--- a/cli/module_generate.go
+++ b/cli/module_generate.go
@@ -330,11 +330,11 @@ func wrapResolveOrg(cCtx *cli.Context, c *viamClient, newModule *modulegen.Modul
 }
 
 // TODO(RSDK-9758) - this logic will never be relevant currently because we're now checking if
-// we're logged in at the first opportunity in `viam module generate`, and returning an error
-// if not. However, I'm leaving this logic here because we will likely want to revisit if and how
-// to use it more broadly (not just for `viam module generate` but for _all_ CLI commands),
-// and because disentangling it immediately may be complicated and delay the current attempt
-// to solve the problems this causes (see RSDK-9300).
+// we're logged in at the first opportunity in `viam module generate`, and returning an error if
+// not. However, I (ethan) am leaving this logic here because we will likely want to revisit if
+// and how to use it more broadly (not just for `viam module generate` but for _all_ CLI commands),
+// and because disentangling it immediately may be complicated and delay the current attempt to
+// solve the problems this causes (see RSDK-9452).
 func catchResolveOrgErr(cCtx *cli.Context, c *viamClient, newModule *modulegen.ModuleInputs, caughtErr error) error {
 	if strings.Contains(caughtErr.Error(), "not logged in") || strings.Contains(caughtErr.Error(), "error while refreshing token") {
 		originalWriter := cCtx.App.Writer

--- a/cli/module_generate.go
+++ b/cli/module_generate.go
@@ -325,6 +325,12 @@ func wrapResolveOrg(cCtx *cli.Context, c *viamClient, newModule *modulegen.Modul
 	return nil
 }
 
+// TODO(RSDK-9758) - this logic will never be relevant currently because we're now checking if
+// we're logged in at the first opportunity in `viam module generate`, and returning an error
+// if not. However, I'm leaving this logic here because we will likely want to revisit if and how
+// to use it more broadly (not just for `viam module generate` but for _all_ CLI commands),
+// and because disentangling it immediately may be complicated and delay the current attempt
+// to solve the problems this causes (see RSDK-9300).
 func catchResolveOrgErr(cCtx *cli.Context, c *viamClient, newModule *modulegen.ModuleInputs, caughtErr error) error {
 	if strings.Contains(caughtErr.Error(), "not logged in") || strings.Contains(caughtErr.Error(), "error while refreshing token") {
 		originalWriter := cCtx.App.Writer


### PR DESCRIPTION
The current state of the CLI is, for all* commands except for `viam module generate`, to error out pretty much immediately if the user is not logged in, with a "please run `viam login`" message. `viam module generate`, however, will do much of the work happily even if not logged in (e.g., it will run all the user prompting and take in inputs), and then only at the last moment will it try to log in. The behavior after login is inconsistent, however. While I have had no problems with the job successfully logging in and completing, @felixreichenbach, @stevebriskin, and @npentrel have all had issues where the job then failed and had to be rerun. This is a frustrating case because there is non-trivial time and work done in the steps leading up to that failure (e.g., filling out all the user prompts) that all needs to be repeated.

As a first pass solution, this PR brings `viam module generate` in line with other CLI actions by immediately checking if we're logged in and returning an error if not. As a follow-up, we have a [ticket](https://viam.atlassian.net/browse/RSDK-9758) to revisit the `ensureLoggedIn` logic to try to create more generalized consistency in the direction of not erroring out when possible but instead trying to log in and then proceed with the requested action.

*I haven't tested everything so I might be mistaken when I say _all_, but at any rate it's very close to all.