### PR TITLE
Further bump timeouts when behind SOCKS proxy

### DIFF
--- a/config/reader.go
+++ b/config/reader.go
@@ -35,7 +35,7 @@ var (
 const (
 	initialReadTimeout     = 1 * time.Second
 	readTimeout            = 5 * time.Second
-	readTimeoutBehindProxy = 15 * time.Second
+	readTimeoutBehindProxy = time.Minute
 	// PackagesDirName is where packages go underneath viamDotDir.
 	PackagesDirName = "packages"
 	// LocalPackagesSuffix is used by the local package manager.

--- a/logging/net_appender.go
+++ b/logging/net_appender.go
@@ -24,7 +24,7 @@ var (
 	writeBatchSize             = 100
 	errUninitializedConnection = errors.New("sharedConn is true and connection is not initialized")
 	logWriteTimeout            = 4 * time.Second
-	logWriteTimeoutBehindProxy = 12 * time.Second
+	logWriteTimeoutBehindProxy = time.Minute
 )
 
 // CloudConfig contains the necessary inputs to send logs to the app backend over grpc.


### PR DESCRIPTION
Bumps config read timeout, cloud service connection timeout, and net logging timeout to 1 minute when behind SOCKS proxy. Previous values were causing timeouts when using the SOCKS proxy.