### PR TITLE
APP-7171: Add README.md to module generate CLI

### DIFF
--- a/cli/module_generate.go
+++ b/cli/module_generate.go
@@ -410,7 +410,7 @@ func renderCommonFiles(c *cli.Context, module modulegen.ModuleInputs, globalArgs
 	}
 
 	// Render README.md
-	if err := renderReadme(c, module, globalArgs); err != nil {
+	if err := renderReadme(module); err != nil {
 		return errors.Wrap(err, "failed to render README.md")
 	}
 
@@ -784,7 +784,7 @@ func createModuleAndManifest(cCtx *cli.Context, c *viamClient, module modulegen.
 }
 
 // Create the README.md file.
-func renderReadme(c *cli.Context, module modulegen.ModuleInputs, globalArgs globalArgs) error {
+func renderReadme(module modulegen.ModuleInputs) error {
 	readmeTemplatePath, err := templates.Open(filepath.Join(templatesPath, defaultReadmeFilename))
 	readmeDest := filepath.Join(module.ModuleName, defaultReadmeFilename)
 	if err != nil {

--- a/cli/module_generate.go
+++ b/cli/module_generate.go
@@ -824,7 +824,7 @@ func renderManifest(c *cli.Context, moduleID string, module modulegen.ModuleInpu
 		visibility = moduleVisibilityPublic
 	}
 
-	modelDescription := "Provide a short (<100 character) description of this model here"
+	modelDescription := "Provide a short (100 characters or less) description of this model here"
 	manifest := moduleManifest{
 		Schema:      "https://dl.viam.dev/module.schema.json",
 		ModuleID:    moduleID,

--- a/cli/module_generate/_templates/README.md
+++ b/cli/module_generate/_templates/README.md
@@ -1,0 +1,50 @@
+# Module {{.ModuleName}} 
+
+Provide a description of the purpose of the module and any relevant information.
+
+## Model {{.ModelTriple}}
+
+Provide a description of the model and any relevant information.
+
+### Configuration
+The following attribute template can be used to configure this model:
+
+```json
+{
+"attribute_1": <float>,
+"attribute_2": <string>
+}
+```
+
+#### Attributes
+
+The following attributes are available for this model:
+
+| Name          | Type   | Inclusion | Description                |
+|---------------|--------|-----------|----------------------------|
+| `attribute_1` | float  | Required  | Description of attribute 1 |
+| `attribute_2` | string | Optional  | Description of attribute 2 |
+
+#### Example Configuration
+
+```json
+{
+  "attribute_1": 1.0,
+  "attribute_2": "foo"
+}
+```
+
+### DoCommand
+
+If your model implements DoCommand, provide an example payload of each command that is supported and the arguments that can be used. If your model does not implement DoCommand, remove this section.
+
+#### Example DoCommand
+
+```json
+{
+  "command_name": {
+    "arg1": "foo",
+    "arg2": 1
+  }
+}
+```

--- a/cli/module_generate/modulegen/inputs.go
+++ b/cli/module_generate/modulegen/inputs.go
@@ -36,7 +36,7 @@ type ModuleInputs struct {
 	ModelTriple           string `json:"-"`
 	ModelLowercase        string `json:"-"`
 	ModelReadmeLink       string `json:"-"`
-	SDKVersion string `json:"-"`
+	SDKVersion            string `json:"-"`
 }
 
 // Resources is a list of all the available resources in Viam.

--- a/cli/module_generate/modulegen/inputs.go
+++ b/cli/module_generate/modulegen/inputs.go
@@ -35,7 +35,7 @@ type ModuleInputs struct {
 	ModelCamel            string `json:"-"`
 	ModelTriple           string `json:"-"`
 	ModelLowercase        string `json:"-"`
-
+	ModelReadmeLink       string `json:"-"`
 	SDKVersion string `json:"-"`
 }
 

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -106,6 +106,7 @@ type moduleManifest struct {
 
 const (
 	defaultManifestFilename = "meta.json"
+	defaultReadmeFilename   = "README.md"
 )
 
 type createModuleActionArgs struct {


### PR DESCRIPTION
Generates a base README.md for modules created with `viam module generate`. The template is inspired by our [docs](https://docs.viam.com/operate/get-started/other-hardware/#upload-your-module) readme example. Meta.json is updated to have a relative link to the model level documentation of the readme. I adjusted the template with this feature in mind, attempting to reduce repetitive sentences "to configure a component/service go to..." and "This is a model that implements the ... API" so that the docs embedded in the app are to the point.

Tested the generator locally:
`go run cli/viam/main.go module generate`
Selected: "my-module-4", "test" namespace, Python, Arm Component, "my-model-4", Use CloudBuild, Register with Viam.

Generated markdown:
```markdown
# Module my-module-4 

TODO: Provide a description of the purpose of the module and any relevant information.

## Model test:my-module-4:my-model-4

TODO: Provide a description of the model and any relevant information.

### Configuration
The following attribute template can be used to configure this model:

\`\`\`json
{
"attribute_1": <float>,
"attribute_2": <string>
}
\`\`\`

#### Attributes

The following attributes are available for this model:

| Name          | Type   | Inclusion | Description                |
|---------------|--------|-----------|----------------------------|
| `attribute_1` | float  | Required  | Description of attribute 1 |
| `attribute_2` | string | Optional  | Description of attribute 2 |

#### Example Configuration

\`\`\`json
{
  "attribute_1": 1.0,
  "attribute_2": "foo"
}
\`\`\`

### DoCommand

TODO: If your model implements DoCommand, provide an example payload of each command that is supported and the arguments that can be used. If your model does not implement DoCommand, remove this section.

#### Example DoCommand

\`\`\`json
{
  "command_name": {
    "arg1": "foo",
    "arg2": 1
  }
}
\`\`\`

```


Generated meta.json:
```json
{
  "$schema": "https://dl.viam.dev/module.schema.json",
  "module_id": "test:my-module-4",
  "visibility": "private",
  "url": "",
  "description": "Modular arm component: my-model-4",
  "models": [
    {
      "api": "rdk:component:arm",
      "model": "test:my-module-4:my-model-4",
      "short_description": "Provide a short (100 characters or less) description of this model here",
      "markdown_link": "README.md#model-testmy-module-4my-model-4"
    }
  ],
  "entrypoint": "dist/main",
  "first_run": "",
  "build": {
    "build": "./build.sh",
    "setup": "./setup.sh",
    "path": "dist/archive.tar.gz",
    "arch": [
      "linux/amd64",
      "linux/arm64"
    ]
  }
}
```