### PR TITLE
special-case datamanager sync.isOffline on windows

### DIFF
--- a/services/datamanager/builtin/sync/connectivity.go
+++ b/services/datamanager/builtin/sync/connectivity.go
@@ -35,9 +35,13 @@ func (oc offlineChecker) GetState() connectivity.State {
 	return connectivity.Ready
 }
 
+// returns true if the device is offline.
 func isOffline() bool {
 	timeout := 5 * time.Second
-	_, err := net.DialTimeout("tcp", "app.viam.com:443", timeout)
-	// If there's an error, the system is likely offline.
-	return err != nil
+	conn, err := net.DialTimeout("tcp", "app.viam.com:443", timeout)
+	if err != nil {
+		return true
+	}
+	conn.Close() //nolint:gosec,errcheck
+	return false
 }


### PR DESCRIPTION
## What changed
- on windows only, in `isOffline`, temporarily increase the timeout, and add a second attempt
- (incidental) close the temporary connection
## Why
I'm not sure if a specific test machine is on a slow network, or if this is an OS-specific issue, but this is a hack to make this check more forgiving until RSDK-8344 lands.