### PR TITLE
RSDK-9756-draft

### DIFF
--- a/components/camera/client.go
+++ b/components/camera/client.go
@@ -84,6 +84,7 @@ func NewClientFromConn(
 	streamClient := streampb.NewStreamServiceClient(conn)
 	trackClosed := make(chan struct{})
 	close(trackClosed)
+	logger.Infof("NICK!!! conn: %#v, streamClient: %#v", conn, streamClient)
 	return &client{
 		remoteName:     remoteName,
 		Named:          name.PrependRemote(remoteName).AsNamed(),
@@ -429,6 +430,7 @@ func (c *client) SubscribeRTP(
 		return rtppassthrough.NilSubscription, ErrNoSharedPeerConnection
 	}
 
+	c.logger.CInfow(ctx, "Client conn", "connType", fmt.Sprintf("%T", c.conn), "conn", fmt.Sprintf("%#v", c.conn))
 	c.logger.CDebugw(ctx, "SubscribeRTP", "subID", sub.ID.String(), "name", c.Name(), "bufAndCBByID", c.bufAndCBToString())
 	defer func() {
 		c.logger.CDebugw(ctx, "SubscribeRTP after", "subID", sub.ID.String(),

--- a/go.mod
+++ b/go.mod
@@ -432,3 +432,5 @@ require (
 	github.com/ziutek/mymysql v1.5.4 // indirect
 	golang.org/x/exp v0.0.0-20240904232852-e7e105dedf7e
 )
+
+replace go.viam.com/utils => /Users/nicksanford/code/goutils

--- a/gostream/stream.go
+++ b/gostream/stream.go
@@ -166,6 +166,7 @@ func (bs *basicStream) Start() {
 // if we also need to support writing audio RTP packets, we should split
 // this method into WriteVideoRTP and WriteAudioRTP.
 func (bs *basicStream) WriteRTP(pkt *rtp.Packet) error {
+	bs.logger.Info("basic stream calling WriteRTP")
 	return bs.videoTrackLocal.rtpTrack.WriteRTP(pkt)
 }
 

--- a/grpc/conn.go
+++ b/grpc/conn.go
@@ -71,9 +71,12 @@ func (c *ReconfigurableClientConn) ReplaceConn(conn rpc.ClientConn) {
 	if c.onTrackCBByTrackName == nil {
 		c.onTrackCBByTrackName = make(map[string]OnTrackCB)
 	}
-
+	logging.Global().Infof("ReconfigurableClientConn.ReplaceConn START: %p, %#v, pc: %p, %#v", c, c, conn.PeerConn(), conn.PeerConn())
+	defer logging.Global().Infof("ReconfigurableClientConn.ReplaceConn END: %p, %#v, pc: %p, %#v", c, c, conn.PeerConn(), conn.PeerConn())
 	if pc := conn.PeerConn(); pc != nil {
+		logging.Global().Infof("ReconfigurableClientConn.ReplaceConn installing OnTrack on %p, %#v, pc: %p, %#v", c, c, conn.PeerConn(), conn.PeerConn())
 		pc.OnTrack(func(trackRemote *webrtc.TrackRemote, rtpReceiver *webrtc.RTPReceiver) {
+			logging.Global().Infof("OnTrack called on pc: %p, %#v, tr: %p %#v, receiver: %p, %#v", pc, pc, trackRemote, trackRemote, rtpReceiver, rtpReceiver)
 			c.onTrackCBByTrackNameMu.Lock()
 			onTrackCB, ok := c.onTrackCBByTrackName[trackRemote.StreamID()]
 			c.onTrackCBByTrackNameMu.Unlock()

--- a/module/module.go
+++ b/module/module.go
@@ -375,6 +375,9 @@ func (m *Module) connectParent(ctx context.Context) error {
 	}
 
 	m.parent = rc
+	if m.pc != nil {
+		m.parent.SetPeerConnection(m.pc)
+	}
 	return nil
 }
 

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -403,6 +403,7 @@ func (rc *RobotClient) Changed() <-chan bool {
 }
 
 func (rc *RobotClient) SetPeerConnection(pc *webrtc.PeerConnection) {
+	rc.logger.Infof("RobotClient: %p, SetPeerConnection called on pc: %p, reconfigurableClientConn: %p, %#v", rc, pc, &rc.conn, &rc.conn)
 	rc.mu.Lock()
 	rc.pc = pc
 	rc.mu.Unlock()
@@ -414,7 +415,7 @@ func (rc *RobotClient) getClientConn() rpc.ClientConn {
 		return &rc.conn
 	}
 
-	return grpc.NewSharedConn(&rc.conn, rc.pc)
+	return grpc.NewSharedConn(&rc.conn, rc.pc, rc.logger)
 }
 
 // Connect will close any existing connection and try to reconnect to the remote.

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -498,6 +498,10 @@ func newWithResources(
 	if rOpts.viamHomeDir != "" {
 		homeDir = rOpts.viamHomeDir
 	}
+	var m web.ModularResourceToPeerConnectionMapper
+	if mm, ok := r.webSvc.(web.ModularResourceToPeerConnectionMapper); ok {
+		m = mm
+	}
 	// Once web service is started, start module manager
 	r.manager.startModuleManager(
 		closeCtx,
@@ -508,6 +512,7 @@ func newWithResources(
 		cloudID,
 		logger,
 		cfg.PackagePath,
+		m,
 	)
 
 	if !rOpts.disableCompleteConfigWorker {

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -122,6 +122,7 @@ func (manager *resourceManager) startModuleManager(
 	robotCloudID string,
 	logger logging.Logger,
 	packagesDir string,
+	m web.ModularResourceToPeerConnectionMapper,
 ) {
 	mmOpts := modmanageroptions.Options{
 		UntrustedEnv:            untrustedEnv,
@@ -131,7 +132,7 @@ func (manager *resourceManager) startModuleManager(
 		PackagesDir:             packagesDir,
 		FTDC:                    manager.opts.ftdc,
 	}
-	modmanager := modmanager.NewManager(ctx, parentAddr, logger, mmOpts)
+	modmanager := modmanager.NewManager(ctx, parentAddr, logger, mmOpts, m)
 	manager.modManagerLock.Lock()
 	manager.moduleManager = modmanager
 	manager.modManagerLock.Unlock()
@@ -744,7 +745,6 @@ func (manager *resourceManager) completeConfig(
 
 					switch {
 					case resName.API.IsComponent(), resName.API.IsService():
-
 						newRes, newlyBuilt, err := manager.processResource(ctxWithTimeout, conf, gNode, lr)
 						if newlyBuilt || err != nil {
 							if err := manager.markChildrenForUpdate(resName); err != nil {
@@ -759,7 +759,8 @@ func (manager *resourceManager) completeConfig(
 							gNode.LogAndSetLastError(
 								fmt.Errorf("resource build error: %w", err),
 								"resource", conf.ResourceName(),
-								"model", conf.Model)
+								"model", conf.Model,
+								"newlyBuilt", newlyBuilt)
 							return
 						}
 

--- a/robot/web/stream/server.go
+++ b/robot/web/stream/server.go
@@ -143,8 +143,8 @@ func (server *Server) AddStream(ctx context.Context, req *streampb.AddStreamRequ
 	defer span.End()
 	// Get the peer connection to the caller.
 	pc, ok := rpc.ContextPeerConnection(ctx)
-	server.logger.Infow("Adding video stream", "name", req.Name, "peerConn", pc)
-	defer server.logger.Warnf("AddStream END %s", req.Name)
+	server.logger.Warnf("AddStream START %s, pc: %p, activePeerStreams: %#v", req.Name, pc, server.activePeerStreams)
+	defer server.logger.Warnf("AddStream END %s, pc: %p, activePeerStreams: %#v", req.Name, pc, server.activePeerStreams)
 
 	if !ok {
 		return nil, errors.New("can only add a stream over a WebRTC based connection")

--- a/robot/web/stream/state/state.go
+++ b/robot/web/stream/state/state.go
@@ -369,6 +369,7 @@ func (state *StreamState) streamH264Passthrough() error {
 		}
 	}
 
+	state.logger.Infof("Stream calling SubscribeRTP on camera %p %s using experimental H264 passthrough", rtpPassthroughSource, state.Stream.Name())
 	sub, err := rtpPassthroughSource.SubscribeRTP(state.closedCtx, rtpBufferSize, cb)
 	if err != nil {
 		return fmt.Errorf("SubscribeRTP failed: %w", err)

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -218,7 +218,6 @@ func (svc *webService) StartModule(ctx context.Context) error {
 		if !strings.HasPrefix(info.FullMethod, "/proto.stream.v1.StreamService") {
 			return handler(ctx, req)
 		}
-		defer svc.logger.Info("NICK done")
 		svc.logger.Infof("ctx before: %#v", ctx)
 		svc.logger.Infof("req: %#v", req)
 		svc.logger.Infof("info: %#v", info)

--- a/robot/web/web_c.go
+++ b/robot/web/web_c.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
+	"github.com/viamrobotics/webrtc/v3"
 	streampb "go.viam.com/api/stream/v1"
 	"go.viam.com/utils/rpc"
 
@@ -26,13 +27,14 @@ func New(r robot.Robot, logger logging.Logger, opts ...Option) Service {
 		opt.apply(&wOpts)
 	}
 	webSvc := &webService{
-		Named:        InternalServiceName.AsNamed(),
-		r:            r,
-		logger:       logger,
-		rpcServer:    nil,
-		streamServer: nil,
-		services:     map[resource.API]resource.APIResourceCollection[resource.Resource]{},
-		opts:         wOpts,
+		resourceNameToPeerConnectionMap: make(map[string]*webrtc.PeerConnection),
+		Named:                           InternalServiceName.AsNamed(),
+		r:                               r,
+		logger:                          logger,
+		rpcServer:                       nil,
+		streamServer:                    nil,
+		services:                        map[resource.API]resource.APIResourceCollection[resource.Resource]{},
+		opts:                            wOpts,
 	}
 	return webSvc
 }
@@ -55,6 +57,9 @@ type webService struct {
 	isRunning    bool
 	webWorkers   sync.WaitGroup
 	modWorkers   sync.WaitGroup
+
+	resourceNameToPeerConnectionMu  sync.Mutex
+	resourceNameToPeerConnectionMap map[string]*webrtc.PeerConnection
 }
 
 // Reconfigure pulls resources and updates the stream server audio and video streams with the new resources.

--- a/robot/web/web_c.go
+++ b/robot/web/web_c.go
@@ -83,13 +83,15 @@ func (svc *webService) closeStreamServer() {
 
 func (svc *webService) initStreamServer(ctx context.Context) error {
 	// Check to make sure stream config option is set in the webservice.
-	var streamConfig gostream.StreamConfig
-	if svc.opts.streamConfig != nil {
-		streamConfig = *svc.opts.streamConfig
-	} else {
-		svc.logger.Warn("streamConfig is nil, using empty config")
+	if svc.streamServer == nil {
+		var streamConfig gostream.StreamConfig
+		if svc.opts.streamConfig != nil {
+			streamConfig = *svc.opts.streamConfig
+		} else {
+			svc.logger.Warn("streamConfig is nil, using empty config")
+		}
+		svc.streamServer = webstream.NewServer(svc.r, streamConfig, svc.logger)
 	}
-	svc.streamServer = webstream.NewServer(svc.r, streamConfig, svc.logger)
 	if err := svc.streamServer.AddNewStreams(svc.cancelCtx); err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR attempts to allow a module to stream a webrtc video track from viam-server's StreamServer.

Currently it doesn't work as the GRPC client a module has for communicating with viam-server goes over unix socket, as opposed to WebRTC. 

As a result, the viam-server stream server is unable to add a webrtc track b/c the GRPC communication is happening over unix socket, not webrtc.

Logs:
```
\_ 2025-01-23T18:16:27.761Z	DEBUG	networking.module-connection.camera-1	camera/client.go:480	SubscribeRTP AddStream hit error	{"subID":"3ab2035e-3c1d-40c6-8350-f20dcd3a0e9c","trackName":"rdk:component:camera/camera-1","err":"rpc error: code = Unknown desc = can only add a stream over a WebRTC based connection"}
2025-01-23T18:16:27.761Z	INFO	rdk.modmanager.local-module-2.local-module-2.StdOut	pexec/managed_process.go:294	
\_ 2025-01-23T18:16:27.761Z	DEBUG	networking.module-connection.camera-1	camera/client.go:436	SubscribeRTP after	{"subID":"3ab2035e-3c1d-40c6-8350-f20dcd3a0e9c","name":"rdk:component:camera/camera-1","bufAndCBByID":"len: 0"}
2025-01-23T18:16:27.761Z	INFO	rdk.modmanager.local-module-2.local-module-2.StdOut	pexec/managed_process.go:294	
\_ 2025-01-23T18:16:27.761Z	DEBUG	networking.module-connection.camera-1	camera/client.go:408	Error subscribing to RTP. Closing passthrough buffer.
2025-01-23T18:16:27.763Z	INFO	rdk:component:camera/camera-2	passthroughcam/passthroughcam.go:76	SubscribeRTP STOP	{"log_ts":"2025-01-23T18:16:27.761Z"}
2025-01-23T18:16:27.763Z	DEBUG	rdk.modmanager	camera/client.go:480	SubscribeRTP AddStream hit error	{"subID":"11d91e54-1bdb-4607-a3f4-152e2f0ea91e","trackName":"rdk:component:camera/camera-2","err":"rpc error: code = Unknown desc = error setting up stream subscription: rpc error: code = Unknown desc = can only add a stream over a WebRTC based connection"}
2025-01-23T18:16:27.764Z	DEBUG	rdk.modmanager	camera/client.go:436	SubscribeRTP after	{"subID":"11d91e54-1bdb-4607-a3f4-152e2f0ea91e","name":"rdk:component:camera/camera-2","bufAndCBByID":"len: 0"}
2025-01-23T18:16:27.764Z	DEBUG	rdk.modmanager	camera/client.go:408	Error subscribing to RTP. Closing passthrough buffer.
2025-01-23T18:16:27.764Z	WARN	rdk.camera-2	state/state.go:296	tick: rtp_passthrough not possible, falling back to GoStream	{"err":"SubscribeRTP failed: rpc error: code = Unknown desc = error setting up stream subscription: rpc error: code = Unknown desc = can only add a stream over a WebRTC based connection"}
```


``2025-01-23T18:16:27.764Z	WARN	rdk.camera-2	state/state.go:296	tick: rtp_passthrough not possible, falling back to GoStream	{"err":"SubscribeRTP failed: rpc error: code = Unknown desc = error setting up stream subscription: rpc error: code = Unknown desc = can only add a stream over a WebRTC based connection"}`