### PR TITLE
[RSDK-9703] - Maintain dynamic resolution preference through reconfigures

### DIFF
--- a/robot/web/stream/server.go
+++ b/robot/web/stream/server.go
@@ -658,6 +658,16 @@ func (server *Server) refreshVideoSources() {
 		}
 		existing, ok := server.videoSources[cam.Name().SDPTrackName()]
 		if ok {
+			// Check stream state for the camera to see if it is in resized mode.
+			// If it is, we do not want to swap the camera source.
+			// This comes with the risk that a camera is added or changed to the same name
+			// as the previously resized stream source causing the stream to be pointed to the
+			// wrong camera.
+			streamState, ok := server.nameToStreamState[cam.Name().SDPTrackName()]
+			if ok && streamState.IsResized() {
+				server.logger.Debugf("stream %q is resized, skipping swap", cam.Name().SDPTrackName())
+				continue
+			}
 			existing.Swap(cam)
 			continue
 		}

--- a/robot/web/stream/server.go
+++ b/robot/web/stream/server.go
@@ -668,8 +668,7 @@ func (server *Server) refreshVideoSources() {
 				if err != nil {
 					server.logger.Errorf("error getting media properties from resize source: %v", err)
 				} else {
-					// resizeVideoSource should always have a width and height set. If it doesn't, we
-					// have to fall back to the original source.
+					// resizeVideoSource should always have a width and height set.
 					height, width := mediaProps.Height, mediaProps.Width
 					if height != 0 && width != 0 {
 						server.logger.Debugf(
@@ -680,6 +679,14 @@ func (server *Server) refreshVideoSources() {
 						existing.Swap(resizer)
 						continue
 					}
+				}
+				// If we can't get the media properties or the width and height are 0, we fall back to
+				// the original source and need to notify the stream state that the source is no longer
+				// resized.
+				server.logger.Warnf("falling back to original source for stream %q", cam.Name().SDPTrackName())
+				err = streamState.Reset()
+				if err != nil {
+					server.logger.Errorf("error resetting stream %q: %v", cam.Name().SDPTrackName(), err)
 				}
 			}
 			existing.Swap(cam)

--- a/robot/web/stream/state/state.go
+++ b/robot/web/stream/state/state.go
@@ -409,3 +409,7 @@ func (state *StreamState) unsubscribeH264Passthrough(ctx context.Context, id rtp
 
 	return nil
 }
+
+func (state *StreamState) IsResized() bool {
+	return state.isResized
+}

--- a/robot/web/stream/state/state.go
+++ b/robot/web/stream/state/state.go
@@ -410,6 +410,7 @@ func (state *StreamState) unsubscribeH264Passthrough(ctx context.Context, id rtp
 	return nil
 }
 
+// IsResized returns whether the stream is in a resized state.
 func (state *StreamState) IsResized() bool {
 	return state.isResized
 }


### PR DESCRIPTION
## Description

This PR adds a check before refreshing a video source to see if it is in resized mode. If the streamState is resized, we re-apply the resize transformation before swapping.

## Tests

  - fake camera
    - maintains resize state through reconfigures ✅ 
    - toggle animated flag ✅ 
  - webcam
    - maintains resize state through reconfigures ✅ 
    - can change video_path ✅ 
  - viamrtsp
    - maintains resize state through reconfigures ✅ 
    - can change rtsp url ✅

