### PR TITLE
APP-7497: Add Button client, server, and fake model

### DIFF
--- a/components/button/button.go
+++ b/components/button/button.go
@@ -44,6 +44,11 @@ func FromRobot(r robot.Robot, name string) (Button, error) {
 	return robot.ResourceFromRobot[Button](r, Named(name))
 }
 
+// FromDependencies is a helper for getting the named button component from a collection of dependencies.
+func FromDependencies(deps resource.Dependencies, name string) (Button, error) {
+	return resource.FromDependencies[Button](deps, Named(name))
+}
+
 // NamesFromRobot is a helper for getting all gripper names from the given Robot.
 func NamesFromRobot(r robot.Robot) []string {
 	return robot.NamesByAPI(r, API)

--- a/components/button/button.go
+++ b/components/button/button.go
@@ -1,0 +1,50 @@
+// Package button defines a button on your machine.
+package button
+
+import (
+	"context"
+
+	pb "go.viam.com/api/component/button/v1"
+
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/robot"
+)
+
+func init() {
+	resource.RegisterAPI(API, resource.APIRegistration[Button]{
+		RPCServiceServerConstructor: NewRPCServiceServer,
+		RPCServiceHandler:           pb.RegisterButtonServiceHandlerFromEndpoint,
+		RPCServiceDesc:              &pb.ButtonService_ServiceDesc,
+		RPCClient:                   NewClientFromConn,
+	})
+}
+
+// SubtypeName is a constant that identifies the component resource API string.
+const SubtypeName = "button"
+
+// API is a variable that identifies the component resource API.
+var API = resource.APINamespaceRDK.WithComponentType(SubtypeName)
+
+// Named is a helper for getting the named grippers's typed resource name.
+func Named(name string) resource.Name {
+	return resource.NewName(API, name)
+}
+
+// A Button represents a physical button.
+type Button interface {
+	resource.Resource
+
+	// Push pushes the button.
+	// This will block until done or a new operation cancels this one.
+	Push(ctx context.Context, extra map[string]interface{}) error
+}
+
+// FromRobot is a helper for getting the named Button from the given Robot.
+func FromRobot(r robot.Robot, name string) (Button, error) {
+	return robot.ResourceFromRobot[Button](r, Named(name))
+}
+
+// NamesFromRobot is a helper for getting all gripper names from the given Robot.
+func NamesFromRobot(r robot.Robot) []string {
+	return robot.NamesByAPI(r, API)
+}

--- a/components/button/button_test.go
+++ b/components/button/button_test.go
@@ -1,0 +1,31 @@
+package button_test
+
+import (
+	"context"
+	"testing"
+
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/components/button"
+	"go.viam.com/rdk/components/button/fake"
+	"go.viam.com/rdk/resource"
+)
+
+const (
+	testButtonName    = "button1"
+	testButtonName2   = "button2"
+	failButtonName    = "button3"
+	missingButtonName = "button4"
+)
+
+func TestPush(t *testing.T) {
+	cfg := resource.Config{
+		Name: "fakeButton",
+		API:  button.API,
+	}
+	button, err := fake.NewButton(context.Background(), nil, cfg, nil)
+	test.That(t, err, test.ShouldBeNil)
+
+	err = button.Push(context.Background(), nil)
+	test.That(t, err, test.ShouldBeNil)
+}

--- a/components/button/button_test.go
+++ b/components/button/button_test.go
@@ -8,6 +8,7 @@ import (
 
 	"go.viam.com/rdk/components/button"
 	"go.viam.com/rdk/components/button/fake"
+	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 )
 
@@ -19,11 +20,12 @@ const (
 )
 
 func TestPush(t *testing.T) {
+	logger := logging.NewTestLogger(t)
 	cfg := resource.Config{
 		Name: "fakeButton",
 		API:  button.API,
 	}
-	button, err := fake.NewButton(context.Background(), nil, cfg, nil)
+	button, err := fake.NewButton(context.Background(), nil, cfg, logger)
 	test.That(t, err, test.ShouldBeNil)
 
 	err = button.Push(context.Background(), nil)

--- a/components/button/client.go
+++ b/components/button/client.go
@@ -1,0 +1,57 @@
+// Package button contains a gRPC based button client.
+package button
+
+import (
+	"context"
+
+	pb "go.viam.com/api/component/button/v1"
+	"go.viam.com/utils/protoutils"
+	"go.viam.com/utils/rpc"
+
+	"go.viam.com/rdk/logging"
+	rprotoutils "go.viam.com/rdk/protoutils"
+	"go.viam.com/rdk/resource"
+)
+
+// client implements GripperServiceClient.
+type client struct {
+	resource.Named
+	resource.TriviallyReconfigurable
+	resource.TriviallyCloseable
+	name   string
+	client pb.ButtonServiceClient
+	logger logging.Logger
+}
+
+// NewClientFromConn constructs a new Client from connection passed in.
+func NewClientFromConn(
+	ctx context.Context,
+	conn rpc.ClientConn,
+	remoteName string,
+	name resource.Name,
+	logger logging.Logger,
+) (Button, error) {
+	c := pb.NewButtonServiceClient(conn)
+	return &client{
+		Named:  name.PrependRemote(remoteName).AsNamed(),
+		name:   name.ShortName(),
+		client: c,
+		logger: logger,
+	}, nil
+}
+
+func (c *client) Push(ctx context.Context, extra map[string]interface{}) error {
+	ext, err := protoutils.StructToStructPb(extra)
+	if err != nil {
+		return err
+	}
+	_, err = c.client.Push(ctx, &pb.PushRequest{
+		Name:  c.name,
+		Extra: ext,
+	})
+	return err
+}
+
+func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+	return rprotoutils.DoFromResourceClient(ctx, c.client, c.name, cmd)
+}

--- a/components/button/client_test.go
+++ b/components/button/client_test.go
@@ -1,0 +1,103 @@
+package button_test
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"go.viam.com/test"
+	"go.viam.com/utils/rpc"
+
+	"go.viam.com/rdk/components/button"
+	viamgrpc "go.viam.com/rdk/grpc"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/testutils"
+	"go.viam.com/rdk/testutils/inject"
+)
+
+func TestClient(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	listener1, err := net.Listen("tcp", "localhost:0")
+	test.That(t, err, test.ShouldBeNil)
+	rpcServer, err := rpc.NewServer(logger, rpc.WithUnauthenticated())
+	test.That(t, err, test.ShouldBeNil)
+
+	var buttonPushed string
+	var extraOptions map[string]interface{}
+
+	injectButton := &inject.Button{}
+	injectButton.PushFunc = func(ctx context.Context, extra map[string]interface{}) error {
+		extraOptions = extra
+		buttonPushed = testButtonName
+		return nil
+	}
+
+	injectButton2 := &inject.Button{}
+	injectButton2.PushFunc = func(ctx context.Context, extra map[string]interface{}) error {
+		buttonPushed = failButtonName
+		return errCantPush
+	}
+
+	buttonSvc, err := resource.NewAPIResourceCollection(
+		button.API,
+		map[resource.Name]button.Button{button.Named(testButtonName): injectButton, button.Named(failButtonName): injectButton2})
+	test.That(t, err, test.ShouldBeNil)
+	resourceAPI, ok, err := resource.LookupAPIRegistration[button.Button](button.API)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, resourceAPI.RegisterRPCService(context.Background(), rpcServer, buttonSvc), test.ShouldBeNil)
+
+	injectButton.DoFunc = testutils.EchoFunc
+
+	go rpcServer.Serve(listener1)
+	defer rpcServer.Stop()
+
+	// failing
+	t.Run("Failing client", func(t *testing.T) {
+		cancelCtx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := viamgrpc.Dial(cancelCtx, listener1.Addr().String(), logger)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err, test.ShouldBeError, context.Canceled)
+	})
+
+	// working
+	t.Run("button client 1", func(t *testing.T) {
+		conn, err := viamgrpc.Dial(context.Background(), listener1.Addr().String(), logger)
+		test.That(t, err, test.ShouldBeNil)
+		button1Client, err := button.NewClientFromConn(context.Background(), conn, "", button.Named(testButtonName), logger)
+		test.That(t, err, test.ShouldBeNil)
+
+		// DoCommand
+		resp, err := button1Client.DoCommand(context.Background(), testutils.TestCommand)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, resp["command"], test.ShouldEqual, testutils.TestCommand["command"])
+		test.That(t, resp["data"], test.ShouldEqual, testutils.TestCommand["data"])
+
+		extra := map[string]interface{}{"foo": "Push"}
+		err = button1Client.Push(context.Background(), extra)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, extraOptions, test.ShouldResemble, extra)
+		test.That(t, buttonPushed, test.ShouldEqual, testButtonName)
+
+		test.That(t, button1Client.Close(context.Background()), test.ShouldBeNil)
+		test.That(t, conn.Close(), test.ShouldBeNil)
+	})
+
+	t.Run("button client 2", func(t *testing.T) {
+		conn, err := viamgrpc.Dial(context.Background(), listener1.Addr().String(), logger)
+		test.That(t, err, test.ShouldBeNil)
+		client2, err := resourceAPI.RPCClient(context.Background(), conn, "", button.Named(failButtonName), logger)
+		test.That(t, err, test.ShouldBeNil)
+
+		extra := map[string]interface{}{}
+		err = client2.Push(context.Background(), extra)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, errCantPush.Error())
+		test.That(t, buttonPushed, test.ShouldEqual, failButtonName)
+
+		test.That(t, client2.Close(context.Background()), test.ShouldBeNil)
+		test.That(t, conn.Close(), test.ShouldBeNil)
+	})
+}

--- a/components/button/client_test.go
+++ b/components/button/client_test.go
@@ -26,14 +26,14 @@ func TestClient(t *testing.T) {
 	var buttonPushed string
 	var extraOptions map[string]interface{}
 
-	injectButton := &inject.Button{}
+	injectButton := inject.NewButton(testButtonName)
 	injectButton.PushFunc = func(ctx context.Context, extra map[string]interface{}) error {
 		extraOptions = extra
 		buttonPushed = testButtonName
 		return nil
 	}
 
-	injectButton2 := &inject.Button{}
+	injectButton2 := inject.NewButton(failButtonName)
 	injectButton2.PushFunc = func(ctx context.Context, extra map[string]interface{}) error {
 		buttonPushed = failButtonName
 		return errCantPush

--- a/components/button/client_test.go
+++ b/components/button/client_test.go
@@ -16,6 +16,13 @@ import (
 	"go.viam.com/rdk/testutils/inject"
 )
 
+const (
+	testButtonName    = "button1"
+	testButtonName2   = "button2"
+	failButtonName    = "button3"
+	missingButtonName = "button4"
+)
+
 func TestClient(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	listener1, err := net.Listen("tcp", "localhost:0")

--- a/components/button/fake/button.go
+++ b/components/button/fake/button.go
@@ -15,11 +15,11 @@ func init() {
 	resource.RegisterComponent(button.API, model, resource.Registration[button.Button, *resource.NoNativeConfig]{Constructor: NewButton})
 }
 
-// Button is a fake button that logs when it is pressed
+// Button is a fake button that logs when it is pressed.
 type Button struct {
 	resource.Named
 	resource.TriviallyCloseable
-  resource.AlwaysRebuild
+	resource.AlwaysRebuild
 	logger logging.Logger
 }
 
@@ -34,7 +34,7 @@ func NewButton(
 	return b, nil
 }
 
-// Push logs the push
+// Push logs the push.
 func (b *Button) Push(ctx context.Context, extra map[string]interface{}) error {
 	b.logger.Info("pushed button")
 	return nil

--- a/components/button/fake/button.go
+++ b/components/button/fake/button.go
@@ -3,7 +3,6 @@ package fake
 
 import (
 	"context"
-	"sync"
 
 	"go.viam.com/rdk/components/button"
 	"go.viam.com/rdk/logging"
@@ -12,20 +11,15 @@ import (
 
 var model = resource.DefaultModelFamily.WithModel("fake")
 
-// Config is the config for a fake button.
-type Config struct {
-	resource.TriviallyValidateConfig
-}
-
 func init() {
-	resource.RegisterComponent(button.API, model, resource.Registration[button.Button, *Config]{Constructor: NewButton})
+	resource.RegisterComponent(button.API, model, resource.Registration[button.Button, *resource.NoNativeConfig]{Constructor: NewButton})
 }
 
 // Button is a fake button that logs when it is pressed
 type Button struct {
 	resource.Named
 	resource.TriviallyCloseable
-	mu     sync.Mutex
+  resource.AlwaysRebuild
 	logger logging.Logger
 }
 
@@ -37,18 +31,7 @@ func NewButton(
 		Named:  conf.ResourceName().AsNamed(),
 		logger: logger,
 	}
-	if err := b.Reconfigure(ctx, deps, conf); err != nil {
-		return nil, err
-	}
 	return b, nil
-}
-
-// Reconfigure reconfigures the button atomically and in place.
-func (b *Button) Reconfigure(_ context.Context, _ resource.Dependencies, conf resource.Config) error {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	return nil
 }
 
 // Push logs the push

--- a/components/button/fake/button.go
+++ b/components/button/fake/button.go
@@ -1,0 +1,58 @@
+// Package fake implements a fake button.
+package fake
+
+import (
+	"context"
+	"sync"
+
+	"go.viam.com/rdk/components/button"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+)
+
+var model = resource.DefaultModelFamily.WithModel("fake")
+
+// Config is the config for a fake button.
+type Config struct {
+	resource.TriviallyValidateConfig
+}
+
+func init() {
+	resource.RegisterComponent(button.API, model, resource.Registration[button.Button, *Config]{Constructor: NewButton})
+}
+
+// Button is a fake button that logs when it is pressed
+type Button struct {
+	resource.Named
+	resource.TriviallyCloseable
+	mu     sync.Mutex
+	logger logging.Logger
+}
+
+// NewButton instantiates a new button of the fake model type.
+func NewButton(
+	ctx context.Context, deps resource.Dependencies, conf resource.Config, logger logging.Logger,
+) (button.Button, error) {
+	b := &Button{
+		Named:  conf.ResourceName().AsNamed(),
+		logger: logger,
+	}
+	if err := b.Reconfigure(ctx, deps, conf); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// Reconfigure reconfigures the button atomically and in place.
+func (b *Button) Reconfigure(_ context.Context, _ resource.Dependencies, conf resource.Config) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return nil
+}
+
+// Push logs the push
+func (b *Button) Push(ctx context.Context, extra map[string]interface{}) error {
+	b.logger.Info("pushed button")
+	return nil
+}

--- a/components/button/fake/button_test.go
+++ b/components/button/fake/button_test.go
@@ -1,4 +1,4 @@
-package button_test
+package fake_test
 
 import (
 	"context"
@@ -10,13 +10,6 @@ import (
 	"go.viam.com/rdk/components/button/fake"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
-)
-
-const (
-	testButtonName    = "button1"
-	testButtonName2   = "button2"
-	failButtonName    = "button3"
-	missingButtonName = "button4"
 )
 
 func TestPush(t *testing.T) {

--- a/components/button/register/register.go
+++ b/components/button/register/register.go
@@ -1,0 +1,7 @@
+// Package register registers all relevant buttons and also API specific functions
+package register
+
+import (
+	// for buttons.
+	_ "go.viam.com/rdk/components/button/fake"
+)

--- a/components/button/server.go
+++ b/components/button/server.go
@@ -36,9 +36,9 @@ func (s *serviceServer) Push(ctx context.Context, req *pb.PushRequest) (*pb.Push
 func (s *serviceServer) DoCommand(ctx context.Context,
 	req *commonpb.DoCommandRequest,
 ) (*commonpb.DoCommandResponse, error) {
-	gripper, err := s.coll.Resource(req.GetName())
+	button, err := s.coll.Resource(req.GetName())
 	if err != nil {
 		return nil, err
 	}
-	return protoutils.DoFromResourceServer(ctx, gripper, req)
+	return protoutils.DoFromResourceServer(ctx, button, req)
 }

--- a/components/button/server.go
+++ b/components/button/server.go
@@ -1,0 +1,44 @@
+// Package button contains a gRPC based button service server.
+package button
+
+import (
+	"context"
+
+	commonpb "go.viam.com/api/common/v1"
+	pb "go.viam.com/api/component/button/v1"
+
+	"go.viam.com/rdk/protoutils"
+	"go.viam.com/rdk/resource"
+)
+
+// serviceServer implements the ButtonService from button.proto.
+type serviceServer struct {
+	pb.UnimplementedButtonServiceServer
+	coll resource.APIResourceCollection[Button]
+}
+
+// NewRPCServiceServer constructs an gripper gRPC service server.
+// It is intentionally untyped to prevent use outside of tests.
+func NewRPCServiceServer(coll resource.APIResourceCollection[Button]) interface{} {
+	return &serviceServer{coll: coll}
+}
+
+// Pushes a button
+func (s *serviceServer) Push(ctx context.Context, req *pb.PushRequest) (*pb.PushResponse, error) {
+	button, err := s.coll.Resource(req.Name)
+	if err != nil {
+		return nil, err
+	}
+	return &pb.PushResponse{}, button.Push(ctx, req.Extra.AsMap())
+}
+
+// DoCommand receives arbitrary commands.
+func (s *serviceServer) DoCommand(ctx context.Context,
+	req *commonpb.DoCommandRequest,
+) (*commonpb.DoCommandResponse, error) {
+	gripper, err := s.coll.Resource(req.GetName())
+	if err != nil {
+		return nil, err
+	}
+	return protoutils.DoFromResourceServer(ctx, gripper, req)
+}

--- a/components/button/server.go
+++ b/components/button/server.go
@@ -23,7 +23,7 @@ func NewRPCServiceServer(coll resource.APIResourceCollection[Button]) interface{
 	return &serviceServer{coll: coll}
 }
 
-// Pushes a button
+// Pushes a button.
 func (s *serviceServer) Push(ctx context.Context, req *pb.PushRequest) (*pb.PushResponse, error) {
 	button, err := s.coll.Resource(req.Name)
 	if err != nil {

--- a/components/button/server_test.go
+++ b/components/button/server_test.go
@@ -67,7 +67,7 @@ func TestServer(t *testing.T) {
 
 		_, err = buttonServer.Push(context.Background(), &pb.PushRequest{Name: testButtonName2})
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, errCantPush.Error())
+		test.That(t, err, test.ShouldBeError, errCantPush)
 		test.That(t, buttonPushed, test.ShouldEqual, testButtonName2)
 	})
 

--- a/components/button/server_test.go
+++ b/components/button/server_test.go
@@ -1,0 +1,94 @@
+package button_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	pbcommon "go.viam.com/api/common/v1"
+	pb "go.viam.com/api/component/button/v1"
+	"go.viam.com/test"
+	"go.viam.com/utils/protoutils"
+
+	"go.viam.com/rdk/components/button"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/testutils/inject"
+)
+
+var (
+	errCantPush       = errors.New("can't push")
+	errButtonNotFound = errors.New("not found")
+)
+
+func newServer() (pb.ButtonServiceServer, *inject.Button, *inject.Button, error) {
+	injectButton := &inject.Button{}
+	injectButton2 := &inject.Button{}
+	buttons := map[resource.Name]button.Button{
+		button.Named(testButtonName):  injectButton,
+		button.Named(testButtonName2): injectButton2,
+	}
+	buttonSvc, err := resource.NewAPIResourceCollection(button.API, buttons)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return button.NewRPCServiceServer(buttonSvc).(pb.ButtonServiceServer), injectButton, injectButton2, nil
+}
+
+func TestServer(t *testing.T) {
+	buttonServer, injectButton, injectButton2, err := newServer()
+	test.That(t, err, test.ShouldBeNil)
+
+	var buttonPushed string
+	var extraOptions map[string]interface{}
+
+	injectButton.PushFunc = func(ctx context.Context, extra map[string]interface{}) error {
+		extraOptions = extra
+		buttonPushed = testButtonName
+		return nil
+	}
+
+	injectButton2.PushFunc = func(ctx context.Context, extra map[string]interface{}) error {
+		buttonPushed = testButtonName2
+		return errCantPush
+	}
+
+	t.Run("push", func(t *testing.T) {
+		_, err := buttonServer.Push(context.Background(), &pb.PushRequest{Name: missingButtonName})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, errButtonNotFound.Error())
+
+		extra := map[string]interface{}{"foo": "Push"}
+		ext, err := protoutils.StructToStructPb(extra)
+		test.That(t, err, test.ShouldBeNil)
+		_, err = buttonServer.Push(context.Background(), &pb.PushRequest{Name: testButtonName, Extra: ext})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, buttonPushed, test.ShouldEqual, testButtonName)
+		test.That(t, extraOptions, test.ShouldResemble, extra)
+
+		_, err = buttonServer.Push(context.Background(), &pb.PushRequest{Name: testButtonName2})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, errCantPush.Error())
+		test.That(t, buttonPushed, test.ShouldEqual, testButtonName2)
+	})
+
+	t.Run("do command", func(t *testing.T) {
+		_, err := buttonServer.DoCommand(context.Background(), &pbcommon.DoCommandRequest{Name: missingButtonName})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, errButtonNotFound.Error())
+
+		injectButton.DoFunc = func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+			return cmd, nil
+		}
+
+		extra := map[string]interface{}{"foo": "DoCommand"}
+		ext, err := protoutils.StructToStructPb(extra)
+		test.That(t, err, test.ShouldBeNil)
+		resp, err := buttonServer.DoCommand(context.Background(), &pbcommon.DoCommandRequest{
+			Name:    testButtonName,
+			Command: ext,
+		})
+		test.That(t, err, test.ShouldBeNil)
+		respMap := resp.GetResult().AsMap()
+		test.That(t, respMap, test.ShouldResemble, extra)
+	})
+}

--- a/components/button/verify_main_test.go
+++ b/components/button/verify_main_test.go
@@ -1,0 +1,12 @@
+package button
+
+import (
+	"testing"
+
+	testutilsext "go.viam.com/utils/testutils/ext"
+)
+
+// TestMain is used to control the execution of all tests run within this package (including _test packages).
+func TestMain(m *testing.M) {
+	testutilsext.VerifyTestMain(m)
+}

--- a/components/register/all.go
+++ b/components/register/all.go
@@ -5,6 +5,7 @@ import (
 	// register components.
 	_ "go.viam.com/rdk/components/base/register"
 	_ "go.viam.com/rdk/components/board/register"
+	_ "go.viam.com/rdk/components/button/register"
 	_ "go.viam.com/rdk/components/camera/register"
 	_ "go.viam.com/rdk/components/encoder/register"
 	_ "go.viam.com/rdk/components/gantry/register"

--- a/testutils/inject/button.go
+++ b/testutils/inject/button.go
@@ -10,12 +10,20 @@ import (
 // Button implements button.Button for testing.
 type Button struct {
 	button.Button
+	name      resource.Name
+	PushFunc  func(ctx context.Context, extra map[string]interface{}) error
+	DoFunc    func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
+	CloseFunc func(ctx context.Context) error
+}
 
-	resource.Named
-	resource.TriviallyReconfigurable
-	resource.TriviallyCloseable
-	PushFunc func(ctx context.Context, extra map[string]interface{}) error
-	DoFunc   func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
+// NewButton returns a new injected button.
+func NewButton(name string) *Button {
+	return &Button{name: button.Named(name)}
+}
+
+// Name returns the name of the resource.
+func (b *Button) Name() resource.Name {
+	return b.name
 }
 
 // Push calls PushFunc.
@@ -32,4 +40,12 @@ func (b *Button) DoCommand(ctx context.Context, cmd map[string]interface{}) (map
 		return b.Button.DoCommand(ctx, cmd)
 	}
 	return b.DoFunc(ctx, cmd)
+}
+
+// Close calls CloseFunc.
+func (b *Button) Close(ctx context.Context) error {
+	if b.CloseFunc == nil {
+		return b.Button.Close(ctx)
+	}
+	return b.CloseFunc(ctx)
 }

--- a/testutils/inject/button.go
+++ b/testutils/inject/button.go
@@ -17,6 +17,9 @@ type Button struct {
 
 // Push calls PushFunc.
 func (b *Button) Push(ctx context.Context, extra map[string]interface{}) error {
+	if b.PushFunc == nil {
+		return nil
+	}
 	return b.PushFunc(ctx, extra)
 }
 

--- a/testutils/inject/button.go
+++ b/testutils/inject/button.go
@@ -1,0 +1,29 @@
+package inject
+
+import (
+	"context"
+
+	"go.viam.com/rdk/resource"
+)
+
+// Button implements button.Button for testing.
+type Button struct {
+	resource.Named
+	resource.TriviallyReconfigurable
+	resource.TriviallyCloseable
+	PushFunc func(ctx context.Context, extra map[string]interface{}) error
+	DoFunc   func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
+}
+
+// Push calls PushFunc.
+func (b *Button) Push(ctx context.Context, extra map[string]interface{}) error {
+	return b.PushFunc(ctx, extra)
+}
+
+// DoCommand calls DoFunc.
+func (b *Button) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+	if b.DoFunc == nil {
+		return nil, nil
+	}
+	return b.DoFunc(ctx, cmd)
+}

--- a/testutils/inject/button.go
+++ b/testutils/inject/button.go
@@ -3,11 +3,14 @@ package inject
 import (
 	"context"
 
+	"go.viam.com/rdk/components/button"
 	"go.viam.com/rdk/resource"
 )
 
 // Button implements button.Button for testing.
 type Button struct {
+	button.Button
+
 	resource.Named
 	resource.TriviallyReconfigurable
 	resource.TriviallyCloseable
@@ -18,7 +21,7 @@ type Button struct {
 // Push calls PushFunc.
 func (b *Button) Push(ctx context.Context, extra map[string]interface{}) error {
 	if b.PushFunc == nil {
-		return nil
+		return b.Button.Push(ctx, extra)
 	}
 	return b.PushFunc(ctx, extra)
 }
@@ -26,7 +29,7 @@ func (b *Button) Push(ctx context.Context, extra map[string]interface{}) error {
 // DoCommand calls DoFunc.
 func (b *Button) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
 	if b.DoFunc == nil {
-		return nil, nil
+		return b.Button.DoCommand(ctx, cmd)
 	}
 	return b.DoFunc(ctx, cmd)
 }


### PR DESCRIPTION
This adds the button client and server, and registers a button fake model.

Here's a button component properly configured in app:
![image](https://github.com/user-attachments/assets/cd8c580c-66d2-4ee6-baa2-d8db7f018902)

1. https://github.com/viamrobotics/api/pull/619
2. #4740
3. #4741 

## Change log

I used Cursor quite a bit here:
- Bump `go.viam.com/api` version
- Add `Button` SDK helpers
- Add client and tests
- Add server and tests
- Add inject testutil
- Add fake button implementation and register it
  - This implementation just logs a message when pushed

## Review requests

- Code review
- Try a config with the button fake - does it work as expected?