### PR TITLE
APP-7497: Add Switch client, server, and fake models

### DIFF
--- a/components/register/all.go
+++ b/components/register/all.go
@@ -14,9 +14,11 @@ import (
 	_ "go.viam.com/rdk/components/input/register"
 	_ "go.viam.com/rdk/components/motor/register"
 	_ "go.viam.com/rdk/components/movementsensor/register"
+
 	// register APIs without implementations directly.
 	_ "go.viam.com/rdk/components/posetracker"
 	_ "go.viam.com/rdk/components/powersensor/register"
 	_ "go.viam.com/rdk/components/sensor/register"
 	_ "go.viam.com/rdk/components/servo/register"
+	_ "go.viam.com/rdk/components/switch/register"
 )

--- a/components/register/all.go
+++ b/components/register/all.go
@@ -14,7 +14,6 @@ import (
 	_ "go.viam.com/rdk/components/input/register"
 	_ "go.viam.com/rdk/components/motor/register"
 	_ "go.viam.com/rdk/components/movementsensor/register"
-
 	// register APIs without implementations directly.
 	_ "go.viam.com/rdk/components/posetracker"
 	_ "go.viam.com/rdk/components/powersensor/register"

--- a/components/switch/client.go
+++ b/components/switch/client.go
@@ -1,5 +1,5 @@
-// Package switch_component contains a gRPC based switch client.
-package switch_component
+// Package toggleswitch contains a gRPC based switch client.
+package toggleswitch
 
 import (
 	"context"
@@ -68,7 +68,7 @@ func (c *client) GetPosition(ctx context.Context, extra map[string]interface{}) 
 	return resp.Position, nil
 }
 
-func (c *client) GetNumberOfPositions(ctx context.Context, extra map[string]interface{}) (int, error) {
+func (c *client) GetNumberOfPositions(ctx context.Context, extra map[string]interface{}) (uint32, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return 0, err
@@ -80,7 +80,7 @@ func (c *client) GetNumberOfPositions(ctx context.Context, extra map[string]inte
 	if err != nil {
 		return 0, err
 	}
-	return int(resp.NumberOfPositions), nil
+	return resp.NumberOfPositions, nil
 }
 
 func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {

--- a/components/switch/client.go
+++ b/components/switch/client.go
@@ -1,0 +1,88 @@
+// Package switch_component contains a gRPC based switch client.
+package switch_component
+
+import (
+	"context"
+
+	pb "go.viam.com/api/component/switch/v1"
+	"go.viam.com/utils/protoutils"
+	"go.viam.com/utils/rpc"
+
+	"go.viam.com/rdk/logging"
+	rprotoutils "go.viam.com/rdk/protoutils"
+	"go.viam.com/rdk/resource"
+)
+
+// client implements SwitchServiceClient.
+type client struct {
+	resource.Named
+	resource.TriviallyReconfigurable
+	resource.TriviallyCloseable
+	name   string
+	client pb.SwitchServiceClient
+	logger logging.Logger
+}
+
+// NewClientFromConn constructs a new Client from connection passed in.
+func NewClientFromConn(
+	ctx context.Context,
+	conn rpc.ClientConn,
+	remoteName string,
+	name resource.Name,
+	logger logging.Logger,
+) (Switch, error) {
+	c := pb.NewSwitchServiceClient(conn)
+	return &client{
+		Named:  name.PrependRemote(remoteName).AsNamed(),
+		name:   name.ShortName(),
+		client: c,
+		logger: logger,
+	}, nil
+}
+
+func (c *client) SetPosition(ctx context.Context, position uint32, extra map[string]interface{}) error {
+	ext, err := protoutils.StructToStructPb(extra)
+	if err != nil {
+		return err
+	}
+	_, err = c.client.SetPosition(ctx, &pb.SetPositionRequest{
+		Name:     c.name,
+		Position: position,
+		Extra:    ext,
+	})
+	return err
+}
+
+func (c *client) GetPosition(ctx context.Context, extra map[string]interface{}) (uint32, error) {
+	ext, err := protoutils.StructToStructPb(extra)
+	if err != nil {
+		return 0, err
+	}
+	resp, err := c.client.GetPosition(ctx, &pb.GetPositionRequest{
+		Name:  c.name,
+		Extra: ext,
+	})
+	if err != nil {
+		return 0, err
+	}
+	return resp.Position, nil
+}
+
+func (c *client) GetNumberOfPositions(ctx context.Context, extra map[string]interface{}) (int, error) {
+	ext, err := protoutils.StructToStructPb(extra)
+	if err != nil {
+		return 0, err
+	}
+	resp, err := c.client.GetNumberOfPositions(ctx, &pb.GetNumberOfPositionsRequest{
+		Name:  c.name,
+		Extra: ext,
+	})
+	if err != nil {
+		return 0, err
+	}
+	return int(resp.NumberOfPositions), nil
+}
+
+func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+	return rprotoutils.DoFromResourceClient(ctx, c.client, c.name, cmd)
+}

--- a/components/switch/client_test.go
+++ b/components/switch/client_test.go
@@ -1,4 +1,4 @@
-package switch_component_test
+package toggleswitch_test
 
 import (
 	"context"
@@ -8,7 +8,7 @@ import (
 	"go.viam.com/test"
 	"go.viam.com/utils/rpc"
 
-	switch_component "go.viam.com/rdk/components/switch"
+	toggleswitch "go.viam.com/rdk/components/switch"
 	viamgrpc "go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -42,7 +42,7 @@ func TestClient(t *testing.T) {
 		extraOptions = extra
 		return 0, nil
 	}
-	injectSwitch.GetNumberOfPositionsFunc = func(ctx context.Context, extra map[string]interface{}) (int, error) {
+	injectSwitch.GetNumberOfPositionsFunc = func(ctx context.Context, extra map[string]interface{}) (uint32, error) {
 		extraOptions = extra
 		return 2, nil
 	}
@@ -55,18 +55,18 @@ func TestClient(t *testing.T) {
 	injectSwitch2.GetPositionFunc = func(ctx context.Context, extra map[string]interface{}) (uint32, error) {
 		return 0, errCantGetPosition
 	}
-	injectSwitch2.GetNumberOfPositionsFunc = func(ctx context.Context, extra map[string]interface{}) (int, error) {
+	injectSwitch2.GetNumberOfPositionsFunc = func(ctx context.Context, extra map[string]interface{}) (uint32, error) {
 		return 0, errCantGetNumberOfPositions
 	}
 
 	switchSvc, err := resource.NewAPIResourceCollection(
-		switch_component.API,
-		map[resource.Name]switch_component.Switch{
-			switch_component.Named(testSwitchName): injectSwitch,
-			switch_component.Named(failSwitchName): injectSwitch2,
+		toggleswitch.API,
+		map[resource.Name]toggleswitch.Switch{
+			toggleswitch.Named(testSwitchName): injectSwitch,
+			toggleswitch.Named(failSwitchName): injectSwitch2,
 		})
 	test.That(t, err, test.ShouldBeNil)
-	resourceAPI, ok, err := resource.LookupAPIRegistration[switch_component.Switch](switch_component.API)
+	resourceAPI, ok, err := resource.LookupAPIRegistration[toggleswitch.Switch](toggleswitch.API)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, ok, test.ShouldBeTrue)
 	test.That(t, resourceAPI.RegisterRPCService(context.Background(), rpcServer, switchSvc), test.ShouldBeNil)
@@ -89,7 +89,7 @@ func TestClient(t *testing.T) {
 	t.Run("switch client 1", func(t *testing.T) {
 		conn, err := viamgrpc.Dial(context.Background(), listener1.Addr().String(), logger)
 		test.That(t, err, test.ShouldBeNil)
-		client1, err := switch_component.NewClientFromConn(context.Background(), conn, "", switch_component.Named(testSwitchName), logger)
+		client1, err := toggleswitch.NewClientFromConn(context.Background(), conn, "", toggleswitch.Named(testSwitchName), logger)
 		test.That(t, err, test.ShouldBeNil)
 
 		// DoCommand
@@ -123,7 +123,7 @@ func TestClient(t *testing.T) {
 	t.Run("switch client 2", func(t *testing.T) {
 		conn, err := viamgrpc.Dial(context.Background(), listener1.Addr().String(), logger)
 		test.That(t, err, test.ShouldBeNil)
-		client2, err := resourceAPI.RPCClient(context.Background(), conn, "", switch_component.Named(failSwitchName), logger)
+		client2, err := resourceAPI.RPCClient(context.Background(), conn, "", toggleswitch.Named(failSwitchName), logger)
 		test.That(t, err, test.ShouldBeNil)
 
 		extra := map[string]interface{}{}

--- a/components/switch/client_test.go
+++ b/components/switch/client_test.go
@@ -16,6 +16,12 @@ import (
 	"go.viam.com/rdk/testutils/inject"
 )
 
+const (
+	testSwitchName    = "switch1"
+	failSwitchName    = "switch2"
+	missingSwitchName = "missing"
+)
+
 func TestClient(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	listener1, err := net.Listen("tcp", "localhost:0")

--- a/components/switch/client_test.go
+++ b/components/switch/client_test.go
@@ -1,0 +1,146 @@
+package switch_component_test
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"go.viam.com/test"
+	"go.viam.com/utils/rpc"
+
+	switch_component "go.viam.com/rdk/components/switch"
+	viamgrpc "go.viam.com/rdk/grpc"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/testutils"
+	"go.viam.com/rdk/testutils/inject"
+)
+
+const (
+	testSwitchName    = "switch1"
+	failSwitchName    = "switch2"
+	missingSwitchName = "missing"
+)
+
+func TestClient(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	listener1, err := net.Listen("tcp", "localhost:0")
+	test.That(t, err, test.ShouldBeNil)
+	rpcServer, err := rpc.NewServer(logger, rpc.WithUnauthenticated())
+	test.That(t, err, test.ShouldBeNil)
+
+	var switchName string
+	var extraOptions map[string]interface{}
+
+	injectSwitch := &inject.Switch{}
+	injectSwitch.SetPositionFunc = func(ctx context.Context, position uint32, extra map[string]interface{}) error {
+		extraOptions = extra
+		switchName = testSwitchName
+		return nil
+	}
+	injectSwitch.GetPositionFunc = func(ctx context.Context, extra map[string]interface{}) (uint32, error) {
+		extraOptions = extra
+		return 0, nil
+	}
+	injectSwitch.GetNumberOfPositionsFunc = func(ctx context.Context, extra map[string]interface{}) (int, error) {
+		extraOptions = extra
+		return 2, nil
+	}
+
+	injectSwitch2 := &inject.Switch{}
+	injectSwitch2.SetPositionFunc = func(ctx context.Context, position uint32, extra map[string]interface{}) error {
+		switchName = failSwitchName
+		return errCantSetPosition
+	}
+	injectSwitch2.GetPositionFunc = func(ctx context.Context, extra map[string]interface{}) (uint32, error) {
+		return 0, errCantGetPosition
+	}
+	injectSwitch2.GetNumberOfPositionsFunc = func(ctx context.Context, extra map[string]interface{}) (int, error) {
+		return 0, errCantGetNumberOfPositions
+	}
+
+	switchSvc, err := resource.NewAPIResourceCollection(
+		switch_component.API,
+		map[resource.Name]switch_component.Switch{
+			switch_component.Named(testSwitchName): injectSwitch,
+			switch_component.Named(failSwitchName): injectSwitch2,
+		})
+	test.That(t, err, test.ShouldBeNil)
+	resourceAPI, ok, err := resource.LookupAPIRegistration[switch_component.Switch](switch_component.API)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, resourceAPI.RegisterRPCService(context.Background(), rpcServer, switchSvc), test.ShouldBeNil)
+
+	injectSwitch.DoFunc = testutils.EchoFunc
+
+	go rpcServer.Serve(listener1)
+	defer rpcServer.Stop()
+
+	// failing
+	t.Run("Failing client", func(t *testing.T) {
+		cancelCtx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := viamgrpc.Dial(cancelCtx, listener1.Addr().String(), logger)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err, test.ShouldBeError, context.Canceled)
+	})
+
+	// working
+	t.Run("switch client 1", func(t *testing.T) {
+		conn, err := viamgrpc.Dial(context.Background(), listener1.Addr().String(), logger)
+		test.That(t, err, test.ShouldBeNil)
+		client1, err := switch_component.NewClientFromConn(context.Background(), conn, "", switch_component.Named(testSwitchName), logger)
+		test.That(t, err, test.ShouldBeNil)
+
+		// DoCommand
+		resp, err := client1.DoCommand(context.Background(), testutils.TestCommand)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, resp["command"], test.ShouldEqual, testutils.TestCommand["command"])
+		test.That(t, resp["data"], test.ShouldEqual, testutils.TestCommand["data"])
+
+		extra := map[string]interface{}{"foo": "SetPosition"}
+		err = client1.SetPosition(context.Background(), 0, extra)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, extraOptions, test.ShouldResemble, extra)
+		test.That(t, switchName, test.ShouldEqual, testSwitchName)
+
+		extra = map[string]interface{}{"foo": "GetPosition"}
+		pos, err := client1.GetPosition(context.Background(), extra)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, extraOptions, test.ShouldResemble, extra)
+		test.That(t, pos, test.ShouldEqual, 0)
+
+		extra = map[string]interface{}{"foo": "GetNumberOfPositions"}
+		count, err := client1.GetNumberOfPositions(context.Background(), extra)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, extraOptions, test.ShouldResemble, extra)
+		test.That(t, count, test.ShouldEqual, 2)
+
+		test.That(t, client1.Close(context.Background()), test.ShouldBeNil)
+		test.That(t, conn.Close(), test.ShouldBeNil)
+	})
+
+	t.Run("switch client 2", func(t *testing.T) {
+		conn, err := viamgrpc.Dial(context.Background(), listener1.Addr().String(), logger)
+		test.That(t, err, test.ShouldBeNil)
+		client2, err := resourceAPI.RPCClient(context.Background(), conn, "", switch_component.Named(failSwitchName), logger)
+		test.That(t, err, test.ShouldBeNil)
+
+		extra := map[string]interface{}{}
+		err = client2.SetPosition(context.Background(), 0, extra)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, errCantSetPosition.Error())
+		test.That(t, switchName, test.ShouldEqual, failSwitchName)
+
+		_, err = client2.GetPosition(context.Background(), extra)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, errCantGetPosition.Error())
+
+		_, err = client2.GetNumberOfPositions(context.Background(), extra)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, errCantGetNumberOfPositions.Error())
+
+		test.That(t, client2.Close(context.Background()), test.ShouldBeNil)
+		test.That(t, conn.Close(), test.ShouldBeNil)
+	})
+}

--- a/components/switch/fake/switch.go
+++ b/components/switch/fake/switch.go
@@ -13,8 +13,8 @@ import (
 
 var model = resource.DefaultModelFamily.WithModel("fake")
 
-// switchConfig is the config for a fake switch.
-type switchConfig struct {
+// Config is the config for a fake switch.
+type Config struct {
 	resource.TriviallyValidateConfig
 
 	// PositionCount is the number of positions that the switch can be in.
@@ -24,10 +24,8 @@ type switchConfig struct {
 
 func init() {
 	// Register all three switch models
-	resource.RegisterComponent(toggleswitch.API, model, resource.Registration[toggleswitch.Switch, *switchConfig]{
-		Constructor: func(ctx context.Context, deps resource.Dependencies, conf resource.Config, logger logging.Logger) (toggleswitch.Switch, error) {
-			return NewSwitch(ctx, deps, conf, logger)
-		},
+	resource.RegisterComponent(toggleswitch.API, model, resource.Registration[toggleswitch.Switch, *Config]{
+		Constructor: NewSwitch,
 	})
 }
 
@@ -49,7 +47,6 @@ func NewSwitch(
 	conf resource.Config,
 	logger logging.Logger,
 ) (toggleswitch.Switch, error) {
-
 	s := &Switch{
 		Named:         conf.ResourceName().AsNamed(),
 		logger:        logger,
@@ -57,7 +54,7 @@ func NewSwitch(
 		positionCount: 2,
 	}
 
-	newConf, err := resource.NativeConfig[*switchConfig](conf)
+	newConf, err := resource.NativeConfig[*Config](conf)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +71,7 @@ func (s *Switch) SetPosition(ctx context.Context, position uint32, extra map[str
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if position >= uint32(s.positionCount) {
+	if position >= s.positionCount {
 		return fmt.Errorf("switch component %v position %d is invalid (valid range: 0-%d)", s.Name(), position, s.positionCount-1)
 	}
 	s.position = position

--- a/components/switch/fake/switch.go
+++ b/components/switch/fake/switch.go
@@ -1,0 +1,108 @@
+// Package fake implements fake switches with different position counts.
+package fake
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	switch_component "go.viam.com/rdk/components/switch"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+)
+
+var (
+	model2Way  = resource.DefaultModelFamily.WithModel("fake-2way")
+	model3Way  = resource.DefaultModelFamily.WithModel("fake-3way")
+	model10Way = resource.DefaultModelFamily.WithModel("fake-10way")
+)
+
+// Config is the config for a fake switch.
+type Config struct {
+	resource.TriviallyValidateConfig
+}
+
+func init() {
+	// Register all three switch models
+	resource.RegisterComponent(switch_component.API, model2Way, resource.Registration[switch_component.Switch, *Config]{
+		Constructor: func(ctx context.Context, deps resource.Dependencies, conf resource.Config, logger logging.Logger) (switch_component.Switch, error) {
+			return NewSwitch(ctx, deps, conf, logger, 2)
+		},
+	})
+	resource.RegisterComponent(switch_component.API, model3Way, resource.Registration[switch_component.Switch, *Config]{
+		Constructor: func(ctx context.Context, deps resource.Dependencies, conf resource.Config, logger logging.Logger) (switch_component.Switch, error) {
+			return NewSwitch(ctx, deps, conf, logger, 3)
+		},
+	})
+	resource.RegisterComponent(switch_component.API, model10Way, resource.Registration[switch_component.Switch, *Config]{
+		Constructor: func(ctx context.Context, deps resource.Dependencies, conf resource.Config, logger logging.Logger) (switch_component.Switch, error) {
+			return NewSwitch(ctx, deps, conf, logger, 10)
+		},
+	})
+}
+
+// Switch is a fake switch that can be set to different positions.
+type Switch struct {
+	resource.Named
+	resource.TriviallyCloseable
+	mu            sync.Mutex
+	logger        logging.Logger
+	position      uint32
+	positionCount int
+}
+
+// NewSwitch instantiates a new switch of the fake model type.
+func NewSwitch(
+	ctx context.Context,
+	deps resource.Dependencies,
+	conf resource.Config,
+	logger logging.Logger,
+	positionCount int,
+) (switch_component.Switch, error) {
+	s := &Switch{
+		Named:         conf.ResourceName().AsNamed(),
+		logger:        logger,
+		position:      0,
+		positionCount: positionCount,
+	}
+	if err := s.Reconfigure(ctx, deps, conf); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// Reconfigure reconfigures the switch atomically and in place.
+func (s *Switch) Reconfigure(_ context.Context, _ resource.Dependencies, conf resource.Config) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return nil
+}
+
+// SetPosition sets the switch to the specified position.
+func (s *Switch) SetPosition(ctx context.Context, position uint32, extra map[string]interface{}) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if position >= uint32(s.positionCount) {
+		return fmt.Errorf("switch component %v position %d is invalid (valid range: 0-%d)", s.Name(), position, s.positionCount-1)
+	}
+	s.position = position
+	return nil
+}
+
+// GetPosition returns the current position of the switch.
+func (s *Switch) GetPosition(ctx context.Context, extra map[string]interface{}) (uint32, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.position, nil
+}
+
+// GetNumberOfPositions returns the total number of valid positions for this switch.
+func (s *Switch) GetNumberOfPositions(ctx context.Context, extra map[string]interface{}) (int, error) {
+	return s.positionCount, nil
+}
+
+// DoCommand executes a command on the switch.
+func (s *Switch) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+	return cmd, nil
+}

--- a/components/switch/fake/switch_test.go
+++ b/components/switch/fake/switch_test.go
@@ -1,4 +1,4 @@
-package toggleswitch_test
+package fake_test
 
 import (
 	"context"
@@ -12,15 +12,9 @@ import (
 	"go.viam.com/rdk/resource"
 )
 
-const (
-	testSwitchName    = "switch1"
-	failSwitchName    = "switch2"
-	missingSwitchName = "missing"
-)
-
 func TestSwitch(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-  positionCount := uint32(3)
+	positionCount := uint32(3)
 	cfg := resource.Config{
 		Name: "fakeSwitch",
 		API:  toggleswitch.API,

--- a/components/switch/register/register.go
+++ b/components/switch/register/register.go
@@ -1,0 +1,7 @@
+// Package register registers all relevant switches and also API specific functions
+package register
+
+import (
+	// for switches.
+	_ "go.viam.com/rdk/components/switch/fake"
+)

--- a/components/switch/server.go
+++ b/components/switch/server.go
@@ -1,5 +1,5 @@
-// Package switch_component contains a gRPC based switch service server.
-package switch_component
+// Package toggleswitch contains a gRPC based switch service server.
+package toggleswitch
 
 import (
 	"context"

--- a/components/switch/server.go
+++ b/components/switch/server.go
@@ -46,11 +46,13 @@ func (s *serviceServer) GetPosition(ctx context.Context, req *pb.GetPositionRequ
 	if err != nil {
 		return nil, err
 	}
-	return &pb.GetPositionResponse{Position: uint32(position)}, nil
+	return &pb.GetPositionResponse{Position: position}, nil
 }
 
 // GetNumberOfPositions gets the total number of positions for a switch of the underlying robot.
-func (s *serviceServer) GetNumberOfPositions(ctx context.Context, req *pb.GetNumberOfPositionsRequest) (*pb.GetNumberOfPositionsResponse, error) {
+func (s *serviceServer) GetNumberOfPositions(
+	ctx context.Context, req *pb.GetNumberOfPositionsRequest,
+) (*pb.GetNumberOfPositionsResponse, error) {
 	sw, err := s.coll.Resource(req.Name)
 	if err != nil {
 		return nil, err
@@ -59,5 +61,5 @@ func (s *serviceServer) GetNumberOfPositions(ctx context.Context, req *pb.GetNum
 	if err != nil {
 		return nil, err
 	}
-	return &pb.GetNumberOfPositionsResponse{NumberOfPositions: uint32(count)}, nil
+	return &pb.GetNumberOfPositionsResponse{NumberOfPositions: count}, nil
 }

--- a/components/switch/server.go
+++ b/components/switch/server.go
@@ -1,0 +1,63 @@
+// Package switch_component contains a gRPC based switch service server.
+package switch_component
+
+import (
+	"context"
+	"fmt"
+
+	pb "go.viam.com/api/component/switch/v1"
+
+	"go.viam.com/rdk/resource"
+)
+
+// ErrInvalidPosition is the returned error if switch position is invalid.
+var ErrInvalidPosition = func(switchName string, position, maxPosition int) error {
+	return fmt.Errorf("switch component %v position %d is invalid (max: %d)", switchName, position, maxPosition)
+}
+
+// serviceServer implements the SwitchService from switch.proto.
+type serviceServer struct {
+	pb.UnimplementedSwitchServiceServer
+	coll resource.APIResourceCollection[Switch]
+}
+
+// NewRPCServiceServer constructs a switch gRPC service server.
+// It is intentionally untyped to prevent use outside of tests.
+func NewRPCServiceServer(coll resource.APIResourceCollection[Switch]) interface{} {
+	return &serviceServer{coll: coll}
+}
+
+// SetPosition sets the position of a switch of the underlying robot.
+func (s *serviceServer) SetPosition(ctx context.Context, req *pb.SetPositionRequest) (*pb.SetPositionResponse, error) {
+	sw, err := s.coll.Resource(req.Name)
+	if err != nil {
+		return nil, err
+	}
+	return &pb.SetPositionResponse{}, sw.SetPosition(ctx, req.Position, req.Extra.AsMap())
+}
+
+// GetPosition gets the current position of a switch of the underlying robot.
+func (s *serviceServer) GetPosition(ctx context.Context, req *pb.GetPositionRequest) (*pb.GetPositionResponse, error) {
+	sw, err := s.coll.Resource(req.Name)
+	if err != nil {
+		return nil, err
+	}
+	position, err := sw.GetPosition(ctx, req.Extra.AsMap())
+	if err != nil {
+		return nil, err
+	}
+	return &pb.GetPositionResponse{Position: uint32(position)}, nil
+}
+
+// GetNumberOfPositions gets the total number of positions for a switch of the underlying robot.
+func (s *serviceServer) GetNumberOfPositions(ctx context.Context, req *pb.GetNumberOfPositionsRequest) (*pb.GetNumberOfPositionsResponse, error) {
+	sw, err := s.coll.Resource(req.Name)
+	if err != nil {
+		return nil, err
+	}
+	count, err := sw.GetNumberOfPositions(ctx, req.Extra.AsMap())
+	if err != nil {
+		return nil, err
+	}
+	return &pb.GetNumberOfPositionsResponse{NumberOfPositions: uint32(count)}, nil
+}

--- a/components/switch/server.go
+++ b/components/switch/server.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"fmt"
 
+	commonpb "go.viam.com/api/common/v1"
 	pb "go.viam.com/api/component/switch/v1"
 
+	"go.viam.com/rdk/protoutils"
 	"go.viam.com/rdk/resource"
 )
 
@@ -62,4 +64,15 @@ func (s *serviceServer) GetNumberOfPositions(
 		return nil, err
 	}
 	return &pb.GetNumberOfPositionsResponse{NumberOfPositions: count}, nil
+}
+
+// DoCommand receives arbitrary commands.
+func (s *serviceServer) DoCommand(ctx context.Context,
+	req *commonpb.DoCommandRequest,
+) (*commonpb.DoCommandResponse, error) {
+	sw, err := s.coll.Resource(req.GetName())
+	if err != nil {
+		return nil, err
+	}
+	return protoutils.DoFromResourceServer(ctx, sw, req)
 }

--- a/components/switch/server_test.go
+++ b/components/switch/server_test.go
@@ -1,4 +1,4 @@
-package switch_component_test
+package toggleswitch_test
 
 import (
 	"context"
@@ -9,7 +9,7 @@ import (
 	"go.viam.com/test"
 	"go.viam.com/utils/protoutils"
 
-	switch_component "go.viam.com/rdk/components/switch"
+	toggleswitch "go.viam.com/rdk/components/switch"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/testutils/inject"
 )
@@ -26,15 +26,15 @@ const testSwitchName2 = "switch3"
 func newServer() (pb.SwitchServiceServer, *inject.Switch, *inject.Switch, error) {
 	injectSwitch := &inject.Switch{}
 	injectSwitch2 := &inject.Switch{}
-	switches := map[resource.Name]switch_component.Switch{
-		switch_component.Named(testSwitchName):  injectSwitch,
-		switch_component.Named(testSwitchName2): injectSwitch2,
+	switches := map[resource.Name]toggleswitch.Switch{
+		toggleswitch.Named(testSwitchName):  injectSwitch,
+		toggleswitch.Named(testSwitchName2): injectSwitch2,
 	}
-	switchSvc, err := resource.NewAPIResourceCollection(switch_component.API, switches)
+	switchSvc, err := resource.NewAPIResourceCollection(toggleswitch.API, switches)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	return switch_component.NewRPCServiceServer(switchSvc).(pb.SwitchServiceServer), injectSwitch, injectSwitch2, nil
+	return toggleswitch.NewRPCServiceServer(switchSvc).(pb.SwitchServiceServer), injectSwitch, injectSwitch2, nil
 }
 
 func TestServer(t *testing.T) {
@@ -53,7 +53,7 @@ func TestServer(t *testing.T) {
 		extraOptions = extra
 		return 0, nil
 	}
-	injectSwitch.GetNumberOfPositionsFunc = func(ctx context.Context, extra map[string]interface{}) (int, error) {
+	injectSwitch.GetNumberOfPositionsFunc = func(ctx context.Context, extra map[string]interface{}) (uint32, error) {
 		extraOptions = extra
 		return 2, nil
 	}
@@ -65,7 +65,7 @@ func TestServer(t *testing.T) {
 	injectSwitch2.GetPositionFunc = func(ctx context.Context, extra map[string]interface{}) (uint32, error) {
 		return 0, errCantGetPosition
 	}
-	injectSwitch2.GetNumberOfPositionsFunc = func(ctx context.Context, extra map[string]interface{}) (int, error) {
+	injectSwitch2.GetNumberOfPositionsFunc = func(ctx context.Context, extra map[string]interface{}) (uint32, error) {
 		return 0, errCantGetNumberOfPositions
 	}
 

--- a/components/switch/server_test.go
+++ b/components/switch/server_test.go
@@ -1,0 +1,126 @@
+package switch_component_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	pb "go.viam.com/api/component/switch/v1"
+	"go.viam.com/test"
+	"go.viam.com/utils/protoutils"
+
+	switch_component "go.viam.com/rdk/components/switch"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/testutils/inject"
+)
+
+var (
+	errCantSetPosition          = errors.New("can't set position")
+	errCantGetPosition          = errors.New("can't get position")
+	errCantGetNumberOfPositions = errors.New("can't get number of positions")
+	errSwitchNotFound           = errors.New("not found")
+)
+
+const testSwitchName2 = "switch3"
+
+func newServer() (pb.SwitchServiceServer, *inject.Switch, *inject.Switch, error) {
+	injectSwitch := &inject.Switch{}
+	injectSwitch2 := &inject.Switch{}
+	switches := map[resource.Name]switch_component.Switch{
+		switch_component.Named(testSwitchName):  injectSwitch,
+		switch_component.Named(testSwitchName2): injectSwitch2,
+	}
+	switchSvc, err := resource.NewAPIResourceCollection(switch_component.API, switches)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return switch_component.NewRPCServiceServer(switchSvc).(pb.SwitchServiceServer), injectSwitch, injectSwitch2, nil
+}
+
+func TestServer(t *testing.T) {
+	switchServer, injectSwitch, injectSwitch2, err := newServer()
+	test.That(t, err, test.ShouldBeNil)
+
+	var switchName string
+	var extraOptions map[string]interface{}
+
+	injectSwitch.SetPositionFunc = func(ctx context.Context, position uint32, extra map[string]interface{}) error {
+		extraOptions = extra
+		switchName = testSwitchName
+		return nil
+	}
+	injectSwitch.GetPositionFunc = func(ctx context.Context, extra map[string]interface{}) (uint32, error) {
+		extraOptions = extra
+		return 0, nil
+	}
+	injectSwitch.GetNumberOfPositionsFunc = func(ctx context.Context, extra map[string]interface{}) (int, error) {
+		extraOptions = extra
+		return 2, nil
+	}
+
+	injectSwitch2.SetPositionFunc = func(ctx context.Context, position uint32, extra map[string]interface{}) error {
+		switchName = testSwitchName2
+		return errCantSetPosition
+	}
+	injectSwitch2.GetPositionFunc = func(ctx context.Context, extra map[string]interface{}) (uint32, error) {
+		return 0, errCantGetPosition
+	}
+	injectSwitch2.GetNumberOfPositionsFunc = func(ctx context.Context, extra map[string]interface{}) (int, error) {
+		return 0, errCantGetNumberOfPositions
+	}
+
+	t.Run("set position", func(t *testing.T) {
+		_, err := switchServer.SetPosition(context.Background(), &pb.SetPositionRequest{Name: missingSwitchName})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, errSwitchNotFound.Error())
+
+		extra := map[string]interface{}{"foo": "SetPosition"}
+		ext, err := protoutils.StructToStructPb(extra)
+		test.That(t, err, test.ShouldBeNil)
+		_, err = switchServer.SetPosition(context.Background(), &pb.SetPositionRequest{Name: testSwitchName, Position: 0, Extra: ext})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, switchName, test.ShouldEqual, testSwitchName)
+		test.That(t, extraOptions, test.ShouldResemble, extra)
+
+		_, err = switchServer.SetPosition(context.Background(), &pb.SetPositionRequest{Name: testSwitchName2})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, errCantSetPosition.Error())
+		test.That(t, switchName, test.ShouldEqual, testSwitchName2)
+	})
+
+	t.Run("get position", func(t *testing.T) {
+		_, err := switchServer.GetPosition(context.Background(), &pb.GetPositionRequest{Name: missingSwitchName})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, errSwitchNotFound.Error())
+
+		extra := map[string]interface{}{"foo": "GetPosition"}
+		ext, err := protoutils.StructToStructPb(extra)
+		test.That(t, err, test.ShouldBeNil)
+		resp, err := switchServer.GetPosition(context.Background(), &pb.GetPositionRequest{Name: testSwitchName, Extra: ext})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, resp.Position, test.ShouldEqual, 0)
+		test.That(t, extraOptions, test.ShouldResemble, extra)
+
+		_, err = switchServer.GetPosition(context.Background(), &pb.GetPositionRequest{Name: testSwitchName2})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, errCantGetPosition.Error())
+	})
+
+	t.Run("get number of positions", func(t *testing.T) {
+		_, err := switchServer.GetNumberOfPositions(context.Background(), &pb.GetNumberOfPositionsRequest{Name: missingSwitchName})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, errSwitchNotFound.Error())
+
+		extra := map[string]interface{}{"foo": "GetNumberOfPositions"}
+		ext, err := protoutils.StructToStructPb(extra)
+		test.That(t, err, test.ShouldBeNil)
+		resp, err := switchServer.GetNumberOfPositions(context.Background(), &pb.GetNumberOfPositionsRequest{Name: testSwitchName, Extra: ext})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, resp.NumberOfPositions, test.ShouldEqual, 2)
+		test.That(t, extraOptions, test.ShouldResemble, extra)
+
+		_, err = switchServer.GetNumberOfPositions(context.Background(), &pb.GetNumberOfPositionsRequest{Name: testSwitchName2})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, errCantGetNumberOfPositions.Error())
+	})
+}

--- a/components/switch/switch.go
+++ b/components/switch/switch.go
@@ -1,0 +1,57 @@
+// Package switch_component defines a multi-position switch.
+package switch_component
+
+import (
+	"context"
+
+	pb "go.viam.com/api/component/switch/v1"
+
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/robot"
+)
+
+func init() {
+	resource.RegisterAPI(API, resource.APIRegistration[Switch]{
+		RPCServiceServerConstructor: NewRPCServiceServer,
+		RPCServiceHandler:           pb.RegisterSwitchServiceHandlerFromEndpoint,
+		RPCServiceDesc:              &pb.SwitchService_ServiceDesc,
+		RPCClient:                   NewClientFromConn,
+	})
+}
+
+// SubtypeName is a constant that identifies the component resource API string.
+const SubtypeName = "switch"
+
+// API is a variable that identifies the component resource API.
+var API = resource.APINamespaceRDK.WithComponentType(SubtypeName)
+
+// Named is a helper for getting the named switch's typed resource name.
+func Named(name string) resource.Name {
+	return resource.NewName(API, name)
+}
+
+// A Switch represents a physical multi-position switch.
+type Switch interface {
+	resource.Resource
+
+	// SetPosition sets the switch to the specified position.
+	// Position must be within the valid range for the switch type.
+	// This will block until done or a new operation cancels this one.
+	SetPosition(ctx context.Context, position uint32, extra map[string]interface{}) error
+
+	// GetPosition returns the current position of the switch.
+	GetPosition(ctx context.Context, extra map[string]interface{}) (uint32, error)
+
+	// GetNumberOfPositions returns the total number of valid positions for this switch.
+	GetNumberOfPositions(ctx context.Context, extra map[string]interface{}) (int, error)
+}
+
+// FromRobot is a helper for getting the named Switch from the given Robot.
+func FromRobot(r robot.Robot, name string) (Switch, error) {
+	return robot.ResourceFromRobot[Switch](r, Named(name))
+}
+
+// NamesFromRobot is a helper for getting all switch names from the given Robot.
+func NamesFromRobot(r robot.Robot) []string {
+	return robot.NamesByAPI(r, API)
+}

--- a/components/switch/switch.go
+++ b/components/switch/switch.go
@@ -1,5 +1,5 @@
-// Package switch_component defines a multi-position switch.
-package switch_component
+// Package toggleswitch defines a multi-position switch.
+package toggleswitch
 
 import (
 	"context"
@@ -43,12 +43,17 @@ type Switch interface {
 	GetPosition(ctx context.Context, extra map[string]interface{}) (uint32, error)
 
 	// GetNumberOfPositions returns the total number of valid positions for this switch.
-	GetNumberOfPositions(ctx context.Context, extra map[string]interface{}) (int, error)
+	GetNumberOfPositions(ctx context.Context, extra map[string]interface{}) (uint32, error)
 }
 
 // FromRobot is a helper for getting the named Switch from the given Robot.
 func FromRobot(r robot.Robot, name string) (Switch, error) {
 	return robot.ResourceFromRobot[Switch](r, Named(name))
+}
+
+// FromDependencies is a helper for getting the named button component from a collection of dependencies.
+func FromDependencies(deps resource.Dependencies, name string) (Switch, error) {
+	return resource.FromDependencies[Switch](deps, Named(name))
 }
 
 // NamesFromRobot is a helper for getting all switch names from the given Robot.

--- a/components/switch/switch_test.go
+++ b/components/switch/switch_test.go
@@ -1,0 +1,37 @@
+package toggleswitch_test
+
+import (
+	"context"
+	"testing"
+
+	"go.viam.com/test"
+
+	toggleswitch "go.viam.com/rdk/components/switch"
+	"go.viam.com/rdk/components/switch/fake"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+)
+
+const (
+	testSwitchName    = "switch1"
+	failSwitchName    = "switch2"
+	missingSwitchName = "missing"
+)
+
+func TestSwitch(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+  positionCount := uint32(3)
+	cfg := resource.Config{
+		Name: "fakeSwitch",
+		API:  toggleswitch.API,
+		ConvertedAttributes: &fake.Config{
+			PositionCount: &positionCount,
+		},
+	}
+	s, err := fake.NewSwitch(context.Background(), nil, cfg, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	n, err := s.GetNumberOfPositions(context.Background(), nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, n, test.ShouldEqual, positionCount)
+}

--- a/testutils/inject/switch.go
+++ b/testutils/inject/switch.go
@@ -3,23 +3,23 @@ package inject
 import (
 	"context"
 
-	switch_component "go.viam.com/rdk/components/switch"
+	toggleswitch "go.viam.com/rdk/components/switch"
 	"go.viam.com/rdk/resource"
 )
 
 // Switch is an injected switch.
 type Switch struct {
-	switch_component.Switch
+	toggleswitch.Switch
 	name                     resource.Name
 	DoFunc                   func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
 	SetPositionFunc          func(ctx context.Context, position uint32, extra map[string]interface{}) error
 	GetPositionFunc          func(ctx context.Context, extra map[string]interface{}) (uint32, error)
-	GetNumberOfPositionsFunc func(ctx context.Context, extra map[string]interface{}) (int, error)
+	GetNumberOfPositionsFunc func(ctx context.Context, extra map[string]interface{}) (uint32, error)
 }
 
 // NewSwitch returns a new injected switch.
 func NewSwitch(name string) *Switch {
-	return &Switch{name: switch_component.Named(name)}
+	return &Switch{name: toggleswitch.Named(name)}
 }
 
 // Name returns the name of the resource.
@@ -29,20 +29,32 @@ func (s *Switch) Name() resource.Name {
 
 // DoCommand executes a command on the switch.
 func (s *Switch) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+	if s.DoFunc == nil {
+		return nil, nil
+	}
 	return s.DoFunc(ctx, cmd)
 }
 
 // SetPosition sets the switch position.
 func (s *Switch) SetPosition(ctx context.Context, position uint32, extra map[string]interface{}) error {
+	if s.SetPositionFunc == nil {
+		return nil
+	}
 	return s.SetPositionFunc(ctx, position, extra)
 }
 
 // GetPosition gets the current switch position.
 func (s *Switch) GetPosition(ctx context.Context, extra map[string]interface{}) (uint32, error) {
+	if s.GetPositionFunc == nil {
+		return 0, nil
+	}
 	return s.GetPositionFunc(ctx, extra)
 }
 
 // GetNumberOfPositions gets the total number of positions for the switch.
-func (s *Switch) GetNumberOfPositions(ctx context.Context, extra map[string]interface{}) (int, error) {
+func (s *Switch) GetNumberOfPositions(ctx context.Context, extra map[string]interface{}) (uint32, error) {
+	if s.GetNumberOfPositionsFunc == nil {
+		return 0, nil
+	}
 	return s.GetNumberOfPositionsFunc(ctx, extra)
 }

--- a/testutils/inject/switch.go
+++ b/testutils/inject/switch.go
@@ -1,0 +1,48 @@
+package inject
+
+import (
+	"context"
+
+	switch_component "go.viam.com/rdk/components/switch"
+	"go.viam.com/rdk/resource"
+)
+
+// Switch is an injected switch.
+type Switch struct {
+	switch_component.Switch
+	name                     resource.Name
+	DoFunc                   func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
+	SetPositionFunc          func(ctx context.Context, position uint32, extra map[string]interface{}) error
+	GetPositionFunc          func(ctx context.Context, extra map[string]interface{}) (uint32, error)
+	GetNumberOfPositionsFunc func(ctx context.Context, extra map[string]interface{}) (int, error)
+}
+
+// NewSwitch returns a new injected switch.
+func NewSwitch(name string) *Switch {
+	return &Switch{name: switch_component.Named(name)}
+}
+
+// Name returns the name of the resource.
+func (s *Switch) Name() resource.Name {
+	return s.name
+}
+
+// DoCommand executes a command on the switch.
+func (s *Switch) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+	return s.DoFunc(ctx, cmd)
+}
+
+// SetPosition sets the switch position.
+func (s *Switch) SetPosition(ctx context.Context, position uint32, extra map[string]interface{}) error {
+	return s.SetPositionFunc(ctx, position, extra)
+}
+
+// GetPosition gets the current switch position.
+func (s *Switch) GetPosition(ctx context.Context, extra map[string]interface{}) (uint32, error) {
+	return s.GetPositionFunc(ctx, extra)
+}
+
+// GetNumberOfPositions gets the total number of positions for the switch.
+func (s *Switch) GetNumberOfPositions(ctx context.Context, extra map[string]interface{}) (int, error) {
+	return s.GetNumberOfPositionsFunc(ctx, extra)
+}

--- a/testutils/inject/switch.go
+++ b/testutils/inject/switch.go
@@ -11,10 +11,11 @@ import (
 type Switch struct {
 	toggleswitch.Switch
 	name                     resource.Name
-	DoFunc                   func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
 	SetPositionFunc          func(ctx context.Context, position uint32, extra map[string]interface{}) error
 	GetPositionFunc          func(ctx context.Context, extra map[string]interface{}) (uint32, error)
 	GetNumberOfPositionsFunc func(ctx context.Context, extra map[string]interface{}) (uint32, error)
+	DoFunc                   func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
+	CloseFunc                func(ctx context.Context) error
 }
 
 // NewSwitch returns a new injected switch.
@@ -27,18 +28,10 @@ func (s *Switch) Name() resource.Name {
 	return s.name
 }
 
-// DoCommand executes a command on the switch.
-func (s *Switch) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
-	if s.DoFunc == nil {
-		return nil, nil
-	}
-	return s.DoFunc(ctx, cmd)
-}
-
 // SetPosition sets the switch position.
 func (s *Switch) SetPosition(ctx context.Context, position uint32, extra map[string]interface{}) error {
 	if s.SetPositionFunc == nil {
-		return nil
+		return s.Switch.SetPosition(ctx, position, extra)
 	}
 	return s.SetPositionFunc(ctx, position, extra)
 }
@@ -46,7 +39,7 @@ func (s *Switch) SetPosition(ctx context.Context, position uint32, extra map[str
 // GetPosition gets the current switch position.
 func (s *Switch) GetPosition(ctx context.Context, extra map[string]interface{}) (uint32, error) {
 	if s.GetPositionFunc == nil {
-		return 0, nil
+		return s.Switch.GetPosition(ctx, extra)
 	}
 	return s.GetPositionFunc(ctx, extra)
 }
@@ -54,7 +47,23 @@ func (s *Switch) GetPosition(ctx context.Context, extra map[string]interface{}) 
 // GetNumberOfPositions gets the total number of positions for the switch.
 func (s *Switch) GetNumberOfPositions(ctx context.Context, extra map[string]interface{}) (uint32, error) {
 	if s.GetNumberOfPositionsFunc == nil {
-		return 0, nil
+		return s.Switch.GetNumberOfPositions(ctx, extra)
 	}
 	return s.GetNumberOfPositionsFunc(ctx, extra)
+}
+
+// DoCommand calls DoFunc.
+func (s *Switch) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+	if s.DoFunc == nil {
+		return s.Switch.DoCommand(ctx, cmd)
+	}
+	return s.DoFunc(ctx, cmd)
+}
+
+// Close calls CloseFunc.
+func (s *Switch) Close(ctx context.Context) error {
+	if s.CloseFunc == nil {
+		return s.Switch.Close(ctx)
+	}
+	return s.CloseFunc(ctx)
 }


### PR DESCRIPTION
This adds the switch client and server, and registers switch 2-way, 3-way, and 10-way fake models.

Here are switch components properly configured in app:
![image](https://github.com/user-attachments/assets/5f4ab5cf-c12c-4bc8-a2c7-0a37f71d2c29)

1. https://github.com/viamrobotics/api/pull/619
2. #4740
3. #4741

## Change log

I used Cursor quite a bit here:
- Add `Switch` SDK helpers
- Add client and tests
- Add server and tests
- Add inject testutil
- Add fake switch implementations and register them

## Review requests

- Code review
- Try a config with the switch fakes - does they work as expected?