### PR TITLE
RSDK-9778: add resource base stubs to python modules

### DIFF
--- a/cli/module_generate/scripts/generate_stubs.py
+++ b/cli/module_generate/scripts/generate_stubs.py
@@ -155,6 +155,24 @@ def main(
                         )
                         abstract_methods.append(indented_code)
 
+    type_module = import_module(f"viam.{resource_type}s.{resource_type}_base")
+    with open(type_module.__file__, "r") as f:
+        tree = ast.parse(f.read())
+        for stmt in tree.body:
+            if isinstance(stmt, ast.ClassDef):
+                for cstmt in stmt.body:
+                    if isinstance(cstmt, ast.AsyncFunctionDef):
+                        replace_async_func("", cstmt, [])
+                        indented_code = '\n'.join(
+                            ['    ' + line for line in ast.unparse(cstmt).splitlines()]
+                        )
+                        abstract_methods.append(indented_code)
+                        if cstmt.name == "do_command":
+                            imports.append("from viam.utils import ValueTypes")
+                        elif cstmt.name == "get_geometries":
+                            imports.append("from typing import List")
+                            imports.append("from viam.proto.common import Geometry")
+
     model_name_pascal = "".join(
         [word.capitalize() for word in slugify(model_name).split("-")]
     )

--- a/cli/module_generate/scripts/generate_stubs.py
+++ b/cli/module_generate/scripts/generate_stubs.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 import sys
 from importlib import import_module
-from typing import List, Set
+from typing import List, Set, Union
 
 
 def return_attribute(value: str, attr: str) -> ast.Attribute:
@@ -168,9 +168,10 @@ def main(
                         )
                         abstract_methods.append(indented_code)
                         if cstmt.name == "do_command":
+                            imports.append("from typing import Optional")
                             imports.append("from viam.utils import ValueTypes")
                         elif cstmt.name == "get_geometries":
-                            imports.append("from typing import List")
+                            imports.append("from typing import List, Optional")
                             imports.append("from viam.proto.common import Geometry")
 
     model_name_pascal = "".join(


### PR DESCRIPTION
Changes:
- generated module resources will now include async functions from `ComponentBase` or `ServiceBase`

Arm Component:
<img width="1184" alt="arm_imports" src="https://github.com/user-attachments/assets/7af0af1c-2576-4697-bea3-47e513ec96a7" />
<img width="1187" alt="arm_commands" src="https://github.com/user-attachments/assets/d4a65e9d-5991-4c50-a4b5-9e5eefc5ac66" />
Vision Service:
<img width="1187" alt="vision_commands" src="https://github.com/user-attachments/assets/1c6a9573-94f0-46d6-8a49-b3078d81d22b" />