### PR TITLE
[RSDK-8292] Create Single App Connection and Use for Net Appender and Restart Checker

### DIFF
--- a/config/reader.go
+++ b/config/reader.go
@@ -257,7 +257,7 @@ func readFromCloud(
 	if !cfg.Cloud.SignalingInsecure && (checkForNewCert || tls.certificate == "" || tls.privateKey == "") {
 		logger.Debug("reading tlsCertificate from the cloud")
 
-		ctxWithTimeout, cancel := getTimeoutCtx(ctx, shouldReadFromCache, cloudCfg.ID)
+		ctxWithTimeout, cancel := GetTimeoutCtx(ctx, shouldReadFromCache, cloudCfg.ID)
 		certData, err := readCertificateDataFromCloudGRPC(ctxWithTimeout, cloudCfg, logger)
 		if err != nil {
 			cancel()
@@ -609,7 +609,7 @@ func processConfig(unprocessedConfig *Config, fromCloud bool, logger logging.Log
 func getFromCloudOrCache(ctx context.Context, cloudCfg *Cloud, shouldReadFromCache bool, logger logging.Logger) (*Config, bool, error) {
 	var cached bool
 
-	ctxWithTimeout, cancel := getTimeoutCtx(ctx, shouldReadFromCache, cloudCfg.ID)
+	ctxWithTimeout, cancel := GetTimeoutCtx(ctx, shouldReadFromCache, cloudCfg.ID)
 	defer cancel()
 
 	cfg, errorShouldCheckCache, err := getFromCloudGRPC(ctxWithTimeout, cloudCfg, logger)

--- a/config/reader.go
+++ b/config/reader.go
@@ -181,6 +181,8 @@ func isLocationSecretsEqual(prevCloud, cloud *Cloud) bool {
 	return true
 }
 
+// GetTimeoutCtx returns a context [and its cancel function] with a timeout value determined by whether we are behind a proxy and whether a
+// cached config exists.
 func GetTimeoutCtx(ctx context.Context, shouldReadFromCache bool, id string) (context.Context, func()) {
 	timeout := readTimeout
 	// When environment indicates we are behind a proxy, bump timeout. Network

--- a/config/reader.go
+++ b/config/reader.go
@@ -181,7 +181,7 @@ func isLocationSecretsEqual(prevCloud, cloud *Cloud) bool {
 	return true
 }
 
-func getTimeoutCtx(ctx context.Context, shouldReadFromCache bool, id string) (context.Context, func()) {
+func GetTimeoutCtx(ctx context.Context, shouldReadFromCache bool, id string) (context.Context, func()) {
 	timeout := readTimeout
 	// When environment indicates we are behind a proxy, bump timeout. Network
 	// operations tend to take longer when behind a proxy.

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -47,6 +47,10 @@ func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger)
 				for {
 					appConn.connMu.Lock()
 
+					if ctx.Err() != nil {
+						break
+					}
+
 					ctxWithTimeOut, ctxWithTimeOutCancel := context.WithTimeout(ctx, 5*time.Second)
 					appConn.conn, err = rpc.DialDirectGRPC(ctxWithTimeOut, grpcURL.Host, logger, dialOpts...)
 					if err != nil {

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -16,17 +16,12 @@ import (
 // attempts to dial App until a connection is successfully established.
 type AppConn struct {
 	ReconfigurableClientConn
-
-	// Err stores the most recent error returned by the serialized dial attempts running in the background. It can also be used to tell
-	// whether dial attempts are currently happening; If err is a non-nil value, dial attempts have stopped. Accesses to Err should respect
-	// ReconfigurableClientConn.connMu
-	Err error
 }
 
 // NewAppConn creates an AppConn instance with a gRPC client connection to App. An initial dial attempt blocks. If it errors, the error is
 // returned. If it times out, an AppConn object will return with a nil underlying client connection. Serialized attempts at establishing a
 // connection to App will continue to occur, however, in a background Goroutine. These attempts will continue until a connection is made or
-// an error that is not a context.DeadlineExceeded occurs - in which case the resulting error will be stored in AppConn.Err.
+// an error that is not a context.DeadlineExceeded occurs.
 func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger) (*AppConn, error) {
 	grpcURL, err := url.Parse(cloud.AppAddress)
 	if err != nil {
@@ -63,8 +58,6 @@ func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger)
 					}
 
 					ctxWithTimeOutCancel()
-
-					appConn.Err = err
 
 					break
 				}

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -61,15 +61,17 @@ func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger)
 			}
 
 			ctxWithTimeout, ctxWithTimeoutCancel := context.WithTimeout(ctx, 5*time.Second)
-			appConn.connMu.Lock()
-			appConn.conn, err = rpc.DialDirectGRPC(ctxWithTimeout, grpcURL.Host, logger, dialOpts...)
-			appConn.connMu.Unlock()
+			conn, err := rpc.DialDirectGRPC(ctxWithTimeout, grpcURL.Host, logger, dialOpts...)
 			ctxWithTimeoutCancel()
 			if err != nil {
 				logger.Debugw("error while dialing App. Could not establish global, unified connection", "error", err)
 
 				continue
 			}
+
+			appConn.connMu.Lock()
+			defer appConn.connMu.Unlock()
+			appConn.conn = conn
 
 			return
 		}

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -1,0 +1,43 @@
+package grpc
+
+import (
+	"context"
+	"net/url"
+
+	"go.viam.com/rdk/logging"
+	"go.viam.com/utils/rpc"
+)
+
+// spin off Goroutine that attempts to create connection
+// routine should at first block for some time interval
+// if connection is not created after initial timeout, no longer block
+// however, continue re-attempting connection at other specified time interval
+// once connection establishes, close off routine
+
+type AppConn struct {
+	ReconfigurableClientConn
+}
+
+func CreateNewGRPCClient(ctx context.Context, cloudCfg *logging.CloudConfig, logger logging.Logger) (rpc.ClientConn, error) {
+	grpcURL, err := url.Parse(cloudCfg.AppAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	dialOpts := make([]rpc.DialOption, 0, 2)
+	// Only add credentials when secret is set.
+	if cloudCfg.Secret != "" {
+		dialOpts = append(dialOpts, rpc.WithEntityCredentials(cloudCfg.ID,
+			rpc.Credentials{
+				Type:    "robot-secret",
+				Payload: cloudCfg.Secret,
+			},
+		))
+	}
+
+	if grpcURL.Scheme == "http" {
+		dialOpts = append(dialOpts, rpc.WithInsecure())
+	}
+
+	return rpc.DialDirectGRPC(ctx, grpcURL.Host, logger, dialOpts...)
+}

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -77,7 +77,6 @@ func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger)
 		}
 	})
 
-	// if initial dial attempt fails due to time out, return nil error
 	return appConn, nil
 }
 

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -48,9 +48,9 @@ func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger)
 					appConn.connMu.Lock()
 
 					ctxWithTimeOut, ctxWithTimeOutCancel := context.WithTimeout(ctx, 5*time.Second)
-
 					appConn.conn, err = rpc.DialDirectGRPC(ctxWithTimeOut, grpcURL.Host, logger, dialOpts...)
 					if err != nil {
+						logger.Debug("error while dialing App. Could not establish global, unified connection", err)
 						appConn.connMu.Unlock()
 
 						continue

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/pkg/errors"
 	"go.viam.com/utils"
 	"go.viam.com/utils/rpc"
 

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -53,11 +53,11 @@ func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger)
 				}
 
 				ctxWithTimeOut, ctxWithTimeOutCancel := context.WithTimeout(ctx, 5*time.Second)
-				defer ctxWithTimeOutCancel()
 
 				appConn.connMu.Lock()
 
 				appConn.conn, err = rpc.DialDirectGRPC(ctxWithTimeOut, grpcURL.Host, logger, dialOpts...)
+				ctxWithTimeOutCancel()
 				if err != nil {
 					logger.Debug("error while dialing App. Could not establish global, unified connection", err)
 					appConn.connMu.Unlock()
@@ -66,6 +66,7 @@ func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger)
 				}
 
 				appConn.connMu.Unlock()
+
 				return
 			}
 		}()

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -13,7 +13,7 @@ import (
 	"go.viam.com/rdk/logging"
 )
 
-// AppConn maintains an underlying client connection meant to be used globally to connect to App. The AppConn constructor repeatedly
+// AppConn maintains an underlying client connection meant to be used globally to connect to App. The `AppConn` constructor repeatedly
 // attempts to dial App until a connection is successfully established.
 type AppConn struct {
 	ReconfigurableClientConn
@@ -21,10 +21,10 @@ type AppConn struct {
 	dialer *utils.StoppableWorkers
 }
 
-// NewAppConn creates an AppConn instance with a gRPC client connection to App. An initial dial attempt blocks. If it errors, the error is
-// returned. If it times out, an AppConn object will return with a nil underlying client connection. Serialized attempts at establishing a
-// connection to App will continue to occur, however, in a background Goroutine. These attempts will continue until a connection is made or
-// an error that is not a context.DeadlineExceeded occurs.
+// NewAppConn creates an `AppConn` instance with a gRPC client connection to App. An initial dial attempt blocks. If it errors, the error
+// is returned. If it times out, an `AppConn` object with a nil underlying client connection will return. Serialized attempts at establishing
+// a connection to App will continue to occur, however, in a background Goroutine. These attempts will continue until a connection is made.
+// If `cloud` is nil, an `AppConn` with a nil underlying connection will return, and the background dialer will not start.
 func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger) (*AppConn, error) {
 	appConn := &AppConn{}
 
@@ -83,7 +83,7 @@ func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger)
 	return appConn, nil
 }
 
-// Close attempts to close the underlying connection if there is one and stops background dialing attempts.
+// Close attempts to close the underlying connection and stops background dialing attempts.
 func (ac *AppConn) Close() error {
 	if ac.dialer != nil {
 		ac.dialer.Stop()

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -61,9 +61,7 @@ func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger)
 			}
 
 			ctxWithTimeout, ctxWithTimeoutCancel := context.WithTimeout(ctx, 5*time.Second)
-
 			appConn.connMu.Lock()
-
 			appConn.conn, err = rpc.DialDirectGRPC(ctxWithTimeout, grpcURL.Host, logger, dialOpts...)
 			appConn.connMu.Unlock()
 			ctxWithTimeoutCancel()

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -22,9 +22,10 @@ type AppConn struct {
 }
 
 // NewAppConn creates an `AppConn` instance with a gRPC client connection to App. An initial dial attempt blocks. If it errors, the error
-// is returned. If it times out, an `AppConn` object with a nil underlying client connection will return. Serialized attempts at establishing
-// a connection to App will continue to occur, however, in a background Goroutine. These attempts will continue until a connection is made.
-// If `cloud` is nil, an `AppConn` with a nil underlying connection will return, and the background dialer will not start.
+// is returned. If it times out, an `AppConn` object with a nil underlying client connection will return. Serialized attempts at
+// establishing a connection to App will continue to occur, however, in a background Goroutine. These attempts will continue until a
+// connection is made. If `cloud` is nil, an `AppConn` with a nil underlying connection will return, and the background dialer will not
+// start.
 func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger) (*AppConn, error) {
 	appConn := &AppConn{}
 

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -41,8 +41,11 @@ func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger)
 
 	appConn := &AppConn{}
 
+	ctxWithTimeout, ctxWithTimeoutCancel := config.GetTimeoutCtx(ctx, true, cloud.ID)
+	defer ctxWithTimeoutCancel()
+
 	// a lock is not necessary here because this call is blocking
-	appConn.conn, err = rpc.DialDirectGRPC(ctx, grpcURL.Host, logger, dialOpts...)
+	appConn.conn, err = rpc.DialDirectGRPC(ctxWithTimeout, grpcURL.Host, logger, dialOpts...)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			go func() {

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -50,10 +50,9 @@ func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger)
 					ctxWithTimeOut, ctxWithTimeOutCancel := context.WithTimeout(ctx, 5*time.Second)
 
 					appConn.conn, err = rpc.DialDirectGRPC(ctxWithTimeOut, grpcURL.Host, logger, dialOpts...)
-					if errors.Is(err, context.DeadlineExceeded) {
+					if err != nil {
 						appConn.connMu.Unlock()
 
-						// only dial again if previous attempt timed out
 						continue
 					}
 

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -62,7 +62,6 @@ func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger)
 				}
 			}()
 		} else {
-			appConn.Err = err
 			return nil, err
 		}
 	}

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -45,22 +45,21 @@ func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger)
 		if errors.Is(err, context.DeadlineExceeded) {
 			go func() {
 				for {
-					appConn.connMu.Lock()
-
 					if ctx.Err() != nil {
 						break
 					}
 
+					appConn.connMu.Lock()
+
 					ctxWithTimeOut, ctxWithTimeOutCancel := context.WithTimeout(ctx, 5*time.Second)
 					appConn.conn, err = rpc.DialDirectGRPC(ctxWithTimeOut, grpcURL.Host, logger, dialOpts...)
+					ctxWithTimeOutCancel()
 					if err != nil {
 						logger.Debug("error while dialing App. Could not establish global, unified connection", err)
 						appConn.connMu.Unlock()
 
 						continue
 					}
-
-					ctxWithTimeOutCancel()
 
 					break
 				}

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -79,7 +79,7 @@ func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger)
 	return appConn, nil
 }
 
-// Close attempts to close the underlying connection if there is one and stops background dialing attempts
+// Close attempts to close the underlying connection if there is one and stops background dialing attempts.
 func (ac *AppConn) Close() error {
 	if ac.dialer != nil {
 		ac.dialer.Stop()

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -81,7 +81,7 @@ func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger)
 	return appConn, nil
 }
 
-// Close calls `ReconfigurableClientConn.Close()` in addition to `Stop`ping `dialer`
+// Close calls `ReconfigurableClientConn.Close()` in addition to `Stop`ping `dialer`.
 func (ac *AppConn) Close() error {
 	ac.dialer.Stop()
 

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -53,10 +53,6 @@ func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger)
 		return appConn, nil
 	}
 
-	if !errors.Is(err, context.DeadlineExceeded) {
-		return nil, err
-	}
-
 	appConn.dialer = utils.NewStoppableWorkers(ctx)
 
 	appConn.dialer.Add(func(ctx context.Context) {

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -26,6 +26,12 @@ type AppConn struct {
 // connection to App will continue to occur, however, in a background Goroutine. These attempts will continue until a connection is made or
 // an error that is not a context.DeadlineExceeded occurs.
 func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger) (*AppConn, error) {
+	appConn := &AppConn{}
+
+	if cloud == nil {
+		return appConn, nil
+	}
+
 	grpcURL, err := url.Parse(cloud.AppAddress)
 	if err != nil {
 		return nil, err
@@ -36,8 +42,6 @@ func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger)
 	if grpcURL.Scheme == "http" {
 		dialOpts = append(dialOpts, rpc.WithInsecure())
 	}
-
-	appConn := &AppConn{}
 
 	ctxWithTimeout, ctxWithTimeoutCancel := config.GetTimeoutCtx(ctx, true, cloud.ID)
 	defer ctxWithTimeoutCancel()

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -57,15 +57,13 @@ func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger)
 				appConn.connMu.Lock()
 
 				appConn.conn, err = rpc.DialDirectGRPC(ctxWithTimeOut, grpcURL.Host, logger, dialOpts...)
+				appConn.connMu.Unlock()
 				ctxWithTimeOutCancel()
 				if err != nil {
 					logger.Debug("error while dialing App. Could not establish global, unified connection", err)
-					appConn.connMu.Unlock()
 
 					continue
 				}
-
-				appConn.connMu.Unlock()
 
 				return
 			}

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -67,7 +67,7 @@ func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger)
 			appConn.connMu.Unlock()
 			ctxWithTimeoutCancel()
 			if err != nil {
-				logger.Debug("error while dialing App. Could not establish global, unified connection", err)
+				logger.Debugw("error while dialing App. Could not establish global, unified connection", "error", err)
 
 				continue
 			}

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -83,7 +83,9 @@ func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger)
 
 // Close calls `ReconfigurableClientConn.Close()` in addition to `Stop`ping `dialer`.
 func (ac *AppConn) Close() error {
-	ac.dialer.Stop()
+	if ac.dialer != nil {
+		ac.dialer.Stop()
+	}
 
 	return ac.ReconfigurableClientConn.Close()
 }

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -81,6 +81,7 @@ func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger)
 	return appConn, nil
 }
 
+// Close calls `ReconfigurableClientConn.Close()` in addition to `Stop`ping `dialer`
 func (ac *AppConn) Close() error {
 	ac.dialer.Stop()
 

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -70,8 +70,8 @@ func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger)
 			}
 
 			appConn.connMu.Lock()
-			defer appConn.connMu.Unlock()
 			appConn.conn = conn
+			appConn.connMu.Unlock()
 
 			return
 		}

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -42,7 +42,7 @@ func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger)
 	ctxWithTimeout, ctxWithTimeoutCancel := config.GetTimeoutCtx(ctx, true, cloud.ID)
 	defer ctxWithTimeoutCancel()
 
-	// a lock is not necessary here because this call is blocking
+	// lock not necessary here because call is blocking
 	appConn.conn, err = rpc.DialDirectGRPC(ctxWithTimeout, grpcURL.Host, logger, dialOpts...)
 	if err == nil {
 		return appConn, nil
@@ -77,7 +77,7 @@ func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger)
 		}
 	})
 
-	// if the initial dial attempt fails due to a time out, we return the connection-lacking `AppConn` and a nil `error`
+	// if initial dial attempt fails due to time out, return `AppConn` and nil `error` and no underlying connection
 	return appConn, nil
 }
 

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -75,11 +75,11 @@ func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger)
 		}
 	})
 
-	// if initial dial attempt fails due to time out, return `AppConn` and nil `error` and no underlying connection
+	// if initial dial attempt fails due to time out, return nil error
 	return appConn, nil
 }
 
-// Close calls `ReconfigurableClientConn.Close()` in addition to `Stop`ping `dialer`.
+// Close attempts to close the underlying connection if there is one and stops background dialing attempts
 func (ac *AppConn) Close() error {
 	if ac.dialer != nil {
 		ac.dialer.Stop()

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -43,7 +43,6 @@ func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger)
 				for {
 					appConn.connMu.Lock()
 
-					// TODO(RSDK-8292): [qu] should I use ctx instead of context.Background()
 					ctxWithTimeOut, ctxWithTimeOutCancel := context.WithTimeout(context.Background(), 5*time.Second)
 
 					appConn.conn, err = rpc.DialDirectGRPC(ctxWithTimeOut, grpcURL.Host, logger, dialOpts...)

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -52,7 +52,7 @@ func NewAppConn(ctx context.Context, cloud *config.Cloud, logger logging.Logger)
 				for {
 					appConn.connMu.Lock()
 
-					ctxWithTimeOut, ctxWithTimeOutCancel := context.WithTimeout(context.Background(), 5*time.Second)
+					ctxWithTimeOut, ctxWithTimeOutCancel := context.WithTimeout(ctx, 5*time.Second)
 
 					appConn.conn, err = rpc.DialDirectGRPC(ctxWithTimeOut, grpcURL.Host, logger, dialOpts...)
 					if errors.Is(err, context.DeadlineExceeded) {

--- a/logging/net_appender.go
+++ b/logging/net_appender.go
@@ -406,7 +406,6 @@ func (w *remoteLogWriterGRPC) write(ctx context.Context, logs []*commonpb.LogEnt
 	return nil
 }
 
-// TODO(RSDK-8292): [qu] do we need this anymore?
 func (w *remoteLogWriterGRPC) getOrCreateClient(ctx context.Context) (apppb.RobotServiceClient, error) {
 	w.clientMutex.Lock()
 	defer w.clientMutex.Unlock()

--- a/logging/net_appender.go
+++ b/logging/net_appender.go
@@ -406,6 +406,7 @@ func (w *remoteLogWriterGRPC) write(ctx context.Context, logs []*commonpb.LogEnt
 	return nil
 }
 
+// TODO(RSDK-8292): [qu] do we need this anymore?
 func (w *remoteLogWriterGRPC) getOrCreateClient(ctx context.Context) (apppb.RobotServiceClient, error) {
 	w.clientMutex.Lock()
 	defer w.clientMutex.Unlock()

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -32,7 +32,6 @@ import (
 	"go.viam.com/rdk/robot/web"
 	weboptions "go.viam.com/rdk/robot/web/options"
 	rutils "go.viam.com/rdk/utils"
-	"go.viam.com/rdk/utils/contextutils"
 )
 
 var viamDotDir = filepath.Join(rutils.PlatformHomeDir(), ".viam")

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -192,12 +192,10 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 	// Start remote logging with config from disk.
 	// This is to ensure we make our best effort to write logs for failures loading the remote config.
 	if cfgFromDisk.Cloud != nil && (cfgFromDisk.Cloud.LogPath != "" || cfgFromDisk.Cloud.AppAddress != "") {
-		ctxWithTimeout, ctxWithTimeoutCancel := config.GetTimeoutCtx(ctx, true, cfgFromDisk.Cloud.ID)
-		appConn, err := grpc.NewAppConn(ctxWithTimeout, cfgFromDisk.Cloud, logger.Sublogger("networking").Sublogger("app_connection"))
+		appConn, err := grpc.NewAppConn(ctx, cfgFromDisk.Cloud, logger.Sublogger("networking").Sublogger("app_connection"))
 		if err != nil {
 			return err
 		}
-		ctxWithTimeoutCancel()
 
 		netAppender, err := logging.NewNetAppender(
 			&logging.CloudConfig{

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -195,7 +195,7 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 		ctxWithTimeout, ctxWithTimeoutCancel := config.GetTimeoutCtx(ctx, true, cfgFromDisk.Cloud.ID)
 		appConn, err := grpc.NewAppConn(ctxWithTimeout, cfgFromDisk.Cloud, logger) // TODO(RSDK-8292): [q] what logger should I pass here?
 		if err != nil {
-			logger.Info("error establishing global App gRPC connection:", err)
+			return err
 		}
 		ctxWithTimeoutCancel()
 

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -195,6 +195,7 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 		ctxWithTimeout, ctxWithTimeoutCancel := config.GetTimeoutCtx(ctx, true, cfgFromDisk.Cloud.ID)
 		appConn, err := grpc.NewAppConn(ctxWithTimeout, cfgFromDisk.Cloud, logger) // TODO(RSDK-8292): [q] what logger should I pass here?
 		ctxWithTimeoutCancel()
+
 		netAppender, err := logging.NewNetAppender(
 			&logging.CloudConfig{
 				AppAddress: cfgFromDisk.Cloud.AppAddress,

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -189,7 +189,7 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 		defer exporter.Stop()
 	}
 
-	appConn, err := grpc.NewAppConn(ctx, cfgFromDisk.Cloud, logger.Sublogger("networking").Sublogger("appconnection"))
+	appConn, err := grpc.NewAppConn(ctx, cfgFromDisk.Cloud, logger.Sublogger("networking").Sublogger("app_connection"))
 	if err != nil {
 		return err
 	}

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -189,14 +189,14 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 		defer exporter.Stop()
 	}
 
-	appConn, err := grpc.NewAppConn(ctx, cfgFromDisk.Cloud, logger.Sublogger("networking").Sublogger("appconnection"))
-	if err != nil {
-		return err
-	}
-
 	// Start remote logging with config from disk.
 	// This is to ensure we make our best effort to write logs for failures loading the remote config.
 	if cfgFromDisk.Cloud != nil && (cfgFromDisk.Cloud.LogPath != "" || cfgFromDisk.Cloud.AppAddress != "") {
+		appConn, err := grpc.NewAppConn(ctx, cfgFromDisk.Cloud, logger.Sublogger("networking").Sublogger("appconnection"))
+		if err != nil {
+			return err
+		}
+
 		netAppender, err := logging.NewNetAppender(
 			&logging.CloudConfig{
 				AppAddress: cfgFromDisk.Cloud.AppAddress,

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -463,11 +463,7 @@ func (s *robotServer) serveWeb(ctx context.Context, cfg *config.Config, conn rpc
 		cloudRestartCheckerActive = make(chan struct{})
 		utils.PanicCapturingGo(func() {
 			defer close(cloudRestartCheckerActive)
-			restartCheck, err := newRestartChecker(cfg.Cloud, s.logger, conn)
-			if err != nil {
-				s.logger.Errorw("error creating restart checker", "error", err)
-				panic(fmt.Sprintf("error creating restart checker: %v", err))
-			}
+			restartCheck := newRestartChecker(cfg.Cloud, s.logger, conn)
 			defer restartCheck.close()
 			restartInterval := defaultNeedsRestartCheckInterval
 

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -193,7 +193,7 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 	// This is to ensure we make our best effort to write logs for failures loading the remote config.
 	if cfgFromDisk.Cloud != nil && (cfgFromDisk.Cloud.LogPath != "" || cfgFromDisk.Cloud.AppAddress != "") {
 		ctxWithTimeout, ctxWithTimeoutCancel := config.GetTimeoutCtx(ctx, true, cfgFromDisk.Cloud.ID)
-		appConn, err := grpc.NewAppConn(ctxWithTimeout, cfgFromDisk.Cloud, logger) // TODO(RSDK-8292): [q] what logger should I pass here?
+		appConn, err := grpc.NewAppConn(ctxWithTimeout, cfgFromDisk.Cloud, logger.Sublogger("networking").Sublogger("app_connection"))
 		if err != nil {
 			return err
 		}

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -463,11 +463,8 @@ func (s *robotServer) serveWeb(ctx context.Context, cfg *config.Config, conn rpc
 		cloudRestartCheckerActive = make(chan struct{})
 		utils.PanicCapturingGo(func() {
 			defer close(cloudRestartCheckerActive)
-			restartCheck, err := newRestartChecker(ctx, cfg.Cloud, s.logger, conn)
+			restartCheck, err := newRestartChecker(cfg.Cloud, s.logger, conn)
 			if err != nil {
-				if errors.Is(err, context.Canceled) {
-					return
-				}
 				s.logger.Errorw("error creating restart checker", "error", err)
 				panic(fmt.Sprintf("error creating restart checker: %v", err))
 			}

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -223,7 +223,7 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 	}
 
 	// Run the server with remote logging enabled.
-	err = server.runServer(ctx)
+	err = server.runServer(ctx, appConn)
 	if err != nil {
 		logger.Error("Fatal error running server, exiting now: ", err)
 	}
@@ -233,7 +233,7 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 
 // runServer is an entry point to starting the web server after the local config is read. Once the local config
 // is read the logger may be initialized to remote log. This ensure we capture errors starting up the server and report to the cloud.
-func (s *robotServer) runServer(ctx context.Context) error {
+func (s *robotServer) runServer(ctx context.Context, conn rpc.ClientConn) error {
 	initialReadCtx, cancel := context.WithTimeout(ctx, time.Second*5)
 	cfg, err := config.Read(initialReadCtx, s.args.ConfigFile, s.logger)
 	if err != nil {
@@ -243,7 +243,7 @@ func (s *robotServer) runServer(ctx context.Context) error {
 	cancel()
 	config.UpdateFileConfigDebug(cfg.Debug)
 
-	err = s.serveWeb(ctx, cfg)
+	err = s.serveWeb(ctx, cfg, conn)
 	if err != nil {
 		s.logger.Errorw("error serving web", "error", err)
 	}
@@ -363,7 +363,7 @@ func (s *robotServer) configWatcher(ctx context.Context, currCfg *config.Config,
 	}
 }
 
-func (s *robotServer) serveWeb(ctx context.Context, cfg *config.Config) (err error) {
+func (s *robotServer) serveWeb(ctx context.Context, cfg *config.Config, conn rpc.ClientConn) (err error) {
 	ctx, cancel := context.WithCancel(ctx)
 
 	hungShutdownDeadline := 90 * time.Second
@@ -463,14 +463,7 @@ func (s *robotServer) serveWeb(ctx context.Context, cfg *config.Config) (err err
 		cloudRestartCheckerActive = make(chan struct{})
 		utils.PanicCapturingGo(func() {
 			defer close(cloudRestartCheckerActive)
-			restartCheck, err := newRestartChecker(ctx, cfg.Cloud, s.logger)
-			if err != nil {
-				if errors.Is(err, context.Canceled) {
-					return
-				}
-				s.logger.Errorw("error creating restart checker", "error", err)
-				panic(fmt.Sprintf("error creating restart checker: %v", err))
-			}
+			restartCheck := newRestartChecker(cfg.Cloud, s.logger, conn)
 			defer restartCheck.close()
 			restartInterval := defaultNeedsRestartCheckInterval
 

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -189,14 +189,14 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 		defer exporter.Stop()
 	}
 
-	appConn, err := grpc.NewAppConn(ctx, cfgFromDisk.Cloud, logger.Sublogger("networking").Sublogger("appconnection"))
-	if err != nil {
-		return err
-	}
-
 	// Start remote logging with config from disk.
 	// This is to ensure we make our best effort to write logs for failures loading the remote config.
 	if cfgFromDisk.Cloud != nil && (cfgFromDisk.Cloud.LogPath != "" || cfgFromDisk.Cloud.AppAddress != "") {
+		appConn, err := grpc.NewAppConn(ctx, cfgFromDisk.Cloud, logger.Sublogger("networking").Sublogger("appconnection"))
+		if err != nil {
+			return err
+		}
+
 		netAppender, err := logging.NewNetAppender(
 			&logging.CloudConfig{
 				AppAddress: cfgFromDisk.Cloud.AppAddress,
@@ -223,7 +223,7 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 	}
 
 	// Run the server with remote logging enabled.
-	err = server.runServer(ctx, appConn)
+	err = server.runServer(ctx)
 	if err != nil {
 		logger.Error("Fatal error running server, exiting now: ", err)
 	}
@@ -233,7 +233,7 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 
 // runServer is an entry point to starting the web server after the local config is read. Once the local config
 // is read the logger may be initialized to remote log. This ensure we capture errors starting up the server and report to the cloud.
-func (s *robotServer) runServer(ctx context.Context, conn rpc.ClientConn) error {
+func (s *robotServer) runServer(ctx context.Context) error {
 	initialReadCtx, cancel := context.WithTimeout(ctx, time.Second*5)
 	cfg, err := config.Read(initialReadCtx, s.args.ConfigFile, s.logger)
 	if err != nil {
@@ -243,7 +243,7 @@ func (s *robotServer) runServer(ctx context.Context, conn rpc.ClientConn) error 
 	cancel()
 	config.UpdateFileConfigDebug(cfg.Debug)
 
-	err = s.serveWeb(ctx, cfg, conn)
+	err = s.serveWeb(ctx, cfg)
 	if err != nil {
 		s.logger.Errorw("error serving web", "error", err)
 	}
@@ -363,7 +363,7 @@ func (s *robotServer) configWatcher(ctx context.Context, currCfg *config.Config,
 	}
 }
 
-func (s *robotServer) serveWeb(ctx context.Context, cfg *config.Config, conn rpc.ClientConn) (err error) {
+func (s *robotServer) serveWeb(ctx context.Context, cfg *config.Config) (err error) {
 	ctx, cancel := context.WithCancel(ctx)
 
 	hungShutdownDeadline := 90 * time.Second
@@ -463,7 +463,14 @@ func (s *robotServer) serveWeb(ctx context.Context, cfg *config.Config, conn rpc
 		cloudRestartCheckerActive = make(chan struct{})
 		utils.PanicCapturingGo(func() {
 			defer close(cloudRestartCheckerActive)
-			restartCheck := newRestartChecker(cfg.Cloud, s.logger, conn)
+			restartCheck, err := newRestartChecker(ctx, cfg.Cloud, s.logger)
+			if err != nil {
+				if errors.Is(err, context.Canceled) {
+					return
+				}
+				s.logger.Errorw("error creating restart checker", "error", err)
+				panic(fmt.Sprintf("error creating restart checker: %v", err))
+			}
 			defer restartCheck.close()
 			restartInterval := defaultNeedsRestartCheckInterval
 

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -194,6 +194,9 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 	if cfgFromDisk.Cloud != nil && (cfgFromDisk.Cloud.LogPath != "" || cfgFromDisk.Cloud.AppAddress != "") {
 		ctxWithTimeout, ctxWithTimeoutCancel := config.GetTimeoutCtx(ctx, true, cfgFromDisk.Cloud.ID)
 		appConn, err := grpc.NewAppConn(ctxWithTimeout, cfgFromDisk.Cloud, logger) // TODO(RSDK-8292): [q] what logger should I pass here?
+		if err != nil {
+			logger.Info("error establishing global App gRPC connection:", err)
+		}
 		ctxWithTimeoutCancel()
 
 		netAppender, err := logging.NewNetAppender(

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -192,7 +192,7 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 	// Start remote logging with config from disk.
 	// This is to ensure we make our best effort to write logs for failures loading the remote config.
 	if cfgFromDisk.Cloud != nil && (cfgFromDisk.Cloud.LogPath != "" || cfgFromDisk.Cloud.AppAddress != "") {
-		appConn, err := grpc.NewAppConn(ctx, cfgFromDisk.Cloud, logger.Sublogger("networking").Sublogger("app_connection"))
+		appConn, err := grpc.NewAppConn(ctx, cfgFromDisk.Cloud, logger.Sublogger("networking").Sublogger("appconnection"))
 		if err != nil {
 			return err
 		}

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -190,6 +190,8 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 		defer exporter.Stop()
 	}
 
+	// the underlying connection in `appConn` can be nil. In this case, a background Goroutine is kicked off to reattempt dials in a
+	// serialized manner
 	appConn, err := grpc.NewAppConn(ctx, cfgFromDisk.Cloud, logger.Sublogger("networking").Sublogger("app_connection"))
 	if err != nil {
 		return err

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -189,14 +189,14 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 		defer exporter.Stop()
 	}
 
+	appConn, err := grpc.NewAppConn(ctx, cfgFromDisk.Cloud, logger.Sublogger("networking").Sublogger("appconnection"))
+	if err != nil {
+		return err
+	}
+
 	// Start remote logging with config from disk.
 	// This is to ensure we make our best effort to write logs for failures loading the remote config.
 	if cfgFromDisk.Cloud != nil && (cfgFromDisk.Cloud.LogPath != "" || cfgFromDisk.Cloud.AppAddress != "") {
-		appConn, err := grpc.NewAppConn(ctx, cfgFromDisk.Cloud, logger.Sublogger("networking").Sublogger("appconnection"))
-		if err != nil {
-			return err
-		}
-
 		netAppender, err := logging.NewNetAppender(
 			&logging.CloudConfig{
 				AppAddress: cfgFromDisk.Cloud.AppAddress,

--- a/web/server/restart_checker.go
+++ b/web/server/restart_checker.go
@@ -59,15 +59,10 @@ func (c *needsRestartCheckerGRPC) needsRestart(ctx context.Context) (bool, time.
 	return res.MustRestart, restartInterval, nil
 }
 
-func newRestartChecker(ctx context.Context, cfg *config.Cloud, logger logging.Logger) (needsRestartChecker, error) {
-	client, err := config.CreateNewGRPCClient(ctx, cfg, logger)
-	if err != nil {
-		return nil, err
-	}
-
+func newRestartChecker(cfg *config.Cloud, logger logging.Logger, client rpc.ClientConn) needsRestartChecker {
 	return &needsRestartCheckerGRPC{
 		cfg:    cfg,
 		logger: logger,
 		client: client,
-	}, nil
+	}
 }

--- a/web/server/restart_checker.go
+++ b/web/server/restart_checker.go
@@ -59,12 +59,7 @@ func (c *needsRestartCheckerGRPC) needsRestart(ctx context.Context) (bool, time.
 	return res.MustRestart, restartInterval, nil
 }
 
-func newRestartChecker(ctx context.Context, cfg *config.Cloud, logger logging.Logger) (needsRestartChecker, error) {
-	client, err := config.CreateNewGRPCClient(ctx, cfg, logger)
-	if err != nil {
-		return nil, err
-	}
-
+func newRestartChecker(ctx context.Context, cfg *config.Cloud, logger logging.Logger, client rpc.ClientConn) (needsRestartChecker, error) {
 	return &needsRestartCheckerGRPC{
 		cfg:    cfg,
 		logger: logger,

--- a/web/server/restart_checker.go
+++ b/web/server/restart_checker.go
@@ -59,10 +59,15 @@ func (c *needsRestartCheckerGRPC) needsRestart(ctx context.Context) (bool, time.
 	return res.MustRestart, restartInterval, nil
 }
 
-func newRestartChecker(cfg *config.Cloud, logger logging.Logger, client rpc.ClientConn) needsRestartChecker {
+func newRestartChecker(ctx context.Context, cfg *config.Cloud, logger logging.Logger) (needsRestartChecker, error) {
+	client, err := config.CreateNewGRPCClient(ctx, cfg, logger)
+	if err != nil {
+		return nil, err
+	}
+
 	return &needsRestartCheckerGRPC{
 		cfg:    cfg,
 		logger: logger,
 		client: client,
-	}
+	}, nil
 }

--- a/web/server/restart_checker.go
+++ b/web/server/restart_checker.go
@@ -59,10 +59,10 @@ func (c *needsRestartCheckerGRPC) needsRestart(ctx context.Context) (bool, time.
 	return res.MustRestart, restartInterval, nil
 }
 
-func newRestartChecker(cfg *config.Cloud, logger logging.Logger, client rpc.ClientConn) (needsRestartChecker, error) {
+func newRestartChecker(cfg *config.Cloud, logger logging.Logger, client rpc.ClientConn) needsRestartChecker {
 	return &needsRestartCheckerGRPC{
 		cfg:    cfg,
 		logger: logger,
 		client: client,
-	}, nil
+	}
 }

--- a/web/server/restart_checker.go
+++ b/web/server/restart_checker.go
@@ -59,7 +59,7 @@ func (c *needsRestartCheckerGRPC) needsRestart(ctx context.Context) (bool, time.
 	return res.MustRestart, restartInterval, nil
 }
 
-func newRestartChecker(ctx context.Context, cfg *config.Cloud, logger logging.Logger, client rpc.ClientConn) (needsRestartChecker, error) {
+func newRestartChecker(cfg *config.Cloud, logger logging.Logger, client rpc.ClientConn) (needsRestartChecker, error) {
 	return &needsRestartCheckerGRPC{
 		cfg:    cfg,
 		logger: logger,


### PR DESCRIPTION
This PR accomplishes two main things:

1) creates a new type to implement the  [`rpc.ClientConn`](https://github.com/viamrobotics/goutils/blob/main/rpc/dialer.go#L65) interface that we'll use as our one global connection to app in [unifying](https://viam.atlassian.net/browse/RSDK-8291) the many that already exist.
2) uses said global connection to replace (or unify, rather) the two separate connections currently created in our `NetAppender` and `RestartChecker`.

The global connection works as follows. It's first instantiated - and thus made available to the entire RDK server - when the NetAppender is created in [web/server/entrypoint.go](https://github.com/viamrobotics/rdk/blob/main/web/server/entrypoint.go#L194). This could change in coming PR's as more connections are roped into this global one. A more important focal point is of this PR is _how_ the connection is created [and managed]. When the `grpc.NewAppConn()` is called, a dial attempt to App is made. This initial attempt blocks for some time. If not successful, a Goroutine will spin in off in the background that'll repeatedly attempt to dial App. These attempts are serialized, and each times out after 5 seconds. Once a successful connection is created, the Goroutine is done.

**Testing**
`NetAppender`
_Offline startup_ | `NetAppender` fails logging to network because it's "not connected."
_Offline startup -> connection_ | `NetAppender` fails logging to network at first but is then able to, signifying background Goroutine continually attempting to dial App works.
_Offline startup -> connection -> disconnection -> reconnection_ | `NetAppender` fails logging to network at first but is then able to. After disconnecting from the internet, `NetAppender` logs time out. Logs succeed when an internet connection returns.
_Online startup -> disconnection -> connection_ | `NetAppender` is able to log at first. Once WiFi is cut out, logs time out but succeed after it returns.

`RestartChecker`
Same as above. Signal to restart was received after multiple disconnections/reconnections.