### PR TITLE
RSDK-9818: Annotate gRPC requests from modules to the viam-server with module names.

### DIFF
--- a/grpc/interceptors.go
+++ b/grpc/interceptors.go
@@ -51,7 +51,8 @@ type modNameKeyType int
 
 const modNameKeyID = modNameKeyType(iota)
 
-// GetName returns the debug log key included when enabling the context for debug logging.
+// GetModuleName returns the module name (if any) the request came from. The module name will match
+// a string from the robot config.
 func GetModuleName(ctx context.Context) string {
 	valI := ctx.Value(modNameKeyID)
 	if val, ok := valI.(string); ok {
@@ -63,12 +64,13 @@ func GetModuleName(ctx context.Context) string {
 
 const modNameMetadataKey = "modName"
 
+// ModInterceptors takes a user input `ModName` and exposes an interceptor method that will attach
+// it to outgoing gRPC requests.
 type ModInterceptors struct {
 	ModName string
 }
 
-// UnaryClientInterceptor adds debug directives from the current context (if any) to the
-// outgoing request's metadata.
+// UnaryClientInterceptor adds a module name to any outgoing unary gRPC request.
 func (mc *ModInterceptors) UnaryClientInterceptor(
 	ctx context.Context,
 	method string,
@@ -81,8 +83,8 @@ func (mc *ModInterceptors) UnaryClientInterceptor(
 	return invoker(ctx, method, req, reply, cc, opts...)
 }
 
-// UnaryServerInterceptor checks the incoming RPC metadata for a distributed tracing directive and
-// attaches any information to a debug context.
+// ModNameUnaryServerInterceptor checks the incoming RPC metadata for a module name and attaches any
+// information to a context that can be retrieved with `GetModuleName`.
 func ModNameUnaryServerInterceptor(
 	ctx context.Context,
 	req interface{},

--- a/grpc/interceptors.go
+++ b/grpc/interceptors.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 // DefaultMethodTimeout is the default context timeout for all inbound gRPC
@@ -42,4 +43,61 @@ func EnsureTimeoutUnaryClientInterceptor(
 	}
 
 	return invoker(ctx, method, req, reply, cc, opts...)
+}
+
+// The following code is for appending/extracting grpc metadata regarding module names/origins via
+// contexts.
+type modNameKeyType int
+
+const modNameKeyID = modNameKeyType(iota)
+
+// GetName returns the debug log key included when enabling the context for debug logging.
+func GetModuleName(ctx context.Context) string {
+	valI := ctx.Value(modNameKeyID)
+	if val, ok := valI.(string); ok {
+		return val
+	}
+
+	return ""
+}
+
+const modNameMetadataKey = "modName"
+
+type ModInterceptors struct {
+	ModName string
+}
+
+// UnaryClientInterceptor adds debug directives from the current context (if any) to the
+// outgoing request's metadata.
+func (mc *ModInterceptors) UnaryClientInterceptor(
+	ctx context.Context,
+	method string,
+	req, reply interface{},
+	cc *grpc.ClientConn,
+	invoker grpc.UnaryInvoker,
+	opts ...grpc.CallOption,
+) error {
+	ctx = metadata.AppendToOutgoingContext(ctx, modNameMetadataKey, mc.ModName)
+	return invoker(ctx, method, req, reply, cc, opts...)
+}
+
+// UnaryServerInterceptor checks the incoming RPC metadata for a distributed tracing directive and
+// attaches any information to a debug context.
+func ModNameUnaryServerInterceptor(
+	ctx context.Context,
+	req interface{},
+	info *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler,
+) (interface{}, error) {
+	meta, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return handler(ctx, req)
+	}
+
+	values := meta.Get(modNameMetadataKey)
+	if len(values) == 1 {
+		ctx = context.WithValue(ctx, modNameKeyID, values[0])
+	}
+
+	return handler(ctx, req)
 }

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -1408,6 +1408,7 @@ func getFullEnvironment(
 	environment := map[string]string{
 		"VIAM_HOME":        viamHomeDir,
 		"VIAM_MODULE_DATA": dataDir,
+		"VIAM_MODULE_NAME": cfg.Name,
 	}
 	if cfg.Type == config.ModuleTypeRegistry {
 		environment["VIAM_MODULE_ID"] = cfg.ModuleID

--- a/module/module.go
+++ b/module/module.go
@@ -175,7 +175,8 @@ type peerResourceState struct {
 
 // Module represents an external resource module that services components/services.
 type Module struct {
-	// The name of the module as per the robot config.
+	// The name of the module as per the robot config. This value is communicated via the
+	// `VIAM_MODULE_NAME` env var.
 	name string
 
 	shutdownCtx             context.Context

--- a/module/testmodule/main.go
+++ b/module/testmodule/main.go
@@ -108,10 +108,8 @@ func newHelper(
 	ctx context.Context, deps resource.Dependencies, conf resource.Config, logger logging.Logger,
 ) (resource.Resource, error) {
 	var dependsOnSensor sensor.Sensor
-	for _, resObj := range deps {
-		if resSensor, ok := resObj.(sensor.Sensor); ok {
-			dependsOnSensor = resSensor
-		}
+	if len(conf.DependsOn) > 0 {
+		dependsOnSensor, err := sensor.FromDependencies(deps, conf.DependsOn[0])
 	}
 
 	if len(deps) > 0 && dependsOnSensor == nil {

--- a/module/testmodule/main.go
+++ b/module/testmodule/main.go
@@ -206,8 +206,8 @@ func (h *helper) DoCommand(ctx context.Context, req map[string]interface{}) (map
 	case "get_num_reconfigurations":
 		return map[string]any{"num_reconfigurations": h.numReconfigurations}, nil
 	case "do_readings_on_dep":
-		h.dependsOnSensor.Readings(ctx, nil)
-		return nil, nil
+		_, err := h.dependsOnSensor.Readings(ctx, nil)
+		return nil, err
 	default:
 		return nil, fmt.Errorf("unknown command string %s", cmd)
 	}

--- a/module/testmodule/main.go
+++ b/module/testmodule/main.go
@@ -108,12 +108,16 @@ func newHelper(
 	ctx context.Context, deps resource.Dependencies, conf resource.Config, logger logging.Logger,
 ) (resource.Resource, error) {
 	var dependsOnSensor sensor.Sensor
+	var err error
 	if len(conf.DependsOn) > 0 {
-		dependsOnSensor, err := sensor.FromDependencies(deps, conf.DependsOn[0])
+		dependsOnSensor, err = sensor.FromDependencies(deps, conf.DependsOn[0])
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if len(deps) > 0 && dependsOnSensor == nil {
-		panic("bad")
+		return nil, fmt.Errorf("Sensor not found in deps: %v", deps)
 	}
 
 	return &helper{

--- a/module/testmodule/main.go
+++ b/module/testmodule/main.go
@@ -117,7 +117,7 @@ func newHelper(
 	}
 
 	if len(deps) > 0 && dependsOnSensor == nil {
-		return nil, fmt.Errorf("Sensor not found in deps: %v", deps)
+		return nil, fmt.Errorf("sensor not found in deps: %v", deps)
 	}
 
 	return &helper{

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -290,6 +290,11 @@ func New(ctx context.Context, address string, clientLogger logging.ZapCompatible
 		rpc.WithStreamClientInterceptor(streamClientInterceptor()),
 	)
 
+	if rOpts.modName != "" {
+		inter := &grpc.ModInterceptors{ModName: rOpts.modName}
+		rc.dialOptions = append(rc.dialOptions, rpc.WithUnaryClientInterceptor(inter.UnaryClientInterceptor))
+	}
+
 	if err := rc.Connect(ctx); err != nil {
 		return nil, err
 	}

--- a/robot/client/client_options.go
+++ b/robot/client/client_options.go
@@ -32,6 +32,8 @@ type robotClientOpts struct {
 
 	// controls whether or not sessions are disabled.
 	disableSessions bool
+
+	modName string
 }
 
 // RobotClientOption configures how we set up the connection.
@@ -54,6 +56,12 @@ func newFuncRobotClientOption(f func(*robotClientOpts)) *funcRobotClientOption {
 	return &funcRobotClientOption{
 		f: f,
 	}
+}
+
+func WithModName(modName string) RobotClientOption {
+	return newFuncRobotClientOption(func(o *robotClientOpts) {
+		o.modName = modName
+	})
 }
 
 // WithRefreshEvery returns a RobotClientOption for how often to refresh the status/parts of the

--- a/robot/client/client_options.go
+++ b/robot/client/client_options.go
@@ -58,6 +58,8 @@ func newFuncRobotClientOption(f func(*robotClientOpts)) *funcRobotClientOption {
 	}
 }
 
+// WithModName attaches a unary interceptor that attaches the module name for each outgoing gRPC
+// request.
 func WithModName(modName string) RobotClientOption {
 	return newFuncRobotClientOption(func(o *robotClientOpts) {
 		o.modName = modName

--- a/robot/client/client_options.go
+++ b/robot/client/client_options.go
@@ -59,7 +59,7 @@ func newFuncRobotClientOption(f func(*robotClientOpts)) *funcRobotClientOption {
 }
 
 // WithModName attaches a unary interceptor that attaches the module name for each outgoing gRPC
-// request.
+// request. Should only be used in Viam module library code.
 func WithModName(modName string) RobotClientOption {
 	return newFuncRobotClientOption(func(o *robotClientOpts) {
 		o.modName = modName

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -46,7 +46,6 @@ import (
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/examples/customresources/apis/gizmoapi"
 	"go.viam.com/rdk/examples/customresources/apis/summationapi"
-	"go.viam.com/rdk/grpc"
 	rgrpc "go.viam.com/rdk/grpc"
 	internalcloud "go.viam.com/rdk/internal/cloud"
 	"go.viam.com/rdk/logging"
@@ -4538,7 +4537,7 @@ func TestRemovingOfflineRemotes(t *testing.T) {
 
 // TestModuleNamePassing asserts that module names are passed from viam-server -> module
 // properly. Such that incoming requests from module -> viam-server identify themselves. And can be
-// observed on contexts via `grpc.GetModuleName(ctx)`.
+// observed on contexts via `[r]grpc.GetModuleName(ctx)`.
 func TestModuleNamePassing(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 
@@ -4553,7 +4552,7 @@ func TestModuleNamePassing(t *testing.T) {
 	moduleNameCh := make(chan string, 1)
 	callbackSensor := &inject.Sensor{
 		ReadingsFunc: func(ctx context.Context, extra map[string]any) (map[string]any, error) {
-			moduleNameCh <- grpc.GetModuleName(ctx)
+			moduleNameCh <- rgrpc.GetModuleName(ctx)
 			return map[string]any{
 				"reading": 42,
 			}, nil

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -194,6 +194,10 @@ func (svc *webService) StartModule(ctx context.Context) error {
 
 	unaryInterceptors = append(unaryInterceptors, grpc.EnsureTimeoutUnaryServerInterceptor)
 
+	// Attach the module name (as defined by the robot config) to the handler context. Can be
+	// accessed via `grpc.GetModuleName`.
+	unaryInterceptors = append(unaryInterceptors, grpc.ModNameUnaryServerInterceptor)
+
 	opManager := svc.r.OperationManager()
 	unaryInterceptors = append(unaryInterceptors,
 		opManager.UnaryServerInterceptor, logging.UnaryServerInterceptor)


### PR DESCRIPTION
Pass a VIAM_MODULE_NAME env variable to module processes.