### PR TITLE
Remove TagsByFilter in preparation of deprecating API

### DIFF
--- a/app/data_client.go
+++ b/app/data_client.go
@@ -668,18 +668,6 @@ func (d *DataClient) RemoveTagsFromBinaryDataByFilter(ctx context.Context,
 	return int(resp.DeletedCount), nil
 }
 
-// TagsByFilter retrieves all unique tags associated with the data that match the specified filter.
-// It returns the list of these unique tags. If no filter is given, all data tags are returned.
-func (d *DataClient) TagsByFilter(ctx context.Context, filter *Filter) ([]string, error) {
-	resp, err := d.dataClient.TagsByFilter(ctx, &pb.TagsByFilterRequest{
-		Filter: filterToProto(filter),
-	})
-	if err != nil {
-		return nil, err
-	}
-	return resp.Tags, nil
-}
-
 // AddBoundingBoxToImageByID adds a bounding box to an image with the specified ID,
 // using the provided label and position in normalized coordinates.
 // All normalized coordinates (xMin, yMin, xMax, yMax) must be float values in the range [0, 1].

--- a/app/data_client_test.go
+++ b/app/data_client_test.go
@@ -564,20 +564,6 @@ func TestDataClient(t *testing.T) {
 		test.That(t, resp, test.ShouldEqual, count)
 	})
 
-	t.Run("TagsByFilter", func(t *testing.T) {
-		grpcClient.TagsByFilterFunc = func(ctx context.Context, in *pb.TagsByFilterRequest,
-			opts ...grpc.CallOption,
-		) (*pb.TagsByFilterResponse, error) {
-			test.That(t, in.Filter, test.ShouldResemble, pbFilter)
-			return &pb.TagsByFilterResponse{
-				Tags: tags,
-			}, nil
-		}
-		resp, err := client.TagsByFilter(context.Background(), &filter)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, resp, test.ShouldResemble, tags)
-	})
-
 	t.Run("AddBoundingBoxToImageByID", func(t *testing.T) {
 		grpcClient.AddBoundingBoxToImageByIDFunc = func(ctx context.Context,
 			in *pb.AddBoundingBoxToImageByIDRequest,

--- a/testutils/inject/data_service_client.go
+++ b/testutils/inject/data_service_client.go
@@ -220,16 +220,6 @@ func (client *DataServiceClient) RemoveTagsFromBinaryDataByFilter(ctx context.Co
 	return client.RemoveTagsFromBinaryDataByFilterFunc(ctx, in, opts...)
 }
 
-// TagsByFilter calls the injected TagsByFilter or the real version.
-func (client *DataServiceClient) TagsByFilter(ctx context.Context, in *datapb.TagsByFilterRequest,
-	opts ...grpc.CallOption,
-) (*datapb.TagsByFilterResponse, error) {
-	if client.TagsByFilterFunc == nil {
-		return client.DataServiceClient.TagsByFilter(ctx, in, opts...)
-	}
-	return client.TagsByFilterFunc(ctx, in, opts...)
-}
-
 // AddBoundingBoxToImageByID calls the injected AddBoundingBoxToImageByID or the real version.
 func (client *DataServiceClient) AddBoundingBoxToImageByID(ctx context.Context, in *datapb.AddBoundingBoxToImageByIDRequest,
 	opts ...grpc.CallOption,


### PR DESCRIPTION
Hey folks, we are deprecating this API, so I'm starting to remove references of it from RDK and app. 