### PR TITLE
APP-7356 alter windows release filename to work with discovery

### DIFF
--- a/packaging.make
+++ b/packaging.make
@@ -55,18 +55,17 @@ static-release: server-static-compressed
 		--arch ${UNAME_M} \
 		--output-path etc/packaging/static/manifest/viam-server-${BUILD_CHANNEL}-${UNAME_M}.json
 
-static-release-win: FILENAME_OS=-windows
 static-release-win:
-	# note: FILENAME_OS will be -windows for windows builds; for backwards compatibility, we don't do this for linux.
 	rm -f bin/static/viam-server-windows.exe
 	GOOS=windows GOARCH=amd64 go build -tags no_cgo,osusergo,netgo -ldflags="-extldflags=-static $(COMMON_LDFLAGS)" -o bin/static/viam-server-windows.exe ./web/cmd/server
 	upx --best --lzma bin/static/viam-server-windows.exe
 
 	rm -rf etc/packaging/static/deploy/
 	mkdir -p etc/packaging/static/deploy/
-	cp bin/static/viam-server-windows.exe etc/packaging/static/deploy/viam-server$(FILENAME_OS)-${BUILD_CHANNEL}-${UNAME_M}.exe
+	cp bin/static/viam-server-windows.exe etc/packaging/static/deploy/viam-server-${BUILD_CHANNEL}-windows-${UNAME_M}
+	# note: the stable/latest file still has a .exe extension because we expect this to be a known URL that people download + want to have usable.
 	if [ "${RELEASE_TYPE}" = "stable" ] || [ "${RELEASE_TYPE}" = "latest" ]; then \
-		cp bin/static/viam-server-windows.exe etc/packaging/static/deploy/viam-server$(FILENAME_OS)-${RELEASE_TYPE}-${UNAME_M}.exe; \
+		cp bin/static/viam-server-windows.exe etc/packaging/static/deploy/viam-server-${RELEASE_TYPE}-windows-${UNAME_M}.exe; \
 	fi
 
 	# note: GOOS=windows would break this on a linux runner
@@ -75,9 +74,9 @@ static-release-win:
 	rm -rf etc/packaging/static/manifest/
 	mkdir -p etc/packaging/static/manifest/
 	go run ./etc/subsystem_manifest \
-		--binary-path etc/packaging/static/deploy/viam-server$(FILENAME_OS)-${BUILD_CHANNEL}-${UNAME_M}.exe \
-		--upload-path packages.viam.com/apps/viam-server/viam-server$(FILENAME_OS)-${BUILD_CHANNEL}-${UNAME_M}.exe \
+		--binary-path etc/packaging/static/deploy/viam-server-${BUILD_CHANNEL}-windows-${UNAME_M} \
+		--upload-path packages.viam.com/apps/viam-server/viam-server-${BUILD_CHANNEL}-windows-${UNAME_M} \
 		--version ${BUILD_CHANNEL} \
 		--arch ${UNAME_M} \
 		--resources-json win-resources.json \
-		--output-path etc/packaging/static/manifest/viam-server$(FILENAME_OS)-${BUILD_CHANNEL}-${UNAME_M}.json
+		--output-path etc/packaging/static/manifest/viam-server-${BUILD_CHANNEL}-windows-${UNAME_M}.json


### PR DESCRIPTION
## What changed
- in `make static-release-win`, change output path from `windows-BUILD_CHANNEL-uname.exe` to `BUILD_CHANNEL-windows-uname` (no exe)
## Why
Previous attempt wasn't working with the discovery regex.
## Sanity check
Working and non-working patterns in prod:
- non-working: `viam-server-windows-v0.60.1-x86_64.exe`
- working: `viam-server-v0.60.1-windows-x86_64`

I ran this locally and got:
```sh
$ ls etc/packaging/static/deploy
viam-server-local-windows-x86_64
```