### PR TITLE
[RSDK-9869] Globally Manage Lifecycle of Shared Connection to App

### DIFF
--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -196,6 +196,7 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 	if err != nil {
 		return err
 	}
+	defer appConn.Close()
 
 	// Start remote logging with config from disk.
 	// This is to ensure we make our best effort to write logs for failures loading the remote config.
@@ -468,7 +469,6 @@ func (s *robotServer) serveWeb(ctx context.Context, cfg *config.Config) (err err
 		utils.PanicCapturingGo(func() {
 			defer close(cloudRestartCheckerActive)
 			restartCheck := newRestartChecker(cfg.Cloud, s.logger, s.conn)
-			defer restartCheck.close()
 			restartInterval := defaultNeedsRestartCheckInterval
 
 			for {

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -192,11 +192,17 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 
 	// the underlying connection in `appConn` can be nil. In this case, a background Goroutine is kicked off to reattempt dials in a
 	// serialized manner
-	appConn, err := grpc.NewAppConn(ctx, cfgFromDisk.Cloud, logger.Sublogger("networking").Sublogger("app_connection"))
+	appConnLogger := logger.Sublogger("networking").Sublogger("app_connection")
+	appConn, err := grpc.NewAppConn(ctx, cfgFromDisk.Cloud, appConnLogger)
 	if err != nil {
 		return err
 	}
-	defer appConn.Close()
+	defer func() {
+		err := appConn.Close()
+		if err != nil {
+			appConnLogger.Error(err)
+		}
+	}()
 
 	// Start remote logging with config from disk.
 	// This is to ensure we make our best effort to write logs for failures loading the remote config.

--- a/web/server/restart_checker.go
+++ b/web/server/restart_checker.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	apppb "go.viam.com/api/app/v1"
-	"go.viam.com/utils"
 	"go.viam.com/utils/rpc"
 
 	"go.viam.com/rdk/config"
@@ -20,19 +19,12 @@ const (
 
 type needsRestartChecker interface {
 	needsRestart(ctx context.Context) (bool, time.Duration, error)
-	close()
 }
 
 type needsRestartCheckerGRPC struct {
 	cfg    *config.Cloud
 	logger logging.Logger
 	client rpc.ClientConn
-}
-
-func (c *needsRestartCheckerGRPC) close() {
-	if c.client != nil {
-		utils.UncheckedErrorFunc(c.client.Close)
-	}
 }
 
 // ForceRestart lets random other parts of the app request an exit.


### PR DESCRIPTION
After [unifying](https://github.com/viamrobotics/rdk/pull/4746) the connections to App used by RDK's net appender and restart checker, we realized that the lifecycle of the connection they now share should not be managed by either of them. The net appender already does not manage it (i.e., it never tries to close it), but the restart checker _does_ try to close the connection. This PR stops the restart checker from closing it and instead closes the connection when the server exits - once we know it [the connection] isn't getting used anymore. This oversight became apparent through the logs below. The net appender was incorrectly logging messages in its queue because the restart checker was closing the connection required for the logging to succeed.

`2025-01-30T15:03:54.717Z        INFO    rdk.networking.netlogger  logging/net_appender.go:303     error logging to network: not connected
2025-01-30T15:03:56.356Z        WARN    rdk.networking.netlogger  logging/net_appender.go:181     NetAppender.Close() did not progress in 1.5s, closing with 22 still in queue`