### PR TITLE
RSDK-9878: Move webService into web.go.

### DIFF
--- a/robot/web/stream/backoff.go
+++ b/robot/web/stream/backoff.go
@@ -5,8 +5,9 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"go.viam.com/rdk/logging"
 	"go.viam.com/utils"
+
+	"go.viam.com/rdk/logging"
 )
 
 // BackoffTuningOptions represents a set of parameters for determining exponential

--- a/robot/web/stream/backoff.go
+++ b/robot/web/stream/backoff.go
@@ -1,40 +1,13 @@
-//go:build !no_cgo || android
-
-// Package webstream provides controls for streaming from the web server.
 package webstream
 
 import (
 	"context"
-	"errors"
 	"time"
 
-	"go.viam.com/utils"
-
-	"go.viam.com/rdk/gostream"
+	"github.com/pkg/errors"
 	"go.viam.com/rdk/logging"
+	"go.viam.com/utils"
 )
-
-// streamVideoSource starts a stream from a video source with a throttled error handler.
-func streamVideoSource(
-	ctx context.Context,
-	source gostream.VideoSource,
-	stream gostream.Stream,
-	backoffOpts *BackoffTuningOptions,
-	logger logging.Logger,
-) error {
-	return gostream.StreamVideoSourceWithErrorHandler(ctx, source, stream, backoffOpts.getErrorThrottledHandler(logger, stream.Name()), logger)
-}
-
-// streamAudioSource starts a stream from an audio source with a throttled error handler.
-func streamAudioSource(
-	ctx context.Context,
-	source gostream.AudioSource,
-	stream gostream.Stream,
-	backoffOpts *BackoffTuningOptions,
-	logger logging.Logger,
-) error {
-	return gostream.StreamAudioSourceWithErrorHandler(ctx, source, stream, backoffOpts.getErrorThrottledHandler(logger, "audio"), logger)
-}
 
 // BackoffTuningOptions represents a set of parameters for determining exponential
 // backoff when receiving multiple simultaneous errors.

--- a/robot/web/stream/stream_c.go
+++ b/robot/web/stream/stream_c.go
@@ -1,0 +1,33 @@
+//go:build !no_cgo || android
+
+// Package webstream provides controls for streaming from the web server.
+package webstream
+
+import (
+	"context"
+
+	"go.viam.com/rdk/gostream"
+	"go.viam.com/rdk/logging"
+)
+
+// streamVideoSource starts a stream from a video source with a throttled error handler.
+func streamVideoSource(
+	ctx context.Context,
+	source gostream.VideoSource,
+	stream gostream.Stream,
+	backoffOpts *BackoffTuningOptions,
+	logger logging.Logger,
+) error {
+	return gostream.StreamVideoSourceWithErrorHandler(ctx, source, stream, backoffOpts.getErrorThrottledHandler(logger, stream.Name()), logger)
+}
+
+// streamAudioSource starts a stream from an audio source with a throttled error handler.
+func streamAudioSource(
+	ctx context.Context,
+	source gostream.AudioSource,
+	stream gostream.Stream,
+	backoffOpts *BackoffTuningOptions,
+	logger logging.Logger,
+) error {
+	return gostream.StreamAudioSourceWithErrorHandler(ctx, source, stream, backoffOpts.getErrorThrottledHandler(logger, "audio"), logger)
+}

--- a/robot/web/stream/stream_notc.go
+++ b/robot/web/stream/stream_notc.go
@@ -1,0 +1,34 @@
+//go:build no_cgo && !android
+
+// Package webstream provides controls for streaming from the web server.
+package webstream
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"go.viam.com/rdk/gostream"
+	"go.viam.com/rdk/logging"
+)
+
+// streamVideoSource starts a stream from a video source with a throttled error handler.
+func streamVideoSource(
+	ctx context.Context,
+	source gostream.VideoSource,
+	stream gostream.Stream,
+	backoffOpts *BackoffTuningOptions,
+	logger logging.Logger,
+) error {
+	return errors.New("not implemented for non-cgo")
+}
+
+// streamAudioSource starts a stream from an audio source with a throttled error handler.
+func streamAudioSource(
+	ctx context.Context,
+	source gostream.AudioSource,
+	stream gostream.Stream,
+	backoffOpts *BackoffTuningOptions,
+	logger logging.Logger,
+) error {
+	return errors.New("not implemented for non-cgo")
+}

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -39,6 +39,7 @@ import (
 	"go.viam.com/rdk/robot"
 	grpcserver "go.viam.com/rdk/robot/server"
 	weboptions "go.viam.com/rdk/robot/web/options"
+	webstream "go.viam.com/rdk/robot/web/stream"
 	rutils "go.viam.com/rdk/utils"
 )
 
@@ -78,6 +79,26 @@ type Service interface {
 	ModuleAddress() string
 
 	Stats() any
+}
+
+type webService struct {
+	resource.Named
+
+	mu           sync.Mutex
+	r            robot.Robot
+	rpcServer    rpc.Server
+	modServer    rpc.Server
+	streamServer *webstream.Server
+	services     map[resource.API]resource.APIResourceCollection[resource.Resource]
+	opts         options
+	addr         string
+	modAddr      string
+	logger       logging.Logger
+	cancelCtx    context.Context
+	cancelFunc   func()
+	isRunning    bool
+	webWorkers   sync.WaitGroup
+	modWorkers   sync.WaitGroup
 }
 
 var internalWebServiceName = resource.NewName(

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -84,10 +84,12 @@ type Service interface {
 type webService struct {
 	resource.Named
 
-	mu           sync.Mutex
-	r            robot.Robot
-	rpcServer    rpc.Server
-	modServer    rpc.Server
+	mu        sync.Mutex
+	r         robot.Robot
+	rpcServer rpc.Server
+	modServer rpc.Server
+
+	// Will be nil on non-cgo builds.
 	streamServer *webstream.Server
 	services     map[resource.API]resource.APIResourceCollection[resource.Resource]
 	opts         options

--- a/robot/web/web_c.go
+++ b/robot/web/web_c.go
@@ -6,11 +6,9 @@ import (
 	"bytes"
 	"context"
 	"net/http"
-	"sync"
 
 	"github.com/pkg/errors"
 	streampb "go.viam.com/api/stream/v1"
-	"go.viam.com/utils/rpc"
 
 	"go.viam.com/rdk/gostream"
 	"go.viam.com/rdk/logging"
@@ -35,26 +33,6 @@ func New(r robot.Robot, logger logging.Logger, opts ...Option) Service {
 		opts:         wOpts,
 	}
 	return webSvc
-}
-
-type webService struct {
-	resource.Named
-
-	mu           sync.Mutex
-	r            robot.Robot
-	rpcServer    rpc.Server
-	modServer    rpc.Server
-	streamServer *webstream.Server
-	services     map[resource.API]resource.APIResourceCollection[resource.Resource]
-	opts         options
-	addr         string
-	modAddr      string
-	logger       logging.Logger
-	cancelCtx    context.Context
-	cancelFunc   func()
-	isRunning    bool
-	webWorkers   sync.WaitGroup
-	modWorkers   sync.WaitGroup
 }
 
 // Reconfigure pulls resources and updates the stream server audio and video streams with the new resources.

--- a/robot/web/web_notc.go
+++ b/robot/web/web_notc.go
@@ -4,12 +4,10 @@ package web
 
 import (
 	"context"
-	"sync"
 
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot"
-	"go.viam.com/utils/rpc"
 )
 
 // New returns a new web service for the given robot.
@@ -27,25 +25,6 @@ func New(r robot.Robot, logger logging.Logger, opts ...Option) Service {
 		opts:      wOpts,
 	}
 	return webSvc
-}
-
-type webService struct {
-	resource.Named
-
-	mu         sync.Mutex
-	r          robot.Robot
-	rpcServer  rpc.Server
-	modServer  rpc.Server
-	services   map[resource.API]resource.APIResourceCollection[resource.Resource]
-	opts       options
-	addr       string
-	modAddr    string
-	logger     logging.Logger
-	cancelCtx  context.Context
-	cancelFunc func()
-	isRunning  bool
-	webWorkers sync.WaitGroup
-	modWorkers sync.WaitGroup
 }
 
 // Update updates the web service when the robot has changed.


### PR DESCRIPTION
The webstream package is now always imported. Split up webstream package into C and not-C pieces to accommodate this.