### PR TITLE
RSDK-9882 - stop erroring out when unable to refresh token on login

### DIFF
--- a/cli/auth.go
+++ b/cli/auth.go
@@ -166,10 +166,13 @@ func (c *viamClient) loginAction(cCtx *cli.Context) error {
 		t, err = c.authFlow.refreshToken(c.c.Context, currentToken)
 		if err != nil {
 			debugf(c.c.App.Writer, globalArgs.Debug, "Token refresh error: %v", err)
-			utils.UncheckedError(c.logout()) // clear cache if failed to refresh
-			return errors.New("error while refreshing token, logging out. Please log in again")
+			if err = c.logout(); err != nil { // clear cache if failed to refresh
+				Errorf(c.c.App.Writer, "Error clearing cache: %v", err)
+				return err
+			}
 		}
-	} else {
+	}
+	if t == nil {
 		t, err = c.authFlow.loginAsUser(c.c)
 		if err != nil {
 			debugf(c.c.App.Writer, globalArgs.Debug, "Login error: %v", err)

--- a/cli/auth.go
+++ b/cli/auth.go
@@ -166,13 +166,10 @@ func (c *viamClient) loginAction(cCtx *cli.Context) error {
 		t, err = c.authFlow.refreshToken(c.c.Context, currentToken)
 		if err != nil {
 			debugf(c.c.App.Writer, globalArgs.Debug, "Token refresh error: %v", err)
-			if err = c.logout(); err != nil { // clear cache if failed to refresh
-				Errorf(c.c.App.Writer, "Error clearing cache: %v", err)
-				return err
-			}
+			utils.UncheckedError(c.logout()) // clear cache if failed to refresh
 		}
 	}
-	if t == nil {
+	if t == nil { // either there was no current token, or the current token couldn't be refreshed
 		t, err = c.authFlow.loginAsUser(c.c)
 		if err != nil {
 			debugf(c.c.App.Writer, globalArgs.Debug, "Login error: %v", err)


### PR DESCRIPTION
Stop erroring when unable to refresh token in login action.

~~Not tested; I believe this only arises after someone has been logged in for more than 24 hours such that a new login action is required, and then tries to run `viam login` without running an intervening command that causes a logout first. However, the change is fairly straightforward so I think it's probably fine. If people want testing to confirm, I can do so tomorrow (Tuesday, February 4th, 2025).~~

Tested locally, it works.