### PR TITLE
RSDK-9885: Add network stats to ftdc.

### DIFF
--- a/ftdc/cmd/parser.go
+++ b/ftdc/cmd/parser.go
@@ -156,6 +156,10 @@ var ratioMetricToFields = map[string]ratioMetric{
 	"SystemCPU": {"SystemCPUSecs", "ElapsedTimeSecs"},
 	// PerSec ratios use an empty string denominator.
 	"HeadersProcessedPerSec": {"HeadersProcessed", ""},
+	"TxPacketsPerSec":        {"TxPackets", ""},
+	"RxPacketsPerSec":        {"RxPackets", ""},
+	"TxBytesPerSec":          {"TxBytes", ""},
+	"RxBytesPerSec":          {"RxBytes", ""},
 }
 
 // ratioReading is a reading of two metrics described by `ratioMetric`. This is what will be graphed.
@@ -359,7 +363,10 @@ func (gpw *gnuplotWriter) CompileAndClose() string {
 	// We're making separate graphs instead of a single big graph. The graphs will be arranged in a
 	// rectangle with 1 column and X rows. Where X is the number of metrics.  Add some margins for
 	// aesthetics.
-	writelnf(gnuFile, "set multiplot layout %v,1 margins 0.05,0.9, 0.05,0.9 spacing screen 0, char 5", len(gpw.metricFiles))
+	//
+	// The first margin is the left-hand margin. We set it a bit bigger to allow for larger numbers
+	// for labeling the Y-axis values.
+	writelnf(gnuFile, "set multiplot layout %v,1 margins 0.10,0.9, 0.05,0.9 spacing screen 0, char 5", len(gpw.metricFiles))
 
 	//  Axis labeling/formatting/type information.
 	writeln(gnuFile, "set timefmt '%s'")

--- a/ftdc/sys/net.go
+++ b/ftdc/sys/net.go
@@ -1,0 +1,71 @@
+package sys
+
+import (
+	"github.com/prometheus/procfs"
+)
+
+type NetStatser struct {
+	fs procfs.FS
+}
+
+func NewNetUsage() (*NetStatser, error) {
+	fs, err := procfs.NewDefaultFS()
+	if err != nil {
+		return nil, err
+	}
+
+	return &NetStatser{fs}, nil
+}
+
+type NetDevLine struct {
+	RxBytes   uint64
+	RxPackets uint64
+	RxErrors  uint64
+	RxDropped uint64
+	TxBytes   uint64
+	TxPackets uint64
+	TxErrors  uint64
+	TxDropped uint64
+}
+
+type IfaceStats struct {
+	TxQueueLength uint64
+	RxQueueLength uint64
+	UsedSockets   uint64
+	Drops         uint64
+}
+
+type NetworkStats struct {
+	Ifaces map[string]NetDevLine
+	TCP    IfaceStats
+	UDP    IfaceStats
+}
+
+func (netStatser *NetStatser) Stats() any {
+	ret := NetworkStats{
+		Ifaces: make(map[string]NetDevLine),
+	}
+	if dev, err := netStatser.fs.NetDev(); err == nil {
+		for ifaceName, stats := range dev {
+			ret.Ifaces[ifaceName] = NetDevLine{
+				stats.RxBytes, stats.RxPackets, stats.RxErrors, stats.RxDropped,
+				stats.TxBytes, stats.TxPackets, stats.TxErrors, stats.TxDropped,
+			}
+		}
+	}
+
+	if netTcpSummary, err := netStatser.fs.NetTCPSummary(); err == nil {
+		ret.TCP.TxQueueLength = netTcpSummary.TxQueueLength
+		ret.TCP.RxQueueLength = netTcpSummary.RxQueueLength
+		ret.TCP.UsedSockets = netTcpSummary.UsedSockets
+	}
+
+	if netUdpSummary, err := netStatser.fs.NetUDPSummary(); err == nil {
+		ret.UDP.TxQueueLength = netUdpSummary.TxQueueLength
+		ret.UDP.RxQueueLength = netUdpSummary.RxQueueLength
+		ret.UDP.UsedSockets = netUdpSummary.UsedSockets
+		ret.UDP.Drops = *netUdpSummary.Drops
+	}
+
+	return ret
+}

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -377,6 +377,9 @@ func newWithResources(
 		if statser, err := sys.NewSelfSysUsageStatser(); err == nil {
 			ftdcWorker.Add("proc.viam-server", statser)
 		}
+		if statser, err := sys.NewNetUsage(); err == nil {
+			ftdcWorker.Add("net", statser)
+		}
 	}
 
 	closeCtx, cancel := context.WithCancel(ctx)


### PR DESCRIPTION
This continues to add more usages to the prometheus procfs library. The new usages read from 3 files:
- `/proc/net/dev` (this powers the numbers in `ifconfig`)
- `/proc/net/tcp` (i.e: grpc to app)
- `/proc/net/udp` (i.e: webrtc)

How the graph looks before the `parser.go` changes:
![image](https://github.com/user-attachments/assets/b8163c04-7e3d-4340-829b-1efbcb0ba0a2)

How the graph looks after the `parser.go` changes:
![image](https://github.com/user-attachments/assets/05d5411c-c0ee-4c38-9693-765251ca4e23)
