### PR TITLE
[RSDK-6469]  Set x264 bitrate based on resolution and fps

### DIFF
--- a/gostream/codec/x264/encoder.go
+++ b/gostream/codec/x264/encoder.go
@@ -3,6 +3,7 @@ package x264
 
 import (
 	"context"
+	"fmt"
 	"image"
 
 	"github.com/pion/mediadevices/pkg/codec"
@@ -19,9 +20,6 @@ type encoder struct {
 	logger logging.Logger
 }
 
-// Gives suitable results. Probably want to make this configurable this in the future.
-const bitrate = 3_200_000
-
 // NewEncoder returns an x264 encoder that can encode images of the given width and height. It will
 // also ensure that it produces key frames at the given interval.
 func NewEncoder(width, height, keyFrameInterval int, logger logging.Logger) (ourcodec.VideoEncoder, error) {
@@ -33,8 +31,13 @@ func NewEncoder(width, height, keyFrameInterval int, logger logging.Logger) (our
 		return nil, err
 	}
 	builder = &params
-	params.BitRate = bitrate
 	params.KeyFrameInterval = keyFrameInterval
+	params.BitRate = calcBitrateFromResolution(width, height, float32(params.KeyFrameInterval))
+	// TODO(seanp): this if for debugging. remove it before merging.
+	fmt.Println("KeyFrameInterval: ", params.KeyFrameInterval)
+	fmt.Println("Width: ", width)
+	fmt.Println("Height: ", height)
+	fmt.Println("Bitrate: ", params.BitRate)
 
 	codec, err := builder.BuildVideoEncoder(enc, prop.Media{
 		Video: prop.Video{

--- a/gostream/codec/x264/encoder.go
+++ b/gostream/codec/x264/encoder.go
@@ -3,7 +3,6 @@ package x264
 
 import (
 	"context"
-	"fmt"
 	"image"
 
 	"github.com/pion/mediadevices/pkg/codec"
@@ -33,11 +32,6 @@ func NewEncoder(width, height, keyFrameInterval int, logger logging.Logger) (our
 	builder = &params
 	params.KeyFrameInterval = keyFrameInterval
 	params.BitRate = calcBitrateFromResolution(width, height, float32(params.KeyFrameInterval))
-	// TODO(seanp): this if for debugging. remove it before merging.
-	fmt.Println("KeyFrameInterval: ", params.KeyFrameInterval)
-	fmt.Println("Width: ", width)
-	fmt.Println("Height: ", height)
-	fmt.Println("Bitrate: ", params.BitRate)
 
 	codec, err := builder.BuildVideoEncoder(enc, prop.Media{
 		Video: prop.Video{

--- a/gostream/codec/x264/encoder.go
+++ b/gostream/codec/x264/encoder.go
@@ -25,7 +25,7 @@ type encoder struct {
 func NewEncoder(width, height, keyFrameInterval int, logger logging.Logger) (ourcodec.VideoEncoder, error) {
 	// Check to make sure dimensions are even.
 	if width%2 != 0 || height%2 != 0 {
-		return nil, errors.New("x264 encoder does not support odd dimensions. Please provide frames with dimensions for width and height.")
+		return nil, errors.New("x264 encoder does not support odd dimensions. Please provide frames with even dimensions for width and height.")
 	}
 
 	enc := &encoder{logger: logger}

--- a/gostream/codec/x264/encoder.go
+++ b/gostream/codec/x264/encoder.go
@@ -3,6 +3,7 @@ package x264
 
 import (
 	"context"
+	"errors"
 	"image"
 
 	"github.com/pion/mediadevices/pkg/codec"
@@ -22,6 +23,11 @@ type encoder struct {
 // NewEncoder returns an x264 encoder that can encode images of the given width and height. It will
 // also ensure that it produces key frames at the given interval.
 func NewEncoder(width, height, keyFrameInterval int, logger logging.Logger) (ourcodec.VideoEncoder, error) {
+	// Check to make sure dimensions are even.
+	if width%2 != 0 || height%2 != 0 {
+		return nil, errors.New("x264 encoder does not support odd dimensions")
+	}
+
 	enc := &encoder{logger: logger}
 
 	var builder codec.VideoEncoderBuilder

--- a/gostream/codec/x264/encoder.go
+++ b/gostream/codec/x264/encoder.go
@@ -25,7 +25,7 @@ type encoder struct {
 func NewEncoder(width, height, keyFrameInterval int, logger logging.Logger) (ourcodec.VideoEncoder, error) {
 	// Check to make sure dimensions are even.
 	if width%2 != 0 || height%2 != 0 {
-		return nil, errors.New("x264 encoder does not support odd dimensions")
+		return nil, errors.New("x264 encoder does not support odd dimensions. Please provide frames with dimensions for width and height.")
 	}
 
 	enc := &encoder{logger: logger}

--- a/gostream/codec/x264/encoder.go
+++ b/gostream/codec/x264/encoder.go
@@ -25,7 +25,8 @@ type encoder struct {
 func NewEncoder(width, height, keyFrameInterval int, logger logging.Logger) (ourcodec.VideoEncoder, error) {
 	// Check to make sure dimensions are even.
 	if width%2 != 0 || height%2 != 0 {
-		return nil, errors.New("x264 encoder does not support odd dimensions. Please provide frames with even dimensions for width and height.")
+		return nil, errors.New("x264 encoder does not support odd dimensions. " +
+			"Please provide frames with even dimensions for width and height")
 	}
 
 	enc := &encoder{logger: logger}

--- a/gostream/codec/x264/encoder_test.go
+++ b/gostream/codec/x264/encoder_test.go
@@ -104,3 +104,23 @@ func BenchmarkEncodeYCbCr(b *testing.B) {
 		w = !w
 	}
 }
+
+func TestCalcBitrateFromResolution(t *testing.T) {
+	bitrateTests := []struct {
+		width, height int
+		framerate     float32
+		expected      int
+	}{
+		{640, 480, 30, 1382400},
+		{1920, 1080, 30, 9331200},
+		{3840, 2160, 30, maxBitrate},
+		{240, 180, 30, minBitrate},
+	}
+
+	for _, bt := range bitrateTests {
+		t.Run("", func(t *testing.T) {
+			bitrate := calcBitrateFromResolution(bt.width, bt.height, bt.framerate)
+			test.That(t, bitrate, test.ShouldEqual, bt.expected)
+		})
+	}
+}

--- a/gostream/codec/x264/utils.go
+++ b/gostream/codec/x264/utils.go
@@ -6,6 +6,16 @@ import (
 	"go.viam.com/rdk/logging"
 )
 
+const (
+	encodeCompressionRatio = 0.15 // bits per pixel when encoded
+	// For very small resolutions, we need to ensure that the vbv buffer size is large enough to
+	// handle frame bursts. This is the minimum bitrate that we can use.
+	minBitrate = 300_000 // 300kbps
+	// Setting a reasonable max bitrate to prevent the encoder from using too much bandwidth.
+	// 4K resolution at 20fps is around 24.8Mbps
+	maxBitrate = 25_000_000 // 25Mbps
+)
+
 // DefaultStreamConfig configures x264 as the encoder for a stream.
 var DefaultStreamConfig gostream.StreamConfig
 
@@ -26,4 +36,15 @@ func (f *factory) New(width, height, keyFrameInterval int, logger logging.Logger
 
 func (f *factory) MIMEType() string {
 	return "video/H264"
+}
+
+func calcBitrateFromResolution(width, height int, framerate float32) int {
+	bitrate := int(float32(width) * float32(height) * framerate * encodeCompressionRatio)
+	if bitrate < minBitrate {
+		return minBitrate
+	}
+	if bitrate > maxBitrate {
+		return maxBitrate
+	}
+	return bitrate
 }

--- a/gostream/codec/x264/utils.go
+++ b/gostream/codec/x264/utils.go
@@ -42,6 +42,7 @@ func (f *factory) MIMEType() string {
 // calcBitrateFromResolution calculates the bitrate based on the given resolution and framerate.
 func calcBitrateFromResolution(width, height int, framerate float32) int {
 	bitrate := int(float32(width) * float32(height) * framerate * encodeCompressionRatio)
+	// This accounts for zero bitrates too.
 	if bitrate < minBitrate {
 		return minBitrate
 	}

--- a/gostream/codec/x264/utils.go
+++ b/gostream/codec/x264/utils.go
@@ -9,10 +9,11 @@ import (
 const (
 	encodeCompressionRatio = 0.15 // bits per pixel when encoded
 	// For very small resolutions, we need to ensure that the vbv buffer size is large enough to
-	// handle frame bursts. This is the minimum bitrate that we can use.
+	// handle frame bursts. This is the minimum bitrate that we can use without causing the encoder
+	// to spew out warnings about the buffer size being too small.
 	minBitrate = 300_000 // 300kbps
 	// Setting a reasonable max bitrate to prevent the encoder from using too much bandwidth.
-	// 4K resolution at 20fps is around 24.8Mbps
+	// 4K resolution at 20fps is around 24.8Mbps.
 	maxBitrate = 25_000_000 // 25Mbps
 )
 

--- a/gostream/codec/x264/utils.go
+++ b/gostream/codec/x264/utils.go
@@ -1,6 +1,8 @@
 package x264
 
 import (
+	"math"
+
 	"go.viam.com/rdk/gostream"
 	"go.viam.com/rdk/gostream/codec"
 	"go.viam.com/rdk/logging"
@@ -41,7 +43,9 @@ func (f *factory) MIMEType() string {
 
 // calcBitrateFromResolution calculates the bitrate based on the given resolution and framerate.
 func calcBitrateFromResolution(width, height int, framerate float32) int {
-	bitrate := int(float32(width) * float32(height) * framerate * encodeCompressionRatio)
+	bitrate := float32(width) * float32(height) * framerate * encodeCompressionRatio
+	// Round up to the nearest integer value.
+	bitrate = float32(math.Ceil(float64(bitrate)))
 	// This accounts for zero bitrates too.
 	if bitrate < minBitrate {
 		return minBitrate
@@ -49,5 +53,5 @@ func calcBitrateFromResolution(width, height int, framerate float32) int {
 	if bitrate > maxBitrate {
 		return maxBitrate
 	}
-	return bitrate
+	return int(bitrate)
 }

--- a/gostream/codec/x264/utils.go
+++ b/gostream/codec/x264/utils.go
@@ -39,6 +39,7 @@ func (f *factory) MIMEType() string {
 	return "video/H264"
 }
 
+// calcBitrateFromResolution calculates the bitrate based on the given resolution and framerate.
 func calcBitrateFromResolution(width, height int, framerate float32) int {
 	bitrate := int(float32(width) * float32(height) * framerate * encodeCompressionRatio)
 	if bitrate < minBitrate {

--- a/robot/web/stream/server.go
+++ b/robot/web/stream/server.go
@@ -507,11 +507,17 @@ func (server *Server) AddNewStreams(ctx context.Context) error {
 			server.logger.Warn("video streaming not supported on Windows yet")
 			break
 		}
+		framerate, err := server.getFramerateFromCamera(name)
+		if err != nil {
+			server.logger.Debugf("error getting framerate from camera %q: %v", name, err)
+		}
+		// encoderFactory := server.streamConfig.VideoEncoderFactory
 		// We walk the updated set of `videoSources` and ensure all of the sources are "created" and
 		// "started".
 		config := gostream.StreamConfig{
 			Name:                name,
 			VideoEncoderFactory: server.streamConfig.VideoEncoderFactory,
+			TargetFrameRate:     framerate,
 		}
 		// Call `createStream`. `createStream` is responsible for first checking if the stream
 		// already exists. If it does, it skips creating a new stream and we continue to the next source.
@@ -756,6 +762,18 @@ func (server *Server) startAudioStream(ctx context.Context, source gostream.Audi
 		streamAudioCtx, _ := utils.MergeContext(server.closedCtx, ctx)
 		return streamAudioSource(streamAudioCtx, source, stream, opts, server.logger)
 	})
+}
+
+func (server *Server) getFramerateFromCamera(name string) (int, error) {
+	cam, err := camera.FromRobot(server.robot, name)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get camera from robot: %w", err)
+	}
+	props, err := cam.Properties(context.Background())
+	if err != nil {
+		return 0, fmt.Errorf("failed to get camera properties: %w", err)
+	}
+	return int(props.FrameRate), nil
 }
 
 // GenerateResolutions takes the original width and height of an image and returns

--- a/robot/web/stream/server.go
+++ b/robot/web/stream/server.go
@@ -507,6 +507,8 @@ func (server *Server) AddNewStreams(ctx context.Context) error {
 			server.logger.Warn("video streaming not supported on Windows yet")
 			break
 		}
+		// Attempt to look up the framerate for the camera. If the framerate is not available, we'll
+		// end up with a framerate of 0. This is fine as gostream will default to 30fps in this case.
 		framerate, err := server.getFramerateFromCamera(name)
 		if err != nil {
 			server.logger.Debugf("error getting framerate from camera %q: %v", name, err)

--- a/robot/web/stream/server.go
+++ b/robot/web/stream/server.go
@@ -511,7 +511,6 @@ func (server *Server) AddNewStreams(ctx context.Context) error {
 		if err != nil {
 			server.logger.Debugf("error getting framerate from camera %q: %v", name, err)
 		}
-		// encoderFactory := server.streamConfig.VideoEncoderFactory
 		// We walk the updated set of `videoSources` and ensure all of the sources are "created" and
 		// "started".
 		config := gostream.StreamConfig{


### PR DESCRIPTION
## Description

This PR gives a more accurate bitrate estimation to our libx264 pipeline based on resolution and framerate. The idea here is that smaller streams will use less bandwidth and we will get better quality out of larger streams.
- Removes hardcoded 3.2 Mbps bitrate.
- Adds look up for framerate from Properties and if it is not found default to 30. 
- Calculates bitrate using a reasonable 0.15 bits per pixel ratio.
- Adds minimum bitrate to avoid buffering issues with small frame sizes.
- Adds a maximum bitrate that is safely over 20fps 4k stream size.


Examples bitrates:
```
640p at 30 fps: 640*480*30*0.15 - > 1.382400 Mbps
1080p at 30fps : 1920*1080*30*0.15 -> 9.331200 Mbps
4k at 20fps: 3840*2160*20*0.15 -> 24.883200 Mbps
```

## Tests
- add unit test for bitrate calculation ✅ 

- webcam
  - picks up framerate from properties ✅ 
  - suitable quality across multiple resolutions ✅ 

https://github.com/user-attachments/assets/b3f837e2-9625-4632-a606-ff351731b7ce


- viamrtsp
  - suitable quality at 2k and 4k resolutions ✅ 
![rtsp-cam-1-2025-02-25_14_53_53](https://github.com/user-attachments/assets/886cd8c2-dce4-49b2-bbcd-a95ee606d0bf)


 - dyanmic resolution
   - suitable quality at extremely small frame sizes ✅ 

