### PR TITLE
RSDK-9744: support module generation in python 3.9

### DIFF
--- a/cli/module_generate/scripts/generate_stubs.py
+++ b/cli/module_generate/scripts/generate_stubs.py
@@ -15,10 +15,10 @@ def return_attribute(value: str, attr: str) -> ast.Attribute:
 
 def update_annotation(
     resource_name: str,
-    annotation: ast.Name | ast.Subscript,
+    annotation: Union[ast.Name, ast.Subscript],
     nodes: Set[str],
     parent: str
-) -> ast.Attribute | ast.Subscript:
+) -> Union[ast.Attribute, ast.Subscript]:
     if isinstance(annotation, ast.Name) and annotation.id in nodes:
         value = parent if parent else resource_name
         return return_attribute(value, annotation.id)


### PR DESCRIPTION
The `|` character was only introduced in Python 3.10. Using `Union` instead so that 3.9 can be supported