### PR TITLE
RSDK-9910: require namespace for module generation

### DIFF
--- a/cli/module_generate.go
+++ b/cli/module_generate.go
@@ -326,7 +326,7 @@ func wrapResolveOrg(cCtx *cli.Context, c *viamClient, newModule *modulegen.Modul
 		newModule.OrgID = newModule.Namespace
 		newModule.Namespace = org.GetPublicNamespace()
 		if newModule.Namespace == "" {
-			return errors.New("cannot create module in an organization with no public namespace. Set a namespace for your organization.")
+			return errors.New("cannot create module in an organization with no public namespace. Set a namespace for your organization")
 		}
 	}
 	return nil

--- a/cli/module_generate.go
+++ b/cli/module_generate.go
@@ -97,12 +97,12 @@ func (c *viamClient) generateModuleAction(cCtx *cli.Context, args generateModule
 			return err
 		}
 	}
-	populateAdditionalInfo(newModule)
 	if !args.DryRun {
 		if err := wrapResolveOrg(cCtx, c, newModule); err != nil {
 			return err
 		}
 	}
+	populateAdditionalInfo(newModule)
 
 	s := spinner.New()
 	var fatalError error

--- a/cli/module_generate.go
+++ b/cli/module_generate.go
@@ -325,6 +325,9 @@ func wrapResolveOrg(cCtx *cli.Context, c *viamClient, newModule *modulegen.Modul
 		}
 		newModule.OrgID = newModule.Namespace
 		newModule.Namespace = org.GetPublicNamespace()
+		if newModule.Namespace == "" {
+			return errors.New("cannot create module in an organization with no public namespace. Set a namespace for your organization.")
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
We weren't requiring namespaces when calling `module generate` with an Org ID, which allowed models to be: `:module:component`. In the `meta.json`, the model triplet would show up to be `xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxx:module:component`.

Changes:
- Fix the order so that the generated `meta.json` has the updated information.
- Require a namespace for the organization