### PR TITLE
rsdk-9781 - add `viam machines part list` command

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -2075,8 +2075,9 @@ Organization and location are required flags if the machine/part name are not un
 
 								&AliasStringFlag{
 									cli.StringFlag{
-										Name:    generalFlagMachine,
-										Aliases: []string{generalFlagAliasRobot, generalFlagMachineID, generalFlagMachineName},
+										Name:     generalFlagMachine,
+										Aliases:  []string{generalFlagAliasRobot, generalFlagMachineID, generalFlagMachineName},
+										Required: true,
 									},
 								},
 								&cli.StringFlag{

--- a/cli/app.go
+++ b/cli/app.go
@@ -2068,6 +2068,29 @@ Organization and location are required flags if the machine/part name are not un
 							Action: createCommandWithT[robotsPartShellArgs](RobotsPartShellAction),
 						},
 						{
+							Name:      "list",
+							Usage:     "list parts on a machine",
+							UsageText: createUsageText("machines part list", []string{generalFlagMachine}, true, false),
+							Flags: []cli.Flag{
+
+								&AliasStringFlag{
+									cli.StringFlag{
+										Name:    generalFlagMachine,
+										Aliases: []string{generalFlagAliasRobot, generalFlagMachineID, generalFlagMachineName},
+									},
+								},
+								&cli.StringFlag{
+									Name:    generalFlagOrganization,
+									Aliases: []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
+								},
+								&cli.StringFlag{
+									Name:    generalFlagLocation,
+									Aliases: []string{generalFlagLocationID, generalFlagAliasLocationName},
+								},
+							},
+							Action: createCommandWithT[machinesPartListArgs](MachinesPartListAction),
+						},
+						{
 							Name:  "cp",
 							Usage: "copy files to and from a machine part",
 							Description: `

--- a/cli/client.go
+++ b/cli/client.go
@@ -1049,7 +1049,7 @@ func RobotsPartStatusAction(c *cli.Context, args robotsPartStatusArgs) error {
 		printf(c.App.Writer, "%s -> %s -> %s", orgName, locName, robot.Name)
 	}
 
-	printMachinePartStatus(c, []*apppb.RobotPart{&part})
+	printMachinePartStatus(c, []*apppb.RobotPart{part})
 
 	return nil
 }

--- a/cli/client.go
+++ b/cli/client.go
@@ -643,6 +643,47 @@ func ListLocationsAction(c *cli.Context, args listLocationsArgs) error {
 	return listLocations(orgStr)
 }
 
+type machinesPartListArgs struct {
+	Organization string
+	Location     string
+	Machine      string
+}
+
+func MachinesPartListAction(c *cli.Context, args machinesPartListArgs) error {
+	client, err := newViamClient(c)
+	if err != nil {
+		return err
+	}
+
+	if err = client.ensureLoggedIn(); err != nil {
+		return err
+	}
+
+	parts, err := client.robotParts(args.Organization, args.Location, args.Machine)
+	if err != nil {
+		return err
+	}
+
+	for _, part := range parts {
+
+		name := part.Name
+		if part.MainPart {
+			name += " (main)"
+		}
+		printf(
+			c.App.Writer,
+			"ID: %s\nName: %s\nLast Access: %s (%s ago)",
+			part.Id,
+			name,
+			part.LastAccess.AsTime().Format(time.UnixDate),
+			time.Since(part.LastAccess.AsTime()),
+		)
+		printf(c.App.Writer, "%s", part.String())
+	}
+
+	return nil
+}
+
 type listRobotsActionArgs struct {
 	Organization string
 	Location     string


### PR DESCRIPTION
Factors out printing of part data and creates a new command focused on providing part data for discoverability purposes.

cc @penguinland 