### PR TITLE
[RSDK-8291] Use Global Connection to App in Config Watcher

### DIFF
--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/robot/client"
@@ -644,7 +645,7 @@ func resolvePartID(ctx context.Context, partIDFromFlag, cloudJSON string) (strin
 	if len(cloudJSON) == 0 {
 		return "", errors.New("no --part and no default json")
 	}
-	conf, err := config.ReadLocalConfig(ctx, cloudJSON, logging.NewLogger("config"))
+	conf, err := config.ReadLocalConfig(ctx, cloudJSON, logging.NewLogger("config"), &grpc.AppConn{})
 	if err != nil {
 		return "", err
 	}

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -28,7 +28,6 @@ import (
 	"google.golang.org/grpc/status"
 
 	"go.viam.com/rdk/config"
-	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/robot/client"

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -645,7 +645,7 @@ func resolvePartID(ctx context.Context, partIDFromFlag, cloudJSON string) (strin
 	if len(cloudJSON) == 0 {
 		return "", errors.New("no --part and no default json")
 	}
-	conf, err := config.ReadLocalConfig(ctx, cloudJSON, logging.NewLogger("config"), &grpc.AppConn{})
+	conf, err := config.ReadLocalConfig(ctx, cloudJSON, logging.NewLogger("config"))
 	if err != nil {
 		return "", err
 	}

--- a/components/camera/transformpipeline/detector_test.go
+++ b/components/camera/transformpipeline/detector_test.go
@@ -11,7 +11,6 @@ import (
 
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/config"
-	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/rimage"
@@ -46,8 +45,7 @@ func writeTempConfig(cfg *config.Config) (string, error) {
 // make a fake robot with a vision service.
 func buildRobotWithFakeCamera(logger logging.Logger) (robot.Robot, error) {
 	// add a fake camera to the config
-	cfg, err := config.Read(context.Background(), artifact.MustPath("components/camera/transformpipeline/vision.json"), logger,
-		&grpc.AppConn{})
+	cfg, err := config.Read(context.Background(), artifact.MustPath("components/camera/transformpipeline/vision.json"), logger, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/components/camera/transformpipeline/detector_test.go
+++ b/components/camera/transformpipeline/detector_test.go
@@ -11,6 +11,7 @@ import (
 
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/rimage"
@@ -45,7 +46,8 @@ func writeTempConfig(cfg *config.Config) (string, error) {
 // make a fake robot with a vision service.
 func buildRobotWithFakeCamera(logger logging.Logger) (robot.Robot, error) {
 	// add a fake camera to the config
-	cfg, err := config.Read(context.Background(), artifact.MustPath("components/camera/transformpipeline/vision.json"), logger)
+	cfg, err := config.Read(context.Background(), artifact.MustPath("components/camera/transformpipeline/vision.json"), logger,
+		&grpc.AppConn{})
 	if err != nil {
 		return nil, err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -280,7 +280,7 @@ func (c *Config) StoreToCache() error {
 	if c.toCache == nil {
 		return errors.New("no unprocessed config to cache")
 	}
-	if err := os.MkdirAll(ViamDotDir, 0o700); err != nil {
+	if err := os.MkdirAll(rutils.ViamDotDir, 0o700); err != nil {
 		return err
 	}
 	reader := bytes.NewReader(c.toCache)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -30,6 +30,7 @@ import (
 	"go.viam.com/rdk/components/encoder/incremental"
 	fakemotor "go.viam.com/rdk/components/motor/fake"
 	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/resource"
@@ -40,7 +41,7 @@ import (
 
 func TestConfigRobot(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(context.Background(), "data/robot.json", logger)
+	cfg, err := config.Read(context.Background(), "data/robot.json", logger, &grpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 
 	test.That(t, cfg.Components, test.ShouldHaveLength, 3)
@@ -76,7 +77,7 @@ func TestConfig3(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 
 	test.That(t, os.Setenv("TEST_THING_FOO", "5"), test.ShouldBeNil)
-	cfg, err := config.Read(context.Background(), "data/config3.json", logger)
+	cfg, err := config.Read(context.Background(), "data/config3.json", logger, &grpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 
 	test.That(t, len(cfg.Components), test.ShouldEqual, 4)
@@ -152,7 +153,7 @@ func TestConfig3(t *testing.T) {
 
 func TestConfigWithLogDeclarations(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(context.Background(), "data/config_with_log.json", logger)
+	cfg, err := config.Read(context.Background(), "data/config_with_log.json", logger, &grpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 
 	test.That(t, len(cfg.Components), test.ShouldEqual, 4)
@@ -1207,7 +1208,7 @@ func TestPackageConfig(t *testing.T) {
 
 func TestConfigRobotWebProfile(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(context.Background(), "data/config_with_web_profile.json", logger)
+	cfg, err := config.Read(context.Background(), "data/config_with_web_profile.json", logger, &grpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 
 	test.That(t, cfg.EnableWebProfile, test.ShouldBeTrue)
@@ -1215,7 +1216,7 @@ func TestConfigRobotWebProfile(t *testing.T) {
 
 func TestConfigRobotRevision(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(context.Background(), "data/config_with_revision.json", logger)
+	cfg, err := config.Read(context.Background(), "data/config_with_revision.json", logger, &grpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 
 	test.That(t, cfg.Revision, test.ShouldEqual, "rev1")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -30,7 +30,6 @@ import (
 	"go.viam.com/rdk/components/encoder/incremental"
 	fakemotor "go.viam.com/rdk/components/motor/fake"
 	"go.viam.com/rdk/config"
-	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/resource"
@@ -41,7 +40,7 @@ import (
 
 func TestConfigRobot(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(context.Background(), "data/robot.json", logger, &grpc.AppConn{})
+	cfg, err := config.Read(context.Background(), "data/robot.json", logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 
 	test.That(t, cfg.Components, test.ShouldHaveLength, 3)
@@ -77,7 +76,7 @@ func TestConfig3(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 
 	test.That(t, os.Setenv("TEST_THING_FOO", "5"), test.ShouldBeNil)
-	cfg, err := config.Read(context.Background(), "data/config3.json", logger, &grpc.AppConn{})
+	cfg, err := config.Read(context.Background(), "data/config3.json", logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 
 	test.That(t, len(cfg.Components), test.ShouldEqual, 4)
@@ -153,7 +152,7 @@ func TestConfig3(t *testing.T) {
 
 func TestConfigWithLogDeclarations(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(context.Background(), "data/config_with_log.json", logger, &grpc.AppConn{})
+	cfg, err := config.Read(context.Background(), "data/config_with_log.json", logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 
 	test.That(t, len(cfg.Components), test.ShouldEqual, 4)
@@ -1208,7 +1207,7 @@ func TestPackageConfig(t *testing.T) {
 
 func TestConfigRobotWebProfile(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(context.Background(), "data/config_with_web_profile.json", logger, &grpc.AppConn{})
+	cfg, err := config.Read(context.Background(), "data/config_with_web_profile.json", logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 
 	test.That(t, cfg.EnableWebProfile, test.ShouldBeTrue)
@@ -1216,7 +1215,7 @@ func TestConfigRobotWebProfile(t *testing.T) {
 
 func TestConfigRobotRevision(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(context.Background(), "data/config_with_revision.json", logger, &grpc.AppConn{})
+	cfg, err := config.Read(context.Background(), "data/config_with_revision.json", logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 
 	test.That(t, cfg.Revision, test.ShouldEqual, "rev1")

--- a/config/diff_test.go
+++ b/config/diff_test.go
@@ -14,6 +14,7 @@ import (
 	"go.viam.com/rdk/components/board"
 	fakeboard "go.viam.com/rdk/components/board/fake"
 	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/utils"
@@ -400,9 +401,9 @@ func TestDiffConfigs(t *testing.T) {
 				t.Run(fmt.Sprintf("revealSensitiveConfigDiffs=%t", revealSensitiveConfigDiffs), func(t *testing.T) {
 					logger.Infof("Test name: %v LeftFile: `%v` RightFile: `%v`", tc.Name, tc.LeftFile, tc.RightFile)
 					logger := logging.NewTestLogger(t)
-					left, err := config.Read(context.Background(), tc.LeftFile, logger)
+					left, err := config.Read(context.Background(), tc.LeftFile, logger, &grpc.AppConn{})
 					test.That(t, err, test.ShouldBeNil)
-					right, err := config.Read(context.Background(), tc.RightFile, logger)
+					right, err := config.Read(context.Background(), tc.RightFile, logger, &grpc.AppConn{})
 					test.That(t, err, test.ShouldBeNil)
 
 					diff, err := config.DiffConfigs(*left, *right, revealSensitiveConfigDiffs)
@@ -445,9 +446,9 @@ func TestDiffConfigHeterogenousTypes(t *testing.T) {
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			logger := logging.NewTestLogger(t)
-			left, err := config.Read(context.Background(), tc.LeftFile, logger)
+			left, err := config.Read(context.Background(), tc.LeftFile, logger, &grpc.AppConn{})
 			test.That(t, err, test.ShouldBeNil)
-			right, err := config.Read(context.Background(), tc.RightFile, logger)
+			right, err := config.Read(context.Background(), tc.RightFile, logger, &grpc.AppConn{})
 			test.That(t, err, test.ShouldBeNil)
 
 			_, err = config.DiffConfigs(*left, *right, true)

--- a/config/diff_test.go
+++ b/config/diff_test.go
@@ -14,7 +14,6 @@ import (
 	"go.viam.com/rdk/components/board"
 	fakeboard "go.viam.com/rdk/components/board/fake"
 	"go.viam.com/rdk/config"
-	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/utils"
@@ -401,9 +400,9 @@ func TestDiffConfigs(t *testing.T) {
 				t.Run(fmt.Sprintf("revealSensitiveConfigDiffs=%t", revealSensitiveConfigDiffs), func(t *testing.T) {
 					logger.Infof("Test name: %v LeftFile: `%v` RightFile: `%v`", tc.Name, tc.LeftFile, tc.RightFile)
 					logger := logging.NewTestLogger(t)
-					left, err := config.Read(context.Background(), tc.LeftFile, logger, &grpc.AppConn{})
+					left, err := config.Read(context.Background(), tc.LeftFile, logger, nil)
 					test.That(t, err, test.ShouldBeNil)
-					right, err := config.Read(context.Background(), tc.RightFile, logger, &grpc.AppConn{})
+					right, err := config.Read(context.Background(), tc.RightFile, logger, nil)
 					test.That(t, err, test.ShouldBeNil)
 
 					diff, err := config.DiffConfigs(*left, *right, revealSensitiveConfigDiffs)
@@ -446,9 +445,9 @@ func TestDiffConfigHeterogenousTypes(t *testing.T) {
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			logger := logging.NewTestLogger(t)
-			left, err := config.Read(context.Background(), tc.LeftFile, logger, &grpc.AppConn{})
+			left, err := config.Read(context.Background(), tc.LeftFile, logger, nil)
 			test.That(t, err, test.ShouldBeNil)
-			right, err := config.Read(context.Background(), tc.RightFile, logger, &grpc.AppConn{})
+			right, err := config.Read(context.Background(), tc.RightFile, logger, nil)
 			test.That(t, err, test.ShouldBeNil)
 
 			_, err = config.DiffConfigs(*left, *right, true)

--- a/config/reader.go
+++ b/config/reader.go
@@ -628,7 +628,13 @@ func processConfig(unprocessedConfig *Config, fromCloud bool, logger logging.Log
 
 // getFromCloudOrCache returns the config from the gRPC endpoint. If failures during cloud lookup fallback to the
 // local cache if the error indicates it should.
-func getFromCloudOrCache(ctx context.Context, cloudCfg *Cloud, shouldReadFromCache bool, logger logging.Logger, conn rpc.ClientConn) (*Config, bool, error) {
+func getFromCloudOrCache(
+	ctx context.Context,
+	cloudCfg *Cloud,
+	shouldReadFromCache bool,
+	logger logging.Logger,
+	conn rpc.ClientConn,
+) (*Config, bool, error) {
 	var cached bool
 
 	ctxWithTimeout, cancel := contextutils.GetTimeoutCtx(ctx, shouldReadFromCache, cloudCfg.ID)

--- a/config/reader.go
+++ b/config/reader.go
@@ -121,7 +121,6 @@ func clearCache(id string) {
 
 func readCertificateDataFromCloudGRPC(ctx context.Context,
 	cloudConfigFromDisk *Cloud,
-	logger logging.Logger,
 	conn rpc.ClientConn,
 ) (tlsConfig, error) {
 	service := apppb.NewRobotServiceClient(conn)
@@ -232,7 +231,7 @@ func readFromCloud(
 		logger.Debug("reading tlsCertificate from the cloud")
 
 		ctxWithTimeout, cancel := contextutils.GetTimeoutCtx(ctx, shouldReadFromCache, cloudCfg.ID)
-		certData, err := readCertificateDataFromCloudGRPC(ctxWithTimeout, cloudCfg, logger, conn)
+		certData, err := readCertificateDataFromCloudGRPC(ctxWithTimeout, cloudCfg, conn)
 		if err != nil {
 			cancel()
 			if !errors.As(err, &context.DeadlineExceeded) {

--- a/config/reader.go
+++ b/config/reader.go
@@ -351,13 +351,14 @@ func Read(
 	ctx context.Context,
 	filePath string,
 	logger logging.Logger,
+	conn rpc.ClientConn,
 ) (*Config, error) {
 	buf, err := envsubst.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}
 
-	return FromReader(ctx, filePath, bytes.NewReader(buf), logger)
+	return FromReader(ctx, filePath, bytes.NewReader(buf), logger, conn)
 }
 
 // ReadLocalConfig reads a config from the given file but does not fetch any config from the remote servers.
@@ -365,13 +366,14 @@ func ReadLocalConfig(
 	ctx context.Context,
 	filePath string,
 	logger logging.Logger,
+	conn rpc.ClientConn,
 ) (*Config, error) {
 	buf, err := envsubst.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}
 
-	return fromReader(ctx, filePath, bytes.NewReader(buf), logger, false)
+	return fromReader(ctx, filePath, bytes.NewReader(buf), logger, false, conn)
 }
 
 // FromReader reads a config from the given reader and specifies
@@ -381,8 +383,9 @@ func FromReader(
 	originalPath string,
 	r io.Reader,
 	logger logging.Logger,
+	conn rpc.ClientConn,
 ) (*Config, error) {
-	return fromReader(ctx, originalPath, r, logger, true)
+	return fromReader(ctx, originalPath, r, logger, true, conn)
 }
 
 // fromReader reads a config from the given reader and specifies
@@ -393,6 +396,7 @@ func fromReader(
 	r io.Reader,
 	logger logging.Logger,
 	shouldReadFromCloud bool,
+	conn rpc.ClientConn,
 ) (*Config, error) {
 	// First read and process config from disk
 	unprocessedConfig := Config{
@@ -408,7 +412,7 @@ func fromReader(
 	}
 
 	if shouldReadFromCloud && cfgFromDisk.Cloud != nil {
-		cfg, err := readFromCloud(ctx, cfgFromDisk, nil, true, true, logger)
+		cfg, err := readFromCloud(ctx, cfgFromDisk, nil, true, true, logger, conn)
 		return cfg, err
 	}
 

--- a/config/reader.go
+++ b/config/reader.go
@@ -341,8 +341,7 @@ func ReadLocalConfig(
 		return nil, err
 	}
 
-	var nilConn rpc.ClientConn
-	return fromReader(ctx, filePath, bytes.NewReader(buf), logger, nilConn)
+	return fromReader(ctx, filePath, bytes.NewReader(buf), logger, nil)
 }
 
 // FromReader reads a config from the given reader and specifies

--- a/config/reader.go
+++ b/config/reader.go
@@ -348,7 +348,7 @@ func ReadLocalConfig(
 	}
 
 	var nilConn rpc.ClientConn
-	return fromReader(ctx, filePath, bytes.NewReader(buf), logger, false, nilConn)
+	return fromReader(ctx, filePath, bytes.NewReader(buf), logger, nilConn)
 }
 
 // FromReader reads a config from the given reader and specifies
@@ -360,7 +360,7 @@ func FromReader(
 	logger logging.Logger,
 	conn rpc.ClientConn,
 ) (*Config, error) {
-	return fromReader(ctx, originalPath, r, logger, true, conn)
+	return fromReader(ctx, originalPath, r, logger, conn)
 }
 
 // fromReader reads a config from the given reader and specifies
@@ -370,7 +370,6 @@ func fromReader(
 	originalPath string,
 	r io.Reader,
 	logger logging.Logger,
-	shouldReadFromCloud bool,
 	conn rpc.ClientConn,
 ) (*Config, error) {
 	// First read and process config from disk
@@ -386,7 +385,7 @@ func fromReader(
 		return nil, errors.Wrapf(err, "failed to process Config")
 	}
 
-	if shouldReadFromCloud && cfgFromDisk.Cloud != nil {
+	if conn != nil && cfgFromDisk.Cloud != nil {
 		cfg, err := readFromCloud(ctx, cfgFromDisk, nil, true, true, logger, conn)
 		return cfg, err
 	}

--- a/config/reader.go
+++ b/config/reader.go
@@ -78,20 +78,14 @@ func getAgentInfo(logger logging.Logger) (*apppb.AgentInfo, error) {
 	}, nil
 }
 
-var (
-	// ViamDotDir is the directory for Viam's cached files.
-	ViamDotDir      string
-	viamPackagesDir string
-)
+var viamPackagesDir string
 
 func init() {
-	home := rutils.PlatformHomeDir()
-	ViamDotDir = filepath.Join(home, ".viam")
-	viamPackagesDir = filepath.Join(ViamDotDir, PackagesDirName)
+	viamPackagesDir = filepath.Join(rutils.ViamDotDir, PackagesDirName)
 }
 
 func getCloudCacheFilePath(id string) string {
-	return filepath.Join(ViamDotDir, fmt.Sprintf("cached_cloud_config_%s.json", id))
+	return filepath.Join(rutils.ViamDotDir, fmt.Sprintf("cached_cloud_config_%s.json", id))
 }
 
 func readFromCache(id string) (*Config, error) {

--- a/config/reader.go
+++ b/config/reader.go
@@ -341,14 +341,14 @@ func ReadLocalConfig(
 	ctx context.Context,
 	filePath string,
 	logger logging.Logger,
-	conn rpc.ClientConn,
 ) (*Config, error) {
 	buf, err := envsubst.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}
 
-	return fromReader(ctx, filePath, bytes.NewReader(buf), logger, false, conn)
+	var nilConn rpc.ClientConn
+	return fromReader(ctx, filePath, bytes.NewReader(buf), logger, false, nilConn)
 }
 
 // FromReader reads a config from the given reader and specifies

--- a/config/reader_ext_test.go
+++ b/config/reader_ext_test.go
@@ -10,21 +10,22 @@ import (
 
 	"go.viam.com/rdk/components/arm"
 	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 )
 
 func TestFromReaderValidate(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	_, err := config.FromReader(context.Background(), "somepath", strings.NewReader(""), logger)
+	_, err := config.FromReader(context.Background(), "somepath", strings.NewReader(""), logger, &grpc.AppConn{})
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "json: EOF")
 
-	_, err = config.FromReader(context.Background(), "somepath", strings.NewReader(`{"cloud": 1}`), logger)
+	_, err = config.FromReader(context.Background(), "somepath", strings.NewReader(`{"cloud": 1}`), logger, &grpc.AppConn{})
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "unmarshal")
 
-	conf, err := config.FromReader(context.Background(), "somepath", strings.NewReader(`{}`), logger)
+	conf, err := config.FromReader(context.Background(), "somepath", strings.NewReader(`{}`), logger, &grpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, conf, test.ShouldResemble, &config.Config{
 		ConfigFilePath: "somepath",
@@ -39,12 +40,12 @@ func TestFromReaderValidate(t *testing.T) {
 		},
 	})
 
-	_, err = config.FromReader(context.Background(), "somepath", strings.NewReader(`{"cloud": {}}`), logger)
+	_, err = config.FromReader(context.Background(), "somepath", strings.NewReader(`{"cloud": {}}`), logger, &grpc.AppConn{})
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, resource.GetFieldFromFieldRequiredError(err), test.ShouldEqual, "id")
 
 	_, err = config.FromReader(context.Background(),
-		"somepath", strings.NewReader(`{"disable_partial_start":true,"components": [{}]}`), logger)
+		"somepath", strings.NewReader(`{"disable_partial_start":true,"components": [{}]}`), logger, &grpc.AppConn{})
 	test.That(t, err, test.ShouldNotBeNil)
 	var fre resource.FieldRequiredError
 	test.That(t, errors.As(err, &fre), test.ShouldBeTrue)
@@ -54,7 +55,7 @@ func TestFromReaderValidate(t *testing.T) {
 	conf, err = config.FromReader(context.Background(),
 		"somepath",
 		strings.NewReader(`{"components": [{"name": "foo", "type": "arm", "model": "foo"}]}`),
-		logger)
+		logger, &grpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 	expected := &config.Config{
 		ConfigFilePath: "somepath",

--- a/config/reader_ext_test.go
+++ b/config/reader_ext_test.go
@@ -10,22 +10,21 @@ import (
 
 	"go.viam.com/rdk/components/arm"
 	"go.viam.com/rdk/config"
-	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 )
 
 func TestFromReaderValidate(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	_, err := config.FromReader(context.Background(), "somepath", strings.NewReader(""), logger, &grpc.AppConn{})
+	_, err := config.FromReader(context.Background(), "somepath", strings.NewReader(""), logger, nil)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "json: EOF")
 
-	_, err = config.FromReader(context.Background(), "somepath", strings.NewReader(`{"cloud": 1}`), logger, &grpc.AppConn{})
+	_, err = config.FromReader(context.Background(), "somepath", strings.NewReader(`{"cloud": 1}`), logger, nil)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "unmarshal")
 
-	conf, err := config.FromReader(context.Background(), "somepath", strings.NewReader(`{}`), logger, &grpc.AppConn{})
+	conf, err := config.FromReader(context.Background(), "somepath", strings.NewReader(`{}`), logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, conf, test.ShouldResemble, &config.Config{
 		ConfigFilePath: "somepath",
@@ -40,12 +39,12 @@ func TestFromReaderValidate(t *testing.T) {
 		},
 	})
 
-	_, err = config.FromReader(context.Background(), "somepath", strings.NewReader(`{"cloud": {}}`), logger, &grpc.AppConn{})
+	_, err = config.FromReader(context.Background(), "somepath", strings.NewReader(`{"cloud": {}}`), logger, nil)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, resource.GetFieldFromFieldRequiredError(err), test.ShouldEqual, "id")
 
 	_, err = config.FromReader(context.Background(),
-		"somepath", strings.NewReader(`{"disable_partial_start":true,"components": [{}]}`), logger, &grpc.AppConn{})
+		"somepath", strings.NewReader(`{"disable_partial_start":true,"components": [{}]}`), logger, nil)
 	test.That(t, err, test.ShouldNotBeNil)
 	var fre resource.FieldRequiredError
 	test.That(t, errors.As(err, &fre), test.ShouldBeTrue)
@@ -55,7 +54,7 @@ func TestFromReaderValidate(t *testing.T) {
 	conf, err = config.FromReader(context.Background(),
 		"somepath",
 		strings.NewReader(`{"components": [{"name": "foo", "type": "arm", "model": "foo"}]}`),
-		logger, &grpc.AppConn{})
+		logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 	expected := &config.Config{
 		ConfigFilePath: "somepath",

--- a/config/reader_test.go
+++ b/config/reader_test.go
@@ -319,7 +319,7 @@ func TestProcessConfig(t *testing.T) {
 func TestReadTLSFromCache(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	ctx := context.Background()
-	cfg, err := FromReader(ctx, "", strings.NewReader(`{}`), logger, &grpc.AppConn{})
+	cfg, err := FromReader(ctx, "", strings.NewReader(`{}`), logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 
 	robotPartID := "forCachingTest"

--- a/config/reader_test.go
+++ b/config/reader_test.go
@@ -16,6 +16,7 @@ import (
 	"go.viam.com/utils/rpc"
 
 	"go.viam.com/rdk/config/testutils"
+	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/utils"
 )
@@ -67,8 +68,10 @@ func TestFromReader(t *testing.T) {
 		fakeServer.StoreDeviceConfig(robotPartID, protoConfig, certProto)
 
 		appAddress := fmt.Sprintf("http://%s", fakeServer.Addr().String())
+		appConn, err := grpc.NewAppConn(ctx, appAddress, secret, robotPartID, logger)
+		test.That(t, err, test.ShouldBeNil)
 		cfgText := fmt.Sprintf(`{"cloud":{"id":%q,"app_address":%q,"secret":%q}}`, robotPartID, appAddress, secret)
-		gotCfg, err := FromReader(ctx, "", strings.NewReader(cfgText), logger)
+		gotCfg, err := FromReader(ctx, "", strings.NewReader(cfgText), logger, appConn)
 		test.That(t, err, test.ShouldBeNil)
 
 		expectedCloud := *cloudResponse
@@ -116,8 +119,10 @@ func TestFromReader(t *testing.T) {
 		fakeServer.StoreDeviceConfig(robotPartID, nil, nil)
 
 		appAddress := fmt.Sprintf("http://%s", fakeServer.Addr().String())
+		appConn, err := grpc.NewAppConn(ctx, appAddress, secret, robotPartID, logger)
+		test.That(t, err, test.ShouldBeNil)
 		cfgText := fmt.Sprintf(`{"cloud":{"id":%q,"app_address":%q,"secret":%q}}`, robotPartID, appAddress, secret)
-		gotCfg, err := FromReader(ctx, "", strings.NewReader(cfgText), logger)
+		gotCfg, err := FromReader(ctx, "", strings.NewReader(cfgText), logger, appConn)
 		test.That(t, err, test.ShouldBeNil)
 
 		expectedCloud := *cachedCloud
@@ -155,8 +160,10 @@ func TestFromReader(t *testing.T) {
 		fakeServer.StoreDeviceConfig(robotPartID, protoConfig, certProto)
 
 		appAddress := fmt.Sprintf("http://%s", fakeServer.Addr().String())
+		appConn, err := grpc.NewAppConn(ctx, appAddress, secret, robotPartID, logger)
+		test.That(t, err, test.ShouldBeNil)
 		cfgText := fmt.Sprintf(`{"cloud":{"id":%q,"app_address":%q,"secret":%q}}`, robotPartID, appAddress, secret)
-		gotCfg, err := FromReader(ctx, "", strings.NewReader(cfgText), logger)
+		gotCfg, err := FromReader(ctx, "", strings.NewReader(cfgText), logger, appConn)
 		test.That(t, err, test.ShouldBeNil)
 
 		expectedCloud := *cloudResponse

--- a/config/reader_test.go
+++ b/config/reader_test.go
@@ -182,9 +182,10 @@ func TestFromReader(t *testing.T) {
 }
 
 func TestStoreToCache(t *testing.T) {
+	var appConn rpc.ClientConn
+
 	logger := logging.NewTestLogger(t)
 	ctx := context.Background()
-	appConn := &grpc.AppConn{}
 	cfg, err := FromReader(ctx, "", strings.NewReader(`{}`), logger, appConn)
 
 	test.That(t, err, test.ShouldBeNil)

--- a/config/reader_test.go
+++ b/config/reader_test.go
@@ -185,11 +185,9 @@ func TestFromReader(t *testing.T) {
 }
 
 func TestStoreToCache(t *testing.T) {
-	var appConn rpc.ClientConn
-
 	logger := logging.NewTestLogger(t)
 	ctx := context.Background()
-	cfg, err := FromReader(ctx, "", strings.NewReader(`{}`), logger, appConn)
+	cfg, err := FromReader(ctx, "", strings.NewReader(`{}`), logger, nil)
 
 	test.That(t, err, test.ShouldBeNil)
 
@@ -209,7 +207,7 @@ func TestStoreToCache(t *testing.T) {
 	}
 	cfg.Cloud = cloud
 
-	appConn, err = grpc.NewAppConn(ctx, cloud.AppAddress, cloud.Secret, cloud.ID, logger)
+	appConn, err := grpc.NewAppConn(ctx, cloud.AppAddress, cloud.Secret, cloud.ID, logger)
 	test.That(t, err, test.ShouldBeNil)
 	defer appConn.Close()
 

--- a/config/reader_test.go
+++ b/config/reader_test.go
@@ -70,6 +70,7 @@ func TestFromReader(t *testing.T) {
 		appAddress := fmt.Sprintf("http://%s", fakeServer.Addr().String())
 		appConn, err := grpc.NewAppConn(ctx, appAddress, secret, robotPartID, logger)
 		test.That(t, err, test.ShouldBeNil)
+		defer appConn.Close()
 		cfgText := fmt.Sprintf(`{"cloud":{"id":%q,"app_address":%q,"secret":%q}}`, robotPartID, appAddress, secret)
 		gotCfg, err := FromReader(ctx, "", strings.NewReader(cfgText), logger, appConn)
 		test.That(t, err, test.ShouldBeNil)
@@ -121,6 +122,7 @@ func TestFromReader(t *testing.T) {
 		appAddress := fmt.Sprintf("http://%s", fakeServer.Addr().String())
 		appConn, err := grpc.NewAppConn(ctx, appAddress, secret, robotPartID, logger)
 		test.That(t, err, test.ShouldBeNil)
+		defer appConn.Close()
 		cfgText := fmt.Sprintf(`{"cloud":{"id":%q,"app_address":%q,"secret":%q}}`, robotPartID, appAddress, secret)
 		gotCfg, err := FromReader(ctx, "", strings.NewReader(cfgText), logger, appConn)
 		test.That(t, err, test.ShouldBeNil)
@@ -162,6 +164,7 @@ func TestFromReader(t *testing.T) {
 		appAddress := fmt.Sprintf("http://%s", fakeServer.Addr().String())
 		appConn, err := grpc.NewAppConn(ctx, appAddress, secret, robotPartID, logger)
 		test.That(t, err, test.ShouldBeNil)
+		defer appConn.Close()
 		cfgText := fmt.Sprintf(`{"cloud":{"id":%q,"app_address":%q,"secret":%q}}`, robotPartID, appAddress, secret)
 		gotCfg, err := FromReader(ctx, "", strings.NewReader(cfgText), logger, appConn)
 		test.That(t, err, test.ShouldBeNil)
@@ -208,6 +211,7 @@ func TestStoreToCache(t *testing.T) {
 
 	appConn, err = grpc.NewAppConn(ctx, cloud.AppAddress, cloud.Secret, cloud.ID, logger)
 	test.That(t, err, test.ShouldBeNil)
+	defer appConn.Close()
 
 	// errors if no unprocessed config to cache
 	cfgToCache := &Config{Cloud: &Cloud{ID: "forCachingTest"}}

--- a/config/watcher.go
+++ b/config/watcher.go
@@ -119,7 +119,7 @@ type fsConfigWatcher struct {
 }
 
 // newFSWatcher returns a new v that will fetch new configs
-// as soon as the underlying file is written to.Jk
+// as soon as the underlying file is written to.Jk.
 func newFSWatcher(ctx context.Context, configPath string, logger logging.Logger, conn rpc.ClientConn) (*fsConfigWatcher, error) {
 	fsWatcher, err := fsnotify.NewWatcher()
 	if err != nil {

--- a/config/watcher.go
+++ b/config/watcher.go
@@ -32,7 +32,7 @@ func NewWatcher(ctx context.Context, config *Config, logger logging.Logger, conn
 		return newCloudWatcher(ctx, config, logger, conn), nil
 	}
 	if config.ConfigFilePath != "" {
-		return newFSWatcher(ctx, config.ConfigFilePath, logger)
+		return newFSWatcher(ctx, config.ConfigFilePath, logger, conn)
 	}
 	return noopWatcher{}, nil
 }
@@ -119,8 +119,8 @@ type fsConfigWatcher struct {
 }
 
 // newFSWatcher returns a new v that will fetch new configs
-// as soon as the underlying file is written to.
-func newFSWatcher(ctx context.Context, configPath string, logger logging.Logger) (*fsConfigWatcher, error) {
+// as soon as the underlying file is written to.Jk
+func newFSWatcher(ctx context.Context, configPath string, logger logging.Logger, conn rpc.ClientConn) (*fsConfigWatcher, error) {
 	fsWatcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		return nil, err
@@ -155,7 +155,7 @@ func newFSWatcher(ctx context.Context, configPath string, logger logging.Logger)
 							return
 						}
 						lastRd = rd
-						newConfig, err := FromReader(cancelCtx, configPath, bytes.NewReader(rd), logger)
+						newConfig, err := FromReader(cancelCtx, configPath, bytes.NewReader(rd), logger, conn)
 						if err != nil {
 							logger.Errorw("error reading config after write", "error", err)
 							return

--- a/config/watcher.go
+++ b/config/watcher.go
@@ -119,7 +119,7 @@ type fsConfigWatcher struct {
 }
 
 // newFSWatcher returns a new v that will fetch new configs
-// as soon as the underlying file is written to.Jk.
+// as soon as the underlying file is written to.
 func newFSWatcher(ctx context.Context, configPath string, logger logging.Logger, conn rpc.ClientConn) (*fsConfigWatcher, error) {
 	fsWatcher, err := fsnotify.NewWatcher()
 	if err != nil {

--- a/config/watcher_test.go
+++ b/config/watcher_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestNewWatcherNoop(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	watcher, err := config.NewWatcher(context.Background(), &config.Config{}, logger, &grpc.AppConn{})
+	watcher, err := config.NewWatcher(context.Background(), &config.Config{}, logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 
 	timer := time.NewTimer(time.Second)
@@ -46,7 +46,7 @@ func TestNewWatcherFile(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	defer os.Remove(temp.Name())
 
-	watcher, err := config.NewWatcher(context.Background(), &config.Config{ConfigFilePath: temp.Name()}, logger, &grpc.AppConn{})
+	watcher, err := config.NewWatcher(context.Background(), &config.Config{ConfigFilePath: temp.Name()}, logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 
 	writeConf := func(conf *config.Config) {

--- a/config/watcher_test.go
+++ b/config/watcher_test.go
@@ -17,6 +17,7 @@ import (
 	"go.viam.com/rdk/components/arm"
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/config/testutils"
+	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	rutils "go.viam.com/rdk/utils"
@@ -24,7 +25,7 @@ import (
 
 func TestNewWatcherNoop(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	watcher, err := config.NewWatcher(context.Background(), &config.Config{}, logger)
+	watcher, err := config.NewWatcher(context.Background(), &config.Config{}, logger, &grpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 
 	timer := time.NewTimer(time.Second)
@@ -45,7 +46,7 @@ func TestNewWatcherFile(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	defer os.Remove(temp.Name())
 
-	watcher, err := config.NewWatcher(context.Background(), &config.Config{ConfigFilePath: temp.Name()}, logger)
+	watcher, err := config.NewWatcher(context.Background(), &config.Config{ConfigFilePath: temp.Name()}, logger, &grpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 
 	writeConf := func(conf *config.Config) {
@@ -271,7 +272,10 @@ func TestNewWatcherCloud(t *testing.T) {
 
 	storeConfigInServer(confToReturn)
 
-	watcher, err := config.NewWatcher(context.Background(), &config.Config{Cloud: newCloudConf()}, logger)
+	appConn, err := grpc.NewAppConn(context.Background(), confToReturn.Cloud.AppAddress, confToReturn.Cloud.Secret, confToReturn.Cloud.ID,
+		logger)
+	test.That(t, err, test.ShouldBeNil)
+	watcher, err := config.NewWatcher(context.Background(), &config.Config{Cloud: newCloudConf()}, logger, appConn)
 	test.That(t, err, test.ShouldBeNil)
 
 	confToExpect := confToReturn

--- a/config/watcher_test.go
+++ b/config/watcher_test.go
@@ -275,6 +275,7 @@ func TestNewWatcherCloud(t *testing.T) {
 	appConn, err := grpc.NewAppConn(context.Background(), confToReturn.Cloud.AppAddress, confToReturn.Cloud.Secret, confToReturn.Cloud.ID,
 		logger)
 	test.That(t, err, test.ShouldBeNil)
+	defer appConn.Close()
 	watcher, err := config.NewWatcher(context.Background(), &config.Config{Cloud: newCloudConf()}, logger, appConn)
 	test.That(t, err, test.ShouldBeNil)
 

--- a/examples/customresources/demos/complexmodule/moduletest/module_test.go
+++ b/examples/customresources/demos/complexmodule/moduletest/module_test.go
@@ -21,6 +21,7 @@ import (
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/examples/customresources/apis/gizmoapi"
 	"go.viam.com/rdk/examples/customresources/apis/summationapi"
+	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/robot/client"
@@ -324,7 +325,7 @@ func modifyCfg(t *testing.T, cfgIn string, logger logging.Logger) (string, int, 
 		return "", 0, err
 	}
 
-	cfg, err := config.Read(context.Background(), cfgIn, logger)
+	cfg, err := config.Read(context.Background(), cfgIn, logger, &grpc.AppConn{})
 	if err != nil {
 		return "", 0, err
 	}

--- a/examples/customresources/demos/complexmodule/moduletest/module_test.go
+++ b/examples/customresources/demos/complexmodule/moduletest/module_test.go
@@ -21,7 +21,6 @@ import (
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/examples/customresources/apis/gizmoapi"
 	"go.viam.com/rdk/examples/customresources/apis/summationapi"
-	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/robot/client"
@@ -325,7 +324,7 @@ func modifyCfg(t *testing.T, cfgIn string, logger logging.Logger) (string, int, 
 		return "", 0, err
 	}
 
-	cfg, err := config.Read(context.Background(), cfgIn, logger, &grpc.AppConn{})
+	cfg, err := config.Read(context.Background(), cfgIn, logger, nil)
 	if err != nil {
 		return "", 0, err
 	}

--- a/examples/customresources/demos/multiplemodules/moduletest/module_test.go
+++ b/examples/customresources/demos/multiplemodules/moduletest/module_test.go
@@ -17,7 +17,6 @@ import (
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/examples/customresources/apis/gizmoapi"
 	"go.viam.com/rdk/examples/customresources/apis/summationapi"
-	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/robot/client"
@@ -137,7 +136,7 @@ func modifyCfg(t *testing.T, cfgIn string, logger logging.Logger) (string, int, 
 		return "", 0, err
 	}
 
-	cfg, err := config.Read(context.Background(), cfgIn, logger, &grpc.AppConn{})
+	cfg, err := config.Read(context.Background(), cfgIn, logger, nil)
 	if err != nil {
 		return "", 0, err
 	}

--- a/examples/customresources/demos/multiplemodules/moduletest/module_test.go
+++ b/examples/customresources/demos/multiplemodules/moduletest/module_test.go
@@ -17,6 +17,7 @@ import (
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/examples/customresources/apis/gizmoapi"
 	"go.viam.com/rdk/examples/customresources/apis/summationapi"
+	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/robot/client"
@@ -136,7 +137,7 @@ func modifyCfg(t *testing.T, cfgIn string, logger logging.Logger) (string, int, 
 		return "", 0, err
 	}
 
-	cfg, err := config.Read(context.Background(), cfgIn, logger)
+	cfg, err := config.Read(context.Background(), cfgIn, logger, &grpc.AppConn{})
 	if err != nil {
 		return "", 0, err
 	}

--- a/examples/customresources/demos/remoteserver/server.go
+++ b/examples/customresources/demos/remoteserver/server.go
@@ -9,6 +9,7 @@ import (
 
 	"go.viam.com/rdk/config"
 	_ "go.viam.com/rdk/examples/customresources/models/mygizmo"
+	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	robotimpl "go.viam.com/rdk/robot/impl"
 	"go.viam.com/rdk/robot/web"
@@ -35,7 +36,7 @@ func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) (er
 		return errors.New("please specify a config file through the -config parameter")
 	}
 
-	cfg, err := config.Read(ctx, argsParsed.ConfigFile, logger)
+	cfg, err := config.Read(ctx, argsParsed.ConfigFile, logger, &grpc.AppConn{})
 	if err != nil {
 		return err
 	}

--- a/examples/customresources/demos/remoteserver/server.go
+++ b/examples/customresources/demos/remoteserver/server.go
@@ -9,7 +9,6 @@ import (
 
 	"go.viam.com/rdk/config"
 	_ "go.viam.com/rdk/examples/customresources/models/mygizmo"
-	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	robotimpl "go.viam.com/rdk/robot/impl"
 	"go.viam.com/rdk/robot/web"
@@ -36,7 +35,7 @@ func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) (er
 		return errors.New("please specify a config file through the -config parameter")
 	}
 
-	cfg, err := config.Read(ctx, argsParsed.ConfigFile, logger, &grpc.AppConn{})
+	cfg, err := config.Read(ctx, argsParsed.ConfigFile, logger, nil)
 	if err != nil {
 		return err
 	}

--- a/examples/customresources/demos/remoteserver/server_test.go
+++ b/examples/customresources/demos/remoteserver/server_test.go
@@ -16,7 +16,6 @@ import (
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/examples/customresources/apis/gizmoapi"
 	_ "go.viam.com/rdk/examples/customresources/models/mygizmo"
-	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	robotimpl "go.viam.com/rdk/robot/impl"
 	weboptions "go.viam.com/rdk/robot/web/options"
@@ -41,8 +40,7 @@ func TestGizmo(t *testing.T) {
 		remoteAddrB = fmt.Sprintf("localhost:%d", port)
 		test.That(t, err, test.ShouldBeNil)
 
-		cfgServer, err := config.Read(ctx, utils.ResolveFile("./examples/customresources/demos/remoteserver/remote.json"), logger,
-			&grpc.AppConn{})
+		cfgServer, err := config.Read(ctx, utils.ResolveFile("./examples/customresources/demos/remoteserver/remote.json"), logger, nil)
 		test.That(t, err, test.ShouldBeNil)
 		remoteB, err := robotimpl.New(ctx, cfgServer, logger.Sublogger("remoteB"))
 		test.That(t, err, test.ShouldBeNil)

--- a/examples/customresources/demos/remoteserver/server_test.go
+++ b/examples/customresources/demos/remoteserver/server_test.go
@@ -16,6 +16,7 @@ import (
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/examples/customresources/apis/gizmoapi"
 	_ "go.viam.com/rdk/examples/customresources/models/mygizmo"
+	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	robotimpl "go.viam.com/rdk/robot/impl"
 	weboptions "go.viam.com/rdk/robot/web/options"
@@ -40,7 +41,8 @@ func TestGizmo(t *testing.T) {
 		remoteAddrB = fmt.Sprintf("localhost:%d", port)
 		test.That(t, err, test.ShouldBeNil)
 
-		cfgServer, err := config.Read(ctx, utils.ResolveFile("./examples/customresources/demos/remoteserver/remote.json"), logger)
+		cfgServer, err := config.Read(ctx, utils.ResolveFile("./examples/customresources/demos/remoteserver/remote.json"), logger,
+			&grpc.AppConn{})
 		test.That(t, err, test.ShouldBeNil)
 		remoteB, err := robotimpl.New(ctx, cfgServer, logger.Sublogger("remoteB"))
 		test.That(t, err, test.ShouldBeNil)

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -26,7 +26,7 @@ type AppConn struct {
 // connection is made. If `cloud` is nil, an `AppConn` with a nil underlying connection will return, and the background dialer will not
 // start.
 func NewAppConn(ctx context.Context, appAddress, secret, id string, logger logging.Logger) (rpc.ClientConn, error) {
-	appConn := &AppConn{}
+	appConn := &AppConn{ReconfigurableClientConn: &ReconfigurableClientConn{}}
 
 	grpcURL, err := url.Parse(appAddress)
 	if err != nil {

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -15,7 +15,7 @@ import (
 // AppConn maintains an underlying client connection meant to be used globally to connect to App. The `AppConn` constructor repeatedly
 // attempts to dial App until a connection is successfully established.
 type AppConn struct {
-	ReconfigurableClientConn
+	*ReconfigurableClientConn
 
 	dialer *utils.StoppableWorkers
 }
@@ -25,7 +25,7 @@ type AppConn struct {
 // establishing a connection to App will continue to occur, however, in a background Goroutine. These attempts will continue until a
 // connection is made. If `cloud` is nil, an `AppConn` with a nil underlying connection will return, and the background dialer will not
 // start.
-func NewAppConn(ctx context.Context, appAddress string, secret string, id string, logger logging.Logger) (*AppConn, error) {
+func NewAppConn(ctx context.Context, appAddress, secret, id string, logger logging.Logger) (rpc.ClientConn, error) {
 	appConn := &AppConn{}
 
 	grpcURL, err := url.Parse(appAddress)
@@ -85,7 +85,7 @@ func (ac *AppConn) Close() error {
 	return ac.ReconfigurableClientConn.Close()
 }
 
-func dialOpts(secret string, id string) []rpc.DialOption {
+func dialOpts(secret, id string) []rpc.DialOption {
 	dialOpts := make([]rpc.DialOption, 0, 2)
 	// Only add credentials when secret is set.
 	if secret != "" {

--- a/robot/framesystem/framesystem_test.go
+++ b/robot/framesystem/framesystem_test.go
@@ -11,6 +11,7 @@ import (
 
 	_ "go.viam.com/rdk/components/register"
 	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/referenceframe"
 	robotimpl "go.viam.com/rdk/robot/impl"
@@ -93,7 +94,7 @@ func TestNewFrameSystemFromConfigWithTransforms(t *testing.T) {
 	blankPos := make(referenceframe.FrameSystemInputs)
 	blankPos["pieceArm"] = zeroIn
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(context.Background(), rdkutils.ResolveFile("robot/impl/data/fake.json"), logger)
+	cfg, err := config.Read(context.Background(), rdkutils.ResolveFile("robot/impl/data/fake.json"), logger, &grpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 
 	r, err := robotimpl.New(context.Background(), cfg, logger)
@@ -225,7 +226,7 @@ func TestNewFrameSystemFromBadConfig(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg, err := config.Read(ctx, rdkutils.ResolveFile("robot/impl/data/fake_wrongconfig"+tc.num+".json"), logger)
+			cfg, err := config.Read(ctx, rdkutils.ResolveFile("robot/impl/data/fake_wrongconfig"+tc.num+".json"), logger, &grpc.AppConn{})
 			test.That(t, err, test.ShouldBeNil)
 			r, err := robotimpl.New(ctx, cfg, logger)
 			test.That(t, err, test.ShouldBeNil)
@@ -240,7 +241,7 @@ func TestNewFrameSystemFromBadConfig(t *testing.T) {
 		})
 	}
 
-	cfg, err := config.Read(ctx, rdkutils.ResolveFile("robot/impl/data/fake.json"), logger)
+	cfg, err := config.Read(ctx, rdkutils.ResolveFile("robot/impl/data/fake.json"), logger, &grpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 	r, err := robotimpl.New(ctx, cfg, logger)
 	test.That(t, err, test.ShouldBeNil)

--- a/robot/framesystem/framesystem_test.go
+++ b/robot/framesystem/framesystem_test.go
@@ -11,7 +11,6 @@ import (
 
 	_ "go.viam.com/rdk/components/register"
 	"go.viam.com/rdk/config"
-	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/referenceframe"
 	robotimpl "go.viam.com/rdk/robot/impl"
@@ -94,7 +93,7 @@ func TestNewFrameSystemFromConfigWithTransforms(t *testing.T) {
 	blankPos := make(referenceframe.FrameSystemInputs)
 	blankPos["pieceArm"] = zeroIn
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(context.Background(), rdkutils.ResolveFile("robot/impl/data/fake.json"), logger, &grpc.AppConn{})
+	cfg, err := config.Read(context.Background(), rdkutils.ResolveFile("robot/impl/data/fake.json"), logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 
 	r, err := robotimpl.New(context.Background(), cfg, logger)
@@ -226,7 +225,7 @@ func TestNewFrameSystemFromBadConfig(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg, err := config.Read(ctx, rdkutils.ResolveFile("robot/impl/data/fake_wrongconfig"+tc.num+".json"), logger, &grpc.AppConn{})
+			cfg, err := config.Read(ctx, rdkutils.ResolveFile("robot/impl/data/fake_wrongconfig"+tc.num+".json"), logger, nil)
 			test.That(t, err, test.ShouldBeNil)
 			r, err := robotimpl.New(ctx, cfg, logger)
 			test.That(t, err, test.ShouldBeNil)
@@ -241,7 +240,7 @@ func TestNewFrameSystemFromBadConfig(t *testing.T) {
 		})
 	}
 
-	cfg, err := config.Read(ctx, rdkutils.ResolveFile("robot/impl/data/fake.json"), logger, &grpc.AppConn{})
+	cfg, err := config.Read(ctx, rdkutils.ResolveFile("robot/impl/data/fake.json"), logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 	r, err := robotimpl.New(ctx, cfg, logger)
 	test.That(t, err, test.ShouldBeNil)

--- a/robot/impl/discovery_test.go
+++ b/robot/impl/discovery_test.go
@@ -17,6 +17,7 @@ import (
 	"go.viam.com/rdk/examples/customresources/models/mygizmo"
 	"go.viam.com/rdk/examples/customresources/models/mynavigation"
 	"go.viam.com/rdk/examples/customresources/models/mysum"
+	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot"
@@ -29,7 +30,7 @@ func setupLocalRobotWithFakeConfig(t *testing.T) robot.LocalRobot {
 
 	logger := logging.NewTestLogger(t)
 	ctx := context.Background()
-	cfg, err := config.Read(ctx, "data/fake.json", logger)
+	cfg, err := config.Read(ctx, "data/fake.json", logger, &grpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 	return setupLocalRobot(t, ctx, cfg, logger)
 }

--- a/robot/impl/discovery_test.go
+++ b/robot/impl/discovery_test.go
@@ -17,7 +17,6 @@ import (
 	"go.viam.com/rdk/examples/customresources/models/mygizmo"
 	"go.viam.com/rdk/examples/customresources/models/mynavigation"
 	"go.viam.com/rdk/examples/customresources/models/mysum"
-	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot"
@@ -30,7 +29,7 @@ func setupLocalRobotWithFakeConfig(t *testing.T) robot.LocalRobot {
 
 	logger := logging.NewTestLogger(t)
 	ctx := context.Background()
-	cfg, err := config.Read(ctx, "data/fake.json", logger, &grpc.AppConn{})
+	cfg, err := config.Read(ctx, "data/fake.json", logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 	return setupLocalRobot(t, ctx, cfg, logger)
 }

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -27,6 +27,7 @@ import (
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/ftdc"
 	"go.viam.com/rdk/ftdc/sys"
+	"go.viam.com/rdk/grpc"
 	icloud "go.viam.com/rdk/internal/cloud"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/operation"
@@ -997,7 +998,7 @@ func (r *localRobot) TransformPointCloud(
 
 // RobotFromConfigPath is a helper to read and process a config given its path and then create a robot based on it.
 func RobotFromConfigPath(ctx context.Context, cfgPath string, logger logging.Logger, opts ...Option) (robot.LocalRobot, error) {
-	cfg, err := config.Read(ctx, cfgPath, logger)
+	cfg, err := config.Read(ctx, cfgPath, logger, &grpc.AppConn{})
 	if err != nil {
 		logger.CError(ctx, "cannot read config")
 		return nil, err

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -373,7 +373,7 @@ func newWithResources(
 		// - Guarantee that the `rpcServer` is initialized (enough) when the web service is
 		//   constructed to get a valid copy of its stats object (for the schema's sake). Even if
 		//   the web service has not been "started".
-		ftdcWorker = ftdc.New(ftdc.DefaultDirectory(config.ViamDotDir, partID), logger.Sublogger("ftdc"))
+		ftdcWorker = ftdc.New(ftdc.DefaultDirectory(utils.ViamDotDir, partID), logger.Sublogger("ftdc"))
 		if statser, err := sys.NewSelfSysUsageStatser(); err == nil {
 			ftdcWorker.Add("proc.viam-server", statser)
 		}
@@ -500,7 +500,7 @@ func newWithResources(
 		cloudID = cfg.Cloud.ID
 	}
 
-	homeDir := config.ViamDotDir
+	homeDir := utils.ViamDotDir
 	if rOpts.viamHomeDir != "" {
 		homeDir = rOpts.viamHomeDir
 	}

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -27,7 +27,6 @@ import (
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/ftdc"
 	"go.viam.com/rdk/ftdc/sys"
-	"go.viam.com/rdk/grpc"
 	icloud "go.viam.com/rdk/internal/cloud"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/operation"
@@ -998,7 +997,7 @@ func (r *localRobot) TransformPointCloud(
 
 // RobotFromConfigPath is a helper to read and process a config given its path and then create a robot based on it.
 func RobotFromConfigPath(ctx context.Context, cfgPath string, logger logging.Logger, opts ...Option) (robot.LocalRobot, error) {
-	cfg, err := config.Read(ctx, cfgPath, logger, &grpc.AppConn{})
+	cfg, err := config.Read(ctx, cfgPath, logger, nil)
 	if err != nil {
 		logger.CError(ctx, "cannot read config")
 		return nil, err

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -77,7 +77,7 @@ var fakeModel = resource.DefaultModelFamily.WithModel("fake")
 
 func TestConfig1(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(context.Background(), "data/cfgtest1.json", logger, &rgrpc.AppConn{})
+	cfg, err := config.Read(context.Background(), "data/cfgtest1.json", logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 
 	r := setupLocalRobot(t, context.Background(), cfg, logger)
@@ -96,7 +96,7 @@ func TestConfig1(t *testing.T) {
 
 func TestConfigFake(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(context.Background(), "data/fake.json", logger, &rgrpc.AppConn{})
+	cfg, err := config.Read(context.Background(), "data/fake.json", logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 
 	setupLocalRobot(t, context.Background(), cfg, logger)
@@ -106,7 +106,7 @@ func TestConfigFake(t *testing.T) {
 // dependency on all resources.
 func TestConfigRemote(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(context.Background(), "data/fake.json", logger, &rgrpc.AppConn{})
+	cfg, err := config.Read(context.Background(), "data/fake.json", logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 
 	ctx := context.Background()
@@ -234,7 +234,7 @@ func TestConfigRemote(t *testing.T) {
 
 func TestConfigRemoteWithAuth(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(context.Background(), "data/fake.json", logger, &rgrpc.AppConn{})
+	cfg, err := config.Read(context.Background(), "data/fake.json", logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 
 	for _, tc := range []struct {
@@ -391,7 +391,7 @@ func TestConfigRemoteWithAuth(t *testing.T) {
 
 func TestConfigRemoteWithTLSAuth(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(context.Background(), "data/fake.json", logger, &rgrpc.AppConn{})
+	cfg, err := config.Read(context.Background(), "data/fake.json", logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 
 	ctx := context.Background()
@@ -597,7 +597,7 @@ func TestStopAll(t *testing.T) {
 		resource.Deregister(arm.API, model)
 	}()
 
-	cfg, err := config.FromReader(context.Background(), "", strings.NewReader(armConfig), logger, &rgrpc.AppConn{})
+	cfg, err := config.FromReader(context.Background(), "", strings.NewReader(armConfig), logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 
 	ctx := context.Background()
@@ -704,7 +704,7 @@ func TestNewTeardown(t *testing.T) {
     ]
 }
 `, model)
-	cfg, err := config.FromReader(context.Background(), "", strings.NewReader(failingConfig), logger, &rgrpc.AppConn{})
+	cfg, err := config.FromReader(context.Background(), "", strings.NewReader(failingConfig), logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 
 	ctx := context.Background()
@@ -715,7 +715,7 @@ func TestNewTeardown(t *testing.T) {
 
 func TestMetadataUpdate(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(context.Background(), "data/fake.json", logger, &rgrpc.AppConn{})
+	cfg, err := config.Read(context.Background(), "data/fake.json", logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 
 	ctx := context.Background()
@@ -810,7 +810,7 @@ func TestGetRemoteResourceAndGrandFather(t *testing.T) {
 		},
 	}
 
-	cfg, err := config.Read(context.Background(), "data/fake.json", logger, &rgrpc.AppConn{})
+	cfg, err := config.Read(context.Background(), "data/fake.json", logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 	cfg.Remotes = append(cfg.Remotes, config.Remote{
 		Name:    "foo",
@@ -1317,7 +1317,7 @@ func TestConfigMethod(t *testing.T) {
 
 	// Use a remote with components and services to ensure none of its resources
 	// will be returned by Config.
-	remoteCfg, err := config.Read(context.Background(), "data/remote_fake.json", logger, &rgrpc.AppConn{})
+	remoteCfg, err := config.Read(context.Background(), "data/remote_fake.json", logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 	remoteRobot := setupLocalRobot(t, ctx, remoteCfg, logger)
 

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -77,7 +77,7 @@ var fakeModel = resource.DefaultModelFamily.WithModel("fake")
 
 func TestConfig1(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(context.Background(), "data/cfgtest1.json", logger)
+	cfg, err := config.Read(context.Background(), "data/cfgtest1.json", logger, &rgrpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 
 	r := setupLocalRobot(t, context.Background(), cfg, logger)
@@ -96,7 +96,7 @@ func TestConfig1(t *testing.T) {
 
 func TestConfigFake(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(context.Background(), "data/fake.json", logger)
+	cfg, err := config.Read(context.Background(), "data/fake.json", logger, &rgrpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 
 	setupLocalRobot(t, context.Background(), cfg, logger)
@@ -106,7 +106,7 @@ func TestConfigFake(t *testing.T) {
 // dependency on all resources.
 func TestConfigRemote(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(context.Background(), "data/fake.json", logger)
+	cfg, err := config.Read(context.Background(), "data/fake.json", logger, &rgrpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 
 	ctx := context.Background()
@@ -234,7 +234,7 @@ func TestConfigRemote(t *testing.T) {
 
 func TestConfigRemoteWithAuth(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(context.Background(), "data/fake.json", logger)
+	cfg, err := config.Read(context.Background(), "data/fake.json", logger, &rgrpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 
 	for _, tc := range []struct {
@@ -391,7 +391,7 @@ func TestConfigRemoteWithAuth(t *testing.T) {
 
 func TestConfigRemoteWithTLSAuth(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(context.Background(), "data/fake.json", logger)
+	cfg, err := config.Read(context.Background(), "data/fake.json", logger, &rgrpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 
 	ctx := context.Background()
@@ -597,7 +597,7 @@ func TestStopAll(t *testing.T) {
 		resource.Deregister(arm.API, model)
 	}()
 
-	cfg, err := config.FromReader(context.Background(), "", strings.NewReader(armConfig), logger)
+	cfg, err := config.FromReader(context.Background(), "", strings.NewReader(armConfig), logger, &rgrpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 
 	ctx := context.Background()
@@ -704,7 +704,7 @@ func TestNewTeardown(t *testing.T) {
     ]
 }
 `, model)
-	cfg, err := config.FromReader(context.Background(), "", strings.NewReader(failingConfig), logger)
+	cfg, err := config.FromReader(context.Background(), "", strings.NewReader(failingConfig), logger, &rgrpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 
 	ctx := context.Background()
@@ -715,7 +715,7 @@ func TestNewTeardown(t *testing.T) {
 
 func TestMetadataUpdate(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(context.Background(), "data/fake.json", logger)
+	cfg, err := config.Read(context.Background(), "data/fake.json", logger, &rgrpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 
 	ctx := context.Background()
@@ -810,7 +810,7 @@ func TestGetRemoteResourceAndGrandFather(t *testing.T) {
 		},
 	}
 
-	cfg, err := config.Read(context.Background(), "data/fake.json", logger)
+	cfg, err := config.Read(context.Background(), "data/fake.json", logger, &rgrpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 	cfg.Remotes = append(cfg.Remotes, config.Remote{
 		Name:    "foo",
@@ -1317,7 +1317,7 @@ func TestConfigMethod(t *testing.T) {
 
 	// Use a remote with components and services to ensure none of its resources
 	// will be returned by Config.
-	remoteCfg, err := config.Read(context.Background(), "data/remote_fake.json", logger)
+	remoteCfg, err := config.Read(context.Background(), "data/remote_fake.json", logger, &rgrpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 	remoteRobot := setupLocalRobot(t, ctx, remoteCfg, logger)
 

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -1178,7 +1178,7 @@ func TestManagerMarkRemoved(t *testing.T) {
 
 func TestConfigRemoteAllowInsecureCreds(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(context.Background(), "data/fake.json", logger)
+	cfg, err := config.Read(context.Background(), "data/fake.json", logger, &grpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 
 	ctx := context.Background()
@@ -1523,7 +1523,7 @@ func TestReconfigure(t *testing.T) {
 	api := resource.APINamespaceRDK.WithServiceType(subtypeName)
 
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(context.Background(), "data/fake.json", logger)
+	cfg, err := config.Read(context.Background(), "data/fake.json", logger, &grpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 
 	ctx := context.Background()

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -1178,7 +1178,7 @@ func TestManagerMarkRemoved(t *testing.T) {
 
 func TestConfigRemoteAllowInsecureCreds(t *testing.T) {
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(context.Background(), "data/fake.json", logger, &grpc.AppConn{})
+	cfg, err := config.Read(context.Background(), "data/fake.json", logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 
 	ctx := context.Background()
@@ -1523,7 +1523,7 @@ func TestReconfigure(t *testing.T) {
 	api := resource.APINamespaceRDK.WithServiceType(subtypeName)
 
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(context.Background(), "data/fake.json", logger, &grpc.AppConn{})
+	cfg, err := config.Read(context.Background(), "data/fake.json", logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 
 	ctx := context.Background()

--- a/robot/impl/robot_framesystem_test.go
+++ b/robot/impl/robot_framesystem_test.go
@@ -13,7 +13,6 @@ import (
 	"go.viam.com/rdk/components/base"
 	"go.viam.com/rdk/components/gripper"
 	"go.viam.com/rdk/config"
-	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/resource"
@@ -28,8 +27,7 @@ import (
 func TestFrameSystemConfigWithRemote(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	// make the remote robots
-	remoteConfig, err := config.Read(context.Background(), rutils.ResolveFile("robot/impl/data/fake.json"), logger.Sublogger("remote"),
-		&grpc.AppConn{})
+	remoteConfig, err := config.Read(context.Background(), rutils.ResolveFile("robot/impl/data/fake.json"), logger.Sublogger("remote"), nil)
 	test.That(t, err, test.ShouldBeNil)
 	ctx := context.Background()
 	remoteRobot := setupLocalRobot(t, ctx, remoteConfig, logger)

--- a/robot/impl/robot_framesystem_test.go
+++ b/robot/impl/robot_framesystem_test.go
@@ -13,6 +13,7 @@ import (
 	"go.viam.com/rdk/components/base"
 	"go.viam.com/rdk/components/gripper"
 	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/resource"
@@ -27,7 +28,8 @@ import (
 func TestFrameSystemConfigWithRemote(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	// make the remote robots
-	remoteConfig, err := config.Read(context.Background(), rutils.ResolveFile("robot/impl/data/fake.json"), logger.Sublogger("remote"))
+	remoteConfig, err := config.Read(context.Background(), rutils.ResolveFile("robot/impl/data/fake.json"), logger.Sublogger("remote"),
+		&grpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 	ctx := context.Background()
 	remoteRobot := setupLocalRobot(t, ctx, remoteConfig, logger)

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -20,7 +20,6 @@ import (
 	"go.viam.com/utils/testutils"
 
 	"go.viam.com/rdk/config"
-	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	// TODO(RSDK-7884): change everything that depends on this import to a mock.
@@ -51,7 +50,7 @@ func ConfigFromFile(tb testing.TB, filePath string) *config.Config {
 	logger := logging.NewTestLogger(tb)
 	buf, err := envsubst.ReadFile(filePath)
 	test.That(tb, err, test.ShouldBeNil)
-	conf, err := config.FromReader(context.Background(), filePath, bytes.NewReader(buf), logger, &grpc.AppConn{})
+	conf, err := config.FromReader(context.Background(), filePath, bytes.NewReader(buf), logger, nil)
 	test.That(tb, err, test.ShouldBeNil)
 	return conf
 }

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -20,6 +20,7 @@ import (
 	"go.viam.com/utils/testutils"
 
 	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	// TODO(RSDK-7884): change everything that depends on this import to a mock.
@@ -50,7 +51,7 @@ func ConfigFromFile(tb testing.TB, filePath string) *config.Config {
 	logger := logging.NewTestLogger(tb)
 	buf, err := envsubst.ReadFile(filePath)
 	test.That(tb, err, test.ShouldBeNil)
-	conf, err := config.FromReader(context.Background(), filePath, bytes.NewReader(buf), logger)
+	conf, err := config.FromReader(context.Background(), filePath, bytes.NewReader(buf), logger, &grpc.AppConn{})
 	test.That(tb, err, test.ShouldBeNil)
 	return conf
 }

--- a/robot/session_test.go
+++ b/robot/session_test.go
@@ -175,7 +175,7 @@ func TestSessions(t *testing.T) {
 			}
 			`, windowSize, model, streamModel)
 
-			cfg, err := config.FromReader(context.Background(), "", strings.NewReader(roboConfig), logger, &grpc.AppConn{})
+			cfg, err := config.FromReader(context.Background(), "", strings.NewReader(roboConfig), logger, nil)
 			test.That(t, err, test.ShouldBeNil)
 
 			ctx := context.Background()
@@ -372,7 +372,7 @@ func TestSessionsWithRemote(t *testing.T) {
 	}
 	`, model, streamModel)
 
-	cfg, err := config.FromReader(context.Background(), "", strings.NewReader(remoteConfig), logger, &grpc.AppConn{})
+	cfg, err := config.FromReader(context.Background(), "", strings.NewReader(remoteConfig), logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 
 	ctx := context.Background()
@@ -405,7 +405,7 @@ func TestSessionsWithRemote(t *testing.T) {
 	}
 	`, remoteAddr, model)
 
-	cfg, err = config.FromReader(context.Background(), "", strings.NewReader(roboConfig), logger, &grpc.AppConn{})
+	cfg, err = config.FromReader(context.Background(), "", strings.NewReader(roboConfig), logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 
 	r, err := robotimpl.New(ctx, cfg, logger.Sublogger("main"))
@@ -564,7 +564,7 @@ func TestSessionsMixedClients(t *testing.T) {
 	}
 	`, model)
 
-	cfg, err := config.FromReader(context.Background(), "", strings.NewReader(roboConfig), logger, &grpc.AppConn{})
+	cfg, err := config.FromReader(context.Background(), "", strings.NewReader(roboConfig), logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 
 	ctx := context.Background()
@@ -657,7 +657,7 @@ func TestSessionsMixedOwnersNoAuth(t *testing.T) {
 	}
 	`, model)
 
-	cfg, err := config.FromReader(context.Background(), "", strings.NewReader(roboConfig), logger, &grpc.AppConn{})
+	cfg, err := config.FromReader(context.Background(), "", strings.NewReader(roboConfig), logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 
 	ctx := context.Background()
@@ -764,7 +764,7 @@ func TestSessionsMixedOwnersImplicitAuth(t *testing.T) {
 	}
 	`, model)
 
-	cfg, err := config.FromReader(context.Background(), "", strings.NewReader(roboConfig), logger, &grpc.AppConn{})
+	cfg, err := config.FromReader(context.Background(), "", strings.NewReader(roboConfig), logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 
 	ctx := context.Background()

--- a/robot/session_test.go
+++ b/robot/session_test.go
@@ -175,7 +175,7 @@ func TestSessions(t *testing.T) {
 			}
 			`, windowSize, model, streamModel)
 
-			cfg, err := config.FromReader(context.Background(), "", strings.NewReader(roboConfig), logger)
+			cfg, err := config.FromReader(context.Background(), "", strings.NewReader(roboConfig), logger, &grpc.AppConn{})
 			test.That(t, err, test.ShouldBeNil)
 
 			ctx := context.Background()
@@ -372,7 +372,7 @@ func TestSessionsWithRemote(t *testing.T) {
 	}
 	`, model, streamModel)
 
-	cfg, err := config.FromReader(context.Background(), "", strings.NewReader(remoteConfig), logger)
+	cfg, err := config.FromReader(context.Background(), "", strings.NewReader(remoteConfig), logger, &grpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 
 	ctx := context.Background()
@@ -405,7 +405,7 @@ func TestSessionsWithRemote(t *testing.T) {
 	}
 	`, remoteAddr, model)
 
-	cfg, err = config.FromReader(context.Background(), "", strings.NewReader(roboConfig), logger)
+	cfg, err = config.FromReader(context.Background(), "", strings.NewReader(roboConfig), logger, &grpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 
 	r, err := robotimpl.New(ctx, cfg, logger.Sublogger("main"))
@@ -564,7 +564,7 @@ func TestSessionsMixedClients(t *testing.T) {
 	}
 	`, model)
 
-	cfg, err := config.FromReader(context.Background(), "", strings.NewReader(roboConfig), logger)
+	cfg, err := config.FromReader(context.Background(), "", strings.NewReader(roboConfig), logger, &grpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 
 	ctx := context.Background()
@@ -657,7 +657,7 @@ func TestSessionsMixedOwnersNoAuth(t *testing.T) {
 	}
 	`, model)
 
-	cfg, err := config.FromReader(context.Background(), "", strings.NewReader(roboConfig), logger)
+	cfg, err := config.FromReader(context.Background(), "", strings.NewReader(roboConfig), logger, &grpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 
 	ctx := context.Background()
@@ -764,7 +764,7 @@ func TestSessionsMixedOwnersImplicitAuth(t *testing.T) {
 	}
 	`, model)
 
-	cfg, err := config.FromReader(context.Background(), "", strings.NewReader(roboConfig), logger)
+	cfg, err := config.FromReader(context.Background(), "", strings.NewReader(roboConfig), logger, &grpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 
 	ctx := context.Background()

--- a/services/datamanager/builtin/builtin_test.go
+++ b/services/datamanager/builtin/builtin_test.go
@@ -28,7 +28,6 @@ import (
 	"go.viam.com/rdk/components/sensor"
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/data"
-	rgrpc "go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/internal/cloud"
 	cloudinject "go.viam.com/rdk/internal/testutils/inject"
 	"go.viam.com/rdk/logging"
@@ -819,7 +818,7 @@ func setupRobot(
 func setupConfig(t *testing.T, r *inject.Robot, configPath string) (resource.Config, resource.Dependencies) {
 	t.Helper()
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(context.Background(), utils.ResolveFile(configPath), logger, &rgrpc.AppConn{})
+	cfg, err := config.Read(context.Background(), utils.ResolveFile(configPath), logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 	return resourceConfigAndDeps(t, cfg, r)
 }

--- a/services/datamanager/builtin/builtin_test.go
+++ b/services/datamanager/builtin/builtin_test.go
@@ -28,6 +28,7 @@ import (
 	"go.viam.com/rdk/components/sensor"
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/data"
+	rgrpc "go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/internal/cloud"
 	cloudinject "go.viam.com/rdk/internal/testutils/inject"
 	"go.viam.com/rdk/logging"
@@ -818,7 +819,7 @@ func setupRobot(
 func setupConfig(t *testing.T, r *inject.Robot, configPath string) (resource.Config, resource.Dependencies) {
 	t.Helper()
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(context.Background(), utils.ResolveFile(configPath), logger)
+	cfg, err := config.Read(context.Background(), utils.ResolveFile(configPath), logger, &rgrpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 	return resourceConfigAndDeps(t, cfg, r)
 }

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -26,6 +26,7 @@ import (
 	"go.viam.com/rdk/components/movementsensor"
 	_ "go.viam.com/rdk/components/register"
 	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/motionplan"
 	"go.viam.com/rdk/pointcloud"
@@ -45,7 +46,7 @@ func setupMotionServiceFromConfig(t *testing.T, configFilename string) (motion.S
 	t.Helper()
 	ctx := context.Background()
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(ctx, configFilename, logger)
+	cfg, err := config.Read(ctx, configFilename, logger, &grpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 	myRobot, err := robotimpl.New(ctx, cfg, logger)
 	test.That(t, err, test.ShouldBeNil)

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -26,7 +26,6 @@ import (
 	"go.viam.com/rdk/components/movementsensor"
 	_ "go.viam.com/rdk/components/register"
 	"go.viam.com/rdk/config"
-	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/motionplan"
 	"go.viam.com/rdk/pointcloud"
@@ -46,7 +45,7 @@ func setupMotionServiceFromConfig(t *testing.T, configFilename string) (motion.S
 	t.Helper()
 	ctx := context.Background()
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(ctx, configFilename, logger, &grpc.AppConn{})
+	cfg, err := config.Read(ctx, configFilename, logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 	myRobot, err := robotimpl.New(ctx, cfg, logger)
 	test.That(t, err, test.ShouldBeNil)

--- a/services/motion/builtin/move_on_map_test.go
+++ b/services/motion/builtin/move_on_map_test.go
@@ -14,7 +14,6 @@ import (
 	"go.viam.com/rdk/components/base"
 	_ "go.viam.com/rdk/components/register"
 	"go.viam.com/rdk/config"
-	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/motionplan"
 	"go.viam.com/rdk/referenceframe"
@@ -40,7 +39,7 @@ func TestMoveOnMap(t *testing.T) {
 	}
 
 	t.Run("Timeout", func(t *testing.T) {
-		cfg, err := config.Read(ctx, "../data/real_wheeled_base.json", logger, &grpc.AppConn{})
+		cfg, err := config.Read(ctx, "../data/real_wheeled_base.json", logger, nil)
 		test.That(t, err, test.ShouldBeNil)
 		myRobot, err := robotimpl.New(ctx, cfg, logger)
 		test.That(t, err, test.ShouldBeNil)

--- a/services/motion/builtin/move_on_map_test.go
+++ b/services/motion/builtin/move_on_map_test.go
@@ -14,6 +14,7 @@ import (
 	"go.viam.com/rdk/components/base"
 	_ "go.viam.com/rdk/components/register"
 	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/motionplan"
 	"go.viam.com/rdk/referenceframe"
@@ -39,7 +40,7 @@ func TestMoveOnMap(t *testing.T) {
 	}
 
 	t.Run("Timeout", func(t *testing.T) {
-		cfg, err := config.Read(ctx, "../data/real_wheeled_base.json", logger)
+		cfg, err := config.Read(ctx, "../data/real_wheeled_base.json", logger, &grpc.AppConn{})
 		test.That(t, err, test.ShouldBeNil)
 		myRobot, err := robotimpl.New(ctx, cfg, logger)
 		test.That(t, err, test.ShouldBeNil)

--- a/services/navigation/builtin/builtin_test.go
+++ b/services/navigation/builtin/builtin_test.go
@@ -23,6 +23,7 @@ import (
 	"go.viam.com/rdk/components/movementsensor"
 	_ "go.viam.com/rdk/components/movementsensor/fake"
 	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/motionplan"
 	"go.viam.com/rdk/pointcloud"
@@ -56,7 +57,7 @@ func setupNavigationServiceFromConfig(t *testing.T, configFilename string) (navi
 	t.Helper()
 	ctx := context.Background()
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(ctx, configFilename, logger)
+	cfg, err := config.Read(ctx, configFilename, logger, &grpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, cfg.Ensure(false, logger), test.ShouldBeNil)
 	myRobot, err := robotimpl.New(ctx, cfg, logger)
@@ -593,7 +594,7 @@ func TestNavSetUpFromFaultyConfig(t *testing.T) {
 	ctx := context.Background()
 	logger := logging.NewTestLogger(t)
 	for _, tc := range testCases {
-		cfg, err := config.Read(ctx, tc.configPath, logger)
+		cfg, err := config.Read(ctx, tc.configPath, logger, &grpc.AppConn{})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, cfg.Ensure(false, logger), test.ShouldBeNil)
 		myRobot, err := robotimpl.New(ctx, cfg, logger)

--- a/services/navigation/builtin/builtin_test.go
+++ b/services/navigation/builtin/builtin_test.go
@@ -23,7 +23,6 @@ import (
 	"go.viam.com/rdk/components/movementsensor"
 	_ "go.viam.com/rdk/components/movementsensor/fake"
 	"go.viam.com/rdk/config"
-	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/motionplan"
 	"go.viam.com/rdk/pointcloud"
@@ -57,7 +56,7 @@ func setupNavigationServiceFromConfig(t *testing.T, configFilename string) (navi
 	t.Helper()
 	ctx := context.Background()
 	logger := logging.NewTestLogger(t)
-	cfg, err := config.Read(ctx, configFilename, logger, &grpc.AppConn{})
+	cfg, err := config.Read(ctx, configFilename, logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, cfg.Ensure(false, logger), test.ShouldBeNil)
 	myRobot, err := robotimpl.New(ctx, cfg, logger)
@@ -594,7 +593,7 @@ func TestNavSetUpFromFaultyConfig(t *testing.T) {
 	ctx := context.Background()
 	logger := logging.NewTestLogger(t)
 	for _, tc := range testCases {
-		cfg, err := config.Read(ctx, tc.configPath, logger, &grpc.AppConn{})
+		cfg, err := config.Read(ctx, tc.configPath, logger, nil)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, cfg.Ensure(false, logger), test.ShouldBeNil)
 		myRobot, err := robotimpl.New(ctx, cfg, logger)

--- a/utils/contextutils/context.go
+++ b/utils/contextutils/context.go
@@ -35,14 +35,6 @@ const (
 	initialReadTimeout     = 1 * time.Second
 )
 
-// ViamDotDir is the directory for Viam's cached files.
-var ViamDotDir string
-
-func init() {
-	home := utils.PlatformHomeDir()
-	ViamDotDir = filepath.Join(home, ".viam")
-}
-
 // ContextWithMetadata attaches a metadata map to the context.
 func ContextWithMetadata(ctx context.Context) (context.Context, map[string][]string) {
 	// If the context already has metadata, return that and leave the context untouched.
@@ -107,7 +99,7 @@ func GetTimeoutCtx(ctx context.Context, shouldReadFromCache bool, id string) (co
 	// if cached config exists
 	cachedConfigExists := false
 	cloudCacheFilepath := fmt.Sprintf("cached_cloud_config_%s.json", id)
-	if _, err := os.Stat(filepath.Join(ViamDotDir, cloudCacheFilepath)); err == nil {
+	if _, err := os.Stat(filepath.Join(utils.ViamDotDir, cloudCacheFilepath)); err == nil {
 		cachedConfigExists = true
 	}
 	if shouldReadFromCache && cachedConfigExists {

--- a/utils/contextutils/context.go
+++ b/utils/contextutils/context.go
@@ -35,11 +35,8 @@ const (
 	initialReadTimeout     = 1 * time.Second
 )
 
-var (
-	// ViamDotDir is the directory for Viam's cached files.
-	ViamDotDir      string
-	viamPackagesDir string
-)
+// ViamDotDir is the directory for Viam's cached files.
+var ViamDotDir string
 
 func init() {
 	home := utils.PlatformHomeDir()

--- a/utils/env.go
+++ b/utils/env.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"os"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"slices"
@@ -63,6 +64,8 @@ var EnvTrueValues = []string{"true", "yes", "1", "TRUE", "YES"}
 
 // TCPRegex tests whether a module address is TCP (vs unix sockets). See also ViamTCPSockets().
 var TCPRegex = regexp.MustCompile(`:\d+$`)
+
+var ViamDotDir = filepath.Join(PlatformHomeDir(), ".viam")
 
 // GetResourceConfigurationTimeout calculates the resource configuration
 // timeout (env variable value if set, DefaultResourceConfigurationTimeout

--- a/utils/env.go
+++ b/utils/env.go
@@ -65,6 +65,7 @@ var EnvTrueValues = []string{"true", "yes", "1", "TRUE", "YES"}
 // TCPRegex tests whether a module address is TCP (vs unix sockets). See also ViamTCPSockets().
 var TCPRegex = regexp.MustCompile(`:\d+$`)
 
+// ViamDotDir is the directory for Viam's cached files.
 var ViamDotDir = filepath.Join(PlatformHomeDir(), ".viam")
 
 // GetResourceConfigurationTimeout calculates the resource configuration

--- a/vision/segmentation/debug_plane_segmentation_test.go
+++ b/vision/segmentation/debug_plane_segmentation_test.go
@@ -8,7 +8,6 @@ import (
 	"go.viam.com/test"
 
 	"go.viam.com/rdk/config"
-	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	pc "go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/rimage"
@@ -26,7 +25,7 @@ var (
 func TestPlaneSegmentImageAndDepthMap(t *testing.T) {
 	d := rimage.NewMultipleImageTestDebugger(t, "segmentation/planes/color", "*.png", "segmentation/planes/depth")
 	logger := logging.NewTestLogger(t)
-	config, err := config.Read(context.Background(), intelJSONPath, logger, &grpc.AppConn{})
+	config, err := config.Read(context.Background(), intelJSONPath, logger, nil)
 	test.That(t, err, test.ShouldBeNil)
 
 	c := config.FindComponent("front")

--- a/vision/segmentation/debug_plane_segmentation_test.go
+++ b/vision/segmentation/debug_plane_segmentation_test.go
@@ -8,6 +8,7 @@ import (
 	"go.viam.com/test"
 
 	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	pc "go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/rimage"
@@ -25,7 +26,7 @@ var (
 func TestPlaneSegmentImageAndDepthMap(t *testing.T) {
 	d := rimage.NewMultipleImageTestDebugger(t, "segmentation/planes/color", "*.png", "segmentation/planes/depth")
 	logger := logging.NewTestLogger(t)
-	config, err := config.Read(context.Background(), intelJSONPath, logger)
+	config, err := config.Read(context.Background(), intelJSONPath, logger, &grpc.AppConn{})
 	test.That(t, err, test.ShouldBeNil)
 
 	c := config.FindComponent("front")

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -1,6 +1,8 @@
 // Package server implements the entry point for running a robot web server.
 package server
 
+// TODO: use global connection in config watcher
+
 import (
 	"cmp"
 	"context"

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -1,8 +1,6 @@
 // Package server implements the entry point for running a robot web server.
 package server
 
-// TODO: use global connection in config watcher
-
 import (
 	"cmp"
 	"context"
@@ -544,7 +542,7 @@ func (s *robotServer) serveWeb(ctx context.Context, cfg *config.Config) (err err
 	}()
 
 	// watch for and deliver changes to the robot
-	watcher, err := config.NewWatcher(ctx, cfg, s.logger.Sublogger("config"))
+	watcher, err := config.NewWatcher(ctx, cfg, s.logger.Sublogger("config"), s.conn) // TODO(bashar)
 	if err != nil {
 		cancel()
 		return err

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -177,7 +177,7 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 
 	// Read the config from disk and use it to initialize the remote logger.
 	initialReadCtx, cancel := context.WithTimeout(ctx, time.Second*5)
-	cfgFromDisk, err := config.ReadLocalConfig(initialReadCtx, argsParsed.ConfigFile, logger.Sublogger("config"), appConn)
+	cfgFromDisk, err := config.ReadLocalConfig(initialReadCtx, argsParsed.ConfigFile, logger.Sublogger("config"))
 	if err != nil {
 		cancel()
 		return err

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -1,8 +1,6 @@
 // Package server implements the entry point for running a robot web server.
 package server
 
-// TODO(RSDK-8296): use global connection to App in first config/cert retrieval
-
 import (
 	"cmp"
 	"context"

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -1,6 +1,8 @@
 // Package server implements the entry point for running a robot web server.
 package server
 
+// TODO(RSDK-8296): use global connection to App in first config/cert retrieval
+
 import (
 	"cmp"
 	"context"

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -544,7 +544,7 @@ func (s *robotServer) serveWeb(ctx context.Context, cfg *config.Config) (err err
 	}()
 
 	// watch for and deliver changes to the robot
-	watcher, err := config.NewWatcher(ctx, cfg, s.logger.Sublogger("config"), s.conn) // TODO(bashar)
+	watcher, err := config.NewWatcher(ctx, cfg, s.logger.Sublogger("config"), s.conn)
 	if err != nil {
 		cancel()
 		return err

--- a/web/server/entrypoint_test.go
+++ b/web/server/entrypoint_test.go
@@ -28,6 +28,7 @@ import (
 	"go.viam.com/rdk/components/generic"
 	_ "go.viam.com/rdk/components/register"
 	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot"
@@ -51,7 +52,7 @@ func TestEntrypoint(t *testing.T) {
 	t.Run("number of resources", func(t *testing.T) {
 		logger, logObserver := logging.NewObservedTestLogger(t)
 		cfgFilename := utils.ResolveFile("/etc/configs/fake.json")
-		cfg, err := config.Read(context.Background(), cfgFilename, logger)
+		cfg, err := config.Read(context.Background(), cfgFilename, logger, &grpc.AppConn{})
 		test.That(t, err, test.ShouldBeNil)
 
 		var port int
@@ -134,7 +135,7 @@ func TestShutdown(t *testing.T) {
 		serverLogObserver := serverLogger.Observer
 
 		cfgFilename := utils.ResolveFile("/etc/configs/fake.json")
-		cfg, err := config.Read(context.Background(), cfgFilename, testLogger)
+		cfg, err := config.Read(context.Background(), cfgFilename, testLogger, &grpc.AppConn{})
 		test.That(t, err, test.ShouldBeNil)
 
 		var port int

--- a/web/server/entrypoint_test.go
+++ b/web/server/entrypoint_test.go
@@ -28,7 +28,6 @@ import (
 	"go.viam.com/rdk/components/generic"
 	_ "go.viam.com/rdk/components/register"
 	"go.viam.com/rdk/config"
-	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot"
@@ -52,7 +51,7 @@ func TestEntrypoint(t *testing.T) {
 	t.Run("number of resources", func(t *testing.T) {
 		logger, logObserver := logging.NewObservedTestLogger(t)
 		cfgFilename := utils.ResolveFile("/etc/configs/fake.json")
-		cfg, err := config.Read(context.Background(), cfgFilename, logger, &grpc.AppConn{})
+		cfg, err := config.Read(context.Background(), cfgFilename, logger, nil)
 		test.That(t, err, test.ShouldBeNil)
 
 		var port int
@@ -135,7 +134,7 @@ func TestShutdown(t *testing.T) {
 		serverLogObserver := serverLogger.Observer
 
 		cfgFilename := utils.ResolveFile("/etc/configs/fake.json")
-		cfg, err := config.Read(context.Background(), cfgFilename, testLogger, &grpc.AppConn{})
+		cfg, err := config.Read(context.Background(), cfgFilename, testLogger, nil)
 		test.That(t, err, test.ShouldBeNil)
 
 		var port int


### PR DESCRIPTION
This PR propagates the global connection to App that's instantiated in viam-server's entrypoint down to the function actually used by the config watcher to retrieve a new config. Before, this function would create and manage its own connection to App. Now, it receives a preexisting connection as a function parameter. The changes made here resulted in many modified function signatures, so lots of tests had to be edited to pass a connection even if not ultimately used (i.e., a config is being retrieved locally). In these test files, I simply pass in an empty `&grpc.AppConn{}`. This suffices because, again, the connection does not get used in the code path used by the test. In the few instances that it _is_ used (usually when a mock server is spun up to deliver the config), I use the proper AppConn constructor and defer its closing.

For what's its worth, I've gone through the PR and marked the actual core functionality changes (i.e., _not_ the test changes that are a mere side effect).

**Testing** RDK successfully reconfigures after config update following various combinations of connecting to/disconnecting from the internet.