### PR TITLE
DATA-3698: fix weird file path behavior with export

### DIFF
--- a/cli/data.go
+++ b/cli/data.go
@@ -673,7 +673,13 @@ func filenameForDownload(meta *datapb.BinaryMetadata) string {
 	// that directory. Otherwise, the file will be hidden due to the .viam directory.
 	// Use ReplaceAll rather than TrimPrefix since it will be stored under os.Getenv("HOME"), which differs between upload
 	// to export time.
-	fileName = strings.ReplaceAll(fileName, viamCaptureDotSubdir, "")
+	if strings.HasPrefix(fileName, viamCaptureDotSubdir) {
+		// If it's the first occurrence, remove it
+		fileName = strings.Replace(fileName, viamCaptureDotSubdir, "", 1)
+	}
+
+	// Otherwise, replace with "/"
+	fileName = strings.ReplaceAll(fileName, viamCaptureDotSubdir, "/")
 
 	// The file name will end with .gz if the user uploaded a gzipped file. We will unzip it below, so remove the last
 	// .gz from the file name. If the user has gzipped the file multiple times, we will only unzip once.

--- a/cli/data.go
+++ b/cli/data.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -46,6 +47,8 @@ const (
 
 	noExistingADFErrCode = "NotFound"
 )
+
+var viamCaptureSubdirPattern = regexp.MustCompile(`.*` + viamCaptureDotSubdir)
 
 type commonFilterArgs struct {
 	OrgIDs        []string
@@ -670,16 +673,10 @@ func filenameForDownload(meta *datapb.BinaryMetadata) string {
 	}
 
 	// If the file name is not a data capture file but was manually saved in the default viam capture directory, remove
-	// that directory. Otherwise, the file will be hidden due to the .viam directory.
+	// that directory + home directories. Otherwise, the file will be hidden due to the .viam directory.
 	// Use ReplaceAll rather than TrimPrefix since it will be stored under os.Getenv("HOME"), which differs between upload
 	// to export time.
-	if strings.HasPrefix(fileName, viamCaptureDotSubdir) {
-		// If it's the first occurrence, remove it
-		fileName = strings.Replace(fileName, viamCaptureDotSubdir, "", 1)
-	}
-
-	// Otherwise, replace with "/"
-	fileName = strings.ReplaceAll(fileName, viamCaptureDotSubdir, "/")
+	fileName = viamCaptureSubdirPattern.ReplaceAllString(fileName, "")
 
 	// The file name will end with .gz if the user uploaded a gzipped file. We will unzip it below, so remove the last
 	// .gz from the file name. If the user has gzipped the file multiple times, we will only unzip once.

--- a/cli/data_test.go
+++ b/cli/data_test.go
@@ -24,6 +24,9 @@ func TestFilenameForDownload(t *testing.T) {
 	nestedViamCaptureFolder := filenameForDownload(&datapb.BinaryMetadata{FileName: "Users/hi/.viam/capture/2024-01-30Twhatever.jpg"})
 	test.That(t, nestedViamCaptureFolder, test.ShouldEqual, "2024-01-30Twhatever.jpg")
 
+	nestedDirViamCaptureFolder := filenameForDownload(&datapb.BinaryMetadata{FileName: "Users/hi/.viam/capture/dir/2024-01-30Twhatever.jpg"})
+	test.That(t, nestedDirViamCaptureFolder, test.ShouldEqual, "dir/2024-01-30Twhatever.jpg")
+
 	gzAtRoot := filenameForDownload(&datapb.BinaryMetadata{FileName: "whatever.gz"})
 	test.That(t, gzAtRoot, test.ShouldEqual, expectedUTC+"_whatever")
 

--- a/cli/data_test.go
+++ b/cli/data_test.go
@@ -22,7 +22,7 @@ func TestFilenameForDownload(t *testing.T) {
 	test.That(t, inViamCaptureFolder, test.ShouldEqual, "2024-01-30Twhatever.jpg")
 
 	nestedViamCaptureFolder := filenameForDownload(&datapb.BinaryMetadata{FileName: "Users/hi/.viam/capture/2024-01-30Twhatever.jpg"})
-	test.That(t, nestedViamCaptureFolder, test.ShouldEqual, "Users/hi/2024-01-30Twhatever.jpg")
+	test.That(t, nestedViamCaptureFolder, test.ShouldEqual, "2024-01-30Twhatever.jpg")
 
 	gzAtRoot := filenameForDownload(&datapb.BinaryMetadata{FileName: "whatever.gz"})
 	test.That(t, gzAtRoot, test.ShouldEqual, expectedUTC+"_whatever")

--- a/cli/data_test.go
+++ b/cli/data_test.go
@@ -21,6 +21,9 @@ func TestFilenameForDownload(t *testing.T) {
 	inViamCaptureFolder := filenameForDownload(&datapb.BinaryMetadata{FileName: "/.viam/capture/2024-01-30Twhatever.jpg"})
 	test.That(t, inViamCaptureFolder, test.ShouldEqual, "2024-01-30Twhatever.jpg")
 
+	nestedViamCaptureFolder := filenameForDownload(&datapb.BinaryMetadata{FileName: "Users/hi/.viam/capture/2024-01-30Twhatever.jpg"})
+	test.That(t, nestedViamCaptureFolder, test.ShouldEqual, "Users/hi/2024-01-30Twhatever.jpg")
+
 	gzAtRoot := filenameForDownload(&datapb.BinaryMetadata{FileName: "whatever.gz"})
 	test.That(t, gzAtRoot, test.ShouldEqual, expectedUTC+"_whatever")
 


### PR DESCRIPTION
If user wants to upload an arbitrary file with a filepath that contains a `/.viam/capture/` in the middle, ie Users/gloriacai/.viam/capture/123,  it would download as data/Users/gloriacai123. This PR fixes this missing backslash issue and removes the preceding directories for the /.viam/capture/ case.

Testing:
- added some testcases with nested ./viam/capture directories
- uploaded a file with filepath Users/gloriacai/.viam/capture/123, ran `go run cli/viam/main.go data export binary --destination="." --start=2025-02-06T14:00:00Z` and checked that the file downloaded directly inside the data folder.