### PR TITLE
DATA-3399: Dataset Data Remove Functions

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -1463,7 +1463,8 @@ var app = &cli.App{
 										&cli.StringSliceFlag{
 											Name: generalFlagTags,
 											Usage: "tags filter. " +
-												"accepts 'tagged' for all tagged data, 'untagged' for all untagged data, or a list of tags for all data matching any of the tags",
+												"accepts 'tagged' for all tagged data, 'untagged' for all untagged data, " +
+												"or a list of tags for all data matching any of the tags",
 										},
 									},
 										commonFilterFlags...),
@@ -1520,7 +1521,8 @@ var app = &cli.App{
 										&cli.StringSliceFlag{
 											Name: generalFlagTags,
 											Usage: "tags filter. " +
-												"accepts 'tagged' for all tagged data, 'untagged' for all untagged data, or a list of tags for all data matching any of the tags",
+												"accepts 'tagged' for all tagged data, 'untagged' for all untagged data, " +
+												"or a list of tags for all data matching any of the tags",
 										},
 									},
 										commonFilterFlags...),

--- a/cli/app.go
+++ b/cli/app.go
@@ -1414,6 +1414,7 @@ var app = &cli.App{
 					UsageText:       createUsageText("dataset data", nil, false, true),
 					HideHelpCommand: true,
 					Subcommands: []*cli.Command{
+						//nolint:dupl
 						{
 							Name:            "add",
 							Usage:           "adds binary data either by IDs or filter to dataset",
@@ -1472,6 +1473,7 @@ var app = &cli.App{
 								},
 							},
 						},
+						//nolint:dupl
 						{
 							Name:            "remove",
 							Usage:           "removes binary data either by IDs or filter from dataset",

--- a/cli/app.go
+++ b/cli/app.go
@@ -239,7 +239,7 @@ var dataTagByFilterFlags = append([]cli.Flag{
 	&cli.StringSliceFlag{
 		Name: dataFlagFilterTags,
 		Usage: "tags filter. " +
-			"accepts tagged for all tagged data, untagged for all untagged data, or a list of tags for all data matching any of the tags",
+			"accepts 'tagged' for all tagged data, 'untagged' for all untagged data, or a list of tags for all data matching any of the tags",
 	},
 },
 	commonFilterFlags...)
@@ -1053,7 +1053,7 @@ var app = &cli.App{
 								},
 								&cli.StringSliceFlag{
 									Name:  generalFlagTags,
-									Usage: "tags filter. accepts tagged for all tagged data, untagged for all untagged data, or a list of tags",
+									Usage: "tags filter. accepts 'tagged' for all tagged data, 'untagged' for all untagged data, or a list of tags",
 								},
 							}, commonFilterFlags...),
 							Action: createCommandWithT[dataExportBinaryArgs](DataExportBinaryAction),
@@ -1452,7 +1452,7 @@ var app = &cli.App{
 								},
 								{
 									Name:      "filter",
-									Usage:     "adds binary data from the specified filter to dataset",
+									Usage:     "adds binary data associated with a filter to a dataset",
 									UsageText: createUsageText("dataset data add filter", []string{datasetFlagDatasetID}, true, false),
 									Flags: append([]cli.Flag{
 										&cli.StringFlag{
@@ -1463,7 +1463,7 @@ var app = &cli.App{
 										&cli.StringSliceFlag{
 											Name: generalFlagTags,
 											Usage: "tags filter. " +
-												"accepts tagged for all tagged data, untagged for all untagged data, or a list of tags for all data matching any of the tags",
+												"accepts 'tagged' for all tagged data, 'untagged' for all untagged data, or a list of tags for all data matching any of the tags",
 										},
 									},
 										commonFilterFlags...),
@@ -1478,7 +1478,8 @@ var app = &cli.App{
 							HideHelpCommand: true,
 							Subcommands: []*cli.Command{
 								{
-									Name: "ids",
+									Name:  "ids",
+									Usage: "removes binary data with file IDs in a single org and location from a dataset",
 									UsageText: createUsageText(
 										"dataset data remove ids", []string{datasetFlagDatasetID, generalFlagOrgID, dataFlagLocationID, dataFlagFileIDs}, false, false,
 									),
@@ -1508,7 +1509,7 @@ var app = &cli.App{
 								},
 								{
 									Name:      "filter",
-									Usage:     "removes binary data from the specified filter from dataset",
+									Usage:     "removes binary data associated with a filter from a dataset",
 									UsageText: createUsageText("dataset data remove filter", []string{datasetFlagDatasetID}, true, false),
 									Flags: append([]cli.Flag{
 										&cli.StringFlag{
@@ -1519,7 +1520,7 @@ var app = &cli.App{
 										&cli.StringSliceFlag{
 											Name: generalFlagTags,
 											Usage: "tags filter. " +
-												"accepts tagged for all tagged data, untagged for all untagged data, or a list of tags for all data matching any of the tags",
+												"accepts 'tagged' for all tagged data, 'untagged' for all untagged data, or a list of tags for all data matching any of the tags",
 										},
 									},
 										commonFilterFlags...),

--- a/cli/app.go
+++ b/cli/app.go
@@ -1472,34 +1472,60 @@ var app = &cli.App{
 							},
 						},
 						{
-							Name:  "remove",
-							Usage: "removes binary data with file IDs in a single org and location from dataset",
-							UsageText: createUsageText(
-								"dataset data remove", []string{datasetFlagDatasetID, generalFlagOrgID, dataFlagLocationID, dataFlagFileIDs}, false, false,
-							),
-							Flags: []cli.Flag{
-								&cli.StringFlag{
-									Name:     datasetFlagDatasetID,
-									Usage:    "dataset ID from which data will be removed",
-									Required: true,
+							Name:            "remove",
+							Usage:           "removes binary data either by IDs or filter from dataset",
+							UsageText:       createUsageText("dataset data remove", nil, false, true),
+							HideHelpCommand: true,
+							Subcommands: []*cli.Command{
+								{
+									Name: "ids",
+									UsageText: createUsageText(
+										"dataset data remove ids", []string{datasetFlagDatasetID, generalFlagOrgID, dataFlagLocationID, dataFlagFileIDs}, false, false,
+									),
+									Flags: []cli.Flag{
+										&cli.StringFlag{
+											Name:     datasetFlagDatasetID,
+											Usage:    "dataset ID from which data will be removed",
+											Required: true,
+										},
+										&cli.StringFlag{
+											Name:     generalFlagOrgID,
+											Usage:    "org ID to which data belongs",
+											Required: true,
+										},
+										&cli.StringFlag{
+											Name:     dataFlagLocationID,
+											Usage:    "location ID to which data belongs",
+											Required: true,
+										},
+										&cli.StringSliceFlag{
+											Name:     dataFlagFileIDs,
+											Usage:    "file IDs of data belonging to specified org and location",
+											Required: true,
+										},
+									},
+									Action: createCommandWithT[dataRemoveFromDatasetArgs](DataRemoveFromDataset),
 								},
-								&cli.StringFlag{
-									Name:     generalFlagOrgID,
-									Usage:    "org ID to which data belongs",
-									Required: true,
-								},
-								&cli.StringFlag{
-									Name:     dataFlagLocationID,
-									Usage:    "location ID to which data belongs",
-									Required: true,
-								},
-								&cli.StringSliceFlag{
-									Name:     dataFlagFileIDs,
-									Usage:    "file IDs of data belonging to specified org and location",
-									Required: true,
+								{
+									Name:      "filter",
+									Usage:     "removes binary data from the specified filter from dataset",
+									UsageText: createUsageText("dataset data remove filter", []string{datasetFlagDatasetID}, true, false),
+									Flags: append([]cli.Flag{
+										&cli.StringFlag{
+											Name:     datasetFlagDatasetID,
+											Usage:    "dataset ID from which data will be removed",
+											Required: true,
+										},
+										&cli.StringSliceFlag{
+											Name: generalFlagTags,
+											Usage: "tags filter. " +
+												"accepts tagged for all tagged data, untagged for all untagged data, or a list of tags for all data matching any of the tags",
+										},
+									},
+										commonFilterFlags...),
+									Action: createCommandWithT[dataRemoveFromDatasetByFilterArgs](DataRemoveFromDatasetByFilter),
 								},
 							},
-							Action: createCommandWithT[dataRemoveFromDatasetArgs](DataRemoveFromDataset),
 						},
 					},
 				},

--- a/cli/data.go
+++ b/cli/data.go
@@ -1025,7 +1025,7 @@ type dataRemoveFromDatasetArgs struct {
 	FileIDs    []string
 }
 
-// DataRemoveFromDataset is the corresponding action for 'data dataset remove'.
+// DataRemoveFromDataset is the corresponding action for 'data dataset remove ids'.
 func DataRemoveFromDataset(c *cli.Context, args dataRemoveFromDatasetArgs) error {
 	client, err := newViamClient(c)
 	if err != nil {

--- a/cli/data.go
+++ b/cli/data.go
@@ -1076,6 +1076,7 @@ func DataRemoveFromDatasetByFilter(c *cli.Context, args dataRemoveFromDatasetByF
 		return err
 	}
 
+	// set the dataset ID in the filter, so that we do not attempt to remove data that is not in the dataset
 	filter.DatasetId = args.DatasetID
 
 	if err := client.dataRemoveFromDatasetByFilter(filter, args.DatasetID); err != nil {

--- a/cli/data.go
+++ b/cli/data.go
@@ -944,7 +944,7 @@ type dataAddToDatasetByIDsArgs struct {
 	FileIDs    []string
 }
 
-// DataAddToDatasetByIDs is the corresponding action for 'data dataset add ids'.
+// DataAddToDatasetByIDs is the corresponding action for 'dataset data add ids'.
 func DataAddToDatasetByIDs(c *cli.Context, args dataAddToDatasetByIDsArgs) error {
 	client, err := newViamClient(c)
 	if err != nil {
@@ -983,7 +983,7 @@ type dataAddToDatasetByFilterArgs struct {
 	DatasetID string
 }
 
-// DataAddToDatasetByFilter is the corresponding action for 'data dataset add filter'.
+// DataAddToDatasetByFilter is the corresponding action for 'dataset data add filter'.
 func DataAddToDatasetByFilter(c *cli.Context, args dataAddToDatasetByFilterArgs) error {
 	client, err := newViamClient(c)
 	if err != nil {
@@ -1025,7 +1025,7 @@ type dataRemoveFromDatasetArgs struct {
 	FileIDs    []string
 }
 
-// DataRemoveFromDataset is the corresponding action for 'data dataset remove ids'.
+// DataRemoveFromDataset is the corresponding action for 'dataset data remove ids'.
 func DataRemoveFromDataset(c *cli.Context, args dataRemoveFromDatasetArgs) error {
 	client, err := newViamClient(c)
 	if err != nil {
@@ -1065,7 +1065,7 @@ type dataRemoveFromDatasetByFilterArgs struct {
 	DatasetID string
 }
 
-// DataRemoveFromDatasetByFilter is the corresponding action for 'data dataset remove filter'.
+// DataRemoveFromDatasetByFilter is the corresponding action for 'dataset data remove filter'.
 func DataRemoveFromDatasetByFilter(c *cli.Context, args dataRemoveFromDatasetByFilterArgs) error {
 	client, err := newViamClient(c)
 	if err != nil {


### PR DESCRIPTION
- Renames `dataset data remove` to `dataset data remove ids` 
- Creates new command `dataset data remove filter`

Manually tested:
`viam dataset data add ids --dataset-id=67a512205da1bc26ca01cd5a --location-id=nihu6z0k8c --org-id=0fbe951e-d4c6-427f-985f-784b7b85842c --file-ids=rXu0LkivJtEZojTkmO86xdy5Ft3QovKQfYo17a6EsCNhgCPngHGgab9zj6jCpwLK,9kw4DyE5qxYai0c86xzXXyQNnpN2K26FKT3UzM68WdwmhB4zNValb4bSKkvl7b5V`

<img width="1165" alt="Screenshot 2025-02-06 at 3 59 42 PM" src="https://github.com/user-attachments/assets/ee9d519e-7f39-4a13-88e5-773dd22e3a56" />

`viam dataset data remove filter --dataset-id=67a512205da1bc26ca01cd5a --location-ids=nihu6z0k8c --start=2023-01-01T05:00:00.000Z --end=2024-10-01T04:00:00.000Z --tags=blue_star`
<img width="1182" alt="Screenshot 2025-02-06 at 3 56 20 PM" src="https://github.com/user-attachments/assets/e0228244-dd2c-408c-9442-b12ae42089b5" />
- Both commands correctly add and remove images from dataset