### PR TITLE
RSDK-9884 - support invisible aliases

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -907,10 +907,12 @@ var app = &cli.App{
 					// use custom usage text to show default organization flag usage even if it isn't required
 					UsageText: "viam locations list [--organization=<organization>]",
 					Flags: []cli.Flag{
-						&cli.StringFlag{
-							Name:        generalFlagOrganization,
-							Aliases:     []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
-							DefaultText: "first organization alphabetically",
+						&AliasStringFlag{
+							cli.StringFlag{
+								Name:        generalFlagOrganization,
+								Aliases:     []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
+								DefaultText: "first organization alphabetically",
+							},
 						},
 					},
 					Action: createCommandWithT[listLocationsArgs](ListLocationsAction),
@@ -1752,15 +1754,19 @@ var app = &cli.App{
 					Usage:     "list machines in an organization and location",
 					UsageText: createUsageText("machines list", nil, true, false),
 					Flags: []cli.Flag{
-						&cli.StringFlag{
-							Name:        generalFlagOrganization,
-							Aliases:     []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
-							DefaultText: "first organization alphabetically",
+						&AliasStringFlag{
+							cli.StringFlag{
+								Name:        generalFlagOrganization,
+								Aliases:     []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
+								DefaultText: "first organization alphabetically",
+							},
 						},
-						&cli.StringFlag{
-							Name:        generalFlagLocation,
-							Aliases:     []string{generalFlagLocationID, generalFlagAliasLocationName},
-							DefaultText: "first location alphabetically",
+						&AliasStringFlag{
+							cli.StringFlag{
+								Name:        generalFlagLocation,
+								Aliases:     []string{generalFlagLocationID, generalFlagAliasLocationName},
+								DefaultText: "first location alphabetically",
+							},
 						},
 					},
 					Action: createCommandWithT[listRobotsActionArgs](ListRobotsAction),
@@ -1811,15 +1817,19 @@ var app = &cli.App{
 								Required: true,
 							},
 						},
-						&cli.StringFlag{
-							Name:        generalFlagOrganization,
-							Aliases:     []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
-							DefaultText: "first organization alphabetically",
+						&AliasStringFlag{
+							cli.StringFlag{
+								Name:        generalFlagOrganization,
+								Aliases:     []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
+								DefaultText: "first organization alphabetically",
+							},
 						},
-						&cli.StringFlag{
-							Name:        generalFlagLocation,
-							Aliases:     []string{generalFlagLocationID, generalFlagAliasLocationName},
-							DefaultText: "first location alphabetically",
+						&AliasStringFlag{
+							cli.StringFlag{
+								Name:        generalFlagLocation,
+								Aliases:     []string{generalFlagLocationID, generalFlagAliasLocationName},
+								DefaultText: "first location alphabetically",
+							},
 						},
 					},
 					Action: createCommandWithT[robotsStatusArgs](RobotsStatusAction),
@@ -1837,15 +1847,19 @@ var app = &cli.App{
 								Required: true,
 							},
 						},
-						&cli.StringFlag{
-							Name:        generalFlagOrganization,
-							Aliases:     []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
-							DefaultText: "first organization alphabetically",
+						&AliasStringFlag{
+							cli.StringFlag{
+								Name:        generalFlagOrganization,
+								Aliases:     []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
+								DefaultText: "first organization alphabetically",
+							},
 						},
-						&cli.StringFlag{
-							Name:        generalFlagLocation,
-							Aliases:     []string{generalFlagLocationID, generalFlagAliasLocationName},
-							DefaultText: "first location alphabetically",
+						&AliasStringFlag{
+							cli.StringFlag{
+								Name:        generalFlagLocation,
+								Aliases:     []string{generalFlagLocationID, generalFlagAliasLocationName},
+								DefaultText: "first location alphabetically",
+							},
 						},
 						&cli.StringFlag{
 							Name:  logsFlagOutputFile,
@@ -1897,15 +1911,19 @@ var app = &cli.App{
 										Required: true,
 									},
 								},
-								&cli.StringFlag{
-									Name:        generalFlagOrganization,
-									Aliases:     []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
-									DefaultText: "first organization alphabetically",
+								&AliasStringFlag{
+									cli.StringFlag{
+										Name:        generalFlagOrganization,
+										Aliases:     []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
+										DefaultText: "first organization alphabetically",
+									},
 								},
-								&cli.StringFlag{
-									Name:        generalFlagLocation,
-									Aliases:     []string{generalFlagLocationID, generalFlagAliasLocationName},
-									DefaultText: "first location alphabetically",
+								&AliasStringFlag{
+									cli.StringFlag{
+										Name:        generalFlagLocation,
+										Aliases:     []string{generalFlagLocationID, generalFlagAliasLocationName},
+										DefaultText: "first location alphabetically",
+									},
 								},
 								&AliasStringFlag{
 									cli.StringFlag{
@@ -1929,15 +1947,19 @@ var app = &cli.App{
 										Required: true,
 									},
 								},
-								&cli.StringFlag{
-									Name:        generalFlagOrganization,
-									Aliases:     []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
-									DefaultText: "first organization alphabetically",
+								&AliasStringFlag{
+									cli.StringFlag{
+										Name:        generalFlagOrganization,
+										Aliases:     []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
+										DefaultText: "first organization alphabetically",
+									},
 								},
-								&cli.StringFlag{
-									Name:        generalFlagLocation,
-									Aliases:     []string{generalFlagLocationID, generalFlagAliasLocationName},
-									DefaultText: "first location alphabetically",
+								&AliasStringFlag{
+									cli.StringFlag{
+										Name:        generalFlagLocation,
+										Aliases:     []string{generalFlagLocationID, generalFlagAliasLocationName},
+										DefaultText: "first location alphabetically",
+									},
 								},
 								&AliasStringFlag{
 									cli.StringFlag{
@@ -1974,15 +1996,19 @@ var app = &cli.App{
 										Required: true,
 									},
 								},
-								&cli.StringFlag{
-									Name:        generalFlagOrganization,
-									Aliases:     []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
-									DefaultText: "first organization alphabetically",
+								&AliasStringFlag{
+									cli.StringFlag{
+										Name:        generalFlagOrganization,
+										Aliases:     []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
+										DefaultText: "first organization alphabetically",
+									},
 								},
-								&cli.StringFlag{
-									Name:        generalFlagLocation,
-									Aliases:     []string{generalFlagLocationID, generalFlagAliasLocationName},
-									DefaultText: "first location alphabetically",
+								&AliasStringFlag{
+									cli.StringFlag{
+										Name:        generalFlagLocation,
+										Aliases:     []string{generalFlagLocationID, generalFlagAliasLocationName},
+										DefaultText: "first location alphabetically",
+									},
 								},
 								&AliasStringFlag{
 									cli.StringFlag{
@@ -2048,18 +2074,24 @@ Organization and location are required flags if the machine/part name are not un
 `,
 							UsageText: createUsageText("machines part shell", []string{generalFlagPart}, false, false),
 							Flags: []cli.Flag{
-								&cli.StringFlag{
-									Name:     generalFlagPart,
-									Aliases:  []string{generalFlagPartID, generalFlagPartName},
-									Required: true,
+								&AliasStringFlag{
+									cli.StringFlag{
+										Name:     generalFlagPart,
+										Aliases:  []string{generalFlagPartID, generalFlagPartName},
+										Required: true,
+									},
 								},
-								&cli.StringFlag{
-									Name:    generalFlagOrganization,
-									Aliases: []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
+								&AliasStringFlag{
+									cli.StringFlag{
+										Name:    generalFlagOrganization,
+										Aliases: []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
+									},
 								},
-								&cli.StringFlag{
-									Name:    generalFlagLocation,
-									Aliases: []string{generalFlagLocationID, generalFlagAliasLocationName},
+								&AliasStringFlag{
+									cli.StringFlag{
+										Name:    generalFlagLocation,
+										Aliases: []string{generalFlagLocationID, generalFlagAliasLocationName},
+									},
 								},
 								&AliasStringFlag{
 									cli.StringFlag{
@@ -2111,13 +2143,17 @@ Copy multiple files from the machine to a local destination with recursion and k
 										Required: true,
 									},
 								},
-								&cli.StringFlag{
-									Name:    generalFlagOrganization,
-									Aliases: []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
+								&AliasStringFlag{
+									cli.StringFlag{
+										Name:    generalFlagOrganization,
+										Aliases: []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
+									},
 								},
-								&cli.StringFlag{
-									Name:    generalFlagLocation,
-									Aliases: []string{generalFlagLocationID, generalFlagAliasLocationName},
+								&AliasStringFlag{
+									cli.StringFlag{
+										Name:    generalFlagLocation,
+										Aliases: []string{generalFlagLocationID, generalFlagAliasLocationName},
+									},
 								},
 								&AliasStringFlag{
 									cli.StringFlag{

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -2,8 +2,9 @@ package cli
 
 import "github.com/urfave/cli/v2"
 
-// AliasStringFlag returns f.Name as the last member of Names(), which is useful if aliases shouldn't
-// be exposed to the user. Otherwise it is the same as cli.StringFlag.
+// AliasStringFlag returns f.Name as the last member of Names(), and hides aliases from the
+// String representation of the flag. This is useful for decluttering error messages and help
+// text when aliases shouldn't be exposed to the user. Otherwise it is the same as cli.StringFlag.
 type AliasStringFlag struct {
 	cli.StringFlag
 }
@@ -15,4 +16,12 @@ func (f AliasStringFlag) Names() []string {
 	names = append(names, f.Aliases...)
 	names = append(names, f.Name)
 	return cli.FlagNames(names[0], names[1:])
+}
+
+func (f *AliasStringFlag) String() string {
+	aliases := f.Aliases
+	f.Aliases = []string{}
+	s := cli.FlagStringer(f)
+	f.Aliases = aliases
+	return s
 }

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -18,6 +18,9 @@ func (f AliasStringFlag) Names() []string {
 	return cli.FlagNames(names[0], names[1:])
 }
 
+// String has to be overwritten to avoid cluttering help text with all aliases for a flag,
+// (e.g., `--organization, --org-id, --org-name, --org`). Instead, the string representation
+// includes just the expected, canonical flag name.
 func (f *AliasStringFlag) String() string {
 	aliases := f.Aliases
 	f.Aliases = []string{}

--- a/cli/flags_test.go
+++ b/cli/flags_test.go
@@ -13,8 +13,9 @@ func TestAliasStringFlag(t *testing.T) {
 			Name: "foo",
 		},
 	}
+	stringRepresentationWithoutAliases := f.StringFlag.String()
 	test.That(t, f.Names(), test.ShouldResemble, []string{"foo"})
-	test.That(t, f.String(), test.ShouldEqual, f.StringFlag.String())
+	test.That(t, f.String(), test.ShouldEqual, stringRepresentationWithoutAliases)
 
 	f = AliasStringFlag{
 		cli.StringFlag{
@@ -23,7 +24,7 @@ func TestAliasStringFlag(t *testing.T) {
 		},
 	}
 	test.That(t, f.Names(), test.ShouldResemble, []string{"hello", "foo"})
-	test.That(t, f.String(), test.ShouldEqual, f.StringFlag.String())
+	test.That(t, f.String(), test.ShouldEqual, stringRepresentationWithoutAliases)
 
 	f = AliasStringFlag{
 		cli.StringFlag{
@@ -32,5 +33,5 @@ func TestAliasStringFlag(t *testing.T) {
 		},
 	}
 	test.That(t, f.Names(), test.ShouldResemble, []string{"hello", "world", "foo"})
-	test.That(t, f.String(), test.ShouldEqual, f.StringFlag.String())
+	test.That(t, f.String(), test.ShouldEqual, stringRepresentationWithoutAliases)
 }


### PR DESCRIPTION
Updates the `String` method of `AliasStringFlag` to hide aliases, and ensures that `AliasStringFlag` is used consistently for `organization`, `location`, `machine`, and `part`.

Note: I opted to update `AliasStringFlag` rather than creating a new `InvisibleAliasStringFlag` type. My reasoning was 1) avoiding excessive type proliferation is a good thing, and 2) the only places `AliasStringFlag` was being used was for org/location/machine/part, so after this PR it wasn't actually being used anywhere. However, if in the future we have a string flag that is required and has aliases that we _don't_ want to hide in the help text, we may have to revisit. Happy to discuss the decision here if there's any pushback.

Tested locally to confirm the new help text, and to confirm that despite not appearing in help text, the aliases are still respected.

`viam machine part shell` the old way:
![Screenshot 2025-02-07 at 12 44 29](https://github.com/user-attachments/assets/2ced9835-7b8a-42dd-845a-90980a0d2c1f)

`viam machine part shell` the new way:
![Screenshot 2025-02-07 at 12 44 42](https://github.com/user-attachments/assets/3bb630eb-334c-442f-a412-681044872e59)

cc @JessamyT 