### PR TITLE
RSDK-9758 - refactor ensureLoggedIn call sites

### DIFF
--- a/cli/auth.go
+++ b/cli/auth.go
@@ -229,10 +229,6 @@ func PrintAccessTokenAction(cCtx *cli.Context, args emptyArgs) error {
 }
 
 func (c *viamClient) printAccessTokenAction(cCtx *cli.Context) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
-
 	if token, ok := c.conf.Auth.(*token); ok {
 		printf(cCtx.App.Writer, token.AccessToken)
 	} else {
@@ -312,9 +308,6 @@ func OrganizationsAPIKeyCreateAction(cCtx *cli.Context, args organizationsAPIKey
 }
 
 func (c *viamClient) organizationsAPIKeyCreateAction(cCtx *cli.Context, args organizationsAPIKeyCreateArgs) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
 	orgID := args.OrgID
 	keyName := args.Name
 	if keyName == "" {
@@ -333,10 +326,6 @@ func (c *viamClient) organizationsAPIKeyCreateAction(cCtx *cli.Context, args org
 }
 
 func (c *viamClient) createOrganizationAPIKey(orgID, keyName string) (*apppb.CreateKeyResponse, error) {
-	if err := c.ensureLoggedIn(); err != nil {
-		return nil, err
-	}
-
 	req := &apppb.CreateKeyRequest{
 		Authorizations: []*apppb.Authorization{
 			{
@@ -372,10 +361,6 @@ func LocationAPIKeyCreateAction(cCtx *cli.Context, args locationAPIKeyCreateArgs
 }
 
 func (c *viamClient) locationAPIKeyCreateAction(cCtx *cli.Context, args locationAPIKeyCreateArgs) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
-
 	locationID := args.LocationID
 	orgID := args.OrgID
 	keyName := args.Name
@@ -437,10 +422,6 @@ func RobotAPIKeyCreateAction(cCtx *cli.Context, args robotAPIKeyCreateArgs) erro
 }
 
 func (c *viamClient) robotAPIKeyCreateAction(cCtx *cli.Context, args robotAPIKeyCreateArgs) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
-
 	robotID := args.MachineID
 	keyName := args.Name
 	orgID := args.OrgID
@@ -595,9 +576,6 @@ func (c *viamClient) prepareDial(
 	orgStr, locStr, robotStr, partStr string,
 	debug bool,
 ) (context.Context, string, []rpc.DialOption, error) {
-	if err := c.ensureLoggedIn(); err != nil {
-		return nil, "", nil, err
-	}
 	if err := c.selectOrganization(orgStr); err != nil {
 		return nil, "", nil, err
 	}

--- a/cli/client.go
+++ b/cli/client.go
@@ -144,10 +144,6 @@ func OrganizationsSupportEmailSetAction(cCtx *cli.Context, args organizationsSup
 }
 
 func (c *viamClient) organizationsSupportEmailSetAction(cCtx *cli.Context, orgID, supportEmail string) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
-
 	_, err := c.client.OrganizationSetSupportEmail(c.c.Context, &apppb.OrganizationSetSupportEmailRequest{
 		OrgId: orgID,
 		Email: supportEmail,
@@ -179,10 +175,6 @@ func OrganizationsSupportEmailGetAction(cCtx *cli.Context, args organizationsSup
 }
 
 func (c *viamClient) organizationsSupportEmailGetAction(cCtx *cli.Context, orgID string) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
-
 	resp, err := c.client.OrganizationGetSupportEmail(c.c.Context, &apppb.OrganizationGetSupportEmailRequest{
 		OrgId: orgID,
 	})
@@ -240,10 +232,6 @@ func (c *viamClient) disableAuthServiceAction(cCtx *cli.Context, orgID string) e
 		return errors.New("cannot disable auth service without an organization ID")
 	}
 
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
-
 	if _, err := c.client.DisableAuthService(cCtx.Context, &apppb.DisableAuthServiceRequest{OrgId: orgID}); err != nil {
 		return err
 	}
@@ -272,10 +260,6 @@ func EnableAuthServiceAction(cCtx *cli.Context, args enableAuthServiceArgs) erro
 }
 
 func (c *viamClient) enableAuthServiceAction(cCtx *cli.Context, orgID string) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
-
 	_, err := c.client.EnableAuthService(cCtx.Context, &apppb.EnableAuthServiceRequest{OrgId: orgID})
 	if err != nil {
 		return err
@@ -310,9 +294,6 @@ func UpdateBillingServiceAction(cCtx *cli.Context, args updateBillingServiceArgs
 }
 
 func (c *viamClient) updateBillingServiceAction(cCtx *cli.Context, orgID, addressAsString string) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
 	address, err := parseBillingAddress(addressAsString)
 	if err != nil {
 		return err
@@ -353,10 +334,6 @@ func GetBillingConfigAction(cCtx *cli.Context, args getBillingConfigArgs) error 
 }
 
 func (c *viamClient) getBillingConfig(cCtx *cli.Context, orgID string) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
-
 	resp, err := c.client.GetBillingServiceConfig(cCtx.Context, &apppb.GetBillingServiceConfigRequest{
 		OrgId: orgID,
 	})
@@ -409,10 +386,6 @@ func OrganizationEnableBillingServiceAction(cCtx *cli.Context, args organization
 }
 
 func (c *viamClient) organizationEnableBillingServiceAction(cCtx *cli.Context, orgID, addressAsString string) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
-
 	address, err := parseBillingAddress(addressAsString)
 	if err != nil {
 		return err
@@ -447,10 +420,6 @@ func OrganizationDisableBillingServiceAction(cCtx *cli.Context, args organizatio
 }
 
 func (c *viamClient) organizationDisableBillingServiceAction(cCtx *cli.Context, orgID string) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
-
 	if _, err := c.client.DisableBillingService(cCtx.Context, &apppb.DisableBillingServiceRequest{
 		OrgId: orgID,
 	}); err != nil {
@@ -486,10 +455,6 @@ func OrganizationLogoSetAction(cCtx *cli.Context, args organizationsLogoSetArgs)
 }
 
 func (c *viamClient) organizationLogoSetAction(cCtx *cli.Context, orgID, logoFilePath string) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
-
 	logoFile, err := os.Open(filepath.Clean(logoFilePath))
 	if err != nil {
 		return errors.WithMessagef(err, "could not open logo file: %s", logoFilePath)
@@ -542,10 +507,6 @@ func OrganizationsLogoGetAction(cCtx *cli.Context, args organizationsLogoGetArgs
 }
 
 func (c *viamClient) organizationsLogoGetAction(cCtx *cli.Context, orgID string) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
-
 	resp, err := c.client.OrganizationGetLogo(cCtx.Context, &apppb.OrganizationGetLogoRequest{
 		OrgId: orgID,
 	})
@@ -582,10 +543,6 @@ func ListOAuthAppsAction(cCtx *cli.Context, args listOAuthAppsArgs) error {
 }
 
 func (c *viamClient) listOAuthAppsAction(cCtx *cli.Context, orgID string) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
-
 	resp, err := c.client.ListOAuthApps(cCtx.Context, &apppb.ListOAuthAppsRequest{
 		OrgId: orgID,
 	})
@@ -1422,10 +1379,6 @@ func tunnelTraffic(ctx *cli.Context, robotClient *client.RobotClient, local, des
 }
 
 func (c *viamClient) robotPartTunnel(cCtx *cli.Context, args robotsPartTunnelArgs) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
-
 	orgStr := args.Organization
 	locStr := args.Location
 	robotStr := args.Machine
@@ -1735,7 +1688,14 @@ func newViamClientInner(c *cli.Context, disableBrowserOpen bool) (*viamClient, e
 // Creates a new viam client, defaulting to _not_ passing the `disableBrowerOpen` arg (which
 // users don't even have an option of setting for any CLI method currently except `Login`).
 func newViamClient(c *cli.Context) (*viamClient, error) {
-	return newViamClientInner(c, false)
+	client, err := newViamClientInner(c, false)
+	if err != nil {
+		return nil, err
+	}
+	if err := client.ensureLoggedIn(); err != nil {
+		return nil, err
+	}
+	return client, nil
 }
 
 func (c *viamClient) loadOrganizations() error {
@@ -1748,9 +1708,6 @@ func (c *viamClient) loadOrganizations() error {
 }
 
 func (c *viamClient) selectOrganization(orgStr string) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
 	if orgStr != "" && (c.selectedOrg.Id == orgStr || c.selectedOrg.Name == orgStr) {
 		return nil
 	}
@@ -1796,9 +1753,6 @@ func (c *viamClient) selectOrganization(orgStr string) error {
 // org UUID, then this matchs on organization ID, otherwise this will match
 // on organization name.
 func (c *viamClient) getOrg(orgStr string) (*apppb.Organization, error) {
-	if err := c.ensureLoggedIn(); err != nil {
-		return nil, err
-	}
 	resp, err := c.client.ListOrganizations(c.c.Context, &apppb.ListOrganizationsRequest{})
 	if err != nil {
 		return nil, err
@@ -1823,10 +1777,6 @@ func (c *viamClient) getOrg(orgStr string) (*apppb.Organization, error) {
 // getUserOrgByPublicNamespace searches the logged in users orgs to see
 // if any have a matching public namespace.
 func (c *viamClient) getUserOrgByPublicNamespace(publicNamespace string) (*apppb.Organization, error) {
-	if err := c.ensureLoggedIn(); err != nil {
-		return nil, err
-	}
-
 	if err := c.loadOrganizations(); err != nil {
 		return nil, err
 	}
@@ -1839,9 +1789,6 @@ func (c *viamClient) getUserOrgByPublicNamespace(publicNamespace string) (*apppb
 }
 
 func (c *viamClient) listOrganizations() ([]*apppb.Organization, error) {
-	if err := c.ensureLoggedIn(); err != nil {
-		return nil, err
-	}
 	if err := c.loadOrganizations(); err != nil {
 		return nil, err
 	}
@@ -1895,9 +1842,6 @@ func (c *viamClient) selectLocation(locStr string) error {
 }
 
 func (c *viamClient) listLocations(orgID string) ([]*apppb.Location, error) {
-	if err := c.ensureLoggedIn(); err != nil {
-		return nil, err
-	}
 	if err := c.selectOrganization(orgID); err != nil {
 		return nil, err
 	}
@@ -1908,9 +1852,6 @@ func (c *viamClient) listLocations(orgID string) ([]*apppb.Location, error) {
 }
 
 func (c *viamClient) listRobots(orgStr, locStr string) ([]*apppb.Robot, error) {
-	if err := c.ensureLoggedIn(); err != nil {
-		return nil, err
-	}
 	if err := c.selectOrganization(orgStr); err != nil {
 		return nil, err
 	}
@@ -1927,10 +1868,6 @@ func (c *viamClient) listRobots(orgStr, locStr string) ([]*apppb.Robot, error) {
 }
 
 func (c *viamClient) robot(orgStr, locStr, robotStr string) (*apppb.Robot, error) {
-	if err := c.ensureLoggedIn(); err != nil {
-		return nil, err
-	}
-
 	robots, err := c.listRobots(orgStr, locStr)
 	if err != nil {
 		return nil, err
@@ -1969,9 +1906,6 @@ func (c *viamClient) robotPart(orgStr, locStr, robotStr, partStr string) (*apppb
 }
 
 func (c *viamClient) robotPartInner(orgStr, locStr, robotStr, partStr string) (*apppb.RobotPart, error) {
-	if err := c.ensureLoggedIn(); err != nil {
-		return nil, err
-	}
 	parts, err := c.robotParts(orgStr, locStr, robotStr)
 	if err != nil {
 		return nil, err
@@ -2007,16 +1941,10 @@ func (c *viamClient) robotPartInner(orgStr, locStr, robotStr, partStr string) (*
 // note: overlaps with viamClient.robotPart, which wraps GetRobotParts.
 // Use this variant if you don't know the robot ID.
 func (c *viamClient) getRobotPart(partID string) (*apppb.GetRobotPartResponse, error) {
-	if err := c.ensureLoggedIn(); err != nil {
-		return nil, err
-	}
 	return c.client.GetRobotPart(c.c.Context, &apppb.GetRobotPartRequest{Id: partID})
 }
 
 func (c *viamClient) updateRobotPart(part *apppb.RobotPart, confMap map[string]any) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
 	confStruct, err := structpb.NewStruct(confMap)
 	if err != nil {
 		return errors.Wrap(err, "in NewStruct")
@@ -2074,9 +2002,6 @@ func (c *viamClient) robotPartLogs(orgStr, locStr, robotStr, partStr string, err
 }
 
 func (c *viamClient) robotParts(orgStr, locStr, robotStr string) ([]*apppb.RobotPart, error) {
-	if err := c.ensureLoggedIn(); err != nil {
-		return nil, err
-	}
 	robot, err := c.robot(orgStr, locStr, robotStr)
 	if err != nil {
 		return nil, err
@@ -2604,10 +2529,6 @@ func ReadOAuthAppAction(c *cli.Context, args readOAuthAppArgs) error {
 }
 
 func (c *viamClient) readOAuthAppAction(cCtx *cli.Context, orgID, clientID string) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
-
 	req := &apppb.ReadOAuthAppRequest{OrgId: orgID, ClientId: clientID}
 	resp, err := c.client.ReadOAuthApp(c.c.Context, req)
 	if err != nil {
@@ -2683,10 +2604,6 @@ func DeleteOAuthAppAction(c *cli.Context, args deleteOAuthAppArgs) error {
 }
 
 func (c *viamClient) deleteOAuthAppAction(cCtx *cli.Context, orgID, clientID string) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
-
 	req := &apppb.DeleteOAuthAppRequest{
 		OrgId:    orgID,
 		ClientId: clientID,
@@ -2831,10 +2748,6 @@ func CreateOAuthAppAction(c *cli.Context, args createOAuthAppArgs) error {
 }
 
 func (c *viamClient) createOAuthAppAction(cCtx *cli.Context, args createOAuthAppArgs) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
-
 	config, err := generateOAuthConfig(args.ClientAuthentication, args.Pkce, args.UrlValidation,
 		args.LogoutURI, args.OriginURIs, args.RedirectURIs, args.EnabledGrants)
 	if err != nil {
@@ -2881,10 +2794,6 @@ func UpdateOAuthAppAction(c *cli.Context, args updateOAuthAppArgs) error {
 }
 
 func (c *viamClient) updateOAuthAppAction(cCtx *cli.Context, args updateOAuthAppArgs) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
-
 	req, err := createUpdateOAuthAppRequest(args)
 	if err != nil {
 		return err

--- a/cli/data.go
+++ b/cli/data.go
@@ -354,10 +354,6 @@ func (c *viamClient) dataExportTabularAction(cCtx *cli.Context, args dataExportT
 
 // BinaryData downloads binary data matching filter to dst.
 func (c *viamClient) binaryData(dst string, filter *datapb.Filter, parallelDownloads, timeout uint) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
-
 	return c.performActionOnBinaryDataFromFilter(
 		func(id *datapb.BinaryID) error {
 			return c.downloadBinary(dst, id, timeout)
@@ -692,10 +688,6 @@ func filenameForDownload(meta *datapb.BinaryMetadata) string {
 
 // tabularData downloads unified tabular data and metadata for the requested data source and interval to the specified destination.
 func (c *viamClient) tabularData(dest string, request *datapb.ExportTabularDataRequest) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
-
 	if err := makeDestinationDirs(dest); err != nil {
 		return errors.Wrapf(err, "could not create destination directories")
 	}
@@ -844,9 +836,6 @@ func makeDestinationDirs(dst string) error {
 }
 
 func (c *viamClient) deleteBinaryData(filter *datapb.Filter) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
 	resp, err := c.dataClient.DeleteBinaryDataByFilter(context.Background(),
 		&datapb.DeleteBinaryDataByFilterRequest{Filter: filter})
 	if err != nil {
@@ -857,9 +846,6 @@ func (c *viamClient) deleteBinaryData(filter *datapb.Filter) error {
 }
 
 func (c *viamClient) dataAddTagsToBinaryByFilter(filter *datapb.Filter, tags []string) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
 	_, err := c.dataClient.AddTagsToBinaryDataByFilter(context.Background(),
 		&datapb.AddTagsToBinaryDataByFilterRequest{Filter: filter, Tags: tags})
 	if err != nil {
@@ -870,9 +856,6 @@ func (c *viamClient) dataAddTagsToBinaryByFilter(filter *datapb.Filter, tags []s
 }
 
 func (c *viamClient) dataRemoveTagsFromBinaryByFilter(filter *datapb.Filter, tags []string) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
 	_, err := c.dataClient.RemoveTagsFromBinaryDataByFilter(context.Background(),
 		&datapb.RemoveTagsFromBinaryDataByFilterRequest{Filter: filter, Tags: tags})
 	if err != nil {
@@ -883,9 +866,6 @@ func (c *viamClient) dataRemoveTagsFromBinaryByFilter(filter *datapb.Filter, tag
 }
 
 func (c *viamClient) dataAddTagsToBinaryByIDs(tags []string, orgID, locationID string, fileIDs []string) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
 	binaryData := make([]*datapb.BinaryID, 0, len(fileIDs))
 	for _, fileID := range fileIDs {
 		binaryData = append(binaryData, &datapb.BinaryID{
@@ -906,9 +886,6 @@ func (c *viamClient) dataAddTagsToBinaryByIDs(tags []string, orgID, locationID s
 // dataRemoveTagsFromData removes tags from data, with the specified org ID, location ID,
 // and file IDs.
 func (c *viamClient) dataRemoveTagsFromBinaryByIDs(tags []string, orgID, locationID string, fileIDs []string) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
 	binaryData := make([]*datapb.BinaryID, 0, len(fileIDs))
 	for _, fileID := range fileIDs {
 		binaryData = append(binaryData, &datapb.BinaryID{
@@ -928,9 +905,6 @@ func (c *viamClient) dataRemoveTagsFromBinaryByIDs(tags []string, orgID, locatio
 
 // deleteTabularData delete tabular data matching filter.
 func (c *viamClient) deleteTabularData(orgID string, deleteOlderThanDays int) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
 	resp, err := c.dataClient.DeleteTabularData(context.Background(),
 		&datapb.DeleteTabularDataRequest{OrganizationId: orgID, DeleteOlderThanDays: uint32(deleteOlderThanDays)})
 	if err != nil {
@@ -962,9 +936,6 @@ func DataAddToDatasetByIDs(c *cli.Context, args dataAddToDatasetByIDsArgs) error
 
 // dataAddToDatasetByIDs adds data, with the specified org ID, location ID, and file IDs to the dataset corresponding to the dataset ID.
 func (c *viamClient) dataAddToDatasetByIDs(datasetID, orgID, locationID string, fileIDs []string) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
 	binaryData := make([]*datapb.BinaryID, 0, len(fileIDs))
 	for _, fileID := range fileIDs {
 		binaryData = append(binaryData, &datapb.BinaryID{
@@ -1004,9 +975,6 @@ func DataAddToDatasetByFilter(c *cli.Context, args dataAddToDatasetByFilterArgs)
 
 // dataAddToDatasetByFilter adds data, with the specified filter to the dataset corresponding to the dataset ID.
 func (c *viamClient) dataAddToDatasetByFilter(filter *datapb.Filter, datasetID string) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
 	parallelActions := uint(100)
 
 	return c.performActionOnBinaryDataFromFilter(
@@ -1044,9 +1012,6 @@ func DataRemoveFromDataset(c *cli.Context, args dataRemoveFromDatasetArgs) error
 // dataRemoveFromDataset removes data, with the specified org ID, location ID,
 // and file IDs from the dataset corresponding to the dataset ID.
 func (c *viamClient) dataRemoveFromDataset(datasetID, orgID, locationID string, fileIDs []string) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
 	binaryData := make([]*datapb.BinaryID, 0, len(fileIDs))
 	for _, fileID := range fileIDs {
 		binaryData = append(binaryData, &datapb.BinaryID{
@@ -1128,9 +1093,6 @@ func DataConfigureDatabaseUser(c *cli.Context, args dataConfigureDatabaseUserArg
 // being configured. Viam uses gRPC over TLS, so the entire request will be encrypted while in
 // flight, including the password.
 func (c *viamClient) dataConfigureDatabaseUser(orgID, password string) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
 	_, err := c.dataClient.ConfigureDatabaseUser(context.Background(),
 		&datapb.ConfigureDatabaseUserRequest{OrganizationId: orgID, Password: password})
 	if err != nil {
@@ -1162,9 +1124,6 @@ func DataGetDatabaseConnection(c *cli.Context, args dataGetDatabaseConnectionArg
 // dataGetDatabaseConnection gets the hostname of the MongoDB Atlas Data Federation instance
 // for the given organization ID.
 func (c *viamClient) dataGetDatabaseConnection(orgID string) (*datapb.GetDatabaseConnectionResponse, error) {
-	if err := c.ensureLoggedIn(); err != nil {
-		return nil, err
-	}
 	res, err := c.dataClient.GetDatabaseConnection(context.Background(), &datapb.GetDatabaseConnectionRequest{OrganizationId: orgID})
 	if err != nil {
 		return nil, errors.Wrapf(err, serverErrorMessage)

--- a/cli/dataset.go
+++ b/cli/dataset.go
@@ -42,9 +42,6 @@ func DatasetCreateAction(c *cli.Context, args datasetCreateArgs) error {
 
 // createDataset creates a dataset with the a dataset ID.
 func (c *viamClient) createDataset(orgID, datasetName string) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
 	resp, err := c.datasetClient.CreateDataset(context.Background(),
 		&datasetpb.CreateDatasetRequest{OrganizationId: orgID, Name: datasetName})
 	if err != nil {
@@ -73,9 +70,6 @@ func DatasetRenameAction(c *cli.Context, args datasetRenameArgs) error {
 
 // renameDataset renames an existing datasetID with the newDatasetName.
 func (c *viamClient) renameDataset(datasetID, newDatasetName string) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
 	_, err := c.datasetClient.RenameDataset(context.Background(),
 		&datasetpb.RenameDatasetRequest{Id: datasetID, Name: newDatasetName})
 	if err != nil {
@@ -117,9 +111,6 @@ func DatasetListAction(c *cli.Context, args datasetListArgs) error {
 
 // listDatasetByIDs list all datasets by ID.
 func (c *viamClient) listDatasetByIDs(datasetIDs []string) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
 	resp, err := c.datasetClient.ListDatasetsByIDs(context.Background(),
 		&datasetpb.ListDatasetsByIDsRequest{Ids: datasetIDs})
 	if err != nil {
@@ -133,9 +124,6 @@ func (c *viamClient) listDatasetByIDs(datasetIDs []string) error {
 
 // listDatasetByOrg list all datasets for the specified org ID.
 func (c *viamClient) listDatasetByOrg(orgID string) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
 	resp, err := c.datasetClient.ListDatasetsByOrganizationID(context.Background(),
 		&datasetpb.ListDatasetsByOrganizationIDRequest{OrganizationId: orgID})
 	if err != nil {
@@ -165,9 +153,6 @@ func DatasetDeleteAction(c *cli.Context, args datasetDeleteArgs) error {
 
 // deleteDataset deletes a dataset with the specified ID.
 func (c *viamClient) deleteDataset(datasetID string) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
 	_, err := c.datasetClient.DeleteDataset(context.Background(),
 		&datasetpb.DeleteDatasetRequest{Id: datasetID})
 	if err != nil {
@@ -200,10 +185,6 @@ func DatasetDownloadAction(c *cli.Context, args datasetDownloadArgs) error {
 
 // downloadDataset downloads a dataset with the specified ID.
 func (c *viamClient) downloadDataset(dst, datasetID string, includeJSONLines bool, parallelDownloads, timeout uint) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
-
 	var datasetFile *os.File
 	var err error
 	if includeJSONLines {

--- a/cli/ml_training.go
+++ b/cli/ml_training.go
@@ -131,9 +131,6 @@ func MLSubmitTrainingJob(c *cli.Context, args mlSubmitTrainingJobArgs) error {
 func (c *viamClient) mlSubmitTrainingJob(datasetID, orgID, modelName, modelVersion, modelType string,
 	labels []string,
 ) (string, error) {
-	if err := c.ensureLoggedIn(); err != nil {
-		return "", err
-	}
 	if modelVersion == "" {
 		modelVersion = time.Now().Format("2006-01-02T15-04-05")
 	}
@@ -159,9 +156,6 @@ func (c *viamClient) mlSubmitTrainingJob(datasetID, orgID, modelName, modelVersi
 func (c *viamClient) mlSubmitCustomTrainingJob(datasetID, registryItemID, registryItemVersion, orgID, modelName,
 	modelVersion string, args []string,
 ) (string, error) {
-	if err := c.ensureLoggedIn(); err != nil {
-		return "", err
-	}
 	splitName := strings.Split(registryItemID, ":")
 	if len(splitName) != 2 {
 		return "", errors.Errorf("invalid training script name '%s'."+
@@ -220,9 +214,6 @@ func DataGetTrainingJob(c *cli.Context, args dataGetTrainingJobArgs) error {
 
 // dataGetTrainingJob gets a training job with the given ID.
 func (c *viamClient) dataGetTrainingJob(trainingJobID string) (*mltrainingpb.TrainingJobMetadata, error) {
-	if err := c.ensureLoggedIn(); err != nil {
-		return nil, err
-	}
 	resp, err := c.mlTrainingClient.GetTrainingJob(context.Background(), &mltrainingpb.GetTrainingJobRequest{Id: trainingJobID})
 	if err != nil {
 		return nil, err
@@ -256,9 +247,6 @@ func MLGetTrainingJobLogs(c *cli.Context, args mlGetTrainingJobLogsArgs) error {
 
 // mlGetTrainingJobLogs gets the training job logs with the given ID.
 func (c *viamClient) mlGetTrainingJobLogs(trainingJobID string) ([]*mltrainingpb.TrainingJobLogEntry, error) {
-	if err := c.ensureLoggedIn(); err != nil {
-		return nil, err
-	}
 	var allLogs []*mltrainingpb.TrainingJobLogEntry
 	var page string
 
@@ -299,9 +287,6 @@ func DataCancelTrainingJob(c *cli.Context, args dataCancelTrainingJobArgs) error
 
 // dataCancelTrainingJob cancels a training job with the given ID.
 func (c *viamClient) dataCancelTrainingJob(trainingJobID string) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
 	if _, err := c.mlTrainingClient.CancelTrainingJob(
 		context.Background(), &mltrainingpb.CancelTrainingJobRequest{Id: trainingJobID}); err != nil {
 		return err
@@ -332,10 +317,6 @@ func DataListTrainingJobs(c *cli.Context, args dataListTrainingJobsArgs) error {
 
 // dataListTrainingJobs lists training jobs for the given org.
 func (c *viamClient) dataListTrainingJobs(orgID, status string) ([]*mltrainingpb.TrainingJobMetadata, error) {
-	if err := c.ensureLoggedIn(); err != nil {
-		return nil, err
-	}
-
 	if status == "" {
 		status = "unspecified"
 	}
@@ -465,10 +446,6 @@ func MLTrainingUpdateAction(c *cli.Context, args mlTrainingUpdateArgs) error {
 }
 
 func (c *viamClient) updateTrainingScript(orgID, name, visibility, description, url string) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
-
 	// Get registry item
 	itemID := fmt.Sprintf("%s:%s", orgID, name)
 	resp, err := c.client.GetRegistryItem(c.c.Context, &v1.GetRegistryItemRequest{

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -102,9 +102,6 @@ func (c *viamClient) moduleBuildStartAction(cCtx *cli.Context, args moduleBuildS
 		Token:         &token,
 		Workdir:       &workdir,
 	}
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
 	res, err := c.buildClient.StartBuild(c.c.Context, &req)
 	if err != nil {
 		return err
@@ -352,9 +349,6 @@ func ModuleBuildLinkRepoAction(c *cli.Context, args moduleBuildLinkRepoArgs) err
 	if err != nil {
 		return err
 	}
-	if err := client.ensureLoggedIn(); err != nil {
-		return err
-	}
 	res, err := client.buildClient.LinkRepo(c.Context, &req)
 	if err != nil {
 		return err
@@ -364,10 +358,6 @@ func ModuleBuildLinkRepoAction(c *cli.Context, args moduleBuildLinkRepoArgs) err
 }
 
 func (c *viamClient) printModuleBuildLogs(buildID, platform string) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
-
 	logsReq := &buildpb.GetLogsRequest{
 		BuildId:  buildID,
 		Platform: platform,
@@ -400,9 +390,6 @@ func (c *viamClient) printModuleBuildLogs(buildID, platform string) error {
 }
 
 func (c *viamClient) listModuleBuildJobs(moduleIDFilter string, count *int32, buildIDFilter *string) (*buildpb.ListJobsResponse, error) {
-	if err := c.ensureLoggedIn(); err != nil {
-		return nil, err
-	}
 	req := buildpb.ListJobsRequest{
 		ModuleId:      moduleIDFilter,
 		MaxJobsLength: count,
@@ -519,6 +506,7 @@ func ReloadModuleAction(c *cli.Context, args reloadModuleArgs) error {
 
 // reloadModuleAction is the testable inner reload logic.
 func reloadModuleAction(c *cli.Context, vc *viamClient, args reloadModuleArgs, logger logging.Logger) error {
+	// TODO(RSDK-9727) it'd be nice for this to be a method on a viam client rather than taking one as an arg
 	partID, err := resolvePartID(c.Context, args.PartID, "/etc/viam.json")
 	if err != nil {
 		return err
@@ -691,11 +679,9 @@ func restartModule(
 	manifest *moduleManifest,
 	logger logging.Logger,
 ) error {
+	// TODO(RSDK-9727) it'd be nice for this to be a method on a viam client rather than taking one as an arg
 	restartReq, err := resolveTargetModule(c, manifest)
 	if err != nil {
-		return err
-	}
-	if err := vc.ensureLoggedIn(); err != nil {
 		return err
 	}
 	apiRes, err := vc.client.GetRobotAPIKeys(c.Context, &apppb.GetRobotAPIKeysRequest{RobotId: part.Robot})

--- a/cli/module_generate.go
+++ b/cli/module_generate.go
@@ -70,9 +70,6 @@ func GenerateModuleAction(cCtx *cli.Context, args generateModuleArgs) error {
 }
 
 func (c *viamClient) generateModuleAction(cCtx *cli.Context, args generateModuleArgs) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
 	var newModule *modulegen.ModuleInputs
 	var err error
 

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -413,9 +413,6 @@ func UpdateModelsAction(c *cli.Context, args updateModelsArgs) error {
 }
 
 func (c *viamClient) createModule(moduleName, organizationID string) (*apppb.CreateModuleResponse, error) {
-	if err := c.ensureLoggedIn(); err != nil {
-		return nil, err
-	}
 	req := apppb.CreateModuleRequest{
 		Name:           moduleName,
 		OrganizationId: organizationID,
@@ -424,9 +421,6 @@ func (c *viamClient) createModule(moduleName, organizationID string) (*apppb.Cre
 }
 
 func (c *viamClient) getModule(moduleID moduleID) (*apppb.GetModuleResponse, error) {
-	if err := c.ensureLoggedIn(); err != nil {
-		return nil, err
-	}
 	req := apppb.GetModuleRequest{
 		ModuleId: moduleID.String(),
 	}
@@ -434,9 +428,6 @@ func (c *viamClient) getModule(moduleID moduleID) (*apppb.GetModuleResponse, err
 }
 
 func (c *viamClient) updateModule(moduleID moduleID, manifest moduleManifest) (*apppb.UpdateModuleResponse, error) {
-	if err := c.ensureLoggedIn(); err != nil {
-		return nil, err
-	}
 	var models []*apppb.Model
 	for _, moduleComponent := range manifest.Models {
 		models = append(models, moduleComponentToProto(moduleComponent))
@@ -466,10 +457,6 @@ func (c *viamClient) uploadModuleFile(
 	constraints []string,
 	tarballPath string,
 ) (*apppb.UploadModuleFileResponse, error) {
-	if err := c.ensureLoggedIn(); err != nil {
-		return nil, err
-	}
-
 	//nolint:gosec
 	file, err := os.Open(tarballPath)
 	if err != nil {
@@ -995,9 +982,6 @@ func DownloadModuleAction(c *cli.Context, flags downloadModuleFlags) error {
 	}
 	client, err := newViamClient(c)
 	if err != nil {
-		return err
-	}
-	if err := client.ensureLoggedIn(); err != nil {
 		return err
 	}
 	req := &apppb.GetModuleRequest{ModuleId: moduleID}

--- a/cli/packages.go
+++ b/cli/packages.go
@@ -84,9 +84,6 @@ func convertPackageTypeToProto(packageType string) (*packagespb.PackageType, err
 }
 
 func (c *viamClient) packageExportAction(orgID, name, version, packageType, destination string) error {
-	if err := c.ensureLoggedIn(); err != nil {
-		return err
-	}
 	if orgID == "" || name == "" {
 		if orgID != "" || name != "" {
 			return fmt.Errorf("if either of %s or %s is missing, both must be missing", generalFlagOrgID, generalFlagName)
@@ -227,10 +224,6 @@ func (c *viamClient) uploadPackage(
 	orgID, name, version, packageType, tarballPath string,
 	metadataStruct *structpb.Struct,
 ) (*packagespb.CreatePackageResponse, error) {
-	if err := c.ensureLoggedIn(); err != nil {
-		return nil, err
-	}
-
 	//nolint:gosec
 	file, err := os.Open(tarballPath)
 	if err != nil {


### PR DESCRIPTION
`ensureLoggedIn` has turned into a gotcha where everyone adding a new CLI command is responsible for calling it themselves or else risking trying to run actions without being logged in. This feature creates a single canonical call site when a viam client is first created (except when running a login action) so that no one has to think about this anymore!

Tested locally after logging out. For non-login actions (e.g. `viam organizations list` and `viam module generate`), being logged out resulted in an error. for `viam login`, the normal login process proceeded as normal.