### PR TITLE
rename os_codename to codename in docstring

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -2443,7 +2443,7 @@ viam module upload --version "0.1.0" --platform "linux/amd64" --upload "packaged
 							Name: generalFlagTags,
 							Usage: `extra fields for constraining the platforms to which this binary
                              is deployed. Examples: distro:debian, distro:ubuntu, os_version:22.04,
-                             os_codename:jammy. For a machine to use an upload, all tags must be
+                             codename:jammy. For a machine to use an upload, all tags must be
                              satisified as well as the --platform field.`,
 						},
 						&cli.BoolFlag{


### PR DESCRIPTION
## What changed
In the CLI docstring for `viam module build upload`, replace `os_codename` with `codename`.
## Why
To agree with the actual tag key [here](https://github.com/viamrobotics/rdk/blob/5e0a4e281881823b39dba3683deb70704235af95/config/platform.go#L135):
```go
tags = appendPairIfNonempty(tags, "codename", osRelease["VERSION_CODENAME"])
```