### PR TITLE
correct manifest filename in `static-release-win` target

### DIFF
--- a/packaging.make
+++ b/packaging.make
@@ -79,4 +79,4 @@ static-release-win:
 		--version ${BUILD_CHANNEL} \
 		--arch ${UNAME_M} \
 		--resources-json win-resources.json \
-		--output-path etc/packaging/static/manifest/viam-server-${BUILD_CHANNEL}-windows-${UNAME_M}.json
+		--output-path etc/packaging/static/manifest/viam-server-windows-${BUILD_CHANNEL}-${UNAME_M}.json


### PR DESCRIPTION
## What changed
In the `static-release-win` makefile target, correct the filename pattern of the manifest json.
## Why
The json filename has to agree with the `subsystemParsedName.objectPath` function in the backend job that consumes this.

This is confusing because the filename pattern of the executable is different from the name pattern of the json file, but it's compatible with the logic we have. I could alternatively patch this on the backend, but I'm slightly concerned about creating incompatibility with previous deploys, so I went with this approach.