### PR TITLE
RSDK-9972 Update server tunnel to connect to 127.0.0.1 instead of localhost

### DIFF
--- a/robot/server/server.go
+++ b/robot/server/server.go
@@ -71,7 +71,7 @@ func (s *Server) Tunnel(srv pb.RobotService_TunnelServer) error {
 	s.robot.Logger().CDebugw(srv.Context(), "dialing to destination port", "port", dest)
 
 	dialTimeout := 10 * time.Second
-	conn, err := net.DialTimeout("tcp", net.JoinHostPort("localhost", dest), dialTimeout)
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", dest), dialTimeout)
 	if err != nil {
 		return fmt.Errorf("failed to dial to destination port %v: %w", dest, err)
 	}


### PR DESCRIPTION
Still need to talk with @abe-winter about why this might be necessary, and double check that everything still actually works (tests still seem to pass.)