### PR TITLE
RSDK-10006 - Fix dials to robot when using api key authentication

### DIFF
--- a/cli/auth.go
+++ b/cli/auth.go
@@ -628,7 +628,9 @@ func (c *viamClient) prepareDialInner(
 	if err != nil {
 		return nil, "", nil, err
 	}
-	rpcOpts = append(rpcOpts, rpc.WithExternalAuth(c.baseURL.Host, partFqdn))
+	if _, ok := c.conf.Auth.(*token); ok {
+		rpcOpts = append(rpcOpts, rpc.WithExternalAuth(c.baseURL.Host, partFqdn))
+	}
 
 	if debug {
 		rpcOpts = append(rpcOpts, rpc.WithDialDebug())


### PR DESCRIPTION
maybe there's a better way to figure out which auth method we're using, but I saw this pattern in a few other places so thought this is fine for now

tested connecting with robot parts with both an api key (both robot-scoped and org-scoped) login and a regular app.viam login

cc: @njooma 