### PR TITLE
RSDK-9460: add resource logging in python generated modules

### DIFF
--- a/cli/module_generate/_templates/python/src/models/tmpl-resource.py
+++ b/cli/module_generate/_templates/python/src/models/tmpl-resource.py
@@ -1,3 +1,4 @@
+import logging
 from typing import ClassVar, Mapping, Sequence, Self
 from viam.logging import getLogger
 from viam.proto.app.robot import ComponentConfig
@@ -12,6 +13,7 @@ LOGGER = getLogger(__name__)
 
 class {{ .ModelPascal  }}({{ .ResourceSubtypePascal }}, EasyResource):
     MODEL: ClassVar[Model] = "{{ .ModelTriple }}"
+    logger = logging.getLogger(__name__)
 
     @classmethod
     def new(cls, config: ComponentConfig, dependencies: Mapping[ResourceName, ResourceBase]) -> Self:

--- a/cli/module_generate/_templates/python/src/models/tmpl-resource.py
+++ b/cli/module_generate/_templates/python/src/models/tmpl-resource.py
@@ -1,14 +1,11 @@
 import logging
 from typing import ClassVar, Mapping, Sequence, Self
-from viam.logging import getLogger
 from viam.proto.app.robot import ComponentConfig
 from viam.proto.common import ResourceName
 from viam.resource.base import ResourceBase
 from viam.resource.easy_resource import EasyResource
 from viam.resource.types import Model, ModelFamily
 from viam.{{ .ResourceType }}s.{{ .ResourceSubtype }} import {{ .ResourceSubtypePascal }}
-
-LOGGER = getLogger(__name__)
 
 
 class {{ .ModelPascal  }}({{ .ResourceSubtypePascal }}, EasyResource):

--- a/cli/module_generate/_templates/python/src/models/tmpl-resource.py
+++ b/cli/module_generate/_templates/python/src/models/tmpl-resource.py
@@ -1,10 +1,13 @@
 from typing import ClassVar, Mapping, Sequence, Self
+from viam.logging import getLogger
 from viam.proto.app.robot import ComponentConfig
 from viam.proto.common import ResourceName
 from viam.resource.base import ResourceBase
 from viam.resource.easy_resource import EasyResource
 from viam.resource.types import Model, ModelFamily
 from viam.{{ .ResourceType }}s.{{ .ResourceSubtype }} import {{ .ResourceSubtypePascal }}
+
+LOGGER = getLogger(__name__)
 
 
 class {{ .ModelPascal  }}({{ .ResourceSubtypePascal }}, EasyResource):

--- a/cli/module_generate/_templates/python/src/models/tmpl-resource.py
+++ b/cli/module_generate/_templates/python/src/models/tmpl-resource.py
@@ -13,6 +13,8 @@ LOGGER = getLogger(__name__)
 
 class {{ .ModelPascal  }}({{ .ResourceSubtypePascal }}, EasyResource):
     MODEL: ClassVar[Model] = "{{ .ModelTriple }}"
+    # To enable debug-level logging, either run viam-server with the --debug option,
+    # or configure your resource/machine to display debug logs.
     logger = logging.getLogger(__name__)
 
     @classmethod

--- a/cli/module_generate/scripts/generate_stubs.py
+++ b/cli/module_generate/scripts/generate_stubs.py
@@ -180,6 +180,7 @@ def main(
     resource_file = '''
 from typing import ClassVar, Mapping, Sequence
 from typing_extensions import Self
+from viam.logging import getLogger
 from viam.proto.app.robot import ComponentConfig
 from viam.proto.common import ResourceName
 from viam.resource.base import ResourceBase
@@ -187,6 +188,8 @@ from viam.resource.easy_resource import EasyResource
 from viam.resource.types import Model, ModelFamily
 {0}
 from viam.{1}s.{2} import *
+
+LOGGER = getLogger(__name__)
 
 
 class {3}({4}, EasyResource):

--- a/cli/module_generate/scripts/generate_stubs.py
+++ b/cli/module_generate/scripts/generate_stubs.py
@@ -196,6 +196,8 @@ LOGGER = getLogger(__name__)
 
 class {3}({4}, EasyResource):
     MODEL: ClassVar[Model] = Model(ModelFamily("{5}", "{6}"), "{7}")
+    # To enable debug-level logging, either run viam-server with the --debug option,
+    # or configure your resource/machine to display debug logs.
     logger = logging.getLogger(__name__)
 
     @classmethod

--- a/cli/module_generate/scripts/generate_stubs.py
+++ b/cli/module_generate/scripts/generate_stubs.py
@@ -178,6 +178,7 @@ def main(
         [word.capitalize() for word in slugify(model_name).split("-")]
     )
     resource_file = '''
+import logging
 from typing import ClassVar, Mapping, Sequence
 from typing_extensions import Self
 from viam.logging import getLogger
@@ -192,8 +193,10 @@ from viam.{1}s.{2} import *
 LOGGER = getLogger(__name__)
 
 
+
 class {3}({4}, EasyResource):
     MODEL: ClassVar[Model] = Model(ModelFamily("{5}", "{6}"), "{7}")
+    logger = logging.getLogger(__name__)
 
     @classmethod
     def new(cls, config: ComponentConfig, dependencies: Mapping[ResourceName, ResourceBase]) -> Self:

--- a/cli/module_generate/scripts/generate_stubs.py
+++ b/cli/module_generate/scripts/generate_stubs.py
@@ -44,11 +44,18 @@ def replace_async_func(
             nodes,
             parent)
     func.body = [
+        ast.Expr(ast.Call(
+            func=ast.Attribute(
+                value=ast.Attribute(
+                    ast.Name(id="self"),
+                    attr="logger"),
+                attr="error",
+            ),
+            args=[ast.Constant(value=f"`{func.name}` is not implemented")]
+        )),
         ast.Raise(
             exc=ast.Call(func=ast.Name(id='NotImplementedError',
-                                       ctx=ast.Load()),
-                         args=[],
-                         keywords=[]),
+                                       ctx=ast.Load())),
             cause=None)
     ]
     func.decorator_list = []

--- a/cli/module_generate/scripts/generate_stubs.py
+++ b/cli/module_generate/scripts/generate_stubs.py
@@ -181,7 +181,6 @@ def main(
 import logging
 from typing import ClassVar, Mapping, Sequence
 from typing_extensions import Self
-from viam.logging import getLogger
 from viam.proto.app.robot import ComponentConfig
 from viam.proto.common import ResourceName
 from viam.resource.base import ResourceBase
@@ -189,9 +188,6 @@ from viam.resource.easy_resource import EasyResource
 from viam.resource.types import Model, ModelFamily
 {0}
 from viam.{1}s.{2} import *
-
-LOGGER = getLogger(__name__)
-
 
 
 class {3}({4}, EasyResource):


### PR DESCRIPTION
```
2025-02-19T16:29:22.605Z	DEBUG	viam/rpc/server	server.py:74	[gRPC] Received message from xxxx:xxxx - /viam.component.sensor.v1.SensorService/DoCommand for resource named: sensor1	{"log_ts":"2025-02-19T11:29:22.603Z"}
2025-02-19T16:29:22.605Z	DEBUG	rdk:component:sensor/sensor1	hello_sensor.py:78	shhh, this is a debug	{"log_ts":"2025-02-19T11:29:22.604Z"}
2025-02-19T16:29:22.606Z	INFO	rdk:component:sensor/sensor1	hello_sensor.py:79	this is some info	{"log_ts":"2025-02-19T11:29:22.604Z"}
2025-02-19T16:29:22.606Z	WARN	rdk:component:sensor/sensor1	hello_sensor.py:80	warning!	{"log_ts":"2025-02-19T11:29:22.604Z"}
2025-02-19T16:29:22.607Z	ERROR	rdk:component:sensor/sensor1	hello_sensor.py:81	`do_command` is not implemented	{"log_ts":"2025-02-19T11:29:22.604Z"}
```