### PR TITLE
[RSDK-9664] - Fix deadlock in hotSwappableMediaSource

### DIFF
--- a/gostream/swapper.go
+++ b/gostream/swapper.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"image"
 	"sync"
-	"time"
 
 	"github.com/pion/mediadevices/pkg/prop"
 	"github.com/pion/mediadevices/pkg/wave"
@@ -144,8 +143,6 @@ func (cs *hotSwappableMediaSourceStream[T, U]) init(ctx context.Context) error {
 		utils.UncheckedError(cs.stream.Close(ctx))
 		cs.stream = nil
 	}
-	// TODO(seanp): remove sleep before merging.
-	time.Sleep(time.Second)
 	cs.parent.mu.RLock()
 	defer cs.parent.mu.RUnlock()
 	cs.cancelCtx = cs.parent.cancelCtx

--- a/gostream/swapper.go
+++ b/gostream/swapper.go
@@ -67,15 +67,16 @@ func (swapper *hotSwappableMediaSource[T, U]) Stream(
 		swapper.mu.RUnlock()
 		return nil, errSwapperClosed
 	}
-	// We dont want to hold the read lock during initialization to avoid deadlocks
-	// with the swapper's lock.
-	swapper.mu.RUnlock()
 
 	stream := &hotSwappableMediaSourceStream[T, U]{
 		parent:      swapper,
 		errHandlers: errHandlers,
 		cancelCtx:   swapper.cancelCtx,
 	}
+
+	// Release the read lock before initialization to avoid deadlocks
+	swapper.mu.RUnlock()
+
 	stream.mu.Lock()
 	defer stream.mu.Unlock()
 	if err := stream.init(ctx); err != nil {

--- a/gostream/swapper.go
+++ b/gostream/swapper.go
@@ -74,7 +74,9 @@ func (swapper *hotSwappableMediaSource[T, U]) Stream(
 		cancelCtx:   swapper.cancelCtx,
 	}
 
-	// Release the read lock before initialization to avoid deadlocks
+	// Release the read lock before calling init to avoid potential deadlocks.
+	// This ensures that the Swap method can acquire the write lock if needed
+	// while the initialization process is ongoing.
 	swapper.mu.RUnlock()
 
 	stream.mu.Lock()


### PR DESCRIPTION
## Description

See [ticket](https://viam.atlassian.net/browse/RSDK-9664) for Dan's detailed explanation of deadlock case. This PR simply removes holding the read lock during `init` calls to avoid the case where a swap is hit during initialization. 

## Testing
Added Dan's patch to sleep for a second in `init` to repro the deadlock. See how the tests are now passing in CI.