### PR TITLE
clean up the PoseTracker interface

### DIFF
--- a/components/posetracker/client.go
+++ b/components/posetracker/client.go
@@ -42,7 +42,7 @@ func NewClientFromConn(
 
 func (c *client) Poses(
 	ctx context.Context, bodyNames []string, extra map[string]interface{},
-) (BodyToPoseInFrame, error) {
+) (referenceframe.FrameSystemPoses, error) {
 	ext, err := protoutils.StructToStructPb(extra)
 	if err != nil {
 		return nil, err
@@ -56,15 +56,11 @@ func (c *client) Poses(
 	if err != nil {
 		return nil, err
 	}
-	result := BodyToPoseInFrame{}
+	result := referenceframe.FrameSystemPoses{}
 	for key, pf := range resp.GetBodyPoses() {
 		result[key] = referenceframe.ProtobufToPoseInFrame(pf)
 	}
 	return result, nil
-}
-
-func (c *client) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
-	return Readings(ctx, c)
 }
 
 func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {

--- a/components/posetracker/client_test.go
+++ b/components/posetracker/client_test.go
@@ -40,14 +40,14 @@ func TestClient(t *testing.T) {
 	pose := spatialmath.NewPose(r3.Vector{X: 2, Y: 4, Z: 6}, &spatialmath.R4AA{Theta: math.Pi, RX: 0, RY: 0, RZ: 1})
 	pose2 := spatialmath.NewPose(r3.Vector{X: 1, Y: 2, Z: 3}, &spatialmath.R4AA{Theta: math.Pi, RX: 0, RY: 0, RZ: 1})
 	zeroPose := spatialmath.NewZeroPose()
-	allBodiesToPoseInFrames := posetracker.BodyToPoseInFrame{
+	allBodiesToPoseInFrames := referenceframe.FrameSystemPoses{
 		zeroPoseBody:     referenceframe.NewPoseInFrame(bodyFrame, zeroPose),
 		nonZeroPoseBody:  referenceframe.NewPoseInFrame(bodyFrame, pose),
 		nonZeroPoseBody2: referenceframe.NewPoseInFrame(otherBodyFrame, pose2),
 	}
 	var extraOptions map[string]interface{}
 	poseTester := func(
-		t *testing.T, receivedPoseInFrames posetracker.BodyToPoseInFrame,
+		t *testing.T, receivedPoseInFrames referenceframe.FrameSystemPoses,
 		bodyName string,
 	) {
 		t.Helper()
@@ -60,14 +60,14 @@ func TestClient(t *testing.T) {
 	}
 
 	workingPT.PosesFunc = func(ctx context.Context, bodyNames []string, extra map[string]interface{}) (
-		posetracker.BodyToPoseInFrame, error,
+		referenceframe.FrameSystemPoses, error,
 	) {
 		extraOptions = extra
 		return allBodiesToPoseInFrames, nil
 	}
 
 	failingPT.PosesFunc = func(ctx context.Context, bodyNames []string, extra map[string]interface{}) (
-		posetracker.BodyToPoseInFrame, error,
+		referenceframe.FrameSystemPoses, error,
 	) {
 		return nil, errPoseFailed
 	}

--- a/components/posetracker/pose_tracker.go
+++ b/components/posetracker/pose_tracker.go
@@ -7,7 +7,6 @@ import (
 
 	pb "go.viam.com/api/component/posetracker/v1"
 
-	"go.viam.com/rdk/components/sensor"
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot"
@@ -33,31 +32,15 @@ func Named(name string) resource.Name {
 	return resource.NewName(API, name)
 }
 
-// BodyToPoseInFrame represents a map of body names to PoseInFrames.
-type BodyToPoseInFrame map[string]*referenceframe.PoseInFrame
-
 // A PoseTracker represents a robot component that can observe bodies in an
 // environment and provide their respective poses in space. These poses are
 // given in the context of the PoseTracker's frame of reference.
 type PoseTracker interface {
-	sensor.Sensor
-	Poses(ctx context.Context, bodyNames []string, extra map[string]interface{}) (BodyToPoseInFrame, error)
+	resource.Resource
+	Poses(ctx context.Context, bodyNames []string, extra map[string]interface{}) (referenceframe.FrameSystemPoses, error)
 }
 
 // FromRobot is a helper for getting the named force matrix sensor from the given Robot.
 func FromRobot(r robot.Robot, name string) (PoseTracker, error) {
 	return robot.ResourceFromRobot[PoseTracker](r, Named(name))
-}
-
-// Readings is a helper for getting all readings from a PoseTracker.
-func Readings(ctx context.Context, poseTracker PoseTracker) (map[string]interface{}, error) {
-	poseLookup, err := poseTracker.Poses(ctx, []string{}, map[string]interface{}{})
-	if err != nil {
-		return nil, err
-	}
-	result := map[string]interface{}{}
-	for bodyName, poseInFrame := range poseLookup {
-		result[bodyName] = poseInFrame
-	}
-	return result, nil
 }

--- a/components/posetracker/server_test.go
+++ b/components/posetracker/server_test.go
@@ -47,17 +47,17 @@ func TestGetPoses(t *testing.T) {
 
 	var extraOptions map[string]interface{}
 	workingPT.PosesFunc = func(ctx context.Context, bodyNames []string, extra map[string]interface{}) (
-		posetracker.BodyToPoseInFrame, error,
+		referenceframe.FrameSystemPoses, error,
 	) {
 		extraOptions = extra
 		zeroPose := spatialmath.NewZeroPose()
-		return posetracker.BodyToPoseInFrame{
+		return referenceframe.FrameSystemPoses{
 			bodyName: referenceframe.NewPoseInFrame(bodyFrame, zeroPose),
 		}, nil
 	}
 
 	failingPT.PosesFunc = func(ctx context.Context, bodyNames []string, extra map[string]interface{}) (
-		posetracker.BodyToPoseInFrame, error,
+		referenceframe.FrameSystemPoses, error,
 	) {
 		return nil, errPoseFailed
 	}

--- a/testutils/inject/pose_tracker.go
+++ b/testutils/inject/pose_tracker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"go.viam.com/rdk/components/posetracker"
+	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/resource"
 )
 
@@ -11,7 +12,7 @@ import (
 type PoseTracker struct {
 	posetracker.PoseTracker
 	name      resource.Name
-	PosesFunc func(ctx context.Context, bodyNames []string, extra map[string]interface{}) (posetracker.BodyToPoseInFrame, error)
+	PosesFunc func(ctx context.Context, bodyNames []string, extra map[string]interface{}) (referenceframe.FrameSystemPoses, error)
 	DoFunc    func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
 }
 
@@ -28,7 +29,7 @@ func (pT *PoseTracker) Name() resource.Name {
 // Poses calls the injected Poses or the real version.
 func (pT *PoseTracker) Poses(
 	ctx context.Context, bodyNames []string, extra map[string]interface{},
-) (posetracker.BodyToPoseInFrame, error) {
+) (referenceframe.FrameSystemPoses, error) {
 	if pT.PosesFunc == nil {
 		return pT.PoseTracker.Poses(ctx, bodyNames, extra)
 	}


### PR DESCRIPTION
This code hasn't been touched in a couple years because its not a super popular component.  This PR does two things:

- change the return type of the `Poses` method to be compatible with more recent motion/frame system code
- removes the `Readings` function from the interface.  It is not supported in the proto definition of the component and now that the `Sensor` service has been removed there is nothing that can even call this anymore using our module based paradigm