### PR TITLE
RSDK-10057 - up limits on FTDC local storage

### DIFF
--- a/ftdc/ftdc.go
+++ b/ftdc/ftdc.go
@@ -126,8 +126,8 @@ type FTDC struct {
 // `ftdcDirectory`.
 func New(ftdcDirectory string, logger logging.Logger) *FTDC {
 	ret := newFTDC(logger)
-	ret.maxFileSizeBytes = 1_000_000
-	ret.maxNumFiles = 10
+	ret.maxFileSizeBytes = 10_000_000
+	ret.maxNumFiles = 20
 	ret.ftdcDir = ftdcDirectory
 	return ret
 }
@@ -604,7 +604,7 @@ func (ftdc *FTDC) checkAndDeleteOldFiles() error {
 // deletion testing. Filename generation uses padding such that we can rely on there before 2/4
 // digits for every numeric value.
 //
-//nolint
+// nolint
 // Example filename: countingBytesTest1228324349/viam-server-2024-11-18T20-37-01Z.ftdc
 var filenameTimeRe = regexp.MustCompile(`viam-server-(\d{4})-(\d{2})-(\d{2})T(\d{2})-(\d{2})-(\d{2})Z.ftdc`)
 

--- a/ftdc/ftdc.go
+++ b/ftdc/ftdc.go
@@ -604,7 +604,7 @@ func (ftdc *FTDC) checkAndDeleteOldFiles() error {
 // deletion testing. Filename generation uses padding such that we can rely on there before 2/4
 // digits for every numeric value.
 //
-// nolint
+//nolint
 // Example filename: countingBytesTest1228324349/viam-server-2024-11-18T20-37-01Z.ftdc
 var filenameTimeRe = regexp.MustCompile(`viam-server-(\d{4})-(\d{2})-(\d{2})T(\d{2})-(\d{2})-(\d{2})Z.ftdc`)
 


### PR DESCRIPTION
in some machines, the current limits means ~8hrs of data, this aims to get the limit closer to 1 week of data (200mbs should is 20x of 10mb, which is the current limit)