### PR TITLE
Revert "RSDK-9758 - refactor ensureLoggedIn call sites (#4784)"

### DIFF
--- a/cli/auth.go
+++ b/cli/auth.go
@@ -230,6 +230,10 @@ func PrintAccessTokenAction(cCtx *cli.Context, args emptyArgs) error {
 }
 
 func (c *viamClient) printAccessTokenAction(cCtx *cli.Context) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+
 	if token, ok := c.conf.Auth.(*token); ok {
 		printf(cCtx.App.Writer, token.AccessToken)
 	} else {
@@ -309,6 +313,9 @@ func OrganizationsAPIKeyCreateAction(cCtx *cli.Context, args organizationsAPIKey
 }
 
 func (c *viamClient) organizationsAPIKeyCreateAction(cCtx *cli.Context, args organizationsAPIKeyCreateArgs) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
 	orgID := args.OrgID
 	keyName := args.Name
 	if keyName == "" {
@@ -327,6 +334,10 @@ func (c *viamClient) organizationsAPIKeyCreateAction(cCtx *cli.Context, args org
 }
 
 func (c *viamClient) createOrganizationAPIKey(orgID, keyName string) (*apppb.CreateKeyResponse, error) {
+	if err := c.ensureLoggedIn(); err != nil {
+		return nil, err
+	}
+
 	req := &apppb.CreateKeyRequest{
 		Authorizations: []*apppb.Authorization{
 			{
@@ -362,6 +373,10 @@ func LocationAPIKeyCreateAction(cCtx *cli.Context, args locationAPIKeyCreateArgs
 }
 
 func (c *viamClient) locationAPIKeyCreateAction(cCtx *cli.Context, args locationAPIKeyCreateArgs) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+
 	locationID := args.LocationID
 	orgID := args.OrgID
 	keyName := args.Name
@@ -423,6 +438,10 @@ func RobotAPIKeyCreateAction(cCtx *cli.Context, args robotAPIKeyCreateArgs) erro
 }
 
 func (c *viamClient) robotAPIKeyCreateAction(cCtx *cli.Context, args robotAPIKeyCreateArgs) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+
 	robotID := args.MachineID
 	keyName := args.Name
 	orgID := args.OrgID
@@ -578,6 +597,9 @@ func (c *viamClient) prepareDial(
 	orgStr, locStr, robotStr, partStr string,
 	debug bool,
 ) (context.Context, string, []rpc.DialOption, error) {
+	if err := c.ensureLoggedIn(); err != nil {
+		return nil, "", nil, err
+	}
 	if err := c.selectOrganization(orgStr); err != nil {
 		return nil, "", nil, err
 	}

--- a/cli/client.go
+++ b/cli/client.go
@@ -146,6 +146,10 @@ func OrganizationsSupportEmailSetAction(cCtx *cli.Context, args organizationsSup
 }
 
 func (c *viamClient) organizationsSupportEmailSetAction(cCtx *cli.Context, orgID, supportEmail string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+
 	_, err := c.client.OrganizationSetSupportEmail(c.c.Context, &apppb.OrganizationSetSupportEmailRequest{
 		OrgId: orgID,
 		Email: supportEmail,
@@ -177,6 +181,10 @@ func OrganizationsSupportEmailGetAction(cCtx *cli.Context, args organizationsSup
 }
 
 func (c *viamClient) organizationsSupportEmailGetAction(cCtx *cli.Context, orgID string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+
 	resp, err := c.client.OrganizationGetSupportEmail(c.c.Context, &apppb.OrganizationGetSupportEmailRequest{
 		OrgId: orgID,
 	})
@@ -234,6 +242,10 @@ func (c *viamClient) disableAuthServiceAction(cCtx *cli.Context, orgID string) e
 		return errors.New("cannot disable auth service without an organization ID")
 	}
 
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+
 	if _, err := c.client.DisableAuthService(cCtx.Context, &apppb.DisableAuthServiceRequest{OrgId: orgID}); err != nil {
 		return err
 	}
@@ -262,6 +274,10 @@ func EnableAuthServiceAction(cCtx *cli.Context, args enableAuthServiceArgs) erro
 }
 
 func (c *viamClient) enableAuthServiceAction(cCtx *cli.Context, orgID string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+
 	_, err := c.client.EnableAuthService(cCtx.Context, &apppb.EnableAuthServiceRequest{OrgId: orgID})
 	if err != nil {
 		return err
@@ -296,6 +312,9 @@ func UpdateBillingServiceAction(cCtx *cli.Context, args updateBillingServiceArgs
 }
 
 func (c *viamClient) updateBillingServiceAction(cCtx *cli.Context, orgID, addressAsString string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
 	address, err := parseBillingAddress(addressAsString)
 	if err != nil {
 		return err
@@ -336,6 +355,10 @@ func GetBillingConfigAction(cCtx *cli.Context, args getBillingConfigArgs) error 
 }
 
 func (c *viamClient) getBillingConfig(cCtx *cli.Context, orgID string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+
 	resp, err := c.client.GetBillingServiceConfig(cCtx.Context, &apppb.GetBillingServiceConfigRequest{
 		OrgId: orgID,
 	})
@@ -388,6 +411,10 @@ func OrganizationEnableBillingServiceAction(cCtx *cli.Context, args organization
 }
 
 func (c *viamClient) organizationEnableBillingServiceAction(cCtx *cli.Context, orgID, addressAsString string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+
 	address, err := parseBillingAddress(addressAsString)
 	if err != nil {
 		return err
@@ -422,6 +449,10 @@ func OrganizationDisableBillingServiceAction(cCtx *cli.Context, args organizatio
 }
 
 func (c *viamClient) organizationDisableBillingServiceAction(cCtx *cli.Context, orgID string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+
 	if _, err := c.client.DisableBillingService(cCtx.Context, &apppb.DisableBillingServiceRequest{
 		OrgId: orgID,
 	}); err != nil {
@@ -457,6 +488,10 @@ func OrganizationLogoSetAction(cCtx *cli.Context, args organizationsLogoSetArgs)
 }
 
 func (c *viamClient) organizationLogoSetAction(cCtx *cli.Context, orgID, logoFilePath string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+
 	logoFile, err := os.Open(filepath.Clean(logoFilePath))
 	if err != nil {
 		return errors.WithMessagef(err, "could not open logo file: %s", logoFilePath)
@@ -509,6 +544,10 @@ func OrganizationsLogoGetAction(cCtx *cli.Context, args organizationsLogoGetArgs
 }
 
 func (c *viamClient) organizationsLogoGetAction(cCtx *cli.Context, orgID string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+
 	resp, err := c.client.OrganizationGetLogo(cCtx.Context, &apppb.OrganizationGetLogoRequest{
 		OrgId: orgID,
 	})
@@ -545,6 +584,10 @@ func ListOAuthAppsAction(cCtx *cli.Context, args listOAuthAppsArgs) error {
 }
 
 func (c *viamClient) listOAuthAppsAction(cCtx *cli.Context, orgID string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+
 	resp, err := c.client.ListOAuthApps(cCtx.Context, &apppb.ListOAuthAppsRequest{
 		OrgId: orgID,
 	})
@@ -1405,6 +1448,10 @@ func tunnelTraffic(ctx *cli.Context, robotClient *client.RobotClient, local, des
 }
 
 func (c *viamClient) robotPartTunnel(cCtx *cli.Context, args robotsPartTunnelArgs) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+
 	orgStr := args.Organization
 	locStr := args.Location
 	robotStr := args.Machine
@@ -1714,14 +1761,7 @@ func newViamClientInner(c *cli.Context, disableBrowserOpen bool) (*viamClient, e
 // Creates a new viam client, defaulting to _not_ passing the `disableBrowerOpen` arg (which
 // users don't even have an option of setting for any CLI method currently except `Login`).
 func newViamClient(c *cli.Context) (*viamClient, error) {
-	client, err := newViamClientInner(c, false)
-	if err != nil {
-		return nil, err
-	}
-	if err := client.ensureLoggedIn(); err != nil {
-		return nil, err
-	}
-	return client, nil
+	return newViamClientInner(c, false)
 }
 
 func (c *viamClient) loadOrganizations() error {
@@ -1734,6 +1774,9 @@ func (c *viamClient) loadOrganizations() error {
 }
 
 func (c *viamClient) selectOrganization(orgStr string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
 	if orgStr != "" && (c.selectedOrg.Id == orgStr || c.selectedOrg.Name == orgStr) {
 		return nil
 	}
@@ -1779,6 +1822,9 @@ func (c *viamClient) selectOrganization(orgStr string) error {
 // org UUID, then this matchs on organization ID, otherwise this will match
 // on organization name.
 func (c *viamClient) getOrg(orgStr string) (*apppb.Organization, error) {
+	if err := c.ensureLoggedIn(); err != nil {
+		return nil, err
+	}
 	resp, err := c.client.ListOrganizations(c.c.Context, &apppb.ListOrganizationsRequest{})
 	if err != nil {
 		return nil, err
@@ -1803,6 +1849,10 @@ func (c *viamClient) getOrg(orgStr string) (*apppb.Organization, error) {
 // getUserOrgByPublicNamespace searches the logged in users orgs to see
 // if any have a matching public namespace.
 func (c *viamClient) getUserOrgByPublicNamespace(publicNamespace string) (*apppb.Organization, error) {
+	if err := c.ensureLoggedIn(); err != nil {
+		return nil, err
+	}
+
 	if err := c.loadOrganizations(); err != nil {
 		return nil, err
 	}
@@ -1815,6 +1865,9 @@ func (c *viamClient) getUserOrgByPublicNamespace(publicNamespace string) (*apppb
 }
 
 func (c *viamClient) listOrganizations() ([]*apppb.Organization, error) {
+	if err := c.ensureLoggedIn(); err != nil {
+		return nil, err
+	}
 	if err := c.loadOrganizations(); err != nil {
 		return nil, err
 	}
@@ -1868,6 +1921,9 @@ func (c *viamClient) selectLocation(locStr string) error {
 }
 
 func (c *viamClient) listLocations(orgID string) ([]*apppb.Location, error) {
+	if err := c.ensureLoggedIn(); err != nil {
+		return nil, err
+	}
 	if err := c.selectOrganization(orgID); err != nil {
 		return nil, err
 	}
@@ -1878,6 +1934,9 @@ func (c *viamClient) listLocations(orgID string) ([]*apppb.Location, error) {
 }
 
 func (c *viamClient) listRobots(orgStr, locStr string) ([]*apppb.Robot, error) {
+	if err := c.ensureLoggedIn(); err != nil {
+		return nil, err
+	}
 	if err := c.selectOrganization(orgStr); err != nil {
 		return nil, err
 	}
@@ -1894,6 +1953,10 @@ func (c *viamClient) listRobots(orgStr, locStr string) ([]*apppb.Robot, error) {
 }
 
 func (c *viamClient) robot(orgStr, locStr, robotStr string) (*apppb.Robot, error) {
+	if err := c.ensureLoggedIn(); err != nil {
+		return nil, err
+	}
+
 	robots, err := c.listRobots(orgStr, locStr)
 	if err != nil {
 		return nil, err
@@ -1932,6 +1995,9 @@ func (c *viamClient) robotPart(orgStr, locStr, robotStr, partStr string) (*apppb
 }
 
 func (c *viamClient) robotPartInner(orgStr, locStr, robotStr, partStr string) (*apppb.RobotPart, error) {
+	if err := c.ensureLoggedIn(); err != nil {
+		return nil, err
+	}
 	parts, err := c.robotParts(orgStr, locStr, robotStr)
 	if err != nil {
 		return nil, err
@@ -1967,10 +2033,16 @@ func (c *viamClient) robotPartInner(orgStr, locStr, robotStr, partStr string) (*
 // note: overlaps with viamClient.robotPart, which wraps GetRobotParts.
 // Use this variant if you don't know the robot ID.
 func (c *viamClient) getRobotPart(partID string) (*apppb.GetRobotPartResponse, error) {
+	if err := c.ensureLoggedIn(); err != nil {
+		return nil, err
+	}
 	return c.client.GetRobotPart(c.c.Context, &apppb.GetRobotPartRequest{Id: partID})
 }
 
 func (c *viamClient) updateRobotPart(part *apppb.RobotPart, confMap map[string]any) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
 	confStruct, err := structpb.NewStruct(confMap)
 	if err != nil {
 		return errors.Wrap(err, "in NewStruct")
@@ -2028,6 +2100,9 @@ func (c *viamClient) robotPartLogs(orgStr, locStr, robotStr, partStr string, err
 }
 
 func (c *viamClient) robotParts(orgStr, locStr, robotStr string) ([]*apppb.RobotPart, error) {
+	if err := c.ensureLoggedIn(); err != nil {
+		return nil, err
+	}
 	robot, err := c.robot(orgStr, locStr, robotStr)
 	if err != nil {
 		return nil, err
@@ -2555,6 +2630,10 @@ func ReadOAuthAppAction(c *cli.Context, args readOAuthAppArgs) error {
 }
 
 func (c *viamClient) readOAuthAppAction(cCtx *cli.Context, orgID, clientID string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+
 	req := &apppb.ReadOAuthAppRequest{OrgId: orgID, ClientId: clientID}
 	resp, err := c.client.ReadOAuthApp(c.c.Context, req)
 	if err != nil {
@@ -2630,6 +2709,10 @@ func DeleteOAuthAppAction(c *cli.Context, args deleteOAuthAppArgs) error {
 }
 
 func (c *viamClient) deleteOAuthAppAction(cCtx *cli.Context, orgID, clientID string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+
 	req := &apppb.DeleteOAuthAppRequest{
 		OrgId:    orgID,
 		ClientId: clientID,
@@ -2774,6 +2857,10 @@ func CreateOAuthAppAction(c *cli.Context, args createOAuthAppArgs) error {
 }
 
 func (c *viamClient) createOAuthAppAction(cCtx *cli.Context, args createOAuthAppArgs) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+
 	config, err := generateOAuthConfig(args.ClientAuthentication, args.Pkce, args.UrlValidation,
 		args.LogoutURI, args.OriginURIs, args.RedirectURIs, args.EnabledGrants)
 	if err != nil {
@@ -2820,6 +2907,10 @@ func UpdateOAuthAppAction(c *cli.Context, args updateOAuthAppArgs) error {
 }
 
 func (c *viamClient) updateOAuthAppAction(cCtx *cli.Context, args updateOAuthAppArgs) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+
 	req, err := createUpdateOAuthAppRequest(args)
 	if err != nil {
 		return err

--- a/cli/data.go
+++ b/cli/data.go
@@ -354,6 +354,10 @@ func (c *viamClient) dataExportTabularAction(cCtx *cli.Context, args dataExportT
 
 // BinaryData downloads binary data matching filter to dst.
 func (c *viamClient) binaryData(dst string, filter *datapb.Filter, parallelDownloads, timeout uint) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+
 	return c.performActionOnBinaryDataFromFilter(
 		func(id *datapb.BinaryID) error {
 			return c.downloadBinary(dst, id, timeout)
@@ -688,6 +692,10 @@ func filenameForDownload(meta *datapb.BinaryMetadata) string {
 
 // tabularData downloads unified tabular data and metadata for the requested data source and interval to the specified destination.
 func (c *viamClient) tabularData(dest string, request *datapb.ExportTabularDataRequest) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+
 	if err := makeDestinationDirs(dest); err != nil {
 		return errors.Wrapf(err, "could not create destination directories")
 	}
@@ -836,6 +844,9 @@ func makeDestinationDirs(dst string) error {
 }
 
 func (c *viamClient) deleteBinaryData(filter *datapb.Filter) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
 	resp, err := c.dataClient.DeleteBinaryDataByFilter(context.Background(),
 		&datapb.DeleteBinaryDataByFilterRequest{Filter: filter})
 	if err != nil {
@@ -846,6 +857,9 @@ func (c *viamClient) deleteBinaryData(filter *datapb.Filter) error {
 }
 
 func (c *viamClient) dataAddTagsToBinaryByFilter(filter *datapb.Filter, tags []string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
 	_, err := c.dataClient.AddTagsToBinaryDataByFilter(context.Background(),
 		&datapb.AddTagsToBinaryDataByFilterRequest{Filter: filter, Tags: tags})
 	if err != nil {
@@ -856,6 +870,9 @@ func (c *viamClient) dataAddTagsToBinaryByFilter(filter *datapb.Filter, tags []s
 }
 
 func (c *viamClient) dataRemoveTagsFromBinaryByFilter(filter *datapb.Filter, tags []string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
 	_, err := c.dataClient.RemoveTagsFromBinaryDataByFilter(context.Background(),
 		&datapb.RemoveTagsFromBinaryDataByFilterRequest{Filter: filter, Tags: tags})
 	if err != nil {
@@ -866,6 +883,9 @@ func (c *viamClient) dataRemoveTagsFromBinaryByFilter(filter *datapb.Filter, tag
 }
 
 func (c *viamClient) dataAddTagsToBinaryByIDs(tags []string, orgID, locationID string, fileIDs []string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
 	binaryData := make([]*datapb.BinaryID, 0, len(fileIDs))
 	for _, fileID := range fileIDs {
 		binaryData = append(binaryData, &datapb.BinaryID{
@@ -886,6 +906,9 @@ func (c *viamClient) dataAddTagsToBinaryByIDs(tags []string, orgID, locationID s
 // dataRemoveTagsFromData removes tags from data, with the specified org ID, location ID,
 // and file IDs.
 func (c *viamClient) dataRemoveTagsFromBinaryByIDs(tags []string, orgID, locationID string, fileIDs []string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
 	binaryData := make([]*datapb.BinaryID, 0, len(fileIDs))
 	for _, fileID := range fileIDs {
 		binaryData = append(binaryData, &datapb.BinaryID{
@@ -905,6 +928,9 @@ func (c *viamClient) dataRemoveTagsFromBinaryByIDs(tags []string, orgID, locatio
 
 // deleteTabularData delete tabular data matching filter.
 func (c *viamClient) deleteTabularData(orgID string, deleteOlderThanDays int) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
 	resp, err := c.dataClient.DeleteTabularData(context.Background(),
 		&datapb.DeleteTabularDataRequest{OrganizationId: orgID, DeleteOlderThanDays: uint32(deleteOlderThanDays)})
 	if err != nil {
@@ -936,6 +962,9 @@ func DataAddToDatasetByIDs(c *cli.Context, args dataAddToDatasetByIDsArgs) error
 
 // dataAddToDatasetByIDs adds data, with the specified org ID, location ID, and file IDs to the dataset corresponding to the dataset ID.
 func (c *viamClient) dataAddToDatasetByIDs(datasetID, orgID, locationID string, fileIDs []string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
 	binaryData := make([]*datapb.BinaryID, 0, len(fileIDs))
 	for _, fileID := range fileIDs {
 		binaryData = append(binaryData, &datapb.BinaryID{
@@ -975,6 +1004,9 @@ func DataAddToDatasetByFilter(c *cli.Context, args dataAddToDatasetByFilterArgs)
 
 // dataAddToDatasetByFilter adds data, with the specified filter to the dataset corresponding to the dataset ID.
 func (c *viamClient) dataAddToDatasetByFilter(filter *datapb.Filter, datasetID string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
 	parallelActions := uint(100)
 
 	return c.performActionOnBinaryDataFromFilter(
@@ -1012,6 +1044,9 @@ func DataRemoveFromDataset(c *cli.Context, args dataRemoveFromDatasetArgs) error
 // dataRemoveFromDataset removes data, with the specified org ID, location ID,
 // and file IDs from the dataset corresponding to the dataset ID.
 func (c *viamClient) dataRemoveFromDataset(datasetID, orgID, locationID string, fileIDs []string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
 	binaryData := make([]*datapb.BinaryID, 0, len(fileIDs))
 	for _, fileID := range fileIDs {
 		binaryData = append(binaryData, &datapb.BinaryID{
@@ -1136,6 +1171,9 @@ func DataConfigureDatabaseUser(c *cli.Context, args dataConfigureDatabaseUserArg
 // being configured. Viam uses gRPC over TLS, so the entire request will be encrypted while in
 // flight, including the password.
 func (c *viamClient) dataConfigureDatabaseUser(orgID, password string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
 	_, err := c.dataClient.ConfigureDatabaseUser(context.Background(),
 		&datapb.ConfigureDatabaseUserRequest{OrganizationId: orgID, Password: password})
 	if err != nil {
@@ -1167,6 +1205,9 @@ func DataGetDatabaseConnection(c *cli.Context, args dataGetDatabaseConnectionArg
 // dataGetDatabaseConnection gets the hostname of the MongoDB Atlas Data Federation instance
 // for the given organization ID.
 func (c *viamClient) dataGetDatabaseConnection(orgID string) (*datapb.GetDatabaseConnectionResponse, error) {
+	if err := c.ensureLoggedIn(); err != nil {
+		return nil, err
+	}
 	res, err := c.dataClient.GetDatabaseConnection(context.Background(), &datapb.GetDatabaseConnectionRequest{OrganizationId: orgID})
 	if err != nil {
 		return nil, errors.Wrapf(err, serverErrorMessage)

--- a/cli/dataset.go
+++ b/cli/dataset.go
@@ -42,6 +42,9 @@ func DatasetCreateAction(c *cli.Context, args datasetCreateArgs) error {
 
 // createDataset creates a dataset with the a dataset ID.
 func (c *viamClient) createDataset(orgID, datasetName string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
 	resp, err := c.datasetClient.CreateDataset(context.Background(),
 		&datasetpb.CreateDatasetRequest{OrganizationId: orgID, Name: datasetName})
 	if err != nil {
@@ -70,6 +73,9 @@ func DatasetRenameAction(c *cli.Context, args datasetRenameArgs) error {
 
 // renameDataset renames an existing datasetID with the newDatasetName.
 func (c *viamClient) renameDataset(datasetID, newDatasetName string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
 	_, err := c.datasetClient.RenameDataset(context.Background(),
 		&datasetpb.RenameDatasetRequest{Id: datasetID, Name: newDatasetName})
 	if err != nil {
@@ -111,6 +117,9 @@ func DatasetListAction(c *cli.Context, args datasetListArgs) error {
 
 // listDatasetByIDs list all datasets by ID.
 func (c *viamClient) listDatasetByIDs(datasetIDs []string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
 	resp, err := c.datasetClient.ListDatasetsByIDs(context.Background(),
 		&datasetpb.ListDatasetsByIDsRequest{Ids: datasetIDs})
 	if err != nil {
@@ -124,6 +133,9 @@ func (c *viamClient) listDatasetByIDs(datasetIDs []string) error {
 
 // listDatasetByOrg list all datasets for the specified org ID.
 func (c *viamClient) listDatasetByOrg(orgID string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
 	resp, err := c.datasetClient.ListDatasetsByOrganizationID(context.Background(),
 		&datasetpb.ListDatasetsByOrganizationIDRequest{OrganizationId: orgID})
 	if err != nil {
@@ -153,6 +165,9 @@ func DatasetDeleteAction(c *cli.Context, args datasetDeleteArgs) error {
 
 // deleteDataset deletes a dataset with the specified ID.
 func (c *viamClient) deleteDataset(datasetID string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
 	_, err := c.datasetClient.DeleteDataset(context.Background(),
 		&datasetpb.DeleteDatasetRequest{Id: datasetID})
 	if err != nil {
@@ -185,6 +200,10 @@ func DatasetDownloadAction(c *cli.Context, args datasetDownloadArgs) error {
 
 // downloadDataset downloads a dataset with the specified ID.
 func (c *viamClient) downloadDataset(dst, datasetID string, includeJSONLines bool, parallelDownloads, timeout uint) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+
 	var datasetFile *os.File
 	var err error
 	if includeJSONLines {

--- a/cli/ml_training.go
+++ b/cli/ml_training.go
@@ -131,6 +131,9 @@ func MLSubmitTrainingJob(c *cli.Context, args mlSubmitTrainingJobArgs) error {
 func (c *viamClient) mlSubmitTrainingJob(datasetID, orgID, modelName, modelVersion, modelType string,
 	labels []string,
 ) (string, error) {
+	if err := c.ensureLoggedIn(); err != nil {
+		return "", err
+	}
 	if modelVersion == "" {
 		modelVersion = time.Now().Format("2006-01-02T15-04-05")
 	}
@@ -156,6 +159,9 @@ func (c *viamClient) mlSubmitTrainingJob(datasetID, orgID, modelName, modelVersi
 func (c *viamClient) mlSubmitCustomTrainingJob(datasetID, registryItemID, registryItemVersion, orgID, modelName,
 	modelVersion string, args []string,
 ) (string, error) {
+	if err := c.ensureLoggedIn(); err != nil {
+		return "", err
+	}
 	splitName := strings.Split(registryItemID, ":")
 	if len(splitName) != 2 {
 		return "", errors.Errorf("invalid training script name '%s'."+
@@ -214,6 +220,9 @@ func DataGetTrainingJob(c *cli.Context, args dataGetTrainingJobArgs) error {
 
 // dataGetTrainingJob gets a training job with the given ID.
 func (c *viamClient) dataGetTrainingJob(trainingJobID string) (*mltrainingpb.TrainingJobMetadata, error) {
+	if err := c.ensureLoggedIn(); err != nil {
+		return nil, err
+	}
 	resp, err := c.mlTrainingClient.GetTrainingJob(context.Background(), &mltrainingpb.GetTrainingJobRequest{Id: trainingJobID})
 	if err != nil {
 		return nil, err
@@ -247,6 +256,9 @@ func MLGetTrainingJobLogs(c *cli.Context, args mlGetTrainingJobLogsArgs) error {
 
 // mlGetTrainingJobLogs gets the training job logs with the given ID.
 func (c *viamClient) mlGetTrainingJobLogs(trainingJobID string) ([]*mltrainingpb.TrainingJobLogEntry, error) {
+	if err := c.ensureLoggedIn(); err != nil {
+		return nil, err
+	}
 	var allLogs []*mltrainingpb.TrainingJobLogEntry
 	var page string
 
@@ -287,6 +299,9 @@ func DataCancelTrainingJob(c *cli.Context, args dataCancelTrainingJobArgs) error
 
 // dataCancelTrainingJob cancels a training job with the given ID.
 func (c *viamClient) dataCancelTrainingJob(trainingJobID string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
 	if _, err := c.mlTrainingClient.CancelTrainingJob(
 		context.Background(), &mltrainingpb.CancelTrainingJobRequest{Id: trainingJobID}); err != nil {
 		return err
@@ -317,6 +332,10 @@ func DataListTrainingJobs(c *cli.Context, args dataListTrainingJobsArgs) error {
 
 // dataListTrainingJobs lists training jobs for the given org.
 func (c *viamClient) dataListTrainingJobs(orgID, status string) ([]*mltrainingpb.TrainingJobMetadata, error) {
+	if err := c.ensureLoggedIn(); err != nil {
+		return nil, err
+	}
+
 	if status == "" {
 		status = "unspecified"
 	}
@@ -446,6 +465,10 @@ func MLTrainingUpdateAction(c *cli.Context, args mlTrainingUpdateArgs) error {
 }
 
 func (c *viamClient) updateTrainingScript(orgID, name, visibility, description, url string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
+
 	// Get registry item
 	itemID := fmt.Sprintf("%s:%s", orgID, name)
 	resp, err := c.client.GetRegistryItem(c.c.Context, &v1.GetRegistryItemRequest{

--- a/cli/module_generate.go
+++ b/cli/module_generate.go
@@ -70,6 +70,9 @@ func GenerateModuleAction(cCtx *cli.Context, args generateModuleArgs) error {
 }
 
 func (c *viamClient) generateModuleAction(cCtx *cli.Context, args generateModuleArgs) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
 	var newModule *modulegen.ModuleInputs
 	var err error
 

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -413,6 +413,9 @@ func UpdateModelsAction(c *cli.Context, args updateModelsArgs) error {
 }
 
 func (c *viamClient) createModule(moduleName, organizationID string) (*apppb.CreateModuleResponse, error) {
+	if err := c.ensureLoggedIn(); err != nil {
+		return nil, err
+	}
 	req := apppb.CreateModuleRequest{
 		Name:           moduleName,
 		OrganizationId: organizationID,
@@ -421,6 +424,9 @@ func (c *viamClient) createModule(moduleName, organizationID string) (*apppb.Cre
 }
 
 func (c *viamClient) getModule(moduleID moduleID) (*apppb.GetModuleResponse, error) {
+	if err := c.ensureLoggedIn(); err != nil {
+		return nil, err
+	}
 	req := apppb.GetModuleRequest{
 		ModuleId: moduleID.String(),
 	}
@@ -428,6 +434,9 @@ func (c *viamClient) getModule(moduleID moduleID) (*apppb.GetModuleResponse, err
 }
 
 func (c *viamClient) updateModule(moduleID moduleID, manifest moduleManifest) (*apppb.UpdateModuleResponse, error) {
+	if err := c.ensureLoggedIn(); err != nil {
+		return nil, err
+	}
 	var models []*apppb.Model
 	for _, moduleComponent := range manifest.Models {
 		models = append(models, moduleComponentToProto(moduleComponent))
@@ -457,6 +466,10 @@ func (c *viamClient) uploadModuleFile(
 	constraints []string,
 	tarballPath string,
 ) (*apppb.UploadModuleFileResponse, error) {
+	if err := c.ensureLoggedIn(); err != nil {
+		return nil, err
+	}
+
 	//nolint:gosec
 	file, err := os.Open(tarballPath)
 	if err != nil {
@@ -982,6 +995,9 @@ func DownloadModuleAction(c *cli.Context, flags downloadModuleFlags) error {
 	}
 	client, err := newViamClient(c)
 	if err != nil {
+		return err
+	}
+	if err := client.ensureLoggedIn(); err != nil {
 		return err
 	}
 	req := &apppb.GetModuleRequest{ModuleId: moduleID}

--- a/cli/packages.go
+++ b/cli/packages.go
@@ -84,6 +84,9 @@ func convertPackageTypeToProto(packageType string) (*packagespb.PackageType, err
 }
 
 func (c *viamClient) packageExportAction(orgID, name, version, packageType, destination string) error {
+	if err := c.ensureLoggedIn(); err != nil {
+		return err
+	}
 	if orgID == "" || name == "" {
 		if orgID != "" || name != "" {
 			return fmt.Errorf("if either of %s or %s is missing, both must be missing", generalFlagOrgID, generalFlagName)
@@ -224,6 +227,10 @@ func (c *viamClient) uploadPackage(
 	orgID, name, version, packageType, tarballPath string,
 	metadataStruct *structpb.Struct,
 ) (*packagespb.CreatePackageResponse, error) {
+	if err := c.ensureLoggedIn(); err != nil {
+		return nil, err
+	}
+
 	//nolint:gosec
 	file, err := os.Open(tarballPath)
 	if err != nil {


### PR DESCRIPTION
This reverts commit 26b7cfc49778b93df96728109ededfdacc5785aa, which was breaking `viam login api-key`. A fix will be incoming shortly but wanted to revert quickly to allow for a timely update to RDK stable.