### PR TITLE
RSDK-10112 - Fix maintenance config to proto

### DIFF
--- a/config/proto_conversions.go
+++ b/config/proto_conversions.go
@@ -650,12 +650,18 @@ func NetworkConfigToProto(network *NetworkConfig) (*pb.NetworkConfig, error) {
 	return &proto, nil
 }
 
-// MaintenanceConfigToProto converts MaintenanceConfig from the proto equivalent.
+// MaintenanceConfigToProto converts MaintenanceConfig to the proto equivalent.
 func MaintenanceConfigToProto(maintenanceConfig *MaintenanceConfig) (*pb.MaintenanceConfig, error) {
 	// convert from string to resource name
-	name, err := resource.NewFromString(maintenanceConfig.SensorName)
-	if err != nil {
-		return nil, err
+	var (
+		name resource.Name
+		err  error
+	)
+	if maintenanceConfig.SensorName != "" {
+		name, err = resource.NewFromString(maintenanceConfig.SensorName)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	proto := pb.MaintenanceConfig{
@@ -684,11 +690,11 @@ func NetworkConfigFromProto(proto *pb.NetworkConfig) (*NetworkConfig, error) {
 
 // MaintenanceConfigFromProto creates a MaintenanceConfig from the proto equivalent.
 func MaintenanceConfigFromProto(proto *pb.MaintenanceConfig) (*MaintenanceConfig, error) {
-	MaintenanceConfig := MaintenanceConfig{
-		SensorName:            protoRdkUtils.ResourceNameFromProto(proto.SensorName).String(),
+	maintenanceConfig := MaintenanceConfig{
+		SensorName:            protoRdkUtils.ResourceNameFromProto(proto.GetSensorName()).String(),
 		MaintenanceAllowedKey: proto.GetMaintenanceAllowedKey(),
 	}
-	return &MaintenanceConfig, nil
+	return &maintenanceConfig, nil
 }
 
 // AuthConfigToProto converts AuthConfig to the proto equivalent.

--- a/config/proto_conversions_test.go
+++ b/config/proto_conversions_test.go
@@ -1058,6 +1058,19 @@ func TestMaintenanceConfigToProtoSuccess(t *testing.T) {
 
 	test.That(t, *out, test.ShouldResemble, testMaintenanceConfig)
 }
+func TestMaintenanceConfigToProtoEmptyName(t *testing.T) {
+	testMaintenanceConfig := MaintenanceConfig{
+		SensorName:            "",
+		MaintenanceAllowedKey: "honk",
+	}
+
+	proto, err := MaintenanceConfigToProto(&testMaintenanceConfig)
+	test.That(t, err, test.ShouldBeNil)
+	out, err := MaintenanceConfigFromProto(proto)
+	test.That(t, err, test.ShouldBeNil)
+
+	test.That(t, *out, test.ShouldResemble, testMaintenanceConfig)
+}
 
 func TestMaintenanceConfigToProtoRemoteSuccess(t *testing.T) {
 	testMaintenanceConfig := MaintenanceConfig{

--- a/config/proto_conversions_test.go
+++ b/config/proto_conversions_test.go
@@ -1058,6 +1058,7 @@ func TestMaintenanceConfigToProtoSuccess(t *testing.T) {
 
 	test.That(t, *out, test.ShouldResemble, testMaintenanceConfig)
 }
+
 func TestMaintenanceConfigToProtoEmptyName(t *testing.T) {
 	testMaintenanceConfig := MaintenanceConfig{
 		SensorName:            "",

--- a/config/proto_conversions_test.go
+++ b/config/proto_conversions_test.go
@@ -1075,7 +1075,7 @@ func TestMaintenanceConfigToProtoEmptyName(t *testing.T) {
 
 func TestMaintenanceConfigToProtoMalformedName(t *testing.T) {
 	testMaintenanceConfig := MaintenanceConfig{
-		SensorName:            "abc",
+		SensorName:            "car:go",
 		MaintenanceAllowedKey: "honk",
 	}
 
@@ -1100,14 +1100,4 @@ func TestMaintenanceConfigToProtoRemoteSuccess(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	test.That(t, *out, test.ShouldResemble, testMaintenanceConfig)
-}
-
-func TestMaintenanceConfigToProtoFailure(t *testing.T) {
-	testMaintenanceConfig := MaintenanceConfig{
-		SensorName:            "car:go",
-		MaintenanceAllowedKey: "slow",
-	}
-
-	_, err := MaintenanceConfigToProto(&testMaintenanceConfig)
-	test.That(t, err.Error(), test.ShouldEqual, "string \"car:go\" is not a fully qualified resource name")
 }

--- a/config/proto_conversions_test.go
+++ b/config/proto_conversions_test.go
@@ -1072,6 +1072,21 @@ func TestMaintenanceConfigToProtoEmptyName(t *testing.T) {
 	test.That(t, *out, test.ShouldResemble, testMaintenanceConfig)
 }
 
+func TestMaintenanceConfigToProtoMalformedName(t *testing.T) {
+	testMaintenanceConfig := MaintenanceConfig{
+		SensorName:            "abc",
+		MaintenanceAllowedKey: "honk",
+	}
+
+	proto, err := MaintenanceConfigToProto(&testMaintenanceConfig)
+	test.That(t, err, test.ShouldBeNil)
+	out, err := MaintenanceConfigFromProto(proto)
+	test.That(t, err, test.ShouldBeNil)
+
+	testMaintenanceConfig.SensorName = resource.NewName(resource.API{}, testMaintenanceConfig.SensorName).String()
+	test.That(t, *out, test.ShouldResemble, testMaintenanceConfig)
+}
+
 func TestMaintenanceConfigToProtoRemoteSuccess(t *testing.T) {
 	testMaintenanceConfig := MaintenanceConfig{
 		SensorName:            "rdk:component:sensor/go:store",

--- a/resource/name.go
+++ b/resource/name.go
@@ -132,9 +132,6 @@ func (n Name) Validate() error {
 
 // String returns the fully qualified name for the resource.
 func (n Name) String() string {
-	if n == (Name{}) {
-		return ""
-	}
 	name := n.API.String()
 	if n.Remote != "" {
 		name = fmt.Sprintf("%s/%s:%s", name, n.Remote, n.Name)

--- a/resource/name.go
+++ b/resource/name.go
@@ -132,6 +132,9 @@ func (n Name) Validate() error {
 
 // String returns the fully qualified name for the resource.
 func (n Name) String() string {
+	if n == (Name{}) {
+		return ""
+	}
 	name := n.API.String()
 	if n.Remote != "" {
 		name = fmt.Sprintf("%s/%s:%s", name, n.Remote, n.Name)


### PR DESCRIPTION
allows for all types of malformed names to pass on MaintenanceConfigToProto, issue was that any errors were preventing configs from returning from the config endpoint

this will allow for some janky resource names on both sides of the conversion (ToProto and FromProto), but the hope is that validation will take care of it