### PR TITLE
[RSDK-10100, RSDK-10111] - Add utils to lazy encoded image to decode and return errors instead of panic-ing always

### DIFF
--- a/components/camera/camera.go
+++ b/components/camera/camera.go
@@ -161,13 +161,22 @@ func DecodeImageFromCamera(ctx context.Context, mimeType string, extra map[strin
 	if err != nil {
 		return nil, fmt.Errorf("could not get image bytes from camera: %w", err)
 	}
+
 	if len(resBytes) == 0 {
 		return nil, errors.New("received empty bytes from camera")
 	}
+
 	img, err := rimage.DecodeImage(ctx, resBytes, utils.WithLazyMIMEType(resMetadata.MimeType))
 	if err != nil {
 		return nil, fmt.Errorf("could not decode into image.Image: %w", err)
 	}
+
+	if lazyImg, ok := img.(*rimage.LazyEncodedImage); ok {
+		if err := lazyImg.GetErrors(); err != nil {
+			return nil, err
+		}
+	}
+
 	return img, nil
 }
 

--- a/components/camera/camera.go
+++ b/components/camera/camera.go
@@ -161,22 +161,13 @@ func DecodeImageFromCamera(ctx context.Context, mimeType string, extra map[strin
 	if err != nil {
 		return nil, fmt.Errorf("could not get image bytes from camera: %w", err)
 	}
-
 	if len(resBytes) == 0 {
 		return nil, errors.New("received empty bytes from camera")
 	}
-
 	img, err := rimage.DecodeImage(ctx, resBytes, utils.WithLazyMIMEType(resMetadata.MimeType))
 	if err != nil {
 		return nil, fmt.Errorf("could not decode into image.Image: %w", err)
 	}
-
-	if lazyImg, ok := img.(*rimage.LazyEncodedImage); ok {
-		if err := lazyImg.GetErrors(); err != nil {
-			return nil, err
-		}
-	}
-
 	return img, nil
 }
 

--- a/components/camera/transformpipeline/mods_test.go
+++ b/components/camera/transformpipeline/mods_test.go
@@ -608,7 +608,8 @@ func BenchmarkColorRotate(b *testing.B) {
 	am := utils.AttributeMap{
 		"angle_degs": 180,
 	}
-	vs := videoSourceFromCamera(context.Background(), src)
+	vs, err := videoSourceFromCamera(context.Background(), src)
+	test.That(b, err, test.ShouldBeNil)
 	rs, stream, err := newRotateTransform(context.Background(), vs, camera.ColorStream, am)
 	test.That(b, err, test.ShouldBeNil)
 	test.That(b, stream, test.ShouldEqual, camera.ColorStream)
@@ -634,7 +635,8 @@ func BenchmarkDepthRotate(b *testing.B) {
 	am := utils.AttributeMap{
 		"angle_degs": 180,
 	}
-	vs := videoSourceFromCamera(context.Background(), src)
+	vs, err := videoSourceFromCamera(context.Background(), src)
+	test.That(b, err, test.ShouldBeNil)
 	rs, stream, err := newRotateTransform(context.Background(), vs, camera.DepthStream, am)
 	test.That(b, err, test.ShouldBeNil)
 	test.That(b, stream, test.ShouldEqual, camera.DepthStream)

--- a/components/camera/transformpipeline/pipeline_test.go
+++ b/components/camera/transformpipeline/pipeline_test.go
@@ -2,6 +2,7 @@ package transformpipeline
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/pion/mediadevices/pkg/prop"
@@ -213,6 +214,6 @@ func TestVideoSourceFromCameraError(t *testing.T) {
 
 	vs, err := videoSourceFromCamera(context.Background(), malformedCam)
 	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, "failed to create video source from camera")
+	test.That(t, errors.Is(err, ErrVideoSourceCreation), test.ShouldBeTrue)
 	test.That(t, vs, test.ShouldBeNil)
 }

--- a/components/camera/transformpipeline/pipeline_test.go
+++ b/components/camera/transformpipeline/pipeline_test.go
@@ -34,7 +34,8 @@ func TestTransformPipelineColor(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	source := gostream.NewVideoSource(&fake.StaticSource{ColorImg: img}, prop.Video{})
 	src, err := camera.WrapVideoSourceWithProjector(context.Background(), source, nil, camera.ColorStream)
-	vs := videoSourceFromCamera(context.Background(), src)
+	test.That(t, err, test.ShouldBeNil)
+	vs, err := videoSourceFromCamera(context.Background(), src)
 	test.That(t, err, test.ShouldBeNil)
 	inImg, err := camera.DecodeImageFromCamera(context.Background(), "", nil, src)
 	test.That(t, err, test.ShouldBeNil)
@@ -87,7 +88,8 @@ func TestTransformPipelineDepth(t *testing.T) {
 	test.That(t, inImg.Bounds().Dx(), test.ShouldEqual, 128)
 	test.That(t, inImg.Bounds().Dy(), test.ShouldEqual, 72)
 
-	vs := videoSourceFromCamera(context.Background(), src)
+	vs, err := videoSourceFromCamera(context.Background(), src)
+	test.That(t, err, test.ShouldBeNil)
 	depth, err := newTransformPipeline(context.Background(), vs, nil, transformConf, r, logger)
 	test.That(t, err, test.ShouldBeNil)
 

--- a/components/camera/transformpipeline/pipeline_test.go
+++ b/components/camera/transformpipeline/pipeline_test.go
@@ -203,3 +203,16 @@ func TestTransformPipelineValidateFail(t *testing.T) {
 	test.That(t, resource.GetFieldFromFieldRequiredError(err), test.ShouldEqual, "source")
 	test.That(t, deps, test.ShouldBeNil)
 }
+
+func TestVideoSourceFromCameraError(t *testing.T) {
+	malformedCam := &inject.Camera{
+		ImageFunc: func(ctx context.Context, mimeType string, extra map[string]interface{}) ([]byte, camera.ImageMetadata, error) {
+			return []byte("not a valid image"), camera.ImageMetadata{MimeType: utils.MimeTypePNG}, nil
+		},
+	}
+
+	vs, err := videoSourceFromCamera(context.Background(), malformedCam)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "failed to create video source from camera")
+	test.That(t, vs, test.ShouldBeNil)
+}

--- a/rimage/depth_map_raw.go
+++ b/rimage/depth_map_raw.go
@@ -312,9 +312,9 @@ func WriteRawDepthMapTo(img image.Image, out io.Writer) (int64, error) {
 // the Viam custom depth type writes 8 bytes of "magic number", 8 bytes of width, 8 bytes of height, and 2 bytes per pixel.
 func WriteViamDepthMapTo(img image.Image, out io.Writer) (int64, error) {
 	if lazy, ok := img.(*LazyEncodedImage); ok {
-		lazy.decode()
-		if lazy.decodeErr != nil {
-			return 0, errors.Errorf("could not decode LazyEncodedImage to a depth image: %v", lazy.decodeErr)
+		err := lazy.DecodeImage()
+		if err != nil {
+			return 0, errors.Errorf("could not decode LazyEncodedImage to a depth image: %v", err)
 		}
 		img = lazy.decodedImage
 	}

--- a/rimage/image_file.go
+++ b/rimage/image_file.go
@@ -288,9 +288,9 @@ func EncodeImage(ctx context.Context, img image.Image, mimeType string) ([]byte,
 			return lazy.imgBytes, nil
 		}
 		// LazyImage holds bytes different from requested mime type: decode and re-encode
-		lazy.decode()
-		if lazy.decodeErr != nil {
-			return nil, errors.Errorf("could not decode LazyEncodedImage: %v", lazy.decodeErr)
+		err := lazy.DecodeImage()
+		if err != nil {
+			return nil, errors.Errorf("could not decode LazyEncodedImage: %v", err)
 		}
 		return EncodeImage(ctx, lazy.decodedImage, actualOutMIME)
 	}

--- a/rimage/image_file.go
+++ b/rimage/image_file.go
@@ -180,7 +180,11 @@ func WriteImageToFile(path string, img image.Image) (err error) {
 // ConvertImage converts a go image into our Image type.
 func ConvertImage(img image.Image) *Image {
 	if lazyImg, ok := img.(*LazyEncodedImage); ok {
-		img = lazyImg.DecodedImage()
+		decodedImg, err := lazyImg.DecodedImage()
+		if err != nil {
+			panic(err) // TODO(hexbabe): not ideal
+		}
+		img = decodedImg
 	}
 	ii, ok := img.(*Image)
 	if ok {
@@ -239,7 +243,11 @@ func SaveImage(pic image.Image, loc string) error {
 		}
 	}()
 	if lazyImg, ok := pic.(*LazyEncodedImage); ok {
-		pic = lazyImg.DecodedImage()
+		decodedPic, err := lazyImg.DecodedImage()
+		if err != nil {
+			return err
+		}
+		pic = decodedPic
 	}
 	if err = jpeg.Encode(f, pic, &jpeg.Options{Quality: 75}); err != nil {
 		return errors.Wrapf(err, "the 'image' will not encode")

--- a/rimage/lazy_encoded.go
+++ b/rimage/lazy_encoded.go
@@ -3,14 +3,13 @@ package rimage
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"image"
 	"image/color"
 	"net/http"
 	"strings"
 	"sync"
-
-	"go.uber.org/multierr"
 
 	"go.viam.com/rdk/logging"
 )
@@ -110,7 +109,7 @@ func (lei *LazyEncodedImage) DecodeAll() error {
 	configErr := lei.DecodeConfig()
 	decodeErr := lei.DecodeImage()
 	if configErr != nil || decodeErr != nil {
-		return multierr.Combine(configErr, decodeErr)
+		return errors.Join(configErr, decodeErr)
 	}
 	return nil
 }

--- a/rimage/lazy_encoded.go
+++ b/rimage/lazy_encoded.go
@@ -66,23 +66,6 @@ func checkError(err interface{}) error {
 	return nil
 }
 
-// safeCall executes the given function and catches any panics, converting them to errors.
-// It returns any error that occurred during execution.
-func safeCall(f func()) (err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			switch e := r.(type) {
-			case error:
-				err = e
-			default:
-				err = fmt.Errorf("%v", r)
-			}
-		}
-	}()
-	f()
-	return nil
-}
-
 // DecodeImage decodes the image. Returns nil if no errors occurred.
 // This method is idempotent.
 func (lei *LazyEncodedImage) DecodeImage() error {
@@ -154,40 +137,27 @@ func (lei *LazyEncodedImage) DecodedImage() (image.Image, error) {
 	return lei.decodedImage, nil
 }
 
-// ColorModel returns the Image's color model.
-//
-// It is recommended to call DecodeConfig and check for errors before using this method.
-func (lei *LazyEncodedImage) ColorModel() color.Model {
-	err := lei.DecodeConfig()
-	if err != nil {
-		panic(err)
-	}
-	return lei.colorModel
-}
-
 // ColorModelSafe returns the Image's color model.
 //
 // This method is a safer alternative to the ColorModel method, as it provides error handling
 // instead of panicking, ensuring that the caller can manage any decoding issues gracefully.
 func (lei *LazyEncodedImage) ColorModelSafe() (color.Model, error) {
-	var model color.Model
-	err := safeCall(func() {
-		model = lei.ColorModel()
-	})
-	return model, err
+	err := lei.DecodeConfig()
+	if err != nil {
+		return nil, err
+	}
+	return lei.colorModel, nil
 }
 
-// Bounds returns the domain for which At can return non-zero color.
-// The bounds do not necessarily contain the point (0, 0).
+// ColorModel returns the Image's color model.
 //
 // It is recommended to call DecodeConfig and check for errors before using this method.
-// This method is considered unsafe as it will panic if the image is not decoded.
-func (lei *LazyEncodedImage) Bounds() image.Rectangle {
-	err := lei.DecodeConfig()
+func (lei *LazyEncodedImage) ColorModel() color.Model {
+	model, err := lei.ColorModelSafe()
 	if err != nil {
 		panic(err)
 	}
-	return *lei.bounds
+	return model
 }
 
 // BoundsSafe returns the domain for which At can return non-zero color.
@@ -196,37 +166,46 @@ func (lei *LazyEncodedImage) Bounds() image.Rectangle {
 // This method is a safer alternative to the Bounds method, as it provides error handling
 // instead of panicking, allowing the caller to handle any issues that arise during decoding.
 func (lei *LazyEncodedImage) BoundsSafe() (image.Rectangle, error) {
-	var bounds image.Rectangle
-	err := safeCall(func() {
-		bounds = lei.Bounds()
-	})
-	return bounds, err
+	err := lei.DecodeConfig()
+	if err != nil {
+		return image.Rectangle{}, err
+	}
+	return *lei.bounds, nil
 }
 
-// At returns the color of the pixel at (x, y).
-// At(Bounds().Min.X, Bounds().Min.Y) returns the upper-left pixel of the grid.
-// At(Bounds().Max.X-1, Bounds().Max.Y-1) returns the lower-right one.
+// Bounds returns the domain for which At can return non-zero color.
+// The bounds do not necessarily contain the point (0, 0).
 //
-// It is recommended to call DecodeImage and check for errors before using this method.
-// This method is unsafe as it will panic if the image is not decoded.
-func (lei *LazyEncodedImage) At(x, y int) color.Color {
-	err := lei.DecodeImage()
+// It is recommended to call DecodeConfig and check for errors before using this method, or use BoundsSafe.
+// This method is considered unsafe as it will panic if the image is not decoded.
+func (lei *LazyEncodedImage) Bounds() image.Rectangle {
+	bounds, err := lei.BoundsSafe()
 	if err != nil {
 		panic(err)
 	}
-	return lei.decodedImage.At(x, y)
+	return bounds
 }
 
 // AtSafe returns the color of the pixel at (x, y).
-// At(Bounds().Min.X, Bounds().Min.Y) returns the upper-left pixel of the grid.
-// At(Bounds().Max.X-1, Bounds().Max.Y-1) returns the lower-right one.
 //
 // This method is a safer alternative to the At method, as it provides error handling
 // instead of panicking, enabling the caller to manage any decoding errors appropriately.
 func (lei *LazyEncodedImage) AtSafe(x, y int) (color.Color, error) {
-	var c color.Color
-	err := safeCall(func() {
-		c = lei.At(x, y)
-	})
-	return c, err
+	err := lei.DecodeImage()
+	if err != nil {
+		return nil, err
+	}
+	return lei.decodedImage.At(x, y), nil
+}
+
+// At returns the color of the pixel at (x, y).
+//
+// It is recommended to call DecodeImage and check for errors before using this method, or use AtSafe.
+// This method is unsafe as it will panic if the image is not decoded.
+func (lei *LazyEncodedImage) At(x, y int) color.Color {
+	c, err := lei.AtSafe(x, y)
+	if err != nil {
+		panic(err)
+	}
+	return c
 }

--- a/rimage/lazy_encoded.go
+++ b/rimage/lazy_encoded.go
@@ -3,7 +3,6 @@ package rimage
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"image"
 	"image/color"
@@ -107,10 +106,11 @@ func (lei *LazyEncodedImage) DecodeConfig() error {
 // DecodeAll decodes the image and its configuration. Returns nil if no errors occurred.
 // This method is idempotent.
 func (lei *LazyEncodedImage) DecodeAll() error {
-	configErr := lei.DecodeConfig()
-	decodeErr := lei.DecodeImage()
-	if configErr != nil || decodeErr != nil {
-		return errors.Join(configErr, decodeErr)
+	if err := lei.DecodeConfig(); err != nil {
+		return err
+	}
+	if err := lei.DecodeImage(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/rimage/lazy_encoded.go
+++ b/rimage/lazy_encoded.go
@@ -52,8 +52,9 @@ func NewLazyEncodedImage(imgBytes []byte, mimeType string) image.Image {
 	}
 }
 
-// Helper method for checking lei errors.
-func (lei *LazyEncodedImage) checkError(err interface{}) error {
+// Helper method for checking generic typed errors such as the one in lei structs.
+// TODO(hexbabe): why?
+func checkError(err interface{}) error {
 	if err != nil {
 		switch e := err.(type) {
 		case error:
@@ -80,7 +81,7 @@ func (lei *LazyEncodedImage) DecodeImage() error {
 			lei.mimeType,
 		)
 	})
-	return lei.checkError(lei.decodeImageErr)
+	return checkError(lei.decodeImageErr)
 }
 
 // DecodeConfig decodes the image configuration. Returns nil if no errors occurred.
@@ -100,7 +101,7 @@ func (lei *LazyEncodedImage) DecodeConfig() error {
 			lei.colorModel = header.ColorModel
 		}
 	})
-	return lei.checkError(lei.decodeConfigErr)
+	return checkError(lei.decodeConfigErr)
 }
 
 // DecodeAll decodes the image and its configuration. Returns nil if no errors occurred.

--- a/rimage/lazy_encoded.go
+++ b/rimage/lazy_encoded.go
@@ -3,11 +3,14 @@ package rimage
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"image"
 	"image/color"
 	"net/http"
 	"strings"
 	"sync"
+
+	"go.uber.org/multierr"
 
 	"go.viam.com/rdk/logging"
 )
@@ -31,7 +34,6 @@ type LazyEncodedImage struct {
 // from it. This is helpful for zero copy scenarios. If a width or height of the image is unknown,
 // pass 0 or -1; when done a decode will happen on Bounds. In the future this can probably go
 // away with reading all metadata from the header of the image bytes.
-// NOTE: Usage of an image that would fail to decode causes a lazy panic.
 func NewLazyEncodedImage(imgBytes []byte, mimeType string) image.Image {
 	if mimeType == "" {
 		logging.Global().Warn("NewLazyEncodedImage called without a mime_type. " +
@@ -49,6 +51,8 @@ func NewLazyEncodedImage(imgBytes []byte, mimeType string) image.Image {
 	}
 }
 
+// decode performs the actual decoding of the image data.
+// If there's an error, it stores it.
 func (lei *LazyEncodedImage) decode() {
 	lei.decodeOnce.Do(func() {
 		defer func() {
@@ -62,11 +66,10 @@ func (lei *LazyEncodedImage) decode() {
 			lei.mimeType,
 		)
 	})
-	if lei.decodeErr != nil {
-		panic(lei.decodeErr)
-	}
 }
 
+// decodeConfig decodes just the image configuration.
+// If there's an error, it stores it.
 func (lei *LazyEncodedImage) decodeConfig() {
 	lei.decodeConfigOnce.Do(func() {
 		defer func() {
@@ -82,9 +85,6 @@ func (lei *LazyEncodedImage) decodeConfig() {
 			lei.colorModel = header.ColorModel
 		}
 	})
-	if lei.decodeConfigErr != nil {
-		panic(lei.decodeConfigErr)
-	}
 }
 
 // MIMEType returns the encoded Image's MIME type.
@@ -98,29 +98,73 @@ func (lei *LazyEncodedImage) RawData() []byte {
 	return lei.imgBytes
 }
 
-// DecodedImage returns the decoded image.
+// GetErrors returns any errors that occurred during decoding the image or its configuration.
+// Returns nil if no errors occurred.
+func (lei *LazyEncodedImage) GetErrors() error {
+	// Helper function for checking lei errors
+	checkError := func(err interface{}, errMsg string) error {
+		if err != nil {
+			switch e := err.(type) {
+			case error:
+				return e
+			default:
+				return fmt.Errorf("%s: %v", errMsg, err)
+			}
+		}
+		return nil
+	}
+
+	lei.decodeConfig()
+	err := checkError(lei.decodeConfigErr, "decode lazy encoded image config error")
+
+	lei.decode()
+	err = multierr.Combine(err, checkError(lei.decodeErr, "decode lazy encoded image error"))
+
+	return fmt.Errorf("lazy encoded image error(s): %w", err)
+}
+
+// DecodedImage returns the decoded image or nil if decoding failed.
 func (lei *LazyEncodedImage) DecodedImage() image.Image {
 	lei.decode()
+	if lei.decodeErr != nil {
+		logging.Global().Errorf("Failed to decode image (DecodedImage): %v", lei.decodeErr)
+		return nil
+	}
 	return lei.decodedImage
 }
 
 // ColorModel returns the Image's color model.
+// Returns a default color model if decoding failed.
 func (lei *LazyEncodedImage) ColorModel() color.Model {
 	lei.decodeConfig()
+	if lei.decodeConfigErr != nil {
+		logging.Global().Errorf("Failed to decode (color model): %v", lei.decodeConfigErr)
+		return color.RGBAModel
+	}
 	return lei.colorModel
 }
 
 // Bounds returns the domain for which At can return non-zero color.
 // The bounds do not necessarily contain the point (0, 0).
+// Returns an empty rectangle if decoding failed.
 func (lei *LazyEncodedImage) Bounds() image.Rectangle {
 	lei.decodeConfig()
+	if lei.decodeConfigErr != nil || lei.bounds == nil {
+		logging.Global().Errorf("Failed to decode (image bounds): %v", lei.decodeConfigErr)
+		return image.Rectangle{}
+	}
 	return *lei.bounds
 }
 
 // At returns the color of the pixel at (x, y).
 // At(Bounds().Min.X, Bounds().Min.Y) returns the upper-left pixel of the grid.
 // At(Bounds().Max.X-1, Bounds().Max.Y-1) returns the lower-right one.
+// Returns transparent black if decoding failed.
 func (lei *LazyEncodedImage) At(x, y int) color.Color {
 	lei.decode()
+	if lei.decodeErr != nil || lei.decodedImage == nil {
+		logging.Global().Errorf("Failed to decode image (At): %v", lei.decodeErr)
+		return color.RGBA{}
+	}
 	return lei.decodedImage.At(x, y)
 }

--- a/rimage/lazy_encoded.go
+++ b/rimage/lazy_encoded.go
@@ -115,12 +115,15 @@ func (lei *LazyEncodedImage) GetErrors() error {
 	}
 
 	lei.decodeConfig()
-	err := checkError(lei.decodeConfigErr, "decode lazy encoded image config error")
+	configErr := checkError(lei.decodeConfigErr, "decode lazy encoded image config error")
 
 	lei.decode()
-	err = multierr.Combine(err, checkError(lei.decodeErr, "decode lazy encoded image error"))
-
-	return fmt.Errorf("lazy encoded image error(s): %w", err)
+	decodeErr := checkError(lei.decodeErr, "decode lazy encoded image error")
+	
+	if configErr != nil || decodeErr != nil {
+		return multierr.Combine(configErr, decodeErr)
+	}
+	return nil
 }
 
 // DecodedImage returns the decoded image or nil if decoding failed.

--- a/rimage/lazy_encoded.go
+++ b/rimage/lazy_encoded.go
@@ -149,8 +149,12 @@ func (lei *LazyEncodedImage) ColorModel() color.Model {
 // Returns an empty rectangle if decoding failed.
 func (lei *LazyEncodedImage) Bounds() image.Rectangle {
 	lei.decodeConfig()
-	if lei.decodeConfigErr != nil || lei.bounds == nil {
+	if lei.decodeConfigErr != nil {
 		logging.Global().Errorf("Failed to decode (image bounds): %v", lei.decodeConfigErr)
+		return image.Rectangle{}
+	}
+	if lei.bounds == nil {
+		logging.Global().Error("Bounds were nil after decoding configuration.")
 		return image.Rectangle{}
 	}
 	return *lei.bounds
@@ -162,8 +166,12 @@ func (lei *LazyEncodedImage) Bounds() image.Rectangle {
 // Returns transparent black if decoding failed.
 func (lei *LazyEncodedImage) At(x, y int) color.Color {
 	lei.decode()
-	if lei.decodeErr != nil || lei.decodedImage == nil {
+	if lei.decodeErr != nil {
 		logging.Global().Errorf("Failed to decode image (At): %v", lei.decodeErr)
+		return color.RGBA{}
+	}
+	if lei.decodedImage == nil {
+		logging.Global().Error("Decoded image was nil after decoding.")
 		return color.RGBA{}
 	}
 	return lei.decodedImage.At(x, y)

--- a/rimage/lazy_encoded_test.go
+++ b/rimage/lazy_encoded_test.go
@@ -24,7 +24,7 @@ func TestLazyEncodedImage(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	imgLazy := NewLazyEncodedImage(pngBuf.Bytes(), utils.MimeTypePNG)
-
+	test.That(t, imgLazy.(*LazyEncodedImage).DecodeAll(), test.ShouldBeNil)
 	test.That(t, imgLazy.(*LazyEncodedImage).MIMEType(), test.ShouldEqual, utils.MimeTypePNG)
 	test.That(t, NewColorFromColor(imgLazy.At(0, 0)), test.ShouldEqual, Black)
 	test.That(t, NewColorFromColor(imgLazy.At(3, 3)), test.ShouldEqual, Red)
@@ -39,28 +39,27 @@ func TestLazyEncodedImage(t *testing.T) {
 	imgLazy = NewLazyEncodedImage([]byte{1, 2, 3}, utils.MimeTypePNG)
 
 	test.That(t, imgLazy.(*LazyEncodedImage).MIMEType(), test.ShouldEqual, utils.MimeTypePNG)
-	// Test that methods return safe defaults
-	test.That(t, imgLazy.Bounds(), test.ShouldResemble, image.Rectangle{})
-	test.That(t, imgLazy.ColorModel(), test.ShouldNotBeNil)
-	test.That(t, imgLazy.At(0, 0), test.ShouldNotBeNil)
-	test.That(t, imgLazy.(*LazyEncodedImage).GetErrors(), test.ShouldNotBeNil)
+	test.That(t, imgLazy.(*LazyEncodedImage).DecodeAll(), test.ShouldNotBeNil)
+	test.That(t, func() { _ = imgLazy.Bounds() }, test.ShouldPanic)
+	test.That(t, func() { _ = imgLazy.ColorModel() }, test.ShouldPanic)
+	test.That(t, func() { NewColorFromColor(imgLazy.At(0, 0)) }, test.ShouldPanic)
 
 	imgLazy = NewLazyEncodedImage([]byte{1, 2, 3}, "weeeee")
 
 	test.That(t, imgLazy.(*LazyEncodedImage).MIMEType(), test.ShouldEqual, "weeeee")
-	test.That(t, imgLazy.Bounds(), test.ShouldResemble, image.Rectangle{})
-	test.That(t, imgLazy.ColorModel(), test.ShouldNotBeNil)
-	test.That(t, imgLazy.At(0, 0), test.ShouldNotBeNil)
-	test.That(t, imgLazy.(*LazyEncodedImage).GetErrors(), test.ShouldNotBeNil)
+	test.That(t, imgLazy.(*LazyEncodedImage).DecodeAll(), test.ShouldNotBeNil)
+	test.That(t, func() { _ = imgLazy.Bounds() }, test.ShouldPanic)
+	test.That(t, func() { _ = imgLazy.ColorModel() }, test.ShouldPanic)
+	test.That(t, func() { NewColorFromColor(imgLazy.At(0, 0)) }, test.ShouldPanic)
 
 	// png without a mime type
 	imgLazy = NewLazyEncodedImage(pngBuf.Bytes(), "")
 	test.That(t, imgLazy.(*LazyEncodedImage).MIMEType(), test.ShouldEqual, utils.MimeTypePNG)
+	test.That(t, imgLazy.(*LazyEncodedImage).DecodeAll(), test.ShouldBeNil)
 	test.That(t, NewColorFromColor(imgLazy.At(0, 0)), test.ShouldEqual, Black)
 	test.That(t, NewColorFromColor(imgLazy.At(3, 3)), test.ShouldEqual, Red)
 	test.That(t, imgLazy.Bounds(), test.ShouldResemble, img.Bounds())
 	test.That(t, imgLazy.ColorModel(), test.ShouldResemble, img.ColorModel())
-	test.That(t, imgLazy.(*LazyEncodedImage).GetErrors(), test.ShouldBeNil)
 
 	img2, err = png.Decode(bytes.NewBuffer(imgLazy.(*LazyEncodedImage).RawData()))
 	test.That(t, err, test.ShouldBeNil)
@@ -69,9 +68,9 @@ func TestLazyEncodedImage(t *testing.T) {
 	// jpeg without a mime type
 	imgLazy = NewLazyEncodedImage(jpegBuf.Bytes(), "")
 	test.That(t, imgLazy.(*LazyEncodedImage).MIMEType(), test.ShouldEqual, utils.MimeTypeJPEG)
+	test.That(t, imgLazy.(*LazyEncodedImage).DecodeAll(), test.ShouldBeNil)
 	test.That(t, imgLazy.Bounds(), test.ShouldResemble, jpegImg.Bounds())
 	test.That(t, imgLazy.ColorModel(), test.ShouldResemble, jpegImg.ColorModel())
-	test.That(t, imgLazy.(*LazyEncodedImage).GetErrors(), test.ShouldBeNil)
 
 	img2, err = jpeg.Decode(bytes.NewBuffer(imgLazy.(*LazyEncodedImage).RawData()))
 	test.That(t, err, test.ShouldBeNil)

--- a/rimage/lazy_encoded_test.go
+++ b/rimage/lazy_encoded_test.go
@@ -41,7 +41,7 @@ func TestLazyEncodedImage(t *testing.T) {
 	test.That(t, imgLazy.(*LazyEncodedImage).MIMEType(), test.ShouldEqual, utils.MimeTypePNG)
 	err = imgLazy.(*LazyEncodedImage).DecodeAll()
 	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, image.ErrFormat.Error())
+	test.That(t, err, test.ShouldBeError, image.ErrFormat)
 	test.That(t, func() { imgLazy.Bounds() }, test.ShouldPanic)
 	test.That(t, func() { imgLazy.ColorModel() }, test.ShouldPanicWith, image.ErrFormat)
 	test.That(t, func() { NewColorFromColor(imgLazy.At(0, 0)) }, test.ShouldPanicWith, image.ErrFormat)
@@ -52,7 +52,7 @@ func TestLazyEncodedImage(t *testing.T) {
 	test.That(t, imgLazy.(*LazyEncodedImage).MIMEType(), test.ShouldEqual, "weeeee")
 	err = imgLazy.(*LazyEncodedImage).DecodeAll()
 	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldBeError, image.ErrFormat.Error())
+	test.That(t, err, test.ShouldBeError, image.ErrFormat)
 	test.That(t, func() { imgLazy.Bounds() }, test.ShouldPanic)
 	test.That(t, func() { imgLazy.ColorModel() }, test.ShouldPanicWith, image.ErrFormat)
 	test.That(t, func() { NewColorFromColor(imgLazy.At(0, 0)) }, test.ShouldPanicWith, image.ErrFormat)
@@ -97,7 +97,7 @@ func TestLazyEncodedImageSafeUnsafe(t *testing.T) {
 		t.Run("with bad image", func(t *testing.T) {
 			bounds, err := badImgLazy.(*LazyEncodedImage).BoundsSafe()
 			test.That(t, err, test.ShouldNotBeNil)
-			test.That(t, err.Error(), test.ShouldContainSubstring, image.ErrFormat.Error())
+			test.That(t, err, test.ShouldBeError, image.ErrFormat)
 			test.That(t, bounds, test.ShouldResemble, image.Rectangle{})
 		})
 
@@ -112,7 +112,7 @@ func TestLazyEncodedImageSafeUnsafe(t *testing.T) {
 		t.Run("with bad image", func(t *testing.T) {
 			colorModel, err := badImgLazy.(*LazyEncodedImage).ColorModelSafe()
 			test.That(t, err, test.ShouldNotBeNil)
-			test.That(t, err.Error(), test.ShouldContainSubstring, image.ErrFormat.Error())
+			test.That(t, err, test.ShouldBeError, image.ErrFormat)
 			test.That(t, colorModel, test.ShouldBeNil)
 		})
 
@@ -127,7 +127,7 @@ func TestLazyEncodedImageSafeUnsafe(t *testing.T) {
 		t.Run("with bad image", func(t *testing.T) {
 			pixelColor, err := badImgLazy.(*LazyEncodedImage).AtSafe(0, 0)
 			test.That(t, err, test.ShouldNotBeNil)
-			test.That(t, err.Error(), test.ShouldContainSubstring, image.ErrFormat.Error())
+			test.That(t, err, test.ShouldBeError, image.ErrFormat)
 			test.That(t, pixelColor, test.ShouldBeNil)
 		})
 
@@ -142,7 +142,7 @@ func TestLazyEncodedImageSafeUnsafe(t *testing.T) {
 		t.Run("with bad image", func(t *testing.T) {
 			decodedImg, err := badImgLazy.(*LazyEncodedImage).DecodedImage()
 			test.That(t, err, test.ShouldNotBeNil)
-			test.That(t, err.Error(), test.ShouldContainSubstring, image.ErrFormat.Error())
+			test.That(t, err, test.ShouldBeError, image.ErrFormat)
 			test.That(t, decodedImg, test.ShouldBeNil)
 		})
 

--- a/rimage/lazy_encoded_test.go
+++ b/rimage/lazy_encoded_test.go
@@ -39,18 +39,19 @@ func TestLazyEncodedImage(t *testing.T) {
 	imgLazy = NewLazyEncodedImage([]byte{1, 2, 3}, utils.MimeTypePNG)
 
 	test.That(t, imgLazy.(*LazyEncodedImage).MIMEType(), test.ShouldEqual, utils.MimeTypePNG)
-	test.That(t, func() { imgLazy.Bounds() }, test.ShouldPanic)
-	test.That(t, func() { imgLazy.ColorModel() }, test.ShouldPanicWith, image.ErrFormat)
-	test.That(t, func() { NewColorFromColor(imgLazy.At(0, 0)) }, test.ShouldPanicWith, image.ErrFormat)
-	test.That(t, func() { NewColorFromColor(imgLazy.At(4, 4)) }, test.ShouldPanicWith, image.ErrFormat)
+	// Test that methods return safe defaults
+	test.That(t, imgLazy.Bounds(), test.ShouldResemble, image.Rectangle{})
+	test.That(t, imgLazy.ColorModel(), test.ShouldNotBeNil)
+	test.That(t, imgLazy.At(0, 0), test.ShouldNotBeNil)
+	test.That(t, imgLazy.(*LazyEncodedImage).GetErrors(), test.ShouldNotBeNil)
 
 	imgLazy = NewLazyEncodedImage([]byte{1, 2, 3}, "weeeee")
 
 	test.That(t, imgLazy.(*LazyEncodedImage).MIMEType(), test.ShouldEqual, "weeeee")
-	test.That(t, func() { imgLazy.Bounds() }, test.ShouldPanic)
-	test.That(t, func() { imgLazy.ColorModel() }, test.ShouldPanic)
-	test.That(t, func() { NewColorFromColor(imgLazy.At(0, 0)) }, test.ShouldPanic)
-	test.That(t, func() { NewColorFromColor(imgLazy.At(4, 4)) }, test.ShouldPanic)
+	test.That(t, imgLazy.Bounds(), test.ShouldResemble, image.Rectangle{})
+	test.That(t, imgLazy.ColorModel(), test.ShouldNotBeNil)
+	test.That(t, imgLazy.At(0, 0), test.ShouldNotBeNil)
+	test.That(t, imgLazy.(*LazyEncodedImage).GetErrors(), test.ShouldNotBeNil)
 
 	// png without a mime type
 	imgLazy = NewLazyEncodedImage(pngBuf.Bytes(), "")
@@ -59,6 +60,7 @@ func TestLazyEncodedImage(t *testing.T) {
 	test.That(t, NewColorFromColor(imgLazy.At(3, 3)), test.ShouldEqual, Red)
 	test.That(t, imgLazy.Bounds(), test.ShouldResemble, img.Bounds())
 	test.That(t, imgLazy.ColorModel(), test.ShouldResemble, img.ColorModel())
+	test.That(t, imgLazy.(*LazyEncodedImage).GetErrors(), test.ShouldBeNil)
 
 	img2, err = png.Decode(bytes.NewBuffer(imgLazy.(*LazyEncodedImage).RawData()))
 	test.That(t, err, test.ShouldBeNil)
@@ -69,6 +71,7 @@ func TestLazyEncodedImage(t *testing.T) {
 	test.That(t, imgLazy.(*LazyEncodedImage).MIMEType(), test.ShouldEqual, utils.MimeTypeJPEG)
 	test.That(t, imgLazy.Bounds(), test.ShouldResemble, jpegImg.Bounds())
 	test.That(t, imgLazy.ColorModel(), test.ShouldResemble, jpegImg.ColorModel())
+	test.That(t, imgLazy.(*LazyEncodedImage).GetErrors(), test.ShouldBeNil)
 
 	img2, err = jpeg.Decode(bytes.NewBuffer(imgLazy.(*LazyEncodedImage).RawData()))
 	test.That(t, err, test.ShouldBeNil)

--- a/rimage/lazy_encoded_test.go
+++ b/rimage/lazy_encoded_test.go
@@ -41,7 +41,7 @@ func TestLazyEncodedImage(t *testing.T) {
 	test.That(t, imgLazy.(*LazyEncodedImage).MIMEType(), test.ShouldEqual, utils.MimeTypePNG)
 	err = imgLazy.(*LazyEncodedImage).DecodeAll()
 	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, "unknown format")
+	test.That(t, err.Error(), test.ShouldContainSubstring, image.ErrFormat.Error())
 	test.That(t, func() { imgLazy.Bounds() }, test.ShouldPanic)
 	test.That(t, func() { imgLazy.ColorModel() }, test.ShouldPanicWith, image.ErrFormat)
 	test.That(t, func() { NewColorFromColor(imgLazy.At(0, 0)) }, test.ShouldPanicWith, image.ErrFormat)
@@ -52,7 +52,7 @@ func TestLazyEncodedImage(t *testing.T) {
 	test.That(t, imgLazy.(*LazyEncodedImage).MIMEType(), test.ShouldEqual, "weeeee")
 	err = imgLazy.(*LazyEncodedImage).DecodeAll()
 	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, "unknown format")
+	test.That(t, err.Error(), test.ShouldBeError, image.ErrFormat.Error())
 	test.That(t, func() { imgLazy.Bounds() }, test.ShouldPanic)
 	test.That(t, func() { imgLazy.ColorModel() }, test.ShouldPanicWith, image.ErrFormat)
 	test.That(t, func() { NewColorFromColor(imgLazy.At(0, 0)) }, test.ShouldPanicWith, image.ErrFormat)
@@ -97,7 +97,7 @@ func TestLazyEncodedImageSafeUnsafe(t *testing.T) {
 		t.Run("with bad image", func(t *testing.T) {
 			bounds, err := badImgLazy.(*LazyEncodedImage).BoundsSafe()
 			test.That(t, err, test.ShouldNotBeNil)
-			test.That(t, err.Error(), test.ShouldContainSubstring, "unknown format")
+			test.That(t, err.Error(), test.ShouldContainSubstring, image.ErrFormat.Error())
 			test.That(t, bounds, test.ShouldResemble, image.Rectangle{})
 		})
 
@@ -112,7 +112,7 @@ func TestLazyEncodedImageSafeUnsafe(t *testing.T) {
 		t.Run("with bad image", func(t *testing.T) {
 			colorModel, err := badImgLazy.(*LazyEncodedImage).ColorModelSafe()
 			test.That(t, err, test.ShouldNotBeNil)
-			test.That(t, err.Error(), test.ShouldContainSubstring, "unknown format")
+			test.That(t, err.Error(), test.ShouldContainSubstring, image.ErrFormat.Error())
 			test.That(t, colorModel, test.ShouldBeNil)
 		})
 
@@ -127,7 +127,7 @@ func TestLazyEncodedImageSafeUnsafe(t *testing.T) {
 		t.Run("with bad image", func(t *testing.T) {
 			pixelColor, err := badImgLazy.(*LazyEncodedImage).AtSafe(0, 0)
 			test.That(t, err, test.ShouldNotBeNil)
-			test.That(t, err.Error(), test.ShouldContainSubstring, "unknown format")
+			test.That(t, err.Error(), test.ShouldContainSubstring, image.ErrFormat.Error())
 			test.That(t, pixelColor, test.ShouldBeNil)
 		})
 
@@ -142,7 +142,7 @@ func TestLazyEncodedImageSafeUnsafe(t *testing.T) {
 		t.Run("with bad image", func(t *testing.T) {
 			decodedImg, err := badImgLazy.(*LazyEncodedImage).DecodedImage()
 			test.That(t, err, test.ShouldNotBeNil)
-			test.That(t, err.Error(), test.ShouldContainSubstring, "unknown format")
+			test.That(t, err.Error(), test.ShouldContainSubstring, image.ErrFormat.Error())
 			test.That(t, decodedImg, test.ShouldBeNil)
 		})
 

--- a/rimage/lazy_encoded_test.go
+++ b/rimage/lazy_encoded_test.go
@@ -39,18 +39,24 @@ func TestLazyEncodedImage(t *testing.T) {
 	imgLazy = NewLazyEncodedImage([]byte{1, 2, 3}, utils.MimeTypePNG)
 
 	test.That(t, imgLazy.(*LazyEncodedImage).MIMEType(), test.ShouldEqual, utils.MimeTypePNG)
-	test.That(t, imgLazy.(*LazyEncodedImage).DecodeAll(), test.ShouldNotBeNil)
-	test.That(t, func() { _ = imgLazy.Bounds() }, test.ShouldPanic)
-	test.That(t, func() { _ = imgLazy.ColorModel() }, test.ShouldPanic)
-	test.That(t, func() { NewColorFromColor(imgLazy.At(0, 0)) }, test.ShouldPanic)
+	err = imgLazy.(*LazyEncodedImage).DecodeAll()
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "unknown format")
+	test.That(t, func() { imgLazy.Bounds() }, test.ShouldPanic)
+	test.That(t, func() { imgLazy.ColorModel() }, test.ShouldPanicWith, image.ErrFormat)
+	test.That(t, func() { NewColorFromColor(imgLazy.At(0, 0)) }, test.ShouldPanicWith, image.ErrFormat)
+	test.That(t, func() { NewColorFromColor(imgLazy.At(4, 4)) }, test.ShouldPanicWith, image.ErrFormat)
 
 	imgLazy = NewLazyEncodedImage([]byte{1, 2, 3}, "weeeee")
 
 	test.That(t, imgLazy.(*LazyEncodedImage).MIMEType(), test.ShouldEqual, "weeeee")
-	test.That(t, imgLazy.(*LazyEncodedImage).DecodeAll(), test.ShouldNotBeNil)
-	test.That(t, func() { _ = imgLazy.Bounds() }, test.ShouldPanic)
-	test.That(t, func() { _ = imgLazy.ColorModel() }, test.ShouldPanic)
-	test.That(t, func() { NewColorFromColor(imgLazy.At(0, 0)) }, test.ShouldPanic)
+	err = imgLazy.(*LazyEncodedImage).DecodeAll()
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "unknown format")
+	test.That(t, func() { imgLazy.Bounds() }, test.ShouldPanic)
+	test.That(t, func() { imgLazy.ColorModel() }, test.ShouldPanicWith, image.ErrFormat)
+	test.That(t, func() { NewColorFromColor(imgLazy.At(0, 0)) }, test.ShouldPanicWith, image.ErrFormat)
+	test.That(t, func() { NewColorFromColor(imgLazy.At(4, 4)) }, test.ShouldPanicWith, image.ErrFormat)
 
 	// png without a mime type
 	imgLazy = NewLazyEncodedImage(pngBuf.Bytes(), "")

--- a/robot/web/stream/camera/camera.go
+++ b/robot/web/stream/camera/camera.go
@@ -39,15 +39,14 @@ func VideoSourceFromCamera(ctx context.Context, cam camera.Camera) (gostream.Vid
 	})
 
 	img, err := camera.DecodeImageFromCamera(ctx, "", nil, cam)
+	if err != nil {
+		// Okay to return empty prop because processInputFrames will tick and set them
+		return gostream.NewVideoSource(reader, prop.Video{}), nil //nolint:nilerr
+	}
 	if lazyImg, ok := img.(*rimage.LazyEncodedImage); ok {
 		if err := lazyImg.DecodeConfig(); err != nil {
 			return nil, fmt.Errorf("failed to decode lazy encoded image: %w", err)
 		}
-	}
-
-	if err != nil {
-		// Okay to return empty prop because processInputFrames will tick and set them
-		return gostream.NewVideoSource(reader, prop.Video{}), nil //nolint:nilerr
 	}
 
 	return gostream.NewVideoSource(reader, prop.Video{Width: img.Bounds().Dx(), Height: img.Bounds().Dy()}), nil

--- a/robot/web/stream/camera/camera_test.go
+++ b/robot/web/stream/camera/camera_test.go
@@ -23,7 +23,8 @@ func TestVideoSourceFromCamera(t *testing.T) {
 			return imgBytes, camera.ImageMetadata{MimeType: utils.MimeTypePNG}, nil
 		},
 	}
-	vs := camerautils.VideoSourceFromCamera(context.Background(), cam)
+	vs, err := camerautils.VideoSourceFromCamera(context.Background(), cam)
+	test.That(t, err, test.ShouldBeNil)
 
 	stream, err := vs.Stream(context.Background())
 	test.That(t, err, test.ShouldBeNil)

--- a/robot/web/stream/camera/camera_test.go
+++ b/robot/web/stream/camera/camera_test.go
@@ -36,3 +36,17 @@ func TestVideoSourceFromCamera(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, diffVal, test.ShouldEqual, 0)
 }
+
+func TestVideoSourceFromCameraFailure(t *testing.T) {
+	malformedCam := &inject.Camera{
+		ImageFunc: func(ctx context.Context, mimeType string, extra map[string]interface{}) ([]byte, camera.ImageMetadata, error) {
+			return []byte("not a valid image"), camera.ImageMetadata{MimeType: utils.MimeTypePNG}, nil
+		},
+	}
+
+	vs, err := camerautils.VideoSourceFromCamera(context.Background(), malformedCam)
+	test.That(t, err, test.ShouldNotBeNil)
+	expectedErrPrefix := "failed to decode lazy encoded image: "
+	test.That(t, err.Error(), test.ShouldStartWith, expectedErrPrefix)
+	test.That(t, vs, test.ShouldBeNil)
+}

--- a/robot/web/stream/server.go
+++ b/robot/web/stream/server.go
@@ -671,12 +671,12 @@ func (server *Server) refreshVideoSources(ctx context.Context) {
 		if err != nil {
 			continue
 		}
-		existing, ok := server.videoSources[cam.Name().SDPTrackName()]
 		src, err := camerautils.VideoSourceFromCamera(ctx, cam)
 		if err != nil {
 			server.logger.Errorf("error creating video source from camera: %v", err)
 			continue
 		}
+		existing, ok := server.videoSources[cam.Name().SDPTrackName()]
 		if ok {
 			// Check stream state for the camera to see if it is in resized mode.
 			// If it is in resized mode, we want to apply the resize transformation to the

--- a/robot/web/stream/server.go
+++ b/robot/web/stream/server.go
@@ -447,7 +447,11 @@ func (server *Server) resizeVideoSource(ctx context.Context, name string, width,
 	if !ok {
 		return fmt.Errorf("stream state not found with name %q", name)
 	}
-	resizer := gostream.NewResizeVideoSource(camerautils.VideoSourceFromCamera(ctx, cam), width, height)
+	vs, err := camerautils.VideoSourceFromCamera(ctx, cam)
+	if err != nil {
+		return fmt.Errorf("failed to create video source from camera: %w", err)
+	}
+	resizer := gostream.NewResizeVideoSource(vs, width, height)
 	server.logger.Debugf(
 		"resizing video source to width %d and height %d",
 		width, height,
@@ -475,7 +479,11 @@ func (server *Server) resetVideoSource(ctx context.Context, name string) error {
 		return fmt.Errorf("stream state not found with name %q", name)
 	}
 	server.logger.Debug("resetting video source")
-	existing.Swap(camerautils.VideoSourceFromCamera(ctx, cam))
+	vs, err := camerautils.VideoSourceFromCamera(ctx, cam)
+	if err != nil {
+		return fmt.Errorf("failed to create video source from camera: %w", err)
+	}
+	existing.Swap(vs)
 	err = streamState.Reset()
 	if err != nil {
 		return fmt.Errorf("failed to reset stream %q: %w", name, err)
@@ -664,7 +672,11 @@ func (server *Server) refreshVideoSources(ctx context.Context) {
 			continue
 		}
 		existing, ok := server.videoSources[cam.Name().SDPTrackName()]
-		src := camerautils.VideoSourceFromCamera(ctx, cam)
+		src, err := camerautils.VideoSourceFromCamera(ctx, cam)
+		if err != nil {
+			server.logger.Errorf("error creating video source from camera: %v", err)
+			continue
+		}
 		if ok {
 			// Check stream state for the camera to see if it is in resized mode.
 			// If it is in resized mode, we want to apply the resize transformation to the


### PR DESCRIPTION
### PR Guide
Essential changes
- Change signature of camerautils `VideoSourceFromCamera` to return an error in order to report the lazy encoding failure to the stream server safely
- Made the decode and decodeConfig methods on lazy encoded images public so we can call them and check for errors instead of doing it in the `image.Image` methods `Bounds` `At` and `ColorModel` methods which give no ways to return errors and forces a panic when decoding fails. 
- Added notes to use these util methods and check for errors before using `image.Image` methods.

### Note

This is no longer a breaking change because it is an additive change to the `LazyEncodedImage` struct.

It is an alternative to un-Golang-ly directly recovering from panics.

### Manual testing
Tested with machine config with Rand's malformed camera that returns bad lazy encoded bytes. It would previously (on main) panic when adding the malformed stream. With this change, it returns this error:

```
3/4/2025, 12:04:11 PM error rdk.networking   utils@v0.1.130/logger.go:161   finished unary call with code Unknown   error rpc error: code = Unknown desc = failed to sample frame size: failed to get frame after 5 attempts: lazy encoded image error(s): image: unknown format; image: unknown format  grpc.code Unknown  grpc.start_time 2025-03-04T17:04:10.760Z  span.kind server  system grpc  grpc.service proto.stream.v1.StreamService  grpc.method GetStreamOptions

3/4/2025, 12:04:11 PM error rdk   stream/backoff.go:72   error getting media   streamName malformed-1  error lazy encoded image error(s): image: unknown format; image: unknown format
```