### PR TITLE
[RSDK-7007] Update CI to build semver "dev" versions for latest

### DIFF
--- a/.github/workflows/staticbuild.yml
+++ b/.github/workflows/staticbuild.yml
@@ -62,13 +62,13 @@ jobs:
 
     - name: Check out code
       if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0 # needed for dev-version.sh to work
 
     - name: Check out PR branch code
       if: github.event_name == 'pull_request_target'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
@@ -78,7 +78,7 @@ jobs:
         sudo -Hu testbot bash -lc 'make clean-all'
 
     - name: Authorize GCP Upload
-      uses: google-github-actions/auth@v1.1.1
+      uses: google-github-actions/auth@v2
       with:
         credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
 
@@ -89,7 +89,7 @@ jobs:
 
     - name: Upload Files (PR)
       if: contains(github.event.pull_request.labels.*.name, 'static-build') || contains(github.event.pull_request.labels.*.name, 'static-ignore-tests')
-      uses: google-github-actions/upload-cloud-storage@v0.10.4
+      uses: google-github-actions/upload-cloud-storage@v2
       with:
         headers: "cache-control: no-cache"
         path: 'etc/packaging/static/deploy/'
@@ -114,7 +114,7 @@ jobs:
 
     - name: Upload Files (Testing)
       if: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'push') && !inputs.no-upload }}
-      uses: google-github-actions/upload-cloud-storage@v0.10.4
+      uses: google-github-actions/upload-cloud-storage@v2
       with:
         headers: "cache-control: no-cache"
         path: 'etc/packaging/static/deploy/'
@@ -125,7 +125,7 @@ jobs:
 
     - name: Upload Manifest (Testing)
       if: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'push') && !inputs.no-upload }}
-      uses: google-github-actions/upload-cloud-storage@v0.10.4
+      uses: google-github-actions/upload-cloud-storage@v2
       with:
         headers: "cache-control: no-cache"
         path: 'etc/packaging/static/manifest/'
@@ -202,12 +202,12 @@ jobs:
 
     steps:
     - name: Authorize GCP
-      uses: google-github-actions/auth@v1.1.1
+      uses: google-github-actions/auth@v2
       with:
         credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
 
     - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v1
+      uses: google-github-actions/setup-gcloud@v2
 
     - name: Publish Static Binary
       if: inputs.release_type != 'latest'

--- a/.github/workflows/staticbuild.yml
+++ b/.github/workflows/staticbuild.yml
@@ -212,16 +212,16 @@ jobs:
     - name: Publish Static Binary
       if: inputs.release_type != 'latest'
       run: |
-        gsutil mv "gs://packages.viam.com/apps/viam-server/testing/static/${{ needs.static_test.outputs.date }}/${{ github.sha }}/*" "gs://packages.viam.com/apps/viam-server/"
+        gsutil mv "gs://packages.viam.com/apps/viam-server/testing/static/${{ needs.static_test.outputs.date }}/${{ github.sha }}/*" "gs://packages.viam.com/temp/apps/viam-server/"
 
     - name: Publish Static Binary (Latest)
       if: inputs.release_type == 'latest'
       run: |
-        gsutil mv "gs://packages.viam.com/apps/viam-server/testing/static/${{ needs.static_test.outputs.date }}/${{ github.sha }}/*" "gs://packages.viam.com/apps/viam-server/prerelease/"
+        gsutil mv "gs://packages.viam.com/apps/viam-server/testing/static/${{ needs.static_test.outputs.date }}/${{ github.sha }}/*" "gs://packages.viam.com/temp/apps/viam-server/prerelease/"
 
     - name: Publish Subsystem Metadata
       run: |
-        gsutil mv "gs://packages.viam.com/apps/viam-subsystems/testing/viam-server/${{ needs.static_test.outputs.date }}/${{ github.sha }}/*" "gs://packages.viam.com/apps/viam-subsystems/"
+        gsutil mv "gs://packages.viam.com/apps/viam-subsystems/testing/viam-server/${{ needs.static_test.outputs.date }}/${{ github.sha }}/*" "gs://packages.viam.com/temp/apps/viam-subsystems/"
 
     - name: Output Summary
       run: |

--- a/.github/workflows/staticbuild.yml
+++ b/.github/workflows/staticbuild.yml
@@ -172,7 +172,7 @@ jobs:
       run: |
         channel="${{ github.ref_name }}"
         # we call our main branch releases "latest"
-        if [ "$channel" = "devreleases" ]; then
+        if [ "$channel" = "main" ]; then
           channel="latest"
         fi
 
@@ -212,17 +212,17 @@ jobs:
     - name: Publish Static Binary
       if: inputs.release_type != 'latest'
       run: |
-        gsutil mv "gs://packages.viam.com/apps/viam-server/testing/static/${{ needs.static_test.outputs.date }}/${{ github.sha }}/*" "gs://packages.viam.com/temp/apps/viam-server/"
+        gsutil mv "gs://packages.viam.com/apps/viam-server/testing/static/${{ needs.static_test.outputs.date }}/${{ github.sha }}/*" "gs://packages.viam.com/apps/viam-server/"
 
     - name: Publish Static Binary (Latest)
       if: inputs.release_type == 'latest'
       run: |
-        gsutil mv "gs://packages.viam.com/apps/viam-server/testing/static/${{ needs.static_test.outputs.date }}/${{ github.sha }}/viam-server-v*" "gs://packages.viam.com/temp/apps/viam-server/prerelease/"
-        gsutil mv "gs://packages.viam.com/apps/viam-server/testing/static/${{ needs.static_test.outputs.date }}/${{ github.sha }}/viam-server-latest*" "gs://packages.viam.com/temp/apps/viam-server/"
+        gsutil mv "gs://packages.viam.com/apps/viam-server/testing/static/${{ needs.static_test.outputs.date }}/${{ github.sha }}/viam-server-v*" "gs://packages.viam.com/apps/viam-server/prerelease/"
+        gsutil mv "gs://packages.viam.com/apps/viam-server/testing/static/${{ needs.static_test.outputs.date }}/${{ github.sha }}/viam-server-latest*" "gs://packages.viam.com/apps/viam-server/"
 
     - name: Publish Subsystem Metadata
       run: |
-        gsutil mv "gs://packages.viam.com/apps/viam-subsystems/testing/viam-server/${{ needs.static_test.outputs.date }}/${{ github.sha }}/*" "gs://packages.viam.com/temp/apps/viam-subsystems/"
+        gsutil mv "gs://packages.viam.com/apps/viam-subsystems/testing/viam-server/${{ needs.static_test.outputs.date }}/${{ github.sha }}/*" "gs://packages.viam.com/apps/viam-subsystems/"
 
     - name: Output Summary
       run: |

--- a/.github/workflows/staticbuild.yml
+++ b/.github/workflows/staticbuild.yml
@@ -217,7 +217,8 @@ jobs:
     - name: Publish Static Binary (Latest)
       if: inputs.release_type == 'latest'
       run: |
-        gsutil mv "gs://packages.viam.com/apps/viam-server/testing/static/${{ needs.static_test.outputs.date }}/${{ github.sha }}/*" "gs://packages.viam.com/temp/apps/viam-server/prerelease/"
+        gsutil mv "gs://packages.viam.com/apps/viam-server/testing/static/${{ needs.static_test.outputs.date }}/${{ github.sha }}/viam-server-v*" "gs://packages.viam.com/temp/apps/viam-server/prerelease/"
+        gsutil mv "gs://packages.viam.com/apps/viam-server/testing/static/${{ needs.static_test.outputs.date }}/${{ github.sha }}/viam-server-latest*" "gs://packages.viam.com/temp/apps/viam-server/"
 
     - name: Publish Subsystem Metadata
       run: |

--- a/.github/workflows/staticbuild.yml
+++ b/.github/workflows/staticbuild.yml
@@ -172,7 +172,7 @@ jobs:
       run: |
         channel="${{ github.ref_name }}"
         # we call our main branch releases "latest"
-        if [ "$channel" = "main" ]; then
+        if [ "$channel" = "devreleases" ]; then
           channel="latest"
         fi
 

--- a/.github/workflows/staticbuild.yml
+++ b/.github/workflows/staticbuild.yml
@@ -101,7 +101,7 @@ jobs:
     - name: Build (Latest)
       if: inputs.release_type == 'latest'
       run: |
-        sudo -Hu testbot bash -lc 'make RELEASE_TYPE="latest" BUILD_CHANNEL="$(etc/dev-version.sh)" ${{ matrix.target }}'
+        sudo -Hu testbot bash -lc 'make RELEASE_TYPE="latest" BUILD_CHANNEL="$(./etc/dev-version.sh)" ${{ matrix.target }}'
 
     - name: Build (Tagged)
       if: inputs.release_type == 'stable' || inputs.release_type == 'rc'

--- a/.github/workflows/staticbuild.yml
+++ b/.github/workflows/staticbuild.yml
@@ -20,20 +20,8 @@ on:
         required: true
 
 jobs:
-  build_timestamp:
-    name: Set Build Timestamp 
-    runs-on: ubuntu-latest
-    outputs:
-      date: ${{ steps.build_time.outputs.date }}
-    steps:
-    - name: Build Time
-      id: build_time
-      if: inputs.release_type == 'latest'
-      run: echo "date=`date +%Y%m%d%H%M%S`" >> $GITHUB_OUTPUT
-
   static:
     name: Antique Build
-    needs: build_timestamp
     strategy:
       fail-fast: false
       matrix:
@@ -111,7 +99,7 @@ jobs:
     - name: Build (Latest)
       if: inputs.release_type == 'latest'
       run: |
-        sudo -Hu testbot bash -lc 'make RELEASE_TYPE="latest" BUILD_CHANNEL="${{needs.build_timestamp.outputs.date}}" ${{ matrix.target }}'
+        sudo -Hu testbot bash -lc 'make RELEASE_TYPE="latest" BUILD_CHANNEL="$(etc/dev-version.sh)" ${{ matrix.target }}'
 
     - name: Build (Tagged)
       if: inputs.release_type == 'stable' || inputs.release_type == 'rc'
@@ -220,8 +208,14 @@ jobs:
       uses: google-github-actions/setup-gcloud@v1
 
     - name: Publish Static Binary
+      if: inputs.release_type != 'latest'
       run: |
         gsutil mv "gs://packages.viam.com/apps/viam-server/testing/static/${{ needs.static_test.outputs.date }}/${{ github.sha }}/*" "gs://packages.viam.com/apps/viam-server/"
+
+    - name: Publish Static Binary (Latest)
+      if: inputs.release_type == 'latest'
+      run: |
+        gsutil mv "gs://packages.viam.com/apps/viam-server/testing/static/${{ needs.static_test.outputs.date }}/${{ github.sha }}/*" "gs://packages.viam.com/apps/viam-server/prerelease/"
 
     - name: Publish Subsystem Metadata
       run: |

--- a/.github/workflows/staticbuild.yml
+++ b/.github/workflows/staticbuild.yml
@@ -63,6 +63,8 @@ jobs:
     - name: Check out code
       if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
       uses: actions/checkout@v3
+      with:
+        fetch-depth: 0 # needed for dev-version.sh to work
 
     - name: Check out PR branch code
       if: github.event_name == 'pull_request_target'

--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,7 @@ lf_logs/
 
 # exclude credential created during CI
 google-credentials.json
-gha_creds_*.json
+gha-creds-*.json
 
 # frontend built artifacts are not committed (they are generated during appimage github workflow step)
 web/runtime-shared/static

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ lf_logs/
 
 # exclude credential created during CI
 google-credentials.json
+gha_creds_*.json
 
 # frontend built artifacts are not committed (they are generated during appimage github workflow step)
 web/runtime-shared/static

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BUILD_CHANNEL ?= local
 PATH_WITH_TOOLS="`pwd`/$(TOOL_BIN):`pwd`/node_modules/.bin:${PATH}"
 
 GIT_REVISION = $(shell git rev-parse HEAD | tr -d '\n')
-TAG_VERSION?=$(shell etc/dev-version.sh | sed 's/^v//')
+TAG_VERSION?=$(shell etc/dev-version.sh')
 DATE_COMPILED?=$(shell date +'%Y-%m-%d')
 COMMON_LDFLAGS = -s -w -X 'go.viam.com/rdk/config.Version=${TAG_VERSION}' -X 'go.viam.com/rdk/config.GitRevision=${GIT_REVISION}' -X 'go.viam.com/rdk/config.DateCompiled=${DATE_COMPILED}'
 LDFLAGS = -ldflags "-extld=$(shell pwd)/etc/ld_wrapper.sh $(COMMON_LDFLAGS)"

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BUILD_CHANNEL ?= local
 PATH_WITH_TOOLS="`pwd`/$(TOOL_BIN):`pwd`/node_modules/.bin:${PATH}"
 
 GIT_REVISION = $(shell git rev-parse HEAD | tr -d '\n')
-TAG_VERSION?=$(shell etc/dev-version.sh')
+TAG_VERSION?=$(shell etc/dev-version.sh' | sed 's/^v//')
 DATE_COMPILED?=$(shell date +'%Y-%m-%d')
 COMMON_LDFLAGS = -s -w -X 'go.viam.com/rdk/config.Version=${TAG_VERSION}' -X 'go.viam.com/rdk/config.GitRevision=${GIT_REVISION}' -X 'go.viam.com/rdk/config.DateCompiled=${DATE_COMPILED}'
 LDFLAGS = -ldflags "-extld=$(shell pwd)/etc/ld_wrapper.sh $(COMMON_LDFLAGS)"

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BUILD_CHANNEL ?= local
 PATH_WITH_TOOLS="`pwd`/$(TOOL_BIN):`pwd`/node_modules/.bin:${PATH}"
 
 GIT_REVISION = $(shell git rev-parse HEAD | tr -d '\n')
-TAG_VERSION?=$(shell git tag --points-at | sort -Vr | head -n1)
+TAG_VERSION?=$(shell etc/dev-version.sh | sed 's/^v//')
 DATE_COMPILED?=$(shell date +'%Y-%m-%d')
 COMMON_LDFLAGS = -s -w -X 'go.viam.com/rdk/config.Version=${TAG_VERSION}' -X 'go.viam.com/rdk/config.GitRevision=${GIT_REVISION}' -X 'go.viam.com/rdk/config.DateCompiled=${DATE_COMPILED}'
 LDFLAGS = -ldflags "-extld=$(shell pwd)/etc/ld_wrapper.sh $(COMMON_LDFLAGS)"

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BUILD_CHANNEL ?= local
 PATH_WITH_TOOLS="`pwd`/$(TOOL_BIN):`pwd`/node_modules/.bin:${PATH}"
 
 GIT_REVISION = $(shell git rev-parse HEAD | tr -d '\n')
-TAG_VERSION?=$(shell etc/dev-version.sh' | sed 's/^v//')
+TAG_VERSION?=$(shell etc/dev-version.sh | sed 's/^v//')
 DATE_COMPILED?=$(shell date +'%Y-%m-%d')
 COMMON_LDFLAGS = -s -w -X 'go.viam.com/rdk/config.Version=${TAG_VERSION}' -X 'go.viam.com/rdk/config.GitRevision=${GIT_REVISION}' -X 'go.viam.com/rdk/config.DateCompiled=${DATE_COMPILED}'
 LDFLAGS = -ldflags "-extld=$(shell pwd)/etc/ld_wrapper.sh $(COMMON_LDFLAGS)"

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BUILD_CHANNEL ?= local
 PATH_WITH_TOOLS="`pwd`/$(TOOL_BIN):`pwd`/node_modules/.bin:${PATH}"
 
 GIT_REVISION = $(shell git rev-parse HEAD | tr -d '\n')
-TAG_VERSION?=$(shell etc/dev-version.sh | sed 's/^v//')
+TAG_VERSION?=$(shell ./etc/dev-version.sh | sed 's/^v//')
 DATE_COMPILED?=$(shell date +'%Y-%m-%d')
 COMMON_LDFLAGS = -s -w -X 'go.viam.com/rdk/config.Version=${TAG_VERSION}' -X 'go.viam.com/rdk/config.GitRevision=${GIT_REVISION}' -X 'go.viam.com/rdk/config.DateCompiled=${DATE_COMPILED}'
 LDFLAGS = -ldflags "-extld=$(shell pwd)/etc/ld_wrapper.sh $(COMMON_LDFLAGS)"

--- a/etc/dev-version.sh
+++ b/etc/dev-version.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Get the most recent tag
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null)
+
+# Count commits since last tag
+COMMITS_SINCE_TAG=$(git rev-list "${LAST_TAG}..HEAD" --count 2>/dev/null)
+
+# Remove 'v' prefix from tag
+BASE_VERSION=${LAST_TAG#v}
+
+# Calculate next version by incrementing patch number
+NEXT_VERSION=$(echo "$BASE_VERSION" | awk -F. '{$3+=1}1' OFS=.)
+
+# Set TAG_VERSION based on commits since last tag
+if [ "$COMMITS_SINCE_TAG" -eq 0 ]; then
+    TAG_VERSION="$BASE_VERSION"
+else
+    TAG_VERSION="${NEXT_VERSION}-dev.${COMMITS_SINCE_TAG}"
+fi
+
+# Set PATH_VERSION based on TAG_VERSION
+PATH_VERSION="v${TAG_VERSION}"
+
+echo ${PATH_VERSION}

--- a/etc/dev-version.sh
+++ b/etc/dev-version.sh
@@ -2,13 +2,14 @@
 
 # Exit with a blank if tree is dirty
 if [ -n "$(git status -s)" ]; then
+    echo "SMURF1"
     exit 0
 fi
 
 # See if we have a direct tag
 DIRECT_TAG=$(git tag --points-at | sort -Vr | head -n1)
 if [ -n "$DIRECT_TAG" ]; then
-    echo ${DIRECT_TAG}
+    echo "SMURF2${DIRECT_TAG}"
     exit 0
 fi
 

--- a/etc/dev-version.sh
+++ b/etc/dev-version.sh
@@ -17,9 +17,9 @@ if [ -z "$GITHUB_REF_NAME" ]; then
 fi
 
 # If we're not on main, we have no (automated) version to create
-if [ "$GITHUB_REF_NAME" != "main" ]; then
-    exit 0
-fi
+# if [ "$GITHUB_REF_NAME" != "main" ]; then
+#     exit 0
+# fi
 
 # If we don't have a direct tag, use the most recent non-RC tag
 DESC=$(git describe --tags --match="v*" --exclude="*-rc*" --long | sed 's/^v//')

--- a/etc/dev-version.sh
+++ b/etc/dev-version.sh
@@ -2,14 +2,13 @@
 
 # Exit with a blank if tree is dirty
 if [ -n "$(git status -s)" ]; then
-    echo "SMURF1"
     exit 0
 fi
 
 # See if we have a direct tag
 DIRECT_TAG=$(git tag --points-at | sort -Vr | head -n1)
 if [ -n "$DIRECT_TAG" ]; then
-    echo "SMURF2${DIRECT_TAG}"
+    echo ${DIRECT_TAG}
     exit 0
 fi
 
@@ -18,9 +17,9 @@ if [ -z "$GITHUB_REF_NAME" ]; then
 fi
 
 # If we're not on main, we have no (automated) version to create
-# if [ "$GITHUB_REF_NAME" != "main" ]; then
-#     exit 0
-# fi
+if [ "$GITHUB_REF_NAME" != "devreleases" ]; then
+    exit 0
+fi
 
 # If we don't have a direct tag, use the most recent non-RC tag
 DESC=$(git describe --tags --match="v*" --exclude="*-rc*" --long | sed 's/^v//')

--- a/etc/dev-version.sh
+++ b/etc/dev-version.sh
@@ -17,7 +17,7 @@ if [ -z "$GITHUB_REF_NAME" ]; then
 fi
 
 # If we're not on main, we have no (automated) version to create
-if [ "$GITHUB_REF_NAME" != "devreleases" ]; then
+if [ "$GITHUB_REF_NAME" != "main" ]; then
     exit 0
 fi
 

--- a/etc/dev-version.sh
+++ b/etc/dev-version.sh
@@ -12,6 +12,15 @@ if [ -n "$DIRECT_TAG" ]; then
     exit 0
 fi
 
+if [ -z "$GITHUB_REF_NAME" ]; then
+    GITHUB_REF_NAME=$(git rev-parse --abbrev-ref HEAD)
+fi
+
+# If we're not on main, we have no (automated) version to create
+if [ "$GITHUB_REF_NAME" != "main" ]; then
+    exit 0
+fi
+
 # If we don't have a direct tag, use the most recent non-RC tag
 DESC=$(git describe --tags --match="v*" --exclude="*-rc*" --long | sed 's/^v//')
 

--- a/packaging.make
+++ b/packaging.make
@@ -6,6 +6,8 @@ DPKG_ARCH ?= $(shell dpkg --print-architecture)
 APPIMAGE_ARCH ?= $(shell dpkg --print-architecture)
 endif
 
+PRERELEASE_PATH := $(if $(findstring -dev,$(BUILD_CHANNEL)),"prerelease/","")
+
 appimage-arch:
 	# build appimage for a target architecture using existing aix + viam-server binaries
 	cd etc/packaging/appimages && BUILD_CHANNEL=${BUILD_CHANNEL} UNAME_M=$(UNAME_M) DPKG_ARCH=$(DPKG_ARCH) appimage-builder --recipe viam-server.yml
@@ -50,7 +52,7 @@ static-release: server-static-compressed
 	mkdir -p etc/packaging/static/manifest/
 	go run etc/subsystem_manifest/main.go \
 		--binary-path etc/packaging/static/deploy/viam-server-${BUILD_CHANNEL}-${UNAME_M} \
-		--upload-path "packages.viam.com/apps/viam-server/viam-server-${BUILD_CHANNEL}-${UNAME_M}" \
+		--upload-path "packages.viam.com/apps/viam-server/${PRERELEASE_PATH}viam-server-${BUILD_CHANNEL}-${UNAME_M}" \
 		--version ${BUILD_CHANNEL} \
 		--arch ${UNAME_M} \
 		--output-path etc/packaging/static/manifest/viam-server-${BUILD_CHANNEL}-${UNAME_M}.json
@@ -75,8 +77,8 @@ static-release-win:
 	mkdir -p etc/packaging/static/manifest/
 	go run ./etc/subsystem_manifest \
 		--binary-path etc/packaging/static/deploy/viam-server-${BUILD_CHANNEL}-windows-${UNAME_M} \
-		--upload-path packages.viam.com/apps/viam-server/viam-server-${BUILD_CHANNEL}-windows-${UNAME_M} \
+		--upload-path packages.viam.com/apps/viam-server/${PRERELEASE_PATH}viam-server-${BUILD_CHANNEL}-windows-${UNAME_M} \
 		--version ${BUILD_CHANNEL} \
 		--arch ${UNAME_M} \
 		--resources-json win-resources.json \
-		--output-path etc/packaging/static/manifest/viam-server-windows-${BUILD_CHANNEL}-${UNAME_M}.json
+		--output-path etc/packaging/static/manifest/viam-server-${BUILD_CHANNEL}-windows-${UNAME_M}.json


### PR DESCRIPTION
Previously we'd been building "latest" as timestamp (20250304121314) style "versions." This switches to using a semantic version compatible format with a "dev" prerelease tag. It also embeds that version properly in builds.

This will be picked up by upcoming changes in App, along with similar work for Agent.