### PR TITLE
RSDK-10041 - better warnings on out-of-date CLI

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -1493,7 +1493,8 @@ func CheckUpdateAction(c *cli.Context, args emptyArgs) error {
 		warningf(c.App.ErrWriter, "CLI Update Check: failed to parse build version")
 	}
 
-	// we know both the local version and the latest version so we can make a determination from that alone on whether or not to alert users to update
+	// we know both the local version and the latest version so we can make a determination
+	// from that alone on whether or not to alert users to update
 	if localVersion != nil && latestVersion != nil {
 		// the local version is out of date, so we know to warn
 		if localVersion.LessThan(latestVersion) {

--- a/cli/client.go
+++ b/cli/client.go
@@ -1475,6 +1475,34 @@ func CheckUpdateAction(c *cli.Context, args emptyArgs) error {
 		return nil
 	}
 
+	appVersion := rconfig.Version
+	latestRelease, err := getLatestReleaseVersion()
+	if err != nil {
+		warningf(c.App.ErrWriter, "CLI Update Check: failed to get latest release information: %w", err)
+	}
+
+	latestVersion, err := semver.NewVersion(latestRelease)
+
+	// failure to parse `latestRelease` is expected for local builds; we don't want overly
+	// noisy warnings here so only alert in these cases if debug flag is on
+	if err != nil && globalArgs.Debug {
+		warningf(c.App.ErrWriter, "CLI Update Check: failed to parse latest release version")
+	}
+	localVersion, err := semver.NewVersion(appVersion)
+	if err != nil && globalArgs.Debug {
+		warningf(c.App.ErrWriter, "CLI Update Check: failed to parse build version")
+	}
+
+	// we know both the local version and the latest version so we can make a determination from that alone on whether or not to alert users to update
+	if localVersion != nil && latestVersion != nil {
+		// the local version is out of date, so we know to warn
+		if localVersion.LessThan(latestVersion) {
+			warningf(c.App.ErrWriter, "CLI Update Check: Your CLI (%s) is out of date. Consider updating to version %s. "+
+				"See https://docs.viam.com/cli/#install", localVersion.Original(), latestVersion.Original())
+		}
+		return nil
+	}
+
 	dateCompiledRaw := rconfig.DateCompiled
 
 	// `go build` will not set the compilation flags needed for this check
@@ -1488,73 +1516,14 @@ func CheckUpdateAction(c *cli.Context, args emptyArgs) error {
 		return nil
 	}
 
-	// install is less than six weeks old
-	if time.Since(dateCompiled) < time.Hour*24*7*6 {
-		return nil
-	}
-
-	conf, err := ConfigFromCache(c)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			utils.UncheckedError(err)
-			return nil
+	// the local build is more than a week old, so we should warn
+	if time.Since(dateCompiled) > time.Hour*24*7 {
+		var updateInstructions string
+		if latestVersion != nil {
+			updateInstructions = fmt.Sprintf(" to version: %s", latestVersion.Original())
 		}
-		conf = &Config{}
-	}
-
-	var lastCheck time.Time
-	if conf.LastUpdateCheck == "" {
-		conf.LastUpdateCheck = time.Now().Format("2006-01-02")
-	} else {
-		lastCheck, err = time.Parse("2006-01-02", conf.LastUpdateCheck)
-		if err != nil {
-			warningf(c.App.ErrWriter, "CLI Update Check: failed to parse date of last check: %w", err)
-			return nil
-		}
-	}
-
-	// The latest version info is cached to limit api calls to once every three days
-	if time.Since(lastCheck) < time.Hour*24*3 && conf.LatestVersion != "" {
-		warningf(c.App.ErrWriter, "CLI Update Check: Your CLI is more than 6 weeks old. "+
-			"Consider updating to version: %s", conf.LatestVersion)
-		return nil
-	}
-
-	latestRelease, err := getLatestReleaseVersion()
-	if err != nil {
-		warningf(c.App.ErrWriter, "CLI Update Check: failed to get latest release information: %w", err)
-		return nil
-	}
-
-	latestVersion, err := semver.NewVersion(latestRelease)
-	if err != nil {
-		warningf(c.App.ErrWriter, "CLI Update Check: failed to parse latest version: %w", err)
-		return nil
-	}
-
-	conf.LatestVersion = latestVersion.String()
-
-	err = storeConfigToCache(conf)
-	if err != nil {
-		utils.UncheckedError(err)
-	}
-
-	appVersion := rconfig.Version
-	if appVersion == "" {
-		warningf(c.App.ErrWriter, "CLI Update Check: Your CLI is more than 6 weeks old. "+
-			"Consider updating to version: %s", latestVersion.Original())
-		return nil
-	}
-
-	localVersion, err := semver.NewVersion(appVersion)
-	if err != nil {
-		warningf(c.App.ErrWriter, "CLI Update Check: failed to parse compiled version: %w", err)
-		return nil
-	}
-
-	if localVersion.LessThan(latestVersion) {
-		warningf(c.App.ErrWriter, "CLI Update Check: Your CLI is out of date. Consider updating to version %s. "+
-			"See https://docs.viam.com/cli/#install", latestVersion.Original())
+		warningf(c.App.ErrWriter, "CLI Update Check: Your CLI is more than a week old. "+
+			"New CLI releases happen weekly; consider updating%s. See https://docs.viam.com/cli/#install", updateInstructions)
 	}
 
 	return nil

--- a/cli/config.go
+++ b/cli/config.go
@@ -113,6 +113,9 @@ func storeConfigToCache(cfg *Config) error {
 	return os.WriteFile(path, md, 0o640)
 }
 
+// TODO(RSDK-9727) - `LastUpdateCheck` and `LatestVersion` are no longer used anywhere.
+// Confirm that it's safe to remove these and then get rid of them.
+
 // Config is the schema for saved CLI credentials.
 type Config struct {
 	BaseURL         string     `json:"base_url"`


### PR DESCRIPTION
Adds better warnings on out-of-date CLI. The logic flow is as such:

- Determine the local version and the latest version.
 -- if both can be determined and the local version is older than the latest version, emit warning and return
-- if both can be determined and the local version is _not_ older than the latest version, then emit no warning and return
- if local version and/or latest version can't be determined, then determine when the binary was built.
-- if we can't determine when the binary was built, return
-- if we _can_ determine when the binary was built, emit a warning if it's more than a week old

Tested locally by artificially amending the version tag and build window (from one week to one second), confirmed the cases worked as described.