### PR TITLE
RSDK-6155 - add initialDialAttempts to robot client options

### DIFF
--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -314,10 +314,12 @@ func New(ctx context.Context, address string, clientLogger logging.ZapCompatible
 
 	for {
 		if err := rc.Connect(ctx); err != nil {
-			numAttempts -= 1
+			numAttempts--
 			if numAttempts == 0 {
 				return nil, err
 			}
+		} else {
+			break
 		}
 	}
 

--- a/robot/client/client_options.go
+++ b/robot/client/client_options.go
@@ -34,7 +34,7 @@ type robotClientOpts struct {
 	disableSessions bool
 
 	// initialConnectionAttempts indicates the number of times to try dialing when making
-	// initial connection to a machine. Defaults to three. If set to a zero or a negative
+	// initial connection to a machine. Defaults to three. If set to zero or a negative
 	// value, will attempt to connect forever.
 	initialConnectionAttempts *int
 
@@ -80,7 +80,7 @@ func WithRefreshEvery(refreshEvery time.Duration) RobotClientOption {
 }
 
 // WithInitialDialAttempts sets the number of times to attempt to connect to a robot when
-// initially dialing. Defaults to 3 attempts. If set to a zero or a negative value, will
+// initially dialing. Defaults to 3 attempts. If set to zero or a negative value, will
 // attempt to connect forever.
 
 func WithInitialDialAttempts(attempts int) RobotClientOption {

--- a/robot/client/client_options.go
+++ b/robot/client/client_options.go
@@ -82,7 +82,6 @@ func WithRefreshEvery(refreshEvery time.Duration) RobotClientOption {
 // WithInitialDialAttempts sets the number of times to attempt to connect to a robot when
 // initially dialing. Defaults to 3 attempts. If set to zero or a negative value, will
 // attempt to connect forever.
-
 func WithInitialDialAttempts(attempts int) RobotClientOption {
 	return newFuncRobotClientOption(func(o *robotClientOpts) {
 		o.initialConnectionAttempts = &attempts

--- a/robot/client/client_options.go
+++ b/robot/client/client_options.go
@@ -33,6 +33,10 @@ type robotClientOpts struct {
 	// controls whether or not sessions are disabled.
 	disableSessions bool
 
+	// initialConnectionAttempts indicates the number of times to try dialing when making
+	// initial connection to a machine. Defaults to three.
+	initialConnectionAttempts *int
+
 	modName string
 }
 
@@ -71,6 +75,14 @@ func WithModName(modName string) RobotClientOption {
 func WithRefreshEvery(refreshEvery time.Duration) RobotClientOption {
 	return newFuncRobotClientOption(func(o *robotClientOpts) {
 		o.refreshEvery = &refreshEvery
+	})
+}
+
+// WithInitialDialAttempts sets the number of times to attempt to connect to a robot when
+// initially dialing. Defaults to 3 attempts.
+func WithInitialDialAttempts(attempts int) RobotClientOption {
+	return newFuncRobotClientOption(func(o *robotClientOpts) {
+		o.initialConnectionAttempts = &attempts
 	})
 }
 

--- a/robot/client/client_options.go
+++ b/robot/client/client_options.go
@@ -34,7 +34,8 @@ type robotClientOpts struct {
 	disableSessions bool
 
 	// initialConnectionAttempts indicates the number of times to try dialing when making
-	// initial connection to a machine. Defaults to three.
+	// initial connection to a machine. Defaults to three. If set to a zero or a negative
+	// value, will attempt to connect forever.
 	initialConnectionAttempts *int
 
 	modName string
@@ -79,7 +80,9 @@ func WithRefreshEvery(refreshEvery time.Duration) RobotClientOption {
 }
 
 // WithInitialDialAttempts sets the number of times to attempt to connect to a robot when
-// initially dialing. Defaults to 3 attempts.
+// initially dialing. Defaults to 3 attempts. If set to a zero or a negative value, will
+// attempt to connect forever.
+
 func WithInitialDialAttempts(attempts int) RobotClientOption {
 	return newFuncRobotClientOption(func(o *robotClientOpts) {
 		o.initialConnectionAttempts = &attempts


### PR DESCRIPTION
Adds `initialDialAttempts` to robot client options, to indicate the number of attempts when initially dialing.

I opted not to include a timeout, under the thinking that adding a timeout to a context is the more idiomatic way to work with timeouts in go (and is already respected by the `dial` func in goutils).