### PR TITLE
APP-7537: Update `viam module reload` to set "reload_path" instead of overwriting "execution_path"

### DIFF
--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -568,7 +568,7 @@ func reloadModuleAction(c *cli.Context, vc *viamClient, args reloadModuleArgs, l
 				return err
 			}
 		}
-		needsRestart, err = configureModule(c, vc, manifest, part.Part, args.Local)
+		needsRestart, err = configureModule(c, vc, manifest, part.Part)
 		if err != nil {
 			return err
 		}

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -568,7 +568,7 @@ func reloadModuleAction(c *cli.Context, vc *viamClient, args reloadModuleArgs, l
 				return err
 			}
 		}
-		needsRestart, err = configureModule(c, vc, manifest, part.Part)
+		needsRestart, err = configureModule(c, vc, manifest, part.Part, args.Local)
 		if err != nil {
 			return err
 		}

--- a/cli/module_reload.go
+++ b/cli/module_reload.go
@@ -208,6 +208,7 @@ func createNewModuleMap(moduleID, entryPoint string) ModuleMap {
 	localName := localizeModuleID(moduleID)
 	newMod := ModuleMap(map[string]any{
 		"type":           string(rdkConfig.ModuleTypeRegistry),
+		"module_id":      moduleID,
 		"name":           localName,
 		"reload_path":    entryPoint,
 		"reload_enabled": true,

--- a/cli/module_reload.go
+++ b/cli/module_reload.go
@@ -200,7 +200,7 @@ func mutateModuleConfig(
 		} else {
 			debugf(c.App.Writer, args.Debug, "found local module, inserting registry module")
 		}
-		newMod, err := createNewModuleMap(c, vc, localName, absEntrypoint)
+		newMod, err := createNewModuleMap(c, vc, manifest.ModuleID, localName, absEntrypoint)
 		if err != nil {
 			return nil, false, err
 		}
@@ -209,13 +209,9 @@ func mutateModuleConfig(
 	return modules, dirty, nil
 }
 
-func createNewModuleMap(c *cli.Context, vc *viamClient, localName, entryPoint string) (ModuleMap, error) {
-	moduleID := moduleID{
-		prefix: vc.selectedOrg.Id,
-		name:   localName,
-	}
+func createNewModuleMap(c *cli.Context, vc *viamClient, moduleID, localName, entryPoint string) (ModuleMap, error) {
 	request := apppb.GetModuleRequest{
-		ModuleId: moduleID.String(),
+		ModuleId: moduleID,
 	}
 	module, err := vc.client.GetModule(c.Context, &request)
 	if err != nil {

--- a/cli/module_reload.go
+++ b/cli/module_reload.go
@@ -206,14 +206,14 @@ func createNewModuleMap(c *cli.Context, vc *viamClient, localName, entryPoint st
 		return nil, err
 	}
 	versions := module.Module.Versions
-	modVersion := versions[len(versions)-1]
+	latestVersion := versions[len(versions)-1].Version
 
 	newMod := ModuleMap(map[string]any{
 		"type":           string(rdkConfig.ModuleTypeRegistry),
 		"name":           localName,
 		"reload_path":    entryPoint,
 		"reload_enabled": true,
-		"version":        modVersion,
+		"version":        latestVersion,
 	})
 	return newMod, nil
 }

--- a/cli/module_reload.go
+++ b/cli/module_reload.go
@@ -177,9 +177,14 @@ func mutateModuleConfig(c *cli.Context, modules []ModuleMap, manifest moduleMani
 			return nil, dirty, err
 		}
 		dirty = true
-		debugf(c.App.Writer, args.Debug, "updating ReloadPath and ReloadEnabled")
-		foundMod["reload_path"] = absEntrypoint
-		foundMod["reload_enabled"] = true
+		if samePath {
+			debugf(c.App.Writer, args.Debug, "ReloadPath is up to date, setting ReloadEnabled true")
+			foundMod["reload_enabled"] = true
+		} else {
+			debugf(c.App.Writer, args.Debug, "updating ReloadPath and ReloadEnabled")
+			foundMod["reload_path"] = absEntrypoint
+			foundMod["reload_enabled"] = true
+		}
 	} else {
 		dirty = true
 		if foundMod == nil {

--- a/cli/module_reload_test.go
+++ b/cli/module_reload_test.go
@@ -125,6 +125,7 @@ func TestMutateModuleConfig(t *testing.T) {
 		JSONManifest: rdkConfig.JSONManifest{Entrypoint: "/bin/mod"},
 		Build:        &manifestBuildInfo{Path: "module.tar.gz"},
 	}
+	expectedName := "viam-labs_test-module_from_reload"
 	expectedVersion := "latest-with-prerelease"
 	remoteReloadPath := ".viam/packages-local/viam-labs_test-module_from_reload-module.tar.gz"
 
@@ -186,6 +187,8 @@ func TestMutateModuleConfig(t *testing.T) {
 	t.Run("insert_when_missing", func(t *testing.T) {
 		modules := []ModuleMap{}
 		modules, _, _ = mutateModuleConfig(c, modules, manifest, true)
+		test.That(t, modules[0]["module_id"], test.ShouldEqual, manifest.ModuleID)
+		test.That(t, modules[0]["name"], test.ShouldEqual, expectedName)
 		test.That(t, modules[0]["reload_path"], test.ShouldEqual, manifest.Entrypoint)
 		test.That(t, modules[0]["reload_enabled"], test.ShouldBeTrue)
 		test.That(t, modules[0]["version"], test.ShouldEqual, expectedVersion)
@@ -207,6 +210,8 @@ func TestMutateModuleConfig(t *testing.T) {
 	c = newTestContext(t, map[string]any{})
 	t.Run("remote_insert", func(t *testing.T) {
 		modules, _, _ := mutateModuleConfig(c, []ModuleMap{}, manifest, false)
+		test.That(t, modules[0]["module_id"], test.ShouldEqual, manifest.ModuleID)
+		test.That(t, modules[0]["name"], test.ShouldEqual, expectedName)
 		test.That(t, modules[0]["reload_path"], test.ShouldEqual, remoteReloadPath)
 		test.That(t, modules[0]["reload_enabled"], test.ShouldBeTrue)
 		test.That(t, modules[0]["version"], test.ShouldEqual, expectedVersion)

--- a/cli/module_reload_test.go
+++ b/cli/module_reload_test.go
@@ -46,7 +46,7 @@ func TestFullReloadFlow(t *testing.T) {
 		) (*apppb.GetRobotPartResponse, error) {
 			return &apppb.GetRobotPartResponse{Part: &apppb.RobotPart{
 				RobotConfig: confStruct,
-				Fqdn:        "restart-module-robot.local",
+				Fqdn:        "restart-module-robot",
 			}, ConfigJson: ``}, nil
 		},
 		UpdateRobotPartFunc: func(ctx context.Context, req *apppb.UpdateRobotPartRequest,

--- a/cli/module_reload_test.go
+++ b/cli/module_reload_test.go
@@ -62,6 +62,9 @@ func TestFullReloadFlow(t *testing.T) {
 				{ApiKey: &apppb.APIKey{}},
 			}}, nil
 		},
+		GetModuleFunc: func(ctx context.Context, req *apppb.GetModuleRequest, opts ...grpc.CallOption) (*apppb.GetModuleResponse, error) {
+			return &apppb.GetModuleResponse{Module: &apppb.Module{Versions: []*apppb.VersionHistory{{Version: "1.0.0"}}}}, nil
+		},
 	}, nil, &inject.BuildServiceClient{},
 		map[string]any{
 			moduleFlagPath: manifestPath, generalFlagPartID: "part-123",

--- a/cli/module_reload_test.go
+++ b/cli/module_reload_test.go
@@ -126,49 +126,85 @@ func TestMutateModuleConfig(t *testing.T) {
 		Build:        &manifestBuildInfo{Path: "module.tar.gz"},
 	}
 
-	t.Run("correct_exepath", func(t *testing.T) {
-		// correct ExePath (do nothing)
-		modules := []ModuleMap{{"module_id": manifest.ModuleID, "executable_path": manifest.Entrypoint}}
+	t.Run("correct_reload_path_and_enabled", func(t *testing.T) {
+		// correct ReloadPath and ReloadEnabled (do nothing) in registry module
+		modules := []ModuleMap{{
+			"type":           string(rdkConfig.ModuleTypeRegistry),
+			"module_id":      manifest.ModuleID,
+			"reload_path":    manifest.Entrypoint,
+			"reload_enabled": true,
+		}}
 		_, dirty, err := mutateModuleConfig(c, modules, manifest, true)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, dirty, test.ShouldBeFalse)
 	})
 
-	t.Run("wrong_exepath", func(t *testing.T) {
-		// wrong ExePath
-		modules := []ModuleMap{{"module_id": manifest.ModuleID, "executable_path": "WRONG"}}
+	t.Run("correct_reload_path_and_disabled", func(t *testing.T) {
+		// correct ReloadPath, but ReloadEnabled is false in registry module
+		modules := []ModuleMap{{
+			"type":           string(rdkConfig.ModuleTypeRegistry),
+			"module_id":      manifest.ModuleID,
+			"reload_path":    manifest.Entrypoint,
+			"reload_enabled": false,
+		}}
 		_, dirty, err := mutateModuleConfig(c, modules, manifest, true)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, dirty, test.ShouldBeTrue)
-		test.That(t, modules[0]["executable_path"], test.ShouldEqual, manifest.Entrypoint)
+		test.That(t, modules[0]["reload_enabled"], test.ShouldBeTrue)
 	})
 
-	t.Run("wrong_exepath_local", func(t *testing.T) {
-		// wrong ExePath with localName
-		modules := []ModuleMap{{"name": localizeModuleID(manifest.ModuleID)}}
-		mutateModuleConfig(c, modules, manifest, true)
-		test.That(t, modules[0]["executable_path"], test.ShouldEqual, manifest.Entrypoint)
+	t.Run("incorrect_reload_path_and_disabled", func(t *testing.T) {
+		// incorrect ReloadPath and ReloadEnabled is false in registry module
+		modules := []ModuleMap{{
+			"type":           string(rdkConfig.ModuleTypeRegistry),
+			"module_id":      manifest.ModuleID,
+			"reload_path":    "incorrect/path",
+			"reload_enabled": false,
+		}}
+		_, dirty, err := mutateModuleConfig(c, modules, manifest, true)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, dirty, test.ShouldBeTrue)
+		test.That(t, modules[0]["reload_path"], test.ShouldEqual, manifest.Entrypoint)
+		test.That(t, modules[0]["reload_enabled"], test.ShouldBeTrue)
 	})
 
-	t.Run("insert", func(t *testing.T) {
-		// insert case
+	t.Run("reload_fields_missing", func(t *testing.T) {
+		// ReloadPath and ReloadEnabled are both missing from the module map in registry module
+		modules := []ModuleMap{{
+			"type":      string(rdkConfig.ModuleTypeRegistry),
+			"module_id": manifest.ModuleID,
+		}}
+		_, dirty, err := mutateModuleConfig(c, modules, manifest, true)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, dirty, test.ShouldBeTrue)
+		test.That(t, modules[0]["reload_path"], test.ShouldEqual, manifest.Entrypoint)
+		test.That(t, modules[0]["reload_enabled"], test.ShouldBeTrue)
+	})
+
+	t.Run("insert_when_missing", func(t *testing.T) {
 		modules := []ModuleMap{}
 		modules, _, _ = mutateModuleConfig(c, modules, manifest, true)
-		test.That(t, modules[0]["executable_path"], test.ShouldEqual, manifest.Entrypoint)
+		test.That(t, modules[0]["reload_path"], test.ShouldEqual, manifest.Entrypoint)
+		test.That(t, modules[0]["reload_enabled"], test.ShouldBeTrue)
 	})
 
-	t.Run("registry_to_local", func(t *testing.T) {
-		// registry to local
-		// todo(RSDK-6712): this goes away once we reconcile registry + local modules
-		modules := []ModuleMap{{"module_id": manifest.ModuleID, "executable_path": "WRONG", "type": string(rdkConfig.ModuleTypeRegistry)}}
-		mutateModuleConfig(c, modules, manifest, true)
-		test.That(t, modules[0]["name"], test.ShouldEqual, localizeModuleID(manifest.ModuleID))
+	t.Run("insert_when_local_module_found", func(t *testing.T) {
+		// ReloadPath and ReloadEnabled are both missing from the module map in registry module
+		modules := []ModuleMap{{
+			"type":      string(rdkConfig.ModuleTypeLocal),
+			"module_id": manifest.ModuleID,
+		}}
+		updatedModules, _, _ := mutateModuleConfig(c, modules, manifest, true)
+		test.That(t, len(updatedModules), test.ShouldEqual, 2)
+		test.That(t, updatedModules[1]["reload_path"], test.ShouldEqual, manifest.Entrypoint)
+		test.That(t, updatedModules[1]["reload_enabled"], test.ShouldBeTrue)
 	})
 
 	c = newTestContext(t, map[string]any{})
 	t.Run("remote_insert", func(t *testing.T) {
 		modules, _, _ := mutateModuleConfig(c, []ModuleMap{}, manifest, false)
-		test.That(t, modules[0]["executable_path"], test.ShouldEqual,
+		test.That(t, modules[0]["reload_path"], test.ShouldEqual,
 			".viam/packages-local/viam-labs_test-module_from_reload-module.tar.gz")
+		test.That(t, modules[0]["reload_enabled"], test.ShouldBeTrue)
 	})
 }


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/APP-7537)

When developing a registry module, users often want to temporarily point a part to the local version of the module that has the changes they're making on it. The `viam module reload` command currently does this by overwriting the `execution_path` setting in the config. However, this is a destructive change, so when they user wants to switch the part back to using the registry version of the module, they have to look back at its history and figure out what the config used to be and either revert or paste that old setting back in.

With this PR we're instead going to write this local dev path to a new field called `reload_path` and set `reload_enabled` to true. We've already made changes in the app backend to reference these fields when setting a part config, this is updating the CLI command to update these fields instead of `executable_path`.