### PR TITLE
RSDK-9978 - fix profile updating

### DIFF
--- a/cli/profile.go
+++ b/cli/profile.go
@@ -79,6 +79,20 @@ func addOrUpdateProfile(c *cli.Context, args addOrUpdateProfileArgs, isAdd bool)
 		addOrUpdate = "added"
 	} else {
 		addOrUpdate = "updated"
+
+		conf, err := configFromCacheInner(getCLIProfilePath(profile.Name))
+		if err != nil {
+			return err
+		}
+
+		conf.Auth = &profile.APIKey
+		conf.profile = profile.Name
+
+		// if we're updating, make sure we actually store the updated config
+		err = storeConfigToCache(conf)
+		if err != nil {
+			return err
+		}
 	}
 
 	printf(c.App.Writer, "Successfully %s profile %s", addOrUpdate, args.ProfileName)


### PR DESCRIPTION
Makes sure that when `viam profile update` is called, we actually store an updated config.

Tested locally, was able to create a poorly formatted profile, then run `viam profile update` on it, then successfully use it.