### PR TITLE
[RSDK-10205] Ignore the error of getGlobalArgs

### DIFF
--- a/cli/auth.go
+++ b/cli/auth.go
@@ -493,11 +493,11 @@ func (c *viamClient) ensureLoggedInInner() error {
 		// expired.
 		newToken, err := c.authFlow.refreshToken(c.c.Context, authToken)
 		if err != nil {
-			globalArgs, err := getGlobalArgs(c.c)
-			if err != nil {
-				return err
+			debugFlag := false
+			if globalArgs, err := getGlobalArgs(c.c); err == nil {
+				debugFlag = globalArgs.Debug
 			}
-			debugf(c.c.App.Writer, globalArgs.Debug, "Token refresh error: %v", err)
+			debugf(c.c.App.Writer, debugFlag, "Token refresh error: %v", err)
 			utils.UncheckedError(c.logout()) // clear cache if failed to refresh
 			return errors.New("error while refreshing token, logging out. Please log in again")
 		}


### PR DESCRIPTION
Trying to debug why sometimes we get refresh errors, but the existing code was replacing the refresh error with a different error (or nil) from `getGlobalArgs`. Because that function is only used for setting a debug flag and shouldn't break the rest of the code, I updated the code to basically ignore that error. 

Hopefully we can get improved error messaging when this refresh issue happens now.