### PR TITLE
RSDK-10247 Guard FTDC net dereference

### DIFF
--- a/ftdc/sys/net.go
+++ b/ftdc/sys/net.go
@@ -67,7 +67,9 @@ func (netStatser *netStatser) Stats() any {
 		ret.UDP.TxQueueLength = netUDPSummary.TxQueueLength
 		ret.UDP.RxQueueLength = netUDPSummary.RxQueueLength
 		ret.UDP.UsedSockets = netUDPSummary.UsedSockets
-		ret.UDP.Drops = *netUDPSummary.Drops
+		if netUDPSummary != nil {
+			ret.UDP.Drops = *netUDPSummary.Drops
+		}
 	}
 
 	return ret

--- a/ftdc/sys/net.go
+++ b/ftdc/sys/net.go
@@ -57,17 +57,19 @@ func (netStatser *netStatser) Stats() any {
 		}
 	}
 
-	if netTCPSummary, err := netStatser.fs.NetTCPSummary(); err == nil && netTCPSummary != nil {
+	if netTCPSummary, err := netStatser.fs.NetTCPSummary(); err == nil {
 		ret.TCP.TxQueueLength = netTCPSummary.TxQueueLength
 		ret.TCP.RxQueueLength = netTCPSummary.RxQueueLength
 		ret.TCP.UsedSockets = netTCPSummary.UsedSockets
 	}
 
-	if netUDPSummary, err := netStatser.fs.NetUDPSummary(); err == nil && netUDPSummary != nil {
+	if netUDPSummary, err := netStatser.fs.NetUDPSummary(); err == nil {
 		ret.UDP.TxQueueLength = netUDPSummary.TxQueueLength
 		ret.UDP.RxQueueLength = netUDPSummary.RxQueueLength
 		ret.UDP.UsedSockets = netUDPSummary.UsedSockets
-		ret.UDP.Drops = *netUDPSummary.Drops
+		if netUDPSummary.Drops != nil {
+			ret.UDP.Drops = *(netUDPSummary.Drops)
+		}
 	}
 
 	return ret

--- a/ftdc/sys/net.go
+++ b/ftdc/sys/net.go
@@ -68,7 +68,7 @@ func (netStatser *netStatser) Stats() any {
 		ret.UDP.RxQueueLength = netUDPSummary.RxQueueLength
 		ret.UDP.UsedSockets = netUDPSummary.UsedSockets
 		if netUDPSummary.Drops != nil {
-			ret.UDP.Drops = *(netUDPSummary.Drops)
+			ret.UDP.Drops = *netUDPSummary.Drops
 		}
 	}
 

--- a/ftdc/sys/net.go
+++ b/ftdc/sys/net.go
@@ -57,19 +57,17 @@ func (netStatser *netStatser) Stats() any {
 		}
 	}
 
-	if netTCPSummary, err := netStatser.fs.NetTCPSummary(); err == nil {
+	if netTCPSummary, err := netStatser.fs.NetTCPSummary(); err == nil && netTCPSummary != nil {
 		ret.TCP.TxQueueLength = netTCPSummary.TxQueueLength
 		ret.TCP.RxQueueLength = netTCPSummary.RxQueueLength
 		ret.TCP.UsedSockets = netTCPSummary.UsedSockets
 	}
 
-	if netUDPSummary, err := netStatser.fs.NetUDPSummary(); err == nil {
+	if netUDPSummary, err := netStatser.fs.NetUDPSummary(); err == nil && netUDPSummary != nil {
 		ret.UDP.TxQueueLength = netUDPSummary.TxQueueLength
 		ret.UDP.RxQueueLength = netUDPSummary.RxQueueLength
 		ret.UDP.UsedSockets = netUDPSummary.UsedSockets
-		if netUDPSummary != nil {
-			ret.UDP.Drops = *netUDPSummary.Drops
-		}
+		ret.UDP.Drops = *netUDPSummary.Drops
 	}
 
 	return ret


### PR DESCRIPTION
RSDK-10247

I _think_ `netStatser.fs.NetUDPSummary()` can return `nil` and cause a npe in some circumstances (after robot close maybe?) Guarded the one actual dereference (the calls above don't cause issue.)

I saw this stack trace from a new test I was writing:

```
goroutine 236 [running]:
runtime/debug.Stack()
	/usr/local/go/src/runtime/debug/stack.go:26 +0x67
runtime/debug.PrintStack()
	/usr/local/go/src/runtime/debug/stack.go:18 +0x1d
go.viam.com/utils.PanicCapturingGoWithCallback.func1.1()
	/home/testbot/go/pkg/mod/go.viam.com/utils@v0.1.132/runtime.go:146 +0x65
panic({0x35e85a0?, 0x53a1280?})
	/usr/local/go/src/runtime/panic.go:785 +0x132
go.viam.com/rdk/ftdc/sys.(*netStatser).Stats(0xc000cb8678)
	/host/ftdc/sys/net.go:70 +0x23c
go.viam.com/rdk/ftdc.(*FTDC).constructDatum(0xc000396600)
	/host/ftdc/ftdc.go:300 +0x1f8
go.viam.com/rdk/ftdc.(*FTDC).statsReader(0xc000396600, {0x3f65e80, 0xc001272230})
	/host/ftdc/ftdc.go:215 +0x4c
go.viam.com/utils.NewStoppableWorkerWithTicker.func1()
	/home/testbot/go/pkg/mod/go.viam.com/utils@v0.1.132/stoppable_workers.go:66 +0x192
go.viam.com/utils.PanicCapturingGoWithCallback.func1()
	/home/testbot/go/pkg/mod/go.viam.com/utils@v0.1.132/runtime.go:156 +0x82
created by go.viam.com/utils.PanicCapturingGoWithCallback in goroutine 46
	/home/testbot/go/pkg/mod/go.viam.com/utils@v0.1.132/runtime.go:143 +0xd1
2025-03-12T18:46:12.623Z	ERROR	utils@v0.1.132/runtime.go:147	panic while running function	{"error": "runtime error: invalid memory address or nil pointer dereference"}
```