### PR TITLE
RSDK-10245 Use VIAM_MODULE_NAME as logger name for golang module loggers

### DIFF
--- a/module/log.go
+++ b/module/log.go
@@ -59,6 +59,9 @@ type moduleLogger struct {
 // to start modules with a "log-level" commandline argument. The created logger
 // will send log events back to the module's parent (the RDK) via gRPC when
 // possible and to STDOUT when not possible.
+//
+// `moduleName` will be the name of the created logger. Pass `""` if you wish to
+// use the value specified by the `VIAM_MODULE_NAME` environment variable.
 func NewLoggerFromArgs(moduleName string) logging.Logger {
 	// If no `moduleName` was specified, grab it from the environment (will still be empty
 	// string if not specified in environment.)

--- a/module/log.go
+++ b/module/log.go
@@ -60,6 +60,12 @@ type moduleLogger struct {
 // will send log events back to the module's parent (the RDK) via gRPC when
 // possible and to STDOUT when not possible.
 func NewLoggerFromArgs(moduleName string) logging.Logger {
+	// If no `moduleName` was specified, grab it from the environment (will still be empty
+	// string if not specified in environment.)
+	if moduleName == "" {
+		moduleName, _ = os.LookupEnv("VIAM_MODULE_NAME")
+	}
+
 	modAppender := newModuleAppender()
 	baseLogger := logging.NewBlankLogger(moduleName)
 	baseLogger.AddAppender(modAppender)


### PR DESCRIPTION
RSDK-10245

Uses `VIAM_MODULE_NAME` as the logger name for loggers created through `NewLoggerFromArgs` if passed in `moduleName` is `""`.

Golang modular resource logs that used to look like:
```
2025-03-12T19:20:59.145Z	INFO	rdk:component:generic/counter1	simplemodule/module.go:37	Creating a new counter component!	{"log_ts":"2025-03-12T19:20:59.144Z"}
```
now look like:
```
2025-03-12T19:21:52.640Z	INFO	SimpleModule.rdk:component:generic/counter1	simplemodule/module.go:37	Creating a new counter component!	{"log_ts":"2025-03-12T19:21:52.640Z"}
```