### PR TITLE
[APP-7829] Fix tag sorting when -rc involved

### DIFF
--- a/etc/dev-version.sh
+++ b/etc/dev-version.sh
@@ -6,7 +6,7 @@ if [ -n "$(git status -s)" ]; then
 fi
 
 # See if we have a direct tag
-DIRECT_TAG=$(git tag --points-at | sort -Vr | head -n1)
+DIRECT_TAG=$(git tag --points-at | tr - \~ | sort -Vr | tr \~ - | head -n1)
 if [ -n "$DIRECT_TAG" ]; then
     echo ${DIRECT_TAG}
     exit 0


### PR DESCRIPTION
One liner to fix the sorting of versions so that -rc is sorted as BEFORE the stable version.