### PR TITLE
RSDK-10246 Skip E2E tunnel tests on 32 bit arch for now

### DIFF
--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -1325,6 +1326,11 @@ func TestUpdateOAuthAppAction(t *testing.T) {
 }
 
 func TestTunnelE2ECLI(t *testing.T) {
+	// TODO(RSDK-10246): Remove this skip and fix the test on 32-bit arch.
+	if runtime.GOARCH == "arm" {
+		t.Skip("skipping on 32-bit arm, as there is an unknown issue with the timing of entity closure")
+	}
+
 	// `TestTunnelE2ECLI` attempts to send "Hello, World!" across a tunnel created by the
 	// CLI. It is mostly identical to `TestTunnelE2E` in web/server/entrypoint_test.go.
 	// The tunnel is:

--- a/web/server/entrypoint_test.go
+++ b/web/server/entrypoint_test.go
@@ -369,6 +369,11 @@ func TestMachineStateNoResources(t *testing.T) {
 }
 
 func TestTunnelE2E(t *testing.T) {
+	// TODO(RSDK-10246): Remove this skip and fix the test on 32-bit arch.
+	if runtime.GOARCH == "arm" {
+		t.Skip("skipping on 32-bit arm, as there is an unknown issue with the timing of entity closure")
+	}
+
 	// `TestTunnelE2E` attempts to send "Hello, World!" across a tunnel. The tunnel is:
 	//
 	// test-process <-> source-listener(localhost:23656) <-> machine(localhost:23655) <-> dest-listener(localhost:23654)


### PR DESCRIPTION
@cheukt would be nice to skip these for now. Don't know if I'll have time to fix before going OOO, and they are causing failures on the main branch (only with 32-bit.) Can diagnose further once I get back.