### PR TITLE
RSDK-10227 - Propagate env vars for local modules

### DIFF
--- a/config/reader.go
+++ b/config/reader.go
@@ -599,8 +599,8 @@ func processConfig(unprocessedConfig *Config, fromCloud bool, logger logging.Log
 	// adding them here ensures that if the parsed API key changes, the module will be restarted with the updated environment.
 	env := additionalModuleEnvVars(cfg.Cloud, cfg.Auth)
 	if len(env) > 0 {
-		for _, m := range cfg.Modules {
-			m.MergeEnvVars(env)
+		for idx := 0; idx < len(cfg.Modules); idx++ {
+			cfg.Modules[idx].MergeEnvVars(env)
 		}
 	}
 

--- a/config/reader_ext_test.go
+++ b/config/reader_ext_test.go
@@ -12,6 +12,7 @@ import (
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
+	rutils "go.viam.com/rdk/utils"
 )
 
 func TestFromReaderValidate(t *testing.T) {
@@ -63,6 +64,39 @@ func TestFromReaderValidate(t *testing.T) {
 				Name:  "foo",
 				API:   arm.API,
 				Model: resource.DefaultModelFamily.WithModel("foo"),
+			},
+		},
+		Network: config.NetworkConfig{NetworkConfigData: config.NetworkConfigData{
+			BindAddress:           "localhost:8080",
+			BindAddressDefaultSet: true,
+			Sessions: config.SessionsConfig{
+				HeartbeatWindow: config.DefaultSessionHeartbeatWindow,
+			},
+		}},
+	}
+	test.That(t, expected.Ensure(false, logger), test.ShouldBeNil)
+	test.That(t, conf, test.ShouldResemble, expected)
+}
+
+func TestFromReaderEmptyModuleEnvironment(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	conf, err := config.FromReader(context.Background(),
+		"somepath",
+		strings.NewReader(`{"cloud":{"id":"123","secret":"abc"},"modules": [{"name": "foo"}]}`),
+		logger, nil)
+	test.That(t, err, test.ShouldBeNil)
+	expected := &config.Config{
+		ConfigFilePath: "somepath",
+		Cloud:          &config.Cloud{ID: "123", Secret: "abc"},
+		Modules: []config.Module{
+			{
+				Name: "foo",
+				Environment: map[string]string{
+					rutils.MachinePartIDEnvVar: "123",
+					rutils.PrimaryOrgIDEnvVar:  "",
+					rutils.LocationIDEnvVar:    "",
+					rutils.MachineIDEnvVar:     "",
+				},
 			},
 		},
 		Network: config.NetworkConfig{NetworkConfigData: config.NetworkConfigData{


### PR DESCRIPTION
did a dumb thing and was making a copy (since we're passing by value) before modifying, so we end up losing the modifications