### PR TITLE
RSDK-10211 - create app client from env vars

### DIFF
--- a/app/viam_client.go
+++ b/app/viam_client.go
@@ -72,7 +72,7 @@ func CreateViamClientWithAPIKey(
 
 // CreateViamClientFromEnvVars creates a ViamClient from env vars set by the module manager.
 // It is intended to be used from within modular resources, and will likely fail if called
-// in another context
+// in another context.
 func CreateViamClientFromEnvVars(ctx context.Context, options *Options, logger logging.Logger) (*ViamClient, error) {
 	if options == nil {
 		options = &Options{}

--- a/app/viam_client.go
+++ b/app/viam_client.go
@@ -70,9 +70,10 @@ func CreateViamClientWithAPIKey(
 	return CreateViamClientWithOptions(ctx, options, logger)
 }
 
-// CreateViamClientFromEnvVars creates a ViamClient from env vars set by the module manager.
-// It is intended to be used from within modular resources, and will likely fail if called
-// in another context.
+// CreateViamClientFromEnvVars creates a ViamClient using credentials set in the environment
+// as `VIAM_API_KEY` and `VIAM_API_KEY_ID`. These will typically be set by the module manager
+// and this API is primarily intended for use within modular resources, though can be used
+// in another context so long as the user manually sets the appropriate env vars.
 func CreateViamClientFromEnvVars(ctx context.Context, options *Options, logger logging.Logger) (*ViamClient, error) {
 	if options == nil {
 		options = &Options{}

--- a/app/viam_client.go
+++ b/app/viam_client.go
@@ -4,12 +4,15 @@ package app
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/url"
+	"os"
 	"strings"
 
 	"go.viam.com/utils/rpc"
 
 	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/utils"
 )
 
 // ViamClient is a gRPC client for method calls to Viam app.
@@ -65,6 +68,23 @@ func CreateViamClientWithAPIKey(
 		Payload: apiKey,
 	}
 	return CreateViamClientWithOptions(ctx, options, logger)
+}
+
+// CreateViamClientFromEnvVars creates a ViamClient from env vars set by the module manager.
+// It is intended to be used from within modular resources, and will likely fail if called
+// in another context
+func CreateViamClientFromEnvVars(ctx context.Context, options *Options, logger logging.Logger) (*ViamClient, error) {
+	if options == nil {
+		options = &Options{}
+	}
+
+	apiKey := os.Getenv(utils.APIKeyEnvVar)
+	apiKeyID := os.Getenv(utils.APIKeyIDEnvVar)
+	if apiKey == "" || apiKeyID == "" {
+		return nil, fmt.Errorf("api key (%s) and/or api key ID (%s) were set improperly, cannot be empty", apiKey, apiKeyID)
+	}
+
+	return CreateViamClientWithAPIKey(ctx, *options, apiKey, apiKeyID, logger)
 }
 
 // AppClient initializes and returns an AppClient instance used to make app method calls.

--- a/app/viam_client_test.go
+++ b/app/viam_client_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/viamrobotics/webrtc/v3"
@@ -17,6 +18,7 @@ import (
 	"google.golang.org/grpc"
 
 	"go.viam.com/rdk/logging"
+	rutils "go.viam.com/rdk/utils"
 )
 
 var (
@@ -82,6 +84,36 @@ func TestCreateViamClientWithOptions(t *testing.T) {
 				},
 			}
 			client, err := CreateViamClientWithOptions(context.Background(), opts, logger)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("Expected error: %v, got: %v", tt.expectErr, err)
+			}
+			if !tt.expectErr {
+				if client == nil {
+					t.Error("Expected a valid client, got nil")
+				} else {
+					client.Close()
+				}
+			}
+		})
+	}
+}
+
+func TestCreateViamClientFromEnvVarsTests(t *testing.T) {
+	apiKeyTests := []struct {
+		name      string
+		apiKey    string
+		apiKeyID  string
+		expectErr bool
+	}{
+		{"Valid API Key", testAPIKey, testAPIKeyID, false},
+		{"Empty API Key", "", testAPIKeyID, true},
+		{"Empty API Key ID", testAPIKey, "", true},
+	}
+	for _, tt := range apiKeyTests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Setenv(rutils.APIKeyEnvVar, tt.apiKey)
+			os.Setenv(rutils.APIKeyIDEnvVar, tt.apiKeyID)
+			client, err := CreateViamClientFromEnvVars(context.Background(), &Options{}, logger)
 			if (err != nil) != tt.expectErr {
 				t.Errorf("Expected error: %v, got: %v", tt.expectErr, err)
 			}


### PR DESCRIPTION
Adds support for building an app client from env vars, to be used within modular resources.

Blocked on release of https://github.com/viamrobotics/rdk/pull/4853