### PR TITLE
RSDK-10257 - Early return if tunnel destination port not allowed

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -1379,7 +1379,11 @@ func tunnelTraffic(ctx *cli.Context, robotClient *client.RobotClient, local, des
 			}
 		}
 		if !allowed {
-			return errors.Errorf("tunneling to destination port %v not allowed", dest)
+			return errors.Errorf(
+				"tunneling to destination port %v not allowed. "+
+					"Please ensure the traffic_tunnel_endpoints configuration is set correctly on the machine.",
+				dest,
+			)
 		}
 	}
 

--- a/cli/client.go
+++ b/cli/client.go
@@ -1379,7 +1379,7 @@ func tunnelTraffic(ctx *cli.Context, robotClient *client.RobotClient, local, des
 			}
 		}
 		if !allowed {
-			return errors.Errorf("tunneling to destination port %v not allowed.", dest)
+			return errors.Errorf("tunneling to destination port %v not allowed", dest)
 		}
 	}
 

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -1417,6 +1417,12 @@ func TestTunnelE2ECLI(t *testing.T) {
 	// Start CLI tunneler.
 	//nolint:dogsled
 	cCtx, _, _, _ := setup(nil, nil, nil, nil, "token")
+
+	// error early if tunnel not listed
+	err = tunnelTraffic(cCtx, rc, sourcePort, 1)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "not allowed")
+
 	wg.Add(1)
 	go func() {
 		defer wg.Done()


### PR DESCRIPTION
maybe merge next week to allow for the rollout of config changes first.

example output
```
❯ viam machine part tunnel --part XXXX --destination-port 1010 --local-port 8888
Error: Tunneling to destination port 1010 not allowed.
```
