### PR TITLE
RSDK-10246 Fix `TestTunnelE2E*` tests

### DIFF
--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -1325,9 +1325,6 @@ func TestUpdateOAuthAppAction(t *testing.T) {
 }
 
 func TestTunnelE2ECLI(t *testing.T) {
-	// TODO(RSDK-10246): Remove this skip and fix the test.
-	t.Skip("skipping for now, as there is an unknown issue with the timing of entity closure")
-
 	// `TestTunnelE2ECLI` attempts to send "Hello, World!" across a tunnel created by the
 	// CLI. It is mostly identical to `TestTunnelE2E` in web/server/entrypoint_test.go.
 	// The tunnel is:
@@ -1375,10 +1372,6 @@ func TestTunnelE2ECLI(t *testing.T) {
 		n, err = conn.Write([]byte(tunnelMsg))
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, n, test.ShouldEqual, len(tunnelMsg))
-
-		// Cancel `runServerCtx` once message has made it all the way across and has been
-		// echoed back. This should stop the `RunServer` goroutine below.
-		runServerCtxCancel()
 	}()
 
 	// Start a machine at `machineAddr` (`RunServer` in a goroutine.)
@@ -1436,6 +1429,10 @@ func TestTunnelE2ECLI(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, n, test.ShouldEqual, len(tunnelMsg))
 	test.That(t, string(bytes), test.ShouldContainSubstring, tunnelMsg)
+
+	// Cancel `runServerCtx` once message has made it all the way across and has been
+	// echoed back. This should stop the `RunServer` goroutine.
+	runServerCtxCancel()
 
 	wg.Wait()
 }

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -1257,6 +1257,8 @@ func (rc *RobotClient) Tunnel(ctx context.Context, conn io.ReadWriteCloser, dest
 
 	wg.Wait()
 	rc.Logger().CInfow(ctx, "tunnel to server closed", "port", dest)
+	rc.Logger().Infow("errors were", "err", err, "readerSenderErr", readerSenderErr,
+		"recvWriterErr", recvWriterErr)
 	return errors.Join(err, readerSenderErr, recvWriterErr)
 }
 

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -1257,8 +1257,6 @@ func (rc *RobotClient) Tunnel(ctx context.Context, conn io.ReadWriteCloser, dest
 
 	wg.Wait()
 	rc.Logger().CInfow(ctx, "tunnel to server closed", "port", dest)
-	rc.Logger().Infow("errors were", "err", err, "readerSenderErr", readerSenderErr,
-		"recvWriterErr", recvWriterErr)
 	return errors.Join(err, readerSenderErr, recvWriterErr)
 }
 

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -14,10 +14,12 @@ import (
 )
 
 func filterError(ctx context.Context, err error, closeChan <-chan struct{}, logger logging.Logger) error {
-	// if connection is expected to be closed, filter out "use of closed network connection" errors
+	// If the connection is expected to be closed, filter out any errors that may have
+	// resulted from previous connection closure.
 	select {
 	case <-closeChan:
-		if errors.Is(err, net.ErrClosed) {
+		if errors.Is(err, net.ErrClosed) || errors.Is(err, io.ErrClosedPipe) ||
+			errors.Is(err, context.Canceled) {
 			logger.CDebugw(ctx, "expected error received", "err", err)
 			return nil
 		}

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -18,8 +18,8 @@ func filterError(ctx context.Context, err error, closeChan <-chan struct{}, logg
 	// resulted from previous connection closure.
 	select {
 	case <-closeChan:
-		if errors.Is(err, net.ErrClosed) || errors.Is(err, io.ErrClosedPipe) ||
-			errors.Is(err, context.Canceled) {
+		if errors.Is(err, net.ErrClosed) || errors.Is(err, io.ErrClosedPipe) || errors.Is(err, context.Canceled) ||
+			(err != nil && strings.Contains(err.Error(), "missing HTTP content-type")) {
 			logger.CDebugw(ctx, "expected error received", "err", err)
 			return nil
 		}

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -18,20 +18,31 @@ func filterError(ctx context.Context, err error, closeChan <-chan struct{}, logg
 	// resulted from previous connection closure.
 	select {
 	case <-closeChan:
-		if errors.Is(err, net.ErrClosed) || errors.Is(err, io.ErrClosedPipe) || errors.Is(err, context.Canceled) ||
-			(err != nil && strings.Contains(err.Error(), "missing HTTP content-type")) {
-			logger.CDebugw(ctx, "expected error received", "err", err)
+		if errors.Is(err, net.ErrClosed) || errors.Is(err, io.ErrClosedPipe) {
+			logger.CDebugw(ctx, "expected error due to connection closure received", "err", err)
 			return nil
 		}
 	default:
 	}
 
+	// context.Canceled indicates that the context on the bidi stream was canceled midway
+	// through sending or receiving.
+	if errors.Is(err, context.Canceled) {
+		logger.CDebug(ctx, "ignoring context cancelation")
+		return nil
+	}
+
 	// EOF indicates that the connection passed in is not going to receive any more data
 	// and is not expecting any more data to be written to it.
-	//
-	// This is expected and does not indicate an error, so filter it out.
 	if errors.Is(err, io.EOF) {
-		logger.CDebugw(ctx, "expected EOF received")
+		logger.CDebug(ctx, "ignoring EOF error")
+		return nil
+	}
+
+	// Depending on when the tunnel is closed, the server may not have a chance to complete
+	// sending the HTTP2 header (gRPC is implemented over HTTP2.)
+	if err != nil && strings.Contains(err.Error(), "missing HTTP content-type") {
+		logger.CDebug(ctx, "ignoring error about malformed header")
 		return nil
 	}
 
@@ -39,6 +50,7 @@ func filterError(ctx context.Context, err error, closeChan <-chan struct{}, logg
 	// trailers.
 	if err != nil && strings.Contains(err.Error(),
 		"server closed the stream without sending trailers") {
+		logger.CDebug(ctx, "ignoring error about failure to receive trailers")
 		return nil
 	}
 

--- a/web/server/entrypoint_test.go
+++ b/web/server/entrypoint_test.go
@@ -369,8 +369,7 @@ func TestMachineStateNoResources(t *testing.T) {
 }
 
 func TestTunnelE2E(t *testing.T) {
-	// TODO(RSDK-10246): Remove this skip and fix the test.
-	t.Skip("skipping for now, as there is an unknown issue with the timing of entity closure")
+	logger := logging.NewTestLogger(t)
 
 	// `TestTunnelE2E` attempts to send "Hello, World!" across a tunnel. The tunnel is:
 	//
@@ -382,27 +381,35 @@ func TestTunnelE2E(t *testing.T) {
 	machineAddr := net.JoinHostPort("localhost", "23655")
 	sourceListenerAddr := net.JoinHostPort("localhost", "23656")
 
-	logger := logging.NewTestLogger(t)
 	ctx := context.Background()
 	runServerCtx, runServerCtxCancel := context.WithCancel(ctx)
 	var wg sync.WaitGroup
+
+	logger.Info("BLINKY: Starting main test program")
 
 	// Start "destination" listener.
 	destListener, err := net.Listen("tcp", destListenerAddr)
 	test.That(t, err, test.ShouldBeNil)
 	defer func() {
+		logger.Info("BLINKY: Closing destination listener")
 		test.That(t, destListener.Close(), test.ShouldBeNil)
+		logger.Info("BLINKY: Done closing destination listener")
 	}()
+	logger.Info("BLINKY: Now listening at destination listener")
 
 	wg.Add(1)
 	go func() {
+		logger.Info("BLINKY: Starting destination listener goroutine")
+
 		defer wg.Done()
 
 		logger.Infof("Listening on %s for tunnel message", destListenerAddr)
 		conn, err := destListener.Accept()
 		test.That(t, err, test.ShouldBeNil)
 		defer func() {
+			logger.Info("BLINKY: Closing destination conn")
 			test.That(t, conn.Close(), test.ShouldBeNil)
+			logger.Info("BLINKY: Done closing destination conn")
 		}()
 
 		bytes := make([]byte, 1024)
@@ -420,11 +427,15 @@ func TestTunnelE2E(t *testing.T) {
 		// Cancel `runServerCtx` once message has made it all the way across and has been
 		// echoed back. This should stop the `RunServer` goroutine below.
 		runServerCtxCancel()
+
+		logger.Info("BLINKY: Ending destination listener goroutine")
 	}()
 
 	// Start a machine at `machineAddr` (`RunServer` in a goroutine.)
 	wg.Add(1)
 	go func() {
+		logger.Info("BLINKY: Starting machine goroutine")
+
 		defer wg.Done()
 
 		// Create a temporary config file.
@@ -452,6 +463,8 @@ func TestTunnelE2E(t *testing.T) {
 
 		args := []string{"viam-server", "-config", tempConfigFile.Name()}
 		test.That(t, server.RunServer(runServerCtx, args, logger), test.ShouldBeNil)
+
+		logger.Info("BLINKY: Ending machine goroutine")
 	}()
 
 	// Open a robot client to `machineAddr`.
@@ -484,10 +497,14 @@ func TestTunnelE2E(t *testing.T) {
 	sourceListener, err := net.Listen("tcp", sourceListenerAddr)
 	test.That(t, err, test.ShouldBeNil)
 	defer func() {
+		logger.Info("BLINKY: Closing source listener")
 		test.That(t, sourceListener.Close(), test.ShouldBeNil)
+		logger.Info("BLINKY: Done closing source listener")
 	}()
 	wg.Add(1)
 	go func() {
+		logger.Info("BLINKY: Starting source listener goroutine")
+
 		defer wg.Done()
 
 		logger.Infof("Connections opened at %s will be tunneled", sourceListenerAddr)
@@ -496,6 +513,8 @@ func TestTunnelE2E(t *testing.T) {
 
 		err = rc.Tunnel(ctx, conn /* will be eventually closed by `Tunnel` */, destPort)
 		test.That(t, err, test.ShouldBeNil)
+
+		logger.Info("BLINKY: Ending source listener goroutine")
 	}()
 
 	// Write `tunnelMsg` to "source" listener over TCP from this test process.
@@ -516,4 +535,6 @@ func TestTunnelE2E(t *testing.T) {
 	test.That(t, string(bytes), test.ShouldContainSubstring, tunnelMsg)
 
 	wg.Wait()
+
+	logger.Info("BLINKY: Ending main test program")
 }

--- a/web/server/entrypoint_test.go
+++ b/web/server/entrypoint_test.go
@@ -424,10 +424,6 @@ func TestTunnelE2E(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, n, test.ShouldEqual, len(tunnelMsg))
 
-		// Cancel `runServerCtx` once message has made it all the way across and has been
-		// echoed back. This should stop the `RunServer` goroutine below.
-		runServerCtxCancel()
-
 		logger.Info("BLINKY: Ending destination listener goroutine")
 	}()
 
@@ -533,6 +529,10 @@ func TestTunnelE2E(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, n, test.ShouldEqual, len(tunnelMsg))
 	test.That(t, string(bytes), test.ShouldContainSubstring, tunnelMsg)
+
+	// Cancel `runServerCtx` once message has made it all the way across and has been
+	// echoed back. This should stop the `RunServer` goroutine.
+	runServerCtxCancel()
 
 	wg.Wait()
 


### PR DESCRIPTION
RSDK-10246

- Unskips `TestTunnelE2E` and `TestTunnelE2ECLI`
- "Fixes" ordering for those tests (cancels context at "correct" time)
- Swallows more errors in `filterError` for tunneling code

Tests passed ~200 times on blinky with this change where they used to fail about 1 every 20 times.

cc @dgottlieb 