### PR TITLE
in no_cgo mode, flag on image_file camera and vision services

### DIFF
--- a/components/camera/fake/image_file.go
+++ b/components/camera/fake/image_file.go
@@ -1,5 +1,3 @@
-//go:build !no_cgo
-
 package fake
 
 import (

--- a/components/camera/register/register_cgo_android.go
+++ b/components/camera/register/register_cgo_android.go
@@ -5,6 +5,5 @@ package register
 
 import (
 	// for cameras.
-	_ "go.viam.com/rdk/components/camera/fake"
 	_ "go.viam.com/rdk/components/camera/transformpipeline"
 )

--- a/components/camera/register/register_cgo_android.go
+++ b/components/camera/register/register_cgo_android.go
@@ -1,7 +1,10 @@
+//go:build !no_cgo || android
+
 // Package register registers all relevant cameras and also API specific functions
 package register
 
 import (
 	// for cameras.
 	_ "go.viam.com/rdk/components/camera/fake"
+	_ "go.viam.com/rdk/components/camera/transformpipeline"
 )

--- a/services/register/all.go
+++ b/services/register/all.go
@@ -9,4 +9,5 @@ import (
 	_ "go.viam.com/rdk/services/generic/register"
 	_ "go.viam.com/rdk/services/shell/register"
 	_ "go.viam.com/rdk/services/slam/register"
+	_ "go.viam.com/rdk/services/vision/register"
 )

--- a/services/register/all_cgo_droid.go
+++ b/services/register/all_cgo_droid.go
@@ -5,5 +5,4 @@ package register
 import (
 	// register services.
 	_ "go.viam.com/rdk/services/mlmodel/register"
-	_ "go.viam.com/rdk/services/vision/register"
 )


### PR DESCRIPTION
## What changed
- add back some components and services in no_cgo mode
## Why
Needed on a no_cgo platform (and C dependency cleanup work has made this easy).
## Pre-merge todo
- [x] test on win machine