### PR TITLE
RSDK-10319 fix collision spec for origin frames.

### DIFF
--- a/motionplan/planManager.go
+++ b/motionplan/planManager.go
@@ -519,7 +519,17 @@ func (pm *planManager) plannerSetupFromMoveRequest(
 		return nil, err
 	}
 
-	allowedCollisions, err := collisionSpecifications(constraints.GetCollisionSpecification(), frameSystemGeometries, worldState)
+	frameNames := map[string]bool{}
+	for _, fName := range pm.fs.FrameNames() {
+		frameNames[fName] = true
+	}
+
+	allowedCollisions, err := collisionSpecifications(
+		constraints.GetCollisionSpecification(),
+		frameSystemGeometries,
+		frameNames,
+		worldState.ObstacleNames(),
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Include origin frame geoms in collision spec in case where specified frame is a Transform rather than an RDK component.