### PR TITLE
Update CloudPackageManager to cleanup in Windows

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1193,7 +1193,9 @@ func (p *PackageConfig) LocalDataParentDirectory(packagesDir string) string {
 
 // SanitizedName returns the package name for the symlink/filepath of the package on the system.
 func (p *PackageConfig) SanitizedName() string {
-	return fmt.Sprintf("%s-%s", strings.ReplaceAll(p.Package, string(os.PathSeparator), "-"), p.sanitizedVersion())
+	// p.Package is set by the PackageServiceClient as "{org_id}/{package_name}"
+	// see https://github.com/viamrobotics/app/blob/main/packages/packages.go#L1257
+	return fmt.Sprintf("%s-%s", strings.ReplaceAll(p.Package, "/", "-"), p.sanitizedVersion())
 }
 
 // sanitizedVersion returns a cleaned version of the version so it is file-system-safe.

--- a/config/config.go
+++ b/config/config.go
@@ -1194,7 +1194,7 @@ func (p *PackageConfig) LocalDataParentDirectory(packagesDir string) string {
 // SanitizedName returns the package name for the symlink/filepath of the package on the system.
 func (p *PackageConfig) SanitizedName() string {
 	// p.Package is set by the PackageServiceClient as "{org_id}/{package_name}"
-	// see https://github.com/viamrobotics/app/blob/main/packages/packages.go#L1257
+	// see https://github.com/viamrobotics/app/blob/e0d693d80ae6f308e5b3a6bddb69991521127928/packages/packages.go#L1257
 	return fmt.Sprintf("%s-%s", strings.ReplaceAll(p.Package, "/", "-"), p.sanitizedVersion())
 }
 

--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -12,7 +12,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -239,9 +238,6 @@ func (m *cloudManager) validateAndGetChangedPackages(
 
 // Cleanup removes all unknown packages from the working directory.
 func (m *cloudManager) Cleanup(ctx context.Context) error {
-	if runtime.GOOS == "windows" { //nolint:goconst
-		return nil
-	}
 	// Only allow one rdk process to operate on the manager at once. This is generally safe to keep locked for an extended period of time
 	// since the config reconfiguration process is handled by a single thread.
 	m.mu.Lock()


### PR DESCRIPTION
* Update PackageConfig.SanitizedName() to use strings.ReplaceAll(p.Package, "/", "-") as PackageConfig.Package is always set as "{org_id}/{package_name}", this had the unintended consequence of causing packages modules to be installed in a different directory structure than in Unix which caused CloudPackageManager to fail to cleanup packages in Windows.

https://viam.atlassian.net/browse/APP-7918