### PR TITLE
APP-7464 support unix sockets on windows OS

### DIFF
--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -862,7 +862,10 @@ func readModels(path string, logger logging.Logger) ([]ModuleComponent, error) {
 		ExePath: path,
 	}
 
-	mgr := modmanager.NewManager(context.Background(), parentAddr, logger, modmanageroptions.Options{UntrustedEnv: false})
+	mgr, err := modmanager.NewManager(context.Background(), parentAddr, logger, modmanageroptions.Options{UntrustedEnv: false})
+	if err != nil {
+		return nil, err
+	}
 	defer vutils.UncheckedErrorFunc(func() error { return mgr.Close(context.Background()) })
 
 	err = mgr.Add(context.TODO(), cfg)

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -1074,11 +1074,7 @@ func (m *module) dial() error {
 	var err error
 	addrToDial := m.addr
 	if !rutils.TCPRegex.MatchString(addrToDial) {
-		cleanAddr, err := cleanWindowsSocketPath(runtime.GOOS, addrToDial)
-		if err != nil {
-			return err
-		}
-		addrToDial = "unix://" + cleanAddr
+		addrToDial = "unix://" + addrToDial
 	}
 	conn, err := grpc.Dial( //nolint:staticcheck
 		addrToDial,

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -62,11 +62,11 @@ var (
 func NewManager(
 	ctx context.Context, parentAddr string, logger logging.Logger, options modmanageroptions.Options,
 ) (modmaninterface.ModuleManager, error) {
-	restartCtx, restartCtxCancel := context.WithCancel(ctx)
 	parentAddr, err := cleanWindowsSocketPath(runtime.GOOS, parentAddr)
 	if err != nil {
 		return nil, err
 	}
+	restartCtx, restartCtxCancel := context.WithCancel(ctx)
 	ret := &Manager{
 		logger:                  logger.Sublogger("modmanager"),
 		modules:                 moduleMap{},

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strconv"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -409,7 +410,7 @@ func TestModManagerKill(t *testing.T) {
 	mMgr, ok := mgr.(*Manager)
 	test.That(t, ok, test.ShouldBeTrue)
 
-	_, ok = mMgr.modules.Load(modCfg.Name)
+	mod, ok := mMgr.modules.Load(modCfg.Name)
 	test.That(t, ok, test.ShouldBeTrue)
 
 	mgr.Kill()
@@ -423,11 +424,11 @@ func TestModManagerKill(t *testing.T) {
 	// the manage goroutine actually returns.
 	// We do not care about the error if it is expected.
 	// maybe related to https://github.com/golang/go/issues/18874
-	// pid, err := mod.process.UnixPid()
-	// test.That(t, err, test.ShouldBeNil)
-	// if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
-	// 	test.That(t, errors.Is(err, os.ErrProcessDone), test.ShouldBeFalse)
-	// }
+	pid, err := mod.process.UnixPid()
+	test.That(t, err, test.ShouldBeNil)
+	if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
+		test.That(t, errors.Is(err, os.ErrProcessDone), test.ShouldBeFalse)
+	}
 }
 
 func TestModManagerValidation(t *testing.T) {

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -1707,7 +1707,7 @@ func TestCleanWindowsSocketPath(t *testing.T) {
 	test.That(t, clean, test.ShouldResemble, "/x/y.sock")
 
 	// wrong disk
-	clean, err = cleanWindowsSocketPath("windows", "d:\\x\\y.sock")
+	_, err = cleanWindowsSocketPath("windows", "d:\\x\\y.sock")
 	test.That(t, err, test.ShouldNotBeNil)
 
 	// no disk

--- a/module/server.go
+++ b/module/server.go
@@ -54,7 +54,6 @@ func (s *Server) Serve(listener net.Listener) error {
 	s.mu.Lock()
 	s.addr = listener.Addr()
 	s.mu.Unlock()
-	println("Server.Serve ADDR", s.addr.String())
 	return s.server.Serve(listener)
 }
 

--- a/module/server.go
+++ b/module/server.go
@@ -54,6 +54,7 @@ func (s *Server) Serve(listener net.Listener) error {
 	s.mu.Lock()
 	s.addr = listener.Addr()
 	s.mu.Unlock()
+	println("Server.Serve ADDR", s.addr.String())
 	return s.server.Serve(listener)
 }
 

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -505,7 +505,7 @@ func newWithResources(
 		homeDir = rOpts.viamHomeDir
 	}
 	// Once web service is started, start module manager
-	r.manager.startModuleManager(
+	if err := r.manager.startModuleManager(
 		closeCtx,
 		r.webSvc.ModuleAddress(),
 		r.removeOrphanedResources,
@@ -515,7 +515,9 @@ func newWithResources(
 		logger,
 		cfg.PackagePath,
 		r.webSvc.ModPeerConnTracker(),
-	)
+	); err != nil {
+		return nil, err
+	}
 
 	if !rOpts.disableCompleteConfigWorker {
 		r.activeBackgroundWorkers.Add(1)

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -124,7 +124,7 @@ func (manager *resourceManager) startModuleManager(
 	logger logging.Logger,
 	packagesDir string,
 	modPeerConnTracker *grpc.ModPeerConnTracker,
-) {
+) error {
 	mmOpts := modmanageroptions.Options{
 		UntrustedEnv:            untrustedEnv,
 		RemoveOrphanedResources: removeOrphanedResources,
@@ -134,10 +134,14 @@ func (manager *resourceManager) startModuleManager(
 		FTDC:                    manager.opts.ftdc,
 		ModPeerConnTracker:      modPeerConnTracker,
 	}
-	modmanager := modmanager.NewManager(ctx, parentAddr, logger, mmOpts)
+	modmanager, err := modmanager.NewManager(ctx, parentAddr, logger, mmOpts)
+	if err != nil {
+		return err
+	}
 	manager.modManagerLock.Lock()
 	manager.moduleManager = modmanager
 	manager.modManagerLock.Unlock()
+	return nil
 }
 
 // addRemote adds a remote to the manager.

--- a/utils/env.go
+++ b/utils/env.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"slices"
 	"strings"
 	"time"
 
@@ -122,8 +121,9 @@ func ViamTCPSockets() bool {
 	// note: unix sockets have been supported on windows for a while, but go-grpc does not support them.
 	// 2017 support announcement: https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/
 	// go grpc client bug on win: https://github.com/dotnet/aspnetcore/issues/47043
-	return runtime.GOOS == "windows" ||
-		slices.Contains(EnvTrueValues, os.Getenv("VIAM_TCP_SOCKETS"))
+	return false
+	// return runtime.GOOS == "windows" ||
+	// 	slices.Contains(EnvTrueValues, os.Getenv("VIAM_TCP_SOCKETS"))
 }
 
 // LogViamEnvVariables logs the list of viam environment variables in [os.Environ] along with the env passed in.

--- a/utils/env.go
+++ b/utils/env.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 
@@ -121,9 +122,7 @@ func ViamTCPSockets() bool {
 	// note: unix sockets have been supported on windows for a while, but go-grpc does not support them.
 	// 2017 support announcement: https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/
 	// go grpc client bug on win: https://github.com/dotnet/aspnetcore/issues/47043
-	return false
-	// return runtime.GOOS == "windows" ||
-	// 	slices.Contains(EnvTrueValues, os.Getenv("VIAM_TCP_SOCKETS"))
+	return slices.Contains(EnvTrueValues, os.Getenv("VIAM_TCP_SOCKETS"))
 }
 
 // LogViamEnvVariables logs the list of viam environment variables in [os.Environ] along with the env passed in.


### PR DESCRIPTION
## What changed
- add cleanWindowsUDS function to clean unix socket paths on windows hosts, so they're compatible w/ the grpc library
- still respect VIAM_TCP_SOCKETS env var, but don't force-activate it on goos=windows
## Why
The `url.Parse` call in the (3rd-party) grpc library, [here](https://github.com/grpc/grpc-go/blob/v1.71.0/clientconn.go#L1720-L1727), as well as its direct caller, become unhappy in various ways when given windows-looking filesystem paths. This PR works around that by formatting the paths in a way it likes.

To see this fail in the small, do:

```golang
urls := []string{
	"unix://C:\\hello\\whatever.sock",
	"unix://\\hello\\whatever.sock",
	"unix://C:/hello/whatever.sock",
	"unix:///hello/whatever.sock",
}
for i, raw := range urls {
	if u, err := url.Parse(raw); err != nil {
		println("err", i, err.Error())
	} else {
		println("result", i, u.String())
	}
}
```

(The first two fail, the last two succeed).

I'm stripping the `C:` prefix as well because I get some kind of 'invalid authority' error from grpc when I pass that.
## Notes
### Future work
The `VIAM_TCP_SOCKETS` flag is still respected when present. I think we should remove this feature completely.
### Compatibility with existing windows modules
This seems to work with the windows modules that are currently on the registry and which we've tested in TCP mode. Will test with a few more modules before merging.
## Pre-merge
- [x] clearer comment with some background
- [x] safer prefix trimming