### PR TITLE
[RSDK-10350] - Add a `default-camera` attribute to vizModel

### DIFF
--- a/services/vision/colordetector/color_detector.go
+++ b/services/vision/colordetector/color_detector.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 
+	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot"
@@ -51,6 +52,12 @@ func registerColorDetector(
 	detector, err := objdet.NewColorDetector(conf)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error registering color detector %q", name)
+	}
+	if conf.DefaultCamera != "" {
+		_, err = camera.FromRobot(r, conf.DefaultCamera)
+		if err != nil {
+			return nil, errors.Errorf("could not find camera %q", conf.DefaultCamera)
+		}
 	}
 	return vision.NewService(name, r, nil, nil, detector, nil, conf.DefaultCamera)
 }

--- a/services/vision/colordetector/color_detector.go
+++ b/services/vision/colordetector/color_detector.go
@@ -52,5 +52,5 @@ func registerColorDetector(
 	if err != nil {
 		return nil, errors.Wrapf(err, "error registering color detector %q", name)
 	}
-	return vision.NewService(name, r, nil, nil, detector, nil)
+	return vision.NewService(name, r, nil, nil, detector, nil, conf.DefaultCamera)
 }

--- a/services/vision/detectionstosegments/detections_to_3dsegments.go
+++ b/services/vision/detectionstosegments/detections_to_3dsegments.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 
+	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot"
@@ -64,6 +65,12 @@ func register3DSegmenterFromDetector(
 	segmenter, err := segmentation.DetectionSegmenter(objectdetection.Detector(detector), conf.MeanK, conf.Sigma, confThresh)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot create 3D segmenter from detector")
+	}
+	if conf.DefaultCamera != "" {
+		_, err = camera.FromRobot(r, conf.DefaultCamera)
+		if err != nil {
+			return nil, errors.Errorf("could not find camera %q", conf.DefaultCamera)
+		}
 	}
 	return vision.NewService(name, r, nil, nil, detector, segmenter, conf.DefaultCamera)
 }

--- a/services/vision/detectionstosegments/detections_to_3dsegments.go
+++ b/services/vision/detectionstosegments/detections_to_3dsegments.go
@@ -65,5 +65,5 @@ func register3DSegmenterFromDetector(
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot create 3D segmenter from detector")
 	}
-	return vision.NewService(name, r, nil, nil, detector, segmenter)
+	return vision.NewService(name, r, nil, nil, detector, segmenter, conf.DefaultCamera)
 }

--- a/services/vision/detectionstosegments/detections_to_3dsegments_test.go
+++ b/services/vision/detectionstosegments/detections_to_3dsegments_test.go
@@ -31,7 +31,7 @@ func Test3DSegmentsFromDetector(t *testing.T) {
 	r := &inject.Robot{}
 	m := &simpleDetector{}
 	name := vision.Named("testDetector")
-	svc, err := vision.NewService(name, r, nil, nil, m.Detect, nil)
+	svc, err := vision.NewService(name, r, nil, nil, m.Detect, nil, "")
 	test.That(t, err, test.ShouldBeNil)
 	cam := &inject.Camera{}
 	cam.NextPointCloudFunc = func(ctx context.Context) (pc.PointCloud, error) {

--- a/services/vision/detectionstosegments/detections_to_3dsegments_test.go
+++ b/services/vision/detectionstosegments/detections_to_3dsegments_test.go
@@ -76,6 +76,16 @@ func Test3DSegmentsFromDetector(t *testing.T) {
 	seg, err := register3DSegmenterFromDetector(context.Background(), name3, params, r)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, seg.Name(), test.ShouldResemble, name3)
+	// successful registration, valid default camera
+	params.DefaultCamera = "fakeCamera"
+	seg, err = register3DSegmenterFromDetector(context.Background(), name3, params, r)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, seg.Name(), test.ShouldResemble, name3)
+	// bad registration, invalid default camera
+	params.DefaultCamera = "not-camera"
+	_, err = register3DSegmenterFromDetector(context.Background(), name3, params, r)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "could not find camera \"not-camera\"")
 
 	// fails on not finding camera
 	_, err = seg.GetObjectPointClouds(context.Background(), "no_camera", map[string]interface{}{})

--- a/services/vision/fake/vision.go
+++ b/services/vision/fake/vision.go
@@ -70,5 +70,5 @@ func registerFake(
 	name resource.Name,
 	r robot.Robot,
 ) (vision.Service, error) {
-	return vision.NewService(name, r, nil, fakeClassifier, fakeDetector, nil)
+	return vision.NewService(name, r, nil, fakeClassifier, fakeDetector, nil, "")
 }

--- a/services/vision/mlvision/ml_model.go
+++ b/services/vision/mlvision/ml_model.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 
+	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot"
@@ -67,7 +68,7 @@ type MLModelConfig struct {
 	DefaultConfidence  float64            `json:"default_minimum_confidence"`
 	LabelConfidenceMap map[string]float64 `json:"label_confidences"`
 	LabelPath          string             `json:"label_path"`
-	DefaultCamera      string             `json:"default_camera"`
+	DefaultCamera      string             `json:"camera_name"`
 }
 
 // Validate will add the ModelName as an implicit dependency to the robot.
@@ -209,6 +210,13 @@ func registerMLModelVisionService(
 				"inputs", inputs,
 				"outputs", outputs,
 			)
+		}
+	}
+
+	if params.DefaultCamera != "" {
+		_, err = camera.FromRobot(r, params.DefaultCamera)
+		if err != nil {
+			return nil, errors.Errorf("could not find camera %q", params.DefaultCamera)
 		}
 	}
 

--- a/services/vision/mlvision/ml_model.go
+++ b/services/vision/mlvision/ml_model.go
@@ -67,6 +67,7 @@ type MLModelConfig struct {
 	DefaultConfidence  float64            `json:"default_minimum_confidence"`
 	LabelConfidenceMap map[string]float64 `json:"label_confidences"`
 	LabelPath          string             `json:"label_path"`
+	DefaultCamera      string             `json:"default_camera"`
 }
 
 // Validate will add the ModelName as an implicit dependency to the robot.
@@ -212,7 +213,7 @@ func registerMLModelVisionService(
 	}
 
 	// Don't return a close function, because you don't want to close the underlying ML service
-	return vision.NewService(name, r, nil, classifierFunc, detectorFunc, segmenter3DFunc)
+	return vision.NewService(name, r, nil, classifierFunc, detectorFunc, segmenter3DFunc, params.DefaultCamera)
 }
 
 func getLabelsFromFile(labelPath string) []string {

--- a/services/vision/mlvision/ml_model_test.go
+++ b/services/vision/mlvision/ml_model_test.go
@@ -8,7 +8,9 @@ import (
 	"go.viam.com/test"
 	"go.viam.com/utils/artifact"
 
+	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/rimage"
 	"go.viam.com/rdk/testutils/inject"
 	"go.viam.com/rdk/vision/classification"
@@ -515,6 +517,40 @@ func TestMultipleClassifiersOneModel(t *testing.T) {
 	}()
 
 	wg.Wait()
+}
+
+func TestRegistrationWithDefaultCamera(t *testing.T) {
+	ctx := context.Background()
+	out := mockEffDetModel("myMLModel", "")
+	modelName := out.Name()
+	cameraName := camera.Named("test")
+	modelCfg := MLModelConfig{ModelName: modelName.Name}
+
+	r := &inject.Robot{}
+	r.ResourceByNameFunc = func(name resource.Name) (resource.Resource, error) {
+		switch name {
+		case modelName:
+			return out, nil
+		case cameraName:
+			return inject.NewCamera(cameraName.Name), nil
+		default:
+			return nil, resource.NewNotFoundError(name)
+		}
+	}
+
+	service, err := registerMLModelVisionService(ctx, modelName, &modelCfg, r, logging.NewLogger("benchmark"))
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, service, test.ShouldNotBeNil)
+
+	modelCfg.DefaultCamera = cameraName.Name
+	service, err = registerMLModelVisionService(ctx, modelName, &modelCfg, r, logging.NewLogger("benchmark"))
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, service, test.ShouldNotBeNil)
+
+	modelCfg.DefaultCamera = "not-camera"
+	_, err = registerMLModelVisionService(ctx, modelName, &modelCfg, r, logging.NewLogger("benchmark"))
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "could not find camera \"not-camera\"")
 }
 
 func classifyTwoImages(picPanda, picLion *rimage.Image,

--- a/services/vision/mlvision/ml_model_test.go
+++ b/services/vision/mlvision/ml_model_test.go
@@ -551,6 +551,15 @@ func TestRegistrationWithDefaultCamera(t *testing.T) {
 	_, err = registerMLModelVisionService(ctx, modelName, &modelCfg, r, logging.NewLogger("benchmark"))
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "could not find camera \"not-camera\"")
+
+	// Test that *FromCamera errors when camera is not found
+	modelCfg.DefaultCamera = ""
+	service, err = registerMLModelVisionService(ctx, modelName, &modelCfg, r, logging.NewLogger("benchmark"))
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, service, test.ShouldNotBeNil)
+	_, err = service.DetectionsFromCamera(ctx, "", nil)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "no camera name provided and no default camera found")
 }
 
 func classifyTwoImages(picPanda, picLion *rimage.Image,

--- a/services/vision/obstaclesdepth/obstacles_depth.go
+++ b/services/vision/obstaclesdepth/obstacles_depth.go
@@ -55,7 +55,7 @@ type ObsDepthConfig struct {
 	ClusteringRadius     int     `json:"clustering_radius"`
 	ClusteringStrictness float64 `json:"clustering_strictness"`
 	AngleTolerance       float64 `json:"ground_angle_tolerance_degs"`
-	DefaultCamera        string  `json:"default_camera"`
+	DefaultCamera        string  `json:"camera_name"`
 }
 
 // obsDepth is the underlying struct actually used by the service.
@@ -92,6 +92,12 @@ func registerObstaclesDepth(
 	}
 	myObsDep := &obsDepth{
 		clusteringConf: cfg,
+	}
+	if conf.DefaultCamera != "" {
+		_, err = camera.FromRobot(r, conf.DefaultCamera)
+		if err != nil {
+			return nil, errors.Errorf("could not find camera %q", conf.DefaultCamera)
+		}
 	}
 
 	segmenter := myObsDep.buildObsDepth(logger) // does the thing

--- a/services/vision/obstaclesdepth/obstacles_depth.go
+++ b/services/vision/obstaclesdepth/obstacles_depth.go
@@ -55,6 +55,7 @@ type ObsDepthConfig struct {
 	ClusteringRadius     int     `json:"clustering_radius"`
 	ClusteringStrictness float64 `json:"clustering_strictness"`
 	AngleTolerance       float64 `json:"ground_angle_tolerance_degs"`
+	DefaultCamera        string  `json:"default_camera"`
 }
 
 // obsDepth is the underlying struct actually used by the service.
@@ -94,7 +95,7 @@ func registerObstaclesDepth(
 	}
 
 	segmenter := myObsDep.buildObsDepth(logger) // does the thing
-	return svision.NewService(name, r, nil, nil, nil, segmenter)
+	return svision.NewService(name, r, nil, nil, nil, segmenter, conf.DefaultCamera)
 }
 
 // BuildObsDepth will check for intrinsics and determine how to build based on that.

--- a/services/vision/obstaclesdepth/obstacles_depth_test.go
+++ b/services/vision/obstaclesdepth/obstacles_depth_test.go
@@ -175,6 +175,26 @@ func TestObstacleDepth(t *testing.T) {
 		test.That(t, capt.Classifications, test.ShouldBeNil)
 		test.That(t, capt.Detections, test.ShouldBeNil)
 	})
+
+	t.Run("registration with default camera", func(t *testing.T) {
+		// no default camera
+		withIntrinsicsCfg.DefaultCamera = ""
+		srv2, err := registerObstaclesDepth(ctx, name, &withIntrinsicsCfg, r, testLogger)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, srv2, test.ShouldNotBeNil)
+
+		// default camera with valid name
+		withIntrinsicsCfg.DefaultCamera = "testCam"
+		srv2, err = registerObstaclesDepth(ctx, name, &withIntrinsicsCfg, r, testLogger)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, srv2, test.ShouldNotBeNil)
+
+		// default camera with invalid name
+		withIntrinsicsCfg.DefaultCamera = "not-camera"
+		_, err = registerObstaclesDepth(ctx, name, &withIntrinsicsCfg, r, testLogger)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "could not find camera \"not-camera\"")
+	})
 }
 
 func BenchmarkObstacleDepthIntrinsics(b *testing.B) {

--- a/services/vision/obstaclesdistance/obstacles_distance.go
+++ b/services/vision/obstaclesdistance/obstacles_distance.go
@@ -31,7 +31,7 @@ const DefaultNumQueries = 10
 // for the obstacle distance detection service.
 type DistanceDetectorConfig struct {
 	NumQueries    int    `json:"num_queries"`
-	DefaultCamera string `json:"default_camera"`
+	DefaultCamera string `json:"camera_name"`
 }
 
 func init() {
@@ -113,6 +113,12 @@ func registerObstacleDistanceDetector(
 		toReturn[0] = &vision.Object{PointCloud: pcToReturn, Geometry: pt}
 
 		return toReturn, nil
+	}
+	if conf.DefaultCamera != "" {
+		_, err := camera.FromRobot(r, conf.DefaultCamera)
+		if err != nil {
+			return nil, errors.Errorf("could not find camera %q", conf.DefaultCamera)
+		}
 	}
 	return svision.NewService(name, r, nil, nil, nil, segmenter, conf.DefaultCamera)
 }

--- a/services/vision/obstaclesdistance/obstacles_distance.go
+++ b/services/vision/obstaclesdistance/obstacles_distance.go
@@ -30,7 +30,8 @@ const DefaultNumQueries = 10
 // DistanceDetectorConfig specifies the parameters for the camera to be used
 // for the obstacle distance detection service.
 type DistanceDetectorConfig struct {
-	NumQueries int `json:"num_queries"`
+	NumQueries    int    `json:"num_queries"`
+	DefaultCamera string `json:"default_camera"`
 }
 
 func init() {
@@ -113,7 +114,7 @@ func registerObstacleDistanceDetector(
 
 		return toReturn, nil
 	}
-	return svision.NewService(name, r, nil, nil, nil, segmenter)
+	return svision.NewService(name, r, nil, nil, nil, segmenter, conf.DefaultCamera)
 }
 
 func medianFromPointClouds(ctx context.Context, clouds []pointcloud.PointCloud) (r3.Vector, error) {

--- a/services/vision/obstaclespointcloud/obstacles_pointcloud.go
+++ b/services/vision/obstaclespointcloud/obstacles_pointcloud.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 
+	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot"
@@ -53,5 +54,11 @@ func registerOPSegmenter(
 		return nil, errors.Wrap(err, "obstacles pointcloud segmenter config error")
 	}
 	segmenter := segmentation.Segmenter(conf.ErCCLAlgorithm)
+	if conf.DefaultCamera != "" {
+		_, err := camera.FromRobot(r, conf.DefaultCamera)
+		if err != nil {
+			return nil, errors.Errorf("could not find camera %q", conf.DefaultCamera)
+		}
+	}
 	return vision.NewService(name, r, nil, nil, nil, segmenter, conf.DefaultCamera)
 }

--- a/services/vision/obstaclespointcloud/obstacles_pointcloud.go
+++ b/services/vision/obstaclespointcloud/obstacles_pointcloud.go
@@ -53,5 +53,5 @@ func registerOPSegmenter(
 		return nil, errors.Wrap(err, "obstacles pointcloud segmenter config error")
 	}
 	segmenter := segmentation.Segmenter(conf.ErCCLAlgorithm)
-	return vision.NewService(name, r, nil, nil, nil, segmenter)
+	return vision.NewService(name, r, nil, nil, nil, segmenter, conf.DefaultCamera)
 }

--- a/services/vision/obstaclespointcloud/obstacles_pointcloud_test.go
+++ b/services/vision/obstaclespointcloud/obstacles_pointcloud_test.go
@@ -58,6 +58,16 @@ func TestRadiusClusteringSegmentation(t *testing.T) {
 	seg, err := registerOPSegmenter(context.Background(), name, params, r)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, seg.Name(), test.ShouldResemble, name)
+	// successful registration, valid default camera
+	params.DefaultCamera = "fakeCamera"
+	seg, err = registerOPSegmenter(context.Background(), name, params, r)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, seg.Name(), test.ShouldResemble, name)
+	// successful registration, invalid default camera
+	params.DefaultCamera = "not-camera"
+	_, err = registerOPSegmenter(context.Background(), name, params, r)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "could not find camera \"not-camera\"")
 
 	// Test properties. Should support object PCDs and not detections or classifications
 	props, err := seg.GetProperties(context.Background(), nil)

--- a/services/vision/vision.go
+++ b/services/vision/vision.go
@@ -316,6 +316,11 @@ func (vm *vizModel) DetectionsFromCamera(
 ) ([]objectdetection.Detection, error) {
 	ctx, span := trace.StartSpan(ctx, "service::vision::DetectionsFromCamera::"+vm.Named.Name().String())
 	defer span.End()
+	if cameraName == "" && vm.defaultCamera == "" {
+		return nil, errors.New("no camera name provided and no default camera found")
+	} else if cameraName == "" {
+		cameraName = vm.defaultCamera
+	}
 	if vm.detectorFunc == nil {
 		return nil, errors.Errorf("vision model %q does not implement a Detector", vm.Named.Name())
 	}
@@ -358,6 +363,11 @@ func (vm *vizModel) ClassificationsFromCamera(
 ) (classification.Classifications, error) {
 	ctx, span := trace.StartSpan(ctx, "service::vision::ClassificationsFromCamera::"+vm.Named.Name().String())
 	defer span.End()
+	if cameraName == "" && vm.defaultCamera == "" {
+		return nil, errors.New("no camera name provided and no default camera found")
+	} else if cameraName == "" {
+		cameraName = vm.defaultCamera
+	}
 	if vm.classifierFunc == nil {
 		return nil, errors.Errorf("vision model %q does not implement a Classifier", vm.Named.Name())
 	}
@@ -387,6 +397,11 @@ func (vm *vizModel) GetObjectPointClouds(
 	}
 	ctx, span := trace.StartSpan(ctx, "service::vision::GetObjectPointClouds::"+vm.Named.Name().String())
 	defer span.End()
+	if cameraName == "" && vm.defaultCamera == "" {
+		return nil, errors.New("no camera name provided and no default camera found")
+	} else if cameraName == "" {
+		cameraName = vm.defaultCamera
+	}
 	cam, err := camera.FromRobot(vm.r, cameraName)
 	if err != nil {
 		return nil, err
@@ -410,6 +425,11 @@ func (vm *vizModel) CaptureAllFromCamera(
 ) (viscapture.VisCapture, error) {
 	ctx, span := trace.StartSpan(ctx, "service::vision::ClassificationsFromCamera::"+vm.Named.Name().String())
 	defer span.End()
+	if cameraName == "" && vm.defaultCamera == "" {
+		return viscapture.VisCapture{}, errors.New("no camera name provided and no default camera found")
+	} else if cameraName == "" {
+		cameraName = vm.defaultCamera
+	}
 	cam, err := camera.FromRobot(vm.r, cameraName)
 	if err != nil {
 		return viscapture.VisCapture{}, errors.Wrapf(err, "could not find camera named %s", cameraName)

--- a/services/vision/vision.go
+++ b/services/vision/vision.go
@@ -245,6 +245,7 @@ type vizModel struct {
 	classifierFunc  classification.Classifier
 	detectorFunc    objectdetection.Detector
 	segmenter3DFunc segmentation.Segmenter
+	defaultCamera   string
 }
 
 // Properties returns various information regarding the current vision service,
@@ -263,6 +264,7 @@ func NewService(
 	cf classification.Classifier,
 	df objectdetection.Detector,
 	s3f segmentation.Segmenter,
+	defaultCamera string,
 ) (Service, error) {
 	if cf == nil && df == nil && s3f == nil {
 		return nil, errors.Errorf(
@@ -288,6 +290,7 @@ func NewService(
 		classifierFunc:  cf,
 		detectorFunc:    df,
 		segmenter3DFunc: s3f,
+		defaultCamera:   defaultCamera,
 	}, nil
 }
 

--- a/services/vision/vision_test.go
+++ b/services/vision/vision_test.go
@@ -2,15 +2,23 @@ package vision_test
 
 import (
 	"context"
+	"errors"
 	"image"
 	"testing"
 
 	"go.viam.com/test"
 
+	"go.viam.com/rdk/components/camera"
+	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/rimage"
 	"go.viam.com/rdk/services/vision"
 	"go.viam.com/rdk/testutils/inject"
+	"go.viam.com/rdk/utils"
+	visionObject "go.viam.com/rdk/vision"
+	"go.viam.com/rdk/vision/classification"
 	"go.viam.com/rdk/vision/objectdetection"
+	"go.viam.com/rdk/vision/viscapture"
 )
 
 const (
@@ -38,11 +46,24 @@ func TestFromRobot(t *testing.T) {
 	test.That(t, result[0].Score(), test.ShouldEqual, 0.5)
 }
 
-type simpleDetector struct{}
+type (
+	simpleDetector   struct{}
+	simpleClassifier struct{}
+	simpleSegmenter  struct{}
+)
 
 func (s *simpleDetector) Detect(context.Context, image.Image) ([]objectdetection.Detection, error) {
 	det1 := objectdetection.NewDetection(image.Rectangle{}, 0.5, "yes")
 	return []objectdetection.Detection{det1}, nil
+}
+
+func (s *simpleClassifier) Classify(context.Context, image.Image) (classification.Classifications, error) {
+	class1 := classification.NewClassification(0.5, "yes")
+	return classification.Classifications{class1}, nil
+}
+
+func (s *simpleSegmenter) Segment(ctx context.Context, src camera.Camera) ([]*visionObject.Object, error) {
+	return []*visionObject.Object{}, nil
 }
 
 func TestNewService(t *testing.T) {
@@ -57,4 +78,85 @@ func TestNewService(t *testing.T) {
 	test.That(t, result[0].Score(), test.ShouldEqual, 0.5)
 }
 
-// TODO: Add tests for *FromCamera methods with/without defaultCamera/camera name
+func TestDefaultCameraSettings(t *testing.T) {
+	var r inject.Robot
+	var c simpleClassifier
+	var d simpleDetector
+	var s simpleSegmenter
+
+	fakeCamera := &inject.Camera{
+		ImageFunc: func(ctx context.Context, mimeType string, extra map[string]interface{}) ([]byte, camera.ImageMetadata, error) {
+			sourceImg := image.NewRGBA(image.Rect(0, 0, 3, 3))
+			imgBytes, err := rimage.EncodeImage(ctx, sourceImg, utils.MimeTypePNG)
+			test.That(t, err, test.ShouldBeNil)
+			return imgBytes, camera.ImageMetadata{MimeType: utils.MimeTypePNG}, nil
+		},
+	}
+
+	r.ResourceByNameFunc = func(name resource.Name) (resource.Resource, error) {
+		return fakeCamera, nil
+	}
+	r.LoggerFunc = func() logging.Logger {
+		return logging.NewTestLogger(t)
+	}
+
+	svc, err := vision.NewService(vision.Named("testService"), &r, nil, c.Classify, d.Detect, s.Segment, testCameraName)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, svc, test.ShouldNotBeNil)
+
+	// test *FromCamera methods with default camera and no camera name
+	_, err = svc.DetectionsFromCamera(context.Background(), "", nil)
+	test.That(t, err, test.ShouldBeNil)
+	_, err = svc.ClassificationsFromCamera(context.Background(), "", 1, nil)
+	test.That(t, err, test.ShouldBeNil)
+	_, err = svc.GetObjectPointClouds(context.Background(), "", nil)
+	test.That(t, err, test.ShouldBeNil)
+	_, err = svc.CaptureAllFromCamera(context.Background(), "", viscapture.CaptureOptions{}, nil)
+	test.That(t, err, test.ShouldBeNil)
+
+	// test *FromCamera methods with no default camera or camera name (should throw error)
+	noCameraError := "no camera name provided and no default camera found"
+
+	svc, err = vision.NewService(vision.Named("testService"), &r, nil, c.Classify, d.Detect, s.Segment, "")
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, svc, test.ShouldNotBeNil)
+
+	_, err = svc.DetectionsFromCamera(context.Background(), "", nil)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldEqual, noCameraError)
+	_, err = svc.ClassificationsFromCamera(context.Background(), "", 1, nil)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldEqual, noCameraError)
+	_, err = svc.GetObjectPointClouds(context.Background(), "", nil)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldEqual, noCameraError)
+	_, err = svc.CaptureAllFromCamera(context.Background(), "", viscapture.CaptureOptions{}, nil)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldEqual, noCameraError)
+
+	// test *FromCamera methods with camera name and default camera (should choose camera name)
+	// remove default camera from test robot to ensure that only camera name is used
+	secondCameraName := "used-camera"
+	r.ResourceByNameFunc = func(name resource.Name) (resource.Resource, error) {
+		switch name {
+		case camera.Named(testCameraName):
+			return nil, errors.New("default camera is being used when camera name should instead")
+		case camera.Named(secondCameraName):
+			return fakeCamera, nil
+		default:
+			return nil, errors.New("camera not found")
+		}
+	}
+	svc, err = vision.NewService(vision.Named("testService"), &r, nil, c.Classify, d.Detect, s.Segment, testCameraName)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, svc, test.ShouldNotBeNil)
+
+	_, err = svc.DetectionsFromCamera(context.Background(), secondCameraName, nil)
+	test.That(t, err, test.ShouldBeNil)
+	_, err = svc.ClassificationsFromCamera(context.Background(), secondCameraName, 1, nil)
+	test.That(t, err, test.ShouldBeNil)
+	_, err = svc.GetObjectPointClouds(context.Background(), secondCameraName, nil)
+	test.That(t, err, test.ShouldBeNil)
+	_, err = svc.CaptureAllFromCamera(context.Background(), secondCameraName, viscapture.CaptureOptions{}, nil)
+	test.That(t, err, test.ShouldBeNil)
+}

--- a/services/vision/vision_test.go
+++ b/services/vision/vision_test.go
@@ -16,6 +16,7 @@ import (
 const (
 	testVisionServiceName  = "vision1"
 	testVisionServiceName2 = "vision2"
+	testCameraName         = "camera1"
 )
 
 func TestFromRobot(t *testing.T) {
@@ -47,7 +48,7 @@ func (s *simpleDetector) Detect(context.Context, image.Image) ([]objectdetection
 func TestNewService(t *testing.T) {
 	var r inject.Robot
 	var m simpleDetector
-	svc, err := vision.NewService(vision.Named("testService"), &r, nil, nil, m.Detect, nil)
+	svc, err := vision.NewService(vision.Named("testService"), &r, nil, nil, m.Detect, nil, "")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, svc, test.ShouldNotBeNil)
 	result, err := svc.Detections(context.Background(), nil, nil)
@@ -55,3 +56,5 @@ func TestNewService(t *testing.T) {
 	test.That(t, len(result), test.ShouldEqual, 1)
 	test.That(t, result[0].Score(), test.ShouldEqual, 0.5)
 }
+
+// TODO: Add tests for *FromCamera methods with/without defaultCamera/camera name

--- a/vision/objectdetection/color_detector.go
+++ b/vision/objectdetection/color_detector.go
@@ -18,7 +18,7 @@ type ColorDetectorConfig struct {
 	ValueCutoff       float64 `json:"value_cutoff_pct,omitempty"`
 	DetectColorString string  `json:"detect_color"` // hex string "#RRGGBB"
 	Label             string  `json:"label,omitempty"`
-	DefaultCamera     string  `json:"default_camera"`
+	DefaultCamera     string  `json:"camera_name"`
 }
 
 // NewColorDetector is a detector that identifies objects based on color.

--- a/vision/objectdetection/color_detector.go
+++ b/vision/objectdetection/color_detector.go
@@ -18,6 +18,7 @@ type ColorDetectorConfig struct {
 	ValueCutoff       float64 `json:"value_cutoff_pct,omitempty"`
 	DetectColorString string  `json:"detect_color"` // hex string "#RRGGBB"
 	Label             string  `json:"label,omitempty"`
+	DefaultCamera     string  `json:"default_camera"`
 }
 
 // NewColorDetector is a detector that identifies objects based on color.

--- a/vision/segmentation/detections_to_objects.go
+++ b/vision/segmentation/detections_to_objects.go
@@ -24,7 +24,7 @@ type DetectionSegmenterConfig struct {
 	ConfidenceThresh float64 `json:"confidence_threshold_pct"`
 	MeanK            int     `json:"mean_k"`
 	Sigma            float64 `json:"sigma"`
-	DefaultCamera    string  `json:"default_camera"`
+	DefaultCamera    string  `json:"camera_name"`
 }
 
 // ConvertAttributes changes the AttributeMap input into a DetectionSegmenterConfig.

--- a/vision/segmentation/detections_to_objects.go
+++ b/vision/segmentation/detections_to_objects.go
@@ -24,6 +24,7 @@ type DetectionSegmenterConfig struct {
 	ConfidenceThresh float64 `json:"confidence_threshold_pct"`
 	MeanK            int     `json:"mean_k"`
 	Sigma            float64 `json:"sigma"`
+	DefaultCamera    string  `json:"default_camera"`
 }
 
 // ConvertAttributes changes the AttributeMap input into a DetectionSegmenterConfig.

--- a/vision/segmentation/er_ccl_clustering.go
+++ b/vision/segmentation/er_ccl_clustering.go
@@ -37,6 +37,7 @@ type ErCCLConfig struct {
 	AngleTolerance       float64   `json:"ground_angle_tolerance_degs"`
 	ClusteringRadius     int       `json:"clustering_radius"`
 	ClusteringStrictness float64   `json:"clustering_strictness"`
+	DefaultCamera        string    `json:"default_camera"`
 }
 
 type node struct {

--- a/vision/segmentation/er_ccl_clustering.go
+++ b/vision/segmentation/er_ccl_clustering.go
@@ -37,7 +37,7 @@ type ErCCLConfig struct {
 	AngleTolerance       float64   `json:"ground_angle_tolerance_degs"`
 	ClusteringRadius     int       `json:"clustering_radius"`
 	ClusteringStrictness float64   `json:"clustering_strictness"`
-	DefaultCamera        string    `json:"default_camera"`
+	DefaultCamera        string    `json:"camera_name"`
 }
 
 type node struct {


### PR DESCRIPTION
## Changes
- [x] added `camera-name` as attribute to vizModel and `NewService` entrypoint
- [x] edited all services that implemented vision service to have default camera attribute in config
- [x] edited any tests that would break with this change
- [x] wrote comprehensive tests in all affected services

## Thoughts
- Also tested locally and everything works fine
- I would imagine that this would require a docs change  
- as of this writing, verdict is still out on if this is a breaking change or not