### PR TITLE
[APP-7694] Change logs default to twelve hours

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -1919,7 +1919,7 @@ var app = &cli.App{
 						&cli.StringFlag{
 							Name:        generalFlagStart,
 							Usage:       "ISO-8601 timestamp in RFC3339 format indicating the start of the interval filter (e.g., 2025-01-15T14:00:00Z)",
-							DefaultText: "1 day ago",
+							DefaultText: "12 hours ago",
 						},
 						&cli.StringFlag{
 							Name:  generalFlagEnd,

--- a/cli/client.go
+++ b/cli/client.go
@@ -65,6 +65,10 @@ const (
 	logoMaxSize = 1024 * 200 // 200 KB
 	// defaultLogStartTime is set to the last 12 hours,
 	// logs older than 24 hours are stored in the online archive.
+	//
+	// 12 hours is a temporary decrease from the matching 24 hour window to
+	// avoid an edge case where network latency always triggers an online
+	// archive query and causes a "resource usage limit exceeded" error.
 	defaultLogStartTime = -12 * time.Hour
 	// yellow is the format string used to output warnings in yellow color.
 	yellow = "\033[1;33m%s\033[0m"

--- a/cli/client.go
+++ b/cli/client.go
@@ -63,9 +63,9 @@ const (
 	maxNumLogs = 10000
 	// logoMaxSize is the maximum size of a logo in bytes.
 	logoMaxSize = 1024 * 200 // 200 KB
-	// defaultLogStartTime is set to the last 24 hours
-	// because logs older than 24 hours are stored in the online archive.
-	defaultLogStartTime = -24 * time.Hour
+	// defaultLogStartTime is set to the last 12 hours,
+	// logs older than 24 hours are stored in the online archive.
+	defaultLogStartTime = -12 * time.Hour
 	// yellow is the format string used to output warnings in yellow color.
 	yellow = "\033[1;33m%s\033[0m"
 )


### PR DESCRIPTION
# Description
Update the CLI and API to match the UI change by setting the default log time filter to 12 hours instead of 1 day.

**See ticket [here](https://viam.atlassian.net/browse/APP-7845)**

## Related PRs
- https://github.com/viamrobotics/rdk/pull/4857

## Todo
- [x] Manually test the cli

# Manual Tests
## Using Prods RDK which Defaults to 24 Hours
```
viam machines logs -machine="mac" --organization="Joseph's Org" --location="First Location" 
```
<img width="1470" alt="Screenshot 2025-03-31 at 11 48 44 AM" src="https://github.com/user-attachments/assets/ecfe4e54-8011-457f-a5dd-def8ee0011bc" />

## Using Prods RDK but Manually changing to 12 hours
```
viam machines logs -machine="mac" --organization="Joseph's Org" --location="First Location" --start="2025-03-31T00:00:00Z"
```
<img width="1470" alt="Screenshot 2025-03-31 at 11 49 02 AM" src="https://github.com/user-attachments/assets/ff125cef-e3f2-4cd0-92f0-1e973da27bcc" />

## Running Against this PRs Version of the RDK which Defaults to 12 Hours
```
go run cli/viam/main.go machines logs -machine="mac" --organization="Joseph's Org" --location="First Location"
```
<img width="1265" alt="Screenshot 2025-03-31 at 11 43 50 AM" src="https://github.com/user-attachments/assets/460c91af-ca92-40a3-8711-ac97bfb7f735" />

## Running Against this PRs Version of the RDK but changing to 24 Hours
```
go run cli/viam/main.go machines logs -machine="mac" --organization="Joseph's Org" --location="First Location" --start="2025-03-30T11:00:00Z"
```
<img width="1274" alt="Screenshot 2025-03-31 at 11 49 56 AM" src="https://github.com/user-attachments/assets/6df8493d-becf-45a9-8b0a-f9a3427ec16b" />