### PR TITLE
RSDK-10142 - Add relative (normalized) bounding boxes to RDK

### DIFF
--- a/components/camera/transformpipeline/mods.go
+++ b/components/camera/transformpipeline/mods.go
@@ -262,7 +262,7 @@ func (cs *cropSource) Read(ctx context.Context) (image.Image, func(), error) {
 	switch cs.imgType {
 	case camera.ColorStream, camera.UnspecifiedStream:
 		if cs.showCropBox {
-			newDet := objectdetection.NewDetection(cs.cropWindow, 1.0, "crop")
+			newDet := objectdetection.NewDetection(cs.imgBounds, cs.cropWindow, 1.0, "crop")
 			dets := []objectdetection.Detection{newDet}
 			newImg, err := objectdetection.Overlay(orig, dets)
 			if err != nil {

--- a/services/vision/client.go
+++ b/services/vision/client.go
@@ -113,7 +113,13 @@ func protoToDets(protoDets []*pb.Detection) ([]objdet.Detection, error) {
 			return nil, fmt.Errorf("invalid detection %+v", d)
 		}
 		box := image.Rect(int(*d.XMin), int(*d.YMin), int(*d.XMax), int(*d.YMax))
-		det := objdet.NewDetection(box, d.Confidence, d.ClassName)
+		var det objdet.Detection 
+		if d.XMinNormalized != nil && d.XMaxNormalized != nil && d.YMinNormalized != nil && d.YMaxNormalized != nil {
+			ibx := int(float64(*d.XMax) / *d.XMaxNormalized)
+			iby := int(float64(*d.YMax) / *d.YMaxNormalized)
+			det = objdet.NewDetection(image.Rect(0,0,ibx,iby), box, d.Confidence, d.ClassName)
+		}
+		det = objdet.NewDetectionWithoutImgBounds(box, d.Confidence, d.ClassName)
 		detections = append(detections, det)
 	}
 	return detections, nil

--- a/services/vision/client.go
+++ b/services/vision/client.go
@@ -113,13 +113,14 @@ func protoToDets(protoDets []*pb.Detection) ([]objdet.Detection, error) {
 			return nil, fmt.Errorf("invalid detection %+v", d)
 		}
 		box := image.Rect(int(*d.XMin), int(*d.YMin), int(*d.XMax), int(*d.YMax))
-		var det objdet.Detection 
+		var det objdet.Detection
 		if d.XMinNormalized != nil && d.XMaxNormalized != nil && d.YMinNormalized != nil && d.YMaxNormalized != nil {
 			ibx := int(float64(*d.XMax) / *d.XMaxNormalized)
 			iby := int(float64(*d.YMax) / *d.YMaxNormalized)
-			det = objdet.NewDetection(image.Rect(0,0,ibx,iby), box, d.Confidence, d.ClassName)
+			det = objdet.NewDetection(image.Rect(0, 0, ibx, iby), box, d.Confidence, d.ClassName)
+		} else {
+			det = objdet.NewDetectionWithoutImgBounds(box, d.Confidence, d.ClassName)
 		}
-		det = objdet.NewDetectionWithoutImgBounds(box, d.Confidence, d.ClassName)
 		detections = append(detections, det)
 	}
 	return detections, nil

--- a/services/vision/client_test.go
+++ b/services/vision/client_test.go
@@ -31,7 +31,7 @@ func TestClient(t *testing.T) {
 
 	srv := &inject.VisionService{}
 	srv.DetectionsFunc = func(ctx context.Context, img image.Image, extra map[string]interface{}) ([]objectdetection.Detection, error) {
-		det1 := objectdetection.NewDetection(image.Rect(5, 10, 15, 20), 0.5, "yes")
+		det1 := objectdetection.NewDetection(img.Bounds(), image.Rect(5, 10, 15, 20), 0.5, "yes")
 		return []objectdetection.Detection{det1}, nil
 	}
 	srv.DetectionsFromCameraFunc = func(
@@ -39,7 +39,7 @@ func TestClient(t *testing.T) {
 		camName string,
 		extra map[string]interface{},
 	) ([]objectdetection.Detection, error) {
-		det1 := objectdetection.NewDetection(image.Rect(0, 0, 10, 20), 0.8, "camera")
+		det1 := objectdetection.NewDetection(image.Rect(0, 0, 50, 50), image.Rect(0, 0, 10, 20), 0.8, "camera")
 		return []objectdetection.Detection{det1}, nil
 	}
 	srv.GetPropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (*vision.Properties, error) {

--- a/services/vision/client_test.go
+++ b/services/vision/client_test.go
@@ -53,7 +53,7 @@ func TestClient(t *testing.T) {
 		opts viscapture.CaptureOptions,
 		extra map[string]interface{},
 	) (viscapture.VisCapture, error) {
-		det1 := objectdetection.NewDetectionWithoutImgBounds(image.Rectangle{}, 0.5, "yes")
+		det1 := objectdetection.NewDetection(image.Rect(0, 0, 50, 50), image.Rect(0, 0, 10, 20), 0.5, "yes")
 		return viscapture.VisCapture{
 			Detections: []objectdetection.Detection{det1},
 			Extra:      extra,
@@ -86,7 +86,7 @@ func TestClient(t *testing.T) {
 		client, err := vision.NewClientFromConn(context.Background(), conn, "", vision.Named(testVisionServiceName), logger)
 		test.That(t, err, test.ShouldBeNil)
 
-		dets, err := client.Detections(context.Background(), image.NewRGBA(image.Rect(0, 0, 10, 20)), nil)
+		dets, err := client.Detections(context.Background(), image.NewRGBA(image.Rect(0, 0, 100, 200)), nil)
 		test.That(t, err, test.ShouldBeNil)
 
 		test.That(t, dets, test.ShouldNotBeNil)
@@ -95,7 +95,7 @@ func TestClient(t *testing.T) {
 		box := dets[0].BoundingBox()
 		test.That(t, box.Min, test.ShouldResemble, image.Point{5, 10})
 		test.That(t, box.Max, test.ShouldResemble, image.Point{15, 20})
-
+		test.That(t, dets[0].NormalizedBoundingBox(), test.ShouldResemble, []float64{0.05, 0.05, 0.15, 0.1})
 		test.That(t, client.Close(context.Background()), test.ShouldBeNil)
 		test.That(t, conn.Close(), test.ShouldBeNil)
 	})
@@ -113,7 +113,7 @@ func TestClient(t *testing.T) {
 		box := dets[0].BoundingBox()
 		test.That(t, box.Min, test.ShouldResemble, image.Point{0, 0})
 		test.That(t, box.Max, test.ShouldResemble, image.Point{10, 20})
-
+		test.That(t, dets[0].NormalizedBoundingBox(), test.ShouldResemble, []float64{0.0, 0.0, 0.2, 0.4})
 		test.That(t, client.Close(context.Background()), test.ShouldBeNil)
 		test.That(t, conn.Close(), test.ShouldBeNil)
 	})
@@ -154,6 +154,7 @@ func TestClient(t *testing.T) {
 		test.That(t, capt.Detections, test.ShouldHaveLength, 1)
 		test.That(t, capt.Detections[0].Label(), test.ShouldEqual, "yes")
 		test.That(t, capt.Detections[0].Score(), test.ShouldEqual, 0.5)
+		test.That(t, capt.Detections[0].NormalizedBoundingBox(), test.ShouldResemble, []float64{0.0, 0.0, 0.2, 0.4})
 		test.That(t, capt.Extra, test.ShouldResemble, extra)
 		test.That(t, client.Close(context.Background()), test.ShouldBeNil)
 

--- a/services/vision/client_test.go
+++ b/services/vision/client_test.go
@@ -53,7 +53,7 @@ func TestClient(t *testing.T) {
 		opts viscapture.CaptureOptions,
 		extra map[string]interface{},
 	) (viscapture.VisCapture, error) {
-		det1 := objectdetection.NewDetection(image.Rectangle{}, 0.5, "yes")
+		det1 := objectdetection.NewDetectionWithoutImgBounds(image.Rectangle{}, 0.5, "yes")
 		return viscapture.VisCapture{
 			Detections: []objectdetection.Detection{det1},
 			Extra:      extra,

--- a/services/vision/collectors_test.go
+++ b/services/vision/collectors_test.go
@@ -35,6 +35,7 @@ var viamLogoJpegB64 = []byte("/9j/4QD4RXhpZgAATU0AKgAAAAgABwESAAMAAAABAAEAAAEaAA
 
 type fakeDetection struct {
 	boundingBox *image.Rectangle
+	normalizedBox []float64
 	score       float64
 	label       string
 }
@@ -55,6 +56,7 @@ var fakeDetections = []objectdetection.Detection{
 			Min: image.Point{X: 10, Y: 20},
 			Max: image.Point{X: 110, Y: 120},
 		},
+		normalizedBox: []float64{0.01, 0.02, 0.11, 0.12},
 		score: 0.95,
 		label: "cat",
 	},
@@ -66,6 +68,7 @@ var fakeDetections2 = []objectdetection.Detection{
 			Min: image.Point{X: 10, Y: 20},
 			Max: image.Point{X: 110, Y: 120},
 		},
+		normalizedBox: []float64{0.01, 0.02, 0.11, 0.12},
 		score: 0.3,
 		label: "cat",
 	},
@@ -95,6 +98,10 @@ func (fc *fakeClassification) Label() string {
 
 func (fd *fakeDetection) BoundingBox() *image.Rectangle {
 	return fd.boundingBox
+}
+
+func (fd *fakeDetection) NormalizedBoundingBox() []float64 {
+	return fd.normalizedBox
 }
 
 func (fd *fakeDetection) Score() float64 {

--- a/services/vision/collectors_test.go
+++ b/services/vision/collectors_test.go
@@ -34,10 +34,10 @@ import (
 var viamLogoJpegB64 = []byte("/9j/4QD4RXhpZgAATU0AKgAAAAgABwESAAMAAAABAAEAAAEaAAUAAAABAAAAYgEbAAUAAAABAAAAagEoAAMAAAABAAIAAAExAAIAAAAhAAAAcgITAAMAAAABAAEAAIdpAAQAAAABAAAAlAAAAAAAAABIAAAAAQAAAEgAAAABQWRvYmUgUGhvdG9zaG9wIDIzLjQgKE1hY2ludG9zaCkAAAAHkAAABwAAAAQwMjIxkQEABwAAAAQBAgMAoAAABwAAAAQwMTAwoAEAAwAAAAEAAQAAoAIABAAAAAEAAAAgoAMABAAAAAEAAAAgpAYAAwAAAAEAAAAAAAAAAAAA/9sAhAAcHBwcHBwwHBwwRDAwMERcRERERFx0XFxcXFx0jHR0dHR0dIyMjIyMjIyMqKioqKioxMTExMTc3Nzc3Nzc3NzcASIkJDg0OGA0NGDmnICc5ubm5ubm5ubm5ubm5ubm5ubm5ubm5ubm5ubm5ubm5ubm5ubm5ubm5ubm5ubm5ubm5ub/3QAEAAL/wAARCAAgACADASIAAhEBAxEB/8QBogAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoLEAACAQMDAgQDBQUEBAAAAX0BAgMABBEFEiExQQYTUWEHInEUMoGRoQgjQrHBFVLR8CQzYnKCCQoWFxgZGiUmJygpKjQ1Njc4OTpDREVGR0hJSlNUVVZXWFlaY2RlZmdoaWpzdHV2d3h5eoOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4eLj5OXm5+jp6vHy8/T19vf4+foBAAMBAQEBAQEBAQEAAAAAAAABAgMEBQYHCAkKCxEAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwDm6K0dNu1tZsSgGNuDx0961NX09WT7ZbgcD5gPT1oA5qiul0fT1VPtlwByPlB7D1rL1K7W5mxEAI04GBjPvQB//9Dm66TRr/I+xTf8A/wrm6ASpBXgjpQB0ms34UfYof8AgWP5VzdBJY5PJNFAH//Z")
 
 type fakeDetection struct {
-	boundingBox *image.Rectangle
+	boundingBox   *image.Rectangle
 	normalizedBox []float64
-	score       float64
-	label       string
+	score         float64
+	label         string
 }
 
 type fakeClassification struct {
@@ -57,8 +57,8 @@ var fakeDetections = []objectdetection.Detection{
 			Max: image.Point{X: 110, Y: 120},
 		},
 		normalizedBox: []float64{0.01, 0.02, 0.11, 0.12},
-		score: 0.95,
-		label: "cat",
+		score:         0.95,
+		label:         "cat",
 	},
 }
 
@@ -69,8 +69,8 @@ var fakeDetections2 = []objectdetection.Detection{
 			Max: image.Point{X: 110, Y: 120},
 		},
 		normalizedBox: []float64{0.01, 0.02, 0.11, 0.12},
-		score: 0.3,
-		label: "cat",
+		score:         0.3,
+		label:         "cat",
 	},
 }
 

--- a/services/vision/detectionstosegments/detections_to_3dsegments_test.go
+++ b/services/vision/detectionstosegments/detections_to_3dsegments_test.go
@@ -23,7 +23,7 @@ import (
 type simpleDetector struct{}
 
 func (s *simpleDetector) Detect(context.Context, image.Image) ([]objectdetection.Detection, error) {
-	det1 := objectdetection.NewDetection(image.Rect(10, 10, 20, 20), 0.5, "yes")
+	det1 := objectdetection.NewDetection(image.Rect(0, 0, 50, 50), image.Rect(10, 10, 20, 20), 0.5, "yes")
 	return []objectdetection.Detection{det1}, nil
 }
 

--- a/services/vision/fake/vision.go
+++ b/services/vision/fake/vision.go
@@ -52,7 +52,7 @@ func fakeDetector(ctx context.Context, img image.Image) ([]objectdetection.Detec
 		int(float64(bounds.Max.X)*0.75),
 		int(float64(bounds.Max.Y)*0.75),
 	)
-	fakeDet := objectdetection.NewDetection(boundingBox, fakeDetScore, fakeDetLabel)
+	fakeDet := objectdetection.NewDetection(bounds, boundingBox, fakeDetScore, fakeDetLabel)
 	dets := []objectdetection.Detection{fakeDet}
 	return dets, nil
 }

--- a/services/vision/mlvision/detector.go
+++ b/services/vision/mlvision/detector.go
@@ -160,7 +160,7 @@ func convertBoundingBoxesToDetections(boundingBoxes []data.BoundingBox, origW, o
 		xmax := bbox.XMaxNormalized * float64(origW-1)
 		ymax := bbox.YMaxNormalized * float64(origH-1)
 		rect := image.Rect(int(xmin), int(ymin), int(xmax), int(ymax))
-		detections = append(detections, objectdetection.NewDetection(rect, *bbox.Confidence, bbox.Label))
+		detections = append(detections, objectdetection.NewDetection(image.Rect(0, 0, origW, origH), rect, *bbox.Confidence, bbox.Label))
 	}
 	return detections
 }

--- a/services/vision/server.go
+++ b/services/vision/server.go
@@ -87,6 +87,27 @@ func detsToProto(detections []objectdetection.Detection) []*pb.Detection {
 		yMin := int64(box.Min.Y)
 		xMax := int64(box.Max.X)
 		yMax := int64(box.Max.Y)
+
+		normbox := det.NormalizedBoundingBox()
+		if len(normbox) == 4 {
+			nXmin := normbox[0]
+			nYmin := normbox[1]
+			nXmax := normbox[2]
+			nYmax := normbox[3]
+			d := &pb.Detection{
+				XMin:       &xMin,
+				YMin:       &yMin,
+				XMax:       &xMax,
+				YMax:       &yMax,
+				Confidence: det.Score(),
+				ClassName:  det.Label(),
+				XMinNormalized: &nXmin,
+				YMinNormalized: &nYmin,
+				XMaxNormalized: &nXmax,
+				YMaxNormalized: &nYmax,
+			}
+			protoDets = append(protoDets, d)
+		}
 		d := &pb.Detection{
 			XMin:       &xMin,
 			YMin:       &yMin,

--- a/services/vision/server.go
+++ b/services/vision/server.go
@@ -88,30 +88,20 @@ func detsToProto(detections []objectdetection.Detection) []*pb.Detection {
 		xMax := int64(box.Max.X)
 		yMax := int64(box.Max.Y)
 
+		d := &pb.Detection{
+			XMin:       &xMin,
+			YMin:       &yMin,
+			XMax:       &xMax,
+			YMax:       &yMax,
+			Confidence: det.Score(),
+			ClassName:  det.Label(),
+		}
 		normbox := det.NormalizedBoundingBox()
-		var d *pb.Detection
 		if len(normbox) == 4 {
-			d = &pb.Detection{
-				XMin:           &xMin,
-				YMin:           &yMin,
-				XMax:           &xMax,
-				YMax:           &yMax,
-				Confidence:     det.Score(),
-				ClassName:      det.Label(),
-				XMinNormalized: &normbox[0],
-				YMinNormalized: &normbox[1],
-				XMaxNormalized: &normbox[2],
-				YMaxNormalized: &normbox[3],
-			}
-		} else {
-			d = &pb.Detection{
-				XMin:       &xMin,
-				YMin:       &yMin,
-				XMax:       &xMax,
-				YMax:       &yMax,
-				Confidence: det.Score(),
-				ClassName:  det.Label(),
-			}
+			d.XMinNormalized = &normbox[0]
+			d.YMinNormalized = &normbox[1]
+			d.XMaxNormalized = &normbox[2]
+			d.YMaxNormalized = &normbox[3]
 		}
 		protoDets = append(protoDets, d)
 	}

--- a/services/vision/server.go
+++ b/services/vision/server.go
@@ -89,32 +89,29 @@ func detsToProto(detections []objectdetection.Detection) []*pb.Detection {
 		yMax := int64(box.Max.Y)
 
 		normbox := det.NormalizedBoundingBox()
+		var d *pb.Detection
 		if len(normbox) == 4 {
-			nXmin := normbox[0]
-			nYmin := normbox[1]
-			nXmax := normbox[2]
-			nYmax := normbox[3]
-			d := &pb.Detection{
+			d = &pb.Detection{
+				XMin:           &xMin,
+				YMin:           &yMin,
+				XMax:           &xMax,
+				YMax:           &yMax,
+				Confidence:     det.Score(),
+				ClassName:      det.Label(),
+				XMinNormalized: &normbox[0],
+				YMinNormalized: &normbox[1],
+				XMaxNormalized: &normbox[2],
+				YMaxNormalized: &normbox[3],
+			}
+		} else {
+			d = &pb.Detection{
 				XMin:       &xMin,
 				YMin:       &yMin,
 				XMax:       &xMax,
 				YMax:       &yMax,
 				Confidence: det.Score(),
 				ClassName:  det.Label(),
-				XMinNormalized: &nXmin,
-				YMinNormalized: &nYmin,
-				XMaxNormalized: &nXmax,
-				YMaxNormalized: &nYmax,
 			}
-			protoDets = append(protoDets, d)
-		}
-		d := &pb.Detection{
-			XMin:       &xMin,
-			YMin:       &yMin,
-			XMax:       &xMax,
-			YMax:       &yMax,
-			Confidence: det.Score(),
-			ClassName:  det.Label(),
 		}
 		protoDets = append(protoDets, d)
 	}

--- a/services/vision/server_test.go
+++ b/services/vision/server_test.go
@@ -87,7 +87,7 @@ func TestServerGetDetections(t *testing.T) {
 		Extra:    ext,
 	}
 	injectVS.DetectionsFunc = func(ctx context.Context, img image.Image, extra map[string]interface{}) ([]objectdetection.Detection, error) {
-		det1 := objectdetection.NewDetection(img.Bounds(), image.Rectangle{}, 0.5, "yes")
+		det1 := objectdetection.NewDetection(img.Bounds(), image.Rect(0, 0, 10, 20), 0.5, "yes")
 		return []objectdetection.Detection{det1}, nil
 	}
 	test.That(t, err, test.ShouldBeNil)
@@ -95,6 +95,10 @@ func TestServerGetDetections(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, len(resp.GetDetections()), test.ShouldEqual, 1)
 	test.That(t, resp.GetDetections()[0].GetClassName(), test.ShouldEqual, "yes")
+	test.That(t, resp.GetDetections()[0].GetXMax(), test.ShouldEqual, 10)
+	test.That(t, resp.GetDetections()[0].GetXMaxNormalized(), test.ShouldBeGreaterThan, 0.03)
+	test.That(t, resp.GetDetections()[0].GetXMaxNormalized(), test.ShouldBeLessThan, 0.04)
+
 }
 
 func TestServerGetProperties(t *testing.T) {
@@ -162,7 +166,7 @@ func TestServerCaptureAllFromCamera(t *testing.T) {
 		opts viscapture.CaptureOptions,
 		extra map[string]interface{},
 	) (viscapture.VisCapture, error) {
-		det1 := objectdetection.NewDetection(img.Bounds(), image.Rectangle{}, 0.5, "yes")
+		det1 := objectdetection.NewDetection(img.Bounds(), image.Rect(0, 0, 10, 20), 0.5, "yes")
 		return viscapture.VisCapture{
 			Detections: []objectdetection.Detection{det1},
 			Extra:      extra,
@@ -179,6 +183,8 @@ func TestServerCaptureAllFromCamera(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, len(captAllResp.Detections), test.ShouldEqual, 1)
 	test.That(t, captAllResp.Detections[0].GetClassName(), test.ShouldEqual, "yes")
+	test.That(t, captAllResp.Detections[0].GetXMaxNormalized(), test.ShouldBeGreaterThan, 0.03)
+	test.That(t, captAllResp.Detections[0].GetXMaxNormalized(), test.ShouldBeLessThan, 0.04)
 	test.That(t, captAllResp.Extra.AsMap(), test.ShouldResemble, map[string]interface{}{"foo": "GetDetections"})
 
 	captureRequest = pb.CaptureAllFromCameraRequest{

--- a/services/vision/server_test.go
+++ b/services/vision/server_test.go
@@ -98,7 +98,6 @@ func TestServerGetDetections(t *testing.T) {
 	test.That(t, resp.GetDetections()[0].GetXMax(), test.ShouldEqual, 10)
 	test.That(t, resp.GetDetections()[0].GetXMaxNormalized(), test.ShouldBeGreaterThan, 0.03)
 	test.That(t, resp.GetDetections()[0].GetXMaxNormalized(), test.ShouldBeLessThan, 0.04)
-
 }
 
 func TestServerGetProperties(t *testing.T) {

--- a/services/vision/server_test.go
+++ b/services/vision/server_test.go
@@ -87,7 +87,7 @@ func TestServerGetDetections(t *testing.T) {
 		Extra:    ext,
 	}
 	injectVS.DetectionsFunc = func(ctx context.Context, img image.Image, extra map[string]interface{}) ([]objectdetection.Detection, error) {
-		det1 := objectdetection.NewDetection(image.Rectangle{}, 0.5, "yes")
+		det1 := objectdetection.NewDetection(img.Bounds(), image.Rectangle{}, 0.5, "yes")
 		return []objectdetection.Detection{det1}, nil
 	}
 	test.That(t, err, test.ShouldBeNil)
@@ -147,7 +147,7 @@ func TestServerCaptureAllFromCamera(t *testing.T) {
 		Extra:    ext,
 	}
 	injectVS.DetectionsFunc = func(ctx context.Context, img image.Image, extra map[string]interface{}) ([]objectdetection.Detection, error) {
-		det1 := objectdetection.NewDetection(image.Rectangle{}, 0.5, "yes")
+		det1 := objectdetection.NewDetection(img.Bounds(), image.Rectangle{}, 0.5, "yes")
 		return []objectdetection.Detection{det1}, nil
 	}
 	test.That(t, err, test.ShouldBeNil)
@@ -162,7 +162,7 @@ func TestServerCaptureAllFromCamera(t *testing.T) {
 		opts viscapture.CaptureOptions,
 		extra map[string]interface{},
 	) (viscapture.VisCapture, error) {
-		det1 := objectdetection.NewDetection(image.Rectangle{}, 0.5, "yes")
+		det1 := objectdetection.NewDetection(img.Bounds(), image.Rectangle{}, 0.5, "yes")
 		return viscapture.VisCapture{
 			Detections: []objectdetection.Detection{det1},
 			Extra:      extra,

--- a/services/vision/vision_test.go
+++ b/services/vision/vision_test.go
@@ -21,7 +21,7 @@ const (
 func TestFromRobot(t *testing.T) {
 	svc1 := &inject.VisionService{}
 	svc1.DetectionsFunc = func(ctx context.Context, img image.Image, extra map[string]interface{}) ([]objectdetection.Detection, error) {
-		det1 := objectdetection.NewDetection(img.Bounds(), image.Rectangle{}, 0.5, "yes")
+		det1 := objectdetection.NewDetection(image.Rect(0, 0, 50, 50), image.Rect(0, 0, 10, 20), 0.5, "yes")
 		return []objectdetection.Detection{det1}, nil
 	}
 	var r inject.Robot
@@ -40,7 +40,7 @@ func TestFromRobot(t *testing.T) {
 type simpleDetector struct{}
 
 func (s *simpleDetector) Detect(ctx context.Context, img image.Image) ([]objectdetection.Detection, error) {
-	det1 := objectdetection.NewDetection(img.Bounds(), image.Rectangle{}, 0.5, "yes")
+	det1 := objectdetection.NewDetection(image.Rect(0, 0, 50, 50), image.Rect(0, 0, 10, 20), 0.5, "yes")
 	return []objectdetection.Detection{det1}, nil
 }
 

--- a/services/vision/vision_test.go
+++ b/services/vision/vision_test.go
@@ -21,7 +21,7 @@ const (
 func TestFromRobot(t *testing.T) {
 	svc1 := &inject.VisionService{}
 	svc1.DetectionsFunc = func(ctx context.Context, img image.Image, extra map[string]interface{}) ([]objectdetection.Detection, error) {
-		det1 := objectdetection.NewDetection(image.Rectangle{}, 0.5, "yes")
+		det1 := objectdetection.NewDetection(img.Bounds(), image.Rectangle{}, 0.5, "yes")
 		return []objectdetection.Detection{det1}, nil
 	}
 	var r inject.Robot
@@ -39,8 +39,8 @@ func TestFromRobot(t *testing.T) {
 
 type simpleDetector struct{}
 
-func (s *simpleDetector) Detect(context.Context, image.Image) ([]objectdetection.Detection, error) {
-	det1 := objectdetection.NewDetection(image.Rectangle{}, 0.5, "yes")
+func (s *simpleDetector) Detect(ctx context.Context, img image.Image) ([]objectdetection.Detection, error) {
+	det1 := objectdetection.NewDetection(img.Bounds(), image.Rectangle{}, 0.5, "yes")
 	return []objectdetection.Detection{det1}, nil
 }
 

--- a/vision/objectdetection/connected_components_detector.go
+++ b/vision/objectdetection/connected_components_detector.go
@@ -20,7 +20,7 @@ func (ccd *connectedComponentDetector) Inference(ctx context.Context, img image.
 	detections := []Detection{}
 	_, rectangles := ConnectedComponents(img, ccd.valid)
 	for _, rectangle := range rectangles {
-		detections = append(detections, NewDetection(rectangle, 1, ccd.label))
+		detections = append(detections, NewDetection(img.Bounds(),rectangle, 1, ccd.label))
 	}
 	return detections, nil
 }

--- a/vision/objectdetection/connected_components_detector.go
+++ b/vision/objectdetection/connected_components_detector.go
@@ -20,7 +20,7 @@ func (ccd *connectedComponentDetector) Inference(ctx context.Context, img image.
 	detections := []Detection{}
 	_, rectangles := ConnectedComponents(img, ccd.valid)
 	for _, rectangle := range rectangles {
-		detections = append(detections, NewDetection(img.Bounds(),rectangle, 1, ccd.label))
+		detections = append(detections, NewDetection(img.Bounds(), rectangle, 1, ccd.label))
 	}
 	return detections, nil
 }

--- a/vision/objectdetection/detector.go
+++ b/vision/objectdetection/detector.go
@@ -56,7 +56,7 @@ func NewDetectionWithoutImgBounds(boundingBox image.Rectangle, score float64, la
 // NewNormalizedBoundingBox creates a normalized bounding box from the image bounds and the bounding box.
 func NewNormalizedBoundingBox(imageBounds, boundingBox image.Rectangle) []float64 {
 	if imageBounds.Max.X == 0 || imageBounds.Max.Y == 0 {
-		return []float64{}
+		return nil
 	}
 	return []float64{
 		float64(boundingBox.Min.X) / float64(imageBounds.Max.X),

--- a/vision/objectdetection/detector.go
+++ b/vision/objectdetection/detector.go
@@ -53,6 +53,7 @@ func NewDetectionWithoutImgBounds(boundingBox image.Rectangle, score float64, la
 	return &detection2D{boundingBox, nil, score, label}
 }
 
+// NewNormalizedBoundingBox creates a normalized bounding box from the image bounds and the bounding box.
 func NewNormalizedBoundingBox(imageBounds, boundingBox image.Rectangle) []float64 {
 	// TODO: Check if boundingBox is within imageBounds?? Or maybe just check that the
 	// results are all from 0-1

--- a/vision/objectdetection/detector.go
+++ b/vision/objectdetection/detector.go
@@ -48,8 +48,13 @@ func NewDetection(imageBounds, boundingBox image.Rectangle, score float64, label
 	return &detection2D{boundingBox, normBbox, score, label}
 }
 
+// NewDetectionWithoutImgBounds creates a simple 2D detection.
+func NewDetectionWithoutImgBounds(boundingBox image.Rectangle, score float64, label string) Detection {
+	return &detection2D{boundingBox, nil, score, label}
+}
+
 func NewNormalizedBoundingBox(imageBounds, boundingBox image.Rectangle) []float64 {
-	// TODO: Check if boundingBox is within imageBounds?? Or maybe just check that the 
+	// TODO: Check if boundingBox is within imageBounds?? Or maybe just check that the
 	// results are all from 0-1
 	return []float64{
 		float64(boundingBox.Min.X) / float64(imageBounds.Max.X),
@@ -76,7 +81,6 @@ func (d *detection2D) BoundingBox() *image.Rectangle {
 func (d *detection2D) NormalizedBoundingBox() []float64 {
 	return d.normalizedBoundingBox
 }
-
 
 // Score returns a confidence score of the detection between 0.0 and 1.0.
 func (d *detection2D) Score() float64 {

--- a/vision/objectdetection/detector.go
+++ b/vision/objectdetection/detector.go
@@ -54,6 +54,7 @@ func NewDetectionWithoutImgBounds(boundingBox image.Rectangle, score float64, la
 }
 
 // NewNormalizedBoundingBox creates a normalized bounding box from the image bounds and the bounding box.
+// [xmin, ymin, xmax, ymax].
 func NewNormalizedBoundingBox(imageBounds, boundingBox image.Rectangle) []float64 {
 	if imageBounds.Max.X == 0 || imageBounds.Max.Y == 0 {
 		return nil
@@ -69,7 +70,7 @@ func NewNormalizedBoundingBox(imageBounds, boundingBox image.Rectangle) []float6
 // detection2D is a simple struct for storing 2D detections.
 type detection2D struct {
 	boundingBox           image.Rectangle
-	normalizedBoundingBox []float64
+	normalizedBoundingBox []float64 // [xmin, ymin, xmax, ymax]
 	score                 float64
 	label                 string
 }

--- a/vision/objectdetection/detector.go
+++ b/vision/objectdetection/detector.go
@@ -37,26 +37,46 @@ func Build(prep Preprocessor, det Detector, post Postprocessor) (Detector, error
 // Detection returns a bounding box around the object and a confidence score of the detection.
 type Detection interface {
 	BoundingBox() *image.Rectangle
+	NormalizedBoundingBox() []float64
 	Score() float64
 	Label() string
 }
 
 // NewDetection creates a simple 2D detection.
-func NewDetection(boundingBox image.Rectangle, score float64, label string) Detection {
-	return &detection2D{boundingBox, score, label}
+func NewDetection(imageBounds, boundingBox image.Rectangle, score float64, label string) Detection {
+	normBbox := NewNormalizedBoundingBox(imageBounds, boundingBox)
+	return &detection2D{boundingBox, normBbox, score, label}
+}
+
+func NewNormalizedBoundingBox(imageBounds, boundingBox image.Rectangle) []float64 {
+	// TODO: Check if boundingBox is within imageBounds?? Or maybe just check that the 
+	// results are all from 0-1
+	return []float64{
+		float64(boundingBox.Min.X) / float64(imageBounds.Max.X),
+		float64(boundingBox.Min.Y) / float64(imageBounds.Max.Y),
+		float64(boundingBox.Max.X) / float64(imageBounds.Max.X),
+		float64(boundingBox.Max.Y) / float64(imageBounds.Max.Y),
+	}
 }
 
 // detection2D is a simple struct for storing 2D detections.
 type detection2D struct {
-	boundingBox image.Rectangle
-	score       float64
-	label       string
+	boundingBox           image.Rectangle
+	normalizedBoundingBox []float64
+	score                 float64
+	label                 string
 }
 
 // BoundingBox returns a bounding box around the detected object.
 func (d *detection2D) BoundingBox() *image.Rectangle {
 	return &d.boundingBox
 }
+
+// NormalizedBoundingBox returns a normalized bounding box around the detected object.
+func (d *detection2D) NormalizedBoundingBox() []float64 {
+	return d.normalizedBoundingBox
+}
+
 
 // Score returns a confidence score of the detection between 0.0 and 1.0.
 func (d *detection2D) Score() float64 {

--- a/vision/objectdetection/detector.go
+++ b/vision/objectdetection/detector.go
@@ -55,8 +55,9 @@ func NewDetectionWithoutImgBounds(boundingBox image.Rectangle, score float64, la
 
 // NewNormalizedBoundingBox creates a normalized bounding box from the image bounds and the bounding box.
 func NewNormalizedBoundingBox(imageBounds, boundingBox image.Rectangle) []float64 {
-	// TODO: Check if boundingBox is within imageBounds?? Or maybe just check that the
-	// results are all from 0-1
+	if imageBounds.Max.X == 0 || imageBounds.Max.Y == 0 {
+		return []float64{}
+	}
 	return []float64{
 		float64(boundingBox.Min.X) / float64(imageBounds.Max.X),
 		float64(boundingBox.Min.Y) / float64(imageBounds.Max.Y),

--- a/vision/objectdetection/detector_test.go
+++ b/vision/objectdetection/detector_test.go
@@ -1,0 +1,27 @@
+package objectdetection
+
+import (
+	"image"
+	"testing"
+
+	"go.viam.com/test"
+)
+
+// TestLoadModel validates that the model loads successfully.
+func TestNewDetector(t *testing.T) {
+
+	det := NewDetection(image.Rect(0, 0, 100, 100), image.Rect(0, 0, 30, 30), 0.5, "A")
+	test.That(t, det, test.ShouldNotBeNil)
+	test.That(t, det.Label(), test.ShouldEqual, "A")
+	test.That(t, det.Score(), test.ShouldEqual, 0.5)
+	test.That(t, *det.BoundingBox(), test.ShouldResemble, image.Rect(0, 0, 30, 30))
+	test.That(t, det.NormalizedBoundingBox(), test.ShouldResemble, []float64{0.0, 0.0, 0.3, 0.3})
+
+	det2 := NewDetectionWithoutImgBounds(image.Rect(0, 0, 30, 30), 0.6, "B")
+	test.That(t, det2, test.ShouldNotBeNil)
+	test.That(t, det2.NormalizedBoundingBox(), test.ShouldBeNil)
+	test.That(t, det2.Label(), test.ShouldEqual, "B")
+	test.That(t, det2.Score(), test.ShouldEqual, 0.6)
+	test.That(t, *det2.BoundingBox(), test.ShouldResemble, image.Rect(0, 0, 30, 30))
+
+}

--- a/vision/objectdetection/detector_test.go
+++ b/vision/objectdetection/detector_test.go
@@ -9,7 +9,6 @@ import (
 
 // TestLoadModel validates that the model loads successfully.
 func TestNewDetector(t *testing.T) {
-
 	det := NewDetection(image.Rect(0, 0, 100, 100), image.Rect(0, 0, 30, 30), 0.5, "A")
 	test.That(t, det, test.ShouldNotBeNil)
 	test.That(t, det.Label(), test.ShouldEqual, "A")
@@ -23,5 +22,4 @@ func TestNewDetector(t *testing.T) {
 	test.That(t, det2.Label(), test.ShouldEqual, "B")
 	test.That(t, det2.Score(), test.ShouldEqual, 0.6)
 	test.That(t, *det2.BoundingBox(), test.ShouldResemble, image.Rect(0, 0, 30, 30))
-
 }

--- a/vision/objectdetection/postprocessor_test.go
+++ b/vision/objectdetection/postprocessor_test.go
@@ -8,13 +8,14 @@ import (
 )
 
 func TestLabelConfidencePostprocessor(t *testing.T) {
+	fakeImgBound := image.Rect(0,0,1000,1000)
 	d := []Detection{
-		NewDetection(image.Rect(0, 0, 30, 30), 0.5, "A"),
-		NewDetection(image.Rect(0, 0, 30, 30), 0.1, "a"),
-		NewDetection(image.Rect(0, 0, 300, 300), 0.1, "B"),
-		NewDetection(image.Rect(0, 0, 300, 300), 0.6, "b"),
-		NewDetection(image.Rect(150, 150, 310, 310), 1, "C"),
-		NewDetection(image.Rect(50, 50, 200, 200), 0.8773934448, "D"),
+		NewDetection(fakeImgBound, image.Rect(0, 0, 30, 30), 0.5, "A"),
+		NewDetection(fakeImgBound, image.Rect(0, 0, 30, 30), 0.1, "a"),
+		NewDetection(fakeImgBound, image.Rect(0, 0, 300, 300), 0.1, "B"),
+		NewDetection(fakeImgBound, image.Rect(0, 0, 300, 300), 0.6, "b"),
+		NewDetection(fakeImgBound, image.Rect(150, 150, 310, 310), 1, "C"),
+		NewDetection(fakeImgBound, image.Rect(50, 50, 200, 200), 0.8773934448, "D"),
 	}
 
 	postNoFilter := NewLabelConfidenceFilter(nil) // no filtering
@@ -34,11 +35,12 @@ func TestLabelConfidencePostprocessor(t *testing.T) {
 }
 
 func TestPostprocessors(t *testing.T) {
+	fakeImgBound := image.Rect(0,0,1000,1000)
 	d := []Detection{
-		NewDetection(image.Rect(0, 0, 30, 30), 0.5, "A"),
-		NewDetection(image.Rect(0, 0, 300, 300), 0.6, "B"),
-		NewDetection(image.Rect(150, 150, 310, 310), 1, "C"),
-		NewDetection(image.Rect(50, 50, 200, 200), 0.8773934448, "D"),
+		NewDetection(fakeImgBound, image.Rect(0, 0, 30, 30), 0.5, "A"),
+		NewDetection(fakeImgBound, image.Rect(0, 0, 300, 300), 0.6, "B"),
+		NewDetection(fakeImgBound, image.Rect(150, 150, 310, 310), 1, "C"),
+		NewDetection(fakeImgBound, image.Rect(50, 50, 200, 200), 0.8773934448, "D"),
 	}
 	sorter := SortByArea()
 	got := sorter(d)

--- a/vision/objectdetection/postprocessor_test.go
+++ b/vision/objectdetection/postprocessor_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestLabelConfidencePostprocessor(t *testing.T) {
-	fakeImgBound := image.Rect(0,0,1000,1000)
+	fakeImgBound := image.Rect(0, 0, 1000, 1000)
 	d := []Detection{
 		NewDetection(fakeImgBound, image.Rect(0, 0, 30, 30), 0.5, "A"),
 		NewDetection(fakeImgBound, image.Rect(0, 0, 30, 30), 0.1, "a"),
@@ -35,7 +35,7 @@ func TestLabelConfidencePostprocessor(t *testing.T) {
 }
 
 func TestPostprocessors(t *testing.T) {
-	fakeImgBound := image.Rect(0,0,1000,1000)
+	fakeImgBound := image.Rect(0, 0, 1000, 1000)
 	d := []Detection{
 		NewDetection(fakeImgBound, image.Rect(0, 0, 30, 30), 0.5, "A"),
 		NewDetection(fakeImgBound, image.Rect(0, 0, 300, 300), 0.6, "B"),


### PR DESCRIPTION
Here we're adding normalized bounding boxes to RDK by incorporating it into our idea of a "Detection".  I've edited the Detection constructor to take in the image bounds so the calculations can happen. See scope: (https://docs.google.com/document/d/1cezhhCrPOi6ANjo7laOZ_CBzvZxi7Ea4zx3qgrolwks/edit?tab=t.0#heading=h.tcicyojyqi6c) 

I've also included a "no img bounds" constructor.  Server and client side code were updated and tests were updated as well to include/test the new changes.  