### PR TITLE
[RSDK-9079] - Move to 20fps livestream default

### DIFF
--- a/gostream/stream.go
+++ b/gostream/stream.go
@@ -22,6 +22,10 @@ import (
 	utils2 "go.viam.com/rdk/utils"
 )
 
+const (
+	defaultTargetFrameRate = 20
+)
+
 // A Stream is sink that accepts any image frames for the purpose
 // of displaying in a WebRTC video track.
 type Stream interface {
@@ -66,7 +70,7 @@ func NewStream(config StreamConfig, logger logging.Logger) (Stream, error) {
 		return nil, errors.New("at least one audio or video encoder factory must be set")
 	}
 	if config.TargetFrameRate == 0 {
-		config.TargetFrameRate = codec.DefaultKeyFrameInterval
+		config.TargetFrameRate = defaultTargetFrameRate
 	}
 
 	name := config.Name


### PR DESCRIPTION
## Description

Simply moving from 30fps to 20fps livestream poller.

## Testing

Tested that we see appropriate reduction in CPU utilization.
- Small frame size (352x240) goes from 40% to 30% on a Jetson Orin Nano.

<img width="892" alt="Screenshot 2025-04-01 at 12 49 45 PM" src="https://github.com/user-attachments/assets/7d088938-e028-430f-be1f-b1e3d8df689b" />

<img width="788" alt="Screenshot 2025-04-01 at 12 48 44 PM" src="https://github.com/user-attachments/assets/ba4e3a33-631a-4961-8338-fa9e6b21680f" />
