### PR TITLE
[RSDK-7085] - Set cooldown option for streaming err backoff

### DIFF
--- a/robot/web/stream/backoff.go
+++ b/robot/web/stream/backoff.go
@@ -30,7 +30,7 @@ type BackoffTuningOptions struct {
 
 // Dan: This fixes the backoff bugs where we'd overflow the sleep to a negative value. But this no
 // longer obeys the input tuning options. I'm considering that deprecated and to be removed.
-var backoffSleeps = []time.Duration{500 * time.Millisecond, time.Second, 2 * time.Second, 5 * time.Second, 10 * time.Second}
+var backoffSleeps = []time.Duration{500 * time.Millisecond, time.Second, 2 * time.Second, 5 * time.Second}
 
 // GetSleepTimeFromErrorCount returns a sleep time from an error count.
 func (opts *BackoffTuningOptions) GetSleepTimeFromErrorCount(errorCount int) time.Duration {

--- a/robot/web/stream/backoff.go
+++ b/robot/web/stream/backoff.go
@@ -30,7 +30,7 @@ type BackoffTuningOptions struct {
 
 // Dan: This fixes the backoff bugs where we'd overflow the sleep to a negative value. But this no
 // longer obeys the input tuning options. I'm considering that deprecated and to be removed.
-var backoffSleeps = []time.Duration{500 * time.Millisecond, time.Second, 2 * time.Second, 5 * time.Second}
+var backoffSleeps = []time.Duration{500 * time.Millisecond, time.Second, 2 * time.Second, 5 * time.Second, 10 * time.Second}
 
 // GetSleepTimeFromErrorCount returns a sleep time from an error count.
 func (opts *BackoffTuningOptions) GetSleepTimeFromErrorCount(errorCount int) time.Duration {

--- a/robot/web/stream/server.go
+++ b/robot/web/stream/server.go
@@ -30,6 +30,7 @@ import (
 const (
 	monitorCameraInterval = time.Second
 	retryDelay            = 50 * time.Millisecond
+	backoffCooldown       = 30 * time.Second
 )
 
 const (
@@ -753,7 +754,10 @@ func (server *Server) startStream(streamFunc func(opts *BackoffTuningOptions) er
 	utils.PanicCapturingGo(func() {
 		defer server.activeBackgroundWorkers.Done()
 		close(waitCh)
-		if err := streamFunc(&BackoffTuningOptions{}); err != nil {
+		opts := &BackoffTuningOptions{
+			Cooldown: backoffCooldown,
+		}
+		if err := streamFunc(opts); err != nil {
 			if utils.FilterOutError(err, context.Canceled) != nil {
 				server.logger.Errorw("error streaming", "error", err)
 			}


### PR DESCRIPTION
### Description

Currently, we are not setting the Cooldown backoff option. This means our backoff log throttle for livestreams has not been functional.

### Test

Tested with a fake camera with bursty error returns. The Image endpoint returns an error in the 8-10 second range with following logic:
```
	elapsed := int(time.Since(c.startTime).Seconds()) % 10
	if elapsed >= 8 && elapsed < 10 {
		return nil, nil, errors.New("fake camera read error")
	}
```

Upstream behavior without cooldown (essentially no backoff)
  - We get 10s of errors per minute, however, the errors are swallowed up decently well from the logger. See [here](https://github.com/viamrobotics/rdk/blob/main/logging/impl.go#L276).
  - No actual backoff, we continue to query Image endpoint even if the same error is returned multiple times in a row.

https://github.com/user-attachments/assets/b7336ee5-ef5b-46ac-b789-c6fcc7d08d88

PR branch with backoff and cooldown working
  - We no longer get `Message logged X times in the past X`.


https://github.com/user-attachments/assets/482bb2e0-fa18-4e0c-9562-9a45564eaf2b


