### PR TITLE
RSDK-10345 if motion planning fails before the goal after succeeding on waypoints motion should optionally return the partial path

### DIFF
--- a/motionplan/planManager.go
+++ b/motionplan/planManager.go
@@ -58,7 +58,7 @@ type atomicWaypoint struct {
 	mp         motionPlanner
 	startState *PlanState // A list of starting states, any of which would be valid to start from
 	goalState  *PlanState // A list of goal states, any of which would be valid to arrive at
-	origGoal bool // If partial plans are requested, only return up to the last explicit waypoint solved not automatically generated ones
+	origGoal   bool       // If partial plans are requested, only return up to the last explicit waypoint solved not automatically generated ones
 }
 
 // planMultiWaypoint plans a motion through multiple waypoints, using identical constraints for each
@@ -208,10 +208,10 @@ func (pm *planManager) planAtomicWaypoints(
 	// All goals have been submitted for solving. Reconstruct in order
 	resultSlices := []node{}
 	partialSlices := []node{}
-	
+
 	// Keep track of which user-requested waypoints were solved for
 	lastOrig := 0
-	
+
 	for i, future := range resultPromises {
 		steps, err := future.result()
 		if err != nil {
@@ -480,12 +480,12 @@ func (pm *planManager) plannerSetupFromMoveRequest(
 	}
 
 	if partial, ok := planningOpts["return_partial_plan"]; ok {
-		//~ fmt.Println("partial", partial)
+		// ~ fmt.Println("partial", partial)
 		if use, ok := partial.(bool); ok && use {
 			opt.ReturnPartialPlan = true
 		}
 	}
-	//~ fmt.Println("opt.ReturnPartialPlan", opt.ReturnPartialPlan)
+	// ~ fmt.Println("opt.ReturnPartialPlan", opt.ReturnPartialPlan)
 
 	collisionBufferMM := defaultCollisionBufferMM
 	collisionBufferMMRaw, ok := planningOpts["collision_buffer_mm"]

--- a/motionplan/plannerOptions.go
+++ b/motionplan/plannerOptions.go
@@ -172,6 +172,10 @@ type plannerOptions struct {
 	// Number of seeds to pre-generate for bidirectional position-only solving.
 	PositionSeeds int `json:"position_seeds"`
 
+	// If at least one intermediate waypoint is solved for, but the plan fails before reaching the ultimate goal,
+	// this will if true return the valid plan up to the last solved waypoint.
+	ReturnPartialPlan bool `json:"return_partial_plan"`
+
 	// poseDistanceFunc is the function that the planner will use to measure the degree of "closeness" between two poses
 	poseDistanceFunc ik.SegmentMetric
 

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -4,8 +4,9 @@ package builtin
 import (
 	"context"
 	"fmt"
-	"strings"
 	"strconv"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -4,6 +4,8 @@ package builtin
 import (
 	"context"
 	"fmt"
+	"strings"
+	"strconv"
 	"sync"
 	"time"
 
@@ -11,6 +13,9 @@ import (
 	"github.com/golang/geo/r3"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 	pb "go.viam.com/api/service/motion/v1"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -369,6 +374,14 @@ func (ms *builtIn) DoCommand(ctx context.Context, cmd map[string]interface{}) (m
 			}
 			moveReqProto.Extra = v
 		}
+		// Special handling: we want to observe the logs just for the DoCommand
+		oldLogger := ms.logger
+		obsLogger := oldLogger.Sublogger("observed")
+		observerCore, observedLogs := observer.New(zap.LevelEnablerFunc(zapcore.DebugLevel.Enabled))
+		obsLogger.AddAppender(observerCore)
+		ms.logger = obsLogger
+		defer func() { ms.logger = oldLogger }()
+
 		moveReq, err := motion.MoveReqFromProto(&moveReqProto)
 		if err != nil {
 			return nil, err
@@ -377,6 +390,26 @@ func (ms *builtIn) DoCommand(ctx context.Context, cmd map[string]interface{}) (m
 		if err != nil {
 			return nil, err
 		}
+		partialLogString := "returning partial plan up to waypoint "
+		partialLogs := observedLogs.FilterMessageSnippet(partialLogString).All()
+		if len(partialLogs) > 0 {
+			// Extract the waypoint number from the partial log
+			if len(partialLogs) == 1 {
+				logMsg := partialLogs[0].Message
+				// Find the waypoint number after the partial log string
+				waypointStr := strings.TrimPrefix(logMsg, partialLogString)
+				// Extract just the number
+				waypointNum, err := strconv.Atoi(strings.TrimSpace(strings.Split(waypointStr, " ")[0]))
+				if err == nil {
+					resp[DoPlan+"_partialwp"] = waypointNum
+				} else {
+					ms.logger.CDebugf(ctx, "error parsing log string: %s", logMsg)
+				}
+			} else {
+				ms.logger.CDebugf(ctx, "Unexpected number of partial logs: %d", len(partialLogs))
+			}
+		}
+
 		resp[DoPlan] = plan.Trajectory()
 	}
 	if req, ok := cmd[DoExecute]; ok {


### PR DESCRIPTION
Adds the ability to return a partial plan if `"return_partial_plan"` is passed via `Extra`.

Exclusive for a DoCommand preplan request, if a partial plan was indeed returned, this will populate the `"plan_partialwp"` field of the response with the index of the last successful waypoint.