### PR TITLE
RSDK-10376 Fix motion service file logging

### DIFF
--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -119,11 +119,8 @@ func (ms *builtIn) Reconfigure(
 		return err
 	}
 	if config.LogFilePath != "" {
-		logger, err := utils.NewFilePathDebugLogger(config.LogFilePath, "motion")
-		if err != nil {
-			return err
-		}
-		ms.logger = logger
+		fileAppender, _ := logging.NewFileAppender(config.LogFilePath)
+		ms.logger.AddAppender(fileAppender)
 	}
 	movementSensors := make(map[resource.Name]movementsensor.MovementSensor)
 	slamServices := make(map[resource.Name]slam.Service)


### PR DESCRIPTION
Tested and confirmed we still get logs to the specified file, while also no longer having the assorted issues we have also been encountering when using non-builtin motion services.