### PR TITLE
[RSDK-9823] - Add TestStreamMediaBehavior and logic to support it

### DIFF
--- a/robot/web/stream/server.go
+++ b/robot/web/stream/server.go
@@ -846,3 +846,12 @@ retryLoop:
 	}
 	return frame.Bounds().Dx(), frame.Bounds().Dy(), nil
 }
+
+// GetVideoSourceForTest returns the hot swappable video source for the given stream name.
+// This is intended for use in tests only.
+func (server *Server) GetVideoSourceForTest(name string) (gostream.HotSwappableVideoSource, bool) {
+	server.mu.RLock()
+	defer server.mu.RUnlock()
+	source, ok := server.videoSources[name]
+	return source, ok
+}

--- a/robot/web/stream/stream_test.go
+++ b/robot/web/stream/stream_test.go
@@ -711,8 +711,6 @@ func TestStreamMediaBehavior(t *testing.T) {
 		logger.Info("Performing robot reconfiguration...")
 		newCfg := origCfg
 		robot.Reconfigure(ctx, newCfg)
-		test.That(t, err, test.ShouldBeNil)
-
 		webSvc.Reconfigure(ctx, nil, resource.Config{})
 		logger.Info("Reconfiguration complete.")
 

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -110,6 +110,12 @@ type webService struct {
 	modPeerConnTracker *grpc.ModPeerConnTracker
 }
 
+// GetStreamServer returns the internal stream server instance. Used for testing.
+func (svc *webService) GetStreamServer() *webstream.Server {
+	// This might return nil if CGO is disabled or init failed, handle appropriately in tests.
+	return svc.streamServer
+}
+
 var internalWebServiceName = resource.NewName(
 	resource.APINamespaceRDKInternal.WithServiceType("web"),
 	"builtin",


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-9823

## Overview
Adds `TestStreamMediaBehavior` to check that calling `SetStreamOptions` actually changes the stream's resolution and that resetting it brings it back to the original state. Also confirms streams survive robot reconfigurations.

## Potential Issues Sean P brought up
- Couldn't put the test directly in the webstream package because of import cycles.
- Didn't want to add client-side H264 decoding just for the test (dependency headaches).

## Workarounds
Used the normal client APIs (`SetStreamOptions`, etc.) for the main flow.

### Workaround 1 (Package Cycle): 
Added a small interface (`streamServerGetter`) and helper methods (`GetStreamServer`, `GetVideoSourceForTest`) so the test (outside `webstream`) could peek at the server's video source properties after resize calls to confirm the internal change.

### Workaround 2 (Reset Check):
Checking the internal video source properties immediately after the reset swap is results in a race condition (showed old dimensions).
So, we first check the intended state by looking up the camera resource directly on the server (`robot.ResourceByName`).

After that, to confirm the stream output reverted without decoding video, we compare the final RTP packet payload size to the initial size recorded at the start. Since the resized streams use different encoding paths, matching the original packet size strongly indicates the stream reverted to the original passthrough format.