### PR TITLE
APP-8007 Set default for module readme link

### DIFF
--- a/cli/module_generate.go
+++ b/cli/module_generate.go
@@ -379,6 +379,7 @@ func populateAdditionalInfo(newModule *modulegen.ModuleInputs) {
 	modelTriple := fmt.Sprintf("%s:%s:%s", newModule.Namespace, newModule.ModuleName, newModule.ModelName)
 	newModule.ModelTriple = modelTriple
 	newModule.ModelReadmeLink = "README.md#" + generateAnchor(fmt.Sprintf("Model %s", modelTriple))
+	newModule.ModuleReadmeLink = "README.md"
 }
 
 // Creates a new directory with moduleName.


### PR DESCRIPTION
Actually sets a default for the meta.json markdown description, to the `README.md` when you run `viam module generate`

![image](https://github.com/user-attachments/assets/68832e9f-f6e7-4e96-aaef-347f767190da)
