### PR TITLE
RSDK-10410 - Add No TLS option

### DIFF
--- a/robot/web/options/options.go
+++ b/robot/web/options/options.go
@@ -69,6 +69,9 @@ type Options struct {
 	BakedAuthCreds  rpc.Credentials
 
 	DisableMulticastDNS bool
+
+	// If true, starts an insecure http server without TLS certificates even if one exists
+	NoTLS bool
 }
 
 // New returns a default set of options which will have the

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -388,7 +388,11 @@ func (svc *webService) runWeb(ctx context.Context, options weboptions.Options) (
 		return errors.Errorf("expected *net.TCPAddr but got %T", listener.Addr())
 	}
 
-	options.Secure = options.Network.TLSConfig != nil || options.Network.TLSCertFile != ""
+	if options.NoTLS {
+		options.Secure = false
+	} else {
+		options.Secure = options.Network.TLSConfig != nil || options.Network.TLSCertFile != ""
+	}
 	if options.SignalingAddress == "" && !options.Secure {
 		options.SignalingDialOpts = append(options.SignalingDialOpts, rpc.WithInsecure())
 	}

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -53,6 +53,7 @@ type Arguments struct {
 	DumpResourcesPath          string `flag:"dump-resources,usage=dump all resource registrations as json to the provided file path"`
 	EnableFTDC                 bool   `flag:"ftdc,default=true,usage=enable fulltime data capture for diagnostics"`
 	OutputLogFile              string `flag:"log-file,usage=write logs to a file with log rotation"`
+	NoTLS                      bool   `flag:"no-tls,usage=starts an insecure http server without TLS certificates even if one exists"`
 }
 
 type robotServer struct {
@@ -272,6 +273,7 @@ func (s *robotServer) createWebOptions(cfg *config.Config) (weboptions.Options, 
 	options.Debug = s.args.Debug || cfg.Debug
 	options.PreferWebRTC = s.args.WebRTC
 	options.DisableMulticastDNS = s.args.DisableMulticastDNS
+	options.NoTLS = s.args.NoTLS
 	if cfg.Cloud != nil && s.args.AllowInsecureCreds {
 		options.SignalingDialOpts = append(options.SignalingDialOpts, rpc.WithAllowInsecureWithCredentialsDowngrade())
 	}


### PR DESCRIPTION
tested the ts sdk vanilla end to end and it does work without internet

run rdk with `go run web/cmd/server/main.go -config <CONFIG> -no-tls`

however, the example has to be updated slightly

```
    machine = await VIAM.createRobotClient({
      host: HOST,
      credentials: {
        type: 'api-key',
        payload: API_KEY,
        authEntity: API_KEY_ID,
      },
      signalingAddress: `http://${HOST}.local:8080`,
      reconnectAbortSignal,
    });
```
cc: @stuqdog @ale7714 