### PR TITLE
APP-8020 fix clearCache on windows

### DIFF
--- a/config/reader.go
+++ b/config/reader.go
@@ -101,6 +101,9 @@ func readFromCache(id string) (*Config, error) {
 
 	if err := json.NewDecoder(r).Decode(unprocessedConfig); err != nil {
 		// clear the cache if we cannot parse the file.
+		if runtime.GOOS == "windows" {
+			utils.UncheckedErrorFunc(r.Close)
+		}
 		clearCache(id)
 		return nil, errors.Wrap(err, "cannot parse the cached config as json")
 	}


### PR DESCRIPTION
## What changed
- add `r.Close` call before `clearCache`
## Why
There are various scenarios where the cached json config gets corrupted, so we have a `clearCache` function in config/reader.go which deletes the cache after a json parse failure. This allows RDK to recover after a restart (if online).

On windows, the current setup gives a 'process cannot access the file because it is being used by another process' at debug level (from unchecked error function) inside clearCache.

This PR closes the file before deleting it.
## Reviewer notes
Please review the double-close pattern readFromCache + confirm that this is safe / best practice