### PR TITLE
Change default iterations to 1500

### DIFF
--- a/motionplan/rrt.go
+++ b/motionplan/rrt.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// Number of planner iterations before giving up.
-	defaultPlanIter = 3000
+	defaultPlanIter = 1500
 
 	// The maximum percent of a joints range of motion to allow per step.
 	defaultFrameStep = 0.01


### PR DESCRIPTION
This PR changes the default planner iterations for rrt* to 1500 instead of 3000.
