### PR TITLE
APP-8012 reading module markdown from root level README if not included in meta json

### DIFF
--- a/cli/module_generate.go
+++ b/cli/module_generate.go
@@ -379,7 +379,7 @@ func populateAdditionalInfo(newModule *modulegen.ModuleInputs) {
 	modelTriple := fmt.Sprintf("%s:%s:%s", newModule.Namespace, newModule.ModuleName, newModule.ModelName)
 	newModule.ModelTriple = modelTriple
 	newModule.ModelReadmeLink = "README.md#" + generateAnchor(fmt.Sprintf("Model %s", modelTriple))
-	newModule.ModuleReadmeLink = "README.md"
+	newModule.ModuleReadmeLink = defaultReadmeFilename
 }
 
 // Creates a new directory with moduleName.

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -461,6 +461,7 @@ func (c *viamClient) updateModule(moduleID moduleID, manifest moduleManifest) (*
 		markdownDocs = &content
 	} else {
 		warningf(os.Stderr, "Failed to read markdown content from %s: %v", markdownPath, err)
+		warningf(os.Stderr, "Please document your module with a README.md. You can configure meta.json to read documentation from a file path with the 'markdown_link' field.")
 	}
 	req := apppb.UpdateModuleRequest{
 		ModuleId:            moduleID.String(),

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -461,7 +461,8 @@ func (c *viamClient) updateModule(moduleID moduleID, manifest moduleManifest) (*
 		markdownDocs = &content
 	} else {
 		warningf(os.Stderr, "Failed to read markdown content from %s: %v", markdownPath, err)
-		warningf(os.Stderr, "Please document your module with a README.md. You can configure meta.json to read documentation from a file path with the 'markdown_link' field.")
+		warningf(os.Stderr, "Please document your module with a README.md. You can configure meta.json to read "+
+			"documentation from a file path with the 'markdown_link' field.")
 	}
 	req := apppb.UpdateModuleRequest{
 		ModuleId:            moduleID.String(),

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -451,13 +451,16 @@ func (c *viamClient) updateModule(moduleID moduleID, manifest moduleManifest) (*
 	}
 
 	var markdownDocs *string
-	// If a markdown link is provided, read the content
+	// Try to read markdown content from the specified link or default README
+	markdownPath := defaultReadmeFilename
 	if manifest.MarkdownLink != nil {
-		if content, err := getMarkdownContent(*manifest.MarkdownLink); err == nil {
-			markdownDocs = &content
-		} else {
-			warningf(os.Stderr, "Failed to read markdown content from %s: %v", *manifest.MarkdownLink, err)
-		}
+		markdownPath = *manifest.MarkdownLink
+	}
+
+	if content, err := getMarkdownContent(markdownPath); err == nil {
+		markdownDocs = &content
+	} else {
+		warningf(os.Stderr, "Failed to read markdown content from %s: %v", markdownPath, err)
 	}
 	req := apppb.UpdateModuleRequest{
 		ModuleId:            moduleID.String(),


### PR DESCRIPTION
Automatically looks for the top-level README.md if no `markdown_link` is included in `meta.json` and logs warnings if no README is found