### PR TITLE
run a subset of the test suite on windows in test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,7 +108,7 @@ jobs:
         GOFLAGS: "-tags=no_cgo"
       run:
         # note: this is a subset of tests that are known to pass on windows
-        go run gotest.tools/gotestsum --format standard-verbose ./module
+        go run gotest.tools/gotestsum --format standard-verbose --jsonfile json.log ./module
 
     - name: Upload test.json
       if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,17 @@ jobs:
           path: json.log
           retention-days: 30
 
+  test_win:
+    name: windows
+    runs-on: windows-2019
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
+    - name: test
+      # note: we are beginning with a subset of tests that are known to pass on windows
+      run: go test -tags no_cgo ./module
+
   test32:
     name: Go 32-bit Unit Tests
     runs-on: ubuntu-large-arm
@@ -139,7 +150,7 @@ jobs:
 
   test_passing:
     name: All Tests Passing
-    needs: [test_go, test32, motion_tests]
+    needs: [test_go, test32, motion_tests, test_win]
     runs-on: [ubuntu-latest]
     if: always()
     steps:
@@ -147,6 +158,7 @@ jobs:
         run: |
           echo Go Unit Tests: ${{ needs.test_go.result }}
           echo Go 32-bit Tests: ${{ needs.test32.result }}
+          echo Windows Tests: ${{ needs.test_win.result }}
           echo Motion Tests: ${{ needs.motion_tests.result }}
           [ "${{ needs.test_go.result }}" == "success" ] && \
           [ "${{ needs.test32.result }}" == "success" ] && \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,10 @@ jobs:
       with:
         go-version-file: go.mod
     - name: test
+      env:
+        # otherwise this gives a 'signal arrived during external code execution' error
+        # in runtime.cgocall for github.com/pion/mediadevices/pkg/driver/camera._Cfunc_listCamera
+        CGO_ENABLED: "0"
       # note: we are beginning with a subset of tests that are known to pass on windows
       run: go test -tags no_cgo ./module
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,10 +105,9 @@ jobs:
         # otherwise this gives a 'signal arrived during external code execution' error
         # in runtime.cgocall for github.com/pion/mediadevices/pkg/driver/camera._Cfunc_listCamera
         CGO_ENABLED: "0"
-
+      run:
         # note: this is a subset of tests that are known to pass on windows
-        TEST_TARGET: ./module
-      run: make test-go
+        go run gotest.tools/gotestsum --format standard-verbose ./module
 
     - name: Upload test.json
       if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,6 +97,9 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
     - name: test
       # note: we are beginning with a subset of tests that are known to pass on windows
       run: go test -tags no_cgo ./module

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,7 @@ jobs:
         # otherwise this gives a 'signal arrived during external code execution' error
         # in runtime.cgocall for github.com/pion/mediadevices/pkg/driver/camera._Cfunc_listCamera
         CGO_ENABLED: "0"
+        GOFLAGS: "-tags=no_cgo"
       run:
         # note: this is a subset of tests that are known to pass on windows
         go run gotest.tools/gotestsum --format standard-verbose ./module

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,8 +105,18 @@ jobs:
         # otherwise this gives a 'signal arrived during external code execution' error
         # in runtime.cgocall for github.com/pion/mediadevices/pkg/driver/camera._Cfunc_listCamera
         CGO_ENABLED: "0"
-      # note: we are beginning with a subset of tests that are known to pass on windows
-      run: go test -tags no_cgo ./module
+
+        # note: this is a subset of tests that are known to pass on windows
+        TEST_TARGET: ./module
+      run: make test-go
+
+    - name: Upload test.json
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-windows-amd64.json
+        path: json.log
+        retention-days: 30
 
   test32:
     name: Go 32-bit Unit Tests


### PR DESCRIPTION
## What changed
- add `windows` job to test.yml
## Why
Coverage on windows
## Green test run
- [x] https://github.com/viamrobotics/rdk/actions/runs/14453337446