### PR TITLE
APP-7945 support tilde in hot reloading

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -2811,7 +2811,7 @@ This won't work unless you have an existing installation of our GitHub app on yo
 						&cli.StringFlag{
 							Name:  moduleFlagHomeDir,
 							Usage: "remote user's home directory. only necessary if you're targeting a remote machine where $HOME is not /root",
-							Value: "~",
+							Value: "/root",
 						},
 					},
 					Action: createCommandWithT[reloadModuleArgs](ReloadModuleAction),

--- a/cli/app.go
+++ b/cli/app.go
@@ -2811,7 +2811,7 @@ This won't work unless you have an existing installation of our GitHub app on yo
 						&cli.StringFlag{
 							Name:  moduleFlagHomeDir,
 							Usage: "remote user's home directory. only necessary if you're targeting a remote machine where $HOME is not /root",
-							Value: "/root",
+							Value: "~",
 						},
 					},
 					Action: createCommandWithT[reloadModuleArgs](ReloadModuleAction),

--- a/robot/packages/local_package_manager.go
+++ b/robot/packages/local_package_manager.go
@@ -84,6 +84,10 @@ func (m *localManager) Close(ctx context.Context) error {
 
 // fileCopyHelper is the downloadCallback for local tarball modules.
 func (m *localManager) fileCopyHelper(ctx context.Context, path, dstPath string) (string, string, error) {
+	path, err := rUtils.ExpandHomeDir(path)
+	if err != nil {
+		return "", "", err
+	}
 	src, err := os.Open(path) //nolint:gosec
 	if err != nil {
 		return "", "", err
@@ -174,8 +178,8 @@ func (m *localManager) Sync(ctx context.Context, packages []config.PackageConfig
 
 		err = installPackage(ctx, m.logger, m.packagesDir, mod.ExePath, pkg, m.fileCopyHelper)
 		if err != nil {
-			m.logger.Errorf("Failed downloading package %s from %s, %s", mod.Name, mod.ExePath, err)
-			outErr = multierr.Append(outErr, errors.Wrapf(err, "failed downloading package %s from %s",
+			m.logger.Errorf("Failed copying package %s from %s, %s", mod.Name, mod.ExePath, err)
+			outErr = multierr.Append(outErr, errors.Wrapf(err, "failed copying package %s from %s",
 				mod.Name, mod.ExePath))
 			continue
 		}

--- a/utils/env.go
+++ b/utils/env.go
@@ -99,7 +99,7 @@ func PlatformHomeDir() string {
 	if runtime.GOOS == "android" {
 		return AndroidFilesDir
 	}
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == "windows" { //nolint:goconst
 		homedir, _ := os.UserHomeDir() //nolint:errcheck
 		if homedir != "" {
 			return homedir


### PR DESCRIPTION
## What changed
- ~when hot reloading from CLI, default `--home` to `~` instead of `/root`~ -> nope, postponing this, see below
- add `ExpandHomeDir` util with unit test
- use ExpandHomeDir in module EvaluateExePath, module validate, and the package manager's local file copy helper
## Why
Without this, there are ~5 potential values for `--home` in hot reloading, depending on OS and how viam is running (agent vs local mode).

We originally made this user-configurable bc it was simpler, but the hot reloading feature has spread to more users and more platforms so we are beefing it up.
## Manual testing
Did a hot reload on my system, it worked
## Follow-up work
After one stable release cycle, make `~` the default `--home` in the CLI reload command