### PR TITLE
RSDK-10495: Limit concurrent resource adding to batches of 10

### DIFF
--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -683,6 +683,8 @@ func (manager *resourceManager) completeConfig(
 		// we use an errgroup here instead of a normal waitgroup to conveniently bubble
 		// up errors in resource processing goroutinues that warrant an early exit.
 		var levelErrG errgroup.Group
+		// Add resources in batches instead of all at once. We've observed this to be more
+		// reliable when there are a large number of resources to add (e.g. hundreds).
 		levelErrG.SetLimit(10)
 		for _, resName := range resourceNames {
 			select {


### PR DESCRIPTION
On startup, limit to adding a maximum of 10 resources at a time, instead of unbounded. We've witnessed this to be more reliable when there are a high number of resources to add (e.g. hundreds).

Currently it's hardcoded to 10, but if needed, can be made to be adjustable.