### PR TITLE
APP-8080: Fixing RDK crash when processing logs with certain data types

### DIFF
--- a/logging/appender.go
+++ b/logging/appender.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -61,10 +62,23 @@ func NewFileAppender(filename string) (Appender, io.Closer) {
 
 // ZapcoreFieldsToJSON will serialize the Field objects into a JSON map of key/value pairs. It's
 // unclear what circumstances will result in an error being returned.
-func ZapcoreFieldsToJSON(fields []zapcore.Field) (string, error) {
+func ZapcoreFieldsToJSON(fields []zapcore.Field) (result string, err error) {
 	// Use zap's json encoder which will encode our slice of fields in-order. As opposed to the
 	// random iteration order of a map. Call it with an empty Entry object such that only the fields
 	// become "map-ified".
+	// The json encoder can panic if there is a mismatch between the value in zapcore.Field.Type and
+	// the data in the other fields, which happens in several cases as a result of proto serialization.
+	// We attempt to sanitize incoming data in FieldFromProto, but recover here in case something slips
+	// through to avoid crashing the entire goroutine.
+	defer func() {
+		if r := recover(); r != nil {
+			if perr, ok := r.(error); ok {
+				err = fmt.Errorf("panic serializing log fields: %w", perr)
+				return
+			}
+			err = fmt.Errorf("panic serializing log fields: %v", r)
+		}
+	}()
 	jsonEncoder := zapcore.NewJSONEncoder(zapcore.EncoderConfig{SkipLineEnding: true})
 	buf, err := jsonEncoder.EncodeEntry(zapcore.Entry{}, fields)
 	if err != nil {
@@ -94,9 +108,16 @@ func (appender ConsoleAppender) Write(entry zapcore.Entry, fields []zapcore.Fiel
 
 	fieldsJSON, err := ZapcoreFieldsToJSON(fields)
 	if err != nil {
-		fmt.Fprintln(appender.Writer, strings.Join(toPrint, "\t")) //nolint:errcheck
+		errJSON, err := json.Marshal(map[string]string{"logging_err": err.Error()})
+		if err != nil {
+			// This should never happen but append the raw sting as a last resort just in case.
+			toPrint = append(toPrint, err.Error())
+		} else {
+			toPrint = append(toPrint, string(errJSON))
+		}
+	} else {
+		toPrint = append(toPrint, fieldsJSON)
 	}
-	toPrint = append(toPrint, fieldsJSON)
 
 	fmt.Fprintln(appender.Writer, strings.Join(toPrint, "\t")) //nolint:errcheck
 	return nil


### PR DESCRIPTION
The server was crashing when modules sent logs containing certain types. This seems to be because zap enforces some invariants on `zap.Field` instances that we break when serializing them to protobuf. This PR:

1) Adds code to sanitize incoming log fields so they can be printed.
2) Adds a recover just above where we convert those fields into json to be printed so if we break zap again in the future we at least won't crash the entire server.