### PR TITLE
RSDK-10104 default to tcp sockets on old windows versions

### DIFF
--- a/utils/env.go
+++ b/utils/env.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"slices"
 	"strings"
 	"time"
 
@@ -115,14 +114,6 @@ func PlatformMkdirTemp(dir, pattern string) (string, error) {
 		dir = AndroidFilesDir
 	}
 	return os.MkdirTemp(dir, pattern)
-}
-
-// ViamTCPSockets returns true if an env is set or if the platform requires it.
-func ViamTCPSockets() bool {
-	// note: unix sockets have been supported on windows for a while, but go-grpc does not support them.
-	// 2017 support announcement: https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/
-	// go grpc client bug on win: https://github.com/dotnet/aspnetcore/issues/47043
-	return slices.Contains(EnvTrueValues, os.Getenv("VIAM_TCP_SOCKETS"))
 }
 
 // LogViamEnvVariables logs the list of viam environment variables in [os.Environ] along with the env passed in.

--- a/utils/env_posix.go
+++ b/utils/env_posix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package utils
+
+import (
+	"os"
+	"slices"
+)
+
+// ViamTCPSockets returns true if an env is set or if the platform requires it.
+func ViamTCPSockets() bool {
+	return slices.Contains(EnvTrueValues, os.Getenv("VIAM_TCP_SOCKETS"))
+}

--- a/utils/env_windows.go
+++ b/utils/env_windows.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"os"
+	"slices"
+
+	"golang.org/x/sys/windows"
+)
+
+// ViamTCPSockets returns true if an env is set or if the platform requires it.
+func ViamTCPSockets() bool {
+	// 2017 support announcement: https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/
+	defaultVal := false
+	if v := windows.RtlGetVersion(); v.BuildNumber != 0 && v.BuildNumber < 17063 {
+		defaultVal = true
+	}
+	envVal := os.Getenv("VIAM_TCP_SOCKETS")
+	if envVal == "" {
+		return defaultVal
+	}
+	// note: the control flow here means that any non-empty, non-truthy value is false.
+	return slices.Contains(EnvTrueValues, envVal)
+}


### PR DESCRIPTION
## What changed
- On windows systems older than build 17063, default VIAM_TCP_SOCKETS to true
- (but if a value is given for VIAM_TCP_SOCKETS, it will be respected)
## Why
AF_UNIX socket type was only added 8 years ago https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/
## Manual test
Confirmed via logs that this does the right thing on a recent version of windows:
> 4/25/2025, 3:44:32 PM info rdk.modmanager.awinter_stopper.StdOut   pexec/managed_process.go:297   \_ 2025-04-25T19:44:32.574Z INFO awinter_stopper client/client.go:437 successfully (re)connected to remote at address {"address":"unix:///Users/admin/AppData/Local/Temp/viam-module-3635204454/parent.sock"} 

^ the address is a socket as expected