### PR TITLE
RSDK-10603 Fix deadlock

### DIFF
--- a/motionplan/motionPlanner.go
+++ b/motionplan/motionPlanner.go
@@ -400,11 +400,17 @@ func (mp *planner) getSolutions(ctx context.Context, seed referenceframe.FrameSy
 	ctxWithCancel, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	solutionGen := make(chan *ik.Solution, mp.planOpts.NumThreads*2)
+	solutionGen := make(chan *ik.Solution, mp.planOpts.NumThreads*20)
 	ikErr := make(chan error, 1)
 	var activeSolvers sync.WaitGroup
 	defer activeSolvers.Wait()
 	activeSolvers.Add(1)
+	defer func(){
+		// In the case that we have an error, we need to explicitly drain the channel before we return
+		for len(solutionGen) > 0 {
+			<-solutionGen
+		}
+	}()
 
 	linearSeed, err := mp.lfs.mapToSlice(seed)
 	if err != nil {

--- a/motionplan/motionPlanner.go
+++ b/motionplan/motionPlanner.go
@@ -405,7 +405,7 @@ func (mp *planner) getSolutions(ctx context.Context, seed referenceframe.FrameSy
 	var activeSolvers sync.WaitGroup
 	defer activeSolvers.Wait()
 	activeSolvers.Add(1)
-	defer func(){
+	defer func() {
 		// In the case that we have an error, we need to explicitly drain the channel before we return
 		for len(solutionGen) > 0 {
 			<-solutionGen


### PR DESCRIPTION
In the case where validity checking of IK solutions takes longer than the actual generation of those solutions, the channel used to communicate solutions can fill up.

In these cases, in the case of a failed context, the individual solvers will wait on trying to write to the passed solver channel, causing an indefinite deadlock.

The quickest solution is to explicitly clear the channel in these cases. Additionally, as we do not want our IK workers to be idle, we should increase the size of our solution buffer.