### PR TITLE
[RSDK-10606] Allow for offline testing of go stubs generation

### DIFF
--- a/cli/module_generate/scripts/generate_stubs.go
+++ b/cli/module_generate/scripts/generate_stubs.go
@@ -28,6 +28,7 @@ var goTmpl string
 // typePrefixes lists possible prefixes before function parameter and return types.
 var typePrefixes = []string{"*", "[]*", "[]", "chan "}
 
+// CreateGetClientCodeRequest creates a request to get the client code of the specified resource type.
 var CreateGetClientCodeRequest = func(module modulegen.ModuleInputs) (*http.Request, error) {
 	url := fmt.Sprintf("https://raw.githubusercontent.com/viamrobotics/rdk/refs/tags/v%s/%ss/%s/client.go",
 		module.SDKVersion, module.ResourceType, module.ResourceSubtype)

--- a/cli/module_generate_test.go
+++ b/cli/module_generate_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,6 +16,7 @@ import (
 	"google.golang.org/grpc"
 
 	"go.viam.com/rdk/cli/module_generate/modulegen"
+	modgen "go.viam.com/rdk/cli/module_generate/scripts"
 	"go.viam.com/rdk/testutils/inject"
 )
 
@@ -141,6 +144,237 @@ func TestGenerateModuleAction(t *testing.T) {
 		testModule.Language = "go"
 		testModule.SDKVersion = "0.44.0"
 		setupDirectories(cCtx, testModule.ModuleName, globalArgs)
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			clientCode := `
+// Package arm contains a gRPC based arm client.
+package arm
+
+import (
+	"context"
+
+	commonpb "go.viam.com/api/common/v1"
+	pb "go.viam.com/api/component/arm/v1"
+	"go.viam.com/utils/protoutils"
+	"go.viam.com/utils/rpc"
+
+	"go.viam.com/rdk/logging"
+	rprotoutils "go.viam.com/rdk/protoutils"
+	"go.viam.com/rdk/referenceframe"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/spatialmath"
+)
+
+// client implements ArmServiceClient.
+type client struct {
+	resource.Named
+	resource.TriviallyReconfigurable
+	resource.TriviallyCloseable
+	name   string
+	client pb.ArmServiceClient
+	model  referenceframe.Model
+	logger logging.Logger
+}
+
+// NewClientFromConn constructs a new Client from connection passed in.
+func NewClientFromConn(
+	ctx context.Context,
+	conn rpc.ClientConn,
+	remoteName string,
+	name resource.Name,
+	logger logging.Logger,
+) (Arm, error) {
+	pbClient := pb.NewArmServiceClient(conn)
+	c := &client{
+		Named:  name.PrependRemote(remoteName).AsNamed(),
+		name:   name.ShortName(),
+		client: pbClient,
+		logger: logger,
+	}
+	clientFrame, err := c.updateKinematics(ctx, nil)
+	if err != nil {
+		logger.CWarnw(
+			ctx,
+			"error getting model for arm; making the assumption that joints are revolute and that their positions are specified in degrees",
+			"err",
+			err,
+		)
+	} else {
+		c.model = clientFrame
+	}
+	return c, nil
+}
+
+func (c *client) EndPosition(ctx context.Context, extra map[string]interface{}) (spatialmath.Pose, error) {
+	ext, err := protoutils.StructToStructPb(extra)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.client.GetEndPosition(ctx, &pb.GetEndPositionRequest{
+		Name:  c.name,
+		Extra: ext,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return spatialmath.NewPoseFromProtobuf(resp.Pose), nil
+}
+
+func (c *client) MoveToPosition(ctx context.Context, pose spatialmath.Pose, extra map[string]interface{}) error {
+	ext, err := protoutils.StructToStructPb(extra)
+	if err != nil {
+		return err
+	}
+	if pose == nil {
+		c.logger.Warnf("%s MoveToPosition: pose parameter is nil", c.name)
+	}
+	_, err = c.client.MoveToPosition(ctx, &pb.MoveToPositionRequest{
+		Name:  c.name,
+		To:    spatialmath.PoseToProtobuf(pose),
+		Extra: ext,
+	})
+	return err
+}
+
+func (c *client) MoveToJointPositions(ctx context.Context, positions []referenceframe.Input, extra map[string]interface{}) error {
+	ext, err := protoutils.StructToStructPb(extra)
+	if err != nil {
+		return err
+	}
+	jp, err := referenceframe.JointPositionsFromInputs(c.model, positions)
+	if err != nil {
+		return err
+	}
+	_, err = c.client.MoveToJointPositions(ctx, &pb.MoveToJointPositionsRequest{
+		Name:      c.name,
+		Positions: jp,
+		Extra:     ext,
+	})
+	return err
+}
+
+func (c *client) MoveThroughJointPositions(
+	ctx context.Context,
+	positions [][]referenceframe.Input,
+	options *MoveOptions,
+	extra map[string]interface{},
+) error {
+	ext, err := protoutils.StructToStructPb(extra)
+	if err != nil {
+		return err
+	}
+	if positions == nil {
+		c.logger.Warnf("%s MoveThroughJointPositions: position argument is nil", c.name)
+	}
+	allJPs := make([]*pb.JointPositions, 0, len(positions))
+	for _, position := range positions {
+		jp, err := referenceframe.JointPositionsFromInputs(c.model, position)
+		if err != nil {
+			return err
+		}
+		allJPs = append(allJPs, jp)
+	}
+	req := &pb.MoveThroughJointPositionsRequest{
+		Name:      c.name,
+		Positions: allJPs,
+		Extra:     ext,
+	}
+	if options != nil {
+		req.Options = options.toProtobuf()
+	}
+	_, err = c.client.MoveThroughJointPositions(ctx, req)
+	return err
+}
+
+func (c *client) JointPositions(ctx context.Context, extra map[string]interface{}) ([]referenceframe.Input, error) {
+	ext, err := protoutils.StructToStructPb(extra)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.client.GetJointPositions(ctx, &pb.GetJointPositionsRequest{
+		Name:  c.name,
+		Extra: ext,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return referenceframe.InputsFromJointPositions(c.model, resp.Positions)
+}
+
+func (c *client) Stop(ctx context.Context, extra map[string]interface{}) error {
+	ext, err := protoutils.StructToStructPb(extra)
+	if err != nil {
+		return err
+	}
+	_, err = c.client.Stop(ctx, &pb.StopRequest{
+		Name:  c.name,
+		Extra: ext,
+	})
+	return err
+}
+
+func (c *client) ModelFrame() referenceframe.Model {
+	return c.model
+}
+
+func (c *client) CurrentInputs(ctx context.Context) ([]referenceframe.Input, error) {
+	return c.JointPositions(ctx, nil)
+}
+
+func (c *client) GoToInputs(ctx context.Context, inputSteps ...[]referenceframe.Input) error {
+	return c.MoveThroughJointPositions(ctx, inputSteps, nil, nil)
+}
+
+func (c *client) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+	return rprotoutils.DoFromResourceClient(ctx, c.client, c.name, cmd)
+}
+
+func (c *client) IsMoving(ctx context.Context) (bool, error) {
+	resp, err := c.client.IsMoving(ctx, &pb.IsMovingRequest{Name: c.name})
+	if err != nil {
+		return false, err
+	}
+	return resp.IsMoving, nil
+}
+
+func (c *client) Geometries(ctx context.Context, extra map[string]interface{}) ([]spatialmath.Geometry, error) {
+	ext, err := protoutils.StructToStructPb(extra)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.client.GetGeometries(ctx, &commonpb.GetGeometriesRequest{
+		Name:  c.name,
+		Extra: ext,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return spatialmath.NewGeometriesFromProto(resp.GetGeometries())
+}
+
+func (c *client) updateKinematics(ctx context.Context, extra map[string]interface{}) (referenceframe.Model, error) {
+	ext, err := protoutils.StructToStructPb(extra)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.client.GetKinematics(ctx, &commonpb.GetKinematicsRequest{
+		Name:  c.name,
+		Extra: ext,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return parseKinematicsResponse(c.name, resp)
+}
+`
+			w.Write([]byte(clientCode))
+		}))
+		defer server.Close()
+
+		modgen.CreateGetClientCodeRequest = func(module modulegen.ModuleInputs) (*http.Request, error) {
+			return http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
+		}
 
 		err := generateGolangStubs(testModule)
 		test.That(t, err, test.ShouldBeNil)


### PR DESCRIPTION
The old system called github servers to download client code and generate stubs. The new system embeds a current version of the client code. Addresses [RSDK-10606](https://viam.atlassian.net/browse/RSDK-10606)

[RSDK-10606]: https://viam.atlassian.net/browse/RSDK-10606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ