### PR TITLE
in CLI reload command, default homedir to `~`

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -2790,7 +2790,7 @@ This won't work unless you have an existing installation of our GitHub app on yo
 						&cli.StringFlag{
 							Name:  moduleFlagHomeDir,
 							Usage: "remote user's home directory. only necessary if you're targeting a remote machine where $HOME is not /root",
-							Value: "/root",
+							Value: "~",
 						},
 					},
 					Action: createCommandWithT[reloadModuleArgs](ReloadModuleAction),


### PR DESCRIPTION
## What changed
Change the default `--home` value from `/root` to `~`.
## Why
Follow-up to #4931; that PR supports tilde on the server, this one forces it on the client.
## Checklist
- [x] Do not merge this until 97ff85b2 gets to stable. I want to allow a whole release cycle to minimize the number of people who have a new CLI + old RDK