### PR TITLE
fix failing step in 32-bit appimage build

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -6,6 +6,7 @@ on:
       release_type:
         required: true
         type: string
+        default: latest
   workflow_call:
     inputs:
       release_type:

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -134,7 +134,7 @@ jobs:
   # this job bundles the 32-bit appimage
   # note: this is a separate job because 1) appimage-builder doesn't work on 32-bit, 2) setup-python doesn't work on arm64
   appimage-32bit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: appimage-static-32bit
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -151,7 +151,7 @@ jobs:
       with:
         python-version: '3.11'
     - name: deps
-      run: pip install appimage-builder git+https://github.com/AppImageCrafters/appimage-builder.git@bf6123ee43715e52d2a73639f9acb1251e8af640
+      run: pip install git+https://github.com/AppImageCrafters/appimage-builder.git@bf6123ee43715e52d2a73639f9acb1251e8af640
     - name: build
       env:
         RELEASE_TYPE: ${{ inputs.release_type }}

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -18,7 +18,6 @@ on:
 
 jobs:
   appimage:
-    if: false
     name: AppImage Build
     strategy:
       fail-fast: false

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -151,7 +151,7 @@ jobs:
       with:
         python-version: '3.11'
     - name: deps
-      run: pip install appimage-builder git+https://github.com/AppImageCrafters/appimage-builder.git@42d32f11496de43a9f6a9ada7882a11296e357ca
+      run: pip install appimage-builder git+https://github.com/AppImageCrafters/appimage-builder.git@bf6123ee43715e52d2a73639f9acb1251e8af640
     - name: build
       env:
         RELEASE_TYPE: ${{ inputs.release_type }}

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   appimage:
+    if: false
     name: AppImage Build
     strategy:
       fail-fast: false
@@ -102,6 +103,7 @@ jobs:
 
   # this job builds the 32-bit RDK binary
   appimage-static-32bit:
+    if: false
     name: static 32-bit for appimage
     runs-on: ubuntu-small-arm
     steps:
@@ -134,16 +136,16 @@ jobs:
   # this job bundles the 32-bit appimage
   # note: this is a separate job because 1) appimage-builder doesn't work on 32-bit, 2) setup-python doesn't work on arm64
   appimage-32bit:
-    runs-on: ubuntu-22.04
-    needs: appimage-static-32bit
+    runs-on: ubuntu-latest
+    # needs: appimage-static-32bit
     steps:
     - uses: actions/checkout@v4
       with:
         ref: ${{ github.event == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
-    - uses: actions/download-artifact@v4
-      with:
-        name: appimage-static-32bit
-        path: bin/
+    # - uses: actions/download-artifact@v4
+    #   with:
+    #     name: appimage-static-32bit
+    #     path: bin/
     - uses: actions/setup-python@v4
       with:
         python-version: '3.11'

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -151,7 +151,7 @@ jobs:
       with:
         python-version: '3.11'
     - name: deps
-      run: pip install git+https://github.com/AppImageCrafters/appimage-builder.git@bf6123ee43715e52d2a73639f9acb1251e8af640
+      run: pip install git+https://github.com/AppImageCrafters/appimage-builder.git@42d32f11496de43a9f6a9ada7882a11296e357ca
     - name: build
       env:
         RELEASE_TYPE: ${{ inputs.release_type }}

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -104,7 +104,6 @@ jobs:
 
   # this job builds the 32-bit RDK binary
   appimage-static-32bit:
-    if: false
     name: static 32-bit for appimage
     runs-on: ubuntu-small-arm
     steps:
@@ -138,15 +137,15 @@ jobs:
   # note: this is a separate job because 1) appimage-builder doesn't work on 32-bit, 2) setup-python doesn't work on arm64
   appimage-32bit:
     runs-on: ubuntu-latest
-    # needs: appimage-static-32bit
+    needs: appimage-static-32bit
     steps:
     - uses: actions/checkout@v4
       with:
         ref: ${{ github.event == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
-    # - uses: actions/download-artifact@v4
-    #   with:
-    #     name: appimage-static-32bit
-    #     path: bin/
+    - uses: actions/download-artifact@v4
+      with:
+        name: appimage-static-32bit
+        path: bin/
     - uses: actions/setup-python@v4
       with:
         python-version: '3.11'


### PR DESCRIPTION
## What changed
- remove double `pip install` of appimage build on 32 bit appimage job
## Why
32 bit appimage builds started failing on main. (Example [here](https://github.com/viamrobotics/rdk/actions/runs/14759716922/job/41438555379)).

This has been broken since I originally wrote it (`pip install appimage-builder git+appimage-builder` pattern is installing it twice + leaving ambiguous which version ends up in charge). Not sure why it started failing suddenly, best guess is pip upgrades in the setup-python action. Could potentially confirm this by testing a range of pip versions.
## Manual test
- [x] https://github.com/viamrobotics/rdk/actions/runs/14760890666
## Follow-up work
- do we still need the appimage for 32-bit, or could we just have the static build?
- should we make 32-bit a no_cgo build rather than setting up a docker cross environment?