### PR TITLE
run cli.yml in PRs to protect against breakage

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -4,9 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       release_type:
-        required: true
-        type: string
         default: latest
+        required: true
+        type: choice
+        options: [latest, stable, pr]
   workflow_call:
     inputs:
       release_type:
@@ -55,10 +56,12 @@ jobs:
         GOOS=windows GOARCH=amd64 EXE_SUFFIX=.exe make cli-ci
 
     - name: Authorize GCP Upload
+      if: inputs.release_type != 'pr'
       uses: google-github-actions/auth@v1.1.1
       with:
         credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
     - name: upload
+      if: inputs.release_type != 'pr'
       uses: google-github-actions/upload-cloud-storage@v0.10.4
       with:
         headers: "cache-control: no-cache"

--- a/.github/workflows/pullrequest-trusted.yml
+++ b/.github/workflows/pullrequest-trusted.yml
@@ -80,3 +80,8 @@ jobs:
 
   license_finder:
     uses: viamrobotics/rdk/.github/workflows/license_finder.yml@main
+
+  cli:
+    uses: viamrobotics/rdk/.github/workflows/cli.yml@main
+    with:
+      release_type: pr


### PR DESCRIPTION
## What changed
- add a 'pr' release_type to cli.yml which doesn't upload to GCP
- call cli.yml from pullrequest-trusted.yml
## Why
To protect against breaking the CLI in PRs
## Test run
- [x] https://github.com/viamrobotics/rdk/actions/runs/14761719980