### PR TITLE
DATA-4091 Avoid sending TabularDataSourceTypeUnspecified

### DIFF
--- a/app/data_client.go
+++ b/app/data_client.go
@@ -541,13 +541,18 @@ func (d *DataClient) TabularDataByMQL(
 		opts.TabularDataSourceType = TabularDataSourceTypeHotStorage
 	}
 
+	var dataSource *pb.TabularDataSource
+	if opts.TabularDataSourceType != TabularDataSourceTypeUnspecified {
+		dataSource = &pb.TabularDataSource{
+			Type:       dataSourceTypeToProto(opts.TabularDataSourceType),
+			PipelineId: &opts.PipelineID,
+		}
+	}
+
 	resp, err := d.dataClient.TabularDataByMQL(ctx, &pb.TabularDataByMQLRequest{
 		OrganizationId: organizationID,
 		MqlBinary:      mqlBinary,
-		DataSource: &pb.TabularDataSource{
-			Type:       dataSourceTypeToProto(opts.TabularDataSourceType),
-			PipelineId: &opts.PipelineID,
-		},
+		DataSource:     dataSource,
 	})
 	if err != nil {
 		return nil, err

--- a/app/data_client_test.go
+++ b/app/data_client_test.go
@@ -404,6 +404,9 @@ func TestDataClient(t *testing.T) {
 		) (*pb.TabularDataByMQLResponse, error) {
 			test.That(t, in.OrganizationId, test.ShouldEqual, organizationID)
 			test.That(t, in.MqlBinary, test.ShouldResemble, mqlBinary)
+			if in.DataSource != nil {
+				test.That(t, in.DataSource.Type, test.ShouldNotEqual, pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_UNSPECIFIED)
+			}
 			return &pb.TabularDataByMQLResponse{
 				RawData: expectedRawDataPb,
 			}, nil


### PR DESCRIPTION
TabularDataSourceTypeUnspecified is never an intended behavior - if data
source options were unspecified, should send an empty DataSource field
(and App will apply default behavior).
