### PR TITLE
DATA-4090 - Log FailedToReadErrs at warning level rather than error

### DIFF
--- a/components/arm/collectors.go
+++ b/components/arm/collectors.go
@@ -48,7 +48,7 @@ func newEndPositionCollector(resource interface{}, params data.CollectorParams) 
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.NewFailedToReadErr(params.ComponentName, endPosition.String(), err)
+			return res, data.NewFailedToReadError(params.ComponentName, endPosition.String(), err)
 		}
 		o := v.Orientation().OrientationVectorDegrees()
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
@@ -85,11 +85,11 @@ func newJointPositionsCollector(resource interface{}, params data.CollectorParam
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.NewFailedToReadErr(params.ComponentName, jointPositions.String(), err)
+			return res, data.NewFailedToReadError(params.ComponentName, jointPositions.String(), err)
 		}
 		jp, err := referenceframe.JointPositionsFromInputs(arm.ModelFrame(), v)
 		if err != nil {
-			return res, data.NewFailedToReadErr(params.ComponentName, jointPositions.String(), err)
+			return res, data.NewFailedToReadError(params.ComponentName, jointPositions.String(), err)
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
 		return data.NewTabularCaptureResult(ts, pb.GetJointPositionsResponse{Positions: jp})

--- a/components/arm/collectors.go
+++ b/components/arm/collectors.go
@@ -48,7 +48,7 @@ func newEndPositionCollector(resource interface{}, params data.CollectorParams) 
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.FailedToReadErr(params.ComponentName, endPosition.String(), err)
+			return res, data.NewFailedToReadErr(params.ComponentName, endPosition.String(), err)
 		}
 		o := v.Orientation().OrientationVectorDegrees()
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
@@ -85,11 +85,11 @@ func newJointPositionsCollector(resource interface{}, params data.CollectorParam
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.FailedToReadErr(params.ComponentName, jointPositions.String(), err)
+			return res, data.NewFailedToReadErr(params.ComponentName, jointPositions.String(), err)
 		}
 		jp, err := referenceframe.JointPositionsFromInputs(arm.ModelFrame(), v)
 		if err != nil {
-			return res, data.FailedToReadErr(params.ComponentName, jointPositions.String(), err)
+			return res, data.NewFailedToReadErr(params.ComponentName, jointPositions.String(), err)
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
 		return data.NewTabularCaptureResult(ts, pb.GetJointPositionsResponse{Positions: jp})

--- a/components/board/collectors.go
+++ b/components/board/collectors.go
@@ -45,7 +45,7 @@ func newAnalogCollector(resource interface{}, params data.CollectorParams) (data
 		var res data.CaptureResult
 		var analogValue AnalogValue
 		if _, ok := arg[analogReaderNameKey]; !ok {
-			return res, data.FailedToReadErr(params.ComponentName, analogs.String(),
+			return res, data.NewFailedToReadErr(params.ComponentName, analogs.String(),
 				errors.New("Must supply reader_name in additional_params for analog collector"))
 		}
 		if reader, err := board.AnalogByName(arg[analogReaderNameKey].String()); err == nil {
@@ -56,7 +56,7 @@ func newAnalogCollector(resource interface{}, params data.CollectorParams) (data
 				if errors.Is(err, data.ErrNoCaptureToStore) {
 					return res, err
 				}
-				return res, data.FailedToReadErr(params.ComponentName, analogs.String(), err)
+				return res, data.NewFailedToReadErr(params.ComponentName, analogs.String(), err)
 			}
 		}
 
@@ -84,7 +84,7 @@ func newGPIOCollector(resource interface{}, params data.CollectorParams) (data.C
 		var res data.CaptureResult
 		var value bool
 		if _, ok := arg[gpioPinNameKey]; !ok {
-			return res, data.FailedToReadErr(params.ComponentName, gpios.String(),
+			return res, data.NewFailedToReadErr(params.ComponentName, gpios.String(),
 				errors.New("Must supply pin_name in additional params for gpio collector"))
 		}
 		if gpio, err := board.GPIOPinByName(arg[gpioPinNameKey].String()); err == nil {
@@ -95,7 +95,7 @@ func newGPIOCollector(resource interface{}, params data.CollectorParams) (data.C
 				if errors.Is(err, data.ErrNoCaptureToStore) {
 					return res, err
 				}
-				return res, data.FailedToReadErr(params.ComponentName, gpios.String(), err)
+				return res, data.NewFailedToReadErr(params.ComponentName, gpios.String(), err)
 			}
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}

--- a/components/board/collectors.go
+++ b/components/board/collectors.go
@@ -45,7 +45,7 @@ func newAnalogCollector(resource interface{}, params data.CollectorParams) (data
 		var res data.CaptureResult
 		var analogValue AnalogValue
 		if _, ok := arg[analogReaderNameKey]; !ok {
-			return res, data.NewFailedToReadErr(params.ComponentName, analogs.String(),
+			return res, data.NewFailedToReadError(params.ComponentName, analogs.String(),
 				errors.New("Must supply reader_name in additional_params for analog collector"))
 		}
 		if reader, err := board.AnalogByName(arg[analogReaderNameKey].String()); err == nil {
@@ -56,7 +56,7 @@ func newAnalogCollector(resource interface{}, params data.CollectorParams) (data
 				if errors.Is(err, data.ErrNoCaptureToStore) {
 					return res, err
 				}
-				return res, data.NewFailedToReadErr(params.ComponentName, analogs.String(), err)
+				return res, data.NewFailedToReadError(params.ComponentName, analogs.String(), err)
 			}
 		}
 
@@ -84,7 +84,7 @@ func newGPIOCollector(resource interface{}, params data.CollectorParams) (data.C
 		var res data.CaptureResult
 		var value bool
 		if _, ok := arg[gpioPinNameKey]; !ok {
-			return res, data.NewFailedToReadErr(params.ComponentName, gpios.String(),
+			return res, data.NewFailedToReadError(params.ComponentName, gpios.String(),
 				errors.New("Must supply pin_name in additional params for gpio collector"))
 		}
 		if gpio, err := board.GPIOPinByName(arg[gpioPinNameKey].String()); err == nil {
@@ -95,7 +95,7 @@ func newGPIOCollector(resource interface{}, params data.CollectorParams) (data.C
 				if errors.Is(err, data.ErrNoCaptureToStore) {
 					return res, err
 				}
-				return res, data.NewFailedToReadErr(params.ComponentName, gpios.String(), err)
+				return res, data.NewFailedToReadError(params.ComponentName, gpios.String(), err)
 			}
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}

--- a/components/camera/collectors.go
+++ b/components/camera/collectors.go
@@ -55,7 +55,7 @@ func newNextPointCloudCollector(resource interface{}, params data.CollectorParam
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.FailedToReadErr(params.ComponentName, nextPointCloud.String(), err)
+			return res, data.NewFailedToReadErr(params.ComponentName, nextPointCloud.String(), err)
 		}
 		bytes, err := pointcloud.ToBytes(pc)
 		if err != nil {
@@ -108,7 +108,7 @@ func newReadImageCollector(resource interface{}, params data.CollectorParams) (d
 				return res, err
 			}
 
-			return res, data.FailedToReadErr(params.ComponentName, readImage.String(), err)
+			return res, data.NewFailedToReadErr(params.ComponentName, readImage.String(), err)
 		}
 
 		mimeType := data.CameraFormatToMimeType(utils.MimeTypeToFormat[metadata.MimeType])
@@ -140,7 +140,7 @@ func newGetImagesCollector(resource interface{}, params data.CollectorParams) (d
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.FailedToReadErr(params.ComponentName, getImages.String(), err)
+			return res, data.NewFailedToReadErr(params.ComponentName, getImages.String(), err)
 		}
 
 		var binaries []data.Binary

--- a/components/camera/collectors.go
+++ b/components/camera/collectors.go
@@ -55,7 +55,7 @@ func newNextPointCloudCollector(resource interface{}, params data.CollectorParam
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.NewFailedToReadErr(params.ComponentName, nextPointCloud.String(), err)
+			return res, data.NewFailedToReadError(params.ComponentName, nextPointCloud.String(), err)
 		}
 		bytes, err := pointcloud.ToBytes(pc)
 		if err != nil {
@@ -108,7 +108,7 @@ func newReadImageCollector(resource interface{}, params data.CollectorParams) (d
 				return res, err
 			}
 
-			return res, data.NewFailedToReadErr(params.ComponentName, readImage.String(), err)
+			return res, data.NewFailedToReadError(params.ComponentName, readImage.String(), err)
 		}
 
 		mimeType := data.CameraFormatToMimeType(utils.MimeTypeToFormat[metadata.MimeType])
@@ -140,7 +140,7 @@ func newGetImagesCollector(resource interface{}, params data.CollectorParams) (d
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.NewFailedToReadErr(params.ComponentName, getImages.String(), err)
+			return res, data.NewFailedToReadError(params.ComponentName, getImages.String(), err)
 		}
 
 		var binaries []data.Binary

--- a/components/encoder/collectors.go
+++ b/components/encoder/collectors.go
@@ -42,7 +42,7 @@ func newTicksCountCollector(resource interface{}, params data.CollectorParams) (
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.NewFailedToReadErr(params.ComponentName, ticksCount.String(), err)
+			return res, data.NewFailedToReadError(params.ComponentName, ticksCount.String(), err)
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
 		return data.NewTabularCaptureResult(ts, pb.GetPositionResponse{

--- a/components/encoder/collectors.go
+++ b/components/encoder/collectors.go
@@ -42,7 +42,7 @@ func newTicksCountCollector(resource interface{}, params data.CollectorParams) (
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.FailedToReadErr(params.ComponentName, ticksCount.String(), err)
+			return res, data.NewFailedToReadErr(params.ComponentName, ticksCount.String(), err)
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
 		return data.NewTabularCaptureResult(ts, pb.GetPositionResponse{

--- a/components/gantry/collectors.go
+++ b/components/gantry/collectors.go
@@ -48,7 +48,7 @@ func newPositionCollector(resource interface{}, params data.CollectorParams) (da
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.FailedToReadErr(params.ComponentName, position.String(), err)
+			return res, data.NewFailedToReadErr(params.ComponentName, position.String(), err)
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
 		return data.NewTabularCaptureResult(ts, pb.GetPositionResponse{
@@ -78,7 +78,7 @@ func newLengthsCollector(resource interface{}, params data.CollectorParams) (dat
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.FailedToReadErr(params.ComponentName, lengths.String(), err)
+			return res, data.NewFailedToReadErr(params.ComponentName, lengths.String(), err)
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
 		return data.NewTabularCaptureResult(ts, pb.GetLengthsResponse{

--- a/components/gantry/collectors.go
+++ b/components/gantry/collectors.go
@@ -48,7 +48,7 @@ func newPositionCollector(resource interface{}, params data.CollectorParams) (da
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.NewFailedToReadErr(params.ComponentName, position.String(), err)
+			return res, data.NewFailedToReadError(params.ComponentName, position.String(), err)
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
 		return data.NewTabularCaptureResult(ts, pb.GetPositionResponse{
@@ -78,7 +78,7 @@ func newLengthsCollector(resource interface{}, params data.CollectorParams) (dat
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.NewFailedToReadErr(params.ComponentName, lengths.String(), err)
+			return res, data.NewFailedToReadError(params.ComponentName, lengths.String(), err)
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
 		return data.NewTabularCaptureResult(ts, pb.GetLengthsResponse{

--- a/components/motor/collectors.go
+++ b/components/motor/collectors.go
@@ -46,7 +46,7 @@ func newPositionCollector(resource interface{}, params data.CollectorParams) (da
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.FailedToReadErr(params.ComponentName, position.String(), err)
+			return res, data.NewFailedToReadErr(params.ComponentName, position.String(), err)
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
 		return data.NewTabularCaptureResult(ts, pb.GetPositionResponse{
@@ -74,7 +74,7 @@ func newIsPoweredCollector(resource interface{}, params data.CollectorParams) (d
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.FailedToReadErr(params.ComponentName, isPowered.String(), err)
+			return res, data.NewFailedToReadErr(params.ComponentName, isPowered.String(), err)
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
 		return data.NewTabularCaptureResult(ts, pb.IsPoweredResponse{

--- a/components/motor/collectors.go
+++ b/components/motor/collectors.go
@@ -46,7 +46,7 @@ func newPositionCollector(resource interface{}, params data.CollectorParams) (da
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.NewFailedToReadErr(params.ComponentName, position.String(), err)
+			return res, data.NewFailedToReadError(params.ComponentName, position.String(), err)
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
 		return data.NewTabularCaptureResult(ts, pb.GetPositionResponse{
@@ -74,7 +74,7 @@ func newIsPoweredCollector(resource interface{}, params data.CollectorParams) (d
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.NewFailedToReadErr(params.ComponentName, isPowered.String(), err)
+			return res, data.NewFailedToReadError(params.ComponentName, isPowered.String(), err)
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
 		return data.NewTabularCaptureResult(ts, pb.IsPoweredResponse{

--- a/components/movementsensor/collectors.go
+++ b/components/movementsensor/collectors.go
@@ -73,7 +73,7 @@ func newLinearVelocityCollector(resource interface{}, params data.CollectorParam
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.NewFailedToReadErr(params.ComponentName, position.String(), err)
+			return res, data.NewFailedToReadError(params.ComponentName, position.String(), err)
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
 		return data.NewTabularCaptureResult(ts, pb.GetLinearVelocityResponse{
@@ -105,7 +105,7 @@ func newPositionCollector(resource interface{}, params data.CollectorParams) (da
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.NewFailedToReadErr(params.ComponentName, linearVelocity.String(), err)
+			return res, data.NewFailedToReadError(params.ComponentName, linearVelocity.String(), err)
 		}
 		var lat, lng float64
 		if pos != nil {
@@ -144,7 +144,7 @@ func newAngularVelocityCollector(resource interface{}, params data.CollectorPara
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.NewFailedToReadErr(params.ComponentName, angularVelocity.String(), err)
+			return res, data.NewFailedToReadError(params.ComponentName, angularVelocity.String(), err)
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
 		return data.NewTabularCaptureResult(ts, pb.GetAngularVelocityResponse{
@@ -176,7 +176,7 @@ func newCompassHeadingCollector(resource interface{}, params data.CollectorParam
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.NewFailedToReadErr(params.ComponentName, compassHeading.String(), err)
+			return res, data.NewFailedToReadError(params.ComponentName, compassHeading.String(), err)
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
 		return data.NewTabularCaptureResult(ts, pb.GetCompassHeadingResponse{
@@ -206,7 +206,7 @@ func newLinearAccelerationCollector(resource interface{}, params data.CollectorP
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.NewFailedToReadErr(params.ComponentName, linearAcceleration.String(), err)
+			return res, data.NewFailedToReadError(params.ComponentName, linearAcceleration.String(), err)
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
 		return data.NewTabularCaptureResult(ts, pb.GetLinearAccelerationResponse{
@@ -238,7 +238,7 @@ func newOrientationCollector(resource interface{}, params data.CollectorParams) 
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.NewFailedToReadErr(params.ComponentName, orientation.String(), err)
+			return res, data.NewFailedToReadError(params.ComponentName, orientation.String(), err)
 		}
 		var orientVector *spatialmath.OrientationVectorDegrees
 		if orient != nil {
@@ -275,7 +275,7 @@ func newReadingsCollector(resource interface{}, params data.CollectorParams) (da
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.NewFailedToReadErr(params.ComponentName, readings.String(), err)
+			return res, data.NewFailedToReadError(params.ComponentName, readings.String(), err)
 		}
 
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}

--- a/components/movementsensor/collectors.go
+++ b/components/movementsensor/collectors.go
@@ -73,7 +73,7 @@ func newLinearVelocityCollector(resource interface{}, params data.CollectorParam
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.FailedToReadErr(params.ComponentName, position.String(), err)
+			return res, data.NewFailedToReadErr(params.ComponentName, position.String(), err)
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
 		return data.NewTabularCaptureResult(ts, pb.GetLinearVelocityResponse{
@@ -105,7 +105,7 @@ func newPositionCollector(resource interface{}, params data.CollectorParams) (da
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.FailedToReadErr(params.ComponentName, linearVelocity.String(), err)
+			return res, data.NewFailedToReadErr(params.ComponentName, linearVelocity.String(), err)
 		}
 		var lat, lng float64
 		if pos != nil {
@@ -144,7 +144,7 @@ func newAngularVelocityCollector(resource interface{}, params data.CollectorPara
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.FailedToReadErr(params.ComponentName, angularVelocity.String(), err)
+			return res, data.NewFailedToReadErr(params.ComponentName, angularVelocity.String(), err)
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
 		return data.NewTabularCaptureResult(ts, pb.GetAngularVelocityResponse{
@@ -176,7 +176,7 @@ func newCompassHeadingCollector(resource interface{}, params data.CollectorParam
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.FailedToReadErr(params.ComponentName, compassHeading.String(), err)
+			return res, data.NewFailedToReadErr(params.ComponentName, compassHeading.String(), err)
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
 		return data.NewTabularCaptureResult(ts, pb.GetCompassHeadingResponse{
@@ -206,7 +206,7 @@ func newLinearAccelerationCollector(resource interface{}, params data.CollectorP
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.FailedToReadErr(params.ComponentName, linearAcceleration.String(), err)
+			return res, data.NewFailedToReadErr(params.ComponentName, linearAcceleration.String(), err)
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
 		return data.NewTabularCaptureResult(ts, pb.GetLinearAccelerationResponse{
@@ -238,7 +238,7 @@ func newOrientationCollector(resource interface{}, params data.CollectorParams) 
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.FailedToReadErr(params.ComponentName, orientation.String(), err)
+			return res, data.NewFailedToReadErr(params.ComponentName, orientation.String(), err)
 		}
 		var orientVector *spatialmath.OrientationVectorDegrees
 		if orient != nil {
@@ -275,7 +275,7 @@ func newReadingsCollector(resource interface{}, params data.CollectorParams) (da
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.FailedToReadErr(params.ComponentName, readings.String(), err)
+			return res, data.NewFailedToReadErr(params.ComponentName, readings.String(), err)
 		}
 
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}

--- a/components/powersensor/collectors.go
+++ b/components/powersensor/collectors.go
@@ -62,7 +62,7 @@ func newVoltageCollector(resource interface{}, params data.CollectorParams) (dat
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.FailedToReadErr(params.ComponentName, voltage.String(), err)
+			return res, data.NewFailedToReadErr(params.ComponentName, voltage.String(), err)
 		}
 
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
@@ -94,7 +94,7 @@ func newCurrentCollector(resource interface{}, params data.CollectorParams) (dat
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.FailedToReadErr(params.ComponentName, current.String(), err)
+			return res, data.NewFailedToReadErr(params.ComponentName, current.String(), err)
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
 		return data.NewTabularCaptureResult(ts, pb.GetCurrentResponse{
@@ -123,7 +123,7 @@ func newPowerCollector(resource interface{}, params data.CollectorParams) (data.
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.FailedToReadErr(params.ComponentName, power.String(), err)
+			return res, data.NewFailedToReadErr(params.ComponentName, power.String(), err)
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
 		return data.NewTabularCaptureResult(ts, pb.GetPowerResponse{
@@ -151,7 +151,7 @@ func newReadingsCollector(resource interface{}, params data.CollectorParams) (da
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.FailedToReadErr(params.ComponentName, readings.String(), err)
+			return res, data.NewFailedToReadErr(params.ComponentName, readings.String(), err)
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
 		return data.NewTabularCaptureResultReadings(ts, values)

--- a/components/powersensor/collectors.go
+++ b/components/powersensor/collectors.go
@@ -62,7 +62,7 @@ func newVoltageCollector(resource interface{}, params data.CollectorParams) (dat
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.NewFailedToReadErr(params.ComponentName, voltage.String(), err)
+			return res, data.NewFailedToReadError(params.ComponentName, voltage.String(), err)
 		}
 
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
@@ -94,7 +94,7 @@ func newCurrentCollector(resource interface{}, params data.CollectorParams) (dat
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.NewFailedToReadErr(params.ComponentName, current.String(), err)
+			return res, data.NewFailedToReadError(params.ComponentName, current.String(), err)
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
 		return data.NewTabularCaptureResult(ts, pb.GetCurrentResponse{
@@ -123,7 +123,7 @@ func newPowerCollector(resource interface{}, params data.CollectorParams) (data.
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.NewFailedToReadErr(params.ComponentName, power.String(), err)
+			return res, data.NewFailedToReadError(params.ComponentName, power.String(), err)
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
 		return data.NewTabularCaptureResult(ts, pb.GetPowerResponse{
@@ -151,7 +151,7 @@ func newReadingsCollector(resource interface{}, params data.CollectorParams) (da
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.NewFailedToReadErr(params.ComponentName, readings.String(), err)
+			return res, data.NewFailedToReadError(params.ComponentName, readings.String(), err)
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
 		return data.NewTabularCaptureResultReadings(ts, values)

--- a/components/sensor/collectors.go
+++ b/components/sensor/collectors.go
@@ -41,7 +41,7 @@ func newReadingsCollector(resource interface{}, params data.CollectorParams) (da
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.FailedToReadErr(params.ComponentName, readings.String(), err)
+			return res, data.NewFailedToReadErr(params.ComponentName, readings.String(), err)
 		}
 
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}

--- a/components/sensor/collectors.go
+++ b/components/sensor/collectors.go
@@ -41,7 +41,7 @@ func newReadingsCollector(resource interface{}, params data.CollectorParams) (da
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.NewFailedToReadErr(params.ComponentName, readings.String(), err)
+			return res, data.NewFailedToReadError(params.ComponentName, readings.String(), err)
 		}
 
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}

--- a/components/servo/collectors.go
+++ b/components/servo/collectors.go
@@ -42,7 +42,7 @@ func newPositionCollector(resource interface{}, params data.CollectorParams) (da
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.NewFailedToReadErr(params.ComponentName, position.String(), err)
+			return res, data.NewFailedToReadError(params.ComponentName, position.String(), err)
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
 		return data.NewTabularCaptureResult(ts, pb.GetPositionResponse{

--- a/components/servo/collectors.go
+++ b/components/servo/collectors.go
@@ -42,7 +42,7 @@ func newPositionCollector(resource interface{}, params data.CollectorParams) (da
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.FailedToReadErr(params.ComponentName, position.String(), err)
+			return res, data.NewFailedToReadErr(params.ComponentName, position.String(), err)
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
 		return data.NewTabularCaptureResult(ts, pb.GetPositionResponse{

--- a/data/collector.go
+++ b/data/collector.go
@@ -361,8 +361,8 @@ func (c *collector) logCaptureErrs() {
 		}
 		// Only log a specific error message if we haven't logged it in the past 2 seconds.
 		if lastLogged, ok := c.lastLoggedErrors[err.Error()]; (ok && int(now-lastLogged) > identicalErrorLogFrequencyHz) || !ok {
-			var failedToReadErr *FailedToReadErr
-			if errors.As(err, &failedToReadErr) {
+			var failedToReadError *FailedToReadError
+			if errors.As(err, &failedToReadError) {
 				c.logger.Warn(err)
 			} else {
 				c.logger.Error((err))
@@ -378,26 +378,26 @@ func InvalidInterfaceErr(api resource.API) error {
 	return errors.Errorf("passed interface does not conform to expected resource type %s", api)
 }
 
-// NewFailedToReadErr constructs a new FailedToReadErr.
-func NewFailedToReadErr(component, method string, err error) error {
-	return &FailedToReadErr{
+// NewFailedToReadError constructs a new FailedToReadError.
+func NewFailedToReadError(component, method string, err error) error {
+	return &FailedToReadError{
 		Component: component,
 		Method:    method,
 		Err:       err,
 	}
 }
 
-// FailedToReadErr is the error describing when a Capturer was unable to get the reading of a method.
-type FailedToReadErr struct {
+// FailedToReadError is the error describing when a Capturer was unable to get the reading of a method.
+type FailedToReadError struct {
 	Component string
 	Method    string
 	Err       error
 }
 
-func (e *FailedToReadErr) Error() string {
+func (e *FailedToReadError) Error() string {
 	return fmt.Sprintf("failed to get reading of method %s of component %s: %v", e.Method, e.Component, e.Err)
 }
 
-func (e *FailedToReadErr) Unwrap() error {
+func (e *FailedToReadError) Unwrap() error {
 	return e.Err
 }

--- a/services/slam/collectors.go
+++ b/services/slam/collectors.go
@@ -39,7 +39,7 @@ func newPositionCollector(resource interface{}, params data.CollectorParams) (da
 		var res data.CaptureResult
 		pose, err := slam.Position(ctx)
 		if err != nil {
-			return res, data.NewFailedToReadErr(params.ComponentName, position.String(), err)
+			return res, data.NewFailedToReadError(params.ComponentName, position.String(), err)
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
 		return data.NewTabularCaptureResult(ts, &pb.GetPositionResponse{Pose: spatialmath.PoseToProtobuf(pose)})
@@ -59,12 +59,12 @@ func newPointCloudMapCollector(resource interface{}, params data.CollectorParams
 		// edited maps do not need to be captured because they should not be modified
 		f, err := slam.PointCloudMap(ctx, false)
 		if err != nil {
-			return res, data.NewFailedToReadErr(params.ComponentName, pointCloudMap.String(), err)
+			return res, data.NewFailedToReadError(params.ComponentName, pointCloudMap.String(), err)
 		}
 
 		pcd, err := HelperConcatenateChunksToFull(f)
 		if err != nil {
-			return res, data.NewFailedToReadErr(params.ComponentName, pointCloudMap.String(), err)
+			return res, data.NewFailedToReadError(params.ComponentName, pointCloudMap.String(), err)
 		}
 
 		ts := data.Timestamps{

--- a/services/slam/collectors.go
+++ b/services/slam/collectors.go
@@ -39,7 +39,7 @@ func newPositionCollector(resource interface{}, params data.CollectorParams) (da
 		var res data.CaptureResult
 		pose, err := slam.Position(ctx)
 		if err != nil {
-			return res, data.FailedToReadErr(params.ComponentName, position.String(), err)
+			return res, data.NewFailedToReadErr(params.ComponentName, position.String(), err)
 		}
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
 		return data.NewTabularCaptureResult(ts, &pb.GetPositionResponse{Pose: spatialmath.PoseToProtobuf(pose)})
@@ -59,12 +59,12 @@ func newPointCloudMapCollector(resource interface{}, params data.CollectorParams
 		// edited maps do not need to be captured because they should not be modified
 		f, err := slam.PointCloudMap(ctx, false)
 		if err != nil {
-			return res, data.FailedToReadErr(params.ComponentName, pointCloudMap.String(), err)
+			return res, data.NewFailedToReadErr(params.ComponentName, pointCloudMap.String(), err)
 		}
 
 		pcd, err := HelperConcatenateChunksToFull(f)
 		if err != nil {
-			return res, data.FailedToReadErr(params.ComponentName, pointCloudMap.String(), err)
+			return res, data.NewFailedToReadErr(params.ComponentName, pointCloudMap.String(), err)
 		}
 
 		ts := data.Timestamps{

--- a/services/vision/collectors.go
+++ b/services/vision/collectors.go
@@ -62,7 +62,7 @@ func newCaptureAllFromCameraCollector(resource interface{}, params data.Collecto
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.FailedToReadErr(params.ComponentName, captureAllFromCamera.String(), err)
+			return res, data.NewFailedToReadErr(params.ComponentName, captureAllFromCamera.String(), err)
 		}
 
 		if visCapture.Image == nil {

--- a/services/vision/collectors.go
+++ b/services/vision/collectors.go
@@ -62,7 +62,7 @@ func newCaptureAllFromCameraCollector(resource interface{}, params data.Collecto
 			if errors.Is(err, data.ErrNoCaptureToStore) {
 				return res, err
 			}
-			return res, data.NewFailedToReadErr(params.ComponentName, captureAllFromCamera.String(), err)
+			return res, data.NewFailedToReadError(params.ComponentName, captureAllFromCamera.String(), err)
 		}
 
 		if visCapture.Image == nil {


### PR DESCRIPTION
### Summary

This PR logs FailedToReadErrs at the warning level rather than the error level. It accomplishes this by creating a custom error type for FailedToReadErr.

### Testing

I configured a part with data capture on NextPointCloud on a webcam. Webcams don't support NextPointCloud natively, so this returns an error.

Part config:

```json
{
  "components": [
    {
      "name": "cam",
      "namespace": "rdk",
      "type": "camera",
      "model": "webcam",
      "attributes": {
        "video_path": "FDF90FEB-59E5-4FCF-AABD-DA03C4E19BFB"
      },
      "service_configs": [
        {
          "type": "data_manager",
          "attributes": {
            "capture_methods": [
              {
                "method": "NextPointCloud",
                "capture_frequency_hz": 1,
                "disabled": false,
                "additional_params": {}
              }
            ]
          }
        }
      ]
    }
  ],
  "services": [
    {
      "name": "dmsvc",
      "namespace": "rdk",
      "type": "data_manager",
      "attributes": {
        "sync_disabled": false,
        "capture_disabled": false,
        "capture_dir": "/tmp/capture",
        "tags": [],
        "sync_interval_mins": 0.1
      }
    }
  ]
}
```

Testing:
```bash
➜  ~/viam/rdk git:(main) go run web/cmd/server/main.go -config ~/Downloads/viam-robbie-da-robot-main.json
...
2025-05-01T17:53:49.152Z	ERROR	rdk.resource_manager.rdk:service:data_manager/dmsvc.capture	data/collector.go:364	error while capturing data: failed to get reading of method NextPointCloud of component cam: cannot do a projection to a point cloud: camera intrinsic parameters are not available
2025-05-01T17:53:52.152Z	ERROR	rdk.resource_manager.rdk:service:data_manager/dmsvc.capture	data/collector.go:364	error while capturing data: failed to get reading of method NextPointCloud of component cam: cannot do a projection to a point cloud: camera intrinsic parameters are not available
2025-05-01T17:53:55.152Z	ERROR	rdk.resource_manager.rdk:service:data_manager/dmsvc.capture	data/collector.go:364	error while capturing data: failed to get reading of method NextPointCloud of component cam: cannot do a projection to a point cloud: camera intrinsic parameters are not available
...
➜  ~/viam/rdk git:(DATA-4090) go run web/cmd/server/main.go -config ~/Downloads/viam-robbie-da-robot-main.json
...
2025-05-01T17:52:02.746Z	WARN	rdk.resource_manager.rdk:service:data_manager/dmsvc.capture	data/collector.go:366	error while capturing data: failed to get reading of method NextPointCloud of component cam: cannot do a projection to a point cloud: camera intrinsic parameters are not available
2025-05-01T17:52:05.745Z	WARN	rdk.resource_manager.rdk:service:data_manager/dmsvc.capture	data/collector.go:366	error while capturing data: failed to get reading of method NextPointCloud of component cam: cannot do a projection to a point cloud: camera intrinsic parameters are not available
2025-05-01T17:52:08.746Z	WARN	rdk.resource_manager.rdk:service:data_manager/dmsvc.capture	data/collector.go:366	error while capturing data: failed to get reading of method NextPointCloud of component cam: cannot do a projection to a point cloud: camera intrinsic parameters are not available
...
```