### PR TITLE
RSDK-10633 Send network check logs to app

### DIFF
--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -114,14 +114,6 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 		return err
 	}
 
-	// Run network checks synchronously and immediately exit if `--network-check` flag was
-	// used. Otherwise run network checks asynchronously.
-	if argsParsed.NetworkCheckOnly {
-		runNetworkChecks(ctx)
-		return nil
-	}
-	go runNetworkChecks(ctx)
-
 	ctx, err = rutils.WithTrustedEnvironment(ctx, !argsParsed.UntrustedEnv)
 	if err != nil {
 		return err
@@ -146,6 +138,14 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 	} else {
 		logger.AddAppender(logging.NewStdoutAppender())
 	}
+
+	// Run network checks synchronously and immediately exit if `--network-check` flag was
+	// used. Otherwise run network checks asynchronously.
+	if argsParsed.NetworkCheckOnly {
+		runNetworkChecks(ctx, logger)
+		return nil
+	}
+	go runNetworkChecks(ctx, logger)
 
 	logging.RegisterEventLogger(logger)
 	logging.ReplaceGlobal(logger)

--- a/web/server/network_check.go
+++ b/web/server/network_check.go
@@ -16,8 +16,8 @@ import (
 
 // Characterizes the network through a series of UDP and TCP STUN network checks. Can and
 // should be run asynchronously with server startup to avoid blocking.
-func runNetworkChecks(ctx context.Context) {
-	logger := logging.NewLogger("network-checks")
+func runNetworkChecks(ctx context.Context, rdkLogger logging.Logger) {
+	logger := rdkLogger.Sublogger("network-checks")
 	if testing.Testing() {
 		logger.Debug("Skipping network checks in a testing environment")
 		return

--- a/web/server/network_check_types.go
+++ b/web/server/network_check_types.go
@@ -25,6 +25,35 @@ type STUNResponse struct {
 	ErrorString *string
 }
 
+func stringifySTUNResponses(stunResponses []*STUNResponse) string {
+	ret := "["
+
+	for i, sr := range stunResponses {
+		comma := ","
+		if i == 0 {
+			comma = ""
+		}
+
+		ret += fmt.Sprintf("%v{stun_server_url: %v", comma, sr.STUNServerURL)
+		if sr.STUNServerAddr != nil {
+			ret += fmt.Sprintf(", stun_server_addr: %v", *sr.STUNServerAddr)
+		}
+		if sr.BindResponseAddr != nil {
+			ret += fmt.Sprintf(", bind_response_addr: %v", *sr.BindResponseAddr)
+		}
+		if sr.TimeToBindResponseMS != nil {
+			ret += fmt.Sprintf(", time_to_bind_response_ms: %d", *sr.TimeToBindResponseMS)
+		}
+		if sr.ErrorString != nil {
+			ret += fmt.Sprintf(", error_string: %v", *sr.ErrorString)
+		}
+
+		ret += "}"
+	}
+
+	return ret + "]"
+}
+
 // Logs STUN responses and whether the machine appears to be behind a "hard" NAT device.
 func logSTUNResults(
 	logger logging.Logger,
@@ -66,13 +95,13 @@ func logSTUNResults(
 		logger.Warnw(
 			msg,
 			fmt.Sprintf("%v_source_address", network), sourceAddress,
-			fmt.Sprintf("%v_tests", network), stunResponses,
+			fmt.Sprintf("%v_tests", network), stringifySTUNResponses(stunResponses),
 		)
 	} else {
 		logger.Infow(
 			msg,
 			fmt.Sprintf("%v_source_address", network), sourceAddress,
-			fmt.Sprintf("%v_tests", network), stunResponses,
+			fmt.Sprintf("%v_tests", network), stringifySTUNResponses(stunResponses),
 		)
 	}
 


### PR DESCRIPTION
Network check logs were not actually making it up to app.viam.com. There were two issues: the net appender was not on the logger used for network checks, and the usage of `w` stopped the logs from being readable once they made it up to app. Starts the network check goroutine later and stringifies `[]*STUNResponse` instead of just logging them with `w`.