### PR TITLE
Update link to module documentation to correctly anchor to module section

### DIFF
--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -356,7 +356,7 @@ func UploadModuleAction(c *cli.Context, args uploadModuleArgs) error {
 	if !forceUploadArg {
 		if err := validateModuleFile(client, c, moduleID, tarballPath, versionArg, platformArg); err != nil {
 			return fmt.Errorf(
-				"error validating module: %w. For more details, please visit: https://docs.viam.com/cli/#module ",
+				"error validating module: %w. For more details, please visit: https://docs.viam.com/dev/tools/cli#module ",
 				err)
 		}
 	}


### PR DESCRIPTION
I'm not sure why the current URL loses the anchor point during the redirect. Regardless, it is kinder to link users directly to the module section instead of dropping them at the top of a very long page and hoping they ctrl+f their way to success.