### PR TITLE
[APP-7240] Acquire faux-random port on behalf of child module

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -1236,7 +1236,7 @@ func (m *module) startProcess(
 	if rutils.ViamTCPSockets() {
 		if addr, err := getAutomaticPort(); err != nil {
 			return err
-		} else {
+		} else { //nolint:revive
 			m.addr = addr
 		}
 	} else {

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -134,7 +134,6 @@ func TestModManagerFunctions(t *testing.T) {
 				},
 				dataDir: "module-data-dir",
 				logger:  logger,
-				port:    tcpPortRange,
 			}
 
 			err = mod.startProcess(ctx, parentAddr, nil, viamHomeTemp, filepath.Join(viamHomeTemp, "packages"))

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1759,4 +1760,15 @@ func TestCleanWindowsSocketPath(t *testing.T) {
 	clean, err = cleanWindowsSocketPath("linux", "/x/y.sock")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, clean, test.ShouldResemble, "/x/y.sock")
+}
+
+func TestGetAutomaticPort(t *testing.T) {
+	addr, err := getAutomaticPort()
+	test.That(t, err, test.ShouldBeNil)
+
+	// use the provided port in a new listener; we do this to protect against
+	// any code changes that introduce a TIME_WAIT.
+	lis, err := net.Listen("tcp4", addr)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, lis.Close(), test.ShouldBeNil)
 }

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -1763,12 +1763,14 @@ func TestCleanWindowsSocketPath(t *testing.T) {
 }
 
 func TestGetAutomaticPort(t *testing.T) {
-	addr, err := getAutomaticPort()
-	test.That(t, err, test.ShouldBeNil)
+	for range 1000 {
+		addr, err := getAutomaticPort()
+		test.That(t, err, test.ShouldBeNil)
 
-	// use the provided port in a new listener; we do this to protect against
-	// any code changes that introduce a TIME_WAIT.
-	lis, err := net.Listen("tcp4", addr)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, lis.Close(), test.ShouldBeNil)
+		// use the provided port in a new listener; we do this to protect against
+		// any code changes that introduce a TIME_WAIT.
+		lis, err := net.Listen("tcp4", addr)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, lis.Close(), test.ShouldBeNil)
+	}
 }


### PR DESCRIPTION
This changes the behavior of the TCP sockets code to "randomly" grab a port from the OS, close it, and then pass that to the module as its intended port. Linux randomizes port assignments when done this way, and windows (the main intended user of this) doesn't put ports back in the pool for ~4 minutes, so plenty of time for a module to start up, and thus any collision chance should be extremely minimal.