### PR TITLE
[RSDK-10646] Allow uploading a module via CLI if the windows build's meta.json doesn't have a .exe in the entrypoint

### DIFF
--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -569,8 +569,9 @@ func validateModuleFile(client *viamClient, c *cli.Context, moduleID moduleID, t
 		}
 		path := header.Name
 
-		// if path == entrypoint, we have found the right file. On Windows, allow for an optional
-		// ".exe" at the end.
+		// If path equals entrypoint, we have found the right file. On Windows, allow for an
+		// optional ".exe" at the end, because Windows can automatically resolve the entrypoint
+		// "foo" to the executable "foo.exe" when needed.
 		if filepath.Clean(path) == filepath.Clean(entrypoint) ||
 			(strings.HasPrefix(strings.ToLower(platform), "windows") &&
 				filepath.Clean(path) == filepath.Clean(entrypoint)+".exe") {

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -571,9 +571,9 @@ func validateModuleFile(client *viamClient, c *cli.Context, moduleID moduleID, t
 
 		// if path == entrypoint, we have found the right file. On Windows, allow for an optional
 		// ".exe" at the end.
-		if (filepath.Clean(path) == filepath.Clean(entrypoint) ||
+		if filepath.Clean(path) == filepath.Clean(entrypoint) ||
 			(strings.HasPrefix(strings.ToLower(platform), "windows") &&
-			 filepath.Clean(path) == filepath.Clean(entrypoint) + ".exe")) {
+				filepath.Clean(path) == filepath.Clean(entrypoint)+".exe") {
 			info := header.FileInfo()
 			if info.IsDir() {
 				return errors.Errorf(

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -569,8 +569,11 @@ func validateModuleFile(client *viamClient, c *cli.Context, moduleID moduleID, t
 		}
 		path := header.Name
 
-		// if path == entrypoint, we have found the right file
-		if filepath.Clean(path) == filepath.Clean(entrypoint) {
+		// if path == entrypoint, we have found the right file. On Windows, allow for an optional
+		// ".exe" at the end.
+		if (filepath.Clean(path) == filepath.Clean(entrypoint) ||
+			(strings.HasPrefix(strings.ToLower(platform), "windows") &&
+			 filepath.Clean(path) == filepath.Clean(entrypoint) + ".exe")) {
 			info := header.FileInfo()
 			if info.IsDir() {
 				return errors.Errorf(


### PR DESCRIPTION
I wanted to write a test for this, but I also wanted not to add any binary files (including .tar.gz files) into the repo, and couldn't figure out how to square that circle. This function is not currently tested, so I'm not decreasing the test coverage very much.

Instead, I built the CLI both with and without this change, and tried uploading a Windows module: this version succeeded (see [version 0.1.0-rc1000](https://app.viam.com/module/viam/tflite_cpu)), whereas the `main` branch failed with an `Error validating module: the archive does not contain a file at the desired entrypoint`. 