### PR TITLE
Allow non-`ModelFramer` resource subtypes to expose their frames even if they are not built

### DIFF
--- a/referenceframe/frame_system.go
+++ b/referenceframe/frame_system.go
@@ -168,13 +168,8 @@ func (sfs *simpleFrameSystem) Parent(frame Frame) (Frame, error) {
 
 // frameExists is a helper function to see if a frame with a given name already exists in the system.
 func (sfs *simpleFrameSystem) frameExists(name string) bool {
-	if name == World {
-		return true
-	}
-	if _, ok := sfs.frames[name]; ok {
-		return true
-	}
-	return false
+	_, ok := sfs.frames[name]
+	return ok || name == World
 }
 
 // RemoveFrame will delete the given frame and all descendents from the frame system if it exists.


### PR DESCRIPTION
In testing for a demo, I discovered that a camera resource I need to exist in the FrameSystem was not appearing when the camera was disconnected.  It occurred to me that there is no reason it can't be added even if its down, because all the required info exists in the robot config rather than needing to be returned from the resource itself.  This little change fixes this and should make the framesystem build more completely as a result.

Tested by running a robot with and without a camera resource.  Framesystem builds succesfully regardless of state