### PR TITLE
RSDK-5616: Make config watcher work with editors that save atomically

### DIFF
--- a/config/watcher.go
+++ b/config/watcher.go
@@ -150,14 +150,12 @@ func newFSWatcher(ctx context.Context, configPath string, logger logging.Logger,
 						logger.Info("On-disk config file changed. Reloading the config file.")
 						//nolint:gosec
 						rd, err := os.ReadFile(configPath)
-						defer func() {
-							// Re-add to watcher. Will be a new inode if it was saved atomically.
-							// Adding the same path twice (WRITE case) is a no-op (no error).
-							// Old watches are auto removed from fsWatcher when file is deleted or renamed (REMOVE case).
-							if err := fsWatcher.Add(configPath); err != nil {
-								return
-							}
-						}()
+
+						// Re-add to watcher. Will be a new inode if it was saved atomically.
+						// Adding the same path twice (WRITE case) is a no-op (no error).
+						// Old watches are auto removed from fsWatcher when file is deleted or renamed (REMOVE case).
+						defer utils.UncheckedErrorFunc(func() error { return fsWatcher.Add(configPath) })
+
 						if err != nil {
 							logger.Errorw("error reading config file after write", "error", err)
 							return


### PR DESCRIPTION
We currently only reload the config on WRITE events. However editors that save atomically write to a new temp file and swaps it with the original. The events generated on the original are RENAME->CHMOD->REMOVE. The new file has a different inode, so it also needs to be re-added to the watcher.