### PR TITLE
[APP-8225] Change UpdateRobot API Name and Location to optional

### DIFF
--- a/app/app_client.go
+++ b/app/app_client.go
@@ -1345,13 +1345,26 @@ func (c *AppClient) NewRobot(ctx context.Context, name, location string) (string
 	return resp.Id, nil
 }
 
+// UpdateRobotOptions contains optional parameters for UpdateRobot.
+type UpdateRobotOptions struct {
+	Name     *string
+	Location *string
+}
+
 // UpdateRobot updates a robot.
-func (c *AppClient) UpdateRobot(ctx context.Context, id, name, location string) (*Robot, error) {
-	resp, err := c.client.UpdateRobot(ctx, &pb.UpdateRobotRequest{
-		Id:       id,
-		Name:     name,
-		Location: location,
-	})
+func (c *AppClient) UpdateRobot(ctx context.Context, id string, opts *UpdateRobotOptions) (*Robot, error) {
+	req := &pb.UpdateRobotRequest{
+		Id: id,
+	}
+	if opts != nil {
+		if opts.Name != nil {
+			req.Name = *opts.Name
+		}
+		if opts.Location != nil {
+			req.Location = *opts.Location
+		}
+	}
+	resp, err := c.client.UpdateRobot(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/app/app_client_test.go
+++ b/app/app_client_test.go
@@ -1578,7 +1578,7 @@ func TestAppClient(t *testing.T) {
 				Robot: &pbRobot,
 			}, nil
 		}
-		resp, err := client.UpdateRobot(context.Background(), robotID, name, locationID)
+		resp, err := client.UpdateRobot(context.Background(), robotID, &UpdateRobotOptions{Name: &name, Location: &location.ID})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, resp, test.ShouldResemble, &robot)
 	})


### PR DESCRIPTION
# Description
Per the Scope API section, update the UpdateRobotRequest proto such that name and location are both optional. We will enforce that at least one must be included in code

**See ticket [here](https://viam.atlassian.net/browse/APP-8225)**