### PR TITLE
remove-gostream-dep-on-mediadevices

### DIFF
--- a/gostream/media.go
+++ b/gostream/media.go
@@ -7,7 +7,6 @@ import (
 	"sync/atomic"
 
 	"github.com/pion/mediadevices/pkg/driver"
-	"github.com/pion/mediadevices/pkg/driver/camera"
 	"github.com/pion/mediadevices/pkg/prop"
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
@@ -152,13 +151,18 @@ func PropertiesFromMediaSource[T, U any](src MediaSource[T]) ([]prop.Media, erro
 	return d.Properties(), nil
 }
 
+// labelSeparator is used to separate labels for a driver that
+// is found from multiple locations on a host.
+// from https://github.com/pion/mediadevices/blob/v0.6.4/pkg/driver/camera/camera.go#L16
+const labelSeparator = ";"
+
 // LabelsFromMediaSource returns the labels from the underlying driver in the MediaSource.
 func LabelsFromMediaSource[T, U any](src MediaSource[T]) ([]string, error) {
 	d, err := DriverFromMediaSource[T, U](src)
 	if err != nil {
 		return nil, err
 	}
-	return strings.Split(d.Info().Label, camera.LabelSeparator), nil
+	return strings.Split(d.Info().Label, labelSeparator), nil
 }
 
 // DriverFromMediaSource returns the underlying driver from the MediaSource.

--- a/gostream/query.go
+++ b/gostream/query.go
@@ -10,11 +10,13 @@ import (
 	"github.com/pion/mediadevices"
 	"github.com/pion/mediadevices/pkg/driver"
 	"github.com/pion/mediadevices/pkg/driver/availability"
-	"github.com/pion/mediadevices/pkg/driver/camera"
+
 	"github.com/pion/mediadevices/pkg/frame"
 	"github.com/pion/mediadevices/pkg/prop"
 	"github.com/pion/mediadevices/pkg/wave"
 	"github.com/pkg/errors"
+
+	"slices"
 
 	"go.viam.com/rdk/logging"
 )
@@ -27,9 +29,9 @@ var ErrNotFound = errors.New("failed to find the best driver that fits the const
 // DefaultConstraints are suitable for finding any available device.
 var DefaultConstraints = mediadevices.MediaStreamConstraints{
 	Video: func(constraint *mediadevices.MediaTrackConstraints) {
-		constraint.Width = prop.IntRanged{640, 4096, 1920}
-		constraint.Height = prop.IntRanged{400, 2160, 1080}
-		constraint.FrameRate = prop.FloatRanged{0, 200, 60}
+		constraint.Width = prop.IntRanged{Min: 640, Max: 4096, Ideal: 1920}
+		constraint.Height = prop.IntRanged{Min: 400, Max: 2160, Ideal: 1080}
+		constraint.FrameRate = prop.FloatRanged{Min: 0, Max: 200, Ideal: 60}
 		constraint.FrameFormat = prop.FrameFormatOneOf{
 			frame.FormatI420,
 			frame.FormatI444,
@@ -230,7 +232,7 @@ func getDriverLabels(d driver.Driver, useSep bool) []string {
 	if !useSep {
 		return []string{d.Info().Label}
 	}
-	return strings.Split(d.Info().Label, camera.LabelSeparator)
+	return strings.Split(d.Info().Label, labelSeparator)
 }
 
 func getScreenDriver(
@@ -361,13 +363,8 @@ func labelFilter(target string, useSep bool) driver.FilterFn {
 		if !useSep {
 			return d.Info().Label == target
 		}
-		labels := strings.Split(d.Info().Label, camera.LabelSeparator)
-		for _, label := range labels {
-			if label == target {
-				return true
-			}
-		}
-		return false
+		labels := strings.Split(d.Info().Label, labelSeparator)
+		return slices.Contains(labels, target)
 	})
 }
 
@@ -376,13 +373,8 @@ func labelFilterPattern(labelPattern *regexp.Regexp, useSep bool) driver.FilterF
 		if !useSep {
 			return labelPattern.MatchString(d.Info().Label)
 		}
-		labels := strings.Split(d.Info().Label, camera.LabelSeparator)
-		for _, label := range labels {
-			if labelPattern.MatchString(label) {
-				return true
-			}
-		}
-		return false
+		labels := strings.Split(d.Info().Label, labelSeparator)
+		return slices.ContainsFunc(labels, labelPattern.MatchString)
 	})
 }
 

--- a/gostream/query.go
+++ b/gostream/query.go
@@ -4,19 +4,17 @@ import (
 	"image"
 	"math"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/pion/mediadevices"
 	"github.com/pion/mediadevices/pkg/driver"
 	"github.com/pion/mediadevices/pkg/driver/availability"
-
 	"github.com/pion/mediadevices/pkg/frame"
 	"github.com/pion/mediadevices/pkg/prop"
 	"github.com/pion/mediadevices/pkg/wave"
 	"github.com/pkg/errors"
-
-	"slices"
 
 	"go.viam.com/rdk/logging"
 )


### PR DESCRIPTION
Mediadevices's camera driver's init function, defined in camera_PLATFORM.go, runs C code within it's init() function that tries to discover webcams but doesn't always work on all platforms, sometimes causing the OS process to crash:

https://github.com/pion/mediadevices/blob/v0.6.4/pkg/driver/camera/camera_linux.go
https://github.com/pion/mediadevices/blob/v0.6.4/pkg/driver/camera/camera_darwin.go
https://github.com/pion/mediadevices/blob/v0.6.4/pkg/driver/camera/camera_windows.go

Currently, any module that has a transitive dependency on the RDK camera interface also depends on gostream, and as a consequence, will execute the media devices camera driver's init function on os process startup.

This is completely unnecessary as the only reason why gostream depended on mediadevices is to import a constant.

This code change removes the gostream -> mediadevices dependency, reducing the times when module implementers will unexpectedly.

Long term, we should consider removing the dependency on mediadevices altogether by moving the builtin webcam camera to a module.