### PR TITLE
RSDK-10518: Support setting globalLogger's level from config file

### DIFF
--- a/config/logging_level.go
+++ b/config/logging_level.go
@@ -61,23 +61,25 @@ func UpdateCloudConfigDebug(cloudDebug bool) {
 func refreshLogLevelInLock() {
 	// We have two loggers to update here: logging.GlobalLogLevel (zapcore) and globalLogger.logger (logging)
 	// Also see usages of InitLoggingSettings.
-	var newLevel zapcore.Level
+	var newLevelZap zapcore.Level
+	var newLevel logging.Level
 	if globalLogger.cmdLineDebugFlag ||
 		globalLogger.fileConfigDebugFlag ||
 		globalLogger.cloudConfigDebugFlag {
 		// If anything wants debug logs, set the level to `Debug`.
-		newLevel = zap.DebugLevel
-		globalLogger.logger.SetLevel(logging.DEBUG)
+		newLevelZap = zap.DebugLevel
+		newLevel = logging.DEBUG
 	} else {
 		// If none of the command line, file config or cloud config ask for debug, use the `Info` log
 		// level.
-		newLevel = zap.InfoLevel
-		globalLogger.logger.SetLevel(logging.INFO)
+		newLevelZap = zap.InfoLevel
+		newLevel = logging.INFO
 	}
 
-	if logging.GlobalLogLevel.Level() == newLevel {
+	if logging.GlobalLogLevel.Level() == newLevelZap {
 		return
 	}
-	globalLogger.logger.Info("New log level:", newLevel)
-	logging.GlobalLogLevel.SetLevel(newLevel)
+	globalLogger.logger.Info("New log level:", newLevelZap)
+	logging.GlobalLogLevel.SetLevel(newLevelZap)
+	globalLogger.logger.SetLevel(newLevel)
 }


### PR DESCRIPTION
In the configuration file:

`"debug": true` 
or 
`"log": [     {     "pattern": "*",     "level": "debug",     } ]`
will now display DEBUG logs for modules. Note the latter updates through `config.go:UpdateLoggerRegistryFromConfig` and appears to work fine as-is.

Currently, this is only available when running `viam-server` with `-debug` because:
`RunServer` calls [config.InitLoggingSettings(logger, argsParsed.Debug)](https://github.com/aldenh-viam/rdk/blob/f9a6a19e6f8d7a5b38db27d275e1aab7eca015ab/web/server/entrypoint.go#L145): 

[InitLoggingSettings](https://github.com/aldenh-viam/rdk/blob/f9a6a19e6f8d7a5b38db27d275e1aab7eca015ab/config/logging_level.go#L26-L36) calls both `logging.GlobalLogLevel.SetLevel` and `logger.SetLevel`.

The `refreshLogLevelInLock` is called after configs are read (both initially and when updated) and is missing the `logger.SetLevel` update.