### PR TITLE
RSDK-10682 - Some extra logs around startup

### DIFF
--- a/utils/ticker.go
+++ b/utils/ticker.go
@@ -19,7 +19,7 @@ func SlowStartupLogger(ctx context.Context, msg, fieldName, fieldVal string, log
 			select {
 			case <-slowTicker.C:
 				elapsed := time.Since(startTime).String()
-				logger.CWarnw(ctx, msg, fieldName, fieldVal, "time elapsed", elapsed)
+				logger.CWarnw(ctx, msg, fieldName, fieldVal, "time_elapsed", elapsed)
 				if firstTick {
 					slowTicker.Reset(3 * time.Second)
 					firstTick = false

--- a/utils/ticker.go
+++ b/utils/ticker.go
@@ -18,7 +18,7 @@ func SlowStartupLogger(ctx context.Context, msg, fieldName, fieldVal string, log
 		for {
 			select {
 			case <-slowTicker.C:
-				elapsed := time.Since(startTime).Seconds()
+				elapsed := time.Since(startTime).String()
 				logger.CWarnw(ctx, msg, fieldName, fieldVal, "time elapsed", elapsed)
 				if firstTick {
 					slowTicker.Reset(3 * time.Second)

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -333,8 +333,9 @@ func (s *robotServer) configWatcher(ctx context.Context, currCfg *config.Config,
 ) {
 	// Reconfigure robot to have passed-in config before listening for any config
 	// changes.
+	startTime := time.Now()
 	r.Reconfigure(ctx, currCfg)
-
+	s.logger.CInfow(ctx, "Robot initialized with full config", "elapsed time", time.Since(startTime).String())
 	for {
 		select {
 		case <-ctx.Done():
@@ -543,11 +544,14 @@ func (s *robotServer) serveWeb(ctx context.Context, cfg *config.Config) (err err
 	// state of initializing until reconfigured with full config.
 	minimalProcessedConfig.Initial = true
 
+	startTime := time.Now()
 	myRobot, err := robotimpl.New(ctx, &minimalProcessedConfig, s.conn, s.logger, robotOptions...)
 	if err != nil {
 		cancel()
 		return err
 	}
+	s.logger.CInfow(ctx, "Robot created with minimal config", "elapsed time", time.Since(startTime).String())
+
 	theRobotLock.Lock()
 	theRobot = myRobot
 	theRobotLock.Unlock()
@@ -580,6 +584,7 @@ func (s *robotServer) serveWeb(ctx context.Context, cfg *config.Config) (err err
 		cancel()
 		<-onWatchDone
 	}()
+	s.logger.CInfo(ctx, "Config watcher started")
 
 	// Create initial web options with `minimalProcessedConfig`.
 	options, err := s.createWebOptions(&minimalProcessedConfig)

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -335,7 +335,7 @@ func (s *robotServer) configWatcher(ctx context.Context, currCfg *config.Config,
 	// changes.
 	startTime := time.Now()
 	r.Reconfigure(ctx, currCfg)
-	s.logger.CInfow(ctx, "Robot initialized with full config", "time_to_reconfigure", time.Since(startTime).String())
+	s.logger.CInfow(ctx, "Robot reconfigured with full config", "time_to_reconfigure", time.Since(startTime).String())
 	for {
 		select {
 		case <-ctx.Done():

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -335,7 +335,7 @@ func (s *robotServer) configWatcher(ctx context.Context, currCfg *config.Config,
 	// changes.
 	startTime := time.Now()
 	r.Reconfigure(ctx, currCfg)
-	s.logger.CInfow(ctx, "Robot initialized with full config", "elapsed time", time.Since(startTime).String())
+	s.logger.CInfow(ctx, "Robot initialized with full config", "time_to_reconfigure", time.Since(startTime).String())
 	for {
 		select {
 		case <-ctx.Done():
@@ -550,7 +550,7 @@ func (s *robotServer) serveWeb(ctx context.Context, cfg *config.Config) (err err
 		cancel()
 		return err
 	}
-	s.logger.CInfow(ctx, "Robot created with minimal config", "elapsed time", time.Since(startTime).String())
+	s.logger.CInfow(ctx, "Robot created with minimal config", "time_to_create", time.Since(startTime).String())
 
 	theRobotLock.Lock()
 	theRobot = myRobot


### PR DESCRIPTION
```
2025-05-14T21:45:05.065Z        WARN    rdk.resource_manager    utils/ticker.go:22      Waiting for resource to complete (re)configuration      {"resource":"rdk-internal:service:frame_system/builtin","time elapsed":"2.000356s"}
2025-05-14T21:45:10.066Z        WARN    rdk.resource_manager    utils/ticker.go:22      Waiting for resource to complete (re)configuration      {"resource":"rdk:service:motion/builtin","time elapsed":"2.000263667s"}
2025-05-14T21:45:10.066Z        WARN    rdk.resource_manager    utils/ticker.go:22      Waiting for resource to complete (re)configuration      {"resource":"rdk-internal:service:packagemanager/deferred-manager","time elapsed":"2.000353875s"}

----

2025-05-14T21:54:30.182Z        INFO    rdk     impl/local_robot.go:1454        Robot (re)configured
2025-05-14T21:54:30.182Z        INFO    rdk     server/entrypoint.go:553        Robot created with minimal config       {"elapsed time":"6.129417ms"}
2025-05-14T21:54:30.183Z        INFO    rdk     server/entrypoint.go:587        Config watcher started

----

2025-05-14T21:54:32.421Z        INFO    rdk     impl/local_robot.go:1454        Robot (re)configured
2025-05-14T21:54:32.421Z        INFO    rdk     server/entrypoint.go:338        Robot initialized with full config      {"elapsed time":"2.237918875s"}
```

some extra logging during startup to give us a better idea of if something happened or not.
also changed time log to a string so it doesn't freak out on app