### PR TITLE
APP-8298 expand homedir in reloading

### DIFF
--- a/robot/packages/local_package_manager.go
+++ b/robot/packages/local_package_manager.go
@@ -253,7 +253,11 @@ func (m *localManager) SyncOne(ctx context.Context, mod config.Module) error {
 	}
 	pkgDir := pkg.LocalDataDirectory(m.packagesDir)
 
-	dirty, err := newerOrMissing(mod.ExePath, pkgDir)
+	exePath, err := rUtils.ExpandHomeDir(mod.ExePath)
+	if err != nil {
+		return err
+	}
+	dirty, err := newerOrMissing(exePath, pkgDir)
 	if err != nil {
 		return err
 	}

--- a/robot/packages/utils.go
+++ b/robot/packages/utils.go
@@ -53,6 +53,7 @@ func installPackage(
 	}
 
 	dstPath := p.LocalDownloadPath(packagesDir)
+	println("calling installFn with", url)
 	checksum, contentType, err := installFn(ctx, url, dstPath)
 	if err != nil {
 		return err

--- a/robot/packages/utils.go
+++ b/robot/packages/utils.go
@@ -53,7 +53,6 @@ func installPackage(
 	}
 
 	dstPath := p.LocalDownloadPath(packagesDir)
-	println("calling installFn with", url)
 	checksum, contentType, err := installFn(ctx, url, dstPath)
 	if err != nil {
 		return err


### PR DESCRIPTION
## What changed
- call `ExpandHomeDir` in localManager.SyncOne
## Why
The `viam module reload` command was failing here with a no such path error on the second attempt. (i.e. you reload, it works, you make changes, and reload again).
> Error: Rpc error: code = Unknown desc = while restarting module id=----, name=: stat ~/.viam/packages-local/----_from_reload-dist-archive.tar.gz: no such file or directory