### PR TITLE
RSDK-10740 - Download packages after server startup

### DIFF
--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -528,7 +528,7 @@ func (s *robotServer) serveWeb(ctx context.Context, cfg *config.Config) (err err
 	}
 
 	// Create `minimalProcessedConfig`, a copy of `fullProcessedConfig`. Remove
-	// all components, services, remotes, modules, and processes from
+	// all components, services, remotes, modules, processes, and packages from
 	// `minimalProcessedConfig`. Create new robot with `minimalProcessedConfig`
 	// and immediately start web service. We need the machine to be reachable
 	// through the web service ASAP, even if some resources take a long time to
@@ -539,6 +539,7 @@ func (s *robotServer) serveWeb(ctx context.Context, cfg *config.Config) (err err
 	minimalProcessedConfig.Remotes = nil
 	minimalProcessedConfig.Modules = nil
 	minimalProcessedConfig.Processes = nil
+	minimalProcessedConfig.Packages = nil
 
 	// Mark minimalProcessedConfig as an initial config, so robot reports a
 	// state of initializing until reconfigured with full config.


### PR DESCRIPTION
we did not clear the packages config when creating the minimal config, so we were still downloading packages on the initial startup phase

cc: @stevebriskin 