### PR TITLE
RSDK-10765 - Let mlvision resize to mlmodel's input size

### DIFF
--- a/services/vision/mlvision/detector.go
+++ b/services/vision/mlvision/detector.go
@@ -109,12 +109,11 @@ func attemptToBuildDetector(mlm mlmodel.Service,
 		if err != nil {
 			return nil, err
 		}
-
 		boundingBoxes, err := ml.FormatDetectionOutputs(outNameMap, outMap, resizeW, resizeH, boxOrder, labels)
 		if err != nil {
 			return nil, err
 		}
-		detections := convertBoundingBoxesToDetections(boundingBoxes, origW, origH)
+		detections := convertBoundingBoxesToDetections(boundingBoxes, resizeW, resizeH)
 		if postprocessor != nil {
 			detections = postprocessor(detections)
 		}

--- a/services/vision/mlvision/detector.go
+++ b/services/vision/mlvision/detector.go
@@ -70,6 +70,7 @@ func attemptToBuildDetector(mlm mlmodel.Service,
 		if resizeH == -1 {
 			resizeH = origH
 		}
+
 		resized := img
 		if (origW != resizeW) || (origH != resizeH) {
 			resized = resize.Resize(uint(resizeW), uint(resizeH), img, resize.Bilinear)
@@ -113,7 +114,7 @@ func attemptToBuildDetector(mlm mlmodel.Service,
 		if err != nil {
 			return nil, err
 		}
-		detections := convertBoundingBoxesToDetections(boundingBoxes, resizeW, resizeH)
+		detections := convertBoundingBoxesToDetections(boundingBoxes, origW, origH)
 		if postprocessor != nil {
 			detections = postprocessor(detections)
 		}

--- a/services/vision/mlvision/detector.go
+++ b/services/vision/mlvision/detector.go
@@ -110,7 +110,7 @@ func attemptToBuildDetector(mlm mlmodel.Service,
 			return nil, err
 		}
 
-		boundingBoxes, err := ml.FormatDetectionOutputs(outNameMap, outMap, origW, origH, boxOrder, labels)
+		boundingBoxes, err := ml.FormatDetectionOutputs(outNameMap, outMap, resizeW, resizeH, boxOrder, labels)
 		if err != nil {
 			return nil, err
 		}

--- a/services/vision/mlvision/ml_model_mock_test.go
+++ b/services/vision/mlvision/ml_model_mock_test.go
@@ -274,7 +274,7 @@ func mockSuperFakeModel(name string) mlmodel.Service {
 	}
 
 	location := []float32{
-		0, 100, 200, 300,
+		150, 100, 250, 400,
 		0, 100, 400, 450,
 		100, 200, 450, 499,
 		100, 300, 499, 499,

--- a/services/vision/mlvision/ml_model_mock_test.go
+++ b/services/vision/mlvision/ml_model_mock_test.go
@@ -258,6 +258,40 @@ func mockEffNetModel(name, labelLoc string) mlmodel.Service {
 	return effNetMock
 }
 
+func mockSuperFakeModel(name string) mlmodel.Service {
+	mock := inject.NewMLModelService(name)
+	md := mlmodel.MLMetadata{}
+	inputs := make([]mlmodel.TensorInfo, 0, 1)
+	imageIn := mlmodel.TensorInfo{
+		DataType: "float32",
+		Shape:    []int{1, 500, 500, 3},
+	}
+	inputs = append(inputs, imageIn)
+	md.Inputs = inputs
+
+	mock.MetadataFunc = func(ctx context.Context) (mlmodel.MLMetadata, error) {
+		return md, nil
+	}
+
+	location := []float32{
+		0, 100, 200, 300,
+		0, 100, 400, 450,
+		100, 200, 450, 499,
+		100, 300, 499, 499,
+	}
+	scores := []float32{0.1, 0.2, 0.8, 0.9}
+	outputInfer := ml.Tensors{}
+	outputInfer["category"] = tensor.New(tensor.WithShape(1, 4), tensor.WithBacking([]float32{0, 1, 2, 3}))
+	outputInfer["location"] = tensor.New(tensor.WithShape(1, 4, 4), tensor.WithBacking(location))
+	outputInfer["score"] = tensor.New(tensor.WithShape(1, 4), tensor.WithBacking(scores))
+
+	mock.InferFunc = func(ctx context.Context, tensors ml.Tensors) (ml.Tensors, error) {
+		return outputInfer, nil
+	}
+
+	return mock
+}
+
 func mockYOLOv4Model(name, labelLoc string) mlmodel.Service {
 	// using the yolov4_tiny_416_person.tflite model as a template (only identifies people)
 	yolov4Mock := inject.NewMLModelService(name)

--- a/services/vision/mlvision/ml_model_test.go
+++ b/services/vision/mlvision/ml_model_test.go
@@ -2,6 +2,7 @@ package mlvision
 
 import (
 	"context"
+	"math"
 	"sync"
 	"testing"
 
@@ -268,8 +269,21 @@ func TestMLDetectorBboxResized(t *testing.T) {
 	gotDetections, err := gotDetector(ctx, pic)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotDetections, test.ShouldNotBeNil)
-	test.That(t, gotDetections[0].NormalizedBoundingBox(), test.ShouldResemble, []float64{0.2, 0, 0.6, 0.4})
-	test.That(t, gotDetections[0].BoundingBox().Min.X, test.ShouldEqual, 100)
+
+	// There's some floating point math, so check that the numbers are basically desiredValues (within a delta)
+	desiredNDelta := 0.01
+	desiredNValues := []float64{0.2, 0.3, 0.8, 0.5}
+	test.That(t, math.Abs(gotDetections[0].NormalizedBoundingBox()[0]-desiredNValues[0]), test.ShouldBeLessThan, desiredNDelta)
+	test.That(t, math.Abs(gotDetections[0].NormalizedBoundingBox()[1]-desiredNValues[1]), test.ShouldBeLessThan, desiredNDelta)
+	test.That(t, math.Abs(gotDetections[0].NormalizedBoundingBox()[2]-desiredNValues[2]), test.ShouldBeLessThan, desiredNDelta)
+	test.That(t, math.Abs(gotDetections[0].NormalizedBoundingBox()[3]-desiredNValues[3]), test.ShouldBeLessThan, desiredNDelta)
+
+	desiredDelta := 0.5
+	desiredValues := []float64{100, 100, 400, 166}
+	test.That(t, math.Abs(float64(gotDetections[0].BoundingBox().Min.X)-desiredValues[0]), test.ShouldBeLessThan, desiredDelta)
+	test.That(t, math.Abs(float64(gotDetections[0].BoundingBox().Min.Y)-desiredValues[1]), test.ShouldBeLessThan, desiredDelta)
+	test.That(t, math.Abs(float64(gotDetections[0].BoundingBox().Max.X)-desiredValues[2]), test.ShouldBeLessThan, desiredDelta)
+	test.That(t, math.Abs(float64(gotDetections[0].BoundingBox().Max.Y)-desiredValues[3]), test.ShouldBeLessThan, desiredDelta)
 }
 
 func TestMLDetectorWithNoCategory(t *testing.T) {


### PR DESCRIPTION
Hey, so this fix comes from a bug Nick ran into.  Basically if someone uses a custom mlmodel module with a set input size different from the original image, we mess up the bounding box.  Like, any absolute bbox coordinates that were read in were "normalized" using the original image and not the resized one.  I think we've been so far getting lucky either with proportional bbox tensors or mlmodels that have [1 -1 -1 3] (variable) size input. 

Here we just fix it by checking if we resized the image and using the appropriate image dims for normalization.  

Tested via Python SDK with Nick's funky ncnn-ml module (0.1.1-rc1) and with our classic EffDet mlmodel setup.  Nick's module used to not work now it does! And EffDet didn't break!