### PR TITLE
RSDK-7848 remove side-by-side meta.json support

### DIFF
--- a/config/module_test.go
+++ b/config/module_test.go
@@ -103,11 +103,8 @@ func TestSyntheticModule(t *testing.T) {
 		testWriteJSON(t, filepath.Join(tmp, "meta.json"), &meta)
 
 		// local tarball case
-		syntheticPath, err := modNeedsSynthetic.EvaluateExePath(tmp)
-		test.That(t, err, test.ShouldBeNil)
-		exeDir, err := modNeedsSynthetic.exeDir(tmp)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, syntheticPath, test.ShouldEqual, filepath.Join(exeDir, meta.Entrypoint))
+		_, err := modNeedsSynthetic.EvaluateExePath(tmp)
+		test.That(t, err, test.ShouldEqual, errLocalTarballEntrypoint)
 
 		// vanilla case
 		notTarPath, err := modNotTar.EvaluateExePath(tmp)

--- a/config/module_test.go
+++ b/config/module_test.go
@@ -425,6 +425,8 @@ func TestMergeEnvVars(t *testing.T) {
 // testWriteJSON is a t.Helper that serializes `value` to `path` as json.
 func testWriteJSON(t *testing.T, path string, value any) {
 	t.Helper()
+	err := os.MkdirAll(filepath.Dir(path), 0o700)
+	test.That(t, err, test.ShouldBeNil)
 	file, err := os.Create(path)
 	test.That(t, err, test.ShouldBeNil)
 	defer file.Close()

--- a/config/module_test.go
+++ b/config/module_test.go
@@ -298,7 +298,6 @@ func TestGetJSONManifest(t *testing.T) {
 
 		exePath := filepath.Join(tmp, "module.tgz")
 		exeDir := filepath.Dir(exePath)
-		exeMetaJSONFilepath := filepath.Join(exeDir, "meta.json")
 		unpackedModDir := filepath.Join(tmp, "unpacked-mod-dir")
 		unpackedModMetaJSONFilepath := filepath.Join(unpackedModDir, "meta.json")
 		env := map[string]string{}
@@ -316,26 +315,6 @@ func TestGetJSONManifest(t *testing.T) {
 		test.That(t, errors.Is(err, os.ErrNotExist), test.ShouldBeTrue)
 		test.That(t, err.Error(), test.ShouldContainSubstring, unpackedModDir)
 		test.That(t, err.Error(), test.ShouldContainSubstring, exeDir)
-
-		// meta.json found in executable directory; parsing fails
-		exeMetaJSONFile, err := os.Create(exeMetaJSONFilepath)
-		test.That(t, err, test.ShouldBeNil)
-		defer exeMetaJSONFile.Close()
-
-		meta, moduleWorkingDirectory, err = modLocalTar.getJSONManifest(unpackedModDir, env)
-		test.That(t, meta, test.ShouldBeNil)
-		test.That(t, moduleWorkingDirectory, test.ShouldBeEmpty)
-		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "local tarball")
-		test.That(t, errors.Is(err, os.ErrNotExist), test.ShouldBeFalse)
-
-		// meta.json found in executable directory; parsing succeeds
-		testWriteJSON(t, exeMetaJSONFilepath, validJSONManifest)
-
-		meta, moduleWorkingDirectory, err = modLocalTar.getJSONManifest(unpackedModDir, env)
-		test.That(t, *meta, test.ShouldResemble, validJSONManifest)
-		test.That(t, moduleWorkingDirectory, test.ShouldEqual, exeDir)
-		test.That(t, err, test.ShouldBeNil)
 
 		// meta.json found in unpacked modular directory; parsing fails
 		unpackedModMetaJSONFile, err := os.Create(unpackedModMetaJSONFilepath)


### PR DESCRIPTION
## What changed
- remove side-by-side support from `Module.EvaluateExePath` and `Module.getJSONManifest`
- (incidental) automatically `MkdirAll` in testWriteJSON`
## Why
Side-by-side mode was an RDK feature that we rushed in order to support local modules under the odd execution rules of android OS. We fast-followed with meta-in-tarball which is now the standard. Side-by-side has been deprecated for a while; I'm removing now because APP-8193 requires touching these code paths, and will be simpler without the third case.

How they differ:
- side-by-side mode means that a meta.json file is **next to** a local tarball, e.g. you have a `mymodule/module.tar.gz` and a `mymodule/meta.json` next to it
- meta-in-tarball means that there is a meta.json **inside the tarball** at the root level. This is necessary in the local tarball case, and optional in the registry case; when present for registry modules, the meta-in-tarball `entrypoint` field takes precedence over what's specified in cloud