### PR TITLE
RSDK-10695 fix nil pointer dereference when orientation tolerance is unspecified

### DIFF
--- a/motionplan/constraint.go
+++ b/motionplan/constraint.go
@@ -579,8 +579,12 @@ func ConstraintsFromProtobuf(pbConstraint *motionpb.Constraints) *Constraints {
 	orientConstraintFromProto := func(orientConstraints []*motionpb.OrientationConstraint) []OrientationConstraint {
 		toRet := make([]OrientationConstraint, 0, len(orientConstraints))
 		for _, orientConstraint := range orientConstraints {
+			orientTol := 0.
+			if orientConstraint.OrientationToleranceDegs != nil {
+				orientTol = float64(*orientConstraint.OrientationToleranceDegs)
+			}
 			toRet = append(toRet, OrientationConstraint{
-				OrientationToleranceDegs: float64(*orientConstraint.OrientationToleranceDegs),
+				OrientationToleranceDegs: orientTol,
 			})
 		}
 		return toRet


### PR DESCRIPTION
Its possible to construct valid protobuf structs that cause this to error at the moment, as @JessamyT discovered.  This PR should patch this from being able to happen.