### PR TITLE
whitelist starting collisions with pointclouds for non-SLAM applications

### DIFF
--- a/motionplan/constraint.go
+++ b/motionplan/constraint.go
@@ -133,12 +133,24 @@ func createAllCollisionConstraints(
 		}
 
 		// create constraint to keep moving geometries from hitting world state obstacles
-		obstacleConstraint, err := NewCollisionConstraint(movingRobotGeometries, worldGeometries, allowedCollisions, false, collisionBufferMM)
+		obstacleConstraint, err := NewCollisionConstraint(
+			movingRobotGeometries,
+			worldGeometries,
+			allowedCollisions,
+			false,
+			collisionBufferMM,
+		)
 		if err != nil {
 			return nil, nil, err
 		}
 		// create constraint to keep moving geometries from hitting world state obstacles
-		obstacleConstraintFS, err := NewCollisionConstraintFS(movingRobotGeometries, worldGeometries, allowedCollisions, false, collisionBufferMM)
+		obstacleConstraintFS, err := NewCollisionConstraintFS(
+			movingRobotGeometries,
+			worldGeometries,
+			allowedCollisions,
+			false,
+			collisionBufferMM,
+		)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/motionplan/constraint.go
+++ b/motionplan/constraint.go
@@ -9,7 +9,6 @@ import (
 	motionpb "go.viam.com/api/service/motion/v1"
 
 	"go.viam.com/rdk/motionplan/ik"
-	"go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/referenceframe"
 	spatial "go.viam.com/rdk/spatialmath"
 )
@@ -108,30 +107,8 @@ func createAllCollisionConstraints(
 ) (map[string]StateFSConstraint, map[string]StateConstraint, error) {
 	constraintFSMap := map[string]StateFSConstraint{}
 	constraintMap := map[string]StateConstraint{}
-	var err error
 
 	if len(worldGeometries) > 0 {
-		// Check if a moving geometry is in collision with a pointcloud. If so, error.
-		// TODO: This is not the most robust way to deal with this but is better than driving through walls.
-		var zeroCG *collisionGraph
-		for _, geom := range worldGeometries {
-			if octree, ok := geom.(*pointcloud.BasicOctree); ok {
-				if zeroCG == nil {
-					zeroCG, err = setupZeroCG(movingRobotGeometries, worldGeometries, allowedCollisions, false, collisionBufferMM)
-					if err != nil {
-						return nil, nil, err
-					}
-				}
-				for _, collision := range zeroCG.collisions(collisionBufferMM) {
-					if collision.name1 == octree.Label() {
-						return nil, nil, fmt.Errorf("starting collision between SLAM map and %s, cannot move", collision.name2)
-					} else if collision.name2 == octree.Label() {
-						return nil, nil, fmt.Errorf("starting collision between SLAM map and %s, cannot move", collision.name1)
-					}
-				}
-			}
-		}
-
 		// create constraint to keep moving geometries from hitting world state obstacles
 		obstacleConstraint, err := NewCollisionConstraint(
 			movingRobotGeometries,

--- a/motionplan/motionPlanner.go
+++ b/motionplan/motionPlanner.go
@@ -119,6 +119,7 @@ func (req *PlanRequest) validatePlanRequest() error {
 					if err != nil {
 						return err
 					}
+					octree.SetLabel(geometry.Label())
 					geometry = octree
 				}
 				pcdGeometries = append(pcdGeometries, geometry)

--- a/motionplan/motionPlanner.go
+++ b/motionplan/motionPlanner.go
@@ -119,7 +119,6 @@ func (req *PlanRequest) validatePlanRequest() error {
 					if err != nil {
 						return err
 					}
-					octree.SetLabel(geometry.Label())
 					geometry = octree
 				}
 				pcdGeometries = append(pcdGeometries, geometry)


### PR DESCRIPTION
This is a follow-on from a recent PR that fixes a case that was not caught during testing where the end effector begins in collision with a pointcloud. Currently this is simply an error as motionplan expects all point clouds to be associated with SLAM maps.  This PR changes the scope of where this check is made, moving it to the planager, which has knowledge of whether the motionplan is using TP space or not.  