### PR TITLE
 RSDK-9648: Add viam CLI command to grab all captured FTDC data

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -2370,7 +2370,7 @@ Download FTDC data to the current working directory:
 'viam machine part get-ftdc --organization "org" --location "location" --machine "m1" --part "m1-main"
 
 Download FTDC data to an absolute path:
-'viam machine part get-ftdc --part "m1-main" -r $HOME/Downloads'
+'viam machine part get-ftdc --part "m1-main" $HOME/Downloads'
 `,
 							UsageText: createUsageText(
 								"machines part get-ftdc",

--- a/cli/app.go
+++ b/cli/app.go
@@ -2360,23 +2360,18 @@ Copy multiple files from the machine to a local destination with recursion and k
 						},
 						{
 							Name:  "get-ftdc",
-							Usage: "download ftdc data from a machine part",
+							Usage: "download FTDC data from a machine part",
 							Description: `
 In order to use the get-ftdc command, the machine must have a valid shell type service.
 Organization and location are required flags if using name (rather than ID) for the part.
+If [target] is not specified then the FTDC data will be saved to the current working directory.
 Note: There is no progress meter while copying is in progress.
-
-Download FTDC data to the current working directory:
-'viam machine part get-ftdc --organization "org" --location "location" --machine "m1" --part "m1-main"
-
-Download FTDC data to an absolute path:
-'viam machine part get-ftdc --part "m1-main" $HOME/Downloads'
 `,
 							UsageText: createUsageText(
 								"machines part get-ftdc",
 								[]string{generalFlagPart},
 								true, false,
-								"<target>"),
+								"[target]"),
 							Flags:  commonPartFlags,
 							Action: createCommandWithT(MachinesPartGetFTDCAction),
 						},

--- a/cli/app.go
+++ b/cli/app.go
@@ -2377,13 +2377,7 @@ Download FTDC data to an absolute path:
 								[]string{generalFlagPart},
 								true, false,
 								"<target>"),
-							Flags: append(commonPartFlags, []cli.Flag{
-								&cli.BoolFlag{
-									Name:    generalFlagNoProgress,
-									Aliases: []string{"n"},
-									Usage:   "hide progress of the file transfer",
-								},
-							}...),
+							Flags:  commonPartFlags,
 							Action: createCommandWithT(MachinesPartGetFTDCAction),
 						},
 						{

--- a/cli/app.go
+++ b/cli/app.go
@@ -2359,6 +2359,34 @@ Copy multiple files from the machine to a local destination with recursion and k
 							Action: createCommandWithT[machinesPartCopyFilesArgs](MachinesPartCopyFilesAction),
 						},
 						{
+							Name:  "get-ftdc",
+							Usage: "download ftdc data from a machine part",
+							Description: `
+In order to use the get-ftdc command, the machine must have a valid shell type service.
+Organization and location are required flags if using name (rather than ID) for the part.
+Note: There is no progress meter while copying is in progress.
+
+Download FTDC data to the current working directory:
+'viam machine part get-ftdc --organization "org" --location "location" --machine "m1" --part "m1-main"
+
+Download FTDC data to an absolute path:
+'viam machine part get-ftdc --part "m1-main" -r $HOME/Downloads'
+`,
+							UsageText: createUsageText(
+								"machines part get-ftdc",
+								[]string{generalFlagPart},
+								true, false,
+								"<target>"),
+							Flags: append(commonPartFlags, []cli.Flag{
+								&cli.BoolFlag{
+									Name:    generalFlagNoProgress,
+									Aliases: []string{"n"},
+									Usage:   "hide progress of the file transfer",
+								},
+							}...),
+							Action: createCommandWithT(MachinesPartGetFTDCAction),
+						},
+						{
 							Name:  "tunnel",
 							Usage: "tunnel connections to the specified port on a machine part",
 							UsageText: createUsageText("machines part tunnel", []string{

--- a/cli/client.go
+++ b/cli/client.go
@@ -1335,7 +1335,7 @@ func MachinesPartGetFTDCAction(c *cli.Context, args machinesPartGetFTDCArgs) err
 	}
 	logger := globalArgs.createLogger()
 
-	return client.machinesPartGetFTDCAction(c, args, logger)
+	return client.machinesPartGetFTDCAction(c, args, globalArgs.Debug, logger)
 }
 
 // MachinesPartCopyFilesAction is the corresponding Action for 'machines part cp'.
@@ -1459,6 +1459,7 @@ func (c *viamClient) machinesPartCopyFilesAction(
 func (c *viamClient) machinesPartGetFTDCAction(
 	ctx *cli.Context,
 	flagArgs machinesPartGetFTDCArgs,
+	debug bool,
 	logger logging.Logger,
 ) error {
 	args := ctx.Args().Slice()
@@ -1476,11 +1477,6 @@ func (c *viamClient) machinesPartGetFTDCAction(
 		return wrongNumArgsError{numArgs, 0, 1}
 	}
 
-	globalArgs, err := getGlobalArgs(ctx)
-	if err != nil {
-		return err
-	}
-
 	part, err := c.robotPart(flagArgs.Organization, flagArgs.Location, flagArgs.Machine, flagArgs.Part)
 	if err != nil {
 		return err
@@ -1494,7 +1490,7 @@ func (c *viamClient) machinesPartGetFTDCAction(
 		flagArgs.Location,
 		flagArgs.Machine,
 		flagArgs.Part,
-		globalArgs.Debug,
+		debug,
 		true,
 		false,
 		[]string{src},

--- a/cli/client.go
+++ b/cli/client.go
@@ -1320,7 +1320,6 @@ type machinesPartGetFTDCArgs struct {
 	Location     string
 	Machine      string
 	Part         string
-	NoProgress   bool
 }
 
 // MachinesPartGetFTDCAction is the corresponding Action for 'machines part get-ftdc'.
@@ -1487,7 +1486,7 @@ func (c *viamClient) machinesPartGetFTDCAction(
 		return err
 	}
 	// Intentional use of path instead of filepath: Windows understands both / and
-	// / as path separators, and we don't want a cli running on Windows to send
+	// \ as path separators, and we don't want a cli running on Windows to send
 	// a path using \ to a *NIX machine.
 	src := path.Join(ftdcPath, part.Id)
 	if err := c.copyFilesFromMachine(

--- a/cli/client.go
+++ b/cli/client.go
@@ -78,7 +78,10 @@ const (
 	yellow = "\033[1;33m%s\033[0m"
 )
 
-var errNoShellService = errors.New("shell service is not enabled on this machine part")
+var (
+	errNoShellService = errors.New("shell service is not enabled on this machine part")
+	ftdcPath          = path.Join("~", ".viam", "diagnostics.data")
+)
 
 // viamClient wraps a cli.Context and provides all the CLI command functionality
 // needed to talk to the app and data services but not directly to robot parts.
@@ -1469,7 +1472,10 @@ func (c *viamClient) machinesPartGetFTDCAction(
 	if err != nil {
 		return err
 	}
-	src := path.Join("~", ".viam", "diagnostics.data", part.Id)
+	// Intentional use of path instead of filepath: Windows understands both / and
+	// / as path separators, and we don't want a cli running on Windows to send
+	// a path using \ to a *NIX machine.
+	src := path.Join(ftdcPath, part.Id)
 	if err := c.copyFilesFromMachine(
 		flagArgs.Organization,
 		flagArgs.Location,

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -1224,7 +1224,7 @@ func TestShellGetFTDC(t *testing.T) {
 		args := []string{"foo", "bar"}
 		cCtx, viamClient, _, _ := setup(asc, nil, nil, partFlags, "token", args...)
 		test.That(t,
-			viamClient.machinesPartGetFTDCAction(cCtx, parseStructFromCtx[machinesPartGetFTDCArgs](cCtx), logger),
+			viamClient.machinesPartGetFTDCAction(cCtx, parseStructFromCtx[machinesPartGetFTDCArgs](cCtx), true, logger),
 			test.ShouldBeError, wrongNumArgsError{2, 0, 1})
 	})
 
@@ -1243,7 +1243,7 @@ func TestShellGetFTDC(t *testing.T) {
 		cCtx, viamClient, _, _ := setupWithRunningPart(
 			t, asc, nil, nil, partFlags, "token", partFqdn, args...)
 		test.That(t,
-			viamClient.machinesPartGetFTDCAction(cCtx, parseStructFromCtx[machinesPartGetFTDCArgs](cCtx), logger),
+			viamClient.machinesPartGetFTDCAction(cCtx, parseStructFromCtx[machinesPartGetFTDCArgs](cCtx), true, logger),
 			test.ShouldNotBeNil)
 
 		entries, err := os.ReadDir(tempDir)
@@ -1277,7 +1277,7 @@ func TestShellGetFTDC(t *testing.T) {
 			cCtx, viamClient, _, _ := setupWithRunningPart(
 				t, asc, nil, nil, partFlags, "token", partFqdn, args...)
 			test.That(t,
-				viamClient.machinesPartGetFTDCAction(cCtx, parseStructFromCtx[machinesPartGetFTDCArgs](cCtx), logger),
+				viamClient.machinesPartGetFTDCAction(cCtx, parseStructFromCtx[machinesPartGetFTDCArgs](cCtx), true, logger),
 				test.ShouldBeNil)
 
 			entries, err := os.ReadDir(filepath.Join(targetPath, partID))

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -1175,6 +1175,128 @@ func TestShellFileCopy(t *testing.T) {
 	})
 }
 
+func TestShellGetFTDC(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+
+	listOrganizationsFunc := func(ctx context.Context, in *apppb.ListOrganizationsRequest,
+		opts ...grpc.CallOption,
+	) (*apppb.ListOrganizationsResponse, error) {
+		orgs := []*apppb.Organization{{Name: "jedi", Id: uuid.NewString(), PublicNamespace: "anakin"}, {Name: "mandalorians"}}
+		return &apppb.ListOrganizationsResponse{Organizations: orgs}, nil
+	}
+	listLocationsFunc := func(ctx context.Context, in *apppb.ListLocationsRequest,
+		opts ...grpc.CallOption,
+	) (*apppb.ListLocationsResponse, error) {
+		locs := []*apppb.Location{{Name: "naboo"}}
+		return &apppb.ListLocationsResponse{Locations: locs}, nil
+	}
+	listRobotsFunc := func(ctx context.Context, in *apppb.ListRobotsRequest,
+		opts ...grpc.CallOption,
+	) (*apppb.ListRobotsResponse, error) {
+		robots := []*apppb.Robot{{Name: "r2d2"}}
+		return &apppb.ListRobotsResponse{Robots: robots}, nil
+	}
+
+	partFqdn := uuid.NewString()
+	partID := uuid.NewString()
+	getRobotPartsFunc := func(ctx context.Context, in *apppb.GetRobotPartsRequest,
+		opts ...grpc.CallOption,
+	) (*apppb.GetRobotPartsResponse, error) {
+		parts := []*apppb.RobotPart{{Name: "main", Fqdn: partFqdn, Id: partID}}
+		return &apppb.GetRobotPartsResponse{Parts: parts}, nil
+	}
+
+	asc := &inject.AppServiceClient{
+		ListOrganizationsFunc: listOrganizationsFunc,
+		ListLocationsFunc:     listLocationsFunc,
+		ListRobotsFunc:        listRobotsFunc,
+		GetRobotPartsFunc:     getRobotPartsFunc,
+	}
+
+	partFlags := map[string]any{
+		"organization": "jedi",
+		"location":     "naboo",
+		"robot":        "r2d2",
+		"part":         "main",
+	}
+
+	t.Run("no arguments or files", func(t *testing.T) {
+		cCtx, viamClient, _, _ := setup(asc, nil, nil, partFlags, "token")
+		test.That(t,
+			viamClient.machinesPartGetFTDCAction(cCtx, parseStructFromCtx[machinesPartGetFTDCArgs](cCtx), logger),
+			test.ShouldBeError, wrongNumArgsError{1, 0})
+	})
+
+	t.Run("too many arguments", func(t *testing.T) {
+		args := []string{"foo", "bar"}
+		cCtx, viamClient, _, _ := setup(asc, nil, nil, partFlags, "token", args...)
+		test.That(t,
+			viamClient.machinesPartGetFTDCAction(cCtx, parseStructFromCtx[machinesPartGetFTDCArgs](cCtx), logger),
+			test.ShouldBeError, wrongNumArgsError{1, 2})
+	})
+
+	tfs := shelltestutils.SetupTestFileSystem(t)
+
+	t.Run("ftdc data does not exist", func(t *testing.T) {
+		tempDir := t.TempDir()
+
+		originalFTDCPath := ftdcPath
+		ftdcPath = filepath.Join(tfs.Root, "FAKEDIR")
+		t.Cleanup(func() {
+			ftdcPath = originalFTDCPath
+		})
+
+		args := []string{tempDir}
+		cCtx, viamClient, _, _ := setupWithRunningPart(
+			t, asc, nil, nil, partFlags, "token", partFqdn, args...)
+		test.That(t,
+			viamClient.machinesPartGetFTDCAction(cCtx, parseStructFromCtx[machinesPartGetFTDCArgs](cCtx), logger),
+			test.ShouldNotBeNil)
+
+		entries, err := os.ReadDir(tempDir)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, entries, test.ShouldHaveLength, 0)
+	})
+
+	t.Run("ftdc data exists", func(t *testing.T) {
+		tempDir := t.TempDir()
+
+		tmpPartFtdcPath := filepath.Join(tfs.Root, partID)
+		err := os.Mkdir(tmpPartFtdcPath, 0o750)
+		test.That(t, err, test.ShouldBeNil)
+		t.Cleanup(func() {
+			os.RemoveAll(tmpPartFtdcPath)
+			test.That(t, err, test.ShouldBeNil)
+		})
+		err = os.WriteFile(filepath.Join(tfs.Root, partID, "foo"), nil, 0o640)
+		test.That(t, err, test.ShouldBeNil)
+		originalFTDCPath := ftdcPath
+		ftdcPath = tfs.Root
+		t.Cleanup(func() {
+			ftdcPath = originalFTDCPath
+		})
+
+		args := []string{tempDir}
+		cCtx, viamClient, _, _ := setupWithRunningPart(
+			t, asc, nil, nil, partFlags, "token", partFqdn, args...)
+		test.That(t,
+			viamClient.machinesPartGetFTDCAction(cCtx, parseStructFromCtx[machinesPartGetFTDCArgs](cCtx), logger),
+			test.ShouldBeNil)
+
+		entries, err := os.ReadDir(tempDir)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, entries, test.ShouldHaveLength, 1)
+		subdirEntry := entries[0]
+		test.That(t, subdirEntry.Name(), test.ShouldEqual, partID)
+		test.That(t, subdirEntry.IsDir(), test.ShouldBeTrue)
+		subdirEntries, err := os.ReadDir(filepath.Join(tempDir, subdirEntry.Name()))
+		test.That(t, subdirEntries, test.ShouldHaveLength, 1)
+		ftdcFile := subdirEntries[0]
+		test.That(t, ftdcFile.Name(), test.ShouldEqual, "foo")
+		test.That(t, ftdcFile.IsDir(), test.ShouldBeFalse)
+	})
+}
+
 func TestCreateOAuthAppAction(t *testing.T) {
 	createOAuthAppFunc := func(ctx context.Context, in *apppb.CreateOAuthAppRequest,
 		opts ...grpc.CallOption,


### PR DESCRIPTION
Does what the title says. Internally the new command is reusing the file copy code with presets for the path and flags.