### PR TITLE
APP-8440 upgrade runner for windows tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,7 @@ jobs:
 
   test_win:
     name: windows
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
## What changed
- Move windows tests from windows-2019 to windows-2022 runner
## Why
Github is [deprecating the windows-2019 runner](https://github.com/actions/runner-images/issues/12045).
## Manual tests
- :heavy_check_mark: successful CI run [here](https://github.com/viamrobotics/rdk/actions/runs/15424790628/job/43408898257)
## Note
This doesn't affect the windows RDK build, which happens on an ubuntu runner [here](https://github.com/viamrobotics/rdk/blob/main/.github/workflows/staticbuild.yml#L37-L40) using the `make windows` cross-compilation target.