### PR TITLE
RSDK-10679: Download images from Viam Cloud by Binary Data ID using Viam CLI

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -1071,35 +1071,64 @@ var app = &cli.App{
 					HideHelpCommand: true,
 					Subcommands: []*cli.Command{
 						{
-							Name:      "binary",
-							Usage:     "download binary data",
-							UsageText: createUsageText("data export binary", []string{generalFlagDestination}, true, false),
-							Flags: append([]cli.Flag{
-								&cli.PathFlag{
-									Name:     generalFlagDestination,
-									Required: true,
-									Usage:    "output directory for downloaded data",
+							Name:            "binary",
+							Usage:           "download binary data",
+							UsageText:       createUsageText("data export binary", nil, false, true),
+							HideHelpCommand: true,
+							Subcommands: []*cli.Command{
+								{
+									Name:            "filter",
+									Usage:           "download binary data using filters",
+									UsageText:       createUsageText("data export binary filter", []string{generalFlagDestination}, true, false),
+									HideHelpCommand: true,
+									Flags: append([]cli.Flag{
+										&cli.PathFlag{
+											Name:     generalFlagDestination,
+											Required: true,
+											Usage:    "output directory for downloaded data",
+										},
+										&cli.UintFlag{
+											Name:  dataFlagParallelDownloads,
+											Usage: "number of download requests to make in parallel",
+											Value: 100,
+										},
+										&cli.UintFlag{
+											Name:  dataFlagTimeout,
+											Usage: "number of seconds to wait for large file downloads",
+											Value: 30,
+										},
+										&cli.StringSliceFlag{
+											Name:  generalFlagTags,
+											Usage: "tags filter. accepts 'tagged' for all tagged data, 'untagged' for all untagged data, or a list of tags",
+										},
+									}, commonFilterFlags...),
+									Action: createCommandWithT[dataExportBinaryArgs](DataExportBinaryAction),
 								},
-								&cli.UintFlag{
-									Name:  dataFlagParallelDownloads,
-									Usage: "number of download requests to make in parallel",
-									Value: 100,
+								{
+									Name:            "ids",
+									Usage:           "download binary data by specific IDs",
+									UsageText:       createUsageText("data export binary ids", []string{generalFlagDestination, dataFlagBinaryDataIDs}, true, false),
+									HideHelpCommand: true,
+									Flags: []cli.Flag{
+										&cli.PathFlag{
+											Name:     generalFlagDestination,
+											Required: true,
+											Usage:    "output directory for downloaded data",
+										},
+										&cli.UintFlag{
+											Name:  dataFlagTimeout,
+											Usage: "number of seconds to wait for large file downloads",
+											Value: 30,
+										},
+										&cli.StringSliceFlag{
+											Name:     dataFlagBinaryDataIDs,
+											Required: true,
+											Usage:    "binary data ids to query for. accepts a single binary data id or list of comma-separated binary data ids",
+										},
+									},
+									Action: createCommandWithT[dataExportBinaryIDsArgs](DataExportBinaryIDsAction),
 								},
-								&cli.UintFlag{
-									Name:  dataFlagTimeout,
-									Usage: "number of seconds to wait for large file downloads",
-									Value: 30,
-								},
-								&cli.StringSliceFlag{
-									Name:  generalFlagTags,
-									Usage: "tags filter. accepts 'tagged' for all tagged data, 'untagged' for all untagged data, or a list of tags",
-								},
-								&cli.StringSliceFlag{
-									Name:  dataFlagBinaryDataIDs,
-									Usage: "binary id to query for. accepts a single binary id or list of comma-separated binary ids",
-								},
-							}, commonFilterFlags...),
-							Action: createCommandWithT[dataExportBinaryArgs](DataExportBinaryAction),
+							},
 						},
 						{
 							Name:  "tabular",

--- a/cli/app.go
+++ b/cli/app.go
@@ -1094,6 +1094,10 @@ var app = &cli.App{
 									Name:  generalFlagTags,
 									Usage: "tags filter. accepts 'tagged' for all tagged data, 'untagged' for all untagged data, or a list of tags",
 								},
+								&cli.StringSliceFlag{
+									Name:  dataFlagBinaryDataIDs,
+									Usage: "binary id to query for. accepts a single binary id or list of comma-separated binary ids",
+								},
 							}, commonFilterFlags...),
 							Action: createCommandWithT[dataExportBinaryArgs](DataExportBinaryAction),
 						},

--- a/cli/data.go
+++ b/cli/data.go
@@ -69,11 +69,12 @@ type commonFilterArgs struct {
 }
 
 type dataExportBinaryArgs struct {
-	Destination string
-	ChunkLimit  uint
-	Parallel    uint
-	DataType    string
-	Timeout     uint
+	Destination   string
+	ChunkLimit    uint
+	Parallel      uint
+	DataType      string
+	Timeout       uint
+	BinaryDataIds []string
 }
 
 type dataExportTabularArgs struct {
@@ -325,16 +326,23 @@ func createCaptureInterval(startStr, endStr string) (*datapb.CaptureInterval, er
 }
 
 func (c *viamClient) dataExportBinaryAction(cCtx *cli.Context, args dataExportBinaryArgs) error {
-	filter, err := createDataFilter(cCtx)
-	if err != nil {
-		return err
-	}
+	if args.BinaryDataIds != nil && len(args.BinaryDataIds) > 0 {
+		result := c.downloadBinary(args.Destination, args.Timeout, args.BinaryDataIds...)
+		if result == nil { // nil result means success
+			printf(c.c.App.Writer, "Downloaded %d files", len(args.BinaryDataIds))
+		}
+		return result
+	} else {
+		filter, err := createDataFilter(cCtx)
+		if err != nil {
+			return err
+		}
 
-	if err := c.binaryData(args.Destination, filter, args.Parallel, args.Timeout); err != nil {
-		return err
+		if err := c.binaryData(args.Destination, filter, args.Parallel, args.Timeout); err != nil {
+			return err
+		}
+		return nil
 	}
-
-	return nil
 }
 
 func (c *viamClient) dataExportTabularAction(cCtx *cli.Context, args dataExportTabularArgs) error {
@@ -354,7 +362,7 @@ func (c *viamClient) dataExportTabularAction(cCtx *cli.Context, args dataExportT
 func (c *viamClient) binaryData(dst string, filter *datapb.Filter, parallelDownloads, timeout uint) error {
 	return c.performActionOnBinaryDataFromFilter(
 		func(id string) error {
-			return c.downloadBinary(dst, id, timeout)
+			return c.downloadBinary(dst, timeout, id)
 		},
 		filter, parallelDownloads,
 		func(i int32) {
@@ -486,27 +494,27 @@ func getMatchingBinaryIDs(ctx context.Context, client datapb.DataServiceClient, 
 	}
 }
 
-func (c *viamClient) downloadBinary(dst, id string, timeout uint) error {
+func (c *viamClient) downloadBinary(dst string, timeout uint, id ...string) error {
 	args, err := getGlobalArgs(c.c)
 	if err != nil {
 		return err
 	}
-	debugf(c.c.App.Writer, args.Debug, "Attempting to download binary file %s", id)
+	debugf(c.c.App.Writer, args.Debug, "Attempting to download binary files: %v", id)
 
 	var resp *datapb.BinaryDataByIDsResponse
 	largeFile := false
-	// To begin, we assume the file is small and downloadable, so we try getting the binary directly
+	// To begin, we assume the files are small and downloadable, so we try getting the binary directly
 	for count := 0; count < maxRetryCount; count++ {
 		resp, err = c.dataClient.BinaryDataByIDs(c.c.Context, &datapb.BinaryDataByIDsRequest{
-			BinaryDataIds: []string{id},
+			BinaryDataIds: id,
 			IncludeBinary: !largeFile,
 		})
-		// If the file is too large, we break and try a different pathway for downloading
+		// If any file is too large, we break and try a different pathway for downloading
 		if err == nil || status.Code(err) == codes.ResourceExhausted {
-			debugf(c.c.App.Writer, args.Debug, "Small file download file %s: attempt %d/%d succeeded", id, count+1, maxRetryCount)
+			debugf(c.c.App.Writer, args.Debug, "Small file download for files %v: attempt %d/%d succeeded", id, count+1, maxRetryCount)
 			break
 		}
-		debugf(c.c.App.Writer, args.Debug, "Small file download for file %s: attempt %d/%d failed", id, count+1, maxRetryCount)
+		debugf(c.c.App.Writer, args.Debug, "Small file download for files %v: attempt %d/%d failed", id, count+1, maxRetryCount)
 	}
 	// For large files, we get the metadata but not the binary itself
 	// Resource exhausted is returned when the message we're receiving exceeds the GRPC maximum limit
@@ -514,14 +522,14 @@ func (c *viamClient) downloadBinary(dst, id string, timeout uint) error {
 		largeFile = true
 		for count := 0; count < maxRetryCount; count++ {
 			resp, err = c.dataClient.BinaryDataByIDs(c.c.Context, &datapb.BinaryDataByIDsRequest{
-				BinaryDataIds: []string{id},
+				BinaryDataIds: id,
 				IncludeBinary: !largeFile,
 			})
 			if err == nil {
-				debugf(c.c.App.Writer, args.Debug, "Metadata fetch for file %s: attempt %d/%d succeeded", id, count+1, maxRetryCount)
+				debugf(c.c.App.Writer, args.Debug, "Metadata fetch for files %v: attempt %d/%d succeeded", id, count+1, maxRetryCount)
 				break
 			}
-			debugf(c.c.App.Writer, args.Debug, "Metadata fetch for file %s: attempt %d/%d failed", id, count+1, maxRetryCount)
+			debugf(c.c.App.Writer, args.Debug, "Metadata fetch for files %v: attempt %d/%d failed", id, count+1, maxRetryCount)
 		}
 	}
 	if err != nil {
@@ -529,122 +537,125 @@ func (c *viamClient) downloadBinary(dst, id string, timeout uint) error {
 	}
 
 	data := resp.GetData()
-	if len(data) != 1 {
-		return errors.Errorf("expected a single response, received %d", len(data))
-	}
-	datum := data[0]
 
-	fileName := filenameForDownload(datum.GetMetadata())
-	// Modify the file name in the metadata to reflect what it will be saved as.
-	metadata := datum.GetMetadata()
-	metadata.FileName = fileName
-
-	jsonPath := filepath.Join(dst, metadataDir, fileName+".json")
-	if err := os.MkdirAll(filepath.Dir(jsonPath), 0o700); err != nil {
-		return errors.Wrapf(err, "could not create metadata directory %s", filepath.Dir(jsonPath))
-	}
-	//nolint:gosec
-	jsonFile, err := os.Create(jsonPath)
-	if err != nil {
-		return err
-	}
-	mdJSONBytes, err := protojson.Marshal(metadata)
-	if err != nil {
-		return err
-	}
-	if _, err := jsonFile.Write(mdJSONBytes); err != nil {
-		return err
+	// Loop through responses and download each file
+	if len(data) != len(id) {
+		return errors.Errorf("expected %d responses for %d files, received %d responses", len(id), len(id), len(data))
 	}
 
-	var r io.ReadCloser
-	if largeFile {
-		debugf(c.c.App.Writer, args.Debug, "Attempting file %s as a large file download", id)
-		// Make request to the URI for large files since we exceed the message limit for gRPC
-		req, err := http.NewRequestWithContext(c.c.Context, http.MethodGet, datum.GetMetadata().GetUri(), nil)
+	for i, datum := range data {
+		currentID := id[i]
+		fileName := filenameForDownload(datum.GetMetadata())
+		// Modify the file name in the metadata to reflect what it will be saved as.
+		metadata := datum.GetMetadata()
+		metadata.FileName = fileName
+
+		jsonPath := filepath.Join(dst, metadataDir, fileName+".json")
+		if err := os.MkdirAll(filepath.Dir(jsonPath), 0o700); err != nil {
+			return errors.Wrapf(err, "could not create metadata directory %s", filepath.Dir(jsonPath))
+		}
+		//nolint:gosec
+		jsonFile, err := os.Create(jsonPath)
 		if err != nil {
-			return errors.Wrapf(err, serverErrorMessage)
-		}
-
-		// Set the headers so HTTP requests that are not gRPC calls can still be authenticated in app
-		// We can authenticate via token or API key, so we try both.
-		token, ok := c.conf.Auth.(*token)
-		if ok {
-			req.Header.Add(rpc.MetadataFieldAuthorization, rpc.AuthorizationValuePrefixBearer+token.AccessToken)
-		}
-		apiKey, ok := c.conf.Auth.(*apiKey)
-		if ok {
-			req.Header.Add("key_id", apiKey.KeyID)
-			req.Header.Add("key", apiKey.KeyCrypto)
-		}
-
-		httpClient := &http.Client{Timeout: time.Duration(timeout) * time.Second}
-
-		var res *http.Response
-		for count := 0; count < maxRetryCount; count++ {
-			res, err = httpClient.Do(req)
-
-			if err == nil && res.StatusCode == http.StatusOK {
-				debugf(c.c.App.Writer, args.Debug,
-					"Large file download for file %s: attempt %d/%d succeeded", id, count+1, maxRetryCount)
-				break
-			}
-			debugf(c.c.App.Writer, args.Debug, "Large file download for file %s: attempt %d/%d failed", id, count+1, maxRetryCount)
-		}
-
-		if err != nil {
-			debugf(c.c.App.Writer, args.Debug, "Failed downloading large file %s: %s", id, err)
-			return errors.Wrapf(err, serverErrorMessage)
-		}
-		if res.StatusCode != http.StatusOK {
-			debugf(c.c.App.Writer, args.Debug, "Failed downloading large file %s: Server returned %d response", id, res.StatusCode)
-			return errors.New(serverErrorMessage)
-		}
-		defer func() {
-			utils.UncheckedError(res.Body.Close())
-		}()
-
-		r = res.Body
-	} else {
-		// If the binary has not already been populated as large file download,
-		// get the binary data from the response.
-		r = io.NopCloser(bytes.NewReader(datum.GetBinary()))
-	}
-
-	dataPath := filepath.Join(dst, dataDir, fileName)
-	ext := datum.GetMetadata().GetFileExt()
-
-	// If the file is gzipped, unzip.
-	if ext == gzFileExt {
-		r, err = gzip.NewReader(r)
-		if err != nil {
-			debugf(c.c.App.Writer, args.Debug, "Failed unzipping file %s: %s", id, err)
 			return err
 		}
-	} else if filepath.Ext(dataPath) != ext {
-		// If the file name did not already include the extension (e.g. for data capture files), add it.
-		// Don't do this for files that we're unzipping.
-		dataPath += ext
-	}
+		mdJSONBytes, err := protojson.Marshal(metadata)
+		if err != nil {
+			return err
+		}
+		if _, err := jsonFile.Write(mdJSONBytes); err != nil {
+			return err
+		}
 
-	if err := os.MkdirAll(filepath.Dir(dataPath), 0o700); err != nil {
-		debugf(c.c.App.Writer, args.Debug, "Failed creating data directory %s: %s", dataPath, err)
-		return errors.Wrapf(err, "could not create data directory %s", filepath.Dir(dataPath))
-	}
-	//nolint:gosec
-	dataFile, err := os.Create(dataPath)
-	if err != nil {
-		debugf(c.c.App.Writer, args.Debug, "Failed creating file %s: %s", id, err)
-		//nolint:deprecated,staticcheck
-		return errors.Wrapf(err, fmt.Sprintf("could not create file for datum %s", datum.GetMetadata().GetId())) //nolint:govet
-	}
-	//nolint:gosec
-	if _, err := io.Copy(dataFile, r); err != nil {
-		debugf(c.c.App.Writer, args.Debug, "Failed writing data to file %s: %s", id, err)
-		return err
-	}
-	if err := r.Close(); err != nil {
-		debugf(c.c.App.Writer, args.Debug, "Failed closing file %s: %s", id, err)
-		return err
+		var r io.ReadCloser
+		if largeFile {
+			debugf(c.c.App.Writer, args.Debug, "Attempting file %s as a large file download", currentID)
+			// Make request to the URI for large files since we exceed the message limit for gRPC
+			req, err := http.NewRequestWithContext(c.c.Context, http.MethodGet, datum.GetMetadata().GetUri(), nil)
+			if err != nil {
+				return errors.Wrapf(err, serverErrorMessage)
+			}
+
+			// Set the headers so HTTP requests that are not gRPC calls can still be authenticated in app
+			// We can authenticate via token or API key, so we try both.
+			token, ok := c.conf.Auth.(*token)
+			if ok {
+				req.Header.Add(rpc.MetadataFieldAuthorization, rpc.AuthorizationValuePrefixBearer+token.AccessToken)
+			}
+			apiKey, ok := c.conf.Auth.(*apiKey)
+			if ok {
+				req.Header.Add("key_id", apiKey.KeyID)
+				req.Header.Add("key", apiKey.KeyCrypto)
+			}
+
+			httpClient := &http.Client{Timeout: time.Duration(timeout) * time.Second}
+
+			var res *http.Response
+			for count := 0; count < maxRetryCount; count++ {
+				res, err = httpClient.Do(req)
+
+				if err == nil && res.StatusCode == http.StatusOK {
+					debugf(c.c.App.Writer, args.Debug,
+						"Large file download for file %s: attempt %d/%d succeeded", currentID, count+1, maxRetryCount)
+					break
+				}
+				debugf(c.c.App.Writer, args.Debug, "Large file download for file %s: attempt %d/%d failed", currentID, count+1, maxRetryCount)
+			}
+
+			if err != nil {
+				debugf(c.c.App.Writer, args.Debug, "Failed downloading large file %s: %s", currentID, err)
+				return errors.Wrapf(err, serverErrorMessage)
+			}
+			if res.StatusCode != http.StatusOK {
+				debugf(c.c.App.Writer, args.Debug, "Failed downloading large file %s: Server returned %d response", currentID, res.StatusCode)
+				return errors.New(serverErrorMessage)
+			}
+			defer func() {
+				utils.UncheckedError(res.Body.Close())
+			}()
+
+			r = res.Body
+		} else {
+			// If the binary has not already been populated as large file download,
+			// get the binary data from the response.
+			r = io.NopCloser(bytes.NewReader(datum.GetBinary()))
+		}
+
+		dataPath := filepath.Join(dst, dataDir, fileName)
+		ext := datum.GetMetadata().GetFileExt()
+
+		// If the file is gzipped, unzip.
+		if ext == gzFileExt {
+			r, err = gzip.NewReader(r)
+			if err != nil {
+				debugf(c.c.App.Writer, args.Debug, "Failed unzipping file %s: %s", currentID, err)
+				return err
+			}
+		} else if filepath.Ext(dataPath) != ext {
+			// If the file name did not already include the extension (e.g. for data capture files), add it.
+			// Don't do this for files that we're unzipping.
+			dataPath += ext
+		}
+
+		if err := os.MkdirAll(filepath.Dir(dataPath), 0o700); err != nil {
+			debugf(c.c.App.Writer, args.Debug, "Failed creating data directory %s: %s", dataPath, err)
+			return errors.Wrapf(err, "could not create data directory %s", filepath.Dir(dataPath))
+		}
+		//nolint:gosec
+		dataFile, err := os.Create(dataPath)
+		if err != nil {
+			debugf(c.c.App.Writer, args.Debug, "Failed creating file %s: %s", currentID, err)
+			return errors.Wrapf(err, "could not create file for datum %s", currentID)
+		}
+		//nolint:gosec
+		if _, err := io.Copy(dataFile, r); err != nil {
+			debugf(c.c.App.Writer, args.Debug, "Failed writing data to file %s: %s", currentID, err)
+			return err
+		}
+		if err := r.Close(); err != nil {
+			debugf(c.c.App.Writer, args.Debug, "Failed closing file %s: %s", currentID, err)
+			return err
+		}
 	}
 	return nil
 }

--- a/cli/dataset.go
+++ b/cli/dataset.go
@@ -214,7 +214,7 @@ func (c *viamClient) downloadDataset(dst, datasetID string, includeJSONLines boo
 
 	return c.performActionOnBinaryDataFromFilter(
 		func(id string) error {
-			downloadErr := c.downloadBinary(dst, id, timeout)
+			downloadErr := c.downloadBinary(dst, timeout, id)
 			var datasetErr error
 			if includeJSONLines {
 				datasetErr = binaryDataToJSONLines(c.c.Context, c.dataClient, dst, datasetFile, id)


### PR DESCRIPTION
Allowing export/download of images from Viam Cloud from the CLI.

This PR includes:
- addition of --binary data-ids string slice flag to the data export binary command in the cli
- modifications to downloadBinary() to take in a variate string slice id instead of a single id
- modifications to dataExportBinaryAction() to call downloadBinary() directly when flag --binary-data-ids is provided

Tested using a mock machine with dummy images. Checked that the correct files were downloaded and correct function was called whenever the binary data flag was set even if other flags are provided. Functional for a single binary id as well as multiple comma separated binary ids are provided. 