### PR TITLE
APP-8183: Print client name for oauth app read command

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -2765,7 +2765,7 @@ func (c *viamClient) readOAuthAppAction(cCtx *cli.Context, orgID, clientID strin
 	config := resp.OauthConfig
 	printf(cCtx.App.Writer, "OAuth config for client ID %s:", clientID)
 	printf(cCtx.App.Writer, "")
-	printf(cCtx.App.Writer, "Client name: %s", resp.ClientName)
+	printf(cCtx.App.Writer, "Client Name: %s", resp.ClientName)
 	printf(cCtx.App.Writer, "Client Authentication: %s", formatStringForOutput(config.ClientAuthentication.String(),
 		clientAuthenticationPrefix))
 	printf(cCtx.App.Writer, "PKCE (Proof Key for Code Exchange): %s", formatStringForOutput(config.Pkce.String(), pkcePrefix))

--- a/cli/client.go
+++ b/cli/client.go
@@ -2765,6 +2765,7 @@ func (c *viamClient) readOAuthAppAction(cCtx *cli.Context, orgID, clientID strin
 	config := resp.OauthConfig
 	printf(cCtx.App.Writer, "OAuth config for client ID %s:", clientID)
 	printf(cCtx.App.Writer, "")
+	printf(cCtx.App.Writer, "Client name: %s", resp.ClientName)
 	printf(cCtx.App.Writer, "Client Authentication: %s", formatStringForOutput(config.ClientAuthentication.String(),
 		clientAuthenticationPrefix))
 	printf(cCtx.App.Writer, "PKCE (Proof Key for Code Exchange): %s", formatStringForOutput(config.Pkce.String(), pkcePrefix))

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -1253,7 +1253,7 @@ func TestReadOAuthApp(t *testing.T) {
 	test.That(t, len(out.messages), test.ShouldEqual, 10)
 	test.That(t, len(errOut.messages), test.ShouldEqual, 0)
 	test.That(t, out.messages[0], test.ShouldContainSubstring, "OAuth config for client ID test-client-id")
-	test.That(t, out.messages[2], test.ShouldContainSubstring, "Client name: clientname")
+	test.That(t, out.messages[2], test.ShouldContainSubstring, "Client Name: clientname")
 	test.That(t, out.messages[3], test.ShouldContainSubstring, "Client Authentication: required")
 	test.That(t, out.messages[4], test.ShouldContainSubstring, "PKCE (Proof Key for Code Exchange): required")
 	test.That(t, out.messages[5], test.ShouldContainSubstring, "URL Validation Policy: allow_wildcards")

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -1250,16 +1250,17 @@ func TestReadOAuthApp(t *testing.T) {
 	cCtx, ac, out, errOut := setup(asc, nil, nil, nil, "token")
 
 	test.That(t, ac.readOAuthAppAction(cCtx, "test-org-id", "test-client-id"), test.ShouldBeNil)
-	test.That(t, len(out.messages), test.ShouldEqual, 9)
+	test.That(t, len(out.messages), test.ShouldEqual, 10)
 	test.That(t, len(errOut.messages), test.ShouldEqual, 0)
 	test.That(t, out.messages[0], test.ShouldContainSubstring, "OAuth config for client ID test-client-id")
-	test.That(t, out.messages[2], test.ShouldContainSubstring, "Client Authentication: required")
-	test.That(t, out.messages[3], test.ShouldContainSubstring, "PKCE (Proof Key for Code Exchange): required")
-	test.That(t, out.messages[4], test.ShouldContainSubstring, "URL Validation Policy: allow_wildcards")
-	test.That(t, out.messages[5], test.ShouldContainSubstring, "Logout URL: https://my-logout-uri.com")
-	test.That(t, out.messages[6], test.ShouldContainSubstring, "Redirect URLs: https://my-redirect-uri.com")
-	test.That(t, out.messages[7], test.ShouldContainSubstring, "Origin URLs: https://my-origin-uri.com, https://second-origin-uri.com")
-	test.That(t, out.messages[8], test.ShouldContainSubstring, "Enabled Grants: implicit, password")
+	test.That(t, out.messages[2], test.ShouldContainSubstring, "Client name: clientname")
+	test.That(t, out.messages[3], test.ShouldContainSubstring, "Client Authentication: required")
+	test.That(t, out.messages[4], test.ShouldContainSubstring, "PKCE (Proof Key for Code Exchange): required")
+	test.That(t, out.messages[5], test.ShouldContainSubstring, "URL Validation Policy: allow_wildcards")
+	test.That(t, out.messages[6], test.ShouldContainSubstring, "Logout URL: https://my-logout-uri.com")
+	test.That(t, out.messages[7], test.ShouldContainSubstring, "Redirect URLs: https://my-redirect-uri.com")
+	test.That(t, out.messages[8], test.ShouldContainSubstring, "Origin URLs: https://my-origin-uri.com, https://second-origin-uri.com")
+	test.That(t, out.messages[9], test.ShouldContainSubstring, "Enabled Grants: implicit, password")
 }
 
 func TestUpdateOAuthAppAction(t *testing.T) {


### PR DESCRIPTION
When somebody runs `viam organization auth-service oauth-app read` we only print the oauth config information. We should also print the client name. 