### PR TITLE
in hot reload, clearer error when no file is at build.path

### DIFF
--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -605,7 +605,7 @@ func reloadingDestination(c *cli.Context, manifest *moduleManifest) string {
 func validateReloadableArchive(c *cli.Context, build *manifestBuildInfo) error {
 	reader, err := os.Open(build.Path)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "error opening the build.path field in your meta.json")
 	}
 	decompressed, err := gzip.NewReader(reader)
 	if err != nil {


### PR DESCRIPTION
## What changed
- wrap the os.Open failure in hot reloading
## Why
I've seen multiple users get to this step in reloading and not know that they need to look at meta.json to resolve