### PR TITLE
RSDK-10508 Client-side latency measurements

### DIFF
--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -386,10 +386,14 @@ func New(ctx context.Context, address string, clientLogger logging.ZapCompatible
 			timeElapsed := time.Since(startTime).Milliseconds()
 			totalTime += float64(timeElapsed)
 		}
-		totalTime /= float64(latencyPingNum)
-		rc.Logger().CInfo(ctx, fmt.Sprintf("average connection latency is %.2f ms", totalTime))
-		if totalTime > latencyWarningThresholdMs {
-			rc.Logger().CWarn(ctx, "average latency is higher than 1 second")
+		if totalTime < 1.0 {
+			rc.Logger().CInfo(ctx, "average connection latency is < 1ms")
+		} else {
+			totalTime /= float64(latencyPingNum)
+			rc.Logger().CInfo(ctx, fmt.Sprintf("average connection latency is %.2f ms", totalTime))
+			if totalTime > latencyWarningThresholdMs {
+				rc.Logger().CWarn(ctx, "average latency is higher than 1 second")
+			}
 		}
 	}
 

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -391,7 +391,6 @@ func New(ctx context.Context, address string, clientLogger logging.ZapCompatible
 		} else {
 			totalTime /= float64(latencyPingNum)
 			rc.Logger().CInfo(ctx, fmt.Sprintf("average connection latency is %.2f ms", totalTime))
-			totalTime += 1000.0
 			if totalTime > latencyWarningThresholdMs {
 				rc.Logger().CWarn(ctx, fmt.Sprintf("average latency is higher than %.0f ms", latencyWarningThresholdMs))
 			}

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -391,8 +391,9 @@ func New(ctx context.Context, address string, clientLogger logging.ZapCompatible
 		} else {
 			totalTime /= float64(latencyPingNum)
 			rc.Logger().CInfo(ctx, fmt.Sprintf("average connection latency is %.2f ms", totalTime))
+			totalTime += 1000.0
 			if totalTime > latencyWarningThresholdMs {
-				rc.Logger().CWarn(ctx, "average latency is higher than 1 second")
+				rc.Logger().CWarn(ctx, fmt.Sprintf("average latency is higher than %.0f ms", latencyWarningThresholdMs))
 			}
 		}
 	}

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -378,6 +378,7 @@ func New(ctx context.Context, address string, clientLogger logging.ZapCompatible
 		totalTime := 0.0
 		for range latencyPingNum {
 			startTime := time.Now()
+			// GetOperations is used because app.viam.com's "Control" tab measures latency this way.
 			_, err := rc.client.GetOperations(ctx, &pb.GetOperationsRequest{})
 			if err != nil {
 				rc.Logger().CDebug(ctx, fmt.Sprintf("gRPC request failed with error: %e during latency checks", err))

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -386,12 +386,12 @@ func New(ctx context.Context, address string, clientLogger logging.ZapCompatible
 			timeElapsed := time.Since(startTime).Milliseconds()
 			totalTime += float64(timeElapsed)
 		}
-		if totalTime < 1.0 {
+		avgTime := totalTime / float64(latencyPingNum)
+		if avgTime < 1.0 {
 			rc.Logger().CInfo(ctx, "average connection latency is < 1ms")
 		} else {
-			totalTime /= float64(latencyPingNum)
-			rc.Logger().CInfo(ctx, fmt.Sprintf("average connection latency is %.2f ms", totalTime))
-			if totalTime > latencyWarningThresholdMs {
+			rc.Logger().CInfo(ctx, fmt.Sprintf("average connection latency is %.2f ms", avgTime))
+			if avgTime > latencyWarningThresholdMs {
 				rc.Logger().CWarn(ctx, fmt.Sprintf("average latency is higher than %.0f ms", latencyWarningThresholdMs))
 			}
 		}


### PR DESCRIPTION
If a client specifies `WithNetworkStats()` option, there are `latencyPingNum` gRPC `GetOperations` requests that are sent to server. The average time, in milliseconds, is measured and logged back to the client. If the average latency exceeds `latencyWarningThresholdMs`, the client gets an addition warning log line.