### PR TITLE
RSDK-10762 Add test for optional dependency cycles

### DIFF
--- a/robot/impl/optional_dependencies_test.go
+++ b/robot/impl/optional_dependencies_test.go
@@ -619,3 +619,218 @@ func TestModularOptionalDependencies(t *testing.T) {
 		test.That(t, doCommandResp, test.ShouldResemble, map[string]any{"optional_motor_state": "moving: false"})
 	}
 }
+
+// Contains _another_ MOC that this MOC will optionally depend upon.
+type mutualOptionalChildConfig struct {
+	OtherMOC string `json:"other_moc"`
+}
+
+// Validate validates the config and returns an optional dependency on `other_moc`.
+func (mocCfg *mutualOptionalChildConfig) Validate(path string) ([]string, []string, error) {
+	if mocCfg.OtherMOC == "" {
+		return nil, nil,
+			fmt.Errorf(`expected "other_moc" attribute for MOC %q`, path)
+	}
+	return nil, []string{mocCfg.OtherMOC}, nil
+}
+
+type mutualOptionalChild struct {
+	resource.Named
+	resource.TriviallyCloseable
+	logger logging.Logger
+
+	otherMOC      resource.Resource
+	reconfigCount int
+}
+
+func newMutualOptionalChild(ctx context.Context,
+	deps resource.Dependencies,
+	conf resource.Config,
+	logger logging.Logger,
+) (*mutualOptionalChild, error) {
+	moc := &mutualOptionalChild{
+		Named:  conf.ResourceName().AsNamed(),
+		logger: logger,
+	}
+
+	if err := moc.Reconfigure(ctx, deps, conf); err != nil {
+		return nil, err
+	}
+
+	return moc, nil
+}
+
+func (moc *mutualOptionalChild) Reconfigure(ctx context.Context, deps resource.Dependencies,
+	conf resource.Config,
+) error {
+	moc.reconfigCount++
+
+	mutualOptionalChildConfig, err := resource.NativeConfig[*mutualOptionalChildConfig](conf)
+	if err != nil {
+		return err
+	}
+
+	moc.otherMOC, err = generic.FromDependencies(deps, mutualOptionalChildConfig.OtherMOC)
+	if err != nil {
+		moc.logger.Infof("could not get other MOC %s from dependencies; continuing",
+			mutualOptionalChildConfig.OtherMOC)
+	}
+
+	return nil
+}
+
+func TestModularOptionalDependenciesCycles(t *testing.T) {
+	logger, logs := logging.NewObservedTestLogger(t)
+	ctx := context.Background()
+
+	lr := setupLocalRobot(t, ctx, &config.Config{}, logger)
+
+	// Register the mutual optional child component defined above and defer its deregistration.
+	mutualOptionalChildModel := resource.DefaultModelFamily.WithModel(utils.RandomAlphaString(5))
+	mocName := generic.Named("moc")
+	mocName2 := generic.Named("moc2")
+	resource.Register(
+		generic.API,
+		mutualOptionalChildModel,
+		resource.Registration[*mutualOptionalChild, *mutualOptionalChildConfig]{
+			Constructor: newMutualOptionalChild,
+		})
+	defer resource.Deregister(generic.API, mutualOptionalChildModel)
+
+	// Reconfigure the robot to have a mutual optional child component that is missing its
+	// mutual.
+	cfg := config.Config{
+		Components: []resource.Config{
+			{
+				Name:  mocName.Name,
+				API:   generic.API,
+				Model: mutualOptionalChildModel,
+				ConvertedAttributes: &mutualOptionalChildConfig{
+					OtherMOC: mocName2.Name,
+				},
+			},
+		},
+	}
+	// Ensure here and for all configs below before `Reconfigure`ing to make sure optional
+	// dependencies are calculated (`ImplicitOptionalDependsOn` is filled in).
+	test.That(t, cfg.Ensure(false, logger), test.ShouldBeNil)
+	lr.Reconfigure(ctx, &cfg)
+
+	{ // Assertions
+		// Assert that the mutual optional child component built successfully (optional
+		// dependency on non-existent 'moc2' did not cause a failure to build).
+		mocRes, err := lr.ResourceByName(mocName)
+		test.That(t, err, test.ShouldBeNil)
+
+		// Assert that the mutual optional child reconfigured and logged its inability to get
+		// 'moc2' from dependencies _twice_. The first of both is from construction (invokes
+		// `Reconfigure`) of the resource, and the second of both is from reconfiguring of the
+		// resource due to an unconditional call to `updateWeakAndOptionalDependents` directly
+		// after `completeConfig`.
+		moc, err := resource.AsType[*mutualOptionalChild](mocRes)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, moc.reconfigCount, test.ShouldEqual, 2)
+		msgNum := logs.FilterMessageSnippet("could not get other MOC").Len()
+		test.That(t, msgNum, test.ShouldEqual, 2)
+
+		// Assert that, on the component itself, `otherMOC` remains unset.
+		test.That(t, moc.otherMOC, test.ShouldBeNil)
+	}
+
+	// Reconfigure the robot to have the other MOC.
+	cfg = config.Config{
+		Components: []resource.Config{
+			{
+				Name:  mocName.Name,
+				API:   generic.API,
+				Model: mutualOptionalChildModel,
+				ConvertedAttributes: &mutualOptionalChildConfig{
+					OtherMOC: mocName2.Name,
+				},
+			},
+			{
+				Name:  mocName2.Name,
+				API:   generic.API,
+				Model: mutualOptionalChildModel,
+				ConvertedAttributes: &mutualOptionalChildConfig{
+					OtherMOC: mocName.Name,
+				},
+			},
+		},
+	}
+	test.That(t, cfg.Ensure(false, logger), test.ShouldBeNil)
+	lr.Reconfigure(ctx, &cfg)
+
+	{ // Assertions
+		// Assert that the first 'moc' component is still accessible (did not fail to
+		// reconfigure).
+		mocRes, err := lr.ResourceByName(mocName)
+		test.That(t, err, test.ShouldBeNil)
+
+		// Assert that the 'moc' mutual optional child has reconfigured _three_ times. Two
+		// from the previous construction and one from the reconfigure to pass 'moc2' as a
+		// dependency. Assert that there were no more logs (still 2) about failures to "get
+		// other MOC."
+		moc, err := resource.AsType[*mutualOptionalChild](mocRes)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, moc.reconfigCount, test.ShouldEqual, 3)
+		msgNum := logs.FilterMessageSnippet("could not get other MOC").Len()
+		test.That(t, msgNum, test.ShouldEqual, 2)
+
+		// Assert that, on the 'moc' component itself, `otherMOC` is now set.
+		test.That(t, moc.otherMOC, test.ShouldNotBeNil)
+
+		// Assert that the second 'moc2' component is now accessible (did not fail to
+		// construct).
+		mocRes2, err := lr.ResourceByName(mocName2)
+		test.That(t, err, test.ShouldBeNil)
+
+		// Assert that the second mutual optional child has reconfigured _two_ times.
+		moc2, err := resource.AsType[*mutualOptionalChild](mocRes2)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, moc2.reconfigCount, test.ShouldEqual, 2)
+
+		// Assert that, on the 'moc2' component itself, `otherMOC` is now set.
+		test.That(t, moc2.otherMOC, test.ShouldNotBeNil)
+	}
+
+	// Reconfigure the robot to remove the original 'moc'.
+	cfg = config.Config{
+		Components: []resource.Config{
+			{
+				Name:  mocName2.Name,
+				API:   generic.API,
+				Model: mutualOptionalChildModel,
+				ConvertedAttributes: &mutualOptionalChildConfig{
+					OtherMOC: mocName.Name,
+				},
+			},
+		},
+	}
+	test.That(t, cfg.Ensure(false, logger), test.ShouldBeNil)
+	lr.Reconfigure(ctx, &cfg)
+
+	{ // Assertions
+		// Assert that the original optional child component 'moc' is no longer accessible.
+		_, err := lr.ResourceByName(mocName)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, resource.IsNotFoundError(err), test.ShouldBeTrue)
+
+		// Assert that the second optional child component 'moc2' is still accessible.
+		mocRes2, err := lr.ResourceByName(mocName2)
+		test.That(t, err, test.ShouldBeNil)
+
+		// Assert that the second optional child 'moc2' has reconfigured three times. Two from
+		// the previous construction and reconfigure, and one from the most recent reconfigure
+		// to remove 'moc1' as a dependency. Assert that there was another log (now 3) about
+		// failures to "get other MOC."
+		moc2, err := resource.AsType[*mutualOptionalChild](mocRes2)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, moc2.reconfigCount, test.ShouldEqual, 3)
+		msgNum := logs.FilterMessageSnippet("could not get other MOC").Len()
+		test.That(t, msgNum, test.ShouldEqual, 3)
+
+		// Assert that, on the 'moc2' component itself, `otherMOC` is no longer set.
+		test.That(t, moc2.otherMOC, test.ShouldBeNil)
+	}
+}


### PR DESCRIPTION
RSDK-10762

Adding some quick test coverage for optional dependency cycles, since we have had issues in the past with weak dependency cycles.