### PR TITLE
make lint-go: display detected lints nicely before fixing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ generate-go: tool-install
 lint-go: tool-install
 	go mod tidy
 	export pkgs="`go list -f '{{.Dir}}' ./... | grep -v /proto/`" && echo "$$pkgs" | xargs go vet -vettool=$(TOOL_BIN)/combined
-	GOGC=50 $(TOOL_BIN)/golangci-lint run --config=./etc/.golangci.yaml
+	GOGC=50 $(TOOL_BIN)/golangci-lint run --config=./etc/.golangci.yaml || true
 	GOGC=50 $(TOOL_BIN)/golangci-lint run -v --fix --config=./etc/.golangci.yaml
 
 cover-only: tool-install


### PR DESCRIPTION
For example, if I forget the line breaks between the imports in [robot.go](https://github.com/viamrobotics/rdk/blob/main/robot/robot.go), `make lint-go`'s current `golangci-lint run -v --fix` outputs this before fixing it for me:
```
$ GOGC=50 bin/gotools/Linux-x86_64/golangci-lint run -v --fix --config=./etc/.golangci.yaml
. . .
INFO [runner] Line 6 has multiple issues but at least one of them isn't inline: []result.Issue{result.Issue{FromLinter:"gci", Text:"File is not `gci`-ed with --skip-generated -s standard -s default -s prefix(go.viam.com/rdk)", Severity:
"", SourceLines:[]string{"\t\"fmt\""}, Replacement:(*result.Replacement)(0xc0022b5710), Pkg:(*packages.Package)(0xc002
0beb60), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"robot/robot.go", Offset:0, Line:6, Column:0}, Hu
nkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}, result.Issue{FromLinter:"gofumpt", Text:"File is not `gofumpt`-
ed with `-extra`", Severity:"", SourceLines:[]string{"\t\"fmt\""}, Replacement:(*result.Replacement)(0xc0022b57a0), Pk
g:(*packages.Package)(0xc0020beb60), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"robot/robot.go", Off
set:0, Line:6, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}}
INFO [runner] Line 22 has multiple issues but at least one of them is ranged: []result.Issue{result.Issue{FromLinter:"
gci", Text:"File is not `gci`-ed with --skip-generated -s standard -s default -s prefix(go.viam.com/rdk)", Severity:""
, SourceLines:[]string{"\t\"runtime/debug\"", "\t\"strings\""}, Replacement:(*result.Replacement)(0xc0022b5770), Pkg:(
*packages.Package)(0xc0020beb60), LineRange:(*result.Range)(0xc001ff51d0), Pos:token.Position{Filename:"robot/robot.go
", Offset:0, Line:22, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}, result.Issue{FromLinter:"gof
umpt", Text:"File is not `gofumpt`-ed with `-extra`", Severity:"", SourceLines:[]string{"\t\"runtime/debug\"", "\t\"st
rings\""}, Replacement:(*result.Replacement)(0xc0022b57d0), Pkg:(*packages.Package)(0xc0020beb60), LineRange:(*result.
Range)(0xc001ff5220), Pos:token.Position{Filename:"robot/robot.go", Offset:0, Line:22, Column:0}, HunkPos:0, ExpectNoL
int:false, ExpectedNoLintLinter:""}}
. . .
```

The added extra `golangci-lint run` displays the detected issues more nicely (note not every lint supports auto-fixing with `--fix`). `-v` (verbose) does not seem necessary for this informational run. :
```
$ GOGC=50 bin/gotools/Linux-x86_64/golangci-lint run --config=./etc/.golangci.yaml
WARN [config_reader] The configuration option `run.skip-dirs-use-default` is deprecated, please use `issues.exclude-dirs-use-default`.
WARN [config_reader] The configuration option `linters.gofumpt.lang-version` is deprecated, please use global `run.go`.
WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar.
WARN The linter 'execinquery' is deprecated (since v1.58.0) due to: The repository of the linter has been archived by the owner.
WARN [runner/nolint] Found unknown linters in //nolint directives: deprecated, var-naming
app/common.go:88: File is not `gofumpt`-ed with `-extra` (gofumpt)

robot/robot.go:6: File is not `gci`-ed with --skip-generated -s standard -s default -s prefix(go.viam.com/rdk) (gci)
	"fmt"
robot/robot.go:9: File is not `gci`-ed with --skip-generated -s standard -s default -s prefix(go.viam.com/rdk) (gci)
	"github.com/pkg/errors"
robot/robot.go:22: File is not `gci`-ed with --skip-generated -s standard -s default -s prefix(go.viam.com/rdk) (gci)
	"runtime/debug"
	"strings"
```

It is not ideal to have to run this twice, and will obviously extend the execution time of this Make target, but I could not find an option to have `--fix` nicely display what it's fixing.