### PR TITLE
fix build.path for golang generated modules

### DIFF
--- a/cli/module_generate.go
+++ b/cli/module_generate.go
@@ -831,7 +831,7 @@ func renderManifest(c *cli.Context, moduleID string, module modulegen.ModuleInpu
 		manifest.Build = &manifestBuildInfo{
 			Setup: "make setup",
 			Build: "make module.tar.gz",
-			Path:  "bin/module.tar.gz",
+			Path:  "module.tar.gz",
 			Arch:  []string{"linux/amd64", "linux/arm64", "darwin/arm64", "windows/amd64"},
 		}
 		manifest.Entrypoint = fmt.Sprintf("bin/%s", module.ModuleName)


### PR DESCRIPTION
## What changed
- in the golang case in module_generate.go, change meta.json `build.path` from `bin/module.tar.gz` to `module.tar.gz`
## Why
The go makefile template [here](https://github.com/viamrobotics/rdk/blob/main/cli/module_generate/_templates/go/tmpl-Makefile#L31) generates this in the module root