### PR TITLE
RSDK-10833 Added slow shutdown logs and TestSlowShutdownTicker test

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -349,7 +349,7 @@ func (mgr *Manager) startModule(ctx context.Context, mod *module) error {
 		}
 	}
 
-	cleanup := rutils.SlowStartupLogger(
+	cleanup := rutils.SlowLogger(
 		ctx, "Waiting for module to complete startup and registration", "module", mod.cfg.Name, mod.logger)
 	defer cleanup()
 
@@ -988,7 +988,7 @@ func (mgr *Manager) attemptRestart(ctx context.Context, mod *module) error {
 	// No need to check mgr.untrustedEnv, as we're restarting the same
 	// executable we were given for initial module addition.
 
-	cleanup := rutils.SlowStartupLogger(
+	cleanup := rutils.SlowLogger(
 		ctx, "Waiting for module to complete restart and re-registration", "module", mod.cfg.Name, mod.logger)
 	defer cleanup()
 

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -472,6 +472,10 @@ func (mgr *Manager) closeModule(mod *module, reconfigure bool) error {
 		mod.logger.Warnw("Forcing removal of module with active resources", "module", mod.cfg.Name)
 	}
 
+	cleanup := rutils.SlowLogger(
+		context.Background(), "Waiting for module to complete shutdown", "module", mod.cfg.Name, mod.logger)
+	defer cleanup()
+
 	// need to actually close the resources within the module itself before stopping
 	for res := range mod.resources {
 		_, err := mod.client.RemoveResource(context.Background(), &pb.RemoveResourceRequest{Name: res.String()})

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -826,7 +826,7 @@ func (r *localRobot) updateWeakAndOptionalDependents(ctx context.Context) {
 		ctxWithTimeout, timeoutCancel := context.WithTimeout(ctx, timeout)
 		defer timeoutCancel()
 
-		cleanup := utils.SlowStartupLogger(
+		cleanup := utils.SlowLogger(
 			ctx,
 			"Waiting for internal resource to complete reconfiguration during weak/optional dependencies update",
 			"resource", resName.String(),
@@ -966,7 +966,7 @@ func (r *localRobot) updateWeakAndOptionalDependents(ctx context.Context) {
 		ctxWithTimeout, timeoutCancel := context.WithTimeout(ctx, timeout)
 		defer timeoutCancel()
 
-		cleanup := utils.SlowStartupLogger(
+		cleanup := utils.SlowLogger(
 			ctx,
 			"Waiting for resource to complete reconfiguration during weak/optional dependencies update",
 			"resource",

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -1678,6 +1678,47 @@ func TestDependentResources(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 }
 
+func TestSlowShutdownTicker(t *testing.T) {
+	ctx := context.Background()
+	logger, logs := logging.NewObservedTestLogger(t)
+
+	os.Setenv("VIAM_TESTMODULE_SLOW_CLOSE", "5s")
+	slowModel := resource.NewModel("rdk", "test", "slow")
+	testPath := rtestutils.BuildTempModule(t, "module/testmodule")
+	cfg := &config.Config{
+		Modules: []config.Module{
+			{
+				Name:    "mod",
+				ExePath: testPath,
+			},
+		},
+		Components: []resource.Config{
+			{
+				Name:  "h",
+				Model: slowModel,
+				API:   generic.API,
+				Attributes: rutils.AttributeMap{
+					"config_duration": "5s",
+				},
+			},
+		},
+	}
+
+	r, err := New(ctx, cfg, nil, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	r.Close(ctx)
+
+	// Assert that if a module is taking a while to close, we will see slow logger messages.
+	testutils.WaitForAssertionWithSleep(t, time.Second, 20, func(tb testing.TB) {
+		tb.Helper()
+		test.That(tb, logs.FilterMessage("Waiting for resource to shut down").Len(),
+			test.ShouldBeGreaterThanOrEqualTo, 1)
+		test.That(tb, logs.FilterMessage("Waiting for module to complete shutdown").Len(),
+			test.ShouldBeGreaterThanOrEqualTo, 1)
+	})
+}
+
 func TestOrphanedResources(t *testing.T) {
 	ctx := context.Background()
 	logger, logs := logging.NewObservedTestLogger(t)

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -511,6 +511,14 @@ func (manager *resourceManager) closeResource(ctx context.Context, res resource.
 	closeCtx, cancel := context.WithTimeout(ctx, resourceCloseTimeout)
 	defer cancel()
 
+	cleanup := rutils.SlowLogger(
+		closeCtx,
+		"Waiting for resource to shut down",
+		"resource", res.Name().String(),
+		manager.logger,
+	)
+	defer cleanup()
+
 	allErrs := res.Close(closeCtx)
 
 	resName := res.Name()

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -686,7 +686,7 @@ func (manager *resourceManager) completeConfig(
 				ctxWithTimeout, timeoutCancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
 				defer timeoutCancel()
 
-				stopSlowLogger := rutils.SlowStartupLogger(
+				stopSlowLogger := rutils.SlowLogger(
 					ctx, "Waiting for resource to complete (re)configuration", "resource", resName.String(), manager.logger)
 
 				lr.reconfigureWorkers.Add(1)

--- a/utils/ticker.go
+++ b/utils/ticker.go
@@ -7,8 +7,8 @@ import (
 	"go.viam.com/rdk/logging"
 )
 
-// SlowStartupLogger starts a goroutine that logs every few seconds as long as the context has not timed out or was not cancelled.
-func SlowStartupLogger(ctx context.Context, msg, fieldName, fieldVal string, logger logging.Logger) func() {
+// SlowLogger starts a goroutine that logs every few seconds as long as the context has not timed out or was not cancelled.
+func SlowLogger(ctx context.Context, msg, fieldName, fieldVal string, logger logging.Logger) func() {
 	slowTicker := time.NewTicker(2 * time.Second)
 	firstTick := true
 


### PR DESCRIPTION
`SlowStartupLogger` is now renamed to `SlowLogger`, and is used to measure shutdown time as well. In particular, it is added to `closeModule` and `closeResource`, since these are the most important and used pieces by the clients. 

To check this functionality, `TestSlowShutdownTicker` test was created to capture the logs that are output when resources/modules are taking a while to cleanly shutdown. 