### PR TITLE
RSDK-10762 Add test for modular optional dependency cycles

### DIFF
--- a/examples/customresources/demos/optionaldepsmodule/module.go
+++ b/examples/customresources/demos/optionaldepsmodule/module.go
@@ -209,7 +209,21 @@ func (moc *mutualOptionalChild) DoCommand(ctx context.Context, req map[string]an
 		if moc.otherMOC == nil {
 			return map[string]any{"other_moc_state": "unset"}, nil
 		}
-		return map[string]any{"other_moc_state": "set"}, nil
+
+		resp, err := moc.otherMOC.DoCommand(ctx, map[string]any{"command": "query"})
+		if err != nil {
+			return map[string]any{"other_moc_state": "unreachable"}, nil //nolint:nilerr
+		}
+
+		if _, exists := resp["usable"]; exists {
+			return map[string]any{"other_moc_state": "usable"}, nil
+		}
+		return map[string]any{"other_moc_state": "unusable"}, nil
+	}
+
+	// "query" will respond with {"usable": nil}
+	if cmd == "query" {
+		return map[string]any{"usable": nil}, nil
 	}
 
 	// The command must've been something else (unrecognized).

--- a/examples/customresources/demos/optionaldepsmodule/module.go
+++ b/examples/customresources/demos/optionaldepsmodule/module.go
@@ -1,6 +1,7 @@
 // Package main is a module that utilizes both required and optional implicit
 // dependencies. It serves a generic component that has a required dependency on one motor
-// and an optional dependency on another motor.
+// and an optional dependency on another motor. It also serves a generic component that
+// exhibits optional dependency cycles.
 package main
 
 import (
@@ -15,25 +16,32 @@ import (
 	"go.viam.com/rdk/resource"
 )
 
-var model = resource.NewModel("acme", "demo", "foo")
+var (
+	fooModel = resource.NewModel("acme", "demo", "foo")
+	mocModel = resource.NewModel("acme", "demo", "moc" /* "mutual optional child" */)
+)
 
 func main() {
-	resource.RegisterComponent(generic.API, model, resource.Registration[resource.Resource, *FooConfig]{
+	resource.RegisterComponent(generic.API, fooModel, resource.Registration[resource.Resource, *FooConfig]{
 		Constructor: newFoo,
 	})
+	resource.RegisterComponent(generic.API, mocModel, resource.Registration[resource.Resource, *MutualOptionalChildConfig]{
+		Constructor: newMutualOptionalChild,
+	})
 
-	module.ModularMain(resource.APIModel{generic.API, model})
+	module.ModularMain(resource.APIModel{generic.API, fooModel},
+		resource.APIModel{generic.API, mocModel})
 }
 
-// FooConfig contains a required and optional motor that the component will
-// necessarily and optionally depend upon.
+// FooConfig contains a required and optional motor that the component will necessarily
+// and optionally depend upon respectively.
 type FooConfig struct {
 	RequiredMotor string `json:"required_motor"`
 	OptionalMotor string `json:"optional_motor"`
 }
 
-// Validate validates the config and returns a required dependency on
-// `required_motor` and an optional dependency on `optional_motor`.
+// Validate validates the config and returns a required dependency on `required_motor` and
+// an optional dependency on `optional_motor`.
 func (fCfg *FooConfig) Validate(path string) ([]string, []string, error) {
 	var requiredDeps, optionalDeps []string
 
@@ -53,6 +61,7 @@ func (fCfg *FooConfig) Validate(path string) ([]string, []string, error) {
 type foo struct {
 	resource.Named
 	resource.TriviallyCloseable
+
 	logger logging.Logger
 
 	requiredMotor motor.Motor
@@ -136,3 +145,77 @@ func (f *foo) DoCommand(ctx context.Context, req map[string]any) (map[string]any
 	// The command must've been something else (unrecognized).
 	return nil, fmt.Errorf("unknown command string %s", cmd)
 }
+
+// MutualOptionalChildConfig contains _another_ MOC that this MOC will optionally depend
+// upon.
+type MutualOptionalChildConfig struct {
+	OtherMOC string `json:"other_moc"`
+}
+
+// Validate validates the config and returns an optional dependency on `other_moc`.
+//
+//nolint:unparam
+func (mocCfg *MutualOptionalChildConfig) Validate(path string) ([]string, []string, error) {
+	if mocCfg.OtherMOC == "" {
+		return nil, nil,
+			fmt.Errorf(`expected "other_moc" attribute for MOC %q`, path)
+	}
+	return nil, []string{mocCfg.OtherMOC}, nil
+}
+
+type mutualOptionalChild struct {
+	resource.Named
+	resource.TriviallyCloseable
+	resource.AlwaysRebuild
+
+	logger logging.Logger
+
+	otherMOC resource.Resource
+}
+
+func newMutualOptionalChild(ctx context.Context,
+	deps resource.Dependencies,
+	conf resource.Config,
+	logger logging.Logger,
+) (resource.Resource, error) {
+	moc := &mutualOptionalChild{
+		Named:  conf.ResourceName().AsNamed(),
+		logger: logger,
+	}
+
+	mutualOptionalChildConfig, err := resource.NativeConfig[*MutualOptionalChildConfig](conf)
+	if err != nil {
+		return nil, err
+	}
+
+	moc.otherMOC, err = generic.FromDependencies(deps, mutualOptionalChildConfig.OtherMOC)
+	if err != nil {
+		moc.logger.Infof("could not get other MOC %s from dependencies; continuing",
+			mutualOptionalChildConfig.OtherMOC)
+	}
+
+	return moc, nil
+}
+
+// DoCommand is the only method of this component.
+func (moc *mutualOptionalChild) DoCommand(ctx context.Context, req map[string]any) (map[string]any, error) {
+	cmd, ok := req["command"]
+	if !ok {
+		return nil, errors.New("missing 'command' string")
+	}
+
+	// "other_moc_state" will check the state of the required motor.
+	if cmd == "other_moc_state" {
+		if moc.otherMOC == nil {
+			return map[string]any{"other_moc_state": "unset"}, nil
+		}
+		return map[string]any{"other_moc_state": "set"}, nil
+	}
+
+	// The command must've been something else (unrecognized).
+	return nil, fmt.Errorf("unknown command string %s", cmd)
+}
+
+// `moc` is notably missing a `Reconfigure` method. Modular resources with optional
+// dependencies should be able to leverage optional dependencies even as "always rebuild"
+// resources.

--- a/module/module.go
+++ b/module/module.go
@@ -617,7 +617,7 @@ func (m *Module) ReconfigureResource(ctx context.Context, req *pb.ReconfigureRes
 		return nil, err
 	}
 
-	m.logger.Debugw("rebuilding", "name", conf.ResourceName())
+	m.logger.Debugw("rebuilding", "name", conf.ResourceName().String())
 	if err := res.Close(ctx); err != nil {
 		m.logger.Error(err)
 	}

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -947,12 +947,20 @@ func (r *localRobot) updateWeakAndOptionalDependents(ctx context.Context) {
 			err = res.Reconfigure(ctx, deps, conf)
 		}
 		if err != nil {
-			r.Logger().CErrorw(
-				ctx,
-				"failed to reconfigure resource during weak/optional dependencies update",
-				"resource", resName,
-				"error", err,
-			)
+			if resource.IsMustRebuildError(err) {
+				r.Logger().CErrorw(
+					ctx,
+					"non-modular resource uses weak/optional dependencies but is missing a Reconfigure method",
+					"resource", resName,
+				)
+			} else {
+				r.Logger().CErrorw(
+					ctx,
+					"failed to reconfigure resource during weak/optional dependencies update",
+					"resource", resName,
+					"error", err,
+				)
+			}
 		}
 	}
 

--- a/robot/impl/optional_dependencies_test.go
+++ b/robot/impl/optional_dependencies_test.go
@@ -46,6 +46,7 @@ func (ocCfg *optionalChildConfig) Validate(path string) ([]string, []string, err
 type optionalChild struct {
 	resource.Named
 	resource.TriviallyCloseable
+
 	logger logging.Logger
 
 	requiredMotor motor.Motor
@@ -95,7 +96,7 @@ func (oc *optionalChild) Reconfigure(ctx context.Context, deps resource.Dependen
 	return nil
 }
 
-func TestNonModularOptionalDependencies(t *testing.T) {
+func TestOptionalDependencies(t *testing.T) {
 	logger, logs := logging.NewObservedTestLogger(t)
 	ctx := context.Background()
 
@@ -347,8 +348,8 @@ func TestNonModularOptionalDependencies(t *testing.T) {
 }
 
 func TestModularOptionalDependencies(t *testing.T) {
-	// A copy of TestNonModularOptionalDependencies with a modular component instead of a
-	// resource defined in this file.
+	// A copy of TestOptionalDependencies with a modular component instead of a resource
+	// defined in this file.
 
 	logger, logs := logging.NewObservedTestLogger(t)
 	ctx := context.Background()
@@ -637,6 +638,7 @@ func (mocCfg *mutualOptionalChildConfig) Validate(path string) ([]string, []stri
 type mutualOptionalChild struct {
 	resource.Named
 	resource.TriviallyCloseable
+
 	logger logging.Logger
 
 	otherMOC      resource.Resource
@@ -680,7 +682,9 @@ func (moc *mutualOptionalChild) Reconfigure(ctx context.Context, deps resource.D
 }
 
 func TestOptionalDependenciesCycles(t *testing.T) {
-	// This test ensures that there can be a "cycle" of optional dependencies.
+	// This test ensures that there can be a "cycle" of non-modular optional dependencies.
+	// Note that the usage of non-modular optional dependencies requires that the resource
+	// have a `Reconfigure` method (defined above).
 	//
 	// A resource 'moc' will optionally depend upon 'moc2', and 'moc2' will optionally
 	// depend upon 'moc'. We will start with only 'moc' in the config, and assert that 'moc'
@@ -841,5 +845,165 @@ func TestOptionalDependenciesCycles(t *testing.T) {
 
 		// Assert that, on the 'moc2' component itself, `otherMOC` is no longer set.
 		test.That(t, moc2.otherMOC, test.ShouldBeNil)
+	}
+}
+
+func TestModularOptionalDependenciesCycles(t *testing.T) {
+	// This test is a copy of TestOptionalDependenciesCycles, but it also ensures that
+	// modular resources can optionally depend upon each other _and_ lack a `Reconfigure`
+	// method (leverage `resource.AlwaysRebuild`).
+
+	logger, logs := logging.NewObservedTestLogger(t)
+	ctx := context.Background()
+
+	lr := setupLocalRobot(t, ctx, &config.Config{}, logger)
+
+	optionalDepsModulePath := testutils.BuildTempModule(t, "examples/customresources/demos/optionaldepsmodule")
+
+	mutualOptionalChildModel := resource.NewModel("acme", "demo", "moc")
+	mocName := generic.Named("moc")
+	mocName2 := generic.Named("moc2")
+
+	// Reconfigure the robot to have a mutual optional child component that is missing its
+	// mutual.
+	cfg := config.Config{
+		Modules: []config.Module{
+			{
+				Name:    "optional-deps",
+				ExePath: optionalDepsModulePath,
+			},
+		},
+		Components: []resource.Config{
+			{
+				Name:  mocName.Name,
+				API:   generic.API,
+				Model: mutualOptionalChildModel,
+				Attributes: rutils.AttributeMap{
+					"other_moc": mocName2.Name,
+				},
+			},
+		},
+	}
+	// Ensure here and for all configs below before `Reconfigure`ing to make sure optional
+	// dependencies are calculated (`ImplicitOptionalDependsOn` is filled in).
+	test.That(t, cfg.Ensure(false, logger), test.ShouldBeNil)
+	lr.Reconfigure(ctx, &cfg)
+
+	{ // Assertions
+		// Assert that the mutual optional child component built successfully (optional
+		// dependency on non-existent 'moc2' did not cause a failure to build).
+		mocRes, err := lr.ResourceByName(mocName)
+		test.That(t, err, test.ShouldBeNil)
+
+		// Assert that the mutual optional logged its inability to get 'moc2' from
+		// dependencies _twice_. The first is from construction of the resource, and the
+		// second is from reconstruction of the resource (always rebuild) due to a call to
+		// `updateWeakAndOptionalDependents` directly after `completeConfig`.
+		msgNum := logs.FilterMessageSnippet("could not get other MOC").Len()
+		test.That(t, msgNum, test.ShouldEqual, 2)
+
+		// Assert that, on the component itself, `otherMOC` remains unset.
+		doCommandResp, err := mocRes.DoCommand(ctx, map[string]any{"command": "other_moc_state"})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, doCommandResp, test.ShouldResemble, map[string]any{"other_moc_state": "unset"})
+	}
+
+	// Reconfigure the robot to have the other MOC.
+	cfg = config.Config{
+		Modules: []config.Module{
+			{
+				Name:    "optional-deps",
+				ExePath: optionalDepsModulePath,
+			},
+		},
+		Components: []resource.Config{
+			{
+				Name:  mocName.Name,
+				API:   generic.API,
+				Model: mutualOptionalChildModel,
+				Attributes: rutils.AttributeMap{
+					"other_moc": mocName2.Name,
+				},
+			},
+			{
+				Name:  mocName2.Name,
+				API:   generic.API,
+				Model: mutualOptionalChildModel,
+				Attributes: rutils.AttributeMap{
+					"other_moc": mocName.Name,
+				},
+			},
+		},
+	}
+	test.That(t, cfg.Ensure(false, logger), test.ShouldBeNil)
+	lr.Reconfigure(ctx, &cfg)
+
+	{ // Assertions
+		// Assert that the first 'moc' component is still accessible (did not fail to
+		// reconstruct).
+		mocRes, err := lr.ResourceByName(mocName)
+		test.That(t, err, test.ShouldBeNil)
+
+		// Assert that there were no more logs (still 2) about failures to "get other MOC."
+		msgNum := logs.FilterMessageSnippet("could not get other MOC").Len()
+		test.That(t, msgNum, test.ShouldEqual, 2)
+
+		// Assert that, on the 'moc' component itself, `otherMOC` is now set.
+		doCommandResp, err := mocRes.DoCommand(ctx, map[string]any{"command": "other_moc_state"})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, doCommandResp, test.ShouldResemble, map[string]any{"other_moc_state": "set"})
+
+		// Assert that the second 'moc2' component is now accessible (did not fail to
+		// construct).
+		mocRes2, err := lr.ResourceByName(mocName2)
+		test.That(t, err, test.ShouldBeNil)
+
+		// Assert that, on the 'moc2' component itself, `otherMOC` is now set.
+		doCommandResp, err = mocRes2.DoCommand(ctx, map[string]any{"command": "other_moc_state"})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, doCommandResp, test.ShouldResemble, map[string]any{"other_moc_state": "set"})
+	}
+
+	// Reconfigure the robot to remove the original 'moc'.
+	cfg = config.Config{
+		Modules: []config.Module{
+			{
+				Name:    "optional-deps",
+				ExePath: optionalDepsModulePath,
+			},
+		},
+		Components: []resource.Config{
+			{
+				Name:  mocName2.Name,
+				API:   generic.API,
+				Model: mutualOptionalChildModel,
+				Attributes: rutils.AttributeMap{
+					"other_moc": mocName.Name,
+				},
+			},
+		},
+	}
+	test.That(t, cfg.Ensure(false, logger), test.ShouldBeNil)
+	lr.Reconfigure(ctx, &cfg)
+
+	{ // Assertions
+		// Assert that the original optional child component 'moc' is no longer accessible.
+		_, err := lr.ResourceByName(mocName)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, resource.IsNotFoundError(err), test.ShouldBeTrue)
+
+		// Assert that the second optional child component 'moc2' is still accessible (did not
+		// fail to reconstruct).
+		mocRes2, err := lr.ResourceByName(mocName2)
+		test.That(t, err, test.ShouldBeNil)
+
+		// Assert that there was another log (now 3) about failures to "get other MOC."
+		msgNum := logs.FilterMessageSnippet("could not get other MOC").Len()
+		test.That(t, msgNum, test.ShouldEqual, 3)
+
+		// Assert that, on the 'moc2' component itself, `otherMOC` is no longer set.
+		doCommandResp, err := mocRes2.DoCommand(ctx, map[string]any{"command": "other_moc_state"})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, doCommandResp, test.ShouldResemble, map[string]any{"other_moc_state": "unset"})
 	}
 }

--- a/robot/impl/optional_dependencies_test.go
+++ b/robot/impl/optional_dependencies_test.go
@@ -948,20 +948,20 @@ func TestModularOptionalDependenciesCycles(t *testing.T) {
 		msgNum := logs.FilterMessageSnippet("could not get other MOC").Len()
 		test.That(t, msgNum, test.ShouldEqual, 2)
 
-		// Assert that, on the 'moc' component itself, `otherMOC` is now set.
+		// Assert that, on the 'moc' component itself, `otherMOC` is now usable.
 		doCommandResp, err := mocRes.DoCommand(ctx, map[string]any{"command": "other_moc_state"})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, doCommandResp, test.ShouldResemble, map[string]any{"other_moc_state": "set"})
+		test.That(t, doCommandResp, test.ShouldResemble, map[string]any{"other_moc_state": "usable"})
 
 		// Assert that the second 'moc2' component is now accessible (did not fail to
 		// construct).
 		mocRes2, err := lr.ResourceByName(mocName2)
 		test.That(t, err, test.ShouldBeNil)
 
-		// Assert that, on the 'moc2' component itself, `otherMOC` is now set.
+		// Assert that, on the 'moc2' component itself, `otherMOC` is now usable.
 		doCommandResp, err = mocRes2.DoCommand(ctx, map[string]any{"command": "other_moc_state"})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, doCommandResp, test.ShouldResemble, map[string]any{"other_moc_state": "set"})
+		test.That(t, doCommandResp, test.ShouldResemble, map[string]any{"other_moc_state": "usable"})
 	}
 
 	// Reconfigure the robot to remove the original 'moc'.


### PR DESCRIPTION
RSDK-10762

Adds a test for _modular_ optional dependency cycles that ensures modular resources can optionally depend upon each other _without_ any `Reconfigure` methods (using `AlwaysRebuild`).