### PR TITLE
RSDK-10929: Log slow package download progress

### DIFF
--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -419,9 +419,9 @@ func (m *cloudManager) downloadFileFromGCSURL(
 	defer utils.UncheckedErrorFunc(out.Close)
 
 	hash := crc32Hash()
-	w := io.MultiWriter(out, hash)
+	w := io.MultiWriter(out, hash, newLogProgressWriter(m.logger, downloadPath, resp.ContentLength))
 
-	_, err = io.CopyN(w, io.TeeReader(resp.Body, newLogProgressWriter(m.logger, downloadPath, resp.ContentLength)), maxPackageSize)
+	_, err = io.CopyN(w, resp.Body, maxPackageSize)
 	if err != nil && !errors.Is(err, io.EOF) {
 		utils.UncheckedError(os.Remove(downloadPath))
 		return checksum, contentType, err


### PR DESCRIPTION
Prints download path and download progress for package downloads. Hardcoded for now to log every 5 seconds.

Quick download shows completion message only (<5s)
```
2025-06-17T21:02:27.502Z INFO	rdk.package_manager packages/cloud_package_manager.go:369	/home/viam/.viam/packages/data/module/e76d1b3b-0468-4efd-bb7f-fb1d2b352fcb-viamrtsp-0_4_7-linux-amd64.download: downloaded 33893493 bytes (100%) in 3.528057355s
```

Slow download logs progress every 5s:
```
2025-06-18T12:55:05.460Z INFO	rdk.package_manager packages/cloud_package_manager.go:361	/home/viam/.viam/packages/data/module/e76d1b3b-0468-4efd-bb7f-fb1d2b352fcb-viamrtsp-0_4_7-linux-amd64.download: downloaded 4228252 / 33893493 bytes (12%) [477 KB/s]
2025-06-18T12:55:10.929Z INFO	rdk.package_manager packages/cloud_package_manager.go:361	/home/viam/.viam/packages/data/module/e76d1b3b-0468-4efd-bb7f-fb1d2b352fcb-viamrtsp-0_4_7-linux-amd64.download: downloaded 8422556 / 33893493 bytes (25%) [582 KB/s]
2025-06-18T12:55:20.217Z INFO	rdk.package_manager packages/cloud_package_manager.go:361	/home/viam/.viam/packages/data/module/e76d1b3b-0468-4efd-bb7f-fb1d2b352fcb-viamrtsp-0_4_7-linux-amd64.download: downloaded 13108380 / 33893493 bytes (39%) [547 KB/s]
2025-06-18T12:55:27.118Z INFO	rdk.package_manager packages/cloud_package_manager.go:361	/home/viam/.viam/packages/data/module/e76d1b3b-0468-4efd-bb7f-fb1d2b352fcb-viamrtsp-0_4_7-linux-amd64.download: downloaded 17450140 / 33893493 bytes (51%) [562 KB/s]
2025-06-18T12:55:33.323Z INFO	rdk.package_manager packages/cloud_package_manager.go:361	/home/viam/.viam/packages/data/module/e76d1b3b-0468-4efd-bb7f-fb1d2b352fcb-viamrtsp-0_4_7-linux-amd64.download: downloaded 21464220 / 33893493 bytes (63%) [574 KB/s]
2025-06-18T12:55:39.967Z INFO	rdk.package_manager packages/cloud_package_manager.go:361	/home/viam/.viam/packages/data/module/e76d1b3b-0468-4efd-bb7f-fb1d2b352fcb-viamrtsp-0_4_7-linux-amd64.download: downloaded 25003164 / 33893493 bytes (74%) [566 KB/s]
2025-06-18T12:55:51.348Z INFO	rdk.package_manager packages/cloud_package_manager.go:361	/home/viam/.viam/packages/data/module/e76d1b3b-0468-4efd-bb7f-fb1d2b352fcb-viamrtsp-0_4_7-linux-amd64.download: downloaded 31671452 / 33893493 bytes (93%) [567 KB/s]
2025-06-18T12:55:53.610Z INFO	rdk.package_manager packages/cloud_package_manager.go:370	/home/viam/.viam/packages/data/module/e76d1b3b-0468-4efd-bb7f-fb1d2b352fcb-viamrtsp-0_4_7-linux-amd64.download: downloaded 33893493 bytes (100%) in 56.801073702s
```