### PR TITLE
module template: no need to modify meta.json when building on Windows

### DIFF
--- a/cli/module_generate/_templates/go/tmpl-Makefile
+++ b/cli/module_generate/_templates/go/tmpl-Makefile
@@ -5,7 +5,7 @@ MODULE_BINARY := bin/{{ .ModuleName }}
 
 ifeq ($(VIAM_TARGET_OS), windows)
 	GO_BUILD_ENV += GOOS=windows GOARCH=amd64
-	GO_BUILD_FLAGS := -tags no_cgo	
+	GO_BUILD_FLAGS := -tags no_cgo
 	MODULE_BINARY = bin/{{ .ModuleName }}.exe
 endif
 
@@ -23,15 +23,10 @@ test:
 	go test ./...
 
 module.tar.gz: meta.json $(MODULE_BINARY)
-ifeq ($(VIAM_TARGET_OS), windows)
-	jq '.entrypoint = "./bin/{{ .ModuleName }}.exe"' meta.json > temp.json && mv temp.json meta.json
-else
+ifneq ($(VIAM_TARGET_OS), windows)
 	strip $(MODULE_BINARY)
 endif
 	tar czf $@ meta.json $(MODULE_BINARY)
-ifeq ($(VIAM_TARGET_OS), windows)
-	git checkout meta.json
-endif
 
 module: test module.tar.gz
 


### PR DESCRIPTION
Per discussion in https://github.com/viam-modules/mlmodel-tflite/pull/35, https://github.com/viamrobotics/rdk/pull/4969, and on Slack, Windows is smart enough to know that if you try executing `foo` and the only file present is `foo.exe`, that's the one to use. So, no need to rewrite meta.json to add the `.exe` suffix on Windows.

This also makes the code less surprising: if I modify meta.json myself and then build without committing, I don't expect that to discard my changes! :flushed: 

I'm tagging Julie on this PR, but that might be wrong. Julie, feel free to reassign if you don't want to review.