### PR TITLE
[RSDK-10480] Log full module path upon success

### DIFF
--- a/cli/module_generate.go
+++ b/cli/module_generate.go
@@ -177,8 +177,11 @@ func (c *viamClient) generateModuleAction(cCtx *cli.Context, args generateModule
 	if nonFatalError {
 		return fmt.Errorf("some steps of module generation failed, incomplete module located at %s", newModule.ModuleName)
 	}
-
-	printf(cCtx.App.Writer, "Module successfully generated at %s", newModule.ModuleName)
+	cwd, err := os.Getwd()
+	if err != nil {
+		cwd = "."
+	}
+	printf(cCtx.App.Writer, "Module successfully generated at %s%s%s", cwd, string(os.PathSeparator), newModule.ModuleName)
 	return nil
 }
 


### PR DESCRIPTION
Instead of printing `Module successfully generated at my-module`, this will now print `Module successfully generated at /Users/njooma/my-module`