### PR TITLE
[RSDK-10933] use PlanningAlgorithm enum in favor of function pointer

### DIFF
--- a/motionplan/motionPlanner.go
+++ b/motionplan/motionPlanner.go
@@ -40,8 +40,6 @@ type motionPlanner interface {
 	sample(node, int) (node, error)
 }
 
-type plannerConstructor func(referenceframe.FrameSystem, *rand.Rand, logging.Logger, *plannerOptions) (motionPlanner, error)
-
 // PlanRequest is a struct to store all the data necessary to make a call to PlanMotion.
 type PlanRequest struct {
 	Logger logging.Logger

--- a/motionplan/planManager.go
+++ b/motionplan/planManager.go
@@ -378,7 +378,7 @@ func (pm *planManager) planParallelRRTMotion(
 		var fallbackPlanner motionPlanner
 		if pathPlanner.opt().Fallback != nil {
 			//nolint: gosec
-			fallbackPlanner, err = getPlanner(
+			fallbackPlanner, err = newMotionPlanner(
 				pathPlanner.opt().Fallback.planningAlgorithm,
 				pm.fs,
 				rand.New(rand.NewSource(int64(pm.randseed.Int()))),
@@ -816,7 +816,7 @@ func (pm *planManager) generateWaypoints(request *PlanRequest, seedPlan Plan, wp
 	// TPspace should never use subwaypoints
 	if !subWaypoints || opt.useTPspace {
 		//nolint: gosec
-		pathPlanner, err := getPlanner(
+		pathPlanner, err := newMotionPlanner(
 			opt.planningAlgorithm,
 			pm.fs,
 			rand.New(rand.NewSource(int64(pm.randseed.Int()))),
@@ -878,7 +878,7 @@ func (pm *planManager) generateWaypoints(request *PlanRequest, seedPlan Plan, wp
 			return nil, err
 		}
 		//nolint: gosec
-		pathPlanner, err := getPlanner(
+		pathPlanner, err := newMotionPlanner(
 			wpOpt.planningAlgorithm,
 			pm.fs,
 			rand.New(rand.NewSource(int64(pm.randseed.Int()))),

--- a/motionplan/plannerOptions.go
+++ b/motionplan/plannerOptions.go
@@ -110,7 +110,7 @@ func newBasicPlannerOptions() *plannerOptions {
 	// Note the direct reference to a default here.
 	// This is due to a Go compiler issue where it will incorrectly refuse to compile with a circular reference error if this
 	// is placed in a global default var.
-	opt.PlannerConstructor = newCBiRRTMotionPlanner
+	opt.planningAlgorithm = CBiRRT
 
 	opt.SmoothIter = defaultSmoothIter
 
@@ -190,7 +190,7 @@ type plannerOptions struct {
 	// profile is the string representing the motion profile
 	profile string
 
-	PlannerConstructor plannerConstructor
+	planningAlgorithm PlanningAlgorithm
 
 	Fallback *plannerOptions
 

--- a/motionplan/plannerOptions.go
+++ b/motionplan/plannerOptions.go
@@ -107,9 +107,6 @@ func newBasicPlannerOptions() *plannerOptions {
 	opt.InputIdentDist = defaultInputIdentDist
 	opt.IterBeforeRand = defaultIterBeforeRand
 
-	// Note the direct reference to a default here.
-	// This is due to a Go compiler issue where it will incorrectly refuse to compile with a circular reference error if this
-	// is placed in a global default var.
 	opt.planningAlgorithm = CBiRRT
 
 	opt.SmoothIter = defaultSmoothIter

--- a/motionplan/planning_algorithms.go
+++ b/motionplan/planning_algorithms.go
@@ -1,0 +1,48 @@
+package motionplan
+
+import (
+	"math/rand"
+
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/referenceframe"
+)
+
+// PlanningAlgorithm is an enum that determines which implmentation of motion planning should be used.
+// It is meant to be passed to getPlanner (along with the arguments expected by the plannerConstructor
+// function type) in order to acquire an implementer of motionPlanner.
+type PlanningAlgorithm int
+
+const (
+	// CBiRRT indicates that a CBiRRTMotionPlanner should be used. This is currently the
+	// default motion planner.
+	CBiRRT PlanningAlgorithm = iota
+	// RRTStar indicates that an RRTStarConnectMotionPlanner should be used.
+	RRTStar
+	// TPSpace indicates that TPSpaceMotionPlanner should be used.
+	TPSpace
+)
+
+type plannerConstructor func(referenceframe.FrameSystem, *rand.Rand, logging.Logger, *plannerOptions) (motionPlanner, error)
+
+func getPlannerConstructor(algo PlanningAlgorithm) plannerConstructor {
+	switch algo {
+	case CBiRRT:
+		return newCBiRRTMotionPlanner
+	case RRTStar:
+		return newRRTStarConnectMotionPlanner
+	case TPSpace:
+		return newTPSpaceMotionPlanner
+	default:
+		return newCBiRRTMotionPlanner
+	}
+}
+
+func getPlanner(
+	algo PlanningAlgorithm,
+	fs referenceframe.FrameSystem,
+	seed *rand.Rand,
+	logger logging.Logger,
+	opt *plannerOptions,
+) (motionPlanner, error) {
+	return getPlannerConstructor(algo)(fs, seed, logger, opt)
+}

--- a/motionplan/planning_algorithms.go
+++ b/motionplan/planning_algorithms.go
@@ -8,7 +8,7 @@ import (
 )
 
 // PlanningAlgorithm is an enum that determines which implmentation of motion planning should be used.
-// It is meant to be passed to getPlanner (along with the arguments expected by the plannerConstructor
+// It is meant to be passed to newMotionPlanner (along with the arguments expected by the plannerConstructor
 // function type) in order to acquire an implementer of motionPlanner.
 type PlanningAlgorithm int
 
@@ -24,7 +24,7 @@ const (
 
 type plannerConstructor func(referenceframe.FrameSystem, *rand.Rand, logging.Logger, *plannerOptions) (motionPlanner, error)
 
-func getPlannerConstructor(algo PlanningAlgorithm) plannerConstructor {
+func newPlannerConstructor(algo PlanningAlgorithm) plannerConstructor {
 	switch algo {
 	case CBiRRT:
 		return newCBiRRTMotionPlanner
@@ -37,12 +37,12 @@ func getPlannerConstructor(algo PlanningAlgorithm) plannerConstructor {
 	}
 }
 
-func getPlanner(
+func newMotionPlanner(
 	algo PlanningAlgorithm,
 	fs referenceframe.FrameSystem,
 	seed *rand.Rand,
 	logger logging.Logger,
 	opt *plannerOptions,
 ) (motionPlanner, error) {
-	return getPlannerConstructor(algo)(fs, seed, logger, opt)
+	return newPlannerConstructor(algo)(fs, seed, logger, opt)
 }

--- a/motionplan/tpSpaceRRT_test.go
+++ b/motionplan/tpSpaceRRT_test.go
@@ -54,7 +54,7 @@ func TestPtgRrtBidirectional(t *testing.T) {
 	opt := newBasicPlannerOptions()
 	opt.poseDistanceFunc = ik.NewSquaredNormSegmentMetric(30.)
 	opt.scoreFunc = tpspace.NewPTGDistanceMetric([]string{ackermanFrame.Name()})
-	opt.PlannerConstructor = newTPSpaceMotionPlanner
+	opt.planningAlgorithm = TPSpace
 
 	opt.fillMotionChains(fs, goal)
 
@@ -135,7 +135,7 @@ func TestPtgWithObstacle(t *testing.T) {
 	opt := newBasicPlannerOptions()
 	opt.poseDistanceFunc = ik.NewSquaredNormSegmentMetric(30.)
 	opt.GoalThreshold = 5
-	opt.PlannerConstructor = newTPSpaceMotionPlanner
+	opt.planningAlgorithm = TPSpace
 	opt.scoreFunc = tpspace.NewPTGDistanceMetric([]string{ackermanFrame.Name()})
 	opt.fillMotionChains(fs, goal)
 
@@ -226,7 +226,7 @@ func TestTPsmoothing(t *testing.T) {
 	opt := newBasicPlannerOptions()
 	opt.poseDistanceFunc = ik.NewSquaredNormSegmentMetric(30.)
 	opt.scoreFunc = tpspace.NewPTGDistanceMetric([]string{ackermanFrame.Name()})
-	opt.PlannerConstructor = newTPSpaceMotionPlanner
+	opt.planningAlgorithm = TPSpace
 
 	// Needed to determine motion chains
 	goalPos := spatialmath.NewPoseFromPoint(r3.Vector{X: 6500, Y: 0, Z: 0})


### PR DESCRIPTION
First of many PRs to clean up `PlanRequest` and `plannerOptions`.

This particular PR is the start of trying to remove function pointers from these structs wherever possible (due to them not being serializable or explicit)