### PR TITLE
RSDK-10723 Warn about inability to modify module logger levels for now

### DIFF
--- a/config/logging_level.go
+++ b/config/logging_level.go
@@ -80,6 +80,11 @@ func refreshLogLevelInLock() {
 		return
 	}
 	globalLogger.logger.Info("New log level:", newLevelZap)
+
+	// TODO(RSDK-10723): Remove this WARN log, and restart all modules at
+	// `--log-level=debug` at this point.
+	globalLogger.logger.Warn("Changes to 'debug' field of config will not affect modular logs; use 'log_level' or 'log_configuration' instead")
+
 	logging.GlobalLogLevel.SetLevel(newLevelZap)
 	globalLogger.logger.SetLevel(newLevel)
 }

--- a/config/logging_level.go
+++ b/config/logging_level.go
@@ -83,7 +83,7 @@ func refreshLogLevelInLock() {
 
 	// TODO(RSDK-10723): Remove this WARN log, and restart all modules at
 	// `--log-level=debug` at this point.
-	globalLogger.logger.Warn("Changes to 'debug' field of config will not affect modular logs; use 'log_level' or 'log_configuration' instead")
+	globalLogger.logger.Warn("Changes to global debug settings will not affect modular logs; use 'log_level' or 'log_configuration' instead")
 
 	logging.GlobalLogLevel.SetLevel(newLevelZap)
 	globalLogger.logger.SetLevel(newLevel)

--- a/config/logging_level.go
+++ b/config/logging_level.go
@@ -83,7 +83,10 @@ func refreshLogLevelInLock() {
 
 	// TODO(RSDK-10723): Remove this WARN log, and restart all modules at
 	// `--log-level=debug` at this point.
-	globalLogger.logger.Warn("Changes to global debug settings will not affect modular logs; use 'log_level' or 'log_configuration' instead")
+	globalLogger.logger.Warn(
+		"Changes to global debug settings will not affect modular logs. " +
+			"Use 'log_level' in module config or 'log_configuration' in resource config instead",
+	)
 
 	logging.GlobalLogLevel.SetLevel(newLevelZap)
 	globalLogger.logger.SetLevel(newLevel)

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -394,7 +394,10 @@ func (s *robotServer) configWatcher(ctx context.Context, currCfg *config.Config,
 
 				// TODO(RSDK-10723): Remove this WARN log, and mutate the config to reconfigure
 				// all appropriate modular resources at this point.
-				s.logger.Warn("Changes to 'log' field of config will not affect modular logs; use 'log_level' or 'log_configuration' instead")
+				s.logger.Warn(
+					"Changes to 'log' field will not affect modular logs. " +
+						"Use 'log_level' in module config or 'log_configuration' in resource config instead",
+				)
 
 				config.UpdateLoggerRegistryFromConfig(s.registry, processedConfig, s.logger)
 			}

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -391,6 +391,11 @@ func (s *robotServer) configWatcher(ctx context.Context, currCfg *config.Config,
 			// This functionality is tested in `TestLogPropagation` in `local_robot_test.go`.
 			if !diff.LogEqual {
 				s.logger.Debug("Detected potential changes to log patterns; updating logger levels")
+
+				// TODO(RSDK-10723): Remove this WARN log, and mutate the config to reconfigure
+				// all appropriate modular resources at this point.
+				s.logger.Warn("Changes to 'log' field of config will not affect modular logs; use 'log_level' or 'log_configuration' instead")
+
 				config.UpdateLoggerRegistryFromConfig(s.registry, processedConfig, s.logger)
 			}
 


### PR DESCRIPTION
[RDSK-10723](https://viam.atlassian.net/browse/RSDK-10723)

For now, leave a `TODO` comment and `Warn` about inability to modify module logger levels through the `"debug"` or `"log"` field for now.

I won't close the ticket, but until we do this work, let's at least log what _won't_ work.

cc @bkaravan 