### PR TITLE
[RSDK-10933] refactor motion chains structure

### DIFF
--- a/motionplan/check.go
+++ b/motionplan/check.go
@@ -62,7 +62,7 @@ func CheckPlan(
 
 	// This should be done for any plan whose configurations are specified in relative terms rather than absolute ones.
 	// Currently this is only TP-space, so we check if the PTG length is >0.
-	if planOpts.useTPspace {
+	if planOpts.useTPspace() {
 		return checkPlanRelative(checkFrame, executionState, worldState, fs, lookAheadDistanceMM, sfPlanner)
 	}
 	return checkPlanAbsolute(checkFrame, executionState, worldState, fs, lookAheadDistanceMM, sfPlanner)

--- a/motionplan/check.go
+++ b/motionplan/check.go
@@ -261,7 +261,7 @@ func checkPlanAbsolute(
 
 func checkSegmentsFS(sfPlanner *planManager, segments []*ik.SegmentFS, lookAheadDistanceMM float64) error {
 	// go through segments and check that we satisfy constraints
-	moving, _ := sfPlanner.frameLists()
+	moving, _ := sfPlanner.planOpts.motionChains.framesFilteredByMovingAndNonmoving(sfPlanner.fs)
 	dists := map[string]float64{}
 	for _, segment := range segments {
 		ok, lastValid := sfPlanner.planOpts.CheckSegmentAndStateValidityFS(segment, sfPlanner.planOpts.Resolution)

--- a/motionplan/motionPlanner.go
+++ b/motionplan/motionPlanner.go
@@ -595,10 +595,6 @@ func (mp *planner) linearizeFSmetric(metric ik.StateFSMetric) func([]float64) fl
 	}
 }
 
-func (mp *planner) frameLists() (moving, nonmoving []string) {
-	return mp.planOpts.motionChains.framesFilteredByMovingAndNonmoving(mp.fs)
-}
-
 // The purpose of this function is to allow solves that require the movement of components not in a motion chain, while preventing wild or
 // random motion of these components unnecessarily. A classic example would be a scene with two arms. One arm is given a goal in World
 // which it could reach, but the other arm is in the way. Randomly seeded IK will produce a valid configuration for the moving arm, and a
@@ -606,7 +602,7 @@ func (mp *planner) frameLists() (moving, nonmoving []string) {
 // and if invalid will interpolate the solved random configuration towards the seed and set its configuration to the closest valid
 // configuration to the seed.
 func (mp *planner) nonchainMinimize(seed, step referenceframe.FrameSystemInputs) referenceframe.FrameSystemInputs {
-	moving, nonmoving := mp.frameLists()
+	moving, nonmoving := mp.planOpts.motionChains.framesFilteredByMovingAndNonmoving(mp.fs)
 	// Create a map with nonmoving configurations replaced with their seed values
 	alteredStep := referenceframe.FrameSystemInputs{}
 	for _, frame := range moving {

--- a/motionplan/motionPlanner.go
+++ b/motionplan/motionPlanner.go
@@ -596,22 +596,7 @@ func (mp *planner) linearizeFSmetric(metric ik.StateFSMetric) func([]float64) fl
 }
 
 func (mp *planner) frameLists() (moving, nonmoving []string) {
-	movingMap := map[string]referenceframe.Frame{}
-	for _, chain := range mp.planOpts.motionChains {
-		for _, frame := range chain.frames {
-			movingMap[frame.Name()] = frame
-		}
-	}
-
-	// Here we account for anything in the framesystem that is not part of a motion chain
-	for _, frameName := range mp.fs.FrameNames() {
-		if _, ok := movingMap[frameName]; ok {
-			moving = append(moving, frameName)
-		} else {
-			nonmoving = append(nonmoving, frameName)
-		}
-	}
-	return moving, nonmoving
+	return mp.planOpts.motionChains.framesFilteredByMovingAndNonmoving(mp.fs)
 }
 
 // The purpose of this function is to allow solves that require the movement of components not in a motion chain, while preventing wild or

--- a/motionplan/motionPlanner_test.go
+++ b/motionplan/motionPlanner_test.go
@@ -144,7 +144,11 @@ func constrainedXArmMotion() (*planConfig, error) {
 
 	start := &PlanState{configuration: map[string][]frame.Input{model.Name(): home7}}
 	goal := &PlanState{poses: frame.FrameSystemPoses{model.Name(): frame.NewPoseInFrame(frame.World, pos)}}
-	opt.fillMotionChains(fs, goal)
+	motionChains, err := motionChainsFromPlanState(fs, goal)
+	if err != nil {
+		return nil, err
+	}
+	opt.motionChains = motionChains
 
 	return &planConfig{
 		Start:   start,
@@ -274,7 +278,11 @@ func simple2DMap() (*planConfig, error) {
 	for name, constraint := range collisionConstraints {
 		opt.AddStateConstraint(name, constraint)
 	}
-	opt.fillMotionChains(fs, goal)
+	motionChains, err := motionChainsFromPlanState(fs, goal)
+	if err != nil {
+		return nil, err
+	}
+	opt.motionChains = motionChains
 
 	return &planConfig{
 		Start:   &PlanState{configuration: startInput},
@@ -342,7 +350,11 @@ func simpleXArmMotion() (*planConfig, error) {
 		opt.AddStateFSConstraint(name, constraint)
 	}
 	start := map[string][]frame.Input{xarm.Name(): home7}
-	opt.fillMotionChains(fs, goal)
+	motionChains, err := motionChainsFromPlanState(fs, goal)
+	if err != nil {
+		return nil, err
+	}
+	opt.motionChains = motionChains
 
 	return &planConfig{
 		Start:   &PlanState{configuration: start},
@@ -409,7 +421,11 @@ func simpleUR5eMotion() (*planConfig, error) {
 		opt.AddStateFSConstraint(name, constraint)
 	}
 	start := map[string][]frame.Input{ur5e.Name(): home6}
-	opt.fillMotionChains(fs, goal)
+	motionChains, err := motionChainsFromPlanState(fs, goal)
+	if err != nil {
+		return nil, err
+	}
+	opt.motionChains = motionChains
 
 	return &planConfig{
 		Start:   &PlanState{configuration: start},

--- a/motionplan/plannerOptions.go
+++ b/motionplan/plannerOptions.go
@@ -114,13 +114,15 @@ func newBasicPlannerOptions() *plannerOptions {
 	opt.TimeMultipleAfterFindingFirstSolution = defaultTimeMultipleAfterFindingFirstSolution
 	opt.NumThreads = defaultNumThreads
 
+	opt.motionChains = &motionChains{}
+
 	return opt
 }
 
 // plannerOptions are a set of options to be passed to a planner which will specify how to solve a motion planning problem.
 type plannerOptions struct {
 	ConstraintHandler
-	motionChains []*motionChain
+	motionChains *motionChains
 
 	// This is used to create functions which are passed to IK for solving. This may be used to turn starting or ending state poses into
 	// configurations for nodes.
@@ -192,9 +194,6 @@ type plannerOptions struct {
 	Fallback *plannerOptions
 
 	TimeMultipleAfterFindingFirstSolution int
-
-	useTPspace   bool
-	ptgFrameName string
 }
 
 // getGoalMetric creates the distance metric for the solver using the configured options.
@@ -234,6 +233,20 @@ func (p *plannerOptions) SetMaxSolutions(maxSolutions int) {
 // SetMinScore specifies the IK stopping score for the planner.
 func (p *plannerOptions) SetMinScore(minScore float64) {
 	p.MinScore = minScore
+}
+
+func (p *plannerOptions) useTPspace() bool {
+	if p.motionChains == nil {
+		return false
+	}
+	return p.motionChains.useTPspace
+}
+
+func (p *plannerOptions) ptgFrameName() string {
+	if p.motionChains == nil {
+		return ""
+	}
+	return p.motionChains.ptgFrameName
 }
 
 // addPbConstraints will add all constraints from the passed Constraint struct. This will deal with only the topological
@@ -341,26 +354,5 @@ func (p *plannerOptions) addOrientationConstraints(
 	}
 	p.AddStateFSConstraint(defaultConstraintName, constraint)
 	p.pathMetric = ik.CombineFSMetrics(p.pathMetric, pathDist)
-	return nil
-}
-
-func (p *plannerOptions) fillMotionChains(fs referenceframe.FrameSystem, to *PlanState) error {
-	motionChains := make([]*motionChain, 0, len(to.poses)+len(to.configuration))
-
-	for frame, pif := range to.poses {
-		chain, err := motionChainFromGoal(fs, frame, pif.Parent())
-		if err != nil {
-			return err
-		}
-		motionChains = append(motionChains, chain)
-	}
-	for frame := range to.configuration {
-		chain, err := motionChainFromGoal(fs, frame, frame)
-		if err != nil {
-			return err
-		}
-		motionChains = append(motionChains, chain)
-	}
-	p.motionChains = motionChains
 	return nil
 }

--- a/motionplan/tpSpaceRRT.go
+++ b/motionplan/tpSpaceRRT.go
@@ -141,10 +141,10 @@ func newTPSpaceMotionPlanner(
 		planner: mp,
 	}
 	// TODO: Only one motion chain allowed if tpspace for now. Eventually this may not be a restriction.
-	if len(opt.motionChains) != 1 {
-		return nil, fmt.Errorf("exactly one motion chain permitted for tpspace, but planner option had %d", len(opt.motionChains))
+	if len(opt.motionChains.inner) != 1 {
+		return nil, fmt.Errorf("exactly one motion chain permitted for tpspace, but planner option had %d", len(opt.motionChains.inner))
 	}
-	for _, frame := range opt.motionChains[0].frames {
+	for _, frame := range opt.motionChains.inner[0].frames {
 		if tpFrame, ok := frame.(tpspace.PTGProvider); ok {
 			tpPlanner.tpFrame = frame
 			tpPlanner.solvers = tpFrame.PTGSolvers()

--- a/motionplan/tpSpaceRRT_test.go
+++ b/motionplan/tpSpaceRRT_test.go
@@ -56,7 +56,9 @@ func TestPtgRrtBidirectional(t *testing.T) {
 	opt.scoreFunc = tpspace.NewPTGDistanceMetric([]string{ackermanFrame.Name()})
 	opt.planningAlgorithm = TPSpace
 
-	opt.fillMotionChains(fs, goal)
+	motionChains, err := motionChainsFromPlanState(fs, goal)
+	test.That(t, err, test.ShouldBeNil)
+	opt.motionChains = motionChains
 
 	mp, err := newTPSpaceMotionPlanner(fs, rand.New(rand.NewSource(42)), logger, opt)
 	test.That(t, err, test.ShouldBeNil)
@@ -137,7 +139,9 @@ func TestPtgWithObstacle(t *testing.T) {
 	opt.GoalThreshold = 5
 	opt.planningAlgorithm = TPSpace
 	opt.scoreFunc = tpspace.NewPTGDistanceMetric([]string{ackermanFrame.Name()})
-	opt.fillMotionChains(fs, goal)
+	motionChains, err := motionChainsFromPlanState(fs, goal)
+	test.That(t, err, test.ShouldBeNil)
+	opt.motionChains = motionChains
 
 	// Create collision constraints
 	worldGeometries, err := worldState.ObstaclesInWorldFrame(fs, nil)
@@ -234,7 +238,9 @@ func TestTPsmoothing(t *testing.T) {
 		ackermanFrame.Name(): referenceframe.NewPoseInFrame(referenceframe.World, goalPos),
 	}}
 
-	opt.fillMotionChains(fs, goal)
+	motionChains, err := motionChainsFromPlanState(fs, goal)
+	test.That(t, err, test.ShouldBeNil)
+	opt.motionChains = motionChains
 
 	// Create and initialize planner
 	mp, err := newTPSpaceMotionPlanner(fs, rand.New(rand.NewSource(42)), logger, opt)


### PR DESCRIPTION
Another incremental step on refactoring `PlanRequest` and `planningOptions`. This one targets the infrastructure around motion chains. In this PR, we consolidate the logic around motion chains to a single struct instance (`motionChains`). The intention is that all chain processing occurs in a single constructor function and information about the chains comes from instance methods on the struct.

This will eventually make writing the simplified constructor for `planningOptions` easier.

