### PR TITLE
merge 2 `initStreamServer` implementations

### DIFF
--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -255,7 +255,7 @@ func (svc *webService) startProtocolModuleParentServer(ctx context.Context, tcpM
 		return err
 	}
 
-	if err := svc.initStreamServerForModule(ctx, server); err != nil {
+	if err := svc.initStreamServer(ctx, server); err != nil {
 		return err
 	}
 
@@ -460,7 +460,7 @@ func (svc *webService) runWeb(ctx context.Context, options weboptions.Options) (
 		return err
 	}
 
-	if err := svc.initStreamServer(ctx); err != nil {
+	if err := svc.initStreamServer(ctx, svc.rpcServer); err != nil {
 		return err
 	}
 

--- a/robot/web/web_c.go
+++ b/robot/web/web_c.go
@@ -63,7 +63,7 @@ func (svc *webService) closeStreamServer() {
 	svc.streamServer = nil
 }
 
-func (svc *webService) initStreamServer(ctx context.Context) error {
+func (svc *webService) initStreamServer(ctx context.Context, srv rpc.Server) error {
 	// The webService depends on the stream server in addition to modules. We relax expectations on
 	// what will be started first and allow for any order.
 	if svc.streamServer == nil {
@@ -80,36 +80,6 @@ func (svc *webService) initStreamServer(ctx context.Context) error {
 		return err
 	}
 
-	// Register the stream server + APIs with the outward facing gRPC server.
-	if err := svc.rpcServer.RegisterServiceServer(
-		ctx,
-		&streampb.StreamService_ServiceDesc,
-		svc.streamServer,
-		streampb.RegisterStreamServiceHandlerFromEndpoint,
-	); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (svc *webService) initStreamServerForModule(ctx context.Context, srv rpc.Server) error {
-	// Module's can depend on the stream server, in addition to the general "client facing" RPC
-	// server. We relax expectations on what will be started first and allow for any order.
-	if svc.streamServer == nil {
-		var streamConfig gostream.StreamConfig
-		if svc.opts.streamConfig != nil {
-			streamConfig = *svc.opts.streamConfig
-		} else {
-			svc.logger.Warn("streamConfig is nil, using empty config")
-		}
-		svc.streamServer = webstream.NewServer(svc.r, streamConfig, svc.logger)
-	}
-
-	if err := svc.streamServer.AddNewStreams(svc.cancelCtx); err != nil {
-		return err
-	}
-
-	// Register the stream server + APIs with the gRPC server for modules.
 	return srv.RegisterServiceServer(
 		ctx,
 		&streampb.StreamService_ServiceDesc,

--- a/robot/web/web_notc.go
+++ b/robot/web/web_notc.go
@@ -48,10 +48,5 @@ func (svc *webService) initStreamServer(ctx context.Context) error {
 	return nil
 }
 
-// stub implementation when gostream is not available.
-func (svc *webService) initStreamServerForModule(_ context.Context, _ rpc.Server) error {
-	return nil
-}
-
 // stub for missing gostream
 type options struct{}


### PR DESCRIPTION
## What changed
- web_c.go had two mostly-identical implementations of `initStreamServer`
## Why
Follow-up work to https://github.com/viamrobotics/rdk/pull/5056; this is primarily just cleanup of duplicated logic, but note that AddNewStreams gets called 3 times during startup. Is that heavy / dangerous in any way?