### PR TITLE
DATA-4260: Enable additional_params support in sensor data capture collector

### DIFF
--- a/components/sensor/collectors.go
+++ b/components/sensor/collectors.go
@@ -34,7 +34,14 @@ func newReadingsCollector(resource interface{}, params data.CollectorParams) (da
 	cFunc := data.CaptureFunc(func(ctx context.Context, arg map[string]*anypb.Any) (data.CaptureResult, error) {
 		timeRequested := time.Now()
 		var res data.CaptureResult
-		values, err := sensorResource.Readings(ctx, data.FromDMExtraMap)
+		// merge additional params with data.FromDMExtraMap
+		argMap := make(map[string]interface{})
+		argMap[data.FromDMString] = true
+		for k, v := range arg {
+			argMap[k] = v
+		}
+
+		values, err := sensorResource.Readings(ctx, argMap)
 		if err != nil {
 			// A modular filter component can be created to filter the readings from a component. The error ErrNoCaptureToStore
 			// is used in the datamanager to exclude readings from being captured and stored.


### PR DESCRIPTION
Changes made: merging args with data.FromDMString before passing to `sensor.Readings`

### Testing
Modified local tests accordingly

**Manual Testing**
Used logging to check that map merging is successful
```golang
logger := logging.NewLogger("sensor_readings_collector")
logger.Debugf("argMap: %v", argMap)
```
Resulted in:
2025-06-26T17:29:15.319Z	DEBUG	sensor_readings_collector	sensor/collectors.go:45	argMap: map[fake:[[type.googleapis.com/google.protobuf.Value]:{string_value](http://type.googleapis.com/google.protobuf.Value]:%7Bstring_value):"test"} fromDataManagement:true]2025-06-

Tested this rdk change on viam.dev to ensure that additional_params can be passed into the data capture config.

**Testing with app from [this PR](https://github.com/viamrobotics/app/pull/8846)**
To handle the wrapping that happens when converting protobuf types to interfaces

Result:
<img width="1221" alt="Screenshot 2025-06-26 at 1 48 50 PM" src="https://github.com/user-attachments/assets/199be639-506e-4567-aba6-d09457fa7844" />
