### PR TITLE
Log fake button press with time to avoid log deduping

### DIFF
--- a/components/button/fake/button.go
+++ b/components/button/fake/button.go
@@ -3,6 +3,7 @@ package fake
 
 import (
 	"context"
+	"time"
 
 	"go.viam.com/rdk/components/button"
 	"go.viam.com/rdk/logging"
@@ -36,6 +37,6 @@ func NewButton(
 
 // Push logs the push.
 func (b *Button) Push(ctx context.Context, extra map[string]interface{}) error {
-	b.logger.Info("pushed button")
+	b.logger.Infof("Button pushed at %s", time.Now().Format(time.RFC3339))
 	return nil
 }


### PR DESCRIPTION
A pretty silly change...

Now that we dedupe identical logs that happen in succession, testing with a fake button is difficult as its `Push` log messages get suppressed. Adding a timestamp to the log to stop the logger from deduping.