### PR TITLE
RSDK-10777: Better test coverage of mesh and triangle collisions

### DIFF
--- a/spatialmath/geometry_utils.go
+++ b/spatialmath/geometry_utils.go
@@ -52,7 +52,7 @@ func SegmentDistanceToSegment(ap1, ap2, bp1, bp2 r3.Vector) float64 {
 }
 
 // ClosestPointsSegmentSegment will return the points at which two line segments are closest to one another.
-func ClosestPointsSegmentSegment(ap1, ap2, bp1, bp2 r3.Vector) (r3.Vector, r3.Vector) {
+func ClosestPointsSegmentSegment(a1, a2, b1, b2 r3.Vector) (r3.Vector, r3.Vector) {
 	// // vectors between line endpoints:
 	// v0 := bp1.Sub(ap1)
 	// v1 := bp2.Sub(ap1)
@@ -79,24 +79,29 @@ func ClosestPointsSegmentSegment(ap1, ap2, bp1, bp2 r3.Vector) (r3.Vector, r3.Ve
 
 	// ==================================================
 
+	// fix variable names:
+	// get rid of the ps
+
 	// Proceed according to this math.stackexchange solution: https://math.stackexchange.com/a/2812513
 	// The stack solution has a sign error, which we correct
-	D3121 := bp1.Sub(ap1).Dot(ap2.Sub(ap1))
-	D4321 := bp2.Sub(bp1).Dot(ap2.Sub(ap1))
-	D4331 := bp2.Sub(bp1).Dot(bp1.Sub(ap1))
-	R1pow2 := ap2.Sub(ap1).Dot(ap2.Sub(ap1))
-	R2pow2 := bp2.Sub(bp1).Dot(bp2.Sub(bp1))
+	// These (ugly) variable names were chosen to match those in the stack exchange, for easy reference
+	d3121 := b1.Sub(a1).Dot(a2.Sub(a1))
+	d4321 := b2.Sub(b1).Dot(a2.Sub(a1))
+	d4331 := b2.Sub(b1).Dot(b1.Sub(a1))
+	r1pow2 := a2.Sub(a1).Norm2()
+	r2pow2 := b2.Sub(b1).Norm2()
 
-	denom := R1pow2*R2pow2 - D4321*D4321
+	denom := r1pow2*r2pow2 - d4321*d4321
 	// If denom is 0, the segments are parallel, and we can jump to the endpt case below
+	// If denom is not 0, we finish our algebra
 	if denom != 0 {
 		// Find the closest points on the lines each segment define
 		// If s or t lie outside of [0,1], the closest points on the lines are NOT on the finite segments
-		s := (D3121*R2pow2 - D4331*D4321) / denom
-		t := (D3121*D4321 - D4331*R1pow2) / denom
+		s := (d3121*r2pow2 - d4331*d4321) / denom
+		t := (d3121*d4321 - d4331*r1pow2) / denom
 		if 0 <= s && s <= 1 && 0 <= t && t <= 1 {
-			bestSeg1Pt := ap1.Add(ap2.Sub(ap1).Mul(s))
-			bestSeg2Pt := bp1.Add(bp2.Sub(bp1).Mul(t))
+			bestSeg1Pt := a1.Add(a2.Sub(a1).Mul(s))
+			bestSeg2Pt := b1.Add(b2.Sub(b1).Mul(t))
 			return bestSeg1Pt, bestSeg2Pt
 		}
 	}
@@ -104,14 +109,14 @@ func ClosestPointsSegmentSegment(ap1, ap2, bp1, bp2 r3.Vector) (r3.Vector, r3.Ve
 	// If we're here, the lines are either parallel or their closest points lie off at least one of the segments
 	// It suffices to just check each segment against the other segment's endpoints
 	// (early return makes this a little harder to read)
-	bestSeg1Pt := ap1
-	bestSeg2Pt := ClosestPointSegmentPoint(bp1, bp2, ap1)
+	bestSeg1Pt := a1
+	bestSeg2Pt := ClosestPointSegmentPoint(b1, b2, a1)
 	bestDist := bestSeg1Pt.Sub(bestSeg2Pt).Norm2()
 	if bestDist == 0 {
 		return bestSeg1Pt, bestSeg2Pt
 	}
-	seg1Pt := ap2
-	seg2Pt := ClosestPointSegmentPoint(bp1, bp2, ap2)
+	seg1Pt := a2
+	seg2Pt := ClosestPointSegmentPoint(b1, b2, a2)
 	dist := seg2Pt.Sub(seg1Pt).Norm2()
 	if dist == 0 {
 		return seg1Pt, seg2Pt
@@ -120,8 +125,8 @@ func ClosestPointsSegmentSegment(ap1, ap2, bp1, bp2 r3.Vector) (r3.Vector, r3.Ve
 		bestSeg1Pt, bestSeg2Pt = seg1Pt, seg2Pt
 		bestDist = dist
 	}
-	seg1Pt = ClosestPointSegmentPoint(ap1, ap2, bp1)
-	seg2Pt = bp1
+	seg1Pt = ClosestPointSegmentPoint(a1, a2, b1)
+	seg2Pt = b1
 	dist = seg2Pt.Sub(seg1Pt).Norm2()
 	if dist == 0 {
 		return seg1Pt, seg2Pt
@@ -130,8 +135,8 @@ func ClosestPointsSegmentSegment(ap1, ap2, bp1, bp2 r3.Vector) (r3.Vector, r3.Ve
 		bestSeg1Pt, bestSeg2Pt = seg1Pt, seg2Pt
 		bestDist = dist
 	}
-	seg1Pt = ClosestPointSegmentPoint(ap1, ap2, bp2)
-	seg2Pt = bp2
+	seg1Pt = ClosestPointSegmentPoint(a1, a2, b2)
+	seg2Pt = b2
 	dist = seg2Pt.Sub(seg1Pt).Norm2()
 	if dist == 0 {
 		return seg1Pt, seg2Pt

--- a/spatialmath/geometry_utils.go
+++ b/spatialmath/geometry_utils.go
@@ -79,9 +79,6 @@ func ClosestPointsSegmentSegment(a1, a2, b1, b2 r3.Vector) (r3.Vector, r3.Vector
 
 	// ==================================================
 
-	// fix variable names:
-	// get rid of the ps
-
 	// Proceed according to this math.stackexchange solution: https://math.stackexchange.com/a/2812513
 	// The stack solution has a sign error, which we correct
 	// These (ugly) variable names were chosen to match those in the stack exchange, for easy reference

--- a/spatialmath/mesh_test.go
+++ b/spatialmath/mesh_test.go
@@ -1,7 +1,6 @@
 package spatialmath
 
 import (
-	"fmt"
 	"math"
 	"testing"
 
@@ -79,30 +78,14 @@ func TestMeshTransform(t *testing.T) {
 }
 
 func TestMeshCollidesWithMesh(t *testing.T) {
-	// mesh1 := makeSimpleTriangleMesh()
-
-	// Test collision with overlapping mesh
-	// mesh2 := makeTestMesh(NewZeroOrientation(), r3.Vector{X: 0.5, Y: 0.5, Z: 0},
-	// 	[]*Triangle{NewTriangle(
-	// 		r3.Vector{X: 0, Y: 0, Z: 0},
-	// 		r3.Vector{X: 1, Y: 0, Z: 0},
-	// 		r3.Vector{X: 0, Y: 1, Z: 0},
-	// 	)})
-
-	// collides, err := mesh1.CollidesWith(mesh2, defaultCollisionBufferMM)
-	// test.That(t, err, test.ShouldBeNil)
-	// test.That(t, collides, test.ShouldBeTrue)
-
-	// dont need to erase the above but let's try to be more systematic
-
-	// A mesh has 3 parts: {vertex, edge, face} ==> 6 possible collisions, accounting for symmetry
-	// if using this repeatedly, may want to define above
 	mesh1 := makeTestMesh(NewZeroOrientation(), r3.Vector{},
 		[]*Triangle{NewTriangle(
 			r3.Vector{X: 0, Y: 0, Z: 0},
 			r3.Vector{X: 1, Y: 0, Z: 0},
 			r3.Vector{X: 0, Y: 1, Z: 0},
 		)})
+
+	// A mesh has 3 parts: {vertex, edge, face} ==> 6 possible basic collisions, accounting for symmetry
 
 	// v-v
 	t.Run("triangle vertex against triangle vertex", func(t *testing.T) {
@@ -156,8 +139,8 @@ func TestMeshCollidesWithMesh(t *testing.T) {
 		test.That(t, collides, test.ShouldBeTrue)
 	})
 
-	// e-f -- implies one of the above collision types (e.g., e-e, so if they all work we're fine)
-	// but right now, e-e isn't working. What if we try e-f that implies only e-e (and nothing involving v?)
+	// e-f. This implies one of the above collision types (e.g., e-e) so if they're all perfectly tested (difficult to guarantee) we're fine
+	// nonetheless worth keeping: e-f is the basic collision type checked by collidesWithMesh, and the special case of e parallel to f is important
 	t.Run("triangle edge against triangle face", func(t *testing.T) {
 		mesh2 := makeTestMesh(NewZeroOrientation(), r3.Vector{},
 			[]*Triangle{NewTriangle(
@@ -170,11 +153,7 @@ func TestMeshCollidesWithMesh(t *testing.T) {
 		test.That(t, collides, test.ShouldBeTrue)
 	})
 
-	// f-f -- implies one of the above collision types
-	// again, let's try one that just applies e-e
-	// actually redundancy claim isn't 100% true, it's difficult to test every type of e-e for example
-	// in fact, originally parallel e-e was failing, wouldn't have realized without this f-f test!
-	// but not sure what exactly the generalization is... hard to think of every case
+	// f-f. This implies one of the above collision types
 	t.Run("triangle face against triangle face", func(t *testing.T) {
 		mesh2 := makeTestMesh(NewZeroOrientation(), r3.Vector{},
 			[]*Triangle{NewTriangle(
@@ -187,33 +166,21 @@ func TestMeshCollidesWithMesh(t *testing.T) {
 		test.That(t, collides, test.ShouldBeTrue)
 	})
 
-	// DELETE THIS
-	t.Run("debug triangle face against triangle face", func(t *testing.T) {
+	// Test collision with no edge intersections
+	t.Run("clipped triangles", func(t *testing.T) {
 		mesh2 := makeTestMesh(NewZeroOrientation(), r3.Vector{},
 			[]*Triangle{NewTriangle(
-				r3.Vector{X: 0.5, Y: -0.1, Z: 0},
-				r3.Vector{X: -0.1, Y: 0.5, Z: 0},
-				r3.Vector{X: 0.6, Y: 0.6, Z: 0},
+				r3.Vector{X: 0.5, Y: 0.1, Z: 0.5},
+				r3.Vector{X: 0.5, Y: 0.1, Z: -0.5},
+				r3.Vector{X: -1, Y: 0, Z: 0},
 			)})
-		p0 := r3.Vector{X: 0.5, Y: -0.1, Z: 0}
-		p1 := r3.Vector{X: -0.1, Y: 0.5, Z: 0}
-		fmt.Println(closestPointsSegmentTriangle(p0, p1, mesh1.Triangles()[0]))
-		fmt.Println(ClosestPointsSegmentSegment(p0, p1, r3.Vector{X: 0, Y: 0, Z: 0}, r3.Vector{X: 0, Y: 1, Z: 0}))
-		fmt.Println(ClosestPointsSegmentSegment(r3.Vector{X: -1, Y: 0.4, Z: 0}, r3.Vector{X: 1, Y: 0.6, Z: 0}, r3.Vector{X: 0, Y: 0, Z: 0}, r3.Vector{X: 0, Y: 1, Z: 0}))
-		fmt.Println(ClosestPointsSegmentSegment(r3.Vector{X: -3, Y: 0.2, Z: 0}, r3.Vector{X: 3, Y: 0.8, Z: 0}, r3.Vector{X: 0, Y: 0, Z: 0}, r3.Vector{X: 0, Y: 1, Z: 0}))
-		fmt.Println(ClosestPointsSegmentSegment(r3.Vector{X: -1, Y: 0.5, Z: 0}, r3.Vector{X: 1, Y: 0.5, Z: 0}, r3.Vector{X: 0, Y: 0, Z: 0}, r3.Vector{X: 0, Y: 1, Z: 0}))
-		// ok, closest points segment-segment is also bugged
-		// hmm, the logic is slightly funny isn't it?? yeah it def is, it's assuming the segments are like far away or smthn
-		// when they "overlap" so to speak, the sitch is ugly (eh not sure exactly what the case is, like perp or || is fine)
-		// anyway defo fails the general case
-
 		collides, err := mesh1.CollidesWith(mesh2, defaultCollisionBufferMM)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, collides, test.ShouldBeTrue)
 	})
 
 	// Test collision with non-overlapping mesh
-	t.Run("non-overlapping mesh", func(t *testing.T) {
+	t.Run("non-overlapping triangles", func(t *testing.T) {
 		mesh2 := makeTestMesh(NewZeroOrientation(), r3.Vector{},
 			[]*Triangle{NewTriangle(
 				r3.Vector{X: 0, Y: 0, Z: 0.2},
@@ -224,148 +191,148 @@ func TestMeshCollidesWithMesh(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, collides, test.ShouldBeFalse)
 	})
-
-	// ENCOMPASSING?
 }
 
 func TestMeshCollidesWithCapsule(t *testing.T) {
-	mesh := makeSimpleTriangleMesh()
-	mesh1 := makeTestMesh(NewZeroOrientation(), r3.Vector{},
+	mesh := makeTestMesh(NewZeroOrientation(), r3.Vector{},
 		[]*Triangle{NewTriangle(
 			r3.Vector{X: 0, Y: 0, Z: 0},
 			r3.Vector{X: 1, Y: 0, Z: 0},
 			r3.Vector{X: 0, Y: 1, Z: 0},
 		)})
-	// looks like capsule canonically points on z-axis
 
 	// A mesh has 3 parts: {vertex, edge, face}
 	// A capsule has approx 3 parts: {extreme point, general spherical point, cylinder point}
-	// we enumerate the 9 possible pairs
+	// We enumerate the 9 possible pairs
 
 	// Collision with triangle vertex
 	// Capsule extreme vertex collision (with triangle vertex)
-	// shift up by 1.5
-	capsule, err := NewCapsule(NewPose(r3.Vector{X: 0, Y: 0, Z: 1.5},
-		NewZeroOrientation()), 1, 3, "")
-	test.That(t, err, test.ShouldBeNil)
-	collides, err := mesh1.CollidesWith(capsule, defaultCollisionBufferMM)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, collides, test.ShouldBeTrue)
-	// Capsule non-extreme spherical vertex collision (with triangle vertex)
-	// shift up by 1.5, then down by r/2 and back by 3r/4
-	capsule, err = NewCapsule(NewPose(r3.Vector{X: -0.75, Y: 0, Z: 1},
-		NewZeroOrientation()), 1, 3, "")
-	test.That(t, err, test.ShouldBeNil)
-	collides, err = mesh.CollidesWith(capsule, defaultCollisionBufferMM)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, collides, test.ShouldBeTrue)
-	// Capsule cylinder vertex collision (with triangle vertex)
-	// shift left by r
-	capsule, err = NewCapsule(NewPose(r3.Vector{X: -1, Y: 0, Z: 0},
-		NewZeroOrientation()), 1, 3, "")
-	test.That(t, err, test.ShouldBeNil)
-	collides, err = mesh.CollidesWith(capsule, defaultCollisionBufferMM)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, collides, test.ShouldBeTrue)
-	// Capsule cylinder line collision (with triangle vertex) (not possible)
+	t.Run("triangle vertex against capsule endpoint", func(t *testing.T) {
+		capsule, err := NewCapsule(NewPose(r3.Vector{X: 0, Y: 0, Z: 1.5},
+			NewZeroOrientation()), 1, 3, "")
+		test.That(t, err, test.ShouldBeNil)
+		collides, err := mesh.CollidesWith(capsule, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeTrue)
+	})
+
+	// Capsule non-extreme spherical point collision (with triangle vertex)
+	t.Run("triangle vertex against capsule generic spherical point", func(t *testing.T) {
+		capsule, err := NewCapsule(NewPose(r3.Vector{X: -0.75, Y: 0, Z: 1},
+			NewZeroOrientation()), 1, 3, "")
+		test.That(t, err, test.ShouldBeNil)
+		collides, err := mesh.CollidesWith(capsule, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeTrue)
+	})
+
+	// Capsule cylinder point collision (with triangle vertex)
+	t.Run("triangle vertex against capsule cylinder point", func(t *testing.T) {
+		capsule, err := NewCapsule(NewPose(r3.Vector{X: -1, Y: 0, Z: 0},
+			NewZeroOrientation()), 1, 3, "")
+		test.That(t, err, test.ShouldBeNil)
+		collides, err := mesh.CollidesWith(capsule, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeTrue)
+	})
 
 	// Collision with triangle edge
 	// Capsule extreme vertex collision (with triangle edge)
-	// shift (0.5, 0, 1.5)
-	capsule, err = NewCapsule(NewPose(r3.Vector{X: 0.5, Y: 0, Z: 1.5},
-		NewZeroOrientation()), 1, 3, "")
-	test.That(t, err, test.ShouldBeNil)
-	collides, err = mesh.CollidesWith(capsule, defaultCollisionBufferMM)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, collides, test.ShouldBeTrue)
+	t.Run("triangle edge against capsule endpoint", func(t *testing.T) {
+		capsule, err := NewCapsule(NewPose(r3.Vector{X: 0.5, Y: 0, Z: 1.5},
+			NewZeroOrientation()), 1, 3, "")
+		test.That(t, err, test.ShouldBeNil)
+		collides, err := mesh.CollidesWith(capsule, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeTrue)
+	})
+
 	// Capsule non-extreme spherical vertex collision (with triangle edge)
-	// shift (-0.75, 0.5, 1)
-	capsule, err = NewCapsule(NewPose(r3.Vector{X: -0.75, Y: 0.5, Z: 1},
-		NewZeroOrientation()), 1, 3, "")
-	test.That(t, err, test.ShouldBeNil)
-	collides, err = mesh.CollidesWith(capsule, defaultCollisionBufferMM)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, collides, test.ShouldBeTrue)
+	t.Run("triangle edge against capsule generic spherical point", func(t *testing.T) {
+		capsule, err := NewCapsule(NewPose(r3.Vector{X: -0.75, Y: 0.5, Z: 1},
+			NewZeroOrientation()), 1, 3, "")
+		test.That(t, err, test.ShouldBeNil)
+		collides, err := mesh.CollidesWith(capsule, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeTrue)
+	})
+
 	// Capsule cylinder vertex collision (with triangle edge)
-	capsule, err = NewCapsule(NewPose(r3.Vector{X: 0.5, Y: -1, Z: 0},
-		NewZeroOrientation()), 1, 3, "")
-	test.That(t, err, test.ShouldBeNil)
-	collides, err = mesh.CollidesWith(capsule, defaultCollisionBufferMM)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, collides, test.ShouldBeTrue)
-	// Capsule cylinder line collision (with triangle edge)
-	capsule, err = NewCapsule(NewPose(r3.Vector{X: 0, Y: -1, Z: 0},
-		&OrientationVector{OX: 1}), 1, 3, "")
-	test.That(t, err, test.ShouldBeNil)
-	collides, err = mesh.CollidesWith(capsule, defaultCollisionBufferMM)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, collides, test.ShouldBeTrue)
+	t.Run("triangle edge against capsule cylinder point", func(t *testing.T) {
+		capsule, err := NewCapsule(NewPose(r3.Vector{X: 0.5, Y: -1, Z: 0},
+			NewZeroOrientation()), 1, 3, "")
+		test.That(t, err, test.ShouldBeNil)
+		collides, err := mesh.CollidesWith(capsule, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeTrue)
+	})
 
 	// Collision with triangle face
 	// Capsule extreme vertex collision (with triangle face)
-	// (0.5, 0.5, 1.5)
-	capsule, err = NewCapsule(NewPose(r3.Vector{X: 0.5, Y: 0.5, Z: 1.5},
-		NewZeroOrientation()), 1, 3, "")
-	test.That(t, err, test.ShouldBeNil)
-	collides, err = mesh.CollidesWith(capsule, defaultCollisionBufferMM)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, collides, test.ShouldBeTrue)
+	t.Run("triangle face against capsule endpoint", func(t *testing.T) {
+		capsule, err := NewCapsule(NewPose(r3.Vector{X: 0.5, Y: 0.5, Z: 1.5},
+			NewZeroOrientation()), 1, 3, "")
+		test.That(t, err, test.ShouldBeNil)
+		collides, err := mesh.CollidesWith(capsule, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeTrue)
+	})
+
 	// Capsule non-extreme spherical vertex collision (with triangle face)
-	// this one is super cringe... math.Sqrt()
-	// (0,1,1) orientation, (0.5,0.5,1+math.Sqrt(2)/2)
-	// this is presumably failing due to rounding error... except actually the error seems pretty big
-	capsule, err = NewCapsule(NewPose(r3.Vector{X: 0.5, Y: 0.5, Z: 1 + math.Sqrt(2)/4},
-		&OrientationVector{OY: 1, OZ: 1}), 1, 3, "")
-	test.That(t, err, test.ShouldBeNil)
-	collides, err = mesh.CollidesWith(capsule, defaultCollisionBufferMM)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, collides, test.ShouldBeTrue)
-	// Capsule cylinder vertex collision (with triangle face)
-	// NOT POSSIBLE
-	// Capsule cylinder line collision (with triangle face)
-	// on its side again, but tiny modified capsule
-	capsule, err = NewCapsule(NewPose(r3.Vector{X: 0.2, Y: 0.2, Z: 0.1},
-		&OrientationVector{OX: 1}), 0.1, 0.3, "")
-	test.That(t, err, test.ShouldBeNil)
-	collides, err = mesh.CollidesWith(capsule, defaultCollisionBufferMM)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, collides, test.ShouldBeTrue)
+	t.Run("triangle face against capsule generic spherical point", func(t *testing.T) {
+		capsule, err := NewCapsule(NewPose(r3.Vector{X: 0.5, Y: 0.5, Z: 1 + math.Sqrt(2)/4},
+			&OrientationVector{OY: 1, OZ: 1}), 1, 3, "")
+		test.That(t, err, test.ShouldBeNil)
+		collides, err := mesh.CollidesWith(capsule, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeTrue)
+	})
+
+	// Capsule cylinder vertex collision (with triangle face) point collision not possible, have to use a line
+	t.Run("triangle face against capsule cylinder point", func(t *testing.T) {
+		capsule, err := NewCapsule(NewPose(r3.Vector{X: 0.2, Y: 0.2, Z: 0.1},
+			&OrientationVector{OX: 1}), 0.1, 0.3, "")
+		test.That(t, err, test.ShouldBeNil)
+		collides, err := mesh.CollidesWith(capsule, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeTrue)
+	})
 
 	// Partially encompassing capsule (could potentially divide into more cases, but this (only face collisions) should be most restrictive)
-	capsule, err = NewCapsule(NewPose(r3.Vector{X: 0.2, Y: 0.2, Z: 0},
-		NewZeroOrientation()), 0.1, 0.3, "")
-	test.That(t, err, test.ShouldBeNil)
-	collides, err = mesh.CollidesWith(capsule, defaultCollisionBufferMM)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, collides, test.ShouldBeTrue)
+	t.Run("capsule encompassing triangle face", func(t *testing.T) {
+		capsule, err := NewCapsule(NewPose(r3.Vector{X: 0.2, Y: 0.2, Z: 0},
+			NewZeroOrientation()), 0.1, 0.3, "")
+		test.That(t, err, test.ShouldBeNil)
+		collides, err := mesh.CollidesWith(capsule, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeTrue)
+	})
 
 	// Completely encompassing capsule, no boundary collision
-	capsule, err = NewCapsule(NewZeroPose(), 2, 4.5, "")
-	test.That(t, err, test.ShouldBeNil)
-	collides, err = mesh.CollidesWith(capsule, defaultCollisionBufferMM)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, collides, test.ShouldBeTrue)
+	t.Run("capsule completely encompassing triangle", func(t *testing.T) {
+		capsule, err := NewCapsule(NewZeroPose(), 2, 4.5, "")
+		test.That(t, err, test.ShouldBeNil)
+		collides, err := mesh.CollidesWith(capsule, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeTrue)
+	})
 
 	// Non-overlapping capsule
-	capsule, err = NewCapsule(NewPose(r3.Vector{X: -1.1, Y: -1.1, Z: 0},
-		NewZeroOrientation()), 1, 3, "")
-	test.That(t, err, test.ShouldBeNil)
-	collides, err = mesh.CollidesWith(capsule, defaultCollisionBufferMM)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, collides, test.ShouldBeFalse)
+	t.Run("capsule not touching triangle", func(t *testing.T) {
+		capsule, err := NewCapsule(NewPose(r3.Vector{X: -1.1, Y: -1.1, Z: 0},
+			NewZeroOrientation()), 1, 3, "")
+		test.That(t, err, test.ShouldBeNil)
+		collides, err := mesh.CollidesWith(capsule, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeFalse)
+	})
 }
 
 func TestMeshCollidesWithBox(t *testing.T) {
-
 	mesh := makeSimpleTriangleMesh()
-	// why is encompassing only specified as a special case for box? (what makes box different?)!
-	// ^ this is quite confusing because what if you just make a mesh that looks like a meshified box?
-	// AHHHHHHHHHH
-
-	// non-point collisions (e.g., edges with more than a point of overlap) are redundant with point collisions
-	// types of triangle points: {vertex, edge, face}
-	// types of box points: {vertex, edge, face}
-	// exhaust the 9 collision options:
+	// Types of triangle points: {vertex, edge, face}
+	// Types of box points: {vertex, edge, face}
+	// We exhaust the 9 collision options
 
 	// Collision with triangle vertex
 	// Box vertex collision (with triangle vertex)
@@ -408,150 +375,26 @@ func TestMeshCollidesWithBox(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, collides, test.ShouldBeTrue)
 	})
+
 	// Box edge collision (with triangle edge)
-	// TODO: revise this (just rotate 45deg about z axis) to make it more readable
-	// I guess revision is like orientation Theta: math.Pi/4, then shift by half-diagonals (sqrt(2)/2)...
 	t.Run("Box edge against triangle edge", func(t *testing.T) {
-		box, err := NewBox(NewPose(r3.Vector{X: 0.5, Y: -0.5, Z: 0.5},
-			&OrientationVector{Theta: math.Pi / 4, OY: 1, OZ: 1}), r3.Vector{X: 1, Y: 1, Z: 1}, "")
+		box, err := NewBox(NewPose(r3.Vector{X: 0.5, Y: -math.Sqrt(2) / 2, Z: 0},
+			&OrientationVector{Theta: math.Pi / 4}), r3.Vector{X: 1, Y: 1, Z: 1}, "")
 		test.That(t, err, test.ShouldBeNil)
 		collides, err := mesh.CollidesWith(box, defaultCollisionBufferMM)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, collides, test.ShouldBeTrue)
 	})
 
-	t.Run("example edge collision failure", func(t *testing.T) {
-		ABC := makeTestMesh(NewZeroOrientation(), r3.Vector{},
-			[]*Triangle{NewTriangle(
-				r3.Vector{X: 0, Y: 0, Z: 0},
-				r3.Vector{X: 1, Y: 0, Z: 0},
-				r3.Vector{X: 0, Y: 1, Z: 0},
-			)})
-		DEF := makeTestMesh(NewZeroOrientation(), r3.Vector{},
-			[]*Triangle{NewTriangle(
-				r3.Vector{X: 0.5, Y: 0, Z: 0.5},
-				r3.Vector{X: 0.5, Y: 0, Z: -0.5},
-				r3.Vector{X: 0.5, Y: -1, Z: 0},
-			)})
-		collides, err := ABC.CollidesWith(DEF, defaultCollisionBufferMM)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, collides, test.ShouldBeTrue)
-	})
-
-	t.Run("debug edge collision", func(t *testing.T) {
-		// continuing to litter all over this file, need to clean up
-
-		p0 := r3.Vector{X: 0, Y: 0, Z: 0}
-		p1 := r3.Vector{X: 0, Y: 1, Z: 0}
-		p2 := r3.Vector{X: 1, Y: 0, Z: 0}
-		basicTri := NewTriangle(p0, p1, p2)
-		t0 := r3.Vector{X: 0.5, Y: 0, Z: 0.5}
-		t1 := r3.Vector{X: 0.5, Y: 0, Z: -0.5}
-		t2 := r3.Vector{X: 0.5, Y: -1, Z: 0}
-		basicTri2 := NewTriangle(t0, t1, t2)
-
-		mesh1 := makeTestMesh(NewZeroOrientation(), r3.Vector{},
-			[]*Triangle{basicTri})
-		mesh2 := makeTestMesh(NewZeroOrientation(), r3.Vector{},
-			[]*Triangle{basicTri2})
-
-		fmt.Println(mesh1.collidesWithMesh(mesh2, defaultCollisionBufferMM))
-		fmt.Println(closestPointsSegmentTriangle(t0, t1, basicTri))
-		fmt.Println(closestPointsSegmentTriangle(p0, p2, basicTri2))
-		// looks like tendency is to overestimate the "t" parameter on the segment
-		// no, underestimate
-
-		segPt, _ := closestPointsSegmentPlane(t0, t1, basicTri.p0, basicTri.normal)
-		triPt, inside := closestTriangleInsidePoint(basicTri, segPt)
-		fmt.Println(segPt)
-		fmt.Println(triPt)
-		fmt.Println(inside)
-		// looks like we are explicitly making an error here inside closestPointsSegmentPlane
-		fmt.Println("BUFFER")
-		fmt.Println(basicTri.normal) // no error here
-
-		segVec := t1.Sub(t0)
-		d := basicTri.p0.Dot(basicTri.normal)
-		denom := basicTri.normal.Dot(segVec)
-		time := (d - basicTri.normal.Dot(t0)) / (denom) //  + 1e-6 causing errors
-		coplanarPt := segVec.Mul(time).Add(t0)
-		fmt.Println(time)
-		fmt.Println(coplanarPt)
-
-		// yay! it really just is that denominator adjustment
-
-		// test.That(t, R3VectorAlmostEqual(bestSegPt, r3.Vector{0.5, 0, 0}, 1e-7), test.ShouldBeTrue)
-		// test.That(t, bestSegPt, test.ShouldAlmostEqual, r3.Vector{0.5, 0, 0})
-	})
-
-	//hmm....
-	// ok so dummy_mesh does intersect, mesh does not !!!
-	// dummy_mesh := makeTestMesh(NewZeroOrientation(), r3.Vector{},
-	// 	[]*Triangle{NewTriangle(
-	// 		r3.Vector{X: 0.5, Y: 0, Z: 0},
-	// 		r3.Vector{X: 0, Y: 1, Z: 0},
-	// 		r3.Vector{X: 1, Y: 0, Z: 0},
-	// 	)})
-	// box, err := NewBox(NewPose(r3.Vector{X: 0.5, Y: -0.5, Z: 0.5},
-	// 	&OrientationVector{Theta: math.Pi / 4, OY: 1, OZ: 1}), r3.Vector{X: 1, Y: 1, Z: 1}, "")
-	// test.That(t, err, test.ShouldBeNil)
-	// collides, err := dummy_mesh.CollidesWith(box, defaultCollisionBufferMM)
-	// test.That(t, err, test.ShouldBeNil)
-	// test.That(t, collides, test.ShouldBeTrue)
-
-	// now lets try 2 perpendicular triangles
-	t.Run("Box edge against two triangle edges", func(t *testing.T) {
-		tri1 := NewTriangle(
-			r3.Vector{X: 0, Y: 0, Z: 0},
-			r3.Vector{X: 1, Y: 0, Z: 0},
-			r3.Vector{X: 0, Y: 1, Z: 0},
-		)
-		tri2 := NewTriangle(
-			r3.Vector{X: 0, Y: 0, Z: 0},
-			r3.Vector{X: 1, Y: 0, Z: 0},
-			r3.Vector{X: 0, Y: 0, Z: -1},
-		)
-		extendedMesh := makeTestMesh(NewZeroOrientation(), r3.Vector{}, []*Triangle{tri1, tri2})
-		box, err := NewBox(NewPose(r3.Vector{X: 0.5, Y: -0.5, Z: 0.5},
-			&OrientationVector{Theta: math.Pi / 4, OY: 1, OZ: 1}), r3.Vector{X: 1, Y: 1, Z: 1}, "")
-		test.That(t, err, test.ShouldBeNil)
-		collides, err := extendedMesh.CollidesWith(box, defaultCollisionBufferMM)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, collides, test.ShouldBeTrue)
-	})
-
-	// try again with mesh, slight indentation
-	// slight indentation FAILS
-	t.Run("Box edge into triangle edge (slight indentation)", func(t *testing.T) {
-		box, err := NewBox(NewPose(r3.Vector{X: 0.5, Y: -0.5, Z: 0.5},
-			&OrientationVector{Theta: math.Pi / 4, OY: 1, OZ: 1}), r3.Vector{X: 1, Y: 1, Z: 1}, "")
+	// Partially encompassing box, no triangle vertices inside the box
+	t.Run("Box clipping triangle", func(t *testing.T) {
+		box, err := NewBox(NewPose(r3.Vector{X: 0.9, Y: 0.9, Z: 0}, NewZeroOrientation()),
+			r3.Vector{X: 1, Y: 1, Z: 1}, "")
 		test.That(t, err, test.ShouldBeNil)
 		collides, err := mesh.CollidesWith(box, defaultCollisionBufferMM)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, collides, test.ShouldBeTrue)
 	})
-
-	// Box face collision (with triangle edge) (redundant)
-	// box, err = NewBox(NewPose(r3.Vector{X: -0.5, Y: 0.5, Z: 0}, NewZeroOrientation()),
-	// 	r3.Vector{X: 1, Y: 1, Z: 1}, "")
-	// test.That(t, err, test.ShouldBeNil)
-	// collides, err = mesh.CollidesWith(box, defaultCollisionBufferMM)
-	// test.That(t, err, test.ShouldBeNil)
-	// test.That(t, collides, test.ShouldBeTrue)
-
-	// Collision with triangle face
-	// Box vertex collision (with triangle face)
-	// Box edge collision (with triangle face)
-	// Box face collision (with triangle face)
-
-	// Partially encompassing box, no vertex collisions
-	// REVIST THIS TEST, BUT IT SHOULD BE USELESS
-	// box, err = NewBox(NewZeroPose(),
-	// 	r3.Vector{X: 1, Y: 1, Z: 1}, "")
-	// test.That(t, err, test.ShouldBeNil)
-	// collides, err = mesh.CollidesWith(box, defaultCollisionBufferMM)
-	// test.That(t, err, test.ShouldBeNil)
-	// test.That(t, collides, test.ShouldBeTrue)
 
 	// Completely encompassing box, no boundary collision
 	t.Run("Box strictly encompassing triangle", func(t *testing.T) {
@@ -563,16 +406,8 @@ func TestMeshCollidesWithBox(t *testing.T) {
 		test.That(t, collides, test.ShouldBeTrue)
 	})
 
-	// // Create overlapping box
-	// box, err = NewBox(NewZeroPose(), r3.Vector{X: 1, Y: 1, Z: 1}, "")
-	// test.That(t, err, test.ShouldBeNil)
-
-	// collides, err = mesh.CollidesWith(box, defaultCollisionBufferMM)
-	// test.That(t, err, test.ShouldBeNil)
-	// test.That(t, collides, test.ShouldBeTrue)
-
 	// Create non-overlapping box
-	t.Run("Box vertex not touching triangle", func(t *testing.T) {
+	t.Run("Box not touching triangle", func(t *testing.T) {
 		box, err := NewBox(NewPose(r3.Vector{X: 2, Y: 2, Z: 2}, NewZeroOrientation()),
 			r3.Vector{X: 1, Y: 1, Z: 1}, "")
 		test.That(t, err, test.ShouldBeNil)
@@ -583,17 +418,109 @@ func TestMeshCollidesWithBox(t *testing.T) {
 	})
 }
 
-// e.g., could write something like the below:
-// func TestMeshCollisionExpectation(t *testing.T, mesh *Mesh, g Geometry, expected bool) {
-// 	collides, err := mesh.CollidesWith(g, defaultCollisionBufferMM)
-// 	test.That(t, err, test.ShouldBeNil)
-// 	if expected {
-// 		test.That(t, collides, test.ShouldBeTrue)
-// 	} else {
-// 		test.That(t, collides, test.ShouldBeFalse)
-// 	}
-// }
-// BUT this doesnt seem like licit function for the testing file
+func TestMeshCollidesWithPoint(t *testing.T) {
+	mesh := makeTestMesh(NewZeroOrientation(), r3.Vector{},
+		[]*Triangle{NewTriangle(
+			r3.Vector{X: 0, Y: 0, Z: 0},
+			r3.Vector{X: 1, Y: 0, Z: 0},
+			r3.Vector{X: 0, Y: 1, Z: 0},
+		)})
+
+	// Collision with triangle vertex
+	t.Run("Point against triangle vertex", func(t *testing.T) {
+		point := NewPoint(r3.Vector{}, "")
+		collides, err := mesh.CollidesWith(point, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeTrue)
+	})
+
+	// Collision with triangle edge
+	t.Run("Point against triangle edge", func(t *testing.T) {
+		point := NewPoint(r3.Vector{X: 0, Y: 0.5, Z: 0}, "")
+		collides, err := mesh.CollidesWith(point, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeTrue)
+	})
+
+	// Collision with triangle face
+	t.Run("Point against triangle face", func(t *testing.T) {
+		point := NewPoint(r3.Vector{X: 0.3, Y: 0.3, Z: 0}, "")
+		collides, err := mesh.CollidesWith(point, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeTrue)
+	})
+
+	// Point not touching triangle
+	t.Run("Point not touching triangle", func(t *testing.T) {
+		point := NewPoint(r3.Vector{X: 0, Y: 0, Z: 2 * defaultCollisionBufferMM}, "")
+		collides, err := mesh.CollidesWith(point, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeFalse)
+	})
+}
+
+func TestMeshCollidesWithSphere(t *testing.T) {
+	mesh := makeTestMesh(NewZeroOrientation(), r3.Vector{},
+		[]*Triangle{NewTriangle(
+			r3.Vector{X: 0, Y: 0, Z: 0},
+			r3.Vector{X: 1, Y: 0, Z: 0},
+			r3.Vector{X: 0, Y: 1, Z: 0},
+		)})
+
+	// Collision with triangle vertex
+	t.Run("Sphere against triangle vertex", func(t *testing.T) {
+		sphere, err := NewSphere(NewPose(r3.Vector{X: 0, Y: 0, Z: 1}, NewZeroOrientation()), 1, "")
+		test.That(t, err, test.ShouldBeNil)
+		collides, err := mesh.CollidesWith(sphere, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeTrue)
+	})
+
+	// Collision with triangle edge
+	t.Run("Sphere against triangle edge", func(t *testing.T) {
+		sphere, err := NewSphere(NewPose(r3.Vector{X: 0.5, Y: 0, Z: 1}, NewZeroOrientation()), 1, "")
+		test.That(t, err, test.ShouldBeNil)
+		collides, err := mesh.CollidesWith(sphere, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeTrue)
+	})
+
+	// Collision with triangle face
+	t.Run("Sphere against triangle face", func(t *testing.T) {
+		sphere, err := NewSphere(NewPose(r3.Vector{X: 0.3, Y: 0.3, Z: 1}, NewZeroOrientation()), 1, "")
+		test.That(t, err, test.ShouldBeNil)
+		collides, err := mesh.CollidesWith(sphere, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeTrue)
+	})
+
+	// Sphere clipping triangle
+	t.Run("Sphere clipping triangle", func(t *testing.T) {
+		sphere, err := NewSphere(NewPose(r3.Vector{X: 0.3, Y: 0.3, Z: 0}, NewZeroOrientation()), 0.1, "")
+		test.That(t, err, test.ShouldBeNil)
+		collides, err := mesh.CollidesWith(sphere, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeTrue)
+	})
+
+	// Sphere completely encompassing triangle
+	t.Run("Sphere completely encompassing triangle", func(t *testing.T) {
+		sphere, err := NewSphere(NewZeroPose(), 2, "")
+		test.That(t, err, test.ShouldBeNil)
+		collides, err := mesh.CollidesWith(sphere, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeTrue)
+	})
+
+	// Sphere not touching triangle
+	t.Run("Sphere not touching triangle", func(t *testing.T) {
+		sphere, err := NewSphere(NewPose(r3.Vector{X: 0, Y: 0, Z: 1 + 2*defaultCollisionBufferMM}, NewZeroOrientation()), 1, "")
+		test.That(t, err, test.ShouldBeNil)
+		collides, err := mesh.CollidesWith(sphere, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeFalse)
+	})
+}
 
 func TestMeshDistanceFrom(t *testing.T) {
 	mesh1 := makeSimpleTriangleMesh()

--- a/spatialmath/mesh_test.go
+++ b/spatialmath/mesh_test.go
@@ -140,7 +140,8 @@ func TestMeshCollidesWithMesh(t *testing.T) {
 	})
 
 	// e-f. This implies one of the above collision types (e.g., e-e) so if they're all perfectly tested (difficult to guarantee) we're fine
-	// nonetheless worth keeping: e-f is the basic collision type checked by collidesWithMesh, and the special case of e parallel to f is important
+	// nonetheless worth keeping: e-f is the basic collision type checked by collidesWithMesh,
+	// and the special case of e parallel to f is important
 	t.Run("triangle edge against triangle face", func(t *testing.T) {
 		mesh2 := makeTestMesh(NewZeroOrientation(), r3.Vector{},
 			[]*Triangle{NewTriangle(

--- a/spatialmath/mesh_test.go
+++ b/spatialmath/mesh_test.go
@@ -1,6 +1,8 @@
 package spatialmath
 
 import (
+	"fmt"
+	"math"
 	"testing"
 
 	"github.com/golang/geo/r3"
@@ -104,26 +106,364 @@ func TestMeshCollidesWithMesh(t *testing.T) {
 	test.That(t, collides, test.ShouldBeFalse)
 }
 
-func TestMeshCollidesWithBox(t *testing.T) {
+func TestMeshCollidesWithCapsule(t *testing.T) {
 	mesh := makeSimpleTriangleMesh()
+	// TODOTODOTODO: NEED TO REORGANIZE AS WITH BOX, AND ADD t.RUNS
+	// e.g., like capsule line is not a necessary thing to specify, for example. glad to have better clarity on this.
+	// looks like capsule canonically points on z-axis
 
-	// Create overlapping box
-	box, err := NewBox(NewZeroPose(), r3.Vector{X: 1, Y: 1, Z: 1}, "")
+	// Collision with triangle vertex
+	// Capsule extreme vertex collision (with triangle vertex)
+	// shift up by 1.5
+	capsule, err := NewCapsule(NewPose(r3.Vector{X: 0, Y: 0, Z: 1.5},
+		NewZeroOrientation()), 1, 3, "")
 	test.That(t, err, test.ShouldBeNil)
+	collides, err := mesh.CollidesWith(capsule, defaultCollisionBufferMM)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, collides, test.ShouldBeTrue)
+	// Capsule non-extreme spherical vertex collision (with triangle vertex)
+	// shift up by 1.5, then down by r/2 and back by 3r/4
+	capsule, err = NewCapsule(NewPose(r3.Vector{X: -0.75, Y: 0, Z: 1},
+		NewZeroOrientation()), 1, 3, "")
+	test.That(t, err, test.ShouldBeNil)
+	collides, err = mesh.CollidesWith(capsule, defaultCollisionBufferMM)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, collides, test.ShouldBeTrue)
+	// Capsule cylinder vertex collision (with triangle vertex)
+	// shift left by r
+	capsule, err = NewCapsule(NewPose(r3.Vector{X: -1, Y: 0, Z: 0},
+		NewZeroOrientation()), 1, 3, "")
+	test.That(t, err, test.ShouldBeNil)
+	collides, err = mesh.CollidesWith(capsule, defaultCollisionBufferMM)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, collides, test.ShouldBeTrue)
+	// Capsule cylinder line collision (with triangle vertex) (not possible)
 
-	collides, err := mesh.CollidesWith(box, defaultCollisionBufferMM)
+	// Collision with triangle edge
+	// Capsule extreme vertex collision (with triangle edge)
+	// shift (0.5, 0, 1.5)
+	capsule, err = NewCapsule(NewPose(r3.Vector{X: 0.5, Y: 0, Z: 1.5},
+		NewZeroOrientation()), 1, 3, "")
+	test.That(t, err, test.ShouldBeNil)
+	collides, err = mesh.CollidesWith(capsule, defaultCollisionBufferMM)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, collides, test.ShouldBeTrue)
+	// Capsule non-extreme spherical vertex collision (with triangle edge)
+	// shift (-0.75, 0.5, 1)
+	capsule, err = NewCapsule(NewPose(r3.Vector{X: -0.75, Y: 0.5, Z: 1},
+		NewZeroOrientation()), 1, 3, "")
+	test.That(t, err, test.ShouldBeNil)
+	collides, err = mesh.CollidesWith(capsule, defaultCollisionBufferMM)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, collides, test.ShouldBeTrue)
+	// Capsule cylinder vertex collision (with triangle edge)
+	capsule, err = NewCapsule(NewPose(r3.Vector{X: 0.5, Y: -1, Z: 0},
+		NewZeroOrientation()), 1, 3, "")
+	test.That(t, err, test.ShouldBeNil)
+	collides, err = mesh.CollidesWith(capsule, defaultCollisionBufferMM)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, collides, test.ShouldBeTrue)
+	// Capsule cylinder line collision (with triangle edge)
+	capsule, err = NewCapsule(NewPose(r3.Vector{X: 0, Y: -1, Z: 0},
+		&OrientationVector{OX: 1}), 1, 3, "")
+	test.That(t, err, test.ShouldBeNil)
+	collides, err = mesh.CollidesWith(capsule, defaultCollisionBufferMM)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, collides, test.ShouldBeTrue)
 
-	// Create non-overlapping box
-	box2, err := NewBox(NewPose(r3.Vector{X: 2, Y: 2, Z: 2}, NewZeroOrientation()),
-		r3.Vector{X: 1, Y: 1, Z: 1}, "")
+	// Collision with triangle face
+	// Capsule extreme vertex collision (with triangle face)
+	// (0.5, 0.5, 1.5)
+	capsule, err = NewCapsule(NewPose(r3.Vector{X: 0.5, Y: 0.5, Z: 1.5},
+		NewZeroOrientation()), 1, 3, "")
 	test.That(t, err, test.ShouldBeNil)
+	collides, err = mesh.CollidesWith(capsule, defaultCollisionBufferMM)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, collides, test.ShouldBeTrue)
+	// Capsule non-extreme spherical vertex collision (with triangle face)
+	// this one is super cringe... math.Sqrt()
+	// (0,1,1) orientation, (0.5,0.5,1+math.Sqrt(2)/2)
+	// this is presumably failing due to rounding error... except actually the error seems pretty big
+	capsule, err = NewCapsule(NewPose(r3.Vector{X: 0.5, Y: 0.5, Z: 1 + math.Sqrt(2)/4},
+		&OrientationVector{OY: 1, OZ: 1}), 1, 3, "")
+	test.That(t, err, test.ShouldBeNil)
+	collides, err = mesh.CollidesWith(capsule, defaultCollisionBufferMM)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, collides, test.ShouldBeTrue)
+	// Capsule cylinder vertex collision (with triangle face)
+	// NOT POSSIBLE
+	// Capsule cylinder line collision (with triangle face)
+	// on its side again, but tiny modified capsule
+	capsule, err = NewCapsule(NewPose(r3.Vector{X: 0.2, Y: 0.2, Z: 0.1},
+		&OrientationVector{OX: 1}), 0.1, 0.3, "")
+	test.That(t, err, test.ShouldBeNil)
+	collides, err = mesh.CollidesWith(capsule, defaultCollisionBufferMM)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, collides, test.ShouldBeTrue)
 
-	collides, err = mesh.CollidesWith(box2, defaultCollisionBufferMM)
+	// Partially encompassing capsule (could potentially divide into more cases, but this (only face collisions) should be most restrictive)
+	capsule, err = NewCapsule(NewPose(r3.Vector{X: 0.2, Y: 0.2, Z: 0},
+		NewZeroOrientation()), 0.1, 0.3, "")
+	test.That(t, err, test.ShouldBeNil)
+	collides, err = mesh.CollidesWith(capsule, defaultCollisionBufferMM)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, collides, test.ShouldBeTrue)
+
+	// Completely encompassing capsule, no boundary collision
+	capsule, err = NewCapsule(NewZeroPose(), 2, 4.5, "")
+	test.That(t, err, test.ShouldBeNil)
+	collides, err = mesh.CollidesWith(capsule, defaultCollisionBufferMM)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, collides, test.ShouldBeTrue)
+
+	// Non-overlapping capsule
+	capsule, err = NewCapsule(NewPose(r3.Vector{X: -1.1, Y: -1.1, Z: 0},
+		NewZeroOrientation()), 1, 3, "")
+	test.That(t, err, test.ShouldBeNil)
+	collides, err = mesh.CollidesWith(capsule, defaultCollisionBufferMM)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, collides, test.ShouldBeFalse)
 }
+
+func TestMeshCollidesWithBox(t *testing.T) {
+
+	mesh := makeSimpleTriangleMesh()
+	// why is encompassing only specified as a special case for box? (what makes box different?)!
+	// ^ this is quite confusing because what if you just make a mesh that looks like a meshified box?
+	// AHHHHHHHHHH
+
+	// non-point collisions (e.g., edges with more than a point of overlap) are redundant with point collisions
+	// types of triangle points: {vertex, edge, face}
+	// types of box points: {vertex, edge, face}
+	// exhaust the 9 collision options:
+
+	// Collision with triangle vertex
+	// Box vertex collision (with triangle vertex)
+	t.Run("Box vertex against triangle vertex", func(t *testing.T) {
+		box, err := NewBox(NewPose(r3.Vector{X: 1.5, Y: 0.5, Z: 0.5}, NewZeroOrientation()),
+			r3.Vector{X: 1, Y: 1, Z: 1}, "")
+		test.That(t, err, test.ShouldBeNil)
+		collides, err := mesh.CollidesWith(box, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeTrue)
+	})
+
+	// Box edge collision (with triangle vertex)
+	t.Run("Box edge against triangle vertex", func(t *testing.T) {
+		box, err := NewBox(NewPose(r3.Vector{X: 1.5, Y: 0, Z: 0.5}, NewZeroOrientation()),
+			r3.Vector{X: 1, Y: 1, Z: 1}, "")
+		test.That(t, err, test.ShouldBeNil)
+		collides, err := mesh.CollidesWith(box, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeTrue)
+	})
+
+	// Box face collision (with triangle vertex)
+	t.Run("Box face against triangle vertex", func(t *testing.T) {
+		box, err := NewBox(NewPose(r3.Vector{X: 1.5, Y: 0, Z: 0}, NewZeroOrientation()),
+			r3.Vector{X: 1, Y: 1, Z: 1}, "")
+		test.That(t, err, test.ShouldBeNil)
+		collides, err := mesh.CollidesWith(box, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeTrue)
+	})
+
+	// Collision with triangle edge
+	// Box vertex collision (with triangle edge)
+	t.Run("Box vertex against triangle edge", func(t *testing.T) {
+		box, err := NewBox(NewPose(r3.Vector{X: 0.7, Y: 1.5 - 0.7*(3.0/2), Z: 0.5}, NewZeroOrientation()), // idk how to do orientation loool
+			r3.Vector{X: 1, Y: 1, Z: 1}, "")
+		test.That(t, err, test.ShouldBeNil)
+		collides, err := mesh.CollidesWith(box, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeTrue)
+	})
+	// Box edge collision (with triangle edge)
+	// TODO: revise this (just rotate 45deg about z axis) to make it more readable
+	// I guess revision is like orientation Theta: math.Pi/4, then shift by half-diagonals (sqrt(2)/2)...
+	t.Run("Box edge against triangle edge", func(t *testing.T) {
+		box, err := NewBox(NewPose(r3.Vector{X: 0.5, Y: -0.5, Z: 0.5},
+			&OrientationVector{Theta: math.Pi / 4, OY: 1, OZ: 1}), r3.Vector{X: 1, Y: 1, Z: 1}, "")
+		test.That(t, err, test.ShouldBeNil)
+		collides, err := mesh.CollidesWith(box, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeTrue)
+	})
+
+	t.Run("example edge collision failure", func(t *testing.T) {
+		ABC := makeTestMesh(NewZeroOrientation(), r3.Vector{},
+			[]*Triangle{NewTriangle(
+				r3.Vector{X: 0, Y: 0, Z: 0},
+				r3.Vector{X: 1, Y: 0, Z: 0},
+				r3.Vector{X: 0, Y: 1, Z: 0},
+			)})
+		DEF := makeTestMesh(NewZeroOrientation(), r3.Vector{},
+			[]*Triangle{NewTriangle(
+				r3.Vector{X: 0.5, Y: 0, Z: 0.5},
+				r3.Vector{X: 0.5, Y: 0, Z: -0.5},
+				r3.Vector{X: 0.5, Y: -1, Z: 0},
+			)})
+		collides, err := ABC.CollidesWith(DEF, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeTrue)
+	})
+
+	t.Run("debug edge collision", func(t *testing.T) {
+		// continuing to litter all over this file, need to clean up
+
+		p0 := r3.Vector{X: 0, Y: 0, Z: 0}
+		p1 := r3.Vector{X: 0, Y: 1, Z: 0}
+		p2 := r3.Vector{X: 1, Y: 0, Z: 0}
+		basicTri := NewTriangle(p0, p1, p2)
+		t0 := r3.Vector{X: 0.5, Y: 0, Z: 0.5}
+		t1 := r3.Vector{X: 0.5, Y: 0, Z: -0.5}
+		t2 := r3.Vector{X: 0.5, Y: -1, Z: 0}
+		basicTri2 := NewTriangle(t0, t1, t2)
+
+		mesh1 := makeTestMesh(NewZeroOrientation(), r3.Vector{},
+			[]*Triangle{basicTri})
+		mesh2 := makeTestMesh(NewZeroOrientation(), r3.Vector{},
+			[]*Triangle{basicTri2})
+
+		fmt.Println(mesh1.collidesWithMesh(mesh2, defaultCollisionBufferMM))
+		fmt.Println(closestPointsSegmentTriangle(t0, t1, basicTri))
+		fmt.Println(closestPointsSegmentTriangle(p0, p2, basicTri2))
+		// looks like tendency is to overestimate the "t" parameter on the segment
+		// no, underestimate
+
+		segPt, _ := closestPointsSegmentPlane(t0, t1, basicTri.p0, basicTri.normal)
+		triPt, inside := closestTriangleInsidePoint(basicTri, segPt)
+		fmt.Println(segPt)
+		fmt.Println(triPt)
+		fmt.Println(inside)
+		// looks like we are explicitly making an error here inside closestPointsSegmentPlane
+		fmt.Println("BUFFER")
+		fmt.Println(basicTri.normal) // no error here
+
+		segVec := t1.Sub(t0)
+		d := basicTri.p0.Dot(basicTri.normal)
+		denom := basicTri.normal.Dot(segVec)
+		time := (d - basicTri.normal.Dot(t0)) / (denom) //  + 1e-6 causing errors
+		coplanarPt := segVec.Mul(time).Add(t0)
+		fmt.Println(time)
+		fmt.Println(coplanarPt)
+
+		// yay! it really just is that denominator adjustment
+
+		// test.That(t, R3VectorAlmostEqual(bestSegPt, r3.Vector{0.5, 0, 0}, 1e-7), test.ShouldBeTrue)
+		// test.That(t, bestSegPt, test.ShouldAlmostEqual, r3.Vector{0.5, 0, 0})
+	})
+
+	//hmm....
+	// ok so dummy_mesh does intersect, mesh does not !!!
+	// dummy_mesh := makeTestMesh(NewZeroOrientation(), r3.Vector{},
+	// 	[]*Triangle{NewTriangle(
+	// 		r3.Vector{X: 0.5, Y: 0, Z: 0},
+	// 		r3.Vector{X: 0, Y: 1, Z: 0},
+	// 		r3.Vector{X: 1, Y: 0, Z: 0},
+	// 	)})
+	// box, err := NewBox(NewPose(r3.Vector{X: 0.5, Y: -0.5, Z: 0.5},
+	// 	&OrientationVector{Theta: math.Pi / 4, OY: 1, OZ: 1}), r3.Vector{X: 1, Y: 1, Z: 1}, "")
+	// test.That(t, err, test.ShouldBeNil)
+	// collides, err := dummy_mesh.CollidesWith(box, defaultCollisionBufferMM)
+	// test.That(t, err, test.ShouldBeNil)
+	// test.That(t, collides, test.ShouldBeTrue)
+
+	// now lets try 2 perpendicular triangles
+	t.Run("Box edge against two triangle edges", func(t *testing.T) {
+		tri1 := NewTriangle(
+			r3.Vector{X: 0, Y: 0, Z: 0},
+			r3.Vector{X: 1, Y: 0, Z: 0},
+			r3.Vector{X: 0, Y: 1, Z: 0},
+		)
+		tri2 := NewTriangle(
+			r3.Vector{X: 0, Y: 0, Z: 0},
+			r3.Vector{X: 1, Y: 0, Z: 0},
+			r3.Vector{X: 0, Y: 0, Z: -1},
+		)
+		extendedMesh := makeTestMesh(NewZeroOrientation(), r3.Vector{}, []*Triangle{tri1, tri2})
+		box, err := NewBox(NewPose(r3.Vector{X: 0.5, Y: -0.5, Z: 0.5},
+			&OrientationVector{Theta: math.Pi / 4, OY: 1, OZ: 1}), r3.Vector{X: 1, Y: 1, Z: 1}, "")
+		test.That(t, err, test.ShouldBeNil)
+		collides, err := extendedMesh.CollidesWith(box, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeTrue)
+	})
+
+	// try again with mesh, slight indentation
+	// slight indentation FAILS
+	t.Run("Box edge into triangle edge (slight indentation)", func(t *testing.T) {
+		box, err := NewBox(NewPose(r3.Vector{X: 0.5, Y: -0.5, Z: 0.5},
+			&OrientationVector{Theta: math.Pi / 4, OY: 1, OZ: 1}), r3.Vector{X: 1, Y: 1, Z: 1}, "")
+		test.That(t, err, test.ShouldBeNil)
+		collides, err := mesh.CollidesWith(box, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeTrue)
+	})
+
+	// Box face collision (with triangle edge) (redundant)
+	// box, err = NewBox(NewPose(r3.Vector{X: -0.5, Y: 0.5, Z: 0}, NewZeroOrientation()),
+	// 	r3.Vector{X: 1, Y: 1, Z: 1}, "")
+	// test.That(t, err, test.ShouldBeNil)
+	// collides, err = mesh.CollidesWith(box, defaultCollisionBufferMM)
+	// test.That(t, err, test.ShouldBeNil)
+	// test.That(t, collides, test.ShouldBeTrue)
+
+	// Collision with triangle face
+	// Box vertex collision (with triangle face)
+	// Box edge collision (with triangle face)
+	// Box face collision (with triangle face)
+
+	// Partially encompassing box, no vertex collisions
+	// REVIST THIS TEST, BUT IT SHOULD BE USELESS
+	// box, err = NewBox(NewZeroPose(),
+	// 	r3.Vector{X: 1, Y: 1, Z: 1}, "")
+	// test.That(t, err, test.ShouldBeNil)
+	// collides, err = mesh.CollidesWith(box, defaultCollisionBufferMM)
+	// test.That(t, err, test.ShouldBeNil)
+	// test.That(t, collides, test.ShouldBeTrue)
+
+	// Completely encompassing box, no boundary collision
+	t.Run("Box strictly encompassing triangle", func(t *testing.T) {
+		box, err := NewBox(NewZeroPose(),
+			r3.Vector{X: 4, Y: 4, Z: 4}, "")
+		test.That(t, err, test.ShouldBeNil)
+		collides, err := mesh.CollidesWith(box, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeTrue)
+	})
+
+	// // Create overlapping box
+	// box, err = NewBox(NewZeroPose(), r3.Vector{X: 1, Y: 1, Z: 1}, "")
+	// test.That(t, err, test.ShouldBeNil)
+
+	// collides, err = mesh.CollidesWith(box, defaultCollisionBufferMM)
+	// test.That(t, err, test.ShouldBeNil)
+	// test.That(t, collides, test.ShouldBeTrue)
+
+	// Create non-overlapping box
+	t.Run("Box vertex not touching triangle", func(t *testing.T) {
+		box, err := NewBox(NewPose(r3.Vector{X: 2, Y: 2, Z: 2}, NewZeroOrientation()),
+			r3.Vector{X: 1, Y: 1, Z: 1}, "")
+		test.That(t, err, test.ShouldBeNil)
+
+		collides, err := mesh.CollidesWith(box, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeFalse)
+	})
+}
+
+// e.g., could write something like the below:
+// func TestMeshCollisionExpectation(t *testing.T, mesh *Mesh, g Geometry, expected bool) {
+// 	collides, err := mesh.CollidesWith(g, defaultCollisionBufferMM)
+// 	test.That(t, err, test.ShouldBeNil)
+// 	if expected {
+// 		test.That(t, collides, test.ShouldBeTrue)
+// 	} else {
+// 		test.That(t, collides, test.ShouldBeFalse)
+// 	}
+// }
+// BUT this doesnt seem like licit function for the testing file
 
 func TestMeshDistanceFrom(t *testing.T) {
 	mesh1 := makeSimpleTriangleMesh()

--- a/spatialmath/triangle_test.go
+++ b/spatialmath/triangle_test.go
@@ -42,31 +42,45 @@ func TestBasicTriangleFunctions(t *testing.T) {
 		// interior
 		closestPoint, isInside := closestTriangleInsidePoint(tri, r3.Vector{1, 1, 1})
 		test.That(t, closestPoint, test.ShouldResemble, r3.Vector{1, 1, 0})
-		test.That(t, isInside, test.ShouldResemble, true)
+		test.That(t, isInside, test.ShouldBeTrue)
 
 		// directly above edge
 		closestPoint, isInside = closestTriangleInsidePoint(tri, r3.Vector{2, 0, 1})
 		test.That(t, closestPoint, test.ShouldResemble, r3.Vector{2, 0, 0})
-		test.That(t, isInside, test.ShouldResemble, true)
+		test.That(t, isInside, test.ShouldBeTrue)
 
 		// directly above vertex
 		closestPoint, isInside = closestTriangleInsidePoint(tri, r3.Vector{0, 3, 1})
 		test.That(t, closestPoint, test.ShouldResemble, r3.Vector{0, 3, 0})
-		test.That(t, isInside, test.ShouldResemble, true)
+		test.That(t, isInside, test.ShouldBeTrue)
 
 		// outside (obtuse)
 		closestPoint, isInside = closestTriangleInsidePoint(tri, r3.Vector{1, -1, 1})
-		test.That(t, isInside, test.ShouldResemble, false)
+		test.That(t, isInside, test.ShouldBeFalse)
 
 		// outside (straight)
 		closestPoint, isInside = closestTriangleInsidePoint(tri, r3.Vector{0, 4, 0})
-		test.That(t, isInside, test.ShouldResemble, false)
+		test.That(t, isInside, test.ShouldBeFalse)
 
-		// interior, an isoceles right triangle rotated off the xy-plane; numbers large to keep integers (floats hit rounding error)
+		// interior, triangle rotated off the xy-plane (still right isoceles)
 		rotatedPts := []r3.Vector{{0, 0, 0}, {50, 0, 0}, {0, 30, 40}}
 		rotatedTri := NewTriangle(rotatedPts[0], rotatedPts[1], rotatedPts[2])
 		closestPoint, isInside = closestTriangleInsidePoint(rotatedTri, r3.Vector{1, 3 + 4, 4 - 3})
-		test.That(t, closestPoint, test.ShouldResembleProto, r3.Vector{1, 3, 4})
-		test.That(t, isInside, test.ShouldResemble, true)
+		test.That(t, closestPoint, test.ShouldResemble, r3.Vector{1, 3, 4})
+		test.That(t, isInside, test.ShouldBeTrue)
+	})
+
+	t.Run("closest triangle point", func(t *testing.T) {
+		// double check on interior point
+		closestPoint := closestPointTrianglePoint(tri, r3.Vector{1, 1, 1})
+		test.That(t, closestPoint, test.ShouldResemble, r3.Vector{1, 1, 0})
+
+		// closest point is edge
+		closestPoint = closestPointTrianglePoint(tri, r3.Vector{3, 2, 1})
+		test.That(t, closestPoint, test.ShouldResemble, r3.Vector{2, 1, 0})
+
+		// closest point is vertex
+		closestPoint = closestPointTrianglePoint(tri, r3.Vector{-1, -1, 1})
+		test.That(t, closestPoint, test.ShouldResemble, r3.Vector{0, 0, 0})
 	})
 }

--- a/spatialmath/triangle_test.go
+++ b/spatialmath/triangle_test.go
@@ -44,25 +44,25 @@ func TestBasicTriangleFunctions(t *testing.T) {
 		test.That(t, closestPoint, test.ShouldResemble, r3.Vector{1, 1, 0})
 		test.That(t, isInside, test.ShouldBeTrue)
 
-		// directly above edge
+		// above edge
 		closestPoint, isInside = closestTriangleInsidePoint(tri, r3.Vector{2, 0, 1})
 		test.That(t, closestPoint, test.ShouldResemble, r3.Vector{2, 0, 0})
 		test.That(t, isInside, test.ShouldBeTrue)
 
-		// directly above vertex
+		// above vertex
 		closestPoint, isInside = closestTriangleInsidePoint(tri, r3.Vector{0, 3, 1})
 		test.That(t, closestPoint, test.ShouldResemble, r3.Vector{0, 3, 0})
 		test.That(t, isInside, test.ShouldBeTrue)
 
-		// outside (obtuse)
+		// outside (obtuse with triangle)
 		closestPoint, isInside = closestTriangleInsidePoint(tri, r3.Vector{1, -1, 1})
 		test.That(t, isInside, test.ShouldBeFalse)
 
-		// outside (straight)
+		// outside (straight with triange)
 		closestPoint, isInside = closestTriangleInsidePoint(tri, r3.Vector{0, 4, 0})
 		test.That(t, isInside, test.ShouldBeFalse)
 
-		// interior, triangle rotated off the xy-plane (still right isoceles)
+		// interior, testing a traingle rotated off the xy-plane
 		rotatedPts := []r3.Vector{{0, 0, 0}, {50, 0, 0}, {0, 30, 40}}
 		rotatedTri := NewTriangle(rotatedPts[0], rotatedPts[1], rotatedPts[2])
 		closestPoint, isInside = closestTriangleInsidePoint(rotatedTri, r3.Vector{1, 3 + 4, 4 - 3})

--- a/spatialmath/triangle_test.go
+++ b/spatialmath/triangle_test.go
@@ -38,49 +38,58 @@ func TestBasicTriangleFunctions(t *testing.T) {
 		}
 	})
 
-	t.Run("closest triangle inside point", func(t *testing.T) {
-		// interior
-		closestPoint, isInside := closestTriangleInsidePoint(tri, r3.Vector{1, 1, 1})
-		test.That(t, closestPoint, test.ShouldResemble, r3.Vector{1, 1, 0})
-		test.That(t, isInside, test.ShouldBeTrue)
+	t.Run("closestTriangleInsidePoint", func(t *testing.T) {
+		t.Run("closest inside triangle point to interior point (triangle on coordinate plane)", func(t *testing.T) {
+			closestPoint, isInside := closestTriangleInsidePoint(tri, r3.Vector{1, 1, 1})
+			test.That(t, closestPoint, test.ShouldResemble, r3.Vector{1, 1, 0})
+			test.That(t, isInside, test.ShouldBeTrue)
+		})
 
-		// above edge
-		closestPoint, isInside = closestTriangleInsidePoint(tri, r3.Vector{2, 0, 1})
-		test.That(t, closestPoint, test.ShouldResemble, r3.Vector{2, 0, 0})
-		test.That(t, isInside, test.ShouldBeTrue)
+		t.Run("closestTriangleInsidePoint: interior point (triangle off coordinate plane)", func(t *testing.T) {
+			rotatedPts := []r3.Vector{{0, 0, 0}, {50, 0, 0}, {0, 30, 40}}
+			rotatedTri := NewTriangle(rotatedPts[0], rotatedPts[1], rotatedPts[2])
+			closestPoint, isInside := closestTriangleInsidePoint(rotatedTri, r3.Vector{1, 3 + 4, 4 - 3})
+			test.That(t, closestPoint, test.ShouldResemble, r3.Vector{1, 3, 4})
+			test.That(t, isInside, test.ShouldBeTrue)
+		})
 
-		// above vertex
-		closestPoint, isInside = closestTriangleInsidePoint(tri, r3.Vector{0, 3, 1})
-		test.That(t, closestPoint, test.ShouldResemble, r3.Vector{0, 3, 0})
-		test.That(t, isInside, test.ShouldBeTrue)
+		t.Run("closestTriangleInsidePoint: point above edge", func(t *testing.T) {
+			closestPoint, isInside := closestTriangleInsidePoint(tri, r3.Vector{2, 0, 1})
+			test.That(t, closestPoint, test.ShouldResemble, r3.Vector{2, 0, 0})
+			test.That(t, isInside, test.ShouldBeTrue)
+		})
 
-		// outside (obtuse with triangle)
-		closestPoint, isInside = closestTriangleInsidePoint(tri, r3.Vector{1, -1, 1})
-		test.That(t, isInside, test.ShouldBeFalse)
+		t.Run("closestTriangleInsidePoint: point above vertex", func(t *testing.T) {
+			closestPoint, isInside := closestTriangleInsidePoint(tri, r3.Vector{0, 3, 1})
+			test.That(t, closestPoint, test.ShouldResemble, r3.Vector{0, 3, 0})
+			test.That(t, isInside, test.ShouldBeTrue)
+		})
 
-		// outside (straight with triange)
-		closestPoint, isInside = closestTriangleInsidePoint(tri, r3.Vector{0, 4, 0})
-		test.That(t, isInside, test.ShouldBeFalse)
+		t.Run("closestTriangleInsidePoint: outside vertex (obtuse case)", func(t *testing.T) {
+			_, isInside := closestTriangleInsidePoint(tri, r3.Vector{1, -1, 1})
+			test.That(t, isInside, test.ShouldBeFalse)
+		})
 
-		// interior, testing a traingle rotated off the xy-plane
-		rotatedPts := []r3.Vector{{0, 0, 0}, {50, 0, 0}, {0, 30, 40}}
-		rotatedTri := NewTriangle(rotatedPts[0], rotatedPts[1], rotatedPts[2])
-		closestPoint, isInside = closestTriangleInsidePoint(rotatedTri, r3.Vector{1, 3 + 4, 4 - 3})
-		test.That(t, closestPoint, test.ShouldResemble, r3.Vector{1, 3, 4})
-		test.That(t, isInside, test.ShouldBeTrue)
+		t.Run("closestTriangleInsidePoint: outside vertex (straight case)", func(t *testing.T) {
+			_, isInside := closestTriangleInsidePoint(tri, r3.Vector{0, 4, 0})
+			test.That(t, isInside, test.ShouldBeFalse)
+		})
 	})
 
-	t.Run("closest triangle point", func(t *testing.T) {
-		// double check on interior point
-		closestPoint := closestPointTrianglePoint(tri, r3.Vector{1, 1, 1})
-		test.That(t, closestPoint, test.ShouldResemble, r3.Vector{1, 1, 0})
+	t.Run("closestPointTrianglePoint", func(t *testing.T) {
+		t.Run("closestPointTrianglePoint: interior point", func(t *testing.T) {
+			closestPoint := closestPointTrianglePoint(tri, r3.Vector{1, 1, 1})
+			test.That(t, closestPoint, test.ShouldResemble, r3.Vector{1, 1, 0})
+		})
 
-		// closest point is edge
-		closestPoint = closestPointTrianglePoint(tri, r3.Vector{3, 2, 1})
-		test.That(t, closestPoint, test.ShouldResemble, r3.Vector{2, 1, 0})
+		t.Run("closestTriangleInsidePoint: closest point is edge", func(t *testing.T) {
+			closestPoint := closestPointTrianglePoint(tri, r3.Vector{3, 2, 1})
+			test.That(t, closestPoint, test.ShouldResemble, r3.Vector{2, 1, 0})
+		})
 
-		// closest point is vertex
-		closestPoint = closestPointTrianglePoint(tri, r3.Vector{-1, -1, 1})
-		test.That(t, closestPoint, test.ShouldResemble, r3.Vector{0, 0, 0})
+		t.Run("closestTriangleInsidePoint: closest point is vertex", func(t *testing.T) {
+			closestPoint := closestPointTrianglePoint(tri, r3.Vector{-1, -1, 1})
+			test.That(t, closestPoint, test.ShouldResemble, r3.Vector{0, 0, 0})
+		})
 	})
 }

--- a/spatialmath/triangle_test.go
+++ b/spatialmath/triangle_test.go
@@ -37,4 +37,36 @@ func TestBasicTriangleFunctions(t *testing.T) {
 			test.That(t, tri2.Points()[i], test.ShouldResemble, NewPoint(expectedPts[i], "").Transform(tf).Pose().Point())
 		}
 	})
+
+	t.Run("closest triangle inside point", func(t *testing.T) {
+		// interior
+		closestPoint, isInside := closestTriangleInsidePoint(tri, r3.Vector{1, 1, 1})
+		test.That(t, closestPoint, test.ShouldResemble, r3.Vector{1, 1, 0})
+		test.That(t, isInside, test.ShouldResemble, true)
+
+		// directly above edge
+		closestPoint, isInside = closestTriangleInsidePoint(tri, r3.Vector{2, 0, 1})
+		test.That(t, closestPoint, test.ShouldResemble, r3.Vector{2, 0, 0})
+		test.That(t, isInside, test.ShouldResemble, true)
+
+		// directly above vertex
+		closestPoint, isInside = closestTriangleInsidePoint(tri, r3.Vector{0, 3, 1})
+		test.That(t, closestPoint, test.ShouldResemble, r3.Vector{0, 3, 0})
+		test.That(t, isInside, test.ShouldResemble, true)
+
+		// outside (obtuse)
+		closestPoint, isInside = closestTriangleInsidePoint(tri, r3.Vector{1, -1, 1})
+		test.That(t, isInside, test.ShouldResemble, false)
+
+		// outside (straight)
+		closestPoint, isInside = closestTriangleInsidePoint(tri, r3.Vector{0, 4, 0})
+		test.That(t, isInside, test.ShouldResemble, false)
+
+		// interior, an isoceles right triangle rotated off the xy-plane; numbers large to keep integers (floats hit rounding error)
+		rotatedPts := []r3.Vector{{0, 0, 0}, {50, 0, 0}, {0, 30, 40}}
+		rotatedTri := NewTriangle(rotatedPts[0], rotatedPts[1], rotatedPts[2])
+		closestPoint, isInside = closestTriangleInsidePoint(rotatedTri, r3.Vector{1, 3 + 4, 4 - 3})
+		test.That(t, closestPoint, test.ShouldResembleProto, r3.Vector{1, 3, 4})
+		test.That(t, isInside, test.ShouldResemble, true)
+	})
 }


### PR DESCRIPTION
This PR adds more extensive and systematic test coverage for triangle closest point functions and mesh-Geometry collisions. It also fixes problematic numerical error in closestPointsSegmentPlane and changes the logic of ClosestPointsSegmentSegment (see [here](https://docs.google.com/document/d/1sYIIddAeRU253xQyeAjzs0FjYAe1t0F1CwS6iq-Wa_A/edit?tab=t.0) for justification of the latter).