### PR TITLE
[RSDK-10933] Move ConstraintHandler from plannerOptions to planner

### DIFF
--- a/motionplan/cBiRRT_test.go
+++ b/motionplan/cBiRRT_test.go
@@ -42,7 +42,7 @@ func TestSimpleLinearMotion(t *testing.T) {
 	goalMetric := opt.getGoalMetric(referenceframe.FrameSystemPoses{m.Name(): referenceframe.NewPoseInFrame(referenceframe.World, goalPos)})
 	fs := referenceframe.NewEmptyFrameSystem("")
 	fs.AddFrame(m, fs.World())
-	mp, err := newCBiRRTMotionPlanner(fs, rand.New(rand.NewSource(42)), logger, opt)
+	mp, err := newCBiRRTMotionPlanner(fs, rand.New(rand.NewSource(42)), logger, opt, newEmptyConstraintHandler())
 	test.That(t, err, test.ShouldBeNil)
 	cbirrt, _ := mp.(*cBiRRTMotionPlanner)
 	solutions, err := mp.getSolutions(ctx, referenceframe.FrameSystemInputs{m.Name(): home7}, goalMetric)

--- a/motionplan/check.go
+++ b/motionplan/check.go
@@ -47,7 +47,7 @@ func CheckPlan(
 	}
 
 	// Spot check plan for options
-	planOpts, err := sfPlanner.plannerSetupFromMoveRequest(
+	planOpts, _, err := sfPlanner.plannerAndConstraintSetupFromMoveRequest(
 		&PlanState{poses: plan.Path()[0]},
 		&PlanState{poses: plan.Path()[len(plan.Path())-1]},
 		plan.Trajectory()[0],
@@ -63,6 +63,7 @@ func CheckPlan(
 	// This should be done for any plan whose configurations are specified in relative terms rather than absolute ones.
 	// Currently this is only TP-space, so we check if the PTG length is >0.
 	if planOpts.useTPspace() {
+		sfPlanner.ConstraintHandler = newEmptyConstraintHandler()
 		return checkPlanRelative(checkFrame, executionState, worldState, fs, lookAheadDistanceMM, sfPlanner)
 	}
 	return checkPlanAbsolute(checkFrame, executionState, worldState, fs, lookAheadDistanceMM, sfPlanner)
@@ -94,7 +95,7 @@ func checkPlanRelative(
 	zeroPosePIF := referenceframe.NewPoseInFrame(checkFrame.Name(), spatialmath.NewZeroPose())
 
 	// setup the planOpts. Poses should be in world frame. This allows us to know e.g. which obstacles may ephemerally collide.
-	if sfPlanner.planOpts, err = sfPlanner.plannerSetupFromMoveRequest(
+	if sfPlanner.planOpts, sfPlanner.ConstraintHandler, err = sfPlanner.plannerAndConstraintSetupFromMoveRequest(
 		&PlanState{poses: plan.Path()[0], configuration: plan.Trajectory()[0]},
 		&PlanState{poses: plan.Path()[len(plan.Path())-1]},
 		plan.Trajectory()[0],
@@ -231,7 +232,7 @@ func checkPlanAbsolute(
 	poses := offsetPlan.Path()
 
 	// setup the planOpts
-	if sfPlanner.planOpts, err = sfPlanner.plannerSetupFromMoveRequest(
+	if sfPlanner.planOpts, sfPlanner.ConstraintHandler, err = sfPlanner.plannerAndConstraintSetupFromMoveRequest(
 		&PlanState{poses: executionState.CurrentPoses(), configuration: startingInputs},
 		&PlanState{poses: poses[len(poses)-1]},
 		startingInputs,
@@ -264,14 +265,14 @@ func checkSegmentsFS(sfPlanner *planManager, segments []*ik.SegmentFS, lookAhead
 	moving, _ := sfPlanner.planOpts.motionChains.framesFilteredByMovingAndNonmoving(sfPlanner.fs)
 	dists := map[string]float64{}
 	for _, segment := range segments {
-		ok, lastValid := sfPlanner.planOpts.CheckSegmentAndStateValidityFS(segment, sfPlanner.planOpts.Resolution)
+		ok, lastValid := sfPlanner.CheckSegmentAndStateValidityFS(segment, sfPlanner.planOpts.Resolution)
 		if !ok {
 			checkConf := segment.StartConfiguration
 			if lastValid != nil {
 				checkConf = lastValid.EndConfiguration
 			}
 			var reason string
-			err := sfPlanner.planOpts.CheckStateFSConstraints(&ik.StateFS{Configuration: checkConf, FS: sfPlanner.fs})
+			err := sfPlanner.CheckStateFSConstraints(&ik.StateFS{Configuration: checkConf, FS: sfPlanner.fs})
 			if err != nil {
 				reason = " reason: " + err.Error()
 			} else {
@@ -355,7 +356,7 @@ func checkSegments(sfPlanner *planManager, segments []*ik.Segment, lookAheadDist
 			}
 
 			// Checks for collision along the interpolated route and returns a the first interpolated pose where a collision is detected.
-			if err := sfPlanner.planOpts.CheckStateConstraints(interpolatedState); err != nil {
+			if err := sfPlanner.CheckStateConstraints(interpolatedState); err != nil {
 				return errors.Wrapf(err,
 					"found constraint violation or collision in segment between %v and %v at %v",
 					segment.StartPosition.Point(),

--- a/motionplan/constraint.go
+++ b/motionplan/constraint.go
@@ -661,6 +661,23 @@ func (c *Constraints) ToProtobuf() *motionpb.Constraints {
 	}
 }
 
+func (c *Constraints) updateFromOptions(opt *plannerOptions) {
+	switch opt.MotionProfile {
+	case LinearMotionProfile:
+		c.AddLinearConstraint(LinearConstraint{opt.LineTolerance, opt.OrientationTolerance})
+	case PseudolinearMotionProfile:
+		c.AddPseudolinearConstraint(PseudolinearConstraint{opt.ToleranceFactor, opt.ToleranceFactor})
+	case OrientationMotionProfile:
+		c.AddOrientationConstraint(OrientationConstraint{opt.OrientationTolerance})
+	// FreeMotionProfile or PositionOnlyMotionProfile produce no additional constraints.
+	case FreeMotionProfile, PositionOnlyMotionProfile:
+	}
+}
+
+func (c *Constraints) hasTopoConstraint() bool {
+	return (len(c.LinearConstraint) + len(c.OrientationConstraint)) != 0
+}
+
 // AddLinearConstraint appends a LinearConstraint to a Constraints object.
 func (c *Constraints) AddLinearConstraint(linConstraint LinearConstraint) {
 	c.LinearConstraint = append(c.LinearConstraint, linConstraint)

--- a/motionplan/constraint_test.go
+++ b/motionplan/constraint_test.go
@@ -25,7 +25,8 @@ func TestIKTolerances(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	fs := frame.NewEmptyFrameSystem("")
 	fs.AddFrame(m, fs.World())
-	mp, err := newCBiRRTMotionPlanner(fs, rand.New(rand.NewSource(1)), logger, newBasicPlannerOptions())
+	mp, err := newCBiRRTMotionPlanner(
+		fs, rand.New(rand.NewSource(1)), logger, newBasicPlannerOptions(), newEmptyConstraintHandler())
 	test.That(t, err, test.ShouldBeNil)
 
 	// Test inability to arrive at another position due to orientation
@@ -41,7 +42,7 @@ func TestIKTolerances(t *testing.T) {
 	opt := newBasicPlannerOptions()
 	opt.GoalMetricType = ik.PositionOnly
 	opt.SetMaxSolutions(50)
-	mp, err = newCBiRRTMotionPlanner(fs, rand.New(rand.NewSource(1)), logger, opt)
+	mp, err = newCBiRRTMotionPlanner(fs, rand.New(rand.NewSource(1)), logger, opt, newEmptyConstraintHandler())
 	test.That(t, err, test.ShouldBeNil)
 	_, err = mp.plan(context.Background(), seed, goal)
 	test.That(t, err, test.ShouldBeNil)
@@ -145,7 +146,7 @@ func TestLineFollow(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	goalFrame := fs.World()
 
-	opt := newBasicPlannerOptions()
+	opt := newEmptyConstraintHandler()
 	startCfg := map[string][]frame.Input{m.Name(): m.InputFromProtobuf(mp1)}
 	from := frame.FrameSystemPoses{markerFrame.Name(): frame.NewPoseInFrame(markerFrame.Name(), p1)}
 	to := frame.FrameSystemPoses{markerFrame.Name(): frame.NewPoseInFrame(goalFrame.Name(), p2)}
@@ -157,7 +158,7 @@ func TestLineFollow(t *testing.T) {
 	pointGrad := innerGradFunc(&ik.State{Position: query})
 	test.That(t, pointGrad, test.ShouldBeLessThan, 0.001*0.001)
 
-	opt.SetPathMetric(gradFunc)
+	opt.pathMetric = gradFunc
 	opt.AddStateFSConstraint("whiteboard", validFunc)
 
 	// This tests that we are able to advance partway, but not entirely, to the goal while keeping constraints, and return the last good

--- a/motionplan/motionPlanner_test.go
+++ b/motionplan/motionPlanner_test.go
@@ -1018,7 +1018,7 @@ func TestPtgPosOnlyBidirectional(t *testing.T) {
 
 	goal := spatialmath.NewPoseFromPoint(r3.Vector{1000, -8000, 0})
 
-	extra := map[string]interface{}{"motion_profile": "position_only", "position_seeds": 2, "smooth_iter": 5}
+	extra := map[string]interface{}{"motion_profile": PositionOnlyMotionProfile, "position_seeds": 2, "smooth_iter": 5}
 
 	baseFS := frame.NewEmptyFrameSystem("baseFS")
 	err = baseFS.AddFrame(kinematicFrame, baseFS.World())

--- a/motionplan/planManager.go
+++ b/motionplan/planManager.go
@@ -461,6 +461,8 @@ func (pm *planManager) planParallelRRTMotion(
 }
 
 // This is where the map[string]interface{} passed in via `extra` is used to decide how planning happens.
+// NOTE: In the near future, this function should only return a `ConstraintHandler` and the `plannerOptions`
+// object should be obtained by marshalling `planningOpts` to JSON and unmarshalling to `plannerOptions`.
 func (pm *planManager) plannerAndConstraintSetupFromMoveRequest(
 	from, to *PlanState,
 	seedMap referenceframe.FrameSystemInputs, // A known good configuration to set up collsiion constraints. Not necessarily `from`.

--- a/motionplan/planning_algorithms.go
+++ b/motionplan/planning_algorithms.go
@@ -22,7 +22,13 @@ const (
 	TPSpace = "tpspace"
 )
 
-type plannerConstructor func(referenceframe.FrameSystem, *rand.Rand, logging.Logger, *plannerOptions) (motionPlanner, error)
+type plannerConstructor func(
+	referenceframe.FrameSystem,
+	*rand.Rand,
+	logging.Logger,
+	*plannerOptions,
+	*ConstraintHandler,
+) (motionPlanner, error)
 
 func newPlannerConstructor(algo PlanningAlgorithm) plannerConstructor {
 	switch algo {
@@ -43,6 +49,7 @@ func newMotionPlanner(
 	seed *rand.Rand,
 	logger logging.Logger,
 	opt *plannerOptions,
+	constraintHandler *ConstraintHandler,
 ) (motionPlanner, error) {
-	return newPlannerConstructor(algo)(fs, seed, logger, opt)
+	return newPlannerConstructor(algo)(fs, seed, logger, opt, constraintHandler)
 }

--- a/motionplan/rrtStarConnect.go
+++ b/motionplan/rrtStarConnect.go
@@ -69,11 +69,12 @@ func newRRTStarConnectMotionPlanner(
 	seed *rand.Rand,
 	logger logging.Logger,
 	opt *plannerOptions,
+	constraintHandler *ConstraintHandler,
 ) (motionPlanner, error) {
 	if opt == nil {
 		return nil, errNoPlannerOptions
 	}
-	mp, err := newPlanner(fs, seed, logger, opt)
+	mp, err := newPlanner(fs, seed, logger, opt, constraintHandler)
 	if err != nil {
 		return nil, err
 	}

--- a/motionplan/stubs_nocgo.go
+++ b/motionplan/stubs_nocgo.go
@@ -21,6 +21,7 @@ func newCBiRRTMotionPlanner(
 	seed *rand.Rand,
 	logger logging.Logger,
 	opt *plannerOptions,
+	constraintHandler *ConstraintHandler,
 ) (motionPlanner, error) {
 	return nil, errNotSupported
 }
@@ -31,6 +32,7 @@ func newTPSpaceMotionPlanner(
 	seed *rand.Rand,
 	logger logging.Logger,
 	opt *plannerOptions,
+	constraintHandler *ConstraintHandler,
 ) (motionPlanner, error) {
 	return nil, errNotSupported
 }
@@ -41,6 +43,7 @@ func newRRTStarConnectMotionPlanner(
 	seed *rand.Rand,
 	logger logging.Logger,
 	opt *plannerOptions,
+	constraintHandler *ConstraintHandler,
 ) (motionPlanner, error) {
 	return nil, errNotSupported
 }

--- a/motionplan/tpSpaceRRT.go
+++ b/motionplan/tpSpaceRRT.go
@@ -156,12 +156,13 @@ func newTPSpaceMotionPlanner(
 	seed *rand.Rand,
 	logger logging.Logger,
 	opt *plannerOptions,
+	constraintHandler *ConstraintHandler,
 ) (motionPlanner, error) {
 	if opt == nil {
 		return nil, errNoPlannerOptions
 	}
 
-	mp, err := newPlanner(fs, seed, logger, opt)
+	mp, err := newPlanner(fs, seed, logger, opt, constraintHandler)
 	if err != nil {
 		return nil, err
 	}
@@ -623,7 +624,7 @@ func (mp *tpSpaceRRTMotionPlanner) checkTraj(trajK []*tpspace.TrajNode, arcStart
 		trajState := &ik.State{Position: spatialmath.Compose(arcStartPose, trajPt.Pose), Frame: mp.tpFrame}
 
 		// In addition to checking every `Resolution`, we also check both endpoints.
-		err := mp.planOpts.CheckStateConstraints(trajState)
+		err := mp.CheckStateConstraints(trajState)
 		if err != nil {
 			okDist := trajPt.Dist * defaultCollisionWalkbackPct
 			if okDist > defaultMinTrajectoryLength {
@@ -893,7 +894,7 @@ func ptgSolution(ptg tpspace.PTGSolver,
 func (mp *tpSpaceRRTMotionPlanner) smoothPath(ctx context.Context, path []node) []node {
 	toIter := int(math.Min(float64(len(path)*len(path))/2, float64(mp.planOpts.SmoothIter)))
 	currCost := sumCosts(path)
-	smoothPlannerMP, err := newTPSpaceMotionPlanner(mp.fs, mp.randseed, mp.logger, mp.planOpts)
+	smoothPlannerMP, err := newTPSpaceMotionPlanner(mp.fs, mp.randseed, mp.logger, mp.planOpts, mp.ConstraintHandler)
 	if err != nil {
 		return path
 	}

--- a/motionplan/tpSpaceRRT_test.go
+++ b/motionplan/tpSpaceRRT_test.go
@@ -57,7 +57,8 @@ func TestPtgRrtBidirectional(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	opt.motionChains = motionChains
 
-	mp, err := newTPSpaceMotionPlanner(fs, rand.New(rand.NewSource(42)), logger, opt)
+	mp, err := newTPSpaceMotionPlanner(
+		fs, rand.New(rand.NewSource(42)), logger, opt, newEmptyConstraintHandler())
 	test.That(t, err, test.ShouldBeNil)
 	tp, ok := mp.(*tpSpaceRRTMotionPlanner)
 	test.That(t, ok, test.ShouldBeTrue)
@@ -152,12 +153,14 @@ func TestPtgWithObstacle(t *testing.T) {
 	)
 	test.That(t, err, test.ShouldBeNil)
 
+	constraintHandler := newEmptyConstraintHandler()
 	for name, constraint := range collisionConstraints {
-		opt.AddStateConstraint(name, constraint)
+		constraintHandler.AddStateConstraint(name, constraint)
 	}
 
 	// Create and initialize planner
-	mp, err := newTPSpaceMotionPlanner(fs, rand.New(rand.NewSource(42)), logger, opt)
+	mp, err := newTPSpaceMotionPlanner(
+		fs, rand.New(rand.NewSource(42)), logger, opt, constraintHandler)
 	test.That(t, err, test.ShouldBeNil)
 	tp, _ := mp.(*tpSpaceRRTMotionPlanner)
 
@@ -237,7 +240,8 @@ func TestTPsmoothing(t *testing.T) {
 	opt.motionChains = motionChains
 
 	// Create and initialize planner
-	mp, err := newTPSpaceMotionPlanner(fs, rand.New(rand.NewSource(42)), logger, opt)
+	mp, err := newTPSpaceMotionPlanner(
+		fs, rand.New(rand.NewSource(42)), logger, opt, newEmptyConstraintHandler())
 	test.That(t, err, test.ShouldBeNil)
 	tp, _ := mp.(*tpSpaceRRTMotionPlanner)
 

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -230,14 +230,14 @@ func (ms *builtIn) MoveOnMap(ctx context.Context, req motion.MoveOnMapReq) (moti
 type validatedExtra struct {
 	maxReplans       int
 	replanCostFactor float64
-	motionProfile    string
+	motionProfile    motionplan.MotionProfile
 	extra            map[string]interface{}
 }
 
 func newValidatedExtra(extra map[string]interface{}) (validatedExtra, error) {
 	maxReplans := -1
 	replanCostFactor := defaultReplanCostFactor
-	motionProfile := ""
+	motionProfile := motionplan.FreeMotionProfile
 	v := validatedExtra{}
 	if extra == nil {
 		v.extra = map[string]interface{}{"smooth_iter": defaultSmoothIter}
@@ -249,7 +249,7 @@ func newValidatedExtra(extra map[string]interface{}) (validatedExtra, error) {
 		}
 	}
 	if profile, ok := extra["motion_profile"]; ok {
-		motionProfile, ok = profile.(string)
+		motionProfile, ok = profile.(motionplan.MotionProfile)
 		if !ok {
 			return v, errors.New("could not interpret motion_profile field as string")
 		}

--- a/services/motion/builtin/move_on_globe_test.go
+++ b/services/motion/builtin/move_on_globe_test.go
@@ -16,6 +16,7 @@ import (
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/components/movementsensor"
 	_ "go.viam.com/rdk/components/register"
+	"go.viam.com/rdk/motionplan"
 	"go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/services/motion"
@@ -34,7 +35,7 @@ func TestMoveOnGlobe(t *testing.T) {
 	dst := geo.NewPoint(gpsPoint.Lat(), gpsPoint.Lng()+7e-5)
 	// create motion config
 	extra := map[string]interface{}{
-		"motion_profile": "position_only",
+		"motion_profile": motionplan.PositionOnlyMotionProfile,
 		"timeout":        15.,
 		"smooth_iter":    5.,
 	}
@@ -166,7 +167,7 @@ func TestBoundingRegionsConstraint(t *testing.T) {
 	origin := geo.NewPoint(0, 0)
 	dst := geo.NewPoint(origin.Lat(), origin.Lng()+1e-5)
 	extra := map[string]interface{}{
-		"motion_profile": "position_only",
+		"motion_profile": motionplan.PositionOnlyMotionProfile,
 		"timeout":        5.,
 		"smooth_iter":    5.,
 	}
@@ -318,7 +319,12 @@ func TestObstacleReplanningGlobe(t *testing.T) {
 		AngularDegsPerSec:     60,
 	}
 
-	extra := map[string]interface{}{"max_replans": 10, "max_ik_solutions": 1, "smooth_iter": 1, "motion_profile": "position_only"}
+	extra := map[string]interface{}{
+		"max_replans":      10,
+		"max_ik_solutions": 1,
+		"smooth_iter":      1,
+		"motion_profile":   motionplan.PositionOnlyMotionProfile,
+	}
 	extraNoReplan := map[string]interface{}{"max_replans": 0, "max_ik_solutions": 1, "smooth_iter": 1}
 
 	// We set a flag here per test case so that detections are not returned the first time each vision service is called

--- a/services/motion/builtin/move_on_map_test.go
+++ b/services/motion/builtin/move_on_map_test.go
@@ -155,7 +155,7 @@ func TestMoveOnMapStaticObs(t *testing.T) {
 	ctx := context.Background()
 	logger := logging.NewTestLogger(t)
 	extra := map[string]interface{}{
-		"motion_profile": "position_only",
+		"motion_profile": motionplan.PositionOnlyMotionProfile,
 		"timeout":        5.,
 		"smooth_iter":    10.,
 	}

--- a/services/motion/builtin/validation_test.go
+++ b/services/motion/builtin/validation_test.go
@@ -17,6 +17,7 @@ import (
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/components/movementsensor"
 	_ "go.viam.com/rdk/components/register"
+	"go.viam.com/rdk/motionplan"
 	"go.viam.com/rdk/services/motion"
 	"go.viam.com/rdk/services/slam"
 	"go.viam.com/rdk/services/vision"
@@ -283,7 +284,8 @@ func TestMoveCallInputs(t *testing.T) {
 				timeoutCtx, timeoutFn := context.WithTimeout(ctx, time.Second*5)
 				defer timeoutFn()
 				executionID, err := ms.(*builtIn).MoveOnMap(timeoutCtx, req)
-				test.That(t, err, test.ShouldBeError, errors.New("could not interpret collision_buffer_mm field as float64"))
+				test.That(t, err, test.ShouldBeError, errors.New(
+					"json: cannot unmarshal string into Go struct field plannerOptions.collision_buffer_mm of type float64"))
 				test.That(t, executionID, test.ShouldNotBeEmpty)
 			})
 
@@ -498,7 +500,7 @@ func TestMoveCallInputs(t *testing.T) {
 				Heading:            90,
 				Destination:        dst,
 				Extra: map[string]interface{}{
-					"motion_profile": "position_only",
+					"motion_profile": motionplan.PositionOnlyMotionProfile,
 					"timeout":        5.,
 					"smooth_iter":    5.,
 				},
@@ -518,7 +520,7 @@ func TestMoveCallInputs(t *testing.T) {
 				Heading:            90,
 				Destination:        dst,
 				Extra: map[string]interface{}{
-					"motion_profile": "position_only",
+					"motion_profile": motionplan.PositionOnlyMotionProfile,
 					"timeout":        5.,
 					"smooth_iter":    5.,
 				},
@@ -705,7 +707,8 @@ func TestMoveCallInputs(t *testing.T) {
 					Extra:              map[string]interface{}{"collision_buffer_mm": "not a float"},
 				}
 				executionID, err := ms.MoveOnGlobe(ctx, req)
-				test.That(t, err, test.ShouldBeError, errors.New("could not interpret collision_buffer_mm field as float64"))
+				test.That(t, err, test.ShouldBeError, errors.New(
+					"json: cannot unmarshal string into Go struct field plannerOptions.collision_buffer_mm of type float64"))
 				test.That(t, executionID, test.ShouldResemble, uuid.Nil)
 			})
 

--- a/services/navigation/builtin/builtin_test.go
+++ b/services/navigation/builtin/builtin_test.go
@@ -986,7 +986,7 @@ func TestStartWaypoint(t *testing.T) {
 					test.That(t, s.mogrs[0].MovementSensorName, test.ShouldResemble, s.movementSensor.Name())
 
 					test.That(t, s.mogrs[0].Extra, test.ShouldResemble, map[string]interface{}{
-						"motion_profile": motionplan.PositionOnlyMotionProfile,
+						"motion_profile": "position_only",
 					})
 					test.That(t, s.mogrs[0].MotionCfg, test.ShouldResemble, expectedMotionCfg)
 					test.That(t, s.mogrs[0].Obstacles, test.ShouldBeNil)
@@ -997,7 +997,7 @@ func TestStartWaypoint(t *testing.T) {
 					test.That(t, math.IsNaN(s.mogrs[1].Heading), test.ShouldBeTrue)
 					test.That(t, s.mogrs[1].MovementSensorName, test.ShouldResemble, s.movementSensor.Name())
 					test.That(t, s.mogrs[1].Extra, test.ShouldResemble, map[string]interface{}{
-						"motion_profile": motionplan.PositionOnlyMotionProfile,
+						"motion_profile": "position_only",
 					})
 					test.That(t, s.mogrs[1].MotionCfg, test.ShouldResemble, expectedMotionCfg)
 					test.That(t, s.mogrs[1].Obstacles, test.ShouldBeNil)
@@ -1115,13 +1115,13 @@ func TestStartWaypoint(t *testing.T) {
 			if len(s.mogrs) == 3 {
 				// MoveOnGlobe was called twice, once for each waypoint
 				test.That(t, s.mogrs[0].Extra, test.ShouldResemble, map[string]interface{}{
-					"motion_profile": motionplan.PositionOnlyMotionProfile,
+					"motion_profile": "position_only",
 				})
 				test.That(t, s.mogrs[1].Extra, test.ShouldResemble, map[string]interface{}{
-					"motion_profile": motionplan.PositionOnlyMotionProfile,
+					"motion_profile": "position_only",
 				})
 				test.That(t, s.mogrs[2].Extra, test.ShouldResemble, map[string]interface{}{
-					"motion_profile": motionplan.PositionOnlyMotionProfile,
+					"motion_profile": "position_only",
 					"some_other":     "config_param",
 				})
 				s.RUnlock()

--- a/services/navigation/builtin/builtin_test.go
+++ b/services/navigation/builtin/builtin_test.go
@@ -986,7 +986,7 @@ func TestStartWaypoint(t *testing.T) {
 					test.That(t, s.mogrs[0].MovementSensorName, test.ShouldResemble, s.movementSensor.Name())
 
 					test.That(t, s.mogrs[0].Extra, test.ShouldResemble, map[string]interface{}{
-						"motion_profile": "position_only",
+						"motion_profile": motionplan.PositionOnlyMotionProfile,
 					})
 					test.That(t, s.mogrs[0].MotionCfg, test.ShouldResemble, expectedMotionCfg)
 					test.That(t, s.mogrs[0].Obstacles, test.ShouldBeNil)
@@ -997,7 +997,7 @@ func TestStartWaypoint(t *testing.T) {
 					test.That(t, math.IsNaN(s.mogrs[1].Heading), test.ShouldBeTrue)
 					test.That(t, s.mogrs[1].MovementSensorName, test.ShouldResemble, s.movementSensor.Name())
 					test.That(t, s.mogrs[1].Extra, test.ShouldResemble, map[string]interface{}{
-						"motion_profile": "position_only",
+						"motion_profile": motionplan.PositionOnlyMotionProfile,
 					})
 					test.That(t, s.mogrs[1].MotionCfg, test.ShouldResemble, expectedMotionCfg)
 					test.That(t, s.mogrs[1].Obstacles, test.ShouldBeNil)
@@ -1115,13 +1115,13 @@ func TestStartWaypoint(t *testing.T) {
 			if len(s.mogrs) == 3 {
 				// MoveOnGlobe was called twice, once for each waypoint
 				test.That(t, s.mogrs[0].Extra, test.ShouldResemble, map[string]interface{}{
-					"motion_profile": "position_only",
+					"motion_profile": motionplan.PositionOnlyMotionProfile,
 				})
 				test.That(t, s.mogrs[1].Extra, test.ShouldResemble, map[string]interface{}{
-					"motion_profile": "position_only",
+					"motion_profile": motionplan.PositionOnlyMotionProfile,
 				})
 				test.That(t, s.mogrs[2].Extra, test.ShouldResemble, map[string]interface{}{
-					"motion_profile": "position_only",
+					"motion_profile": motionplan.PositionOnlyMotionProfile,
 					"some_other":     "config_param",
 				})
 				s.RUnlock()


### PR DESCRIPTION
Continuing on the path to make `plannerOptions` and `PathRequest` serializable, we now move `ConstraintHandler` to the `planner` struct.