### PR TITLE
DATA-4241 Fix capture directory

### DIFF
--- a/data/capture_file.go
+++ b/data/capture_file.go
@@ -285,7 +285,7 @@ func CaptureFilePathWithReplacedReservedChars(filepath string) string {
 	return strings.ReplaceAll(filepath, filePathReservedChars, "_")
 }
 
-// isWindowsAbsolutePath returns true if the path is a Windows absolute path. Ex: C:\path\to\file.txt
+// isWindowsAbsolutePath returns true if the path is a Windows absolute path. Ex: C:\path\to\file.txt.
 func isWindowsAbsolutePath(path string) bool {
 	driveLetter := path[0] | 32 // convert to lowercase.
 	return len(path) >= 2 && path[1] == ':' && driveLetter >= 'a' && driveLetter <= 'z'

--- a/data/capture_file.go
+++ b/data/capture_file.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -277,6 +278,12 @@ func SensorDataFromCaptureFile(f *CaptureFile) ([]*v1.SensorData, error) {
 
 // CaptureFilePathWithReplacedReservedChars returns the filepath with substitutions
 // for reserved characters.
+// CaptureFilePathWithReplacedReservedChars returns the filepath with substitutions
+// for reserved characters.
 func CaptureFilePathWithReplacedReservedChars(filepath string) string {
+	// Handle Windows drive letters by preserving them and replacing other colons.
+	if runtime.GOOS == "windows" && len(filepath) >= 2 && filepath[1] == ':' {
+		return filepath[:2] + strings.ReplaceAll(filepath[2:], filePathReservedChars, "_")
+	}
 	return strings.ReplaceAll(filepath, filePathReservedChars, "_")
 }

--- a/data/capture_file.go
+++ b/data/capture_file.go
@@ -278,8 +278,6 @@ func SensorDataFromCaptureFile(f *CaptureFile) ([]*v1.SensorData, error) {
 
 // CaptureFilePathWithReplacedReservedChars returns the filepath with substitutions
 // for reserved characters.
-// CaptureFilePathWithReplacedReservedChars returns the filepath with substitutions
-// for reserved characters.
 func CaptureFilePathWithReplacedReservedChars(filepath string) string {
 	// Handle Windows drive letters by preserving them and replacing other colons.
 	if runtime.GOOS == "windows" && len(filepath) >= 2 && filepath[1] == ':' {

--- a/data/capture_file.go
+++ b/data/capture_file.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -280,8 +279,14 @@ func SensorDataFromCaptureFile(f *CaptureFile) ([]*v1.SensorData, error) {
 // for reserved characters.
 func CaptureFilePathWithReplacedReservedChars(filepath string) string {
 	// Handle Windows drive letters by preserving them and replacing other colons.
-	if runtime.GOOS == "windows" && len(filepath) >= 2 && filepath[1] == ':' {
+	if isWindowsAbsolutePath(filepath) {
 		return filepath[:2] + strings.ReplaceAll(filepath[2:], filePathReservedChars, "_")
 	}
 	return strings.ReplaceAll(filepath, filePathReservedChars, "_")
+}
+
+// isWindowsAbsolutePath returns true if the path is a Windows absolute path. Ex: C:\path\to\file.txt
+func isWindowsAbsolutePath(path string) bool {
+	driveLetter := path[0] | 32 // convert to lowercase.
+	return len(path) >= 2 && path[1] == ':' && driveLetter >= 'a' && driveLetter <= 'z'
 }

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"errors"
 	"os"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -28,6 +27,7 @@ import (
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/services/datamanager"
 	"go.viam.com/rdk/services/datamanager/builtin/capture"
+	"go.viam.com/rdk/services/datamanager/builtin/shared"
 	datasync "go.viam.com/rdk/services/datamanager/builtin/sync"
 	"go.viam.com/rdk/services/slam"
 	"go.viam.com/rdk/services/vision"
@@ -38,7 +38,6 @@ var (
 	// ErrCaptureDirectoryConfigurationDisabled happens when the viam-server is run with
 	// `-untrusted-env` and the capture directory is not `~/.viam/capture`.
 	ErrCaptureDirectoryConfigurationDisabled = errors.New("changing the capture directory is prohibited in this environment")
-	viamCaptureDotDir                        = filepath.Join(utils.ViamDotDir, "capture")
 	// This clock only exists for tests.
 	// At time of writing only a single test depends on it.
 	// We should endevor to not add more tests that depend on it unless absolutiely necessary.
@@ -180,7 +179,7 @@ func (b *builtIn) Reconfigure(ctx context.Context, deps resource.Dependencies, c
 		return err
 	}
 
-	if !utils.IsTrustedEnvironment(ctx) && c.CaptureDir != "" && c.CaptureDir != viamCaptureDotDir {
+	if !utils.IsTrustedEnvironment(ctx) && c.CaptureDir != "" && c.CaptureDir != shared.ViamCaptureDotDir {
 		// see comment above this error definition for when this happens
 		return ErrCaptureDirectoryConfigurationDisabled
 	}

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -38,7 +38,7 @@ var (
 	// ErrCaptureDirectoryConfigurationDisabled happens when the viam-server is run with
 	// `-untrusted-env` and the capture directory is not `~/.viam/capture`.
 	ErrCaptureDirectoryConfigurationDisabled = errors.New("changing the capture directory is prohibited in this environment")
-	viamCaptureDotDir                        = filepath.Join(os.Getenv("HOME"), ".viam", "capture")
+	viamCaptureDotDir                        = filepath.Join(utils.ViamDotDir, "capture")
 	// This clock only exists for tests.
 	// At time of writing only a single test depends on it.
 	// We should endevor to not add more tests that depend on it unless absolutiely necessary.

--- a/services/datamanager/builtin/builtin_test.go
+++ b/services/datamanager/builtin/builtin_test.go
@@ -36,6 +36,7 @@ import (
 	"go.viam.com/rdk/rimage"
 	"go.viam.com/rdk/services/datamanager"
 	"go.viam.com/rdk/services/datamanager/builtin/capture"
+	"go.viam.com/rdk/services/datamanager/builtin/shared"
 	datasync "go.viam.com/rdk/services/datamanager/builtin/sync"
 	"go.viam.com/rdk/spatialmath"
 	"go.viam.com/rdk/testutils/inject"
@@ -118,7 +119,7 @@ func TestNew(t *testing.T) {
 		t.Run("returns successfully if config uses the default capture dir", func(t *testing.T) {
 			mockDeps := mockDeps(nil, nil)
 			c := &Config{}
-			test.That(t, c.getCaptureDir(logger), test.ShouldResemble, viamCaptureDotDir)
+			test.That(t, c.getCaptureDir(logger), test.ShouldResemble, shared.ViamCaptureDotDir)
 			b, err := New(
 				ctx,
 				mockDeps,
@@ -200,7 +201,7 @@ func TestReconfigure(t *testing.T) {
 		t.Run("returns successfully if config uses the default capture dir", func(t *testing.T) {
 			mockDeps := mockDeps(nil, nil)
 			c := &Config{}
-			test.That(t, c.getCaptureDir(logger), test.ShouldResemble, viamCaptureDotDir)
+			test.That(t, c.getCaptureDir(logger), test.ShouldResemble, shared.ViamCaptureDotDir)
 			err := b.Reconfigure(ctx, mockDeps, resource.Config{ConvertedAttributes: c})
 			test.That(t, err, test.ShouldBeNil)
 		})

--- a/services/datamanager/builtin/config.go
+++ b/services/datamanager/builtin/config.go
@@ -11,6 +11,7 @@ import (
 	"go.viam.com/rdk/internal/cloud"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/services/datamanager/builtin/capture"
+	"go.viam.com/rdk/services/datamanager/builtin/shared"
 	datasync "go.viam.com/rdk/services/datamanager/builtin/sync"
 	"go.viam.com/rdk/utils"
 )
@@ -91,7 +92,7 @@ func (c *Config) Validate(path string) ([]string, []string, error) {
 }
 
 func (c *Config) getCaptureDir(logger logging.Logger) string {
-	captureDir := viamCaptureDotDir
+	captureDir := shared.ViamCaptureDotDir
 	if c.CaptureDir != "" {
 		captureDir = c.CaptureDir
 		if strings.HasPrefix(captureDir, "~") {

--- a/services/datamanager/builtin/config_test.go
+++ b/services/datamanager/builtin/config_test.go
@@ -12,6 +12,7 @@ import (
 	"go.viam.com/rdk/internal/cloud"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/services/datamanager/builtin/capture"
+	"go.viam.com/rdk/services/datamanager/builtin/shared"
 	"go.viam.com/rdk/services/datamanager/builtin/sync"
 	"go.viam.com/rdk/testutils/inject"
 )
@@ -101,7 +102,7 @@ func TestConfig(t *testing.T) {
 	t.Run("getCaptureDir", func(t *testing.T) {
 		t.Run("returns the default capture directory by default", func(t *testing.T) {
 			c := &Config{}
-			test.That(t, c.getCaptureDir(logger), test.ShouldResemble, viamCaptureDotDir)
+			test.That(t, c.getCaptureDir(logger), test.ShouldResemble, shared.ViamCaptureDotDir)
 		})
 
 		t.Run("returns home directory if starts with ~", func(t *testing.T) {
@@ -121,7 +122,7 @@ func TestConfig(t *testing.T) {
 		t.Run("returns a capture config with defaults when called on an empty config", func(t *testing.T) {
 			c := &Config{}
 			test.That(t, c.captureConfig(logger), test.ShouldResemble, capture.Config{
-				CaptureDir:                  viamCaptureDotDir,
+				CaptureDir:                  shared.ViamCaptureDotDir,
 				MaximumCaptureFileSizeBytes: defaultMaxCaptureSize,
 			})
 		})
@@ -140,7 +141,7 @@ func TestConfig(t *testing.T) {
 		t.Run("returns a sync config with defaults when called on an empty config", func(t *testing.T) {
 			c := &Config{}
 			test.That(t, c.syncConfig(nil, false, logger), test.ShouldResemble, sync.Config{
-				CaptureDir:                  viamCaptureDotDir,
+				CaptureDir:                  shared.ViamCaptureDotDir,
 				DeleteEveryNthWhenDiskFull:  5,
 				FileLastModifiedMillis:      10000,
 				MaximumNumSyncThreads:       runtime.NumCPU() / 2,
@@ -153,7 +154,7 @@ func TestConfig(t *testing.T) {
 		t.Run("returns a sync config with defaults when called on a config with SyncIntervalMins which is practically 0", func(t *testing.T) {
 			c := &Config{SyncIntervalMins: 0.000000000000000001}
 			test.That(t, c.syncConfig(nil, false, logger), test.ShouldResemble, sync.Config{
-				CaptureDir:                  viamCaptureDotDir,
+				CaptureDir:                  shared.ViamCaptureDotDir,
 				DeleteEveryNthWhenDiskFull:  5,
 				FileLastModifiedMillis:      10000,
 				MaximumNumSyncThreads:       runtime.NumCPU() / 2,

--- a/services/datamanager/builtin/shared/default_capture_directory.go
+++ b/services/datamanager/builtin/shared/default_capture_directory.go
@@ -1,0 +1,12 @@
+package shared
+
+import (
+	"os"
+	"path/filepath"
+
+	"go.viam.com/rdk/utils"
+)
+
+var ViamCaptureDotDir = filepath.Join(utils.ViamDotDir, "capture")
+var OldViamCaptureDotDir = filepath.Join(os.Getenv("HOME"), ".viam", "capture")
+var CaptureDirChanged = ViamCaptureDotDir != OldViamCaptureDotDir

--- a/services/datamanager/builtin/shared/default_capture_directory.go
+++ b/services/datamanager/builtin/shared/default_capture_directory.go
@@ -1,3 +1,4 @@
+// Package shared is for any variables/functions shared amongst the datamanager builtin package and its subpackages.
 package shared
 
 import (
@@ -7,6 +8,12 @@ import (
 	"go.viam.com/rdk/utils"
 )
 
-var ViamCaptureDotDir = filepath.Join(utils.ViamDotDir, "capture")
-var OldViamCaptureDotDir = filepath.Join(os.Getenv("HOME"), ".viam", "capture")
-var DefaultCaptureDirChanged = ViamCaptureDotDir != OldViamCaptureDotDir
+var (
+	// ViamCaptureDotDir is the default directory for capturing and syncing data.
+	ViamCaptureDotDir = filepath.Join(utils.ViamDotDir, "capture")
+	// OldViamCaptureDotDir is the old default directory for capturing and syncing data.
+	// We will continue syncing data from this directory for backwards compatibility.
+	OldViamCaptureDotDir = filepath.Join(os.Getenv("HOME"), ".viam", "capture")
+	// DefaultCaptureDirChanged is true if the default capture directory has changed since fixing the capture directory location.
+	DefaultCaptureDirChanged = ViamCaptureDotDir != OldViamCaptureDotDir
+)

--- a/services/datamanager/builtin/shared/default_capture_directory.go
+++ b/services/datamanager/builtin/shared/default_capture_directory.go
@@ -9,4 +9,4 @@ import (
 
 var ViamCaptureDotDir = filepath.Join(utils.ViamDotDir, "capture")
 var OldViamCaptureDotDir = filepath.Join(os.Getenv("HOME"), ".viam", "capture")
-var CaptureDirChanged = ViamCaptureDotDir != OldViamCaptureDotDir
+var DefaultCaptureDirChanged = ViamCaptureDotDir != OldViamCaptureDotDir

--- a/services/datamanager/builtin/sync/config.go
+++ b/services/datamanager/builtin/sync/config.go
@@ -1,6 +1,8 @@
 package sync
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 
@@ -188,5 +190,7 @@ func (c *Config) logDiff(o Config, logger logging.Logger) {
 
 // SyncPaths returns the capture directory and additional sync paths as a slice.
 func (c Config) SyncPaths() []string {
-	return append([]string{c.CaptureDir}, c.AdditionalSyncPaths...)
+	// TODO(DATA-4287): Remove this once all windows machines have updated to a version of viam-server that uses the new capture directory.
+	oldCaptureDir := filepath.Join(os.Getenv("HOME"), ".viam", "capture")
+	return append([]string{c.CaptureDir, oldCaptureDir}, c.AdditionalSyncPaths...)
 }

--- a/services/datamanager/builtin/sync/config.go
+++ b/services/datamanager/builtin/sync/config.go
@@ -1,13 +1,12 @@
 package sync
 
 import (
-	"os"
-	"path/filepath"
 	"reflect"
 	"strings"
 
 	"go.viam.com/rdk/components/sensor"
 	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/services/datamanager/builtin/shared"
 )
 
 // Config is the sync config from builtin.
@@ -191,10 +190,9 @@ func (c *Config) logDiff(o Config, logger logging.Logger) {
 // SyncPaths returns the capture directory and additional sync paths as a slice.
 func (c Config) SyncPaths() []string {
 	// TODO(DATA-4287): Remove this once all windows machines have updated to a version of viam-server that uses the new capture directory.
-	oldCaptureDir := filepath.Join(os.Getenv("HOME"), ".viam", "capture")
 	syncPaths := append([]string{c.CaptureDir}, c.AdditionalSyncPaths...)
-	if c.CaptureDir != oldCaptureDir {
-		syncPaths = append(syncPaths, oldCaptureDir)
+	if c.CaptureDir == shared.ViamCaptureDotDir && shared.CaptureDirChanged {
+		syncPaths = append(syncPaths, shared.OldViamCaptureDotDir)
 	}
 	return syncPaths
 }

--- a/services/datamanager/builtin/sync/config.go
+++ b/services/datamanager/builtin/sync/config.go
@@ -191,7 +191,7 @@ func (c *Config) logDiff(o Config, logger logging.Logger) {
 func (c Config) SyncPaths() []string {
 	// TODO(DATA-4287): Remove this once all windows machines have updated to a version of viam-server that uses the new capture directory.
 	syncPaths := append([]string{c.CaptureDir}, c.AdditionalSyncPaths...)
-	if c.CaptureDir == shared.ViamCaptureDotDir && shared.CaptureDirChanged {
+	if c.CaptureDir == shared.ViamCaptureDotDir && shared.DefaultCaptureDirChanged {
 		syncPaths = append(syncPaths, shared.OldViamCaptureDotDir)
 	}
 	return syncPaths

--- a/services/datamanager/builtin/sync/config.go
+++ b/services/datamanager/builtin/sync/config.go
@@ -192,5 +192,9 @@ func (c *Config) logDiff(o Config, logger logging.Logger) {
 func (c Config) SyncPaths() []string {
 	// TODO(DATA-4287): Remove this once all windows machines have updated to a version of viam-server that uses the new capture directory.
 	oldCaptureDir := filepath.Join(os.Getenv("HOME"), ".viam", "capture")
-	return append([]string{c.CaptureDir, oldCaptureDir}, c.AdditionalSyncPaths...)
+	syncPaths := append([]string{c.CaptureDir}, c.AdditionalSyncPaths...)
+	if c.CaptureDir != oldCaptureDir {
+		syncPaths = append(syncPaths, oldCaptureDir)
+	}
+	return syncPaths
 }

--- a/services/datamanager/builtin/sync/sync.go
+++ b/services/datamanager/builtin/sync/sync.go
@@ -337,14 +337,14 @@ func (s *Sync) runWorker(config Config) {
 func (s *Sync) syncFile(config Config, filePath string) {
 	// don't sync in progress files
 	if filepath.Ext(filePath) == data.InProgressCaptureFileExt {
-		s.logger.Warnf("ignoreing request to sync in progress capture file: %s", filePath)
+		s.logger.Warnf("ignoring request to sync in progress capture file: %s", filePath)
 		return
 	}
 
 	// If the file is already being synced, do not kick off a new goroutine.
 	// The goroutine will again check and return early if sync is already in progress.
 	if !s.fileTracker.markInProgress(filePath) {
-		s.logger.Warnf("ignoreing request to sync file which sync is already working on %s", filePath)
+		s.logger.Warnf("ignoring request to sync file which sync is already working on %s", filePath)
 		return
 	}
 	defer s.fileTracker.unmarkInProgress(filePath)


### PR DESCRIPTION
This PR updates datamanager to use a variable that netcode provides to determine the location of the `.viam/capture` directory, while syncing from both the old and the new locations in order to not lose any data when machines update viam server.

Also needed to update `CaptureFilePathWithReplacedReservedChars` so that it wasn't replacing the colon after a Windows drive with an underscore.

Manually tested on a Windows machine and was able to sync data from both capture directory locations ✅ 