### PR TITLE
RSDK-11150 - Reregister models after crash recovery

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -383,7 +383,7 @@ func (mgr *Manager) startModule(ctx context.Context, mod *module) error {
 		mgr.modPeerConnTracker.Add(mod.cfg.Name, pc)
 	}
 
-	mod.registerResources(mgr)
+	mod.registerResourceModels(mgr)
 	mgr.modules.Store(mod.cfg.Name, mod)
 	mod.logger.Infow("Module successfully added", "module", mod.cfg.Name)
 	success = true
@@ -506,7 +506,7 @@ func (mgr *Manager) closeModule(mod *module, reconfigure bool) error {
 		mod.logger.Warnw("Error closing connection to module", "error", err)
 	}
 
-	mod.deregisterResources()
+	mod.deregisterResourceModels()
 
 	for r, m := range mgr.rMap.Range {
 		if m == mod {
@@ -982,7 +982,7 @@ func (mgr *Manager) newOnUnexpectedExitHandler(ctx context.Context, mod *module)
 			for _, n := range orphanedResourceNames {
 				orphanedResourceNamesStr = append(orphanedResourceNamesStr, n.String())
 			}
-			mod.logger.Warnw("Some modules failed to re-add after crashed module restart and will be removed",
+			mod.logger.Warnw("Some resources failed to re-add after crashed module restart and will be removed",
 				"module", mod.cfg.Name,
 				"orphanedResources", orphanedResourceNamesStr)
 			unlock()
@@ -1062,7 +1062,7 @@ func (mgr *Manager) attemptRestart(ctx context.Context, mod *module) error {
 	if pc := mod.sharedConn.PeerConn(); mgr.modPeerConnTracker != nil && pc != nil {
 		mgr.modPeerConnTracker.Add(mod.cfg.Name, pc)
 	}
-
+	mod.registerResourceModels(mgr)
 	success = true
 	return nil
 }

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -151,13 +151,13 @@ func TestModManagerFunctions(t *testing.T) {
 			err = mod.checkReady(ctx, parentAddr)
 			test.That(t, err, test.ShouldBeNil)
 
-			mod.registerResources(mgr)
+			mod.registerResourceModels(mgr)
 			reg, ok := resource.LookupRegistration(generic.API, myCounterModel)
 			test.That(t, ok, test.ShouldBeTrue)
 			test.That(t, reg, test.ShouldNotBeNil)
 			test.That(t, reg.Constructor, test.ShouldNotBeNil)
 
-			mod.deregisterResources()
+			mod.deregisterResourceModels()
 			_, ok = resource.LookupRegistration(generic.API, myCounterModel)
 			test.That(t, ok, test.ShouldBeFalse)
 

--- a/module/modmanager/module.go
+++ b/module/modmanager/module.go
@@ -326,7 +326,7 @@ func (m *module) killProcessGroup() {
 	m.process.KillGroup()
 }
 
-func (m *module) registerResources(mgr modmaninterface.ModuleManager) {
+func (m *module) registerResourceModels(mgr modmaninterface.ModuleManager) {
 	for api, models := range m.handles {
 		if _, ok := resource.LookupGenericAPIRegistration(api.API); !ok {
 			resource.RegisterAPI(
@@ -370,7 +370,7 @@ func (m *module) registerResources(mgr modmaninterface.ModuleManager) {
 	}
 }
 
-func (m *module) deregisterResources() {
+func (m *module) deregisterResourceModels() {
 	for api, models := range m.handles {
 		for _, model := range models {
 			resource.Deregister(api.API, model)
@@ -388,7 +388,7 @@ func (m *module) cleanupAfterStartupFailure() {
 }
 
 func (m *module) cleanupAfterCrash(mgr *Manager) {
-	m.deregisterResources()
+	m.deregisterResourceModels()
 	if err := m.sharedConn.Close(); err != nil {
 		m.logger.Warnw("Error closing connection to crashed module", "error", err)
 	}

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -791,7 +791,8 @@ func (rc *RobotClient) resources(ctx context.Context) ([]resource.Name, []resour
 				// has a remote. This can be solved by either integrating reflection into
 				// robot.proto or by overriding the gRPC reflection service to return
 				// reflection results from its remotes.
-				rc.Logger().CDebugw(ctx, "failed to find symbol for resource API", "api", resAPI, "error", err)
+				rc.Logger().
+					CDebugw(ctx, "failed to find symbol for resource API", "api", rprotoutils.ResourceNameFromProto(resAPI.Subtype).API.String(), "error", err)
 				continue
 			}
 			svcDesc, ok := symDesc.(*desc.ServiceDescriptor)

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -792,7 +792,12 @@ func (rc *RobotClient) resources(ctx context.Context) ([]resource.Name, []resour
 				// robot.proto or by overriding the gRPC reflection service to return
 				// reflection results from its remotes.
 				rc.Logger().
-					CDebugw(ctx, "failed to find symbol for resource API", "api", rprotoutils.ResourceNameFromProto(resAPI.Subtype).API.String(), "error", err)
+					CDebugw(
+						ctx,
+						"failed to find symbol for resource API",
+						"api", rprotoutils.ResourceNameFromProto(resAPI.Subtype).API.String(),
+						"error", err,
+					)
 				continue
 			}
 			svcDesc, ok := symDesc.(*desc.ServiceDescriptor)

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -1997,9 +1997,31 @@ func TestCrashedModuleModelReregisteredAfterRecovery(t *testing.T) {
 	_, err = h.DoCommand(ctx, map[string]any{"command": "get_num_reconfigurations"})
 	test.That(t, err, test.ShouldBeNil)
 
-	// Also assert that testmodule's resources were reregistered.
+	// Also assert that testmodule's resources were reregistered and
+	// test that a new resource in the config gets built successfully.
 	_, ok = resource.LookupRegistration(generic.API, helperModel)
 	test.That(t, ok, test.ShouldBeTrue)
+
+	cfg2 := &config.Config{
+		Modules: []config.Module{
+			{
+				Name:    "mod",
+				ExePath: testPath,
+			},
+		},
+		Components: []resource.Config{
+			{
+				Name:  "h2",
+				Model: helperModel,
+				API:   generic.API,
+			},
+		},
+	}
+	r.Reconfigure(ctx, cfg2)
+	h, err = r.ResourceByName(generic.Named("h2"))
+	test.That(t, err, test.ShouldBeNil)
+	_, err = h.DoCommand(ctx, map[string]any{"command": "get_num_reconfigurations"})
+	test.That(t, err, test.ShouldBeNil)
 }
 
 var (

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -1906,7 +1906,7 @@ func TestOrphanedResources(t *testing.T) {
 		// Wait for restart attempt in logs.
 		testutils.WaitForAssertionWithSleep(t, time.Second, 20, func(tb testing.TB) {
 			tb.Helper()
-			test.That(tb, logs.FilterMessage("Some modules failed to re-add after crashed module restart and will be removed").Len(),
+			test.That(tb, logs.FilterMessage("Some resources failed to re-add after crashed module restart and will be removed").Len(),
 				test.ShouldBeGreaterThanOrEqualTo, 1)
 		})
 		time.Sleep(2 * time.Second)

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -1925,6 +1925,83 @@ func TestOrphanedResources(t *testing.T) {
 	})
 }
 
+func TestCrashedModuleModelReregisteredAfterRecovery(t *testing.T) {
+	ctx := context.Background()
+	logger, logs := logging.NewObservedTestLogger(t)
+
+	// Precompile modules to avoid timeout issues when building takes too long.
+	testPath := rtestutils.BuildTempModule(t, "module/testmodule")
+
+	// Manually define models, as importing them can cause double registration.
+	helperModel := resource.NewModel("rdk", "test", "helper")
+
+	r := setupLocalRobot(t, ctx, &config.Config{}, logger)
+
+	cfg := &config.Config{
+		Modules: []config.Module{
+			{
+				Name:    "mod",
+				ExePath: testPath,
+			},
+		},
+		Components: []resource.Config{
+			{
+				Name:  "h",
+				Model: helperModel,
+				API:   generic.API,
+			},
+		},
+	}
+	r.Reconfigure(ctx, cfg)
+
+	h, err := r.ResourceByName(generic.Named("h"))
+	test.That(t, err, test.ShouldBeNil)
+
+	// Assert that removing testmodule binary and killing testmodule orphans
+	// helper 'h' after the first restart attempt
+	err = os.Rename(testPath, testPath+".disabled")
+	test.That(t, err, test.ShouldBeNil)
+	_, err = h.DoCommand(ctx, map[string]interface{}{"command": "kill_module"})
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "rpc error")
+
+	// Wait for restart attempt in logs.
+	testutils.WaitForAssertionWithSleep(t, time.Second, 20, func(tb testing.TB) {
+		tb.Helper()
+		test.That(tb, logs.FilterMessage("Error while restarting crashed module").Len(),
+			test.ShouldBeGreaterThanOrEqualTo, 1)
+	})
+
+	// Also assert that testmodule's resources were deregistered.
+	_, ok := resource.LookupRegistration(generic.API, helperModel)
+	test.That(t, ok, test.ShouldBeFalse)
+
+	// Check that h is still present but commands fail
+	h, err = r.ResourceByName(generic.Named("h"))
+	test.That(t, err, test.ShouldBeNil)
+	_, err = h.DoCommand(ctx, map[string]any{"command": "get_num_reconfigurations"})
+	test.That(t, err, test.ShouldNotBeNil)
+
+	// Assert that restoring the testmodule binary makes h start working again
+	// after the auto-restart code succeeds.
+	err = os.Rename(testPath+".disabled", testPath)
+	test.That(t, err, test.ShouldBeNil)
+	testutils.WaitForAssertionWithSleep(t, time.Second, 20, func(tb testing.TB) {
+		tb.Helper()
+		test.That(tb, logs.FilterMessage("Module resources successfully re-added after module restart").Len(),
+			test.ShouldEqual, 1)
+	})
+
+	h, err = r.ResourceByName(generic.Named("h"))
+	test.That(t, err, test.ShouldBeNil)
+	_, err = h.DoCommand(ctx, map[string]any{"command": "get_num_reconfigurations"})
+	test.That(t, err, test.ShouldBeNil)
+
+	// Also assert that testmodule's resources were reregistered.
+	_, ok = resource.LookupRegistration(generic.API, helperModel)
+	test.That(t, ok, test.ShouldBeTrue)
+}
+
 var (
 	doodadModel = resource.DefaultModelFamily.WithModel("mydoodad")
 	doodadAPI   = resource.APINamespaceRDK.WithComponentType("doodad")

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -721,7 +721,7 @@ func (manager *resourceManager) completeConfig(
 					} else {
 						prefix = "re"
 					}
-					manager.logger.CInfow(ctx, fmt.Sprintf("Now %sconfiguring resource", prefix), "resource", resName)
+					manager.logger.CInfow(ctx, fmt.Sprintf("Now %sconfiguring resource", prefix), "resource", resName, "model", conf.Model)
 
 					// this is done in config validation but partial start rules require us to check again
 					if _, _, err := conf.Validate("", resName.API.Type.Name); err != nil {
@@ -771,7 +771,7 @@ func (manager *resourceManager) completeConfig(
 								ctx, "error building resource", "resource", conf.ResourceName(), "model", conf.Model, "error", ctxWithTimeout.Err())
 						} else {
 							gNode.SwapResource(newRes, conf.Model, manager.opts.ftdc)
-							manager.logger.CInfow(ctx, fmt.Sprintf("Successfully %sconfigured resource", prefix), "resource", resName)
+							manager.logger.CInfow(ctx, fmt.Sprintf("Successfully %sconfigured resource", prefix), "resource", resName, "model", conf.Model)
 						}
 
 					default:

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -712,18 +712,16 @@ func (manager *resourceManager) completeConfig(
 						return
 					}
 
-					var verb string
+					var prefix string
 					conf := gNode.Config()
 					if gNode.IsUninitialized() {
-						verb = "configuring"
-
 						gNode.InitializeLogger(
 							manager.logger, resName.String(),
 						)
 					} else {
-						verb = "reconfiguring"
+						prefix = "re"
 					}
-					manager.logger.CInfow(ctx, fmt.Sprintf("Now %s resource", verb), "resource", resName)
+					manager.logger.CInfow(ctx, fmt.Sprintf("Now %sconfiguring resource", prefix), "resource", resName)
 
 					// this is done in config validation but partial start rules require us to check again
 					if _, _, err := conf.Validate("", resName.API.Type.Name); err != nil {
@@ -773,6 +771,7 @@ func (manager *resourceManager) completeConfig(
 								ctx, "error building resource", "resource", conf.ResourceName(), "model", conf.Model, "error", ctxWithTimeout.Err())
 						} else {
 							gNode.SwapResource(newRes, conf.Model, manager.opts.ftdc)
+							manager.logger.CInfow(ctx, fmt.Sprintf("Successfully %sconfigured resource", prefix), "resource", resName)
 						}
 
 					default:


### PR DESCRIPTION
actual fix was just one line, but renamed some functions and added a "Success" log for when resources get configured/reconfigured successfully