### PR TITLE
RSDK-11177: add missing get dependencies method to ml model service

### DIFF
--- a/services/mlmodel/mlmodel.go
+++ b/services/mlmodel/mlmodel.go
@@ -338,7 +338,7 @@ func FromRobot(r robot.Robot, name string) (Service, error) {
 	return robot.ResourceFromRobot[Service](r, Named(name))
 }
 
-// FromDependencies is a helper for getting the named vision service from a collection of dependencies.
+// FromDependencies is a helper for getting the named ml model service from a collection of dependencies.
 func FromDependencies(deps resource.Dependencies, name string) (Service, error) {
 	return resource.FromDependencies[Service](deps, Named(name))
 }


### PR DESCRIPTION
ML Model Service never had a GetDependencies method, oops!