### PR TITLE
pin runner for CLI builds

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   viam-cli:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'


### PR DESCRIPTION
## What changed
- in the CLI build, pin the runner instead of using latest
## Why
When the default runner changed from 22 to 24, the cloud build base image started throwing GLIBC errors when it tried to run the CLI binary.