### PR TITLE
require non-cgo build for CLI

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   viam-cli:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: Check out code
       if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ GOARCH ?= $(shell go env GOARCH)
 bin/$(GOOS)-$(GOARCH)/viam-cli: $(GO_FILES) Makefile go.mod go.sum
 	# no_cgo necessary here because of motionplan -> nlopt dependency.
 	# can be removed if you can run CGO_ENABLED=0 go build ./cli/viam on your local machine.
-	go build $(GCFLAGS) $(LDFLAGS) -tags osusergo,netgo,no_cgo -o $@ ./cli/viam
+	# CGO_ENABLED=0 is necessary after bedf954b to prevent go from sneakily doing a cgo build
+	CGO_ENABLED=0 go build $(GCFLAGS) $(LDFLAGS) -tags osusergo,netgo,no_cgo -o $@ ./cli/viam
 
 .PHONY: cli
 cli: bin/$(GOOS)-$(GOARCH)/viam-cli


### PR DESCRIPTION
## What changed
- force CGO_ENABLED=0 in the cli target in Makefile
- revert https://github.com/viamrobotics/rdk/pull/5110 (my previous, wrong fix for this)
## Why
The extra dependencies in bedf954b caused the cli build to silently switch to CGo for the build. (You can test this for yourself by doing CLI builds from that commit + the previous commit, then doing `ldd` on both).

This created a GLIBC dependency which broke cloud build. Cloud build is on an older ubuntu image intentionally to create broadly compatible binaries.