### PR TITLE
RSDK-11208 Propagate DisablePartialStart to the config struct

### DIFF
--- a/config/proto_conversions.go
+++ b/config/proto_conversions.go
@@ -51,6 +51,7 @@ func FromProto(proto *pb.RobotConfig, logger logging.Logger) (*Config, error) {
 	disablePartialStart := false
 	if proto.DisablePartialStart != nil {
 		disablePartialStart = *proto.DisablePartialStart
+		cfg.DisablePartialStart = disablePartialStart
 	}
 
 	cfg.Modules, err = toRDKSlice(proto.Modules, ModuleConfigFromProto, disablePartialStart, logger)


### PR DESCRIPTION
One of the two PRs for [this](https://viam.atlassian.net/browse/RSDK-11208) ticket. Most of the changes are in app, but there was a small bug in rdk that was never propagating the value of `disableParitalStart` from the proto message to the internal config struct.