### PR TITLE
RSDK-11045: cli get-ftdc show where files are saved

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -1487,7 +1487,9 @@ func (c *viamClient) machinesPartGetFTDCAction(
 	src := path.Join(ftdcPath, part.Id)
 	gArgs, err := getGlobalArgs(ctx)
 	quiet := err == nil && gArgs != nil && gArgs.Quiet
+	var startTime time.Time
 	if !quiet {
+		startTime = time.Now()
 		printf(ctx.App.Writer, "Saving to %s ...", path.Join(targetPath, part.GetId()))
 	}
 	if err := c.copyFilesFromMachine(
@@ -1510,7 +1512,7 @@ func (c *viamClient) machinesPartGetFTDCAction(
 		return err
 	}
 	if !quiet {
-		printf(ctx.App.Writer, "Done.")
+		printf(ctx.App.Writer, "Done in %s.", time.Since(startTime))
 	}
 	return nil
 }


### PR DESCRIPTION
Show where ftdc files are downloaded to:

```
$ viam machine part get-ftdc --part=12345-67890-12345
Saving to /home/viam/viam/rdk/12345-67890-12345 ...
Done in 20.002164135s.
```

```
$ viam machine part get-ftdc --part=12345-67890-12345 /tmp
Saving to /tmp/12345-67890-12345 ...
Done in 20.002164136s.
```
`viam --quiet machine ...` hides the output.

In the above examples, the files will be downloaded to `[...]/12345-67890-12345/*.ftdc`.