### PR TITLE
RSDK-11209 Nil check before FTDC.StoppableWorkers.Stop()

### DIFF
--- a/ftdc/ftdc.go
+++ b/ftdc/ftdc.go
@@ -291,7 +291,9 @@ func (ftdc *FTDC) StopAndJoin(ctx context.Context) {
 	ftdc.stopOnce.Do(func() {
 		// Only one caller should close the datum channel. And it should be the caller that called
 		// stop on the worker writing to the channel.
-		ftdc.readStatsWorker.Stop()
+		if ftdc.readStatsWorker != nil {
+			ftdc.readStatsWorker.Stop()
+		}
 		close(ftdc.datumCh)
 	})
 


### PR DESCRIPTION
Adding a nil check before calling `ftdc.readStatsWorker.Stop()`, since in case `newWithResources` fails, it might not have had enough time to setup the worker yet. Even though this happens only when the server errors and shuts down anyway, the nil pointer dereference panic hides the error messages coming from `newWithResources` which should be useful. 

