### PR TITLE
RSDK-10314 fix proto for meshes created from triangles

### DIFF
--- a/spatialmath/mesh.go
+++ b/spatialmath/mesh.go
@@ -38,7 +38,7 @@ type Mesh struct {
 }
 
 // NewMesh creates a mesh from the given triangles and pose.
-func NewMesh(pose Pose, triangles []*Triangle, label string) (*Mesh, error) {
+func NewMesh(pose Pose, triangles []*Triangle, label string) *Mesh {
 	mesh := &Mesh{
 		pose:      pose,
 		triangles: triangles,
@@ -46,14 +46,11 @@ func NewMesh(pose Pose, triangles []*Triangle, label string) (*Mesh, error) {
 	}
 
 	// Convert triangles to PLY for protobuf
-	plyBytes, err := mesh.trianglesToPLYBytes()
-	if err != nil {
-		return nil, err
-	}
+	plyBytes := mesh.trianglesToPLYBytes()
 	mesh.fileType = plyType
 	mesh.rawBytes = plyBytes
 
-	return mesh, nil
+	return mesh
 }
 
 // NewMeshFromPLYFile is a helper function to create a Mesh geometry from a PLY file.
@@ -439,10 +436,7 @@ func MeshBoxIntersectionArea(mesh, theBox Geometry) (float64, error) {
 // or the actual intersection area otherwise.
 func boxTriangleIntersectionArea(b *box, t *Triangle) (float64, error) {
 	// Quick check if they don't intersect at all
-	mesh, err := NewMesh(NewZeroPose(), []*Triangle{t}, "")
-	if err != nil {
-		return -1, err
-	}
+	mesh := NewMesh(NewZeroPose(), []*Triangle{t}, "")
 	collides, err := b.CollidesWith(mesh, defaultCollisionBufferMM)
 	if err != nil {
 		return -1, err
@@ -552,11 +546,7 @@ func calculatePolygonAreaWithTriangulation(vertices []r3.Vector) float64 {
 }
 
 // trianglesToPLYBytes converts the mesh's triangles to bytes in PLY format.
-func (m *Mesh) trianglesToPLYBytes() ([]byte, error) {
-	if len(m.triangles) == 0 {
-		return nil, errors.New("no triangles to convert")
-	}
-
+func (m *Mesh) trianglesToPLYBytes() []byte {
 	// Collect all unique vertices and create vertex-to-index mapping
 	vertexMap := make(map[string]int)
 	vertices := make([]r3.Vector, 0)
@@ -605,5 +595,5 @@ func (m *Mesh) trianglesToPLYBytes() ([]byte, error) {
 		buf.WriteString("\n")
 	}
 
-	return buf.Bytes(), nil
+	return buf.Bytes()
 }

--- a/spatialmath/mesh_test.go
+++ b/spatialmath/mesh_test.go
@@ -11,11 +11,7 @@ import (
 )
 
 func makeTestMesh(o Orientation, pt r3.Vector, triangles []*Triangle) *Mesh {
-	mesh, err := NewMesh(NewPose(pt, o), triangles, "")
-	if err != nil {
-		panic(err)
-	}
-	return mesh
+	return NewMesh(NewPose(pt, o), triangles, "")
 }
 
 func makeSimpleTriangleMesh() *Mesh {
@@ -46,8 +42,7 @@ func TestNewMesh(t *testing.T) {
 	)
 	pose := NewPose(r3.Vector{X: 1, Y: 2, Z: 3}, NewZeroOrientation())
 
-	mesh, err := NewMesh(pose, []*Triangle{tri}, "test_mesh")
-	test.That(t, err, test.ShouldBeNil)
+	mesh := NewMesh(pose, []*Triangle{tri}, "test_mesh")
 
 	test.That(t, mesh.Label(), test.ShouldEqual, "test_mesh")
 	test.That(t, PoseAlmostEqual(mesh.Pose(), pose), test.ShouldBeTrue)
@@ -676,8 +671,7 @@ func TestMeshProtoConversionFromTriangles(t *testing.T) {
 
 	// Create mesh with a pose and label
 	originalPose := NewPose(r3.Vector{X: 100, Y: 200, Z: 300}, NewZeroOrientation())
-	originalMesh, err := NewMesh(originalPose, triangles, "test_mesh_from_triangles")
-	test.That(t, err, test.ShouldBeNil)
+	originalMesh := NewMesh(originalPose, triangles, "test_mesh_from_triangles")
 
 	// Convert to protobuf
 	proto := originalMesh.ToProtobuf()


### PR DESCRIPTION
This updates NewMesh to create the bytes necessary to transmit a mesh over proto.