### PR TITLE
[RSDK-11339] Allow for unauthenticated local module generation

### DIFF
--- a/cli/module_generate.go
+++ b/cli/module_generate.go
@@ -81,7 +81,10 @@ func promptUnauthenticated() bool {
 				Title("Unable to authenticate"),
 			huh.NewConfirm().
 				Title("Continue without authenticating?").
-				Description("In order to register a module with Viam, you must be authenticatd.\nYou can continue to generate a module, but you will be unable to\nregister the module with Viam.\n\nWould you like to conitnue without authenticating?").
+				Description("In order to register a module with Viam, you must be authenticated.\n"+
+					"You can continue to generate a module, but you will be unable to\n"+
+					"register the module with Viam.\n\n"+
+					"Would you like to conitnue without authenticating?").
 				Value(&unauthenticatedMode).
 				Affirmative("Contiue without authentication").
 				Negative("Do not continue"),

--- a/cli/module_generate.go
+++ b/cli/module_generate.go
@@ -262,13 +262,10 @@ func promptUser(module *modulegen.ModuleInputs) error {
 	} else {
 		registerWidget = huh.NewConfirm().
 			Title("Register module").
-			DescriptionFunc(func() string {
-				if unauthenticatedMode {
-					return "You are unauthenticated and cannot register this module with Viam.\n\nThis module will be a local-only module."
-				}
-				return "Register this module with Viam.\nIf selected, " +
-					"this will associate the module with your organization.\nOtherwise, this will be a local-only module."
-			}, unauthenticatedMode).
+			Description("Register this module with Viam.\nIf selected, " +
+				"this will associate the module with your organization.\n" +
+				"Otherwise, this will be a local-only module.",
+			).
 			Value(&module.RegisterOnApp)
 	}
 


### PR DESCRIPTION
If a user is unauthenticated/we get an error with auth and tries generating a module, show this prompt to the user:
<img width="569" height="221" alt="Screenshot 2025-07-15 at 4 14 11 PM" src="https://github.com/user-attachments/assets/5bac5615-3def-4060-b7bc-eff4fc8cebc9" />


If they select "Do not continue", they will get the usual error:
<img width="475" height="86" alt="Screenshot 2025-07-15 at 4 06 31 PM" src="https://github.com/user-attachments/assets/42bb105c-06e8-429f-9a43-bc9b20c12fc4" />

If they select continue, they will get prompted for the rest of the information per usual, except the last option (register module) will be disabled:
<img width="683" height="972" alt="Screenshot 2025-07-15 at 4 07 07 PM" src="https://github.com/user-attachments/assets/410e8e94-c894-440d-ac49-0383af71df15" />

Cc @dgottlieb since you ran into this issue recently