### PR TITLE
Simplify local-app-teting command

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -2510,7 +2510,7 @@ Note: There is no progress meter while copying is in progress.
 					Name:  "local-app-testing",
 					Usage: "test your viam application locally",
 					UsageText: createUsageText("module local-app-testing",
-						[]string{"app-url", "machine-id", "machine-api-key", "machine-api-key-id"}, false, false),
+						[]string{"app-url", "machine-id"}, false, false),
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:     "app-url",
@@ -2521,18 +2521,6 @@ Note: There is no progress meter while copying is in progress.
 							Name: "machine-id",
 							Usage: "machine ID of the machine you want to test with, you can get it at " +
 								"https://app.viam.com/fleet/machines",
-							Required: true,
-						},
-						&cli.StringFlag{
-							Name: "machine-api-key-id",
-							Usage: "machine API key ID for the machine you provided the ID of, you can get it at " +
-								"https://app.viam.comm/machine/<machineID>/connect/api-keys",
-							Required: true,
-						},
-						&cli.StringFlag{
-							Name: "machine-api-key",
-							Usage: "machine API key for the machine you provided the ID of, you can get it at " +
-								"https://app.viam.comm/machine/<machineID>/connect/api-keys",
 							Required: true,
 						},
 					},

--- a/cli/module_local_viam_apps_setup.go
+++ b/cli/module_local_viam_apps_setup.go
@@ -15,61 +15,53 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
-	"go.viam.com/utils/rpc"
 
-	appclient "go.viam.com/rdk/app"
-	"go.viam.com/rdk/logging"
+	apppb "go.viam.com/api/app/v1"
 )
 
 // localAppTestingArgs contains the arguments for the local-app-testing command.
 type localAppTestingArgs struct {
 	AppURL    string `json:"app-url"`
 	MachineID string `json:"machine-id"`
-	//nolint: revive,stylecheck // The CLI args parsing prevents us from using API (uppercase)
-	MachineApiKey string `json:"machine-api-key"`
-	//nolint: revive,stylecheck // The CLI args parsing prevents us from using API (uppercase)
-	MachineApiKeyID string `json:"machine-api-key-id"`
 }
 
 type localAppTestingServer struct {
 	machineID       string
+	machineHostname string
 	machineAPIKey   string
 	machineAPIKeyID string
 	serverURL       string
-	viamClient      *appclient.ViamClient
 	logger          io.Writer
 }
 
 // LocalAppTestingAction is the action for the local-app-testing command.
 func LocalAppTestingAction(ctx *cli.Context, args localAppTestingArgs) error {
 	serverPort := 8000
-	viamURL := "https://app.viam.com"
-	baseURL, _, err := getBaseURL(ctx)
-	if err != nil || baseURL == nil {
-		printf(ctx.App.Writer, "could not determine Viam base URL from context, defaulting to https://app.viam.com")
-	} else {
-		viamURL = baseURL.String()
+	viamClient, err := newViamClient(ctx)
+	if err != nil {
+		return err
 	}
-
-	viamClient, err := appclient.CreateViamClientWithOptions(context.Background(), appclient.Options{
-		Entity:  args.MachineApiKeyID,
-		BaseURL: viamURL,
-		Credentials: rpc.Credentials{
-			Type:    rpc.CredentialsTypeAPIKey,
-			Payload: args.MachineApiKey,
-		},
-	}, logging.NewLogger("appClient"))
 	if err != nil {
 		printf(ctx.App.ErrWriter, "error initializing the Viam client: "+err.Error())
 		return err
 	}
 
+	machineAPIKeyID, machineAPIKey, err := getMachineAPIKeys(ctx.Context, viamClient.client, args.MachineID)
+	if err != nil {
+		return err
+	}
+
+	machineHostname, err := getMachineHostname(ctx.Context, viamClient.client, args.MachineID)
+	if err != nil {
+		return err
+	}
+
 	localAppTesting := localAppTestingServer{
 		machineID:       args.MachineID,
-		machineAPIKey:   args.MachineApiKey,
-		machineAPIKeyID: args.MachineApiKeyID,
+		machineHostname: machineHostname,
+		machineAPIKey:   machineAPIKey,
+		machineAPIKeyID: machineAPIKeyID,
 		serverURL:       fmt.Sprintf("http://localhost:%d", serverPort),
-		viamClient:      viamClient,
 		logger:          ctx.App.Writer,
 	}
 
@@ -94,6 +86,40 @@ func LocalAppTestingAction(ctx *cli.Context, args localAppTestingArgs) error {
 	}
 
 	return nil
+}
+
+func getMachineAPIKeys(ctx context.Context, viamAppClient apppb.AppServiceClient, machineID string) (string, string, error) {
+	resp, err := viamAppClient.GetRobotAPIKeys(ctx, &apppb.GetRobotAPIKeysRequest{
+		RobotId: machineID,
+	})
+	if err != nil {
+		return "", "", err
+	}
+
+	keys := resp.GetApiKeys()
+	if len(keys) == 0 {
+		return "", "", errors.Errorf("Machine % has no API keys", machineID)
+	}
+
+	return keys[0].GetApiKey().GetId(), keys[0].GetApiKey().GetKey(), nil
+}
+
+func getMachineHostname(ctx context.Context, viamAppClient apppb.AppServiceClient, machineID string) (string, error) {
+	resp, err := viamAppClient.GetRobotParts(context.Background(), &apppb.GetRobotPartsRequest{
+		RobotId: machineID,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	robotParts := resp.GetParts()
+	for _, robotPart := range robotParts {
+		if robotPart.MainPart {
+			return robotPart.Fqdn, nil
+		}
+	}
+
+	return "", errors.New("Could not resolve machine hostname, no main part found")
 }
 
 // setupHTTPServer creates and configures an HTTP server with the given HTML file.
@@ -144,14 +170,8 @@ type machineAPIKey struct {
 
 func (l *localAppTestingServer) cookieSetup(resp http.ResponseWriter, req *http.Request) {
 	// Generate machine auth cookie
-	machineHostname, err := l.getRobotHostname(l.machineID)
-	if err != nil {
-		printf(l.logger, "Could not resolve machine hostname, defaulting to UNKNOWN: %s", err.Error())
-		machineHostname = "UNKNOWN"
-	}
-
 	cookieValue := machineAuthCookieValue{
-		Hostname:  machineHostname,
+		Hostname:  l.machineHostname,
 		MachineID: l.machineID,
 		Credentials: machineCredentials{
 			Type:       "api-key",
@@ -177,27 +197,12 @@ func (l *localAppTestingServer) cookieSetup(resp http.ResponseWriter, req *http.
 	})
 
 	http.SetCookie(resp, &http.Cookie{
-		Name:  machineHostname,
+		Name:  l.machineHostname,
 		Value: cookieValueString,
 	})
 
 	// redirect to the machine path
-	http.Redirect(resp, req, fmt.Sprintf("%s/machine/%s", l.serverURL, l.machineID), http.StatusFound)
-}
-
-func (l *localAppTestingServer) getRobotHostname(machineID string) (string, error) {
-	robotParts, err := l.viamClient.AppClient().GetRobotParts(context.Background(), machineID)
-	if err != nil {
-		return "", err
-	}
-
-	for _, robotPart := range robotParts {
-		if robotPart.MainPart {
-			return robotPart.FQDN, nil
-		}
-	}
-
-	return "", errors.New("Could not resolve machine hostname, no main part found")
+	http.Redirect(resp, req, fmt.Sprintf("%s/machine/%s", l.serverURL, l.machineHostname), http.StatusFound)
 }
 
 func removeMachinePathFromURL(originalDirector func(*http.Request)) func(*http.Request) {


### PR DESCRIPTION
https://viam.atlassian.net/browse/APP-8173
Follow up to https://github.com/viamrobotics/rdk/pull/5116

Reduce the number of needed arguments to spin up the local testing proxy. We can rely on the logged in user in the CLI context rather than requesting the user to provide the machine API keys.

This makes usage much simpler

```
viam module local-app-testing -h
NAME:
   viam module local-app-testing - test your viam application locally

USAGE:
   viam module local-app-testing --app-url=<app-url> --machine-id=<machine-id>

OPTIONS:
   --app-url value     url where local app is running (including port number), e.g http://localhost:5000
   --machine-id value  machine ID of the machine you want to test with, you can get it at https://app.viam.com/fleet/machines
```