### PR TITLE
[APP-7819] CLI command to read metadata

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -2508,8 +2508,8 @@ Note: There is no progress meter while copying is in progress.
 			Subcommands: []*cli.Command{
 				{
 					Name:      "read",
-					Usage:     "read metadata attached to your orgs, locations, machines, or machine parts",
-					UsageText: createUsageText("metadata read", nil, false, false, "organization-id", "location-id", "machine-id", "machine-part-id"),
+					Usage:     "read metadata attached to your orgs, locations, machines, and/or machine parts",
+					UsageText: "Provide at least one of the identifiers using CLI arguments to fetch the corresponding metadata",
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:  "organization-id",

--- a/cli/app.go
+++ b/cli/app.go
@@ -2501,6 +2501,38 @@ Note: There is no progress meter while copying is in progress.
 			},
 		},
 		{
+			Name:            "metadata",
+			Usage:           "manage the metadata attached to your orgs, locations, machines, and/or machine parts",
+			UsageText:       createUsageText("metadata", nil, false, true),
+			HideHelpCommand: true,
+			Subcommands: []*cli.Command{
+				{
+					Name:      "read",
+					Usage:     "read metadata attached to your orgs, locations, machines, or machine parts",
+					UsageText: createUsageText("metadata read", nil, false, false, "organization-id", "location-id", "machine-id", "machine-part-id"),
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:  "organization-id",
+							Usage: "ID of the organization you want to read the metadata from",
+						},
+						&cli.StringFlag{
+							Name:  "location-id",
+							Usage: "ID of the location you want to read the metadata from",
+						},
+						&cli.StringFlag{
+							Name:  "machine-id",
+							Usage: "ID of the machine you want to read the metadata from",
+						},
+						&cli.StringFlag{
+							Name:  "machine-part-id",
+							Usage: "ID of the machine part you want to read the metadata from",
+						},
+					},
+					Action: createCommandWithT[metadataReadArgs](MetadataReadAction),
+				},
+			},
+		},
+		{
 			Name:            "module",
 			Usage:           "manage your modules in Viam's registry",
 			UsageText:       createUsageText("module", nil, false, true),

--- a/cli/metadata_read.go
+++ b/cli/metadata_read.go
@@ -1,0 +1,127 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/pkg/errors"
+	"github.com/urfave/cli/v2"
+	apppb "go.viam.com/api/app/v1"
+	structpb "google.golang.org/protobuf/types/known/structpb"
+)
+
+type metadataReadArgs struct {
+	OrganizationID string
+	LocationID     string
+	MachineID      string
+	MachinePartID  string
+}
+
+// MetadataReadAction is the action for the CLI command "viam metadata read".
+func MetadataReadAction(ctx *cli.Context, args metadataReadArgs) error {
+	if args.OrganizationID == "" && args.LocationID == "" && args.MachineID == "" && args.MachinePartID == "" {
+		return errors.New("You must specify at least one of --organization-id, --location-id, --machine-id, --machine-part-id")
+	}
+
+	viamClient, err := newViamClient(ctx)
+	if err != nil {
+		printf(ctx.App.ErrWriter, "error initializing the Viam client: "+err.Error())
+		return err
+	}
+
+	// Organization
+	if args.OrganizationID != "" {
+		err = displayOrganizationMetadata(ctx, viamClient.client, args.OrganizationID)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Location
+	if args.LocationID != "" {
+		err = displayLocationMetadata(ctx, viamClient.client, args.LocationID)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Machine
+	if args.MachineID != "" {
+		err = displayMachineMetadata(ctx, viamClient.client, args.MachineID)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Machine Part
+	if args.MachinePartID != "" {
+		err = displayMachinePartMetadata(ctx, viamClient.client, args.MachinePartID)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func displayOrganizationMetadata(ctx *cli.Context, viamClient apppb.AppServiceClient, organizationID string) error {
+	resp, err := viamClient.GetOrganizationMetadata(ctx.Context, &apppb.GetOrganizationMetadataRequest{
+		OrganizationId: organizationID,
+	})
+	if err != nil {
+		return errors.Wrap(err, "error fetching organization metadata")
+	}
+
+	return displayMetadata(ctx, "organization", organizationID, resp.GetData())
+}
+
+func displayLocationMetadata(ctx *cli.Context, viamClient apppb.AppServiceClient, locationID string) error {
+	resp, err := viamClient.GetLocationMetadata(ctx.Context, &apppb.GetLocationMetadataRequest{
+		LocationId: locationID,
+	})
+	if err != nil {
+		return errors.Wrap(err, "error fetching location metadata")
+	}
+
+	return displayMetadata(ctx, "location", locationID, resp.GetData())
+}
+
+func displayMachineMetadata(ctx *cli.Context, viamClient apppb.AppServiceClient, machineID string) error {
+	resp, err := viamClient.GetRobotMetadata(ctx.Context, &apppb.GetRobotMetadataRequest{
+		Id: machineID,
+	})
+	if err != nil {
+		return errors.Wrap(err, "error fetching machine metadata")
+	}
+
+	return displayMetadata(ctx, "machine", machineID, resp.GetData())
+}
+
+func displayMachinePartMetadata(ctx *cli.Context, viamClient apppb.AppServiceClient, machinePartID string) error {
+	resp, err := viamClient.GetRobotPartMetadata(ctx.Context, &apppb.GetRobotPartMetadataRequest{
+		Id: machinePartID,
+	})
+	if err != nil {
+		return errors.Wrap(err, "error fetching machine part metadata")
+	}
+
+	return displayMetadata(ctx, "machine part", machinePartID, resp.GetData())
+}
+
+func displayMetadata(ctx *cli.Context, metadataType, metadataTypeID string, metadata *structpb.Struct) error {
+	jsonData, err := metadata.MarshalJSON()
+	if err != nil {
+		return errors.Wrap(err, "error formatting metadata into JSON")
+	}
+
+	var prettyJSON bytes.Buffer
+	err = json.Indent(&prettyJSON, jsonData, "", "\t")
+	if err != nil {
+		return errors.Wrap(err, "error formatting metadata into JSON")
+	}
+
+	printf(ctx.App.Writer, "\nMetadata for %s %s:\n", metadataType, metadataTypeID)
+	printf(ctx.App.Writer, prettyJSON.String())
+
+	return nil
+}


### PR DESCRIPTION
https://viam.atlassian.net/browse/APP-7819

# Summary

Provide a way to read organization/location/machine/machine part metadata through the CLI
```
viam metadata read -h
NAME:
   viam metadata read - read metadata attached to your orgs, locations, machines, and/or machine parts

USAGE:
   Provide at least one of the identifiers using CLI arguments to fetch the corresponding metadata

OPTIONS:
   --location-id value      ID of the location you want to read the metadata from
   --machine-id value       ID of the machine you want to read the metadata from
   --machine-part-id value  ID of the machine part you want to read the metadata from
   --organization-id value  ID of the organization you want to read the metadata from
```


# Testing

```
viam metadata read --organization-id <redacted> --location-id <redacted> --machine-id<redacted> --machine-part-id <redacted>

Metadata for organization <redacted>:

{
	"key": "testValue",
	"metadata_type": "organization",
	"other_key": "other_value"
}

Metadata for location 0u9ekd5j4j:

{
	"key": "testValue",
	"metadata_type": "location",
	"other_key": "other_value"
}

Metadata for machine <redacted>:

{
	"key": "testValue",
	"metadata_type": "machine",
	"other_key": "other_value"
}

Metadata for machine part <redacted>:

{
	"key": "testValue",
	"metadata_type": "machine part",
	"other_key": "other_value"
}
```

```
viam metadata read
Error: You must specify at least one of --organization-id, --location-id, --machine-id, --machine-part-id
```

```
viam metadata read --organization-id bad-id
Error: Error fetching organization metadata: rpc error: code = NotFound desc = requestID=<requestID>: no organization with that id
```