### PR TITLE
viam module local-app-testing - Change port number and improve description

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -2552,7 +2552,7 @@ Note: There is no progress meter while copying is in progress.
 			Subcommands: []*cli.Command{
 				{
 					Name:  "local-app-testing",
-					Usage: "Test your viam application locally. This will stand up a local proxy at http://locahost:8012 to simulate the Viam app server",
+					Usage: "Test your viam application locally. This will stand up a local proxy at http://localhost:8012 to simulate the Viam app server",
 					UsageText: createUsageText("module local-app-testing",
 						[]string{"app-url", "machine-id"}, false, false),
 					Flags: []cli.Flag{

--- a/cli/app.go
+++ b/cli/app.go
@@ -2552,7 +2552,7 @@ Note: There is no progress meter while copying is in progress.
 			Subcommands: []*cli.Command{
 				{
 					Name:  "local-app-testing",
-					Usage: "test your viam application locally",
+					Usage: "Test your viam application locally. This will stand up a local proxy at http://locahost:8012 to simulate the Viam app server",
 					UsageText: createUsageText("module local-app-testing",
 						[]string{"app-url", "machine-id"}, false, false),
 					Flags: []cli.Flag{

--- a/cli/module_local_viam_apps_setup.go
+++ b/cli/module_local_viam_apps_setup.go
@@ -35,7 +35,7 @@ type localAppTestingServer struct {
 
 // LocalAppTestingAction is the action for the local-app-testing command.
 func LocalAppTestingAction(ctx *cli.Context, args localAppTestingArgs) error {
-	serverPort := 8000
+	serverPort := 8012
 	viamClient, err := newViamClient(ctx)
 	if err != nil {
 		printf(ctx.App.ErrWriter, "error initializing the Viam client: "+err.Error())


### PR DESCRIPTION
Running the proxy on port 8000 makes conflicts too likely, switching to a less commonly used port 8012.
We have considered adding a CLI arg to specify the port but we are afraid it might be more confusing than helpful

Adding some details to the description

```
viam module local-app-testing -h
NAME:
   viam module local-app-testing - Test your viam application locally. This will stand up a local proxy at http://localhost:8012 to simulate the Viam app server

USAGE:
   viam module local-app-testing --app-url=<app-url> --machine-id=<machine-id>

OPTIONS:
   --app-url value     url where local app is running (including port number), e.g http://localhost:5000
   --machine-id value  machine ID of the machine you want to test with, you can get it at https://app.viam.com/fleet/machines
```