### PR TITLE
APP-8851: Allow all viam supported modules in untrusted environments

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -200,10 +200,10 @@ func (mgr *Manager) Handles() map[string]modlib.HandlerMap {
 	return res
 }
 
-// An allowed list of specific viam namespace modules. We want to allow running some of our official
-// modules even in an untrusted environment.
-var allowedModules = map[string]bool{
-	"viam:raspberry-pi": true,
+// An allowed list of specific namespaces that are allowed to run in an untrusted environment.
+// We want to allow running all of our official modules even in an untrusted environment.
+var allowedModulesNamespaces = map[string]bool{
+	"viam": true,
 }
 
 // Checks if the modules added in an untrusted environment are Viam modules
@@ -212,7 +212,12 @@ func checkIfAllowed(confs ...config.Module) (
 	allowed bool /*false*/, newConfs []config.Module,
 ) {
 	for _, conf := range confs {
-		if ok := allowedModules[conf.ModuleID]; ok {
+		parts := strings.Split(conf.ModuleID, ":")
+		if len(parts) == 0 {
+			continue
+		}
+		namespace := parts[0]
+		if ok := allowedModulesNamespaces[namespace]; ok {
 			allowed = true
 			newConfs = append(newConfs, conf)
 		}

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -1058,7 +1058,7 @@ func TestModuleMisc(t *testing.T) {
 		}
 
 		allowedCfg2 := config.Module{
-			Name:     "test-module",
+			Name:     "test-module-2",
 			ExePath:  modPath,
 			Type:     config.ModuleTypeLocal,
 			ModuleID: "viam:tflite_cpu",
@@ -1068,7 +1068,7 @@ func TestModuleMisc(t *testing.T) {
 		err = mgr.Add(ctx, allowedCfg, allowedCfg2, modCfg)
 		test.That(t, err, test.ShouldBeNil)
 
-		// confirm only the 	spberry-pi and tflite_cpu modules were added
+		// confirm only the raspberry-pi and tflite_cpu modules were added
 		test.That(t, len(mgr.Configs()), test.ShouldEqual, 2)
 		for _, conf := range mgr.Configs() {
 			test.That(t, conf.ModuleID, test.ShouldContainSubstring, "viam")

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -1040,7 +1040,7 @@ func TestModuleMisc(t *testing.T) {
 		test.That(t, modWorkingDirectory, test.ShouldEndWith, filepath.Dir(modPath))
 	})
 
-	t.Run("allowed viam modules only in untrusted environment", func(t *testing.T) {
+	t.Run("only viam namespace is allowed in untrusted environment", func(t *testing.T) {
 		logger := logging.NewTestLogger(t)
 		mgr := setupModManager(t, ctx, parentAddr, logger, modmanageroptions.Options{
 			UntrustedEnv: true,
@@ -1057,14 +1057,22 @@ func TestModuleMisc(t *testing.T) {
 			ModuleID: "viam:raspberry-pi",
 		}
 
+		allowedCfg2 := config.Module{
+			Name:     "test-module",
+			ExePath:  modPath,
+			Type:     config.ModuleTypeLocal,
+			ModuleID: "viam:tflite_cpu",
+		}
+
 		// this currently logs and does not return an error
-		err = mgr.Add(ctx, allowedCfg, modCfg)
+		err = mgr.Add(ctx, allowedCfg, allowedCfg2, modCfg)
 		test.That(t, err, test.ShouldBeNil)
 
-		// confirm only the raspberry-pi module was added
-		test.That(t, len(mgr.Configs()), test.ShouldEqual, 1)
+		// confirm only the 	spberry-pi and tflite_cpu modules were added
+		test.That(t, len(mgr.Configs()), test.ShouldEqual, 2)
 		for _, conf := range mgr.Configs() {
 			test.That(t, conf.ModuleID, test.ShouldContainSubstring, "viam")
+			test.That(t, conf.ModuleID, test.ShouldNotContainSubstring, "testmodule")
 		}
 	})
 }


### PR DESCRIPTION
This PR will allow any viam namespace modules to run on Try rovers. Specifically this fixes the case where the webcamera discovery service cannot be used, but will also fix future cases where we want to allow additional viam supported modules in Try.