### PR TITLE
[RSDK-11351]   Discovering 0 resource configs should not result in error

### DIFF
--- a/services/discovery/client.go
+++ b/services/discovery/client.go
@@ -56,9 +56,6 @@ func (c *client) DiscoverResources(ctx context.Context, extra map[string]any) ([
 		return nil, err
 	}
 	protoConfigs := resp.GetDiscoveries()
-	if protoConfigs == nil {
-		return nil, ErrNilResponse
-	}
 
 	discoveredConfigs := []resource.Config{}
 	for _, proto := range protoConfigs {

--- a/services/discovery/client_test.go
+++ b/services/discovery/client_test.go
@@ -108,7 +108,7 @@ func TestClient(t *testing.T) {
 		test.That(t, conn.Close(), test.ShouldBeNil)
 	})
 
-	t.Run("client tests for failing discovery due to nil response", func(t *testing.T) {
+	t.Run("client tests for nil response", func(t *testing.T) {
 		conn, err := viamgrpc.Dial(context.Background(), listener1.Addr().String(), logger)
 		test.That(t, err, test.ShouldBeNil)
 		failingDiscoveryClient, err := discovery.NewClientFromConn(context.Background(), conn, "", discovery.Named(failDiscoveryName), logger)
@@ -117,9 +117,9 @@ func TestClient(t *testing.T) {
 		failingDiscovery.DiscoverResourcesFunc = func(ctx context.Context, extra map[string]any) ([]resource.Config, error) {
 			return nil, nil
 		}
-		_, err = failingDiscoveryClient.DiscoverResources(context.Background(), nil)
-		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, discovery.ErrNilResponse.Error())
+		resp, err := failingDiscoveryClient.DiscoverResources(context.Background(), nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, resp, test.ShouldBeEmpty)
 
 		test.That(t, failingDiscoveryClient.Close(context.Background()), test.ShouldBeNil)
 		test.That(t, conn.Close(), test.ShouldBeNil)

--- a/services/discovery/discovery.go
+++ b/services/discovery/discovery.go
@@ -6,7 +6,6 @@ package discovery
 
 import (
 	"context"
-	"errors"
 
 	pb "go.viam.com/api/service/discovery/v1"
 
@@ -35,9 +34,6 @@ const (
 
 // API is a variable that identifies the discovery resource API.
 var API = resource.APINamespaceRDK.WithServiceType(SubtypeName)
-
-// ErrNilResponse is the error for when a nil response is returned from a discovery service.
-var ErrNilResponse = errors.New("discovery service returned a nil response")
 
 // Named is a helper for getting the named service's typed resource name.
 func Named(name string) resource.Name {

--- a/services/discovery/server.go
+++ b/services/discovery/server.go
@@ -41,9 +41,6 @@ func (server *serviceServer) DiscoverResources(ctx context.Context, req *pb.Disc
 	if err != nil {
 		return nil, err
 	}
-	if configs == nil {
-		return nil, ErrNilResponse
-	}
 
 	protoConfigs := []*apppb.ComponentConfig{}
 	for _, cfg := range configs {

--- a/services/discovery/server_test.go
+++ b/services/discovery/server_test.go
@@ -128,8 +128,9 @@ func TestDiscoveryServiceServer(t *testing.T) {
 			return nil, nil
 		}
 		resp, err := discoveryServer.DiscoverResources(context.Background(), &pb.DiscoverResourcesRequest{Name: failDiscoveryName})
-		test.That(t, err, test.ShouldEqual, discovery.ErrNilResponse)
-		test.That(t, resp, test.ShouldEqual, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, resp, test.ShouldNotBeNil)
+		test.That(t, resp.GetDiscoveries(), test.ShouldBeEmpty)
 	})
 
 	t.Run("Test DoCommand", func(t *testing.T) {


### PR DESCRIPTION
[RSDK-11351](https://viam.atlassian.net/browse/RSDK-11351)