### PR TITLE
pass a logger to collision constraint functions for better logging

### DIFF
--- a/motionplan/check.go
+++ b/motionplan/check.go
@@ -48,12 +48,13 @@ func CheckPlan(
 	// This should be done for any plan whose configurations are specified in relative terms rather than absolute ones.
 	// Currently this is only TP-space, so we check if the PTG length is >0.
 	if motionChains.useTPspace {
-		return checkPlanRelative(checkFrame, executionState, worldState, fs, lookAheadDistanceMM)
+		return checkPlanRelative(logger, checkFrame, executionState, worldState, fs, lookAheadDistanceMM)
 	}
-	return checkPlanAbsolute(checkFrame, executionState, worldState, fs, lookAheadDistanceMM)
+	return checkPlanAbsolute(logger, checkFrame, executionState, worldState, fs, lookAheadDistanceMM)
 }
 
 func checkPlanRelative(
+	logger logging.Logger,
 	checkFrame referenceframe.Frame, // TODO(RSDK-7421): remove this
 	executionState ExecutionState,
 	worldState *referenceframe.WorldState,
@@ -93,6 +94,7 @@ func checkPlanRelative(
 
 	constraintHandler, err := newConstraintHandler(
 		planOpts,
+		logger,
 		nil,
 		&PlanState{poses: plan.Path()[0], configuration: plan.Trajectory()[0]},
 		&PlanState{poses: plan.Path()[len(plan.Path())-1]},
@@ -194,6 +196,7 @@ func checkPlanRelative(
 }
 
 func checkPlanAbsolute(
+	logger logging.Logger,
 	checkFrame referenceframe.Frame, // TODO(RSDK-7421): remove this
 	executionState ExecutionState,
 	worldState *referenceframe.WorldState,
@@ -239,6 +242,7 @@ func checkPlanAbsolute(
 
 	constraintHandler, err := newConstraintHandler(
 		planOpts,
+		logger,
 		nil,
 		&PlanState{poses: executionState.CurrentPoses(), configuration: startingInputs},
 		&PlanState{poses: poses[len(poses)-1]},

--- a/motionplan/constraint.go
+++ b/motionplan/constraint.go
@@ -112,7 +112,7 @@ func createAllCollisionConstraints(
 
 	if len(worldGeometries) > 0 {
 		// create constraint to keep moving geometries from hitting world state obstacles
-		obstacleConstraint, err := newCollisionConstraint(
+		obstacleConstraint, err := NewCollisionConstraint(
 			movingRobotGeometries,
 			worldGeometries,
 			allowedCollisions,
@@ -124,7 +124,7 @@ func createAllCollisionConstraints(
 			return nil, nil, err
 		}
 		// create constraint to keep moving geometries from hitting world state obstacles
-		obstacleConstraintFS, err := newCollisionConstraintFS(
+		obstacleConstraintFS, err := NewCollisionConstraintFS(
 			movingRobotGeometries,
 			worldGeometries,
 			allowedCollisions,
@@ -148,7 +148,7 @@ func createAllCollisionConstraints(
 
 	if len(staticRobotGeometries) > 0 {
 		// create constraint to keep moving geometries from hitting other geometries on robot that are not moving
-		robotConstraint, err := newCollisionConstraint(
+		robotConstraint, err := NewCollisionConstraint(
 			movingRobotGeometries,
 			staticRobotGeometries,
 			allowedCollisions,
@@ -159,7 +159,7 @@ func createAllCollisionConstraints(
 		if err != nil {
 			return nil, nil, err
 		}
-		robotConstraintFS, err := newCollisionConstraintFS(
+		robotConstraintFS, err := NewCollisionConstraintFS(
 			movingRobotGeometries,
 			staticRobotGeometries,
 			allowedCollisions,
@@ -176,7 +176,7 @@ func createAllCollisionConstraints(
 
 	// create constraint to keep moving geometries from hitting themselves
 	if len(movingRobotGeometries) > 1 {
-		selfCollisionConstraint, err := newCollisionConstraint(
+		selfCollisionConstraint, err := NewCollisionConstraint(
 			movingRobotGeometries,
 			nil,
 			allowedCollisions,
@@ -188,7 +188,7 @@ func createAllCollisionConstraints(
 			return nil, nil, err
 		}
 		constraintMap[selfCollisionConstraintDescription] = selfCollisionConstraint
-		selfCollisionConstraintFS, err := newCollisionConstraintFS(
+		selfCollisionConstraintFS, err := NewCollisionConstraintFS(
 			movingRobotGeometries,
 			nil,
 			allowedCollisions,
@@ -221,11 +221,11 @@ func setupZeroCG(
 	return zeroCG, nil
 }
 
-// newCollisionConstraint is the most general method to create a collision constraint, which will be violated if geometries constituting
+// NewCollisionConstraint is the most general method to create a collision constraint, which will be violated if geometries constituting
 // the given frame ever come into collision with obstacle geometries outside of the collisions present for the observationInput.
 // Collisions specified as collisionSpecifications will also be ignored
 // if reportDistances is false, this check will be done as fast as possible, if true maximum information will be available for debugging.
-func newCollisionConstraint(
+func NewCollisionConstraint(
 	moving, static []spatial.Geometry,
 	collisionSpecifications []*Collision,
 	reportDistances bool,
@@ -284,11 +284,11 @@ func newCollisionConstraint(
 	return constraint, nil
 }
 
-// newCollisionConstraintFS is the most general method to create a collision constraint for a frame system,
+// NewCollisionConstraintFS is the most general method to create a collision constraint for a frame system,
 // which will be violated if geometries constituting the given frame ever come into collision with obstacle geometries
 // outside of the collisions present for the observationInput. Collisions specified as collisionSpecifications will also be ignored.
 // If reportDistances is false, this check will be done as fast as possible, if true maximum information will be available for debugging.
-func newCollisionConstraintFS(
+func NewCollisionConstraintFS(
 	moving, static []spatial.Geometry,
 	collisionSpecifications []*Collision,
 	reportDistances bool,

--- a/motionplan/constraint_handler.go
+++ b/motionplan/constraint_handler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/motionplan/ik"
 	"go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/referenceframe"
@@ -33,6 +34,7 @@ func newEmptyConstraintHandler() *ConstraintHandler {
 
 func newConstraintHandler(
 	opt *PlannerOptions,
+	logger logging.Logger,
 	constraints *Constraints,
 	from, to *PlanState,
 	fs *referenceframe.FrameSystem,
@@ -119,6 +121,7 @@ func newConstraintHandler(
 		boundingRegions,
 		allowedCollisions,
 		opt.CollisionBufferMM,
+		logger,
 	)
 	if err != nil {
 		return nil, err

--- a/motionplan/constraint_test.go
+++ b/motionplan/constraint_test.go
@@ -245,6 +245,7 @@ func TestCollisionConstraints(t *testing.T) {
 		worldGeometries.Geometries(),
 		nil, nil,
 		defaultCollisionBufferMM,
+		logger,
 	)
 	test.That(t, err, test.ShouldBeNil)
 	for name, constraint := range collisionConstraints {
@@ -309,6 +310,7 @@ func BenchmarkCollisionConstraints(b *testing.B) {
 		worldGeometries.Geometries(),
 		nil, nil,
 		defaultCollisionBufferMM,
+		logger,
 	)
 	test.That(b, err, test.ShouldBeNil)
 	for name, constraint := range collisionConstraints {

--- a/motionplan/motionPlanner.go
+++ b/motionplan/motionPlanner.go
@@ -325,6 +325,7 @@ func newPlannerFromPlanRequest(logger logging.Logger, request *PlanRequest) (*pl
 
 	constraintHandler, err := newConstraintHandler(
 		opt,
+		logger,
 		request.Constraints,
 		request.StartState,
 		request.Goals[0],

--- a/motionplan/motionPlanner_test.go
+++ b/motionplan/motionPlanner_test.go
@@ -279,6 +279,7 @@ func simple2DMap() (*planConfig, error) {
 		worldGeometries.Geometries(),
 		nil, nil,
 		defaultCollisionBufferMM,
+		logger,
 	)
 	if err != nil {
 		return nil, err
@@ -348,6 +349,7 @@ func simpleXArmMotion() (*planConfig, error) {
 		nil,
 		nil,
 		defaultCollisionBufferMM,
+		logger,
 	)
 	if err != nil {
 		return nil, err
@@ -422,6 +424,7 @@ func simpleUR5eMotion() (*planConfig, error) {
 		nil,
 		nil,
 		defaultCollisionBufferMM,
+		logger,
 	)
 	if err != nil {
 		return nil, err

--- a/motionplan/planManager.go
+++ b/motionplan/planManager.go
@@ -474,6 +474,7 @@ func (pm *planManager) generateWaypoints(seedPlan Plan, wpi int) ([]atomicWaypoi
 
 	constraintHandler, err := newConstraintHandler(
 		opt,
+		pm.logger,
 		pm.request.Constraints,
 		startState,
 		wpGoals,
@@ -508,6 +509,7 @@ func (pm *planManager) generateWaypoints(seedPlan Plan, wpi int) ([]atomicWaypoi
 
 		constraintHandler, err = newConstraintHandler(
 			opt,
+			pm.logger,
 			pm.request.Constraints,
 			startState,
 			wpGoals,
@@ -587,6 +589,7 @@ func (pm *planManager) generateWaypoints(seedPlan Plan, wpi int) ([]atomicWaypoi
 
 		wpConstraintHandler, err := newConstraintHandler(
 			wpOpt,
+			pm.logger,
 			pm.request.Constraints,
 			from,
 			to,

--- a/motionplan/tpSpaceRRT_test.go
+++ b/motionplan/tpSpaceRRT_test.go
@@ -150,6 +150,7 @@ func TestPtgWithObstacle(t *testing.T) {
 		worldGeometries.Geometries(),
 		nil, nil,
 		defaultCollisionBufferMM,
+		logger,
 	)
 	test.That(t, err, test.ShouldBeNil)
 


### PR DESCRIPTION
Logs right now are noisy because a Global logger is being used.  This does the more correct thing of passing the logger down several levels so that it ultimately inherits the logger from motion-builtin