### PR TITLE
[RSDK-11421] Use our own fork of appimage-builder in workflows

### DIFF
--- a/.canon.yaml
+++ b/.canon.yaml
@@ -4,7 +4,7 @@ viam-rdk:
     image_amd64: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
     image_arm64: ghcr.io/viamrobotics/rdk-devenv:arm64-cache
     image_arm: ghcr.io/viamrobotics/rdk-devenv:armhf-cache
-    minimum_date: 2023-10-26T20:00:00.0Z
+    minimum_date: 2025-07-22T06:00:00.0Z
     update_interval: 168h0m0s
     user: testbot
     group: testbot
@@ -14,7 +14,7 @@ viam-rdk-antique:
     image_amd64: ghcr.io/viamrobotics/antique2:amd64-cache
     image_arm64: ghcr.io/viamrobotics/antique2:arm64-cache
     image_arm: ghcr.io/viamrobotics/antique2:armhf-cache
-    minimum_date: 2023-10-26T20:00:00.0Z
+    minimum_date: 2025-07-22T06:00:00.0Z
     update_interval: 168h0m0s
     user: testbot
     group: testbot

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -149,7 +149,7 @@ jobs:
       with:
         python-version: '3.11'
     - name: deps
-      run: pip install git+https://github.com/AppImageCrafters/appimage-builder.git@42d32f11496de43a9f6a9ada7882a11296e357ca
+      run: pip install git+https://github.com/viamrobotics/appimage-builder.git@viam-2025-07-22
     - name: build
       env:
         RELEASE_TYPE: ${{ inputs.release_type }}


### PR DESCRIPTION
Per the linked issue, we've had to fork and update appimage-builder. Mostly this meant rebuilding the docker images used in CI, but one workflow directly installs it, so this updates that. It also updates the minimum date field for canon.