### PR TITLE
RSDK-8923 - hot reload across platform (golang)

### DIFF
--- a/cli/module_generate/_templates/go/tmpl-Makefile
+++ b/cli/module_generate/_templates/go/tmpl-Makefile
@@ -10,7 +10,7 @@ ifeq ($(VIAM_TARGET_OS), windows)
 endif
 
 $(MODULE_BINARY): Makefile go.mod *.go cmd/module/*.go 
-	$(GO_BUILD_ENV) go build $(GO_BUILD_FLAGS) -o $(MODULE_BINARY) cmd/module/main.go
+	GOOS=$(VIAM_BUILD_OS) GOARCH=$(VIAM_BUILD_ARCH) $(GO_BUILD_ENV) go build $(GO_BUILD_FLAGS) -o $(MODULE_BINARY) cmd/module/main.go
 
 lint:
 	gofmt -s -w .


### PR DESCRIPTION
Adds the ability to hot reload golang modules across platforms. Additional work is underway to address the `not included yet` section, but wanted to lock this in now.

**Testing**
* Ran two go modules on linux (one with cloud build, one without), successfully hot reloaded both from dev work done on a mac.
* Successfully hot swapped a module running on a mac from another mac

**Not included yet**
* No changes to CLI options yet
* No python support for cross platform reloads yet
* Default `home` value (meaning that manually passing `home` will be possible for swapping on a mac unless `viam-server` is being run as root)
* No support for `VIAM_RELOAD` env var yet