### PR TITLE
RSDK-11245 FTDC Windows System metrics

### DIFF
--- a/ftdc/sys/net.go
+++ b/ftdc/sys/net.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 package sys
 
 import (
@@ -18,30 +20,6 @@ func NewNetUsage() (*netStatser, error) {
 	}
 
 	return &netStatser{fs}, nil
-}
-
-type netDevLine struct {
-	RxBytes   uint64
-	RxPackets uint64
-	RxErrors  uint64
-	RxDropped uint64
-	TxBytes   uint64
-	TxPackets uint64
-	TxErrors  uint64
-	TxDropped uint64
-}
-
-type ifaceStats struct {
-	TxQueueLength uint64
-	RxQueueLength uint64
-	UsedSockets   uint64
-	Drops         uint64
-}
-
-type networkStats struct {
-	Ifaces map[string]netDevLine
-	TCP    ifaceStats
-	UDP    ifaceStats
 }
 
 func (netStatser *netStatser) Stats() any {

--- a/ftdc/sys/net_windows.go
+++ b/ftdc/sys/net_windows.go
@@ -1,0 +1,173 @@
+//go:build windows
+
+package sys
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+type netStatser struct {
+	iphlpapi *windows.LazyDLL
+}
+
+// NewNetUsage returns an object that can interpreted as an `ftdc.Statser`.
+func NewNetUsage() (*netStatser, error) {
+	return &netStatser{
+		iphlpapi: windows.NewLazySystemDLL("iphlpapi.dll"),
+	}, nil
+}
+
+// MIB_IFROW structure for GetIfTable
+type mibIfRow struct {
+	Name            [256]uint16
+	Index           uint32
+	Type            uint32
+	Mtu             uint32
+	Speed           uint32
+	PhysAddrLen     uint32
+	PhysAddr        [8]byte
+	AdminStatus     uint32
+	OperStatus      uint32
+	LastChange      uint32
+	InOctets        uint32
+	InUcastPkts     uint32
+	InNUcastPkts    uint32
+	InDiscards      uint32
+	InErrors        uint32
+	InUnknownProtos uint32
+	OutOctets       uint32
+	OutUcastPkts    uint32
+	OutNUcastPkts   uint32
+	OutDiscards     uint32
+	OutErrors       uint32
+	OutQLen         uint32
+	DescrLen        uint32
+	Descr           [256]byte
+}
+
+// TCP connection stats from GetTcpStatistics
+type mibTcpStats struct {
+	RtoAlgorithm uint32
+	RtoMin       uint32
+	RtoMax       uint32
+	MaxConn      uint32
+	ActiveOpens  uint32
+	PassiveOpens uint32
+	AttemptFails uint32
+	EstabResets  uint32
+	CurrEstab    uint32
+	InSegs       uint32
+	OutSegs      uint32
+	RetransSegs  uint32
+	InErrs       uint32
+	OutRsts      uint32
+}
+
+// UDP stats from GetUdpStatistics
+type mibUdpStats struct {
+	InDatagrams  uint32
+	NoPorts      uint32
+	InErrors     uint32
+	OutDatagrams uint32
+	NumAddrs     uint32
+}
+
+func (n *netStatser) Stats() any {
+	ret := networkStats{
+		Ifaces: make(map[string]netDevLine),
+	}
+
+	// Get network interface statistics using GetIfTable
+	n.getInterfaceStats(&ret)
+
+	// Get TCP statistics
+	n.getTCPStats(&ret)
+
+	// Get UDP statistics
+	n.getUDPStats(&ret)
+
+	return ret
+}
+
+func (n *netStatser) getInterfaceStats(ret *networkStats) {
+	getIfTable := n.iphlpapi.NewProc("GetIfTable")
+
+	var size uint32
+	// First call to get required buffer size
+	getIfTable.Call(0, uintptr(unsafe.Pointer(&size)), 0)
+
+	if size == 0 {
+		return
+	}
+
+	buffer := make([]byte, size)
+	r1, _, _ := getIfTable.Call(
+		uintptr(unsafe.Pointer(&buffer[0])),
+		uintptr(unsafe.Pointer(&size)),
+		0,
+	)
+
+	if r1 != 0 { // NO_ERROR is 0
+		return
+	}
+
+	// Parse the MIB_IFTABLE structure
+	numEntries := *(*uint32)(unsafe.Pointer(&buffer[0]))
+	offset := unsafe.Sizeof(uint32(0))
+
+	for i := uint32(0); i < numEntries; i++ {
+		row := (*mibIfRow)(unsafe.Pointer(&buffer[offset]))
+
+		// Convert interface name from UTF-16
+		name := windows.UTF16ToString(row.Name[:])
+		if name == "" {
+			// Fallback to description if name is empty
+			name = string(row.Descr[:row.DescrLen])
+		}
+
+		ret.Ifaces[name] = netDevLine{
+			RxBytes:   uint64(row.InOctets),
+			RxPackets: uint64(row.InUcastPkts + row.InNUcastPkts),
+			RxErrors:  uint64(row.InErrors),
+			RxDropped: uint64(row.InDiscards),
+			TxBytes:   uint64(row.OutOctets),
+			TxPackets: uint64(row.OutUcastPkts + row.OutNUcastPkts),
+			TxErrors:  uint64(row.OutErrors),
+			TxDropped: uint64(row.OutDiscards),
+		}
+
+		offset += unsafe.Sizeof(mibIfRow{})
+	}
+}
+
+func (n *netStatser) getTCPStats(ret *networkStats) {
+	getTcpStatistics := n.iphlpapi.NewProc("GetTcpStatistics")
+
+	var stats mibTcpStats
+	r1, _, _ := getTcpStatistics.Call(uintptr(unsafe.Pointer(&stats)))
+
+	if r1 == 0 { // NO_ERROR
+		ret.TCP.UsedSockets = uint64(stats.CurrEstab)
+		// Windows doesn't directly expose TX/RX queue lengths like Linux /proc
+		// These values would need additional API calls to GetTcpTable for per-connection data
+		ret.TCP.TxQueueLength = 0 // Not directly available
+		ret.TCP.RxQueueLength = 0 // Not directly available
+	}
+}
+
+func (n *netStatser) getUDPStats(ret *networkStats) {
+	getUdpStatistics := n.iphlpapi.NewProc("GetUdpStatistics")
+
+	var stats mibUdpStats
+	r1, _, _ := getUdpStatistics.Call(uintptr(unsafe.Pointer(&stats)))
+
+	if r1 == 0 { // NO_ERROR
+		ret.UDP.UsedSockets = uint64(stats.NumAddrs)
+		ret.UDP.Drops = uint64(stats.InErrors)
+		// Windows doesn't directly expose TX/RX queue lengths like Linux /proc
+		ret.UDP.TxQueueLength = 0 // Not directly available
+		ret.UDP.RxQueueLength = 0 // Not directly available
+	}
+}

--- a/ftdc/sys/sys.go
+++ b/ftdc/sys/sys.go
@@ -1,4 +1,5 @@
-// Package sys provides functionality for gathering system metrics in an FTDC compliant API.
+//go:build unix
+
 package sys
 
 import (
@@ -55,14 +56,6 @@ func NewPidSysUsageStatser(pid int) (*UsageStatser, error) {
 	}
 
 	return &UsageStatser{process}, nil
-}
-
-type stats struct {
-	UserCPUSecs     float64
-	SystemCPUSecs   float64
-	ElapsedTimeSecs float64
-	VssMB           float64
-	RssMB           float64
 }
 
 // Stats returns Stats.

--- a/ftdc/sys/sys_common.go
+++ b/ftdc/sys/sys_common.go
@@ -1,8 +1,6 @@
 // Package sys provides functionality for gathering system metrics in an FTDC compliant API.
 package sys
 
-// Common types and interfaces shared between Unix and Windows implementations
-
 type stats struct {
 	UserCPUSecs     float64
 	SystemCPUSecs   float64

--- a/ftdc/sys/sys_common.go
+++ b/ftdc/sys/sys_common.go
@@ -1,0 +1,41 @@
+// Package sys provides functionality for gathering system metrics in an FTDC compliant API.
+package sys
+
+// Common types and interfaces shared between Unix and Windows implementations
+
+type stats struct {
+	UserCPUSecs     float64
+	SystemCPUSecs   float64
+	ElapsedTimeSecs float64
+	VssMB           float64
+	RssMB           float64
+}
+
+type netDevLine struct {
+	RxBytes   uint64
+	RxPackets uint64
+	RxErrors  uint64
+	RxDropped uint64
+	TxBytes   uint64
+	TxPackets uint64
+	TxErrors  uint64
+	TxDropped uint64
+}
+
+type ifaceStats struct {
+	TxQueueLength uint64
+	RxQueueLength uint64
+	UsedSockets   uint64
+	Drops         uint64
+}
+
+type networkStats struct {
+	Ifaces map[string]netDevLine
+	TCP    ifaceStats
+	UDP    ifaceStats
+}
+
+// Statser interface for process usage statistics
+type Statser interface {
+	Stats() any
+}

--- a/ftdc/sys/sys_windows.go
+++ b/ftdc/sys/sys_windows.go
@@ -1,0 +1,85 @@
+//go:build windows
+
+package sys
+
+import (
+	"os"
+	"time"
+
+	"github.com/shirou/gopsutil/v3/host"
+	"github.com/shirou/gopsutil/v3/process"
+)
+
+var (
+	osPageSize                    int
+	machineBootTimeSecsSinceEpoch float64
+)
+
+func init() {
+	osPageSize = os.Getpagesize()
+
+	// Get boot time using gopsutil
+	bootTime, err := host.BootTime()
+	if err != nil {
+		// Fallback - could also use WMI or other methods
+		machineBootTimeSecsSinceEpoch = 0
+	} else {
+		machineBootTimeSecsSinceEpoch = float64(bootTime)
+	}
+}
+
+// UsageStatser can be used to get system metrics for a process.
+type UsageStatser struct {
+	proc *process.Process
+}
+
+// NewSelfSysUsageStatser will return a `SysUsageStatser` for the current process.
+func NewSelfSysUsageStatser() (*UsageStatser, error) {
+	pid := int32(os.Getpid())
+	proc, err := process.NewProcess(pid)
+	if err != nil {
+		return nil, err
+	}
+	return &UsageStatser{proc}, nil
+}
+
+// NewPidSysUsageStatser will return a `SysUsageStatser` for the given process id.
+func NewPidSysUsageStatser(pid int) (*UsageStatser, error) {
+	proc, err := process.NewProcess(int32(pid))
+	if err != nil {
+		return nil, err
+	}
+	return &UsageStatser{proc}, nil
+}
+
+// Stats returns Stats.
+func (sys *UsageStatser) Stats() any {
+	// Get CPU times
+	cpuTimes, err := sys.proc.Times()
+	if err != nil {
+		return stats{}
+	}
+
+	// Get memory info
+	memInfo, err := sys.proc.MemoryInfo()
+	if err != nil {
+		return stats{}
+	}
+
+	// Get process creation time
+	createTime, err := sys.proc.CreateTime()
+	if err != nil {
+		return stats{}
+	}
+
+	// Calculate elapsed time
+	elapsedTimeSecs := float64(time.Now().UnixMilli()-createTime) / 1000.0
+
+	return stats{
+		UserCPUSecs:     cpuTimes.User,   // Already in seconds
+		SystemCPUSecs:   cpuTimes.System, // Already in seconds
+		ElapsedTimeSecs: elapsedTimeSecs,
+		VssMB:           float64(memInfo.VMS) / 1_000_000.0, // Virtual memory
+		RssMB:           float64(memInfo.RSS) / 1_000_000.0, // Resident memory
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	github.com/rhysd/actionlint v1.6.24
 	github.com/rs/cors v1.11.1
 	github.com/sergi/go-diff v1.3.1
+	github.com/shirou/gopsutil/v3 v3.24.5
 	github.com/spf13/cast v1.5.0
 	github.com/u2takey/ffmpeg-go v0.4.1
 	github.com/urfave/cli/v2 v2.10.3
@@ -222,6 +223,7 @@ require (
 	github.com/go-latex/latex v0.0.0-20230307184459-12ec69307ad9 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-pdf/fpdf v0.6.0 // indirect
 	github.com/go-toolsmith/astcast v1.1.0 // indirect
 	github.com/go-toolsmith/astcopy v1.1.0 // indirect
@@ -293,6 +295,7 @@ require (
 	github.com/lestrrat-go/option v1.0.1 // indirect
 	github.com/lib/pq v1.10.9 // indirect
 	github.com/lufeee/execinquery v1.2.1 // indirect
+	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/macabu/inamedparam v0.1.3 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/maratori/testableexamples v1.0.0 // indirect
@@ -343,6 +346,7 @@ require (
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/polyfloyd/go-errorlint v1.6.0 // indirect
+	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.64.0 // indirect
@@ -364,6 +368,7 @@ require (
 	github.com/sashamelentyev/usestdlibvars v1.27.0 // indirect
 	github.com/securego/gosec/v2 v2.21.2 // indirect
 	github.com/shazow/go-diff v0.0.0-20160112020656-b6b7b6733b8c // indirect
+	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/sivchari/containedctx v1.0.3 // indirect
 	github.com/sivchari/tenv v1.10.0 // indirect
@@ -386,6 +391,8 @@ require (
 	github.com/tetafro/godot v1.4.17 // indirect
 	github.com/timakin/bodyclose v0.0.0-20230421092635-574207250966 // indirect
 	github.com/timonwong/loggercheck v0.9.4 // indirect
+	github.com/tklauser/go-sysconf v0.3.12 // indirect
+	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/tomarrell/wrapcheck/v2 v2.9.0 // indirect
 	github.com/tommy-muehle/go-mnd/v2 v2.5.1 // indirect
 	github.com/u2takey/go-utils v0.3.1 // indirect
@@ -406,6 +413,7 @@ require (
 	github.com/yeya24/promlinter v0.3.0 // indirect
 	github.com/ykadowak/zerologlint v0.1.5 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
+	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	github.com/zeebo/errs v1.4.0 // indirect
 	github.com/zitadel/oidc/v3 v3.37.0 // indirect
 	github.com/zitadel/schema v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1262,8 +1262,11 @@ github.com/shirou/gopsutil/v3 v3.24.5 h1:i0t8kL+kQTvpAYToeuiVk3TgDeKOFioZO3Ztz/i
 github.com/shirou/gopsutil/v3 v3.24.5/go.mod h1:bsoOS1aStSs9ErQ1WWfxllSeS1K5D+U30r2NfcubMVk=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
 github.com/shoenig/go-m1cpu v0.1.6/go.mod h1:1JJMcUBvfNwpq05QDQVAnx3gUHr9IYF7GNg9SUEw2VQ=
+<<<<<<< HEAD
 github.com/shoenig/test v0.6.4 h1:kVTaSd7WLz5WZ2IaoM0RSzRsUD+m8wRR+5qvntpn4LU=
 github.com/shoenig/test v0.6.4/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnjqq0k=
+=======
+>>>>>>> 5b171ed2b (dependancy fix)
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=

--- a/go.sum
+++ b/go.sum
@@ -1262,11 +1262,8 @@ github.com/shirou/gopsutil/v3 v3.24.5 h1:i0t8kL+kQTvpAYToeuiVk3TgDeKOFioZO3Ztz/i
 github.com/shirou/gopsutil/v3 v3.24.5/go.mod h1:bsoOS1aStSs9ErQ1WWfxllSeS1K5D+U30r2NfcubMVk=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
 github.com/shoenig/go-m1cpu v0.1.6/go.mod h1:1JJMcUBvfNwpq05QDQVAnx3gUHr9IYF7GNg9SUEw2VQ=
-<<<<<<< HEAD
 github.com/shoenig/test v0.6.4 h1:kVTaSd7WLz5WZ2IaoM0RSzRsUD+m8wRR+5qvntpn4LU=
 github.com/shoenig/test v0.6.4/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnjqq0k=
-=======
->>>>>>> 5b171ed2b (dependancy fix)
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=

--- a/go.sum
+++ b/go.sum
@@ -468,6 +468,8 @@ github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre
 github.com/go-nlopt/nlopt v0.0.0-20230219125344-443d3362dcb5 h1:JlR5qQ/dy4NPpeKld/CJR6cIcL0ll4OQ7ieylY5kJ20=
 github.com/go-nlopt/nlopt v0.0.0-20230219125344-443d3362dcb5/go.mod h1:crLzNxWuUkZODn9zme0coCcBvPQrM3hnbQWR3uolF8o=
 github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
+github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
+github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-pdf/fpdf v0.6.0 h1:MlgtGIfsdMEEQJr2le6b/HNr1ZlQwxyWr77r2aj2U/8=
 github.com/go-pdf/fpdf v0.6.0/go.mod h1:HzcnA+A23uwogo0tp9yU+l3V+KXhiESpt1PMayhOh5M=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
@@ -890,6 +892,8 @@ github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lufeee/execinquery v1.2.1 h1:hf0Ems4SHcUGBxpGN7Jz78z1ppVkP/837ZlETPCEtOM=
 github.com/lufeee/execinquery v1.2.1/go.mod h1:EC7DrEKView09ocscGHC+apXMIaorh4xqSxS/dy8SbM=
+github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
+github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/lyft/protoc-gen-star v0.5.3/go.mod h1:V0xaHgaf5oCCqmcxYcWiDfTiKsZsRc87/1qhoTACD8w=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
 github.com/macabu/inamedparam v0.1.3 h1:2tk/phHkMlEL/1GNe/Yf6kkR/hkcUdAEY3L0hjYV1Mk=
@@ -1147,6 +1151,8 @@ github.com/polyfloyd/go-errorlint v0.0.0-20201127212506-19bd8db6546f/go.mod h1:w
 github.com/polyfloyd/go-errorlint v1.6.0 h1:tftWV9DE7txiFzPpztTAwyoRLKNj9gpVm2cg8/OwcYY=
 github.com/polyfloyd/go-errorlint v1.6.0/go.mod h1:HR7u8wuP1kb1NeN1zqTd1ZMlqUKPPHF+Id4vIPvDqVw=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
+github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
+github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -1252,6 +1258,12 @@ github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NF
 github.com/shazow/go-diff v0.0.0-20160112020656-b6b7b6733b8c h1:W65qqJCIOVP4jpqPQ0YvHYKwcMEMVWIzWC5iNQQfBTU=
 github.com/shazow/go-diff v0.0.0-20160112020656-b6b7b6733b8c/go.mod h1:/PevMnwAxekIXwN8qQyfc5gl2NlkB3CQlkizAbOkeBs=
 github.com/shirou/gopsutil/v3 v3.21.1/go.mod h1:igHnfak0qnw1biGeI2qKQvu0ZkwvEkUcCLlYhZzdr/4=
+github.com/shirou/gopsutil/v3 v3.24.5 h1:i0t8kL+kQTvpAYToeuiVk3TgDeKOFioZO3Ztz/iZ9pI=
+github.com/shirou/gopsutil/v3 v3.24.5/go.mod h1:bsoOS1aStSs9ErQ1WWfxllSeS1K5D+U30r2NfcubMVk=
+github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
+github.com/shoenig/go-m1cpu v0.1.6/go.mod h1:1JJMcUBvfNwpq05QDQVAnx3gUHr9IYF7GNg9SUEw2VQ=
+github.com/shoenig/test v0.6.4 h1:kVTaSd7WLz5WZ2IaoM0RSzRsUD+m8wRR+5qvntpn4LU=
+github.com/shoenig/test v0.6.4/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnjqq0k=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
@@ -1357,6 +1369,10 @@ github.com/timakin/bodyclose v0.0.0-20230421092635-574207250966 h1:quvGphlmUVU+n
 github.com/timakin/bodyclose v0.0.0-20230421092635-574207250966/go.mod h1:27bSVNWSBOHm+qRp1T9qzaIpsWEP6TbUnei/43HK+PQ=
 github.com/timonwong/loggercheck v0.9.4 h1:HKKhqrjcVj8sxL7K77beXh0adEm6DLjV/QOGeMXEVi4=
 github.com/timonwong/loggercheck v0.9.4/go.mod h1:caz4zlPcgvpEkXgVnAJGowHAMW2NwHaNlpS8xDbVhTg=
+github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
+github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
+github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=
+github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tomarrell/wrapcheck v0.0.0-20201130113247-1683564d9756/go.mod h1:yiFB6fFoV7saXirUGfuK+cPtUh4NX/Hf5y2WC2lehu0=
@@ -1439,6 +1455,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
+github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zeebo/errs v1.4.0 h1:XNdoD/RRMKP7HD0UhJnIzUy74ISdGGxURlYG8HSWSfM=
 github.com/zeebo/errs v1.4.0/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtCw4=
 github.com/zhuyie/golzf v0.0.0-20161112031142-8387b0307ade h1:bafvQukPrIYwYWcft4rl3WpHo3qO0/voaAgnCwgdhi0=
@@ -1704,6 +1722,7 @@ golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190913121621-c3b328c6e5a7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1729,6 +1748,7 @@ golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201024232916-9f70ab9862d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210303074136-134d130e1a04/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -6,7 +6,6 @@ package robotimpl
 
 import (
 	"context"
-	"runtime"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -379,16 +378,14 @@ func newWithResources(
 		ftdcDir := ftdc.DefaultDirectory(utils.ViamDotDir, partID)
 		ftdcLogger := logger.Sublogger("ftdc")
 		ftdcWorker = ftdc.NewWithUploader(ftdcDir, conn, partID, ftdcLogger)
-		if runtime.GOOS == "windows" {
-			// note: this logs a panic on RDK start on windows.
-			ftdcLogger.Debug("System level FTDC not implemented on windows, not starting CPU and network metrics")
-		} else {
-			if statser, err := sys.NewSelfSysUsageStatser(); err == nil {
-				ftdcWorker.Add("proc.viam-server", statser)
-			}
-			if statser, err := sys.NewNetUsage(); err == nil {
-				ftdcWorker.Add("net", statser)
-			}
+		if statser, err := sys.NewSelfSysUsageStatser(); err == nil {
+			ftdcWorker.Add("proc.viam-server", statser)
+		}
+		if statser, err := sys.NewNetUsage(); err == nil {
+			ftdcWorker.Add("net", statser)
+		}
+		if statser, err := sys.NewNetUsage(); err == nil {
+			ftdcWorker.Add("net", statser)
 		}
 	}
 

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -384,9 +384,6 @@ func newWithResources(
 		if statser, err := sys.NewNetUsage(); err == nil {
 			ftdcWorker.Add("net", statser)
 		}
-		if statser, err := sys.NewNetUsage(); err == nil {
-			ftdcWorker.Add("net", statser)
-		}
 	}
 
 	closeCtx, cancel := context.WithCancel(ctx)


### PR DESCRIPTION
As the second part of the [ticket](https://viam.atlassian.net/jira/software/c/projects/RSDK/boards/69?assignee=712020%3A41710d7e-57d4-4faa-993a-66e0e9f5b64b&selectedIssue=RSDK-11245), introducing an attempt to log system metrics on Windows machines. 

Things to note: 
- Unix and Windows versions are separated by using `//go:build` constraints, though it is worth noting that `unix` includes `darwin` (MacOS), but `darwin` does not have `/proc` files, so it will not work on Macs. 
- The library `gopsutil/v3` seem to have support for ANY architecture, not just Windows. We can look into making a unified `sys.go` file that would work for for any OS, but I did not want to remove any existing code for now. 
- The net side is quite different, and I have not found a package that would be able to support multiple OSs. The windows side is a lot more verbose, but I believe that it's getting to the information that the linux side is currently getting. 
- Windows provides RSS memory in bytes right away, so there is no need to compute osPageSize. Unless there is another reason to keep it, happy to remove it from the windows file. 

I will do a final test of this code once the CI finishes the windows build and viam-server can measure some metrics. 