### PR TITLE
RSDK-11281: Log when dependency name is not found

### DIFF
--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -658,7 +658,7 @@ func (r *localRobot) getDependencies(
 	gNode *resource.GraphNode,
 ) (resource.Dependencies, error) {
 	if deps := gNode.UnresolvedDependencies(); len(deps) != 0 {
-		return nil, errors.Errorf("resource has unresolved dependencies: %v", deps)
+		return nil, errors.Errorf("resource has unresolved dependencies not found in machine config or connected remotes: %v", deps)
 	}
 	allDeps := make(resource.Dependencies)
 


### PR DESCRIPTION
This updated log line helps quickly identify when a dependency does not exist at all (e.g. a typo in the name, and the user should update their config). If a dependency is just slow to start up, it will continue logging as normal.



```
2025-07-29T14:18:04.795Z ERROR	rdk.resource_manager.rdk:component:generic/f	resource/graph_node.go:297	resource build error: resource has unresolved dependencies not found in machine config or connected remotes: [asdfg]	{"resource":"rdk:component:generic/f","model":"acme:demo:foo"}
```