### PR TITLE
RSDK-11217 - Stop trying to remove addr if in TCP mode

### DIFF
--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -292,9 +292,12 @@ func (svc *webService) startProtocolModuleParentServer(ctx context.Context, tcpM
 		defer svc.modWorkers.Done()
 		svc.logger.Debugw("module server listening", "socket path", lis.Addr())
 		defer func() {
-			err := os.RemoveAll(filepath.Dir(addr))
-			if err != nil {
-				svc.logger.Debugf("RemoveAll failed: %v", err)
+			// tcpMode starts listens on a port, not a socket file, so no need to remove.
+			if !tcpMode {
+				err := os.RemoveAll(filepath.Dir(addr))
+				if err != nil {
+					svc.logger.Debugf("RemoveAll failed: %v", err)
+				}
 			}
 		}()
 		if err := server.Serve(lis); err != nil {

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -292,7 +292,7 @@ func (svc *webService) startProtocolModuleParentServer(ctx context.Context, tcpM
 		defer svc.modWorkers.Done()
 		svc.logger.Debugw("module server listening", "socket path", lis.Addr())
 		defer func() {
-			// tcpMode starts listens on a port, not a socket file, so no need to remove.
+			// tcpMode starts listening on a port, not a socket file, so no need to remove.
 			if !tcpMode {
 				err := os.RemoveAll(filepath.Dir(addr))
 				if err != nil {


### PR DESCRIPTION
tests were spewing these errors but we also shouldn't be trying to remove a file in TCP mode