### PR TITLE
fix missing motion service in `make server-static` builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,11 +81,11 @@ test-go-no-race: tool-install
 
 server:
 	rm -f $(BIN_OUTPUT_PATH)/viam-server
-	go build $(GCFLAGS) $(LDFLAGS) -o $(BIN_OUTPUT_PATH)/viam-server web/cmd/server/main.go
+	go build $(GCFLAGS) $(LDFLAGS) -o $(BIN_OUTPUT_PATH)/viam-server ./web/cmd/server
 
 server-static:
 	rm -f $(BIN_OUTPUT_PATH)/viam-server
-	VIAM_STATIC_BUILD=1 GOFLAGS=$(GOFLAGS) go build $(GCFLAGS) $(LDFLAGS) -o $(BIN_OUTPUT_PATH)/viam-server web/cmd/server/main.go
+	VIAM_STATIC_BUILD=1 GOFLAGS=$(GOFLAGS) go build $(GCFLAGS) $(LDFLAGS) -o $(BIN_OUTPUT_PATH)/viam-server ./web/cmd/server
 
 full-static:
 	mkdir -p bin/static

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ If you have a bug or an idea, please open an issue [here](https://viam.atlassian
 
 ### Build and Run
 * Build: `make server`. Then run `./bin/<your architecture>/server [parameters]`
-* Run without building: `go run web/cmd/server/main.go [parameters]`
+* Run without building: `go run ./web/cmd/server [parameters]`
 
-Example with a dummy configuration: `go run web/cmd/server/main.go -config etc/configs/fake.json`.
+Example with a dummy configuration: `go run ./web/cmd/server -config etc/configs/fake.json`.
 
 ### Examples
 * [CustomResources](https://pkg.go.dev/go.viam.com/rdk/examples/customresources) - example for creating custom resources.

--- a/examples/customresources/demos/complexmodule/Makefile
+++ b/examples/customresources/demos/complexmodule/Makefile
@@ -6,7 +6,7 @@ module:
 	go build ./
 
 run-module:
-	go run ../../../../web/cmd/server/main.go -config module.json
+	go run ../../../../web/cmd/server -config module.json
 
 run-client:
 	cd client && make

--- a/examples/customresources/demos/multiplemodules/Makefile
+++ b/examples/customresources/demos/multiplemodules/Makefile
@@ -7,7 +7,7 @@ module:
 	go build -o gizmomodule/gizmomodule ./gizmomodule
 
 run-module:
-	go run ../../../../web/cmd/server/main.go -config module.json
+	go run ../../../../web/cmd/server -config module.json
 
 run-client:
 	cd client && make

--- a/examples/customresources/demos/optionaldepsmodule/Makefile
+++ b/examples/customresources/demos/optionaldepsmodule/Makefile
@@ -6,4 +6,4 @@ module:
 	go build ./
 
 run-module: module
-	go run ../../../../web/cmd/server/main.go -config module.json
+	go run ../../../../web/cmd/server -config module.json

--- a/examples/customresources/demos/remoteserver/Makefile
+++ b/examples/customresources/demos/remoteserver/Makefile
@@ -2,7 +2,7 @@ run-remote:
 	go run ./ -config remote.json
 
 run-parent:
-	go run ../../../../web/cmd/server/main.go -config parent.json
+	go run ../../../../web/cmd/server -config parent.json
 
 run-client:
 	cd client && make

--- a/examples/customresources/demos/remoteserver/server_test.go
+++ b/examples/customresources/demos/remoteserver/server_test.go
@@ -85,7 +85,7 @@ func TestGizmo(t *testing.T) {
 		pCfg := pexec.ProcessConfig{
 			ID:      "Intermediate",
 			Name:    "go",
-			Args:    []string{"run", utils.ResolveFile("./web/cmd/server/main.go"), "-config", tmpConf.Name()},
+			Args:    []string{"run", utils.ResolveFile("./web/cmd/server"), "-config", tmpConf.Name()},
 			CWD:     "",
 			OneShot: false,
 			Log:     true,

--- a/examples/customresources/demos/simplemodule/Makefile
+++ b/examples/customresources/demos/simplemodule/Makefile
@@ -6,7 +6,7 @@ module:
 	go build ./
 
 run-module: module
-	go run ../../../../web/cmd/server/main.go -config module.json
+	go run ../../../../web/cmd/server -config module.json
 
 run-client:
 	cd client && make


### PR DESCRIPTION
## What changed
- change `go build web/cmd/server/main.go` to `go build ./web/cmd/server` throughout codebase
## Why
The `main.go` style excludes `main_nocgo.go`, the new file where the services registration lives. The `./web/cmd/server` style is a package build which is subtly different in go + includes all files in the package. (it also has some vcs metadata automation that would be useful if we wanted)