### PR TITLE
RSDK-11450 Add DNS network checks

### DIFF
--- a/web/networkcheck/network-check-types.go
+++ b/web/networkcheck/network-check-types.go
@@ -133,7 +133,7 @@ func stringifyDNSResults(dnsResults []*DNSResult) string {
 }
 
 // Logs DNS test results.
-func logDNSResults(logger logging.Logger, dnsResults []*DNSResult) {
+func logDNSResults(logger logging.Logger, dnsResults []*DNSResult, resolveConfContents string) {
 	var successfulConnectionTests, totalConnectionTests int
 	var successfulResolutionTests, totalResolutionTests int
 	var slowResolutions []string
@@ -173,6 +173,10 @@ func logDNSResults(logger logging.Logger, dnsResults []*DNSResult) {
 	if successfulConnectionTests < totalConnectionTests ||
 		successfulResolutionTests < totalResolutionTests {
 		logger.Warnw(systemMsg, keysAndValues...)
+		// Only log `/etc/resolve.conf` contents in the event of a DNS test failure.
+		if resolveConfContents != "" {
+			logger.Infof("/etc/resolve.conf contents: %s", resolveConfContents)
+		}
 	} else {
 		logger.Infow(systemMsg, keysAndValues...)
 	}

--- a/web/networkcheck/network-check-types.go
+++ b/web/networkcheck/network-check-types.go
@@ -2,32 +2,188 @@ package networkcheck
 
 import (
 	"fmt"
+	"strings"
 
 	"go.viam.com/rdk/logging"
 )
 
-// STUNResponse represents a response from a STUN server.
-type STUNResponse struct {
-	// STUNServerURL is the URL of the STUN server.
-	STUNServerURL string
+type (
+	// DNSTestType is an enumeration of test types
+	DNSTestType int
 
-	// TCPSourceAddress is the source address for the bind request if this was a TCP test.
-	// If it was a UDP test, it will be the same UDP source address for all UDP tests, and
-	// that value will be passed to `logSTUNResults`.
-	TCPSourceAddress *string
+	// STUNResponse represents a response from a STUN server.
+	STUNResponse struct {
+		// STUNServerURL is the URL of the STUN server.
+		STUNServerURL string
 
-	// STUNServerAddr is the resolved address of the STUN server.
-	STUNServerAddr *string
+		// TCPSourceAddress is the source address for the bind request if this was a TCP test.
+		// If it was a UDP test, it will be the same UDP source address for all UDP tests, and
+		// that value will be passed to `logSTUNResults`.
+		TCPSourceAddress *string
 
-	// BindResponseAddr is our address as reported by the STUN server.
-	BindResponseAddr *string
+		// STUNServerAddr is the resolved address of the STUN server.
+		STUNServerAddr *string
 
-	// Time taken to send bind request, receive bind response, and extract address. A vague
-	// measurement of RTT to the STUN server.
-	TimeToBindResponseMS *int64
+		// BindResponseAddr is our address as reported by the STUN server.
+		BindResponseAddr *string
 
-	// Any error received during STUN interactions.
-	ErrorString *string
+		// Time taken to send bind request, receive bind response, and extract address. A vague
+		// measurement of RTT to the STUN server.
+		TimeToBindResponseMS *int64
+
+		// Any error received during STUN interactions.
+		ErrorString *string
+	}
+
+	// DNSResult represents the result of a DNS resolution test.
+	DNSResult struct {
+		// TestType indicates the type of DNS test.
+		TestType DNSTestType
+
+		// Any error encountered during the test.
+		ErrorString *string
+
+		/* Fields populated in Connection tests below */
+
+		// DNS server being tested.
+		DNSServer *string
+
+		// Time taken to connect to DNS server.
+		ConnectTimeMS *int64
+
+		// Time taken to send query and receive response.
+		QueryTimeMS *int64
+
+		// Size of DNS response in bytes.
+		ResponseSize *int64
+
+		/* Fields populated in Resolution tests below */
+
+		// Hostname being resolved.
+		Hostname *string
+
+		// Resolved IP addresses (comma-separated).
+		ResolvedIPs *string
+
+		// Time taken to resolve the hostname.
+		ResolutionTimeMS *int64
+	}
+)
+
+const (
+	ConnectionDNSTestType DNSTestType = iota
+	ResolutionDNSTestType
+)
+
+// String stringifies a DNS test type.
+func (dtt DNSTestType) String() string {
+	switch dtt {
+	case ConnectionDNSTestType:
+		return "connection"
+	case ResolutionDNSTestType:
+		return "resolution"
+	default:
+		return "unknown"
+	}
+}
+
+func stringifyDNSResults(dnsResults []*DNSResult) string {
+	ret := "["
+
+	for i, dr := range dnsResults {
+		comma := ","
+		if i == 0 {
+			comma = ""
+		}
+
+		ret += fmt.Sprintf("%v{test_type: %s", comma, dr.TestType)
+		if dr.ErrorString != nil {
+			ret += fmt.Sprintf(", error_string: %v", *dr.ErrorString)
+		}
+
+		// Connection fields.
+		if dr.DNSServer != nil {
+			ret += fmt.Sprintf(", dns_server: %v", *dr.DNSServer)
+		}
+		if dr.ConnectTimeMS != nil {
+			ret += fmt.Sprintf(", connect_time_ms: %d", *dr.ConnectTimeMS)
+		}
+		if dr.QueryTimeMS != nil {
+			ret += fmt.Sprintf(", query_time_ms: %d", *dr.QueryTimeMS)
+		}
+		if dr.ResponseSize != nil {
+			ret += fmt.Sprintf(", response_size: %d", *dr.ResponseSize)
+		}
+
+		// Resolution fields.
+		if dr.Hostname != nil {
+			ret += fmt.Sprintf(", hostname: %v", *dr.Hostname)
+		}
+		if dr.ResolutionTimeMS != nil {
+			ret += fmt.Sprintf(", resolution_time_ms: %d", *dr.ResolutionTimeMS)
+		}
+		if dr.ResolvedIPs != nil {
+			ret += fmt.Sprintf(", resolved_ips: %v", *dr.ResolvedIPs)
+		}
+
+		ret += "}"
+	}
+
+	return ret + "]"
+}
+
+// Logs DNS test results.
+func logDNSResults(logger logging.Logger, dnsResults []*DNSResult) {
+	var successfulConnectionTests, totalConnectionTests int
+	var successfulResolutionTests, totalResolutionTests int
+	var slowResolutions []string
+
+	for _, dr := range dnsResults {
+		switch dr.TestType {
+		case ConnectionDNSTestType:
+			totalConnectionTests++
+			if dr.ErrorString == nil {
+				successfulConnectionTests++
+			}
+		case ResolutionDNSTestType:
+			totalResolutionTests++
+			if dr.ErrorString == nil {
+				successfulResolutionTests++
+				// Flag slow DNS resolutions (>1s).
+				if dr.ResolutionTimeMS != nil && *dr.ResolutionTimeMS > 1000 {
+					if dr.Hostname != nil /* should be non-nil */ {
+						slowResolutions = append(slowResolutions, *dr.Hostname)
+					}
+				}
+			}
+		default:
+			logger.Warnf("Unknown DNS test type; cannot handle %s", dr.TestType)
+		}
+	}
+
+	systemMsg := fmt.Sprintf(
+		"%d/%d dns connection and %d/%d dns resolution tests succeeded",
+		successfulConnectionTests,
+		totalConnectionTests,
+		successfulResolutionTests,
+		totalResolutionTests,
+	)
+	keysAndValues := []any{"dns_tests", stringifyDNSResults(dnsResults)}
+
+	if successfulConnectionTests < totalConnectionTests ||
+		successfulResolutionTests < totalResolutionTests {
+		logger.Warnw(systemMsg, keysAndValues...)
+	} else {
+		logger.Infow(systemMsg, keysAndValues...)
+	}
+
+	// Warn about slow DNS resolutions
+	if len(slowResolutions) > 0 {
+		logger.Warnw(
+			"Slow DNS resolutions detected (>1000ms)",
+			"slow_hostnames", strings.Join(slowResolutions, ", "),
+		)
+	}
 }
 
 func stringifySTUNResponses(stunResponses []*STUNResponse) string {

--- a/web/networkcheck/network-check.go
+++ b/web/networkcheck/network-check.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -200,6 +201,16 @@ func testDNSResolution(ctx context.Context, hostname string) *DNSResult {
 	return dnsResult
 }
 
+// Gets the contents of `/etc/resolve.conf` is it exists. Returns an empty string if file
+// does not exist.
+func getResolveConfContents() string {
+	resolveConfContents, err := os.ReadFile("/etc/resolv.conf")
+	if err != nil {
+		return ""
+	}
+	return string(resolveConfContents)
+}
+
 // Tests connectivity to DNS servers and attempts to resolve hostnames with the system DNS
 // resolver.
 func testDNS(ctx context.Context, logger logging.Logger) {
@@ -223,7 +234,7 @@ func testDNS(ctx context.Context, logger logging.Logger) {
 		dnsResults = append(dnsResults, testDNSResolution(ctx, hostname))
 	}
 
-	logDNSResults(logger, dnsResults)
+	logDNSResults(logger, dnsResults, getResolveConfContents())
 }
 
 // Sends the provided bindRequest to the provided STUN server with the provided packet

--- a/web/networkcheck/network-check.go
+++ b/web/networkcheck/network-check.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -27,6 +28,8 @@ func RunNetworkChecks(ctx context.Context, rdkLogger logging.Logger) {
 
 	logger.Info("Starting network checks")
 
+	testDNS(ctx, logger.Sublogger("dns"))
+
 	if err := testUDP(ctx, logger.Sublogger("udp")); err != nil {
 		logger.Errorw("Error running udp network tests", "error", err)
 	}
@@ -36,10 +39,22 @@ func RunNetworkChecks(ctx context.Context, rdkLogger logging.Logger) {
 	}
 }
 
-// All reads, both UDP and TCP, get 5 seconds before being considered a timeout.
-const readTimeout = 5 * time.Second
+// All blocking I/O for all network checks gets 5 seconds before being considered a timeout.
+const timeout = 5 * time.Second
 
 var (
+	serverIPSToTestDNS = []string{
+		"1.1.1.1:53",        // Cloudflare DNS
+		"8.8.8.8:53",        // Google DNS
+		"208.67.222.222:53", // OpenDNS
+	}
+	hostnamesToResolveDNS = []string{
+		"cloudflare.com",
+		"google.com",
+		"github.com",
+		"viam.com",
+	}
+
 	// TODO(RSDK-10657): Attempt raw IPs of STUN server URLs in the event that DNS
 	// resolution does not work.
 	stunServerURLsToTestUDP = []string{
@@ -51,12 +66,163 @@ var (
 		"stun.sipgate.net:3478",
 		"stun.sipgate.net:3479",
 	}
+
 	stunServerURLsToTestTCP = []string{
 		// Viam's coturn is the only STUN server that accepts TCP STUN traffic.
 		"turn.viam.com:443",
 		"turn.viam.com:3478",
 	}
 )
+
+// Tests connectivity to a specific DNS server.
+func testDNSServerConnectivity(ctx context.Context, dnsServer string) *DNSResult {
+	dnsResult := &DNSResult{
+		TestType:  ConnectionDNSTestType,
+		DNSServer: &dnsServer,
+	}
+
+	// TODO(benji): Should I also dial with TCP? And, is that what local system resolver does?
+	start := time.Now()
+	conn, err := net.DialTimeout("udp", dnsServer, timeout)
+	if err != nil {
+		errorString := fmt.Sprintf("failed to connect to DNS server: %v", err)
+		dnsResult.ErrorString = &errorString
+		return dnsResult
+	}
+	connectTime := time.Since(start).Milliseconds()
+	dnsResult.ConnectTimeMS = &connectTime
+
+	// `net.Conn`s do not function with contexts (only deadlines). If passed-in context
+	// expires (machine is likely shutting down), _or_ tests finish, close the underlying
+	// `net.PacketConn` asynchronously to stop ongoing network checks.
+	testDNSServerConnectivityDone := make(chan struct{})
+	defer close(testDNSServerConnectivityDone)
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-testDNSServerConnectivityDone:
+		}
+		conn.Close() //nolint:gosec,errcheck
+	}()
+
+	// Send a simple DNS query for "google.com"'s A record.
+	dnsQuery := []byte{
+		0x12, 0x34, // Transaction ID
+		0x01, 0x00, // Flags: standard query
+		0x00, 0x01, // Questions: 1
+		0x00, 0x00, // Answer RRs: 0
+		0x00, 0x00, // Authority RRs: 0
+		0x00, 0x00, // Additional RRs: 0
+		0x06, 'g', 'o', 'o', 'g', 'l', 'e', // length + "google"
+		0x03, 'c', 'o', 'm', // length + "com"
+		0x00,       // null terminator
+		0x00, 0x01, // Type: A
+		0x00, 0x01, // Class: IN
+	}
+
+	queryStart := time.Now()
+	_, err = conn.Write(dnsQuery)
+	if err != nil {
+		errorString := fmt.Sprintf("failed to send DNS query: %v", err)
+		dnsResult.ErrorString = &errorString
+		return dnsResult
+	}
+
+	err = conn.SetReadDeadline(time.Now().Add(timeout))
+	if err != nil {
+		errorString := fmt.Sprintf("failed to set read deadline: %v", err)
+		dnsResult.ErrorString = &errorString
+		return dnsResult
+	}
+
+	response := make([]byte, 512 /* standard DNS response size */)
+	n, err := conn.Read(response)
+	if err != nil {
+		errorString := fmt.Sprintf("failed to read DNS response: %v", err)
+		dnsResult.ErrorString = &errorString
+		return dnsResult
+	}
+	queryTime := time.Since(queryStart).Milliseconds()
+	dnsResult.QueryTimeMS = &queryTime
+
+	if n < 12 /* minimum DNS header size */ {
+		errorString := "DNS response too short"
+		dnsResult.ErrorString = &errorString
+		return dnsResult
+	}
+	if response[0] != 0x12 || response[1] != 0x34 {
+		errorString := "DNS response transaction ID mismatch"
+		dnsResult.ErrorString = &errorString
+		return dnsResult
+	}
+	if response[2]&0x80 == 0 {
+		errorString := "received query instead of response"
+		dnsResult.ErrorString = &errorString
+		return dnsResult
+	}
+
+	responseSize := int64(n)
+	dnsResult.ResponseSize = &responseSize
+
+	return dnsResult
+}
+
+// Tests DNS resolution using the system's default resolver.
+func testDNSResolution(hostname string) *DNSResult {
+	dnsResult := &DNSResult{
+		TestType: ResolutionDNSTestType,
+		Hostname: &hostname,
+	}
+
+	start := time.Now()
+	// TODO(benji): This addr lookup fails every time.
+	addrs, err := net.LookupAddr(hostname)
+	resolutionTime := time.Since(start).Milliseconds()
+	dnsResult.ResolutionTimeMS = &resolutionTime
+
+	if err != nil {
+		errorString := fmt.Sprintf("system DNS resolution failed: %v", err.Error())
+		dnsResult.ErrorString = &errorString
+		return dnsResult
+	}
+
+	if len(addrs) == 0 {
+		errorString := "no IP addresses returned"
+		dnsResult.ErrorString = &errorString
+		return dnsResult
+	}
+
+	resolvedIPs := strings.Join(addrs, ", ")
+	dnsResult.ResolvedIPs = &resolvedIPs
+
+	return dnsResult
+}
+
+// Tests connectivity to DNS servers and attempts to resolve hostnames with the system DNS
+// resolver.
+func testDNS(ctx context.Context, logger logging.Logger) {
+	var dnsResults []*DNSResult
+
+	for _, dnsServer := range serverIPSToTestDNS {
+		if ctx.Err() != nil {
+			logger.Info("Shutdown detected; stopping DNS connectivity tests")
+			return
+		}
+
+		dnsResults = append(dnsResults, testDNSServerConnectivity(ctx, dnsServer))
+	}
+
+	for _, hostname := range hostnamesToResolveDNS {
+		if ctx.Err() != nil {
+			logger.Info("Shutdown detected; stopping DNS resolution tests")
+			return
+		}
+
+		dnsResults = append(dnsResults, testDNSResolution(hostname))
+	}
+
+	logDNSResults(logger, dnsResults)
+}
 
 // Sends the provided bindRequest to the provided STUN server with the provided packet
 // connection and expects the provided transaction ID. Uses cached resolved IPs if
@@ -121,7 +287,7 @@ func sendUDPBindRequest(
 
 	// Set a read deadline for reading on the conn in this test and remove that deadline at
 	// the end of this test.
-	if err = conn.SetReadDeadline(time.Now().Add(readTimeout)); err != nil {
+	if err = conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
 		errorString := fmt.Sprintf("error setting read deadline on packet conn: %v", err.Error())
 		stunResponse.ErrorString = &errorString
 		return
@@ -284,7 +450,7 @@ func sendTCPBindRequest(
 
 	// Set a read deadline for reading on the conn in this test and remove that deadline at
 	// the end of this test.
-	if err = conn.SetReadDeadline(time.Now().Add(readTimeout)); err != nil {
+	if err = conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
 		errorString := fmt.Sprintf("error setting read deadline on connection: %v", err.Error())
 		stunResponse.ErrorString = &errorString
 		return
@@ -391,7 +557,7 @@ func testTCP(ctx context.Context, logger logging.Logger) error {
 		}
 
 		connMu.Lock()
-		dialCtx, cancel := context.WithTimeout(ctx, readTimeout)
+		dialCtx, cancel := context.WithTimeout(ctx, timeout)
 		dialer := &net.Dialer{} // use an empty dialer to get access to the `DialContext` method
 		conn, err = dialer.DialContext(dialCtx, "tcp", stunServerURLToTest)
 		cancel()


### PR DESCRIPTION
Adds DNS network checks for connectivity to popular DNS root nameservers (Google, Cloudflare, OpenDNS) and the linux [`systemd-resolved`](https://man7.org/linux/man-pages/man8/systemd-resolved.service.8.html) system DNS service. Also adds DNS network checks for ability to resolve `cloudflare.com`, `google.com`, `github.com`, and `viam.com` domain names to IP addresses.

Prints out contents of `/etc/resolv.conf` in the event of any test failure.