### PR TITLE
RSDK-11485 Re-Enable Job manager on Windows

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -3,10 +3,8 @@ package modmanager
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strings"
 	"sync"
@@ -40,7 +38,6 @@ var (
 	// name of the folder under the viamHomeDir that holds all the folders for the module data
 	// ex: /home/walle/.viam/module-data/<cloud-robot-id>/<module-name>
 	parentModuleDataFolderName = "module-data"
-	windowsPathRegex           = regexp.MustCompile(`^(\w:)?(.+)$`)
 )
 
 // NewManager returns a Manager.
@@ -48,7 +45,7 @@ func NewManager(
 	ctx context.Context, parentAddrs config.ParentSockAddrs, logger logging.Logger, options modmanageroptions.Options,
 ) (modmaninterface.ModuleManager, error) {
 	var err error
-	parentAddrs.UnixAddr, err = CleanWindowsSocketPath(runtime.GOOS, parentAddrs.UnixAddr)
+	parentAddrs.UnixAddr, err = rutils.CleanWindowsSocketPath(runtime.GOOS, parentAddrs.UnixAddr)
 	if err != nil {
 		return nil, err
 	}
@@ -1027,25 +1024,6 @@ func (mgr *Manager) FirstRun(ctx context.Context, conf config.Module) error {
 	env := getFullEnvironment(conf, dataDir, mgr.viamHomeDir)
 
 	return conf.FirstRun(ctx, pkgsDir, dataDir, env, mgr.logger)
-}
-
-// CleanWindowsSocketPath mutates socket paths on windows only so they
-// work well with the GRPC library.
-// It converts e.g. C:\x\y.sock to /x/y.sock
-// If you don't do this, it will confuse grpc-go's url.Parse call and surrounding logic.
-// See https://github.com/grpc/grpc-go/blob/v1.71.0/clientconn.go#L1720-L1727
-func CleanWindowsSocketPath(goos, orig string) (string, error) {
-	if goos == "windows" {
-		match := windowsPathRegex.FindStringSubmatch(orig)
-		if match == nil {
-			return "", fmt.Errorf("error cleaning socket path %s", orig)
-		}
-		if match[1] != "" && strings.ToLower(match[1]) != "c:" {
-			return "", fmt.Errorf("we expect unix sockets on C: drive, not %s", match[1])
-		}
-		return strings.ReplaceAll(match[2], "\\", "/"), nil
-	}
-	return orig, nil
 }
 
 func getFullEnvironment(

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -1029,7 +1029,7 @@ func (mgr *Manager) FirstRun(ctx context.Context, conf config.Module) error {
 	return conf.FirstRun(ctx, pkgsDir, dataDir, env, mgr.logger)
 }
 
-// CleanWindowsSocketPath works on windows only, this mutates socket paths so they
+// CleanWindowsSocketPath mutates socket paths on windows only so they
 // work well with the GRPC library.
 // It converts e.g. C:\x\y.sock to /x/y.sock
 // If you don't do this, it will confuse grpc-go's url.Parse call and surrounding logic.

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -48,7 +48,7 @@ func NewManager(
 	ctx context.Context, parentAddrs config.ParentSockAddrs, logger logging.Logger, options modmanageroptions.Options,
 ) (modmaninterface.ModuleManager, error) {
 	var err error
-	parentAddrs.UnixAddr, err = cleanWindowsSocketPath(runtime.GOOS, parentAddrs.UnixAddr)
+	parentAddrs.UnixAddr, err = CleanWindowsSocketPath(runtime.GOOS, parentAddrs.UnixAddr)
 	if err != nil {
 		return nil, err
 	}
@@ -1029,11 +1029,12 @@ func (mgr *Manager) FirstRun(ctx context.Context, conf config.Module) error {
 	return conf.FirstRun(ctx, pkgsDir, dataDir, env, mgr.logger)
 }
 
-// On windows only, this mutates socket paths so they work well with the GRPC library.
+// CleanWindowsSocketPath works on windows only, this mutates socket paths so they
+// work well with the GRPC library.
 // It converts e.g. C:\x\y.sock to /x/y.sock
 // If you don't do this, it will confuse grpc-go's url.Parse call and surrounding logic.
 // See https://github.com/grpc/grpc-go/blob/v1.71.0/clientconn.go#L1720-L1727
-func cleanWindowsSocketPath(goos, orig string) (string, error) {
+func CleanWindowsSocketPath(goos, orig string) (string, error) {
 	if goos == "windows" {
 		match := windowsPathRegex.FindStringSubmatch(orig)
 		if match == nil {

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -1749,27 +1749,27 @@ func TestFirstRun(t *testing.T) {
 
 func TestCleanWindowsSocketPath(t *testing.T) {
 	// uppercase and lowercase
-	clean, err := CleanWindowsSocketPath("windows", "C:\\x\\y.sock")
+	clean, err := rutils.CleanWindowsSocketPath("windows", "C:\\x\\y.sock")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, clean, test.ShouldResemble, "/x/y.sock")
-	clean, err = CleanWindowsSocketPath("windows", "c:\\x\\y.sock")
+	clean, err = rutils.CleanWindowsSocketPath("windows", "c:\\x\\y.sock")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, clean, test.ShouldResemble, "/x/y.sock")
 
 	// wrong disk
-	_, err = CleanWindowsSocketPath("windows", "d:\\x\\y.sock")
+	_, err = rutils.CleanWindowsSocketPath("windows", "d:\\x\\y.sock")
 	test.That(t, err, test.ShouldNotBeNil)
 
 	// no disk
-	clean, err = CleanWindowsSocketPath("windows", "\\x\\y.sock")
+	clean, err = rutils.CleanWindowsSocketPath("windows", "\\x\\y.sock")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, clean, test.ShouldResemble, "/x/y.sock")
-	clean, err = CleanWindowsSocketPath("windows", "/x/y.sock")
+	clean, err = rutils.CleanWindowsSocketPath("windows", "/x/y.sock")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, clean, test.ShouldResemble, "/x/y.sock")
 
 	// linux
-	clean, err = CleanWindowsSocketPath("linux", "/x/y.sock")
+	clean, err = rutils.CleanWindowsSocketPath("linux", "/x/y.sock")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, clean, test.ShouldResemble, "/x/y.sock")
 }

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -1749,27 +1749,27 @@ func TestFirstRun(t *testing.T) {
 
 func TestCleanWindowsSocketPath(t *testing.T) {
 	// uppercase and lowercase
-	clean, err := cleanWindowsSocketPath("windows", "C:\\x\\y.sock")
+	clean, err := CleanWindowsSocketPath("windows", "C:\\x\\y.sock")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, clean, test.ShouldResemble, "/x/y.sock")
-	clean, err = cleanWindowsSocketPath("windows", "c:\\x\\y.sock")
+	clean, err = CleanWindowsSocketPath("windows", "c:\\x\\y.sock")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, clean, test.ShouldResemble, "/x/y.sock")
 
 	// wrong disk
-	_, err = cleanWindowsSocketPath("windows", "d:\\x\\y.sock")
+	_, err = CleanWindowsSocketPath("windows", "d:\\x\\y.sock")
 	test.That(t, err, test.ShouldNotBeNil)
 
 	// no disk
-	clean, err = cleanWindowsSocketPath("windows", "\\x\\y.sock")
+	clean, err = CleanWindowsSocketPath("windows", "\\x\\y.sock")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, clean, test.ShouldResemble, "/x/y.sock")
-	clean, err = cleanWindowsSocketPath("windows", "/x/y.sock")
+	clean, err = CleanWindowsSocketPath("windows", "/x/y.sock")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, clean, test.ShouldResemble, "/x/y.sock")
 
 	// linux
-	clean, err = cleanWindowsSocketPath("linux", "/x/y.sock")
+	clean, err = CleanWindowsSocketPath("linux", "/x/y.sock")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, clean, test.ShouldResemble, "/x/y.sock")
 }

--- a/module/modmanager/module.go
+++ b/module/modmanager/module.go
@@ -179,7 +179,7 @@ func (m *module) startProcess(
 			filepath.Dir(parentAddr), fmt.Sprintf("%s-%s", m.cfg.Name, utils.RandomAlphaString(5))); err != nil {
 			return err
 		}
-		m.addr, err = CleanWindowsSocketPath(runtime.GOOS, m.addr)
+		m.addr, err = rutils.CleanWindowsSocketPath(runtime.GOOS, m.addr)
 		if err != nil {
 			return err
 		}

--- a/module/modmanager/module.go
+++ b/module/modmanager/module.go
@@ -179,7 +179,7 @@ func (m *module) startProcess(
 			filepath.Dir(parentAddr), fmt.Sprintf("%s-%s", m.cfg.Name, utils.RandomAlphaString(5))); err != nil {
 			return err
 		}
-		m.addr, err = cleanWindowsSocketPath(runtime.GOOS, m.addr)
+		m.addr, err = CleanWindowsSocketPath(runtime.GOOS, m.addr)
 		if err != nil {
 			return err
 		}

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -560,7 +560,7 @@ func newWithResources(
 
 	jobManager, err := jobmanager.New(ctx, logger, getResource, r.webSvc.ModuleAddresses())
 	if err != nil {
-		r.logger.CErrorw(ctx, "Job manager could not start", "error", err)
+		r.logger.CErrorw(ctx, "Job manager failed to start", "error", err)
 	}
 	r.jobManager = jobManager
 

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -538,34 +538,31 @@ func newWithResources(
 		}, r.activeBackgroundWorkers.Done)
 	}
 
-	// TODO(RDSK-11485): JobManager might try to dial a unix socket on windows, which will crash the server.
-	if runtime.GOOS != "windows" {
-		// getResource is passed in to the jobmanager to have access to the resource graph.
-		getResource := func(res string) (resource.Resource, error) {
-			var found bool
-			var match resource.Name
-			names := r.manager.resources.Names()
-			for _, name := range names {
-				if name.Name == res {
-					if found {
-						return nil, errors.Errorf("found duplicate entries for name %s: %s and %s", res, name.String(), match.String())
-					}
-					match = name
-					found = true
+	// getResource is passed in to the jobmanager to have access to the resource graph.
+	getResource := func(res string) (resource.Resource, error) {
+		var found bool
+		var match resource.Name
+		names := r.manager.resources.Names()
+		for _, name := range names {
+			if name.Name == res {
+				if found {
+					return nil, errors.Errorf("found duplicate entries for name %s: %s and %s", res, name.String(), match.String())
 				}
+				match = name
+				found = true
 			}
-			if !found {
-				return nil, errors.Errorf("could not find the resource for name %s", res)
-			}
-			return r.manager.ResourceByName(match)
 		}
-
-		jobManager, err := jobmanager.New(ctx, logger, getResource, r.webSvc.ModuleAddresses())
-		if err != nil {
-			return nil, err
+		if !found {
+			return nil, errors.Errorf("could not find the resource for name %s", res)
 		}
-		r.jobManager = jobManager
+		return r.manager.ResourceByName(match)
 	}
+
+	jobManager, err := jobmanager.New(ctx, logger, getResource, r.webSvc.ModuleAddresses())
+	if err != nil {
+		return nil, err
+	}
+	r.jobManager = jobManager
 
 	r.reconfigure(ctx, cfg, false)
 

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -6,7 +6,6 @@ package robotimpl
 
 import (
 	"context"
-	"runtime"
 	"slices"
 	"sync"
 	"sync/atomic"

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -560,7 +560,7 @@ func newWithResources(
 
 	jobManager, err := jobmanager.New(ctx, logger, getResource, r.webSvc.ModuleAddresses())
 	if err != nil {
-		return nil, err
+		r.logger.CErrorw(ctx, "Job manager could not start", "error", err)
 	}
 	r.jobManager = jobManager
 

--- a/robot/jobmanager/jobmanager.go
+++ b/robot/jobmanager/jobmanager.go
@@ -24,7 +24,6 @@ import (
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
-	"go.viam.com/rdk/module/modmanager"
 	"go.viam.com/rdk/resource"
 	rutils "go.viam.com/rdk/utils"
 )
@@ -66,7 +65,7 @@ func New(
 		return nil, err
 	}
 
-	parentAddr.UnixAddr, err = modmanager.CleanWindowsSocketPath(runtime.GOOS, parentAddr.UnixAddr)
+	parentAddr.UnixAddr, err = rutils.CleanWindowsSocketPath(runtime.GOOS, parentAddr.UnixAddr)
 	if err != nil {
 		return nil, err
 	}

--- a/robot/jobmanager/jobmanager.go
+++ b/robot/jobmanager/jobmanager.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -15,6 +16,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jhump/protoreflect/grpcreflect"
 	"github.com/pkg/errors"
+	"go.viam.com/rdk/module/modmanager"
 	"go.viam.com/utils"
 	"go.viam.com/utils/rpc"
 	"google.golang.org/grpc/metadata"
@@ -64,6 +66,10 @@ func New(
 		return nil, err
 	}
 
+	parentAddr.UnixAddr, err = modmanager.CleanWindowsSocketPath(runtime.GOOS, parentAddr.UnixAddr)
+	if err != nil {
+		return nil, err
+	}
 	dialAddr := "unix://" + parentAddr.UnixAddr
 	if rutils.ViamTCPSockets() {
 		dialAddr = parentAddr.TCPAddr

--- a/robot/jobmanager/jobmanager.go
+++ b/robot/jobmanager/jobmanager.go
@@ -16,7 +16,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/jhump/protoreflect/grpcreflect"
 	"github.com/pkg/errors"
-	"go.viam.com/rdk/module/modmanager"
 	"go.viam.com/utils"
 	"go.viam.com/utils/rpc"
 	"google.golang.org/grpc/metadata"
@@ -25,6 +24,7 @@ import (
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/module/modmanager"
 	"go.viam.com/rdk/resource"
 	rutils "go.viam.com/rdk/utils"
 )

--- a/utils/env.go
+++ b/utils/env.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -75,6 +76,8 @@ var TCPRegex = regexp.MustCompile(`:\d+$`)
 
 // ViamDotDir is the directory for Viam's cached files.
 var ViamDotDir = filepath.Join(PlatformHomeDir(), ".viam")
+
+var windowsPathRegex = regexp.MustCompile(`^(\w:)?(.+)$`)
 
 // GetResourceConfigurationTimeout calculates the resource configuration
 // timeout (env variable value if set, DefaultResourceConfigurationTimeout
@@ -159,4 +162,23 @@ func GetenvInt(v string, def int) int {
 	}
 
 	return num
+}
+
+// CleanWindowsSocketPath mutates socket paths on windows only so they
+// work well with the GRPC library.
+// It converts e.g. C:\x\y.sock to /x/y.sock
+// If you don't do this, it will confuse grpc-go's url.Parse call and surrounding logic.
+// See https://github.com/grpc/grpc-go/blob/v1.71.0/clientconn.go#L1720-L1727
+func CleanWindowsSocketPath(goos, orig string) (string, error) {
+	if goos == "windows" {
+		match := windowsPathRegex.FindStringSubmatch(orig)
+		if match == nil {
+			return "", fmt.Errorf("error cleaning socket path %s", orig)
+		}
+		if match[1] != "" && strings.ToLower(match[1]) != "c:" {
+			return "", fmt.Errorf("we expect unix sockets on C: drive, not %s", match[1])
+		}
+		return strings.ReplaceAll(match[2], "\\", "/"), nil
+	}
+	return orig, nil
 }


### PR DESCRIPTION
Re-Enabling Job manager on Windows has two major changes: 
- Job manager's failure to start will no longer crash the whole server. Rather, an error message will be logged instead.
- Job manager will leverage the existing `CleanWindowsSocketsPath` helper to adjust the unix socket address to work appropriately on windows. 