### PR TITLE
RSDK-11488 - module reload cli improvements

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -2995,7 +2995,7 @@ This won't work unless you have an existing installation of our GitHub app on yo
 						},
 						&cli.BoolFlag{
 							Name:  moduleBuildFlagCloudBuild,
-							Usage: "Run the build script of the module using cloud build instead of locally. The file will be downloaded to the build.path field in meta.json",
+							Usage: "Run the module's build script using cloud build instead of locally, downloading to the build.path field in meta.json",
 						},
 						&cli.StringFlag{
 							Name:        moduleBuildFlagID,
@@ -3004,7 +3004,7 @@ This won't work unless you have an existing installation of our GitHub app on yo
 						},
 						&cli.PathFlag{
 							Name:  moduleBuildFlagCloudConfig,
-							Usage: "Provide the location of the viam.json file to lookup the part-id. Use instead of --part-id option.",
+							Usage: "Provide the location of the viam.json file with robot ID to lookup the part-id. Use instead of --part-id option.",
 							Value: "/etc/viam.json",
 						},
 						&cli.StringFlag{

--- a/cli/app.go
+++ b/cli/app.go
@@ -2996,11 +2996,6 @@ This won't work unless you have an existing installation of our GitHub app on yo
 							Name:  moduleBuildFlagCloudBuild,
 							Usage: "Run the module's build script using cloud build instead of locally, downloading to the build.path field in meta.json",
 						},
-						&cli.StringFlag{
-							Name:        generalFlagVersion,
-							Usage:       "Provide with --cloud-build to reload with a previous build instead of generating a new one",
-							DefaultText: "create a new build",
-						},
 						&cli.PathFlag{
 							Name:  moduleBuildFlagCloudConfig,
 							Usage: "Provide the location of the viam.json file with robot ID to lookup the part-id. Use instead of --part-id option.",
@@ -3012,15 +3007,6 @@ This won't work unless you have an existing installation of our GitHub app on yo
 							DefaultText: "Don't create a new resource",
 						},
 						&cli.StringFlag{
-							Name:  moduleBuildFlagRef,
-							Usage: "git ref to clone when building your module. This can be a branch name or a commit hash",
-							Value: "main",
-						},
-						&cli.StringFlag{
-							Name:  moduleBuildFlagToken,
-							Usage: "checkout token for private repos, not necessary for public repos",
-						},
-						&cli.StringFlag{
 							Name:  moduleBuildFlagWorkdir,
 							Usage: "use this to indicate that your meta.json is in a subdirectory of your repo. --module flag should be relative to this",
 							Value: ".",
@@ -3029,6 +3015,11 @@ This won't work unless you have an existing installation of our GitHub app on yo
 							Name:        dataFlagResourceName,
 							Usage:       "Use with model-name to name the newly added resource",
 							DefaultText: "resource type with a unique numerical suffix",
+						},
+						&cli.StringFlag{
+							Name:        generalFlagPath,
+							Usage:       "Use this with --cloud-build to indicate the path to the root of the git repo to build",
+							DefaultText: ".",
 						},
 					},
 					Action: createCommandWithT[reloadModuleArgs](ReloadModuleAction),

--- a/cli/app.go
+++ b/cli/app.go
@@ -2949,7 +2949,7 @@ This won't work unless you have an existing installation of our GitHub app on yo
 
 	# Specify which component/service to add to the config along with the module (the API is
 	# automatically looked up from meta.json)
-	viam module reload --model-name acme:module-name:mybase
+	viam module reload --model-name acme:module-name:mybase --name my-resource
 
 	# Build and configure a module on your local machine without shipping a tarball.
 	viam module reload --local`,
@@ -2998,7 +2998,7 @@ This won't work unless you have an existing installation of our GitHub app on yo
 							Usage: "Run the module's build script using cloud build instead of locally, downloading to the build.path field in meta.json",
 						},
 						&cli.StringFlag{
-							Name:        moduleBuildFlagID,
+							Name:        generalFlagVersion,
 							Usage:       "Provide with --cloud-build to reload with a previous build instead of generating a new one",
 							DefaultText: "create a new build",
 						},
@@ -3025,6 +3025,11 @@ This won't work unless you have an existing installation of our GitHub app on yo
 							Name:  moduleBuildFlagWorkdir,
 							Usage: "use this to indicate that your meta.json is in a subdirectory of your repo. --module flag should be relative to this",
 							Value: ".",
+						},
+						&cli.StringFlag{
+							Name:        dataFlagResourceName,
+							Usage:       "Use with model-name to name the newly added resource",
+							DefaultText: "resource type with a unique numerical suffix",
 						},
 					},
 					Action: createCommandWithT[reloadModuleArgs](ReloadModuleAction),

--- a/cli/app.go
+++ b/cli/app.go
@@ -3009,8 +3009,8 @@ This won't work unless you have an existing installation of our GitHub app on yo
 						},
 						&cli.StringFlag{
 							Name:        moduleFlagModelName,
-							Usage:       "The model triple to create as a component/service in the part config",
-							DefaultText: "The first model in meta.json",
+							Usage:       "If passed, creates a resource in the part config with the given model triple",
+							DefaultText: "Don't create a new resource",
 						},
 						&cli.StringFlag{
 							Name:  moduleBuildFlagRef,

--- a/cli/app.go
+++ b/cli/app.go
@@ -3009,6 +3009,20 @@ This won't work unless you have an existing installation of our GitHub app on yo
 							Usage:       "The model triple to create as a component/service in the part config",
 							DefaultText: "The first model in meta.json",
 						},
+						&cli.StringFlag{
+							Name:  moduleBuildFlagRef,
+							Usage: "git ref to clone when building your module. This can be a branch name or a commit hash",
+							Value: "main",
+						},
+						&cli.StringFlag{
+							Name:  moduleBuildFlagToken,
+							Usage: "checkout token for private repos, not necessary for public repos",
+						},
+						&cli.StringFlag{
+							Name:  moduleBuildFlagWorkdir,
+							Usage: "use this to indicate that your meta.json is in a subdirectory of your repo. --module flag should be relative to this",
+							Value: ".",
+						},
 					},
 					Action: createCommandWithT[reloadModuleArgs](ReloadModuleAction),
 				},

--- a/cli/app.go
+++ b/cli/app.go
@@ -88,16 +88,19 @@ const (
 	moduleFlagDryRun          = "dry-run"
 	moduleFlagUpload          = "upload"
 
-	moduleBuildFlagRef       = "ref"
-	moduleBuildFlagWait      = "wait"
-	moduleBuildFlagToken     = "token"
-	moduleBuildFlagWorkdir   = "workdir"
-	moduleBuildFlagPlatforms = "platforms"
-	moduleBuildFlagGroupLogs = "group-logs"
-	moduleBuildRestartOnly   = "restart-only"
-	moduleBuildFlagNoBuild   = "no-build"
-	moduleBuildFlagOAuthLink = "oauth-link"
-	moduleBuildFlagRepo      = "repo"
+	moduleBuildFlagRef         = "ref"
+	moduleBuildFlagWait        = "wait"
+	moduleBuildFlagToken       = "token"
+	moduleBuildFlagWorkdir     = "workdir"
+	moduleBuildFlagPlatforms   = "platforms"
+	moduleBuildFlagGroupLogs   = "group-logs"
+	moduleBuildRestartOnly     = "restart-only"
+	moduleBuildFlagNoBuild     = "no-build"
+	moduleBuildFlagCloudBuild  = "cloud-build"
+	moduleBuildFlagCloudConfig = "cloud-config"
+	moduleBuildFlagId          = "build-id"
+	moduleBuildFlagOAuthLink   = "oauth-link"
+	moduleBuildFlagRepo        = "repo"
 
 	mlTrainingFlagName        = "script-name"
 	mlTrainingFlagFramework   = "framework"
@@ -2935,6 +2938,16 @@ This won't work unless you have an existing installation of our GitHub app on yo
 	# Restart a module running on your local viam server, by name, without building or reconfiguring.
 	viam module reload --restart-only --id viam:python-example-module
 
+	# Use cloudbuild to build the tar.gz that will be copied to the part for hot reloading.
+	viam module reload --cloud-build
+
+	# Run viam module reload on a mac and use the downloaded viam.json file instead of --part-id
+	viam module reload --cloud-config ~/Downloads/viam-mac-main.json
+
+	# Specify which component/service to add to the config along with the module (the API is
+	# automatically looked up from meta.json)
+	viam module reload --model-name acme:module-name:mybase
+
 	# Build and configure a module on your local machine without shipping a tarball.
 	viam module reload --local`,
 					Flags: []cli.Flag{
@@ -2976,6 +2989,25 @@ This won't work unless you have an existing installation of our GitHub app on yo
 							Name:  moduleFlagHomeDir,
 							Usage: "remote user's home directory. only necessary if you're targeting a remote machine where $HOME is not /root",
 							Value: "~",
+						},
+						&cli.BoolFlag{
+							Name:  moduleBuildFlagCloudBuild,
+							Usage: "Run the build script of the module using cloud build instead of locally. The file will be downloaded to the build.path field in meta.json",
+						},
+						&cli.StringFlag{
+							Name:        moduleBuildFlagId,
+							Usage:       "Provide with --cloud-build to reload with a previous build instead of generating a new one",
+							DefaultText: "create a new build",
+						},
+						&cli.PathFlag{
+							Name:  moduleBuildFlagCloudConfig,
+							Usage: "Provide the location of the viam.json file to lookup the part-id. Use instead of --part-id option.",
+							Value: "/etc/viam.json",
+						},
+						&cli.StringFlag{
+							Name:        moduleFlagModelName,
+							Usage:       "The model triple to create as a component/service in the part config",
+							DefaultText: "The first model in meta.json",
 						},
 					},
 					Action: createCommandWithT[reloadModuleArgs](ReloadModuleAction),

--- a/cli/app.go
+++ b/cli/app.go
@@ -98,7 +98,7 @@ const (
 	moduleBuildFlagNoBuild     = "no-build"
 	moduleBuildFlagCloudBuild  = "cloud-build"
 	moduleBuildFlagCloudConfig = "cloud-config"
-	moduleBuildFlagId          = "build-id"
+	moduleBuildFlagID          = "build-id"
 	moduleBuildFlagOAuthLink   = "oauth-link"
 	moduleBuildFlagRepo        = "repo"
 
@@ -2875,7 +2875,7 @@ Example:
 							Flags: []cli.Flag{
 								&AliasStringFlag{
 									cli.StringFlag{
-										Name:     moduleBuildFlagId,
+										Name:     moduleBuildFlagID,
 										Usage:    "build that you want to get the logs for",
 										Aliases:  []string{generalFlagID},
 										Required: true,
@@ -2998,7 +2998,7 @@ This won't work unless you have an existing installation of our GitHub app on yo
 							Usage: "Run the build script of the module using cloud build instead of locally. The file will be downloaded to the build.path field in meta.json",
 						},
 						&cli.StringFlag{
-							Name:        moduleBuildFlagId,
+							Name:        moduleBuildFlagID,
 							Usage:       "Provide with --cloud-build to reload with a previous build instead of generating a new one",
 							DefaultText: "create a new build",
 						},

--- a/cli/app.go
+++ b/cli/app.go
@@ -2873,10 +2873,13 @@ Example:
 							Usage:     "get the logs from one of your cloud builds",
 							UsageText: createUsageText("module build logs", []string{generalFlagID}, true, false),
 							Flags: []cli.Flag{
-								&cli.StringFlag{
-									Name:     generalFlagID,
-									Usage:    "build that you want to get the logs for",
-									Required: true,
+								&AliasStringFlag{
+									cli.StringFlag{
+										Name:     moduleBuildFlagId,
+										Usage:    "build that you want to get the logs for",
+										Aliases:  []string{generalFlagID},
+										Required: true,
+									},
 								},
 								&cli.StringFlag{
 									Name:        moduleFlagPlatform,

--- a/cli/app.go
+++ b/cli/app.go
@@ -2934,9 +2934,7 @@ This won't work unless you have an existing installation of our GitHub app on yo
 
 	# A full reload command. This will build your module, send the tarball to the machine with given part ID,
 	# and configure or restart it.
-	# The GOARCH env in this case would get passed to an underlying go build (assuming you're targeting an arm device).
-	# Note that you'll still need to add the components for your models after your module is installed.
-	GOARCH=arm64 viam module reload --part-id UUID
+	viam module reload --part-id UUID
 
 	# Restart a module running on your local viam server, by name, without building or reconfiguring.
 	viam module reload --restart-only --id viam:python-example-module
@@ -2947,8 +2945,9 @@ This won't work unless you have an existing installation of our GitHub app on yo
 	# Run viam module reload on a mac and use the downloaded viam.json file instead of --part-id
 	viam module reload --cloud-config ~/Downloads/viam-mac-main.json
 
-	# Specify which component/service to add to the config along with the module (the API is
-	# automatically looked up from meta.json)
+	# Specify a component/service model (and optionally a name) to add to the config along with
+	# the module (the API is automatically looked up from meta.json)
+	# By default, no resources are added when a module is reloaded
 	viam module reload --model-name acme:module-name:mybase --name my-resource
 
 	# Build and configure a module on your local machine without shipping a tarball.

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -677,7 +677,14 @@ func reloadModuleAction(c *cli.Context, vc *viamClient, args reloadModuleArgs, l
 				return fmt.Errorf("failed copying to part (%v): %w", dest, err)
 			}
 		}
-		needsRestart, err = configureModule(c, vc, manifest, part.Part, args.Local)
+		var newPart *apppb.RobotPart
+		newPart, needsRestart, err = configureModule(c, vc, manifest, part.Part, args.Local)
+		// if the module has been configured, the cached response we have may no longer accurately reflect
+		// the update, so we set the updated `part.Part`
+		if newPart != nil {
+			part.Part = newPart
+		}
+
 		if err != nil {
 			return err
 		}
@@ -691,9 +698,6 @@ func reloadModuleAction(c *cli.Context, vc *viamClient, args reloadModuleArgs, l
 	}
 
 	if args.ModelName != "" {
-		print("sleepy time!!")
-		time.Sleep(time.Second * 30)
-
 		if err = vc.addResourceFromModule(c, part.Part, manifest, args.ModelName, args.ResourceName); err != nil {
 			warningf(c.App.ErrWriter, "unable to add requested resource to robot config: %s", err)
 		}

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -485,14 +485,16 @@ func jobStatusFromProto(s buildpb.JobStatus) jobStatus {
 }
 
 type reloadModuleArgs struct {
-	PartID       string
-	Module       string
-	RestartOnly  bool
-	NoBuild      bool
-	Local        bool
-	NoProgress   bool
-	CloudBuild   bool
-	Version      string
+	PartID      string
+	Module      string
+	RestartOnly bool
+	NoBuild     bool
+	Local       bool
+	NoProgress  bool
+	CloudBuild  bool
+	Version     string
+
+	// CloudConfig is a path to the `viam.json`, or the config containing the robot ID.
 	CloudConfig  string
 	ModelName    string
 	Ref          string
@@ -521,7 +523,7 @@ func (c *viamClient) moduleCloudReload(ctx *cli.Context, args reloadModuleArgs, 
 		return c.downloadModuleAction(ctx, downloadArgs)
 	}
 
-	// create a new build
+	// (TODO RSDK-11531) It'd be nice to add some streaming logs for this so we can see how the progress is going. create a new build
 	infof(c.c.App.Writer, "Creating a new cloud build and swapping it onto the requested machine part. This may take a few minutes...")
 	buildArgs := moduleBuildStartArgs{
 		Module:    args.Module,

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -503,6 +503,7 @@ type reloadModuleArgs struct {
 	ResourceName string
 }
 
+// moduleCloudReload triggers a cloud build and then reloads the specified module with that build.
 func (c *viamClient) moduleCloudReload(ctx *cli.Context, args reloadModuleArgs, platform string) (string, error) {
 	manifest, err := loadManifest(args.Module)
 	if err != nil {

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -612,7 +612,6 @@ func reloadModuleAction(c *cli.Context, vc *viamClient, args reloadModuleArgs, l
 	environment := map[string]string{
 		"VIAM_BUILD_OS":   partOs,
 		"VIAM_BUILD_ARCH": partArch,
-		"VIAM_RELOAD":     "1",
 	}
 
 	// Add all environment variables with VIAM_ prefix

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -533,8 +533,9 @@ func reloadModuleAction(c *cli.Context, vc *viamClient, args reloadModuleArgs, l
 
 	var partOs string
 	var partArch string
+	var platform string
 	if part.Part.UserSuppliedInfo != nil {
-		platform := part.Part.UserSuppliedInfo.Fields["platform"].GetStringValue()
+		platform = part.Part.UserSuppliedInfo.Fields["platform"].GetStringValue()
 		if partInfo := strings.SplitN(platform, "/", 2); len(partInfo) == 2 {
 			partOs = partInfo[0]
 			partArch = partInfo[1]

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -525,7 +525,7 @@ func (c *viamClient) moduleCloudReload(ctx *cli.Context, args reloadModuleArgs, 
 	infof(c.c.App.Writer, "Creating a new cloud build and swapping it onto the requested machine part. This may take a few minutes...")
 	buildArgs := moduleBuildStartArgs{
 		Module:    args.Module,
-		Version:   "reload2",
+		Version:   "reload",
 		Ref:       args.Ref,
 		Token:     args.Token,
 		Workdir:   args.Workdir,
@@ -549,7 +549,7 @@ func (c *viamClient) moduleCloudReload(ctx *cli.Context, args reloadModuleArgs, 
 
 	downloadArgs := downloadModuleFlags{
 		ID:       id,
-		Version:  "reload2",
+		Version:  "reload",
 		Platform: platform,
 	}
 

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -542,8 +542,8 @@ func (c *viamClient) moduleCloudReload(ctx *cli.Context, args reloadModuleArgs, 
 		return "", err
 	}
 
-	// There seems to be some delay between a build finishing and being findable for download. In testing,
-	// a delay of 3 seconds wasn't reliably long enough but 5 seconds was.
+	// (TODO RSDK-11517) There seems to be some delay between a build finishing and being findable
+	// for download. In testing, a delay of 3 seconds wasn't reliably long enough but 5 seconds was.
 	time.Sleep(time.Second * 5)
 
 	downloadArgs := downloadModuleFlags{

--- a/cli/module_build_test.go
+++ b/cli/module_build_test.go
@@ -57,8 +57,9 @@ func TestStartBuild(t *testing.T) {
 			return &v1.StartBuildResponse{BuildId: "xyz123"}, nil
 		},
 	}, map[string]any{moduleFlagPath: manifest, generalFlagVersion: "1.2.3"}, "token")
-	err := ac.moduleBuildStartAction(cCtx, parseStructFromCtx[moduleBuildStartArgs](cCtx))
+	path, err := ac.moduleBuildStartAction(cCtx, parseStructFromCtx[moduleBuildStartArgs](cCtx))
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, path, test.ShouldEqual, "xyz123")
 	test.That(t, out.messages, test.ShouldHaveLength, 1)
 	test.That(t, out.messages[0], test.ShouldEqual, "xyz123\n")
 	test.That(t, errOut.messages, test.ShouldHaveLength, 1)

--- a/cli/module_generate/_templates/python/build.sh
+++ b/cli/module_generate/_templates/python/build.sh
@@ -10,4 +10,4 @@ if ! $PYTHON -m pip install pyinstaller -Uqq; then
 fi
 
 $PYTHON -m PyInstaller --onefile --hidden-import="googleapiclient" src/main.py
-tar -czvf dist/archive.tar.gz ./dist/main
+tar -czvf dist/archive.tar.gz meta.json ./dist/main

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -1065,26 +1065,22 @@ type downloadModuleFlags struct {
 	Platform    string
 }
 
-func downloadModuleActionInner(c *cli.Context, flags downloadModuleFlags) (error, string) {
+func (c *viamClient) downloadModuleAction(ctx *cli.Context, flags downloadModuleFlags) (string, error) {
 	moduleID := flags.ID
 	if moduleID == "" {
 		manifest, err := loadManifest(defaultManifestFilename)
 		if err != nil {
-			return errors.Wrap(err, "trying to get package ID from meta.json"), ""
+			return "", errors.Wrap(err, "trying to get package ID from meta.json")
 		}
 		moduleID = manifest.ModuleID
 	}
-	client, err := newViamClient(c)
-	if err != nil {
-		return err, ""
-	}
 	req := &apppb.GetModuleRequest{ModuleId: moduleID}
-	res, err := client.client.GetModule(c.Context, req)
+	res, err := c.client.GetModule(ctx.Context, req)
 	if err != nil {
-		return err, ""
+		return "", err
 	}
 	if len(res.Module.Versions) == 0 {
-		return errors.New("module has 0 uploaded versions, nothing to download"), ""
+		return "", errors.New("module has 0 uploaded versions, nothing to download")
 	}
 	requestedVersion := flags.Version
 	var ver *apppb.VersionHistory
@@ -1098,45 +1094,49 @@ func downloadModuleActionInner(c *cli.Context, flags downloadModuleFlags) (error
 			}
 		}
 		if ver == nil {
-			return fmt.Errorf("version %s not found in versions for module", requestedVersion), ""
+			return "", fmt.Errorf("version %s not found in versions for module", requestedVersion)
 		}
 	}
-	infof(c.App.ErrWriter, "found version %s", ver.Version)
+	infof(ctx.App.ErrWriter, "found version %s", ver.Version)
 	if len(ver.Files) == 0 {
-		return fmt.Errorf("version %s has 0 files uploaded", ver.Version), ""
+		return "", fmt.Errorf("version %s has 0 files uploaded", ver.Version)
 	}
 	platform := flags.Platform
 	if platform == "" {
 		platform = fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
-		infof(c.App.ErrWriter, "using default platform %s", platform)
+		infof(ctx.App.ErrWriter, "using default platform %s", platform)
 	}
 	if !slices.ContainsFunc(ver.Files, func(file *apppb.Uploads) bool { return file.Platform == platform }) {
-		return fmt.Errorf("platform %s not present for version %s", platform, ver.Version), ""
+		return "", fmt.Errorf("platform %s not present for version %s", platform, ver.Version)
 	}
 	include := true
 	packageType := packagespb.PackageType_PACKAGE_TYPE_MODULE
 	// note: this is working around a GetPackage quirk where platform messes with version
 	fullVersion := fmt.Sprintf("%s-%s", ver.Version, strings.ReplaceAll(platform, "/", "-"))
-	pkg, err := client.packageClient.GetPackage(c.Context, &packagespb.GetPackageRequest{
+	pkg, err := c.packageClient.GetPackage(ctx.Context, &packagespb.GetPackageRequest{
 		Id:         strings.ReplaceAll(moduleID, ":", "/"),
 		Version:    fullVersion,
 		IncludeUrl: &include,
 		Type:       &packageType,
 	})
 	if err != nil {
-		return err, ""
+		return "", err
 	}
 	destName := strings.ReplaceAll(moduleID, ":", "-")
-	infof(c.App.ErrWriter, "saving to %s", path.Join(flags.Destination, fullVersion, destName+".tar.gz"))
-	return downloadPackageFromURL(c.Context, client.authFlow.httpClient,
+	infof(ctx.App.ErrWriter, "saving to %s", path.Join(flags.Destination, fullVersion, destName+".tar.gz"))
+	return downloadPackageFromURL(ctx.Context, c.authFlow.httpClient,
 		flags.Destination, destName,
-		fullVersion, pkg.Package.Url, client.conf.Auth,
+		fullVersion, pkg.Package.Url, c.conf.Auth,
 	)
 }
 
 // DownloadModuleAction downloads a module.
 func DownloadModuleAction(c *cli.Context, flags downloadModuleFlags) error {
-	err, _ := downloadModuleActionInner(c, flags)
+	client, err := newViamClient(c)
+	if err != nil {
+		return err
+	}
+	_, err = client.downloadModuleAction(c, flags)
 	return err
 }
 

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -1065,8 +1065,7 @@ type downloadModuleFlags struct {
 	Platform    string
 }
 
-// DownloadModuleAction downloads a module.
-func DownloadModuleAction(c *cli.Context, flags downloadModuleFlags) error {
+func downloadModuleActionInner(c *cli.Context, flags downloadModuleFlags, includeVersion bool) error {
 	moduleID := flags.ID
 	if moduleID == "" {
 		manifest, err := loadManifest(defaultManifestFilename)
@@ -1129,10 +1128,18 @@ func DownloadModuleAction(c *cli.Context, flags downloadModuleFlags) error {
 	}
 	destName := strings.ReplaceAll(moduleID, ":", "-")
 	infof(c.App.ErrWriter, "saving to %s", path.Join(flags.Destination, fullVersion, destName+".tar.gz"))
+	if !includeVersion {
+		fullVersion = ""
+	}
 	return downloadPackageFromURL(c.Context, client.authFlow.httpClient,
 		flags.Destination, destName,
 		fullVersion, pkg.Package.Url, client.conf.Auth,
 	)
+}
+
+// DownloadModuleAction downloads a module.
+func DownloadModuleAction(c *cli.Context, flags downloadModuleFlags) error {
+	return downloadModuleActionInner(c, flags, true)
 }
 
 // getMarkdownContent reads and returns the content from a markdown file path.

--- a/cli/module_reload.go
+++ b/cli/module_reload.go
@@ -18,6 +18,8 @@ import (
 	rutils "go.viam.com/rdk/utils"
 )
 
+const reloadVersion = "reload"
+
 // ModuleMap is a type alias to indicate where a map represents a module config.
 // We don't convert to rdkConfig.Module because it can get out of date with what's in the db.
 // Using maps directly also saves a lot of high-maintenance ser/des work.

--- a/cli/module_reload_test.go
+++ b/cli/module_reload_test.go
@@ -24,8 +24,9 @@ func TestConfigureModule(t *testing.T) {
 			return &v1.StartBuildResponse{BuildId: "xyz123"}, nil
 		},
 	}, map[string]any{moduleFlagPath: manifestPath, generalFlagVersion: "1.2.3"}, "token")
-	err := ac.moduleBuildStartAction(cCtx, parseStructFromCtx[moduleBuildStartArgs](cCtx))
+	path, err := ac.moduleBuildStartAction(cCtx, parseStructFromCtx[moduleBuildStartArgs](cCtx))
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, path, test.ShouldEqual, "xyz123")
 	test.That(t, out.messages, test.ShouldHaveLength, 1)
 	test.That(t, out.messages[0], test.ShouldEqual, "xyz123\n")
 	test.That(t, errOut.messages, test.ShouldHaveLength, 1)

--- a/cli/packages.go
+++ b/cli/packages.go
@@ -121,7 +121,15 @@ func downloadPackageFromURL(ctx context.Context, httpClient *http.Client,
 	destination, name, version, packageURL string, auth authMethod,
 ) error {
 	// All packages are stored as .tar.gz
-	packagePath := filepath.Join(destination, version, name+".tar.gz")
+	var packagePath string
+	// CR erodkin: checking on version emptiness is a bit hacky, let's make this a new arg instead. or better yet, save to the expected location but just figure out how to send _that_ instead of the module.tar.gz at root
+	if version != "" {
+		print("version is", version)
+		packagePath = filepath.Join(destination, version, name+".tar.gz")
+	} else {
+		packagePath = filepath.Join(".", "module.tar.gz")
+	}
+	print("packagePath is", packagePath)
 	if err := os.MkdirAll(filepath.Dir(packagePath), 0o700); err != nil {
 		return err
 	}


### PR DESCRIPTION
Testing:

1. `viam module reload` without cloudbuild has no regression
2. `viam module reload --cloud-build` when no `reload` version exists successfully builds and reloads
3. `viam module reload --cloud-build` when a previous `reload` version already exists also successfully builds and reloads
4. `viam module reload --cloud-build` works across platforms
5. `viam module reload --cloud-build` to machine A causes no change to machine B that is running the same module.