### PR TITLE
RSDK-11454 "log" Warnings only on "log" field changes

### DIFF
--- a/config/diff.go
+++ b/config/diff.go
@@ -22,7 +22,7 @@ type Diff struct {
 	Removed        *Config
 	ResourcesEqual bool
 	NetworkEqual   bool
-	// LogFieldEqual is a hacky field to determine an appropriate warning about Log
+	// LogFieldEqual is a field to determine if an appropriate warning about Log
 	// changes needs to be displayed.
 	LogFieldEqual       bool
 	LogEqual            bool

--- a/config/diff.go
+++ b/config/diff.go
@@ -16,15 +16,12 @@ import (
 // where left is usually old and right is new. So the diff is the
 // changes from left to right.
 type Diff struct {
-	Left, Right    *Config
-	Added          *Config
-	Modified       *ModifiedConfigDiff
-	Removed        *Config
-	ResourcesEqual bool
-	NetworkEqual   bool
-	// LogFieldEqual is a field to determine if an appropriate warning about Log
-	// changes needs to be displayed.
-	LogFieldEqual       bool
+	Left, Right         *Config
+	Added               *Config
+	Modified            *ModifiedConfigDiff
+	Removed             *Config
+	ResourcesEqual      bool
+	NetworkEqual        bool
 	LogEqual            bool
 	JobsEqual           bool
 	PrettyDiff          string
@@ -98,7 +95,7 @@ func DiffConfigs(left, right Config, revealSensitiveConfigDiffs bool) (_ *Diff, 
 	networkDifferent := diffNetworkingCfg(&left, &right)
 	diff.NetworkEqual = !networkDifferent
 
-	logDifferent := diffLogCfg(&left, &right, servicesDifferent, componentsDifferent, &diff)
+	logDifferent := diffLogCfg(&left, &right)
 	diff.LogEqual = !logDifferent
 
 	return &diff, nil
@@ -528,17 +525,8 @@ func diffModule(left, right Module, diff *Diff) bool {
 
 // diffLogCfg returns true if any part of the log config is different or if any
 // services or components have been updated.
-func diffLogCfg(left, right *Config, servicesDifferent, componentsDifferent bool, diff *Diff) bool {
-	if !reflect.DeepEqual(left.LogConfig, right.LogConfig) {
-		return true
-	}
-	// the `log` fields are equal when their DeepEqual is true.
-	diff.LogFieldEqual = true
-	// If there was any change in services or components; attempt to update logger levels.
-	if servicesDifferent || componentsDifferent {
-		return true
-	}
-	return false
+func diffLogCfg(left, right *Config) bool {
+	return !reflect.DeepEqual(left.LogConfig, right.LogConfig)
 }
 
 //nolint:dupl

--- a/config/diff.go
+++ b/config/diff.go
@@ -523,8 +523,7 @@ func diffModule(left, right Module, diff *Diff) bool {
 	return true
 }
 
-// diffLogCfg returns true if any part of the log config is different or if any
-// services or components have been updated.
+// diffLogCfg returns true if any part of the log config is different.
 func diffLogCfg(left, right *Config) bool {
 	return !reflect.DeepEqual(left.LogConfig, right.LogConfig)
 }

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -389,11 +389,15 @@ func (s *robotServer) configWatcher(ctx context.Context, currCfg *config.Config,
 			//
 			// This functionality is tested in `TestLogPropagation` in `local_robot_test.go`.
 			if !diff.LogEqual {
-				s.logger.Debug("Detected potential changes to log patterns; updating logger levels")
-				s.logger.Warn(
-					"Changes to 'log' field may not affect modular logs. " +
-						"Use 'log_level' in module config or 'log_configuration' in resource config instead",
-				)
+				// Only display the warning when the user attempted to change the `log` field of
+				// the config.
+				if !diff.LogFieldEqual {
+					s.logger.Debug("Detected potential changes to log patterns; updating logger levels")
+					s.logger.Warn(
+						"Changes to 'log' field may not affect modular logs. " +
+							"Use 'log_level' in module config or 'log_configuration' in resource config instead",
+					)
+				}
 				config.UpdateLoggerRegistryFromConfig(s.registry, processedConfig, s.logger)
 			}
 

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -388,10 +388,10 @@ func (s *robotServer) configWatcher(ctx context.Context, currCfg *config.Config,
 			// Update logger registry if log patterns may have changed.
 			//
 			// This functionality is tested in `TestLogPropagation` in `local_robot_test.go`.
-			if !diff.LogEqual {
+			if !diff.LogEqual || !diff.ResourcesEqual {
 				// Only display the warning when the user attempted to change the `log` field of
 				// the config.
-				if !diff.LogFieldEqual {
+				if !diff.LogEqual {
 					s.logger.Debug("Detected potential changes to log patterns; updating logger levels")
 					s.logger.Warn(
 						"Changes to 'log' field may not affect modular logs. " +


### PR DESCRIPTION
The warning was logged too often because the `LogEqual` field of Diff struct is set to false even when `log` fields are the same, but some of the components or services have changed (in an effort to propagate their own loggers and applied patterns from `log`). I have added an extra field to keep track of the equality of the `log` field specifically, which helps to only output the warning only when the `log` field was actually changed. 