### PR TITLE
Add PartID when exporting dataset

### DIFF
--- a/cli/dataset.go
+++ b/cli/dataset.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
@@ -241,9 +240,9 @@ type ImageMetadata struct {
 	ImagePath                 string           `json:"image_path"`
 	ClassificationAnnotations []Annotation     `json:"classification_annotations"`
 	BBoxAnnotations           []BBoxAnnotation `json:"bounding_box_annotations"`
+	Timestamp                 string           `json:"timestamp"`
 	PartID                    string           `json:"part_id"`
 	ComponentName             string           `json:"component_name"`
-	Timestamp                 time.Time        `json:"timestamp"`
 }
 
 // BBoxAnnotation holds the information associated with each bounding box.
@@ -303,7 +302,7 @@ func binaryDataToJSONLines(ctx context.Context, client datapb.DataServiceClient,
 		BBoxAnnotations:           bboxAnnotations,
 		PartID:                    datum.GetMetadata().GetCaptureMetadata().GetPartId(),
 		ComponentName:             datum.GetMetadata().GetCaptureMetadata().GetComponentName(),
-		Timestamp:                 datum.GetMetadata().GetTimeRequested().AsTime(),
+		Timestamp:                 datum.GetMetadata().GetTimeRequested().AsTime().String(),
 	}
 
 	line, err := json.Marshal(jsonl)


### PR DESCRIPTION
Enables easier local development for Kongsberg LSTM classifier.