### PR TITLE
DATA-3781: Deprecating AddTagsToBinaryDataByFilter/RemoveTagsFromBinaryDataByFilter

### DIFF
--- a/cli/data.go
+++ b/cli/data.go
@@ -888,7 +888,6 @@ func (c *viamClient) dataAddTagsToBinaryByFilter(filter *datapb.Filter, tags []s
 			_, err := c.dataClient.AddTagsToBinaryDataByIDs(context.Background(),
 				&datapb.AddTagsToBinaryDataByIDsRequest{Tags: tags, BinaryDataIds: []string{id}})
 			return errors.Wrapf(err, serverErrorMessage)
-
 		},
 		filter, parallelActions,
 		func(i int32) {


### PR DESCRIPTION
We are implementing a workaround for the CLI so commands of the form `viam data tag filter add/remove --tags=new_tag_1,new_tag_2 <filter_fields>` still function, despite the deprecation of two endpoints. Tested manually.