### PR TITLE
Support multi-machine Viam apps in "viam module local-app-testing"

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -2527,8 +2527,9 @@ Note: There is no progress meter while copying is in progress.
 			HideHelpCommand: true,
 			Subcommands: []*cli.Command{
 				{
-					Name:  "local-app-testing",
-					Usage: "Test your viam application locally. This will stand up a local proxy at http://localhost:8012 to simulate the Viam app server",
+					Name: "local-app-testing",
+					Usage: "Test your viam application locally. This will stand up a local proxy at http://localhost:8012 to simulate the Viam app server. " +
+						"If testing a single-machhine app you MUST provide the machine-id parameter, omit it to test a multi-machine app.",
 					UsageText: createUsageText("module local-app-testing",
 						[]string{"app-url", "machine-id"}, false, false),
 					Flags: []cli.Flag{
@@ -2539,9 +2540,9 @@ Note: There is no progress meter while copying is in progress.
 						},
 						&cli.StringFlag{
 							Name: "machine-id",
-							Usage: "machine ID of the machine you want to test with, you can get it at " +
+							Usage: "For single-machine Viam apps: machine ID of the machine you want to test with, you can get it at " +
 								"https://app.viam.com/fleet/machines",
-							Required: true,
+							Required: false,
 						},
 					},
 					Action: createCommandWithT[localAppTestingArgs](LocalAppTestingAction),

--- a/cli/app.go
+++ b/cli/app.go
@@ -2529,7 +2529,7 @@ Note: There is no progress meter while copying is in progress.
 				{
 					Name: "local-app-testing",
 					Usage: "Test your viam application locally. This will stand up a local proxy at http://localhost:8012 to simulate " +
-						"the Viam app server. If testing a single-machhine app you MUST provide the machine-id parameter, " +
+						"the Viam app server. If testing a single-machine app you MUST provide the machine-id parameter, " +
 						"omit it to test a multi-machine app.",
 					UsageText: createUsageText("module local-app-testing",
 						[]string{"app-url", "machine-id"}, false, false),

--- a/cli/app.go
+++ b/cli/app.go
@@ -2528,8 +2528,9 @@ Note: There is no progress meter while copying is in progress.
 			Subcommands: []*cli.Command{
 				{
 					Name: "local-app-testing",
-					Usage: "Test your viam application locally. This will stand up a local proxy at http://localhost:8012 to simulate the Viam app server. " +
-						"If testing a single-machhine app you MUST provide the machine-id parameter, omit it to test a multi-machine app.",
+					Usage: "Test your viam application locally. This will stand up a local proxy at http://localhost:8012 to simulate " +
+						"the Viam app server. If testing a single-machhine app you MUST provide the machine-id parameter, " +
+						"omit it to test a multi-machine app.",
 					UsageText: createUsageText("module local-app-testing",
 						[]string{"app-url", "machine-id"}, false, false),
 					Flags: []cli.Flag{

--- a/cli/module_local_viam_apps_setup.go
+++ b/cli/module_local_viam_apps_setup.go
@@ -79,7 +79,8 @@ func LocalAppTestingAction(ctx *cli.Context, args localAppTestingArgs) error {
 
 		currentToken, found := viamClient.conf.Auth.(*token)
 		if !found || currentToken.AccessToken == "" {
-			printf(ctx.App.ErrWriter, "You need an access token configured in the CLI to proceed. Run the `viam login` command to re-authenticate, do NOT use an API key")
+			printf(ctx.App.ErrWriter, "You need an access token configured in the CLI to proceed. "+
+				"Run the `viam login` command to re-authenticate, do NOT use an API key")
 		}
 
 		httpServer = localAppTesting.setupHTTPServerMultiMachineApp(serverPort, args.AppURL, currentToken.AccessToken)

--- a/cli/module_local_viam_apps_setup.go
+++ b/cli/module_local_viam_apps_setup.go
@@ -311,7 +311,7 @@ func (l *localAppTestingServer) addBaseTagToHTMLResponse() func(resp *http.Respo
 }
 
 // setupHTTPServerMultiMachineApp creates and configures an HTTP server for a multi-machine Viam app.
-func (l *localAppTestingServer) setupHTTPServerMultiMachineApp(port int, targetURL string, accessToken string) *http.Server {
+func (l *localAppTestingServer) setupHTTPServerMultiMachineApp(port int, targetURL, accessToken string) *http.Server {
 	// Endpoint to start the flow
 	http.HandleFunc("/start", l.multiMachineCookieSetup(accessToken))
 

--- a/cli/module_local_viam_apps_setup.go
+++ b/cli/module_local_viam_apps_setup.go
@@ -42,30 +42,49 @@ func LocalAppTestingAction(ctx *cli.Context, args localAppTestingArgs) error {
 		return err
 	}
 
-	machineAPIKeyID, machineAPIKey, err := getMachineAPIKeys(ctx.Context, viamClient.client, args.MachineID)
-	if err != nil {
-		return err
-	}
-
-	machineHostname, err := getMachineHostname(ctx.Context, viamClient.client, args.MachineID)
-	if err != nil {
-		return err
-	}
-
 	localAppTesting := localAppTestingServer{
-		machineID:       args.MachineID,
-		machineHostname: machineHostname,
-		machineAPIKey:   machineAPIKey,
-		machineAPIKeyID: machineAPIKeyID,
-		serverURL:       fmt.Sprintf("http://localhost:%d", serverPort),
-		logger:          ctx.App.Writer,
+		serverURL: fmt.Sprintf("http://localhost:%d", serverPort),
+		logger:    ctx.App.Writer,
 	}
-
-	httpServer := localAppTesting.setupHTTPServer(serverPort, args.AppURL)
 
 	printf(ctx.App.Writer, "Starting server to locally test viam apps on %s", localAppTesting.serverURL)
 	printf(ctx.App.Writer, "Proxying local app from: %s", args.AppURL)
+	if args.MachineID != "" {
+		printf(ctx.App.Writer, "Local testing for a single-machine Viam app, machine ID: %s", args.MachineID)
+	} else {
+		printf(ctx.App.Writer, "Local testing for a multi-machine Viam app")
+	}
 	printf(ctx.App.Writer, "Press Ctrl+C to stop the server")
+
+	var httpServer *http.Server
+
+	// Single-machine Viam app
+	if args.MachineID != "" {
+		machineAPIKeyID, machineAPIKey, err := getMachineAPIKeys(ctx.Context, viamClient.client, args.MachineID)
+		if err != nil {
+			return err
+		}
+
+		machineHostname, err := getMachineHostname(ctx.Context, viamClient.client, args.MachineID)
+		if err != nil {
+			return err
+		}
+
+		localAppTesting.machineID = args.MachineID
+		localAppTesting.machineHostname = machineHostname
+		localAppTesting.machineAPIKey = machineAPIKey
+		localAppTesting.machineAPIKeyID = machineAPIKeyID
+
+		httpServer = localAppTesting.setupHTTPServerSingleMachineApp(serverPort, args.AppURL)
+	} else {
+		// Multi machine Viam app
+		currentToken, found := viamClient.conf.Auth.(*token)
+		if !found || currentToken.AccessToken == "" {
+			printf(ctx.App.ErrWriter, "You need an access token configured in the CLI to proceed. Run the `viam login` command to re-authenticate, do NOT use an API key")
+		}
+
+		httpServer = localAppTesting.setupHTTPServerMultiMachineApp(serverPort, args.AppURL, currentToken.AccessToken)
+	}
 
 	if err := startServerInBackground(httpServer, ctx.App.Writer); err != nil {
 		return fmt.Errorf("failed to start server: %w", err)
@@ -118,10 +137,10 @@ func getMachineHostname(ctx context.Context, viamAppClient apppb.AppServiceClien
 	return "", errors.New("Could not resolve machine hostname, no main part found")
 }
 
-// setupHTTPServer creates and configures an HTTP server with the given HTML file.
-func (l *localAppTestingServer) setupHTTPServer(port int, targetURL string) *http.Server {
+// setupHTTPServerSingleMachineApp creates and configures an HTTP server for a single-machine Viam app.
+func (l *localAppTestingServer) setupHTTPServerSingleMachineApp(port int, targetURL string) *http.Server {
 	// Endpoint to start the flow
-	http.HandleFunc("/start", l.cookieSetup)
+	http.HandleFunc("/start", l.singleMachineCookieSetup)
 
 	// Proxy setup
 	targetURLParsed, err := url.Parse(targetURL)
@@ -164,7 +183,7 @@ type machineAPIKey struct {
 	ID  string `json:"id"`
 }
 
-func (l *localAppTestingServer) cookieSetup(resp http.ResponseWriter, req *http.Request) {
+func (l *localAppTestingServer) singleMachineCookieSetup(resp http.ResponseWriter, req *http.Request) {
 	// Generate machine auth cookie
 	cookieValue := machineAuthCookieValue{
 		Hostname:  l.machineHostname,
@@ -288,6 +307,55 @@ func (l *localAppTestingServer) addBaseTagToHTMLResponse() func(resp *http.Respo
 			}
 		}
 		return nil
+	}
+}
+
+// setupHTTPServerMultiMachineApp creates and configures an HTTP server for a multi-machine Viam app.
+func (l *localAppTestingServer) setupHTTPServerMultiMachineApp(port int, targetURL string, accessToken string) *http.Server {
+	// Endpoint to start the flow
+	http.HandleFunc("/start", l.multiMachineCookieSetup(accessToken))
+
+	// Proxy setup
+	targetURLParsed, err := url.Parse(targetURL)
+	if err != nil {
+		printf(l.logger, "Error parsing target URL: %v", err)
+		return nil
+	}
+	proxy := httputil.NewSingleHostReverseProxy(targetURLParsed)
+
+	http.Handle("/", proxy)
+
+	return &http.Server{
+		Addr:              fmt.Sprintf(":%d", port),
+		ReadHeaderTimeout: time.Minute * 5,
+	}
+}
+
+type userTokenCookie struct {
+	AccesToken string `json:"access_token"`
+}
+
+func (l *localAppTestingServer) multiMachineCookieSetup(accessToken string) func(http.ResponseWriter, *http.Request) {
+	return func(resp http.ResponseWriter, req *http.Request) {
+		// Generate user token cookie
+		cookieValue := userTokenCookie{
+			AccesToken: accessToken,
+		}
+
+		cookieValueBytes, err := json.Marshal(cookieValue)
+		if err != nil {
+			printf(l.logger, err.Error())
+		}
+		cookieValueString := url.QueryEscape(string(cookieValueBytes))
+
+		// Add cookie
+		http.SetCookie(resp, &http.Cookie{
+			Name:  "userToken",
+			Value: cookieValueString,
+		})
+
+		// redirect to the selected path
+		http.Redirect(resp, req, "/", http.StatusFound)
 	}
 }
 

--- a/cli/module_local_viam_apps_setup.go
+++ b/cli/module_local_viam_apps_setup.go
@@ -49,17 +49,14 @@ func LocalAppTestingAction(ctx *cli.Context, args localAppTestingArgs) error {
 
 	printf(ctx.App.Writer, "Starting server to locally test viam apps on %s", localAppTesting.serverURL)
 	printf(ctx.App.Writer, "Proxying local app from: %s", args.AppURL)
-	if args.MachineID != "" {
-		printf(ctx.App.Writer, "Local testing for a single-machine Viam app, machine ID: %s", args.MachineID)
-	} else {
-		printf(ctx.App.Writer, "Local testing for a multi-machine Viam app")
-	}
 	printf(ctx.App.Writer, "Press Ctrl+C to stop the server")
 
 	var httpServer *http.Server
 
 	// Single-machine Viam app
 	if args.MachineID != "" {
+		printf(ctx.App.Writer, "Local testing for a single-machine Viam app, machine ID: %s", args.MachineID)
+
 		machineAPIKeyID, machineAPIKey, err := getMachineAPIKeys(ctx.Context, viamClient.client, args.MachineID)
 		if err != nil {
 			return err
@@ -78,6 +75,8 @@ func LocalAppTestingAction(ctx *cli.Context, args localAppTestingArgs) error {
 		httpServer = localAppTesting.setupHTTPServerSingleMachineApp(serverPort, args.AppURL)
 	} else {
 		// Multi machine Viam app
+		printf(ctx.App.Writer, "Local testing for a multi-machine Viam app")
+
 		currentToken, found := viamClient.conf.Auth.(*token)
 		if !found || currentToken.AccessToken == "" {
 			printf(ctx.App.ErrWriter, "You need an access token configured in the CLI to proceed. Run the `viam login` command to re-authenticate, do NOT use an API key")


### PR DESCRIPTION
https://viam.atlassian.net/browse/APP-9074

Extend the `viam module local-app-testing` CLI command to support multi-machine Viam apps.

We use the `--machine-id` CLI argument to determine if we should run the local testing for a single machine Viam app setup or a multi-machine one.
For the multi-machine setup we extract the access token from the CLI context and return it as a cookie as the Viam app server does.

```
viam module local-app-testing -h
NAME:
   viam module local-app-testing - Test your viam application locally. This will stand up a local proxy at http://localhost:8012 to simulate the Viam app server. If testing a single-machhine app you MUST provide the machine-id parameter, omit it to test a multi-machine app.

USAGE:
   viam module local-app-testing --app-url=<app-url> --machine-id=<machine-id>

OPTIONS:
   --app-url value     url where local app is running (including port number), e.g http://localhost:5000
   --machine-id value  For single-machine Viam apps: machine ID of the machine you want to test with, you can get it at https://app.viam.com/fleet/machines
```

Both the multi-machine and single-machine modes were tested locally