### PR TITLE
RSDK-11680 Include time elapsed in slow shutdown log for machine

### DIFF
--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -445,6 +445,7 @@ func (s *robotServer) serveWeb(ctx context.Context, cfg *config.Config) (err err
 		defer close(forceShutdown)
 
 		<-ctx.Done()
+		shutdownStarted := time.Now()
 
 		slowTicker := time.NewTicker(10 * time.Second)
 		defer slowTicker.Stop()
@@ -488,7 +489,8 @@ func (s *robotServer) serveWeb(ctx context.Context, cfg *config.Config) (err err
 				if checkDone() {
 					return
 				}
-				s.logger.Warn("waiting for clean shutdown")
+				s.logger.Warnw("Waiting for clean shutdown", "time_elapsed",
+					time.Since(shutdownStarted).String())
 			}
 		}
 	})


### PR DESCRIPTION
 Adds `time_elapsed` field to the slow shutdown warning log that ticks every 20s. 

New log Looks like this locally:
```
2025-08-19T16:05:53.129Z	WARN	rdk	server/entrypoint.go:492	Waiting for clean shutdown	{"time_elapsed":"10.001088209s"}
```
And like this on app:
```
8/19/2025, 12:05:53 PM warn rdk   server/entrypoint.go:492   Waiting for clean shutdown   time_elapsed 10.001088209s
```


[This log](https://github.com/viamrobotics/rdk/blob/053ae5c1c6dde3c834dd3802afd15feb3dca8a86/web/server/entrypoint.go#L491-L491) is missing time elapsed, so it both gets deduped and is lacking key information.