### PR TITLE
Reenable windows entrypoint tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,7 +105,7 @@ jobs:
         GOFLAGS: "-tags=no_cgo"
       run:
         # note: this is a subset of tests that are known to pass on windows
-        go run gotest.tools/gotestsum --format standard-verbose --jsonfile json.log ./module ./logging/...
+        go run gotest.tools/gotestsum --format standard-verbose --jsonfile json.log ./web/server ./module ./logging/...
 
     - name: Upload test.json
       if: always()


### PR DESCRIPTION
this isn't great in the sense that modules still don't seem to be working (perhaps related to https://github.com/actions/runner-images/issues/12744)

but at least this test will ensure that the executable itself can start up