### PR TITLE
[APP-8840] Add support for adding prefix to remote config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -377,6 +377,7 @@ type Remote struct {
 
 	// Secret is a helper for a robot location secret.
 	Secret string
+	Prefix string
 
 	alreadyValidated bool
 	cachedErr        error
@@ -396,6 +397,7 @@ type remoteData struct {
 
 	// Secret is a helper for a robot location secret.
 	Secret string `json:"secret"`
+	Prefix string `json:"prefix,omitempty"`
 }
 
 // Equals checks if the two configs are deeply equal to each other.
@@ -423,6 +425,7 @@ func (conf *Remote) UnmarshalJSON(data []byte) error {
 		Insecure:                  temp.Insecure,
 		AssociatedResourceConfigs: temp.AssociatedResourceConfigs,
 		Secret:                    temp.Secret,
+		Prefix:                    temp.Prefix,
 	}
 	if temp.ConnectionCheckInterval != "" {
 		dur, err := time.ParseDuration(temp.ConnectionCheckInterval)
@@ -452,6 +455,9 @@ func (conf Remote) MarshalJSON() ([]byte, error) {
 		Insecure:                  conf.Insecure,
 		AssociatedResourceConfigs: conf.AssociatedResourceConfigs,
 		Secret:                    conf.Secret,
+	}
+	if conf.Prefix != "" {
+		temp.Prefix = conf.Prefix
 	}
 	if conf.ConnectionCheckInterval != 0 {
 		temp.ConnectionCheckInterval = conf.ConnectionCheckInterval.String()

--- a/config/proto_conversions.go
+++ b/config/proto_conversions.go
@@ -556,6 +556,7 @@ func RemoteConfigToProto(remote *Remote) (*pb.RemoteConfig, error) {
 		ServiceConfigs:          serviceConfigs,
 		Secret:                  remote.Secret,
 		Auth:                    remoteAuth,
+		Prefix:                  remote.Prefix,
 	}
 
 	if remote.Frame != nil {

--- a/config/proto_conversions.go
+++ b/config/proto_conversions.go
@@ -586,6 +586,7 @@ func RemoteConfigFromProto(proto *pb.RemoteConfig, _ logging.Logger) (*Remote, e
 		ReconnectInterval:         proto.ReconnectInterval.AsDuration(),
 		AssociatedResourceConfigs: associatedResourceConfigs,
 		Secret:                    proto.GetSecret(),
+		Prefix:                    proto.GetPrefix(),
 	}
 
 	if proto.GetAuth() != nil {

--- a/config/proto_conversions_test.go
+++ b/config/proto_conversions_test.go
@@ -102,6 +102,7 @@ var testRemote = Remote{
 			},
 		},
 	},
+	Prefix: "some-prefix",
 }
 
 var testService = resource.Config{
@@ -562,6 +563,7 @@ func validateRemote(t *testing.T, actual, expected Remote) {
 	test.That(t, actual.Insecure, test.ShouldEqual, expected.Insecure)
 	test.That(t, actual.ReconnectInterval, test.ShouldEqual, expected.ReconnectInterval)
 	test.That(t, actual.ConnectionCheckInterval, test.ShouldEqual, expected.ConnectionCheckInterval)
+	test.That(t, actual.Prefix, test.ShouldEqual, expected.Prefix)
 	test.That(t, actual.Auth, test.ShouldResemble, expected.Auth)
 	f1, err := actual.Frame.ParseConfig()
 	test.That(t, err, test.ShouldBeNil)
@@ -604,13 +606,14 @@ func TestRemoteConfigToProto(t *testing.T) {
 		proto := pb.RemoteConfig{
 			Name:    "some-name",
 			Address: "localohst:8080",
+			Prefix:  "test-prefix",
 		}
 
 		out, err := RemoteConfigFromProto(&proto, logger)
 		test.That(t, err, test.ShouldBeNil)
-
 		test.That(t, out.Name, test.ShouldEqual, proto.Name)
 		test.That(t, out.Address, test.ShouldEqual, proto.Address)
+		test.That(t, out.Prefix, test.ShouldEqual, proto.Prefix)
 		test.That(t, out.Auth, test.ShouldResemble, RemoteAuth{})
 	})
 }

--- a/config/proto_conversions_test.go
+++ b/config/proto_conversions_test.go
@@ -606,7 +606,7 @@ func TestRemoteConfigToProto(t *testing.T) {
 		proto := pb.RemoteConfig{
 			Name:    "some-name",
 			Address: "localohst:8080",
-			Prefix:  "test-prefix",
+			Prefix:  "some-prefix",
 		}
 
 		out, err := RemoteConfigFromProto(&proto, logger)


### PR DESCRIPTION
- Add `Prefix` field to `Remote` and `remoteData` structs in `config/config.go`
- Add Prefix handling to `MarshalJSON` and `UnmarshalJSON` functions in `config/config.go`
- Add Prefix handling to `RemoteConfigToProto` and `RemoteConfigFromProto` functions in `config/proto_conversions.go`
- Add `Prefix` field to `testRemote`, add Prefix handling to `validateRemote` function and `TestRemoteConfigToProto` test in `config/proto_conversions_test.go`