### PR TITLE
[APP-8439] Ensure VIAM_MODULE_ROOT is set for local modules

### DIFF
--- a/config/module.go
+++ b/config/module.go
@@ -180,8 +180,8 @@ func (m Module) SyntheticPackage() (PackageConfig, error) {
 	return PackageConfig{Name: name, Package: name, Type: PackageTypeModule, Version: m.LocalVersion}, nil
 }
 
-// exeDir returns the parent directory for the unpacked module.
-func (m Module) exeDir(packagesDir string) (string, error) {
+// ExeDir returns the parent directory for the unpacked module.
+func (m Module) ExeDir(packagesDir string) (string, error) {
 	if !m.NeedsSyntheticPackage() {
 		return filepath.Dir(m.ExePath), nil
 	}
@@ -218,7 +218,7 @@ func (m Module) EvaluateExePath(packagesDir string) (string, error) {
 	if !filepath.IsAbs(path) {
 		return "", fmt.Errorf("expected ExePath to be absolute path, got %s", path)
 	}
-	exeDir, err := m.exeDir(packagesDir)
+	exeDir, err := m.ExeDir(packagesDir)
 	if err != nil {
 		return "", err
 	}
@@ -270,7 +270,7 @@ func (m *Module) FirstRun(
 ) error {
 	logger = logger.Sublogger("first_run").WithFields("module", m.Name)
 
-	unpackedModDir, err := m.exeDir(localPackagesDir)
+	unpackedModDir, err := m.ExeDir(localPackagesDir)
 	if err != nil {
 		return err
 	}

--- a/config/module_test.go
+++ b/config/module_test.go
@@ -40,7 +40,7 @@ func TestInternalMeta(t *testing.T) {
 		})
 
 		t.Run("meta.json present", func(t *testing.T) {
-			exeDir, err := mod.exeDir(packagesDir)
+			exeDir, err := mod.ExeDir(packagesDir)
 			test.That(t, err, test.ShouldBeNil)
 			manifest := JSONManifest{Entrypoint: "entry"}
 			testWriteJSON(t, filepath.Join(exeDir, "meta.json"), manifest)
@@ -91,7 +91,7 @@ func TestSyntheticModule(t *testing.T) {
 	})
 
 	t.Run("syntheticPackageExeDir", func(t *testing.T) {
-		dir, err := modNeedsSynthetic.exeDir(tmp)
+		dir, err := modNeedsSynthetic.ExeDir(tmp)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, dir, test.ShouldEqual, filepath.Join(tmp, "data/module/synthetic--"))
 	})

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -1046,23 +1046,20 @@ func getFullEnvironment(
 
 	// For local non-tarball modules, we set VIAM_MODULE_ROOT to the directory containing the executable.
 	// For local tarball modules, we set VIAM_MODULE_ROOT to the directory containing the synthetic package.
+	// VIAM_MODULE_ROOT is filled out by app.viam.com in cloud robots.
 	if _, exists := environment["VIAM_MODULE_ROOT"]; !exists && cfg.Type == config.ModuleTypeLocal {
 		var moduleRoot string
 
 		if cfg.NeedsSyntheticPackage() {
-			pkg, _ := cfg.SyntheticPackage() // Is it safe to call this more than once? Should be ok
-			moduleRoot = pkg.LocalDataDirectory(packagesDir)
+			moduleRoot = packagesDir
 		} else {
 			moduleRoot = filepath.Dir(cfg.ExePath)
 		}
 
 		environment["VIAM_MODULE_ROOT"] = moduleRoot
 	}
-	// Besides explicitly setting VIAM_MODULE_ROOT, can it be set anywhere else for local modules?
-	// Note: Does not actually modify the config to have VIAM_MODULE_ROOT set, but will propagate to modules pexec. Does this matter?
 
 	// Overwrite the base environment variables with the module's environment variables (if specified)
-	// VIAM_MODULE_ROOT is filled out by app.viam.com in cloud robots.
 	for key, value := range cfg.Environment {
 		environment[key] = value
 	}

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -1046,7 +1046,7 @@ func getFullEnvironment(
 
 	// For local modules, we set VIAM_MODULE_ROOT to the parent directory of the unpacked module.
 	// VIAM_MODULE_ROOT is filled out by app.viam.com in cloud robots.
-	if _, exists := environment["VIAM_MODULE_ROOT"]; !exists && cfg.Type == config.ModuleTypeLocal {
+	if cfg.Type == config.ModuleTypeLocal {
 		moduleRoot, err := cfg.ExeDir(packagesDir)
 		// err should never not be nil since we are working with local modules
 		if err == nil {

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -1048,6 +1048,7 @@ func getFullEnvironment(
 	// VIAM_MODULE_ROOT is filled out by app.viam.com in cloud robots.
 	if _, exists := environment["VIAM_MODULE_ROOT"]; !exists && cfg.Type == config.ModuleTypeLocal {
 		moduleRoot, err := cfg.ExeDir(packagesDir)
+		// err should never not be nil since we are working with local modules
 		if err == nil {
 			environment["VIAM_MODULE_ROOT"] = moduleRoot
 		}

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -1044,19 +1044,13 @@ func getFullEnvironment(
 		environment["VIAM_MODULE_ID"] = cfg.ModuleID
 	}
 
-	// For local non-tarball modules, we set VIAM_MODULE_ROOT to the directory containing the executable.
-	// For local tarball modules, we set VIAM_MODULE_ROOT to the directory containing the synthetic package.
+	// For local modules, we set VIAM_MODULE_ROOT to the parent directory of the unpacked module.
 	// VIAM_MODULE_ROOT is filled out by app.viam.com in cloud robots.
 	if _, exists := environment["VIAM_MODULE_ROOT"]; !exists && cfg.Type == config.ModuleTypeLocal {
-		var moduleRoot string
-
-		if cfg.NeedsSyntheticPackage() {
-			moduleRoot = packagesDir
-		} else {
-			moduleRoot = filepath.Dir(cfg.ExePath)
+		moduleRoot, err := cfg.ExeDir(packagesDir)
+		if err == nil {
+			environment["VIAM_MODULE_ROOT"] = moduleRoot
 		}
-
-		environment["VIAM_MODULE_ROOT"] = moduleRoot
 	}
 
 	// Overwrite the base environment variables with the module's environment variables (if specified)

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -171,13 +171,7 @@ func TestModManagerFunctions(t *testing.T) {
 			modEnv = mod.getFullEnvironment(viamHomeTemp, filepath.Join(viamHomeTemp, "packages"))
 			_, ok = modEnv["VIAM_MODULE_ID"]
 			test.That(t, ok, test.ShouldBeFalse)
-			test.That(t, modEnv["VIAM_MODULE_ROOT"], test.ShouldEqual, filepath.Dir(modPath))
-
-			originalModPath := modPath
-			mod.cfg.ExePath = filepath.Join(modPath, "fake-module.tar.gz")
-			modEnv = mod.getFullEnvironment(viamHomeTemp, filepath.Join(viamHomeTemp, "packages"))
-			mod.cfg.ExePath = originalModPath
-			test.That(t, modEnv["VIAM_MODULE_ROOT"], test.ShouldEqual, filepath.Join(viamHomeTemp, "packages"))
+			test.That(t, modEnv["VIAM_MODULE_ROOT"], test.ShouldNotBeEmpty)
 
 			// Make a copy of addr and client to test that connections are properly remade
 			oldAddr := mod.addr

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -166,12 +166,18 @@ func TestModManagerFunctions(t *testing.T) {
 			test.That(t, modEnv["VIAM_MODULE_ID"], test.ShouldEqual, "new:york")
 			test.That(t, modEnv["SMART"], test.ShouldEqual, "MACHINES")
 
-			// Test that VIAM_MODULE_ID is unset and VIAM_MODULE_ROOT is set correctly the exePath for local non-tarball modules
+			// Test that VIAM_MODULE_ID is unset and VIAM_MODULE_ROOT is set correctly for local modules
 			mod.cfg.Type = config.ModuleTypeLocal
 			modEnv = mod.getFullEnvironment(viamHomeTemp, filepath.Join(viamHomeTemp, "packages"))
 			_, ok = modEnv["VIAM_MODULE_ID"]
 			test.That(t, ok, test.ShouldBeFalse)
 			test.That(t, modEnv["VIAM_MODULE_ROOT"], test.ShouldEqual, filepath.Dir(modPath))
+
+			originalModPath := modPath
+			mod.cfg.ExePath = filepath.Join(modPath, "fake-module.tar.gz")
+			modEnv = mod.getFullEnvironment(viamHomeTemp, filepath.Join(viamHomeTemp, "packages"))
+			mod.cfg.ExePath = originalModPath
+			test.That(t, modEnv["VIAM_MODULE_ROOT"], test.ShouldEqual, filepath.Join(viamHomeTemp, "packages"))
 
 			// Make a copy of addr and client to test that connections are properly remade
 			oldAddr := mod.addr

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -160,7 +160,7 @@ func TestModManagerFunctions(t *testing.T) {
 
 			test.That(t, mod.process.Stop(), test.ShouldBeNil)
 
-			modEnv := mod.getFullEnvironment(viamHomeTemp)
+			modEnv := mod.getFullEnvironment(viamHomeTemp, filepath.Join(viamHomeTemp, "packages"))
 			test.That(t, modEnv["VIAM_HOME"], test.ShouldEqual, viamHomeTemp)
 			test.That(t, modEnv["VIAM_MODULE_DATA"], test.ShouldEqual, "module-data-dir")
 			test.That(t, modEnv["VIAM_MODULE_ID"], test.ShouldEqual, "new:york")
@@ -168,7 +168,7 @@ func TestModManagerFunctions(t *testing.T) {
 
 			// Test that VIAM_MODULE_ID is unset for local modules
 			mod.cfg.Type = config.ModuleTypeLocal
-			modEnv = mod.getFullEnvironment(viamHomeTemp)
+			modEnv = mod.getFullEnvironment(viamHomeTemp, filepath.Join(viamHomeTemp, "packages"))
 			_, ok = modEnv["VIAM_MODULE_ID"]
 			test.That(t, ok, test.ShouldBeFalse)
 

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -166,11 +166,12 @@ func TestModManagerFunctions(t *testing.T) {
 			test.That(t, modEnv["VIAM_MODULE_ID"], test.ShouldEqual, "new:york")
 			test.That(t, modEnv["SMART"], test.ShouldEqual, "MACHINES")
 
-			// Test that VIAM_MODULE_ID is unset for local modules
+			// Test that VIAM_MODULE_ID is unset and VIAM_MODULE_ROOT is set correctly the exePath for local non-tarball modules
 			mod.cfg.Type = config.ModuleTypeLocal
 			modEnv = mod.getFullEnvironment(viamHomeTemp, filepath.Join(viamHomeTemp, "packages"))
 			_, ok = modEnv["VIAM_MODULE_ID"]
 			test.That(t, ok, test.ShouldBeFalse)
+			test.That(t, modEnv["VIAM_MODULE_ROOT"], test.ShouldEqual, filepath.Dir(modPath))
 
 			// Make a copy of addr and client to test that connections are properly remade
 			oldAddr := mod.addr

--- a/module/modmanager/module.go
+++ b/module/modmanager/module.go
@@ -399,7 +399,7 @@ func (m *module) cleanupAfterCrash(mgr *Manager) {
 	}
 }
 
-func (m *module) getFullEnvironment(viamHomeDir string, packagesDir string) map[string]string {
+func (m *module) getFullEnvironment(viamHomeDir, packagesDir string) map[string]string {
 	return getFullEnvironment(m.cfg, packagesDir, m.dataDir, viamHomeDir)
 }
 

--- a/module/modmanager/module.go
+++ b/module/modmanager/module.go
@@ -190,7 +190,7 @@ func (m *module) startProcess(
 	if err != nil {
 		return err
 	}
-	moduleEnvironment := m.getFullEnvironment(viamHomeDir)
+	moduleEnvironment := m.getFullEnvironment(viamHomeDir, packagesDir)
 	// Prefer VIAM_MODULE_ROOT as the current working directory if present but fallback to the directory of the exepath
 	moduleWorkingDirectory, ok := moduleEnvironment["VIAM_MODULE_ROOT"]
 	if !ok {
@@ -399,8 +399,8 @@ func (m *module) cleanupAfterCrash(mgr *Manager) {
 	}
 }
 
-func (m *module) getFullEnvironment(viamHomeDir string) map[string]string {
-	return getFullEnvironment(m.cfg, m.dataDir, viamHomeDir)
+func (m *module) getFullEnvironment(viamHomeDir string, packagesDir string) map[string]string {
+	return getFullEnvironment(m.cfg, packagesDir, m.dataDir, viamHomeDir)
 }
 
 func (m *module) getFTDCName() string {


### PR DESCRIPTION
### Description
[APP-8439](https://viam.atlassian.net/browse/APP-8439?actionerId=615b581da7071000698f89c8&sourceType=assign) Ensure VIAM_MODULE_ROOT is set when getting module environment

* Modifies module manager's `getFullEnvironment` helper to check and set `VIAM_MODULE_ROOT` for local modules.
    * Local non-tarball root is set to the module's exe path in it's config
    * Local tarball root is set to the local package directory where it gets unpacked.


### Testing
* `TestModManagerFunctions` has a section that tests that environment variables get set correctly for registry and local modules. I extended this section by testing that the env var `VIAM_MODULE_ROOT` gets set correctly for both local non-tarball and tarball modules. 

[APP-8439]: https://viam.atlassian.net/browse/APP-8439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ