### PR TITLE
Updating github actions config for MacOS runner to point to main

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build:
+    if: ${{ false }} # This job is temporarily disabled
     runs-on: macos-13
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/pullrequest-trusted.yml
+++ b/.github/workflows/pullrequest-trusted.yml
@@ -76,7 +76,7 @@ jobs:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
   macos:
-    uses: viamrobotics/rdk/.github/workflows/macos.yml
+    uses: viamrobotics/rdk/.github/workflows/macos.yml@main
 
   license_finder:
     uses: viamrobotics/rdk/.github/workflows/license_finder.yml@main

--- a/.github/workflows/pullrequest-trusted.yml
+++ b/.github/workflows/pullrequest-trusted.yml
@@ -76,7 +76,7 @@ jobs:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
   macos:
-    uses: viamrobotics/rdk/.github/workflows/macos.yml@main
+    uses: viamrobotics/rdk/.github/workflows/macos.yml
 
   license_finder:
     uses: viamrobotics/rdk/.github/workflows/license_finder.yml@main

--- a/.github/workflows/pullrequest-trusted.yml
+++ b/.github/workflows/pullrequest-trusted.yml
@@ -76,7 +76,7 @@ jobs:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
   macos:
-    uses: viamrobotics/rdk/.github/workflows/macos.yml@testing-ci-fix
+    uses: viamrobotics/rdk/.github/workflows/macos.yml@main
 
   license_finder:
     uses: viamrobotics/rdk/.github/workflows/license_finder.yml@main


### PR DESCRIPTION
This change update the github actions config for the MacOS runner to point to the `main` branch.