### PR TITLE
more efficient implementation of BasicOctree.PointsCollidingWith()

### DIFF
--- a/pointcloud/basic_octree.go
+++ b/pointcloud/basic_octree.go
@@ -406,8 +406,9 @@ func (octree *BasicOctree) FinalizeAfterReading() (PointCloud, error) {
 // A point is considered colliding if it meets the confidence threshold and is within the collision buffer distance.
 func (octree *BasicOctree) PointsCollidingWith(geometries []spatialmath.Geometry, collisionBufferMM float64) []r3.Vector {
 	// Finding these points in an octree involves recursing into each child node of the tree.
-	// Rather than copying points from each recursive call, we pass an accumulator in, which
-	// greatly reduces the number of copies of data created.
+	// Rather than returning a list of points from each recursive call and concatenating copies of
+	// them together, we pass an accumulator in, which greatly reduces the number of copies of data
+	// created.
 	results := []r3.Vector{}
 	octree.accumulatePointsCollidingWith(geometries, collisionBufferMM, &results)
 	return results


### PR DESCRIPTION
A doubt: although the pointcloud tests in this repo pass with this change and the sanding ICP tests also pass, one of the sanding coverage tests fails with it. ~I don't think this should be merged until I get to the bottom of that issue. but it's an interesting enough PR that I don't want to forget about it over the weekend.~ edit: it's something else already changed in RDK, unrelated to this PR.

I got annoyed that the sanding tests kept using so much memory that my computer would become sluggish and sometimes my web browser would crash from OOM. So, I profiled the tests, and found that the literal majority(!) of memory was used in `BasicOctree.PointsCollidingWith()`. It uses so much memory because every time it recurses from a parent node to a child node, the child starts building the list of points anew, and then the parent copies everything the child returns into its own list.

(This is a problem because Go uses mark-and-sweep garbage collection: all copies of temporary variables remain allocated until the garbage collector finishes deciding what data is currently live, so large temporary variables can add up if allocated quickly.)

With this PR, we create just one list of points, and pass it around as an accumulator: recursing into a child node passes the pointer to the list, and then the child adds any relevant data to that list directly. Then at the very end, we return this one list of points, without ever making a second copy.

Tried in the sanding ICP tests: instead of allocating 167 gigabytes(!) of memory, this function now allocates "only" 26 gigabytes. I still don't like how memory-intensive those tests are, but this is an easy improvement. Tried in the rest of the sanding tests: one coverage test fails, which is confusing and needs to be understood before this PR should be merged.

## Old memory profile of ICP tests: 
<img width="646" height="772" alt="Screenshot_2025-09-12_14-25-34" src="https://github.com/user-attachments/assets/e0b450b2-c2ba-4590-b029-6882900ac16f" />

## New memory profile:
<img width="784" height="646" alt="Screenshot_2025-09-12_14-25-49" src="https://github.com/user-attachments/assets/4c0f6f76-966a-4d14-a5d4-35653903c014" />
