### PR TITLE
RSDK-11947 Run DNS network checks asynchronously upon app connection failure

### DIFF
--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -71,12 +71,12 @@ func NewAppConn(ctx context.Context, appAddress, secret, id string, logger loggi
 		err,
 	)
 
-	// Upon failing to dial app.viam.com, run DNS network checks to reveal more DNS
-	// information.
-	networkcheck.TestDNS(ctx, logger, false /* non-verbose to only log failures */)
-
 	appConn.dialer = utils.NewStoppableWorkers(ctx)
-
+	appConn.dialer.Add(func(ctx context.Context) {
+		// Upon failing to dial app.viam.com, run DNS network checks asynchronously to reveal
+		// more DNS information.
+		networkcheck.TestDNS(ctx, logger, false /* non-verbose to only log failures */)
+	})
 	appConn.dialer.Add(func(ctx context.Context) {
 		for {
 			if ctx.Err() != nil {


### PR DESCRIPTION
RSDK-11947

We currently run DNS network checks after the global app connection fails to establish [synchronously](https://github.com/viamrobotics/rdk/blob/ccfebbd44639d21e714816f20819284e737e0b22/grpc/app_conn.go#L76-L76). That means that if we’re truly offline, establishing the global app connection will take 2 minutes to fail, which will stop viam-agent from beginning the process of reactivating whatever connection it needs to for at least 2 minutes. We should run those checks asynchronously.