### PR TITLE
Move AIX references to viam org

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,7 +32,6 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch"]
     assignees:
-      - Otterverse
       - joncha1
       - 10zingpd
       - IanWhalen

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -119,7 +119,7 @@ jobs:
     - name: build server
       run: docker run --rm -v $PWD:/rdk ghcr.io/viamrobotics/rdk-devenv:armhf-cache sh -c "cd /rdk && make server-static"
     - name: build aix
-      run: docker run --rm -v $PWD:/rdk ghcr.io/viamrobotics/rdk-devenv:armhf-cache sh -c 'cd /rdk && GOBIN=`pwd`/bin/`uname -s`-`uname -m` go install -ldflags "-s -w" -tags osusergo,netgo github.com/Otterverse/aix@latest'
+      run: docker run --rm -v $PWD:/rdk ghcr.io/viamrobotics/rdk-devenv:armhf-cache sh -c 'cd /rdk && GOBIN=`pwd`/bin/`uname -s`-`uname -m` go install -ldflags "-s -w" -tags osusergo,netgo github.com/viamrobotics/aix@latest'
     - name: permissions
       run: sudo chown -R $USER bin
     # note: we do this because uname sees the arm64 kernel underneath the armhf container

--- a/etc/packaging/appimages/viam-server-aarch64.yml
+++ b/etc/packaging/appimages/viam-server-aarch64.yml
@@ -10,7 +10,7 @@ script:
  - cp ./install ./postupdate "$TARGET_APPDIR/aix.d/"
  - chmod 755 "$TARGET_APPDIR/aix.d/install" "$TARGET_APPDIR/aix.d/postupdate"
  - cp ./viam-server.service "$TARGET_APPDIR/"
- - go install -ldflags "-s -w" -tags osusergo,netgo github.com/Otterverse/aix@latest
+ - go install -ldflags "-s -w" -tags osusergo,netgo github.com/viamrobotics/aix@latest
  - cp `go env GOPATH`/bin/aix "$TARGET_APPDIR/usr/bin/"
  - cp `which env` "$TARGET_APPDIR/usr/bin/"
  - chmod 755 "$TARGET_APPDIR/usr/bin/"*

--- a/etc/packaging/appimages/viam-server-x86_64.yml
+++ b/etc/packaging/appimages/viam-server-x86_64.yml
@@ -10,7 +10,7 @@ script:
  - cp ./install ./postupdate "$TARGET_APPDIR/aix.d/"
  - chmod 755 "$TARGET_APPDIR/aix.d/install" "$TARGET_APPDIR/aix.d/postupdate"
  - cp ./viam-server.service "$TARGET_APPDIR/"
- - go install -ldflags "-s -w" -tags osusergo,netgo github.com/Otterverse/aix@latest
+ - go install -ldflags "-s -w" -tags osusergo,netgo github.com/viamrobotics/aix@latest
  - cp `go env GOPATH`/bin/aix "$TARGET_APPDIR/usr/bin/"
  - cp `which env` "$TARGET_APPDIR/usr/bin/"
  - chmod 755 "$TARGET_APPDIR/usr/bin/"*


### PR DESCRIPTION
Moved the AIX tool (AppImage helper) from my personal repo to the viam org. This updates the RDK uses of it.