### PR TITLE
RSDK-11954 - Remove quotes from resource build errors

### DIFF
--- a/resource/errors.go
+++ b/resource/errors.go
@@ -25,7 +25,7 @@ type notFoundError struct {
 }
 
 func (e *notFoundError) Error() string {
-	return fmt.Sprintf("resource %q not found", e.name)
+	return fmt.Sprintf("resource %v not found", e.name)
 }
 
 // NewNotAvailableError is used when a resource is not available because of some error.
@@ -45,7 +45,7 @@ type notAvailableError struct {
 }
 
 func (e *notAvailableError) Error() string {
-	return fmt.Sprintf("resource %q not available; reason=%q", e.name, e.reason)
+	return fmt.Sprintf("resource %v not available; reason=%v", e.name, e.reason)
 }
 
 // NewMustRebuildError is returned when a resource cannot be reconfigured in place and
@@ -66,7 +66,7 @@ type mustRebuildError struct {
 }
 
 func (e *mustRebuildError) Error() string {
-	return fmt.Sprintf("cannot reconfigure %q; must rebuild", e.name)
+	return fmt.Sprintf("cannot reconfigure %v; must rebuild", e.name)
 }
 
 // DependencyNotFoundError is used when a resource is not found in a dependencies.
@@ -78,7 +78,7 @@ func DependencyNotFoundError(name Name) error {
 // DependencyTypeError is used when a resource doesn't implement the expected interface.
 func DependencyTypeError[T Resource](name Name, actual interface{}) error {
 	// This error represents a coding error. Include a stack trace for diagnostics.
-	return errors.Errorf("dependency %q should be an implementation of %s but it was a %T", name, utils.TypeStr[T](), actual)
+	return errors.Errorf("dependency %v should be an implementation of %s but it was a %T", name, utils.TypeStr[T](), actual)
 }
 
 // TypeError is used when a resource is an unexpected type.

--- a/resource/errors_test.go
+++ b/resource/errors_test.go
@@ -11,13 +11,13 @@ func TestDependencyTypeError(t *testing.T) {
 	test.That(t,
 		DependencyTypeError[someRes1](name, someRes2{}).Error(),
 		test.ShouldContainSubstring,
-		`dependency "foo:bar:baz/bark" should be an implementation of resource.someRes1 but it was a resource.someRes2`,
+		`dependency foo:bar:baz/bark should be an implementation of resource.someRes1 but it was a resource.someRes2`,
 	)
 
 	test.That(t,
 		DependencyTypeError[someIfc](name, someRes2{}).Error(),
 		test.ShouldContainSubstring,
-		`dependency "foo:bar:baz/bark" should be an implementation of resource.someIfc but it was a resource.someRes2`,
+		`dependency foo:bar:baz/bark should be an implementation of resource.someIfc but it was a resource.someRes2`,
 	)
 }
 

--- a/resource/resource_graph.go
+++ b/resource/resource_graph.go
@@ -597,7 +597,7 @@ func (g *Graph) RemoveChild(child, parent Name) {
 
 func (g *Graph) addChild(child, parent Name) error {
 	if child == parent {
-		return errors.Errorf("%q cannot depend on itself", child.Name)
+		return errors.Errorf("%v cannot depend on itself", child.Name)
 	}
 	// Maybe we haven't encountered yet the parent so let's add it here and assign an uninitialized node
 	if _, ok := g.nodes.Get(parent); !ok {
@@ -605,7 +605,7 @@ func (g *Graph) addChild(child, parent Name) error {
 			return err
 		}
 	} else if g.transitiveClosureMatrix[parent][child] != 0 {
-		return errors.Errorf("circular dependency - %q already depends on %q", parent.Name, child.Name)
+		return errors.Errorf("circular dependency - %v already depends on %v", parent.Name, child.Name)
 	}
 	if _, ok := g.parents[child][parent]; ok {
 		return nil
@@ -945,7 +945,7 @@ func (g *Graph) SubGraphFrom(node Name) (*Graph, error) {
 // This method is NOT threadsafe: A client must hold [Graph.mu] while calling this method.
 func (g *Graph) subGraphFromWithMutex(node Name) (*Graph, error) {
 	if _, ok := g.nodes.Get(node); !ok {
-		return nil, errors.Errorf("cannot create sub-graph from non existing node %q ", node.Name)
+		return nil, errors.Errorf("cannot create sub-graph from non existing node %v ", node.Name)
 	}
 	subGraph := g.clone()
 	sorted := subGraph.ReverseTopologicalSort()

--- a/resource/resource_graph_test.go
+++ b/resource/resource_graph_test.go
@@ -104,7 +104,7 @@ func TestResourceGraphConstruct(t *testing.T) {
 					DependsOn: []Name{NewName(apiA, "A")},
 				},
 			},
-			"circular dependency - \"A\" already depends on \"B\"",
+			"circular dependency - A already depends on B",
 		},
 		{
 			[]fakeComponent{
@@ -117,7 +117,7 @@ func TestResourceGraphConstruct(t *testing.T) {
 					DependsOn: []Name{NewName(apiA, "B")},
 				},
 			},
-			"\"B\" cannot depend on itself",
+			"B cannot depend on itself",
 		},
 	} {
 		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
@@ -254,7 +254,7 @@ func TestResourceGraphSubGraph(t *testing.T) {
 	sg, err := g.SubGraphFrom(NewName(apiA, "W"))
 	test.That(t, sg, test.ShouldBeNil)
 	test.That(t, err.Error(), test.ShouldResemble,
-		"cannot create sub-graph from non existing node \"W\" ")
+		"cannot create sub-graph from non existing node W ")
 	sg, err = g.SubGraphFrom(NewName(apiA, "C"))
 	test.That(t, sg, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldBeNil)
@@ -307,7 +307,7 @@ func TestResourceGraphDepTree(t *testing.T) {
 	}
 	err := g.AddChild(NewName(apiA, "A"),
 		NewName(apiA, "F"))
-	test.That(t, err.Error(), test.ShouldEqual, "circular dependency - \"F\" already depends on \"A\"")
+	test.That(t, err.Error(), test.ShouldEqual, "circular dependency - F already depends on A")
 	test.That(t, g.AddChild(NewName(apiA, "D"),
 		NewName(apiA, "F")), test.ShouldBeNil)
 }

--- a/resource/resource_registry.go
+++ b/resource/resource_registry.go
@@ -70,7 +70,7 @@ type DependencyNotReadyError struct {
 }
 
 func (e *DependencyNotReadyError) Error() string {
-	return fmt.Sprintf("dependency %q is not ready yet; reason=%s", e.Name, e.Reason)
+	return fmt.Sprintf("dependency %v is not ready yet; reason=%s", e.Name, e.Reason)
 }
 
 // PrettyPrint returns a formatted string representing a `DependencyNotReadyError` error. This can be useful as a
@@ -83,10 +83,10 @@ func (e *DependencyNotReadyError) PrettyPrint() string {
 	for curError := e; curError != nil; indent = fmt.Sprintf("%v%v", indent, "  ") {
 		// Give the top-level error different language.
 		if curError == e {
-			ret.WriteString(fmt.Sprintf("Dependency %q is not ready yet\n", curError.Name))
+			ret.WriteString(fmt.Sprintf("Dependency %v is not ready yet\n", curError.Name))
 		} else {
 			ret.WriteString(indent)
-			ret.WriteString(fmt.Sprintf("- Because %q is not ready yet\n", curError.Name))
+			ret.WriteString(fmt.Sprintf("- Because %v is not ready yet\n", curError.Name))
 		}
 
 		// If the `Reason` is also of type `DependencyNotReadyError`, we keep going with the
@@ -101,7 +101,7 @@ func (e *DependencyNotReadyError) PrettyPrint() string {
 	}
 
 	ret.WriteString(indent)
-	ret.WriteString(fmt.Sprintf("- Because %q", leafError))
+	ret.WriteString(fmt.Sprintf("- Because %v", leafError))
 
 	return ret.String()
 }

--- a/resource/resource_registry_test.go
+++ b/resource/resource_registry_test.go
@@ -301,9 +301,9 @@ func TestDependencyNotReadyError(t *testing.T) {
 	human := &resource.DependencyNotReadyError{"human", leg}
 
 	test.That(t, strings.Count(human.Error(), "\\"), test.ShouldEqual, 0)
-	test.That(t, human.PrettyPrint(), test.ShouldEqual, `Dependency "human" is not ready yet
-  - Because "leg" is not ready yet
-    - Because "foot" is not ready yet
-      - Because "toe" is not ready yet
-        - Because "turf toe"`)
+	test.That(t, human.PrettyPrint(), test.ShouldEqual, `Dependency human is not ready yet
+  - Because leg is not ready yet
+    - Because foot is not ready yet
+      - Because toe is not ready yet
+        - Because turf toe`)
 }

--- a/robot/framesystem/framesystem_test.go
+++ b/robot/framesystem/framesystem_test.go
@@ -220,7 +220,7 @@ func TestNewFrameSystemFromBadConfig(t *testing.T) {
 	}{
 		{"no world node", "2", referenceframe.ErrNoWorldConnection},
 		{"frame named world", "3", errors.Errorf("cannot give frame system part the name %s", referenceframe.World)},
-		{"parent field empty", "4", errors.New("parent field in frame config for part \"cameraOver\" is empty")},
+		{"parent field empty", "4", errors.New("parent field in frame config for part cameraOver is empty")},
 	}
 
 	for _, tc := range testCases {

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -800,7 +800,7 @@ func (r *localRobot) newResource(
 	resName := conf.ResourceName()
 	resInfo, ok := resource.LookupRegistration(resName.API, conf.Model)
 	if !ok {
-		return nil, errors.Errorf("unknown resource type: API %q with model %q not registered", resName.API, conf.Model)
+		return nil, errors.Errorf("unknown resource type: API %v with model %v not registered", resName.API, conf.Model)
 	}
 
 	deps, err := r.getDependencies(resName, gNode)

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -1111,7 +1111,7 @@ func TestValidationErrorOnReconfigure(t *testing.T) {
 	s, err := r.ResourceByName(navigation.Named("fake1"))
 	test.That(t, s, test.ShouldBeNil)
 	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, "resource \"rdk:service:navigation/fake1\" not available")
+	test.That(t, err.Error(), test.ShouldContainSubstring, "resource rdk:service:navigation/fake1 not available")
 	// Test Remote Error
 	rem, ok := r.RemoteByName("remote")
 	test.That(t, rem, test.ShouldBeNil)
@@ -1193,7 +1193,7 @@ func TestConfigStartsInvalidReconfiguresValid(t *testing.T) {
 	s, err := r.ResourceByName(datamanager.Named("fake1"))
 	test.That(t, s, test.ShouldBeNil)
 	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, "resource \"rdk:service:data_manager/fake1\" not available")
+	test.That(t, err.Error(), test.ShouldContainSubstring, "resource rdk:service:data_manager/fake1 not available")
 	// Test Remote Error
 	rem, ok := r.RemoteByName("remote")
 	test.That(t, rem, test.ShouldBeNil)
@@ -1314,7 +1314,7 @@ func TestConfigStartsValidReconfiguresInvalid(t *testing.T) {
 	s, err = r.ResourceByName(datamanager.Named("fake1"))
 	test.That(t, s, test.ShouldBeNil)
 	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, "resource \"rdk:service:data_manager/fake1\" not available")
+	test.That(t, err.Error(), test.ShouldContainSubstring, "resource rdk:service:data_manager/fake1 not available")
 	// Test Remote Error
 	rem, ok = r.RemoteByName("remote")
 	test.That(t, rem, test.ShouldBeNil)
@@ -1368,7 +1368,7 @@ func TestResourceStartsOnReconfigure(t *testing.T) {
 		test.ShouldBeError,
 		resource.NewNotAvailableError(
 			base.Named("fake0"),
-			errors.New(`resource build error: unknown resource type: API "rdk:component:base" with model "rdk:builtin:random" not registered`),
+			errors.New(`resource build error: unknown resource type: API rdk:component:base with model rdk:builtin:random not registered`),
 		),
 	)
 	test.That(t, noBase, test.ShouldBeNil)
@@ -1956,7 +1956,7 @@ func TestOrphanedResources(t *testing.T) {
 		test.That(t, err, test.ShouldBeError,
 			resource.NewNotAvailableError(
 				gizmoapi.Named("g"),
-				errors.New(`resource build error: unknown resource type: API "acme:component:gizmo" with model "acme:demo:mygizmo" not registered`),
+				errors.New(`resource build error: unknown resource type: API acme:component:gizmo with model acme:demo:mygizmo not registered`),
 			),
 		)
 		test.That(t, res, test.ShouldBeNil)
@@ -1964,7 +1964,7 @@ func TestOrphanedResources(t *testing.T) {
 		test.That(t, err, test.ShouldBeError,
 			resource.NewNotAvailableError(
 				summationapi.Named("s"),
-				errors.New(`resource build error: unknown resource type: API "acme:service:summation" with model "acme:demo:mysum" not registered`),
+				errors.New(`resource build error: unknown resource type: API acme:service:summation with model acme:demo:mysum not registered`),
 			),
 		)
 		test.That(t, res, test.ShouldBeNil)
@@ -2323,14 +2323,14 @@ func TestDependentAndOrphanedResources(t *testing.T) {
 	test.That(t, err, test.ShouldBeError,
 		resource.NewNotAvailableError(
 			gizmoapi.Named("g"),
-			errors.New(`resource build error: unknown resource type: API "acme:component:gizmo" with model "acme:demo:mygizmo" not registered`),
+			errors.New(`resource build error: unknown resource type: API acme:component:gizmo with model acme:demo:mygizmo not registered`),
 		),
 	)
 	test.That(t, res, test.ShouldBeNil)
 	res, err = r.ResourceByName(resource.NewName(doodadAPI, "d"))
 	test.That(
 		t, err.Error(), test.ShouldContainSubstring,
-		`resource "rdk:component:doodad/d" not available; reason="resource build error: dependency \"g\" is not ready yet`,
+		`resource rdk:component:doodad/d not available; reason=resource build error: dependency g is not ready yet`,
 	)
 	test.That(t, res, test.ShouldBeNil)
 	_, err = r.ResourceByName(motor.Named("m"))
@@ -2538,7 +2538,7 @@ func TestCrashedModuleReconfigure(t *testing.T) {
 		test.That(t, err, test.ShouldBeError,
 			resource.NewNotAvailableError(
 				generic.Named("h"),
-				errors.New(`resource build error: unknown resource type: API "rdk:component:generic" with model "rdk:test:helper" not registered`),
+				errors.New(`resource build error: unknown resource type: API rdk:component:generic with model rdk:test:helper not registered`),
 			),
 		)
 	})

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -812,7 +812,7 @@ func (manager *resourceManager) completeConfig(
 
 						if err != nil {
 							gNode.LogAndSetLastError(
-								fmt.Errorf("resource build error: %w", err),
+								fmt.Errorf("resource build error: %v", err.Error()),
 								"resource", conf.ResourceName(),
 								"model", conf.Model)
 							return

--- a/robot/web/web_test.go
+++ b/robot/web/web_test.go
@@ -1213,7 +1213,7 @@ func TestUnaryRequestCounter(t *testing.T) {
 	_, err = genericclient.DoCommand(ctx, nil)
 	// errors here but RC still counts the request.
 	test.That(t, err.Error(), test.ShouldEqual,
-		"rpc error: code = Unknown desc = resource \"rdk:service:generic/generictest\" not found")
+		"rpc error: code = Unknown desc = resource rdk:service:generic/generictest not found")
 
 	count = svc.RequestCounter().Stats().(map[string]int64)["generictest.GenericService/DoCommand"]
 	test.That(t, count, test.ShouldEqual, 1)

--- a/services/baseremotecontrol/builtin/builtin_test.go
+++ b/services/baseremotecontrol/builtin/builtin_test.go
@@ -151,7 +151,7 @@ func TestBaseRemoteControl(t *testing.T) {
 		},
 		logger)
 	test.That(t, err, test.ShouldBeError,
-		errors.New("dependency \"rdk:component:base/baseTest\" should be an implementation of base.Base but it was a *inject.InputController"))
+		errors.New("dependency rdk:component:base/baseTest should be an implementation of base.Base but it was a *inject.InputController"))
 
 	// Controller event by mode
 	t.Run("controller events joystick control mode", func(t *testing.T) {

--- a/services/datamanager/server_test.go
+++ b/services/datamanager/server_test.go
@@ -33,7 +33,7 @@ func TestServerSync(t *testing.T) {
 	}{
 		"missing datamanager": {
 			resourceMap:   map[resource.Name]datamanager.Service{},
-			expectedError: errors.New("resource \"rdk:service:data_manager/DataManager1\" not found"),
+			expectedError: errors.New("resource rdk:service:data_manager/DataManager1 not found"),
 		},
 		"returns error": {
 			resourceMap: map[resource.Name]datamanager.Service{

--- a/services/mlmodel/server_test.go
+++ b/services/mlmodel/server_test.go
@@ -31,7 +31,7 @@ func TestServerNotFound(t *testing.T) {
 	server, err := newServer(resources)
 	test.That(t, err, test.ShouldBeNil)
 	_, err = server.Metadata(context.Background(), metadataRequest)
-	test.That(t, err, test.ShouldBeError, errors.New("resource \"rdk:service:mlmodel/mlmodel1\" not found"))
+	test.That(t, err, test.ShouldBeError, errors.New("resource rdk:service:mlmodel/mlmodel1 not found"))
 }
 
 func TestServerMetadata(t *testing.T) {

--- a/services/motion/builtin/validation_test.go
+++ b/services/motion/builtin/validation_test.go
@@ -419,7 +419,7 @@ func TestMoveCallInputs(t *testing.T) {
 				Destination:        geo.NewPoint(0, 0),
 			}
 			executionID, err := ms.MoveOnGlobe(ctx, req)
-			test.That(t, err, test.ShouldBeError, errors.New("resource \"rdk:component:base/non existent base\" not found"))
+			test.That(t, err, test.ShouldBeError, errors.New("resource rdk:component:base/non existent base not found"))
 			test.That(t, executionID, test.ShouldResemble, uuid.Nil)
 		})
 
@@ -504,7 +504,7 @@ func TestMoveCallInputs(t *testing.T) {
 				},
 			}
 			executionID, err := ms.MoveOnGlobe(ctx, req)
-			test.That(t, err, test.ShouldBeError, errors.New("resource \"rdk:component:movement_sensor/test-movement-sensor\" not found"))
+			test.That(t, err, test.ShouldBeError, errors.New("resource rdk:component:movement_sensor/test-movement-sensor not found"))
 			test.That(t, executionID, test.ShouldResemble, uuid.Nil)
 		})
 

--- a/services/motion/server_test.go
+++ b/services/motion/server_test.go
@@ -50,7 +50,7 @@ func TestServerMove(t *testing.T) {
 	server, err := newServer(resources)
 	test.That(t, err, test.ShouldBeNil)
 	_, err = server.Move(context.Background(), grabRequest)
-	test.That(t, err, test.ShouldBeError, errors.New("resource \"rdk:service:motion/motion1\" not found"))
+	test.That(t, err, test.ShouldBeError, errors.New("resource rdk:service:motion/motion1 not found"))
 
 	// error
 	injectMS := injectmotion.NewMotionService("test")
@@ -117,7 +117,7 @@ func TestServerMoveOnGlobe(t *testing.T) {
 
 		moveOnGlobeResponse, err := server.MoveOnGlobe(context.Background(), moveOnGlobeRequest)
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err, test.ShouldBeError, errors.New("resource \"rdk:service:motion/\" not found"))
+		test.That(t, err, test.ShouldBeError, errors.New("resource rdk:service:motion/ not found"))
 		test.That(t, moveOnGlobeResponse, test.ShouldBeNil)
 	})
 
@@ -300,7 +300,7 @@ func TestServerMoveOnMap(t *testing.T) {
 
 		moveOnMapResponse, err := server.MoveOnMap(context.Background(), moveOnMapRequest)
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err, test.ShouldBeError, errors.New("resource \"rdk:service:motion/\" not found"))
+		test.That(t, err, test.ShouldBeError, errors.New("resource rdk:service:motion/ not found"))
 		test.That(t, moveOnMapResponse, test.ShouldBeNil)
 	})
 
@@ -480,7 +480,7 @@ func TestServerStopPlan(t *testing.T) {
 
 		stopPlanResponse, err := server.StopPlan(context.Background(), stopPlanRequest)
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err, test.ShouldBeError, errors.New("resource \"rdk:service:motion/\" not found"))
+		test.That(t, err, test.ShouldBeError, errors.New("resource rdk:service:motion/ not found"))
 		test.That(t, stopPlanResponse, test.ShouldBeNil)
 	})
 
@@ -539,7 +539,7 @@ func TestServerListPlanStatuses(t *testing.T) {
 
 		listPlanStatusesResponse, err := server.ListPlanStatuses(context.Background(), listPlanStatusesRequest)
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err, test.ShouldBeError, errors.New("resource \"rdk:service:motion/\" not found"))
+		test.That(t, err, test.ShouldBeError, errors.New("resource rdk:service:motion/ not found"))
 		test.That(t, listPlanStatusesResponse, test.ShouldBeNil)
 	})
 
@@ -650,7 +650,7 @@ func TestServerGetPlan(t *testing.T) {
 
 		getPlanResponse, err := server.GetPlan(context.Background(), getPlanRequest)
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err, test.ShouldBeError, errors.New("resource \"rdk:service:motion/\" not found"))
+		test.That(t, err, test.ShouldBeError, errors.New("resource rdk:service:motion/ not found"))
 		test.That(t, getPlanResponse, test.ShouldBeNil)
 	})
 

--- a/services/vision/server_test.go
+++ b/services/vision/server_test.go
@@ -46,7 +46,7 @@ func TestVisionServerFailures(t *testing.T) {
 	server, err := newServer(m)
 	test.That(t, err, test.ShouldBeNil)
 	_, err = server.GetDetections(context.Background(), detectRequest)
-	test.That(t, err, test.ShouldBeError, errors.New("resource \"rdk:service:vision/vision1\" not found"))
+	test.That(t, err, test.ShouldBeError, errors.New("resource rdk:service:vision/vision1 not found"))
 	// correct server with error returned
 	injectVS := &inject.VisionService{}
 	passedErr := errors.New("fake error")


### PR DESCRIPTION
currently
```
9/18/2025, 4:55:04 PM error rdk.resource_manager.rdk:component:arm/arm-10   resource/graph_node.go:308   resource build error: dependency "arm-9" is not ready yet; reason=resource "rdk:component:arm/arm-9" not available; reason="resource build error: dependency \"arm-8\" is not ready yet; reason=resource \"rdk:component:arm/arm-8\" not available; reason=\"resource build error: dependency \\\"arm-7\\\" is not ready yet; reason=resource \\\"rdk:component:arm/arm-7\\\" not available; reason=\\\"resource build error: dependency \\\\\\\"arm-6\\\\\\\" is not ready yet; reason=resource \\\\\\\"rdk:component:arm/arm-6\\\\\\\" not available; reason=\\\\\\\"resource build error: dependency \\\\\\\\\\\\\\\"arm-5\\\\\\\\\\\\\\\" is not ready yet; reason=resource \\\\\\\\\\\\\\\"rdk:component:arm/arm-5\\\\\\\\\\\\\\\" not available; reason=\\\\\\\\\\\\\\\"resource build error: dependency \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"arm-4\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\" is not ready yet; reason=resource \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"rdk:component:arm/arm-4\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\" not available; reason=\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"resource build error: dependency \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"arm-3\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\" is not ready yet; reason=resource \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"rdk:component:arm/arm-3\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\" not available; reason=\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"resource build error: dependency \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"arm-2\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\" is not ready yet; reason=resource \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"rdk:component:arm/arm-2\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\" not available; reason=\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"resource build error: dependency \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"arm-1\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\" is not ready yet; reason=resource \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"rdk:component:arm/arm-1\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\" not available; reason=\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"resource build error: oops\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"\\\\\\\\\\\\\\\"\\\\\\\"\\\"\""   resource rdk:component:arm/arm-10  model rdk:builtin:fake
```

with this change
```
2025-09-18T21:26:20.441Z        ERROR   rdk.resource_manager.rdk:component:arm/arm-10   resource/graph_node.go:308      resource build error: dependency arm-9 is not ready yet; reason=resource rdk:component:arm/arm-9 not available; reason=resource build error: dependency arm-8 is not ready yet; reason=resource rdk:component:arm/arm-8 not available; reason=resource build error: dependency arm-7 is not ready yet; reason=resource rdk:component:arm/arm-7 not available; reason=resource build error: dependency arm-6 is not ready yet; reason=resource rdk:component:arm/arm-6 not available; reason=resource build error: dependency arm-5 is not ready yet; reason=resource rdk:component:arm/arm-5 not available; reason=resource build error: dependency arm-4 is not ready yet; reason=resource rdk:component:arm/arm-4 not available; reason=resource build error: dependency arm-3 is not ready yet; reason=resource rdk:component:arm/arm-3 not available; reason=resource build error: dependency arm-2 is not ready yet; reason=resource rdk:component:arm/arm-2 not available; reason=resource build error: dependency arm-1 is not ready yet; reason=resource rdk:component:arm/arm-1 not available; reason=resource build error: oops{"resource":"rdk:component:arm/arm-10","model":"rdk:builtin:fake"}
```
at least readable