### PR TITLE
[APP-9575] Update job manager error logging

### DIFF
--- a/robot/jobmanager/jobmanager.go
+++ b/robot/jobmanager/jobmanager.go
@@ -244,6 +244,7 @@ func (jm *JobManager) scheduleJob(jc config.JobConfig, verbose bool) {
 		jm.logger.CWarnw(jm.ctx, "Job failed to validate", "name", jc.Name, "error", err.Error())
 		return
 	}
+
 	var jobType gocron.JobDefinition
 	var jobLimitMode gocron.LimitMode
 	t, err := time.ParseDuration(jc.Schedule)
@@ -290,14 +291,17 @@ func (jm *JobManager) scheduleJob(jc config.JobConfig, verbose bool) {
 		// queued on the job scheduler, while CRON jobs are tied to the physical clock.
 		gocron.WithSingletonMode(jobLimitMode),
 	)
+
+	jobLogger := jm.logger.Sublogger(jc.Name)
+
 	if err != nil {
-		jm.logger.CErrorw(jm.ctx, "Failed to create a new job", "name", jc.Name, "error", err.Error())
+		jobLogger.CErrorw(jm.ctx, "Failed to create a new job", "name", jc.Name, "error", err.Error())
 		return
 	}
 	jobID := j.ID()
 
 	if verbose {
-		jm.logger.CInfow(jm.ctx, "Job created", "name", jc.Name)
+		jobLogger.CInfow(jm.ctx, "Job created", "name", jc.Name)
 	}
 
 	jm.namesToJobIDs[jc.Name] = jobID


### PR DESCRIPTION
**Context:**
Currently job scheduler errors are not job-name-specific (e.g. `rdk.job_manager`). This makes it impossible for app frontend to show job errors inside a job card. This PR changes job scheduler errors to be job-name-specific (e.g. `rdk.job_manager.job-1`).

**Changes:**
- Updates `scheduleJob` function in `jobmanager.go` to make job creation error and info logs job-name-specific. Validation error remains not job-name-specific in case the name field is missing.