### PR TITLE
RSDK-11955 - Facilitate revert of goutils ClientConn interface change

### DIFF
--- a/app/viam_client_test.go
+++ b/app/viam_client_test.go
@@ -16,7 +16,6 @@ import (
 	"go.viam.com/utils"
 	"go.viam.com/utils/rpc"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/connectivity"
 
 	"go.viam.com/rdk/logging"
 	rutils "go.viam.com/rdk/utils"
@@ -44,8 +43,6 @@ func (m *MockConn) Invoke(ctx context.Context, method string, args, reply any, o
 	return nil
 }
 func (m *MockConn) PeerConn() *webrtc.PeerConnection { return nil }
-
-func (m *MockConn) GetState() connectivity.State { return rpc.Unknown }
 
 func (m *MockConn) Close() error { return nil }
 func mockDialDirectGRPC(

--- a/app/viam_client_test.go
+++ b/app/viam_client_test.go
@@ -16,6 +16,7 @@ import (
 	"go.viam.com/utils"
 	"go.viam.com/utils/rpc"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 
 	"go.viam.com/rdk/logging"
 	rutils "go.viam.com/rdk/utils"
@@ -43,6 +44,11 @@ func (m *MockConn) Invoke(ctx context.Context, method string, args, reply any, o
 	return nil
 }
 func (m *MockConn) PeerConn() *webrtc.PeerConnection { return nil }
+
+func (m *MockConn) GetState() connectivity.State {
+	// TO BE REMOVED after v0.94.0
+	return connectivity.Idle
+}
 
 func (m *MockConn) Close() error { return nil }
 func mockDialDirectGRPC(

--- a/grpc/app_conn.go
+++ b/grpc/app_conn.go
@@ -14,6 +14,13 @@ import (
 	"go.viam.com/rdk/web/networkcheck"
 )
 
+// ConnectivityState allows callers to check the connectivity state of
+// the connection
+// see https://github.com/grpc/grpc-go/blob/master/clientconn.go#L648
+type ConnectivityState interface {
+	GetState() connectivity.State
+}
+
 // AppConn maintains an underlying client connection meant to be used globally to connect to App. The `AppConn` constructor repeatedly
 // attempts to dial App until a connection is successfully established.
 type AppConn struct {
@@ -109,7 +116,11 @@ func (ac *AppConn) GetState() connectivity.State {
 		return connectivity.Connecting
 	}
 
-	return ac.conn.GetState()
+	checker, ok := ac.conn.(ConnectivityState)
+	if !ok {
+		return connectivity.Connecting
+	}
+	return checker.GetState()
 }
 
 // Close attempts to close the underlying connection and stops background dialing attempts.

--- a/grpc/conn.go
+++ b/grpc/conn.go
@@ -9,7 +9,6 @@ import (
 	"go.viam.com/utils/rpc"
 	"golang.org/x/exp/maps"
 	googlegrpc "google.golang.org/grpc"
-	"google.golang.org/grpc/connectivity"
 
 	"go.viam.com/rdk/logging"
 )
@@ -100,18 +99,6 @@ func (c *ReconfigurableClientConn) PeerConn() *webrtc.PeerConnection {
 	}
 
 	return c.conn.PeerConn()
-}
-
-// GetState returns the current state of the connection.
-func (c *ReconfigurableClientConn) GetState() connectivity.State {
-	c.connMu.RLock()
-	defer c.connMu.RUnlock()
-
-	if c.conn == nil {
-		return rpc.Unknown
-	}
-
-	return c.conn.GetState()
 }
 
 // Close attempts to close the underlying client connection if there is one.

--- a/grpc/conn.go
+++ b/grpc/conn.go
@@ -9,6 +9,7 @@ import (
 	"go.viam.com/utils/rpc"
 	"golang.org/x/exp/maps"
 	googlegrpc "google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 
 	"go.viam.com/rdk/logging"
 )
@@ -99,6 +100,19 @@ func (c *ReconfigurableClientConn) PeerConn() *webrtc.PeerConnection {
 	}
 
 	return c.conn.PeerConn()
+}
+
+// GetState returns the current state of the connection.
+func (c *ReconfigurableClientConn) GetState() connectivity.State {
+	// TO BE REMOVED after v0.94.0
+	c.connMu.RLock()
+	defer c.connMu.RUnlock()
+
+	if c.conn == nil {
+		return connectivity.Idle
+	}
+
+	return c.conn.GetState()
 }
 
 // Close attempts to close the underlying client connection if there is one.

--- a/grpc/shared_conn.go
+++ b/grpc/shared_conn.go
@@ -16,7 +16,6 @@ import (
 	"go.viam.com/utils/rpc"
 	"golang.org/x/exp/maps"
 	googlegrpc "google.golang.org/grpc"
-	"google.golang.org/grpc/connectivity"
 
 	"go.viam.com/rdk/logging"
 	rutils "go.viam.com/rdk/utils"
@@ -26,7 +25,7 @@ import (
 // a resource may register with a SharedConn which supports WebRTC.
 type OnTrackCB func(tr *webrtc.TrackRemote, r *webrtc.RTPReceiver)
 
-//nolint
+// nolint
 // The following describes the SharedConn lifetime for viam-server's modmanager communicating with
 // modules it has spawned.
 //
@@ -358,12 +357,6 @@ func (sc *SharedConn) ProcessEncodedAnswer(encodedAnswer string) error {
 
 	guard.Success()
 	return nil
-}
-
-// GetState returns the current state of the connection.
-func (sc *SharedConn) GetState() connectivity.State {
-	// TODO: RSDK-11849 - Handle surfacing dual connectivity states (grpc + webrtc).
-	return rpc.Unknown
 }
 
 // Close closes a shared connection.

--- a/grpc/shared_conn.go
+++ b/grpc/shared_conn.go
@@ -16,6 +16,7 @@ import (
 	"go.viam.com/utils/rpc"
 	"golang.org/x/exp/maps"
 	googlegrpc "google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 
 	"go.viam.com/rdk/logging"
 	rutils "go.viam.com/rdk/utils"
@@ -25,7 +26,7 @@ import (
 // a resource may register with a SharedConn which supports WebRTC.
 type OnTrackCB func(tr *webrtc.TrackRemote, r *webrtc.RTPReceiver)
 
-// nolint
+//nolint
 // The following describes the SharedConn lifetime for viam-server's modmanager communicating with
 // modules it has spawned.
 //
@@ -357,6 +358,13 @@ func (sc *SharedConn) ProcessEncodedAnswer(encodedAnswer string) error {
 
 	guard.Success()
 	return nil
+}
+
+// GetState returns the current state of the connection.
+func (sc *SharedConn) GetState() connectivity.State {
+	// TO BE REMOVED after v0.94.0
+	// TODO: RSDK-11849 - Handle surfacing dual connectivity states (grpc + webrtc).
+	return connectivity.Idle
 }
 
 // Close closes a shared connection.

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/grpc"
 
 	"go.viam.com/rdk/components/sensor"
+	rgrpc "go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/internal/cloud"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -95,7 +96,7 @@ func New(
 	deps resource.Dependencies,
 	conf resource.Config,
 	cloudClientConstructor func(grpc.ClientConnInterface) v1.DataSyncServiceClient,
-	connToConnectivityStateEnabled func(conn rpc.ClientConn) datasync.ConnectivityState,
+	connToConnectivityStateEnabled func(conn rpc.ClientConn) rgrpc.ConnectivityState,
 	logger logging.Logger,
 ) (datamanager.Service, error) {
 	logger.Info("New START")

--- a/services/datamanager/builtin/builtin_sync_test.go
+++ b/services/datamanager/builtin/builtin_sync_test.go
@@ -25,6 +25,7 @@ import (
 	"go.viam.com/rdk/components/arm"
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/data"
+	rgrpc "go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/rimage"
@@ -45,7 +46,7 @@ func TestSyncEnabled(t *testing.T) {
 		name                 string
 		syncStartDisabled    bool
 		syncEndDisabled      bool
-		connStateConstructor func(rpc.ClientConn) datasync.ConnectivityState
+		connStateConstructor func(rpc.ClientConn) rgrpc.ConnectivityState
 		cloudConnectionErr   error
 	}{
 		{
@@ -226,7 +227,7 @@ func TestDataCaptureUploadIntegration(t *testing.T) {
 		scheduledSyncDisabled bool
 		failTransiently       bool
 		emptyFile             bool
-		connStateConstructor  func(rpc.ClientConn) datasync.ConnectivityState
+		connStateConstructor  func(rpc.ClientConn) rgrpc.ConnectivityState
 		cloudConnectionErr    error
 	}{
 		{
@@ -558,7 +559,7 @@ func TestArbitraryFileUpload(t *testing.T) {
 		scheduleSyncDisabled bool
 		uploadToDataset      bool
 		serviceFail          bool
-		connStateConstructor func(rpc.ClientConn) datasync.ConnectivityState
+		connStateConstructor func(rpc.ClientConn) rgrpc.ConnectivityState
 		cloudConnectionErr   error
 	}{
 		{

--- a/services/datamanager/builtin/builtin_test.go
+++ b/services/datamanager/builtin/builtin_test.go
@@ -28,6 +28,7 @@ import (
 	"go.viam.com/rdk/components/sensor"
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/data"
+	rgrpc "go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/internal/cloud"
 	cloudinject "go.viam.com/rdk/internal/testutils/inject"
 	"go.viam.com/rdk/logging"
@@ -380,7 +381,7 @@ func TestSync(t *testing.T) {
 		name                 string
 		dataType             v1.DataType
 		failTransiently      bool
-		connStateConstructor func(rpc.ClientConn) datasync.ConnectivityState
+		connStateConstructor func(rpc.ClientConn) rgrpc.ConnectivityState
 		cloudConnectionErr   error
 	}{
 		{

--- a/services/datamanager/builtin/noop_client_conn_with_connectivity_test.go
+++ b/services/datamanager/builtin/noop_client_conn_with_connectivity_test.go
@@ -62,6 +62,11 @@ func (*NoOpClientConn) PeerConn() *webrtc.PeerConnection {
 	return nil
 }
 
+func (*NoOpClientConn) GetState() connectivity.State {
+	// TO BE REMOVED after v0.94.0
+	return connectivity.Idle
+}
+
 func (*NoOpClientConn) Close() error {
 	return nil
 }

--- a/services/datamanager/builtin/noop_client_conn_with_connectivity_test.go
+++ b/services/datamanager/builtin/noop_client_conn_with_connectivity_test.go
@@ -8,18 +8,19 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
 
+	rgrpc "go.viam.com/rdk/grpc"
 	datasync "go.viam.com/rdk/services/datamanager/builtin/sync"
 )
 
-func ConnToConnectivityStateReady(rpc.ClientConn) datasync.ConnectivityState {
+func ConnToConnectivityStateReady(rpc.ClientConn) rgrpc.ConnectivityState {
 	return newNoOpClientConnWithConnectivity(func() connectivity.State { return connectivity.Ready })
 }
 
-func connToConnectivityStateError(rpc.ClientConn) datasync.ConnectivityState {
+func connToConnectivityStateError(rpc.ClientConn) rgrpc.ConnectivityState {
 	return newNoOpClientConnWithConnectivity(func() connectivity.State { return connectivity.TransientFailure })
 }
 
-func newNoOpClientConnWithConnectivity(f func() connectivity.State) datasync.ConnectivityState {
+func newNoOpClientConnWithConnectivity(f func() connectivity.State) rgrpc.ConnectivityState {
 	return &noOpClientConnWithConnectivity{getStateFunc: f}
 }
 
@@ -59,10 +60,6 @@ func (*NoOpClientConn) Invoke(
 
 func (*NoOpClientConn) PeerConn() *webrtc.PeerConnection {
 	return nil
-}
-
-func (*NoOpClientConn) GetState() connectivity.State {
-	return rpc.Unknown
 }
 
 func (*NoOpClientConn) Close() error {

--- a/services/datamanager/builtin/sync/connectivity.go
+++ b/services/datamanager/builtin/sync/connectivity.go
@@ -5,9 +5,10 @@ import (
 	"runtime"
 	"time"
 
-	"go.viam.com/rdk/grpc"
 	"go.viam.com/utils/rpc"
 	"google.golang.org/grpc/connectivity"
+
+	"go.viam.com/rdk/grpc"
 )
 
 // ConnToConnectivityState takes an rpc.ClientConn and returns an object

--- a/services/datamanager/builtin/sync/connectivity.go
+++ b/services/datamanager/builtin/sync/connectivity.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 	"time"
 
+	"go.viam.com/rdk/grpc"
 	"go.viam.com/utils/rpc"
 	"google.golang.org/grpc/connectivity"
 )
@@ -16,15 +17,8 @@ import (
 // with app.viam.com, but once https://viam.atlassian.net/browse/DATA-3009 is
 // unblocked & implemented, we will either remove this function or have it call the appropriate
 // methods on conn.
-func ConnToConnectivityState(conn rpc.ClientConn) ConnectivityState {
+func ConnToConnectivityState(conn rpc.ClientConn) grpc.ConnectivityState {
 	return offlineChecker{}
-}
-
-// ConnectivityState allows callers to check the connectivity state of
-// the connection
-// see https://github.com/grpc/grpc-go/blob/master/clientconn.go#L648
-type ConnectivityState interface {
-	GetState() connectivity.State
 }
 
 type offlineChecker struct{}

--- a/services/datamanager/builtin/sync/sync.go
+++ b/services/datamanager/builtin/sync/sync.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/grpc/connectivity"
 
 	"go.viam.com/rdk/data"
+	rgrpc "go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/internal/cloud"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/services/datamanager"
@@ -58,7 +59,7 @@ const (
 type Sync struct {
 	// ScheduledTicker only exists for tests
 	ScheduledTicker         *clock.Ticker
-	connToConnectivityState func(conn rpc.ClientConn) ConnectivityState
+	connToConnectivityState func(conn rpc.ClientConn) rgrpc.ConnectivityState
 	logger                  logging.Logger
 	workersWg               sync.WaitGroup
 	flushCollectors         func()
@@ -88,7 +89,7 @@ type Sync struct {
 // New creates a new Sync.
 func New(
 	clientConstructor func(cc grpc.ClientConnInterface) v1.DataSyncServiceClient,
-	connToConnectivityState func(conn rpc.ClientConn) ConnectivityState,
+	connToConnectivityState func(conn rpc.ClientConn) rgrpc.ConnectivityState,
 	flushCollectors func(),
 	clock clock.Clock,
 	logger logging.Logger,
@@ -234,7 +235,7 @@ type cloudConn struct {
 	partID                       string
 	client                       v1.DataSyncServiceClient
 	conn                         rpc.ClientConn
-	connectivityStateEnabledConn ConnectivityState
+	connectivityStateEnabledConn rgrpc.ConnectivityState
 }
 
 // BEGIN connection management


### PR DESCRIPTION
mostly moved the connectivity interface out of data manager, tested and works

doesn't require https://github.com/viamrobotics/goutils/pull/482, we should merge this in before the next release then after the release is cut, merge https://github.com/viamrobotics/goutils/pull/482 and release that. since this PR removes the dependency on GetState as part of the ClientConn interface, we will be able to do that without breaking anyone at any point