### PR TITLE
RSDK-11959: When a reload with cloud-build fails, output the logs before exiting

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -37,3 +37,13 @@ Building (you must [install go](https://go.dev/doc/install) first):
 ```sh
 go build -o ~/go/bin/viam cli/viam/main.go
 ```
+
+Or if you have installed the CLI through homebrew:
+```sh
+go build -o /opt/homebrew/bin/viam cli/viam/main.go
+```
+
+Then afterwards reset your homebrew installation with:
+```sh
+brew link --overwrite viam
+```

--- a/cli/print.go
+++ b/cli/print.go
@@ -59,6 +59,14 @@ func warningf(w io.Writer, format string, a ...interface{}) {
 // Errorf prints a message prefixed with a bold red "Error: " prefix and exits with 1.
 // It also capitalizes the first letter of the message.
 func Errorf(w io.Writer, format string, a ...interface{}) {
+	errorf(w, format, a...)
+
+	os.Exit(1)
+}
+
+// rrrorf prints a message prefixed with a bold red "Error: " prefix without exiting.
+// It also capitalizes the first letter of the message.
+func errorf(w io.Writer, format string, a ...interface{}) {
 	if _, err := color.New(color.Bold, color.FgRed).Fprint(w, "Error: "); err != nil {
 		log.Fatal(err)
 	}
@@ -70,8 +78,6 @@ func Errorf(w io.Writer, format string, a ...interface{}) {
 	}
 	upperR := unicode.ToUpper(r)
 	fmt.Fprintf(w, string(upperR)+toPrint[i:]) //nolint:errcheck
-
-	os.Exit(1)
 }
 
 // viamLogo prints an ASCII Viam logo.

--- a/cli/print.go
+++ b/cli/print.go
@@ -64,7 +64,7 @@ func Errorf(w io.Writer, format string, a ...interface{}) {
 	os.Exit(1)
 }
 
-// rrrorf prints a message prefixed with a bold red "Error: " prefix without exiting.
+// errorf prints a message prefixed with a bold red "Error: " prefix without exiting.
 // It also capitalizes the first letter of the message.
 func errorf(w io.Writer, format string, a ...interface{}) {
 	if _, err := color.New(color.Bold, color.FgRed).Fprint(w, "Error: "); err != nil {


### PR DESCRIPTION
When using `viam module reload --cloud-build` and the build fails, there isn't any troubleshooting provided and the response is just:

```
Started build:
d92d4b01-25c9-4e82-ab18-46c4c79455c1
Error: Module has 0 uploaded versions, nothing to download
```

Instead the logs from the build are printed after the build failure, and then exited before trying to proceed with the rest of the reload process (no need to try and download if the build failed).

### Testing
I created a module with a build.sh that always fails (placed an `exit 1` to always run). When running the CLI on this branch I get the logs correctly:

michaellee@ROBOT-MYHLX2FTJN test-reload-3 % viam module reload --cloud-build --part-id e1555e66-fa60-4cf6-a697-a0297124cc00
Uploading... 100% (12018/12018 bytes)
Info: Creating a new cloud build and swapping it onto the requested machine part. This may take a few minutes...
Started build:
aa9aaa2c-7efa-49b3-aff1-e8c44c9689c9
Error: Build "aa9aaa2c-7efa-49b3-aff1-e8c44c9689c9" failed to complete. Please check the logs below for more information.
Info: viam version

...

viam module build local

Info: Starting build
Info: Starting setup step: "./setup.sh"
Virtualenv found/created. Installing/upgrading Python packages...
Info: Starting build step: "./build.sh"
./build.sh: 4: this: not found
Error: Error running process "bash": exit status 1

Exited with code exit status 1
Info: Uploading artifacts
Uploading /tmp/module.tar.gz to tmp/module.tar.gz
  No artifact files found at /tmp/module.tar.gz
Total size uploaded: 0 B
Error: Reloading module failed
```

