### PR TITLE
CaptureAll Default Confidence Threshold

### DIFF
--- a/services/vision/collectors.go
+++ b/services/vision/collectors.go
@@ -169,8 +169,8 @@ func additionalParamExtraction(methodParams map[string]*anypb.Any) (methodParams
 
 	minConfidenceParam := methodParams["min_confidence_score"]
 
-	// Default min_confidence_score is 0.5
-	minConfidenceScore := 0.5
+	// Default min_confidence_score is 0.0
+	minConfidenceScore := 0.0
 
 	if minConfidenceParam != nil {
 		minConfidenceScoreWrapper := new(wrapperspb.DoubleValue)

--- a/services/vision/collectors_test.go
+++ b/services/vision/collectors_test.go
@@ -58,7 +58,7 @@ var fakeDetections = []objectdetection.Detection{
 			Max: image.Point{X: 110, Y: 120},
 		},
 		normalizedBox: []float64{0.01, 0.02, 0.11, 0.12},
-		score:         0.95,
+		score:         0.45,
 		label:         "cat",
 	},
 }
@@ -156,7 +156,7 @@ func TestCollectors(t *testing.T) {
 	// 32 x 32 image
 	test.That(t, img.Bounds().Dx(), test.ShouldEqual, 32)
 	test.That(t, img.Bounds().Dy(), test.ShouldEqual, 32)
-	bboxConf := 0.95
+	bboxConf := 0.45
 	classConf := 0.85
 	tests := []struct {
 		name      string
@@ -190,17 +190,6 @@ func TestCollectors(t *testing.T) {
 				Data: &datasyncpb.SensorData_Binary{Binary: viamLogoJpeg},
 			}},
 			vision: newVisionService(img),
-		},
-		{
-			name:      "CaptureAllFromCameraCollector w/ Classifications & Detections < 0.5 returns empty CaptureAllFromCameraResp",
-			collector: visionservice.NewCaptureAllFromCameraCollector,
-			expected: []*datasyncpb.SensorData{{
-				Metadata: &datasyncpb.SensorMetadata{
-					MimeType: datasyncpb.MimeType_MIME_TYPE_IMAGE_JPEG,
-				},
-				Data: &datasyncpb.SensorData_Binary{Binary: viamLogoJpeg},
-			}},
-			vision: newVisionService2(img),
 		},
 	}
 
@@ -254,24 +243,6 @@ func newVisionService(img image.Image) visionservice.Service {
 			Image:           img,
 			Detections:      fakeDetections,
 			Classifications: fakeClassifications,
-		}, nil
-	}
-	v.DoCommandFunc = func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
-		return doCommandMap, nil
-	}
-
-	return v
-}
-
-func newVisionService2(img image.Image) visionservice.Service {
-	v := &inject.VisionService{}
-	v.CaptureAllFromCameraFunc = func(ctx context.Context, cameraName string, opts viscapture.CaptureOptions,
-		extra map[string]interface{},
-	) (viscapture.VisCapture, error) {
-		return viscapture.VisCapture{
-			Image:           img,
-			Detections:      fakeDetections2,
-			Classifications: fakeClassifications2,
 		}, nil
 	}
 	v.DoCommandFunc = func(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {

--- a/services/vision/collectors_test.go
+++ b/services/vision/collectors_test.go
@@ -63,28 +63,9 @@ var fakeDetections = []objectdetection.Detection{
 	},
 }
 
-var fakeDetections2 = []objectdetection.Detection{
-	&fakeDetection{
-		boundingBox: &image.Rectangle{
-			Min: image.Point{X: 10, Y: 20},
-			Max: image.Point{X: 110, Y: 120},
-		},
-		normalizedBox: []float64{0.01, 0.02, 0.11, 0.12},
-		score:         0.3,
-		label:         "cat",
-	},
-}
-
 var fakeClassifications = []classification.Classification{
 	&fakeClassification{
 		score: 0.85,
-		label: "cat",
-	},
-}
-
-var fakeClassifications2 = []classification.Classification{
-	&fakeClassification{
-		score: 0.49,
 		label: "cat",
 	},
 }


### PR DESCRIPTION
Currently, the test card on the vision service displays all bounding boxes / classifications, regardless of confidence. However, when using captureAllFromCamera, only annotations with confidence > 0.5 are saved by default. This is confusing to the user, who expects that all annotations that are displayed in the test card should be saved. This PR changes the default min_confidence value to 0.