### PR TITLE
Update dev-version release to include a short hash

### DIFF
--- a/etc/dev-version.sh
+++ b/etc/dev-version.sh
@@ -26,6 +26,7 @@ DESC=$(git describe --tags --match="v*" --exclude="*-rc*" --long | sed 's/^v//')
 
 BASE_VERSION=$(echo "$DESC" | cut -d'-' -f1)
 COMMITS_SINCE_TAG=$(echo "$DESC" | cut -d'-' -f2)
+COMMIT_HASH=$(echo "$DESC" | cut -d'-' -f3)
 
 # Calculate next version by incrementing patch number
 NEXT_VERSION=$(echo "$BASE_VERSION" | awk -F. '{$3+=1}1' OFS=.)
@@ -34,7 +35,7 @@ NEXT_VERSION=$(echo "$BASE_VERSION" | awk -F. '{$3+=1}1' OFS=.)
 if [ "$COMMITS_SINCE_TAG" -eq 0 ]; then
     TAG_VERSION="$BASE_VERSION"
 else
-    TAG_VERSION="${NEXT_VERSION}-dev.${COMMITS_SINCE_TAG}"
+    TAG_VERSION="${NEXT_VERSION}-dev.${COMMITS_SINCE_TAG}-${COMMIT_HASH}"
 fi
 
 # Set PATH_VERSION based on TAG_VERSION


### PR DESCRIPTION
dev versions will go from `v0.93.1-dev.9` to `v0.93.1-dev.9-gd23fe503c`

Needs this [PR](https://github.com/viamrobotics/app/pull/9809) to be merged for the releases to properly be picked up 